### PR TITLE
feat: add lemmas for std bitvectors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1914,6 +1914,7 @@ import Mathlib.Data.Sigma.Interval
 import Mathlib.Data.Sigma.Lex
 import Mathlib.Data.Sigma.Order
 import Mathlib.Data.Sign
+import Mathlib.Data.StdBitVec.Lemmas
 import Mathlib.Data.Stream.Defs
 import Mathlib.Data.Stream.Init
 import Mathlib.Data.String.Basic

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -314,6 +314,12 @@ theorem testBit_two_pow (n m : ℕ) : testBit (2 ^ n) m = (n = m) := by
     simp [h]
 #align nat.test_bit_two_pow Nat.testBit_two_pow
 
+theorem and_two_pow {n i} : n &&& 2 ^ i = (n.testBit i).toNat * 2 ^ i := by
+  apply eq_of_testBit_eq; intro j
+  rw [mul_comm, testBit_land]
+  cases' h : n.testBit i <;> cases' (ne_or_eq i j) with h1 h1
+  <;> simp [testBit_two_pow_of_ne _, *] at * <;> assumption
+
 theorem bitwise_swap {f : Bool → Bool → Bool} :
     bitwise (Function.swap f) = Function.swap (bitwise f) := by
   funext m n

--- a/Mathlib/Data/Nat/Pow.lean
+++ b/Mathlib/Data/Nat/Pow.lean
@@ -66,6 +66,12 @@ theorem one_le_two_pow (n : ℕ) : 1 ≤ 2 ^ n :=
   one_le_pow n 2 (by decide)
 #align nat.one_le_two_pow Nat.one_le_two_pow
 
+theorem two_pow_pos (n : ℕ) : 0 < 2^n :=
+  Nat.pos_pow_of_pos _ (by decide)
+
+theorem two_pow_succ (n : ℕ) : 2^(n + 1) = 2^n + 2^n := by
+  simp [pow_succ, mul_two]
+
 theorem one_lt_pow (n m : ℕ) (h₀ : 0 < n) (h₁ : 1 < m) : 1 < m ^ n := by
   rw [← one_pow n]
   exact pow_lt_pow_of_lt_left h₁ h₀

--- a/Mathlib/Data/StdBitVec/Lemmas.lean
+++ b/Mathlib/Data/StdBitVec/Lemmas.lean
@@ -102,6 +102,21 @@ theorem ofFin_toFin {n} (v : BitVec n) : ofFin (toFin v) = v := by
 -- #align bitvec.of_fin_to_fin Std.BitVec.ofFin_toFin
 
 /-!
+  ### Distributivity of ofFin
+  We add simp-lemmas that show how `ofFin` distributes over various bitvector operations, showing
+  that bitvector operations are equivalent to `Fin` operations
+-/
+@[simp] lemma neg_ofFin (x : Fin (2^w)) : -(ofFin x) = ofFin (-x) := by
+  rw [neg_eq_zero_sub]; rfl
+
+@[simp] lemma ofFin_and_ofFin (x y : Fin (2^w)) : (ofFin x) &&& (ofFin y) = ofFin (x &&& y) := rfl
+@[simp] lemma ofFin_or_ofFin  (x y : Fin (2^w)) : (ofFin x) ||| (ofFin y) = ofFin (x ||| y) := rfl
+@[simp] lemma ofFin_xor_ofFin (x y : Fin (2^w)) : (ofFin x) ^^^ (ofFin y) = ofFin (x ^^^ y) := rfl
+@[simp] lemma ofFin_add_ofFin (x y : Fin (2^w)) : (ofFin x) + (ofFin y) = ofFin (x + y)     := rfl
+@[simp] lemma ofFin_sub_ofFin (x y : Fin (2^w)) : (ofFin x) - (ofFin y) = ofFin (x - y)     := rfl
+@[simp] lemma ofFin_mul_ofFin (x y : Fin (2^w)) : (ofFin x) * (ofFin y) = ofFin (x * y)     := rfl
+
+/-!
 ## Extract / Get bits
 -/
 

--- a/Mathlib/Data/StdBitVec/Lemmas.lean
+++ b/Mathlib/Data/StdBitVec/Lemmas.lean
@@ -109,12 +109,12 @@ theorem ofFin_toFin {n} (v : BitVec n) : ofFin (toFin v) = v := by
 @[simp] lemma neg_ofFin (x : Fin (2^w)) : -(ofFin x) = ofFin (-x) := by
   rw [neg_eq_zero_sub]; rfl
 
