### PR TITLE
[Merged by Bors] - refactor(CategoryTheory/Idempotents): replacing equalities of functors by isomorphisms

### DIFF
--- a/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
@@ -66,24 +66,31 @@ def Γ [IsIdempotentComplete C] [HasFiniteCoproducts C] : ChainComplex C ℕ ⥤
 
 variable [IsIdempotentComplete C] [HasFiniteCoproducts C]
 
-theorem hN₁ :
-    (toKaroubiEquivalence (SimplicialObject C)).functor ⋙ Preadditive.DoldKan.equivalence.functor =
-      N₁ :=
-  Functor.congr_obj (functorExtension₁_comp_whiskeringLeft_toKaroubi _ _) N₁
-set_option linter.uppercaseLean3 false in
-#align category_theory.idempotents.dold_kan.hN₁ CategoryTheory.Idempotents.DoldKan.hN₁
+def isoN₁ :
+    (toKaroubiEquivalence (SimplicialObject C)).functor ⋙
+      Preadditive.DoldKan.equivalence.functor ≅ N₁ := toKaroubiCompN₂IsoN₁
 
-theorem hΓ₀ :
-    (toKaroubiEquivalence (ChainComplex C ℕ)).functor ⋙ Preadditive.DoldKan.equivalence.inverse =
+@[simp]
+lemma isoN₁_hom_app_f (X : SimplicialObject C) :
+    (isoN₁.hom.app X).f = PInfty := by
+  simp [isoN₁]
+
+def isoΓ₀ :
+    (toKaroubiEquivalence (ChainComplex C ℕ)).functor ⋙ Preadditive.DoldKan.equivalence.inverse ≅
       Γ ⋙ (toKaroubiEquivalence _).functor :=
-  Functor.congr_obj (functorExtension₂_comp_whiskeringLeft_toKaroubi _ _) Γ₀
-#align category_theory.idempotents.dold_kan.hΓ₀ CategoryTheory.Idempotents.DoldKan.hΓ₀
+  (functorExtension₂CompWhiskeringLeftToKaroubiIso _ _).app Γ₀
+
+@[simp]
+lemma N₂_map_isoΓ₀_hom_app_f (X : ChainComplex C ℕ) :
+    (N₂.map (isoΓ₀.hom.app X)).f = PInfty := by
+  ext
+  apply comp_id
 
 /-- The Dold-Kan equivalence for pseudoabelian categories given
 by the functors `N` and `Γ`. It is obtained by applying the results in
 `Compatibility.lean` to the equivalence `Preadditive.DoldKan.Equivalence`. -/
 def equivalence : SimplicialObject C ≌ ChainComplex C ℕ :=
-  Compatibility.equivalence (eqToIso hN₁) (eqToIso hΓ₀)
+  Compatibility.equivalence isoN₁ isoΓ₀
 #align category_theory.idempotents.dold_kan.equivalence CategoryTheory.Idempotents.DoldKan.equivalence
 
 theorem equivalence_functor : (equivalence : SimplicialObject C ≌ _).functor = N :=
@@ -98,12 +105,12 @@ theorem equivalence_inverse : (equivalence : SimplicialObject C ≌ _).inverse =
 for the construction of our counit isomorphism `η` -/
 theorem hη :
     Compatibility.τ₀ =
-      Compatibility.τ₁ (eqToIso hN₁) (eqToIso hΓ₀)
+      Compatibility.τ₁ isoN₁ isoΓ₀
         (N₁Γ₀ : Γ ⋙ N₁ ≅ (toKaroubiEquivalence (ChainComplex C ℕ)).functor) := by
   ext K : 3
   simp only [Compatibility.τ₀_hom_app, Compatibility.τ₁_hom_app, eqToIso.hom]
-  refine' (N₂Γ₂_compatible_with_N₁Γ₀ K).trans _
-  simp only [N₂Γ₂ToKaroubiIso_hom, eqToHom_map, eqToHom_app, eqToHom_trans_assoc]
+  dsimp
+  refine' (N₂Γ₂_compatible_with_N₁Γ₀ K).trans (by simp)
 #align category_theory.idempotents.dold_kan.hη CategoryTheory.Idempotents.DoldKan.hη
 
 /-- The counit isomorphism induced by `N₁Γ₀` -/
@@ -119,9 +126,10 @@ theorem equivalence_counitIso :
 #align category_theory.idempotents.dold_kan.equivalence_counit_iso CategoryTheory.Idempotents.DoldKan.equivalence_counitIso
 
 theorem hε :
-    Compatibility.υ (eqToIso hN₁) =
+    Compatibility.υ (isoN₁) =
       (Γ₂N₁ : (toKaroubiEquivalence _).functor ≅
           (N₁ : SimplicialObject C ⥤ _) ⋙ Preadditive.DoldKan.equivalence.inverse) := by
+  dsimp only [isoN₁]
   ext1
   rw [← cancel_epi Γ₂N₁.inv, Iso.inv_hom_id]
   ext X : 2
