### PR TITLE
[Merged by Bors] - feat: add induction principle for intervals

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -57,6 +57,11 @@ theorem logb_one : logb b 1 = 0 := by simp [logb]
 lemma logb_self_eq_one (hb : 1 < b) : logb b b = 1 :=
   div_self (fun H => (ne_of_lt (log_pos hb)).symm H)
 
+lemma logb_self_eq_one' (hb₀ : 0 < b) (hb₁ : b ≠ 1) : logb b b = 1 := by
+  refine div_self ?_
+  rw [log_ne_zero]
+  exact ⟨ne_of_gt hb₀, hb₁, by linarith⟩
+
 @[simp]
 theorem logb_abs (x : ℝ) : logb b |x| = logb b x := by rw [logb, logb, log_abs]
 #align real.logb_abs Real.logb_abs
@@ -183,8 +188,8 @@ theorem logb_le_logb (h : 0 < x) (h₁ : 0 < y) : logb b x ≤ logb b y ↔ x �
 #align real.logb_le_logb Real.logb_le_logb
 
 @[gcongr]
-theorem logb_le_logb_of_le (h : 0 < x) (h₁ : 0 < y) (hxy : x ≤ y) : logb b x ≤ logb b y :=
-  (logb_le_logb hb h h₁).mpr hxy
+theorem logb_le_logb_of_le (h : 0 < x) (hxy : x ≤ y) : logb b x ≤ logb b y :=
+  (logb_le_logb hb h (by linarith)).mpr hxy
 
 @[gcongr]
 theorem logb_lt_logb (hx : 0 < x) (hxy : x < y) : logb b x < logb b y := by

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -57,7 +57,7 @@ theorem logb_one : logb b 1 = 0 := by simp [logb]
 lemma logb_self_eq_one (hb : 1 < b) : logb b b = 1 :=
    div_self (log_pos hb).ne'
 
-lemma logb_self_eq_one' : logb b b = 1 ↔ b ≠ 0 ∧ b ≠ 1 ∧ b ≠ -1 :=
+lemma logb_self_eq_one_iff : logb b b = 1 ↔ b ≠ 0 ∧ b ≠ 1 ∧ b ≠ -1 :=
   Iff.trans ⟨fun h h' => by simp [logb, h'] at h, div_self⟩ log_ne_zero
 
 @[simp]

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -444,7 +444,6 @@ end Real
 
 section Induction
 
-open Real in
 /-- Induction principle for intervals of real numbers: if a proposition `P` is true
 on `[x₀, r * x₀)` and if `P` for `[x₀, r^n * x₀)` implies `P` for `[r^n * x₀, r^(n+1) * x₀)`,
 then `P` is true for all `x ≥ x₀`. -/
