### PR TITLE
[Merged by Bors] - feat: (co)limits in FintypeCat

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1035,6 +1035,7 @@ import Mathlib.CategoryTheory.Limits.Filtered
 import Mathlib.CategoryTheory.Limits.FilteredColimitCommutesFiniteLimit
 import Mathlib.CategoryTheory.Limits.Final
 import Mathlib.CategoryTheory.Limits.FinallySmall
+import Mathlib.CategoryTheory.Limits.FintypeCat
 import Mathlib.CategoryTheory.Limits.Fubini
 import Mathlib.CategoryTheory.Limits.FullSubcategory
 import Mathlib.CategoryTheory.Limits.FunctorCategory

--- a/Mathlib/CategoryTheory/Limits/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/Limits/FintypeCat.lean
@@ -21,6 +21,8 @@ open CategoryTheory Limits Functor
 
 namespace CategoryTheory.Limits.FintypeCat
 
+/-- Any functor from a finite category to Types that only involves finite objects,
+has a finite limit. -/
 noncomputable def finiteLimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J]
     (K : J ⥤ Type*) (_ : (j : J) → Finite (K.obj j)) : Fintype (limit K) := by
   have : Fintype (sections K) := Fintype.ofFinite ↑(sections K)
@@ -49,6 +51,8 @@ noncomputable instance inclusionPreservesFiniteLimits :
   preservesFiniteLimits _ :=
     preservesLimitOfShapeOfCreatesLimitsOfShapeAndHasLimitsOfShape FintypeCat.incl
 
+/-- Any functor from a finite category to Types that only involves finite objects,
+has a finite colimit. -/
 noncomputable def finiteColimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J]
     (K : J ⥤ Type*) (_ : (j : J) → Finite (K.obj j)) : Fintype (colimit K) := by
   have : Finite (Types.Quot K) := Quot.finite (Types.Quot.Rel K)

