### PR TITLE
feat: meta utils for `refine?`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2217,6 +2217,7 @@ import Mathlib.Init.ZeroOne
 import Mathlib.Lean.CoreM
 import Mathlib.Lean.Data.NameMap
 import Mathlib.Lean.Elab.Tactic.Basic
+import Mathlib.Lean.Elab.Tactic.ElabTerm
 import Mathlib.Lean.Elab.Term
 import Mathlib.Lean.EnvExtension
 import Mathlib.Lean.Exception

--- a/Mathlib/Lean/CoreM.lean
+++ b/Mathlib/Lean/CoreM.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Scott Morrison
+Authors: Scott Morrison, Thomas R. Murrills
 -/
 import Lean
 import Mathlib.Tactic.ToExpr
@@ -27,3 +27,24 @@ def CoreM.withImportModules (modules : Array Name) (run : CoreM α)
     let state := {env}
     Prod.fst <$> (CoreM.toIO · ctx state) do
       run
+
+/--
+Evaluates `k`, and returns the result along with an indicator of whether new errors were
+produced during its execution.
+
+Note that `hasNewErrors` only counts the number of errors present in `(← Core.getMessageLog).msgs`
+before and after `k`; if `k` has the ability to e.g. reset the `CoreM` state,
+`hasNewErrors` may not behave as expected.
+-/
+def hasNewErrors [Monad m] [MonadOptions m] [MonadLiftT CoreM m] (k : m α) : m (α × Bool) := do
+  let warningAsError := warningAsError.get (← getOptions)
+  let isError : MessageSeverity → Bool
+  | .error => true
+  | .warning => warningAsError
+  | _ => false
+  let getNumErrors :=
+    return (← Core.getMessageLog).msgs.filter (fun msg => isError msg.severity) |>.size
+  let numErrors ← getNumErrors
+  let val ← k
+  let numErrors' ← getNumErrors
+  return (val, numErrors < numErrors')

--- a/Mathlib/Lean/Elab/Tactic/ElabTerm.lean
+++ b/Mathlib/Lean/Elab/Tactic/ElabTerm.lean
@@ -48,6 +48,7 @@ def withCollectingNewGoalsFrom' (k : TacticM Expr) (tagSuffix : Option Name := n
       withAssignableSyntheticOpaque go
   | _ => go
 where
+  /-- The core of `withCollectingNewGoalsFrom'`. -/
   go := do
     let mvarCounterSaved := (← getMCtx).mvarCounter
     let val ← k

--- a/Mathlib/Lean/Elab/Tactic/ElabTerm.lean
+++ b/Mathlib/Lean/Elab/Tactic/ElabTerm.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2023 Thomas R. Murrills. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas R. Murrills
+-/
+import Lean
+
+/-!
+# Additions to `Lean.Elab.Tactic.ElabTerm`
+-/
+
+namespace Lean.Elab.Tactic
+
+open Lean Meta Elab Tactic
+
+/-- Config option for `withCollectingNewGoalsFrom'` and `elabTermWithHoles'`: determines whether to
+`.allowNaturalHoles`, `.allowNaturalHolesAsSyntheticOpaque`, or `disallowNaturalHoles`. -/
+inductive AllowedHoles where
+  /-- Fail if any natural holes are not assigned. This is the behavior used by `refine`. -/
+  | disallowNaturalHoles
+  /-- Allow natural holes (`_`), but elaborate them as `.syntheticOpaque` holes.
+    This is the behavior used by `refine'`. -/
+  | allowNaturalHolesAsSyntheticOpaque
+  /-- Allow natural holes. -/
+  | allowNaturalHoles
+deriving Repr, DecidableEq
+
+/--
+  Like `withCollectingNewGoalsFrom`, execute `k`, and collect new "holes" appearing in the resulting
+  expression. However, this function differs in two key respects:
+
+  1. If `allowedHoles := .allowNaturalHoles`, preserve the `MetavarKind` of each metavariable (in
+    contrast, when `allowNaturalHoles := true`, `withCollectingNewGoalsFrom` turns natural holes
+    into synthetic opaque holes via `holesAsSyntheticOpaque := true` and uses
+    `withAssignableSyntheticOpaque` to assign them.
+  2. If `tagSuffix := none`, we do not tag all untagged goals.
+
+  Note that `allowedHoles` can take three values: `.disallowNaturalHoles` (which replicates
+  `refine` behavior), `.allowNaturalHolesAsSyntheticOpaque` (which replicates `refine'` behavior),
+  and `.allowNaturalHoles`, which preserves `MetavarKind`s as described in (1).
+-/
+-- See `withCollectingNewGoalsFrom` for more detailed code comments.
+def withCollectingNewGoalsFrom' (k : TacticM Expr) (tagSuffix : Option Name := none)
+    (allowedHoles : AllowedHoles := .disallowNaturalHoles) : TacticM (Expr × List MVarId) :=
+  match allowedHoles with
+  | .allowNaturalHolesAsSyntheticOpaque => withTheReader Term.Context
+    (fun ctx => { ctx with holesAsSyntheticOpaque := ctx.holesAsSyntheticOpaque || true }) do
+      withAssignableSyntheticOpaque go
+  | _ => go
+where
+  go := do
+    let mvarCounterSaved := (← getMCtx).mvarCounter
+    let val ← k
+    let newMVarIds ← getMVarsNoDelayed val
+    /- ignore let-rec auxiliary variables, they are synthesized automatically later -/
+    let newMVarIds ← newMVarIds.filterM fun mvarId => return !(← Term.isLetRecAuxMVar mvarId)
+    /- Filter out all mvars that were created prior to `k`. -/
+    let newMVarIds ← filterOldMVars newMVarIds mvarCounterSaved
+    /- If `allowedHoles := .disallowNaturalHoles`, all natural mvarIds must be assigned.
+    Passing this guard ensures that `newMVarIds` does not contain unassigned natural mvars. -/
+    if allowedHoles = .disallowNaturalHoles then
+      let naturalMVarIds ← newMVarIds.filterM fun mvarId => return (← mvarId.getKind).isNatural
+      logUnassignedAndAbort naturalMVarIds
+    /- We sort the new metavariable ids by index to ensure the new goals are ordered using the
+    order the metavariables have been created. -/
+    let newMVarIds ← sortMVarIdsByIndex newMVarIds.toList
+    if let some tagSuffix := tagSuffix then tagUntaggedGoals (← getMainTag) tagSuffix newMVarIds
+    return (val, newMVarIds)
+
+/--
+  Like `elabTermWithHoles`, elaborates `stx` and collects new `MVarId`s occurring in the result.
+  It has three key differences:
+
+  1. We may preserve the `MetavarKind` of metavariables with `allowedHoles := .allowNaturalHoles`.
+  2. We do not tag untagged goals if `tagSuffix := none`.
+  3. We may postpone metavariable assignments via `mayPostpone := true` (`mayPostpone := false` by
+     default).
+
+  Note that `allowedHoles` can take three values: `.disallowNaturalHoles` (which replicates
+  `refine` behavior), `.allowNaturalHolesAsSyntheticOpaque` (which replicates `refine'` behavior),
+  and `.allowNaturalHoles`, which preserves `MetavarKind`s as described in (1).
+-/
+def elabTermWithHoles' (stx : Syntax) (expectedType? : Option Expr)
+    (tagSuffix : Option Name := none) (allowedHoles : AllowedHoles := .disallowNaturalHoles)
+    (mayPostpone := false) : TacticM (Expr × List MVarId) :=
+  withCollectingNewGoalsFrom'
+    (elabTermEnsuringType stx expectedType? mayPostpone) tagSuffix allowedHoles

--- a/Mathlib/Lean/Elab/Term.lean
+++ b/Mathlib/Lean/Elab/Term.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kyle Miller
+Authors: Kyle Miller, Thomas R. Murrills
 -/
 import Lean.Elab
 
@@ -10,6 +10,8 @@ import Lean.Elab
 -/
 
 namespace Lean.Elab.Term
+
+set_option autoImplicit true
 
 /-- Fully elaborates the term `patt`, allowing typeclass inference failure,
 but while setting `errToSorry` to false.
@@ -21,3 +23,34 @@ def elabPattern (patt : Term) (expectedType? : Option Expr) : TermElabM Expr := 
       let t ← elabTerm patt expectedType?
       synthesizeSyntheticMVars (mayPostpone := false) (ignoreStuckTC := true)
       instantiateMVars t
+
+/-- Given a combinator `f {α} : TermElabM α → TermElabM α` and a way to run `m` in `TermElabM`,
+turn `f` into a combinator of type `m α → m α`. -/
+@[inline] def mapTermElabM [MonadControlT TermElabM m] [Monad m]
+    (f : forall {α}, TermElabM α → TermElabM α) {α} (x : m α) : m α :=
+  controlAt TermElabM fun runInBase => f <| runInBase x
+
+@[inline] private def withoutModifyingStateImp (restoreInfo : Bool) (x : TermElabM α) :
+    TermElabM α := do
+  let s ← saveState
+  try
+    withSaveInfoContextUnless restoreInfo x
+  finally
+    s.restore restoreInfo
+where
+  withSaveInfoContextUnless : Bool → TermElabM α → TermElabM α
+  | true  => fun x => x
+  | false => withSaveInfoContext
+
+/-- A "safe" version of `withoutModifyingState` for monads in which we're running `TermElabM` (e.g.
+`TermElabM`, `TacticM`). If `restoreInfo := false` (the default), we wrap the execution in
+`withSaveInfoContext`. If `restoreInfo := true`, we restore the infotrees to their values before
+execution.
+
+Note that `withoutModifyingState` does not restore the infotrees to their values before the monad
+execution. However, `MVarId`s can be introduced to the infotree, which now might be unknown. For
+this reason, we either need to save the context before restoring the rest of the state or restore
+the infotree state as well. -/
+def withoutModifyingState [MonadControlT TermElabM m] [Monad m] (x : m α)
+    (restoreInfo := false) : m α :=
+  mapTermElabM (withoutModifyingStateImp restoreInfo) x

--- a/Mathlib/Util/Delaborators.lean
+++ b/Mathlib/Util/Delaborators.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kyle Miller
+Authors: Kyle Miller, Thomas R. Murrills
 -/
 import Std.Classes.SetNotation
 
@@ -164,3 +164,63 @@ open Lean Lean.PrettyPrinter.Delaborator
   let stx₁ ← SubExpr.withAppArg <| SubExpr.withNaryArg 3 delab
   let stx₂ ← SubExpr.withAppArg <| SubExpr.withNaryArg 4 delab
   return ← `($stx₁ ∉ $stx₂)
+
+/-!
+# Anonymous mvar suffixes
+
+The option `pp.anonymousMVarSuffixes` controls whether anonymous mvars are printed with numeric s
+suffixes. When `false`, all anonymous mvars are printed as `?m✝` (or in the case of universe mvars
+in `Sort` or `Type`, `?u✝`).
+
+Note that this does not handle universe mvars in constants.
+
+Note also that mvar names are not distinguished by superscripts as inaccessible fvars are: both
+`?m.1` and `?m.2` are delaborated to `?m✝`.
+-/
+
+register_option pp.anonymousMVarSuffixes : Bool := {
+  defValue := true
+  group    := "pp"
+  descr    := s!"(pretty printer) if false, do not use numeric suffixes to distinguish anonymous {
+              ""}metavariables. E.g., `?m.1234` will instead be rendered as `?m✝`."
+}
+
+/-- Get the value of the option `pp.anonymousMVarSuffixes`. -/
+def getPPAnonymousMVarSuffixes (o : Options) : Bool := o.get pp.anonymousMVarSuffixes.name true
+
+namespace Lean.Level
+
+private def PP.toResultNoSuffix : Level → Result
+  | .zero       => Result.num 0
+  | .succ l     => Result.succ (toResult l)
+  | .max l₁ l₂  => Result.max (toResult l₁) (toResult l₂)
+  | .imax l₁ l₂ => Result.imax (toResult l₁) (toResult l₂)
+  | .param n    => Result.leaf n
+  | .mvar _     => Result.leaf (Name.mkSimple "?u✝")
+
+private def quoteNoSuffix (u : Level) (prec : Nat := 0) : Syntax.Level :=
+  (PP.toResultNoSuffix u).quote prec
+
+end Lean.Level
+
+namespace Lean.PrettyPrinter.Delaborator
+
+open SubExpr
+
+@[delab sort]
+def delabSortNoLevelSuffix : Delab := whenNotPPOption getPPAnonymousMVarSuffixes do
+  let Expr.sort l ← getExpr | unreachable!
+  match l with
+  | Level.zero => `(Prop)
+  | Level.succ .zero => `(Type)
+  | _ => match l.dec with
+    | some l' => `(Type $(Level.quoteNoSuffix l' max_prec))
+    | none    => `(Sort $(Level.quoteNoSuffix l max_prec))
+
+@[delab mvar]
+def delabMVarNoSuffix : Delab := whenNotPPOption getPPAnonymousMVarSuffixes do
+  let Expr.mvar mvarId ← getExpr | unreachable!
+  let n := match ← mvarId.getTag with
+    | .anonymous => Name.mkSimple "m✝"
+    | n => n
+  `(?$(mkIdent n))

--- a/Mathlib/Util/Delaborators.lean
+++ b/Mathlib/Util/Delaborators.lean
@@ -178,6 +178,8 @@ Note also that mvar names are not distinguished by superscripts as inaccessible 
 `?m.1` and `?m.2` are delaborated to `?m✝`.
 -/
 
+/-- If false, do not use numeric suffixes to distinguish anonymous metavariables. E.g., `?m.1234`
+will instead be rendered as `?m✝`. -/
 register_option pp.anonymousMVarSuffixes : Bool := {
   defValue := true
   group    := "pp"
@@ -190,6 +192,7 @@ def getPPAnonymousMVarSuffixes (o : Options) : Bool := o.get pp.anonymousMVarSuf
 
 namespace Lean.Level
 
+/-- Exactly like `PP.toResult`, but uses `?u✝` in the `mvar` case. -/
 private def PP.toResultNoSuffix : Level → Result
   | .zero       => Result.num 0
   | .succ l     => Result.succ (toResult l)
@@ -198,6 +201,7 @@ private def PP.toResultNoSuffix : Level → Result
   | .param n    => Result.leaf n
   | .mvar _     => Result.leaf (Name.mkSimple "?u✝")
 
+/-- Exactly like `Level.quote`, but uses `?u✝` for level mvars. -/
 private def quoteNoSuffix (u : Level) (prec : Nat := 0) : Syntax.Level :=
   (PP.toResultNoSuffix u).quote prec
 
@@ -207,6 +211,10 @@ namespace Lean.PrettyPrinter.Delaborator
 
 open SubExpr
 
+/-- Delaborate `Sort`s/`Type`s without using numeric suffixes to distinguish between level mvars.
+E.g., `?u.1234` will instead be rendered as `?u✝`.
+
+Requires `set_option pp.anonymousMVarSuffxies false`. -/
 @[delab sort]
 def delabSortNoLevelSuffix : Delab := whenNotPPOption getPPAnonymousMVarSuffixes do
   let Expr.sort l ← getExpr | unreachable!
@@ -217,6 +225,10 @@ def delabSortNoLevelSuffix : Delab := whenNotPPOption getPPAnonymousMVarSuffixes
     | some l' => `(Type $(Level.quoteNoSuffix l' max_prec))
     | none    => `(Sort $(Level.quoteNoSuffix l max_prec))
 
+/-- Delaborate metavariables without using numeric suffixes to distinguish between anonymous mvars.
+E.g., `?m.1234` will instead be rendered as `?m✝`.
+
+Requires `set_option pp.anonymousMVarSuffxies false`. -/
 @[delab mvar]
 def delabMVarNoSuffix : Delab := whenNotPPOption getPPAnonymousMVarSuffixes do
   let Expr.mvar mvarId ← getExpr | unreachable!

--- a/Mathlib/Util/Syntax.lean
+++ b/Mathlib/Util/Syntax.lean
@@ -1,9 +1,10 @@
 /-
 Copyright (c) 2022 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Gabriel Ebner
+Authors: Gabriel Ebner, Thomas R. Murrills
 -/
 import Lean
+import Std.Tactic.OpenPrivate
 
 /-!
 # Helper functions for working with typed syntaxes.
@@ -13,13 +14,21 @@ set_option autoImplicit true
 
 namespace Lean
 
+/-- Acts on the raw `Syntax` underlying some `TSyntax ks` with `f : Syntax → Syntax`. -/
+def TSyntax.map (f : Syntax → Syntax) {ks} : TSyntax ks → TSyntax ks
+  | ⟨raw⟩ => ⟨f raw⟩
+
+/-- Monadically acts on the raw `Syntax` underlying some `TSyntax ks` with `f : Syntax → m Syntax`-/
+def TSyntax.mapM [Monad m] (f : Syntax → m Syntax) {ks} : TSyntax ks → m (TSyntax ks)
+  | ⟨raw⟩ => return ⟨← f raw⟩
+
 /--
 Applies the given function to every subsyntax.
 
 Like `Syntax.replaceM` but for typed syntax.
 -/
 def TSyntax.replaceM [Monad M] (f : Syntax → M (Option Syntax)) (stx : TSyntax k) : M (TSyntax k) :=
-  .mk <$> stx.1.replaceM f
+  stx.mapM (·.replaceM f)
 
 /--
 Constructs a typed separated array from elements.
@@ -29,3 +38,86 @@ Like `Syntax.SepArray.ofElems` but for typed syntax.
 -/
 def Syntax.TSepArray.ofElems {sep} (elems : Array (TSyntax k)) : TSepArray k sep :=
   .mk (SepArray.ofElems (sep := sep) elems).1
+
+/--
+Determines if `lhs : Syntax` and `rhs : Syntax` have the same range. If either does not
+have position info, returns `false`.
+
+If `lhsCanonical` or `rhsCanonical` are `true` (default: `false`), only consider
+`lhs` or `rhs` as having position info if they are canonical, respectively.
+-/
+def Syntax.isEqByRange (lhs rhs : Syntax) (lhsCanonical rhsCanonical := true) :=
+  match lhs.getRange? lhsCanonical, rhs.getRange? rhsCanonical with
+  | some r₁, some r₂ => r₁ == r₂
+  | _, _ => false
+
+/--
+Determines if the range of `super : Syntax` includes the range of `sub : Syntax`. If either does
+not have position info, returns `false`.
+
+If `superCanonical` or `subCanonical` are `true` (default: `false`), only consider
+`super` or `sub` as having position info if they are canonical, respectively.
+-/
+def Syntax.includes (super sub : Syntax) (superCanonical subCanonical := false) :=
+  match super.getRange? superCanonical, sub.getRange? subCanonical with
+  | some rSuper, some rSub => rSuper.includes rSub
+  | _, _ => false
+
+/--
+Determines if the range of `super : TSyntax ks` includes the range of `sub : Syntax`. If either
+does not have position info, returns `false`.
+
+If `superCanonical` or `subCanonical` are `true` (default: `false`), only consider
+`super` or `sub` as having position info if they are canonical, respectively.
+
+Like `Syntax.includes`, but enables dot notation for `TSyntax` on its first argument.
+-/
+def TSyntax.includes {ks} (super : TSyntax ks) (sub : Syntax)
+    (superCanonical subCanonical := false) :=
+  super.raw.includes sub superCanonical subCanonical
+
+open private updateLast from Init.Meta in
+/-- Finds the rightmost, lowermost `info : SourceInfo` for which `f info` is `some newInfo`, and
+replaces `info` with `newInfo`. If no such `SourceInfo` is found, returns `none`. -/
+partial def Syntax.setTrailingInfoBy? (f : SourceInfo → Option SourceInfo) :
+    Syntax → Option Syntax
+  | .node info kind args => match updateLast args (setTrailingInfoBy? f) args.size with
+    | some args => some <| .node info kind args
+    | none => (f info).map (.node · kind args)
+  | .ident info rv v pr => (f info).map (.ident · rv v pr)
+  | .atom info val => (f info).map (.atom · val)
+  | _ => none
+
+@[inherit_doc Syntax.setTrailingInfoBy?]
+def TSyntax.setTrailingInfoBy? (f : SourceInfo → Option SourceInfo) {ks} :
+    TSyntax ks → Option (TSyntax ks) :=
+  mapM (·.setTrailingInfoBy? f)
+
+/-- Given some `SourceInfo.original ..`, replace its `trailing` argument with the empty string.
+If the argument is not an `.original` `SourceInfo`, return `none`. -/
+def SourceInfo.unsetOriginalTrailing? : SourceInfo → Option SourceInfo
+  | .original l p _ e => some <| .original l p "".toSubstring e
+  | _ => none
+
+/-- Removes the trailing string of the rightmost, lowermost `.original .. : SourceInfo`. If no
+`.original` `SourceInfo` is found, returns `none`. -/
+def Syntax.unsetOriginalTrailing? : Syntax → Option Syntax :=
+  setTrailingInfoBy? (·.unsetOriginalTrailing?)
+
+/-- Removes the trailing string of the rightmost, lowermost `.original .. : SourceInfo`. If no
+`.original` `SourceInfo` is found, leave the argument syntax unchanged.
+
+Contrast with `unsetTrailing`, which, while it does unset `.original` source info, does so for the
+rightmost, *uppermost* node, instead of the rightmost, lowermost node. -/
+-- TODO: as of writing, a bug in `setTrailingInfo` means that `unsetTrailing` does not even
+-- necessarily behave as described.
+def Syntax.unsetOriginalTrailing (stx : Syntax) : Syntax :=
+  stx.unsetOriginalTrailing?.getD stx
+
+@[inherit_doc Syntax.unsetOriginalTrailing?]
+def TSyntax.unsetOriginalTrailing? {ks} (stx : TSyntax ks) : Option (TSyntax ks) :=
+  stx.mapM (·.unsetOriginalTrailing?)
+
+@[inherit_doc Syntax.unsetOriginalTrailing]
+def TSyntax.unsetOriginalTrailing {ks} (stx : TSyntax ks) : TSyntax ks :=
+  stx.map (·.unsetOriginalTrailing)


### PR DESCRIPTION
This PR introduces some metaprogramming infrastructure and utilities that are necessary for `refine?` (#8364).

* `elabTermWithHoles'` (and `withCollectingNewGoalsFrom'`): a more configurable version of `elabTermWithHoles`, which allows: preserving the initial mvar type; *not* tagging untagged goals; and postponing mvars.
* Some `Syntax` and `TSyntax` functionality, including:
  * `TSyntax.map`(`M`), for acting on `TSyntax` with functions `f : Syntax -> (m) Syntax`
  * Range operations: `includes` and `isEqByRange`
  * `setTrailingInfoBy?` and `unsetOriginalTrailing`, which is like `unsetTrailing`, but behaves as expected.
* `Term.withoutModifyingState`, which does not allow unknown mvarIds to escape via the infotree
* `hasNewErrors`, which runs a monad computation and returns the value along with `true` or `false` depending on whether new error messages have been logged
* the option `pp.anonymousMVarSuffixes`, which can be set to `false` to replace all numeric suffixes of anonymous mvars with `✝`, which is useful in tandem with `#guard_msgs` for tests (but is essentially a workaround—although it can make some tactic states more legible).

---

I'm open to suggestions on the location and name of the option/delaborator used for trimming the numeric suffixes of anonymous mvar names (which is used in the tests)—including whether or not it should exist in the first place, as it's essentially just a workaround.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
