### PR TITLE
chore: update Mathlib for leanprover/lean4#2825

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -124,8 +124,6 @@ instance (priority := 100) sMulCommClass_mk {R : Type u₁} {S : Type u₂} [Rin
     (f : R →+* S) (M : Type v) [I : AddCommGroup M] [Module S M] :
     haveI : SMul R M := (RestrictScalars.obj' f (ModuleCat.mk M)).isModule.toSMul
     SMulCommClass R S M :=
-  -- Porting note: cannot synth SMul R M
-  have : SMul R M := (RestrictScalars.obj' f (ModuleCat.mk M)).isModule.toSMul
   @SMulCommClass.mk R S M (_) _
    <| fun r s m => (by simp [← mul_smul, mul_comm] : f r • s • m = s • f r • m)
 #align category_theory.Module.smul_comm_class_mk ModuleCat.sMulCommClass_mk

--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -282,7 +282,7 @@ instance {R S A} [CommSemiring R] [CommSemiring S] [CommSemiring A]
     rw [smul_assoc, ←smul_one_mul]
 
 instance {R S A} [CommSemiring R] [CommSemiring S] [CommSemiring A]
-    [Algebra R A] [Algebra S A] [SMulCommClass R S A] :
+    [Algebra R A] [Algebra S A] :
     SMulCommClass R S (FreeAlgebra A X) where
   smul_comm r s x := smul_comm (algebraMap R A r) (algebraMap S A s) x
 

--- a/Mathlib/CategoryTheory/Limits/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/Limits/FintypeCat.lean
@@ -23,7 +23,7 @@ universe u
 
 namespace CategoryTheory.Limits.FintypeCat
 
-instance {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ FintypeCat.{u}) (j : J) :
+instance {J : Type} [SmallCategory J] (K : J ⥤ FintypeCat.{u}) (j : J) :
     Finite ((K ⋙ FintypeCat.incl.{u}).obj j) := by
   simp only [comp_obj, FintypeCat.incl_obj]
   infer_instance

--- a/Mathlib/CategoryTheory/Sites/RegularExtensive.lean
+++ b/Mathlib/CategoryTheory/Sites/RegularExtensive.lean
@@ -216,7 +216,7 @@ def EqualizerFirstObjIso (F : Cᵒᵖ ⥤ Type (max u v)) {B X : C} (π : X ⟶ 
       | mk => rfl
     inv_hom_id := by aesop }
 
-instance {B X : C} (π : X ⟶ B) [EffectiveEpi π] [HasPullback π π] :
+instance {B X : C} (π : X ⟶ B) [HasPullback π π] :
     (Presieve.singleton π).hasPullbacks where
   has_pullbacks hf _ hg := by
     cases hf

--- a/Mathlib/CategoryTheory/Sites/RegularExtensive.lean
+++ b/Mathlib/CategoryTheory/Sites/RegularExtensive.lean
@@ -228,8 +228,7 @@ The `SecondObj` in the sheaf condition diagram is isomorphic to `F` applied to
 with itself
 -/
 noncomputable
-def EqualizerSecondObjIso (F : Cᵒᵖ ⥤ Type (max u v)) {B X : C} (π : X ⟶ B) [EffectiveEpi π]
-    [HasPullback π π] :
+def EqualizerSecondObjIso (F : Cᵒᵖ ⥤ Type (max u v)) {B X : C} (π : X ⟶ B) [HasPullback π π] :
     Equalizer.Presieve.SecondObj F (Presieve.singleton π) ≅ F.obj (op (Limits.pullback π π)) :=
   Types.productIso.{max u v, max u v} _ ≪≫
   { hom := fun e ↦ e (⟨X, ⟨π, Presieve.singleton_self π⟩⟩, ⟨X, ⟨π, Presieve.singleton_self π⟩⟩)

--- a/Mathlib/Data/LazyList/Basic.lean
+++ b/Mathlib/Data/LazyList/Basic.lean
@@ -66,6 +66,7 @@ instance : Traversable LazyList where
   map := @LazyList.traverse Id _
   traverse := @LazyList.traverse
 
+@[nolint unusedHavesSuffices] -- Otherwise the linter complains, after leanprover/lean4#2825
 instance : LawfulTraversable LazyList := by
   apply Equiv.isLawfulTraversable' listEquivLazyList <;> intros <;> ext <;> rename_i f xs
   · induction' xs using LazyList.rec with _ _ _ _ ih

--- a/Mathlib/Data/LazyList/Basic.lean
+++ b/Mathlib/Data/LazyList/Basic.lean
@@ -66,7 +66,6 @@ instance : Traversable LazyList where
   map := @LazyList.traverse Id _
   traverse := @LazyList.traverse
 
-@[nolint unusedHavesSuffices] -- Otherwise the linter complains, after leanprover/lean4#2825
 instance : LawfulTraversable LazyList := by
   apply Equiv.isLawfulTraversable' listEquivLazyList <;> intros <;> ext <;> rename_i f xs
   · induction' xs using LazyList.rec with _ _ _ _ ih
@@ -83,7 +82,7 @@ instance : LawfulTraversable LazyList := by
   · simp only [traverse, Equiv.traverse, listEquivLazyList, Equiv.coe_fn_mk, Equiv.coe_fn_symm_mk]
     induction' xs using LazyList.rec with _ tl ih _ ih
     · simp only [List.traverse, map_pure]; rfl
-    · have : tl.get.traverse f = ofList <$> tl.get.toList.traverse f := ih
+    · replace ih : tl.get.traverse f = ofList <$> tl.get.toList.traverse f := ih
       simp only [traverse._eq_2, ih, Functor.map_map, seq_map_assoc, toList, List.traverse, map_seq]
       · rfl
     · apply ih

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -1153,7 +1153,6 @@ protected instance instHasGroupoid [ClosedUnderRestriction G] : HasGroupoid s G 
   compatible := by
     rintro e e' ⟨_, ⟨x, hc⟩, he⟩ ⟨_, ⟨x', hc'⟩, he'⟩
     haveI : Nonempty s := ⟨x⟩
-    have asdf := he
     rw [hc.symm, mem_singleton_iff] at he
     rw [hc'.symm, mem_singleton_iff] at he'
     rw [he, he']

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -426,8 +426,6 @@ instance smoothMfldWithCorners {n : ℕ} [Fact (finrank ℝ E = n + 1)] :
         (-- Removed type ascription, and this helped for some reason with timeout issues?
             OrthonormalBasis.fromOrthogonalSpanSingleton (𝕜 := ℝ)
             n (ne_zero_of_mem_unit_sphere v')).repr
-      -- Porting note: trouble synth instances
-      have := findim (E := E) n
       have H₁ := U'.contDiff.comp_contDiffOn contDiffOn_stereoToFun
       -- Porting note: need to help with implicit variables again
       have H₂ := (contDiff_stereoInvFunAux (v := v.val)|>.comp

--- a/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
@@ -227,7 +227,7 @@ instance : SMul Mᵈᵐᵃ (A →+ B) where
 instance [DistribSMul M' A] [SMulCommClass M M' A] : SMulCommClass Mᵈᵐᵃ M'ᵈᵐᵃ (A →+ B) :=
   FunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
-instance [Monoid M'] [DistribSMul M' B] : SMulCommClass Mᵈᵐᵃ M' (A →+ B) :=
+instance [DistribSMul M' B] : SMulCommClass Mᵈᵐᵃ M' (A →+ B) :=
   FunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 theorem smul_addMonoidHom_apply (c : Mᵈᵐᵃ) (f : A →+ B) (a : A) : (c • f) a = f (mk.symm c • a) :=

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -97,7 +97,7 @@ instance instAlgebra : Algebra R (CliffordAlgebra Q) := instAlgebra' _
 
 instance {R S A M} [CommSemiring R] [CommSemiring S] [AddCommGroup M] [CommRing A]
     [Algebra R A] [Algebra S A] [Module R M] [Module S M] [Module A M] (Q : QuadraticForm A M)
-    [IsScalarTower R A M] [IsScalarTower S A M] [SMulCommClass R S A] :
+    [IsScalarTower R A M] [IsScalarTower S A M] :
     SMulCommClass R S (CliffordAlgebra Q) :=
   RingQuot.instSMulCommClass _
 

--- a/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
@@ -81,7 +81,7 @@ example : (algebraNat : Algebra ℕ (TensorAlgebra R M)) = instAlgebra := rfl
 
 instance {R S A M} [CommSemiring R] [CommSemiring S] [AddCommMonoid M] [CommSemiring A]
     [Algebra R A] [Algebra S A] [Module R M] [Module S M] [Module A M]
-    [IsScalarTower R A M] [IsScalarTower S A M] [SMulCommClass R S A] :
+    [IsScalarTower R A M] [IsScalarTower S A M] :
     SMulCommClass R S (TensorAlgebra A M) :=
   RingQuot.instSMulCommClass _
 

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -921,7 +921,6 @@ instance add_covariantClass_le : CovariantClass Ordinal.{u} Ordinal.{u} (· + ·
     refine inductionOn b (fun α₂ r₂ _ ↦ ?_)
     rintro c ⟨⟨⟨f, fo⟩, fi⟩⟩
     refine inductionOn c (fun β s _ ↦ ?_)
-    have := (Embedding.refl β).sumMap f
     refine ⟨⟨⟨(Embedding.refl.{u+1} _).sumMap f, ?_⟩, ?_⟩⟩
     · intros a b
       match a, b with

--- a/Mathlib/Topology/Algebra/ValuedField.lean
+++ b/Mathlib/Topology/Algebra/ValuedField.lean
@@ -167,11 +167,10 @@ instance (priority := 100) completable : CompletableTopField K :=
       · rw [mem_map]
         apply mem_of_superset (Filter.inter_mem M₀_in M₁_in)
         exact subset_preimage_image _ _
-      · rintro _ ⟨x, ⟨x_in₀, x_in₁⟩, rfl⟩ _ ⟨y, ⟨y_in₀, y_in₁⟩, rfl⟩
+      · rintro _ ⟨x, ⟨x_in₀, x_in₁⟩, rfl⟩ _ ⟨y, ⟨_, y_in₁⟩, rfl⟩
         simp only [mem_setOf_eq]
         specialize H₁ x x_in₁ y y_in₁
         replace x_in₀ := H₀ x x_in₀
-        replace := H₀ y y_in₀
         clear H₀
         apply Valuation.inversion_estimate
         · have : (v x : Γ₀) ≠ 0 := by

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -225,7 +225,7 @@ def spanCone [∀ (s : Finset I) (i : I), Decidable (i ∈ s)] : Cone (spanFunct
 
 /-- `spanCone` is a limit cone. -/
 noncomputable
-def spanCone_isLimit [∀ (s : Finset I) (i : I), Decidable (i ∈ s)] [DecidableEq I] :
+def spanCone_isLimit [∀ (s : Finset I) (i : I), Decidable (i ∈ s)] :
     CategoryTheory.Limits.IsLimit (spanCone hC) := by
   refine (IsLimit.postcomposeHomEquiv (NatIso.ofComponents
     (fun s ↦ (Profinite.isoOfBijective _ (iso_map_bijective C (· ∈ unop s)))) ?_) (spanCone hC))

--- a/Mathlib/Topology/Category/Profinite/Product.lean
+++ b/Mathlib/Topology/Category/Profinite/Product.lean
@@ -93,7 +93,7 @@ def indexCone : Cone (indexFunctor hC) where
   pt := @Profinite.of C _ (by rwa [← isCompact_iff_compactSpace]) _ _
   π := { app := fun J ↦ π_app C (· ∈ unop J) }
 
-instance isIso_indexCone_lift [DecidableEq ι] :
+instance isIso_indexCone_lift :
     IsIso ((limitConeIsLimit (indexFunctor hC)).lift (indexCone hC)) :=
   haveI : CompactSpace C := by rwa [← isCompact_iff_compactSpace]
   isIso_of_bijective _

--- a/Mathlib/Topology/Category/Profinite/Product.lean
+++ b/Mathlib/Topology/Category/Profinite/Product.lean
@@ -131,19 +131,19 @@ instance isIso_indexCone_lift :
 
 /-- The canonical map from `C` to the explicit limit as an isomorphism. -/
 noncomputable
-def isoindexConeLift [DecidableEq ι] :
+def isoindexConeLift :
     @Profinite.of C _ (by rwa [← isCompact_iff_compactSpace]) _ _ ≅
     (Profinite.limitCone (indexFunctor hC)).pt :=
   asIso <| (Profinite.limitConeIsLimit _).lift (indexCone hC)
 
 /-- The isomorphism of cones induced by `isoindexConeLift`. -/
 noncomputable
-def asLimitindexConeIso [DecidableEq ι] : indexCone hC ≅ Profinite.limitCone _ :=
+def asLimitindexConeIso : indexCone hC ≅ Profinite.limitCone _ :=
   Limits.Cones.ext (isoindexConeLift hC) fun _ => rfl
 
 /-- `indexCone` is a limit cone. -/
 noncomputable
-def indexCone_isLimit [DecidableEq ι] : CategoryTheory.Limits.IsLimit (indexCone hC) :=
+def indexCone_isLimit : CategoryTheory.Limits.IsLimit (indexCone hC) :=
   Limits.IsLimit.ofIsoLimit (Profinite.limitConeIsLimit _) (asLimitindexConeIso hC).symm
 
 end Profinite

--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -954,7 +954,7 @@ theorem tendsto_order_unbounded {f : β → α} {a : α} {x : Filter β} (hu : �
 
 end Preorder
 
-instance tendstoIxxNhdsWithin {α : Type*} [Preorder α] [TopologicalSpace α] (a : α) {s t : Set α}
+instance tendstoIxxNhdsWithin {α : Type*} [TopologicalSpace α] (a : α) {s t : Set α}
     {Ixx} [TendstoIxxClass Ixx (𝓝 a) (𝓝 a)] [TendstoIxxClass Ixx (𝓟 s) (𝓟 t)] :
     TendstoIxxClass Ixx (𝓝[s] a) (𝓝[t] a) :=
   Filter.tendstoIxxClass_inf

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-11-05
+leanprover/lean4-pr-releases:pr-release-2825

--- a/test/Clean.lean
+++ b/test/Clean.lean
@@ -19,22 +19,22 @@ info: def Tests.x' : Id Nat :=
 #guard_msgs in #print x'
 -- def x : Id Nat := 1
 
-def withClean : 2 + 2 = 4 := clean% by exact id rfl
-def withoutClean : 2 + 2 = 4 := by exact id rfl
+theorem withClean : 2 + 2 = 4 := clean% by exact id rfl
+theorem withoutClean : 2 + 2 = 4 := by exact id rfl
 
 /--
-info: theorem Tests.withClean.proof_1 : 2 + 2 = 2 + 2 :=
+info: theorem Tests.withClean : 2 + 2 = 4 :=
 rfl
 -/
 #guard_msgs in
-#print Tests.withClean.proof_1
+#print Tests.withClean
 
 /--
-info: theorem Tests.withoutClean.proof_1 : 2 + 2 = 4 :=
+info: theorem Tests.withoutClean : 2 + 2 = 4 :=
 id rfl
 -/
 #guard_msgs in
-#print Tests.withoutClean.proof_1
+#print Tests.withoutClean
 
 example : True := by
   let x : id Nat := by dsimp; exact 1


### PR DESCRIPTION
Changes to how abstraction works, so has affected the `clean%` test which cares about these details.
