### PR TITLE
[Merged by Bors] - chore: remove redundant coercion in SlashInvariantForms

### DIFF
--- a/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
@@ -91,11 +91,6 @@ open SlashInvariantForm
 
 variable {F : Type*} {Γ : outParam <| Subgroup SL(2, ℤ)} {k : outParam ℤ}
 
-instance (priority := 100) SlashInvariantFormClass.coeToFun [SlashInvariantFormClass F Γ k] :
-    CoeFun F fun _ => ℍ → ℂ :=
-  FunLike.hasCoeToFun
-#align slash_invariant_form.slash_invariant_form_class.coe_to_fun SlashInvariantForm.SlashInvariantFormClass.coeToFun
-
 -- @[simp] -- Porting note: simpNF says LHS simplifies to something more complex
 theorem slash_action_eqn [SlashInvariantFormClass F Γ k] (f : F) (γ : Γ) : ↑f ∣[k] γ = ⇑f :=
   SlashInvariantFormClass.slash_action_eq f γ


### PR DESCRIPTION
This coercion is redundant with one already available via a FunLike instance. It's not actually particularly significant by itself, but it is shows up in many typeclass search traces, and because it comes first, obscures more serious problems!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
