### PR TITLE
[Merged by Bors] - refactor: fold isStrictIntComparison into mkNonstrictIntProof in Linarith.Preprocessing

### DIFF
--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -193,50 +193,34 @@ end natToInt
 section strengthenStrictInt
 
 /--
-`isStrictIntComparison tp` is true iff `tp` is a strict inequality between integers
-or the negation of a weak inequality between integers.
--/
-def isStrictIntComparison (e : Expr) : MetaM Bool := do
-  match (← instantiateMVars e).getAppFnArgs with
-  | (``LT.lt, #[.const ``Int [], _, _, _]) => return true
-  | (``GT.gt, #[.const ``Int [], _, _, _]) => return true
-  | (``Not, #[e]) => match e.getAppFnArgs with
-    | (``LE.le, #[.const ``Int [], _, _, _]) => return true
-    | (``GE.ge, #[.const ``Int [], _, _, _]) => return true
-    | _ => return false
-  | _ => return false
-
-/--
 If `pf` is a proof of a strict inequality `(a : ℤ) < b`,
 `mkNonstrictIntProof pf` returns a proof of `a + 1 ≤ b`,
 and similarly if `pf` proves a negated weak inequality.
 -/
-def mkNonstrictIntProof (pf : Expr) : MetaM Expr := do
+def mkNonstrictIntProof (pf : Expr) : MetaM (Option Expr) := do
   match (← instantiateMVars (← inferType pf)).getAppFnArgs with
-  | (``LT.lt, #[_, _, a, b]) =>
+  | (``LT.lt, #[.const ``Int [], _, a, b]) =>
     return mkApp (← mkAppM ``Iff.mpr #[← mkAppOptM ``Int.add_one_le_iff #[a, b]]) pf
-  | (``GT.gt, #[_, _, a, b]) =>
+  | (``GT.gt, #[.const ``Int [], _, a, b]) =>
     return mkApp (← mkAppM ``Iff.mpr #[← mkAppOptM ``Int.add_one_le_iff #[b, a]]) pf
   | (``Not, #[P]) => match P.getAppFnArgs with
-    | (``LE.le, #[_, _, a, b]) =>
+    | (``LE.le, #[.const ``Int [], _, a, b]) =>
       return mkApp (← mkAppM ``Iff.mpr #[← mkAppOptM ``Int.add_one_le_iff #[b, a]])
         (← mkAppM ``lt_of_not_ge #[pf])
-    | (``GE.ge, #[_, _, a, b]) =>
+    | (``GE.ge, #[.const ``Int [], _, a, b]) =>
       return mkApp (← mkAppM ``Iff.mpr #[← mkAppOptM ``Int.add_one_le_iff #[a, b]])
         (← mkAppM ``lt_of_not_ge #[pf])
-    | _ => throwError "mkNonstrictIntProof failed: proof is not an inequality"
-  | _ => throwError "mkNonstrictIntProof failed: proof is not an inequality"
-
+    | _ => return none
+  | _ => return none
 
 /-- `strengthenStrictInt h` turns a proof `h` of a strict integer inequality `t1 < t2`
 into a proof of `t1 ≤ t2 + 1`. -/
 def strengthenStrictInt : Preprocessor where
   name := "strengthen strict inequalities over int"
   transform h := do
-    if ← isStrictIntComparison (← inferType h) then
-      return [← mkNonstrictIntProof h]
-    else
-      return [h]
+    match ← mkNonstrictIntProof h with
+    | some x => return [x]
+    | none => return [h]
 
 end strengthenStrictInt
 

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -196,9 +196,8 @@ section strengthenStrictInt
 If `pf` is a proof of a strict inequality `(a : ℤ) < b`,
 `mkNonstrictIntProof pf` returns a proof of `a + 1 ≤ b`,
 and similarly if `pf` proves a negated weak inequality.
-Otherwise, returns `pf` unchanged.
 -/
-def mkNonstrictIntProof (pf : Expr) : MetaM Expr := do
+def mkNonstrictIntProof (pf : Expr) : MetaM (Option Expr) := do
   match (← instantiateMVars (← inferType pf)).getAppFnArgs with
   | (``LT.lt, #[.const ``Int [], _, a, b]) =>
     return mkApp (← mkAppM ``Iff.mpr #[← mkAppOptM ``Int.add_one_le_iff #[a, b]]) pf
@@ -211,14 +210,17 @@ def mkNonstrictIntProof (pf : Expr) : MetaM Expr := do
     | (``GE.ge, #[.const ``Int [], _, a, b]) =>
       return mkApp (← mkAppM ``Iff.mpr #[← mkAppOptM ``Int.add_one_le_iff #[a, b]])
         (← mkAppM ``lt_of_not_ge #[pf])
-    | _ => return pf
-  | _ => return pf
+    | _ => return none
+  | _ => return none
 
 /-- `strengthenStrictInt h` turns a proof `h` of a strict integer inequality `t1 < t2`
 into a proof of `t1 ≤ t2 + 1`. -/
 def strengthenStrictInt : Preprocessor where
   name := "strengthen strict inequalities over int"
-  transform h := return [← mkNonstrictIntProof h]
+  transform h := do
+    match ← mkNonstrictIntProof h with
+    | some x => return [x]
+    | none => return [h]
 
 end strengthenStrictInt
 

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -217,10 +217,7 @@ def mkNonstrictIntProof (pf : Expr) : MetaM (Option Expr) := do
 into a proof of `t1 ≤ t2 + 1`. -/
 def strengthenStrictInt : Preprocessor where
   name := "strengthen strict inequalities over int"
-  transform h := do
-    match ← mkNonstrictIntProof h with
-    | some x => return [x]
-    | none => return [h]
+  transform h := return [(← mkNonstrictIntProof h).getD h]
 
 end strengthenStrictInt
 


### PR DESCRIPTION
Implements the refactor proposed in https://github.com/leanprover-community/mathlib4/pull/8310#issuecomment-1817330246.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
