### PR TITLE
[Merged by Bors] - feat: descend a continuous map along a quotient map

### DIFF
--- a/Mathlib/Topology/ContinuousFunction/Basic.lean
+++ b/Mathlib/Topology/ContinuousFunction/Basic.lean
@@ -523,8 +523,7 @@ f |  / hf.lift g h
 @[simp]
 theorem lift_comp : (hf.lift g h).comp f = g := by
   ext
-  simpa [lift, homeomorph, Setoid.quotientKerEquivOfSurjective,
-    Setoid.quotientKerEquivOfRightInverse] using h (Function.rightInverse_surjInv _ _)
+  simpa using h (Function.rightInverse_surjInv _ _)
 
 @[simps]
 noncomputable def liftEquiv : { g : C(X, Z) // Function.FactorsThrough g f} ≃ C(Y, Z) where
@@ -532,11 +531,9 @@ noncomputable def liftEquiv : { g : C(X, Z) // Function.FactorsThrough g f} ≃ 
   invFun g := ⟨g.comp f, fun _ _ h ↦ by simp only [ContinuousMap.comp_apply]; rw [h]⟩
   left_inv := by intro; simp
   right_inv := by
-    intro
-    ext
-    simp only [lift_apply, ContinuousMap.coe_comp, comp_apply, homeomorph_symm_apply,
-      Quotient.liftOn'_mk'']
-    rw [Function.rightInverse_surjInv hf.surjective]
+    intro g
+    ext a
+    simpa using congrArg g (Function.rightInverse_surjInv hf.surjective a)
 
 end QuotientMap
 

--- a/Mathlib/Topology/ContinuousFunction/Basic.lean
+++ b/Mathlib/Topology/ContinuousFunction/Basic.lean
@@ -489,26 +489,26 @@ def homeomorph : Quotient (Setoid.ker f) ≃ₜ Y where
 
 /-- Descend a continuous map, which is constant on the fibres, along a quotient map. -/
 noncomputable
-def descend : C(Y, Z) where
-  toFun := ((fun i ↦ Quotient.liftOn' i g (fun _ _ (hab : f _ = f _) ↦ h _ _ hab)) :
+def lift : C(Y, Z) where
+  toFun := ((fun i ↦ Quotient.liftOn' i g (fun _ _ (hab : f _ = f _) ↦ h hab)) :
     Quotient (Setoid.ker f) → Z) ∘ hf.homeomorph.symm
   continuous_toFun := Continuous.comp (continuous_quot_lift _ g.2) (Homeomorph.continuous _)
 
 /--
-The obvious triangle induced by `QuotientMap.descend` commutes:
+The obvious triangle induced by `QuotientMap.lift` commutes:
 ```
      g
   X --→ Z
   |   ↗
-f |  / hf.descend g h
+f |  / hf.lift g h
   v /
   Y
 ```
 -/
-theorem descend_comp : (hf.descend g h) ∘ f = g := by
+theorem lift_comp : (hf.lift g h) ∘ f = g := by
   ext
-  simpa [descend, homeomorph, Setoid.quotientKerEquivOfSurjective,
-    Setoid.quotientKerEquivOfRightInverse] using h _ _ (Function.rightInverse_surjInv _ _)
+  simpa [lift, homeomorph, Setoid.quotientKerEquivOfSurjective,
+    Setoid.quotientKerEquivOfRightInverse] using h (Function.rightInverse_surjInv _ _)
 
 end QuotientMap
 

--- a/Mathlib/Topology/ContinuousFunction/Basic.lean
+++ b/Mathlib/Topology/ContinuousFunction/Basic.lean
@@ -469,6 +469,39 @@ end Gluing
 
 end ContinuousMap
 
+namespace QuotientMap
+
+variable {X Y Z : Type*} [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z]
+    {f : C(X, Y)} (hf : QuotientMap f) (g : C(X, Z)) (h : ∀ a b, f a = f b → g a = g b)
+
+/-- The homeomorphism from the quotient of a quotient map to its codomain. -/
+noncomputable
+def homeomorph : Quotient (Setoid.ker f) ≃ₜ Y where
+  toEquiv := Setoid.quotientKerEquivOfSurjective _ hf.surjective
+  continuous_toFun := quotientMap_quot_mk.continuous_iff.mpr hf.continuous
+  continuous_invFun := by
+    rw [hf.continuous_iff]
+    convert continuous_quotient_mk'
+    ext
+    simp only [Equiv.invFun_as_coe, Function.comp_apply,
+      (Setoid.quotientKerEquivOfSurjective f hf.surjective).symm_apply_eq]
+    rfl
+
+/-- Descend a continuous map which is constant on the fibres along a quotient map. -/
+noncomputable
+def descend : C(Y, Z) where
+  toFun := ((fun i ↦ Quotient.liftOn' i g (fun _ _ (hab : f _ = f _) ↦ h _ _ hab)) :
+    Quotient (Setoid.ker f) → Z) ∘ hf.homeomorph.symm
+  continuous_toFun := Continuous.comp (continuous_quot_lift _ g.2) (Homeomorph.continuous _)
+
+/-- The obvious triangle induced by `QuotientMap.descend` commutes. -/
+theorem descend_comp : (hf.descend g h) ∘ f = g := by
+  ext
+  simpa [descend, homeomorph, Setoid.quotientKerEquivOfSurjective,
+    Setoid.quotientKerEquivOfRightInverse] using h _ _ (Function.rightInverse_surjInv _ _)
+
+end QuotientMap
+
 namespace Homeomorph
 
 variable {α β γ : Type*} [TopologicalSpace α] [TopologicalSpace β] [TopologicalSpace γ]

--- a/Mathlib/Topology/ContinuousFunction/Basic.lean
+++ b/Mathlib/Topology/ContinuousFunction/Basic.lean
@@ -472,7 +472,7 @@ end ContinuousMap
 namespace QuotientMap
 
 variable {X Y Z : Type*} [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z]
-    {f : C(X, Y)} (hf : QuotientMap f) (g : C(X, Z)) (h : ∀ a b, f a = f b → g a = g b)
+    {f : C(X, Y)} (hf : QuotientMap f) (g : C(X, Z)) (h : Function.FactorsThrough g f)
 
 /-- The homeomorphism from the quotient of a quotient map to its codomain. -/
 noncomputable

--- a/Mathlib/Topology/ContinuousFunction/Basic.lean
+++ b/Mathlib/Topology/ContinuousFunction/Basic.lean
@@ -525,6 +525,7 @@ theorem lift_comp : (hf.lift g h).comp f = g := by
   ext
   simpa using h (Function.rightInverse_surjInv _ _)
 
+/-- `QuotientMap.lift` as an equivalence. -/
 @[simps]
 noncomputable def liftEquiv : { g : C(X, Z) // Function.FactorsThrough g f} ≃ C(Y, Z) where
   toFun g := hf.lift g g.prop

--- a/Mathlib/Topology/ContinuousFunction/Basic.lean
+++ b/Mathlib/Topology/ContinuousFunction/Basic.lean
@@ -487,14 +487,24 @@ def homeomorph : Quotient (Setoid.ker f) ≃ₜ Y where
       (Setoid.quotientKerEquivOfSurjective f hf.surjective).symm_apply_eq]
     rfl
 
-/-- Descend a continuous map which is constant on the fibres along a quotient map. -/
+/-- Descend a continuous map, which is constant on the fibres, along a quotient map. -/
 noncomputable
 def descend : C(Y, Z) where
   toFun := ((fun i ↦ Quotient.liftOn' i g (fun _ _ (hab : f _ = f _) ↦ h _ _ hab)) :
     Quotient (Setoid.ker f) → Z) ∘ hf.homeomorph.symm
   continuous_toFun := Continuous.comp (continuous_quot_lift _ g.2) (Homeomorph.continuous _)
 
-/-- The obvious triangle induced by `QuotientMap.descend` commutes. -/
+/--
+The obvious triangle induced by `QuotientMap.descend` commutes:
+```
+     g
+  X --→ Z
+  |   ↗
+f |  / hf.descend g h
+  v /
+  Y
+```
+-/
 theorem descend_comp : (hf.descend g h) ∘ f = g := by
   ext
   simpa [descend, homeomorph, Setoid.quotientKerEquivOfSurjective,


### PR DESCRIPTION
This was done for profinite sets in LTE. 

We give a homeomorphism from the quotient of a quotient map to its codomain, and prove that a continuous map which is constant on the fibres of a quotient map can be descended along the quotient map. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
