### PR TITLE
[Merged by Bors] - fix: discharger syntax for field_simp

### DIFF
--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -148,7 +148,7 @@ syntax (name := fieldSimp) "field_simp" (config)? (discharger)? (&" only")?
   (simpArgs)? (location)? : tactic
 
 elab_rules : tactic
-| `(tactic| field_simp $[$cfg:config]? $[$dis:discharger]? $[only%$only?]?
+| `(tactic| field_simp $[$cfg:config]? $[(discharger := $dis)]? $[only%$only?]?
     $[$sa:simpArgs]? $[$loc:location]?) => withMainContext do
   let cfg ← elabSimpConfig (cfg.getD ⟨.missing⟩) .simp
   let loc := expandOptLocation (mkOptionalNode loc)
@@ -156,8 +156,8 @@ elab_rules : tactic
   let dis ← match dis with
   | none => pure discharge
   | some d => do
-     let ⟨_,d⟩ ← tacticToDischarge d
-     pure d
+    let ⟨_, d⟩ ← tacticToDischarge d
+    pure d
 
   let thms0 ← if only?.isSome then
     simpOnlyBuiltins.foldlM (·.addConst ·) ({} : SimpTheorems)

--- a/test/FieldSimp.lean
+++ b/test/FieldSimp.lean
@@ -16,20 +16,17 @@ variable {R : Type _} [CommRing R] (a b c d e f g : R) (u₁ u₂ : Rˣ)
 /--
 Check that `divp_add_divp_same` takes priority over `divp_add_divp`.
 -/
-example : a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁ :=
-by field_simp
+example : a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁ := by field_simp
 
 /--
 Check that `divp_sub_divp_same` takes priority over `divp_sub_divp`.
 -/
-example : a /ₚ u₁ - b /ₚ u₁ = (a - b) /ₚ u₁ :=
-by field_simp
+example : a /ₚ u₁ - b /ₚ u₁ = (a - b) /ₚ u₁ := by field_simp
 
 /-
 Combining `eq_divp_iff_mul_eq` and `divp_eq_iff_mul_eq`.
 -/
-example : a /ₚ u₁ = b /ₚ u₂ ↔ a * u₂ = b * u₁ :=
-by field_simp
+example : a /ₚ u₁ = b /ₚ u₂ ↔ a * u₂ = b * u₁ := by field_simp
 
 /--
 Making sure inverses of units are rewritten properly.
@@ -40,17 +37,14 @@ example : ↑u₁⁻¹ = 1 /ₚ u₁ := by field_simp
 Checking arithmetic expressions.
 -/
 example : (f - (e + c * -(a /ₚ u₁) * b + d) - g) =
-  (f * u₁ - (e * u₁ + c * (-a) * b + d * u₁) - g * u₁) /ₚ u₁ :=
-by field_simp
+    (f * u₁ - (e * u₁ + c * (-a) * b + d * u₁) - g * u₁) /ₚ u₁ := by field_simp
 
 /--
 Division of units.
 -/
-example : a /ₚ (u₁ / u₂) = a * u₂ /ₚ u₁ :=
-by field_simp
+example : a /ₚ (u₁ / u₂) = a * u₂ /ₚ u₁ := by field_simp
 
-example : a /ₚ u₁ /ₚ u₂ = a /ₚ (u₂ * u₁) :=
-by field_simp
+example : a /ₚ u₁ /ₚ u₂ = a /ₚ (u₂ * u₁) := by field_simp
 
 /--
 Test that the discharger can clear nontrivial denominators in ℚ.
@@ -58,6 +52,12 @@ Test that the discharger can clear nontrivial denominators in ℚ.
 example (x : ℚ) (h₀ : x ≠ 0) :
     (4 / x)⁻¹ * ((3 * x^3) / x)^2 * ((1 / (2 * x))⁻¹)^3 = 18 * x^8 := by
   field_simp
+  ring
+
+/-- Use a custom discharger -/
+example (x : ℚ) (h₀ : x ≠ 0) :
+    (4 / x)⁻¹ * ((3 * x^3) / x)^2 * ((1 / (2 * x))⁻¹)^3 = 18 * x^8 := by
+  field_simp (discharger := simp; assumption)
   ring
 
 example {x y z w : ℚ} (h : x / y = z / w) (hy : y ≠ 0) (hw : w ≠ 0) : x * w = z * y := by


### PR DESCRIPTION
The original code was passing the wrong term to `tacticToDischarge`, which made the discharger argument unusable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
