### PR TITLE
[Merged by Bors] - feat: add 2-coloring of `pathGraph` and prove its chromatic number is 2

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1295,6 +1295,7 @@ import Mathlib.Combinatorics.SimpleGraph.AdjMatrix
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Clique
 import Mathlib.Combinatorics.SimpleGraph.Coloring
+import Mathlib.Combinatorics.SimpleGraph.ConcreteColorings
 import Mathlib.Combinatorics.SimpleGraph.Connectivity
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Subgraph
 import Mathlib.Combinatorics.SimpleGraph.DegreeSum

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -16,8 +16,7 @@ This file defines colorings for some common graphs
 ## Main declarations
 
 * `SimpleGraph.pathGraph.bicoloring`: Bicoloring of a path graph.
-* `SimpleGraph.pathGraph_two_embedding`: Embedding of `pathGraph 2` into the first
-  two elements of `pathGraph n` for `2 ≤ n`.
+
 -/
 
 namespace SimpleGraph
@@ -30,6 +29,7 @@ def pathGraph.bicoloring (n : ℕ) :
     rw [pathGraph_adj]
     rintro (h | h) <;> simp [← h, not_iff, Nat.succ_mod_two_eq_zero_iff]
 
+/-- Embedding of `pathGraph 2` into the first two elements of `pathGraph n` for `2 ≤ n` -/
 def pathGraph_two_embedding (n : ℕ) (h : 2 ≤ n) : pathGraph 2 ↪g pathGraph n where
   toFun v := ⟨v, trans v.2 h⟩
   inj' := by

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -5,6 +5,7 @@ Authors: Iván Renison
 -/
 import Mathlib.Combinatorics.SimpleGraph.Coloring
 import Mathlib.Combinatorics.SimpleGraph.Hasse
+import Mathlib.Data.Nat.Parity
 import Mathlib.Data.ZMod.Basic
 
 /-!
@@ -19,29 +20,13 @@ This file defines colorings for some common graphs
 
 namespace SimpleGraph
 
-theorem suc_mod2_neq (m : ℕ) : (m % 2 == 0) ≠ ((m + 1) % 2 == 0) := by
-  intro h
-  rw [Bool.eq_iff_eq_true_iff, beq_iff_eq] at h
-  simp only [beq_iff_eq, ←Nat.even_iff, Nat.even_add_one] at h
-  exact not_iff_self h.symm
-
 /-- Bicoloring of a path graph -/
 def pathGraph.bicoloring (n : ℕ) :
     Coloring (pathGraph n) Bool :=
-  Coloring.mk (fun u ↦ u.val % 2 == 0)
-    (by
-      intro u v h
-      simp
-      have : u ⋖ v ∨ v ⋖ u := by simp_all [pathGraph]
-      have : u.val ⋖ v.val ∨ v.val ⋖ u.val := by simp_all [Fin.coe_covby_iff]
-      have : u.val + 1 = v.val ∨ v.val + 1 = u.val := by simp_all [Nat.covby_iff_succ_eq]
-      match this with
-        | Or.inl h' =>
-          rw [←h']
-          exact suc_mod2_neq u
-        | Or.inr h' =>
-          rw [←h']
-          exact (suc_mod2_neq v).symm)
+  Coloring.mk (fun u ↦ u.val % 2 = 0) <| by
+    intro u v
+    rw [pathGraph_adj]
+    rintro (h | h) <;> simp [← h, not_iff, Nat.succ_mod_two_eq_zero_iff]
 
 /-- Convert a coloring to bool to a coloring to Fin 2 -/
 def Coloring.BoolToFin2 {α} {G : SimpleGraph α} (c : Coloring G Bool) :

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -23,6 +23,7 @@ theorem aux (m n : ℕ) (h : m + 1 = n) : (m % 2 == 0) ≠ (n % 2 == 0) := by
   simp only [beq_iff_eq, ←h, ←Nat.even_iff, Nat.even_add_one] at h₁
   exact not_iff_self h₁.symm
 
+/-- Bicoloring of a path graph -/
 def SimpleGraph.pathGraph.bicoloring (n : ℕ) :
     SimpleGraph.Coloring (pathGraph n) Bool :=
   Coloring.mk (fun u => u.val % 2 == 0)
@@ -37,7 +38,7 @@ def SimpleGraph.pathGraph.bicoloring (n : ℕ) :
         | Or.inr h' => exact (aux v u h').symm
     )
 
