### PR TITLE
[Merged by Bors] - fix(Cache): correctly handle local copies of `Mathlib`

### DIFF
--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -69,11 +69,11 @@ This happens with the `lean-pr-testing-NNNN` toolchains when Lean 4 PRs are upda
 def getRootHash : IO UInt64 := do
   let rootFiles : List FilePath := ["lakefile.lean", "lean-toolchain", "lake-manifest.json"]
   let isMathlibRoot ← isMathlibRoot
-  let qualifyPath := if isMathlibRoot then
-      fun path => path
+  let qualifyPath ←
+    if isMathlibRoot then
+      pure id
     else
-      let root := (←mathlibDepPath)
-      fun path => root / path
+      pure ((←mathlibDepPath) / ·)
   let hashs ← rootFiles.mapM fun path =>
     hashFileContents <$> IO.FS.readFile (qualifyPath path)
   return hash ((hash Lean.versionString) :: hashs)

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -69,8 +69,13 @@ This happens with the `lean-pr-testing-NNNN` toolchains when Lean 4 PRs are upda
 def getRootHash : IO UInt64 := do
   let rootFiles : List FilePath := ["lakefile.lean", "lean-toolchain", "lake-manifest.json"]
   let isMathlibRoot ← isMathlibRoot
+  let qualifyPath := if isMathlibRoot then
+      fun path => path
+    else
+      let root := (←mathlibDepPath)
+      fun path => root / path
   let hashs ← rootFiles.mapM fun path =>
-    hashFileContents <$> IO.FS.readFile (if isMathlibRoot then path else mathlibDepPath / path)
+    hashFileContents <$> IO.FS.readFile (qualifyPath path)
   return hash ((hash Lean.versionString) :: hashs)
 
 /--

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -73,7 +73,7 @@ def getRootHash : IO UInt64 := do
     if isMathlibRoot then
       pure id
     else
-      pure ((←mathlibDepPath) / ·)
+      pure ((← mathlibDepPath) / ·)
   let hashs ← rootFiles.mapM fun path =>
     hashFileContents <$> IO.FS.readFile (qualifyPath path)
   return hash ((hash Lean.versionString) :: hashs)

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -115,7 +115,7 @@ def mathlibDepPath : IO FilePath := do
         return ⟨"."⟩
       else
         throw $ IO.userError s!"Mathlib not found in dependencies"
