### PR TITLE
[Merged by Bors] - feat: comparison isomorphism for the two homology APIs

### DIFF
--- a/Mathlib/Algebra/Homology/ShortComplex/Abelian.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Abelian.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 
+import Mathlib.Algebra.Homology.Homology
 import Mathlib.Algebra.Homology.ShortComplex.Homology
 import Mathlib.CategoryTheory.Abelian.Basic
 
@@ -180,5 +181,10 @@ noncomputable def HomologyData.ofAbelian : S.HomologyData where
 instance _root_.CategoryTheory.categoryWithHomology_of_abelian :
     CategoryWithHomology C where
   hasHomology S := HasHomology.mk' (HomologyData.ofAbelian S)
+
+/-- Comparison isomorphism between two definitions of homology. -/
+noncomputable def homology'IsoHomology :
+    _root_.homology' S.f S.g S.zero ≅ S.homology :=
+  homology'IsoCokernelLift S.f S.g S.zero ≪≫ S.homologyIsoCokernelLift.symm
 
 end ShortComplex

--- a/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 import Mathlib.Algebra.Homology.HomologicalComplex
-import Mathlib.Algebra.Homology.ShortComplex.Homology
+import Mathlib.Algebra.Homology.ShortComplex.Abelian
 
 /-!
 # The short complexes attached to homological complexes
@@ -71,6 +71,12 @@ variable [K.HasHomology i]
 
 /-- The homology in degree `i` of a homological complex. -/
 noncomputable def homology := (K.sc i).homology
+
+/-- Comparison isomorphism between the homology for the two homology API. -/
+noncomputable def homology'IsoHomology {A : Type*} [Category A] [Abelian A]
+    (K : HomologicalComplex A c) (i : ι) :
+    K.homology' i ≅ K.homology i :=
+  (K.sc i).homology'IsoHomology
 
 /-- The cycles in degree `i` of a homological complex. -/
 noncomputable def cycles := (K.sc i).cycles

--- a/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amelia Livingston
 -/
 import Mathlib.Algebra.Homology.Opposite
+import Mathlib.Algebra.Homology.ShortComplex.HomologicalComplex
 import Mathlib.RepresentationTheory.GroupCohomology.Resolution
 
 #align_import representation_theory.group_cohomology.basic from "leanprover-community/mathlib"@"cc5dd6244981976cc9da7afc4eee5682b037a013"
@@ -227,14 +228,15 @@ open groupCohomology
 /-- The group cohomology of a `k`-linear `G`-representation `A`, as the cohomology of its complex
 of inhomogeneous cochains. -/
 def groupCohomology [Group G] (A : Rep k G) (n : ℕ) : ModuleCat k :=
-  (inhomogeneousCochains A).homology' n
+  (inhomogeneousCochains A).homology n
 #align group_cohomology groupCohomology
 
 /-- The `n`th group cohomology of a `k`-linear `G`-representation `A` is isomorphic to
 `Extⁿ(k, A)` (taken in `Rep k G`), where `k` is a trivial `k`-linear `G`-representation. -/
 def groupCohomologyIsoExt [Group G] (A : Rep k G) (n : ℕ) :
     groupCohomology A n ≅ ((Ext k (Rep k G) n).obj (Opposite.op <| Rep.trivial k G k)).obj A :=
-  homologyObjIsoOfHomotopyEquiv (HomotopyEquiv.ofIso (inhomogeneousCochainsIso _)) _ ≪≫
+  ((inhomogeneousCochains A).homology'IsoHomology n).symm ≪≫
+    homologyObjIsoOfHomotopyEquiv (HomotopyEquiv.ofIso (inhomogeneousCochainsIso _)) _ ≪≫
     HomologicalComplex.homology'Unop _ _ ≪≫ (extIso k G A n).symm
 set_option linter.uppercaseLean3 false in
 #align group_cohomology_iso_Ext groupCohomologyIsoExt


### PR DESCRIPTION
This PR also changes the definition of group cohomology so as to use the new homology API. 

---

When the `ModuleCat` variant of #7966 is done, this will ease computations in (low degree) group cohomology.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