@@ -129,13 +137,16 @@ theorem hε :
   erw [compatibility_Γ₂N₁_Γ₂N₂_natTrans X]
   rw [Compatibility.υ_hom_app, Preadditive.DoldKan.equivalence_unitIso, Iso.app_inv, assoc]
   erw [← NatTrans.comp_app_assoc, IsIso.hom_inv_id]
-  rw [NatTrans.id_app, id_comp, NatTrans.id_app, eqToIso.hom, eqToHom_app, eqToHom_map]
-  rw [compatibility_Γ₂N₁_Γ₂N₂_inv_app, eqToHom_trans, eqToHom_refl]
+  rw [NatTrans.id_app, id_comp, NatTrans.id_app]
+  rw [Γ₂N₂ToKaroubiIso_inv_app]
+  dsimp only [Preadditive.DoldKan.equivalence_inverse, Preadditive.DoldKan.Γ]
+  rw [← Γ₂.map_comp, Iso.inv_hom_id_app, Γ₂.map_id]
+  rfl
 #align category_theory.idempotents.dold_kan.hε CategoryTheory.Idempotents.DoldKan.hε
 
 /-- The unit isomorphism induced by `Γ₂N₁`. -/
 def ε : 𝟭 (SimplicialObject C) ≅ N ⋙ Γ :=
-  Compatibility.equivalenceUnitIso (eqToIso hΓ₀) Γ₂N₁
+  Compatibility.equivalenceUnitIso isoΓ₀ Γ₂N₁
 #align category_theory.idempotents.dold_kan.ε CategoryTheory.Idempotents.DoldKan.ε
 
 theorem equivalence_unitIso :

--- a/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
@@ -72,8 +72,7 @@ def isoN₁ :
 
 @[simp]
 lemma isoN₁_hom_app_f (X : SimplicialObject C) :
-    (isoN₁.hom.app X).f = PInfty := by
-  simp [isoN₁]
+    (isoN₁.hom.app X).f = PInfty := rfl
 
 def isoΓ₀ :
     (toKaroubiEquivalence (ChainComplex C ℕ)).functor ⋙ Preadditive.DoldKan.equivalence.inverse ≅

--- a/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
@@ -66,6 +66,7 @@ def Γ [IsIdempotentComplete C] [HasFiniteCoproducts C] : ChainComplex C ℕ ⥤
 
 variable [IsIdempotentComplete C] [HasFiniteCoproducts C]
 
+/-- A reformulation of the isomorphism `toKaroubi (SimplicialObject C) ⋙ N₂ ≅ N₁` -/
 def isoN₁ :
     (toKaroubiEquivalence (SimplicialObject C)).functor ⋙
       Preadditive.DoldKan.equivalence.functor ≅ N₁ := toKaroubiCompN₂IsoN₁
@@ -74,6 +75,8 @@ def isoN₁ :
 lemma isoN₁_hom_app_f (X : SimplicialObject C) :
     (isoN₁.hom.app X).f = PInfty := rfl
 
+/-- A reformulation of the canonical isomorphism
+`toKaroubi (ChainComplex C ℕ) ⋙ Γ₂ ≅ Γ ⋙ toKaroubi (SimplicialObject C)`. -/
 def isoΓ₀ :
     (toKaroubiEquivalence (ChainComplex C ℕ)).functor ⋙ Preadditive.DoldKan.equivalence.inverse ≅
       Γ ⋙ (toKaroubiEquivalence _).functor :=

--- a/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
@@ -107,9 +107,8 @@ theorem hη :
       Compatibility.τ₁ isoN₁ isoΓ₀
         (N₁Γ₀ : Γ ⋙ N₁ ≅ (toKaroubiEquivalence (ChainComplex C ℕ)).functor) := by
   ext K : 3
-  simp only [Compatibility.τ₀_hom_app, Compatibility.τ₁_hom_app, eqToIso.hom]
-  dsimp
-  refine' (N₂Γ₂_compatible_with_N₁Γ₀ K).trans (by simp)
+  simp only [Compatibility.τ₀_hom_app, Compatibility.τ₁_hom_app]
+  refine' (N₂Γ₂_compatible_with_N₁Γ₀ K).trans (by simp )
 #align category_theory.idempotents.dold_kan.hη CategoryTheory.Idempotents.DoldKan.hη
 
 /-- The counit isomorphism induced by `N₁Γ₀` -/
@@ -136,8 +135,7 @@ theorem hε :
   erw [compatibility_Γ₂N₁_Γ₂N₂_natTrans X]
   rw [Compatibility.υ_hom_app, Preadditive.DoldKan.equivalence_unitIso, Iso.app_inv, assoc]
   erw [← NatTrans.comp_app_assoc, IsIso.hom_inv_id]
