### PR TITLE
[Merged by Bors] - refactor: review normed group structure on `ContinuousLinearMap`

### DIFF
--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -182,15 +182,16 @@ instance as a special case of a more general `SeminormedGroup` instance. -/
 satisfying `∀ x, ‖x‖ = 0 → x = 0`. This avoids having to go back to the `(Pseudo)MetricSpace`
 level when declaring a `NormedAddGroup` instance as a special case of a more general
 `SeminormedAddGroup` instance."]
-def NormedGroup.ofSeparation [SeminormedGroup E] (h : ∀ x : E, ‖x‖ = 0 → x = 1) : NormedGroup E :=
-  { ‹SeminormedGroup E› with
-    toMetricSpace :=
-      { eq_of_dist_eq_zero := fun hxy =>
-          div_eq_one.1 <| h _ <| by exact (‹SeminormedGroup E›.dist_eq _ _).symm.trans hxy } }
-        -- porting note: the `rwa` no longer worked, but it was easy enough to provide the term.
-        -- however, notice that if you make `x` and `y` accessible, then the following does work:
-        -- `have := ‹SeminormedGroup E›.dist_eq x y; rwa [←this]`, so I'm not sure why the `rwa`
-        -- was broken.
+def NormedGroup.ofSeparation [SeminormedGroup E] (h : ∀ x : E, ‖x‖ = 0 → x = 1) :
+    NormedGroup E where
+  dist_eq := ‹SeminormedGroup E›.dist_eq
+  toMetricSpace :=
+    { eq_of_dist_eq_zero := fun hxy =>
+        div_eq_one.1 <| h _ <| by exact (‹SeminormedGroup E›.dist_eq _ _).symm.trans hxy }
+      -- porting note: the `rwa` no longer worked, but it was easy enough to provide the term.
+      -- however, notice that if you make `x` and `y` accessible, then the following does work:
+      -- `have := ‹SeminormedGroup E›.dist_eq x y; rwa [←this]`, so I'm not sure why the `rwa`
+      -- was broken.
 #align normed_group.of_separation NormedGroup.ofSeparation
 #align normed_add_group.of_separation NormedAddGroup.ofSeparation
 

