### PR TITLE
[Merged by Bors] - chore: split Algebra.CharP.Basic, reduce imports in RingTheory.Multiplicity

### DIFF
--- a/Counterexamples/CharPZeroNeCharZero.lean
+++ b/Counterexamples/CharPZeroNeCharZero.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa, Eric Wieser
 -/
 import Mathlib.Algebra.CharP.Basic
+import Mathlib.Algebra.PUnitInstances
 
 #align_import char_p_zero_ne_char_zero from "leanprover-community/mathlib"@"328375597f2c0dd00522d9c2e5a33b6a6128feeb"
 

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3103,6 +3103,7 @@ import Mathlib.RingTheory.Valuation.Basic
 import Mathlib.RingTheory.Valuation.ExtendToLocalization
 import Mathlib.RingTheory.Valuation.Integers
 import Mathlib.RingTheory.Valuation.Integral
+import Mathlib.RingTheory.Valuation.PrimeMultiplicity
 import Mathlib.RingTheory.Valuation.Quotient
 import Mathlib.RingTheory.Valuation.RamificationGroup
 import Mathlib.RingTheory.Valuation.ValuationRing

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -103,6 +103,7 @@ import Mathlib.Algebra.CharP.LocalRing
 import Mathlib.Algebra.CharP.MixedCharZero
 import Mathlib.Algebra.CharP.Pi
 import Mathlib.Algebra.CharP.Quotient
+import Mathlib.Algebra.CharP.Reduced
 import Mathlib.Algebra.CharP.Subring
 import Mathlib.Algebra.CharP.Two
 import Mathlib.Algebra.CharZero.Defs

--- a/Mathlib/Algebra/CharP/Basic.lean
+++ b/Mathlib/Algebra/CharP/Basic.lean
@@ -5,6 +5,9 @@ Authors: Kenny Lau, Joey van Langen, Casper Putz
 -/
 import Mathlib.Data.Int.ModEq
 import Mathlib.Data.Nat.Multiplicity
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Data.Nat.Cast.Prod
+import Mathlib.Algebra.Group.ULift
 import Mathlib.GroupTheory.OrderOfElement
 
 #align_import algebra.char_p.basic from "leanprover-community/mathlib"@"47a1a73351de8dd6c8d3d32b569c8e434b03ca47"

--- a/Mathlib/Algebra/CharP/Basic.lean
+++ b/Mathlib/Algebra/CharP/Basic.lean
@@ -6,7 +6,6 @@ Authors: Kenny Lau, Joey van Langen, Casper Putz
 import Mathlib.Data.Int.ModEq
 import Mathlib.Data.Nat.Multiplicity
 import Mathlib.GroupTheory.OrderOfElement
-import Mathlib.RingTheory.Nilpotent
 
 #align_import algebra.char_p.basic from "leanprover-community/mathlib"@"47a1a73351de8dd6c8d3d32b569c8e434b03ca47"
 
@@ -439,23 +438,6 @@ end CommRing
 
 end frobenius
 
-theorem frobenius_inj [CommRing R] [IsReduced R] (p : ℕ) [Fact p.Prime] [CharP R p] :
-    Function.Injective (frobenius R p) := fun x h H => by
-  rw [← sub_eq_zero] at H ⊢
-  rw [← frobenius_sub] at H
-  exact IsReduced.eq_zero _ ⟨_, H⟩
-#align frobenius_inj frobenius_inj
-
-/-- If `ringChar R = 2`, where `R` is a finite reduced commutative ring,
-then every `a : R` is a square. -/
-theorem isSquare_of_charTwo' {R : Type*} [Finite R] [CommRing R] [IsReduced R] [CharP R 2]
-    (a : R) : IsSquare a := by
-  cases nonempty_fintype R
-  exact
-    Exists.imp (fun b h => pow_two b ▸ Eq.symm h)
-      (((Fintype.bijective_iff_injective_and_card _).mpr ⟨frobenius_inj R 2, rfl⟩).surjective a)
-#align is_square_of_char_two' isSquare_of_charTwo'
-
 namespace CharP
 
 section
@@ -491,23 +473,6 @@ theorem ringChar_zero_iff_CharZero [NonAssocRing R] : ringChar R = 0 ↔ CharZer
   rw [ringChar.eq_iff, charP_zero_iff_charZero]
 
 end
