### PR TITLE
[Merged by Bors] - chore (NumberTheory/ZetaFunction): fix typo

### DIFF
--- a/Mathlib/NumberTheory/ZetaFunction.lean
+++ b/Mathlib/NumberTheory/ZetaFunction.lean
@@ -30,7 +30,7 @@ I haven't checked exactly what they are).
 * `differentiableAt_completed_zeta` : the function `Λ(s)` is differentiable away from `s = 0` and
   `s = 1`.
 * `differentiableAt_riemannZeta` : the function `ζ(s)` is differentiable away from `s = 1`.
-* `zeta_eq_tsum_of_one_lt_re` : for `1 < re s`, we have
+* `zeta_eq_tsum_one_div_nat_add_one_cpow` : for `1 < re s`, we have
   `ζ(s) = ∑' (n : ℕ), 1 / (n + 1) ^ s`.
 * `riemannCompletedZeta₀_one_sub`, `riemannCompletedZeta_one_sub`, and `riemannZeta_one_sub` :
   functional equation relating values at `s` and `1 - s`


### PR DESCRIPTION
Fix a typo in module doc string (pointed out on zulip: https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Euler.20products/near/400126787)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