-
+/-- Convert a coloring to bool to a coloring to Fin 2 -/
 def SimpleGraph.Coloring.BoolToFin2 {α} {G : SimpleGraph α} (c : SimpleGraph.Coloring G Bool) :
     SimpleGraph.Coloring G (Fin 2) :=
   (SimpleGraph.recolorOfEquiv G (finTwoEquiv)).invFun c

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -15,7 +15,9 @@ This file defines colorings for some common graphs
 
 ## Main declarations
 
-* `SimpleGraph.pathGraph.bicoloring`: Bicoloring of a path graph
+* `SimpleGraph.pathGraph.bicoloring`: Bicoloring of a path graph.
+* `SimpleGraph.pathGraph_two_embedding`: Embedding of `pathGraph 2` into the first
+  two elements of `pathGraph n` for `2 ≤ n`.
 -/
 
 namespace SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -17,16 +17,16 @@ This file defines colorings for some common graphs
 * `SimpleGraph.pathGraph.bicoloring`: Bicoloring of a path graph
 -/
 
-theorem aux (m n : ℕ) (h : m + 1 = n) : (m % 2 == 0) ≠ (n % 2 == 0) := by
-  intro h₁
-  rw [Bool.eq_iff_eq_true_iff, beq_iff_eq] at h₁
-  simp only [beq_iff_eq, ←h, ←Nat.even_iff, Nat.even_add_one] at h₁
-  exact not_iff_self h₁.symm
+theorem suc_mod2_neq (m : ℕ) : (m % 2 == 0) ≠ ((m + 1) % 2 == 0) := by
+  intro h
+  rw [Bool.eq_iff_eq_true_iff, beq_iff_eq] at h
+  simp only [beq_iff_eq, ←Nat.even_iff, Nat.even_add_one] at h
+  exact not_iff_self h.symm
 
 /-- Bicoloring of a path graph -/
 def SimpleGraph.pathGraph.bicoloring (n : ℕ) :
     SimpleGraph.Coloring (pathGraph n) Bool :=
-  Coloring.mk (fun u => u.val % 2 == 0)
+  Coloring.mk (fun u ↦ u.val % 2 == 0)
     (by
       intro u v h
       simp
@@ -34,9 +34,12 @@ def SimpleGraph.pathGraph.bicoloring (n : ℕ) :
       have : u.val ⋖ v.val ∨ v.val ⋖ u.val := by simp_all [Fin.coe_covby_iff]
       have : u.val + 1 = v.val ∨ v.val + 1 = u.val := by simp_all [Nat.covby_iff_succ_eq]
       match this with
-        | Or.inl h' => exact aux u v h'
-        | Or.inr h' => exact (aux v u h').symm
-    )
+        | Or.inl h' =>
+          rw [←h']
+          exact suc_mod2_neq u
+        | Or.inr h' =>
+          rw [←h']
+          exact (suc_mod2_neq v).symm)
 
 /-- Convert a coloring to bool to a coloring to Fin 2 -/
 def SimpleGraph.Coloring.BoolToFin2 {α} {G : SimpleGraph α} (c : SimpleGraph.Coloring G Bool) :
@@ -52,23 +55,13 @@ theorem SimpleGraph.pathGraph.clique (n : ℕ) (h : n > 1) :
     -- Adj (pathGraph n) ↑x ↑y
     simp [pathGraph]
     -- ↑x ⋖ ↑y ∨ ↑y ⋖ ↑x
-    have x_val : x.val.val = 0 ∨ x.val.val = 1 := by aesop
-    have i1 : x.val.val = 0 ↔ y.val.val = 1 := by aesop
-    have i2 : x.val.val = 1 ↔ y.val.val = 0 := by aesop
+    have : (x : ℕ) = 0 ↔ (y : ℕ) = 1 := by aesop
+    have : (x : ℕ) = 1 ↔ (y : ℕ) = 0 := by aesop
+    have x_val : (x : ℕ) = 0 ∨ (x : ℕ) = 1 := by aesop
     apply Or.elim x_val
-    · intro (x0 : x.val.val = 0)
-      have y1 : y.val.val = 1 := by rw [←i1, x0]
-      apply Or.inl
-      -- ↑x ⋖ ↑y
-      simp_all [Fin.coe_covby_iff.symm]
-      exact Nat.covby_iff_succ_eq.mpr rfl
-    · intro (x1 : x.val.val = 1)
-      have y0 : y.val.val = 0 := by rw [←i2, x1]
-      apply Or.inr
-      -- ↑y ⋖ ↑x
-      simp_all [Fin.coe_covby_iff.symm]
-      exact Nat.covby_iff_succ_eq.mpr rfl
-
+    repeat
+      intro _
+      simp_all [Fin.coe_covby_iff.symm, Nat.covby_iff_succ_eq.mpr rfl]
   simp_all [Finset.mem_singleton, Fin.mk.injEq, Finset.coe_insert,
             Finset.coe_singleton, Set.mem_singleton_iff]
 

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -36,3 +36,48 @@ def SimpleGraph.pathGraph.bicoloring (n : ℕ) :
         | Or.inl h' => exact aux u v h'
         | Or.inr h' => exact (aux v u h').symm
     )
