### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits/Fubini): Fubini theorem for colimits

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -61,6 +61,15 @@ structure DiagramOfCones where
     (map (f ≫ g)).hom = (map f).hom ≫ (map g).hom := by aesop_cat
 #align category_theory.limits.diagram_of_cones CategoryTheory.Limits.DiagramOfCones
 
+/-- A structure carrying a diagram of cocones over the functors `F.obj j`.
+-/
+structure DiagramOfCocones where
+  obj : ∀ j : J, Cocone (F.obj j)
+  map : ∀ {j j' : J} (f : j ⟶ j'), (obj j) ⟶ (Cocones.precompose (F.map f)).obj (obj j')
+  id : ∀ j : J, (map (𝟙 j)).hom = 𝟙 _ := by aesop_cat
+  comp : ∀ {j₁ j₂ j₃ : J} (f : j₁ ⟶ j₂) (g : j₂ ⟶ j₃),
+    (map (f ≫ g)).hom = (map f).hom ≫ (map g).hom := by aesop_cat
+
 variable {F}
 
 /-- Extract the functor `J ⥤ C` consisting of the cone points and the maps between them,
@@ -73,6 +82,16 @@ def DiagramOfCones.conePoints (D : DiagramOfCones F) : J ⥤ C where
   map_id j := D.id j
   map_comp f g := D.comp f g
 #align category_theory.limits.diagram_of_cones.cone_points CategoryTheory.Limits.DiagramOfCones.conePoints
+
+/-- Extract the functor `J ⥤ C` consisting of the cone points and the maps between them,
+from a `DiagramOfCocones`.
+-/
+@[simps]
+def DiagramOfCocones.coconePoints (D : DiagramOfCocones F) : J ⥤ C where
+  obj j := (D.obj j).pt
+  map f := (D.map f).hom
+  map_id j := D.id j
+  map_comp f g := D.comp f g
 
 /-- Given a diagram `D` of limit cones over the `F.obj j`, and a cone over `uncurry.obj F`,
 we can construct a cone over the diagram consisting of the cone points from `D`.
@@ -108,6 +127,40 @@ def coneOfConeUncurry {D : DiagramOfCones F} (Q : ∀ j, IsLimit (D.obj j))
               NatTrans.id_app] at this
             exact this) }
 #align category_theory.limits.cone_of_cone_uncurry CategoryTheory.Limits.coneOfConeUncurry
