### PR TITLE
[Merged by Bors] - chore: merge master into nightly-testing via cron, not on every commit

### DIFF
--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: '30 */3 * * *'  # 8AM CET/11PM PT
 
 jobs:
   merge-to-nightly:
@@ -25,9 +27,11 @@ jobs:
       - name: Merge master to nightly favoring nightly changes
         run: |
           git checkout nightly-testing
-          # If the merge goes badly, we proceed anyway via '|| true'
+          # If the merge goes badly, we proceed anyway via '|| true'.
           # CI will report failures on the 'nightly-testing' branch direct to Zulip.
           git merge master --strategy-option ours --no-commit --allow-unrelated-histories || true
           git add .
-          git commit -m "Merge master into nightly-testing"
+          # If there's nothing to do (because there are no new commits from master),
+          # that's okay, hence the '|| true'.
+          git commit -m "Merge master into nightly-testing" || true
           git push origin nightly-testing

--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -3,9 +3,6 @@
 name: Merge master to nightly
 
 on:
-  push:
-    branches:
-      - master
   schedule:
     - cron: '30 */3 * * *'  # 8AM CET/11PM PT
 


### PR DESCRIPTION
In the current setup, every commit to master is being merged into `nightly-testing`. This results in the cancellation of the previous CI job running on `nightly-testing`. If commits to master land often enough, this means that successful results never occur, and so the `nightly-testing-YYYY-MM-DD` branch is never created, even if `nightly-testing` would actually get green CI.

This changes to only merging master on a regular basis, long enough for CI to complete.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
