### PR TITLE
[Merged by Bors] - feat: add `norm_num` extensions for factorials

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5368,6 +5368,7 @@ import Mathlib.Tactic.NormNum.Ineq
 import Mathlib.Tactic.NormNum.Inv
 import Mathlib.Tactic.NormNum.IsCoprime
 import Mathlib.Tactic.NormNum.LegendreSymbol
+import Mathlib.Tactic.NormNum.NatFactorial
 import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.NatLog
 import Mathlib.Tactic.NormNum.NatSqrt

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -235,6 +235,16 @@ theorem factorial_mul_ascFactorial' (n k : ℕ) (h : 0 < n) :
   nth_rw 2 [Nat.eq_add_of_sub_eq h rfl]
   rw [Nat.sub_one, factorial_mul_ascFactorial]
 
+theorem ascFactorial_mul_ascFactorial (n l k : ℕ) :
+    n.ascFactorial l * (n + l).ascFactorial k = n.ascFactorial (l + k) := by
+  cases' n with n'
+  · cases' l with l'
+    · simp only [ascFactorial_zero, Nat.add_zero, Nat.one_mul, Nat.zero_add]
+    · simp only [Nat.add_right_comm, zero_ascFactorial, Nat.zero_add, Nat.zero_mul]
+  · apply Nat.mul_left_cancel (factorial_pos n')
+    simp only [Nat.add_assoc, ← Nat.mul_assoc, factorial_mul_ascFactorial]
+    rw [Nat.add_comm 1 l, ← Nat.add_assoc, factorial_mul_ascFactorial, Nat.add_assoc]
+
 /-- Avoid in favor of `Nat.factorial_mul_ascFactorial` if you can. ℕ-division isn't worth it. -/
 theorem ascFactorial_eq_div (n k : ℕ) : (n + 1).ascFactorial k = (n + k)! / n ! :=
   Nat.eq_div_of_mul_eq_right n.factorial_ne_zero (factorial_mul_ascFactorial _ _)

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -185,6 +185,7 @@ import Mathlib.Tactic.NormNum.Ineq
 import Mathlib.Tactic.NormNum.Inv
 import Mathlib.Tactic.NormNum.IsCoprime
 import Mathlib.Tactic.NormNum.LegendreSymbol
+import Mathlib.Tactic.NormNum.NatFactorial
 import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.NatLog
 import Mathlib.Tactic.NormNum.NatSqrt

--- a/Mathlib/Tactic/NormNum/NatFactorial.lean
+++ b/Mathlib/Tactic/NormNum/NatFactorial.lean
@@ -27,7 +27,7 @@ lemma asc_factorial_aux (n l m a b : ℕ) (h₁ : n.ascFactorial l = a)
 
 /-- Calculate `n.ascFactorial l` and return this value along with a proof of the result. -/
 partial def proveAscFactorial (n l : ℕ) (en el : Q(ℕ)) :
-    (result : ℕ) × (eresult : Q(ℕ)) × Q(($en).ascFactorial $el = $eresult) :=
+    ℕ × (eresult : Q(ℕ)) × Q(($en).ascFactorial $el = $eresult) :=
   if l ≤ 50 then
     have res : ℕ := n.ascFactorial l
     have eres : Q(ℕ) := mkRawNatLit (n.ascFactorial l)
@@ -59,7 +59,7 @@ lemma isNat_factorial {n x : ℕ} (h₁ : IsNat n x) (a : ℕ) (h₂ : (1).ascFa
   simp only [h₁.out, cast_id, ← h₂, one_ascFactorial]
 
 /-- Evaluates the `Nat.factorial` function. -/
-@[norm_num Nat.factorial _]
+@[nolint unusedHavesSuffices, norm_num Nat.factorial _]
 def evalNatFactorial : NormNumExt where eval {u α} e := do
   let .app _ (x : Q(ℕ)) ← Meta.whnfR e | failure
   have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩; have : $e =Q Nat.factorial $x := ⟨⟩
@@ -74,7 +74,7 @@ lemma isNat_ascFactorial {n x l y : ℕ} (h₁ : IsNat n x) (h₂ : IsNat l y) (
   simp [h₁.out, h₂.out, ← p]
 
 /-- Evaluates the Nat.ascFactorial function. -/
-@[norm_num Nat.ascFactorial _ _]
+@[nolint unusedHavesSuffices, norm_num Nat.ascFactorial _ _]
 def evalNatAscFactorial : NormNumExt where eval {u α} e := do
   let .app (.app _ (x : Q(ℕ))) (y : Q(ℕ)) ← Meta.whnfR e | failure
   have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩; have : $e =Q Nat.ascFactorial $x $y := ⟨⟩
@@ -111,7 +111,7 @@ private partial def evalNatDescFactorialZero {x' y' : Q(ℕ)} (x y z : Q(ℕ))
   ⟨q(nat_lit 0), q(isNat_descFactorial_zero $z $px $py rfl)⟩
 
 /-- Evaluates the `Nat.descFactorial` function. -/
-@[norm_num Nat.descFactorial _ _]
+@[nolint unusedHavesSuffices, norm_num Nat.descFactorial _ _]
 def evalNatDescFactorial : NormNumExt where eval {u α} e := do
   let .app (.app _ (x' : Q(ℕ))) (y' : Q(ℕ)) ← Meta.whnfR e | failure
   have : u =QL 0 := ⟨⟩

--- a/Mathlib/Tactic/NormNum/NatFactorial.lean
+++ b/Mathlib/Tactic/NormNum/NatFactorial.lean
@@ -26,17 +26,32 @@ lemma asc_factorial_aux (n l m a b : ℕ) (h₁ : n.ascFactorial l = a)
   apply ascFactorial_mul_ascFactorial
 
 /-- Calculate `n.ascFactorial l` and return this value along with a proof of the result. -/
-partial def proveAscFactorial (n l : ℕ) : (result : Q(ℕ)) × Q(($n).ascFactorial $l = $result) :=
+partial def proveAscFactorial (n l : ℕ) (en el : Q(ℕ)) :
+    (result : ℕ) × (eresult : Q(ℕ)) × Q(($en).ascFactorial $el = $eresult) :=
   if l ≤ 50 then
-    let res : Q(ℕ) := mkRawNatLit (n.ascFactorial l)
-    ⟨res, (q(Eq.refl $res) : Expr)⟩
+    have res : ℕ := n.ascFactorial l
+    have eres : Q(ℕ) := mkRawNatLit (n.ascFactorial l)
+    have : ($en).ascFactorial $el =Q $eres := ⟨⟩
+    ⟨res, eres, q(Eq.refl $eres)⟩
   else
-    let m : ℕ := l / 2
-    let r : ℕ := l - m
-    let ⟨a, a_prf⟩ := proveAscFactorial n m
-    let ⟨b, b_prf⟩ := proveAscFactorial (n + m) r
-    let prf : Expr := q(asc_factorial_aux $n $m $r $a $b $a_prf $b_prf)
-    ⟨mkRawNatLit (a.natLit! * b.natLit!), prf⟩
+    have m : ℕ := l / 2
+    have em : Q(ℕ) := mkRawNatLit m
+    have : $em =Q $el / 2 := ⟨⟩
+
+    have r : ℕ := l - m
+    have er : Q(ℕ) := mkRawNatLit r
+    have : $er =Q $el - $em := ⟨⟩
+    have : $el =Q ($em + $er) := ⟨⟩
+
+    have nm : ℕ := n + m
+    have enm : Q(ℕ) := mkRawNatLit nm
+    have : $enm =Q $en + $em := ⟨⟩
+
+    let ⟨a, ea, a_prf⟩ := proveAscFactorial n m en em
+    let ⟨b, eb, b_prf⟩ := proveAscFactorial (n + m) r enm er
+    have eab : Q(ℕ) := mkRawNatLit (a * b)
+    have : $eab =Q $ea * $eb := ⟨⟩
+    ⟨a * b, eab, q(by convert asc_factorial_aux $en $em $er $ea $eb $a_prf $b_prf)⟩
 
 lemma isNat_factorial {n x : ℕ} (h₁ : IsNat n x) (a : ℕ) (h₂ : (1).ascFactorial x = a) :
     IsNat (n !) a := by
@@ -47,12 +62,11 @@ lemma isNat_factorial {n x : ℕ} (h₁ : IsNat n x) (a : ℕ) (h₂ : (1).ascFa
 @[norm_num Nat.factorial _]
 def evalNatFactorial : NormNumExt where eval {u α} e := do
   let .app _ (x : Q(ℕ)) ← Meta.whnfR e | failure
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩; have : $e =Q Nat.factorial $x := ⟨⟩
   let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
   let ⟨ex, p⟩ ← deriveNat x sℕ
-  let ⟨val, ascPrf⟩ := proveAscFactorial 1 ex.natLit!
-  let ascPrf' : Q(ascFactorial 1 $ex = $val) := ascPrf
-  let prf := q(isNat_factorial $p $val $ascPrf')
-  return .isNat sℕ q($val) prf
+  let ⟨_, val, ascPrf⟩ := proveAscFactorial 1 ex.natLit! q(nat_lit 1) ex
+  return .isNat sℕ q($val) q(isNat_factorial $p $val $ascPrf)
 
 lemma isNat_ascFactorial {n x l y : ℕ} (h₁ : IsNat n x) (h₂ : IsNat l y) (a : ℕ)
     (p : x.ascFactorial y = a) : IsNat (n.ascFactorial l) a := by
@@ -63,13 +77,12 @@ lemma isNat_ascFactorial {n x l y : ℕ} (h₁ : IsNat n x) (h₂ : IsNat l y) (
 @[norm_num Nat.ascFactorial _ _]
 def evalNatAscFactorial : NormNumExt where eval {u α} e := do
   let .app (.app _ (x : Q(ℕ))) (y : Q(ℕ)) ← Meta.whnfR e | failure
+  have : u =QL 0 := ⟨⟩; have : $α =Q ℕ := ⟨⟩; have : $e =Q Nat.ascFactorial $x $y := ⟨⟩
   let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
   let ⟨ex₁, p₁⟩ ← deriveNat x sℕ
   let ⟨ex₂, p₂⟩ ← deriveNat y sℕ
-  let ⟨val, ascPrf⟩ := proveAscFactorial (ex₁.natLit!) (ex₂.natLit!)
-  let ascPrf' : Q(ascFactorial $ex₁ $ex₂ = $val) := ascPrf
-  let prf := q(isNat_ascFactorial $p₁ $p₂ $val $ascPrf')
-  return .isNat sℕ q($val) prf
+  let ⟨_, val, ascPrf⟩ := proveAscFactorial ex₁.natLit! ex₂.natLit! ex₁ ex₂
+  return .isNat sℕ q($val) q(isNat_ascFactorial $p₁ $p₂ $val $ascPrf)
 
 lemma isNat_descFactorial {n x l y : ℕ} (z : ℕ) (h₁ : IsNat n x) (h₂ : IsNat l y)
     (h₃ : x = z + y) (a : ℕ) (p : (z + 1).ascFactorial y = a) : IsNat (n.descFactorial l) a := by
@@ -82,37 +95,41 @@ lemma isNat_descFactorial_zero {n x l y : ℕ} (z : ℕ) (h₁ : IsNat n x) (h�
   constructor
   simp [h₁.out, h₂.out, h₃]
 
-private partial def evalNatDescFactorialNotZero {x' y' : Q(ℕ)} (x y z : Q(ℕ)) (px : Q(IsNat $x' $x))
-    (py : Q(IsNat $y' $y)) : (n : Q(ℕ)) × Q(IsNat (descFactorial $x' $y') $n) :=
-  let eq_prf : Q($x = $z + $y) := (q(Eq.refl $x) : Expr)
-  let ⟨val, ascPrf⟩ := proveAscFactorial (z.natLit! + 1) (y.natLit!)
-  let ascPrf : Q(ascFactorial ($z + 1) $y = $val) := ascPrf
-  let prf : Q(IsNat (descFactorial $x' $y') $val) :=
-    q(isNat_descFactorial $z $px $py $eq_prf $val $ascPrf)
-  ⟨val, prf⟩
+private partial def evalNatDescFactorialNotZero {x' y' : Q(ℕ)} (x y z : Q(ℕ))
+    (_hx : $x =Q $z + $y)
+    (px : Q(IsNat $x' $x)) (py : Q(IsNat $y' $y)) :
+    (n : Q(ℕ)) × Q(IsNat (descFactorial $x' $y') $n) :=
+  have zp1 :Q(ℕ) := mkRawNatLit (z.natLit! + 1)
+  have : $zp1 =Q $z + 1 := ⟨⟩
+  let ⟨_, val, ascPrf⟩ := proveAscFactorial (z.natLit! + 1) y.natLit! zp1 y
+  ⟨val, q(isNat_descFactorial $z $px $py rfl $val $ascPrf)⟩
 
-private partial def evalNatDescFactorialZero {x' y' : Q(ℕ)} (x y z : Q(ℕ)) (px : Q(IsNat $x' $x))
-    (py : Q(IsNat $y' $y)) : (n : Q(ℕ)) × Q(IsNat (descFactorial $x' $y') $n) :=
-  let eq_prf : Q($y = $z + $x + 1) := (q(Eq.refl $y) : Expr)
-  let prf : Q(IsNat (descFactorial $x' $y') 0) :=
-    q(isNat_descFactorial_zero $z $px $py $eq_prf)
-  ⟨q(nat_lit 0), prf⟩
+private partial def evalNatDescFactorialZero {x' y' : Q(ℕ)} (x y z : Q(ℕ))
+    (_hy : $y =Q $z + $x + 1)
+    (px : Q(IsNat $x' $x)) (py : Q(IsNat $y' $y)) :
+    (n : Q(ℕ)) × Q(IsNat (descFactorial $x' $y') $n) :=
+  ⟨q(nat_lit 0), q(isNat_descFactorial_zero $z $px $py rfl)⟩
 
-/-- Evaluates the Nat.ascFactorial function. -/
+/-- Evaluates the `Nat.descFactorial` function. -/
 @[norm_num Nat.descFactorial _ _]
 def evalNatDescFactorial : NormNumExt where eval {u α} e := do
   let .app (.app _ (x' : Q(ℕ))) (y' : Q(ℕ)) ← Meta.whnfR e | failure
+  have : u =QL 0 := ⟨⟩
+  have : $α =Q ℕ := ⟨⟩
+  have : $e =Q Nat.descFactorial $x' $y' := ⟨⟩
   let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
   let ⟨x, p₁⟩ ← deriveNat x' sℕ
   let ⟨y, p₂⟩ ← deriveNat y' sℕ
   if x.natLit! ≥ y.natLit! then
-    let z : ℕ := x.natLit! - y.natLit!
-    let ⟨val, prf⟩ := evalNatDescFactorialNotZero (x' := x') (y' := y') x y (mkRawNatLit z) p₁ p₂
-    return .isNat sℕ val prf
+    have z : Q(ℕ) := mkRawNatLit (x.natLit! - y.natLit!)
+    have : $x =Q $z + $y := ⟨⟩
+    let ⟨val, prf⟩ := evalNatDescFactorialNotZero (x' := x') (y' := y') x y z ‹_› p₁ p₂
+    return .isNat sℕ val q($prf)
   else
-    let z : ℕ := y.natLit! - x.natLit! - 1
-    let ⟨val, prf⟩ := evalNatDescFactorialZero (x' := x') (y' := y') x y (mkRawNatLit z) p₁ p₂
-    return .isNat sℕ val prf
+    have z : Q(ℕ) := mkRawNatLit (y.natLit! - x.natLit! - 1)
+    have : $y =Q $z + $x + 1 := ⟨⟩
+    let ⟨val, prf⟩ := evalNatDescFactorialZero (x' := x') (y' := y') x y z ‹_› p₁ p₂
+    return .isNat sℕ val q($prf)
 
 end NormNum
 

--- a/Mathlib/Tactic/NormNum/NatFactorial.lean
+++ b/Mathlib/Tactic/NormNum/NatFactorial.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2023 Sebastian Zimmer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Zimmer
+-/
+import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Tactic.NormNum
+
+/-! # `norm_num` extensions for factorials
+
+Extensions for `norm_num` that compute `Nat.factorial`, `Nat.ascFactorial` and `Nat.descFactorial`.
+
+This is done by reducing each of these to `ascFactorial`, which is computed using a divide and
+conquer strategy that improves performance and avoids exceeding the recursion depth.
+
+-/
+
+namespace Mathlib.Meta.NormNum
+
+open Nat Qq Lean Elab.Tactic Qq Meta
+
+lemma ascFactorial_mul_ascFactorial (n l k : ℕ) :
+    n.ascFactorial l * (n + l).ascFactorial k = n.ascFactorial (l + k) := by
+  apply mul_left_cancel₀ (factorial_pos n).ne.symm
+  simp [factorial_mul_ascFactorial, ← mul_assoc, add_assoc]
+
+lemma asc_factorial_aux (n l m a b : ℕ) (h₁ : n.ascFactorial l = a)
+    (h₂ : (n + l).ascFactorial m = b) : n.ascFactorial (l + m) = a * b := by
+  rw [← h₁, ← h₂]
+  symm
+  apply ascFactorial_mul_ascFactorial
+
+/-- Calculate `n.ascFactorial l` and return this value along with a proof of the result. -/
+partial def proveAscFactorial (n l : ℕ) : (result : Q(ℕ)) × Q(($n).ascFactorial $l = $result) :=
+  if l ≤ 50 then
+    let res : Q(ℕ) := mkRawNatLit (n.ascFactorial l)
+    ⟨res, (q(Eq.refl $res) : Expr)⟩
+  else
+    let m : ℕ := l / 2
+    let r : ℕ := l - m
+    let ⟨a, a_prf⟩ := proveAscFactorial n m
+    let ⟨b, b_prf⟩ := proveAscFactorial (n + m) r
+    let prf : Expr := q(asc_factorial_aux $n $m $r $a $b $a_prf $b_prf)
+    ⟨mkRawNatLit (a.natLit! * b.natLit!), prf⟩
+
+lemma isNat_factorial {n x : ℕ} (h₁ : IsNat n x) (a : ℕ) (h₂ : (0).ascFactorial x = a) :
+    IsNat (n !) a := by
+  constructor
+  simp [zero_ascFactorial, h₁.out, ← h₂]
+
+/-- Evaluates the `Nat.factorial` function. -/
+@[norm_num Nat.factorial _]
+def evalNatFactorial : NormNumExt where eval {u α} e := do
+  let .app _ (x : Q(ℕ)) ← Meta.whnfR e | failure
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let ⟨ex, p⟩ ← deriveNat x sℕ
+  let ⟨val, ascPrf⟩ := proveAscFactorial 0 ex.natLit!
+  let ascPrf' : Q(ascFactorial 0 $ex = $val) := ascPrf
+  let prf := q(isNat_factorial $p $val $ascPrf')
+  return .isNat sℕ q($val) prf
+
+lemma isNat_ascFactorial {n x l y : ℕ} (h₁ : IsNat n x) (h₂ : IsNat l y) (a : ℕ)
+    (p : (x).ascFactorial y = a) : IsNat (n.ascFactorial l) a := by
+  constructor
+  simp [h₁.out, h₂.out, ← p]
+
+/-- Evaluates the Nat.ascFactorial function. -/
+@[norm_num Nat.ascFactorial _ _]
+def evalNatAscFactorial : NormNumExt where eval {u α} e := do
+  let .app (.app _ (x : Q(ℕ))) (y : Q(ℕ)) ← Meta.whnfR e | failure
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let ⟨ex₁, p₁⟩ ← deriveNat x sℕ
+  let ⟨ex₂, p₂⟩ ← deriveNat y sℕ
+  let ⟨val, ascPrf⟩ := proveAscFactorial (ex₁.natLit!) (ex₂.natLit!)
+  let ascPrf' : Q(ascFactorial $ex₁ $ex₂ = $val) := ascPrf
+  let prf := q(isNat_ascFactorial $p₁ $p₂ $val $ascPrf')
+  return .isNat sℕ q($val) prf
+
+lemma isNat_descFactorial {n x l y : ℕ} (z : ℕ) (h₁ : IsNat n x) (h₂ : IsNat l y)
+    (h₃ : x = z + y) (a : ℕ) (p : z.ascFactorial y = a) : IsNat (n.descFactorial l) a := by
+  constructor
+  simp [h₁.out, h₂.out, ← p, h₃]
+  apply Nat.add_descFactorial_eq_ascFactorial
+
+lemma isNat_descFactorial_zero {n x l y : ℕ} (z : ℕ) (h₁ : IsNat n x) (h₂ : IsNat l y)
+    (h₃ : y = z + x + 1) : IsNat (n.descFactorial l) 0 := by
+  constructor
+  simp [h₁.out, h₂.out, h₃]
+
+private partial def evalNatDescFactorialNotZero {x' y' : Q(ℕ)} (x y z : Q(ℕ)) (px : Q(IsNat $x' $x))
+    (py : Q(IsNat $y' $y)) : Expr × Expr :=
+  let eq_prf : Q($x = $z + $y) := (q(Eq.refl $x) : Expr)
+  let ⟨val, ascPrf⟩ := proveAscFactorial (z.natLit!) (y.natLit!)
+  let ascPrf : Q(ascFactorial $z $y = $val) := ascPrf
+  let prf : Q(IsNat (descFactorial $x' $y') $val) :=
+    q(isNat_descFactorial $z $px $py $eq_prf $val $ascPrf)
+  (val, prf)
+
+private partial def evalNatDescFactorialZero {x' y' : Q(ℕ)} (x y z : Q(ℕ)) (px : Q(IsNat $x' $x))
+    (py : Q(IsNat $y' $y)) : Expr × Expr :=
+  let eq_prf : Q($y = $z + $x + 1) := (q(Eq.refl $y) : Expr)
+  let prf : Q(IsNat (descFactorial $x' $y') 0) :=
+    q(isNat_descFactorial_zero $z $px $py $eq_prf)
+  (mkRawNatLit 0, prf)
+
+/-- Evaluates the Nat.ascFactorial function. -/
+@[norm_num Nat.descFactorial _ _]
+def evalNatDescFactorial : NormNumExt where eval {u α} e := do
+  let .app (.app _ (x' : Q(ℕ))) (y' : Q(ℕ)) ← Meta.whnfR e | failure
+  let sℕ : Q(AddMonoidWithOne ℕ) := q(instAddMonoidWithOneNat)
+  let ⟨x, p₁⟩ ← deriveNat x' sℕ
+  let ⟨y, p₂⟩ ← deriveNat y' sℕ
+  if x.natLit! ≥ y.natLit! then
+    let z : ℕ := x.natLit! - y.natLit!
+    let (val, prf) := evalNatDescFactorialNotZero (x' := x') (y' := y') x y (mkRawNatLit z) p₁ p₂
+    return .isNat sℕ val prf
+  else
+    let z : ℕ := y.natLit! - x.natLit! - 1
+    let (val, prf) := evalNatDescFactorialZero (x' := x') (y' := y') x y (mkRawNatLit z) p₁ p₂
+    return .isNat sℕ val prf

--- a/Mathlib/Tactic/NormNum/NatFactorial.lean
+++ b/Mathlib/Tactic/NormNum/NatFactorial.lean
@@ -88,20 +88,20 @@ lemma isNat_descFactorial_zero {n x l y : ℕ} (z : ℕ) (h₁ : IsNat n x) (h�
   simp [h₁.out, h₂.out, h₃]
 
 private partial def evalNatDescFactorialNotZero {x' y' : Q(ℕ)} (x y z : Q(ℕ)) (px : Q(IsNat $x' $x))
-    (py : Q(IsNat $y' $y)) : Expr × Expr :=
+    (py : Q(IsNat $y' $y)) : (n : Q(ℕ)) × Q(IsNat (descFactorial $x' $y') $n) :=
   let eq_prf : Q($x = $z + $y) := (q(Eq.refl $x) : Expr)
   let ⟨val, ascPrf⟩ := proveAscFactorial (z.natLit!) (y.natLit!)
   let ascPrf : Q(ascFactorial $z $y = $val) := ascPrf
   let prf : Q(IsNat (descFactorial $x' $y') $val) :=
     q(isNat_descFactorial $z $px $py $eq_prf $val $ascPrf)
-  (val, prf)
+  ⟨val, prf⟩
 
 private partial def evalNatDescFactorialZero {x' y' : Q(ℕ)} (x y z : Q(ℕ)) (px : Q(IsNat $x' $x))
-    (py : Q(IsNat $y' $y)) : Expr × Expr :=
+    (py : Q(IsNat $y' $y)) : (n : Q(ℕ)) × Q(IsNat (descFactorial $x' $y') $n) :=
   let eq_prf : Q($y = $z + $x + 1) := (q(Eq.refl $y) : Expr)
   let prf : Q(IsNat (descFactorial $x' $y') 0) :=
     q(isNat_descFactorial_zero $z $px $py $eq_prf)
-  (mkRawNatLit 0, prf)
+  ⟨q(nat_lit 0), prf⟩
 
 /-- Evaluates the Nat.ascFactorial function. -/
 @[norm_num Nat.descFactorial _ _]
@@ -112,9 +112,9 @@ def evalNatDescFactorial : NormNumExt where eval {u α} e := do
   let ⟨y, p₂⟩ ← deriveNat y' sℕ
   if x.natLit! ≥ y.natLit! then
     let z : ℕ := x.natLit! - y.natLit!
-    let (val, prf) := evalNatDescFactorialNotZero (x' := x') (y' := y') x y (mkRawNatLit z) p₁ p₂
+    let ⟨val, prf⟩ := evalNatDescFactorialNotZero (x' := x') (y' := y') x y (mkRawNatLit z) p₁ p₂
     return .isNat sℕ val prf
   else
     let z : ℕ := y.natLit! - x.natLit! - 1
-    let (val, prf) := evalNatDescFactorialZero (x' := x') (y' := y') x y (mkRawNatLit z) p₁ p₂
+    let ⟨val, prf⟩ := evalNatDescFactorialZero (x' := x') (y' := y') x y (mkRawNatLit z) p₁ p₂
     return .isNat sℕ val prf

--- a/MathlibTest/norm_num_ext.lean
+++ b/MathlibTest/norm_num_ext.lean
@@ -7,6 +7,7 @@ import Mathlib.Tactic.NormNum.BigOperators
 import Mathlib.Tactic.NormNum.GCD
 import Mathlib.Tactic.NormNum.IsCoprime
 import Mathlib.Tactic.NormNum.DivMod
+import Mathlib.Tactic.NormNum.NatFactorial
 import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.NatLog
 import Mathlib.Tactic.NormNum.NatSqrt
@@ -493,3 +494,25 @@ example : Real.sqrt 0 = 0 := by norm_num
 example : NNReal.sqrt 0 = 0 := by norm_num
 
 end real_sqrt
+
+section Factorial
+
+open Nat
+
+example : 0! = 1 := by norm_num1
+example : 1! = 1 := by norm_num1
+example : 2! = 2 := by norm_num1
+example : 3! = 6 := by norm_num1
+example : 4! = 24 := by norm_num1
+
+example : 10! = 3628800 := by norm_num1
+example : 1000! / 999! = 1000 := by norm_num1
+example : (Nat.sqrt 1024)! = 32! := by norm_num1
+example : (1 : ℚ) / 0 ! + 1 / 1 ! + 1 / 2 ! + 1 / 3! + 1 / 4! = 65 / 24 := by norm_num1
+
+example : (3 + 2).ascFactorial 3 = 336 := by norm_num1
+
+example : (5 + 5).descFactorial 2 = 90 := by norm_num1
+example : (1000000).descFactorial 1000001 = 0 := by norm_num1
+
+end Factorial

--- a/MathlibTest/norm_num_ext.lean
+++ b/MathlibTest/norm_num_ext.lean
@@ -514,4 +514,6 @@ example : (4 + 2).ascFactorial 3 = 336 := by norm_num1
 example : (5 + 5).descFactorial 2 = 90 := by norm_num1
 example : (1000000).descFactorial 1000001 = 0 := by norm_num1
 
+example : (200 : ℕ) ! / (10 ^ 370) = 78865 := by norm_num1
+
 end Factorial

--- a/MathlibTest/norm_num_ext.lean
+++ b/MathlibTest/norm_num_ext.lean
@@ -510,8 +510,7 @@ example : 1000! / 999! = 1000 := by norm_num1
 example : (Nat.sqrt 1024)! = 32! := by norm_num1
 example : (1 : ℚ) / 0 ! + 1 / 1 ! + 1 / 2 ! + 1 / 3! + 1 / 4! = 65 / 24 := by norm_num1
 
-example : (3 + 2).ascFactorial 3 = 336 := by norm_num1
-
+example : (4 + 2).ascFactorial 3 = 336 := by norm_num1
 example : (5 + 5).descFactorial 2 = 90 := by norm_num1
 example : (1000000).descFactorial 1000001 = 0 := by norm_num1
 


### PR DESCRIPTION
Add `norm_num` extensions to evaluate `Nat.factorial`, `Nat.ascFactorial` and `Nat.descFactorial`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
