### PR TITLE
[Merged by Bors] - feat: analysis delaborator for `LinearIndependent`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2254,6 +2254,7 @@ import Mathlib.Lean.EnvExtension
 import Mathlib.Lean.Exception
 import Mathlib.Lean.Expr
 import Mathlib.Lean.Expr.Basic
+import Mathlib.Lean.Expr.ExtraRecognizers
 import Mathlib.Lean.Expr.ReplaceRec
 import Mathlib.Lean.Expr.Traverse
 import Mathlib.Lean.IO.Process

--- a/Mathlib/Lean/Expr/ExtraRecognizers.lean
+++ b/Mathlib/Lean/Expr/ExtraRecognizers.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2023 Kyle Miller. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kyle Miller
+-/
+import Mathlib.Lean.Expr.Basic
+import Mathlib.Data.Set.Basic
+
+/-!
+# Additional Expr recognizers needing theory imports
+
+-/
+
+namespace Lean.Expr
+
+/-- If `e` is a coercion of a set to a type, return the set.
+Succeeds either for `Set.Elem s` terms or `{x // x ∈ s}` subtype terms. -/
+def coeTypeSet? (e : Expr) : Option Expr := do
+  if e.isAppOfArity ``Set.Elem 2 then
+    return e.appArg!
+  else if e.isAppOfArity ``Subtype 2 then
+    let .lam _ _ body _ := e.appArg! | failure
+    guard <| body.isAppOfArity ``Membership.mem 5
+    let #[_, _, inst, .bvar 0, s] := body.getAppArgs | failure
+    guard <| inst.isAppOfArity ``Set.instMembershipSet 1
+    return s
+  else
+    failure
+
+end Lean.Expr

--- a/Mathlib/Lean/PrettyPrinter/Delaborator.lean
+++ b/Mathlib/Lean/PrettyPrinter/Delaborator.lean
@@ -46,3 +46,10 @@ def withBindingBodyUnusedName' {α} (d : Syntax → Expr → DelabM α) : DelabM
   let n ← getUnusedName (← getExpr).bindingName! (← getExpr).bindingBody!
   let stxN ← annotateCurPos (mkIdent n)
   withBindingBody' n $ d stxN
+
+/-- Update `OptionsPerPos` at the given position, setting the key `n`
+to have the boolean value `v`. -/
+def OptionsPerPos.setBool (opts : OptionsPerPos) (p : SubExpr.Pos) (n : Name) (v : Bool) :
+    OptionsPerPos :=
+  let e := opts.findD p {} |>.setBool n v
+  opts.insert p e

--- a/test/delabLinearIndependent.lean
+++ b/test/delabLinearIndependent.lean
@@ -3,11 +3,19 @@ import Mathlib.LinearAlgebra.LinearIndependent
 set_option pp.unicode.fun true
 
 variable {K V : Type*} [DivisionRing K] [AddCommGroup V] [Module K V] {s : Set V} {x : V}
-  (hs : LinearIndependent K (fun b => b : s → V))
-  (hs' : LinearIndependent K (Subtype.val : s → V))
 
-/-- info: hs : LinearIndependent K fun (b : ↑s) ↦ ↑b -/
-#guard_msgs in #check hs
+variable (h : LinearIndependent K (fun b => b : s → V)) in
+/-- info: h : LinearIndependent K fun (b : ↑s) ↦ ↑b -/
+#guard_msgs in #check h
 
-/-- info: hs' : LinearIndependent (ι := { x // x ∈ s }) K Subtype.val -/
-#guard_msgs in #check hs'
+variable (h : LinearIndependent K (Subtype.val : s → V)) in
+/-- info: h : LinearIndependent (ι := { x // x ∈ s }) K Subtype.val -/
+#guard_msgs in #check h
+
+variable (h : LinearIndependent K (by exact Subtype.val : s → V)) in
+/-- info: h : LinearIndependent (ι := ↑s) K Subtype.val -/
+#guard_msgs in #check h
+
+variable (h : LinearIndependent K (fun b => (fun b => b : s → V) b)) in
+/-- info: h : LinearIndependent K fun (b : ↑s) ↦ (fun b ↦ ↑b) b -/
+#guard_msgs in #check h

--- a/test/delabLinearIndependent.lean
+++ b/test/delabLinearIndependent.lean
@@ -1,6 +1,6 @@
 import Mathlib.LinearAlgebra.LinearIndependent
 
-#check LinearIndependent.insert
+set_option pp.unicode.fun true
 
 variable {K V : Type*} [DivisionRing K] [AddCommGroup V] [Module K V] {s : Set V} {x : V}
   (hs : LinearIndependent K (fun b => b : s → V))

--- a/test/delabLinearIndependent.lean
+++ b/test/delabLinearIndependent.lean
@@ -1,0 +1,13 @@
+import Mathlib.LinearAlgebra.LinearIndependent
+
+#check LinearIndependent.insert
+
+variable {K V : Type*} [DivisionRing K] [AddCommGroup V] [Module K V] {s : Set V} {x : V}
+  (hs : LinearIndependent K (fun b => b : s → V))
+  (hs' : LinearIndependent K (Subtype.val : s → V))
+
+/-- info: hs : LinearIndependent K fun (b : ↑s) ↦ ↑b -/
+#guard_msgs in #check hs
+
+/-- info: hs' : LinearIndependent (ι := { x // x ∈ s }) K Subtype.val -/
+#guard_msgs in #check hs'


### PR DESCRIPTION
This is an experimental delaborator that works by analyzing the expression and tagging it with `pp.analysis`-style hints.

This causes pretty printing `LinearIndependent` like `LinearIndependent K fun (b : ↑s) ↦ ↑b` rather than `LinearIndependent K fun b ↦ ↑b` and `LinearIndependent (ι := { x // x ∈ s }) K Subtype.val` rather than `LinearIndependent K Subtype.val`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