+
+
+def SimpleGraph.Coloring.BoolToFin2 {α} {G : SimpleGraph α} (c : SimpleGraph.Coloring G Bool) :
+    SimpleGraph.Coloring G (Fin 2) :=
+  (SimpleGraph.recolorOfEquiv G (finTwoEquiv)).invFun c
+
+theorem SimpleGraph.pathGraph.clique (n : ℕ) (h : n > 1) :
+    SimpleGraph.IsClique (pathGraph n) {⟨0, Nat.zero_lt_of_lt h⟩, ⟨1, h⟩} := by
+  let s : Finset (Fin n) := {⟨0, Nat.zero_lt_of_lt h⟩, ⟨1, h⟩}
+  have hs : SimpleGraph.IsClique (pathGraph n) s := by
+    refine (pairwise_subtype_iff_pairwise_set s (pathGraph n).Adj).mp ?_
+    intro (x : s) (y : s) (hxy : x ≠ y)
+    -- Adj (pathGraph n) ↑x ↑y
+    simp [pathGraph]
+    -- ↑x ⋖ ↑y ∨ ↑y ⋖ ↑x
+    have x_val : x.val.val = 0 ∨ x.val.val = 1 := by aesop
+    have i1 : x.val.val = 0 ↔ y.val.val = 1 := by aesop
+    have i2 : x.val.val = 1 ↔ y.val.val = 0 := by aesop
+    apply Or.elim x_val
+    · intro (x0 : x.val.val = 0)
+      have y1 : y.val.val = 1 := by rw [←i1, x0]
+      apply Or.inl
+      -- ↑x ⋖ ↑y
+      simp_all [Fin.coe_covby_iff.symm]
+      exact Nat.covby_iff_succ_eq.mpr rfl
+    · intro (x1 : x.val.val = 1)
+      have y0 : y.val.val = 0 := by rw [←i2, x1]
+      apply Or.inr
+      -- ↑y ⋖ ↑x
+      simp_all [Fin.coe_covby_iff.symm]
+      exact Nat.covby_iff_succ_eq.mpr rfl
+
+  simp_all [Finset.mem_singleton, Fin.mk.injEq, Finset.coe_insert,
+            Finset.coe_singleton, Set.mem_singleton_iff]
+
+theorem SimpleGraph.pathGraph.chromaticNumber (n : ℕ) (h : n > 1) :
+    (pathGraph n).chromaticNumber = 2 := by
+  refine Nat.le_antisymm_iff.mpr ?_
+  apply And.intro
+  · apply SimpleGraph.chromaticNumber_le_of_colorable
+    exact Nonempty.intro (SimpleGraph.pathGraph.bicoloring n).BoolToFin2
+  · let s : Finset (Fin n) := {⟨0, Nat.zero_lt_of_lt h⟩, ⟨1, h⟩}
+    have hs : SimpleGraph.IsClique (pathGraph n) s := by
+      simp [(SimpleGraph.pathGraph.clique n)]
+    apply SimpleGraph.IsClique.card_le_chromaticNumber hs

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -17,6 +17,8 @@ This file defines colorings for some common graphs
 * `SimpleGraph.pathGraph.bicoloring`: Bicoloring of a path graph
 -/
 
