### PR TITLE
[Merged by Bors] - feat({ Tactic + test }/ComputeDegree): Add support for `hsmul`

### DIFF
--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -118,11 +118,11 @@ theorem coeff_pow_of_natDegree_le_of_eq_ite' [Semiring R] {m n o : ℕ} {a : R} 
 
 theorem natDegree_smul_le_of_le {n : ℕ} {a : R} {f : R[X]} (hf : natDegree f ≤ n) :
     natDegree (a • f) ≤ n :=
-(natDegree_smul_le a f).trans hf
+  (natDegree_smul_le a f).trans hf
 
 theorem degree_smul_le_of_le {n : ℕ} {a : R} {f : R[X]} (hf : degree f ≤ n) :
     degree (a • f) ≤ n :=
-(degree_smul_le a f).trans hf
+  (degree_smul_le a f).trans hf
 
 theorem coeff_smul {n : ℕ} {a : R} {f : R[X]} : (a • f).coeff n = a * f.coeff n := rfl
 

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -116,6 +116,16 @@ theorem coeff_pow_of_natDegree_le_of_eq_ite' [Semiring R] {m n o : ℕ} {a : R} 
     · exact natDegree_pow_le_of_le m ‹_›
     · exact Iff.mp ne_comm h
 
+theorem natDegree_smul_le_of_le {n : ℕ} {a : R} {f : R[X]} (hf : natDegree f ≤ n) :
+    natDegree (a • f) ≤ n :=
+(natDegree_smul_le a f).trans hf
+
+theorem degree_smul_le_of_le {n : ℕ} {a : R} {f : R[X]} (hf : degree f ≤ n) :
+    degree (a • f) ≤ n :=
+(degree_smul_le a f).trans hf
+
+theorem coeff_smul {n : ℕ} {a : R} {f : R[X]} : (a • f).coeff n = a * f.coeff n := rfl
+
 section congr_lemmas
 
 /--  The following two lemmas should be viewed as a hand-made "congr"-lemmas.
@@ -320,6 +330,8 @@ def dispatchLemma
           π ``natDegree_monomial_le ``degree_monomial_le ``coeff_monomial
         | .inr ``Polynomial.C =>
           π ``natDegree_C_le ``degree_C_le ``coeff_C
+        | .inr ``HSMul.hSMul =>
+          π ``natDegree_smul_le_of_le ``degree_smul_le_of_le ``coeff_smul
         | _ => π ``le_rfl ``le_rfl ``rfl
 
 /-- `try_rfl mvs` takes as input a list of `MVarId`s, scans them partitioning them into two

--- a/test/ComputeDegree.lean
+++ b/test/ComputeDegree.lean
@@ -1,5 +1,4 @@
 import Mathlib.Tactic.ComputeDegree
-import Mathlib.adomaniLeanUtils.inspect
 
 open Polynomial
 

--- a/test/ComputeDegree.lean
+++ b/test/ComputeDegree.lean
@@ -219,8 +219,6 @@ example {F} [Ring F] {a : F} : natDegree (X ^ 3 + C a * X ^ 10 : F[X]) ≤ 10 :=
 
 example [Semiring R] : natDegree (7 * X : R[X]) ≤ 1 := by compute_degree
 
-example [Semiring R] : natDegree (7 * X : R[X]) ≤ 1 := by compute_degree
-
 example [Semiring R] {a : R} : natDegree (a • X ^ 5 : R[X]) ≤ 5 := by
   compute_degree
 

--- a/test/ComputeDegree.lean
+++ b/test/ComputeDegree.lean
@@ -1,4 +1,5 @@
 import Mathlib.Tactic.ComputeDegree
+import Mathlib.adomaniLeanUtils.inspect
 
 open Polynomial
 
@@ -218,5 +219,16 @@ example : natDegree (C a * C b + X + monomial 3 4 * X) ≤ 4 := by compute_degre
 example {F} [Ring F] {a : F} : natDegree (X ^ 3 + C a * X ^ 10 : F[X]) ≤ 10 := by compute_degree
 
 example [Semiring R] : natDegree (7 * X : R[X]) ≤ 1 := by compute_degree
+
+example [Semiring R] : natDegree (7 * X : R[X]) ≤ 1 := by compute_degree
+
+example [Semiring R] {a : R} : natDegree (a • X ^ 5 : R[X]) ≤ 5 := by
+  compute_degree
+
+example [Semiring R] {a : R} (a0 : a ≠ 0) : natDegree (a • X ^ 5 + X : R[X]) = 5 := by
+  compute_degree!
+
+example [Semiring R] {a : R} (a0 : a ≠ 0) : degree (a • X ^ 5 + X ^ 2 : R[X]) = 5 := by
+  compute_degree!
 
 end tests_from_mathlib3


### PR DESCRIPTION
This PR adds support for `smul` in `compute_degree`.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/compute_total_degree/near/404468840)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
