### PR TITLE
[Merged by Bors] - fix: elaborate `linarith` arguments without errToSorry

### DIFF
--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -390,8 +390,8 @@ syntax (name := nlinarith) "nlinarith" "!"? linarithArgsRest : tactic
   `(tactic| nlinarith ! $rest:linarithArgsRest)
 
 /-- Elaborate `t` in a way that is suitable for linarith. -/
-def elabLinarithArg (tactic : String) (t : Term) : TacticM Expr := Term.withoutErrToSorry do
-  let (e, mvars) ← elabTermWithHoles t none `linarith (allowNaturalHoles := true)
+def elabLinarithArg (tactic : Name) (t : Term) : TacticM Expr := Term.withoutErrToSorry do
+  let (e, mvars) ← elabTermWithHoles t none tactic
   unless mvars.isEmpty do
     throwErrorAt t "Argument passed to {tactic} has metavariables:{indentD e}"
   return e
@@ -406,7 +406,7 @@ elab_rules : tactic
     withMainContext do commitIfNoEx do
       liftMetaFinishingTactic <|
         Linarith.linarith o.isSome
-          (← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg "linarith")).toList
+          (← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg `linarith)).toList
           ((← elabLinarithConfig (mkOptionalNode cfg)).updateReducibility bang.isSome)
 
 -- TODO restore this when `add_tactic_doc` is ported
@@ -427,7 +427,7 @@ elab_rules : tactic
         [(nlinarithExtras : GlobalBranchingPreprocessor)]) }
     liftMetaFinishingTactic <|
       Linarith.linarith o.isSome
-        (← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg "nlinarith")).toList
+        (← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg `nlinarith)).toList
         (cfg.updateReducibility bang.isSome)
 
 -- TODO restore this when `add_tactic_doc` is ported

--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -402,12 +402,10 @@ Allow elaboration of `LinarithConfig` arguments to tactics.
 declare_config_elab elabLinarithConfig Linarith.LinarithConfig
 
 elab_rules : tactic
-  | `(tactic| linarith $[!%$bang]? $[$cfg]? $[only%$o]? $[[$args,*]]?) =>
-    withMainContext do commitIfNoEx do
-      liftMetaFinishingTactic <|
-        Linarith.linarith o.isSome
-          (← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg `linarith)).toList
-          ((← elabLinarithConfig (mkOptionalNode cfg)).updateReducibility bang.isSome)
+  | `(tactic| linarith $[!%$bang]? $[$cfg]? $[only%$o]? $[[$args,*]]?) => withMainContext do
+    let args ← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg `linarith)
+    let cfg := (← elabLinarithConfig (mkOptionalNode cfg)).updateReducibility bang.isSome
+    commitIfNoEx do liftMetaFinishingTactic <| Linarith.linarith o.isSome args.toList cfg
 
 -- TODO restore this when `add_tactic_doc` is ported
 -- add_tactic_doc

--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -389,6 +389,13 @@ syntax (name := nlinarith) "nlinarith" "!"? linarithArgsRest : tactic
 @[inherit_doc nlinarith] macro "nlinarith!" rest:linarithArgsRest : tactic =>
   `(tactic| nlinarith ! $rest:linarithArgsRest)
 
+/-- Elaborate `t` in a way that is suitable for linarith. -/
+def elabLinarithArg (tactic : String) (t : Term) : TacticM Expr := Term.withoutErrToSorry do
+  let (e, mvars) ← elabTermWithHoles t none `linarith (allowNaturalHoles := true)
+  unless mvars.isEmpty do
+    throwErrorAt t "Argument passed to {tactic} has metavariables:{indentD e}"
+  return e
+
 /--
 Allow elaboration of `LinarithConfig` arguments to tactics.
 -/
@@ -399,7 +406,7 @@ elab_rules : tactic
     withMainContext do commitIfNoEx do
       liftMetaFinishingTactic <|
         Linarith.linarith o.isSome
-          (← ((args.map (TSepArray.getElems)).getD {}).mapM (elabTerm ·.raw none)).toList
+          (← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg "linarith")).toList
           ((← elabLinarithConfig (mkOptionalNode cfg)).updateReducibility bang.isSome)
 
 -- TODO restore this when `add_tactic_doc` is ported
@@ -420,7 +427,7 @@ elab_rules : tactic
         [(nlinarithExtras : GlobalBranchingPreprocessor)]) }
     liftMetaFinishingTactic <|
       Linarith.linarith o.isSome
