### PR TITLE
[Merged by Bors] - chore: Remove `le_antisymm'`

### DIFF
--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -57,15 +57,6 @@ universe u v w
 
 variable {α : Type u} {β : Type v}
 
--- TODO: move this eventually, if we decide to use them
--- Porting note: no ematch attribute
---attribute [ematch] le_trans lt_of_le_of_lt lt_of_lt_of_le lt_trans
-
--- Porting note: Without ematch, this is just a copy of `le_antisymm`
--- TODO: this seems crazy, but it also seems to work reasonably well
--- @[ematch]
--- theorem le_antisymm' [PartialOrder α] : ∀ {a b : α}, a ≤ b → b ≤ a → a = b :=
---   @le_antisymm _ _
 #align le_antisymm' le_antisymm
 
 /-!

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -61,16 +61,12 @@ variable {α : Type u} {β : Type v}
 -- Porting note: no ematch attribute
 --attribute [ematch] le_trans lt_of_le_of_lt lt_of_lt_of_le lt_trans
 
-section
-
+-- Porting note: Without ematch, this is just a copy of `le_antisymm`
 -- TODO: this seems crazy, but it also seems to work reasonably well
--- Porting note: no ematch attribute
---@[ematch]
-theorem le_antisymm' [PartialOrder α] : ∀ {a b : α}, a ≤ b → b ≤ a → a = b :=
-  @le_antisymm _ _
-#align le_antisymm' le_antisymm'
-
-end
+-- @[ematch]
+-- theorem le_antisymm' [PartialOrder α] : ∀ {a b : α}, a ≤ b → b ≤ a → a = b :=
+--   @le_antisymm _ _
+#align le_antisymm' le_antisymm
 
 /-!
 ### Join-semilattices

--- a/test/LibrarySearch/basic.lean
+++ b/test/LibrarySearch/basic.lean
@@ -223,10 +223,10 @@ lemma prime_of_prime (n : ℕ) : Prime n ↔ Nat.Prime n := by
 lemma ex' (x : ℕ) (_h₁ : x = 0) (h : 2 * 2 ∣ x) : 2 ∣ x := by
   exact? says exact dvd_of_mul_left_dvd h
 
--- This example non-deterministically picks between `le_antisymm hxy hyx` and `ge_antisymm hyx hxy`.
 -- Example from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Exact.3F.20fails.20on.20le_antisymm/near/388993167
 set_option linter.unreachableTactic false in
 example {x y : ℝ} (hxy : x ≤ y) (hyx : y ≤ x) : x = y := by
+  -- This example non-deterministically picks between `le_antisymm hxy hyx` and `ge_antisymm hyx hxy`.
   first
   | exact? says exact le_antisymm hxy hyx
   | exact? says exact ge_antisymm hyx hxy

--- a/test/LibrarySearch/basic.lean
+++ b/test/LibrarySearch/basic.lean
@@ -225,8 +225,11 @@ lemma ex' (x : ℕ) (_h₁ : x = 0) (h : 2 * 2 ∣ x) : 2 ∣ x := by
 
 -- This example non-deterministically picks between `le_antisymm hxy hyx` and `ge_antisymm hyx hxy`.
 -- Example from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Exact.3F.20fails.20on.20le_antisymm/near/388993167
+set_option linter.unreachableTactic false in
 example {x y : ℝ} (hxy : x ≤ y) (hyx : y ≤ x) : x = y := by
-  exact? says exact le_antisymm hxy hyx <|> exact? says exact ge_antisymm hyx hxy
+  first
+  | exact? says exact le_antisymm hxy hyx
+  | exact? says exact ge_antisymm hyx hxy
 
 -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/apply.3F.20failure/near/402534407
 example (P Q : Prop) (h : P → Q) (h' : ¬Q) : ¬P := by

--- a/test/LibrarySearch/basic.lean
+++ b/test/LibrarySearch/basic.lean
@@ -222,10 +222,13 @@ lemma prime_of_prime (n : ℕ) : Prime n ↔ Nat.Prime n := by
 -- Example from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/exact.3F.20recent.20regression.3F/near/387691588
 lemma ex' (x : ℕ) (_h₁ : x = 0) (h : 2 * 2 ∣ x) : 2 ∣ x := by
   exact? says exact dvd_of_mul_left_dvd h
+mul_left_dvd h
 
+-- This example non-deterministically picks between `le_antisymm hxy hyx` and `ge_antisymm hyx hxy`.
+-- Commenting out for now.
 -- Example from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Exact.3F.20fails.20on.20le_antisymm/near/388993167
-example {x y : ℝ} (hxy : x ≤ y) (hyx : y ≤ x) : x = y := by
-  exact? says exact le_antisymm hxy hyx
+-- example {x y : ℝ} (hxy : x ≤ y) (hyx : y ≤ x) : x = y := by
+--   exact? says exact le_antisymm hxy hyx
 
 -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/apply.3F.20failure/near/402534407
 example (P Q : Prop) (h : P → Q) (h' : ¬Q) : ¬P := by

--- a/test/LibrarySearch/basic.lean
+++ b/test/LibrarySearch/basic.lean
@@ -222,13 +222,11 @@ lemma prime_of_prime (n : ℕ) : Prime n ↔ Nat.Prime n := by
 -- Example from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/exact.3F.20recent.20regression.3F/near/387691588
 lemma ex' (x : ℕ) (_h₁ : x = 0) (h : 2 * 2 ∣ x) : 2 ∣ x := by
   exact? says exact dvd_of_mul_left_dvd h
-mul_left_dvd h
 
 -- This example non-deterministically picks between `le_antisymm hxy hyx` and `ge_antisymm hyx hxy`.
--- Commenting out for now.
 -- Example from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Exact.3F.20fails.20on.20le_antisymm/near/388993167
--- example {x y : ℝ} (hxy : x ≤ y) (hyx : y ≤ x) : x = y := by
---   exact? says exact le_antisymm hxy hyx
+example {x y : ℝ} (hxy : x ≤ y) (hyx : y ≤ x) : x = y := by
+  exact? says exact le_antisymm hxy hyx <|> exact? says exact ge_antisymm hyx hxy
 
 -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/apply.3F.20failure/near/402534407
 example (P Q : Prop) (h : P → Q) (h' : ¬Q) : ¬P := by


### PR DESCRIPTION
This was a duplicate of `le_antisymm` for use in e-match, but e-matching never was ported.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
