### PR TITLE
refactor: allow non-unital `AlgEquiv`

### DIFF
--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -111,7 +111,7 @@ variable {A₁' : Type uA₁'} {A₂' : Type uA₂'} {A₃' : Type uA₃'}
 section Semiring
 
 @[reducible, inline]
-def AlgEquiv.ofCommutes [CommSemiring R] [Semiring A₁] [Semiring A₂] [Algebra R A₁] [Algebra R A₂]
+def ofCommutes [CommSemiring R] [Semiring A₁] [Semiring A₂] [Algebra R A₁] [Algebra R A₂]
     (e : A₁ ≃+* A₂) (h_comm : ∀ r : R, e (algebraMap R A₁ r) = algebraMap R A₂ r) :
     A₁ ≃ₐ[R] A₂ where
   toEquiv := e.toEquiv

--- a/Mathlib/Algebra/Algebra/Opposite.lean
+++ b/Mathlib/Algebra/Algebra/Opposite.lean
@@ -59,7 +59,7 @@ variable (R A)
 @[simps!]
 def opOp : A ≃ₐ[R] Aᵐᵒᵖᵐᵒᵖ where
   __ := RingEquiv.opOp A
-  commutes' _ := rfl
+  map_smul' _ _ := rfl
 
 @[simp] theorem toRingEquiv_opOp : (opOp R A : A ≃+* Aᵐᵒᵖᵐᵒᵖ) = RingEquiv.opOp A := rfl
 
