### PR TITLE
[Merged by Bors] - fix: continuity: remove npowRec rule

### DIFF
--- a/Mathlib/Tactic/Continuity.lean
+++ b/Mathlib/Tactic/Continuity.lean
@@ -13,10 +13,6 @@ import Mathlib.Algebra.Group.Defs
 We define the `continuity` tactic using `aesop`. -/
 
 attribute [aesop (rule_sets [Continuous]) unfold norm] Function.comp
--- FIXME: `npowRec` is an internal implementation detail,
--- and `aesop` certainly should not know about it.
--- If anyone is working on the `continuity` tactic, please try to fix this!
-attribute [aesop (rule_sets [Continuous]) norm] npowRec
 
 /--
 The `continuity` attribute used to tag continuity statements for the `continuity` tactic. -/

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -573,7 +573,16 @@ instance AddMonoid.continuousSMul_nat {A} [AddMonoid A] [TopologicalSpace A]
   ⟨continuous_prod_of_discrete_left.mpr continuous_nsmul⟩
 #align add_monoid.has_continuous_smul_nat AddMonoid.continuousSMul_nat
 
-@[to_additive (attr := continuity)]
+-- We register `Continuous.pow` as a `continuity` lemma with low penalty (so
+-- `continuity` will try it before other `continuity` lemmas). This is a
+-- workaround for goals of the form `Continuous fun x => x ^ 2`, where
+-- `continuity` applies `Continuous.mul` since the goal is defeq to
+-- `Continuous fun x => x * x`.
+--
+-- To properly fix this, we should make sure that `continuity` applies its
+-- lemmas with reducible transparency, preventing the unfolding of `^`. But this
+-- is quite an invasive change.
+@[to_additive (attr := aesop safe -100 (rule_sets [Continuous]))]
 theorem Continuous.pow {f : X → M} (h : Continuous f) (n : ℕ) : Continuous fun b => f b ^ n :=
   (continuous_pow n).comp h
 #align continuous.pow Continuous.pow


### PR DESCRIPTION
This rule used to unfold the recursive function `npowRec` unconditionally, so Aesop would loop during normalisation unless another normalisation rule (usually simp) happened to close the goal. To prevent this issue, Aesop master now disallows recursive unfold rules, so we have to remove the `npowRec` rule.


---

I'm also working on a bigger `continuity` refactor along the lines of #7909. But I'd like to merge this first so that mathlib can track Aesop master again.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
