### PR TITLE
[Merged by Bors] - chore: bump leantar 0.1.8

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -69,7 +69,7 @@ def CURLBIN :=
 
 /-- leantar version at https://github.com/digama0/leangz -/
 def LEANTARVERSION :=
-  "0.1.7"
+  "0.1.8"
 
 def EXE := if System.Platform.isWindows then ".exe" else ""
 


### PR DESCRIPTION
The latest version of leantar [includes](https://github.com/digama0/leangz/compare/v0.1.7...v0.1.8) the following features and bug fixes:

* Compression for `.hash` files
* Support for non-GMP bignum (de)compression

This is a backward compatible release, meaning that v0.1.8 can understand .ltar files produced by v0.1.7 and previous versions. So there should not be any hiccups during the transition period.

The important fix is the non-GMP bignum bug: previously, leantar would always compress and decompress olean files as if they contained GMP bignums, but GMP is only enabled on some architectures. The CI machines enable GMP, so compression is not a problem, but decompression happens on user machines of all architectures and this can cause crashes or invalid .olean files on MacOS Arm64, Linux Arm64 and Windows.

Surprisingly, no one has noticed this, and I believe the reason is because mathlib has never contained a numeric literal of size 2^64 or larger. Lean [has one](https://github.com/leanprover/lean4/blob/65d08fdcdd9fb825b588660cce4e082a758954fa/src/Init/Prelude.lean#L1972), but we don't ship oleans from the Init package as these come with the toolchain.