### PR TITLE
[Merged by Bors] - fix: lean4-ify names of inductive constructors

### DIFF
--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -61,14 +61,14 @@ namespace FreeAlgebra
 -/
 inductive Pre
   | of : X → Pre
-  | of_scalar : R → Pre
+  | ofScalar : R → Pre
   | add : Pre → Pre → Pre
   | mul : Pre → Pre → Pre
 #align free_algebra.pre FreeAlgebra.Pre
 
 namespace Pre
 
-instance : Inhabited (Pre R X) := ⟨of_scalar 0⟩
+instance : Inhabited (Pre R X) := ⟨ofScalar 0⟩
 
 -- Note: These instances are only used to simplify the notation.
 /-- Coercion from `X` to `Pre R X`. Note: Used for notation only. -/
@@ -76,7 +76,7 @@ def hasCoeGenerator : Coe X (Pre R X) := ⟨of⟩
 #align free_algebra.pre.has_coe_generator FreeAlgebra.Pre.hasCoeGenerator
 
 /-- Coercion from `R` to `Pre R X`. Note: Used for notation only. -/
-def hasCoeSemiring : Coe R (Pre R X) := ⟨of_scalar⟩
+def hasCoeSemiring : Coe R (Pre R X) := ⟨ofScalar⟩
 #align free_algebra.pre.has_coe_semiring FreeAlgebra.Pre.hasCoeSemiring
 
 /-- Multiplication in `Pre R X` defined as `Pre.mul`. Note: Used for notation only. -/
@@ -88,17 +88,17 @@ def hasAdd : Add (Pre R X) := ⟨add⟩
 #align free_algebra.pre.has_add FreeAlgebra.Pre.hasAdd
 
 /-- Zero in `Pre R X` defined as the image of `0` from `R`. Note: Used for notation only. -/
-def hasZero : Zero (Pre R X) := ⟨of_scalar 0⟩
+def hasZero : Zero (Pre R X) := ⟨ofScalar 0⟩
 #align free_algebra.pre.has_zero FreeAlgebra.Pre.hasZero
 
 /-- One in `Pre R X` defined as the image of `1` from `R`. Note: Used for notation only. -/
-def hasOne : One (Pre R X) := ⟨of_scalar 1⟩
+def hasOne : One (Pre R X) := ⟨ofScalar 1⟩
 #align free_algebra.pre.has_one FreeAlgebra.Pre.hasOne
 
 /-- Scalar multiplication defined as multiplication by the image of elements from `R`.
 Note: Used for notation only.
 -/
-def hasSmul : SMul R (Pre R X) := ⟨fun r m ↦ mul (of_scalar r) m⟩
+def hasSmul : SMul R (Pre R X) := ⟨fun r m ↦ mul (ofScalar r) m⟩
 #align free_algebra.pre.has_smul FreeAlgebra.Pre.hasSmul
 
 end Pre
@@ -115,14 +115,14 @@ def liftFun {A : Type*} [Semiring A] [Algebra R A] (f : X → A) :
   | .of t => f t
   | .add a b => liftFun f a + liftFun f b
   | .mul a b => liftFun f a * liftFun f b
-  | .of_scalar c => algebraMap _ _ c
+  | .ofScalar c => algebraMap _ _ c
 #align free_algebra.lift_fun FreeAlgebra.liftFun
 
 /-- An inductively defined relation on `Pre R X` used to force the initial algebra structure on
 the associated quotient.
 -/
 inductive Rel : Pre R X → Pre R X → Prop
-  -- force `of_scalar` to be a central semiring morphism
+  -- force `ofScalar` to be a central semiring morphism
   | add_scalar {r s : R} : Rel (↑(r + s)) (↑r + ↑s)
   | mul_scalar {r s : R} : Rel (↑(r * s)) (↑r * ↑s)
   | central_scalar {r : R} {a : Pre R X} : Rel (r * a) (a * r)