-
-section CommRing
-
-variable [CommRing R] [IsReduced R] {R}
-
-@[simp]
-theorem pow_prime_pow_mul_eq_one_iff (p k m : ℕ) [Fact p.Prime] [CharP R p] (x : R) :
-    x ^ (p ^ k * m) = 1 ↔ x ^ m = 1 := by
-  induction' k with k hk
-  · rw [pow_zero, one_mul]
-  · refine' ⟨fun h => _, fun h => _⟩
-    · rw [pow_succ, mul_assoc, pow_mul', ← frobenius_def, ← frobenius_one p] at h
-      exact hk.1 (frobenius_inj R p h)
-    · rw [pow_mul', h, one_pow]
-#align char_p.pow_prime_pow_mul_eq_one_iff CharP.pow_prime_pow_mul_eq_one_iff
-
-end CommRing
 
 section Semiring
 

--- a/Mathlib/Algebra/CharP/Quotient.lean
+++ b/Mathlib/Algebra/CharP/Quotient.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau, Eric Wieser
 -/
 import Mathlib.Algebra.CharP.Basic
 import Mathlib.RingTheory.Ideal.Quotient
+import Mathlib.RingTheory.Ideal.Operations
 
 #align_import algebra.char_p.quotient from "leanprover-community/mathlib"@"85e3c05a94b27c84dc6f234cf88326d5e0096ec3"
 

--- a/Mathlib/Algebra/CharP/Reduced.lean
+++ b/Mathlib/Algebra/CharP/Reduced.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2018 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau, Joey van Langen, Casper Putz
+-/
+import Mathlib.Algebra.CharP.Basic
+import Mathlib.RingTheory.Nilpotent
+
+#align_import algebra.char_p.basic from "leanprover-community/mathlib"@"47a1a73351de8dd6c8d3d32b569c8e434b03ca47"
+
+/-!
+# Results about characteristic p reduced rings
+-/
+
+
+open Finset
+
+open BigOperators
+
+theorem frobenius_inj (R : Type*) [CommRing R] [IsReduced R] (p : ℕ) [Fact p.Prime] [CharP R p] :
+    Function.Injective (frobenius R p) := fun x h H => by
+  rw [← sub_eq_zero] at H ⊢
+  rw [← frobenius_sub] at H
+  exact IsReduced.eq_zero _ ⟨_, H⟩
+#align frobenius_inj frobenius_inj
+
+/-- If `ringChar R = 2`, where `R` is a finite reduced commutative ring,
+then every `a : R` is a square. -/
+theorem isSquare_of_charTwo' {R : Type*} [Finite R] [CommRing R] [IsReduced R] [CharP R 2]
+    (a : R) : IsSquare a := by
+  cases nonempty_fintype R
+  exact
+    Exists.imp (fun b h => pow_two b ▸ Eq.symm h)
+      (((Fintype.bijective_iff_injective_and_card _).mpr ⟨frobenius_inj R 2, rfl⟩).surjective a)
+#align is_square_of_char_two' isSquare_of_charTwo'
+
+namespace CharP
+
+variable {R : Type*} [CommRing R] [IsReduced R]
+
+@[simp]
+theorem pow_prime_pow_mul_eq_one_iff (p k m : ℕ) [Fact p.Prime] [CharP R p] (x : R) :
+    x ^ (p ^ k * m) = 1 ↔ x ^ m = 1 := by
+  induction' k with k hk
+  · rw [pow_zero, one_mul]
+  · refine' ⟨fun h => _, fun h => _⟩
+    · rw [pow_succ, mul_assoc, pow_mul', ← frobenius_def, ← frobenius_one p] at h
+      exact hk.1 (frobenius_inj R p h)
+    · rw [pow_mul', h, one_pow]
+#align char_p.pow_prime_pow_mul_eq_one_iff CharP.pow_prime_pow_mul_eq_one_iff
+
+end CharP

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import Mathlib.Algebra.CharP.Basic
+import Mathlib.RingTheory.Ideal.Operations
 import Mathlib.Data.Fintype.Units
 import Mathlib.Data.Nat.Parity
 import Mathlib.Tactic.FinCases

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes, Joey van Langen, Casper Putz
 -/
 import Mathlib.FieldTheory.Separable
 import Mathlib.RingTheory.IntegralDomain
+import Mathlib.Algebra.CharP.Reduced
 import Mathlib.Tactic.ApplyFun
 
 #align_import field_theory.finite.basic from "leanprover-community/mathlib"@"12a85fac627bea918960da036049d611b1a3ee43"

--- a/Mathlib/FieldTheory/Perfect.lean
+++ b/Mathlib/FieldTheory/Perfect.lean
@@ -5,6 +5,7 @@ Authors: Oliver Nash
 -/
 import Mathlib.FieldTheory.Separable
 import Mathlib.FieldTheory.SplittingField.Construction
+import Mathlib.Algebra.CharP.Reduced
 
 /-!
 

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
+import Mathlib.RingTheory.Valuation.Basic
 import Mathlib.NumberTheory.Padics.PadicNorm
 import Mathlib.Analysis.Normed.Field.Basic
 

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -5,8 +5,7 @@ Authors: Kevin Buzzard
 -/
 import Mathlib.RingTheory.PrincipalIdealDomain
 import Mathlib.RingTheory.Ideal.LocalRing
-import Mathlib.RingTheory.Multiplicity
-import Mathlib.RingTheory.Valuation.Basic
+import Mathlib.RingTheory.Valuation.PrimeMultiplicity
 import Mathlib.LinearAlgebra.AdicCompletion
 
 #align_import ring_theory.discrete_valuation_ring.basic from "leanprover-community/mathlib"@"c163ec99dfc664628ca15d215fce0a5b9c265b68"

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Chris Hughes
 -/
 import Mathlib.Algebra.Associated
-import Mathlib.RingTheory.Valuation.Basic
+import Mathlib.Algebra.SMulWithZero
+import Mathlib.Data.Nat.PartENat
+import Mathlib.Tactic.Linarith
 
 #align_import ring_theory.multiplicity from "leanprover-community/mathlib"@"e8638a0fcaf73e4500469f368ef9494e495099b3"
 
@@ -621,23 +623,6 @@ theorem multiplicity_pow_self_of_prime {p : α} (hp : Prime p) (n : ℕ) :
 #align multiplicity.multiplicity_pow_self_of_prime multiplicity.multiplicity_pow_self_of_prime
 
 end CancelCommMonoidWithZero
-
-section Valuation
-
-variable {R : Type*} [CommRing R] [IsDomain R] {p : R} [DecidableRel (Dvd.dvd : R → R → Prop)]
-
-/-- `multiplicity` of a prime in an integral domain as an additive valuation to `PartENat`. -/
-noncomputable def addValuation (hp : Prime p) : AddValuation R PartENat :=
-  AddValuation.of (multiplicity p) (multiplicity.zero _) (one_right hp.not_unit)
-    (fun _ _ => min_le_multiplicity_add) fun _ _ => multiplicity.mul hp
-#align multiplicity.add_valuation multiplicity.addValuation
-
-@[simp]
-theorem addValuation_apply {hp : Prime p} {r : R} : addValuation hp r = multiplicity p r :=
-  rfl
-#align multiplicity.add_valuation_apply multiplicity.addValuation_apply
-
-end Valuation
 
 end multiplicity
 

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Chris Hughes
 -/
 import Mathlib.Algebra.Associated
-import Mathlib.Algebra.BigOperators.Basic
 import Mathlib.RingTheory.Valuation.Basic
 
 #align_import ring_theory.multiplicity from "leanprover-community/mathlib"@"e8638a0fcaf73e4500469f368ef9494e495099b3"

--- a/Mathlib/RingTheory/Valuation/PrimeMultiplicity.lean
+++ b/Mathlib/RingTheory/Valuation/PrimeMultiplicity.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis, Chris Hughes
+-/
+import Mathlib.RingTheory.Multiplicity
+import Mathlib.RingTheory.Valuation.Basic
+
+/-!
+# `multiplicity` of a prime in an integral domain as an additive valuation
+-/
+
+variable {R : Type*} [CommRing R] [IsDomain R] {p : R} [DecidableRel (Dvd.dvd : R → R → Prop)]
+
+/-- `multiplicity` of a prime in an integral domain as an additive valuation to `PartENat`. -/
+noncomputable def multiplicity.addValuation (hp : Prime p) : AddValuation R PartENat :=
+  AddValuation.of (multiplicity p) (multiplicity.zero _) (one_right hp.not_unit)
+    (fun _ _ => min_le_multiplicity_add) fun _ _ => multiplicity.mul hp
+#align multiplicity.add_valuation multiplicity.addValuation
+
+@[simp]
+theorem multiplicity.addValuation_apply {hp : Prime p} {r : R} : addValuation hp r = multiplicity p r :=
+  rfl
+#align multiplicity.add_valuation_apply multiplicity.addValuation_apply

--- a/Mathlib/RingTheory/Valuation/PrimeMultiplicity.lean
+++ b/Mathlib/RingTheory/Valuation/PrimeMultiplicity.lean
@@ -19,6 +19,7 @@ noncomputable def multiplicity.addValuation (hp : Prime p) : AddValuation R Part
 #align multiplicity.add_valuation multiplicity.addValuation
 
 @[simp]
-theorem multiplicity.addValuation_apply {hp : Prime p} {r : R} : addValuation hp r = multiplicity p r :=
+theorem multiplicity.addValuation_apply {hp : Prime p} {r : R} :
+    addValuation hp r = multiplicity p r :=
   rfl
 #align multiplicity.add_valuation_apply multiplicity.addValuation_apply


### PR DESCRIPTION
This was adding unnecessary imports to `Data.ZMod.Basic`.

---

Despite adding several files, this reduces the total number of transitive imports reported via:

```
import Mathlib

open Lean Meta
#eval show MetaM Nat from do
  let mut t := 0
  for (_, s) in (← getEnv).importGraph.transitiveClosure do
    t := t + s.size
  return t
```
(only by about 600 out of 5.3m, but it's a start :-)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
