### PR TITLE
[Merged by Bors] - chore(UniformConvergenceTopology): golf, reflow

### DIFF
--- a/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
@@ -377,29 +377,24 @@ protected theorem inf_eq {u₁ u₂ : UniformSpace γ} :
   cases i <;> rfl
 #align uniform_fun.inf_eq UniformFun.inf_eq
 
+/-- Post-composition by a uniform inducing is a uniform inducing for the
+uniform structures of uniform convergence.
+
+More precisely, if `f : γ → β` is a uniform inducing, then `(f ∘ ·) : (α →ᵤ γ) → (α →ᵤ β)` is
+a uniform inducing. -/
+protected theorem postcomp_uniformInducing [UniformSpace γ] {f : γ → β} (hf : UniformInducing f) :
+    UniformInducing (ofFun ∘ (f ∘ ·) ∘ toFun : (α →ᵤ γ) → α →ᵤ β) :=
+  ⟨((UniformFun.hasBasis_uniformity _ _).comap _).eq_of_same_basis <|
+    UniformFun.hasBasis_uniformity_of_basis _ _ (hf.basis_uniformity (𝓤 β).basis_sets)⟩
+#align uniform_fun.postcomp_uniform_inducing UniformFun.postcomp_uniformInducing
+
 -- porting note: had to add a type annotation at `((f ∘ ·) : ((α → γ) → (α → β)))`
 /-- If `u` is a uniform structures on `β` and `f : γ → β`, then
 `𝒰(α, γ, comap f u) = comap (fun g ↦ f ∘ g) 𝒰(α, γ, u₁)`. -/
 protected theorem comap_eq {f : γ → β} :
