### PR TITLE
[Merged by Bors] - feat: add and use not_irreducible_pow

### DIFF
--- a/Mathlib/Algebra/Associated.lean
+++ b/Mathlib/Algebra/Associated.lean
@@ -215,15 +215,16 @@ theorem of_irreducible_mul {α} [Monoid α] {x y : α} : Irreducible (x * y) →
   | ⟨_, h⟩ => h _ _ rfl
 #align of_irreducible_mul of_irreducible_mul
 
-theorem of_irreducible_pow {α} [Monoid α] {x : α} {n : ℕ} (hn : n ≠ 1) :
-    Irreducible (x ^ n) → IsUnit x := by
-  obtain hn | hn := hn.lt_or_lt
-  · simp only [Nat.lt_one_iff.mp hn, IsEmpty.forall_iff, not_irreducible_one, pow_zero]
-  intro h
-  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_lt hn
-  rw [pow_succ, add_comm] at h
-  exact (or_iff_left_of_imp isUnit_pow_succ_iff.mp).mp (of_irreducible_mul h)
-#align of_irreducible_pow of_irreducible_pow
+theorem not_irreducible_pow {α} [Monoid α] {x : α} {n : ℕ} (hn : n ≠ 1) :
+    ¬ Irreducible (x ^ n) := by
+  cases n with
+  | zero => simp
+  | succ n =>
+    intro ⟨h₁, h₂⟩
+    have := h₂ _ _ (pow_succ _ _)
+    rw [isUnit_pow_iff (Nat.succ_ne_succ.mp hn), or_self] at this
+    exact h₁ (this.pow _)
+#noalign of_irreducible_pow
 
 theorem irreducible_or_factor {α} [Monoid α] (x : α) (h : ¬IsUnit x) :
     Irreducible x ∨ ∃ a b, ¬IsUnit a ∧ ¬IsUnit b ∧ a * b = x := by
@@ -301,9 +302,9 @@ section CommMonoid
 variable [CommMonoid α] {a : α}
 
 theorem Irreducible.not_square (ha : Irreducible a) : ¬IsSquare a := by
+  rw [isSquare_iff_exists_sq]
   rintro ⟨b, rfl⟩
-  simp only [irreducible_mul_iff, or_self_iff] at ha
-  exact ha.1.not_unit ha.2
+  exact not_irreducible_pow one_lt_two.ne' ha
 #align irreducible.not_square Irreducible.not_square
 
 theorem IsSquare.not_irreducible (ha : IsSquare a) : ¬Irreducible a := fun h => h.not_square ha
@@ -368,9 +369,9 @@ theorem Prime.not_square (hp : Prime p) : ¬IsSquare p :=
 theorem IsSquare.not_prime (ha : IsSquare a) : ¬Prime a := fun h => h.not_square ha
 #align is_square.not_prime IsSquare.not_prime
 
-theorem pow_not_prime {n : ℕ} (hn : n ≠ 1) : ¬Prime (a ^ n) := fun hp =>
-  hp.not_unit <| IsUnit.pow _ <| of_irreducible_pow hn <| hp.irreducible
-#align pow_not_prime pow_not_prime
+theorem not_prime_pow {n : ℕ} (hn : n ≠ 1) : ¬Prime (a ^ n) := fun hp =>
+  not_irreducible_pow hn hp.irreducible
+#align pow_not_prime not_prime_pow
 
 end CancelCommMonoidWithZero
 

--- a/Mathlib/Data/Nat/Prime.lean
+++ b/Mathlib/Data/Nat/Prime.lean
@@ -585,16 +585,16 @@ theorem Prime.dvd_of_dvd_pow {p m n : ℕ} (pp : Prime p) (h : p ∣ m ^ n) : p 
   pp.prime.dvd_of_dvd_pow h
 #align nat.prime.dvd_of_dvd_pow Nat.Prime.dvd_of_dvd_pow
 
-theorem Prime.pow_not_prime' {x n : ℕ} (hn : n ≠ 1) : ¬(x ^ n).Prime :=
-  pow_not_prime hn ∘ Nat.Prime.prime
-#align nat.prime.pow_not_prime' Nat.Prime.pow_not_prime'
+theorem Prime.not_prime_pow' {x n : ℕ} (hn : n ≠ 1) : ¬(x ^ n).Prime :=
+  not_irreducible_pow hn
+#align nat.prime.pow_not_prime' Nat.Prime.not_prime_pow'
 
-theorem Prime.pow_not_prime {x n : ℕ} (hn : 2 ≤ n) : ¬(x ^ n).Prime :=
-  pow_not_prime' ((two_le_iff _).mp hn).2
-#align nat.prime.pow_not_prime Nat.Prime.pow_not_prime
+theorem Prime.not_prime_pow {x n : ℕ} (hn : 2 ≤ n) : ¬(x ^ n).Prime :=
+  not_prime_pow' ((two_le_iff _).mp hn).2
+#align nat.prime.pow_not_prime Nat.Prime.not_prime_pow
 
 theorem Prime.eq_one_of_pow {x n : ℕ} (h : (x ^ n).Prime) : n = 1 :=
-  not_imp_not.mp Prime.pow_not_prime' h
+  not_imp_not.mp Prime.not_prime_pow' h
 #align nat.prime.eq_one_of_pow Nat.Prime.eq_one_of_pow
 
 theorem Prime.pow_eq_iff {p a k : ℕ} (hp : p.Prime) : a ^ k = p ↔ a = p ∧ k = 1 := by

--- a/Mathlib/FieldTheory/Perfect.lean
+++ b/Mathlib/FieldTheory/Perfect.lean
@@ -108,7 +108,7 @@ lemma polynomial_expand_eq (f : R[X]) :
 theorem not_irreducible_expand (f : R[X]) : ¬ Irreducible (expand R p f) := by
   have hp : Fact p.Prime := inferInstance
   rw [polynomial_expand_eq]
-  exact fun hf ↦ hf.not_unit $ (of_irreducible_pow hp.out.ne_one hf).pow p
+  exact not_irreducible_pow hp.out.ne_one
 
 instance (S : Type*) [CommSemiring S] [CharP S p] [PerfectRing S p] :
     PerfectRing (R × S) p := by


### PR DESCRIPTION
Also rename `pow_not_prime` theorems to match.

`not_irreducible_pow` is extracted from flt-regular.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
