### PR TITLE
[Merged by Bors] - feat(Algebra/DirectLimit): add `map, congr, lift_injective` for direct limits of modules, abelian groups and rings

### DIFF
--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -196,12 +196,11 @@ Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` resp
 family of linear maps `gᵢ : Gᵢ ⟶ G'ᵢ` such that `g ∘ f = f' ∘ g` induces a linear map
 `lim G ⟶ lim G'`.
 -/
-def map (maps : (i : ι) → G i →ₗ[R] G' i)
-    (maps_compatible : ∀ i j h, maps j ∘ₗ f i j h = f' i j h ∘ₗ maps i) :
+def map (g : (i : ι) → G i →ₗ[R] G' i) (hg : ∀ i j h, g j ∘ₗ f i j h = f' i j h ∘ₗ g i) :
     DirectLimit G f →ₗ[R] DirectLimit G' f' :=
-  lift _ _ _ _ (fun i ↦ of _ _ _ _ _ ∘ₗ maps i) fun i j h g ↦ (isEmpty_or_nonempty ι).elim
+  lift _ _ _ _ (fun i ↦ of _ _ _ _ _ ∘ₗ g i) fun i j h g ↦ (isEmpty_or_nonempty ι).elim
     (fun _ ↦ Subsingleton.elim _ _) fun _ ↦ by
-      have eq1 := LinearMap.congr_fun (maps_compatible i j h) g
+      have eq1 := LinearMap.congr_fun (hg i j h) g
       simp only [LinearMap.coe_comp, Function.comp_apply] at eq1 ⊢
       rw [eq1, of_f]
 
@@ -211,7 +210,7 @@ def map (maps : (i : ι) → G i →ₗ[R] G' i)
     map maps maps_compatible (of _ _ _ _ _ g) = of R ι G' f' i (maps i g) :=
   lift_of _ _ _
 
-lemma map_id [IsDirected ι (· ≤ ·)] :
+@[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
     map (fun i ↦ LinearMap.id) (fun _ _ _ ↦ rfl) = LinearMap.id (R := R) (M := DirectLimit G f) :=
   FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
     x.induction_on fun i g ↦ by simp
@@ -448,7 +447,6 @@ theorem lift_unique [IsDirected ι (· ≤ ·)] (F : DirectLimit G f →+ P) (x)
   · simp_rw [Subsingleton.elim x 0, _root_.map_zero]
   · exact DirectLimit.induction_on x fun i x => by simp
 #align add_comm_group.direct_limit.lift_unique AddCommGroup.DirectLimit.lift_unique
-
 
 lemma lift_injective [IsDirected ι (· ≤ ·)]
     (injective : ∀ i, Function.Injective <| g i) :

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -241,7 +241,7 @@ def congr [IsDirected ι (· ≤ ·)]
     (map (fun i ↦ (equivs i).symm) fun i j h ↦ by
       rw [toLinearMap_symm_comp_eq, ← comp_assoc, equivs_compatible i, comp_assoc, comp_coe,
         symm_trans_self, refl_toLinearMap, comp_id])
-    (by simp [map_comp, map_id]) (by simp [map_comp, map_id])
+    (by simp [map_comp]) (by simp [map_comp])
 
 lemma congr_apply_of [IsDirected ι (· ≤ ·)]
     (equivs : (i : ι) → G i ≃ₗ[R] G' i)
@@ -488,7 +488,7 @@ def map (g : (i : ι) → G i →+ G' i)
     map g hg (of _ _ _ x) = of G' f' i (g i x) :=
   lift_of _ _ _ _ _
 
-lemma map_id [IsDirected ι (· ≤ ·)] :
+@[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
     map (fun i ↦ AddMonoidHom.id _) (fun _ _ _ ↦ rfl) = AddMonoidHom.id (DirectLimit G f) :=
   FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
     x.induction_on fun i g ↦ by simp
@@ -917,7 +917,7 @@ def map (g : (i : ι) → G i →+* G' i)
     map g hg (of _ _ _ g) = of G' (fun _ _ h ↦ f' _ _ h) i (g i g) :=
   lift_of _ _ _ _ _
 
-lemma map_id [IsDirected ι (· ≤ ·)] :
+@[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
     map (fun i ↦ RingHom.id _) (fun _ _ _ ↦ rfl) =
     RingHom.id (DirectLimit G fun _ _ h ↦ f _ _ h) :=
   FunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -230,12 +230,11 @@ lemma map_comp [IsDirected ι (· ≤ ·)]
 open LinearEquiv LinearMap in
 /--
 Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
-family of equivalences `gᵢ : Gᵢ ≅ G'ᵢ` such that `g ∘ f = f' ∘ g` induces an equivalence
-`lim G ⟶ lim G'`.
+family of equivalences `eᵢ : Gᵢ ≅ G'ᵢ` such that `e ∘ f = f' ∘ e` induces an equivalence
+`lim G ≅ lim G'`.
 -/
 def congr [IsDirected ι (· ≤ ·)]
-    (equivs : (i : ι) → G i ≃ₗ[R] G' i)
-    (equivs_compatible : ∀ i j h, equivs j ∘ₗ f i j h = f' i j h ∘ₗ equivs i) :
+    (e : (i : ι) → G i ≃ₗ[R] G' i) (he : ∀ i j h, e j ∘ₗ f i j h = f' i j h ∘ₗ e i) :
     DirectLimit G f ≃ₗ[R] DirectLimit G' f' :=
   LinearEquiv.ofLinear (map (equivs ·) equivs_compatible)
     (map (fun i ↦ (equivs i).symm) fun i j h ↦ by

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -207,7 +207,7 @@ def map (g : (i : ι) → G i →ₗ[R] G' i) (hg : ∀ i j h, g j ∘ₗ f i j 
 @[simp] lemma map_apply_of (g : (i : ι) → G i →ₗ[R] G' i)
     (hg : ∀ i j h, g j ∘ₗ f i j h = f' i j h ∘ₗ g i)
     {i : ι} (x : G i) :
-    map g hg (of _ _ _ _ _ x) = of R ι G' f' i (g i x) :=
+    map g hg (of _ _ G f _ x) = of R ι G' f' i (g i x) :=
   lift_of _ _ _
 
 @[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
@@ -245,16 +245,14 @@ def congr [IsDirected ι (· ≤ ·)]
 lemma congr_apply_of [IsDirected ι (· ≤ ·)]
     (e : (i : ι) → G i ≃ₗ[R] G' i) (he : ∀ i j h, e j ∘ₗ f i j h = f' i j h ∘ₗ e i)
     {i : ι} (g : G i) :
-    congr e he (of _ _ _ _ i g) =
-    (of _ _ _ _ i (e i g) : DirectLimit G' f') :=
+    congr e he (of _ _ G f i g) = of _ _ G' f' i (e i g) :=
   map_apply_of _ he _
 
 open LinearEquiv LinearMap in
 lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
     (e : (i : ι) → G i ≃ₗ[R] G' i) (he : ∀ i j h, e j ∘ₗ f i j h = f' i j h ∘ₗ e i)
     {i : ι} (g : G' i) :
-    (congr e he).symm (of _ _ _ _ i g) =
-    (of _ _ _ _ i ((e i).symm g) : DirectLimit G f) :=
+    (congr e he).symm (of _ _ G' f' i g) = of _ _ G f i ((e i).symm g) :=
   map_apply_of _ (fun i j h ↦ by
     rw [toLinearMap_symm_comp_eq, ← comp_assoc, he i, comp_assoc, comp_coe, symm_trans_self,
       refl_toLinearMap, comp_id]) _
@@ -482,7 +480,7 @@ def map (g : (i : ι) → G i →+ G' i)
 @[simp] lemma map_apply_of (g : (i : ι) → G i →+ G' i)
     (hg : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i))
     {i : ι} (x : G i) :
-    map g hg (of _ _ _ x) = of G' f' i (g i x) :=
+    map g hg (of G f _ x) = of G' f' i (g i x) :=
   lift_of _ _ _ _ _
 
 @[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
@@ -525,16 +523,14 @@ lemma congr_apply_of [IsDirected ι (· ≤ ·)]
     (e : (i : ι) → G i ≃+ G' i)
     (he : ∀ i j h, (e j).toAddMonoidHom.comp (f i j h) = (f' i j h).comp (e i))
     {i : ι} (g : G i) :
-    congr e he (of _ _ i g) =
-    (of _ _ i (e i g) : DirectLimit G' f') :=
+    congr e he (of G f i g) = of G' f' i (e i g) :=
   map_apply_of _ he _
 
 lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
     (e : (i : ι) → G i ≃+ G' i)
     (he : ∀ i j h, (e j).toAddMonoidHom.comp (f i j h) = (f' i j h).comp (e i))
     {i : ι} (g : G' i) :
-    (congr e he).symm (of _  _ i g) =
-    (of _ _ i ((e i).symm g) : DirectLimit G f) := by
+    (congr e he).symm (of G' f' i g) = of G f i ((e i).symm g) := by
   simp only [congr, AddMonoidHom.toAddEquiv_symm_apply, map_apply_of, AddMonoidHom.coe_coe]
 
 end interaction_with_other_directLimits
@@ -908,7 +904,7 @@ def map (g : (i : ι) → G i →+* G' i)
 @[simp] lemma map_apply_of (g : (i : ι) → G i →+* G' i)
     (hg : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i))
     {i : ι} (x : G i) :
-    map g hg (of _ _ _ x) = of G' (fun _ _ h ↦ f' _ _ h) i (g i x) :=
+    map g hg (of G _ _ x) = of G' (fun _ _ h ↦ f' _ _ h) i (g i x) :=
   lift_of _ _ _ _ _
 
 @[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
@@ -950,16 +946,14 @@ lemma congr_apply_of [IsDirected ι (· ≤ ·)]
     (e : (i : ι) → G i ≃+* G' i)
     (he : ∀ i j h, (e j).toRingHom.comp (f i j h) = (f' i j h).comp (e i))
     {i : ι} (g : G i) :
-    congr e he (of _ _ i g) =
-    (of _ _ i (e i g) : DirectLimit G' fun _ _ h ↦ f' _ _ h) :=
-  map_apply_of _ equivs_compatible _
+    congr e he (of G _ i g) = of G' (fun _ _ h ↦ f' _ _ h) i (e i g) :=
+  map_apply_of _ he _
 
 lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
     (e : (i : ι) → G i ≃+* G' i)
-    (he : ∀ i j h, (equivs j).toRingHom.comp (f i j h) = (f' i j h).comp (equivs i))
+    (he : ∀ i j h, (e j).toRingHom.comp (f i j h) = (f' i j h).comp (e i))
     {i : ι} (g : G' i) :
-    (congr e he).symm (of _  _ i g) =
-    (of _ _ i ((e i).symm g) : DirectLimit G fun _ _ h ↦ f _ _ h) := by
+    (congr e he).symm (of G' _ i g) = of G (fun _ _ h ↦ f _ _ h) i ((e i).symm g) := by
   simp only [congr, RingEquiv.ofHomInv_symm_apply, map_apply_of, RingHom.coe_coe]
 
 end interaction_with_other_directLimits

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -921,9 +921,9 @@ def map (maps : (i : ι) → G i →+* G' i)
   lift_of _ _ _ _ _
 
 lemma map_id [IsDirected ι (· ≤ ·)] :
-    map (fun i ↦ RingHom.id _) (fun _ _ _ ↦ rfl) = AddMonoidHom.id (DirectLimit G f) :=
-  FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
-    x.induction_on fun i g ↦ by simp
+    map (fun i ↦ RingHom.id _) (fun _ _ _ ↦ rfl) =
+    RingHom.id (DirectLimit G (fun _ _ h ↦ f _ _ h)) :=
+  FunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp
 
 lemma map_comp [IsDirected ι (· ≤ ·)]
     (maps : (i : ι) → G i →+* G' i) (maps' : (i : ι) → G' i →+* G'' i)
@@ -932,11 +932,10 @@ lemma map_comp [IsDirected ι (· ≤ ·)]
     ((map maps' maps_compatible').comp (map maps maps_compatible) :
       DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' (fun _ _ h ↦ f'' _ _ h) ) =
     (map (fun i ↦ (maps' i).comp (maps i)) fun i j h ↦ by
-      rw [AddMonoidHom.comp_assoc, maps_compatible i, ← AddMonoidHom.comp_assoc,
-        maps_compatible' i, AddMonoidHom.comp_assoc] :
+      rw [RingHom.comp_assoc, maps_compatible i, ← RingHom.comp_assoc,
+        maps_compatible' i, RingHom.comp_assoc] :
       DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' (fun _ _ h ↦ f'' _ _ h)) :=
-  FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
-    x.induction_on fun i g ↦ by simp
+  FunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp
 
 /--
 Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
@@ -944,18 +943,19 @@ family of equivalences `gᵢ : Gᵢ ≅ G'ᵢ` such that `g ∘ f = f' ∘ g` in
 `lim G ⟶ lim G'`.
 -/
 def congr [IsDirected ι (· ≤ ·)]
-    (equivs : (i : ι) → G i ≃+ G' i)
-    (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
+    (equivs : (i : ι) → G i ≃+* G' i)
+    (equivs_compatible : ∀ i j h, (equivs j).toRingHom.comp (f i j h) =
       (f' i j h).comp (equivs i)) :
-    DirectLimit G f ≃+ DirectLimit G' f' :=
-  AddMonoidHom.toAddEquiv (map (equivs ·) equivs_compatible)
+    DirectLimit G (fun _ _ h ↦ f _ _ h) ≃+* DirectLimit G' (fun _ _ h ↦ f' _ _ h) :=
+  RingEquiv.ofHomInv
+    (map (equivs ·) equivs_compatible)
     (map (fun i ↦ (equivs i).symm) fun i j h ↦ FunLike.ext _ _ fun x ↦ by
       have eq1 := FunLike.congr_fun (equivs_compatible i j h) ((equivs i).symm x)
-      simp only [AddMonoidHom.coe_comp, AddEquiv.coe_toAddMonoidHom, Function.comp_apply,
-        AddMonoidHom.coe_coe, AddEquiv.apply_symm_apply] at eq1 ⊢
+      simp only [RingEquiv.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply,
+        RingEquiv.apply_symm_apply] at eq1 ⊢
       simp [← eq1, of_f])
-    (by rw [map_comp]; convert map_id <;> aesop)
-    (by rw [map_comp]; convert map_id <;> aesop)
+    (FunLike.ext _ _ fun x ↦ x.induction_on <| by simp)
+    (FunLike.ext _ _ fun x ↦ x.induction_on <| by simp)
 
 lemma congr_apply_of [IsDirected ι (· ≤ ·)]
     (equivs : (i : ι) → G i ≃+ G' i)

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Kenny Lau, Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kenny Lau, Chris Hughes
+Authors: Kenny Lau, Chris Hughes, Jujian Zhang
 -/
 import Mathlib.Data.Finset.Order
 import Mathlib.Algebra.DirectSum.Module
@@ -32,7 +32,7 @@ so as to make the operations (addition etc.) "computable".
 -/
 
 
-universe u v w u₁
+universe u v v' v'' w u₁
 
 open Submodule
 
@@ -172,6 +172,99 @@ theorem lift_unique [IsDirected ι (· ≤ ·)] (F : DirectLimit G f →ₗ[R] P
   · exact DirectLimit.induction_on x fun i x => by rw [lift_of]; rfl
 #align module.direct_limit.lift_unique Module.DirectLimit.lift_unique
 
+lemma lift_injective [IsDirected ι (· ≤ ·)]
+    (injective : ∀ i, Function.Injective <| g i) :
+    Function.Injective (lift R ι G f g Hg) := by
+  cases isEmpty_or_nonempty ι
+  · apply Function.injective_of_subsingleton
+  simp_rw [injective_iff_map_eq_zero] at injective ⊢
+  intros z hz
+  induction' z using DirectLimit.induction_on with _ g
+  rw [lift_of] at hz
+  rw [injective _ g hz, _root_.map_zero]
+
+section interaction_with_other_directLimits
+
+variable {G' : ι → Type v'} [∀ i, AddCommGroup (G' i)] [∀ i, Module R (G' i)]
+variable {f' : ∀ i j, i ≤ j → G' i →ₗ[R] G' j}
+
+variable {G'' : ι → Type v''} [∀ i, AddCommGroup (G'' i)] [∀ i, Module R (G'' i)]
+variable {f'' : ∀ i j, i ≤ j → G'' i →ₗ[R] G'' j}
+
+/--
+Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
+family of linear maps `gᵢ : Gᵢ ⟶ G'ᵢ` such that `g ∘ f = f' ∘ g` induces a linear map
+`lim G ⟶ lim G'`.
+-/
+def map (maps : (i : ι) → G i →ₗ[R] G' i)
+    (maps_compatible : ∀ i j h, maps j ∘ₗ f i j h = f' i j h ∘ₗ maps i) :
+    DirectLimit G f →ₗ[R] DirectLimit G' f' :=
+  lift _ _ _ _ (fun i ↦ of _ _ _ _ _ ∘ₗ maps i) fun i j h g ↦ (isEmpty_or_nonempty ι).elim
+    (fun _ ↦ Subsingleton.elim _ _) fun _ ↦ by
+      have eq1 := LinearMap.congr_fun (maps_compatible i j h) g
+      simp only [LinearMap.coe_comp, Function.comp_apply] at eq1 ⊢
+      rw [eq1, of_f]
+
+@[simp] lemma map_apply_of (maps : (i : ι) → G i →ₗ[R] G' i)
+    (maps_compatible : ∀ i j h, maps j ∘ₗ f i j h = f' i j h ∘ₗ maps i)
+    {i : ι} (g : G i) :
+    map maps maps_compatible (of _ _ _ _ _ g) = of R ι G' f' i (maps i g) :=
+  lift_of _ _ _
+
+lemma map_id [IsDirected ι (· ≤ ·)] :
+    map (fun i ↦ LinearMap.id) (fun _ _ _ ↦ rfl) = LinearMap.id (R := R) (M := DirectLimit G f) :=
+  FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
+    x.induction_on fun i g ↦ by simp
+
+lemma map_comp [IsDirected ι (· ≤ ·)]
+    (maps : (i : ι) → G i →ₗ[R] G' i) (maps' : (i : ι) → G' i →ₗ[R] G'' i)
+    (maps_compatible : ∀ i j h, maps j ∘ₗ f i j h = f' i j h ∘ₗ maps i)
+    (maps_compatible' : ∀ i j h, maps' j ∘ₗ f' i j h = f'' i j h ∘ₗ maps' i) :
+    (map maps' maps_compatible' ∘ₗ map maps maps_compatible :
+      DirectLimit G f →ₗ[R] DirectLimit G'' f'') =
+    (map (fun i ↦ maps' i ∘ₗ maps i) fun i j h ↦ by
+        rw [LinearMap.comp_assoc, maps_compatible i, ← LinearMap.comp_assoc, maps_compatible' i,
+         LinearMap.comp_assoc] : DirectLimit G f →ₗ[R] DirectLimit G'' f'') :=
+  FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
+    x.induction_on fun i g ↦ by simp
+
+open LinearEquiv LinearMap in
+/--
+Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
+family of equivalences `gᵢ : Gᵢ ≅ G'ᵢ` such that `g ∘ f = f' ∘ g` induces an equivalence
+`lim G ⟶ lim G'`.
+-/
+def congr [IsDirected ι (· ≤ ·)]
+    (equivs : (i : ι) → G i ≃ₗ[R] G' i)
+    (equivs_compatible : ∀ i j h, equivs j ∘ₗ f i j h = f' i j h ∘ₗ equivs i) :
+    DirectLimit G f ≃ₗ[R] DirectLimit G' f' :=
+  LinearEquiv.ofLinear (map (equivs ·) equivs_compatible)
+    (map (fun i ↦ (equivs i).symm) fun i j h ↦ by
+      rw [toLinearMap_symm_comp_eq, ← comp_assoc, equivs_compatible i, comp_assoc, comp_coe,
+        symm_trans_self, refl_toLinearMap, comp_id])
+    (by simp [map_comp, map_id]) (by simp [map_comp, map_id])
+
+lemma congr_apply_of [IsDirected ι (· ≤ ·)]
+    (equivs : (i : ι) → G i ≃ₗ[R] G' i)
+    (equivs_compatible : ∀ i j h, equivs j ∘ₗ f i j h = f' i j h ∘ₗ equivs i)
+    {i : ι} (g : G i) :
+    congr equivs equivs_compatible (of _ _ _ _ i g) =
+    (of _ _ _ _ i (equivs i g) : DirectLimit G' f') :=
+  map_apply_of _ equivs_compatible _
+
+open LinearEquiv LinearMap in
+lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
+    (equivs : (i : ι) → G i ≃ₗ[R] G' i)
+    (equivs_compatible : ∀ i j h, equivs j ∘ₗ f i j h = f' i j h ∘ₗ equivs i)
+    {i : ι} (g : G' i) :
+    (congr equivs equivs_compatible).symm (of _ _ _ _ i g) =
+    (of _ _ _ _ i ((equivs i).symm g) : DirectLimit G f) :=
+  map_apply_of _ (fun i j h ↦ by
+    rw [toLinearMap_symm_comp_eq, ← comp_assoc, equivs_compatible i, comp_assoc, comp_coe,
+      symm_trans_self, refl_toLinearMap, comp_id]) _
+
+end interaction_with_other_directLimits
+
 section Totalize
 
 open Classical
@@ -302,8 +395,8 @@ instance : Inhabited (DirectLimit G f) :=
 instance [IsEmpty ι] : Unique (DirectLimit G f) := Module.DirectLimit.unique _ _
 
 /-- The canonical map from a component to the direct limit. -/
-def of (i) : G i →ₗ[ℤ] DirectLimit G f :=
-  Module.DirectLimit.of ℤ ι G (fun i j hij => (f i j hij).toIntLinearMap) i
+def of (i) : G i →+ DirectLimit G f :=
+  (Module.DirectLimit.of ℤ ι G (fun i j hij => (f i j hij).toIntLinearMap) i).toAddMonoidHom
 #align add_comm_group.direct_limit.of AddCommGroup.DirectLimit.of
 
 variable {G f}
@@ -337,9 +430,9 @@ variable (G f)
 /-- The universal property of the direct limit: maps from the components to another abelian group
 that respect the directed system structure (i.e. make some diagram commute) give rise
 to a unique map out of the direct limit. -/
-def lift : DirectLimit G f →ₗ[ℤ] P :=
-  Module.DirectLimit.lift ℤ ι G (fun i j hij => (f i j hij).toIntLinearMap)
-    (fun i => (g i).toIntLinearMap) Hg
+def lift : DirectLimit G f →+ P :=
+  (Module.DirectLimit.lift ℤ ι G (fun i j hij => (f i j hij).toIntLinearMap)
+    (fun i => (g i).toIntLinearMap) Hg).toAddMonoidHom
 #align add_comm_group.direct_limit.lift AddCommGroup.DirectLimit.lift
 
 variable {G f}
@@ -350,11 +443,110 @@ theorem lift_of (i x) : lift G f P g Hg (of G f i x) = g i x :=
 #align add_comm_group.direct_limit.lift_of AddCommGroup.DirectLimit.lift_of
 
 theorem lift_unique [IsDirected ι (· ≤ ·)] (F : DirectLimit G f →+ P) (x) :
-    F x = lift G f P (fun i => F.comp (of G f i).toAddMonoidHom) (fun i j hij x => by simp) x := by
+    F x = lift G f P (fun i => F.comp (of G f i)) (fun i j hij x => by simp) x := by
   cases isEmpty_or_nonempty ι
   · simp_rw [Subsingleton.elim x 0, _root_.map_zero]
   · exact DirectLimit.induction_on x fun i x => by simp
 #align add_comm_group.direct_limit.lift_unique AddCommGroup.DirectLimit.lift_unique
+
+
+lemma lift_injective [IsDirected ι (· ≤ ·)]
+    (injective : ∀ i, Function.Injective <| g i) :
+    Function.Injective (lift G f P g Hg) := by
+  cases isEmpty_or_nonempty ι
+  · apply Function.injective_of_subsingleton
+  simp_rw [injective_iff_map_eq_zero] at injective ⊢
+  intros z hz
+  induction' z using DirectLimit.induction_on with _ g
+  rw [lift_of] at hz
+  rw [injective _ g hz, _root_.map_zero]
+
+section interaction_with_other_directLimits
+
+variable {G' : ι → Type v'} [∀ i, AddCommGroup (G' i)]
+variable {f' : ∀ i j, i ≤ j → G' i →+ G' j}
+
+variable {G'' : ι → Type v''} [∀ i, AddCommGroup (G'' i)]
+variable {f'' : ∀ i j, i ≤ j → G'' i →+ G'' j}
+
+/--
+Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
+family of group homomorphisms `gᵢ : Gᵢ ⟶ G'ᵢ` such that `g ∘ f = f' ∘ g` induces a group
+homomorphism `lim G ⟶ lim G'`.
+-/
+def map (maps : (i : ι) → G i →+ G' i)
+    (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i)) :
+    DirectLimit G f →+ DirectLimit G' f' :=
+  lift _ _ _ (fun i ↦ (of _ _ _).comp (maps i)) fun i j h g ↦
+    (isEmpty_or_nonempty ι).elim
+    (fun _ ↦ Subsingleton.elim _ _) fun _ ↦ by
+      have eq1 := FunLike.congr_fun (maps_compatible i j h) g
+      simp only [AddMonoidHom.coe_comp, Function.comp_apply] at eq1 ⊢
+      rw [eq1, of_f]
+
+@[simp] lemma map_apply_of (maps : (i : ι) → G i →+ G' i)
+    (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i))
+    {i : ι} (g : G i) :
+    map maps maps_compatible (of _ _ _ g) = of G' f' i (maps i g) :=
+  lift_of _ _ _ _ _
+
+lemma map_id [IsDirected ι (· ≤ ·)] :
+    map (fun i ↦ AddMonoidHom.id _) (fun _ _ _ ↦ rfl) = AddMonoidHom.id (DirectLimit G f) :=
+  FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
+    x.induction_on fun i g ↦ by simp
+
+lemma map_comp [IsDirected ι (· ≤ ·)]
+    (maps : (i : ι) → G i →+ G' i) (maps' : (i : ι) → G' i →+ G'' i)
+    (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i))
+    (maps_compatible' : ∀ i j h, (maps' j).comp (f' i j h) = (f'' i j h).comp (maps' i)) :
+    ((map maps' maps_compatible').comp (map maps maps_compatible) :
+      DirectLimit G f →+ DirectLimit G'' f'') =
+    (map (fun i ↦ (maps' i).comp (maps i)) fun i j h ↦ by
+      rw [AddMonoidHom.comp_assoc, maps_compatible i, ← AddMonoidHom.comp_assoc,
+        maps_compatible' i, AddMonoidHom.comp_assoc] :
+      DirectLimit G f →+ DirectLimit G'' f'') :=
+  FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
+    x.induction_on fun i g ↦ by simp
+
+/--
+Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
+family of equivalences `gᵢ : Gᵢ ≅ G'ᵢ` such that `g ∘ f = f' ∘ g` induces an equivalence
+`lim G ⟶ lim G'`.
+-/
+def congr [IsDirected ι (· ≤ ·)]
+    (equivs : (i : ι) → G i ≃+ G' i)
+    (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
+      (f' i j h).comp (equivs i)) :
+    DirectLimit G f ≃+ DirectLimit G' f' :=
+  AddMonoidHom.toAddEquiv (map (equivs ·) equivs_compatible)
+    (map (fun i ↦ (equivs i).symm) fun i j h ↦ FunLike.ext _ _ fun x ↦ by
+      have eq1 := FunLike.congr_fun (equivs_compatible i j h) ((equivs i).symm x)
+      simp only [AddMonoidHom.coe_comp, AddEquiv.coe_toAddMonoidHom, Function.comp_apply,
+        AddMonoidHom.coe_coe, AddEquiv.apply_symm_apply] at eq1 ⊢
+      simp [← eq1, of_f])
+    (by rw [map_comp]; convert map_id <;> aesop)
+    (by rw [map_comp]; convert map_id <;> aesop)
+
+lemma congr_apply_of [IsDirected ι (· ≤ ·)]
+    (equivs : (i : ι) → G i ≃+ G' i)
+    (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
+      (f' i j h).comp (equivs i))
+    {i : ι} (g : G i) :
+    congr equivs equivs_compatible (of _ _ i g) =
+    (of _ _ i (equivs i g) : DirectLimit G' f') :=
+  map_apply_of _ equivs_compatible _
+
+open LinearEquiv LinearMap in
+lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
+    (equivs : (i : ι) → G i ≃+ G' i)
+    (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
+      (f' i j h).comp (equivs i))
+    {i : ι} (g : G' i) :
+    (congr equivs equivs_compatible).symm (of _  _ i g) =
+    (of _ _ i ((equivs i).symm g) : DirectLimit G f) := by
+  simp only [congr, AddMonoidHom.toAddEquiv_symm_apply, map_apply_of, AddMonoidHom.coe_coe]
+
+end interaction_with_other_directLimits
 
 end DirectLimit
 
@@ -689,6 +881,102 @@ theorem lift_unique [IsDirected ι (· ≤ ·)] (F : DirectLimit G f →+* P) (x
     exact IsEmpty.elim' inferInstance i
   · exact DirectLimit.induction_on x fun i x => by simp [lift_of]
 #align ring.direct_limit.lift_unique Ring.DirectLimit.lift_unique
+
+lemma lift_injective [Nonempty ι] [IsDirected ι (· ≤ ·)]
+    (injective : ∀ i, Function.Injective <| g i) :
+    Function.Injective (lift G f P g Hg) := by
+  simp_rw [injective_iff_map_eq_zero] at injective ⊢
+  intros z hz
+  induction' z using DirectLimit.induction_on with _ g
+  rw [lift_of] at hz
+  rw [injective _ g hz, _root_.map_zero]
+
+section interaction_with_other_directLimits
+
+variable {f : ∀ i j, i ≤ j → G i →+* G j}
+variable {G' : ι → Type v'} [∀ i, CommRing (G' i)]
+variable {f' : ∀ i j, i ≤ j → G' i →+* G' j}
+
+variable {G'' : ι → Type v''} [∀ i, CommRing (G'' i)]
+variable {f'' : ∀ i j, i ≤ j → G'' i →+* G'' j}
+
+variable [Nonempty ι]
+/--
+Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
+family of ring homomorphisms `gᵢ : Gᵢ ⟶ G'ᵢ` such that `g ∘ f = f' ∘ g` induces a ring
+homomorphism `lim G ⟶ lim G'`.
+-/
+def map (maps : (i : ι) → G i →+* G' i)
+    (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i)) :
+    DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G' (fun _ _ h ↦ f' _ _ h) :=
+  lift _ _ _ (fun i ↦ (of _ _ _).comp (maps i)) fun i j h g ↦ by
+      have eq1 := FunLike.congr_fun (maps_compatible i j h) g
+      simp only [RingHom.coe_comp, Function.comp_apply] at eq1 ⊢
+      rw [eq1, of_f]
+
+@[simp] lemma map_apply_of (maps : (i : ι) → G i →+* G' i)
+    (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i))
+    {i : ι} (g : G i) :
+    map maps maps_compatible (of _ _ _ g) = of G' (fun _ _ h ↦ f' _ _ h) i (maps i g) :=
+  lift_of _ _ _ _ _
+
+lemma map_id [IsDirected ι (· ≤ ·)] :
+    map (fun i ↦ RingHom.id _) (fun _ _ _ ↦ rfl) = AddMonoidHom.id (DirectLimit G f) :=
+  FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
+    x.induction_on fun i g ↦ by simp
+
+lemma map_comp [IsDirected ι (· ≤ ·)]
+    (maps : (i : ι) → G i →+* G' i) (maps' : (i : ι) → G' i →+* G'' i)
+    (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i))
+    (maps_compatible' : ∀ i j h, (maps' j).comp (f' i j h) = (f'' i j h).comp (maps' i)) :
+    ((map maps' maps_compatible').comp (map maps maps_compatible) :
+      DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' (fun _ _ h ↦ f'' _ _ h) ) =
+    (map (fun i ↦ (maps' i).comp (maps i)) fun i j h ↦ by
+      rw [AddMonoidHom.comp_assoc, maps_compatible i, ← AddMonoidHom.comp_assoc,
+        maps_compatible' i, AddMonoidHom.comp_assoc] :
+      DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' (fun _ _ h ↦ f'' _ _ h)) :=
+  FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
+    x.induction_on fun i g ↦ by simp
+
+/--
+Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
+family of equivalences `gᵢ : Gᵢ ≅ G'ᵢ` such that `g ∘ f = f' ∘ g` induces an equivalence
+`lim G ⟶ lim G'`.
+-/
+def congr [IsDirected ι (· ≤ ·)]
+    (equivs : (i : ι) → G i ≃+ G' i)
+    (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
+      (f' i j h).comp (equivs i)) :
+    DirectLimit G f ≃+ DirectLimit G' f' :=
+  AddMonoidHom.toAddEquiv (map (equivs ·) equivs_compatible)
+    (map (fun i ↦ (equivs i).symm) fun i j h ↦ FunLike.ext _ _ fun x ↦ by
+      have eq1 := FunLike.congr_fun (equivs_compatible i j h) ((equivs i).symm x)
+      simp only [AddMonoidHom.coe_comp, AddEquiv.coe_toAddMonoidHom, Function.comp_apply,
+        AddMonoidHom.coe_coe, AddEquiv.apply_symm_apply] at eq1 ⊢
+      simp [← eq1, of_f])
+    (by rw [map_comp]; convert map_id <;> aesop)
+    (by rw [map_comp]; convert map_id <;> aesop)
+
+lemma congr_apply_of [IsDirected ι (· ≤ ·)]
+    (equivs : (i : ι) → G i ≃+ G' i)
+    (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
+      (f' i j h).comp (equivs i))
+    {i : ι} (g : G i) :
+    congr equivs equivs_compatible (of _ _ i g) =
+    (of _ _ i (equivs i g) : DirectLimit G' f') :=
+  map_apply_of _ equivs_compatible _
+
+open LinearEquiv LinearMap in
+lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
+    (equivs : (i : ι) → G i ≃+ G' i)
+    (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
+      (f' i j h).comp (equivs i))
+    {i : ι} (g : G' i) :
+    (congr equivs equivs_compatible).symm (of _  _ i g) =
+    (of _ _ i ((equivs i).symm g) : DirectLimit G f) := by
+  simp only [congr, AddMonoidHom.toAddEquiv_symm_apply, map_apply_of, AddMonoidHom.coe_coe]
+
+end interaction_with_other_directLimits
 
 end DirectLimit
 

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -198,9 +198,10 @@ family of linear maps `gᵢ : Gᵢ ⟶ G'ᵢ` such that `g ∘ f = f' ∘ g` ind
 -/
 def map (g : (i : ι) → G i →ₗ[R] G' i) (hg : ∀ i j h, g j ∘ₗ f i j h = f' i j h ∘ₗ g i) :
     DirectLimit G f →ₗ[R] DirectLimit G' f' :=
-  lift _ _ _ _ (fun i ↦ of _ _ _ _ _ ∘ₗ g i) fun i j h g ↦ (isEmpty_or_nonempty ι).elim
-    (fun _ ↦ Subsingleton.elim _ _) fun _ ↦ by
-      have eq1 := LinearMap.congr_fun (hg i j h) g
+  lift _ _ _ _ (fun i ↦ of _ _ _ _ _ ∘ₗ g i) fun i j h g ↦ by
+    cases isEmpty_or_nonempty ι
+    · exact Subsingleton.elim _ _
+    · have eq1 := LinearMap.congr_fun (hg i j h) g
       simp only [LinearMap.coe_comp, Function.comp_apply] at eq1 ⊢
       rw [eq1, of_f]
 
@@ -470,10 +471,10 @@ homomorphism `lim G ⟶ lim G'`.
 def map (g : (i : ι) → G i →+ G' i)
     (hg : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i)) :
     DirectLimit G f →+ DirectLimit G' f' :=
-  lift _ _ _ (fun i ↦ (of _ _ _).comp (g i)) fun i j h g ↦
-    (isEmpty_or_nonempty ι).elim
-    (fun _ ↦ Subsingleton.elim _ _) fun _ ↦ by
-      have eq1 := FunLike.congr_fun (hg i j h) g
+  lift _ _ _ (fun i ↦ (of _ _ _).comp (g i)) fun i j h g ↦ by
+    cases isEmpty_or_nonempty ι
+    · exact Subsingleton.elim _ _
+    · have eq1 := FunLike.congr_fun (hg i j h) g
       simp only [AddMonoidHom.coe_comp, Function.comp_apply] at eq1 ⊢
       rw [eq1, of_f]
 

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -914,7 +914,7 @@ def map (g : (i : ι) → G i →+* G' i)
 @[simp] lemma map_apply_of (g : (i : ι) → G i →+* G' i)
     (hg : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i))
     {i : ι} (x : G i) :
-    map g hg (of _ _ _ g) = of G' (fun _ _ h ↦ f' _ _ h) i (g i g) :=
+    map g hg (of _ _ _ x) = of G' (fun _ _ h ↦ f' _ _ h) i (g i x) :=
   lift_of _ _ _ _ _
 
 @[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
@@ -924,7 +924,7 @@ def map (g : (i : ι) → G i →+* G' i)
 
 lemma map_comp [IsDirected ι (· ≤ ·)]
     (g₁ : (i : ι) → G i →+* G' i) (g₂ : (i : ι) → G' i →+* G'' i)
-    (hg₁ : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i))
+    (hg₁ : ∀ i j h, (g₁ j).comp (f i j h) = (f' i j h).comp (g₁ i))
     (hg₂ : ∀ i j h, (g₂ j).comp (f' i j h) = (f'' i j h).comp (g₂ i)) :
     ((map g₂ hg₂).comp (map g₁ hg₁) :
       DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' fun _ _ h ↦ f'' _ _ h) =

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -204,10 +204,10 @@ def map (g : (i : ι) → G i →ₗ[R] G' i) (hg : ∀ i j h, g j ∘ₗ f i j 
       simp only [LinearMap.coe_comp, Function.comp_apply] at eq1 ⊢
       rw [eq1, of_f]
 
-@[simp] lemma map_apply_of (maps : (i : ι) → G i →ₗ[R] G' i)
-    (maps_compatible : ∀ i j h, maps j ∘ₗ f i j h = f' i j h ∘ₗ maps i)
-    {i : ι} (g : G i) :
-    map maps maps_compatible (of _ _ _ _ _ g) = of R ι G' f' i (maps i g) :=
+@[simp] lemma map_apply_of (g : (i : ι) → G i →ₗ[R] G' i)
+    (hg : ∀ i j h, g j ∘ₗ f i j h = f' i j h ∘ₗ g i)
+    {i : ι} (x : G i) :
+    map g hg (of _ _ _ _ _ x) = of R ι G' f' i (g i x) :=
   lift_of _ _ _
 
 @[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
@@ -216,14 +216,14 @@ def map (g : (i : ι) → G i →ₗ[R] G' i) (hg : ∀ i j h, g j ∘ₗ f i j 
     x.induction_on fun i g ↦ by simp
 
 lemma map_comp [IsDirected ι (· ≤ ·)]
-    (maps : (i : ι) → G i →ₗ[R] G' i) (maps' : (i : ι) → G' i →ₗ[R] G'' i)
-    (maps_compatible : ∀ i j h, maps j ∘ₗ f i j h = f' i j h ∘ₗ maps i)
-    (maps_compatible' : ∀ i j h, maps' j ∘ₗ f' i j h = f'' i j h ∘ₗ maps' i) :
-    (map maps' maps_compatible' ∘ₗ map maps maps_compatible :
+    (g₁ : (i : ι) → G i →ₗ[R] G' i) (g₂ : (i : ι) → G' i →ₗ[R] G'' i)
+    (hg₁ : ∀ i j h, g₁ j ∘ₗ f i j h = f' i j h ∘ₗ g₁ i)
+    (hg₂ : ∀ i j h, g₂ j ∘ₗ f' i j h = f'' i j h ∘ₗ g₂ i) :
+    (map g₂ hg₂ ∘ₗ map g₁ hg₁ :
       DirectLimit G f →ₗ[R] DirectLimit G'' f'') =
-    (map (fun i ↦ maps' i ∘ₗ maps i) fun i j h ↦ by
-        rw [LinearMap.comp_assoc, maps_compatible i, ← LinearMap.comp_assoc, maps_compatible' i,
-         LinearMap.comp_assoc] : DirectLimit G f →ₗ[R] DirectLimit G'' f'') :=
+    (map (fun i ↦ g₂ i ∘ₗ g₁ i) fun i j h ↦ by
+        rw [LinearMap.comp_assoc, hg₁ i, ← LinearMap.comp_assoc, hg₂ i, LinearMap.comp_assoc] :
+      DirectLimit G f →ₗ[R] DirectLimit G'' f'') :=
   FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
     x.induction_on fun i g ↦ by simp
 
@@ -472,20 +472,20 @@ Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` resp
 family of group homomorphisms `gᵢ : Gᵢ ⟶ G'ᵢ` such that `g ∘ f = f' ∘ g` induces a group
 homomorphism `lim G ⟶ lim G'`.
 -/
-def map (maps : (i : ι) → G i →+ G' i)
-    (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i)) :
+def map (g : (i : ι) → G i →+ G' i)
+    (hg : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i)) :
     DirectLimit G f →+ DirectLimit G' f' :=
-  lift _ _ _ (fun i ↦ (of _ _ _).comp (maps i)) fun i j h g ↦
+  lift _ _ _ (fun i ↦ (of _ _ _).comp (g i)) fun i j h g ↦
     (isEmpty_or_nonempty ι).elim
     (fun _ ↦ Subsingleton.elim _ _) fun _ ↦ by
-      have eq1 := FunLike.congr_fun (maps_compatible i j h) g
+      have eq1 := FunLike.congr_fun (hg i j h) g
       simp only [AddMonoidHom.coe_comp, Function.comp_apply] at eq1 ⊢
       rw [eq1, of_f]
 
-@[simp] lemma map_apply_of (maps : (i : ι) → G i →+ G' i)
-    (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i))
-    {i : ι} (g : G i) :
-    map maps maps_compatible (of _ _ _ g) = of G' f' i (maps i g) :=
+@[simp] lemma map_apply_of (g : (i : ι) → G i →+ G' i)
+    (hg : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i))
+    {i : ι} (x : G i) :
+    map g hg (of _ _ _ x) = of G' f' i (g i x) :=
   lift_of _ _ _ _ _
 
 lemma map_id [IsDirected ι (· ≤ ·)] :
@@ -494,14 +494,14 @@ lemma map_id [IsDirected ι (· ≤ ·)] :
     x.induction_on fun i g ↦ by simp
 
 lemma map_comp [IsDirected ι (· ≤ ·)]
-    (maps : (i : ι) → G i →+ G' i) (maps' : (i : ι) → G' i →+ G'' i)
-    (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i))
-    (maps_compatible' : ∀ i j h, (maps' j).comp (f' i j h) = (f'' i j h).comp (maps' i)) :
-    ((map maps' maps_compatible').comp (map maps maps_compatible) :
+    (g₁ : (i : ι) → G i →+ G' i) (g₂ : (i : ι) → G' i →+ G'' i)
+    (hg₁ : ∀ i j h, (g₁ j).comp (f i j h) = (f' i j h).comp (g₁ i))
+    (hg₂ : ∀ i j h, (g₂ j).comp (f' i j h) = (f'' i j h).comp (g₂ i)) :
+    ((map g₂ hg₂).comp (map g₁ hg₁) :
       DirectLimit G f →+ DirectLimit G'' f'') =
-    (map (fun i ↦ (maps' i).comp (maps i)) fun i j h ↦ by
-      rw [AddMonoidHom.comp_assoc, maps_compatible i, ← AddMonoidHom.comp_assoc,
-        maps_compatible' i, AddMonoidHom.comp_assoc] :
+    (map (fun i ↦ (g₂ i).comp (g₁ i)) fun i j h ↦ by
+      rw [AddMonoidHom.comp_assoc, hg₁ i, ← AddMonoidHom.comp_assoc, hg₂ i,
+        AddMonoidHom.comp_assoc] :
       DirectLimit G f →+ DirectLimit G'' f'') :=
   FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
     x.induction_on fun i g ↦ by simp
@@ -903,18 +903,18 @@ Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` resp
 family of ring homomorphisms `gᵢ : Gᵢ ⟶ G'ᵢ` such that `g ∘ f = f' ∘ g` induces a ring
 homomorphism `lim G ⟶ lim G'`.
 -/
-def map (maps : (i : ι) → G i →+* G' i)
-    (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i)) :
+def map (g : (i : ι) → G i →+* G' i)
+    (hg : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i)) :
     DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G' fun _ _ h ↦ f' _ _ h :=
-  lift _ _ _ (fun i ↦ (of _ _ _).comp (maps i)) fun i j h g ↦ by
-      have eq1 := FunLike.congr_fun (maps_compatible i j h) g
+  lift _ _ _ (fun i ↦ (of _ _ _).comp (g i)) fun i j h g ↦ by
+      have eq1 := FunLike.congr_fun (hg i j h) g
       simp only [RingHom.coe_comp, Function.comp_apply] at eq1 ⊢
       rw [eq1, of_f]
 
-@[simp] lemma map_apply_of (maps : (i : ι) → G i →+* G' i)
-    (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i))
-    {i : ι} (g : G i) :
-    map maps maps_compatible (of _ _ _ g) = of G' (fun _ _ h ↦ f' _ _ h) i (maps i g) :=
+@[simp] lemma map_apply_of (g : (i : ι) → G i →+* G' i)
+    (hg : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i))
+    {i : ι} (x : G i) :
+    map g hg (of _ _ _ g) = of G' (fun _ _ h ↦ f' _ _ h) i (g i g) :=
   lift_of _ _ _ _ _
 
 lemma map_id [IsDirected ι (· ≤ ·)] :
@@ -923,14 +923,13 @@ lemma map_id [IsDirected ι (· ≤ ·)] :
   FunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp
 
 lemma map_comp [IsDirected ι (· ≤ ·)]
-    (maps : (i : ι) → G i →+* G' i) (maps' : (i : ι) → G' i →+* G'' i)
-    (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i))
-    (maps_compatible' : ∀ i j h, (maps' j).comp (f' i j h) = (f'' i j h).comp (maps' i)) :
-    ((map maps' maps_compatible').comp (map maps maps_compatible) :
+    (g₁ : (i : ι) → G i →+* G' i) (g₂ : (i : ι) → G' i →+* G'' i)
+    (hg₁ : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i))
+    (hg₂ : ∀ i j h, (g₂ j).comp (f' i j h) = (f'' i j h).comp (g₂ i)) :
+    ((map g₂ hg₂).comp (map g₁ hg₁) :
       DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' fun _ _ h ↦ f'' _ _ h) =
-    (map (fun i ↦ (maps' i).comp (maps i)) fun i j h ↦ by
-      rw [RingHom.comp_assoc, maps_compatible i, ← RingHom.comp_assoc,
-        maps_compatible' i, RingHom.comp_assoc] :
+    (map (fun i ↦ (g₂ i).comp (g₁ i)) fun i j h ↦ by
+      rw [RingHom.comp_assoc, hg₁ i, ← RingHom.comp_assoc, hg₂ i, RingHom.comp_assoc] :
       DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' fun _ _ h ↦ f'' _ _ h) :=
   FunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp
 

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -536,7 +536,6 @@ lemma congr_apply_of [IsDirected ι (· ≤ ·)]
     (of _ _ i (equivs i g) : DirectLimit G' f') :=
   map_apply_of _ equivs_compatible _
 
-open LinearEquiv LinearMap in
 lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
     (equivs : (i : ι) → G i ≃+ G' i)
     (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
@@ -908,7 +907,7 @@ homomorphism `lim G ⟶ lim G'`.
 -/
 def map (maps : (i : ι) → G i →+* G' i)
     (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i)) :
-    DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G' (fun _ _ h ↦ f' _ _ h) :=
+    DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G' fun _ _ h ↦ f' _ _ h :=
   lift _ _ _ (fun i ↦ (of _ _ _).comp (maps i)) fun i j h g ↦ by
       have eq1 := FunLike.congr_fun (maps_compatible i j h) g
       simp only [RingHom.coe_comp, Function.comp_apply] at eq1 ⊢
@@ -922,7 +921,7 @@ def map (maps : (i : ι) → G i →+* G' i)
 
 lemma map_id [IsDirected ι (· ≤ ·)] :
     map (fun i ↦ RingHom.id _) (fun _ _ _ ↦ rfl) =
-    RingHom.id (DirectLimit G (fun _ _ h ↦ f _ _ h)) :=
+    RingHom.id (DirectLimit G fun _ _ h ↦ f _ _ h) :=
   FunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp
 
 lemma map_comp [IsDirected ι (· ≤ ·)]
@@ -930,11 +929,11 @@ lemma map_comp [IsDirected ι (· ≤ ·)]
     (maps_compatible : ∀ i j h, (maps j).comp (f i j h) = (f' i j h).comp (maps i))
     (maps_compatible' : ∀ i j h, (maps' j).comp (f' i j h) = (f'' i j h).comp (maps' i)) :
     ((map maps' maps_compatible').comp (map maps maps_compatible) :
-      DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' (fun _ _ h ↦ f'' _ _ h) ) =
+      DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' fun _ _ h ↦ f'' _ _ h) =
     (map (fun i ↦ (maps' i).comp (maps i)) fun i j h ↦ by
       rw [RingHom.comp_assoc, maps_compatible i, ← RingHom.comp_assoc,
         maps_compatible' i, RingHom.comp_assoc] :
-      DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' (fun _ _ h ↦ f'' _ _ h)) :=
+      DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' fun _ _ h ↦ f'' _ _ h) :=
   FunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp
 
 /--
@@ -946,7 +945,7 @@ def congr [IsDirected ι (· ≤ ·)]
     (equivs : (i : ι) → G i ≃+* G' i)
     (equivs_compatible : ∀ i j h, (equivs j).toRingHom.comp (f i j h) =
       (f' i j h).comp (equivs i)) :
-    DirectLimit G (fun _ _ h ↦ f _ _ h) ≃+* DirectLimit G' (fun _ _ h ↦ f' _ _ h) :=
+    DirectLimit G (fun _ _ h ↦ f _ _ h) ≃+* DirectLimit G' fun _ _ h ↦ f' _ _ h :=
   RingEquiv.ofHomInv
     (map (equivs ·) equivs_compatible)
     (map (fun i ↦ (equivs i).symm) fun i j h ↦ FunLike.ext _ _ fun x ↦ by
@@ -958,23 +957,22 @@ def congr [IsDirected ι (· ≤ ·)]
     (FunLike.ext _ _ fun x ↦ x.induction_on <| by simp)
 
 lemma congr_apply_of [IsDirected ι (· ≤ ·)]
-    (equivs : (i : ι) → G i ≃+ G' i)
-    (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
+    (equivs : (i : ι) → G i ≃+* G' i)
+    (equivs_compatible : ∀ i j h, (equivs j).toRingHom.comp (f i j h) =
       (f' i j h).comp (equivs i))
     {i : ι} (g : G i) :
     congr equivs equivs_compatible (of _ _ i g) =
-    (of _ _ i (equivs i g) : DirectLimit G' f') :=
+    (of _ _ i (equivs i g) : DirectLimit G' fun _ _ h ↦ f' _ _ h) :=
   map_apply_of _ equivs_compatible _
 
-open LinearEquiv LinearMap in
 lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
-    (equivs : (i : ι) → G i ≃+ G' i)
-    (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
+    (equivs : (i : ι) → G i ≃+* G' i)
+    (equivs_compatible : ∀ i j h, (equivs j).toRingHom.comp (f i j h) =
       (f' i j h).comp (equivs i))
     {i : ι} (g : G' i) :
     (congr equivs equivs_compatible).symm (of _  _ i g) =
-    (of _ _ i ((equivs i).symm g) : DirectLimit G f) := by
-  simp only [congr, AddMonoidHom.toAddEquiv_symm_apply, map_apply_of, AddMonoidHom.coe_coe]
+    (of _ _ i ((equivs i).symm g) : DirectLimit G fun _ _ h ↦ f _ _ h) := by
+  simp only [congr, RingEquiv.ofHomInv_symm_apply, map_apply_of, RingHom.coe_coe]
 
 end interaction_with_other_directLimits
 

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -236,30 +236,28 @@ family of equivalences `eᵢ : Gᵢ ≅ G'ᵢ` such that `e ∘ f = f' ∘ e` in
 def congr [IsDirected ι (· ≤ ·)]
     (e : (i : ι) → G i ≃ₗ[R] G' i) (he : ∀ i j h, e j ∘ₗ f i j h = f' i j h ∘ₗ e i) :
     DirectLimit G f ≃ₗ[R] DirectLimit G' f' :=
-  LinearEquiv.ofLinear (map (equivs ·) equivs_compatible)
-    (map (fun i ↦ (equivs i).symm) fun i j h ↦ by
-      rw [toLinearMap_symm_comp_eq, ← comp_assoc, equivs_compatible i, comp_assoc, comp_coe,
-        symm_trans_self, refl_toLinearMap, comp_id])
+  LinearEquiv.ofLinear (map (e ·) he)
+    (map (fun i ↦ (e i).symm) fun i j h ↦ by
+      rw [toLinearMap_symm_comp_eq, ← comp_assoc, he i, comp_assoc, comp_coe, symm_trans_self,
+        refl_toLinearMap, comp_id])
     (by simp [map_comp]) (by simp [map_comp])
 
 lemma congr_apply_of [IsDirected ι (· ≤ ·)]
-    (equivs : (i : ι) → G i ≃ₗ[R] G' i)
-    (equivs_compatible : ∀ i j h, equivs j ∘ₗ f i j h = f' i j h ∘ₗ equivs i)
+    (e : (i : ι) → G i ≃ₗ[R] G' i) (he : ∀ i j h, e j ∘ₗ f i j h = f' i j h ∘ₗ e i)
     {i : ι} (g : G i) :
-    congr equivs equivs_compatible (of _ _ _ _ i g) =
-    (of _ _ _ _ i (equivs i g) : DirectLimit G' f') :=
-  map_apply_of _ equivs_compatible _
+    congr e he (of _ _ _ _ i g) =
+    (of _ _ _ _ i (e i g) : DirectLimit G' f') :=
+  map_apply_of _ he _
 
 open LinearEquiv LinearMap in
 lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
-    (equivs : (i : ι) → G i ≃ₗ[R] G' i)
-    (equivs_compatible : ∀ i j h, equivs j ∘ₗ f i j h = f' i j h ∘ₗ equivs i)
+    (e : (i : ι) → G i ≃ₗ[R] G' i) (he : ∀ i j h, e j ∘ₗ f i j h = f' i j h ∘ₗ e i)
     {i : ι} (g : G' i) :
-    (congr equivs equivs_compatible).symm (of _ _ _ _ i g) =
-    (of _ _ _ _ i ((equivs i).symm g) : DirectLimit G f) :=
+    (congr e he).symm (of _ _ _ _ i g) =
+    (of _ _ _ _ i ((e i).symm g) : DirectLimit G f) :=
   map_apply_of _ (fun i j h ↦ by
-    rw [toLinearMap_symm_comp_eq, ← comp_assoc, equivs_compatible i, comp_assoc, comp_coe,
-      symm_trans_self, refl_toLinearMap, comp_id]) _
+    rw [toLinearMap_symm_comp_eq, ← comp_assoc, he i, comp_assoc, comp_coe, symm_trans_self,
+      refl_toLinearMap, comp_id]) _
 
 end interaction_with_other_directLimits
 
@@ -507,17 +505,16 @@ lemma map_comp [IsDirected ι (· ≤ ·)]
 
 /--
 Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
-family of equivalences `gᵢ : Gᵢ ≅ G'ᵢ` such that `g ∘ f = f' ∘ g` induces an equivalence
+family of equivalences `eᵢ : Gᵢ ≅ G'ᵢ` such that `e ∘ f = f' ∘ e` induces an equivalence
 `lim G ⟶ lim G'`.
 -/
 def congr [IsDirected ι (· ≤ ·)]
-    (equivs : (i : ι) → G i ≃+ G' i)
-    (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
-      (f' i j h).comp (equivs i)) :
+    (e : (i : ι) → G i ≃+ G' i)
+    (he : ∀ i j h, (e j).toAddMonoidHom.comp (f i j h) = (f' i j h).comp (e i)) :
     DirectLimit G f ≃+ DirectLimit G' f' :=
-  AddMonoidHom.toAddEquiv (map (equivs ·) equivs_compatible)
-    (map (fun i ↦ (equivs i).symm) fun i j h ↦ FunLike.ext _ _ fun x ↦ by
-      have eq1 := FunLike.congr_fun (equivs_compatible i j h) ((equivs i).symm x)
+  AddMonoidHom.toAddEquiv (map (e ·) he)
+    (map (fun i ↦ (e i).symm) fun i j h ↦ FunLike.ext _ _ fun x ↦ by
+      have eq1 := FunLike.congr_fun (he i j h) ((e i).symm x)
       simp only [AddMonoidHom.coe_comp, AddEquiv.coe_toAddMonoidHom, Function.comp_apply,
         AddMonoidHom.coe_coe, AddEquiv.apply_symm_apply] at eq1 ⊢
       simp [← eq1, of_f])
@@ -525,21 +522,19 @@ def congr [IsDirected ι (· ≤ ·)]
     (by rw [map_comp]; convert map_id <;> aesop)
 
 lemma congr_apply_of [IsDirected ι (· ≤ ·)]
-    (equivs : (i : ι) → G i ≃+ G' i)
-    (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
-      (f' i j h).comp (equivs i))
+    (e : (i : ι) → G i ≃+ G' i)
+    (he : ∀ i j h, (e j).toAddMonoidHom.comp (f i j h) = (f' i j h).comp (e i))
     {i : ι} (g : G i) :
-    congr equivs equivs_compatible (of _ _ i g) =
-    (of _ _ i (equivs i g) : DirectLimit G' f') :=
-  map_apply_of _ equivs_compatible _
+    congr e he (of _ _ i g) =
+    (of _ _ i (e i g) : DirectLimit G' f') :=
+  map_apply_of _ he _
 
 lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
-    (equivs : (i : ι) → G i ≃+ G' i)
-    (equivs_compatible : ∀ i j h, (equivs j).toAddMonoidHom.comp (f i j h) =
-      (f' i j h).comp (equivs i))
+    (e : (i : ι) → G i ≃+ G' i)
+    (he : ∀ i j h, (e j).toAddMonoidHom.comp (f i j h) = (f' i j h).comp (e i))
     {i : ι} (g : G' i) :
-    (congr equivs equivs_compatible).symm (of _  _ i g) =
-    (of _ _ i ((equivs i).symm g) : DirectLimit G f) := by
+    (congr e he).symm (of _  _ i g) =
+    (of _ _ i ((e i).symm g) : DirectLimit G f) := by
   simp only [congr, AddMonoidHom.toAddEquiv_symm_apply, map_apply_of, AddMonoidHom.coe_coe]
 
 end interaction_with_other_directLimits
@@ -934,18 +929,17 @@ lemma map_comp [IsDirected ι (· ≤ ·)]
 
 /--
 Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
-family of equivalences `gᵢ : Gᵢ ≅ G'ᵢ` such that `g ∘ f = f' ∘ g` induces an equivalence
+family of equivalences `eᵢ : Gᵢ ≅ G'ᵢ` such that `e ∘ f = f' ∘ e` induces an equivalence
 `lim G ⟶ lim G'`.
 -/
 def congr [IsDirected ι (· ≤ ·)]
-    (equivs : (i : ι) → G i ≃+* G' i)
-    (equivs_compatible : ∀ i j h, (equivs j).toRingHom.comp (f i j h) =
-      (f' i j h).comp (equivs i)) :
+    (e : (i : ι) → G i ≃+* G' i)
+    (he : ∀ i j h, (e j).toRingHom.comp (f i j h) = (f' i j h).comp (e i)) :
     DirectLimit G (fun _ _ h ↦ f _ _ h) ≃+* DirectLimit G' fun _ _ h ↦ f' _ _ h :=
   RingEquiv.ofHomInv
-    (map (equivs ·) equivs_compatible)
-    (map (fun i ↦ (equivs i).symm) fun i j h ↦ FunLike.ext _ _ fun x ↦ by
-      have eq1 := FunLike.congr_fun (equivs_compatible i j h) ((equivs i).symm x)
+    (map (e ·) he)
+    (map (fun i ↦ (e i).symm) fun i j h ↦ FunLike.ext _ _ fun x ↦ by
+      have eq1 := FunLike.congr_fun (he i j h) ((e i).symm x)
       simp only [RingEquiv.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply,
         RingEquiv.apply_symm_apply] at eq1 ⊢
       simp [← eq1, of_f])
@@ -953,21 +947,19 @@ def congr [IsDirected ι (· ≤ ·)]
     (FunLike.ext _ _ fun x ↦ x.induction_on <| by simp)
 
 lemma congr_apply_of [IsDirected ι (· ≤ ·)]
-    (equivs : (i : ι) → G i ≃+* G' i)
-    (equivs_compatible : ∀ i j h, (equivs j).toRingHom.comp (f i j h) =
-      (f' i j h).comp (equivs i))
+    (e : (i : ι) → G i ≃+* G' i)
+    (he : ∀ i j h, (e j).toRingHom.comp (f i j h) = (f' i j h).comp (e i))
     {i : ι} (g : G i) :
-    congr equivs equivs_compatible (of _ _ i g) =
-    (of _ _ i (equivs i g) : DirectLimit G' fun _ _ h ↦ f' _ _ h) :=
+    congr e he (of _ _ i g) =
+    (of _ _ i (e i g) : DirectLimit G' fun _ _ h ↦ f' _ _ h) :=
   map_apply_of _ equivs_compatible _
 
 lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
-    (equivs : (i : ι) → G i ≃+* G' i)
-    (equivs_compatible : ∀ i j h, (equivs j).toRingHom.comp (f i j h) =
-      (f' i j h).comp (equivs i))
+    (e : (i : ι) → G i ≃+* G' i)
+    (he : ∀ i j h, (equivs j).toRingHom.comp (f i j h) = (f' i j h).comp (equivs i))
     {i : ι} (g : G' i) :
-    (congr equivs equivs_compatible).symm (of _  _ i g) =
-    (of _ _ i ((equivs i).symm g) : DirectLimit G fun _ _ h ↦ f _ _ h) := by
+    (congr e he).symm (of _  _ i g) =
+    (of _ _ i ((e i).symm g) : DirectLimit G fun _ _ h ↦ f _ _ h) := by
   simp only [congr, RingEquiv.ofHomInv_symm_apply, map_apply_of, RingHom.coe_coe]
 
 end interaction_with_other_directLimits

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -183,7 +183,7 @@ lemma lift_injective [IsDirected ι (· ≤ ·)]
   rw [lift_of] at hz
   rw [injective _ g hz, _root_.map_zero]
 
-section interaction_with_other_directLimits
+section functorial
 
 variable {G' : ι → Type v'} [∀ i, AddCommGroup (G' i)] [∀ i, Module R (G' i)]
 variable {f' : ∀ i j, i ≤ j → G' i →ₗ[R] G' j}
@@ -259,7 +259,7 @@ lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
     rw [toLinearMap_symm_comp_eq, ← comp_assoc, he i, comp_assoc, comp_coe, symm_trans_self,
       refl_toLinearMap, comp_id]) _
 
-end interaction_with_other_directLimits
+end functorial
 
 section Totalize
 
@@ -456,7 +456,7 @@ lemma lift_injective [IsDirected ι (· ≤ ·)]
   rw [lift_of] at hz
   rw [injective _ g hz, _root_.map_zero]
 
-section interaction_with_other_directLimits
+section functorial
 
 variable {G' : ι → Type v'} [∀ i, AddCommGroup (G' i)]
 variable {f' : ∀ i j, i ≤ j → G' i →+ G' j}
@@ -537,7 +537,7 @@ lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
     (of _ _ i ((e i).symm g) : DirectLimit G f) := by
   simp only [congr, AddMonoidHom.toAddEquiv_symm_apply, map_apply_of, AddMonoidHom.coe_coe]
 
-end interaction_with_other_directLimits
+end functorial
 
 end DirectLimit
 
@@ -882,7 +882,7 @@ lemma lift_injective [Nonempty ι] [IsDirected ι (· ≤ ·)]
   rw [lift_of] at hz
   rw [injective _ g hz, _root_.map_zero]
 
-section interaction_with_other_directLimits
+section functorial
 
 variable {f : ∀ i j, i ≤ j → G i →+* G j}
 variable {G' : ι → Type v'} [∀ i, CommRing (G' i)]
@@ -962,7 +962,7 @@ lemma congr_symm_apply_of [IsDirected ι (· ≤ ·)]
     (of _ _ i ((e i).symm g) : DirectLimit G fun _ _ h ↦ f _ _ h) := by
   simp only [congr, RingEquiv.ofHomInv_symm_apply, map_apply_of, RingHom.coe_coe]
 
-end interaction_with_other_directLimits
+end functorial
 
 end DirectLimit
 


### PR DESCRIPTION
Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
family of linear maps `gᵢ : Gᵢ ⟶ G'ᵢ` such that `g ∘ f = f' ∘ g` induces a linear map
`lim G ⟶ lim G'`. When `gᵢ`'s are equivalence, so is the induced. Similarly for direct limits of groups and rings

This PR is splitted from #8473

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