--- a/Mathlib/Analysis/NormedSpace/CompactOperator.lean
+++ b/Mathlib/Analysis/NormedSpace/CompactOperator.lean
@@ -434,8 +434,7 @@ theorem isClosed_setOf_isCompactOperator {𝕜₁ 𝕜₂ : Type*} [Nontrivially
 theorem compactOperator_topologicalClosure {𝕜₁ 𝕜₂ : Type*} [NontriviallyNormedField 𝕜₁]
     [NormedField 𝕜₂] {σ₁₂ : 𝕜₁ →+* 𝕜₂} {M₁ M₂ : Type*} [SeminormedAddCommGroup M₁]
     [AddCommGroup M₂] [NormedSpace 𝕜₁ M₁] [Module 𝕜₂ M₂] [UniformSpace M₂] [UniformAddGroup M₂]
-    [ContinuousConstSMul 𝕜₂ M₂] [T2Space M₂] [CompleteSpace M₂]
-    [ContinuousSMul 𝕜₂ (M₁ →SL[σ₁₂] M₂)] :
+    [ContinuousConstSMul 𝕜₂ M₂] [T2Space M₂] [CompleteSpace M₂] :
     (compactOperator σ₁₂ M₁ M₂).topologicalClosure = compactOperator σ₁₂ M₁ M₂ :=
   SetLike.ext' isClosed_setOf_isCompactOperator.closure_eq
 #align compact_operator_topological_closure compactOperator_topologicalClosure

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -1833,7 +1833,7 @@ def smulRightL : (E →L[𝕜] 𝕜) →L[𝕜] Fₗ →L[𝕜] E →L[𝕜] F�
     1 fun c x => (norm_smulRight_apply c x).le.trans_eq <| by simp
     -- was
     -- simp only [coe_smulRightₗ, one_mul, norm_smulRight_apply, LinearMap.coe_mk, AddHom.coe_mk,
-         le_refl]
+    --   le_refl]
     -- after `=>` above
     -- Now it fails to use `AddHom.coe_mk`. WHY?
 #align continuous_linear_map.smul_rightL ContinuousLinearMap.smulRightL

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -293,6 +293,11 @@ theorem op_norm_smul_le {𝕜' : Type*} [NormedField 𝕜'] [NormedSpace 𝕜' F
     exact mul_le_mul_of_nonneg_left (le_op_norm _ _) (norm_nonneg _)
 #align continuous_linear_map.op_norm_smul_le ContinuousLinearMap.op_norm_smul_le
 
+/-- Operator seminorm on the space of continuous (semi)linear maps, as `Seminorm`.
+
+We use this seminorm to define a `SeminormedGroup` structure on `E →SL[σ] F`,
+but we have to override the projection `UniformSpace`
+so that it is definitionally equal to the one coming from the topologies on `E` and `F`. -/
 protected def seminorm : Seminorm 𝕜₂ (E →SL[σ₁₂] F) :=
   .ofSMulLE norm op_norm_zero op_norm_add_le op_norm_smul_le
 

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -29,7 +29,9 @@ is isometric, as expressed by the typeclass `[RingHomIsometric σ]`.
 
 suppress_compilation
 
-open Classical NNReal Topology Bornology
+open Bornology
+open Filter hiding map_smul
+open scoped Classical NNReal Topology Uniformity
 
 -- the `ₗ` subscript variables are for special cases about linear (as opposed to semilinear) maps
 variable {𝕜 𝕜₂ 𝕜₃ E Eₗ F Fₗ G Gₗ 𝓕 : Type*}
@@ -291,107 +293,48 @@ theorem op_norm_smul_le {𝕜' : Type*} [NormedField 𝕜'] [NormedSpace 𝕜' F
     exact mul_le_mul_of_nonneg_left (le_op_norm _ _) (norm_nonneg _)
 #align continuous_linear_map.op_norm_smul_le ContinuousLinearMap.op_norm_smul_le
 
-/-- Continuous linear maps themselves form a seminormed space with respect to
-the operator norm. This is only a temporary definition because we want to replace the topology
-with `ContinuousLinearMap.topologicalSpace` to avoid diamond issues.
-See Note [forgetful inheritance] -/
-protected def tmpSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) :=
-  AddGroupSeminorm.toSeminormedAddCommGroup
-    { toFun := norm
-      map_zero' := op_norm_zero
-      add_le' := op_norm_add_le
-      neg' := op_norm_neg }
-#align continuous_linear_map.tmp_seminormed_add_comm_group ContinuousLinearMap.tmpSeminormedAddCommGroup
+protected def seminorm : Seminorm 𝕜₂ (E →SL[σ₁₂] F) :=
+  .ofSMulLE norm op_norm_zero op_norm_add_le op_norm_smul_le
 
-/-- The `PseudoMetricSpace` structure on `E →SL[σ₁₂] F` coming from
-`ContinuousLinearMap.tmpSeminormedAddCommGroup`.
-See Note [forgetful inheritance] -/
-protected def tmpPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) :=
-  ContinuousLinearMap.tmpSeminormedAddCommGroup.toPseudoMetricSpace
-#align continuous_linear_map.tmp_pseudo_metric_space ContinuousLinearMap.tmpPseudoMetricSpace
-
-/-- The `UniformSpace` structure on `E →SL[σ₁₂] F` coming from
-`ContinuousLinearMap.tmpSeminormedAddCommGroup`.
-See Note [forgetful inheritance] -/
-protected def tmpUniformSpace : UniformSpace (E →SL[σ₁₂] F) :=
-  ContinuousLinearMap.tmpPseudoMetricSpace.toUniformSpace
-#align continuous_linear_map.tmp_uniform_space ContinuousLinearMap.tmpUniformSpace
-
-/-- The `TopologicalSpace` structure on `E →SL[σ₁₂] F` coming from
-`ContinuousLinearMap.tmpSeminormedAddCommGroup`.
-See Note [forgetful inheritance] -/
-protected def tmpTopologicalSpace : TopologicalSpace (E →SL[σ₁₂] F) :=
-  ContinuousLinearMap.tmpUniformSpace.toTopologicalSpace
-#align continuous_linear_map.tmp_topological_space ContinuousLinearMap.tmpTopologicalSpace
-
-section Tmp
-
-attribute [-instance] ContinuousLinearMap.topologicalSpace
-
-attribute [-instance] ContinuousLinearMap.uniformSpace
-
-attribute [local instance] ContinuousLinearMap.tmpSeminormedAddCommGroup
-
-protected theorem tmpTopologicalAddGroup : TopologicalAddGroup (E →SL[σ₁₂] F) :=
-  inferInstance
-#align continuous_linear_map.tmp_topological_add_group ContinuousLinearMap.tmpTopologicalAddGroup
-
-protected theorem tmp_closedBall_div_subset {a b : ℝ} (ha : 0 < a) (hb : 0 < b) :
-    closedBall (0 : E →SL[σ₁₂] F) (a / b) ⊆
-      { f | ∀ x ∈ closedBall (0 : E) b, f x ∈ closedBall (0 : F) a } := by
-  intro f hf x hx
-  rw [mem_closedBall_zero_iff] at hf hx ⊢
-  calc
-    ‖f x‖ ≤ ‖f‖ * ‖x‖ := le_op_norm _ _
-    _ ≤ a / b * b := by gcongr
-    _ = a := div_mul_cancel a hb.ne.symm
-#align continuous_linear_map.tmp_closed_ball_div_subset ContinuousLinearMap.tmp_closedBall_div_subset
-
-end Tmp
-
-protected theorem tmp_topology_eq :
-    (ContinuousLinearMap.tmpTopologicalSpace : TopologicalSpace (E →SL[σ₁₂] F)) =
-      ContinuousLinearMap.topologicalSpace := by
-  refine'
-    ContinuousLinearMap.tmpTopologicalAddGroup.ext inferInstance
-      ((@Metric.nhds_basis_closedBall _ ContinuousLinearMap.tmpPseudoMetricSpace 0).ext
-        (ContinuousLinearMap.hasBasis_nhds_zero_of_basis Metric.nhds_basis_closedBall) _ _)
-  · rcases NormedField.exists_norm_lt_one 𝕜 with ⟨c, hc₀, hc₁⟩
-    intro ε hε
-    refine' ⟨⟨closedBall 0 (1 / ‖c‖), ε⟩, ⟨⟨_, hε⟩, _⟩⟩
-    · exact NormedSpace.isVonNBounded_closedBall _ _ _
-    intro f (hf : ∀ x, _)
-    simp_rw [mem_closedBall_zero_iff] at hf
-    convert (@mem_closedBall_zero_iff _ (_) f ε).2 _ -- Porting note: needed `convert`
-    refine' op_norm_le_of_shell' (div_pos one_pos hc₀) hε.le hc₁ fun x hx₁ hxc => _
-    rw [div_mul_cancel 1 hc₀.ne.symm] at hx₁
-    exact (hf x hxc.le).trans (le_mul_of_one_le_right hε.le hx₁)
-  · rintro ⟨S, ε⟩ ⟨hS, hε⟩
-    rw [NormedSpace.isVonNBounded_iff] at hS
-    rcases hS.subset_closedBall_lt 0 0 with ⟨δ, hδ, hSδ⟩
-    exact ⟨ε / δ, div_pos hε hδ,
-      (ContinuousLinearMap.tmp_closedBall_div_subset hε hδ).trans fun f hf x hx => hf x <| hSδ hx⟩
-#align continuous_linear_map.tmp_topology_eq ContinuousLinearMap.tmp_topology_eq
-
-protected theorem tmpUniformSpace_eq :
-    (ContinuousLinearMap.tmpUniformSpace : UniformSpace (E →SL[σ₁₂] F)) =
-      ContinuousLinearMap.uniformSpace := by
-  rw [← @UniformAddGroup.toUniformSpace_eq _ ContinuousLinearMap.tmpUniformSpace, ←
-    @UniformAddGroup.toUniformSpace_eq _ ContinuousLinearMap.uniformSpace]
-  congr! 1
-  exact ContinuousLinearMap.tmp_topology_eq
-#align continuous_linear_map.tmp_uniform_space_eq ContinuousLinearMap.tmpUniformSpace_eq
-
-instance toPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) :=
-  ContinuousLinearMap.tmpPseudoMetricSpace.replaceUniformity
-    (congr_arg _ ContinuousLinearMap.tmpUniformSpace_eq.symm)
-#align continuous_linear_map.to_pseudo_metric_space ContinuousLinearMap.toPseudoMetricSpace
-
+private lemma uniformity_eq_seminorm :
+    𝓤 (E →SL[σ₁₂] F) = ⨅ r > 0, 𝓟 {f | ‖f.1 - f.2‖ < r} := by
+  refine ContinuousLinearMap.seminorm.uniformity_eq_of_hasBasis
+    (ContinuousLinearMap.hasBasis_nhds_zero_of_basis Metric.nhds_basis_closedBall)
+    ?_ fun (s, r) ⟨hs, hr⟩ ↦ ?_
+  · rcases NormedField.exists_lt_norm 𝕜 1 with ⟨c, hc⟩
+    refine ⟨‖c‖, ContinuousLinearMap.hasBasis_nhds_zero.mem_iff.2
+      ⟨(closedBall 0 1, closedBall 0 1), ?_⟩⟩
+    suffices ∀ f : E →SL[σ₁₂] F, (∀ x, ‖x‖ ≤ 1 → ‖f x‖ ≤ 1) → ‖f‖ ≤ ‖c‖ by
+      simpa [NormedSpace.isVonNBounded_closedBall, closedBall_mem_nhds, subset_def] using this
+    intro f hf
+    refine op_norm_le_of_shell (f := f) one_pos (norm_nonneg c) hc fun x hcx hx ↦ ?_
+    exact (hf x hx.le).trans ((div_le_iff' <| one_pos.trans hc).1 hcx)
+  · rcases (NormedSpace.isVonNBounded_iff' _ _ _).1 hs with ⟨ε, hε⟩
+    rcases exists_pos_mul_lt hr ε with ⟨δ, hδ₀, hδ⟩
+    refine ⟨δ, hδ₀, fun f hf x hx ↦ ?_⟩
+    simp only [Seminorm.mem_ball_zero, mem_closedBall_zero_iff] at hf ⊢
+    rw [mul_comm] at hδ
+    exact le_trans (le_of_op_norm_le_of_le _ hf.le (hε _ hx)) hδ.le
+    
 /-- Continuous linear maps themselves form a seminormed space with respect to
     the operator norm. -/
-instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) where
-  dist_eq := ContinuousLinearMap.tmpSeminormedAddCommGroup.dist_eq
+instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) :=
+  { ContinuousLinearMap.seminorm.toSeminormedAddCommGroup with
+    toUniformSpace := inferInstance
+    uniformity_dist := uniformity_eq_seminorm }
 #align continuous_linear_map.to_seminormed_add_comm_group ContinuousLinearMap.toSeminormedAddCommGroup
+
+#noalign continuous_linear_map.tmp_seminormed_add_comm_group
+#noalign continuous_linear_map.tmp_pseudo_metric_space
+#noalign continuous_linear_map.tmp_uniform_space
+#noalign continuous_linear_map.tmp_topological_space
+#noalign continuous_linear_map.tmp_topological_add_group
+#noalign continuous_linear_map.tmp_closed_ball_div_subset
+#noalign continuous_linear_map.tmp_topology_eq
+#noalign continuous_linear_map.tmp_uniform_space_eq
+
+instance toPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) := inferInstance
+#align continuous_linear_map.to_pseudo_metric_space ContinuousLinearMap.toPseudoMetricSpace
 
 theorem nnnorm_def (f : E →SL[σ₁₂] F) : ‖f‖₊ = sInf { c | ∀ x, ‖f x‖₊ ≤ c * ‖x‖₊ } := by
   ext
