### PR TITLE
[Merged by Bors] - feat: abstract `KleinFour` into a class `IsKleinFour`.

### DIFF
--- a/Mathlib/GroupTheory/Exponent.lean
+++ b/Mathlib/GroupTheory/Exponent.lean
@@ -286,6 +286,19 @@ section LeftCancelMonoid
 
 variable [LeftCancelMonoid G]
 
+@[to_additive AddMonoid.one_lt_exponent]
+lemma one_lt_exponent [Finite G] [Nontrivial G] :
+    1 < Monoid.exponent G := by
+  let _inst := Fintype.ofFinite G
+  obtain ⟨g, hg⟩ := exists_ne (1 : G)
+  rw [← Monoid.lcm_order_eq_exponent]
+  have hg' : 2 ≤ orderOf g := Nat.lt_of_le_of_ne (orderOf_pos g) <| by
+    simpa [eq_comm, orderOf_eq_one_iff] using hg
+  refine hg'.trans <| Nat.le_of_dvd ?_ <| Finset.dvd_lcm (by simp)
+  rw [Nat.pos_iff_ne_zero, Ne.def, Finset.lcm_eq_zero_iff]
+  rintro ⟨x, -, hx⟩
+  exact (orderOf_pos x).ne' hx
+
 @[to_additive]
 theorem exponent_ne_zero_of_finite [Finite G] : exponent G ≠ 0 := by
   cases nonempty_fintype G

--- a/Mathlib/GroupTheory/Exponent.lean
+++ b/Mathlib/GroupTheory/Exponent.lean
@@ -286,19 +286,6 @@ section LeftCancelMonoid
 
 variable [LeftCancelMonoid G]
 
-@[to_additive AddMonoid.one_lt_exponent]
-lemma one_lt_exponent [Finite G] [Nontrivial G] :
-    1 < Monoid.exponent G := by
-  let _inst := Fintype.ofFinite G
-  obtain ⟨g, hg⟩ := exists_ne (1 : G)
-  rw [← Monoid.lcm_order_eq_exponent]
-  have hg' : 2 ≤ orderOf g := Nat.lt_of_le_of_ne (orderOf_pos g) <| by
-    simpa [eq_comm, orderOf_eq_one_iff] using hg
-  refine hg'.trans <| Nat.le_of_dvd ?_ <| Finset.dvd_lcm (by simp)
-  rw [Nat.pos_iff_ne_zero, Ne.def, Finset.lcm_eq_zero_iff]
-  rintro ⟨x, -, hx⟩
-  exact (orderOf_pos x).ne' hx
-
 @[to_additive]
 theorem exponent_ne_zero_of_finite [Finite G] : exponent G ≠ 0 := by
   cases nonempty_fintype G

--- a/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
@@ -39,74 +39,179 @@ produces the third one.
 non-cyclic abelian group
 -/
 
-/-- Klein four-group. -/
-abbrev KleinFour := Multiplicative (ZMod 2 × ZMod 2)
+/-! # Properties of groups with exponent two -/
 
-namespace KleinFour
+section ExponentTwo
 
-open DihedralGroup Equiv
+variable {G : Type*} [Group G]
 
-/-- Element `a` of Klein four-group. -/
-def a : KleinFour := Multiplicative.ofAdd (0, 1)
+@[to_additive AddMonoid.one_lt_exponent]
+lemma Monoid.one_lt_exponent {G : Type*} [LeftCancelMonoid G] [Finite G] [Nontrivial G] :
+    1 < Monoid.exponent G := by
+  let _inst := Fintype.ofFinite G
+  obtain ⟨g, hg⟩ := exists_ne (1 : G)
+  rw [Ne.def, ← orderOf_eq_one_iff] at hg
+  rw [← Monoid.lcm_order_eq_exponent, ← Nat.succ_le_iff]
+  have hg' : 2 ≤ orderOf g := Nat.lt_of_le_of_ne (orderOf_pos g) (Ne.symm hg)
+  refine hg'.trans <| Nat.le_of_dvd ?_ <| Finset.dvd_lcm (by simp)
+  rw [Nat.pos_iff_ne_zero, Ne.def, Finset.lcm_eq_zero_iff]
+  rintro ⟨x, -, hx⟩
+  exact (orderOf_pos x).ne' hx
 
