### PR TITLE
[Merged by Bors] - feat(LiminfLimsup, LpSeminorm): add lemmas/golf

### DIFF
--- a/Mathlib/MeasureTheory/Function/EssSup.lean
+++ b/Mathlib/MeasureTheory/Function/EssSup.lean
@@ -159,11 +159,8 @@ theorem essInf_mono_ae {f g : α → β} (hfg : f ≤ᵐ[μ] g) : essInf f μ �
   liminf_le_liminf hfg
 #align ess_inf_mono_ae essInf_mono_ae
 
-theorem essSup_le_of_ae_le {f : α → β} (c : β) (hf : f ≤ᵐ[μ] fun _ => c) : essSup f μ ≤ c := by
-  refine' (essSup_mono_ae hf).trans _
-  by_cases hμ : μ = 0
-  · simp [hμ]
-  · rwa [essSup_const]
+theorem essSup_le_of_ae_le {f : α → β} (c : β) (hf : f ≤ᵐ[μ] fun _ => c) : essSup f μ ≤ c :=
+  limsup_le_of_le (by isBoundedDefault) hf
 #align ess_sup_le_of_ae_le essSup_le_of_ae_le
 
 theorem le_essInf_of_ae_le {f : α → β} (c : β) (hf : (fun _ => c) ≤ᵐ[μ] f) : c ≤ essInf f μ :=
@@ -262,44 +259,19 @@ end TopologicalSpace
 
 end CompleteLattice
 