-  rw [NatTrans.id_app, id_comp, NatTrans.id_app]
-  rw [Γ₂N₂ToKaroubiIso_inv_app]
+  rw [NatTrans.id_app, id_comp, NatTrans.id_app, Γ₂N₂ToKaroubiIso_inv_app]
   dsimp only [Preadditive.DoldKan.equivalence_inverse, Preadditive.DoldKan.Γ]
   rw [← Γ₂.map_comp, Iso.inv_hom_id_app, Γ₂.map_id]
   rfl

--- a/Mathlib/AlgebraicTopology/DoldKan/FunctorN.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/FunctorN.lean
@@ -63,9 +63,16 @@ def N₂ : Karoubi (SimplicialObject C) ⥤ Karoubi (ChainComplex C ℕ) :=
 set_option linter.uppercaseLean3 false in
 #align algebraic_topology.dold_kan.N₂ AlgebraicTopology.DoldKan.N₂
 
--- porting note: added to ease the port of `AlgebraicTopology.DoldKan.NCompGamma`
-lemma compatibility_N₁_N₂ : toKaroubi (SimplicialObject C) ⋙ N₂ = N₁ :=
-  Functor.congr_obj (functorExtension₁_comp_whiskeringLeft_toKaroubi _ _) N₁
+def toKaroubiCompN₂IsoN₁ : toKaroubi (SimplicialObject C) ⋙ N₂ ≅ N₁ :=
+  (functorExtension₁CompWhiskeringLeftToKaroubiIso _ _).app N₁
+
+@[simp]
+lemma toKaroubiCompN₂IsoN₁_hom_app (X : SimplicialObject C) :
+    (toKaroubiCompN₂IsoN₁.hom.app X).f = PInfty := rfl
+
+@[simp]
+lemma toKaroubiCompN₂IsoN₁_inv_app (X : SimplicialObject C) :
+    (toKaroubiCompN₂IsoN₁.inv.app X).f = PInfty := rfl
 
 end DoldKan
 

--- a/Mathlib/AlgebraicTopology/DoldKan/FunctorN.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/FunctorN.lean
@@ -63,6 +63,7 @@ def N₂ : Karoubi (SimplicialObject C) ⥤ Karoubi (ChainComplex C ℕ) :=
 set_option linter.uppercaseLean3 false in
 #align algebraic_topology.dold_kan.N₂ AlgebraicTopology.DoldKan.N₂
 
+/-- The canonical isomorphism `toKaroubi (SimplicialObject C) ⋙ N₂ ≅ N₁`. -/
 def toKaroubiCompN₂IsoN₁ : toKaroubi (SimplicialObject C) ⋙ N₂ ≅ N₁ :=
   (functorExtension₁CompWhiskeringLeftToKaroubiIso _ _).app N₁
 

--- a/Mathlib/AlgebraicTopology/DoldKan/GammaCompN.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/GammaCompN.lean
@@ -119,23 +119,45 @@ set_option linter.uppercaseLean3 false in
 -- Porting note: added to speed up elaboration
 attribute [irreducible] N₁Γ₀
 