-/-- Element `b` of Klein four-group. -/
-def b : KleinFour := Multiplicative.ofAdd (1, 0)
+/-- In a group of exponent two, every element is its own inverse. -/
+@[to_additive]
+lemma inv_eq_self_of_exponent_two (hG : Monoid.exponent G = 2) (x : G) :
+    x⁻¹ = x :=
+  inv_eq_of_mul_eq_one_left <| pow_two (a := x) ▸ hG ▸ Monoid.pow_exponent_eq_one x
 
-/-- Element `c` of Klein four-group. -/
-def c : KleinFour := Multiplicative.ofAdd (1, 1)
+/-- If an element in a group has order two, then it is its own inverse. -/
+@[to_additive]
+lemma inv_eq_self_of_orderOf_eq_two {x : G} (hx : orderOf x = 2) :
+    x⁻¹ = x :=
+  inv_eq_of_mul_eq_one_left <| pow_two (a := x) ▸ hx ▸ pow_orderOf_eq_one x
 
-/-- Klein four-group is a group of order 4. -/
-theorem card : Fintype.card KleinFour = 4 :=
-  rfl
+/-- In a group of exponent two, all elements commute. -/
+@[to_additive]
+lemma mul_comm_of_exponent_two (hG : Monoid.exponent G = 2) (x y : G) :
+    x * y = y * x := by
+  simpa only [inv_eq_self_of_exponent_two hG] using mul_inv_rev x y
 
-/-- Klein four-group is a group of order 4. -/
-theorem nat_card : Nat.card KleinFour = 4 := by
-  simp (config := {decide := true}) only [Nat.card_eq_fintype_card]
+/-- Any group of exponent two is abelian. -/
+@[to_additive (attr := reducible) "Any additive group of exponent two is abelian."]
+def instCommGroupOfExponentTwo (hG : Monoid.exponent G = 2) : CommGroup G where
+  mul_comm := mul_comm_of_exponent_two hG
 
-@[simp] theorem a_sq : a ^ 2 = 1 :=
-  rfl
+@[to_additive]
+lemma mul_not_mem_of_orderOf_eq_two {G : Type*} [Group G] {x y : G} (hx : orderOf x = 2)
+    (hy : orderOf y = 2) (hxy : x ≠ y) : x * y ∉ ({x, y, 1} : Set G) := by
+  simp only [Set.mem_singleton_iff, Set.mem_insert_iff, mul_right_eq_self, mul_left_eq_self, not_or]
+  refine ⟨?_, ?_, fun h' ↦ hxy <| by
+    simpa only [mul_eq_one_iff_eq_inv, inv_eq_self_of_orderOf_eq_two hx,
+      inv_eq_self_of_orderOf_eq_two hy] using h'⟩
+  all_goals rw [← orderOf_eq_one_iff]; norm_num [hy, hx]
 
-@[simp] theorem b_sq : b ^ 2 = 1 :=
-  rfl
+@[to_additive]
+lemma mul_not_mem_of_exponent_two {G : Type*} [Group G] (h : Monoid.exponent G = 2) {x y : G}
+    (hx : x ≠ 1) (hy : y ≠ 1) (hxy : x ≠ y) : x * y ∉ ({x, y, 1} : Set G) :=
+  mul_not_mem_of_orderOf_eq_two (orderOf_eq_prime (h ▸ Monoid.pow_exponent_eq_one x) hx)
+    (orderOf_eq_prime (h ▸ Monoid.pow_exponent_eq_one y) hy) hxy
 
-@[simp] theorem c_sq : c ^ 2 = 1 :=
-  rfl
+lemma mul_self_of_orderOf_eq_two {G : Type*} [Group G] {x : G} (hx : orderOf x = 2) : x * x = 1 :=
+  pow_two (a := x) ▸ hx ▸ pow_orderOf_eq_one x
 
-@[simp] theorem orderOf_a : orderOf a = 2 :=
-  orderOf_eq_prime a_sq (by decide)
+end ExponentTwo
 
-@[simp] theorem orderOf_b : orderOf b = 2 :=
-  orderOf_eq_prime b_sq (by decide)
+/-! # Klein four-groups as a mixin class -/
 
