### PR TITLE
[Merged by Bors] - fix: remove `++` in `throwError` in favor of {""}

### DIFF
--- a/Mathlib/Tactic/Cases.lean
+++ b/Mathlib/Tactic/Cases.lean
@@ -75,11 +75,11 @@ elab (name := induction') "induction' " tgts:(Parser.Tactic.casesTarget,+)
       let mut s ← getFVarSetToGeneralize targets forbidden
       for v in genArgs do
         if forbidden.contains v then
-          throwError ("variable cannot be generalized " ++
-            "because target depends on it{indentExpr (mkFVar v)}")
+          throwError "variable cannot be generalized {""
+            }because target depends on it{indentExpr (mkFVar v)}"
         if s.contains v then
-          throwError ("unnecessary 'generalizing' argument, " ++
-            "variable '{mkFVar v}' is generalized automatically")
+          throwError "unnecessary 'generalizing' argument, {""
+            }variable '{mkFVar v}' is generalized automatically"
         s := s.insert v
       let (fvarIds, g) ← g.revert (← sortFVarIds s.toArray)
       g.withContext do


### PR DESCRIPTION
This correctly interpolates the error messages
in the `cases'` tactic.

Reported at:
https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/uninterpolated.20error.20message.3A.20unecessary.20generalizing/near/400018518


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