+namespace SimpleGraph
+
 theorem suc_mod2_neq (m : ℕ) : (m % 2 == 0) ≠ ((m + 1) % 2 == 0) := by
   intro h
   rw [Bool.eq_iff_eq_true_iff, beq_iff_eq] at h
@@ -24,8 +26,8 @@ theorem suc_mod2_neq (m : ℕ) : (m % 2 == 0) ≠ ((m + 1) % 2 == 0) := by
   exact not_iff_self h.symm
 
 /-- Bicoloring of a path graph -/
-def SimpleGraph.pathGraph.bicoloring (n : ℕ) :
-    SimpleGraph.Coloring (pathGraph n) Bool :=
+def pathGraph.bicoloring (n : ℕ) :
+    Coloring (pathGraph n) Bool :=
   Coloring.mk (fun u ↦ u.val % 2 == 0)
     (by
       intro u v h
@@ -42,14 +44,14 @@ def SimpleGraph.pathGraph.bicoloring (n : ℕ) :
           exact (suc_mod2_neq v).symm)
 
 /-- Convert a coloring to bool to a coloring to Fin 2 -/
-def SimpleGraph.Coloring.BoolToFin2 {α} {G : SimpleGraph α} (c : SimpleGraph.Coloring G Bool) :
-    SimpleGraph.Coloring G (Fin 2) :=
-  (SimpleGraph.recolorOfEquiv G (finTwoEquiv)).invFun c
+def Coloring.BoolToFin2 {α} {G : SimpleGraph α} (c : Coloring G Bool) :
+    Coloring G (Fin 2) :=
+  (recolorOfEquiv G (finTwoEquiv)).invFun c
 
-theorem SimpleGraph.pathGraph.clique (n : ℕ) (h : n > 1) :
-    SimpleGraph.IsClique (pathGraph n) {⟨0, Nat.zero_lt_of_lt h⟩, ⟨1, h⟩} := by
+theorem pathGraph.clique (n : ℕ) (h : n > 1) :
+    IsClique (pathGraph n) {⟨0, Nat.zero_lt_of_lt h⟩, ⟨1, h⟩} := by
   let s : Finset (Fin n) := {⟨0, Nat.zero_lt_of_lt h⟩, ⟨1, h⟩}
-  have hs : SimpleGraph.IsClique (pathGraph n) s := by
+  have hs : IsClique (pathGraph n) s := by
     refine (pairwise_subtype_iff_pairwise_set s (pathGraph n).Adj).mp ?_
     intro (x : s) (y : s) (hxy : x ≠ y)
     -- Adj (pathGraph n) ↑x ↑y
@@ -65,13 +67,15 @@ theorem SimpleGraph.pathGraph.clique (n : ℕ) (h : n > 1) :
   simp_all [Finset.mem_singleton, Fin.mk.injEq, Finset.coe_insert,
             Finset.coe_singleton, Set.mem_singleton_iff]
 
-theorem SimpleGraph.pathGraph.chromaticNumber (n : ℕ) (h : n > 1) :
+theorem pathGraph.chromaticNumber (n : ℕ) (h : n > 1) :
     (pathGraph n).chromaticNumber = 2 := by
   refine Nat.le_antisymm_iff.mpr ?_
   apply And.intro
-  · apply SimpleGraph.chromaticNumber_le_of_colorable
-    exact Nonempty.intro (SimpleGraph.pathGraph.bicoloring n).BoolToFin2
+  · apply chromaticNumber_le_of_colorable
+    exact Nonempty.intro (pathGraph.bicoloring n).BoolToFin2
   · let s : Finset (Fin n) := {⟨0, Nat.zero_lt_of_lt h⟩, ⟨1, h⟩}