-@[simp] theorem orderOf_c : orderOf c = 2 :=
-  orderOf_eq_prime c_sq (by decide)
+/-- An (additive) Klein four-group is an (additive) group of cardinality four and exponent two. -/
+class IsAddKleinFour (G : Type*) [AddGroup G] [Fintype G] : Prop where
+  card_four : Fintype.card G = 4
+  exponent_two : AddMonoid.exponent G = 2
 
-@[simp high]
-theorem exponent : Monoid.exponent KleinFour = 2 := by
-  simp [AddMonoid.exponent_prod]
+/-- A Klein four-group is a group of cardinality four and exponent two. -/
+@[to_additive existing IsAddKleinFour]
+class IsKleinFour (G : Type*) [Group G] [Fintype G] : Prop where
+  card_four : Fintype.card G = 4
+  exponent_two : Monoid.exponent G = 2
 
-/-- Klein four-group is a non-cyclic group. -/
-theorem notIsCyclic : ¬ IsCyclic KleinFour := by
-  intro h
-  have h₁ := IsCyclic.iff_exponent_eq_card.mp h
-  rw [exponent, card] at h₁
-  contradiction
+attribute [simp] IsKleinFour.card_four IsKleinFour.exponent_two
+  IsAddKleinFour.card_four IsAddKleinFour.exponent_two
 
-/-- Klein four-group is isomorphic to the Dihedral group of order 4. -/
-@[simps]
-def mulEquivDihedralGroupTwo : KleinFour ≃* DihedralGroup 2 where
-  toFun := fun
-    | (0, 0) => 1
-    | (0, 1) => sr 1
-    | (1, 0) => r 1
-    | (1, 1) => sr 1 * r 1
-  invFun := fun
-    | 1 => (0, 0)
-    | sr 1 => (0, 1)
-    | r 1 => (1, 0)
-    | sr 1 * r 1 => (1, 1)
-  left_inv := by decide
-  right_inv := by decide
-  map_mul' := by simp (config := {decide := true})
+instance : IsAddKleinFour (ZMod 2 × ZMod 2) where
+  card_four := rfl
+  exponent_two := by simp [AddMonoid.exponent_prod]
 
