### PR TITLE
chore: move `bump/v4.4.0` to `nightly-2023-11-29`

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,15 +2,12 @@ import Lake
 
 open Lake DSL
 
-def moreServerArgs := #[
-  "-Dpp.unicode.fun=true", -- pretty-prints `fun a ↦ b`
-  "-Dpp.proofs.withType=false",
-  "-DautoImplicit=false",
-  "-DrelaxedAutoImplicit=false"
-]
-
--- These settings only apply during `lake build`, but not in VSCode editor.
-def moreLeanArgs := moreServerArgs
+def leanOptions : Array LeanOption := #[
+    ⟨`pp.unicode.fun, true⟩,
+    ⟨`pp.proofs.withType, false⟩,
+    ⟨`autoImplicit, false⟩,
+    ⟨`relaxedAutoImplicit, false⟩
+  ]
 
 -- These are additional settings which do not affect the lake hash,
 -- so they can be enabled in CI and disabled locally or vice versa.
@@ -23,8 +20,7 @@ def weakLeanArgs : Array String :=
     #[]
 
 package mathlib where
-  moreServerArgs := moreServerArgs
-  moreLeanArgs := moreLeanArgs
+  leanOptions := leanOptions
   weakLeanArgs := weakLeanArgs
 
 /-!

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,26 +2,22 @@ import Lake
 
 open Lake DSL
 
-def leanOptions : Array LeanOption := #[
+package mathlib where
+  leanOptions := #[
     ⟨`pp.unicode.fun, true⟩,
     ⟨`pp.proofs.withType, false⟩,
     ⟨`autoImplicit, false⟩,
     ⟨`relaxedAutoImplicit, false⟩
   ]
-
--- These are additional settings which do not affect the lake hash,
--- so they can be enabled in CI and disabled locally or vice versa.
--- Warning: Do not put any options here that actually change the olean files,
--- or inconsistent behavior may result
-def weakLeanArgs : Array String :=
-  if get_config? CI |>.isSome then
-    #["-DwarningAsError=true"]
-  else
-    #[]
-
-package mathlib where
-  leanOptions := leanOptions
-  weakLeanArgs := weakLeanArgs
+  -- These are additional settings which do not affect the lake hash,
+  -- so they can be enabled in CI and disabled locally or vice versa.
+  -- Warning: Do not put any options here that actually change the olean files,
+  -- or inconsistent behavior may result
+  weakLeanArgs :=
+    if get_config? CI |>.isSome then
+      #["-DwarningAsError=true"]
+    else
+      #[]
 
 /-!
 ## Mathlib dependencies on upstream projects.

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-11-25
+leanprover/lean4:nightly-2023-11-29

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-11-28
+leanprover/lean4:nightly-2023-11-29

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-11-29
+leanprover/lean4:nightly-2023-11-28


### PR DESCRIPTION
Bumps `bump/v4.4.0` to `nightly-2023-11-29`.

---

- [ ] depends on: #8728

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
