### PR TITLE
[Merged by Bors] - fix: remove unused arguments

### DIFF
--- a/Mathlib/CategoryTheory/Limits/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/Limits/FintypeCat.lean
@@ -23,7 +23,7 @@ universe u
 
 namespace CategoryTheory.Limits.FintypeCat
 
-instance {J : Type} [SmallCategory J] [FinCategory J] (K : J ⥤ FintypeCat.{u}) (j : J) :
+instance {J : Type} [SmallCategory J] (K : J ⥤ FintypeCat.{u}) (j : J) :
     Finite ((K ⋙ FintypeCat.incl.{u}).obj j) := by
   simp only [comp_obj, FintypeCat.incl_obj]
   infer_instance

--- a/Mathlib/CategoryTheory/Preadditive/Injective.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Injective.lean
@@ -88,7 +88,7 @@ section
 
 open ZeroObject
 
-instance zero_injective [HasZeroObject C] [HasZeroMorphisms C] : Injective (0 : C) :=
+instance zero_injective [HasZeroObject C] : Injective (0 : C) :=
   (isZero_zero C).injective
 #align category_theory.injective.zero_injective CategoryTheory.Injective.zero_injective
 

--- a/Mathlib/CategoryTheory/Preadditive/Projective.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Projective.lean
@@ -93,7 +93,7 @@ section
 
 open ZeroObject
 
-instance zero_projective [HasZeroObject C] [HasZeroMorphisms C] : Projective (0 : C) :=
+instance zero_projective [HasZeroObject C] : Projective (0 : C) :=
   (isZero_zero C).projective
 #align category_theory.projective.zero_projective CategoryTheory.Projective.zero_projective
 

--- a/Mathlib/CategoryTheory/Sites/RegularExtensive.lean
+++ b/Mathlib/CategoryTheory/Sites/RegularExtensive.lean
@@ -216,7 +216,7 @@ def EqualizerFirstObjIso (F : Cᵒᵖ ⥤ Type (max u v)) {B X : C} (π : X ⟶ 
       | mk => rfl
     inv_hom_id := by aesop }
 
-instance {B X : C} (π : X ⟶ B) [EffectiveEpi π] [HasPullback π π] :
+instance {B X : C} (π : X ⟶ B) [HasPullback π π] :
     (Presieve.singleton π).hasPullbacks where
   has_pullbacks hf _ hg := by
     cases hf

--- a/Mathlib/CategoryTheory/Sites/RegularExtensive.lean
+++ b/Mathlib/CategoryTheory/Sites/RegularExtensive.lean
@@ -228,8 +228,7 @@ The `SecondObj` in the sheaf condition diagram is isomorphic to `F` applied to
 with itself
 -/
 noncomputable