-end KleinFour
+instance : IsKleinFour (DihedralGroup 2) where
+  card_four := rfl
+  exponent_two := by simp [DihedralGroup.exponent]
+
+instance {G : Type*} [Group G] [Fintype G] [IsKleinFour G] :
+    IsAddKleinFour (Additive G) where
+  card_four := by rw [← IsKleinFour.card_four (G := G)]; congr!
+  exponent_two := by simp
+
+instance {G : Type*} [AddGroup G] [Fintype G] [IsAddKleinFour G] :
+    IsKleinFour (Multiplicative G) where
+  card_four := by rw [← IsAddKleinFour.card_four (G := G)]; congr!
+  exponent_two := by simp
+
+namespace IsKleinFour
+
+open Finset
+
+variable {G : Type*} [Group G] [Fintype G]
+
+/-- A group of order 4 is not cyclic if and only if its exponent is two. -/
+@[to_additive]
+lemma not_isCyclic_iff (hG : Fintype.card G = 4) :
+    ¬ IsCyclic G ↔ Monoid.exponent G = 2 := by
+  refine ⟨fun h_cyc ↦ ?_, fun h_exp h_cyc ↦ by simpa [hG, h_exp] using h_cyc.exponent_eq_card⟩
+  apply le_antisymm
+  · refine Nat.le_of_dvd zero_lt_two <| Monoid.exponent_dvd_of_forall_pow_eq_one G 2 fun g ↦ ?_
+    have hg' : orderOf g ∈ {1, 2, 4} :=
+      (Nat.mem_divisors (m := 4)).mpr ⟨hG ▸ orderOf_dvd_card, by norm_num⟩
+    simp only [mem_singleton, Nat.succ.injEq, OfNat.one_ne_ofNat, mem_insert, or_self,
+      orderOf_eq_one_iff] at hg'
+    obtain (rfl|hg|hg) := hg'
+    · simp
+    · exact hg ▸ pow_orderOf_eq_one g
+    · apply False.elim <| h_cyc <| isCyclic_of_orderOf_eq_card g (hG ▸ hg)
+  · have := (Fintype.one_lt_card_iff_nontrivial (α := G)).mp <| by norm_num [hG]
+    exact Monoid.one_lt_exponent
+
+variable [IsKleinFour G]
+
+@[to_additive]
+lemma not_isCyclic : ¬ IsCyclic G :=
+  fun h ↦ by simpa using h.exponent_eq_card
+
+@[to_additive]
+lemma eq_finset_univ [DecidableEq G]
+    {x y : G} (hx : x ≠ 1) (hy : y ≠ 1) (hxy : x ≠ y) : {x * y, x, y, (1 : G)} = Finset.univ := by
+  apply Finset.eq_univ_of_card
+  rw [card_four]
+  repeat rw [card_insert_of_not_mem]
+  on_goal 4 => simpa using mul_not_mem_of_exponent_two (by simp) hx hy hxy
+  all_goals aesop
+
+@[to_additive]
+lemma eq_mul_of_ne_all {x y z : G} (hx : x ≠ 1)
+    (hy : y ≠ 1) (hxy : x ≠ y) (hz : z ≠ 1) (hzx : z ≠ x) (hzy : z ≠ y) : z = x * y := by
+  classical
+  apply eq_of_not_mem_of_mem_insert <| (eq_finset_univ hx hy hxy).symm ▸ mem_univ _
+  simpa only [mem_singleton, mem_insert, not_or] using ⟨hzx, hzy, hz⟩
+
+variable {G₁ G₂ : Type*} [Group G₁] [Group G₂] [Fintype G₁] [IsKleinFour G₁]
+
+/-- An equivalence between an `IsKleinFour` group `G₁` and a group `G₂` of exponent two which sends
+`1 : G₁` to `1 : G₂` is in fact an isomorphism. -/
+@[to_additive "An equivalence between an `IsAddKleinFour` group `G₁` and a group `G₂` of exponent
+two which sends `0 : G₁` to `0 : G₂` is in fact an isomorphism."]
+def mulEquiv' (e : G₁ ≃ G₂) (he : e 1 = 1) (h : Monoid.exponent G₂ = 2) : G₁ ≃* G₂ where
+  toEquiv := e
+  map_mul' := by
+    let _ := Fintype.ofEquiv G₁ e
+    intro x y
+    by_cases hx : x = 1 <;> by_cases hy : y = 1
+    all_goals try simp only [hx, hy, mul_one, one_mul, Equiv.toFun_as_coe, he]
+    by_cases hxy : x = y
+    · simp [hxy, ← pow_two, exponent_two (G := G₁) ▸ Monoid.pow_exponent_eq_one y,
+      h ▸ Monoid.pow_exponent_eq_one (e y), he]
+    · classical
+      have univ₂ : {e (x * y), e x, e y, (1 : G₂)} = Finset.univ := by
+        simpa [map_univ_equiv e, map_insert, he]
+          using congr(Finset.map e.toEmbedding $(eq_finset_univ hx hy hxy))
+      rw [←Ne.def, ←e.injective.ne_iff] at hx hy hxy
+      rw [he] at hx hy
+      symm
+      apply eq_of_not_mem_of_mem_insert <| univ₂.symm ▸ mem_univ _
+      simpa using mul_not_mem_of_exponent_two h hx hy hxy
+
+/-- Any two `IsKleinFour` groups are isomorphic via any equivalence which sends the identity of one
+group to the identity of the other. -/
+@[to_additive (attr := reducible) "Any two `IsAddKleinFour` groups are isomorphic via any
+equivalence which sends the identity of one group to the identity of the other."]
+def mulEquiv [Fintype G₂] [IsKleinFour G₂] (e : G₁ ≃ G₂) (he : e 1 = 1) : G₁ ≃* G₂ :=
+  mulEquiv' e he exponent_two
+
+end IsKleinFour

--- a/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
@@ -45,19 +45,6 @@ section ExponentTwo
 
 variable {G : Type*} [Group G]
 
-@[to_additive AddMonoid.one_lt_exponent]
-lemma Monoid.one_lt_exponent {G : Type*} [LeftCancelMonoid G] [Finite G] [Nontrivial G] :
-    1 < Monoid.exponent G := by
-  let _inst := Fintype.ofFinite G
-  obtain ⟨g, hg⟩ := exists_ne (1 : G)
-  rw [Ne.def, ← orderOf_eq_one_iff] at hg
-  rw [← Monoid.lcm_order_eq_exponent, ← Nat.succ_le_iff]
-  have hg' : 2 ≤ orderOf g := Nat.lt_of_le_of_ne (orderOf_pos g) (Ne.symm hg)
-  refine hg'.trans <| Nat.le_of_dvd ?_ <| Finset.dvd_lcm (by simp)
-  rw [Nat.pos_iff_ne_zero, Ne.def, Finset.lcm_eq_zero_iff]
-  rintro ⟨x, -, hx⟩
-  exact (orderOf_pos x).ne' hx
-
 /-- In a group of exponent two, every element is its own inverse. -/
 @[to_additive]
 lemma inv_eq_self_of_exponent_two (hG : Monoid.exponent G = 2) (x : G) :
@@ -95,9 +82,6 @@ lemma mul_not_mem_of_exponent_two {G : Type*} [Group G] (h : Monoid.exponent G =
     (hx : x ≠ 1) (hy : y ≠ 1) (hxy : x ≠ y) : x * y ∉ ({x, y, 1} : Set G) :=
   mul_not_mem_of_orderOf_eq_two (orderOf_eq_prime (h ▸ Monoid.pow_exponent_eq_one x) hx)
     (orderOf_eq_prime (h ▸ Monoid.pow_exponent_eq_one y) hy) hxy
-
-lemma mul_self_of_orderOf_eq_two {G : Type*} [Group G] {x : G} (hx : orderOf x = 2) : x * x = 1 :=
-  pow_two (a := x) ▸ hx ▸ pow_orderOf_eq_one x
 
 end ExponentTwo
 

--- a/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
@@ -58,6 +58,11 @@ lemma inv_eq_self_of_orderOf_eq_two {x : G} (hx : orderOf x = 2) :
     x⁻¹ = x :=
   inv_eq_of_mul_eq_one_left <| pow_two (a := x) ▸ hx ▸ pow_orderOf_eq_one x
 
+@[to_additive]
+lemma orderOf_eq_two_iff (hG : Monoid.exponent G = 2) {x : G} :
+    orderOf x = 2 ↔ x ≠ 1 :=
+  ⟨by rintro hx rfl; norm_num at hx, orderOf_eq_prime (hG ▸ Monoid.pow_exponent_eq_one x)⟩
+
 /-- In a group of exponent two, all elements commute. -/
 @[to_additive]
 lemma mul_comm_of_exponent_two (hG : Monoid.exponent G = 2) (x y : G) :
@@ -150,6 +155,13 @@ variable [IsKleinFour G]
 lemma not_isCyclic : ¬ IsCyclic G :=
   fun h ↦ by simpa using h.exponent_eq_card
 
+@[to_additive (attr := simp)]
+lemma inv_eq_self (x : G) : x⁻¹ = x := inv_eq_self_of_exponent_two (by simp) x
+
+@[to_additive (attr := simp)]
+lemma mul_self (x : G) : x * x = 1 := by
+  rw [mul_eq_one_iff_eq_inv, inv_eq_self]
+
 @[to_additive]
 lemma eq_finset_univ [DecidableEq G]
     {x y : G} (hx : x ≠ 1) (hy : y ≠ 1) (hxy : x ≠ y) : {x * y, x, y, (1 : G)} = Finset.univ := by
@@ -180,8 +192,7 @@ def mulEquiv' (e : G₁ ≃ G₂) (he : e 1 = 1) (h : Monoid.exponent G₂ = 2) 
     by_cases hx : x = 1 <;> by_cases hy : y = 1
     all_goals try simp only [hx, hy, mul_one, one_mul, Equiv.toFun_as_coe, he]
     by_cases hxy : x = y
-    · simp [hxy, ← pow_two, exponent_two (G := G₁) ▸ Monoid.pow_exponent_eq_one y,
-      h ▸ Monoid.pow_exponent_eq_one (e y), he]
+    · simp [hxy, ← pow_two (e y), h ▸ Monoid.pow_exponent_eq_one (e y), he]
     · classical
       have univ₂ : {e (x * y), e x, e y, (1 : G₂)} = Finset.univ := by
         simpa [map_univ_equiv e, map_insert, he]

--- a/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
@@ -223,4 +223,12 @@ equivalence which sends the identity of one group to the identity of the other."
 def mulEquiv [IsKleinFour G₂] (e : G₁ ≃ G₂) (he : e 1 = 1) : G₁ ≃* G₂ :=
   mulEquiv' e he exponent_two
 
+/-- Any two `IsKleinFour` groups are isomorphic. -/
+@[to_additive "Any two `IsAddKleinFour` groups are isomorphic."]
+lemma nonempty_mulEquiv [IsKleinFour G₂] : Nonempty (G₁ ≃* G₂) := by
+  classical
+  let _inst₁ := Fintype.ofFinite G₁
+  let _inst₁ := Fintype.ofFinite G₂
+  exact ⟨mulEquiv ((Fintype.equivOfCardEq <| by simp).setValue 1 1) <| by simp⟩
+
 end IsKleinFour

--- a/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
@@ -77,11 +77,9 @@ def instCommGroupOfExponentTwo (hG : Monoid.exponent G = 2) : CommGroup G where
 @[to_additive]
 lemma mul_not_mem_of_orderOf_eq_two {G : Type*} [Group G] {x y : G} (hx : orderOf x = 2)
     (hy : orderOf y = 2) (hxy : x ≠ y) : x * y ∉ ({x, y, 1} : Set G) := by
-  simp only [Set.mem_singleton_iff, Set.mem_insert_iff, mul_right_eq_self, mul_left_eq_self, not_or]
-  refine ⟨?_, ?_, fun h' ↦ hxy <| by
-    simpa only [mul_eq_one_iff_eq_inv, inv_eq_self_of_orderOf_eq_two hx,
-      inv_eq_self_of_orderOf_eq_two hy] using h'⟩
-  all_goals rw [← orderOf_eq_one_iff]; norm_num [hy, hx]
+  simp only [Set.mem_singleton_iff, Set.mem_insert_iff, mul_right_eq_self, mul_left_eq_self,
+    mul_eq_one_iff_eq_inv, inv_eq_self_of_orderOf_eq_two hy, not_or]
+  aesop
 
 @[to_additive]
 lemma mul_not_mem_of_exponent_two {G : Type*} [Group G] (h : Monoid.exponent G = 2) {x y : G}

--- a/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
@@ -155,10 +155,10 @@ variable [IsKleinFour G]
 lemma not_isCyclic : ¬ IsCyclic G :=
   fun h ↦ by simpa using h.exponent_eq_card
 
-@[to_additive (attr := simp)]
+@[to_additive]
 lemma inv_eq_self (x : G) : x⁻¹ = x := inv_eq_self_of_exponent_two (by simp) x
 
-@[to_additive (attr := simp)]
+@[to_additive]
 lemma mul_self (x : G) : x * x = 1 := by
   rw [mul_eq_one_iff_eq_inv, inv_eq_self]
 
@@ -192,7 +192,7 @@ def mulEquiv' (e : G₁ ≃ G₂) (he : e 1 = 1) (h : Monoid.exponent G₂ = 2) 
     by_cases hx : x = 1 <;> by_cases hy : y = 1
     all_goals try simp only [hx, hy, mul_one, one_mul, Equiv.toFun_as_coe, he]
     by_cases hxy : x = y
-    · simp [hxy, ← pow_two (e y), h ▸ Monoid.pow_exponent_eq_one (e y), he]
+    · simp [hxy, mul_self, ← pow_two (e y), h ▸ Monoid.pow_exponent_eq_one (e y), he]
     · classical
       have univ₂ : {e (x * y), e x, e y, (1 : G₂)} = Finset.univ := by
         simpa [map_univ_equiv e, map_insert, he]

--- a/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
@@ -136,29 +136,7 @@ lemma card_four' {G : Type*} [Group G] [Fintype G] [IsKleinFour G] :
 
 open Finset
 
-variable {G : Type*} [Group G]
-
-/-- A group of order 4 is not cyclic if and only if its exponent is two. -/
-@[to_additive]
-lemma not_isCyclic_iff (hG : Nat.card G = 4) :
-    ¬ IsCyclic G ↔ Monoid.exponent G = 2 := by
-  let _inst : Fintype G := @Fintype.ofFinite G <| Nat.finite_of_card_ne_zero <| by norm_num [hG]
-  have hG' : Fintype.card G = 4 := by simpa using hG
-  refine ⟨fun h_cyc ↦ ?_, fun h_exp h_cyc ↦ by simpa [hG', h_exp] using h_cyc.exponent_eq_card⟩
-  apply le_antisymm
-  · refine Nat.le_of_dvd zero_lt_two <| Monoid.exponent_dvd_of_forall_pow_eq_one G 2 fun g ↦ ?_
-    have hg' : orderOf g ∈ {1, 2, 4} :=
-      (Nat.mem_divisors (m := 4)).mpr ⟨hG' ▸ orderOf_dvd_card, by norm_num⟩
-    simp only [mem_singleton, Nat.succ.injEq, OfNat.one_ne_ofNat, mem_insert, or_self,
-      orderOf_eq_one_iff] at hg'
-    obtain (rfl|hg|hg) := hg'
-    · simp
-    · exact hg ▸ pow_orderOf_eq_one g
-    · apply False.elim <| h_cyc <| isCyclic_of_orderOf_eq_card g (hG' ▸ hg)
-  · have := (Fintype.one_lt_card_iff_nontrivial (α := G)).mp <| by norm_num [hG']
-    exact Monoid.one_lt_exponent
-
-variable [IsKleinFour G]
+variable {G : Type*} [Group G] [IsKleinFour G]
 
 @[to_additive]
 lemma not_isCyclic : ¬ IsCyclic G :=

--- a/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
@@ -15,9 +15,10 @@ produces the third one.
 
 ## Main definitions
 
-* `KleinFour` : Klein four-group with elements `e`, `a`, `b`, and `c`, which is defined
-  in terms of `Multiplicative (ZMod 2 × ZMod 2)`.
-* `mulEquivDihedralGroup2` : Klein four-group is isomorphic to `DihedralGroup 2`.
+* `IsKleinFour` : A mixin class which states that the group has order four and exponent two.
+* `mulEquiv'` : An equivalence between a Klein four-group and a group of exponent two which
+  preserves the identity is in fact an isomorphism.
+* `mulEquiv`: Any two Klein four-groups are isomorphic via any identity preserving equivalence.
 
 ## References
 
@@ -26,7 +27,7 @@ produces the third one.
 
 ## TODO
 
-* Prove `KleinFour` is isomorphic to the normal subgroup of `alternatingGroup (Fin 4)`
+* Prove an `IsKleinFour` group is isomorphic to the normal subgroup of `alternatingGroup (Fin 4)`
   with the permutation cycles `V = {(), (1 2)(3 4), (1 3)(2 4), (1 4)(2 3)}`.  This is the kernel
   of the surjection of `alternatingGroup (Fin 4)` onto `alternatingGroup (Fin 3) ≃ (ZMod 3)`.
   In other words, we have the exact sequence `V → A₄ → A₃`.

--- a/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
@@ -145,6 +145,12 @@ lemma not_isCyclic : ¬ IsCyclic G :=
 @[to_additive]
 lemma inv_eq_self (x : G) : x⁻¹ = x := inv_eq_self_of_exponent_two (by simp) x
 
+/- this is not an appropriate global `simp` lemma for a `Prop`-mixin class. Indeed, if it were
+then every time Lean sees `·⁻¹` it would try to apply `inv_eq_self` which would trigger
+type class inference to try and synthesize an `IsKleinFour` instance. -/
+scoped[IsKleinFour] attribute [simp] inv_eq_self
+scoped[IsAddKleinFour] attribute [simp] neg_eq_self
+
 @[to_additive]
 lemma mul_self (x : G) : x * x = 1 := by
   rw [mul_eq_one_iff_eq_inv, inv_eq_self]


### PR DESCRIPTION
This removes `KleinFour` in favor of a class `IsKleinFour` and proves that any two `IsKleinFour` groups are isomorphic via any identity-preserving equivalence. In addition, we prove that a group of order 4 is not cyclic if and only if it has exponent two.

There are several advantages:

1. this provides a general API accessible by other groups
2. we prove some generic facts about groups of exponent two
3. it is easy to `@[to_additive]` everything

If we want, we can always redefine an explicit `KleinFour` group, and give it an `IsKleinFour` instance. In that case we probably want to make a bespoke type for it, so that it can be `to_additive`-ized.

---

I deleted the `KleinFour` definition (and related material) primarily because it doesn't allow for a `to_additive` version. I'm happy to revert that deletion though if it's preferred.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
