### PR TITLE
[Merged by Bors] - docs: improve `Set` documentation

### DIFF
--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -35,9 +35,16 @@ This file is a port of the core Lean 3 file `lib/lean/library/init/data/set.lean
 
 set_option autoImplicit true
 
+/-- A set is a collection of elements of some type `α`.
+
+    Although `Set` is defined as `α → Prop`, this is an implementation detail which should not be
+    relied on. Instead, `setOf` and membership of a set (`∈`) should be used to convert between sets
+    and predicates.
+-/
 def Set (α : Type u) := α → Prop
 #align set Set
 
+/-- Turn a predicate `p : α → Prop` into a set, also written as `{x | p x}` -/
 def setOf {α : Type u} (p : α → Prop) : Set α :=
   p
 #align set_of setOf


### PR DESCRIPTION
Document the fact that the defeq between `Set α` and `α → Prop` is an internal implementation detail

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Inspired by: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Predicate.20vs.20Set, 
and the fact that I did not know this defeq was not to be used until recently.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
