### PR TITLE
[Merged by Bors] - feat: existence of simultaneous eigenvectors given simultaneous generalized eigenvectors for Lie modules

### DIFF
--- a/Mathlib/Algebra/Lie/Weights/Linear.lean
+++ b/Mathlib/Algebra/Lie/Weights/Linear.lean
@@ -31,6 +31,9 @@ or `R` has characteristic zero.
    Abelian Lie algebra, the weights of any Lie module are linear.
  * `LieModule.instLinearWeightsOfIsLieAbelian`: a typeclass instance encoding the fact that in
    characteristic zero, the weights of any finite-dimensional Lie module are linear.
+ * `LieModule.exists_forall_lie_eq_smul_ofweightSpace_ne_bot`: existence of simultaneous
+   eigenvectors from existence of simultaneous generalized eigenvectors for Noetherian Lie modules
+   with linear weights.
 
 -/
 
@@ -173,13 +176,7 @@ instance : LieModule R L (shiftedWeightSpace R L M χ) where
 
 /-- Forgetting the action of `L`, the spaces `weightSpace M χ` and `shiftedWeightSpace R L M χ` are
 equivalent. -/
-@[simps] def shift : weightSpace M χ ≃ₗ[R] shiftedWeightSpace R L M χ where
-  toFun := id
-  map_add' _ _ := rfl
-  map_smul' _ _ := rfl
-  invFun := id
-  left_inv _ := rfl
-  right_inv _ := rfl
+@[simps!] def shift : weightSpace M χ ≃ₗ[R] shiftedWeightSpace R L M χ := LinearEquiv.refl R _
 
 lemma toEndomorphism_eq (x : L) :
     toEndomorphism R L (shiftedWeightSpace R L M χ) x =
@@ -192,5 +189,19 @@ instance [IsNoetherian R M] : IsNilpotent R L (shiftedWeightSpace R L M χ) :=
   LieModule.isNilpotent_iff_forall'.mpr fun x ↦ isNilpotent_toEndomorphism_sub_algebraMap M χ x
 
 end shiftedWeightSpace
+
+/-- Given a Lie module `M` of a Lie algebra `L` with coefficients in `R`, if a function `χ : L → R`
+has a simultaneous generalized eigenvector for the action of `L` then it has a simultaneous true
+eigenvector, provided `M` is Noetherian and has linear weights. -/
+lemma exists_forall_lie_eq_smul_ofweightSpace_ne_bot
+    [IsNoetherian R M] (hχ : weightSpace M χ ≠ ⊥) :
+    ∃ m : M, m ≠ 0 ∧ ∀ x : L, ⁅x, m⁆ = χ x • m := by
+  replace hχ : Nontrivial (shiftedWeightSpace R L M χ) :=
+    (LieSubmodule.nontrivial_iff_ne_bot R L M).mpr hχ
+  obtain ⟨⟨⟨m, _⟩, hm₁⟩, hm₂⟩ :=
+    @exists_ne _ (nontrivial_max_triv_of_isNilpotent R L (shiftedWeightSpace R L M χ)) 0
+  simp_rw [LieSubmodule.mem_coeSubmodule, mem_maxTrivSubmodule, Subtype.ext_iff,
+    shiftedWeightSpace.coe_lie_shiftedWeightSpace_apply, ZeroMemClass.coe_zero, sub_eq_zero] at hm₁
+  exact ⟨m, by simpa using hm₂, hm₁⟩
 
 end LieModule

--- a/Mathlib/Algebra/Lie/Weights/Linear.lean
+++ b/Mathlib/Algebra/Lie/Weights/Linear.lean
@@ -17,6 +17,7 @@ non-linear weights do exist. For example if we take:
  * `R`: the field with two elements (or indeed any perfect field of characteristic two),
  * `L`: `sl₂` (this is nilpotent in characteristic two),
  * `M`: the natural two-dimensional representation of `L`,
+
 then there is a single weight and it is non-linear. (See remark following Proposition 9 of
 chapter VII, §1.3 in [N. Bourbaki, Chapters 7--9](bourbaki1975b).)
 
@@ -31,7 +32,7 @@ or `R` has characteristic zero.
    Abelian Lie algebra, the weights of any Lie module are linear.
  * `LieModule.instLinearWeightsOfIsLieAbelian`: a typeclass instance encoding the fact that in
    characteristic zero, the weights of any finite-dimensional Lie module are linear.
- * `LieModule.exists_forall_lie_eq_smul_ofweightSpace_ne_bot`: existence of simultaneous
+ * `LieModule.exists_forall_lie_eq_smul_of_weightSpace_ne_bot`: existence of simultaneous
    eigenvectors from existence of simultaneous generalized eigenvectors for Noetherian Lie modules
    with linear weights.
 
@@ -193,7 +194,7 @@ end shiftedWeightSpace
 /-- Given a Lie module `M` of a Lie algebra `L` with coefficients in `R`, if a function `χ : L → R`
 has a simultaneous generalized eigenvector for the action of `L` then it has a simultaneous true
 eigenvector, provided `M` is Noetherian and has linear weights. -/
-lemma exists_forall_lie_eq_smul_ofweightSpace_ne_bot
+lemma exists_forall_lie_eq_smul_of_weightSpace_ne_bot
     [IsNoetherian R M] (hχ : weightSpace M χ ≠ ⊥) :
     ∃ m : M, m ≠ 0 ∧ ∀ x : L, ⁅x, m⁆ = χ x • m := by
   replace hχ : Nontrivial (shiftedWeightSpace R L M χ) :=


### PR DESCRIPTION



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
