### PR TITLE
[Merged by Bors] - chore: exp -> NormedSpace.exp

### DIFF
--- a/Mathlib/Analysis/NormedSpace/DualNumber.lean
+++ b/Mathlib/Analysis/NormedSpace/DualNumber.lean
@@ -19,6 +19,7 @@ These are just restatements of similar statements about `TrivSqZeroExt R M`.
 
 -/
 
+open NormedSpace -- For `exp`.
 
 namespace DualNumber
 

--- a/Mathlib/Analysis/NormedSpace/Exponential.lean
+++ b/Mathlib/Analysis/NormedSpace/Exponential.lean
@@ -61,8 +61,31 @@ We prove most result for an arbitrary field `𝕂`, and then specialize to `𝕂
 
 - `exp_eq_exp` : if `𝔸` is a normed algebra over two fields `𝕂` and `𝕂'`, then `exp 𝕂 = exp 𝕂' 𝔸`
 
+### Notes
+
+We put nearly all the statements in this file in the `NormedSpace` namespace,
+to avoid collisions with the `Real` or `Complex` namespaces.
+
+As of 2023-11-16 due to bad instances in Mathlib
+```
+import Mathlib
+
+open Real
+
+#time example (x : ℝ) : 0 < exp x      := exp_pos _ -- 250ms
+#time example (x : ℝ) : 0 < Real.exp x := exp_pos _ -- 2ms
+```
+This is because `exp x` tries the `exp` function defined here,
+and generates a slow coercion search from `Real` to `Type`, to fit the first argument here.
+We will resolve this slow coercion separately,
+but we want to move `exp` out of the root namespace in any case to avoid this ambiguity.
+
+In the long term is may be possible to replace `Real.exp` and `Complex.exp` with this one.
+
 -/
 
+
+namespace NormedSpace
 
 open Filter IsROrC ContinuousMultilinearMap NormedField Asymptotics
 
@@ -76,7 +99,7 @@ variable (𝕂 𝔸 : Type*) [Field 𝕂] [Ring 𝔸] [Algebra 𝕂 𝔸] [Topol
 `(xᵢ) : 𝔸ⁿ ↦ (1/n! : 𝕂) • ∏ xᵢ`. Its sum is the exponential map `exp 𝕂 : 𝔸 → 𝔸`. -/
 def expSeries : FormalMultilinearSeries 𝕂 𝔸 𝔸 := fun n =>
   (n !⁻¹ : 𝕂) • ContinuousMultilinearMap.mkPiAlgebraFin 𝕂 n 𝔸
-#align exp_series expSeries
+#align exp_series NormedSpace.expSeries
 
 variable {𝔸}
 
@@ -88,26 +111,26 @@ Note that when `𝔸 = Matrix n n 𝕂`, this is the **Matrix Exponential**; see
 case. -/
 noncomputable def exp (x : 𝔸) : 𝔸 :=
   (expSeries 𝕂 𝔸).sum x
-#align exp exp
+#align exp NormedSpace.exp
 
 variable {𝕂}
 
 theorem expSeries_apply_eq (x : 𝔸) (n : ℕ) : (expSeries 𝕂 𝔸 n fun _ => x) = (n !⁻¹ : 𝕂) • x ^ n :=
   by simp [expSeries]
-#align exp_series_apply_eq expSeries_apply_eq
+#align exp_series_apply_eq NormedSpace.expSeries_apply_eq
 
 theorem expSeries_apply_eq' (x : 𝔸) :
     (fun n => expSeries 𝕂 𝔸 n fun _ => x) = fun n => (n !⁻¹ : 𝕂) • x ^ n :=
   funext (expSeries_apply_eq x)
-#align exp_series_apply_eq' expSeries_apply_eq'
+#align exp_series_apply_eq' NormedSpace.expSeries_apply_eq'
 
 theorem expSeries_sum_eq (x : 𝔸) : (expSeries 𝕂 𝔸).sum x = ∑' n : ℕ, (n !⁻¹ : 𝕂) • x ^ n :=
   tsum_congr fun n => expSeries_apply_eq x n
-#align exp_series_sum_eq expSeries_sum_eq
+#align exp_series_sum_eq NormedSpace.expSeries_sum_eq
 
 theorem exp_eq_tsum : exp 𝕂 = fun x : 𝔸 => ∑' n : ℕ, (n !⁻¹ : 𝕂) • x ^ n :=
   funext expSeries_sum_eq
-#align exp_eq_tsum exp_eq_tsum
+#align exp_eq_tsum NormedSpace.exp_eq_tsum
 
 theorem expSeries_apply_zero (n : ℕ) :
     (expSeries 𝕂 𝔸 n fun _ => (0 : 𝔸)) = Pi.single (f := fun _ => 𝔸) 0 1 n := by
@@ -115,45 +138,45 @@ theorem expSeries_apply_zero (n : ℕ) :
   cases' n with n
   · rw [pow_zero, Nat.factorial_zero, Nat.cast_one, inv_one, one_smul, Pi.single_eq_same]
   · rw [zero_pow (Nat.succ_pos _), smul_zero, Pi.single_eq_of_ne n.succ_ne_zero]
-#align exp_series_apply_zero expSeries_apply_zero
+#align exp_series_apply_zero NormedSpace.expSeries_apply_zero
 
 @[simp]
 theorem exp_zero : exp 𝕂 (0 : 𝔸) = 1 := by
   simp_rw [exp_eq_tsum, ← expSeries_apply_eq, expSeries_apply_zero, tsum_pi_single]
-#align exp_zero exp_zero
+#align exp_zero NormedSpace.exp_zero
 
 @[simp]
 theorem exp_op [T2Space 𝔸] (x : 𝔸) : exp 𝕂 (MulOpposite.op x) = MulOpposite.op (exp 𝕂 x) := by
   simp_rw [exp, expSeries_sum_eq, ← MulOpposite.op_pow, ← MulOpposite.op_smul, tsum_op]
-#align exp_op exp_op
+#align exp_op NormedSpace.exp_op
 
 @[simp]
 theorem exp_unop [T2Space 𝔸] (x : 𝔸ᵐᵒᵖ) : exp 𝕂 (MulOpposite.unop x) = MulOpposite.unop (exp 𝕂 x) :=
   by simp_rw [exp, expSeries_sum_eq, ← MulOpposite.unop_pow, ← MulOpposite.unop_smul, tsum_unop]
-#align exp_unop exp_unop
+#align exp_unop NormedSpace.exp_unop
 
 theorem star_exp [T2Space 𝔸] [StarRing 𝔸] [ContinuousStar 𝔸] (x : 𝔸) :
     star (exp 𝕂 x) = exp 𝕂 (star x) := by
   simp_rw [exp_eq_tsum, ← star_pow, ← star_inv_nat_cast_smul, ← tsum_star]
-#align star_exp star_exp
+#align star_exp NormedSpace.star_exp
 
 variable (𝕂)
 
-theorem IsSelfAdjoint.exp [T2Space 𝔸] [StarRing 𝔸] [ContinuousStar 𝔸] {x : 𝔸}
+theorem _root_.IsSelfAdjoint.exp [T2Space 𝔸] [StarRing 𝔸] [ContinuousStar 𝔸] {x : 𝔸}
     (h : IsSelfAdjoint x) : IsSelfAdjoint (exp 𝕂 x) :=
   (star_exp x).trans <| h.symm ▸ rfl
 #align is_self_adjoint.exp IsSelfAdjoint.exp
 
-theorem Commute.exp_right [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) : Commute x (exp 𝕂 y) := by
+theorem _root_.Commute.exp_right [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) : Commute x (exp 𝕂 y) := by
   rw [exp_eq_tsum]
   exact Commute.tsum_right x fun n => (h.pow_right n).smul_right _
 #align commute.exp_right Commute.exp_right
 
-theorem Commute.exp_left [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) : Commute (exp 𝕂 x) y :=
+theorem _root_.Commute.exp_left [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) : Commute (exp 𝕂 x) y :=
   (h.symm.exp_right 𝕂).symm
 #align commute.exp_left Commute.exp_left
 
-theorem Commute.exp [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) : Commute (exp 𝕂 x) (exp 𝕂 y) :=
+theorem _root_.Commute.exp [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) : Commute (exp 𝕂 x) (exp 𝕂 y) :=
   (h.exp_left _).exp_right _
 #align commute.exp Commute.exp
 
@@ -167,20 +190,20 @@ variable {𝕂 𝔸 : Type*} [Field 𝕂] [DivisionRing 𝔸] [Algebra 𝕂 𝔸
 theorem expSeries_apply_eq_div (x : 𝔸) (n : ℕ) : (expSeries 𝕂 𝔸 n fun _ => x) = x ^ n / n ! := by
   rw [div_eq_mul_inv, ← (Nat.cast_commute n ! (x ^ n)).inv_left₀.eq, ← smul_eq_mul,
     expSeries_apply_eq, inv_nat_cast_smul_eq 𝕂 𝔸]
-#align exp_series_apply_eq_div expSeries_apply_eq_div
+#align exp_series_apply_eq_div NormedSpace.expSeries_apply_eq_div
 
 theorem expSeries_apply_eq_div' (x : 𝔸) :
     (fun n => expSeries 𝕂 𝔸 n fun _ => x) = fun n => x ^ n / n ! :=
   funext (expSeries_apply_eq_div x)
-#align exp_series_apply_eq_div' expSeries_apply_eq_div'
+#align exp_series_apply_eq_div' NormedSpace.expSeries_apply_eq_div'
 
 theorem expSeries_sum_eq_div (x : 𝔸) : (expSeries 𝕂 𝔸).sum x = ∑' n : ℕ, x ^ n / n ! :=
   tsum_congr (expSeries_apply_eq_div x)
-#align exp_series_sum_eq_div expSeries_sum_eq_div
+#align exp_series_sum_eq_div NormedSpace.expSeries_sum_eq_div
 
 theorem exp_eq_tsum_div : exp 𝕂 = fun x : 𝔸 => ∑' n : ℕ, x ^ n / n ! :=
   funext expSeries_sum_eq_div
-#align exp_eq_tsum_div exp_eq_tsum_div
+#align exp_eq_tsum_div NormedSpace.exp_eq_tsum_div
 
 end TopologicalDivisionAlgebra
 
@@ -196,7 +219,7 @@ theorem norm_expSeries_summable_of_mem_ball (x : 𝔸)
     (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) :
     Summable fun n => ‖expSeries 𝕂 𝔸 n fun _ => x‖ :=
   (expSeries 𝕂 𝔸).summable_norm_apply hx
-#align norm_exp_series_summable_of_mem_ball norm_expSeries_summable_of_mem_ball
+#align norm_exp_series_summable_of_mem_ball NormedSpace.norm_expSeries_summable_of_mem_ball
 
 theorem norm_expSeries_summable_of_mem_ball' (x : 𝔸)
     (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) :
@@ -204,7 +227,7 @@ theorem norm_expSeries_summable_of_mem_ball' (x : 𝔸)
   change Summable (norm ∘ _)
   rw [← expSeries_apply_eq']
   exact norm_expSeries_summable_of_mem_ball x hx
-#align norm_exp_series_summable_of_mem_ball' norm_expSeries_summable_of_mem_ball'
+#align norm_exp_series_summable_of_mem_ball' NormedSpace.norm_expSeries_summable_of_mem_ball'
 
 section CompleteAlgebra
 
@@ -214,40 +237,40 @@ theorem expSeries_summable_of_mem_ball (x : 𝔸)
     (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) :
     Summable fun n => expSeries 𝕂 𝔸 n fun _ => x :=
   (norm_expSeries_summable_of_mem_ball x hx).of_norm
-#align exp_series_summable_of_mem_ball expSeries_summable_of_mem_ball
+#align exp_series_summable_of_mem_ball NormedSpace.expSeries_summable_of_mem_ball
 
 theorem expSeries_summable_of_mem_ball' (x : 𝔸)
     (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) :
     Summable fun n => (n !⁻¹ : 𝕂) • x ^ n :=
   (norm_expSeries_summable_of_mem_ball' x hx).of_norm
-#align exp_series_summable_of_mem_ball' expSeries_summable_of_mem_ball'
+#align exp_series_summable_of_mem_ball' NormedSpace.expSeries_summable_of_mem_ball'
 
 theorem expSeries_hasSum_exp_of_mem_ball (x : 𝔸)
     (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) :
     HasSum (fun n => expSeries 𝕂 𝔸 n fun _ => x) (exp 𝕂 x) :=
   FormalMultilinearSeries.hasSum (expSeries 𝕂 𝔸) hx
-#align exp_series_has_sum_exp_of_mem_ball expSeries_hasSum_exp_of_mem_ball
+#align exp_series_has_sum_exp_of_mem_ball NormedSpace.expSeries_hasSum_exp_of_mem_ball
 
 theorem expSeries_hasSum_exp_of_mem_ball' (x : 𝔸)
     (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) :
     HasSum (fun n => (n !⁻¹ : 𝕂) • x ^ n) (exp 𝕂 x) := by
   rw [← expSeries_apply_eq']
   exact expSeries_hasSum_exp_of_mem_ball x hx
-#align exp_series_has_sum_exp_of_mem_ball' expSeries_hasSum_exp_of_mem_ball'
+#align exp_series_has_sum_exp_of_mem_ball' NormedSpace.expSeries_hasSum_exp_of_mem_ball'
 
 theorem hasFPowerSeriesOnBall_exp_of_radius_pos (h : 0 < (expSeries 𝕂 𝔸).radius) :
     HasFPowerSeriesOnBall (exp 𝕂) (expSeries 𝕂 𝔸) 0 (expSeries 𝕂 𝔸).radius :=
   (expSeries 𝕂 𝔸).hasFPowerSeriesOnBall h
-#align has_fpower_series_on_ball_exp_of_radius_pos hasFPowerSeriesOnBall_exp_of_radius_pos
+#align has_fpower_series_on_ball_exp_of_radius_pos NormedSpace.hasFPowerSeriesOnBall_exp_of_radius_pos
 
 theorem hasFPowerSeriesAt_exp_zero_of_radius_pos (h : 0 < (expSeries 𝕂 𝔸).radius) :
     HasFPowerSeriesAt (exp 𝕂) (expSeries 𝕂 𝔸) 0 :=
   (hasFPowerSeriesOnBall_exp_of_radius_pos h).hasFPowerSeriesAt
-#align has_fpower_series_at_exp_zero_of_radius_pos hasFPowerSeriesAt_exp_zero_of_radius_pos
+#align has_fpower_series_at_exp_zero_of_radius_pos NormedSpace.hasFPowerSeriesAt_exp_zero_of_radius_pos
 
 theorem continuousOn_exp : ContinuousOn (exp 𝕂 : 𝔸 → 𝔸) (EMetric.ball 0 (expSeries 𝕂 𝔸).radius) :=
   FormalMultilinearSeries.continuousOn
-#align continuous_on_exp continuousOn_exp
+#align continuous_on_exp NormedSpace.continuousOn_exp
 
 theorem analyticAt_exp_of_mem_ball (x : 𝔸) (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) :
     AnalyticAt 𝕂 (exp 𝕂) x := by
@@ -255,7 +278,7 @@ theorem analyticAt_exp_of_mem_ball (x : 𝔸) (hx : x ∈ EMetric.ball (0 : 𝔸
   · rw [h] at hx; exact (ENNReal.not_lt_zero hx).elim
   · have h := pos_iff_ne_zero.mpr h
     exact (hasFPowerSeriesOnBall_exp_of_radius_pos h).analyticAt_of_mem hx
-#align analytic_at_exp_of_mem_ball analyticAt_exp_of_mem_ball
+#align analytic_at_exp_of_mem_ball NormedSpace.analyticAt_exp_of_mem_ball
 
 /-- In a Banach-algebra `𝔸` over a normed field `𝕂` of characteristic zero, if `x` and `y` are
 in the disk of convergence and commute, then `exp 𝕂 (x + y) = (exp 𝕂 x) * (exp 𝕂 y)`. -/
@@ -276,7 +299,7 @@ theorem exp_add_of_commute_of_mem_ball [CharZero 𝕂] {x y : 𝔸} (hxy : Commu
   congr 1
   have : (n ! : 𝕂) ≠ 0 := Nat.cast_ne_zero.mpr n.factorial_ne_zero
   field_simp [this]
-#align exp_add_of_commute_of_mem_ball exp_add_of_commute_of_mem_ball
+#align exp_add_of_commute_of_mem_ball NormedSpace.exp_add_of_commute_of_mem_ball
 
 /-- `exp 𝕂 x` has explicit two-sided inverse `exp 𝕂 (-x)`. -/
 noncomputable def invertibleExpOfMemBall [CharZero 𝕂] {x : 𝔸}
@@ -294,18 +317,18 @@ noncomputable def invertibleExpOfMemBall [CharZero 𝕂] {x : 𝔸}
       exact hx
     rw [← exp_add_of_commute_of_mem_ball (Commute.neg_right <| Commute.refl x) hx hnx, add_neg_self,
       exp_zero]
-#align invertible_exp_of_mem_ball invertibleExpOfMemBall
+#align invertible_exp_of_mem_ball NormedSpace.invertibleExpOfMemBall
 
 theorem isUnit_exp_of_mem_ball [CharZero 𝕂] {x : 𝔸}
     (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) : IsUnit (exp 𝕂 x) :=
   @isUnit_of_invertible _ _ _ (invertibleExpOfMemBall hx)
-#align is_unit_exp_of_mem_ball isUnit_exp_of_mem_ball
+#align is_unit_exp_of_mem_ball NormedSpace.isUnit_exp_of_mem_ball
 
 theorem invOf_exp_of_mem_ball [CharZero 𝕂] {x : 𝔸}
     (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) [Invertible (exp 𝕂 x)] :
     ⅟ (exp 𝕂 x) = exp 𝕂 (-x) := by
   letI := invertibleExpOfMemBall hx; convert (rfl : ⅟ (exp 𝕂 x) = _)
-#align inv_of_exp_of_mem_ball invOf_exp_of_mem_ball
+#align inv_of_exp_of_mem_ball NormedSpace.invOf_exp_of_mem_ball
 
 /-- Any continuous ring homomorphism commutes with `exp`. -/
 theorem map_exp_of_mem_ball {F} [RingHomClass F 𝔸 𝔹] (f : F) (hf : Continuous f) (x : 𝔸)
@@ -314,7 +337,7 @@ theorem map_exp_of_mem_ball {F} [RingHomClass F 𝔸 𝔹] (f : F) (hf : Continu
   refine' ((expSeries_summable_of_mem_ball' _ hx).hasSum.map f hf).tsum_eq.symm.trans _
   dsimp only [Function.comp]
   simp_rw [map_inv_nat_cast_smul f 𝕂 𝕂, map_pow]
-#align map_exp_of_mem_ball map_exp_of_mem_ball
+#align map_exp_of_mem_ball NormedSpace.map_exp_of_mem_ball
 
 end CompleteAlgebra
 
@@ -322,7 +345,7 @@ theorem algebraMap_exp_comm_of_mem_ball [CompleteSpace 𝕂] (x : 𝕂)
     (hx : x ∈ EMetric.ball (0 : 𝕂) (expSeries 𝕂 𝕂).radius) :
     algebraMap 𝕂 𝔸 (exp 𝕂 x) = exp 𝕂 (algebraMap 𝕂 𝔸 x) :=
   map_exp_of_mem_ball _ (continuous_algebraMap 𝕂 𝔸) _ hx
-#align algebra_map_exp_comm_of_mem_ball algebraMap_exp_comm_of_mem_ball
+#align algebra_map_exp_comm_of_mem_ball NormedSpace.algebraMap_exp_comm_of_mem_ball
 
 end AnyFieldAnyAlgebra
 
@@ -338,19 +361,19 @@ theorem norm_expSeries_div_summable_of_mem_ball (x : 𝔸)
   change Summable (norm ∘ _)
   rw [← expSeries_apply_eq_div' (𝕂 := 𝕂) x]
   exact norm_expSeries_summable_of_mem_ball x hx
-#align norm_exp_series_div_summable_of_mem_ball norm_expSeries_div_summable_of_mem_ball
+#align norm_exp_series_div_summable_of_mem_ball NormedSpace.norm_expSeries_div_summable_of_mem_ball
 
 theorem expSeries_div_summable_of_mem_ball [CompleteSpace 𝔸] (x : 𝔸)
     (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) : Summable fun n => x ^ n / n ! :=
   (norm_expSeries_div_summable_of_mem_ball 𝕂 x hx).of_norm
-#align exp_series_div_summable_of_mem_ball expSeries_div_summable_of_mem_ball
+#align exp_series_div_summable_of_mem_ball NormedSpace.expSeries_div_summable_of_mem_ball
 
 theorem expSeries_div_hasSum_exp_of_mem_ball [CompleteSpace 𝔸] (x : 𝔸)
     (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) :
     HasSum (fun n => x ^ n / n !) (exp 𝕂 x) := by
   rw [← expSeries_apply_eq_div' (𝕂 := 𝕂) x]
   exact expSeries_hasSum_exp_of_mem_ball x hx
-#align exp_series_div_has_sum_exp_of_mem_ball expSeries_div_hasSum_exp_of_mem_ball
+#align exp_series_div_has_sum_exp_of_mem_ball NormedSpace.expSeries_div_hasSum_exp_of_mem_ball
 
 variable {𝕂}
 
@@ -358,7 +381,7 @@ theorem exp_neg_of_mem_ball [CharZero 𝕂] [CompleteSpace 𝔸] {x : 𝔸}
     (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) : exp 𝕂 (-x) = (exp 𝕂 x)⁻¹ :=
   letI := invertibleExpOfMemBall hx
   invOf_eq_inv (exp 𝕂 x)
-#align exp_neg_of_mem_ball exp_neg_of_mem_ball
+#align exp_neg_of_mem_ball NormedSpace.exp_neg_of_mem_ball
 
 end AnyFieldDivisionAlgebra
 
@@ -373,7 +396,7 @@ theorem exp_add_of_mem_ball [CharZero 𝕂] {x y : 𝔸}
     (hx : x ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius)
     (hy : y ∈ EMetric.ball (0 : 𝔸) (expSeries 𝕂 𝔸).radius) : exp 𝕂 (x + y) = exp 𝕂 x * exp 𝕂 y :=
   exp_add_of_commute_of_mem_ball (Commute.all x y) hx hy
-#align exp_add_of_mem_ball exp_add_of_mem_ball
+#align exp_add_of_mem_ball NormedSpace.exp_add_of_mem_ball
 
 end AnyFieldCommAlgebra
 
@@ -398,22 +421,22 @@ theorem expSeries_radius_eq_top : (expSeries 𝕂 𝔸).radius = ∞ := by
   have : ‖ContinuousMultilinearMap.mkPiAlgebraFin 𝕂 n 𝔸‖ ≤ 1 :=
     norm_mkPiAlgebraFin_le_of_pos (Ei := fun _ => 𝔸) (Nat.pos_of_ne_zero hn)
   exact mul_le_of_le_one_right (div_nonneg (pow_nonneg r.coe_nonneg n) n !.cast_nonneg) this
-#align exp_series_radius_eq_top expSeries_radius_eq_top
+#align exp_series_radius_eq_top NormedSpace.expSeries_radius_eq_top
 
 theorem expSeries_radius_pos : 0 < (expSeries 𝕂 𝔸).radius := by
   rw [expSeries_radius_eq_top]
   exact WithTop.zero_lt_top
-#align exp_series_radius_pos expSeries_radius_pos
+#align exp_series_radius_pos NormedSpace.expSeries_radius_pos
 
 variable {𝕂 𝔸 𝔹}
 
 theorem norm_expSeries_summable (x : 𝔸) : Summable fun n => ‖expSeries 𝕂 𝔸 n fun _ => x‖ :=
   norm_expSeries_summable_of_mem_ball x ((expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
-#align norm_exp_series_summable norm_expSeries_summable
+#align norm_exp_series_summable NormedSpace.norm_expSeries_summable
 
 theorem norm_expSeries_summable' (x : 𝔸) : Summable fun n => ‖(n !⁻¹ : 𝕂) • x ^ n‖ :=
   norm_expSeries_summable_of_mem_ball' x ((expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
-#align norm_exp_series_summable' norm_expSeries_summable'
+#align norm_exp_series_summable' NormedSpace.norm_expSeries_summable'
 
 section CompleteAlgebra
 
@@ -421,45 +444,45 @@ variable [CompleteSpace 𝔸]
 
 theorem expSeries_summable (x : 𝔸) : Summable fun n => expSeries 𝕂 𝔸 n fun _ => x :=
   (norm_expSeries_summable x).of_norm
-#align exp_series_summable expSeries_summable
+#align exp_series_summable NormedSpace.expSeries_summable
 
 theorem expSeries_summable' (x : 𝔸) : Summable fun n => (n !⁻¹ : 𝕂) • x ^ n :=
   (norm_expSeries_summable' x).of_norm
-#align exp_series_summable' expSeries_summable'
+#align exp_series_summable' NormedSpace.expSeries_summable'
 
 theorem expSeries_hasSum_exp (x : 𝔸) : HasSum (fun n => expSeries 𝕂 𝔸 n fun _ => x) (exp 𝕂 x) :=
   expSeries_hasSum_exp_of_mem_ball x ((expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
-#align exp_series_has_sum_exp expSeries_hasSum_exp
+#align exp_series_has_sum_exp NormedSpace.expSeries_hasSum_exp
 
 theorem exp_series_hasSum_exp' (x : 𝔸) : HasSum (fun n => (n !⁻¹ : 𝕂) • x ^ n) (exp 𝕂 x) :=
   expSeries_hasSum_exp_of_mem_ball' x ((expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
-#align exp_series_has_sum_exp' exp_series_hasSum_exp'
+#align exp_series_has_sum_exp' NormedSpace.exp_series_hasSum_exp'
 
 theorem exp_hasFPowerSeriesOnBall : HasFPowerSeriesOnBall (exp 𝕂) (expSeries 𝕂 𝔸) 0 ∞ :=
   expSeries_radius_eq_top 𝕂 𝔸 ▸ hasFPowerSeriesOnBall_exp_of_radius_pos (expSeries_radius_pos _ _)
-#align exp_has_fpower_series_on_ball exp_hasFPowerSeriesOnBall
+#align exp_has_fpower_series_on_ball NormedSpace.exp_hasFPowerSeriesOnBall
 
 theorem exp_hasFPowerSeriesAt_zero : HasFPowerSeriesAt (exp 𝕂) (expSeries 𝕂 𝔸) 0 :=
   exp_hasFPowerSeriesOnBall.hasFPowerSeriesAt
-#align exp_has_fpower_series_at_zero exp_hasFPowerSeriesAt_zero
+#align exp_has_fpower_series_at_zero NormedSpace.exp_hasFPowerSeriesAt_zero
 
 @[continuity]
 theorem exp_continuous : Continuous (exp 𝕂 : 𝔸 → 𝔸) := by
   rw [continuous_iff_continuousOn_univ, ← Metric.eball_top_eq_univ (0 : 𝔸), ←
     expSeries_radius_eq_top 𝕂 𝔸]
   exact continuousOn_exp
-#align exp_continuous exp_continuous
+#align exp_continuous NormedSpace.exp_continuous
 
 theorem exp_analytic (x : 𝔸) : AnalyticAt 𝕂 (exp 𝕂) x :=
   analyticAt_exp_of_mem_ball x ((expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
-#align exp_analytic exp_analytic
+#align exp_analytic NormedSpace.exp_analytic
 
 /-- In a Banach-algebra `𝔸` over `𝕂 = ℝ` or `𝕂 = ℂ`, if `x` and `y` commute, then
 `exp 𝕂 (x+y) = (exp 𝕂 x) * (exp 𝕂 y)`. -/
 theorem exp_add_of_commute {x y : 𝔸} (hxy : Commute x y) : exp 𝕂 (x + y) = exp 𝕂 x * exp 𝕂 y :=
   exp_add_of_commute_of_mem_ball hxy ((expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
     ((expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
-#align exp_add_of_commute exp_add_of_commute
+#align exp_add_of_commute NormedSpace.exp_add_of_commute
 
 section
 
@@ -468,17 +491,17 @@ variable (𝕂)
 /-- `exp 𝕂 x` has explicit two-sided inverse `exp 𝕂 (-x)`. -/
 noncomputable def invertibleExp (x : 𝔸) : Invertible (exp 𝕂 x) :=
   invertibleExpOfMemBall <| (expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _
-#align invertible_exp invertibleExp
+#align invertible_exp NormedSpace.invertibleExp
 
 theorem isUnit_exp (x : 𝔸) : IsUnit (exp 𝕂 x) :=
   isUnit_exp_of_mem_ball <| (expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _
-#align is_unit_exp isUnit_exp
+#align is_unit_exp NormedSpace.isUnit_exp
 
 theorem invOf_exp (x : 𝔸) [Invertible (exp 𝕂 x)] : ⅟ (exp 𝕂 x) = exp 𝕂 (-x) :=
   invOf_exp_of_mem_ball <| (expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _
-#align inv_of_exp invOf_exp
+#align inv_of_exp NormedSpace.invOf_exp
 
-theorem Ring.inverse_exp (x : 𝔸) : Ring.inverse (exp 𝕂 x) = exp 𝕂 (-x) :=
+theorem _root_.Ring.inverse_exp (x : 𝔸) : Ring.inverse (exp 𝕂 x) = exp 𝕂 (-x) :=
   letI := invertibleExp 𝕂 x
   Ring.inverse_invertible _
 #align ring.inverse_exp Ring.inverse_exp
@@ -488,7 +511,7 @@ theorem exp_mem_unitary_of_mem_skewAdjoint [StarRing 𝔸] [ContinuousStar 𝔸]
   rw [unitary.mem_iff, star_exp, skewAdjoint.mem_iff.mp h, ←
     exp_add_of_commute (Commute.refl x).neg_left, ← exp_add_of_commute (Commute.refl x).neg_right,
     add_left_neg, add_right_neg, exp_zero, and_self_iff]
-#align exp_mem_unitary_of_mem_skew_adjoint exp_mem_unitary_of_mem_skewAdjoint
+#align exp_mem_unitary_of_mem_skew_adjoint NormedSpace.exp_mem_unitary_of_mem_skewAdjoint
 
 end
 
@@ -505,13 +528,13 @@ theorem exp_sum_of_commute {ι} (s : Finset ι) (f : ι → 𝔸)
       ih (h.mono <| Finset.subset_insert _ _)]
     refine' Commute.sum_right _ _ _ fun i hi => _
     exact h.of_refl (Finset.mem_insert_self _ _) (Finset.mem_insert_of_mem hi)
-#align exp_sum_of_commute exp_sum_of_commute
+#align exp_sum_of_commute NormedSpace.exp_sum_of_commute
 
 theorem exp_nsmul (n : ℕ) (x : 𝔸) : exp 𝕂 (n • x) = exp 𝕂 x ^ n := by
   induction' n with n ih
   · rw [Nat.zero_eq, zero_smul, pow_zero, exp_zero]
   · rw [succ_nsmul, pow_succ, exp_add_of_commute ((Commute.refl x).smul_right n), ih]
-#align exp_nsmul exp_nsmul
+#align exp_nsmul NormedSpace.exp_nsmul
 
 variable (𝕂)
 
@@ -519,46 +542,46 @@ variable (𝕂)
 theorem map_exp {F} [RingHomClass F 𝔸 𝔹] (f : F) (hf : Continuous f) (x : 𝔸) :
     f (exp 𝕂 x) = exp 𝕂 (f x) :=
   map_exp_of_mem_ball f hf x <| (expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _
-#align map_exp map_exp
+#align map_exp NormedSpace.map_exp
 
 theorem exp_smul {G} [Monoid G] [MulSemiringAction G 𝔸] [ContinuousConstSMul G 𝔸] (g : G) (x : 𝔸) :
     exp 𝕂 (g • x) = g • exp 𝕂 x :=
   (map_exp 𝕂 (MulSemiringAction.toRingHom G 𝔸 g) (continuous_const_smul g) x).symm
-#align exp_smul exp_smul
+#align exp_smul NormedSpace.exp_smul
 
 theorem exp_units_conj (y : 𝔸ˣ) (x : 𝔸) : exp 𝕂 (y * x * ↑y⁻¹ : 𝔸) = y * exp 𝕂 x * ↑y⁻¹ :=
   exp_smul _ (ConjAct.toConjAct y) x
-#align exp_units_conj exp_units_conj
+#align exp_units_conj NormedSpace.exp_units_conj
 
 theorem exp_units_conj' (y : 𝔸ˣ) (x : 𝔸) : exp 𝕂 (↑y⁻¹ * x * y) = ↑y⁻¹ * exp 𝕂 x * y :=
   exp_units_conj _ _ _
-#align exp_units_conj' exp_units_conj'
+#align exp_units_conj' NormedSpace.exp_units_conj'
 
 @[simp]
-theorem Prod.fst_exp [CompleteSpace 𝔹] (x : 𝔸 × 𝔹) : (exp 𝕂 x).fst = exp 𝕂 x.fst :=
+theorem _root_.Prod.fst_exp [CompleteSpace 𝔹] (x : 𝔸 × 𝔹) : (exp 𝕂 x).fst = exp 𝕂 x.fst :=
   map_exp _ (RingHom.fst 𝔸 𝔹) continuous_fst x
 #align prod.fst_exp Prod.fst_exp
 
 @[simp]
-theorem Prod.snd_exp [CompleteSpace 𝔹] (x : 𝔸 × 𝔹) : (exp 𝕂 x).snd = exp 𝕂 x.snd :=
+theorem _root_.Prod.snd_exp [CompleteSpace 𝔹] (x : 𝔸 × 𝔹) : (exp 𝕂 x).snd = exp 𝕂 x.snd :=
   map_exp _ (RingHom.snd 𝔸 𝔹) continuous_snd x
 #align prod.snd_exp Prod.snd_exp
 
 @[simp]
-theorem Pi.exp_apply {ι : Type*} {𝔸 : ι → Type*} [Fintype ι] [∀ i, NormedRing (𝔸 i)]
+theorem _root_.Pi.exp_apply {ι : Type*} {𝔸 : ι → Type*} [Fintype ι] [∀ i, NormedRing (𝔸 i)]
     [∀ i, NormedAlgebra 𝕂 (𝔸 i)] [∀ i, CompleteSpace (𝔸 i)] (x : ∀ i, 𝔸 i) (i : ι) :
     exp 𝕂 x i = exp 𝕂 (x i) :=
   map_exp _ (Pi.evalRingHom 𝔸 i) (continuous_apply _) x
   -- porting note: Lean can now handle Π-types in type class inference!
 #align pi.exp_apply Pi.exp_apply
 
-theorem Pi.exp_def {ι : Type*} {𝔸 : ι → Type*} [Fintype ι] [∀ i, NormedRing (𝔸 i)]
+theorem _root_.Pi.exp_def {ι : Type*} {𝔸 : ι → Type*} [Fintype ι] [∀ i, NormedRing (𝔸 i)]
     [∀ i, NormedAlgebra 𝕂 (𝔸 i)] [∀ i, CompleteSpace (𝔸 i)] (x : ∀ i, 𝔸 i) :
     exp 𝕂 x = fun i => exp 𝕂 (x i) :=
   funext <| Pi.exp_apply 𝕂 x
 #align pi.exp_def Pi.exp_def
 
-theorem Function.update_exp {ι : Type*} {𝔸 : ι → Type*} [Fintype ι] [DecidableEq ι]
+theorem _root_.Function.update_exp {ι : Type*} {𝔸 : ι → Type*} [Fintype ι] [DecidableEq ι]
     [∀ i, NormedRing (𝔸 i)] [∀ i, NormedAlgebra 𝕂 (𝔸 i)] [∀ i, CompleteSpace (𝔸 i)] (x : ∀ i, 𝔸 i)
     (j : ι) (xj : 𝔸 j) :
     Function.update (exp 𝕂 x) j (exp 𝕂 xj) = exp 𝕂 (Function.update x j xj) := by
@@ -571,7 +594,7 @@ end CompleteAlgebra
 
 theorem algebraMap_exp_comm (x : 𝕂) : algebraMap 𝕂 𝔸 (exp 𝕂 x) = exp 𝕂 (algebraMap 𝕂 𝔸 x) :=
   algebraMap_exp_comm_of_mem_ball x <| (expSeries_radius_eq_top 𝕂 𝕂).symm ▸ edist_lt_top _ _
-#align algebra_map_exp_comm algebraMap_exp_comm
+#align algebra_map_exp_comm NormedSpace.algebraMap_exp_comm
 
 end AnyAlgebra
 
@@ -584,37 +607,37 @@ variable (𝕂)
 theorem norm_expSeries_div_summable (x : 𝔸) : Summable fun n => ‖(x ^ n / n ! : 𝔸)‖ :=
   norm_expSeries_div_summable_of_mem_ball 𝕂 x
     ((expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
-#align norm_exp_series_div_summable norm_expSeries_div_summable
+#align norm_exp_series_div_summable NormedSpace.norm_expSeries_div_summable
 
 variable [CompleteSpace 𝔸]
 
 theorem expSeries_div_summable (x : 𝔸) : Summable fun n => x ^ n / n ! :=
   (norm_expSeries_div_summable 𝕂 x).of_norm
-#align exp_series_div_summable expSeries_div_summable
+#align exp_series_div_summable NormedSpace.expSeries_div_summable
 
 theorem expSeries_div_hasSum_exp (x : 𝔸) : HasSum (fun n => x ^ n / n !) (exp 𝕂 x) :=
   expSeries_div_hasSum_exp_of_mem_ball 𝕂 x ((expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
-#align exp_series_div_has_sum_exp expSeries_div_hasSum_exp
+#align exp_series_div_has_sum_exp NormedSpace.expSeries_div_hasSum_exp
 
 variable {𝕂}
 
 theorem exp_neg (x : 𝔸) : exp 𝕂 (-x) = (exp 𝕂 x)⁻¹ :=
   exp_neg_of_mem_ball <| (expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _
-#align exp_neg exp_neg
+#align exp_neg NormedSpace.exp_neg
 
 theorem exp_zsmul (z : ℤ) (x : 𝔸) : exp 𝕂 (z • x) = exp 𝕂 x ^ z := by
   obtain ⟨n, rfl | rfl⟩ := z.eq_nat_or_neg
   · rw [zpow_ofNat, coe_nat_zsmul, exp_nsmul]
   · rw [zpow_neg, zpow_ofNat, neg_smul, exp_neg, coe_nat_zsmul, exp_nsmul]
-#align exp_zsmul exp_zsmul
+#align exp_zsmul NormedSpace.exp_zsmul
 
 theorem exp_conj (y : 𝔸) (x : 𝔸) (hy : y ≠ 0) : exp 𝕂 (y * x * y⁻¹) = y * exp 𝕂 x * y⁻¹ :=
   exp_units_conj _ (Units.mk0 y hy) x
-#align exp_conj exp_conj
+#align exp_conj NormedSpace.exp_conj
 
 theorem exp_conj' (y : 𝔸) (x : 𝔸) (hy : y ≠ 0) : exp 𝕂 (y⁻¹ * x * y) = y⁻¹ * exp 𝕂 x * y :=
   exp_units_conj' _ (Units.mk0 y hy) x
-#align exp_conj' exp_conj'
+#align exp_conj' NormedSpace.exp_conj'
 
 end DivisionAlgebra
 
@@ -627,13 +650,13 @@ variable {𝕂 𝔸 : Type*} [IsROrC 𝕂] [NormedCommRing 𝔸] [NormedAlgebra 
 theorem exp_add {x y : 𝔸} : exp 𝕂 (x + y) = exp 𝕂 x * exp 𝕂 y :=
   exp_add_of_mem_ball ((expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
     ((expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
-#align exp_add exp_add
+#align exp_add NormedSpace.exp_add
 
 /-- A version of `exp_sum_of_commute` for a commutative Banach-algebra. -/
 theorem exp_sum {ι} (s : Finset ι) (f : ι → 𝔸) : exp 𝕂 (∑ i in s, f i) = ∏ i in s, exp 𝕂 (f i) := by
   rw [exp_sum_of_commute, Finset.noncommProd_eq_prod]
   exact fun i _hi j _hj _ => Commute.all _ _
-#align exp_sum exp_sum
+#align exp_sum NormedSpace.exp_sum
 
 end CommAlgebra
 
@@ -651,7 +674,7 @@ variable (𝕂 𝕂' 𝔸 : Type*) [Field 𝕂] [Field 𝕂'] [Ring 𝔸] [Algeb
 theorem expSeries_eq_expSeries (n : ℕ) (x : 𝔸) :
     (expSeries 𝕂 𝔸 n fun _ => x) = expSeries 𝕂' 𝔸 n fun _ => x := by
   rw [expSeries_apply_eq, expSeries_apply_eq, inv_nat_cast_smul_eq 𝕂 𝕂']
-#align exp_series_eq_exp_series expSeries_eq_expSeries
+#align exp_series_eq_exp_series NormedSpace.expSeries_eq_expSeries
 
 /-- If a normed ring `𝔸` is a normed algebra over two fields, then they define the same
 exponential function on `𝔸`. -/
@@ -660,16 +683,16 @@ theorem exp_eq_exp : (exp 𝕂 : 𝔸 → 𝔸) = exp 𝕂' := by
   rw [exp, exp]
   refine' tsum_congr fun n => _
   rw [expSeries_eq_expSeries 𝕂 𝕂' 𝔸 n x]
-#align exp_eq_exp exp_eq_exp
+#align exp_eq_exp NormedSpace.exp_eq_exp
 
 theorem exp_ℝ_ℂ_eq_exp_ℂ_ℂ : (exp ℝ : ℂ → ℂ) = exp ℂ :=
   exp_eq_exp ℝ ℂ ℂ
-#align exp_ℝ_ℂ_eq_exp_ℂ_ℂ exp_ℝ_ℂ_eq_exp_ℂ_ℂ
+#align exp_ℝ_ℂ_eq_exp_ℂ_ℂ NormedSpace.exp_ℝ_ℂ_eq_exp_ℂ_ℂ
 
 /-- A version of `Complex.ofReal_exp` for `exp` instead of `Complex.exp` -/
 @[simp, norm_cast]
 theorem of_real_exp_ℝ_ℝ (r : ℝ) : ↑(exp ℝ r) = exp ℂ (r : ℂ) :=
   (map_exp ℝ (algebraMap ℝ ℂ) (continuous_algebraMap _ _) r).trans (congr_fun exp_ℝ_ℂ_eq_exp_ℂ_ℂ _)
-#align of_real_exp_ℝ_ℝ of_real_exp_ℝ_ℝ
+#align of_real_exp_ℝ_ℝ NormedSpace.of_real_exp_ℝ_ℝ
 
 end ScalarTower

--- a/Mathlib/Analysis/NormedSpace/Exponential.lean
+++ b/Mathlib/Analysis/NormedSpace/Exponential.lean
@@ -167,7 +167,8 @@ theorem _root_.IsSelfAdjoint.exp [T2Space 𝔸] [StarRing 𝔸] [ContinuousStar 
   (star_exp x).trans <| h.symm ▸ rfl
 #align is_self_adjoint.exp IsSelfAdjoint.exp
 
-theorem _root_.Commute.exp_right [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) : Commute x (exp 𝕂 y) := by
+theorem _root_.Commute.exp_right [T2Space 𝔸] {x y : 𝔸} (h : Commute x y) :
+    Commute x (exp 𝕂 y) := by
   rw [exp_eq_tsum]
   exact Commute.tsum_right x fun n => (h.pow_right n).smul_right _
 #align commute.exp_right Commute.exp_right

--- a/Mathlib/Analysis/NormedSpace/MatrixExponential.lean
+++ b/Mathlib/Analysis/NormedSpace/MatrixExponential.lean
@@ -62,6 +62,8 @@ results for general rings are instead stated about `Ring.inverse`:
 
 open scoped Matrix BigOperators
 
+open NormedSpace -- For `exp`.
+
 variable (𝕂 : Type*) {m n p : Type*} {n' : m → Type*} {𝔸 : Type*}
 
 namespace Matrix

--- a/Mathlib/Analysis/NormedSpace/QuaternionExponential.lean
+++ b/Mathlib/Analysis/NormedSpace/QuaternionExponential.lean
@@ -24,8 +24,9 @@ This file contains results about `exp` on `Quaternion ℝ`.
 
 -/
 
-
 open scoped Quaternion Nat
+
+open NormedSpace
 
 namespace Quaternion
 

--- a/Mathlib/Analysis/NormedSpace/Spectrum.lean
+++ b/Mathlib/Analysis/NormedSpace/Spectrum.lean
@@ -47,6 +47,8 @@ This file contains the basic theory for the resolvent and spectrum of a Banach a
 
 open scoped ENNReal NNReal
 
+open NormedSpace -- For `exp`.
+
 /-- The *spectral radius* is the supremum of the `nnnorm` (`‖·‖₊`) of elements in the spectrum,
     coerced into an element of `ℝ≥0∞`. Note that it is possible for `spectrum 𝕜 a = ∅`. In this
     case, `spectralRadius a = 0`. It is also possible that `spectrum 𝕜 a` be unbounded (though

--- a/Mathlib/Analysis/NormedSpace/Star/Exponential.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Exponential.lean
@@ -20,6 +20,7 @@ subtypes `selfAdjoint A` and `unitary A`.
   unitaries.
 -/
 
+open NormedSpace -- For `exp`.
 
 section Star
 

--- a/Mathlib/Analysis/NormedSpace/Star/Spectrum.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Spectrum.lean
@@ -21,7 +21,7 @@ section
 
 open scoped Topology ENNReal
 
-open Filter ENNReal spectrum CstarRing
+open Filter ENNReal spectrum CstarRing NormedSpace
 
 section UnitarySpectrum
 
@@ -91,7 +91,7 @@ theorem IsSelfAdjoint.mem_spectrum_eq_re [StarModule ℂ A] {a : A} (ha : IsSelf
     (hz : z ∈ spectrum ℂ a) : z = z.re := by
   have hu := exp_mem_unitary_of_mem_skewAdjoint ℂ (ha.smul_mem_skewAdjoint conj_I)
   let Iu := Units.mk0 I I_ne_zero
-  have : _root_.exp ℂ (I • z) ∈ spectrum ℂ (_root_.exp ℂ (I • a)) := by
+  have : NormedSpace.exp ℂ (I • z) ∈ spectrum ℂ (NormedSpace.exp ℂ (I • a)) := by
     simpa only [Units.smul_def, Units.val_mk0] using
       spectrum.exp_mem_exp (Iu • a) (smul_mem_smul_iff.mpr hz)
   exact Complex.ext (ofReal_re _) <| by

--- a/Mathlib/Analysis/NormedSpace/TrivSqZeroExt.lean
+++ b/Mathlib/Analysis/NormedSpace/TrivSqZeroExt.lean
@@ -38,6 +38,8 @@ variable (𝕜 : Type*) {R M : Type*}
 
 local notation "tsze" => TrivSqZeroExt
 
+open NormedSpace -- For `exp`.
+
 namespace TrivSqZeroExt
 
 section Topology

--- a/Mathlib/Analysis/SpecialFunctions/Exponential.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exponential.lean
@@ -53,7 +53,7 @@ We prove most results for an arbitrary field `𝕂`, and then specialize to `�
 -/
 
 