--- a/Mathlib/CategoryTheory/Limits/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/Limits/FintypeCat.lean
@@ -37,10 +37,8 @@ noncomputable instance finiteLimitOfFiniteDiagram {J : Type} [SmallCategory J] [
 
 noncomputable instance inclusionCreatesFiniteLimits {J : Type} [SmallCategory J] [FinCategory J] :
     CreatesLimitsOfShape J FintypeCat.incl.{u} where
-  CreatesLimit := by
-    intro K
-    exact createsLimitOfFullyFaithfulOfIso (FintypeCat.of <| limit <| K ⋙ FintypeCat.incl)
-      (Iso.refl _)
+  CreatesLimit {K} := createsLimitOfFullyFaithfulOfIso
+    (FintypeCat.of <| limit <| K ⋙ FintypeCat.incl) (Iso.refl _)
 
 instance {J : Type} [SmallCategory J] [FinCategory J] : HasLimitsOfShape J FintypeCat.{u} where
   has_limit F := hasLimit_of_created F FintypeCat.incl
@@ -63,10 +61,8 @@ noncomputable instance finiteColimitOfFiniteDiagram {J : Type} [SmallCategory J]
 
 noncomputable instance inclusionCreatesFiniteColimits {J : Type} [SmallCategory J] [FinCategory J] :
     CreatesColimitsOfShape J FintypeCat.incl.{u} where
-  CreatesColimit := by
-    intro K
-    exact createsColimitOfFullyFaithfulOfIso (FintypeCat.of <| colimit <| K ⋙ FintypeCat.incl)
-      (Iso.refl _)
+  CreatesColimit {K} := createsColimitOfFullyFaithfulOfIso
+    (FintypeCat.of <| colimit <| K ⋙ FintypeCat.incl) (Iso.refl _)
 
 instance {J : Type} [SmallCategory J] [FinCategory J] : HasColimitsOfShape J FintypeCat.{u} where
   has_colimit F := hasColimit_of_created F FintypeCat.incl

--- a/Mathlib/CategoryTheory/Limits/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/Limits/FintypeCat.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2023 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Christian Merten
+-/
+import Mathlib.CategoryTheory.FintypeCat
+import Mathlib.CategoryTheory.Limits.Shapes.FiniteLimits
+import Mathlib.CategoryTheory.Limits.Types
+import Mathlib.CategoryTheory.Limits.Creates
+import Mathlib.CategoryTheory.Limits.Preserves.Finite
+import Mathlib.Data.FunLike.Fintype
+
+/-!
+# (Co)limits in the category of finite types
+
+We show that finite (co)limits exist in `FintypeCat` and that they are preserved by the natural
+inclusion `FintypeCat.incl`.
+-/
+
+open CategoryTheory Limits Functor
+
+instance {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ Type*)
+    (_ : (j : J) → Finite (K.obj j)) : Finite ((j : J) → K.obj j) :=
+  Pi.finite
+
+instance {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ Type*)
+    (_ : (j : J) → Finite (K.obj j)) : Finite (sections K) :=
+  inferInstance
+
+lemma finiteLimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ Type*)
+    (_ : (j : J) → Finite (K.obj j)) : Fintype (limit K) := by
+  have : Fintype (sections K) := Fintype.ofFinite ↑(sections K)
+  exact Fintype.ofEquiv (sections K) (Types.limitEquivSections K).symm
+
+noncomputable instance inclusionCreatesFiniteLimits {J : Type} [SmallCategory J] [FinCategory J]
+    : CreatesLimitsOfShape J FintypeCat.incl where
+  CreatesLimit := by
+    intro K
+    have : Fintype (limit (K ⋙ FintypeCat.incl)) := by
+      apply finiteLimitOfFiniteDiagram (K ⋙ FintypeCat.incl)
+      intro j
+      simp only [comp_obj, FintypeCat.incl_obj]
+      exact inferInstance
+    exact createsLimitOfFullyFaithfulOfIso (FintypeCat.of <| limit <| K ⋙ FintypeCat.incl)
+      (eqToIso rfl)
+
+instance {J : Type} [SmallCategory J] [FinCategory J] : HasLimitsOfShape J FintypeCat where
+  has_limit F := hasLimit_of_created F FintypeCat.incl
+
+instance hasFiniteLimits : HasFiniteLimits FintypeCat where
+  out _ := inferInstance
+
+noncomputable instance inclusionPreservesFiniteLimits :
+    PreservesFiniteLimits FintypeCat.incl where
+  preservesFiniteLimits _ :=
+    preservesLimitOfShapeOfCreatesLimitsOfShapeAndHasLimitsOfShape FintypeCat.incl
+
+lemma finiteColimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ Type*)
+    (_ : (j : J) → Finite (K.obj j)) : Fintype (colimit K) := by
+  have : Finite (Types.Quot K) := Quot.finite (Types.Quot.Rel K)
+  have : Fintype (Types.Quot K) := Fintype.ofFinite (Types.Quot K) 
+  exact Fintype.ofEquiv (Types.Quot K) (Types.colimitEquivQuot K).symm
+
+noncomputable instance inclusionCreatesFiniteColimits {J : Type} [SmallCategory J] [FinCategory J] :
+    CreatesColimitsOfShape J FintypeCat.incl where
+  CreatesColimit := by
+    intro K
+    have : Fintype (colimit (K ⋙ FintypeCat.incl)) := by
+      apply finiteColimitOfFiniteDiagram (K ⋙ FintypeCat.incl)
+      intro j
+      simp
+      exact inferInstance
+    exact createsColimitOfFullyFaithfulOfIso (FintypeCat.of <| colimit <| K ⋙ FintypeCat.incl)
+      (eqToIso rfl)
+
+instance {J : Type} [SmallCategory J] [FinCategory J] : HasColimitsOfShape J FintypeCat where
+  has_colimit F := hasColimit_of_created F FintypeCat.incl
+
+instance hasFiniteColimits : HasFiniteColimits FintypeCat where
+  out _ := inferInstance
+
+noncomputable instance inclusionPreservesFiniteColimits :
+    PreservesFiniteColimits FintypeCat.incl where
+  preservesFiniteColimits _ :=
+    preservesColimitOfShapeOfCreatesColimitsOfShapeAndHasColimitsOfShape FintypeCat.incl

--- a/Mathlib/CategoryTheory/Limits/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/Limits/FintypeCat.lean
@@ -21,8 +21,8 @@ open CategoryTheory Limits Functor
 
 namespace CategoryTheory.Limits.FintypeCat
 
