### PR TITLE
refactor: replace `(· ∘ ·)` with Function.comp_def

### DIFF
--- a/Counterexamples/CliffordAlgebra_not_injective.lean
+++ b/Counterexamples/CliffordAlgebra_not_injective.lean
@@ -47,7 +47,7 @@ theorem mem_kIdeal_iff (x : MvPolynomial (Fin 3) (ZMod 2)) :
   have :
       kIdeal = Ideal.span ((monomial · (1 : ZMod 2)) '' Set.range (Finsupp.single · 2)) := by
     simp_rw [kIdeal, X, monomial_mul, one_mul, ← Finsupp.single_add, ← Set.range_comp,
-      Function.comp]
+      Function.comp_def]
   rw [this, mem_ideal_span_monomial_image]
   simp
 

--- a/Counterexamples/SorgenfreyLine.lean
+++ b/Counterexamples/SorgenfreyLine.lean
@@ -141,7 +141,7 @@ theorem map_toReal_nhds (a : ℝₗ) : map toReal (𝓝 a) = 𝓝[≥] toReal a 
 #align counterexample.sorgenfrey_line.map_to_real_nhds Counterexample.SorgenfreyLine.map_toReal_nhds
 
 theorem nhds_eq_map (a : ℝₗ) : 𝓝 a = map toReal.symm (𝓝[≥] (toReal a)) := by
