### PR TITLE
[Merged by Bors] - chore: faster help text from 'lake exe cache'

### DIFF
--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -68,6 +68,9 @@ def main (args : List String) : IO Unit := do
   let extraRoots := match args with
   | [] => #[]
   | _ :: t => t.toArray.map FilePath.mk
+  if args.isEmpty then
+    println help
+    Process.exit 0
   let hashMemo ← getHashMemo extraRoots
   let hashMap := hashMemo.hashMap
   let goodCurl ← pure !curlArgs.contains (args.headD "") <||> validateCurl


### PR DESCRIPTION
Don't traverse the project when the user just wants help text.

Reduces runtime of `lake exe cache` (with pre-built binary) from 600ms to 200ms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