-noncomputable def finiteLimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ Type*)
-    (_ : (j : J) → Finite (K.obj j)) : Fintype (limit K) := by
+noncomputable def finiteLimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J]
+    (K : J ⥤ Type*) (_ : (j : J) → Finite (K.obj j)) : Fintype (limit K) := by
   have : Fintype (sections K) := Fintype.ofFinite ↑(sections K)
   exact Fintype.ofEquiv (sections K) (Types.limitEquivSections K).symm
 
@@ -49,8 +49,8 @@ noncomputable instance inclusionPreservesFiniteLimits :
   preservesFiniteLimits _ :=
     preservesLimitOfShapeOfCreatesLimitsOfShapeAndHasLimitsOfShape FintypeCat.incl
 
-noncomputable def finiteColimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ Type*)
-    (_ : (j : J) → Finite (K.obj j)) : Fintype (colimit K) := by
+noncomputable def finiteColimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J]
+    (K : J ⥤ Type*) (_ : (j : J) → Finite (K.obj j)) : Fintype (colimit K) := by
   have : Finite (Types.Quot K) := Quot.finite (Types.Quot.Rel K)
   have : Fintype (Types.Quot K) := Fintype.ofFinite (Types.Quot K)
   exact Fintype.ofEquiv (Types.Quot K) (Types.colimitEquivQuot K).symm

--- a/Mathlib/CategoryTheory/Limits/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/Limits/FintypeCat.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Christian Merten
+Authors: Christian Merten
 -/
 import Mathlib.CategoryTheory.FintypeCat
 import Mathlib.CategoryTheory.Limits.Shapes.FiniteLimits
@@ -19,21 +19,15 @@ inclusion `FintypeCat.incl`.
 
 open CategoryTheory Limits Functor
 
-instance {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ Type*)
-    (_ : (j : J) → Finite (K.obj j)) : Finite ((j : J) → K.obj j) :=
-  Pi.finite
+namespace CategoryTheory.Limits.FintypeCat
 
-instance {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ Type*)
-    (_ : (j : J) → Finite (K.obj j)) : Finite (sections K) :=
-  inferInstance
-
-lemma finiteLimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ Type*)
+noncomputable def finiteLimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ Type*)
     (_ : (j : J) → Finite (K.obj j)) : Fintype (limit K) := by
   have : Fintype (sections K) := Fintype.ofFinite ↑(sections K)
   exact Fintype.ofEquiv (sections K) (Types.limitEquivSections K).symm
 
-noncomputable instance inclusionCreatesFiniteLimits {J : Type} [SmallCategory J] [FinCategory J]
-    : CreatesLimitsOfShape J FintypeCat.incl where
+noncomputable instance inclusionCreatesFiniteLimits {J : Type} [SmallCategory J] [FinCategory J] :
+    CreatesLimitsOfShape J FintypeCat.incl where
   CreatesLimit := by
     intro K
     have : Fintype (limit (K ⋙ FintypeCat.incl)) := by
@@ -55,10 +49,10 @@ noncomputable instance inclusionPreservesFiniteLimits :
   preservesFiniteLimits _ :=
     preservesLimitOfShapeOfCreatesLimitsOfShapeAndHasLimitsOfShape FintypeCat.incl
 
-lemma finiteColimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ Type*)
+noncomputable def finiteColimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ Type*)
     (_ : (j : J) → Finite (K.obj j)) : Fintype (colimit K) := by
   have : Finite (Types.Quot K) := Quot.finite (Types.Quot.Rel K)
-  have : Fintype (Types.Quot K) := Fintype.ofFinite (Types.Quot K) 
+  have : Fintype (Types.Quot K) := Fintype.ofFinite (Types.Quot K)
   exact Fintype.ofEquiv (Types.Quot K) (Types.colimitEquivQuot K).symm
 
 noncomputable instance inclusionCreatesFiniteColimits {J : Type} [SmallCategory J] [FinCategory J] :
@@ -83,3 +77,5 @@ noncomputable instance inclusionPreservesFiniteColimits :
     PreservesFiniteColimits FintypeCat.incl where
   preservesFiniteColimits _ :=
     preservesColimitOfShapeOfCreatesColimitsOfShapeAndHasColimitsOfShape FintypeCat.incl
+
+end CategoryTheory.Limits.FintypeCat

--- a/Mathlib/CategoryTheory/Limits/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/Limits/FintypeCat.lean
@@ -19,6 +19,8 @@ inclusion `FintypeCat.incl`.
 
 open CategoryTheory Limits Functor
 
