### PR TITLE
[Merged by Bors] - feat(CategoryTheory): a version of `sheafCompose` for functors preserving smaller limits

### DIFF
--- a/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
@@ -149,7 +149,8 @@ variable [ConcreteCategory.{max v u} D] [PreservesLimits (forget D)]
 @[simp]
 theorem sheafifyCompIso_inv_eq_sheafifyLift :
     (J.sheafifyCompIso F P).inv =
-      J.sheafifyLift (whiskerRight (J.toSheafify P) F) ((J.sheafify_isSheaf _).comp _) := by
+      J.sheafifyLift (whiskerRight (J.toSheafify P) F)
+        (HasSheafCompose.isSheaf _ ((J.sheafify_isSheaf _))) := by
   apply J.sheafifyLift_unique
   rw [Iso.comp_inv_eq]
   simp

--- a/Mathlib/CategoryTheory/Sites/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Sites/Whiskering.lean
@@ -114,6 +114,8 @@ def mapMultifork :
 
 end GrothendieckTopology.Cover
 
+section Multicospan
+
 variable [∀ (X : C) (S : J.Cover X) (P : Cᵒᵖ ⥤ A), PreservesLimit (S.index P).multicospan F]
 variable [∀ (X : C) (S : J.Cover X) (P : Cᵒᵖ ⥤ A), PreservesLimit (S.index P).multicospan G]
 variable [∀ (X : C) (S : J.Cover X) (P : Cᵒᵖ ⥤ A), PreservesLimit (S.index P).multicospan H]
@@ -156,5 +158,24 @@ lemma sheafCompose_id : sheafCompose_map (F := F) J (𝟙 _) = 𝟙 _ := rfl
 @[simp]
 lemma sheafCompose_comp :
     sheafCompose_map J (η ≫ γ) = sheafCompose_map J η ≫ sheafCompose_map J γ := rfl
+
+end Multicospan
+
+section Preserves
+
+/--
+Composing a sheaf with a functor preserving limits of the same size as the hom sets in `C` yields a
+functor between sheaf categories.
+
+Note: the size of the limit `(S.index P).multicospan` that `F` is required to preserve in
+`CategoryTheory.sheafCompose` is in general larger than this.
+-/
+def sheafCompose' [PreservesLimitsOfSize.{v₁} F] : Sheaf J A ⥤ Sheaf J B where
+  obj G := ⟨G.val ⋙ F, Presheaf.isSheaf_comp_of_isSheaf J _ F G.cond⟩
+  map η := ⟨whiskerRight η.val _⟩
+  map_id _ := Sheaf.Hom.ext _ _ <| whiskerRight_id _
+  map_comp _ _ := Sheaf.Hom.ext _ _ <| whiskerRight_comp _ _ _
+
+end Preserves
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Sites/Whiskering.lean
@@ -163,8 +163,8 @@ end Multicospan
 
 section Preserves
 
-variable [PreservesLimitsOfSize.{v₁} F] [PreservesLimitsOfSize.{v₁} G]
-  [PreservesLimitsOfSize.{v₁} H] (J)
+variable [PreservesLimitsOfSize.{v₁, max u₁ v₁} F] [PreservesLimitsOfSize.{v₁, max u₁ v₁} G]
+  [PreservesLimitsOfSize.{v₁, max u₁ v₁} H] (J)
 
 /--
 Composing a sheaf with a functor preserving limits of the same size as the hom sets in `C` yields a

--- a/Mathlib/CategoryTheory/Sites/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Sites/Whiskering.lean
@@ -152,8 +152,6 @@ end GrothendieckTopology.Cover
 section Multicospan
 
 variable [∀ (X : C) (S : J.Cover X) (P : Cᵒᵖ ⥤ A), PreservesLimit (S.index P).multicospan F]
-variable [∀ (X : C) (S : J.Cover X) (P : Cᵒᵖ ⥤ A), PreservesLimit (S.index P).multicospan G]
-variable [∀ (X : C) (S : J.Cover X) (P : Cᵒᵖ ⥤ A), PreservesLimit (S.index P).multicospan H]
 variable (F)
 
 theorem Presheaf.IsSheaf.comp {P : Cᵒᵖ ⥤ A} (hP : Presheaf.IsSheaf J P) :

