### PR TITLE
[Merged by Bors] - feat: Add Set.Nonempty.eq_zero and variations

### DIFF
--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1529,18 +1529,6 @@ theorem eq_of_nonempty_of_subsingleton' {α} [Subsingleton α] {s : Set α} (t :
     (hs : s.Nonempty) [Nonempty t] : s = t :=
   have := hs.to_subtype; eq_of_nonempty_of_subsingleton s t
 
-theorem Nonempty.eq_of_unique [Unique α] {s : Set α} (h : s.Nonempty) :
-    s = {default} := eq_of_nonempty_of_subsingleton' {default} h
-
-theorem Nonempty.eq_zero_of_unique [Zero α] [Unique α] {s : Set α} (h : s.Nonempty) :
-    s = {0} := eq_of_nonempty_of_subsingleton' {0} h
-
-theorem Nonempty.eq_one_of_unique [One α] [Unique α] {s : Set α} (h : s.Nonempty) :
-    s = {1} := eq_of_nonempty_of_subsingleton' {1} h
-
-theorem Nonempty.eq_of_subsingleton [Subsingleton α] {s : Set α} (h : s.Nonempty) (a : α) :
-    s = {a} := eq_of_nonempty_of_subsingleton' {a} h
-
 theorem Nonempty.eq_zero [Subsingleton α] [Zero α] {s : Set α} (h : s.Nonempty) :
     s = {0} := eq_of_nonempty_of_subsingleton' {0} h
 

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1521,33 +1521,31 @@ theorem eq_empty_of_ssubset_singleton {s : Set α} {x : α} (hs : s ⊂ {x}) : s
   ssubset_singleton_iff.1 hs
 #align set.eq_empty_of_ssubset_singleton Set.eq_empty_of_ssubset_singleton
 
-theorem Nonempty.eq_singleton_of_unique [Unique α] {s : Set α} (h : s.Nonempty) :
-    s = {default} := h.subset_singleton_iff.mp (fun x _ => by simp [Unique.uniq _ x])
+theorem eq_of_nonempty_of_subsingleton {α} [Subsingleton α] (s t : Set α) [Nonempty s]
+    [Nonempty t] : s = t :=
+  nonempty_of_nonempty_subtype.eq_univ.trans nonempty_of_nonempty_subtype.eq_univ.symm
 
-theorem Nonempty.eq_singleton_zero_of_unique[Zero α] [Unique α] {s : Set α} (h : s.Nonempty) :
-    s = {0} := by convert h.eq_singleton_of_unique
+theorem eq_of_nonempty_of_subsingleton' {α} [Subsingleton α] {s : Set α} (t : Set α)
+    (hs : s.Nonempty) [Nonempty t] : s = t :=
+  have := hs.to_subtype; eq_of_nonempty_of_subsingleton s t
 
-theorem Nonempty.eq_singleton_one_of_unique [One α] [Unique α] {s : Set α} (h : s.Nonempty) :
-    s = {1} := by convert h.eq_singleton_of_unique
+theorem Nonempty.eq_of_unique [Unique α] {s : Set α} (h : s.Nonempty) :
+    s = {default} := eq_of_nonempty_of_subsingleton' {default} h
 
-noncomputable def uniqueOfNonempty [Subsingleton α] {s : Set α} (h : s.Nonempty) :
-    Unique α := uniqueOfSubsingleton h.choose
+theorem Nonempty.eq_zero_of_unique [Zero α] [Unique α] {s : Set α} (h : s.Nonempty) :
+    s = {0} := eq_of_nonempty_of_subsingleton' {0} h
 
-theorem Nonempty.eq_singleton_of_subsingleton [Subsingleton α] {s : Set α}
-    (h : s.Nonempty) :
-    letI := uniqueOfNonempty h
-    s = {default} := by
-  letI := uniqueOfNonempty h
-  exact h.eq_singleton_of_unique
+theorem Nonempty.eq_one_of_unique [One α] [Unique α] {s : Set α} (h : s.Nonempty) :
+    s = {1} := eq_of_nonempty_of_subsingleton' {1} h
 
 theorem Nonempty.eq_of_subsingleton [Subsingleton α] {s : Set α} (h : s.Nonempty) (a : α) :