@@ -375,7 +375,7 @@ def lift : (X → A) ≃ (FreeAlgebra R X →ₐ[R] A) :=
       case of =>
         change ((F : FreeAlgebra R X → A) ∘ ι R) _ = _
         simp only [Function.comp_apply, ι_def]
-      case of_scalar x =>
+      case ofScalar x =>
         change algebraMap _ _ x = F (algebraMap _ _ x)
         rw [AlgHom.commutes F _]
       case add a b ha hb =>

--- a/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
@@ -44,7 +44,7 @@ tensor products of identities, unitors and associators.
 -/
 inductive FreeMonoidalCategory : Type u
   | of : C → FreeMonoidalCategory
-  | Unit : FreeMonoidalCategory
+  | unit : FreeMonoidalCategory
   | tensor : FreeMonoidalCategory → FreeMonoidalCategory → FreeMonoidalCategory
   deriving Inhabited
 #align category_theory.free_monoidal_category CategoryTheory.FreeMonoidalCategory
@@ -55,7 +55,7 @@ local notation "F" => FreeMonoidalCategory
 
 namespace FreeMonoidalCategory
 
-attribute [nolint simpNF] Unit.sizeOf_spec tensor.injEq tensor.sizeOf_spec
+attribute [nolint simpNF] unit.sizeOf_spec tensor.injEq tensor.sizeOf_spec
 
 /-- Formal compositions and tensor products of identities, unitors and associators. The morphisms
     of the free monoidal category are obtained as a quotient of these formal morphisms by the
@@ -66,10 +66,10 @@ inductive Hom : F C → F C → Type u
   | id (X) : Hom X X
   | α_hom (X Y Z : F C) : Hom ((X.tensor Y).tensor Z) (X.tensor (Y.tensor Z))
   | α_inv (X Y Z : F C) : Hom (X.tensor (Y.tensor Z)) ((X.tensor Y).tensor Z)
-  | l_hom (X) : Hom (Unit.tensor X) X
-  | l_inv (X) : Hom X (Unit.tensor X)
-  | ρ_hom (X : F C) : Hom (X.tensor Unit) X
-  | ρ_inv (X : F C) : Hom X (X.tensor Unit)
+  | l_hom (X) : Hom (unit.tensor X) X
+  | l_inv (X) : Hom X (unit.tensor X)
+  | ρ_hom (X : F C) : Hom (X.tensor unit) X
+  | ρ_inv (X : F C) : Hom X (X.tensor unit)
   | comp {X Y Z} (f : Hom X Y) (g : Hom Y Z) : Hom X Z
   | tensor {W X Y Z} (f : Hom W Y) (g : Hom X Z) : Hom (W.tensor X) (Y.tensor Z)
 #align category_theory.free_monoidal_category.hom CategoryTheory.FreeMonoidalCategory.Hom
@@ -102,18 +102,18 @@ inductive HomEquiv : ∀ {X Y : F C}, (X ⟶ᵐ Y) → (X ⟶ᵐ Y) → Prop
   | ρ_hom_inv {X} : HomEquiv ((Hom.ρ_hom X).comp (Hom.ρ_inv X)) (Hom.id _)
   | ρ_inv_hom {X} : HomEquiv ((Hom.ρ_inv X).comp (Hom.ρ_hom X)) (Hom.id _)
   | ρ_naturality {X Y} (f : X ⟶ᵐ Y) :
-      HomEquiv ((f.tensor (Hom.id Unit)).comp (Hom.ρ_hom Y)) ((Hom.ρ_hom X).comp f)
+      HomEquiv ((f.tensor (Hom.id unit)).comp (Hom.ρ_hom Y)) ((Hom.ρ_hom X).comp f)
   | l_hom_inv {X} : HomEquiv ((Hom.l_hom X).comp (Hom.l_inv X)) (Hom.id _)
   | l_inv_hom {X} : HomEquiv ((Hom.l_inv X).comp (Hom.l_hom X)) (Hom.id _)
   | l_naturality {X Y} (f : X ⟶ᵐ Y) :