-theorem N₂Γ₂_toKaroubi : toKaroubi (ChainComplex C ℕ) ⋙ Γ₂ ⋙ N₂ = Γ₀ ⋙ N₁ := by
-  have h := Functor.congr_obj (functorExtension₂_comp_whiskeringLeft_toKaroubi
-    (ChainComplex C ℕ) (SimplicialObject C)) Γ₀
-  have h' := Functor.congr_obj (functorExtension₁_comp_whiskeringLeft_toKaroubi
-    (SimplicialObject C) (ChainComplex C ℕ)) N₁
-  dsimp [N₂, Γ₂, functorExtension₁] at h h' ⊢
-  rw [← Functor.assoc, h, Functor.assoc, h']
-set_option linter.uppercaseLean3 false in
-#align algebraic_topology.dold_kan.N₂Γ₂_to_karoubi AlgebraicTopology.DoldKan.N₂Γ₂_toKaroubi
-
 /-- Compatibility isomorphism between `toKaroubi _ ⋙ Γ₂ ⋙ N₂` and `Γ₀ ⋙ N₁` which
 are functors `ChainComplex C ℕ ⥤ Karoubi (ChainComplex C ℕ)`. -/
-@[simps!]
 def N₂Γ₂ToKaroubiIso : toKaroubi (ChainComplex C ℕ) ⋙ Γ₂ ⋙ N₂ ≅ Γ₀ ⋙ N₁ :=
-  eqToIso N₂Γ₂_toKaroubi
+  calc
+    toKaroubi (ChainComplex C ℕ) ⋙ Γ₂ ⋙ N₂ ≅
+      toKaroubi (ChainComplex C ℕ) ⋙ (Γ₂ ⋙ N₂) := (Functor.associator _ _ _).symm
+    _ ≅ (Γ₀ ⋙ toKaroubi (SimplicialObject C)) ⋙ N₂ :=
+        isoWhiskerRight ((functorExtension₂CompWhiskeringLeftToKaroubiIso _ _).app Γ₀) N₂
+    _ ≅ Γ₀ ⋙ toKaroubi (SimplicialObject C) ⋙ N₂ := Functor.associator _ _ _
+    _ ≅ Γ₀ ⋙ N₁ :=
+      isoWhiskerLeft Γ₀ ((functorExtension₁CompWhiskeringLeftToKaroubiIso _ _).app N₁)
 set_option linter.uppercaseLean3 false in
 #align algebraic_topology.dold_kan.N₂Γ₂_to_karoubi_iso AlgebraicTopology.DoldKan.N₂Γ₂ToKaroubiIso
+
+@[simp]
+lemma N₂Γ₂ToKaroubiIso_hom_app (X : ChainComplex C ℕ) :
+    (N₂Γ₂ToKaroubiIso.hom.app X).f = PInfty := by
+  ext n
+  dsimp [N₂Γ₂ToKaroubiIso]
+  simp only [comp_id, assoc, PInfty_f_idem]
+  conv_rhs =>
+    rw [← PInfty_f_idem]
+  congr 1
+  apply (Γ₀.splitting X).hom_ext'
+  intro A
+  rw [Splitting.ι_desc_assoc, assoc]
+  apply id_comp
+
+@[simp]
+lemma N₂Γ₂ToKaroubiIso_inv_app (X : ChainComplex C ℕ) :
+    (N₂Γ₂ToKaroubiIso.inv.app X).f = PInfty := by
+  ext n
+  dsimp [N₂Γ₂ToKaroubiIso]
+  simp only [comp_id, PInfty_f_idem_assoc, AlternatingFaceMapComplex.obj_X, Γ₀_obj_obj]
+  convert comp_id _
+  apply (Γ₀.splitting X).hom_ext'
+  intro A
+  rw [Splitting.ι_desc]
+  erw [comp_id, id_comp]
 
 -- Porting note: added to speed up elaboration
 attribute [irreducible] N₂Γ₂ToKaroubiIso
@@ -151,16 +173,15 @@ set_option linter.uppercaseLean3 false in
 theorem N₂Γ₂_inv_app_f_f (X : Karoubi (ChainComplex C ℕ)) (n : ℕ) :
     (N₂Γ₂.inv.app X).f.f n =
       X.p.f n ≫ (Γ₀.splitting X.X).ιSummand (Splitting.IndexSet.id (op [n])) := by
-  simp only [N₂Γ₂, Functor.preimageIso, Iso.trans,
-    whiskeringLeft_obj_preimage_app, N₂Γ₂ToKaroubiIso_inv, assoc,
-    Functor.id_map, NatTrans.comp_app, eqToHom_app, Karoubi.comp_f,
-    Karoubi.eqToHom_f, Karoubi.decompId_p_f, HomologicalComplex.comp_f,
-    N₁Γ₀_inv_app_f_f, Splitting.toKaroubiNondegComplexIsoN₁_hom_f_f,
-    Functor.comp_map, Functor.comp_obj, Karoubi.decompId_i_f,
-    eqToHom_refl, comp_id, N₂_map_f_f, Γ₂_map_f_app, N₁_obj_p,
-    PInfty_on_Γ₀_splitting_summand_eq_self_assoc, toKaroubi_obj_X,
-    Splitting.ι_desc, Splitting.IndexSet.id_fst, SimplexCategory.len_mk, unop_op,
-    Karoubi.HomologicalComplex.p_idem_assoc]
+  dsimp [N₂Γ₂]
+  simp only [whiskeringLeft_obj_preimage_app, NatTrans.comp_app, Functor.comp_map,
+    Karoubi.comp_f, N₂Γ₂ToKaroubiIso_inv_app, HomologicalComplex.comp_f,
+    N₁Γ₀_inv_app_f_f, toKaroubi_obj_X, Splitting.toKaroubiNondegComplexIsoN₁_hom_f_f,
+    Γ₀.obj_obj, PInfty_on_Γ₀_splitting_summand_eq_self, N₂_map_f_f,
+    Γ₂_map_f_app, unop_op, Karoubi.decompId_p_f, PInfty_f_idem_assoc,
+    PInfty_on_Γ₀_splitting_summand_eq_self_assoc, Splitting.IndexSet.id_fst, SimplexCategory.len_mk,
+    Splitting.ι_desc]
+  apply Karoubi.HomologicalComplex.p_idem_assoc
 set_option linter.uppercaseLean3 false in
 #align algebraic_topology.dold_kan.N₂Γ₂_inv_app_f_f AlgebraicTopology.DoldKan.N₂Γ₂_inv_app_f_f
 

--- a/Mathlib/AlgebraicTopology/DoldKan/NCompGamma.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/NCompGamma.lean
@@ -234,16 +234,17 @@ theorem identity_N₂_objectwise (P : Karoubi (SimplicialObject C)) :
     simp only [N₂Γ₂_inv_app_f_f, N₂_obj_p_f, assoc]
   have eq₂ : (Γ₀.splitting (N₂.obj P).X).ιSummand (Splitting.IndexSet.id (op [n])) ≫
       (N₂.map (Γ₂N₂.natTrans.app P)).f.f n = PInfty.f n ≫ P.p.app (op [n]) := by
-    sorry
-    --dsimp
-    --simp only [assoc, Γ₂N₂.natTrans_app_f_app, Functor.comp_map, NatTrans.comp_app,
-    --  Karoubi.comp_f, compatibility_Γ₂N₁_Γ₂N₂_hom_app, eqToHom_refl, Karoubi.eqToHom_f,
-    --  PInfty_on_Γ₀_splitting_summand_eq_self_assoc, Functor.comp_obj]
-    --dsimp [N₂]
-    --simp only [Splitting.ι_desc_assoc, assoc, id_comp, unop_op,
-    --  Splitting.IndexSet.id_fst, len_mk, Splitting.IndexSet.e,
-    --  Splitting.IndexSet.id_snd_coe, op_id, P.X.map_id, id_comp,
-    --  PInfty_f_naturality_assoc, PInfty_f_idem_assoc, app_idem]
+    dsimp
+    rw [PInfty_on_Γ₀_splitting_summand_eq_self_assoc, Γ₂N₂.natTrans_app_f_app]
+    dsimp
+    rw [Γ₂N₂ToKaroubiIso_hom_app, assoc, Splitting.ι_desc_assoc, assoc, assoc]
+    dsimp [toKaroubi]
+    rw [Splitting.ι_desc_assoc]
+    dsimp
+    simp only [assoc, Splitting.ι_desc_assoc, unop_op, Splitting.IndexSet.id_fst,
+      len_mk, NatTrans.naturality, PInfty_f_idem_assoc,
+      PInfty_f_naturality_assoc, app_idem_assoc]
+    erw [P.X.map_id, comp_id]
   simp only [Karoubi.comp_f, HomologicalComplex.comp_f, Karoubi.id_eq, N₂_obj_p_f, assoc,
     eq₁, eq₂, PInfty_f_naturality_assoc, app_idem, PInfty_f_idem_assoc]
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/AlgebraicTopology/DoldKan/NCompGamma.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/NCompGamma.lean
@@ -172,43 +172,39 @@ end Γ₂N₁
 
 -- porting note: removed @[simps] attribute because it was creating timeouts
 /-- The compatibility isomorphism relating `N₂ ⋙ Γ₂` and `N₁ ⋙ Γ₂`. -/
-def compatibility_Γ₂N₁_Γ₂N₂ : toKaroubi (SimplicialObject C) ⋙ N₂ ⋙ Γ₂ ≅ N₁ ⋙ Γ₂ :=
-  eqToIso (by rw [← Functor.assoc, compatibility_N₁_N₂])
+def Γ₂N₂ToKaroubiIso : toKaroubi (SimplicialObject C) ⋙ N₂ ⋙ Γ₂ ≅ N₁ ⋙ Γ₂ :=
+  (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight toKaroubiCompN₂IsoN₁ Γ₂
 set_option linter.uppercaseLean3 false in
-#align algebraic_topology.dold_kan.compatibility_Γ₂N₁_Γ₂N₂ AlgebraicTopology.DoldKan.compatibility_Γ₂N₁_Γ₂N₂
+#align algebraic_topology.dold_kan.compatibility_Γ₂N₁_Γ₂N₂ AlgebraicTopology.DoldKan.Γ₂N₂ToKaroubiIso
 
--- porting note: no @[simp] attribute because this would trigger a timeout
-lemma compatibility_Γ₂N₁_Γ₂N₂_hom_app (X : SimplicialObject C) :
-    compatibility_Γ₂N₁_Γ₂N₂.hom.app X =
-      eqToHom (by rw [← Functor.assoc, compatibility_N₁_N₂]) := by
-  dsimp only [compatibility_Γ₂N₁_Γ₂N₂, CategoryTheory.eqToIso]
-  apply eqToHom_app
+@[simp]
+lemma Γ₂N₂ToKaroubiIso_hom_app (X : SimplicialObject C) :
+    Γ₂N₂ToKaroubiIso.hom.app X = Γ₂.map (toKaroubiCompN₂IsoN₁.hom.app X) := by
+  simp [Γ₂N₂ToKaroubiIso]
+
+@[simp]
+lemma Γ₂N₂ToKaroubiIso_inv_app (X : SimplicialObject C) :
+    Γ₂N₂ToKaroubiIso.inv.app X = Γ₂.map (toKaroubiCompN₂IsoN₁.inv.app X) := by
+  simp [Γ₂N₂ToKaroubiIso]
 
 -- Porting note: added to speed up elaboration
-attribute [irreducible] compatibility_Γ₂N₁_Γ₂N₂
-
-lemma compatibility_Γ₂N₁_Γ₂N₂_inv_app (X : SimplicialObject C) :
-    compatibility_Γ₂N₁_Γ₂N₂.inv.app X =
-      eqToHom (by rw [← Functor.assoc, compatibility_N₁_N₂]) := by
-  rw [← cancel_mono (compatibility_Γ₂N₁_Γ₂N₂.hom.app X), Iso.inv_hom_id_app,
-    compatibility_Γ₂N₁_Γ₂N₂_hom_app, eqToHom_trans, eqToHom_refl]
+attribute [irreducible] Γ₂N₂ToKaroubiIso
 
 namespace Γ₂N₂
 
 /-- The natural transformation `N₂ ⋙ Γ₂ ⟶ 𝟭 (SimplicialObject C)`. -/
 def natTrans : (N₂ : Karoubi (SimplicialObject C) ⥤ _) ⋙ Γ₂ ⟶ 𝟭 _ :=
   ((whiskeringLeft _ _ _).obj (toKaroubi (SimplicialObject C))).preimage
-    (by exact compatibility_Γ₂N₁_Γ₂N₂.hom ≫ Γ₂N₁.natTrans)
+    (Γ₂N₂ToKaroubiIso.hom ≫ Γ₂N₁.natTrans)
 set_option linter.uppercaseLean3 false in
 #align algebraic_topology.dold_kan.Γ₂N₂.nat_trans AlgebraicTopology.DoldKan.Γ₂N₂.natTrans
 
 theorem natTrans_app_f_app (P : Karoubi (SimplicialObject C)) :
-    Γ₂N₂.natTrans.app P = by
-      exact (N₂ ⋙ Γ₂).map P.decompId_i ≫
-        (compatibility_Γ₂N₁_Γ₂N₂.hom ≫ Γ₂N₁.natTrans).app P.X ≫ P.decompId_p := by
+    Γ₂N₂.natTrans.app P =
+      (N₂ ⋙ Γ₂).map P.decompId_i ≫
+        (Γ₂N₂ToKaroubiIso.hom ≫ Γ₂N₁.natTrans).app P.X ≫ P.decompId_p := by
   dsimp only [natTrans]
-  rw [whiskeringLeft_obj_preimage_app
-    (compatibility_Γ₂N₁_Γ₂N₂.hom ≫ Γ₂N₁.natTrans : _ ⟶ toKaroubi _ ⋙ 𝟭 _) P, Functor.id_map]
+  simp only [whiskeringLeft_obj_preimage_app, Functor.id_map, assoc]
 set_option linter.uppercaseLean3 false in
 #align algebraic_topology.dold_kan.Γ₂N₂.nat_trans_app_f_app AlgebraicTopology.DoldKan.Γ₂N₂.natTrans_app_f_app
 
@@ -219,7 +215,7 @@ end Γ₂N₂
 
 theorem compatibility_Γ₂N₁_Γ₂N₂_natTrans (X : SimplicialObject C) :
     Γ₂N₁.natTrans.app X =
-      (compatibility_Γ₂N₁_Γ₂N₂.app X).inv ≫
+      (Γ₂N₂ToKaroubiIso.app X).inv ≫
         Γ₂N₂.natTrans.app ((toKaroubi (SimplicialObject C)).obj X) := by
   rw [Γ₂N₂.natTrans_app_f_app]
   dsimp only [Karoubi.decompId_i_toKaroubi, Karoubi.decompId_p_toKaroubi, Functor.comp_map,
@@ -238,15 +234,16 @@ theorem identity_N₂_objectwise (P : Karoubi (SimplicialObject C)) :
     simp only [N₂Γ₂_inv_app_f_f, N₂_obj_p_f, assoc]
   have eq₂ : (Γ₀.splitting (N₂.obj P).X).ιSummand (Splitting.IndexSet.id (op [n])) ≫
       (N₂.map (Γ₂N₂.natTrans.app P)).f.f n = PInfty.f n ≫ P.p.app (op [n]) := by
-    dsimp
-    simp only [assoc, Γ₂N₂.natTrans_app_f_app, Functor.comp_map, NatTrans.comp_app,
-      Karoubi.comp_f, compatibility_Γ₂N₁_Γ₂N₂_hom_app, eqToHom_refl, Karoubi.eqToHom_f,
-      PInfty_on_Γ₀_splitting_summand_eq_self_assoc, Functor.comp_obj]
-    dsimp [N₂]
-    simp only [Splitting.ι_desc_assoc, assoc, id_comp, unop_op,
-      Splitting.IndexSet.id_fst, len_mk, Splitting.IndexSet.e,
-      Splitting.IndexSet.id_snd_coe, op_id, P.X.map_id, id_comp,
-      PInfty_f_naturality_assoc, PInfty_f_idem_assoc, app_idem]
+    sorry
+    --dsimp
+    --simp only [assoc, Γ₂N₂.natTrans_app_f_app, Functor.comp_map, NatTrans.comp_app,
+    --  Karoubi.comp_f, compatibility_Γ₂N₁_Γ₂N₂_hom_app, eqToHom_refl, Karoubi.eqToHom_f,
+    --  PInfty_on_Γ₀_splitting_summand_eq_self_assoc, Functor.comp_obj]
+    --dsimp [N₂]
+    --simp only [Splitting.ι_desc_assoc, assoc, id_comp, unop_op,
+    --  Splitting.IndexSet.id_fst, len_mk, Splitting.IndexSet.e,
+    --  Splitting.IndexSet.id_snd_coe, op_id, P.X.map_id, id_comp,
+    --  PInfty_f_naturality_assoc, PInfty_f_idem_assoc, app_idem]
   simp only [Karoubi.comp_f, HomologicalComplex.comp_f, Karoubi.id_eq, N₂_obj_p_f, assoc,
     eq₁, eq₂, PInfty_f_naturality_assoc, app_idem, PInfty_f_idem_assoc]
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/CategoryTheory/Idempotents/FunctorExtension.lean
+++ b/Mathlib/CategoryTheory/Idempotents/FunctorExtension.lean
@@ -20,22 +20,13 @@ when `D` is idempotent complete, we get equivalences
 `karoubiUniversal₂ C D : C ⥤ D ≌ Karoubi C ⥤ Karoubi D`
 and `karoubiUniversal C D : C ⥤ D ≌ Karoubi C ⥤ D`.
 
-We occasionally state and use equalities of functors because it is
-sometimes convenient to use rewrites when proving properties of
-functors obtained using the constructions in this file. Users are
-encouraged to use the corresponding natural isomorphism
-whenever possible.
-
 -/
-
-
-open CategoryTheory.Category
-
-open CategoryTheory.Idempotents.Karoubi
 
 namespace CategoryTheory
 
 namespace Idempotents
+
+open Category Karoubi
 
 variable {C D E : Type*} [Category C] [Category D] [Category E]
 
@@ -44,9 +35,7 @@ by its value on objects coming from `C`. -/
 theorem natTrans_eq {F G : Karoubi C ⥤ D} (φ : F ⟶ G) (P : Karoubi C) :
     φ.app P = F.map (decompId_i P) ≫ φ.app P.X ≫ G.map (decompId_p P) := by
   rw [← φ.naturality, ← assoc, ← F.map_comp]
-  conv =>
-    lhs
-    rw [← id_comp (φ.app P), ← F.map_id]
+  conv_lhs => rw [← id_comp (φ.app P), ← F.map_id]
   congr
   apply decompId
 #align category_theory.idempotents.nat_trans_eq CategoryTheory.Idempotents.natTrans_eq
@@ -110,28 +99,19 @@ def functorExtension₁ : (C ⥤ Karoubi D) ⥤ Karoubi C ⥤ Karoubi D where
     simp only [assoc]
 #align category_theory.idempotents.functor_extension₁ CategoryTheory.Idempotents.functorExtension₁
 
-theorem functorExtension₁_comp_whiskeringLeft_toKaroubi :
-    functorExtension₁ C D ⋙ (whiskeringLeft C (Karoubi C) (Karoubi D)).obj (toKaroubi C) =
-      𝟭 _ := by
-  refine' Functor.ext _ _
-  · intro F
-    refine' Functor.ext _ _
-    · intro X
-      ext
-      · simp
-      · simp
-    · aesop_cat
-  · intro F G φ
-    aesop_cat
-#align category_theory.idempotents.functor_extension₁_comp_whiskering_left_to_karoubi CategoryTheory.Idempotents.functorExtension₁_comp_whiskeringLeft_toKaroubi
-
 /-- The natural isomorphism expressing that functors `Karoubi C ⥤ Karoubi D` obtained
 using `functorExtension₁` actually extends the original functors `C ⥤ Karoubi D`. -/
 @[simps!]
-def functorExtension₁_comp_whiskeringLeft_toKaroubi_iso :
+def functorExtension₁CompWhiskeringLeftToKaroubiIso :
     functorExtension₁ C D ⋙ (whiskeringLeft C (Karoubi C) (Karoubi D)).obj (toKaroubi C) ≅ 𝟭 _ :=
-  eqToIso (functorExtension₁_comp_whiskeringLeft_toKaroubi C D)
-#align category_theory.idempotents.functor_extension₁_comp_whiskering_left_to_karoubi_iso CategoryTheory.Idempotents.functorExtension₁_comp_whiskeringLeft_toKaroubi_iso
+  NatIso.ofComponents
+    (fun F => NatIso.ofComponents
+      (fun X =>
+        { hom := { f := (F.obj X).p }
+          inv := { f := (F.obj X).p } })
+      (fun {X Y} f => by aesop_cat))
+    (by aesop_cat)
+#align category_theory.idempotents.functor_extension₁_comp_whiskering_left_to_karoubi_iso CategoryTheory.Idempotents.functorExtension₁CompWhiskeringLeftToKaroubiIso
 
 /-- The counit isomorphism of the equivalence `(C ⥤ Karoubi D) ≌ (Karoubi C ⥤ Karoubi D)`. -/
 @[simps!]
@@ -177,26 +157,20 @@ def KaroubiUniversal₁.counitIso :
 def karoubiUniversal₁ : C ⥤ Karoubi D ≌ Karoubi C ⥤ Karoubi D where
   functor := functorExtension₁ C D
   inverse := (whiskeringLeft C (Karoubi C) (Karoubi D)).obj (toKaroubi C)
-  unitIso := (functorExtension₁_comp_whiskeringLeft_toKaroubi_iso C D).symm
+  unitIso := (functorExtension₁CompWhiskeringLeftToKaroubiIso C D).symm
   counitIso := KaroubiUniversal₁.counitIso C D
   functor_unitIso_comp F := by
     ext P
-    dsimp [FunctorExtension₁.map, KaroubiUniversal₁.counitIso]
-    simp only [eqToHom_app, Functor.id_obj, Functor.comp_obj, functorExtension₁_obj,
-      whiskeringLeft_obj_obj, eqToHom_f, FunctorExtension₁.obj_obj_X, toKaroubi_obj_X,
-      eqToHom_refl, comp_id, comp_p, ←comp_f, ← F.map_comp, P.idem]
+    dsimp
+    rw [comp_p, ← comp_f, ← F.map_comp, P.idem]
 #align category_theory.idempotents.karoubi_universal₁ CategoryTheory.Idempotents.karoubiUniversal₁
 
-theorem functorExtension₁_comp (F : C ⥤ Karoubi D) (G : D ⥤ Karoubi E) :
-    (functorExtension₁ C E).obj (F ⋙ (functorExtension₁ D E).obj G) =
-      (functorExtension₁ C D).obj F ⋙ (functorExtension₁ D E).obj G := by
-  refine' Functor.ext _ _
-  · aesop_cat
-  · intro X Y f
-    ext
-    simp only [eqToHom_refl, id_comp, comp_id]
-    rfl
-#align category_theory.idempotents.functor_extension₁_comp CategoryTheory.Idempotents.functorExtension₁_comp
+/-- Compatibility isomorphisms of `functorExtension₁` with respect to the
+composition of functors. -/
+def functorExtension₁Comp (F : C ⥤ Karoubi D) (G : D ⥤ Karoubi E) :
+    (functorExtension₁ C E).obj (F ⋙ (functorExtension₁ D E).obj G) ≅
+      (functorExtension₁ C D).obj F ⋙ (functorExtension₁ D E).obj G :=
+  Iso.refl _
 
 /-- The canonical functor `(C ⥤ D) ⥤ (Karoubi C ⥤ Karoubi D)` -/
 @[simps!]
@@ -204,20 +178,19 @@ def functorExtension₂ : (C ⥤ D) ⥤ Karoubi C ⥤ Karoubi D :=
   (whiskeringRight C D (Karoubi D)).obj (toKaroubi D) ⋙ functorExtension₁ C D
 #align category_theory.idempotents.functor_extension₂ CategoryTheory.Idempotents.functorExtension₂
 
-theorem functorExtension₂_comp_whiskeringLeft_toKaroubi :
-    functorExtension₂ C D ⋙ (whiskeringLeft C (Karoubi C) (Karoubi D)).obj (toKaroubi C) =
-      (whiskeringRight C D (Karoubi D)).obj (toKaroubi D) := by
-  simp only [functorExtension₂, Functor.assoc, functorExtension₁_comp_whiskeringLeft_toKaroubi,
-    Functor.comp_id]
-#align category_theory.idempotents.functor_extension₂_comp_whiskering_left_to_karoubi CategoryTheory.Idempotents.functorExtension₂_comp_whiskeringLeft_toKaroubi
-
 /-- The natural isomorphism expressing that functors `Karoubi C ⥤ Karoubi D` obtained
 using `functorExtension₂` actually extends the original functors `C ⥤ D`. -/
 @[simps!]
 def functorExtension₂CompWhiskeringLeftToKaroubiIso :
     functorExtension₂ C D ⋙ (whiskeringLeft C (Karoubi C) (Karoubi D)).obj (toKaroubi C) ≅
       (whiskeringRight C D (Karoubi D)).obj (toKaroubi D) :=
-  eqToIso (functorExtension₂_comp_whiskeringLeft_toKaroubi C D)
+  NatIso.ofComponents
+    (fun F => NatIso.ofComponents
+      (fun X =>
+        { hom := { f := 𝟙 _ }
+          inv := { f := 𝟙 _ } })
+      (by aesop_cat))
+    (by aesop_cat)
 #align category_theory.idempotents.functor_extension₂_comp_whiskering_left_to_karoubi_iso CategoryTheory.Idempotents.functorExtension₂CompWhiskeringLeftToKaroubiIso
 
 section IsIdempotentComplete


### PR DESCRIPTION
In the context of idempotent completion of categories and the Dold-Kan equivalence, constructing some isomorphisms was very slow in Lean 3 but has been much faster in Lean 4, while using equalities of functors in Lean 3 was fast, but in Lean 4 it became very slow. In this PR, we switch to using mostly isomorphisms of functors: this also became necessary in order to make the refactor #8531 possible.

---


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
