### PR TITLE
[Merged by Bors] - refactor: golf Normal.of_isSplittingField

### DIFF
--- a/Mathlib/Data/Polynomial/Splits.lean
+++ b/Mathlib/Data/Polynomial/Splits.lean
@@ -21,12 +21,6 @@ irreducible factors over `L` have degree `1`.
   field and a polynomial `f` saying that `f.map i` is zero or all of its irreducible factors over
   `L` have degree `1`.
 
-## Main statements
-
-* `lift_of_splits`: If `K` and `L` are field extensions of a field `F` and for some finite subset
-  `S` of `K`, the minimal polynomial of every `x ∈ K` splits as a polynomial with coefficients in
-  `L`, then `Algebra.adjoin F S` embeds into `L`.
-
 -/
 
 

--- a/Mathlib/Data/Polynomial/Splits.lean
+++ b/Mathlib/Data/Polynomial/Splits.lean
@@ -430,6 +430,16 @@ theorem splits_iff_exists_multiset {f : K[X]} :
     splits_of_exists_multiset i hs⟩
 #align polynomial.splits_iff_exists_multiset Polynomial.splits_iff_exists_multiset
 
+theorem splits_of_comp (j : L →+* F) {f : K[X]} (h : Splits (j.comp i) f)
+    (roots_mem_range : ∀ a ∈ (f.map (j.comp i)).roots, a ∈ j.range) : Splits i f := by
+  choose lift lift_eq using roots_mem_range
+  rw [splits_iff_exists_multiset]
+  refine ⟨(f.map (j.comp i)).roots.pmap lift fun _ ↦ id, map_injective _ j.injective ?_⟩
+  conv_lhs => rw [Polynomial.map_map, eq_prod_roots_of_splits h]
+  simp_rw [Polynomial.map_mul, Polynomial.map_multiset_prod, Multiset.map_pmap, Polynomial.map_sub,
+    map_C, map_X, lift_eq, Multiset.pmap_eq_map]
+  rfl
+
 theorem splits_comp_of_splits (j : L →+* F) {f : K[X]} (h : Splits i f) : Splits (j.comp i) f := by
   -- Porting note: was
   -- change i with (RingHom.id _).comp i at h

--- a/Mathlib/Data/Polynomial/Splits.lean
+++ b/Mathlib/Data/Polynomial/Splits.lean
@@ -434,6 +434,10 @@ theorem splits_of_comp (j : L →+* F) {f : K[X]} (h : Splits (j.comp i) f)
     map_C, map_X, lift_eq, Multiset.pmap_eq_map]
   rfl
 
+theorem splits_id_of_splits {f : K[X]} (h : Splits i f)
+    (roots_mem_range : ∀ a ∈ (f.map i).roots, a ∈ i.range) : Splits (RingHom.id K) f :=
+  splits_of_comp (RingHom.id K) i h roots_mem_range
+
 theorem splits_comp_of_splits (j : L →+* F) {f : K[X]} (h : Splits i f) : Splits (j.comp i) f := by
   -- Porting note: was
   -- change i with (RingHom.id _).comp i at h

--- a/Mathlib/FieldTheory/Adjoin.lean
+++ b/Mathlib/FieldTheory/Adjoin.lean
@@ -899,6 +899,12 @@ noncomputable def algHomAdjoinIntegralEquiv (h : IsIntegral F α) :
       rw [adjoin.powerBasis_gen, minpoly_gen, Equiv.refl_apply])
 #align intermediate_field.alg_hom_adjoin_integral_equiv IntermediateField.algHomAdjoinIntegralEquiv
 
