### PR TITLE
[Merged by Bors] - feat: Combinatorial subspaces and multidimensional Hales-Jewett

### DIFF
--- a/Mathlib/Combinatorics/HalesJewett.lean
+++ b/Mathlib/Combinatorics/HalesJewett.lean
@@ -100,15 +100,15 @@ variable {l : Line α ι} {i : ι} {a x : α}
 instance (α ι) : CoeFun (Line α ι) fun _ => α → ι → α :=
   ⟨fun l x i => (l.idxFun i).getD x⟩
 
-instance instFunLike [Nontrivial α] : FunLike (Line α ι) α fun _ => ι → α where
-  coe := (⇑)
-  coe_injective' l m hlm := by
-    ext i a
-    obtain ⟨b, hba⟩ := exists_ne a
-    simp only [Option.mem_def, funext_iff] at hlm ⊢
-    refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-    · cases hi : idxFun m i <;> simpa [@eq_comm _ a, hi, h, hba] using hlm b i
-    · cases hi : idxFun l i <;> simpa [@eq_comm _ a, hi, h, hba] using hlm b i
+-- Note: This is not made a `FunLike` instance to avoid having two syntactically different coercions
+lemma coe_injective [Nontrivial α] : Injective ((⇑) : Line α ι → α → ι → α) := by
+  rintro l m hlm
+  ext i a
+  obtain ⟨b, hba⟩ := exists_ne a
+  simp only [Option.mem_def, funext_iff] at hlm ⊢
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · cases hi : idxFun m i <;> simpa [@eq_comm _ a, hi, h, hba] using hlm b i
+  · cases hi : idxFun l i <;> simpa [@eq_comm _ a, hi, h, hba] using hlm b i
 
 /-- A line is monochromatic if all its points are the same color. -/
 def IsMono {α ι κ} (C : (ι → α) → κ) (l : Line α ι) : Prop :=
@@ -393,25 +393,25 @@ instance : Inhabited (Subspace ι α ι) := ⟨⟨Sum.inr, fun i ↦ ⟨i, rfl�
 instance instCoeFun : CoeFun (Subspace η α ι) (fun _ ↦ (η → α) → ι → α) :=
   ⟨fun l x i ↦ (l.idxFun i).elim id x⟩
 
-instance instFunLike [Nontrivial α] : FunLike (Subspace η α ι) (η → α) (fun _ ↦ ι → α) where
-  coe := (⇑)
-  coe_injective' l m hlm := by
-    ext i
-    simp only [funext_iff] at hlm
-    cases hl : idxFun l i with
+-- Note: This is not made a `FunLike` instance to avoid having two syntactically different coercions
+lemma coe_injective [Nontrivial α] : Injective ((⇑) : Subspace η α ι → (η → α) → ι → α) := by
+  rintro l m hlm
+  ext i
+  simp only [funext_iff] at hlm
+  cases hl : idxFun l i with
+  | inl a =>
+    obtain ⟨b, hba⟩ := exists_ne a
+    cases hm : idxFun m i <;> simpa [hl, hm, hba.symm] using hlm (const _ b) i
+  | inr e =>
+    cases hm : idxFun m i with
     | inl a =>
       obtain ⟨b, hba⟩ := exists_ne a
-      cases hm : idxFun m i <;> simpa [hl, hm, hba.symm] using hlm (const _ b) i
-    | inr e =>
-      cases hm : idxFun m i with
-      | inl a =>
-        obtain ⟨b, hba⟩ := exists_ne a
-        simpa [hl, hm, hba] using hlm (const _ b) i
-      | inr f =>
-        obtain ⟨a, b, hab⟩ := exists_pair_ne α
-        simp only [Sum.inr.injEq]
-        by_contra' hef
-        simpa [hl, hm, hef, hab] using hlm (Function.update (const _ a) f b) i
+      simpa [hl, hm, hba] using hlm (const _ b) i
+    | inr f =>
+      obtain ⟨a, b, hab⟩ := exists_pair_ne α
+      simp only [Sum.inr.injEq]
+      by_contra! hef
+      simpa [hl, hm, hef, hab] using hlm (Function.update (const _ a) f b) i
 
 lemma apply_def (l : Subspace η α ι) (x : η → α) (i : ι) : l x i = (l.idxFun i).elim id x := rfl
 lemma apply_inl (h : l.idxFun i = Sum.inl a) : l x i = a := by simp [apply_def, h]

