### PR TITLE
[Merged by Bors] - fix(CategoryTheory): remove unnecessary noncomputable modifier

### DIFF
--- a/Mathlib/CategoryTheory/Sites/EffectiveEpimorphic.lean
+++ b/Mathlib/CategoryTheory/Sites/EffectiveEpimorphic.lean
@@ -573,7 +573,7 @@ section Regular
 
 open RegularEpi in
 /-- The data of an `EffectiveEpi` structure on a `RegularEpi`. -/
-noncomputable def effectiveEpiStructOfRegularEpi {B X : C} (f : X ⟶ B) [RegularEpi f] :
+def effectiveEpiStructOfRegularEpi {B X : C} (f : X ⟶ B) [RegularEpi f] :
     EffectiveEpiStruct f where
   desc _ h := Cofork.IsColimit.desc isColimit _ (h _ _ w)
   fac _ _ := Cofork.IsColimit.π_desc' isColimit _ _


### PR DESCRIPTION
The `EffectiveEpiStruct` for a `RegularEpi` turned out to become computable after applying suggestions from code review.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
