### PR TITLE
feat(RingTheory/PowerSeries): add chain rule for composition of a polynomial and a formal power series

### DIFF
--- a/Mathlib/RingTheory/PowerSeries/Derivative.lean
+++ b/Mathlib/RingTheory/PowerSeries/Derivative.lean
@@ -134,7 +134,7 @@ theorem trunc_derivative' (f : R⟦X⟧) (n : ℕ) :
 /--
 A special case of the chain rule for composition of a polynomial `f` and a power series `g`:
 $$ d/dX (f ∘ g) = (df/dX ∘ g) * dg/dX. $$
-In this statement, the composition $f ∘ g$ is `aeval g f`.
+In this statement, the composition $f ∘ g$ is expressed as `aeval g f`.
 -/
 @[simp]
 theorem derivative_aeval (f : R[X]) (g : R⟦X⟧) :

--- a/Mathlib/RingTheory/PowerSeries/Derivative.lean
+++ b/Mathlib/RingTheory/PowerSeries/Derivative.lean
@@ -5,6 +5,7 @@ Authors: Richard M. Hill
 -/
 import Mathlib.RingTheory.PowerSeries.Basic
 import Mathlib.RingTheory.Derivation.Basic
+import Mathlib.Data.Polynomial.Derivation
 
 /-!
 # Definitions
@@ -129,6 +130,16 @@ theorem trunc_derivative' (f : R⟦X⟧) (n : ℕ) :
     rfl
   | succ n =>
     rw [succ_sub_one, trunc_derivative]
+
+/--
+A special case of the chain rule for composition of a polynomial `f` and a power series `g`:
+$$ d/dX (f ∘ g) = (df/dX ∘ g) * dg/dX. $$
+In this statement, the composition $f ∘ g$ is `aeval g f`.
+-/
+@[simp]
+theorem derivative_aeval (f : R[X]) (g : R⟦X⟧) :
+    d⁄dX R (aeval g f) = aeval g (Polynomial.derivative f) * d⁄dX R g := by
+  apply Derivation.comp_aeval_eq
 
 end CommutativeSemiring
 


### PR DESCRIPTION
In this version of the chain rule, `f` is a polynomial and `g` is a power series.
We have $\frac{d}{dX}( f \circ g ) = \left(\frac{df}{dX} \circ g\right) \cdot \frac{dg}{dX}$.

This is part of #7271.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
