### PR TITLE
[Merged by Bors] - refactor(LinearAlgebra.ProjectiveSpace): localize notation and rename folder

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2379,9 +2379,9 @@ import Mathlib.LinearAlgebra.Pi
 import Mathlib.LinearAlgebra.PiTensorProduct
 import Mathlib.LinearAlgebra.Prod
 import Mathlib.LinearAlgebra.Projection
-import Mathlib.LinearAlgebra.ProjectiveSpace.Basic
-import Mathlib.LinearAlgebra.ProjectiveSpace.Independence
-import Mathlib.LinearAlgebra.ProjectiveSpace.Subspace
+import Mathlib.LinearAlgebra.Projectivization.Basic
+import Mathlib.LinearAlgebra.Projectivization.Independence
+import Mathlib.LinearAlgebra.Projectivization.Subspace
 import Mathlib.LinearAlgebra.QuadraticForm.Basic
 import Mathlib.LinearAlgebra.QuadraticForm.Complex
 import Mathlib.LinearAlgebra.QuadraticForm.Dual

--- a/Mathlib/LinearAlgebra/Projectivization/Basic.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Basic.lean
@@ -45,8 +45,8 @@ The notation `ℙ K V` is preferred. -/
 def Projectivization := Quotient (projectivizationSetoid K V)
 #align projectivization Projectivization
 
-scoped[LinearAlgebra.Projectivization]
-notation "ℙ" => Projectivization
+/-- We define notations `ℙ K V` for the projectivization of the `K`-vector space `V`. -/
+scoped[LinearAlgebra.Projectivization] notation "ℙ" => Projectivization
 
 namespace Projectivization
 

--- a/Mathlib/LinearAlgebra/Projectivization/Basic.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Basic.lean
@@ -16,7 +16,8 @@ as well as the bijection between said projectivization and the collection of all
 dimensional subspaces of the vector space.
 
 ## Notation
-`ℙ K V` is notation for `Projectivization K V`, the projectivization of a `K`-vector space `V`.
+`ℙ K V` is localized notation for `Projectivization K V`, the projectivization of a `K`-vector
+space `V`.
 
 ## Constructing terms of `ℙ K V`.
 We have three ways to construct terms of `ℙ K V`:
@@ -32,7 +33,6 @@ We have three ways to construct terms of `ℙ K V`:
 
 -/
 
-
 variable (K V : Type*) [DivisionRing K] [AddCommGroup V] [Module K V]
 
 /-- The setoid whose quotient is the projectivization of `V`. -/
@@ -45,9 +45,12 @@ The notation `ℙ K V` is preferred. -/
 def Projectivization := Quotient (projectivizationSetoid K V)
 #align projectivization Projectivization
 
+scoped[LinearAlgebra.Projectivization]
 notation "ℙ" => Projectivization
 
 namespace Projectivization
+
+open scoped LinearAlgebra.Projectivization
 
 variable {V}
 

--- a/Mathlib/LinearAlgebra/Projectivization/Independence.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Independence.lean
@@ -30,6 +30,7 @@ ambient vector space. Similarly for the definition of dependence.
 - Define projective linear subspaces.
 -/
 
+open scoped LinearAlgebra.Projectivization
 
 variable {ι K V : Type*} [Field K] [AddCommGroup V] [Module K V] {f : ι → ℙ K V}
 

--- a/Mathlib/LinearAlgebra/Projectivization/Independence.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Independence.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Michael Blyth. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Blyth
 -/
-import Mathlib.LinearAlgebra.ProjectiveSpace.Basic
+import Mathlib.LinearAlgebra.Projectivization.Basic
 
 #align_import linear_algebra.projective_space.independence from "leanprover-community/mathlib"@"1e82f5ec4645f6a92bb9e02fce51e44e3bc3e1fe"
 

--- a/Mathlib/LinearAlgebra/Projectivization/Subspace.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Subspace.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Michael Blyth. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Blyth
 -/
-import Mathlib.LinearAlgebra.ProjectiveSpace.Basic
+import Mathlib.LinearAlgebra.Projectivization.Basic
 
 #align_import linear_algebra.projective_space.subspace from "leanprover-community/mathlib"@"70fd9563a21e7b963887c9360bd29b2393e6225a"
 
@@ -35,6 +35,8 @@ also in the subset.
 variable (K V : Type*) [Field K] [AddCommGroup V] [Module K V]
 
 namespace Projectivization
+
+open scoped LinearAlgebra.Projectivization
 
 /-- A subspace of a projective space is a structure consisting of a set of points such that:
 If two nonzero vectors determine points which are in the set, and the sum of the two vectors is


### PR DESCRIPTION
Following https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Projectivization I localize the notation $\mathbb{P}$ to the namespace `LinearAlgebra.Projectivization`. Following the discussion there, the namespace `Projectivization` is not optimal, as the notion can refer to different constructions, hence the choice of adding `LinearAlgebra.` in front of it.

Also, in accordance with the philosophy in the implementation, I replace "Projective Space" by "Projectivization" in the name of the folder, because the idea is that there is no "canonical" choice of the vector space one should start with to construct the projectivization.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
