### PR TITLE
[Merged by Bors] - feat(CategoryTheory): relate mathlib's notion of `EffectiveEpi` to more standard definitions and `RegularEpi`

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
@@ -212,6 +212,15 @@ instance coequalizerRegular (g h : X ⟶ Y) [HasColimit (parallelPair g h)] :
       simp [← w]
 #align category_theory.coequalizer_regular CategoryTheory.coequalizerRegular
 
+/-- A morphism which is a coequalizer for its kernel pair is a regular epi. -/
+noncomputable def regularEpiOfKernelPair {B X : C} (f : X ⟶ B) [HasPullback f f]
+    (hc : IsColimit (Cofork.ofπ f pullback.condition)) : RegularEpi f where
+  W := pullback f f
+  left := pullback.fst
+  right := pullback.snd
+  w := pullback.condition
+  isColimit := hc
+
 /-- Every split epimorphism is a regular epimorphism. -/
 instance (priority := 100) RegularEpi.ofSplitEpi (f : X ⟶ Y) [IsSplitEpi f] : RegularEpi f
     where

--- a/Mathlib/CategoryTheory/Sites/EffectiveEpimorphic.lean
+++ b/Mathlib/CategoryTheory/Sites/EffectiveEpimorphic.lean
@@ -575,9 +575,10 @@ open RegularEpi in
 /-- The data of an `EffectiveEpi` structure on a `RegularEpi`. -/
 noncomputable def effectiveEpiStructOfRegularEpi {B X : C} (f : X ⟶ B) [RegularEpi f] :
     EffectiveEpiStruct f where
-  desc e h := (Cofork.IsColimit.existsUnique isColimit e (h _ _ w)).choose
-  fac e h := (Cofork.IsColimit.existsUnique isColimit e (h _ _ w)).choose_spec.1
-  uniq e h _ hg := (Cofork.IsColimit.existsUnique isColimit e (h _ _ w)).choose_spec.2 _ hg
+  desc _ h := Cofork.IsColimit.desc isColimit _ (h _ _ w)
+  fac _ _ := Cofork.IsColimit.π_desc' isColimit _ _
+  uniq _ _ _ hg := Cofork.IsColimit.hom_ext isColimit (hg.trans
+    (Cofork.IsColimit.π_desc' _ _ _).symm)
 
 instance {B X : C} (f : X ⟶ B) [RegularEpi f] : EffectiveEpi f :=
   ⟨⟨effectiveEpiStructOfRegularEpi f⟩⟩

--- a/Mathlib/CategoryTheory/Sites/EffectiveEpimorphic.lean
+++ b/Mathlib/CategoryTheory/Sites/EffectiveEpimorphic.lean
@@ -21,9 +21,11 @@ The analogous statement for a family of morphisms is in the theorem
 
 We have defined the notion of effective epi for morphisms and families of morphisms in such a
 way that avoids requiring the existence of pullbacks. However, if the relevant pullbacks exist
-then these definitions should be equivalent (project: formalize this!).
+then these definitions are equivalent, see `effectiveEpiStructOfRegularEpi`,
+`regularEpiOfEffectiveEpi`, and `effectiveEpiOfKernelPair`.
 See [nlab: *Effective Epimorphism*](https://ncatlab.org/nlab/show/effective+epimorphism) and
-[Stacks 00WP](https://stacks.math.columbia.edu/tag/00WP) for the standard definitions.
+[Stacks 00WP](https://stacks.math.columbia.edu/tag/00WP) for the standard definitions. Note that
+our notion of `EffectiveEpi` is often called "strict epi" in the literature.
 
 ## References
 - [Elephant]: *Sketches of an Elephant*, P. T. Johnstone: C2.1, Example 2.1.12.
@@ -566,5 +568,50 @@ lemma effectiveEpi_iff_epi {X Y : C} (f : X ⟶ Y) : EffectiveEpi f ↔ Epi f :=
   exact epi_comp _ _
 
 end Epi
+
+section Regular
+
+open RegularEpi in
+/-- The data of an `EffectiveEpi` structure on a `RegularEpi`. -/
+noncomputable def effectiveEpiStructOfRegularEpi {B X : C} (f : X ⟶ B) [RegularEpi f] :
+    EffectiveEpiStruct f where
+  desc e h := (Cofork.IsColimit.existsUnique isColimit e (h _ _ w)).choose
+  fac e h := (Cofork.IsColimit.existsUnique isColimit e (h _ _ w)).choose_spec.1
+  uniq e h _ hg := (Cofork.IsColimit.existsUnique isColimit e (h _ _ w)).choose_spec.2 _ hg
+
+instance {B X : C} (f : X ⟶ B) [RegularEpi f] : EffectiveEpi f :=
+  ⟨⟨effectiveEpiStructOfRegularEpi f⟩⟩
+
+/-- A morphism which is a coequalizer for its kernel pair is an effective epi. -/
+theorem effectiveEpiOfKernelPair {B X : C} (f : X ⟶ B) [HasPullback f f]
+    (hc : IsColimit (Cofork.ofπ f pullback.condition)) : EffectiveEpi f :=
+  let _ := regularEpiOfKernelPair f hc
+  inferInstance
+
+/-- An effective epi which has a kernel pair is a regular epi. -/
+noncomputable instance regularEpiOfEffectiveEpi {B X : C} (f : X ⟶ B) [HasPullback f f]
+    [EffectiveEpi f] : RegularEpi f where
+  W := pullback f f
+  left := pullback.fst
+  right := pullback.snd
+  w := pullback.condition
+  isColimit := {
+    desc := fun s ↦ EffectiveEpi.desc f (s.ι.app WalkingParallelPair.one) fun g₁ g₂ hg ↦ (by
+      simp only [Cofork.app_one_eq_π]
+      rw [← pullback.lift_snd g₁ g₂ hg, Category.assoc, ← Cofork.app_zero_eq_comp_π_right]
+      simp)
+    fac := by
+      intro s j
+      have := EffectiveEpi.fac f (s.ι.app WalkingParallelPair.one) fun g₁ g₂ hg ↦ (by
+          simp only [Cofork.app_one_eq_π]
+          rw [← pullback.lift_snd g₁ g₂ hg, Category.assoc, ← Cofork.app_zero_eq_comp_π_right]
+          simp)
+      simp only [Functor.const_obj_obj, Cofork.app_one_eq_π] at this
+      cases j with
+      | zero => simp [this]
+      | one => simp [this]
+    uniq := fun _ _ h ↦ EffectiveEpi.uniq f _ _ _ (h WalkingParallelPair.one) }
+
+end Regular
 
 end CategoryTheory


### PR DESCRIPTION
We prove that `RegularEpi` implies `EffectiveEpi` in full generality, and its converse under additional hypotheses. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
