### PR TITLE
[Merged by Bors] - feat: term elaborator for associativity equivalences between iterated products.

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3269,6 +3269,7 @@ import Mathlib.Tactic.Polyrith
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Positivity.Basic
 import Mathlib.Tactic.Positivity.Core
+import Mathlib.Tactic.ProdAssoc
 import Mathlib.Tactic.ProjectionNotation
 import Mathlib.Tactic.Propose
 import Mathlib.Tactic.ProxyType

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -284,6 +284,11 @@ def fvarId? : Expr → Option FVarId
   | .fvar n => n
   | _ => none
 
+/-- If an `Expr` has the form `Type u`, then return `some u`, otherwise `none`. -/
+def type? : Expr → Option Level
+  | .sort u => u.dec
+  | _ => none
+
 /-- `isConstantApplication e` checks whether `e` is syntactically an application of the form
   `(fun x₁ ⋯ xₙ => H) y₁ ⋯ yₙ` where `H` does not contain the variable `xₙ`. In other words,
   it does a syntactic check that the expression does not depend on `yₙ`. -/

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -119,6 +119,7 @@ import Mathlib.Tactic.Polyrith
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Positivity.Basic
 import Mathlib.Tactic.Positivity.Core
+import Mathlib.Tactic.ProdAssoc
 import Mathlib.Tactic.ProjectionNotation
 import Mathlib.Tactic.Propose
 import Mathlib.Tactic.ProxyType

--- a/Mathlib/Tactic/ProdAssoc.lean
+++ b/Mathlib/Tactic/ProdAssoc.lean
@@ -12,7 +12,7 @@ import Mathlib.Logic.Equiv.Basic
 This file constructs a term elaborator for "obvious" equivalences between iterated products.
 For example,
 ```lean
-prod_assoc((α × β) × (γ × δ), α × (β × γ) × δ)
+(prod_assoc% : (α × β) × (γ × δ) ≃ α × (β × γ) × δ)
 ```
 gives the "obvious" equivalence between `(α × β) × (γ × δ)` and `α × (β × γ) × δ`.
 -/

--- a/Mathlib/Tactic/ProdAssoc.lean
+++ b/Mathlib/Tactic/ProdAssoc.lean
@@ -136,6 +136,10 @@ For example, `(prod_assoc% : (α × β) × (γ × δ) ≃ α × (β × γ) × δ
 
 The elaborator can handle holes in the expected type,
 so long as they eventually get filled by unification.
+```lean
+example : (α × β) × (γ × δ) ≃ α × (β × γ) × δ :=
+  (prod_assoc% : _ ≃ α × β × γ × δ).trans prod_assoc%
+```
 -/
 macro "prod_assoc%" : term => `((prod_assoc_internal% : _ ≃ _))
 

--- a/Mathlib/Tactic/ProdAssoc.lean
+++ b/Mathlib/Tactic/ProdAssoc.lean
@@ -112,8 +112,6 @@ def mkProdEquiv (a b : Expr) : MetaM Expr := do
       .app (.const ``rfl [.succ u]) a,
       .app (.const ``rfl [.succ v]) b]
 
---syntax (name := prodAssocStx) "prod_assoc(" term "," term ")" : term
-
 /-- IMPLEMENTATION: Syntax used in the implementation of `prod_assoc%`. -/
 syntax (name := prodAssocStx) "prod_assoc_internal%" : term
 

--- a/Mathlib/Tactic/ProdAssoc.lean
+++ b/Mathlib/Tactic/ProdAssoc.lean
@@ -100,7 +100,8 @@ def mkProdFun (a b : Expr) : MetaM Expr := do
   for (x,y) in pa.components.zip pb.components do
     unless ← isDefEq x y do
       throwError "Component{indentD x}\nis not definitionally equal to component{indentD y}."
-  return .lam `t a (← pa.convertTo pb <| .bvar 0) .default
+  withLocalDeclD `t a fun fvar => do
+    mkLambdaFVars #[fvar] (← pa.convertTo pb fvar)
 
 /-- Construct the equivalence between iterated products of the same type, associated
 in possibly different ways. -/