-      HomEquiv (((Hom.id Unit).tensor f).comp (Hom.l_hom Y)) ((Hom.l_hom X).comp f)
+      HomEquiv (((Hom.id unit).tensor f).comp (Hom.l_hom Y)) ((Hom.l_hom X).comp f)
   | pentagon {W X Y Z} :
       HomEquiv
         (((Hom.α_hom W X Y).tensor (Hom.id Z)).comp
           ((Hom.α_hom W (X.tensor Y) Z).comp ((Hom.id W).tensor (Hom.α_hom X Y Z))))
         ((Hom.α_hom (W.tensor X) Y Z).comp (Hom.α_hom W X (Y.tensor Z)))
   | triangle {X Y} :
-      HomEquiv ((Hom.α_hom X Unit Y).comp ((Hom.id X).tensor (Hom.l_hom Y)))
+      HomEquiv ((Hom.α_hom X unit Y).comp ((Hom.id X).tensor (Hom.l_hom Y)))
         ((Hom.ρ_hom X).tensor (Hom.id Y))
 set_option linter.uppercaseLean3 false
 #align category_theory.free_monoidal_category.HomEquiv CategoryTheory.FreeMonoidalCategory.HomEquiv
@@ -185,7 +185,7 @@ instance : MonoidalCategory (F C) where
   tensor_comp := @fun X₁ Y₁ Z₁ X₂ Y₂ Z₂ => by
     rintro ⟨f₁⟩ ⟨f₂⟩ ⟨g₁⟩ ⟨g₂⟩
     exact Quotient.sound (tensor_comp _ _ _ _)
-  tensorUnit := FreeMonoidalCategory.Unit
+  tensorUnit := FreeMonoidalCategory.unit
   associator X Y Z :=
     ⟨⟦Hom.α_hom X Y Z⟧, ⟦Hom.α_inv X Y Z⟧, Quotient.sound α_hom_inv, Quotient.sound α_inv_hom⟩
   associator_naturality := @fun X₁ X₂ X₃ Y₁ Y₂ Y₃ => by
@@ -256,7 +256,7 @@ theorem tensor_eq_tensor {X Y : F C} : X.tensor Y = X ⊗ Y :=
 #align category_theory.free_monoidal_category.tensor_eq_tensor CategoryTheory.FreeMonoidalCategory.tensor_eq_tensor
 
 @[simp]
-theorem unit_eq_unit : FreeMonoidalCategory.Unit = 𝟙_ (F C) :=
+theorem unit_eq_unit : FreeMonoidalCategory.unit = 𝟙_ (F C) :=
   rfl
 #align category_theory.free_monoidal_category.unit_eq_unit CategoryTheory.FreeMonoidalCategory.unit_eq_unit
 
@@ -267,7 +267,7 @@ variable {D : Type u'} [Category.{v'} D] [MonoidalCategory D] (f : C → D)
 /-- Auxiliary definition for `free_monoidal_category.project`. -/
 def projectObj : F C → D
   | FreeMonoidalCategory.of X => f X
-  | FreeMonoidalCategory.Unit => 𝟙_ D
+  | FreeMonoidalCategory.unit => 𝟙_ D
   | FreeMonoidalCategory.tensor X Y => projectObj X ⊗ projectObj Y
 #align category_theory.free_monoidal_category.project_obj CategoryTheory.FreeMonoidalCategory.projectObj
 

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -55,7 +55,7 @@ variable (C)
     `(((𝟙_ C) ⊗ X₁) ⊗ X₂) ⊗ ⋯`. -/
 -- porting note: removed @[nolint has_nonempty_instance]
 inductive NormalMonoidalObject : Type u
-  | Unit : NormalMonoidalObject
+  | unit : NormalMonoidalObject
   | tensor : NormalMonoidalObject → C → NormalMonoidalObject
 #align category_theory.free_monoidal_category.normal_monoidal_object CategoryTheory.FreeMonoidalCategory.NormalMonoidalObject
 
@@ -73,7 +73,7 @@ instance (x y : N C) : Subsingleton (x ⟶ y) := Discrete.instSubsingletonDiscre
 /-- Auxiliary definition for `inclusion`. -/
 @[simp]
 def inclusionObj : NormalMonoidalObject C → F C
