### PR TITLE
[Merged by Bors] - feat: Mapping extreme points under continuous maps

### DIFF
--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -62,10 +62,7 @@ open Function
 
 universe u u' v w x y z
 
-variable {R : Type*} {R₁ : Type*} {R₂ : Type*} {R₃ : Type*}
-variable {k : Type*} {S : Type*} {S₃ : Type*} {T : Type*}
-variable {M : Type*} {M₁ : Type*} {M₂ : Type*} {M₃ : Type*}
-variable {N₁ : Type*} {N₂ : Type*} {N₃ : Type*} {ι : Type*}
+variable {R R₁ R₂ R₃ k S S₃ T M M₁ M₂ M₃ N₁ N₂ N₃ ι : Type*}
 
 /-- A map `f` between modules over a semiring is linear if it satisfies the two properties
 `f (x + y) = f x + f y` and `f (c • x) = c • f x`. The predicate `IsLinearMap R f` asserts this
@@ -87,7 +84,7 @@ is semilinear if it satisfies the two properties `f (x + y) = f x + f y` and
 `M →ₛₗ[σ] M₂`) are bundled versions of such maps. For plain linear maps (i.e. for which
 `σ = RingHom.id R`), the notation `M →ₗ[R] M₂` is available. An unbundled version of plain linear
 maps is available with the predicate `IsLinearMap`, but it should be avoided most of the time. -/
-structure LinearMap {R : Type*} {S : Type*} [Semiring R] [Semiring S] (σ : R →+* S) (M : Type*)
+structure LinearMap {R S : Type*} [Semiring R] [Semiring S] (σ : R →+* S) (M : Type*)
     (M₂ : Type*) [AddCommMonoid M] [AddCommMonoid M₂] [Module R M] [Module S M₂] extends
     AddHom M M₂ where
   /-- A linear map preserves scalar multiplication.
