### PR TITLE
[Merged by Bors] - feat(Algebra/Group/Hom/Instances): missing instances on `AddMonoid.End`

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -655,15 +655,15 @@ class Monoid (M : Type u) extends Semigroup M, MulOneClass M where
 -- Bug #660
 attribute [to_additive existing] Monoid.toMulOneClass
 
-@[default_instance high] instance Monoid.Pow {M : Type*} [Monoid M] : Pow M ℕ :=
+@[default_instance high] instance Monoid.toNatPow {M : Type*} [Monoid M] : Pow M ℕ :=
   ⟨fun x n ↦ Monoid.npow n x⟩
-#align monoid.has_pow Monoid.Pow
+#align monoid.has_pow Monoid.toNatPow
 
-instance AddMonoid.SMul {M : Type*} [AddMonoid M] : SMul ℕ M :=
+instance AddMonoid.toNatSMul {M : Type*} [AddMonoid M] : SMul ℕ M :=
   ⟨AddMonoid.nsmul⟩
-#align add_monoid.has_smul_nat AddMonoid.SMul
+#align add_monoid.has_smul_nat AddMonoid.toNatSMul
 
-attribute [to_additive existing SMul] Monoid.Pow
+attribute [to_additive existing toNatSMul] Monoid.toNatPow
 
 section
 

--- a/Mathlib/Algebra/Group/Hom/Instances.lean
+++ b/Mathlib/Algebra/Group/Hom/Instances.lean
@@ -73,10 +73,10 @@ instance MonoidHom.commGroup {M G} [MulOneClass M] [CommGroup G] : CommGroup (M 
       ext x
       simp [Nat.succ_eq_add_one, zpow_ofNat, -Int.natCast_add] }
 
-instance [AddCommMonoid M] : AddCommMonoid (AddMonoid.End M) :=
+instance AddMonoid.End.instAddCommMonoid [AddCommMonoid M] : AddCommMonoid (AddMonoid.End M) :=
   AddMonoidHom.addCommMonoid
 
