### PR TITLE
[Merged by Bors] - refactor(Logic/Unique): remove dependency on `Fin`

### DIFF
--- a/Mathlib/Data/Countable/Defs.lean
+++ b/Mathlib/Data/Countable/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Data.Finite.Defs
+import Mathlib.Init.Data.Fin.Basic
 import Mathlib.Tactic.Common
 
 #align_import data.countable.defs from "leanprover-community/mathlib"@"70d50ecfd4900dd6d328da39ab7ebd516abe4025"

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -542,7 +542,7 @@ instance inhabited (n : ℕ) [NeZero n] : Inhabited (Fin n) :=
   ⟨0⟩
 
 instance inhabitedFinOneAdd (n : ℕ) : Inhabited (Fin (1 + n)) :=
-  ⟨⟨0, by rw [Nat.add_comm]; exact Nat.zero_lt_succ _⟩⟩
+  ⟨letI : NeZero (1 + n) := (by rw [Nat.add_comm]; infer_instance); 0⟩
 
 @[simp]
 theorem default_eq_zero (n : ℕ) [NeZero n] : (default : Fin n) = 0 :=

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -541,6 +541,9 @@ instance [NeZero n] : OfNat (Fin n) a where
 instance inhabited (n : ℕ) [NeZero n] : Inhabited (Fin n) :=
   ⟨0⟩
 
+instance inhabitedFinOneAdd (n : ℕ) : Inhabited (Fin (1 + n)) :=
+  ⟨⟨0, by rw [Nat.add_comm]; exact Nat.zero_lt_succ _⟩⟩
+
 @[simp]
 theorem default_eq_zero (n : ℕ) [NeZero n] : (default : Fin n) = 0 :=
   rfl

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -545,6 +545,7 @@ instance inhabited (n : ℕ) [NeZero n] : Inhabited (Fin n) :=
 theorem default_eq_zero (n : ℕ) [NeZero n] : (default : Fin n) = 0 :=
   rfl
 #align fin.default_eq_zero Fin.default_eq_zero
+
 section from_ad_hoc
 
 @[simp] lemma ofNat'_zero [NeZero n] : (Fin.ofNat' 0 h : Fin n) = 0 := rfl

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -542,7 +542,8 @@ instance inhabited (n : ℕ) [NeZero n] : Inhabited (Fin n) :=
   ⟨0⟩
 
 instance inhabitedFinOneAdd (n : ℕ) : Inhabited (Fin (1 + n)) :=
-  ⟨letI : NeZero (1 + n) := (by rw [Nat.add_comm]; infer_instance); 0⟩
+  letI : NeZero (1 + n) := by rw [Nat.add_comm]; infer_instance
+  inferInstance
 
 @[simp]
 theorem default_eq_zero (n : ℕ) [NeZero n] : (default : Fin n) = 0 :=

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -5,6 +5,7 @@ Authors: Robert Y. Lewis, Keeley Hoek
 -/
 import Mathlib.Algebra.NeZero
 import Mathlib.Algebra.Order.WithZero
+import Mathlib.Init.Data.Fin.Basic
 import Mathlib.Order.RelIso.Basic
 import Mathlib.Data.Nat.Order.Basic
 import Mathlib.Order.Hom.Set
@@ -537,6 +538,13 @@ protected theorem zero_add [NeZero n] (k : Fin n) : 0 + k = k := by
 instance [NeZero n] : OfNat (Fin n) a where
   ofNat := Fin.ofNat' a (NeZero.pos n)
 
+instance inhabited (n : ℕ) [NeZero n] : Inhabited (Fin n) :=
+  ⟨0⟩
+
+@[simp]
+theorem default_eq_zero (n : ℕ) [NeZero n] : (default : Fin n) = 0 :=
+  rfl
+#align fin.default_eq_zero Fin.default_eq_zero
 section from_ad_hoc
 
 @[simp] lemma ofNat'_zero [NeZero n] : (Fin.ofNat' 0 h : Fin n) = 0 := rfl
@@ -1225,6 +1233,12 @@ protected theorem coe_neg (a : Fin n) : ((-a : Fin n) : ℕ) = (n - a) % n :=
 protected theorem coe_sub (a b : Fin n) : ((a - b : Fin n) : ℕ) = (a + (n - b)) % n := by
   cases a; cases b; rfl
 #align fin.coe_sub Fin.coe_sub