+universe u
+
 namespace CategoryTheory.Limits.FintypeCat
 
 /-- Any functor from a finite category to Types that only involves finite objects,
@@ -29,10 +31,10 @@ noncomputable def finiteLimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCa
   exact Fintype.ofEquiv (sections K) (Types.limitEquivSections K).symm
 
 noncomputable instance inclusionCreatesFiniteLimits {J : Type} [SmallCategory J] [FinCategory J] :
-    CreatesLimitsOfShape J FintypeCat.incl where
+    CreatesLimitsOfShape J FintypeCat.incl.{u} where
   CreatesLimit := by
     intro K
-    have : Fintype (limit (K ⋙ FintypeCat.incl)) := by
+    have : Fintype (limit (K ⋙ FintypeCat.incl.{u})) := by
       apply finiteLimitOfFiniteDiagram (K ⋙ FintypeCat.incl)
       intro j
       simp only [comp_obj, FintypeCat.incl_obj]
@@ -40,14 +42,14 @@ noncomputable instance inclusionCreatesFiniteLimits {J : Type} [SmallCategory J]
     exact createsLimitOfFullyFaithfulOfIso (FintypeCat.of <| limit <| K ⋙ FintypeCat.incl)
       (eqToIso rfl)
 
-instance {J : Type} [SmallCategory J] [FinCategory J] : HasLimitsOfShape J FintypeCat where
+instance {J : Type} [SmallCategory J] [FinCategory J] : HasLimitsOfShape J FintypeCat.{u} where
   has_limit F := hasLimit_of_created F FintypeCat.incl
 
-instance hasFiniteLimits : HasFiniteLimits FintypeCat where
+instance hasFiniteLimits : HasFiniteLimits FintypeCat.{u} where
   out _ := inferInstance
 
 noncomputable instance inclusionPreservesFiniteLimits :
-    PreservesFiniteLimits FintypeCat.incl where
+    PreservesFiniteLimits FintypeCat.incl.{u} where
   preservesFiniteLimits _ :=
     preservesLimitOfShapeOfCreatesLimitsOfShapeAndHasLimitsOfShape FintypeCat.incl
 
@@ -60,7 +62,7 @@ noncomputable def finiteColimitOfFiniteDiagram {J : Type} [SmallCategory J] [Fin
   exact Fintype.ofEquiv (Types.Quot K) (Types.colimitEquivQuot K).symm
 
 noncomputable instance inclusionCreatesFiniteColimits {J : Type} [SmallCategory J] [FinCategory J] :
-    CreatesColimitsOfShape J FintypeCat.incl where
+    CreatesColimitsOfShape J FintypeCat.incl.{u} where
   CreatesColimit := by
     intro K
     have : Fintype (colimit (K ⋙ FintypeCat.incl)) := by
@@ -71,14 +73,14 @@ noncomputable instance inclusionCreatesFiniteColimits {J : Type} [SmallCategory 
     exact createsColimitOfFullyFaithfulOfIso (FintypeCat.of <| colimit <| K ⋙ FintypeCat.incl)
       (eqToIso rfl)
 
-instance {J : Type} [SmallCategory J] [FinCategory J] : HasColimitsOfShape J FintypeCat where
+instance {J : Type} [SmallCategory J] [FinCategory J] : HasColimitsOfShape J FintypeCat.{u} where
   has_colimit F := hasColimit_of_created F FintypeCat.incl
 
-instance hasFiniteColimits : HasFiniteColimits FintypeCat where
+instance hasFiniteColimits : HasFiniteColimits FintypeCat.{u} where
   out _ := inferInstance
 
 noncomputable instance inclusionPreservesFiniteColimits :
-    PreservesFiniteColimits FintypeCat.incl where
+    PreservesFiniteColimits FintypeCat.incl.{u} where
   preservesFiniteColimits _ :=
     preservesColimitOfShapeOfCreatesColimitsOfShapeAndHasColimitsOfShape FintypeCat.incl
 

--- a/Mathlib/CategoryTheory/Limits/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/Limits/FintypeCat.lean
@@ -24,9 +24,9 @@ universe u
 namespace CategoryTheory.Limits.FintypeCat
 
 instance {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ FintypeCat.{u}) (j : J) :
-  Finite ((K ⋙ FintypeCat.incl.{u}).obj j) := by
-    simp only [comp_obj, FintypeCat.incl_obj]
-    exact inferInstance
+    Finite ((K ⋙ FintypeCat.incl.{u}).obj j) := by
+  simp only [comp_obj, FintypeCat.incl_obj]
+  infer_instance
 
 /-- Any functor from a finite category to Types that only involves finite objects,
 has a finite limit. -/

--- a/Mathlib/CategoryTheory/Limits/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/Limits/FintypeCat.lean
@@ -23,24 +23,24 @@ universe u
 
 namespace CategoryTheory.Limits.FintypeCat
 
+instance {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ FintypeCat.{u}) (j : J) :
+  Finite ((K ⋙ FintypeCat.incl.{u}).obj j) := by
+    simp only [comp_obj, FintypeCat.incl_obj]
+    exact inferInstance
+
 /-- Any functor from a finite category to Types that only involves finite objects,
 has a finite limit. -/
-noncomputable def finiteLimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J]
-    (K : J ⥤ Type*) (_ : (j : J) → Finite (K.obj j)) : Fintype (limit K) := by
-  have : Fintype (sections K) := Fintype.ofFinite ↑(sections K)
+noncomputable instance finiteLimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J]
+    (K : J ⥤ Type*) [∀ j, Finite (K.obj j)] : Fintype (limit K) := by
+  have : Fintype (sections K) := Fintype.ofFinite (sections K)
   exact Fintype.ofEquiv (sections K) (Types.limitEquivSections K).symm
 
 noncomputable instance inclusionCreatesFiniteLimits {J : Type} [SmallCategory J] [FinCategory J] :
     CreatesLimitsOfShape J FintypeCat.incl.{u} where
   CreatesLimit := by
     intro K
