### PR TITLE
[Merged by Bors] - feat(Algebra/Module/Hom): `AddMonoid.End` application forms a `Module`

### DIFF
--- a/Mathlib/Algebra/Module/Hom.lean
+++ b/Mathlib/Algebra/Module/Hom.lean
@@ -65,18 +65,14 @@ instance isCentralScalar [DistribMulAction Rᵐᵒᵖ B] [IsCentralScalar R B] :
 end
 
 /-- Scalar multiplication on the left as an additive monoid homomorphism. -/
-@[simps (config := .asFn)]
-protected def smulLeft [Monoid M] [AddMonoid A] [DistribMulAction M A] (c : M) : A →+ A where
-  toFun := (c • ·)
-  map_zero' := smul_zero c
-  map_add' := smul_add c
+@[simps! (config := .asFn)]
+protected def smulLeft [Monoid M] [AddMonoid A] [DistribMulAction M A] (c : M) : A →+ A :=
+  DistribMulAction.toAddMonoidHom _ c
 
 /-- Scalar multiplication as a biadditive monoid homomorphism. We need `M` to be commutative
 to have addition on `M →+ M`. -/
-protected def smul [Semiring R] [AddCommMonoid M] [Module R M] : R →+ M →+ M where
-  toFun := .smulLeft
-  map_zero' := AddMonoidHom.ext <| zero_smul _
-  map_add' _ _ := AddMonoidHom.ext <| add_smul _ _
+protected def smul [Semiring R] [AddCommMonoid M] [Module R M] : R →+ M →+ M :=
+  (Module.toAddMonoidEnd R M).toAddMonoidHom
 
 @[simp] theorem coe_smul' [Semiring R] [AddCommMonoid M] [Module R M] :
     ⇑(.smul : R →+ M →+ M) = AddMonoidHom.smulLeft := rfl
@@ -87,3 +83,10 @@ instance module [Semiring R] [AddMonoid A] [AddCommMonoid B] [Module R B] : Modu
 #align add_monoid_hom.module AddMonoidHom.module
 
 end AddMonoidHom
+
+/-- The tautological action by `AddMonoid.End α` on `α`.
+
+This generalizes `AddMonoid.End.applyDistribMulAction`. -/
+instance AddMonoid.End.applyModule [AddCommMonoid A] : Module (AddMonoid.End A) A where
+  add_smul _ _ _ := rfl
+  zero_smul _ := rfl

--- a/Mathlib/Geometry/Euclidean/Angle/Oriented/Affine.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Oriented/Affine.lean
@@ -742,7 +742,7 @@ theorem _root_.Collinear.oangle_sign_of_sameRay_vsub {p₁ p₂ p₃ p₄ : P} (
         exact smul_vsub_rev_mem_vectorSpan_pair _ _ _
     have hp₁p₂s : (p₁, p₅, p₂) ∈ s := by
       simp_rw [Set.mem_image, Set.mem_prod, Set.mem_setOf, Set.mem_univ, true_and_iff, Prod.ext_iff]
-      refine' ⟨⟨⟨p₁, left_mem_affineSpan_pair _ _ _⟩, p₂ -ᵥ p₁⟩,
+      refine' ⟨⟨⟨p₁, left_mem_affineSpan_pair ℝ _ _⟩, p₂ -ᵥ p₁⟩,
         ⟨SameRay.rfl, vsub_ne_zero.2 hp₁p₂.symm⟩, _⟩
       simp
     have hp₃p₄s : (p₃, p₅, p₄) ∈ s := by

--- a/Mathlib/GroupTheory/GroupAction/Defs.lean
+++ b/Mathlib/GroupTheory/GroupAction/Defs.lean
@@ -1121,6 +1121,7 @@ variable {α}
 This is generalized to bundled endomorphisms by:
 * `Equiv.Perm.applyMulAction`
 * `AddMonoid.End.applyDistribMulAction`
+* `AddMonoid.End.applyModule`
 * `AddAut.applyDistribMulAction`
 * `MulAut.applyMulDistribMulAction`
 * `RingHom.applyDistribMulAction`


### PR DESCRIPTION
Mathlib already knew it formed a `DistribMulAction`.

This also cleans up some duplicate definitions from @urkud's #2968.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
