### PR TITLE
[Merged by Bors] - chore: uncomment a norm_num test that passes now

### DIFF
--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -37,7 +37,7 @@ example : (6:ℝ) < 10 := by norm_num1
 example : (7:ℝ)/2 > 3 := by norm_num1
 example : (4:ℝ)⁻¹ < 1 := by norm_num1
 example : ((1:ℝ) / 2)⁻¹ = 2 := by norm_num1
--- example : 2 ^ 17 - 1 = 131071 := by norm_num1
+example : 2 ^ 17 - 1 = 131071 := by norm_num1
 -- example : (3 : ℝ) ^ (-2 : ℤ) = 1/9 := by norm_num1
 -- example : (3 : ℝ) ^ (-2 : ℤ) = 1/9 := by norm_num1
 -- example : (-3 : ℝ) ^ (0 : ℤ) = 1 := by norm_num1


### PR DESCRIPTION
This test started passing in https://github.com/leanprover-community/mathlib4/commit/60790d4fd15e2d67606041b9f7058872911a8ac8.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
