### PR TITLE
chore: add `open Mathlib` benchmark

### DIFF
--- a/scripts/bench/temci-config.run.yml
+++ b/scripts/bench/temci-config.run.yml
@@ -19,6 +19,15 @@
     cmd: |
       make lint
 - attributes:
+    description: open Mathlib
+  run_config:
+    runner: perf_stat
+    perf_stat:
+      properties: ['wall-clock', 'instructions']
+    rusage_properties: ['maxrss']
+    cmd: |
+      LEAN_PATH=$(lake print-paths --no-build Mathlib | jq -r '.oleanPath | join(":")') lean Mathlib.lean
+- attributes:
     description: size
   run_config:
     cmd: |


### PR DESCRIPTION
A measure for the worst-case run time of opening a Mathlib file, and presumably roughly proportional to the average case.