### PR TITLE
[Merged by Bors] - Extend RingTheory.Flat.iff_rTensor_injective to all ideals

### DIFF
--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -425,7 +425,7 @@ theorem exists_fg_le_eq_rTensor_subtype_codRestrict {R : Type*} [CommRing R]
     {M : Type*} [AddCommGroup M] [Module R M] {N : Type*} [AddCommGroup N] [Module R N]
     {I : Submodule R N} (x : I ⊗ M) :
     ∃ (J : Submodule R N) (_ : J.FG) (hle : J ≤ I) (y : J ⊗ M),
-      x = LinearMap.rTensor M (J.subtype.codRestrict I (fun c => hle.subset c.property)) y := by
+      x = rTensor M (J.subtype.codRestrict I (fun c => hle.subset c.property)) y := by
   induction x using TensorProduct.induction_on with
   | zero => refine ⟨⊥, fg_bot, zero_le _, 0, rfl⟩
   | tmul i m =>

--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -425,18 +425,17 @@ theorem exists_fg_le_eq_rTensor_inclusion {R M N : Type*} [CommRing R] [AddCommG
       ∃ (J : Submodule R N) (_ : J.FG) (hle : J ≤ I) (y : J ⊗ M),
         x = rTensor M (J.inclusion hle) y := by
   induction x using TensorProduct.induction_on with
-  | zero => refine ⟨⊥, fg_bot, zero_le _, 0, rfl⟩
-  | tmul i m =>
-    refine ⟨R ∙ i.val, ?_, ?_, ⟨i.val, mem_span_singleton_self _⟩ ⊗ₜ[R] m, rfl⟩
-    · exact fg_span_singleton i.val
-    · rewrite [span_le, Set.singleton_subset_iff]; exact Subtype.mem i
+  | zero => exact ⟨⊥, fg_bot, zero_le _, 0, rfl⟩
+  | tmul i m => exact ⟨R ∙ i.val, fg_span_singleton i.val,
+      (span_singleton_le_iff_mem _ _).mpr i.property,
+      ⟨i.val, mem_span_singleton_self _⟩ ⊗ₜ[R] m, rfl⟩
   | add x₁ x₂ ihx₁ ihx₂ =>
-    have ⟨J₁, hfg₁, hle₁, y₁, hy₁⟩ := ihx₁
-    have ⟨J₂, hfg₂, hle₂, y₂, hy₂⟩ := ihx₂
-    refine ⟨J₁ ⊔ J₂, FG.sup hfg₁ hfg₂, sup_le hle₁ hle₂,
+    obtain ⟨J₁, hfg₁, hle₁, y₁, rfl⟩ := ihx₁
+    obtain ⟨J₂, hfg₂, hle₂, y₂, rfl⟩ := ihx₂
+    refine ⟨J₁ ⊔ J₂, hfg₁.sup hfg₂, sup_le hle₁ hle₂,
       rTensor M (J₁.inclusion (le_sup_left : J₁ ≤ J₁ ⊔ J₂)) y₁ +
         rTensor M (J₂.inclusion (le_sup_right : J₂ ≤ J₁ ⊔ J₂)) y₂, ?_⟩
-    rewrite [map_add, ← comp_apply, ← rTensor_comp, ← comp_apply, ← rTensor_comp, hy₁, hy₂]
+    rewrite [map_add, ← rTensor_comp_apply, ← rTensor_comp_apply]
     rfl
 
 end Submodule

--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -420,11 +420,10 @@ theorem fg_iff_compact (s : Submodule R M) : s.FG ↔ CompleteLattice.IsCompactE
 open TensorProduct LinearMap in
 /-- Every `x : I ⊗ M` is the image of some `y : J ⊗ M` where `J ≤ I` is finitely generated,
 under the tensor product of `J.inclusion ‹J ≤ I› : J → I` and the identity `M → M`. -/
-theorem exists_fg_le_eq_rTensor_inclusion {R : Type*} [CommRing R]
-    {M : Type*} [AddCommGroup M] [Module R M] {N : Type*} [AddCommGroup N] [Module R N]
-    {I : Submodule R N} (x : I ⊗ M) :
-    ∃ (J : Submodule R N) (_ : J.FG) (hle : J ≤ I) (y : J ⊗ M),
-      x = rTensor M (J.inclusion hle) y := by
+theorem exists_fg_le_eq_rTensor_inclusion {R M N : Type*} [CommRing R] [AddCommGroup M]
+    [AddCommGroup N] [Module R M] [Module R N] {I : Submodule R N} (x : I ⊗ M) :
+      ∃ (J : Submodule R N) (_ : J.FG) (hle : J ≤ I) (y : J ⊗ M),
+        x = rTensor M (J.inclusion hle) y := by
   induction x using TensorProduct.induction_on with
   | zero => refine ⟨⊥, fg_bot, zero_le _, 0, rfl⟩
   | tmul i m =>
@@ -434,10 +433,9 @@ theorem exists_fg_le_eq_rTensor_inclusion {R : Type*} [CommRing R]
   | add x₁ x₂ ihx₁ ihx₂ =>
     have ⟨J₁, hfg₁, hle₁, y₁, hy₁⟩ := ihx₁
     have ⟨J₂, hfg₂, hle₂, y₂, hy₂⟩ := ihx₂
-    let z₁ :=
+    refine ⟨J₁ ⊔ J₂, FG.sup hfg₁ hfg₂, sup_le hle₁ hle₂,
       rTensor M (J₁.inclusion (le_sup_left : J₁ ≤ J₁ ⊔ J₂)) y₁ +
-      rTensor M (J₂.inclusion (le_sup_right : J₂ ≤ J₁ ⊔ J₂)) y₂
-    refine ⟨J₁ ⊔ J₂, FG.sup hfg₁ hfg₂, sup_le hle₁ hle₂, z₁, ?_⟩
+        rTensor M (J₂.inclusion (le_sup_right : J₂ ≤ J₁ ⊔ J₂)) y₂, ?_⟩
     rewrite [map_add, ← comp_apply, ← rTensor_comp, ← comp_apply, ← rTensor_comp, hy₁, hy₂]
     rfl
 

--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -417,6 +417,36 @@ theorem fg_iff_compact (s : Submodule R M) : s.FG ↔ CompleteLattice.IsCompactE
       exact ⟨t, ssup⟩
 #align submodule.fg_iff_compact Submodule.fg_iff_compact
 
+open TensorProduct LinearMap in
+/-- Every `x : I ⊗ M` is the image of some `y : J ⊗ M` where `J ≤ I` is finitely generated,
+under the tensor product of the inclusion `J.subtype.codRestrict I ‹_› : J → I`
+and the identity `M → M`. -/
+theorem exists_fg_le_eq_rTensor_subtype_codRestrict {R : Type*} [CommRing R]
+    {M : Type*} [AddCommGroup M] [Module R M] {N : Type*} [AddCommGroup N] [Module R N]
+    {I : Submodule R N} (x : I ⊗ M) :
+    ∃ (J : Submodule R N) (_ : J.FG) (hle : J ≤ I) (y : J ⊗ M),
+      x = LinearMap.rTensor M (J.subtype.codRestrict I (fun c => hle.subset c.property)) y := by
+  induction x using TensorProduct.induction_on with
+  | zero => refine ⟨⊥, fg_bot, zero_le _, 0, rfl⟩
+  | tmul i m =>
+    refine ⟨R ∙ i.val, ?_, ?_, ⟨i.val, mem_span_singleton_self _⟩ ⊗ₜ[R] m, rfl⟩
+    . exact fg_span_singleton i.val
+    . rewrite [span_le, Set.singleton_subset_iff] ; exact Subtype.mem i
+  | add x₁ x₂ ihx₁ ihx₂ =>
+    have ⟨J₁, hfg₁, hle₁, y₁, hy₁⟩ := ihx₁
+    have ⟨J₂, hfg₂, hle₂, y₂, hy₂⟩ := ihx₂
+    have h₁ (c : J₁) := (le_sup_left : J₁ ≤ J₁ ⊔ J₂).subset c.property
+    have h₂ (c : J₂) := (le_sup_right : J₂ ≤ J₁ ⊔ J₂).subset c.property
+    let z₁ :=
+      rTensor M (J₁.subtype.codRestrict (J₁ ⊔ J₂) h₁) y₁ +
+      rTensor M (J₂.subtype.codRestrict (J₁ ⊔ J₂) h₂) y₂
+    refine ⟨J₁ ⊔ J₂, FG.sup hfg₁ hfg₂, sup_le hle₁ hle₂, z₁, ?_⟩
+    rewrite [map_add,
+      ← comp_apply, ← rTensor_comp, comp_codRestrict,
+      ← comp_apply, ← rTensor_comp, comp_codRestrict]
+    simp_rw [subtype_comp_codRestrict]
+    rw [hy₁, hy₂]
+
 end Submodule
 
 namespace Submodule

--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -418,7 +418,7 @@ theorem fg_iff_compact (s : Submodule R M) : s.FG ↔ CompleteLattice.IsCompactE
 #align submodule.fg_iff_compact Submodule.fg_iff_compact
 
 open TensorProduct LinearMap in
-/-- Every `x : I ⊗ M` is the image of some `y : J ⊗ M` where `J ≤ I` is finitely generated,
+/-- Every `x : I ⊗ M` is the image of some `y : J ⊗ M`, where `J ≤ I` is finitely generated,
 under the tensor product of `J.inclusion ‹J ≤ I› : J → I` and the identity `M → M`. -/
 theorem exists_fg_le_eq_rTensor_inclusion {R M N : Type*} [CommRing R] [AddCommGroup M]
     [AddCommGroup N] [Module R M] [Module R N] {I : Submodule R N} (x : I ⊗ M) :

--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -419,13 +419,12 @@ theorem fg_iff_compact (s : Submodule R M) : s.FG ↔ CompleteLattice.IsCompactE
 
 open TensorProduct LinearMap in
 /-- Every `x : I ⊗ M` is the image of some `y : J ⊗ M` where `J ≤ I` is finitely generated,
-under the tensor product of the inclusion `J.subtype.codRestrict I ‹_› : J → I`
-and the identity `M → M`. -/
-theorem exists_fg_le_eq_rTensor_subtype_codRestrict {R : Type*} [CommRing R]
+under the tensor product of `J.inclusion ‹J ≤ I› : J → I` and the identity `M → M`. -/
+theorem exists_fg_le_eq_rTensor_inclusion {R : Type*} [CommRing R]
     {M : Type*} [AddCommGroup M] [Module R M] {N : Type*} [AddCommGroup N] [Module R N]
     {I : Submodule R N} (x : I ⊗ M) :
     ∃ (J : Submodule R N) (_ : J.FG) (hle : J ≤ I) (y : J ⊗ M),
-      x = rTensor M (J.subtype.codRestrict I (fun c => hle.subset c.property)) y := by
+      x = rTensor M (J.inclusion hle) y := by
   induction x using TensorProduct.induction_on with
   | zero => refine ⟨⊥, fg_bot, zero_le _, 0, rfl⟩
   | tmul i m =>
@@ -435,17 +434,12 @@ theorem exists_fg_le_eq_rTensor_subtype_codRestrict {R : Type*} [CommRing R]
   | add x₁ x₂ ihx₁ ihx₂ =>
     have ⟨J₁, hfg₁, hle₁, y₁, hy₁⟩ := ihx₁
     have ⟨J₂, hfg₂, hle₂, y₂, hy₂⟩ := ihx₂
-    have h₁ (c : J₁) := (le_sup_left : J₁ ≤ J₁ ⊔ J₂).subset c.property
-    have h₂ (c : J₂) := (le_sup_right : J₂ ≤ J₁ ⊔ J₂).subset c.property
     let z₁ :=
-      rTensor M (J₁.subtype.codRestrict (J₁ ⊔ J₂) h₁) y₁ +
-      rTensor M (J₂.subtype.codRestrict (J₁ ⊔ J₂) h₂) y₂
+      rTensor M (J₁.inclusion (le_sup_left : J₁ ≤ J₁ ⊔ J₂)) y₁ +
+      rTensor M (J₂.inclusion (le_sup_right : J₂ ≤ J₁ ⊔ J₂)) y₂
     refine ⟨J₁ ⊔ J₂, FG.sup hfg₁ hfg₂, sup_le hle₁ hle₂, z₁, ?_⟩
-    rewrite [map_add,
-      ← comp_apply, ← rTensor_comp, comp_codRestrict,
-      ← comp_apply, ← rTensor_comp, comp_codRestrict]
-    simp_rw [subtype_comp_codRestrict]
-    rw [hy₁, hy₂]
+    rewrite [map_add, ← comp_apply, ← rTensor_comp, ← comp_apply, ← rTensor_comp, hy₁, hy₂]
+    rfl
 
 end Submodule
 

--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -430,8 +430,8 @@ theorem exists_fg_le_eq_rTensor_subtype_codRestrict {R : Type*} [CommRing R]
   | zero => refine ⟨⊥, fg_bot, zero_le _, 0, rfl⟩
   | tmul i m =>
     refine ⟨R ∙ i.val, ?_, ?_, ⟨i.val, mem_span_singleton_self _⟩ ⊗ₜ[R] m, rfl⟩
-    . exact fg_span_singleton i.val
-    . rewrite [span_le, Set.singleton_subset_iff] ; exact Subtype.mem i
+    · exact fg_span_singleton i.val
+    · rewrite [span_le, Set.singleton_subset_iff]; exact Subtype.mem i
   | add x₁ x₂ ihx₁ ihx₂ =>
     have ⟨J₁, hfg₁, hle₁, y₁, hy₁⟩ := ihx₁
     have ⟨J₂, hfg₂, hle₂, y₂, hy₂⟩ := ihx₂

--- a/Mathlib/RingTheory/Flat.lean
+++ b/Mathlib/RingTheory/Flat.lean
@@ -97,8 +97,8 @@ variable (M : Type v) [AddCommGroup M] [Module R M]
 tensor product of the inclusion `I → R` and the identity `M → M` is injective. See
 `iff_rTensor_injective'` to extend to all ideals `I`. --/
 lemma iff_rTensor_injective :
-    Flat R M ↔ (∀ ⦃I : Ideal R⦄ (_ : I.FG), Injective (rTensor M I.subtype)) := by
-  have aux : ∀ (I : Ideal R), ((TensorProduct.lid R M).comp (rTensor M I.subtype)) =
+    Flat R M ↔ ∀ ⦃I : Ideal R⦄, I.FG → Injective (rTensor M I.subtype) := by
+  have aux : ∀ I : Ideal R, (TensorProduct.lid R M).comp (rTensor M I.subtype) =
     (TensorProduct.lift ((lsmul R M).comp I.subtype))
   · intro I; apply TensorProduct.ext'; intro x y; simp
   constructor

--- a/Mathlib/RingTheory/Flat.lean
+++ b/Mathlib/RingTheory/Flat.lean
@@ -123,9 +123,9 @@ theorem iff_rTensor_injective' :
   letI : AddCommGroup (I ⊗[R] M) := inferInstance -- Type class reminder
   rewrite [injective_iff_map_eq_zero]
   intro x hx₀
-  have ⟨J, hfg, hle, y, hy⟩ := exists_fg_le_eq_rTensor_subtype_codRestrict x
+  have ⟨J, hfg, hle, y, hy⟩ := exists_fg_le_eq_rTensor_inclusion x
   apply (fun hy₀ => by rw [hy, hy₀, _root_.map_zero] : y = 0 → x = 0)
-  rewrite [hy, ← comp_apply, ← rTensor_comp, subtype_comp_codRestrict] at hx₀
+  rewrite [hy, ← comp_apply, ← rTensor_comp] at hx₀
   letI : AddCommGroup (J ⊗[R] M) := inferInstance -- Type class reminder
   exact (injective_iff_map_eq_zero _).mp (h hfg) y hx₀
 

--- a/Mathlib/RingTheory/Flat.lean
+++ b/Mathlib/RingTheory/Flat.lean
@@ -93,9 +93,9 @@ instance self (R : Type u) [CommRing R] : Flat R R :=
 
 variable (M : Type v) [AddCommGroup M] [Module R M]
 
-/-- An  `R`-module `M` is flat iff for all finitely generated ideals `I` of `R`, the tensor
-product of the inclusion `I → R` and the identity `M → M` is injective.
-See `iff_rTensor_injective'` to extend to all ideals `I`. --/
+/-- An `R`-module `M` is flat iff for all finitely generated ideals `I` of `R`, the
+tensor product of the inclusion `I → R` and the identity `M → M` is injective. See
+`iff_rTensor_injective'` to extend to all ideals `I`. --/
 lemma iff_rTensor_injective :
     Flat R M ↔ (∀ ⦃I : Ideal R⦄ (_ : I.FG), Injective (rTensor M I.subtype)) := by
   have aux : ∀ (I : Ideal R), ((TensorProduct.lid R M).comp (rTensor M I.subtype)) =
@@ -113,9 +113,9 @@ lemma iff_rTensor_injective :
     rw [← aux]
     simp [h₁ hI]
 
-/-- An  `R`-module `M` is flat iff for all finitely generated ideals `I` of `R`, the tensor
-product of the inclusion `I → R` and the identity `M → M` is injective.
-See `iff_rTensor_injective` to restrict to finitely generated ideals `I`. --/
+/-- An `R`-module `M` is flat iff for all ideals `I` of `R`, the tensor product of the
+inclusion `I → R` and the identity `M → M` is injective. See `iff_rTensor_injective` to
+restrict to finitely generated ideals `I`. --/
 theorem iff_rTensor_injective' :
     Module.Flat R M ↔ (∀ (I : Ideal R), Function.Injective (LinearMap.rTensor M I.subtype)) := by
   rewrite [Module.Flat.iff_rTensor_injective]

--- a/Mathlib/RingTheory/Flat.lean
+++ b/Mathlib/RingTheory/Flat.lean
@@ -97,10 +97,10 @@ variable (M : Type v) [AddCommGroup M] [Module R M]
 tensor product of the inclusion `I → R` and the identity `M → M` is injective. See
 `iff_rTensor_injective'` to extend to all ideals `I`. --/
 lemma iff_rTensor_injective :
-    Flat R M ↔ (∀ ⦃I : Ideal R⦄ (_ : I.FG), Injective (rTensor M I.subtype)) := by
-  have aux : ∀ (I : Ideal R), ((TensorProduct.lid R M).comp (rTensor M I.subtype)) =
-    (TensorProduct.lift ((lsmul R M).comp I.subtype))
-  · intro I; apply TensorProduct.ext'; intro x y; simp
+    Flat R M ↔ ∀ ⦃I : Ideal R⦄ (_ : I.FG), Injective (rTensor M I.subtype) := by
+  have aux : ∀ I : Ideal R, (TensorProduct.lid R M).comp (rTensor M I.subtype) =
+      TensorProduct.lift ((lsmul R M).comp I.subtype) := by
+    intro I; apply TensorProduct.ext'; intro x y; simp
   constructor
   · intro F I hI
     erw [← Equiv.comp_injective _ (TensorProduct.lid R M).toEquiv]

--- a/Mathlib/RingTheory/Flat.lean
+++ b/Mathlib/RingTheory/Flat.lean
@@ -97,8 +97,8 @@ variable (M : Type v) [AddCommGroup M] [Module R M]
 tensor product of the inclusion `I → R` and the identity `M → M` is injective. See
 `iff_rTensor_injective'` to extend to all ideals `I`. --/
 lemma iff_rTensor_injective :
-    Flat R M ↔ ∀ ⦃I : Ideal R⦄, I.FG → Injective (rTensor M I.subtype) := by
-  have aux : ∀ I : Ideal R, (TensorProduct.lid R M).comp (rTensor M I.subtype) =
+    Flat R M ↔ (∀ ⦃I : Ideal R⦄ (_ : I.FG), Injective (rTensor M I.subtype)) := by
+  have aux : ∀ (I : Ideal R), ((TensorProduct.lid R M).comp (rTensor M I.subtype)) =
     (TensorProduct.lift ((lsmul R M).comp I.subtype))
   · intro I; apply TensorProduct.ext'; intro x y; simp
   constructor

--- a/Mathlib/RingTheory/Flat.lean
+++ b/Mathlib/RingTheory/Flat.lean
@@ -93,6 +93,9 @@ instance self (R : Type u) [CommRing R] : Flat R R :=
 
 variable (M : Type v) [AddCommGroup M] [Module R M]
 
+/-- An  `R`-module `M` is flat iff for all finitely generated ideals `I` of `R`, the tensor
+product of the inclusion `I → R` and the identity `M → M` is injective.
+See `iff_rTensor_injective'` to extend to all ideals `I`. --/
 lemma iff_rTensor_injective :
     Flat R M ↔ (∀ ⦃I : Ideal R⦄ (_ : I.FG), Injective (rTensor M I.subtype)) := by
   have aux : ∀ (I : Ideal R), ((TensorProduct.lid R M).comp (rTensor M I.subtype)) =
@@ -109,6 +112,22 @@ lemma iff_rTensor_injective :
     intro I hI
     rw [← aux]
     simp [h₁ hI]
+
+/-- An  `R`-module `M` is flat iff for all finitely generated ideals `I` of `R`, the tensor
+product of the inclusion `I → R` and the identity `M → M` is injective.
+See `iff_rTensor_injective` to restrict to finitely generated ideals `I`. --/
+theorem iff_rTensor_injective' :
+    Module.Flat R M ↔ (∀ (I : Ideal R), Function.Injective (LinearMap.rTensor M I.subtype)) := by
+  rewrite [Module.Flat.iff_rTensor_injective]
+  refine ⟨fun h I => ?_, fun h I _ => h I⟩
+  letI : AddCommGroup (I ⊗[R] M) := inferInstance -- typeclass reminder
+  rewrite [injective_iff_map_eq_zero]
+  intro x hx₀
+  have ⟨J, hfg, hle, y, hy⟩ := exists_fg_le_eq_rTensor_subtype_codRestrict x
+  apply (fun hy₀ => by rw [hy, hy₀, _root_.map_zero] : y = 0 → x = 0)
+  rewrite [hy, ← comp_apply, ← rTensor_comp, subtype_comp_codRestrict] at hx₀
+  letI : AddCommGroup (J ⊗[R] M) := inferInstance -- typeclass reminder
+  exact (injective_iff_map_eq_zero _).mp (h hfg) y hx₀
 
 variable (N : Type w) [AddCommGroup N] [Module R N]
 

--- a/Mathlib/RingTheory/Flat.lean
+++ b/Mathlib/RingTheory/Flat.lean
@@ -120,13 +120,13 @@ theorem iff_rTensor_injective' :
     Module.Flat R M ↔ (∀ (I : Ideal R), Function.Injective (LinearMap.rTensor M I.subtype)) := by
   rewrite [Module.Flat.iff_rTensor_injective]
   refine ⟨fun h I => ?_, fun h I _ => h I⟩
-  letI : AddCommGroup (I ⊗[R] M) := inferInstance -- typeclass reminder
+  letI : AddCommGroup (I ⊗[R] M) := inferInstance -- Type class reminder
   rewrite [injective_iff_map_eq_zero]
   intro x hx₀
   have ⟨J, hfg, hle, y, hy⟩ := exists_fg_le_eq_rTensor_subtype_codRestrict x
   apply (fun hy₀ => by rw [hy, hy₀, _root_.map_zero] : y = 0 → x = 0)
   rewrite [hy, ← comp_apply, ← rTensor_comp, subtype_comp_codRestrict] at hx₀
-  letI : AddCommGroup (J ⊗[R] M) := inferInstance -- typeclass reminder
+  letI : AddCommGroup (J ⊗[R] M) := inferInstance -- Type class reminder
   exact (injective_iff_map_eq_zero _).mp (h hfg) y hx₀
 
 variable (N : Type w) [AddCommGroup N] [Module R N]

--- a/Mathlib/RingTheory/Flat.lean
+++ b/Mathlib/RingTheory/Flat.lean
@@ -117,17 +117,16 @@ lemma iff_rTensor_injective :
 inclusion `I → R` and the identity `M → M` is injective. See `iff_rTensor_injective` to
 restrict to finitely generated ideals `I`. --/
 theorem iff_rTensor_injective' :
-    Flat R M ↔ (∀ (I : Ideal R), Injective (rTensor M I.subtype)) := by
+    Flat R M ↔ ∀ I : Ideal R, Injective (rTensor M I.subtype) := by
   rewrite [Flat.iff_rTensor_injective]
   refine ⟨fun h I => ?_, fun h I _ => h I⟩
   letI : AddCommGroup (I ⊗[R] M) := inferInstance -- Type class reminder
   rewrite [injective_iff_map_eq_zero]
   intro x hx₀
-  have ⟨J, hfg, hle, y, hy⟩ := exists_fg_le_eq_rTensor_inclusion x
-  apply (fun hy₀ => by rw [hy, hy₀, _root_.map_zero] : y = 0 → x = 0)
-  rewrite [hy, ← comp_apply, ← rTensor_comp] at hx₀
+  obtain ⟨J, hfg, hle, y, rfl⟩ := exists_fg_le_eq_rTensor_inclusion x
+  rewrite [← rTensor_comp_apply] at hx₀
   letI : AddCommGroup (J ⊗[R] M) := inferInstance -- Type class reminder
-  exact (injective_iff_map_eq_zero _).mp (h hfg) y hx₀
+  rw [(injective_iff_map_eq_zero _).mp (h hfg) y hx₀, _root_.map_zero]
 
 variable (N : Type w) [AddCommGroup N] [Module R N]
 

--- a/Mathlib/RingTheory/Flat.lean
+++ b/Mathlib/RingTheory/Flat.lean
@@ -117,8 +117,8 @@ lemma iff_rTensor_injective :
 inclusion `I → R` and the identity `M → M` is injective. See `iff_rTensor_injective` to
 restrict to finitely generated ideals `I`. --/
 theorem iff_rTensor_injective' :
-    Module.Flat R M ↔ (∀ (I : Ideal R), Function.Injective (LinearMap.rTensor M I.subtype)) := by
-  rewrite [Module.Flat.iff_rTensor_injective]
+    Flat R M ↔ (∀ (I : Ideal R), Injective (rTensor M I.subtype)) := by
+  rewrite [Flat.iff_rTensor_injective]
   refine ⟨fun h I => ?_, fun h I _ => h I⟩
   letI : AddCommGroup (I ⊗[R] M) := inferInstance -- Type class reminder
   rewrite [injective_iff_map_eq_zero]


### PR DESCRIPTION
Extend `RingTheory.Flat.iff_rTensor_injective` to all ideals

Using an elementary argument after Dummit and Foote (2004, Ex. 10.25)

---
[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/flat.20modules/near/402873609)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)