-    have hs : SimpleGraph.IsClique (pathGraph n) s := by
-      simp [(SimpleGraph.pathGraph.clique n)]
-    apply SimpleGraph.IsClique.card_le_chromaticNumber hs
+    have hs : IsClique (pathGraph n) s := by
+      simp [(pathGraph.clique n)]
+    apply IsClique.card_le_chromaticNumber hs
+
+end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2023 Iván Renison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Iván Renison
+-/
+import Mathlib.Combinatorics.SimpleGraph.Coloring
+import Mathlib.Combinatorics.SimpleGraph.Hasse
+import Mathlib.Data.ZMod.Basic
+
+/-!
+# Concrete colorings of common graphs
+
+This file defines colorings for some common graphs
+
+## Main declarations
+
+* `SimpleGraph.pathGraph.bicoloring`: Bicoloring of a path graph
+-/
+
+theorem aux (m n : ℕ) (h : m + 1 = n) : (m % 2 == 0) ≠ (n % 2 == 0) := by
+  intro h₁
+  rw [Bool.eq_iff_eq_true_iff, beq_iff_eq] at h₁
+  simp only [beq_iff_eq, ←h, ←Nat.even_iff, Nat.even_add_one] at h₁
+  exact not_iff_self h₁.symm
+
+def SimpleGraph.pathGraph.bicoloring (n : ℕ) :
+    SimpleGraph.Coloring (pathGraph n) Bool :=
+  Coloring.mk (fun u => u.val % 2 == 0)
+    (by
+      intro u v h
+      simp
+      have : u ⋖ v ∨ v ⋖ u := by simp_all [pathGraph]
+      have : u.val ⋖ v.val ∨ v.val ⋖ u.val := by simp_all [Fin.coe_covby_iff]
+      have : u.val + 1 = v.val ∨ v.val + 1 = u.val := by simp_all [Nat.covby_iff_succ_eq]
+      match this with
+        | Or.inl h' => exact aux u v h'
+        | Or.inr h' => exact (aux v u h').symm
+    )

--- a/Mathlib/Combinatorics/SimpleGraph/Hasse.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hasse.lean
@@ -117,4 +117,8 @@ theorem pathGraph_connected (n : ℕ) : (pathGraph (n + 1)).Connected :=
   ⟨pathGraph_preconnected _⟩
 #align simple_graph.path_graph_connected SimpleGraph.pathGraph_connected
 
+theorem pathGraph_two_eq_top : pathGraph 2 = ⊤ := by
+  ext u v
+  fin_cases u <;> fin_cases v <;> simp [pathGraph, ← Fin.coe_covby_iff, Nat.covby_iff_succ_eq]
+
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Hasse.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hasse.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Combinatorics.SimpleGraph.Prod
 import Mathlib.Data.Fin.SuccPred
+import Mathlib.Data.ZMod.Basic
 import Mathlib.Order.SuccPred.Relation
 
 #align_import combinatorics.simple_graph.hasse from "leanprover-community/mathlib"@"8a38a697305292b37a61650e2c3bd3502d98c805"
@@ -102,6 +103,11 @@ end LinearOrder
 def pathGraph (n : ℕ) : SimpleGraph (Fin n) :=
   hasse _
 #align simple_graph.path_graph SimpleGraph.pathGraph
+
+theorem pathGraph_adj {n : ℕ} {u v : Fin n} :
+    (pathGraph n).Adj u v ↔ u.val + 1 = v.val ∨ v.val + 1 = u.val := by
+  simp only [pathGraph, hasse]
+  simp_rw [← Fin.coe_covby_iff, Nat.covby_iff_succ_eq]
 
 theorem pathGraph_preconnected (n : ℕ) : (pathGraph n).Preconnected :=
   hasse_preconnected_of_succ _

--- a/Mathlib/Data/Nat/Parity.lean
+++ b/Mathlib/Data/Nat/Parity.lean
@@ -238,11 +238,9 @@ theorem one_add_div_two_mul_two_of_odd (h : Odd n) : 1 + n / 2 * 2 = n := by
 
 theorem succ_mod_two_eq_zero_iff {m : ℕ} : (m + 1) % 2 = 0 ↔ m % 2 = 1 := by
   simp [← Nat.even_iff, ← Nat.not_even_iff, parity_simps]
