### PR TITLE
chore: remove unnecessary lambda in Analysis/Calculus/Derive/Add.lean

### DIFF
--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -50,21 +50,21 @@ section Add
 
 
 nonrec theorem HasDerivAtFilter.add (hf : HasDerivAtFilter f f' x L)
-    (hg : HasDerivAtFilter g g' x L) : HasDerivAtFilter (fun y => f y + g y) (f' + g') x L := by
+    (hg : HasDerivAtFilter g g' x L) : HasDerivAtFilter (f + g) (f' + g') x L := by
   simpa using (hf.add hg).hasDerivAtFilter
 #align has_deriv_at_filter.add HasDerivAtFilter.add
 
 nonrec theorem HasStrictDerivAt.add (hf : HasStrictDerivAt f f' x) (hg : HasStrictDerivAt g g' x) :
-    HasStrictDerivAt (fun y => f y + g y) (f' + g') x := by simpa using (hf.add hg).hasStrictDerivAt
+    HasStrictDerivAt (f + g) (f' + g') x := by simpa using (hf.add hg).hasStrictDerivAt
 #align has_strict_deriv_at.add HasStrictDerivAt.add
 
 nonrec theorem HasDerivWithinAt.add (hf : HasDerivWithinAt f f' s x)
-    (hg : HasDerivWithinAt g g' s x) : HasDerivWithinAt (fun y => f y + g y) (f' + g') s x :=
+    (hg : HasDerivWithinAt g g' s x) : HasDerivWithinAt (f + g) (f' + g') s x :=
   hf.add hg
 #align has_deriv_within_at.add HasDerivWithinAt.add
 
 nonrec theorem HasDerivAt.add (hf : HasDerivAt f f' x) (hg : HasDerivAt g g' x) :
-    HasDerivAt (fun x => f x + g x) (f' + g') x :=
+    HasDerivAt (f + g) (f' + g') x :=
   hf.add hg
 #align has_deriv_at.add HasDerivAt.add
 
@@ -198,20 +198,20 @@ section Neg
 /-! ### Derivative of the negative of a function -/
 
 nonrec theorem HasDerivAtFilter.neg (h : HasDerivAtFilter f f' x L) :
-    HasDerivAtFilter (fun x => -f x) (-f') x L := by simpa using h.neg.hasDerivAtFilter
+    HasDerivAtFilter (-f) (-f') x L := by simpa using h.neg.hasDerivAtFilter
 #align has_deriv_at_filter.neg HasDerivAtFilter.neg
 
 nonrec theorem HasDerivWithinAt.neg (h : HasDerivWithinAt f f' s x) :
-    HasDerivWithinAt (fun x => -f x) (-f') s x :=
+    HasDerivWithinAt (-f) (-f') s x :=
   h.neg
 #align has_deriv_within_at.neg HasDerivWithinAt.neg
 
-nonrec theorem HasDerivAt.neg (h : HasDerivAt f f' x) : HasDerivAt (fun x => -f x) (-f') x :=
+nonrec theorem HasDerivAt.neg (h : HasDerivAt f f' x) : HasDerivAt (-f) (-f') x :=
   h.neg
 #align has_deriv_at.neg HasDerivAt.neg
 
 nonrec theorem HasStrictDerivAt.neg (h : HasStrictDerivAt f f' x) :
-    HasStrictDerivAt (fun x => -f x) (-f') x := by simpa using h.neg.hasStrictDerivAt
+    HasStrictDerivAt (-f) (-f') x := by simpa using h.neg.hasStrictDerivAt
 #align has_strict_deriv_at.neg HasStrictDerivAt.neg
 
 theorem derivWithin.neg (hxs : UniqueDiffWithinAt 𝕜 s x) :
@@ -289,22 +289,22 @@ section Sub
 /-! ### Derivative of the difference of two functions -/
 
 theorem HasDerivAtFilter.sub (hf : HasDerivAtFilter f f' x L) (hg : HasDerivAtFilter g g' x L) :
-    HasDerivAtFilter (fun x => f x - g x) (f' - g') x L := by
+    HasDerivAtFilter (f - g) (f' - g') x L := by
   simpa only [sub_eq_add_neg] using hf.add hg.neg
 #align has_deriv_at_filter.sub HasDerivAtFilter.sub
 
 nonrec theorem HasDerivWithinAt.sub (hf : HasDerivWithinAt f f' s x)
-    (hg : HasDerivWithinAt g g' s x) : HasDerivWithinAt (fun x => f x - g x) (f' - g') s x :=
+    (hg : HasDerivWithinAt g g' s x) : HasDerivWithinAt (f - g) (f' - g') s x :=
   hf.sub hg
 #align has_deriv_within_at.sub HasDerivWithinAt.sub
 
 nonrec theorem HasDerivAt.sub (hf : HasDerivAt f f' x) (hg : HasDerivAt g g' x) :
-    HasDerivAt (fun x => f x - g x) (f' - g') x :=
+    HasDerivAt (f - g) (f' - g') x :=
   hf.sub hg
 #align has_deriv_at.sub HasDerivAt.sub
 
 theorem HasStrictDerivAt.sub (hf : HasStrictDerivAt f f' x) (hg : HasStrictDerivAt g g' x) :
-    HasStrictDerivAt (fun x => f x - g x) (f' - g') x := by
+    HasStrictDerivAt (f - g) (f' - g') x := by
   simpa only [sub_eq_add_neg] using hf.add hg.neg
 #align has_strict_deriv_at.sub HasStrictDerivAt.sub
 

--- a/test/LibrarySearch/HasDerivAt.lean
+++ b/test/LibrarySearch/HasDerivAt.lean
@@ -1,0 +1,7 @@
+import Mathlib.Analysis.Calculus.Deriv.Add
+import Mathlib.Analysis.Complex.Basic
+
+-- From https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Power.20series.20.2F.20bound.20for.20complex.20logarithm/near/403007421
+example {f g : ℝ → ℂ} {x : ℝ} {a b : ℂ} (hf : HasDerivAt f a x) (hg : HasDerivAt g b x) :
+    HasDerivAt (f + g) (a + b) x := by
+  exact? says exact HasDerivAt.add hf hg


### PR DESCRIPTION
so exact? can index the theorems.

This is prompted by https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Power.20series.20.2F.20bound.20for.20complex.20logarithm/near/403007421.

I'm not sure what the long term solution is here.
* We can get rid of unnecessary `fun`, for better `DiscrTree` matching (but sometimes it is needed!)
* I can use the existing `DiscrTree` but replace `.other` keys with `.star` keys to get more flexible matching (at the cost of some(?) performance)
* Jovan has a replacement `DiscrTree` implementation that potentially `exact?` could use.

But it would be good to know if this PR in isolation is okay.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
