### PR TITLE
refactor: Homotopy between Functions not ContinuousMaps

### DIFF
--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/InducedMaps.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/InducedMaps.lean
@@ -69,7 +69,7 @@ def uhpath01 : @fromTop (TopCat.of <| ULift.{u} I) (ULift.up (0 : I)) ⟶ fromTo
 
 end unitInterval
 
-namespace ContinuousMap.Homotopy
+namespace Function.Homotopy
 
 open unitInterval (uhpath01)
 
@@ -80,12 +80,12 @@ section Casts
 /-- Abbreviation for `eqToHom` that accepts points in a topological space -/
 abbrev hcast {X : TopCat} {x₀ x₁ : X} (hx : x₀ = x₁) : fromTop x₀ ⟶ fromTop x₁ :=
   eqToHom hx
-#align continuous_map.homotopy.hcast ContinuousMap.Homotopy.hcast
+#align continuous_map.homotopy.hcast Function.Homotopy.hcast
 
 @[simp]
 theorem hcast_def {X : TopCat} {x₀ x₁ : X} (hx₀ : x₀ = x₁) : hcast hx₀ = eqToHom hx₀ :=
   rfl
-#align continuous_map.homotopy.hcast_def ContinuousMap.Homotopy.hcast_def
+#align continuous_map.homotopy.hcast_def Function.Homotopy.hcast_def
 
 variable {X₁ X₂ Y : TopCat.{u}} {f : C(X₁, Y)} {g : C(X₂, Y)} {x₀ x₁ : X₁} {x₂ x₃ : X₂}
   {p : Path x₀ x₁} {q : Path x₂ x₃} (hfg : ∀ t, f (p t) = g (q t))
