### PR TITLE
refactor: noncommutative tensor product

### DIFF
--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -1052,10 +1052,50 @@ instance module : Module S (M →ₛₗ[σ₁₂] M₂) where
 instance [NoZeroSMulDivisors S M₂] : NoZeroSMulDivisors S (M →ₛₗ[σ₁₂] M₂) :=
   coe_injective.noZeroSMulDivisors _ rfl coe_smul
 
-instance {S'} [Semiring S'] [Module S' M] [SMulCommClass R S' M] :
-    Module S'ᵈᵐᵃ (M →ₛₗ[σ₁₂] M₂) where
+variable {S : Type*} [Semiring S] [Module S M]
+
+instance : Module Sᵈᵐᵃ (M →+ M₂) where
+  add_smul s s' f := AddMonoidHom.ext fun m ↦ by
+    simp_rw [AddMonoidHom.add_apply, DomMulAct.smul_addMonoidHom_apply, ← map_add, ← add_smul]; rfl
+  zero_smul _ := AddMonoidHom.ext fun _ ↦ by
+    erw [DomMulAct.smul_addMonoidHom_apply, zero_smul, map_zero]; rfl
+
+instance [SMulCommClass R S M] : Module Sᵈᵐᵃ (M →ₛₗ[σ₁₂] M₂) where
   add_smul _ _ _ := ext fun _ ↦ by simp_rw [add_apply, smul_apply', ← map_add, ← add_smul]; rfl
   zero_smul _ := ext fun _ ↦ by erw [smul_apply', zero_smul, map_zero]; rfl
+
+abbrev _root_.AddMonoidHom.domModule' : Module Sᵐᵒᵖ (M →+ M₂) := inferInstanceAs (Module Sᵈᵐᵃ _)
+
+abbrev domModule' [SMulCommClass S R M] : Module Sᵐᵒᵖ (M →ₛₗ[σ₁₂] M₂) :=
+  have := SMulCommClass.symm S R M; inferInstanceAs (Module Sᵈᵐᵃ _)
+
+attribute [local instance] AddMonoidHom.domModule' domModule'
+
+@[simp] lemma _root_.AddMonoidHom.domModule_smul_apply' (s : Sᵐᵒᵖ) (f : M →+ M₂) (m : M) :
+    (s • f) m = f (s.unop • m) := rfl
+
+@[simp] lemma domModule_smul_apply' [SMulCommClass S R M] (s : Sᵐᵒᵖ) (f : M →ₛₗ[σ₁₂] M₂) (m : M) :
+    (s • f) m = f (s.unop • m) := rfl
+
+variable {S : Type*} [Semiring S] [Module Sᵐᵒᵖ M]
+
+/-- If `M` is a right `S`-module and `M₂` is an commutative monoid, then `M →+ M₂` is
+  a left `S`-module. This is not an instance because `S` may also act on `M₂`. -/
+abbrev _root_.AddMonoidHom.domModule : Module S (M →+ M₂) :=
+  Module.compHom _ (show S →+* (Sᵐᵒᵖ)ᵈᵐᵃ from (RingEquiv.opOp S).toRingHom)
+
+/-- If `M` is a `(R,S)`-bimodule, `M₂` is a `R₂`-module, and `σ₁₂` is a ring homomorphism from
+  `R` to `R₂`, then `M →ₗ[σ₁₂] M₂` is a `S`-module. -/
+abbrev domModule [SMulCommClass R Sᵐᵒᵖ M] : Module S (M →ₛₗ[σ₁₂] M₂) :=
+  Module.compHom _ (show S →+* (Sᵐᵒᵖ)ᵈᵐᵃ from (RingEquiv.opOp S).toRingHom)
+
+attribute [local instance] AddMonoidHom.domModule domModule
+
+@[simp] lemma _root_.AddMonoidHom.domModule_smul_apply (s : S) (f : M →+ M₂) (m : M) :
+    (s • f) m = f (MulOpposite.op s • m) := rfl
+
+@[simp] lemma domModule_smul_apply [SMulCommClass R Sᵐᵒᵖ M]
+    (s : S) (f : M →ₛₗ[σ₁₂] M₂) (m : M) : (s • f) m = f (MulOpposite.op s • m) := rfl
 
 end Module
 

--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Module.Pi
 import Mathlib.Algebra.Ring.CompTypeclasses
 import Mathlib.Algebra.Star.Basic
 import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 import Mathlib.GroupTheory.GroupAction.Hom
 
 #align_import algebra.module.linear_map from "leanprover-community/mathlib"@"cc8e88c7c8c7bc80f91f84d11adb584bf9bd658f"
@@ -858,6 +859,27 @@ instance [DistribMulAction Sᵐᵒᵖ M₂] [SMulCommClass R₂ Sᵐᵒᵖ M₂]
     IsCentralScalar S (M →ₛₗ[σ₁₂] M₂) where
   op_smul_eq_smul _ _ := ext fun _ ↦ op_smul_eq_smul _ _
 
+variable {S' T' : Type*}
+variable [Monoid S'] [DistribMulAction S' M] [SMulCommClass R S' M]
+variable [Monoid T'] [DistribMulAction T' M] [SMulCommClass R T' M]
+
+instance : SMul S'ᵈᵐᵃ (M →ₛₗ[σ₁₂] M₂) :=
+  ⟨fun a f ↦
+    { toFun := a • (f : M → M₂)
+      map_add' := fun x y ↦ by simp only [DomMulAct.smul_apply, f.map_add, smul_add]
+      map_smul' := fun c x ↦ by simp_rw [DomMulAct.smul_apply, ← smul_comm, f.map_smulₛₗ] }⟩
+
+@[simp]
+theorem smul_apply' (a : S'ᵈᵐᵃ) (f : M →ₛₗ[σ₁₂] M₂) (x : M) :
+    (a • f) x = f (DomMulAct.mk.symm a • x) :=
+  rfl
+
+theorem coe_smul' (a : S'ᵈᵐᵃ) (f : M →ₛₗ[σ₁₂] M₂) : (a • f : M →ₛₗ[σ₁₂] M₂) = a • (f : M → M₂) :=
+  rfl
+
+instance [SMulCommClass S' T' M] : SMulCommClass S'ᵈᵐᵃ T'ᵈᵐᵃ (M →ₛₗ[σ₁₂] M₂) :=
+  ⟨fun s t f ↦ ext fun m ↦ by simp_rw [smul_apply', smul_comm]⟩
+
 end SMul
 
 /-! ### Arithmetic on the codomain -/
@@ -1010,6 +1032,13 @@ theorem comp_smul [Module R M₂] [Module R M₃] [SMulCommClass R S M₂] [Dist
   ext fun _ ↦ g.map_smul_of_tower _ _
 #align linear_map.comp_smul LinearMap.comp_smul
 
+instance {S'} [Monoid S'] [DistribMulAction S' M] [SMulCommClass R S' M] :
+    DistribMulAction S'ᵈᵐᵃ (M →ₛₗ[σ₁₂] M₂) where
+  one_smul _ := ext fun _ ↦ congr_arg _ (one_smul _ _)
+  mul_smul _ _ _ := ext fun _ ↦ congr_arg _ (mul_smul _ _ _)
+  smul_add _ _ _ := ext fun _ ↦ rfl
+  smul_zero _ := ext fun _ ↦ rfl
+
 end SMul
 
 section Module
@@ -1022,6 +1051,11 @@ instance module : Module S (M →ₛₗ[σ₁₂] M₂) where
 
 instance [NoZeroSMulDivisors S M₂] : NoZeroSMulDivisors S (M →ₛₗ[σ₁₂] M₂) :=
   coe_injective.noZeroSMulDivisors _ rfl coe_smul
+
+instance {S'} [Semiring S'] [Module S' M] [SMulCommClass R S' M] :
+    Module S'ᵈᵐᵃ (M →ₛₗ[σ₁₂] M₂) where
+  add_smul _ _ _ := ext fun _ ↦ by simp_rw [add_apply, smul_apply', ← map_add, ← add_smul]; rfl
+  zero_smul _ := ext fun _ ↦ by erw [smul_apply', zero_smul, map_zero]; rfl
 
 end Module
 

--- a/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
@@ -110,7 +110,7 @@ run_cmd
     `RightCancelSemigroup, `MulOneClass, `Monoid, `CommMonoid, `LeftCancelMonoid,
     `RightCancelMonoid, `CancelMonoid, `CancelCommMonoid, `InvolutiveInv, `DivInvMonoid,
     `InvOneClass, `DivInvOneMonoid, `DivisionMonoid, `DivisionCommMonoid, `Group,
-    `CommGroup].map Lean.mkIdent do
+    `CommGroup, `Semiring, `Ring, `CommSemiring, `CommRing].map Lean.mkIdent do
   Lean.Elab.Command.elabCommand (← `(
     @[to_additive] instance [$n Mᵐᵒᵖ] : $n Mᵈᵐᵃ := ‹_›
   ))


### PR DESCRIPTION
Co-authored-by: Eric Wieser <wieser.eric@gmail.com>
Co-authored-by: Jujian Zhang <jujian.zhang1998@outlook.com>

This draft PR currently only generalizes a single file TensorProduct.lean; it allows TensorProduct to be taken over a non-commutative ring. Most of the declarations in TensorProduct.lean are now generalized to the non-commutative setting, and very few are deleted (their commutative version will be restored in another file).

Next plans:

+ Change the namespace in TensorProduct.lean from TensorProduct to NonCommTensorProduct, and remove the #aligns

+ I plan to use the same notation for the non-commutative and the commutative TensorProduct, and the user will need to `open scoped` different namespaces to use the one of their choice.

+ Start a new file TensorProduct/Comm.lean, copy the content of TensorProduct.lean on master into it, change the definition TensorProduct to be semi-reducibly defeq to NonCommTensorProduct (in order to support more instances or unify non-defeq instances that become prop-eq in the commutative setting, e.g. we've chosen the R-action on a tensor product over commutative R to come from the left factor, since the action from the right factor is the same), and reuse the NonComm constructions as much as possible. We then change all files that imports TensorProduct.lean to import TensorProduct/Comm.lean instead. Once we do that, mathlib would compile and  this PR would be complete. We can gradually generalize other files about tensor products this way.

In this PR:

`TensorProduct.map` is now defined in terms of `lTensor` and `rTensor` rather than the other way around, which requires moving `lTensor` and `rTensor` up from their original location. The definition of `rid` also becomes more challenging and is moved down.

An evident observation is that actions on the domain of AddMonoidHom / LinearMap is really natural in the context of tensor products and Hom-tensor adjunction (`TensorProduct.lift`), not the default actions on the codomain. For example, it allows us to write the "balanced biadditive monoid homs" in #8536 as simply `N →ₗ[R] M →+ P` (where the right R-action on M turns into the left action on `M →+ P`).

For this reason, we disable the default instances `AddMonoidHom/LinearMap.module` at the beginning of the file and enable the `AddMonoidHom/LinearMap.domModule` instances instead. (The action on the codomain would be necessary for the non-commutative version of [TensorProduct.lTensorHomToHomLTensor](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/TensorProduct.html#TensorProduct.lTensorHomToHomLTensor) (in the form of `P ⊗[R] (M →+ Q) →+ M →+ P ⊗[R] Q`), but I've deleted it for now.)

We register actions on the left factor of a tensor product as the default instance, but we also talk about actions on the right factor (`attribute [local instance] rightModule`).

The Tensor-Hom adjunction #8495 is now `uncurryEquiv` in this PR.

#8519 is now included in this PR and #8584 is now called `lift` in this PR.

`CharacterModule.homEquiv` in #8559 can be obtained by combining `liftEquiv` and `flipMop` in this PR (except for a mop). To refactor the commutative tensor product, we'd need to transfer many R^mop-action to R-action and R^mop-LinearMaps to R-LinearMaps, which can be achieved via `Module.compHom` and `LinearMap.restrictScalars` (requires `LinearMap.CompatibleSMul` instance) given `RingEquiv.toOpposite`. `LinearMap.characterfy` and `CharacterModule.cong` could be obtained from `LinearMap.compAddMonoidHom` in this PR.

TODO:

+ Move delarations that belong to other files.

+ Change docstrings that are no longer accurate.

+ Fix some argument order to be more natural.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
