### PR TITLE
[Merged by Bors] - feat(Algebra/Homology): computation of the connecting morphism of the snake lemma

### DIFF
--- a/Mathlib/Algebra/Homology/ShortComplex/SnakeLemma.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/SnakeLemma.lean
@@ -223,6 +223,11 @@ noncomputable def P := pullback S.L₁.g S.v₀₁.τ₃
 /-- The canonical map `P ⟶ L₂.X₂`. -/
 noncomputable def φ₂ : S.P ⟶ S.L₂.X₂ := pullback.fst ≫ S.v₁₂.τ₂
 
+@[reassoc (attr := simp)]
+lemma lift_φ₂ {A : C} (a : A ⟶ S.L₁.X₂) (b : A ⟶ S.L₀.X₃) (h : a ≫ S.L₁.g = b ≫ S.v₀₁.τ₃) :
+    pullback.lift a b h ≫ S.φ₂ = a ≫ S.v₁₂.τ₂ := by
+  simp [φ₂]
+
 /-- The canonical map `P ⟶ L₂.X₁`. -/
 noncomputable def φ₁ : S.P ⟶ S.L₂.X₁ :=
   S.L₂_exact.lift S.φ₂
@@ -361,6 +366,15 @@ lemma snake_lemma : S.composableArrows.Exact :=
     (exact_of_δ₀ S.L₁'_exact.exact_toComposableArrows
     (exact_of_δ₀ S.L₂'_exact.exact_toComposableArrows
     S.L₃_exact.exact_toComposableArrows))
+
+lemma δ_eq {A : C} (x₃ : A ⟶ S.L₀.X₃) (x₂ : A ⟶ S.L₁.X₂) (x₁ : A ⟶ S.L₂.X₁)
+    (h₂ : x₂ ≫ S.L₁.g = x₃ ≫ S.v₀₁.τ₃) (h₁ : x₁ ≫ S.L₂.f = x₂ ≫ S.v₁₂.τ₂) :
+    x₃ ≫ S.δ = x₁ ≫ S.v₂₃.τ₁ := by
+  have H := (pullback.lift x₂ x₃ h₂) ≫= S.snd_δ
+  rw [pullback.lift_snd_assoc] at H
+  rw [H, ← assoc]
+  congr 1
+  simp only [← cancel_mono S.L₂.f, assoc, φ₁_L₂_f, lift_φ₂, h₁]
 
 variable (S₁ S₂ S₃ : SnakeInput C)
 


### PR DESCRIPTION
This PR introduces a lemma which allows to compute the connecting homomorphism of the snake lemma by diagram chase.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