-    s = {a} := by rw [h.eq_singleton_of_subsingleton, Unique.uniq _ a]
+    s = {a} := eq_of_nonempty_of_subsingleton' {a} h
 
 theorem Nonempty.eq_zero [Subsingleton α] [Zero α] {s : Set α} (h : s.Nonempty) :
-    s = {0} := h.eq_of_subsingleton 0
+    s = {0} := eq_of_nonempty_of_subsingleton' {0} h
 
-theorem Nonempty.subset_eq_one [Subsingleton α] [One α] {s : Set α} (h : s.Nonempty) :
-    s = {1} := h.eq_of_subsingleton 1
+theorem Nonempty.eq_one [Subsingleton α] [One α] {s : Set α} (h : s.Nonempty) :
+    s = {1} := eq_of_nonempty_of_subsingleton' {1} h
 
 /-! ### Disjointness -/
 

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1521,6 +1521,36 @@ theorem eq_empty_of_ssubset_singleton {s : Set α} {x : α} (hs : s ⊂ {x}) : s
   ssubset_singleton_iff.1 hs
 #align set.eq_empty_of_ssubset_singleton Set.eq_empty_of_ssubset_singleton
 
+theorem Nonempty.eq_singleton_of_nonempty [Unique α] {s : Set α} (h : s.Nonempty) :
+    s = {default} := h.subset_singleton_iff.mp (fun x _ => by simp [Unique.uniq _ x])
+
+theorem Nonempty.eq_singleton_zero_of_nonempty [Zero α] [Unique α] {s : Set α} (h : s.Nonempty) :
+    s = {0} := by convert h.eq_singleton_of_nonempty
+
+theorem Nonempty.eq_singleton_one_of_nonempty [One α] [Unique α] {s : Set α} (h : s.Nonempty) :
+    s = {1} := by convert h.eq_singleton_of_nonempty
+
+noncomputable def uniqueOfNonempty [Subsingleton α] {s : Set α} (h : s.Nonempty) :
+    Unique α := uniqueOfSubsingleton h.choose
+
+theorem Nonempty.eq_singleton_of_nonempty_of_subsingleton [Subsingleton α] {s : Set α}
+    (h : s.Nonempty) :
+    letI := uniqueOfNonempty h
+    s = {default} := by
+  letI := uniqueOfNonempty h
+  exact h.eq_singleton_of_nonempty
+
+theorem subset_eq_of_subsingleton [Subsingleton α] {s : Set α} (h : s.Nonempty) (a : α) :
+    s = {a} := by rw [h.eq_singleton_of_nonempty_of_subsingleton, Unique.uniq _ a]
+
+@[simp]
+theorem subset_eq_zero_of_subsingleton [Subsingleton α] [Zero α] {s : Set α} (h : s.Nonempty) :
+    s = {0} := subset_eq_of_subsingleton h 0
+
+@[simp]
+theorem subset_eq_one_of_subsingleton [Subsingleton α] [One α] {s : Set α} (h : s.Nonempty) :
+    s = {1} := subset_eq_of_subsingleton h 1
+
 /-! ### Disjointness -/
 
 

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1521,14 +1521,14 @@ theorem eq_empty_of_ssubset_singleton {s : Set α} {x : α} (hs : s ⊂ {x}) : s
   ssubset_singleton_iff.1 hs
 #align set.eq_empty_of_ssubset_singleton Set.eq_empty_of_ssubset_singleton
 
-theorem Nonempty.eq_singleton_of_nonempty [Unique α] {s : Set α} (h : s.Nonempty) :
+theorem Nonempty.eq_singleton_of_unique [Unique α] {s : Set α} (h : s.Nonempty) :
     s = {default} := h.subset_singleton_iff.mp (fun x _ => by simp [Unique.uniq _ x])
 
