### PR TITLE
[Merged by Bors] - feat: `CompHaus` and friends are preregular

### DIFF
--- a/Mathlib/CategoryTheory/Sites/EffectiveEpimorphic.lean
+++ b/Mathlib/CategoryTheory/Sites/EffectiveEpimorphic.lean
@@ -540,6 +540,14 @@ instance {B : C} {α : Type*} (X : α → C) (π : (a : α) → (X a ⟶ B)) [Ha
     [IsIso (Sigma.desc π)] : EffectiveEpiFamily X π :=
   ⟨⟨EffectiveEpiFamilyStruct_of_isIso_desc X π⟩⟩
 
+/-- The identity is an effective epi. -/
+def EffectiveEpiStructId {X : C} : EffectiveEpiStruct (𝟙 X) where
+  desc e _ := e
+  fac _ _ := by simp only [Category.id_comp]
+  uniq _ _ _ h := by simp only [Category.id_comp] at h; exact h
+
+instance {X : C} : EffectiveEpi (𝟙 X) := ⟨⟨EffectiveEpiStructId⟩⟩
+
 end instances
 
 section Epi

--- a/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
 
-import Mathlib.CategoryTheory.Sites.Coherent
+import Mathlib.CategoryTheory.Sites.RegularExtensive
 import Mathlib.Topology.Category.CompHaus.Limits
 
 /-!
@@ -18,7 +18,7 @@ In this file, we show that the following are all equivalent:
 - The family `π` is jointly surjective.
 This is the main result of this file, which can be found in `CompHaus.effectiveEpiFamily_tfae`
 
-As a consequence, we also show that `CompHaus` is precoherent.
+As a consequence, we also show that `CompHaus` is precoherent and preregular.
 
 # Projects
 
@@ -246,5 +246,14 @@ lemma effectiveEpi_iff_surjective {X Y : CompHaus} (f : X ⟶ Y) :
     EffectiveEpi f ↔ Function.Surjective f := by
   rw [← epi_iff_surjective]
   exact effectiveEpi_iff_epi (fun _ _ ↦ (effectiveEpiFamily_tfae _ _).out 0 1) f
+
+instance : Preregular CompHaus where
+  exists_fac := by
+    intro X Y Z f π hπ
+    refine ⟨pullback f π, pullback.fst f π, ?_, pullback.snd f π, (pullback.condition _ _).symm⟩
+    rw [CompHaus.effectiveEpi_iff_surjective] at hπ ⊢
+    intro y
+    obtain ⟨z,hz⟩ := hπ (f y)
+    exact ⟨⟨(y, z), hz.symm⟩, rfl⟩
 
 end CompHaus

--- a/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
@@ -192,6 +192,7 @@ theorem effectiveEpiFamily_of_jointly_surjective
 
 open EffectiveEpiFamily
 
+-- TODO: prove this for `Type*`
 open List in
 theorem effectiveEpiFamily_tfae
     {α : Type} [Fintype α] {B : CompHaus.{u}}

--- a/Mathlib/Topology/Category/Profinite/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/Profinite/EffectiveEpi.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Jon Eugster. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson, Boris Bolvig Kjær, Jon Eugster, Sina Hazratpour
 -/
-import Mathlib.CategoryTheory.Sites.Coherent
+import Mathlib.CategoryTheory.Sites.RegularExtensive
 import Mathlib.Topology.Category.Profinite.Limits
 
 /-!
@@ -14,6 +14,9 @@ In this file, we show that the following are all equivalent:
 - The family `π` is effective epimorphic.
 - The induced map `∐ X ⟶ B` is epimorphic.
 - The family `π` is jointly surjective.
+
+As a consequence, we show (see `effectiveEpi_iff_surjective`) that all epimorphisms in `Profinite` 
+are effective, and that `Profinite` is preregular.
 
 ## Main results
 
@@ -268,6 +271,15 @@ lemma effectiveEpi_iff_surjective {X Y : Profinite} (f : X ⟶ Y) :
     EffectiveEpi f ↔ Function.Surjective f := by
   rw [← epi_iff_surjective]
   exact effectiveEpi_iff_epi (fun _ _ ↦ (effectiveEpiFamily_tfae _ _).out 0 1) f
+
+instance : Preregular Profinite where
+  exists_fac := by
+    intro X Y Z f π hπ
+    refine ⟨pullback f π, pullback.fst f π, ?_, pullback.snd f π, (pullback.condition _ _).symm⟩
+    rw [Profinite.effectiveEpi_iff_surjective] at hπ ⊢
+    intro y
+    obtain ⟨z,hz⟩ := hπ (f y)
+    exact ⟨⟨(y, z), hz.symm⟩, rfl⟩
 
 end JointlySurjective
 

--- a/Mathlib/Topology/Category/Stonean/Basic.lean
+++ b/Mathlib/Topology/Category/Stonean/Basic.lean
@@ -240,6 +240,17 @@ instance (X : Stonean) : Projective (toProfinite.obj X) where
     ext
     exact congr_fun h.right _
 
+/-- Every Stonean space is projective in `Stonean`. -/
+instance (X : Stonean) : Projective X where
+  factors := by
+    intro B C φ f _
+    haveI : ExtremallyDisconnected X.compHaus.toTop := X.extrDisc
+    have hf : Function.Surjective f := by rwa [← Stonean.epi_iff_surjective]
+    obtain ⟨f', h⟩ := CompactT2.ExtremallyDisconnected.projective φ.continuous f.continuous hf
+    use ⟨f', h.left⟩
+    ext
+    exact congr_fun h.right _
+
 end Stonean
 
 namespace CompHaus

--- a/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
@@ -15,6 +15,9 @@ In this file, we show that the following are all equivalent:
 - The induced map `∐ X ⟶ B` is epimorphic.
 - The family `π` is jointly surjective.
 
+As a consequence, we show (see `effectiveEpi_iff_surjective`) that all epimorphisms in `Stonean` 
+are effective, and that `Stonean` is preregular.
+
 ## Main results
 - `Stonean.effectiveEpiFamily_tfae`: characterise being an effective epimorphic family.
 - `Stonean.instPrecoherent`: `Stonean` is precoherent.
@@ -169,6 +172,11 @@ lemma effectiveEpi_iff_surjective {X Y : Stonean} (f : X ⟶ Y) :
     EffectiveEpi f ↔ Function.Surjective f := by
   rw [← epi_iff_surjective]
   exact effectiveEpi_iff_epi (fun _ _ ↦ (effectiveEpiFamily_tfae _ _).out 0 1) f
+
+instance : Preregular Stonean where
+  exists_fac := by
+    intro X Y Z f π hπ
+    exact ⟨X, 𝟙 X, inferInstance, Projective.factors f π⟩
 
 end JointlySurjective
 


### PR DESCRIPTION
We prove that `CompHaus`, `Profinite` and `Stonean` are preregular (that effective epis can be pulled back).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
