### PR TITLE
[Merged by Bors] - chore: fix `Set` docstring

### DIFF
--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -38,9 +38,9 @@ set_option autoImplicit true
 
 /-- A set is a collection of elements of some type `α`.
 
-    Although `Set` is defined as `α → Prop`, this is an implementation detail which should not be
-    relied on. Instead, `setOf` and membership of a set (`∈`) should be used to convert between sets
-    and predicates.
+Although `Set` is defined as `α → Prop`, this is an implementation detail which should not be
+relied on. Instead, `setOf` and membership of a set (`∈`) should be used to convert between sets
+and predicates.
 -/
 def Set (α : Type u) := α → Prop
 #align set Set


### PR DESCRIPTION
Indented docstring get parsed as a Markdown code block, so we remove the indentation

Co-authored-by: Anne Baanen <Vierkantor@users.noreply.github.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Applies a suggestion by @Vierkantor I missed in #8320 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
