### PR TITLE
feat: support right actions for `Con`

### DIFF
--- a/Mathlib/GroupTheory/Congruence.lean
+++ b/Mathlib/GroupTheory/Congruence.lean
@@ -1147,10 +1147,36 @@ instance one [MulOneClass M] (c : Con M) : One c.Quotient where
   one := Quotient.mk'' (1 : M)
   -- one := ((1 : M) : c.Quotient)
 
+/-- The proposition that the `+ᵥ` operation is compatible with the congruence relation.
+
+Note that this is similar to `AddAction.QuotientAction`, but with slightly different assumptions. -/
+class _root_.AddCon.CompatibleVAdd (α : Type*) [Add M] [VAdd α M] (c : AddCon M) :
+    Prop where
+  rel_smul (a : α) {w x : M} : c w x → c (a +ᵥ w) (a +ᵥ x)
+
+/-- The proposition that the `•` operation is compatible with the congruence relation.
+
+Note that this is similar to `MulAction.QuotientAction`, but with slightly different assumptions. -/
 @[to_additive]
-theorem smul {α M : Type*} [MulOneClass M] [SMul α M] [IsScalarTower α M M] (c : Con M) (a : α)
-    {w x : M} (h : c w x) : c (a • w) (a • x) := by
-  simpa only [smul_one_mul] using c.mul (c.refl' (a • (1 : M) : M)) h
+class CompatibleSMul (α : Type*) [Mul M] [SMul α M] (c : Con M) : Prop where
+  rel_smul (a : α) {w x : M} : c w x → c (a • w) (a • x)
+
+/-- This instance notably works for `α = M`. -/
+@[to_additive]
+instance CompatibleSMul.ofIsScalarTower {α M : Type*}
+    [MulOneClass M] [SMul α M] [IsScalarTower α M M] (c : Con M) : CompatibleSMul α c where
+  rel_smul a w x h := by simpa only [smul_one_mul] using c.mul (c.refl' (a • (1 : M) : M)) h
+
+/-- This instance notably works for `α = Mᵐᵒᵖ`. -/
+@[to_additive]
+instance CompatibleSMul.ofSMulCommClass {α M : Type*}
+    [MulOneClass M] [SMul α M] [SMulCommClass α M M] (c : Con M) : CompatibleSMul α c where
+  rel_smul a w x h := by simpa only [mul_smul_one] using c.mul h (c.refl' (a • (1 : M) : M))
+
+@[to_additive]
+theorem smul {α M : Type*} [Mul M] [SMul α M] (c : Con M) [CompatibleSMul α c] (a : α)
+    {w x : M} (h : c w x) : c (a • w) (a • x) :=
+  CompatibleSMul.rel_smul _ h
 #align con.smul Con.smul
 #align add_con.vadd AddCon.vadd
 
@@ -1370,29 +1396,47 @@ end Units
 section Actions
 
 @[to_additive]
-instance instSMul {α M : Type*} [MulOneClass M] [SMul α M] [IsScalarTower α M M] (c : Con M) :
+instance instSMul {α M : Type*} [Mul M] [SMul α M] (c : Con M) [CompatibleSMul α c] :
     SMul α c.Quotient where
   smul a := (Quotient.map' ((· • ·) a)) fun _ _ => c.smul a
 #align con.has_smul Con.instSMul
 #align add_con.has_vadd AddCon.instVAdd
 
+instance instIsScalarTower
+    {α β M : Type*} [Mul M] [SMul α β] [SMul α M] [SMul β M] (c : Con M)
+    [CompatibleSMul α c] [CompatibleSMul β c] [IsScalarTower α β M] :
+    IsScalarTower α β c.Quotient where
+  smul_assoc _ _ := Quotient.ind' fun _ => congr_arg Quotient.mk'' <| smul_assoc _ _ _
+
+instance instSMulCommClass
+    {α β M : Type*} [Mul M] [SMul α M] [SMul β M] (c : Con M)
+    [CompatibleSMul α c] [CompatibleSMul β c] [SMulCommClass α β M] :
+    SMulCommClass α β c.Quotient where
+  smul_comm _ _ := Quotient.ind' fun _ => congr_arg Quotient.mk'' <| smul_comm _ _ _
+
+instance instIsCentralScalar
+    {α M : Type*} [Mul M] [SMul α M] [SMul αᵐᵒᵖ M] (c : Con M)
+    [CompatibleSMul α c] [CompatibleSMul αᵐᵒᵖ c] [IsCentralScalar α M] :
+    IsCentralScalar α c.Quotient where
+  op_smul_eq_smul _ := Quotient.ind' fun _ => congr_arg Quotient.mk'' <| op_smul_eq_smul _ _
+
 @[to_additive]
-theorem coe_smul {α M : Type*} [MulOneClass M] [SMul α M] [IsScalarTower α M M] (c : Con M)
+theorem coe_smul {α M : Type*} [Mul M] [SMul α M] (c : Con M) [CompatibleSMul α c]
     (a : α) (x : M) : (↑(a • x) : c.Quotient) = a • (x : c.Quotient) :=
   rfl
 #align con.coe_smul Con.coe_smul
 #align add_con.coe_vadd AddCon.coe_vadd
 
 @[to_additive]
-instance mulAction {α M : Type*} [Monoid α] [MulOneClass M] [MulAction α M] [IsScalarTower α M M]
-    (c : Con M) : MulAction α c.Quotient where
+instance mulAction {α M : Type*} [Monoid α] [Mul M] [MulAction α M]
+    (c : Con M) [CompatibleSMul α c] : MulAction α c.Quotient where
   one_smul := Quotient.ind' fun _ => congr_arg Quotient.mk'' <| one_smul _ _
   mul_smul _ _ := Quotient.ind' fun _ => congr_arg Quotient.mk'' <| mul_smul _ _ _
 #align con.mul_action Con.mulAction
 #align add_con.add_action AddCon.addAction
 
 instance mulDistribMulAction {α M : Type*} [Monoid α] [Monoid M] [MulDistribMulAction α M]
-    [IsScalarTower α M M] (c : Con M) : MulDistribMulAction α c.Quotient :=
+    (c : Con M) [CompatibleSMul α c] : MulDistribMulAction α c.Quotient :=
   { smul_one := fun _ => congr_arg Quotient.mk'' <| smul_one _
     smul_mul := fun _ => Quotient.ind₂' fun _ _ => congr_arg Quotient.mk'' <| smul_mul' _ _ _ }
 #align con.mul_distrib_mul_action Con.mulDistribMulAction

--- a/Mathlib/GroupTheory/Congruence.lean
+++ b/Mathlib/GroupTheory/Congruence.lean
@@ -1173,6 +1173,12 @@ instance CompatibleSMul.ofSMulCommClass {α M : Type*}
     [MulOneClass M] [SMul α M] [SMulCommClass α M M] (c : Con M) : CompatibleSMul α c where
   rel_smul a w x h := by simpa only [mul_smul_one] using c.mul h (c.refl' (a • (1 : M) : M))
 
+/-- This instance notably works for `α = Mᵐᵒᵖ`. -/
+@[to_additive]
+instance CompatibleSMul.ofSMulCommClass' {α M : Type*}
+    [MulOneClass M] [SMul α M] [SMulCommClass M α M] (c : Con M) : CompatibleSMul α c :=
+  letI := SMulCommClass.symm; inferInstance
+
 @[to_additive]
 theorem smul {α M : Type*} [Mul M] [SMul α M] (c : Con M) [CompatibleSMul α c] (a : α)
     {w x : M} (h : c w x) : c (a • w) (a • x) :=

--- a/Mathlib/RingTheory/Congruence.lean
+++ b/Mathlib/RingTheory/Congruence.lean
@@ -45,7 +45,7 @@ add_decl_doc RingCon.toCon
 /-- The induced additive congruence from a `RingCon`. -/
 add_decl_doc RingCon.toAddCon
 
-variable {α R : Type*}
+variable {α β R : Type*}
 
 /-- The inductively defined smallest ring congruence relation containing a given binary
     relation. -/
@@ -223,9 +223,21 @@ end One
 
 section SMul
 
-variable [Add R] [MulOneClass R] [SMul α R] [IsScalarTower α R R] (c : RingCon R)
+variable [Add R] [Mul R]
+variable [SMul α R] [SMul β R] (c : RingCon R)
+variable [Con.CompatibleSMul α c.toCon] [Con.CompatibleSMul β c.toCon]
 
 instance : SMul α c.Quotient := inferInstanceAs (SMul α c.toCon.Quotient)
+
+instance [SMul α β] [IsScalarTower α β R] : IsScalarTower α β c.Quotient :=
+  inferInstanceAs (IsScalarTower α β c.toCon.Quotient)
+
+instance [SMulCommClass α β R] : SMulCommClass α β c.Quotient :=
+  inferInstanceAs (SMulCommClass α β c.toCon.Quotient)
+
+instance [SMul αᵐᵒᵖ R] [Con.CompatibleSMul αᵐᵒᵖ c.toCon] [IsCentralScalar α R] :
+    IsCentralScalar α c.Quotient :=
+  inferInstanceAs (IsCentralScalar α c.toCon.Quotient)
 
 @[simp, norm_cast]
 theorem coe_smul (a : α) (x : R) : (↑(a • x) : c.Quotient) = a • (x : c.Quotient) :=

--- a/Mathlib/RingTheory/Congruence.lean
+++ b/Mathlib/RingTheory/Congruence.lean
@@ -390,25 +390,25 @@ instance isScalarTower_right [Add R] [MulOneClass R] [SMul α R] [IsScalarTower 
   smul_assoc _ := Quotient.ind₂' fun _ _ => congr_arg Quotient.mk'' <| smul_mul_assoc _ _ _
 #align ring_con.is_scalar_tower_right RingCon.isScalarTower_right
 
-instance smulCommClass [Add R] [MulOneClass R] [SMul α R] [IsScalarTower α R R]
-    [SMulCommClass α R R] (c : RingCon R) : SMulCommClass α c.Quotient c.Quotient where
+instance smulCommClass [Add R] [MulOneClass R] [SMul α R] [SMulCommClass α R R]
+    (c : RingCon R) : SMulCommClass α c.Quotient c.Quotient where
   smul_comm _ := Quotient.ind₂' fun _ _ => congr_arg Quotient.mk'' <| (mul_smul_comm _ _ _).symm
 #align ring_con.smul_comm_class RingCon.smulCommClass
 
-instance smulCommClass' [Add R] [MulOneClass R] [SMul α R] [IsScalarTower α R R]
-    [SMulCommClass R α R] (c : RingCon R) : SMulCommClass c.Quotient α c.Quotient :=
+instance smulCommClass' [Add R] [MulOneClass R] [SMul α R] [SMulCommClass R α R]
+    (c : RingCon R) : SMulCommClass c.Quotient α c.Quotient :=
   haveI := SMulCommClass.symm R α R
   SMulCommClass.symm _ _ _
 #align ring_con.smul_comm_class' RingCon.smulCommClass'
 
-instance [Monoid α] [NonAssocSemiring R] [DistribMulAction α R] [IsScalarTower α R R]
-    (c : RingCon R) : DistribMulAction α c.Quotient :=
+instance [Monoid α] [NonAssocSemiring R] [DistribMulAction α R] (c : RingCon R)
+    [Con.CompatibleSMul α c.toCon] : DistribMulAction α c.Quotient :=
   { c.toCon.mulAction with
     smul_zero := fun _ => congr_arg toQuotient <| smul_zero _
     smul_add := fun _ => Quotient.ind₂' fun _ _ => congr_arg toQuotient <| smul_add _ _ _ }
 
-instance [Monoid α] [Semiring R] [MulSemiringAction α R] [IsScalarTower α R R] (c : RingCon R) :
-    MulSemiringAction α c.Quotient :=
+instance [Monoid α] [Semiring R] [MulSemiringAction α R] (c : RingCon R)
+    [Con.CompatibleSMul α c.toCon] : MulSemiringAction α c.Quotient :=
   { smul_one := fun _ => congr_arg toQuotient <| smul_one _
     smul_mul := fun _ => Quotient.ind₂' fun _ _ => congr_arg toQuotient <|
       MulSemiringAction.smul_mul _ _ _ }


### PR DESCRIPTION
This adds a new `Con.CompatibleSMul` typeclass that captures exactly the condition when `smul` descends to the quotient.

I was not quite able to merge this with `MulAction.QuotientAction`:
* The imports are such that the congruence relation `QuotientGroup.con` is not yet available in that file
* `QuotientGroup.con` requires the subgroup to be normal, while `MulAction.QuotientAction` does not

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