-  simp_rw [← map_toReal_nhds, map_map, (· ∘ ·), toReal.symm_apply_apply, map_id']
+  simp_rw [← map_toReal_nhds, map_map, Function.comp_def, toReal.symm_apply_apply, map_id']
 #align counterexample.sorgenfrey_line.nhds_eq_map Counterexample.SorgenfreyLine.nhds_eq_map
 
 theorem nhds_eq_comap (a : ℝₗ) : 𝓝 a = comap toReal (𝓝[≥] (toReal a)) := by

--- a/Mathlib/Algebra/BigOperators/Finsupp.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp.lean
@@ -439,7 +439,7 @@ def liftAddHom [AddZeroClass M] [AddCommMonoid N] : (α → M →+ N) ≃+ ((α 
   right_inv F := by
   -- Porting note: This was `ext` and used the wrong lemma
     apply Finsupp.addHom_ext'
-    simp [singleAddHom, AddMonoidHom.comp, Function.comp]
+    simp [singleAddHom, AddMonoidHom.comp, comp_def]
   map_add' F G := by
     ext x
     exact sum_add

--- a/Mathlib/Algebra/Free.lean
+++ b/Mathlib/Algebra/Free.lean
@@ -272,11 +272,11 @@ instance : LawfulTraversable FreeMagma.{u} :=
         rw [traverse_mul, ih1, ih2, mul_map_seq]
     comp_traverse := fun f g x ↦
       FreeMagma.recOnPure x
-        (fun x ↦ by simp only [(· ∘ ·), traverse_pure, traverse_pure', functor_norm])
+        (fun x ↦ by simp only [Function.comp_def, traverse_pure, traverse_pure', functor_norm])
         (fun x y ih1 ih2 ↦ by
           rw [traverse_mul, ih1, ih2, traverse_mul];
-          simp [Functor.Comp.map_mk, Functor.map_map, (· ∘ ·), Comp.seq_mk, seq_map_assoc,
-            map_seq, traverse_mul])
+          simp [Functor.Comp.map_mk, Functor.map_map,
+            Function.comp_def, Comp.seq_mk, seq_map_assoc, map_seq, traverse_mul])
     naturality := fun η α β f x ↦
       FreeMagma.recOnPure x
         (fun x ↦ by simp only [traverse_pure, functor_norm, Function.comp_apply])
@@ -657,8 +657,9 @@ theorem traverse_mul (x y : FreeSemigroup α) :
   List.recOn L1 (fun x ↦ rfl)
     (fun hd tl ih x ↦ show
         (· * ·) <$> pure <$> F x <*> traverse F (mk hd tl * mk y L2) =
-          (· * ·) <$> ((· * ·) <$> pure <$> F x <*> traverse F (mk hd tl)) <*> traverse F (mk y L2)
-        by rw [ih]; simp only [(· ∘ ·), (mul_assoc _ _ _).symm, functor_norm])
+        (· * ·) <$> ((· * ·) <$> pure <$> F x <*> traverse F (mk hd tl)) <*> traverse F (mk y L2) by
+          rw [ih]
+          simp only [Function.comp_def, (mul_assoc _ _ _).symm, functor_norm])
     x
 #align free_semigroup.traverse_mul FreeSemigroup.traverse_mul
 
@@ -687,9 +688,11 @@ instance : LawfulTraversable FreeSemigroup.{u} :=
       FreeSemigroup.recOnMul x (fun x ↦ rfl) fun x y ih1 ih2 ↦ by
         rw [traverse_mul, ih1, ih2, mul_map_seq]
     comp_traverse := fun f g x ↦
-      recOnPure x (fun x ↦ by simp only [traverse_pure, functor_norm, (· ∘ ·)])
-        fun x y ih1 ih2 ↦ by (rw [traverse_mul, ih1, ih2,
-          traverse_mul, Functor.Comp.map_mk]; simp only [Function.comp, functor_norm, traverse_mul])
+      recOnPure x (fun x ↦ by
+        simp only [traverse_pure, functor_norm, Function.comp_def])
+        fun x y ih1 ih2 ↦ by
+          rw [traverse_mul, ih1, ih2, traverse_mul, Functor.Comp.map_mk]
+          simp only [Function.comp_def, functor_norm, traverse_mul]
     naturality := fun η α β f x ↦
       recOnPure x (fun x ↦ by simp only [traverse_pure, functor_norm, Function.comp])
           (fun x y ih1 ih2 ↦ by simp only [traverse_mul, functor_norm, ih1, ih2])

--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -595,7 +595,7 @@ variable {A : Type*} [Semiring A] [Algebra R A]
 theorem _root_.Algebra.adjoin_range_eq_range_freeAlgebra_lift (f : X → A) :
     Algebra.adjoin R (Set.range f) = (FreeAlgebra.lift R f).range := by
   simp only [← Algebra.map_top, ←adjoin_range_ι, AlgHom.map_adjoin, ← Set.range_comp,
-    (· ∘ ·), lift_ι_apply]
+    Function.comp_def, lift_ι_apply]
 
 /-- Noncommutative version of `Algebra.adjoin_range_eq_range`. -/
 theorem _root_.Algebra.adjoin_eq_range_freeAlgebra_lift (s : Set A) :

--- a/Mathlib/Algebra/MonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Basic.lean
@@ -944,7 +944,7 @@ def mapDomainNonUnitalAlgHom (k A : Type*) [CommSemiring k] [Semiring A] [Algebr
 variable (A) in
 theorem mapDomain_algebraMap {F : Type*} [MonoidHomClass F G H] (f : F) (r : k) :
     mapDomain f (algebraMap k (MonoidAlgebra A G) r) = algebraMap k (MonoidAlgebra A H) r := by
-  simp only [coe_algebraMap, mapDomain_single, map_one, (· ∘ ·)]
+  simp only [coe_algebraMap, mapDomain_single, map_one, Function.comp_def]
 #align monoid_algebra.map_domain_algebra_map MonoidAlgebra.mapDomain_algebraMap
 
 /-- If `f : G → H` is a multiplicative homomorphism between two monoids, then

--- a/Mathlib/Algebra/Support.lean
+++ b/Mathlib/Algebra/Support.lean
@@ -204,7 +204,7 @@ theorem mulSupport_iInf [ConditionallyCompleteLattice M] [Nonempty ι] (f : ι �
 
 @[to_additive]
 theorem mulSupport_comp_subset {g : M → N} (hg : g 1 = 1) (f : α → M) :
-    mulSupport (g ∘ f) ⊆ mulSupport f := fun x => mt fun h => by simp only [(· ∘ ·), *]
+    mulSupport (g ∘ f) ⊆ mulSupport f := fun x => mt fun h => by simp only [Function.comp_def, *]
 #align function.mul_support_comp_subset Function.mulSupport_comp_subset
 #align function.support_comp_subset Function.support_comp_subset
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -658,7 +658,7 @@ instance monoid [Monoid R] [AddMonoid M] [DistribMulAction R M] [DistribMulActio
           rw [List.range_succ, List.map_append, List.sum_append, List.map_singleton,
             List.sum_singleton, Nat.sub_self, pow_zero, one_smul, List.smul_sum, List.map_map,
             fst_pow]  --porting note: `Function.comp` no longer works in `rw` so move to `simp_rw`
-          simp_rw [Function.comp, smul_smul, ← pow_succ, Nat.succ_eq_add_one]
+          simp_rw [Function.comp_def, smul_smul, ← pow_succ, Nat.succ_eq_add_one]
           congr 2
           refine' List.map_congr fun i hi => _
           rw [List.mem_range, Nat.lt_succ_iff] at hi
@@ -682,7 +682,7 @@ theorem snd_list_prod [Semiring R] [AddCommMonoid M] [Module R M] [Module Rᵐ�
   induction' l with x xs ih
   · simp
   · rw [List.enum_cons, ← List.map_fst_add_enum_eq_enumFrom]
-    simp_rw [List.map_cons, List.map_map, Function.comp, Prod.map_snd, Prod.map_fst, id,
+    simp_rw [List.map_cons, List.map_map, Function.comp_def, Prod.map_snd, Prod.map_fst, id,
       List.take_zero, List.take_cons, List.prod_nil, List.prod_cons, snd_mul, one_smul, List.drop,
       mul_smul, List.sum_cons, fst_list_prod, ih, List.smul_sum, List.map_map]
     exact add_comm _ _

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -197,7 +197,7 @@ theorem gc_set :
     @GaloisConnection (Set R) (Set (PrimeSpectrum R))ᵒᵈ _ _ (fun s => zeroLocus s) fun t =>
       vanishingIdeal t := by
   have ideal_gc : GaloisConnection Ideal.span _ := (Submodule.gi R R).gc
-  simpa [zeroLocus_span, Function.comp] using ideal_gc.compose (gc R)
+  simpa [zeroLocus_span, Function.comp_def] using ideal_gc.compose (gc R)
 #align prime_spectrum.gc_set PrimeSpectrum.gc_set
 
 theorem subset_zeroLocus_iff_subset_vanishingIdeal (t : Set (PrimeSpectrum R)) (s : Set R) :

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Topology.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Topology.lean
@@ -139,7 +139,7 @@ theorem gc_set :
     @GaloisConnection (Set A) (Set (ProjectiveSpectrum 𝒜))ᵒᵈ _ _
       (fun s => zeroLocus 𝒜 s) fun t => vanishingIdeal t := by
   have ideal_gc : GaloisConnection Ideal.span _ := (Submodule.gi A _).gc
-  simpa [zeroLocus_span, Function.comp] using GaloisConnection.compose ideal_gc (gc_ideal 𝒜)
+  simpa [zeroLocus_span, Function.comp_def] using GaloisConnection.compose ideal_gc (gc_ideal 𝒜)
 #align projective_spectrum.gc_set ProjectiveSpectrum.gc_set
 
 theorem gc_homogeneousIdeal :

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -861,7 +861,7 @@ theorem HasFPowerSeriesOnBall.tendstoUniformlyOn' {r' : ℝ≥0} (hf : HasFPower
     (h : (r' : ℝ≥0∞) < r) :
     TendstoUniformlyOn (fun n y => p.partialSum n (y - x)) f atTop (Metric.ball (x : E) r') := by
   convert (hf.tendstoUniformlyOn h).comp fun y => y - x using 1
-  · simp [(· ∘ ·)]
+  · simp [Function.comp_def]
   · ext z
     simp [dist_eq_norm]
 #align has_fpower_series_on_ball.tendsto_uniformly_on' HasFPowerSeriesOnBall.tendstoUniformlyOn'
@@ -1220,7 +1220,7 @@ theorem changeOriginSeries_summable_aux₁ {r r' : ℝ≥0} (hr : (r + r' : ℝ�
     Summable fun s : Σk l : ℕ, { s : Finset (Fin (k + l)) // s.card = l } =>
       ‖p (s.1 + s.2.1)‖₊ * r ^ s.2.1 * r' ^ s.1 := by
   rw [← changeOriginIndexEquiv.symm.summable_iff]
-  dsimp only [(· ∘ ·), changeOriginIndexEquiv_symm_apply_fst,
+  dsimp only [Function.comp_def, changeOriginIndexEquiv_symm_apply_fst,
     changeOriginIndexEquiv_symm_apply_snd_fst]
   have : ∀ n : ℕ,
       HasSum (fun s : Finset (Fin n) => ‖p (n - s.card + s.card)‖₊ * r ^ s.card * r' ^ (n - s.card))

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -1336,7 +1336,7 @@ theorem changeOrigin_eval (h : (‖x‖₊ + ‖y‖₊ : ℝ≥0∞) < p.radius
   -- porting note: added explicit function
   convert hasSum_fintype (fun c : Finset (Fin n) => f (changeOriginIndexEquiv.symm ⟨n, c⟩))
   rename_i s _
-  dsimp only [changeOriginSeriesTerm, (· ∘ ·), changeOriginIndexEquiv_symm_apply_fst,
+  dsimp only [changeOriginSeriesTerm, Function.comp_def, changeOriginIndexEquiv_symm_apply_fst,
     changeOriginIndexEquiv_symm_apply_snd_fst, changeOriginIndexEquiv_symm_apply_snd_snd_coe]
   rw [ContinuousMultilinearMap.curryFinFinset_apply_const]
   have : ∀ (m) (hm : n = m), p n (s.piecewise (fun _ => x) fun _ => y) =

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -1149,7 +1149,7 @@ def sigmaEquivSigmaPi (n : ℕ) :
     -- but we need to massage it to take care of the dependent setting.
     rintro ⟨c, d⟩
     have : map List.sum (ofFn fun i : Fin (Composition.length c) => (d i).blocks) = c.blocks := by
-      simp [map_ofFn, (· ∘ ·), Composition.blocks_sum, Composition.ofFn_blocksFun]
+      simp [map_ofFn, Function.comp_def, Composition.blocks_sum, Composition.ofFn_blocksFun]
     rw [sigma_pi_composition_eq_iff]
     dsimp
     congr! 1

--- a/Mathlib/Analysis/Analytic/Inverse.lean
+++ b/Mathlib/Analysis/Analytic/Inverse.lean
@@ -144,7 +144,7 @@ theorem leftInv_comp (p : FormalMultilinearSeries 𝕜 E F) (i : E ≃L[𝕜] F)
       ext c
       congr
       ext k
-      simp [h, Function.comp]
+      simp [h, Function.comp_def]
     simp [FormalMultilinearSeries.comp, show n + 2 ≠ 1 by norm_num, A, Finset.sum_union B,
       applyComposition_ones, C, D, -Set.toFinset_setOf]
 #align formal_multilinear_series.left_inv_comp FormalMultilinearSeries.leftInv_comp

--- a/Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean
+++ b/Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean
@@ -28,7 +28,7 @@ theorem Filter.IsBoundedUnder.isLittleO_sub_self_inv {𝕜 E : Type*} [NormedFie
     {f : 𝕜 → E} (h : IsBoundedUnder (· ≤ ·) (𝓝[≠] a) (norm ∘ f)) :
     f =o[𝓝[≠] a] fun x => (x - a)⁻¹ := by
   refine' (h.isBigO_const (one_ne_zero' ℝ)).trans_isLittleO (isLittleO_const_left.2 <| Or.inr _)
-  simp only [(· ∘ ·), norm_inv]
+  simp only [Function.comp_def, norm_inv]
   exact (tendsto_norm_sub_self_punctured_nhds a).inv_tendsto_zero
 #align filter.is_bounded_under.is_o_sub_self_inv Filter.IsBoundedUnder.isLittleO_sub_self_inv
 

--- a/Mathlib/Analysis/Asymptotics/Theta.lean
+++ b/Mathlib/Analysis/Asymptotics/Theta.lean
@@ -220,7 +220,8 @@ theorem IsTheta.tendsto_zero_iff (h : f'' =Θ[l] g'') : Tendsto f'' l (𝓝 0) �
 
 theorem IsTheta.tendsto_norm_atTop_iff (h : f' =Θ[l] g') :
     Tendsto (norm ∘ f') l atTop ↔ Tendsto (norm ∘ g') l atTop := by
-  simp only [Function.comp, ← isLittleO_const_left_of_ne (one_ne_zero' ℝ), h.isLittleO_congr_right]
+  simp only [Function.comp_def, ← isLittleO_const_left_of_ne (one_ne_zero' ℝ),
+    h.isLittleO_congr_right]
 #align asymptotics.is_Theta.tendsto_norm_at_top_iff Asymptotics.IsTheta.tendsto_norm_atTop_iff
 
 theorem IsTheta.isBoundedUnder_le_iff (h : f' =Θ[l] g') :

--- a/Mathlib/Analysis/BoxIntegral/DivergenceTheorem.lean
+++ b/Mathlib/Analysis/BoxIntegral/DivergenceTheorem.lean
@@ -126,7 +126,8 @@ theorem norm_volume_sub_integral_face_upper_sub_lower_smul_le {f : (Fin (n + 1) 
       rw [← integral_sub (Hi _ Hu) (Hi _ Hl), ← Box.volume_face_mul i, mul_smul, ← Box.volume_apply,
         ← BoxAdditiveMap.toSMul_apply, ← integral_const, ← BoxAdditiveMap.volume,
         ← integral_sub (integrable_const _) ((Hi _ Hu).sub (Hi _ Hl))]
-      simp only [Function.comp_def, Pi.sub_def, ← f'.map_smul, ← Pi.single_smul', smul_eq_mul, mul_one]
+      simp only [Function.comp_def, Pi.sub_def, ← f'.map_smul, ← Pi.single_smul', smul_eq_mul,
+        mul_one]
     _ ≤ (volume (I.face i : Set (Fin n → ℝ))).toReal * (2 * ε * c * (I.upper i - I.lower i)) := by
       -- The hard part of the estimate was done above, here we just replace `diam I.Icc`
       -- with `c * (I.upper i - I.lower i)`

--- a/Mathlib/Analysis/BoxIntegral/DivergenceTheorem.lean
+++ b/Mathlib/Analysis/BoxIntegral/DivergenceTheorem.lean
@@ -126,7 +126,7 @@ theorem norm_volume_sub_integral_face_upper_sub_lower_smul_le {f : (Fin (n + 1) 
       rw [← integral_sub (Hi _ Hu) (Hi _ Hl), ← Box.volume_face_mul i, mul_smul, ← Box.volume_apply,
         ← BoxAdditiveMap.toSMul_apply, ← integral_const, ← BoxAdditiveMap.volume,
         ← integral_sub (integrable_const _) ((Hi _ Hu).sub (Hi _ Hl))]
-      simp only [(· ∘ ·), Pi.sub_def, ← f'.map_smul, ← Pi.single_smul', smul_eq_mul, mul_one]
+      simp only [Function.comp_def, Pi.sub_def, ← f'.map_smul, ← Pi.single_smul', smul_eq_mul, mul_one]
     _ ≤ (volume (I.face i : Set (Fin n → ℝ))).toReal * (2 * ε * c * (I.upper i - I.lower i)) := by
       -- The hard part of the estimate was done above, here we just replace `diam I.Icc`
       -- with `c * (I.upper i - I.lower i)`

--- a/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
@@ -201,7 +201,7 @@ def upperSubLower.{u} {G : Type u} [AddCommGroup G] (I₀ : Box (Fin (n + 1))) (
       rw [WithTop.coe_le_coe] at hJ
       refine' i.succAboveCases (fun hx => _) (fun j hx => _) j
       · simp only [Box.splitLower_def hx, Box.splitUpper_def hx, update_same, ← WithBot.some_eq_coe,
-          Option.elim', Box.face, (· ∘ ·), update_noteq (Fin.succAbove_ne _ _)]
+          Option.elim', Box.face, Function.comp_def, update_noteq (Fin.succAbove_ne _ _)]
         abel
       · have : (J.face i : WithTop (Box (Fin n))) ≤ I₀.face i :=
           WithTop.coe_le_coe.2 (face_mono hJ i)

--- a/Mathlib/Analysis/BoxIntegral/Partition/Measure.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Measure.lean
@@ -131,7 +131,7 @@ theorem volume_apply' (I : Box ι) :
 theorem volume_face_mul {n} (i : Fin (n + 1)) (I : Box (Fin (n + 1))) :
     (∏ j, ((I.face i).upper j - (I.face i).lower j)) * (I.upper i - I.lower i) =
       ∏ j, (I.upper j - I.lower j) := by
-  simp only [face_lower, face_upper, (· ∘ ·), Fin.prod_univ_succAbove _ i, mul_comm]
+  simp only [face_lower, face_upper, Function.comp_def, Fin.prod_univ_succAbove _ i, mul_comm]
 #align box_integral.box.volume_face_mul BoxIntegral.Box.volume_face_mul
 
 end Box

--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -320,7 +320,7 @@ point in a domain. -/
 theorem ContinuousLinearEquiv.comp_contDiffWithinAt_iff (e : F ≃L[𝕜] G) :
     ContDiffWithinAt 𝕜 n (e ∘ f) s x ↔ ContDiffWithinAt 𝕜 n f s x :=
   ⟨fun H => by
-    simpa only [(· ∘ ·), e.symm.coe_coe, e.symm_apply_apply] using
+    simpa only [Function.comp_def, e.symm.coe_coe, e.symm_apply_apply] using
       H.continuousLinearMap_comp (e.symm : G →L[𝕜] F),
     fun H => H.continuousLinearMap_comp (e : F →L[𝕜] G)⟩
 #align continuous_linear_equiv.comp_cont_diff_within_at_iff ContinuousLinearEquiv.comp_contDiffWithinAt_iff
@@ -466,7 +466,7 @@ theorem ContinuousLinearEquiv.contDiffWithinAt_comp_iff (e : G ≃L[𝕜] E) :
     ContDiffWithinAt 𝕜 n (f ∘ e) (e ⁻¹' s) (e.symm x) ↔ ContDiffWithinAt 𝕜 n f s x := by
   constructor
   · intro H
-    simpa [← preimage_comp, (· ∘ ·)] using H.comp_continuousLinearMap (e.symm : E →L[𝕜] G)
+    simpa [← preimage_comp, Function.comp_def] using H.comp_continuousLinearMap (e.symm : E →L[𝕜] G)
   · intro H
     rw [← e.apply_symm_apply x, ← e.coe_coe] at H
     exact H.comp_continuousLinearMap _
@@ -484,8 +484,8 @@ theorem ContinuousLinearEquiv.contDiffAt_comp_iff (e : G ≃L[𝕜] E) :
 domains. -/
 theorem ContinuousLinearEquiv.contDiffOn_comp_iff (e : G ≃L[𝕜] E) :
     ContDiffOn 𝕜 n (f ∘ e) (e ⁻¹' s) ↔ ContDiffOn 𝕜 n f s :=
-  ⟨fun H => by simpa [(· ∘ ·)] using H.comp_continuousLinearMap (e.symm : E →L[𝕜] G), fun H =>
-    H.comp_continuousLinearMap (e : G →L[𝕜] E)⟩
+  ⟨fun H => by simpa [Function.comp_def] using H.comp_continuousLinearMap (e.symm : E →L[𝕜] G),
+    fun H => H.comp_continuousLinearMap (e : G →L[𝕜] E)⟩
 #align continuous_linear_equiv.cont_diff_on_comp_iff ContinuousLinearEquiv.contDiffOn_comp_iff
 
 /-- Composition by continuous linear equivs on the right respects higher differentiability. -/

--- a/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
@@ -894,7 +894,7 @@ theorem Filter.EventuallyEq.iterated_fderiv_within' (h : f₁ =ᶠ[𝓝[s] x] f)
   · have : fderivWithin 𝕜 _ t =ᶠ[𝓝[s] x] fderivWithin 𝕜 _ t := ihn.fderiv_within' ht
     apply this.mono
     intro y hy
-    simp only [iteratedFDerivWithin_succ_eq_comp_left, hy, (· ∘ ·)]
+    simp only [iteratedFDerivWithin_succ_eq_comp_left, hy, Function.comp_def]
 #align filter.eventually_eq.iterated_fderiv_within' Filter.EventuallyEq.iterated_fderiv_within'
 
 protected theorem Filter.EventuallyEq.iteratedFDerivWithin (h : f₁ =ᶠ[𝓝[s] x] f) (n : ℕ) :
@@ -931,7 +931,7 @@ theorem iteratedFDerivWithin_eventually_congr_set' (y : E) (h : s =ᶠ[𝓝[{y}�
   induction' n with n ihn generalizing x
   · rfl
   · refine' (eventually_nhds_nhdsWithin.2 h).mono fun y hy => _
-    simp only [iteratedFDerivWithin_succ_eq_comp_left, (· ∘ ·)]
+    simp only [iteratedFDerivWithin_succ_eq_comp_left, Function.comp_def]
     rw [(ihn hy).fderivWithin_eq_nhds, fderivWithin_congr_set' _ hy]
 #align iterated_fderiv_within_eventually_congr_set' iteratedFDerivWithin_eventually_congr_set'
 

--- a/Mathlib/Analysis/Calculus/Deriv/Comp.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Comp.lean
@@ -240,7 +240,7 @@ equal to the Fréchet derivative of `l` applied to the derivative of `f`. -/
 theorem HasFDerivWithinAt.comp_hasDerivWithinAt {t : Set F} (hl : HasFDerivWithinAt l l' t (f x))
     (hf : HasDerivWithinAt f f' s x) (hst : MapsTo f s t) :
     HasDerivWithinAt (l ∘ f) (l' f') s x := by
-  simpa only [one_apply, one_smul, smulRight_apply, coe_comp', (· ∘ ·)] using
+  simpa only [one_apply, one_smul, smulRight_apply, coe_comp', Function.comp_def] using
     (hl.comp x hf.hasFDerivWithinAt hst).hasDerivWithinAt
 #align has_fderiv_within_at.comp_has_deriv_within_at HasFDerivWithinAt.comp_hasDerivWithinAt
 
@@ -258,7 +258,7 @@ theorem HasFDerivAt.comp_hasDerivAt (hl : HasFDerivAt l l' (f x)) (hf : HasDeriv
 
 theorem HasStrictFDerivAt.comp_hasStrictDerivAt (hl : HasStrictFDerivAt l l' (f x))
     (hf : HasStrictDerivAt f f' x) : HasStrictDerivAt (l ∘ f) (l' f') x := by
-  simpa only [one_apply, one_smul, smulRight_apply, coe_comp', (· ∘ ·)] using
+  simpa only [one_apply, one_smul, smulRight_apply, coe_comp', Function.comp_def] using
     (hl.comp x hf.hasStrictFDerivAt).hasStrictDerivAt
 #align has_strict_fderiv_at.comp_has_strict_deriv_at HasStrictFDerivAt.comp_hasStrictDerivAt
 

--- a/Mathlib/Analysis/Calculus/Deriv/Inv.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inv.lean
@@ -185,7 +185,7 @@ theorem HasDerivWithinAt.div (hc : HasDerivWithinAt c c' s x) (hd : HasDerivWith
     (hx : d x ≠ 0) :
     HasDerivWithinAt (fun y => c y / d y) ((c' * d x - c x * d') / d x ^ 2) s x := by
   convert hc.mul ((hasDerivAt_inv hx).comp_hasDerivWithinAt x hd) using 1
-  · simp only [div_eq_mul_inv, (· ∘ ·)]
+  · simp only [div_eq_mul_inv, Function.comp_def]
   · field_simp
     ring
 #align has_deriv_within_at.div HasDerivWithinAt.div
@@ -193,7 +193,7 @@ theorem HasDerivWithinAt.div (hc : HasDerivWithinAt c c' s x) (hd : HasDerivWith
 theorem HasStrictDerivAt.div (hc : HasStrictDerivAt c c' x) (hd : HasStrictDerivAt d d' x)
     (hx : d x ≠ 0) : HasStrictDerivAt (fun y => c y / d y) ((c' * d x - c x * d') / d x ^ 2) x := by
   convert hc.mul ((hasStrictDerivAt_inv hx).comp x hd) using 1
-  · simp only [div_eq_mul_inv, (· ∘ ·)]
+  · simp only [div_eq_mul_inv, Function.comp_def]
   · field_simp
     ring
 #align has_strict_deriv_at.div HasStrictDerivAt.div
@@ -240,4 +240,3 @@ theorem deriv_div (hc : DifferentiableAt 𝕜 c x) (hd : DifferentiableAt 𝕜 d
 #align deriv_div deriv_div
 
 end Division
-

--- a/Mathlib/Analysis/Calculus/Deriv/Slope.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Slope.lean
@@ -89,7 +89,7 @@ theorem hasDerivAt_iff_tendsto_slope_zero :
     HasDerivAt f f' x ↔ Tendsto (fun t ↦ t⁻¹ • (f (x + t) - f x)) (𝓝[≠] 0) (𝓝 f') := by
   have : 𝓝[≠] x = Filter.map (fun t ↦ x + t) (𝓝[≠] 0) := by
     simp [nhdsWithin, map_add_left_nhds_zero x, Filter.map_inf, add_right_injective x]
-  simp [hasDerivAt_iff_tendsto_slope, this, slope, Function.comp]
+  simp [hasDerivAt_iff_tendsto_slope, this, slope, Function.comp_def]
 
 alias ⟨HasDerivAt.tendsto_slope_zero, _⟩ := hasDerivAt_iff_tendsto_slope_zero
 

--- a/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
@@ -51,7 +51,7 @@ theorem hasStrictDerivAt_zpow (m : ℤ) (x : 𝕜) (h : x ≠ 0 ∨ 0 ≤ m) :
   · have hx : x ≠ 0 := h.resolve_right hm.not_le
     have := (hasStrictDerivAt_inv ?_).scomp _ (this (-m) (neg_pos.2 hm)) <;>
       [skip; exact zpow_ne_zero_of_ne_zero hx _]
-    simp only [(· ∘ ·), zpow_neg, one_div, inv_inv, smul_eq_mul] at this
+    simp only [Function.comp_def, zpow_neg, one_div, inv_inv, smul_eq_mul] at this
     convert this using 1
     rw [sq, mul_inv, inv_inv, Int.cast_neg, neg_mul, neg_mul_neg, ← zpow_add₀ hx, mul_assoc, ←
       zpow_add₀ hx]

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -331,7 +331,7 @@ theorem hasFDerivAt_iff_tendsto :
 theorem hasFDerivAt_iff_isLittleO_nhds_zero :
     HasFDerivAt f f' x ↔ (fun h : E => f (x + h) - f x - f' h) =o[𝓝 0] fun h => h := by
   rw [HasFDerivAt, HasFDerivAtFilter, ← map_add_left_nhds_zero x, isLittleO_map]
-  simp [(· ∘ ·)]
+  simp [Function.comp_def]
 #align has_fderiv_at_iff_is_o_nhds_zero hasFDerivAt_iff_isLittleO_nhds_zero
 
 /-- Converse to the mean value inequality: if `f` is differentiable at `x₀` and `C`-lipschitz

--- a/Mathlib/Analysis/Calculus/FDeriv/Bilinear.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Bilinear.lean
@@ -79,7 +79,7 @@ theorem IsBoundedBilinearMap.hasStrictFDerivAt (h : IsBoundedBilinearMap 𝕜 b)
       refine (isBigO_refl _ _).mul_isLittleO ((isLittleO_one_iff _).2 ?_)
       -- TODO: `continuity` fails
       exact (continuous_snd.fst.prod_mk continuous_fst.snd).norm.tendsto' _ _ (by simp)
-    _ = _ := by simp [(· ∘ ·)]
+    _ = _ := by simp [Function.comp_def]
 #align is_bounded_bilinear_map.has_strict_fderiv_at IsBoundedBilinearMap.hasStrictFDerivAt
 
 theorem IsBoundedBilinearMap.hasFDerivAt (h : IsBoundedBilinearMap 𝕜 b) (p : E × F) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Equiv.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Equiv.lean
@@ -376,7 +376,7 @@ theorem HasStrictFDerivAt.of_local_left_inverse {f : E → F} {f' : E ≃L[𝕜]
   · refine (hf.isBigO_sub_rev.comp_tendsto hg).congr' (eventually_of_forall fun _ => rfl)
       (hfg.mono ?_)
     rintro p ⟨hp1, hp2⟩
-    simp only [(· ∘ ·), hp1, hp2]
+    simp only [Function.comp_def, hp1, hp2]
 #align has_strict_fderiv_at.of_local_left_inverse HasStrictFDerivAt.of_local_left_inverse
 
 /-- If `f (g y) = y` for `y` in some neighborhood of `a`, `g` is continuous at `a`, and `f` has an
@@ -401,7 +401,7 @@ theorem HasFDerivAt.of_local_left_inverse {f : E → F} {f' : E ≃L[𝕜] F} {g
   · refine' ((hf.isBigO_sub_rev f'.antilipschitz).comp_tendsto hg).congr'
       (eventually_of_forall fun _ => rfl) (hfg.mono _)
     rintro p hp
-    simp only [(· ∘ ·), hp, hfg.self_of_nhds]
+    simp only [Function.comp_def, hp, hfg.self_of_nhds]
 #align has_fderiv_at.of_local_left_inverse HasFDerivAt.of_local_left_inverse
 
 /-- If `f` is a local homeomorphism defined on a neighbourhood of `f.symm a`, and `f` has an

--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -496,7 +496,7 @@ theorem HasLineDerivWithinAt.smul (h : HasLineDerivWithinAt 𝕜 f f' s x v) (c 
   have A : HasDerivAt g c 0 := by simpa using (hasDerivAt_id (0 : 𝕜)).const_smul c
   have B : HasDerivWithinAt (fun t ↦ f (x + t • v)) f' s' (g 0) := by simpa using h
   have Z := B.scomp (0 : 𝕜) A.hasDerivWithinAt (mapsTo_preimage g s')
-  simp only [Function.comp, smul_eq_mul, mul_comm c, ← smul_smul] at Z
+  simp only [Function.comp_def, smul_eq_mul, mul_comm c, ← smul_smul] at Z
   convert Z
   ext t
   simp [← smul_smul]

--- a/Mathlib/Analysis/Calculus/ParametricIntegral.lean
+++ b/Mathlib/Analysis/Calculus/ParametricIntegral.lean
@@ -213,13 +213,13 @@ theorem hasDerivAt_integral_of_dominated_loc_of_lip {F : 𝕜 → α → E} {F' 
     hF'_int key
   replace hF'_int : Integrable F' μ
   · rw [← integrable_norm_iff hm] at hF'_int
-    simpa only [(· ∘ ·), integrable_norm_iff, hF'_meas, one_mul, norm_one,
+    simpa only [Function.comp_def, integrable_norm_iff, hF'_meas, one_mul, norm_one,
       ContinuousLinearMap.comp_apply, ContinuousLinearMap.coe_restrict_scalarsL',
       ContinuousLinearMap.norm_restrictScalars, ContinuousLinearMap.norm_smulRightL_apply] using
       hF'_int
   refine' ⟨hF'_int, _⟩
   simp_rw [hasDerivAt_iff_hasFDerivAt] at h_diff ⊢
-  simpa only [(· ∘ ·), ContinuousLinearMap.integral_comp_comm _ hF'_int] using key
+  simpa only [Function.comp_def, ContinuousLinearMap.integral_comp_comm _ hF'_int] using key
 #align has_deriv_at_integral_of_dominated_loc_of_lip hasDerivAt_integral_of_dominated_loc_of_lip
 
 /-- Derivative under integral of `x ↦ ∫ F x a` at a given point `x₀ : ℝ`, assuming

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -147,7 +147,7 @@ theorem norm_max_aux₂ {f : ℂ → F} {z w : ℂ} (hd : DiffContOnCl ℂ f (ba
   have he : ∀ x, ‖e x‖ = ‖x‖ := UniformSpace.Completion.norm_coe
   replace hz : IsMaxOn (norm ∘ e ∘ f) (closedBall z (dist w z)) z
   · simpa only [IsMaxOn, Function.comp_def, he] using hz
-  simpa only [he, (· ∘ ·)]
+  simpa only [he, Function.comp_def]
     using norm_max_aux₁ (e.differentiable.comp_diffContOnCl hd) hz
 #align complex.norm_max_aux₂ Complex.norm_max_aux₂
 
@@ -424,4 +424,3 @@ theorem eqOn_of_eqOn_frontier {f g : E → F} {U : Set E} (hU : IsBounded U) (hf
 #align complex.eq_on_of_eq_on_frontier Complex.eqOn_of_eqOn_frontier
 
 end Complex
-

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -146,7 +146,7 @@ theorem norm_max_aux₂ {f : ℂ → F} {z w : ℂ} (hd : DiffContOnCl ℂ f (ba
   set e : F →L[ℂ] F̂ := UniformSpace.Completion.toComplL
   have he : ∀ x, ‖e x‖ = ‖x‖ := UniformSpace.Completion.norm_coe
   replace hz : IsMaxOn (norm ∘ e ∘ f) (closedBall z (dist w z)) z
-  · simpa only [IsMaxOn, (· ∘ ·), he] using hz
+  · simpa only [IsMaxOn, Function.comp_def, he] using hz
   simpa only [he, (· ∘ ·)]
     using norm_max_aux₁ (e.differentiable.comp_diffContOnCl hd) hz
 #align complex.norm_max_aux₂ Complex.norm_max_aux₂

--- a/Mathlib/Analysis/Complex/PhragmenLindelof.lean
+++ b/Mathlib/Analysis/Complex/PhragmenLindelof.lean
@@ -198,8 +198,8 @@ theorem horizontal_strip (hfd : DiffContOnCl ℂ f (im ⁻¹' Ioo a b))
     suffices H : Tendsto (fun R => δ + B * (expR ((d - c) * R))⁻¹) atTop (𝓝 (δ + B * 0))
     · rw [mul_zero, add_zero] at H
       refine' Tendsto.atBot_add _ tendsto_const_nhds
-      simpa only [id, Function.comp_def, add_mul, mul_assoc, ← div_eq_inv_mul, ← Real.exp_sub, ← sub_mul,
-        sub_sub_cancel]
+      simpa only [id, Function.comp_def, add_mul, mul_assoc, ← div_eq_inv_mul, ← Real.exp_sub,
+        ← sub_mul, sub_sub_cancel]
         using H.neg_mul_atTop δ₀ <| Real.tendsto_exp_atTop.comp <|
           tendsto_const_nhds.mul_atTop hd₀ tendsto_id
     refine' tendsto_const_nhds.add (tendsto_const_nhds.mul _)

--- a/Mathlib/Analysis/Complex/PhragmenLindelof.lean
+++ b/Mathlib/Analysis/Complex/PhragmenLindelof.lean
@@ -298,8 +298,8 @@ theorem vertical_strip (hfd : DiffContOnCl ℂ f (re ⁻¹' Ioo a b))
     have : Tendsto (· * -I) (comap (|re ·|) atTop ⊓ 𝓟 (im ⁻¹' Ioo a b))
         (comap (|im ·|) atTop ⊓ 𝓟 (re ⁻¹' Ioo a b)) := by
       refine' (tendsto_comap_iff.2 _).inf H.tendsto
-      simpa [(· ∘ ·)] using tendsto_comap
-    simpa [(· ∘ ·)] using hO.comp_tendsto this
+      simpa [Function.comp_def] using tendsto_comap
+    simpa [Function.comp_def] using hO.comp_tendsto this
   all_goals simpa
 #align phragmen_lindelof.vertical_strip PhragmenLindelof.vertical_strip
 
@@ -479,7 +479,7 @@ theorem quadrant_II (hd : DiffContOnCl ℂ f (Iio 0 ×ℂ Ioi 0))
   rcases hB with ⟨c, hc, B, hO⟩
   refine' quadrant_I (hd.comp (differentiable_id.mul_const _).diffContOnCl H) ⟨c, hc, B, ?_⟩ him
     (fun x hx => _) hz_im hz_re
-  · simpa only [(· ∘ ·), map_mul, abs_I, mul_one]
+  · simpa only [Function.comp_def, map_mul, abs_I, mul_one]
       using hO.comp_tendsto ((tendsto_mul_right_cobounded I_ne_zero).inf H.tendsto)
   · rw [comp_apply, mul_assoc, I_mul_I, mul_neg_one, ← ofReal_neg]
     exact hre _ (neg_nonpos.2 hx)
@@ -550,7 +550,7 @@ theorem quadrant_III (hd : DiffContOnCl ℂ f (Iio 0 ×ℂ Iio 0))
       hz_re hz_im
   · rcases hB with ⟨c, hc, B, hO⟩
     refine ⟨c, hc, B, ?_⟩
-    simpa only [(· ∘ ·), Complex.abs.map_neg]
+    simpa only [Function.comp_def, Complex.abs.map_neg]
       using hO.comp_tendsto (tendsto_neg_cobounded.inf H.tendsto)
   · rw [comp_apply, ← ofReal_neg]
     exact hre (-x) (neg_nonpos.2 hx)
@@ -620,7 +620,7 @@ theorem quadrant_IV (hd : DiffContOnCl ℂ f (Ioi 0 ×ℂ Iio 0))
     hz_re hz_im
   · rcases hB with ⟨c, hc, B, hO⟩
     refine ⟨c, hc, B, ?_⟩
-    simpa only [(· ∘ ·), Complex.abs.map_neg]
+    simpa only [Function.comp_def, Complex.abs.map_neg]
       using hO.comp_tendsto (tendsto_neg_cobounded.inf H.tendsto)
   · rw [comp_apply, ← ofReal_neg]
     exact hre (-x) (neg_nonneg.2 hx)

--- a/Mathlib/Analysis/Complex/PhragmenLindelof.lean
+++ b/Mathlib/Analysis/Complex/PhragmenLindelof.lean
@@ -184,7 +184,7 @@ theorem horizontal_strip (hfd : DiffContOnCl ℂ f (im ⁻¹' Ioo a b))
     refine' ((eventually_gt_atTop _).and _).exists
     rcases hO.exists_pos with ⟨A, hA₀, hA⟩
     simp only [isBigOWith_iff, eventually_inf_principal, eventually_comap, mem_Ioo, ← abs_lt,
-      mem_preimage, (· ∘ ·), Real.norm_eq_abs, abs_of_pos (Real.exp_pos _)] at hA
+      mem_preimage, Function.comp_def, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _)] at hA
     suffices :
         Tendsto (fun R => expR (δ * expR (d * R) + B * expR (c * R) + Real.log A)) atTop (𝓝 0)
     · filter_upwards [this.eventually (ge_mem_nhds hC₀), hA] with R hR Hle w hre him
@@ -198,7 +198,7 @@ theorem horizontal_strip (hfd : DiffContOnCl ℂ f (im ⁻¹' Ioo a b))
     suffices H : Tendsto (fun R => δ + B * (expR ((d - c) * R))⁻¹) atTop (𝓝 (δ + B * 0))
     · rw [mul_zero, add_zero] at H
       refine' Tendsto.atBot_add _ tendsto_const_nhds
-      simpa only [id, (· ∘ ·), add_mul, mul_assoc, ← div_eq_inv_mul, ← Real.exp_sub, ← sub_mul,
+      simpa only [id, Function.comp_def, add_mul, mul_assoc, ← div_eq_inv_mul, ← Real.exp_sub, ← sub_mul,
         sub_sub_cancel]
         using H.neg_mul_atTop δ₀ <| Real.tendsto_exp_atTop.comp <|
           tendsto_const_nhds.mul_atTop hd₀ tendsto_id

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -517,7 +517,7 @@ theorem Set.Finite.convexHull_eq_image {s : Set E} (hs : s.Finite) : convexHull 
   -- Porting note: Original proof didn't need to specify `hs.fintype`
   rw [← @convexHull_basis_eq_stdSimplex _ _ _ hs.fintype, ← LinearMap.convexHull_image,
     ← Set.range_comp]
-  simp_rw [Function.comp]
+  simp_rw [Function.comp_def]
   apply congr_arg
   convert Subtype.range_coe.symm
   -- Porting note: Original proof didn't need to specify `hs.fintype` and `(1 : R)`

--- a/Mathlib/Analysis/Convolution.lean
+++ b/Mathlib/Analysis/Convolution.lean
@@ -1365,13 +1365,13 @@ theorem contDiffOn_convolution_right_with_param {f : G → E} {n : ℕ∞} (L : 
     have hes : IsOpen (isoP ⁻¹' s) := isoP.continuous.isOpen_preimage _ hs
     refine' contDiffOn_convolution_right_with_param_aux eL hes hek _ _ _
     · intro p x hp hx
-      simp only [(· ∘ ·), ContinuousLinearEquiv.prod_apply, LinearIsometryEquiv.coe_coe,
+      simp only [Function.comp_def, ContinuousLinearEquiv.prod_apply, LinearIsometryEquiv.coe_coe,
         ContinuousLinearEquiv.map_eq_zero_iff]
       exact hgs _ _ hp hx
     · apply (locallyIntegrable_map_homeomorph isoG.symm.toHomeomorph).2
       convert hf
       ext1 x
-      simp only [ContinuousLinearEquiv.coe_toHomeomorph, (· ∘ ·),
+      simp only [ContinuousLinearEquiv.coe_toHomeomorph, Function.comp_def,
         ContinuousLinearEquiv.apply_symm_apply]
     · apply isoE'.symm.contDiff.comp_contDiffOn
       apply hg.comp (isoP.prod isoG).contDiff.contDiffOn
@@ -1387,14 +1387,14 @@ theorem contDiffOn_convolution_right_with_param {f : G → E} {n : ℕ∞} (L : 
   have : isoF ∘ R ∘ (isoP.prod isoG).symm = fun q : P × G => (f ⋆[L, μ] g q.1) q.2 := by
     apply funext
     rintro ⟨p, x⟩
-    simp only [LinearIsometryEquiv.coe_coe, (· ∘ ·), ContinuousLinearEquiv.prod_symm,
+    simp only [LinearIsometryEquiv.coe_coe, Function.comp_def, ContinuousLinearEquiv.prod_symm,
       ContinuousLinearEquiv.prod_apply]
-    simp only [convolution, coe_comp', ContinuousLinearEquiv.coe_coe, (· ∘ ·)]
+    simp only [convolution, coe_comp', ContinuousLinearEquiv.coe_coe, Function.comp_def]
     rw [ClosedEmbedding.integral_map, ← isoF.integral_comp_comm]
     swap; · exact isoG.symm.toHomeomorph.closedEmbedding
     congr 1
     ext1 a
-    simp only [(· ∘ ·), ContinuousLinearEquiv.apply_symm_apply, coe_comp',
+    simp only [Function.comp_def, ContinuousLinearEquiv.apply_symm_apply, coe_comp',
       ContinuousLinearEquiv.prod_apply, ContinuousLinearEquiv.map_sub,
       ContinuousLinearEquiv.arrowCongr, ContinuousLinearEquiv.arrowCongrSL_symm_apply,
       ContinuousLinearEquiv.coe_coe, Function.comp_apply, ContinuousLinearEquiv.apply_symm_apply]

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -125,7 +125,7 @@ theorem geom_mean_le_arith_mean_weighted (w z : ι → ℝ) (hw : ∀ i ∈ s, 0
   -- for `exp` and numbers `log (z i)` with weights `w i`.
   · simp only [not_exists, not_and, Ne.def, Classical.not_not] at A
     have := convexOn_exp.map_sum_le hw hw' fun i _ => Set.mem_univ <| log (z i)
-    simp only [exp_sum, (· ∘ ·), smul_eq_mul, mul_comm (w _) (log _)] at this
+    simp only [exp_sum, Function.comp_def, smul_eq_mul, mul_comm (w _) (log _)] at this
     convert this using 1 <;> [apply prod_congr rfl;apply sum_congr rfl] <;> intro i hi
     · cases' eq_or_lt_of_le (hz i hi) with hz hz
       · simp [A i hi hz.symm]

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -620,7 +620,7 @@ theorem Filter.tendsto_mul_right_cobounded {a : α} (ha : a ≠ 0) :
 lemma Filter.inv_cobounded₀ : (cobounded α)⁻¹ = 𝓝[≠] 0 := by
   rw [← comap_norm_atTop, ← Filter.comap_inv, ← comap_norm_nhdsWithin_Ioi_zero,
     ← inv_atTop₀, ← Filter.comap_inv]
-  simp only [comap_comap, (· ∘ ·), norm_inv]
+  simp only [comap_comap, Function.comp_def, norm_inv]
 
 @[simp]
 lemma Filter.inv_nhdsWithin_ne_zero : (𝓝[≠] (0 : α))⁻¹ = cobounded α := by

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -604,7 +604,7 @@ theorem nndist_inv_inv₀ {z w : α} (hz : z ≠ 0) (hw : w ≠ 0) :
 infinity. TODO: use `Bornology.cobounded` instead of `Filter.comap Norm.norm Filter.atTop`. -/
 theorem Filter.tendsto_mul_left_cobounded {a : α} (ha : a ≠ 0) :
     Tendsto ((· * ·) a) (comap norm atTop) (comap norm atTop) := by
-  simpa only [tendsto_comap_iff, (· ∘ ·), norm_mul] using
+  simpa only [tendsto_comap_iff, Function.comp_def, norm_mul] using
     tendsto_const_nhds.mul_atTop (norm_pos_iff.2 ha) tendsto_comap
 #align filter.tendsto_mul_left_cobounded Filter.tendsto_mul_left_cobounded
 
@@ -612,7 +612,7 @@ theorem Filter.tendsto_mul_left_cobounded {a : α} (ha : a ≠ 0) :
 infinity. TODO: use `Bornology.cobounded` instead of `Filter.comap Norm.norm Filter.atTop`. -/
 theorem Filter.tendsto_mul_right_cobounded {a : α} (ha : a ≠ 0) :
     Tendsto (fun x => x * a) (comap norm atTop) (comap norm atTop) := by
-  simpa only [tendsto_comap_iff, (· ∘ ·), norm_mul] using
+  simpa only [tendsto_comap_iff, Function.comp_def, norm_mul] using
     tendsto_comap.atTop_mul (norm_pos_iff.2 ha) tendsto_const_nhds
 #align filter.tendsto_mul_right_cobounded Filter.tendsto_mul_right_cobounded
 

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -473,7 +473,7 @@ theorem dist_div_eq_dist_mul_right (a b c : E) : dist a (b / c) = dist (a * c) b
 `Bornology.cobounded` instead of `Filter.comap Norm.norm Filter.atTop`."]
 theorem Filter.tendsto_inv_cobounded :
     Tendsto (Inv.inv : E → E) (comap norm atTop) (comap norm atTop) := by
-  simpa only [norm_inv', tendsto_comap_iff, (· ∘ ·)] using tendsto_comap
+  simpa only [norm_inv', tendsto_comap_iff, Function.comp_def] using tendsto_comap
 #align filter.tendsto_inv_cobounded Filter.tendsto_inv_cobounded
 #align filter.tendsto_neg_cobounded Filter.tendsto_neg_cobounded
 

--- a/Mathlib/Analysis/NormedSpace/FiniteDimension.lean
+++ b/Mathlib/Analysis/NormedSpace/FiniteDimension.lean
@@ -217,7 +217,7 @@ theorem LipschitzOnWith.extend_finite_dimension {α : Type*} [PseudoMetricSpace 
     refine' mul_le_mul' (le_max_left _ _) le_rfl
   · intro x hx
     have : A (f x) = g x := gs hx
-    simp only [(· ∘ ·), ← this, A.symm_apply_apply]
+    simp only [Function.comp_def, ← this, A.symm_apply_apply]
 #align lipschitz_on_with.extend_finite_dimension LipschitzOnWith.extend_finite_dimension
 
 theorem LinearMap.exists_antilipschitzWith [FiniteDimensional 𝕜 E] (f : E →ₗ[𝕜] F)

--- a/Mathlib/Analysis/NormedSpace/PiLp.lean
+++ b/Mathlib/Analysis/NormedSpace/PiLp.lean
@@ -920,7 +920,7 @@ nonrec theorem basis_toMatrix_basisFun_mul (b : Basis ι 𝕜 (PiLp p fun _ : ι
       Matrix.of fun i j => b.repr ((WithLp.equiv _ _).symm (Aᵀ j)) i := by
   have := basis_toMatrix_basisFun_mul (b.map (WithLp.linearEquiv _ 𝕜 _)) A
   simp_rw [← PiLp.basisFun_map p, Basis.map_repr, LinearEquiv.trans_apply,
-    WithLp.linearEquiv_symm_apply, Basis.toMatrix_map, Function.comp, Basis.map_apply,
+    WithLp.linearEquiv_symm_apply, Basis.toMatrix_map, Function.comp_def, Basis.map_apply,
     LinearEquiv.symm_apply_apply] at this
   exact this
 #align pi_Lp.basis_to_matrix_basis_fun_mul PiLp.basis_toMatrix_basisFun_mul

--- a/Mathlib/Analysis/NormedSpace/Spectrum.lean
+++ b/Mathlib/Analysis/NormedSpace/Spectrum.lean
@@ -153,7 +153,7 @@ theorem spectralRadius_lt_of_forall_lt_of_nonempty [ProperSpace 𝕜] {a : A} (h
   sSup_image.symm.trans_lt <|
     ((spectrum.isCompact a).sSup_lt_iff_of_continuous ha
           (ENNReal.continuous_coe.comp continuous_nnnorm).continuousOn (r : ℝ≥0∞)).mpr
-      (by dsimp only [(· ∘ ·)]; exact_mod_cast hr)
+      (by dsimp only [Function.comp_def]; exact_mod_cast hr)
 #align spectrum.spectral_radius_lt_of_forall_lt_of_nonempty spectrum.spectralRadius_lt_of_forall_lt_of_nonempty
 
 open ENNReal Polynomial

--- a/Mathlib/Analysis/NormedSpace/Units.lean
+++ b/Mathlib/Analysis/NormedSpace/Units.lean
@@ -218,7 +218,7 @@ theorem inverse_continuousAt (x : Rˣ) : ContinuousAt inverse (x : R) := by
     refine' tendsto_zero_iff_norm_tendsto_zero.mpr _
     exact tendsto_iff_norm_sub_tendsto_zero.mp tendsto_id
   rw [ContinuousAt, tendsto_iff_norm_sub_tendsto_zero, inverse_unit]
-  simpa [(· ∘ ·)] using h_is_o.norm_left.tendsto_div_nhds_zero.comp h_lim
+  simpa [Function.comp_def] using h_is_o.norm_left.tendsto_div_nhds_zero.comp h_lim
 #align normed_ring.inverse_continuous_at NormedRing.inverse_continuousAt
 
 end NormedRing

--- a/Mathlib/Analysis/NormedSpace/lpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/lpSpace.lean
@@ -665,7 +665,7 @@ theorem norm_const_smul_le (hp : p ≠ 0) (c : 𝕜) (f : lp E p) : ‖c • f�
     · simp [lp.eq_zero' f]
     have hcf := lp.isLUB_norm (c • f)
     have hfc := (lp.isLUB_norm f).mul_left (norm_nonneg c)
-    simp_rw [← Set.range_comp, Function.comp] at hfc
+    simp_rw [← Set.range_comp, Function.comp_def] at hfc
     -- TODO: some `IsLUB` API should make it a one-liner from here.
     refine' hcf.right _
     have := hfc.left

--- a/Mathlib/Analysis/ODE/PicardLindelof.lean
+++ b/Mathlib/Analysis/ODE/PicardLindelof.lean
@@ -365,8 +365,8 @@ theorem exists_solution :
       HasDerivWithinAt f (v t (f t)) (Icc v.tMin v.tMax) t := by
   rcases v.exists_fixed with ⟨f, hf⟩
   refine' ⟨f ∘ v.proj, _, fun t ht => _⟩
-  · simp only [(· ∘ ·), proj_coe, f.map_t₀]
-  · simp only [(· ∘ ·), v.proj_of_mem ht]
+  · simp only [Function.comp_def, proj_coe, f.map_t₀]
+  · simp only [Function.comp_def, v.proj_of_mem ht]
     lift t to Icc v.tMin v.tMax using ht
     simpa only [hf, v.proj_coe] using f.hasDerivWithinAt_next t
 #align picard_lindelof.exists_solution PicardLindelof.exists_solution

--- a/Mathlib/Analysis/ODE/PicardLindelof.lean
+++ b/Mathlib/Analysis/ODE/PicardLindelof.lean
@@ -281,7 +281,7 @@ theorem next_apply (t : Icc v.tMin v.tMax) : f.next t = v.x₀ + ∫ τ : ℝ in
 theorem hasDerivWithinAt_next (t : Icc v.tMin v.tMax) :
     HasDerivWithinAt (f.next ∘ v.proj) (v t (f t)) (Icc v.tMin v.tMax) t := by
   haveI : Fact ((t : ℝ) ∈ Icc v.tMin v.tMax) := ⟨t.2⟩
-  simp only [(· ∘ ·), next_apply]
+  simp only [Function.comp_def, next_apply]
   refine' HasDerivWithinAt.const_add _ _
   have : HasDerivWithinAt (∫ τ in v.t₀..·, f.vComp τ) (f.vComp t) (Icc v.tMin v.tMax) t :=
     integral_hasDerivWithinAt_right (f.intervalIntegrable_vComp _ _)

--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -423,7 +423,7 @@ namespace Complex
 theorem comap_exp_comap_abs_atTop : comap exp (comap abs atTop) = comap re atTop :=
   calc
     comap exp (comap abs atTop) = comap re (comap Real.exp atTop) := by
-      simp only [comap_comap, (· ∘ ·), abs_exp]
+      simp only [comap_comap, Function.comp_def, abs_exp]
     _ = comap re atTop := by rw [Real.comap_exp_atTop]
 
 #align complex.comap_exp_comap_abs_at_top Complex.comap_exp_comap_abs_atTop
@@ -431,7 +431,7 @@ theorem comap_exp_comap_abs_atTop : comap exp (comap abs atTop) = comap re atTop
 theorem comap_exp_nhds_zero : comap exp (𝓝 0) = comap re atBot :=
   calc
     comap exp (𝓝 0) = comap re (comap Real.exp (𝓝 0)) := by
-      simp only [comap_comap, ← comap_abs_nhds_zero, (· ∘ ·), abs_exp]
+      simp only [comap_comap, ← comap_abs_nhds_zero, Function.comp_def, abs_exp]
     _ = comap re atBot := by rw [Real.comap_exp_nhds_zero]
 
 #align complex.comap_exp_nhds_zero Complex.comap_exp_nhds_zero

--- a/Mathlib/Analysis/SpecialFunctions/Gaussian.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian.lean
@@ -133,7 +133,7 @@ theorem integrable_rpow_mul_exp_neg_mul_sq {b : ℝ} (hb : 0 < b) {s : ℝ} (hs 
   refine' ⟨_, integrableOn_rpow_mul_exp_neg_mul_sq hb hs⟩
   rw [← (Measure.measurePreserving_neg (volume : Measure ℝ)).integrableOn_comp_preimage
       (Homeomorph.neg ℝ).measurableEmbedding]
-  simp only [Function.comp, neg_sq, neg_preimage, preimage_neg_Iio, neg_neg, neg_zero]
+  simp only [Function.comp_def, neg_sq, neg_preimage, preimage_neg_Iio, neg_neg, neg_zero]
   apply Integrable.mono' (integrableOn_rpow_mul_exp_neg_mul_sq hb hs)
   · apply Measurable.aestronglyMeasurable
     exact (measurable_id'.neg.pow measurable_const).mul
@@ -656,7 +656,7 @@ theorem Complex.tsum_exp_neg_mul_int_sq {a : ℂ} (ha : 0 < a.re) :
       ((1 : ℂ) / a ^ (1 / 2 : ℂ)) using 2
     congr 1
     ring_nf
-  simpa only [fourier_transform_gaussian_pi ha, tsum_mul_left, Function.comp] using
+  simpa only [fourier_transform_gaussian_pi ha, tsum_mul_left, Function.comp_def] using
     Real.tsum_eq_tsum_fourierIntegral_of_rpow_decay
       (Complex.continuous_exp.comp (continuous_const.mul (continuous_ofReal.pow 2)) : Continuous f)
       one_lt_two f_bd Ff_bd

--- a/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
@@ -299,7 +299,7 @@ theorem hasSum_log_sub_log_of_abs_lt_1 {x : ℝ} (h : |x| < 1) :
   have h_term_eq_goal :
       term ∘ (· * ·) 2 = fun k : ℕ => 2 * (1 / (2 * k + 1)) * x ^ (2 * k + 1) := by
     ext n
-    dsimp only [(· ∘ ·)]
+    dsimp only [Function.comp_def]
     rw [Odd.neg_pow (⟨n, rfl⟩ : Odd (2 * n + 1)) x]
     push_cast
     ring_nf

--- a/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
@@ -213,7 +213,7 @@ theorem tendsto_mul_log_one_plus_div_atTop (t : ℝ) :
       (((hasDerivAt_id (0 : ℝ)).const_mul t).const_add 1).log (by simp)
   have h₂ : Tendsto (fun x : ℝ => x⁻¹) atTop (𝓝[≠] 0) :=
     tendsto_inv_atTop_zero'.mono_right (nhdsWithin_mono _ fun x hx => (Set.mem_Ioi.mp hx).ne')
-  simpa only [(· ∘ ·), inv_inv] using h₁.comp h₂
+  simpa only [Function.comp_def, inv_inv] using h₁.comp h₂
 #align real.tendsto_mul_log_one_plus_div_at_top Real.tendsto_mul_log_one_plus_div_atTop
 
 open scoped BigOperators

--- a/Mathlib/Analysis/SpecialFunctions/Sqrt.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Sqrt.lean
@@ -80,18 +80,18 @@ variable {f : ℝ → ℝ} {s : Set ℝ} {f' x : ℝ}
 
 theorem HasDerivWithinAt.sqrt (hf : HasDerivWithinAt f f' s x) (hx : f x ≠ 0) :
     HasDerivWithinAt (fun y => sqrt (f y)) (f' / (2 * sqrt (f x))) s x := by
-  simpa only [(· ∘ ·), div_eq_inv_mul, mul_one] using
+  simpa only [Function.comp_def, div_eq_inv_mul, mul_one] using
     (hasDerivAt_sqrt hx).comp_hasDerivWithinAt x hf
 #align has_deriv_within_at.sqrt HasDerivWithinAt.sqrt
 
 theorem HasDerivAt.sqrt (hf : HasDerivAt f f' x) (hx : f x ≠ 0) :
     HasDerivAt (fun y => sqrt (f y)) (f' / (2 * sqrt (f x))) x := by
-  simpa only [(· ∘ ·), div_eq_inv_mul, mul_one] using (hasDerivAt_sqrt hx).comp x hf
+  simpa only [Function.comp_def, div_eq_inv_mul, mul_one] using (hasDerivAt_sqrt hx).comp x hf
 #align has_deriv_at.sqrt HasDerivAt.sqrt
 
 theorem HasStrictDerivAt.sqrt (hf : HasStrictDerivAt f f' x) (hx : f x ≠ 0) :
     HasStrictDerivAt (fun t => sqrt (f t)) (f' / (2 * sqrt (f x))) x := by
-  simpa only [(· ∘ ·), div_eq_inv_mul, mul_one] using (hasStrictDerivAt_sqrt hx).comp x hf
+  simpa only [Function.comp_def, div_eq_inv_mul, mul_one] using (hasStrictDerivAt_sqrt hx).comp x hf
 #align has_strict_deriv_at.sqrt HasStrictDerivAt.sqrt
 
 theorem derivWithin_sqrt (hf : DifferentiableWithinAt ℝ f s x) (hx : f x ≠ 0)

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/InverseDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/InverseDeriv.lean
@@ -95,7 +95,7 @@ theorem differentiableWithinAt_arcsin_Iic {x : ℝ} :
   refine' ⟨fun h => _, fun h => (hasDerivWithinAt_arcsin_Iic h).differentiableWithinAt⟩
   rw [← neg_neg x, ← image_neg_Ici] at h
   have := (h.comp (-x) differentiableWithinAt_id.neg (mapsTo_image _ _)).neg
-  simpa [(· ∘ ·), differentiableWithinAt_arcsin_Ici] using this
+  simpa [Function.comp_def, differentiableWithinAt_arcsin_Ici] using this
 #align real.differentiable_within_at_arcsin_Iic Real.differentiableWithinAt_arcsin_Iic
 
 theorem differentiableAt_arcsin {x : ℝ} : DifferentiableAt ℝ arcsin x ↔ x ≠ -1 ∧ x ≠ 1 :=

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Series.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Series.lean
@@ -34,7 +34,7 @@ theorem Complex.hasSum_cos' (z : ℂ) :
   have := ((expSeries_div_hasSum_exp ℂ (z * Complex.I)).add
     (expSeries_div_hasSum_exp ℂ (-z * Complex.I))).div_const 2
   replace := (Nat.divModEquiv 2).symm.hasSum_iff.mpr this
-  dsimp [Function.comp] at this
+  dsimp [Function.comp_def] at this
   simp_rw [← mul_comm 2 _] at this
   refine' this.prod_fiberwise fun k => _
   dsimp only
@@ -52,7 +52,7 @@ theorem Complex.hasSum_sin' (z : ℂ) :
   have := (((expSeries_div_hasSum_exp ℂ (-z * Complex.I)).sub
     (expSeries_div_hasSum_exp ℂ (z * Complex.I))).mul_right Complex.I).div_const 2
   replace := (Nat.divModEquiv 2).symm.hasSum_iff.mpr this
-  dsimp [Function.comp] at this
+  dsimp [Function.comp_def] at this
   simp_rw [← mul_comm 2 _] at this
   refine' this.prod_fiberwise fun k => _
   dsimp only

--- a/Mathlib/Analysis/Subadditive.lean
+++ b/Mathlib/Analysis/Subadditive.lean
@@ -71,13 +71,13 @@ theorem eventually_div_lt_of_div_lt {L : ℝ} {n : ℕ} (hn : n ≠ 0) (hL : u n
   have B : Tendsto (fun x => (x * u n + u r) / (x * n + r)) atTop (𝓝 (u n / n)) := by
     rw [add_zero, add_zero] at A
     refine A.congr' <| (eventually_ne_atTop 0).mono fun x hx => ?_
-    simp only [(· ∘ ·), add_div' _ _ _ hx, div_div_div_cancel_right _ hx, mul_comm]
+    simp only [Function.comp_def, add_div' _ _ _ hx, div_div_div_cancel_right _ hx, mul_comm]
   refine ((B.comp tendsto_nat_cast_atTop_atTop).eventually (gt_mem_nhds hL)).mono fun k hk => ?_
   /- Finally, we use an upper estimate on `u (k * n + r)` to get an estimate on
   `u (k * n + r) / (k * n + r)`. -/
   rw [mul_comm]
   refine lt_of_le_of_lt ?_ hk
-  simp only [(· ∘ ·), ← Nat.cast_add, ← Nat.cast_mul]
+  simp only [Function.comp_def, ← Nat.cast_add, ← Nat.cast_mul]
   exact div_le_div_of_le (Nat.cast_nonneg _) (h.apply_mul_add_le _ _ _)
 #align subadditive.eventually_div_lt_of_div_lt Subadditive.eventually_div_lt_of_div_lt
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Biproducts.lean
@@ -419,7 +419,7 @@ theorem biproduct.map_lift_mapBiprod (g : ∀ j, W ⟶ f j) :
     haveI : HasBiproduct fun j => F.obj (f j) := hasBiproduct_of_preserves F f
     F.map (biproduct.lift g) ≫ (F.mapBiproduct f).hom = biproduct.lift fun j => F.map (g j) := by
   ext j
-  dsimp only [Function.comp]
+  dsimp only [Function.comp_def]
   haveI : HasBiproduct fun j => F.obj (f j) := hasBiproduct_of_preserves F f
   simp only [mapBiproduct_hom, Category.assoc, biproduct.lift_π, ← F.map_comp]
 #align category_theory.limits.biproduct.map_lift_map_biprod CategoryTheory.Limits.biproduct.map_lift_mapBiprod

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -411,7 +411,7 @@ theorem hasBiproductsOfShape_of_equiv {K : Type w'} [HasBiproductsOfShape K C] (
     let ⟨⟨h⟩⟩ := HasBiproductsOfShape.has_biproduct (F ∘ e.symm)
     let ⟨c, hc⟩ := h
     HasBiproduct.mk <| by
-      simpa only [(· ∘ ·), e.symm_apply_apply] using
+      simpa only [Function.comp_def, e.symm_apply_apply] using
         LimitBicone.mk (c.whisker e) ((c.whiskerIsBilimitIff _).2 hc)⟩
 #align category_theory.limits.has_biproducts_of_shape_of_equiv CategoryTheory.Limits.hasBiproductsOfShape_of_equiv
 

--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -270,7 +270,7 @@ theorem exists_code.comp {m n} {f : Vector ℕ n →. ℕ} {g : Fin n → Vector
   · obtain ⟨cf, hf⟩ := hf
     exact
       ⟨cf.comp cg, fun v => by
-        simp [hg, hf, map_bind, seq_bind_eq, Function.comp]
+        simp [hg, hf, map_bind, seq_bind_eq, Function.comp_def]
         rfl⟩
   clear hf f; induction' n with n IH
   · exact ⟨nil, fun v => by simp [Vector.mOfFn, Bind.bind]; rfl⟩

--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -278,7 +278,7 @@ theorem exists_code.comp {m n} {f : Vector ℕ n →. ℕ} {g : Fin n → Vector
     obtain ⟨cl, hl⟩ := IH fun i => hg i.succ
     exact
       ⟨cons cg cl, fun v => by
-        simp [Vector.mOfFn, hg₁, map_bind, seq_bind_eq, bind_assoc, (· ∘ ·), hl]
+        simp [Vector.mOfFn, hg₁, map_bind, seq_bind_eq, bind_assoc, Function.comp_def, hl]
         rfl⟩
 #align turing.to_partrec.code.exists_code.comp Turing.ToPartrec.Code.exists_code.comp
 

--- a/Mathlib/Control/Applicative.lean
+++ b/Mathlib/Control/Applicative.lean
@@ -95,12 +95,14 @@ theorem map_pure (f : α → β) (x : α) : (f <$> pure x : Comp F G β) = pure 
 #align functor.comp.map_pure Functor.Comp.map_pure
 
 theorem seq_pure (f : Comp F G (α → β)) (x : α) : f <*> pure x = (fun g : α → β => g x) <$> f :=
-  Comp.ext <| by simp [(· ∘ ·), functor_norm]
+  Comp.ext <| by
+    simp [Function.comp_def, functor_norm]
 #align functor.comp.seq_pure Functor.Comp.seq_pure
 
 theorem seq_assoc (x : Comp F G α) (f : Comp F G (α → β)) (g : Comp F G (β → γ)) :
     g <*> (f <*> x) = @Function.comp α β γ <$> g <*> f <*> x :=
-  Comp.ext <| by simp [(· ∘ ·), functor_norm]
+  Comp.ext <| by
+    simp [Function.comp_def, functor_norm]
 #align functor.comp.seq_assoc Functor.Comp.seq_assoc
 
 theorem pure_seq_eq_map (f : α → β) (x : Comp F G α) : pure f <*> x = f <$> x :=
@@ -138,7 +140,7 @@ instance {f : Type u → Type w} {g : Type v → Type u} [Applicative f] [Applic
   intros
   simp! [map, Seq.seq, functor_norm]
   rw [commutative_map]
-  simp only [mk, flip, seq_map_assoc, Function.comp, map_map]
+  simp only [mk, flip, seq_map_assoc, Function.comp_def, map_map]
   congr
   funext x y
   rw [commutative_map]

--- a/Mathlib/Control/Basic.lean
+++ b/Mathlib/Control/Basic.lean
@@ -151,7 +151,8 @@ theorem joinM_map_joinM {α : Type u} (a : m (m (m α))) : joinM (joinM <$> a) =
 
 @[simp]
 theorem joinM_map_pure {α : Type u} (a : m α) : joinM (pure <$> a) = a := by
-  simp only [joinM, Function.comp_def, id.def, map_bind, ← bind_pure_comp, bind_assoc, pure_bind, bind_pure]
+  simp only [joinM, Function.comp_def, id.def, map_bind, ← bind_pure_comp, bind_assoc, pure_bind,
+    bind_pure]
 #align mjoin_map_pure joinM_map_pure
 
 @[simp]

--- a/Mathlib/Control/Basic.lean
+++ b/Mathlib/Control/Basic.lean
@@ -89,7 +89,7 @@ theorem map_bind (x : m α) {g : α → m β} {f : β → γ} :
 theorem seq_bind_eq (x : m α) {g : β → m γ} {f : α → β} :
     f <$> x >>= g = x >>= g ∘ f :=
   show bind (f <$> x) g = bind x (g ∘ f)
-  by rw [← bind_pure_comp, bind_assoc]; simp [pure_bind, (· ∘ ·)]
+  by rw [← bind_pure_comp, bind_assoc]; simp [pure_bind, Function.comp_def]
 #align seq_bind_eq seq_bind_eq
 
 #align seq_eq_bind_map seq_eq_bind_mapₓ
@@ -142,16 +142,16 @@ variable {m : Type u → Type u} [Monad m] [LawfulMonad m]
 
 theorem joinM_map_map {α β : Type u} (f : α → β) (a : m (m α)) :
     joinM (Functor.map f <$> a) = f <$> joinM a := by
-  simp only [joinM, (· ∘ ·), id.def, ← bind_pure_comp, bind_assoc, map_bind, pure_bind]
+  simp only [joinM, Function.comp_def, id.def, ← bind_pure_comp, bind_assoc, map_bind, pure_bind]
 #align mjoin_map_map joinM_map_map
 
 theorem joinM_map_joinM {α : Type u} (a : m (m (m α))) : joinM (joinM <$> a) = joinM (joinM a) := by
-  simp only [joinM, (· ∘ ·), id.def, map_bind, ← bind_pure_comp, bind_assoc, pure_bind]
+  simp only [joinM, Function.comp_def, id.def, map_bind, ← bind_pure_comp, bind_assoc, pure_bind]
 #align mjoin_map_mjoin joinM_map_joinM
 
 @[simp]
 theorem joinM_map_pure {α : Type u} (a : m α) : joinM (pure <$> a) = a := by
-  simp only [joinM, (· ∘ ·), id.def, map_bind, ← bind_pure_comp, bind_assoc, pure_bind, bind_pure]
+  simp only [joinM, Function.comp_def, id.def, map_bind, ← bind_pure_comp, bind_assoc, pure_bind, bind_pure]
 #align mjoin_map_pure joinM_map_pure
 
 @[simp]

--- a/Mathlib/Control/Basic.lean
+++ b/Mathlib/Control/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.Init.Control.Combinators
+import Mathlib.Init.Function
 import Mathlib.Tactic.CasesM
 import Mathlib.Tactic.Attr.Core
 import Std.Data.List.Basic
@@ -60,7 +61,7 @@ theorem pure_id'_seq (x : F α) : (pure fun x => x) <*> x = x :=
 theorem seq_map_assoc (x : F (α → β)) (f : γ → α) (y : F γ) :
     x <*> f <$> y = (· ∘ f) <$> x <*> y := by
   simp only [← pure_seq]
-  simp only [seq_assoc, Function.comp, seq_pure, ← comp_map]
+  simp only [seq_assoc, Function.comp_def, seq_pure, ← comp_map]
   simp [pure_seq]
 #align seq_map_assoc seq_map_assoc
 
@@ -254,5 +255,5 @@ theorem CommApplicative.commutative_map {m : Type u → Type v} [h : Applicative
       simp [seq_map_assoc, map_seq, seq_assoc, seq_pure, map_map]; rfl
     _ = (fun b a => f a b) <$> b <*> a := by
       rw [@CommApplicative.commutative_prod m h]
-      simp [seq_map_assoc, map_seq, seq_assoc, seq_pure, map_map, (· ∘ ·)]
+      simp [seq_map_assoc, map_seq, seq_assoc, seq_pure, map_map, Function.comp_def]
 #align is_comm_applicative.commutative_map CommApplicative.commutative_map

--- a/Mathlib/Control/Bitraversable/Instances.lean
+++ b/Mathlib/Control/Bitraversable/Instances.lean
@@ -104,7 +104,8 @@ instance (priority := 10) Bitraversable.isLawfulTraversable [LawfulBitraversable
   constructor <;> intros <;>
     simp [traverse, comp_tsnd, functor_norm, -ApplicativeTransformation.app_eq_coe]
   · simp [tsnd_eq_snd_id]; rfl
-  · simp [tsnd, binaturality, Function.comp, functor_norm, -ApplicativeTransformation.app_eq_coe]
+  · simp [tsnd, binaturality, Function.comp_def, functor_norm,
+      -ApplicativeTransformation.app_eq_coe]
 #align bitraversable.is_lawful_traversable Bitraversable.isLawfulTraversable
 
 end

--- a/Mathlib/Control/Bitraversable/Lemmas.lean
+++ b/Mathlib/Control/Bitraversable/Lemmas.lean
@@ -75,7 +75,7 @@ theorem id_tsnd : ∀ {α β} (x : t α β), tsnd (F := Id) pure x = pure x :=
 theorem comp_tfst {α₀ α₁ α₂ β} (f : α₀ → F α₁) (f' : α₁ → G α₂) (x : t α₀ β) :
     Comp.mk (tfst f' <$> tfst f x) = tfst (Comp.mk ∘ map f' ∘ f) x := by
   rw [← comp_bitraverse]
-  simp only [Function.comp, tfst, map_pure, Pure.pure]
+  simp only [Function.comp_def, tfst, map_pure, Pure.pure]
 #align bitraversable.comp_tfst Bitraversable.comp_tfst
 
 @[higher_order tfst_comp_tsnd]
@@ -83,7 +83,7 @@ theorem tfst_tsnd {α₀ α₁ β₀ β₁} (f : α₀ → F α₁) (f' : β₀ 
     Comp.mk (tfst f <$> tsnd f' x)
       = bitraverse (Comp.mk ∘ pure ∘ f) (Comp.mk ∘ map pure ∘ f') x := by
   rw [← comp_bitraverse]
-  simp only [Function.comp, map_pure]
+  simp only [Function.comp_def, map_pure]
 #align bitraversable.tfst_tsnd Bitraversable.tfst_tsnd
 
 @[higher_order tsnd_comp_tfst]
@@ -91,14 +91,14 @@ theorem tsnd_tfst {α₀ α₁ β₀ β₁} (f : α₀ → F α₁) (f' : β₀ 
     Comp.mk (tsnd f' <$> tfst f x)
       = bitraverse (Comp.mk ∘ map pure ∘ f) (Comp.mk ∘ pure ∘ f') x := by
   rw [← comp_bitraverse]
-  simp only [Function.comp, map_pure]
+  simp only [Function.comp_def, map_pure]
 #align bitraversable.tsnd_tfst Bitraversable.tsnd_tfst
 
 @[higher_order tsnd_comp_tsnd]
 theorem comp_tsnd {α β₀ β₁ β₂} (g : β₀ → F β₁) (g' : β₁ → G β₂) (x : t α β₀) :
     Comp.mk (tsnd g' <$> tsnd g x) = tsnd (Comp.mk ∘ map g' ∘ g) x := by
   rw [← comp_bitraverse]
-  simp only [Function.comp, map_pure]
+  simp only [Function.comp_def, map_pure]
   rfl
 #align bitraversable.comp_tsnd Bitraversable.comp_tsnd
 

--- a/Mathlib/Control/Fold.lean
+++ b/Mathlib/Control/Fold.lean
@@ -318,7 +318,7 @@ theorem foldr.ofFreeMonoid_comp_of (f : β → α → α) :
 theorem foldlm.ofFreeMonoid_comp_of {m} [Monad m] [LawfulMonad m] (f : α → β → m α) :
     foldlM.ofFreeMonoid f ∘ FreeMonoid.of = foldlM.mk ∘ flip f := by
   ext1 x
-  simp [Function.comp_def, foldlM.ofFreeMonoid, foldlM.mk, Function.flip_def]
+  simp [Function.comp_def, foldlM.ofFreeMonoid, foldlM.mk, flip]
   rfl
 #align traversable.mfoldl.of_free_monoid_comp_of Traversable.foldlm.ofFreeMonoid_comp_of
 
@@ -326,7 +326,7 @@ theorem foldlm.ofFreeMonoid_comp_of {m} [Monad m] [LawfulMonad m] (f : α → β
 theorem foldrm.ofFreeMonoid_comp_of {m} [Monad m] [LawfulMonad m] (f : β → α → m α) :
     foldrM.ofFreeMonoid f ∘ FreeMonoid.of = foldrM.mk ∘ f := by
   ext
-  simp [Function.comp_def, foldrM.ofFreeMonoid, foldrM.mk, Function.flip_def]
+  simp [Function.comp_def, foldrM.ofFreeMonoid, foldrM.mk, flip]
 #align traversable.mfoldr.of_free_monoid_comp_of Traversable.foldrm.ofFreeMonoid_comp_of
 
 theorem toList_spec (xs : t α) : toList xs = FreeMonoid.toList (foldMap FreeMonoid.of xs) :=
@@ -372,13 +372,13 @@ theorem toList_map (f : α → β) (xs : t α) : toList (f <$> xs) = f <$> toLis
 @[simp]
 theorem foldl_map (g : β → γ) (f : α → γ → α) (a : α) (l : t β) :
     foldl f a (g <$> l) = foldl (fun x y => f x (g y)) a l := by
-  simp only [foldl, foldMap_map, Function.comp_def, Function.flip_def]
+  simp only [foldl, foldMap_map, Function.comp_def, flip]
 #align traversable.foldl_map Traversable.foldl_map
 
 @[simp]
 theorem foldr_map (g : β → γ) (f : γ → α → α) (a : α) (l : t β) :
     foldr f a (g <$> l) = foldr (f ∘ g) a l := by
-  simp only [foldr, foldMap_map, Function.comp_def, Function.flip_def]
+  simp only [foldr, foldMap_map, Function.comp_def, flip]
 #align traversable.foldr_map Traversable.foldr_map
 
 @[simp]
@@ -421,13 +421,13 @@ theorem foldrm_toList (f : α → β → m β) (x : β) (xs : t α) :
 @[simp]
 theorem foldlm_map (g : β → γ) (f : α → γ → m α) (a : α) (l : t β) :
     foldlm f a (g <$> l) = foldlm (fun x y => f x (g y)) a l := by
-  simp only [foldlm, foldMap_map, Function.comp_def, Function.flip_def]
+  simp only [foldlm, foldMap_map, Function.comp_def, flip]
 #align traversable.mfoldl_map Traversable.foldlm_map
 
 @[simp]
 theorem foldrm_map (g : β → γ) (f : γ → α → m α) (a : α) (l : t β) :
     foldrm f a (g <$> l) = foldrm (f ∘ g) a l := by
-  simp only [foldrm, foldMap_map, Function.comp_def, Function.flip_def]
+  simp only [foldrm, foldMap_map, Function.comp_def, flip]
 #align traversable.mfoldr_map Traversable.foldrm_map
 
 end Equalities

--- a/Mathlib/Control/Fold.lean
+++ b/Mathlib/Control/Fold.lean
@@ -318,7 +318,7 @@ theorem foldr.ofFreeMonoid_comp_of (f : β → α → α) :
 theorem foldlm.ofFreeMonoid_comp_of {m} [Monad m] [LawfulMonad m] (f : α → β → m α) :
     foldlM.ofFreeMonoid f ∘ FreeMonoid.of = foldlM.mk ∘ flip f := by
   ext1 x
-  simp [(· ∘ ·), foldlM.ofFreeMonoid, foldlM.mk, flip]
+  simp [Function.comp_def, foldlM.ofFreeMonoid, foldlM.mk, Function.flip_def]
   rfl
 #align traversable.mfoldl.of_free_monoid_comp_of Traversable.foldlm.ofFreeMonoid_comp_of
 
@@ -326,7 +326,7 @@ theorem foldlm.ofFreeMonoid_comp_of {m} [Monad m] [LawfulMonad m] (f : α → β
 theorem foldrm.ofFreeMonoid_comp_of {m} [Monad m] [LawfulMonad m] (f : β → α → m α) :
     foldrM.ofFreeMonoid f ∘ FreeMonoid.of = foldrM.mk ∘ f := by
   ext
-  simp [(· ∘ ·), foldrM.ofFreeMonoid, foldrM.mk, flip]
+  simp [Function.comp_def, foldrM.ofFreeMonoid, foldrM.mk, Function.flip_def]
 #align traversable.mfoldr.of_free_monoid_comp_of Traversable.foldrm.ofFreeMonoid_comp_of
 
 theorem toList_spec (xs : t α) : toList xs = FreeMonoid.toList (foldMap FreeMonoid.of xs) :=
@@ -346,7 +346,8 @@ theorem toList_spec (xs : t α) : toList xs = FreeMonoid.toList (foldMap FreeMon
 #align traversable.to_list_spec Traversable.toList_spec
 
 theorem foldMap_map [Monoid γ] (f : α → β) (g : β → γ) (xs : t α) :
-    foldMap g (f <$> xs) = foldMap (g ∘ f) xs := by simp only [foldMap, traverse_map, Function.comp]
+    foldMap g (f <$> xs) = foldMap (g ∘ f) xs := by
+  simp only [foldMap, traverse_map, Function.comp_def]
 #align traversable.fold_map_map Traversable.foldMap_map
 
 theorem foldl_toList (f : α → β → α) (xs : t β) (x : α) :
@@ -365,18 +366,19 @@ theorem foldr_toList (f : α → β → β) (xs : t α) (x : β) :
 
 theorem toList_map (f : α → β) (xs : t α) : toList (f <$> xs) = f <$> toList xs := by
   simp only [toList_spec, Free.map_eq_map, foldMap_hom, foldMap_map, FreeMonoid.ofList_toList,
-    FreeMonoid.map_of, (· ∘ ·)]
+    FreeMonoid.map_of, Function.comp_def]
 #align traversable.to_list_map Traversable.toList_map
 
 @[simp]
 theorem foldl_map (g : β → γ) (f : α → γ → α) (a : α) (l : t β) :
     foldl f a (g <$> l) = foldl (fun x y => f x (g y)) a l := by
-  simp only [foldl, foldMap_map, (· ∘ ·), flip]
+  simp only [foldl, foldMap_map, Function.comp_def, Function.flip_def]
 #align traversable.foldl_map Traversable.foldl_map
 
 @[simp]
 theorem foldr_map (g : β → γ) (f : γ → α → α) (a : α) (l : t β) :
-    foldr f a (g <$> l) = foldr (f ∘ g) a l := by simp only [foldr, foldMap_map, (· ∘ ·), flip]
+    foldr f a (g <$> l) = foldr (f ∘ g) a l := by
+  simp only [foldr, foldMap_map, Function.comp_def, Function.flip_def]
 #align traversable.foldr_map Traversable.foldr_map
 
 @[simp]
@@ -419,12 +421,13 @@ theorem foldrm_toList (f : α → β → m β) (x : β) (xs : t α) :
 @[simp]
 theorem foldlm_map (g : β → γ) (f : α → γ → m α) (a : α) (l : t β) :
     foldlm f a (g <$> l) = foldlm (fun x y => f x (g y)) a l := by
-  simp only [foldlm, foldMap_map, (· ∘ ·), flip]
+  simp only [foldlm, foldMap_map, Function.comp_def, Function.flip_def]
 #align traversable.mfoldl_map Traversable.foldlm_map
 
 @[simp]
 theorem foldrm_map (g : β → γ) (f : γ → α → m α) (a : α) (l : t β) :
-    foldrm f a (g <$> l) = foldrm (f ∘ g) a l := by simp only [foldrm, foldMap_map, (· ∘ ·), flip]
+    foldrm f a (g <$> l) = foldrm (f ∘ g) a l := by
+  simp only [foldrm, foldMap_map, Function.comp_def, Function.flip_def]
 #align traversable.mfoldr_map Traversable.foldrm_map
 
 end Equalities

--- a/Mathlib/Control/Monad/Cont.lean
+++ b/Mathlib/Control/Monad/Cont.lean
@@ -102,7 +102,7 @@ instance [Monad m] : MonadLift m (ContT r m) where
 theorem monadLift_bind [Monad m] [LawfulMonad m] {α β} (x : m α) (f : α → m β) :
     (monadLift (x >>= f) : ContT r m β) = monadLift x >>= monadLift ∘ f := by
   ext
-  simp only [monadLift, MonadLift.monadLift, (· ∘ ·), (· >>= ·), bind_assoc, id.def, run,
+  simp only [monadLift, MonadLift.monadLift, Function.comp_def, (· >>= ·), bind_assoc, id.def, run,
     ContT.monadLift]
 #align cont_t.monad_lift_bind ContT.monadLift_bind
 

--- a/Mathlib/Data/Fin/Tuple/Curry.lean
+++ b/Mathlib/Data/Fin/Tuple/Curry.lean
@@ -46,7 +46,7 @@ theorem curry_uncurry {n} (f : Function.OfArity α β n) :
   match n with
   | 0 => rfl
   | n + 1 => funext fun a => by
-    dsimp [curry, uncurry, Function.comp]
+    dsimp only [curry, uncurry, Function.comp_def]
     simp only [Fin.cons_zero, Fin.cons_succ]
     rw [curry_uncurry]
 
@@ -57,7 +57,7 @@ theorem uncurry_curry {n} (f : (Fin n → α) → β) :
   induction args using Fin.consInduction with
   | h0 => rfl
   | h a as ih =>
-    dsimp [curry, uncurry, Function.comp]
+    dsimp [curry, uncurry, Function.comp_def]
     simp only [Fin.cons_zero, Fin.cons_succ, ih (f <| Fin.cons a ·)]
 
 /-- `Equiv.curry` for n-ary functions. -/

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -190,7 +190,7 @@ theorem filter_map {p : β → Prop} [DecidablePred p] :
 lemma map_filter' (p : α → Prop) [DecidablePred p] (f : α ↪ β) (s : Finset α)
     [DecidablePred (∃ a, p a ∧ f a = ·)] :
     (s.filter p).map f = (s.map f).filter fun b => ∃ a, p a ∧ f a = b := by
-  simp [(· ∘ ·), filter_map, f.injective.eq_iff]
+  simp [Function.comp_def, filter_map, f.injective.eq_iff]
 #align finset.map_filter' Finset.map_filter'
 
 lemma filter_attach' [DecidableEq α] (s : Finset α) (p : s → Prop) [DecidablePred p] :

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -208,7 +208,7 @@ lemma filter_attach (p : α → Prop) [DecidablePred p] (s : Finset α) :
 
 theorem map_filter {f : α ≃ β} {p : α → Prop} [DecidablePred p] :
     (s.filter p).map f.toEmbedding = (s.map f.toEmbedding).filter (p ∘ f.symm) := by
-  simp only [filter_map, Function.comp, Equiv.toEmbedding_apply, Equiv.symm_apply_apply]
+  simp only [filter_map, Function.comp_def, Equiv.toEmbedding_apply, Equiv.symm_apply_apply]
 #align finset.map_filter Finset.map_filter
 
 @[simp]

--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -584,7 +584,7 @@ theorem inf_sup {κ : ι → Type*} (s : Finset ι) (t : ∀ i, Finset (κ i)) (
   -- porting note: `simpa` doesn't support placeholders in proof terms
   have := h (fun j hj => if hji : j = i then cast (congr_arg κ hji.symm) a
       else g _ <| mem_of_mem_insert_of_ne hj hji) (fun j hj => ?_)
-  simpa only [cast_eq, dif_pos, Function.comp, Subtype.coe_mk, dif_neg, aux] using this
+  · simpa only [cast_eq, dif_pos, Function.comp_def, Subtype.coe_mk, dif_neg, aux] using this
   rw [mem_insert] at hj
   obtain (rfl | hj) := hj
   · simpa

--- a/Mathlib/Data/Finset/NoncommProd.lean
+++ b/Mathlib/Data/Finset/NoncommProd.lean
@@ -51,7 +51,7 @@ def noncommFoldr (s : Multiset α)
 @[simp]
 theorem noncommFoldr_coe (l : List α) (comm) (b : β) :
     noncommFoldr f (l : Multiset α) comm b = l.foldr f b := by
-  simp only [noncommFoldr, coe_foldr, coe_attach, List.attach, Function.comp]
+  simp only [noncommFoldr, coe_foldr, coe_attach, List.attach, Function.comp_def]
   rw [← List.foldr_map]
   simp [List.map_pmap, List.pmap_eq_map]
 #align multiset.noncomm_foldr_coe Multiset.noncommFoldr_coe

--- a/Mathlib/Data/Finset/Pointwise.lean
+++ b/Mathlib/Data/Finset/Pointwise.lean
@@ -1719,7 +1719,7 @@ instance smulCommClass [SMul α γ] [SMul β γ] [SMulCommClass α β γ] :
 @[to_additive vaddAssocClass]
 instance isScalarTower [SMul α β] [SMul α γ] [SMul β γ] [IsScalarTower α β γ] :
     IsScalarTower α β (Finset γ) :=
-  ⟨fun a b s => by simp only [← image_smul, image_image, smul_assoc, Function.comp]⟩
+  ⟨fun a b s => by simp only [← image_smul, image_image, smul_assoc, Function.comp_def]⟩
 #align finset.is_scalar_tower Finset.isScalarTower
 #align finset.vadd_assoc_class Finset.vaddAssocClass
 
@@ -2170,7 +2170,7 @@ variable [Monoid α] [AddGroup β] [DistribMulAction α β] [DecidableEq β] (a 
 
 @[simp]
 theorem smul_finset_neg : a • -t = -(a • t) := by
-  simp only [← image_smul, ← image_neg, Function.comp, image_image, smul_neg]
+  simp only [← image_smul, ← image_neg, Function.comp_def, image_image, smul_neg]
 #align finset.smul_finset_neg Finset.smul_finset_neg
 
 @[simp]
@@ -2188,7 +2188,7 @@ variable [Ring α] [AddCommGroup β] [Module α β] [DecidableEq β] {s : Finset
 
 @[simp]
 theorem neg_smul_finset : -a • t = -(a • t) := by
-  simp only [← image_smul, ← image_neg, image_image, neg_smul, Function.comp]
+  simp only [← image_smul, ← image_neg, image_image, neg_smul, Function.comp_def]
 #align finset.neg_smul_finset Finset.neg_smul_finset
 
 @[simp]

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -97,7 +97,8 @@ theorem not_mem_graph_snd_zero (a : α) (f : α →₀ M) : (a, (0 : M)) ∉ f.g
 
 @[simp]
 theorem image_fst_graph [DecidableEq α] (f : α →₀ M) : f.graph.image Prod.fst = f.support := by
-  classical simp only [graph, map_eq_image, image_image, Embedding.coeFn_mk, (· ∘ ·), image_id']
+  classical
+  simp only [graph, map_eq_image, image_image, Embedding.coeFn_mk, Function.comp_def, image_id']
 #align finsupp.image_fst_graph Finsupp.image_fst_graph
 
 theorem graph_injective (α M) [Zero M] : Injective (@graph α M _) := by

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -704,7 +704,7 @@ theorem comapDomain_apply [Zero M] (f : α → β) (l : β →₀ M) (hf : Set.I
 theorem sum_comapDomain [Zero M] [AddCommMonoid N] (f : α → β) (l : β →₀ M) (g : β → M → N)
     (hf : Set.BijOn f (f ⁻¹' ↑l.support) ↑l.support) :
     (comapDomain f l hf.injOn).sum (g ∘ f) = l.sum g := by
-  simp only [sum, comapDomain_apply, (· ∘ ·), comapDomain]
+  simp only [sum, comapDomain_apply, Function.comp_def, comapDomain]
   exact Finset.sum_preimage_of_bij f _ hf fun x => g x (l x)
 #align finsupp.sum_comap_domain Finsupp.sum_comapDomain
 

--- a/Mathlib/Data/Finsupp/BigOperators.lean
+++ b/Mathlib/Data/Finsupp/BigOperators.lean
@@ -103,7 +103,7 @@ theorem Multiset.support_sum_eq [AddCommMonoid M] (s : Multiset (ι →₀ M))
   suffices : a.Pairwise (_root_.Disjoint on Finsupp.support)
   · convert List.support_sum_eq a this
     · simp only [Multiset.quot_mk_to_coe'', Multiset.coe_sum]
-    · dsimp only [Function.comp]
+    · dsimp only [Function.comp_def]
       simp only [quot_mk_to_coe'', coe_map, sup_coe, ge_iff_le, Finset.le_eq_subset,
         Finset.sup_eq_union, Finset.bot_eq_empty, List.foldr_map]
   · simp only [Multiset.quot_mk_to_coe'', Multiset.coe_map, Multiset.coe_eq_coe] at hl

--- a/Mathlib/Data/Fintype/Fin.lean
+++ b/Mathlib/Data/Fintype/Fin.lean
@@ -86,7 +86,7 @@ theorem card_filter_univ_eq_vector_get_eq_count [DecidableEq α] (a : α) (v : V
     (univ.filter fun i => a = v.get i).card = v.toList.count a := by
   induction' v using Vector.inductionOn with n x xs hxs
   · simp
-  · simp_rw [card_filter_univ_succ', Vector.get_cons_zero, Vector.toList_cons, Function.comp,
+  · simp_rw [card_filter_univ_succ', Vector.get_cons_zero, Vector.toList_cons, Function.comp_def,
       Vector.get_cons_succ, hxs, List.count_cons, add_comm (ite (a = x) 1 0)]
 #align fin.card_filter_univ_eq_vector_nth_eq_count Fin.card_filter_univ_eq_vector_get_eq_count
 

--- a/Mathlib/Data/Fintype/Perm.lean
+++ b/Mathlib/Data/Fintype/Perm.lean
@@ -39,8 +39,8 @@ theorem length_permsOfList : ∀ l : List α, length (permsOfList l) = l.length 
   | [] => rfl
   | a :: l => by
     rw [length_cons, Nat.factorial_succ]
-    simp only [permsOfList, length_append, length_permsOfList, length_bind, comp,
-     length_map, map_const', sum_replicate, smul_eq_mul, succ_mul]
+    simp only [permsOfList, length_append, length_permsOfList, length_bind, comp_def, length_map,
+      map_const', sum_replicate, smul_eq_mul, succ_mul]
     ring
 #align length_perms_of_list length_permsOfList
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -3502,8 +3502,8 @@ lemma filter_attach (l : List α) (p : α → Bool) :
     (l.attach.filter fun x => p x : List {x // x ∈ l}) =
       (l.filter p).attach.map (Subtype.map id fun x => mem_of_mem_filter) :=
   map_injective_iff.2 Subtype.coe_injective <| by
-    simp_rw [map_map, Function.comp_def, Subtype.map, id.def, ←Function.comp_apply (g := Subtype.val),
-      ←map_filter, attach_map_val]
+    simp_rw [map_map, Function.comp_def, Subtype.map, id.def,
+      ←Function.comp_apply (g := Subtype.val), ←map_filter, attach_map_val]
 #align list.filter_attach List.filter_attach
 
 #align list.filter_filter List.filter_filter

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -3486,7 +3486,7 @@ theorem monotone_filter_right (l : List α) ⦃p q : α → Bool⦄
 lemma map_filter' {f : α → β} (hf : Injective f) (l : List α)
     [DecidablePred fun b => ∃ a, p a ∧ f a = b] :
     (l.filter p).map f = (l.map f).filter fun b => ∃ a, p a ∧ f a = b := by
-  simp [(· ∘ ·), map_filter, hf.eq_iff]
+  simp [Function.comp_def, map_filter, hf.eq_iff]
 #align list.map_filter' List.map_filter'
 
 lemma filter_attach' (l : List α) (p : {a // a ∈ l} → Bool) [DecidableEq α] :
@@ -3494,7 +3494,7 @@ lemma filter_attach' (l : List α) (p : {a // a ∈ l} → Bool) [DecidableEq α
       (l.filter fun x => ∃ h, p ⟨x, h⟩).attach.map (Subtype.map id fun x => mem_of_mem_filter) := by
   classical
   refine' map_injective_iff.2 Subtype.coe_injective _
-  simp [(· ∘ ·), map_filter' _ Subtype.coe_injective]
+  simp [Function.comp_def, map_filter' _ Subtype.coe_injective]
 #align list.filter_attach' List.filter_attach'
 
 -- porting note: `Lean.Internal.coeM` forces us to type-ascript `{x // x ∈ l}`
@@ -3502,7 +3502,7 @@ lemma filter_attach (l : List α) (p : α → Bool) :
     (l.attach.filter fun x => p x : List {x // x ∈ l}) =
       (l.filter p).attach.map (Subtype.map id fun x => mem_of_mem_filter) :=
   map_injective_iff.2 Subtype.coe_injective <| by
-    simp_rw [map_map, (· ∘ ·), Subtype.map, id.def, ←Function.comp_apply (g := Subtype.val),
+    simp_rw [map_map, Function.comp_def, Subtype.map, id.def, ←Function.comp_apply (g := Subtype.val),
       ←map_filter, attach_map_val]
 #align list.filter_attach List.filter_attach
 

--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -160,7 +160,7 @@ lemma count_attach (a : {x // x ∈ l}) : l.attach.count a = l.count ↑a :=
 @[simp]
 theorem count_map_of_injective {α β} [DecidableEq α] [DecidableEq β] (l : List α) (f : α → β)
     (hf : Function.Injective f) (x : α) : count (f x) (map f l) = count x l := by
-  simp only [count, countP_map, (· ∘ ·), hf.beq_eq]
+  simp only [count, countP_map, Function.comp_def, hf.beq_eq]
 #align list.count_map_of_injective List.count_map_of_injective
 
 #align list.count_le_count_map List.count_le_count_map

--- a/Mathlib/Data/List/FinRange.lean
+++ b/Mathlib/Data/List/FinRange.lean
@@ -31,7 +31,7 @@ theorem finRange_succ_eq_map (n : ℕ) : finRange n.succ = 0 :: (finRange n).map
   apply map_injective_iff.mpr Fin.val_injective
   rw [map_cons, map_coe_finRange, range_succ_eq_map, Fin.val_zero, ← map_coe_finRange, map_map,
     map_map]
-  simp only [Function.comp, Fin.val_succ]
+  simp only [Function.comp_def, Fin.val_succ]
 #align list.fin_range_succ_eq_map List.finRange_succ_eq_map
 
 theorem finRange_succ (n : ℕ) :

--- a/Mathlib/Data/List/Infix.lean
+++ b/Mathlib/Data/List/Infix.lean
@@ -377,8 +377,8 @@ theorem tails_cons (a : α) (l : List α) : tails (a :: l) = (a :: l) :: l.tails
 @[simp]
 theorem inits_append : ∀ s t : List α, inits (s ++ t) = s.inits ++ t.inits.tail.map fun l => s ++ l
   | [], [] => by simp
-  | [], a :: t => by simp[· ∘ ·]
-  | a :: s, t => by simp [inits_append s t, · ∘ ·]
+  | [], a :: t => by simp [Function.comp_def]
+  | a :: s, t => by simp [inits_append s t, Function.comp_def]
 #align list.inits_append List.inits_append
 
 @[simp]

--- a/Mathlib/Data/List/Permutation.lean
+++ b/Mathlib/Data/List/Permutation.lean
@@ -195,8 +195,8 @@ theorem mem_foldr_permutationsAux2 {t : α} {ts : List α} {r L : List (List α)
 
 theorem length_foldr_permutationsAux2 (t : α) (ts : List α) (r L : List (List α)) :
     length (foldr (fun y r => (permutationsAux2 t ts r y id).2) r L) =
-      sum (map length L) + length r :=
-  by simp [foldr_permutationsAux2, (· ∘ ·), length_permutationsAux2]
+      sum (map length L) + length r := by
+  simp [foldr_permutationsAux2, Function.comp_def, length_permutationsAux2]
 #align list.length_foldr_permutations_aux2 List.length_foldr_permutationsAux2
 
 theorem length_foldr_permutationsAux2' (t : α) (ts : List α) (r L : List (List α)) (n)

--- a/Mathlib/Data/List/Sublists.lean
+++ b/Mathlib/Data/List/Sublists.lean
@@ -161,7 +161,7 @@ theorem sublists_append (l₁ l₂ : List α) :
   · case nil => simp
   · case cons a l₁ ih =>
       rw [foldr_cons, ih]
-      simp [List.bind, join_join, Function.comp]
+      simp [List.bind, join_join, Function.comp_def]
 #align list.sublists_append List.sublists_append
 
 --Portin note: New theorem
@@ -181,7 +181,7 @@ theorem sublists_concat (l : List α) (a : α) :
 theorem sublists_reverse (l : List α) : sublists (reverse l) = map reverse (sublists' l) := by
   induction' l with hd tl ih <;> [rfl;
     simp only [reverse_cons, sublists_append, sublists'_cons, map_append, ih, sublists_singleton,
-      map_eq_map, bind_eq_bind, map_map, cons_bind, append_nil, nil_bind, (· ∘ ·)]]
+      map_eq_map, bind_eq_bind, map_map, cons_bind, append_nil, nil_bind, Function.comp_def]]
 #align list.sublists_reverse List.sublists_reverse
 
 theorem sublists_eq_sublists' (l : List α) : sublists l = map reverse (sublists' (reverse l)) := by
@@ -189,7 +189,7 @@ theorem sublists_eq_sublists' (l : List α) : sublists l = map reverse (sublists
 #align list.sublists_eq_sublists' List.sublists_eq_sublists'
 
 theorem sublists'_reverse (l : List α) : sublists' (reverse l) = map reverse (sublists l) := by
-  simp only [sublists_eq_sublists', map_map, map_id' reverse_reverse, Function.comp]
+  simp only [sublists_eq_sublists', map_map, map_id' reverse_reverse, Function.comp_def]
 #align list.sublists'_reverse List.sublists'_reverse
 
 theorem sublists'_eq_sublists (l : List α) : sublists' l = map reverse (sublists (reverse l)) := by
@@ -408,7 +408,8 @@ theorem sublists_map (f : α → β) : ∀ (l : List α),
 theorem sublists'_map (f : α → β) : ∀ (l : List α),
     sublists' (map f l) = map (map f) (sublists' l)
   | [] => by simp
-  | a::l => by simp [map_cons, sublists'_cons, sublists'_map f l, Function.comp]
+  | a::l => by
+    simp [map_cons, sublists'_cons, sublists'_map f l, Function.comp_def]
 
 --Porting note: moved because it is now used to prove `sublists_cons_perm_append`
 theorem sublists_perm_sublists' (l : List α) : sublists l ~ sublists' l := by

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -837,7 +837,7 @@ theorem dotProduct_comp_equiv_symm (e : n ≃ m) : u ⬝ᵥ x ∘ e.symm = u ∘
 @[simp]
 theorem comp_equiv_dotProduct_comp_equiv (e : m ≃ n) : x ∘ e ⬝ᵥ y ∘ e = x ⬝ᵥ y := by
   -- Porting note: was `simp only` with all three lemmas
-  rw [← dotProduct_comp_equiv_symm]; simp only [Function.comp, Equiv.apply_symm_apply]
+  rw [← dotProduct_comp_equiv_symm]; simp only [Function.comp_def, Equiv.apply_symm_apply]
 #align matrix.comp_equiv_dot_product_comp_equiv Matrix.comp_equiv_dotProduct_comp_equiv
 
 end NonUnitalNonAssocSemiring
@@ -2708,12 +2708,12 @@ theorem map_dotProduct [NonAssocSemiring R] [NonAssocSemiring S] (f : R →+* S)
 
 theorem map_vecMul [NonAssocSemiring R] [NonAssocSemiring S] (f : R →+* S) (M : Matrix n m R)
     (v : n → R) (i : m) : f (M.vecMul v i) = (M.map f).vecMul (f ∘ v) i := by
-  simp only [Matrix.vecMul, Matrix.map_apply, RingHom.map_dotProduct, Function.comp]
+  simp only [Matrix.vecMul, Matrix.map_apply, RingHom.map_dotProduct, Function.comp_def]
 #align ring_hom.map_vec_mul RingHom.map_vecMul
 
 theorem map_mulVec [NonAssocSemiring R] [NonAssocSemiring S] (f : R →+* S) (M : Matrix m n R)
     (v : n → R) (i : m) : f (M.mulVec v i) = (M.map f).mulVec (f ∘ v) i := by
-  simp only [Matrix.mulVec, Matrix.map_apply, RingHom.map_dotProduct, Function.comp]
+  simp only [Matrix.mulVec, Matrix.map_apply, RingHom.map_dotProduct, Function.comp_def]
 #align ring_hom.map_mul_vec RingHom.map_mulVec
 
 end RingHom

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -2115,7 +2115,7 @@ theorem map_filter (f : β → α) (s : Multiset β) : filter p (map f s) = map 
 lemma map_filter' {f : α → β} (hf : Injective f) (s : Multiset α)
     [DecidablePred fun b => ∃ a, p a ∧ f a = b] :
     (s.filter p).map f = (s.map f).filter fun b => ∃ a, p a ∧ f a = b := by
-  simp [(· ∘ ·), map_filter, hf.eq_iff]
+  simp [Function.comp_def, map_filter, hf.eq_iff]
 #align multiset.map_filter' Multiset.map_filter'
 
 /-! ### Simultaneously filter and map elements of a multiset -/

--- a/Mathlib/Data/Multiset/Bind.lean
+++ b/Mathlib/Data/Multiset/Bind.lean
@@ -352,7 +352,7 @@ theorem mem_sigma {s t} : ∀ {p : Σa, σ a}, p ∈ @Multiset.sigma α σ s t �
 
 @[simp]
 theorem card_sigma : card (s.sigma t) = sum (map (fun a => card (t a)) s) := by
-  simp [Multiset.sigma, (· ∘ ·)]
+  simp [Multiset.sigma, Function.comp_def]
 #align multiset.card_sigma Multiset.card_sigma
 
 end Sigma

--- a/Mathlib/Data/Multiset/Functor.lean
+++ b/Mathlib/Data/Multiset/Functor.lean
@@ -56,7 +56,7 @@ def traverse : Multiset α' → F (Multiset β') := by
       congr
       funext a b l
       simpa [flip] using Perm.swap a b l
-    simp [(· ∘ ·), this, functor_norm, Coe.coe]
+    simp [Function.comp_def, this, functor_norm, Coe.coe]
   case trans => simp [*]
 #align multiset.traverse Multiset.traverse
 
@@ -111,7 +111,7 @@ theorem comp_traverse {G H : Type _ → Type _} [Applicative G] [Applicative H] 
   intro
   simp only [traverse, quot_mk_to_coe, lift_coe, Coe.coe, Function.comp_apply, Functor.map_map,
     functor_norm]
-  simp only [Function.comp, lift_coe]
+  simp only [Function.comp_def, lift_coe]
 #align multiset.comp_traverse Multiset.comp_traverse
 
 theorem map_traverse {G : Type* → Type _} [Applicative G] [CommApplicative G] {α β γ : Type _}

--- a/Mathlib/Data/Multiset/Sections.lean
+++ b/Mathlib/Data/Multiset/Sections.lean
@@ -46,7 +46,7 @@ theorem coe_sections :
   | a :: l => by
     simp only [List.map_cons, List.sections]
     rw [← cons_coe, sections_cons, bind_map_comm, coe_sections l]
-    simp [List.sections, (· ∘ ·), List.bind]
+    simp [List.sections, Function.comp_def, List.bind]
 #align multiset.coe_sections Multiset.coe_sections
 
 @[simp]

--- a/Mathlib/Data/MvPolynomial/Basic.lean
+++ b/Mathlib/Data/MvPolynomial/Basic.lean
@@ -1596,7 +1596,7 @@ variable (R)
 theorem _root_.Algebra.adjoin_range_eq_range_aeval :
     Algebra.adjoin R (Set.range f) = (MvPolynomial.aeval f).range := by
   simp only [← Algebra.map_top, ← MvPolynomial.adjoin_range_X, AlgHom.map_adjoin, ← Set.range_comp,
-    (· ∘ ·), MvPolynomial.aeval_X]
+    Function.comp_def, MvPolynomial.aeval_X]
 #align algebra.adjoin_range_eq_range_aeval Algebra.adjoin_range_eq_range_aeval
 
 theorem _root_.Algebra.adjoin_eq_range (s : Set S₁) :

--- a/Mathlib/Data/MvPolynomial/Expand.lean
+++ b/Mathlib/Data/MvPolynomial/Expand.lean
@@ -83,7 +83,7 @@ theorem map_expand (f : R →+* S) (p : ℕ) (φ : MvPolynomial σ R) :
 @[simp]
 theorem rename_expand (f : σ → τ) (p : ℕ) (φ : MvPolynomial σ R) :
     rename f (expand p φ) = expand p (rename f φ) := by
-  simp [expand, bind₁_rename, rename_bind₁, Function.comp]
+  simp [expand, bind₁_rename, rename_bind₁, Function.comp_def]
 #align mv_polynomial.rename_expand MvPolynomial.rename_expand
 
 @[simp]

--- a/Mathlib/Data/MvPolynomial/Rename.lean
+++ b/Mathlib/Data/MvPolynomial/Rename.lean
@@ -276,7 +276,7 @@ theorem exists_fin_rename (p : MvPolynomial σ R) :
   let e := Fintype.equivFin { x // x ∈ s }
   refine' ⟨n, (↑) ∘ e.symm, Subtype.val_injective.comp e.symm.injective, rename e q, _⟩
   rw [← rename_rename, rename_rename e]
-  simp only [Function.comp, Equiv.symm_apply_apply, rename_rename]
+  simp only [Function.comp_def, Equiv.symm_apply_apply, rename_rename]
 #align mv_polynomial.exists_fin_rename MvPolynomial.exists_fin_rename
 
 end Rename

--- a/Mathlib/Data/MvPolynomial/Rename.lean
+++ b/Mathlib/Data/MvPolynomial/Rename.lean
@@ -85,7 +85,7 @@ theorem rename_rename (f : σ → τ) (g : τ → α) (p : MvPolynomial σ R) :
     -- porting note: the Lean 3 proof of this was very fragile and included a nonterminal `simp`.
     -- Hopefully this is less prone to breaking
     rw [eval₂_comp_left (eval₂Hom (algebraMap R (MvPolynomial α R)) (X ∘ g)) C (X ∘ f) p]
-    simp only [(· ∘ ·), eval₂Hom_X', coe_eval₂Hom]
+    simp only [Function.comp_def, eval₂Hom_X', coe_eval₂Hom]
     refine' eval₂Hom_congr _ rfl rfl
     ext1; simp only [comp_apply, RingHom.coe_comp, eval₂Hom_C]
 #align mv_polynomial.rename_rename MvPolynomial.rename_rename

--- a/Mathlib/Data/PFunctor/Univariate/M.lean
+++ b/Mathlib/Data/PFunctor/Univariate/M.lean
@@ -104,7 +104,7 @@ theorem truncate_eq_of_agree {n : ℕ} (x : CofixA F n) (y : CofixA F (succ n)) 
   · rfl
   · -- cases' h with _ _ _ _ _ h₀ h₁
     cases h
-    simp only [truncate, Function.comp, true_and_iff, eq_self_iff_true, heq_iff_eq]
+    simp only [truncate, Function.comp_def, true_and_iff, eq_self_iff_true, heq_iff_eq]
     -- porting note: used to be `ext y`
     rename_i n_ih a f y h₁
     suffices (fun x => truncate (y x)) = f

--- a/Mathlib/Data/Polynomial/RingDivision.lean
+++ b/Mathlib/Data/Polynomial/RingDivision.lean
@@ -780,7 +780,7 @@ set_option linter.uppercaseLean3 false in
 theorem natDegree_multiset_prod_X_sub_C_eq_card (s : Multiset R) :
     (s.map fun a => X - C a).prod.natDegree = Multiset.card s := by
   rw [natDegree_multiset_prod_of_monic, Multiset.map_map]
-  · simp only [(· ∘ ·), natDegree_X_sub_C, Multiset.map_const', Multiset.sum_replicate, smul_eq_mul,
+  · simp only [Function.comp_def, natDegree_X_sub_C, Multiset.map_const', Multiset.sum_replicate, smul_eq_mul,
       mul_one]
   · exact Multiset.forall_mem_map_iff.2 fun a _ => monic_X_sub_C a
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/Data/Polynomial/RingDivision.lean
+++ b/Mathlib/Data/Polynomial/RingDivision.lean
@@ -780,8 +780,8 @@ set_option linter.uppercaseLean3 false in
 theorem natDegree_multiset_prod_X_sub_C_eq_card (s : Multiset R) :
     (s.map fun a => X - C a).prod.natDegree = Multiset.card s := by
   rw [natDegree_multiset_prod_of_monic, Multiset.map_map]
-  · simp only [Function.comp_def, natDegree_X_sub_C, Multiset.map_const', Multiset.sum_replicate, smul_eq_mul,
-      mul_one]
+  · simp only [Function.comp_def, natDegree_X_sub_C, Multiset.map_const', Multiset.sum_replicate,
+      smul_eq_mul, mul_one]
   · exact Multiset.forall_mem_map_iff.2 fun a _ => monic_X_sub_C a
 set_option linter.uppercaseLean3 false in
 #align polynomial.nat_degree_multiset_prod_X_sub_C_eq_card Polynomial.natDegree_multiset_prod_X_sub_C_eq_card

--- a/Mathlib/Data/QPF/Multivariate/Constructions/Comp.lean
+++ b/Mathlib/Data/QPF/Multivariate/Constructions/Comp.lean
@@ -79,9 +79,9 @@ instance : MvQPF (Comp F G) where
   abs := Comp.mk ∘ (map fun i ↦ abs) ∘ abs ∘ MvPFunctor.comp.get
   repr {α} := MvPFunctor.comp.mk ∘ repr ∘
               (map fun i ↦ (repr : G i α → (fun i : Fin2 n ↦ Obj (P (G i)) α) i)) ∘ Comp.get
-  abs_repr := by intros; simp only [(· ∘ ·), comp.get_mk, abs_repr, map_map,
+  abs_repr := by intros; simp only [Function.comp_def, comp.get_mk, abs_repr, map_map,
                                     TypeVec.comp, MvFunctor.id_map', Comp.mk_get]
-  abs_map := by intros; simp only [(· ∘ ·)]; rw [← abs_map]
+  abs_map := by intros; simp only [Function.comp_def]; rw [← abs_map]
                 simp only [comp.get_map, map_map, TypeVec.comp, abs_map, map_mk]
 
 end Comp

--- a/Mathlib/Data/QPF/Multivariate/Constructions/Fix.lean
+++ b/Mathlib/Data/QPF/Multivariate/Constructions/Fix.lean
@@ -357,7 +357,7 @@ def Fix.drec {β : Fix F α → Type u}
       rhs
       rw [← ih]
     rw [MvFunctor.map_map, ← appendFun_comp, id_comp]
-    simp only [Function.comp]
+    simp only [Function.comp_def]
   cast (by rw [this]) y.2
 #align mvqpf.fix.drec MvQPF.Fix.drec
 

--- a/Mathlib/Data/QPF/Univariate/Basic.lean
+++ b/Mathlib/Data/QPF/Univariate/Basic.lean
@@ -193,7 +193,8 @@ theorem recF_eq_of_Wequiv {α : Type u} (u : F α → α) (x y : q.P.W) :
     Wequiv x y → recF u x = recF u y := by
   intro h
   induction h
-  case ind a f f' _ ih => simp only [recF_eq', PFunctor.map_eq, Function.comp, ih]
+  case ind a f f' _ ih =>
+    simp only [recF_eq', PFunctor.map_eq, Function.comp_def, ih]
   case abs a f a' f' h => simp only [recF_eq', abs_map, h]
   case trans x y z _ _ ih₁ ih₂ => exact Eq.trans ih₁ ih₂
 set_option linter.uppercaseLean3 false in
@@ -557,7 +558,7 @@ def comp : QPF (Functor.Comp F₂ F₁) where
     apply abs_map
     congr
     rw [PFunctor.map_eq]
-    dsimp [Function.comp]
+    dsimp [Function.comp_def]
     congr
     ext x
     rw [← abs_map]

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -752,7 +752,7 @@ theorem range_subset_iff : range f ⊆ s ↔ ∀ y, f y ∈ s :=
 
 theorem range_subset_range_iff_exists_comp {f : α → γ} {g : β → γ} :
     range f ⊆ range g ↔ ∃ h : α → β, f = g ∘ h := by
-  simp only [range_subset_iff, mem_range, Classical.skolem, Function.funext_iff, (· ∘ ·), eq_comm]
+  simp only [range_subset_iff, mem_range, Classical.skolem, Function.funext_iff, Function.comp_def, eq_comm]
 
 theorem range_eq_iff (f : α → β) (s : Set β) :
     range f = s ↔ (∀ a, f a ∈ s) ∧ ∀ b ∈ s, ∃ a, f a = b := by
@@ -1511,7 +1511,7 @@ namespace Option
 
 theorem injective_iff {α β} {f : Option α → β} :
     Injective f ↔ Injective (f ∘ some) ∧ f none ∉ range (f ∘ some) := by
-  simp only [mem_range, not_exists, (· ∘ ·)]
+  simp only [mem_range, not_exists, Function.comp_def]
   refine'
     ⟨fun hf => ⟨hf.comp (Option.some_injective _), fun x => hf.ne <| Option.some_ne_none _⟩, _⟩
   rintro ⟨h_some, h_none⟩ (_ | a) (_ | b) hab

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -752,7 +752,8 @@ theorem range_subset_iff : range f ⊆ s ↔ ∀ y, f y ∈ s :=
 
 theorem range_subset_range_iff_exists_comp {f : α → γ} {g : β → γ} :
     range f ⊆ range g ↔ ∃ h : α → β, f = g ∘ h := by
-  simp only [range_subset_iff, mem_range, Classical.skolem, Function.funext_iff, Function.comp_def, eq_comm]
+  simp only [range_subset_iff, mem_range, Classical.skolem, Function.funext_iff, Function.comp_def,
+    eq_comm]
 
 theorem range_eq_iff (f : α → β) (s : Set β) :
     range f = s ↔ (∀ a, f a ∈ s) ∧ ∀ b ∈ s, ∃ a, f a = b := by

--- a/Mathlib/Data/Set/List.lean
+++ b/Mathlib/Data/Set/List.lean
@@ -54,7 +54,7 @@ theorem range_list_get? : range l.get? = insert none (some '' { x | x ∈ l }) :
 theorem range_list_getD (d : α) : (range fun n => l.getD n d) = insert d { x | x ∈ l } :=
   calc
     (range fun n => l.getD n d) = (fun o : Option α => o.getD d) '' range l.get? := by
-      simp only [← range_comp, (· ∘ ·), getD_eq_getD_get?]
+      simp only [← range_comp, Function.comp_def, getD_eq_getD_get?]
     _ = insert d { x | x ∈ l } := by
       simp only [range_list_get?, image_insert_eq, Option.getD, image_image, image_id']
 #align set.range_list_nthd Set.range_list_getD

--- a/Mathlib/Data/Set/Pointwise/Interval.lean
+++ b/Mathlib/Data/Set/Pointwise/Interval.lean
@@ -316,49 +316,57 @@ theorem image_neg_Ioo : Neg.neg '' Ioo a b = Ioo (-b) (-a) := by simp
 
 @[simp]
 theorem image_const_sub_Ici : (fun x => a - x) '' Ici b = Iic (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp] at this
+  have := image_comp (fun x => a + x) fun x => -x
+  dsimp [Function.comp_def] at this
   simp [sub_eq_add_neg, this, add_comm]
 #align set.image_const_sub_Ici Set.image_const_sub_Ici
 
 @[simp]
 theorem image_const_sub_Iic : (fun x => a - x) '' Iic b = Ici (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp] at this
+  have := image_comp (fun x => a + x) fun x => -x
+  dsimp [Function.comp_def] at this
   simp [sub_eq_add_neg, this, add_comm]
 #align set.image_const_sub_Iic Set.image_const_sub_Iic
 
 @[simp]
 theorem image_const_sub_Ioi : (fun x => a - x) '' Ioi b = Iio (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp] at this
+  have := image_comp (fun x => a + x) fun x => -x
+  dsimp [Function.comp_def] at this
   simp [sub_eq_add_neg, this, add_comm]
 #align set.image_const_sub_Ioi Set.image_const_sub_Ioi
 
 @[simp]
 theorem image_const_sub_Iio : (fun x => a - x) '' Iio b = Ioi (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp] at this
+  have := image_comp (fun x => a + x) fun x => -x
+  dsimp [Function.comp_def] at this
   simp [sub_eq_add_neg, this, add_comm]
 #align set.image_const_sub_Iio Set.image_const_sub_Iio
 
 @[simp]
 theorem image_const_sub_Icc : (fun x => a - x) '' Icc b c = Icc (a - c) (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp] at this
+  have := image_comp (fun x => a + x) fun x => -x
+  dsimp [Function.comp_def] at this
   simp [sub_eq_add_neg, this, add_comm]
 #align set.image_const_sub_Icc Set.image_const_sub_Icc
 
 @[simp]
 theorem image_const_sub_Ico : (fun x => a - x) '' Ico b c = Ioc (a - c) (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp] at this
+  have := image_comp (fun x => a + x) fun x => -x
+  dsimp [Function.comp_def] at this
   simp [sub_eq_add_neg, this, add_comm]
 #align set.image_const_sub_Ico Set.image_const_sub_Ico
 
 @[simp]
 theorem image_const_sub_Ioc : (fun x => a - x) '' Ioc b c = Ico (a - c) (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp] at this
+  have := image_comp (fun x => a + x) fun x => -x
+  dsimp [Function.comp_def] at this
   simp [sub_eq_add_neg, this, add_comm]
 #align set.image_const_sub_Ioc Set.image_const_sub_Ioc
 
 @[simp]
 theorem image_const_sub_Ioo : (fun x => a - x) '' Ioo b c = Ioo (a - c) (a - b) := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp] at this
+  have := image_comp (fun x => a + x) fun x => -x
+  dsimp [Function.comp_def] at this
   simp [sub_eq_add_neg, this, add_comm]
 #align set.image_const_sub_Ioo Set.image_const_sub_Ioo
 
@@ -459,7 +467,8 @@ theorem image_add_const_uIcc : (fun x => x + a) '' [[b, c]] = [[b + a, c + a]] :
 
 @[simp]
 theorem image_const_sub_uIcc : (fun x => a - x) '' [[b, c]] = [[a - b, a - c]] := by
-  have := image_comp (fun x => a + x) fun x => -x; dsimp [Function.comp] at this
+  have := image_comp (fun x => a + x) fun x => -x
+  dsimp [Function.comp_def] at this
   simp [sub_eq_add_neg, this, add_comm]
 #align set.image_const_sub_uIcc Set.image_const_sub_uIcc
 

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -713,7 +713,7 @@ protected theorem comp_traverse (f : β → F γ) (g : α → G β) (x : Vector 
   simp! [cast, *, functor_norm]
   · rfl
   · rw [Vector.traverse_def, ih]
-    simp [functor_norm, (· ∘ ·)]
+    simp [functor_norm, Function.comp_def]
 #align vector.comp_traverse Vector.comp_traverse
 
 protected theorem traverse_eq_map_id {α β} (f : α → β) :

--- a/Mathlib/Deprecated/Subring.lean
+++ b/Mathlib/Deprecated/Subring.lean
@@ -115,7 +115,7 @@ theorem exists_list_of_mem_closure {a : R} (h : a ∈ closure s) :
       ⟨L1.map (List.cons (-1)),
         fun L2 h2 ↦ match L2, List.mem_map.1 h2 with
         | _, ⟨L3, h3, rfl⟩ => List.forall_mem_cons.2 ⟨Or.inr rfl, h1 L3 h3⟩, by
-        simp only [List.map_map, (· ∘ ·), List.prod_cons, neg_one_mul]
+        simp only [List.map_map, Function.comp_def, List.prod_cons, neg_one_mul]
         refine' List.recOn L1 neg_zero.symm fun hd tl ih ↦ _
         rw [List.map_cons, List.sum_cons, ih, List.map_cons, List.sum_cons, neg_add]⟩
     fun {r1 r2} _ _ ih1 ih2 ↦ match r1, r2, ih1, ih2 with

--- a/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
+++ b/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
@@ -653,7 +653,7 @@ theorem translationNumber_eq_of_tendsto_aux {τ' : ℝ} (h : Tendsto f.transnumA
 theorem translationNumber_eq_of_tendsto₀ {τ' : ℝ}
     (h : Tendsto (fun n : ℕ => f^[n] 0 / n) atTop (𝓝 τ')) : τ f = τ' :=
   f.translationNumber_eq_of_tendsto_aux <| by
-    simpa [(· ∘ ·), transnumAuxSeq_def, coe_pow] using
+    simpa [Function.comp_def, transnumAuxSeq_def, coe_pow] using
       h.comp (Nat.tendsto_pow_atTop_atTop_of_one_lt one_lt_two)
 #align circle_deg1_lift.translation_number_eq_of_tendsto₀ CircleDeg1Lift.translationNumber_eq_of_tendsto₀
 

--- a/Mathlib/Geometry/Manifold/BumpFunction.lean
+++ b/Mathlib/Geometry/Manifold/BumpFunction.lean
@@ -105,7 +105,7 @@ theorem eventuallyEq_of_mem_source (hx : x ∈ (chartAt H c).source) :
 
 theorem one_of_dist_le (hs : x ∈ (chartAt H c).source)
     (hd : dist (extChartAt I c x) (extChartAt I c c) ≤ f.rIn) : f x = 1 := by
-  simp only [f.eqOn_source hs, (· ∘ ·), f.one_of_mem_closedBall hd]
+  simp only [f.eqOn_source hs, Function.comp_def, f.one_of_mem_closedBall hd]
 #align smooth_bump_function.one_of_dist_le SmoothBumpFunction.one_of_dist_le
 
 theorem support_eq_inter_preimage :

--- a/Mathlib/Geometry/Manifold/Complex.lean
+++ b/Mathlib/Geometry/Manifold/Complex.lean
@@ -74,7 +74,7 @@ theorem Complex.norm_eventually_eq_of_mdifferentiableAt_of_isLocalMax {f : M →
     exact hy₂.2
   convert norm_eventually_eq_of_isLocalMax hd _
   · exact congr_arg f (extChartAt_to_inv _ _).symm
-  · simpa only [IsLocalMax, IsMaxFilter, ← H₂, (· ∘ ·), extChartAt_to_inv] using hc
+  · simpa only [IsLocalMax, IsMaxFilter, ← H₂, Function.comp_def, extChartAt_to_inv] using hc
 
 /-!
 ### Functions holomorphic on a set

--- a/Mathlib/Geometry/Manifold/ContMDiff.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff.lean
@@ -1214,7 +1214,7 @@ variable {c : M'}
 theorem contMDiff_const : ContMDiff I I' n fun _ : M => c := by
   intro x
   refine' ⟨continuousWithinAt_const, _⟩
-  simp only [ContDiffWithinAtProp, (· ∘ ·)]
+  simp only [ContDiffWithinAtProp, Function.comp_def]
   exact contDiffWithinAt_const
 #align cont_mdiff_const contMDiff_const
 
@@ -1758,7 +1758,7 @@ theorem contMDiffWithinAt_pi_space :
   -- Porting note: `simp` fails to apply it on the LHS
   rw [contMDiffWithinAt_iff]
   simp only [contMDiffWithinAt_iff, continuousWithinAt_pi, contDiffWithinAt_pi, forall_and,
-    writtenInExtChartAt, extChartAt_model_space_eq_id, (· ∘ ·), LocalEquiv.refl_coe, id]
+    writtenInExtChartAt, extChartAt_model_space_eq_id, Function.comp_def, LocalEquiv.refl_coe, id]
 #align cont_mdiff_within_at_pi_space contMDiffWithinAt_pi_space
 
 theorem contMDiffOn_pi_space :

--- a/Mathlib/Geometry/Manifold/ContMDiff.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff.lean
@@ -946,7 +946,8 @@ theorem ContMDiffWithinAt.comp {t : Set M'} {g : M' → M''} (x : M)
   · filter_upwards [A]
     rintro x' ⟨-, hfx'⟩
     simp only [*, Function.comp_def, writtenInExtChartAt, e'.left_inv]
-  · simp only [writtenInExtChartAt, Function.comp_def, mem_extChartAt_source, e.left_inv, e'.left_inv]
+  · simp only [writtenInExtChartAt, Function.comp_def, mem_extChartAt_source, e.left_inv,
+      e'.left_inv]
 #align cont_mdiff_within_at.comp ContMDiffWithinAt.comp
 
 /-- See note [comp_of_eq lemmas] -/

--- a/Mathlib/Geometry/Manifold/ContMDiff.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff.lean
@@ -940,13 +940,13 @@ theorem ContMDiffWithinAt.comp {t : Set M'} {g : M' → M''} (x : M)
     (inter_mem _ self_mem_nhdsWithin)).congr_of_eventuallyEq _ _
   · filter_upwards [A]
     rintro x' ⟨ht, hfx'⟩
-    simp only [*, mem_preimage, writtenInExtChartAt, (· ∘ ·), mem_inter_iff, e'.left_inv,
+    simp only [*, mem_preimage, writtenInExtChartAt, Function.comp_def, mem_inter_iff, e'.left_inv,
       true_and_iff]
     exact mem_range_self _
   · filter_upwards [A]
     rintro x' ⟨-, hfx'⟩
-    simp only [*, (· ∘ ·), writtenInExtChartAt, e'.left_inv]
-  · simp only [writtenInExtChartAt, (· ∘ ·), mem_extChartAt_source, e.left_inv, e'.left_inv]
+    simp only [*, Function.comp_def, writtenInExtChartAt, e'.left_inv]
+  · simp only [writtenInExtChartAt, Function.comp_def, mem_extChartAt_source, e.left_inv, e'.left_inv]
 #align cont_mdiff_within_at.comp ContMDiffWithinAt.comp
 
 /-- See note [comp_of_eq lemmas] -/

--- a/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
@@ -97,7 +97,7 @@ protected theorem ContMDiffAt.mfderiv {x₀ : N} (f : N → M → M') (g : N →
           (range I) (extChartAt I (g x₀) (g ((extChartAt J x₀).symm x))))
       (range J) (extChartAt J x₀ x₀) := by
     rw [contMDiffAt_iff] at hf hg
-    simp_rw [Function.comp, uncurry, extChartAt_prod, LocalEquiv.prod_coe_symm,
+    simp_rw [Function.comp_def, uncurry, extChartAt_prod, LocalEquiv.prod_coe_symm,
       ModelWithCorners.range_prod] at hf ⊢
     refine' ContDiffWithinAt.fderivWithin _ hg.2 I.unique_diff hmn (mem_range_self _) _
     · simp_rw [extChartAt_to_inv]; exact hf.2
@@ -111,7 +111,7 @@ protected theorem ContMDiffAt.mfderiv {x₀ : N} (f : N → M → M') (g : N →
           (extChartAt I (g x₀) (g x)))
       x₀ := by
     simp_rw [contMDiffAt_iff_source_of_mem_source (mem_chart_source G x₀),
-      contMDiffWithinAt_iff_contDiffWithinAt, Function.comp]
+      contMDiffWithinAt_iff_contDiffWithinAt, Function.comp_def]
     exact this
   have :
     ContMDiffAt J 𝓘(𝕜, E →L[𝕜] E') m
@@ -507,7 +507,7 @@ theorem ContMDiffOn.contMDiffOn_tangentMapWithin (hf : ContMDiffOn I I' n f s) (
       refine' tangentMapWithin_subset (by mfld_set_tac) U'q _
       apply hf.mdifferentiableOn one_le_n
       simp only [hq, mfld_simps]
-    dsimp only [(· ∘ ·)] at A B C D E ⊢
+    dsimp only [Function.comp_def] at A B C D E ⊢
     simp only [A, B, C, D, ← E]
   exact diff_DrirrflilDl.congr eq_comp
 #align cont_mdiff_on.cont_mdiff_on_tangent_map_within ContMDiffOn.contMDiffOn_tangentMapWithin

--- a/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
@@ -301,7 +301,7 @@ theorem ContMDiffOn.contMDiffOn_tangentMapWithin_aux {f : H → H'} {s : Set H}
         tangentMapWithin I I' f s ∘
           (TotalSpace.toProd H E).symm ∘ fun p : E × E => (I.symm p.fst, p.snd))
       ((range I ∩ I.symm ⁻¹' s) ×ˢ univ)
-  · -- Porting note: was `simpa [(· ∘ ·)] using h`
+  · -- Porting note: was `simpa [Function.comp_def] using h`
     convert h using 1
     · ext1 ⟨x, y⟩
       simp only [mfld_simps]; rfl

--- a/Mathlib/Geometry/Manifold/Diffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/Diffeomorph.lean
@@ -321,7 +321,7 @@ theorem contMDiffWithinAt_comp_diffeomorph_iff {m} (h : M ≃ₘ^n⟮I, J⟯ N) 
   constructor
   · intro Hfh
     rw [← h.symm_apply_apply x] at Hfh
-    simpa only [(· ∘ ·), h.apply_symm_apply] using
+    simpa only [Function.comp_def, h.apply_symm_apply] using
       Hfh.comp (h x) (h.symm.contMDiffWithinAt.of_le hm) (mapsTo_preimage _ _)
   · rw [← h.image_eq_preimage]
     exact fun hf => hf.comp x (h.contMDiffWithinAt.of_le hm) (mapsTo_image _ _)
@@ -351,7 +351,7 @@ theorem contMDiff_comp_diffeomorph_iff {m} (h : M ≃ₘ^n⟮I, J⟯ N) {f : N �
 theorem contMDiffWithinAt_diffeomorph_comp_iff {m} (h : M ≃ₘ^n⟮I, J⟯ N) {f : M' → M} (hm : m ≤ n)
     {s x} : ContMDiffWithinAt I' J m (h ∘ f) s x ↔ ContMDiffWithinAt I' I m f s x :=
   ⟨fun Hhf => by
-    simpa only [(· ∘ ·), h.symm_apply_apply] using
+    simpa only [Function.comp_def, h.symm_apply_apply] using
       (h.symm.contMDiffAt.of_le hm).comp_contMDiffWithinAt _ Hhf,
     fun Hf => (h.contMDiffAt.of_le hm).comp_contMDiffWithinAt _ Hf⟩
 #align diffeomorph.cont_mdiff_within_at_diffeomorph_comp_iff Diffeomorph.contMDiffWithinAt_diffeomorph_comp_iff

--- a/Mathlib/Geometry/Manifold/Diffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/Diffeomorph.lean
@@ -568,7 +568,7 @@ def toTransDiffeomorph (e : E ≃ₘ[𝕜] F) : M ≃ₘ⟮I, I.transDiffeomorph
   contMDiff_toFun x := by
     refine' contMDiffWithinAt_iff'.2 ⟨continuousWithinAt_id, _⟩
     refine' e.contDiff.contDiffWithinAt.congr' (fun y hy => _) _
-    · simp only [Equiv.coe_refl, id, (· ∘ ·), I.coe_extChartAt_transDiffeomorph]
+    · simp only [Equiv.coe_refl, id, Function.comp_def, I.coe_extChartAt_transDiffeomorph]
       -- porting note: `simp only` failed to used next lemma, converted to `rw`
       rw [(extChartAt I x).right_inv hy.1]
     exact
@@ -577,7 +577,7 @@ def toTransDiffeomorph (e : E ≃ₘ[𝕜] F) : M ≃ₘ⟮I, I.transDiffeomorph
     refine' contMDiffWithinAt_iff'.2 ⟨continuousWithinAt_id, _⟩
     refine' e.symm.contDiff.contDiffWithinAt.congr' (fun y hy => _) _
     · simp only [mem_inter_iff, I.extChartAt_transDiffeomorph_target] at hy
-      simp only [Equiv.coe_refl, Equiv.refl_symm, id, (· ∘ ·),
+      simp only [Equiv.coe_refl, Equiv.refl_symm, id, Function.comp_def,
         I.coe_extChartAt_transDiffeomorph_symm, (extChartAt I x).right_inv hy.1]
     exact ⟨(extChartAt _ x).map_source (mem_extChartAt_source _ x), trivial, by
       simp only [e.symm_apply_apply, Equiv.refl_symm, Equiv.coe_refl, mfld_simps]⟩

--- a/Mathlib/Geometry/Manifold/MFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv.lean
@@ -1352,7 +1352,7 @@ variable {c : M'}
 theorem hasMFDerivAt_const (c : M') (x : M) :
     HasMFDerivAt I I' (fun _ : M => c) x (0 : TangentSpace I x →L[𝕜] TangentSpace I' c) := by
   refine' ⟨continuous_const.continuousAt, _⟩
-  simp only [writtenInExtChartAt, (· ∘ ·), hasFDerivWithinAt_const]
+  simp only [writtenInExtChartAt, Function.comp_def, hasFDerivWithinAt_const]
 #align has_mfderiv_at_const hasMFDerivAt_const
 
 theorem hasMFDerivWithinAt_const (c : M') (s : Set M) (x : M) :

--- a/Mathlib/Geometry/Manifold/MFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv.lean
@@ -1881,7 +1881,7 @@ theorem tangentMap_chart_symm {p : TangentBundle I M} {q : TangentBundle I H}
   dsimp only [tangentMap]
   rw [MDifferentiableAt.mfderiv (mdifferentiableAt_atlas_symm _ (chart_mem_atlas _ _) h)]
   simp only [ContinuousLinearMap.coe_coe, TangentBundle.chartAt, h, tangentBundleCore,
-    mfld_simps, (· ∘ ·)]
+    mfld_simps, Function.comp_def]
   -- `simp` fails to apply `LocalEquiv.prod_symm` with `ModelProd`
   congr
   exact ((chartAt H (TotalSpace.proj p)).right_inv h).symm

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -1102,7 +1102,7 @@ theorem tendsto_extend_comp_iff {l : Filter α} {g : α → M} (hg : ∀ᶠ z in
   have := (f.continuousAt_extend_symm I hy).tendsto.comp h
   rw [extend_left_inv _ _ hy] at this
   filter_upwards [hg, mem_map.1 (this hu)] with z hz hzu
-  simpa only [(· ∘ ·), extend_left_inv _ _ hz, mem_preimage] using hzu
+  simpa only [Function.comp_def, extend_left_inv _ _ hz, mem_preimage] using hzu
 
 -- there is no definition `writtenInExtend` but we already use some made-up names in this file
 theorem continuousWithinAt_writtenInExtend_iff {f' : LocalHomeomorph M' H'} {g : M → M'}

--- a/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
@@ -184,9 +184,9 @@ theorem contMDiffWithinAt_totalSpace (f : M → TotalSpace F E) {s : Set M} {x�
   simp (config := { singlePass := true }) only [contMDiffWithinAt_iff_target]
   rw [and_and_and_comm, ← FiberBundle.continuousWithinAt_totalSpace, and_congr_right_iff]
   intro hf
-  simp_rw [modelWithCornersSelf_prod, FiberBundle.extChartAt, Function.comp, LocalEquiv.trans_apply,
-    LocalEquiv.prod_coe, LocalEquiv.refl_coe, extChartAt_self_apply, modelWithCornersSelf_coe,
-    id_def]
+  simp_rw [modelWithCornersSelf_prod, FiberBundle.extChartAt, Function.comp_def,
+    LocalEquiv.trans_apply, LocalEquiv.prod_coe, LocalEquiv.refl_coe, extChartAt_self_apply,
+    modelWithCornersSelf_coe, id_def]
   refine (contMDiffWithinAt_prod_iff _).trans (and_congr ?_ Iff.rfl)
   have h1 : (fun x => (f x).proj) ⁻¹' (trivializationAt F E (f x₀).proj).baseSet ∈ 𝓝[s] x₀ :=
     ((FiberBundle.continuous_proj F E).continuousWithinAt.comp hf (mapsTo_image f s))

--- a/Mathlib/Geometry/Manifold/WhitneyEmbedding.lean
+++ b/Mathlib/Geometry/Manifold/WhitneyEmbedding.lean
@@ -93,7 +93,7 @@ theorem comp_embeddingPiTangent_mfderiv (x : M) (hx : x ∈ s) :
   convert hasMFDerivAt_unique this _
   refine' (hasMFDerivAt_extChartAt I (f.mem_chartAt_ind_source x hx)).congr_of_eventuallyEq _
   refine' (f.eventuallyEq_one x hx).mono fun y hy => _
-  simp only [embeddingPiTangent_coe, ContinuousLinearMap.coe_comp', (· ∘ ·),
+  simp only [embeddingPiTangent_coe, ContinuousLinearMap.coe_comp', Function.comp_def,
     ContinuousLinearMap.coe_fst', ContinuousLinearMap.proj_apply]
   rw [hy, Pi.one_apply, one_smul]
 #align smooth_bump_covering.comp_embedding_pi_tangent_mfderiv SmoothBumpCovering.comp_embeddingPiTangent_mfderiv

--- a/Mathlib/GroupTheory/FreeAbelianGroup.lean
+++ b/Mathlib/GroupTheory/FreeAbelianGroup.lean
@@ -130,7 +130,7 @@ theorem map_hom {α β γ} [AddCommGroup β] [AddCommGroup γ] (a : FreeAbelianG
   apply lift.unique
   intro a
   show g ((lift f) (of a)) = g (f a)
-  simp only [(· ∘ ·), lift.of]
+  simp only [Function.comp_def, lift.of]
 #align free_abelian_group.lift.map_hom FreeAbelianGroup.lift.map_hom
 
 end lift

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -558,8 +558,8 @@ theorem invRev_length : (invRev L₁).length = L₁.length := by simp [invRev]
 #align free_add_group.neg_rev_length FreeAddGroup.negRev_length
 
 @[to_additive (attr := simp)]
-theorem invRev_invRev : invRev (invRev L₁) = L₁ :=
-  by simp [invRev, List.map_reverse, (· ∘ ·)]
+theorem invRev_invRev : invRev (invRev L₁) = L₁ := by
+  simp [invRev, List.map_reverse, Function.comp_def]
 #align free_group.inv_rev_inv_rev FreeGroup.invRev_invRev
 #align free_add_group.neg_rev_neg_rev FreeAddGroup.negRev_negRev
 
@@ -813,7 +813,7 @@ theorem map.id' (x : FreeGroup α) : map (fun z => z) x = x :=
 @[to_additive]
 theorem map.comp {γ : Type w} (f : α → β) (g : β → γ) (x) :
     map g (map f x) = map (g ∘ f) x := by
-  rcases x with ⟨L⟩; simp [(· ∘ ·)]
+  rcases x with ⟨L⟩; simp [Function.comp_def]
 #align free_group.map.comp FreeGroup.map.comp
 #align free_add_group.map.comp FreeAddGroup.map.comp
 

--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -68,7 +68,7 @@ theorem cycleType_eq {σ : Perm α} (l : List (Perm α)) (h0 : l.prod = σ)
     σ.cycleType = l.map (Finset.card ∘ support) := by
   have hl : l.Nodup := nodup_of_pairwise_disjoint_cycles h1 h2
   rw [cycleType_eq' l.toFinset]
-  · simp [List.dedup_eq_self.mpr hl, (· ∘ ·)]
+  · simp [List.dedup_eq_self.mpr hl, Function.comp_def]
   · simpa using h1
   · simpa [hl] using h2
   · simp [hl, h0]

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -750,7 +750,7 @@ theorem sign_prodCongrRight (σ : α → Perm β) : sign (prodCongrRight σ) = �
     exact List.mem_toFinset.mpr (mem_l b)
   rw [← prod_prodExtendRight σ hl mem_l, sign.map_list_prod, List.map_map, ← l_to_finset,
     List.prod_toFinset _ hl]
-  simp_rw [← fun a => sign_prodExtendRight a (σ a), Function.comp]
+  simp_rw [← fun a => sign_prodExtendRight a (σ a), comp_def]
 #align equiv.perm.sign_prod_congr_right Equiv.Perm.sign_prodCongrRight
 
 theorem sign_prodCongrLeft (σ : α → Perm β) : sign (prodCongrLeft σ) = ∏ k, sign (σ k) := by

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineEquiv.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineEquiv.lean
@@ -324,7 +324,7 @@ def trans (e : P₁ ≃ᵃ[k] P₂) (e' : P₂ ≃ᵃ[k] P₃) : P₁ ≃ᵃ[k] 
   toEquiv := e.toEquiv.trans e'.toEquiv
   linear := e.linear.trans e'.linear
   map_vadd' p v := by
-    simp only [LinearEquiv.trans_apply, coe_toEquiv, (· ∘ ·), Equiv.coe_trans, map_vadd]
+    simp only [LinearEquiv.trans_apply, coe_toEquiv, Function.comp_def, Equiv.coe_trans, map_vadd]
 #align affine_equiv.trans AffineEquiv.trans
 
 @[simp]

--- a/Mathlib/LinearAlgebra/AffineSpace/Matrix.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Matrix.lean
@@ -67,7 +67,7 @@ theorem affineIndependent_of_toMatrix_right_inv [DecidableEq ι'] (p : ι' → P
     ext j
     change (∑ i, w₁ i • b.coord j (p i)) = ∑ i, w₂ i • b.coord j (p i)
     -- Porting note: Added `u` because `∘` was causing trouble
-    have u : (fun i => b.coord j (p i)) = b.coord j ∘ p := by simp only [(· ∘ ·)]
+    have u : (fun i => b.coord j (p i)) = b.coord j ∘ p := by simp only [Function.comp_def]
     rw [← Finset.univ.affineCombination_eq_linear_combination _ _ hw₁,
       ← Finset.univ.affineCombination_eq_linear_combination _ _ hw₂, u,
       ← Finset.univ.map_affineCombination p w₁ hw₁, ← Finset.univ.map_affineCombination p w₂ hw₂,

--- a/Mathlib/LinearAlgebra/AffineSpace/Slope.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Slope.lean
@@ -81,7 +81,7 @@ theorem eq_of_slope_eq_zero {f : k → PE} {a b : k} (h : slope f a b = (0 : E))
 
 theorem AffineMap.slope_comp {F PF : Type*} [AddCommGroup F] [Module k F] [AddTorsor F PF]
     (f : PE →ᵃ[k] PF) (g : k → PE) (a b : k) : slope (f ∘ g) a b = f.linear (slope g a b) := by
-  simp only [slope, (· ∘ ·), f.linear.map_smul, f.linearMap_vsub]
+  simp only [slope, Function.comp_def, f.linear.map_smul, f.linearMap_vsub]
 #align affine_map.slope_comp AffineMap.slope_comp
 
 theorem LinearMap.slope_comp {F : Type*} [AddCommGroup F] [Module k F] (f : E →ₗ[k] F) (g : k → E)

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -770,10 +770,10 @@ def domDomCongrEquiv (σ : ι ≃ ι') : AlternatingMap R M N ι ≃+ Alternatin
   invFun := domDomCongr σ.symm
   left_inv f := by
     ext
-    simp [Function.comp]
+    simp [Function.comp_def]
   right_inv m := by
     ext
-    simp [Function.comp]
+    simp [Function.comp_def]
   map_add' := domDomCongr_add σ
 #align alternating_map.dom_dom_congr_equiv AlternatingMap.domDomCongrEquiv
 #align alternating_map.dom_dom_congr_equiv_apply AlternatingMap.domDomCongrEquiv_apply
@@ -788,8 +788,8 @@ variable (S : Type*) [Semiring S] [Module S N] [SMulCommClass R S N]
 def domDomLcongr (σ : ι ≃ ι') : AlternatingMap R M N ι ≃ₗ[S] AlternatingMap R M N ι' where
   toFun := domDomCongr σ
   invFun := domDomCongr σ.symm
-  left_inv f := by ext; simp [Function.comp]
-  right_inv m := by ext; simp [Function.comp]
+  left_inv f := by ext; simp [Function.comp_def]
+  right_inv m := by ext; simp [Function.comp_def]
   map_add' := domDomCongr_add σ
   map_smul' := domDomCongr_smul σ
 #align alternating_map.dom_dom_lcongr AlternatingMap.domDomLcongr

--- a/Mathlib/LinearAlgebra/Alternating/DomCoprod.lean
+++ b/Mathlib/LinearAlgebra/Alternating/DomCoprod.lean
@@ -253,8 +253,8 @@ theorem MultilinearMap.domCoprod_alternization [DecidableEq ιa] [DecidableEq ι
     fun x _ => QuotientGroup.eq' (s := MonoidHom.range (Perm.sumCongrHom ιa ιb)) (a := x) (b := σ)]
   -- eliminate a multiplication
   rw [← Finset.map_univ_equiv (Equiv.mulLeft σ), Finset.filter_map, Finset.sum_map]
-  simp_rw [Equiv.coe_toEmbedding, Equiv.coe_mulLeft, (· ∘ ·), mul_inv_rev, inv_mul_cancel_right,
-    Subgroup.inv_mem_iff, MonoidHom.mem_range, Finset.univ_filter_exists,
+  simp_rw [Equiv.coe_toEmbedding, Equiv.coe_mulLeft, Function.comp_def, mul_inv_rev,
+    inv_mul_cancel_right, Subgroup.inv_mem_iff, MonoidHom.mem_range, Finset.univ_filter_exists,
     Finset.sum_image (Perm.sumCongrHom_injective.injOn _)]
   -- now we're ready to clean up the RHS, pulling out the summation
   rw [domCoprod.summand_mk'', MultilinearMap.domCoprod_alternization_coe, ← Finset.sum_product',

--- a/Mathlib/LinearAlgebra/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Finsupp.lean
@@ -1163,7 +1163,7 @@ protected theorem Submodule.finsupp_sum_mem {ι β : Type*} [Zero β] (S : Submo
 theorem LinearMap.map_finsupp_total (f : M →ₗ[R] N) {ι : Type*} {g : ι → M} (l : ι →₀ R) :
     f (Finsupp.total ι M R g l) = Finsupp.total ι N R (f ∘ g) l := by
   -- Porting note: `(· ∘ ·)` is required.
-  simp only [Finsupp.total_apply, Finsupp.total_apply, Finsupp.sum, map_sum, map_smul, (· ∘ ·)]
+  simp only [Finsupp.total_apply, Finsupp.total_apply, Finsupp.sum, map_sum, map_smul, Function.comp_def]
 #align linear_map.map_finsupp_total LinearMap.map_finsupp_total
 
 theorem Submodule.exists_finset_of_mem_iSup {ι : Sort _} (p : ι → Submodule R M) {m : M}

--- a/Mathlib/LinearAlgebra/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Finsupp.lean
@@ -1162,8 +1162,9 @@ protected theorem Submodule.finsupp_sum_mem {ι β : Type*} [Zero β] (S : Submo
 
 theorem LinearMap.map_finsupp_total (f : M →ₗ[R] N) {ι : Type*} {g : ι → M} (l : ι →₀ R) :
     f (Finsupp.total ι M R g l) = Finsupp.total ι N R (f ∘ g) l := by
-  -- Porting note: `(· ∘ ·)` is required.
-  simp only [Finsupp.total_apply, Finsupp.total_apply, Finsupp.sum, map_sum, map_smul, Function.comp_def]
+  -- Porting note: `Function.comp_def` is required.
+  simp only [Finsupp.total_apply, Finsupp.total_apply, Finsupp.sum, map_sum, map_smul,
+    Function.comp_def]
 #align linear_map.map_finsupp_total LinearMap.map_finsupp_total
 
 theorem Submodule.exists_finset_of_mem_iSup {ι : Sort _} (p : ι → Submodule R M) {m : M}

--- a/Mathlib/LinearAlgebra/FreeModule/PID.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/PID.lean
@@ -592,7 +592,7 @@ noncomputable def Ideal.smithNormalForm [Fintype ι] (b : Basis ι R S) (I : Ide
   let e : Fin n ≃ Fin (Fintype.card ι) := Fintype.equivOfCardEq (by rw [eq, Fintype.card_fin])
   ⟨bS, bI.reindex e, e.symm.toEmbedding.trans f, a ∘ e.symm, fun i ↦ by
     simp only [snf, Basis.coe_reindex, Function.Embedding.trans_apply, Equiv.toEmbedding_apply,
-      (· ∘ ·)]⟩
+      Function.comp_def]⟩
 #align ideal.smith_normal_form Ideal.smithNormalForm
 
 variable [Finite ι]
@@ -620,7 +620,7 @@ theorem Ideal.exists_smith_normal_form (b : Basis ι R S) (I : Ideal S) (hI : I 
     ⟨bS, a ∘ e.symm, (bI.reindex e).map ((restrictScalarsEquiv R S _ _).restrictScalars R),
       fun i ↦ by
         simp only [snf, fe, Basis.map_apply, LinearEquiv.restrictScalars_apply R,
-          Submodule.restrictScalarsEquiv_apply, Basis.coe_reindex, (· ∘ ·)]⟩
+          Submodule.restrictScalarsEquiv_apply, Basis.coe_reindex, Function.comp_def]⟩
 #align ideal.exists_smith_normal_form Ideal.exists_smith_normal_form
 
 /-- If `S` a finite-dimensional ring extension of a PID `R` which is free as an `R`-module,

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -1016,7 +1016,7 @@ theorem eq_of_linearIndependent_of_span_subtype [Nontrivial R] {s t : Set M}
     ⟨fun x => ⟨x.1, h x.2⟩, fun a b hab => Subtype.coe_injective (Subtype.mk.inj hab)⟩
   have h_surj : Surjective f := by
     apply surjective_of_linearIndependent_of_span hs f _
-    convert hst <;> simp [comp]
+    convert hst <;> simp [comp_def]
   show s = t
   · apply Subset.antisymm _ h
     intro x hx
@@ -1270,7 +1270,7 @@ theorem linearIndependent_insert' {ι} {s : Set ι} {a : ι} {f : ι → V} (has
     linearIndependent_option]
   -- Porting note: `simp [(· ∘ ·), range_comp f]` → `simp [(· ∘ ·)]; erw [range_comp f ..]; simp`
   -- https://github.com/leanprover-community/mathlib4/issues/5164
-  simp only [(· ∘ ·)]
+  simp only [Function.comp_def]
   erw [range_comp f ((↑) : s → ι)]
   simp
 #align linear_independent_insert' linearIndependent_insert'

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -375,7 +375,7 @@ section Subtype
 theorem linearIndependent_comp_subtype {s : Set ι} :
     LinearIndependent R (v ∘ (↑) : s → M) ↔
       ∀ l ∈ Finsupp.supported R R s, (Finsupp.total ι M R v) l = 0 → l = 0 := by
-  simp only [linearIndependent_iff, (· ∘ ·), Finsupp.mem_supported, Finsupp.total_apply,
+  simp only [linearIndependent_iff, Function.comp_def, Finsupp.mem_supported, Finsupp.total_apply,
     Set.subset_def, Finset.mem_coe]
   constructor
   · intro h l hl₁ hl₂
@@ -1244,7 +1244,7 @@ theorem linearIndependent_option' :
   -- Porting note: Explicit universe level is required in `Equiv.optionEquivSumPUnit`.
   rw [← linearIndependent_equiv (Equiv.optionEquivSumPUnit.{_, u'} ι).symm, linearIndependent_sum,
     @range_unique _ PUnit, @linearIndependent_unique_iff PUnit, disjoint_span_singleton]
-  dsimp [(· ∘ ·)]
+  dsimp [Function.comp_def]
   refine' ⟨fun h => ⟨h.1, fun hx => h.2.1 <| h.2.2 hx⟩, fun h => ⟨h.1, _, fun hx => (h.2 hx).elim⟩⟩
   rintro rfl
   exact h.2 (zero_mem _)
@@ -1268,7 +1268,7 @@ theorem linearIndependent_insert' {ι} {s : Set ι} {a : ι} {f : ι → V} (has
   classical
   rw [← linearIndependent_equiv ((Equiv.optionEquivSumPUnit _).trans (Equiv.Set.insert has).symm),
     linearIndependent_option]
-  -- Porting note: `simp [(· ∘ ·), range_comp f]` → `simp [(· ∘ ·)]; erw [range_comp f ..]; simp`
+  -- Porting note: `simp [Function.comp_def, range_comp f]` → `simp [Function.comp_def]; erw [range_comp f ..]; simp`
   -- https://github.com/leanprover-community/mathlib4/issues/5164
   simp only [Function.comp_def]
   erw [range_comp f ((↑) : s → ι)]

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -1268,7 +1268,8 @@ theorem linearIndependent_insert' {ι} {s : Set ι} {a : ι} {f : ι → V} (has
   classical
   rw [← linearIndependent_equiv ((Equiv.optionEquivSumPUnit _).trans (Equiv.Set.insert has).symm),
     linearIndependent_option]
-  -- Porting note: `simp [Function.comp_def, range_comp f]` → `simp [Function.comp_def]; erw [range_comp f ..]; simp`
+  -- Porting note: `simp [Function.comp_def, range_comp f]` →
+  -- `simp [Function.comp_def]; erw [range_comp f ..]; simp`
   -- https://github.com/leanprover-community/mathlib4/issues/5164
   simp only [Function.comp_def]
   erw [range_comp f ((↑) : s → ι)]

--- a/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
@@ -175,7 +175,7 @@ theorem cramer_submatrix_equiv (A : Matrix m m α) (e : n ≃ m) (b : n → α) 
     cramer (A.submatrix e e) b = cramer A (b ∘ e.symm) ∘ e := by
   ext i
   simp_rw [Function.comp_apply, cramer_apply, updateColumn_submatrix_equiv,
-    det_submatrix_equiv_self e, Function.comp]
+    det_submatrix_equiv_self e, Function.comp_def]
 #align matrix.cramer_submatrix_equiv Matrix.cramer_submatrix_equiv
 
 theorem cramer_reindex (e : m ≃ n) (A : Matrix m m α) (b : n → α) :

--- a/Mathlib/LinearAlgebra/Matrix/Basis.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Basis.lean
@@ -272,7 +272,7 @@ theorem Basis.toMatrix_reindex (b : Basis ι R M) (v : ι' → M) (e : ι ≃ ι
 theorem Basis.toMatrix_map (b : Basis ι R M) (f : M ≃ₗ[R] N) (v : ι → N) :
     (b.map f).toMatrix v = b.toMatrix (f.symm ∘ v) := by
   ext
-  simp only [Basis.toMatrix_apply, Basis.map, LinearEquiv.trans_apply, (· ∘ ·)]
+  simp only [Basis.toMatrix_apply, Basis.map, LinearEquiv.trans_apply, Function.comp_def]
 #align basis.to_matrix_map Basis.toMatrix_map
 
 end MulLinearMapToMatrix

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -71,7 +71,7 @@ theorem PosSemidef.submatrix {M : Matrix n n R} (hM : M.PosSemidef) (e : m ≃ n
   refine' ⟨hM.1.submatrix e, fun x => _⟩
   have : (M.submatrix (⇑e) e).mulVec x = (M.mulVec fun i : n => x (e.symm i)) ∘ e := by
     ext i
-    dsimp only [(· ∘ ·), mulVec, dotProduct]
+    dsimp only [Function.comp_def, mulVec, dotProduct]
     rw [Finset.sum_bij' (fun i _ => e i) _ _ fun i _ => e.symm i] <;>
       simp only [eq_self_iff_true, imp_true_iff, Equiv.symm_apply_apply, Finset.mem_univ,
         submatrix_apply, Equiv.apply_symm_apply]

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -116,7 +116,7 @@ theorem spectral_theorem :
     simp_rw [mulVec_single, mul_one, OrthonormalBasis.coe_toBasis_repr_apply,
       OrthonormalBasis.repr_reindex]
     rfl
-  · simp only [diagonal_mul, (· ∘ ·), eigenvalues]
+  · simp only [diagonal_mul, Function.comp_def, eigenvalues]
     rw [eigenvectorBasis, Basis.toMatrix_apply, OrthonormalBasis.coe_toBasis_repr_apply,
       OrthonormalBasis.repr_reindex, eigenvalues₀, PiLp.basisFun_apply, WithLp.equiv_symm_single]
 #align matrix.is_hermitian.spectral_theorem Matrix.IsHermitian.spectral_theorem

--- a/Mathlib/LinearAlgebra/Matrix/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Transvection.lean
@@ -542,8 +542,8 @@ theorem exists_isTwoBlockDiagonal_of_ne_zero (hM : M (inr unit) (inr unit) ≠ 0
     List.ofFn fun i : Fin r =>
       ⟨inr unit, inl i, by simp, -M (inr unit) (inl i) / M (inr unit) (inr unit)⟩
   refine' ⟨L, L', _⟩
-  have A : L.map toMatrix = listTransvecCol M := by simp [listTransvecCol, (· ∘ ·)]
-  have B : L'.map toMatrix = listTransvecRow M := by simp [listTransvecRow, (· ∘ ·)]
+  have A : L.map toMatrix = listTransvecCol M := by simp [listTransvecCol, Function.comp_def]
+  have B : L'.map toMatrix = listTransvecRow M := by simp [listTransvecRow, Function.comp_def]
   rw [A, B]
   exact isTwoBlockDiagonal_listTransvecCol_mul_mul_listTransvecRow M hM
 #align matrix.pivot.exists_is_two_block_diagonal_of_ne_zero Matrix.Pivot.exists_isTwoBlockDiagonal_of_ne_zero

--- a/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
@@ -144,19 +144,19 @@ theorem _root_.TensorPower.list_prod_gradedMonoid_mk_single (n : ℕ) (x : Fin n
     rfl
   · intro n x₀ x ih
     rw [List.finRange_succ_eq_map, List.map_cons, List.prod_cons, List.map_map]
-    simp_rw [Function.comp, Fin.cons_zero, Fin.cons_succ]
+    simp_rw [Function.comp_def, Fin.cons_zero, Fin.cons_succ]
     rw [ih, GradedMonoid.mk_mul_mk, TensorPower.tprod_mul_tprod]
     refine' TensorPower.gradedMonoid_eq_of_cast (add_comm _ _) _
     dsimp only [GradedMonoid.mk]
     rw [TensorPower.cast_tprod]
-    simp_rw [Fin.append_left_eq_cons, Function.comp]
+    simp_rw [Fin.append_left_eq_cons, Function.comp_def]
     congr 1 with i
 #align tensor_power.list_prod_graded_monoid_mk_single TensorPower.list_prod_gradedMonoid_mk_single
 
 theorem toDirectSum_tensorPower_tprod {n} (x : Fin n → M) :
     toDirectSum (tprod R M n x) = DirectSum.of _ n (PiTensorProduct.tprod R x) := by
   rw [tprod_apply, AlgHom.map_list_prod, List.map_ofFn]
-  simp_rw [Function.comp, toDirectSum_ι]
+  simp_rw [Function.comp_def, toDirectSum_ι]
   rw [DirectSum.list_prod_ofFn_of_eq_dProd]
   apply DirectSum.of_eq_of_gradedMonoid_eq
   rw [GradedMonoid.mk_list_dProd]

--- a/Mathlib/MeasureTheory/Constructions/Prod/Integral.lean
+++ b/Mathlib/MeasureTheory/Constructions/Prod/Integral.lean
@@ -461,7 +461,7 @@ theorem integral_prod (f : α × β → E) (hf : Integrable f (μ.prod ν)) :
   revert f
   apply Integrable.induction
   · intro c s hs h2s
-    simp_rw [integral_indicator hs, ← indicator_comp_right, Function.comp,
+    simp_rw [integral_indicator hs, ← indicator_comp_right, Function.comp_def,
       integral_indicator (measurable_prod_mk_left hs), set_integral_const, integral_smul_const,
       integral_toReal (measurable_measure_prod_mk_left hs).aemeasurable
         (ae_measure_lt_top hs h2s.ne)]

--- a/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
+++ b/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
@@ -387,7 +387,7 @@ protected theorem aEStronglyMeasurable_on_iff {β : Type*} [TopologicalSpace β]
       have he : MeasurableEmbedding ((· • ·) g⁻¹ : α → α) := measurableEmbedding_const_smul _
       rw [← image_smul, ← ((measurePreserving_smul g⁻¹ μ).restrict_image_emb he
         _).aestronglyMeasurable_comp_iff he]
-      simp only [(· ∘ ·), hf]
+      simp only [Function.comp_def, hf]
     _ ↔ AEStronglyMeasurable f (μ.restrict t) := by
       simp only [← aestronglyMeasurable_sum_measure_iff, ← hs.restrict_restrict,
         hs.sum_restrict_of_ac restrict_le_self.absolutelyContinuous]

--- a/Mathlib/MeasureTheory/Group/Measure.lean
+++ b/Mathlib/MeasureTheory/Group/Measure.lean
@@ -484,7 +484,7 @@ instance inv.instIsMulRightInvariant [IsMulLeftInvariant μ] : IsMulRightInvaria
   intro g
   conv_rhs => rw [← map_mul_left_eq_self μ g⁻¹]
   simp_rw [Measure.inv, map_map (measurable_mul_const g) measurable_inv,
-    map_map measurable_inv (measurable_const_mul g⁻¹), Function.comp, mul_inv_rev, inv_inv]
+    map_map measurable_inv (measurable_const_mul g⁻¹), Function.comp_def, mul_inv_rev, inv_inv]
 #align measure_theory.measure.inv.is_mul_right_invariant MeasureTheory.Measure.inv.instIsMulRightInvariant
 #align measure_theory.measure.neg.is_mul_right_invariant MeasureTheory.Measure.neg.instIsAddRightInvariant
 
@@ -494,7 +494,7 @@ instance inv.instIsMulLeftInvariant [IsMulRightInvariant μ] : IsMulLeftInvarian
   intro g
   conv_rhs => rw [← map_mul_right_eq_self μ g⁻¹]
   simp_rw [Measure.inv, map_map (measurable_const_mul g) measurable_inv,
-    map_map measurable_inv (measurable_mul_const g⁻¹), Function.comp, mul_inv_rev, inv_inv]
+    map_map measurable_inv (measurable_mul_const g⁻¹), Function.comp_def, mul_inv_rev, inv_inv]
 #align measure_theory.measure.inv.is_mul_left_invariant MeasureTheory.Measure.inv.instIsMulLeftInvariant
 #align measure_theory.measure.neg.is_mul_left_invariant MeasureTheory.Measure.neg.instIsAddLeftInvariant
 

--- a/Mathlib/MeasureTheory/Group/Prod.lean
+++ b/Mathlib/MeasureTheory/Group/Prod.lean
@@ -504,7 +504,7 @@ theorem quasiMeasurePreserving_mul_left [IsMulRightInvariant μ] (g : G) :
   have :=
     (quasiMeasurePreserving_inv_of_right_invariant μ).comp
       (this.comp (quasiMeasurePreserving_inv_of_right_invariant μ))
-  simp_rw [Function.comp, mul_inv_rev, inv_inv] at this
+  simp_rw [Function.comp_def, mul_inv_rev, inv_inv] at this
   exact this
 #align measure_theory.quasi_measure_preserving_mul_left MeasureTheory.quasiMeasurePreserving_mul_left
 #align measure_theory.quasi_measure_preserving_add_left MeasureTheory.quasiMeasurePreserving_add_left

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -482,7 +482,7 @@ nonrec def posPart (f : α →₁ₛ[μ] ℝ) : α →₁ₛ[μ] ℝ :=
     simp only [Subtype.coe_mk, Lp.coe_posPart, ← hsf, AEEqFun.posPart_mk,
       SimpleFunc.coe_map, mk_eq_mk]
     -- Porting note: added
-    simp [SimpleFunc.posPart, Function.comp, EventuallyEq.rfl] ⟩
+    simp [SimpleFunc.posPart, Function.comp_def, EventuallyEq.rfl] ⟩
 #align measure_theory.L1.simple_func.pos_part MeasureTheory.L1.SimpleFunc.posPart
 
 /-- Negative part of a simple function in L1 space. -/

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -142,8 +142,8 @@ theorem circleMap_ne_mem_ball {c : ℂ} {R : ℝ} {w : ℂ} (hw : w ∈ ball c R
 theorem range_circleMap (c : ℂ) (R : ℝ) : range (circleMap c R) = sphere c |R| :=
   calc
     range (circleMap c R) = c +ᵥ R • range fun θ : ℝ => exp (θ * I) := by
-      simp only [← image_vadd, ← image_smul, ← range_comp, vadd_eq_add, circleMap, Function.comp_def,
-        real_smul]
+      simp only [← image_vadd, ← image_smul, ← range_comp, vadd_eq_add, circleMap,
+        Function.comp_def, real_smul]
     _ = sphere c |R| := by
       rw [Complex.range_exp_mul_I, smul_sphere R 0 zero_le_one]
       simp

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -142,7 +142,7 @@ theorem circleMap_ne_mem_ball {c : ℂ} {R : ℝ} {w : ℂ} (hw : w ∈ ball c R
 theorem range_circleMap (c : ℂ) (R : ℝ) : range (circleMap c R) = sphere c |R| :=
   calc
     range (circleMap c R) = c +ᵥ R • range fun θ : ℝ => exp (θ * I) := by
-      simp only [← image_vadd, ← image_smul, ← range_comp, vadd_eq_add, circleMap, (· ∘ ·),
+      simp only [← image_vadd, ← image_smul, ← range_comp, vadd_eq_add, circleMap, Function.comp_def,
         real_smul]
     _ = sphere c |R| := by
       rw [Complex.range_exp_mul_I, smul_sphere R 0 zero_le_one]

--- a/Mathlib/MeasureTheory/Integral/DivergenceTheorem.lean
+++ b/Mathlib/MeasureTheory/Integral/DivergenceTheorem.lean
@@ -355,7 +355,7 @@ theorem integral_divergence_of_hasFDerivWithinAt_off_countable_of_equiv {F : Typ
         simpa only [Set.mem_preimage, eL.apply_symm_apply, ← pi_univ_Icc,
           interior_pi_set (@finite_univ (Fin _) _), interior_Icc] using hx.1
       · rw [← he_vol.integrableOn_comp_preimage he_emb, hIcc]
-        simp [← hDF, (· ∘ ·), Hi]
+        simp [← hDF, Function.comp_def, Hi]
 #align measure_theory.integral_divergence_of_has_fderiv_within_at_off_countable_of_equiv MeasureTheory.integral_divergence_of_hasFDerivWithinAt_off_countable_of_equiv
 
 end

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -407,7 +407,7 @@ theorem lintegral_iSup {f : ℕ → α → ℝ≥0∞} (hf : ∀ n, Measurable (
       rw [← SimpleFunc.lintegral_eq_lintegral]
       refine' lintegral_mono fun a => _
       simp only [map_apply] at h_meas
-      simp only [coe_map, restrict_apply _ (h_meas _), (· ∘ ·)]
+      simp only [coe_map, restrict_apply _ (h_meas _), Function.comp_def]
       exact indicator_apply_le id
 #align measure_theory.lintegral_supr MeasureTheory.lintegral_iSup
 

--- a/Mathlib/MeasureTheory/Integral/TorusIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/TorusIntegral.lean
@@ -248,7 +248,7 @@ theorem torusIntegral_succAbove {f : ℂⁿ⁺¹ → E} {c : ℂⁿ⁺¹} {R : �
       torusMap, circleMap_zero]
     refine' set_integral_congr measurableSet_Icc fun Θ _ => _
     simp only [MeasurableEquiv.piFinSuccAboveEquiv_symm_apply, i.insertNth_apply_same,
-      i.insertNth_apply_succAbove, (· ∘ ·)]
+      i.insertNth_apply_succAbove, Function.comp_def]
     congr 2
     simp only [funext_iff, i.forall_iff_succAbove, circleMap, Fin.insertNth_apply_same,
       eq_self_iff_true, Fin.insertNth_apply_succAbove, imp_true_iff, and_self_iff]

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -612,7 +612,7 @@ alias Measurable.subtype_val := Measurable.subtype_coe
 @[measurability]
 theorem Measurable.subtype_mk {p : β → Prop} {f : α → β} (hf : Measurable f) {h : ∀ x, p (f x)} :
     Measurable fun x => (⟨f x, h x⟩ : Subtype p) := fun t ⟨s, hs⟩ =>
-  hs.2 ▸ by simp only [← preimage_comp, (· ∘ ·), Subtype.coe_mk, hf hs.1]
+  hs.2 ▸ by simp only [← preimage_comp, comp_def, Subtype.coe_mk, hf hs.1]
 #align measurable.subtype_mk Measurable.subtype_mk
 
 @[measurability]
@@ -890,7 +890,7 @@ variable [∀ a, MeasurableSpace (π a)] [MeasurableSpace γ]
 
 theorem measurable_pi_iff {g : α → ∀ a, π a} : Measurable g ↔ ∀ a, Measurable fun x => g x a := by
   simp_rw [measurable_iff_comap_le, MeasurableSpace.pi, MeasurableSpace.comap_iSup,
-    MeasurableSpace.comap_comp, Function.comp, iSup_le_iff]
+    MeasurableSpace.comap_comp, comp_def, iSup_le_iff]
 #align measurable_pi_iff measurable_pi_iff
 
 @[aesop safe 100 apply (rule_sets [Measurable])]

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
@@ -115,7 +115,7 @@ theorem integral_comp_abs {f : ℝ → ℝ} :
       rw [← Measure.map_neg_eq_self (volume : Measure ℝ)]
       let m : MeasurableEmbedding fun x : ℝ => -x := (Homeomorph.neg ℝ).measurableEmbedding
       rw [m.integrableOn_map_iff]
-      simp_rw [Function.comp, abs_neg, neg_preimage, preimage_neg_Iic, neg_zero]
+      simp_rw [Function.comp_def, abs_neg, neg_preimage, preimage_neg_Iic, neg_zero]
       exact integrableOn_Ici_iff_integrableOn_Ioi.mpr hf
     calc
       _ = (∫ x in Iic 0, f |x|) + ∫ x in Ioi 0, f |x| := by

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -463,7 +463,7 @@ theorem measure_iUnion_eq_iSup [Countable ι] {s : ι → Set α} (hd : Directed
   replace hd : Directed (· ⊆ ·) t := ht ▸ hd.extend_bot Encodable.encode_injective
   suffices μ (⋃ n, t n) = ⨆ n, μ (t n) by
     simp only [← ht, Encodable.encode_injective.apply_extend μ, ← iSup_eq_iUnion,
-      iSup_extend_bot Encodable.encode_injective, (· ∘ ·), Pi.bot_apply, bot_eq_empty,
+      iSup_extend_bot Encodable.encode_injective, Function.comp_def, Pi.bot_apply, bot_eq_empty,
       measure_empty] at this
     exact this.trans (iSup_extend_bot Encodable.encode_injective _)
   clear! ι

--- a/Mathlib/ModelTheory/ElementaryMaps.lean
+++ b/Mathlib/ModelTheory/ElementaryMaps.lean
@@ -264,7 +264,7 @@ def ElementaryEmbedding.ofModelsElementaryDiagram (N : Type*) [L.Structure N] [L
                   (Constants.term ∘ Sum.inr ∘ x)).alls).trans
           _)
     · simp_rw [Sentence.Realize, BoundedFormula.realize_alls, BoundedFormula.realize_subst,
-        LHom.realize_onBoundedFormula, Formula.Realize, Unique.forall_iff, Function.comp,
+        LHom.realize_onBoundedFormula, Formula.Realize, Unique.forall_iff, Function.comp_def,
         Term.realize_constants]
     · simp_rw [Sentence.Realize, BoundedFormula.realize_alls, BoundedFormula.realize_subst,
         LHom.realize_onBoundedFormula, Formula.Realize, Unique.forall_iff]

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -917,12 +917,12 @@ theorem _root_.FirstOrder.Language.Formula.realize_iAlls
       ∀ (i : γ → M), φ.Realize (fun a => Sum.elim v i (f a)) := by
   let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin γ))
   rw [Formula.iAlls]
-  simp only [Nat.add_zero, realize_alls, realize_relabel, Function.comp,
+  simp only [Nat.add_zero, realize_alls, realize_relabel, Function.comp_def,
     castAdd_zero, castIso_refl, OrderIso.refl_apply, Sum.elim_map, id_eq]
   refine Equiv.forall_congr ?_ ?_
   · exact ⟨fun v => v ∘ e, fun v => v ∘ e.symm,
-      fun _ => by simp [Function.comp],
-      fun _ => by simp [Function.comp]⟩
+      fun _ => by simp [Function.comp_def],
+      fun _ => by simp [Function.comp_def]⟩
   · intro x
     rw [Formula.Realize, iff_iff_eq]
     congr
@@ -943,13 +943,13 @@ theorem _root_.FirstOrder.Language.Formula.realize_iExs
       ∃ (i : γ → M), φ.Realize (fun a => Sum.elim v i (f a)) := by
   let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin γ))
   rw [Formula.iExs]
-  simp only [Nat.add_zero, realize_exs, realize_relabel, Function.comp,
+  simp only [Nat.add_zero, realize_exs, realize_relabel, Function.comp_def,
     castAdd_zero, castIso_refl, OrderIso.refl_apply, Sum.elim_map, id_eq]
   rw [← not_iff_not, not_exists, not_exists]
   refine Equiv.forall_congr ?_ ?_
   · exact ⟨fun v => v ∘ e, fun v => v ∘ e.symm,
-      fun _ => by simp [Function.comp],
-      fun _ => by simp [Function.comp]⟩
+      fun _ => by simp [Function.comp_def],
+      fun _ => by simp [Function.comp_def]⟩
   · intro x
     rw [Formula.Realize, iff_iff_eq]
     congr
@@ -977,7 +977,7 @@ theorem realize_toFormula (φ : L.BoundedFormula α n) (v : Sum α (Fin n) → M
     have h := ih3 (Sum.elim (v ∘ Sum.inl) (snoc (v ∘ Sum.inr) a))
     simp only [Sum.elim_comp_inl, Sum.elim_comp_inr] at h
     rw [← h, realize_relabel, Formula.Realize, iff_iff_eq]
-    simp only [Function.comp]
+    simp only [Function.comp_def]
     congr with x
     · cases' x with _ x
       · simp

--- a/Mathlib/ModelTheory/Ultraproducts.lean
+++ b/Mathlib/ModelTheory/Ultraproducts.lean
@@ -132,7 +132,7 @@ theorem boundedFormula_realize_cast {β : Type*} {n : ℕ} (φ : L.BoundedFormul
       · simp only [Fin.snoc_last]
       · simp only [Fin.snoc_castSucc]
     simp only [← Fin.comp_snoc]
-    simp only [Function.comp, ih, h']
+    simp only [Function.comp_def, ih, h']
     refine' ⟨fun h => _, fun h m => _⟩
     · contrapose! h
       simp_rw [← Ultrafilter.eventually_not, not_forall] at h

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -372,7 +372,7 @@ theorem DiophList.forall (l : List (Set <| α → ℕ)) (d : l.Forall Dioph) :
             ⟨m ⊗ n, by
               rw [show (v ⊗ m ⊗ n) ∘ (inl ⊗ inr ∘ inl) = v ⊗ m from
                     funext fun s => by cases' s with a b <;> rfl]; exact hm, by
-              refine List.Forall.imp (fun q hq => ?_) hn; dsimp [(· ∘ ·)]
+              refine List.Forall.imp (fun q hq => ?_) hn; dsimp [Function.comp_def]
               rw [show
                     (fun x : Sum α γ => (v ⊗ m ⊗ n) ((inl ⊗ fun x : γ => inr (inr x)) x)) = v ⊗ n
                     from funext fun s => by cases' s with a b <;> rfl]; exact hq⟩,
@@ -381,7 +381,7 @@ theorem DiophList.forall (l : List (Set <| α → ℕ)) (d : l.Forall Dioph) :
                 rwa [show (v ⊗ t) ∘ (inl ⊗ inr ∘ inl) = v ⊗ t ∘ inl from
                     funext fun s => by cases' s with a b <;> rfl] at hl⟩,
               ⟨t ∘ inr, by
-                refine List.Forall.imp (fun q hq => ?_) hr; dsimp [(· ∘ ·)] at hq
+                refine List.Forall.imp (fun q hq => ?_) hr; dsimp [Function.comp_def] at hq
                 rwa [show
                     (fun x : Sum α γ => (v ⊗ t) ((inl ⊗ fun x : γ => inr (inr x)) x)) =
                       v ⊗ t ∘ inr

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -327,7 +327,7 @@ theorem inject_dummies_lem (f : β → γ) (g : γ → Option β) (inv : ∀ x, 
     (∃ t, p (v ⊗ t) = 0) ↔ ∃ t, p.map (inl ⊗ inr ∘ f) (v ⊗ t) = 0 := by
   dsimp; refine ⟨fun t => ?_, fun t => ?_⟩ <;> cases' t with t ht
   · have : (v ⊗ (0 ::ₒ t) ∘ g) ∘ (inl ⊗ inr ∘ f) = v ⊗ t :=
-      funext fun s => by cases' s with a b <;> dsimp [(· ∘ ·)]; try rw [inv]; rfl
+      funext fun s => by cases' s with a b <;> dsimp [Function.comp_def]; try rw [inv]; rfl
     exact ⟨(0 ::ₒ t) ∘ g, by rwa [this]⟩
   · have : v ⊗ t ∘ f = (v ⊗ t) ∘ (inl ⊗ inr ∘ f) := funext fun s => by cases' s with a b <;> rfl
     exact ⟨t ∘ f, by rwa [this]⟩

--- a/Mathlib/NumberTheory/Liouville/LiouvilleWith.lean
+++ b/Mathlib/NumberTheory/Liouville/LiouvilleWith.lean
@@ -98,7 +98,7 @@ theorem frequently_lt_rpow_neg (h : LiouvilleWith p x) (hlt : q < p) :
     ∃ᶠ n : ℕ in atTop, ∃ m : ℤ, x ≠ m / n ∧ |x - m / n| < n ^ (-q) := by
   rcases h.exists_pos with ⟨C, _hC₀, hC⟩
   have : ∀ᶠ n : ℕ in atTop, C < n ^ (p - q) := by
-    simpa only [(· ∘ ·), neg_sub, one_div] using
+    simpa only [Function.comp_def, neg_sub, one_div] using
       ((tendsto_rpow_atTop (sub_pos.2 hlt)).comp tendsto_nat_cast_atTop_atTop).eventually
         (eventually_gt_atTop C)
   refine (this.and_frequently hC).mono ?_

--- a/Mathlib/NumberTheory/RamificationInertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia.lean
@@ -281,7 +281,7 @@ theorem FinrankQuotientMap.linearIndependent_of_nontrivial [IsDomain R] [IsDedek
     rw [LinearMap.map_smul, ← IsScalarTower.algebraMap_smul K, hg' i hi, ← smul_assoc,
       smul_eq_mul, Function.comp_apply]
   simp only [IsScalarTower.algebraMap_smul, ← map_smul, ← map_sum,
-    (f.map_eq_zero_iff hf).mp eq, LinearMap.map_zero, (· ∘ ·)]
+    (f.map_eq_zero_iff hf).mp eq, LinearMap.map_zero, Function.comp_def]
 #align ideal.finrank_quotient_map.linear_independent_of_nontrivial Ideal.FinrankQuotientMap.linearIndependent_of_nontrivial
 
 open scoped Matrix

--- a/Mathlib/Order/Filter/AtTopBot.lean
+++ b/Mathlib/Order/Filter/AtTopBot.lean
@@ -961,14 +961,16 @@ variable [OrderedRing α] {l : Filter β} {f g : β → α}
 theorem Tendsto.atTop_mul_atBot (hf : Tendsto f l atTop) (hg : Tendsto g l atBot) :
     Tendsto (fun x => f x * g x) l atBot := by
   have := hf.atTop_mul_atTop <| tendsto_neg_atBot_atTop.comp hg
-  simpa only [Function.comp_def, neg_mul_eq_mul_neg, neg_neg] using tendsto_neg_atTop_atBot.comp this
+  simpa only [Function.comp_def, neg_mul_eq_mul_neg, neg_neg]
+    using tendsto_neg_atTop_atBot.comp this
 #align filter.tendsto.at_top_mul_at_bot Filter.Tendsto.atTop_mul_atBot
 
 theorem Tendsto.atBot_mul_atTop (hf : Tendsto f l atBot) (hg : Tendsto g l atTop) :
     Tendsto (fun x => f x * g x) l atBot := by
   have : Tendsto (fun x => -f x * g x) l atTop :=
     (tendsto_neg_atBot_atTop.comp hf).atTop_mul_atTop hg
-  simpa only [Function.comp_def, neg_mul_eq_neg_mul, neg_neg] using tendsto_neg_atTop_atBot.comp this
+  simpa only [Function.comp_def, neg_mul_eq_neg_mul, neg_neg]
+    using tendsto_neg_atTop_atBot.comp this
 #align filter.tendsto.at_bot_mul_at_top Filter.Tendsto.atBot_mul_atTop
 
 theorem Tendsto.atBot_mul_atBot (hf : Tendsto f l atBot) (hg : Tendsto g l atBot) :

--- a/Mathlib/Order/Filter/AtTopBot.lean
+++ b/Mathlib/Order/Filter/AtTopBot.lean
@@ -961,14 +961,14 @@ variable [OrderedRing α] {l : Filter β} {f g : β → α}
 theorem Tendsto.atTop_mul_atBot (hf : Tendsto f l atTop) (hg : Tendsto g l atBot) :
     Tendsto (fun x => f x * g x) l atBot := by
   have := hf.atTop_mul_atTop <| tendsto_neg_atBot_atTop.comp hg
-  simpa only [(· ∘ ·), neg_mul_eq_mul_neg, neg_neg] using tendsto_neg_atTop_atBot.comp this
+  simpa only [Function.comp_def, neg_mul_eq_mul_neg, neg_neg] using tendsto_neg_atTop_atBot.comp this
 #align filter.tendsto.at_top_mul_at_bot Filter.Tendsto.atTop_mul_atBot
 
 theorem Tendsto.atBot_mul_atTop (hf : Tendsto f l atBot) (hg : Tendsto g l atTop) :
     Tendsto (fun x => f x * g x) l atBot := by
   have : Tendsto (fun x => -f x * g x) l atTop :=
     (tendsto_neg_atBot_atTop.comp hf).atTop_mul_atTop hg
-  simpa only [(· ∘ ·), neg_mul_eq_neg_mul, neg_neg] using tendsto_neg_atTop_atBot.comp this
+  simpa only [Function.comp_def, neg_mul_eq_neg_mul, neg_neg] using tendsto_neg_atTop_atBot.comp this
 #align filter.tendsto.at_bot_mul_at_top Filter.Tendsto.atBot_mul_atTop
 
 theorem Tendsto.atBot_mul_atBot (hf : Tendsto f l atBot) (hg : Tendsto g l atBot) :
@@ -2067,7 +2067,7 @@ theorem Antitone.piecewise_eventually_eq_iInter {β : α → Type*} [Preorder ι
   classical
   convert ← (compl_anti.comp hs).piecewise_eventually_eq_iUnion g f a using 3
   · convert congr_fun (Set.piecewise_compl (s _) g f) a
-  · simp only [(· ∘ ·), ← compl_iInter, Set.piecewise_compl]
+  · simp only [Function.comp_def, ← compl_iInter, Set.piecewise_compl]
 
 /-- Let `g : γ → β` be an injective function and `f : β → α` be a function from the codomain of `g`
 to a commutative monoid. Suppose that `f x = 1` outside of the range of `g`. Then the filters

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -2164,7 +2164,7 @@ theorem map_const [NeBot f] {c : β} : (f.map fun _ => c) = pure c := by
 #align filter.map_const Filter.map_const
 
 theorem comap_comap {m : γ → β} {n : β → α} : comap m (comap n f) = comap (n ∘ m) f :=
-  Filter.coext fun s => by simp only [compl_mem_comap, image_image, (· ∘ ·)]
+  Filter.coext fun s => by simp only [compl_mem_comap, image_image, Function.comp_def]
 #align filter.comap_comap Filter.comap_comap
 
 section comm
@@ -3084,7 +3084,7 @@ theorem tendsto_comap_iff {f : α → β} {g : β → γ} {a : Filter α} {c : F
 theorem tendsto_comap'_iff {m : α → β} {f : Filter α} {g : Filter β} {i : γ → α} (h : range i ∈ f) :
     Tendsto (m ∘ i) (comap i f) g ↔ Tendsto m f g := by
   rw [Tendsto, ← map_compose]
-  simp only [(· ∘ ·), map_comap_of_mem h, Tendsto]
+  simp only [Function.comp_def, map_comap_of_mem h, Tendsto]
 #align filter.tendsto_comap'_iff Filter.tendsto_comap'_iff
 
 theorem Tendsto.of_tendsto_comp {f : α → β} {g : β → γ} {a : Filter α} {b : Filter β} {c : Filter γ}

--- a/Mathlib/Order/Filter/EventuallyConst.lean
+++ b/Mathlib/Order/Filter/EventuallyConst.lean
@@ -130,7 +130,7 @@ variable [One β] {s : Set α} {c : β}
 @[to_additive]
 lemma of_mulIndicator_const (h : EventuallyConst (s.mulIndicator fun _ ↦ c) l) (hc : c ≠ 1) :
     EventuallyConst s l := by
-  simpa [(· ∘ ·), hc, imp_false] using h.comp (· = c)
+  simpa [Function.comp_def, hc, imp_false] using h.comp (· = c)
 
 @[to_additive]
 theorem mulIndicator_const (h : EventuallyConst s l) (c : β) :

--- a/Mathlib/Order/Filter/Extr.lean
+++ b/Mathlib/Order/Filter/Extr.lean
@@ -425,7 +425,7 @@ theorem IsExtrOn.on_preimage (g : δ → α) {b : δ} (hf : IsExtrOn f s (g b)) 
 
 theorem IsMinOn.comp_mapsTo {t : Set δ} {g : δ → α} {b : δ} (hf : IsMinOn f s a) (hg : MapsTo g t s)
     (ha : g b = a) : IsMinOn (f ∘ g) t b := fun y hy => by
-  simpa only [ha, (· ∘ ·)] using hf (hg hy)
+  simpa only [ha, Function.comp_def] using hf (hg hy)
 #align is_min_on.comp_maps_to IsMinOn.comp_mapsTo
 
 theorem IsMaxOn.comp_mapsTo {t : Set δ} {g : δ → α} {b : δ} (hf : IsMaxOn f s a) (hg : MapsTo g t s)

--- a/Mathlib/Order/Filter/FilterProduct.lean
+++ b/Mathlib/Order/Filter/FilterProduct.lean
@@ -43,7 +43,7 @@ instance groupWithZero [GroupWithZero β] : GroupWithZero β* :=
       (φ.em fun y => f y = 0).elim (fun H => (hf <| coe_eq.2 H).elim) fun H =>
         H.mono fun x => mul_inv_cancel
     inv_zero := coe_eq.2 <| by
-       simp only [Function.comp, inv_zero]
+       simp only [Function.comp_def, inv_zero]
        exact EventuallyEq.refl _ fun _ => 0 }
 
 instance divisionSemiring [DivisionSemiring β] : DivisionSemiring β* where

--- a/Mathlib/Order/Filter/Lift.lean
+++ b/Mathlib/Order/Filter/Lift.lean
@@ -292,7 +292,8 @@ theorem lift'_cong (hh : ∀ s ∈ f, h₁ s = h₂ s) : f.lift' h₁ = f.lift' 
 theorem map_lift'_eq {m : β → γ} (hh : Monotone h) : map m (f.lift' h) = f.lift' (image m ∘ h) :=
   calc
     map m (f.lift' h) = f.lift (map m ∘ 𝓟 ∘ h) := map_lift_eq <| monotone_principal.comp hh
-    _ = f.lift' (image m ∘ h) := by simp only [comp, Filter.lift', map_principal]
+    _ = f.lift' (image m ∘ h) := by
+      simp only [comp_def, Filter.lift', map_principal]
 #align filter.map_lift'_eq Filter.map_lift'_eq
 
 theorem lift'_map_le {g : Set β → Set γ} {m : α → β} : (map m f).lift' g ≤ f.lift' (g ∘ image m) :=
@@ -305,7 +306,7 @@ theorem map_lift'_eq2 {g : Set β → Set γ} {m : α → β} (hg : Monotone g) 
 #align filter.map_lift'_eq2 Filter.map_lift'_eq2
 
 theorem comap_lift'_eq {m : γ → β} : comap m (f.lift' h) = f.lift' (preimage m ∘ h) := by
-  simp only [Filter.lift', comap_lift_eq, (· ∘ ·), comap_principal]
+  simp only [Filter.lift', comap_lift_eq, comp_def, comap_principal]
 #align filter.comap_lift'_eq Filter.comap_lift'_eq
 
 theorem comap_lift'_eq2 {m : β → α} {g : Set β → Set γ} (hg : Monotone g) :

--- a/Mathlib/Order/Filter/Lift.lean
+++ b/Mathlib/Order/Filter/Lift.lean
@@ -370,7 +370,8 @@ theorem lift_lift'_same_eq_lift' {g : Set α → Set α → Set β} (hg₁ : ∀
 
 theorem lift'_inf_principal_eq {h : Set α → Set β} {s : Set β} :
     f.lift' h ⊓ 𝓟 s = f.lift' fun t => h t ∩ s := by
-  simp only [Filter.lift', Filter.lift, Function.comp_def, ← inf_principal, iInf_subtype', ← iInf_inf]
+  simp only [Filter.lift', Filter.lift, Function.comp_def, ← inf_principal, iInf_subtype',
+    ← iInf_inf]
 #align filter.lift'_inf_principal_eq Filter.lift'_inf_principal_eq
 
 theorem lift'_neBot_iff (hh : Monotone h) : NeBot (f.lift' h) ↔ ∀ s ∈ f, (h s).Nonempty :=

--- a/Mathlib/Order/Filter/Lift.lean
+++ b/Mathlib/Order/Filter/Lift.lean
@@ -370,7 +370,7 @@ theorem lift_lift'_same_eq_lift' {g : Set α → Set α → Set β} (hg₁ : ∀
 
 theorem lift'_inf_principal_eq {h : Set α → Set β} {s : Set β} :
     f.lift' h ⊓ 𝓟 s = f.lift' fun t => h t ∩ s := by
-  simp only [Filter.lift', Filter.lift, (· ∘ ·), ← inf_principal, iInf_subtype', ← iInf_inf]
+  simp only [Filter.lift', Filter.lift, Function.comp_def, ← inf_principal, iInf_subtype', ← iInf_inf]
 #align filter.lift'_inf_principal_eq Filter.lift'_inf_principal_eq
 
 theorem lift'_neBot_iff (hh : Monotone h) : NeBot (f.lift' h) ↔ ∀ s ∈ f, (h s).Nonempty :=

--- a/Mathlib/Order/Filter/Pointwise.lean
+++ b/Mathlib/Order/Filter/Pointwise.lean
@@ -1316,7 +1316,7 @@ protected def mulAction [Monoid α] [MulAction α β] : MulAction (Filter α) (F
 @[to_additive "An additive action of an additive monoid on a type `β` gives an additive action on
  `Filter β`."]
 protected def mulActionFilter [Monoid α] [MulAction α β] : MulAction α (Filter β) where
-  mul_smul a b f := by simp only [← map_smul, map_map, Function.comp, ← mul_smul]
+  mul_smul a b f := by simp only [← map_smul, map_map, Function.comp_def, ← mul_smul]
   one_smul f := by simp only [← map_smul, one_smul, map_id']
 #align filter.mul_action_filter Filter.mulActionFilter
 #align filter.add_action_filter Filter.addActionFilter

--- a/Mathlib/Order/Filter/Prod.lean
+++ b/Mathlib/Order/Filter/Prod.lean
@@ -297,7 +297,7 @@ theorem eventually_swap_iff {p : α × β → Prop} :
 
 theorem prod_assoc (f : Filter α) (g : Filter β) (h : Filter γ) :
     map (Equiv.prodAssoc α β γ) ((f ×ˢ g) ×ˢ h) = f ×ˢ (g ×ˢ h) := by
-  simp_rw [← comap_equiv_symm, SProd.sprod, Filter.prod, comap_inf, comap_comap, inf_assoc, (· ∘ ·),
+  simp_rw [← comap_equiv_symm, SProd.sprod, Filter.prod, comap_inf, comap_comap, inf_assoc, Function.comp_def,
     Equiv.prodAssoc_symm_apply]
 #align filter.prod_assoc Filter.prod_assoc
 

--- a/Mathlib/Order/Filter/Prod.lean
+++ b/Mathlib/Order/Filter/Prod.lean
@@ -297,8 +297,8 @@ theorem eventually_swap_iff {p : α × β → Prop} :
 
 theorem prod_assoc (f : Filter α) (g : Filter β) (h : Filter γ) :
     map (Equiv.prodAssoc α β γ) ((f ×ˢ g) ×ˢ h) = f ×ˢ (g ×ˢ h) := by
-  simp_rw [← comap_equiv_symm, SProd.sprod, Filter.prod, comap_inf, comap_comap, inf_assoc, Function.comp_def,
-    Equiv.prodAssoc_symm_apply]
+  simp_rw [← comap_equiv_symm, SProd.sprod, Filter.prod, comap_inf, comap_comap, inf_assoc,
+    Function.comp_def, Equiv.prodAssoc_symm_apply]
 #align filter.prod_assoc Filter.prod_assoc
 
 theorem prod_assoc_symm (f : Filter α) (g : Filter β) (h : Filter γ) :

--- a/Mathlib/Order/Filter/Prod.lean
+++ b/Mathlib/Order/Filter/Prod.lean
@@ -238,11 +238,12 @@ theorem prod_mono_right (f : Filter α) {g₁ g₂ : Filter β} (hf : g₁ ≤ g
 theorem prod_comap_comap_eq.{u, v, w, x} {α₁ : Type u} {α₂ : Type v} {β₁ : Type w} {β₂ : Type x}
     {f₁ : Filter α₁} {f₂ : Filter α₂} {m₁ : β₁ → α₁} {m₂ : β₂ → α₂} :
     comap m₁ f₁ ×ˢ comap m₂ f₂ = comap (fun p : β₁ × β₂ => (m₁ p.1, m₂ p.2)) (f₁ ×ˢ f₂) := by
-  simp only [SProd.sprod, Filter.prod, comap_comap, comap_inf, (· ∘ ·)]
+  simp only [SProd.sprod, Filter.prod, comap_comap, comap_inf, Function.comp_def]
 #align filter.prod_comap_comap_eq Filter.prod_comap_comap_eq
 
 theorem prod_comm' : f ×ˢ g = comap Prod.swap (g ×ˢ f) := by
-  simp only [SProd.sprod, Filter.prod, comap_comap, (· ∘ ·), inf_comm, Prod.swap, comap_inf]
+  simp only [SProd.sprod, Filter.prod, comap_comap, Function.comp_def, inf_comm, Prod.swap,
+    comap_inf]
 #align filter.prod_comm' Filter.prod_comm'
 
 theorem prod_comm : f ×ˢ g = map (fun p : β × α => (p.2, p.1)) (g ×ˢ f) := by
@@ -455,7 +456,7 @@ theorem tendsto_prod_iff' {g' : Filter γ} {s : α → β × γ} :
     Tendsto s f (g ×ˢ g') ↔ Tendsto (fun n => (s n).1) f g ∧ Tendsto (fun n => (s n).2) f g' := by
   dsimp only [SProd.sprod]
   unfold Filter.prod
-  simp only [tendsto_inf, tendsto_comap_iff, (· ∘ ·)]
+  simp only [tendsto_inf, tendsto_comap_iff, Function.comp_def]
 #align filter.tendsto_prod_iff' Filter.tendsto_prod_iff'
 
 theorem le_prod {f : Filter (α × β)} {g : Filter α} {g' : Filter β} :

--- a/Mathlib/Order/Hom/CompleteLattice.lean
+++ b/Mathlib/Order/Hom/CompleteLattice.lean
@@ -126,7 +126,8 @@ export sInfHomClass (map_sInf)
 attribute [simp] map_sSup map_sInf
 
 @[simp] theorem map_iSup [SupSet α] [SupSet β] [sSupHomClass F α β] (f : F) (g : ι → α) :
-    f (⨆ i, g i) = ⨆ i, f (g i) := by simp [iSup, ← Set.range_comp, Function.comp]
+    f (⨆ i, g i) = ⨆ i, f (g i) := by
+  simp [iSup, ← Set.range_comp, Function.comp_def]
 #align map_supr map_iSup
 
 theorem map_iSup₂ [SupSet α] [SupSet β] [sSupHomClass F α β] (f : F) (g : ∀ i, κ i → α) :
@@ -134,7 +135,8 @@ theorem map_iSup₂ [SupSet α] [SupSet β] [sSupHomClass F α β] (f : F) (g : 
 #align map_supr₂ map_iSup₂
 
 @[simp] theorem map_iInf [InfSet α] [InfSet β] [sInfHomClass F α β] (f : F) (g : ι → α) :
-    f (⨅ i, g i) = ⨅ i, f (g i) := by simp [iInf, ← Set.range_comp, Function.comp]
+    f (⨅ i, g i) = ⨅ i, f (g i) := by
+  simp [iInf, ← Set.range_comp, Function.comp_def]
 #align map_infi map_iInf
 
 theorem map_iInf₂ [InfSet α] [InfSet β] [sInfHomClass F α β] (f : F) (g : ∀ i, κ i → α) :

--- a/Mathlib/Order/LiminfLimsup.lean
+++ b/Mathlib/Order/LiminfLimsup.lean
@@ -1144,12 +1144,12 @@ theorem liminf_sdiff [NeBot f] (a : α) : liminf u f \ a = liminf (fun b => u b 
 
 theorem sdiff_limsup [NeBot f] (a : α) : a \ limsup u f = liminf (fun b => a \ u b) f := by
   rw [← compl_inj_iff]
-  simp only [sdiff_eq, liminf_compl, (· ∘ ·), compl_inf, compl_compl, sup_limsup]
+  simp only [sdiff_eq, liminf_compl, comp_def, compl_inf, compl_compl, sup_limsup]
 #align filter.sdiff_limsup Filter.sdiff_limsup
 
 theorem sdiff_liminf (a : α) : a \ liminf u f = limsup (fun b => a \ u b) f := by
   rw [← compl_inj_iff]
-  simp only [sdiff_eq, limsup_compl, (· ∘ ·), compl_inf, compl_compl, sup_liminf]
+  simp only [sdiff_eq, limsup_compl, comp_def, compl_inf, compl_compl, sup_liminf]
 #align filter.sdiff_liminf Filter.sdiff_liminf
 
 end CompleteBooleanAlgebra

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -826,7 +826,7 @@ protected def ωSup (c : Chain (α →𝒄 β)) : α →𝒄 β :=
     apply eq_of_forall_ge_iff; intro z
     simp only [ωSup_le_iff, (c _).continuous, Chain.map_coe, OrderHom.apply_coe, toMono_coe,
       OrderHom.omegaCompletePartialOrder_ωSup_coe, forall_forall_merge, OrderHomClass.coe_coe,
-      forall_forall_merge', (· ∘ ·), Function.eval]
+      forall_forall_merge', Function.comp_def, Function.eval]
 #align omega_complete_partial_order.continuous_hom.ωSup OmegaCompletePartialOrder.ContinuousHom.ωSup
 #align omega_complete_partial_order.continuous_hom.ωSup_apply OmegaCompletePartialOrder.ContinuousHom.ωSup_apply
 

--- a/Mathlib/Order/SemiconjSup.lean
+++ b/Mathlib/Order/SemiconjSup.lean
@@ -104,7 +104,7 @@ theorem semiconj_of_isLUB [PartialOrder α] [Group G] (f₁ f₂ : G →* α ≃
   refine' fun y => (H _).unique _
   have := (f₁ g).leftOrdContinuous (H y)
   rw [← range_comp, ← (Equiv.mulRight g).surjective.range_comp _] at this
-  simpa [(· ∘ ·)] using this
+  simpa [Function.comp_def] using this
 #align function.semiconj_of_is_lub Function.semiconj_of_isLUB
 
 /-- Consider two actions `f₁ f₂ : G → α → α` of a group on a complete lattice by order

--- a/Mathlib/Order/SuccPred/IntervalSucc.lean
+++ b/Mathlib/Order/SuccPred/IntervalSucc.lean
@@ -76,21 +76,21 @@ theorem pairwise_disjoint_on_Ioo_succ [SuccOrder α] [Preorder β] {f : α → �
 the intervals `Set.Ioc (f Order.pred n) (f n)` are pairwise disjoint. -/
 theorem pairwise_disjoint_on_Ioc_pred [PredOrder α] [Preorder β] {f : α → β} (hf : Monotone f) :
     Pairwise (Disjoint on fun n => Ioc (f (pred n)) (f n)) := by
-  simpa only [(· ∘ ·), dual_Ico] using hf.dual.pairwise_disjoint_on_Ico_succ
+  simpa only [Function.comp_def, dual_Ico] using hf.dual.pairwise_disjoint_on_Ico_succ
 #align monotone.pairwise_disjoint_on_Ioc_pred Monotone.pairwise_disjoint_on_Ioc_pred
 
 /-- If `α` is a linear pred order, `β` is a preorder, and `f : α → β` is a monotone function, then
 the intervals `Set.Ico (f Order.pred n) (f n)` are pairwise disjoint. -/
 theorem pairwise_disjoint_on_Ico_pred [PredOrder α] [Preorder β] {f : α → β} (hf : Monotone f) :
     Pairwise (Disjoint on fun n => Ico (f (pred n)) (f n)) := by
-  simpa only [(· ∘ ·), dual_Ioc] using hf.dual.pairwise_disjoint_on_Ioc_succ
+  simpa only [Function.comp_def, dual_Ioc] using hf.dual.pairwise_disjoint_on_Ioc_succ
 #align monotone.pairwise_disjoint_on_Ico_pred Monotone.pairwise_disjoint_on_Ico_pred
 
 /-- If `α` is a linear pred order, `β` is a preorder, and `f : α → β` is a monotone function, then
 the intervals `Set.Ioo (f Order.pred n) (f n)` are pairwise disjoint. -/
 theorem pairwise_disjoint_on_Ioo_pred [PredOrder α] [Preorder β] {f : α → β} (hf : Monotone f) :
     Pairwise (Disjoint on fun n => Ioo (f (pred n)) (f n)) := by
-  simpa only [(· ∘ ·), dual_Ioo] using hf.dual.pairwise_disjoint_on_Ioo_succ
+  simpa only [Function.comp_def, dual_Ioo] using hf.dual.pairwise_disjoint_on_Ioo_succ
 #align monotone.pairwise_disjoint_on_Ioo_pred Monotone.pairwise_disjoint_on_Ioo_pred
 
 end Monotone

--- a/Mathlib/Probability/Kernel/IntegralCompProd.lean
+++ b/Mathlib/Probability/Kernel/IntegralCompProd.lean
@@ -247,7 +247,7 @@ theorem integral_compProd :
       ∫ z, f z ∂(κ ⊗ₖ η) a = ∫ x, ∫ y, f (x, y) ∂η (a, x) ∂κ a := by
   apply Integrable.induction
   · intro c s hs h2s
-    simp_rw [integral_indicator hs, ← indicator_comp_right, Function.comp,
+    simp_rw [integral_indicator hs, ← indicator_comp_right, Function.comp_def,
       integral_indicator (measurable_prod_mk_left hs), MeasureTheory.set_integral_const,
       integral_smul_const]
     congr 1

--- a/Mathlib/Probability/ProbabilityMassFunction/Constructions.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Constructions.lean
@@ -66,7 +66,7 @@ theorem map_id : map id p = p :=
   bind_pure _
 #align pmf.map_id PMF.map_id
 
-theorem map_comp (g : β → γ) : (p.map f).map g = p.map (g ∘ f) := by simp [map, Function.comp]
+theorem map_comp (g : β → γ) : (p.map f).map g = p.map (g ∘ f) := by simp [map, Function.comp_def]
 #align pmf.map_comp PMF.map_comp
 
 theorem pure_map (a : α) : (pure a).map f = pure (f a) :=
@@ -84,7 +84,7 @@ theorem bind_map (p : PMF α) (f : α → β) (q : β → PMF γ) : (p.map f).bi
 
 @[simp]
 theorem map_const : p.map (Function.const α b) = pure b := by
-  simp only [map, Function.comp, bind_const, Function.const]
+  simp only [map, Function.comp_def, bind_const, Function.const]
 #align pmf.map_const PMF.map_const
 
 section Measure

--- a/Mathlib/RingTheory/AlgebraicIndependent.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent.lean
@@ -105,7 +105,7 @@ namespace AlgebraicIndependent
 variable (hx : AlgebraicIndependent R x)
 
 theorem algebraMap_injective : Injective (algebraMap R A) := by
-  simpa [← MvPolynomial.algebraMap_eq, Function.comp] using
+  simpa [← MvPolynomial.algebraMap_eq, Function.comp_def] using
     (Injective.of_comp_iff (algebraicIndependent_iff_injective_aeval.1 hx) MvPolynomial.C).2
       (MvPolynomial.C_injective _ _)
 #align algebraic_independent.algebra_map_injective AlgebraicIndependent.algebraMap_injective
@@ -146,7 +146,7 @@ theorem map {f : A →ₐ[R] A'} (hf_inj : Set.InjOn f (adjoin R (range x))) :
     intro p
     rw [AlgHom.mem_range]
     refine' ⟨MvPolynomial.rename (codRestrict x (range x) mem_range_self) p, _⟩
-    simp [Function.comp, aeval_rename]
+    simp [Function.comp_def, aeval_rename]
   intro x y hxy
   rw [this] at hxy
   rw [adjoin_eq_range] at hf_inj

--- a/Mathlib/RingTheory/MvPolynomial/Tower.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Tower.lean
@@ -55,7 +55,7 @@ theorem aeval_algebraMap_apply (x : σ → A) (p : MvPolynomial σ R) :
   rw [aeval_def, aeval_def, ← coe_eval₂Hom, ← coe_eval₂Hom, map_eval₂Hom, ←
     IsScalarTower.algebraMap_eq]
   -- Porting note: added
-  simp only [Function.comp]
+  simp only [Function.comp_def]
 #align mv_polynomial.aeval_algebra_map_apply MvPolynomial.aeval_algebraMap_apply
 
 theorem aeval_algebraMap_eq_zero_iff [NoZeroSMulDivisors A B] [Nontrivial B] (x : σ → A)

--- a/Mathlib/RingTheory/WittVector/IsPoly.lean
+++ b/Mathlib/RingTheory/WittVector/IsPoly.lean
@@ -118,7 +118,7 @@ theorem poly_eq_of_wittPolynomial_bind_eq' [Fact p.Prime] (f g : ℕ → MvPolyn
   rw [← Function.funext_iff] at h
   replace h :=
     congr_arg (fun fam => bind₁ (MvPolynomial.map (Int.castRingHom ℚ) ∘ fam) (xInTermsOfW p ℚ n)) h
-  simpa only [Function.comp, map_bind₁, map_wittPolynomial, ← bind₁_bind₁,
+  simpa only [Function.comp_def, map_bind₁, map_wittPolynomial, ← bind₁_bind₁,
     bind₁_wittPolynomial_xInTermsOfW, bind₁_X_right] using h
 #align witt_vector.poly_eq_of_witt_polynomial_bind_eq' WittVector.poly_eq_of_wittPolynomial_bind_eq'
 
@@ -129,7 +129,7 @@ theorem poly_eq_of_wittPolynomial_bind_eq [Fact p.Prime] (f g : ℕ → MvPolyno
   rw [← Function.funext_iff] at h
   replace h :=
     congr_arg (fun fam => bind₁ (MvPolynomial.map (Int.castRingHom ℚ) ∘ fam) (xInTermsOfW p ℚ n)) h
-  simpa only [Function.comp, map_bind₁, map_wittPolynomial, ← bind₁_bind₁,
+  simpa only [Function.comp_def, map_bind₁, map_wittPolynomial, ← bind₁_bind₁,
     bind₁_wittPolynomial_xInTermsOfW, bind₁_X_right] using h
 #align witt_vector.poly_eq_of_witt_polynomial_bind_eq WittVector.poly_eq_of_wittPolynomial_bind_eq
 
@@ -250,7 +250,8 @@ instance IsPoly₂.comp {h f g} [hh : IsPoly₂ p h] [hf : IsPoly p f] [hg : IsP
     <;>
     open Matrix in
     simp only [algebraMap_int_eq, coe_eval₂Hom, Fin.mk_zero, Fin.mk_one, cons_val', empty_val',
-      cons_val_fin_one, cons_val_zero, cons_val_one, eval₂Hom_rename, Function.comp, head_fin_const]
+      cons_val_fin_one, cons_val_zero, cons_val_one, eval₂Hom_rename, Function.comp_def,
+      head_fin_const]
 
 #align witt_vector.is_poly₂.comp WittVector.IsPoly₂.comp
 

--- a/Mathlib/RingTheory/WittVector/MulP.lean
+++ b/Mathlib/RingTheory/WittVector/MulP.lean
@@ -77,7 +77,7 @@ theorem bind₁_wittMulN_wittPolynomial (n k : ℕ) :
   · rw [wittMulN, ← bind₁_bind₁, wittAdd, wittStructureInt_prop]
     simp only [AlgHom.map_add, Nat.cast_succ, bind₁_X_right]
     rw [add_mul, one_mul, bind₁_rename, bind₁_rename]
-    simp only [ih, Function.uncurry, Function.comp, bind₁_X_left, AlgHom.id_apply,
+    simp only [ih, Function.uncurry, Function.comp_def, bind₁_X_left, AlgHom.id_apply,
       Matrix.cons_val_zero, Matrix.head_cons, Matrix.cons_val_one]
 #align witt_vector.bind₁_witt_mul_n_witt_polynomial WittVector.bind₁_wittMulN_wittPolynomial
 

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -1193,7 +1193,7 @@ theorem lift_sSup {s : Set Cardinal} (hs : BddAbove s) :
 theorem lift_iSup {ι : Type v} {f : ι → Cardinal.{w}} (hf : BddAbove (range f)) :
     lift.{u} (iSup f) = ⨆ i, lift.{u} (f i) := by
   rw [iSup, iSup, lift_sSup hf, ← range_comp]
-  simp [Function.comp]
+  simp [Function.comp_def]
 #align cardinal.lift_supr Cardinal.lift_iSup
 
 /-- To prove that the lift of a supremum is bounded by some cardinal `t`,

--- a/Mathlib/Testing/SlimCheck/Functions.lean
+++ b/Mathlib/Testing/SlimCheck/Functions.lean
@@ -356,7 +356,7 @@ theorem applyId_mem_iff [DecidableEq α] {xs ys : List α} (h₀ : List.Nodup xs
         simp only [Prod.toSigma, List.mem_map, heq_iff_eq, Prod.exists] at h₃
         rcases h₃ with ⟨a, b, h₃, h₄, h₅⟩
         apply (List.mem_zip h₃).2
-        simp only [List.NodupKeys, List.keys, comp, Prod.fst_toSigma, List.map_map]
+        simp only [List.NodupKeys, List.keys, comp_def, Prod.fst_toSigma, List.map_map]
         rwa [List.map_fst_zip _ _ (le_of_eq h₆)]
 #align slim_check.injective_function.apply_id_mem_iff SlimCheck.InjectiveFunction.applyId_mem_iff
 
@@ -457,9 +457,9 @@ protected def shrink {α : Type} [DecidableEq α] :
     have h₄ : ys'.length ≤ xs'.length := le_of_eq (List.Perm.length_eq h₀.symm)
     pure
       ⟨(List.zip xs' ys').map Prod.toSigma,
-        by simp only [comp, List.map_fst_zip, List.map_snd_zip, *, Prod.fst_toSigma,
+        by simp only [comp_def, List.map_fst_zip, List.map_snd_zip, *, Prod.fst_toSigma,
           Prod.snd_toSigma, List.map_map],
-        by simp only [comp, List.map_snd_zip, *, Prod.snd_toSigma, List.map_map]⟩
+        by simp only [comp_def, List.map_snd_zip, *, Prod.snd_toSigma, List.map_map]⟩
 #align slim_check.injective_function.shrink SlimCheck.InjectiveFunction.shrink
 
 /-- Create an injective function from one list and a permutation of that list. -/
@@ -468,9 +468,9 @@ protected def mk (xs ys : List α) (h : xs ~ ys) (h' : ys.Nodup) : InjectiveFunc
   have h₁ : ys.length ≤ xs.length := le_of_eq h.length_eq.symm
   InjectiveFunction.mapToSelf (List.toFinmap' (xs.zip ys))
     (by
-      simp only [List.toFinmap', comp, List.map_fst_zip, List.map_snd_zip, *, Prod.fst_toSigma,
+      simp only [List.toFinmap', comp_def, List.map_fst_zip, List.map_snd_zip, *, Prod.fst_toSigma,
         Prod.snd_toSigma, List.map_map])
-    (by simp only [List.toFinmap', comp, List.map_snd_zip, *, Prod.snd_toSigma, List.map_map])
+    (by simp only [List.toFinmap', comp_def, List.map_snd_zip, *, Prod.snd_toSigma, List.map_map])
 #align slim_check.injective_function.mk SlimCheck.InjectiveFunction.mk
 
 protected theorem injective [DecidableEq α] (f : InjectiveFunction α) : Injective (apply f) := by

--- a/Mathlib/Topology/Algebra/Constructions.lean
+++ b/Mathlib/Topology/Algebra/Constructions.lean
@@ -168,7 +168,7 @@ theorem continuous_val : Continuous ((↑) : Mˣ → M) :=
 @[to_additive]
 protected theorem continuous_iff {f : X → Mˣ} :
     Continuous f ↔ Continuous (val ∘ f) ∧ Continuous (fun x => ↑(f x)⁻¹ : X → M) := by
-  simp only [inducing_embedProduct.continuous_iff, embedProduct_apply, (· ∘ ·),
+  simp only [inducing_embedProduct.continuous_iff, embedProduct_apply, Function.comp_def,
     continuous_prod_mk, opHomeomorph.symm.inducing.continuous_iff, opHomeomorph_symm_apply,
     unop_op]
 #align units.continuous_iff Units.continuous_iff

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -407,7 +407,7 @@ end LatticeOps
 theorem Inducing.continuousInv {G H : Type*} [Inv G] [Inv H] [TopologicalSpace G]
     [TopologicalSpace H] [ContinuousInv H] {f : G → H} (hf : Inducing f)
     (hf_inv : ∀ x, f x⁻¹ = (f x)⁻¹) : ContinuousInv G :=
-  ⟨hf.continuous_iff.2 <| by simpa only [(· ∘ ·), hf_inv] using hf.continuous.inv⟩
+  ⟨hf.continuous_iff.2 <| by simpa only [Function.comp_def, hf_inv] using hf.continuous.inv⟩
 #align inducing.has_continuous_inv Inducing.continuousInv
 #align inducing.has_continuous_neg Inducing.continuousNeg
 
@@ -870,8 +870,8 @@ theorem continuous_of_continuousAt_one {M hom : Type*} [MulOneClass M] [Topologi
     [ContinuousMul M] [MonoidHomClass hom G M] (f : hom) (hf : ContinuousAt f 1) :
     Continuous f :=
   continuous_iff_continuousAt.2 fun x => by
-    simpa only [ContinuousAt, ← map_mul_left_nhds_one x, tendsto_map'_iff, (· ∘ ·), map_mul,
-      map_one, mul_one] using hf.tendsto.const_mul (f x)
+    simpa only [ContinuousAt, ← map_mul_left_nhds_one x, tendsto_map'_iff, Function.comp_def,
+      map_mul, map_one, mul_one] using hf.tendsto.const_mul (f x)
 #align continuous_of_continuous_at_one continuous_of_continuousAt_one
 #align continuous_of_continuous_at_zero continuous_of_continuousAt_zero
 
@@ -883,7 +883,7 @@ theorem continuous_of_continuousAt_one₂ {H M : Type*} [CommMonoid M] [Topologi
     (hl : ∀ x, ContinuousAt (f x) 1) (hr : ∀ y, ContinuousAt (fun x => f x y) 1) :
     Continuous (fun x : G × H ↦ f x.1 x.2) := continuous_iff_continuousAt.2 fun (x, y) => by
   simp only [ContinuousAt, nhds_prod_eq, ← map_mul_left_nhds_one x, ← map_mul_left_nhds_one y,
-    prod_map_map_eq, tendsto_map'_iff, (· ∘ ·), map_mul, MonoidHom.mul_apply] at *
+    prod_map_map_eq, tendsto_map'_iff, Function.comp_def, map_mul, MonoidHom.mul_apply] at *
   refine ((tendsto_const_nhds.mul ((hr y).comp tendsto_fst)).mul
     (((hl x).comp tendsto_snd).mul hf)).mono_right (le_of_eq ?_)
   simp only [map_one, mul_one, MonoidHom.one_apply]
@@ -913,8 +913,8 @@ theorem ContinuousInv.of_nhds_one {G : Type*} [Group G] [TopologicalSpace G]
   refine' ⟨continuous_iff_continuousAt.2 fun x₀ => _⟩
   have : Tendsto (fun x => x₀⁻¹ * (x₀ * x⁻¹ * x₀⁻¹)) (𝓝 1) (map ((· * ·) x₀⁻¹) (𝓝 1)) :=
     (tendsto_map.comp <| hconj x₀).comp hinv
-  simpa only [ContinuousAt, hleft x₀, hleft x₀⁻¹, tendsto_map'_iff, (· ∘ ·), mul_assoc, mul_inv_rev,
-    inv_mul_cancel_left] using this
+  simpa only [ContinuousAt, hleft x₀, hleft x₀⁻¹, tendsto_map'_iff, Function.comp_def, mul_assoc,
+    mul_inv_rev, inv_mul_cancel_left] using this
 #align has_continuous_inv.of_nhds_one ContinuousInv.of_nhds_one
 #align has_continuous_neg.of_nhds_zero ContinuousNeg.of_nhds_zero
 
@@ -946,7 +946,7 @@ theorem TopologicalGroup.of_nhds_one {G : Type u} [Group G] [TopologicalSpace G]
   · exact fun x₀ =>
       map_eq_of_inverse (fun x => x₀⁻¹ * x * x₀⁻¹⁻¹) (by ext; simp [mul_assoc]) (hconj _) (hconj _)
   rw [← hconj x₀]
-  simpa [(· ∘ ·)] using hleft _
+  simpa [Function.comp_def] using hleft _
 #align topological_group.of_nhds_one TopologicalGroup.of_nhds_one
 #align topological_add_group.of_nhds_zero TopologicalAddGroup.of_nhds_zero
 

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -931,7 +931,7 @@ theorem TopologicalGroup.of_nhds_one' {G : Type u} [Group G] [TopologicalSpace G
           (by
             rw [show (fun x => x₀ * x * x₀⁻¹) = (fun x => x * x₀⁻¹) ∘ fun x => x₀ * x from rfl, ←
               map_map, ← hleft, hright, map_map]
-            simp [(· ∘ ·)]) }
+            simp [Function.comp_def]) }
 #align topological_group.of_nhds_one' TopologicalGroup.of_nhds_one'
 #align topological_add_group.of_nhds_zero' TopologicalAddGroup.of_nhds_zero'
 

--- a/Mathlib/Topology/Algebra/GroupWithZero.lean
+++ b/Mathlib/Topology/Algebra/GroupWithZero.lean
@@ -316,7 +316,7 @@ theorem HasContinuousInv₀.of_nhds_one (h : Tendsto Inv.inv (𝓝 (1 : G₀)) (
     have hx' := inv_ne_zero hx
     rw [ContinuousAt, ← map_mul_left_nhds_one₀ hx, ← nhds_translation_mul_inv₀ hx',
       tendsto_map'_iff, tendsto_comap_iff]
-    simpa only [(· ∘ ·), mul_inv_rev, mul_inv_cancel_right₀ hx']
+    simpa only [Function.comp_def, mul_inv_rev, mul_inv_cancel_right₀ hx']
 
 end map_comap
 

--- a/Mathlib/Topology/Algebra/GroupWithZero.lean
+++ b/Mathlib/Topology/Algebra/GroupWithZero.lean
@@ -156,7 +156,7 @@ lemma nhds_inv₀ (hx : x ≠ 0) : 𝓝 x⁻¹ = (𝓝 x)⁻¹ := by
 
 lemma tendsto_inv_iff₀ {l : Filter α} {f : α → G₀} (hx : x ≠ 0) :
     Tendsto (fun x ↦ (f x)⁻¹) l (𝓝 x⁻¹) ↔ Tendsto f l (𝓝 x) := by
-  simp only [nhds_inv₀ hx, ← Filter.comap_inv, tendsto_comap_iff, (· ∘ ·), inv_inv]
+  simp only [nhds_inv₀ hx, ← Filter.comap_inv, tendsto_comap_iff, Function.comp_def, inv_inv]
 
 end NhdsInv
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -386,7 +386,7 @@ theorem HasSum.even_add_odd {f : ℕ → α} (he : HasSum (fun k => f (2 * k)) a
   replace he := this.hasSum_range_iff.2 he
   replace ho := ((add_left_injective 1).comp this).hasSum_range_iff.2 ho
   refine' he.add_isCompl _ ho
-  simpa [(· ∘ ·)] using Nat.isCompl_even_odd
+  simpa [Function.comp_def] using Nat.isCompl_even_odd
 #align has_sum.even_add_odd HasSum.even_add_odd
 
 theorem Summable.compl_add {s : Set β} (hs : Summable (f ∘ (↑) : (sᶜ : Set β) → α))
@@ -1108,7 +1108,7 @@ theorem cauchySeq_finset_iff_vanishing :
       ∀ e ∈ 𝓝 (0 : α), ∃ s : Finset β, ∀ t, Disjoint t s → (∑ b in t, f b) ∈ e := by
   classical
   simp_rw [CauchySeq, cauchy_map_iff, and_iff_right atTop_neBot, prod_atTop_atTop_eq,
-    uniformity_eq_comap_nhds_zero α, tendsto_comap_iff, (· ∘ ·), tendsto_atTop']
+    uniformity_eq_comap_nhds_zero α, tendsto_comap_iff, Function.comp_def, tendsto_atTop']
   constructor
   · intro h e he
     obtain ⟨⟨s₁, s₂⟩, h⟩ := h e he

--- a/Mathlib/Topology/Algebra/Module/Alternating.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating.lean
@@ -337,8 +337,8 @@ def _root_.ContinuousLinearEquiv.compContinuousAlternatingMap (e : N ≃L[R] N')
     M [Λ^ι]→L[R] N ≃ M [Λ^ι]→L[R] N' where
   toFun := (e : N →L[R] N').compContinuousAlternatingMap
   invFun := (e.symm : N' →L[R] N).compContinuousAlternatingMap
-  left_inv f := by ext; simp [(· ∘ ·)]
-  right_inv f := by ext; simp [(· ∘ ·)]
+  left_inv f := by ext; simp [Function.comp_def]
+  right_inv f := by ext; simp [Function.comp_def]
 
 @[simp]
 theorem _root_.ContinuousLinearEquiv.compContinuousAlternatingMap_coe

--- a/Mathlib/Topology/Algebra/Module/Alternating.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating.lean
@@ -328,8 +328,8 @@ def _root_.ContinuousLinearEquiv.continuousAlternatingMapComp (e : M ≃L[R] M')
     M [Λ^ι]→L[R] N ≃ M' [Λ^ι]→L[R] N where
   toFun f := f.compContinuousLinearMap ↑e.symm
   invFun f := f.compContinuousLinearMap ↑e
-  left_inv f := by ext; simp [(· ∘ ·)]
-  right_inv f := by ext; simp [(· ∘ ·)]
+  left_inv f := by ext; simp [Function.comp_def]
+  right_inv f := by ext; simp [Function.comp_def]
 
 /-- A continuous linear equivalence of codomains defines an equivalence between continuous
 alternating maps. -/
@@ -605,12 +605,12 @@ def alternatization : ContinuousMultilinearMap R (fun _ : ι => M) N →+ M [Λ^
 
 theorem alternatization_apply_apply (v : ι → M) :
     alternatization f v = ∑ σ : Equiv.Perm ι, Equiv.Perm.sign σ • f (v ∘ σ) := by
-  simp [alternatization, (· ∘ ·)]
+  simp [alternatization, Function.comp_def]
 
 @[simp]
 theorem alternatization_apply_toAlternatingMap :
     (alternatization f).toAlternatingMap = MultilinearMap.alternatization f.1 := by
   ext v
-  simp [alternatization_apply_apply, MultilinearMap.alternatization_apply, (· ∘ ·)]
+  simp [alternatization_apply_apply, MultilinearMap.alternatization_apply, Function.comp_def]
 
 end ContinuousMultilinearMap

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -105,7 +105,7 @@ variable {ι R M₁ M₂ : Type*} [Semiring R] [AddCommMonoid M₁] [AddCommMono
 theorem continuousSMul_induced : @ContinuousSMul R M₁ _ u (t.induced f) := by
   let _ : TopologicalSpace M₁ := t.induced f
   refine' ⟨continuous_induced_rng.2 _⟩
-  simp_rw [Function.comp, f.map_smul]
+  simp_rw [Function.comp_def, f.map_smul]
   exact continuous_fst.smul (continuous_induced_dom.comp continuous_snd)
 #align has_continuous_smul_induced continuousSMul_induced
 

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -376,7 +376,7 @@ theorem Inducing.continuousMul {M N F : Type*} [Mul M] [Mul N] [MulHomClass F M 
     [TopologicalSpace M] [TopologicalSpace N] [ContinuousMul N] (f : F) (hf : Inducing f) :
     ContinuousMul M :=
   ⟨hf.continuous_iff.2 <| by
-      simpa only [(· ∘ ·), map_mul f] using hf.continuous.fst'.mul hf.continuous.snd'⟩
+      simpa only [Function.comp_def, map_mul f] using hf.continuous.fst'.mul hf.continuous.snd'⟩
 #align inducing.has_continuous_mul Inducing.continuousMul
 #align inducing.has_continuous_add Inducing.continuousAdd
 

--- a/Mathlib/Topology/Algebra/Order/Field.lean
+++ b/Mathlib/Topology/Algebra/Order/Field.lean
@@ -78,7 +78,8 @@ tends to a negative constant `C` then `f * g` tends to `Filter.atBot`. -/
 theorem Filter.Tendsto.atTop_mul_neg {C : 𝕜} (hC : C < 0) (hf : Tendsto f l atTop)
     (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atBot := by
   have := hf.atTop_mul (neg_pos.2 hC) hg.neg
-  simpa only [(· ∘ ·), neg_mul_eq_mul_neg, neg_neg] using tendsto_neg_atTop_atBot.comp this
+  simpa only [Function.comp_def, neg_mul_eq_mul_neg, neg_neg] using
+    tendsto_neg_atTop_atBot.comp this
 #align filter.tendsto.at_top_mul_neg Filter.Tendsto.atTop_mul_neg
 
 /-- In a linearly ordered field with the order topology, if `f` tends to a negative constant `C` and
@@ -93,7 +94,7 @@ tends to a positive constant `C` then `f * g` tends to `Filter.atBot`. -/
 theorem Filter.Tendsto.atBot_mul {C : 𝕜} (hC : 0 < C) (hf : Tendsto f l atBot)
     (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atBot := by
   have := (tendsto_neg_atBot_atTop.comp hf).atTop_mul hC hg
-  simpa [(· ∘ ·)] using tendsto_neg_atTop_atBot.comp this
+  simpa [Function.comp_def] using tendsto_neg_atTop_atBot.comp this
 #align filter.tendsto.at_bot_mul Filter.Tendsto.atBot_mul
 
 /-- In a linearly ordered field with the order topology, if `f` tends to `Filter.atBot` and `g`
@@ -101,7 +102,7 @@ tends to a negative constant `C` then `f * g` tends to `Filter.atTop`. -/
 theorem Filter.Tendsto.atBot_mul_neg {C : 𝕜} (hC : C < 0) (hf : Tendsto f l atBot)
     (hg : Tendsto g l (𝓝 C)) : Tendsto (fun x => f x * g x) l atTop := by
   have := (tendsto_neg_atBot_atTop.comp hf).atTop_mul_neg hC hg
-  simpa [(· ∘ ·)] using tendsto_neg_atBot_atTop.comp this
+  simpa [Function.comp_def] using tendsto_neg_atBot_atTop.comp this
 #align filter.tendsto.at_bot_mul_neg Filter.Tendsto.atBot_mul_neg
 
 /-- In a linearly ordered field with the order topology, if `f` tends to a positive constant `C` and

--- a/Mathlib/Topology/Algebra/UniformGroup.lean
+++ b/Mathlib/Topology/Algebra/UniformGroup.lean
@@ -169,7 +169,7 @@ theorem uniformity_translate_mul (a : α) : ((𝓤 α).map fun x : α × α => (
       𝓤 α =
           ((𝓤 α).map fun x : α × α => (x.1 * a⁻¹, x.2 * a⁻¹)).map fun x : α × α =>
             (x.1 * a, x.2 * a) :=
-        by simp [Filter.map_map, (· ∘ ·)]
+        by simp [Filter.map_map, Function.comp_def]
       _ ≤ (𝓤 α).map fun x : α × α => (x.1 * a, x.2 * a) :=
         Filter.map_mono (uniformContinuous_id.mul uniformContinuous_const)
       )
@@ -245,7 +245,7 @@ theorem uniformGroup_comap {γ : Type*} [Group γ] {u : UniformSpace γ} [Unifor
     [MonoidHomClass F β γ] (f : F) : @UniformGroup β (u.comap f) _ :=
   letI : UniformSpace β := u.comap f
   ⟨uniformContinuous_comap' <| by
-    simp_rw [Function.comp, map_div]
+    simp_rw [Function.comp_def, map_div]
     exact uniformContinuous_div.comp (uniformContinuous_comap.prod_map uniformContinuous_comap)⟩
 #align uniform_group_comap uniformGroup_comap
 #align uniform_add_group_comap uniformAddGroup_comap
@@ -315,7 +315,7 @@ theorem uniformity_eq_comap_inv_mul_nhds_one :
     𝓤 α = comap (fun x : α × α => x.1⁻¹ * x.2) (𝓝 (1 : α)) := by
   rw [← comap_uniformity_mulOpposite, uniformity_eq_comap_nhds_one, ← op_one, ← comap_unop_nhds,
     comap_comap, comap_comap]
-  simp [(· ∘ ·)]
+  simp [Function.comp_def]
 #align uniformity_eq_comap_inv_mul_nhds_one uniformity_eq_comap_inv_mul_nhds_one
 #align uniformity_eq_comap_neg_add_nhds_zero uniformity_eq_comap_neg_add_nhds_zero
 
@@ -564,7 +564,8 @@ def TopologicalGroup.toUniformSpace : UniformSpace G where
     rintro ⟨x, y⟩ ⟨z, hz₁, hz₂⟩
     simpa using V_mul _ hz₂ _ hz₁
   isOpen_uniformity S := by
-    simp only [isOpen_iff_mem_nhds, ← mem_comap_prod_mk, comap_comap, (· ∘ ·), nhds_translation_div]
+    simp only [isOpen_iff_mem_nhds, ← mem_comap_prod_mk, comap_comap, Function.comp_def,
+      nhds_translation_div]
 #align topological_group.to_uniform_space TopologicalGroup.toUniformSpace
 #align topological_add_group.to_uniform_space TopologicalAddGroup.toUniformSpace
 
@@ -685,7 +686,7 @@ theorem comm_topologicalGroup_is_uniform : UniformGroup G := by
   constructor
   rw [UniformContinuous, uniformity_prod_eq_prod, tendsto_map'_iff, uniformity_eq_comap_nhds_one' G,
     tendsto_comap_iff, prod_comap_comap_eq]
-  simp only [Function.comp, div_eq_mul_inv, mul_inv_rev, inv_inv, mul_comm, mul_left_comm] at *
+  simp only [Function.comp_def, div_eq_mul_inv, mul_inv_rev, inv_inv, mul_comm, mul_left_comm] at *
   simp only [inv_one, mul_one, ← mul_assoc] at this
   simp_rw [←mul_assoc, mul_comm]
   assumption

--- a/Mathlib/Topology/Algebra/WithZeroTopology.lean
+++ b/Mathlib/Topology/Algebra/WithZeroTopology.lean
@@ -185,7 +185,7 @@ scoped instance (priority := 100) : ContinuousMul Γ₀ where
     rintro ⟨x, y⟩
     wlog hle : x ≤ y generalizing x y
     · have := (this y x (le_of_not_le hle)).comp (continuous_swap.tendsto (x, y))
-      simpa only [mul_comm, Function.comp, Prod.swap] using this
+      simpa only [mul_comm, Function.comp_def, Prod.swap] using this
     rcases eq_or_ne x 0 with (rfl | hx) <;> [rcases eq_or_ne y 0 with (rfl | hy); skip]
     · rw [zero_mul]
       refine ((hasBasis_nhds_zero.prod_nhds hasBasis_nhds_zero).tendsto_iff hasBasis_nhds_zero).2

--- a/Mathlib/Topology/CompactOpen.lean
+++ b/Mathlib/Topology/CompactOpen.lean
@@ -284,7 +284,7 @@ theorem tendsto_compactOpen_iff_forall {ι : Type*} {l : Filter ι} (F : ι → 
     Filter.Tendsto F l (𝓝 f) ↔
     ∀ (s) (hs : IsCompact s), Filter.Tendsto (fun i => (F i).restrict s) l (𝓝 (f.restrict s)) := by
     rw [compactOpen_eq_sInf_induced]
-    simp [nhds_iInf, nhds_induced, Filter.tendsto_comap_iff, Function.comp]
+    simp [nhds_iInf, nhds_induced, Filter.tendsto_comap_iff, Function.comp_def]
 #align continuous_map.tendsto_compact_open_iff_forall ContinuousMap.tendsto_compactOpen_iff_forall
 
 /-- A family `F` of functions in `C(α, β)` converges in the compact-open topology, if and only if

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -492,7 +492,7 @@ theorem trans_continuous_family {ι : Type*} [TopologicalSpace ι]
     Continuous ↿fun t => (γ₁ t).trans (γ₂ t) := by
   have h₁' := Path.continuous_uncurry_extend_of_continuous_family γ₁ h₁
   have h₂' := Path.continuous_uncurry_extend_of_continuous_family γ₂ h₂
-  simp only [HasUncurry.uncurry, CoeFun.coe, Path.trans, (· ∘ ·)]
+  simp only [HasUncurry.uncurry, CoeFun.coe, Path.trans, Function.comp_def]
   refine' Continuous.if_le _ _ (continuous_subtype_val.comp continuous_snd) continuous_const _
   · change
       Continuous ((fun p : ι × ℝ => (γ₁ p.1).extend p.2) ∘ Prod.map id (fun x => 2 * x : I → ℝ))

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -799,19 +799,20 @@ theorem DenseRange.prod_map {ι : Type*} {κ : Type*} {f : ι → β} {g : κ �
 
 theorem Inducing.prod_map {f : α → β} {g : γ → δ} (hf : Inducing f) (hg : Inducing g) :
     Inducing (Prod.map f g) :=
-  inducing_iff_nhds.2 fun (a, b) => by simp_rw [Prod.map, nhds_prod_eq, hf.nhds_eq_comap,
-    hg.nhds_eq_comap, prod_comap_comap_eq]
+  inducing_iff_nhds.2 fun (a, b) => by
+    simp (config := { unfoldPartialApp := true }) only [Prod.map]
+    simp_rw [nhds_prod_eq, hf.nhds_eq_comap, hg.nhds_eq_comap, prod_comap_comap_eq]
 #align inducing.prod_mk Inducing.prod_map
 
 @[simp]
 theorem inducing_const_prod {a : α} {f : β → γ} : (Inducing fun x => (a, f x)) ↔ Inducing f := by
-  simp_rw [inducing_iff, instTopologicalSpaceProd, induced_inf, induced_compose, Function.comp,
+  simp_rw [inducing_iff, instTopologicalSpaceProd, induced_inf, induced_compose, Function.comp_def,
     induced_const, top_inf_eq]
 #align inducing_const_prod inducing_const_prod
 
 @[simp]
 theorem inducing_prod_const {b : β} {f : α → γ} : (Inducing fun x => (f x, b)) ↔ Inducing f := by
-  simp_rw [inducing_iff, instTopologicalSpaceProd, induced_inf, induced_compose, Function.comp,
+  simp_rw [inducing_iff, instTopologicalSpaceProd, induced_inf, induced_compose, Function.comp_def,
     induced_const, inf_top_eq]
 #align inducing_prod_const inducing_prod_const
 
@@ -967,7 +968,7 @@ theorem Continuous.sum_map {f : α → β} {g : γ → δ} (hf : Continuous f) (
 
 theorem isOpenMap_sum {f : Sum α β → γ} :
     IsOpenMap f ↔ (IsOpenMap fun a => f (inl a)) ∧ IsOpenMap fun b => f (inr b) := by
-  simp only [isOpenMap_iff_nhds_le, Sum.forall, nhds_inl, nhds_inr, Filter.map_map, comp]
+  simp only [isOpenMap_iff_nhds_le, Sum.forall, nhds_inl, nhds_inr, Filter.map_map, comp_def]
 #align is_open_map_sum isOpenMap_sum
 
 @[simp]
@@ -1204,7 +1205,7 @@ variable {ι : Type*} {π : ι → Type*} {κ : Type*} [TopologicalSpace α]
   [T : ∀ i, TopologicalSpace (π i)] {f : α → ∀ i : ι, π i}
 
 theorem continuous_pi_iff : Continuous f ↔ ∀ i, Continuous fun a => f a i := by
-  simp only [continuous_iInf_rng, continuous_induced_rng, comp]
+  simp only [continuous_iInf_rng, continuous_induced_rng, comp_def]
 #align continuous_pi_iff continuous_pi_iff
 
 @[continuity]
@@ -1266,7 +1267,7 @@ theorem Pi.continuous_postcomp [TopologicalSpace β] {g : α → β} (hg : Conti
 lemma Pi.induced_precomp' {ι' : Type*} (φ : ι' → ι) :
     induced (fun (f : (∀ i, π i)) (j : ι') ↦ f (φ j)) Pi.topologicalSpace =
     ⨅ i', induced (eval (φ i')) (T (φ i')) := by
-  simp [Pi.topologicalSpace, induced_iInf, induced_compose, comp]
+  simp [Pi.topologicalSpace, induced_iInf, induced_compose, comp_def]
 
 lemma Pi.induced_precomp [TopologicalSpace β] {ι' : Type*} (φ : ι' → ι) :
     induced (· ∘ φ) Pi.topologicalSpace =
@@ -1606,7 +1607,7 @@ theorem inducing_sigma {f : Sigma σ → α} :
 @[simp 1100]
 theorem continuous_sigma_map {f₁ : ι → κ} {f₂ : ∀ i, σ i → τ (f₁ i)} :
     Continuous (Sigma.map f₁ f₂) ↔ ∀ i, Continuous (f₂ i) :=
-  continuous_sigma_iff.trans <| by simp only [Sigma.map, embedding_sigmaMk.continuous_iff, comp]
+  continuous_sigma_iff.trans <| by simp only [Sigma.map, embedding_sigmaMk.continuous_iff, comp_def]
 #align continuous_sigma_map continuous_sigma_map
 
 @[continuity]
@@ -1616,7 +1617,7 @@ theorem Continuous.sigma_map {f₁ : ι → κ} {f₂ : ∀ i, σ i → τ (f₁
 #align continuous.sigma_map Continuous.sigma_map
 
 theorem isOpenMap_sigma {f : Sigma σ → α} : IsOpenMap f ↔ ∀ i, IsOpenMap fun a => f ⟨i, a⟩ := by
-  simp only [isOpenMap_iff_nhds_le, Sigma.forall, Sigma.nhds_eq, map_map, comp]
+  simp only [isOpenMap_iff_nhds_le, Sigma.forall, Sigma.nhds_eq, map_map, comp_def]
 #align is_open_map_sigma isOpenMap_sigma
 
 theorem isOpenMap_sigma_map {f₁ : ι → κ} {f₂ : ∀ i, σ i → τ (f₁ i)} :

--- a/Mathlib/Topology/DenseEmbedding.lean
+++ b/Mathlib/Topology/DenseEmbedding.lean
@@ -286,7 +286,7 @@ protected theorem subtype (p : α → Prop) : DenseEmbedding (subtypeEmb p e) :=
     induced :=
       (induced_iff_nhds_eq _).2 fun ⟨x, hx⟩ => by
         simp [subtypeEmb, nhds_subtype_eq_comap, de.toInducing.nhds_eq_comap, comap_comap,
-          (· ∘ ·)] }
+          Function.comp_def] }
 #align dense_embedding.subtype DenseEmbedding.subtype
 
 theorem dense_image {s : Set α} : Dense (e '' s) ↔ Dense s :=

--- a/Mathlib/Topology/DenseEmbedding.lean
+++ b/Mathlib/Topology/DenseEmbedding.lean
@@ -281,7 +281,7 @@ protected theorem subtype (p : α → Prop) : DenseEmbedding (subtypeEmb p e) :=
       dense_iff_closure_eq.2 <| by
         ext ⟨x, hx⟩
         rw [image_eq_range] at hx
-        simpa [closure_subtype, ← range_comp, (· ∘ ·)]
+        simpa [closure_subtype, ← range_comp, Function.comp_def]
     inj := (de.inj.comp Subtype.coe_injective).codRestrict _
     induced :=
       (induced_iff_nhds_eq _).2 fun ⟨x, hx⟩ => by

--- a/Mathlib/Topology/FiberBundle/Basic.lean
+++ b/Mathlib/Topology/FiberBundle/Basic.lean
@@ -723,7 +723,7 @@ instance fiberBundle : FiberBundle F Z.Fiber where
   totalSpaceMk_inducing' b := inducing_iff_nhds.2 fun x ↦ by
     rw [(Z.localTrivAt b).nhds_eq_comap_inf_principal (mk_mem_localTrivAt_source _ _ _), comap_inf,
       comap_principal, comap_comap]
-    simp only [(· ∘ ·), localTrivAt_apply_mk, Trivialization.coe_coe,
+    simp only [Function.comp_def, localTrivAt_apply_mk, Trivialization.coe_coe,
       ← (embedding_prod_mk b).nhds_eq_comap]
     convert_to 𝓝 x = 𝓝 x ⊓ 𝓟 univ
     · congr

--- a/Mathlib/Topology/FiberBundle/Basic.lean
+++ b/Mathlib/Topology/FiberBundle/Basic.lean
@@ -537,7 +537,7 @@ theorem localTrivAsLocalEquiv_trans (i j : ι) :
   · rintro ⟨x, v⟩ hx
     simp only [trivChange, localTrivAsLocalEquiv, LocalEquiv.symm, true_and_iff,
       Prod.mk.inj_iff, prod_mk_mem_set_prod_eq, LocalEquiv.trans_source, mem_inter_iff,
-      and_true_iff, mem_preimage, proj, mem_univ, eq_self_iff_true, (· ∘ ·),
+      and_true_iff, mem_preimage, proj, mem_univ, eq_self_iff_true, Function.comp_def,
       LocalEquiv.coe_trans, TotalSpace.proj] at hx ⊢
     simp only [Z.coordChange_comp, hx, mem_inter_iff, and_self_iff, mem_baseSet_at]
 #align fiber_bundle_core.local_triv_as_local_equiv_trans FiberBundleCore.localTrivAsLocalEquiv_trans
@@ -626,7 +626,7 @@ theorem continuous_const_section (v : F)
   refine ((Z.localTrivAt x).toLocalHomeomorph.continuousAt_iff_continuousAt_comp_left ?_).2 ?_
   · exact A
   · apply continuousAt_id.prod
-    simp only [(· ∘ ·), mfld_simps, localTrivAt_snd]
+    simp only [Function.comp_def, mfld_simps, localTrivAt_snd]
     have : ContinuousOn (fun _ : B => v) (Z.baseSet (Z.indexAt x)) := continuousOn_const
     refine (this.congr fun y hy ↦ ?_).continuousAt A
     exact h _ _ _ ⟨mem_baseSet_at _ _, hy⟩

--- a/Mathlib/Topology/FiberBundle/Constructions.lean
+++ b/Mathlib/Topology/FiberBundle/Constructions.lean
@@ -322,7 +322,7 @@ variable [TopologicalSpace F] [TopologicalSpace B]
 theorem Pullback.continuous_totalSpaceMk [∀ x, TopologicalSpace (E x)] [FiberBundle F E]
     {f : B' → B} {x : B'} : Continuous (@TotalSpace.mk _ F (f *ᵖ E) x) := by
   simp only [continuous_iff_le_induced, Pullback.TotalSpace.topologicalSpace, induced_compose,
-    induced_inf, Function.comp, induced_const, top_inf_eq, pullbackTopology_def]
+    induced_inf, Function.comp_def, induced_const, top_inf_eq, pullbackTopology_def]
   exact le_of_eq (FiberBundle.totalSpaceMk_inducing F E (f x)).induced
 #align pullback.continuous_total_space_mk Pullback.continuous_totalSpaceMk
 
@@ -360,7 +360,7 @@ noncomputable def Trivialization.pullback (e : Trivialization F (π F E)) (f : K
         e.continuousOn.comp (Pullback.continuous_lift F E f).continuousOn Subset.rfl)
   continuous_invFun := by
     dsimp only
-    simp_rw [(inducing_pullbackTotalSpaceEmbedding F E f).continuousOn_iff, Function.comp,
+    simp_rw [(inducing_pullbackTotalSpaceEmbedding F E f).continuousOn_iff, Function.comp_def,
       pullbackTotalSpaceEmbedding]
     refine'
       continuousOn_fst.prod

--- a/Mathlib/Topology/FiberBundle/Trivialization.lean
+++ b/Mathlib/Topology/FiberBundle/Trivialization.lean
@@ -543,7 +543,7 @@ protected def compHomeomorph {Z' : Type*} [TopologicalSpace Z'] (h : Z' ≃ₜ Z
   toLocalHomeomorph := h.toLocalHomeomorph.trans e.toLocalHomeomorph
   baseSet := e.baseSet
   open_baseSet := e.open_baseSet
-  source_eq := by simp [source_eq, preimage_preimage, (· ∘ ·)]
+  source_eq := by simp [source_eq, preimage_preimage, Function.comp_def]
   target_eq := by simp [target_eq]
   proj_toFun p hp := by
     have hp : h p ∈ e.source := by simpa using hp

--- a/Mathlib/Topology/Filter.lean
+++ b/Mathlib/Topology/Filter.lean
@@ -78,7 +78,7 @@ theorem nhds_eq (l : Filter α) : 𝓝 l = l.lift' (Iic ∘ 𝓟) :=
 #align filter.nhds_eq Filter.nhds_eq
 
 theorem nhds_eq' (l : Filter α) : 𝓝 l = l.lift' fun s => { l' | s ∈ l' } := by
-  simpa only [(· ∘ ·), Iic_principal] using nhds_eq l
+  simpa only [Function.comp_def, Iic_principal] using nhds_eq l
 #align filter.nhds_eq' Filter.nhds_eq'
 
 protected theorem tendsto_nhds {la : Filter α} {lb : Filter β} {f : α → Filter β} :
@@ -117,7 +117,7 @@ theorem mem_nhds_iff' {l : Filter α} {S : Set (Filter α)} :
 
 @[simp]
 theorem nhds_bot : 𝓝 (⊥ : Filter α) = pure ⊥ := by
-  simp [nhds_eq, (· ∘ ·), lift'_bot monotone_principal.Iic]
+  simp [nhds_eq, Function.comp_def, lift'_bot monotone_principal.Iic]
 #align filter.nhds_bot Filter.nhds_bot
 
 @[simp]
@@ -150,8 +150,8 @@ theorem monotone_nhds : Monotone (𝓝 : Filter α → Filter (Filter α)) :=
 #align filter.monotone_nhds Filter.monotone_nhds
 
 theorem sInter_nhds (l : Filter α) : ⋂₀ { s | s ∈ 𝓝 l } = Iic l := by
-  simp_rw [nhds_eq, (· ∘ ·), sInter_lift'_sets monotone_principal.Iic, Iic, le_principal_iff,
-    ← setOf_forall, ← Filter.le_def]
+  simp_rw [nhds_eq, Function.comp_def, sInter_lift'_sets monotone_principal.Iic, Iic,
+    le_principal_iff, ← setOf_forall, ← Filter.le_def]
 #align filter.Inter_nhds Filter.sInter_nhds
 
 @[simp]

--- a/Mathlib/Topology/Filter.lean
+++ b/Mathlib/Topology/Filter.lean
@@ -68,13 +68,13 @@ theorem isTopologicalBasis_Iic_principal :
 
 theorem isOpen_iff {s : Set (Filter α)} : IsOpen s ↔ ∃ T : Set (Set α), s = ⋃ t ∈ T, Iic (𝓟 t) :=
   isTopologicalBasis_Iic_principal.open_iff_eq_sUnion.trans <| by
-    simp only [exists_subset_range_and_iff, sUnion_image, (· ∘ ·)]
+    simp only [exists_subset_range_and_iff, sUnion_image, Function.comp_def]
 #align filter.is_open_iff Filter.isOpen_iff
 
 theorem nhds_eq (l : Filter α) : 𝓝 l = l.lift' (Iic ∘ 𝓟) :=
   nhds_generateFrom.trans <| by
     simp only [mem_setOf_eq, @and_comm (l ∈ _), iInf_and, iInf_range, Filter.lift', Filter.lift,
-      (· ∘ ·), mem_Iic, le_principal_iff]
+      Function.comp_def, mem_Iic, le_principal_iff]
 #align filter.nhds_eq Filter.nhds_eq
 
 theorem nhds_eq' (l : Filter α) : 𝓝 l = l.lift' fun s => { l' | s ∈ l' } := by

--- a/Mathlib/Topology/Instances/ENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal.lean
@@ -299,8 +299,8 @@ instance : ContinuousAdd ℝ≥0∞ := by
   · exact tendsto_nhds_top_mono' continuousAt_fst fun p => le_add_right le_rfl
   rcases b with (_ | b)
   · exact tendsto_nhds_top_mono' continuousAt_snd fun p => le_add_left le_rfl
-  simp only [ContinuousAt, some_eq_coe, nhds_coe_coe, ← coe_add, tendsto_map'_iff, (· ∘ ·),
-    tendsto_coe, tendsto_add]
+  simp only [ContinuousAt, some_eq_coe, nhds_coe_coe, ← coe_add, tendsto_map'_iff,
+    Function.comp_def, tendsto_coe, tendsto_add]
 
 protected theorem tendsto_atTop_zero [Nonempty β] [SemilatticeSup β] {f : β → ℝ≥0∞} :
     Tendsto f atTop (𝓝 0) ↔ ∀ ε > 0, ∃ N, ∀ n ≥ N, f n ≤ ε :=
@@ -324,7 +324,7 @@ theorem tendsto_sub : ∀ {a b : ℝ≥0∞}, (a ≠ ∞ ∨ b ≠ ∞) →
       (lt_mem_nhds <| @coe_lt_top (a + 1))).mono fun x hx =>
         tsub_eq_zero_iff_le.2 (hx.1.trans hx.2).le
   | (a : ℝ≥0), (b : ℝ≥0), _ => by
-    simp only [nhds_coe_coe, tendsto_map'_iff, ← ENNReal.coe_sub, (· ∘ ·), tendsto_coe]
+    simp only [nhds_coe_coe, tendsto_map'_iff, ← ENNReal.coe_sub, Function.comp_def, tendsto_coe]
     exact continuous_sub.tendsto (a, b)
 #align ennreal.tendsto_sub ENNReal.tendsto_sub
 
@@ -351,10 +351,11 @@ protected theorem tendsto_mul (ha : a ≠ 0 ∨ b ≠ ⊤) (hb : b ≠ 0 ∨ a �
     induction b using recTopCoe with
     | top =>
       simp only [ne_eq, or_false] at ha
-      simpa [(· ∘ ·), mul_comm, mul_top ha]
+      simpa [Function.comp_def, mul_comm, mul_top ha]
         using (ht a ha).comp (continuous_swap.tendsto (ofNNReal a, ⊤))
     | coe b =>
-      simp only [nhds_coe_coe, ← coe_mul, tendsto_coe, tendsto_map'_iff, (· ∘ ·), tendsto_mul]
+      simp only [nhds_coe_coe, ← coe_mul, tendsto_coe, tendsto_map'_iff, Function.comp_def,
+        tendsto_mul]
 #align ennreal.tendsto_mul ENNReal.tendsto_mul
 
 protected theorem Tendsto.mul {f : Filter α} {ma : α → ℝ≥0∞} {mb : α → ℝ≥0∞} {a b : ℝ≥0∞}
@@ -1297,7 +1298,7 @@ theorem tsum_comp_le_tsum_of_inj {β : Type*} {f : α → ℝ} (hf : Summable f)
     {i : β → α} (hi : Function.Injective i) : tsum (f ∘ i) ≤ tsum f := by
   lift f to α → ℝ≥0 using hn
   rw [NNReal.summable_coe] at hf
-  simpa only [(· ∘ ·), ← NNReal.coe_tsum] using NNReal.tsum_comp_le_tsum_of_inj hf hi
+  simpa only [Function.comp_def, ← NNReal.coe_tsum] using NNReal.tsum_comp_le_tsum_of_inj hf hi
 #align tsum_comp_le_tsum_of_inj tsum_comp_le_tsum_of_inj
 
 /-- Comparison test of convergence of series of non-negative real numbers. -/

--- a/Mathlib/Topology/Instances/EReal.lean
+++ b/Mathlib/Topology/Instances/EReal.lean
@@ -174,8 +174,8 @@ theorem tendsto_nhds_bot_iff_real {α : Type*} {m : α → EReal} {f : Filter α
 
 theorem continuousAt_add_coe_coe (a b : ℝ) :
     ContinuousAt (fun p : EReal × EReal => p.1 + p.2) (a, b) := by
-  simp only [ContinuousAt, nhds_coe_coe, ← coe_add, tendsto_map'_iff, (· ∘ ·), tendsto_coe,
-    tendsto_add]
+  simp only [ContinuousAt, nhds_coe_coe, ← coe_add, tendsto_map'_iff, Function.comp_def,
+    tendsto_coe, tendsto_add]
 #align ereal.continuous_at_add_coe_coe EReal.continuousAt_add_coe_coe
 
 theorem continuousAt_add_top_coe (a : ℝ) :
@@ -188,7 +188,7 @@ theorem continuousAt_add_top_coe (a : ℝ) :
 
 theorem continuousAt_add_coe_top (a : ℝ) :
     ContinuousAt (fun p : EReal × EReal => p.1 + p.2) (a, ⊤) := by
-  simpa only [add_comm, (· ∘ ·), ContinuousAt, Prod.swap]
+  simpa only [add_comm, Function.comp_def, ContinuousAt, Prod.swap]
     using Tendsto.comp (continuousAt_add_top_coe a) (continuous_swap.tendsto ((a : EReal), ⊤))
 #align ereal.continuous_at_add_coe_top EReal.continuousAt_add_coe_top
 
@@ -209,7 +209,7 @@ theorem continuousAt_add_bot_coe (a : ℝ) :
 
 theorem continuousAt_add_coe_bot (a : ℝ) :
     ContinuousAt (fun p : EReal × EReal => p.1 + p.2) (a, ⊥) := by
-  simpa only [add_comm, (· ∘ ·), ContinuousAt, Prod.swap]
+  simpa only [add_comm, Function.comp_def, ContinuousAt, Prod.swap]
     using Tendsto.comp (continuousAt_add_bot_coe a) (continuous_swap.tendsto ((a : EReal), ⊥))
 #align ereal.continuous_at_add_coe_bot EReal.continuousAt_add_coe_bot
 

--- a/Mathlib/Topology/Instances/Rat.lean
+++ b/Mathlib/Topology/Instances/Rat.lean
@@ -85,7 +85,7 @@ instance : NoncompactSpace ℚ := Int.closedEmbedding_coe_rat.noncompactSpace
 
 theorem uniformContinuous_add : UniformContinuous fun p : ℚ × ℚ => p.1 + p.2 :=
   Rat.uniformEmbedding_coe_real.toUniformInducing.uniformContinuous_iff.2 <| by
-    simp only [(· ∘ ·), Rat.cast_add]
+    simp only [Function.comp_def, Rat.cast_add]
     exact Real.uniformContinuous_add.comp
       (Rat.uniformContinuous_coe_real.prod_map Rat.uniformContinuous_coe_real)
 #align rat.uniform_continuous_add Rat.uniformContinuous_add

--- a/Mathlib/Topology/List.lean
+++ b/Mathlib/Topology/List.lean
@@ -89,7 +89,7 @@ theorem tendsto_cons_iff {β : Type*} {f : List α → β} {b : Filter β} {a : 
   have : 𝓝 (a::l) = (𝓝 a ×ˢ 𝓝 l).map fun p : α × List α => p.1::p.2 := by
     simp only [nhds_cons, Filter.prod_eq, (Filter.map_def _ _).symm,
       (Filter.seq_eq_filter_seq _ _).symm]
-    simp [-Filter.map_def, (· ∘ ·), functor_norm]
+    simp [-Filter.map_def, Function.comp_def, functor_norm]
   rw [this, Filter.tendsto_map'_iff]; rfl
 #align list.tendsto_cons_iff List.tendsto_cons_iff
 
@@ -128,7 +128,7 @@ theorem tendsto_insertNth' {a : α} :
     have : 𝓝 a ×ˢ 𝓝 (a'::l) =
         (𝓝 a ×ˢ (𝓝 a' ×ˢ 𝓝 l)).map fun p : α × α × List α => (p.1, p.2.1::p.2.2) := by
       simp only [nhds_cons, Filter.prod_eq, ← Filter.map_def, ← Filter.seq_eq_filter_seq]
-      simp [-Filter.map_def, (· ∘ ·), functor_norm]
+      simp [-Filter.map_def, Function.comp_def, functor_norm]
     rw [this, tendsto_map'_iff]
     exact
       (tendsto_fst.comp tendsto_snd).cons

--- a/Mathlib/Topology/LocalHomeomorph.lean
+++ b/Mathlib/Topology/LocalHomeomorph.lean
@@ -1257,7 +1257,7 @@ theorem nhds_eq_comap_inf_principal {x} (hx : x ∈ e.source) :
   lift x to e.source using hx
   rw [← e.open_source.nhdsWithin_eq x.2, ← map_nhds_subtype_val, ← map_comap_setCoe_val,
     e.toHomeomorphSourceTarget.nhds_eq_comap, nhds_subtype_eq_comap]
-  simp only [(· ∘ ·), toHomeomorphSourceTarget_apply_coe, comap_comap]
+  simp only [Function.comp_def, toHomeomorphSourceTarget_apply_coe, comap_comap]
 
 /-- If a local homeomorphism has source and target equal to univ, then it induces a homeomorphism
 between the whole spaces, expressed in this definition. -/

--- a/Mathlib/Topology/LocalHomeomorph.lean
+++ b/Mathlib/Topology/LocalHomeomorph.lean
@@ -1159,7 +1159,7 @@ theorem continuousWithinAt_iff_continuousWithinAt_comp_right {f : β → γ} {s 
     (h : x ∈ e.target) :
     ContinuousWithinAt f s x ↔ ContinuousWithinAt (f ∘ e) (e ⁻¹' s) (e.symm x) := by
   simp_rw [ContinuousWithinAt, ← @tendsto_map'_iff _ _ _ _ e,
-    e.map_nhdsWithin_preimage_eq (e.map_target h), (· ∘ ·), e.right_inv h]
+    e.map_nhdsWithin_preimage_eq (e.map_target h), Function.comp_def, e.right_inv h]
 #align local_homeomorph.continuous_within_at_iff_continuous_within_at_comp_right LocalHomeomorph.continuousWithinAt_iff_continuousWithinAt_comp_right
 
 /-- Continuity at a point can be read under right composition with a local homeomorphism, if the

--- a/Mathlib/Topology/LocallyFinite.lean
+++ b/Mathlib/Topology/LocallyFinite.lean
@@ -207,7 +207,8 @@ end LocallyFinite
 
 @[simp]
 theorem Equiv.locallyFinite_comp_iff (e : ι' ≃ ι) : LocallyFinite (f ∘ e) ↔ LocallyFinite f :=
-  ⟨fun h => by simpa only [(· ∘ ·), e.apply_symm_apply] using h.comp_injective e.symm.injective,
+  ⟨fun h => by
+    simpa only [Function.comp_def, e.apply_symm_apply] using h.comp_injective e.symm.injective,
     fun h => h.comp_injective e.injective⟩
 #align equiv.locally_finite_comp_iff Equiv.locallyFinite_comp_iff
 

--- a/Mathlib/Topology/LocallyFinite.lean
+++ b/Mathlib/Topology/LocallyFinite.lean
@@ -215,7 +215,7 @@ theorem Equiv.locallyFinite_comp_iff (e : ι' ≃ ι) : LocallyFinite (f ∘ e) 
 theorem locallyFinite_sum {f : Sum ι ι' → Set X} :
     LocallyFinite f ↔ LocallyFinite (f ∘ Sum.inl) ∧ LocallyFinite (f ∘ Sum.inr) := by
   simp only [locallyFinite_iff_smallSets, ← forall_and, ← finite_preimage_inl_and_inr,
-    preimage_setOf_eq, (· ∘ ·), eventually_and]
+    preimage_setOf_eq, Function.comp_def, eventually_and]
 #align locally_finite_sum locallyFinite_sum
 
 theorem LocallyFinite.sum_elim {g : ι' → Set X} (hf : LocallyFinite f) (hg : LocallyFinite g) :

--- a/Mathlib/Topology/Maps.lean
+++ b/Mathlib/Topology/Maps.lean
@@ -219,7 +219,7 @@ protected theorem Embedding.comp {g : β → γ} {f : α → β} (hg : Embedding
 theorem embedding_of_embedding_compose {f : α → β} {g : β → γ} (hf : Continuous f)
     (hg : Continuous g) (hgf : Embedding (g ∘ f)) : Embedding f :=
   { induced := (inducing_of_inducing_compose hf hg hgf.toInducing).induced
-    inj := fun a₁ a₂ h => hgf.inj <| by simp [h, (· ∘ ·)] }
+    inj := fun a₁ a₂ h => hgf.inj <| by simp [h, Function.comp_def] }
 #align embedding_of_embedding_compose embedding_of_embedding_compose
 
 protected theorem Function.LeftInverse.embedding {f : α → β} {g : β → α} (h : LeftInverse f g)

--- a/Mathlib/Topology/MetricSpace/Contracting.lean
+++ b/Mathlib/Topology/MetricSpace/Contracting.lean
@@ -172,7 +172,7 @@ theorem exists_fixedPoint' {s : Set α} (hsc : IsComplete s) (hsf : MapsTo f s s
   rcases hf.exists_fixedPoint ⟨x, hxs⟩ hx with ⟨y, hfy, h_tendsto, hle⟩
   refine' ⟨y, y.2, Subtype.ext_iff_val.1 hfy, _, fun n ↦ _⟩
   · convert (continuous_subtype_val.tendsto _).comp h_tendsto
-    simp only [(· ∘ ·), MapsTo.iterate_restrict, MapsTo.val_restrict_apply]
+    simp only [Function.comp_def, MapsTo.iterate_restrict, MapsTo.val_restrict_apply]
   · convert hle n
     rw [MapsTo.iterate_restrict]
     rfl

--- a/Mathlib/Topology/MetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Lipschitz.lean
@@ -203,12 +203,12 @@ variable [PseudoEMetricSpace α] {f g : α → ℝ} {Kf Kg : ℝ≥0}
 
 protected theorem max (hf : LipschitzWith Kf f) (hg : LipschitzWith Kg g) :
     LipschitzWith (max Kf Kg) fun x => max (f x) (g x) := by
-  simpa only [(· ∘ ·), one_mul] using lipschitzWith_max.comp (hf.prod hg)
+  simpa only [Function.comp_def, one_mul] using lipschitzWith_max.comp (hf.prod hg)
 #align lipschitz_with.max LipschitzWith.max
 
 protected theorem min (hf : LipschitzWith Kf f) (hg : LipschitzWith Kg g) :
     LipschitzWith (max Kf Kg) fun x => min (f x) (g x) := by
-  simpa only [(· ∘ ·), one_mul] using lipschitzWith_min.comp (hf.prod hg)
+  simpa only [Function.comp_def, one_mul] using lipschitzWith_min.comp (hf.prod hg)
 #align lipschitz_with.min LipschitzWith.min
 
 theorem max_const (hf : LipschitzWith Kf f) (a : ℝ) : LipschitzWith Kf fun x => max (f x) a := by

--- a/Mathlib/Topology/MetricSpace/PseudoMetric.lean
+++ b/Mathlib/Topology/MetricSpace/PseudoMetric.lean
@@ -1710,7 +1710,7 @@ protected theorem Filter.Tendsto.dist {f g : β → α} {x : Filter β} {a b : �
 
 theorem nhds_comap_dist (a : α) : ((𝓝 (0 : ℝ)).comap (dist · a)) = 𝓝 a := by
   simp only [@nhds_eq_comap_uniformity α, Metric.uniformity_eq_comap_nhds_zero, comap_comap,
-    (· ∘ ·), dist_comm]
+    Function.comp_def, dist_comm]
 #align nhds_comap_dist nhds_comap_dist
 
 theorem tendsto_iff_dist_tendsto_zero {f : β → α} {x : Filter β} {a : α} :

--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -965,7 +965,7 @@ instance tendstoIccClassNhdsPi {ι : Type*} {α : ι → Type*} [∀ i, Preorder
     TendstoIxxClass Icc (𝓝 f) (𝓝 f) := by
   constructor
   conv in (𝓝 f).smallSets => rw [nhds_pi, Filter.pi]
-  simp only [smallSets_iInf, smallSets_comap, tendsto_iInf, tendsto_lift', (· ∘ ·),
+  simp only [smallSets_iInf, smallSets_comap, tendsto_iInf, tendsto_lift', Function.comp_def,
     mem_powerset_iff]
   intro i s hs
   have : Tendsto (fun g : ∀ i, α i => g i) (𝓝 f) (𝓝 (f i)) := (continuous_apply i).tendsto f

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -162,7 +162,7 @@ theorem FrechetUrysohnSpace.of_seq_tendsto_imp_tendsto
   by_cases hx : x ∈ s;
   · exact subset_seqClosure hx
   · obtain ⟨u, hux, hus⟩ : ∃ u : ℕ → X, Tendsto u atTop (𝓝 x) ∧ ∃ᶠ x in atTop, u x ∈ s
-    · simpa only [ContinuousAt, hx, tendsto_nhds_true, (· ∘ ·), ← not_frequently, exists_prop,
+    · simpa only [ContinuousAt, hx, tendsto_nhds_true, Function.comp_def, ← not_frequently, exists_prop,
         ← mem_closure_iff_frequently, hcx, imp_false, not_forall, not_not] using h (· ∉ s) x
     rcases extraction_of_frequently_atTop hus with ⟨φ, φ_mono, hφ⟩
     exact ⟨u ∘ φ, hφ, hux.comp φ_mono.tendsto_atTop⟩

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -162,8 +162,9 @@ theorem FrechetUrysohnSpace.of_seq_tendsto_imp_tendsto
   by_cases hx : x ∈ s;
   · exact subset_seqClosure hx
   · obtain ⟨u, hux, hus⟩ : ∃ u : ℕ → X, Tendsto u atTop (𝓝 x) ∧ ∃ᶠ x in atTop, u x ∈ s
-    · simpa only [ContinuousAt, hx, tendsto_nhds_true, Function.comp_def, ← not_frequently, exists_prop,
-        ← mem_closure_iff_frequently, hcx, imp_false, not_forall, not_not] using h (· ∉ s) x
+    · simpa only [ContinuousAt, hx, tendsto_nhds_true, Function.comp_def, ← not_frequently,
+        exists_prop, ← mem_closure_iff_frequently, hcx, imp_false, not_forall, not_not]
+        using h (· ∉ s) x
     rcases extraction_of_frequently_atTop hus with ⟨φ, φ_mono, hφ⟩
     exact ⟨u ∘ φ, hφ, hux.comp φ_mono.tendsto_atTop⟩
 #align frechet_urysohn_space.of_seq_tendsto_imp_tendsto FrechetUrysohnSpace.of_seq_tendsto_imp_tendsto

--- a/Mathlib/Topology/UniformSpace/AbstractCompletion.lean
+++ b/Mathlib/Topology/UniformSpace/AbstractCompletion.lean
@@ -208,7 +208,7 @@ theorem map_unique {f : α → β} {g : hatα → hatβ} (hg : UniformContinuous
   pkg.funext (pkg.continuous_map _ _) hg.continuous <| by
     intro a
     change pkg.extend (ι' ∘ f) _ = _
-    simp only [(· ∘ ·), h, ←comp_apply (f := g)]
+    simp only [Function.comp_def, h, ←comp_apply (f := g)]
     rw [pkg.extend_coe (hg.comp pkg.uniformContinuous_coe)]
 #align abstract_completion.map_unique AbstractCompletion.map_unique
 

--- a/Mathlib/Topology/UniformSpace/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Basic.lean
@@ -872,13 +872,13 @@ theorem tendsto_left_nhds_uniformity {a : α} : Tendsto (fun a' => (a, a')) (�
 theorem lift_nhds_left {x : α} {g : Set α → Filter β} (hg : Monotone g) :
     (𝓝 x).lift g = (𝓤 α).lift fun s : Set (α × α) => g (ball x s) := by
   rw [nhds_eq_comap_uniformity, comap_lift_eq2 hg]
-  simp_rw [ball, Function.comp]
+  simp_rw [ball, Function.comp_def]
 #align lift_nhds_left lift_nhds_left
 
 theorem lift_nhds_right {x : α} {g : Set α → Filter β} (hg : Monotone g) :
     (𝓝 x).lift g = (𝓤 α).lift fun s : Set (α × α) => g { y | (y, x) ∈ s } := by
   rw [nhds_eq_comap_uniformity', comap_lift_eq2 hg]
-  simp_rw [Function.comp, preimage]
+  simp_rw [Function.comp_def, preimage]
 #align lift_nhds_right lift_nhds_right
 
 theorem nhds_nhds_eq_uniformity_uniformity_prod {a b : α} :
@@ -1255,7 +1255,7 @@ def UniformSpace.comap (f : α → β) (u : UniformSpace β) : UniformSpace α :
     { uniformity := 𝓤[u].comap fun p : α × α => (f p.1, f p.2)
       refl := le_trans (by simp) (comap_mono u.refl)
       symm := by
-        simp only [tendsto_comap_iff, Prod.swap, (· ∘ ·)]
+        simp only [tendsto_comap_iff, Prod.swap, Function.comp_def]
         exact tendsto_swap_uniformity.comp tendsto_comap
       comp := le_trans
         (by
@@ -1264,7 +1264,7 @@ def UniformSpace.comap (f : α → β) (u : UniformSpace β) : UniformSpace α :
           exact monotone_id.compRel monotone_id)
         (comap_mono u.comp) }
     (u.toTopologicalSpace.induced f) fun x => by
-      simp only [nhds_induced, nhds_eq_comap_uniformity, comap_comap, Function.comp]
+      simp only [nhds_induced, nhds_eq_comap_uniformity, comap_comap, Function.comp_def]
 #align uniform_space.comap UniformSpace.comap
 
 theorem uniformity_comap {_ : UniformSpace β} (f : α → β) :

--- a/Mathlib/Topology/UniformSpace/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Basic.lean
@@ -1534,7 +1534,7 @@ theorem uniformity_mulOpposite [UniformSpace α] :
 @[to_additive (attr := simp)]
 theorem comap_uniformity_mulOpposite [UniformSpace α] :
     comap (fun p : α × α => (MulOpposite.op p.1, MulOpposite.op p.2)) (𝓤 αᵐᵒᵖ) = 𝓤 α := by
-  simpa [uniformity_mulOpposite, comap_comap, (· ∘ ·)] using comap_id
+  simpa [uniformity_mulOpposite, comap_comap, Function.comp_def] using comap_id
 #align comap_uniformity_mul_opposite comap_uniformity_mulOpposite
 #align comap_uniformity_add_opposite comap_uniformity_addOpposite
 

--- a/Mathlib/Topology/UniformSpace/Cauchy.lean
+++ b/Mathlib/Topology/UniformSpace/Cauchy.lean
@@ -241,7 +241,7 @@ theorem Function.Bijective.cauchySeq_comp_iff {f : ℕ → ℕ} (hf : Bijective 
     CauchySeq (u ∘ f) ↔ CauchySeq u := by
   refine' ⟨fun H => _, fun H => H.comp_injective hf.injective⟩
   lift f to ℕ ≃ ℕ using hf
-  simpa only [(· ∘ ·), f.apply_symm_apply] using H.comp_injective f.symm.injective
+  simpa only [Function.comp_def, f.apply_symm_apply] using H.comp_injective f.symm.injective
 #align function.bijective.cauchy_seq_comp_iff Function.Bijective.cauchySeq_comp_iff
 
 theorem CauchySeq.subseq_subseq_mem {V : ℕ → Set (α × α)} (hV : ∀ n, V n ∈ 𝓤 α) {u : ℕ → α}

--- a/Mathlib/Topology/UniformSpace/Compact.lean
+++ b/Mathlib/Topology/UniformSpace/Compact.lean
@@ -149,7 +149,7 @@ def uniformSpaceOfCompactT2 [TopologicalSpace γ] [CompactSpace γ] [T2Space γ]
       intro s
       simp_rw [isOpen_iff_mem_nhds, ← mem_comap_prod_mk, this]
     intro x
-    simp_rw [nhdsSet_diagonal, comap_iSup, nhds_prod_eq, comap_prod, (· ∘ ·), comap_id']
+    simp_rw [nhdsSet_diagonal, comap_iSup, nhds_prod_eq, comap_prod, Function.comp_def, comap_id']
     rw [iSup_split_single _ x, comap_const_of_mem fun V => mem_of_mem_nhds]
     suffices ∀ (y) (_ : y ≠ x), comap (fun _ : γ => x) (𝓝 y) ⊓ 𝓝 y ≤ 𝓝 x by simpa
     intro y hxy

--- a/Mathlib/Topology/UniformSpace/Completion.lean
+++ b/Mathlib/Topology/UniformSpace/Completion.lean
@@ -89,7 +89,7 @@ private theorem symm_gen : map Prod.swap ((𝓤 α).lift' gen) ≤ (𝓤 α).lif
         { p : CauchyFilter α × CauchyFilter α | s ∈ (p.2.val ×ˢ p.1.val : Filter (α × α)) }
   have h₁ : map Prod.swap ((𝓤 α).lift' gen) = (𝓤 α).lift' f := by
     delta gen
-    simp [map_lift'_eq, monotone_setOf, Filter.monotone_mem, Function.comp,
+    simp [map_lift'_eq, monotone_setOf, Filter.monotone_mem, Function.comp_def,
       image_swap_eq_preimage_swap]
   have h₂ : (𝓤 α).lift' f ≤ (𝓤 α).lift' gen :=
     uniformity_lift_le_swap

--- a/Mathlib/Topology/UniformSpace/Pi.lean
+++ b/Mathlib/Topology/UniformSpace/Pi.lean
@@ -45,7 +45,7 @@ variable {α}
 theorem uniformContinuous_pi {β : Type*} [UniformSpace β] {f : β → ∀ i, α i} :
     UniformContinuous f ↔ ∀ i, UniformContinuous fun x => f x i := by
   -- porting note: required `Function.comp` to close
-  simp only [UniformContinuous, Pi.uniformity, tendsto_iInf, tendsto_comap_iff, Function.comp]
+  simp only [UniformContinuous, Pi.uniformity, tendsto_iInf, tendsto_comap_iff, Function.comp_def]
 #align uniform_continuous_pi uniformContinuous_pi
 
 variable (α)
@@ -74,7 +74,7 @@ theorem Pi.uniformContinuous_postcomp {α : Type*} [UniformSpace α] {g : α →
 lemma Pi.uniformSpace_comap_precomp' (φ : ι' → ι) :
     UniformSpace.comap (fun g i' ↦ g (φ i')) (Pi.uniformSpace (fun i' ↦ α (φ i'))) =
     ⨅ i', UniformSpace.comap (eval (φ i')) (U (φ i')) := by
-  simp [Pi.uniformSpace_eq, UniformSpace.comap_iInf, ← UniformSpace.comap_comap, comp]
+  simp [Pi.uniformSpace_eq, UniformSpace.comap_iInf, ← UniformSpace.comap_comap, comp_def]
 
 lemma Pi.uniformSpace_comap_precomp (φ : ι' → ι) :
     UniformSpace.comap (· ∘ φ) (Pi.uniformSpace (fun _ ↦ β)) =

--- a/Mathlib/Topology/UniformSpace/Separation.lean
+++ b/Mathlib/Topology/UniformSpace/Separation.lean
@@ -411,7 +411,7 @@ theorem map_id : map (@id α) = id :=
 
 theorem map_comp {f : α → β} {g : β → γ} (hf : UniformContinuous f) (hg : UniformContinuous g) :
     map g ∘ map f = map (g ∘ f) :=
-  (map_unique (hg.comp hf) <| by simp only [Function.comp, map_mk, hf, hg]).symm
+  (map_unique (hg.comp hf) <| by simp only [Function.comp_def, map_mk, hf, hg]).symm
 #align uniform_space.separation_quotient.map_comp UniformSpace.SeparationQuotient.map_comp
 
 end SeparationQuotient

--- a/Mathlib/Topology/UniformSpace/UniformConvergence.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergence.lean
@@ -377,7 +377,7 @@ theorem UniformContinuousOn.tendstoUniformlyOn [UniformSpace α] [UniformSpace �
   simp only [nhdsWithin, SProd.sprod, Filter.prod, comap_inf, inf_assoc, comap_principal,
     inf_principal]
   refine hF.comp (Tendsto.inf ?_ <| tendsto_principal_principal.2 <| fun x hx => ⟨⟨hU, hx.2⟩, hx⟩)
-  simp only [uniformity_prod_eq_comap_prod, tendsto_comap_iff, (· ∘ ·),
+  simp only [uniformity_prod_eq_comap_prod, tendsto_comap_iff, Function.comp_def,
     nhds_eq_comap_uniformity, comap_comap]
   exact tendsto_comap.prod_mk (tendsto_diag_uniformity _ _)
 

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -106,7 +106,7 @@ theorem UniformInducing.inducing {f : α → β} (h : UniformInducing f) : Induc
 theorem UniformInducing.prod {α' : Type*} {β' : Type*} [UniformSpace α'] [UniformSpace β']
     {e₁ : α → α'} {e₂ : β → β'} (h₁ : UniformInducing e₁) (h₂ : UniformInducing e₂) :
     UniformInducing fun p : α × β => (e₁ p.1, e₂ p.2) :=
-  ⟨by simp [(· ∘ ·), uniformity_prod, ← h₁.1, ← h₂.1, comap_inf, comap_comap]⟩
+  ⟨by simp [Function.comp_def, uniformity_prod, ← h₁.1, ← h₂.1, comap_inf, comap_comap]⟩
 #align uniform_inducing.prod UniformInducing.prod
 
 theorem UniformInducing.denseInducing {f : α → β} (h : UniformInducing f) (hd : DenseRange f) :
@@ -258,7 +258,7 @@ theorem closure_image_mem_nhds_of_uniformInducing {s : Set (α × α)} {e : α �
 theorem uniformEmbedding_subtypeEmb (p : α → Prop) {e : α → β} (ue : UniformEmbedding e)
     (de : DenseEmbedding e) : UniformEmbedding (DenseEmbedding.subtypeEmb p e) :=
   { comap_uniformity := by
-      simp [comap_comap, (· ∘ ·), DenseEmbedding.subtypeEmb, uniformity_subtype,
+      simp [comap_comap, Function.comp_def, DenseEmbedding.subtypeEmb, uniformity_subtype,
         ue.comap_uniformity.symm]
     inj := (de.subtype p).inj }
 #align uniform_embedding_subtype_emb uniformEmbedding_subtypeEmb


### PR DESCRIPTION
This will be needed for leanprover/lean4#2783, and is split from #8023.

Co-authored by: Scott Morrison <scott.morrison@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