--- a/Mathlib/Tactic/ProdAssoc.lean
+++ b/Mathlib/Tactic/ProdAssoc.lean
@@ -139,17 +139,4 @@ so long as they eventually get filled by unification.
 -/
 macro "prod_assoc%" : term => `((prod_assoc_internal% : _ ≃ _))
 
-variable {α β γ δ : Type*}
-
-example : (α × β) × (γ × δ) ≃ α × (β × γ) × δ := by
-  have := (prod_assoc% : (α × β) × (γ × δ) ≃ α × (β × γ) × δ)
-  exact this
-
-example : (α × β) × (γ × δ) ≃ α × (β × γ) × δ := prod_assoc%
-
-example : (α × β) × (γ × δ) ≃ α × (β × γ) × δ :=
-  (prod_assoc% : _ ≃ α × β × γ × δ).trans prod_assoc%
-
-example {α β γ δ : Type*} (x : (α × β) × (γ × δ)) : α × (β × γ) × δ := prod_assoc% x
-
 end Lean.Expr

--- a/Mathlib/Tactic/ProdAssoc.lean
+++ b/Mathlib/Tactic/ProdAssoc.lean
@@ -113,7 +113,11 @@ def mkProdEquiv (a b : Expr) : MetaM Expr := do
       .app (.const ``rfl [.succ u]) a,
       .app (.const ``rfl [.succ v]) b]
 
-/-- IMPLEMENTATION: Syntax used in the implementation of `prod_assoc%`. -/
+/-- IMPLEMENTATION: Syntax used in the implementation of `prod_assoc%`.
+This elaborator postpones if there are metavariables in the expected type,
+and to propagate the fact that this elaborator produces an `Equiv`,
+the `prod_assoc%` macro sets things up with a type ascription.
+This enables using `prod_assoc%` with, for example `Equiv.trans` dot notation. -/
 syntax (name := prodAssocStx) "prod_assoc_internal%" : term
 
 open Elab Term in

--- a/Mathlib/Tactic/ProdEquiv.lean
+++ b/Mathlib/Tactic/ProdEquiv.lean
@@ -111,21 +111,12 @@ def mkProdEquiv (a b : Expr) : MetaM Expr := do
 
 --syntax (name := prodAssocStx) "prod_assoc(" term "," term ")" : term
 
-/-- An elaborator version of `Lean.Expr.mkEquiv`. -/
-elab "prod_assoc(" a:term "," b:term ")" : term => do
-  let a ← Elab.Term.elabTerm a none
-  let b ← Elab.Term.elabTerm b none
-  mkProdEquiv a b
-
-elab "prod_assoc%" : term <= expectedType => do
+elab "associate%" : term <= expectedType => do
   match expectedType with
     | .app (.app (.const ``Equiv _) a) b => do
       mkProdEquiv a b
     | _ => throwError "Expected type {expectedType} is not of the form `α ≃ β`."
 
-variable {α β γ δ : Type*}
-
-example : (α × β) × (γ × δ) ≃ α × (β × γ) × δ := prod_assoc((α × β) × (γ × δ), α × (β × γ) × δ)
-example : (α × β) × (γ × δ) ≃ α × (β × γ) × δ := prod_assoc%
+--example {α β γ δ : Type*} (x : (α × β) × (γ × δ)) : α × (β × γ) × δ := associate% x
 
 end Lean.Expr

--- a/Mathlib/Tactic/ProdEquiv.lean
+++ b/Mathlib/Tactic/ProdEquiv.lean
@@ -1,0 +1,73 @@
+import Mathlib.Lean.Expr.Basic
+import Mathlib.Logic.Equiv.Basic
+import Qq
+
+namespace Lean.Expr
+
+open Lean Meta
+
+inductive ProdTree where
+  | type (tp : Expr) (l : Level)
+  | prod (fst snd : ProdTree) (lfst lsnd : Level)
+
+def ProdTree.getType : ProdTree → Expr
+  | type tp _ => tp
+  | prod fst snd u v => mkAppN (.const ``Prod [u,v]) #[fst.getType, snd.getType]
+
+
+def ProdTree.size : ProdTree → Nat
+  | type _ _ => 1
+  | prod fst snd _ _ => fst.size + snd.size
+
+def mkProdTree (e : Expr) : MetaM ProdTree :=
+  match e with
+    | .app (.app (.const ``Prod [u,v]) X) Y => do
+        return .prod (← X.mkProdTree) (← Y.mkProdTree) u v
+    | X => do
+      let .sort (.succ u) ← inferType X | throwError "Type expected."
+      return .type X u
+
+def ProdTree.unpack (t : Expr) : ProdTree → MetaM (List Expr)
+  | type _ _ => return [t]
+  | prod fst snd u v => do
+      let fst' ← fst.unpack <| mkAppN (.const ``Prod.fst [u,v]) #[fst.getType, snd.getType, t]
+      let snd' ← snd.unpack <| mkAppN (.const ``Prod.snd [u,v]) #[fst.getType, snd.getType, t]
+      return fst' ++ snd'
+
+def ProdTree.pack (ts : List Expr) : ProdTree → MetaM Expr
+  | type tp _ => do
+    match ts with
+      | [] => throwError "empty list"
+      | [a] =>
+        if ← isDefEq tp (← inferType a) then return a
+        else throwError "Types are different"
+      | _ => throwError "Wrong size"
+  | prod fst snd u v => do
+    let fstSize := fst.size
+    let sndSize := snd.size
+    unless ts.length == fstSize + sndSize do throwError "Wrong size"
+    let tsfst := ts.toArray[:fstSize] |>.toArray.toList
+    let tssnd := ts.toArray[fstSize:] |>.toArray.toList
+    let mk : Expr := mkAppN (.const ``Prod.mk [u,v]) #[fst.getType, snd.getType]
+    return .app (.app mk (← fst.pack tsfst)) (← snd.pack tssnd)
+
+def mkFun (a b : Expr) : MetaM Expr := do
+  let pa ← a.mkProdTree
+  let pb ← b.mkProdTree
+  return .lam `t a (← pb.pack <| (← pa.unpack <| .bvar 0)) .default
+
+def mkEquiv (a b : Expr) : MetaM Expr := do
+  let .sort (u) ← inferType a | throwError "Type expected."
+  let .sort (v) ← inferType b | throwError "Type expected."
+  return mkAppN (.const ``Equiv.mk [u,v])
+    #[a, b, ← mkFun a b, ← mkFun b a, .app (.const ``rfl [u]) a, .app (.const ``rfl [v]) b]
+
+elab "associate(" a:term "," b:term ")" : term => do
+  let a ← Elab.Term.elabTerm a none
+  let b ← Elab.Term.elabTerm b none
+  mkEquiv a b
+
+example {α β γ δ : Type*} (a : α) (b : β) (g : γ) (d : δ) :
+  associate((α × β) × (γ × δ), α × (β × γ) × δ) ((a,b),(g,d)) = (a,(b,g),d) := rfl
+
+end Lean.Expr

