### PR TITLE
[Merged by Bors] - fix: nonspecific lemmas are poisoning apply?

### DIFF
--- a/Mathlib/Lean/Meta/DiscrTree.lean
+++ b/Mathlib/Lean/Meta/DiscrTree.lean
@@ -43,4 +43,11 @@ partial def getSubexpressionMatches (d : DiscrTree α) (e : Expr) (config : Whnf
     e.foldlM (fun a f => do
       pure <| a ++ (← d.getSubexpressionMatches f config)) (← d.getMatch e config).reverse
 
+/--
+Check if a `keys : Array DiscTree.Key` is "specific",
+i.e. something other than `[*]` or `[=, *, *, *]`.
+-/
+def keysSpecific (keys : Array DiscrTree.Key) : Bool :=
+  keys != #[Key.star] && keys != #[Key.const `Eq 3, Key.star, Key.star, Key.star]
+
 end Lean.Meta.DiscrTree

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -49,6 +49,10 @@ deriving DecidableEq, Ord
 instance : ToString DeclMod where
   toString m := match m with | .none => "" | .mp => "mp" | .mpr => "mpr"
 
+open DiscrTree in
+def keySpecific (keys : Array DiscrTree.Key) : Bool :=
+  keys != #[Key.star] && keys != #[Key.const `Eq 3, Key.star, Key.star, Key.star]
+
 /-- Prepare the discrimination tree entries for a lemma. -/
 def processLemma (name : Name) (constInfo : ConstantInfo) :
     MetaM (Array (Array DiscrTree.Key × (Name × DeclMod))) := do
@@ -60,9 +64,10 @@ def processLemma (name : Name) (constInfo : ConstantInfo) :
     let mut r := #[(keys, (name, .none))]
     match type.getAppFnArgs with
     | (``Iff, #[lhs, rhs]) => do
-      return r.push (← DiscrTree.mkPath rhs discrTreeConfig, (name, .mp))
+      r := r.push (← DiscrTree.mkPath rhs discrTreeConfig, (name, .mp))
         |>.push (← DiscrTree.mkPath lhs discrTreeConfig, (name, .mpr))
-    | _ => return r
+    | _ => pure ()
+    return r.filter (keySpecific ·.1)
 
 /-- Construct the discrimination tree of all lemmas. -/
 def buildDiscrTree : IO (DiscrTreeCache (Name × DeclMod)) :=

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -64,7 +64,7 @@ def processLemma (name : Name) (constInfo : ConstantInfo) :
       r := r.push (← DiscrTree.mkPath rhs discrTreeConfig, (name, .mp))
         |>.push (← DiscrTree.mkPath lhs discrTreeConfig, (name, .mpr))
     | _ => pure ()
-    return r.filter (DiscrTree.keySpecific ·.1)
+    return r.filter (DiscrTree.keysSpecific ·.1)
 
 /-- Construct the discrimination tree of all lemmas. -/
 def buildDiscrTree : IO (DiscrTreeCache (Name × DeclMod)) :=

--- a/Mathlib/Tactic/LibrarySearch.lean
+++ b/Mathlib/Tactic/LibrarySearch.lean
@@ -8,6 +8,7 @@ import Std.Util.Cache
 import Mathlib.Tactic.SolveByElim
 import Std.Data.MLList.Heartbeats
 import Mathlib.Lean.Name
+import Mathlib.Lean.Meta.DiscrTree
 
 /-!
 # Library search
@@ -49,10 +50,6 @@ deriving DecidableEq, Ord
 instance : ToString DeclMod where
   toString m := match m with | .none => "" | .mp => "mp" | .mpr => "mpr"
 
-open DiscrTree in
-def keySpecific (keys : Array DiscrTree.Key) : Bool :=
-  keys != #[Key.star] && keys != #[Key.const `Eq 3, Key.star, Key.star, Key.star]
-
 /-- Prepare the discrimination tree entries for a lemma. -/
 def processLemma (name : Name) (constInfo : ConstantInfo) :
     MetaM (Array (Array DiscrTree.Key × (Name × DeclMod))) := do
@@ -67,7 +64,7 @@ def processLemma (name : Name) (constInfo : ConstantInfo) :
       r := r.push (← DiscrTree.mkPath rhs discrTreeConfig, (name, .mp))
         |>.push (← DiscrTree.mkPath lhs discrTreeConfig, (name, .mpr))
     | _ => pure ()
-    return r.filter (keySpecific ·.1)
+    return r.filter (DiscrTree.keySpecific ·.1)
 
 /-- Construct the discrimination tree of all lemmas. -/
 def buildDiscrTree : IO (DiscrTreeCache (Name × DeclMod)) :=

--- a/Mathlib/Tactic/Rewrites.lean
+++ b/Mathlib/Tactic/Rewrites.lean
@@ -56,9 +56,7 @@ def backwardWeight := 1
 /-- Configuration for `DiscrTree`. -/
 def discrTreeConfig : WhnfCoreConfig := {}
 
-/-- We will discard -/
-def keysSpecific (keys : Array DiscrTree.Key) : Bool :=
-  !(keys == #[.star] || keys == #[.const `Eq 3, .star, .star, .star])
+open Lean.Meta.DiscrTree (keysSpecific)
 
 /-- Prepare the discrimination tree entries for a lemma. -/
 def processLemma (name : Name) (constInfo : ConstantInfo) :

--- a/test/LibrarySearch/basic.lean
+++ b/test/LibrarySearch/basic.lean
@@ -223,10 +223,12 @@ lemma prime_of_prime (n : ℕ) : Prime n ↔ Nat.Prime n := by
 lemma ex' (x : ℕ) (_h₁ : x = 0) (h : 2 * 2 ∣ x) : 2 ∣ x := by
   exact? says exact dvd_of_mul_left_dvd h
 
--- Example from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Exact.3F.20fails.20on.20le_antisymm/near/388993167
-example {x y : ℝ} (hxy : x ≤ y) (hyx : y ≤ x) : x = y := by
-  exact? says exact le_antisymm hxy hyx
-
 -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/apply.3F.20failure/near/402534407
 example (P Q : Prop) (h : P → Q) (h' : ¬Q) : ¬P := by
   exact? says exact mt h h'
+
+-- Removed until we come up with a way of handling nonspecific lemmas
+-- that does not pollute the output or cause too much slow-down.
+-- -- Example from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Exact.3F.20fails.20on.20le_antisymm/near/388993167
+-- example {x y : ℝ} (hxy : x ≤ y) (hyx : y ≤ x) : x = y := by
+--   exact? says exact le_antisymm hxy hyx


### PR DESCRIPTION
I would like to include the "nonspecific" lemmas in the results, but it will need more work (making sure they come after more specific results, and that they don't slow down output).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