+
+theorem eq_zero (n : Fin 1) : n = 0 := Subsingleton.elim _ _
+#align fin.eq_zero Fin.eq_zero
+
+instance uniqueFinOne : Unique (Fin 1) where
+  uniq _ := Subsingleton.elim _ _
 
 @[simp]
 theorem coe_fin_one (a : Fin 1) : (a : ℕ) = 0 := by simp [Subsingleton.elim a 0]

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -542,7 +542,7 @@ instance inhabited (n : ℕ) [NeZero n] : Inhabited (Fin n) :=
   ⟨0⟩
 
 instance inhabitedFinOneAdd (n : ℕ) : Inhabited (Fin (1 + n)) :=
-  letI : NeZero (1 + n) := by rw [Nat.add_comm]; infer_instance
+  haveI : NeZero (1 + n) := by rw [Nat.add_comm]; infer_instance
   inferInstance
 
 @[simp]

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.List.Lattice
 import Mathlib.Data.List.Pairwise
 import Mathlib.Data.List.Forall2
 import Mathlib.Data.Set.Pairwise.Basic
+import Mathlib.Init.Data.Fin.Basic
 
 #align_import data.list.nodup from "leanprover-community/mathlib"@"c227d107bbada5d0d9d20287e3282c0a7f1651a0"
 

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -5,6 +5,7 @@ Authors: Eric Rodriguez
 -/
 import Mathlib.Algebra.NeZero
 import Mathlib.Data.Nat.ModEq
+import Mathlib.Data.Fin.Basic
 import Mathlib.Data.Fintype.Lattice
 
 #align_import data.zmod.defs from "leanprover-community/mathlib"@"3a2b5524a138b5d0b818b858b516d4ac8a484b03"

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -5,7 +5,6 @@ Authors: Eric Rodriguez
 -/
 import Mathlib.Algebra.NeZero
 import Mathlib.Data.Nat.ModEq
-import Mathlib.Data.Fin.Basic
 import Mathlib.Data.Fintype.Lattice
 
 #align_import data.zmod.defs from "leanprover-community/mathlib"@"3a2b5524a138b5d0b818b858b516d4ac8a484b03"
@@ -109,7 +108,7 @@ instance ZMod.repr : ∀ n : ℕ, Repr (ZMod n)
 
 namespace ZMod
 
-instance instUnique : Unique (ZMod 1) := Fin.unique
+instance instUnique : Unique (ZMod 1) := Fin.uniqueFinOne
 
 instance fintype : ∀ (n : ℕ) [NeZero n], Fintype (ZMod n)
   | 0, h => (h.ne rfl).elim

--- a/Mathlib/Logic/Unique.lean
+++ b/Mathlib/Logic/Unique.lean
@@ -5,7 +5,6 @@ Authors: Johan Commelin
 -/
 import Mathlib.Logic.IsEmpty
 import Mathlib.Init.Logic
-import Mathlib.Init.Data.Fin.Basic
 import Mathlib.Tactic.Inhabit
 
 #align_import logic.unique from "leanprover-community/mathlib"@"c4658a649d216f57e99621708b09dcb3dcccbd23"
@@ -109,24 +108,6 @@ def uniqueProp {p : Prop} (h : p) : Unique.{0} p where
 
 instance : Unique True :=
   uniqueProp trivial
-
-theorem Fin.eq_zero : ∀ n : Fin 1, n = 0
-  | ⟨_, hn⟩ => Fin.eq_of_veq (Nat.eq_zero_of_le_zero (Nat.le_of_lt_succ hn))
-#align fin.eq_zero Fin.eq_zero
-
-instance {n : ℕ} : Inhabited (Fin n.succ) :=
-  ⟨0⟩
-
-instance inhabitedFinOneAdd (n : ℕ) : Inhabited (Fin (1 + n)) :=
-  ⟨⟨0, by rw [Nat.add_comm]; exact Nat.zero_lt_succ _⟩⟩
-
-@[simp]
-theorem Fin.default_eq_zero (n : ℕ) : (default : Fin n.succ) = 0 :=
-  rfl
-#align fin.default_eq_zero Fin.default_eq_zero
-
-instance Fin.unique : Unique (Fin 1) where
-  uniq := Fin.eq_zero
 
 namespace Unique
 


### PR DESCRIPTION
`Unique` should be available earlier than results about `Fin n`, by virtue of being a very basic logic typeclass with no dependencies on Nat or algebra.

This also generalizes some of the moved instances and lemmas.
There are no new declarations in this PR, only renames of existing ones.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