-  | NormalMonoidalObject.Unit => Unit
+  | NormalMonoidalObject.unit => unit
   | NormalMonoidalObject.tensor n a => tensor (inclusionObj n) (of a)
 #align category_theory.free_monoidal_category.inclusion_obj CategoryTheory.FreeMonoidalCategory.inclusionObj
 
@@ -86,7 +86,7 @@ def inclusion : N C ⥤ F C :=
 /-- Auxiliary definition for `normalize`. -/
 @[simp]
 def normalizeObj : F C → NormalMonoidalObject C → N C
-  | Unit, n => ⟨n⟩
+  | unit, n => ⟨n⟩
   | of X, n => ⟨NormalMonoidalObject.tensor n X⟩
   | tensor X Y, n => normalizeObj Y (normalizeObj X n).as
 #align category_theory.free_monoidal_category.normalize_obj CategoryTheory.FreeMonoidalCategory.normalizeObj
@@ -154,8 +154,8 @@ def normalize' : F C ⥤ N C ⥤ F C :=
 
 /-- The normalization functor for the free monoidal category over `C`. -/
 def fullNormalize : F C ⥤ N C where
-  obj X := ((normalize C).obj X).obj ⟨NormalMonoidalObject.Unit⟩
-  map f := ((normalize C).map f).app ⟨NormalMonoidalObject.Unit⟩
+  obj X := ((normalize C).obj X).obj ⟨NormalMonoidalObject.unit⟩
+  map f := ((normalize C).map f).app ⟨NormalMonoidalObject.unit⟩
 #align category_theory.free_monoidal_category.full_normalize CategoryTheory.FreeMonoidalCategory.fullNormalize
 
 /-- Given an object `X` of the free monoidal category and an object `n` in normal form, taking