-theorem Nonempty.eq_singleton_zero_of_nonempty [Zero α] [Unique α] {s : Set α} (h : s.Nonempty) :
-    s = {0} := by convert h.eq_singleton_of_nonempty
+theorem Nonempty.eq_singleton_zero_of_unique[Zero α] [Unique α] {s : Set α} (h : s.Nonempty) :
+    s = {0} := by convert h.eq_singleton_of_unique
 
-theorem Nonempty.eq_singleton_one_of_nonempty [One α] [Unique α] {s : Set α} (h : s.Nonempty) :
-    s = {1} := by convert h.eq_singleton_of_nonempty
+theorem Nonempty.eq_singleton_one_of_unique [One α] [Unique α] {s : Set α} (h : s.Nonempty) :
+    s = {1} := by convert h.eq_singleton_of_unique
 
 noncomputable def uniqueOfNonempty [Subsingleton α] {s : Set α} (h : s.Nonempty) :
     Unique α := uniqueOfSubsingleton h.choose
@@ -1538,18 +1538,16 @@ theorem Nonempty.eq_singleton_of_nonempty_of_subsingleton [Subsingleton α] {s :
     letI := uniqueOfNonempty h
     s = {default} := by
   letI := uniqueOfNonempty h
-  exact h.eq_singleton_of_nonempty
+  exact h.eq_singleton_of_unique
 
-theorem subset_eq_of_subsingleton [Subsingleton α] {s : Set α} (h : s.Nonempty) (a : α) :
+theorem Nonempty.eq_of_subsingleton [Subsingleton α] {s : Set α} (h : s.Nonempty) (a : α) :
     s = {a} := by rw [h.eq_singleton_of_nonempty_of_subsingleton, Unique.uniq _ a]
 
-@[simp]
-theorem subset_eq_zero_of_subsingleton [Subsingleton α] [Zero α] {s : Set α} (h : s.Nonempty) :
-    s = {0} := subset_eq_of_subsingleton h 0
+theorem Nonempty.eq_zero [Subsingleton α] [Zero α] {s : Set α} (h : s.Nonempty) :
+    s = {0} := h.eq_of_subsingleton 0
 
-@[simp]
-theorem subset_eq_one_of_subsingleton [Subsingleton α] [One α] {s : Set α} (h : s.Nonempty) :
-    s = {1} := subset_eq_of_subsingleton h 1
+theorem Nonempty.subset_eq_one [Subsingleton α] [One α] {s : Set α} (h : s.Nonempty) :
+    s = {1} := h.eq_of_subsingleton 1
 
 /-! ### Disjointness -/
 

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1533,7 +1533,7 @@ theorem Nonempty.eq_singleton_one_of_unique [One α] [Unique α] {s : Set α} (h
 noncomputable def uniqueOfNonempty [Subsingleton α] {s : Set α} (h : s.Nonempty) :
     Unique α := uniqueOfSubsingleton h.choose
 
-theorem Nonempty.eq_singleton_of_nonempty_of_subsingleton [Subsingleton α] {s : Set α}
+theorem Nonempty.eq_singleton_of_subsingleton [Subsingleton α] {s : Set α}
     (h : s.Nonempty) :
     letI := uniqueOfNonempty h
     s = {default} := by
@@ -1541,7 +1541,7 @@ theorem Nonempty.eq_singleton_of_nonempty_of_subsingleton [Subsingleton α] {s :
   exact h.eq_singleton_of_unique
 
 theorem Nonempty.eq_of_subsingleton [Subsingleton α] {s : Set α} (h : s.Nonempty) (a : α) :
-    s = {a} := by rw [h.eq_singleton_of_nonempty_of_subsingleton, Unique.uniq _ a]
+    s = {a} := by rw [h.eq_singleton_of_subsingleton, Unique.uniq _ a]
 
 theorem Nonempty.eq_zero [Subsingleton α] [Zero α] {s : Set α} (h : s.Nonempty) :
     s = {0} := h.eq_of_subsingleton 0


### PR DESCRIPTION
See [the Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Subset.20equal.20.7B0.7D.20of.20Subsingleton/near/402193512)

Co-authored-by: Ruben Van de Velde <ruben.vandevelde+github@gmail.com>

Co-authored-by: Junyan Xu <junyanxumath@gmail.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
