### PR TITLE
[Merged by Bors] - fix: Exists delaborator merging

### DIFF
--- a/Mathlib/Util/Delaborators.lean
+++ b/Mathlib/Util/Delaborators.lean
@@ -149,7 +149,8 @@ def exists_delab : Delab := whenPPOption Lean.getPPNotation do
       if x == y then `(∃ $x:ident ⊃ $z, $body) else pure stx
     | _ => pure stx
   match stx with
-  | `(∃ $group:bracketedExplicitBinders, ∃ $groups*, $body) => `(∃ $group $groups*, $body)
+  | `(∃ $group:bracketedExplicitBinders, ∃ $[$groups:bracketedExplicitBinders]*, $body) =>
+    `(∃ $group $groups*, $body)
   | `(∃ $b:binderIdent, ∃ $[$bs:binderIdent]*, $body) => `(∃ $b:binderIdent $[$bs]*, $body)
   | _ => pure stx
 end existential

--- a/test/delaborators.lean
+++ b/test/delaborators.lean
@@ -197,6 +197,26 @@ variable (Q : Set ℕ → Prop)
 #guard_msgs in
 #check ∃ n, ∃ k, n = k
 
+section merging
+
+/-- info: ∃ (_ : True), True : Prop -/
+#guard_msgs in #check ∃ (_ : True), True
+
+/-- info: ∃ (_ : True), ∃ x, x = x : Prop -/
+#guard_msgs in #check ∃ (_ : True) (x : Nat), x = x
+
+/-- info: ∃ (_ : True), ∃ x y, x = y : Prop -/
+#guard_msgs in #check ∃ (_ : True) (x y : Nat), x = y
+
+/-- info: ∃ (_ : True) (_ : False), True : Prop -/
+#guard_msgs in #check ∃ (_ : True) (_ : False), True
+
+set_option pp.funBinderTypes true in
+/-- info: ∃ (x : ℕ) (x : ℕ), True : Prop -/
+#guard_msgs in #check ∃ (_ : Nat) (_ : Nat), True
+
+end merging
+
 end existential
 
 section prod


### PR DESCRIPTION
The binder merging feature of the delaborator was matching too much and creating ill-formed terms like `∃ (_ : True) x, True`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
