### PR TITLE
[Merged by Bors] - feat: switch to weaker UnivLE

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2468,6 +2468,7 @@ import Mathlib.Logic.Pairwise
 import Mathlib.Logic.Relation
 import Mathlib.Logic.Relator
 import Mathlib.Logic.Small.Basic
+import Mathlib.Logic.Small.Defs
 import Mathlib.Logic.Small.Group
 import Mathlib.Logic.Small.List
 import Mathlib.Logic.Small.Module
@@ -3124,6 +3125,7 @@ import Mathlib.SetTheory.Cardinal.Divisibility
 import Mathlib.SetTheory.Cardinal.Finite
 import Mathlib.SetTheory.Cardinal.Ordinal
 import Mathlib.SetTheory.Cardinal.SchroederBernstein
+import Mathlib.SetTheory.Cardinal.UnivLE
 import Mathlib.SetTheory.Game.Basic
 import Mathlib.SetTheory.Game.Birthday
 import Mathlib.SetTheory.Game.Domineering

--- a/Mathlib/CategoryTheory/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/EssentiallySmall.lean
@@ -6,6 +6,7 @@ Authors: Scott Morrison
 import Mathlib.CategoryTheory.Category.ULift
 import Mathlib.CategoryTheory.Skeletal
 import Mathlib.Logic.UnivLE
+import Mathlib.Logic.Small.Basic
 
 #align_import category_theory.essentially_small from "leanprover-community/mathlib"@"f7707875544ef1f81b32cb68c79e0e24e45a0e76"
 

--- a/Mathlib/CategoryTheory/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/EssentiallySmall.lean
@@ -3,9 +3,9 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Logic.Small.Basic
 import Mathlib.CategoryTheory.Category.ULift
 import Mathlib.CategoryTheory.Skeletal
+import Mathlib.Logic.UnivLE
 
 #align_import category_theory.essentially_small from "leanprover-community/mathlib"@"f7707875544ef1f81b32cb68c79e0e24e45a0e76"
 
@@ -33,6 +33,7 @@ namespace CategoryTheory
 
 /-- A category is `EssentiallySmall.{w}` if there exists
 an equivalence to some `S : Type w` with `[SmallCategory S]`. -/
+@[pp_with_univ]
 class EssentiallySmall (C : Type u) [Category.{v} C] : Prop where
   /-- An essentially small category is equivalent to some small category. -/
   equiv_smallCategory : ∃ (S : Type w) (_ : SmallCategory S), Nonempty (C ≌ S)
@@ -47,6 +48,7 @@ theorem EssentiallySmall.mk' {C : Type u} [Category.{v} C] {S : Type w} [SmallCa
 /-- An arbitrarily chosen small model for an essentially small category.
 -/
 --@[nolint has_nonempty_instance]
+@[pp_with_univ]
 def SmallModel (C : Type u) [Category.{v} C] [EssentiallySmall.{w} C] : Type w :=
   Classical.choose (@EssentiallySmall.equiv_smallCategory C _ _)
 #align category_theory.small_model CategoryTheory.SmallModel
@@ -89,6 +91,7 @@ theorem essentiallySmallSelf : EssentiallySmall.{max w v u} C :=
 
 See `ShrinkHoms C` for a category instance where every hom set has been replaced by a small model.
 -/
+@[pp_with_univ]
 class LocallySmall (C : Type u) [Category.{v} C] : Prop where
   /-- A locally small category has small hom-types. -/
   hom_small : ∀ X Y : C, Small.{w} (X ⟶ Y) := by infer_instance
@@ -118,6 +121,9 @@ instance (priority := 100) locallySmall_self (C : Type u) [Category.{v} C] : Loc
     where
 #align category_theory.locally_small_self CategoryTheory.locallySmall_self
 
+instance (priority := 100) locallySmall_of_univLE (C : Type u) [Category.{v} C] [UnivLE.{v, w}] :
+    LocallySmall.{w} C where
+
 theorem locallySmall_max {C : Type u} [Category.{v} C] : LocallySmall.{max v w} C
     where
   hom_small _ _ := small_max.{w} _
