### PR TITLE
[Merged by Bors] - fix: stop exposing an implicit accessible name in by_cases

### DIFF
--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -58,13 +58,6 @@ def pushFVarAliasInfo [Monad m] [MonadInfoTree m]
       let decl := newLCtx.get! new
       pushInfoLeaf (.ofFVarAliasInfo { id := new, baseId := old, userName := decl.userName })
 
-/--
-`by_cases p` makes a case distinction on `p`,
-resulting in two subgoals `h : p ⊢` and `h : ¬ p ⊢`.
--/
-macro "by_cases " e:term : tactic =>
-  `(tactic| by_cases $(mkIdent `h) : $e)
-
 syntax "transitivity" (ppSpace colGt term)? : tactic
 set_option hygiene false in
 macro_rules


### PR DESCRIPTION
This makes us use the core implementation of `by_cases`, which is more consistent with other lean 4 tactics.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