-#align nat.succ_mod_two_eq_zero_iff Nat.succ_mod_two_eq_zero_iff
 
 theorem succ_mod_two_eq_one_iff {m : ℕ} : (m + 1) % 2 = 1 ↔ m % 2 = 0 := by
   simp [← Nat.even_iff, ← Nat.not_even_iff, parity_simps]
-#align nat.succ_mod_two_eq_one_iff Nat.succ_mod_two_eq_one_iff
 
 set_option linter.deprecated false in
 section

--- a/Mathlib/Data/Nat/Parity.lean
+++ b/Mathlib/Data/Nat/Parity.lean
@@ -122,6 +122,12 @@ theorem even_add' : Even (m + n) ↔ (Odd m ↔ Odd n) := by
 theorem even_add_one : Even (n + 1) ↔ ¬Even n := by simp [even_add]
 #align nat.even_add_one Nat.even_add_one
 
+theorem succ_mod_two_eq_zero_iff {m : ℕ} : (m + 1) % 2 = 0 ↔ m % 2 = 1 := by
+  simp [← Nat.even_iff, ← Nat.not_even_iff, parity_simps]
+
+theorem succ_mod_two_eq_one_iff {m : ℕ} : (m + 1) % 2 = 1 ↔ m % 2 = 0 := by
+  simp [← Nat.even_iff, ← Nat.not_even_iff, parity_simps]
+
 set_option linter.deprecated false in
 @[simp]
 theorem not_even_bit1 (n : ℕ) : ¬Even (bit1 n) := by simp [bit1, parity_simps]
@@ -235,12 +241,6 @@ theorem div_two_mul_two_add_one_of_odd (h : Odd n) : n / 2 * 2 + 1 = n := by
 theorem one_add_div_two_mul_two_of_odd (h : Odd n) : 1 + n / 2 * 2 = n := by
   rw [← odd_iff.mp h, mod_add_div']
 #align nat.one_add_div_two_mul_two_of_odd Nat.one_add_div_two_mul_two_of_odd
-
-theorem succ_mod_two_eq_zero_iff {m : ℕ} : (m + 1) % 2 = 0 ↔ m % 2 = 1 := by
-  simp [← Nat.even_iff, ← Nat.not_even_iff, parity_simps]
-
-theorem succ_mod_two_eq_one_iff {m : ℕ} : (m + 1) % 2 = 1 ↔ m % 2 = 0 := by
-  simp [← Nat.even_iff, ← Nat.not_even_iff, parity_simps]
 
 set_option linter.deprecated false in
 section

--- a/Mathlib/Data/Nat/Parity.lean
+++ b/Mathlib/Data/Nat/Parity.lean
@@ -236,6 +236,14 @@ theorem one_add_div_two_mul_two_of_odd (h : Odd n) : 1 + n / 2 * 2 = n := by
   rw [← odd_iff.mp h, mod_add_div']
 #align nat.one_add_div_two_mul_two_of_odd Nat.one_add_div_two_mul_two_of_odd
 
+theorem succ_mod_two_eq_zero_iff {m : ℕ} : (m + 1) % 2 = 0 ↔ m % 2 = 1 := by
+  simp [← Nat.even_iff, ← Nat.not_even_iff, parity_simps]
+#align nat.succ_mod_two_eq_zero_iff Nat.succ_mod_two_eq_zero_iff
+
+theorem succ_mod_two_eq_one_iff {m : ℕ} : (m + 1) % 2 = 1 ↔ m % 2 = 0 := by
+  simp [← Nat.even_iff, ← Nat.not_even_iff, parity_simps]
+#align nat.succ_mod_two_eq_one_iff Nat.succ_mod_two_eq_one_iff
+
 set_option linter.deprecated false in
 section
 


### PR DESCRIPTION
Define a bicoloring for `pathGraph` and prove that when `2 ≤ n` its chromatic number is 2. Creates a ConcreteColorings module to hold such colorings of concrete graphs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
