### PR TITLE
feat(Tactic): add `unify_denoms` and `collect_signs` tactics

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5396,6 +5396,7 @@ import Mathlib.Tactic.ClearExcept
 import Mathlib.Tactic.ClearExclamation
 import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Coe
+import Mathlib.Tactic.CollectSigns
 import Mathlib.Tactic.Common
 import Mathlib.Tactic.ComputeDegree
 import Mathlib.Tactic.CongrExclamation
@@ -5609,6 +5610,7 @@ import Mathlib.Tactic.Trace
 import Mathlib.Tactic.TryThis
 import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.TypeStar
+import Mathlib.Tactic.UnifyDenoms
 import Mathlib.Tactic.UnsetOption
 import Mathlib.Tactic.Use
 import Mathlib.Tactic.Variable

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -97,6 +97,9 @@ theorem mul_div_assoc (x : R) {y z : R} (h : z ∣ y) : x * y / z = x * (y / z) 
 protected theorem mul_div_cancel' {a b : R} (hb : b ≠ 0) (hab : b ∣ a) : b * (a / b) = a := by
   rw [← mul_div_assoc _ hab, mul_div_cancel_left₀ _ hb]
 
+lemma div_mul_assoc  {a b : R} (hba : b ∣ a) (c : R) : a / b * c = (a * c) / b := by
+  rw [mul_comm,← EuclideanDomain.mul_div_assoc _ hba, mul_comm]
+
 -- This generalizes `Int.div_one`, see note [simp-normal form]
 @[simp]
 theorem div_one (p : R) : p / 1 = p :=
@@ -397,6 +400,24 @@ theorem div_eq_div_iff_mul_eq_mul_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t �
   obtain ⟨a, ha⟩ := h4
   use y * a
   rw [ha, mul_comm, mul_assoc, mul_comm y a]
+
+lemma div_div' {a b c : R} (hcb : c ∣ b) (hbca : b / c ∣ a) : a / (b / c) = a * c / b := by
+  by_cases hb : b = 0
+  · simp [hb]
+  · obtain ⟨d, hd⟩ := hcb
+    rw [ div_eq_div_iff_mul_eq_mul_of_dvd _ hb hbca,div_mul_assoc,← mul_assoc,mul_comm _ c,
+    ← div_mul_assoc,div_self ,one_mul]
+    · intro hc
+      apply hb
+      rw [hd,hc,zero_mul]
+    · exact dvd_of_eq rfl
+    · use d
+    · obtain ⟨x, hx⟩ := hbca
+      rw [hd,hx]
+      use x
+      simp_all
+      rw [mul_rotate c d x]
+    simp_all
 
 end Div
 

--- a/Mathlib/Algebra/EuclideanDomain/Basic.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Basic.lean
@@ -97,8 +97,8 @@ theorem mul_div_assoc (x : R) {y z : R} (h : z ∣ y) : x * y / z = x * (y / z) 
 protected theorem mul_div_cancel' {a b : R} (hb : b ≠ 0) (hab : b ∣ a) : b * (a / b) = a := by
   rw [← mul_div_assoc _ hab, mul_div_cancel_left₀ _ hb]
 
-lemma div_mul_assoc  {a b : R} (hba : b ∣ a) (c : R) : a / b * c = (a * c) / b := by
-  rw [mul_comm,← EuclideanDomain.mul_div_assoc _ hba, mul_comm]
+lemma div_mul_assoc {a b : R} (hba : b ∣ a) (c : R) : a / b * c = (a * c) / b := by
+  rw [mul_comm, ← mul_div_assoc _ hba, mul_comm]
 
 -- This generalizes `Int.div_one`, see note [simp-normal form]
 @[simp]
@@ -402,22 +402,15 @@ theorem div_eq_div_iff_mul_eq_mul_of_dvd {x y z t : R} (h1 : y ≠ 0) (h2 : t �
   rw [ha, mul_comm, mul_assoc, mul_comm y a]
 
 lemma div_div' {a b c : R} (hcb : c ∣ b) (hbca : b / c ∣ a) : a / (b / c) = a * c / b := by
-  by_cases hb : b = 0
-  · simp [hb]
-  · obtain ⟨d, hd⟩ := hcb
-    rw [ div_eq_div_iff_mul_eq_mul_of_dvd _ hb hbca,div_mul_assoc,← mul_assoc,mul_comm _ c,
-    ← div_mul_assoc,div_self ,one_mul]
-    · intro hc
-      apply hb
-      rw [hd,hc,zero_mul]
-    · exact dvd_of_eq rfl
-    · use d
-    · obtain ⟨x, hx⟩ := hbca
-      rw [hd,hx]
-      use x
-      simp_all
-      rw [mul_rotate c d x]
-    simp_all
+  obtain rfl | hc := eq_or_ne c 0
+  · simp
+  obtain ⟨d, rfl⟩ := hcb
+  rw [mul_div_cancel_left₀ _ hc] at *
+  obtain rfl | hd := eq_or_ne d 0
+  · simp
+  obtain ⟨e, rfl⟩ := hbca
+  rw [mul_div_cancel_left₀ _ hd, ← mul_rotate, mul_div_cancel_left₀]
+  rwa [mul_ne_zero_iff_right hd]
 
 end Div
 

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -267,8 +267,8 @@ import Mathlib.Tactic.TryThis
 import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.TypeStar
 import Mathlib.Tactic.UnsetOption
-import Mathlib.Tactic.Use
 import Mathlib.Tactic.UnifyDenoms
+import Mathlib.Tactic.Use
 import Mathlib.Tactic.Variable
 import Mathlib.Tactic.WLOG
 import Mathlib.Tactic.Widget.Calc

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -52,6 +52,7 @@ import Mathlib.Tactic.ClearExcept
 import Mathlib.Tactic.ClearExclamation
 import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Coe
+import Mathlib.Tactic.CollectSigns
 import Mathlib.Tactic.Common
 import Mathlib.Tactic.ComputeDegree
 import Mathlib.Tactic.CongrExclamation

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -267,6 +267,7 @@ import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.TypeStar
 import Mathlib.Tactic.UnsetOption
 import Mathlib.Tactic.Use
+import Mathlib.Tactic.UnifyDenoms
 import Mathlib.Tactic.Variable
 import Mathlib.Tactic.WLOG
 import Mathlib.Tactic.Widget.Calc

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -266,8 +266,8 @@ import Mathlib.Tactic.Trace
 import Mathlib.Tactic.TryThis
 import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.TypeStar
-import Mathlib.Tactic.UnsetOption
 import Mathlib.Tactic.UnifyDenoms
+import Mathlib.Tactic.UnsetOption
 import Mathlib.Tactic.Use
 import Mathlib.Tactic.Variable
 import Mathlib.Tactic.WLOG

--- a/Mathlib/Tactic/CollectSigns.lean
+++ b/Mathlib/Tactic/CollectSigns.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2023 Miguel Marco. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Miguel Marco
+-/
+import Init.Data.Nat.Basic
+import Mathlib.Algebra.Group.Basic
+import Mathlib.Algebra.Field.Basic
+import Mathlib.Algebra.GroupWithZero.Units.Lemmas
+import Mathlib.Algebra.Order.Field.Basic
+import Mathlib.Algebra.Order.Sub.Defs
+import Mathlib.Tactic.FieldSimp
+
+open Lean Meta Elab Tactic Parser Tactic
+
+/-!
+# `collect_signs` and `collect_signs!` tactics.
+
+The `collect_signs` tactic rewrites expression combining additions and substractions into
+an expression with only additions minus annother expression with only additions.
+
+
+The `collect_signs!` tactic extends `collect_signs`, trying to cancel additions and
+substractions of naturals, adding the necessary inequalities as new goals.
+-/
+
+/-
+These lemmas are used as rewriting rules later
+-/
+lemma add_sub_add_cancel (G : Type) [AddCommGroup G] (x y z : G) : (x + y) - (z + x) = y - z := by
+  rw [add_comm x y,add_sub_add_right_eq_sub]
+
+lemma add_sub_add_cancel' (G : Type) [AddCommGroup G] (x y z : G) : (y + x) - (x + z) = y - z := by
+  rw [add_comm x z,add_sub_add_right_eq_sub]
+
+/--
+The `collect_signs` tactic rewrites expression combining additions and substractions into
+an expression with only additions minus annother expression with only additions.
+--/
+syntax (name := collect_signs) "collect_signs" (location)?: tactic
+
+/-These rules either reduce the number of minus signs, fix it but push
+a minus sign closer to the root of the expression tree, or fix
+the minus signs but reduce the number of terms in the expression.-/
+macro_rules
+| `(tactic | collect_signs $[at $location]?) => `(tactic |(
+  repeat (first
+  | (rw [sub_self]                    $[at $location]?) -- x - x = 0
+  | (rw [Nat.sub_self]                $[at $location]?) -- n - n = 0 (ℕ)
+  | (rw [add_zero]                    $[at $location]?) -- x + 0 = x
+  | (rw [zero_add]                    $[at $location]?) -- 0 + x = x
+  | (rw [sub_zero]                    $[at $location]?) -- x - 0 = x
+  | (rw [Nat.sub_zero]                $[at $location]?) -- n - 0 = n (ℕ)
+  | (rw [zero_sub]                    $[at $location]?) -- 0 - x = - x
+  | (rw [add_tsub_cancel_right]       $[at $location]?) -- x + y - y = x
+  | (rw [add_tsub_cancel_left]        $[at $location]?) -- x + y - x = y
+  | (rw [add_sub_add_left_eq_sub]     $[at $location]?) -- z + x - (z + y) = x - y
+  | (rw [add_sub_add_right_eq_sub]    $[at $location]?) -- x + z - (y + z) = x - y
+  | (rw [add_sub_add_cancel]          $[at $location]?) -- x + y - (z + x) = y - z
+  | (rw [add_sub_add_cancel']         $[at $location]?) -- y + x - (x + z) = y - x
+  | (rw [sub_sub]                     $[at $location]?) -- x - y - z = x - (y + z)
+  | (rw [Nat.sub_sub]                 $[at $location]?) -- n - m - k = n - (m + k) (ℕ)
+  | (rw [sub_sub_eq_add_sub]          $[at $location]?) -- x - (y - z) = x + z - y
+  | (rw [sub_add, sub_sub_eq_add_sub] $[at $location]?) -- (x - y) + z = x + z - y
+  | (rw [add_sub]                     $[at $location]?) -- x + (y - z) = x + y - z
+  | (rw [sub_neg_eq_add]              $[at $location]?) -- x - -y = x + y
+  | (rw [← sub_eq_add_neg]            $[at $location]?) -- x + -y = x - y
+  | (rw [neg_add_eq_sub]              $[at $location]?) -- -x + y = x - y
+  | (rw [← add_assoc]                 $[at $location]?)))) -- x + (y + z) = x + y + z
+
+/-These two lemmas are also used as rewriting rules later.-/
+lemma Nat.sub_sub_of_le (m n k : ℕ) (h : k ≤ n) : m - (n - k) = m + k - n := by
+  have haux := Nat.le.dest h
+  cases haux with
+  | intro d hd =>
+    . rw [← hd, add_comm m k, add_tsub_cancel_left,Nat.add_sub_add_left]
+
+lemma Nat.add_sub_comm_of_le (m n k : ℕ) (h : k ≤ n) : m + (n - k) = (m + n) - k := by
+  have haux := Nat.le.dest h
+  cases haux with
+  | intro d hd =>
+    . rw [← hd, add_comm k d,←  add_assoc, add_tsub_cancel_right, add_tsub_cancel_right]
+
+/--
+The `collect_signs!` tactic extends `collect_signs`, trying to cancel additions and
+substractions of naturals, adding the necessary inequalities as new goals.
+--/
+syntax (name := collect_signs!) "collect_signs!" (location)?: tactic
+
+-- These rules either reduce the number of minus signs, fix it but push
+-- a minus sign closer to the root of the expression tree, or fix
+-- the minus signs but reduce the number of terms in the expression.
+macro_rules
+| `(tactic | collect_signs! $[at $location]?) => `(tactic |(
+  repeat (first
+  | (rw [sub_self]                    $[at $location]?) -- x - x = 0
+  | (rw [Nat.sub_self]                $[at $location]?) -- n - n = 0 (ℕ)
+  | (rw [add_zero]                    $[at $location]?) -- x + 0 = x
+  | (rw [zero_add]                    $[at $location]?) -- 0 + x = x
+  | (rw [sub_zero]                    $[at $location]?) -- x - 0 = x
+  | (rw [Nat.sub_zero]                $[at $location]?) -- n - 0 = n (ℕ)
+  | (rw [zero_sub]                    $[at $location]?) -- 0 - x = - x
+  | (rw [add_tsub_cancel_right]       $[at $location]?) -- x + y - y = x
+  | (rw [add_tsub_cancel_left]        $[at $location]?) -- x + y - x = y
+  | (rw [Nat.add_sub_of_le]           $[at $location]?) -- n + (m - n) = m (ℕ)
+  | (rw [Nat.sub_sub_self]            $[at $location]?) -- n - (n - m) = m (ℕ)
+  | (rw [Nat.sub_sub_of_le]           $[at $location]?) -- m - (n - k) = m + k - n (ℕ)
+  | (rw [Nat.add_sub_of_le]           $[at $location]?) -- m + k - (n + k) = m - n (ℕ)
+  | (rw [add_sub_add_left_eq_sub]     $[at $location]?) -- z + x - (y + z) = x - y
+  | (rw [add_sub_add_right_eq_sub]    $[at $location]?) -- x + z - (y + z) = x - y
+  | (rw [add_sub_add_cancel]          $[at $location]?) -- x + y - (z + x) = y - z
+  | (rw [add_sub_add_cancel']         $[at $location]?) -- y + x - (x + z) = y - z
+  | (rw [sub_sub]                     $[at $location]?) -- x - y - z = x - (y + z)
+  | (rw [Nat.sub_sub]                 $[at $location]?) -- n - m - k = n - (m + k) (ℕ)
+  | (rw [sub_sub_eq_add_sub]          $[at $location]?) -- x - (y - z) = x + z - y
+  | (rw [sub_add, sub_sub_eq_add_sub] $[at $location]?) -- (x - y) + z = x + z - y
+  | (rw [← Nat.sub_add_comm]          $[at $location]?) -- (n - k) + m = (n + m) - k (ℕ)
+  | (rw [Nat.add_sub_comm_of_le]      $[at $location]?) -- m + (n - k) = m + n - k (ℕ)
+  | (rw [add_sub]                     $[at $location]?) -- x + (y - z) = x + y - z
+  | (rw [sub_neg_eq_add]              $[at $location]?) -- x - -y = x + y
+  | (rw [← sub_eq_add_neg]            $[at $location]?) -- x + -y = x - y
+  | (rw [neg_add_eq_sub]              $[at $location]?) -- -x + y = y - x
+  | (rw [← add_assoc]                 $[at $location]?)))) -- x + (y + z) = x + y + z

--- a/Mathlib/Tactic/CollectSigns.lean
+++ b/Mathlib/Tactic/CollectSigns.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Miguel Marco. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Miguel Marco
+Authors: Miguel Marco
 -/
 import Init.Data.Nat.Basic
 import Mathlib.Algebra.Group.Basic
@@ -10,8 +10,6 @@ import Mathlib.Algebra.GroupWithZero.Units.Lemmas
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Order.Sub.Defs
 import Mathlib.Tactic.FieldSimp
-
-open Lean Meta Elab Tactic Parser Tactic
 
 /-!
 # `collect_signs` and `collect_signs!` tactics.
@@ -23,6 +21,8 @@ an expression with only additions minus annother expression with only additions.
 The `collect_signs!` tactic extends `collect_signs`, trying to cancel additions and
 substractions of naturals, adding the necessary inequalities as new goals.
 -/
+
+open Lean Meta Elab Tactic Parser Tactic
 
 /--
 The `collect_signs` tactic rewrites expression combining additions and substractions into

--- a/Mathlib/Tactic/CollectSigns.lean
+++ b/Mathlib/Tactic/CollectSigns.lean
@@ -64,7 +64,7 @@ lemma Nat.sub_sub_of_le (m n k : ℕ) (h : k ≤ n) : m - (n - k) = m + k - n :=
   have haux := Nat.le.dest h
   cases haux with
   | intro d hd =>
-    . rw [←hd,add_comm m k,add_tsub_cancel_left,Nat.add_sub_add_left]
+    · rw [←hd,add_comm m k,add_tsub_cancel_left,Nat.add_sub_add_left]
 
 lemma Nat.add_sub_comm_of_le (m n k : ℕ) (h : k ≤ n) : m + (n - k) = (m + n) - k := by
   have haux := Nat.le.dest h

--- a/Mathlib/Tactic/CollectSigns.lean
+++ b/Mathlib/Tactic/CollectSigns.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Field.Basic
 import Mathlib.Algebra.GroupWithZero.Units.Lemmas
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Order.Sub.Defs
+import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Tactic.FieldSimp
 
 /-!
@@ -57,7 +58,8 @@ macro_rules
   | (rw [sub_neg_eq_add]              $[at $location]?) -- x - -y = x + y
   | (rw [← sub_eq_add_neg]            $[at $location]?) -- x + -y = x - y
   | (rw [neg_add_eq_sub]              $[at $location]?) -- -x + y = x - y
-  | (rw [← add_assoc]                 $[at $location]?)))) -- x + (y + z) = x + y + z
+  | (rw [← add_assoc]                 $[at $location]?)) -- x + (y + z) = x + y + z
+  try (any_goals assumption) ))
 
 /-These two lemmas are also used as rewriting rules later.-/
 lemma Nat.sub_sub_of_le (m n k : ℕ) (h : k ≤ n) : m - (n - k) = m + k - n := by
