### PR TITLE
[Merged by Bors] - fix: `have` should check that the type is a type

### DIFF
--- a/Mathlib/Tactic/Have.lean
+++ b/Mathlib/Tactic/Have.lean
@@ -67,9 +67,9 @@ def haveLetCore (goal : MVarId) (name : TSyntax ``optBinderIdent)
       let t ← match t with
       | none => mkFreshTypeMVar
       | some stx => withRef stx do
-          let e ← Term.elabTerm stx none
-          Term.synthesizeSyntheticMVars false
-          instantiateMVars e
+        let e ← Term.elabType stx
+        Term.synthesizeSyntheticMVars false
+        instantiateMVars e
       let p ← mkFreshExprMVar t MetavarKind.syntheticOpaque n
       pure (p.mvarId!, ← mkForallFVars es t, ← mkLambdaFVars es p)
     let (fvar, goal2) ← (← declFn goal n t p).intro1P

--- a/test/Have.lean
+++ b/test/Have.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Arthur Paulino. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino
 -/
+import Std.Tactic.GuardMsgs
 import Mathlib.Tactic.Have
 
 example : Nat := by
@@ -43,3 +44,10 @@ example : True := by
   have _q
   · exact 6
   simp
+
+/--
+error: type expected, got
+  (Nat.zero : Nat)
+-/
+#guard_msgs in
+example : True := by have h : Nat.zero


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/bug.20in.20mathlib's.20have.20extension/near/402472594).