### PR TITLE
[Merged by Bors] - feat: prove an upper bound on bitwise operations

### DIFF
--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -486,4 +486,34 @@ theorem lt_xor_cases {a b c : ℕ} (h : a < b ^^^ c) : a ^^^ c < b ∨ a ^^^ b <
   (or_iff_right fun h' => (h.asymm h').elim).1 <| xor_trichotomy h.ne
 #align nat.lt_lxor_cases Nat.lt_xor_cases
 
+@[simp] theorem bit_lt_two_pow_succ_iff {b x n} : bit b x < 2 ^ (n + 1) ↔ x < 2 ^ n := by
+  rw [pow_succ', ←bit0_eq_two_mul]
+  cases b <;> simp
+
+/-- If `x` and `y` fit within `n` bits, then the result of any bitwise operation on `x` and `y` also
+fits within `n` bits -/
+theorem bitwise_lt {f x y n} (hx : x < 2 ^ n) (hy : y < 2 ^ n) :
+    bitwise f x y < 2 ^ n := by
+  induction x using Nat.binaryRec' generalizing n y with
+  | z =>
+    simp only [bitwise_zero_left]
+    split <;> assumption
+  | @f bx nx hnx ih =>
+    cases y using Nat.binaryRec' with
+    | z =>
+      simp only [bitwise_zero_right]
+      split <;> assumption
+    | f «by» ny hny =>
+      rw [bitwise_bit' _ _ _ _ hnx hny]
+      cases n <;> simp_all
+
+lemma shiftLeft_lt {x n m : ℕ} (h : x < 2 ^ n) : x <<< m < 2 ^ (n + m) := by
+  simp only [pow_add, shiftLeft_eq, mul_lt_mul_right (two_pow_pos _), h]
+
+lemma append_lt {x y n m} (hx : x < 2 ^ n) (hy : y < 2 ^ m) : y <<< n ||| x < 2 ^ (n + m) := by
+  apply bitwise_lt
+  · rw [add_comm]; apply shiftLeft_lt hy
+  · apply lt_of_lt_of_le hx <| pow_le_pow (le_succ _) (le_add_right _ _)
+
+
 end Nat

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -515,5 +515,4 @@ lemma append_lt {x y n m} (hx : x < 2 ^ n) (hy : y < 2 ^ m) : y <<< n ||| x < 2 
   · rw [add_comm]; apply shiftLeft_lt hy
   · apply lt_of_lt_of_le hx <| pow_le_pow (le_succ _) (le_add_right _ _)
 
-
 end Nat

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -510,6 +510,7 @@ theorem bitwise_lt {f x y n} (hx : x < 2 ^ n) (hy : y < 2 ^ n) :
 lemma shiftLeft_lt {x n m : ℕ} (h : x < 2 ^ n) : x <<< m < 2 ^ (n + m) := by
   simp only [pow_add, shiftLeft_eq, mul_lt_mul_right (two_pow_pos _), h]
 
+/-- Note that the LHS is the expression used within `Std.BitVec.append`, hence the name. -/
 lemma append_lt {x y n m} (hx : x < 2 ^ n) (hy : y < 2 ^ m) : y <<< n ||| x < 2 ^ (n + m) := by
   apply bitwise_lt
   · rw [add_comm]; apply shiftLeft_lt hy


### PR DESCRIPTION
A simple result which shows that if `x` and `y` fit within `n` bits, then the result of any bitwise operation on `x` and `y` also
fits within `n` bits.

Co-authored-by: mhk119 [58151072+mhk119@users.noreply.github.com](mailto:58151072+mhk119@users.noreply.github.com)
Co-authored-by: Eric Wieser [wieser.eric@gmail.com](mailto:wieser.eric@gmail.com)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Factored out from #5920 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