@@ -1436,8 +1379,7 @@ theorem bound_of_shell [RingHomIsometric σ₁₂] (f : E →ₛₗ[σ₁₂] F)
     (hc : 1 < ‖c‖) (hf : ∀ x, ε / ‖c‖ ≤ ‖x‖ → ‖x‖ < ε → ‖f x‖ ≤ C * ‖x‖) (x : E) :
     ‖f x‖ ≤ C * ‖x‖ := by
   by_cases hx : x = 0; · simp [hx]
-  exact
-    SemilinearMapClass.bound_of_shell_semi_normed f ε_pos hc hf (ne_of_lt (norm_pos_iff.2 hx)).symm
+  exact SemilinearMapClass.bound_of_shell_semi_normed f ε_pos hc hf (norm_ne_zero_iff.2 hx)
 #align linear_map.bound_of_shell LinearMap.bound_of_shell
 
 /-- `LinearMap.bound_of_ball_bound'` is a version of this lemma over a field satisfying `IsROrC`

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -321,11 +321,13 @@ private lemma uniformity_eq_seminorm :
     rw [mul_comm] at hδ
     exact le_trans (le_of_op_norm_le_of_le _ hf.le (hε _ hx)) hδ.le
 
+instance toPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) := .replaceUniformity
+  ContinuousLinearMap.seminorm.toSeminormedAddCommGroup.toPseudoMetricSpace uniformity_eq_seminorm
+#align continuous_linear_map.to_pseudo_metric_space ContinuousLinearMap.toPseudoMetricSpace
+
 /-- Continuous linear maps themselves form a seminormed space with respect to
     the operator norm. -/
 instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) where