-def EqualizerSecondObjIso (F : Cᵒᵖ ⥤ Type (max u v)) {B X : C} (π : X ⟶ B) [EffectiveEpi π]
-    [HasPullback π π] :
+def EqualizerSecondObjIso (F : Cᵒᵖ ⥤ Type (max u v)) {B X : C} (π : X ⟶ B) [HasPullback π π] :
     Equalizer.Presieve.SecondObj F (Presieve.singleton π) ≅ F.obj (op (Limits.pullback π π)) :=
   Types.productIso.{max u v, max u v} _ ≪≫
   { hom := fun e ↦ e (⟨X, ⟨π, Presieve.singleton_self π⟩⟩, ⟨X, ⟨π, Presieve.singleton_self π⟩⟩)

--- a/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
@@ -227,7 +227,7 @@ instance : SMul Mᵈᵐᵃ (A →+ B) where
 instance [DistribSMul M' A] [SMulCommClass M M' A] : SMulCommClass Mᵈᵐᵃ M'ᵈᵐᵃ (A →+ B) :=
   FunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
-instance [Monoid M'] [DistribSMul M' B] : SMulCommClass Mᵈᵐᵃ M' (A →+ B) :=
+instance [DistribSMul M' B] : SMulCommClass Mᵈᵐᵃ M' (A →+ B) :=
   FunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 theorem smul_addMonoidHom_apply (c : Mᵈᵐᵃ) (f : A →+ B) (a : A) : (c • f) a = f (mk.symm c • a) :=

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -156,7 +156,7 @@ theorem mutuallySingular_singularPart (μ ν : Measure α) : μ.singularPart ν 
     exact MutuallySingular.zero_left
 #align measure_theory.measure.mutually_singular_singular_part MeasureTheory.Measure.mutuallySingular_singularPart
 
-instance instHaveLebesgueDecomposition_singularPart [HaveLebesgueDecomposition μ ν] :
+instance instHaveLebesgueDecomposition_singularPart :
     HaveLebesgueDecomposition (μ.singularPart ν) ν :=
   ⟨⟨μ.singularPart ν, 0⟩, measurable_zero, mutuallySingular_singularPart μ ν, by simp⟩
 

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -240,8 +240,7 @@ lemma MutuallySingular.rnDeriv_ae_eq_zero {μ ν : Measure α} (hμν : μ ⟂�
     exact hμν
   · rw [rnDeriv_of_not_haveLebesgueDecomposition h]
 
-lemma rnDeriv_singularPart (μ ν : Measure α) [μ.HaveLebesgueDecomposition ν] :
-    (μ.singularPart ν).rnDeriv ν =ᵐ[ν] 0 := by
+lemma rnDeriv_singularPart (μ ν : Measure α) : (μ.singularPart ν).rnDeriv ν =ᵐ[ν] 0 := by
   rw [rnDeriv_eq_zero]
   exact mutuallySingular_singularPart μ ν
 

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -226,7 +226,7 @@ def spanCone [∀ (s : Finset I) (i : I), Decidable (i ∈ s)] : Cone (spanFunct
 
 /-- `spanCone` is a limit cone. -/
 noncomputable
-def spanCone_isLimit [∀ (s : Finset I) (i : I), Decidable (i ∈ s)] [DecidableEq I] :
+def spanCone_isLimit [∀ (s : Finset I) (i : I), Decidable (i ∈ s)] :
     CategoryTheory.Limits.IsLimit (spanCone hC) := by
   refine (IsLimit.postcomposeHomEquiv (NatIso.ofComponents
     (fun s ↦ (Profinite.isoOfBijective _ (iso_map_bijective C (· ∈ unop s)))) ?_) (spanCone hC))

--- a/Mathlib/Topology/Category/Profinite/Product.lean
+++ b/Mathlib/Topology/Category/Profinite/Product.lean
@@ -131,19 +131,19 @@ instance isIso_indexCone_lift [DecidableEq ι] :
 
 /-- The canonical map from `C` to the explicit limit as an isomorphism. -/
 noncomputable
-def isoindexConeLift [DecidableEq ι] :
+def isoindexConeLift :
     @Profinite.of C _ (by rwa [← isCompact_iff_compactSpace]) _ _ ≅
     (Profinite.limitCone (indexFunctor hC)).pt :=
   asIso <| (Profinite.limitConeIsLimit _).lift (indexCone hC)
 
 /-- The isomorphism of cones induced by `isoindexConeLift`. -/
 noncomputable
-def asLimitindexConeIso [DecidableEq ι] : indexCone hC ≅ Profinite.limitCone _ :=
+def asLimitindexConeIso : indexCone hC ≅ Profinite.limitCone _ :=
   Limits.Cones.ext (isoindexConeLift hC) fun _ => rfl
 
 /-- `indexCone` is a limit cone. -/
 noncomputable
-def indexCone_isLimit [DecidableEq ι] : CategoryTheory.Limits.IsLimit (indexCone hC) :=
+def indexCone_isLimit : CategoryTheory.Limits.IsLimit (indexCone hC) :=
   Limits.IsLimit.ofIsoLimit (Profinite.limitConeIsLimit _) (asLimitindexConeIso hC).symm
 
 end Profinite

--- a/Mathlib/Topology/Category/Profinite/Product.lean
+++ b/Mathlib/Topology/Category/Profinite/Product.lean
@@ -93,7 +93,7 @@ def indexCone : Cone (indexFunctor hC) where
   pt := @Profinite.of C _ (by rwa [← isCompact_iff_compactSpace]) _ _
   π := { app := fun J ↦ π_app C (· ∈ unop J) }
 
-instance isIso_indexCone_lift [DecidableEq ι] :
+instance isIso_indexCone_lift :
     IsIso ((limitConeIsLimit (indexFunctor hC)).lift (indexCone hC)) :=
   haveI : CompactSpace C := by rwa [← isCompact_iff_compactSpace]
   isIso_of_bijective _

--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -954,7 +954,7 @@ theorem tendsto_order_unbounded {f : β → α} {a : α} {x : Filter β} (hu : �
 
 end Preorder
 
-instance tendstoIxxNhdsWithin {α : Type*} [Preorder α] [TopologicalSpace α] (a : α) {s t : Set α}
+instance tendstoIxxNhdsWithin {α : Type*} [TopologicalSpace α] (a : α) {s t : Set α}
     {Ixx} [TendstoIxxClass Ixx (𝓝 a) (𝓝 a)] [TendstoIxxClass Ixx (𝓟 s) (𝓟 t)] :
     TendstoIxxClass Ixx (𝓝[s] a) (𝓝[t] a) :=
   Filter.tendstoIxxClass_inf


### PR DESCRIPTION
These are split from #8226 (and subsequent changes in #8366), and arise from the fact the latest Lean is better at detecting these due to better abstraction.

I can't comment on whether any of these should be concerning, but putting them in a small commit makes it easier for someone to find and review them later.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

These are cherry-picked so will produce no merge conflicts.