### PR TITLE
[Merged by Bors] - fix(NumberTheory/LegendreSymbol/AddCharacter): Disentangle coercion mess for `AddChar`

### DIFF
--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -95,16 +95,12 @@ def toMonoidHom : AddChar R R' → Multiplicative R →* R' :=
 
 open Multiplicative
 
--- Porting note: added.
-@[coe]
-def toFun (ψ : AddChar R R') (x : R) : R' := ψ.toMonoidHom (ofAdd x)
-
 /-- Define coercion to a function so that it includes the move from `R` to `Multiplicative R`.
 After we have proved the API lemmas below, we don't need to worry about writing `ofAdd a`
 when we want to apply an additive character. -/
-instance hasCoeToFun : CoeFun (AddChar R R') fun _ => R → R' where
-  coe := toFun
-#align add_char.has_coe_to_fun AddChar.hasCoeToFun
+instance instFunLike : FunLike (AddChar R R') R fun _ ↦ R' :=
+  inferInstanceAs (FunLike (Multiplicative R →* R') R fun _ ↦ R')
+#noalign add_char.has_coe_to_fun
 
 theorem coe_to_fun_apply (ψ : AddChar R R') (a : R) : ψ a = ψ.toMonoidHom (ofAdd a) :=
   rfl
@@ -118,9 +114,7 @@ theorem mul_apply (ψ φ : AddChar R R') (a : R) : (ψ * φ) a = ψ a * φ a :=
 @[simp]
 theorem one_apply (a : R) : (1 : AddChar R R') a = 1 := rfl
 
-instance monoidHomClass : MonoidHomClass (AddChar R R') (Multiplicative R) R' :=
-  MonoidHom.monoidHomClass
-#align add_char.monoid_hom_class AddChar.monoidHomClass
+#noalign add_char.monoid_hom_class
 
 -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5229): added.
 @[ext]

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -114,6 +114,7 @@ theorem mul_apply (ψ φ : AddChar R R') (a : R) : (ψ * φ) a = ψ a * φ a :=
 @[simp]
 theorem one_apply (a : R) : (1 : AddChar R R') a = 1 := rfl
 
+-- this instance was a bad idea and conflicted with `instFunLike` above
 #noalign add_char.monoid_hom_class
 
 -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5229): added.

--- a/Mathlib/NumberTheory/LegendreSymbol/GaussSum.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/GaussSum.lean
@@ -296,10 +296,10 @@ theorem FiniteField.two_pow_card {F : Type*} [Fintype F] [Field F] (hF : ringCha
   let τ : FF := ψ₈char 1
   have τ_spec : τ ^ 4 = -1 := by
     refine (sq_eq_one_iff.1 ?_).resolve_left ?_
-    · rw [← pow_mul, ← map_nsmul_pow ψ₈char, AddChar.IsPrimitive.zmod_char_eq_one_iff 8 ψ₈.prim]
-      decide
-    · rw [← map_nsmul_pow ψ₈char, AddChar.IsPrimitive.zmod_char_eq_one_iff 8 ψ₈.prim]
-      decide
+    · rw [← pow_mul, ← map_nsmul_pow ψ₈char]
+      exact (AddChar.IsPrimitive.zmod_char_eq_one_iff 8 ψ₈.prim _).2 $ by decide
+    · rw [← map_nsmul_pow ψ₈char]
+      exact (AddChar.IsPrimitive.zmod_char_eq_one_iff 8 ψ₈.prim _).not.2 $ by decide
 
   -- we consider `χ₈` as a multiplicative character `ℤ/8ℤ → FF`
   let χ := χ₈.ringHomComp (Int.castRingHom FF)

--- a/Mathlib/NumberTheory/LegendreSymbol/GaussSum.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/GaussSum.lean
@@ -297,9 +297,13 @@ theorem FiniteField.two_pow_card {F : Type*} [Fintype F] [Field F] (hF : ringCha
   have τ_spec : τ ^ 4 = -1 := by
     refine (sq_eq_one_iff.1 ?_).resolve_left ?_
     · rw [← pow_mul, ← map_nsmul_pow ψ₈char]
-      exact (AddChar.IsPrimitive.zmod_char_eq_one_iff 8 ψ₈.prim _).2 $ by decide
+      -- doesn't match syntactically for `rw`
+      refine (AddChar.IsPrimitive.zmod_char_eq_one_iff 8 ψ₈.prim _).2 ?_
+      decide
     · rw [← map_nsmul_pow ψ₈char]
-      exact (AddChar.IsPrimitive.zmod_char_eq_one_iff 8 ψ₈.prim _).not.2 $ by decide
+      -- doesn't match syntactically for `rw`
+      refine (AddChar.IsPrimitive.zmod_char_eq_one_iff 8 ψ₈.prim _).not.2 ?_
+      decide
 
   -- we consider `χ₈` as a multiplicative character `ℤ/8ℤ → FF`
   let χ := χ₈.ringHomComp (Int.castRingHom FF)


### PR DESCRIPTION
There are two things going on here:
* `AddChar G R` has two syntactically different coercions to function `G → R`:
  * `FunLike.coe` via `AddChar.monoidHomClass`
  * `AddChar.toFun` via `AddChar.hasCoeToFun`
* `AddChar.hasCoeToFun` and `AddChar.monoidHomClass` together create a diamond for the typeclass problem `FunLike (AddChar G R) _ _`

This PR fixes both problems by
* removing the `HasCoeToFun` instance and the corresponding `AddChar.toFun`
* changing `MonoidHomClass (AddChar G R) (Multiplicative G) R` to `FunLike (AddChar G R) G fun _ ↦ R` (isn't the whole point of `AddChar` to go from an additive group to a multiplicative one anyway?)

This PR isn't meant to be perfect. It is a stopgag to an issue that has completely startled progress on LeanAPAP. Once it is fixed, a much more thorough refactor will follow.

This breaks a rewrite downstream that now unifies to some defeq but not syntactically equal type.
This is more an indication of fragility in the original proof.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