-instance AddMonoid.End.semiring [AddCommMonoid M] : Semiring (AddMonoid.End M) :=
+instance AddMonoid.End.instSemiring [AddCommMonoid M] : Semiring (AddMonoid.End M) :=
   { AddMonoid.End.monoid M, AddMonoidHom.addCommMonoid with
     zero_mul := fun _ => AddMonoidHom.ext fun _ => rfl,
     mul_zero := fun _ => AddMonoidHom.ext fun _ => AddMonoidHom.map_zero _,
@@ -93,11 +93,11 @@ theorem AddMonoid.End.natCast_apply [AddCommMonoid M] (n : ℕ) (m : M) :
   rfl
 #align add_monoid.End.nat_cast_apply AddMonoid.End.natCast_apply
 
-instance [AddCommGroup M] : AddCommGroup (AddMonoid.End M) :=
+instance AddMonoid.End.instAddCommGroup [AddCommGroup M] : AddCommGroup (AddMonoid.End M) :=
   AddMonoidHom.addCommGroup
 
-instance [AddCommGroup M] : Ring (AddMonoid.End M) :=
-  { AddMonoid.End.semiring, AddMonoidHom.addCommGroup with
+instance AddMonoid.End.instRing [AddCommGroup M] : Ring (AddMonoid.End M) :=
+  { AddMonoid.End.instSemiring, AddMonoid.End.instAddCommGroup with
     intCast := fun z => z • (1 : AddMonoid.End M),
     intCast_ofNat := ofNat_zsmul _,
     intCast_negSucc := negSucc_zsmul _ }

--- a/Mathlib/Algebra/Module/Hom.lean
+++ b/Mathlib/Algebra/Module/Hom.lean
@@ -112,14 +112,14 @@ end
 instance instModule [Semiring R] [AddCommMonoid A] [Module R A] : Module R (AddMonoid.End A) :=
   AddMonoidHom.instModule
 
-end AddMonoid.End
-
 /-- The tautological action by `AddMonoid.End α` on `α`.
 
 This generalizes `AddMonoid.End.applyDistribMulAction`. -/
-instance AddMonoid.End.applyModule [AddCommMonoid A] : Module (AddMonoid.End A) A where
+instance applyModule [AddCommMonoid A] : Module (AddMonoid.End A) A where
   add_smul _ _ _ := rfl
   zero_smul _ := rfl
+
+end AddMonoid.End
 
 /-! ### Miscelaneous morphisms -/
 

--- a/Mathlib/Algebra/Module/Hom.lean
+++ b/Mathlib/Algebra/Module/Hom.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Module.Pi
+import Mathlib.Algebra.Group.Hom.Instances
 
 #align_import algebra.module.hom from "leanprover-community/mathlib"@"134625f523e737f650a6ea7f0c82a6177e45e622"
 
@@ -19,15 +20,15 @@ We also define bundled versions of `(c • ·)` and `(· • ·)` as `AddMonoidH
 `AddMonoidHom.smul`, respectively.
 -/
 
-set_option autoImplicit true
+variable {R S M A B : Type*}
 
-variable {R S A B : Type*}
+/-! ### Instances for `AddMonoidHom` -/
 
 namespace AddMonoidHom
 
 section
 
-instance distribSMul [AddZeroClass A] [AddCommMonoid B] [DistribSMul M B] :
+instance instDistribSMul [AddZeroClass A] [AddCommMonoid B] [DistribSMul M B] :
     DistribSMul M (A →+ B) where
   smul_add _ _ _ := ext fun _ => smul_add _ _ _
 
@@ -35,12 +36,12 @@ variable [Monoid R] [Monoid S] [AddMonoid A] [AddCommMonoid B]
 
 variable [DistribMulAction R B] [DistribMulAction S B]
 
-instance distribMulAction : DistribMulAction R (A →+ B) where
+instance instDistribMulAction : DistribMulAction R (A →+ B) where
   smul_zero := smul_zero
   smul_add := smul_add
   one_smul _ := ext fun _ => one_smul _ _
   mul_smul _ _ _ := ext fun _ => mul_smul _ _ _
-#align add_monoid_hom.distrib_mul_action AddMonoidHom.distribMulAction
+#align add_monoid_hom.distrib_mul_action AddMonoidHom.instDistribMulAction
 
 @[simp] theorem coe_smul (r : R) (f : A →+ B) : ⇑(r • f) = r • ⇑f := rfl
 #align add_monoid_hom.coe_smul AddMonoidHom.coe_smul
@@ -64,6 +65,66 @@ instance isCentralScalar [DistribMulAction Rᵐᵒᵖ B] [IsCentralScalar R B] :
 
 end
 
+instance instModule [Semiring R] [AddMonoid A] [AddCommMonoid B] [Module R B] : Module R (A →+ B) :=
+  { add_smul := fun _ _ _=> ext fun _ => add_smul _ _ _
+    zero_smul := fun _ => ext fun _ => zero_smul _ _ }
+#align add_monoid_hom.module AddMonoidHom.instModule
+
+end AddMonoidHom
+
+/-!
+### Instances for `AddMonoid.End`
+
+These are direct copies of the instances above.
+-/
+
+namespace AddMonoid.End
+
+section
+
+variable [Monoid R] [Monoid S] [AddCommMonoid A]
+
+instance instDistribSMul [DistribSMul M A] : DistribSMul M (AddMonoid.End A) :=
+  AddMonoidHom.instDistribSMul
+
+variable [DistribMulAction R A] [DistribMulAction S A]
+
+instance instDistribMulAction : DistribMulAction R (AddMonoid.End A) :=
+  AddMonoidHom.instDistribMulAction
+
+@[simp] theorem coe_smul (r : R) (f : AddMonoid.End A) : ⇑(r • f) = r • ⇑f := rfl
+
+theorem smul_apply (r : R) (f : AddMonoid.End A) (x : A) : (r • f) x = r • f x :=
+  rfl
+
+instance smulCommClass [SMulCommClass R S A] : SMulCommClass R S (AddMonoid.End A) :=
+  AddMonoidHom.smulCommClass
+
+instance isScalarTower [SMul R S] [IsScalarTower R S A] : IsScalarTower R S (AddMonoid.End A) :=
+  AddMonoidHom.isScalarTower
+
+instance isCentralScalar [DistribMulAction Rᵐᵒᵖ A] [IsCentralScalar R A] :
+    IsCentralScalar R (AddMonoid.End A) :=
+  AddMonoidHom.isCentralScalar
+
+end
+
+instance instModule [Semiring R] [AddCommMonoid A] [Module R A] : Module R (AddMonoid.End A) :=
+  AddMonoidHom.instModule
+
+end AddMonoid.End
+
+/-- The tautological action by `AddMonoid.End α` on `α`.
+
+This generalizes `AddMonoid.End.applyDistribMulAction`. -/
+instance AddMonoid.End.applyModule [AddCommMonoid A] : Module (AddMonoid.End A) A where
+  add_smul _ _ _ := rfl
+  zero_smul _ := rfl
+
+/-! ### Miscelaneous morphisms -/
+
+namespace AddMonoidHom
+
 /-- Scalar multiplication on the left as an additive monoid homomorphism. -/
 @[simps! (config := .asFn)]
 protected def smulLeft [Monoid M] [AddMonoid A] [DistribMulAction M A] (c : M) : A →+ A :=
@@ -77,16 +138,4 @@ protected def smul [Semiring R] [AddCommMonoid M] [Module R M] : R →+ M →+ M
 @[simp] theorem coe_smul' [Semiring R] [AddCommMonoid M] [Module R M] :
     ⇑(.smul : R →+ M →+ M) = AddMonoidHom.smulLeft := rfl
 
-instance module [Semiring R] [AddMonoid A] [AddCommMonoid B] [Module R B] : Module R (A →+ B) :=
-  { add_smul := fun _ _ _=> ext fun _ => add_smul _ _ _
-    zero_smul := fun _ => ext fun _ => zero_smul _ _ }
-#align add_monoid_hom.module AddMonoidHom.module
-
 end AddMonoidHom
-
-/-- The tautological action by `AddMonoid.End α` on `α`.
-
-This generalizes `AddMonoid.End.applyDistribMulAction`. -/
-instance AddMonoid.End.applyModule [AddCommMonoid A] : Module (AddMonoid.End A) A where
-  add_smul _ _ _ := rfl
-  zero_smul _ := rfl

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -258,16 +258,17 @@ instance : Add (CentroidHom α) :=
 instance : Mul (CentroidHom α) :=
   ⟨comp⟩
 
-instance hasNsmul : SMul ℕ (CentroidHom α) :=
-  ⟨fun n f ↦
-    { ((SMul.smul n f) : α →+ α) with
-        map_mul_left' := fun a b ↦ by
-          change n • f (a * b) = a * n • f b
-          rw [map_mul_left f, ← mul_smul_comm]
-        map_mul_right' := fun a b ↦ by
-          change n • f (a * b) = n • f a * b
-          rw [map_mul_right f, ← smul_mul_assoc] }⟩
-#align centroid_hom.has_nsmul CentroidHom.hasNsmul
+instance instSmul {M} [Monoid M] [DistribMulAction M α] [SMulCommClass M α α] [IsScalarTower M α α] :
+    SMul M (CentroidHom α) where
+  smul n f :=
+    { (n • f : α →+ α) with
+      map_mul_left' := fun a b ↦ by
+        change n • f (a * b) = a * n • f b
+        rw [map_mul_left f, ← mul_smul_comm]
+      map_mul_right' := fun a b ↦ by
+        change n • f (a * b) = n • f a * b
+        rw [map_mul_right f, ← smul_mul_assoc] }
+#noalign centroid_hom.has_nsmul
 
 instance hasNpowNat : Pow (CentroidHom α) ℕ :=
   ⟨fun f n ↦
@@ -426,16 +427,7 @@ instance : Sub (CentroidHom α) :=
         change (FunLike.coe f - FunLike.coe g) (a * b) = ((FunLike.coe f - FunLike.coe g) a) * b
         simp [map_mul_right, sub_mul] }⟩
 
-instance hasZsmul : SMul ℤ (CentroidHom α) :=
-  ⟨fun n f ↦
-    { (SMul.smul n f : α →+ α) with
-      map_mul_left' := fun a b ↦ by
-        change n • f (a * b) = a * n • f b
-        rw [map_mul_left f, ← mul_smul_comm]
-      map_mul_right' := fun a b ↦ by
-        change n • f (a * b) = n • f a * b
-        rw [map_mul_right f, ← smul_mul_assoc] }⟩
-#align centroid_hom.has_zsmul CentroidHom.hasZsmul
+#noalign centroid_hom.has_zsmul
 
 instance : IntCast (CentroidHom α) where intCast z := z • (1 : CentroidHom α)
 

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -258,17 +258,16 @@ instance : Add (CentroidHom α) :=
 instance : Mul (CentroidHom α) :=
   ⟨comp⟩
 
-instance instSmul {M} [Monoid M] [DistribMulAction M α] [SMulCommClass M α α] [IsScalarTower M α α] :
-    SMul M (CentroidHom α) where
-  smul n f :=
-    { (n • f : α →+ α) with
-      map_mul_left' := fun a b ↦ by
-        change n • f (a * b) = a * n • f b
-        rw [map_mul_left f, ← mul_smul_comm]
-      map_mul_right' := fun a b ↦ by
-        change n • f (a * b) = n • f a * b
-        rw [map_mul_right f, ← smul_mul_assoc] }
-#noalign centroid_hom.has_nsmul
+instance hasNsmul : SMul ℕ (CentroidHom α) :=
+  ⟨fun n f ↦
+    { ((SMul.smul n f) : α →+ α) with
+        map_mul_left' := fun a b ↦ by
+          change n • f (a * b) = a * n • f b
+          rw [map_mul_left f, ← mul_smul_comm]
+        map_mul_right' := fun a b ↦ by
+          change n • f (a * b) = n • f a * b
+          rw [map_mul_right f, ← smul_mul_assoc] }⟩
+#align centroid_hom.has_nsmul CentroidHom.hasNsmul
 
 instance hasNpowNat : Pow (CentroidHom α) ℕ :=
   ⟨fun f n ↦
@@ -427,7 +426,16 @@ instance : Sub (CentroidHom α) :=
         change (FunLike.coe f - FunLike.coe g) (a * b) = ((FunLike.coe f - FunLike.coe g) a) * b
         simp [map_mul_right, sub_mul] }⟩
 
-#noalign centroid_hom.has_zsmul
+instance hasZsmul : SMul ℤ (CentroidHom α) :=
+  ⟨fun n f ↦
+    { (SMul.smul n f : α →+ α) with
+      map_mul_left' := fun a b ↦ by
+        change n • f (a * b) = a * n • f b
+        rw [map_mul_left f, ← mul_smul_comm]
+      map_mul_right' := fun a b ↦ by
+        change n • f (a * b) = n • f a * b
+        rw [map_mul_right f, ← smul_mul_assoc] }⟩
+#align centroid_hom.has_zsmul CentroidHom.hasZsmul
 
 instance : IntCast (CentroidHom α) where intCast z := z • (1 : CentroidHom α)
 

--- a/Mathlib/Data/ZMod/IntUnitsPower.lean
+++ b/Mathlib/Data/ZMod/IntUnitsPower.lean
@@ -59,7 +59,7 @@ instance Int.instUnitsPow : Pow ℤˣ R where
   pow u r := Additive.toMul (r • Additive.ofMul u)
 
 -- The above instance forms no typeclass diamonds with the standard power operators
-example : Int.instUnitsPow = Monoid.Pow := rfl
+example : Int.instUnitsPow = Monoid.toNatPow := rfl
 example : Int.instUnitsPow = DivInvMonoid.Pow := rfl
 
 @[simp] lemma ofMul_uzpow (u : ℤˣ) (r : R) : Additive.ofMul (u ^ r) = r • Additive.ofMul u := rfl


### PR DESCRIPTION
We already had these instance for `AddMonoidHom`, but did not copy them across.

This also corrects some instances names, both for cosmetic reasons, and to avoid name clashes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