--- a/Mathlib/CategoryTheory/Sites/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Sites/Whiskering.lean
@@ -42,16 +42,16 @@ variable {U : C} (R : Presieve U)
 variable (F G H : A ⥤ B) (η : F ⟶ G) (γ : G ⟶ H)
 
 /-- Describes the property of a functor to "preserve sheaves". -/
-class Functor.HasSheafCompose : Prop where
+class GrothendieckTopology.HasSheafCompose : Prop where
   /-- For every sheaf `P`, `P ⋙ F` is a sheaf. -/
   isSheaf (P : Cᵒᵖ ⥤ A) (hP : Presheaf.IsSheaf J P) : Presheaf.IsSheaf J (P ⋙ F)
 
-variable [F.HasSheafCompose J] [G.HasSheafCompose J] [H.HasSheafCompose J]
+variable [J.HasSheafCompose F] [J.HasSheafCompose G] [J.HasSheafCompose H]
 
 /-- Composing a functor which `HasSheafCompose`, yields a functor between sheaf categories. -/
 @[simps]
-def sheafCompose [F.HasSheafCompose J] : Sheaf J A ⥤ Sheaf J B where
-  obj G := ⟨G.val ⋙ F, Functor.HasSheafCompose.isSheaf G.val G.2⟩
+def sheafCompose : Sheaf J A ⥤ Sheaf J B where
+  obj G := ⟨G.val ⋙ F, GrothendieckTopology.HasSheafCompose.isSheaf G.val G.2⟩
   map η := ⟨whiskerRight η.val _⟩
   map_id _ := Sheaf.Hom.ext _ _ <| whiskerRight_id _
   map_comp _ _ := Sheaf.Hom.ext _ _ <| whiskerRight_comp _ _ _
@@ -149,29 +149,20 @@ def mapMultifork :
 
 end GrothendieckTopology.Cover
 
-section Multicospan
-
-variable [∀ (X : C) (S : J.Cover X) (P : Cᵒᵖ ⥤ A), PreservesLimit (S.index P).multicospan F]
-variable (F)
-
-theorem Presheaf.IsSheaf.comp {P : Cᵒᵖ ⥤ A} (hP : Presheaf.IsSheaf J P) :
-    Presheaf.IsSheaf J (P ⋙ F) := by
-  rw [Presheaf.isSheaf_iff_multifork] at hP ⊢
-  intro X S
-  obtain ⟨h⟩ := hP X S
-  replace h := isLimitOfPreserves F h
-  replace h := Limits.IsLimit.ofIsoLimit h (S.mapMultifork F P)
-  exact ⟨Limits.IsLimit.postcomposeHomEquiv (S.multicospanComp F P) _ h⟩
-#align category_theory.presheaf.is_sheaf.comp CategoryTheory.Presheaf.IsSheaf.comp
-
-instance hasSheafCompose_of_preservesMulticospan : F.HasSheafCompose J where
-  isSheaf _ hP := Presheaf.IsSheaf.comp J F hP
-
-end Multicospan
-
-section Preserves
-
-variable [PreservesLimitsOfSize.{v₁, max u₁ v₁} F]
+/--
+Composing a sheaf with a functor preserving the limit of `(S.index P).multicospan` yields a functor
+between sheaf categories.
+-/
+instance hasSheafCompose_of_preservesMulticospan (F : A ⥤ B)
+    [∀ (X : C) (S : J.Cover X) (P : Cᵒᵖ ⥤ A), PreservesLimit (S.index P).multicospan F] :
+    J.HasSheafCompose F where
+  isSheaf P hP := by
+    rw [Presheaf.isSheaf_iff_multifork] at hP ⊢
+    intro X S
+    obtain ⟨h⟩ := hP X S
+    replace h := isLimitOfPreserves F h
+    replace h := Limits.IsLimit.ofIsoLimit h (S.mapMultifork F P)
+    exact ⟨Limits.IsLimit.postcomposeHomEquiv (S.multicospanComp F P) _ h⟩
 
 /--
 Composing a sheaf with a functor preserving limits of the same size as the hom sets in `C` yields a
