### PR TITLE
[Merged by Bors] - refactor(Probability/Density): define pdf using rnDeriv

### DIFF
--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -141,6 +141,9 @@ instance haveLebesgueDecomposition_smul_right (μ ν : Measure α) [HaveLebesgue
       · simp [hr]
       · exact ENNReal.coe_ne_top
 
+theorem haveLebesgueDecomposition_withDensity (μ : Measure α) {f : α → ℝ≥0∞} (hf : Measurable f) :
+    (μ.withDensity f).HaveLebesgueDecomposition μ := ⟨⟨⟨0, f⟩, hf, .zero_left, (zero_add _).symm⟩⟩
+
 @[measurability]
 theorem measurable_rnDeriv (μ ν : Measure α) : Measurable <| μ.rnDeriv ν := by
   by_cases h : HaveLebesgueDecomposition μ ν

--- a/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kexing Ying, Rémy Degenne
 -/
 import Mathlib.MeasureTheory.Decomposition.SignedLebesgue
+import Mathlib.MeasureTheory.Measure.WithDensityVectorMeasure
 
 #align_import measure_theory.decomposition.radon_nikodym from "leanprover-community/mathlib"@"fc75855907eaa8ff39791039710f567f37d4556f"
 
@@ -418,5 +419,44 @@ theorem absolutelyContinuous_iff_withDensityᵥ_rnDeriv_eq (s : SignedMeasure α
 #align measure_theory.signed_measure.absolutely_continuous_iff_with_densityᵥ_rn_deriv_eq MeasureTheory.SignedMeasure.absolutelyContinuous_iff_withDensityᵥ_rnDeriv_eq
 
 end SignedMeasure
+
+section IntegralRNDerivMul
+
+open Measure
+
+variable {α : Type*} {m : MeasurableSpace α} {μ ν : Measure α}
+
+theorem lintegral_rnDeriv_mul [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν) {f : α → ℝ≥0∞}
+    (hf : Measurable f) : ∫⁻ x, μ.rnDeriv ν x * f x ∂ν = ∫⁻ x, f x ∂μ := by
+  nth_rw 2 [← withDensity_rnDeriv_eq μ ν hμν]
+  rw [lintegral_withDensity_eq_lintegral_mul ν (measurable_rnDeriv μ ν) hf]
+  rfl
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+
+theorem integrable_rnDeriv_smul_iff [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν)
+    [SigmaFinite μ] {f : α → E} :
+    Integrable (fun x ↦ (μ.rnDeriv ν x).toReal • f x) ν ↔ Integrable f μ := by
+  nth_rw 2 [← withDensity_rnDeriv_eq μ ν hμν]
+  rw [← integrable_withDensity_iff_integrable_smul' (E := E)
+    (measurable_rnDeriv μ ν) (rnDeriv_lt_top μ ν)]
+
+theorem withDensityᵥ_rnDeriv_smul [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν)
+    [SigmaFinite μ] {f : α → E} (hf : Integrable f μ) :
+    ν.withDensityᵥ (fun x ↦ ENNReal.toReal (rnDeriv μ ν x) • f x) = μ.withDensityᵥ f := by
+  rw [withDensityᵥ_smul_eq_withDensityᵥ_withDensity' (measurable_rnDeriv μ ν) (rnDeriv_lt_top μ ν)
+    <| (integrable_rnDeriv_smul_iff hμν).mpr hf, withDensity_rnDeriv_eq μ ν hμν]
+
+theorem integral_rnDeriv_smul [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν)
+    [SigmaFinite μ] {f : α → E} :
+    ∫ x, (μ.rnDeriv ν x).toReal • f x ∂ν = ∫ x, f x ∂μ := by
+  by_cases hf : Integrable f μ
+  · rw [← integral_univ, ← withDensityᵥ_apply ((integrable_rnDeriv_smul_iff hμν).mpr hf) .univ,
+      ← integral_univ, ← withDensityᵥ_apply hf .univ, withDensityᵥ_rnDeriv_smul hμν hf]
+  · rw [integral_undef hf, integral_undef]
+    contrapose! hf
+    exact (integrable_rnDeriv_smul_iff hμν).mp hf
+
+end IntegralRNDerivMul
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
@@ -427,9 +427,9 @@ open Measure
 variable {α : Type*} {m : MeasurableSpace α} {μ ν : Measure α}
 
 theorem lintegral_rnDeriv_mul [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν) {f : α → ℝ≥0∞}
-    (hf : Measurable f) : ∫⁻ x, μ.rnDeriv ν x * f x ∂ν = ∫⁻ x, f x ∂μ := by
+    (hf : AEMeasurable f ν) : ∫⁻ x, μ.rnDeriv ν x * f x ∂ν = ∫⁻ x, f x ∂μ := by
   nth_rw 2 [← withDensity_rnDeriv_eq μ ν hμν]
-  rw [lintegral_withDensity_eq_lintegral_mul ν (measurable_rnDeriv μ ν) hf]
+  rw [lintegral_withDensity_eq_lintegral_mul₀ (measurable_rnDeriv μ ν).aemeasurable hf]
   rfl
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
@@ -444,8 +444,8 @@ theorem integrable_rnDeriv_smul_iff [HaveLebesgueDecomposition μ ν] (hμν : �
 theorem withDensityᵥ_rnDeriv_smul [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν)
     [SigmaFinite μ] {f : α → E} (hf : Integrable f μ) :
     ν.withDensityᵥ (fun x ↦ (rnDeriv μ ν x).toReal • f x) = μ.withDensityᵥ f := by
-  rw [withDensityᵥ_smul_eq_withDensityᵥ_withDensity' (measurable_rnDeriv μ ν) (rnDeriv_lt_top μ ν)
-    <| (integrable_rnDeriv_smul_iff hμν).mpr hf, withDensity_rnDeriv_eq μ ν hμν]
+  rw [withDensityᵥ_smul_eq_withDensityᵥ_withDensity' (measurable_rnDeriv μ ν).aemeasurable
+    (rnDeriv_lt_top μ ν) ((integrable_rnDeriv_smul_iff hμν).mpr hf), withDensity_rnDeriv_eq μ ν hμν]
 
 theorem integral_rnDeriv_smul [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν)
     [SigmaFinite μ] {f : α → E} :

--- a/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
@@ -443,7 +443,7 @@ theorem integrable_rnDeriv_smul_iff [HaveLebesgueDecomposition μ ν] (hμν : �
 
 theorem withDensityᵥ_rnDeriv_smul [HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν)
     [SigmaFinite μ] {f : α → E} (hf : Integrable f μ) :
-    ν.withDensityᵥ (fun x ↦ ENNReal.toReal (rnDeriv μ ν x) • f x) = μ.withDensityᵥ f := by
+    ν.withDensityᵥ (fun x ↦ (rnDeriv μ ν x).toReal • f x) = μ.withDensityᵥ f := by
   rw [withDensityᵥ_smul_eq_withDensityᵥ_withDensity' (measurable_rnDeriv μ ν) (rnDeriv_lt_top μ ν)
     <| (integrable_rnDeriv_smul_iff hμν).mpr hf, withDensity_rnDeriv_eq μ ν hμν]
 

--- a/Mathlib/MeasureTheory/Measure/WithDensityVectorMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensityVectorMeasure.lean
@@ -130,16 +130,16 @@ theorem withDensityᵥ_smul' {𝕜 : Type*} [NontriviallyNormedField 𝕜] [Norm
 #align measure_theory.with_densityᵥ_smul' MeasureTheory.withDensityᵥ_smul'
 
 theorem withDensityᵥ_smul_eq_withDensityᵥ_withDensity {f : α → ℝ≥0} {g : α → E}
-    (hf : Measurable f) (hfg : Integrable (f • g) μ) :
+    (hf : AEMeasurable f μ) (hfg : Integrable (f • g) μ) :
     μ.withDensityᵥ (f • g) = (μ.withDensity (fun x ↦ f x)).withDensityᵥ g := by
   ext s hs
   rw [withDensityᵥ_apply hfg hs,
-    withDensityᵥ_apply ((integrable_withDensity_iff_integrable_smul hf).mpr hfg) hs,
-    set_integral_withDensity_eq_set_integral_smul₀ hf.aemeasurable.restrict _ hs]
+    withDensityᵥ_apply ((integrable_withDensity_iff_integrable_smul₀ hf).mpr hfg) hs,
+    set_integral_withDensity_eq_set_integral_smul₀ hf.restrict _ hs]
   rfl
 
 theorem withDensityᵥ_smul_eq_withDensityᵥ_withDensity' {f : α → ℝ≥0∞} {g : α → E}
-    (hf : Measurable f) (hflt : ∀ᵐ x ∂μ, f x < ∞)
+    (hf : AEMeasurable f μ) (hflt : ∀ᵐ x ∂μ, f x < ∞)
     (hfg : Integrable (fun x ↦ (f x).toReal • g x) μ) :
     μ.withDensityᵥ (fun x ↦ (f x).toReal • g x) = (μ.withDensity f).withDensityᵥ g := by
   rw [← withDensity_congr_ae (coe_toNNReal_ae_eq hflt),

--- a/Mathlib/MeasureTheory/Measure/WithDensityVectorMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensityVectorMeasure.lean
@@ -129,6 +129,23 @@ theorem withDensityᵥ_smul' {𝕜 : Type*} [NontriviallyNormedField 𝕜] [Norm
   withDensityᵥ_smul f r
 #align measure_theory.with_densityᵥ_smul' MeasureTheory.withDensityᵥ_smul'
 
+theorem withDensityᵥ_smul_eq_withDensityᵥ_withDensity {f : α → ℝ≥0} {g : α → E}
+    (hf : Measurable f) (hfg : Integrable (f • g) μ) :
+    μ.withDensityᵥ (f • g) = (μ.withDensity (fun x ↦ f x)).withDensityᵥ g := by
+  ext s hs
+  rw [withDensityᵥ_apply hfg hs,
+    withDensityᵥ_apply ((integrable_withDensity_iff_integrable_smul hf).mpr hfg) hs,
+    set_integral_withDensity_eq_set_integral_smul₀ hf.aemeasurable.restrict _ hs]
+  rfl
+
+theorem withDensityᵥ_smul_eq_withDensityᵥ_withDensity' {f : α → ℝ≥0∞} {g : α → E}
+    (hf : Measurable f) (hflt : ∀ᵐ x ∂μ, f x < ∞)
+    (hfg : Integrable (fun x ↦ (f x).toReal • g x) μ) :
+    μ.withDensityᵥ (fun x ↦ (f x).toReal • g x) = (μ.withDensity f).withDensityᵥ g := by
+  rw [← withDensity_congr_ae (coe_toNNReal_ae_eq hflt),
+    ← withDensityᵥ_smul_eq_withDensityᵥ_withDensity hf.ennreal_toNNReal hfg]
+  rfl
+
 theorem Measure.withDensityᵥ_absolutelyContinuous (μ : Measure α) (f : α → ℝ) :
     μ.withDensityᵥ f ≪ᵥ μ.toENNRealVectorMeasure := by
   by_cases hf : Integrable f μ

--- a/Mathlib/Probability/Density.lean
+++ b/Mathlib/Probability/Density.lean
@@ -94,17 +94,14 @@ instance HasPDF.haveLebesgueDecomposition {X : Ω → E} {ℙ : Measure Ω}
     {μ : Measure E} [hX : HasPDF X ℙ μ] : (map X ℙ).HaveLebesgueDecomposition μ :=
   hX.pdf'.2.1
 
-theorem HasPDF.absolutelyContinuous (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E)
-    [hX : HasPDF X ℙ μ] : map X ℙ ≪ μ := hX.pdf'.2.2
-
-theorem HasPDF.ac {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E}
+theorem HasPDF.absolutelyContinuous {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E}
     [hX : HasPDF X ℙ μ] : map X ℙ ≪ μ := hX.pdf'.2.2
 
 /-- A random variable that `HasPDF` is quasi-measure preserving. -/
 theorem HasPDF.quasiMeasurePreserving_of_measurable (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E)
     [HasPDF X ℙ μ] (h : Measurable X) : QuasiMeasurePreserving X ℙ μ :=
   { measurable := h
-    absolutelyContinuous := HasPDF.ac }
+    absolutelyContinuous := HasPDF.absolutelyContinuous }
 
 theorem HasPDF.congr {X Y : Ω → E} {ℙ : Measure Ω} {μ : Measure E} (hXY : X =ᵐ[ℙ] Y)
     [hX : HasPDF X ℙ μ] : HasPDF Y ℙ μ :=
@@ -231,8 +228,9 @@ section IntegralPDFMul
 /-- **The Law of the Unconscious Statistician** for nonnegative random variables. -/
 theorem lintegral_pdf_mul {X : Ω → E} [HasPDF X ℙ μ] {f : E → ℝ≥0∞}
     (hf : AEMeasurable f μ) : ∫⁻ x, pdf X ℙ μ x * f x ∂μ = ∫⁻ x, f (X x) ∂ℙ := by
-  rw [pdf_def, ← lintegral_map' (hf.mono_ac HasPDF.ac) (HasPDF.aemeasurable X ℙ μ),
-  lintegral_rnDeriv_mul HasPDF.ac hf]
+  rw [pdf_def,
+    ← lintegral_map' (hf.mono_ac HasPDF.absolutelyContinuous) (HasPDF.aemeasurable X ℙ μ),
+  lintegral_rnDeriv_mul HasPDF.absolutelyContinuous hf]
 
 variable {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
 
@@ -241,18 +239,19 @@ theorem integrable_pdf_smul_iff [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X �
     Integrable (fun x => (pdf X ℙ μ x).toReal • f x) μ ↔ Integrable (fun x => f (X x)) ℙ := by
   -- porting note: using `erw` because `rw` doesn't recognize `(f <| X ·)` as `f ∘ X`
   -- https://github.com/leanprover-community/mathlib4/issues/5164
-  erw [← integrable_map_measure (hf.mono' HasPDF.ac) (HasPDF.aemeasurable X ℙ μ),
-    map_eq_withDensity_pdf X ℙ μ, pdf_def, integrable_rnDeriv_smul_iff (E := F) HasPDF.ac]
+  erw [← integrable_map_measure (hf.mono' HasPDF.absolutelyContinuous) (HasPDF.aemeasurable X ℙ μ),
+    map_eq_withDensity_pdf X ℙ μ, pdf_def, integrable_rnDeriv_smul_iff HasPDF.absolutelyContinuous]
   eta_reduce
-  rw [withDensity_rnDeriv_eq _ _ HasPDF.ac]
+  rw [withDensity_rnDeriv_eq _ _ HasPDF.absolutelyContinuous]
 
 /-- **The Law of the Unconscious Statistician**: Given a random variable `X` and a measurable
 function `f`, `f ∘ X` is a random variable with expectation `∫ x, pdf X x • f x ∂μ`
 where `μ` is a measure on the codomain of `X`. -/
 theorem integral_pdf_smul [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X ℙ μ] {f : E → F}
     (hf : AEStronglyMeasurable f μ) : ∫ x, (pdf X ℙ μ x).toReal • f x ∂μ = ∫ x, f (X x) ∂ℙ := by
-  rw [← integral_map (HasPDF.aemeasurable X ℙ μ) (hf.mono' HasPDF.ac), map_eq_withDensity_pdf X ℙ μ,
-    pdf_def, integral_rnDeriv_smul HasPDF.ac, withDensity_rnDeriv_eq _ _ HasPDF.ac]
+  rw [← integral_map (HasPDF.aemeasurable X ℙ μ) (hf.mono' HasPDF.absolutelyContinuous),
+    map_eq_withDensity_pdf X ℙ μ, pdf_def, integral_rnDeriv_smul HasPDF.absolutelyContinuous,
+    withDensity_rnDeriv_eq _ _ HasPDF.absolutelyContinuous]
 
 end IntegralPDFMul
 

--- a/Mathlib/Probability/Density.lean
+++ b/Mathlib/Probability/Density.lean
@@ -67,41 +67,62 @@ variable {Ω E : Type*} [MeasurableSpace E]
 `μ` and they `HaveLebesgueDecomposition`. -/
 class HasPDF {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
     (μ : Measure E := by volume_tac) : Prop where
-  pdf' : Measurable X ∧ HaveLebesgueDecomposition (map X ℙ) μ ∧ map X ℙ ≪ μ
+  pdf' : AEMeasurable X ℙ ∧ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ
 #align measure_theory.has_pdf MeasureTheory.HasPDF
 
 section HasPDF
 
-theorem hasPDF_iff {_ : MeasurableSpace Ω} {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E} :
-    HasPDF X ℙ μ ↔ Measurable X ∧ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ :=
+variable {_ : MeasurableSpace Ω}
+
+theorem hasPDF_iff {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E} :
+    HasPDF X ℙ μ ↔ AEMeasurable X ℙ ∧ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ :=
   ⟨@HasPDF.pdf' _ _ _ _ _ _ _, HasPDF.mk⟩
 #align measure_theory.has_pdf_iff MeasureTheory.hasPDF_iff
 
-theorem hasPDF_iff_of_measurable {_ : MeasurableSpace Ω} {X : Ω → E} {ℙ : Measure Ω}
-    {μ : Measure E} (hX : Measurable X) :
+theorem hasPDF_iff_of_aemeasurable {X : Ω → E} {ℙ : Measure Ω}
+    {μ : Measure E} (hX : AEMeasurable X ℙ) :
     HasPDF X ℙ μ ↔ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ := by
   rw [hasPDF_iff]
   simp only [hX, true_and]
-#align measure_theory.pdf.has_pdf_iff_of_measurable MeasureTheory.hasPDF_iff_of_measurable
-
-variable {_ : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E)
 
 @[measurability]
-theorem HasPDF.measurable [hX : HasPDF X ℙ μ] : Measurable X :=
+theorem HasPDF.aemeasurable (X : Ω → E) (ℙ : Measure Ω)
+    (μ : Measure E) [hX : HasPDF X ℙ μ] : AEMeasurable X ℙ :=
   hX.pdf'.1
-#align measure_theory.has_pdf.measurable MeasureTheory.HasPDF.measurable
 
-instance HasPDF.haveLebesgueDecomposition [hX : HasPDF X ℙ μ] :
-    HaveLebesgueDecomposition (map X ℙ) μ :=
+instance HasPDF.haveLebesgueDecomposition {X : Ω → E} {ℙ : Measure Ω}
+    {μ : Measure E} [hX : HasPDF X ℙ μ] : (map X ℙ).HaveLebesgueDecomposition μ :=
   hX.pdf'.2.1
 
-theorem HasPDF.absolutelyContinuous [hX : HasPDF X ℙ μ] : map X ℙ ≪ μ := hX.pdf'.2.2
+theorem HasPDF.absolutelyContinuous (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E)
+    [hX : HasPDF X ℙ μ] : map X ℙ ≪ μ := hX.pdf'.2.2
+
+theorem HasPDF.ac {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E}
+    [hX : HasPDF X ℙ μ] : map X ℙ ≪ μ := hX.pdf'.2.2
 
 /-- A random variable that `HasPDF` is quasi-measure preserving. -/
-theorem HasPDF.quasiMeasurePreserving [HasPDF X ℙ μ] : QuasiMeasurePreserving X ℙ μ :=
-  { measurable := HasPDF.measurable X ℙ μ
-    absolutelyContinuous := HasPDF.absolutelyContinuous X ℙ μ }
-#align measure_theory.pdf.to_quasi_measure_preserving MeasureTheory.HasPDF.quasiMeasurePreserving
+theorem HasPDF.quasiMeasurePreserving_of_measurable (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E)
+    [HasPDF X ℙ μ] (h : Measurable X) : QuasiMeasurePreserving X ℙ μ :=
+  { measurable := h
+    absolutelyContinuous := HasPDF.ac }
+
+theorem HasPDF.congr {X Y : Ω → E} {ℙ : Measure Ω} {μ : Measure E} (hXY : X =ᵐ[ℙ] Y)
+    [hX : HasPDF X ℙ μ] : HasPDF Y ℙ μ :=
+  ⟨(HasPDF.aemeasurable X ℙ μ).congr hXY, ℙ.map_congr hXY ▸ hX.haveLebesgueDecomposition,
+    ℙ.map_congr hXY ▸ hX.absolutelyContinuous⟩
+
+theorem HasPDF.congr' {X Y : Ω → E} {ℙ : Measure Ω} {μ : Measure E} (hXY : X =ᵐ[ℙ] Y) :
+    HasPDF X ℙ μ ↔ HasPDF Y ℙ μ :=
+  ⟨fun _ ↦ HasPDF.congr hXY, fun _ ↦ HasPDF.congr hXY.symm⟩
+
+/-- X `HasPDF` if there is a pdf `f` such that `map X ℙ = μ.withDensity f`. -/
+theorem hasPDF_of_map_eq_withDensity {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E}
+    (hX : AEMeasurable X ℙ) (f : E → ℝ≥0∞) (hf : AEMeasurable f μ) (h : map X ℙ = μ.withDensity f) :
+    HasPDF X ℙ μ := by
+  refine ⟨hX, ?_, ?_⟩ <;> rw [h]
+  · rw [withDensity_congr_ae hf.ae_eq_mk]
+    exact haveLebesgueDecomposition_withDensity μ hf.measurable_mk
+  · exact withDensity_absolutelyContinuous μ f
 
 end HasPDF
 
@@ -109,50 +130,63 @@ end HasPDF
 derivative of the push-forward measure of `ℙ` along `X` with respect to `μ`. -/
 def pdf {_ : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E := by volume_tac) :
     E → ℝ≥0∞ :=
-  if HasPDF X ℙ μ then (map X ℙ).rnDeriv μ else 0
+  (map X ℙ).rnDeriv μ
 #align measure_theory.pdf MeasureTheory.pdf
 
-theorem pdf_def {_ : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E} {X : Ω → E}
-    [h : HasPDF X ℙ μ] : pdf X ℙ μ = (map X ℙ).rnDeriv μ := if_pos h
+theorem pdf_def {_ : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E} {X : Ω → E} :
+    pdf X ℙ μ = (map X ℙ).rnDeriv μ := rfl
 
-theorem pdf_undef {_ : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E} {X : Ω → E}
-    (h : ¬HasPDF X ℙ μ) : pdf X ℙ μ = 0 := if_neg h
-#align measure_theory.pdf_undef MeasureTheory.pdf_undef
+theorem pdf_of_not_aemeasurable {_ : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E}
+    {X : Ω → E} (hX : ¬AEMeasurable X ℙ) : pdf X ℙ μ =ᵐ[μ] 0 := by
+  unfold pdf
+  rw [map_of_not_aemeasurable hX]
+  exact rnDeriv_zero μ
+
+theorem pdf_of_not_haveLebesgueDecomposition {_ : MeasurableSpace Ω} {ℙ : Measure Ω}
+    {μ : Measure E} {X : Ω → E} (h : ¬(map X ℙ).HaveLebesgueDecomposition μ) : pdf X ℙ μ = 0 := by
+  unfold pdf
+  exact rnDeriv_of_not_haveLebesgueDecomposition h
+
+theorem aemeasurable_of_pdf_ne_zero {m : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E}
+    (X : Ω → E) (h : ¬pdf X ℙ μ =ᵐ[μ] 0) : AEMeasurable X ℙ := by
+  contrapose! h
+  exact pdf_of_not_aemeasurable h
 
 theorem hasPDF_of_pdf_ne_zero {m : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E} {X : Ω → E}
-    (h : pdf X ℙ μ ≠ 0) : HasPDF X ℙ μ := by
-  by_contra hpdf
-  simp [pdf, hpdf] at h
+    (hac : map X ℙ ≪ μ) (hpdf : ¬pdf X ℙ μ =ᵐ[μ] 0) : HasPDF X ℙ μ := by
+  refine ⟨?_, ?_, hac⟩
+  · exact aemeasurable_of_pdf_ne_zero X hpdf
+  · contrapose! hpdf
+    have := pdf_of_not_haveLebesgueDecomposition hpdf
+    filter_upwards using congrFun this
 #align measure_theory.has_pdf_of_pdf_ne_zero MeasureTheory.hasPDF_of_pdf_ne_zero
-
-theorem pdf_eq_zero_of_not_measurable {_ : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E}
-    {X : Ω → E} (hX : ¬Measurable X) : pdf X ℙ μ = 0 :=
-  pdf_undef fun _ => hX (HasPDF.measurable X ℙ μ)
-#align measure_theory.pdf_eq_zero_of_not_measurable MeasureTheory.pdf_eq_zero_of_not_measurable
-
-theorem measurable_of_pdf_ne_zero {m : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E}
-    (X : Ω → E) (h : pdf X ℙ μ ≠ 0) : Measurable X := by
-  by_contra hX
-  exact h (pdf_eq_zero_of_not_measurable hX)
-#align measure_theory.measurable_of_pdf_ne_zero MeasureTheory.measurable_of_pdf_ne_zero
 
 @[measurability]
 theorem measurable_pdf {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
     (μ : Measure E := by volume_tac) : Measurable (pdf X ℙ μ) := by
-  unfold pdf
-  split_ifs
-  exacts [measurable_rnDeriv _ _, measurable_zero]
+  exact measurable_rnDeriv _ _
 #align measure_theory.measurable_pdf MeasureTheory.measurable_pdf
+
+theorem withDensity_pdf_le_map {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
+    (μ : Measure E := by volume_tac) : μ.withDensity (pdf X ℙ μ) ≤ map X ℙ := by
+  rw [pdf_def]
+  exact withDensity_rnDeriv_le _ _
+
+theorem set_lintegral_pdf_le_map {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
+    (μ : Measure E := by volume_tac) {s : Set E} (hs : MeasurableSet s) :
+    ∫⁻ x in s, pdf X ℙ μ x ∂μ ≤ map X ℙ s := by
+  apply (withDensity_apply_le _ s).trans
+  exact withDensity_pdf_le_map _ _ _ s hs
 
 theorem map_eq_withDensity_pdf {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
     (μ : Measure E := by volume_tac) [hX : HasPDF X ℙ μ] :
-    Measure.map X ℙ = μ.withDensity (pdf X ℙ μ) := by
+    map X ℙ = μ.withDensity (pdf X ℙ μ) := by
   rw [pdf_def, withDensity_rnDeriv_eq _ _ hX.absolutelyContinuous]
 #align measure_theory.map_eq_with_density_pdf MeasureTheory.map_eq_withDensity_pdf
 
 theorem map_eq_set_lintegral_pdf {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
     (μ : Measure E := by volume_tac) [hX : HasPDF X ℙ μ] {s : Set E}
-    (hs : MeasurableSet s) : Measure.map X ℙ s = ∫⁻ x in s, pdf X ℙ μ x ∂μ := by
+    (hs : MeasurableSet s) : map X ℙ s = ∫⁻ x in s, pdf X ℙ μ x ∂μ := by
   rw [← withDensity_apply _ hs, map_eq_withDensity_pdf X ℙ μ]
 #align measure_theory.map_eq_set_lintegral_pdf MeasureTheory.map_eq_set_lintegral_pdf
 
@@ -160,30 +194,31 @@ namespace pdf
 
 variable {m : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E}
 
+protected theorem congr {X Y : Ω → E} (hXY : X =ᵐ[ℙ] Y) : pdf X ℙ μ = pdf Y ℙ μ :=
+  by rw [pdf_def, pdf_def, map_congr hXY]
+
 theorem lintegral_eq_measure_univ {X : Ω → E} [HasPDF X ℙ μ] :
     ∫⁻ x, pdf X ℙ μ x ∂μ = ℙ Set.univ := by
   rw [← set_lintegral_univ, ← map_eq_set_lintegral_pdf X ℙ μ MeasurableSet.univ,
-    Measure.map_apply (HasPDF.measurable X ℙ μ) MeasurableSet.univ, Set.preimage_univ]
+    map_apply_of_aemeasurable (HasPDF.aemeasurable X ℙ μ) MeasurableSet.univ, Set.preimage_univ]
 #align measure_theory.pdf.lintegral_eq_measure_univ MeasureTheory.pdf.lintegral_eq_measure_univ
 
 theorem eq_of_map_eq_withDensity [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X ℙ μ] (f : E → ℝ≥0∞)
-    (hmf : AEMeasurable f μ) : ℙ.map X = μ.withDensity f ↔ pdf X ℙ μ =ᵐ[μ] f := by
+    (hmf : AEMeasurable f μ) : map X ℙ = μ.withDensity f ↔ pdf X ℙ μ =ᵐ[μ] f := by
   rw [map_eq_withDensity_pdf X ℙ μ]
   apply withDensity_eq_iff (measurable_pdf X ℙ μ).aemeasurable hmf
   rw [lintegral_eq_measure_univ]
   exact measure_ne_top _ _
 
 theorem eq_of_map_eq_withDensity' [SigmaFinite μ] {X : Ω → E} [HasPDF X ℙ μ] (f : E → ℝ≥0∞)
-    (hmf : AEMeasurable f μ) : ℙ.map X = μ.withDensity f ↔ pdf X ℙ μ =ᵐ[μ] f :=
+    (hmf : AEMeasurable f μ) : map X ℙ = μ.withDensity f ↔ pdf X ℙ μ =ᵐ[μ] f :=
   map_eq_withDensity_pdf X ℙ μ ▸
     withDensity_eq_iff_of_sigmaFinite (measurable_pdf X ℙ μ).aemeasurable hmf
 
 nonrec theorem ae_lt_top [IsFiniteMeasure ℙ] {μ : Measure E} {X : Ω → E} :
     ∀ᵐ x ∂μ, pdf X ℙ μ x < ∞ := by
-  by_cases hpdf : HasPDF X ℙ μ
-  · rw [pdf_def]
-    exact rnDeriv_lt_top (map X ℙ) μ
-  · simp [pdf, hpdf]
+  rw [pdf_def]
+  exact rnDeriv_lt_top (map X ℙ) μ
 #align measure_theory.pdf.ae_lt_top MeasureTheory.pdf.ae_lt_top
 
 nonrec theorem ofReal_toReal_ae_eq [IsFiniteMeasure ℙ] {X : Ω → E} :
@@ -195,9 +230,9 @@ section IntegralPDFMul
 
 /-- **The Law of the Unconscious Statistician** for nonnegative random variables. -/
 theorem lintegral_pdf_mul {X : Ω → E} [HasPDF X ℙ μ] {f : E → ℝ≥0∞}
-    (hf : Measurable f) : ∫⁻ x, pdf X ℙ μ x * f x ∂μ = ∫⁻ x, f (X x) ∂ℙ := by
-  rw [pdf_def, ← lintegral_map hf (HasPDF.measurable X ℙ μ),
-  lintegral_rnDeriv_mul (HasPDF.absolutelyContinuous X ℙ μ) hf]
+    (hf : AEMeasurable f μ) : ∫⁻ x, pdf X ℙ μ x * f x ∂μ = ∫⁻ x, f (X x) ∂ℙ := by
+  rw [pdf_def, ← lintegral_map' (hf.mono_ac HasPDF.ac) (HasPDF.aemeasurable X ℙ μ),
+  lintegral_rnDeriv_mul HasPDF.ac hf]
 
 variable {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
 
@@ -206,21 +241,18 @@ theorem integrable_pdf_smul_iff [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X �
     Integrable (fun x => (pdf X ℙ μ x).toReal • f x) μ ↔ Integrable (fun x => f (X x)) ℙ := by
   -- porting note: using `erw` because `rw` doesn't recognize `(f <| X ·)` as `f ∘ X`
   -- https://github.com/leanprover-community/mathlib4/issues/5164
-  erw [← integrable_map_measure (hf.mono' (HasPDF.absolutelyContinuous X ℙ μ))
-    (HasPDF.measurable X ℙ μ).aemeasurable, map_eq_withDensity_pdf X ℙ μ, pdf_def,
-    integrable_rnDeriv_smul_iff (E := F) (HasPDF.absolutelyContinuous X ℙ μ)]
+  erw [← integrable_map_measure (hf.mono' HasPDF.ac) (HasPDF.aemeasurable X ℙ μ),
+    map_eq_withDensity_pdf X ℙ μ, pdf_def, integrable_rnDeriv_smul_iff (E := F) HasPDF.ac]
   eta_reduce
-  rw [withDensity_rnDeriv_eq _ _ (HasPDF.absolutelyContinuous X ℙ μ)]
+  rw [withDensity_rnDeriv_eq _ _ HasPDF.ac]
 
 /-- **The Law of the Unconscious Statistician**: Given a random variable `X` and a measurable
 function `f`, `f ∘ X` is a random variable with expectation `∫ x, pdf X x • f x ∂μ`
 where `μ` is a measure on the codomain of `X`. -/
 theorem integral_pdf_smul [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X ℙ μ] {f : E → F}
     (hf : AEStronglyMeasurable f μ) : ∫ x, (pdf X ℙ μ x).toReal • f x ∂μ = ∫ x, f (X x) ∂ℙ := by
-  rw [← integral_map (HasPDF.measurable X ℙ μ).aemeasurable
-    (hf.mono' (HasPDF.absolutelyContinuous X ℙ μ)), map_eq_withDensity_pdf X ℙ μ,
-    pdf_def, integral_rnDeriv_smul (HasPDF.absolutelyContinuous X ℙ μ),
-    withDensity_rnDeriv_eq _ _ (HasPDF.absolutelyContinuous X ℙ μ)]
+  rw [← integral_map (HasPDF.aemeasurable X ℙ μ) (hf.mono' HasPDF.ac), map_eq_withDensity_pdf X ℙ μ,
+    pdf_def, integral_rnDeriv_smul HasPDF.ac, withDensity_rnDeriv_eq _ _ HasPDF.ac]
 
 end IntegralPDFMul
 
@@ -233,11 +265,16 @@ map also `HasPDF` if `(map g (map X ℙ)).HaveLebesgueDecomposition μ`.
 
 `quasiMeasurePreserving_hasPDF` is more useful in the case we are working with a
 probability measure and a real-valued random variable. -/
-theorem quasiMeasurePreserving_hasPDF {X : Ω → E} [HasPDF X ℙ μ] {g : E → F}
+theorem quasiMeasurePreserving_hasPDF {X : Ω → E} [HasPDF X ℙ μ] (hX : AEMeasurable X ℙ) {g : E → F}
     (hg : QuasiMeasurePreserving g μ ν) (hmap : (map g (map X ℙ)).HaveLebesgueDecomposition ν) :
     HasPDF (g ∘ X) ℙ ν := by
-  rw [hasPDF_iff, ← map_map hg.measurable (HasPDF.measurable X ℙ μ)]
-  refine' ⟨hg.measurable.comp (HasPDF.measurable X ℙ μ), hmap, _⟩
+  wlog hmX : Measurable X
+  · have hae : g ∘ X =ᵐ[ℙ] g ∘ hX.mk := hX.ae_eq_mk.mono fun x h ↦ by dsimp; rw [h]
+    have hXmk : HasPDF hX.mk ℙ μ := HasPDF.congr hX.ae_eq_mk
+    apply (HasPDF.congr' hae).mpr
+    exact this hX.measurable_mk.aemeasurable hg (map_congr hX.ae_eq_mk ▸ hmap) hX.measurable_mk
+  rw [hasPDF_iff, ← map_map hg.measurable hmX]
+  refine' ⟨(hg.measurable.comp hmX).aemeasurable, hmap, _⟩
   rw [map_eq_withDensity_pdf X ℙ μ]
   refine' AbsolutelyContinuous.mk fun s hsm hs => _
   rw [map_apply hg.measurable hsm, withDensity_apply _ (hg.measurable hsm)]
@@ -247,8 +284,9 @@ theorem quasiMeasurePreserving_hasPDF {X : Ω → E} [HasPDF X ℙ μ] {g : E �
 #align measure_theory.pdf.quasi_measure_preserving_has_pdf MeasureTheory.pdf.quasiMeasurePreserving_hasPDF
 
 theorem quasiMeasurePreserving_hasPDF' [IsFiniteMeasure ℙ] [SigmaFinite ν] {X : Ω → E}
-    [HasPDF X ℙ μ] {g : E → F} (hg : QuasiMeasurePreserving g μ ν) : HasPDF (g ∘ X) ℙ ν :=
-  quasiMeasurePreserving_hasPDF hg inferInstance
+    [HasPDF X ℙ μ] (hX : AEMeasurable X ℙ) {g : E → F} (hg : QuasiMeasurePreserving g μ ν) :
+    HasPDF (g ∘ X) ℙ ν :=
+  quasiMeasurePreserving_hasPDF hX hg inferInstance
 #align measure_theory.pdf.quasi_measure_preserving_has_pdf' MeasureTheory.pdf.quasiMeasurePreserving_hasPDF'
 
 end
@@ -259,15 +297,14 @@ variable [IsFiniteMeasure ℙ] {X : Ω → ℝ}
 
 /-- A real-valued random variable `X` `HasPDF X ℙ λ` (where `λ` is the Lebesgue measure) if and
 only if the push-forward measure of `ℙ` along `X` is absolutely continuous with respect to `λ`. -/
-nonrec theorem _root_.Real.hasPDF_iff_of_measurable (hX : Measurable X) :
+nonrec theorem _root_.Real.hasPDF_iff_of_aemeasurable (hX : AEMeasurable X ℙ) :
     HasPDF X ℙ ↔ map X ℙ ≪ volume := by
-  rw [hasPDF_iff_of_measurable hX]
+  rw [hasPDF_iff_of_aemeasurable hX]
   exact and_iff_right inferInstance
-#align measure_theory.pdf.real.has_pdf_iff_of_measurable Real.hasPDF_iff_of_measurable
 
-theorem _root_.Real.hasPDF_iff : HasPDF X ℙ ↔ Measurable X ∧ map X ℙ ≪ volume := by
-  by_cases hX : Measurable X
-  · rw [Real.hasPDF_iff_of_measurable hX, iff_and_self]
+theorem _root_.Real.hasPDF_iff : HasPDF X ℙ ↔ AEMeasurable X ℙ ∧ map X ℙ ≪ volume := by
+  by_cases hX : AEMeasurable X ℙ
+  · rw [Real.hasPDF_iff_of_aemeasurable hX, iff_and_self]
     exact fun _ => hX
   · exact ⟨fun h => False.elim (hX h.pdf'.1), fun h => False.elim (hX h.1)⟩
 #align measure_theory.pdf.real.has_pdf_iff Real.hasPDF_iff
@@ -299,92 +336,104 @@ section
 
 /-! **Uniform Distribution** -/
 
-/-- A random variable `X` has uniform distribution if it has a probability density function `f`
-with support `s` such that `f = (μ s)⁻¹ 1ₛ` a.e. where `1ₛ` is the indicator function for `s`. -/
-def IsUniform {_ : MeasurableSpace Ω} (X : Ω → E) (support : Set E) (ℙ : Measure Ω)
-    (μ : Measure E := by volume_tac) :=
-  pdf X ℙ μ =ᵐ[μ] support.indicator ((μ support)⁻¹ • (1 : E → ℝ≥0∞))
+/-- A random variable `X` has uniform distribution on `s` if its push-forward measure is
+`(μ s)⁻¹ • μ.restrict s`. -/
+def IsUniform (X : Ω → E) (support : Set E) (ℙ : Measure Ω) (μ : Measure E := by volume_tac) :=
+  map X ℙ = (μ support)⁻¹ • μ.restrict support
 #align measure_theory.pdf.is_uniform MeasureTheory.pdf.IsUniform
 
 namespace IsUniform
 
-theorem hasPDF {m : MeasurableSpace Ω} {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E} {s : Set E}
-    (hns : μ s ≠ 0) (hnt : μ s ≠ ∞) (hu : IsUniform X s ℙ μ) : HasPDF X ℙ μ :=
-  hasPDF_of_pdf_ne_zero
-    (by
-      intro hpdf
-      simp only [IsUniform, hpdf] at hu
-      suffices μ (s ∩ Function.support ((μ s)⁻¹ • (1 : E → ℝ≥0∞))) = 0 by
-        have heq : Function.support ((μ s)⁻¹ • (1 : E → ℝ≥0∞)) = Set.univ := by
-          ext x
-          rw [Function.mem_support]
-          simp [hnt]
-        rw [heq, Set.inter_univ] at this
-        exact hns this
-      exact Set.indicator_ae_eq_zero.1 hu.symm)
-#align measure_theory.pdf.is_uniform.has_pdf MeasureTheory.pdf.IsUniform.hasPDF
+theorem aemeasurable {X : Ω → E} {s : Set E} (hns : μ s ≠ 0) (hnt : μ s ≠ ∞)
+    (hu : IsUniform X s ℙ μ) : AEMeasurable X ℙ := by
+  dsimp [IsUniform] at hu
+  by_contra h
+  rw [map_of_not_aemeasurable h] at hu
+  apply zero_ne_one' ℝ≥0∞
+  calc
+    0 = (0 : Measure E) Set.univ := rfl
+    _ = _ := by rw [hu, smul_apply, restrict_apply MeasurableSet.univ,
+      Set.univ_inter, smul_eq_mul, ENNReal.inv_mul_cancel hns hnt]
 
-theorem pdf_toReal_ae_eq {_ : MeasurableSpace Ω} {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E}
-    {s : Set E} (hX : IsUniform X s ℙ μ) :
-    (fun x => (pdf X ℙ μ x).toReal) =ᵐ[μ] fun x =>
-      (s.indicator ((μ s)⁻¹ • (1 : E → ℝ≥0∞)) x).toReal :=
-  Filter.EventuallyEq.fun_comp hX ENNReal.toReal
-#align measure_theory.pdf.is_uniform.pdf_to_real_ae_eq MeasureTheory.pdf.IsUniform.pdf_toReal_ae_eq
+theorem absolutelyContinuous {X : Ω → E} {s : Set E} (hu : IsUniform X s ℙ μ) : map X ℙ ≪ μ := by
+  intro t ht
+  rw [hu, smul_apply, smul_eq_mul]
+  apply mul_eq_zero.mpr
+  refine Or.inr (le_antisymm ?_ (zero_le _))
+  exact ht ▸ restrict_apply_le s t
 
-theorem measure_preimage {m : MeasurableSpace Ω} {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E}
-    {s : Set E} (hns : μ s ≠ 0) (hnt : μ s ≠ ∞) (hms : MeasurableSet s) (hu : IsUniform X s ℙ μ)
-    {A : Set E} (hA : MeasurableSet A) : ℙ (X ⁻¹' A) = μ (s ∩ A) / μ s := by
-  haveI := hu.hasPDF hns hnt
-  rw [← Measure.map_apply (HasPDF.measurable X ℙ μ) hA, map_eq_set_lintegral_pdf X ℙ μ hA,
-    lintegral_congr_ae hu.restrict]
-  simp only [hms, hA, lintegral_indicator, Pi.smul_apply, Pi.one_apply, Algebra.id.smul_eq_mul,
-    mul_one, lintegral_const, restrict_apply', Set.univ_inter]
-  rw [ENNReal.div_eq_inv_mul]
+theorem measure_preimage {X : Ω → E} {s : Set E} (hns : μ s ≠ 0) (hnt : μ s ≠ ∞)
+    (hu : IsUniform X s ℙ μ) {A : Set E} (hA : MeasurableSet A) :
+    ℙ (X ⁻¹' A) = μ (s ∩ A) / μ s := by
+  rw [← map_apply_of_aemeasurable (hu.aemeasurable hns hnt) hA, hu, smul_apply, restrict_apply hA,
+    ENNReal.div_eq_inv_mul, smul_eq_mul, Set.inter_comm]
 #align measure_theory.pdf.is_uniform.measure_preimage MeasureTheory.pdf.IsUniform.measure_preimage
 
-theorem isProbabilityMeasure {m : MeasurableSpace Ω} {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E}
-    {s : Set E} (hns : μ s ≠ 0) (hnt : μ s ≠ ∞) (hms : MeasurableSet s) (hu : IsUniform X s ℙ μ) :
-    IsProbabilityMeasure ℙ :=
+theorem isProbabilityMeasure {X : Ω → E} {s : Set E} (hns : μ s ≠ 0) (hnt : μ s ≠ ∞)
+    (hu : IsUniform X s ℙ μ) : IsProbabilityMeasure ℙ :=
   ⟨by
     have : X ⁻¹' Set.univ = Set.univ := by simp only [Set.preimage_univ]
-    rw [← this, hu.measure_preimage hns hnt hms MeasurableSet.univ, Set.inter_univ,
+    rw [← this, hu.measure_preimage hns hnt MeasurableSet.univ, Set.inter_univ,
       ENNReal.div_self hns hnt]⟩
 #align measure_theory.pdf.is_uniform.is_probability_measure MeasureTheory.pdf.IsUniform.isProbabilityMeasure
 
-variable {X : Ω → ℝ} {s : Set ℝ} (hms : MeasurableSet s) (hns : volume s ≠ 0)
+theorem hasPDF {X : Ω → E} {s : Set E} (hms : MeasurableSet s) (hns : μ s ≠ 0) (hnt : μ s ≠ ∞)
+    (hu : IsUniform X s ℙ μ) : HasPDF X ℙ μ := by
+  apply hasPDF_of_map_eq_withDensity (hu.aemeasurable hns hnt) (s.indicator ((μ s)⁻¹ • 1)) <|
+    (measurable_one.aemeasurable.const_smul (μ s)⁻¹).indicator hms
+  rw [hu, withDensity_indicator hms, withDensity_smul _ measurable_one, withDensity_one]
+#align measure_theory.pdf.is_uniform.has_pdf MeasureTheory.pdf.IsUniform.hasPDF
+
+theorem hasPDF₀ {X : Ω → E} {s : Set E} (hms : NullMeasurableSet s μ) (hns : μ s ≠ 0)
+    (hnt : μ s ≠ ∞) (hu : IsUniform X s ℙ μ) : HasPDF X ℙ μ := by
+  have hms' := measurableSet_toMeasurable μ s
+  apply hasPDF (m := m) (ℙ := ℙ) (μ := μ) hms'
+    (measure_toMeasurable s ▸ hns) (measure_toMeasurable s ▸ hnt) _
+  unfold IsUniform
+  rw [measure_toMeasurable, restrict_congr_set hms.toMeasurable_ae_eq, hu]
+
+theorem pdf_eq {X : Ω → E} {s : Set E} (hms : MeasurableSet s) (hns : μ s ≠ 0) (hnt : μ s ≠ ∞)
+    (hu : IsUniform X s ℙ μ) : pdf X ℙ μ =ᵐ[μ] s.indicator ((μ s)⁻¹ • (1 : E → ℝ≥0∞)) := by
+  have : HasPDF X ℙ μ := hasPDF hms hns hnt hu
+  have : IsProbabilityMeasure ℙ := isProbabilityMeasure hns hnt hu
+  apply (eq_of_map_eq_withDensity _ _).mp
+  · rw [hu, withDensity_indicator hms, withDensity_smul _ measurable_one, withDensity_one]
+  · exact (measurable_one.aemeasurable.const_smul (μ s)⁻¹).indicator hms
+
+theorem pdf_toReal_ae_eq {X : Ω → E}
+    {s : Set E} (hms : MeasurableSet s) (hns : μ s ≠ 0) (hnt : μ s ≠ ∞)
+    (hX : IsUniform X s ℙ μ) :
+    (fun x => (pdf X ℙ μ x).toReal) =ᵐ[μ] fun x =>
+      (s.indicator ((μ s)⁻¹ • (1 : E → ℝ≥0∞)) x).toReal :=
+  Filter.EventuallyEq.fun_comp (pdf_eq hms hns hnt hX) ENNReal.toReal
+#align measure_theory.pdf.is_uniform.pdf_to_real_ae_eq MeasureTheory.pdf.IsUniform.pdf_toReal_ae_eq
+
+variable {X : Ω → ℝ} {s : Set ℝ} (hms : MeasurableSet s) (hns : volume s ≠ 0) (hnt : volume s ≠ ∞)
 
 theorem mul_pdf_integrable [IsFiniteMeasure ℙ] (hcs : IsCompact s) (huX : IsUniform X s ℙ) :
     Integrable fun x : ℝ => x * (pdf X ℙ volume x).toReal := by
-  by_cases hsupp : volume s = ∞
-  · have : pdf X ℙ =ᵐ[volume] 0 := by
-      refine' ae_eq_trans huX _
-      simp [hsupp, ae_eq_refl]
-    refine' Integrable.congr (integrable_zero _ _ _) _
-    rw [(by simp : (fun x => 0 : ℝ → ℝ) = fun x => x * (0 : ℝ≥0∞).toReal)]
-    refine'
-      Filter.EventuallyEq.mul (ae_eq_refl _) (Filter.EventuallyEq.fun_comp this.symm ENNReal.toReal)
   constructor -- porting note: `refine` was failing, don't know why
   · exact aestronglyMeasurable_id.mul
       (measurable_pdf X ℙ).aemeasurable.ennreal_toReal.aestronglyMeasurable
-  refine' hasFiniteIntegral_mul huX _
+  refine' hasFiniteIntegral_mul (pdf_eq hms hns hnt huX) _
   set ind := (volume s)⁻¹ • (1 : ℝ → ℝ≥0∞)
   have : ∀ x, ↑‖x‖₊ * s.indicator ind x = s.indicator (fun x => ‖x‖₊ * ind x) x := fun x =>
     (s.indicator_mul_right (fun x => ↑‖x‖₊) ind).symm
   simp only [this, lintegral_indicator _ hms, mul_one, Algebra.id.smul_eq_mul, Pi.one_apply,
     Pi.smul_apply]
   rw [lintegral_mul_const _ measurable_nnnorm.coe_nnreal_ennreal]
-  refine' (ENNReal.mul_lt_top (set_lintegral_lt_top_of_isCompact hsupp hcs continuous_nnnorm).ne
+  refine' (ENNReal.mul_lt_top (set_lintegral_lt_top_of_isCompact hnt hcs continuous_nnnorm).ne
     (ENNReal.inv_lt_top.2 (pos_iff_ne_zero.mpr hns)).ne).ne
 #align measure_theory.pdf.is_uniform.mul_pdf_integrable MeasureTheory.pdf.IsUniform.mul_pdf_integrable
 
 /-- A real uniform random variable `X` with support `s` has expectation
 `(λ s)⁻¹ * ∫ x in s, x ∂λ` where `λ` is the Lebesgue measure. -/
-theorem integral_eq (hnt : volume s ≠ ∞) (huX : IsUniform X s ℙ) :
+theorem integral_eq (huX : IsUniform X s ℙ) :
     ∫ x, X x ∂ℙ = (volume s)⁻¹.toReal * ∫ x in s, x := by
-  haveI := hasPDF hns hnt huX
-  haveI := huX.isProbabilityMeasure hns hnt hms
+  haveI := hasPDF hms hns hnt huX
+  haveI := huX.isProbabilityMeasure hns hnt
   rw [← integral_mul_eq_integral]
-  rw [integral_congr_ae (Filter.EventuallyEq.mul (ae_eq_refl _) (pdf_toReal_ae_eq huX))]
+  rw [integral_congr_ae (Filter.EventuallyEq.mul (ae_eq_refl _) (pdf_toReal_ae_eq hms hns hnt huX))]
   have :
     ∀ x,
       x * (s.indicator ((volume s)⁻¹ • (1 : ℝ → ℝ≥0∞)) x).toReal =
@@ -413,16 +462,16 @@ theorem indepFun_iff_pdf_prod_eq_pdf_mul_pdf
     [IsFiniteMeasure ℙ] [SigmaFinite μ] [SigmaFinite ν] [HasPDF (fun ω ↦ (X ω, Y ω)) ℙ (μ.prod ν)] :
     IndepFun X Y ℙ ↔
       pdf (fun ω ↦ (X ω, Y ω)) ℙ (μ.prod ν) =ᵐ[μ.prod ν] fun z ↦ pdf X ℙ μ z.1 * pdf Y ℙ ν z.2 := by
-  have : HasPDF X ℙ μ := quasiMeasurePreserving_hasPDF' (μ := μ.prod ν) (X := fun ω ↦ (X ω, Y ω))
-    quasiMeasurePreserving_fst
-  have : HasPDF Y ℙ ν := quasiMeasurePreserving_hasPDF' (μ := μ.prod ν) (X := fun ω ↦ (X ω, Y ω))
-    quasiMeasurePreserving_snd
+  have : HasPDF X ℙ μ := quasiMeasurePreserving_hasPDF' (μ := μ.prod ν)
+    (HasPDF.aemeasurable (fun ω ↦ (X ω, Y ω)) ℙ (μ.prod ν)) quasiMeasurePreserving_fst
+  have : HasPDF Y ℙ ν := quasiMeasurePreserving_hasPDF' (μ := μ.prod ν)
+    (HasPDF.aemeasurable (fun ω ↦ (X ω, Y ω)) ℙ (μ.prod ν)) quasiMeasurePreserving_snd
   have h₀ : (ℙ.map X).prod (ℙ.map Y) =
       (μ.prod ν).withDensity fun z ↦ pdf X ℙ μ z.1 * pdf Y ℙ ν z.2 :=
     prod_eq fun s t hs ht ↦ by rw [withDensity_apply _ (hs.prod ht), ← prod_restrict,
       lintegral_prod_mul (measurable_pdf X ℙ μ).aemeasurable (measurable_pdf Y ℙ ν).aemeasurable,
       map_eq_set_lintegral_pdf X ℙ μ hs, map_eq_set_lintegral_pdf Y ℙ ν ht]
-  rw [indepFun_iff_map_prod_eq_prod_map_map (HasPDF.measurable X ℙ μ) (HasPDF.measurable Y ℙ ν),
+  rw [indepFun_iff_map_prod_eq_prod_map_map (HasPDF.aemeasurable X ℙ μ) (HasPDF.aemeasurable Y ℙ ν),
     ← eq_of_map_eq_withDensity, h₀]
   exact (((measurable_pdf X ℙ μ).comp measurable_fst).mul
     ((measurable_pdf Y ℙ ν).comp measurable_snd)).aemeasurable

--- a/Mathlib/Probability/Density.lean
+++ b/Mathlib/Probability/Density.lean
@@ -35,9 +35,9 @@ random variables with this distribution.
 
 ## Main results
 
-* `MeasureTheory.pdf.integral_fun_mul_eq_integral` : Law of the unconscious statistician,
-  i.e. if a random variable `X : Ω → E` has pdf `f`, then `𝔼(g(X)) = ∫ x, g x * f x dx` for
-  all measurable `g : E → ℝ`.
+* `MeasureTheory.pdf.integral_pdf_smul` : Law of the unconscious statistician,
+  i.e. if a random variable `X : Ω → E` has pdf `f`, then `𝔼(g(X)) = ∫ x, f x • g x dx` for
+  all measurable `g : E → F`.
 * `MeasureTheory.pdf.integral_mul_eq_integral` : A real-valued random variable `X` with
   pdf `f` has expectation `∫ x, x * f x dx`.
 * `MeasureTheory.pdf.IsUniform.integral_eq` : If `X` follows the uniform distribution with
@@ -70,16 +70,40 @@ class HasPDF {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
   pdf' : Measurable X ∧ HaveLebesgueDecomposition (map X ℙ) μ ∧ map X ℙ ≪ μ
 #align measure_theory.has_pdf MeasureTheory.HasPDF
 
+section HasPDF
+
+theorem hasPDF_iff {_ : MeasurableSpace Ω} {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E} :
+    HasPDF X ℙ μ ↔ Measurable X ∧ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ :=
+  ⟨@HasPDF.pdf' _ _ _ _ _ _ _, HasPDF.mk⟩
+#align measure_theory.has_pdf_iff MeasureTheory.hasPDF_iff
+
+theorem hasPDF_iff_of_measurable {_ : MeasurableSpace Ω} {X : Ω → E} {ℙ : Measure Ω}
+    {μ : Measure E} (hX : Measurable X) :
+    HasPDF X ℙ μ ↔ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ := by
+  rw [hasPDF_iff]
+  simp only [hX, true_and]
+#align measure_theory.pdf.has_pdf_iff_of_measurable MeasureTheory.hasPDF_iff_of_measurable
+
+variable {_ : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E)
+
 @[measurability]
-theorem HasPDF.measurable {_ : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
-    (μ : Measure E := by volume_tac) [hX : HasPDF X ℙ μ] :
-    Measurable X :=
+theorem HasPDF.measurable [hX : HasPDF X ℙ μ] : Measurable X :=
   hX.pdf'.1
 #align measure_theory.has_pdf.measurable MeasureTheory.HasPDF.measurable
 
-instance HasPDF.haveLebesgueDecomposition {_ : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
-    (μ : Measure E := by volume_tac) [hX : HasPDF X ℙ μ] : HaveLebesgueDecomposition (map X ℙ) μ :=
+instance HasPDF.haveLebesgueDecomposition [hX : HasPDF X ℙ μ] :
+    HaveLebesgueDecomposition (map X ℙ) μ :=
   hX.pdf'.2.1
+
+theorem HasPDF.absolutelyContinuous [hX : HasPDF X ℙ μ] : map X ℙ ≪ μ := hX.pdf'.2.2
+
+/-- A random variable that `HasPDF` is quasi-measure preserving. -/
+theorem HasPDF.quasiMeasurePreserving [HasPDF X ℙ μ] : QuasiMeasurePreserving X ℙ μ :=
+  { measurable := HasPDF.measurable X ℙ μ
+    absolutelyContinuous := HasPDF.absolutelyContinuous X ℙ μ }
+#align measure_theory.pdf.to_quasi_measure_preserving MeasureTheory.HasPDF.quasiMeasurePreserving
+
+end HasPDF
 
 /-- If `X` is a random variable that `HasPDF X ℙ μ`, then `pdf X` is the Radon–Nikodym
 derivative of the push-forward measure of `ℙ` along `X` with respect to `μ`. -/
@@ -87,6 +111,9 @@ def pdf {_ : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω) (μ : Measure
     E → ℝ≥0∞ :=
   if HasPDF X ℙ μ then (map X ℙ).rnDeriv μ else 0
 #align measure_theory.pdf MeasureTheory.pdf
+
+theorem pdf_def {_ : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E} {X : Ω → E}
+    [h : HasPDF X ℙ μ] : pdf X ℙ μ = (map X ℙ).rnDeriv μ := if_pos h
 
 theorem pdf_undef {_ : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E} {X : Ω → E}
     (h : ¬HasPDF X ℙ μ) : pdf X ℙ μ = 0 := if_neg h
@@ -100,7 +127,7 @@ theorem hasPDF_of_pdf_ne_zero {m : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : 
 
 theorem pdf_eq_zero_of_not_measurable {_ : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E}
     {X : Ω → E} (hX : ¬Measurable X) : pdf X ℙ μ = 0 :=
-  pdf_undef fun hpdf => hX hpdf.pdf'.1
+  pdf_undef fun _ => hX (HasPDF.measurable X ℙ μ)
 #align measure_theory.pdf_eq_zero_of_not_measurable MeasureTheory.pdf_eq_zero_of_not_measurable
 
 theorem measurable_of_pdf_ne_zero {m : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E}
@@ -113,15 +140,14 @@ theorem measurable_of_pdf_ne_zero {m : MeasurableSpace Ω} {ℙ : Measure Ω} {�
 theorem measurable_pdf {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
     (μ : Measure E := by volume_tac) : Measurable (pdf X ℙ μ) := by
   unfold pdf
-  split_ifs with h
+  split_ifs
   exacts [measurable_rnDeriv _ _, measurable_zero]
 #align measure_theory.measurable_pdf MeasureTheory.measurable_pdf
 
 theorem map_eq_withDensity_pdf {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
     (μ : Measure E := by volume_tac) [hX : HasPDF X ℙ μ] :
     Measure.map X ℙ = μ.withDensity (pdf X ℙ μ) := by
-  simp [pdf, if_pos hX]
-  rw [withDensity_rnDeriv_eq _ _ hX.pdf'.2.2]
+  rw [pdf_def, withDensity_rnDeriv_eq _ _ hX.absolutelyContinuous]
 #align measure_theory.map_eq_with_density_pdf MeasureTheory.map_eq_withDensity_pdf
 
 theorem map_eq_set_lintegral_pdf {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
@@ -140,14 +166,14 @@ theorem lintegral_eq_measure_univ {X : Ω → E} [HasPDF X ℙ μ] :
     Measure.map_apply (HasPDF.measurable X ℙ μ) MeasurableSet.univ, Set.preimage_univ]
 #align measure_theory.pdf.lintegral_eq_measure_univ MeasureTheory.pdf.lintegral_eq_measure_univ
 
-theorem unique [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X ℙ μ] (f : E → ℝ≥0∞)
+theorem eq_of_map_eq_withDensity [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X ℙ μ] (f : E → ℝ≥0∞)
     (hmf : AEMeasurable f μ) : ℙ.map X = μ.withDensity f ↔ pdf X ℙ μ =ᵐ[μ] f := by
   rw [map_eq_withDensity_pdf X ℙ μ]
   apply withDensity_eq_iff (measurable_pdf X ℙ μ).aemeasurable hmf
   rw [lintegral_eq_measure_univ]
   exact measure_ne_top _ _
 
-theorem unique' [SigmaFinite μ] {X : Ω → E} [HasPDF X ℙ μ] (f : E → ℝ≥0∞) (hmf : AEMeasurable f μ) :
+theorem eq_of_map_eq_withDensity' [SigmaFinite μ] {X : Ω → E} [HasPDF X ℙ μ] (f : E → ℝ≥0∞) (hmf : AEMeasurable f μ) :
     ℙ.map X = μ.withDensity f ↔ pdf X ℙ μ =ᵐ[μ] f :=
   map_eq_withDensity_pdf X ℙ μ ▸
     withDensity_eq_iff_of_sigmaFinite (measurable_pdf X ℙ μ).aemeasurable hmf
@@ -155,10 +181,8 @@ theorem unique' [SigmaFinite μ] {X : Ω → E} [HasPDF X ℙ μ] (f : E → ℝ
 nonrec theorem ae_lt_top [IsFiniteMeasure ℙ] {μ : Measure E} {X : Ω → E} :
     ∀ᵐ x ∂μ, pdf X ℙ μ x < ∞ := by
   by_cases hpdf : HasPDF X ℙ μ
-  · haveI := hpdf
-    refine' ae_lt_top (measurable_pdf X ℙ μ) _
-    rw [lintegral_eq_measure_univ]
-    exact measure_ne_top _ _
+  · rw [pdf_def]
+    exact rnDeriv_lt_top (map X ℙ) μ
   · simp [pdf, hpdf]
 #align measure_theory.pdf.ae_lt_top MeasureTheory.pdf.ae_lt_top
 
@@ -167,83 +191,38 @@ nonrec theorem ofReal_toReal_ae_eq [IsFiniteMeasure ℙ] {X : Ω → E} :
   ofReal_toReal_ae_eq ae_lt_top
 #align measure_theory.pdf.of_real_to_real_ae_eq MeasureTheory.pdf.ofReal_toReal_ae_eq
 
-theorem integrable_iff_integrable_mul_pdf [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X ℙ μ] {f : E → ℝ}
-    (hf : Measurable f) :
-    Integrable (fun x => f (X x)) ℙ ↔ Integrable (fun x => f x * (pdf X ℙ μ x).toReal) μ := by
+section IntegralPDFMul
+
+/-- **The Law of the Unconscious Statistician** for nonnegative random variables. -/
+theorem lintegral_pdf_mul {X : Ω → E} [HasPDF X ℙ μ] {f : E → ℝ≥0∞}
+    (hf : Measurable f) : ∫⁻ x, pdf X ℙ μ x * f x ∂μ = ∫⁻ x, f (X x) ∂ℙ := by
+  rw [pdf_def, ← lintegral_map hf (HasPDF.measurable X ℙ μ),
+  lintegral_rnDeriv_mul (HasPDF.absolutelyContinuous X ℙ μ) hf]
+
+variable {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
+
+theorem integrable_pdf_smul_iff [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X ℙ μ] {f : E → F}
+    (hf : AEStronglyMeasurable f μ) :
+    Integrable (fun x => (pdf X ℙ μ x).toReal • f x) μ ↔ Integrable (fun x => f (X x)) ℙ := by
   -- porting note: using `erw` because `rw` doesn't recognize `(f <| X ·)` as `f ∘ X`
   -- https://github.com/leanprover-community/mathlib4/issues/5164
-  erw [← integrable_map_measure hf.aestronglyMeasurable (HasPDF.measurable X ℙ μ).aemeasurable,
-    map_eq_withDensity_pdf X ℙ μ, integrable_withDensity_iff (measurable_pdf _ _ _) ae_lt_top]
-#align measure_theory.pdf.integrable_iff_integrable_mul_pdf MeasureTheory.pdf.integrable_iff_integrable_mul_pdf
+  erw [← integrable_map_measure (hf.mono' (HasPDF.absolutelyContinuous X ℙ μ))
+    (HasPDF.measurable X ℙ μ).aemeasurable, map_eq_withDensity_pdf X ℙ μ, pdf_def,
+    integrable_rnDeriv_smul_iff (E := F) (HasPDF.absolutelyContinuous X ℙ μ)]
+  eta_reduce
+  rw [withDensity_rnDeriv_eq _ _ (HasPDF.absolutelyContinuous X ℙ μ)]
 
 /-- **The Law of the Unconscious Statistician**: Given a random variable `X` and a measurable
-function `f`, `f ∘ X` is a random variable with expectation `∫ x, f x * pdf X ∂μ`
+function `f`, `f ∘ X` is a random variable with expectation `∫ x, pdf X x • f x ∂μ`
 where `μ` is a measure on the codomain of `X`. -/
-theorem integral_fun_mul_eq_integral [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X ℙ μ] {f : E → ℝ}
-    (hf : Measurable f) : ∫ x, f x * (pdf X ℙ μ x).toReal ∂μ = ∫ x, f (X x) ∂ℙ := by
-  by_cases hpdf : Integrable (fun x => f x * (pdf X ℙ μ x).toReal) μ
-  · rw [← integral_map (HasPDF.measurable X ℙ μ).aemeasurable hf.aestronglyMeasurable,
-      map_eq_withDensity_pdf X ℙ μ, integral_eq_lintegral_pos_part_sub_lintegral_neg_part hpdf,
-      integral_eq_lintegral_pos_part_sub_lintegral_neg_part,
-      lintegral_withDensity_eq_lintegral_mul _ (measurable_pdf X ℙ μ) hf.neg.ennreal_ofReal,
-      lintegral_withDensity_eq_lintegral_mul _ (measurable_pdf X ℙ μ) hf.ennreal_ofReal]
-    · congr 2
-      · have : ∀ x, ENNReal.ofReal (f x * (pdf X ℙ μ x).toReal) =
-            ENNReal.ofReal (pdf X ℙ μ x).toReal * ENNReal.ofReal (f x) := fun x ↦ by
-          rw [mul_comm, ENNReal.ofReal_mul ENNReal.toReal_nonneg]
-        simp_rw [this]
-        exact lintegral_congr_ae (Filter.EventuallyEq.mul ofReal_toReal_ae_eq (ae_eq_refl _))
-      · have :
-          ∀ x,
-            ENNReal.ofReal (-(f x * (pdf X ℙ μ x).toReal)) =
-              ENNReal.ofReal (pdf X ℙ μ x).toReal * ENNReal.ofReal (-f x) := by
-          intro x
-          rw [neg_mul_eq_neg_mul, mul_comm, ENNReal.ofReal_mul ENNReal.toReal_nonneg]
-        simp_rw [this]
-        exact lintegral_congr_ae (Filter.EventuallyEq.mul ofReal_toReal_ae_eq (ae_eq_refl _))
-    · refine' ⟨hf.aestronglyMeasurable, _⟩
-      rw [HasFiniteIntegral,
-        lintegral_withDensity_eq_lintegral_mul _ (measurable_pdf _ _ _)
-          hf.nnnorm.coe_nnreal_ennreal]
-      have : (fun x => (pdf X ℙ μ * fun x => (‖f x‖₊ : ℝ≥0∞)) x) =ᵐ[μ]
-          fun x => ‖f x * (pdf X ℙ μ x).toReal‖₊ := by
-        simp_rw [← smul_eq_mul, nnnorm_smul, ENNReal.coe_mul]
-        rw [smul_eq_mul, mul_comm]
-        refine' Filter.EventuallyEq.mul (ae_eq_refl _) (ae_eq_trans ofReal_toReal_ae_eq.symm _)
-        simp only [Real.ennnorm_eq_ofReal ENNReal.toReal_nonneg, ae_eq_refl]
-      rw [lintegral_congr_ae this]
-      exact hpdf.2
-  · rw [integral_undef hpdf, integral_undef]
-    rwa [← integrable_iff_integrable_mul_pdf hf] at hpdf
-#align measure_theory.pdf.integral_fun_mul_eq_integral MeasureTheory.pdf.integral_fun_mul_eq_integral
+theorem integral_pdf_smul [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X ℙ μ] {f : E → F}
+    (hf : AEStronglyMeasurable f μ) : ∫ x, (pdf X ℙ μ x).toReal • f x ∂μ = ∫ x, f (X x) ∂ℙ := by
+  rw [← integral_map (HasPDF.measurable X ℙ μ).aemeasurable
+    (hf.mono' (HasPDF.absolutelyContinuous X ℙ μ)), map_eq_withDensity_pdf X ℙ μ,
+    pdf_def, integral_rnDeriv_smul (HasPDF.absolutelyContinuous X ℙ μ),
+    withDensity_rnDeriv_eq _ _ (HasPDF.absolutelyContinuous X ℙ μ)]
 
-theorem map_absolutelyContinuous {X : Ω → E} [HasPDF X ℙ μ] : map X ℙ ≪ μ := by
-  rw [map_eq_withDensity_pdf X ℙ μ]; exact withDensity_absolutelyContinuous _ _
-#align measure_theory.pdf.map_absolutely_continuous MeasureTheory.pdf.map_absolutelyContinuous
-
-/-- A random variable that `HasPDF` is quasi-measure preserving. -/
-theorem to_quasiMeasurePreserving {X : Ω → E} [HasPDF X ℙ μ] : QuasiMeasurePreserving X ℙ μ :=
-  { measurable := HasPDF.measurable X ℙ μ
-    absolutelyContinuous := map_absolutelyContinuous }
-#align measure_theory.pdf.to_quasi_measure_preserving MeasureTheory.pdf.to_quasiMeasurePreserving
-
-theorem haveLebesgueDecomposition_of_hasPDF {X : Ω → E} [hX' : HasPDF X ℙ μ] :
-    (map X ℙ).HaveLebesgueDecomposition μ :=
-  ⟨⟨⟨0, pdf X ℙ μ⟩, by
-      simp only [zero_add, measurable_pdf X ℙ μ, true_and_iff, MutuallySingular.zero_left,
-        map_eq_withDensity_pdf X ℙ μ]⟩⟩
-#align measure_theory.pdf.have_lebesgue_decomposition_of_has_pdf MeasureTheory.pdf.haveLebesgueDecomposition_of_hasPDF
-
-theorem hasPDF_iff {X : Ω → E} :
-    HasPDF X ℙ μ ↔ Measurable X ∧ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ :=
-  ⟨@HasPDF.pdf' _ _ _ _ _ _ _, HasPDF.mk⟩
-#align measure_theory.pdf.has_pdf_iff MeasureTheory.pdf.hasPDF_iff
-
-theorem hasPDF_iff_of_measurable {X : Ω → E} (hX : Measurable X) :
-    HasPDF X ℙ μ ↔ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ := by
-  rw [hasPDF_iff]
-  simp only [hX, true_and]
-#align measure_theory.pdf.has_pdf_iff_of_measurable MeasureTheory.pdf.hasPDF_iff_of_measurable
+end IntegralPDFMul
 
 section
 
@@ -296,7 +275,9 @@ theorem _root_.Real.hasPDF_iff : HasPDF X ℙ ↔ Measurable X ∧ map X ℙ ≪
 /-- If `X` is a real-valued random variable that has pdf `f`, then the expectation of `X` equals
 `∫ x, x * f x ∂λ` where `λ` is the Lebesgue measure. -/
 theorem integral_mul_eq_integral [HasPDF X ℙ] : ∫ x, x * (pdf X ℙ volume x).toReal = ∫ x, X x ∂ℙ :=
-  integral_fun_mul_eq_integral measurable_id
+  calc
+    _ = ∫ x, (pdf X ℙ volume x).toReal * x := by congr with x; exact mul_comm _ _
+    _ = _ := integral_pdf_smul measurable_id.aestronglyMeasurable
 #align measure_theory.pdf.integral_mul_eq_integral MeasureTheory.pdf.integral_mul_eq_integral
 
 theorem hasFiniteIntegral_mul {f : ℝ → ℝ} {g : ℝ → ℝ≥0∞} (hg : pdf X ℙ =ᵐ[volume] g)
@@ -442,7 +423,7 @@ theorem indepFun_iff_pdf_prod_eq_pdf_mul_pdf
       lintegral_prod_mul (measurable_pdf X ℙ μ).aemeasurable (measurable_pdf Y ℙ ν).aemeasurable,
       map_eq_set_lintegral_pdf X ℙ μ hs, map_eq_set_lintegral_pdf Y ℙ ν ht]
   rw [indepFun_iff_map_prod_eq_prod_map_map (HasPDF.measurable X ℙ μ) (HasPDF.measurable Y ℙ ν),
-    ← unique, h₀]
+    ← eq_of_map_eq_withDensity, h₀]
   exact (((measurable_pdf X ℙ μ).comp measurable_fst).mul
     ((measurable_pdf Y ℙ ν).comp measurable_snd)).aemeasurable
 

--- a/Mathlib/Probability/Density.lean
+++ b/Mathlib/Probability/Density.lean
@@ -77,31 +77,36 @@ variable {_ : MeasurableSpace Ω}
 theorem hasPDF_iff {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E} :
     HasPDF X ℙ μ ↔ AEMeasurable X ℙ ∧ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ :=
   ⟨@HasPDF.pdf' _ _ _ _ _ _ _, HasPDF.mk⟩
-#align measure_theory.has_pdf_iff MeasureTheory.hasPDF_iff
+#align measure_theory.pdf.has_pdf_iff MeasureTheory.hasPDF_iff
 
 theorem hasPDF_iff_of_aemeasurable {X : Ω → E} {ℙ : Measure Ω}
     {μ : Measure E} (hX : AEMeasurable X ℙ) :
     HasPDF X ℙ μ ↔ (map X ℙ).HaveLebesgueDecomposition μ ∧ map X ℙ ≪ μ := by
   rw [hasPDF_iff]
   simp only [hX, true_and]
+#align measure_theory.pdf.has_pdf_iff_of_measurable MeasureTheory.hasPDF_iff_of_aemeasurable
 
 @[measurability]
 theorem HasPDF.aemeasurable (X : Ω → E) (ℙ : Measure Ω)
     (μ : Measure E) [hX : HasPDF X ℙ μ] : AEMeasurable X ℙ :=
   hX.pdf'.1
+#align measure_theory.has_pdf.measurable MeasureTheory.HasPDF.aemeasurable
 
 instance HasPDF.haveLebesgueDecomposition {X : Ω → E} {ℙ : Measure Ω}
     {μ : Measure E} [hX : HasPDF X ℙ μ] : (map X ℙ).HaveLebesgueDecomposition μ :=
   hX.pdf'.2.1
+#align measure_theory.pdf.have_lebesgue_decomposition_of_has_pdf MeasureTheory.HasPDF.haveLebesgueDecomposition
 
 theorem HasPDF.absolutelyContinuous {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E}
     [hX : HasPDF X ℙ μ] : map X ℙ ≪ μ := hX.pdf'.2.2
+#align measure_theory.pdf.map_absolutely_continuous MeasureTheory.HasPDF.absolutelyContinuous
 
 /-- A random variable that `HasPDF` is quasi-measure preserving. -/
 theorem HasPDF.quasiMeasurePreserving_of_measurable (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E)
     [HasPDF X ℙ μ] (h : Measurable X) : QuasiMeasurePreserving X ℙ μ :=
   { measurable := h
     absolutelyContinuous := HasPDF.absolutelyContinuous }
+#align measure_theory.pdf.to_quasi_measure_preserving MeasureTheory.HasPDF.quasiMeasurePreserving_of_measurable
 
 theorem HasPDF.congr {X Y : Ω → E} {ℙ : Measure Ω} {μ : Measure E} (hXY : X =ᵐ[ℙ] Y)
     [hX : HasPDF X ℙ μ] : HasPDF Y ℙ μ :=
@@ -138,6 +143,7 @@ theorem pdf_of_not_aemeasurable {_ : MeasurableSpace Ω} {ℙ : Measure Ω} {μ 
   unfold pdf
   rw [map_of_not_aemeasurable hX]
   exact rnDeriv_zero μ
+#align measure_theory.pdf_eq_zero_of_not_measurable MeasureTheory.pdf_of_not_aemeasurable
 
 theorem pdf_of_not_haveLebesgueDecomposition {_ : MeasurableSpace Ω} {ℙ : Measure Ω}
     {μ : Measure E} {X : Ω → E} (h : ¬(map X ℙ).HaveLebesgueDecomposition μ) : pdf X ℙ μ = 0 := by
@@ -148,6 +154,7 @@ theorem aemeasurable_of_pdf_ne_zero {m : MeasurableSpace Ω} {ℙ : Measure Ω} 
     (X : Ω → E) (h : ¬pdf X ℙ μ =ᵐ[μ] 0) : AEMeasurable X ℙ := by
   contrapose! h
   exact pdf_of_not_aemeasurable h
+#align measure_theory.measurable_of_pdf_ne_zero MeasureTheory.aemeasurable_of_pdf_ne_zero
 
 theorem hasPDF_of_pdf_ne_zero {m : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E} {X : Ω → E}
     (hac : map X ℙ ≪ μ) (hpdf : ¬pdf X ℙ μ =ᵐ[μ] 0) : HasPDF X ℙ μ := by
@@ -243,6 +250,7 @@ theorem integrable_pdf_smul_iff [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X �
     map_eq_withDensity_pdf X ℙ μ, pdf_def, integrable_rnDeriv_smul_iff HasPDF.absolutelyContinuous]
   eta_reduce
   rw [withDensity_rnDeriv_eq _ _ HasPDF.absolutelyContinuous]
+#align measure_theory.pdf.integrable_iff_integrable_mul_pdf MeasureTheory.pdf.integrable_pdf_smul_iff
 
 /-- **The Law of the Unconscious Statistician**: Given a random variable `X` and a measurable
 function `f`, `f ∘ X` is a random variable with expectation `∫ x, pdf X x • f x ∂μ`
@@ -252,6 +260,7 @@ theorem integral_pdf_smul [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X ℙ μ]
   rw [← integral_map (HasPDF.aemeasurable X ℙ μ) (hf.mono' HasPDF.absolutelyContinuous),
     map_eq_withDensity_pdf X ℙ μ, pdf_def, integral_rnDeriv_smul HasPDF.absolutelyContinuous,
     withDensity_rnDeriv_eq _ _ HasPDF.absolutelyContinuous]
+#align measure_theory.pdf.integral_fun_mul_eq_integral MeasureTheory.pdf.integral_pdf_smul
 
 end IntegralPDFMul
 
@@ -300,6 +309,7 @@ nonrec theorem _root_.Real.hasPDF_iff_of_aemeasurable (hX : AEMeasurable X ℙ) 
     HasPDF X ℙ ↔ map X ℙ ≪ volume := by
   rw [hasPDF_iff_of_aemeasurable hX]
   exact and_iff_right inferInstance
+#align measure_theory.pdf.real.has_pdf_iff_of_measurable Real.hasPDF_iff_of_aemeasurable
 
 theorem _root_.Real.hasPDF_iff : HasPDF X ℙ ↔ AEMeasurable X ℙ ∧ map X ℙ ≪ volume := by
   by_cases hX : AEMeasurable X ℙ

--- a/Mathlib/Probability/Density.lean
+++ b/Mathlib/Probability/Density.lean
@@ -126,8 +126,8 @@ theorem hasPDF_of_map_eq_withDensity {X : Ω → E} {ℙ : Measure Ω} {μ : Mea
 
 end HasPDF
 
-/-- If `X` is a random variable that `HasPDF X ℙ μ`, then `pdf X` is the Radon–Nikodym
-derivative of the push-forward measure of `ℙ` along `X` with respect to `μ`. -/
+/-- If `X` is a random variable, then `pdf X` is the Radon–Nikodym derivative of the push-forward
+measure of `ℙ` along `X` with respect to `μ`. -/
 def pdf {_ : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E := by volume_tac) :
     E → ℝ≥0∞ :=
   (map X ℙ).rnDeriv μ

--- a/Mathlib/Probability/Density.lean
+++ b/Mathlib/Probability/Density.lean
@@ -173,8 +173,8 @@ theorem eq_of_map_eq_withDensity [IsFiniteMeasure ℙ] {X : Ω → E} [HasPDF X 
   rw [lintegral_eq_measure_univ]
   exact measure_ne_top _ _
 
-theorem eq_of_map_eq_withDensity' [SigmaFinite μ] {X : Ω → E} [HasPDF X ℙ μ] (f : E → ℝ≥0∞) (hmf : AEMeasurable f μ) :
-    ℙ.map X = μ.withDensity f ↔ pdf X ℙ μ =ᵐ[μ] f :=
+theorem eq_of_map_eq_withDensity' [SigmaFinite μ] {X : Ω → E} [HasPDF X ℙ μ] (f : E → ℝ≥0∞)
+    (hmf : AEMeasurable f μ) : ℙ.map X = μ.withDensity f ↔ pdf X ℙ μ =ᵐ[μ] f :=
   map_eq_withDensity_pdf X ℙ μ ▸
     withDensity_eq_iff_of_sigmaFinite (measurable_pdf X ℙ μ).aemeasurable hmf
 

--- a/Mathlib/Probability/Density.lean
+++ b/Mathlib/Probability/Density.lean
@@ -13,7 +13,8 @@ import Mathlib.Probability.Independence.Basic
 # Probability density function
 
 This file defines the probability density function of random variables, by which we mean
-measurable functions taking values in a Borel space. In particular, a measurable function `f`
+measurable functions taking values in a Borel space. The probability density function is defined
+as the Radon–Nikodym derivative of the law of `X`. In particular, a measurable function `f`
 is said to the probability density function of a random variable `X` if for all measurable
 sets `S`, `ℙ(X ∈ S) = ∫ x in S, f x dx`. Probability density functions are one way of describing
 the distribution of a random variable, and are useful for calculating probabilities and
@@ -25,11 +26,10 @@ random variables with this distribution.
 ## Main definitions
 
 * `MeasureTheory.HasPDF` : A random variable `X : Ω → E` is said to `HasPDF` with
-  respect to the measure `ℙ` on `Ω` and `μ` on `E` if there exists a measurable function `f`
-  such that the push-forward measure of `ℙ` along `X` equals `μ.withDensity f`.
+  respect to the measure `ℙ` on `Ω` and `μ` on `E` if the push-forward measure of `ℙ` along `X`
+  is absolutely continuous with respect to `μ` and they `HaveLebesgueDecomposition`.
 * `MeasureTheory.pdf` : If `X` is a random variable that `HasPDF X ℙ μ`, then `pdf X`
-  is the measurable function `f` such that the push-forward measure of `ℙ` along `X` equals
-  `μ.withDensity f`.
+  is the Radon–Nikodym derivative of the push-forward measure of `ℙ` along `X` with respect to `μ`.
 * `MeasureTheory.pdf.IsUniform` : A random variable `X` is said to follow the uniform
   distribution if it has a constant probability density function with a compact, non-null support.
 

--- a/Mathlib/Probability/Density.lean
+++ b/Mathlib/Probability/Density.lean
@@ -98,7 +98,8 @@ instance HasPDF.haveLebesgueDecomposition {X : Ω → E} {ℙ : Measure Ω}
 #align measure_theory.pdf.have_lebesgue_decomposition_of_has_pdf MeasureTheory.HasPDF.haveLebesgueDecomposition
 
 theorem HasPDF.absolutelyContinuous {X : Ω → E} {ℙ : Measure Ω} {μ : Measure E}
-    [hX : HasPDF X ℙ μ] : map X ℙ ≪ μ := hX.pdf'.2.2
+    [hX : HasPDF X ℙ μ] : map X ℙ ≪ μ :=
+  hX.pdf'.2.2
 #align measure_theory.pdf.map_absolutely_continuous MeasureTheory.HasPDF.absolutelyContinuous
 
 /-- A random variable that `HasPDF` is quasi-measure preserving. -/
@@ -140,15 +141,13 @@ theorem pdf_def {_ : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E} {X 
 
 theorem pdf_of_not_aemeasurable {_ : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E}
     {X : Ω → E} (hX : ¬AEMeasurable X ℙ) : pdf X ℙ μ =ᵐ[μ] 0 := by
-  unfold pdf
-  rw [map_of_not_aemeasurable hX]
+  rw [pdf_def, map_of_not_aemeasurable hX]
   exact rnDeriv_zero μ
 #align measure_theory.pdf_eq_zero_of_not_measurable MeasureTheory.pdf_of_not_aemeasurable
 
 theorem pdf_of_not_haveLebesgueDecomposition {_ : MeasurableSpace Ω} {ℙ : Measure Ω}
-    {μ : Measure E} {X : Ω → E} (h : ¬(map X ℙ).HaveLebesgueDecomposition μ) : pdf X ℙ μ = 0 := by
-  unfold pdf
-  exact rnDeriv_of_not_haveLebesgueDecomposition h
+    {μ : Measure E} {X : Ω → E} (h : ¬(map X ℙ).HaveLebesgueDecomposition μ) : pdf X ℙ μ = 0 :=
+  rnDeriv_of_not_haveLebesgueDecomposition h
 
 theorem aemeasurable_of_pdf_ne_zero {m : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : Measure E}
     (X : Ω → E) (h : ¬pdf X ℙ μ =ᵐ[μ] 0) : AEMeasurable X ℙ := by
@@ -171,10 +170,9 @@ theorem measurable_pdf {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω
   exact measurable_rnDeriv _ _
 #align measure_theory.measurable_pdf MeasureTheory.measurable_pdf
 
-theorem withDensity_pdf_le_map {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
-    (μ : Measure E := by volume_tac) : μ.withDensity (pdf X ℙ μ) ≤ map X ℙ := by
-  rw [pdf_def]
-  exact withDensity_rnDeriv_le _ _
+theorem withDensity_pdf_le_map {_ : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
+    (μ : Measure E := by volume_tac) : μ.withDensity (pdf X ℙ μ) ≤ map X ℙ :=
+  withDensity_rnDeriv_le _ _
 
 theorem set_lintegral_pdf_le_map {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
     (μ : Measure E := by volume_tac) {s : Set E} (hs : MeasurableSet s) :
@@ -220,9 +218,8 @@ theorem eq_of_map_eq_withDensity' [SigmaFinite μ] {X : Ω → E} [HasPDF X ℙ 
     withDensity_eq_iff_of_sigmaFinite (measurable_pdf X ℙ μ).aemeasurable hmf
 
 nonrec theorem ae_lt_top [IsFiniteMeasure ℙ] {μ : Measure E} {X : Ω → E} :
-    ∀ᵐ x ∂μ, pdf X ℙ μ x < ∞ := by
-  rw [pdf_def]
-  exact rnDeriv_lt_top (map X ℙ) μ
+    ∀ᵐ x ∂μ, pdf X ℙ μ x < ∞ :=
+  rnDeriv_lt_top (map X ℙ) μ
 #align measure_theory.pdf.ae_lt_top MeasureTheory.pdf.ae_lt_top
 
 nonrec theorem ofReal_toReal_ae_eq [IsFiniteMeasure ℙ] {X : Ω → E} :
@@ -237,7 +234,7 @@ theorem lintegral_pdf_mul {X : Ω → E} [HasPDF X ℙ μ] {f : E → ℝ≥0∞
     (hf : AEMeasurable f μ) : ∫⁻ x, pdf X ℙ μ x * f x ∂μ = ∫⁻ x, f (X x) ∂ℙ := by
   rw [pdf_def,
     ← lintegral_map' (hf.mono_ac HasPDF.absolutelyContinuous) (HasPDF.aemeasurable X ℙ μ),
-  lintegral_rnDeriv_mul HasPDF.absolutelyContinuous hf]
+    lintegral_rnDeriv_mul HasPDF.absolutelyContinuous hf]
 
 variable {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
 

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -635,14 +635,14 @@ theorem indepFun_iff_indepSet_preimage {mβ : MeasurableSpace β} {mβ' : Measur
 #align probability_theory.indep_fun_iff_indep_set_preimage ProbabilityTheory.indepFun_iff_indepSet_preimage
 
 theorem indepFun_iff_map_prod_eq_prod_map_map {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
-    [IsFiniteMeasure μ] (hf : Measurable f) (hg : Measurable g) :
+    [IsFiniteMeasure μ] (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     IndepFun f g μ ↔ μ.map (fun ω ↦ (f ω, g ω)) = (μ.map f).prod (μ.map g) := by
   rw [indepFun_iff_measure_inter_preimage_eq_mul]
   have h₀ {s : Set β} {t : Set β'} (hs : MeasurableSet s) (ht : MeasurableSet t) :
       μ (f ⁻¹' s) * μ (g ⁻¹' t) = μ.map f s * μ.map g t ∧
       μ (f ⁻¹' s ∩ g ⁻¹' t) = μ.map (fun ω ↦ (f ω, g ω)) (s ×ˢ t) :=
-    ⟨by rw [Measure.map_apply hf hs, Measure.map_apply hg ht],
-      (Measure.map_apply (hf.prod_mk hg) (hs.prod ht)).symm⟩
+    ⟨by rw [Measure.map_apply_of_aemeasurable hf hs, Measure.map_apply_of_aemeasurable hg ht],
+      (Measure.map_apply_of_aemeasurable (hf.prod_mk hg) (hs.prod ht)).symm⟩
   constructor
   · refine fun h ↦ (Measure.prod_eq fun s t hs ht ↦ ?_).symm
     rw [← (h₀ hs ht).1, ← (h₀ hs ht).2, h s t hs ht]


### PR DESCRIPTION
Defines `pdf` in terms of `rnDeriv`.

Main definition change:
```lean
/-- A random variable `X : Ω → E` is said to `HasPDF` with respect to the measure `ℙ` on `Ω` and
`μ` on `E` if the push-forward measure of `ℙ` along `X` is absolutely continuous with respect to
`μ` and they `HaveLebesgueDecomposition`. -/
class HasPDF {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
    (μ : Measure E := by volume_tac) : Prop where
  pdf' : Measurable X ∧ HaveLebesgueDecomposition (map X ℙ) μ ∧ map X ℙ ≪ μ

/-- If `X` is a random variable that `HasPDF X ℙ μ`, then `pdf X` is the Radon–Nikodym
derivative of the push-forward measure of `ℙ` along `X` with respect to `μ`. -/
def pdf {_ : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω) (μ : Measure E := by volume_tac) :
    E → ℝ≥0∞ :=
  if HasPDF X ℙ μ then (map X ℙ).rnDeriv μ else 0
```

The law of the unconscious statistician is first generalized to `rnDeriv` on a general Banach space (`∫ x, (μ.rnDeriv ν x).toReal • f x ∂ν = ∫ x, f x ∂μ`), and then proven for PDFs.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Definition.20of.20pdf.20as.20rnDeriv)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
