### PR TITLE
[Merged by Bors] - chore: disable global instance `Subtype.measureSpace`

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -1656,6 +1656,7 @@ theorem integral_subtype_comap {α} [MeasurableSpace α] {μ : Measure α} {s : 
   rw [← map_comap_subtype_coe hs]
   exact ((MeasurableEmbedding.subtype_coe hs).integral_map _).symm
 
+attribute [local instance] Measure.Subtype.measureSpace in
 theorem integral_subtype {α} [MeasureSpace α] {s : Set α} (hs : MeasurableSet s) (f : α → G) :
     ∫ x : s, f x = ∫ x in s, f x := integral_subtype_comap hs f
 #align measure_theory.set_integral_eq_subtype MeasureTheory.integral_subtype

--- a/Mathlib/MeasureTheory/Integral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/Periodic.lean
@@ -142,6 +142,7 @@ noncomputable def measurableEquivIco (a : ℝ) : AddCircle T ≃ᵐ Ico a (a + T
   measurable_invFun := AddCircle.measurable_mk'.comp measurable_subtype_coe
 #align add_circle.measurable_equiv_Ico AddCircle.measurableEquivIco
 
+attribute [local instance] Subtype.measureSpace in
 /-- The lower integral of a function over `AddCircle T` is equal to the lower integral over an
 interval (t, t + T] in `ℝ` of its lift to `ℝ`. -/
 protected theorem lintegral_preimage (t : ℝ) (f : AddCircle T → ℝ≥0∞) :
@@ -164,6 +165,7 @@ protected theorem lintegral_preimage (t : ℝ) (f : AddCircle T → ℝ≥0∞) 
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
 
+attribute [local instance] Subtype.measureSpace in
 /-- The integral of an almost-everywhere strongly measurable function over `AddCircle T` is equal
 to the integral over an interval (t, t + T] in `ℝ` of its lift to `ℝ`. -/
 protected theorem integral_preimage (t : ℝ) (f : AddCircle T → E) :

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -1453,7 +1453,11 @@ section MeasureSpace
 
 variable {s : Set α} [MeasureSpace α] {p : α → Prop}
 
-/-- In a measure space, one can restrict the measure to a subtype to get a new measure space. -/
+/-- In a measure space, one can restrict the measure to a subtype to get a new measure space.
+
+Not registered as an instance, as there are other natural choices such as the normalized restriction
+for a probability measure, or the subspace measure when restricting to a vector subspace. Enable
+locally if needed with `attribute [local instance] Measure.Subtype.measureSpace`. -/
 def Subtype.measureSpace : MeasureSpace (Subtype p) where
   volume := Measure.comap Subtype.val volume
 #align measure_theory.measure.subtype.measure_space MeasureTheory.Measure.Subtype.measureSpace

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -1453,10 +1453,12 @@ section MeasureSpace
 
 variable {s : Set α} [MeasureSpace α] {p : α → Prop}
 
-instance Subtype.measureSpace : MeasureSpace (Subtype p) :=
+def Subtype.measureSpace : MeasureSpace (Subtype p) :=
   { Subtype.instMeasurableSpace with
     volume := Measure.comap Subtype.val volume }
 #align measure_theory.measure.subtype.measure_space MeasureTheory.Measure.Subtype.measureSpace
+
+attribute [local instance] Subtype.measureSpace
 
 theorem Subtype.volume_def : (volume : Measure s) = volume.comap Subtype.val :=
   rfl

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -1454,8 +1454,8 @@ section MeasureSpace
 variable {s : Set α} [MeasureSpace α] {p : α → Prop}
 
 /-- In a measure space, one can restrict the measure to a subtype to get a new measure space. -/
-def Subtype.measureSpace : MeasureSpace (Subtype p) :=
-  { volume := Measure.comap Subtype.val volume }
+def Subtype.measureSpace : MeasureSpace (Subtype p) where
+  volume := Measure.comap Subtype.val volume
 #align measure_theory.measure.subtype.measure_space MeasureTheory.Measure.Subtype.measureSpace
 
 attribute [local instance] Subtype.measureSpace
@@ -4216,6 +4216,8 @@ variable [MeasureSpace α] {s t : Set α}
 
 /-!
 ### Volume on `s : Set α`
+
+Note the instance is provided earlier as `Subtype.measureSpace`.
 -/
 attribute [local instance] Subtype.measureSpace
 

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -1453,9 +1453,9 @@ section MeasureSpace
 
 variable {s : Set α} [MeasureSpace α] {p : α → Prop}
 
+/-- In a measure space, one can restrict the measure to a subtype to get a new measure space. -/
 def Subtype.measureSpace : MeasureSpace (Subtype p) :=
-  { Subtype.instMeasurableSpace with
-    volume := Measure.comap Subtype.val volume }
+  { volume := Measure.comap Subtype.val volume }
 #align measure_theory.measure.subtype.measure_space MeasureTheory.Measure.Subtype.measureSpace
 
 attribute [local instance] Subtype.measureSpace
@@ -4217,11 +4217,9 @@ variable [MeasureSpace α] {s t : Set α}
 /-!
 ### Volume on `s : Set α`
 -/
+attribute [local instance] Subtype.measureSpace
 
-
-instance SetCoe.measureSpace (s : Set α) : MeasureSpace s :=
-  ⟨comap ((↑) : s → α) volume⟩
-#align set_coe.measure_space SetCoe.measureSpace
+#align set_coe.measure_space MeasureTheory.Measure.Subtype.measureSpace
 
 theorem volume_set_coe_def (s : Set α) : (volume : Measure s) = comap ((↑) : s → α) volume :=
   rfl


### PR DESCRIPTION
Currently, a subtype of a `MeasureSpace` has a `MeasureSpace` instance, obtained by restricting the initial measure. There are however other reasonable constructions, like the normalized restriction for a probability measure, or the subspace measure when restricting to a vector subspace. We disable the global instance `Subtype.measureSpace` to make these other choices possible, as discussed [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/MeasureSpace.20instance.20on.20Subtype/near/395920337).

It turns out that this instance was duplicated in `SetCoe.measureSpace`, so we delete the other one.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
