### PR TITLE
[Merged by Bors] - feat(Data/Set/Pointwise/Interval): inclusions of pointwise +/*

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1468,6 +1468,7 @@ import Mathlib.Data.Finset.Pairwise
 import Mathlib.Data.Finset.Pi
 import Mathlib.Data.Finset.PiInduction
 import Mathlib.Data.Finset.Pointwise
+import Mathlib.Data.Finset.Pointwise.Interval
 import Mathlib.Data.Finset.Powerset
 import Mathlib.Data.Finset.Preimage
 import Mathlib.Data.Finset.Prod

--- a/Mathlib/Data/Finset/Pointwise/Interval.lean
+++ b/Mathlib/Data/Finset/Pointwise/Interval.lean
@@ -23,7 +23,7 @@ open scoped Pointwise
 
 Note that the subset operations below only cover the cases with the largest possible intervals on
 the LHS: to conclude that `Ioo a b * Ioo c d ⊆ Ioo (a * c) (c * d)`, you can use monotonicity of `*`
-and `Set.Ico_mul_Ioc_subset`.
+and `Finset.Ico_mul_Ioc_subset`.
 
 TODO: repeat these lemmas for the generality of `mul_le_mul` (which assumes nonnegativity), which
 the unprimed names have been reserved for

--- a/Mathlib/Data/Finset/Pointwise/Interval.lean
+++ b/Mathlib/Data/Finset/Pointwise/Interval.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2023 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.Data.Finset.Pointwise
+import Mathlib.Data.Finset.Interval
+import Mathlib.Data.Set.Pointwise.Interval
+
+
+/-! # Pointwise operations on intervals
+
+This should be kept in sync with `Mathlib/Data/Set/Pointwise/Interval.lean`.
+-/
+
+variable {α : Type*}
+
+namespace Finset
+
+open scoped Pointwise
+
+/-! ### Binary pointwise operations
+
+Note that the subset operations below only cover the cases with the largest possible intervals on
+the LHS: to conclude that `Ioo a b * Ioo c d ⊆ Ioo (a * c) (c * d)`, you can use monotonicity of `*`
+and `Set.Ico_mul_Ioc_subset`.
+
+TODO: repeat these lemmas for the generality of `mul_le_mul` (which assumes nonnegativity), which
+the unprimed names have been reserved for
+-/
+
+section ContravariantLE
+
+variable [Mul α] [Preorder α] [DecidableEq α]
+variable [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (Function.swap HMul.hMul) LE.le]
+
+
+@[to_additive Icc_add_Icc_subset]
+theorem Icc_mul_Icc_subset' [LocallyFiniteOrder α] (a b c d : α) : Icc a b * Icc c d ⊆ Icc (a * c) (b * d) :=
+  Finset.coe_subset.mp <| by simpa using Set.Icc_mul_Icc_subset' _ _ _ _
+
+@[to_additive Iic_add_Iic_subset]
+theorem Iic_mul_Iic_subset' [LocallyFiniteOrderBot α] (a b : α) : Iic a * Iic b ⊆ Iic (a * b) :=
+  Finset.coe_subset.mp <| by simpa using Set.Iic_mul_Iic_subset' _ _
+
+@[to_additive Ici_add_Ici_subset]
+theorem Ici_mul_Ici_subset' [LocallyFiniteOrderTop α] (a b : α) : Ici a * Ici b ⊆ Ici (a * b) :=
+  Finset.coe_subset.mp <| by simpa using Set.Ici_mul_Ici_subset' _ _
+
+end ContravariantLE
+
+section ContravariantLT
+
+variable [Mul α] [PartialOrder α] [DecidableEq α]
+variable [CovariantClass α α (· * ·) (· < ·)] [CovariantClass α α (Function.swap HMul.hMul) LT.lt]
+
+@[to_additive Icc_add_Ico_subset]
+theorem Icc_mul_Ico_subset' [LocallyFiniteOrder α] (a b c d : α) :
+    Icc a b * Ico c d ⊆ Ico (a * c) (b * d) :=
+  Finset.coe_subset.mp <| by simpa using Set.Icc_mul_Ico_subset' _ _ _ _
+
+@[to_additive Ico_add_Icc_subset]
+theorem Ico_mul_Icc_subset' [LocallyFiniteOrder α] (a b c d : α) :
+    Ico a b * Icc c d ⊆ Ico (a * c) (b * d) :=
+  Finset.coe_subset.mp <| by simpa using Set.Ico_mul_Icc_subset' _ _ _ _
+
+@[to_additive Ioc_add_Ico_subset]
+theorem Ioc_mul_Ico_subset' [LocallyFiniteOrder α] (a b c d : α) :
+    Ioc a b * Ico c d ⊆ Ioo (a * c) (b * d) :=
+  Finset.coe_subset.mp <| by simpa using Set.Ioc_mul_Ico_subset' _ _ _ _
+
+@[to_additive Ico_add_Ioc_subset]
+theorem Ico_mul_Ioc_subset' [LocallyFiniteOrder α] (a b c d : α) :
+    Ico a b * Ioc c d ⊆ Ioo (a * c) (b * d) :=
+  Finset.coe_subset.mp <| by simpa using Set.Ico_mul_Ioc_subset' _ _ _ _
+
+@[to_additive Iic_add_Iio_subset]
+theorem Iic_mul_Iio_subset' [LocallyFiniteOrderBot α] (a b : α) : Iic a * Iio b ⊆ Iio (a * b) :=
+  Finset.coe_subset.mp <| by simpa using Set.Iic_mul_Iio_subset' _ _
+
+@[to_additive Iio_add_Iic_subset]
+theorem Iio_mul_Iic_subset' [LocallyFiniteOrderBot α] (a b : α) : Iio a * Iic b ⊆ Iio (a * b) :=
+  Finset.coe_subset.mp <| by simpa using Set.Iio_mul_Iic_subset' _ _
+
+@[to_additive Ioi_add_Ici_subset]
+theorem Ioi_mul_Ici_subset' [LocallyFiniteOrderTop α] (a b : α) : Ioi a * Ici b ⊆ Ioi (a * b) :=
+  Finset.coe_subset.mp <| by simpa using Set.Ioi_mul_Ici_subset' _ _
+
+@[to_additive Ici_add_Ioi_subset]
+theorem Ici_mul_Ioi_subset' [LocallyFiniteOrderTop α] (a b : α) : Ici a * Ioi b ⊆ Ioi (a * b) :=
+  Finset.coe_subset.mp <| by simpa using Set.Ici_mul_Ioi_subset' _ _
+
+end ContravariantLT
+
+end Finset

--- a/Mathlib/Data/Finset/Pointwise/Interval.lean
+++ b/Mathlib/Data/Finset/Pointwise/Interval.lean
@@ -34,9 +34,9 @@ section ContravariantLE
 variable [Mul α] [Preorder α] [DecidableEq α]
 variable [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (Function.swap HMul.hMul) LE.le]
 
-
 @[to_additive Icc_add_Icc_subset]
-theorem Icc_mul_Icc_subset' [LocallyFiniteOrder α] (a b c d : α) : Icc a b * Icc c d ⊆ Icc (a * c) (b * d) :=
+theorem Icc_mul_Icc_subset' [LocallyFiniteOrder α] (a b c d : α) :
+    Icc a b * Icc c d ⊆ Icc (a * c) (b * d) :=
   Finset.coe_subset.mp <| by simpa using Set.Icc_mul_Icc_subset' _ _ _ _
 
 @[to_additive Iic_add_Iic_subset]

--- a/Mathlib/Data/Set/Pointwise/Interval.lean
+++ b/Mathlib/Data/Set/Pointwise/Interval.lean
@@ -37,23 +37,20 @@ and `Set.Ico_mul_Ioc_subset`.
 section ContravariantMulLE
 
 variable [Mul α] [Preorder α]
-variable [CovariantClass α α HMul.hMul LE.le] [CovariantClass α α (Function.swap HMul.hMul) LE.le]
+variable [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (Function.swap HMul.hMul) LE.le]
 
 @[to_additive]
-theorem Icc_mul_Icc_subset (a b c d : α) :
-    Set.Icc a b * Set.Icc c d ⊆ Set.Icc (a * c) (b * d) := by
+theorem Icc_mul_Icc_subset (a b c d : α) : Icc a b * Icc c d ⊆ Icc (a * c) (b * d) := by
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_le_mul' hya hzc, mul_le_mul' hyb hzd⟩
 
 @[to_additive]
-theorem Ici_mul_Ici_subset (a b : α) :
-    Set.Ici a * Set.Ici b ⊆ Set.Ici (a * b) := by
+theorem Ici_mul_Ici_subset (a b : α) : Ici a * Ici b ⊆ Ici (a * b) := by
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_le_mul' hya hzb
 
 @[to_additive]
-theorem Iic_mul_Iic_subset (a b : α) :
-    Set.Iic a * Set.Iic b ⊆ Set.Iic (a * b) := by
+theorem Iic_mul_Iic_subset (a b : α) : Iic a * Iic b ⊆ Iic (a * b) := by
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_le_mul' hya hzb
 
@@ -62,52 +59,52 @@ end ContravariantMulLE
 section ContravariantLT
 
 variable [Mul α] [PartialOrder α]
-variable [CovariantClass α α HMul.hMul LT.lt] [CovariantClass α α (Function.swap HMul.hMul) LT.lt]
+variable [CovariantClass α α (· * ·) (· < ·)] [CovariantClass α α (Function.swap HMul.hMul) LT.lt]
 
 @[to_additive]
-theorem Icc_mul_Ico_subset (a b c d : α) : Set.Icc a b * Set.Ico c d ⊆ Set.Ico (a * c) (b * d) := by
+theorem Icc_mul_Ico_subset (a b c d : α) : Icc a b * Ico c d ⊆ Ico (a * c) (b * d) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_le_mul' hya hzc, mul_lt_mul_of_le_of_lt hyb hzd⟩
 
 @[to_additive]
-theorem Iic_mul_Iio_subset (a b : α) : Set.Iic a * Set.Iio b ⊆ Set.Iio (a * b) := by
+theorem Iic_mul_Iio_subset (a b : α) : Iic a * Iio b ⊆ Iio (a * b) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_le_of_lt hya hzb
 
 @[to_additive]
-theorem Ico_mul_Icc_subset (a b c d : α) : Set.Ico a b * Set.Icc c d ⊆ Set.Ico (a * c) (b * d) := by
+theorem Ico_mul_Icc_subset (a b c d : α) : Ico a b * Icc c d ⊆ Ico (a * c) (b * d) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_le_mul' hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
 
 @[to_additive]
-theorem Iio_mul_Iic_subset (a b : α) : Set.Iio a * Set.Iic b ⊆ Set.Iio (a * b) := by
+theorem Iio_mul_Iic_subset (a b : α) : Iio a * Iic b ⊆ Iio (a * b) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_lt_of_le hya hzb
 
 @[to_additive]
-theorem Ioc_mul_Ico_subset (a b c d : α) : Set.Ioc a b * Set.Ico c d ⊆ Set.Ioo (a * c) (b * d) := by
+theorem Ioc_mul_Ico_subset (a b c d : α) : Ioc a b * Ico c d ⊆ Ioo (a * c) (b * d) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_lt_mul_of_lt_of_le hya hzc, mul_lt_mul_of_le_of_lt hyb hzd⟩
 
 @[to_additive]
-theorem Ioi_mul_Ici_subset (a b : α) : Set.Ioi a * Set.Ici b ⊆ Set.Ioi (a * b) := by
+theorem Ioi_mul_Ici_subset (a b : α) : Ioi a * Ici b ⊆ Ioi (a * b) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_lt_of_le hya hzb
 
 @[to_additive]
-theorem Ico_mul_Ioc_subset (a b c d : α) : Set.Ico a b * Set.Ioc c d ⊆ Set.Ioo (a * c) (b * d) := by
+theorem Ico_mul_Ioc_subset (a b c d : α) : Ico a b * Ioc c d ⊆ Ioo (a * c) (b * d) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_lt_mul_of_le_of_lt hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
 
 @[to_additive]
-theorem Ici_mul_Ioi_subset (a b : α) : Set.Ici a * Set.Ioi b ⊆ Set.Ioi (a * b) := by
+theorem Ici_mul_Ioi_subset (a b : α) : Ici a * Ioi b ⊆ Ioi (a * b) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_le_of_lt hya hzb

--- a/Mathlib/Data/Set/Pointwise/Interval.lean
+++ b/Mathlib/Data/Set/Pointwise/Interval.lean
@@ -66,53 +66,49 @@ variable [CovariantClass α α HMul.hMul LT.lt] [CovariantClass α α (Function.
 
 @[to_additive]
 theorem Icc_mul_Ico_subset (a b c d : α) : Set.Icc a b * Set.Ico c d ⊆ Set.Ico (a * c) (b * d) := by
-  letI := covariantClass_le_of_lt
+  haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_le_mul' hya hzc, mul_lt_mul_of_le_of_lt hyb hzd⟩
 
 @[to_additive]
-theorem Iic_mul_Iio_subset (a b : α) :
-    Set.Iic a * Set.Iio b ⊆ Set.Iio (a * b) := by
-  letI := covariantClass_le_of_lt
+theorem Iic_mul_Iio_subset (a b : α) : Set.Iic a * Set.Iio b ⊆ Set.Iio (a * b) := by
+  haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_le_of_lt hya hzb
 
 @[to_additive]
 theorem Ico_mul_Icc_subset (a b c d : α) : Set.Ico a b * Set.Icc c d ⊆ Set.Ico (a * c) (b * d) := by
-  letI := covariantClass_le_of_lt
+  haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_le_mul' hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
 
 @[to_additive]
-theorem Iio_mul_Iic_subset (a b : α) :
-    Set.Iio a * Set.Iic b ⊆ Set.Iio (a * b) := by
-  letI := covariantClass_le_of_lt
+theorem Iio_mul_Iic_subset (a b : α) : Set.Iio a * Set.Iic b ⊆ Set.Iio (a * b) := by
+  haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_lt_of_le hya hzb
 
 @[to_additive]
 theorem Ioc_mul_Ico_subset (a b c d : α) : Set.Ioc a b * Set.Ico c d ⊆ Set.Ioo (a * c) (b * d) := by
-  letI := covariantClass_le_of_lt
+  haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_lt_mul_of_lt_of_le hya hzc, mul_lt_mul_of_le_of_lt hyb hzd⟩
 
 @[to_additive]
-theorem Ioi_mul_Ici_subset (a b : α) :
-    Set.Ioi a * Set.Ici b ⊆ Set.Ioi (a * b) := by
-  letI := covariantClass_le_of_lt
+theorem Ioi_mul_Ici_subset (a b : α) : Set.Ioi a * Set.Ici b ⊆ Set.Ioi (a * b) := by
+  haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_lt_of_le hya hzb
 
 @[to_additive]
 theorem Ico_mul_Ioc_subset (a b c d : α) : Set.Ico a b * Set.Ioc c d ⊆ Set.Ioo (a * c) (b * d) := by
-  letI := covariantClass_le_of_lt
+  haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_lt_mul_of_le_of_lt hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
 
 @[to_additive]
-theorem Ici_mul_Ioi_subset (a b : α) :
-    Set.Ici a * Set.Ioi b ⊆ Set.Ioi (a * b) := by
-  letI := covariantClass_le_of_lt
+theorem Ici_mul_Ioi_subset (a b : α) : Set.Ici a * Set.Ioi b ⊆ Set.Ioi (a * b) := by
+  haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_le_of_lt hya hzb
 

--- a/Mathlib/Data/Set/Pointwise/Interval.lean
+++ b/Mathlib/Data/Set/Pointwise/Interval.lean
@@ -68,22 +68,10 @@ theorem Icc_mul_Ico_subset (a b c d : α) : Icc a b * Ico c d ⊆ Ico (a * c) (b
   exact ⟨mul_le_mul' hya hzc, mul_lt_mul_of_le_of_lt hyb hzd⟩
 
 @[to_additive]
-theorem Iic_mul_Iio_subset (a b : α) : Iic a * Iio b ⊆ Iio (a * b) := by
-  haveI := covariantClass_le_of_lt
-  rintro x ⟨y, z, hya, hzb, rfl⟩
-  exact mul_lt_mul_of_le_of_lt hya hzb
-
-@[to_additive]
 theorem Ico_mul_Icc_subset (a b c d : α) : Ico a b * Icc c d ⊆ Ico (a * c) (b * d) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_le_mul' hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
-
-@[to_additive]
-theorem Iio_mul_Iic_subset (a b : α) : Iio a * Iic b ⊆ Iio (a * b) := by
-  haveI := covariantClass_le_of_lt
-  rintro x ⟨y, z, hya, hzb, rfl⟩
-  exact mul_lt_mul_of_lt_of_le hya hzb
 
 @[to_additive]
 theorem Ioc_mul_Ico_subset (a b c d : α) : Ioc a b * Ico c d ⊆ Ioo (a * c) (b * d) := by
@@ -92,16 +80,28 @@ theorem Ioc_mul_Ico_subset (a b c d : α) : Ioc a b * Ico c d ⊆ Ioo (a * c) (b
   exact ⟨mul_lt_mul_of_lt_of_le hya hzc, mul_lt_mul_of_le_of_lt hyb hzd⟩
 
 @[to_additive]
-theorem Ioi_mul_Ici_subset (a b : α) : Ioi a * Ici b ⊆ Ioi (a * b) := by
+theorem Ico_mul_Ioc_subset (a b c d : α) : Ico a b * Ioc c d ⊆ Ioo (a * c) (b * d) := by
+  haveI := covariantClass_le_of_lt
+  rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
+  exact ⟨mul_lt_mul_of_le_of_lt hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
+
+@[to_additive]
+theorem Iic_mul_Iio_subset (a b : α) : Iic a * Iio b ⊆ Iio (a * b) := by
+  haveI := covariantClass_le_of_lt
+  rintro x ⟨y, z, hya, hzb, rfl⟩
+  exact mul_lt_mul_of_le_of_lt hya hzb
+
+@[to_additive]
+theorem Iio_mul_Iic_subset (a b : α) : Iio a * Iic b ⊆ Iio (a * b) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_lt_of_le hya hzb
 
 @[to_additive]
-theorem Ico_mul_Ioc_subset (a b c d : α) : Ico a b * Ioc c d ⊆ Ioo (a * c) (b * d) := by
+theorem Ioi_mul_Ici_subset (a b : α) : Ioi a * Ici b ⊆ Ioi (a * b) := by
   haveI := covariantClass_le_of_lt
-  rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
-  exact ⟨mul_lt_mul_of_le_of_lt hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
+  rintro x ⟨y, z, hya, hzb, rfl⟩
+  exact mul_lt_mul_of_lt_of_le hya hzb
 
 @[to_additive]
 theorem Ici_mul_Ioi_subset (a b : α) : Ici a * Ioi b ⊆ Ioi (a * b) := by

--- a/Mathlib/Data/Set/Pointwise/Interval.lean
+++ b/Mathlib/Data/Set/Pointwise/Interval.lean
@@ -27,6 +27,57 @@ variable {α : Type*}
 
 namespace Set
 
+/-! ### Binary pointwise operations
+
+Note that the subset operations below only cover the cases with the largest possible intervals on
+the LHS: to conclude that `Ioo a b * Ioo c d ⊆ Ioo (a * c) (c * d)`, you can use monotonicity of `*`
+and `Set.Ico_mul_Ioc_subset`.
+-/
+
+section ContravariantMulLE
+
+variable [Mul α] [Preorder α]
+variable [CovariantClass α α HMul.hMul LE.le] [CovariantClass α α (Function.swap HMul.hMul) LE.le]
+
+@[to_additive]
+theorem Icc_mul_Icc_subset (a b c d : α) :
+    Set.Icc a b * Set.Icc c d ⊆ Set.Icc (a * c) (b * d) := by
+  rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
+  exact ⟨mul_le_mul' hya hzc, mul_le_mul' hyb hzd⟩
+
+end ContravariantMulLE
+
+section ContravariantLT
+
+variable [Mul α] [PartialOrder α]
+variable [CovariantClass α α HMul.hMul LT.lt] [CovariantClass α α (Function.swap HMul.hMul) LT.lt]
+
+@[to_additive]
+theorem Icc_mul_Ico_subset (a b c d : α) : Set.Icc a b * Set.Ico c d ⊆ Set.Ico (a * c) (b * d) := by
+  letI := covariantClass_le_of_lt
+  rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
+  exact ⟨mul_le_mul' hya hzc, mul_lt_mul_of_le_of_lt hyb hzd⟩
+
+@[to_additive]
+theorem Ico_mul_Icc_subset (a b c d : α) : Set.Ico a b * Set.Icc c d ⊆ Set.Ico (a * c) (b * d) := by
+  letI := covariantClass_le_of_lt
+  rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
+  exact ⟨mul_le_mul' hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
+
+@[to_additive]
+theorem Ioc_mul_Ico_subset (a b c d : α) : Set.Ioc a b * Set.Ico c d ⊆ Set.Ioo (a * c) (b * d) := by
+  letI := covariantClass_le_of_lt
+  rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
+  exact ⟨mul_lt_mul_of_lt_of_le hya hzc, mul_lt_mul_of_le_of_lt hyb hzd⟩
+
+@[to_additive]
+theorem Ico_mul_Ioc_subset (a b c d : α) : Set.Ico a b * Set.Ioc c d ⊆ Set.Ioo (a * c) (b * d) := by
+  letI := covariantClass_le_of_lt
+  rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
+  exact ⟨mul_lt_mul_of_le_of_lt hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
+
+end ContravariantLT
+
 section OrderedAddCommGroup
 
 variable [OrderedAddCommGroup α] (a b c : α)

--- a/Mathlib/Data/Set/Pointwise/Interval.lean
+++ b/Mathlib/Data/Set/Pointwise/Interval.lean
@@ -45,6 +45,18 @@ theorem Icc_mul_Icc_subset (a b c d : α) :
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_le_mul' hya hzc, mul_le_mul' hyb hzd⟩
 
+@[to_additive]
+theorem Ici_mul_Ici_subset (a b : α) :
+    Set.Ici a * Set.Ici b ⊆ Set.Ici (a * b) := by
+  rintro x ⟨y, z, hya, hzb, rfl⟩
+  exact mul_le_mul' hya hzb
+
+@[to_additive]
+theorem Iic_mul_Iic_subset (a b : α) :
+    Set.Iic a * Set.Iic b ⊆ Set.Iic (a * b) := by
+  rintro x ⟨y, z, hya, hzb, rfl⟩
+  exact mul_le_mul' hya hzb
+
 end ContravariantMulLE
 
 section ContravariantLT
@@ -59,10 +71,24 @@ theorem Icc_mul_Ico_subset (a b c d : α) : Set.Icc a b * Set.Ico c d ⊆ Set.Ic
   exact ⟨mul_le_mul' hya hzc, mul_lt_mul_of_le_of_lt hyb hzd⟩
 
 @[to_additive]
+theorem Iic_mul_Iio_subset (a b : α) :
+    Set.Iic a * Set.Iio b ⊆ Set.Iio (a * b) := by
+  letI := covariantClass_le_of_lt
+  rintro x ⟨y, z, hya, hzb, rfl⟩
+  exact mul_lt_mul_of_le_of_lt hya hzb
+
+@[to_additive]
 theorem Ico_mul_Icc_subset (a b c d : α) : Set.Ico a b * Set.Icc c d ⊆ Set.Ico (a * c) (b * d) := by
   letI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_le_mul' hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
+
+@[to_additive]
+theorem Iio_mul_Iic_subset (a b : α) :
+    Set.Iio a * Set.Iic b ⊆ Set.Iio (a * b) := by
+  letI := covariantClass_le_of_lt
+  rintro x ⟨y, z, hya, hzb, rfl⟩
+  exact mul_lt_mul_of_lt_of_le hya hzb
 
 @[to_additive]
 theorem Ioc_mul_Ico_subset (a b c d : α) : Set.Ioc a b * Set.Ico c d ⊆ Set.Ioo (a * c) (b * d) := by
@@ -71,10 +97,24 @@ theorem Ioc_mul_Ico_subset (a b c d : α) : Set.Ioc a b * Set.Ico c d ⊆ Set.Io
   exact ⟨mul_lt_mul_of_lt_of_le hya hzc, mul_lt_mul_of_le_of_lt hyb hzd⟩
 
 @[to_additive]
+theorem Ioi_mul_Ici_subset (a b : α) :
+    Set.Ioi a * Set.Ici b ⊆ Set.Ioi (a * b) := by
+  letI := covariantClass_le_of_lt
+  rintro x ⟨y, z, hya, hzb, rfl⟩
+  exact mul_lt_mul_of_lt_of_le hya hzb
+
+@[to_additive]
 theorem Ico_mul_Ioc_subset (a b c d : α) : Set.Ico a b * Set.Ioc c d ⊆ Set.Ioo (a * c) (b * d) := by
   letI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_lt_mul_of_le_of_lt hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
+
+@[to_additive]
+theorem Ici_mul_Ioi_subset (a b : α) :
+    Set.Ici a * Set.Ioi b ⊆ Set.Ioi (a * b) := by
+  letI := covariantClass_le_of_lt
+  rintro x ⟨y, z, hya, hzb, rfl⟩
+  exact mul_lt_mul_of_le_of_lt hya hzb
 
 end ContravariantLT
 

--- a/Mathlib/Data/Set/Pointwise/Interval.lean
+++ b/Mathlib/Data/Set/Pointwise/Interval.lean
@@ -47,13 +47,13 @@ theorem Icc_mul_Icc_subset' (a b c d : α) : Icc a b * Icc c d ⊆ Icc (a * c) (
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_le_mul' hya hzc, mul_le_mul' hyb hzd⟩
 
-@[to_additive Ici_add_Ici_subset]
-theorem Ici_mul_Ici_subset' (a b : α) : Ici a * Ici b ⊆ Ici (a * b) := by
+@[to_additive Iic_add_Iic_subset]
+theorem Iic_mul_Iic_subset' (a b : α) : Iic a * Iic b ⊆ Iic (a * b) := by
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_le_mul' hya hzb
 
-@[to_additive Iic_add_Iic_subset]
-theorem Iic_mul_Iic_subset' (a b : α) : Iic a * Iic b ⊆ Iic (a * b) := by
+@[to_additive Ici_add_Ici_subset]
+theorem Ici_mul_Ici_subset' (a b : α) : Ici a * Ici b ⊆ Ici (a * b) := by
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_le_mul' hya hzb
 

--- a/Mathlib/Data/Set/Pointwise/Interval.lean
+++ b/Mathlib/Data/Set/Pointwise/Interval.lean
@@ -32,79 +32,82 @@ namespace Set
 Note that the subset operations below only cover the cases with the largest possible intervals on
 the LHS: to conclude that `Ioo a b * Ioo c d ⊆ Ioo (a * c) (c * d)`, you can use monotonicity of `*`
 and `Set.Ico_mul_Ioc_subset`.
+
+TODO: repeat these lemmas for the generality of `mul_le_mul` (which assumes nonnegativity), which
+the unprimed names have been reserved for
 -/
 
-section ContravariantMulLE
+section ContravariantLE
 
 variable [Mul α] [Preorder α]
 variable [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (Function.swap HMul.hMul) LE.le]
 
-@[to_additive]
-theorem Icc_mul_Icc_subset (a b c d : α) : Icc a b * Icc c d ⊆ Icc (a * c) (b * d) := by
+@[to_additive Icc_add_Icc_subset]
+theorem Icc_mul_Icc_subset' (a b c d : α) : Icc a b * Icc c d ⊆ Icc (a * c) (b * d) := by
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_le_mul' hya hzc, mul_le_mul' hyb hzd⟩
 
-@[to_additive]
-theorem Ici_mul_Ici_subset (a b : α) : Ici a * Ici b ⊆ Ici (a * b) := by
+@[to_additive Ici_add_Ici_subset]
+theorem Ici_mul_Ici_subset' (a b : α) : Ici a * Ici b ⊆ Ici (a * b) := by
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_le_mul' hya hzb
 
-@[to_additive]
-theorem Iic_mul_Iic_subset (a b : α) : Iic a * Iic b ⊆ Iic (a * b) := by
+@[to_additive Iic_add_Iic_subset]
+theorem Iic_mul_Iic_subset' (a b : α) : Iic a * Iic b ⊆ Iic (a * b) := by
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_le_mul' hya hzb
 
-end ContravariantMulLE
+end ContravariantLE
 
 section ContravariantLT
 
 variable [Mul α] [PartialOrder α]
 variable [CovariantClass α α (· * ·) (· < ·)] [CovariantClass α α (Function.swap HMul.hMul) LT.lt]
 
-@[to_additive]
-theorem Icc_mul_Ico_subset (a b c d : α) : Icc a b * Ico c d ⊆ Ico (a * c) (b * d) := by
+@[to_additive Icc_add_Ico_subset]
+theorem Icc_mul_Ico_subset' (a b c d : α) : Icc a b * Ico c d ⊆ Ico (a * c) (b * d) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_le_mul' hya hzc, mul_lt_mul_of_le_of_lt hyb hzd⟩
 
-@[to_additive]
-theorem Ico_mul_Icc_subset (a b c d : α) : Ico a b * Icc c d ⊆ Ico (a * c) (b * d) := by
+@[to_additive Ico_add_Icc_subset]
+theorem Ico_mul_Icc_subset' (a b c d : α) : Ico a b * Icc c d ⊆ Ico (a * c) (b * d) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_le_mul' hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
 
-@[to_additive]
-theorem Ioc_mul_Ico_subset (a b c d : α) : Ioc a b * Ico c d ⊆ Ioo (a * c) (b * d) := by
+@[to_additive Ioc_add_Ico_subset]
+theorem Ioc_mul_Ico_subset' (a b c d : α) : Ioc a b * Ico c d ⊆ Ioo (a * c) (b * d) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_lt_mul_of_lt_of_le hya hzc, mul_lt_mul_of_le_of_lt hyb hzd⟩
 
-@[to_additive]
-theorem Ico_mul_Ioc_subset (a b c d : α) : Ico a b * Ioc c d ⊆ Ioo (a * c) (b * d) := by
+@[to_additive Ico_add_Ioc_subset]
+theorem Ico_mul_Ioc_subset' (a b c d : α) : Ico a b * Ioc c d ⊆ Ioo (a * c) (b * d) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, ⟨hya, hyb⟩, ⟨hzc, hzd⟩, rfl⟩
   exact ⟨mul_lt_mul_of_le_of_lt hya hzc, mul_lt_mul_of_lt_of_le hyb hzd⟩
 
-@[to_additive]
-theorem Iic_mul_Iio_subset (a b : α) : Iic a * Iio b ⊆ Iio (a * b) := by
+@[to_additive Iic_add_Iio_subset]
+theorem Iic_mul_Iio_subset' (a b : α) : Iic a * Iio b ⊆ Iio (a * b) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_le_of_lt hya hzb
 
-@[to_additive]
-theorem Iio_mul_Iic_subset (a b : α) : Iio a * Iic b ⊆ Iio (a * b) := by
+@[to_additive Iio_add_Iic_subset]
+theorem Iio_mul_Iic_subset' (a b : α) : Iio a * Iic b ⊆ Iio (a * b) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_lt_of_le hya hzb
 
-@[to_additive]
-theorem Ioi_mul_Ici_subset (a b : α) : Ioi a * Ici b ⊆ Ioi (a * b) := by
+@[to_additive Ioi_add_Ici_subset]
+theorem Ioi_mul_Ici_subset' (a b : α) : Ioi a * Ici b ⊆ Ioi (a * b) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_lt_of_le hya hzb
 
-@[to_additive]
-theorem Ici_mul_Ioi_subset (a b : α) : Ici a * Ioi b ⊆ Ioi (a * b) := by
+@[to_additive Ici_add_Ioi_subset]
+theorem Ici_mul_Ioi_subset' (a b : α) : Ici a * Ioi b ⊆ Ioi (a * b) := by
   haveI := covariantClass_le_of_lt
   rintro x ⟨y, z, hya, hzb, rfl⟩
   exact mul_lt_mul_of_le_of_lt hya hzb


### PR DESCRIPTION
As remarked in the docstring, to avoid an explosion of lemmas, the subset operations only cover the cases with the largest possible intervals on the LHS: to conclude that `Ioo a b * Ioo c d ⊆ Ioo (a * c) (c * d)`, you can use monotonicity of `*` and `Finset.Ico_mul_Ioc_subset`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