-open Filter IsROrC ContinuousMultilinearMap NormedField Asymptotics
+open Filter IsROrC ContinuousMultilinearMap NormedField NormedSpace Asymptotics
 
 open scoped Nat Topology BigOperators ENNReal
 
@@ -216,14 +216,14 @@ theorem hasDerivAt_exp_zero : HasDerivAt (exp 𝕂) (1 : 𝕂) 0 :=
 
 end DerivROrC
 
-theorem Complex.exp_eq_exp_ℂ : Complex.exp = _root_.exp ℂ := by
+theorem Complex.exp_eq_exp_ℂ : Complex.exp = NormedSpace.exp ℂ := by
   refine' funext fun x => _
   rw [Complex.exp, exp_eq_tsum_div]
   have : CauSeq.IsComplete ℂ norm := Complex.instIsComplete
   exact tendsto_nhds_unique x.exp'.tendsto_limit (expSeries_div_summable ℝ x).hasSum.tendsto_sum_nat
 #align complex.exp_eq_exp_ℂ Complex.exp_eq_exp_ℂ
 
-theorem Real.exp_eq_exp_ℝ : Real.exp = _root_.exp ℝ := by
+theorem Real.exp_eq_exp_ℝ : Real.exp = NormedSpace.exp ℝ := by
   ext x; exact_mod_cast congr_fun Complex.exp_eq_exp_ℂ x
 #align real.exp_eq_exp_ℝ Real.exp_eq_exp_ℝ
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Series.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Series.lean
@@ -20,6 +20,7 @@ In this file we express trigonometric functions in terms of their series expansi
 * `Real.hasSum_sin`, `Real.sin_eq_tsum`: `Real.sin` as the sum of an infinite series.
 -/
 
+open NormedSpace
 
 open scoped Nat
 

--- a/Mathlib/Combinatorics/Derangements/Exponential.lean
+++ b/Mathlib/Combinatorics/Derangements/Exponential.lean
@@ -17,7 +17,7 @@ The specific lemma is `numDerangements_tendsto_inv_e`.
 -/
 
 
-open Filter
+open Filter NormedSpace
 
 open scoped BigOperators
 

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -71,7 +71,7 @@ Linear algebra:
     examples: ''
   Exponential:
     endomorphism exponential: ''
-    matrix exponential: 'exp'
+    matrix exponential: 'NormedSpace.exp'
 
 # 2.
 Group Theory:


### PR DESCRIPTION
Per discussion at [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Real.2Eexp/near/401485920)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
