### PR TITLE
[Merged by Bors] - feat: MulAction by product monoid

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/Prod.lean
+++ b/Mathlib/GroupTheory/GroupAction/Prod.lean
@@ -209,3 +209,101 @@ def smulMonoidHom [Monoid α] [MulOneClass β] [MulAction α β] [IsScalarTower 
 #align smul_monoid_hom_apply smulMonoidHom_apply
 
 end BundledSMul
+
+section Action_by_Prod
+
+variable (M N α) [Monoid M] [Monoid N]
+
+@[to_additive AddAction.prodEquiv.toFun]
+private abbrev MulAction.prodEquiv.toFun [MulAction (M × N) α] :
+    Σ' (_ : MulAction M α) (_ : MulAction N α), SMulCommClass M N α :=
+  letI : SMul M α := ⟨fun m a ↦ (m, (1 : N)) • a⟩
+  letI : SMul N α := ⟨fun n a ↦ ((1 : M), n) • a⟩
+  PSigma.mk
+  { one_smul := one_smul (M × N)
+    mul_smul := fun m m' ↦ by
+      convert mul_smul (m, (1 : N)) (m', 1)
+      rw [Prod.mk_mul_mk, one_mul]; rfl } <|
+  PSigma.mk
+  { one_smul := one_smul (M × N)
+    mul_smul := fun n n' ↦ by
+      convert mul_smul ((1 : M), n) (1, n')
+      rw [Prod.mk_mul_mk, one_mul]; rfl } <|
+  { smul_comm := fun m n a ↦ by
+      change (m, (1 : N)) • ((1 : M), n) • a = ((1 : M), n) • (m, (1 : N)) • a
+      simp_rw [smul_smul, Prod.mk_mul_mk, mul_one, one_mul] }
+
+/- This is not an instance to avoid diamonds for example when `α := M × N`. -/
+@[to_additive AddAction.prodEquiv.invFun]
+private abbrev MulAction.prodEquiv.invFun [MulAction M α] [MulAction N α] [SMulCommClass M N α] :
+    MulAction (M × N) α where
+  smul mn a := mn.1 • mn.2 • a
+  one_smul a := (one_smul M _).trans (one_smul N a)
+  mul_smul x y a := by
+    change (x.1 * y.1) • (x.2 * y.2) • a = x.1 • x.2 • y.1 • y.2 • a
+    rw [mul_smul, mul_smul, smul_comm y.1 x.2]
+
+/-- A `MulAction` by a product monoid is equivalent to commuting `MulAction`s by the factors. -/
+@[to_additive AddAction.prodEquiv "An `AddAction` by a product monoid is equivalent to
+  commuting `AddAction`s by the factors."]
+abbrev MulAction.prodEquiv :
+    MulAction (M × N) α ≃ Σ' (_ : MulAction M α) (_ : MulAction N α), SMulCommClass M N α where
+  toFun _ := MulAction.prodEquiv.toFun M N α
+  invFun _insts :=
+    letI := _insts.1; letI := _insts.2.1; have := _insts.2.2
+    MulAction.prodEquiv.invFun M N α
+  left_inv := by
+    rintro ⟨-, hsmul⟩; dsimp only; congr; ext ⟨m, n⟩ a
+    change (m, (1 : N)) • ((1 : M), n) • a = _
+    rw [← hsmul, Prod.mk_mul_mk, mul_one, one_mul]; rfl
+  right_inv := by
+    rintro ⟨hM, hN, -⟩
+    dsimp only [MulAction.prodEquiv.toFun]; congr 1
+    · ext m a; conv_rhs => rw [← hN.one_smul a]; rfl
+    congr 1
+    · funext; congr; ext m a; conv_rhs => rw [← hN.one_smul a]; rfl
+    · congr 1; ext n a; conv_rhs => rw [← hM.one_smul (SMul.smul n a)]; rfl
+    · apply heq_prop
+
+variable [AddMonoid α]
+
+private abbrev DistribMulAction.prodEquiv.toFun [DistribMulAction (M × N) α] :
+    Σ' (_ : DistribMulAction M α) (_ : DistribMulAction N α), SMulCommClass M N α :=
+  let _insts := MulAction.prodEquiv.toFun M N α
+  letI := _insts.1; letI := _insts.2.1
+  PSigma.mk
+  { smul_zero := fun m ↦ smul_zero (m, 1)
+    smul_add := fun m ↦ smul_add (m, 1) } <|
+  PSigma.mk
+  { smul_zero := fun n ↦ smul_zero ((1 : M), n)
+    smul_add := fun n ↦ smul_add ((1 : M), n) }
+  _insts.2.2
+
+private abbrev DistribMulAction.prodEquiv.invFun [DistribMulAction M α] [DistribMulAction N α]
+    [SMulCommClass M N α] : DistribMulAction (M × N) α where
+  __ := MulAction.prodEquiv.invFun M N α
+  smul_zero mn := by change mn.1 • mn.2 • 0 = (0 : α); rw [smul_zero, smul_zero]
+  smul_add mn a a' := by change mn.1 • mn.2 • _ = (_ : α); rw [smul_add, smul_add]; rfl
+
+/-- A `DistribMulAction` by a product monoid is equivalent to
+  commuting `DistribMulAction`s by the factors. -/
+abbrev DistribMulAction.prodEquiv : DistribMulAction (M × N) α ≃
+    Σ' (_ : DistribMulAction M α) (_ : DistribMulAction N α), SMulCommClass M N α where
+  toFun _ := DistribMulAction.prodEquiv.toFun M N α
+  invFun _insts :=
+    letI := _insts.1; letI := _insts.2.1; have := _insts.2.2
+    DistribMulAction.prodEquiv.invFun M N α
+  left_inv _ := by
+    dsimp only; congr; ext ⟨m, n⟩ a
+    change (m, (1 : N)) • ((1 : M), n) • a = _
+    rw [smul_smul, Prod.mk_mul_mk, mul_one, one_mul]; rfl
+  right_inv := by
+    rintro ⟨_, x, _⟩
+    dsimp only [DistribMulAction.prodEquiv.toFun]; congr 1
+    · ext m a; conv_rhs => rw [← one_smul N a]; rfl
+    congr 1
+    · funext i; congr; ext m a; clear i; conv_rhs => rw [← one_smul N a]; rfl
+    · congr 1; ext n a; conv_rhs => rw [← one_smul M (SMul.smul n a)]; rfl
+    · apply heq_prop
+
+section Action_by_Prod

--- a/Mathlib/GroupTheory/GroupAction/Prod.lean
+++ b/Mathlib/GroupTheory/GroupAction/Prod.lean
@@ -214,28 +214,12 @@ section Action_by_Prod
 
 variable (M N α) [Monoid M] [Monoid N]
 
-@[to_additive AddAction.prodEquiv.toFun]
-private abbrev MulAction.prodEquiv.toFun [MulAction (M × N) α] :
-    Σ' (_ : MulAction M α) (_ : MulAction N α), SMulCommClass M N α :=
-  letI : SMul M α := ⟨fun m a ↦ (m, (1 : N)) • a⟩
-  letI : SMul N α := ⟨fun n a ↦ ((1 : M), n) • a⟩
-  PSigma.mk
-  { one_smul := one_smul (M × N)
-    mul_smul := fun m m' ↦ by
-      convert mul_smul (m, (1 : N)) (m', 1)
-      rw [Prod.mk_mul_mk, one_mul]; rfl } <|
-  PSigma.mk
-  { one_smul := one_smul (M × N)
-    mul_smul := fun n n' ↦ by
-      convert mul_smul ((1 : M), n) (1, n')
-      rw [Prod.mk_mul_mk, one_mul]; rfl } <|
-  { smul_comm := fun m n a ↦ by
-      change (m, (1 : N)) • ((1 : M), n) • a = ((1 : M), n) • (m, (1 : N)) • a
-      simp_rw [smul_smul, Prod.mk_mul_mk, mul_one, one_mul] }
-
-/- This is not an instance to avoid diamonds for example when `α := M × N`. -/
-@[to_additive AddAction.prodEquiv.invFun]
-private abbrev MulAction.prodEquiv.invFun [MulAction M α] [MulAction N α] [SMulCommClass M N α] :
+/-- Construct a `MulAction` by a product monoid from `MulAction`s by the factors.
+  This is not an instance to avoid diamonds for example when `α := M × N`. -/
+@[to_additive AddAction.prodOfVAddCommClass
+  "Construct an `AddAction` by a product monoid from `AddAction`s by the factors.
+  This is not an instance to avoid diamonds for example when `α := M × N`."]
+abbrev MulAction.prodOfSMulCommClass [MulAction M α] [MulAction N α] [SMulCommClass M N α] :
     MulAction (M × N) α where
   smul mn a := mn.1 • mn.2 • a
   one_smul a := (one_smul M _).trans (one_smul N a)
@@ -246,19 +230,25 @@ private abbrev MulAction.prodEquiv.invFun [MulAction M α] [MulAction N α] [SMu
 /-- A `MulAction` by a product monoid is equivalent to commuting `MulAction`s by the factors. -/
 @[to_additive AddAction.prodEquiv "An `AddAction` by a product monoid is equivalent to
   commuting `AddAction`s by the factors."]
-abbrev MulAction.prodEquiv :
+def MulAction.prodEquiv :
     MulAction (M × N) α ≃ Σ' (_ : MulAction M α) (_ : MulAction N α), SMulCommClass M N α where
-  toFun _ := MulAction.prodEquiv.toFun M N α
+  toFun _ :=
+    letI instM := MulAction.compHom α (.inl M N)
+    letI instN := MulAction.compHom α (.inr M N)
+    ⟨instM, instN,
+    { smul_comm := fun m n a ↦ by
+        change (m, (1 : N)) • ((1 : M), n) • a = ((1 : M), n) • (m, (1 : N)) • a
+        simp_rw [smul_smul, Prod.mk_mul_mk, mul_one, one_mul] }⟩
   invFun _insts :=
     letI := _insts.1; letI := _insts.2.1; have := _insts.2.2
-    MulAction.prodEquiv.invFun M N α
+    MulAction.prodOfSMulCommClass M N α
   left_inv := by
     rintro ⟨-, hsmul⟩; dsimp only; congr; ext ⟨m, n⟩ a
     change (m, (1 : N)) • ((1 : M), n) • a = _
     rw [← hsmul, Prod.mk_mul_mk, mul_one, one_mul]; rfl
   right_inv := by
     rintro ⟨hM, hN, -⟩
-    dsimp only [MulAction.prodEquiv.toFun]; congr 1
+    dsimp only; congr 1
     · ext m a; conv_rhs => rw [← hN.one_smul a]; rfl
     congr 1
     · funext; congr; ext m a; conv_rhs => rw [← hN.one_smul a]; rfl
@@ -267,43 +257,35 @@ abbrev MulAction.prodEquiv :
 
 variable [AddMonoid α]
 
-private abbrev DistribMulAction.prodEquiv.toFun [DistribMulAction (M × N) α] :
-    Σ' (_ : DistribMulAction M α) (_ : DistribMulAction N α), SMulCommClass M N α :=
-  let _insts := MulAction.prodEquiv.toFun M N α
-  letI := _insts.1; letI := _insts.2.1
-  PSigma.mk
-  { smul_zero := fun m ↦ smul_zero (m, 1)
-    smul_add := fun m ↦ smul_add (m, 1) } <|
-  PSigma.mk
-  { smul_zero := fun n ↦ smul_zero ((1 : M), n)
-    smul_add := fun n ↦ smul_add ((1 : M), n) }
-  _insts.2.2
-
-private abbrev DistribMulAction.prodEquiv.invFun [DistribMulAction M α] [DistribMulAction N α]
+/-- Construct a `DistribMulAction` by a product monoid from `DistribMulAction`s by the factors. -/
+abbrev DistribMulAction.prodOfSMulCommClass [DistribMulAction M α] [DistribMulAction N α]
     [SMulCommClass M N α] : DistribMulAction (M × N) α where
-  __ := MulAction.prodEquiv.invFun M N α
+  __ := MulAction.prodOfSMulCommClass M N α
   smul_zero mn := by change mn.1 • mn.2 • 0 = (0 : α); rw [smul_zero, smul_zero]
   smul_add mn a a' := by change mn.1 • mn.2 • _ = (_ : α); rw [smul_add, smul_add]; rfl
 
 /-- A `DistribMulAction` by a product monoid is equivalent to
   commuting `DistribMulAction`s by the factors. -/
-abbrev DistribMulAction.prodEquiv : DistribMulAction (M × N) α ≃
+def DistribMulAction.prodEquiv : DistribMulAction (M × N) α ≃
     Σ' (_ : DistribMulAction M α) (_ : DistribMulAction N α), SMulCommClass M N α where
-  toFun _ := DistribMulAction.prodEquiv.toFun M N α
+  toFun _ :=
+    letI instM := DistribMulAction.compHom α (.inl M N)
+    letI instN := DistribMulAction.compHom α (.inr M N)
+    ⟨instM, instN, (MulAction.prodEquiv M N α inferInstance).2.2⟩
   invFun _insts :=
     letI := _insts.1; letI := _insts.2.1; have := _insts.2.2
-    DistribMulAction.prodEquiv.invFun M N α
+    DistribMulAction.prodOfSMulCommClass M N α
   left_inv _ := by
     dsimp only; congr; ext ⟨m, n⟩ a
     change (m, (1 : N)) • ((1 : M), n) • a = _
     rw [smul_smul, Prod.mk_mul_mk, mul_one, one_mul]; rfl
   right_inv := by
     rintro ⟨_, x, _⟩
-    dsimp only [DistribMulAction.prodEquiv.toFun]; congr 1
+    dsimp only; congr 1
     · ext m a; conv_rhs => rw [← one_smul N a]; rfl
     congr 1
     · funext i; congr; ext m a; clear i; conv_rhs => rw [← one_smul N a]; rfl
     · congr 1; ext n a; conv_rhs => rw [← one_smul M (SMul.smul n a)]; rfl
     · apply heq_prop
 
-section Action_by_Prod
+end Action_by_Prod

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -85,6 +85,9 @@ theorem eq_rec_compose {α β φ : Sort u} :
       (Eq.recOn p₁ (Eq.recOn p₂ a : β) : φ) = Eq.recOn (Eq.trans p₂ p₁) a
   | rfl, rfl, _ => rfl
 
+theorem heq_prop {P Q : Prop} (p : P) (q : Q) : HEq p q :=
+  Subsingleton.helim (propext <| iff_of_true p q) _ _
+
 /- and -/
 
 variable {a b c d : Prop}


### PR DESCRIPTION
Commuting (Distrib)MulActions by two monoids on the same type give rise to a (Distrib)MulAction by the product monoid, and vice versa.

---

I originally thought of generalizing LinearMap to take DistribMulActions rather than Modules, so we can describe (R,S)-bimodule morphisms as LinearMaps w.r.t. the `R × Sᵐᵒᵖ`-action. However, making an `R × S`-action instance from the `R`- and `S`-actions would lead to diamonds, so it's not a practical approach; using IsLinearMap is probably a good compromise. Moreover, for the category of (R,S)-bimodules, the objects are Modules over the tensor product `R ⊗ Sᵐᵒᵖ` and can't be easily described using `R × Sᵐᵒᵖ`, even though the morphisms can.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