-    𝒰(α, γ, ‹UniformSpace β›.comap f) = 𝒰(α, β, _).comap ((f ∘ ·)) := by
-  letI : UniformSpace γ := ‹UniformSpace β›.comap f
-  ext : 1
-  change UniformFun.filter α γ ((𝓤 β).comap _) = (UniformFun.filter α β (𝓤 β)).comap _
-  -- We have the following four Galois connection which form a square diagram, and we want
-  -- to show that the square of upper adjoints is commutative. The trick then is to use
-  -- `GaloisConnection.u_comm_of_l_comm` to reduce it to commutativity of the lower adjoints,
-  -- which is way easier to prove.
-  let fcomp := ((f ∘ ·) : ((α → γ) → (α → β)))
-  have h₁ := Filter.gc_map_comap (Prod.map fcomp fcomp)
-  have h₂ := Filter.gc_map_comap (Prod.map f f)
-  have h₃ := UniformFun.gc α β
-  have h₄ := UniformFun.gc α γ
-  refine' GaloisConnection.u_comm_of_l_comm h₁ h₂ h₃ h₄ fun 𝓐 => _
-  have : Prod.map f f ∘ (UniformFun.phi α γ)
-      = (UniformFun.phi α β) ∘ Prod.map (Prod.map fcomp fcomp) (id : α → α) := by
-    ext <;> rfl
-  rw [map_comm this, ← prod_map_map_eq']
-  rfl
+    𝒰(α, γ, ‹UniformSpace β›.comap f) = 𝒰(α, β, _).comap (f ∘ ·) := by
+  letI : UniformSpace γ := .comap f ‹_›
+  exact (UniformFun.postcomp_uniformInducing (f := f) ⟨rfl⟩).comap_uniformSpace.symm
 #align uniform_fun.comap_eq UniformFun.comap_eq
 
 /-- Post-composition by a uniformly continuous function is uniformly continuous on `α →ᵤ β`.
@@ -419,28 +414,10 @@ protected theorem postcomp_uniformContinuous [UniformSpace γ] {f : γ → β}
     --  _ = 𝒰(α, β, _).comap (f ∘ ·) := @UniformFun.comap_eq α β γ _ f
 #align uniform_fun.postcomp_uniform_continuous UniformFun.postcomp_uniformContinuous
 
-/-- Post-composition by a uniform inducing is a uniform inducing for the
-uniform structures of uniform convergence.
-
-More precisely, if `f : γ → β` is a uniform inducing, then `(λ g, f ∘ g) : (α →ᵤ γ) → (α →ᵤ β)` is
-a uniform inducing. -/
-protected theorem postcomp_uniformInducing [UniformSpace γ] {f : γ → β} (hf : UniformInducing f) :
-    UniformInducing (ofFun ∘ (f ∘ ·) ∘ toFun : (α →ᵤ γ) → α →ᵤ β) := by
-  -- This is a direct consequence of `UniformFun.comap_eq`
-  constructor
-  replace hf : (𝓤 β).comap (Prod.map f f) = _ := hf.comap_uniformity
-  change comap (Prod.map (ofFun ∘ (f ∘ ·) ∘ toFun) (ofFun ∘ (f ∘ ·) ∘ toFun)) _ = _
-  rw [← uniformity_comap] at hf ⊢
-  congr
-  rw [← UniformSpace.ext hf, UniformFun.comap_eq]
-  rfl
-#align uniform_fun.postcomp_uniform_inducing UniformFun.postcomp_uniformInducing
-
 /-- Turn a uniform isomorphism `γ ≃ᵤ β` into a uniform isomorphism `(α →ᵤ γ) ≃ᵤ (α →ᵤ β)` by
 post-composing. -/
 protected def congrRight [UniformSpace γ] (e : γ ≃ᵤ β) : (α →ᵤ γ) ≃ᵤ (α →ᵤ β) :=
-  { Equiv.piCongrRight fun _a =>
-      e.toEquiv with
+  { Equiv.piCongrRight fun _ => e.toEquiv with
     uniformContinuous_toFun := UniformFun.postcomp_uniformContinuous e.uniformContinuous
     uniformContinuous_invFun := UniformFun.postcomp_uniformContinuous e.symm.uniformContinuous }
 #align uniform_fun.congr_right UniformFun.congrRight
@@ -448,7 +425,7 @@ protected def congrRight [UniformSpace γ] (e : γ ≃ᵤ β) : (α →ᵤ γ) �
 /-- Pre-composition by any function is uniformly continuous for the uniform structures of
 uniform convergence.
 
-More precisely, for any `f : γ → α`, the function `(λ g, g ∘ f) : (α →ᵤ β) → (γ →ᵤ β)` is uniformly
+More precisely, for any `f : γ → α`, the function `(· ∘ f) : (α →ᵤ β) → (γ →ᵤ β)` is uniformly
 continuous. -/
 protected theorem precomp_uniformContinuous {f : γ → α} :
     UniformContinuous fun g : α →ᵤ β => ofFun (g ∘ f) := by
@@ -464,17 +441,14 @@ protected theorem precomp_uniformContinuous {f : γ → α} :
 /-- Turn a bijection `γ ≃ α` into a uniform isomorphism
 `(γ →ᵤ β) ≃ᵤ (α →ᵤ β)` by pre-composing. -/
 protected def congrLeft (e : γ ≃ α) : (γ →ᵤ β) ≃ᵤ (α →ᵤ β) :=
-  { Equiv.arrowCongr e
-      (Equiv.refl
-        _) with
+  { Equiv.arrowCongr e (Equiv.refl _) with
     uniformContinuous_toFun := UniformFun.precomp_uniformContinuous
     uniformContinuous_invFun := UniformFun.precomp_uniformContinuous }
 #align uniform_fun.congr_left UniformFun.congrLeft
 
 /-- The topology of uniform convergence is T₂. -/
 instance [T2Space β] : T2Space (α →ᵤ β) where
-  t2 := by
-    intro f g h
+  t2 f g h := by
     obtain ⟨x, hx⟩ := not_forall.mp (mt funext h)
     exact separated_by_continuous (uniformContinuous_eval β x).continuous hx
 
@@ -494,7 +468,7 @@ protected theorem uniformContinuous_toFun : UniformContinuous (toFun : (α →�
 protected theorem tendsto_iff_tendstoUniformly {F : ι → α →ᵤ β} {f : α →ᵤ β} :
     Tendsto F p (𝓝 f) ↔ TendstoUniformly F f p := by
   rw [(UniformFun.hasBasis_nhds α β f).tendsto_right_iff, TendstoUniformly]
-  exact Iff.rfl
+  rfl
 #align uniform_fun.tendsto_iff_tendsto_uniformly UniformFun.tendsto_iff_tendstoUniformly
 
 /-- The natural bijection between `α → β × γ` and `(α → β) × (α → γ)`, upgraded to a uniform
@@ -740,7 +714,7 @@ protected theorem inf_eq {u₁ u₂ : UniformSpace γ} :
 /-- If `u` is a uniform structure on `β` and `f : γ → β`, then
 `𝒱(α, γ, 𝔖, comap f u) = comap (fun g ↦ f ∘ g) 𝒱(α, γ, 𝔖, u₁)`. -/
 protected theorem comap_eq {f : γ → β} :
-    𝒱(α, γ, 𝔖, ‹UniformSpace β›.comap f) = 𝒱(α, β, 𝔖, _).comap ((· ∘ ·) f) := by
+    𝒱(α, γ, 𝔖, ‹UniformSpace β›.comap f) = 𝒱(α, β, 𝔖, _).comap (f ∘ ·) := by
   -- We reduce this to `UniformFun.comap_eq` using the fact that `comap` distributes
   -- on `iInf`.
   simp_rw [UniformOnFun.uniformSpace, UniformSpace.comap_iInf, UniformFun.comap_eq, ←
@@ -755,7 +729,7 @@ uniform structures of `𝔖`-convergence.
 More precisely, if `f : γ → β` is uniformly continuous, then
 `(fun g ↦ f ∘ g) : (α →ᵤ[𝔖] γ) → (α →ᵤ[𝔖] β)` is uniformly continuous. -/
 protected theorem postcomp_uniformContinuous [UniformSpace γ] {f : γ → β}
-    (hf : UniformContinuous f) : UniformContinuous (ofFun 𝔖 ∘ (· ∘ ·) f ∘ toFun 𝔖) := by
+    (hf : UniformContinuous f) : UniformContinuous (ofFun 𝔖 ∘ (f ∘ ·) ∘ toFun 𝔖) := by
   -- This is a direct consequence of `UniformFun.comap_eq`
   rw [uniformContinuous_iff]
   exact (UniformOnFun.mono (uniformContinuous_iff.mp hf) subset_rfl).trans_eq UniformOnFun.comap_eq
@@ -767,11 +741,11 @@ uniform structures of `𝔖`-convergence.
 More precisely, if `f : γ → β` is a uniform inducing, then
 `(fun g ↦ f ∘ g) : (α →ᵤ[𝔖] γ) → (α →ᵤ[𝔖] β)` is a uniform inducing. -/
 protected theorem postcomp_uniformInducing [UniformSpace γ] {f : γ → β} (hf : UniformInducing f) :
-    UniformInducing (ofFun 𝔖 ∘ (· ∘ ·) f ∘ toFun 𝔖) := by
+    UniformInducing (ofFun 𝔖 ∘ (f ∘ ·) ∘ toFun 𝔖) := by
   -- This is a direct consequence of `UniformFun.comap_eq`
   constructor
   replace hf : (𝓤 β).comap (Prod.map f f) = _ := hf.comap_uniformity
-  change comap (Prod.map (ofFun 𝔖 ∘ (· ∘ ·) f ∘ toFun 𝔖) (ofFun 𝔖 ∘ (· ∘ ·) f ∘ toFun 𝔖)) _ = _
+  change comap (Prod.map (ofFun 𝔖 ∘ (f ∘ ·) ∘ toFun 𝔖) (ofFun 𝔖 ∘ (f ∘ ·) ∘ toFun 𝔖)) _ = _
   rw [← uniformity_comap] at hf ⊢
   congr
   rw [← UniformSpace.ext hf, UniformOnFun.comap_eq]
@@ -781,9 +755,7 @@ protected theorem postcomp_uniformInducing [UniformSpace γ] {f : γ → β} (hf
 /-- Turn a uniform isomorphism `γ ≃ᵤ β` into a uniform isomorphism `(α →ᵤ[𝔖] γ) ≃ᵤ (α →ᵤ[𝔖] β)`
 by post-composing. -/
 protected def congrRight [UniformSpace γ] (e : γ ≃ᵤ β) : (α →ᵤ[𝔖] γ) ≃ᵤ (α →ᵤ[𝔖] β) :=
-  {
-    Equiv.piCongrRight fun _a =>
-      e.toEquiv with
+  { Equiv.piCongrRight fun _a => e.toEquiv with
     uniformContinuous_toFun := UniformOnFun.postcomp_uniformContinuous e.uniformContinuous
     uniformContinuous_invFun := UniformOnFun.postcomp_uniformContinuous e.symm.uniformContinuous }
 #align uniform_on_fun.congr_right UniformOnFun.congrRight
@@ -825,27 +797,20 @@ protected theorem precomp_uniformContinuous {𝔗 : Set (Set γ)} {f : γ → α
 `∀ S ∈ 𝔖, e ⁻¹' S ∈ 𝔗` into a uniform isomorphism `(γ →ᵤ[𝔗] β) ≃ᵤ (α →ᵤ[𝔖] β)` by pre-composing. -/
 protected def congrLeft {𝔗 : Set (Set γ)} (e : γ ≃ α) (he : 𝔗 ⊆ image e ⁻¹' 𝔖)
     (he' : 𝔖 ⊆ preimage e ⁻¹' 𝔗) : (γ →ᵤ[𝔗] β) ≃ᵤ (α →ᵤ[𝔖] β) :=
-  { Equiv.arrowCongr e
-      (Equiv.refl
-        _) with
-    uniformContinuous_toFun :=
-      UniformOnFun.precomp_uniformContinuous
-        (by
-          intro s hs
-          change e.symm '' s ∈ 𝔗
-          rw [← preimage_equiv_eq_image_symm]
-          exact he' hs)
+  { Equiv.arrowCongr e (Equiv.refl _) with
+    uniformContinuous_toFun := UniformOnFun.precomp_uniformContinuous fun s hs ↦ by
+      change e.symm '' s ∈ 𝔗
+      rw [← preimage_equiv_eq_image_symm]
+      exact he' hs
     uniformContinuous_invFun := UniformOnFun.precomp_uniformContinuous he }
 #align uniform_on_fun.congr_left UniformOnFun.congrLeft
 
 /-- If `𝔖` covers `α`, then the topology of `𝔖`-convergence is T₂. -/
-theorem t2Space_of_covering [T2Space β] (h : ⋃₀ 𝔖 = univ) : T2Space (α →ᵤ[𝔖] β) :=
-  {
-    t2 := by
-      intro f g hfg
-      obtain ⟨x, hx⟩ := not_forall.mp (mt funext hfg)
-      obtain ⟨s, hs, hxs⟩ : ∃ s ∈ 𝔖, x ∈ s := mem_sUnion.mp (h.symm ▸ True.intro)
-      exact separated_by_continuous (uniformContinuous_eval_of_mem β 𝔖 hxs hs).continuous hx }
+theorem t2Space_of_covering [T2Space β] (h : ⋃₀ 𝔖 = univ) : T2Space (α →ᵤ[𝔖] β) where
+  t2 f g hfg := by
+    obtain ⟨x, hx⟩ := not_forall.mp (mt funext hfg)
+    obtain ⟨s, hs, hxs⟩ : ∃ s ∈ 𝔖, x ∈ s := mem_sUnion.mp (h.symm ▸ True.intro)
+    exact separated_by_continuous (uniformContinuous_eval_of_mem β 𝔖 hxs hs).continuous hx
 #align uniform_on_fun.t2_space_of_covering UniformOnFun.t2Space_of_covering
 
 /-- If `𝔖` covers `α`, the natural map `UniformOnFun.toFun` from `α →ᵤ[𝔖] β` to `α → β` is

--- a/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
@@ -377,11 +377,11 @@ protected theorem inf_eq {u₁ u₂ : UniformSpace γ} :
   cases i <;> rfl
 #align uniform_fun.inf_eq UniformFun.inf_eq
 
-/-- Post-composition by a uniform inducing is a uniform inducing for the
-uniform structures of uniform convergence.
+/-- Post-composition by a uniform inducing function is
+a uniform inducing function for the uniform structures of uniform convergence.
 
-More precisely, if `f : γ → β` is a uniform inducing, then `(f ∘ ·) : (α →ᵤ γ) → (α →ᵤ β)` is
-a uniform inducing. -/
+More precisely, if `f : γ → β` is uniform inducing,
+then `(f ∘ ·) : (α →ᵤ γ) → (α →ᵤ β)` is uniform inducing. -/
 protected theorem postcomp_uniformInducing [UniformSpace γ] {f : γ → β} (hf : UniformInducing f) :
     UniformInducing (ofFun ∘ (f ∘ ·) ∘ toFun : (α →ᵤ γ) → α →ᵤ β) :=
   ⟨((UniformFun.hasBasis_uniformity _ _).comap _).eq_of_same_basis <|


### PR DESCRIPTION
- Move a proof up, golf.
- Replace `(· ∘ ·) f` with `(f ∘ ·)`.
- Reflow structure constructors.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)