### PR TITLE
[Merged by Bors] - feat: Minimum torsion of a group

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2133,6 +2133,7 @@ import Mathlib.GroupTheory.Index
 import Mathlib.GroupTheory.MonoidLocalization
 import Mathlib.GroupTheory.Nilpotent
 import Mathlib.GroupTheory.NoncommPiCoprod
+import Mathlib.GroupTheory.Order.Min
 import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.GroupTheory.PGroup
 import Mathlib.GroupTheory.Perm.Basic

--- a/Mathlib/Data/ZMod/Quotient.lean
+++ b/Mathlib/Data/ZMod/Quotient.lean
@@ -201,7 +201,7 @@ open Subgroup
 variable {α : Type*} [Group α] (a : α)
 
 /-- See also `Fintype.card_zpowers`. -/
-@[to_additive Nat.card_zmultiples "See also `Fintype.card_zmultiples`."]
+@[to_additive (attr := simp) Nat.card_zmultiples "See also `Fintype.card_zmultiples`."]
 theorem Nat.card_zpowers : Nat.card (zpowers a) = orderOf a := by
   have := Nat.card_congr (MulAction.orbitZpowersEquiv a (1 : α))
   rwa [Nat.card_zmod, orbit_subgroup_one_eq_self] at this

--- a/Mathlib/GroupTheory/Order/Min.lean
+++ b/Mathlib/GroupTheory/Order/Min.lean
@@ -25,10 +25,11 @@ namespace Monoid
 section Monoid
 variable (α) [Monoid α]
 