--- a/Mathlib/Tactic/ProdEquiv.lean
+++ b/Mathlib/Tactic/ProdEquiv.lean
@@ -1,32 +1,60 @@
+/-
+Copyright (c) 2023 Adam Topaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Topaz
+-/
 import Mathlib.Lean.Expr.Basic
 import Mathlib.Logic.Equiv.Basic
-import Qq
+
+/-!
+# Associativity of products
+
+This file constructs a term elaborator for "obvious" equivalences between iterated products.
+For example,
+```lean
+prod_assoc((α × β) × (γ × δ), α × (β × γ) × δ)
+```
+gives the "obvious" equivalence between `(α × β) × (γ × δ)` and `α × (β × γ) × δ`.
+-/
 
 namespace Lean.Expr
 
 open Lean Meta
 
+/-- A helper type to keep track of universe levels and types in iterated produts. -/
 inductive ProdTree where
   | type (tp : Expr) (l : Level)
   | prod (fst snd : ProdTree) (lfst lsnd : Level)
 deriving Repr
 
+/-- The iterated product corresponding to a `ProdTree`. -/
 def ProdTree.getType : ProdTree → Expr
   | type tp _ => tp
   | prod fst snd u v => mkAppN (.const ``Prod [u,v]) #[fst.getType, snd.getType]
 
+/-- The number of types appearing in an iterated product encoded as a `ProdTree`. -/
 def ProdTree.size : ProdTree → Nat
   | type _ _ => 1
   | prod fst snd _ _ => fst.size + snd.size
 
+/-- Make a `ProdTree` out of an `Expr`. -/
 def mkProdTree (e : Expr) : MetaM ProdTree :=
   match e with
     | .app (.app (.const ``Prod [u,v]) X) Y => do
         return .prod (← X.mkProdTree) (← Y.mkProdTree) u v
     | X => do
-      let some u := (← inferType X).type? | throwError "Type expected."
+      let some u := (← inferType X).type? | throwError "Not a type{indentExpr X}"
       return .type X u
 
+/-- Given `P : ProdTree` representing an iterated product and `e : Expr` which
+should correspond to a term of the iterated product, this will return
+a list, whose items correspond to the leaves of `P` (i.e. the types appearing in the product),
+where each item is the appropriate composition of `Prod.fst` and `Prod.snd` applied to `e`
+resulting in an element of the type corresponding to the leaf.
+
+For example, if `P` corresponds to `(X × Y) × Z` and `t : (X × Y) × Z`, then this
+should return `[t.fst.fst, t.fst.snd, t.snd]`.
+-/
 def ProdTree.unpack (t : Expr) : ProdTree → MetaM (List Expr)
   | type _ _ => return [t]
   | prod fst snd u v => do
@@ -34,6 +62,8 @@ def ProdTree.unpack (t : Expr) : ProdTree → MetaM (List Expr)
       let snd' ← snd.unpack <| mkAppN (.const ``Prod.snd [u,v]) #[fst.getType, snd.getType, t]
       return fst' ++ snd'
 
