### PR TITLE
[Merged by Bors] - feat: add four lemmas on topological sums

### DIFF
--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -215,9 +215,11 @@ theorem hasSum_single {f : β → α} (b : β) (hf : ∀ (b') (_ : b' ≠ b), f 
   hasSum_sum_of_ne_finset_zero <| by simpa [hf]
 #align has_sum_single hasSum_single
 
-lemma hasSum_singleton (m : β) (f : β → α) : HasSum (({m} : Set β).restrict f) (f m) := by
-  convert_to HasSum (fun x : ({m} : Set β) ↦ f x) (f (⟨m, rfl⟩ : ({m} : Set β)))
-  exact hasSum_single (α := α) _ <| fun m' h ↦ False.elim <| h <| Subtype.ext m'.2
+@[simp] lemma hasSum_unique [Unique β] (f : β → α) : HasSum f (f default) :=
+  hasSum_single default (fun _ hb ↦ False.elim <| hb <| Unique.uniq ..)
+
+@[simp] lemma hasSum_singleton (m : β) (f : β → α) : HasSum (({m} : Set β).restrict f) (f m) :=
+  hasSum_unique (Set.restrict {m} f)
 
 theorem hasSum_ite_eq (b : β) [DecidablePred (· = b)] (a : α) :
     HasSum (fun b' => if b' = b then a else 0) a := by

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -643,19 +643,27 @@ theorem tsum_range {g : γ → β} (f : β → α) (hg : Injective g) :
 #align tsum_range tsum_range
 
 open Set in
-/-- If `f b = 0`, then the sum over all `f a` is the same as the sum over `f a` for `a ≠ b`. -/
-lemma tsum_eq_tsum_diff_singleton {f : β → α} (s : Set β) {b : β} (hf₀ : f b = 0) :
-    ∑' a : s, f a = ∑' a : (s \ {b} : Set β), f a := by
+/-- If `f b = 0` for all `b ∈ t`, then the sum over `f a` with `a ∈ s` is the same as the
+sum over `f a` with `a ∈ a ∖ t`. -/
+lemma tsum_eq_tsum_diff [T2Space α] {f : β → α} (s t : Set β) (hf₀ : ∀ b ∈ t, f b = 0) :
+    ∑' a : s, f a = ∑' a : (s \ t : Set β), f a := by
   simp_rw [_root_.tsum_subtype]
   refine tsum_congr fun b' ↦ ?_
-  by_cases hs : b' ∈ s \ {b}
+  by_cases hs : b' ∈ s \ t
   · rw [indicator_of_mem hs f, indicator_of_mem (mem_of_mem_diff hs) f]
   · rw [indicator_of_not_mem hs f]
-    rcases eq_or_ne b b' with rfl | hb
-    · by_cases h₀ : b ∈ s
-      · rwa [indicator_of_mem h₀ f]
-      · rw [indicator_of_not_mem h₀ f]
-    · rw [indicator_of_not_mem (not_and'.mp (mt mem_diff_singleton.mpr hs) hb.symm) f]
+    rw [mem_diff, not_and, not_not_mem] at hs
+    by_cases h₁ : b' ∈ s
+    · simpa [indicator_of_mem h₁] using hf₀ b' <| hs h₁
+    · exact indicator_of_not_mem h₁ f
+
+open Set in
+/-- If `f b = 0`, then the sum over `f a` with `a ∈ s` is the same as the sum over `f a` for
+`a ∈ s ∖ {b}`. -/
+lemma tsum_eq_tsum_diff_singleton [T2Space α] {f : β → α} (s : Set β) {b : β} (hf₀ : f b = 0) :
+    ∑' a : s, f a = ∑' a : (s \ {b} : Set β), f a :=
+  tsum_eq_tsum_diff s {b} fun a ha ↦ ha ▸ hf₀
+
 section ContinuousAdd
 
 variable [ContinuousAdd α]

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -215,7 +215,7 @@ theorem hasSum_single {f : β → α} (b : β) (hf : ∀ (b') (_ : b' ≠ b), f 
   hasSum_sum_of_ne_finset_zero <| by simpa [hf]
 #align has_sum_single hasSum_single
 
-lemma hasSum_singleton (m : β) (f : β → α) : HasSum (fun x : ({m} : Set β) ↦ f x) (f m) := by
+lemma hasSum_singleton (m : β) (f : β → α) : HasSum (({m} : Set β).restrict f) (f m) := by
   convert_to HasSum (fun x : ({m} : Set β) ↦ f x) (f (⟨m, rfl⟩ : ({m} : Set β)))
   exact hasSum_single (α := α) _ <| fun m' h ↦ False.elim <| h <| Subtype.ext m'.2
 
@@ -644,8 +644,9 @@ theorem tsum_range {g : γ → β} (f : β → α) (hg : Injective g) :
 
 open Set in
 /-- If `f b = 0` for all `b ∈ t`, then the sum over `f a` with `a ∈ s` is the same as the
-sum over `f a` with `a ∈ a ∖ t`. -/
-lemma tsum_eq_tsum_diff [T2Space α] {f : β → α} (s t : Set β) (hf₀ : ∀ b ∈ t, f b = 0) :
+sum over `f a` with `a ∈ s ∖ t`. -/
+lemma tsum_setElem_eq_tsum_setElem_diff [T2Space α] {f : β → α} (s t : Set β)
+    (hf₀ : ∀ b ∈ t, f b = 0) :
     ∑' a : s, f a = ∑' a : (s \ t : Set β), f a := by
   simp_rw [_root_.tsum_subtype]
   refine tsum_congr fun b' ↦ ?_
@@ -657,12 +658,11 @@ lemma tsum_eq_tsum_diff [T2Space α] {f : β → α} (s t : Set β) (hf₀ : ∀
     · simpa [indicator_of_mem h₁] using hf₀ b' <| hs h₁
     · exact indicator_of_not_mem h₁ f
 
-open Set in
 /-- If `f b = 0`, then the sum over `f a` with `a ∈ s` is the same as the sum over `f a` for
 `a ∈ s ∖ {b}`. -/
 lemma tsum_eq_tsum_diff_singleton [T2Space α] {f : β → α} (s : Set β) {b : β} (hf₀ : f b = 0) :
     ∑' a : s, f a = ∑' a : (s \ {b} : Set β), f a :=
-  tsum_eq_tsum_diff s {b} fun _ ha ↦ ha ▸ hf₀
+  tsum_setElem_eq_tsum_setElem_diff s {b} fun _ ha ↦ ha ▸ hf₀
 
 section ContinuousAdd
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -662,7 +662,7 @@ open Set in
 `a ∈ s ∖ {b}`. -/
 lemma tsum_eq_tsum_diff_singleton [T2Space α] {f : β → α} (s : Set β) {b : β} (hf₀ : f b = 0) :
     ∑' a : s, f a = ∑' a : (s \ {b} : Set β), f a :=
-  tsum_eq_tsum_diff s {b} fun a ha ↦ ha ▸ hf₀
+  tsum_eq_tsum_diff s {b} fun _ ha ↦ ha ▸ hf₀
 
 section ContinuousAdd
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -644,7 +644,7 @@ theorem tsum_range {g : γ → β} (f : β → α) (hg : Injective g) :
 
 open Set in
 /-- If `f b = 0`, then the sum over all `f a` is the same as the sum over `f a` for `a ≠ b`. -/
-lemma tsum_eq_tsum_diff_singleton [T2Space α] {f : β → α} (s : Set β) (b : β) (hf₀ : f b = 0) :
+lemma tsum_eq_tsum_diff_singleton {f : β → α} (s : Set β) {b : β} (hf₀ : f b = 0) :
     ∑' a : s, f a = ∑' a : (s \ {b} : Set β), f a := by
   simp_rw [_root_.tsum_subtype]
   refine tsum_congr fun b' ↦ ?_

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -215,6 +215,10 @@ theorem hasSum_single {f : β → α} (b : β) (hf : ∀ (b') (_ : b' ≠ b), f 
   hasSum_sum_of_ne_finset_zero <| by simpa [hf]
 #align has_sum_single hasSum_single
 
+lemma hasSum_singleton (m : β) (f : β → α) : HasSum (fun x : ({m} : Set β) ↦ f x) (f m) := by
+  convert_to HasSum (fun x : ({m} : Set β) ↦ f x) (f (⟨m, rfl⟩ : ({m} : Set β)))
+  exact hasSum_single (α := α) _ <| fun m' h ↦ False.elim <| h <| Subtype.ext m'.2
+
 theorem hasSum_ite_eq (b : β) [DecidablePred (· = b)] (a : α) :
     HasSum (fun b' => if b' = b then a else 0) a := by
   convert @hasSum_single _ _ _ _ (fun b' => if b' = b then a else 0) b (fun b' hb' => if_neg hb')
@@ -638,6 +642,20 @@ theorem tsum_range {g : γ → β} (f : β → α) (hg : Injective g) :
   simp_rw [← comp_apply (g := g), tsum_univ (f ∘ g)]
 #align tsum_range tsum_range
 
+open Set in
+/-- If `f b = 0`, then the sum over all `f a` is the same as the sum over `f a` for `a ≠ b`. -/
+lemma tsum_eq_tsum_diff_singleton [T2Space α] {f : β → α} (s : Set β) (b : β) (hf₀ : f b = 0) :
+    ∑' a : s, f a = ∑' a : (s \ {b} : Set β), f a := by
+  simp_rw [_root_.tsum_subtype]
+  refine tsum_congr fun b' ↦ ?_
+  by_cases hs : b' ∈ s \ {b}
+  · rw [indicator_of_mem hs f, indicator_of_mem (mem_of_mem_diff hs) f]
+  · rw [indicator_of_not_mem hs f]
+    rcases eq_or_ne b b' with rfl | hb
+    · by_cases h₀ : b ∈ s
+      · rwa [indicator_of_mem h₀ f]
+      · rw [indicator_of_not_mem h₀ f]
+    · rw [indicator_of_not_mem (not_and'.mp (mt mem_diff_singleton.mpr hs) hb.symm) f]
 section ContinuousAdd
 
 variable [ContinuousAdd α]


### PR DESCRIPTION
This adds four API lemmas that are useful for establishing Euler products:
```lean
@[simp] lemma hasSum_unique [Unique β] (f : β → α) : HasSum f (f default)

@[simp] lemma hasSum_singleton (m : β) (f : β → α) : HasSum (({m} : Set β).restrict f) (f m)

lemma tsum_setElem_eq_tsum_setElem_diff [T2Space α] {f : β → α} (s t : Set β) (hf₀ : ∀ b ∈ t, f b = 0) :
    ∑' a : s, f a = ∑' a : (s \ t : Set β), f a

lemma tsum_eq_tsum_diff_singleton {α  β : Type*} [AddCommMonoid α] [TopologicalSpace α] [T2Space α]
    {f : β → α} (s : Set β) (b : β) (hf₀ : f b = 0) :
    ∑' a : s, f a = ∑' a : (s \ {b} : Set β), f a
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