@@ -150,7 +147,6 @@ namespace SemilinearMapClass
 variable (F : Type*)
 variable [Semiring R] [Semiring S]
 variable [AddCommMonoid M] [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
-variable [AddCommMonoid N₁] [AddCommMonoid N₂] [AddCommMonoid N₃]
 variable [Module R M] [Module R M₂] [Module S M₃]
 variable {σ : R →+* S}
 
@@ -174,7 +170,22 @@ theorem map_smul_inv {σ' : S →+* R} [RingHomInvPair σ σ'] (c : S) (x : M) :
     c • f x = f (σ' c • x) := by simp
 #align semilinear_map_class.map_smul_inv SemilinearMapClass.map_smul_inv
 
+/-- Reinterpret an element of a type of semilinear maps as a semilinear map. -/
+abbrev semilinearMap : M →ₛₗ[σ] M₃ where
+  toFun := f
+  map_add' := map_add f
+  map_smul' := map_smulₛₗ f
+
 end SemilinearMapClass
+
+namespace LinearMapClass
+variable {F : Type*} [Semiring R] [AddCommMonoid M₁] [AddCommMonoid M₂] [Module R M₁] [Module R M₂]
+  (f : F) [LinearMapClass F R M₁ M₂]
+
+/-- Reinterpret an element of a type of linear maps as a linear map. -/
+abbrev linearMap : M₁ →ₗ[R] M₂ := SemilinearMapClass.semilinearMap f
+
+end LinearMapClass
 
 namespace LinearMap
 
@@ -566,7 +577,7 @@ theorem id_comp : id.comp f = f :=
 #align linear_map.id_comp LinearMap.id_comp
 
 theorem comp_assoc
-    {R₄ : Type*} {M₄ : Type*} [Semiring R₄] [AddCommMonoid M₄] [Module R₄ M₄]
+    {R₄ M₄ : Type*} [Semiring R₄] [AddCommMonoid M₄] [Module R₄ M₄]
     {σ₃₄ : R₃ →+* R₄} {σ₂₄ : R₂ →+* R₄} {σ₁₄ : R₁ →+* R₄}
     [RingHomCompTriple σ₂₃ σ₃₄ σ₂₄] [RingHomCompTriple σ₁₃ σ₃₄ σ₁₄] [RingHomCompTriple σ₁₂ σ₂₄ σ₁₄]
     (f : M₁ →ₛₗ[σ₁₂] M₂) (g : M₂ →ₛₗ[σ₂₃] M₃) (h : M₃ →ₛₗ[σ₃₄] M₄) :

--- a/Mathlib/Analysis/Convex/Exposed.lean
+++ b/Mathlib/Analysis/Convex/Exposed.lean
@@ -265,7 +265,7 @@ protected theorem isExtreme (hAB : IsExposed 𝕜 A B) : IsExtreme 𝕜 A B := b
 end IsExposed
 
 theorem exposedPoints_subset_extremePoints : A.exposedPoints 𝕜 ⊆ A.extremePoints 𝕜 := fun _ hx =>
-  mem_extremePoints_iff_extreme_singleton.2 (mem_exposedPoints_iff_exposed_singleton.1 hx).isExtreme
+  (mem_exposedPoints_iff_exposed_singleton.1 hx).isExtreme.mem_extremePoints
 #align exposed_points_subset_extreme_points exposedPoints_subset_extremePoints
 
 end LinearOrderedRing

--- a/Mathlib/Analysis/Convex/Extreme.lean
+++ b/Mathlib/Analysis/Convex/Extreme.lean
@@ -238,27 +238,13 @@ variable {L : Type*} [OrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E] [AddCom
 
 lemma image_extremePoints (f : L) (s : Set E) :
     f '' extremePoints 𝕜 s = extremePoints 𝕜 (f '' s) := by
-  ext
-  -- TODO: This is absolutely horrible. If we can't have coercions `F → HomType α β` from
-  -- `HomClass F α β`, can we at least have a bare function?
-  have := by simpa using image_openSegment _ {
-    toFun := f
-    linear.toFun := f
-    linear.map_add' := map_add f
-    linear.map_smul' := map_smulₛₗ f
-    map_vadd' := by simp }
-  simp only [mem_extremePoints, ←Equiv.forall_congr_left {
-        toFun := f
-        invFun := EquivLike.inv f
-        left_inv := EquivLike.left_inv f
-        right_inv := EquivLike.right_inv f
-      }, ←exists_and_right, mem_image, Equiv.coe_fn_mk,
-        LinearEquiv.coe_toEquiv, EmbeddingLike.apply_eq_iff_eq, exists_eq_right, ←this]
-  constructor
-  · rintro ⟨x, ⟨hx, hxs⟩, rfl⟩
-    exact ⟨x, ⟨hx, rfl⟩, by simpa using hxs⟩
-  · rintro ⟨x, ⟨hx, rfl⟩, hxs⟩
-    exact ⟨x, ⟨hx, by simpa using hxs⟩, rfl⟩
+  ext b
+  rcases EquivLike.surjective f b with ⟨a, rfl⟩
+  have : ∀ x y, f '' openSegment 𝕜 x y = openSegment 𝕜 (f x) (f y) :=
+    image_openSegment _ <| LinearMap.toAffineMap
+      { toFun := f, map_add' := map_add f, map_smul' := map_smul f}
+  simp only [mem_extremePoints, (EquivLike.surjective f).forall,
+    (EquivLike.injective f).mem_set_image, (EquivLike.injective f).eq_iff, ← this]
 
 end OrderedRing
 

--- a/Mathlib/Analysis/Convex/Extreme.lean
+++ b/Mathlib/Analysis/Convex/Extreme.lean
@@ -233,14 +233,27 @@ theorem extremePoints_pi (s : ∀ i, Set (π i)) :
 end OrderedSemiring
 
 section OrderedRing
-variable [OrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E] [AddCommGroup F] [Module 𝕜 F]
+variable {L : Type*} [OrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E] [AddCommGroup F] [Module 𝕜 F]
+  [LinearEquivClass L 𝕜 E F]
 
-lemma image_extremePoints (f : E ≃ₗ[𝕜] F) (s : Set E) :
+lemma image_extremePoints (f : L) (s : Set E) :
     f '' extremePoints 𝕜 s = extremePoints 𝕜 (f '' s) := by
   ext
-  have := by simpa using image_openSegment _ f.toAffineMap
-  simp only [mem_extremePoints, ←f.toEquiv.forall_congr_left, ←exists_and_right, mem_image,
-    LinearEquiv.coe_toEquiv, EmbeddingLike.apply_eq_iff_eq, exists_eq_right, ←this]
+  -- TODO: This is absolutely horrible. If we can't have coercions `F → HomType α β` from
+  -- `HomClass F α β`, can we at least have a bare function?
+  have := by simpa using image_openSegment _ {
+    toFun := f
+    linear.toFun := f
+    linear.map_add' := map_add f
+    linear.map_smul' := map_smulₛₗ f
+    map_vadd' := by simp }
+  simp only [mem_extremePoints, ←Equiv.forall_congr_left {
+        toFun := f
+        invFun := EquivLike.inv f
+        left_inv := EquivLike.left_inv f
+        right_inv := EquivLike.right_inv f
+      }, ←exists_and_right, mem_image, Equiv.coe_fn_mk,
+        LinearEquiv.coe_toEquiv, EmbeddingLike.apply_eq_iff_eq, exists_eq_right, ←this]
   constructor
   · rintro ⟨x, ⟨hx, hxs⟩, rfl⟩
     exact ⟨x, ⟨hx, rfl⟩, by simpa using hxs⟩

--- a/Mathlib/Analysis/Convex/Extreme.lean
+++ b/Mathlib/Analysis/Convex/Extreme.lean
@@ -140,7 +140,7 @@ theorem mem_extremePoints : x ∈ A.extremePoints 𝕜 ↔
   exact hAx hx₁A hx₂A
 #align mem_extreme_points_iff_extreme_singleton isExtreme_singleton
 
-alias ⟨_, IsExtreme.mem_extremePoints⟩ := isExtreme_singleton
+alias ⟨IsExtreme.mem_extremePoints, _⟩ := isExtreme_singleton
 
 theorem extremePoints_subset : A.extremePoints 𝕜 ⊆ A :=
   fun _ hx ↦ hx.1

--- a/Mathlib/Analysis/Convex/Extreme.lean
+++ b/Mathlib/Analysis/Convex/Extreme.lean
@@ -123,12 +123,7 @@ theorem isExtreme_biInter {F : Set (Set E)} (hF : F.Nonempty) (hA : ∀ B ∈ F,
 #align is_extreme_bInter isExtreme_biInter
 
 theorem isExtreme_sInter {F : Set (Set E)} (hF : F.Nonempty) (hAF : ∀ B ∈ F, IsExtreme 𝕜 A B) :
-    IsExtreme 𝕜 A (⋂₀ F) := by
-  obtain ⟨B, hB⟩ := hF
-  refine' ⟨(sInter_subset_of_mem hB).trans (hAF B hB).1, fun x₁ hx₁A x₂ hx₂A x hxF hx ↦ _⟩
-  simp_rw [mem_sInter] at hxF ⊢
-  have h := fun B hB ↦ (hAF B hB).2 hx₁A hx₂A (hxF B hB) hx
-  exact ⟨fun B hB ↦ (h B hB).1, fun B hB ↦ (h B hB).2⟩
+    IsExtreme 𝕜 A (⋂₀ F) := by simpa [sInter_eq_biInter] using isExtreme_biInter hF hAF
 #align is_extreme_sInter isExtreme_sInter
 
 theorem mem_extremePoints : x ∈ A.extremePoints 𝕜 ↔
@@ -137,13 +132,15 @@ theorem mem_extremePoints : x ∈ A.extremePoints 𝕜 ↔
 #align mem_extreme_points mem_extremePoints
 
 /-- x is an extreme point to A iff {x} is an extreme set of A. -/
-theorem mem_extremePoints_iff_extreme_singleton : x ∈ A.extremePoints 𝕜 ↔ IsExtreme 𝕜 A {x} := by
-  refine' ⟨_, fun hx ↦ ⟨singleton_subset_iff.1 hx.1, fun x₁ hx₁ x₂ hx₂ ↦ hx.2 hx₁ hx₂ rfl⟩⟩
+@[simp] lemma isExtreme_singleton : IsExtreme 𝕜 A {x} ↔ x ∈ A.extremePoints 𝕜 := by
+  refine ⟨fun hx ↦ ⟨singleton_subset_iff.1 hx.1, fun x₁ hx₁ x₂ hx₂ ↦ hx.2 hx₁ hx₂ rfl⟩, ?_⟩
   rintro ⟨hxA, hAx⟩
   use singleton_subset_iff.2 hxA
   rintro x₁ hx₁A x₂ hx₂A y (rfl : y = x)
   exact hAx hx₁A hx₂A
-#align mem_extreme_points_iff_extreme_singleton mem_extremePoints_iff_extreme_singleton
+#align mem_extreme_points_iff_extreme_singleton isExtreme_singleton
+
+alias ⟨_, IsExtreme.mem_extremePoints⟩ := isExtreme_singleton
 
 theorem extremePoints_subset : A.extremePoints 𝕜 ⊆ A :=
   fun _ hx ↦ hx.1
@@ -167,8 +164,7 @@ theorem inter_extremePoints_subset_extremePoints_of_subset (hBA : B ⊆ A) :
 
 theorem IsExtreme.extremePoints_subset_extremePoints (hAB : IsExtreme 𝕜 A B) :
     B.extremePoints 𝕜 ⊆ A.extremePoints 𝕜 :=
-  fun _ hx ↦ mem_extremePoints_iff_extreme_singleton.2
-    (hAB.trans (mem_extremePoints_iff_extreme_singleton.1 hx))
+  fun _ ↦ by simpa only [←isExtreme_singleton] using hAB.trans
 #align is_extreme.extreme_points_subset_extreme_points IsExtreme.extremePoints_subset_extremePoints
 
 theorem IsExtreme.extremePoints_eq (hAB : IsExtreme 𝕜 A B) :
@@ -236,6 +232,23 @@ theorem extremePoints_pi (s : ∀ i, Set (π i)) :
 
 end OrderedSemiring
 
+section OrderedRing
+variable [OrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E] [AddCommGroup F] [Module 𝕜 F]
+
+lemma image_extremePoints (f : E ≃ₗ[𝕜] F) (s : Set E) :
+    f '' extremePoints 𝕜 s = extremePoints 𝕜 (f '' s) := by
+  ext
+  have := by simpa using image_openSegment _ f.toAffineMap
+  simp only [mem_extremePoints, ←f.toEquiv.forall_congr_left, ←exists_and_right, mem_image,
+    LinearEquiv.coe_toEquiv, EmbeddingLike.apply_eq_iff_eq, exists_eq_right, ←this]
+  constructor
+  · rintro ⟨x, ⟨hx, hxs⟩, rfl⟩
+    exact ⟨x, ⟨hx, rfl⟩, by simpa using hxs⟩
+  · rintro ⟨x, ⟨hx, rfl⟩, hxs⟩
+    exact ⟨x, ⟨hx, by simpa using hxs⟩, rfl⟩
+
+end OrderedRing
+
 section LinearOrderedRing
 
 variable [LinearOrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E]
@@ -258,7 +271,7 @@ theorem mem_extremePoints_iff_forall_segment : x ∈ A.extremePoints 𝕜 ↔
 
 theorem Convex.mem_extremePoints_iff_convex_diff (hA : Convex 𝕜 A) :
     x ∈ A.extremePoints 𝕜 ↔ x ∈ A ∧ Convex 𝕜 (A \ {x}) := by
-  use fun hx ↦ ⟨hx.1, (mem_extremePoints_iff_extreme_singleton.1 hx).convex_diff hA⟩
+  use fun hx ↦ ⟨hx.1, (isExtreme_singleton.2 hx).convex_diff hA⟩
   rintro ⟨hxA, hAx⟩
   refine' mem_extremePoints_iff_forall_segment.2 ⟨hxA, fun x₁ hx₁ x₂ hx₂ hx ↦ _⟩
   rw [convex_iff_segment_subset] at hAx

--- a/Mathlib/Analysis/Convex/Extreme.lean
+++ b/Mathlib/Analysis/Convex/Extreme.lean
@@ -239,10 +239,9 @@ variable {L : Type*} [OrderedRing 𝕜] [AddCommGroup E] [Module 𝕜 E] [AddCom
 lemma image_extremePoints (f : L) (s : Set E) :
     f '' extremePoints 𝕜 s = extremePoints 𝕜 (f '' s) := by
   ext b
-  rcases EquivLike.surjective f b with ⟨a, rfl⟩
+  obtain ⟨a, rfl⟩ := EquivLike.surjective f b
   have : ∀ x y, f '' openSegment 𝕜 x y = openSegment 𝕜 (f x) (f y) :=
-    image_openSegment _ <| LinearMap.toAffineMap
-      { toFun := f, map_add' := map_add f, map_smul' := map_smul f}
+    image_openSegment _ (LinearMapClass.linearMap f).toAffineMap
   simp only [mem_extremePoints, (EquivLike.surjective f).forall,
     (EquivLike.injective f).mem_set_image, (EquivLike.injective f).eq_iff, ← this]
 

--- a/Mathlib/Analysis/Convex/KreinMilman.lean
+++ b/Mathlib/Analysis/Convex/KreinMilman.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Analysis.Convex.Exposed
 import Mathlib.Analysis.NormedSpace.HahnBanach.Separation
+import Mathlib.Topology.Algebra.ContinuousAffineMap
 
 #align_import analysis.convex.krein_milman from "leanprover-community/mathlib"@"279297937dede7b1b3451b7b0f1786352ad011fa"
 
@@ -51,16 +52,15 @@ See chapter 8 of [Barry Simon, *Convexity*][simon2011]
 
 -/
 
-
 open Set
+open scoped Classical
 
-open Classical
-
-variable {E : Type*} [AddCommGroup E] [Module ℝ E] [TopologicalSpace E] [T2Space E]
+variable {E F : Type*} [AddCommGroup E] [Module ℝ E] [TopologicalSpace E] [T2Space E]
   [TopologicalAddGroup E] [ContinuousSMul ℝ E] [LocallyConvexSpace ℝ E] {s : Set E}
+  [AddCommGroup F] [Module ℝ F] [TopologicalSpace F] [T1Space F]
 
 /-- **Krein-Milman lemma**: In a LCTVS, any nonempty compact set has an extreme point. -/
-theorem IsCompact.has_extreme_point (hscomp : IsCompact s) (hsnemp : s.Nonempty) :
+theorem IsCompact.extremePoints_nonempty (hscomp : IsCompact s) (hsnemp : s.Nonempty) :
     (s.extremePoints ℝ).Nonempty := by
   let S : Set (Set E) := { t | t.Nonempty ∧ IsClosed t ∧ IsExtreme ℝ s t }
   rsuffices ⟨t, ⟨⟨x, hxt⟩, htclos, hst⟩, hBmin⟩ : ∃ t ∈ S, ∀ u ∈ S, u ⊆ t → u = t
@@ -88,7 +88,7 @@ theorem IsCompact.has_extreme_point (hscomp : IsCompact s) (hsnemp : s.Nonempty)
       (hFS t.mem).2.1
   obtain htu | hut := hF.total t.mem u.mem
   exacts [⟨t, Subset.rfl, htu⟩, ⟨u, hut, Subset.rfl⟩]
-#align is_compact.has_extreme_point IsCompact.has_extreme_point
+#align is_compact.has_extreme_point IsCompact.extremePoints_nonempty
 
 /-- **Krein-Milman theorem**: In a LCTVS, any compact convex set is the closure of the convex hull
     of its extreme points. -/
@@ -101,7 +101,24 @@ theorem closure_convexHull_extremePoints (hscomp : IsCompact s) (hAconv : Convex
     geometric_hahn_banach_closed_point (convex_convexHull _ _).closure isClosed_closure hxt
   have h : IsExposed ℝ s ({ y ∈ s | ∀ z ∈ s, l z ≤ l y }) := fun _ => ⟨l, rfl⟩
   obtain ⟨z, hzA, hz⟩ := hscomp.exists_forall_ge ⟨x, hxA⟩ l.continuous.continuousOn
-  obtain ⟨y, hy⟩ := (h.isCompact hscomp).has_extreme_point ⟨z, hzA, hz⟩
+  obtain ⟨y, hy⟩ := (h.isCompact hscomp).extremePoints_nonempty ⟨z, hzA, hz⟩
   linarith [hlr _ (subset_closure <| subset_convexHull _ _ <|
     h.isExtreme.extremePoints_subset_extremePoints hy), hy.1.2 x hxA]
 #align closure_convex_hull_extreme_points closure_convexHull_extremePoints
+
+/-- A continuous affine map sends extreme points of a compact set to a superset of the extreme
+points of the image of that set. This inclusion is in general strict. -/
+lemma extremePoints_image_subset_image_extremePoints (f : E →A[ℝ] F) (hs : IsCompact s) :
+    extremePoints ℝ (f '' s) ⊆ f '' extremePoints ℝ s := by
+  rintro w hw
+  -- The fiber of `w` is nonempty and compact
+  have ht : IsCompact {x ∈ s | f x = w} := hs.inter_right $ isClosed_singleton.preimage f.continuous
+  have ht₀ : {x ∈ s | f x = w}.Nonempty := by simpa using extremePoints_subset hw
+  -- Hence by the Krein-Milman lemma it has an extreme point `x`
+  obtain ⟨x, ⟨hx, rfl⟩, hyt⟩ := ht.extremePoints_nonempty ht₀
+  -- `f x = w` and `x` is an extreme point of `s`, so we're done
+  refine mem_image_of_mem _ ⟨hx, fun y hy z hz hxyz ↦ ?_⟩
+  have := by simpa using image_openSegment _ f.toAffineMap y z
+  have := hw.2 (mem_image_of_mem _ hy) (mem_image_of_mem _ hz) $ by
+    rw [←this]; exact mem_image_of_mem _ hxyz
+  exact hyt ⟨hy, this.1⟩ ⟨hz, this.2⟩ hxyz

--- a/Mathlib/Analysis/Convex/KreinMilman.lean
+++ b/Mathlib/Analysis/Convex/KreinMilman.lean
@@ -64,7 +64,7 @@ theorem IsCompact.extremePoints_nonempty (hscomp : IsCompact s) (hsnemp : s.None
     (s.extremePoints ℝ).Nonempty := by
   let S : Set (Set E) := { t | t.Nonempty ∧ IsClosed t ∧ IsExtreme ℝ s t }
   rsuffices ⟨t, ⟨⟨x, hxt⟩, htclos, hst⟩, hBmin⟩ : ∃ t ∈ S, ∀ u ∈ S, u ⊆ t → u = t
-  · refine' ⟨x, mem_extremePoints_iff_extreme_singleton.2 _⟩
+  · refine ⟨x, IsExtreme.mem_extremePoints ?_⟩
     rwa [← eq_singleton_iff_unique_mem.2 ⟨hxt, fun y hyB => ?_⟩]
     by_contra hyx
     obtain ⟨l, hl⟩ := geometric_hahn_banach_point_point hyx

--- a/Mathlib/Analysis/Convex/KreinMilman.lean
+++ b/Mathlib/Analysis/Convex/KreinMilman.lean
@@ -106,10 +106,10 @@ theorem closure_convexHull_extremePoints (hscomp : IsCompact s) (hAconv : Convex
     h.isExtreme.extremePoints_subset_extremePoints hy), hy.1.2 x hxA]
 #align closure_convex_hull_extreme_points closure_convexHull_extremePoints
 
-/-- A continuous affine map sends extreme points of a compact set to a superset of the extreme
+/-- A continuous affine map is surjective from the extreme points of a compact set to the extreme
 points of the image of that set. This inclusion is in general strict. -/
-lemma extremePoints_image_subset_image_extremePoints (f : E →A[ℝ] F) (hs : IsCompact s) :
-    extremePoints ℝ (f '' s) ⊆ f '' extremePoints ℝ s := by
+lemma surjOn_extremePoints_image (f : E →A[ℝ] F) (hs : IsCompact s) :
+    SurjOn f (extremePoints ℝ s) (extremePoints ℝ (f '' s)) := by
   rintro w hw
   -- The fiber of `w` is nonempty and compact
   have ht : IsCompact {x ∈ s | f x = w} := hs.inter_right $ isClosed_singleton.preimage f.continuous


### PR DESCRIPTION
Prove that extreme points are preserved under affine equivalences, and the less trivial statement that a continuous affine map sends extreme points of a compact set to a superset of the extreme
points of the image of that set.

Also fix a few name and tweak the API a bit.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
