### PR TITLE
[Merged by Bors] - fix: make List.choose 'more' reducible

### DIFF
--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -410,10 +410,10 @@ def chooseX : ∀ l : List α, ∀ _ : ∃ a, a ∈ l ∧ p a, { a // a ∈ l �
   | l :: ls, hp =>
     if pl : p l then ⟨l, ⟨mem_cons.mpr <| Or.inl rfl, pl⟩⟩
     else
-      let ⟨a, ⟨a_mem_ls, pa⟩⟩ :=
+      let x :=
         chooseX ls
           (hp.imp fun _ ⟨o, h₂⟩ => ⟨(mem_cons.mp o).resolve_left fun e => pl <| e ▸ h₂, h₂⟩)
-      ⟨a, ⟨mem_cons.mpr <| Or.inr a_mem_ls, pa⟩⟩
+      ⟨x.1, mem_cons.mpr <| Or.inr x.2.1, x.2.2⟩
 #align list.choose_x List.chooseX
 
 /-- Given a decidable predicate `p` and a proof of existence of `a ∈ l` such that `p a`,

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -410,10 +410,11 @@ def chooseX : ∀ l : List α, ∀ _ : ∃ a, a ∈ l ∧ p a, { a // a ∈ l �
   | l :: ls, hp =>
     if pl : p l then ⟨l, ⟨mem_cons.mpr <| Or.inl rfl, pl⟩⟩
     else
-      let x :=
+      -- pattern matching on `hx` too makes this not reducible!
+      let ⟨a, ha⟩ :=
         chooseX ls
           (hp.imp fun _ ⟨o, h₂⟩ => ⟨(mem_cons.mp o).resolve_left fun e => pl <| e ▸ h₂, h₂⟩)
-      ⟨x.1, mem_cons.mpr <| Or.inr x.2.1, x.2.2⟩
+      ⟨a, mem_cons.mpr <| Or.inr ha.1, ha.2⟩
 #align list.choose_x List.chooseX
 
 /-- Given a decidable predicate `p` and a proof of existence of `a ∈ l` such that `p a`,

--- a/test/choose_reduction.lean
+++ b/test/choose_reduction.lean
@@ -2,9 +2,9 @@ import Mathlib.Data.Finset.Basic
 /-!
 Tests that `List.choose` and friends all reduce appropriately.
 
-Previously this was blocked by a `let ⟨x, hx⟩` pattern match.
+Previously this was blocked by reducibility issues with `And.rec`
+(https://leanprover.zulipchat.com/#narrow/stream/236446-Type-theory/topic/And.2Erec/near/398483665).
 -/
-
 
 namespace List
 

--- a/test/choose_reduction.lean
+++ b/test/choose_reduction.lean
@@ -1,0 +1,49 @@
+import Mathlib.Data.Finset.Basic
+/-!
+Tests that `List.choose` and friends all reduce appropriately.
+
+Previously this was blocked by a `let ⟨x, hx⟩` pattern match.
+-/
+
+
+namespace List
+
+lemma foo : ∃ x, x ∈ ([0,3] : List (Fin 5)) ∧ x = 3 := by
+  use 3
+  simp
+
+example : choose _ _ foo = 3 := by rfl
+example : choose _ _ foo = 3 := rfl
+example : choose _ _ foo = 3 := by eq_refl
+example : choose _ _ foo = 3 := by exact rfl
+example : choose _ _ foo = 3 := by decide
+
+end List
+
+namespace Multiset
+
+lemma foo : ∃! x, x ∈ ({0,3} : Multiset (Fin 5)) ∧ x = 3 := by
+  use 3
+  simp
+
+example : choose _ _ foo = 3 := by rfl
+example : choose _ _ foo = 3 := rfl
+example : choose _ _ foo = 3 := by eq_refl
+example : choose _ _ foo = 3 := by exact rfl
+example : choose _ _ foo = 3 := by decide
+
+end Multiset
+
+namespace Finset
+
+lemma foo : ∃! x, x ∈ ({0,3} : Finset (Fin 5)) ∧ x = 3 := by
+  use 3
+  simp
+
+example : choose _ _ foo = 3 := by rfl
+example : choose _ _ foo = 3 := rfl
+example : choose _ _ foo = 3 := by eq_refl
+example : choose _ _ foo = 3 := by exact rfl
+example : choose _ _ foo = 3 := by decide
+
+end Finset


### PR DESCRIPTION
The pattern match (on the `And`) was blocking (some kinds of) reduction.
This is presumably because eta reduction doesn't apply in `Prop`, as described in [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/236446-Type-theory/topic/And.2Erec/near/398483665).

[Zulip thread that reported this](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Finset.2Echoose/near/405217150).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
