### PR TITLE
[Merged by Bors] - chore(Analysis/InnerProductSpace): LinearMap.isAdjointPair_inner generalization to isROrC

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -477,25 +477,12 @@ theorem isSymmetric_iff_isSelfAdjoint (A : E →ₗ[𝕜] E) : IsSymmetric A ↔
   exact eq_comm
 #align linear_map.is_symmetric_iff_is_self_adjoint LinearMap.isSymmetric_iff_isSelfAdjoint
 
-section Real
-
-variable {E' : Type*} {F' : Type*}
-
-variable [NormedAddCommGroup E'] [NormedAddCommGroup F']
-
-variable [InnerProductSpace ℝ E'] [InnerProductSpace ℝ F']
-
-variable [FiniteDimensional ℝ E'] [FiniteDimensional ℝ F']
-
--- Todo: Generalize this to `IsROrC`.
-theorem isAdjointPair_inner (A : E' →ₗ[ℝ] F') :
-    IsAdjointPair (sesqFormOfInner : E' →ₗ[ℝ] E' →ₗ[ℝ] ℝ) (sesqFormOfInner : F' →ₗ[ℝ] F' →ₗ[ℝ] ℝ) A
+theorem isAdjointPair_inner (A : E →ₗ[𝕜] F) :
+    IsAdjointPair (sesqFormOfInner : E →ₗ[𝕜] E →ₗ⋆[𝕜] 𝕜) (sesqFormOfInner : F →ₗ[𝕜] F →ₗ⋆[𝕜] 𝕜) A
       (LinearMap.adjoint A) := by
   intro x y
   simp only [sesqFormOfInner_apply_apply, adjoint_inner_left]
 #align linear_map.is_adjoint_pair_inner LinearMap.isAdjointPair_inner
-
-end Real
 
 /-- The Gram operator T†T is symmetric. -/
 theorem isSymmetric_adjoint_mul_self (T : E →ₗ[𝕜] E) : IsSymmetric (LinearMap.adjoint T * T) := by


### PR DESCRIPTION
I forgot in the previous PR (#8295) that there are two versions of the adjoint. 

---

Sorry for that.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
