### PR TITLE
[Merged by Bors] - chore: fix universe issue in FinitaryExtensive Stonean

### DIFF
--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -323,15 +323,19 @@ instance : HasPullbacksOfInclusions Stonean where
     apply Stonean.Sigma.openEmbedding_ι
 
 noncomputable
-instance : PreservesPullbacksOfInclusions Stonean.toCompHaus where
+instance : PreservesPullbacksOfInclusions Stonean.toCompHaus.{u} where
   preservesPullbackInl := by
     intros X Y Z f
     apply (config := { allowSynthFailures := true }) preservesPullbackSymmetry
     have : OpenEmbedding (coprod.inl : X ⟶ X ⨿ Y) := Stonean.Sigma.openEmbedding_ι _ _
     have := Stonean.createsPullbacksOfOpenEmbedding f this
-    apply preservesLimitOfReflectsOfPreserves Stonean.toCompHaus compHausToTop
+    refine @preservesLimitOfReflectsOfPreserves _ _ _ _ _ _ _ _ _ Stonean.toCompHaus
+      compHausToTop inferInstance ?_
+    apply (config := { allowSynthFailures := true }) ReflectsLimitsOfShape.reflectsLimit
+    apply (config := { allowSynthFailures := true }) ReflectsLimitsOfSize.reflectsLimitsOfShape
+    exact reflectsLimitsOfSizeShrink _
 
-instance : FinitaryExtensive Stonean :=
+instance : FinitaryExtensive Stonean.{u} :=
   have := fullyFaithfulReflectsLimits Stonean.toCompHaus
   have := fullyFaithfulReflectsColimits Stonean.toCompHaus
   finitaryExtensive_of_preserves_and_reflects Stonean.toCompHaus


### PR DESCRIPTION
Now `Stonean.{u}` is finitary extensive for any universe `u`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