-@[simp] lemma ofFin_and_ofFin (x y : Fin (2^w)) : (ofFin x) &&& (ofFin y) = ofFin (x &&& y) := rfl
-@[simp] lemma ofFin_or_ofFin  (x y : Fin (2^w)) : (ofFin x) ||| (ofFin y) = ofFin (x ||| y) := rfl
-@[simp] lemma ofFin_xor_ofFin (x y : Fin (2^w)) : (ofFin x) ^^^ (ofFin y) = ofFin (x ^^^ y) := rfl
-@[simp] lemma ofFin_add_ofFin (x y : Fin (2^w)) : (ofFin x) + (ofFin y) = ofFin (x + y)     := rfl
-@[simp] lemma ofFin_sub_ofFin (x y : Fin (2^w)) : (ofFin x) - (ofFin y) = ofFin (x - y)     := rfl
-@[simp] lemma ofFin_mul_ofFin (x y : Fin (2^w)) : (ofFin x) * (ofFin y) = ofFin (x * y)     := rfl
+@[simp] lemma ofFin_and_ofFin (x y : Fin (2^w)) : ofFin x &&& ofFin y = ofFin (x &&& y) := rfl
+@[simp] lemma ofFin_or_ofFin  (x y : Fin (2^w)) : ofFin x ||| ofFin y = ofFin (x ||| y) := rfl
+@[simp] lemma ofFin_xor_ofFin (x y : Fin (2^w)) : ofFin x ^^^ ofFin y = ofFin (x ^^^ y) := rfl
+@[simp] lemma ofFin_add_ofFin (x y : Fin (2^w)) : ofFin x + ofFin y   = ofFin (x + y)   := rfl
+@[simp] lemma ofFin_sub_ofFin (x y : Fin (2^w)) : ofFin x - ofFin y   = ofFin (x - y)   := rfl
+@[simp] lemma ofFin_mul_ofFin (x y : Fin (2^w)) : ofFin x * ofFin y   = ofFin (x * y)   := rfl
 
 /-!
 ## Extract / Get bits

