### PR TITLE
chore: bump Std to include leanprover/std4#366 (alternative to #8700)

### DIFF
--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -47,14 +47,7 @@ theorem of_decide_iff {p : Prop} [Decidable p] : decide p ↔ p :=
   coe_decide p
 #align bool.of_to_bool_iff Bool.of_decide_iff
 
-@[simp]
-theorem true_eq_decide_iff {p : Prop} [Decidable p] : true = decide p ↔ p :=
-  eq_comm.trans of_decide_iff
 #align bool.tt_eq_to_bool_iff Bool.true_eq_decide_iff
-
-@[simp]
-theorem false_eq_decide_iff {p : Prop} [Decidable p] : false = decide p ↔ ¬p :=
-  eq_comm.trans (decide_false_iff _)
 #align bool.ff_eq_to_bool_iff Bool.false_eq_decide_iff
 
 theorem decide_not (p : Prop) [Decidable p] : (decide ¬p) = !(decide p) := by
@@ -308,21 +301,12 @@ theorem right_le_or : ∀ x y : Bool, y ≤ (x || y) := by decide
 theorem or_le : ∀ {x y z}, x ≤ z → y ≤ z → (x || y) ≤ z := by decide
 #align bool.bor_le Bool.or_le
 
-/-- convert a `Bool` to a `ℕ`, `false -> 0`, `true -> 1` -/
-def toNat (b : Bool) : Nat :=
-  cond b 1 0
 #align bool.to_nat Bool.toNat
-
-lemma toNat_le_one (b : Bool) : b.toNat ≤ 1 := by
-  cases b <;> decide
 
 /-- convert a `ℕ` to a `Bool`, `0 -> false`, everything else -> `true` -/
 def ofNat (n : Nat) : Bool :=
   decide (n ≠ 0)
 #align bool.of_nat Bool.ofNat
-
-@[simp] lemma toNat_true  : toNat true = 1  := rfl
-@[simp] lemma toNat_false : toNat false = 0 := rfl
 
 @[simp] lemma toNat_beq_zero (b : Bool) : (b.toNat == 0) = !b := by cases b <;> rfl
 @[simp] lemma toNat_bne_zero (b : Bool) : (b.toNat != 0) =  b := by simp [bne]

--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -195,20 +195,20 @@ end deprecated
 
 @[simp]
 theorem testBit_zero (b) : ∀ n, testBit (bit b n) 0 = b
-  | (n : ℕ) => by rw [bit_coe_nat]; apply Nat.testBit_zero
+  | (n : ℕ) => by rw [bit_coe_nat]; apply Nat.testBit'_zero
   | -[n+1] => by
