### PR TITLE
[Merged by Bors] - feat(RingTheory/Coalgebra): product of coalgebras

### DIFF
--- a/Mathlib/LinearAlgebra/Prod.lean
+++ b/Mathlib/LinearAlgebra/Prod.lean
@@ -172,6 +172,14 @@ theorem ker_fst : ker (fst R M M₂) = range (inr R M M₂) :=
   Eq.symm <| range_inr R M M₂
 #align linear_map.ker_fst LinearMap.ker_fst
 
+@[simp] theorem fst_comp_inl : fst R M M₂ ∘ₗ inl R M M₂ = id := rfl
+
+@[simp] theorem snd_comp_inl : snd R M M₂ ∘ₗ inl R M M₂ = 0 := rfl
+
+@[simp] theorem fst_comp_inr : fst R M M₂ ∘ₗ inr R M M₂ = 0 := rfl
+
+@[simp] theorem snd_comp_inr : snd R M M₂ ∘ₗ inr R M M₂ = id := rfl
+
 end
 
 @[simp]

--- a/Mathlib/LinearAlgebra/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct.lean
@@ -797,11 +797,19 @@ theorem map_tmul (f : M →ₗ[R] P) (g : N →ₗ[R] Q) (m : M) (n : N) : map f
   rfl
 #align tensor_product.map_tmul TensorProduct.map_tmul
 
