### PR TITLE
[Merged by Bors] - feat: add `Trans` instance for List.Perm and a lemma on `List`s

### DIFF
--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -181,16 +181,6 @@ theorem prod_eq_pow_single [Monoid α] (a : α)
 #align list.prod_eq_pow_single List.prod_eq_pow_single
 #align list.sum_eq_nsmul_single List.sum_eq_nsmul_single
 
-lemma count_filter_add_count_filter {α} [DecidableEq α] (P : α → Prop) [DecidablePred P]
-    (l : List α) (a : α) :
-    count a (l.filter P) + count a (l.filter (¬ P ·)) = count a l := by
-  induction l with
-  | nil => simp
-  | cons head tail ih =>
-      rcases eq_or_ne head a with rfl | ha
-      · by_cases h : P head <;> simpa [h] using ih
-      · by_cases h : P head <;> simpa [h, List.count_cons_of_ne ha.symm] using ih
-
 end Count
 
 end List

--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -181,6 +181,16 @@ theorem prod_eq_pow_single [Monoid α] (a : α)
 #align list.prod_eq_pow_single List.prod_eq_pow_single
 #align list.sum_eq_nsmul_single List.sum_eq_nsmul_single
 
+lemma count_filter_add_count_filter {α} [DecidableEq α] (P : α → Prop) [DecidablePred P]
+    (l : List α) (a : α) :
+    count a (l.filter P) + count a (l.filter (¬ P ·)) = count a l := by
+  induction l with
+  | nil => simp
+  | cons head tail ih =>
+      rcases eq_or_ne head a with rfl | ha
+      · by_cases h : P head <;> simpa [h] using ih
+      · by_cases h : P head <;> simpa [h, List.count_cons_of_ne ha.symm] using ih
+
 end Count
 
 end List

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -878,14 +878,6 @@ theorem perm_iff_count {l₁ l₂ : List α} : l₁ ~ l₂ ↔ ∀ a, count a l�
       by_cases h : b = a <;> simpa [h] using H⟩
 #align list.perm_iff_count List.perm_iff_count
 
-lemma filter_append_filter {α} [DecidableEq α] (P : α → Prop) [DecidablePred P] (l : List α) :
-    l.filter P ++ l.filter (¬ P ·) ~ l :=
-  List.perm_iff_count.mpr fun a ↦ List.count_append a _ _ ▸ count_filter_add_count_filter P l a
-
-lemma filter_append_filter' {α} [DecidableEq α] (P : α → Prop) [DecidablePred P] (l : List α) :
-    l.filter (¬ P ·) ++ l.filter P ~ l :=
-  List.perm_append_comm.trans <| filter_append_filter ..
-
 theorem perm_replicate_append_replicate {l : List α} {a b : α} {m n : ℕ} (h : a ≠ b) :
     l ~ replicate m a ++ replicate n b ↔ count a l = m ∧ count b l = n ∧ l ⊆ [a, b] := by
   rw [perm_iff_count, ← Decidable.and_forall_ne a, ← Decidable.and_forall_ne b]

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -493,6 +493,12 @@ theorem countP_eq_countP_filter_add (l : List α) (p q : α → Bool) :
   exact Perm.countP_eq _ (filter_append_perm _ _).symm
 #align list.countp_eq_countp_filter_add List.countP_eq_countP_filter_add
 
+lemma count_eq_count_filter_add [DecidableEq α] (P : α → Prop) [DecidablePred P]
+    (l : List α) (a : α) :
+    count a l = count a (l.filter P) + count a (l.filter (¬ P ·)) := by
+  convert countP_eq_countP_filter_add l _ P
+  simp only [decide_eq_true_eq]
+
 theorem Perm.count_eq [DecidableEq α] {l₁ l₂ : List α} (p : l₁ ~ l₂) (a) :
     count a l₁ = count a l₂ :=
   p.countP_eq _

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -39,6 +39,9 @@ inductive Perm : List α → List α → Prop
   | trans {l₁ l₂ l₃ : List α} : Perm l₁ l₂ → Perm l₂ l₃ → Perm l₁ l₃
 #align list.perm List.Perm
 
+instance {α : Type*} : Trans (@List.Perm α) (@List.Perm α) (@List.Perm α) where
+  trans := @List.Perm.trans α
+
 open Perm (swap)
 
 /-- `Perm l₁ l₂` or `l₁ ~ l₂` asserts that `l₁` and `l₂` are permutations
@@ -874,6 +877,14 @@ theorem perm_iff_count {l₁ l₂ : List α} : l₁ ~ l₂ ↔ ∀ a, count a l�
       rw [(perm_cons_erase this).count_eq] at H
       by_cases h : b = a <;> simpa [h] using H⟩
 #align list.perm_iff_count List.perm_iff_count
+
+lemma filter_append_filter {α} [DecidableEq α] (P : α → Prop) [DecidablePred P] (l : List α) :
+    l.filter P ++ l.filter (¬ P ·) ~ l :=
+  List.perm_iff_count.mpr fun a ↦ List.count_append a _ _ ▸ count_filter_add_count_filter P l a
+
+lemma filter_append_filter' {α} [DecidableEq α] (P : α → Prop) [DecidablePred P] (l : List α) :
+    l.filter (¬ P ·) ++ l.filter P ~ l :=
+  List.perm_append_comm.trans <| filter_append_filter ..
 
 theorem perm_replicate_append_replicate {l : List α} {a b : α} {m n : ℕ} (h : a ≠ b) :
     l ~ replicate m a ++ replicate n b ↔ count a l = m ∧ count b l = n ∧ l ⊆ [a, b] := by

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -39,7 +39,7 @@ inductive Perm : List α → List α → Prop
   | trans {l₁ l₂ l₃ : List α} : Perm l₁ l₂ → Perm l₂ l₃ → Perm l₁ l₃
 #align list.perm List.Perm
 
-instance {α : Type*} : Trans (@List.Perm α) (@List.Perm α) (@List.Perm α) where
+instance {α : Type*} : Trans (@List.Perm α) (@List.Perm α) List.Perm where
   trans := @List.Perm.trans α
 
 open Perm (swap)


### PR DESCRIPTION
This PR adds

- a lemma `List.count_filter_add_count_filter` in `Data.List.Count`
- an instance `Trans (@List.Perm α) (@List.Perm α) (@List.Perm α)` to allow using permutation equivalence of `Lists` in a `calc` block in `Data.List.Perm`

See [here on Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Struggling.20with.20List.2Efilter/near/400293835).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
