### PR TITLE
[Merged by Bors] - chore(RingTheory/TensorProduct): missing trivial lemmas

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -308,10 +308,13 @@ protected def rid : M ⊗[R] R ≃ₗ[A] M :=
 theorem rid_eq_rid : AlgebraTensorModule.rid R R M = TensorProduct.rid R M :=
   LinearEquiv.toLinearMap_injective <| TensorProduct.ext' fun _ _ => rfl
 
-variable {R M}
-
+variable {R M} in
 @[simp]
 theorem rid_tmul (r : R) (m : M) : AlgebraTensorModule.rid R A M (m ⊗ₜ r) = r • m := rfl
+
+variable {M} in
+@[simp]
+theorem rid_symm_apply (m : M) : (AlgebraTensorModule.rid R A M).symm m = m ⊗ₜ 1 := rfl
 
 end Semiring
 

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -733,9 +733,14 @@ protected nonrec def lid : R ⊗[R] A ≃ₐ[R] A :=
 @[simp] theorem lid_toLinearEquiv :
     (TensorProduct.lid R A).toLinearEquiv = _root_.TensorProduct.lid R A := rfl
 
+variable {R} {A} in
 @[simp]
-theorem lid_tmul (r : R) (a : A) : (TensorProduct.lid R A : R ⊗ A → A) (r ⊗ₜ a) = r • a := rfl
+theorem lid_tmul (r : R) (a : A) : TensorProduct.lid R A (r ⊗ₜ a) = r • a := rfl
 #align algebra.tensor_product.lid_tmul Algebra.TensorProduct.lid_tmul
+
+variable {A} in
+@[simp]
+theorem lid_symm_apply (a : A) : (TensorProduct.lid R A).symm a = 1 ⊗ₜ a := rfl
 
 variable (S)
 
@@ -757,6 +762,9 @@ variable {R A} in
 theorem rid_tmul (r : R) (a : A) : TensorProduct.rid R S A (a ⊗ₜ r) = r • a := rfl
 #align algebra.tensor_product.rid_tmul Algebra.TensorProduct.rid_tmul
 
+variable {A} in
+@[simp]
+theorem rid_symm_apply (a : A) : (TensorProduct.rid R S A).symm a = a ⊗ₜ 1 := rfl
 
 section
 
@@ -771,11 +779,22 @@ protected def comm : A ⊗[R] B ≃ₐ[R] B ⊗[R] A :=
 @[simp] theorem comm_toLinearEquiv :
     (Algebra.TensorProduct.comm R A B).toLinearEquiv = _root_.TensorProduct.comm R A B := rfl
 
+variable {A B} in
 @[simp]
 theorem comm_tmul (a : A) (b : B) :
-    (TensorProduct.comm R A B : A ⊗[R] B → B ⊗[R] A) (a ⊗ₜ b) = b ⊗ₜ a :=
+    TensorProduct.comm R A B (a ⊗ₜ b) = b ⊗ₜ a :=
   rfl
 #align algebra.tensor_product.comm_tmul Algebra.TensorProduct.comm_tmul
+
+variable {A B} in
+@[simp]
+theorem comm_symm_tmul (a : A) (b : B) :
+    (TensorProduct.comm R A B).symm (b ⊗ₜ a) = a ⊗ₜ b :=
+  rfl
+
+theorem comm_symm :
+    (TensorProduct.comm R A B).symm = TensorProduct.comm R B A := by
+  ext; rfl
 
 theorem adjoin_tmul_eq_top : adjoin R { t : A ⊗[R] B | ∃ a b, a ⊗ₜ[R] b = t } = ⊤ :=
   top_le_iff.mp <| (top_le_iff.mpr <| span_tmul_eq_top R A B).trans (span_le_adjoin R _)
@@ -816,9 +835,14 @@ variable {A B C}
 
 @[simp]
 theorem assoc_tmul (a : A) (b : B) (c : C) :
-    Algebra.TensorProduct.assoc R A B C (a ⊗ₜ b ⊗ₜ c) = a ⊗ₜ (b ⊗ₜ c) :=
+    Algebra.TensorProduct.assoc R A B C ((a ⊗ₜ b) ⊗ₜ c) = a ⊗ₜ (b ⊗ₜ c) :=
   rfl
 #align algebra.tensor_product.assoc_tmul Algebra.TensorProduct.assoc_tmul
+
+@[simp]
+theorem assoc_symm_tmul (a : A) (b : B) (c : C) :
+    (Algebra.TensorProduct.assoc R A B C).symm (a ⊗ₜ (b ⊗ₜ c)) = (a ⊗ₜ b) ⊗ₜ c :=
+  rfl
 
 end
 


### PR DESCRIPTION
This also tweaks some argument explicitness, and removes unnecessary type ascriptions

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