+/-- Given linear maps `f : M → P`, `g : N → Q`, if we identify `M ⊗ N` with `N ⊗ M` and `P ⊗ Q`
+with `Q ⊗ P`, then this lemma states that `f ⊗ g = g ⊗ f`. -/
 lemma map_comp_comm_eq (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
-    map f g ∘ₗ TensorProduct.comm R N M =
-      TensorProduct.comm R Q P ∘ₗ map g f :=
+    map f g ∘ₗ TensorProduct.comm R N M = TensorProduct.comm R Q P ∘ₗ map g f :=
   ext rfl
 
+lemma map_comm (f : M →ₗ[R] P) (g : N →ₗ[R] Q) (x : N ⊗[R] M):
+    map f g (TensorProduct.comm R N M x) = TensorProduct.comm R Q P (map g f x) :=
+  FunLike.congr_fun (map_comp_comm_eq _ _) _
+
+/-- Given linear maps `f : M → Q`, `g : N → S`, and `h : P → T`, if we identify `(M ⊗ N) ⊗ P`
+with `M ⊗ (N ⊗ P)` and `(Q ⊗ S) ⊗ T` with `Q ⊗ (S ⊗ T)`, then this lemma states that
+`f ⊗ (g ⊗ h) = (f ⊗ g) ⊗ h`. -/
 lemma map_map_comp_assoc_eq (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P →ₗ[R] T) :
     map f (map g h) ∘ₗ TensorProduct.assoc R M N P =
       TensorProduct.assoc R Q S T ∘ₗ map (map f g) h :=
@@ -812,6 +820,9 @@ lemma map_map_assoc (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P →ₗ[R] T) 
       TensorProduct.assoc R Q S T (map (map f g) h x) :=
   FunLike.congr_fun (map_map_comp_assoc_eq _ _ _) _
 
+/-- Given linear maps `f : M → Q`, `g : N → S`, and `h : P → T`, if we identify `M ⊗ (N ⊗ P)`
+with `(M ⊗ N) ⊗ P` and `Q ⊗ (S ⊗ T)` with `(Q ⊗ S) ⊗ T`, then this lemma states that
+`(f ⊗ g) ⊗ h = f ⊗ (g ⊗ h)`. -/
 lemma map_map_comp_assoc_symm_eq (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P →ₗ[R] T) :
     map (map f g) h ∘ₗ (TensorProduct.assoc R M N P).symm =
       (TensorProduct.assoc R Q S T).symm ∘ₗ map f (map g h) :=

--- a/Mathlib/LinearAlgebra/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct.lean
@@ -807,10 +807,20 @@ lemma map_map_comp_assoc_eq (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P →�
       TensorProduct.assoc R Q S T ∘ₗ map (map f g) h :=
   ext <| ext <| LinearMap.ext fun _ => LinearMap.ext fun _ => LinearMap.ext fun _ => rfl
 
+lemma map_map_assoc (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P →ₗ[R] T) (x : (M ⊗[R] N) ⊗[R] P) :
+    map f (map g h) (TensorProduct.assoc R M N P x) =
+      TensorProduct.assoc R Q S T (map (map f g) h x) :=
+  FunLike.congr_fun (map_map_comp_assoc_eq _ _ _) _
+
 lemma map_map_comp_assoc_symm_eq (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P →ₗ[R] T) :
     map (map f g) h ∘ₗ (TensorProduct.assoc R M N P).symm =
       (TensorProduct.assoc R Q S T).symm ∘ₗ map f (map g h) :=
   ext <| LinearMap.ext fun _ => ext <| LinearMap.ext fun _ => LinearMap.ext fun _ => rfl
+
+lemma map_map_assoc_symm (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P →ₗ[R] T) (x : M ⊗[R] (N ⊗[R] P)) :
+    map (map f g) h ((TensorProduct.assoc R M N P).symm x) =
+      (TensorProduct.assoc R Q S T).symm (map f (map g h) x) :=
+  FunLike.congr_fun (map_map_comp_assoc_symm_eq _ _ _) _
 
 theorem map_range_eq_span_tmul (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
     range (map f g) = Submodule.span R { t | ∃ m n, f m ⊗ₜ g n = t } := by

--- a/Mathlib/LinearAlgebra/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct.lean
@@ -965,6 +965,14 @@ theorem homTensorHomMap_apply (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
   rfl
 #align tensor_product.hom_tensor_hom_map_apply TensorProduct.homTensorHomMap_apply
 
+@[simp]
+theorem map_zero_left (g : N →ₗ[R] Q) : map (0 : M →ₗ[R] P) g = 0 :=
+  (mapBilinear R M N P Q).map_zero₂ _
+
+@[simp]
+theorem map_zero_right (f : M →ₗ[R] P) : map f (0 : N →ₗ[R] Q) = 0 :=
+  (mapBilinear R M N P Q _).map_zero
+
 end
 
 /-- If `M` and `P` are linearly equivalent and `N` and `Q` are linearly equivalent
@@ -1101,6 +1109,16 @@ theorem lTensor_tmul (m : M) (n : N) : f.lTensor M (m ⊗ₜ n) = m ⊗ₜ f n :
 theorem rTensor_tmul (m : M) (n : N) : f.rTensor M (n ⊗ₜ m) = f n ⊗ₜ m :=
   rfl
 #align linear_map.rtensor_tmul LinearMap.rTensor_tmul
+
+@[simp]
+theorem lTensor_comp_mk (m : M) :
+    f.lTensor M ∘ₗ TensorProduct.mk R M N m = TensorProduct.mk R M P m ∘ₗ f :=
+  rfl
+
+@[simp]
+theorem rTensor_comp_flip_mk (m : M) :
+    f.rTensor M ∘ₗ (TensorProduct.mk R N M).flip m = (TensorProduct.mk R P M).flip m ∘ₗ f :=
+  rfl
 
 lemma comm_comp_rTensor_comp_comm_eq (g : N →ₗ[R] P) :
     TensorProduct.comm R P Q ∘ₗ rTensor Q g ∘ₗ TensorProduct.comm R Q N =

--- a/Mathlib/LinearAlgebra/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct.lean
@@ -41,9 +41,10 @@ section Semiring
 variable {R : Type*} [CommSemiring R]
 variable {R' : Type*} [Monoid R']
 variable {R'' : Type*} [Semiring R'']
-variable {M : Type*} {N : Type*} {P : Type*} {Q : Type*} {S : Type*}
-variable [AddCommMonoid M] [AddCommMonoid N] [AddCommMonoid P] [AddCommMonoid Q] [AddCommMonoid S]
-variable [Module R M] [Module R N] [Module R P] [Module R Q] [Module R S]
+variable {M : Type*} {N : Type*} {P : Type*} {Q : Type*} {S : Type*} {T : Type*}
+variable [AddCommMonoid M] [AddCommMonoid N] [AddCommMonoid P]
+variable [AddCommMonoid Q] [AddCommMonoid S] [AddCommMonoid T]
+variable [Module R M] [Module R N] [Module R P] [Module R Q] [Module R S] [Module R T]
 variable [DistribMulAction R' M]
 variable [Module R'' M]
 variable (M N)
@@ -800,6 +801,16 @@ lemma map_comp_comm_eq (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
     map f g ∘ₗ TensorProduct.comm R N M =
       TensorProduct.comm R Q P ∘ₗ map g f :=
   ext rfl
+
+lemma map_map_comp_assoc_eq (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P →ₗ[R] T) :
+    map f (map g h) ∘ₗ TensorProduct.assoc R M N P =
+      TensorProduct.assoc R Q S T ∘ₗ map (map f g) h :=
+  ext <| ext <| LinearMap.ext fun _ => LinearMap.ext fun _ => LinearMap.ext fun _ => rfl
+
+lemma map_map_comp_assoc_symm_eq (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P →ₗ[R] T) :
+    map (map f g) h ∘ₗ (TensorProduct.assoc R M N P).symm =
+      (TensorProduct.assoc R Q S T).symm ∘ₗ map f (map g h) :=
+  ext <| LinearMap.ext fun _ => ext <| LinearMap.ext fun _ => LinearMap.ext fun _ => rfl
 
 theorem map_range_eq_span_tmul (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
     range (map f g) = Submodule.span R { t | ∃ m n, f m ⊗ₜ g n = t } := by

--- a/Mathlib/RingTheory/Coalgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra.lean
@@ -13,6 +13,7 @@ import Mathlib.LinearAlgebra.TensorProduct
 In this file we define `Coalgebra`, and provide instances for:
 
 * Commutative semirings: `CommSemiring.toCoalgebra`
+* Binary products: `Prod.instCoalgebra`
 * Finitely supported functions: `Finsupp.instCoalgebra`
 
 ## References

--- a/Mathlib/RingTheory/Coalgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra.lean
@@ -20,7 +20,7 @@ In this file we define `Coalgebra`, and provide instances for:
 
 suppress_compilation
 
-universe u v
+universe u v w
 
 open scoped TensorProduct
 
@@ -89,6 +89,62 @@ theorem comul_apply (r : R) : comul r = 1 ⊗ₜ[R] r := rfl
 theorem counit_apply (r : R) : counit r = r := rfl
 
 end CommSemiring
+
+namespace Prod
+variable (R : Type u) (A : Type v) (B : Type w)
+variable [CommSemiring R] [AddCommMonoid A] [AddCommMonoid B] [Module R A] [Module R B]
+variable [Coalgebra R A] [Coalgebra R B]
+
+notation f " ∘ₗ' " g => LinearMap.comp f g
+
+open LinearMap in
+instance instCoalgebra : Coalgebra R (A × B) where
+  comul := .coprod
+    (TensorProduct.map (.inl R A B) (.inl R A B) ∘ₗ comul)
+    (TensorProduct.map (.inr R A B) (.inr R A B) ∘ₗ comul)
+  counit := .coprod counit counit
+  rTensor_counit_comp_comul := by
+    ext x : 2 <;> dsimp
+    · simp only [map_zero, add_zero]
+      simp_rw [←LinearMap.comp_apply, ←LinearMap.comp_assoc, ←LinearMap.lTensor_comp_rTensor,
+        ←LinearMap.comp_assoc, LinearMap.rTensor_comp_lTensor, ←LinearMap.lTensor_comp_rTensor,
+        LinearMap.comp_assoc _ (.rTensor _ _), ←LinearMap.rTensor_comp, LinearMap.coprod_inl,
+        LinearMap.comp_assoc, rTensor_counit_comp_comul]
+      rfl
+    · simp only [map_zero, zero_add]
+      simp_rw [←LinearMap.comp_apply, ←LinearMap.comp_assoc, ←LinearMap.lTensor_comp_rTensor,
+        ←LinearMap.comp_assoc, LinearMap.rTensor_comp_lTensor, ←LinearMap.lTensor_comp_rTensor,
+        LinearMap.comp_assoc _ (.rTensor _ _), ←LinearMap.rTensor_comp, LinearMap.coprod_inr,
+        LinearMap.comp_assoc, rTensor_counit_comp_comul]
+      rfl
+  lTensor_counit_comp_comul := by
+    ext x : 2 <;> dsimp
+    · simp only [map_zero, add_zero]
+      simp_rw [←LinearMap.comp_apply, ←LinearMap.comp_assoc, ←LinearMap.rTensor_comp_lTensor,
+        ←LinearMap.comp_assoc, LinearMap.lTensor_comp_rTensor, ←LinearMap.rTensor_comp_lTensor,
+        LinearMap.comp_assoc _ (.lTensor _ _), ←LinearMap.lTensor_comp, LinearMap.coprod_inl,
+        LinearMap.comp_assoc, lTensor_counit_comp_comul]
+      rfl
+    · simp only [map_zero, zero_add]
+      simp_rw [←LinearMap.comp_apply, ←LinearMap.comp_assoc, ←LinearMap.rTensor_comp_lTensor,
+        ←LinearMap.comp_assoc, LinearMap.lTensor_comp_rTensor, ←LinearMap.rTensor_comp_lTensor,
+        LinearMap.comp_assoc _ (.lTensor _ _), ←LinearMap.lTensor_comp, LinearMap.coprod_inr,
+        LinearMap.comp_assoc, lTensor_counit_comp_comul]
+      rfl
+  coassoc := by
+    ext x : 2 <;> dsimp
+    sorry
+
+@[simp]
+theorem comul_apply (r : A × B) :
+  comul r =
+    TensorProduct.map (.inl R A B) (.inl R A B) (comul r.1) +
+    TensorProduct.map (.inr R A B) (.inr R A B) (comul r.2) := rfl
+
+@[simp]
+theorem counit_apply (r : A × B) : (counit r : R) = counit r.1 + counit r.2 := rfl
+
+end Prod
 
 namespace Finsupp
 variable (ι : Type v)

--- a/Mathlib/RingTheory/Coalgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra.lean
@@ -29,7 +29,8 @@ open scoped TensorProduct
 /-- Data fields for `Coalgebra`, to allow API to be constructed before proving `Coalgebra.coassoc`.
 
 See `Coalgebra` for documentation. -/
-class CoalgebraStruct (R : Type u) (A : Type v) [CommSemiring R] [AddCommMonoid A] [Module R A] where
+class CoalgebraStruct (R : Type u) (A : Type v)
+    [CommSemiring R] [AddCommMonoid A] [Module R A] where
   /-- The comultiplication of the coalgebra -/
   comul : A →ₗ[R] A ⊗[R] A
   /-- The counit of the coalgebra -/
@@ -41,8 +42,8 @@ end Coalgebra
 
 /-- A coalgebra over a commutative (semi)ring `R` is an `R`-module equipped with a coassociative
 comultiplication `Δ` and a counit `ε` obeying the left and right conunitality laws. -/
-class Coalgebra (R : Type u) (A : Type v) [CommSemiring R] [AddCommMonoid A] [Module R A] extends
-    CoalgebraStruct R A where
+class Coalgebra (R : Type u) (A : Type v)
+    [CommSemiring R] [AddCommMonoid A] [Module R A] extends CoalgebraStruct R A where
   /-- The comultiplication is coassociative -/
   coassoc : TensorProduct.assoc R A A A ∘ₗ comul.rTensor A ∘ₗ comul = comul.lTensor A ∘ₗ comul
   /-- The counit satisfies the left counitality law -/

--- a/Mathlib/RingTheory/Coalgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra.lean
@@ -133,21 +133,21 @@ theorem comul_comp_inr :
     comul ∘ₗ inr R A B = TensorProduct.map (.inr R A B) (.inr R A B) ∘ₗ comul := by
   ext; simp
 
-theorem map_fst_fst_comp_comul :
-    TensorProduct.map (.fst R A B) (.fst R A B) ∘ₗ comul = comul ∘ₗ .fst R A B := by
+theorem comul_comp_fst :
+    comul ∘ₗ .fst R A B = TensorProduct.map (.fst R A B) (.fst R A B) ∘ₗ comul := by
   ext : 1
-  · rw [comp_assoc, comul_comp_inl, ← comp_assoc, ← TensorProduct.map_comp, fst_comp_inl,
-      TensorProduct.map_id, id_comp, comp_assoc, fst_comp_inl, comp_id]
-  · rw [comp_assoc, comul_comp_inr, ← comp_assoc, ← TensorProduct.map_comp, fst_comp_inr,
-      TensorProduct.map_zero_left, zero_comp, comp_assoc, fst_comp_inr, comp_zero]
+  · rw [comp_assoc, fst_comp_inl, comp_id, comp_assoc, comul_comp_inl, ← comp_assoc,
+      ← TensorProduct.map_comp, fst_comp_inl, TensorProduct.map_id, id_comp]
+  · rw [comp_assoc, fst_comp_inr, comp_zero, comp_assoc, comul_comp_inr, ← comp_assoc,
+      ← TensorProduct.map_comp, fst_comp_inr, TensorProduct.map_zero_left, zero_comp]
 
-theorem map_snd_snd_comp_comul :
-    TensorProduct.map (.snd R A B) (.snd R A B) ∘ₗ comul = comul ∘ₗ .snd R A B := by
+theorem comul_comp_snd :
+    comul ∘ₗ .snd R A B = TensorProduct.map (.snd R A B) (.snd R A B) ∘ₗ comul := by
   ext : 1
-  · rw [comp_assoc, comul_comp_inl, ← comp_assoc, ← TensorProduct.map_comp, snd_comp_inl,
-      TensorProduct.map_zero_left, zero_comp, comp_assoc, snd_comp_inl, comp_zero]
-  · rw [comp_assoc, comul_comp_inr, ← comp_assoc, ← TensorProduct.map_comp, snd_comp_inr,
-      TensorProduct.map_id, id_comp, comp_assoc, snd_comp_inr, comp_id]
+  · rw [comp_assoc, snd_comp_inl, comp_zero, comp_assoc, comul_comp_inl, ← comp_assoc,
+      ← TensorProduct.map_comp, snd_comp_inl, TensorProduct.map_zero_left, zero_comp]
+  · rw [comp_assoc, snd_comp_inr, comp_id, comp_assoc, comul_comp_inr, ← comp_assoc,
+      ← TensorProduct.map_comp, snd_comp_inr, TensorProduct.map_id, id_comp]
 
 @[simp] theorem counit_comp_inr : counit ∘ₗ inr R A B = counit := by ext; simp
 

--- a/Mathlib/RingTheory/Coalgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra.lean
@@ -133,7 +133,13 @@ instance instCoalgebra : Coalgebra R (A × B) where
       rfl
   coassoc := by
     ext x : 2 <;> dsimp
-    sorry
+    · simp only [map_zero, add_zero]
+      simp_rw [←LinearMap.comp_apply, ←LinearMap.comp_assoc, rTensor_comp_map, lTensor_comp_map,
+        coprod_inl, ←map_comp_rTensor, ←map_comp_lTensor, comp_assoc, ←coassoc, assoc_map]
+      simp?
+      have := coassoc (R := R) (A := A)
+      sorry
+    · sorry
 
 @[simp]
 theorem comul_apply (r : A × B) :

--- a/Mathlib/RingTheory/Coalgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra.lean
@@ -3,7 +3,9 @@ Copyright (c) 2023 Ali Ramsey. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ali Ramsey
 -/
-import Mathlib.RingTheory.TensorProduct
+import Mathlib.LinearAlgebra.Finsupp
+import Mathlib.LinearAlgebra.Prod
+import Mathlib.LinearAlgebra.TensorProduct
 
 /-!
 # Coalgebras
@@ -95,8 +97,6 @@ variable (R : Type u) (A : Type v) (B : Type w)
 variable [CommSemiring R] [AddCommMonoid A] [AddCommMonoid B] [Module R A] [Module R B]
 variable [Coalgebra R A] [Coalgebra R B]
 
-notation f " ∘ₗ' " g => LinearMap.comp f g
-
 open LinearMap in
 instance instCoalgebra : Coalgebra R (A × B) where
   comul := .coprod
@@ -106,46 +106,43 @@ instance instCoalgebra : Coalgebra R (A × B) where
   rTensor_counit_comp_comul := by
     ext x : 2 <;> dsimp
     · simp only [map_zero, add_zero]
-      simp_rw [←LinearMap.comp_apply, ←LinearMap.comp_assoc, ←LinearMap.lTensor_comp_rTensor,
-        ←LinearMap.comp_assoc, LinearMap.rTensor_comp_lTensor, ←LinearMap.lTensor_comp_rTensor,
-        LinearMap.comp_assoc _ (.rTensor _ _), ←LinearMap.rTensor_comp, LinearMap.coprod_inl,
-        LinearMap.comp_assoc, rTensor_counit_comp_comul]
+      simp_rw [←comp_apply, ←comp_assoc, ←lTensor_comp_rTensor, ←comp_assoc, rTensor_comp_lTensor,
+        ←lTensor_comp_rTensor, comp_assoc _ (.rTensor _ _), ←rTensor_comp, coprod_inl, comp_assoc,
+        rTensor_counit_comp_comul]
       rfl
     · simp only [map_zero, zero_add]
-      simp_rw [←LinearMap.comp_apply, ←LinearMap.comp_assoc, ←LinearMap.lTensor_comp_rTensor,
-        ←LinearMap.comp_assoc, LinearMap.rTensor_comp_lTensor, ←LinearMap.lTensor_comp_rTensor,
-        LinearMap.comp_assoc _ (.rTensor _ _), ←LinearMap.rTensor_comp, LinearMap.coprod_inr,
-        LinearMap.comp_assoc, rTensor_counit_comp_comul]
+      simp_rw [←comp_apply, ←comp_assoc, ←lTensor_comp_rTensor, ←comp_assoc, rTensor_comp_lTensor,
+        ←lTensor_comp_rTensor, comp_assoc _ (.rTensor _ _), ←rTensor_comp, coprod_inr, comp_assoc,
+        rTensor_counit_comp_comul]
       rfl
   lTensor_counit_comp_comul := by
     ext x : 2 <;> dsimp
     · simp only [map_zero, add_zero]
-      simp_rw [←LinearMap.comp_apply, ←LinearMap.comp_assoc, ←LinearMap.rTensor_comp_lTensor,
-        ←LinearMap.comp_assoc, LinearMap.lTensor_comp_rTensor, ←LinearMap.rTensor_comp_lTensor,
-        LinearMap.comp_assoc _ (.lTensor _ _), ←LinearMap.lTensor_comp, LinearMap.coprod_inl,
-        LinearMap.comp_assoc, lTensor_counit_comp_comul]
+      simp_rw [←comp_apply, ←comp_assoc, ←rTensor_comp_lTensor, ←comp_assoc, lTensor_comp_rTensor,
+        ←rTensor_comp_lTensor, comp_assoc _ (.lTensor _ _), ←lTensor_comp, coprod_inl, comp_assoc,
+        lTensor_counit_comp_comul]
       rfl
     · simp only [map_zero, zero_add]
-      simp_rw [←LinearMap.comp_apply, ←LinearMap.comp_assoc, ←LinearMap.rTensor_comp_lTensor,
-        ←LinearMap.comp_assoc, LinearMap.lTensor_comp_rTensor, ←LinearMap.rTensor_comp_lTensor,
-        LinearMap.comp_assoc _ (.lTensor _ _), ←LinearMap.lTensor_comp, LinearMap.coprod_inr,
-        LinearMap.comp_assoc, lTensor_counit_comp_comul]
+      simp_rw [←comp_apply, ←comp_assoc, ←rTensor_comp_lTensor, ←comp_assoc, lTensor_comp_rTensor,
+        ←rTensor_comp_lTensor, comp_assoc _ (.lTensor _ _), ←lTensor_comp, coprod_inr, comp_assoc,
+        lTensor_counit_comp_comul]
       rfl
   coassoc := by
     ext x : 2 <;> dsimp
     · simp only [map_zero, add_zero]
-      simp_rw [←LinearMap.comp_apply, ←LinearMap.comp_assoc, rTensor_comp_map, lTensor_comp_map,
-        coprod_inl, ←map_comp_rTensor, ←map_comp_lTensor, comp_assoc, ←coassoc, assoc_map]
-      simp?
-      have := coassoc (R := R) (A := A)
-      sorry
-    · sorry
+      simp_rw [←comp_apply, ←comp_assoc, rTensor_comp_map, lTensor_comp_map, coprod_inl,
+        ←map_comp_rTensor, ←map_comp_lTensor, comp_assoc, ←coassoc, ←comp_assoc,
+        TensorProduct.map_map_comp_assoc_eq, comp_apply, LinearEquiv.coe_coe]
+    · simp only [map_zero, zero_add]
+      simp_rw [←comp_apply, ←comp_assoc, rTensor_comp_map, lTensor_comp_map, coprod_inr,
+        ←map_comp_rTensor, ←map_comp_lTensor, comp_assoc, ←coassoc, ←comp_assoc,
+        TensorProduct.map_map_comp_assoc_eq, comp_apply, LinearEquiv.coe_coe]
 
 @[simp]
 theorem comul_apply (r : A × B) :
-  comul r =
-    TensorProduct.map (.inl R A B) (.inl R A B) (comul r.1) +
-    TensorProduct.map (.inr R A B) (.inr R A B) (comul r.2) := rfl
+    comul r =
+      TensorProduct.map (.inl R A B) (.inl R A B) (comul r.1) +
+      TensorProduct.map (.inr R A B) (.inr R A B) (comul r.2) := rfl
 
 @[simp]
 theorem counit_apply (r : A × B) : (counit r : R) = counit r.1 + counit r.2 := rfl

--- a/Mathlib/RingTheory/Coalgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra.lean
@@ -155,10 +155,6 @@ theorem comul_comp_snd :
 @[simp] theorem counit_comp_inl : counit ∘ₗ inl R A B = counit := by ext; simp
 
 instance instCoalgebra : Coalgebra R (A × B) where
-  comul := .coprod
-    (TensorProduct.map (.inl R A B) (.inl R A B) ∘ₗ comul)
-    (TensorProduct.map (.inr R A B) (.inr R A B) ∘ₗ comul)
-  counit := .coprod counit counit
   rTensor_counit_comp_comul := by
     ext : 1
     · rw [comp_assoc, comul_comp_inl, ← comp_assoc, rTensor_comp_map, counit_comp_inl,
@@ -172,6 +168,7 @@ instance instCoalgebra : Coalgebra R (A × B) where
     · rw [comp_assoc, comul_comp_inr, ← comp_assoc, lTensor_comp_map, counit_comp_inr,
         ← rTensor_comp_lTensor, comp_assoc, lTensor_counit_comp_comul, rTensor_comp_flip_mk]
   coassoc := by
+    dsimp only [instCoalgebraStruct]
     ext x : 2 <;> dsimp only [comp_apply, LinearEquiv.coe_coe, coe_inl, coe_inr, coprod_apply]
     · simp only [map_zero, add_zero]
       simp_rw [← comp_apply, ← comp_assoc, rTensor_comp_map, lTensor_comp_map, coprod_inl,

--- a/Mathlib/RingTheory/Coalgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra.lean
@@ -104,38 +104,38 @@ instance instCoalgebra : Coalgebra R (A × B) where
     (TensorProduct.map (.inr R A B) (.inr R A B) ∘ₗ comul)
   counit := .coprod counit counit
   rTensor_counit_comp_comul := by
-    ext x : 2 <;> dsimp
+    ext x : 2 <;> dsimp only [comp_apply, coe_inl, coe_inr, coprod_apply, TensorProduct.mk_apply]
     · simp only [map_zero, add_zero]
-      simp_rw [←comp_apply, ←comp_assoc, ←lTensor_comp_rTensor, ←comp_assoc, rTensor_comp_lTensor,
-        ←lTensor_comp_rTensor, comp_assoc _ (.rTensor _ _), ←rTensor_comp, coprod_inl, comp_assoc,
+      simp_rw [← comp_apply, ← comp_assoc, ← lTensor_comp_rTensor, ← comp_assoc, rTensor_comp_lTensor,
+        ← lTensor_comp_rTensor, comp_assoc _ (.rTensor _ _), ← rTensor_comp, coprod_inl, comp_assoc,
         rTensor_counit_comp_comul]
       rfl
     · simp only [map_zero, zero_add]
-      simp_rw [←comp_apply, ←comp_assoc, ←lTensor_comp_rTensor, ←comp_assoc, rTensor_comp_lTensor,
-        ←lTensor_comp_rTensor, comp_assoc _ (.rTensor _ _), ←rTensor_comp, coprod_inr, comp_assoc,
+      simp_rw [← comp_apply, ← comp_assoc, ← lTensor_comp_rTensor, ← comp_assoc, rTensor_comp_lTensor,
+        ← lTensor_comp_rTensor, comp_assoc _ (.rTensor _ _), ← rTensor_comp, coprod_inr, comp_assoc,
         rTensor_counit_comp_comul]
       rfl
   lTensor_counit_comp_comul := by
-    ext x : 2 <;> dsimp
+    ext x : 2 <;> dsimp only [comp_apply, coe_inl, coe_inr, coprod_apply, TensorProduct.mk_apply]
     · simp only [map_zero, add_zero]
-      simp_rw [←comp_apply, ←comp_assoc, ←rTensor_comp_lTensor, ←comp_assoc, lTensor_comp_rTensor,
-        ←rTensor_comp_lTensor, comp_assoc _ (.lTensor _ _), ←lTensor_comp, coprod_inl, comp_assoc,
+      simp_rw [← comp_apply, ← comp_assoc, ← rTensor_comp_lTensor, ← comp_assoc, lTensor_comp_rTensor,
+        ← rTensor_comp_lTensor, comp_assoc _ (.lTensor _ _), ← lTensor_comp, coprod_inl, comp_assoc,
         lTensor_counit_comp_comul]
       rfl
     · simp only [map_zero, zero_add]
-      simp_rw [←comp_apply, ←comp_assoc, ←rTensor_comp_lTensor, ←comp_assoc, lTensor_comp_rTensor,
-        ←rTensor_comp_lTensor, comp_assoc _ (.lTensor _ _), ←lTensor_comp, coprod_inr, comp_assoc,
+      simp_rw [← comp_apply, ← comp_assoc, ← rTensor_comp_lTensor, ← comp_assoc, lTensor_comp_rTensor,
+        ← rTensor_comp_lTensor, comp_assoc _ (.lTensor _ _), ← lTensor_comp, coprod_inr, comp_assoc,
         lTensor_counit_comp_comul]
       rfl
   coassoc := by
-    ext x : 2 <;> dsimp
+    ext x : 2 <;> dsimp only [comp_apply, LinearEquiv.coe_coe, coe_inl, coe_inr, coprod_apply]
     · simp only [map_zero, add_zero]
-      simp_rw [←comp_apply, ←comp_assoc, rTensor_comp_map, lTensor_comp_map, coprod_inl,
-        ←map_comp_rTensor, ←map_comp_lTensor, comp_assoc, ←coassoc, ←comp_assoc,
+      simp_rw [← comp_apply, ← comp_assoc, rTensor_comp_map, lTensor_comp_map, coprod_inl,
+        ← map_comp_rTensor, ← map_comp_lTensor, comp_assoc, ← coassoc, ← comp_assoc,
         TensorProduct.map_map_comp_assoc_eq, comp_apply, LinearEquiv.coe_coe]
     · simp only [map_zero, zero_add]
-      simp_rw [←comp_apply, ←comp_assoc, rTensor_comp_map, lTensor_comp_map, coprod_inr,
-        ←map_comp_rTensor, ←map_comp_lTensor, comp_assoc, ←coassoc, ←comp_assoc,
+      simp_rw [← comp_apply, ← comp_assoc, rTensor_comp_map, lTensor_comp_map, coprod_inr,
+        ← map_comp_rTensor, ← map_comp_lTensor, comp_assoc, ← coassoc, ← comp_assoc,
         TensorProduct.map_map_comp_assoc_eq, comp_apply, LinearEquiv.coe_coe]
 
 @[simp]


### PR DESCRIPTION
This also splits out a `CoalgebraStruct` typeclass, to allow defining the operators and their definitional properties before committing to proving coassociativity.

These proofs are extremely painful, as you're fighting associativity all the time (and `LinearMap.comp` is very verbose in the goal view)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Salvaged from https://github.com/leanprover-community/mathlib4/pull/8621#discussion_r1408558962.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