@@ -180,9 +171,8 @@ functor between sheaf categories.
 Note: the size of the limit that `F` is required to preserve in
 `hasSheafCompose_of_preservesMulticospan` is in general larger than this.
 -/
-instance hasSheafCompose_of_preservesLimitsOfSize : F.HasSheafCompose J where
+instance hasSheafCompose_of_preservesLimitsOfSize [PreservesLimitsOfSize.{v₁, max u₁ v₁} F] :
+    J.HasSheafCompose F where
   isSheaf _ hP := Presheaf.isSheaf_comp_of_isSheaf J _ F hP
-
-end Preserves
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Sites/Whiskering.lean
@@ -163,6 +163,9 @@ end Multicospan
 
 section Preserves
 
+variable [PreservesLimitsOfSize.{v₁} F] [PreservesLimitsOfSize.{v₁} G]
+  [PreservesLimitsOfSize.{v₁} H] (J)
+
 /--
 Composing a sheaf with a functor preserving limits of the same size as the hom sets in `C` yields a
 functor between sheaf categories.
@@ -170,11 +173,28 @@ functor between sheaf categories.
 Note: the size of the limit `(S.index P).multicospan` that `F` is required to preserve in
 `CategoryTheory.sheafCompose` is in general larger than this.
 -/
-def sheafCompose' [PreservesLimitsOfSize.{v₁} F] : Sheaf J A ⥤ Sheaf J B where
+@[simps]
+def sheafCompose' : Sheaf J A ⥤ Sheaf J B where
   obj G := ⟨G.val ⋙ F, Presheaf.isSheaf_comp_of_isSheaf J _ F G.cond⟩
   map η := ⟨whiskerRight η.val _⟩
   map_id _ := Sheaf.Hom.ext _ _ <| whiskerRight_id _
   map_comp _ _ := Sheaf.Hom.ext _ _ <| whiskerRight_comp _ _ _
+
+variable {F G}
+
+/--
+If `η : F ⟶ G` is a natural transformation then we obtain a morphism of functors
+`sheafCompose' J F ⟶ sheafCompose' J G` by whiskering with `η` on the level of presheaves.
+-/
+def sheafCompose'_map : sheafCompose' J F ⟶ sheafCompose' J G where
+  app := fun X => .mk <| whiskerLeft _ η
+
+@[simp]
+lemma sheafCompose'_id : sheafCompose'_map (F := F) J (𝟙 _) = 𝟙 _ := rfl
+
+@[simp]
+lemma sheafCompose'_comp :
+    sheafCompose'_map J (η ≫ γ) = sheafCompose'_map J η ≫ sheafCompose'_map J γ := rfl
 
 end Preserves
 

--- a/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
+++ b/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
@@ -273,7 +273,7 @@ def smoothSheafCommRing : TopCat.Sheaf CommRingCat.{u} (TopCat.of M) :=
 
 -- sanity check: applying the `CommRingCat`-to-`TypeCat` forgetful functor to the sheaf-of-rings of
 -- smooth functions gives the sheaf-of-types of smooth functions.
-example : (CategoryTheory.sheafCompose _ (CategoryTheory.forget CommRingCat)).obj
+example : (CategoryTheory.sheafCompose _ (CategoryTheory.forget CommRingCat.{u})).obj
     (smoothSheafCommRing IM I M R) = (smoothSheaf IM I M R) := rfl
 
 instance smoothSheafCommRing.coeFun (U : (Opens (TopCat.of M))ᵒᵖ) :


### PR DESCRIPTION

Introduces a new typeclass `GrothendieckTopology.HasSheafCompose F` which says that a sheaf postcomposed with the functor `F` is still a sheaf. The previous API proved that a functor preserving certain limits has this property, this PR also adds a proof that a functor preserving limits of a smaller size has this property. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
