### PR TITLE
feat(RingTheory/PowerSeries): define composition of formal power series

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3012,6 +3012,7 @@ import Mathlib.RingTheory.Polynomial.Vieta
 import Mathlib.RingTheory.PolynomialAlgebra
 import Mathlib.RingTheory.PowerBasis
 import Mathlib.RingTheory.PowerSeries.Basic
+import Mathlib.RingTheory.PowerSeries.Comp
 import Mathlib.RingTheory.PowerSeries.Derivative
 import Mathlib.RingTheory.PowerSeries.WellKnown
 import Mathlib.RingTheory.Prime

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -1919,6 +1919,11 @@ theorem eval₂_trunc_eq_sum_range {S : Type*} [Semiring S] (s : S) (G : R →+*
     congr
     rw [coeff_trunc, if_pos h]
 
+lemma aeval_trunc_eq_sum_range {R S : Type*} [CommSemiring R] [Semiring S] [Algebra R S]
+    (s : S) (n) (f : R⟦X⟧) : aeval s (trunc n f) = ∑ i in range n, (coeff R i f) • s ^ i := by
+  simp_rw [aeval_def, Algebra.smul_def]
+  apply eval₂_trunc_eq_sum_range
+
 @[simp] theorem trunc_X (n) : trunc (n + 2) X = (Polynomial.X : R[X]) := by
   ext d
   rw [coeff_trunc, coeff_X]

--- a/Mathlib/RingTheory/PowerSeries/Comp.lean
+++ b/Mathlib/RingTheory/PowerSeries/Comp.lean
@@ -1,0 +1,274 @@
+/-
+Copyright (c) 2023 Richard M. Hill. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Richard M. Hill
+-/
+import Mathlib.RingTheory.PowerSeries.Basic
+/-!
+# Definitions
+
+Let `R` be a commutative semiring. Give two formal power series `f(X)` and `g(X)` with coefficients
+in `R`, their formal composition, when it exists, is the power series
+
+  `f ( g ( X ))= ∑ₙ fₙ * g^n`
+
+I.e the `d`-th coefficient of the composition is the sum
+
+  `∑ₙ fₙ * coeff R d (g ^ n)`.
+
+The formal composition exists when all of these sums have finite support. This happens for example
+when `f` is a polynomial, or when the constant term of `g` is nilpotent. There are also other cases
+where the composition is defined, although these cases are less easy to classify.
+
+In this file we define
+
+  `PowerSeries.hasComp` : a relation on `R⟦X⟧`, where `f.hasComp g` means that the formal
+                          composition of `f` and `g` exists.
+
+  `PowerSeries.comp`    : a binary operation on `R⟦X⟧`, where `f.comp g` is the formal composition
+                          in the case `f.hasComp g`, or zero otherwise.
+
+## Notation
+
+The operation `f.comp g` can also be written `f ∘ᶠ g`.
+
+
+## Main results
+
+  `add_hasComp` if `f.hasComp h` and `g.hasComp h` then `(f+g).hasComp h`.
+
+  `coe_hasComp` if `f` is a polynomial then `(f : R⟦X⟧).hasComp h`.
+
+  `hasComp_of_isNilpotent_constantCoeff` if the constant term of `g`
+                is nilpotent then `f.hasComp g`.
+
+  `add_comp` if `f.hasComp h` and `g.hasComp h` then `(f + g) ∘ᶠ h = f ∘ᶠ h + g ∘ᶠ h`.
+
+  `coe_comp_eq_aeval` if `f` is a polynomial then `f ∘ᶠ g = aeval g f`.
+-/
+
+open Nat Finset BigOperators Polynomial
+open scoped Classical
+
+namespace PowerSeries
+
+section CommutativeSemiring
+variable {R : Type*} [CommSemiring R]
+
+/--`f.hasComp g` states that the power series `g` may be substituted into
+the power series `f = ∑ₙ fₙ * Xⁿ` to give a new power series, whose `d`-coefficient is
+
+  `∑ₙ fₙ * coeff R d (g ^ n)`
+
+For the formal composition to make sense, we require that each of these sums
+has finite support. There are two common situations when `f.hasComp g`:
+either `f` could be a polynomial or the constant term of `g` could be zero.
+However, there are other intermediate cases if `R` is not an integral domain.
+-/
+def hasComp (f g : R⟦X⟧) : Prop := ∀ d, ∃ N, ∀ n, N ≤ n → (coeff R n f) * coeff R d (g^n) = 0
+
+/--
+Formal composition of power series.
+If `f.hasComp g` then `f ∘ᶠ g` is defined in the usual way.
+If not then `f ∘ᶠ g` defaults to `0`.
+-/
+noncomputable def comp (f g : R⟦X⟧) : R⟦X⟧ :=
+  if f.hasComp g then mk fun d ↦ ∑ᶠ n : ℕ, (coeff R n f) * coeff R d (g^n) else 0
+
+/--
+`f ∘ᶠ g` is notation for `f.comp g`, which is the
+composition of the formal power series `f` and `g`.
+
+If `f.hasComp g` then `f ∘ᶠ g` is defined in the usual way.
+If not then `f ∘ᶠ g` defaults to `0`.
+-/
+scoped infixr:90 " ∘ᶠ "  => PowerSeries.comp
+
+/-!
+## Criteria for `hasComp`
+
+The relation `hasComp` seems quite difficult to describe. It is neither symmetric,
+reflexive, nor transitive. It can happen that `f.hasComp g` and `g.hasComp h` but
+`¬f.hasComp (g ∘ ᶠh)` and `¬(f ∘ᶠ g).hasComp h`.
+For example, we may take `g = X` and `h = 1`, and almost any `f`.
+-/
+
+private lemma X_pow_dvd_pow_of_isNilpotent_constantCoeff {g} (d : ℕ)
+    (hg : IsNilpotent (constantCoeff R g)) :
+    ∃ N, X^d ∣ g^N := by
+  obtain ⟨N, hN⟩ := hg
+  use N * d
+  rw [pow_mul]
+  apply pow_dvd_pow_of_dvd
+  rwa [X_dvd_iff, map_pow]
+
+/--If `g` has nilpotent constant term then `f.hasComp g`.-/
+lemma hasComp_of_isNilpotent_constantCoeff {f g : R⟦X⟧} (hg : IsNilpotent (constantCoeff R g)) :
+    f.hasComp g := by
+  intro d
+  obtain ⟨N, hN⟩ := X_pow_dvd_pow_of_isNilpotent_constantCoeff d.succ hg
+  use N
+  intro n hn
+  have : X ^ d.succ ∣ g^n
+  · trans g ^ N
+    exact hN
+    apply pow_dvd_pow (h := hn)
+  rw [X_pow_dvd_iff] at this
+  rw [this, mul_zero]
+  exact lt.base d
+
+/--If the constant term of `g` is zero then `f.hasComp g`.-/
+lemma hasComp_of_constantCoeff_eq_zero {f g} (hg : constantCoeff R g = 0) :
+    hasComp f g := by
+  apply hasComp_of_isNilpotent_constantCoeff
+  rw [hg]
+  exact IsNilpotent.zero
+
+/--If `f` is a polynomial then `(↑f).hasComp g`-/
+lemma coe_hasComp {f : R[X]} {g} : (↑f : R⟦X⟧).hasComp g := by
+  intro
+  use f.natDegree + 1
+  intro _ hn
+  rw [Polynomial.coeff_coe, coeff_eq_zero_of_natDegree_lt, zero_mul]
+  rw [←succ_le]
+  exact hn
+
+lemma zero_hasComp {f} : hasComp 0 f (R := R) := by
+  rw [←Polynomial.coe_zero]
+  apply coe_hasComp
+
+lemma one_hasComp {f} : hasComp 1 f (R := R):= by
+  rw [←Polynomial.coe_one]
+  apply coe_hasComp
+
+lemma C_hasComp {f r}: (C R r).hasComp f := by
+  rw [←Polynomial.coe_C]
+  apply coe_hasComp
+
+lemma X_hasComp {f} : X.hasComp f (R := R):= by
+  rw [←Polynomial.coe_X]
+  apply coe_hasComp
+
+lemma add_hasComp {f₁ f₂ g : R⟦X⟧} (h₁ : f₁.hasComp g) (h₂ : f₂.hasComp g) :
+    (f₁ + f₂).hasComp g := by
+  intro d
+  obtain ⟨N₁,hN₁⟩ := h₁ d
+  obtain ⟨N₂,hN₂⟩ := h₂ d
+  use max N₁ N₂
+  intro _ hn
+  rw [map_add, add_mul, hN₁, hN₂, add_zero]
+  exact le_of_max_le_right hn
+  exact le_of_max_le_left hn
+
+/-
+Some lemmas allowing us to calculate compositions.
+-/
+lemma coeff_comp {f g n} (h : f.hasComp g (R := R)) :
+    coeff R n (f ∘ᶠ g) = ∑ᶠ d : ℕ, coeff R d f * coeff R n (g ^ d) := by
+  rw [comp, if_pos h, coeff_mk]
+
+lemma comp_eq_zero {f g} (h : ¬f.hasComp g (R := R)) : f ∘ᶠ g  = 0 := by
+  rw [comp, if_neg h]
+
+/--The `n`-th coefficient of `f ∘ᶠ g` may be calculated from a truncation of `f`.-/
+lemma coeff_comp_eq_coeff_aeval_trunc {f g n} (h : f.hasComp g) :
+    coeff R n (f ∘ᶠ g) = coeff R n (aeval g (trunc (h n).choose f)) := by
+  rw [aeval_trunc_eq_sum_range, map_sum, coeff_comp h]
+  apply finsum_eq_sum_of_support_subset
+  intro d hd
+  rw [Function.mem_support] at hd
+  rw [coe_range, Set.mem_Iio]
+  by_contra' h'
+  apply hd
+  apply (h n).choose_spec _ h'
+
+private lemma coeff_aeval_trunc_of_zero {N n M f g}
+    (hN : ∀ m, N ≤ m → coeff R m f * coeff R n (g^m) = 0) (hM : N ≤ M) :
+    coeff R n (aeval g (trunc M f)) = coeff R n (aeval g (trunc N f)) := by
+  induction hM with
+  | refl => rfl
+  | step ih1 ih2 => rw [trunc_succ, aeval_add, aeval_monomial, map_add, ←C_eq_algebraMap,
+      coeff_C_mul, ih2, hN _ ih1, add_zero]
+
+/--The `n`-th coefficient of `f ∘ᶠ g` may be calculated from a sufficiently long
+truncation of `f`.-/
+private lemma coeff_comp_eq_coeff_aeval_of_le {f g : R⟦X⟧} {d n} {h : f.hasComp g}
+    (hn : (h d).choose ≤ n) :
+    coeff R d (f ∘ᶠ g) = coeff R d (aeval g (trunc n f)) := by
+  rw [coeff_comp_eq_coeff_aeval_trunc h]
+  symm
+  apply coeff_aeval_trunc_of_zero
+  apply (h d).choose_spec
+  exact hn
+
+private lemma coeff_comp_eq_coeff_aeval_of {f g n N} (h : f.hasComp g (R := R))
+    (hN : ∀ m, N ≤ m → coeff R m f * coeff R n (g^m) = 0) :
+    coeff R n (f ∘ᶠ g) = coeff R n (aeval g (trunc N f)) := by
+  by_cases h' : N ≤ (h n).choose
+  · rw [coeff_comp_eq_coeff_aeval_trunc]
+    apply coeff_aeval_trunc_of_zero hN h'
+  · rw [not_le] at h'
+    apply coeff_comp_eq_coeff_aeval_of_le
+    apply le_of_lt h'
+
+theorem coe_comp_eq_aeval (f : R[X]) (g : R⟦X⟧):
+    f ∘ᶠ g = aeval g f := by
+  ext n
+  have := trunc_coe_eq_self f.natDegree.lt_succ_self
+  nth_rw 3 [←this]
+  apply coeff_comp_eq_coeff_aeval_of coe_hasComp
+  intro m hm
+  rw [succ_le] at hm
+  apply mul_eq_zero_of_left
+  rw [Polynomial.coeff_coe]
+  apply coeff_eq_zero_of_natDegree_lt hm
+
+theorem trunc_comp_eq_sum_range {n f g} :
+    (trunc n f) ∘ᶠ g = ∑ i in range n, C R (coeff R i f) * g ^ i := by
+  rw [coe_comp_eq_aeval, aeval_trunc_eq_sum_range]
+  simp_rw [smul_eq_C_mul]
+
+theorem coe_comp_eq_sum_range (f : R[X]) (g):
+    f ∘ᶠ g = ∑ i in range (natDegree f + 1), C R (f.coeff i) * g ^ i := by
+  rw [coe_comp_eq_aeval, aeval_eq_sum_range]
+  simp_rw [smul_eq_C_mul]
+
+lemma coeff_comp_of_stable {f g : R⟦X⟧} {n N} (h : f.hasComp g)
+    (hN : ∀ m, N ≤ m → coeff R m f * coeff R n (g^m) = 0) :
+    coeff R n (f ∘ᶠ g) = coeff R n (trunc N f ∘ᶠ g) := by
+  rw [coeff_comp_eq_coeff_aeval_of h hN, coe_comp_eq_aeval]
+
+private lemma coeff_comp_stable {f g : R⟦X⟧} (h : f.hasComp g) (d : ℕ) :
+    ∃ N, ∀ n, N ≤ n → coeff R d (f ∘ᶠ g) = coeff R d (trunc n f ∘ᶠ g) := by
+  use (h d).choose
+  intro _ h
+  rw [coeff_comp_eq_coeff_aeval_of_le h, coe_comp_eq_aeval]
+
+theorem add_comp {f g h : R⟦X⟧} (hf : f.hasComp h) (hg : g.hasComp h) :
+    (f + g) ∘ᶠ h = f ∘ᶠ h + g ∘ᶠ h := by
+  have hfg := add_hasComp hf hg
+  ext d
+  obtain ⟨Nf,hNf⟩ := coeff_comp_stable hf d
+  obtain ⟨Ng,hNg⟩ := coeff_comp_stable hg d
+  obtain ⟨Nfg,hNfg⟩ := coeff_comp_stable hfg d
+  let N := max (max Nf Ng) Nfg
+  rw [map_add, hNf N, hNg N, hNfg N, coe_comp_eq_aeval, coe_comp_eq_aeval, coe_comp_eq_aeval,
+    trunc_add, aeval_add, map_add]
+  apply le_max_right
+  apply le_max_of_le_left <| Nat.le_max_right Nf Ng
+  apply le_max_of_le_left <| le_max_left Nf Ng
+
+@[simp] theorem one_comp {f : R⟦X⟧} : 1 ∘ᶠ f = 1 := by
+  rw [←Polynomial.coe_one, coe_comp_eq_aeval, aeval_one, Polynomial.coe_one]
+
+@[simp] theorem zero_comp {f : R⟦X⟧} : 0 ∘ᶠ f = 0 := by
+  rw [←Polynomial.coe_zero, coe_comp_eq_aeval, aeval_zero, Polynomial.coe_zero]
+
+@[simp] lemma C_comp {f : R⟦X⟧} {a} : (C R a) ∘ᶠ f = C R a := by
+  rw [←Polynomial.coe_C, coe_comp_eq_aeval, aeval_C, Polynomial.coe_C, C_eq_algebraMap]
+
+@[simp] theorem X_comp (f : R⟦X⟧) : X ∘ᶠ f = f := by
+  rw [←Polynomial.coe_X, coe_comp_eq_aeval, aeval_X]
+
+end CommutativeSemiring
+end PowerSeries

--- a/Mathlib/RingTheory/PowerSeries/Comp.lean
+++ b/Mathlib/RingTheory/PowerSeries/Comp.lean
@@ -21,13 +21,10 @@ when `f` is a polynomial, or when the constant term of `g` is nilpotent. There a
 where the composition is defined, although these cases are less easy to classify.
 
 In this file we define
-
-  `PowerSeries.hasComp` : a relation on `R⟦X⟧`, where `f.hasComp g` means that the formal
-                          composition of `f` and `g` exists.
-
-  `PowerSeries.comp`    : a binary operation on `R⟦X⟧`, where `f.comp g` is the formal composition
-                          in the case `f.hasComp g`, or zero otherwise.
-
+* `PowerSeries.hasComp` : a relation on `R⟦X⟧`, where `f.hasComp g` means that the formal
+  composition of `f` and `g` exists.
+* `PowerSeries.comp` : a binary operation on `R⟦X⟧`, where `f.comp g` is the formal composition
+  in the case `f.hasComp g`, or zero otherwise.
 ## Notation
 
 The operation `f.comp g` can also be written `f ∘ᶠ g`.

--- a/Mathlib/RingTheory/PowerSeries/Comp.lean
+++ b/Mathlib/RingTheory/PowerSeries/Comp.lean
@@ -21,10 +21,11 @@ when $f$ is a polynomial, or when the constant term of $g$ is nilpotent. There a
 where the composition is defined, although these cases are less easy to classify.
 
 In this file we define
-* `PowerSeries.hasComp` : a relation on `R⟦X⟧`, where `f.hasComp g` means that the formal
+* `PowerSeries.HasComp` : a relation on `R⟦X⟧`, where `f.hasComp g` means that the formal
   composition of `f` and `g` exists.
 * `PowerSeries.comp` : a binary operation on `R⟦X⟧`, where `f.comp g` is the formal composition
-  in the case `f.hasComp g`, or zero otherwise.
+  in the case `f.HasComp g`, or zero otherwise.
+
 ## Notation
 
 The operation `f.comp g` can also be written `f ∘ᶠ g`.
@@ -33,14 +34,10 @@ The operation `f.comp g` can also be written `f ∘ᶠ g`.
 ## Main results
 
 * `add_HasComp` if `f.HasComp h` and `g.HasComp h` then `(f+g).HasComp h`.
-
 * `coe_HasComp` if `f` is a polynomial then `(f : R⟦X⟧).HasComp h`.
-
 * `HasComp_of_isNilpotent_constantCoeff` if the constant term of `g`
-                is nilpotent then `f.HasComp g`.
-
+    is nilpotent then `f.HasComp g`.
 * `add_comp` if `f.HasComp h` and `g.HasComp h` then `(f + g) ∘ᶠ h = f ∘ᶠ h + g ∘ᶠ h`.
-
 * `coe_comp_eq_aeval` if `f` is a polynomial then `f ∘ᶠ g = aeval g f`.
 -/
 

--- a/Mathlib/RingTheory/PowerSeries/Comp.lean
+++ b/Mathlib/RingTheory/PowerSeries/Comp.lean
@@ -7,26 +7,26 @@ import Mathlib.RingTheory.PowerSeries.Basic
 /-!
 # Definitions
 
-Let `R` be a commutative semiring. Give two formal power series `f(X)` and `g(X)` with coefficients
-in `R`, their formal composition, when it exists, is the power series
+Let $R$ be a commutative semiring. Give two formal power series $f(X)$ and $g(X)$ with coefficients
+in $R$, their formal composition, when it exists, is the power series
 
-  `f ( g ( X ))= ∑ₙ fₙ * g^n`
+$$ f ( g ( X ))= ∑_{n=0}^∞ \mathrm{coeff}_n(f) ⬝ g^n.$$
 
-I.e the `d`-th coefficient of the composition is the sum
+I.e the $d$-th coefficient of the composition is the sum
 
-  `∑ₙ fₙ * coeff R d (g ^ n)`.
+$$ ∑_{n=0}^∞ \mathrm{coeff}_n(f) ⬝ \mathrm{coeff}_d (g ^ n).$$
 
 The formal composition exists when all of these sums have finite support. This happens for example
-when `f` is a polynomial, or when the constant term of `g` is nilpotent. There are also other cases
+when $f$ is a polynomial, or when the constant term of $g$ is nilpotent. There are also other cases
 where the composition is defined, although these cases are less easy to classify.
 
 In this file we define
 
-  `PowerSeries.hasComp` : a relation on `R⟦X⟧`, where `f.hasComp g` means that the formal
+* `PowerSeries.HasComp` : a relation on `R⟦X⟧`, where `f.HasComp g` means that the formal
                           composition of `f` and `g` exists.
 
-  `PowerSeries.comp`    : a binary operation on `R⟦X⟧`, where `f.comp g` is the formal composition
-                          in the case `f.hasComp g`, or zero otherwise.
+* `PowerSeries.comp`    : a binary operation on `R⟦X⟧`, where `f.comp g` is the formal composition
+                          in the case `f.HasComp g`, or zero otherwise.
 
 ## Notation
 
@@ -35,16 +35,16 @@ The operation `f.comp g` can also be written `f ∘ᶠ g`.
 
 ## Main results
 
-  `add_hasComp` if `f.hasComp h` and `g.hasComp h` then `(f+g).hasComp h`.
+* `add_HasComp` if `f.HasComp h` and `g.HasComp h` then `(f+g).HasComp h`.
 
-  `coe_hasComp` if `f` is a polynomial then `(f : R⟦X⟧).hasComp h`.
+* `coe_HasComp` if `f` is a polynomial then `(f : R⟦X⟧).HasComp h`.
 
-  `hasComp_of_isNilpotent_constantCoeff` if the constant term of `g`
-                is nilpotent then `f.hasComp g`.
+* `HasComp_of_isNilpotent_constantCoeff` if the constant term of `g`
+                is nilpotent then `f.HasComp g`.
 
-  `add_comp` if `f.hasComp h` and `g.hasComp h` then `(f + g) ∘ᶠ h = f ∘ᶠ h + g ∘ᶠ h`.
+* `add_comp` if `f.HasComp h` and `g.HasComp h` then `(f + g) ∘ᶠ h = f ∘ᶠ h + g ∘ᶠ h`.
 
-  `coe_comp_eq_aeval` if `f` is a polynomial then `f ∘ᶠ g = aeval g f`.
+* `coe_comp_eq_aeval` if `f` is a polynomial then `f ∘ᶠ g = aeval g f`.
 -/
 
 open Nat Finset BigOperators Polynomial
@@ -55,41 +55,38 @@ namespace PowerSeries
 section CommutativeSemiring
 variable {R : Type*} [CommSemiring R]
 
-/--`f.hasComp g` states that the power series `g` may be substituted into
-the power series `f = ∑ₙ fₙ * Xⁿ` to give a new power series, whose `d`-coefficient is
+/--`f.HasComp g` states that the power series `g` may be substituted into the power series `f`
+to give a new power series, whose `d`-coefficient is $∑ fₙ ⬝ {coeff}_d(g^n)$. For the formal
+composition to make sense, we require that each of these sums has finite support.
+`f.HasComp g` is precisely this condition.
 
-  `∑ₙ fₙ * coeff R d (g ^ n)`
-
-For the formal composition to make sense, we require that each of these sums
-has finite support. There are two common situations when `f.hasComp g`:
-either `f` could be a polynomial or the constant term of `g` could be zero.
-However, there are other intermediate cases if `R` is not an integral domain.
+There are two common situations when `f.HasComp g`: either `f` could be a polynomial,
+or the constant term of `g` could be zero. However, there are other intermediate cases if `R`
+is not an integral domain.
 -/
-def hasComp (f g : R⟦X⟧) : Prop := ∀ d, ∃ N, ∀ n, N ≤ n → (coeff R n f) * coeff R d (g^n) = 0
+def HasComp (f g : R⟦X⟧) : Prop := ∀ d, ∃ N, ∀ n, N ≤ n → (coeff R n f) * coeff R d (g^n) = 0
 
 /--
-Formal composition of power series.
-If `f.hasComp g` then `f ∘ᶠ g` is defined in the usual way.
+Formal composition of power series. If `f.HasComp g` then `f ∘ᶠ g` is defined in the usual way.
 If not then `f ∘ᶠ g` defaults to `0`.
 -/
 noncomputable def comp (f g : R⟦X⟧) : R⟦X⟧ :=
-  if f.hasComp g then mk fun d ↦ ∑ᶠ n : ℕ, (coeff R n f) * coeff R d (g^n) else 0
+  if f.HasComp g then mk fun d ↦ ∑ᶠ n : ℕ, (coeff R n f) * coeff R d (g^n) else 0
 
 /--
-`f ∘ᶠ g` is notation for `f.comp g`, which is the
-composition of the formal power series `f` and `g`.
+`f ∘ᶠ g` is notation for `f.comp g`, which is the composition of the formal power series
+`f` and `g`.
 
-If `f.hasComp g` then `f ∘ᶠ g` is defined in the usual way.
-If not then `f ∘ᶠ g` defaults to `0`.
+If `f.HasComp g` then `f ∘ᶠ g` is defined in the usual way. If not then `f ∘ᶠ g` defaults to `0`.
 -/
 scoped infixr:90 " ∘ᶠ "  => PowerSeries.comp
 
 /-!
-## Criteria for `hasComp`
+## Criteria for `HasComp`
 
-The relation `hasComp` seems quite difficult to describe. It is neither symmetric,
-reflexive, nor transitive. It can happen that `f.hasComp g` and `g.hasComp h` but
-`¬f.hasComp (g ∘ ᶠh)` and `¬(f ∘ᶠ g).hasComp h`.
+The relation `HasComp` seems quite difficult to describe. It is neither symmetric,
+reflexive, nor transitive. It can happen that `f.HasComp g` and `g.HasComp h` but
+`¬f.HasComp (g ∘ ᶠh)` and `¬(f ∘ᶠ g).HasComp h`.
 For example, we may take `g = X` and `h = 1`, and almost any `f`.
 -/
 
@@ -102,9 +99,9 @@ private lemma X_pow_dvd_pow_of_isNilpotent_constantCoeff {g} (d : ℕ)
   apply pow_dvd_pow_of_dvd
   rwa [X_dvd_iff, map_pow]
 
-/--If `g` has nilpotent constant term then `f.hasComp g`.-/
-lemma hasComp_of_isNilpotent_constantCoeff {f g : R⟦X⟧} (hg : IsNilpotent (constantCoeff R g)) :
-    f.hasComp g := by
+/--If `g` has nilpotent constant term then `f.HasComp g`.-/
+lemma HasComp_of_isNilpotent_constantCoeff {f g : R⟦X⟧} (hg : IsNilpotent (constantCoeff R g)) :
+    f.HasComp g := by
   intro d
   obtain ⟨N, hN⟩ := X_pow_dvd_pow_of_isNilpotent_constantCoeff d.succ hg
   use N
@@ -117,15 +114,15 @@ lemma hasComp_of_isNilpotent_constantCoeff {f g : R⟦X⟧} (hg : IsNilpotent (c
   rw [this, mul_zero]
   exact lt.base d
 
-/--If the constant term of `g` is zero then `f.hasComp g`.-/
-lemma hasComp_of_constantCoeff_eq_zero {f g} (hg : constantCoeff R g = 0) :
-    hasComp f g := by
-  apply hasComp_of_isNilpotent_constantCoeff
+/--If the constant term of `g` is zero then `f.HasComp g`.-/
+lemma HasComp_of_constantCoeff_eq_zero {f g} (hg : constantCoeff R g = 0) :
+    HasComp f g := by
+  apply HasComp_of_isNilpotent_constantCoeff
   rw [hg]
   exact IsNilpotent.zero
 
-/--If `f` is a polynomial then `(↑f).hasComp g`-/
-lemma coe_hasComp {f : R[X]} {g} : (↑f : R⟦X⟧).hasComp g := by
+/--If `f` is a polynomial then `(↑f).HasComp g`-/
+lemma coe_HasComp {f : R[X]} {g} : (↑f : R⟦X⟧).HasComp g := by
   intro
   use f.natDegree + 1
   intro _ hn
@@ -133,24 +130,24 @@ lemma coe_hasComp {f : R[X]} {g} : (↑f : R⟦X⟧).hasComp g := by
   rw [←succ_le]
   exact hn
 
-lemma zero_hasComp {f} : hasComp 0 f (R := R) := by
+lemma zero_HasComp {f} : HasComp 0 f (R := R) := by
   rw [←Polynomial.coe_zero]
-  apply coe_hasComp
+  apply coe_HasComp
 
-lemma one_hasComp {f} : hasComp 1 f (R := R):= by
+lemma one_HasComp {f} : HasComp 1 f (R := R):= by
   rw [←Polynomial.coe_one]
-  apply coe_hasComp
+  apply coe_HasComp
 
-lemma C_hasComp {f r}: (C R r).hasComp f := by
+lemma C_HasComp {f r}: (C R r).HasComp f := by
   rw [←Polynomial.coe_C]
-  apply coe_hasComp
+  apply coe_HasComp
 
-lemma X_hasComp {f} : X.hasComp f (R := R):= by
+lemma X_HasComp {f} : X.HasComp f (R := R):= by
   rw [←Polynomial.coe_X]
-  apply coe_hasComp
+  apply coe_HasComp
 
-lemma add_hasComp {f₁ f₂ g : R⟦X⟧} (h₁ : f₁.hasComp g) (h₂ : f₂.hasComp g) :
-    (f₁ + f₂).hasComp g := by
+lemma add_HasComp {f₁ f₂ g : R⟦X⟧} (h₁ : f₁.HasComp g) (h₂ : f₂.HasComp g) :
+    (f₁ + f₂).HasComp g := by
   intro d
   obtain ⟨N₁,hN₁⟩ := h₁ d
   obtain ⟨N₂,hN₂⟩ := h₂ d
@@ -163,15 +160,15 @@ lemma add_hasComp {f₁ f₂ g : R⟦X⟧} (h₁ : f₁.hasComp g) (h₂ : f₂.
 /-
 Some lemmas allowing us to calculate compositions.
 -/
-lemma coeff_comp {f g n} (h : f.hasComp g (R := R)) :
+lemma coeff_comp {f g n} (h : f.HasComp g (R := R)) :
     coeff R n (f ∘ᶠ g) = ∑ᶠ d : ℕ, coeff R d f * coeff R n (g ^ d) := by
   rw [comp, if_pos h, coeff_mk]
 
-lemma comp_eq_zero {f g} (h : ¬f.hasComp g (R := R)) : f ∘ᶠ g  = 0 := by
+lemma comp_eq_zero {f g} (h : ¬f.HasComp g (R := R)) : f ∘ᶠ g  = 0 := by
   rw [comp, if_neg h]
 
 /--The `n`-th coefficient of `f ∘ᶠ g` may be calculated from a truncation of `f`.-/
-lemma coeff_comp_eq_coeff_aeval_trunc {f g n} (h : f.hasComp g) :
+lemma coeff_comp_eq_coeff_aeval_trunc {f g n} (h : f.HasComp g) :
     coeff R n (f ∘ᶠ g) = coeff R n (aeval g (trunc (h n).choose f)) := by
   rw [aeval_trunc_eq_sum_range, map_sum, coeff_comp h]
   apply finsum_eq_sum_of_support_subset
@@ -192,7 +189,7 @@ private lemma coeff_aeval_trunc_of_zero {N n M f g}
 
 /--The `n`-th coefficient of `f ∘ᶠ g` may be calculated from a sufficiently long
 truncation of `f`.-/
-private lemma coeff_comp_eq_coeff_aeval_of_le {f g : R⟦X⟧} {d n} {h : f.hasComp g}
+private lemma coeff_comp_eq_coeff_aeval_of_le {f g : R⟦X⟧} {d n} {h : f.HasComp g}
     (hn : (h d).choose ≤ n) :
     coeff R d (f ∘ᶠ g) = coeff R d (aeval g (trunc n f)) := by
   rw [coeff_comp_eq_coeff_aeval_trunc h]
@@ -201,7 +198,7 @@ private lemma coeff_comp_eq_coeff_aeval_of_le {f g : R⟦X⟧} {d n} {h : f.hasC
   apply (h d).choose_spec
   exact hn
 
-private lemma coeff_comp_eq_coeff_aeval_of {f g n N} (h : f.hasComp g (R := R))
+private lemma coeff_comp_eq_coeff_aeval_of {f g n N} (h : f.HasComp g (R := R))
     (hN : ∀ m, N ≤ m → coeff R m f * coeff R n (g^m) = 0) :
     coeff R n (f ∘ᶠ g) = coeff R n (aeval g (trunc N f)) := by
   by_cases h' : N ≤ (h n).choose
@@ -216,7 +213,7 @@ theorem coe_comp_eq_aeval (f : R[X]) (g : R⟦X⟧):
   ext n
   have := trunc_coe_eq_self f.natDegree.lt_succ_self
   nth_rw 3 [←this]
-  apply coeff_comp_eq_coeff_aeval_of coe_hasComp
+  apply coeff_comp_eq_coeff_aeval_of coe_HasComp
   intro m hm
   rw [succ_le] at hm
   apply mul_eq_zero_of_left
@@ -233,20 +230,20 @@ theorem coe_comp_eq_sum_range (f : R[X]) (g):
   rw [coe_comp_eq_aeval, aeval_eq_sum_range]
   simp_rw [smul_eq_C_mul]
 
-lemma coeff_comp_of_stable {f g : R⟦X⟧} {n N} (h : f.hasComp g)
+lemma coeff_comp_of_stable {f g : R⟦X⟧} {n N} (h : f.HasComp g)
     (hN : ∀ m, N ≤ m → coeff R m f * coeff R n (g^m) = 0) :
     coeff R n (f ∘ᶠ g) = coeff R n (trunc N f ∘ᶠ g) := by
   rw [coeff_comp_eq_coeff_aeval_of h hN, coe_comp_eq_aeval]
 
-private lemma coeff_comp_stable {f g : R⟦X⟧} (h : f.hasComp g) (d : ℕ) :
+private lemma coeff_comp_stable {f g : R⟦X⟧} (h : f.HasComp g) (d : ℕ) :
     ∃ N, ∀ n, N ≤ n → coeff R d (f ∘ᶠ g) = coeff R d (trunc n f ∘ᶠ g) := by
   use (h d).choose
   intro _ h
   rw [coeff_comp_eq_coeff_aeval_of_le h, coe_comp_eq_aeval]
 
-theorem add_comp {f g h : R⟦X⟧} (hf : f.hasComp h) (hg : g.hasComp h) :
+theorem add_comp {f g h : R⟦X⟧} (hf : f.HasComp h) (hg : g.HasComp h) :
     (f + g) ∘ᶠ h = f ∘ᶠ h + g ∘ᶠ h := by
-  have hfg := add_hasComp hf hg
+  have hfg := add_HasComp hf hg
   ext d
   obtain ⟨Nf,hNf⟩ := coeff_comp_stable hf d
   obtain ⟨Ng,hNg⟩ := coeff_comp_stable hg d


### PR DESCRIPTION
Define composition of formal power series in one variable over a commutative semiring `R`.

More precisely, if $f = \sum f_n \cdot X^n$ and $g$ are formal power series then their composition, if it is defined at all,
will have $d$-th coefficient equal to the sum

$$S_d = \sum_{n=0}^\infty f_n \cdot \mathrm{coeff}_d (g^n).$$

Define a relation `f.HasComp g` on `R[[X]]` to mean that all of the sums $S_d$ have finite support.
Define `f.comp g` to be the power series with coefficients `S_d` if `f.HasComp g`, or the zero power series if not.
Prove some simple properties of `HasComp` and `comp`.

Note : if every zero-divisor in `R` is nilpotent, then `f.HasComp g` is true iff either `f` is a polynomial or the constant term of `g` is zero. For more general rings `R`, the classification is not so simple. It is however true that for fixed `g`, the set of `f` satisfying `f.HasComp g` is a subring of `R[[X]]`, and the map $f \mapsto f \circ g$ is a ring homomorphism.

This is part of #7271.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