-    have : Fintype (limit (K ⋙ FintypeCat.incl.{u})) := by
-      apply finiteLimitOfFiniteDiagram (K ⋙ FintypeCat.incl)
-      intro j
-      simp only [comp_obj, FintypeCat.incl_obj]
-      exact inferInstance
     exact createsLimitOfFullyFaithfulOfIso (FintypeCat.of <| limit <| K ⋙ FintypeCat.incl)
-      (eqToIso rfl)
+      (Iso.refl _)
 
 instance {J : Type} [SmallCategory J] [FinCategory J] : HasLimitsOfShape J FintypeCat.{u} where
   has_limit F := hasLimit_of_created F FintypeCat.incl
@@ -55,8 +55,8 @@ noncomputable instance inclusionPreservesFiniteLimits :
 
 /-- Any functor from a finite category to Types that only involves finite objects,
 has a finite colimit. -/
-noncomputable def finiteColimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J]
-    (K : J ⥤ Type*) (_ : (j : J) → Finite (K.obj j)) : Fintype (colimit K) := by
+noncomputable instance finiteColimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J]
+    (K : J ⥤ Type*) [∀ j, Finite (K.obj j)] : Fintype (colimit K) := by
   have : Finite (Types.Quot K) := Quot.finite (Types.Quot.Rel K)
   have : Fintype (Types.Quot K) := Fintype.ofFinite (Types.Quot K)
   exact Fintype.ofEquiv (Types.Quot K) (Types.colimitEquivQuot K).symm
@@ -65,13 +65,8 @@ noncomputable instance inclusionCreatesFiniteColimits {J : Type} [SmallCategory 
     CreatesColimitsOfShape J FintypeCat.incl.{u} where
   CreatesColimit := by
     intro K
-    have : Fintype (colimit (K ⋙ FintypeCat.incl)) := by
-      apply finiteColimitOfFiniteDiagram (K ⋙ FintypeCat.incl)
-      intro j
-      simp
-      exact inferInstance
     exact createsColimitOfFullyFaithfulOfIso (FintypeCat.of <| colimit <| K ⋙ FintypeCat.incl)
-      (eqToIso rfl)
+      (Iso.refl _)
 
 instance {J : Type} [SmallCategory J] [FinCategory J] : HasColimitsOfShape J FintypeCat.{u} where
   has_colimit F := hasColimit_of_created F FintypeCat.incl


### PR DESCRIPTION
Shows that (co)limits exist in `FintypeCat` and that they are created and preserved by `FintypeCat.incl`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