-  toPseudoMetricSpace := .replaceUniformity
-    ContinuousLinearMap.seminorm.toSeminormedAddCommGroup.toPseudoMetricSpace uniformity_eq_seminorm
   dist_eq _ _ := rfl
 #align continuous_linear_map.to_seminormed_add_comm_group ContinuousLinearMap.toSeminormedAddCommGroup
 
@@ -337,9 +339,6 @@ instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F)
 #noalign continuous_linear_map.tmp_closed_ball_div_subset
 #noalign continuous_linear_map.tmp_topology_eq
 #noalign continuous_linear_map.tmp_uniform_space_eq
-
-instance toPseudoMetricSpace : PseudoMetricSpace (E →SL[σ₁₂] F) := inferInstance
-#align continuous_linear_map.to_pseudo_metric_space ContinuousLinearMap.toPseudoMetricSpace
 
 theorem nnnorm_def (f : E →SL[σ₁₂] F) : ‖f‖₊ = sInf { c | ∀ x, ‖f x‖₊ ≤ c * ‖x‖₊ } := by
   ext

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -318,10 +318,10 @@ private lemma uniformity_eq_seminorm :
 
 /-- Continuous linear maps themselves form a seminormed space with respect to
     the operator norm. -/
-instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) :=
-  { ContinuousLinearMap.seminorm.toSeminormedAddCommGroup with
-    toUniformSpace := inferInstance
-    uniformity_dist := uniformity_eq_seminorm }
+instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) where
+  toPseudoMetricSpace := .replaceUniformity
+    ContinuousLinearMap.seminorm.toSeminormedAddCommGroup.toPseudoMetricSpace uniformity_eq_seminorm
+  dist_eq _ _ := rfl
 #align continuous_linear_map.to_seminormed_add_comm_group ContinuousLinearMap.toSeminormedAddCommGroup
 
 #noalign continuous_linear_map.tmp_seminormed_add_comm_group
@@ -1830,12 +1830,9 @@ def smulRightL : (E →L[𝕜] 𝕜) →L[𝕜] Fₗ →L[𝕜] E →L[𝕜] F�
         ext x
         simp only [smul_smul, coe_smulRightₗ, Algebra.id.smul_eq_mul, coe_smul', smulRight_apply,
           LinearMap.smul_apply, RingHom.id_apply, Pi.smul_apply] }