-    rw [bit_negSucc]; dsimp [testBit]; rw [Nat.testBit_zero]; clear testBit_zero;
+    rw [bit_negSucc]; dsimp [testBit]; rw [Nat.testBit'_zero]; clear testBit_zero;
         cases b <;>
       rfl
 #align int.test_bit_zero Int.testBit_zero
 
 @[simp]
 theorem testBit_succ (m b) : ∀ n, testBit (bit b n) (Nat.succ m) = testBit n m
-  | (n : ℕ) => by rw [bit_coe_nat]; apply Nat.testBit_succ
+  | (n : ℕ) => by rw [bit_coe_nat]; apply Nat.testBit'_succ
   | -[n+1] => by
     dsimp only [testBit]
     simp only [bit_negSucc]
-    cases b <;> simp only [Bool.not_false, Bool.not_true, Nat.testBit_succ]
+    cases b <;> simp only [Bool.not_false, Bool.not_true, Nat.testBit'_succ]
 #align int.test_bit_succ Int.testBit_succ
 
 -- Porting note: TODO
@@ -338,19 +338,19 @@ theorem testBit_bitwise (f : Bool → Bool → Bool) (m n k) :
 #align int.test_bit_bitwise Int.testBit_bitwise
 
 @[simp]
-theorem testBit_lor (m n k) : testBit (lor m n) k = (testBit m k || testBit n k) := by
+theorem testBit'_lor (m n k) : testBit (lor m n) k = (testBit m k || testBit n k) := by
   rw [← bitwise_or, testBit_bitwise]
-#align int.test_bit_lor Int.testBit_lor
+#align int.test_bit_lor Int.testBit'_lor
 
 @[simp]
-theorem testBit_land (m n k) : testBit (land m n) k = (testBit m k && testBit n k) := by
+theorem testBit'_land (m n k) : testBit (land m n) k = (testBit m k && testBit n k) := by
   rw [← bitwise_and, testBit_bitwise]
-#align int.test_bit_land Int.testBit_land
+#align int.test_bit_land Int.testBit'_land
 
 @[simp]
-theorem testBit_ldiff (m n k) : testBit (ldiff m n) k = (testBit m k && not (testBit n k)) := by
+theorem testBit'_ldiff (m n k) : testBit (ldiff m n) k = (testBit m k && not (testBit n k)) := by
   rw [← bitwise_diff, testBit_bitwise]
-#align int.test_bit_ldiff Int.testBit_ldiff
+#align int.test_bit_ldiff Int.testBit'_ldiff
 
 @[simp]
 theorem testBit_lxor (m n k) : testBit (Int.xor m n) k = xor (testBit m k) (testBit n k) := by
@@ -407,15 +407,15 @@ attribute [local simp] Int.zero_div
 
 theorem shiftLeft_add : ∀ (m : ℤ) (n : ℕ) (k : ℤ), m <<< (n + k) = (m <<< (n : ℤ)) <<< k
   | (m : ℕ), n, (k : ℕ) =>
-    congr_arg ofNat (by simp [Nat.pow_add, mul_assoc])
+    congr_arg ofNat (by simp [Nat.shiftLeft_eq, Nat.pow_add, mul_assoc])
   | -[m+1], n, (k : ℕ) => congr_arg negSucc (Nat.shiftLeft'_add _ _ _ _)
   | (m : ℕ), n, -[k+1] =>
     subNatNat_elim n k.succ (fun n k i => (↑m) <<< i = (Nat.shiftLeft' false m n) >>> k)
       (fun (i n : ℕ) =>
-        by dsimp; simp [- Nat.shiftLeft_eq, ← Nat.shiftLeft_sub _ , add_tsub_cancel_left])
+        by dsimp; simp [← Nat.shiftLeft_sub _ , add_tsub_cancel_left])
       fun i n => by
         dsimp
-        simp [- Nat.shiftLeft_eq, Nat.shiftLeft_zero, Nat.shiftRight_add, ← Nat.shiftLeft_sub]
+        simp [Nat.shiftLeft_zero, Nat.shiftRight_add, ← Nat.shiftLeft_sub]
         rfl
   | -[m+1], n, -[k+1] =>
     subNatNat_elim n k.succ
@@ -433,7 +433,7 @@ theorem shiftLeft_sub (m : ℤ) (n : ℕ) (k : ℤ) : m <<< (n - k) = (m <<< (n 
 #align int.shiftl_sub Int.shiftLeft_sub
 
 theorem shiftLeft_eq_mul_pow : ∀ (m : ℤ) (n : ℕ), m <<< (n : ℤ) = m * (2 ^ n : ℕ)
-  | (m : ℕ), _ => congr_arg ((↑) : ℕ → ℤ) (by simp)
+  | (m : ℕ), _ => congr_arg ((↑) : ℕ → ℤ) (by simp [Nat.shiftLeft_eq])
   | -[_+1], _ => @congr_arg ℕ ℤ _ _ (fun i => -i) (Nat.shiftLeft'_tt_eq_mul_pow _ _)
 #align int.shiftl_eq_mul_pow Int.shiftLeft_eq_mul_pow
 
@@ -445,7 +445,7 @@ theorem shiftRight_eq_div_pow : ∀ (m : ℤ) (n : ℕ), m >>> (n : ℤ) = m / (
 #align int.shiftr_eq_div_pow Int.shiftRight_eq_div_pow
 
 theorem one_shiftLeft (n : ℕ) : 1 <<< (n : ℤ) = (2 ^ n : ℕ) :=
-  congr_arg ((↑) : ℕ → ℤ) (by simp)
+  congr_arg ((↑) : ℕ → ℤ) (by simp [Nat.shiftLeft_eq])
 #align int.one_shiftl Int.one_shiftLeft
 
 @[simp]

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -838,11 +838,10 @@ theorem lt_mul_div_succ (m : ℕ) {n : ℕ} (n0 : 0 < n) : m < n * (m / n + 1) :
   exact lt_succ_self _
 #align nat.lt_mul_div_succ Nat.lt_mul_div_succ
 
-theorem mul_add_mod (a b c : ℕ) : (a * b + c) % b = c % b := by simp [Nat.add_mod]
 #align nat.mul_add_mod Nat.mul_add_mod
 
 theorem mul_add_mod_of_lt {a b c : ℕ} (h : c < b) : (a * b + c) % b = c := by
-  rw [Nat.mul_add_mod, Nat.mod_eq_of_lt h]
+  rw [mul_comm, Nat.mul_add_mod, Nat.mod_eq_of_lt h]
 #align nat.mul_add_mod_of_lt Nat.mul_add_mod_of_lt
 
 theorem pred_eq_self_iff {n : ℕ} : n.pred = n ↔ n = 0 := by

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -372,26 +372,11 @@ theorem zero_xor (n : ℕ) : 0 ^^^ n = n := by simp [HXor.hXor, Xor.xor, xor]
 theorem xor_zero (n : ℕ) : n ^^^ 0 = n := by simp [HXor.hXor, Xor.xor, xor]
 #align nat.lxor_zero Nat.xor_zero
 
-@[simp]
-theorem zero_land (n : ℕ) : 0 &&& n = 0 := by
-  simp only [HAnd.hAnd, AndOp.and, land, bitwise_zero_left, ite_false, Bool.and_true];
-#align nat.zero_land Nat.zero_land
+#align nat.zero_land Nat.zero_and
+#align nat.land_zero Nat.and_zero
 
-@[simp]
-theorem land_zero (n : ℕ) : n &&& 0 = 0 := by
-  simp only [HAnd.hAnd, AndOp.and, land, bitwise_zero_right, ite_false, Bool.and_false]
-#align nat.land_zero Nat.land_zero
-
-@[simp]
-theorem zero_lor (n : ℕ) : 0 ||| n = n := by
-  simp only [HOr.hOr, OrOp.or, lor, bitwise_zero_left, ite_true, Bool.or_true]
-#align nat.zero_lor Nat.zero_lor
-
-@[simp]
-theorem lor_zero (n : ℕ) : n ||| 0 = n := by
-  simp only [HOr.hOr, OrOp.or, lor, bitwise_zero_right, ite_true, Bool.or_false]
-#align nat.lor_zero Nat.lor_zero
-
+#align nat.zero_lor Nat.zero_or
+#align nat.lor_zero Nat.or_zero
 
 /-- Proving associativity of bitwise operations in general essentially boils down to a huge case
     distinction, so it is shorter to use this tactic instead of proving it in the general case. -/

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -17,10 +17,10 @@ bitwise properties. In the second half of this file, we show properties of the b
 `lor`, `land` and `xor`, which are defined in core.
 
 ## Main results
-* `eq_of_testBit_eq`: two natural numbers are equal if they have equal bits at every position.
+* `eq_of_testBit'_eq`: two natural numbers are equal if they have equal bits at every position.
 * `exists_most_significant_bit`: if `n ≠ 0`, then there is some position `i` that contains the most
   significant `1`-bit of `n`.
-* `lt_of_testBit`: if `n` and `m` are numbers and `i` is a position such that the `i`-th bit of
+* `lt_of_testBit'`: if `n` and `m` are numbers and `i` is a position such that the `i`-th bit of
   of `n` is zero, the `i`-th bit of `m` is one, and all more significant bits are equal, then
   `n < m`.
 
@@ -127,35 +127,35 @@ theorem xor_bit : ∀ a m b n, bit a m ^^^ bit b n = bit (bne a b) (m ^^^ n) :=
 #align nat.lxor_bit Nat.xor_bit
 
 @[simp]
-theorem testBit_bitwise {f : Bool → Bool → Bool} (h : f false false = false) (m n k) :
-    testBit (bitwise f m n) k = f (testBit m k) (testBit n k) := by
+theorem testBit'_bitwise {f : Bool → Bool → Bool} (h : f false false = false) (m n k) :
+    testBit' (bitwise f m n) k = f (testBit' m k) (testBit' n k) := by
   induction' k with k ih generalizing m n
   <;> cases' m using bitCasesOn with a m
   <;> cases' n using bitCasesOn with b n
   <;> rw [bitwise_bit h]
-  · simp [testBit_zero]
-  · simp [testBit_succ, ih]
-#align nat.test_bit_bitwise Nat.testBit_bitwise
+  · simp [testBit'_zero]
+  · simp [testBit'_succ, ih]
+#align nat.test_bit_bitwise Nat.testBit'_bitwise
 
 @[simp]
-theorem testBit_lor : ∀ m n k, testBit (m ||| n) k = (testBit m k || testBit n k) :=
-  testBit_bitwise rfl
-#align nat.test_bit_lor Nat.testBit_lor
+theorem testBit'_lor : ∀ m n k, testBit' (m ||| n) k = (testBit' m k || testBit' n k) :=
+  testBit'_bitwise rfl
+#align nat.test_bit_lor Nat.testBit'_lor
 
 @[simp]
-theorem testBit_land : ∀ m n k, testBit (m &&& n) k = (testBit m k && testBit n k) :=
-  testBit_bitwise rfl
-#align nat.test_bit_land Nat.testBit_land
+theorem testBit'_land : ∀ m n k, testBit' (m &&& n) k = (testBit' m k && testBit' n k) :=
+  testBit'_bitwise rfl
+#align nat.test_bit_land Nat.testBit'_land
 
 @[simp]
-theorem testBit_ldiff : ∀ m n k, testBit (ldiff m n) k = (testBit m k && not (testBit n k)) :=
-  testBit_bitwise rfl
-#align nat.test_bit_ldiff Nat.testBit_ldiff
+theorem testBit'_ldiff : ∀ m n k, testBit' (ldiff m n) k = (testBit' m k && not (testBit' n k)) :=
+  testBit'_bitwise rfl
+#align nat.test_bit_ldiff Nat.testBit'_ldiff
 
 @[simp]
-theorem testBit_xor : ∀ m n k, testBit (m ^^^ n) k = bne (testBit m k) (testBit n k) :=
-  testBit_bitwise rfl
-#align nat.test_bit_lxor Nat.testBit_xor
+theorem testBit'_xor : ∀ m n k, testBit' (m ^^^ n) k = bne (testBit' m k) (testBit' n k) :=
+  testBit'_bitwise rfl
+#align nat.test_bit_lxor Nat.testBit'_xor
 
 end
 
@@ -207,45 +207,45 @@ lemma bitwise_eq_binaryRec (f : Bool → Bool → Bool) :
       simp_rw [binaryRec_of_ne_zero _ _ hyb, bitwise_of_ne_zero hxb hyb, bodd_bit, ←div2_val,
         div2_bit, eq_rec_constant, ih]
 
-theorem zero_of_testBit_eq_false {n : ℕ} (h : ∀ i, testBit n i = false) : n = 0 := by
+theorem zero_of_testBit'_eq_false {n : ℕ} (h : ∀ i, testBit' n i = false) : n = 0 := by
   induction' n using Nat.binaryRec with b n hn
   · rfl
   · have : b = false := by simpa using h 0
-    rw [this, bit_false, bit0_val, hn fun i => by rw [← h (i + 1), testBit_succ], mul_zero]
-#align nat.zero_of_test_bit_eq_ff Nat.zero_of_testBit_eq_false
+    rw [this, bit_false, bit0_val, hn fun i => by rw [← h (i + 1), testBit'_succ], mul_zero]
+#align nat.zero_of_test_bit_eq_ff Nat.zero_of_testBit'_eq_false
 
-theorem testBit_eq_false_of_lt {n i} (h : n < 2 ^ i) : n.testBit i = false := by
-  simp [testBit, shiftRight_eq_div_pow, Nat.div_eq_of_lt h]
+theorem testBit'_eq_false_of_lt {n i} (h : n < 2 ^ i) : n.testBit' i = false := by
+  simp [testBit', shiftRight_eq_div_pow, Nat.div_eq_of_lt h]
 
 @[simp]
-theorem zero_testBit (i : ℕ) : testBit 0 i = false := by
-  simp only [testBit, zero_shiftRight, bodd_zero]
+theorem zero_testBit' (i : ℕ) : testBit' 0 i = false := by
+  simp only [testBit', zero_shiftRight, bodd_zero]
 #align nat.zero_test_bit Nat.zero_testBit
 
 /-- The ith bit is the ith element of `n.bits`. -/
-theorem testBit_eq_inth (n i : ℕ) : n.testBit i = n.bits.getI i := by
+theorem testBit'_eq_inth (n i : ℕ) : n.testBit' i = n.bits.getI i := by
   induction' i with i ih generalizing n
-  · simp [testBit, bodd_eq_bits_head, List.getI_zero_eq_headI]
+  · simp [testBit', bodd_eq_bits_head, List.getI_zero_eq_headI]
   conv_lhs => rw [← bit_decomp n]
-  rw [testBit_succ, ih n.div2, div2_bits_eq_tail]
+  rw [testBit'_succ, ih n.div2, div2_bits_eq_tail]
   cases n.bits <;> simp
-#align nat.test_bit_eq_inth Nat.testBit_eq_inth
+#align nat.test_bit_eq_inth Nat.testBit'_eq_inth
 
 /-- Bitwise extensionality: Two numbers agree if they agree at every bit position. -/
-theorem eq_of_testBit_eq {n m : ℕ} (h : ∀ i, testBit n i = testBit m i) : n = m := by
+theorem eq_of_testBit'_eq {n m : ℕ} (h : ∀ i, testBit' n i = testBit' m i) : n = m := by
   induction' n using Nat.binaryRec with b n hn generalizing m
-  · simp only [zero_testBit] at h
-    exact (zero_of_testBit_eq_false fun i => (h i).symm).symm
+  · simp only [zero_testBit'] at h
+    exact (zero_of_testBit'_eq_false fun i => (h i).symm).symm
   induction' m using Nat.binaryRec with b' m
-  · simp only [zero_testBit] at h
-    exact zero_of_testBit_eq_false h
+  · simp only [zero_testBit'] at h
+    exact zero_of_testBit'_eq_false h
   suffices h' : n = m by
     rw [h', show b = b' by simpa using h 0]
-  exact hn fun i => by convert h (i + 1) using 1 <;> rw [testBit_succ]
-#align nat.eq_of_test_bit_eq Nat.eq_of_testBit_eq
+  exact hn fun i => by convert h (i + 1) using 1 <;> rw [testBit'_succ]
+#align nat.eq_of_test_bit_eq Nat.eq_of_testBit'_eq
 
 theorem exists_most_significant_bit {n : ℕ} (h : n ≠ 0) :
-    ∃ i, testBit n i = true ∧ ∀ j, i < j → testBit n j = false := by
+    ∃ i, testBit' n i = true ∧ ∀ j, i < j → testBit' n j = false := by
   induction' n using Nat.binaryRec with b n hn
   · exact False.elim (h rfl)
   by_cases h' : n = 0
@@ -253,35 +253,35 @@ theorem exists_most_significant_bit {n : ℕ} (h : n ≠ 0) :
     rw [show b = true by
         revert h
         cases b <;> simp]
-    refine' ⟨0, ⟨by rw [testBit_zero], fun j hj => _⟩⟩
+    refine' ⟨0, ⟨by rw [testBit'_zero], fun j hj => _⟩⟩
     obtain ⟨j', rfl⟩ := exists_eq_succ_of_ne_zero (ne_of_gt hj)
-    rw [testBit_succ, zero_testBit]
+    rw [testBit'_succ, zero_testBit']
   · obtain ⟨k, ⟨hk, hk'⟩⟩ := hn h'
-    refine' ⟨k + 1, ⟨by rw [testBit_succ, hk], fun j hj => _⟩⟩
+    refine' ⟨k + 1, ⟨by rw [testBit'_succ, hk], fun j hj => _⟩⟩
     obtain ⟨j', rfl⟩ := exists_eq_succ_of_ne_zero (show j ≠ 0 by intro x; subst x; simp at hj)
-    exact (testBit_succ _ _ _).trans (hk' _ (lt_of_succ_lt_succ hj))
+    exact (testBit'_succ _ _ _).trans (hk' _ (lt_of_succ_lt_succ hj))
 #align nat.exists_most_significant_bit Nat.exists_most_significant_bit
 
-theorem lt_of_testBit {n m : ℕ} (i : ℕ) (hn : testBit n i = false) (hm : testBit m i = true)
-    (hnm : ∀ j, i < j → testBit n j = testBit m j) : n < m := by
+theorem lt_of_testBit' {n m : ℕ} (i : ℕ) (hn : testBit' n i = false) (hm : testBit' m i = true)
+    (hnm : ∀ j, i < j → testBit' n j = testBit' m j) : n < m := by
   induction' n using Nat.binaryRec with b n hn' generalizing i m
   · contrapose! hm
     rw [le_zero_iff] at hm
     simp [hm]
   induction' m using Nat.binaryRec with b' m hm' generalizing i
-  · exact False.elim (Bool.false_ne_true ((zero_testBit i).symm.trans hm))
+  · exact False.elim (Bool.false_ne_true ((zero_testBit' i).symm.trans hm))
   by_cases hi : i = 0
   · subst hi
-    simp only [testBit_zero] at hn hm
+    simp only [testBit'_zero] at hn hm
     have : n = m :=
-      eq_of_testBit_eq fun i => by convert hnm (i + 1) (Nat.zero_lt_succ _) using 1
-      <;> rw [testBit_succ]
+      eq_of_testBit'_eq fun i => by convert hnm (i + 1) (Nat.zero_lt_succ _) using 1
+      <;> rw [testBit'_succ]
     rw [hn, hm, this, bit_false, bit_true, bit0_val, bit1_val]
     exact lt_add_one _
   · obtain ⟨i', rfl⟩ := exists_eq_succ_of_ne_zero hi
-    simp only [testBit_succ] at hn hm
+    simp only [testBit'_succ] at hn hm
     have :=
-      hn' _ hn hm fun j hj => by convert hnm j.succ (succ_lt_succ hj) using 1 <;> rw [testBit_succ]
+      hn' _ hn hm fun j hj => by convert hnm j.succ (succ_lt_succ hj) using 1 <;> rw [testBit'_succ]
     have this' : 2 * n < 2 * m := Nat.mul_lt_mul' (le_refl _) this two_pos
     cases b <;> cases b'
     <;> simp only [bit_false, bit_true, bit0_val n, bit1_val n, bit0_val m, bit1_val m]
@@ -291,15 +291,15 @@ theorem lt_of_testBit {n m : ℕ} (i : ℕ) (hn : testBit n i = false) (hm : tes
         2 * n + 1 < 2 * n + 2 := lt.base _
         _ ≤ 2 * m := mul_le_mul_left 2 this
     · exact Nat.succ_lt_succ this'
-#align nat.lt_of_test_bit Nat.lt_of_testBit
+#align nat.lt_of_test_bit Nat.lt_of_testBit'
 
 @[simp]
-theorem testBit_two_pow_self (n : ℕ) : testBit (2 ^ n) n = true := by
-  rw [testBit, shiftRight_eq_div_pow, Nat.div_self (pow_pos (α := ℕ) zero_lt_two n), bodd_one]
-#align nat.test_bit_two_pow_self Nat.testBit_two_pow_self
+theorem testBit'_two_pow_self (n : ℕ) : testBit' (2 ^ n) n = true := by
+  rw [testBit', shiftRight_eq_div_pow, Nat.div_self (pow_pos (α := ℕ) zero_lt_two n), bodd_one]
+#align nat.test_bit_two_pow_self Nat.testBit'_two_pow_self
 
-theorem testBit_two_pow_of_ne {n m : ℕ} (hm : n ≠ m) : testBit (2 ^ n) m = false := by
-  rw [testBit, shiftRight_eq_div_pow]
+theorem testBit'_two_pow_of_ne {n m : ℕ} (hm : n ≠ m) : testBit' (2 ^ n) m = false := by
+  rw [testBit', shiftRight_eq_div_pow]
   cases' hm.lt_or_lt with hm hm
   · rw [Nat.div_eq_of_lt, bodd_zero]
     exact Nat.pow_lt_pow_of_lt_right one_lt_two hm
@@ -309,15 +309,15 @@ theorem testBit_two_pow_of_ne {n m : ℕ} (hm : n ≠ m) : testBit (2 ^ n) m = f
     simp only [ge_iff_le, tsub_le_iff_right, pow_succ, bodd_mul,
       Bool.and_eq_false_eq_eq_false_or_eq_false, or_true]
     exact Or.inr rfl
-#align nat.test_bit_two_pow_of_ne Nat.testBit_two_pow_of_ne
+#align nat.test_bit_two_pow_of_ne Nat.testBit'_two_pow_of_ne
 
-theorem testBit_two_pow (n m : ℕ) : testBit (2 ^ n) m = (n = m) := by
+theorem testBit'_two_pow (n m : ℕ) : testBit' (2 ^ n) m = (n = m) := by
   by_cases h : n = m
   · cases h
     simp
-  · rw [testBit_two_pow_of_ne h]
+  · rw [testBit'_two_pow_of_ne h]
     simp [h]
-#align nat.test_bit_two_pow Nat.testBit_two_pow
+#align nat.test_bit_two_pow Nat.testBit'_two_pow
 
 theorem bitwise_swap {f : Bool → Bool → Bool} :
     bitwise (Function.swap f) = Function.swap (bitwise f) := by
@@ -353,15 +353,15 @@ theorem xor_comm (n m : ℕ) : n ^^^ m = m ^^^ n :=
   bitwise_comm (Bool.bne_eq_xor ▸ Bool.xor_comm) n m
 #align nat.lxor_comm Nat.xor_comm
 
-lemma and_two_pow (n i : ℕ) : n &&& 2 ^ i = (n.testBit i).toNat * 2 ^ i := by
-  refine eq_of_testBit_eq fun j => ?_
-  obtain rfl | hij := Decidable.eq_or_ne i j <;> cases' h : n.testBit i
+lemma and_two_pow (n i : ℕ) : n &&& 2 ^ i = (n.testBit' i).toNat * 2 ^ i := by
+  refine eq_of_testBit'_eq fun j => ?_
+  obtain rfl | hij := Decidable.eq_or_ne i j <;> cases' h : n.testBit' i
   · simp [h]
   · simp [h]
-  · simp [h, testBit_two_pow_of_ne hij]
-  · simp [h, testBit_two_pow_of_ne hij]
+  · simp [h, testBit'_two_pow_of_ne hij]
+  · simp [h, testBit'_two_pow_of_ne hij]
 
-lemma two_pow_and (n i : ℕ) : 2 ^ i &&& n = 2 ^ i * (n.testBit i).toNat := by
+lemma two_pow_and (n i : ℕ) : 2 ^ i &&& n = 2 ^ i * (n.testBit' i).toNat := by
   rw [mul_comm, land_comm, and_two_pow]
 
 @[simp]
@@ -416,7 +416,7 @@ theorem lor_assoc (n m k : ℕ) : (n ||| m) ||| k = n ||| (m ||| k) := by bitwis
 
 @[simp]
 theorem xor_self (n : ℕ) : n ^^^ n = 0 :=
-  zero_of_testBit_eq_false fun i => by simp
+  zero_of_testBit'_eq_false fun i => by simp
 #align nat.lxor_self Nat.xor_self
 
 -- These lemmas match `mul_inv_cancel_right` and `mul_inv_cancel_left`.
@@ -475,9 +475,9 @@ theorem xor_trichotomy {a b c : ℕ} (h : a ≠ b ^^^ c) :
   -- If `i` is the position of the most significant bit of `v`, then at least one of `a`, `b`, `c`
   -- has a one bit at position `i`.
   obtain ⟨i, ⟨hi, hi'⟩⟩ := exists_most_significant_bit (xor_ne_zero.2 h)
-  have : testBit a i = true ∨ testBit b i = true ∨ testBit c i = true := by
+  have : testBit' a i = true ∨ testBit' b i = true ∨ testBit' c i = true := by
     contrapose! hi
-    simp only [Bool.eq_false_eq_not_eq_true, Ne, testBit_xor, Bool.bne_eq_xor] at hi ⊢
+    simp only [Bool.eq_false_eq_not_eq_true, Ne, testBit'_xor, Bool.bne_eq_xor] at hi ⊢
     rw [hi.1, hi.2.1, hi.2.2, Bool.xor_false, Bool.xor_false]
   -- If, say, `a` has a one bit at position `i`, then `a xor v` has a zero bit at position `i`, but
   -- the same bits as `a` in positions greater than `j`, so `a xor v < a`.
@@ -486,13 +486,13 @@ theorem xor_trichotomy {a b c : ℕ} (h : a ≠ b ^^^ c) :
   on_goal 2 => right; left; rw [hac]
   on_goal 3 => right; right; rw [hab]
   all_goals
-    exact lt_of_testBit i (by
+    exact lt_of_testBit' i (by
       -- Porting note: this was originally `simp [h, hi]`
-      rw [Nat.testBit_xor, h, Bool.bne_eq_xor, Bool.true_xor,hi]
+      rw [Nat.testBit'_xor, h, Bool.bne_eq_xor, Bool.true_xor,hi]
       rfl
     ) h fun j hj => by
       -- Porting note: this was originally `simp [hi' _ hj]`
-      rw [Nat.testBit_xor, hi' _ hj, Bool.bne_eq_xor, Bool.xor_false, eq_self_iff_true]
+      rw [Nat.testBit'_xor, hi' _ hj, Bool.bne_eq_xor, Bool.xor_false, eq_self_iff_true]
       trivial
 #align nat.lxor_trichotomy Nat.xor_trichotomy
 

--- a/Mathlib/Data/Nat/Order/Lemmas.lean
+++ b/Mathlib/Data/Nat/Order/Lemmas.lean
@@ -223,11 +223,6 @@ theorem le_of_lt_add_of_dvd (h : a < b + n) : n ∣ a → n ∣ b → a ≤ b :=
   exact mul_le_mul_left' (lt_succ_iff.1 <| lt_of_mul_lt_mul_left h bot_le) _
 #align nat.le_of_lt_add_of_dvd Nat.le_of_lt_add_of_dvd
 
-@[simp]
-theorem mod_div_self (m n : ℕ) : m % n / n = 0 := by
-  cases n
-  · exact (m % 0).div_zero
-  · case succ n => exact Nat.div_eq_of_lt (m.mod_lt n.succ_pos)
 #align nat.mod_div_self Nat.mod_div_self
 
 /-- `n` is not divisible by `a` iff it is between `a * k` and `a * (k + 1)` for some `k`. -/

--- a/Mathlib/Data/Nat/Size.lean
+++ b/Mathlib/Data/Nat/Size.lean
@@ -32,10 +32,7 @@ theorem shiftLeft'_tt_eq_mul_pow (m) : ∀ n, shiftLeft' true m n + 1 = (m + 1) 
 end
 
 #align nat.one_shiftl Nat.one_shiftLeft
-
-theorem zero_shiftLeft (n) : 0 <<< n = 0 := by simp
 #align nat.zero_shiftl Nat.zero_shiftLeft
-
 #align nat.shiftr_eq_div_pow Nat.shiftRight_eq_div_pow
 
 theorem shiftLeft'_ne_zero_left (b) {m} (h : m ≠ 0) (n) : shiftLeft' b m n ≠ 0 := by
@@ -118,7 +115,7 @@ theorem lt_size_self (n : ℕ) : n < 2 ^ size n := by
   by_cases h : bit b n = 0
   · apply this h
   rw [size_bit h, shiftLeft_succ, shiftLeft_eq, one_mul, ← bit0_val]
-  exact bit_lt_bit0 _ (by simpa [shiftRight_eq_div_pow] using IH)
+  exact bit_lt_bit0 _ (by simpa [shiftLeft_eq, shiftRight_eq_div_pow] using IH)
 #align nat.lt_size_self Nat.lt_size_self
 
 theorem size_le {m n : ℕ} : size m ≤ n ↔ m < 2 ^ n :=

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -968,9 +968,9 @@ theorem castNum_shiftRight (m : Num) (n : Nat) : ↑(m >>> n) = (m : ℕ) >>> (n
 #align num.shiftr_to_nat Num.castNum_shiftRight
 
 @[simp]
-theorem castNum_testBit (m n) : testBit m n = Nat.testBit m n := by
+theorem castNum_testBit (m n) : testBit m n = Nat.testBit' m n := by
   -- Porting note: `unfold` → `dsimp only`
-  cases m <;> dsimp only [testBit, Nat.testBit]
+  cases m <;> dsimp only [testBit, Nat.testBit']
   case zero =>
     change false = Nat.bodd (0 >>> n)
     rw [Nat.zero_shiftRight]

--- a/Mathlib/Init/Data/Int/Bitwise.lean
+++ b/Mathlib/Init/Data/Int/Bitwise.lean
@@ -41,8 +41,8 @@ def bit (b : Bool) : ℤ → ℤ :=
 
 /-- `testBit m n` returns whether the `(n+1)ˢᵗ` least significant bit is `1` or `0`-/
 def testBit : ℤ → ℕ → Bool
-  | (m : ℕ), n => Nat.testBit m n
-  | -[m +1], n => !(Nat.testBit m n)
+  | (m : ℕ), n => Nat.testBit' m n
+  | -[m +1], n => !(Nat.testBit' m n)
 #align int.test_bit Int.testBit
 
 /-- `Int.natBitwise` is an auxiliary definition for `Int.bitwise`. -/

--- a/Mathlib/Init/Data/Nat/Bitwise.lean
+++ b/Mathlib/Init/Data/Nat/Bitwise.lean
@@ -199,13 +199,10 @@ lemma shiftLeft_eq' (m n : Nat) : shiftLeft m n = m <<< n := rfl
 @[simp]
 lemma shiftRight_eq (m n : Nat) : shiftRight m n = m >>> n := rfl
 
-theorem shiftLeft_zero (m) : m <<< 0 = m := rfl
-
-theorem shiftLeft_succ (m n) : m <<< (n + 1) = 2 * (m <<< n) := by
-  simp only [shiftLeft_eq, Nat.pow_add, Nat.pow_one, ← Nat.mul_assoc, Nat.mul_comm]
-
 /-- `testBit m n` returns whether the `(n+1)ˢᵗ` least significant bit is `1` or `0`-/
-def testBit (m n : ℕ) : Bool :=
+-- Std has adopted a new and different definition of `testBit`.
+-- This should be removed.
+def testBit' (m n : ℕ) : Bool :=
   bodd (m >>> n)
 #align nat.test_bit Nat.testBit
 
@@ -301,17 +298,17 @@ theorem shiftLeft_sub : ∀ (m : Nat) {n k}, k ≤ n → m <<< (n - k) = (m <<< 
   fun _ _ _ hk => by simp only [← shiftLeft'_false, shiftLeft'_sub false _ hk]
 
 @[simp]
-theorem testBit_zero (b n) : testBit (bit b n) 0 = b :=
+theorem testBit'_zero (b n) : testBit' (bit b n) 0 = b :=
   bodd_bit _ _
-#align nat.test_bit_zero Nat.testBit_zero
+#align nat.test_bit_zero Nat.testBit'_zero
 
-theorem testBit_succ (m b n) : testBit (bit b n) (succ m) = testBit n m := by
+theorem testBit'_succ (m b n) : testBit' (bit b n) (succ m) = testBit' n m := by
   have : bodd (((bit b n) >>> 1) >>> m) = bodd (n >>> m) := by
-    dsimp [shiftRight]
+    simp only [← shiftRight_eq]
     simp [← div2_val, div2_bit]
   rw [← shiftRight_add, Nat.add_comm] at this
   exact this
-#align nat.test_bit_succ Nat.testBit_succ
+#align nat.test_bit_succ Nat.testBit'_succ
 
 theorem binaryRec_eq {C : Nat → Sort u} {z : C 0} {f : ∀ b n, C n → C (bit b n)}
     (h : f false 0 z = z) (b n) : binaryRec z f (bit b n) = f b n (binaryRec z f n) := by

--- a/Mathlib/Init/Data/Nat/Bitwise.lean
+++ b/Mathlib/Init/Data/Nat/Bitwise.lean
@@ -189,8 +189,8 @@ theorem shiftLeft'_false : ∀ n, shiftLeft' false m n = m <<< n
   | 0 => rfl
   | n + 1 => by
     have : 2 * (m * 2^n) = 2^(n+1)*m := by
-      rw [Nat.mul_comm, Nat.mul_assoc, ← pow_succ]; simp
-    simp [shiftLeft', bit_val, shiftLeft'_false, this]
+      rw [Nat.mul_comm, Nat.mul_assoc, Nat.mul_comm, ← pow_succ]
+    simp [shiftLeft', shiftLeft_eq, bit_val, shiftLeft'_false, this]
 
 /-- Std4 takes the unprimed name for `Nat.shiftLeft_eq m n : m <<< n = m * 2 ^ n`. -/
 @[simp]
@@ -199,7 +199,7 @@ lemma shiftLeft_eq' (m n : Nat) : shiftLeft m n = m <<< n := rfl
 @[simp]
 lemma shiftRight_eq (m n : Nat) : shiftRight m n = m >>> n := rfl
 
-/-- `testBit m n` returns whether the `(n+1)ˢᵗ` least significant bit is `1` or `0`-/
+/-- `testBit' m n` returns whether the `(n+1)ˢᵗ` least significant bit is `1` or `0`-/
 -- Std has adopted a new and different definition of `testBit`.
 -- This should be removed.
 def testBit' (m n : ℕ) : Bool :=
@@ -304,7 +304,7 @@ theorem testBit'_zero (b n) : testBit' (bit b n) 0 = b :=
 
 theorem testBit'_succ (m b n) : testBit' (bit b n) (succ m) = testBit' n m := by
   have : bodd (((bit b n) >>> 1) >>> m) = bodd (n >>> m) := by
-    simp only [← shiftRight_eq]
+    simp only [shiftRight_eq_div_pow]
     simp [← div2_val, div2_bit]
   rw [← shiftRight_add, Nat.add_comm] at this
   exact this

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/std4",
    "type": "git",
    "subDir": null,
-   "rev": "bf8a6ea960d5a99f8e30cbf5597ab05cd233eadf",
+   "rev": "415a6731db08f4d98935e5d80586d5a5499e02af",
    "name": "std",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/std4",
    "type": "git",
    "subDir": null,
-   "rev": "415a6731db08f4d98935e5d80586d5a5499e02af",
+   "rev": "a93d4aab761b7962a6aab845b24837e192eaabc5",
    "name": "std",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
This is an alternative bump PR, which perhaps should replace #8700. This one keeps Mathlib's `Nat.testBit`, renaming it to `Nat.testBit'`.

