### PR TITLE
[Merged by Bors] - feat: add actions script to label new contributors

### DIFF
--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -1,0 +1,45 @@
+name: Label New Contributors
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  label-new-contributor:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+    - name: Get PR author
+      id: pr-author
+      run: echo "::set-output name=author::$(jq -r .pull_request.user.login "$GITHUB_EVENT_PATH")"
+      shell: bash
+
+    - name: Check if user is new contributor
+      id: check-contributor
+      uses: actions/github-script@v5
+      with:
+        script: |
+          const { owner, repo } = context.repo
+          const author = "${{ steps.pr-author.outputs.author }}"
+          const prs = await github.rest.pulls.list({
+            owner,
+            repo,
+            state: "closed",
+            author
+          })
+          return (prs.data.length < 5)
+
+    - name: Add label if new contributor
+      if: steps.check-contributor.outputs.result == 'true'
+      uses: actions/github-script@v5
+      with:
+        script: |
+          const { owner, repo, number } = context.issue
+          await github.rest.issues.addLabels({
+            owner,
+            repo,
+            issue_number: number,
+            labels: ['new-contributor']
+          })


### PR DESCRIPTION
This action will add the `new-contributor' label to any PR from a GitHub user with fewer than 5 closed PRs. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I've tested in a [personal repo](https://github.com/robertylewis/actions-test/actions) and it has the expected behavior. I took the liberty of adding the label already.

Up for debate: is "5 closed PRs" the right cutoff? Should it be 5 PRs total? A different number?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