-  | .error e => throw $ IO.userError s!"Cannot parse lake-manifest: {e}"
+  | .error e => throw $ IO.userError s!"Cannot parse lake-manifest.json: {e}"
 
 -- TODO this should be generated automatically from the information in `lakefile.lean`.
 def getPackageDirs : IO PackageDirs := do

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -334,7 +334,7 @@ def unpackCache (hashMap : HashMap) (force : Bool) : IO Unit := do
     let args := (if force then #["-f"] else #[]) ++ #["-x", "-j", "-"]
     let child ← IO.Process.spawn { cmd := ← getLeanTar, args, stdin := .piped }
     let (stdin, child) ← child.takeStdin
-    let mathlibDepPath := (←mathlibDepPath).toString
+    let mathlibDepPath := (← mathlibDepPath).toString
     let config : Array Lean.Json := hashMap.fold (init := #[]) fun config path hash =>
       let pathStr := s!"{CACHEDIR / hash.asLTar}"
       if isMathlibRoot || !isPathFromMathlib path then

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -8,6 +8,7 @@ import Lean.Data.HashMap
 import Lean.Data.RBMap
 import Lean.Data.RBTree
 import Lean.Data.Json.Printer
+import Lean.Data.Json.Parser
 
 set_option autoImplicit true
 
@@ -92,21 +93,37 @@ abbrev PackageDirs := Lean.RBMap String FilePath compare
 def isMathlibRoot : IO Bool :=
   FilePath.mk "Mathlib" |>.pathExists
 
-def mathlibDepPath : FilePath :=
-  LAKEPACKAGESDIR / "mathlib"
+def parseMathlibDepPath (json : Lean.Json) : Except String FilePath := do
+  let deps ← (← json.getObjVal? "packages").getArr?
+  let some mathlib ← deps.findSomeM? (fun j => do
+    let t := ← (←j.getObjVal? "type").getStr?
+    if t == "path" then
+      return some ⟨←(←j.getObjVal? "dir").getStr?⟩
+    else
+      return LAKEPACKAGESDIR / "mathlib"
+    ) | .error "Mathlib not found in dependencies"
+  pure mathlib
+
+def mathlibDepPath : IO FilePath := do
+  let raw ← IO.FS.readFile "lake-manifest.json"
+  match (Lean.Json.parse raw >>= parseMathlibDepPath) with
+  | .ok p => return p
+  | .error e => throw $ IO.userError s!"Cannot parse lake-manifest: {e}"
 
 -- TODO this should be generated automatically from the information in `lakefile.lean`.
-def getPackageDirs : IO PackageDirs := return .ofList [
-  ("Mathlib", if ← isMathlibRoot then "." else mathlibDepPath),
-  ("MathlibExtras", if ← isMathlibRoot then "." else mathlibDepPath),
-  ("Archive", if ← isMathlibRoot then "." else mathlibDepPath),
-  ("Counterexamples", if ← isMathlibRoot then "." else mathlibDepPath),
-  ("Aesop", LAKEPACKAGESDIR / "aesop"),
-  ("Std", LAKEPACKAGESDIR / "std"),
-  ("Cli", LAKEPACKAGESDIR / "Cli"),
-  ("ProofWidgets", LAKEPACKAGESDIR / "proofwidgets"),
-  ("Qq", LAKEPACKAGESDIR / "Qq")
-]
+def getPackageDirs : IO PackageDirs := do
+  let root : FilePath := if ← isMathlibRoot then "." else ←mathlibDepPath
+  return .ofList [
+    ("Mathlib", root),
+    ("MathlibExtras", root),
+    ("Archive", root),
+    ("Counterexamples", root),
+    ("Aesop", LAKEPACKAGESDIR / "aesop"),
+    ("Std", LAKEPACKAGESDIR / "std"),
+    ("Cli", LAKEPACKAGESDIR / "Cli"),
+    ("ProofWidgets", LAKEPACKAGESDIR / "proofwidgets"),
+    ("Qq", LAKEPACKAGESDIR / "Qq")
+  ]
 
 initialize pkgDirs : PackageDirs ← getPackageDirs
 
@@ -310,12 +327,13 @@ def unpackCache (hashMap : HashMap) (force : Bool) : IO Unit := do
     let args := (if force then #["-f"] else #[]) ++ #["-x", "-j", "-"]
     let child ← IO.Process.spawn { cmd := ← getLeanTar, args, stdin := .piped }
     let (stdin, child) ← child.takeStdin
+    let mathlibDepPath := (←mathlibDepPath).toString
     let config : Array Lean.Json := hashMap.fold (init := #[]) fun config path hash =>
       let pathStr := s!"{CACHEDIR / hash.asLTar}"
       if isMathlibRoot || !isPathFromMathlib path then
         config.push <| .str pathStr
       else -- only mathlib files, when not in the mathlib4 repo, need to be redirected
-        config.push <| .mkObj [("file", pathStr), ("base", mathlibDepPath.toString)]
+        config.push <| .mkObj [("file", pathStr), ("base", mathlibDepPath)]
     stdin.putStr <| Lean.Json.compress <| .arr config
     let exitCode ← child.wait
     if exitCode != 0 then throw $ IO.userError s!"leantar failed with error code {exitCode}"

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -130,7 +130,7 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
   else IO.println "No files to download"
 
 def checkForToolchainMismatch : IO Unit := do
-  let mathlibToolchainFile := IO.mathlibDepPath / "lean-toolchain"
+  let mathlibToolchainFile := (← IO.mathlibDepPath) / "lean-toolchain"
   let downstreamToolchain ← IO.FS.readFile "lean-toolchain"
   let mathlibToolchain ← IO.FS.readFile mathlibToolchainFile
   if !(mathlibToolchain.trim = downstreamToolchain.trim) then


### PR DESCRIPTION
This parses the `lake-manifest` to work out where mathlib is.

Previously this assumed it was in `.lake/packages`, but this is only true of `git` packages. As a result, it would fail with:
```
uncaught exception: no such file or directory (error code: 2)
  file: .lake/packages/mathlib/lakefile.lean
```

Tested on a blank project created with `lake new test math`, with `require mathlib from "../mathlib4"` in the lakefile.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
