### PR TITLE
[Merged by Bors] - feat: make `imp_false` a simp-lemma

### DIFF
--- a/Archive/Examples/IfNormalization/WithoutAesop.lean
+++ b/Archive/Examples/IfNormalization/WithoutAesop.lean
@@ -100,8 +100,7 @@ def normalize' (l : AList (fun _ : ℕ => Bool)) :
             simp_all
           · simp_all? says simp_all only [ne_eq, hasNestedIf, Bool.or_self, hasConstantIf,
               and_self, hasRedundantIf, Bool.or_false, beq_eq_false_iff_ne, not_false_eq_true,
-              disjoint, List.disjoint, decide_not, Bool.and_true, Bool.and_eq_true,
-              Bool.not_eq_true', decide_eq_false_iff_not, true_and]
+              disjoint, List.disjoint, decide_True, Bool.and_self]
             rfl
         · have := ht₃ w
           have := he₃ w

--- a/Archive/Examples/IfNormalization/WithoutAesop.lean
+++ b/Archive/Examples/IfNormalization/WithoutAesop.lean
@@ -93,7 +93,7 @@ def normalize' (l : AList (fun _ : ℕ => Bool)) :
         · have := ht₃ v
           have := he₃ v
           simp_all? says simp_all only [Option.elim, ne_eq, normalized, Bool.and_eq_true,
-            Bool.not_eq_true', AList.lookup_insert, imp_false]
+              Bool.not_eq_true', AList.lookup_insert, imp_false]
           obtain ⟨⟨⟨tn, tc⟩, tr⟩, td⟩ := ht₂
           split <;> rename_i h'
           · subst h'

--- a/Archive/Examples/IfNormalization/WithoutAesop.lean
+++ b/Archive/Examples/IfNormalization/WithoutAesop.lean
@@ -93,7 +93,7 @@ def normalize' (l : AList (fun _ : ℕ => Bool)) :
         · have := ht₃ v
           have := he₃ v
           simp_all? says simp_all only [Option.elim, ne_eq, normalized, Bool.and_eq_true,
-              Bool.not_eq_true', AList.lookup_insert]
+            Bool.not_eq_true', AList.lookup_insert, imp_false]
           obtain ⟨⟨⟨tn, tc⟩, tr⟩, td⟩ := ht₂
           split <;> rename_i h'
           · subst h'
@@ -102,7 +102,7 @@ def normalize' (l : AList (fun _ : ℕ => Bool)) :
               and_self, hasRedundantIf, Bool.or_false, beq_eq_false_iff_ne, not_false_eq_true,
               disjoint, List.disjoint, decide_not, Bool.and_true, Bool.and_eq_true,
               Bool.not_eq_true', decide_eq_false_iff_not, true_and]
-            constructor <;> assumption
+            rfl
         · have := ht₃ w
           have := he₃ w
           by_cases h : w = v

--- a/Archive/Examples/IfNormalization/WithoutAesop.lean
+++ b/Archive/Examples/IfNormalization/WithoutAesop.lean
@@ -101,7 +101,6 @@ def normalize' (l : AList (fun _ : ℕ => Bool)) :
           · simp_all? says simp_all only [ne_eq, hasNestedIf, Bool.or_self, hasConstantIf,
               and_self, hasRedundantIf, Bool.or_false, beq_eq_false_iff_ne, not_false_eq_true,
               disjoint, List.disjoint, decide_True, Bool.and_self]
-            rfl
         · have := ht₃ w
           have := he₃ w
           by_cases h : w = v

--- a/Mathlib/GroupTheory/Perm/List.lean
+++ b/Mathlib/GroupTheory/Perm/List.lean
@@ -113,8 +113,6 @@ theorem mem_of_formPerm_apply_mem (x : α) (l : List α) (h : l.formPerm x ∈ l
         List.mem_cons, swap_apply_def, ite_eq_left_iff] at h
       simp only [List.mem_cons]
       rcases h with h | h | h <;> split_ifs at h with h1 <;> try { aesop }
-      · simp [h1, imp_false] at h
-        simp [h]
 #align list.mem_of_form_perm_apply_mem List.mem_of_formPerm_apply_mem
 
 theorem formPerm_mem_iff_mem : l.formPerm x ∈ l ↔ x ∈ l :=

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -39,7 +39,7 @@ section Miscellany
 --   And.decidable Or.decidable Decidable.false Xor.decidable Iff.decidable Decidable.true
 --   Implies.decidable Not.decidable Ne.decidable Bool.decidableEq Decidable.toBool
 
-attribute [simp] cast_eq cast_heq
+attribute [simp] cast_eq cast_heq imp_false
 
 /-- An identity function with its main argument implicit. This will be printed as `hidden` even
 if it is applied to a large term, so it can be used for elision,

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -281,7 +281,7 @@ theorem realize_top : (⊤ : L.BoundedFormula α l).Realize v xs ↔ True := by 
 
 @[simp]
 theorem realize_inf : (φ ⊓ ψ).Realize v xs ↔ φ.Realize v xs ∧ ψ.Realize v xs := by
-  simp [Inf.inf, Realize]; tauto
+  simp [Inf.inf, Realize]
 #align first_order.language.bounded_formula.realize_inf FirstOrder.Language.BoundedFormula.realize_inf
 
 @[simp]

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -1328,12 +1328,10 @@ theorem frequently_iff {f : Filter α} {P : α → Prop} :
   rfl
 #align filter.frequently_iff Filter.frequently_iff
 
-@[simp]
 theorem not_eventually {p : α → Prop} {f : Filter α} : (¬∀ᶠ x in f, p x) ↔ ∃ᶠ x in f, ¬p x := by
   simp [Filter.Frequently]
 #align filter.not_eventually Filter.not_eventually
 
-@[simp]
 theorem not_frequently {p : α → Prop} {f : Filter α} : (¬∃ᶠ x in f, p x) ↔ ∀ᶠ x in f, ¬p x := by
   simp only [Filter.Frequently, not_not]
 #align filter.not_frequently Filter.not_frequently
@@ -1344,7 +1342,7 @@ theorem frequently_true_iff_neBot (f : Filter α) : (∃ᶠ _ in f, True) ↔ Ne
 #align filter.frequently_true_iff_ne_bot Filter.frequently_true_iff_neBot
 
 @[simp]
-theorem frequently_false (f : Filter α) : ¬∃ᶠ _ in f, False := by simp
+theorem frequently_false (f : Filter α) : ¬∃ᶠ _ in f, False := by simp [not_frequently]
 #align filter.frequently_false Filter.frequently_false
 
 @[simp]
@@ -1399,7 +1397,7 @@ theorem frequently_and_distrib_right {f : Filter α} {p : α → Prop} {q : Prop
 #align filter.frequently_and_distrib_right Filter.frequently_and_distrib_right
 
 @[simp]
-theorem frequently_bot {p : α → Prop} : ¬∃ᶠ x in ⊥, p x := by simp
+theorem frequently_bot {p : α → Prop} : ¬∃ᶠ x in ⊥, p x := by simp [not_frequently]
 #align filter.frequently_bot Filter.frequently_bot
 
 @[simp]

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -1328,10 +1328,12 @@ theorem frequently_iff {f : Filter α} {P : α → Prop} :
   rfl
 #align filter.frequently_iff Filter.frequently_iff
 
+@[simp]
 theorem not_eventually {p : α → Prop} {f : Filter α} : (¬∀ᶠ x in f, p x) ↔ ∃ᶠ x in f, ¬p x := by
   simp [Filter.Frequently]
 #align filter.not_eventually Filter.not_eventually
 
+@[simp]
 theorem not_frequently {p : α → Prop} {f : Filter α} : (¬∃ᶠ x in f, p x) ↔ ∀ᶠ x in f, ¬p x := by
   simp only [Filter.Frequently, not_not]
 #align filter.not_frequently Filter.not_frequently
@@ -1342,7 +1344,7 @@ theorem frequently_true_iff_neBot (f : Filter α) : (∃ᶠ _ in f, True) ↔ Ne
 #align filter.frequently_true_iff_ne_bot Filter.frequently_true_iff_neBot
 
 @[simp]
-theorem frequently_false (f : Filter α) : ¬∃ᶠ _ in f, False := by simp [not_frequently]
+theorem frequently_false (f : Filter α) : ¬∃ᶠ _ in f, False := by simp
 #align filter.frequently_false Filter.frequently_false
 
 @[simp]
@@ -1364,21 +1366,19 @@ theorem frequently_or_distrib_right {f : Filter α} [NeBot f] {p : α → Prop} 
     (∃ᶠ x in f, p x ∨ q) ↔ (∃ᶠ x in f, p x) ∨ q := by simp
 #align filter.frequently_or_distrib_right Filter.frequently_or_distrib_right
 
-@[simp]
 theorem frequently_imp_distrib {f : Filter α} {p q : α → Prop} :
     (∃ᶠ x in f, p x → q x) ↔ (∀ᶠ x in f, p x) → ∃ᶠ x in f, q x := by
-  simp [imp_iff_not_or, not_eventually, frequently_or_distrib]
+  simp [imp_iff_not_or]
 #align filter.frequently_imp_distrib Filter.frequently_imp_distrib
 
 theorem frequently_imp_distrib_left {f : Filter α} [NeBot f] {p : Prop} {q : α → Prop} :
-    (∃ᶠ x in f, p → q x) ↔ p → ∃ᶠ x in f, q x := by simp
+    (∃ᶠ x in f, p → q x) ↔ p → ∃ᶠ x in f, q x := by simp [frequently_imp_distrib]
 #align filter.frequently_imp_distrib_left Filter.frequently_imp_distrib_left
 
 theorem frequently_imp_distrib_right {f : Filter α} [NeBot f] {p : α → Prop} {q : Prop} :
-    (∃ᶠ x in f, p x → q) ↔ (∀ᶠ x in f, p x) → q := by simp
+    (∃ᶠ x in f, p x → q) ↔ (∀ᶠ x in f, p x) → q := by simp [frequently_imp_distrib]
 #align filter.frequently_imp_distrib_right Filter.frequently_imp_distrib_right
 
-@[simp]
 theorem eventually_imp_distrib_right {f : Filter α} {p : α → Prop} {q : Prop} :
     (∀ᶠ x in f, p x → q) ↔ (∃ᶠ x in f, p x) → q := by
   simp only [imp_iff_not_or, eventually_or_distrib_right, not_frequently]
@@ -1397,7 +1397,7 @@ theorem frequently_and_distrib_right {f : Filter α} {p : α → Prop} {q : Prop
 #align filter.frequently_and_distrib_right Filter.frequently_and_distrib_right
 
 @[simp]
-theorem frequently_bot {p : α → Prop} : ¬∃ᶠ x in ⊥, p x := by simp [not_frequently]
+theorem frequently_bot {p : α → Prop} : ¬∃ᶠ x in ⊥, p x := by simp
 #align filter.frequently_bot Filter.frequently_bot
 
 @[simp]


### PR DESCRIPTION
* This shortens various proofs
* There is already a unification hint in core from `¬ p` to `p → False`, which is probably why we didn't miss this simp-lemma too badly.
* There was an inconsistency that `simp` pull out most connectives into `Filter.eventually`/`Filter.frequently`, but pushed negations inside. This loops together with this new simp-lemma, and the fact that there is a unification hint . So I removed some simp attributes in `Filter.Basic`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