-    1 fun c x => (norm_smulRight_apply c x).le.trans_eq <| by simp
-    -- was
-    -- simp only [coe_smulRightₗ, one_mul, norm_smulRight_apply, LinearMap.coe_mk, AddHom.coe_mk,
-    --   le_refl]
-    -- after `=>` above
-    -- Now it fails to use `AddHom.coe_mk`. WHY?
+    1 fun c x => by
+      simp only [coe_smulRightₗ, one_mul, norm_smulRight_apply, LinearMap.coe_mk, AddHom.coe_mk,
+        le_refl]
 #align continuous_linear_map.smul_rightL ContinuousLinearMap.smulRightL
 
 variable {𝕜 E Fₗ}

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -1830,9 +1830,12 @@ def smulRightL : (E →L[𝕜] 𝕜) →L[𝕜] Fₗ →L[𝕜] E →L[𝕜] F�
         ext x
         simp only [smul_smul, coe_smulRightₗ, Algebra.id.smul_eq_mul, coe_smul', smulRight_apply,
           LinearMap.smul_apply, RingHom.id_apply, Pi.smul_apply] }
-    1 fun c x => by
-      simp only [coe_smulRightₗ, one_mul, norm_smulRight_apply, LinearMap.coe_mk, AddHom.coe_mk,
-        le_refl]
+    1 fun c x => (norm_smulRight_apply c x).le.trans_eq <| by simp
+    -- was
+    -- simp only [coe_smulRightₗ, one_mul, norm_smulRight_apply, LinearMap.coe_mk, AddHom.coe_mk,
+         le_refl]
+    -- after `=>` above
+    -- Now it fails to use `AddHom.coe_mk`. WHY?
 #align continuous_linear_map.smul_rightL ContinuousLinearMap.smulRightL
 
 variable {𝕜 E Fₗ}

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -315,7 +315,7 @@ private lemma uniformity_eq_seminorm :
     simp only [Seminorm.mem_ball_zero, mem_closedBall_zero_iff] at hf ⊢
     rw [mul_comm] at hδ
     exact le_trans (le_of_op_norm_le_of_le _ hf.le (hε _ hx)) hδ.le
-    
+
 /-- Continuous linear maps themselves form a seminormed space with respect to
     the operator norm. -/
 instance toSeminormedAddCommGroup : SeminormedAddCommGroup (E →SL[σ₁₂] F) :=

--- a/Mathlib/Analysis/Seminorm.lean
+++ b/Mathlib/Analysis/Seminorm.lean
@@ -40,7 +40,7 @@ set_option autoImplicit true
 
 open NormedField Set Filter
 
-open BigOperators NNReal Pointwise Topology
+open scoped BigOperators NNReal Pointwise Topology Uniformity
 
 variable {R R' 𝕜 𝕜₂ 𝕜₃ 𝕝 E E₂ E₃ F G ι : Type*}
 
@@ -396,7 +396,7 @@ theorem finset_sup_apply (p : ι → Seminorm 𝕜 E) (s : Finset ι) (x : E) :
   · rw [Finset.sup_empty, Finset.sup_empty, coe_bot, _root_.bot_eq_zero, Pi.zero_apply]
     norm_cast
   · rw [Finset.sup_cons, Finset.sup_cons, coe_sup, sup_eq_max, Pi.sup_apply, sup_eq_max,
-      NNReal.coe_max, coe_mk, ih]
+      NNReal.coe_max, NNReal.coe_mk, ih]
 #align seminorm.finset_sup_apply Seminorm.finset_sup_apply
 
 theorem exists_apply_eq_finset_sup (p : ι → Seminorm 𝕜 E) {s : Finset ι} (hs : s.Nonempty) (x : E) :
@@ -897,14 +897,14 @@ theorem ball_finset_sup_eq_iInter (p : ι → Seminorm 𝕜 E) (s : Finset ι) (
     (hr : 0 < r) : ball (s.sup p) x r = ⋂ i ∈ s, ball (p i) x r := by
   lift r to NNReal using hr.le
   simp_rw [ball, iInter_setOf, finset_sup_apply, NNReal.coe_lt_coe,
-    Finset.sup_lt_iff (show ⊥ < r from hr), ← NNReal.coe_lt_coe, coe_mk]
+    Finset.sup_lt_iff (show ⊥ < r from hr), ← NNReal.coe_lt_coe, NNReal.coe_mk]
 #align seminorm.ball_finset_sup_eq_Inter Seminorm.ball_finset_sup_eq_iInter
 
 theorem closedBall_finset_sup_eq_iInter (p : ι → Seminorm 𝕜 E) (s : Finset ι) (x : E) {r : ℝ}
     (hr : 0 ≤ r) : closedBall (s.sup p) x r = ⋂ i ∈ s, closedBall (p i) x r := by
   lift r to NNReal using hr
   simp_rw [closedBall, iInter_setOf, finset_sup_apply, NNReal.coe_le_coe, Finset.sup_le_iff, ←
-    NNReal.coe_le_coe, coe_mk]
+    NNReal.coe_le_coe, NNReal.coe_mk]
 #align seminorm.closed_ball_finset_sup_eq_Inter Seminorm.closedBall_finset_sup_eq_iInter
 
 theorem ball_finset_sup (p : ι → Seminorm 𝕜 E) (s : Finset ι) (x : E) {r : ℝ} (hr : 0 < r) :
