### PR TITLE
chore adaptations for leanprover/lean4#2816

### DIFF
--- a/Archive/Examples/IfNormalization/WithoutAesop.lean
+++ b/Archive/Examples/IfNormalization/WithoutAesop.lean
@@ -107,7 +107,7 @@ def normalize' (l : AList (fun _ : ℕ => Bool)) :
           · simp_all? says simp_all only [ne_eq, hasNestedIf, Bool.or_self, hasConstantIf,
               and_self, hasRedundantIf, Bool.or_false, beq_eq_false_iff_ne, not_false_eq_true,
               disjoint, List.disjoint, decide_not, Bool.and_true, Bool.and_eq_true,
-              Bool.not_eq_true', Bool.decide_false_iff, true_and]
+              Bool.not_eq_true', decide_eq_false_iff_not, true_and]
             constructor <;> assumption
         · have := ht₃ w
           have := he₃ w

--- a/Archive/Examples/IfNormalization/WithoutAesop.lean
+++ b/Archive/Examples/IfNormalization/WithoutAesop.lean
@@ -106,8 +106,8 @@ def normalize' (l : AList (fun _ : ℕ => Bool)) :
             simp_all
           · simp_all? says simp_all only [ne_eq, hasNestedIf, Bool.or_self, hasConstantIf,
               and_self, hasRedundantIf, Bool.or_false, beq_eq_false_iff_ne, not_false_eq_true,
-              disjoint, List.disjoint, Bool.and_true, Bool.and_eq_true, decide_eq_true_eq',
-              true_and]
+              disjoint, List.disjoint, decide_not, Bool.and_true, Bool.and_eq_true,
+              Bool.not_eq_true', Bool.decide_false_iff, true_and]
             constructor <;> assumption
         · have := ht₃ w
           have := he₃ w

--- a/Mathlib/Init/Data/Bool/Lemmas.lean
+++ b/Mathlib/Init/Data/Bool/Lemmas.lean
@@ -132,7 +132,7 @@ theorem bool_eq_false {b : Bool} : ¬b → b = false :=
   bool_iff_false.1
 #align bool_eq_false Bool.bool_eq_false
 
-@[simp] theorem decide_false_iff (p : Prop) {_ : Decidable p} : decide p = false ↔ ¬p :=
+theorem decide_false_iff (p : Prop) {_ : Decidable p} : decide p = false ↔ ¬p :=
   bool_iff_false.symm.trans (not_congr (decide_iff _))
 #align to_bool_ff_iff Bool.decide_false_iff
 

--- a/Mathlib/Init/Data/Bool/Lemmas.lean
+++ b/Mathlib/Init/Data/Bool/Lemmas.lean
@@ -132,7 +132,7 @@ theorem bool_eq_false {b : Bool} : ¬b → b = false :=
   bool_iff_false.1
 #align bool_eq_false Bool.bool_eq_false
 
-theorem decide_false_iff (p : Prop) [Decidable p] : decide p = false ↔ ¬p :=
+@[simp] theorem decide_false_iff (p : Prop) {_ : Decidable p} : decide p = false ↔ ¬p :=
   bool_iff_false.symm.trans (not_congr (decide_iff _))
 #align to_bool_ff_iff Bool.decide_false_iff
 

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,10 +4,10 @@
  [{"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "4167e5e4f60a47906d6fc42000b64cd93205f710",
+    "rev": "b3b7603d93e92b7383aa8ba89377031dcb48da7b",
     "opts": {},
     "name": "std",
-    "inputRev?": "nightly-testing",
+    "inputRev?": "lean-pr-testing-2816",
     "inherited": false}},
   {"git":
    {"url": "https://github.com/leanprover-community/quote4",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "b3b7603d93e92b7383aa8ba89377031dcb48da7b",
+    "rev": "5e086edfb4c56a951eb8e11b395824813d320038",
     "opts": {},
     "name": "std",
     "inputRev?": "lean-pr-testing-2816",

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -46,7 +46,7 @@ lean_exe checkYaml where
 meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
-require std from git "https://github.com/leanprover/std4" @ "nightly-testing"
+require std from git "https://github.com/leanprover/std4" @ "lean-pr-testing-2816"
 require Qq from git "https://github.com/leanprover-community/quote4" @ "master"
 require aesop from git "https://github.com/leanprover-community/aesop" @ "nightly-testing"
 require Cli from git "https://github.com/leanprover/lean4-cli" @ "nightly"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-11-06
+leanprover/lean4-pr-releases:pr-release-2816


### PR DESCRIPTION
Changes to match leanprover/lean4#2816.  Based off nightly-testing-2023-11-06.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
