### PR TITLE
[Merged by Bors] - feat(Condensed): adjunctions between categories of condensed objects

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1348,6 +1348,7 @@ import Mathlib.Computability.TMComputable
 import Mathlib.Computability.TMToPartrec
 import Mathlib.Computability.TuringMachine
 import Mathlib.Condensed.Abelian
+import Mathlib.Condensed.Adjunctions
 import Mathlib.Condensed.Basic
 import Mathlib.Condensed.Equivalence
 import Mathlib.Control.Applicative

--- a/Mathlib/Condensed/Adjunctions.lean
+++ b/Mathlib/Condensed/Adjunctions.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2023 Dagur Asgeirsson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dagur Asgeirsson
+-/
+import Mathlib.Algebra.Category.GroupCat.Adjunctions
+import Mathlib.CategoryTheory.Sites.Adjunction
+import Mathlib.Condensed.Abelian
+
+/-!
+# Adjunctions regarding categories of condensed objects
+
+This file shows that the forgetful functor from condensed abelian groups to condensed sets has a
+left adjoint, called the free condensed abelian group on a condensed set.
+
+TODO (Dagur):
+* Add the "discrete-underlying" adjunction (the discrete functor from sets to condensed sets is
+  left adjoint to the evalation functor at a point).
+* Add free condensed modules over more general rings.
+-/
+
+universe u
+
+open CategoryTheory
+
+/-- The forgetful functor from condensed abelian groups to condensed sets. -/
+def Condensed.abForget : CondensedAb ⥤ CondensedSet := sheafCompose _ (forget AddCommGroupCat)
+
+/--
+The left adjoint to the forgetful functor. The *free condensed abelian group* on a condensed set.
+-/
+noncomputable
+def Condensed.freeAb : CondensedSet ⥤ CondensedAb :=
+  Sheaf.composeAndSheafify _ AddCommGroupCat.free
+
+/-- The condensed version of the free-forgetful adjunction. -/
+noncomputable
+def Condensed.setAbAdjunction : freeAb ⊣ abForget := Sheaf.adjunction _ AddCommGroupCat.adj

--- a/Mathlib/Condensed/Basic.lean
+++ b/Mathlib/Condensed/Basic.lean
@@ -48,3 +48,9 @@ def Condensed (C : Type w) [Category.{v} C] :=
 
 instance {C : Type w} [Category.{v} C] : Category (Condensed.{u} C) :=
   show Category (Sheaf _ _) from inferInstance
+
+/--
+Condensed sets (types) with the appropriate universe levels, i.e. `Type (u+1)`-valued
+sheaves on `CompHaus.{u}`.
+-/
+abbrev CondensedSet := Condensed.{u} (Type (u+1))


### PR DESCRIPTION

Creates the file `Condensed/Adjunctions`. For now there is only the free-forgetful adjunction for condensed sets/abelian groups, but there are others on the to-do list.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
