### PR TITLE
fix: allow `peel` to handle `∃ ε > 0 ... ↔` goals

### DIFF
--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -207,6 +207,7 @@ def peelIffAux : TacticM Unit := do
           | apply exists_congr
           | apply eventually_congr
           | apply frequently_congr
+          | apply and_congr_right
           | fail "failed to apply a quantifier congruence lemma."))
 
 /-- Peel off quantifiers from an `↔` and assign the names given in `l` to the introduced

--- a/test/peel.lean
+++ b/test/peel.lean
@@ -150,6 +150,10 @@ example (x y : ℝ) : (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) ↔
     intro
     linarith
 
+example : (∃ k > 0, ∃ n ≥ k, n = k) ↔ ∃ k > 0, ∃ n ≥ k, k = n := by
+  peel 4
+  exact eq_comm
+
 /-! ## Eventually and frequently -/
 
 example {f : ℝ → ℝ} (h : ∀ x : ℝ, ∀ᶠ y in 𝓝 x, |f y - f x| ≤ |y - x|) :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