+/-- This function should act as the "reverse" of `ProdTree.unpack`, constructing
+a term of the iterated product out of a list of terms of the types appearing in the product. -/
 def ProdTree.pack (ts : List Expr) : ProdTree → MetaM Expr
   | type tp _ => do
     match ts with
@@ -51,25 +81,31 @@ def ProdTree.pack (ts : List Expr) : ProdTree → MetaM Expr
     let mk : Expr := mkAppN (.const ``Prod.mk [u,v]) #[fst.getType, snd.getType]
     return .app (.app mk (← fst.pack tsfst)) (← snd.pack tssnd)
 
-def mkFun (a b : Expr) : MetaM Expr := do
+/-- Given two expressions corresponding to iterated products of the same types, associated in
+possibly different ways, this constructs the "obvious" function from one to the other. -/
+def mkProdFun (a b : Expr) : MetaM Expr := do
   let pa ← a.mkProdTree
   let pb ← b.mkProdTree
   return .lam `t a (← pb.pack <| (← pa.unpack <| .bvar 0)) .default
 
-def mkEquiv (a b : Expr) : MetaM Expr := do
-  let some u := (← inferType a).type? | throwError "Type expected."
-  let some v := (← inferType b).type? | throwError "Type expected."
+/-- Construct the equivalence between iterated products of the same type, associated
+in possibly different ways. -/
+def mkProdEquiv (a b : Expr) : MetaM Expr := do
+  let some u := (← inferType a).type? | throwError "Not a type{indentExpr a}"
+  let some v := (← inferType b).type? | throwError "Not a type{indentExpr b}"
   return mkAppN (.const ``Equiv.mk [.succ u,.succ v])
-    #[a, b, ← mkFun a b, ← mkFun b a,
+    #[a, b, ← mkProdFun a b, ← mkProdFun b a,
       .app (.const ``rfl [.succ u]) a,
       .app (.const ``rfl [.succ v]) b]
 
+
+/-- An elaborator version of `Lean.Expr.mkEquiv`. -/
 elab "prod_assoc(" a:term "," b:term ")" : term => do
   let a ← Elab.Term.elabTerm a none
   let b ← Elab.Term.elabTerm b none
-  mkEquiv a b
+  mkProdEquiv a b
 
-example {α β γ δ : Type*} (a : α) (b : β) (g : γ) (d : δ) :
-  prod_assoc((α × β) × (γ × δ), α × (β × γ) × δ) ((a,b),(g,d)) = (a,(b,g),d) := rfl
+#check prod_assoc(Nat,Nat)
 
 end Lean.Expr
+#lint

--- a/test/ProdAssoc.lean
+++ b/test/ProdAssoc.lean
@@ -1,0 +1,14 @@
+import Mathlib.Tactic.ProdAssoc
+
+variable {α β γ δ : Type*}
+
+example : (α × β) × (γ × δ) ≃ α × (β × γ) × δ := by
+  have := (prod_assoc% : (α × β) × (γ × δ) ≃ α × (β × γ) × δ)
+  exact this
+
+example : (α × β) × (γ × δ) ≃ α × (β × γ) × δ := prod_assoc%
+
+example : (α × β) × (γ × δ) ≃ α × (β × γ) × δ :=
+  (prod_assoc% : _ ≃ α × β × γ × δ).trans prod_assoc%
+
+example {α β γ δ : Type*} (x : (α × β) × (γ × δ)) : α × (β × γ) × δ := prod_assoc% x

--- a/test/ProdAssoc.lean
+++ b/test/ProdAssoc.lean
@@ -12,3 +12,16 @@ example : (α × β) × (γ × δ) ≃ α × (β × γ) × δ :=
   (prod_assoc% : _ ≃ α × β × γ × δ).trans prod_assoc%
 
 example {α β γ δ : Type*} (x : (α × β) × (γ × δ)) : α × (β × γ) × δ := prod_assoc% x
+
+example : Nat ≃ Nat := prod_assoc%
+
+example (x : α) (y : β) (z : γ) (w : δ) :
+    prod_assoc% ((x,y),(z,w)) = (x,y,z,w) :=
+  rfl
+
+example (x : α) (y : β) (z : γ) (w : δ) :
+    prod_assoc% ((x,y),(z,w)) = (x,(y,z),w) :=
+  rfl
+
+example : (α × β) × (γ × δ) → α × (β × γ) × δ :=
+  prod_assoc%


### PR DESCRIPTION
For example,
```lean
(prod_assoc% : (α × β) × (γ × δ) ≃ α × (β × γ) × δ)
```
gives the "obvious" equivalence between `(α × β) × (γ × δ)` and `α × (β × γ) × δ`.

Special thanks to @kmill for help getting the expected type to work in the elaborator!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
