### PR TITLE
[Merged by Bors] - fix: add 'squash' to 'norm_cast' attribute for 'Int.cast_negSucc'

### DIFF
--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -49,7 +49,7 @@ namespace Int
 
 variable {R : Type u} [AddGroupWithOne R]
 
-@[simp, norm_cast]
+@[simp, norm_cast squash]
 theorem cast_negSucc (n : ℕ) : (-[n+1] : R) = -(n + 1 : ℕ) :=
   AddGroupWithOne.intCast_negSucc n
 #align int.cast_neg_succ_of_nat Int.cast_negSuccₓ


### PR DESCRIPTION
This is an attempt at fixing the following behavior of `norm_cast`.
```lean

example (n : ℤ) : (-37 : ℤ) = n := by
  norm_cast -- goal is `Int.negSucc 36 = n`
  sorry
```
See [this discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/linarith.20fails.20in.20a.20simple.20example/near/401592369).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
