### PR TITLE
[Merged by Bors] - chore(Order/BooleanAlgebra): reduce risk of instance diamonds

### DIFF
--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -785,20 +785,22 @@ instance Pi.booleanAlgebra {ι : Type u} {α : ι → Type v} [∀ i, BooleanAlg
     top_le_sup_compl := fun _ _ => BooleanAlgebra.top_le_sup_compl _ }
 #align pi.boolean_algebra Pi.booleanAlgebra
 
-instance : BooleanAlgebra Bool :=
-  { Bool.linearOrder, Bool.boundedOrder, Bool.instDistribLattice with
-    compl := not,
-    inf_compl_le_bot := fun a => a.and_not_self.le,
-    top_le_sup_compl := fun a => a.or_not_self.ge }
+instance : BooleanAlgebra Bool where
+  __ := Bool.linearOrder
+  __ := Bool.boundedOrder
+  __ := Bool.instDistribLattice
+  -- the `(Bool.*_eq_* _ _)` terms can be dropped after std4#329 is integrated into mathlib
+  inf_compl_le_bot a := (Bool.min_eq_and _ _).trans_le <| a.and_not_self.le
+  top_le_sup_compl a := a.or_not_self.ge.trans_eq <| (Bool.max_eq_or _ _).symm
 
 @[simp]
 theorem Bool.sup_eq_bor : (· ⊔ ·) = or :=
-  rfl
+  funext₂ Bool.max_eq_or -- TODO: replace with `rfl` after std4#329 is integrated into mathlib
 #align bool.sup_eq_bor Bool.sup_eq_bor
 
 @[simp]
 theorem Bool.inf_eq_band : (· ⊓ ·) = and :=
-  rfl
+  funext₂ Bool.min_eq_and -- TODO: replace with `rfl` after std4#329 is integrated into mathlib
 #align bool.inf_eq_band Bool.inf_eq_band
 
 @[simp]

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -785,24 +785,22 @@ instance Pi.booleanAlgebra {ι : Type u} {α : ι → Type v} [∀ i, BooleanAlg
     top_le_sup_compl := fun _ _ => BooleanAlgebra.top_le_sup_compl _ }
 #align pi.boolean_algebra Pi.booleanAlgebra
 
-instance : BooleanAlgebra Bool where
+instance Bool.instBooleanAlgebra : BooleanAlgebra Bool where
   __ := Bool.linearOrder
   __ := Bool.boundedOrder
   __ := Bool.instDistribLattice
-  -- the `(Bool.*_eq_* _ _)` terms can be dropped after std4#329 is integrated into mathlib
-  inf_compl_le_bot a := (Bool.min_eq_and _ _).trans_le <| a.and_not_self.le
-  top_le_sup_compl a := a.or_not_self.ge.trans_eq <| (Bool.max_eq_or _ _).symm
+  compl := not
+  inf_compl_le_bot a := a.and_not_self.le
+  top_le_sup_compl a := a.or_not_self.ge
 
 @[simp]
-theorem Bool.sup_eq_bor : (· ⊔ ·) = or := by
-  fail_if_success rfl  -- TODO: replace with `rfl` after std4#329 is integrated into mathlib
-  exact funext₂ Bool.max_eq_or
+theorem Bool.sup_eq_bor : (· ⊔ ·) = or :=
+  rfl
 #align bool.sup_eq_bor Bool.sup_eq_bor
 
 @[simp]
-theorem Bool.inf_eq_band : (· ⊓ ·) = and := by
-  fail_if_success rfl  -- TODO: replace with `rfl` after std4#329 is integrated into mathlib
-  exact funext₂ Bool.min_eq_and
+theorem Bool.inf_eq_band : (· ⊓ ·) = and :=
+  rfl
 #align bool.inf_eq_band Bool.inf_eq_band
 
 @[simp]

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -794,13 +794,15 @@ instance : BooleanAlgebra Bool where
   top_le_sup_compl a := a.or_not_self.ge.trans_eq <| (Bool.max_eq_or _ _).symm
 
 @[simp]
-theorem Bool.sup_eq_bor : (· ⊔ ·) = or :=
-  funext₂ Bool.max_eq_or -- TODO: replace with `rfl` after std4#329 is integrated into mathlib
+theorem Bool.sup_eq_bor : (· ⊔ ·) = or := by
+  fail_if_success rfl  -- TODO: replace with `rfl` after std4#329 is integrated into mathlib
+  exact funext₂ Bool.max_eq_or
 #align bool.sup_eq_bor Bool.sup_eq_bor
 
 @[simp]
-theorem Bool.inf_eq_band : (· ⊓ ·) = and :=
-  funext₂ Bool.min_eq_and -- TODO: replace with `rfl` after std4#329 is integrated into mathlib
+theorem Bool.inf_eq_band : (· ⊓ ·) = and := by
+  fail_if_success rfl  -- TODO: replace with `rfl` after std4#329 is integrated into mathlib
+  exact funext₂ Bool.min_eq_and
 #align bool.inf_eq_band Bool.inf_eq_band
 
 @[simp]

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -787,11 +787,11 @@ instance Pi.booleanAlgebra {ι : Type u} {α : ι → Type v} [∀ i, BooleanAlg
 
 instance : BooleanAlgebra Bool :=
   { Bool.linearOrder, Bool.boundedOrder with
-    sup := or,
+    sup := max,
     le_sup_left := Bool.left_le_or,
     le_sup_right := Bool.right_le_or,
     sup_le := fun _ _ _ => Bool.or_le,
-    inf := and,
+    inf := min,
     inf_le_left := Bool.and_le_left,
     inf_le_right := Bool.and_le_right,
     le_inf := fun _ _ _ => Bool.le_and,

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -786,16 +786,7 @@ instance Pi.booleanAlgebra {ι : Type u} {α : ι → Type v} [∀ i, BooleanAlg
 #align pi.boolean_algebra Pi.booleanAlgebra
 
 instance : BooleanAlgebra Bool :=
-  { Bool.linearOrder, Bool.boundedOrder with
-    sup := max,
-    le_sup_left := Bool.left_le_or,
-    le_sup_right := Bool.right_le_or,
-    sup_le := fun _ _ _ => Bool.or_le,
-    inf := min,
-    inf_le_left := Bool.and_le_left,
-    inf_le_right := Bool.and_le_right,
-    le_inf := fun _ _ _ => Bool.le_and,
-    le_sup_inf := by decide,
+  { Bool.linearOrder, Bool.boundedOrder, Bool.instDistribLattice with
     compl := not,
     inf_compl_le_bot := fun a => a.and_not_self.le,
     top_le_sup_compl := fun a => a.or_not_self.ge }

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -1550,5 +1550,5 @@ instance [LinearOrder α] : LinearOrder (ULift.{v} α) :=
 end ULift
 
 --To avoid noncomputability poisoning from `Bool.completeBooleanAlgebra`
-instance : DistribLattice Bool :=
+instance Bool.instDistribLattice : DistribLattice Bool :=
   inferInstance


### PR DESCRIPTION
We need `sup` and `max` to be defeq, and `max` is defined in Std. To achieve this, we define one in terms of the other.

Until #8105 was merged (which fixed up leanprover/std4#183), they were not defeq:
```lean
example :
  (GeneralizedCoheytingAlgebra.toLattice : Lattice Bool).sup =
    DistribLattice.toLattice.sup :=
  rfl -- failed
```

This instance in this PR should have been written such that it couldn't silently cause a diamond in the first place, by reusing existing data rather than creating new data.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
