### PR TITLE
[Merged by Bors] - feat(NumberTheory/EulerProduct): add Euler Products for zeta function and Dirichlet L series

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2679,6 +2679,7 @@ import Mathlib.NumberTheory.DirichletCharacter.Basic
 import Mathlib.NumberTheory.DirichletCharacter.Bounds
 import Mathlib.NumberTheory.Divisors
 import Mathlib.NumberTheory.EulerProduct.Basic
+import Mathlib.NumberTheory.EulerProduct.DirichletLSeries
 import Mathlib.NumberTheory.FLT.Basic
 import Mathlib.NumberTheory.FLT.Four
 import Mathlib.NumberTheory.FermatPsp

--- a/Mathlib/Data/Complex/Abs.lean
+++ b/Mathlib/Data/Complex/Abs.lean
@@ -349,7 +349,6 @@ theorem lim_abs (f : CauSeq ℂ Complex.abs) : lim (cauSeqAbs f) = Complex.abs (
     ⟨i, fun j hj => lt_of_le_of_lt (Complex.abs.abs_abv_sub_le_abv_sub _ _) (hi j hj)⟩
 #align complex.lim_abs Complex.lim_abs
 
-
 lemma ne_zero_of_one_lt_re {s : ℂ} (hs : 1 < s.re) : s ≠ 0 :=
   fun h ↦ ((zero_re ▸ h ▸ hs).trans zero_lt_one).false
 

--- a/Mathlib/Data/Complex/Abs.lean
+++ b/Mathlib/Data/Complex/Abs.lean
@@ -348,3 +348,13 @@ theorem lim_abs (f : CauSeq ℂ Complex.abs) : lim (cauSeqAbs f) = Complex.abs (
     let ⟨i, hi⟩ := equiv_lim f ε ε0
     ⟨i, fun j hj => lt_of_le_of_lt (Complex.abs.abs_abv_sub_le_abv_sub _ _) (hi j hj)⟩
 #align complex.lim_abs Complex.lim_abs
+
+/-!
+### Some useful lemmas
+-/
+
+lemma ne_zero_of_one_lt_re {s : ℂ} (hs : 1 < s.re) : s ≠ 0 :=
+  fun h ↦ ((zero_re ▸ h ▸ hs).trans zero_lt_one).false
+
+lemma re_neg_ne_zero_of_one_lt_re {s : ℂ} (hs : 1 < s.re) : (-s).re ≠ 0 :=
+  ne_iff_lt_or_gt.mpr <| Or.inl <| neg_re s ▸ by linarith

--- a/Mathlib/Data/Complex/Abs.lean
+++ b/Mathlib/Data/Complex/Abs.lean
@@ -349,9 +349,6 @@ theorem lim_abs (f : CauSeq ℂ Complex.abs) : lim (cauSeqAbs f) = Complex.abs (
     ⟨i, fun j hj => lt_of_le_of_lt (Complex.abs.abs_abv_sub_le_abv_sub _ _) (hi j hj)⟩
 #align complex.lim_abs Complex.lim_abs
 
-/-!
-### Some useful lemmas
--/
 
 lemma ne_zero_of_one_lt_re {s : ℂ} (hs : 1 < s.re) : s ≠ 0 :=
   fun h ↦ ((zero_re ▸ h ▸ hs).trans zero_lt_one).false

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -69,7 +69,7 @@ lemma Complex.re_neg_ne_zero_of_one_lt_re (hs : 1 < s.re) : (-s).re ≠ 0 :=
 
 /-- When `s.re > 1`, the map `n ↦ n^(-s)` is norm-summable. -/
 lemma summable_riemannZetaSummand (hs : 1 < s.re) :
-  Summable (fun n ↦ ‖riemannZetaSummandHom (Complex.ne_zero_of_one_lt_re hs) n‖) := by
+    Summable (fun n ↦ ‖riemannZetaSummandHom (Complex.ne_zero_of_one_lt_re hs) n‖) := by
   simp only [riemannZetaSummandHom, riemannZetaSummand, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk]
   convert Real.summable_nat_rpow_inv.mpr hs with n
   rw [n.complex_norm_cpow_eq_rpow_re <| Complex.re_neg_ne_zero_of_one_lt_re hs, neg_re,
@@ -77,7 +77,7 @@ lemma summable_riemannZetaSummand (hs : 1 < s.re) :
 
 /-- When `s.re > 1`, the map `n ↦ χ(n) * n^(-s)` is norm-summable. -/
 lemma summable_dirichletSummand {N : ℕ} (χ : DirichletCharacter ℂ N) (hs : 1 < s.re) :
-  Summable (fun n ↦ ‖dirichletSummandHom χ (Complex.ne_zero_of_one_lt_re hs) n‖) := by
+    Summable (fun n ↦ ‖dirichletSummandHom χ (Complex.ne_zero_of_one_lt_re hs) n‖) := by
   simp only [dirichletSummandHom, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, norm_mul]
   exact (summable_riemannZetaSummand hs).of_nonneg_of_le (fun _ ↦ by positivity)
     (fun n ↦ mul_le_of_le_one_left (norm_nonneg _) <| χ.norm_le_one n)

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -24,41 +24,38 @@ for Dirichlet L-functions.
 
 open Complex
 
-/-- The `n`th summand in the Dirichlet series giving the Riemann ζ function at `s`. -/
-noncomputable
-def riemannZetaSummand (s : ℂ) (n : ℕ) : ℂ := (n : ℂ) ^ (-s)
-
-lemma riemannZetaSummand.mul (s : ℂ) (m n : ℕ) :
-    riemannZetaSummand s (m * n) = riemannZetaSummand s m * riemannZetaSummand s n := by
-  simpa [riemannZetaSummand] using mul_cpow_ofReal_nonneg m.cast_nonneg n.cast_nonneg _
-
 variable {s : ℂ}
 
 /-- When `s ≠ 0`, the map `n ↦ n^(-s)` is completely multiplicative and vanishes at zero. -/
 noncomputable
 def riemannZetaSummandHom (hs : s ≠ 0) : ℕ →*₀ ℂ where
-  toFun := riemannZetaSummand s
-  map_zero' := by simpa [riemannZetaSummand]
-  map_one' := by simp [riemannZetaSummand]
-  map_mul' := riemannZetaSummand.mul s
+  toFun n := (n : ℂ) ^ (-s)
+  map_zero' := by simp [hs]
+  map_one' := by simp
+  map_mul' m n := by
+    simpa only [Nat.cast_mul, ofReal_nat_cast]
+      using mul_cpow_ofReal_nonneg m.cast_nonneg n.cast_nonneg _
 
 /-- When `χ` is a Dirichlet character and `s ≠ 0`, the map `n ↦ χ n * n^(-s)` is completely
 multiplicative and vanishes at zero. -/
 noncomputable
 def dirichletSummandHom {n : ℕ} (χ : DirichletCharacter ℂ n) (hs : s ≠ 0) : ℕ →*₀ ℂ where
-  toFun n := χ n * riemannZetaSummand s n
-  map_zero' := by simp [riemannZetaSummand, hs]
-  map_one' := by simp [riemannZetaSummand]
+  toFun n := χ n * (n : ℂ) ^ (-s)
+  map_zero' := by simp [hs]
+  map_one' := by simp
   map_mul' m n := by
-    simpa only [Nat.cast_mul, IsUnit.mul_iff, not_and, map_mul, riemannZetaSummand.mul]
+    simp_rw [← ofReal_nat_cast]
+    simpa only [Nat.cast_mul, IsUnit.mul_iff, not_and, map_mul, ofReal_mul,
+      mul_cpow_ofReal_nonneg m.cast_nonneg n.cast_nonneg _]
       using mul_mul_mul_comm ..
 
+example (n : ℕ) : (n : ℂ) = (n : ℝ) := by rw [ofReal_nat_cast]
 /-- When `s.re > 1`, the map `n ↦ n^(-s)` is norm-summable. -/
 lemma summable_riemannZetaSummand (hs : 1 < s.re) :
     Summable (fun n ↦ ‖riemannZetaSummandHom (ne_zero_of_one_lt_re hs) n‖) := by
-  simp only [riemannZetaSummandHom, riemannZetaSummand, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk]
+  simp only [riemannZetaSummandHom, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk]
   convert Real.summable_nat_rpow_inv.mpr hs with n
-  rw [(show (n : ℂ) = (n : ℝ) from rfl), Complex.norm_eq_abs,
+  rw [← ofReal_nat_cast, Complex.norm_eq_abs,
     abs_cpow_eq_rpow_re_of_nonneg (Nat.cast_nonneg n) <| re_neg_ne_zero_of_one_lt_re hs,
     neg_re, Real.rpow_neg <| Nat.cast_nonneg n]
 
@@ -79,7 +76,7 @@ theorem riemannZeta_eulerProduct (hs : 1 < s.re) :
   have hsum := summable_riemannZetaSummand hs
   convert eulerProduct_completely_multiplicative hsum
   rw [zeta_eq_tsum_one_div_nat_add_one_cpow hs, tsum_eq_zero_add hsum.of_norm, map_zero, zero_add]
-  simp [riemannZetaSummandHom, riemannZetaSummand, cpow_neg]
+  simp [riemannZetaSummandHom, cpow_neg]
 
 /-- The Euler product for Dirichlet L-series, valid for `s.re > 1`. -/
 -- TODO: state in terms of `∏'` once this is in Mathlib

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -81,5 +81,5 @@ theorem riemannZeta_eulerProduct (hs : 1 < s.re) :
 -- TODO: state in terms of `∏'` once this is in Mathlib
 theorem dirichletLSeries_eulerProduct {N : ℕ} (χ : DirichletCharacter ℂ N) (hs : 1 < s.re) :
     Tendsto (fun n : ℕ ↦ ∏ p in primesBelow n, (1 - χ p * (p : ℂ) ^ (-s))⁻¹) atTop
-      (𝓝 (∑' n : ℕ, dirichletSummandHom χ (Complex.ne_zero_of_one_lt_re hs) n)) := by
+      (𝓝 (∑' n : ℕ, dirichletSummandHom χ (ne_zero_of_one_lt_re hs) n)) := by
   convert eulerProduct_completely_multiplicative <| summable_dirichletSummand χ hs

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2023 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Stoll
+-/
+import Mathlib.NumberTheory.DirichletCharacter.Bounds
+import Mathlib.NumberTheory.EulerProduct.Basic
+import Mathlib.NumberTheory.ZetaFunction
+
+/-!
+# The Euler Product for the Riemann Zeta Function and Dirichlet L-Series
+
+The first main result of this file is `riemannZeta_eulerProduct`, which states
+the Euler Product formula for the Riemann ζ function
+$$\prod_p \frac{1}{1 - p^{-s}}
+   = \lim_{n \to \infty} \prod_{p < n} \frac{1}{1 - p^{-s}} = \zeta(s)$$
+for $s$ with real part $> 1$ ($p$ runs through the primes).
+The formalized statement is the second equality above, since infinite products are not yet
+available in Mathlib.
+
+The second result is `dirichletLSeries_eulerProduct`, which is the analogous statement
+for Dirichlet L-functions.
+-/
+
+open Complex
+
+-- should perhaps go to `Mathlib.Analysis.SpecialFunctions.Pow.Real`
+lemma Nat.complex_norm_cpow_eq_rpow_re (n : ℕ) {s : ℂ} (h : s.re ≠ 0) :
+    ‖(n : ℂ) ^ s‖ = (n : ℝ) ^ s.re := by
+  rcases n.eq_zero_or_pos with rfl | H
+  · have hs : s ≠ 0 := fun H ↦ H ▸ h <| rfl
+    simp [zero_cpow hs, Real.zero_rpow h]
+  · exact abs_cpow_eq_rpow_re_of_pos (Nat.cast_pos.mpr H) s
+
+/-- The `n`th summand in the Dirichlet series giving the Riemann ζ function at `s`. -/
+noncomputable
+def riemannZetaSummand (s : ℂ) (n : ℕ) : ℂ := (n : ℂ) ^ (-s)
+
+lemma riemannZetaSummand.mul (s : ℂ) (m n : ℕ) :
+    riemannZetaSummand s (m * n) = riemannZetaSummand s m * riemannZetaSummand s n := by
+  simpa [riemannZetaSummand] using mul_cpow_ofReal_nonneg m.cast_nonneg n.cast_nonneg _
+
+variable {s : ℂ}
+
+/-- When `s ≠ 0`, the map `n ↦ n^(-s)` is completely multiplicative and vanishes at zero. -/
+noncomputable
+def riemannZetaSummandHom (hs : s ≠ 0) : ℕ →*₀ ℂ where
+  toFun := riemannZetaSummand s
+  map_zero' := by simpa [riemannZetaSummand]
+  map_one' := by simp [riemannZetaSummand]
+  map_mul' := riemannZetaSummand.mul s
+
+/-- When `χ` is a Dirichlet character and `s ≠ 0`, the map `n ↦ χ n * n^(-s)` is completely
+multiplicative and vanishes at zero. -/
+noncomputable
+def dirichletSummandHom {n : ℕ} (χ : DirichletCharacter ℂ n) (hs : s ≠ 0) : ℕ →*₀ ℂ where
+  toFun n := χ n * riemannZetaSummand s n
+  map_zero' := by simp [riemannZetaSummand, hs]
+  map_one' := by simp [riemannZetaSummand]
+  map_mul' m n := by
+    simpa only [Nat.cast_mul, IsUnit.mul_iff, not_and, map_mul, riemannZetaSummand.mul]
+      using mul_mul_mul_comm ..
+
+lemma Complex.ne_zero_of_one_lt_re (hs : 1 < s.re) : s ≠ 0 :=
+  fun h ↦ ((zero_re ▸ h ▸ hs).trans zero_lt_one).false
+
+lemma Complex.re_neg_ne_zero_of_one_lt_re (hs : 1 < s.re) : (-s).re ≠ 0 :=
+  ne_iff_lt_or_gt.mpr <| Or.inl <| neg_re s ▸ by linarith
+
+/-- When `s.re > 1`, the map `n ↦ n^(-s)` is norm-summable. -/
+lemma summable_riemannZetaSummand (hs : 1 < s.re) :
+  Summable (fun n ↦ ‖riemannZetaSummandHom (Complex.ne_zero_of_one_lt_re hs) n‖) := by
+  simp only [riemannZetaSummandHom, riemannZetaSummand, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk]
+  convert Real.summable_nat_rpow_inv.mpr hs with n
+  rw [n.complex_norm_cpow_eq_rpow_re <| Complex.re_neg_ne_zero_of_one_lt_re hs, neg_re,
+    Real.rpow_neg <| Nat.cast_nonneg _]
+
+/-- When `s.re > 1`, the map `n ↦ χ(n) * n^(-s)` is norm-summable. -/
+lemma summable_dirichletSummand {N : ℕ} (χ : DirichletCharacter ℂ N) (hs : 1 < s.re) :
+  Summable (fun n ↦ ‖dirichletSummandHom χ (Complex.ne_zero_of_one_lt_re hs) n‖) := by
+  simp only [dirichletSummandHom, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, norm_mul]
+  exact (summable_riemannZetaSummand hs).of_nonneg_of_le (fun _ ↦ by positivity)
+    (fun n ↦ mul_le_of_le_one_left (norm_nonneg _) <| χ.norm_le_one n)
+
+open Filter Nat Topology BigOperators EulerProduct
+
+/-- The Euler product for the Riemann ζ function, valid for `s.re > 1`. -/
+-- TODO: state in terms of `∏'` once this is in Mathlib
+theorem riemannZeta_eulerProduct (hs : 1 < s.re) :
+    Tendsto (fun n : ℕ ↦ ∏ p in primesBelow n, (1 - (p : ℂ) ^ (-s))⁻¹) atTop (𝓝 (riemannZeta s))
+    := by
+  have hsum := summable_riemannZetaSummand hs
+  convert eulerProduct_completely_multiplicative hsum
+  rw [zeta_eq_tsum_one_div_nat_add_one_cpow hs, tsum_eq_zero_add hsum.of_norm, map_zero, zero_add]
+  simp [riemannZetaSummandHom, riemannZetaSummand, cpow_neg]
+
+/-- The Euler product for Dirichlet L-series, valid for `s.re > 1`. -/
+-- TODO: state in terms of `∏'` once this is in Mathlib
+theorem dirichletLSeries_eulerProduct {N : ℕ} (χ : DirichletCharacter ℂ N) (hs : 1 < s.re) :
+    Tendsto (fun n : ℕ ↦ ∏ p in primesBelow n, (1 - χ p * (p : ℂ) ^ (-s))⁻¹) atTop
+      (𝓝 (∑' n : ℕ, dirichletSummandHom χ (Complex.ne_zero_of_one_lt_re hs) n)) := by
+  convert eulerProduct_completely_multiplicative <| summable_dirichletSummand χ hs

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -87,8 +87,8 @@ open Filter Nat Topology BigOperators EulerProduct
 /-- The Euler product for the Riemann ζ function, valid for `s.re > 1`. -/
 -- TODO: state in terms of `∏'` once this is in Mathlib
 theorem riemannZeta_eulerProduct (hs : 1 < s.re) :
-    Tendsto (fun n : ℕ ↦ ∏ p in primesBelow n, (1 - (p : ℂ) ^ (-s))⁻¹) atTop (𝓝 (riemannZeta s))
-    := by
+    Tendsto (fun n : ℕ ↦ ∏ p in primesBelow n, (1 - (p : ℂ) ^ (-s))⁻¹) atTop
+      (𝓝 (riemannZeta s)) := by
   have hsum := summable_riemannZetaSummand hs
   convert eulerProduct_completely_multiplicative hsum
   rw [zeta_eq_tsum_one_div_nat_add_one_cpow hs, tsum_eq_zero_add hsum.of_norm, map_zero, zero_add]

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -49,7 +49,6 @@ def dirichletSummandHom {n : ℕ} (χ : DirichletCharacter ℂ n) (hs : s ≠ 0)
       mul_cpow_ofReal_nonneg m.cast_nonneg n.cast_nonneg _]
       using mul_mul_mul_comm ..
 
-example (n : ℕ) : (n : ℂ) = (n : ℝ) := by rw [ofReal_nat_cast]
 /-- When `s.re > 1`, the map `n ↦ n^(-s)` is norm-summable. -/
 lemma summable_riemannZetaSummand (hs : 1 < s.re) :
     Summable (fun n ↦ ‖riemannZetaSummandHom (ne_zero_of_one_lt_re hs) n‖) := by


### PR DESCRIPTION
This adds proofs of the Euler product formula for the Riemann zeta function and Dirichlet L-series.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