-section CompleteLinearOrder
-
-variable [CompleteLinearOrder β]
-theorem essSup_indicator_eq_essSup_restrict [Zero β] {s : Set α} {f : α → β}
-    (hf : 0 ≤ᵐ[μ.restrict s] f) (hs : MeasurableSet s) (hs_not_null : μ s ≠ 0) :
-    essSup (s.indicator f) μ = essSup f (μ.restrict s) := by
-  refine'
-    le_antisymm _
-      (limsSup_le_limsSup_of_le (map_restrict_ae_le_map_indicator_ae hs)
-        (by isBoundedDefault) (by isBoundedDefault) )
-  refine' limsSup_le_limsSup (by isBoundedDefault) (by isBoundedDefault) (fun c h_restrict_le => _)
-  rw [eventually_map] at h_restrict_le ⊢
-  rw [ae_restrict_iff' hs] at h_restrict_le
-  have hc : 0 ≤ c := by
-    rsuffices ⟨x, hx⟩ : ∃ x, 0 ≤ f x ∧ f x ≤ c
-    exact hx.1.trans hx.2
-    refine' Frequently.exists _
-    · exact μ.ae
-    rw [EventuallyLE, ae_restrict_iff' hs] at hf
-    have hs' : ∃ᵐ x ∂μ, x ∈ s := by
-      contrapose! hs_not_null
-      rw [not_frequently, ae_iff] at hs_not_null
-      suffices { a : α | ¬a ∉ s } = s by rwa [← this]
-      simp
-    refine' hs'.mp (hf.mp (h_restrict_le.mono fun x hxs_imp_c hxf_nonneg hxs => _))
-    rw [Pi.zero_apply] at hxf_nonneg
-    exact ⟨hxf_nonneg hxs, hxs_imp_c hxs⟩
-  refine' h_restrict_le.mono fun x hxc => _
-  by_cases hxs : x ∈ s
-  · simpa [hxs] using hxc hxs
-  · simpa [hxs] using hc
-#align ess_sup_indicator_eq_ess_sup_restrict essSup_indicator_eq_essSup_restrict
-
-end CompleteLinearOrder
-
 namespace ENNReal
 
 variable {f : α → ℝ≥0∞}
+
+lemma essSup_piecewise {s : Set α} [DecidablePred (· ∈ s)] {g} (hs : MeasurableSet s) :
+    essSup (s.piecewise f g) μ = max (essSup f (μ.restrict s)) (essSup g (μ.restrict sᶜ)) := by
+  simp only [essSup, limsup_piecewise, blimsup_eq_limsup, ae_restrict_eq, hs, hs.compl]; rfl
+
+theorem essSup_indicator_eq_essSup_restrict {s : Set α} {f : α → ℝ≥0∞} (hs : MeasurableSet s) :
+    essSup (s.indicator f) μ = essSup f (μ.restrict s) := by
+  classical
+  simp only [← piecewise_eq_indicator, essSup_piecewise hs, max_eq_left_iff]
+  exact limsup_const_bot.trans_le (zero_le _)
 
 theorem ae_le_essSup (f : α → ℝ≥0∞) : ∀ᵐ y ∂μ, f y ≤ essSup f μ :=
   eventually_le_limsup f

--- a/Mathlib/MeasureTheory/Function/LpSeminorm.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm.lean
@@ -909,33 +909,19 @@ theorem meas_snormEssSup_lt {f : α → F} : μ { y | snormEssSup f μ < ‖f y�
   meas_essSup_lt
 #align measure_theory.meas_snorm_ess_sup_lt MeasureTheory.meas_snormEssSup_lt
 
-lemma snormEssSup_piecewise_le {s : Set α} (f g : α → E) [DecidablePred (· ∈ s)]
+lemma snormEssSup_piecewise {s : Set α} (f g : α → E) [DecidablePred (· ∈ s)]
     (hs : MeasurableSet s) :
     snormEssSup (Set.piecewise s f g) μ
-      ≤ max (snormEssSup f (μ.restrict s)) (snormEssSup g (μ.restrict sᶜ)) := by
-  refine essSup_le_of_ae_le (max (snormEssSup f (μ.restrict s)) (snormEssSup g (μ.restrict sᶜ))) ?_
-  have hf : ∀ᵐ y ∂(μ.restrict s), ↑‖f y‖₊ ≤ snormEssSup f (μ.restrict s) :=
-    ae_le_snormEssSup (μ := μ.restrict s) (f := f)
-  have hg : ∀ᵐ y ∂(μ.restrict sᶜ), ↑‖g y‖₊ ≤ snormEssSup g (μ.restrict sᶜ) :=
-    ae_le_snormEssSup (μ := μ.restrict sᶜ) (f := g)
-  refine ae_of_ae_restrict_of_ae_restrict_compl s ?_ ?_
-  · rw [ae_restrict_iff' hs] at hf ⊢
-    filter_upwards [hf] with x hx
-    intro hx_mem
-    simp only [hx_mem, Set.piecewise_eq_of_mem]
-    exact (hx hx_mem).trans (le_max_left _ _)
-  · rw [ae_restrict_iff' hs.compl] at hg ⊢
-    filter_upwards [hg] with x hx
-    intro hx_mem
-    rw [Set.mem_compl_iff] at hx_mem
-    simp only [hx_mem, not_false_eq_true, Set.piecewise_eq_of_not_mem]
-    exact (hx hx_mem).trans (le_max_right _ _)
+      = max (snormEssSup f (μ.restrict s)) (snormEssSup g (μ.restrict sᶜ)) := by
+  simp only [snormEssSup, ← essSup_piecewise hs]
+  congr with x
+  by_cases hx : x ∈ s <;> simp [hx]
 
-lemma snorm_top_piecewise_le {s : Set α} (f g : α → E) [DecidablePred (· ∈ s)]
+lemma snorm_top_piecewise {s : Set α} (f g : α → E) [DecidablePred (· ∈ s)]
     (hs : MeasurableSet s) :
     snorm (Set.piecewise s f g) ∞ μ
-      ≤ max (snorm f ∞ (μ.restrict s)) (snorm g ∞ (μ.restrict sᶜ)) :=
-  snormEssSup_piecewise_le f g hs
+      = max (snorm f ∞ (μ.restrict s)) (snorm g ∞ (μ.restrict sᶜ)) :=
+  snormEssSup_piecewise f g hs
 
 section MapMeasure
 

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -730,11 +730,9 @@ lemma Memℒp.piecewise [DecidablePred (· ∈ s)]
   · simp only [hp_zero, memℒp_zero_iff_aestronglyMeasurable]
     exact AEStronglyMeasurable.piecewise hs hf.1 hg.1
   refine ⟨AEStronglyMeasurable.piecewise hs hf.1 hg.1, ?_⟩
-  by_cases hp_top : p = ∞
-  · have hf2 := hf.2
-    have hg2 := hg.2
-    simp only [hp_top] at hf2 hg2 ⊢
-    exact (snorm_top_piecewise_le f g hs).trans_lt (max_lt_iff.mpr ⟨hf2, hg2⟩)
+  rcases eq_or_ne p ∞ with rfl |  hp_top
+  · rw [snorm_top_piecewise f g hs]
+    exact max_lt hf.2 hg.2
   rw [snorm_lt_top_iff_lintegral_rpow_nnnorm_lt_top hp_zero hp_top, ← lintegral_add_compl _ hs,
     ENNReal.add_lt_top]
   constructor

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -730,7 +730,7 @@ lemma Memℒp.piecewise [DecidablePred (· ∈ s)]
   · simp only [hp_zero, memℒp_zero_iff_aestronglyMeasurable]
     exact AEStronglyMeasurable.piecewise hs hf.1 hg.1
   refine ⟨AEStronglyMeasurable.piecewise hs hf.1 hg.1, ?_⟩
-  rcases eq_or_ne p ∞ with rfl |  hp_top
+  rcases eq_or_ne p ∞ with rfl | hp_top
   · rw [snorm_top_piecewise f g hs]
     exact max_lt hf.2 hg.2
   rw [snorm_lt_top_iff_lintegral_rpow_nnnorm_lt_top hp_zero hp_top, ← lintegral_add_compl _ hs,

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -641,17 +641,8 @@ theorem Memℒp.indicator (hs : MeasurableSet s) (hf : Memℒp f p μ) : Memℒp
 
 theorem snormEssSup_indicator_eq_snormEssSup_restrict {f : α → F} (hs : MeasurableSet s) :
     snormEssSup (s.indicator f) μ = snormEssSup f (μ.restrict s) := by
-  simp_rw [snormEssSup, nnnorm_indicator_eq_indicator_nnnorm, ENNReal.coe_indicator]
-  by_cases hs_null : μ s = 0
-  · rw [Measure.restrict_zero_set hs_null]
-    simp only [essSup_measure_zero, ENNReal.essSup_eq_zero_iff, ENNReal.bot_eq_zero]
-    have hs_empty : s =ᵐ[μ] (∅ : Set α) := by rw [ae_eq_set]; simpa using hs_null
-    refine' (indicator_ae_eq_of_ae_eq_set hs_empty).trans _
-    rw [Set.indicator_empty]
-    rfl
-  rw [essSup_indicator_eq_essSup_restrict (eventually_of_forall fun x => ?_) hs hs_null]
-  rw [Pi.zero_apply]
-  exact zero_le _
+  simp_rw [snormEssSup, nnnorm_indicator_eq_indicator_nnnorm, ENNReal.coe_indicator,
+    ENNReal.essSup_indicator_eq_essSup_restrict hs]
 #align measure_theory.snorm_ess_sup_indicator_eq_snorm_ess_sup_restrict MeasureTheory.snormEssSup_indicator_eq_snormEssSup_restrict
 
 theorem snorm_indicator_eq_snorm_restrict {f : α → F} (hs : MeasurableSet s) :

--- a/Mathlib/Order/LiminfLimsup.lean
+++ b/Mathlib/Order/LiminfLimsup.lean
@@ -471,16 +471,17 @@ theorem bliminf_true (f : Filter β) (u : β → α) : (bliminf u f fun _ => Tru
   simp [bliminf_eq, liminf_eq]
 #align filter.bliminf_true Filter.bliminf_true
 
+lemma blimsup_eq_limsup {f : Filter β} {u : β → α} {p : β → Prop} :
+    blimsup u f p = limsup u (f ⊓ 𝓟 {x | p x}) := by
+  simp only [blimsup_eq, limsup_eq, eventually_inf_principal, mem_setOf_eq]
+
+lemma bliminf_eq_liminf {f : Filter β} {u : β → α} {p : β → Prop} :
+    bliminf u f p = liminf u (f ⊓ 𝓟 {x | p x}) :=
+  blimsup_eq_limsup (α := αᵒᵈ)
+
 theorem blimsup_eq_limsup_subtype {f : Filter β} {u : β → α} {p : β → Prop} :
     blimsup u f p = limsup (u ∘ ((↑) : { x | p x } → β)) (comap (↑) f) := by
-  simp only [blimsup_eq, limsup_eq, Function.comp_apply, eventually_comap, SetCoe.forall,
-    Subtype.coe_mk, mem_setOf_eq]
-  congr
-  ext a
-  simp_rw [Subtype.forall]
-  exact eventually_congr (
-       eventually_of_forall
-        fun x => ⟨fun hx y hy hxy => hxy.symm ▸ hx (hxy ▸ hy), fun hx hx' => hx x hx' rfl⟩)
+  rw [blimsup_eq_limsup, limsup, limsup, ← map_map, map_comap_setCoe_val]
 #align filter.blimsup_eq_limsup_subtype Filter.blimsup_eq_limsup_subtype
 
 theorem bliminf_eq_liminf_subtype {f : Filter β} {u : β → α} {p : β → Prop} :
@@ -642,13 +643,7 @@ theorem limsup_congr {α : Type*} [ConditionallyCompleteLattice β] {f : Filter 
 
 theorem blimsup_congr {f : Filter β} {u v : β → α} {p : β → Prop} (h : ∀ᶠ a in f, p a → u a = v a) :
     blimsup u f p = blimsup v f p := by
-  rw [blimsup_eq]
-  congr with b
-  refine' eventually_congr (h.mono fun x hx => ⟨fun h₁ h₂ => _, fun h₁ h₂ => _⟩)
-  · rw [← hx h₂]
-    exact h₁ h₂
-  · rw [hx h₂]
-    exact h₁ h₂
+  simpa only [blimsup_eq_limsup] using limsup_congr <| eventually_inf_principal.2 h
 #align filter.blimsup_congr Filter.blimsup_congr
 
 theorem bliminf_congr {f : Filter β} {u v : β → α} {p : β → Prop} (h : ∀ᶠ a in f, p a → u a = v a) :
@@ -683,11 +678,7 @@ theorem HasBasis.liminf_eq_sSup_iUnion_iInter {ι ι' : Type*} {f : ι → α} {
 theorem HasBasis.liminf_eq_sSup_univ_of_empty {f : ι → α} {v : Filter ι}
     {p : ι' → Prop} {s : ι' → Set ι} (hv : v.HasBasis p s) (i : ι') (hi : p i) (h'i : s i = ∅) :
     liminf f v = sSup univ := by
-  simp_rw [liminf_eq, hv.eventually_iff]
-  congr
-  ext x
-  simp only [mem_setOf_eq, mem_univ, iff_true]
-  exact ⟨i, by simp [hi, h'i]⟩
+  simp [hv.eq_bot_iff.2 ⟨i, hi, h'i⟩, liminf_eq]
 
 theorem HasBasis.limsup_eq_sInf_iUnion_iInter {ι ι' : Type*} {f : ι → α} {v : Filter ι}
     {p : ι' → Prop} {s : ι' → Set ι} (hv : v.HasBasis p s) :
@@ -698,6 +689,20 @@ theorem HasBasis.limsup_eq_sInf_univ_of_empty {f : ι → α} {v : Filter ι}
     {p : ι' → Prop} {s : ι' → Set ι} (hv : v.HasBasis p s) (i : ι') (hi : p i) (h'i : s i = ∅) :
     limsup f v = sInf univ :=
   HasBasis.liminf_eq_sSup_univ_of_empty (α := αᵒᵈ) hv i hi h'i
+
+-- Porting note: simp_nf linter incorrectly says: lhs does not simplify when using simp on itself.
+@[simp, nolint simpNF]
+theorem liminf_nat_add (f : ℕ → α) (k : ℕ) :
+    liminf (fun i => f (i + k)) atTop = liminf f atTop := by
+  change liminf (f ∘ (· + k)) atTop = liminf f atTop
+  rw [liminf, liminf, ← map_map, map_add_atTop_eq_nat]
+#align filter.liminf_nat_add Filter.liminf_nat_add
+
+-- Porting note: simp_nf linter incorrectly says: lhs does not simplify when using simp on itself.
+@[simp, nolint simpNF]
+theorem limsup_nat_add (f : ℕ → α) (k : ℕ) : limsup (fun i => f (i + k)) atTop = limsup f atTop :=
+  @liminf_nat_add αᵒᵈ _ f k
+#align filter.limsup_nat_add Filter.limsup_nat_add
 
 end ConditionallyCompleteLattice
 
@@ -809,8 +814,7 @@ theorem HasBasis.limsup_eq_iInf_iSup {p : ι → Prop} {s : ι → Set β} {f : 
 theorem blimsup_congr' {f : Filter β} {p q : β → Prop} {u : β → α}
     (h : ∀ᶠ x in f, u x ≠ ⊥ → (p x ↔ q x)) : blimsup u f p = blimsup u f q := by
   simp only [blimsup_eq]
-  congr
-  ext a
+  congr with a
   refine' eventually_congr (h.mono fun b hb => _)
   cases' eq_or_ne (u b) ⊥ with hu hu; · simp [hu]
   rw [hb hu]
@@ -821,29 +825,20 @@ theorem bliminf_congr' {f : Filter β} {p q : β → Prop} {u : β → α}
   blimsup_congr' (α := αᵒᵈ) h
 #align filter.bliminf_congr' Filter.bliminf_congr'
 
+lemma HasBasis.blimsup_eq_iInf_iSup {p : ι → Prop} {s : ι → Set β} {f : Filter β} {u : β → α}
+    (hf : f.HasBasis p s) {q : β → Prop} :
+    blimsup u f q = ⨅ (i) (_ : p i), ⨆ a ∈ s i, ⨆ (_ : q a), u a := by
+  simp only [blimsup_eq_limsup, (hf.inf_principal _).limsup_eq_iInf_iSup, mem_inter_iff, iSup_and,
+    mem_setOf_eq]
+
 theorem blimsup_eq_iInf_biSup {f : Filter β} {p : β → Prop} {u : β → α} :
     blimsup u f p = ⨅ s ∈ f, ⨆ (b) (_ : p b ∧ b ∈ s), u b := by
-  refine' le_antisymm (sInf_le_sInf _) (iInf_le_iff.mpr fun a ha => le_sInf_iff.mpr fun a' ha' => _)
-  · rintro - ⟨s, rfl⟩
-    simp only [mem_setOf_eq, le_iInf_iff]
-    conv =>
-      congr
-      ext
-      rw [Imp.swap]
-    refine'
-      eventually_imp_distrib_left.mpr fun h => eventually_iff_exists_mem.2 ⟨s, h, fun x h₁ h₂ => _⟩
-    exact @le_iSup₂ α β (fun b => p b ∧ b ∈ s) _ (fun b _ => u b) x ⟨h₂, h₁⟩
-  · obtain ⟨s, hs, hs'⟩ := eventually_iff_exists_mem.mp ha'
-    have : ∀ (y : β), p y → y ∈ s → u y ≤ a' := fun y ↦ by rw [Imp.swap]; exact hs' y
-    exact (le_iInf_iff.mp (ha s) hs).trans (by simpa only [iSup₂_le_iff, and_imp] )
+  simp only [f.basis_sets.blimsup_eq_iInf_iSup, iSup_and', id, and_comm]
 #align filter.blimsup_eq_infi_bsupr Filter.blimsup_eq_iInf_biSup
 
 theorem blimsup_eq_iInf_biSup_of_nat {p : ℕ → Prop} {u : ℕ → α} :
     blimsup u atTop p = ⨅ i, ⨆ (j) (_ : p j ∧ i ≤ j), u j := by
-  -- Porting note: Making this into a single simp only does not work?
-  simp only [blimsup_eq_limsup_subtype, Function.comp,
-    (atTop_basis.comap ((↑) : { x | p x } → ℕ)).limsup_eq_iInf_iSup, iSup_subtype, iSup_and]
-  simp only [mem_setOf_eq, mem_preimage, mem_Ici, not_le, iInf_pos]
+  simp only [atTop_basis.blimsup_eq_iInf_iSup, @and_comm (p _), iSup_and, mem_Ici, iInf_true]
 #align filter.blimsup_eq_infi_bsupr_of_nat Filter.blimsup_eq_iInf_biSup_of_nat
 
 /-- In a complete lattice, the liminf of a function is the infimum over sets `s` in the filter
@@ -877,15 +872,13 @@ theorem bliminf_eq_iSup_biInf_of_nat {p : ℕ → Prop} {u : ℕ → α} :
 
 theorem limsup_eq_sInf_sSup {ι R : Type*} (F : Filter ι) [CompleteLattice R] (a : ι → R) :
     limsup a F = sInf ((fun I => sSup (a '' I)) '' F.sets) := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · rw [limsup_eq]
     refine' sInf_le_sInf fun x hx => _
     rcases (mem_image _ F.sets x).mp hx with ⟨I, ⟨I_mem_F, hI⟩⟩
     filter_upwards [I_mem_F] with i hi
     exact hI ▸ le_sSup (mem_image_of_mem _ hi)
-  · refine'
-      le_sInf_iff.mpr fun b hb =>
-        sInf_le_of_le (mem_image_of_mem _ <| Filter.mem_sets.mpr hb) <| sSup_le _
+  · refine le_sInf fun b hb => sInf_le_of_le (mem_image_of_mem _ hb) <| sSup_le ?_
     rintro _ ⟨_, h, rfl⟩
     exact h
 set_option linter.uppercaseLean3 false in
@@ -896,20 +889,6 @@ theorem liminf_eq_sSup_sInf {ι R : Type*} (F : Filter ι) [CompleteLattice R] (
   @Filter.limsup_eq_sInf_sSup ι (OrderDual R) _ _ a
 set_option linter.uppercaseLean3 false in
 #align filter.liminf_eq_Sup_Inf Filter.liminf_eq_sSup_sInf
-
--- Porting note: simp_nf linter incorrectly says: lhs does not simplify when using simp on itself.
-@[simp, nolint simpNF]
-theorem liminf_nat_add (f : ℕ → α) (k : ℕ) :
-    liminf (fun i => f (i + k)) atTop = liminf f atTop := by
-  simp_rw [liminf_eq_iSup_iInf_of_nat]
-  exact iSup_iInf_ge_nat_add f k
-#align filter.liminf_nat_add Filter.liminf_nat_add
-
--- Porting note: simp_nf linter incorrectly says: lhs does not simplify when using simp on itself.
-@[simp, nolint simpNF]
-theorem limsup_nat_add (f : ℕ → α) (k : ℕ) : limsup (fun i => f (i + k)) atTop = limsup f atTop :=
-  @liminf_nat_add αᵒᵈ _ f k
-#align filter.limsup_nat_add Filter.limsup_nat_add
 
 theorem liminf_le_of_frequently_le' {α β} [CompleteLattice β] {f : Filter α} {u : α → β} {x : β}
     (h : ∃ᶠ a in f, u a ≤ x) : liminf u f ≤ x := by
@@ -982,7 +961,6 @@ theorem bliminf_antitone_filter (h : f ≤ g) : bliminf u g p ≤ bliminf u f p 
 theorem blimsup_monotone_filter (h : f ≤ g) : blimsup u f p ≤ blimsup u g p :=
   sInf_le_sInf fun _ ha => ha.filter_mono h
 #align filter.blimsup_monotone_filter Filter.blimsup_monotone_filter
-
 
 -- @[simp] -- Porting note: simp_nf linter, lhs simplifies, added _aux versions below
 theorem blimsup_and_le_inf : (blimsup u f fun x => p x ∧ q x) ≤ blimsup u f p ⊓ blimsup u f q :=
@@ -1074,18 +1052,51 @@ section CompleteDistribLattice
 
 variable [CompleteDistribLattice α] {f : Filter β} {p q : β → Prop} {u : β → α}
 
+lemma limsup_sup_filter {g} : limsup u (f ⊔ g) = limsup u f ⊔ limsup u g := by
+  refine le_antisymm ?_
+    (sup_le (limsup_le_limsup_of_le le_sup_left) (limsup_le_limsup_of_le le_sup_right))
+  simp_rw [limsup_eq, sInf_sup_eq, sup_sInf_eq, mem_setOf_eq, le_iInf₂_iff]
+  intro a ha b hb
+  exact sInf_le ⟨ha.mono fun _ h ↦ h.trans le_sup_left, hb.mono fun _ h ↦ h.trans le_sup_right⟩
+
+lemma liminf_sup_filter {g} : liminf u (f ⊔ g) = liminf u f ⊓ liminf u g :=
+  limsup_sup_filter (α := αᵒᵈ)
+
 @[simp]
 theorem blimsup_or_eq_sup : (blimsup u f fun x => p x ∨ q x) = blimsup u f p ⊔ blimsup u f q := by
-  refine' le_antisymm _ blimsup_sup_le_or
-  simp only [blimsup_eq, sInf_sup_eq, sup_sInf_eq, le_iInf₂_iff, mem_setOf_eq]
-  refine' fun a' ha' a ha => sInf_le ((ha.and ha').mono fun b h hb => _)
-  exact Or.elim hb (fun hb => le_sup_of_le_left <| h.1 hb) fun hb => le_sup_of_le_right <| h.2 hb
+  simp only [blimsup_eq_limsup, ← limsup_sup_filter, ← inf_sup_left, sup_principal, setOf_or]
 #align filter.blimsup_or_eq_sup Filter.blimsup_or_eq_sup
 
 @[simp]
 theorem bliminf_or_eq_inf : (bliminf u f fun x => p x ∨ q x) = bliminf u f p ⊓ bliminf u f q :=
   blimsup_or_eq_sup (α := αᵒᵈ)
 #align filter.bliminf_or_eq_inf Filter.bliminf_or_eq_inf
+
+@[simp]
+lemma blimsup_sup_not : blimsup u f p ⊔ blimsup u f (¬p ·) = limsup u f := by
+  simp_rw [← blimsup_or_eq_sup, or_not, blimsup_true]
+
+@[simp]
+lemma bliminf_inf_not : bliminf u f p ⊓ bliminf u f (¬p ·) = liminf u f :=
+  blimsup_sup_not (α := αᵒᵈ)
+
+@[simp]
+lemma blimsup_not_sup : blimsup u f (¬p ·) ⊔ blimsup u f p = limsup u f := by
+  simpa only [not_not] using blimsup_sup_not (p := (¬p ·))
+
+@[simp]
+lemma bliminf_not_inf : bliminf u f (¬p ·) ⊓ bliminf u f p = liminf u f :=
+  blimsup_not_sup (α := αᵒᵈ)
+
+lemma limsup_piecewise {s : Set β} [DecidablePred (· ∈ s)] {v} :
+    limsup (s.piecewise u v) f = blimsup u f (· ∈ s) ⊔ blimsup v f (· ∉ s) := by
+  rw [← blimsup_sup_not (p := (· ∈ s))]
+  refine congr_arg₂ _ (blimsup_congr ?_) (blimsup_congr ?_) <;>
+    refine eventually_of_forall fun _ h ↦ ?_ <;> simp [h]
+
+lemma liminf_piecewise {s : Set β} [DecidablePred (· ∈ s)] {v} :
+    liminf (s.piecewise u v) f = bliminf u f (· ∈ s) ⊓ bliminf v f (· ∉ s) :=
+  limsup_piecewise (α := αᵒᵈ)
 
 theorem sup_limsup [NeBot f] (a : α) : a ⊔ limsup u f = limsup (fun x => a ⊔ u x) f := by
   simp only [limsup_eq_iInf_iSup, iSup_sup_eq, sup_iInf₂_eq]


### PR DESCRIPTION
- Add `blimsup_eq_limsup` and `bliminf_eq_liminf`
- Generalize `limsup_nat_add` and `liminf_nat_add`
  to a `ConditionallyCompleteLattice`.
- Add `Filter.HasBasis.blimsup_eq_iInf_iSup`.
- Add `limsup_sup_filter`, `liminf_sup_filter`, `blimsup_sup_not`,
  `bliminf_inf_not`, `blimsup_not_sup`, `bliminf_not_inf`,
  `limsup_piecewise`, and `liminf_piecewise`.
- Add `essSup_piecewise`.
- Assume that the codomain is `ℝ≥0∞`
  in `essSup_indicator_eq_essSup_restrict`.
  This allows us to drop assumptions `0 ≤ᵐ[_] f` and `μ s ≠ 0`.
- Upgrade inequality to an equality in `snormEssSup_piecewise_le` (now
  `snormEssSup_piecewise`) and `snorm_top_piecewise_le` (now
  `snorm_top_piecewise`).
- Use new lemmas to golf some proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)