--- a/Mathlib/Combinatorics/HalesJewett.lean
+++ b/Mathlib/Combinatorics/HalesJewett.lean
@@ -14,8 +14,8 @@ import Mathlib.Data.Fintype.Sum
 /-!
 # The Hales-Jewett theorem
 
-We prove the Hales-Jewett theorem. We deduce Van der Waerden's theorem and the extended Hales-Jewett
-theorem as corollaries.
+We prove the Hales-Jewett theorem. We deduce Van der Waerden's theorem and the multidimensional
+Hales-Jewett theorem as corollaries.
 
 The Hales-Jewett theorem is a result in Ramsey theory dealing with *combinatorial lines*. Given
 an 'alphabet' `α : Type*` and `a b : α`, an example of a combinatorial line in `α^5` is
@@ -27,8 +27,8 @@ the idea of *color focusing* and a *product argument*. See the proof of
 `Combinatorics.Line.exists_mono_in_high_dimension'` for details.
 
 *Combinatorial subspaces* are higher-dimensional analogues of combinatorial lines. See
-`Combinatorics.Subspace`. The extended Hales-Jewett theorem generalises the statement above from
-combinatorial lines to combinatorial subspaces of a fixed dimension.
+`Combinatorics.Subspace`. The multidimensional Hales-Jewett theorem generalises the statement above
+from combinatorial lines to combinatorial subspaces of a fixed dimension.
 
 The version of Van der Waerden's theorem in this file states that whenever a commutative monoid `M`
 is finitely colored and `S` is a finite subset, there exists a monochromatic homothetic copy of `S`.
@@ -38,7 +38,7 @@ to `∑ i : ι, v i`, which sends a combinatorial line to a homothetic copy of `
 ## Main results
 
 - `Combinatorics.Line.exists_mono_in_high_dimension`: The Hales-Jewett theorem.
-- `Combinatorics.Subspace.exists_mono_in_high_dimension`: The extended Hales-Jewett theorem.
+- `Combinatorics.Subspace.exists_mono_in_high_dimension`: The multidimensional Hales-Jewett theorem.
 - `Combinatorics.exists_mono_homothetic_copy`: A generalization of Van der Waerden's theorem.
 
 ## Implementation details
@@ -484,9 +484,9 @@ theorem exists_mono_homothetic_copy {M κ : Type*} [AddCommMonoid M] (S : Finset
 
 namespace Subspace
 
-/-- The **extended Hales-Jewett theorem**: For any finite types `η`, `α` and `κ`, there exists a
-finite type `ι` such that whenever the hypercube `ι → α` is `κ`-colored, there is a monochromatic
-combinatorial subspace of dimension `η`. -/
+/-- The **multidimensional Hales-Jewett theorem**, aka **extended Hales-Jewett theorem**: For any
+finite types `η`, `α` and `κ`, there exists a finite type `ι` such that whenever the hypercube
+`ι → α` is `κ`-colored, there is a monochromatic combinatorial subspace of dimension `η`. -/
 theorem exists_mono_in_high_dimension (α κ η) [Fintype α] [Fintype κ] [Fintype η] :
     ∃ (ι : Type) (_ : Fintype ι), ∀ C : (ι → α) → κ, ∃ l : Subspace η α ι, l.IsMono C := by
   obtain ⟨ι, _, hι⟩ := Line.exists_mono_in_high_dimension (Shrink.{0} η → α) κ

--- a/Mathlib/Combinatorics/HalesJewett.lean
+++ b/Mathlib/Combinatorics/HalesJewett.lean
@@ -26,7 +26,7 @@ huge) finite type `ι` such that whenever `ι → α` is `κ`-colored (i.e. for 
 the idea of *color focusing* and a *product argument*. See the proof of
 `Combinatorics.Line.exists_mono_in_high_dimension'` for details.
 
-*Combinatorial subspaces* are higher-dimensional analogues of combinatorial lines, defined in
+*Combinatorial subspaces* are higher-dimensional analogues of combinatorial lines. See
 `Combinatorics.Subspace`. The extended Hales-Jewett theorem generalises the statement above from
 combinatorial lines to combinatorial subspaces of a fixed dimension.
 


### PR DESCRIPTION
This PR extends the Hales-Jewett theorem from combinatorial lines to higher-dimensional combinatorial subspaces. It's an example of a theorem proving its own generalisation.

Co-authored-by: David Wärn

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #13725
- [x] depends on: #13988

The plan is to eventually use this to prove existence of monochromatic `(m, p, c)`-sets.

Ported from https://github.com/leanprover-community/mathlib/pull/11305

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