@@ -111,4 +113,43 @@ macro_rules
   | (rw [sub_neg_eq_add]              $[at $location]?) -- x - -y = x + y
   | (rw [← sub_eq_add_neg]            $[at $location]?) -- x + -y = x - y
   | (rw [neg_add_eq_sub]              $[at $location]?) -- -x + y = y - x
-  | (rw [← add_assoc]                 $[at $location]?)))) -- x + (y + z) = x + y + z
+  | (rw [← add_assoc]                 $[at $location]?) -- x + (y + z) = x + y + z
+  | (rw [add_le_add_iff_left]         $[at $location]?) -- a + b ≤ a + c ↔ b ≤ c
+  | (rw [add_lt_add_iff_left]         $[at $location]?) -- a + b < a + c ↔ b < c
+  | (rw [add_le_add_iff_right]        $[at $location]?) -- b + a ≤ c + a ↔ b ≤ c
+  | (rw [add_lt_add_iff_right]        $[at $location]?) -- b + a < c + a ↔ b < c
+  | (rw [sub_le_sub_iff_left]         $[at $location]?) -- a - b ≤ a - c ↔ c ≤ b
+  | (rw [sub_lt_sub_iff_left]         $[at $location]?) -- a - b < a - c ↔ c < b
+  | (rw [sub_le_sub_iff_right]        $[at $location]?) -- a - c ≤ b - c ↔ a ≤ b
+  | (rw [sub_lt_sub_iff_right]        $[at $location]?) -- a - c < b - c ↔ a < b
+  | (rw [Nat.add_le_add_iff_left]     $[at $location]?) -- a + b ≤ a + c ↔ b ≤ c
+  | (rw [Nat.add_lt_add_iff_left]     $[at $location]?) -- a + b < a + c ↔ b < c
+  | (rw [Nat.add_le_add_iff_right]    $[at $location]?) -- b + a ≤ c + a ↔ b ≤ c
+  | (rw [Nat.add_lt_add_iff_right]    $[at $location]?) -- b + a < c + a ↔ b < c
+  | (rw [Nat.sub_le_sub_iff_left]     $[at $location]?) -- a - b ≤ a - c ↔ c ≤ b
+  | (rw [Nat.sub_lt_sub_iff_left]     $[at $location]?) -- a - b < a - c ↔ c < b
+  | (rw [Nat.sub_le_sub_iff_right]    $[at $location]?) -- a - c ≤ b - c ↔ a ≤ b
+  | (rw [Nat.sub_lt_sub_iff_right]    $[at $location]?) -- a - c < b - c ↔ a < b
+  | (simp only [add_assoc,add_le_add_iff_left]         $[at $location]?) -- a + b ≤ a + c ↔ b ≤ c
+  | (simp only [add_assoc,add_lt_add_iff_left]         $[at $location]?) -- a + b < a + c ↔ b < c
+  | (simp only [add_assoc,add_le_add_iff_right]        $[at $location]?) -- b + a ≤ c + a ↔ b ≤ c
+  | (simp only [add_assoc,add_lt_add_iff_right]        $[at $location]?) -- b + a < c + a ↔ b < c
+  | (simp only [add_assoc,sub_le_sub_iff_left]         $[at $location]?) -- a - b ≤ a - c ↔ c ≤ b
+  | (simp only [add_assoc,sub_lt_sub_iff_left]         $[at $location]?) -- a - b < a - c ↔ c < b
+  | (simp only [add_assoc,sub_le_sub_iff_right]        $[at $location]?) -- a - c ≤ b - c ↔ a ≤ b
+  | (simp only [add_assoc,sub_lt_sub_iff_right]        $[at $location]?) -- a - c < b - c ↔ a < b
+  | (simp only [add_assoc,Nat.add_le_add_iff_left]     $[at $location]?) -- a + b ≤ a + c ↔ b ≤ c
+  | (simp only [add_assoc,Nat.add_lt_add_iff_left]     $[at $location]?) -- a + b < a + c ↔ b < c
+  | (simp only [add_assoc,Nat.add_le_add_iff_right]    $[at $location]?) -- b + a ≤ c + a ↔ b ≤ c
+  | (simp only [add_assoc,Nat.add_lt_add_iff_right]    $[at $location]?) -- b + a < c + a ↔ b < c
+  | (simp only [add_assoc,Nat.sub_le_sub_iff_left]     $[at $location]?) -- a - b ≤ a - c ↔ c ≤ b
+  | (simp only [add_assoc,Nat.sub_lt_sub_iff_left]     $[at $location]?) -- a - b < a - c ↔ c < b
+  | (simp only [add_assoc,Nat.sub_le_sub_iff_right]    $[at $location]?) -- a - c ≤ b - c ↔ a ≤ b
+  | (simp only [add_assoc,Nat.sub_lt_sub_iff_right]    $[at $location]?) -- a - c < b - c ↔ a < b
+  | (rw [sub_le_iff_le_add]         $[at $location]?) --  a - c ≤ b ↔ a ≤ b + c
+  | (rw [sub_lt_iff_lt_add]         $[at $location]?) --  a - c < b ↔ a < b + c
+  | (rw [le_sub_iff_add_le]         $[at $location]?) -- a ≤ c - b ↔ a + b ≤ c
+  | (rw [lt_sub_iff_add_lt]         $[at $location]?) -- a < c - b ↔ a + b < c
+  | (rw [Nat.sub_le_iff_le_add]         $[at $location]?) -- a - b ≤ c ↔ a ≤ c + b
+  | (rw [Nat.le_sub_iff_add_le]         $[at $location]?) ) -- x ≤ y - k ↔ x + k ≤ y
+  try (any_goals assumption)))

--- a/Mathlib/Tactic/CollectSigns.lean
+++ b/Mathlib/Tactic/CollectSigns.lean
@@ -24,15 +24,6 @@ The `collect_signs!` tactic extends `collect_signs`, trying to cancel additions 
 substractions of naturals, adding the necessary inequalities as new goals.
 -/
 
-/-
-These lemmas are used as rewriting rules later
--/
-lemma add_sub_add_cancel (G : Type) [AddCommGroup G] (x y z : G) : (x + y) - (z + x) = y - z := by
-  rw [add_comm x y,add_sub_add_right_eq_sub]
-
-lemma add_sub_add_cancel' (G : Type) [AddCommGroup G] (x y z : G) : (y + x) - (x + z) = y - z := by
-  rw [add_comm x z,add_sub_add_right_eq_sub]
-
 /--
 The `collect_signs` tactic rewrites expression combining additions and substractions into
 an expression with only additions minus annother expression with only additions.
@@ -73,13 +64,13 @@ lemma Nat.sub_sub_of_le (m n k : ℕ) (h : k ≤ n) : m - (n - k) = m + k - n :=
   have haux := Nat.le.dest h
   cases haux with
   | intro d hd =>
-    . rw [← hd, add_comm m k, add_tsub_cancel_left,Nat.add_sub_add_left]
+    . rw [←hd,add_comm m k,add_tsub_cancel_left,Nat.add_sub_add_left]
 
 lemma Nat.add_sub_comm_of_le (m n k : ℕ) (h : k ≤ n) : m + (n - k) = (m + n) - k := by
   have haux := Nat.le.dest h
   cases haux with
   | intro d hd =>
-    . rw [← hd, add_comm k d,←  add_assoc, add_tsub_cancel_right, add_tsub_cancel_right]
+    . rw [← hd,add_comm k d,←add_assoc,add_tsub_cancel_right,add_tsub_cancel_right]
 
 /--
 The `collect_signs!` tactic extends `collect_signs`, trying to cancel additions and

--- a/Mathlib/Tactic/CollectSigns.lean
+++ b/Mathlib/Tactic/CollectSigns.lean
@@ -70,7 +70,7 @@ lemma Nat.add_sub_comm_of_le (m n k : ℕ) (h : k ≤ n) : m + (n - k) = (m + n)
   have haux := Nat.le.dest h
   cases haux with
   | intro d hd =>
-    . rw [← hd,add_comm k d,←add_assoc,add_tsub_cancel_right,add_tsub_cancel_right]
+    · rw [← hd,add_comm k d,←add_assoc,add_tsub_cancel_right,add_tsub_cancel_right]
 
 /--
 The `collect_signs!` tactic extends `collect_signs`, trying to cancel additions and

--- a/Mathlib/Tactic/CollectSigns.lean
+++ b/Mathlib/Tactic/CollectSigns.lean
@@ -63,16 +63,10 @@ macro_rules
 
 /-These two lemmas are also used as rewriting rules later.-/
 lemma Nat.sub_sub_of_le (m n k : ℕ) (h : k ≤ n) : m - (n - k) = m + k - n := by
-  have haux := Nat.le.dest h
-  cases haux with
-  | intro d hd =>
-    · rw [←hd,add_comm m k,add_tsub_cancel_left,Nat.add_sub_add_left]
+  omega
 
 lemma Nat.add_sub_comm_of_le (m n k : ℕ) (h : k ≤ n) : m + (n - k) = (m + n) - k := by
-  have haux := Nat.le.dest h
-  cases haux with
-  | intro d hd =>
-    · rw [← hd,add_comm k d,←add_assoc,add_tsub_cancel_right,add_tsub_cancel_right]
+  omega
 
 /--
 The `collect_signs!` tactic extends `collect_signs`, trying to cancel additions and

