### PR TITLE
chore: move 'moreLeanArgs' and 'weakLeanArgs' from 'lean_lib's to 'package'

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -24,11 +24,11 @@ def weakLeanArgs : Array String :=
 
 package mathlib where
   moreServerArgs := moreServerArgs
-
-@[default_target]
-lean_lib Mathlib where
   moreLeanArgs := moreLeanArgs
   weakLeanArgs := weakLeanArgs
+
+@[default_target]
+lean_lib Mathlib
 
 /-- `lake exe runMathlibLinter` runs the linter on all of Mathlib (or individual files). -/
 -- Due to a change in Lake at v4.1.0-rc1, we need to give this a different name
@@ -53,8 +53,6 @@ require Cli from git "https://github.com/leanprover/lean4-cli" @ "main"
 require proofwidgets from git "https://github.com/leanprover-community/ProofWidgets4" @ "v0.0.22"
 
 lean_lib Cache where
-  moreLeanArgs := moreLeanArgs
-  weakLeanArgs := weakLeanArgs
   roots := #[`Cache]
 
 /-- `lake exe cache get` retrieves precompiled `.olean` files from a central server. -/


### PR DESCRIPTION
As far as I can see, these options should just be set for all the libraries in the mathlib package, and it is only historical accident that they were set on a per-library basis.

Ping @tydeu and @digama0 as this came up in our discussion, but I don't think they need to review.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
