### PR TITLE
[Merged by Bors] - feat: remove an assumption

### DIFF
--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -730,7 +730,8 @@ lemma finEquivZpowers_apply (hx) {n : Fin (orderOf x)} :
 
 -- This lemma has always been bad, but the linter only noticed after leaprover/lean4#2644.
 @[to_additive (attr := simp, nolint simpNF) finEquivZmultiples_symm_apply]
-lemma finEquivZpowers_symm_apply (x : G) (hx) (n : ℕ) {hn : ∃ m : ℤ, x ^ m = x ^ n} :
+lemma finEquivZpowers_symm_apply (x : G) (hx) (n : ℕ) :
+    letI hn : ∃ m : ℤ, x ^ m = x ^ n := ⟨n, by simp⟩
     (finEquivZpowers x hx).symm ⟨x ^ n, hn⟩ = ⟨n % orderOf x, Nat.mod_lt _ hx.orderOf_pos⟩ := by
   rw [finEquivZpowers, Equiv.symm_trans_apply]; exact finEquivPowers_symm_apply x _ n
 #align fin_equiv_zpowers_symm_apply finEquivZpowers_symm_apply

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -728,7 +728,7 @@ lemma finEquivZpowers_apply (hx) {n : Fin (orderOf x)} :
 #align fin_equiv_zpowers_apply finEquivZpowers_apply
 #align fin_equiv_zmultiples_apply finEquivZmultiples_apply
 
--- This lemma has always been bad, but the linter only noticed after leaprover/lean4#2644.
+ -- This lemma has always been bad, but the linter only noticed after leanprover/lean4#2644.
 @[to_additive (attr := simp, nolint simpNF) finEquivZmultiples_symm_apply]
 lemma finEquivZpowers_symm_apply (x : G) (hx) (n : ℕ) :
     letI hn : ∃ m : ℤ, x ^ m = x ^ n := ⟨n, by simp⟩

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -731,8 +731,8 @@ lemma finEquivZpowers_apply (hx) {n : Fin (orderOf x)} :
  -- This lemma has always been bad, but the linter only noticed after leanprover/lean4#2644.
 @[to_additive (attr := simp, nolint simpNF) finEquivZmultiples_symm_apply]
 lemma finEquivZpowers_symm_apply (x : G) (hx) (n : ℕ) :
-    letI hn : ∃ m : ℤ, x ^ m = x ^ n := ⟨n, by simp⟩
-    (finEquivZpowers x hx).symm ⟨x ^ n, hn⟩ = ⟨n % orderOf x, Nat.mod_lt _ hx.orderOf_pos⟩ := by
+    (finEquivZpowers x hx).symm ⟨x ^ n, ⟨n, by simp⟩⟩ =
+    ⟨n % orderOf x, Nat.mod_lt _ hx.orderOf_pos⟩ := by
   rw [finEquivZpowers, Equiv.symm_trans_apply]; exact finEquivPowers_symm_apply x _ n
 #align fin_equiv_zpowers_symm_apply finEquivZpowers_symm_apply
 #align fin_equiv_zmultiples_symm_apply finEquivZmultiples_symm_apply


### PR DESCRIPTION
The assumption `hn` in [finEquivZpowers_symm_apply](https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/OrderOfElement.html#finEquivZpowers_symm_apply) always holds.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