--- a/Mathlib/Tactic/CollectSigns.lean
+++ b/Mathlib/Tactic/CollectSigns.lean
@@ -37,27 +37,27 @@ the minus signs but reduce the number of terms in the expression.-/
 macro_rules
 | `(tactic | collect_signs $[at $location]?) => `(tactic |(
   repeat (first
-  | (rw [sub_self]                    $[at $location]?) -- x - x = 0
-  | (rw [Nat.sub_self]                $[at $location]?) -- n - n = 0 (ℕ)
-  | (rw [add_zero]                    $[at $location]?) -- x + 0 = x
-  | (rw [zero_add]                    $[at $location]?) -- 0 + x = x
-  | (rw [sub_zero]                    $[at $location]?) -- x - 0 = x
-  | (rw [Nat.sub_zero]                $[at $location]?) -- n - 0 = n (ℕ)
-  | (rw [zero_sub]                    $[at $location]?) -- 0 - x = - x
-  | (rw [add_tsub_cancel_right]       $[at $location]?) -- x + y - y = x
-  | (rw [add_tsub_cancel_left]        $[at $location]?) -- x + y - x = y
-  | (rw [add_sub_add_left_eq_sub]     $[at $location]?) -- z + x - (z + y) = x - y
-  | (rw [add_sub_add_right_eq_sub]    $[at $location]?) -- x + z - (y + z) = x - y
-  | (rw [add_sub_add_cancel]          $[at $location]?) -- x + y - (z + x) = y - z
-  | (rw [add_sub_add_cancel']         $[at $location]?) -- y + x - (x + z) = y - x
-  | (rw [sub_sub]                     $[at $location]?) -- x - y - z = x - (y + z)
-  | (rw [Nat.sub_sub]                 $[at $location]?) -- n - m - k = n - (m + k) (ℕ)
-  | (rw [sub_sub_eq_add_sub]          $[at $location]?) -- x - (y - z) = x + z - y
+  | (rw [sub_self] $[at $location]?) -- x - x = 0
+  | (rw [Nat.sub_self] $[at $location]?) -- n - n = 0 (ℕ)
+  | (rw [add_zero] $[at $location]?) -- x + 0 = x
+  | (rw [zero_add] $[at $location]?) -- 0 + x = x
+  | (rw [sub_zero] $[at $location]?) -- x - 0 = x
+  | (rw [Nat.sub_zero] $[at $location]?) -- n - 0 = n (ℕ)
+  | (rw [zero_sub] $[at $location]?) -- 0 - x = - x
+  | (rw [add_tsub_cancel_right] $[at $location]?) -- x + y - y = x
+  | (rw [add_tsub_cancel_left] $[at $location]?) -- x + y - x = y
+  | (rw [add_sub_add_left_eq_sub] $[at $location]?) -- z + x - (z + y) = x - y
+  | (rw [add_sub_add_right_eq_sub] $[at $location]?) -- x + z - (y + z) = x - y
+  | (rw [add_sub_add_cancel] $[at $location]?) -- x + y - (z + x) = y - z
+  | (rw [add_sub_add_cancel'] $[at $location]?) -- y + x - (x + z) = y - x
+  | (rw [sub_sub] $[at $location]?) -- x - y - z = x - (y + z)
+  | (rw [Nat.sub_sub] $[at $location]?) -- n - m - k = n - (m + k) (ℕ)
+  | (rw [sub_sub_eq_add_sub] $[at $location]?) -- x - (y - z) = x + z - y
   | (rw [sub_add, sub_sub_eq_add_sub] $[at $location]?) -- (x - y) + z = x + z - y
-  | (rw [add_sub]                     $[at $location]?) -- x + (y - z) = x + y - z
-  | (rw [sub_neg_eq_add]              $[at $location]?) -- x - -y = x + y
-  | (rw [← sub_eq_add_neg]            $[at $location]?) -- x + -y = x - y
-  | (rw [neg_add_eq_sub]              $[at $location]?) -- -x + y = x - y
+  | (rw [add_sub] $[at $location]?) -- x + (y - z) = x + y - z
+  | (rw [sub_neg_eq_add] $[at $location]?) -- x - -y = x + y
+  | (rw [← sub_eq_add_neg] $[at $location]?) -- x + -y = x - y
+  | (rw [neg_add_eq_sub] $[at $location]?) -- -x + y = x - y
   | (rw [← add_assoc]                 $[at $location]?)) -- x + (y + z) = x + y + z
   try (any_goals assumption) ))
 
@@ -80,70 +80,70 @@ syntax (name := collect_signs!) "collect_signs!" (location)?: tactic
 macro_rules
 | `(tactic | collect_signs! $[at $location]?) => `(tactic |(
   repeat (first
-  | (rw [sub_self]                    $[at $location]?) -- x - x = 0
-  | (rw [Nat.sub_self]                $[at $location]?) -- n - n = 0 (ℕ)
-  | (rw [add_zero]                    $[at $location]?) -- x + 0 = x
-  | (rw [zero_add]                    $[at $location]?) -- 0 + x = x
-  | (rw [sub_zero]                    $[at $location]?) -- x - 0 = x
-  | (rw [Nat.sub_zero]                $[at $location]?) -- n - 0 = n (ℕ)
-  | (rw [zero_sub]                    $[at $location]?) -- 0 - x = - x
-  | (rw [add_tsub_cancel_right]       $[at $location]?) -- x + y - y = x
-  | (rw [add_tsub_cancel_left]        $[at $location]?) -- x + y - x = y
-  | (rw [Nat.add_sub_of_le]           $[at $location]?) -- n + (m - n) = m (ℕ)
-  | (rw [Nat.sub_sub_self]            $[at $location]?) -- n - (n - m) = m (ℕ)
-  | (rw [Nat.sub_sub_of_le]           $[at $location]?) -- m - (n - k) = m + k - n (ℕ)
-  | (rw [Nat.add_sub_of_le]           $[at $location]?) -- m + k - (n + k) = m - n (ℕ)
-  | (rw [add_sub_add_left_eq_sub]     $[at $location]?) -- z + x - (y + z) = x - y
-  | (rw [add_sub_add_right_eq_sub]    $[at $location]?) -- x + z - (y + z) = x - y
-  | (rw [add_sub_add_cancel]          $[at $location]?) -- x + y - (z + x) = y - z
-  | (rw [add_sub_add_cancel']         $[at $location]?) -- y + x - (x + z) = y - z
-  | (rw [sub_sub]                     $[at $location]?) -- x - y - z = x - (y + z)
-  | (rw [Nat.sub_sub]                 $[at $location]?) -- n - m - k = n - (m + k) (ℕ)
-  | (rw [sub_sub_eq_add_sub]          $[at $location]?) -- x - (y - z) = x + z - y
+  | (rw [sub_self] $[at $location]?) -- x - x = 0
+  | (rw [Nat.sub_self] $[at $location]?) -- n - n = 0 (ℕ)
+  | (rw [add_zero] $[at $location]?) -- x + 0 = x
+  | (rw [zero_add] $[at $location]?) -- 0 + x = x
+  | (rw [sub_zero] $[at $location]?) -- x - 0 = x
+  | (rw [Nat.sub_zero] $[at $location]?) -- n - 0 = n (ℕ)
+  | (rw [zero_sub] $[at $location]?) -- 0 - x = - x
+  | (rw [add_tsub_cancel_right] $[at $location]?) -- x + y - y = x
+  | (rw [add_tsub_cancel_left] $[at $location]?) -- x + y - x = y
+  | (rw [Nat.add_sub_of_le] $[at $location]?) -- n + (m - n) = m (ℕ)
+  | (rw [Nat.sub_sub_self] $[at $location]?) -- n - (n - m) = m (ℕ)
+  | (rw [Nat.sub_sub_of_le] $[at $location]?) -- m - (n - k) = m + k - n (ℕ)
+  | (rw [Nat.add_sub_of_le] $[at $location]?) -- m + k - (n + k) = m - n (ℕ)
+  | (rw [add_sub_add_left_eq_sub] $[at $location]?) -- z + x - (y + z) = x - y
+  | (rw [add_sub_add_right_eq_sub] $[at $location]?) -- x + z - (y + z) = x - y
+  | (rw [add_sub_add_cancel] $[at $location]?) -- x + y - (z + x) = y - z
+  | (rw [add_sub_add_cancel'] $[at $location]?) -- y + x - (x + z) = y - z
+  | (rw [sub_sub] $[at $location]?) -- x - y - z = x - (y + z)
+  | (rw [Nat.sub_sub] $[at $location]?) -- n - m - k = n - (m + k) (ℕ)
+  | (rw [sub_sub_eq_add_sub] $[at $location]?) -- x - (y - z) = x + z - y
   | (rw [sub_add, sub_sub_eq_add_sub] $[at $location]?) -- (x - y) + z = x + z - y
-  | (rw [← Nat.sub_add_comm]          $[at $location]?) -- (n - k) + m = (n + m) - k (ℕ)
-  | (rw [Nat.add_sub_comm_of_le]      $[at $location]?) -- m + (n - k) = m + n - k (ℕ)
-  | (rw [add_sub]                     $[at $location]?) -- x + (y - z) = x + y - z
-  | (rw [sub_neg_eq_add]              $[at $location]?) -- x - -y = x + y
-  | (rw [← sub_eq_add_neg]            $[at $location]?) -- x + -y = x - y
-  | (rw [neg_add_eq_sub]              $[at $location]?) -- -x + y = y - x
-  | (rw [← add_assoc]                 $[at $location]?) -- x + (y + z) = x + y + z
-  | (rw [add_le_add_iff_left]         $[at $location]?) -- a + b ≤ a + c ↔ b ≤ c
-  | (rw [add_lt_add_iff_left]         $[at $location]?) -- a + b < a + c ↔ b < c
-  | (rw [add_le_add_iff_right]        $[at $location]?) -- b + a ≤ c + a ↔ b ≤ c
-  | (rw [add_lt_add_iff_right]        $[at $location]?) -- b + a < c + a ↔ b < c
-  | (rw [sub_le_sub_iff_left]         $[at $location]?) -- a - b ≤ a - c ↔ c ≤ b
-  | (rw [sub_lt_sub_iff_left]         $[at $location]?) -- a - b < a - c ↔ c < b
-  | (rw [sub_le_sub_iff_right]        $[at $location]?) -- a - c ≤ b - c ↔ a ≤ b
-  | (rw [sub_lt_sub_iff_right]        $[at $location]?) -- a - c < b - c ↔ a < b
-  | (rw [Nat.add_le_add_iff_left]     $[at $location]?) -- a + b ≤ a + c ↔ b ≤ c
-  | (rw [Nat.add_lt_add_iff_left]     $[at $location]?) -- a + b < a + c ↔ b < c
-  | (rw [Nat.add_le_add_iff_right]    $[at $location]?) -- b + a ≤ c + a ↔ b ≤ c
-  | (rw [Nat.add_lt_add_iff_right]    $[at $location]?) -- b + a < c + a ↔ b < c
-  | (rw [Nat.sub_le_sub_iff_left]     $[at $location]?) -- a - b ≤ a - c ↔ c ≤ b
-  | (rw [Nat.sub_lt_sub_iff_left]     $[at $location]?) -- a - b < a - c ↔ c < b
-  | (rw [Nat.sub_le_sub_iff_right]    $[at $location]?) -- a - c ≤ b - c ↔ a ≤ b
-  | (rw [Nat.sub_lt_sub_iff_right]    $[at $location]?) -- a - c < b - c ↔ a < b
-  | (simp only [add_assoc,add_le_add_iff_left]         $[at $location]?) -- a + b ≤ a + c ↔ b ≤ c
-  | (simp only [add_assoc,add_lt_add_iff_left]         $[at $location]?) -- a + b < a + c ↔ b < c
-  | (simp only [add_assoc,add_le_add_iff_right]        $[at $location]?) -- b + a ≤ c + a ↔ b ≤ c
-  | (simp only [add_assoc,add_lt_add_iff_right]        $[at $location]?) -- b + a < c + a ↔ b < c
-  | (simp only [add_assoc,sub_le_sub_iff_left]         $[at $location]?) -- a - b ≤ a - c ↔ c ≤ b
-  | (simp only [add_assoc,sub_lt_sub_iff_left]         $[at $location]?) -- a - b < a - c ↔ c < b
-  | (simp only [add_assoc,sub_le_sub_iff_right]        $[at $location]?) -- a - c ≤ b - c ↔ a ≤ b
-  | (simp only [add_assoc,sub_lt_sub_iff_right]        $[at $location]?) -- a - c < b - c ↔ a < b
-  | (simp only [add_assoc,Nat.add_le_add_iff_left]     $[at $location]?) -- a + b ≤ a + c ↔ b ≤ c
-  | (simp only [add_assoc,Nat.add_lt_add_iff_left]     $[at $location]?) -- a + b < a + c ↔ b < c
-  | (simp only [add_assoc,Nat.add_le_add_iff_right]    $[at $location]?) -- b + a ≤ c + a ↔ b ≤ c
-  | (simp only [add_assoc,Nat.add_lt_add_iff_right]    $[at $location]?) -- b + a < c + a ↔ b < c
-  | (simp only [add_assoc,Nat.sub_le_sub_iff_left]     $[at $location]?) -- a - b ≤ a - c ↔ c ≤ b
-  | (simp only [add_assoc,Nat.sub_lt_sub_iff_left]     $[at $location]?) -- a - b < a - c ↔ c < b
-  | (simp only [add_assoc,Nat.sub_le_sub_iff_right]    $[at $location]?) -- a - c ≤ b - c ↔ a ≤ b
-  | (simp only [add_assoc,Nat.sub_lt_sub_iff_right]    $[at $location]?) -- a - c < b - c ↔ a < b
-  | (rw [sub_le_iff_le_add]         $[at $location]?) --  a - c ≤ b ↔ a ≤ b + c
-  | (rw [sub_lt_iff_lt_add]         $[at $location]?) --  a - c < b ↔ a < b + c
-  | (rw [le_sub_iff_add_le]         $[at $location]?) -- a ≤ c - b ↔ a + b ≤ c
-  | (rw [lt_sub_iff_add_lt]         $[at $location]?) -- a < c - b ↔ a + b < c
-  | (rw [Nat.sub_le_iff_le_add]         $[at $location]?) -- a - b ≤ c ↔ a ≤ c + b
-  | (rw [Nat.le_sub_iff_add_le]         $[at $location]?) ) -- x ≤ y - k ↔ x + k ≤ y
+  | (rw [← Nat.sub_add_comm] $[at $location]?) -- (n - k) + m = (n + m) - k (ℕ)
+  | (rw [Nat.add_sub_comm_of_le] $[at $location]?) -- m + (n - k) = m + n - k (ℕ)
+  | (rw [add_sub] $[at $location]?) -- x + (y - z) = x + y - z
+  | (rw [sub_neg_eq_add] $[at $location]?) -- x - -y = x + y
+  | (rw [← sub_eq_add_neg] $[at $location]?) -- x + -y = x - y
+  | (rw [neg_add_eq_sub] $[at $location]?) -- -x + y = y - x
+  | (rw [← add_assoc] $[at $location]?) -- x + (y + z) = x + y + z
+  | (rw [add_le_add_iff_left] $[at $location]?) -- a + b ≤ a + c ↔ b ≤ c
+  | (rw [add_lt_add_iff_left] $[at $location]?) -- a + b < a + c ↔ b < c
+  | (rw [add_le_add_iff_right] $[at $location]?) -- b + a ≤ c + a ↔ b ≤ c
+  | (rw [add_lt_add_iff_right] $[at $location]?) -- b + a < c + a ↔ b < c
+  | (rw [sub_le_sub_iff_left] $[at $location]?) -- a - b ≤ a - c ↔ c ≤ b
+  | (rw [sub_lt_sub_iff_left] $[at $location]?) -- a - b < a - c ↔ c < b
+  | (rw [sub_le_sub_iff_right] $[at $location]?) -- a - c ≤ b - c ↔ a ≤ b
+  | (rw [sub_lt_sub_iff_right] $[at $location]?) -- a - c < b - c ↔ a < b
+  | (rw [Nat.add_le_add_iff_left] $[at $location]?) -- a + b ≤ a + c ↔ b ≤ c
+  | (rw [Nat.add_lt_add_iff_left] $[at $location]?) -- a + b < a + c ↔ b < c
+  | (rw [Nat.add_le_add_iff_right] $[at $location]?) -- b + a ≤ c + a ↔ b ≤ c
+  | (rw [Nat.add_lt_add_iff_right] $[at $location]?) -- b + a < c + a ↔ b < c
+  | (rw [Nat.sub_le_sub_iff_left] $[at $location]?) -- a - b ≤ a - c ↔ c ≤ b
+  | (rw [Nat.sub_lt_sub_iff_left] $[at $location]?) -- a - b < a - c ↔ c < b
+  | (rw [Nat.sub_le_sub_iff_right] $[at $location]?) -- a - c ≤ b - c ↔ a ≤ b
+  | (rw [Nat.sub_lt_sub_iff_right] $[at $location]?) -- a - c < b - c ↔ a < b
+  | (simp only [add_assoc,add_le_add_iff_left] $[at $location]?) -- a + b ≤ a + c ↔ b ≤ c
+  | (simp only [add_assoc,add_lt_add_iff_left] $[at $location]?) -- a + b < a + c ↔ b < c
+  | (simp only [add_assoc,add_le_add_iff_right] $[at $location]?) -- b + a ≤ c + a ↔ b ≤ c
+  | (simp only [add_assoc,add_lt_add_iff_right] $[at $location]?) -- b + a < c + a ↔ b < c
+  | (simp only [add_assoc,sub_le_sub_iff_left] $[at $location]?) -- a - b ≤ a - c ↔ c ≤ b
+  | (simp only [add_assoc,sub_lt_sub_iff_left] $[at $location]?) -- a - b < a - c ↔ c < b
+  | (simp only [add_assoc,sub_le_sub_iff_right] $[at $location]?) -- a - c ≤ b - c ↔ a ≤ b
+  | (simp only [add_assoc,sub_lt_sub_iff_right] $[at $location]?) -- a - c < b - c ↔ a < b
+  | (simp only [add_assoc,Nat.add_le_add_iff_left] $[at $location]?) -- a + b ≤ a + c ↔ b ≤ c
+  | (simp only [add_assoc,Nat.add_lt_add_iff_left] $[at $location]?) -- a + b < a + c ↔ b < c
+  | (simp only [add_assoc,Nat.add_le_add_iff_right] $[at $location]?) -- b + a ≤ c + a ↔ b ≤ c
+  | (simp only [add_assoc,Nat.add_lt_add_iff_right] $[at $location]?) -- b + a < c + a ↔ b < c
+  | (simp only [add_assoc,Nat.sub_le_sub_iff_left] $[at $location]?) -- a - b ≤ a - c ↔ c ≤ b
+  | (simp only [add_assoc,Nat.sub_lt_sub_iff_left] $[at $location]?) -- a - b < a - c ↔ c < b
+  | (simp only [add_assoc,Nat.sub_le_sub_iff_right] $[at $location]?) -- a - c ≤ b - c ↔ a ≤ b
+  | (simp only [add_assoc,Nat.sub_lt_sub_iff_right] $[at $location]?) -- a - c < b - c ↔ a < b
+  | (rw [sub_le_iff_le_add] $[at $location]?) --  a - c ≤ b ↔ a ≤ b + c
+  | (rw [sub_lt_iff_lt_add] $[at $location]?) --  a - c < b ↔ a < b + c
+  | (rw [le_sub_iff_add_le] $[at $location]?) -- a ≤ c - b ↔ a + b ≤ c
+  | (rw [lt_sub_iff_add_lt] $[at $location]?) -- a < c - b ↔ a + b < c
+  | (rw [Nat.sub_le_iff_le_add] $[at $location]?) -- a - b ≤ c ↔ a ≤ c + b
+  | (rw [Nat.le_sub_iff_add_le] $[at $location]?) ) -- x ≤ y - k ↔ x + k ≤ y
   try (any_goals assumption)))

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -69,7 +69,7 @@ macro_rules
   | (rw [Nat.mul_div_left] $[at $location]?) -- n * m / m = n
   | (rw [Nat.mul_div_right] $[at $location]?) -- m * n / m = n
   | (rw [←Nat.mul_div_assoc] $[at $location]?) -- m * (n / k) = m * n / k
-  | (rw [Nat.div_mul_assoc] $[at $location]?) -- n / k * m = n * m / k
+  | (rw [Nat.div_mul_right_comm] $[at $location]?) -- n / k * m = n * m / k
   | (rw [Nat.div_mul_div_comm] $[at $location]?)-- m / n * (k / l) = m * k / (n * l)
   | (rw [←Nat.mul_add_mul_div_of_dvd] $[at $location]?) -- m / n + k / l = (m * l + n * k) / (n * l)
   | (rw [←Nat.mul_sub_mul_div_of_dvd] $[at $location]?) -- m / n - k / l = (m * l - n * k) / (n * l)
@@ -127,7 +127,7 @@ macro_rules
   | (rw [Nat.mul_div_left] $[at $location]?) -- n * m / m = n
   | (rw [Nat.mul_div_right] $[at $location]?) -- m * n / m = n
   | (rw [←Nat.mul_div_assoc] $[at $location]?) -- m * (n / k) = m * n / k
-  | (rw [Nat.div_mul_assoc] $[at $location]?) -- n / k * m = n * m / k
+  | (rw [Nat.div_mul_right_comm] $[at $location]?) -- n / k * m = n * m / k
   | (rw [Nat.div_mul_div_comm] $[at $location]?)-- m / n * (k / l) = m * k / (n * l)
   | (rw [Nat.div_add_div_of_dvd] $[at $location]?) -- m / n + k / l = (m * l + n * k) / (n * l)
   | (rw [Nat.div_sub_div_of_dvd] $[at $location]?) -- m / n - k / l = (m * l - n * k) / (n * l)

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Miguel Marco. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Miguel Marco
+Authors: Miguel Marco
 -/
 import Init.Data.Nat.Basic
 import Mathlib.Algebra.EuclideanDomain.Basic
@@ -15,8 +15,6 @@ import Mathlib.Data.Nat.Order.Basic
 import Mathlib.Data.Nat.Order.Lemmas
 import Mathlib.Tactic.FieldSimp
 import Std.Data.Nat.Lemmas
-
-open Lean Meta Elab Tactic Parser Tactic
 
 /-!
 # `unify_denoms` and `unify_denoms!` tactics
@@ -36,6 +34,8 @@ The `unify_denoms!` tactic extends `unify_denoms` to work also on
 /-
 The following lemmas are needed to manage divisions in the naturals:
 -/
+
+open Lean Meta Elab Tactic Parser Tactic
 
 /--
 `unify_denoms` reduces expressions with nested fractions to a single fraction.

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -71,12 +71,12 @@ macro_rules
   | (rw [←Nat.mul_div_assoc] $[at $location]?) -- m * (n / k) = m * n / k
   | (rw [Nat.div_mul_assoc] $[at $location]?) -- n / k * m = n * m / k
   | (rw [Nat.div_mul_div_comm] $[at $location]?)-- m / n * (k / l) = m * k / (n * l)
-  | (rw [Nat.div_add_div_of_dvd] $[at $location]?) -- m / n + k / l = (m * l + n * k) / (n * l)
-  | (rw [Nat.div_sub_div_of_dvd] $[at $location]?) -- m / n - k / l = (m * l - n * k) / (n * l)
-  | (rw [Nat.div_add_of_dvd] $[at $location]?) -- m / n + k = (m + n * k) / n
-  | (rw [Nat.div_sub_of_dvd] $[at $location]?) -- m / n - k = (m - n * k) / n
+  | (rw [←Nat.mul_add_mul_div_of_dvd] $[at $location]?) -- m / n + k / l = (m * l + n * k) / (n * l)
+  | (rw [←Nat.mul_sub_mul_div_of_dvd] $[at $location]?) -- m / n - k / l = (m * l - n * k) / (n * l)
+  | (rw [←Nat.add_mul_div_left] $[at $location]?) -- m / n + k = (m + n * k) / n
+  | (rw [←Nat.sub_mul_div] $[at $location]?) -- m / n - k = (m - n * k) / n
   | (rw [Nat.add_div_of_dvd] $[at $location]?) -- m + n / k = (k * m + n) / k
-  | (rw [Nat.sub_div_of_dvd] $[at $location]?) -- m - n / k = (k * m - n) / k
+  | (rw [←Nat.mul_sub_div_of_dvd] $[at $location]?) -- m - n / k = (k * m - n) / k
   | (rw [Int.div_self] $[at $location]?) -- n / n = 1
   | (rw [Int.one_mul] $[at $location]?) -- 1 * n = n
   | (rw [Int.mul_one] $[at $location]?) -- 1 * n = n
@@ -133,7 +133,7 @@ macro_rules
   | (rw [Nat.div_sub_div_of_dvd] $[at $location]?) -- m / n - k / l = (m * l - n * k) / (n * l)
   | (rw [Nat.div_add_of_dvd] $[at $location]?) -- m / n + k = (m + n * k) / n
   | (rw [Nat.div_sub_of_dvd] $[at $location]?) -- m / n - k = (m - n * k) / n
-  | (rw [Nat.add_div_of_dvd] $[at $location]?) -- m + n / k = (k * m + n) / k
+  | (rw [←Nat.mul_add_div] $[at $location]?) -- m + n / k = (k * m + n) / k
   | (rw [Nat.sub_div_of_dvd] $[at $location]?) -- m - n / k = (k * m - n) / k
   | (rw [Int.div_self] $[at $location]?) -- n / n = 1
   | (rw [Int.one_mul] $[at $location]?) -- 1 * n = n

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -146,10 +146,10 @@ macro_rules
   | (rw [EuclideanDomain.div_div] $[at $location]?) -- x / y / z = x / (y * z)
   | (rw [EuclideanDomain.div_add_div_of_dvd] $[at $location]?) -- x/y + z/t = (t*x + y*z)/(t*y)
   | (rw [EuclideanDomain.div_sub_div_of_dvd] $[at $location]?) -- x/y - z/t = (t*x - y*z)/(t*y)
-  | (rw [EuclideanDomain.div_add_of_dvd] $[at $location]?) -- x / y + z = (x + y * z) / y
-  | (rw [EuclideanDomain.div_sub_of_dvd] $[at $location]?) -- x / y - z = (x - y * z) / y
-  | (rw [EuclideanDomain.add_div_of_dvd] $[at $location]?) -- x + y / z = (z * x + y) / z
-  | (rw [EuclideanDomain.sub_div_of_dvd] $[at $location]?)  -- x - y / z = (z * x - y) / z
+  | (rw [←EuclideanDomain.add_mul_div_left] $[at $location]?) -- x / y + z = (x + y * z) / y
+  | (rw [←EuclideanDomain.sub_mul_div_left] $[at $location]?) -- x / y - z = (x - y * z) / y
+  | (rw [←EuclideanDomain.mul_add_div_left] $[at $location]?) -- x + y / z = (z * x + y) / z
+  | (rw [←EuclideanDomain.mul_sub_div_left] $[at $location]?) ) -- x - y / z = (z * x - y) / z
 ----------------------------
   | (rw [mul_eq_zero] $[at $location]?) -- a * b = 0 ↔ a = 0 ∨ b = 0
   | (rw [eq_comm,mul_eq_zero] $[at $location]?) -- 0 = a * b ↔ a = 0 ∨ b = 0

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -88,10 +88,10 @@ macro_rules
   | (rw [EuclideanDomain.div_div] $[at $location]?) -- x / y / z = x / (y * z)
   | (rw [EuclideanDomain.div_add_div_of_dvd] $[at $location]?) -- x/y + z/t = (t*x + y*z)/(t*y)
   | (rw [EuclideanDomain.div_sub_div_of_dvd] $[at $location]?) -- x/y - z/t = (t*x - y*z)/(t*y)
-  | (rw [EuclideanDomain.div_add_of_dvd] $[at $location]?) -- x / y + z = (x + y * z) / y
-  | (rw [EuclideanDomain.div_sub_of_dvd] $[at $location]?) -- x / y - z = (x - y * z) / y
-  | (rw [EuclideanDomain.add_div_of_dvd] $[at $location]?) -- x + y / z = (z * x + y) / z
-  | (rw [EuclideanDomain.sub_div_of_dvd] $[at $location]?) ) -- x - y / z = (z * x - y) / z
+  | (rw [←EuclideanDomain.add_mul_div_left] $[at $location]?) -- x / y + z = (x + y * z) / y
+  | (rw [←EuclideanDomain.sub_mul_div_left] $[at $location]?) -- x / y - z = (x - y * z) / y
+  | (rw [←EuclideanDomain.mul_add_div_left] $[at $location]?) -- x + y / z = (z * x + y) / z
+  | (rw [←EuclideanDomain.mul_sub_div_left] $[at $location]?) ) -- x - y / z = (z * x - y) / z
   try (any_goals assumption) ))
 
 /--

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -81,8 +81,8 @@ macro_rules
   | (rw [EuclideanDomain.mul_div_mul_cancel] $[at $location]?) -- a * b / (a * c) = b / c
   | (rw [←EuclideanDomain.mul_div_assoc] $[at $location]?) -- x * (y / z) = x * y / z
   | (rw [EuclideanDomain.div_div] $[at $location]?) -- x / y / z = x / (y * z)
-  | (rw [EuclideanDomain.div_add_div_of_dvd] $[at $location]?) -- x / y + z / t = (t * x + y * z) / (t * y)
-  | (rw [EuclideanDomain.div_sub_div_of_dvd] $[at $location]?) -- x / y - z / t = (t * x - y * z) / (t * y)
+  | (rw [EuclideanDomain.div_add_div_of_dvd] $[at $location]?) -- x/y + z/t = (t*x + y*z)/(t*y)
+  | (rw [EuclideanDomain.div_sub_div_of_dvd] $[at $location]?) -- x/y - z/t = (t*x - y*z)/(t*y)
   | (rw [EuclideanDomain.div_add_of_dvd] $[at $location]?) -- x / y + z = (x + y * z) / y
   | (rw [EuclideanDomain.div_sub_of_dvd] $[at $location]?) -- x / y - z = (x - y * z) / y
   | (rw [EuclideanDomain.add_div_of_dvd] $[at $location]?) -- x + y / z = (z * x + y) / z
@@ -126,7 +126,7 @@ macro_rules
   | (rw [Nat.le_div_iff_mul_le] $[at $location]?) -- x ≤ y / k ↔ x * k ≤ y
   | (rw [Nat.div_le_iff_le_mul_of_dvd] $[at $location]?) -- m / n ≤ k ↔ m ≤ k * n
   | (rw [Nat.lt_div_iff_mul_lt_of_dvd] $[at $location]?) -- m < n / k ↔ m * k < n
-  | (rw [EuclideanDomain.div_eq_div_iff_mul_eq_mul_of_dvd] $[at $location]?) -- x / y = z / t ↔ t * x = y * z
+  | (rw [EuclideanDomain.div_eq_div_iff_mul_eq_mul_of_dvd] $[at $location]?) -- x/y=z/t↔t*x=y*z
   | (rw [EuclideanDomain.eq_div_iff_mul_eq_of_dvd] $[at $location]?) -- x = y / z ↔ z * x = y
   | (rw [EuclideanDomain.div_eq_iff_eq_mul_of_dvd] $[at $location]?) -- x / y = z ↔ x = y * z
   | (rw [Int.div_le_div_iff_of_dvd_of_pos] $[at $location]?) -- x / y ≤ z / t ↔ t * x ≤ z * y

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -9,7 +9,10 @@ import Mathlib.Algebra.Field.Basic
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.GroupWithZero.Units.Lemmas
 import Mathlib.Algebra.Order.Field.Basic
+import Mathlib.Data.Int.Order.Basic
+import Mathlib.Data.Int.Order.Lemmas
 import Mathlib.Data.Nat.Order.Basic
+import Mathlib.Data.Nat.Order.Lemmas
 import Mathlib.Tactic.FieldSimp
 import Std.Data.Nat.Lemmas
 
@@ -46,40 +49,47 @@ macro_rules
 | `(tactic | unify_denoms $[at $location]?) => `(tactic |(
   try field_simp $[at $location]?
   repeat (first
-  | (rw [← one_div]         $[at $location]?)
-  | (rw [div_add_div]       $[at $location]?)
-  | (rw [div_sub_div]       $[at $location]?)
-  | (rw [add_div']          $[at $location]?)
-  | (rw [div_add']          $[at $location]?)
-  | (rw [div_sub']          $[at $location]?)
-  | (rw [sub_div']          $[at $location]?)
-  | (rw [mul_div_mul_right] $[at $location]?)
-  | (rw [mul_div_mul_left]  $[at $location]?)
-  | (rw [Nat.div_div_eq_div_mul]  $[at $location]?)
-  | (rw [Nat.div_self]                             $[at $location]?)
-  | (rw [Nat.mul_div_mul_right]                    $[at $location]?)
-  | (rw [Nat.mul_div_mul_left]                     $[at $location]?)
-  | (rw [Nat.div_add_div_of_dvd]                   $[at $location]?)
-  | (rw [Nat.div_sub_div_of_dvd]                   $[at $location]?)
-  | (rw [Nat.div_add_of_dvd]                       $[at $location]?)
-  | (rw [Nat.div_sub_of_dvd]                       $[at $location]?)
-  | (rw [Nat.add_div_of_dvd]                       $[at $location]?)
-  | (rw [Nat.sub_div_of_dvd]                       $[at $location]?)
-  | (rw [EuclideanDomain.mul_div_cancel]           $[at $location]?)
-  | (rw [EuclideanDomain.mul_div_cancel']          $[at $location]?)
-  | (rw [EuclideanDomain.mul_div_cancel_left]      $[at $location]?)
-  | (rw [EuclideanDomain.mul_div_mul_cancel]       $[at $location]?)
-  | (rw [←EuclideanDomain.mul_div_assoc]           $[at $location]?)
-  | (rw [EuclideanDomain.div_div]                  $[at $location]?)
-  | (rw [EuclideanDomain.div_add_of_dvd]           $[at $location]?)
-  | (rw [EuclideanDomain.div_sub_of_dvd]           $[at $location]?)
-  | (rw [EuclideanDomain.add_div_of_dvd]           $[at $location]?)
-  | (rw [EuclideanDomain.sub_div_of_dvd]           $[at $location]?)
-  | (rw [EuclideanDomain.div_add_div_of_dvd]       $[at $location]?)
-  | (rw [EuclideanDomain.div_sub_div_of_dvd]       $[at $location]?)
-  | (rw [←Nat.mul_div_assoc]                       $[at $location]?)
-  | (rw [Nat.div_mul_assoc]                        $[at $location]?)
-  | (rw [Nat.div_mul_div_comm]                     $[at $location]?)
+  | (rw [← one_div] $[at $location]?) -- x⁻¹ = 1 / x
+  | (rw [one_mul] $[at $location]?) -- 1 * x = x
+  | (rw [mul_one] $[at $location]?) -- x * 1 = x
+  | (rw [mul_div_mul_right] $[at $location]?) -- a * c / (b * c) = a / b
+  | (rw [mul_div_mul_left] $[at $location]?) -- c * a / (c * b) = a / b
+  | (rw [div_add_div] $[at $location]?) -- a / b + c / d = (a * d + b * c) / (b * d)
+  | (rw [div_sub_div] $[at $location]?) -- a / b - c / d = (a * d - b * c) / (b * d)
+  | (rw [add_div'] $[at $location]?) -- b + a / c = (b * c + a) / c
+  | (rw [div_add'] $[at $location]?) -- a / c + b = (a + b * c) / c
+  | (rw [div_sub'] $[at $location]?) -- a / c - b = (a - c * b) / c
+  | (rw [sub_div'] $[at $location]?) -- b - a / c = (b * c - a) / c
+  | (rw [Nat.div_div_eq_div_mul] $[at $location]?) -- m / n / k = m / (n * k)
+  | (rw [Nat.div_self] $[at $location]?) -- n / n = 1
+  | (rw [Nat.one_mul] $[at $location]?) -- 1 * n = n
+  | (rw [Nat.mul_one] $[at $location]?) -- n * 1 = n
+  | (rw [Nat.mul_div_mul_right] $[at $location]?) -- n * m / (k * m) = n / k
+  | (rw [Nat.mul_div_mul_left] $[at $location]?) -- m * n / (m * k) = n / k
+  | (rw [Nat.div_add_div_of_dvd] $[at $location]?) -- m / n + k / l = (m * l + n * k) / (n * l)
+  | (rw [Nat.div_sub_div_of_dvd] $[at $location]?) -- m / n - k / l = (m * l - n * k) / (n * l)
+  | (rw [Nat.div_add_of_dvd] $[at $location]?) -- m / n + k = (m + n * k) / n
+  | (rw [Nat.div_sub_of_dvd] $[at $location]?) -- m / n - k = (m - n * k) / n
+  | (rw [Nat.add_div_of_dvd] $[at $location]?) -- m + n / k = (k * m + n) / k
+  | (rw [Nat.sub_div_of_dvd] $[at $location]?) -- m - n / k = (k * m - n) / k
+  | (rw [Int.div_self] $[at $location]?) -- n / n = 1
+  | (rw [Int.one_mul] $[at $location]?) -- 1 * n = n
+  | (rw [Int.mul_one] $[at $location]?) -- 1 * n = n
+  | (rw [EuclideanDomain.mul_div_cancel] $[at $location]?) -- a * b / b = a
+  | (rw [EuclideanDomain.mul_div_cancel'] $[at $location]?) -- b * (a / b) = a
+  | (rw [EuclideanDomain.mul_div_cancel_left] $[at $location]?) -- a * b / a = b
+  | (rw [EuclideanDomain.mul_div_mul_cancel] $[at $location]?) -- a * b / (a * c) = b / c
+  | (rw [←EuclideanDomain.mul_div_assoc] $[at $location]?) -- x * (y / z) = x * y / z
+  | (rw [EuclideanDomain.div_div] $[at $location]?) -- x / y / z = x / (y * z)
+  | (rw [EuclideanDomain.div_add_div_of_dvd] $[at $location]?) -- x / y + z / t = (t * x + y * z) / (t * y)
+  | (rw [EuclideanDomain.div_sub_div_of_dvd] $[at $location]?) -- x / y - z / t = (t * x - y * z) / (t * y)
+  | (rw [EuclideanDomain.div_add_of_dvd] $[at $location]?) -- x / y + z = (x + y * z) / y
+  | (rw [EuclideanDomain.div_sub_of_dvd] $[at $location]?) -- x / y - z = (x - y * z) / y
+  | (rw [EuclideanDomain.add_div_of_dvd] $[at $location]?) -- x + y / z = (z * x + y) / z
+  | (rw [EuclideanDomain.sub_div_of_dvd] $[at $location]?) -- x - y / z = (z * x - y) / z
+  | (rw [←Nat.mul_div_assoc] $[at $location]?) -- m * (n / k) = m * n / k
+  | (rw [Nat.div_mul_assoc] $[at $location]?) -- n / k * m = n * m / k
+  | (rw [Nat.div_mul_div_comm] $[at $location]?) -- m * k / (n * l)
    )))
 
 /--
@@ -95,30 +105,35 @@ macro_rules
 | `(tactic | unify_denoms! $[at $location]?) => `(tactic |(
   unify_denoms $[at $location]?
   repeat (first
-  | (rw [mul_eq_zero]                              $[at $location]?)
-  | (rw [eq_comm,mul_eq_zero]                      $[at $location]?)
-  | (rw [div_eq_zero_iff]                          $[at $location]?)
-  | (rw [div_eq_div_iff]                           $[at $location]?)
-  | (rw [gt_iff_lt]                                $[at $location]?)
-  | (rw [ge_iff_le]                                $[at $location]?)
-  | (rw [div_le_div_iff]                           $[at $location]?)
-  | (rw [div_lt_div_iff]                           $[at $location]?)
-  | (rw [div_eq_iff]                               $[at $location]?)
-  | (rw [div_le_iff]                               $[at $location]?)
-  | (rw [div_lt_iff]                               $[at $location]?)
-  | (rw [eq_div_iff]                               $[at $location]?)
-  | (rw [le_div_iff]                               $[at $location]?)
-  | (rw [lt_div_iff]                               $[at $location]?)
-  | (rw [lt_div_iff]                               $[at $location]?)
-  | (rw [Nat.div_eq_iff_eq_mul_left]               $[at $location]?)
-  | (rw [Nat.eq_div_iff_mul_eq_left]               $[at $location]?)
-  | (rw [eq_comm,Nat.div_eq_iff_eq_mul_left]       $[at $location]?)
-  | (rw [Nat.div_lt_iff_lt_mul]                    $[at $location]?)
-  | (rw [Nat.le_div_iff_mul_le]                    $[at $location]?)
-  | (rw [Nat.div_le_iff_le_mul_of_dvd]             $[at $location]?)
-  | (rw [Nat.lt_div_iff_mul_lt_of_dvd]             $[at $location]?)
-  | (rw [EuclideanDomain.div_eq_div_iff_mul_eq_mul_of_dvd] $[at $location]?)
-  | (rw [EuclideanDomain.eq_div_iff_mul_eq_of_dvd]         $[at $location]?)
-  | (rw [EuclideanDomain.div_eq_iff_eq_mul_of_dvd]         $[at $location]?)
-  | (push_neg                                      $[at $location]?) )
+  | (rw [mul_eq_zero] $[at $location]?) -- a * b = 0 ↔ a = 0 ∨ b = 0
+  | (rw [eq_comm,mul_eq_zero] $[at $location]?) -- 0 = a * b ↔ a = 0 ∨ b = 0
+  | (rw [div_eq_zero_iff] $[at $location]?) -- a / b = 0 ↔ a = 0 ∨ b = 0
+  | (rw [div_eq_div_iff] $[at $location]?) -- a / b = c / d ↔ a * d = c * b
+  | (rw [gt_iff_lt] $[at $location]?) -- a > b ↔ b < a
+  | (rw [ge_iff_le] $[at $location]?) -- a ≥ b ↔ b ≤ a
+  | (rw [div_le_div_iff] $[at $location]?) -- a / b ≤ c / d ↔ a * d ≤ c * b
+  | (rw [div_lt_div_iff] $[at $location]?) -- a / b < c / d ↔ a * d < c * b
+  | (rw [div_eq_iff] $[at $location]?) -- a / b = c ↔ a = c * b
+  | (rw [div_le_iff] $[at $location]?) -- a / b ≤ c ↔ a ≤ c * b
+  | (rw [div_lt_iff] $[at $location]?) -- b / c < a ↔ b < a * c
+  | (rw [eq_div_iff] $[at $location]?) -- a / b ↔ c * b = a
+  | (rw [le_div_iff] $[at $location]?) -- a ≤ b / c ↔ a * c ≤ b
+  | (rw [lt_div_iff] $[at $location]?) -- a < b / c ↔ a * c < b
+  | (rw [Nat.div_eq_iff_eq_mul_left] $[at $location]?) -- a / b = c ↔ a = c * b
+  | (rw [Nat.eq_div_iff_mul_eq_left] $[at $location]?) -- m = n / k ↔ n = m * k
+  | (rw [eq_comm,Nat.div_eq_iff_eq_mul_left] $[at $location]?) -- c = a / b ↔ a = c * b
+  | (rw [Nat.div_lt_iff_lt_mul] $[at $location]?) -- x / k < y ↔ x < y * k
+  | (rw [Nat.le_div_iff_mul_le] $[at $location]?) -- x ≤ y / k ↔ x * k ≤ y
+  | (rw [Nat.div_le_iff_le_mul_of_dvd] $[at $location]?) -- m / n ≤ k ↔ m ≤ k * n
+  | (rw [Nat.lt_div_iff_mul_lt_of_dvd] $[at $location]?) -- m < n / k ↔ m * k < n
+  | (rw [EuclideanDomain.div_eq_div_iff_mul_eq_mul_of_dvd] $[at $location]?) -- x / y = z / t ↔ t * x = y * z
+  | (rw [EuclideanDomain.eq_div_iff_mul_eq_of_dvd] $[at $location]?) -- x = y / z ↔ z * x = y
+  | (rw [EuclideanDomain.div_eq_iff_eq_mul_of_dvd] $[at $location]?) -- x / y = z ↔ x = y * z
+  | (rw [Int.div_le_div_iff_of_dvd_of_pos] $[at $location]?) -- x / y ≤ z / t ↔ t * x ≤ z * y
+  | (rw [Int.div_lt_div_iff_of_dvd_of_pos] $[at $location]?) -- x / y < z / t ↔ t * x < z * y
+  | (rw [Int.div_le_iff_of_dvd_of_pos] $[at $location]?) -- x / y ≤ z ↔ x ≤ y * z
+  | (rw [Int.div_lt_iff_of_dvd_of_pos] $[at $location]?) -- x / y < z ↔ x < y * z
+  | (rw [Int.le_div_iff_of_dvd_of_pos] $[at $location]?) -- x ≤ y / z ↔ z * x ≤ y
+  | (rw [Int.lt_div_iff_of_dvd_of_pos] $[at $location]?) -- x < y / z ↔ z * x < y
+  | (push_neg $[at $location]?) )
   try (any_goals assumption) ))

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -4,11 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Miguel Marco
 -/
 import Init.Data.Nat.Basic
-import Mathlib.Algebra.Group.Basic
+import Mathlib.Algebra.EuclideanDomain.Basic
 import Mathlib.Algebra.Field.Basic
+import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.GroupWithZero.Units.Lemmas
 import Mathlib.Algebra.Order.Field.Basic
+import Mathlib.Data.Nat.Order.Basic
 import Mathlib.Tactic.FieldSimp
+import Std.Data.Nat.Lemmas
 
 open Lean Meta Elab Tactic Parser Tactic
 
@@ -20,41 +23,71 @@ rules that require denominators to be nonzero. The corresponding hypotheses are
 added as new goals.
 
 The `unify_denoms` tactic tries to unify denominators in expressions, adding the
-necessary hypothesis about denominators being nonzero as new goals.
+necessary hypothesis about denominators being nonzero (and dividing the numerator in the case
+of euclidean domains) as new goals.
 
 The `unify_denoms!` tactic extends `unify_denoms` to work also on
-(in)equalities.
+(in)equalities. In the case of inequalities, it assumes denominators are positive.
 --/
+
+/-
+The following lemmas are needed to manage divisions in the naturals:
+-/
 
 /--
 `unify_denoms` reduces expressions with nested fractions to a single fraction.
 
-It adds the hypothesis that the corresponding denominators are nonzero
-as new goals.
+It adds the hypothesis that the corresponding denominators are nonzero (and divide the numerator
+in the case of euclidean domains) as new goals.
 -/
 syntax (name := unify_denoms) "unify_denoms" (location)? : tactic
 
-
 macro_rules
 | `(tactic | unify_denoms $[at $location]?) => `(tactic |(
-  field_simp $[at $location]?
+  try field_simp $[at $location]?
   repeat (first
-    | (rw [← one_div]         $[at $location]?)
-    | (rw [div_add_div]       $[at $location]?)
-    | (rw [div_sub_div]       $[at $location]?)
-    | (rw [add_div']          $[at $location]?)
-    | (rw [div_add']          $[at $location]?)
-    | (rw [div_sub']          $[at $location]?)
-    | (rw [sub_div']          $[at $location]?)
-    | (rw [mul_div_mul_right] $[at $location]?)
-    | (rw [mul_div_mul_left]  $[at $location]?) )))
+  | (rw [← one_div]         $[at $location]?)
+  | (rw [div_add_div]       $[at $location]?)
+  | (rw [div_sub_div]       $[at $location]?)
+  | (rw [add_div']          $[at $location]?)
+  | (rw [div_add']          $[at $location]?)
+  | (rw [div_sub']          $[at $location]?)
+  | (rw [sub_div']          $[at $location]?)
+  | (rw [mul_div_mul_right] $[at $location]?)
+  | (rw [mul_div_mul_left]  $[at $location]?)
+  | (rw [Nat.div_div_eq_div_mul]  $[at $location]?)
+  | (rw [Nat.div_self]                             $[at $location]?)
+  | (rw [Nat.mul_div_mul_right]                    $[at $location]?)
+  | (rw [Nat.mul_div_mul_left]                     $[at $location]?)
+  | (rw [Nat.div_add_div_of_dvd]                   $[at $location]?)
+  | (rw [Nat.div_sub_div_of_dvd]                   $[at $location]?)
+  | (rw [Nat.div_add_of_dvd]                       $[at $location]?)
+  | (rw [Nat.div_sub_of_dvd]                       $[at $location]?)
+  | (rw [Nat.add_div_of_dvd]                       $[at $location]?)
+  | (rw [Nat.sub_div_of_dvd]                       $[at $location]?)
+  | (rw [EuclideanDomain.mul_div_cancel]           $[at $location]?)
+  | (rw [EuclideanDomain.mul_div_cancel']          $[at $location]?)
+  | (rw [EuclideanDomain.mul_div_cancel_left]      $[at $location]?)
+  | (rw [EuclideanDomain.mul_div_mul_cancel]       $[at $location]?)
+  | (rw [←EuclideanDomain.mul_div_assoc]           $[at $location]?)
+  | (rw [EuclideanDomain.div_div]                  $[at $location]?)
+  | (rw [EuclideanDomain.div_add_of_dvd]           $[at $location]?)
+  | (rw [EuclideanDomain.div_sub_of_dvd]           $[at $location]?)
+  | (rw [EuclideanDomain.add_div_of_dvd]           $[at $location]?)
+  | (rw [EuclideanDomain.sub_div_of_dvd]           $[at $location]?)
+  | (rw [EuclideanDomain.div_add_div_of_dvd]       $[at $location]?)
+  | (rw [EuclideanDomain.div_sub_div_of_dvd]       $[at $location]?)
+  | (rw [←Nat.mul_div_assoc]                       $[at $location]?)
+  | (rw [Nat.div_mul_assoc]                        $[at $location]?)
+  | (rw [Nat.div_mul_div_comm]                     $[at $location]?)
+   )))
 
 /--
-`unify_denoms!` works as `unify_denoms`, but also tries to cancel denominators
-in both sides of an (in)equality.
+`unify_denoms!` works as `unify_denoms`, but:
+- it also simplifies divisions in euclidean domains, and
+- it also tries to cancel denominators in both sides of an (in)equality.
 
-For transforming inequalities between two fractions,
-it uses the hypothesis the denominators are positive, and adds it as new goals.
+The needed hypothesis about the divisibility and sign of denominators are added as new goals.
 -/
 syntax (name := unify_denoms!) "unify_denoms!" (location)?: tactic
 
@@ -62,17 +95,30 @@ macro_rules
 | `(tactic | unify_denoms! $[at $location]?) => `(tactic |(
   unify_denoms $[at $location]?
   repeat (first
-  | (rw [mul_eq_zero]           $[at $location]?)
-  | (rw [eq_comm,mul_eq_zero]   $[at $location]?)
-  | (rw [div_eq_zero_iff]       $[at $location]?)
-  | (rw [div_eq_div_iff]        $[at $location]?)
-  | (rw [div_le_div_iff]        $[at $location]?)
-  | (rw [div_lt_div_iff]        $[at $location]?)
-  | (rw [div_eq_iff]            $[at $location]?)
-  | (rw [div_le_iff]            $[at $location]?)
-  | (rw [div_lt_iff]            $[at $location]?)
-  | (rw [eq_div_iff]            $[at $location]?)
-  | (rw [le_div_iff]            $[at $location]?)
-  | (rw [lt_div_iff]            $[at $location]?)
-  | (push_neg                   $[at $location]?)
-   )))
+  | (rw [mul_eq_zero]                              $[at $location]?)
+  | (rw [eq_comm,mul_eq_zero]                      $[at $location]?)
+  | (rw [div_eq_zero_iff]                          $[at $location]?)
+  | (rw [div_eq_div_iff]                           $[at $location]?)
+  | (rw [gt_iff_lt]                                $[at $location]?)
+  | (rw [ge_iff_le]                                $[at $location]?)
+  | (rw [div_le_div_iff]                           $[at $location]?)
+  | (rw [div_lt_div_iff]                           $[at $location]?)
+  | (rw [div_eq_iff]                               $[at $location]?)
+  | (rw [div_le_iff]                               $[at $location]?)
+  | (rw [div_lt_iff]                               $[at $location]?)
+  | (rw [eq_div_iff]                               $[at $location]?)
+  | (rw [le_div_iff]                               $[at $location]?)
+  | (rw [lt_div_iff]                               $[at $location]?)
+  | (rw [lt_div_iff]                               $[at $location]?)
+  | (rw [Nat.div_eq_iff_eq_mul_left]               $[at $location]?)
+  | (rw [Nat.eq_div_iff_mul_eq_left]               $[at $location]?)
+  | (rw [eq_comm,Nat.div_eq_iff_eq_mul_left]       $[at $location]?)
+  | (rw [Nat.div_lt_iff_lt_mul]                    $[at $location]?)
+  | (rw [Nat.le_div_iff_mul_le]                    $[at $location]?)
+  | (rw [Nat.div_le_iff_le_mul_of_dvd]             $[at $location]?)
+  | (rw [Nat.lt_div_iff_mul_lt_of_dvd]             $[at $location]?)
+  | (rw [EuclideanDomain.div_eq_div_iff_mul_eq_mul_of_dvd] $[at $location]?)
+  | (rw [EuclideanDomain.eq_div_iff_mul_eq_of_dvd]         $[at $location]?)
+  | (rw [EuclideanDomain.div_eq_iff_eq_mul_of_dvd]         $[at $location]?)
+  | (push_neg                                      $[at $location]?) )
+  try (any_goals assumption) ))

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2023 Miguel Marco. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Miguel Marco
+-/
+import Init.Data.Nat.Basic
+import Mathlib.Algebra.Group.Basic
+import Mathlib.Algebra.Field.Basic
+import Mathlib.Algebra.GroupWithZero.Units.Lemmas
+import Mathlib.Algebra.Order.Field.Basic
+import Mathlib.Tactic.FieldSimp
+
+open Lean Meta Elab Tactic Parser Tactic
+
+/-!
+# `unify_denoms` tactic
+
+Tactics to clear denominators in algebraic expressions, extends `field_simp`  using
+rules that require denominators to be nonzero. The corresponding hypotheses are
+added as new goals.
+
+The `unify_denoms` tactic tries to unify denominators in expressions, adding the
+necessary hypothesis about denominators being nonzero as new goals.
+
+The `unify_denoms!` tactic extends `unify_denoms` to work also on
+(in)equalities.
+--/
+syntax (name := unify_denoms) "unify_denoms" (location)? : tactic
+
+
+macro_rules
+| `(tactic | unify_denoms $[at $location]?) => `(tactic |(
+  field_simp $[at $location]?
+  repeat (first
+    | (rw [← one_div]         $[at $location]?)
+    | (rw [div_add_div]       $[at $location]?)
+    | (rw [div_sub_div]       $[at $location]?)
+    | (rw [add_div']          $[at $location]?)
+    | (rw [div_add']          $[at $location]?)
+    | (rw [div_sub']          $[at $location]?)
+    | (rw [sub_div']          $[at $location]?)
+    | (rw [mul_div_mul_right] $[at $location]?)
+    | (rw [mul_div_mul_left]  $[at $location]?) )))
+
+syntax (name := unify_denoms!) "unify_denoms!" (location)?: tactic
+
+macro_rules
+| `(tactic | unify_denoms! $[at $location]?) => `(tactic |(
+  unify_denoms $[at $location]?
+  repeat (first
+  | (rw [mul_eq_zero]           $[at $location]?)
+  | (rw [eq_comm,mul_eq_zero]   $[at $location]?)
+  | (rw [div_eq_zero_iff]       $[at $location]?)
+  | (rw [div_eq_div_iff]        $[at $location]?)
+  | (rw [div_le_div_iff]        $[at $location]?)
+  | (rw [div_lt_div_iff]        $[at $location]?)
+  | (rw [div_eq_iff]            $[at $location]?)
+  | (rw [div_le_iff]            $[at $location]?)
+  | (rw [div_lt_iff]            $[at $location]?)
+  | (rw [eq_div_iff]            $[at $location]?)
+  | (rw [le_div_iff]            $[at $location]?)
+  | (rw [lt_div_iff]            $[at $location]?)
+  | (push_neg                   $[at $location]?)
+   )))

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -13,7 +13,7 @@ import Mathlib.Tactic.FieldSimp
 open Lean Meta Elab Tactic Parser Tactic
 
 /-!
-# `unify_denoms` tactic
+# `unify_denoms` and `unify_denoms!` tactics
 
 Tactics to clear denominators in algebraic expressions, extends `field_simp`  using
 rules that require denominators to be nonzero. The corresponding hypotheses are
@@ -25,6 +25,13 @@ necessary hypothesis about denominators being nonzero as new goals.
 The `unify_denoms!` tactic extends `unify_denoms` to work also on
 (in)equalities.
 --/
+
+/--
+`unify_denoms` reduces expressions with nested fractions to a single fraction.
+
+It adds the hypothesis that the corresponding denominators are nonzero
+as new goals.
+-/
 syntax (name := unify_denoms) "unify_denoms" (location)? : tactic
 
 
@@ -42,6 +49,13 @@ macro_rules
     | (rw [mul_div_mul_right] $[at $location]?)
     | (rw [mul_div_mul_left]  $[at $location]?) )))
 
+/--
+`unify_denoms!` works as `unify_denoms`, but also tries to cancel denominators
+in both sides of an (in)equality.
+
+For transforming inequalities between two fractions,
+it uses the hypothesis the denominators are positive, and adds it as new goals.
+-/
 syntax (name := unify_denoms!) "unify_denoms!" (location)?: tactic
 
 macro_rules

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -66,6 +66,11 @@ macro_rules
   | (rw [Nat.mul_one] $[at $location]?) -- n * 1 = n
   | (rw [Nat.mul_div_mul_right] $[at $location]?) -- n * m / (k * m) = n / k
   | (rw [Nat.mul_div_mul_left] $[at $location]?) -- m * n / (m * k) = n / k
+  | (rw [Nat.mul_div_left] $[at $location]?) -- n * m / m = n
+  | (rw [Nat.mul_div_right] $[at $location]?) -- m * n / m = n
+  | (rw [←Nat.mul_div_assoc] $[at $location]?) -- m * (n / k) = m * n / k
+  | (rw [Nat.div_mul_assoc] $[at $location]?) -- n / k * m = n * m / k
+  | (rw [Nat.div_mul_div_comm] $[at $location]?)-- m / n * (k / l) = m * k / (n * l)
   | (rw [Nat.div_add_div_of_dvd] $[at $location]?) -- m / n + k / l = (m * l + n * k) / (n * l)
   | (rw [Nat.div_sub_div_of_dvd] $[at $location]?) -- m / n - k / l = (m * l - n * k) / (n * l)
   | (rw [Nat.div_add_of_dvd] $[at $location]?) -- m / n + k = (m + n * k) / n
@@ -86,11 +91,8 @@ macro_rules
   | (rw [EuclideanDomain.div_add_of_dvd] $[at $location]?) -- x / y + z = (x + y * z) / y
   | (rw [EuclideanDomain.div_sub_of_dvd] $[at $location]?) -- x / y - z = (x - y * z) / y
   | (rw [EuclideanDomain.add_div_of_dvd] $[at $location]?) -- x + y / z = (z * x + y) / z
-  | (rw [EuclideanDomain.sub_div_of_dvd] $[at $location]?) -- x - y / z = (z * x - y) / z
-  | (rw [←Nat.mul_div_assoc] $[at $location]?) -- m * (n / k) = m * n / k
-  | (rw [Nat.div_mul_assoc] $[at $location]?) -- n / k * m = n * m / k
-  | (rw [Nat.div_mul_div_comm] $[at $location]?) -- m * k / (n * l)
-   )))
+  | (rw [EuclideanDomain.sub_div_of_dvd] $[at $location]?) ) -- x - y / z = (z * x - y) / z
+  try (any_goals assumption) ))
 
 /--
 `unify_denoms!` works as `unify_denoms`, but:
@@ -103,8 +105,52 @@ syntax (name := unify_denoms!) "unify_denoms!" (location)?: tactic
 
 macro_rules
 | `(tactic | unify_denoms! $[at $location]?) => `(tactic |(
-  unify_denoms $[at $location]?
+  try field_simp $[at $location]?
   repeat (first
+  | (rw [← one_div] $[at $location]?) -- x⁻¹ = 1 / x
+  | (rw [one_mul] $[at $location]?) -- 1 * x = x
+  | (rw [mul_one] $[at $location]?) -- x * 1 = x
+  | (rw [mul_div_mul_right] $[at $location]?) -- a * c / (b * c) = a / b
+  | (rw [mul_div_mul_left] $[at $location]?) -- c * a / (c * b) = a / b
+  | (rw [div_add_div] $[at $location]?) -- a / b + c / d = (a * d + b * c) / (b * d)
+  | (rw [div_sub_div] $[at $location]?) -- a / b - c / d = (a * d - b * c) / (b * d)
+  | (rw [add_div'] $[at $location]?) -- b + a / c = (b * c + a) / c
+  | (rw [div_add'] $[at $location]?) -- a / c + b = (a + b * c) / c
+  | (rw [div_sub'] $[at $location]?) -- a / c - b = (a - c * b) / c
+  | (rw [sub_div'] $[at $location]?) -- b - a / c = (b * c - a) / c
+  | (rw [Nat.div_div_eq_div_mul] $[at $location]?) -- m / n / k = m / (n * k)
+  | (rw [Nat.div_self] $[at $location]?) -- n / n = 1
+  | (rw [Nat.one_mul] $[at $location]?) -- 1 * n = n
+  | (rw [Nat.mul_one] $[at $location]?) -- n * 1 = n
+  | (rw [Nat.mul_div_mul_right] $[at $location]?) -- n * m / (k * m) = n / k
+  | (rw [Nat.mul_div_mul_left] $[at $location]?) -- m * n / (m * k) = n / k
+  | (rw [Nat.mul_div_left] $[at $location]?) -- n * m / m = n
+  | (rw [Nat.mul_div_right] $[at $location]?) -- m * n / m = n
+  | (rw [←Nat.mul_div_assoc] $[at $location]?) -- m * (n / k) = m * n / k
+  | (rw [Nat.div_mul_assoc] $[at $location]?) -- n / k * m = n * m / k
+  | (rw [Nat.div_mul_div_comm] $[at $location]?)-- m / n * (k / l) = m * k / (n * l)
+  | (rw [Nat.div_add_div_of_dvd] $[at $location]?) -- m / n + k / l = (m * l + n * k) / (n * l)
+  | (rw [Nat.div_sub_div_of_dvd] $[at $location]?) -- m / n - k / l = (m * l - n * k) / (n * l)
+  | (rw [Nat.div_add_of_dvd] $[at $location]?) -- m / n + k = (m + n * k) / n
+  | (rw [Nat.div_sub_of_dvd] $[at $location]?) -- m / n - k = (m - n * k) / n
+  | (rw [Nat.add_div_of_dvd] $[at $location]?) -- m + n / k = (k * m + n) / k
+  | (rw [Nat.sub_div_of_dvd] $[at $location]?) -- m - n / k = (k * m - n) / k
+  | (rw [Int.div_self] $[at $location]?) -- n / n = 1
+  | (rw [Int.one_mul] $[at $location]?) -- 1 * n = n
+  | (rw [Int.mul_one] $[at $location]?) -- 1 * n = n
+  | (rw [EuclideanDomain.mul_div_cancel] $[at $location]?) -- a * b / b = a
+  | (rw [EuclideanDomain.mul_div_cancel'] $[at $location]?) -- b * (a / b) = a
+  | (rw [EuclideanDomain.mul_div_cancel_left] $[at $location]?) -- a * b / a = b
+  | (rw [EuclideanDomain.mul_div_mul_cancel] $[at $location]?) -- a * b / (a * c) = b / c
+  | (rw [←EuclideanDomain.mul_div_assoc] $[at $location]?) -- x * (y / z) = x * y / z
+  | (rw [EuclideanDomain.div_div] $[at $location]?) -- x / y / z = x / (y * z)
+  | (rw [EuclideanDomain.div_add_div_of_dvd] $[at $location]?) -- x/y + z/t = (t*x + y*z)/(t*y)
+  | (rw [EuclideanDomain.div_sub_div_of_dvd] $[at $location]?) -- x/y - z/t = (t*x - y*z)/(t*y)
+  | (rw [EuclideanDomain.div_add_of_dvd] $[at $location]?) -- x / y + z = (x + y * z) / y
+  | (rw [EuclideanDomain.div_sub_of_dvd] $[at $location]?) -- x / y - z = (x - y * z) / y
+  | (rw [EuclideanDomain.add_div_of_dvd] $[at $location]?) -- x + y / z = (z * x + y) / z
+  | (rw [EuclideanDomain.sub_div_of_dvd] $[at $location]?)  -- x - y / z = (z * x - y) / z
+----------------------------
   | (rw [mul_eq_zero] $[at $location]?) -- a * b = 0 ↔ a = 0 ∨ b = 0
   | (rw [eq_comm,mul_eq_zero] $[at $location]?) -- 0 = a * b ↔ a = 0 ∨ b = 0
   | (rw [div_eq_zero_iff] $[at $location]?) -- a / b = 0 ↔ a = 0 ∨ b = 0

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -30,7 +30,6 @@ The `unify_denoms!` tactic extends `unify_denoms` to work also on
 (in)equalities. In the case of inequalities, it assumes denominators are positive.
 --/
 
-
 open Lean Meta Elab Tactic Parser Tactic
 
 /--

--- a/Mathlib/Tactic/UnifyDenoms.lean
+++ b/Mathlib/Tactic/UnifyDenoms.lean
@@ -11,10 +11,9 @@ import Mathlib.Algebra.GroupWithZero.Units.Lemmas
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Data.Int.Order.Basic
 import Mathlib.Data.Int.Order.Lemmas
-import Mathlib.Data.Nat.Order.Basic
 import Mathlib.Data.Nat.Order.Lemmas
 import Mathlib.Tactic.FieldSimp
-import Std.Data.Nat.Lemmas
+import Batteries.Data.Nat.Lemmas
 
 /-!
 # `unify_denoms` and `unify_denoms!` tactics
@@ -31,9 +30,6 @@ The `unify_denoms!` tactic extends `unify_denoms` to work also on
 (in)equalities. In the case of inequalities, it assumes denominators are positive.
 --/
 
-/-
-The following lemmas are needed to manage divisions in the naturals:
--/
 
 open Lean Meta Elab Tactic Parser Tactic
 
@@ -85,14 +81,17 @@ macro_rules
   | (rw [EuclideanDomain.mul_div_cancel_left] $[at $location]?) -- a * b / a = b
   | (rw [EuclideanDomain.mul_div_mul_cancel] $[at $location]?) -- a * b / (a * c) = b / c
   | (rw [←EuclideanDomain.mul_div_assoc] $[at $location]?) -- x * (y / z) = x * y / z
+  | (rw [EuclideanDomain.div_mul_assoc] $[at $location]?) -- (x / y) * z = x * z * y
   | (rw [EuclideanDomain.div_div] $[at $location]?) -- x / y / z = x / (y * z)
+  | (rw [EuclideanDomain.div_div'] $[at $location]?) -- x / (y / z) = x * z / y
   | (rw [EuclideanDomain.div_add_div_of_dvd] $[at $location]?) -- x/y + z/t = (t*x + y*z)/(t*y)
   | (rw [EuclideanDomain.div_sub_div_of_dvd] $[at $location]?) -- x/y - z/t = (t*x - y*z)/(t*y)
   | (rw [←EuclideanDomain.add_mul_div_left] $[at $location]?) -- x / y + z = (x + y * z) / y
   | (rw [←EuclideanDomain.sub_mul_div_left] $[at $location]?) -- x / y - z = (x - y * z) / y
   | (rw [←EuclideanDomain.mul_add_div_left] $[at $location]?) -- x + y / z = (z * x + y) / z
   | (rw [←EuclideanDomain.mul_sub_div_left] $[at $location]?) ) -- x - y / z = (z * x - y) / z
-  try (any_goals assumption) ))
+  try (any_goals assumption)
+  try (any_goals omega)))
 
 /--
 `unify_denoms!` works as `unify_denoms`, but:
@@ -131,10 +130,10 @@ macro_rules
   | (rw [Nat.div_mul_div_comm] $[at $location]?)-- m / n * (k / l) = m * k / (n * l)
   | (rw [Nat.div_add_div_of_dvd] $[at $location]?) -- m / n + k / l = (m * l + n * k) / (n * l)
   | (rw [Nat.div_sub_div_of_dvd] $[at $location]?) -- m / n - k / l = (m * l - n * k) / (n * l)
-  | (rw [Nat.div_add_of_dvd] $[at $location]?) -- m / n + k = (m + n * k) / n
-  | (rw [Nat.div_sub_of_dvd] $[at $location]?) -- m / n - k = (m - n * k) / n
-  | (rw [←Nat.mul_add_div] $[at $location]?) -- m + n / k = (k * m + n) / k
-  | (rw [Nat.sub_div_of_dvd] $[at $location]?) -- m - n / k = (k * m - n) / k
+  | (rw [←Nat.add_mul_div_left] $[at $location]?) -- m / n + k = (m + n * k) / n
+  | (rw [←Nat.sub_mul_div] $[at $location]?) -- m / n - k = (m - n * k) / n
+  | (rw [Nat.add_div_of_dvd] $[at $location]?) -- m + n / k = (k * m + n) / k
+  | (rw [←Nat.mul_sub_div_of_dvd] $[at $location]?) -- m - n / k = (k * m - n) / k
   | (rw [Int.div_self] $[at $location]?) -- n / n = 1
   | (rw [Int.one_mul] $[at $location]?) -- 1 * n = n
   | (rw [Int.mul_one] $[at $location]?) -- 1 * n = n
@@ -143,14 +142,15 @@ macro_rules
   | (rw [EuclideanDomain.mul_div_cancel_left] $[at $location]?) -- a * b / a = b
   | (rw [EuclideanDomain.mul_div_mul_cancel] $[at $location]?) -- a * b / (a * c) = b / c
   | (rw [←EuclideanDomain.mul_div_assoc] $[at $location]?) -- x * (y / z) = x * y / z
+  | (rw [EuclideanDomain.div_mul_assoc] $[at $location]?) -- (x / y) * z = x * z * y
   | (rw [EuclideanDomain.div_div] $[at $location]?) -- x / y / z = x / (y * z)
+  | (rw [EuclideanDomain.div_div'] $[at $location]?) -- x / (y / z) = x * z / y
   | (rw [EuclideanDomain.div_add_div_of_dvd] $[at $location]?) -- x/y + z/t = (t*x + y*z)/(t*y)
   | (rw [EuclideanDomain.div_sub_div_of_dvd] $[at $location]?) -- x/y - z/t = (t*x - y*z)/(t*y)
   | (rw [←EuclideanDomain.add_mul_div_left] $[at $location]?) -- x / y + z = (x + y * z) / y
   | (rw [←EuclideanDomain.sub_mul_div_left] $[at $location]?) -- x / y - z = (x - y * z) / y
   | (rw [←EuclideanDomain.mul_add_div_left] $[at $location]?) -- x + y / z = (z * x + y) / z
-  | (rw [←EuclideanDomain.mul_sub_div_left] $[at $location]?) ) -- x - y / z = (z * x - y) / z
-----------------------------
+  | (rw [←EuclideanDomain.mul_sub_div_left] $[at $location]?)  -- x - y / z = (z * x - y) / z
   | (rw [mul_eq_zero] $[at $location]?) -- a * b = 0 ↔ a = 0 ∨ b = 0
   | (rw [eq_comm,mul_eq_zero] $[at $location]?) -- 0 = a * b ↔ a = 0 ∨ b = 0
   | (rw [div_eq_zero_iff] $[at $location]?) -- a / b = 0 ↔ a = 0 ∨ b = 0
@@ -182,4 +182,5 @@ macro_rules
   | (rw [Int.le_div_iff_of_dvd_of_pos] $[at $location]?) -- x ≤ y / z ↔ z * x ≤ y
   | (rw [Int.lt_div_iff_of_dvd_of_pos] $[at $location]?) -- x < y / z ↔ z * x < y
   | (push_neg $[at $location]?) )
-  try (any_goals assumption) ))
+  try (any_goals assumption)
+  try (any_goals omega)))

--- a/MathlibTest/unify_denoms.lean
+++ b/MathlibTest/unify_denoms.lean
@@ -1,0 +1,18 @@
+import Mathlib
+
+open BigOperators
+
+example (n : ℕ ) (h : 2 ∣ n * (n + 1)) : n * (n + 1) / 2 + n + 1 = (n + 1) * (n + 2) / 2 := by
+  unify_denoms
+  · ring
+  · exact Nat.succ_pos 1
+  · induction' n with m hm
+    · use 0
+    · cases' hm with x hx
+      rw [←Nat.add_one]
+      use x + m + 2
+      ring_nf at *
+      rw [←hx]
+      ring
+  · exact Nat.succ_pos 1
+  ·

--- a/MathlibTest/unify_denoms.lean
+++ b/MathlibTest/unify_denoms.lean
@@ -21,7 +21,7 @@ example (n : ℕ) : ∑ i ∈ Icc 0 n, i ^ 2   = (n  * (n + 1) * (2* n + 1)) / 6
     unify_denoms
     ring_nf
 
-example  (a b : ℤ ) (h : a ≠ b): (a ^ 3 - b ^ 3) / (a - b) = a ^ 2 + a * b + b ^ 2 := by
+example  (a b : ℤ ) (h : a ≠ b): (a ^  3 - b ^ 3) / (a - b) = a ^ 2 + a * b + b ^ 2 := by
   unify_denoms!
   ring
   use a ^ 2 + a * b + b ^ 2

--- a/MathlibTest/unify_denoms.lean
+++ b/MathlibTest/unify_denoms.lean
@@ -3,25 +3,27 @@ import Mathlib
 open BigOperators
 open Finset
 
-example (n : ℕ )  : n * (n + 1) / 2 + n + 1 = (n + 1) * (n + 2) / 2 := by
+example (n : ℕ ) : n * (n + 1) / 2 + n + 1 = (n + 1) * (n + 2) / 2 := by
   unify_denoms
   ring_nf
 
-example (n : ℕ) : ∑ i ∈ Icc 0 n, i  = (n * (n + 1)) / 2 := by
-  induction' n with n hn
-  · simp
-  · rw [Finset.sum_Icc_succ_top, hn]
+example (n : ℕ) : ∑ i ∈ Icc 0 n, i = (n * (n + 1)) / 2 := by
+  induction n with
+  | zero => simp
+  | succ n hn =>
+    rw [Finset.sum_Icc_succ_top, hn]
     unify_denoms
     ring_nf
 
-example (n : ℕ) : ∑ i ∈ Icc 0 n, i ^ 2   = (n  * (n + 1) * (2* n + 1)) / 6 := by
-  induction' n with n hn
-  · simp
-  · rw [Finset.sum_Icc_succ_top, hn]
+example (n : ℕ) : ∑ i ∈ Icc 0 n, i ^ 2 = (n * (n + 1) * (2* n + 1)) / 6 := by
+  induction n with
+  | zero => simp
+  |succ n hn =>
+    rw [Finset.sum_Icc_succ_top, hn]
     unify_denoms
     ring_nf
 
-example  (a b : ℤ ) (h : a ≠ b): (a ^  3 - b ^ 3) / (a - b) = a ^ 2 + a * b + b ^ 2 := by
+example (a b : ℤ ) (h : a ≠ b): (a ^ 3 - b ^ 3) / (a - b) = a ^ 2 + a * b + b ^ 2 := by
   unify_denoms!
   ring
   use a ^ 2 + a * b + b ^ 2

--- a/MathlibTest/unify_denoms.lean
+++ b/MathlibTest/unify_denoms.lean
@@ -1,18 +1,36 @@
 import Mathlib
 
 open BigOperators
+open Finset
 
-example (n : ℕ ) (h : 2 ∣ n * (n + 1)) : n * (n + 1) / 2 + n + 1 = (n + 1) * (n + 2) / 2 := by
+example (n : ℕ )  : n * (n + 1) / 2 + n + 1 = (n + 1) * (n + 2) / 2 := by
   unify_denoms
-  · ring
-  · exact Nat.succ_pos 1
-  · induction' n with m hm
-    · use 0
-    · cases' hm with x hx
-      rw [←Nat.add_one]
-      use x + m + 2
-      ring_nf at *
-      rw [←hx]
-      ring
-  · exact Nat.succ_pos 1
-  ·
+  ring_nf
+
+example (n : ℕ) : ∑ i ∈ Icc 0 n, i  = (n * (n + 1)) / 2 := by
+  induction' n with n hn
+  · simp
+  · rw [Finset.sum_Icc_succ_top, hn]
+    unify_denoms
+    ring_nf
+
+example (n : ℕ) : ∑ i ∈ Icc 0 n, i ^ 2   = (n  * (n + 1) * (2* n + 1)) / 6 := by
+  induction' n with n hn
+  · simp
+  · rw [Finset.sum_Icc_succ_top, hn]
+    unify_denoms
+    ring_nf
+
+example  (a b : ℤ ) (h : a ≠ b): (a ^ 3 - b ^ 3) / (a - b) = a ^ 2 + a * b + b ^ 2 := by
+  unify_denoms!
+  ring
+  use a ^ 2 + a * b + b ^ 2
+  ring
+
+example {T : Type} [EuclideanDomain T] (a b : T) (h : a ≠ b): (a ^ 2 - b ^ 2) / (a - b) = a + b := by
+  unify_denoms!
+  ring
+  rw [@sub_ne_zero]
+  exact h
+  use a + b
+  ring

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -214,6 +214,16 @@
   ["ProofWidgets.Component.OfRpcMethod"],
   "Mathlib.Tactic.Widget.CommDiag": ["Mathlib.CategoryTheory.Category.Basic"],
   "Mathlib.Tactic.Use": ["Batteries.Logic", "Mathlib.Tactic.WithoutCDot"],
+  "Mathlib.Tactic.UnifyDenoms":
+  ["Batteries.Data.Nat.Lemmas",
+   "Mathlib.Algebra.EuclideanDomain.Basic",
+   "Mathlib.Algebra.Field.Basic",
+   "Mathlib.Algebra.Group.Basic",
+   "Mathlib.Algebra.GroupWithZero.Units.Lemmas",
+   "Mathlib.Algebra.Order.Field.Basic",
+   "Mathlib.Data.Int.Order.Basic",
+   "Mathlib.Data.Int.Order.Lemmas",
+   "Mathlib.Data.Nat.Order.Lemmas"],
   "Mathlib.Tactic.TermCongr": ["Mathlib.Logic.Basic"],
   "Mathlib.Tactic.TautoSet":
   ["Mathlib.Data.Set.Disjoint", "Mathlib.Data.Set.SymmDiff"],
@@ -293,6 +303,13 @@
   "Mathlib.Tactic.Continuity": ["Mathlib.Tactic.Continuity.Init"],
   "Mathlib.Tactic.CongrM": ["Mathlib.Tactic.WithoutCDot"],
   "Mathlib.Tactic.CongrExclamation": ["Mathlib.Logic.Basic"],
+  "Mathlib.Tactic.CollectSigns":
+  ["Mathlib.Algebra.Field.Basic",
+   "Mathlib.Algebra.Group.Basic",
+   "Mathlib.Algebra.GroupWithZero.Units.Lemmas",
+   "Mathlib.Algebra.Order.Field.Basic",
+   "Mathlib.Algebra.Order.Group.Defs",
+   "Mathlib.Algebra.Order.Sub.Defs"],
   "Mathlib.Tactic.Choose": ["Mathlib.Logic.Function.Basic"],
   "Mathlib.Tactic.CategoryTheory.ToApp":
   ["Mathlib.CategoryTheory.Category.Cat"],


### PR DESCRIPTION
This PR adds four  new tactics: 

- `unify_denoms` tries to put expressions with several divisions in a form with only one division. In the case of fields, it works similarly to `field_simp`, but if the hypothesis about denominators being nonzero are not present, it assumes them, and leaves them as new goals to prove. In that sense, it is an "unsafe" tactic (but can be useful nevertheless, for example when you can't find which exact hypothesis is missing). It also works with expressions of naturals and Euclidean domains, assuming the corresponding hypothesis about the denominators dividing the numerators.

- `unify_denoms!` extends `unify_denoms` to work with (in)equalities, assuming also that the denominators, once in normal form, are positive.

- `collect_signs` works similarly with expressions using sums and substractions: it tries to put them in a form of one sum minus other sum. In the case of working with naturals, it assumes that we never substract a bigger number from a smaller one.

Both are implemented essentially as a macro that combines several rewriting rules. Some new lemmas with the corresponding rules are added.

---