### PR TITLE
[Merged by Bors] - chore: fix lakefile for docs

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -53,7 +53,8 @@ lean_lib Archive
 lean_lib Counterexamples
 lean_lib ImportGraph
 /-- Additional documentation in the form of modules that only contain module docstrings. -/
-lean_lib docs
+lean_lib docs where
+  roots := #[`docs]
 
 /-!
 ## Executables provided by Mathlib


### PR DESCRIPTION
Looks like #8456 broke doc-gen https://github.com/leanprover-community/mathlib4_docs/actions/runs/6927181810, this looks like the likely culprit (but I haven't tested the full workflow).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