@@ -187,7 +187,7 @@ theorem tensorFunc_obj_map (Z : F C) {n n' : N C} (f : n ⟶ n') :
 def normalizeIsoApp :
     ∀ (X : F C) (n : N C), ((tensorFunc C).obj X).obj n ≅ ((normalize' C).obj X).obj n
   | of _, _ => Iso.refl _
-  | Unit, _ => ρ_ _
+  | unit, _ => ρ_ _
   | tensor X _, n =>
     (α_ _ _ _).symm ≪≫ tensorIso (normalizeIsoApp X n) (Iso.refl _) ≪≫ normalizeIsoApp _ _
 #align category_theory.free_monoidal_category.normalize_iso_app CategoryTheory.FreeMonoidalCategory.normalizeIsoApp
@@ -314,13 +314,13 @@ def normalizeIso : tensorFunc C ≅ normalize' C :=
 /-- The isomorphism between an object and its normal form is natural. -/
 def fullNormalizeIso : 𝟭 (F C) ≅ fullNormalize C ⋙ inclusion :=
   NatIso.ofComponents
-  (fun X => (λ_ X).symm ≪≫ ((normalizeIso C).app X).app ⟨NormalMonoidalObject.Unit⟩)
+  (fun X => (λ_ X).symm ≪≫ ((normalizeIso C).app X).app ⟨NormalMonoidalObject.unit⟩)
     (by
       intro X Y f
       dsimp
       rw [leftUnitor_inv_naturality_assoc, Category.assoc, Iso.cancel_iso_inv_left]
       exact
-        congr_arg (fun f => NatTrans.app f (Discrete.mk NormalMonoidalObject.Unit))
+        congr_arg (fun f => NatTrans.app f (Discrete.mk NormalMonoidalObject.unit))
           ((normalizeIso.{u} C).hom.naturality f))
 #align category_theory.free_monoidal_category.full_normalize_iso CategoryTheory.FreeMonoidalCategory.fullNormalizeIso
 

--- a/Mathlib/Geometry/Euclidean/Circumcenter.lean
+++ b/Mathlib/Geometry/Euclidean/Circumcenter.lean
@@ -517,27 +517,27 @@ affine combinations of vertices together with the circumcenter.  (An
 equivalent form sometimes used in the literature is placing the
 circumcenter at the origin and working with vectors for the vertices.) -/
 inductive PointsWithCircumcenterIndex (n : ℕ)
-  | point_index : Fin (n + 1) → PointsWithCircumcenterIndex n
-  | circumcenter_index : PointsWithCircumcenterIndex n
+  | pointIndex : Fin (n + 1) → PointsWithCircumcenterIndex n
+  | circumcenterIndex : PointsWithCircumcenterIndex n
   deriving Fintype
 #align affine.simplex.points_with_circumcenter_index Affine.Simplex.PointsWithCircumcenterIndex
 
 open PointsWithCircumcenterIndex
 
 instance pointsWithCircumcenterIndexInhabited (n : ℕ) : Inhabited (PointsWithCircumcenterIndex n) :=
-  ⟨circumcenter_index⟩
+  ⟨circumcenterIndex⟩
 #align affine.simplex.points_with_circumcenter_index_inhabited Affine.Simplex.pointsWithCircumcenterIndexInhabited
 
-/-- `point_index` as an embedding. -/
+/-- `pointIndex` as an embedding. -/
 def pointIndexEmbedding (n : ℕ) : Fin (n + 1) ↪ PointsWithCircumcenterIndex n :=
-  ⟨fun i => point_index i, fun _ _ h => by injection h⟩
+  ⟨fun i => pointIndex i, fun _ _ h => by injection h⟩
 #align affine.simplex.point_index_embedding Affine.Simplex.pointIndexEmbedding
 
 /-- The sum of a function over `PointsWithCircumcenterIndex`. -/
 theorem sum_pointsWithCircumcenter {α : Type*} [AddCommMonoid α] {n : ℕ}
     (f : PointsWithCircumcenterIndex n → α) :
-    ∑ i, f i = (∑ i : Fin (n + 1), f (point_index i)) + f circumcenter_index := by
-  have h : univ = insert circumcenter_index (univ.map (pointIndexEmbedding n)) := by
+    ∑ i, f i = (∑ i : Fin (n + 1), f (pointIndex i)) + f circumcenterIndex := by
+  have h : univ = insert circumcenterIndex (univ.map (pointIndexEmbedding n)) := by
     ext x
     refine' ⟨fun h => _, fun _ => mem_univ _⟩
     cases' x with i
@@ -552,38 +552,38 @@ theorem sum_pointsWithCircumcenter {α : Type*} [AddCommMonoid α] {n : ℕ}
 
 /-- The vertices of a simplex plus its circumcenter. -/
 def pointsWithCircumcenter {n : ℕ} (s : Simplex ℝ P n) : PointsWithCircumcenterIndex n → P
-  | point_index i => s.points i
-  | circumcenter_index => s.circumcenter
+  | pointIndex i => s.points i
+  | circumcenterIndex => s.circumcenter
 #align affine.simplex.points_with_circumcenter Affine.Simplex.pointsWithCircumcenter
 
-/-- `pointsWithCircumcenter`, applied to a `point_index` value,
+/-- `pointsWithCircumcenter`, applied to a `pointIndex` value,
 equals `points` applied to that value. -/
 @[simp]
 theorem pointsWithCircumcenter_point {n : ℕ} (s : Simplex ℝ P n) (i : Fin (n + 1)) :
-    s.pointsWithCircumcenter (point_index i) = s.points i :=
+    s.pointsWithCircumcenter (pointIndex i) = s.points i :=
   rfl
 #align affine.simplex.points_with_circumcenter_point Affine.Simplex.pointsWithCircumcenter_point
 
-/-- `pointsWithCircumcenter`, applied to `circumcenter_index`, equals the
+/-- `pointsWithCircumcenter`, applied to `circumcenterIndex`, equals the
 circumcenter. -/
 @[simp]
 theorem pointsWithCircumcenter_eq_circumcenter {n : ℕ} (s : Simplex ℝ P n) :
-    s.pointsWithCircumcenter circumcenter_index = s.circumcenter :=
+    s.pointsWithCircumcenter circumcenterIndex = s.circumcenter :=
   rfl
 #align affine.simplex.points_with_circumcenter_eq_circumcenter Affine.Simplex.pointsWithCircumcenter_eq_circumcenter
 
 /-- The weights for a single vertex of a simplex, in terms of
 `pointsWithCircumcenter`. -/
 def pointWeightsWithCircumcenter {n : ℕ} (i : Fin (n + 1)) : PointsWithCircumcenterIndex n → ℝ
-  | point_index j => if j = i then 1 else 0
-  | circumcenter_index => 0
+  | pointIndex j => if j = i then 1 else 0
+  | circumcenterIndex => 0
 #align affine.simplex.point_weights_with_circumcenter Affine.Simplex.pointWeightsWithCircumcenter
 
 /-- `point_weights_with_circumcenter` sums to 1. -/
 @[simp]
 theorem sum_pointWeightsWithCircumcenter {n : ℕ} (i : Fin (n + 1)) :
     ∑ j, pointWeightsWithCircumcenter i j = 1 := by
-  convert sum_ite_eq' univ (point_index i) (Function.const _ (1 : ℝ)) with j
+  convert sum_ite_eq' univ (pointIndex i) (Function.const _ (1 : ℝ)) with j
   · cases j <;> simp [pointWeightsWithCircumcenter]
   · simp
 #align affine.simplex.sum_point_weights_with_circumcenter Affine.Simplex.sum_pointWeightsWithCircumcenter
@@ -610,8 +610,8 @@ theorem point_eq_affineCombination_of_pointsWithCircumcenter {n : ℕ} (s : Simp
 terms of `pointsWithCircumcenter`. -/
 def centroidWeightsWithCircumcenter {n : ℕ} (fs : Finset (Fin (n + 1))) :
     PointsWithCircumcenterIndex n → ℝ
-  | point_index i => if i ∈ fs then (card fs : ℝ)⁻¹ else 0
-  | circumcenter_index => 0
+  | pointIndex i => if i ∈ fs then (card fs : ℝ)⁻¹ else 0
+  | circumcenterIndex => 0
 #align affine.simplex.centroid_weights_with_circumcenter Affine.Simplex.centroidWeightsWithCircumcenter
 
 /-- `centroidWeightsWithCircumcenter` sums to 1, if the `Finset` is nonempty. -/
@@ -641,15 +641,15 @@ theorem centroid_eq_affineCombination_of_pointsWithCircumcenter {n : ℕ} (s : S
 
 /-- The weights for the circumcenter of a simplex, in terms of `pointsWithCircumcenter`. -/
 def circumcenterWeightsWithCircumcenter (n : ℕ) : PointsWithCircumcenterIndex n → ℝ
-  | point_index _ => 0
-  | circumcenter_index => 1
+  | pointIndex _ => 0
+  | circumcenterIndex => 1
 #align affine.simplex.circumcenter_weights_with_circumcenter Affine.Simplex.circumcenterWeightsWithCircumcenter
 
 /-- `circumcenterWeightsWithCircumcenter` sums to 1. -/
 @[simp]
 theorem sum_circumcenterWeightsWithCircumcenter (n : ℕ) :
     ∑ i, circumcenterWeightsWithCircumcenter n i = 1 := by
-  convert sum_ite_eq' univ circumcenter_index (Function.const _ (1 : ℝ)) with j
+  convert sum_ite_eq' univ circumcenterIndex (Function.const _ (1 : ℝ)) with j
   · cases j <;> simp [circumcenterWeightsWithCircumcenter]
   · simp
 #align affine.simplex.sum_circumcenter_weights_with_circumcenter Affine.Simplex.sum_circumcenterWeightsWithCircumcenter
@@ -669,8 +669,8 @@ theorem circumcenter_eq_affineCombination_of_pointsWithCircumcenter {n : ℕ} (s
 simplex.  This definition is only valid with `i₁ ≠ i₂`. -/
 def reflectionCircumcenterWeightsWithCircumcenter {n : ℕ} (i₁ i₂ : Fin (n + 1)) :
     PointsWithCircumcenterIndex n → ℝ
-  | point_index i => if i = i₁ ∨ i = i₂ then 1 else 0
-  | circumcenter_index => -1
+  | pointIndex i => if i = i₁ ∨ i = i₂ then 1 else 0
+  | circumcenterIndex => -1
 #align affine.simplex.reflection_circumcenter_weights_with_circumcenter Affine.Simplex.reflectionCircumcenterWeightsWithCircumcenter
 
 /-- `reflectionCircumcenterWeightsWithCircumcenter` sums to 1. -/

--- a/Mathlib/Geometry/Euclidean/MongePoint.lean
+++ b/Mathlib/Geometry/Euclidean/MongePoint.lean
@@ -161,8 +161,8 @@ centroid of an n-dimensional face, in terms of
 `pointsWithCircumcenter`.  This definition is only valid when `i₁ ≠ i₂`. -/
 def mongePointVSubFaceCentroidWeightsWithCircumcenter {n : ℕ} (i₁ i₂ : Fin (n + 3)) :
     PointsWithCircumcenterIndex (n + 2) → ℝ
-  | point_index i => if i = i₁ ∨ i = i₂ then ((n + 1 : ℕ) : ℝ)⁻¹ else 0
-  | circumcenter_index => -2 / ((n + 1 : ℕ) : ℝ)
+  | pointIndex i => if i = i₁ ∨ i = i₂ then ((n + 1 : ℕ) : ℝ)⁻¹ else 0
+  | circumcenterIndex => -2 / ((n + 1 : ℕ) : ℝ)
 #align affine.simplex.monge_point_vsub_face_centroid_weights_with_circumcenter Affine.Simplex.mongePointVSubFaceCentroidWeightsWithCircumcenter
 
 /-- `mongePointVSubFaceCentroidWeightsWithCircumcenter` is the

--- a/Mathlib/Geometry/Euclidean/MongePoint.lean
+++ b/Mathlib/Geometry/Euclidean/MongePoint.lean
@@ -111,8 +111,8 @@ theorem mongePoint_eq_of_range_eq {n : ℕ} {s₁ s₂ : Simplex ℝ P n}
 /-- The weights for the Monge point of an (n+2)-simplex, in terms of
 `pointsWithCircumcenter`. -/
 def mongePointWeightsWithCircumcenter (n : ℕ) : PointsWithCircumcenterIndex (n + 2) → ℝ
-  | point_index _ => ((n + 1 : ℕ) : ℝ)⁻¹
-  | circumcenter_index => -2 / ((n + 1 : ℕ) : ℝ)
+  | pointIndex _ => ((n + 1 : ℕ) : ℝ)⁻¹
+  | circumcenterIndex => -2 / ((n + 1 : ℕ) : ℝ)
 #align affine.simplex.monge_point_weights_with_circumcenter Affine.Simplex.mongePointWeightsWithCircumcenter
 
 /-- `mongePointWeightsWithCircumcenter` sums to 1. -/

--- a/Mathlib/Tactic/CategoryTheory/Coherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence.lean
@@ -49,7 +49,7 @@ It must be the case that `projectObj id (LiftObj.lift x) = x` by defeq. -/
 class LiftObj (X : C) where
   protected lift : FreeMonoidalCategory C
 
-instance LiftObj_unit : LiftObj (𝟙_ C) := ⟨Unit⟩
+instance LiftObj_unit : LiftObj (𝟙_ C) := ⟨unit⟩
 
 instance LiftObj_tensor (X Y : C) [LiftObj X] [LiftObj Y] : LiftObj (X ⊗ Y) where
   lift := LiftObj.lift X ⊗ LiftObj.lift Y


### PR DESCRIPTION
These inductive types carry data, so these should be `functionCase` not `theorem_case`.

It seems that mathport didn't do this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
