### PR TITLE
[Merged by Bors] - feat: add lemmas on Complex.arg (x * y) and Complex.log (x * y)

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
@@ -520,10 +520,7 @@ lemma arg_mul_eq_add_arg_iff {x y : ℂ} (hx₀ : x ≠ 0) (hy₀ : y ≠ 0) :
   rw [← arg_coe_angle_toReal_eq_arg, arg_mul_coe_angle hx₀ hy₀, ← Real.Angle.coe_add,
       Real.Angle.toReal_coe_eq_self_iff_mem_Ioc]
 
-lemma arg_mul {x y : ℂ} (hx₀ : x ≠ 0) (hx₁ : -π / 2 < x.arg) (hx₂ : x.arg ≤ π / 2)
-    (hy₀ : y ≠ 0) (hy₁ : -π / 2 < y.arg) (hy₂ : y.arg ≤ π / 2) :
-    (x * y).arg = x.arg + y.arg :=
-  (arg_mul_eq_add_arg_iff hx₀ hy₀).mpr (by rw [Set.mem_Ioc]; constructor <;> linarith)
+alias ⟨_, arg_mul⟩ := arg_mul_eq_add_arg_iff
 
 section Continuity
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
@@ -515,19 +515,15 @@ theorem arg_coe_angle_eq_iff {x y : ℂ} : (arg x : Real.Angle) = arg y ↔ arg 
   simp_rw [← Real.Angle.toReal_inj, arg_coe_angle_toReal_eq_arg]
 #align complex.arg_coe_angle_eq_iff Complex.arg_coe_angle_eq_iff
 
-lemma arg_mul' {x y : ℂ} {a₁ a₂ b₁ b₂ : ℝ} (h₁ : -Real.pi ≤ a₁ + b₁) (h₂ : a₂ + b₂ ≤ Real.pi)
-    (hx₀ : x ≠ 0) (hx₁ : a₁ < x.arg) (hx₂ : x.arg ≤ a₂)
-    (hy₀ : y ≠ 0) (hy₁ : b₁ < y.arg) (hy₂ : y.arg ≤ b₂) :
-    (x * y).arg = x.arg + y.arg := by
+lemma arg_mul_eq_add_arg_iff {x y : ℂ} (hx₀ : x ≠ 0) (hy₀ : y ≠ 0) :
+    (x * y).arg = x.arg + y.arg ↔ arg x + arg y ∈ Set.Ioc (-π) π := by
   rw [← arg_coe_angle_toReal_eq_arg, arg_mul_coe_angle hx₀ hy₀, ← Real.Angle.coe_add,
       Real.Angle.toReal_coe_eq_self_iff_mem_Ioc]
-  exact ⟨by linarith, by linarith⟩
 
 lemma arg_mul {x y : ℂ} (hx₀ : x ≠ 0) (hx₁ : -Real.pi / 2 < x.arg) (hx₂ : x.arg ≤ Real.pi / 2)
     (hy₀ : y ≠ 0) (hy₁ : -Real.pi / 2 < y.arg) (hy₂ : y.arg ≤ Real.pi / 2) :
     (x * y).arg = x.arg + y.arg :=
-  arg_mul' (a₁ := -Real.pi / 2) (a₂ := Real.pi / 2) (b₁ := -Real.pi / 2) (b₂ := Real.pi / 2)
-    (by linarith) (by linarith) hx₀ hx₁ hx₂ hy₀ hy₁ hy₂
+  (arg_mul_eq_add_arg_iff hx₀ hy₀).mpr (by rw [Set.mem_Ioc]; constructor <;> linarith)
 
 section Continuity
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
@@ -520,8 +520,8 @@ lemma arg_mul_eq_add_arg_iff {x y : ℂ} (hx₀ : x ≠ 0) (hy₀ : y ≠ 0) :
   rw [← arg_coe_angle_toReal_eq_arg, arg_mul_coe_angle hx₀ hy₀, ← Real.Angle.coe_add,
       Real.Angle.toReal_coe_eq_self_iff_mem_Ioc]
 
