### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Products): opposite of product of categories

### DIFF
--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -5,6 +5,7 @@ Authors: Stephen Morgan, Scott Morrison
 -/
 import Mathlib.CategoryTheory.EqToHom
 import Mathlib.CategoryTheory.Functor.Const
+import Mathlib.CategoryTheory.Opposites
 import Mathlib.Data.Prod.Basic
 
 #align_import category_theory.products.basic from "leanprover-community/mathlib"@"dc6c365e751e34d100e80fe6e314c3c3e0fd2988"
@@ -351,5 +352,26 @@ def functorProdFunctorEquiv : (A ⥤ B) × (A ⥤ C) ≌ A ⥤ B × C :=
     unitIso := functorProdFunctorEquivUnitIso A B C,
     counitIso := functorProdFunctorEquivCounitIso A B C, }
 #align category_theory.functor_prod_functor_equiv CategoryTheory.functorProdFunctorEquiv
+
+section Opposite
+
+open Opposite
+
+/-- The equivalence between the opposite of a product and the product of the opposites. -/
+@[simps]
+def prodOp : (C × D)ᵒᵖ ≌ Cᵒᵖ × Dᵒᵖ where
+  functor :=
+    { obj := λ X => ⟨op X.unop.1, op X.unop.2⟩,
+      map := λ f => ⟨f.unop.1.op, f.unop.2.op⟩ }
+  inverse :=
+    {
+      obj := λ ⟨X,Y⟩ => op ⟨X.unop, Y.unop⟩,
+      map := λ ⟨f,g⟩ => op ⟨f.unop, g.unop⟩ }
+  unitIso := by aesop_cat
+  counitIso := by aesop_cat
+  functor_unitIso_comp := λ ⟨⟨X,Y⟩⟩ => by
+    simp; rw[Category.id_comp (𝟙 (op X)),Category.id_comp (𝟙 (op Y))]; simp
+
+end Opposite
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -359,18 +359,18 @@ open Opposite
 
 /-- The equivalence between the opposite of a product and the product of the opposites. -/
 @[simps]
-def prodOp : (C × D)ᵒᵖ ≌ Cᵒᵖ × Dᵒᵖ where
+def prodOpEquiv : (C × D)ᵒᵖ ≌ Cᵒᵖ × Dᵒᵖ where
   functor :=
     { obj := λ X => ⟨op X.unop.1, op X.unop.2⟩,
       map := λ f => ⟨f.unop.1.op, f.unop.2.op⟩ }
   inverse :=
-    {
-      obj := λ ⟨X,Y⟩ => op ⟨X.unop, Y.unop⟩,
+    { obj := λ ⟨X,Y⟩ => op ⟨X.unop, Y.unop⟩,
       map := λ ⟨f,g⟩ => op ⟨f.unop, g.unop⟩ }
-  unitIso := by aesop_cat
-  counitIso := by aesop_cat
-  functor_unitIso_comp := λ ⟨⟨X,Y⟩⟩ => by
-    simp; rw[Category.id_comp (𝟙 (op X)),Category.id_comp (𝟙 (op Y))]; simp
+  unitIso := Iso.refl _
+  counitIso := Iso.refl _
+  functor_unitIso_comp := fun ⟨X, Y⟩ => by
+    dsimp
+    ext <;> simpa using Category.id_comp _
 
 end Opposite
 


### PR DESCRIPTION
Equivalence between the opposite of a product of categories and the product of the opposites.

---

This equivalence was missing, I thought it would be a good idea to add it to `Product` rather than `Opposites` to avoid possible dependency cycles...

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
