### PR TITLE
[Merged by Bors] - feat(Data/Nat): add Nat.div_pow

### DIFF
--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -707,6 +707,26 @@ protected theorem div_left_inj {a b d : ℕ} (hda : d ∣ a) (hdb : d ∣ b) : a
   rw [← Nat.mul_div_cancel' hda, ← Nat.mul_div_cancel' hdb, h]
 #align nat.div_left_inj Nat.div_left_inj
 
+theorem div_mul_div_comm {l : ℕ} (hmn : n ∣ m) (hkl : l ∣ k) :
+    m / n * (k / l) = m * k / (n * l) := by
+  obtain ⟨x, rfl⟩ := hmn
+  obtain ⟨y, rfl⟩ := hkl
+  rcases n.eq_zero_or_pos with rfl | hn
+  · simp
+  rcases l.eq_zero_or_pos with rfl | hl
+  · simp
+  rw [Nat.mul_div_cancel_left _ hn, Nat.mul_div_cancel_left _ hl, mul_assoc n, Nat.mul_left_comm x,
+    ←mul_assoc n, Nat.mul_div_cancel_left _ (Nat.mul_pos hn hl)]
+#align nat.div_mul_div_comm Nat.div_mul_div_comm
+
+protected theorem div_pow {a b c : ℕ} (h : a ∣ b) : (b / a) ^ c = b ^ c / a ^ c := by
+  rcases c.eq_zero_or_pos with rfl | hc
+  · simp
+  rcases a.eq_zero_or_pos with rfl | ha
+  · simp [Nat.zero_pow hc]
+  refine (Nat.div_eq_of_eq_mul_right (pos_pow_of_pos c ha) ?_).symm
+  rw [←Nat.mul_pow, Nat.mul_div_cancel_left' h]
+
 /-! ### `mod`, `dvd` -/
 
 

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -708,7 +708,7 @@ protected theorem div_left_inj {a b d : ℕ} (hda : d ∣ a) (hdb : d ∣ b) : a
 #align nat.div_left_inj Nat.div_left_inj
 
 theorem div_mul_div_comm {l : ℕ} (hmn : n ∣ m) (hkl : l ∣ k) :
-    m / n * (k / l) = m * k / (n * l) := by
+    (m / n) * (k / l) = (m * k) / (n * l) := by
   obtain ⟨x, rfl⟩ := hmn
   obtain ⟨y, rfl⟩ := hkl
   rcases n.eq_zero_or_pos with rfl | hn

--- a/Mathlib/Data/Nat/Order/Basic.lean
+++ b/Mathlib/Data/Nat/Order/Basic.lean
@@ -506,26 +506,6 @@ theorem add_mod_eq_ite :
   · exact Nat.mod_eq_of_lt (lt_of_not_ge h)
 #align nat.add_mod_eq_ite Nat.add_mod_eq_ite
 
-theorem div_mul_div_comm (hmn : n ∣ m) (hkl : l ∣ k) : m / n * (k / l) = m * k / (n * l) :=
-  have exi1 : ∃ x, m = n * x := hmn
-  have exi2 : ∃ y, k = l * y := hkl
-  if hn : n = 0 then by simp [hn]
-  else
-    have : 0 < n := Nat.pos_of_ne_zero hn
-    if hl : l = 0 then by simp [hl]
-    else by
-      have : 0 < l := Nat.pos_of_ne_zero hl
-      cases' exi1 with x hx
-      cases' exi2 with y hy
-      rw [hx, hy, Nat.mul_div_cancel_left, Nat.mul_div_cancel_left]
-      apply Eq.symm
-      apply Nat.div_eq_of_eq_mul_left
-      apply mul_pos
-      repeat' assumption
-      -- Porting note: this line was `cc` in Lean3
-      simp only [mul_comm, mul_left_comm, mul_assoc]
-#align nat.div_mul_div_comm Nat.div_mul_div_comm
-
 theorem div_eq_self : m / n = m ↔ m = 0 ∨ n = 1 := by
   constructor
   · intro


### PR DESCRIPTION
Adds the missing lemma Nat.div_pow, which seemed to be missing (at least, `exact?%` couldn't find it with all of Mathlib imported). Also moves `div_mul_div_comm` higher in the hierarchy (and golf) because it doesn't need the ordered semiring instance, cf the docstring of `Data/Nat/Order/Basic`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
