### PR TITLE
[Merged by Bors] - chore: bump toolchain to v4.3.0-rc1

### DIFF
--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -463,10 +463,7 @@ protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n �
     obtain ⟨r, rfl⟩ := hx
     exact hr r
   revert hx
-  -- porting note: workaround for lean4#1926, was `simp_rw [pow_succ']`
-  suffices h_lean4_1926 : ∀ (hx' : x ∈ M ^ n * M), C (Nat.succ n) x (by rwa [pow_succ']) from
-    fun hx => h_lean4_1926 (by rwa [← pow_succ'])
-  -- porting note: end workaround
+  simp_rw [pow_succ']
   intro hx
   exact
     Submodule.mul_induction_on' (fun m hm x ih => hmul _ _ hm (n_ih _) _ ih)

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -147,7 +147,7 @@ theorem prod_add [DecidableEq α] (f g : α → β) (s : Finset α) :
           rw [prod_ite]
           congr 1
           exact prod_bij'
-            (fun a _ => a.1) (by simp; tauto) (by simp)
+            (fun a _ => a.1) (by simp) (by simp)
             (fun a ha => ⟨a, (mem_filter.1 ha).1⟩) (fun a ha => by simp at ha; simp; tauto)
             (by simp) (by simp)
           exact prod_bij'

--- a/Mathlib/Algebra/Homology/Homology.lean
+++ b/Mathlib/Algebra/Homology/Homology.lean
@@ -303,16 +303,6 @@ def homology'Functor [HasCokernels V] (i : ι) : HomologicalComplex V c ⥤ V wh
   -- here, but universe implementation details get in the way...
   obj C := C.homology' i
   map {C₁ C₂} f := homology'.map _ _ (f.sqTo i) (f.sqFrom i) rfl
-  map_id _ := by
-    simp only
-    ext1
-    simp only [homology'.π_map, kernelSubobjectMap_id, Hom.sqFrom_id, Category.id_comp,
-      Category.comp_id]
-  map_comp _ _ := by
-    simp only
-    ext1
-    simp only [Hom.sqFrom_comp, kernelSubobjectMap_comp, homology'.π_map_assoc, homology'.π_map,
-      Category.assoc]
 #align homology_functor homology'Functor
 
 /-- The homology functor from `ι`-indexed complexes to `ι`-graded objects in `V`. -/
@@ -320,18 +310,6 @@ def homology'Functor [HasCokernels V] (i : ι) : HomologicalComplex V c ⥤ V wh
 def gradedHomology'Functor [HasCokernels V] : HomologicalComplex V c ⥤ GradedObject ι V where
   obj C i := C.homology' i
   map {C C'} f i := (homology'Functor V c i).map f
-  map_id _ := by
-    ext
-    simp only [GradedObject.categoryOfGradedObjects_id]
-    ext
-    simp only [homology'.π_map, homology'Functor_map, kernelSubobjectMap_id, Hom.sqFrom_id,
-      Category.id_comp, Category.comp_id]
-  map_comp _ _ := by
-    ext
-    simp only [GradedObject.categoryOfGradedObjects_comp]
-    ext
-    simp only [Hom.sqFrom_comp, kernelSubobjectMap_comp, homology'.π_map_assoc, homology'.π_map,
-      homology'Functor_map, Category.assoc]
 #align graded_homology_functor gradedHomology'Functor
 
 end

--- a/Mathlib/Algebra/Homology/Single.lean
+++ b/Mathlib/Algebra/Homology/Single.lean
@@ -131,14 +131,6 @@ def single₀ : V ⥤ ChainComplex V ℕ where
         match n with
         | 0 => f
         | n + 1 => 0 }
-  map_id X := by
-    ext (_|_)
-    · rfl
-    · simp
-  map_comp f g := by
-    ext (_|_)
-    · rfl
-    · simp
 #align chain_complex.single₀ ChainComplex.single₀
 
 @[simp]
@@ -328,14 +320,6 @@ def single₀ : V ⥤ CochainComplex V ℕ where
         match n with
         | 0 => f
         | n + 1 => 0 }
-  map_id X := by
-    ext (_|_)
-    · rfl
-    · simp
-  map_comp f g := by
-    ext (_|_)
-    · rfl
-    · simp
 #align cochain_complex.single₀ CochainComplex.single₀
 
 @[simp]

--- a/Mathlib/Algebra/Jordan/Basic.lean
+++ b/Mathlib/Algebra/Jordan/Basic.lean
@@ -194,7 +194,7 @@ private theorem aux0 {a b c : A} : ⁅L (a + b + c), L ((a + b + c) * (a + b + c
   simp only [lie_add, add_lie, commute_lmul_lmul_sq, zero_add, add_zero]
   abel
 
-set_option maxHeartbeats 400000 in
+set_option maxHeartbeats 300000 in
 private theorem aux1 {a b c : A} :
     ⁅L a + L b + L c, L (a * a) + L (b * b) + L (c * c) +
     2 • L (a * b) + 2 • L (c * a) + 2 • L (b * c)⁆

--- a/Mathlib/Algebra/Order/CompleteField.lean
+++ b/Mathlib/Algebra/Order/CompleteField.lean
@@ -155,7 +155,8 @@ theorem cutMap_add (a b : α) : cutMap β (a + b) = cutMap β a + cutMap β b :=
       rw [coe_mem_cutMap_iff]
       exact_mod_cast sub_lt_comm.mp hq₁q
   · rintro _ ⟨_, _, ⟨qa, ha, rfl⟩, ⟨qb, hb, rfl⟩, rfl⟩
-    refine' ⟨qa + qb, _, by norm_cast⟩
+    -- After leanprover/lean4#2734, `norm_cast` needs help with beta reduction.
+    refine' ⟨qa + qb, _, by dsimp; norm_cast⟩
     rw [mem_setOf_eq, cast_add]
     exact add_lt_add ha hb
 #align linear_ordered_field.cut_map_add LinearOrderedField.cutMap_add

--- a/Mathlib/Algebra/Order/CompleteField.lean
+++ b/Mathlib/Algebra/Order/CompleteField.lean
@@ -156,7 +156,7 @@ theorem cutMap_add (a b : α) : cutMap β (a + b) = cutMap β a + cutMap β b :=
       exact_mod_cast sub_lt_comm.mp hq₁q
   · rintro _ ⟨_, _, ⟨qa, ha, rfl⟩, ⟨qb, hb, rfl⟩, rfl⟩
     -- After leanprover/lean4#2734, `norm_cast` needs help with beta reduction.
-    refine' ⟨qa + qb, _, by dsimp; norm_cast⟩
+    refine' ⟨qa + qb, _, by beta_reduce; norm_cast⟩
     rw [mem_setOf_eq, cast_add]
     exact add_lt_add ha hb
 #align linear_ordered_field.cut_map_add LinearOrderedField.cutMap_add

--- a/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
+++ b/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
@@ -199,7 +199,6 @@ theorem toΓSpecSheafedSpace_app_eq :
   dsimp at this
   rw [←this]
   dsimp
-  congr
 
 #align algebraic_geometry.LocallyRingedSpace.to_Γ_Spec_SheafedSpace_app_eq AlgebraicGeometry.LocallyRingedSpace.toΓSpecSheafedSpace_app_eq
 

--- a/Mathlib/Analysis/Analytic/Inverse.lean
+++ b/Mathlib/Analysis/Analytic/Inverse.lean
@@ -563,7 +563,9 @@ theorem radius_rightInv_pos_of_radius_pos (p : FormalMultilinearSeries 𝕜 E F)
   -- conclude that all coefficients satisfy `aⁿ Qₙ ≤ (I + 1) a`.
   let a' : NNReal := ⟨a, apos.le⟩
   suffices H : (a' : ENNReal) ≤ (p.rightInv i).radius
-  · apply lt_of_lt_of_le _ H; exact_mod_cast apos
+  · apply lt_of_lt_of_le _ H
+    -- Prior to leanprover/lean4#2734, this was `exact_mod_cast apos`.
+    simpa only [ENNReal.coe_pos]
   apply le_radius_of_bound _ ((I + 1) * a) fun n => ?_
   by_cases hn : n = 0
   · have : ‖p.rightInv i n‖ = ‖p.rightInv i 0‖ := by congr <;> try rw [hn]

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -610,7 +610,7 @@ theorem inner_le_Lp_mul_Lq_tsum_of_nonneg (hpq : p.IsConjugateExponent q) (hf : 
   lift f to ι → ℝ≥0 using hf
   lift g to ι → ℝ≥0 using hg
   -- After leanprover/lean4#2734, `norm_cast` needs help with beta reduction.
-  dsimp at *
+  beta_reduce at *
   norm_cast at *
   exact NNReal.inner_le_Lp_mul_Lq_tsum hpq hf_sum hg_sum
 #align real.inner_le_Lp_mul_Lq_tsum_of_nonneg Real.inner_le_Lp_mul_Lq_tsum_of_nonneg
@@ -640,7 +640,7 @@ theorem inner_le_Lp_mul_Lq_hasSum_of_nonneg (hpq : p.IsConjugateExponent q) {A B
   lift A to ℝ≥0 using hA
   lift B to ℝ≥0 using hB
   -- After leanprover/lean4#2734, `norm_cast` needs help with beta reduction.
-  dsimp at *
+  beta_reduce at *
   norm_cast at hf_sum hg_sum
   obtain ⟨C, hC, H⟩ := NNReal.inner_le_Lp_mul_Lq_hasSum hpq hf_sum hg_sum
   refine' ⟨C, C.prop, hC, _⟩
@@ -679,7 +679,7 @@ theorem Lp_add_le_tsum_of_nonneg (hp : 1 ≤ p) (hf : ∀ i, 0 ≤ f i) (hg : �
   lift f to ι → ℝ≥0 using hf
   lift g to ι → ℝ≥0 using hg
   -- After leanprover/lean4#2734, `norm_cast` needs help with beta reduction.
-  dsimp at *
+  beta_reduce at *
   norm_cast0 at *
   exact NNReal.Lp_add_le_tsum hp hf_sum hg_sum
 #align real.Lp_add_le_tsum_of_nonneg Real.Lp_add_le_tsum_of_nonneg
@@ -709,12 +709,12 @@ theorem Lp_add_le_hasSum_of_nonneg (hp : 1 ≤ p) (hf : ∀ i, 0 ≤ f i) (hg : 
   lift A to ℝ≥0 using hA
   lift B to ℝ≥0 using hB
   -- After leanprover/lean4#2734, `norm_cast` needs help with beta reduction.
-  dsimp at hfA hgB
+  beta_reduce at hfA hgB
   norm_cast at hfA hgB
   obtain ⟨C, hC₁, hC₂⟩ := NNReal.Lp_add_le_hasSum hp hfA hgB
   use C
   -- After leanprover/lean4#2734, `norm_cast` needs help with beta reduction.
-  dsimp
+  beta_reduce
   norm_cast
   exact ⟨zero_le _, hC₁, hC₂⟩
 #align real.Lp_add_le_has_sum_of_nonneg Real.Lp_add_le_hasSum_of_nonneg

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -609,6 +609,8 @@ theorem inner_le_Lp_mul_Lq_tsum_of_nonneg (hpq : p.IsConjugateExponent q) (hf : 
       ∑' i, f i * g i ≤ (∑' i, f i ^ p) ^ (1 / p) * (∑' i, g i ^ q) ^ (1 / q) := by
   lift f to ι → ℝ≥0 using hf
   lift g to ι → ℝ≥0 using hg
+  -- After leanprover/lean4#2734, `norm_cast` needs help with beta reduction.
+  dsimp at *
   norm_cast at *
   exact NNReal.inner_le_Lp_mul_Lq_tsum hpq hf_sum hg_sum
 #align real.inner_le_Lp_mul_Lq_tsum_of_nonneg Real.inner_le_Lp_mul_Lq_tsum_of_nonneg
@@ -637,6 +639,8 @@ theorem inner_le_Lp_mul_Lq_hasSum_of_nonneg (hpq : p.IsConjugateExponent q) {A B
   lift g to ι → ℝ≥0 using hg
   lift A to ℝ≥0 using hA
   lift B to ℝ≥0 using hB
+  -- After leanprover/lean4#2734, `norm_cast` needs help with beta reduction.
+  dsimp at *
   norm_cast at hf_sum hg_sum
   obtain ⟨C, hC, H⟩ := NNReal.inner_le_Lp_mul_Lq_hasSum hpq hf_sum hg_sum
   refine' ⟨C, C.prop, hC, _⟩
@@ -674,6 +678,8 @@ theorem Lp_add_le_tsum_of_nonneg (hp : 1 ≤ p) (hf : ∀ i, 0 ≤ f i) (hg : �
         (∑' i, f i ^ p) ^ (1 / p) + (∑' i, g i ^ p) ^ (1 / p) := by
   lift f to ι → ℝ≥0 using hf
   lift g to ι → ℝ≥0 using hg
+  -- After leanprover/lean4#2734, `norm_cast` needs help with beta reduction.
+  dsimp at *
   norm_cast0 at *
   exact NNReal.Lp_add_le_tsum hp hf_sum hg_sum
 #align real.Lp_add_le_tsum_of_nonneg Real.Lp_add_le_tsum_of_nonneg
@@ -702,9 +708,13 @@ theorem Lp_add_le_hasSum_of_nonneg (hp : 1 ≤ p) (hf : ∀ i, 0 ≤ f i) (hg : 
   lift g to ι → ℝ≥0 using hg
   lift A to ℝ≥0 using hA
   lift B to ℝ≥0 using hB
+  -- After leanprover/lean4#2734, `norm_cast` needs help with beta reduction.
+  dsimp at hfA hgB
   norm_cast at hfA hgB
   obtain ⟨C, hC₁, hC₂⟩ := NNReal.Lp_add_le_hasSum hp hfA hgB
   use C
+  -- After leanprover/lean4#2734, `norm_cast` needs help with beta reduction.
+  dsimp
   norm_cast
   exact ⟨zero_le _, hC₁, hC₂⟩
 #align real.Lp_add_le_has_sum_of_nonneg Real.Lp_add_le_hasSum_of_nonneg

--- a/Mathlib/CategoryTheory/Comma.lean
+++ b/Mathlib/CategoryTheory/Comma.lean
@@ -167,9 +167,8 @@ theorem eqToHom_left (X Y : Comma L R) (H : X = Y) :
 #align category_theory.comma.eq_to_hom_left CategoryTheory.Comma.eqToHom_left
 
 @[simp]
-theorem eqToHom_right (X Y : Comma L R) (H : X = Y) : CommaMorphism.right (eqToHom H) = eqToHom (by
-    cases H
-    rfl) := by
+theorem eqToHom_right (X Y : Comma L R) (H : X = Y) :
+    CommaMorphism.right (eqToHom H) = eqToHom (by cases H; rfl) := by
   cases H
   rfl
 #align category_theory.comma.eq_to_hom_right CategoryTheory.Comma.eqToHom_right

--- a/Mathlib/CategoryTheory/DifferentialObject.lean
+++ b/Mathlib/CategoryTheory/DifferentialObject.lean
@@ -219,12 +219,10 @@ variable [(shiftFunctor C (1 : S)).PreservesZeroMorphisms]
 
 open scoped ZeroObject
 
-instance hasZeroObject : HasZeroObject (DifferentialObject S C) := by
-  -- Porting note(https://github.com/leanprover-community/mathlib4/issues/4998): added `aesop_cat`
-  -- Porting note: added `simp only [eq_iff_true_of_subsingleton]`
-  refine' ⟨⟨⟨0, 0, by aesop_cat⟩, fun X => ⟨⟨⟨⟨0, by aesop_cat⟩⟩, fun f => _⟩⟩,
-    fun X => ⟨⟨⟨⟨0, by aesop_cat⟩⟩, fun f => _⟩⟩⟩⟩ <;> ext <;>
-    simp only [eq_iff_true_of_subsingleton]
+instance hasZeroObject : HasZeroObject (DifferentialObject S C) where
+  zero := ⟨{ obj := 0, d := 0 },
+    { unique_to := fun X => ⟨⟨⟨{ f := 0 }⟩, fun f => by ext⟩⟩,
+      unique_from := fun X => ⟨⟨⟨{ f := 0 }⟩, fun f => by ext⟩⟩ }⟩
 #align category_theory.differential_object.has_zero_object CategoryTheory.DifferentialObject.hasZeroObject
 
 end DifferentialObject

--- a/Mathlib/CategoryTheory/Functor/Flat.lean
+++ b/Mathlib/CategoryTheory/Functor/Flat.lean
@@ -208,7 +208,7 @@ theorem uniq {K : J ⥤ C} {c : Cone K} (hc : IsLimit c) (s : Cone (K ⋙ F))
     intro j
     injection c₀.π.naturality (BiconeHom.left j) with _ e₁
     injection c₀.π.naturality (BiconeHom.right j) with _ e₂
-    simpa (config := {zeta := false}) using e₁.symm.trans e₂
+    simpa using e₁.symm.trans e₂
   have : c.extend g₁.right = c.extend g₂.right := by
     unfold Cone.extend
     congr 1

--- a/Mathlib/CategoryTheory/Idempotents/FunctorCategories.lean
+++ b/Mathlib/CategoryTheory/Idempotents/FunctorCategories.lean
@@ -80,7 +80,6 @@ instance functor_category_isIdempotentComplete [IsIdempotentComplete C] :
   use Y, i, e
   constructor
   · ext j
-    apply equalizer.hom_ext
     dsimp
     rw [assoc, equalizer.lift_ι, ← equalizer.condition, id_comp, comp_id]
   · ext j

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
@@ -450,7 +450,10 @@ private theorem edgeDensity_star_not_uniform [Nonempty α]
   set s : ℝ := ↑(G.edgeDensity (G.nonuniformWitness ε U V) (G.nonuniformWitness ε V U))
   set t : ℝ := ↑(G.edgeDensity U V)
   have hrs : |r - s| ≤ ε / 5 := abs_density_star_sub_density_le_eps hPε hε₁ hUVne hUV
-  have hst : ε ≤ |s - t| := by exact_mod_cast G.nonuniformWitness_spec hUVne hUV
+  have hst : ε ≤ |s - t| := by
+    -- After leanprover/lean4#2734, we need to do the zeta reduction before `norm_cast`.
+    unfold_let s t
+    exact_mod_cast G.nonuniformWitness_spec hUVne hUV
   have hpr : |p - r| ≤ ε ^ 5 / 49 :=
     average_density_near_total_density hPα hPε hε₁ star_subset_chunk star_subset_chunk
   have hqt : |q - t| ≤ ε ^ 5 / 49 := by

--- a/Mathlib/Data/Complex/Module.lean
+++ b/Mathlib/Data/Complex/Module.lean
@@ -479,9 +479,9 @@ lemma IsSelfAdjoint.coe_realPart {x : A} (hx : IsSelfAdjoint x) :
     (ℜ x : A) = x :=
   hx.coe_selfAdjointPart_apply ℝ
 
-lemma IsSelfAdjoint.imaginaryPart {x : A} (hx : IsSelfAdjoint x) :
+nonrec lemma IsSelfAdjoint.imaginaryPart {x : A} (hx : IsSelfAdjoint x) :
     ℑ x = 0 := by
-  rw [_root_.imaginaryPart, LinearMap.comp_apply, hx.skewAdjointPart_apply _, map_zero]
+  rw [imaginaryPart, LinearMap.comp_apply, hx.skewAdjointPart_apply _, map_zero]
 
 lemma realPart_comp_subtype_selfAdjoint :
     realPart.comp (selfAdjoint.submodule ℝ A).subtype = LinearMap.id :=

--- a/Mathlib/Data/Complex/Module.lean
+++ b/Mathlib/Data/Complex/Module.lean
@@ -481,7 +481,7 @@ lemma IsSelfAdjoint.coe_realPart {x : A} (hx : IsSelfAdjoint x) :
 
 lemma IsSelfAdjoint.imaginaryPart {x : A} (hx : IsSelfAdjoint x) :
     ℑ x = 0 := by
-  rw [imaginaryPart, LinearMap.comp_apply, hx.skewAdjointPart_apply _, map_zero]
+  rw [_root_.imaginaryPart, LinearMap.comp_apply, hx.skewAdjointPart_apply _, map_zero]
 
 lemma realPart_comp_subtype_selfAdjoint :
     realPart.comp (selfAdjoint.submodule ℝ A).subtype = LinearMap.id :=

--- a/Mathlib/Data/Ordmap/Ordset.lean
+++ b/Mathlib/Data/Ordmap/Ordset.lean
@@ -408,7 +408,7 @@ theorem Sized.dual_iff {t : Ordnode α} : Sized (.dual t) ↔ Sized t :=
 
 theorem Sized.rotateL {l x r} (hl : @Sized α l) (hr : Sized r) : Sized (rotateL l x r) := by
   cases r; · exact hl.node' hr
-  rw [rotateL]; split_ifs
+  rw [Ordnode.rotateL]; split_ifs
   · exact hl.node3L hr.2.1 hr.2.2
   · exact hl.node4L hr.2.1 hr.2.2
 #align ordnode.sized.rotate_l Ordnode.Sized.rotateL
@@ -1247,7 +1247,7 @@ theorem Valid'.rotateL {l} {x : α} {r o₁ o₂} (hl : Valid' o₁ l x) (hr : V
   have ablem : ∀ {a b : ℕ}, 1 ≤ a → a + b ≤ 2 → b ≤ 1 := by intros; linarith
   have hlp : size l > 0 → ¬size rl + size rr ≤ 1 := fun l0 hb =>
     absurd (le_trans (le_trans (Nat.mul_le_mul_left _ l0) H2) hb) (by decide)
-  rw [rotateL]; split_ifs with h
+  rw [Ordnode.rotateL]; split_ifs with h
   · have rr0 : size rr > 0 :=
       (mul_lt_mul_left (by decide)).1 (lt_of_le_of_lt (Nat.zero_le _) h : ratio * 0 < _)
     suffices BalancedSz (size l) (size rl) ∧ BalancedSz (size l + size rl + 1) (size rr) by

--- a/Mathlib/Data/Prod/TProd.lean
+++ b/Mathlib/Data/Prod/TProd.lean
@@ -177,7 +177,7 @@ theorem elim_preimage_pi [DecidableEq ι] {l : List ι} (hnd : l.Nodup) (h : ∀
     simp [h]
   rw [← h2, ← mk_preimage_tprod, preimage_preimage]
   simp only [TProd.mk_elim hnd h]
-  dsimp; rfl
+  dsimp
 #align set.elim_preimage_pi Set.elim_preimage_pi
 
 end Set

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -2202,19 +2202,15 @@ theorem powerset_singleton (x : α) : 𝒫({x} : Set α) = {∅, {x}} := by
 
 /-! ### Sets defined as an if-then-else -/
 
---Porting note: New theorem to prove `mem_dite` lemmas.
--- `simp [h]` where `h : p` does not simplify `∀ (h : p), x ∈ s h` any more.
--- https://github.com/leanprover/lean4/issues/1926
 theorem mem_dite (p : Prop) [Decidable p] (s : p → Set α) (t : ¬ p → Set α) (x : α) :
     (x ∈ if h : p then s h else t h) ↔ (∀ h : p, x ∈ s h) ∧ ∀ h : ¬p, x ∈ t h := by
   split_ifs with hp
   · exact ⟨fun hx => ⟨fun _ => hx, fun hnp => (hnp hp).elim⟩, fun hx => hx.1 hp⟩
   · exact ⟨fun hx => ⟨fun h => (hp h).elim, fun _ => hx⟩, fun hx => hx.2 hp⟩
 
---Porting note: Old proof was `split_ifs; simp [h]`
 theorem mem_dite_univ_right (p : Prop) [Decidable p] (t : p → Set α) (x : α) :
     (x ∈ if h : p then t h else univ) ↔ ∀ h : p, x ∈ t h := by
-  simp [mem_dite]
+  split_ifs <;> simp_all
 #align set.mem_dite_univ_right Set.mem_dite_univ_right
 
 @[simp]
@@ -2225,7 +2221,7 @@ theorem mem_ite_univ_right (p : Prop) [Decidable p] (t : Set α) (x : α) :
 
 theorem mem_dite_univ_left (p : Prop) [Decidable p] (t : ¬p → Set α) (x : α) :
     (x ∈ if h : p then univ else t h) ↔ ∀ h : ¬p, x ∈ t h := by
-  simp [mem_dite]
+  split_ifs <;> simp_all
 #align set.mem_dite_univ_left Set.mem_dite_univ_left
 
 @[simp]

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -5,15 +5,20 @@ import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Algebra.Ring.Basic
 import Mathlib.Data.ZMod.Defs
 
-lemma UInt8.val_eq_of_lt {a : Nat} : a < UInt8.size -> (ofNat a).val = a := Nat.mod_eq_of_lt
+lemma UInt8.val_eq_of_lt {a : Nat} : a < UInt8.size → ((ofNat a).val : Nat) = a :=
+  Nat.mod_eq_of_lt
 
-lemma UInt16.val_eq_of_lt {a : Nat} : a < UInt16.size -> (ofNat a).val = a := Nat.mod_eq_of_lt
+lemma UInt16.val_eq_of_lt {a : Nat} : a < UInt16.size → ((ofNat a).val : Nat) = a :=
+  Nat.mod_eq_of_lt
 
-lemma UInt32.val_eq_of_lt {a : Nat} : a < UInt32.size -> (ofNat a).val = a := Nat.mod_eq_of_lt
+lemma UInt32.val_eq_of_lt {a : Nat} : a < UInt32.size → ((ofNat a).val : Nat) = a :=
+  Nat.mod_eq_of_lt
 
-lemma UInt64.val_eq_of_lt {a : Nat} : a < UInt64.size -> (ofNat a).val = a := Nat.mod_eq_of_lt
+lemma UInt64.val_eq_of_lt {a : Nat} : a < UInt64.size → ((ofNat a).val : Nat) = a :=
+  Nat.mod_eq_of_lt
 
-lemma USize.val_eq_of_lt {a : Nat} : a < USize.size -> (ofNat a).val = a := Nat.mod_eq_of_lt
+lemma USize.val_eq_of_lt {a : Nat} : a < USize.size → ((ofNat a).val : Nat) = a :=
+  Nat.mod_eq_of_lt
 
 instance UInt8.neZero : NeZero UInt8.size := ⟨by decide⟩
 

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
@@ -173,26 +173,9 @@ theorem evenOdd_induction (n : ZMod 2) {P : ∀ x, x ∈ evenOdd Q n → Prop}
     (x : CliffordAlgebra Q) (hx : x ∈ evenOdd Q n) : P x hx := by
   apply Submodule.iSup_induction' (C := P) _ (hr 0 (Submodule.zero_mem _)) @hadd
   refine' Subtype.rec _
-  -- porting note: was `simp_rw [Subtype.coe_mk, ZMod.nat_coe_zmod_eq_iff, add_comm n.val]`
-  -- leanprover/lean4#1926 is to blame.
-  dsimp only [Subtype.coe_mk]
-  let hlean1926 : ∀ val : ℕ, ↑val = n ↔ ∃ k, val = 2 * k + ZMod.val n := by
-    intro val
-    simp_rw [ZMod.nat_coe_zmod_eq_iff, add_comm n.val]
-  have := fun val : ℕ => forall_prop_congr'
-    (q := fun property => ∀ x (hx : x ∈ LinearMap.range (ι Q) ^ val),
-      P x (Submodule.mem_iSup_of_mem { val := val, property := property } hx))
-    (hq := fun property => Iff.rfl) (hp := hlean1926 val)
-  simp_rw [this]; clear this
-  -- end porting note
+  simp_rw [ZMod.nat_coe_zmod_eq_iff, add_comm n.val]
   rintro n' ⟨k, rfl⟩ xv
-  -- porting note: was `simp_rw [pow_add, pow_mul]`
-  -- leanprover/lean4#1926 is to blame.
-  refine (forall_prop_congr' (hq := fun property => Iff.rfl) (
-    show xv ∈ LinearMap.range (ι Q) ^ (2 * k + ZMod.val n)
-        ↔ xv ∈ (LinearMap.range (ι Q) ^ 2) ^ k * LinearMap.range (ι Q) ^ ZMod.val n by
-      simp_rw [pow_add, pow_mul])).mpr ?_
-  -- end porting note
+  simp_rw [pow_add, pow_mul]
   intro hxv
   induction hxv using Submodule.mul_induction_on' with
   | hm a ha b hb =>
@@ -205,13 +188,7 @@ theorem evenOdd_induction (n : ZMod 2) {P : ∀ x, x ∈ evenOdd Q n → Prop}
       apply hadd ihx ihy
     | hmul x hx n'' y hy ihy =>
       revert hx
-      -- porting note: was `simp_rw [pow_two]`
-      -- leanprover/lean4#1926 is to blame.
-      let hlean1926'' : x ∈ LinearMap.range (ι Q) ^ 2
-          ↔ x ∈ LinearMap.range (ι Q) * LinearMap.range (ι Q) := by
-        rw [pow_two]
-      refine (forall_prop_congr' (hq := fun property => Iff.rfl) hlean1926'').mpr ?_
-      -- end porting note
+      simp_rw [pow_two]
       intro hx2
       induction hx2 using Submodule.mul_induction_on' with
       | hm m hm n hn =>

--- a/Mathlib/LinearAlgebra/QuadraticForm/Complex.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Complex.lean
@@ -54,7 +54,7 @@ noncomputable def isometryEquivSumSquares [DecidableEq ι] (w' : ι → ℂ) :
   split_ifs with h
   · simp only [h, zero_smul, zero_mul]
   have hww' : w' j = w j := by simp only [dif_neg h, Units.val_mk0]
-  simp only [one_mul, Units.val_mk0, smul_eq_mul]
+  simp (config := {zeta := false}) only [one_mul, Units.val_mk0, smul_eq_mul]
   rw [hww']
   suffices v j * v j = w j ^ (-(1 / 2 : ℂ)) * w j ^ (-(1 / 2 : ℂ)) * w j * v j * v j by
     rw [this]; ring

--- a/Mathlib/Logic/Equiv/Set.lean
+++ b/Mathlib/Logic/Equiv/Set.lean
@@ -661,11 +661,7 @@ theorem preimage_piEquivPiSubtypeProd_symm_pi {α : Type*} {β : α → Type*} (
   simp only [mem_preimage, mem_univ_pi, prod_mk_mem_set_prod_eq, Subtype.forall, ← forall_and]
   refine' forall_congr' fun i => _
   dsimp only [Subtype.coe_mk]
-  -- Porting note: Two lines below were `by_cases hi <;> simp [hi]`
-  -- This regression is https://github.com/leanprover/lean4/issues/1926
-  by_cases hi : p i
-  · simp [forall_prop_of_true hi, forall_prop_of_false (not_not.2 hi), hi]
-  · simp [forall_prop_of_false hi, hi, forall_prop_of_true hi]
+  by_cases hi : p i <;> simp [hi]
 #align equiv.preimage_pi_equiv_pi_subtype_prod_symm_pi Equiv.preimage_piEquivPiSubtypeProd_symm_pi
 
 -- See also `Equiv.sigmaFiberEquiv`.

--- a/Mathlib/MeasureTheory/Function/Jacobian.lean
+++ b/Mathlib/MeasureTheory/Function/Jacobian.lean
@@ -243,7 +243,8 @@ theorem exists_closed_cover_approximatesLinearOn_of_hasFDerivWithinAt [SecondCou
   obtain ⟨q, hq⟩ : ∃ q, F q = (n, z, p) := hF _
   -- then `x` belongs to `t q`.
   apply mem_iUnion.2 ⟨q, _⟩
-  simp (config := { zeta := false }) only [hq, subset_closure hnz, hp, mem_inter_iff, and_true, hnz]
+  simp (config := { zeta := false }) only [K, hq, mem_inter_iff, hp, and_true]
+  exact subset_closure hnz
 #align exists_closed_cover_approximates_linear_on_of_has_fderiv_within_at exists_closed_cover_approximatesLinearOn_of_hasFDerivWithinAt
 
 variable [MeasurableSpace E] [BorelSpace E] (μ : Measure E) [IsAddHaarMeasure μ]

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -405,7 +405,7 @@ theorem HasFiniteIntegral.smul [NormedAddCommGroup 𝕜] [SMulZeroClass 𝕜 β]
       refine' lintegral_mono _
       intro i
       -- After leanprover/lean4#2734, we need to do beta reduction `exact_mod_cast`
-      dsimp
+      beta_reduce
       exact_mod_cast (nnnorm_smul_le c (f i))
     _ < ∞ := by
       rw [lintegral_const_mul']
@@ -671,7 +671,7 @@ theorem Integrable.add' {f g : α → β} (hf : Integrable f μ) (hg : Integrabl
     (∫⁻ a, ‖f a + g a‖₊ ∂μ) ≤ ∫⁻ a, ‖f a‖₊ + ‖g a‖₊ ∂μ :=
       lintegral_mono fun a => by
         -- After leanprover/lean4#2734, we need to do beta reduction before `exact_mod_cast`
-        dsimp
+        beta_reduce
         exact_mod_cast nnnorm_add_le _ _
     _ = _ := (lintegral_nnnorm_add_left hf.aestronglyMeasurable _)
     _ < ∞ := add_lt_top.2 ⟨hf.hasFiniteIntegral, hg.hasFiniteIntegral⟩

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -404,6 +404,8 @@ theorem HasFiniteIntegral.smul [NormedAddCommGroup 𝕜] [SMulZeroClass 𝕜 β]
     (∫⁻ a : α, ‖c • f a‖₊ ∂μ) ≤ ∫⁻ a : α, ‖c‖₊ * ‖f a‖₊ ∂μ := by
       refine' lintegral_mono _
       intro i
+      -- After leanprover/lean4#2734, we need to do beta reduction `exact_mod_cast`
+      dsimp
       exact_mod_cast (nnnorm_smul_le c (f i))
     _ < ∞ := by
       rw [lintegral_const_mul']
@@ -667,7 +669,10 @@ theorem Integrable.add' {f g : α → β} (hf : Integrable f μ) (hg : Integrabl
     HasFiniteIntegral (f + g) μ :=
   calc
     (∫⁻ a, ‖f a + g a‖₊ ∂μ) ≤ ∫⁻ a, ‖f a‖₊ + ‖g a‖₊ ∂μ :=
-      lintegral_mono fun a => by exact_mod_cast nnnorm_add_le _ _
+      lintegral_mono fun a => by
+        -- After leanprover/lean4#2734, we need to do beta reduction before `exact_mod_cast`
+        dsimp
+        exact_mod_cast nnnorm_add_le _ _
     _ = _ := (lintegral_nnnorm_add_left hf.aestronglyMeasurable _)
     _ < ∞ := add_lt_top.2 ⟨hf.hasFiniteIntegral, hg.hasFiniteIntegral⟩
 #align measure_theory.integrable.add' MeasureTheory.Integrable.add'

--- a/Mathlib/MeasureTheory/Measure/OuterMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/OuterMeasure.lean
@@ -129,7 +129,7 @@ generalising to `Sort`. -/
 theorem iUnion_null_iff' (m : OuterMeasure α) {ι : Prop} {s : ι → Set α} :
     m (⋃ i, s i) = 0 ↔ ∀ i, m (s i) = 0 :=
     ⟨ fun h i => mono_null m (subset_iUnion s i) h,
-      by by_cases i : ι <;> simp [i]; exact (fun h => h (Iff.mpr (Iff.of_eq (eq_true i)) trivial)) ⟩
+      by by_cases i : ι <;> simp [i]⟩
 #align measure_theory.outer_measure.Union_null_iff' MeasureTheory.OuterMeasure.iUnion_null_iff'
 
 theorem biUnion_null_iff (m : OuterMeasure α) {s : Set β} (hs : s.Countable) {t : β → Set α} :

--- a/Mathlib/NumberTheory/LegendreSymbol/GaussEisensteinLemmas.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/GaussEisensteinLemmas.lean
@@ -83,7 +83,7 @@ private theorem gauss_lemma_aux₁ (p : ℕ) [Fact p.Prime] {a : ℤ}
           (∏ x in Ico 1 (p / 2).succ, if (a * x : ZMod p).val ≤ p / 2 then (1 : ZMod p) else -1) =
           ∏ x in (Ico 1 (p / 2).succ).filter fun x : ℕ => ¬(a * x : ZMod p).val ≤ p / 2, -1 :=
         prod_bij_ne_one (fun x _ _ => x)
-          (fun x => by split_ifs <;> simp_all (config := { contextual := true }))
+          (fun x => by split_ifs <;> (dsimp; simp_all))
           (fun _ _ _ _ _ _ => id) (fun b h _ => ⟨b, by simp_all [-not_le]⟩)
           (by intros; split_ifs at * <;> simp_all)
       rw [prod_mul_distrib, this, prod_const]

--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -508,6 +508,7 @@ theorem isCauSeq_nthHom (r : R) : IsCauSeq (padicNorm p) fun n => nthHom f r n :
   use k
   intro j hj
   refine' lt_of_le_of_lt _ hk
+  dsimp -- Need to do beta reduction first, as `norm_cast` doesn't.
   norm_cast
   rw [← padicNorm.dvd_iff_norm_le]
   exact_mod_cast pow_dvd_nthHom_sub f_compat r k j hj

--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -508,7 +508,9 @@ theorem isCauSeq_nthHom (r : R) : IsCauSeq (padicNorm p) fun n => nthHom f r n :
   use k
   intro j hj
   refine' lt_of_le_of_lt _ hk
-  dsimp -- Need to do beta reduction first, as `norm_cast` doesn't.
+  -- Need to do beta reduction first, as `norm_cast` doesn't.
+  -- Added to adapt to leanprover/lean4#2734.
+  beta_reduce
   norm_cast
   rw [← padicNorm.dvd_iff_norm_le]
   exact_mod_cast pow_dvd_nthHom_sub f_compat r k j hj

--- a/Mathlib/NumberTheory/PythagoreanTriples.lean
+++ b/Mathlib/NumberTheory/PythagoreanTriples.lean
@@ -485,6 +485,11 @@ theorem isPrimitiveClassified_of_coprime_of_odd_of_pos (hc : Int.gcd x y = 1) (h
   let m := (q.den : ℤ)
   let n := q.num
   have hm0 : m ≠ 0 := by
+    -- Added to adapt to leanprover/lean4#2734.
+    -- Without `unfold_let`, `norm_cast` can't see the coercion.
+    -- One might try `zeta := true` in `Tactic.NormCast.derive`,
+    -- but that seems to break many other things.
+    unfold_let m
     norm_cast
     apply Rat.den_nz q
   have hq2 : q = n / m := (Rat.num_div_den q).symm

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -697,15 +697,15 @@ theorem lintegral_prodMkLeft (κ : kernel α β) (ca : γ × α) (g : β → ℝ
 #align probability_theory.kernel.lintegral_prod_mk_left ProbabilityTheory.kernel.lintegral_prodMkLeft
 
 instance IsMarkovKernel.prodMkLeft (κ : kernel α β) [IsMarkovKernel κ] :
-    IsMarkovKernel (prodMkLeft γ κ) := by rw [prodMkLeft]; infer_instance
+    IsMarkovKernel (prodMkLeft γ κ) := by rw [kernel.prodMkLeft]; infer_instance
 #align probability_theory.kernel.is_markov_kernel.prod_mk_left ProbabilityTheory.kernel.IsMarkovKernel.prodMkLeft
 
 instance IsFiniteKernel.prodMkLeft (κ : kernel α β) [IsFiniteKernel κ] :
-    IsFiniteKernel (prodMkLeft γ κ) := by rw [prodMkLeft]; infer_instance
+    IsFiniteKernel (prodMkLeft γ κ) := by rw [kernel.prodMkLeft]; infer_instance
 #align probability_theory.kernel.is_finite_kernel.prod_mk_left ProbabilityTheory.kernel.IsFiniteKernel.prodMkLeft
 
 instance IsSFiniteKernel.prodMkLeft (κ : kernel α β) [IsSFiniteKernel κ] :
-    IsSFiniteKernel (prodMkLeft γ κ) := by rw [prodMkLeft]; infer_instance
+    IsSFiniteKernel (prodMkLeft γ κ) := by rw [kernel.prodMkLeft]; infer_instance
 #align probability_theory.kernel.is_s_finite_kernel.prod_mk_left ProbabilityTheory.kernel.IsSFiniteKernel.prodMkLeft
 
 /-- Define a `kernel (β × α) γ` from a `kernel (α × β) γ` by taking the comap of `Prod.swap`. -/
@@ -728,15 +728,15 @@ theorem lintegral_swapLeft (κ : kernel (α × β) γ) (a : β × α) (g : γ �
 #align probability_theory.kernel.lintegral_swap_left ProbabilityTheory.kernel.lintegral_swapLeft
 
 instance IsMarkovKernel.swapLeft (κ : kernel (α × β) γ) [IsMarkovKernel κ] :
-    IsMarkovKernel (swapLeft κ) := by rw [swapLeft]; infer_instance
+    IsMarkovKernel (swapLeft κ) := by rw [kernel.swapLeft]; infer_instance
 #align probability_theory.kernel.is_markov_kernel.swap_left ProbabilityTheory.kernel.IsMarkovKernel.swapLeft
 
 instance IsFiniteKernel.swapLeft (κ : kernel (α × β) γ) [IsFiniteKernel κ] :
-    IsFiniteKernel (swapLeft κ) := by rw [swapLeft]; infer_instance
+    IsFiniteKernel (swapLeft κ) := by rw [kernel.swapLeft]; infer_instance
 #align probability_theory.kernel.is_finite_kernel.swap_left ProbabilityTheory.kernel.IsFiniteKernel.swapLeft
 
 instance IsSFiniteKernel.swapLeft (κ : kernel (α × β) γ) [IsSFiniteKernel κ] :
-    IsSFiniteKernel (swapLeft κ) := by rw [swapLeft]; infer_instance
+    IsSFiniteKernel (swapLeft κ) := by rw [kernel.swapLeft]; infer_instance
 #align probability_theory.kernel.is_s_finite_kernel.swap_left ProbabilityTheory.kernel.IsSFiniteKernel.swapLeft
 
 /-- Define a `kernel α (γ × β)` from a `kernel α (β × γ)` by taking the map of `Prod.swap`. -/
@@ -759,15 +759,15 @@ theorem lintegral_swapRight (κ : kernel α (β × γ)) (a : α) {g : γ × β �
 #align probability_theory.kernel.lintegral_swap_right ProbabilityTheory.kernel.lintegral_swapRight
 
 instance IsMarkovKernel.swapRight (κ : kernel α (β × γ)) [IsMarkovKernel κ] :
-    IsMarkovKernel (swapRight κ) := by rw [swapRight]; infer_instance
+    IsMarkovKernel (swapRight κ) := by rw [kernel.swapRight]; infer_instance
 #align probability_theory.kernel.is_markov_kernel.swap_right ProbabilityTheory.kernel.IsMarkovKernel.swapRight
 
 instance IsFiniteKernel.swapRight (κ : kernel α (β × γ)) [IsFiniteKernel κ] :
-    IsFiniteKernel (swapRight κ) := by rw [swapRight]; infer_instance
+    IsFiniteKernel (swapRight κ) := by rw [kernel.swapRight]; infer_instance
 #align probability_theory.kernel.is_finite_kernel.swap_right ProbabilityTheory.kernel.IsFiniteKernel.swapRight
 
 instance IsSFiniteKernel.swapRight (κ : kernel α (β × γ)) [IsSFiniteKernel κ] :
-    IsSFiniteKernel (swapRight κ) := by rw [swapRight]; infer_instance
+    IsSFiniteKernel (swapRight κ) := by rw [kernel.swapRight]; infer_instance
 #align probability_theory.kernel.is_s_finite_kernel.swap_right ProbabilityTheory.kernel.IsSFiniteKernel.swapRight
 
 /-- Define a `kernel α β` from a `kernel α (β × γ)` by taking the map of the first projection. -/
@@ -789,15 +789,15 @@ theorem lintegral_fst (κ : kernel α (β × γ)) (a : α) {g : β → ℝ≥0�
 #align probability_theory.kernel.lintegral_fst ProbabilityTheory.kernel.lintegral_fst
 
 instance IsMarkovKernel.fst (κ : kernel α (β × γ)) [IsMarkovKernel κ] : IsMarkovKernel (fst κ) := by
-  rw [fst]; infer_instance
+  rw [kernel.fst]; infer_instance
 #align probability_theory.kernel.is_markov_kernel.fst ProbabilityTheory.kernel.IsMarkovKernel.fst
 
 instance IsFiniteKernel.fst (κ : kernel α (β × γ)) [IsFiniteKernel κ] : IsFiniteKernel (fst κ) := by
-  rw [fst]; infer_instance
+  rw [kernel.fst]; infer_instance
 #align probability_theory.kernel.is_finite_kernel.fst ProbabilityTheory.kernel.IsFiniteKernel.fst
 
 instance IsSFiniteKernel.fst (κ : kernel α (β × γ)) [IsSFiniteKernel κ] : IsSFiniteKernel (fst κ) :=
-  by rw [fst]; infer_instance
+  by rw [kernel.fst]; infer_instance
 #align probability_theory.kernel.is_s_finite_kernel.fst ProbabilityTheory.kernel.IsSFiniteKernel.fst
 
 /-- Define a `kernel α γ` from a `kernel α (β × γ)` by taking the map of the second projection. -/
@@ -819,15 +819,15 @@ theorem lintegral_snd (κ : kernel α (β × γ)) (a : α) {g : γ → ℝ≥0�
 #align probability_theory.kernel.lintegral_snd ProbabilityTheory.kernel.lintegral_snd
 
 instance IsMarkovKernel.snd (κ : kernel α (β × γ)) [IsMarkovKernel κ] : IsMarkovKernel (snd κ) := by
-  rw [snd]; infer_instance
+  rw [kernel.snd]; infer_instance
 #align probability_theory.kernel.is_markov_kernel.snd ProbabilityTheory.kernel.IsMarkovKernel.snd
 
 instance IsFiniteKernel.snd (κ : kernel α (β × γ)) [IsFiniteKernel κ] : IsFiniteKernel (snd κ) := by
-  rw [snd]; infer_instance
+  rw [kernel.snd]; infer_instance
 #align probability_theory.kernel.is_finite_kernel.snd ProbabilityTheory.kernel.IsFiniteKernel.snd
 
 instance IsSFiniteKernel.snd (κ : kernel α (β × γ)) [IsSFiniteKernel κ] : IsSFiniteKernel (snd κ) :=
-  by rw [snd]; infer_instance
+  by rw [kernel.snd]; infer_instance
 #align probability_theory.kernel.is_s_finite_kernel.snd ProbabilityTheory.kernel.IsSFiniteKernel.snd
 
 end FstSnd
@@ -932,15 +932,15 @@ theorem lintegral_prod (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel α 
 #align probability_theory.kernel.lintegral_prod ProbabilityTheory.kernel.lintegral_prod
 
 instance IsMarkovKernel.prod (κ : kernel α β) [IsMarkovKernel κ] (η : kernel α γ)
-    [IsMarkovKernel η] : IsMarkovKernel (κ ×ₖ η) := by rw [prod]; infer_instance
+    [IsMarkovKernel η] : IsMarkovKernel (κ ×ₖ η) := by rw [kernel.prod]; infer_instance
 #align probability_theory.kernel.is_markov_kernel.prod ProbabilityTheory.kernel.IsMarkovKernel.prod
 
 instance IsFiniteKernel.prod (κ : kernel α β) [IsFiniteKernel κ] (η : kernel α γ)
-    [IsFiniteKernel η] : IsFiniteKernel (κ ×ₖ η) := by rw [prod]; infer_instance
+    [IsFiniteKernel η] : IsFiniteKernel (κ ×ₖ η) := by rw [kernel.prod]; infer_instance
 #align probability_theory.kernel.is_finite_kernel.prod ProbabilityTheory.kernel.IsFiniteKernel.prod
 
 instance IsSFiniteKernel.prod (κ : kernel α β) (η : kernel α γ) :
-    IsSFiniteKernel (κ ×ₖ η) := by rw [prod]; infer_instance
+    IsSFiniteKernel (κ ×ₖ η) := by rw [kernel.prod]; infer_instance
 #align probability_theory.kernel.is_s_finite_kernel.prod ProbabilityTheory.kernel.IsSFiniteKernel.prod
 
 end Prod

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -203,6 +203,8 @@ theorem isSFiniteKernel_withDensity_of_isFiniteKernel (κ : kernel α β) [IsFin
   refine' isSFiniteKernel_sum fun n => _
   suffices IsFiniteKernel (withDensity κ (fs n)) by haveI := this; infer_instance
   refine' isFiniteKernel_withDensity_of_bounded _ (ENNReal.coe_ne_top : ↑n + 1 ≠ ∞) fun a b => _
+  -- After leanprover/lean4#2734, we need to do beta reduction before `norm_cast`
+  dsimp (config := {zeta := false}) only
   norm_cast
   calc
     fs n a b ≤ min (f a b) (n + 1) := tsub_le_self

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -204,7 +204,7 @@ theorem isSFiniteKernel_withDensity_of_isFiniteKernel (κ : kernel α β) [IsFin
   suffices IsFiniteKernel (withDensity κ (fs n)) by haveI := this; infer_instance
   refine' isFiniteKernel_withDensity_of_bounded _ (ENNReal.coe_ne_top : ↑n + 1 ≠ ∞) fun a b => _
   -- After leanprover/lean4#2734, we need to do beta reduction before `norm_cast`
-  dsimp (config := {zeta := false}) only
+  beta_reduce
   norm_cast
   calc
     fs n a b ≤ min (f a b) (n + 1) := tsub_le_self

--- a/Mathlib/RingTheory/MvPolynomial/Homogeneous.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Homogeneous.lean
@@ -204,7 +204,7 @@ theorem prod {ι : Type*} (s : Finset ι) (φ : ι → MvPolynomial σ R) (n : �
 #align mv_polynomial.is_homogeneous.prod MvPolynomial.IsHomogeneous.prod
 
 theorem totalDegree (hφ : IsHomogeneous φ n) (h : φ ≠ 0) : totalDegree φ = n := by
-  rw [totalDegree]
+  rw [MvPolynomial.totalDegree]
   apply le_antisymm
   · apply Finset.sup_le
     intro d hd

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -31,6 +31,9 @@ open Lean Meta Std.Tactic.TryThis
 initialize registerTraceClass `Tactic.librarySearch
 initialize registerTraceClass `Tactic.librarySearch.lemmas
 
+/-- Configuration for `DiscrTree`. -/
+def discrTreeConfig : WhnfCoreConfig := {}
+
 /--
 A "modifier" for a declaration.
 * `none` indicates the original declaration,
@@ -47,17 +50,17 @@ instance : ToString DeclMod where
 
 /-- Prepare the discrimination tree entries for a lemma. -/
 def processLemma (name : Name) (constInfo : ConstantInfo) :
-    MetaM (Array (Array (DiscrTree.Key true) × (Name × DeclMod))) := do
+    MetaM (Array (Array DiscrTree.Key × (Name × DeclMod))) := do
   if constInfo.isUnsafe then return #[]
   if ← name.isBlackListed then return #[]
   withNewMCtxDepth do withReducible do
     let (_, _, type) ← forallMetaTelescope constInfo.type
-    let keys ← DiscrTree.mkPath type
+    let keys ← DiscrTree.mkPath type discrTreeConfig
     let mut r := #[(keys, (name, .none))]
     match type.getAppFnArgs with
     | (``Iff, #[lhs, rhs]) => do
-      return r.push (← DiscrTree.mkPath rhs, (name, .mp))
-        |>.push (← DiscrTree.mkPath lhs, (name, .mpr))
+      return r.push (← DiscrTree.mkPath rhs discrTreeConfig, (name, .mp))
+        |>.push (← DiscrTree.mkPath lhs discrTreeConfig, (name, .mpr))
     | _ => return r
 
 /-- Insert a lemma into the discrimination tree. -/
@@ -66,15 +69,15 @@ def processLemma (name : Name) (constInfo : ConstantInfo) :
 -- `build/lib/MathlibExtras/LibrarySearch.extra`
 -- so that the cache is rebuilt.
 def addLemma (name : Name) (constInfo : ConstantInfo)
-    (lemmas : DiscrTree (Name × DeclMod) true) : MetaM (DiscrTree (Name × DeclMod) true) := do
+    (lemmas : DiscrTree (Name × DeclMod)) : MetaM (DiscrTree (Name × DeclMod)) := do
   let mut lemmas := lemmas
   for (key, value) in ← processLemma name constInfo do
-    lemmas := lemmas.insertIfSpecific key value
+    lemmas := lemmas.insertIfSpecific key value discrTreeConfig
   return lemmas
 
 /-- Construct the discrimination tree of all lemmas. -/
 def buildDiscrTree : IO (DiscrTreeCache (Name × DeclMod)) :=
-  DiscrTreeCache.mk "apply?: init cache" processLemma
+  DiscrTreeCache.mk "apply?: init cache" processLemma (config := discrTreeConfig)
     -- Sort so lemmas with longest names come first.
     -- This is counter-intuitive, but the way that `DiscrTree.getMatch` returns results
     -- means that the results come in "batches", with more specific matches *later*.
@@ -98,9 +101,10 @@ Retrieve the current current of lemmas.
 initialize librarySearchLemmas : DiscrTreeCache (Name × DeclMod) ← unsafe do
   let path ← cachePath
   if (← path.pathExists) then
-    let (d, _r) ← unpickle (DiscrTree (Name × DeclMod) true) path
+    let (d, _r) ← unpickle (DiscrTree (Name × DeclMod)) path
     -- We can drop the `CompactedRegion` value; we do not plan to free it
     DiscrTreeCache.mk "apply?: using cache" processLemma (init := some d)
+      (config := discrTreeConfig)
   else
     buildDiscrTree
 
@@ -145,7 +149,7 @@ def librarySearchCore (goal : MVarId)
     (required : List Expr) (solveByElimDepth := 6) : Nondet MetaM (List MVarId) :=
   .squash fun _ => do
     let ty ← goal.getType
-    let lemmas := (← librarySearchLemmas.getMatch ty).toList
+    let lemmas := (← librarySearchLemmas.getMatch ty discrTreeConfig).toList
     trace[Tactic.librarySearch.lemmas] m!"Candidate library_search lemmas:\n{lemmas}"
     return (Nondet.ofList lemmas).filterMapM fun (lem, mod) =>
       observing? <| librarySearchLemma lem mod required solveByElimDepth goal

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -62,16 +62,19 @@ def mkPositivityExt (n : Name) : ImportM PositivityExt := do
   let { env, opts, .. } ← read
   IO.ofExcept <| unsafe env.evalConstCheck PositivityExt opts ``PositivityExt n
 
+/-- Configuration for `DiscrTree`. -/
+def discrTreeConfig : WhnfCoreConfig := {}
+
 /-- Each `positivity` extension is labelled with a collection of patterns
 which determine the expressions to which it should be applied. -/
-abbrev Entry := Array (Array (DiscrTree.Key true)) × Name
+abbrev Entry := Array (Array DiscrTree.Key) × Name
 
 /-- Environment extensions for `positivity` declarations -/
 initialize positivityExt : PersistentEnvExtension Entry (Entry × PositivityExt)
-    (List Entry × DiscrTree PositivityExt true) ←
+    (List Entry × DiscrTree PositivityExt) ←
   -- we only need this to deduplicate entries in the DiscrTree
   have : BEq PositivityExt := ⟨fun _ _ => false⟩
-  let insert kss v dt := kss.foldl (fun dt ks => dt.insertCore ks v) dt
+  let insert kss v dt := kss.foldl (fun dt ks => dt.insertCore ks v discrTreeConfig) dt
   registerPersistentEnvExtension {
     mkInitial := pure ([], {})
     addImportedFn := fun s => do
@@ -101,7 +104,7 @@ initialize registerBuiltinAttribute {
             let e ← elabTerm stx none
             let (_, _, e) ← lambdaMetaTelescope (← mkLambdaFVars (← getLCtx).getFVars e)
             return e
-        DiscrTree.mkPath e
+        DiscrTree.mkPath e discrTreeConfig
       setEnv <| positivityExt.addEntry env ((keys, declName), ext)
     | _ => throwUnsupportedSyntax
 }
@@ -287,7 +290,7 @@ def orElse (t₁ : Strictness zα pα e) (t₂ : MetaM (Strictness zα pα e)) :
 def core (e : Q($α)) : MetaM (Strictness zα pα e) := do
   let mut result := .none
   trace[Tactic.positivity] "trying to prove positivity of {e}"
-  for ext in ← (positivityExt.getState (← getEnv)).2.getMatch e do
+  for ext in ← (positivityExt.getState (← getEnv)).2.getMatch e discrTreeConfig do
     try
       result ← orElse result <| ext.eval zα pα e
     catch err =>

--- a/Mathlib/Tactic/Relation/Rfl.lean
+++ b/Mathlib/Tactic/Relation/Rfl.lean
@@ -41,7 +41,7 @@ def _root_.Lean.MVarId.liftReflToEq (mvarId : MVarId) : MetaM MVarId := do
   if rel.isAppOf `Eq then
     -- No need to lift Eq to Eq
     return mvarId
-  for lem in ← (Std.Tactic.reflExt.getState (← getEnv)).getMatch rel do
+  for lem in ← (Std.Tactic.reflExt.getState (← getEnv)).getMatch rel Std.Tactic.reflExt.config do
     let res ← observing? do
       -- First create an equality relating the LHS and RHS
       -- and reduce the goal to proving that LHS is related to LHS.

--- a/Mathlib/Tactic/Rewrites.lean
+++ b/Mathlib/Tactic/Rewrites.lean
@@ -53,9 +53,12 @@ def forwardWeight := 2
 /-- Weight to multiply the "specificity" of a rewrite lemma by when rewriting backwards. -/
 def backwardWeight := 1
 
+/-- Configuration for `DiscrTree`. -/
+def discrTreeConfig : WhnfCoreConfig := {}
+
 /-- Prepare the discrimination tree entries for a lemma. -/
 def processLemma (name : Name) (constInfo : ConstantInfo) :
-    MetaM (Array (Array (DiscrTree.Key true) × (Name × Bool × Nat))) := do
+    MetaM (Array (Array DiscrTree.Key × (Name × Bool × Nat))) := do
   if constInfo.isUnsafe then return #[]
   if ← name.isBlackListed then return #[]
   -- We now remove some injectivity lemmas which are not useful to rewrite by.
@@ -69,8 +72,8 @@ def processLemma (name : Name) (constInfo : ConstantInfo) :
     match type.getAppFnArgs with
     | (``Eq, #[_, lhs, rhs])
     | (``Iff, #[lhs, rhs]) => do
-      let lhsKey ← DiscrTree.mkPath lhs
-      let rhsKey ← DiscrTree.mkPath rhs
+      let lhsKey ← DiscrTree.mkPath lhs discrTreeConfig
+      let rhsKey ← DiscrTree.mkPath rhs discrTreeConfig
       return #[(lhsKey, (name, false, forwardWeight * lhsKey.size)),
         (rhsKey, (name, true, backwardWeight * rhsKey.size))]
     | _ => return #[]
@@ -85,8 +88,8 @@ def localHypotheses (except : List FVarId := []) : MetaM (Array (Expr × Bool ×
     match type.getAppFnArgs with
     | (``Eq, #[_, lhs, rhs])
     | (``Iff, #[lhs, rhs]) => do
-      let lhsKey : Array (DiscrTree.Key true) ← DiscrTree.mkPath lhs
-      let rhsKey : Array (DiscrTree.Key true) ← DiscrTree.mkPath rhs
+      let lhsKey : Array DiscrTree.Key ← DiscrTree.mkPath lhs discrTreeConfig
+      let rhsKey : Array DiscrTree.Key ← DiscrTree.mkPath rhs discrTreeConfig
       result := result.push (h, false, forwardWeight * lhsKey.size)
         |>.push (h, true, backwardWeight * rhsKey.size)
     | _ => pure ()
@@ -98,15 +101,15 @@ def localHypotheses (except : List FVarId := []) : MetaM (Array (Expr × Bool ×
 -- `build/lib/MathlibExtras/Rewrites.extra`
 -- so that the cache is rebuilt.
 def addLemma (name : Name) (constInfo : ConstantInfo)
-    (lemmas : DiscrTree (Name × Bool × Nat) true) : MetaM (DiscrTree (Name × Bool × Nat) true) := do
+    (lemmas : DiscrTree (Name × Bool × Nat)) : MetaM (DiscrTree (Name × Bool × Nat)) := do
   let mut lemmas := lemmas
   for (key, value) in ← processLemma name constInfo do
-    lemmas := lemmas.insertIfSpecific key value
+    lemmas := lemmas.insertIfSpecific key value discrTreeConfig
   return lemmas
 
 /-- Construct the discrimination tree of all lemmas. -/
 def buildDiscrTree : IO (DiscrTreeCache (Name × Bool × Nat)) :=
-  DiscrTreeCache.mk "rw?: init cache" processLemma
+  DiscrTreeCache.mk "rw?: init cache" processLemma (config := discrTreeConfig)
     -- Sort so lemmas with longest names come first.
     -- This is counter-intuitive, but the way that `DiscrTree.getMatch` returns results
     -- means that the results come in "batches", with more specific matches *later*.
@@ -130,9 +133,9 @@ Retrieve the current cache of lemmas.
 initialize rewriteLemmas : DiscrTreeCache (Name × Bool × Nat) ← unsafe do
   let path ← cachePath
   if (← path.pathExists) then
-    let (d, _r) ← unpickle (DiscrTree (Name × Bool × Nat) true) path
+    let (d, _r) ← unpickle (DiscrTree (Name × Bool × Nat)) path
     -- We can drop the `CompactedRegion` value; we do not plan to free it
-    DiscrTreeCache.mk "rw?: using cache" processLemma (init := some d)
+    DiscrTreeCache.mk "rw?: using cache" processLemma (init := some d) (config := discrTreeConfig)
   else
     buildDiscrTree
 
@@ -213,12 +216,12 @@ See also `rewrites` for a more convenient interface.
 -- because `MLList.squash` executes lazily,
 -- so there is no opportunity for `← getMCtx` to record the context at the call site.
 def rewritesCore (hyps : Array (Expr × Bool × Nat))
-    (lemmas : DiscrTree (Name × Bool × Nat) s × DiscrTree (Name × Bool × Nat) s)
+    (lemmas : DiscrTree (Name × Bool × Nat) × DiscrTree (Name × Bool × Nat))
     (ctx : MetavarContext) (goal : MVarId) (target : Expr) (side : SideConditions := .solveByElim) :
     MLList MetaM RewriteResult := MLList.squash fun _ => do
   -- Get all lemmas which could match some subexpression
-  let candidates := (← lemmas.1.getSubexpressionMatches target)
-    ++ (← lemmas.2.getSubexpressionMatches target)
+  let candidates := (← lemmas.1.getSubexpressionMatches target discrTreeConfig)
+    ++ (← lemmas.2.getSubexpressionMatches target discrTreeConfig)
 
   -- Sort them by our preferring weighting
   -- (length of discriminant key, doubled for the forward implication)
@@ -276,7 +279,7 @@ Find lemmas which can rewrite the goal, and deduplicate based on pretty-printed 
 Note that this builds a `HashMap` containing the results, and so may consume significant memory.
 -/
 def rewritesDedup (hyps : Array (Expr × Bool × Nat))
-    (lemmas : DiscrTree (Name × Bool × Nat) s × DiscrTree (Name × Bool × Nat) s)
+    (lemmas : DiscrTree (Name × Bool × Nat) × DiscrTree (Name × Bool × Nat))
     (mctx : MetavarContext)
     (goal : MVarId) (target : Expr) (side : SideConditions := .solveByElim) :
     MLList MetaM RewriteResult := MLList.squash fun _ => do
@@ -289,7 +292,7 @@ def rewritesDedup (hyps : Array (Expr × Bool × Nat))
 
 /-- Find lemmas which can rewrite the goal. -/
 def rewrites (hyps : Array (Expr × Bool × Nat))
-    (lemmas : DiscrTree (Name × Bool × Nat) s × DiscrTree (Name × Bool × Nat) s)
+    (lemmas : DiscrTree (Name × Bool × Nat) × DiscrTree (Name × Bool × Nat))
     (goal : MVarId) (target : Expr)
     (side : SideConditions := .solveByElim) (stopAtRfl : Bool := false) (max : Nat := 20)
     (leavePercentHeartbeats : Nat := 10) : MetaM (List RewriteResult) := do

--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -21,7 +21,7 @@ open Lean Server RequestM
 
 /-- Code action to create a `calc` tactic from the current goal. -/
 @[tactic_code_action calcTactic]
-def createCalc : TacticCodeAction := fun params _snap ctx _stack node => do
+def createCalc : TacticCodeAction := fun _params _snap ctx _stack node => do
   let .node (.ofTacticInfo info) _ := node | return #[]
   if info.goalsBefore.isEmpty then return #[]
   let eager := {
@@ -37,7 +37,7 @@ def createCalc : TacticCodeAction := fun params _snap ctx _stack node => do
       let goal := info.goalsBefore[0]!
       let goalFmt ← ctx.runMetaM {} <| goal.withContext do Meta.ppExpr (← goal.getType)
       return { eager with
-        edit? := some <|.ofTextEdit params.textDocument.uri
+        edit? := some <|.ofTextEdit doc.versionedIdentifier
           { range := ⟨tacPos, endPos⟩, newText := s!"calc {goalFmt} := by sorry" }
       }
   }]

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1029,7 +1029,7 @@ lemma IsClosedMap.restrictPreimage {f : α → β} (hcl : IsClosedMap f) (T : Se
     IsClosedMap (T.restrictPreimage f) := by
   rw [isClosedMap_iff_clusterPt] at hcl ⊢
   intro A ⟨y, hyT⟩ hy
-  rw [restrictPreimage, MapClusterPt, ← inducing_subtype_val.mapClusterPt_iff, MapClusterPt,
+  rw [Set.restrictPreimage, MapClusterPt, ← inducing_subtype_val.mapClusterPt_iff, MapClusterPt,
       map_map, MapsTo.restrict_commutes, ← map_map, ← MapClusterPt, map_principal] at hy
   rcases hcl _ y hy with ⟨x, hxy, hx⟩
   have hxT : f x ∈ T := hxy ▸ hyT

--- a/Mathlib/Topology/DenseEmbedding.lean
+++ b/Mathlib/Topology/DenseEmbedding.lean
@@ -201,8 +201,7 @@ theorem continuousAt_extend [T3Space γ] {b : β} {f : α → γ} (di : DenseInd
   have V₁_in : V₁ ∈ 𝓝 b := by
     filter_upwards [hf]
     rintro x ⟨c, hc⟩
-    unfold_let φ
-    rwa [di.extend_eq_of_tendsto hc]
+    rwa [← di.extend_eq_of_tendsto hc] at hc
   obtain ⟨V₂, V₂_in, V₂_op, hV₂⟩ : ∃ V₂ ∈ 𝓝 b, IsOpen V₂ ∧ ∀ x ∈ i ⁻¹' V₂, f x ∈ V' := by
     simpa [and_assoc] using
       ((nhds_basis_opens' b).comap i).tendsto_left_iff.mp (mem_of_mem_nhds V₁_in : b ∈ V₁) V' V'_in

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -2,14 +2,6 @@
  "packagesDir": "lake-packages",
  "packages":
  [{"git":
-   {"url": "https://github.com/leanprover/std4",
-    "subDir?": null,
-    "rev": "d52c0dead277fae231a36badec636ea34d917d7d",
-    "opts": {},
-    "name": "std",
-    "inputRev?": "bump_v4.3.0-rc1",
-    "inherited": false}},
-  {"git":
    {"url": "https://github.com/leanprover-community/quote4",
     "subDir?": null,
     "rev": "a387c0eb611857e2460cf97a8e861c944286e6b2",
@@ -40,5 +32,13 @@
     "opts": {},
     "name": "proofwidgets",
     "inputRev?": "v0.0.21",
+    "inherited": false}},
+  {"git":
+   {"url": "https://github.com/leanprover/std4",
+    "subDir?": null,
+    "rev": "fa849e09142a3cda1b64107d542abb08956ec069",
+    "opts": {},
+    "name": "std",
+    "inputRev?": "main",
     "inherited": false}}],
  "name": "mathlib"}

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -2,12 +2,28 @@
  "packagesDir": "lake-packages",
  "packages":
  [{"git":
+   {"url": "https://github.com/leanprover/std4",
+    "subDir?": null,
+    "rev": "d52c0dead277fae231a36badec636ea34d917d7d",
+    "opts": {},
+    "name": "std",
+    "inputRev?": "bump_v4.3.0-rc1",
+    "inherited": false}},
+  {"git":
    {"url": "https://github.com/leanprover-community/quote4",
     "subDir?": null,
     "rev": "a387c0eb611857e2460cf97a8e861c944286e6b2",
     "opts": {},
     "name": "Qq",
     "inputRev?": "master",
+    "inherited": false}},
+  {"git":
+   {"url": "https://github.com/leanprover-community/aesop",
+    "subDir?": null,
+    "rev": "ddff16044ebbe28d21e76ef363ca5862bdcbef8a",
+    "opts": {},
+    "name": "aesop",
+    "inputRev?": "nightly-testing",
     "inherited": false}},
   {"git":
    {"url": "https://github.com/leanprover/lean4-cli",
@@ -24,21 +40,5 @@
     "opts": {},
     "name": "proofwidgets",
     "inputRev?": "v0.0.21",
-    "inherited": false}},
-  {"git":
-   {"url": "https://github.com/leanprover/std4",
-    "subDir?": null,
-    "rev": "6747f41f28627bed83e6d5891683538211caa2c1",
-    "opts": {},
-    "name": "std",
-    "inputRev?": "main",
-    "inherited": false}},
-  {"git":
-   {"url": "https://github.com/leanprover-community/aesop",
-    "subDir?": null,
-    "rev": "6749fa4e776919514dae85bfc0ad62a511bc42a7",
-    "opts": {},
-    "name": "aesop",
-    "inputRev?": "master",
     "inherited": false}}],
  "name": "mathlib"}

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -2,6 +2,14 @@
  "packagesDir": "lake-packages",
  "packages":
  [{"git":
+   {"url": "https://github.com/leanprover/std4",
+    "subDir?": null,
+    "rev": "a71c160b1934814837d37f377efaf2964e55c433",
+    "opts": {},
+    "name": "std",
+    "inputRev?": "main",
+    "inherited": false}},
+  {"git":
    {"url": "https://github.com/leanprover-community/quote4",
     "subDir?": null,
     "rev": "a387c0eb611857e2460cf97a8e861c944286e6b2",
@@ -12,10 +20,10 @@
   {"git":
    {"url": "https://github.com/leanprover-community/aesop",
     "subDir?": null,
-    "rev": "ddff16044ebbe28d21e76ef363ca5862bdcbef8a",
+    "rev": "ed733adcb79e54e157fafb805ce3518d4411ab70",
     "opts": {},
     "name": "aesop",
-    "inputRev?": "nightly-testing",
+    "inputRev?": "master",
     "inherited": false}},
   {"git":
    {"url": "https://github.com/leanprover/lean4-cli",
@@ -32,13 +40,5 @@
     "opts": {},
     "name": "proofwidgets",
     "inputRev?": "v0.0.21",
-    "inherited": false}},
-  {"git":
-   {"url": "https://github.com/leanprover/std4",
-    "subDir?": null,
-    "rev": "fa849e09142a3cda1b64107d542abb08956ec069",
-    "opts": {},
-    "name": "std",
-    "inputRev?": "main",
     "inherited": false}}],
  "name": "mathlib"}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -48,7 +48,7 @@ require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
 require std from git "https://github.com/leanprover/std4" @ "bump_v4.3.0-rc1"
 require Qq from git "https://github.com/leanprover-community/quote4" @ "master"
-require aesop from git "https://github.com/leanprover-community/aesop" @ "master"
+require aesop from git "https://github.com/leanprover-community/aesop" @ "nightly-testing"
 require Cli from git "https://github.com/leanprover/lean4-cli" @ "nightly"
 require proofwidgets from git "https://github.com/leanprover-community/ProofWidgets4" @ "v0.0.21"
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -46,7 +46,7 @@ lean_exe checkYaml where
 meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
-require std from git "https://github.com/leanprover/std4" @ "main"
+require std from git "https://github.com/leanprover/std4" @ "lean-pr-testing-2734"
 require Qq from git "https://github.com/leanprover-community/quote4" @ "master"
 require aesop from git "https://github.com/leanprover-community/aesop" @ "nightly-testing"
 require Cli from git "https://github.com/leanprover/lean4-cli" @ "nightly"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -46,7 +46,7 @@ lean_exe checkYaml where
 meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
-require std from git "https://github.com/leanprover/std4" @ "bump_v4.3.0-rc1"
+require std from git "https://github.com/leanprover/std4" @ "main"
 require Qq from git "https://github.com/leanprover-community/quote4" @ "master"
 require aesop from git "https://github.com/leanprover-community/aesop" @ "nightly-testing"
 require Cli from git "https://github.com/leanprover/lean4-cli" @ "nightly"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -46,9 +46,9 @@ lean_exe checkYaml where
 meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
-require std from git "https://github.com/leanprover/std4" @ "lean-pr-testing-2734"
+require std from git "https://github.com/leanprover/std4" @ "main"
 require Qq from git "https://github.com/leanprover-community/quote4" @ "master"
-require aesop from git "https://github.com/leanprover-community/aesop" @ "nightly-testing"
+require aesop from git "https://github.com/leanprover-community/aesop" @ "master"
 require Cli from git "https://github.com/leanprover/lean4-cli" @ "nightly"
 require proofwidgets from git "https://github.com/leanprover-community/ProofWidgets4" @ "v0.0.21"
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -46,7 +46,7 @@ lean_exe checkYaml where
 meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
-require std from git "https://github.com/leanprover/std4" @ "main"
+require std from git "https://github.com/leanprover/std4" @ "bump_v4.3.0-rc1"
 require Qq from git "https://github.com/leanprover-community/quote4" @ "master"
 require aesop from git "https://github.com/leanprover-community/aesop" @ "master"
 require Cli from git "https://github.com/leanprover/lean4-cli" @ "nightly"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.2.0-rc4
+leanprover/lean4:v4.2.0

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.2.0
+leanprover/lean4:v4.3.0-rc1

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,9 +1,1 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
 leanprover/lean4:v4.3.0-rc1
-=======
-leanprover/lean4-pr-releases:pr-release-2734
->>>>>>> lean-pr-testing-2734
-=======
-leanprover/lean4-pr-releases:pr-release-2734
->>>>>>> origin/lean-pr-testing-2734

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 leanprover/lean4:v4.3.0-rc1
+=======
+leanprover/lean4-pr-releases:pr-release-2734
+>>>>>>> lean-pr-testing-2734

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,5 +1,9 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
 leanprover/lean4:v4.3.0-rc1
 =======
 leanprover/lean4-pr-releases:pr-release-2734
 >>>>>>> lean-pr-testing-2734
+=======
+leanprover/lean4-pr-releases:pr-release-2734
+>>>>>>> origin/lean-pr-testing-2734


### PR DESCRIPTION
This incorporates changes from 

* #7845
* #7847
* #7853
* #7872 (was never actually made to work, but the diffs in `nightly-testing` are unexciting: we need to fully qualify a few names)

They can all be closed when this is merged.

---

- [x] depends on: leanprover/std4#338

Once the std PR is merged, we need to change the `lakefile.lean` here to point back to `main`. ✅ 


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