@@ -452,56 +451,19 @@ lemma Real.induction_Ico_mul {P : ℝ → Prop} (x₀ r : ℝ) (hr : 1 < r) (hx�
     (base : ∀ x ∈ Set.Ico x₀ (r * x₀), P x)
     (step : ∀ n : ℕ, n ≥ 1 → (∀ z ∈ Set.Ico x₀ (r ^ n * x₀), P z) →
       (∀ z ∈ Set.Ico (r ^ n * x₀) (r ^ (n+1) * x₀), P z)) :
-    ∀ x ≥ x₀, P x :=
-  fun x hx =>
-    have h₁ : r ≠ 1 := (ne_of_lt hr).symm
-    have h₂ : 0 < r := zero_lt_one.trans hr
-    have h₃ : x₀ ≠ 0 := (ne_of_lt hx₀).symm
-    have h₄ : 0 < x := by linarith
-    if hx' : x < r * x₀ then
-      base x ⟨hx, hx'⟩
-    else by
-      push_neg at hx'
-      refine step ⌊logb r (x / x₀)⌋₊ ?ge_one ?main x ?memIco
-      case ge_one =>
-        calc 1 = ⌊logb r (r * x₀ / x₀)⌋₊ := by
-                simp [mul_div_cancel _ (ne_of_lt hx₀).symm, hr]
-             _ ≤ ⌊logb r (x / x₀)⌋₊ := by gcongr; exact hr
-      case main =>
-        intro z ⟨z_lb, z_ub⟩
-        have z_pos : 0 < z := by linarith
-        have h_nonneg : 0 ≤ logb r (z / x₀) := logb_nonneg hr ((one_le_div hx₀).mpr z_lb)
-        have hlogb : logb r (r ^ ⌊logb r (x / x₀)⌋₊ * x₀ / x₀) =  ⌊logb r (x / x₀)⌋₊ := by
-          rw [mul_div_cancel _ (ne_of_lt hx₀).symm, logb_rpow h₂ h₁]
-        -- Needed by the termination checker
-        have _well_founded : ⌊logb r (z / x₀)⌋₊ < ⌊logb r (x / x₀)⌋₊ := by
-          rw [Nat.floor_lt h_nonneg]
-          calc logb r (z / x₀) < logb r (r ^ ⌊logb r (x / x₀)⌋₊ * x₀ / x₀) := by
-                    refine (logb_lt_logb_iff hr (div_pos z_pos hx₀) (by positivity)).mpr ?_
-                    gcongr
-               _ = ⌊logb r (r ^ ⌊logb r (x / x₀)⌋₊ * x₀ / x₀)⌋₊ := by
-                    nth_rewrite 1 [hlogb]
-                    norm_cast
-                    rw [←rpow_nat_cast, hlogb]
-                    simp
-               _ = ⌊logb r (x / x₀)⌋₊ := by simp only [hlogb, Nat.floor_coe]
-        exact induction_Ico_mul x₀ r hr hx₀ base step z z_lb
-      case memIco =>
-        have h₅ : x = r ^ logb r (x / x₀) * x₀ := by
-          rw [rpow_logb h₂ h₁ (by positivity), div_mul_cancel _ h₃]
-        refine ⟨?lb, ?ub⟩
-        case lb =>
-          calc _ ≤ r ^ logb r (x / x₀) * x₀ := by
-                  gcongr
-                  · exact le_of_lt hr
-                  · exact Nat.floor_le (logb_nonneg hr (by rwa [one_le_div hx₀]))
-               _ = x := by rw [←h₅]
-        case ub =>
-          calc _ = r ^ logb r (x / x₀) * x₀ := by rw [←h₅]
-               _ < r ^ (⌊logb r (x / x₀)⌋₊ + 1) * x₀ := by
-                  gcongr
-                  simp [rpow_lt_rpow_left_iff hr, Nat.lt_floor_add_one]
-  termination_by induction_Ico_mul x₀ r hr hx₀ base step x hx => ⌊logb r (x / x₀)⌋₊
-
+    ∀ x ≥ x₀, P x := by
+  suffices : ∀ n : ℕ, ∀ x ∈ Set.Ico x₀ (r ^ (n + 1) * x₀), P x
+  · intro x hx
+    have hx' : 0 < x / x₀ := div_pos (hx₀.trans_le hx) hx₀
+    refine this ⌊logb r (x / x₀)⌋₊ x ?_
+    rw [mem_Ico, ←div_lt_iff hx₀, ←logb_lt_iff_lt_rpow hr hx']
+    exact ⟨hx, Nat.lt_floor_add_one _⟩
+  intro n
+  induction n
+  case zero => simpa using base
+  case succ n ih =>
+    specialize step (n + 1) (by simp)
+    simp only [Nat.cast_add_one] at step ⊢
+    exact fun x hx => (Ico_subset_Ico_union_Ico hx).elim (ih x) (step ih _)
 
 end Induction

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -55,7 +55,7 @@ theorem logb_one : logb b 1 = 0 := by simp [logb]
 
 @[simp]
 lemma logb_self_eq_one (hb : 1 < b) : logb b b = 1 :=
-  div_self (fun H => (ne_of_lt (log_pos hb)).symm H)
+   div_self (log_pos hb).ne'
 
 lemma logb_self_eq_one' : logb b b = 1 ↔ b ≠ 0 ∧ b ≠ 1 ∧ b ≠ -1 :=
   Iff.trans ⟨fun h h' => by simp [logb, h'] at h, div_self⟩ log_ne_zero

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -57,10 +57,8 @@ theorem logb_one : logb b 1 = 0 := by simp [logb]
 lemma logb_self_eq_one (hb : 1 < b) : logb b b = 1 :=
   div_self (fun H => (ne_of_lt (log_pos hb)).symm H)
 
-lemma logb_self_eq_one' (hb₀ : 0 < b) (hb₁ : b ≠ 1) : logb b b = 1 := by
-  refine div_self ?_
-  rw [log_ne_zero]
-  exact ⟨ne_of_gt hb₀, hb₁, by linarith⟩
+lemma logb_self_eq_one' : logb b b = 1 ↔ b ≠ 0 ∧ b ≠ 1 ∧ b ≠ -1 :=
+  Iff.trans ⟨fun h h' => by simp [logb, h'] at h, div_self⟩ log_ne_zero
 
 @[simp]
 theorem logb_abs (x : ℝ) : logb b |x| = logb b x := by rw [logb, logb, log_abs]


### PR DESCRIPTION
This PR adds an induction principle that says that if a proposition `P` is true on `[x₀, r * x₀)` and if `P` for `[x₀, r^n * x₀)` implies `P` for `[r^n * x₀, r^(n+1) * x₀)`, then `P` is true for all `x ≥ x₀`.

It also adds a few missing lemmas about `logb`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