@@ -94,7 +94,7 @@ variable {X₁ X₂ Y : TopCat.{u}} {f : C(X₁, Y)} {g : C(X₂, Y)} {x₀ x₁
 `f(p)` and `g(p)` are the same as well, despite having a priori different types -/
 theorem heq_path_of_eq_image : HEq ((πₘ f).map ⟦p⟧) ((πₘ g).map ⟦q⟧) := by
   simp only [map_eq, ← Path.Homotopic.map_lift]; apply Path.Homotopic.hpath_hext; exact hfg
-#align continuous_map.homotopy.heq_path_of_eq_image ContinuousMap.Homotopy.heq_path_of_eq_image
+#align continuous_map.homotopy.heq_path_of_eq_image Function.Homotopy.heq_path_of_eq_image
 
 private theorem start_path : f x₀ = g x₂ := by convert hfg 0 <;> simp only [Path.source]
 
@@ -105,12 +105,12 @@ theorem eq_path_of_eq_image :
   rw [Functor.conj_eqToHom_iff_heq
     ((πₘ f).map ⟦p⟧) ((πₘ g).map ⟦q⟧) (start_path hfg) (end_path hfg)]
   exact heq_path_of_eq_image hfg
-#align continuous_map.homotopy.eq_path_of_eq_image ContinuousMap.Homotopy.eq_path_of_eq_image
+#align continuous_map.homotopy.eq_path_of_eq_image Function.Homotopy.eq_path_of_eq_image
 
 end Casts
 
 -- We let `X` and `Y` be spaces, and `f` and `g` be homotopic maps between them
-variable {X Y : TopCat.{u}} {f g : C(X, Y)} (H : ContinuousMap.Homotopy f g) {x₀ x₁ : X}
+variable {X Y : TopCat.{u}} {f g : C(X, Y)} (H : Homotopy f g) {x₀ x₁ : X}
   (p : fromTop x₀ ⟶ fromTop x₁)
 
 /-!
@@ -140,13 +140,13 @@ many of the paths do not have defeq starting/ending points, so we end up needing
 def uliftMap : C(TopCat.of (ULift.{u} I × X), Y) :=
   ⟨fun x => H (x.1.down, x.2),
     H.continuous.comp ((continuous_induced_dom.comp continuous_fst).prod_mk continuous_snd)⟩
-#align continuous_map.homotopy.ulift_map ContinuousMap.Homotopy.uliftMap
+#align continuous_map.homotopy.ulift_map Function.Homotopy.uliftMap
 
 -- This lemma has always been bad, but the linter only noticed after lean4#2644.
 @[simp, nolint simpNF]
 theorem ulift_apply (i : ULift.{u} I) (x : X) : H.uliftMap (i, x) = H (i.down, x) :=
   rfl
-#align continuous_map.homotopy.ulift_apply ContinuousMap.Homotopy.ulift_apply
+#align continuous_map.homotopy.ulift_apply Function.Homotopy.ulift_apply
 
 /-- An abbreviation for `prodToProdTop`, with some types already in place to help the
  typechecker. In particular, the first path should be on the ulifted unit interval. -/
@@ -154,17 +154,17 @@ abbrev prodToProdTopI {a₁ a₂ : TopCat.of (ULift I)} {b₁ b₂ : X} (p₁ : 
     (p₂ : fromTop b₁ ⟶ fromTop b₂) :=
   (prodToProdTop (TopCat.of <| ULift I) X).map (X := (a₁, b₁)) (Y := (a₂, b₂)) (p₁, p₂)
 set_option linter.uppercaseLean3 false in
-#align continuous_map.homotopy.prod_to_prod_Top_I ContinuousMap.Homotopy.prodToProdTopI
+#align continuous_map.homotopy.prod_to_prod_Top_I Function.Homotopy.prodToProdTopI
 
 /-- The diagonal path `d` of a homotopy `H` on a path `p` -/
 def diagonalPath : fromTop (H (0, x₀)) ⟶ fromTop (H (1, x₁)) :=
   (πₘ H.uliftMap).map (prodToProdTopI uhpath01 p)
-#align continuous_map.homotopy.diagonal_path ContinuousMap.Homotopy.diagonalPath
+#align continuous_map.homotopy.diagonal_path Function.Homotopy.diagonalPath
 
 /-- The diagonal path, but starting from `f x₀` and going to `g x₁` -/
 def diagonalPath' : fromTop (f x₀) ⟶ fromTop (g x₁) :=
   hcast (H.apply_zero x₀).symm ≫ H.diagonalPath p ≫ hcast (H.apply_one x₁)
-#align continuous_map.homotopy.diagonal_path' ContinuousMap.Homotopy.diagonalPath'
+#align continuous_map.homotopy.diagonal_path' Function.Homotopy.diagonalPath'
 
 /-- Proof that `f(p) = H(0 ⟶ 0, p)`, with the appropriate casts -/
 theorem apply_zero_path : (πₘ f).map p = hcast (H.apply_zero x₀).symm ≫
@@ -174,7 +174,7 @@ theorem apply_zero_path : (πₘ f).map p = hcast (H.apply_zero x₀).symm ≫
     apply @eq_path_of_eq_image _ _ _ _ H.uliftMap _ _ _ _ _ ((Path.refl (ULift.up _)).prod p')
     -- This used to be `rw`, but we need `erw` after leanprover/lean4#2644
     erw [Path.prod_coe]; simp_rw [ulift_apply]; simp
-#align continuous_map.homotopy.apply_zero_path ContinuousMap.Homotopy.apply_zero_path
+#align continuous_map.homotopy.apply_zero_path Function.Homotopy.apply_zero_path
 
 /-- Proof that `g(p) = H(1 ⟶ 1, p)`, with the appropriate casts -/
 theorem apply_one_path : (πₘ g).map p = hcast (H.apply_one x₀).symm ≫
@@ -184,7 +184,7 @@ theorem apply_one_path : (πₘ g).map p = hcast (H.apply_one x₀).symm ≫
     apply @eq_path_of_eq_image _ _ _ _ H.uliftMap _ _ _ _ _ ((Path.refl (ULift.up _)).prod p')
     -- This used to be `rw`, but we need `erw` after leanprover/lean4#2644
     erw [Path.prod_coe]; simp_rw [ulift_apply]; simp
-#align continuous_map.homotopy.apply_one_path ContinuousMap.Homotopy.apply_one_path
+#align continuous_map.homotopy.apply_one_path Function.Homotopy.apply_one_path
 
 /-- Proof that `H.evalAt x = H(0 ⟶ 1, x ⟶ x)`, with the appropriate casts -/
 theorem evalAt_eq (x : X) : ⟦H.evalAt x⟧ = hcast (H.apply_zero x).symm ≫
@@ -194,7 +194,7 @@ theorem evalAt_eq (x : X) : ⟦H.evalAt x⟧ = hcast (H.apply_zero x).symm ≫
   simp only [id_eq_path_refl, prodToProdTop_map, Path.Homotopic.prod_lift, map_eq, ←
     Path.Homotopic.map_lift]
   apply Path.Homotopic.hpath_hext; intro; rfl
-#align continuous_map.homotopy.eval_at_eq ContinuousMap.Homotopy.evalAt_eq
+#align continuous_map.homotopy.eval_at_eq Function.Homotopy.evalAt_eq
 
 -- Finally, we show `d = f(p) ≫ H₁ = H₀ ≫ g(p)`
 theorem eq_diag_path : (πₘ f).map p ≫ ⟦H.evalAt x₁⟧ = H.diagonalPath' p ∧
@@ -207,9 +207,9 @@ theorem eq_diag_path : (πₘ f).map p ≫ ⟦H.evalAt x₁⟧ = H.diagonalPath'
     slice_lhs 2 4 => simp [← CategoryTheory.Functor.map_comp]
   · slice_lhs 2 4 => rw [eqToHom_trans, eqToHom_refl] -- Porting note: this ↓ `simp` didn't do this
     slice_lhs 2 4 => simp [← CategoryTheory.Functor.map_comp]
-#align continuous_map.homotopy.eq_diag_path ContinuousMap.Homotopy.eq_diag_path
+#align continuous_map.homotopy.eq_diag_path Function.Homotopy.eq_diag_path
 
-end ContinuousMap.Homotopy
+end Function.Homotopy
 
 namespace FundamentalGroupoidFunctor
 
@@ -219,7 +219,7 @@ open scoped FundamentalGroupoid
 
 attribute [local instance] Path.Homotopic.setoid
 
-variable {X Y : TopCat.{u}} {f g : C(X, Y)} (H : ContinuousMap.Homotopy f g)
+variable {X Y : TopCat.{u}} {f g : C(X, Y)} (H : Function.Homotopy f g)
 
 /-- Given a homotopy H : f ∼ g, we have an associated natural isomorphism between the induced
 functors `f` and `g` -/

--- a/Mathlib/Topology/Homotopy/Basic.lean
+++ b/Mathlib/Topology/Homotopy/Basic.lean
@@ -67,7 +67,7 @@ variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] [Topolog
 
 open unitInterval
 
-namespace ContinuousMap
+namespace Function
 
 /-- `ContinuousMap.Homotopy f₀ f₁` is the type of homotopies from `f₀` to `f₁`.
 
@@ -75,12 +75,12 @@ When possible, instead of parametrizing results over `(f : Homotopy f₀ f₁)`,
 you should parametrize over `{F : Type*} [HomotopyLike F f₀ f₁] (f : F)`.
 
 When you extend this structure, make sure to extend `ContinuousMap.HomotopyLike`. -/
-structure Homotopy (f₀ f₁ : C(X, Y)) extends C(I × X, Y) where
+structure Homotopy (f₀ f₁ : X → Y) extends C(I × X, Y) where
   /-- value of the homotopy at 0 -/
   map_zero_left : ∀ x, toFun (0, x) = f₀ x
   /-- value of the homotopy at 1 -/
   map_one_left : ∀ x, toFun (1, x) = f₁ x
-#align continuous_map.homotopy ContinuousMap.Homotopy
+#align continuous_map.homotopy Function.Homotopy
 
 section
 
@@ -89,12 +89,12 @@ section
 
 You should extend this class when you extend `ContinuousMap.Homotopy`. -/
 class HomotopyLike {X Y : outParam (Type*)} [TopologicalSpace X] [TopologicalSpace Y]
-    (F : Type*) (f₀ f₁ : outParam <| C(X, Y)) extends ContinuousMapClass F (I × X) Y where
+    (F : Type*) (f₀ f₁ : outParam <| X → Y) extends ContinuousMapClass F (I × X) Y where
   /-- value of the homotopy at 0 -/
   map_zero_left (f : F) : ∀ x, f (0, x) = f₀ x
   /-- value of the homotopy at 1 -/
   map_one_left (f : F) : ∀ x, f (1, x) = f₁ x
-#align continuous_map.homotopy_like ContinuousMap.HomotopyLike
+#align continuous_map.homotopy_like Function.HomotopyLike
 
 end
 
@@ -102,7 +102,7 @@ namespace Homotopy
 
 section
 
-variable {f₀ f₁ : C(X, Y)}
+variable {f₀ f₁ : X → Y}
 
 instance : HomotopyLike (Homotopy f₀ f₁) f₀ f₁ where
   coe f := f.toFun
@@ -123,84 +123,84 @@ instance : CoeFun (Homotopy f₀ f₁) fun _ => I × X → Y :=
 @[ext]
 theorem ext {F G : Homotopy f₀ f₁} (h : ∀ x, F x = G x) : F = G :=
   FunLike.ext _ _ h
-#align continuous_map.homotopy.ext ContinuousMap.Homotopy.ext
+#align continuous_map.homotopy.ext Function.Homotopy.ext
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
 because it is a composition of multiple projections. -/
 def Simps.apply (F : Homotopy f₀ f₁) : I × X → Y :=
   F
-#align continuous_map.homotopy.simps.apply ContinuousMap.Homotopy.Simps.apply
+#align continuous_map.homotopy.simps.apply Function.Homotopy.Simps.apply
 
 initialize_simps_projections Homotopy (toFun → apply, -toContinuousMap)
 
 /-- Deprecated. Use `map_continuous` instead. -/
 protected theorem continuous (F : Homotopy f₀ f₁) : Continuous F :=
   F.continuous_toFun
-#align continuous_map.homotopy.continuous ContinuousMap.Homotopy.continuous
+#align continuous_map.homotopy.continuous Function.Homotopy.continuous
 
 @[simp]
 theorem apply_zero (F : Homotopy f₀ f₁) (x : X) : F (0, x) = f₀ x :=
   F.map_zero_left x
-#align continuous_map.homotopy.apply_zero ContinuousMap.Homotopy.apply_zero
+#align continuous_map.homotopy.apply_zero Function.Homotopy.apply_zero
 
 @[simp]
 theorem apply_one (F : Homotopy f₀ f₁) (x : X) : F (1, x) = f₁ x :=
   F.map_one_left x
-#align continuous_map.homotopy.apply_one ContinuousMap.Homotopy.apply_one
+#align continuous_map.homotopy.apply_one Function.Homotopy.apply_one
 
 @[simp]
 theorem coe_toContinuousMap (F : Homotopy f₀ f₁) : ⇑F.toContinuousMap = F :=
   rfl
-#align continuous_map.homotopy.coe_to_continuous_map ContinuousMap.Homotopy.coe_toContinuousMap
+#align continuous_map.homotopy.coe_to_continuous_map Function.Homotopy.coe_toContinuousMap
 
 /-- Currying a homotopy to a continuous function from `I` to `C(X, Y)`.
 -/
 def curry (F : Homotopy f₀ f₁) : C(I, C(X, Y)) :=
   F.toContinuousMap.curry
-#align continuous_map.homotopy.curry ContinuousMap.Homotopy.curry
+#align continuous_map.homotopy.curry Function.Homotopy.curry
 
 @[simp]
 theorem curry_apply (F : Homotopy f₀ f₁) (t : I) (x : X) : F.curry t x = F (t, x) :=
   rfl
-#align continuous_map.homotopy.curry_apply ContinuousMap.Homotopy.curry_apply
+#align continuous_map.homotopy.curry_apply Function.Homotopy.curry_apply
 
 /-- Continuously extending a curried homotopy to a function from `ℝ` to `C(X, Y)`.
 -/
 def extend (F : Homotopy f₀ f₁) : C(ℝ, C(X, Y)) :=
   F.curry.IccExtend zero_le_one
-#align continuous_map.homotopy.extend ContinuousMap.Homotopy.extend
+#align continuous_map.homotopy.extend Function.Homotopy.extend
 
 theorem extend_apply_of_le_zero (F : Homotopy f₀ f₁) {t : ℝ} (ht : t ≤ 0) (x : X) :
     F.extend t x = f₀ x := by
   rw [← F.apply_zero]
   exact ContinuousMap.congr_fun (Set.IccExtend_of_le_left (zero_le_one' ℝ) F.curry ht) x
-#align continuous_map.homotopy.extend_apply_of_le_zero ContinuousMap.Homotopy.extend_apply_of_le_zero
+#align continuous_map.homotopy.extend_apply_of_le_zero Function.Homotopy.extend_apply_of_le_zero
 
 theorem extend_apply_of_one_le (F : Homotopy f₀ f₁) {t : ℝ} (ht : 1 ≤ t) (x : X) :
     F.extend t x = f₁ x := by
   rw [← F.apply_one]
   exact ContinuousMap.congr_fun (Set.IccExtend_of_right_le (zero_le_one' ℝ) F.curry ht) x
-#align continuous_map.homotopy.extend_apply_of_one_le ContinuousMap.Homotopy.extend_apply_of_one_le
+#align continuous_map.homotopy.extend_apply_of_one_le Function.Homotopy.extend_apply_of_one_le
 
 @[simp]
 theorem extend_apply_coe (F : Homotopy f₀ f₁) (t : I) (x : X) : F.extend t x = F (t, x) :=
   ContinuousMap.congr_fun (Set.IccExtend_val (zero_le_one' ℝ) F.curry t) x
-#align continuous_map.homotopy.extend_apply_coe ContinuousMap.Homotopy.extend_apply_coe
+#align continuous_map.homotopy.extend_apply_coe Function.Homotopy.extend_apply_coe
 
 @[simp]
 theorem extend_apply_of_mem_I (F : Homotopy f₀ f₁) {t : ℝ} (ht : t ∈ I) (x : X) :
     F.extend t x = F (⟨t, ht⟩, x) :=
   ContinuousMap.congr_fun (Set.IccExtend_of_mem (zero_le_one' ℝ) F.curry ht) x
 set_option linter.uppercaseLean3 false in
-#align continuous_map.homotopy.extend_apply_of_mem_I ContinuousMap.Homotopy.extend_apply_of_mem_I
+#align continuous_map.homotopy.extend_apply_of_mem_I Function.Homotopy.extend_apply_of_mem_I
 
 theorem congr_fun {F G : Homotopy f₀ f₁} (h : F = G) (x : I × X) : F x = G x :=
   ContinuousMap.congr_fun (congr_arg _ h) x
-#align continuous_map.homotopy.congr_fun ContinuousMap.Homotopy.congr_fun
+#align continuous_map.homotopy.congr_fun Function.Homotopy.congr_fun
 
 theorem congr_arg (F : Homotopy f₀ f₁) {x y : I × X} (h : x = y) : F x = F y :=
   F.toContinuousMap.congr_arg h
-#align continuous_map.homotopy.congr_arg ContinuousMap.Homotopy.congr_arg
+#align continuous_map.homotopy.congr_arg Function.Homotopy.congr_arg
 
 end
 
@@ -211,7 +211,7 @@ def refl (f : C(X, Y)) : Homotopy f f where
   toFun x := f x.2
   map_zero_left _ := rfl
   map_one_left _ := rfl
-#align continuous_map.homotopy.refl ContinuousMap.Homotopy.refl
+#align continuous_map.homotopy.refl Function.Homotopy.refl
 
 instance : Inhabited (Homotopy (ContinuousMap.id X) (ContinuousMap.id X)) :=
   ⟨Homotopy.refl _⟩
@@ -219,23 +219,23 @@ instance : Inhabited (Homotopy (ContinuousMap.id X) (ContinuousMap.id X)) :=
 /-- Given a `Homotopy f₀ f₁`, we can define a `Homotopy f₁ f₀` by reversing the homotopy.
 -/
 @[simps]
-def symm {f₀ f₁ : C(X, Y)} (F : Homotopy f₀ f₁) : Homotopy f₁ f₀ where
+def symm {f₀ f₁ : X → Y} (F : Homotopy f₀ f₁) : Homotopy f₁ f₀ where
   toFun x := F (σ x.1, x.2)
   map_zero_left := by norm_num
   map_one_left := by norm_num
-#align continuous_map.homotopy.symm ContinuousMap.Homotopy.symm
+#align continuous_map.homotopy.symm Function.Homotopy.symm
 
 @[simp]
-theorem symm_symm {f₀ f₁ : C(X, Y)} (F : Homotopy f₀ f₁) : F.symm.symm = F := by
+theorem symm_symm {f₀ f₁ : X → Y} (F : Homotopy f₀ f₁) : F.symm.symm = F := by
   ext
   simp
-#align continuous_map.homotopy.symm_symm ContinuousMap.Homotopy.symm_symm
+#align continuous_map.homotopy.symm_symm Function.Homotopy.symm_symm
 
 /--
 Given `Homotopy f₀ f₁` and `Homotopy f₁ f₂`, we can define a `Homotopy f₀ f₂` by putting the first
 homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
 -/
-def trans {f₀ f₁ f₂ : C(X, Y)} (F : Homotopy f₀ f₁) (G : Homotopy f₁ f₂) : Homotopy f₀ f₂ where
+def trans {f₀ f₁ f₂ : X → Y} (F : Homotopy f₀ f₁) (G : Homotopy f₁ f₂) : Homotopy f₀ f₂ where
   toFun x := if (x.1 : ℝ) ≤ 1 / 2 then F.extend (2 * x.1) x.2 else G.extend (2 * x.1 - 1) x.2
   continuous_toFun := by
     refine'
@@ -246,9 +246,9 @@ def trans {f₀ f₁ f₂ : C(X, Y)} (F : Homotopy f₀ f₁) (G : Homotopy f₁
     norm_num [hx]
   map_zero_left x := by norm_num
   map_one_left x := by norm_num
-#align continuous_map.homotopy.trans ContinuousMap.Homotopy.trans
+#align continuous_map.homotopy.trans Function.Homotopy.trans
 
-theorem trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : Homotopy f₀ f₁) (G : Homotopy f₁ f₂) (x : I × X) :
+theorem trans_apply {f₀ f₁ f₂ : X → Y} (F : Homotopy f₀ f₁) (G : Homotopy f₁ f₂) (x : I × X) :
     (F.trans G) x =
       if h : (x.1 : ℝ) ≤ 1 / 2 then
         F (⟨2 * x.1, (unitInterval.mul_pos_mem_iff zero_lt_two).2 ⟨x.1.2.1, h⟩⟩, x.2)
@@ -258,9 +258,9 @@ theorem trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : Homotopy f₀ f₁) (G : Hom
     split_ifs <;>
       · rw [extend, ContinuousMap.coe_IccExtend, Set.IccExtend_of_mem]
         rfl
-#align continuous_map.homotopy.trans_apply ContinuousMap.Homotopy.trans_apply
+#align continuous_map.homotopy.trans_apply Function.Homotopy.trans_apply
 
-theorem symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : Homotopy f₀ f₁) (G : Homotopy f₁ f₂) :
+theorem symm_trans {f₀ f₁ f₂ : X → Y} (F : Homotopy f₀ f₁) (G : Homotopy f₁ f₂) :
     (F.trans G).symm = G.symm.trans F.symm := by
   ext ⟨t, _⟩
   rw [trans_apply, symm_apply, trans_apply]
@@ -278,22 +278,22 @@ theorem symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : Homotopy f₀ f₁) (G : Homo
     linarith
   · exfalso
     linarith
-#align continuous_map.homotopy.symm_trans ContinuousMap.Homotopy.symm_trans
+#align continuous_map.homotopy.symm_trans Function.Homotopy.symm_trans
 
 /-- Casting a `Homotopy f₀ f₁` to a `Homotopy g₀ g₁` where `f₀ = g₀` and `f₁ = g₁`.
 -/
 @[simps]
-def cast {f₀ f₁ g₀ g₁ : C(X, Y)} (F : Homotopy f₀ f₁) (h₀ : f₀ = g₀) (h₁ : f₁ = g₁) :
+def cast {f₀ f₁ g₀ g₁ : X → Y} (F : Homotopy f₀ f₁) (h₀ : f₀ = g₀) (h₁ : f₁ = g₁) :
     Homotopy g₀ g₁ where
   toFun := F
   map_zero_left := by simp [← h₀]
   map_one_left := by simp [← h₁]
-#align continuous_map.homotopy.cast ContinuousMap.Homotopy.cast
+#align continuous_map.homotopy.cast Function.Homotopy.cast
 
 /-- Composition of a `Homotopy g₀ g₁` and `f : C(X, Y)` as a homotopy between `g₀.comp f` and
 `g₁.comp f`. -/
 @[simps!]
-def compContinuousMap {g₀ g₁ : C(Y, Z)} (G : Homotopy g₀ g₁) (f : C(X, Y)) :
+def compContinuousMap {g₀ g₁ : Y → Z} (G : Homotopy g₀ g₁) (f : C(X, Y)) :
     Homotopy (g₀.comp f) (g₁.comp f) where
   toContinuousMap := G.comp (.prodMap (.id _) f)
   map_zero_left _ := G.map_zero_left _
@@ -303,18 +303,18 @@ def compContinuousMap {g₀ g₁ : C(Y, Z)} (G : Homotopy g₀ g₁) (f : C(X, Y
 `Homotopy (g₀.comp f₀) (g₁.comp f₁)`.
 -/
 @[simps]
-def hcomp {f₀ f₁ : C(X, Y)} {g₀ g₁ : C(Y, Z)} (F : Homotopy f₀ f₁) (G : Homotopy g₀ g₁) :
+def hcomp {f₀ f₁ : X → Y} {g₀ g₁ : Y → Z} (F : Homotopy f₀ f₁) (G : Homotopy g₀ g₁) :
     Homotopy (g₀.comp f₀) (g₁.comp f₁) where
   toFun x := G (x.1, F x)
   map_zero_left := by simp
   map_one_left := by simp
-#align continuous_map.homotopy.hcomp ContinuousMap.Homotopy.hcomp
+#align continuous_map.homotopy.hcomp Function.Homotopy.hcomp
 
 /-- Let `F` be a homotopy between `f₀ : C(X, Y)` and `f₁ : C(X, Y)`. Let `G` be a homotopy between
 `g₀ : C(X, Z)` and `g₁ : C(X, Z)`. Then `F.prodMk G` is the homotopy between `f₀.prodMk g₀` and
 `f₁.prodMk g₁` that sends `p` to `(F p, G p)`. -/
-nonrec def prodMk {f₀ f₁ : C(X, Y)} {g₀ g₁ : C(X, Z)} (F : Homotopy f₀ f₁) (G : Homotopy g₀ g₁) :
-    Homotopy (f₀.prodMk g₀) (f₁.prodMk g₁) where
+nonrec def prodMk {f₀ f₁ : X → Y} {g₀ g₁ : X → Z} (F : Homotopy f₀ f₁) (G : Homotopy g₀ g₁) :
+    Homotopy (fun x ↦ (f₀ x, g₀ x)) (fun x ↦ (f₁ x, g₁ x)) where
   toContinuousMap := F.prodMk G
   map_zero_left _ := Prod.ext (F.map_zero_left _) (G.map_zero_left _)
   map_one_left _ := Prod.ext (F.map_one_left _) (G.map_one_left _)
@@ -322,15 +322,15 @@ nonrec def prodMk {f₀ f₁ : C(X, Y)} {g₀ g₁ : C(X, Z)} (F : Homotopy f₀
 /-- Let `F` be a homotopy between `f₀ : C(X, Y)` and `f₁ : C(X, Y)`. Let `G` be a homotopy between
 `g₀ : C(Z, Z')` and `g₁ : C(Z, Z')`. Then `F.prodMap G` is the homotopy between `f₀.prodMap g₀` and
 `f₁.prodMap g₁` that sends `(t, x, z)` to `(F (t, x), G (t, z))`. -/
-def prodMap {f₀ f₁ : C(X, Y)} {g₀ g₁ : C(Z, Z')} (F : Homotopy f₀ f₁) (G : Homotopy g₀ g₁) :
-    Homotopy (f₀.prodMap g₀) (f₁.prodMap g₁) :=
+def prodMap {f₀ f₁ : X → Y} {g₀ g₁ : Z → Z'} (F : Homotopy f₀ f₁) (G : Homotopy g₀ g₁) :
+    Homotopy (Prod.map f₀ g₀) (Prod.map f₁ g₁) :=
   .prodMk (.hcomp (.refl .fst) F) (.hcomp (.refl .snd) G)
 
 /-- Given a family of homotopies `F i` between `f₀ i : C(X, Y i)` and `f₁ i : C(X, Y i)`, returns a
 homotopy between `ContinuousMap.pi f₀` and `ContinuousMap.pi f₁`. -/
-protected def pi {Y : ι → Type*} [∀ i, TopologicalSpace (Y i)] {f₀ f₁ : ∀ i, C(X, Y i)}
+protected def pi {Y : ι → Type*} [∀ i, TopologicalSpace (Y i)] {f₀ f₁ : ∀ i, X → Y i}
     (F : ∀ i, Homotopy (f₀ i) (f₁ i)) :
-    Homotopy (.pi f₀) (.pi f₁) where
+    Homotopy (fun x i ↦ f₀ i x) (fun x i ↦ f₁ i x) where
   toContinuousMap := .pi fun i ↦ F i
   map_zero_left x := funext fun i ↦ (F i).map_zero_left x
   map_one_left x := funext fun i ↦ (F i).map_one_left x
@@ -338,8 +338,8 @@ protected def pi {Y : ι → Type*} [∀ i, TopologicalSpace (Y i)] {f₀ f₁ :
 /-- Given a family of homotopies `F i` between `f₀ i : C(X i, Y i)` and `f₁ i : C(X i, Y i)`,
 returns a homotopy between `ContinuousMap.piMap f₀` and `ContinuousMap.piMap f₁`. -/
 protected def piMap {X Y : ι → Type*} [∀ i, TopologicalSpace (X i)] [∀ i, TopologicalSpace (Y i)]
-    {f₀ f₁ : ∀ i, C(X i, Y i)} (F : ∀ i, Homotopy (f₀ i) (f₁ i)) :
-    Homotopy (.piMap f₀) (.piMap f₁) :=
+    {f₀ f₁ : ∀ i, X i → Y i} (F : ∀ i, Homotopy (f₀ i) (f₁ i)) :
+    Homotopy (X := ∀ i, X i) (fun x i ↦ f₀ i (x i)) (fun x i ↦ f₁ i (x i)) :=
   .pi fun i ↦ .hcomp (.refl <| .eval i) (F i)
 
 end Homotopy
@@ -347,56 +347,56 @@ end Homotopy
 /-- Given continuous maps `f₀` and `f₁`, we say `f₀` and `f₁` are homotopic if there exists a
 `Homotopy f₀ f₁`.
 -/
-def Homotopic (f₀ f₁ : C(X, Y)) : Prop :=
+def Homotopic (f₀ f₁ : X → Y) : Prop :=
   Nonempty (Homotopy f₀ f₁)
-#align continuous_map.homotopic ContinuousMap.Homotopic
+#align continuous_map.homotopic Function.Homotopic
 
 namespace Homotopic
 
 @[refl]
 theorem refl (f : C(X, Y)) : Homotopic f f :=
   ⟨Homotopy.refl f⟩
-#align continuous_map.homotopic.refl ContinuousMap.Homotopic.refl
+#align continuous_map.homotopic.refl Function.Homotopic.refl
 
 @[symm]
-theorem symm ⦃f g : C(X, Y)⦄ (h : Homotopic f g) : Homotopic g f :=
+theorem symm ⦃f g : X → Y⦄ (h : Homotopic f g) : Homotopic g f :=
   h.map Homotopy.symm
-#align continuous_map.homotopic.symm ContinuousMap.Homotopic.symm
+#align continuous_map.homotopic.symm Function.Homotopic.symm
 
 @[trans]
-theorem trans ⦃f g h : C(X, Y)⦄ (h₀ : Homotopic f g) (h₁ : Homotopic g h) : Homotopic f h :=
+theorem trans ⦃f g h :X → Y⦄ (h₀ : Homotopic f g) (h₁ : Homotopic g h) : Homotopic f h :=
   h₀.map2 Homotopy.trans h₁
-#align continuous_map.homotopic.trans ContinuousMap.Homotopic.trans
+#align continuous_map.homotopic.trans Function.Homotopic.trans
 
-theorem hcomp {f₀ f₁ : C(X, Y)} {g₀ g₁ : C(Y, Z)} (h₀ : Homotopic f₀ f₁) (h₁ : Homotopic g₀ g₁) :
+theorem hcomp {f₀ f₁ : X → Y} {g₀ g₁ : Y → Z} (h₀ : Homotopic f₀ f₁) (h₁ : Homotopic g₀ g₁) :
     Homotopic (g₀.comp f₀) (g₁.comp f₁) :=
   h₀.map2 Homotopy.hcomp h₁
-#align continuous_map.homotopic.hcomp ContinuousMap.Homotopic.hcomp
+#align continuous_map.homotopic.hcomp Function.Homotopic.hcomp
 
-theorem equivalence : Equivalence (@Homotopic X Y _ _) :=
-  ⟨refl, by apply symm, by apply trans⟩
-#align continuous_map.homotopic.equivalence ContinuousMap.Homotopic.equivalence
+theorem equivalence : Equivalence fun f₀ f₁ : C(X, Y) ↦ Homotopic f₀ f₁ :=
+  ⟨refl, fun h ↦ symm h, fun h ↦ trans h⟩
+#align continuous_map.homotopic.equivalence Function.Homotopic.equivalence
 
-nonrec theorem prodMk {f₀ f₁ : C(X, Y)} {g₀ g₁ : C(X, Z)} :
-    Homotopic f₀ f₁ → Homotopic g₀ g₁ → Homotopic (f₀.prodMk g₀) (f₁.prodMk g₁)
+nonrec theorem prodMk {f₀ f₁ : X → Y} {g₀ g₁ : X → Z} :
+    Homotopic f₀ f₁ → Homotopic g₀ g₁ → Homotopic (fun x ↦ (f₀ x, g₀ x)) (fun x ↦ (f₁ x, g₁ x))
   | ⟨F⟩, ⟨G⟩ => ⟨F.prodMk G⟩
 
-nonrec theorem prodMap {f₀ f₁ : C(X, Y)} {g₀ g₁ : C(Z, Z')} :
-    Homotopic f₀ f₁ → Homotopic g₀ g₁ → Homotopic (f₀.prodMap g₀) (f₁.prodMap g₁)
+nonrec theorem prodMap {f₀ f₁ : X → Y} {g₀ g₁ : Z → Z'} :
+    Homotopic f₀ f₁ → Homotopic g₀ g₁ → Homotopic (Prod.map f₀ g₀) (Prod.map f₁ g₁)
   | ⟨F⟩, ⟨G⟩ => ⟨F.prodMap G⟩
 
 /-- If each `f₀ i : C(X, Y i)` is homotopic to `f₁ i : C(X, Y i)`, then `ContinuousMap.pi f₀` is
 homotopic to `ContinuousMap.pi f₁`. -/
-protected theorem pi {Y : ι → Type*} [∀ i, TopologicalSpace (Y i)] {f₀ f₁ : ∀ i, C(X, Y i)}
+protected theorem pi {Y : ι → Type*} [∀ i, TopologicalSpace (Y i)] {f₀ f₁ : ∀ i, X → Y i}
     (F : ∀ i, Homotopic (f₀ i) (f₁ i)) :
-    Homotopic (.pi f₀) (.pi f₁) :=
+    Homotopic (fun x i ↦ f₀ i x) (fun x i ↦ f₁ i x) :=
   ⟨.pi fun i ↦ (F i).some⟩
 
 /-- If each `f₀ i : C(X, Y i)` is homotopic to `f₁ i : C(X, Y i)`, then `ContinuousMap.pi f₀` is
 homotopic to `ContinuousMap.pi f₁`. -/
 protected theorem piMap {X Y : ι → Type*} [∀ i, TopologicalSpace (X i)]
     [∀ i, TopologicalSpace (Y i)] {f₀ f₁ : ∀ i, C(X i, Y i)} (F : ∀ i, Homotopic (f₀ i) (f₁ i)) :
-    Homotopic (.piMap f₀) (.piMap f₁) :=
+   Homotopic (X := ∀ i, X i) (fun x i ↦ f₀ i (x i)) (fun x i ↦ f₁ i (x i)) :=
   .pi fun i ↦ .hcomp (.refl <| .eval i) (F i)
 
 end Homotopic
@@ -405,18 +405,17 @@ end Homotopic
 The type of homotopies between `f₀ f₁ : C(X, Y)`, where the intermediate maps satisfy the predicate
 `P : C(X, Y) → Prop`
 -/
-structure HomotopyWith (f₀ f₁ : C(X, Y)) (P : C(X, Y) → Prop) extends Homotopy f₀ f₁ where
+structure HomotopyWith (f₀ f₁ : X → Y) (P : (X → Y) → Prop) extends Homotopy f₀ f₁ where
   -- porting note: todo: use `toHomotopy.curry t`
   /-- the intermediate maps of the homotopy satisfy the property -/
-  prop' : ∀ t, P ⟨fun x => toFun (t, x),
-    Continuous.comp continuous_toFun (continuous_const.prod_mk continuous_id')⟩
-#align continuous_map.homotopy_with ContinuousMap.HomotopyWith
+  prop' : ∀ t, P fun x ↦ toFun (t, x)
+#align continuous_map.homotopy_with Function.HomotopyWith
 
 namespace HomotopyWith
 
 section
 
-variable {f₀ f₁ : C(X, Y)} {P : C(X, Y) → Prop}
+variable {f₀ f₁ : X → Y} {P : (X → Y) → Prop}
 
 instance : HomotopyLike (HomotopyWith f₀ f₁ P) f₀ f₁ where
   coe F := ⇑F.toHomotopy
@@ -428,16 +427,16 @@ instance : HomotopyLike (HomotopyWith f₀ f₁ P) f₀ f₁ where
 
 theorem coeFn_injective : @Function.Injective (HomotopyWith f₀ f₁ P) (I × X → Y) (⇑) :=
   FunLike.coe_injective'
-#align continuous_map.homotopy_with.coe_fn_injective ContinuousMap.HomotopyWith.coeFn_injective
+#align continuous_map.homotopy_with.coe_fn_injective Function.HomotopyWith.coeFn_injective
 
 @[ext]
 theorem ext {F G : HomotopyWith f₀ f₁ P} (h : ∀ x, F x = G x) : F = G := FunLike.ext F G h
-#align continuous_map.homotopy_with.ext ContinuousMap.HomotopyWith.ext
+#align continuous_map.homotopy_with.ext Function.HomotopyWith.ext
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
 because it is a composition of multiple projections. -/
 def Simps.apply (F : HomotopyWith f₀ f₁ P) : I × X → Y := F
-#align continuous_map.homotopy_with.simps.apply ContinuousMap.HomotopyWith.Simps.apply
+#align continuous_map.homotopy_with.simps.apply Function.HomotopyWith.Simps.apply
 
 initialize_simps_projections HomotopyWith (toHomotopy_toContinuousMap_toFun → apply,
   -toHomotopy_toContinuousMap)
@@ -445,37 +444,37 @@ initialize_simps_projections HomotopyWith (toHomotopy_toContinuousMap_toFun → 
 @[continuity]
 protected theorem continuous (F : HomotopyWith f₀ f₁ P) : Continuous F :=
   F.continuous_toFun
-#align continuous_map.homotopy_with.continuous ContinuousMap.HomotopyWith.continuous
+#align continuous_map.homotopy_with.continuous Function.HomotopyWith.continuous
 
 @[simp]
 theorem apply_zero (F : HomotopyWith f₀ f₁ P) (x : X) : F (0, x) = f₀ x :=
   F.map_zero_left x
-#align continuous_map.homotopy_with.apply_zero ContinuousMap.HomotopyWith.apply_zero
+#align continuous_map.homotopy_with.apply_zero Function.HomotopyWith.apply_zero
 
 @[simp]
 theorem apply_one (F : HomotopyWith f₀ f₁ P) (x : X) : F (1, x) = f₁ x :=
   F.map_one_left x
-#align continuous_map.homotopy_with.apply_one ContinuousMap.HomotopyWith.apply_one
+#align continuous_map.homotopy_with.apply_one Function.HomotopyWith.apply_one
 
 -- porting note: removed `simp`
 theorem coe_toContinuousMap (F : HomotopyWith f₀ f₁ P) : ⇑F.toContinuousMap = F :=
   rfl
-#align continuous_map.homotopy_with.coe_to_continuous_map ContinuousMap.HomotopyWith.coe_toContinuousMap
+#align continuous_map.homotopy_with.coe_to_continuous_map Function.HomotopyWith.coe_toContinuousMap
 
 @[simp]
 theorem coe_toHomotopy (F : HomotopyWith f₀ f₁ P) : ⇑F.toHomotopy = F :=
   rfl
-#align continuous_map.homotopy_with.coe_to_homotopy ContinuousMap.HomotopyWith.coe_toHomotopy
+#align continuous_map.homotopy_with.coe_to_homotopy Function.HomotopyWith.coe_toHomotopy
 
 theorem prop (F : HomotopyWith f₀ f₁ P) (t : I) : P (F.toHomotopy.curry t) := F.prop' t
-#align continuous_map.homotopy_with.prop ContinuousMap.HomotopyWith.prop
+#align continuous_map.homotopy_with.prop Function.HomotopyWith.prop
 
 theorem extendProp (F : HomotopyWith f₀ f₁ P) (t : ℝ) : P (F.toHomotopy.extend t) := F.prop _
-#align continuous_map.homotopy_with.extend_prop ContinuousMap.HomotopyWith.extendProp
+#align continuous_map.homotopy_with.extend_prop Function.HomotopyWith.extendProp
 
 end
 
-variable {P : C(X, Y) → Prop}
+variable {P : (X → Y) → Prop}
 
 /-- Given a continuous function `f`, and a proof `h : P f`, we can define a `HomotopyWith f f P` by
 `F (t, x) = f x`
@@ -484,7 +483,7 @@ variable {P : C(X, Y) → Prop}
 def refl (f : C(X, Y)) (hf : P f) : HomotopyWith f f P where
   toHomotopy := Homotopy.refl f
   prop' := fun _ => hf
-#align continuous_map.homotopy_with.refl ContinuousMap.HomotopyWith.refl
+#align continuous_map.homotopy_with.refl Function.HomotopyWith.refl
 
 instance : Inhabited (HomotopyWith (ContinuousMap.id X) (ContinuousMap.id X) fun _ => True) :=
   ⟨HomotopyWith.refl _ trivial⟩
@@ -493,32 +492,32 @@ instance : Inhabited (HomotopyWith (ContinuousMap.id X) (ContinuousMap.id X) fun
 Given a `HomotopyWith f₀ f₁ P`, we can define a `HomotopyWith f₁ f₀ P` by reversing the homotopy.
 -/
 @[simps!]
-def symm {f₀ f₁ : C(X, Y)} (F : HomotopyWith f₀ f₁ P) : HomotopyWith f₁ f₀ P where
+def symm {f₀ f₁ : X → Y} (F : HomotopyWith f₀ f₁ P) : HomotopyWith f₁ f₀ P where
   toHomotopy := F.toHomotopy.symm
   prop' := fun t => F.prop (σ t)
-#align continuous_map.homotopy_with.symm ContinuousMap.HomotopyWith.symm
+#align continuous_map.homotopy_with.symm Function.HomotopyWith.symm
 
 @[simp]
-theorem symm_symm {f₀ f₁ : C(X, Y)} (F : HomotopyWith f₀ f₁ P) : F.symm.symm = F :=
+theorem symm_symm {f₀ f₁ : X → Y} (F : HomotopyWith f₀ f₁ P) : F.symm.symm = F :=
   ext <| Homotopy.congr_fun <| Homotopy.symm_symm _
-#align continuous_map.homotopy_with.symm_symm ContinuousMap.HomotopyWith.symm_symm
+#align continuous_map.homotopy_with.symm_symm Function.HomotopyWith.symm_symm
 
 /--
 Given `HomotopyWith f₀ f₁ P` and `HomotopyWith f₁ f₂ P`, we can define a `HomotopyWith f₀ f₂ P`
 by putting the first homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
 -/
-def trans {f₀ f₁ f₂ : C(X, Y)} (F : HomotopyWith f₀ f₁ P) (G : HomotopyWith f₁ f₂ P) :
+def trans {f₀ f₁ f₂ : X → Y} (F : HomotopyWith f₀ f₁ P) (G : HomotopyWith f₁ f₂ P) :
     HomotopyWith f₀ f₂ P :=
   { F.toHomotopy.trans G.toHomotopy with
     prop' := fun t => by
       simp only [Homotopy.trans]
-      change P ⟨fun _ => ite ((t : ℝ) ≤ _) _ _, _⟩
+      change P fun _ => ite ((t : ℝ) ≤ _) _ _
       split_ifs
       · exact F.extendProp _
       · exact G.extendProp _ }
-#align continuous_map.homotopy_with.trans ContinuousMap.HomotopyWith.trans
+#align continuous_map.homotopy_with.trans Function.HomotopyWith.trans
 
-theorem trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : HomotopyWith f₀ f₁ P) (G : HomotopyWith f₁ f₂ P)
+theorem trans_apply {f₀ f₁ f₂ : X → Y} (F : HomotopyWith f₀ f₁ P) (G : HomotopyWith f₁ f₂ P)
     (x : I × X) :
     (F.trans G) x =
       if h : (x.1 : ℝ) ≤ 1 / 2 then
@@ -526,85 +525,85 @@ theorem trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : HomotopyWith f₀ f₁ P) (G
       else
         G (⟨2 * x.1 - 1, unitInterval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, x.1.2.2⟩⟩, x.2) :=
   Homotopy.trans_apply _ _ _
-#align continuous_map.homotopy_with.trans_apply ContinuousMap.HomotopyWith.trans_apply
+#align continuous_map.homotopy_with.trans_apply Function.HomotopyWith.trans_apply
 
-theorem symm_trans {f₀ f₁ f₂ : C(X, Y)} (F : HomotopyWith f₀ f₁ P) (G : HomotopyWith f₁ f₂ P) :
+theorem symm_trans {f₀ f₁ f₂ : X → Y} (F : HomotopyWith f₀ f₁ P) (G : HomotopyWith f₁ f₂ P) :
     (F.trans G).symm = G.symm.trans F.symm :=
   ext <| Homotopy.congr_fun <| Homotopy.symm_trans _ _
-#align continuous_map.homotopy_with.symm_trans ContinuousMap.HomotopyWith.symm_trans
+#align continuous_map.homotopy_with.symm_trans Function.HomotopyWith.symm_trans
 
 /-- Casting a `HomotopyWith f₀ f₁ P` to a `HomotopyWith g₀ g₁ P` where `f₀ = g₀` and `f₁ = g₁`.
 -/
 @[simps!]
-def cast {f₀ f₁ g₀ g₁ : C(X, Y)} (F : HomotopyWith f₀ f₁ P) (h₀ : f₀ = g₀) (h₁ : f₁ = g₁) :
+def cast {f₀ f₁ g₀ g₁ : X → Y} (F : HomotopyWith f₀ f₁ P) (h₀ : f₀ = g₀) (h₁ : f₁ = g₁) :
     HomotopyWith g₀ g₁ P where
   toHomotopy := F.toHomotopy.cast h₀ h₁
   prop' := F.prop
-#align continuous_map.homotopy_with.cast ContinuousMap.HomotopyWith.cast
+#align continuous_map.homotopy_with.cast Function.HomotopyWith.cast
 
 end HomotopyWith
 
 /-- Given continuous maps `f₀` and `f₁`, we say `f₀` and `f₁` are homotopic with respect to the
 predicate `P` if there exists a `HomotopyWith f₀ f₁ P`.
 -/
-def HomotopicWith (f₀ f₁ : C(X, Y)) (P : C(X, Y) → Prop) : Prop :=
+def HomotopicWith (f₀ f₁ : X → Y) (P : (X → Y) → Prop) : Prop :=
   Nonempty (HomotopyWith f₀ f₁ P)
-#align continuous_map.homotopic_with ContinuousMap.HomotopicWith
+#align continuous_map.homotopic_with Function.HomotopicWith
 
 namespace HomotopicWith
 
-variable {P : C(X, Y) → Prop}
+variable {P : (X → Y) → Prop}
 
 -- porting note: removed @[refl]
 theorem refl (f : C(X, Y)) (hf : P f) : HomotopicWith f f P :=
   ⟨HomotopyWith.refl f hf⟩
-#align continuous_map.homotopic_with.refl ContinuousMap.HomotopicWith.refl
+#align continuous_map.homotopic_with.refl Function.HomotopicWith.refl
 
 @[symm]
-theorem symm ⦃f g : C(X, Y)⦄ (h : HomotopicWith f g P) : HomotopicWith g f P :=
+theorem symm ⦃f g : X → Y⦄ (h : HomotopicWith f g P) : HomotopicWith g f P :=
   ⟨h.some.symm⟩
-#align continuous_map.homotopic_with.symm ContinuousMap.HomotopicWith.symm
+#align continuous_map.homotopic_with.symm Function.HomotopicWith.symm
 
 -- Note: this was formerly tagged with `@[trans]`, and although the `trans` attribute accepted it
 -- the `trans` tactic could not use it.
 -- An update to the trans tactic coming in mathlib4#7014 will reject this attribute.
 -- It could be restored by changing the argument order to `HomotopicWith P f g`.
 @[trans]
-theorem trans ⦃f g h : C(X, Y)⦄ (h₀ : HomotopicWith f g P) (h₁ : HomotopicWith g h P) :
+theorem trans ⦃f g h : X → Y⦄ (h₀ : HomotopicWith f g P) (h₁ : HomotopicWith g h P) :
     HomotopicWith f h P :=
   ⟨h₀.some.trans h₁.some⟩
-#align continuous_map.homotopic_with.trans ContinuousMap.HomotopicWith.trans
+#align continuous_map.homotopic_with.trans Function.HomotopicWith.trans
 
 end HomotopicWith
 
 /--
 A `HomotopyRel f₀ f₁ S` is a homotopy between `f₀` and `f₁` which is fixed on the points in `S`.
 -/
-abbrev HomotopyRel (f₀ f₁ : C(X, Y)) (S : Set X) :=
+abbrev HomotopyRel (f₀ f₁ : X → Y) (S : Set X) :=
   HomotopyWith f₀ f₁ fun f ↦ ∀ x ∈ S, f x = f₀ x
-#align continuous_map.homotopy_rel ContinuousMap.HomotopyRel
+#align continuous_map.homotopy_rel Function.HomotopyRel
 
 namespace HomotopyRel
 
 section
 
-variable {f₀ f₁ : C(X, Y)} {S : Set X}
+variable {f₀ f₁ : X → Y} {S : Set X}
 
 theorem eq_fst (F : HomotopyRel f₀ f₁ S) (t : I) {x : X} (hx : x ∈ S) : F (t, x) = f₀ x :=
   F.prop t x hx
-#align continuous_map.homotopy_rel.eq_fst ContinuousMap.HomotopyRel.eq_fst
+#align continuous_map.homotopy_rel.eq_fst Function.HomotopyRel.eq_fst
 
 theorem eq_snd (F : HomotopyRel f₀ f₁ S) (t : I) {x : X} (hx : x ∈ S) : F (t, x) = f₁ x := by
   rw [F.eq_fst t hx, ← F.eq_fst 1 hx, F.apply_one]
-#align continuous_map.homotopy_rel.eq_snd ContinuousMap.HomotopyRel.eq_snd
+#align continuous_map.homotopy_rel.eq_snd Function.HomotopyRel.eq_snd
 
 theorem fst_eq_snd (F : HomotopyRel f₀ f₁ S) {x : X} (hx : x ∈ S) : f₀ x = f₁ x :=
   F.eq_fst 0 hx ▸ F.eq_snd 0 hx
-#align continuous_map.homotopy_rel.fst_eq_snd ContinuousMap.HomotopyRel.fst_eq_snd
+#align continuous_map.homotopy_rel.fst_eq_snd Function.HomotopyRel.fst_eq_snd
 
 end
 
-variable {f₀ f₁ f₂ : C(X, Y)} {S : Set X}
+variable {f₀ f₁ f₂ : X → Y} {S : Set X}
 
 /-- Given a map `f : C(X, Y)` and a set `S`, we can define a `HomotopyRel f f S` by setting
 `F (t, x) = f x` for all `t`. This is defined using `HomotopyWith.refl`, but with the proof
@@ -613,7 +612,7 @@ filled in.
 @[simps!]
 def refl (f : C(X, Y)) (S : Set X) : HomotopyRel f f S :=
   HomotopyWith.refl f fun _ _ ↦ rfl
-#align continuous_map.homotopy_rel.refl ContinuousMap.HomotopyRel.refl
+#align continuous_map.homotopy_rel.refl Function.HomotopyRel.refl
 
 /--
 Given a `HomotopyRel f₀ f₁ S`, we can define a `HomotopyRel f₁ f₀ S` by reversing the homotopy.
@@ -622,12 +621,12 @@ Given a `HomotopyRel f₀ f₁ S`, we can define a `HomotopyRel f₁ f₀ S` by 
 def symm (F : HomotopyRel f₀ f₁ S) : HomotopyRel f₁ f₀ S where
   toHomotopy := F.toHomotopy.symm
   prop' := fun _ _ hx ↦ F.eq_snd _ hx
-#align continuous_map.homotopy_rel.symm ContinuousMap.HomotopyRel.symm
+#align continuous_map.homotopy_rel.symm Function.HomotopyRel.symm
 
 @[simp]
 theorem symm_symm (F : HomotopyRel f₀ f₁ S) : F.symm.symm = F :=
   HomotopyWith.symm_symm F
-#align continuous_map.homotopy_rel.symm_symm ContinuousMap.HomotopyRel.symm_symm
+#align continuous_map.homotopy_rel.symm_symm Function.HomotopyRel.symm_symm
 
 /-- Given `HomotopyRel f₀ f₁ S` and `HomotopyRel f₁ f₂ S`, we can define a `HomotopyRel f₀ f₂ S`
 by putting the first homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
@@ -639,7 +638,7 @@ def trans (F : HomotopyRel f₀ f₁ S) (G : HomotopyRel f₁ f₂ S) : Homotopy
     split_ifs
     · simp [HomotopyWith.extendProp F (2 * t) x hx, F.fst_eq_snd hx, G.fst_eq_snd hx]
     · simp [HomotopyWith.extendProp G (2 * t - 1) x hx, F.fst_eq_snd hx, G.fst_eq_snd hx]
-#align continuous_map.homotopy_rel.trans ContinuousMap.HomotopyRel.trans
+#align continuous_map.homotopy_rel.trans Function.HomotopyRel.trans
 
 theorem trans_apply (F : HomotopyRel f₀ f₁ S) (G : HomotopyRel f₁ f₂ S) (x : I × X) :
     (F.trans G) x =
@@ -648,26 +647,26 @@ theorem trans_apply (F : HomotopyRel f₀ f₁ S) (G : HomotopyRel f₁ f₂ S) 
       else
         G (⟨2 * x.1 - 1, unitInterval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, x.1.2.2⟩⟩, x.2) :=
   Homotopy.trans_apply _ _ _
-#align continuous_map.homotopy_rel.trans_apply ContinuousMap.HomotopyRel.trans_apply
+#align continuous_map.homotopy_rel.trans_apply Function.HomotopyRel.trans_apply
 
 theorem symm_trans (F : HomotopyRel f₀ f₁ S) (G : HomotopyRel f₁ f₂ S) :
     (F.trans G).symm = G.symm.trans F.symm :=
   HomotopyWith.ext <| Homotopy.congr_fun <| Homotopy.symm_trans _ _
-#align continuous_map.homotopy_rel.symm_trans ContinuousMap.HomotopyRel.symm_trans
+#align continuous_map.homotopy_rel.symm_trans Function.HomotopyRel.symm_trans
 
 /-- Casting a `HomotopyRel f₀ f₁ S` to a `HomotopyRel g₀ g₁ S` where `f₀ = g₀` and `f₁ = g₁`.
 -/
 @[simps!]
-def cast {f₀ f₁ g₀ g₁ : C(X, Y)} (F : HomotopyRel f₀ f₁ S) (h₀ : f₀ = g₀) (h₁ : f₁ = g₁) :
+def cast {f₀ f₁ g₀ g₁ : X → Y} (F : HomotopyRel f₀ f₁ S) (h₀ : f₀ = g₀) (h₁ : f₁ = g₁) :
     HomotopyRel g₀ g₁ S where
   toHomotopy := Homotopy.cast F.toHomotopy h₀ h₁
   prop' t x hx := by simpa only [← h₀, ← h₁] using F.prop t x hx
-#align continuous_map.homotopy_rel.cast ContinuousMap.HomotopyRel.cast
+#align continuous_map.homotopy_rel.cast Function.HomotopyRel.cast
 
 /-- Post-compose a homotopy relative to a set by a continuous function. -/
-@[simps!] def compContinuousMap {f₀ f₁ : C(X, Y)} (F : f₀.HomotopyRel f₁ S) (g : C(Y, Z)) :
-    (g.comp f₀).HomotopyRel (g.comp f₁) S where
-  toHomotopy := F.hcomp (ContinuousMap.Homotopy.refl g)
+@[simps!] def compContinuousMap {f₀ f₁ : X → Y} (F : f₀.HomotopyRel f₁ S) (g : C(Y, Z)) :
+    (comp g f₀).HomotopyRel (comp g f₁) S where
+  toHomotopy := F.hcomp (Homotopy.refl g)
   prop' t x hx := congr_arg g (F.prop t x hx)
 
 end HomotopyRel
@@ -675,41 +674,41 @@ end HomotopyRel
 /-- Given continuous maps `f₀` and `f₁`, we say `f₀` and `f₁` are homotopic relative to a set `S` if
 there exists a `HomotopyRel f₀ f₁ S`.
 -/
-def HomotopicRel (f₀ f₁ : C(X, Y)) (S : Set X) : Prop :=
+def HomotopicRel (f₀ f₁ : X → Y) (S : Set X) : Prop :=
   Nonempty (HomotopyRel f₀ f₁ S)
-#align continuous_map.homotopic_rel ContinuousMap.HomotopicRel
+#align continuous_map.homotopic_rel Function.HomotopicRel
 
 namespace HomotopicRel
 
 variable {S : Set X}
 
 /-- If two maps are homotopic relative to a set, then they are homotopic. -/
-protected theorem homotopic {f₀ f₁ : C(X, Y)} (h : HomotopicRel f₀ f₁ S) : Homotopic f₀ f₁ :=
+protected theorem homotopic {f₀ f₁ : X → Y} (h : HomotopicRel f₀ f₁ S) : Homotopic f₀ f₁ :=
   h.map fun F ↦ F.1
 
 -- porting note: removed @[refl]
 theorem refl (f : C(X, Y)) : HomotopicRel f f S :=
   ⟨HomotopyRel.refl f S⟩
-#align continuous_map.homotopic_rel.refl ContinuousMap.HomotopicRel.refl
+#align continuous_map.homotopic_rel.refl Function.HomotopicRel.refl
 
 @[symm]
-theorem symm ⦃f g : C(X, Y)⦄ (h : HomotopicRel f g S) : HomotopicRel g f S :=
+theorem symm ⦃f g : X → Y⦄ (h : HomotopicRel f g S) : HomotopicRel g f S :=
   h.map HomotopyRel.symm
-#align continuous_map.homotopic_rel.symm ContinuousMap.HomotopicRel.symm
+#align continuous_map.homotopic_rel.symm Function.HomotopicRel.symm
 
 @[trans]
-theorem trans ⦃f g h : C(X, Y)⦄ (h₀ : HomotopicRel f g S) (h₁ : HomotopicRel g h S) :
+theorem trans ⦃f g h : X → Y⦄ (h₀ : HomotopicRel f g S) (h₁ : HomotopicRel g h S) :
     HomotopicRel f h S :=
   h₀.map2 HomotopyRel.trans h₁
-#align continuous_map.homotopic_rel.trans ContinuousMap.HomotopicRel.trans
+#align continuous_map.homotopic_rel.trans Function.HomotopicRel.trans
 
-theorem equivalence : Equivalence fun f g : C(X, Y) => HomotopicRel f g S :=
-  ⟨refl, by apply symm, by apply trans⟩
-#align continuous_map.homotopic_rel.equivalence ContinuousMap.HomotopicRel.equivalence
+theorem equivalence : Equivalence fun f g : C(X, Y) ↦ HomotopicRel f g S :=
+  ⟨refl, fun h ↦ symm h, fun h ↦ trans h⟩
+#align continuous_map.homotopic_rel.equivalence Function.HomotopicRel.equivalence
 
 end HomotopicRel
 
-@[simp] theorem homotopicRel_empty {f₀ f₁ : C(X, Y)} : HomotopicRel f₀ f₁ ∅ ↔ Homotopic f₀ f₁ :=
+@[simp] theorem homotopicRel_empty {f₀ f₁ : X → Y} : HomotopicRel f₀ f₁ ∅ ↔ Homotopic f₀ f₁ :=
   ⟨fun h ↦ h.homotopic, fun ⟨F⟩ ↦ ⟨⟨F, fun _ _ ↦ False.elim⟩⟩⟩
 
-end ContinuousMap
+end Function

--- a/Mathlib/Topology/Homotopy/Contractible.lean
+++ b/Mathlib/Topology/Homotopy/Contractible.lean
@@ -16,34 +16,34 @@ In this file, we define `ContractibleSpace`, a space that is homotopy equivalent
 
 noncomputable section
 
-namespace ContinuousMap
+namespace Function
 
 variable {X Y Z : Type*} [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z]
 
 /-- A map is nullhomotopic if it is homotopic to a constant map. -/
-def Nullhomotopic (f : C(X, Y)) : Prop :=
-  ∃ y : Y, Homotopic f (ContinuousMap.const _ y)
-#align continuous_map.nullhomotopic ContinuousMap.Nullhomotopic
+def Nullhomotopic (f : X → Y) : Prop :=
+  ∃ y : Y, f.Homotopic (const _ y)
+#align continuous_map.nullhomotopic Function.Nullhomotopic
 
-theorem nullhomotopic_of_constant (y : Y) : Nullhomotopic (ContinuousMap.const X y) :=
-  ⟨y, by rfl⟩
-#align continuous_map.nullhomotopic_of_constant ContinuousMap.nullhomotopic_of_constant
+theorem nullhomotopic_of_constant (y : Y) : Nullhomotopic (const X y) :=
+  ⟨y, Homotopic.refl (ContinuousMap.const X y)⟩
+#align continuous_map.nullhomotopic_of_constant Function.nullhomotopic_of_constant
 
-theorem Nullhomotopic.comp_right {f : C(X, Y)} (hf : f.Nullhomotopic) (g : C(Y, Z)) :
-    (g.comp f).Nullhomotopic := by
+theorem Nullhomotopic.comp_right {f : X → Y} (hf : f.Nullhomotopic) (g : C(Y, Z)) :
+    (comp g f).Nullhomotopic := by
   cases' hf with y hy
   use g y
   exact Homotopic.hcomp hy (Homotopic.refl g)
-#align continuous_map.nullhomotopic.comp_right ContinuousMap.Nullhomotopic.comp_right
+#align continuous_map.nullhomotopic.comp_right Function.Nullhomotopic.comp_right
 
-theorem Nullhomotopic.comp_left {f : C(Y, Z)} (hf : f.Nullhomotopic) (g : C(X, Y)) :
+theorem Nullhomotopic.comp_left {f : Y → Z} (hf : f.Nullhomotopic) (g : C(X, Y)) :
     (f.comp g).Nullhomotopic := by
   cases' hf with y hy
   use y
   exact Homotopic.hcomp (Homotopic.refl g) hy
-#align continuous_map.nullhomotopic.comp_left ContinuousMap.Nullhomotopic.comp_left
+#align continuous_map.nullhomotopic.comp_left Function.Nullhomotopic.comp_left
 
-end ContinuousMap
+end Function
 
 open ContinuousMap
 
@@ -59,14 +59,14 @@ theorem ContractibleSpace.hequiv_unit (X : Type*) [TopologicalSpace X] [Contract
 #align contractible_space.hequiv_unit ContractibleSpace.hequiv_unit
 
 theorem id_nullhomotopic (X : Type*) [TopologicalSpace X] [ContractibleSpace X] :
-    (ContinuousMap.id X).Nullhomotopic := by
+    (@id X).Nullhomotopic := by
   obtain ⟨hv⟩ := ContractibleSpace.hequiv_unit X
   use hv.invFun ()
   convert hv.left_inv.symm
 #align id_nullhomotopic id_nullhomotopic
 
 theorem contractible_iff_id_nullhomotopic (Y : Type*) [TopologicalSpace Y] :
-    ContractibleSpace Y ↔ (ContinuousMap.id Y).Nullhomotopic := by
+    ContractibleSpace Y ↔ (@id Y).Nullhomotopic := by
   constructor
   · intro
     apply id_nullhomotopic
@@ -78,7 +78,7 @@ theorem contractible_iff_id_nullhomotopic (Y : Type*) [TopologicalSpace Y] :
             left_inv := ?_
             right_inv := ?_ }⟩ }
   · exact h.symm
-  · convert Homotopic.refl (ContinuousMap.id Unit)
+  · convert Function.Homotopic.refl (ContinuousMap.id Unit)
 #align contractible_iff_id_nullhomotopic contractible_iff_id_nullhomotopic
 
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
@@ -90,7 +90,7 @@ protected theorem ContinuousMap.HomotopyEquiv.contractibleSpace [ContractibleSpa
 
 protected theorem ContinuousMap.HomotopyEquiv.contractibleSpace_iff (e : X ≃ₕ Y) :
     ContractibleSpace X ↔ ContractibleSpace Y :=
-  ⟨fun _ => e.symm.contractibleSpace, fun _ => e.contractibleSpace⟩
+  ⟨fun _ ↦ e.symm.contractibleSpace, fun _ ↦ e.contractibleSpace⟩
 #align continuous_map.homotopy_equiv.contractible_space_iff ContinuousMap.HomotopyEquiv.contractibleSpace_iff
 
 protected theorem Homeomorph.contractibleSpace [ContractibleSpace Y] (e : X ≃ₜ Y) :
@@ -118,7 +118,7 @@ theorem hequiv [ContractibleSpace X] [ContractibleSpace Y] :
 
 instance (priority := 100) [ContractibleSpace X] : PathConnectedSpace X := by
   obtain ⟨p, ⟨h⟩⟩ := id_nullhomotopic X
-  have : ∀ x, Joined p x := fun x => ⟨(h.evalAt x).symm⟩
+  have : ∀ x, Joined p x := fun x ↦ ⟨(h.evalAt x).symm⟩
   rw [pathConnectedSpace_iff_eq]; use p; ext; tauto
 
 end ContractibleSpace

--- a/Mathlib/Topology/Homotopy/Equiv.lean
+++ b/Mathlib/Topology/Homotopy/Equiv.lean
@@ -32,6 +32,8 @@ variable {X : Type u} {Y : Type v} {Z : Type w} {Z' : Type x}
 
 variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] [TopologicalSpace Z']
 
+open Function
+
 namespace ContinuousMap
 
 /-- A homotopy equivalence between topological spaces `X` and `Y` are a pair of functions
@@ -42,8 +44,8 @@ are both homotopic to corresponding identity maps.
 structure HomotopyEquiv (X : Type u) (Y : Type v) [TopologicalSpace X] [TopologicalSpace Y] where
   toFun : C(X, Y)
   invFun : C(Y, X)
-  left_inv : (invFun.comp toFun).Homotopic (ContinuousMap.id X)
-  right_inv : (toFun.comp invFun).Homotopic (ContinuousMap.id Y)
+  left_inv : Homotopic (invFun.comp toFun) (ContinuousMap.id X)
+  right_inv : Homotopic (toFun.comp invFun) (ContinuousMap.id Y)
 #align continuous_map.homotopy_equiv ContinuousMap.HomotopyEquiv
 
 -- mathport name: continuous_map.homotopy_equiv
@@ -57,7 +59,7 @@ auxiliary definition will make porting of Lean 3 code easier.
 Porting note: TODO: drop this definition. -/
 @[coe] def toFun' (e : X ≃ₕ Y) : X → Y := e.toFun
 
-instance : CoeFun (X ≃ₕ Y) fun _ => X → Y := ⟨toFun'⟩
+instance : CoeFun (X ≃ₕ Y) fun _ ↦ X → Y := ⟨toFun'⟩
 
 @[simp]
 theorem toFun_eq_coe (h : HomotopyEquiv X Y) : (h.toFun : X → Y) = h :=

--- a/Mathlib/Topology/Homotopy/HSpaces.lean
+++ b/Mathlib/Topology/Homotopy/HSpaces.lean
@@ -54,7 +54,7 @@ noncomputable section
 
 open scoped unitInterval
 
-open Path ContinuousMap Set.Icc TopologicalSpace
+open Path Function Set.Icc TopologicalSpace
 
 /-- A topological space `X` is an H-space if it behaves like a (potentially non-associative)
 topological group, but where the axioms for a group only hold up to homotopy.
@@ -63,10 +63,8 @@ class HSpace (X : Type u) [TopologicalSpace X] where
   hmul : C(X × X, X)
   e : X
   hmul_e_e : hmul (e, e) = e
-  eHmul :
-    (hmul.comp <| (const X e).prodMk <| ContinuousMap.id X).HomotopyRel (ContinuousMap.id X) {e}
-  hmulE :
-    (hmul.comp <| (ContinuousMap.id X).prodMk <| const X e).HomotopyRel (ContinuousMap.id X) {e}
+  eHmul : (hmul ⟨e, ·⟩).HomotopyRel id {e}
+  hmulE : (hmul ⟨·, e⟩).HomotopyRel id {e}
 #align H_space HSpace
 
 -- We use the notation `⋀`, typeset as \And, to denote the binary operation `hmul` on an H-space
@@ -77,18 +75,18 @@ open HSpaces
 
 instance HSpace.prod (X : Type u) (Y : Type v) [TopologicalSpace X] [TopologicalSpace Y] [HSpace X]
     [HSpace Y] : HSpace (X × Y) where
-  hmul := ⟨fun p => (p.1.1 ⋀ p.2.1, p.1.2 ⋀ p.2.2), by
-    -- porting note: was `continuity`
-    exact ((map_continuous HSpace.hmul).comp ((continuous_fst.comp continuous_fst).prod_mk
+  hmul := ⟨fun p ↦ (p.1.1 ⋀ p.2.1, p.1.2 ⋀ p.2.2),
+    -- porting note: was `by continuity`
+      ((map_continuous HSpace.hmul).comp ((continuous_fst.comp continuous_fst).prod_mk
         (continuous_fst.comp continuous_snd))).prod_mk ((map_continuous HSpace.hmul).comp
-        ((continuous_snd.comp continuous_fst).prod_mk (continuous_snd.comp continuous_snd)))
-  ⟩
+        ((continuous_snd.comp continuous_fst).prod_mk (continuous_snd.comp continuous_snd)))⟩
   e := (HSpace.e, HSpace.e)
   hmul_e_e := by
     simp only [ContinuousMap.coe_mk, Prod.mk.inj_iff]
     exact ⟨HSpace.hmul_e_e, HSpace.hmul_e_e⟩
   eHmul := by
-    let G : I × X × Y → X × Y := fun p => (HSpace.eHmul (p.1, p.2.1), HSpace.eHmul (p.1, p.2.2))
+    let G : I × X × Y → X × Y := fun p ↦
+      (HSpace.eHmul.toFun (p.1, p.2.1), HSpace.eHmul.toFun (p.1, p.2.2))
     have hG : Continuous G :=
       (Continuous.comp HSpace.eHmul.1.1.2
           (continuous_fst.prod_mk (continuous_fst.comp continuous_snd))).prod_mk
@@ -103,7 +101,8 @@ instance HSpace.prod (X : Type u) (Y : Type v) [TopologicalSpace X] [Topological
       replace h := Prod.mk.inj_iff.mp h
       exact Prod.ext (HSpace.eHmul.2 t x h.1) (HSpace.eHmul.2 t y h.2)
   hmulE := by
-    let G : I × X × Y → X × Y := fun p => (HSpace.hmulE (p.1, p.2.1), HSpace.hmulE (p.1, p.2.2))
+    let G : I × X × Y → X × Y :=
+      fun p ↦ (HSpace.hmulE.toFun (p.1, p.2.1), HSpace.hmulE.toFun (p.1, p.2.2))
     have hG : Continuous G :=
       (Continuous.comp HSpace.hmulE.1.1.2
             (continuous_fst.prod_mk (continuous_fst.comp continuous_snd))).prod_mk
@@ -135,8 +134,8 @@ def toHSpace (M : Type u) [MulOneClass M] [TopologicalSpace M] [ContinuousMul M]
   hmul := ⟨Function.uncurry Mul.mul, continuous_mul⟩
   e := 1
   hmul_e_e := one_mul 1
-  eHmul := (HomotopyRel.refl _ _).cast rfl (by ext1; apply one_mul)
-  hmulE := (HomotopyRel.refl _ _).cast rfl (by ext1; apply mul_one)
+  eHmul := (HomotopyRel.refl (ContinuousMap.id M) _).cast (by ext1; symm; apply one_mul) rfl
+  hmulE := (HomotopyRel.refl (ContinuousMap.id M) _).cast (by ext1; symm; apply mul_one) rfl
 #align topological_group.to_H_space TopologicalGroup.toHSpace
 #align topological_add_group.to_H_space TopologicalAddGroup.toHSpace
 

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -44,10 +44,12 @@ open unitInterval
 
 namespace Path
 
+open Function
+
 /-- The type of homotopies between two paths.
 -/
 abbrev Homotopy (p₀ p₁ : Path x₀ x₁) :=
-  ContinuousMap.HomotopyRel p₀.toContinuousMap p₁.toContinuousMap {0, 1}
+  HomotopyRel p₀ p₁ {0, 1}
 #align path.homotopy Path.Homotopy
 
 namespace Homotopy
@@ -56,19 +58,19 @@ section
 
 variable {p₀ p₁ : Path x₀ x₁}
 
-theorem coeFn_injective : @Function.Injective (Homotopy p₀ p₁) (I × I → X) (⇑) :=
+theorem coeFn_injective : @Injective (Homotopy p₀ p₁) (I × I → X) (⇑) :=
   FunLike.coe_injective
 #align path.homotopy.coe_fn_injective Path.Homotopy.coeFn_injective
 
 @[simp]
 theorem source (F : Homotopy p₀ p₁) (t : I) : F (t, 0) = x₀ :=
-  calc F (t, 0) = p₀ 0 := ContinuousMap.HomotopyRel.eq_fst _ _ (.inl rfl)
+  calc F (t, 0) = p₀ 0 := HomotopyRel.eq_fst _ _ (.inl rfl)
   _ = x₀ := p₀.source
 #align path.homotopy.source Path.Homotopy.source
 
 @[simp]
 theorem target (F : Homotopy p₀ p₁) (t : I) : F (t, 1) = x₁ :=
-  calc F (t, 1) = p₀ 1 := ContinuousMap.HomotopyRel.eq_fst _ _ (.inr rfl)
+  calc F (t, 1) = p₀ 1 := HomotopyRel.eq_fst _ _ (.inr rfl)
   _ = x₁ := p₀.target
 #align path.homotopy.target Path.Homotopy.target
 
@@ -102,19 +104,19 @@ variable {p₀ p₁ p₂ : Path x₀ x₁}
 -/
 @[simps!]
 def refl (p : Path x₀ x₁) : Homotopy p p :=
-  ContinuousMap.HomotopyRel.refl p.toContinuousMap {0, 1}
+  HomotopyRel.refl p.toContinuousMap {0, 1}
 #align path.homotopy.refl Path.Homotopy.refl
 
 /-- Given a `Homotopy p₀ p₁`, we can define a `Homotopy p₁ p₀` by reversing the homotopy.
 -/
 @[simps!]
 def symm (F : Homotopy p₀ p₁) : Homotopy p₁ p₀ :=
-  ContinuousMap.HomotopyRel.symm F
+  HomotopyRel.symm F
 #align path.homotopy.symm Path.Homotopy.symm
 
 @[simp]
 theorem symm_symm (F : Homotopy p₀ p₁) : F.symm.symm = F :=
-  ContinuousMap.HomotopyRel.symm_symm F
+  HomotopyRel.symm_symm F
 #align path.homotopy.symm_symm Path.Homotopy.symm_symm
 
 /--
@@ -122,7 +124,7 @@ Given `Homotopy p₀ p₁` and `Homotopy p₁ p₂`, we can define a `Homotopy p
 homotopy on `[0, 1/2]` and the second on `[1/2, 1]`.
 -/
 def trans (F : Homotopy p₀ p₁) (G : Homotopy p₁ p₂) : Homotopy p₀ p₂ :=
-  ContinuousMap.HomotopyRel.trans F G
+  HomotopyRel.trans F G
 #align path.homotopy.trans Path.Homotopy.trans
 
 theorem trans_apply (F : Homotopy p₀ p₁) (G : Homotopy p₁ p₂) (x : I × I) :
@@ -131,19 +133,19 @@ theorem trans_apply (F : Homotopy p₀ p₁) (G : Homotopy p₁ p₂) (x : I × 
         F (⟨2 * x.1, (unitInterval.mul_pos_mem_iff zero_lt_two).2 ⟨x.1.2.1, h⟩⟩, x.2)
       else
         G (⟨2 * x.1 - 1, unitInterval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, x.1.2.2⟩⟩, x.2) :=
-  ContinuousMap.HomotopyRel.trans_apply _ _ _
+  HomotopyRel.trans_apply _ _ _
 #align path.homotopy.trans_apply Path.Homotopy.trans_apply
 
 theorem symm_trans (F : Homotopy p₀ p₁) (G : Homotopy p₁ p₂) :
     (F.trans G).symm = G.symm.trans F.symm :=
-  ContinuousMap.HomotopyRel.symm_trans _ _
+  HomotopyRel.symm_trans _ _
 #align path.homotopy.symm_trans Path.Homotopy.symm_trans
 
 /-- Casting a `Homotopy p₀ p₁` to a `Homotopy q₀ q₁` where `p₀ = q₀` and `p₁ = q₁`. -/
 @[simps!]
 def cast {p₀ p₁ q₀ q₁ : Path x₀ x₁} (F : Homotopy p₀ p₁) (h₀ : p₀ = q₀) (h₁ : p₁ = q₁) :
     Homotopy q₀ q₁ :=
-  ContinuousMap.HomotopyRel.cast F (congr_arg _ h₀) (congr_arg _ h₁)
+  HomotopyRel.cast F (congr_arg _ h₀) (congr_arg _ h₁)
 #align path.homotopy.cast Path.Homotopy.cast
 
 end
@@ -344,7 +346,7 @@ end Homotopic
 `fun _ ↦ x₁`. -/
 @[simps!]
 def toHomotopyConst (p : Path x₀ x₁) :
-    (ContinuousMap.const Y x₀).Homotopy (ContinuousMap.const Y x₁) where
+    (const Y x₀).Homotopy (const Y x₁) where
   toContinuousMap := p.toContinuousMap.comp ContinuousMap.fst
   map_zero_left _ := p.source
   map_one_left _ := p.target
@@ -354,8 +356,8 @@ end Path
 /-- Two constant continuous maps with nonempty domain are homotopic if and only if their values are
 joined by a path in the codomain. -/
 @[simp]
-theorem ContinuousMap.homotopic_const_iff [Nonempty Y] :
-    (ContinuousMap.const Y x₀).Homotopic (ContinuousMap.const Y x₁) ↔ Joined x₀ x₁ := by
+theorem Function.homotopic_const_iff [Nonempty Y] :
+    (const Y x₀).Homotopic (const Y x₁) ↔ Joined x₀ x₁ := by
   inhabit Y
   refine ⟨fun ⟨H⟩ ↦ ⟨⟨(H.toContinuousMap.comp .prodSwap).curry default, ?_, ?_⟩⟩,
     fun ⟨p⟩ ↦ ⟨p.toHomotopyConst⟩⟩ <;> simp
@@ -365,8 +367,8 @@ namespace ContinuousMap.Homotopy
 /-- Given a homotopy `H : f ∼ g`, get the path traced by the point `x` as it moves from
 `f x` to `g x`.
 -/
-def evalAt {X : Type*} {Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {f g : C(X, Y)}
-    (H : ContinuousMap.Homotopy f g) (x : X) : Path (f x) (g x) where
+def evalAt {X : Type*} {Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {f g : X → Y}
+    (H : f.Homotopy g) (x : X) : Path (f x) (g x) where
   toFun t := H (t, x)
   source' := H.apply_zero x
   target' := H.apply_one x

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -362,7 +362,7 @@ theorem Function.homotopic_const_iff [Nonempty Y] :
   refine ⟨fun ⟨H⟩ ↦ ⟨⟨(H.toContinuousMap.comp .prodSwap).curry default, ?_, ?_⟩⟩,
     fun ⟨p⟩ ↦ ⟨p.toHomotopyConst⟩⟩ <;> simp
 
-namespace ContinuousMap.Homotopy
+namespace Function.Homotopy
 
 /-- Given a homotopy `H : f ∼ g`, get the path traced by the point `x` as it moves from
 `f x` to `g x`.
@@ -372,6 +372,6 @@ def evalAt {X : Type*} {Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {f 
   toFun t := H (t, x)
   source' := H.apply_zero x
   target' := H.apply_one x
-#align continuous_map.homotopy.eval_at ContinuousMap.Homotopy.evalAt
+#align continuous_map.homotopy.eval_at Function.Homotopy.evalAt
 
-end ContinuousMap.Homotopy
+end Function.Homotopy

--- a/Mathlib/Topology/Homotopy/Product.lean
+++ b/Mathlib/Topology/Homotopy/Product.lean
@@ -49,14 +49,12 @@ of products.
 
 noncomputable section
 
-namespace ContinuousMap
-
-open ContinuousMap
+namespace Function
 
 section Pi
 
 variable {I A : Type*} {X : I → Type*} [∀ i, TopologicalSpace (X i)] [TopologicalSpace A]
-  {f g : ∀ i, C(A, X i)} {S : Set A}
+  {f g : ∀ i, A → X i} {S : Set A}
 
 -- Porting note: this definition is already in `Topology.Homotopy.Basic`
 -- /-- The product homotopy of `homotopies` between functions `f` and `g` -/
@@ -71,45 +69,44 @@ variable {I A : Type*} {X : I → Type*} [∀ i, TopologicalSpace (X i)] [Topolo
 /-- The relative product homotopy of `homotopies` between functions `f` and `g` -/
 @[simps!]
 def HomotopyRel.pi (homotopies : ∀ i : I, HomotopyRel (f i) (g i) S) :
-    HomotopyRel (pi f) (pi g) S :=
+    HomotopyRel (fun a i ↦ f i a) (fun a i ↦ g i a) S :=
   { Homotopy.pi fun i => (homotopies i).toHomotopy with
     prop' := by
       intro t x hx
-      dsimp only [coe_mk, pi_eval, toFun_eq_coe, HomotopyWith.coe_toContinuousMap]
       simp only [Function.funext_iff, ← forall_and]
       intro i
       exact (homotopies i).prop' t x hx }
-#align continuous_map.homotopy_rel.pi ContinuousMap.HomotopyRel.pi
+#align continuous_map.homotopy_rel.pi Function.HomotopyRel.pi
 
 end Pi
 
 section Prod
 
 variable {α β : Type*} [TopologicalSpace α] [TopologicalSpace β] {A : Type*} [TopologicalSpace A]
-  {f₀ f₁ : C(A, α)} {g₀ g₁ : C(A, β)} {S : Set A}
+  {f₀ f₁ : A → α} {g₀ g₁ : A → β} {S : Set A}
 
 /-- The product of homotopies `F` and `G`,
   where `F` takes `f₀` to `f₁` and `G` takes `g₀` to `g₁` -/
 @[simps]
 def Homotopy.prod (F : Homotopy f₀ f₁) (G : Homotopy g₀ g₁) :
-    Homotopy (ContinuousMap.prodMk f₀ g₀) (ContinuousMap.prodMk f₁ g₁) where
+    Homotopy (fun a ↦ (f₀ a, g₀ a)) (fun a ↦ (f₁ a, g₁ a)) where
   toFun t := (F t, G t)
-  map_zero_left x := by simp only [prod_eval, Homotopy.apply_zero]
-  map_one_left x := by simp only [prod_eval, Homotopy.apply_one]
-#align continuous_map.homotopy.prod ContinuousMap.Homotopy.prod
+  map_zero_left x := by simp only [Homotopy.apply_zero]
+  map_one_left x := by simp only [Homotopy.apply_one]
+#align continuous_map.homotopy.prod Function.Homotopy.prod
 
 /-- The relative product of homotopies `F` and `G`,
   where `F` takes `f₀` to `f₁` and `G` takes `g₀` to `g₁` -/
 @[simps!]
 def HomotopyRel.prod (F : HomotopyRel f₀ f₁ S) (G : HomotopyRel g₀ g₁ S) :
-    HomotopyRel (prodMk f₀ g₀) (prodMk f₁ g₁) S where
+    HomotopyRel (fun a ↦ (f₀ a, g₀ a)) (fun a ↦ (f₁ a, g₁ a)) S where
   toHomotopy := Homotopy.prod F.toHomotopy G.toHomotopy
   prop' t x hx := Prod.ext (F.prop' t x hx) (G.prop' t x hx)
-#align continuous_map.homotopy_rel.prod ContinuousMap.HomotopyRel.prod
+#align continuous_map.homotopy_rel.prod Function.HomotopyRel.prod
 
 end Prod
 
-end ContinuousMap
+end Function
 
 namespace Path.Homotopic
 
@@ -124,7 +121,7 @@ variable {ι : Type*} {X : ι → Type*} [∀ i, TopologicalSpace (X i)] {as bs 
 /-- The product of a family of path homotopies. This is just a specialization of `HomotopyRel`. -/
 def piHomotopy (γ₀ γ₁ : ∀ i, Path (as i) (bs i)) (H : ∀ i, Path.Homotopy (γ₀ i) (γ₁ i)) :
     Path.Homotopy (Path.pi γ₀) (Path.pi γ₁) :=
-  ContinuousMap.HomotopyRel.pi H
+  Function.HomotopyRel.pi H
 #align path.homotopic.pi_homotopy Path.Homotopic.piHomotopy
 
 /-- The product of a family of path homotopy classes. -/
@@ -187,7 +184,7 @@ variable {α β : Type*} [TopologicalSpace α] [TopologicalSpace β] {a₁ a₂ 
     This is `HomotopyRel.prod` specialized for path homotopies. -/
 def prodHomotopy (h₁ : Path.Homotopy p₁ p₁') (h₂ : Path.Homotopy p₂ p₂') :
     Path.Homotopy (p₁.prod p₂) (p₁'.prod p₂') :=
-  ContinuousMap.HomotopyRel.prod h₁ h₂
+  Function.HomotopyRel.prod h₁ h₂
 #align path.homotopic.prod_homotopy Path.Homotopic.prodHomotopy
 
 /-- The product of path classes q₁ and q₂. This is `Path.prod` descended to the quotient. -/


### PR DESCRIPTION
This allows talking about homotopies without needing to supply proofs of continuity for the two ends. This for example simplifies the definition of H-spaces.

Of course, if a homotopy exists between two functions, those two functions are automatically continuous because they are restrictions of the homotopy (which is continuous) to subspaces.

`Homotopy.refl` still needs a continuous map as input, and `Homotopic` is only an equivalence relation when restricted to ContinuousMap.

---

TODO: fix docstrings


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