+lemma algHomAdjoinIntegralEquiv_symm_apply_gen (h : IsIntegral F α)
+    (x : { x // x ∈ (minpoly F α).aroots K }) :
+    (algHomAdjoinIntegralEquiv F h).symm x (AdjoinSimple.gen F α) = x :=
+  (adjoin.powerBasis h).lift_gen x.val <| by
+    rw [adjoin.powerBasis_gen, minpoly_gen]; exact (mem_aroots.mp x.2).2
+
 /-- Fintype of algebra homomorphism `F⟮α⟯ →ₐ[F] K` -/
 noncomputable def fintypeOfAlgHomAdjoinIntegral (h : IsIntegral F α) : Fintype (F⟮α⟯ →ₐ[F] K) :=
   PowerBasis.AlgHom.fintype (adjoin.powerBasis h)

--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -306,17 +306,6 @@ theorem maximalSubfieldWithHom_is_maximal :
   Classical.choose_spec (exists_maximal_subfieldWithHom K L M)
 #align lift.subfield_with_hom.maximal_subfield_with_hom_is_maximal IsAlgClosed.lift.SubfieldWithHom.maximalSubfieldWithHom_is_maximal
 
--- Porting note: split out this definition from `maximalSubfieldWithHom_eq_top`
-/-- Produce an algebra homomorphism `Adjoin R {x} →ₐ[R] T` sending `x` to
-a root of `x`'s minimal polynomial in `T`. -/
-noncomputable def _root_.Algebra.adjoin.liftSingleton (R : Type*) [Field R] {S T : Type*}
-  [CommRing S] [CommRing T] [Algebra R S] [Algebra R T]
-  (x : S) (y : T) (h : aeval y (minpoly R x) = 0) :
-  Algebra.adjoin R {x} →ₐ[R] T :=
-AlgHom.comp
-  (AdjoinRoot.liftHom _ y h)
-  (AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly R x).toAlgHom
-
 -- porting note: this was much faster in lean 3
 set_option synthInstance.maxHeartbeats 200000 in
 theorem maximalSubfieldWithHom_eq_top : (maximalSubfieldWithHom K L M).carrier = ⊤ := by

--- a/Mathlib/FieldTheory/Normal.lean
+++ b/Mathlib/FieldTheory/Normal.lean
@@ -5,9 +5,7 @@ Authors: Kenny Lau, Thomas Browning, Patrick Lutz
 -/
 import Mathlib.FieldTheory.Adjoin
 import Mathlib.FieldTheory.SplittingField.Construction
---import Mathlib.FieldTheory.Tower
 import Mathlib.GroupTheory.Solvable
---import Mathlib.RingTheory.PowerBasis
 
 #align_import field_theory.normal from "leanprover-community/mathlib"@"9fb8964792b4237dac6200193a0d533f1b3f7423"
 

--- a/Mathlib/FieldTheory/Normal.lean
+++ b/Mathlib/FieldTheory/Normal.lean
@@ -4,9 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Thomas Browning, Patrick Lutz
 -/
 import Mathlib.FieldTheory.Adjoin
-import Mathlib.FieldTheory.Tower
+import Mathlib.FieldTheory.SplittingField.Construction
+--import Mathlib.FieldTheory.Tower
 import Mathlib.GroupTheory.Solvable
-import Mathlib.RingTheory.PowerBasis
+--import Mathlib.RingTheory.PowerBasis
 
 #align_import field_theory.normal from "leanprover-community/mathlib"@"9fb8964792b4237dac6200193a0d533f1b3f7423"
 
@@ -150,92 +151,41 @@ theorem AlgEquiv.transfer_normal (f : E ≃ₐ[F] E') : Normal F E ↔ Normal F 
   ⟨fun _ => Normal.of_algEquiv f, fun _ => Normal.of_algEquiv f.symm⟩
 #align alg_equiv.transfer_normal AlgEquiv.transfer_normal
 
--- seems to be causing a diamond in the below proof
--- however, this may be a fluke and the proof below uses non-canonical `Algebra` instances:
--- when I replaced all the instances inside the proof with the "canonical" instances we have,
--- I had the (unprovable) goal (of the form) `AdjoinRoot.mk f (C x) = AdjoinRoot.mk f X`
--- for some `x, f`. So maybe this is indeed the correct approach and rewriting this proof is
--- salient in the future, or at least taking a closer look at the algebra instances it uses.
-attribute [-instance] AdjoinRoot.instSMulAdjoinRoot
+open IntermediateField
 
 theorem Normal.of_isSplittingField (p : F[X]) [hFEp : IsSplittingField F E p] : Normal F E := by
   rcases eq_or_ne p 0 with (rfl | hp)
   · have := hFEp.adjoin_rootSet
     simp only [rootSet_zero, Algebra.adjoin_empty] at this
-    exact
-      Normal.of_algEquiv
-        (AlgEquiv.ofBijective (Algebra.ofId F E) (Algebra.bijective_algebraMap_iff.2 this.symm))
-  refine' normal_iff.2 fun x => _
+    exact Normal.of_algEquiv
+      (AlgEquiv.ofBijective (Algebra.ofId F E) (Algebra.bijective_algebraMap_iff.2 this.symm))
+  refine normal_iff.mpr fun x ↦ ?_
   have hFE : FiniteDimensional F E := IsSplittingField.finiteDimensional E p
-  have Hx : IsIntegral F x := isIntegral_of_noetherian (IsNoetherian.iff_fg.2 hFE) x
-  refine' ⟨Hx, Or.inr _⟩
-  rintro q q_irred ⟨r, hr⟩
-  let D := AdjoinRoot q
-  haveI := Fact.mk q_irred
-  let pbED := AdjoinRoot.powerBasis q_irred.ne_zero
-  haveI : FiniteDimensional E D := PowerBasis.finiteDimensional pbED
-  have finrankED : FiniteDimensional.finrank E D = q.natDegree := by
-    rw [PowerBasis.finrank pbED, AdjoinRoot.powerBasis_dim]
-  haveI : FiniteDimensional F D := FiniteDimensional.trans F E D
-  rsuffices ⟨ϕ⟩ : Nonempty (D →ₐ[F] E)
-  --Porting note: the `change` was `rw [← WithBot.coe_one]`
-  · change degree q = ↑(1 : ℕ)
-    rw [degree_eq_iff_natDegree_eq q_irred.ne_zero, ← finrankED]
-    have nat_lemma : ∀ a b c : ℕ, a * b = c → c ≤ a → 0 < c → b = 1 := by
-      intro a b c h1 h2 h3
-      nlinarith
-    exact
-      nat_lemma _ _ _ (FiniteDimensional.finrank_mul_finrank F E D)
-        (LinearMap.finrank_le_finrank_of_injective
-          (show Function.Injective ϕ.toLinearMap from ϕ.toRingHom.injective))
-        FiniteDimensional.finrank_pos
-  let C := AdjoinRoot (minpoly F x)
-  haveI Hx_irred := Fact.mk (minpoly.irreducible Hx)
--- Porting note: `heval` added since now Lean wants the proof explicitly in several places.
-  have heval : eval₂ (algebraMap F D) (AdjoinRoot.root q) (minpoly F x) = 0 := by
-    rw [algebraMap_eq F E D, ← eval₂_map, hr, AdjoinRoot.algebraMap_eq, eval₂_mul,
-      AdjoinRoot.eval₂_root, zero_mul]
-  letI : Algebra C D :=
-    RingHom.toAlgebra (AdjoinRoot.lift (algebraMap F D) (AdjoinRoot.root q) heval)
-  letI : Algebra C E := RingHom.toAlgebra (AdjoinRoot.lift (algebraMap F E) x (minpoly.aeval F x))
-  haveI : IsScalarTower F C D := of_algebraMap_eq fun y => (AdjoinRoot.lift_of heval).symm
-  haveI : IsScalarTower F C E := by
-    refine' of_algebraMap_eq fun y => (AdjoinRoot.lift_of _).symm
--- Porting note: the following proof was just `_`.
-    rw [← aeval_def, minpoly.aeval]
-  suffices Nonempty (D →ₐ[C] E) by exact Nonempty.map (AlgHom.restrictScalars F) this
-  let S : Set D := ((p.aroots E).map (algebraMap E D)).toFinset
-  suffices ⊤ ≤ IntermediateField.adjoin C S by
-    refine' IntermediateField.algHom_mk_adjoin_splits' (top_le_iff.mp this) fun y hy => _
-    rcases Multiset.mem_map.mp (Multiset.mem_toFinset.mp hy) with ⟨z, hz1, hz2⟩
-    have Hz : IsIntegral F z := isIntegral_of_noetherian (IsNoetherian.iff_fg.2 hFE) z
-    use
-      show IsIntegral C y from
-        isIntegral_of_noetherian (IsNoetherian.iff_fg.2 (FiniteDimensional.right F C D)) y
-    apply splits_of_splits_of_dvd (algebraMap C E) (map_ne_zero (minpoly.ne_zero Hz))
-    · rw [splits_map_iff, ← algebraMap_eq F C E]
-      exact
-        splits_of_splits_of_dvd _ hp hFEp.splits (minpoly.dvd F z (mem_aroots.mp hz1).2)
-    · apply minpoly.dvd
-      rw [← hz2, aeval_def, eval₂_map, ← algebraMap_eq F C D, algebraMap_eq F E D, ← hom_eval₂, ←
-        aeval_def, minpoly.aeval F z, RingHom.map_zero]
-  rw [← IntermediateField.toSubalgebra_le_toSubalgebra, IntermediateField.top_toSubalgebra]
-  apply ge_trans (IntermediateField.algebra_adjoin_le_adjoin C S)
-  suffices
-    (Algebra.adjoin C S).restrictScalars F =
-      (Algebra.adjoin E {AdjoinRoot.root q}).restrictScalars F by
-    rw [AdjoinRoot.adjoinRoot_eq_top, Subalgebra.restrictScalars_top, ←
-      @Subalgebra.restrictScalars_top F C] at this
-    exact top_le_iff.mpr (Subalgebra.restrictScalars_injective F this)
-/- Porting note: the `change` was `dsimp only [S]`. Using `set S ... with hS` doesn't work. -/
-  change Subalgebra.restrictScalars F (Algebra.adjoin C
-    (((p.aroots E).map (algebraMap E D)).toFinset : Set D)) = _
-  rw [← Finset.image_toFinset, Finset.coe_image]
-  apply
-    Eq.trans
-      (Algebra.adjoin_res_eq_adjoin_res F E C D hFEp.adjoin_rootSet AdjoinRoot.adjoinRoot_eq_top)
-  rw [Set.image_singleton, RingHom.algebraMap_toAlgebra, AdjoinRoot.lift_root]
+  have hx : IsIntegral F x := isIntegral_of_noetherian (IsNoetherian.iff_fg.2 hFE) x
+  let L := (p * minpoly F x).SplittingField
+  have hL := splits_of_splits_mul' _ ?_ (SplittingField.splits (p * minpoly F x))
+  · let j : E →ₐ[F] L := IsSplittingField.lift E p hL.1
+    refine ⟨hx, splits_of_comp _ j.toRingHom ?_ fun a ha ↦ ?_⟩
+    · erw [j.comp_algebraMap]; exact hL.2
+    erw [j.comp_algebraMap, mem_roots ((minpoly.monic hx).map _).ne_zero, IsRoot, eval_map] at ha
+    let FxL : F⟮x⟯ →ₐ[F] L := (adjoin.powerBasis hx).lift a ?_
+    · letI : Algebra F⟮x⟯ L := FxL.toRingHom.toAlgebra
+      let j' : E →ₐ[F⟮x⟯] L := IsSplittingField.lift E (p.map (algebraMap F F⟮x⟯)) ?_
+      change a ∈ j.range
+      rw [← IsSplittingField.adjoin_rootSet_eq_range E p j,
+            IsSplittingField.adjoin_rootSet_eq_range E p (j'.restrictScalars F)]
+      use x
+      erw [j'.coe_toRingHom, ← (adjoin.powerBasis hx).lift_gen a]
+      · exact j'.commutes ⟨x, _⟩
+      · rw [splits_map_iff, ← IsScalarTower.algebraMap_eq]; exact hL.1
+    · rw [adjoin.powerBasis_gen, minpoly_gen]; exact ha
+  · rw [Polynomial.map_ne_zero_iff (algebraMap F L).injective, mul_ne_zero_iff]
+    exact ⟨hp, minpoly.ne_zero hx⟩
 #align normal.of_is_splitting_field Normal.of_isSplittingField
+
+instance Polynomial.SplittingField.instNormal [Field F] (p : F[X]) : Normal F p.SplittingField :=
+  Normal.of_isSplittingField p
+#align polynomial.splitting_field.normal Polynomial.SplittingField.instNormal
 
 end NormalTower
 

--- a/Mathlib/FieldTheory/Normal.lean
+++ b/Mathlib/FieldTheory/Normal.lean
@@ -159,20 +159,15 @@ theorem Normal.of_isSplittingField (p : F[X]) [hFEp : IsSplittingField F E p] : 
   let L := (p * minpoly F x).SplittingField
   have hL := splits_of_splits_mul' _ ?_ (SplittingField.splits (p * minpoly F x))
   · let j : E →ₐ[F] L := IsSplittingField.lift E p hL.1
-    refine ⟨hx, splits_of_comp _ (j : E →+* L) ?_ fun a ha ↦ ?_⟩
-    · rw [j.comp_algebraMap]; exact hL.2
-    rw [j.comp_algebraMap, mem_roots ((minpoly.monic hx).map _).ne_zero, IsRoot, eval_map] at ha
-    let FxL : F⟮x⟯ →ₐ[F] L := (adjoin.powerBasis hx).lift a ?_
-    · letI : Algebra F⟮x⟯ L := FxL.toRingHom.toAlgebra
-      let j' : E →ₐ[F⟮x⟯] L := IsSplittingField.lift E (p.map (algebraMap F F⟮x⟯)) ?_
-      · change a ∈ j.range
-        rw [← IsSplittingField.adjoin_rootSet_eq_range E p j,
+    refine ⟨hx, splits_of_comp _ (j : E →+* L) (j.comp_algebraMap ▸ hL.2) fun a ha ↦ ?_⟩
+    rw [j.comp_algebraMap] at ha
+    letI : Algebra F⟮x⟯ L := ((algHomAdjoinIntegralEquiv F hx).symm ⟨a, ha⟩).toRingHom.toAlgebra
+    let j' : E →ₐ[F⟮x⟯] L := IsSplittingField.lift E (p.map (algebraMap F F⟮x⟯)) ?_
+    · change a ∈ j.range
+      rw [← IsSplittingField.adjoin_rootSet_eq_range E p j,
             IsSplittingField.adjoin_rootSet_eq_range E p (j'.restrictScalars F)]
-        use x
-        erw [j'.coe_toRingHom, ← (adjoin.powerBasis hx).lift_gen a]
-        exact j'.commutes ⟨x, _⟩
-      · rw [splits_map_iff, ← IsScalarTower.algebraMap_eq]; exact hL.1
-    · rw [adjoin.powerBasis_gen, minpoly_gen]; exact ha
+      exact ⟨x, (j'.commutes _).trans (algHomAdjoinIntegralEquiv_symm_apply_gen F hx _)⟩
+    · rw [splits_map_iff, ← IsScalarTower.algebraMap_eq]; exact hL.1
   · rw [Polynomial.map_ne_zero_iff (algebraMap F L).injective, mul_ne_zero_iff]
     exact ⟨hp, minpoly.ne_zero hx⟩
 #align normal.of_is_splitting_field Normal.of_isSplittingField

--- a/Mathlib/FieldTheory/Normal.lean
+++ b/Mathlib/FieldTheory/Normal.lean
@@ -69,10 +69,6 @@ instance normal_self : Normal F F :=
     (minpoly.eq_X_sub_C' x).symm ▸ splits_X_sub_C _⟩
 #align normal_self normal_self
 
-variable {K}
-
-variable (K)
-
 theorem Normal.exists_isSplittingField [h : Normal F K] [FiniteDimensional F K] :
     ∃ p : F[X], IsSplittingField F K p := by
   let s := Basis.ofVectorSpace F K

--- a/Mathlib/FieldTheory/Normal.lean
+++ b/Mathlib/FieldTheory/Normal.lean
@@ -163,18 +163,18 @@ theorem Normal.of_isSplittingField (p : F[X]) [hFEp : IsSplittingField F E p] : 
   let L := (p * minpoly F x).SplittingField
   have hL := splits_of_splits_mul' _ ?_ (SplittingField.splits (p * minpoly F x))
   · let j : E →ₐ[F] L := IsSplittingField.lift E p hL.1
-    refine ⟨hx, splits_of_comp _ j.toRingHom ?_ fun a ha ↦ ?_⟩
-    · erw [j.comp_algebraMap]; exact hL.2
-    erw [j.comp_algebraMap, mem_roots ((minpoly.monic hx).map _).ne_zero, IsRoot, eval_map] at ha
+    refine ⟨hx, splits_of_comp _ (j : E →+* L) ?_ fun a ha ↦ ?_⟩
+    · rw [j.comp_algebraMap]; exact hL.2
+    rw [j.comp_algebraMap, mem_roots ((minpoly.monic hx).map _).ne_zero, IsRoot, eval_map] at ha
     let FxL : F⟮x⟯ →ₐ[F] L := (adjoin.powerBasis hx).lift a ?_
     · letI : Algebra F⟮x⟯ L := FxL.toRingHom.toAlgebra
       let j' : E →ₐ[F⟮x⟯] L := IsSplittingField.lift E (p.map (algebraMap F F⟮x⟯)) ?_
-      change a ∈ j.range
-      rw [← IsSplittingField.adjoin_rootSet_eq_range E p j,
+      · change a ∈ j.range
+        rw [← IsSplittingField.adjoin_rootSet_eq_range E p j,
             IsSplittingField.adjoin_rootSet_eq_range E p (j'.restrictScalars F)]
-      use x
-      erw [j'.coe_toRingHom, ← (adjoin.powerBasis hx).lift_gen a]
-      · exact j'.commutes ⟨x, _⟩
+        use x
+        erw [j'.coe_toRingHom, ← (adjoin.powerBasis hx).lift_gen a]
+        exact j'.commutes ⟨x, _⟩
       · rw [splits_map_iff, ← IsScalarTower.algebraMap_eq]; exact hL.1
     · rw [adjoin.powerBasis_gen, minpoly_gen]; exact ha
   · rw [Polynomial.map_ne_zero_iff (algebraMap F L).injective, mul_ne_zero_iff]

--- a/Mathlib/FieldTheory/Normal.lean
+++ b/Mathlib/FieldTheory/Normal.lean
@@ -150,12 +150,12 @@ open IntermediateField
 theorem Normal.of_isSplittingField (p : F[X]) [hFEp : IsSplittingField F E p] : Normal F E := by
   rcases eq_or_ne p 0 with (rfl | hp)
   · have := hFEp.adjoin_rootSet
-    simp only [rootSet_zero, Algebra.adjoin_empty] at this
+    rw [rootSet_zero, Algebra.adjoin_empty] at this
     exact Normal.of_algEquiv
       (AlgEquiv.ofBijective (Algebra.ofId F E) (Algebra.bijective_algebraMap_iff.2 this.symm))
   refine normal_iff.mpr fun x ↦ ?_
-  have hFE : FiniteDimensional F E := IsSplittingField.finiteDimensional E p
-  have hx : IsIntegral F x := isIntegral_of_noetherian (IsNoetherian.iff_fg.2 hFE) x
+  haveI : FiniteDimensional F E := IsSplittingField.finiteDimensional E p
+  have hx := isIntegral_of_finite F x
   let L := (p * minpoly F x).SplittingField
   have hL := splits_of_splits_mul' _ ?_ (SplittingField.splits (p * minpoly F x))
   · let j : E →ₐ[F] L := IsSplittingField.lift E p hL.1

--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import Mathlib.FieldTheory.Normal
+import Mathlib.FieldTheory.SplittingField.IsSplittingField
 
 #align_import field_theory.splitting_field.construction from "leanprover-community/mathlib"@"e3f4be1fcb5376c4948d7f095bec45350bfb9d1a"
 
@@ -381,11 +381,3 @@ def algEquiv (f : K[X]) [IsSplittingField K L f] : L ≃ₐ[K] SplittingField f 
 end IsSplittingField
 
 end Polynomial
-
-section Normal
-
-instance Polynomial.SplittingField.instNormal [Field F] (p : F[X]) : Normal F p.SplittingField :=
-  Normal.of_isSplittingField p
-#align polynomial.splitting_field.normal Polynomial.SplittingField.instNormal
-
-end Normal

--- a/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
+++ b/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
@@ -129,11 +129,9 @@ def lift [Algebra K F] (f : K[X]) [IsSplittingField K L f]
 
 theorem finiteDimensional (f : K[X]) [IsSplittingField K L f] : FiniteDimensional K L :=
   ⟨@Algebra.top_toSubmodule K L _ _ _ ▸
-    adjoin_rootSet L f ▸ FG_adjoin_of_finite (Finset.finite_toSet _) fun y hy =>
+    adjoin_rootSet L f ▸ FG_adjoin_of_finite (Finset.finite_toSet _) fun y hy ↦
       if hf : f = 0 then by rw [hf, rootSet_zero] at hy; cases hy
-      else
-        isAlgebraic_iff_isIntegral.1 ⟨f, hf, (eval₂_eq_eval_map _).trans <|
-          (mem_roots <| map_ne_zero hf).1 (Multiset.mem_toFinset.mp hy)⟩⟩
+      else isAlgebraic_iff_isIntegral.1 ⟨f, hf, (mem_rootSet'.mp hy).2⟩⟩
 #align polynomial.is_splitting_field.finite_dimensional Polynomial.IsSplittingField.finiteDimensional
 
 theorem of_algEquiv [Algebra K F] (p : K[X]) (f : F ≃ₐ[K] L) [IsSplittingField K F p] :

--- a/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
+++ b/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
@@ -145,6 +145,10 @@ theorem of_algEquiv [Algebra K F] (p : K[X]) (f : F ≃ₐ[K] L) [IsSplittingFie
       adjoin_rootSet_eq_range (splits F p), adjoin_rootSet F p]
 #align polynomial.is_splitting_field.of_alg_equiv Polynomial.IsSplittingField.of_algEquiv
 
+def adjoin_rootSet_eq_range [Algebra K F] (f : K[X]) [IsSplittingField K L f] (i : L →ₐ[K] F) :
+    Algebra.adjoin K (rootSet f F) = i.range :=
+  (Polynomial.adjoin_rootSet_eq_range (splits L f) i).mpr (adjoin_rootSet L f)
+
 end IsSplittingField
 
 end Polynomial
@@ -157,15 +161,8 @@ variable {K L} [Field K] [Field L] [Algebra K L] {p : K[X]}
 
 theorem splits_of_splits {F : IntermediateField K L} (h : p.Splits (algebraMap K L))
     (hF : ∀ x ∈ p.rootSet L, x ∈ F) : p.Splits (algebraMap K F) := by
-  simp_rw [rootSet_def, Finset.mem_coe, Multiset.mem_toFinset] at hF
-  rw [splits_iff_exists_multiset]
-  refine' ⟨Multiset.pmap Subtype.mk _ hF, map_injective _ (algebraMap F L).injective _⟩
-  conv_lhs =>
-    rw [Polynomial.map_map, ← IsScalarTower.algebraMap_eq, eq_prod_roots_of_splits h, ←
-      Multiset.pmap_eq_map _ _ _ hF]
-  simp_rw [Polynomial.map_mul, Polynomial.map_multiset_prod, Multiset.map_pmap, Polynomial.map_sub,
-    map_C, map_X]
-  rfl
+  simp_rw [← F.fieldRange_val, rootSet_def, Finset.mem_coe, Multiset.mem_toFinset] at hF
+  exact splits_of_comp _ F.val.toRingHom h hF
 #align intermediate_field.splits_of_splits IntermediateField.splits_of_splits
 
 end IntermediateField

--- a/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
+++ b/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
@@ -145,7 +145,7 @@ theorem of_algEquiv [Algebra K F] (p : K[X]) (f : F ≃ₐ[K] L) [IsSplittingFie
       adjoin_rootSet_eq_range (splits F p), adjoin_rootSet F p]
 #align polynomial.is_splitting_field.of_alg_equiv Polynomial.IsSplittingField.of_algEquiv
 
-def adjoin_rootSet_eq_range [Algebra K F] (f : K[X]) [IsSplittingField K L f] (i : L →ₐ[K] F) :
+theorem adjoin_rootSet_eq_range [Algebra K F] (f : K[X]) [IsSplittingField K L f] (i : L →ₐ[K] F) :
     Algebra.adjoin K (rootSet f F) = i.range :=
   (Polynomial.adjoin_rootSet_eq_range (splits L f) i).mpr (adjoin_rootSet L f)
 

--- a/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
+++ b/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
@@ -79,7 +79,7 @@ instance map (f : F[X]) [IsSplittingField F L f] : IsSplittingField K L (f.map <
 #align polynomial.is_splitting_field.map Polynomial.IsSplittingField.map
 
 theorem splits_iff (f : K[X]) [IsSplittingField K L f] :
-    Polynomial.Splits (RingHom.id K) f ↔ (⊤ : Subalgebra K L) = ⊥ :=
+    Splits (RingHom.id K) f ↔ (⊤ : Subalgebra K L) = ⊥ :=
   ⟨fun h => by -- Porting note: replaced term-mode proof
     rw [eq_bot_iff, ← adjoin_rootSet L f, rootSet, aroots, roots_map (algebraMap K L) h,
       Algebra.adjoin_le_iff]
@@ -112,7 +112,7 @@ end ScalarTower
 
 /-- Splitting field of `f` embeds into any field that splits `f`. -/
 def lift [Algebra K F] (f : K[X]) [IsSplittingField K L f]
-    (hf : Polynomial.Splits (algebraMap K F) f) : L →ₐ[K] F :=
+    (hf : Splits (algebraMap K F) f) : L →ₐ[K] F :=
   if hf0 : f = 0 then
     (Algebra.ofId K F).comp <|
       (Algebra.botEquiv K L : (⊥ : Subalgebra K L) →ₐ[K] K).comp <| by

--- a/Mathlib/RingTheory/Adjoin/Field.lean
+++ b/Mathlib/RingTheory/Adjoin/Field.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import Mathlib.Data.Polynomial.Splits
-import Mathlib.RingTheory.Adjoin.Basic
+import Mathlib.RingTheory.Adjoin.PowerBasis
 import Mathlib.RingTheory.AdjoinRoot
 
 #align_import ring_theory.adjoin.field from "leanprover-community/mathlib"@"c4658a649d216f57e99621708b09dcb3dcccbd23"
@@ -41,16 +41,23 @@ def AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly {R : Type*} [CommRing R] [Alg
     rwa [Minpoly.toAdjoin_apply', liftHom_mk, ← Subalgebra.coe_eq_zero, aeval_subalgebra_coe] at hP₁
 #align alg_equiv.adjoin_singleton_equiv_adjoin_root_minpoly AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly
 
+/-- Produce an algebra homomorphism `Adjoin R {x} →ₐ[R] T` sending `x` to
+a root of `x`'s minimal polynomial in `T`. -/
+noncomputable def Algebra.adjoin.liftSingleton {S T : Type*}
+    [CommRing S] [CommRing T] [Algebra F S] [Algebra F T]
+    (x : S) (y : T) (h : aeval y (minpoly F x) = 0) :
+    Algebra.adjoin F {x} →ₐ[F] T :=
+  (AdjoinRoot.liftHom _ y h).comp (AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly F x).toAlgHom
+
 open Finset
 
-set_option synthInstance.maxHeartbeats 40000 in
 /-- If `K` and `L` are field extensions of `F` and we have `s : Finset K` such that
 the minimal polynomial of each `x ∈ s` splits in `L` then `Algebra.adjoin F s` embeds in `L`. -/
-theorem lift_of_splits {F K L : Type*} [Field F] [Field K] [Field L] [Algebra F K] [Algebra F L]
-    (s : Finset K) : (∀ x ∈ s, IsIntegral F x ∧ Polynomial.Splits (algebraMap F L) (minpoly F x)) →
-      Nonempty (Algebra.adjoin F (↑s : Set K) →ₐ[F] L) := by
+theorem Polynomial.lift_of_splits {F K L : Type*} [Field F] [Field K] [Field L] [Algebra F K]
+    [Algebra F L] (s : Finset K) : (∀ x ∈ s, IsIntegral F x ∧
+      Splits (algebraMap F L) (minpoly F x)) → Nonempty (Algebra.adjoin F (s : Set K) →ₐ[F] L) := by
   classical
-    refine' Finset.induction_on s (fun _ => _) fun a s _ ih H => _
+    refine Finset.induction_on s (fun _ ↦ ?_) fun a s _ ih H ↦ ?_
     · rw [coe_empty, Algebra.adjoin_empty]
       exact ⟨(Algebra.ofId F L).comp (Algebra.botEquiv F K)⟩
     rw [forall_mem_insert] at H
@@ -58,26 +65,20 @@ theorem lift_of_splits {F K L : Type*} [Field F] [Field K] [Field L] [Algebra F 
     cases' ih H3 with f
     choose H3 _ using H3
     rw [coe_insert, Set.insert_eq, Set.union_comm, Algebra.adjoin_union_eq_adjoin_adjoin]
-    letI := (f : Algebra.adjoin F (↑s : Set K) →+* L).toAlgebra
-    haveI : FiniteDimensional F (Algebra.adjoin F (↑s : Set K)) :=
-      ((Submodule.fg_iff_finiteDimensional _).1
-        (FG_adjoin_of_finite s.finite_toSet H3)).of_subalgebra_toSubmodule
-    letI := fieldOfFiniteDimensional F (Algebra.adjoin F (↑s : Set K))
-    have H5 : IsIntegral (Algebra.adjoin F (s : Set K)) a := isIntegral_of_isScalarTower H1
-    have H6 : (minpoly (Algebra.adjoin F (s : Set K)) a).Splits
-        (algebraMap (Algebra.adjoin F (s : Set K)) L) := by
-      have : Polynomial.map (algebraMap F (Algebra.adjoin F (s : Set K))) (minpoly F a) ≠ 0 :=
-        Polynomial.map_ne_zero <| minpoly.ne_zero H1
-      refine' Polynomial.splits_of_splits_of_dvd _ this
-        ((Polynomial.splits_map_iff _ _).2 _) (minpoly.dvd _ _ _)
+    set Ks := Algebra.adjoin F (s : Set K)
+    haveI : FiniteDimensional F Ks := ((Submodule.fg_iff_finiteDimensional _).1
+      (FG_adjoin_of_finite s.finite_toSet H3)).of_subalgebra_toSubmodule
+    letI := fieldOfFiniteDimensional F Ks
+    letI := (f : Ks →+* L).toAlgebra
+    have H5 : IsIntegral Ks a := isIntegral_of_isScalarTower H1
+    have H6 : (minpoly Ks a).Splits (algebraMap Ks L) := by
+      refine splits_of_splits_of_dvd _ ((minpoly.monic H1).map (algebraMap F Ks)).ne_zero
+        ((splits_map_iff _ _).2 ?_) (minpoly.dvd _ _ ?_)
       · rw [← IsScalarTower.algebraMap_eq]
         exact H2
       · rw [Polynomial.aeval_map_algebraMap, minpoly.aeval]
-    obtain ⟨y, hy⟩ := Polynomial.exists_root_of_splits _ H6 (ne_of_lt (minpoly.degree_pos H5)).symm
-    refine' ⟨Subalgebra.ofRestrictScalars F _ _⟩
-    refine' (AdjoinRoot.liftHom (minpoly (Algebra.adjoin F (↑s : Set K)) a) y hy).comp _
-    exact (AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly
-      (Algebra.adjoin F (↑s : Set K)) a).toAlgHom
-#align lift_of_splits lift_of_splits
+    obtain ⟨y, hy⟩ := Polynomial.exists_root_of_splits _ H6 (minpoly.degree_pos H5).ne'
+    exact ⟨Subalgebra.ofRestrictScalars F _ <| Algebra.adjoin.liftSingleton Ks a y hy⟩
+#align lift_of_splits Polynomial.lift_of_splits
 
 end Embeddings

--- a/Mathlib/RingTheory/Adjoin/Field.lean
+++ b/Mathlib/RingTheory/Adjoin/Field.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import Mathlib.Data.Polynomial.Splits
-import Mathlib.RingTheory.Adjoin.PowerBasis
+import Mathlib.RingTheory.Adjoin.Basic
 import Mathlib.RingTheory.AdjoinRoot
 
 #align_import ring_theory.adjoin.field from "leanprover-community/mathlib"@"c4658a649d216f57e99621708b09dcb3dcccbd23"


### PR DESCRIPTION
Before: *Construction* only imports *Normal*, which transitively imports *IsSplittingField*
Now: *Normal* imports *Construction*, *Construction* only imports *IsSplittingField*
So no extra transitive import is added to any file other than *Construction* and *Normal*.
As a consequence, `Polynomial.SplittingField.instNormal` is moved from *Construction* to *Normal*.

`adjoin_rootSet_eq_range` is added to *IsSplittingField*.

`splits_of_comp` in *Splits* is extracted from `splits_of_splits` in *IsSplittingField*.

Source of proof: https://math.stackexchange.com/a/2585087/12932

Move `Algebra.adjoin.liftSingleton` from *IsAlgClosed/Basic* to *Adjoin/Field* in order to speed up `lift_of_splits` (renamed to add namespace `Polynomial`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