@@ -138,10 +138,10 @@ This is the action of the (fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
 def op : (A ≃ₐ[R] B) ≃ Aᵐᵒᵖ ≃ₐ[R] Bᵐᵒᵖ where
   toFun f :=
     { RingEquiv.op f.toRingEquiv with
-      commutes' := fun r => MulOpposite.unop_injective <| f.commutes r }
+      map_smul' := fun r _ =>  MulOpposite.unop_injective <| f.map_smul r _ }
   invFun f :=
     { RingEquiv.unop f.toRingEquiv with
-      commutes' := fun r => MulOpposite.op_injective <| f.commutes r }
+      map_smul' := fun r _ => MulOpposite.op_injective <| f.map_smul r _ }
   left_inv _f := AlgEquiv.ext fun _a => rfl
   right_inv _f := AlgEquiv.ext fun _a => rfl
 
@@ -181,7 +181,7 @@ namespace AlgEquiv
 @[simps!]
 def toOpposite : A ≃ₐ[R] Aᵐᵒᵖ where
   __ := RingEquiv.toOpposite A
-  commutes' _r := rfl
+  map_smul' _ _ := rfl
 
 @[simp] lemma toRingEquiv_toOpposite : (toOpposite R A : A ≃+* Aᵐᵒᵖ) = RingEquiv.toOpposite A := rfl
 @[simp] lemma toLinearEquiv_toOpposite : toLinearEquiv (toOpposite R A) = opLinearEquiv R := rfl

--- a/Mathlib/Algebra/Algebra/Pi.lean
+++ b/Mathlib/Algebra/Algebra/Pi.lean
@@ -137,7 +137,7 @@ def piCongrRight {R ι : Type*} {A₁ A₂ : ι → Type*} [CommSemiring R] [∀
   { @RingEquiv.piCongrRight ι A₁ A₂ _ _ fun i => (e i).toRingEquiv with
     toFun := fun x j => e j (x j)
     invFun := fun x j => (e j).symm (x j)
-    commutes' := fun r => by
+    map_smul' := fun r a => by
       ext i
       simp }
 #align alg_equiv.Pi_congr_right AlgEquiv.piCongrRight

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -704,7 +704,7 @@ variable [CommSemiring R] [Semiring A] [Semiring B] [Algebra R A] [Algebra R B]
 
 This is a computable alternative to `AlgEquiv.ofInjective`. -/
 def ofLeftInverse {g : B → A} {f : A →ₐ[R] B} (h : Function.LeftInverse g f) : A ≃ₐ[R] f.range :=
-  { f.rangeRestrict with
+  { f.rangeRestrict, f.rangeRestrict.toLinearMap with
     toFun := f.rangeRestrict
     invFun := g ∘ f.range.val
     left_inv := h
@@ -747,10 +747,9 @@ noncomputable def ofInjectiveField {E F : Type*} [DivisionRing E] [Semiring F] [
 `subalgebra_map` is the induced equivalence between `S` and `S.map e` -/
 @[simps!]
 def subalgebraMap (e : A ≃ₐ[R] B) (S : Subalgebra R A) : S ≃ₐ[R] S.map (e : A →ₐ[R] B) :=
-  { e.toRingEquiv.subsemiringMap S.toSubsemiring with
-    commutes' := fun r => by
-      ext; dsimp only; erw [RingEquiv.subsemiringMap_apply_coe]
-      exact e.commutes _ }
+  .ofCommutes (e.toRingEquiv.subsemiringMap S.toSubsemiring) fun r => by
+    ext; dsimp only; erw [RingEquiv.subsemiringMap_apply_coe]
+    exact e.commutes _
 #align alg_equiv.subalgebra_map AlgEquiv.subalgebraMap
 
 end AlgEquiv
@@ -1082,7 +1081,7 @@ def equivOfEq (S T : Subalgebra R A) (h : S = T) : S ≃ₐ[R] T where
   toFun x := ⟨x, h ▸ x.2⟩
   invFun x := ⟨x, h.symm ▸ x.2⟩
   map_mul' _ _ := rfl
-  commutes' _ := rfl
+  map_smul' _ _ := rfl
 #align subalgebra.equiv_of_eq Subalgebra.equivOfEq
 
 @[simp]

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -232,10 +232,9 @@ namespace AlgEquiv
 
 /-- R ⟶ S induces S-Alg ⥤ R-Alg -/
 def restrictScalars (f : A ≃ₐ[S] B) : A ≃ₐ[R] B :=
-  { (f : A ≃+* B) with
-    commutes' := fun r => by
-      rw [algebraMap_apply R S A, algebraMap_apply R S B]
-      exact f.commutes (algebraMap R S r) }
+  AlgEquiv.ofCommutes f fun r => by
+    rw [algebraMap_apply R S A, algebraMap_apply R S B]
+    exact f.commutes (algebraMap R S r)
 #align alg_equiv.restrict_scalars AlgEquiv.restrictScalars
 
 theorem restrictScalars_apply (f : A ≃ₐ[S] B) (x : A) : f.restrictScalars R x = f x := rfl

--- a/Mathlib/Algebra/Category/AlgebraCat/Basic.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Basic.lean
@@ -227,7 +227,7 @@ def toAlgEquiv {X Y : AlgebraCat R} (i : X ≅ Y) : X ≃ₐ[R] Y where
     erw [id_apply]
   map_add' := i.hom.map_add -- Porting note: was `by tidy`
   map_mul' := i.hom.map_mul -- Porting note: was `by tidy`
-  commutes' := i.hom.commutes -- Porting note: was `by tidy`
+  map_smul' := i.hom.map_smul -- Porting note: was `by tidy`
 #align category_theory.iso.to_alg_equiv CategoryTheory.Iso.toAlgEquiv
 
 end CategoryTheory.Iso
@@ -248,6 +248,6 @@ instance (X : Type u) [Ring X] [Algebra R X] : CoeOut (Subalgebra R X) (AlgebraC
 instance AlgebraCat.forget_reflects_isos : ReflectsIsomorphisms (forget (AlgebraCat.{u} R)) where
   reflects {X Y} f _ := by
     let i := asIso ((forget (AlgebraCat.{u} R)).map f)
-    let e : X ≃ₐ[R] Y := { f, i.toEquiv with }
+    let e : X ≃ₐ[R] Y := { f, f.toLinearMap, i.toEquiv with }
     exact ⟨(IsIso.of_iso e.toAlgebraIso).1⟩
 #align Algebra.forget_reflects_isos AlgebraCat.forget_reflects_isos

--- a/Mathlib/Algebra/DualQuaternion.lean
+++ b/Mathlib/Algebra/DualQuaternion.lean
@@ -51,7 +51,7 @@ def dualNumberEquiv : Quaternion (DualNumber R) ≃ₐ[R] DualNumber (Quaternion
     rintro ⟨⟨xr, xrε⟩, ⟨xi, xiε⟩, ⟨xj, xjε⟩, ⟨xk, xkε⟩⟩
     rintro ⟨⟨yr, yrε⟩, ⟨yi, yiε⟩, ⟨yj, yjε⟩, ⟨yk, ykε⟩⟩
     rfl
-  commutes' r := rfl
+  map_smul' r a := rfl
 #align quaternion.dual_number_equiv Quaternion.dualNumberEquiv
 
 /-! Lemmas characterizing `Quaternion.dualNumberEquiv`. -/
@@ -108,49 +108,49 @@ theorem imK_snd_dualNumberEquiv (q : Quaternion (DualNumber R)) :
 
 @[simp]
 theorem fst_re_dualNumberEquiv_symm (d : DualNumber (Quaternion R)) :
-    (dualNumberEquiv.symm d).re.fst = d.fst.re :=
+    (dualNumberEquiv (R := R).symm d).re.fst = d.fst.re :=
   rfl
 #align quaternion.fst_re_dual_number_equiv_symm Quaternion.fst_re_dualNumberEquiv_symm
 
 @[simp]
 theorem fst_imI_dualNumberEquiv_symm (d : DualNumber (Quaternion R)) :
-    (dualNumberEquiv.symm d).imI.fst = d.fst.imI :=
+    (dualNumberEquiv (R := R).symm d).imI.fst = d.fst.imI :=
   rfl
 #align quaternion.fst_im_i_dual_number_equiv_symm Quaternion.fst_imI_dualNumberEquiv_symm
 
 @[simp]
 theorem fst_imJ_dualNumberEquiv_symm (d : DualNumber (Quaternion R)) :
-    (dualNumberEquiv.symm d).imJ.fst = d.fst.imJ :=
+    (dualNumberEquiv (R := R).symm d).imJ.fst = d.fst.imJ :=
   rfl
 #align quaternion.fst_im_j_dual_number_equiv_symm Quaternion.fst_imJ_dualNumberEquiv_symm
 
 @[simp]
 theorem fst_imK_dualNumberEquiv_symm (d : DualNumber (Quaternion R)) :
-    (dualNumberEquiv.symm d).imK.fst = d.fst.imK :=
+    (dualNumberEquiv (R := R).symm d).imK.fst = d.fst.imK :=
   rfl
 #align quaternion.fst_im_k_dual_number_equiv_symm Quaternion.fst_imK_dualNumberEquiv_symm
 
 @[simp]
 theorem snd_re_dualNumberEquiv_symm (d : DualNumber (Quaternion R)) :
-    (dualNumberEquiv.symm d).re.snd = d.snd.re :=
+    (dualNumberEquiv (R := R).symm d).re.snd = d.snd.re :=
   rfl
 #align quaternion.snd_re_dual_number_equiv_symm Quaternion.snd_re_dualNumberEquiv_symm
 
 @[simp]
 theorem snd_imI_dualNumberEquiv_symm (d : DualNumber (Quaternion R)) :
-    (dualNumberEquiv.symm d).imI.snd = d.snd.imI :=
+    (dualNumberEquiv (R := R).symm d).imI.snd = d.snd.imI :=
   rfl
 #align quaternion.snd_im_i_dual_number_equiv_symm Quaternion.snd_imI_dualNumberEquiv_symm
 
 @[simp]
 theorem snd_imJ_dualNumberEquiv_symm (d : DualNumber (Quaternion R)) :
-    (dualNumberEquiv.symm d).imJ.snd = d.snd.imJ :=
+    (dualNumberEquiv (R := R).symm d).imJ.snd = d.snd.imJ :=
   rfl
 #align quaternion.snd_im_j_dual_number_equiv_symm Quaternion.snd_imJ_dualNumberEquiv_symm
 
 @[simp]
 theorem snd_imK_dualNumberEquiv_symm (d : DualNumber (Quaternion R)) :
-    (dualNumberEquiv.symm d).imK.snd = d.snd.imK :=
+    (dualNumberEquiv (R := R).symm d).imK.snd = d.snd.imK :=
   rfl
 #align quaternion.snd_im_k_dual_number_equiv_symm Quaternion.snd_imK_dualNumberEquiv_symm
 

--- a/Mathlib/Algebra/MonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Basic.lean
@@ -963,7 +963,6 @@ variable (k A)
 def domCongr (e : G ≃* H) : MonoidAlgebra A G ≃ₐ[k] MonoidAlgebra A H :=
   AlgEquiv.ofLinearEquiv
     (Finsupp.domLCongr e : (G →₀ A) ≃ₗ[k] (H →₀ A))
-    ((equivMapDomain_eq_mapDomain _ _).trans <| mapDomain_one e)
     (fun f g => (equivMapDomain_eq_mapDomain _ _).trans <| (mapDomain_mul e f g).trans <|
         congr_arg₂ _ (equivMapDomain_eq_mapDomain _ _).symm (equivMapDomain_eq_mapDomain _ _).symm)
 
@@ -2089,7 +2088,6 @@ variable [CommSemiring k] [AddMonoid G] [AddMonoid H] [Semiring A] [Algebra k A]
 def domCongr (e : G ≃+ H) : A[G] ≃ₐ[k] A[H] :=
   AlgEquiv.ofLinearEquiv
     (Finsupp.domLCongr e : (G →₀ A) ≃ₗ[k] (H →₀ A))
-    ((equivMapDomain_eq_mapDomain _ _).trans <| mapDomain_one e)
     (fun f g => (equivMapDomain_eq_mapDomain _ _).trans <| (mapDomain_mul e f g).trans <|
         congr_arg₂ _ (equivMapDomain_eq_mapDomain _ _).symm (equivMapDomain_eq_mapDomain _ _).symm)
 
@@ -2122,12 +2120,13 @@ variable [CommSemiring R]
 def AddMonoidAlgebra.toMultiplicativeAlgEquiv [Semiring k] [Algebra R k] [AddMonoid G] :
     AddMonoidAlgebra k G ≃ₐ[R] MonoidAlgebra k (Multiplicative G) :=
   { AddMonoidAlgebra.toMultiplicative k G with
-    commutes' := fun r => by simp [AddMonoidAlgebra.toMultiplicative] }
+    map_smul' := fun r a => by simp [Algebra.smul_def, AddMonoidAlgebra.toMultiplicative] }
 #align add_monoid_algebra.to_multiplicative_alg_equiv AddMonoidAlgebra.toMultiplicativeAlgEquiv
 
 /-- The algebra equivalence between `MonoidAlgebra` and `AddMonoidAlgebra` in terms of
 `Additive`. -/
 def MonoidAlgebra.toAdditiveAlgEquiv [Semiring k] [Algebra R k] [Monoid G] :
     MonoidAlgebra k G ≃ₐ[R] AddMonoidAlgebra k (Additive G) :=
-  { MonoidAlgebra.toAdditive k G with commutes' := fun r => by simp [MonoidAlgebra.toAdditive] }
+  { MonoidAlgebra.toAdditive k G with
+    map_smul' := fun r a => by simp [Algebra.smul_def, MonoidAlgebra.toAdditive] }
 #align monoid_algebra.to_additive_alg_equiv MonoidAlgebra.toAdditiveAlgEquiv

--- a/Mathlib/Algebra/MonoidAlgebra/ToDirectSum.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/ToDirectSum.lean
@@ -230,10 +230,11 @@ def addMonoidAlgebraRingEquivDirectSum [DecidableEq ι] [AddMonoid ι] [Semiring
 @[simps (config := .asFn)]
 def addMonoidAlgebraAlgEquivDirectSum [DecidableEq ι] [AddMonoid ι] [CommSemiring R] [Semiring A]
     [Algebra R A] [∀ m : A, Decidable (m ≠ 0)] : AddMonoidAlgebra A ι ≃ₐ[R] ⨁ _ : ι, A :=
-  { (addMonoidAlgebraRingEquivDirectSum : AddMonoidAlgebra A ι ≃+* ⨁ _ : ι, A) with
-    toFun := AddMonoidAlgebra.toDirectSum
-    invFun := DirectSum.toAddMonoidAlgebra
-    commutes' := fun _r => AddMonoidAlgebra.toDirectSum_single _ _ }
+  .ofCommutes
+    { (addMonoidAlgebraRingEquivDirectSum : AddMonoidAlgebra A ι ≃+* ⨁ _ : ι, A) with
+      toFun := AddMonoidAlgebra.toDirectSum
+      invFun := DirectSum.toAddMonoidAlgebra }
+    fun _r => AddMonoidAlgebra.toDirectSum_single _ _
 #align add_monoid_algebra_alg_equiv_direct_sum addMonoidAlgebraAlgEquivDirectSum
 
 end Equivs

--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -597,7 +597,7 @@ def swapEquiv : ℍ[R,c₁,c₂] ≃ₐ[R] ℍ[R, c₂, c₁] where
                      neg_sub, mk_mul_mk, mul_neg, neg_neg, sub_neg_eq_add]
       <;> ring
   map_add' _ _ := by ext <;> simp [add_comm]
-  commutes' _ := by simp [algebraMap_eq]
+  map_smul' _ _ := by simp [Algebra.smul_def, algebraMap_eq]
 
 end
 
@@ -744,7 +744,7 @@ def starAe : ℍ[R,c₁,c₂] ≃ₐ[R] ℍ[R,c₁,c₂]ᵐᵒᵖ :=
     toFun := op ∘ star
     invFun := star ∘ unop
     map_mul' := fun x y => by simp
-    commutes' := fun r => by simp }
+    map_smul' := by simp }
 #align quaternion_algebra.star_ae QuaternionAlgebra.starAe
 
 @[simp]

--- a/Mathlib/Algebra/Star/Free.lean
+++ b/Mathlib/Algebra/Star/Free.lean
@@ -74,7 +74,7 @@ theorem star_algebraMap (r : R) : star (algebraMap R (FreeAlgebra R X) r) = alge
 
 /-- `star` as an `AlgEquiv` -/
 def starHom : FreeAlgebra R X ≃ₐ[R] (FreeAlgebra R X)ᵐᵒᵖ :=
-  { starRingEquiv with commutes' := fun r => by simp [star_algebraMap] }
+  { starRingEquiv with map_smul' := fun r a => by simp [Algebra.smul_def, star_algebraMap] }
 #align free_algebra.star_hom FreeAlgebra.starHom
 
 end FreeAlgebra

--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -682,20 +682,18 @@ multiplication and the star operation, which allows for considering both unital 
 equivalences with a single structure. Currently, `AlgEquiv` requires unital algebras, which is
 why this structure does not extend it. -/
 structure StarAlgEquiv (R A B : Type*) [Add A] [Add B] [Mul A] [Mul B] [SMul R A] [SMul R B]
-  [Star A] [Star B] extends A ≃+* B where
+  [Star A] [Star B] extends A ≃ₐ[R] B where
   /-- By definition, a ⋆-algebra equivalence preserves the `star` operation. -/
   map_star' : ∀ a : A, toFun (star a) = star (toFun a)
-  /-- By definition, a ⋆-algebra equivalence commutes with the action of scalars. -/
-  map_smul' : ∀ (r : R) (a : A), toFun (r • a) = r • toFun a
 #align star_alg_equiv StarAlgEquiv
 
 @[inherit_doc StarAlgEquiv] infixr:25 " ≃⋆ₐ " => StarAlgEquiv _
 
 @[inherit_doc] notation:25 A " ≃⋆ₐ[" R "] " B => StarAlgEquiv R A B
 
-/-- Reinterpret a star algebra equivalence as a `RingEquiv` by forgetting the interaction with
+/-- Reinterpret a star algebra equivalence as an `AlgEquiv` by forgetting the interaction with
 the star operation and scalar multiplication. -/
-add_decl_doc StarAlgEquiv.toRingEquiv
+add_decl_doc StarAlgEquiv.toAlgEquiv
 
 /-- `StarAlgEquivClass F R A B` asserts `F` is a type of bundled ⋆-algebra equivalences between
 `A` and `B`.
@@ -703,11 +701,9 @@ add_decl_doc StarAlgEquiv.toRingEquiv
 You should also extend this typeclass when you extend `StarAlgEquiv`. -/
 class StarAlgEquivClass (F : Type*) (R : outParam (Type*)) (A : outParam (Type*))
   (B : outParam (Type*)) [Add A] [Mul A] [SMul R A] [Star A] [Add B] [Mul B] [SMul R B]
-  [Star B] extends RingEquivClass F A B where
+  [Star B] extends AlgEquivClass F R A B where
   /-- By definition, a ⋆-algebra equivalence preserves the `star` operation. -/
   map_star : ∀ (f : F) (a : A), f (star a) = star (f a)
-  /-- By definition, a ⋆-algebra equivalence commutes with the action of scalars. -/
-  map_smul : ∀ (f : F) (r : R) (a : A), f (r • a) = r • f a
 #align star_alg_equiv_class StarAlgEquivClass
 
 -- Porting note: no longer needed
@@ -762,15 +758,6 @@ instance (priority := 100) instStarAlgHomClass (F R A B : Type*) [CommSemiring R
     map_zero := map_zero
     commutes := fun f r => by simp only [Algebra.algebraMap_eq_smul_one, map_smul, map_one] }
 
--- See note [lower instance priority]
-instance (priority := 100) toAlgEquivClass {F R A B : Type*} [CommSemiring R]
-    [Ring A] [Ring B] [Algebra R A] [Algebra R B] [Star A] [Star B] [StarAlgEquivClass F R A B] :
-    AlgEquivClass F R A B :=
-  { StarAlgEquivClass.toRingEquivClass,
-    StarAlgEquivClass.instStarAlgHomClass F R A B with
-    coe := fun f => f
-    inv := fun f => EquivLike.inv f }
-
 end StarAlgEquivClass
 
 namespace StarAlgEquiv
@@ -793,10 +780,10 @@ instance : StarAlgEquivClass (A ≃⋆ₐ[R] B) R A B
   map_mul f := f.map_mul'
   map_add f := f.map_add'
   map_star := map_star'
-  map_smul := map_smul'
+  map_smul f := f.map_smul'
 
 @[simp]
-theorem toRingEquiv_eq_coe (e : A ≃⋆ₐ[R] B) : e.toRingEquiv = e :=
+theorem toAlgEquiv_eq_coe (e : A ≃⋆ₐ[R] B) : e.toAlgEquiv = e :=
   rfl
 
 -- Porting note: this is no longer useful
@@ -870,22 +857,8 @@ theorem symm_bijective : Function.Bijective (symm : (A ≃⋆ₐ[R] B) → B ≃
   Equiv.bijective ⟨symm, symm, symm_symm, symm_symm⟩
 #align star_alg_equiv.symm_bijective StarAlgEquiv.symm_bijective
 
--- porting note: doesn't align with Mathlib 3 because `StarAlgEquiv.mk` has a new signature
-@[simp]
-theorem mk_coe' (e : A ≃⋆ₐ[R] B) (f h₁ h₂ h₃ h₄ h₅ h₆) :
-    (⟨⟨⟨f, e, h₁, h₂⟩, h₃, h₄⟩, h₅, h₆⟩ : B ≃⋆ₐ[R] A) = e.symm :=
-  symm_bijective.injective <| ext fun _ => rfl
-#align star_alg_equiv.mk_coe' StarAlgEquiv.mk_coe'ₓ
-
--- porting note: doesn't align with Mathlib 3 because `StarAlgEquiv.mk` has a new signature
-@[simp]
-theorem symm_mk (f f') (h₁ h₂ h₃ h₄ h₅ h₆) :
-    (⟨⟨⟨f, f', h₁, h₂⟩, h₃, h₄⟩, h₅, h₆⟩ : A ≃⋆ₐ[R] B).symm =
-      { (⟨⟨⟨f, f', h₁, h₂⟩, h₃, h₄⟩, h₅, h₆⟩ : A ≃⋆ₐ[R] B).symm with
-        toFun := f'
-        invFun := f } :=
-  rfl
-#align star_alg_equiv.symm_mk StarAlgEquiv.symm_mkₓ
+#noalign star_alg_equiv.mk_coe'
+#noalign star_alg_equiv.symm_mk
 
 @[simp]
 theorem refl_symm : (StarAlgEquiv.refl : A ≃⋆ₐ[R] A).symm = StarAlgEquiv.refl :=

--- a/Mathlib/Analysis/NormedSpace/LpEquiv.lean
+++ b/Mathlib/Analysis/NormedSpace/LpEquiv.lean
@@ -209,7 +209,7 @@ variable (α)
 -- `one_memℓp_infty` to get the `Ring` instance on `lp`.
 /-- The canonical map between `lp (λ (_ : α), A) ∞` and `α →ᵇ A` as an `AlgEquiv`. -/
 noncomputable def AlgEquiv.lpBcf : lp (fun _ : α => A) ∞ ≃ₐ[𝕜] α →ᵇ A :=
-  { RingEquiv.lpBcf A with commutes' := fun _k => rfl }
+  { RingEquiv.lpBcf A with map_smul' := fun _ _ => rfl }
 #align alg_equiv.lp_bcf AlgEquiv.lpBcf
 
 variable {α A 𝕜}

--- a/Mathlib/Data/Complex/Module.lean
+++ b/Mathlib/Data/Complex/Module.lean
@@ -261,7 +261,7 @@ def conjAe : ℂ ≃ₐ[ℝ] ℂ :=
     invFun := conj
     left_inv := star_star
     right_inv := star_star
-    commutes' := conj_ofReal }
+    map_smul' := star_smul }
 #align complex.conj_ae Complex.conjAe
 
 @[simp]

--- a/Mathlib/Data/IsROrC/Basic.lean
+++ b/Mathlib/Data/IsROrC/Basic.lean
@@ -1026,7 +1026,7 @@ def conjAe : K ≃ₐ[ℝ] K :=
     invFun := conj
     left_inv := conj_conj
     right_inv := conj_conj
-    commutes' := conj_ofReal }
+    map_smul' := conj_smul }
 #align is_R_or_C.conj_ae IsROrC.conjAe
 
 @[simp, isROrC_simps]
@@ -1036,7 +1036,7 @@ theorem conjAe_coe : (conjAe : K → K) = conj :=
 
 /-- Conjugate as a linear isometry -/
 noncomputable def conjLie : K ≃ₗᵢ[ℝ] K :=
-  ⟨conjAe.toLinearEquiv, fun _ => norm_conj⟩
+  ⟨conjAe.toLinearEquiv, fun _ => by simp [norm_conj]⟩
 #align is_R_or_C.conj_lie IsROrC.conjLie
 
 @[simp, isROrC_simps]

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1633,7 +1633,7 @@ variable [Algebra R α] [Algebra R β] [Algebra R γ]
 coefficients. This is `Matrix.map` as an `AlgEquiv`. -/
 @[simps apply]
 def mapMatrix (f : α ≃ₐ[R] β) : Matrix m m α ≃ₐ[R] Matrix m m β :=
-  { f.toAlgHom.mapMatrix,
+  { f.toLinearMap.mapMatrix,
     f.toRingEquiv.mapMatrix with
     toFun := fun M => M.map f
     invFun := fun M => M.map f.symm }
@@ -2125,8 +2125,9 @@ def transposeAlgEquiv [CommSemiring R] [CommSemiring α] [Fintype m] [DecidableE
   { (transposeAddEquiv m m α).trans MulOpposite.opAddEquiv,
     transposeRingEquiv m α with
     toFun := fun M => MulOpposite.op Mᵀ
-    commutes' := fun r => by
-      simp only [algebraMap_eq_diagonal, diagonal_transpose, MulOpposite.algebraMap_apply] }
+    map_smul' := fun r a => by
+      simp only [Algebra.smul_def, algebraMap_eq_diagonal, transpose_mul, diagonal_transpose,
+        MulOpposite.op_mul, MulOpposite.algebraMap_apply] }
 #align matrix.transpose_alg_equiv Matrix.transposeAlgEquiv
 
 variable {R m α}

--- a/Mathlib/Data/Matrix/DualNumber.lean
+++ b/Mathlib/Data/Matrix/DualNumber.lean
@@ -36,9 +36,5 @@ def Matrix.dualNumberEquiv : Matrix n n (DualNumber R) ≃ₐ[R] DualNumber (Mat
       simp only [mul_apply, snd_sum, DualNumber.snd_mul, snd_mk, of_apply, fst_mk, add_apply]
       rw [← Finset.sum_add_distrib]
   map_add' A B := TrivSqZeroExt.ext rfl rfl
-  commutes' r := by
-    simp_rw [algebraMap_eq_inl', algebraMap_eq_diagonal, Pi.algebraMap_def,
-      Algebra.id.map_eq_self, algebraMap_eq_inl, ← diagonal_map (inl_zero R), map_apply, fst_inl,
-      snd_inl]
-    rfl
+  map_smul' r a := TrivSqZeroExt.ext rfl rfl
 #align matrix.dual_number_equiv Matrix.dualNumberEquiv

--- a/Mathlib/Data/Matrix/DualNumber.lean
+++ b/Mathlib/Data/Matrix/DualNumber.lean
@@ -36,5 +36,5 @@ def Matrix.dualNumberEquiv : Matrix n n (DualNumber R) ≃ₐ[R] DualNumber (Mat
       simp only [mul_apply, snd_sum, DualNumber.snd_mul, snd_mk, of_apply, fst_mk, add_apply]
       rw [← Finset.sum_add_distrib]
   map_add' A B := TrivSqZeroExt.ext rfl rfl
-  map_smul' r a := TrivSqZeroExt.ext rfl rfl
+  map_smul' r a := rfl
 #align matrix.dual_number_equiv Matrix.dualNumberEquiv

--- a/Mathlib/Data/MvPolynomial/Equiv.lean
+++ b/Mathlib/Data/MvPolynomial/Equiv.lean
@@ -83,7 +83,7 @@ def pUnitAlgEquiv : MvPolynomial PUnit R ≃ₐ[R] R[X] where
         eval₂_mul, eval₂_C, eval₂_pow, eval₂_X]
   map_mul' _ _ := eval₂_mul _ _
   map_add' _ _ := eval₂_add _ _
-  commutes' _ := eval₂_C _ _ _
+  map_smul' _ _ := sorry
 #align mv_polynomial.punit_alg_equiv MvPolynomial.pUnitAlgEquiv
 
 section Map
@@ -127,7 +127,9 @@ variable [Algebra R A₁] [Algebra R A₂] [Algebra R A₃]
 /-- If `e : A ≃ₐ[R] B` is an isomorphism of `R`-algebras, then so is `map e`. -/
 @[simps apply]
 def mapAlgEquiv (e : A₁ ≃ₐ[R] A₂) : MvPolynomial σ A₁ ≃ₐ[R] MvPolynomial σ A₂ :=
-  { mapAlgHom (e : A₁ →ₐ[R] A₂), mapEquiv σ (e : A₁ ≃+* A₂) with toFun := map (e : A₁ →+* A₂) }
+  { mapAlgHom (e : A₁ →ₐ[R] A₂), mapEquiv σ (e : A₁ ≃+* A₂) with
+    toFun := map (e : A₁ →+* A₂),
+    map_smul' := map_smul <| mapAlgHom (e : A₁ →ₐ[R] A₂) }
 #align mv_polynomial.map_alg_equiv MvPolynomial.mapAlgEquiv
 
 @[simp]
@@ -263,13 +265,11 @@ and multivariable polynomials in one of the types,
 with coefficients in multivariable polynomials in the other type.
 -/
 def sumAlgEquiv : MvPolynomial (Sum S₁ S₂) R ≃ₐ[R] MvPolynomial S₁ (MvPolynomial S₂ R) :=
-  { sumRingEquiv R S₁ S₂ with
-    commutes' := by
-      intro r
-      have A : algebraMap R (MvPolynomial S₁ (MvPolynomial S₂ R)) r = (C (C r) : _) := rfl
-      have B : algebraMap R (MvPolynomial (Sum S₁ S₂) R) r = C r := rfl
-      simp only [sumRingEquiv, mvPolynomialEquivMvPolynomial, Equiv.toFun_as_coe,
-        Equiv.coe_fn_mk, B, sumToIter_C, A] }
+  .ofCommutes (sumRingEquiv R S₁ S₂) fun r => by
+    have A : algebraMap R (MvPolynomial S₁ (MvPolynomial S₂ R)) r = (C (C r) : _) := rfl
+    have B : algebraMap R (MvPolynomial (Sum S₁ S₂) R) r = C r := rfl
+    simp only [sumRingEquiv, mvPolynomialEquivMvPolynomial, B, RingEquiv.coe_mk, Equiv.coe_fn_mk,
+      sumToIter_C, A]
 #align mv_polynomial.sum_alg_equiv MvPolynomial.sumAlgEquiv
 
 section

--- a/Mathlib/Data/MvPolynomial/Rename.lean
+++ b/Mathlib/Data/MvPolynomial/Rename.lean
@@ -153,7 +153,7 @@ variable (R)
 /-- `MvPolynomial.rename e` is an equivalence when `e` is. -/
 @[simps apply]
 def renameEquiv (f : σ ≃ τ) : MvPolynomial σ R ≃ₐ[R] MvPolynomial τ R :=
-  { rename f with
+  { rename f, (rename f).toLinearMap with
     toFun := rename f
     invFun := rename f.symm
     left_inv := fun p => by rw [rename_rename, f.symm_comp_self, rename_id]

--- a/Mathlib/Data/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Data/Polynomial/AlgebraMap.lean
@@ -98,9 +98,7 @@ implementation detail, but it can be useful to transfer results from `Finsupp` t
 @[simps!]
 def toFinsuppIsoAlg : R[X] ≃ₐ[R] R[ℕ] :=
   { toFinsuppIso R with
-    commutes' := fun r => by
-      dsimp
-      exact toFinsupp_algebraMap _ }
+    map_smul' := fun _ _ => rfl }
 #align polynomial.to_finsupp_iso_alg Polynomial.toFinsuppIsoAlg
 
 variable {R}

--- a/Mathlib/LinearAlgebra/Matrix/Basis.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Basis.lean
@@ -229,7 +229,7 @@ theorem LinearMap.toMatrix_id_eq_basis_toMatrix [DecidableEq ι] :
 
 /-- See also `Basis.toMatrix_reindex` which gives the `simp` normal form of this result. -/
 theorem Basis.toMatrix_reindex' [DecidableEq ι] [DecidableEq ι'] (b : Basis ι R M) (v : ι' → M)
-    (e : ι ≃ ι') : (b.reindex e).toMatrix v = Matrix.reindexAlgEquiv _ e (b.toMatrix (v ∘ e)) := by
+    (e : ι ≃ ι') : (b.reindex e).toMatrix v = Matrix.reindexAlgEquiv R e (b.toMatrix (v ∘ e)) := by
   ext
   simp only [Basis.toMatrix_apply, Basis.repr_reindex, Matrix.reindexAlgEquiv_apply,
     Matrix.reindex_apply, Matrix.submatrix_apply, Function.comp_apply, e.apply_symm_apply,

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
@@ -292,7 +292,7 @@ lemma reverse_charpoly (M : Matrix n n R) :
       invert.map_mul, involutive_invert p, charpoly_natDegree_eq_dim,
       ← mul_one (Fintype.card n : ℤ), ← T_pow, invert.map_pow, invert_T, mul_comm]
   rw [← det_smul, smul_sub, scalar_apply, ← diagonal_smul, Pi.smul_def, smul_eq_mul, ht,
-    diagonal_one, invert.map_det]
+    diagonal_one, invert.map_det (R := R)]
   simp [map_smul', smul_eq_diagonal_mul]
 
 @[simp] lemma eval_charpolyRev :

--- a/Mathlib/LinearAlgebra/Matrix/Reindex.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Reindex.lean
@@ -116,16 +116,14 @@ end Semiring
 section Algebra
 
 variable [CommSemiring R] [Fintype n] [Fintype m] [DecidableEq m] [DecidableEq n]
-
+#check submatrix
 /-- For square matrices with coefficients in commutative semirings, the natural map that reindexes
 a matrix's rows and columns with equivalent types, `Matrix.reindex`, is an equivalence of algebras.
 -/
 def reindexAlgEquiv (e : m ≃ n) : Matrix m m R ≃ₐ[R] Matrix n n R :=
   { reindexLinearEquiv R R e e with
     toFun := reindex e e
-    map_mul' := fun a b => (reindexLinearEquiv_mul R R e e e a b).symm
-    -- Porting note: `submatrix_smul` needed help
-    commutes' := fun r => by simp [algebraMap, Algebra.toRingHom, submatrix_smul _ 1] }
+    map_mul' := fun a b => (reindexLinearEquiv_mul R R e e e a b).symm }
 #align matrix.reindex_alg_equiv Matrix.reindexAlgEquiv
 
 @[simp]

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -439,7 +439,7 @@ def Matrix.toLin'OfInv [Fintype m] [DecidableEq m] {M : Matrix m n R} {M' : Matr
 
 /-- Linear maps `(n → R) →ₗ[R] (n → R)` are algebra equivalent to `Matrix n n R`. -/
 def LinearMap.toMatrixAlgEquiv' : ((n → R) →ₗ[R] n → R) ≃ₐ[R] Matrix n n R :=
-  AlgEquiv.ofLinearEquiv LinearMap.toMatrix' LinearMap.toMatrix'_one LinearMap.toMatrix'_mul
+  AlgEquiv.ofLinearEquiv LinearMap.toMatrix' LinearMap.toMatrix'_mul
 #align linear_map.to_matrix_alg_equiv' LinearMap.toMatrixAlgEquiv'
 
 /-- A `Matrix n n R` is algebra equivalent to a linear map `(n → R) →ₗ[R] (n → R)`. -/
@@ -461,52 +461,52 @@ theorem Matrix.toLinAlgEquiv'_symm :
 
 @[simp]
 theorem LinearMap.toMatrixAlgEquiv'_toLinAlgEquiv' (M : Matrix n n R) :
-    LinearMap.toMatrixAlgEquiv' (Matrix.toLinAlgEquiv' M) = M :=
+    LinearMap.toMatrixAlgEquiv' (R := R) (Matrix.toLinAlgEquiv' (R := R) M) = M :=
   LinearMap.toMatrixAlgEquiv'.apply_symm_apply M
 #align linear_map.to_matrix_alg_equiv'_to_lin_alg_equiv' LinearMap.toMatrixAlgEquiv'_toLinAlgEquiv'
 
 @[simp]
 theorem Matrix.toLinAlgEquiv'_toMatrixAlgEquiv' (f : (n → R) →ₗ[R] n → R) :
-    Matrix.toLinAlgEquiv' (LinearMap.toMatrixAlgEquiv' f) = f :=
+    Matrix.toLinAlgEquiv' (R := R) (LinearMap.toMatrixAlgEquiv' f (R := R)) = f :=
   Matrix.toLinAlgEquiv'.apply_symm_apply f
 #align matrix.to_lin_alg_equiv'_to_matrix_alg_equiv' Matrix.toLinAlgEquiv'_toMatrixAlgEquiv'
 
 @[simp]
 theorem LinearMap.toMatrixAlgEquiv'_apply (f : (n → R) →ₗ[R] n → R) (i j) :
-    LinearMap.toMatrixAlgEquiv' f i j = f (fun j' => if j' = j then 1 else 0) i := by
+    LinearMap.toMatrixAlgEquiv' (R := R) f i j = f (fun j' => if j' = j then 1 else 0) i := by
   simp [LinearMap.toMatrixAlgEquiv']
 #align linear_map.to_matrix_alg_equiv'_apply LinearMap.toMatrixAlgEquiv'_apply
 
 @[simp]
 theorem Matrix.toLinAlgEquiv'_apply (M : Matrix n n R) (v : n → R) :
-    Matrix.toLinAlgEquiv' M v = M.mulVec v :=
+    Matrix.toLinAlgEquiv' (R := R) M v = M.mulVec v :=
   rfl
 #align matrix.to_lin_alg_equiv'_apply Matrix.toLinAlgEquiv'_apply
 
 -- Porting note: the simpNF lemma rejects this, as `simp` already simplifies the lhs
 -- to `(1 : (n → R) →ₗ[R] n → R)`.
 -- @[simp]
-theorem Matrix.toLinAlgEquiv'_one : Matrix.toLinAlgEquiv' (1 : Matrix n n R) = LinearMap.id :=
+theorem Matrix.toLinAlgEquiv'_one : Matrix.toLinAlgEquiv' (R := R) (1 : Matrix n n R) = LinearMap.id :=
   Matrix.toLin'_one
 #align matrix.to_lin_alg_equiv'_one Matrix.toLinAlgEquiv'_one
 
 @[simp]
 theorem LinearMap.toMatrixAlgEquiv'_id :
-    LinearMap.toMatrixAlgEquiv' (LinearMap.id : (n → R) →ₗ[R] n → R) = 1 :=
+    LinearMap.toMatrixAlgEquiv' (R := R) (LinearMap.id : (n → R) →ₗ[R] n → R) = 1 :=
   LinearMap.toMatrix'_id
 #align linear_map.to_matrix_alg_equiv'_id LinearMap.toMatrixAlgEquiv'_id
 
 #align matrix.to_lin_alg_equiv'_mul map_mulₓ
 
 theorem LinearMap.toMatrixAlgEquiv'_comp (f g : (n → R) →ₗ[R] n → R) :
-    LinearMap.toMatrixAlgEquiv' (f.comp g) =
-      LinearMap.toMatrixAlgEquiv' f * LinearMap.toMatrixAlgEquiv' g :=
+    LinearMap.toMatrixAlgEquiv' (R := R) (f.comp g) =
+      LinearMap.toMatrixAlgEquiv' (R := R) f * LinearMap.toMatrixAlgEquiv' (R := R) g :=
   LinearMap.toMatrix'_comp _ _
 #align linear_map.to_matrix_alg_equiv'_comp LinearMap.toMatrixAlgEquiv'_comp
 
 theorem LinearMap.toMatrixAlgEquiv'_mul (f g : (n → R) →ₗ[R] n → R) :
-    LinearMap.toMatrixAlgEquiv' (f * g) =
-      LinearMap.toMatrixAlgEquiv' f * LinearMap.toMatrixAlgEquiv' g :=
+    LinearMap.toMatrixAlgEquiv' (R := R) (f * g) =
+      LinearMap.toMatrixAlgEquiv' (R := R) f * LinearMap.toMatrixAlgEquiv' (R := R) g :=
   LinearMap.toMatrixAlgEquiv'_comp f g
 #align linear_map.to_matrix_alg_equiv'_mul LinearMap.toMatrixAlgEquiv'_mul
 
@@ -713,7 +713,7 @@ def Matrix.toLinOfInv [DecidableEq m] {M : Matrix m n R} {M' : Matrix n m R} (hM
 equivalence between linear maps `M₁ →ₗ M₁` and square matrices over `R` indexed by the basis. -/
 def LinearMap.toMatrixAlgEquiv : (M₁ →ₗ[R] M₁) ≃ₐ[R] Matrix n n R :=
   AlgEquiv.ofLinearEquiv
-    (LinearMap.toMatrix v₁ v₁) (LinearMap.toMatrix_one v₁) (LinearMap.toMatrix_mul v₁)
+    (LinearMap.toMatrix v₁ v₁) (LinearMap.toMatrix_mul v₁)
 #align linear_map.to_matrix_alg_equiv LinearMap.toMatrixAlgEquiv
 
 /-- Given a basis of a module `M₁` over a commutative ring `R`, we get an algebra
@@ -768,7 +768,7 @@ theorem LinearMap.toMatrixAlgEquiv_transpose_apply' (f : M₁ →ₗ[R] M₁) (j
 
 theorem Matrix.toLinAlgEquiv_apply (M : Matrix n n R) (v : M₁) :
     Matrix.toLinAlgEquiv v₁ M v = ∑ j, M.mulVec (v₁.repr v) j • v₁ j :=
-  show v₁.equivFun.symm (Matrix.toLinAlgEquiv' M (v₁.repr v)) = _ by
+  show v₁.equivFun.symm (Matrix.toLinAlgEquiv' (R := R) M (v₁.repr v)) = _ by
     rw [Matrix.toLinAlgEquiv'_apply, v₁.equivFun_symm_apply]
 #align matrix.to_lin_alg_equiv_apply Matrix.toLinAlgEquiv_apply
 
@@ -967,20 +967,21 @@ variable [AddCommGroup M₁] [Module R M₁] [AddCommGroup M₂] [Module R M₂]
 /-- The natural equivalence between linear endomorphisms of finite free modules and square matrices
 is compatible with the algebra structures. -/
 def algEquivMatrix' [Fintype n] : Module.End R (n → R) ≃ₐ[R] Matrix n n R :=
-  { LinearMap.toMatrix' with
-    map_mul' := LinearMap.toMatrix'_comp
-    -- porting note: golfed away messy failing proof
-    commutes' := LinearMap.toMatrix'_algebraMap }
+  .ofCommutes
+    { LinearMap.toMatrix' with
+      map_mul' := LinearMap.toMatrix'_comp }
+    LinearMap.toMatrix'_algebraMap
 #align alg_equiv_matrix' algEquivMatrix'
 
 /-- A linear equivalence of two modules induces an equivalence of algebras of their
 endomorphisms. -/
 def LinearEquiv.algConj (e : M₁ ≃ₗ[R] M₂) : Module.End R M₁ ≃ₐ[R] Module.End R M₂ :=
-  { e.conj with
-    map_mul' := fun f g => by apply e.arrowCongr_comp
-    commutes' := fun r => by
+  .ofCommutes
+    { e.conj with
+      map_mul' := fun f g => by apply e.arrowCongr_comp }
+    fun r => by
       change e.conj (r • LinearMap.id) = r • LinearMap.id
-      rw [LinearEquiv.map_smul, LinearEquiv.conj_id] }
+      rw [LinearEquiv.map_smul, LinearEquiv.conj_id]
 #align linear_equiv.alg_conj LinearEquiv.algConj
 
 /-- A basis of a module induces an equivalence of algebras from the endomorphisms of the module to

--- a/Mathlib/LinearAlgebra/TensorProduct/Opposite.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Opposite.lean
@@ -35,7 +35,7 @@ def opAlgEquiv : Aᵐᵒᵖ ⊗[R] Bᵐᵒᵖ ≃ₐ[S] (A ⊗[R] B)ᵐᵒᵖ :=
       (opLinearEquiv S).symm (opLinearEquiv R).symm ≪≫ₗ opLinearEquiv S
   letI e₂ : A ⊗[R] B ≃ₗ[S] (Aᵐᵒᵖ ⊗[R] Bᵐᵒᵖ)ᵐᵒᵖ :=
     TensorProduct.AlgebraTensorModule.congr (opLinearEquiv S) (opLinearEquiv R) ≪≫ₗ opLinearEquiv S
-  AlgEquiv.ofAlgHom
+  AlgEquiv.ofAlgHom (R := S) (A₂ := (A ⊗[R] B)ᵐᵒᵖ)
     (algHomOfLinearMapTensorProduct e₁.toLinearMap
       (fun a₁ a₂ b₁ b₂ => unop_injective rfl) (unop_injective rfl))
     (AlgHom.opComm <| algHomOfLinearMapTensorProduct e₂.toLinearMap

--- a/Mathlib/Logic/Equiv/TransferInstance.lean
+++ b/Mathlib/Logic/Equiv/TransferInstance.lean
@@ -571,7 +571,10 @@ def algEquiv (e : α ≃ β) [Semiring β] [Algebra R β] : by
   intros
   exact
     { Equiv.ringEquiv e with
-      commutes' := fun r => by
+      map_smul' := fun r a => by
+        simp only [RingEquiv.toEquiv_eq_coe, Algebra.smul_def, toFun_as_coe,
+          RingEquiv.coe_toEquiv, map_mul, ringEquiv_apply]
+        congr
         apply e.symm.injective
         simp
         rfl }

--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -196,8 +196,8 @@ theorem mvPolynomial_of_finitePresentation (hfp : FinitePresentation.{w₁, w₂
   cases nonempty_fintype (Sum ι ι')
   refine
     ⟨Sum ι ι', by infer_instance, g,
-      (MvPolynomial.map_surjective f.toRingHom hf_surj).comp (AlgEquiv.surjective _),
-      Ideal.fg_ker_comp _ _ ?_ ?_ (AlgEquiv.surjective _)⟩
+      (MvPolynomial.map_surjective f.toRingHom hf_surj).comp (by simpa using AlgEquiv.surjective _),
+      Ideal.fg_ker_comp _ _ ?_ ?_ (by simpa using AlgEquiv.surjective _)⟩
   · erw [RingHom.ker_coe_equiv (MvPolynomial.sumAlgEquiv R ι ι').toRingEquiv]
     exact Submodule.fg_bot
     -- Porting note: was

--- a/Mathlib/RingTheory/GradedAlgebra/Basic.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/Basic.lean
@@ -207,7 +207,7 @@ def decomposeAlgEquiv : A ≃ₐ[R] ⨁ i, 𝒜 i :=
   AlgEquiv.symm
     { (decomposeAddEquiv 𝒜).symm with
       map_mul' := (coeAlgHom 𝒜).map_mul
-      commutes' := (coeAlgHom 𝒜).commutes }
+      map_smul' := (coeAlgHom 𝒜).map_smul }
 #align direct_sum.decompose_alg_equiv DirectSum.decomposeAlgEquiv
 
 @[simp]

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -425,7 +425,7 @@ theorem kerLiftAlg_injective (f : A →ₐ[R₁] B) : Function.Injective (kerLif
 def quotientKerAlgEquivOfRightInverse {f : A →ₐ[R₁] B} {g : B → A}
     (hf : Function.RightInverse g f) : (A ⧸ (RingHom.ker f.toRingHom)) ≃ₐ[R₁] B :=
   { RingHom.quotientKerEquivOfRightInverse fun x => show f.toRingHom (g x) = x from hf x,
-    kerLiftAlg f with }
+    (kerLiftAlg f).toLinearMap with }
 #align ideal.quotient_ker_alg_equiv_of_right_inverse Ideal.quotientKerAlgEquivOfRightInverse
 
 -- This lemma was always bad, but the linter only noticed after lean4#2644
@@ -571,13 +571,9 @@ theorem quotient_map_comp_mkₐ {I : Ideal A} (J : Ideal B) (f : A →ₐ[R₁] 
 where`J = f(I)`. -/
 def quotientEquivAlg (I : Ideal A) (J : Ideal B) (f : A ≃ₐ[R₁] B) (hIJ : J = I.map (f : A →+* B)) :
     (A ⧸ I) ≃ₐ[R₁] B ⧸ J :=
-  { quotientEquiv I J (f : A ≃+* B) hIJ with
-    commutes' := fun r => by
-      -- Porting note: Needed to add the below lemma because Equivs coerce weird
-      have : ∀ (e : RingEquiv (A ⧸ I) (B ⧸ J)), Equiv.toFun e.toEquiv = FunLike.coe e := fun _ ↦ rfl
-      rw [this]
-      simp only [quotientEquiv_apply, RingHom.toFun_eq_coe, quotientMap_algebraMap,
-      RingEquiv.coe_toRingHom, AlgEquiv.coe_ringEquiv, AlgEquiv.commutes, Quotient.mk_algebraMap]}
+  .ofCommutes (quotientEquiv I J (f : A ≃+* B) hIJ) fun r => by
+    simp only [quotientEquiv_apply, toFun_eq_coe, quotientMap_algebraMap, RingEquiv.coe_toRingHom,
+      AlgEquiv.coe_ringEquiv, AlgEquiv.commutes, Quotient.mk_algebraMap]
 #align ideal.quotient_equiv_alg Ideal.quotientEquivAlg
 
 instance (priority := 100) quotientAlgebra {I : Ideal A} [Algebra R A] :
@@ -860,7 +856,7 @@ theorem coe_liftSupQuotQuotMkₐ : ⇑(liftSupQuotQuotMkₐ R I J) = liftSupQuot
 /-- `quotQuotToQuotSup` and `liftSupQuotQuotMk` are inverse isomorphisms. In the case where
 `I ≤ J`, this is the Third Isomorphism Theorem (see `DoubleQuot.quotQuotEquivQuotOfLE`). -/
 def quotQuotEquivQuotSupₐ : ((A ⧸ I) ⧸ J.map (Quotient.mkₐ R I)) ≃ₐ[R] A ⧸ I ⊔ J :=
-  @AlgEquiv.ofRingEquiv R _ _ _ _ _ _ _ (quotQuotEquivQuotSup I J) fun _ => rfl
+  .ofCommutes (quotQuotEquivQuotSup I J) fun _ => rfl
 #align double_quot.quot_quot_equiv_quot_supₐ DoubleQuot.quotQuotEquivQuotSupₐ
 
 @[simp]
@@ -893,7 +889,7 @@ theorem coe_quotQuotEquivQuotSupₐ_symm :
   where `J'` (resp. `I'`) is the projection of `J` in `A / I` (resp. `I` in `A / J`). -/
 def quotQuotEquivCommₐ :
     ((A ⧸ I) ⧸ J.map (Quotient.mkₐ R I)) ≃ₐ[R] (A ⧸ J) ⧸ I.map (Quotient.mkₐ R J) :=
-  @AlgEquiv.ofRingEquiv R _ _ _ _ _ _ _ (quotQuotEquivComm I J) fun _ => rfl
+  .ofCommutes (quotQuotEquivComm I J) fun _ => rfl
 #align double_quot.quot_quot_equiv_commₐ DoubleQuot.quotQuotEquivCommₐ
 
 @[simp]
@@ -932,7 +928,7 @@ variable {I J}
 /-- The **third isomorphism theorem** for algebras. See `quotQuotEquivQuotSupₐ` for version
     that does not assume an inclusion of ideals. -/
 def quotQuotEquivQuotOfLEₐ (h : I ≤ J) : ((A ⧸ I) ⧸ J.map (Quotient.mkₐ R I)) ≃ₐ[R] A ⧸ J :=
-  @AlgEquiv.ofRingEquiv R _ _ _ _ _ _ _ (quotQuotEquivQuotOfLE h) fun _ => rfl
+  .ofCommutes (quotQuotEquivQuotOfLE h) fun _ => rfl
 #align double_quot.quot_quot_equiv_quot_of_leₐ DoubleQuot.quotQuotEquivQuotOfLEₐ
 
 @[simp]

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -731,8 +731,8 @@ variable (M S Q)
 there is an isomorphism of localizations `S ≃ₐ[R] Q`. -/
 @[simps!]
 noncomputable def algEquiv : S ≃ₐ[R] Q :=
-  { ringEquivOfRingEquiv S Q (RingEquiv.refl R) M.map_id with
-    commutes' := ringEquivOfRingEquiv_eq _ }
+  AlgEquiv.ofCommutes (ringEquivOfRingEquiv S Q (RingEquiv.refl R) M.map_id) <|
+    ringEquivOfRingEquiv_eq _
 #align is_localization.alg_equiv IsLocalization.algEquiv
 
 end
@@ -779,7 +779,7 @@ theorem isLocalization_iff_of_algEquiv [Algebra R P] (h : S ≃ₐ[R] P) :
 theorem isLocalization_iff_of_ringEquiv (h : S ≃+* P) :
     IsLocalization M S ↔ @IsLocalization _ _ M P _ (h.toRingHom.comp <| algebraMap R S).toAlgebra :=
   letI := (h.toRingHom.comp <| algebraMap R S).toAlgebra
-  isLocalization_iff_of_algEquiv M { h with commutes' := fun _ => rfl }
+  isLocalization_iff_of_algEquiv M <| .ofCommutes h fun _ => rfl
 #align is_localization.is_localization_iff_of_ring_equiv IsLocalization.isLocalization_iff_of_ringEquiv
 
 variable (S)

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -151,7 +151,9 @@ variable [Fintype n] [DecidableEq n]
 /-- The `R`-algebra isomorphism `Matrix n n A ≃ₐ[R] (A ⊗[R] Matrix n n R)`.
 -/
 def matrixEquivTensor : Matrix n n A ≃ₐ[R] A ⊗[R] Matrix n n R :=
-  AlgEquiv.symm { MatrixEquivTensor.toFunAlgHom R A n, MatrixEquivTensor.equiv R A n with }
+  AlgEquiv.symm
+    { MatrixEquivTensor.toFunAlgHom R A n, MatrixEquivTensor.equiv R A n with
+      map_smul' := map_smul _ }
 #align matrix_equiv_tensor matrixEquivTensor
 
 open MatrixEquivTensor

--- a/Mathlib/RingTheory/Polynomial/Quotient.lean
+++ b/Mathlib/RingTheory/Polynomial/Quotient.lean
@@ -60,14 +60,13 @@ noncomputable def quotientSpanCXSubCAlgEquiv (x y : R) :
     (DoubleQuot.quotQuotEquivQuotSupₐ R _ _).symm.trans <|
       (Ideal.quotientEquivAlg _ _ (quotientSpanXSubCAlgEquiv y) rfl).trans <|
         Ideal.quotientEquivAlgOfEq R <| by
-          simp only [Ideal.map_span, Set.image_singleton]; congr 2; exact eval_C
+          simp_rw [Ideal.map_span, Set.image_singleton]; congr 2; exact eval_C
 #align polynomial.quotient_span_C_X_sub_C_alg_equiv Polynomial.quotientSpanCXSubCAlgEquiv
 
 /-- For a commutative ring $R$, evaluating a polynomial at elements $y(X) \in R[X]$ and $x \in R$
 induces an isomorphism of $R$-algebras $R[X, Y] / \langle X - x, Y - y(X) \rangle \cong R$. -/
 noncomputable def quotientSpanCXSubCXSubCAlgEquiv {x : R} {y : R[X]} :
-    @AlgEquiv R (R[X][X] ⧸ (Ideal.span {C (X - C x), X - C y} : Ideal <| R[X][X])) R _ _ _
-      (Ideal.Quotient.algebra R) _ :=
+    (R[X][X] ⧸ (Ideal.span {C (X - C x), X - C y} : Ideal <| R[X][X])) ≃ₐ[R] R :=
 ((quotientSpanCXSubCAlgEquiv (X - C x) y).restrictScalars R).trans <| quotientSpanXSubCAlgEquiv x
 
 end Polynomial
@@ -281,7 +280,8 @@ noncomputable def quotientEquivQuotientMvPolynomial (I : Ideal R) :
     invFun := Ideal.Quotient.lift (Ideal.map C I : Ideal (MvPolynomial σ R))
       (eval₂Hom (C.comp (Ideal.Quotient.mk I)) X) fun _ ha => eval₂_C_mk_eq_zero ha
     left_inv := quotientEquivQuotientMvPolynomial_rightInverse I
-    right_inv := quotientEquivQuotientMvPolynomial_leftInverse I }
+    right_inv := quotientEquivQuotientMvPolynomial_leftInverse I
+    map_smul' := e.map_smul }
 #align mv_polynomial.quotient_equiv_quotient_mv_polynomial MvPolynomial.quotientEquivQuotientMvPolynomial
 
 end MvPolynomial

--- a/Mathlib/RingTheory/Polynomial/Quotient.lean
+++ b/Mathlib/RingTheory/Polynomial/Quotient.lean
@@ -26,7 +26,7 @@ noncomputable def quotientSpanXSubCAlgEquivAux2 (x : R) :
     (R[X] ⧸ (RingHom.ker (aeval x).toRingHom : Ideal R[X])) ≃ₐ[R] R :=
   let e := RingHom.quotientKerEquivOfRightInverse (fun x => by
     exact eval_C : Function.RightInverse (fun a : R => (C a : R[X])) (@aeval R R _ _ _ x))
-  { e with commutes' := fun r => e.apply_symm_apply r }
+  .ofCommutes e fun r => e.apply_symm_apply r
 
 noncomputable def quotientSpanXSubCAlgEquivAux1 (x : R) :
     (R[X] ⧸ Ideal.span {X - C x}) ≃ₐ[R] (R[X] ⧸ (RingHom.ker (aeval x).toRingHom : Ideal R[X])) :=

--- a/Mathlib/RingTheory/PolynomialAlgebra.lean
+++ b/Mathlib/RingTheory/PolynomialAlgebra.lean
@@ -191,7 +191,9 @@ open PolyEquivTensor
 /-- The `R`-algebra isomorphism `A[X] ≃ₐ[R] (A ⊗[R] R[X])`.
 -/
 def polyEquivTensor : A[X] ≃ₐ[R] A ⊗[R] R[X] :=
-  AlgEquiv.symm { PolyEquivTensor.toFunAlgHom R A, PolyEquivTensor.equiv R A with }
+  AlgEquiv.symm
+    { PolyEquivTensor.toFunAlgHom R A, PolyEquivTensor.equiv R A with
+      map_smul' := map_smul _ }
 #align poly_equiv_tensor polyEquivTensor
 
 @[simp]

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -639,17 +639,16 @@ and evidence of multiplicativity on pure tensors.
 def algEquivOfLinearEquivTripleTensorProduct (f : (A ⊗[R] B) ⊗[R] C ≃ₗ[R] D)
     (h_mul :
       ∀ (a₁ a₂ : A) (b₁ b₂ : B) (c₁ c₂ : C),
-        f ((a₁ * a₂) ⊗ₜ (b₁ * b₂) ⊗ₜ (c₁ * c₂)) = f (a₁ ⊗ₜ b₁ ⊗ₜ c₁) * f (a₂ ⊗ₜ b₂ ⊗ₜ c₂))
-    (h_one : f (((1 : A) ⊗ₜ[R] (1 : B)) ⊗ₜ[R] (1 : C)) = 1) :
+        f ((a₁ * a₂) ⊗ₜ (b₁ * b₂) ⊗ₜ (c₁ * c₂)) = f (a₁ ⊗ₜ b₁ ⊗ₜ c₁) * f (a₂ ⊗ₜ b₂ ⊗ₜ c₂)) :
     (A ⊗[R] B) ⊗[R] C ≃ₐ[R] D :=
-  AlgEquiv.ofLinearEquiv f h_one <| f.map_mul_iff.2 <| by
+  AlgEquiv.ofLinearEquiv f <| f.map_mul_iff.2 <| by
     ext
     exact h_mul _ _ _ _ _ _
 #align algebra.tensor_product.alg_equiv_of_linear_equiv_triple_tensor_product Algebra.TensorProduct.algEquivOfLinearEquivTripleTensorProduct
 
 @[simp]
-theorem algEquivOfLinearEquivTripleTensorProduct_apply (f h_mul h_one x) :
-    (algEquivOfLinearEquivTripleTensorProduct f h_mul h_one : (A ⊗[R] B) ⊗[R] C ≃ₐ[R] D) x = f x :=
+theorem algEquivOfLinearEquivTripleTensorProduct_apply (f h_mul x) :
+    (algEquivOfLinearEquivTripleTensorProduct f h_mul : (A ⊗[R] B) ⊗[R] C ≃ₐ[R] D) x = f x :=
   rfl
 #align algebra.tensor_product.alg_equiv_of_linear_equiv_triple_tensor_product_apply Algebra.TensorProduct.algEquivOfLinearEquivTripleTensorProduct_apply
 
@@ -831,7 +830,6 @@ protected def assoc : (A ⊗[R] B) ⊗[R] C ≃ₐ[R] A ⊗[R] B ⊗[R] C :=
   algEquivOfLinearEquivTripleTensorProduct
     (_root_.TensorProduct.assoc R A B C)
     Algebra.TensorProduct.assoc_aux_1
-    Algebra.TensorProduct.assoc_aux_2
 #align algebra.tensor_product.assoc Algebra.TensorProduct.assoc
 
 @[simp] theorem assoc_toLinearEquiv :
@@ -928,11 +926,14 @@ theorem congr_symm_apply (f : A ≃ₐ[S] B) (g : C ≃ₐ[R] D) (x) :
 
 @[simp]
 theorem congr_refl : congr (.refl : A ≃ₐ[S] A) (.refl : C ≃ₐ[R] C) = .refl :=
-  AlgEquiv.coe_algHom_injective <| map_id
+  -- TODO: why does this need help after the `AlgEquiv` refactor?
+  AlgEquiv.coe_algHom_injective (R := S) (A₁ := A ⊗[R] C) <| map_id
 
 theorem congr_trans (f₁ : A ≃ₐ[S] B) (f₂ : B ≃ₐ[S] C) (g₁ : D ≃ₐ[R] E) (g₂ : E ≃ₐ[R] F) :
     congr (f₁.trans f₂) (g₁.trans g₂) = (congr f₁ g₁).trans (congr f₂ g₂) :=
-  AlgEquiv.coe_algHom_injective <| map_comp f₂.toAlgHom f₁.toAlgHom g₂.toAlgHom g₁.toAlgHom
+  -- TODO: why does this need help after the `AlgEquiv` refactor?
+  AlgEquiv.coe_algHom_injective (R := S) (A₁ := A ⊗[R] D) (A₂ := C ⊗[R] F) <|
+    map_comp f₂.toAlgHom f₁.toAlgHom g₂.toAlgHom g₁.toAlgHom
 
 theorem congr_symm (f : A ≃ₐ[S] B) (g : C ≃ₐ[R] D) : congr f.symm g.symm = (congr f g).symm := rfl
 

--- a/Mathlib/Topology/LocallyConstant/Algebra.lean
+++ b/Mathlib/Topology/LocallyConstant/Algebra.lean
@@ -422,6 +422,7 @@ def congrLeftₐ (R : Type*) [CommSemiring R] [Semiring Z] [Algebra R Z] (e : X 
     LocallyConstant X Z ≃ₐ[R] LocallyConstant Y Z where
   toEquiv := congrLeft e
   __ := comapₐ R _ e.symm.continuous
+  __ := comapₗ R _ e.symm.continuous
 
 end Comap
 


### PR DESCRIPTION
This refactors `AlgEquiv` (and `AlgEquivClass`) to incorporate a `map_smul` field instead of `commutes`. This allows us to weaken the type class assumptions on `AlgEquiv` from:
```lean
structure AlgEquiv (R A B : Type*) [CommSemiring R] [Semiring A] [Semiring B]
	[Algebra R A] [Algebra R B]
```
to:
```lean
structure AlgEquiv (R A B : Type*) [Add A] [Add B] [Mul A] [Mul B] [SMul R A] [SMul R B]
```
in accordance with the other `Equiv` structures (e.g., `MulEquiv`, `AddEquiv`, `RingEquiv`). This allows us to use `AlgEquiv` for both unital and non-unital (even non-associative) algebra homomorphisms. Note in addition that `StarAlgEquiv` already follows this paradigm.

We supply the convenience constructor `AlgEquiv.ofCommutes`, which is marked `inline` and `reducible`, so that users can still provide go via the `commutes` route for constructing and `AlgEquiv` whenever it is more convenient.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