@@ -1175,19 +1175,13 @@ theorem continuousAt_zero_of_forall' [TopologicalSpace E] {p : Seminorm 𝕝 E}
 
 theorem continuousAt_zero' [TopologicalSpace E] [ContinuousConstSMul 𝕜 E] {p : Seminorm 𝕜 E}
     {r : ℝ} (hp : p.closedBall 0 r ∈ (𝓝 0 : Filter E)) : ContinuousAt p 0 := by
-  let r' := max 1 r
-  have hr' : 0 < r' := lt_max_of_lt_left one_pos
-  have hp' : p.closedBall 0 r' ∈ (𝓝 0 : Filter E) :=
-    mem_of_superset hp (closedBall_mono <| le_max_right _ _)
-  refine' continuousAt_zero_of_forall' _
-  intro ε hε
-  rcases exists_norm_lt 𝕜 (div_pos hε hr') with ⟨k, hk0, hkε⟩
-  have hk0' := norm_pos_iff.mp hk0
-  have := (set_smul_mem_nhds_zero_iff hk0').mpr hp'
-  refine' Filter.mem_of_superset this (smul_set_subset_iff.mpr fun x hx => _)
-  rw [mem_closedBall_zero, map_smul_eq_mul, ← div_mul_cancel ε hr'.ne.symm]
-  gcongr
-  exact p.mem_closedBall_zero.mp hx
+  refine continuousAt_zero_of_forall' fun ε hε ↦ ?_
+  obtain ⟨k, hk₀, hk⟩ : ∃ k : 𝕜, 0 < ‖k‖ ∧ ‖k‖ * r < ε := by
+    rcases le_or_lt r 0 with hr | hr
+    · use 1; simpa using hr.trans_lt hε
+    · simpa [lt_div_iff hr] using exists_norm_lt 𝕜 (div_pos hε hr)
+  rw [← set_smul_mem_nhds_zero_iff (norm_pos_iff.1 hk₀), smul_closedBall_zero hk₀] at hp
+  exact mem_of_superset hp <| p.closedBall_mono hk.le
 #align seminorm.continuous_at_zero' Seminorm.continuousAt_zero'
 
 /-- A seminorm is continuous at `0` if `p.ball 0 r ∈ 𝓝 0` for *all* `r > 0`.
@@ -1288,6 +1282,28 @@ lemma ball_mem_nhds [TopologicalSpace E] {p : Seminorm 𝕝 E} (hp : Continuous 
     (hr : 0 < r) : p.ball 0 r ∈ (𝓝 0 : Filter E) :=
   have this : Tendsto p (𝓝 0) (𝓝 0) := map_zero p ▸ hp.tendsto 0
   by simpa only [p.ball_zero_eq] using this (Iio_mem_nhds hr)
+
+lemma uniformSpace_eq_of_hasBasis
+    {ι} [UniformSpace E] [UniformAddGroup E] [ContinuousConstSMul 𝕜 E]
+    {p' : ι → Prop} {s : ι → Set E} (p : Seminorm 𝕜 E) (hb : (𝓝 0 : Filter E).HasBasis p' s)
+    (h₁ : ∃ r, p.closedBall 0 r ∈ 𝓝 0) (h₂ : ∀ i, p' i → ∃ r > 0, p.ball 0 r ⊆ s i) :
+    ‹UniformSpace E› = p.toAddGroupSeminorm.toSeminormedAddGroup.toUniformSpace := by
+  refine UniformAddGroup.ext ‹_› p.toAddGroupSeminorm.toSeminormedAddCommGroup.to_uniformAddGroup ?_
+  apply le_antisymm
+  · rw [← @comap_norm_nhds_zero E p.toAddGroupSeminorm.toSeminormedAddGroup, ← tendsto_iff_comap]
+    suffices Continuous p from this.tendsto' 0 _ (map_zero p)
+    rcases h₁ with ⟨r, hr⟩
+    exact p.continuous' hr
+  · rw [(@NormedAddCommGroup.nhds_zero_basis_norm_lt E
+      p.toAddGroupSeminorm.toSeminormedAddGroup).le_basis_iff hb]
+    simpa only [subset_def, mem_ball_zero] using h₂
+
+lemma uniformity_eq_of_hasBasis
+    {ι} [UniformSpace E] [UniformAddGroup E] [ContinuousConstSMul 𝕜 E]
+    {p' : ι → Prop} {s : ι → Set E} (p : Seminorm 𝕜 E) (hb : (𝓝 0 : Filter E).HasBasis p' s)
+    (h₁ : ∃ r, p.closedBall 0 r ∈ 𝓝 0) (h₂ : ∀ i, p' i → ∃ r > 0, p.ball 0 r ⊆ s i) :
+    𝓤 E = ⨅ r > 0, 𝓟 {x | p (x.1 - x.2) < r} := by
+  rw [uniformSpace_eq_of_hasBasis p hb h₁ h₂]; rfl
 
 end Continuity
 

--- a/Mathlib/Analysis/Seminorm.lean
+++ b/Mathlib/Analysis/Seminorm.lean
@@ -919,6 +919,31 @@ theorem closedBall_finset_sup (p : ι → Seminorm 𝕜 E) (s : Finset ι) (x : 
   exact closedBall_finset_sup_eq_iInter _ _ _ hr
 #align seminorm.closed_ball_finset_sup Seminorm.closedBall_finset_sup
 
+theorem ball_smul_ball (p : Seminorm 𝕜 E) (r₁ r₂ : ℝ) :
+    Metric.ball (0 : 𝕜) r₁ • p.ball 0 r₂ ⊆ p.ball 0 (r₁ * r₂) := by
+  rw [Set.subset_def]
+  intro x hx
+  rw [Set.mem_smul] at hx
+  rcases hx with ⟨a, y, ha, hy, hx⟩
+  rw [← hx, mem_ball_zero, map_smul_eq_mul]
+  gcongr
+  · exact mem_ball_zero_iff.mp ha
+  · exact p.mem_ball_zero.mp hy
+#align seminorm.ball_smul_ball Seminorm.ball_smul_ball
+
+theorem closedBall_smul_closedBall (p : Seminorm 𝕜 E) (r₁ r₂ : ℝ) :
+    Metric.closedBall (0 : 𝕜) r₁ • p.closedBall 0 r₂ ⊆ p.closedBall 0 (r₁ * r₂) := by
+  rw [Set.subset_def]
+  intro x hx
+  rw [Set.mem_smul] at hx
+  rcases hx with ⟨a, y, ha, hy, hx⟩
+  rw [← hx, mem_closedBall_zero, map_smul_eq_mul]
+  rw [mem_closedBall_zero_iff] at ha
+  gcongr
+  · exact (norm_nonneg a).trans ha
+  · exact p.mem_closedBall_zero.mp hy
+#align seminorm.closed_ball_smul_closed_ball Seminorm.closedBall_smul_closedBall
+
 @[simp]
 theorem ball_eq_emptyset (p : Seminorm 𝕜 E) {x : E} {r : ℝ} (hr : r ≤ 0) : p.ball x r = ∅ := by
   ext
@@ -933,37 +958,6 @@ theorem closedBall_eq_emptyset (p : Seminorm 𝕜 E) {x : E} {r : ℝ} (hr : r <
   rw [Seminorm.mem_closedBall, Set.mem_empty_iff_false, iff_false_iff, not_le]
   exact hr.trans_le (map_nonneg _ _)
 #align seminorm.closed_ball_eq_emptyset Seminorm.closedBall_eq_emptyset
-
-theorem closedBall_smul_ball (p : Seminorm 𝕜 E) {r₁ : ℝ} (hr₁ : r₁ ≠ 0) (r₂ : ℝ) :
-    Metric.closedBall (0 : 𝕜) r₁ • p.ball 0 r₂ ⊆ p.ball 0 (r₁ * r₂) := by
-  simp only [smul_subset_iff, mem_ball_zero, mem_closedBall_zero_iff, map_smul_eq_mul]
-  refine fun a ha b hb ↦ mul_lt_mul' ha hb (map_nonneg _ _) ?_
-  exact hr₁.lt_or_lt.resolve_left <| ((norm_nonneg a).trans ha).not_lt
-
-theorem ball_smul_closedBall (p : Seminorm 𝕜 E) (r₁ : ℝ) {r₂ : ℝ} (hr₂ : r₂ ≠ 0) :
-    Metric.ball (0 : 𝕜) r₁ • p.closedBall 0 r₂ ⊆ p.ball 0 (r₁ * r₂) := by
-  simp only [smul_subset_iff, mem_ball_zero, mem_closedBall_zero, mem_ball_zero_iff,
-    map_smul_eq_mul]
-  intro a ha b hb
-  rw [mul_comm, mul_comm r₁]
-  refine mul_lt_mul' hb ha (norm_nonneg _) (hr₂.lt_or_lt.resolve_left ?_)
-  exact ((map_nonneg p b).trans hb).not_lt
-
-theorem ball_smul_ball (p : Seminorm 𝕜 E) (r₁ r₂ : ℝ) :
-    Metric.ball (0 : 𝕜) r₁ • p.ball 0 r₂ ⊆ p.ball 0 (r₁ * r₂) := by
-  rcases eq_or_ne r₂ 0 with rfl | hr₂
-  · simp
-  · exact (smul_subset_smul_left (ball_subset_closedBall _ _ _)).trans
-      (ball_smul_closedBall _ _ hr₂)
-#align seminorm.ball_smul_ball Seminorm.ball_smul_ball
-
-theorem closedBall_smul_closedBall (p : Seminorm 𝕜 E) (r₁ r₂ : ℝ) :
-    Metric.closedBall (0 : 𝕜) r₁ • p.closedBall 0 r₂ ⊆ p.closedBall 0 (r₁ * r₂) := by
-  simp only [smul_subset_iff, mem_closedBall_zero, mem_closedBall_zero_iff, map_smul_eq_mul]
-  intro a ha b hb
-  gcongr
-  exact (norm_nonneg _).trans ha
-#align seminorm.closed_ball_smul_closed_ball Seminorm.closedBall_smul_closedBall
 
 -- Porting note: TODO: make that an `iff`
 theorem neg_mem_ball_zero (r : ℝ) (hx : x ∈ ball p 0 r) : -x ∈ ball p 0 r := by

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -942,9 +942,9 @@ instance applySMulCommClass' : SMulCommClass (M₁ →L[R₁] M₁) R₁ M₁ wh
   smul_comm := ContinuousLinearMap.map_smul
 #align continuous_linear_map.apply_smul_comm_class' ContinuousLinearMap.applySMulCommClass'
 
-instance continuousConstSMul : ContinuousConstSMul (M₁ →L[R₁] M₁) M₁ :=
+instance continuousConstSMul_apply : ContinuousConstSMul (M₁ →L[R₁] M₁) M₁ :=
   ⟨ContinuousLinearMap.continuous⟩
-#align continuous_linear_map.has_continuous_const_smul ContinuousLinearMap.continuousConstSMul
+#align continuous_linear_map.has_continuous_const_smul ContinuousLinearMap.continuousConstSMul_apply
 
 end ApplyAction
 

--- a/Mathlib/Topology/Algebra/Module/StrongTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/StrongTopology.lean
@@ -172,6 +172,21 @@ theorem strongTopology.hasBasis_nhds_zero [TopologicalSpace F] [TopologicalAddGr
   strongTopology.hasBasis_nhds_zero_of_basis σ F 𝔖 h𝔖₁ h𝔖₂ (𝓝 0).basis_sets
 #align continuous_linear_map.strong_topology.has_basis_nhds_zero ContinuousLinearMap.strongTopology.hasBasis_nhds_zero
 
+theorem strongTopology.continuousConstSMul {M : Type*}
+    [Monoid M] [DistribMulAction M F] [SMulCommClass 𝕜₂ M F]
+    [TopologicalSpace F] [TopologicalAddGroup F] [ContinuousConstSMul M F] (𝔖 : Set (Set E))
+    (h𝔖₁ : 𝔖.Nonempty) (h𝔖₂ : DirectedOn (· ⊆ ·) 𝔖) :
+    @ContinuousConstSMul M (E →SL[σ] F) (strongTopology σ F 𝔖) _ := by
+  letI := strongTopology σ F 𝔖
+  haveI : TopologicalAddGroup (E →SL[σ] F) := strongTopology.topologicalAddGroup σ F 𝔖
+  refine ⟨fun c ↦ continuous_of_continuousAt_zero (DistribSMul.toAddMonoidHom _ c) ?_⟩
+  have H₁ := strongTopology.hasBasis_nhds_zero σ F _ h𝔖₁ h𝔖₂
+  have H₂ : Filter.Tendsto (c • ·) (𝓝 0 : Filter F) (𝓝 0) :=
+    (continuous_const_smul c).tendsto' 0 _ (smul_zero _)
+  rw [ContinuousAt, map_zero, H₁.tendsto_iff H₁]
+  rintro ⟨s, t⟩ ⟨hs : s ∈ 𝔖, ht : t ∈ 𝓝 0⟩
+  exact ⟨(s, (c • ·) ⁻¹' t), ⟨hs, H₂ ht⟩, fun f  ↦ _root_.id⟩
+
 end General
 
 section BoundedSets
@@ -224,6 +239,13 @@ protected theorem hasBasis_nhds_zero [TopologicalSpace F] [TopologicalAddGroup F
       fun SV => { f : E →SL[σ] F | ∀ x ∈ SV.1, f x ∈ SV.2 } :=
   ContinuousLinearMap.hasBasis_nhds_zero_of_basis (𝓝 0).basis_sets
 #align continuous_linear_map.has_basis_nhds_zero ContinuousLinearMap.hasBasis_nhds_zero
+
+instance continuousConstSMul {M : Type*} [Monoid M] [DistribMulAction M F] [SMulCommClass 𝕜₂ M F]
+    [TopologicalSpace F] [TopologicalAddGroup F] [ContinuousConstSMul M F] :
+    ContinuousConstSMul M (E →SL[σ] F) :=
+  strongTopology.continuousConstSMul σ F {S | Bornology.IsVonNBounded 𝕜₁ S}
+    ⟨∅, Bornology.isVonNBounded_empty 𝕜₁ E⟩
+    (directedOn_of_sup_mem fun _ _ => Bornology.IsVonNBounded.union)
 
 variable (G) [TopologicalSpace F] [TopologicalSpace G]
 


### PR DESCRIPTION
Move parts of the proof of "two uniformities are equal" up while generalizing it.
Also add a `ContinuousConstSMul` instance that needs less assumptions than `ContinuousSMul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