-/-- The minimum order of a non-identity element. Also the minimum size of a nontrivial subgroup.
-Returns `∞` if the monoid is torsion-free. -/
+/-- The minimum order of a non-identity element. Also the minimum size of a nontrivial subgroup, see
+`Monoid.le_minOrder_iff_forall_subgroup`. Returns `∞` if the monoid is torsion-free. -/
 @[to_additive "The minimum order of a non-identity element. Also the minimum size of a nontrivial
-subgroup. Returns `∞` if the monoid is torsion-free."]
+subgroup, see `AddMonoid.le_minOrder_iff_forall_addSubgroup`. Returns `∞` if the monoid is
+torsion-free."]
 noncomputable def minOrder : ℕ∞ := ⨅ (a : α) (_ha : a ≠ 1) (_ha' : IsOfFinOrder a), orderOf a
 
 variable {α} {a : α}
@@ -51,7 +52,7 @@ end Monoid
 variable [Group α] {s : Subgroup α} {n : ℕ}
 
 @[to_additive]
-lemma le_minOrder' {n : ℕ∞} :
+lemma le_minOrder_iff_forall_subgroup {n : ℕ∞} :
     n ≤ minOrder α ↔ ∀ ⦃s : Subgroup α⦄, s ≠ ⊥ → (s : Set α).Finite → n ≤ Nat.card s := by
   rw [le_minOrder]
   refine ⟨fun h s hs hs' ↦ ?_, fun h a ha ha' ↦ ?_⟩
@@ -63,7 +64,7 @@ lemma le_minOrder' {n : ℕ∞} :
 
 @[to_additive]
 lemma minOrder_le_natCard (hs : s ≠ ⊥) (hs' : (s : Set α).Finite) : minOrder α ≤ Nat.card s :=
-  le_minOrder'.1 le_rfl hs hs'
+  le_minOrder_iff_forall_subgroup.1 le_rfl hs hs'
 
 end Monoid
 
@@ -85,7 +86,7 @@ protected lemma minOrder {n : ℕ} (hn : n ≠ 0) (hn₁ : n ≠ 1) : minOrder (
       not_dvd_of_pos_of_lt (Nat.div_pos (minFac_le hn.bot_lt) n.minFac_pos)
         (div_lt_self hn.bot_lt (minFac_prime hn₁).one_lt)
   refine ((minOrder_le_natCard (zmultiples_eq_bot.not.2 this) $ toFinite _).trans ?_).antisymm $
-    le_minOrder'.2 fun s hs _ ↦ ?_
+    le_minOrder_iff_forall_addSubgroup.2 fun s hs _ ↦ ?_
   · rw [card_eq_fintype_card, Fintype.card_zmultiples, ZMod.addOrderOf_coe _ hn,
       gcd_eq_right (div_dvd_of_dvd n.minFac_dvd), Nat.div_div_self n.minFac_dvd hn]
   · rw [card_eq_fintype_card]

--- a/Mathlib/GroupTheory/Order/Min.lean
+++ b/Mathlib/GroupTheory/Order/Min.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2023 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.GroupTheory.Torsion
+
+/-!
+# Minimum order of an element
+
+This file defines the minimum order of an element of a monoid.
+
+## Main declarations
+
+* `Monoid.minOrder`: The minimum order of an element of a given monoid.
+* `Monoid.minOrder_eq_top`: The minimum order is infinite iff the monoid is torsion-free.
+* `ZMod.minOrder`: The minimum order of $$ℤ/nℤ$$ is the smallest factor of `n`, unless `n = 0, 1`.
+-/
+
+open Subgroup
+
+variable {α : Type*}
+
+namespace Monoid
+section Monoid
+variable (α) [Monoid α]
+
+/-- The minimum order of a non-identity element. Also the minimum size of a nontrivial subgroup.
+Returns `∞` if the monoid is torsion-free. -/
+@[to_additive "The minimum order of a non-identity element. Also the minimum size of a nontrivial
+subgroup. Returns `∞` if the monoid is torsion-free."]
+noncomputable def minOrder : ℕ∞ := ⨅ (a : α) (_ha : a ≠ 1) (_ha' : IsOfFinOrder a), orderOf a
+
+variable {α} {a : α}
+
+@[to_additive (attr := simp)]
+lemma minOrder_eq_top : minOrder α = ⊤ ↔ IsTorsionFree α := by simp [minOrder, IsTorsionFree]
+
+@[to_additive (attr := simp)] protected alias ⟨_, IsTorsionFree.minOrder⟩ := minOrder_eq_top
+
+@[to_additive (attr := simp)]
+lemma le_minOrder {n : ℕ∞} :
+    n ≤ minOrder α ↔ ∀ ⦃a : α⦄, a ≠ 1 → IsOfFinOrder a → n ≤ orderOf a := by simp [minOrder]
+
+@[to_additive]
+lemma minOrder_le_orderOf (ha : a ≠ 1) (ha' : IsOfFinOrder a) : minOrder α ≤ orderOf a :=
+  le_minOrder.1 le_rfl ha ha'
+
+end Monoid
+
+variable [Group α] {s : Subgroup α} {n : ℕ}
+
+@[to_additive]
+lemma le_minOrder' {n : ℕ∞} :
+    n ≤ minOrder α ↔ ∀ ⦃s : Subgroup α⦄, s ≠ ⊥ → (s : Set α).Finite → n ≤ Nat.card s := by
+  rw [le_minOrder]
+  refine ⟨fun h s hs hs' ↦ ?_, fun h a ha ha' ↦ ?_⟩
+  · obtain ⟨a, has, ha⟩ := s.bot_or_exists_ne_one.resolve_left hs
+    exact
+      (h ha $ finite_zpowers.1 $ hs'.subset $ zpowers_le.2 has).trans
+        (WithTop.coe_le_coe.2 $ s.orderOf_le_card hs' has)
+  · simpa using h (zpowers_ne_bot.2 ha) ha'.finite_zpowers
+
+@[to_additive]
+lemma minOrder_le_natCard (hs : s ≠ ⊥) (hs' : (s : Set α).Finite) : minOrder α ≤ Nat.card s :=
+  le_minOrder'.1 le_rfl hs hs'
+
+end Monoid
+
+open AddMonoid AddSubgroup Nat Set
+
+namespace ZMod
+
+@[simp]
+protected lemma minOrder {n : ℕ} (hn : n ≠ 0) (hn₁ : n ≠ 1) : minOrder (ZMod n) = n.minFac := by
+  haveI : Fact (1 < n) := by
+    obtain _ | _ | n := n <;>
+      first
+      | contradiction
+      | exact ⟨n.one_lt_succ_succ⟩
+  classical
+  have : (↑(n / n.minFac) : ZMod n) ≠ 0 := by
+    rw [Ne.def, ringChar.spec, ringChar.eq (ZMod n) n]
+    exact
+      not_dvd_of_pos_of_lt (Nat.div_pos (minFac_le hn.bot_lt) n.minFac_pos)
+        (div_lt_self hn.bot_lt (minFac_prime hn₁).one_lt)
+  refine ((minOrder_le_natCard (zmultiples_eq_bot.not.2 this) $ toFinite _).trans ?_).antisymm $
+    le_minOrder'.2 fun s hs _ ↦ ?_
+  · rw [card_eq_fintype_card, Fintype.card_zmultiples, ZMod.addOrderOf_coe _ hn,
+      gcd_eq_right (div_dvd_of_dvd n.minFac_dvd), Nat.div_div_self n.minFac_dvd hn]
+  · rw [card_eq_fintype_card]
+    haveI : Nontrivial s := s.bot_or_nontrivial.resolve_left hs
+    exact WithTop.coe_le_coe.2 $ minFac_le_of_dvd Fintype.one_lt_card $
+      (card_addSubgroup_dvd_card _).trans (ZMod.card _).dvd
+
+@[simp]
+lemma minOrder_of_prime {p : ℕ} (hp : p.Prime) : minOrder (ZMod p) = p := by
+  rw [ZMod.minOrder hp.ne_zero hp.ne_one, hp.minFac_eq]
+
+end ZMod

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1005,11 +1005,13 @@ theorem orderOf_dvd_natCard {G : Type*} [Group G] (x : G) : orderOf x ∣ Nat.ca
 nonrec lemma Subgroup.orderOf_dvd_natCard (s : Subgroup G) (hx : x ∈ s) :
   orderOf x ∣ Nat.card s := by simpa using orderOf_dvd_natCard (⟨x, hx⟩ : s)
 
+@[to_additive]
 lemma Subgroup.orderOf_le_card (s : Subgroup G) (hs : (s : Set G).Finite) (hx : x ∈ s) :
     orderOf x ≤ Nat.card s :=
   le_of_dvd (Nat.card_pos_iff.2 $ ⟨s.coe_nonempty.to_subtype, hs.to_subtype⟩) $
     s.orderOf_dvd_natCard hx
 
+@[to_additive]
 lemma Submonoid.orderOf_le_card (s : Submonoid G) (hs : (s : Set G).Finite) (hx : x ∈ s) :
     orderOf x ≤ Nat.card s := by
   rw [← Nat.card_submonoidPowers]; exact Nat.card_mono hs $ powers_le.2 hx


### PR DESCRIPTION
This PR define `Monoid.minOrder α`, the minimum order of an element of the monoid `α`. This is also the minimum size of a nontrivial subgroup.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This shows up in the statement of Cauchy-Davenport.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