@@ -131,9 +137,20 @@ instance (priority := 100) locallySmall_of_essentiallySmall (C : Type u) [Catego
 we'll put a `Category.{w}` instance on `ShrinkHoms C`.
 -/
 --@[nolint has_nonempty_instance]
+@[pp_with_univ]
 def ShrinkHoms (C : Type u) :=
   C
 #align category_theory.shrink_homs CategoryTheory.ShrinkHoms
+
+namespace Shrink
+
+noncomputable instance [Small.{w} C] : Category.{v} (Shrink.{w} C) :=
+  InducedCategory.category (equivShrink C).symm
+
+noncomputable def equivalence [Small.{w} C] : C ≌ Shrink.{w} C :=
+  (inducedFunctor (equivShrink C).symm).asEquivalence.symm
+
+end Shrink
 
 namespace ShrinkHoms
 

--- a/Mathlib/CategoryTheory/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/EssentiallySmall.lean
@@ -262,4 +262,6 @@ theorem essentiallySmall_iff_of_thin {C : Type u} [Category.{v} C] [Quiver.IsThi
   simp [essentiallySmall_iff, CategoryTheory.locallySmall_of_thin]
 #align category_theory.essentially_small_iff_of_thin CategoryTheory.essentiallySmall_iff_of_thin
 
+instance [Small.{w} C] : Small.{w} (Discrete C) := small_map discreteEquiv
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/EssentiallySmall.lean
@@ -142,16 +142,6 @@ def ShrinkHoms (C : Type u) :=
   C
 #align category_theory.shrink_homs CategoryTheory.ShrinkHoms
 
-namespace Shrink
-
-noncomputable instance [Small.{w} C] : Category.{v} (Shrink.{w} C) :=
-  InducedCategory.category (equivShrink C).symm
-
-noncomputable def equivalence [Small.{w} C] : C ≌ Shrink.{w} C :=
-  (inducedFunctor (equivShrink C).symm).asEquivalence.symm
-
-end Shrink
-
 namespace ShrinkHoms
 
 section
@@ -216,6 +206,17 @@ noncomputable def equivalence : C ≌ ShrinkHoms C :=
 #align category_theory.shrink_homs.equivalence CategoryTheory.ShrinkHoms.equivalence
 
 end ShrinkHoms
+
+namespace Shrink
+
+noncomputable instance [Small.{w} C] : Category.{v} (Shrink.{w} C) :=
+  InducedCategory.category (equivShrink C).symm
+
+/-- The categorical equivalence between `C` and `Shrink C`, when `C` is small. -/
+noncomputable def equivalence [Small.{w} C] : C ≌ Shrink.{w} C :=
+  (inducedFunctor (equivShrink C).symm).asEquivalence.symm
+
+end Shrink
 
 /-- A category is essentially small if and only if
 the underlying type of its skeleton (i.e. the "set" of isomorphism classes) is small,

--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -618,19 +618,18 @@ theorem hasLimitsOfShape_of_equivalence {J' : Type u₂} [Category.{v₂} J'] (e
 
 variable (C)
 
-/-- `hasLimitsOfSizeShrink.{v u} C` tries to obtain `HasLimitsOfSize.{v u} C`
-from some other `HasLimitsOfSize C`.
--/
-theorem hasLimitsOfSizeShrink [HasLimitsOfSize.{max v₁ v₂, max u₁ u₂} C] :
-    HasLimitsOfSize.{v₁, u₁} C :=
-  ⟨fun J _ => hasLimitsOfShape_of_equivalence (ULiftHomULiftCategory.equiv.{v₂, u₂} J).symm⟩
-#align category_theory.limits.has_limits_of_size_shrink CategoryTheory.Limits.hasLimitsOfSizeShrink
-
 /-- A category that has larger limits also has smaller limits. -/
 theorem hasLimitsOfSizeOfUnivLE [UnivLE.{v₂, v₁}] [UnivLE.{u₂, u₁}]
     [HasLimitsOfSize.{v₁, u₁} C] : HasLimitsOfSize.{v₂, u₂} C where
   has_limits_of_shape J {_} := hasLimitsOfShape_of_equivalence
     ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm
+
+/-- `hasLimitsOfSizeShrink.{v u} C` tries to obtain `HasLimitsOfSize.{v u} C`
+from some other `HasLimitsOfSize C`.
+-/
+theorem hasLimitsOfSizeShrink [HasLimitsOfSize.{max v₁ v₂, max u₁ u₂} C] :
+    HasLimitsOfSize.{v₁, u₁} C := hasLimitsOfSizeOfUnivLE.{max v₁ v₂, max u₁ u₂} C
+#align category_theory.limits.has_limits_of_size_shrink CategoryTheory.Limits.hasLimitsOfSizeShrink
 
 instance (priority := 100) hasSmallestLimitsOfHasLimits [HasLimits C] : HasLimitsOfSize.{0, 0} C :=
   hasLimitsOfSizeShrink.{0, 0} C
@@ -1204,19 +1203,18 @@ theorem hasColimitsOfShape_of_equivalence {J' : Type u₂} [Category.{v₂} J'] 
 
 variable (C)
 
-/-- `hasColimitsOfSizeShrink.{v u} C` tries to obtain `HasColimitsOfSize.{v u} C`
-from some other `HasColimitsOfSize C`.
--/
-theorem hasColimitsOfSizeShrink [HasColimitsOfSize.{max v₁ v₂, max u₁ u₂} C] :
-    HasColimitsOfSize.{v₁, u₁} C :=
-  ⟨fun J _ => hasColimitsOfShape_of_equivalence (ULiftHomULiftCategory.equiv.{v₂, u₂} J).symm⟩
-#align category_theory.limits.has_colimits_of_size_shrink CategoryTheory.Limits.hasColimitsOfSizeShrink
-
 /-- A category that has larger colimits also has smaller colimits. -/
 theorem hasColimitsOfSizeOfUnivLE [UnivLE.{v₂, v₁}] [UnivLE.{u₂, u₁}]
     [HasColimitsOfSize.{v₁, u₁} C] : HasColimitsOfSize.{v₂, u₂} C where
   has_colimits_of_shape J {_} := hasColimitsOfShape_of_equivalence
     ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm
+
+/-- `hasColimitsOfSizeShrink.{v u} C` tries to obtain `HasColimitsOfSize.{v u} C`
+from some other `HasColimitsOfSize C`.
+-/
+theorem hasColimitsOfSizeShrink [HasColimitsOfSize.{max v₁ v₂, max u₁ u₂} C] :
+    HasColimitsOfSize.{v₁, u₁} C := hasColimitsOfSizeOfUnivLE.{max v₁ v₂, max u₁ u₂} C
+#align category_theory.limits.has_colimits_of_size_shrink CategoryTheory.Limits.hasColimitsOfSizeShrink
 
 instance (priority := 100) hasSmallestColimitsOfHasColimits [HasColimits C] :
     HasColimitsOfSize.{0, 0} C :=

--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -5,6 +5,7 @@ Authors: Reid Barton, Mario Carneiro, Scott Morrison, Floris van Doorn
 -/
 import Mathlib.CategoryTheory.Limits.IsLimit
 import Mathlib.CategoryTheory.Category.ULift
+import Mathlib.CategoryTheory.EssentiallySmall
 
 #align_import category_theory.limits.has_limits from "leanprover-community/mathlib"@"2738d2ca56cbc63be80c3bd48e9ed90ad94e947d"
 
@@ -625,6 +626,12 @@ theorem hasLimitsOfSizeShrink [HasLimitsOfSize.{max v₁ v₂, max u₁ u₂} C]
   ⟨fun J _ => hasLimitsOfShape_of_equivalence (ULiftHomULiftCategory.equiv.{v₂, u₂} J).symm⟩
 #align category_theory.limits.has_limits_of_size_shrink CategoryTheory.Limits.hasLimitsOfSizeShrink
 
+/-- A category that has larger limits also has smaller limits. -/
+theorem hasLimitsOfSizeOfUnivLE [UnivLE.{v₂, v₁}] [UnivLE.{u₂, u₁}]
+    [HasLimitsOfSize.{v₁, u₁} C] : HasLimitsOfSize.{v₂, u₂} C where
+  has_limits_of_shape J {_} := hasLimitsOfShape_of_equivalence
+    ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm
+
 instance (priority := 100) hasSmallestLimitsOfHasLimits [HasLimits C] : HasLimitsOfSize.{0, 0} C :=
   hasLimitsOfSizeShrink.{0, 0} C
 #align category_theory.limits.has_smallest_limits_of_has_limits CategoryTheory.Limits.hasSmallestLimitsOfHasLimits
@@ -1200,14 +1207,20 @@ variable (C)
 /-- `hasColimitsOfSizeShrink.{v u} C` tries to obtain `HasColimitsOfSize.{v u} C`
 from some other `HasColimitsOfSize C`.
 -/
-theorem hasColimitsOfSize_shrink [HasColimitsOfSize.{max v₁ v₂, max u₁ u₂} C] :
+theorem hasColimitsOfSizeShrink [HasColimitsOfSize.{max v₁ v₂, max u₁ u₂} C] :
     HasColimitsOfSize.{v₁, u₁} C :=
   ⟨fun J _ => hasColimitsOfShape_of_equivalence (ULiftHomULiftCategory.equiv.{v₂, u₂} J).symm⟩
-#align category_theory.limits.has_colimits_of_size_shrink CategoryTheory.Limits.hasColimitsOfSize_shrink
+#align category_theory.limits.has_colimits_of_size_shrink CategoryTheory.Limits.hasColimitsOfSizeShrink
+
+/-- A category that has larger colimits also has smaller colimits. -/
+theorem hasColimitsOfSizeOfUnivLE [UnivLE.{v₂, v₁}] [UnivLE.{u₂, u₁}]
+    [HasColimitsOfSize.{v₁, u₁} C] : HasColimitsOfSize.{v₂, u₂} C where
+  has_colimits_of_shape J {_} := hasColimitsOfShape_of_equivalence
+    ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm
 
 instance (priority := 100) hasSmallestColimitsOfHasColimits [HasColimits C] :
     HasColimitsOfSize.{0, 0} C :=
-  hasColimitsOfSize_shrink.{0, 0} C
+  hasColimitsOfSizeShrink.{0, 0} C
 #align category_theory.limits.has_smallest_colimits_of_has_colimits CategoryTheory.Limits.hasSmallestColimitsOfHasColimits
 
 end Colimit

--- a/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
@@ -280,6 +280,12 @@ def preservesLimitsOfSizeShrink (F : C ⥤ D) [PreservesLimitsOfSize.{max w w₂
   ⟨fun {J} _ => preservesLimitsOfShapeOfEquiv (ULiftHomULiftCategory.equiv.{w₂, w₂'} J).symm F⟩
 #align category_theory.limits.preserves_limits_of_size_shrink CategoryTheory.Limits.preservesLimitsOfSizeShrink
 
+/-- A functor preserving larger limits also preserves smaller limits. -/
+def preservesLimitsOfSizeOfUnivLE (F : C ⥤ D) [UnivLE.{w, w'}] [UnivLE.{w₂, w₂'}]
+    [PreservesLimitsOfSize.{w', w₂'} F] : PreservesLimitsOfSize.{w, w₂} F where
+  preservesLimitsOfShape {J} := preservesLimitsOfShapeOfEquiv
+    ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm F
+
 /-- Preserving limits at any universe level implies preserving limits in universe `0`. -/
 def preservesSmallestLimitsOfPreservesLimits (F : C ⥤ D) [PreservesLimitsOfSize.{v₃, u₃} F] :
     PreservesLimitsOfSize.{0, 0} F :=
@@ -345,6 +351,12 @@ def preservesColimitsOfSizeShrink (F : C ⥤ D) [PreservesColimitsOfSize.{max w 
   ⟨fun {J} =>
     preservesColimitsOfShapeOfEquiv (ULiftHomULiftCategory.equiv.{w₂, w₂'} J).symm F⟩
 #align category_theory.limits.preserves_colimits_of_size_shrink CategoryTheory.Limits.preservesColimitsOfSizeShrink
+
+/-- A functor preserving larger colimits also preserves smaller colimits. -/
+def preservesColimitsOfSizeOfUnivLE (F : C ⥤ D) [UnivLE.{w, w'}] [UnivLE.{w₂, w₂'}]
+    [PreservesColimitsOfSize.{w', w₂'} F] : PreservesColimitsOfSize.{w, w₂} F where
+  preservesColimitsOfShape {J} := preservesColimitsOfShapeOfEquiv
+    ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm F
 
 /-- Preserving colimits at any universe implies preserving colimits at universe `0`. -/
 def preservesSmallestColimitsOfPreservesColimits (F : C ⥤ D) [PreservesColimitsOfSize.{v₃, u₃} F] :
@@ -624,6 +636,12 @@ def reflectsLimitsOfSizeShrink (F : C ⥤ D) [ReflectsLimitsOfSize.{max w w₂, 
   ⟨fun {J} => reflectsLimitsOfShapeOfEquiv (ULiftHomULiftCategory.equiv.{w₂, w₂'} J).symm F⟩
 #align category_theory.limits.reflects_limits_of_size_shrink CategoryTheory.Limits.reflectsLimitsOfSizeShrink
 
+/-- A functor reflecting larger limits also reflects smaller limits. -/
+def reflectsLimitsOfSizeOfUnivLE (F : C ⥤ D) [UnivLE.{w, w'}] [UnivLE.{w₂, w₂'}]
+    [ReflectsLimitsOfSize.{w', w₂'} F] : ReflectsLimitsOfSize.{w, w₂} F where
+  reflectsLimitsOfShape {J} := reflectsLimitsOfShapeOfEquiv
+    ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm F
+
 /-- Reflecting limits at any universe implies reflecting limits at universe `0`. -/
 def reflectsSmallestLimitsOfReflectsLimits (F : C ⥤ D) [ReflectsLimitsOfSize.{v₃, u₃} F] :
     ReflectsLimitsOfSize.{0, 0} F :=
@@ -733,6 +751,12 @@ def reflectsColimitsOfSizeShrink (F : C ⥤ D) [ReflectsColimitsOfSize.{max w w�
     ReflectsColimitsOfSize.{w, w'} F :=
   ⟨fun {J} => reflectsColimitsOfShapeOfEquiv (ULiftHomULiftCategory.equiv.{w₂, w₂'} J).symm F⟩
 #align category_theory.limits.reflects_colimits_of_size_shrink CategoryTheory.Limits.reflectsColimitsOfSizeShrink
+
+/-- A functor reflecting larger colimits also reflects smaller colimits. -/
+def reflectsColimitsOfSizeOfUnivLE (F : C ⥤ D) [UnivLE.{w, w'}] [UnivLE.{w₂, w₂'}]
+    [ReflectsColimitsOfSize.{w', w₂'} F] : ReflectsColimitsOfSize.{w, w₂} F where
+  reflectsColimitsOfShape {J} := reflectsColimitsOfShapeOfEquiv
+    ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm F
 
 /-- Reflecting colimits at any universe implies reflecting colimits at universe `0`. -/
 def reflectsSmallestColimitsOfReflectsColimits (F : C ⥤ D) [ReflectsColimitsOfSize.{v₃, u₃} F] :

--- a/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
@@ -271,20 +271,19 @@ def preservesLimitsOfShapeOfEquiv {J' : Type w₂} [Category.{w₂'} J'] (e : J 
           simp [← Functor.map_comp] }
 #align category_theory.limits.preserves_limits_of_shape_of_equiv CategoryTheory.Limits.preservesLimitsOfShapeOfEquiv
 
--- See library note [dsimp, simp].
-/-- `PreservesLimitsOfSizeShrink.{w w'} F` tries to obtain `PreservesLimitsOfSize.{w w'} F`
-from some other `PreservesLimitsOfSize F`.
--/
-def preservesLimitsOfSizeShrink (F : C ⥤ D) [PreservesLimitsOfSize.{max w w₂, max w' w₂'} F] :
-    PreservesLimitsOfSize.{w, w'} F :=
-  ⟨fun {J} _ => preservesLimitsOfShapeOfEquiv (ULiftHomULiftCategory.equiv.{w₂, w₂'} J).symm F⟩
-#align category_theory.limits.preserves_limits_of_size_shrink CategoryTheory.Limits.preservesLimitsOfSizeShrink
-
 /-- A functor preserving larger limits also preserves smaller limits. -/
 def preservesLimitsOfSizeOfUnivLE (F : C ⥤ D) [UnivLE.{w, w'}] [UnivLE.{w₂, w₂'}]
     [PreservesLimitsOfSize.{w', w₂'} F] : PreservesLimitsOfSize.{w, w₂} F where
   preservesLimitsOfShape {J} := preservesLimitsOfShapeOfEquiv
     ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm F
+
+-- See library note [dsimp, simp].
+/-- `PreservesLimitsOfSizeShrink.{w w'} F` tries to obtain `PreservesLimitsOfSize.{w w'} F`
+from some other `PreservesLimitsOfSize F`.
+-/
+def preservesLimitsOfSizeShrink (F : C ⥤ D) [PreservesLimitsOfSize.{max w w₂, max w' w₂'} F] :
+    PreservesLimitsOfSize.{w, w'} F := preservesLimitsOfSizeOfUnivLE.{max w w₂, max w' w₂'} F
+#align category_theory.limits.preserves_limits_of_size_shrink CategoryTheory.Limits.preservesLimitsOfSizeShrink
 
 /-- Preserving limits at any universe level implies preserving limits in universe `0`. -/
 def preservesSmallestLimitsOfPreservesLimits (F : C ⥤ D) [PreservesLimitsOfSize.{v₃, u₃} F] :
@@ -341,22 +340,20 @@ def preservesColimitsOfShapeOfEquiv {J' : Type w₂} [Category.{w₂'} J'] (e : 
           simp [← Functor.map_comp] }
 #align category_theory.limits.preserves_colimits_of_shape_of_equiv CategoryTheory.Limits.preservesColimitsOfShapeOfEquiv
 
+/-- A functor preserving larger colimits also preserves smaller colimits. -/
+def preservesColimitsOfSizeOfUnivLE (F : C ⥤ D) [UnivLE.{w, w'}] [UnivLE.{w₂, w₂'}]
+    [PreservesColimitsOfSize.{w', w₂'} F] : PreservesColimitsOfSize.{w, w₂} F where
+  preservesColimitsOfShape {J} := preservesColimitsOfShapeOfEquiv
+    ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm F
+
 -- See library note [dsimp, simp].
 /--
 `PreservesColimitsOfSizeShrink.{w w'} F` tries to obtain `PreservesColimitsOfSize.{w w'} F`
 from some other `PreservesColimitsOfSize F`.
 -/
 def preservesColimitsOfSizeShrink (F : C ⥤ D) [PreservesColimitsOfSize.{max w w₂, max w' w₂'} F] :
-    PreservesColimitsOfSize.{w, w'} F :=
-  ⟨fun {J} =>
-    preservesColimitsOfShapeOfEquiv (ULiftHomULiftCategory.equiv.{w₂, w₂'} J).symm F⟩
+    PreservesColimitsOfSize.{w, w'} F := preservesColimitsOfSizeOfUnivLE.{max w w₂, max w' w₂'} F
 #align category_theory.limits.preserves_colimits_of_size_shrink CategoryTheory.Limits.preservesColimitsOfSizeShrink
-
-/-- A functor preserving larger colimits also preserves smaller colimits. -/
-def preservesColimitsOfSizeOfUnivLE (F : C ⥤ D) [UnivLE.{w, w'}] [UnivLE.{w₂, w₂'}]
-    [PreservesColimitsOfSize.{w', w₂'} F] : PreservesColimitsOfSize.{w, w₂} F where
-  preservesColimitsOfShape {J} := preservesColimitsOfShapeOfEquiv
-    ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm F
 
 /-- Preserving colimits at any universe implies preserving colimits at universe `0`. -/
 def preservesSmallestColimitsOfPreservesColimits (F : C ⥤ D) [PreservesColimitsOfSize.{v₃, u₃} F] :
@@ -628,19 +625,18 @@ def reflectsLimitsOfShapeOfEquiv {J' : Type w₂} [Category.{w₂'} J'] (e : J �
         exact IsLimit.whiskerEquivalence t _ }
 #align category_theory.limits.reflects_limits_of_shape_of_equiv CategoryTheory.Limits.reflectsLimitsOfShapeOfEquiv
 
-/-- `reflectsLimitsOfSizeShrink.{w w'} F` tries to obtain `reflectsLimitsOfSize.{w w'} F`
-from some other `reflectsLimitsOfSize F`.
--/
-def reflectsLimitsOfSizeShrink (F : C ⥤ D) [ReflectsLimitsOfSize.{max w w₂, max w' w₂'} F] :
-    ReflectsLimitsOfSize.{w, w'} F :=
-  ⟨fun {J} => reflectsLimitsOfShapeOfEquiv (ULiftHomULiftCategory.equiv.{w₂, w₂'} J).symm F⟩
-#align category_theory.limits.reflects_limits_of_size_shrink CategoryTheory.Limits.reflectsLimitsOfSizeShrink
-
 /-- A functor reflecting larger limits also reflects smaller limits. -/
 def reflectsLimitsOfSizeOfUnivLE (F : C ⥤ D) [UnivLE.{w, w'}] [UnivLE.{w₂, w₂'}]
     [ReflectsLimitsOfSize.{w', w₂'} F] : ReflectsLimitsOfSize.{w, w₂} F where
   reflectsLimitsOfShape {J} := reflectsLimitsOfShapeOfEquiv
     ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm F
+
+/-- `reflectsLimitsOfSizeShrink.{w w'} F` tries to obtain `reflectsLimitsOfSize.{w w'} F`
+from some other `reflectsLimitsOfSize F`.
+-/
+def reflectsLimitsOfSizeShrink (F : C ⥤ D) [ReflectsLimitsOfSize.{max w w₂, max w' w₂'} F] :
+    ReflectsLimitsOfSize.{w, w'} F := reflectsLimitsOfSizeOfUnivLE.{max w w₂, max w' w₂'} F
+#align category_theory.limits.reflects_limits_of_size_shrink CategoryTheory.Limits.reflectsLimitsOfSizeShrink
 
 /-- Reflecting limits at any universe implies reflecting limits at universe `0`. -/
 def reflectsSmallestLimitsOfReflectsLimits (F : C ⥤ D) [ReflectsLimitsOfSize.{v₃, u₃} F] :
@@ -744,19 +740,18 @@ def reflectsColimitsOfShapeOfEquiv {J' : Type w₂} [Category.{w₂'} J'] (e : J
         exact IsColimit.whiskerEquivalence t _ }
 #align category_theory.limits.reflects_colimits_of_shape_of_equiv CategoryTheory.Limits.reflectsColimitsOfShapeOfEquiv
 
-/-- `reflectsColimitsOfSizeShrink.{w w'} F` tries to obtain `reflectsColimitsOfSize.{w w'} F`
-from some other `reflectsColimitsOfSize F`.
--/
-def reflectsColimitsOfSizeShrink (F : C ⥤ D) [ReflectsColimitsOfSize.{max w w₂, max w' w₂'} F] :
-    ReflectsColimitsOfSize.{w, w'} F :=
-  ⟨fun {J} => reflectsColimitsOfShapeOfEquiv (ULiftHomULiftCategory.equiv.{w₂, w₂'} J).symm F⟩
-#align category_theory.limits.reflects_colimits_of_size_shrink CategoryTheory.Limits.reflectsColimitsOfSizeShrink
-
 /-- A functor reflecting larger colimits also reflects smaller colimits. -/
 def reflectsColimitsOfSizeOfUnivLE (F : C ⥤ D) [UnivLE.{w, w'}] [UnivLE.{w₂, w₂'}]
     [ReflectsColimitsOfSize.{w', w₂'} F] : ReflectsColimitsOfSize.{w, w₂} F where
   reflectsColimitsOfShape {J} := reflectsColimitsOfShapeOfEquiv
     ((ShrinkHoms.equivalence J).trans <| Shrink.equivalence _).symm F
+
+/-- `reflectsColimitsOfSizeShrink.{w w'} F` tries to obtain `reflectsColimitsOfSize.{w w'} F`
+from some other `reflectsColimitsOfSize F`.
+-/
+def reflectsColimitsOfSizeShrink (F : C ⥤ D) [ReflectsColimitsOfSize.{max w w₂, max w' w₂'} F] :
+    ReflectsColimitsOfSize.{w, w'} F := reflectsColimitsOfSizeOfUnivLE.{max w w₂, max w' w₂'} F
+#align category_theory.limits.reflects_colimits_of_size_shrink CategoryTheory.Limits.reflectsColimitsOfSizeShrink
 
 /-- Reflecting colimits at any universe implies reflecting colimits at universe `0`. -/
 def reflectsSmallestColimitsOfReflectsColimits (F : C ⥤ D) [ReflectsColimitsOfSize.{v₃, u₃} F] :

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
@@ -101,7 +101,7 @@ instance (priority := 100) hasColimitsOfShape_of_hasFiniteColimits (J : Type w) 
 instance (priority := 100) hasFiniteColimits_of_hasColimitsOfSize [HasColimitsOfSize.{v', u'} C] :
     HasFiniteColimits C where
   out := fun J hJ hJ' =>
-    haveI := hasColimitsOfSize_shrink.{0, 0} C
+    haveI := hasColimitsOfSizeShrink.{0, 0} C
     let F := @FinCategory.equivAsType J (@FinCategory.fintypeObj J hJ hJ') hJ hJ'
     @hasColimitsOfShape_of_equivalence (@FinCategory.AsType J (@FinCategory.fintypeObj J hJ hJ'))
     (@FinCategory.categoryAsType J (@FinCategory.fintypeObj J hJ hJ') hJ hJ') _ _ J hJ F _

--- a/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
@@ -405,8 +405,9 @@ noncomputable def productLimitCone {J : Type v} (F : J → Type u) [UnivLE.{v, u
     Limits.LimitCone (Discrete.functor F) where
   cone :=
     { pt := Shrink (∀ j, F j)
-      π := Discrete.natTrans (fun ⟨j⟩ f => (equivShrink _).symm f j) }
+      π := Discrete.natTrans (fun ⟨j⟩ f => (equivShrink (∀ j, F j)).symm f j) }
   isLimit :=
+    have : Small.{u} (∀ j, F j) := inferInstance
     { lift := fun s x => (equivShrink _) (fun j => s.π.app ⟨j⟩ x)
       uniq := fun s m w => funext fun x => Shrink.ext <| funext fun j => by
         simpa using (congr_fun (w ⟨j⟩) x : _) }
@@ -419,19 +420,19 @@ noncomputable def productIso {J : Type v} (F : J → Type u) [UnivLE.{v, u}] :
 
 @[simp]
 theorem productIso_hom_comp_eval {J : Type v} (F : J → Type u) [UnivLE.{v, u}] (j : J) :
-    ((productIso.{v, u} F).hom ≫ fun f => (equivShrink _).symm f j) = Pi.π F j :=
+    ((productIso.{v, u} F).hom ≫ fun f => (equivShrink (∀ j, F j)).symm f j) = Pi.π F j :=
   limit.isoLimitCone_hom_π (productLimitCone.{v, u} F) ⟨j⟩
 
 -- Porting note:
 -- `elementwise` seems to be broken. Applied to the previous lemma, it should produce:
 @[simp]
 theorem productIso_hom_comp_eval_apply {J : Type v} (F : J → Type u) [UnivLE.{v, u}] (j : J) (x) :
-    (equivShrink _).symm ((productIso F).hom x) j = Pi.π F j x :=
+    (equivShrink (∀ j, F j)).symm ((productIso F).hom x) j = Pi.π F j x :=
   congr_fun (productIso_hom_comp_eval F j) x
 
 @[elementwise (attr := simp)]
 theorem productIso_inv_comp_π {J : Type v} (F : J → Type u) [UnivLE.{v, u}] (j : J) :
-    (productIso.{v, u} F).inv ≫ Pi.π F j = fun f => ((equivShrink _).symm f) j :=
+    (productIso.{v, u} F).inv ≫ Pi.π F j = fun f => ((equivShrink (∀ j, F j)).symm f) j :=
   limit.isoLimitCone_inv_π (productLimitCone.{v, u} F) ⟨j⟩
 
 end UnivLE

--- a/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
@@ -52,9 +52,12 @@ example [UnivLE.{v, u}] : HasProducts.{v} (Type u) := inferInstance
 -- although I don't understand why, and wish it wasn't.
 instance : HasProducts.{v} (Type v) := inferInstance
 
+instance CategoryTheory.small_discrete (α : Type v) [Small.{u} α] : Small.{u} (Discrete α) :=
+  small_map discreteEquiv
+
 /-- A restatement of `Types.Limit.lift_π_apply` that uses `Pi.π` and `Pi.lift`. -/
 @[simp 1001]
-theorem pi_lift_π_apply [UnivLE.{v, u}] {β : Type v} (f : β → Type u) {P : Type u}
+theorem pi_lift_π_apply {β : Type v} [Small.{u} β] (f : β → Type u) {P : Type u}
     (s : ∀ b, P ⟶ f b) (b : β) (x : P) :
     (Pi.π f b : (piObj f) → f b) (@Pi.lift β _ _ f _ P s x) = s b x :=
   congr_fun (limit.lift_π (Fan.mk P s) ⟨b⟩) x
@@ -70,7 +73,7 @@ theorem pi_lift_π_apply' {β : Type v} (f : β → Type v) {P : Type v}
 
 /-- A restatement of `Types.Limit.map_π_apply` that uses `Pi.π` and `Pi.map`. -/
 @[simp 1001]
-theorem pi_map_π_apply [UnivLE.{v, u}] {β : Type v} {f g : β → Type u}
+theorem pi_map_π_apply {β : Type v} [Small.{u} β] {f g : β → Type u}
     (α : ∀ j, f j ⟶ g j) (b : β) (x) :
     (Pi.π g b : ∏ g → g b) (Pi.map α x) = α b ((Pi.π f b : ∏ f → f b) x) :=
   Limit.map_π_apply.{v, u} _ _ _
@@ -396,12 +399,14 @@ theorem productIso_inv_comp_π {J : Type v} (F : J → TypeMax.{v, u}) (j : J) :
   limit.isoLimitCone_inv_π (productLimitCone.{v, u} F) ⟨j⟩
 #align category_theory.limits.types.product_iso_inv_comp_π CategoryTheory.Limits.Types.productIso_inv_comp_π
 
-namespace UnivLE
+namespace Small
+
+variable {J : Type v} (F : J → Type u) [Small.{u} J]
 
 /--
-A variant of `productLimitCone` using a `UnivLE` hypothesis rather than a function to `TypeMax`.
+A variant of `productLimitCone` using a `Small` hypothesis rather than a function to `TypeMax`.
 -/
-noncomputable def productLimitCone {J : Type v} (F : J → Type u) [UnivLE.{v, u}] :
+noncomputable def productLimitCone :
     Limits.LimitCone (Discrete.functor F) where
   cone :=
     { pt := Shrink (∀ j, F j)
@@ -414,28 +419,28 @@ noncomputable def productLimitCone {J : Type v} (F : J → Type u) [UnivLE.{v, u
 
 /-- The categorical product in `Type u` indexed in `Type v`
 is the type theoretic product `Π j, F j`, after shrinking back to `Type u`. -/
-noncomputable def productIso {J : Type v} (F : J → Type u) [UnivLE.{v, u}] :
+noncomputable def productIso :
     (∏ F : Type u) ≅ Shrink.{u} (∀ j, F j) :=
   limit.isoLimitCone (productLimitCone.{v, u} F)
 
 @[simp]
-theorem productIso_hom_comp_eval {J : Type v} (F : J → Type u) [UnivLE.{v, u}] (j : J) :
+theorem productIso_hom_comp_eval (j : J) :
     ((productIso.{v, u} F).hom ≫ fun f => (equivShrink (∀ j, F j)).symm f j) = Pi.π F j :=
   limit.isoLimitCone_hom_π (productLimitCone.{v, u} F) ⟨j⟩
 
 -- Porting note:
 -- `elementwise` seems to be broken. Applied to the previous lemma, it should produce:
 @[simp]
-theorem productIso_hom_comp_eval_apply {J : Type v} (F : J → Type u) [UnivLE.{v, u}] (j : J) (x) :
+theorem productIso_hom_comp_eval_apply (j : J) (x) :
     (equivShrink (∀ j, F j)).symm ((productIso F).hom x) j = Pi.π F j x :=
   congr_fun (productIso_hom_comp_eval F j) x
 
 @[elementwise (attr := simp)]
-theorem productIso_inv_comp_π {J : Type v} (F : J → Type u) [UnivLE.{v, u}] (j : J) :
+theorem productIso_inv_comp_π (j : J) :
     (productIso.{v, u} F).inv ≫ Pi.π F j = fun f => ((equivShrink (∀ j, F j)).symm f) j :=
   limit.isoLimitCone_inv_π (productLimitCone.{v, u} F) ⟨j⟩
 
-end UnivLE
+end Small
 
 /-- The category of types has `Σ j, f j` as the coproduct of a type family `f : J → Type`.
 -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
@@ -52,9 +52,6 @@ example [UnivLE.{v, u}] : HasProducts.{v} (Type u) := inferInstance
 -- although I don't understand why, and wish it wasn't.
 instance : HasProducts.{v} (Type v) := inferInstance
 
-instance CategoryTheory.small_discrete (α : Type v) [Small.{u} α] : Small.{u} (Discrete α) :=
-  small_map discreteEquiv
-
 /-- A restatement of `Types.Limit.lift_π_apply` that uses `Pi.π` and `Pi.lift`. -/
 @[simp 1001]
 theorem pi_lift_π_apply {β : Type v} [Small.{u} β] (f : β → Type u) {P : Type u}

--- a/Mathlib/CategoryTheory/Limits/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Types.lean
@@ -87,8 +87,8 @@ variable {J : Type v} [SmallCategory J]
 
 /-! We now provide two distinct implementations in the category of types.
 
-The first, in the `CategoryTheory.Limits.Types.UnivLE` namespace,
-assumes `UnivLE.{v, u}` and constructs `v`-small limits in `Type u`.
+The first, in the `CategoryTheory.Limits.Types.Small` namespace,
+assumes `Small.{u} J` and constructs `J`-indexed limits in `Type u`.
 
 The second, in the `CategoryTheory.Limits.Types.TypeMax` namespace
 constructs limits for functors `F : J ⥤ TypeMax.{v, u}`, for `J : Type v`.
@@ -99,9 +99,9 @@ Hopefully we might be able to entirely remove the `TypeMax` constructions,
 but for now they are useful glue for the later parts of the library.
 -/
 
-namespace UnivLE
+namespace Small
 
-variable [UnivLE.{v, u}]
+variable [Small.{u} J]
 
 /-- (internal implementation) the limit cone of a functor,
 implemented as flat sections of a pi type
@@ -130,7 +130,7 @@ noncomputable def limitConeIsLimit (F : J ⥤ Type u) : IsLimit (limitCone.{v, u
     ext x j
     simpa using congr_fun (w j) x
 
-end UnivLE
+end Small
 
 -- TODO: If `UnivLE` works out well, we will eventually want to deprecate these
 -- definitions, and probably as a first step put them in namespace or otherwise rename them.
@@ -174,7 +174,11 @@ we leave them in the main `CategoryTheory.Limits.Types` namespace.
 section UnivLE
 
 open UnivLE
-variable [UnivLE.{v, u}]
+
+instance hasLimit [Small.{u} J] (F : J ⥤ Type u) : HasLimit F :=
+  HasLimit.mk
+    { cone := Small.limitCone.{v, u} F
+      isLimit := Small.limitConeIsLimit F }
 
 /--
 The category of types has all limits.
@@ -183,17 +187,11 @@ More specifically, when `UnivLE.{v, u}`, the category `Type u` has all `v`-small
 
 See <https://stacks.math.columbia.edu/tag/002U>.
 -/
-instance (priority := 1300) hasLimitsOfSize : HasLimitsOfSize.{v} (Type u) where
-  has_limits_of_shape _ :=
-    { has_limit := fun F =>
-        HasLimit.mk
-          { cone := UnivLE.limitCone.{v, u} F
-            isLimit := UnivLE.limitConeIsLimit F } }
+instance (priority := 1300) hasLimitsOfSize [UnivLE.{v, u}] : HasLimitsOfSize.{v} (Type u) where
+  has_limits_of_shape _ := { }
 #align category_theory.limits.types.has_limits_of_size CategoryTheory.Limits.Types.hasLimitsOfSize
 
-instance hasLimit (F : J ⥤ Type u) : HasLimit F :=
-  (Types.hasLimitsOfSize.{v, u}.has_limits_of_shape J).has_limit F
-
+variable [Small.{u} J]
 /-- The equivalence between the abstract limit of `F` in `TypeMax.{v, u}`
 and the "concrete" definition as the sections of `F`.
 -/

--- a/Mathlib/CategoryTheory/Limits/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Types.lean
@@ -110,20 +110,20 @@ implemented as flat sections of a pi type
 noncomputable def limitCone (F : J ⥤ Type u) : Cone F where
   pt := Shrink F.sections
   π :=
-    { app := fun j u => ((equivShrink _).symm u).val j
+    { app := fun j u => ((equivShrink F.sections).symm u).val j
       naturality := fun j j' f => by
         funext x
         simp }
 
 @[ext]
 lemma limitCone_pt_ext (F : J ⥤ Type u) {x y : (limitCone F).pt}
-    (w : (equivShrink _).symm x = (equivShrink _).symm y) : x = y := by
+    (w : (equivShrink F.sections).symm x = (equivShrink F.sections).symm y) : x = y := by
   aesop
 
 /-- (internal implementation) the fact that the proposed limit cone is the limit -/
 @[simps]
 noncomputable def limitConeIsLimit (F : J ⥤ Type u) : IsLimit (limitCone.{v, u} F) where
-  lift s v := (equivShrink _)
+  lift s v := equivShrink F.sections
     { val := fun j => s.π.app j v
       property := fun f => congr_fun (Cone.w s f) _ }
   uniq := fun _ _ w => by

--- a/Mathlib/CategoryTheory/Limits/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Limits/Yoneda.lean
@@ -162,7 +162,5 @@ instance coyonedaFunctorReflectsLimits : ReflectsLimits (@coyoneda D _) := infer
 
 end CategoryTheory
 
-assert_not_exists Set.range
-
 -- Porting note: after the port see if this import can be removed
 -- assert_not_exists AddCommMonoid

--- a/Mathlib/CategoryTheory/Limits/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Limits/Yoneda.lean
@@ -162,5 +162,4 @@ instance coyonedaFunctorReflectsLimits : ReflectsLimits (@coyoneda D _) := infer
 
 end CategoryTheory
 
--- Porting note: after the port see if this import can be removed
--- assert_not_exists AddCommMonoid
+assert_not_exists AddCommMonoid

--- a/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -306,7 +306,7 @@ instance : CompleteLattice (GrothendieckTopology C) :=
       · intro X S hS
         rw [trivial_covering] at hS
         apply covering_of_eq_top _ hS
-      · refine' @CompleteLattice.bot_le _ (completeLatticeOfInf _ isGLB_sInf) (trivial C))
+      · exact @CompleteLattice.bot_le _ (completeLatticeOfInf _ isGLB_sInf) (trivial C))
     _ rfl _ rfl _ rfl sInf rfl
 
 instance : Inhabited (GrothendieckTopology C) :=

--- a/Mathlib/CategoryTheory/UnivLE.lean
+++ b/Mathlib/CategoryTheory/UnivLE.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.Types
 /-!
 # Universe inequalities and essential surjectivity of `uliftFunctor`.
 
-We show `UnivLE.{u, v} ↔ EssSurj (uliftFunctor.{u, v} : Type v ⥤ Type max u v)`.
+We show `UnivLE.{max u v, v} ↔ EssSurj (uliftFunctor.{u, v} : Type v ⥤ Type max u v)`.
 -/
 
 set_option autoImplicit true
@@ -20,27 +20,28 @@ open CategoryTheory
 noncomputable section
 
 theorem UnivLE.ofEssSurj.{u, v} (w : EssSurj (uliftFunctor.{u, v} : Type v ⥤ Type max u v)) :
-    UnivLE.{u, v} :=
-  fun a => by
-    obtain ⟨a', ⟨m⟩⟩ := w.mem_essImage a
+    UnivLE.{max u v, v} :=
+  fun α ↦ by
+    obtain ⟨a', ⟨m⟩⟩ := w.mem_essImage α
     exact ⟨a', ⟨(Iso.toEquiv m).symm.trans Equiv.ulift⟩⟩
 
-instance [UnivLE.{u, v}] : EssSurj (uliftFunctor.{u, v} : Type v ⥤ Type max u v) where
+instance EssSurj.ofUnivLE [UnivLE.{max u v, v}] :
+    EssSurj (uliftFunctor.{u, v} : Type v ⥤ Type max u v) where
   mem_essImage α :=
     ⟨Shrink α, ⟨Equiv.toIso (Equiv.ulift.trans (equivShrink α).symm)⟩⟩
 
 theorem UnivLE_iff_essSurj.{u, v} :
-    UnivLE.{u, v} ↔ EssSurj (uliftFunctor.{u, v} : Type v ⥤ Type max u v) :=
+    UnivLE.{max u v, v} ↔ EssSurj (uliftFunctor.{u, v} : Type v ⥤ Type max u v) :=
   ⟨fun _ => inferInstance, fun w => UnivLE.ofEssSurj w⟩
 
-instance [UnivLE.{u, v}] : IsEquivalence uliftFunctor.{u, v} :=
+instance [UnivLE.{max u v, v}] : IsEquivalence uliftFunctor.{u, v} :=
   Equivalence.ofFullyFaithfullyEssSurj uliftFunctor
 
-def UnivLE.witness.{u, v} [UnivLE.{u, v}] : Type u ⥤ Type v :=
+def UnivLE.witness.{u, v} [UnivLE.{max u v, v}] : Type u ⥤ Type v :=
   uliftFunctor.{v, u} ⋙ (uliftFunctor.{u, v}).inv
 
-instance [UnivLE.{u, v}] : Faithful UnivLE.witness.{u, v} :=
+instance [UnivLE.{max u v, v}] : Faithful UnivLE.witness.{u, v} :=
   inferInstanceAs <| Faithful (_ ⋙ _)
 
-instance [UnivLE.{u, v}] : Full UnivLE.witness.{u, v} :=
+instance [UnivLE.{max u v, v}] : Full UnivLE.witness.{u, v} :=
   inferInstanceAs <| Full (_ ⋙ _)

--- a/Mathlib/Logic/Small/Basic.lean
+++ b/Mathlib/Logic/Small/Basic.lean
@@ -79,9 +79,15 @@ theorem small_lift (α : Type u) [hα : Small.{v} α] : Small.{max v w} α :=
   Small.mk' <| f.trans (Equiv.ulift.{w}).symm
 #align small_lift small_lift
 
-instance (priority := 100) small_max (α : Type v) : Small.{max w v} α :=
+/- This was an instance but useless due to https://github.com/leanprover/lean4/issues/2297. -/
+lemma small_max (α : Type v) : Small.{max w v} α :=
   small_lift.{v, w} α
 #align small_max small_max
+
+instance small_zero (α : Type) : Small.{w} α := small_max α
+
+instance (priority := 100) small_succ (α : Type v) : Small.{v+1} α :=
+  small_lift.{v, v+1} α
 
 instance small_ulift (α : Type u) [Small.{v} α] : Small.{v} (ULift.{w} α) :=
   small_map Equiv.ulift

--- a/Mathlib/Logic/Small/Basic.lean
+++ b/Mathlib/Logic/Small/Basic.lean
@@ -41,6 +41,7 @@ theorem Small.mk' {α : Type v} {S : Type w} (e : α ≃ S) : Small.{w} α :=
 
 /-- An arbitrarily chosen model in `Type w` for a `w`-small type.
 -/
+@[pp_with_univ]
 def Shrink (α : Type v) [Small.{w} α] : Type w :=
   Classical.choose (@Small.equiv_small α _)
 #align shrink Shrink

--- a/Mathlib/Logic/Small/Basic.lean
+++ b/Mathlib/Logic/Small/Basic.lean
@@ -3,21 +3,15 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
+import Mathlib.Logic.Small.Defs
 import Mathlib.Logic.Equiv.Set
-import Mathlib.Tactic.PPWithUniv
 
 #align_import logic.small.basic from "leanprover-community/mathlib"@"d012cd09a9b256d870751284dd6a29882b0be105"
 
 /-!
-# Small types
+# Instances and theorems for `Small`.
 
-A type is `w`-small if there exists an equivalence to some `S : Type w`.
-
-We provide a noncomputable model `Shrink α : Type w`, and `equivShrink α : α ≃ Shrink α`.
-
-A subsingleton type is `w`-small for any `w`.
-
-If `α ≃ β`, then `Small.{w} α ↔ Small.{w} β`.
+In particular we prove `small_of_injective` and `small_of_surjective`.
 -/
 
 set_option autoImplicit true
@@ -25,86 +19,9 @@ set_option autoImplicit true
 
 universe u w v v'
 
-/-- A type is `Small.{w}` if there exists an equivalence to some `S : Type w`.
--/
-@[mk_iff, pp_with_univ]
-class Small (α : Type v) : Prop where
-  /-- If a type is `Small.{w}`, then there exists an equivalence with some `S : Type w` -/
-  equiv_small : ∃ S : Type w, Nonempty (α ≃ S)
-#align small Small
-
-/-- Constructor for `Small α` from an explicit witness type and equivalence.
--/
-theorem Small.mk' {α : Type v} {S : Type w} (e : α ≃ S) : Small.{w} α :=
-  ⟨⟨S, ⟨e⟩⟩⟩
-#align small.mk' Small.mk'
-
-/-- An arbitrarily chosen model in `Type w` for a `w`-small type.
--/
-@[pp_with_univ]
-def Shrink (α : Type v) [Small.{w} α] : Type w :=
-  Classical.choose (@Small.equiv_small α _)
-#align shrink Shrink
-
-/-- The noncomputable equivalence between a `w`-small type and a model.
--/
-noncomputable def equivShrink (α : Type v) [Small.{w} α] : α ≃ Shrink α :=
-  Nonempty.some (Classical.choose_spec (@Small.equiv_small α _))
-#align equiv_shrink equivShrink
-
-@[ext]
-theorem Shrink.ext {α : Type v} [Small.{w} α] {x y : Shrink α}
-    (w : (equivShrink _).symm x = (equivShrink _).symm y) : x = y := by
-  simpa using w
-
--- It would be nice to mark this as `aesop cases` if
--- https://github.com/JLimperg/aesop/issues/59
--- is resolved.
-@[eliminator]
-protected noncomputable def Shrink.rec [Small.{w} α] {F : Shrink α → Sort v}
-    (h : ∀ X, F (equivShrink _ X)) : ∀ X, F X :=
-  fun X => ((equivShrink _).apply_symm_apply X) ▸ (h _)
-
---Porting note: Priority changed to 101
-instance (priority := 101) small_self (α : Type v) : Small.{v} α :=
-  Small.mk' <| Equiv.refl α
-#align small_self small_self
-
-theorem small_map {α : Type*} {β : Type*} [hβ : Small.{w} β] (e : α ≃ β) : Small.{w} α :=
-  let ⟨_, ⟨f⟩⟩ := hβ.equiv_small
-  Small.mk' (e.trans f)
-#align small_map small_map
-
-theorem small_lift (α : Type u) [hα : Small.{v} α] : Small.{max v w} α :=
-  let ⟨⟨_, ⟨f⟩⟩⟩ := hα
-  Small.mk' <| f.trans (Equiv.ulift.{w}).symm
-#align small_lift small_lift
-
-/- This was an instance but useless due to https://github.com/leanprover/lean4/issues/2297. -/
-lemma small_max (α : Type v) : Small.{max w v} α :=
-  small_lift.{v, w} α
-#align small_max small_max
-
-instance small_zero (α : Type) : Small.{w} α := small_max α
-
-instance (priority := 100) small_succ (α : Type v) : Small.{v+1} α :=
-  small_lift.{v, v+1} α
-
-instance small_ulift (α : Type u) [Small.{v} α] : Small.{v} (ULift.{w} α) :=
-  small_map Equiv.ulift
-#align small_ulift small_ulift
-
-theorem small_type : Small.{max (u + 1) v} (Type u) :=
-  small_max.{max (u + 1) v} _
-#align small_type small_type
-
 section
 
 open Classical
-
-theorem small_congr {α : Type*} {β : Type*} (e : α ≃ β) : Small.{w} α ↔ Small.{w} β :=
-  ⟨fun h => @small_map _ _ h e.symm, fun h => @small_map _ _ h e⟩
-#align small_congr small_congr
 
 instance small_subtype (α : Type v) [Small.{w} α] (P : α → Prop) : Small.{w} { x // P x } :=
   small_map (equivShrink α).subtypeEquivOfSubtype'
@@ -146,21 +63,14 @@ theorem small_of_injective_of_exists {α : Type v} {β : Type w} {γ : Type v'} 
 
 /-!
 We don't define `small_of_fintype` or `small_of_countable` in this file,
-to keep imports to `logic` to a minimum.
+to keep imports to `Logic` to a minimum.
 -/
-
 
 instance small_Pi {α} (β : α → Type*) [Small.{w} α] [∀ a, Small.{w} (β a)] :
     Small.{w} (∀ a, β a) :=
   ⟨⟨∀ a' : Shrink α, Shrink (β ((equivShrink α).symm a')),
       ⟨Equiv.piCongr (equivShrink α) fun a => by simpa using equivShrink (β a)⟩⟩⟩
 #align small_Pi small_Pi
-
-instance small_sigma {α} (β : α → Type*) [Small.{w} α] [∀ a, Small.{w} (β a)] :
-    Small.{w} (Σa, β a) :=
-  ⟨⟨Σa' : Shrink α, Shrink (β ((equivShrink α).symm a')),
-      ⟨Equiv.sigmaCongr (equivShrink α) fun a => by simpa using equivShrink (β a)⟩⟩⟩
-#align small_sigma small_sigma
 
 instance small_prod {α β} [Small.{w} α] [Small.{w} β] : Small.{w} (α × β) :=
   ⟨⟨Shrink α × Shrink β, ⟨Equiv.prodCongr (equivShrink α) (equivShrink β)⟩⟩⟩
@@ -183,13 +93,5 @@ instance small_image {α : Type v} {β : Type w} (f : α → β) (S : Set α) [S
     Small.{u} (f '' S) :=
   small_of_surjective Set.surjective_onto_image
 #align small_image small_image
-
-theorem not_small_type : ¬Small.{u} (Type max u v)
-  | ⟨⟨S, ⟨e⟩⟩⟩ =>
-    @Function.cantor_injective (Σα, e.symm α) (fun a => ⟨_, cast (e.3 _).symm a⟩) fun a b e => by
-      dsimp at e
-      injection e with h₁ h₂
-      simpa using h₂
-#align not_small_type not_small_type
 
 end

--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2021 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Mathlib.Logic.Equiv.Defs
+import Mathlib.Tactic.MkIffOfInductiveProp
+import Mathlib.Tactic.PPWithUniv
+
+#align_import logic.small.basic from "leanprover-community/mathlib"@"d012cd09a9b256d870751284dd6a29882b0be105"
+
+/-!
+# Small types
+
+A type is `w`-small if there exists an equivalence to some `S : Type w`.
+
+We provide a noncomputable model `Shrink α : Type w`, and `equivShrink α : α ≃ Shrink α`.
+
+A subsingleton type is `w`-small for any `w`.
+
+If `α ≃ β`, then `Small.{w} α ↔ Small.{w} β`.
+
+See `Mathlib.Logic.Small.Basic` for further instances and theorems.
+-/
+
+set_option autoImplicit true
+
+
+universe u w v v'
+
+/-- A type is `Small.{w}` if there exists an equivalence to some `S : Type w`.
+-/
+@[mk_iff, pp_with_univ]
+class Small (α : Type v) : Prop where
+  /-- If a type is `Small.{w}`, then there exists an equivalence with some `S : Type w` -/
+  equiv_small : ∃ S : Type w, Nonempty (α ≃ S)
+#align small Small
+
+/-- Constructor for `Small α` from an explicit witness type and equivalence.
+-/
+theorem Small.mk' {α : Type v} {S : Type w} (e : α ≃ S) : Small.{w} α :=
+  ⟨⟨S, ⟨e⟩⟩⟩
+#align small.mk' Small.mk'
+
+/-- An arbitrarily chosen model in `Type w` for a `w`-small type.
+-/
+@[pp_with_univ]
+def Shrink (α : Type v) [Small.{w} α] : Type w :=
+  Classical.choose (@Small.equiv_small α _)
+#align shrink Shrink
+
+/-- The noncomputable equivalence between a `w`-small type and a model.
+-/
+noncomputable def equivShrink (α : Type v) [Small.{w} α] : α ≃ Shrink α :=
+  Nonempty.some (Classical.choose_spec (@Small.equiv_small α _))
+#align equiv_shrink equivShrink
+
+@[ext]
+theorem Shrink.ext {α : Type v} [Small.{w} α] {x y : Shrink α}
+    (w : (equivShrink _).symm x = (equivShrink _).symm y) : x = y := by
+  simpa using w
+
+-- It would be nice to mark this as `aesop cases` if
+-- https://github.com/JLimperg/aesop/issues/59
+-- is resolved.
+@[eliminator]
+protected noncomputable def Shrink.rec [Small.{w} α] {F : Shrink α → Sort v}
+    (h : ∀ X, F (equivShrink _ X)) : ∀ X, F X :=
+  fun X => ((equivShrink _).apply_symm_apply X) ▸ (h _)
+
+--Porting note: Priority changed to 101
+instance (priority := 101) small_self (α : Type v) : Small.{v} α :=
+  Small.mk' <| Equiv.refl α
+#align small_self small_self
+
+theorem small_map {α : Type*} {β : Type*} [hβ : Small.{w} β] (e : α ≃ β) : Small.{w} α :=
+  let ⟨_, ⟨f⟩⟩ := hβ.equiv_small
+  Small.mk' (e.trans f)
+#align small_map small_map
+
+theorem small_lift (α : Type u) [hα : Small.{v} α] : Small.{max v w} α :=
+  let ⟨⟨_, ⟨f⟩⟩⟩ := hα
+  Small.mk' <| f.trans (Equiv.ulift.{w}).symm
+#align small_lift small_lift
+
+/- This was an instance but useless due to https://github.com/leanprover/lean4/issues/2297. -/
+lemma small_max (α : Type v) : Small.{max w v} α :=
+  small_lift.{v, w} α
+#align small_max small_max
+
+instance small_zero (α : Type) : Small.{w} α := small_max α
+
+instance (priority := 100) small_succ (α : Type v) : Small.{v+1} α :=
+  small_lift.{v, v+1} α
+
+instance small_ulift (α : Type u) [Small.{v} α] : Small.{v} (ULift.{w} α) :=
+  small_map Equiv.ulift
+#align small_ulift small_ulift
+
+theorem small_type : Small.{max (u + 1) v} (Type u) :=
+  small_max.{max (u + 1) v} _
+#align small_type small_type
+
+section
+
+open Classical
+
+theorem small_congr {α : Type*} {β : Type*} (e : α ≃ β) : Small.{w} α ↔ Small.{w} β :=
+  ⟨fun h => @small_map _ _ h e.symm, fun h => @small_map _ _ h e⟩
+#align small_congr small_congr
+
+instance small_sigma {α} (β : α → Type*) [Small.{w} α] [∀ a, Small.{w} (β a)] :
+    Small.{w} (Σa, β a) :=
+  ⟨⟨Σa' : Shrink α, Shrink (β ((equivShrink α).symm a')),
+      ⟨Equiv.sigmaCongr (equivShrink α) fun a => by simpa using equivShrink (β a)⟩⟩⟩
+#align small_sigma small_sigma
+
+theorem not_small_type : ¬Small.{u} (Type max u v)
+  | ⟨⟨S, ⟨e⟩⟩⟩ =>
+    @Function.cantor_injective (Σα, e.symm α) (fun a => ⟨_, cast (e.3 _).symm a⟩) fun a b e => by
+      dsimp at e
+      injection e with h₁ h₂
+      simpa using h₂
+#align not_small_type not_small_type
+
+end

--- a/Mathlib/Logic/Small/Group.lean
+++ b/Mathlib/Logic/Small/Group.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Logic.Small.Basic
+import Mathlib.Logic.Small.Defs
 import Mathlib.Logic.Equiv.TransferInstance
 
 /-!

--- a/Mathlib/Logic/Small/Ring.lean
+++ b/Mathlib/Logic/Small/Ring.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Logic.Small.Basic
+import Mathlib.Logic.Small.Defs
 import Mathlib.Logic.Equiv.TransferInstance
 
 /-!

--- a/Mathlib/Logic/UnivLE.lean
+++ b/Mathlib/Logic/UnivLE.lean
@@ -3,15 +3,15 @@ Copyright (c) 2023 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Logic.Small.Basic
-import Mathlib.SetTheory.Ordinal.Basic
+import Mathlib.Logic.Small.Defs
+
 /-!
 # UnivLE
 
 A proposition expressing a universe inequality. `UnivLE.{u, v}` expresses that `u ≤ v`,
 in the form `∀ α : Type u, Small.{v} α`.
 
-See the doc-string for the comparison with an alternative weaker definition.
+See the doc-string for the comparison with an alternative stronger definition.
 -/
 
 set_option autoImplicit true
@@ -55,25 +55,9 @@ theorem UnivLE.trans [UnivLE.{u, v}] [UnivLE.{v, w}] : UnivLE.{u, w} :=
 /- This is the crucial instance that subsumes `univLE_max`. -/
 instance univLE_of_max [UnivLE.{max u v, v}] : UnivLE.{u, v} := @UnivLE.trans univLE_max.{v,u} ‹_›
 
-/- uses small_Pi -/
-example (α : Type u) (β : Type v) [UnivLE.{u, v}] : Small.{v} (α → β) := inferInstance
+/- When `small_Pi` from `Mathlib.Logic.Small.Basic` is imported, we have : -/
+-- example (α : Type u) (β : Type v) [UnivLE.{u, v}] : Small.{v} (α → β) := inferInstance
 
 example : ¬ UnivLE.{u+1, u} := by
   simp only [Small_iff, not_forall, not_exists, not_nonempty_iff]
   exact ⟨Type u, fun α => ⟨fun f => Function.not_surjective_Type.{u, u} f.symm f.symm.surjective⟩⟩
-
-open Cardinal
-
-theorem univLE_iff_cardinal_le : UnivLE.{u, v} ↔ univ.{u, v+1} ≤ univ.{v, u+1} := by
-  rw [← not_iff_not, UnivLE]; simp_rw [small_iff_lift_mk_lt_univ]; push_neg
-  -- strange: simp_rw [univ_umax.{v,u}] doesn't work
-  refine ⟨fun ⟨α, le⟩ ↦ ?_, fun h ↦ ?_⟩
-  · rw [univ_umax.{v,u}, ← lift_le.{u+1}, lift_univ, lift_lift] at le
-    exact le.trans_lt (lift_lt_univ'.{u,v+1} #α)
-  · obtain ⟨⟨α⟩, h⟩ := lt_univ'.mp h; use α
-    rw [univ_umax.{v,u}, ← lift_le.{u+1}, lift_univ, lift_lift]
-    exact h.le
-
-/-- Together with transitivity, this shows UnivLE "IsTotalPreorder". -/
-theorem univLE_total : UnivLE.{u, v} ∨ UnivLE.{v, u} := by
-  simp_rw [univLE_iff_cardinal_le]; apply le_total

--- a/Mathlib/Logic/UnivLE.lean
+++ b/Mathlib/Logic/UnivLE.lean
@@ -4,17 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import Mathlib.Logic.Small.Basic
-
+import Mathlib.SetTheory.Ordinal.Basic
 /-!
 # UnivLE
 
 A proposition expressing a universe inequality. `UnivLE.{u, v}` expresses that `u ≤ v`,
-in the form `∀ α : Type max u v, Small.{v} α`.
+in the form `∀ α : Type u, Small.{v} α`.
 
 See the doc-string for the comparison with an alternative weaker definition.
-
-See also `Mathlib.CategoryTheory.UnivLE` for the statement
-`UnivLE.{u,v} ↔ EssSurj (uliftFunctor : Type v ⥤ Type max u v)`.
 -/
 
 set_option autoImplicit true
@@ -24,31 +21,59 @@ noncomputable section
 /--
 A class expressing a universe inequality. `UnivLE.{u, v}` expresses that `u ≤ v`.
 
-There are (at least) two plausible definitions for `u ≤ v`:
-* strong: `∀ α : Type max u v, Small.{v} α`
-* weak: `∀ α : Type u, Small.{v} α`
+There used to be a stronger definition `∀ α : Type max u v, Small.{v} α` that immediately implies
+`Small.{v} ((α : Type u) → (β : Type v))` which is essential for proving that `Type v` has
+`Type u`-indexed limits when `u ≤ v`. However the current weaker condition
+`∀ α : Type u, Small.{v} α` also implies the same, so we switched to use it for
+its simplicity and transitivity.
 
-The weak definition has the advantage of being transitive.
-However only under the strong definition do we have `Small.{v} ((α : Type u) → (β : Type v))`,
-which is essential for proving that `Type v` has `Type u`-indexed limits when `u ≤ v`.
-
-The strong definition implies the weaker definition (see below),
+The strong definition easily implies the weaker definition (see below),
 but we can not prove the reverse implication.
 This is because in Lean's type theory, while `max u v` is at least at big as `u` and `v`,
 it could be bigger than both!
+See also `Mathlib.CategoryTheory.UnivLE` for the statement that the stronger definition is
+equivalent to `EssSurj (uliftFunctor : Type v ⥤ Type max u v)`.
 -/
 @[pp_with_univ]
-abbrev UnivLE.{u, v} : Prop := ∀ α : Type max u v, Small.{v} α
+abbrev UnivLE.{u, v} : Prop := ∀ α : Type u, Small.{v} α
 
 example : UnivLE.{u, u} := inferInstance
 example : UnivLE.{u, u+1} := inferInstance
 example : UnivLE.{0, u} := inferInstance
-example : UnivLE.{u, max u v} := inferInstance
+/- This is useless as an instance due to https://github.com/leanprover/lean4/issues/2297 -/
+theorem univLE_max : UnivLE.{u, max u v} := fun α ↦ small_max.{v} α
 
-instance [UnivLE.{u, v}] (α : Type u) : Small.{v} α :=
-  ⟨Shrink.{v, max u v} (ULift.{v} α),
-    ⟨Equiv.ulift.symm.trans (equivShrink (ULift α))⟩⟩
+theorem Small.trans_univLE.{u, v} (α : Type w) [hα : Small.{u} α] [h : UnivLE.{u, v}] :
+    Small.{v} α :=
+  let ⟨β, ⟨f⟩⟩ := hα.equiv_small
+  let ⟨_, ⟨g⟩⟩ := (h β).equiv_small
+  ⟨_, ⟨f.trans g⟩⟩
+
+theorem UnivLE.trans [UnivLE.{u, v}] [UnivLE.{v, w}] : UnivLE.{u, w} :=
+  fun α ↦ Small.trans_univLE α
+
+/- This is the crucial instance that subsumes `univLE_max`. -/
+instance univLE_of_max [UnivLE.{max u v, v}] : UnivLE.{u, v} := @UnivLE.trans univLE_max.{v,u} ‹_›
+
+/- uses small_Pi -/
+example (α : Type u) (β : Type v) [UnivLE.{u, v}] : Small.{v} (α → β) := inferInstance
 
 example : ¬ UnivLE.{u+1, u} := by
   simp only [Small_iff, not_forall, not_exists, not_nonempty_iff]
   exact ⟨Type u, fun α => ⟨fun f => Function.not_surjective_Type.{u, u} f.symm f.symm.surjective⟩⟩
+
+open Cardinal
+
+theorem univLE_iff_cardinal_le : UnivLE.{u, v} ↔ univ.{u, v+1} ≤ univ.{v, u+1} := by
+  rw [← not_iff_not, UnivLE]; simp_rw [small_iff_lift_mk_lt_univ]; push_neg
+  -- strange: simp_rw [univ_umax.{v,u}] doesn't work
+  refine ⟨fun ⟨α, le⟩ ↦ ?_, fun h ↦ ?_⟩
+  · rw [univ_umax.{v,u}, ← lift_le.{u+1}, lift_univ, lift_lift] at le
+    exact le.trans_lt (lift_lt_univ'.{u,v+1} #α)
+  · obtain ⟨⟨α⟩, h⟩ := lt_univ'.mp h; use α
+    rw [univ_umax.{v,u}, ← lift_le.{u+1}, lift_univ, lift_lift]
+    exact h.le
+
+/-- Together with transitivity, this shows UnivLE "IsTotalPreorder". -/
+theorem univLE_total : UnivLE.{u, v} ∨ UnivLE.{v, u} := by
+  simp_rw [univLE_iff_cardinal_le]; apply le_total

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -446,7 +446,7 @@ cover of the classifying space of `G` as a simplicial set. -/
 def cechNerveTerminalFromIsoCompForget :
     cechNerveTerminalFrom G ≅ classifyingSpaceUniversalCover G ⋙ forget _ :=
   NatIso.ofComponents (fun _ => Types.productIso _) fun _ =>
-    Matrix.ext fun _ _ => Types.Limit.lift_π_apply _ _ _ _
+    Matrix.ext fun _ _ => Types.Limit.lift_π_apply (Discrete.functor fun _ ↦ G) _ _ _
 #align classifying_space_universal_cover.cech_nerve_terminal_from_iso_comp_forget classifyingSpaceUniversalCover.cechNerveTerminalFromIsoCompForget
 
 variable (k)

--- a/Mathlib/SetTheory/Cardinal/UnivLE.lean
+++ b/Mathlib/SetTheory/Cardinal/UnivLE.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Mathlib.Logic.UnivLE
+import Mathlib.SetTheory.Ordinal.Basic
+
+/-!
+# UnivLE and cardinals
+-/
+
+set_option autoImplicit true
+
+noncomputable section
+
+open Cardinal
+
+theorem univLE_iff_cardinal_le : UnivLE.{u, v} ↔ univ.{u, v+1} ≤ univ.{v, u+1} := by
+  rw [← not_iff_not, UnivLE]; simp_rw [small_iff_lift_mk_lt_univ]; push_neg
+  -- strange: simp_rw [univ_umax.{v,u}] doesn't work
+  refine ⟨fun ⟨α, le⟩ ↦ ?_, fun h ↦ ?_⟩
+  · rw [univ_umax.{v,u}, ← lift_le.{u+1}, lift_univ, lift_lift] at le
+    exact le.trans_lt (lift_lt_univ'.{u,v+1} #α)
+  · obtain ⟨⟨α⟩, h⟩ := lt_univ'.mp h; use α
+    rw [univ_umax.{v,u}, ← lift_le.{u+1}, lift_univ, lift_lift]
+    exact h.le
+
+/-- Together with transitivity, this shows UnivLE "IsTotalPreorder". -/
+theorem univLE_total : UnivLE.{u, v} ∨ UnivLE.{v, u} := by
+  simp_rw [univLE_iff_cardinal_le]; apply le_total

--- a/Mathlib/SetTheory/Cardinal/UnivLE.lean
+++ b/Mathlib/SetTheory/Cardinal/UnivLE.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2023 Scott Morrison. All rights reserved.
+Copyright (c) 2023 Junyan Xu. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Scott Morrison
+Authors: Junyan Xu
 -/
 import Mathlib.Logic.UnivLE
 import Mathlib.SetTheory.Ordinal.Basic

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -1224,7 +1224,7 @@ theorem enum_zero_eq_bot {o : Ordinal} (ho : 0 < o) :
 -- intended to be used with explicit universe parameters
 /-- `univ.{u v}` is the order type of the ordinals of `Type u` as a member
   of `Ordinal.{v}` (when `u < v`). It is an inaccessible cardinal. -/
- @[nolint checkUnivs]
+@[pp_with_univ, nolint checkUnivs]
 def univ : Ordinal.{max (u + 1) v} :=
   lift.{v, u + 1} (@type Ordinal (· < ·) _)
 #align ordinal.univ Ordinal.univ
@@ -1475,7 +1475,7 @@ theorem ord.orderEmbedding_coe : (ord.orderEmbedding : Cardinal → Ordinal) = o
 /-- The cardinal `univ` is the cardinality of ordinal `univ`, or
   equivalently the cardinal of `Ordinal.{u}`, or `Cardinal.{u}`,
   as an element of `Cardinal.{v}` (when `u < v`). -/
-@[nolint checkUnivs]
+@[pp_with_univ, nolint checkUnivs]
 def univ :=
   lift.{v, u + 1} #Ordinal
 #align cardinal.univ Cardinal.univ


### PR DESCRIPTION
Switch from the strong version of UnivLE `∀ α : Type max u v, Small.{v} α` to the weaker version `∀ α : Type u, Small.{v} α`.

Transfer Has/Preserves/Reflects(Co)limitsOfSize from a larger size (higher universe) to a smaller size.

In a few places it's now necessary to make the type explicit (for Lean to infer the `Small` instance, I think).

Also prove a characterization of UnivLE and the totality of the UnivLE relation.

A pared down version of #7695.

---

I think the main advantage of switching is to make UnivLE transitive, and transfer of Has/Preserves/Reflects can still be done without the switch.

Previous discussions at #7695, [#2297](https://github.com/leanprover/lean4/issues/2297#issuecomment-1767008247), and [#5723](https://github.com/leanprover-community/mathlib4/pull/5723#discussion_r1359833563).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