--- a/Mathlib/Data/StdBitVec/Lemmas.lean
+++ b/Mathlib/Data/StdBitVec/Lemmas.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2023 Harun Khan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Harun Khan, Alex Keizer
+-/
+
+import Std.Data.BitVec
+import Mathlib.Algebra.GroupPower.Ring
+import Mathlib.Data.Nat.Bitwise
+import Mathlib.Data.Nat.Pow
+import Mathlib.Data.Fin.Basic
+import Mathlib.Tactic.Linarith
+
+/-!
+# Basic Theorems About Bitvectors
+
+This file contains theorems about bitvectors, as defined in `Std`.
+
+Note that `Std.BitVec` is distinct from mathlibs `Bitvec` type, this file is about the former.
+For the latter, go to `Data.Bitvec` (notice the difference in capitalization).
+Eventually, `Std.BitVec` will replace `Bitvec`, so we include the relevant `#align`s, but
+comment them out for now
+-/
+
+namespace Std.BitVec
+
+open Nat
+
+variable {w v : Nat}
+
+@[simp]
+lemma cast_eq (x : BitVec w) : x.cast rfl = x :=
+  rfl
+
+/-!
+## Conversions
+Theorems about `ofNat`, `toNat`, `ofFin`, `toFin`, `ofBool`, etc.
+-/
+
+/-! ### toNat -/
+
+theorem toNat_inj {x y : BitVec w} : x.toNat = y.toNat ↔ x = y :=
+  ⟨(match x, y, · with | ⟨_, _⟩,⟨_, _⟩, rfl => rfl), (· ▸ rfl)⟩
+
+/-- `x < y` as natural numbers if and only if `x < y` as `BitVec w`. -/
+theorem toNat_lt_toNat {x y : BitVec w} : x.toNat < y.toNat ↔ x < y :=
+  ⟨id, id⟩
+
+theorem toNat_lt {n : ℕ} (v : BitVec n) : v.toNat < 2 ^ n :=
+  v.toFin.isLt
+-- #align bitvec.to_nat_lt Std.BitVec.toNat_lt
+
+theorem toNat_ofNat {m} (h : m < 2^w) : (BitVec.ofNat w m).toNat = m := Fin.val_cast_of_lt h
+-- #align bitvec.to_nat_of_nat Std.BitVec.toNat_ofNat
+
+@[simp] lemma toNat_ofFin (x : Fin (2^w)) : (ofFin x).toNat = x.val := rfl
+
+-- #noalign bitvec.bits_to_nat_to_bool
+
+/-! ### ofNat -/
+
+@[simp]
+lemma ofNat_eq_mod_two_pow (n : Nat) : (BitVec.ofNat w n).toNat = n % 2^w := rfl
+
+@[simp]
+lemma ofNat_toNat (x : BitVec w) : BitVec.ofNat w x.toNat = x := by
+  rcases x with ⟨x⟩
+  simp [BitVec.ofNat]
+  apply Fin.cast_val_eq_self x
+#align bitvec.of_nat_to_nat Std.BitVec.ofNat_toNat
+
+lemma ofNat_toNat' (x : BitVec w) (h : w = v):
+    BitVec.ofNat v x.toNat = x.cast h := by
+  cases h; rw [ofNat_toNat, cast_eq]
+
+/-! ### OfFin / ToFin -/
+
+theorem ofFin_val {n : ℕ} (i : Fin <| 2 ^ n) : (ofFin i).toNat = i.val := by
+  rfl
+-- #align bitvec.of_fin_val Std.BitVec.ofFin_val
+
+theorem toFin_val {n : ℕ} (v : BitVec n) : (toFin v : ℕ) = v.toNat := by
+  rfl
+-- #align bitvec.to_fin_val Std.BitVec.toFin_val
+
+theorem toFin_le_toFin_of_le {n} {v₀ v₁ : BitVec n} (h : v₀ ≤ v₁) : v₀.toFin ≤ v₁.toFin :=
+  show (v₀.toFin : ℕ) ≤ v₁.toFin by
+    rw [toFin_val, toFin_val]
+    exact h
+-- #align bitvec.to_fin_le_to_fin_of_le Std.BitVec.toFin_le_toFin_of_le
+
+theorem ofFin_le_ofFin_of_le {n : ℕ} {i j : Fin (2 ^ n)} (h : i ≤ j) : ofFin i ≤ ofFin j := by
+  exact h
+-- #align bitvec.of_fin_le_of_fin_of_le Std.BitVec.ofFin_le_ofFin_of_le
+
+theorem toFin_ofFin {n} (i : Fin <| 2 ^ n) : (ofFin i).toFin = i :=
+  Fin.eq_of_veq (by simp [toFin_val, ofFin, toNat_ofNat, Nat.mod_eq_of_lt, i.is_lt])
+-- #align bitvec.to_fin_of_fin Std.BitVec.toFin_ofFin
+
+theorem ofFin_toFin {n} (v : BitVec n) : ofFin (toFin v) = v := by
+  rfl
+-- #align bitvec.of_fin_to_fin Std.BitVec.ofFin_toFin
+
+/-!
+## Extract / Get bits
+-/
+
+@[simp]
+lemma extractLsb_eq {w : ℕ} (hi lo : ℕ) (a : BitVec w) :
+    extractLsb hi lo a = extractLsb' lo (hi - lo + 1) a :=
+  rfl
+
+theorem toNat_extractLsb' {i j} {x : BitVec w} :
+    (extractLsb' i j x).toNat = x.toNat / 2 ^ i % (2 ^ j) := by
+  simp only [extractLsb', ofNat_eq_mod_two_pow, shiftRight_eq_div_pow]
+
+theorem getLsb_eq_testBit {i} {x : BitVec w} : getLsb x i = x.toNat.testBit i := by
+  simp only [getLsb, Nat.shiftLeft_eq, one_mul, Nat.and_two_pow]
+  cases' testBit (BitVec.toNat x) i
+  <;> simp [pos_iff_ne_zero.mp (Nat.two_pow_pos i)]
+
+end Std.BitVec


### PR DESCRIPTION
Add various lemmas for Std.BitVec, to bring it closer to feature parity with the existing Bitvec type.

Co-authored-by: Harun Khan
Co-authored-by: mhk119 <58151072+mhk119@users.noreply.github.com>
Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

These lemmas are factored out from https://github.com/leanprover-community/mathlib4/pull/5920.
This PR is related to (but independent from) #8345, which contains definitions  factored out from #5920. (The lemmas in this PR are only about definitions from `Std`, so this PR does not depend on #8345). See that PR for the rationale behind splitting these lemmas from the original PR.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