-        (← ((args.map (TSepArray.getElems)).getD {}).mapM (elabTerm ·.raw none)).toList
+        (← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg "nlinarith")).toList
         (cfg.updateReducibility bang.isSome)
 
 -- TODO restore this when `add_tactic_doc` is ported

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -556,32 +556,6 @@ example (q : Prop) (p : ∀ (x : ℤ), q → 1 = 2) : 1 = 2 := by
   nlinarith [p _ garbage]
 
 /--
-error: don't know how to synthesize placeholder for argument 'x'
-context:
-E : Type ?u.243178
-inst✝¹ : AddGroup E
-R : Type ?u.243184
-inst✝ : Ring R
-abs : R → ℚ
-q : Prop
-p : ℤ → 1 = 2
-⊢ ℤ
----
-error: unsolved goals
-E : Type ?u.243178
-inst✝¹ : AddGroup E
-R : Type ?u.243184
-inst✝ : Ring R
-abs : R → ℚ
-q : Prop
-p : ℤ → 1 = 2
-⊢ 1 = 2
--/
-#guard_msgs in
-example (q : Prop) (p : ∀ (x : ℤ), 1 = 2) : 1 = 2 := by
-  linarith [p _]
-
-/--
 error: Argument passed to linarith has metavariables:
   p ?a
 -/

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -556,6 +556,32 @@ example (q : Prop) (p : ∀ (x : ℤ), q → 1 = 2) : 1 = 2 := by
   nlinarith [p _ garbage]
 
 /--
+error: don't know how to synthesize placeholder for argument 'x'
+context:
+E : Type ?u.243178
+inst✝¹ : AddGroup E
+R : Type ?u.243184
+inst✝ : Ring R
+abs : R → ℚ
+q : Prop
+p : ℤ → 1 = 2
+⊢ ℤ
+---
+error: unsolved goals
+E : Type ?u.243178
+inst✝¹ : AddGroup E
+R : Type ?u.243184
+inst✝ : Ring R
+abs : R → ℚ
+q : Prop
+p : ℤ → 1 = 2
+⊢ 1 = 2
+-/
+#guard_msgs in
+example (q : Prop) (p : ∀ (x : ℤ), 1 = 2) : 1 = 2 := by
+  linarith [p _]
+
+/--
 error: Argument passed to linarith has metavariables:
   p ?a
 -/

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -555,6 +555,16 @@ example (q : Prop) (p : ∀ (x : ℤ), q → 1 = 2) : 1 = 2 := by
 example (q : Prop) (p : ∀ (x : ℤ), q → 1 = 2) : 1 = 2 := by
   nlinarith [p _ garbage]
 
+-- Commented out for now since `#guard_msgs` prints the metavariable numbers, which are
+-- subject to change.
+-- /--
+-- error: don't know how to synthesize placeholder for argument 'x'
+-- ...
+-- -/
+-- #guard_msgs in
+-- example (q : Prop) (p : ∀ (x : ℤ), 1 = 2) : 1 = 2 := by
+--   linarith [p _]
+
 /--
 error: Argument passed to linarith has metavariables:
   p ?a

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -544,3 +544,29 @@ example (k : ℤ) (h : k < 1) (h₁ : -1 < k) : k = 0 := by
   -- linarith preprocessor to fail.
   change _ at h₁
   linarith
+
+/-- error: unknown identifier 'garbage' -/
+#guard_msgs in
+example (q : Prop) (p : ∀ (x : ℤ), q → 1 = 2) : 1 = 2 := by
+  linarith [p _ garbage]
+
+/-- error: unknown identifier 'garbage' -/
+#guard_msgs in
+example (q : Prop) (p : ∀ (x : ℤ), q → 1 = 2) : 1 = 2 := by
+  nlinarith [p _ garbage]
+
+/--
+error: Argument passed to linarith has metavariables:
+  p ?a
+-/
+#guard_msgs in
+example (q : Prop) (p : ∀ (x : ℤ), 1 = 2) : 1 = 2 := by
+  linarith [p ?a]
+
+/--
+error: Argument passed to nlinarith has metavariables:
+  p ?a
+-/
+#guard_msgs in
+example (q : Prop) (p : ∀ (x : ℤ), 1 = 2) : 1 = 2 := by
+  nlinarith [p ?a]


### PR DESCRIPTION
This means that `linarith` will fail before executing its algorithm if there is an elaboration error in one of its supplied terms, rather than going ahead and silently failing.

Also, checks for new metavariables in the elaborated terms, which can't be used since `linarith` is a finishing tactic.

Lastly, copies these (and pre-existing) fixes to `nlinarith`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
