### PR TITLE
[Merged by Bors] - chore: reduce imports of Data.List.Defs

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1585,6 +1585,7 @@ import Mathlib.Data.LazyList.Basic
 import Mathlib.Data.List.AList
 import Mathlib.Data.List.Basic
 import Mathlib.Data.List.BigOperators.Basic
+import Mathlib.Data.List.BigOperators.Defs
 import Mathlib.Data.List.BigOperators.Lemmas
 import Mathlib.Data.List.Card
 import Mathlib.Data.List.Chain

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -4192,15 +4192,6 @@ instance (p : α → Prop) [DecidablePred p] : DecidablePred (Forall p) := fun _
 
 end Forall
 
-/-! ### Retroattributes
-
-The list definitions happen earlier than `to_additive`, so here we tag the few multiplicative
-definitions that couldn't be tagged earlier.
--/
-
-attribute [to_additive existing] List.prod -- `List.sum`
-attribute [to_additive existing] alternatingProd -- `List.alternatingSum`
-
 /-! ### Miscellaneous lemmas -/
 
 theorem getLast_reverse {l : List α} (hl : l.reverse ≠ [])

--- a/Mathlib/Data/List/BigOperators/Basic.lean
+++ b/Mathlib/Data/List/BigOperators/Basic.lean
@@ -105,7 +105,7 @@ theorem prod_hom_rel (l : List ι) {r : M → N → Prop} {f : ι → M} {g : ι
 #align list.sum_hom_rel List.sum_hom_rel
 
 @[to_additive]
-theorem rel_prod [Monoid M] [Monoid N] {R} (h : R 1 1) (hf : (R ⇒ R ⇒ R) (· * ·) (· * ·)) :
+theorem rel_prod {R : M → N → Prop} (h : R 1 1) (hf : (R ⇒ R ⇒ R) (· * ·) (· * ·)) :
     (Forall₂ R ⇒ R) prod prod :=
   rel_foldl hf h
 #align list.rel_prod List.rel_prod

--- a/Mathlib/Data/List/BigOperators/Basic.lean
+++ b/Mathlib/Data/List/BigOperators/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Floris van Doorn, Sébastien Gouëzel, Alex J. Best
 -/
+import Mathlib.Data.List.BigOperators.Defs
 import Mathlib.Data.Int.Order.Basic
 import Mathlib.Data.List.Forall2
 
@@ -13,9 +14,8 @@ import Mathlib.Data.List.Forall2
 
 This file provides basic results about `List.prod`, `List.sum`, which calculate the product and sum
 of elements of a list and `List.alternating_prod`, `List.alternating_sum`, their alternating
-counterparts. These are defined in [`Data.List.Defs`](./Defs).
+counterparts. These are defined in [`Data.List.BigOperators.Defs`](./Defs).
 -/
-
 
 variable {ι α M N P M₀ G R : Type*}
 
@@ -103,6 +103,13 @@ theorem prod_hom_rel (l : List ι) {r : M → N → Prop} {f : ι → M} {g : ι
   List.recOn l h₁ fun a l hl => by simp only [map_cons, prod_cons, h₂ hl]
 #align list.prod_hom_rel List.prod_hom_rel
 #align list.sum_hom_rel List.sum_hom_rel
+
+@[to_additive]
+theorem rel_prod [Monoid M] [Monoid N] {R} (h : R 1 1) (hf : (R ⇒ R ⇒ R) (· * ·) (· * ·)) :
+    (Forall₂ R ⇒ R) prod prod :=
+  rel_foldl hf h
+#align list.rel_prod List.rel_prod
+#align list.rel_sum List.rel_sum
 
 @[to_additive]
 theorem prod_hom (l : List M) {F : Type*} [MonoidHomClass F M N] (f : F) :

--- a/Mathlib/Data/List/BigOperators/Defs.lean
+++ b/Mathlib/Data/List/BigOperators/Defs.lean
@@ -13,15 +13,13 @@ import Mathlib.Algebra.Group.Defs
 
 -/
 
-set_option autoImplicit true
-
 namespace List
 
 /-- Product of a list.
 
 `List.prod [a, b, c] = ((1 * a) * b) * c` -/
 @[to_additive "Sum of a list.\n\n`List.sum [a, b, c] = ((0 + a) + b) + c`"]
-def prod [Mul α] [One α] : List α → α :=
+def prod {α} [Mul α] [One α] : List α → α :=
   foldl (· * ·) 1
 #align list.prod List.prod
 #align list.sum List.sum

--- a/Mathlib/Data/List/BigOperators/Defs.lean
+++ b/Mathlib/Data/List/BigOperators/Defs.lean
@@ -19,8 +19,8 @@ namespace List
 
 /-- Product of a list.
 
-     `List.prod [a, b, c] = ((1 * a) * b) * c` -/
-@[to_additive]
+`List.prod [a, b, c] = ((1 * a) * b) * c` -/
+@[to_additive "Sum of a list.\n\n`List.sum [a, b, c] = ((0 + a) + b) + c`"]
 def prod [Mul α] [One α] : List α → α :=
   foldl (· * ·) 1
 #align list.prod List.prod

--- a/Mathlib/Data/List/BigOperators/Defs.lean
+++ b/Mathlib/Data/List/BigOperators/Defs.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2014 Parikshit Khanna. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Mario Carneiro
+-/
+import Mathlib.Data.List.Defs
+import Mathlib.Algebra.Group.Defs
+
+#align_import data.list.defs from "leanprover-community/mathlib"@"d2d8742b0c21426362a9dacebc6005db895ca963"
+
+/-!
+## Products and sums over lists
+
+-/
+
+set_option autoImplicit true
+
+namespace List
+
+/-- Product of a list.
+
+     `List.prod [a, b, c] = ((1 * a) * b) * c` -/
+@[to_additive]
+def prod [Mul α] [One α] : List α → α :=
+  foldl (· * ·) 1
+#align list.prod List.prod
+#align list.sum List.sum
+
+/-- The alternating sum of a list. -/
+def alternatingSum {G : Type*} [Zero G] [Add G] [Neg G] : List G → G
+  | [] => 0
+  | g :: [] => g
+  | g :: h :: t => g + -h + alternatingSum t
+#align list.alternating_sum List.alternatingSum
+
+/-- The alternating product of a list. -/
+@[to_additive existing]
+def alternatingProd {G : Type*} [One G] [Mul G] [Inv G] : List G → G
+  | [] => 1
+  | g :: [] => g
+  | g :: h :: t => g * h⁻¹ * alternatingProd t
+#align list.alternating_prod List.alternatingProd
+
+end List

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -3,9 +3,8 @@ Copyright (c) 2014 Parikshit Khanna. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Mario Carneiro
 -/
-import Mathlib.Algebra.Group.Defs
+import Mathlib.Init.Data.Nat.Notation
 import Mathlib.Control.Functor
-import Mathlib.Data.Nat.Basic
 import Mathlib.Logic.Basic
 import Mathlib.Data.SProd
 import Mathlib.Util.CompileInductive
@@ -74,37 +73,6 @@ def takeI [Inhabited α] (n : Nat) (l : List α) : List α :=
 #align list.take_while List.takeWhile
 #align list.scanl List.scanl
 #align list.scanr List.scanr
-
-/-- Product of a list.
-
-     `List.prod [a, b, c] = ((1 * a) * b) * c` -/
-def prod [Mul α] [One α] : List α → α :=
-  foldl (· * ·) 1
-#align list.prod List.prod
-
--- Later this will be tagged with `to_additive`, but this can't be done yet because of imports.
--- dependencies.
-/-- Sum of a list.
-
-     `List.sum [a, b, c] = ((0 + a) + b) + c` -/
-def sum [Add α] [Zero α] : List α → α :=
-  foldl (· + ·) 0
-#align list.sum List.sum
-
-/-- The alternating sum of a list. -/
-def alternatingSum {G : Type*} [Zero G] [Add G] [Neg G] : List G → G
-  | [] => 0
-  | g :: [] => g
-  | g :: h :: t => g + -h + alternatingSum t
-#align list.alternating_sum List.alternatingSum
-
-/-- The alternating product of a list. -/
-def alternatingProd {G : Type*} [One G] [Mul G] [Inv G] : List G → G
-  | [] => 1
-  | g :: [] => g
-  | g :: h :: t => g * h⁻¹ * alternatingProd t
-#align list.alternating_prod List.alternatingProd
-
 #align list.partition_map List.partitionMap
 #align list.find List.find?
 

--- a/Mathlib/Data/List/Forall2.lean
+++ b/Mathlib/Data/List/Forall2.lean
@@ -309,13 +309,6 @@ theorem rel_filterMap : ((R ⇒ Option.Rel P) ⇒ Forall₂ R ⇒ Forall₂ P) f
       | _, _, Option.Rel.some h => Forall₂.cons h (rel_filterMap (@hfg) h₂)
 #align list.rel_filter_map List.rel_filterMap
 
-@[to_additive]
-theorem rel_prod [Monoid α] [Monoid β] (h : R 1 1) (hf : (R ⇒ R ⇒ R) (· * ·) (· * ·)) :
-    (Forall₂ R ⇒ R) prod prod :=
-  rel_foldl hf h
-#align list.rel_prod List.rel_prod
-#align list.rel_sum List.rel_sum
-
 /-- Given a relation `R`, `sublist_forall₂ r l₁ l₂` indicates that there is a sublist of `l₂` such
   that `forall₂ r l₁ l₂`. -/
 inductive SublistForall₂ (R : α → β → Prop) : List α → List β → Prop

--- a/test/congr.lean
+++ b/test/congr.lean
@@ -2,7 +2,7 @@ import Mathlib.Tactic.Congr!
 import Std.Tactic.GuardExpr
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Data.Subtype
-import Mathlib.Data.List.Defs
+import Mathlib.Data.List.BigOperators.Basic
 
 private axiom test_sorry : ∀ {α}, α
 set_option autoImplicit true

--- a/test/convert2.lean
+++ b/test/convert2.lean
@@ -1,4 +1,4 @@
-import Mathlib.Data.List.Defs
+import Mathlib.Data.List.BigOperators.Defs
 import Mathlib.Data.Nat.Basic
 
 set_option linter.unreachableTactic false


### PR DESCRIPTION
Currently `Data.List.Defs` depends on `Algebra.Group.Defs`, rather unnecessarily.

(This then prevents importing `Data.List.Defs` into `Tactic.Common`, without breaking various `assert_not_exists` statements.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