+
+/-- Given a diagram `D` of colimit cocones over the `F.obj j`, and a cocone over `uncurry.obj F`,
+we can construct a cocone over the diagram consisting of the cocone points from `D`.
+-/
+@[simps]
+def coconeOfCoconeUncurry {D : DiagramOfCocones F} (Q : ∀ j, IsColimit (D.obj j))
+    (c : Cocone (uncurry.obj F)) : Cocone D.coconePoints where
+  pt := c.pt
+  ι :=
+    { app := fun j =>
+        (Q j).desc
+          { pt := c.pt
+            ι :=
+              { app := fun k => c.ι.app (j, k)
+                naturality := fun k k' f => by
+                  dsimp; simp only [Category.comp_id]
+                  conv_lhs =>
+                    arg 1; equals (F.map (𝟙 _)).app _ ≫  (F.obj j).map f =>
+                      simp;
+                  conv_lhs => arg 1; rw [← uncurry_obj_map F ((𝟙 j,f) : (j,k) ⟶ (j,k'))]
+                  rw [c.w] } }
+      naturality := fun j j' f =>
+        (Q j).hom_ext
+          (by
+            dsimp
+            intro k
+            simp only [Limits.CoconeMorphism.w_assoc, Limits.Cocones.precompose_obj_ι,
+              Limits.IsColimit.fac_assoc, Limits.IsColimit.fac, NatTrans.comp_app, Category.comp_id,
+              Category.assoc]
+            have := @NatTrans.naturality _ _ _ _ _ _ c.ι (j, k) (j', k) (f, 𝟙 k)
+            dsimp at this
+            simp only [Category.id_comp, Category.comp_id, CategoryTheory.Functor.map_id,
+              NatTrans.id_app] at this
+            exact this) }
 
 /-- `coneOfConeUncurry Q c` is a limit cone when `c` is a limit cone.
 -/
@@ -148,6 +201,44 @@ def coneOfConeUncurryIsLimit {D : DiagramOfCones F} (Q : ∀ j, IsLimit (D.obj j
     rw [← w j]
     simp
 #align category_theory.limits.cone_of_cone_uncurry_is_limit CategoryTheory.Limits.coneOfConeUncurryIsLimit
+
+/-- `coconeOfCoconeUncurry Q c` is a colimit cocone when `c` is a colimit cocone.
+-/
+def coconeOfCoconeUncurryIsColimit {D : DiagramOfCocones F} (Q : ∀ j, IsColimit (D.obj j))
+    {c : Cocone (uncurry.obj F)} (P : IsColimit c) : IsColimit (coconeOfCoconeUncurry Q c) where
+  desc s :=
+    P.desc
+      { pt := s.pt
+        ι :=
+          { app := fun p => (D.obj p.1).ι.app p.2 ≫ s.ι.app p.1
+            naturality := fun p p' f => by
+              dsimp; simp only [Category.id_comp, Category.assoc]
+              rcases p with ⟨j, k⟩
+              rcases p' with ⟨j', k'⟩
+              rcases f with ⟨fj, fk⟩
+              dsimp
+              slice_lhs 2 3 => rw [(D.obj j').ι.naturality]
+              simp only [Functor.const_obj_map, Category.id_comp, Category.assoc]
+              have w := (D.map fj).w k
+              dsimp at w
+              slice_lhs 1 2 => rw [← w]
+              have n := s.ι.naturality fj
+              dsimp at n
+              simp only [Category.comp_id] at n
+              rw [← n]
+              simp } }
+  fac s j := by
+    apply (Q j).hom_ext
+    intro k
+    simp
+  uniq s m w := by
+    refine' P.uniq
+      { pt := s.pt
+        ι := _ } m _
+    rintro ⟨j, k⟩
+    dsimp
+    rw [← w j]
+    simp
 
 section
 
@@ -214,6 +305,65 @@ end
 
 section
 
+variable (F)
+
+variable [HasColimitsOfShape K C]
+
+/-- Given a functor `F : J ⥤ K ⥤ C`, with all needed colimits,
+we can construct a diagram consisting of the colimit cocone over each functor `F.obj j`,
+and the universal cocone morphisms between these.
+-/
+@[simps]
+noncomputable def DiagramOfCocones.mkOfHasColimits : DiagramOfCocones F where
+  obj j := colimit.cocone (F.obj j)
+  map f := { hom := colim.map (F.map f) }
+
+-- Satisfying the inhabited linter.
+noncomputable instance diagramOfCoconesInhabited : Inhabited (DiagramOfCocones F) :=
+  ⟨DiagramOfCocones.mkOfHasColimits F⟩
+
+@[simp]
+theorem DiagramOfCocones.mkOfHasColimits_coconePoints :
+    (DiagramOfCocones.mkOfHasColimits F).coconePoints = F ⋙ colim :=
+  rfl
+
+variable [HasColimit (uncurry.obj F)]
+
+variable [HasColimit (F ⋙ colim)]
+
+/-- The Fubini theorem for a functor `F : J ⥤ K ⥤ C`,
+showing that the colimit of `uncurry.obj F` can be computed as
+the colimit of the colimits of the functors `F.obj j`.
+-/
+noncomputable def colimitUncurryIsoColimitCompColim :
+    colimit (uncurry.obj F) ≅ colimit (F ⋙ colim) := by
+  let c := colimit.cocone (uncurry.obj F)
+  let P : IsColimit c := colimit.isColimit _
+  let G := DiagramOfCocones.mkOfHasColimits F
+  let Q : ∀ j, IsColimit (G.obj j) := fun j => colimit.isColimit _
+  have Q' := coconeOfCoconeUncurryIsColimit Q P
+  have Q'' := colimit.isColimit (F ⋙ colim)
+  exact IsColimit.coconePointUniqueUpToIso Q' Q''
+
+@[simp, reassoc]
+theorem colimitUncurryIsoColimitCompColim_ι_ι_inv {j} {k} :
+    colimit.ι (F.obj j) k ≫ colimit.ι (F ⋙ colim) j ≫ (colimitUncurryIsoColimitCompColim F).inv =
+      colimit.ι (uncurry.obj F) (j, k) := by
+  dsimp [colimitUncurryIsoColimitCompColim, IsColimit.coconePointUniqueUpToIso,
+    IsColimit.uniqueUpToIso]
+  simp
+
+@[simp, reassoc]
+theorem colimitUncurryIsoColimitCompColim_ι_hom {j} {k} :
+    colimit.ι _ (j, k) ≫ (colimitUncurryIsoColimitCompColim F).hom =
+      (colimit.ι _ k ≫ colimit.ι (F ⋙ colim) j : _ ⟶ (colimit (F ⋙ colim))) := by
+  rw [← cancel_mono (colimitUncurryIsoColimitCompColim F).inv]
+  simp
+
+end
+
+section
+
 variable (F) [HasLimitsOfShape J C] [HasLimitsOfShape K C]
 
 -- With only moderate effort these could be derived if needed:
@@ -251,6 +401,39 @@ end
 
 section
 
+variable (F) [HasColimitsOfShape J C] [HasColimitsOfShape K C]
+
+variable [HasColimitsOfShape (J × K) C] [HasColimitsOfShape (K × J) C]
+
+/-- The colimit of `F.flip ⋙ colim` is isomorphic to the colimit of `F ⋙ colim`. -/
+noncomputable def colimitFlipCompColimIsoColimitCompColim :
+    colimit (F.flip ⋙ colim) ≅ colimit (F ⋙ colim) :=
+  (colimitUncurryIsoColimitCompColim _).symm ≪≫
+    HasColimit.isoOfNatIso (uncurryObjFlip _) ≪≫
+      HasColimit.isoOfEquivalence (Prod.braiding _ _)
+          (NatIso.ofComponents fun _ => by rfl) ≪≫
+        colimitUncurryIsoColimitCompColim _
+
+@[simp, reassoc]
+theorem colimitFlipCompColimIsoColimitCompColim_ι_ι_hom (j) (k) :
+    colimit.ι (F.flip.obj k) j ≫ colimit.ι (F.flip ⋙ colim) k ≫
+      (colimitFlipCompColimIsoColimitCompColim F).hom =
+        (colimit.ι _ k ≫ colimit.ι (F ⋙ colim) j : _ ⟶ colimit (F⋙ colim)) := by
+  dsimp [colimitFlipCompColimIsoColimitCompColim]
+  slice_lhs 1 3 => simp only []
+  simp
+
+@[simp, reassoc]
+theorem colimitFlipCompColimIsoColimitCompColim_ι_ι_inv (k) (j) :
+    colimit.ι (F.obj j) k ≫ colimit.ι (F ⋙ colim) j ≫
+      (colimitFlipCompColimIsoColimitCompColim F).inv =
+        (colimit.ι _ j ≫ colimit.ι (F.flip ⋙ colim) k : _ ⟶ colimit (F.flip ⋙ colim)) := by
+  dsimp [colimitFlipCompColimIsoColimitCompColim]
+  slice_lhs 1 3 => simp only []
+  simp
+
+end
+
 variable (G : J × K ⥤ C)
 
 section
@@ -287,6 +470,41 @@ theorem limitIsoLimitCurryCompLim_inv_π {j} {k} :
   rw [← cancel_epi (limitIsoLimitCurryCompLim G).hom]
   simp
 #align category_theory.limits.limit_iso_limit_curry_comp_lim_inv_π CategoryTheory.Limits.limitIsoLimitCurryCompLim_inv_π
+
+end
+
+section
+
+variable [HasColimitsOfShape K C]
+
+variable [HasColimit G]
+
+variable [HasColimit (curry.obj G ⋙ colim)]
+
+/-- The Fubini theorem for a functor `G : J × K ⥤ C`,
+showing that the colimit of `G` can be computed as
+the colimit of the colimits of the functors `G.obj (j, _)`.
+-/
+noncomputable def colimitIsoColimitCurryCompColim : colimit G ≅ colimit (curry.obj G ⋙ colim) := by
+  have i : G ≅ uncurry.obj ((@curry J _ K _ C _).obj G) := currying.symm.unitIso.app G
+  haveI : Limits.HasColimit (uncurry.obj ((@curry J _ K _ C _).obj G)) := hasColimitOfIso i.symm
+  trans colimit (uncurry.obj ((@curry J _ K _ C _).obj G))
+  apply HasColimit.isoOfNatIso i
+  exact colimitUncurryIsoColimitCompColim ((@curry J _ K _ C _).obj G)
+
+@[simp, reassoc]
+theorem colimitIsoColimitCurryCompColim_ι_ι_inv {j} {k} :
+    colimit.ι ((curry.obj G).obj j) k ≫ colimit.ι (curry.obj G ⋙ colim) j ≫
+      (colimitIsoColimitCurryCompColim G).inv  = colimit.ι _ (j, k) := by
+  simp [colimitIsoColimitCurryCompColim, Trans.simple, HasColimit.isoOfNatIso,
+    colimitUncurryIsoColimitCompColim]
+
+@[simp, reassoc]
+theorem colimitIsoColimitCurryCompColim_ι_hom {j} {k} :
+    colimit.ι _ (j, k) ≫ (colimitIsoColimitCurryCompColim G).hom =
+      (colimit.ι (_) k ≫ colimit.ι (curry.obj G ⋙ colim) j : _ ⟶ colimit (_ ⋙ colim)) := by
+  rw [← cancel_mono (colimitIsoColimitCurryCompColim G).inv]
+  simp
 
 end
 
@@ -341,6 +559,48 @@ theorem limitCurrySwapCompLimIsoLimitCurryCompLim_inv_π_π {j} {k} :
 #align category_theory.limits.limit_curry_swap_comp_lim_iso_limit_curry_comp_lim_inv_π_π CategoryTheory.Limits.limitCurrySwapCompLimIsoLimitCurryCompLim_inv_π_π
 
 end
+
+section
+
+variable [HasColimits C]
+
+open CategoryTheory.prod
+
+/-- A variant of the Fubini theorem for a functor `G : J × K ⥤ C`,
+showing that $\colim_k \colim_j G(j,k) ≅ \colim_j \colim_k G(j,k)$.
+-/
+noncomputable def colimitCurrySwapCompColimIsoColimitCurryCompColim :
+    colimit (curry.obj (Prod.swap K J ⋙ G) ⋙ colim) ≅ colimit (curry.obj G ⋙ colim) :=
+  calc
+    colimit (curry.obj (Prod.swap K J ⋙ G) ⋙ colim) ≅ colimit (Prod.swap K J ⋙ G) :=
+      (colimitIsoColimitCurryCompColim _).symm
+    _ ≅ colimit G := (HasColimit.isoOfEquivalence (Prod.braiding K J) (Iso.refl _))
+    _ ≅ colimit (curry.obj G ⋙ colim) := colimitIsoColimitCurryCompColim _
+
+@[simp]
+theorem colimitCurrySwapCompColimIsoColimitCurryCompColim_ι_ι_hom {j} {k} :
+    colimit.ι _ j ≫  colimit.ι (curry.obj (Prod.swap K J ⋙ G)⋙ colim) k ≫
+      (colimitCurrySwapCompColimIsoColimitCurryCompColim G).hom =
+        (colimit.ι _ k ≫ colimit.ι (curry.obj G ⋙ colim) j : _ ⟶ colimit (curry.obj G⋙ colim)) := by
+  dsimp [colimitCurrySwapCompColimIsoColimitCurryCompColim]
+  slice_lhs 1 3 => simp only []
+  simp
+
+@[simp]
+theorem colimitCurrySwapCompColimIsoColimitCurryCompColim_ι_ι_inv {j} {k} :
+    colimit.ι _ k ≫  colimit.ι (curry.obj G⋙ colim) j ≫
+      (colimitCurrySwapCompColimIsoColimitCurryCompColim G).inv =
+        (colimit.ι _ j ≫
+          colimit.ι (curry.obj _ ⋙ colim) k : _ ⟶ colimit (curry.obj (Prod.swap K J ⋙ G)⋙ colim))
+            := by
+  dsimp [colimitCurrySwapCompColimIsoColimitCurryCompColim]
+  slice_lhs 1 3 => simp only []
+  simp only [colimitIsoColimitCurryCompColim_ι_ι_inv, HasColimit.isoOfEquivalence_inv_π,
+    Functor.id_obj, Functor.comp_obj, Prod.braiding_inverse_obj, Prod.braiding_functor_obj,
+    Prod.braiding_counitIso_inv_app, Prod.swap_obj, Iso.refl_hom, NatTrans.id_app, Category.id_comp,
+    Category.assoc, colimitIsoColimitCurryCompColim_ι_hom, curry_obj_obj_obj]
+  erw [CategoryTheory.Bifunctor.map_id]
+  simp
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -83,7 +83,7 @@ def DiagramOfCones.conePoints (D : DiagramOfCones F) : J ⥤ C where
   map_comp f g := D.comp f g
 #align category_theory.limits.diagram_of_cones.cone_points CategoryTheory.Limits.DiagramOfCones.conePoints
 
-/-- Extract the functor `J ⥤ C` consisting of the cone points and the maps between them,
+/-- Extract the functor `J ⥤ C` consisting of the cocone points and the maps between them,
 from a `DiagramOfCocones`.
 -/
 @[simps]

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -63,7 +63,6 @@ structure DiagramOfCones where
 
 /-- A structure carrying a diagram of cocones over the functors `F.obj j`.
 -/
-@[nolint docBlame] -- As this structure is rather auxiliary
 structure DiagramOfCocones where
   /-- For each object, a cocone. -/
   obj : ∀ j : J, Cocone (F.obj j)

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -587,8 +587,8 @@ theorem colimitCurrySwapCompColimIsoColimitCurryCompColim_ι_ι_inv {j} {k} :
     colimit.ι _ k ≫  colimit.ι (curry.obj G⋙ colim) j ≫
       (colimitCurrySwapCompColimIsoColimitCurryCompColim G).inv =
         (colimit.ι _ j ≫
-          colimit.ι (curry.obj _ ⋙ colim) k : _ ⟶ colimit (curry.obj (Prod.swap K J ⋙ G)⋙ colim))
-            := by
+          colimit.ι (curry.obj _ ⋙ colim) k :
+            _ ⟶ colimit (curry.obj (Prod.swap K J ⋙ G)⋙ colim)) := by
   dsimp [colimitCurrySwapCompColimIsoColimitCurryCompColim]
   slice_lhs 1 3 => simp only []
   simp only [colimitIsoColimitCurryCompColim_ι_ι_inv, HasColimit.isoOfEquivalence_inv_π,

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -31,10 +31,6 @@ and give simp lemmas characterising it.
 For convenience, we also provide
 `limitIsoLimitCurryCompLim G : limit G ≅ limit ((curry.obj G) ⋙ lim)`
 in terms of the uncurried functor.
-
-## Future work
-
-The dual statement.
 -/
 
 

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.Functor.Currying
 #align_import category_theory.limits.fubini from "leanprover-community/mathlib"@"59382264386afdbaf1727e617f5fdda511992eb9"
 
 /-!
-# A Fubini theorem for categorical limits
+# A Fubini theorem for categorical (co)limits
 
 We prove that $lim_{J × K} G = lim_J (lim_K G(j, -))$ for a functor `G : J × K ⥤ C`,
 when all the appropriate limits exist.
@@ -31,6 +31,8 @@ and give simp lemmas characterising it.
 For convenience, we also provide
 `limitIsoLimitCurryCompLim G : limit G ≅ limit ((curry.obj G) ⋙ lim)`
 in terms of the uncurried functor.
+
+All statements have their counterpart for colimits.
 -/
 
 

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -52,7 +52,9 @@ variable (F : J ⥤ K ⥤ C)
 /-- A structure carrying a diagram of cones over the functors `F.obj j`.
 -/
 structure DiagramOfCones where
+  /-- For each object, a cone. -/
   obj : ∀ j : J, Cone (F.obj j)
+  /-- For each map, a map of cones. -/
   map : ∀ {j j' : J} (f : j ⟶ j'), (Cones.postcompose (F.map f)).obj (obj j) ⟶ obj j'
   id : ∀ j : J, (map (𝟙 j)).hom = 𝟙 _ := by aesop_cat
   comp : ∀ {j₁ j₂ j₃ : J} (f : j₁ ⟶ j₂) (g : j₂ ⟶ j₃),
@@ -61,8 +63,11 @@ structure DiagramOfCones where
 
 /-- A structure carrying a diagram of cocones over the functors `F.obj j`.
 -/
+@[nolint docBlame] -- As this structure is rather auxiliary
 structure DiagramOfCocones where
+  /-- For each object, a cocone. -/
   obj : ∀ j : J, Cocone (F.obj j)
+  /-- For each map, a map of cocones. -/
   map : ∀ {j j' : J} (f : j ⟶ j'), (obj j) ⟶ (Cocones.precompose (F.map f)).obj (obj j')
   id : ∀ j : J, (map (𝟙 j)).hom = 𝟙 _ := by aesop_cat
   comp : ∀ {j₁ j₂ j₃ : J} (f : j₁ ⟶ j₂) (g : j₂ ⟶ j₃),

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -581,7 +581,7 @@ noncomputable def colimitCurrySwapCompColimIsoColimitCurryCompColim :
 
 @[simp]
 theorem colimitCurrySwapCompColimIsoColimitCurryCompColim_ι_ι_hom {j} {k} :
-    colimit.ι _ j ≫  colimit.ι (curry.obj (Prod.swap K J ⋙ G)⋙ colim) k ≫
+    colimit.ι _ j ≫  colimit.ι (curry.obj (Prod.swap K J ⋙ G) ⋙ colim) k ≫
       (colimitCurrySwapCompColimIsoColimitCurryCompColim G).hom =
         (colimit.ι _ k ≫ colimit.ι (curry.obj G ⋙ colim) j : _ ⟶ colimit (curry.obj G⋙ colim)) := by
   dsimp [colimitCurrySwapCompColimIsoColimitCurryCompColim]
@@ -590,11 +590,11 @@ theorem colimitCurrySwapCompColimIsoColimitCurryCompColim_ι_ι_hom {j} {k} :
 
 @[simp]
 theorem colimitCurrySwapCompColimIsoColimitCurryCompColim_ι_ι_inv {j} {k} :
-    colimit.ι _ k ≫  colimit.ι (curry.obj G⋙ colim) j ≫
+    colimit.ι _ k ≫  colimit.ι (curry.obj G ⋙ colim) j ≫
       (colimitCurrySwapCompColimIsoColimitCurryCompColim G).inv =
         (colimit.ι _ j ≫
           colimit.ι (curry.obj _ ⋙ colim) k :
-            _ ⟶ colimit (curry.obj (Prod.swap K J ⋙ G)⋙ colim)) := by
+            _ ⟶ colimit (curry.obj (Prod.swap K J ⋙ G) ⋙ colim)) := by
   dsimp [colimitCurrySwapCompColimIsoColimitCurryCompColim]
   slice_lhs 1 3 => simp only []
   simp only [colimitIsoColimitCurryCompColim_ι_ι_inv, HasColimit.isoOfEquivalence_inv_π,

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -581,7 +581,7 @@ noncomputable def colimitCurrySwapCompColimIsoColimitCurryCompColim :
 
 @[simp]
 theorem colimitCurrySwapCompColimIsoColimitCurryCompColim_ι_ι_hom {j} {k} :
-    colimit.ι _ j ≫  colimit.ι (curry.obj (Prod.swap K J ⋙ G) ⋙ colim) k ≫
+    colimit.ι _ j ≫ colimit.ι (curry.obj (Prod.swap K J ⋙ G) ⋙ colim) k ≫
       (colimitCurrySwapCompColimIsoColimitCurryCompColim G).hom =
         (colimit.ι _ k ≫ colimit.ι (curry.obj G ⋙ colim) j : _ ⟶ colimit (curry.obj G⋙ colim)) := by
   dsimp [colimitCurrySwapCompColimIsoColimitCurryCompColim]
@@ -590,7 +590,7 @@ theorem colimitCurrySwapCompColimIsoColimitCurryCompColim_ι_ι_hom {j} {k} :
 
 @[simp]
 theorem colimitCurrySwapCompColimIsoColimitCurryCompColim_ι_ι_inv {j} {k} :
-    colimit.ι _ k ≫  colimit.ι (curry.obj G ⋙ colim) j ≫
+    colimit.ι _ k ≫ colimit.ι (curry.obj G ⋙ colim) j ≫
       (colimitCurrySwapCompColimIsoColimitCurryCompColim G).inv =
         (colimit.ι _ j ≫
           colimit.ι (curry.obj _ ⋙ colim) k :


### PR DESCRIPTION
Dualize all statements in `CategoryTheory/Limits/Fubini.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I did not try to be smart about this and I kept statement and proofs as close as possible to the ones for limits. Main differences are the addition of a few type annotations. Tagged this as chore rather than feat as this consisted mostly copy-pasting.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