-lemma arg_mul {x y : ℂ} (hx₀ : x ≠ 0) (hx₁ : -Real.pi / 2 < x.arg) (hx₂ : x.arg ≤ Real.pi / 2)
-    (hy₀ : y ≠ 0) (hy₁ : -Real.pi / 2 < y.arg) (hy₂ : y.arg ≤ Real.pi / 2) :
+lemma arg_mul {x y : ℂ} (hx₀ : x ≠ 0) (hx₁ : -π / 2 < x.arg) (hx₂ : x.arg ≤ π / 2)
+    (hy₀ : y ≠ 0) (hy₁ : -π / 2 < y.arg) (hy₂ : y.arg ≤ π / 2) :
     (x * y).arg = x.arg + y.arg :=
   (arg_mul_eq_add_arg_iff hx₀ hy₀).mpr (by rw [Set.mem_Ioc]; constructor <;> linarith)
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
@@ -189,6 +189,9 @@ theorem arg_real_mul (x : ℂ) {r : ℝ} (hr : 0 < r) : arg (r * x) = arg x := b
       arg_mul_cos_add_sin_mul_I (mul_pos hr (abs.pos hx)) x.arg_mem_Ioc]
 #align complex.arg_real_mul Complex.arg_real_mul
 
+theorem arg_mul_real {r : ℝ} (hr : 0 < r) (x : ℂ) : arg (x * r) = arg x :=
+  mul_comm x r ▸ arg_real_mul x hr
+
 theorem arg_eq_arg_iff {x y : ℂ} (hx : x ≠ 0) (hy : y ≠ 0) :
     arg x = arg y ↔ (abs y / abs x : ℂ) * x = y := by
   simp only [ext_abs_arg_iff, map_mul, map_div₀, abs_ofReal, abs_abs,
@@ -511,6 +514,20 @@ theorem arg_coe_angle_eq_iff_eq_toReal {z : ℂ} {θ : Real.Angle} :
 theorem arg_coe_angle_eq_iff {x y : ℂ} : (arg x : Real.Angle) = arg y ↔ arg x = arg y := by
   simp_rw [← Real.Angle.toReal_inj, arg_coe_angle_toReal_eq_arg]
 #align complex.arg_coe_angle_eq_iff Complex.arg_coe_angle_eq_iff
+
+lemma arg_mul' {x y : ℂ} {a₁ a₂ b₁ b₂ : ℝ} (h₁ : -Real.pi ≤ a₁ + b₁) (h₂ : a₂ + b₂ ≤ Real.pi)
+    (hx₀ : x ≠ 0) (hx₁ : a₁ < x.arg) (hx₂ : x.arg ≤ a₂)
+    (hy₀ : y ≠ 0) (hy₁ : b₁ < y.arg) (hy₂ : y.arg ≤ b₂) :
+    (x * y).arg = x.arg + y.arg := by
+  rw [← arg_coe_angle_toReal_eq_arg, arg_mul_coe_angle hx₀ hy₀, ← Real.Angle.coe_add,
+      Real.Angle.toReal_coe_eq_self_iff_mem_Ioc]
+  exact ⟨by linarith, by linarith⟩
+
+lemma arg_mul {x y : ℂ} (hx₀ : x ≠ 0) (hx₁ : -Real.pi / 2 < x.arg) (hx₂ : x.arg ≤ Real.pi / 2)
+    (hy₀ : y ≠ 0) (hy₁ : -Real.pi / 2 < y.arg) (hy₂ : y.arg ≤ Real.pi / 2) :
+    (x * y).arg = x.arg + y.arg :=
+  arg_mul' (a₁ := -Real.pi / 2) (a₂ := Real.pi / 2) (b₁ := -Real.pi / 2) (b₂ := Real.pi / 2)
+    (by linarith) (by linarith) hx₀ hx₁ hx₂ hy₀ hy₁ hy₂
 
 section Continuity
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -92,8 +92,8 @@ lemma log_mul_eq_add_log_iff {x y : ℂ} (hx₀ : x ≠ 0) (hy₀ : y ≠ 0) :
   simp_rw [add_re, add_im, log_re, log_im, AbsoluteValue.map_mul,
     Real.log_mul (abs.ne_zero hx₀) (abs.ne_zero hy₀), true_and]
 
-lemma log_mul {x y : ℂ} (hx₀ : x ≠ 0) (hx₁ : -Real.pi / 2 < x.arg) (hx₂ : x.arg ≤ Real.pi / 2)
-    (hy₀ : y ≠ 0) (hy₁ : -Real.pi / 2 < y.arg) (hy₂ : y.arg ≤ Real.pi / 2) :
+lemma log_mul {x y : ℂ} (hx₀ : x ≠ 0) (hx₁ : -π / 2 < x.arg) (hx₂ : x.arg ≤ π / 2)
+    (hy₀ : y ≠ 0) (hy₁ : -π / 2 < y.arg) (hy₂ : y.arg ≤ π / 2) :
     (x * y).log = x.log + y.log :=
   (log_mul_eq_add_log_iff hx₀ hy₀).mpr (by rw [Set.mem_Ioc]; constructor <;> linarith)
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -92,10 +92,7 @@ lemma log_mul_eq_add_log_iff {x y : ℂ} (hx₀ : x ≠ 0) (hy₀ : y ≠ 0) :
   simp_rw [add_re, add_im, log_re, log_im, AbsoluteValue.map_mul,
     Real.log_mul (abs.ne_zero hx₀) (abs.ne_zero hy₀), true_and]
 
-lemma log_mul {x y : ℂ} (hx₀ : x ≠ 0) (hx₁ : -π / 2 < x.arg) (hx₂ : x.arg ≤ π / 2)
-    (hy₀ : y ≠ 0) (hy₁ : -π / 2 < y.arg) (hy₂ : y.arg ≤ π / 2) :
-    (x * y).log = x.log + y.log :=
-  (log_mul_eq_add_log_iff hx₀ hy₀).mpr (by rw [Set.mem_Ioc]; constructor <;> linarith)
+alias ⟨_, log_mul⟩ := log_mul_eq_add_log_iff
 
 @[simp]
 theorem log_zero : log 0 = 0 := by simp [log]

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -86,19 +86,16 @@ theorem log_mul_ofReal (r : ℝ) (hr : 0 < r) (x : ℂ) (hx : x ≠ 0) :
     log (x * r) = Real.log r + log x := by rw [mul_comm, log_ofReal_mul hr hx, add_comm]
 #align complex.log_mul_of_real Complex.log_mul_ofReal
 
-lemma log_mul' {x y : ℂ} {a₁ a₂ b₁ b₂ : ℝ} (h₁ : -Real.pi ≤ a₁ + b₁) (h₂ : a₂ + b₂ ≤ Real.pi)
-    (hx₀ : x ≠ 0) (hx₁ : a₁ < x.arg) (hx₂ : x.arg ≤ a₂)
-    (hy₀ : y ≠ 0) (hy₁ : b₁ < y.arg) (hy₂ : y.arg ≤ b₂) :
-    (x * y).log = x.log + y.log := by
-  refine ext_iff.mpr ⟨?_, ?_⟩
-  · simp_rw [add_re, log_re, map_mul, Real.log_mul (abs.ne_zero hx₀) (abs.ne_zero hy₀)]
-  · simp_rw [add_im, log_im, arg_mul' h₁ h₂ hx₀ hx₁ hx₂ hy₀ hy₁ hy₂]
+lemma log_mul_eq_add_log_iff {x y : ℂ} (hx₀ : x ≠ 0) (hy₀ : y ≠ 0) :
+    log (x * y) = log x + log y ↔ arg x + arg y ∈ Set.Ioc (-π) π := by
+  refine ext_iff.trans <| Iff.trans ?_ <| arg_mul_eq_add_arg_iff hx₀ hy₀
+  simp_rw [add_re, add_im, log_re, log_im, AbsoluteValue.map_mul,
+    Real.log_mul (abs.ne_zero hx₀) (abs.ne_zero hy₀), true_and]
 
 lemma log_mul {x y : ℂ} (hx₀ : x ≠ 0) (hx₁ : -Real.pi / 2 < x.arg) (hx₂ : x.arg ≤ Real.pi / 2)
     (hy₀ : y ≠ 0) (hy₁ : -Real.pi / 2 < y.arg) (hy₂ : y.arg ≤ Real.pi / 2) :
     (x * y).log = x.log + y.log :=
-  log_mul' (a₁ := -Real.pi / 2) (a₂ := Real.pi / 2) (b₁ := -Real.pi / 2) (b₂ := Real.pi / 2)
-    (by linarith) (by linarith) hx₀ hx₁ hx₂ hy₀ hy₁ hy₂
+  (log_mul_eq_add_log_iff hx₀ hy₀).mpr (by rw [Set.mem_Ioc]; constructor <;> linarith)
 
 @[simp]
 theorem log_zero : log 0 = 0 := by simp [log]

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -86,6 +86,20 @@ theorem log_mul_ofReal (r : ℝ) (hr : 0 < r) (x : ℂ) (hx : x ≠ 0) :
     log (x * r) = Real.log r + log x := by rw [mul_comm, log_ofReal_mul hr hx, add_comm]
 #align complex.log_mul_of_real Complex.log_mul_ofReal
 
+lemma log_mul' {x y : ℂ} {a₁ a₂ b₁ b₂ : ℝ} (h₁ : -Real.pi ≤ a₁ + b₁) (h₂ : a₂ + b₂ ≤ Real.pi)
+    (hx₀ : x ≠ 0) (hx₁ : a₁ < x.arg) (hx₂ : x.arg ≤ a₂)
+    (hy₀ : y ≠ 0) (hy₁ : b₁ < y.arg) (hy₂ : y.arg ≤ b₂) :
+    (x * y).log = x.log + y.log := by
+  refine ext_iff.mpr ⟨?_, ?_⟩
+  · simp_rw [add_re, log_re, map_mul, Real.log_mul (abs.ne_zero hx₀) (abs.ne_zero hy₀)]
+  · simp_rw [add_im, log_im, arg_mul' h₁ h₂ hx₀ hx₁ hx₂ hy₀ hy₁ hy₂]
+
+lemma log_mul {x y : ℂ} (hx₀ : x ≠ 0) (hx₁ : -Real.pi / 2 < x.arg) (hx₂ : x.arg ≤ Real.pi / 2)
+    (hy₀ : y ≠ 0) (hy₁ : -Real.pi / 2 < y.arg) (hy₂ : y.arg ≤ Real.pi / 2) :
+    (x * y).log = x.log + y.log :=
+  log_mul' (a₁ := -Real.pi / 2) (a₂ := Real.pi / 2) (b₁ := -Real.pi / 2) (b₂ := Real.pi / 2)
+    (by linarith) (by linarith) hx₀ hx₁ hx₂ hy₀ hy₁ hy₂
+
 @[simp]
 theorem log_zero : log 0 = 0 := by simp [log]
 #align complex.log_zero Complex.log_zero


### PR DESCRIPTION
This adds lemmas as in the title (plus one for `arg (x * r)` with real `r`):
```lean
lemma arg_mul_eq_add_arg_iff {x y : ℂ} (hx₀ : x ≠ 0) (hy₀ : y ≠ 0) :
    (x * y).arg = x.arg + y.arg ↔ arg x + arg y ∈ Set.Ioc (-π) π

lemma arg_mul {x y : ℂ} (hx₀ : x ≠ 0) (hx₁ : -π / 2 < x.arg) (hx₂ : x.arg ≤ π / 2)
    (hy₀ : y ≠ 0) (hy₁ : -π / 2 < y.arg) (hy₂ : y.arg ≤ π / 2) :
    (x * y).arg = x.arg + y.arg

lemma log_mul_eq_add_log_iff {x y : ℂ} (hx₀ : x ≠ 0) (hy₀ : y ≠ 0) :
    log (x * y) = log x + log y ↔ arg x + arg y ∈ Set.Ioc (-π) π

lemma log_mul {x y : ℂ} (hx₀ : x ≠ 0) (hx₁ : -π / 2 < x.arg) (hx₂ : x.arg ≤ π / 2)
    (hy₀ : y ≠ 0) (hy₁ : -π / 2 < y.arg) (hy₂ : y.arg ≤ π / 2) :
    (x * y).log = x.log + y.log
```
See [here](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/log.20.28x*y.29.20.3D.20log.20x.20.2B.20log.20y.20for.20complex.20numbers/near/401233495) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
