### PR TITLE
[Merged by Bors] - chore: updating nightly-testing should not fail

### DIFF
--- a/.github/workflows/nightly_bump_toolchain.yml
+++ b/.github/workflows/nightly_bump_toolchain.yml
@@ -31,4 +31,4 @@ jobs:
         git config user.email "leanprover-community-mathlib4-bot@users.noreply.github.com"
         git add lean-toolchain
         git commit -m "chore: bump to ${RELEASE_TAG}"
-        git push origin nightly-testing
+        git push origin nightly-testing || true

--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -26,5 +26,6 @@ jobs:
         run: |
           git checkout nightly-testing
           git merge master --strategy-option ours --no-commit --allow-unrelated-histories || true
+          git add .
           git commit -m "Merge master into nightly-testing"
           git push origin nightly-testing || true

--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Merge master to nightly favoring nightly changes
         run: |
           git checkout nightly-testing
-          git merge master --strategy-option ours --no-commit --allow-unrelated-histories
+          git merge master --strategy-option ours --no-commit --allow-unrelated-histories || true
           git commit -m "Merge master into nightly-testing"
-          git push origin nightly-testing
+          git push origin nightly-testing || true


### PR DESCRIPTION
As this CI step runs on commits to `master`, it is important that it does not fail, even if something goes wrong.

I would prefer that we commit garbage to `nightly-testing` where something goes wrong: a separate CI job already notifies us of CI failures on the `nightly-testing` branch, so they will be picked up there.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
