### PR TITLE
[Merged by Bors] - fix: fixes of 3 PRs

### DIFF
--- a/Mathlib/Algebra/Order/Group/Defs.lean
+++ b/Mathlib/Algebra/Order/Group/Defs.lean
@@ -1159,19 +1159,19 @@ instance (priority := 100) LinearOrderedCommGroup.toLinearOrderedCancelCommMonoi
 #align linear_ordered_comm_group.to_linear_ordered_cancel_comm_monoid LinearOrderedCommGroup.toLinearOrderedCancelCommMonoid
 #align linear_ordered_add_comm_group.to_linear_ordered_cancel_add_comm_monoid LinearOrderedAddCommGroup.toLinearOrderedAddCancelCommMonoid
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem inv_le_self_iff : a⁻¹ ≤ a ↔ 1 ≤ a := by simp [inv_le_iff_one_le_mul']
 #align neg_le_self_iff neg_le_self_iff
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem inv_lt_self_iff : a⁻¹ < a ↔ 1 < a := by simp [inv_lt_iff_one_lt_mul]
 #align neg_lt_self_iff neg_lt_self_iff
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem le_inv_self_iff : a ≤ a⁻¹ ↔ a ≤ 1 := by simp [← not_iff_not]
 #align le_neg_self_iff le_neg_self_iff
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem lt_inv_self_iff : a < a⁻¹ ↔ a < 1 := by simp [← not_iff_not]
 #align lt_neg_self_iff lt_neg_self_iff
 

--- a/Mathlib/Algebra/Order/Monoid/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Defs.lean
@@ -115,16 +115,16 @@ end LinearOrderedAddCommMonoidWithTop
 
 variable [LinearOrderedCommMonoid α] {a : α}
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem one_le_mul_self_iff : 1 ≤ a * a ↔ 1 ≤ a :=
   ⟨(fun h ↦ by push_neg at h ⊢; exact mul_lt_one' h h).mtr, fun h ↦ one_le_mul h h⟩
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem one_lt_mul_self_iff : 1 < a * a ↔ 1 < a :=
   ⟨(fun h ↦ by push_neg at h ⊢; exact mul_le_one' h h).mtr, fun h ↦ one_lt_mul'' h h⟩
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem mul_self_le_one_iff : a * a ≤ 1 ↔ a ≤ 1 := by simp [← not_iff_not]
 
-@[to_additive, simp]
+@[to_additive (attr := simp)]
 theorem mul_self_lt_one_iff : a * a < 1 ↔ a < 1 := by simp [← not_iff_not]

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -290,12 +290,12 @@ theorem Finset.card_compl [DecidableEq α] [Fintype α] (s : Finset α) :
 #align finset.card_compl Finset.card_compl
 
 @[simp]
-theorem card_add_card_compl [DecidableEq α] [Fintype α] (s : Finset α) :
+theorem Finset.card_add_card_compl [DecidableEq α] [Fintype α] (s : Finset α) :
     s.card + sᶜ.card = Fintype.card α := by
   rw [Finset.card_compl, ← Nat.add_sub_assoc (card_le_univ s), Nat.add_sub_cancel_left]
 
 @[simp]
-theorem card_compl_add_card [DecidableEq α] [Fintype α] (s : Finset α) :
+theorem Finset.card_compl_add_card [DecidableEq α] [Fintype α] (s : Finset α) :
     sᶜ.card + s.card = Fintype.card α := by
   rw [add_comm, card_add_card_compl]
 

--- a/Mathlib/Data/Set/Pointwise/SMul.lean
+++ b/Mathlib/Data/Set/Pointwise/SMul.lean
@@ -77,9 +77,6 @@ section SMul
 variable {ι : Sort*} {κ : ι → Sort*} [SMul α β] {s s₁ s₂ : Set α} {t t₁ t₂ u : Set β} {a : α}
   {b : β}
 
-/- Porting note: Could `@[simp, to_additive]` be automatically changed to
-`@[to_additive (attr := simp)]`?
--/
 @[to_additive (attr := simp)]
 theorem image2_smul : image2 SMul.smul s t = s • t :=
   rfl

--- a/Mathlib/Logic/Equiv/TransferInstance.lean
+++ b/Mathlib/Logic/Equiv/TransferInstance.lean
@@ -41,7 +41,7 @@ section Instances
 variable (e : α ≃ β)
 
 /-- Transfer `One` across an `Equiv` -/
-@[reducible, to_additive "Transfer `Zero` across an `Equiv`"]
+@[to_additive (attr := reducible) "Transfer `Zero` across an `Equiv`"]
 protected def one [One β] : One α :=
   ⟨e.symm 1⟩
 #align equiv.has_one Equiv.one
@@ -56,7 +56,7 @@ theorem one_def [One β] :
 #align equiv.zero_def Equiv.zero_def
 
 /-- Transfer `Mul` across an `Equiv` -/
-@[reducible, to_additive "Transfer `Add` across an `Equiv`"]
+@[to_additive (attr := reducible) "Transfer `Add` across an `Equiv`"]
 protected def mul [Mul β] : Mul α :=
   ⟨fun x y => e.symm (e x * e y)⟩
 #align equiv.has_mul Equiv.mul
@@ -71,7 +71,7 @@ theorem mul_def [Mul β] (x y : α) :
 #align equiv.add_def Equiv.add_def
 
 /-- Transfer `Div` across an `Equiv` -/
-@[reducible, to_additive "Transfer `Sub` across an `Equiv`"]
+@[to_additive (attr := reducible) "Transfer `Sub` across an `Equiv`"]
 protected def div [Div β] : Div α :=
   ⟨fun x y => e.symm (e x / e y)⟩
 #align equiv.has_div Equiv.div
@@ -88,7 +88,7 @@ theorem div_def [Div β] (x y : α) :
 -- Porting note: this should be called `inv`,
 -- but we already have an `Equiv.inv` (which perhaps should move to `Perm.inv`?)
 /-- Transfer `Inv` across an `Equiv` -/
-@[reducible, to_additive "Transfer `Neg` across an `Equiv`"]
+@[to_additive (attr := reducible) "Transfer `Neg` across an `Equiv`"]
 protected def Inv [Inv β] : Inv α :=
   ⟨fun x => e.symm (e x)⁻¹⟩
 #align equiv.has_inv Equiv.Inv
@@ -115,7 +115,7 @@ theorem smul_def {R : Type*} [SMul R β] (r : R) (x : α) :
 #align equiv.smul_def Equiv.smul_def
 
 /-- Transfer `Pow` across an `Equiv` -/
-@[reducible, to_additive existing smul]
+@[to_additive (attr := reducible) existing smul]
 protected def pow (N : Type*) [Pow β N] : Pow α N :=
   ⟨fun x n => e.symm (e x ^ n)⟩
 #align equiv.has_pow Equiv.pow
@@ -189,7 +189,7 @@ theorem ringEquiv_symm_apply (e : α ≃ β) [Add β] [Mul β] (b : β) : by
 #align equiv.ring_equiv_symm_apply Equiv.ringEquiv_symm_apply
 
 /-- Transfer `Semigroup` across an `Equiv` -/
-@[reducible, to_additive "Transfer `add_semigroup` across an `Equiv`"]
+@[to_additive (attr := reducible) "Transfer `add_semigroup` across an `Equiv`"]
 protected def semigroup [Semigroup β] : Semigroup α := by
   let mul := e.mul
   apply e.injective.semigroup _; intros; exact e.apply_symm_apply _
@@ -205,7 +205,7 @@ protected def semigroupWithZero [SemigroupWithZero β] : SemigroupWithZero α :=
 #align equiv.semigroup_with_zero Equiv.semigroupWithZero
 
 /-- Transfer `CommSemigroup` across an `Equiv` -/
-@[reducible, to_additive "Transfer `AddCommSemigroup` across an `Equiv`"]
+@[to_additive (attr := reducible) "Transfer `AddCommSemigroup` across an `Equiv`"]
 protected def commSemigroup [CommSemigroup β] : CommSemigroup α := by
   let mul := e.mul
   apply e.injective.commSemigroup _; intros; exact e.apply_symm_apply _
@@ -221,7 +221,7 @@ protected def mulZeroClass [MulZeroClass β] : MulZeroClass α := by
 #align equiv.mul_zero_class Equiv.mulZeroClass
 
 /-- Transfer `MulOneClass` across an `Equiv` -/
-@[reducible, to_additive "Transfer `AddZeroClass` across an `Equiv`"]
+@[to_additive (attr := reducible) "Transfer `AddZeroClass` across an `Equiv`"]
 protected def mulOneClass [MulOneClass β] : MulOneClass α := by
   let one := e.one
   let mul := e.mul
@@ -239,7 +239,7 @@ protected def mulZeroOneClass [MulZeroOneClass β] : MulZeroOneClass α := by
 #align equiv.mul_zero_one_class Equiv.mulZeroOneClass
 
 /-- Transfer `Monoid` across an `Equiv` -/
-@[reducible, to_additive "Transfer `AddMonoid` across an `Equiv`"]
+@[to_additive (attr := reducible) "Transfer `AddMonoid` across an `Equiv`"]
 protected def monoid [Monoid β] : Monoid α := by
   let one := e.one
   let mul := e.mul
@@ -249,7 +249,7 @@ protected def monoid [Monoid β] : Monoid α := by
 #align equiv.add_monoid Equiv.addMonoid
 
 /-- Transfer `CommMonoid` across an `Equiv` -/
-@[reducible, to_additive "Transfer `AddCommMonoid` across an `Equiv`"]
+@[to_additive (attr := reducible) "Transfer `AddCommMonoid` across an `Equiv`"]
 protected def commMonoid [CommMonoid β] : CommMonoid α := by
   let one := e.one
   let mul := e.mul
@@ -259,7 +259,7 @@ protected def commMonoid [CommMonoid β] : CommMonoid α := by
 #align equiv.add_comm_monoid Equiv.addCommMonoid
 
 /-- Transfer `Group` across an `Equiv` -/
-@[reducible, to_additive "Transfer `AddGroup` across an `Equiv`"]
+@[to_additive (attr := reducible) "Transfer `AddGroup` across an `Equiv`"]
 protected def group [Group β] : Group α := by
   let one := e.one
   let mul := e.mul
@@ -272,7 +272,7 @@ protected def group [Group β] : Group α := by
 #align equiv.add_group Equiv.addGroup
 
 /-- Transfer `CommGroup` across an `Equiv` -/
-@[reducible, to_additive "Transfer `AddCommGroup` across an `Equiv`"]
+@[to_additive (attr := reducible) "Transfer `AddCommGroup` across an `Equiv`"]
 protected def commGroup [CommGroup β] : CommGroup α := by
   let one := e.one
   let mul := e.mul

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -701,8 +701,8 @@ theorem integral_Ioi_of_hasDerivAt_of_tendsto' (hderiv : ∀ x ∈ Ici a, HasDer
 
 /-- A special case of `integral_Ioi_of_hasDerivAt_of_tendsto` where we assume that `f` is C^1 with
 compact support. -/
-theorem _root_.HasCompactSupport.integral_Ioi_deriv_eq (hf : ContDiff ℝ 1 f) (h2f : HasCompactSupport f)
-    (b : ℝ) : ∫ x in Ioi b, deriv f x = - f b := by
+theorem _root_.HasCompactSupport.integral_Ioi_deriv_eq (hf : ContDiff ℝ 1 f)
+    (h2f : HasCompactSupport f) (b : ℝ) : ∫ x in Ioi b, deriv f x = - f b := by
   have := fun x (_ : x ∈ Ioi b) ↦ hf.differentiable le_rfl x |>.hasDerivAt
   rw [integral_Ioi_of_hasDerivAt_of_tendsto hf.continuous.continuousWithinAt this, zero_sub]
   refine hf.continuous_deriv le_rfl |>.integrable_of_hasCompactSupport h2f.deriv |>.integrableOn
@@ -851,8 +851,8 @@ theorem integral_Iic_of_hasDerivAt_of_tendsto'
 
 /-- A special case of `integral_Iic_of_hasDerivAt_of_tendsto` where we assume that `f` is C^1 with
 compact support. -/
-theorem _root_.HasCompactSupport.integral_Iic_deriv_eq (hf : ContDiff ℝ 1 f) (h2f : HasCompactSupport f)
-    (b : ℝ) : ∫ x in Iic b, deriv f x = f b := by
+theorem _root_.HasCompactSupport.integral_Iic_deriv_eq (hf : ContDiff ℝ 1 f)
+    (h2f : HasCompactSupport f) (b : ℝ) : ∫ x in Iic b, deriv f x = f b := by
   have := fun x (_ : x ∈ Iio b) ↦ hf.differentiable le_rfl x |>.hasDerivAt
   rw [integral_Iic_of_hasDerivAt_of_tendsto hf.continuous.continuousWithinAt this, sub_zero]
   refine hf.continuous_deriv le_rfl |>.integrable_of_hasCompactSupport h2f.deriv |>.integrableOn

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -701,7 +701,7 @@ theorem integral_Ioi_of_hasDerivAt_of_tendsto' (hderiv : ∀ x ∈ Ici a, HasDer
 
 /-- A special case of `integral_Ioi_of_hasDerivAt_of_tendsto` where we assume that `f` is C^1 with
 compact support. -/
-theorem HasCompactSupport.integral_Ioi_deriv_eq (hf : ContDiff ℝ 1 f) (h2f : HasCompactSupport f)
+theorem _root_.HasCompactSupport.integral_Ioi_deriv_eq (hf : ContDiff ℝ 1 f) (h2f : HasCompactSupport f)
     (b : ℝ) : ∫ x in Ioi b, deriv f x = - f b := by
   have := fun x (_ : x ∈ Ioi b) ↦ hf.differentiable le_rfl x |>.hasDerivAt
   rw [integral_Ioi_of_hasDerivAt_of_tendsto hf.continuous.continuousWithinAt this, zero_sub]
@@ -851,7 +851,7 @@ theorem integral_Iic_of_hasDerivAt_of_tendsto'
 
 /-- A special case of `integral_Iic_of_hasDerivAt_of_tendsto` where we assume that `f` is C^1 with
 compact support. -/
-theorem HasCompactSupport.integral_Iic_deriv_eq (hf : ContDiff ℝ 1 f) (h2f : HasCompactSupport f)
+theorem _root_.HasCompactSupport.integral_Iic_deriv_eq (hf : ContDiff ℝ 1 f) (h2f : HasCompactSupport f)
     (b : ℝ) : ∫ x in Iic b, deriv f x = f b := by
   have := fun x (_ : x ∈ Iio b) ↦ hf.differentiable le_rfl x |>.hasDerivAt
   rw [integral_Iic_of_hasDerivAt_of_tendsto hf.continuous.continuousWithinAt this, sub_zero]

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -267,7 +267,7 @@ theorem measurable_of_subsingleton_codomain [Subsingleton β] (f : α → β) : 
   fun s _ => Subsingleton.set_cases MeasurableSet.empty MeasurableSet.univ s
 #align measurable_of_subsingleton_codomain measurable_of_subsingleton_codomain
 
-@[measurability, to_additive]
+@[to_additive (attr := measurability)]
 theorem measurable_one [One α] : Measurable (1 : β → α) :=
   @measurable_const _ _ _ _ 1
 #align measurable_one measurable_one


### PR DESCRIPTION
Fixes mistake introduced in #7976 (ping to @alreadydone that you should use `@[to_additive (attr := simp)]` and not `@[to_additive, simp]`) and some namespacing mistakes from my own PRs #7337 and #7755

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
