### PR TITLE
[Merged by Bors] - chore: bump leantar 0.1.9

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -70,7 +70,7 @@ def CURLBIN :=
 
 /-- leantar version at https://github.com/digama0/leangz -/
 def LEANTARVERSION :=
-  "0.1.8"
+  "0.1.9"
 
 def EXE := if System.Platform.isWindows then ".exe" else ""
 

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -221,7 +221,7 @@ def validateLeanTar : IO Unit := do
     pure <|
       if System.Platform.getIsOSX () then s!"{arch}-apple-darwin"
       else s!"{arch}-unknown-linux-musl"
-  IO.println s!"leantar is too old; downloading more recent version"
+  IO.println s!"installing leantar {LEANTARVERSION}"
   IO.FS.createDirAll IO.CACHEDIR
   let ext := if win then "zip" else "tar.gz"
   let _ ← runCmd "curl" #[


### PR DESCRIPTION
leanprover/lean4#2766 changed the format of .olean files, so `leantar` also needs to be updated to support it. `leantar 0.1.9` supports both the new format and the old one, and is fully backward compatible, so it is safe to land this in advance of the next RC bump. (This change has already been tested on [`lean-pr-testing-2766`](https://github.com/leanprover-community/mathlib4/commit/0c9d1236ee4ebdbfdee75eb0c196a9e610b2ee3e).)

In fact, leantar is also forward-compatible in this release: old leantar can pack and unpack oleans made by new lean, but it does not recognize the files as oleans, so it falls back to plain old gzip (with a significant loss in compression quality). But it's probably best to land this first so we don't waste space and download time.