### PR TITLE
chore(lakefile.lean): use `elan` from PATH to fetch cache

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -82,7 +82,7 @@ post_update pkg do
   spawn a new `lake` since the toolchain may have changed.
   -/
   let exitCode ← IO.Process.spawn {
-    cmd := (← getElan?).map (·.toString) |>.getD "elan"
+    cmd := "elan"
     args := #["run", mathlibToolchain, "lake", "exe", "cache", "get"]
   } >>= (·.wait)
   if exitCode ≠ 0 then


### PR DESCRIPTION
This fixes the following error I see when running `lake update` on a custom project:
```
mathlib: running post-update hooks
could not execute external process '/home/username/.elan/bin/elan'
```
I do have a `/home/username/.elan` directory but it does not contain a bin subdir.

---
Using `elan` from PATH was suggested by tydeu in https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Disable.20lake.20post-hook.20when.20importing.20mathlib.3F/near/401541311

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
