### PR TITLE
[Merged by Bors] - feat(MeasureTheory): integrals of rnDeriv without absolute continuity

### DIFF
--- a/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
@@ -89,10 +89,6 @@ lemma inv_rnDeriv [SigmaFinite μ] [SigmaFinite ν] (hμν : μ ≪ ν) (hνμ :
     (by filter_upwards [hνμ.ae_le (rnDeriv_pos hμν)] with x hx using hx.ne')
     (rnDeriv_ne_top _ _)]
 
-lemma set_lintegral_rnDeriv_eq_withDensity {s : Set α} (hs : MeasurableSet s) :
-    ∫⁻ x in s, μ.rnDeriv ν x ∂ν = ν.withDensity (μ.rnDeriv ν) s :=
-  (withDensity_apply _ hs).symm
-
 lemma set_lintegral_rnDeriv_le (s : Set α) :
     ∫⁻ x in s, μ.rnDeriv ν x ∂ν ≤ μ s := by
   let t := toMeasurable μ s
@@ -106,7 +102,7 @@ lemma set_lintegral_rnDeriv_le (s : Set α) :
 lemma set_lintegral_rnDeriv [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν) {s : Set α}
     (hs : MeasurableSet s) :
     ∫⁻ x in s, μ.rnDeriv ν x ∂ν = μ s := by
-  rw [set_lintegral_rnDeriv_eq_withDensity hs, Measure.withDensity_rnDeriv_eq _ _ hμν]
+  rw [← withDensity_apply _ hs, Measure.withDensity_rnDeriv_eq _ _ hμν]
 
 lemma lintegral_rnDeriv [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν) :
     ∫⁻ x, μ.rnDeriv ν x ∂ν = μ Set.univ := by
@@ -121,7 +117,7 @@ lemma set_integral_toReal_rnDeriv_eq_withDensity [SigmaFinite μ]
     {s : Set α} (hs : MeasurableSet s) :
     ∫ x in s, (μ.rnDeriv ν x).toReal ∂ν = (ν.withDensity (μ.rnDeriv ν) s).toReal := by
   rw [integral_toReal (Measure.measurable_rnDeriv _ _).aemeasurable]
-  · rw [ENNReal.toReal_eq_toReal_iff, set_lintegral_rnDeriv_eq_withDensity hs]
+  · rw [ENNReal.toReal_eq_toReal_iff, ← withDensity_apply _ hs]
     simp
   · exact ae_restrict_of_ae (Measure.rnDeriv_lt_top _ _)
 

--- a/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
@@ -69,17 +69,6 @@ theorem absolutelyContinuous_iff_withDensity_rnDeriv_eq
   ⟨withDensity_rnDeriv_eq μ ν, fun h => h ▸ withDensity_absolutelyContinuous _ _⟩
 #align measure_theory.measure.absolutely_continuous_iff_with_density_rn_deriv_eq MeasureTheory.Measure.absolutelyContinuous_iff_withDensity_rnDeriv_eq
 
-theorem withDensity_rnDeriv_toReal_eq [IsFiniteMeasure μ] [HaveLebesgueDecomposition μ ν]
-    (h : μ ≪ ν) {i : Set α} (hi : MeasurableSet i) :
-    (∫ x in i, (μ.rnDeriv ν x).toReal ∂ν) = (μ i).toReal := by
-  rw [integral_toReal, ← withDensity_apply _ hi, withDensity_rnDeriv_eq μ ν h]
-  · measurability
-  · refine' ae_lt_top (μ.measurable_rnDeriv ν)
-      (lt_of_le_of_lt (lintegral_mono_set i.subset_univ) _).ne
-    rw [← withDensity_apply _ MeasurableSet.univ, withDensity_rnDeriv_eq μ ν h]
-    exact measure_lt_top _ _
-#align measure_theory.measure.with_density_rn_deriv_to_real_eq MeasureTheory.Measure.withDensity_rnDeriv_toReal_eq
-
 lemma rnDeriv_pos [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν) :
     ∀ᵐ x ∂μ, 0 < μ.rnDeriv ν x := by
   rw [← Measure.withDensity_rnDeriv_eq _ _  hμν,
@@ -100,22 +89,44 @@ lemma inv_rnDeriv [SigmaFinite μ] [SigmaFinite ν] (hμν : μ ≪ ν) (hνμ :
     (by filter_upwards [hνμ.ae_le (rnDeriv_pos hμν)] with x hx using hx.ne')
     (rnDeriv_ne_top _ _)]
 
+lemma set_lintegral_rnDeriv_eq_withDensity {s : Set α} (hs : MeasurableSet s) :
+    ∫⁻ x in s, μ.rnDeriv ν x ∂ν = ν.withDensity (μ.rnDeriv ν) s :=
+  (withDensity_apply _ hs).symm
+
+lemma set_lintegral_rnDeriv_le {s : Set α} (hs : MeasurableSet s) :
+    ∫⁻ x in s, μ.rnDeriv ν x ∂ν ≤ μ s := by
+  rw [set_lintegral_rnDeriv_eq_withDensity hs]
+  exact withDensity_rnDeriv_le _ _ _ hs
+
 lemma set_lintegral_rnDeriv [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν) {s : Set α}
     (hs : MeasurableSet s) :
     ∫⁻ x in s, μ.rnDeriv ν x ∂ν = μ s := by
-  conv_rhs => rw [← Measure.withDensity_rnDeriv_eq _ _ hμν, withDensity_apply _ hs]
+  rw [set_lintegral_rnDeriv_eq_withDensity hs, Measure.withDensity_rnDeriv_eq _ _ hμν]
 
 lemma lintegral_rnDeriv [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν) :
     ∫⁻ x, μ.rnDeriv ν x ∂ν = μ Set.univ := by
   rw [← set_lintegral_univ, set_lintegral_rnDeriv hμν MeasurableSet.univ]
 
-lemma set_integral_toReal_rnDeriv {μ ν : Measure α} [SigmaFinite μ] [SigmaFinite ν]
-    (hμν : μ ≪ ν) {s : Set α} (hs : MeasurableSet s) :
-    ∫ x in s, (μ.rnDeriv ν x).toReal ∂ν = (μ s).toReal := by
+lemma set_integral_toReal_rnDeriv_eq_withDensity {μ ν : Measure α} [SigmaFinite μ]
+    {s : Set α} (hs : MeasurableSet s) :
+    ∫ x in s, (μ.rnDeriv ν x).toReal ∂ν = (ν.withDensity (μ.rnDeriv ν) s).toReal := by
   rw [integral_toReal (Measure.measurable_rnDeriv _ _).aemeasurable]
-  · rw [ENNReal.toReal_eq_toReal_iff, set_lintegral_rnDeriv hμν hs]
+  · rw [ENNReal.toReal_eq_toReal_iff, set_lintegral_rnDeriv_eq_withDensity hs]
     simp
   · exact ae_restrict_of_ae (Measure.rnDeriv_lt_top _ _)
+
+lemma set_integral_toReal_rnDeriv_le {μ ν : Measure α} [SigmaFinite μ]
+    [HaveLebesgueDecomposition μ ν] {s : Set α} (hs : MeasurableSet s) (hμs : μ s ≠ ∞) :
+    ∫ x in s, (μ.rnDeriv ν x).toReal ∂ν ≤ (μ s).toReal := by
+  rw [set_integral_toReal_rnDeriv_eq_withDensity hs, ENNReal.toReal_le_toReal _ hμs]
+  · exact withDensity_rnDeriv_le _ _ _ hs
+  · exact ((withDensity_rnDeriv_le _ _ _ hs).trans_lt hμs.lt_top).ne
+
+lemma set_integral_toReal_rnDeriv {μ ν : Measure α} [SigmaFinite μ] [HaveLebesgueDecomposition μ ν]
+    (hμν : μ ≪ ν) {s : Set α} (hs : MeasurableSet s) :
+    ∫ x in s, (μ.rnDeriv ν x).toReal ∂ν = (μ s).toReal := by
+  rw [set_integral_toReal_rnDeriv_eq_withDensity hs, Measure.withDensity_rnDeriv_eq _ _ hμν]
+#align measure_theory.measure.with_density_rn_deriv_to_real_eq MeasureTheory.Measure.set_integral_toReal_rnDeriv
 
 lemma integral_toReal_rnDeriv {μ ν : Measure α} [SigmaFinite μ] [SigmaFinite ν] (hμν : μ ≪ ν) :
     ∫ x, (μ.rnDeriv ν x).toReal ∂ν = (μ Set.univ).toReal := by
@@ -133,7 +144,7 @@ theorem withDensityᵥ_rnDeriv_eq (s : SignedMeasure α) (μ : Measure α) [Sigm
     totalVariation_absolutelyContinuous_iff] at h
   · ext1 i hi
     rw [withDensityᵥ_apply (integrable_rnDeriv _ _) hi, rnDeriv, integral_sub,
-      withDensity_rnDeriv_toReal_eq h.1 hi, withDensity_rnDeriv_toReal_eq h.2 hi]
+      set_integral_toReal_rnDeriv h.1 hi, set_integral_toReal_rnDeriv h.2 hi]
     · conv_rhs => rw [← s.toSignedMeasure_toJordanDecomposition]
       erw [VectorMeasure.sub_apply]
       rw [toSignedMeasure_apply_measurable hi, toSignedMeasure_apply_measurable hi]

--- a/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
@@ -116,7 +116,7 @@ lemma set_integral_toReal_rnDeriv_eq_withDensity {μ ν : Measure α} [SigmaFini
   · exact ae_restrict_of_ae (Measure.rnDeriv_lt_top _ _)
 
 lemma set_integral_toReal_rnDeriv_le {μ ν : Measure α} [SigmaFinite μ]
-    [HaveLebesgueDecomposition μ ν] {s : Set α} (hs : MeasurableSet s) (hμs : μ s ≠ ∞) :
+    {s : Set α} (hs : MeasurableSet s) (hμs : μ s ≠ ∞) :
     ∫ x in s, (μ.rnDeriv ν x).toReal ∂ν ≤ (μ s).toReal := by
   rw [set_integral_toReal_rnDeriv_eq_withDensity hs, ENNReal.toReal_le_toReal _ hμs]
   · exact withDensity_rnDeriv_le _ _ _ hs


### PR DESCRIPTION
Add Lemmas about Lebesgue and Bochner integrals of rnDeriv without absolute continuity assumptions.

Also remove a duplicate lemma I introduced in a previous PR: `set_integral_toReal_rnDeriv` was already there under the name `withDensity_rnDeriv_toReal_eq`. I kept the name `set_integral_toReal_rnDeriv `.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
