### PR TITLE
[Merged by Bors] - feat: quasi-isomorphisms of homological complexes

### DIFF
--- a/Mathlib/Algebra/Homology/QuasiIso.lean
+++ b/Mathlib/Algebra/Homology/QuasiIso.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Joël Riou
 -/
 import Mathlib.Algebra.Homology.Homotopy
+import Mathlib.Algebra.Homology.ShortComplex.HomologicalComplex
 import Mathlib.CategoryTheory.Abelian.Homology
 
 #align_import algebra.homology.quasi_iso from "leanprover-community/mathlib"@"956af7c76589f444f2e1313911bad16366ea476d"
@@ -15,7 +16,7 @@ A chain map is a quasi-isomorphism if it induces isomorphisms on homology.
 
 ## Future work
 
-Define the derived category as the localization at quasi-isomorphisms?
+Define the derived category as the localization at quasi-isomorphisms? (TODO @joelriou)
 -/
 
 
@@ -26,6 +27,8 @@ open CategoryTheory.Limits
 universe v u
 
 variable {ι : Type*}
+
+section
 
 variable {V : Type u} [Category.{v} V] [HasZeroMorphisms V] [HasZeroObject V]
 
@@ -216,3 +219,205 @@ theorem CategoryTheory.Functor.quasiIso'_of_map_quasiIso' {C D : HomologicalComp
       infer_instance
     isIso_of_reflects_iso _ F⟩
 #align category_theory.functor.quasi_iso_of_map_quasi_iso CategoryTheory.Functor.quasiIso'_of_map_quasiIso'
+
+end
+
+open HomologicalComplex
+
+variable {ι : Type*} {C : Type u} [Category.{v} C] [HasZeroMorphisms C]
+  {c : ComplexShape ι} {K L M K' L' : HomologicalComplex C c}
+
+/-- A morphism of homological complexes `f : K ⟶ L` is a quasi-isomorphism in degree `i`
+when it induces a quasi-isomorphism of short complexes `K.sc i ⟶ L.sc i`. -/
+class QuasiIsoAt (f : K ⟶ L) (i : ι) [K.HasHomology i] [L.HasHomology i] : Prop where
+  quasiIso : ShortComplex.QuasiIso ((shortComplexFunctor C c i).map f)
+
+lemma quasiIsoAt_iff (f : K ⟶ L) (i : ι) [K.HasHomology i] [L.HasHomology i] :
+    QuasiIsoAt f i ↔
+      ShortComplex.QuasiIso ((shortComplexFunctor C c i).map f) := by
+  constructor
+  · intro h
+    exact h.quasiIso
+  · intro h
+    exact ⟨h⟩
+
+instance quasiIsoAt_of_isIso (f : K ⟶ L) [IsIso f] (i : ι) [K.HasHomology i] [L.HasHomology i] :
+    QuasiIsoAt f i := by
+  rw [quasiIsoAt_iff]
+  infer_instance
+
+lemma quasiIsoAt_iff' (f : K ⟶ L) (i j k : ι) (hi : c.prev j = i) (hk : c.next j = k)
+    [K.HasHomology j] [L.HasHomology j] [(K.sc' i j k).HasHomology] [(L.sc' i j k).HasHomology] :
+    QuasiIsoAt f j ↔
+      ShortComplex.QuasiIso ((shortComplexFunctor' C c i j k).map f) := by
+  rw [quasiIsoAt_iff]
+  exact ShortComplex.quasiIso_iff_of_arrow_mk_iso _ _
+    (Arrow.isoOfNatIso (natIsoSc' C c i j k hi hk) (Arrow.mk f))
+
+lemma quasiIsoAt_iff_isIso_homologyMap (f : K ⟶ L) (i : ι)
+    [K.HasHomology i] [L.HasHomology i] :
+    QuasiIsoAt f i ↔ IsIso (homologyMap f i) := by
+  rw [quasiIsoAt_iff, ShortComplex.quasiIso_iff]
+  rfl
+
+lemma quasiIsoAt_iff_exactAt (f : K ⟶ L) (i : ι) [K.HasHomology i] [L.HasHomology i]
+    (hK : K.ExactAt i) :
+    QuasiIsoAt f i ↔ L.ExactAt i := by
+  simp only [quasiIsoAt_iff, ShortComplex.quasiIso_iff, exactAt_iff,
+    ShortComplex.exact_iff_isZero_homology] at hK ⊢
+  constructor
+  · intro h
+    exact IsZero.of_iso hK (@asIso _ _ _ _ _ h).symm
+  · intro hL
+    exact ⟨⟨0, IsZero.eq_of_src hK _ _, IsZero.eq_of_tgt hL _ _⟩⟩
+
+lemma quasiIsoAt_iff_exactAt' (f : K ⟶ L) (i : ι) [K.HasHomology i] [L.HasHomology i]
+    (hL : L.ExactAt i) :
+    QuasiIsoAt f i ↔ K.ExactAt i := by
+  simp only [quasiIsoAt_iff, ShortComplex.quasiIso_iff, exactAt_iff,
+    ShortComplex.exact_iff_isZero_homology] at hL ⊢
+  constructor
+  · intro h
+    exact IsZero.of_iso hL (@asIso _ _ _ _ _ h)
+  · intro hK
+    exact ⟨⟨0, IsZero.eq_of_src hK _ _, IsZero.eq_of_tgt hL _ _⟩⟩
+
+instance (f : K ⟶ L) (i : ι) [K.HasHomology i] [L.HasHomology i] [hf : QuasiIsoAt f i] :
+    IsIso (homologyMap f i) := by
+  simpa only [quasiIsoAt_iff, ShortComplex.quasiIso_iff] using hf
+
+/-- The isomorphism `K.homology i ≅ L.homology i` induced by a morphism `f : K ⟶ L` such
+that `[QuasiIsoAt f i]` holds. -/
+@[simps! hom]
+noncomputable def isoOfQuasiIsoAt (f : K ⟶ L) (i : ι) [K.HasHomology i] [L.HasHomology i]
+    [QuasiIsoAt f i] : K.homology i ≅ L.homology i :=
+  asIso (homologyMap f i)
+
+@[reassoc (attr := simp)]
+lemma isoOfQuasiIsoAt_hom_inv_id (f : K ⟶ L) (i : ι) [K.HasHomology i] [L.HasHomology i]
+    [QuasiIsoAt f i] :
+    homologyMap f i ≫ (isoOfQuasiIsoAt f i).inv = 𝟙 _ :=
+  (isoOfQuasiIsoAt f i).hom_inv_id
+
+@[reassoc (attr := simp)]
+lemma isoOfQuasiIsoAt_inv_hom_id (f : K ⟶ L) (i : ι) [K.HasHomology i] [L.HasHomology i]
+    [QuasiIsoAt f i] :
+    (isoOfQuasiIsoAt f i).inv ≫ homologyMap f i = 𝟙 _ :=
+  (isoOfQuasiIsoAt f i).inv_hom_id
+
+lemma CochainComplex.quasiIsoAt₀_iff {K L : CochainComplex C ℕ} (f : K ⟶ L)
+    [K.HasHomology 0] [L.HasHomology 0] [(K.sc' 0 0 1).HasHomology] [(L.sc' 0 0 1).HasHomology] :
+    QuasiIsoAt f 0 ↔
+      ShortComplex.QuasiIso ((HomologicalComplex.shortComplexFunctor' C _ 0 0 1).map f) :=
+  quasiIsoAt_iff' _ _ _ _ (by simp) (by simp)
+
+lemma ChainComplex.quasiIsoAt₀_iff {K L : ChainComplex C ℕ} (f : K ⟶ L)
+    [K.HasHomology 0] [L.HasHomology 0] [(K.sc' 1 0 0).HasHomology] [(L.sc' 1 0 0).HasHomology] :
+    QuasiIsoAt f 0 ↔
+      ShortComplex.QuasiIso ((HomologicalComplex.shortComplexFunctor' C _ 1 0 0).map f) :=
+  quasiIsoAt_iff' _ _ _ _ (by simp) (by simp)
+
+/-- A morphism of homological complexes `f : K ⟶ L` is a quasi-isomorphism when it
+is so in every degree, i.e. when the induced maps `homologyMap f i : K.homology i ⟶ L.homology i`
+are all isomorphisms (see `quasiIso_iff` and `quasiIsoAt_iff_isIso_homologyMap`). -/
+class QuasiIso (f : K ⟶ L) [∀ i, K.HasHomology i] [∀ i, L.HasHomology i] : Prop where
+  quasiIsoAt : ∀ i, QuasiIsoAt f i := by infer_instance
+
+lemma quasiIso_iff (f : K ⟶ L) [∀ i, K.HasHomology i] [∀ i, L.HasHomology i] :
+    QuasiIso f ↔ ∀ i, QuasiIsoAt f i :=
+  ⟨fun h => h.quasiIsoAt, fun h => ⟨h⟩⟩
+
+attribute [instance] QuasiIso.quasiIsoAt
+
+instance quasiIso_of_isIso (f : K ⟶ L) [IsIso f] [∀ i, K.HasHomology i] [∀ i, L.HasHomology i] :
+    QuasiIso f where
+
+instance quasiIsoAt_comp (φ : K ⟶ L) (φ' : L ⟶ M) (i : ι) [K.HasHomology i]
+    [L.HasHomology i] [M.HasHomology i]
+    [hφ : QuasiIsoAt φ i] [hφ' : QuasiIsoAt φ' i] :
+    QuasiIsoAt (φ ≫ φ') i := by
+  rw [quasiIsoAt_iff] at hφ hφ' ⊢
+  rw [Functor.map_comp]
+  exact ShortComplex.quasiIso_comp _ _
+
+instance quasiIso_comp (φ : K ⟶ L) (φ' : L ⟶ M) [∀ i, K.HasHomology i]
+    [∀ i, L.HasHomology i] [∀ i, M.HasHomology i]
+    [hφ : QuasiIso φ] [hφ' : QuasiIso φ'] :
+    QuasiIso (φ ≫ φ') where
+
+lemma quasiIsoAt_of_comp_left (φ : K ⟶ L) (φ' : L ⟶ M) (i : ι) [K.HasHomology i]
+    [L.HasHomology i] [M.HasHomology i]
+    [hφ : QuasiIsoAt φ i] [hφφ' : QuasiIsoAt (φ ≫ φ') i] :
+    QuasiIsoAt φ' i := by
+  rw [quasiIsoAt_iff_isIso_homologyMap] at hφ hφφ' ⊢
+  rw [homologyMap_comp] at hφφ'
+  exact IsIso.of_isIso_comp_left (homologyMap φ i) (homologyMap φ' i)
+
+lemma quasiIsoAt_iff_comp_left (φ : K ⟶ L) (φ' : L ⟶ M) (i : ι) [K.HasHomology i]
+    [L.HasHomology i] [M.HasHomology i]
+    [hφ : QuasiIsoAt φ i] :
+    QuasiIsoAt (φ ≫ φ') i ↔ QuasiIsoAt φ' i := by
+  constructor
+  · intro
+    exact quasiIsoAt_of_comp_left φ φ' i
+  · intro
+    infer_instance
+
+lemma quasiIso_iff_comp_left (φ : K ⟶ L) (φ' : L ⟶ M) [∀ i, K.HasHomology i]
+    [∀ i, L.HasHomology i] [∀ i, M.HasHomology i]
+    [hφ : QuasiIso φ] :
+    QuasiIso (φ ≫ φ') ↔ QuasiIso φ' := by
+  simp only [quasiIso_iff, quasiIsoAt_iff_comp_left φ φ']
+
+lemma quasiIso_of_comp_left (φ : K ⟶ L) (φ' : L ⟶ M) [∀ i, K.HasHomology i]
+    [∀ i, L.HasHomology i] [∀ i, M.HasHomology i]
+    [hφ : QuasiIso φ] [hφφ' : QuasiIso (φ ≫ φ')] :
+    QuasiIso φ' := by
+  rw [← quasiIso_iff_comp_left φ φ']
+  infer_instance
+
+lemma quasiIsoAt_of_comp_right (φ : K ⟶ L) (φ' : L ⟶ M) (i : ι) [K.HasHomology i]
+    [L.HasHomology i] [M.HasHomology i]
+    [hφ' : QuasiIsoAt φ' i] [hφφ' : QuasiIsoAt (φ ≫ φ') i] :
+    QuasiIsoAt φ i := by
+  rw [quasiIsoAt_iff_isIso_homologyMap] at hφ' hφφ' ⊢
+  rw [homologyMap_comp] at hφφ'
+  exact IsIso.of_isIso_comp_right (homologyMap φ i) (homologyMap φ' i)
+
+lemma quasiIsoAt_iff_comp_right (φ : K ⟶ L) (φ' : L ⟶ M) (i : ι) [K.HasHomology i]
+    [L.HasHomology i] [M.HasHomology i]
+    [hφ' : QuasiIsoAt φ' i] :
+    QuasiIsoAt (φ ≫ φ') i ↔ QuasiIsoAt φ i := by
+  constructor
+  · intro
+    exact quasiIsoAt_of_comp_right φ φ' i
+  · intro
+    infer_instance
+
+lemma quasiIso_iff_comp_right (φ : K ⟶ L) (φ' : L ⟶ M) [∀ i, K.HasHomology i]
+    [∀ i, L.HasHomology i] [∀ i, M.HasHomology i]
+    [hφ' : QuasiIso φ'] :
+    QuasiIso (φ ≫ φ') ↔ QuasiIso φ := by
+  simp only [quasiIso_iff, quasiIsoAt_iff_comp_right φ φ']
+
+lemma quasiIso_of_comp_right (φ : K ⟶ L) (φ' : L ⟶ M) [∀ i, K.HasHomology i]
+    [∀ i, L.HasHomology i] [∀ i, M.HasHomology i]
+    [hφ : QuasiIso φ'] [hφφ' : QuasiIso (φ ≫ φ')] :
+    QuasiIso φ := by
+  rw [← quasiIso_iff_comp_right φ φ']
+  infer_instance
+
+lemma quasiIso_iff_of_arrow_mk_iso (φ : K ⟶ L) (φ' : K' ⟶ L') (e : Arrow.mk φ ≅ Arrow.mk φ')
+    [∀ i, K.HasHomology i] [∀ i, L.HasHomology i]
+    [∀ i, K'.HasHomology i] [∀ i, L'.HasHomology i] :
+    QuasiIso φ ↔ QuasiIso φ' := by
+  rw [← quasiIso_iff_comp_left (show K' ⟶ K from e.inv.left) φ,
+    ← quasiIso_iff_comp_right φ' (show L' ⟶ L from e.inv.right)]
+  erw [Arrow.w e.inv]
+  rfl
+
+lemma quasiIso_of_arrow_mk_iso (φ : K ⟶ L) (φ' : K' ⟶ L') (e : Arrow.mk φ ≅ Arrow.mk φ')
+    [∀ i, K.HasHomology i] [∀ i, L.HasHomology i]
+    [∀ i, K'.HasHomology i] [∀ i, L'.HasHomology i]
+    [hφ : QuasiIso φ] : QuasiIso φ' := by
+  simpa only [← quasiIso_iff_of_arrow_mk_iso φ φ' e]


### PR DESCRIPTION
This PR defines the typeclass `QuasiIso` which corresponds to quasi-isomorphisms of homological complexes for the new homology API.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
