### PR TITLE
[Merged by Bors] - fix: use `githash` instead of `versionString` in cache

### DIFF
--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -76,7 +76,7 @@ def getRootHash : IO UInt64 := do
       pure ((← mathlibDepPath) / ·)
   let hashs ← rootFiles.mapM fun path =>
     hashFileContents <$> IO.FS.readFile (qualifyPath path)
-  return hash ((hash Lean.versionString) :: hashs)
+  return hash (hash Lean.githash :: hashs)
 
 /--
 Computes the hash of a file, which mixes:


### PR DESCRIPTION
Fixes (or at least mitigates) an issue [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/lake.20exe.20cache.20get.20errors/near/405231700), see there for the explanation.

It is unclear whether we should be using the toolchain name or just the lean githash for cache invalidation purposes, but we should be consistent with lake's own recompilation strategy or we can get wrong results.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
