### PR TITLE
[Merged by Bors] - refactor: generalize `Bool.beq_eq_decide_eq`

### DIFF
--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -82,8 +82,8 @@ theorem eq_iff_eq_true_iff {a b : Bool} : a = b ↔ ((a = true) ↔ (b = true)) 
 
 -- Porting note: new theorem
 /- Even though `DecidableEq α` implies an instance of (`Lawful`)`BEq α`, we keep the seemingly
-    redundant typeclass assumptions so that the theorem is also applicable for types that have
-    overridden this default instance of `LawfulBeq α` -/
+redundant typeclass assumptions so that the theorem is also applicable for types that have
+overridden this default instance of `LawfulBEq α` -/
 theorem beq_eq_decide_eq {α} [BEq α] [LawfulBEq α] [DecidableEq α]
     (a b : α) : (a == b) = decide (a = b) := by
   cases h : a == b

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -81,8 +81,14 @@ theorem eq_iff_eq_true_iff {a b : Bool} : a = b ↔ ((a = true) ↔ (b = true)) 
   cases a <;> cases b <;> simp
 
 -- Porting note: new theorem
-theorem beq_eq_decide_eq {α} [DecidableEq α]
-    (a b : α) : (a == b) = decide (a = b) := rfl
+/- Even though `DecidableEq α` implies an instance of (`Lawful`)`BEq α`, we keep the seemingly
+    redundant typeclass assumptions so that the theorem is also applicable for types that have
+    overridden this default instance of `LawfulBeq α` -/
+theorem beq_eq_decide_eq {α} [BEq α] [LawfulBEq α] [DecidableEq α]
+    (a b : α) : (a == b) = decide (a = b) := by
+  cases h : a == b
+  · simp [ne_of_beq_false h]
+  · simp [eq_of_beq h]
 
 -- Porting note: new theorem
 theorem beq_comm {α} [BEq α] [LawfulBEq α] {a b : α} : (a == b) = (b == a) :=


### PR DESCRIPTION

This PR generalizes `Bool.beq_eq_decide_eq` to also be applicable for types whose `BEq α` is different from the default instance implied by `DecidableEq α`. An example of such a type is `Nat`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
