### PR TITLE
[Merged by Bors] - feat: lake exe cache lookup

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -70,7 +70,7 @@ def CURLBIN :=
 
 /-- leantar version at https://github.com/digama0/leangz -/
 def LEANTARVERSION :=
-  "0.1.9"
+  "0.1.10"
 
 def EXE := if System.Platform.isWindows then ".exe" else ""
 
@@ -360,5 +360,19 @@ instance : Ord FilePath where
 def cleanCache (keep : Lean.RBTree FilePath compare := default) : IO Unit := do
   for path in ← getFilesWithExtension CACHEDIR "ltar" do
     if !keep.contains path then IO.FS.removeFile path
+
+/-- Prints the LTAR file and embedded comments (in particular, the mathlib commit that built the
+file) regarding the files with specified paths. -/
+def lookup (hashMap : HashMap) (paths : List FilePath) : IO Unit := do
+  let mut err := false
+  for path in paths do
+    match hashMap.find? path with
+    | none => err := true
+    | some hash =>
+      let ltar := CACHEDIR / hash.asLTar
+      IO.println s!"{path}: {ltar}"
+      for line in (← runCmd (← getLeanTar) #["-k", ltar.toString]).splitOn "\n" |>.dropLast do
+        println! "  commment: {line}"
+  if err then IO.Process.exit 1
 
 end Cache.IO

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -366,13 +366,11 @@ file) regarding the files with specified paths. -/
 def lookup (hashMap : HashMap) (paths : List FilePath) : IO Unit := do
   let mut err := false
   for path in paths do
-    match hashMap.find? path with
-    | none => err := true
-    | some hash =>
-      let ltar := CACHEDIR / hash.asLTar
-      IO.println s!"{path}: {ltar}"
-      for line in (← runCmd (← getLeanTar) #["-k", ltar.toString]).splitOn "\n" |>.dropLast do
-        println! "  commment: {line}"
+    let some hash := hashMap.find? path | err := true
+    let ltar := CACHEDIR / hash.asLTar
+    IO.println s!"{path}: {ltar}"
+    for line in (← runCmd (← getLeanTar) #["-k", ltar.toString]).splitOn "\n" |>.dropLast do
+      println! "  comment: {line}"
   if err then IO.Process.exit 1
 
 end Cache.IO

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -20,6 +20,7 @@ Commands:
   unpack!      Decompress linked already downloaded files (no skipping)
   clean        Delete non-linked files
   clean!       Delete everything on the local cache
+  lookup       Show information about cache files for the given lean files
 
   # Privilege required
   put          Run 'mk' then upload linked files missing on the server

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -59,7 +59,7 @@ def curlArgs : List String :=
   ["get", "get!", "get-", "put", "put!", "commit", "commit!"]
 
 def leanTarArgs : List String :=
-  ["get", "get!", "pack", "pack!", "unpack"]
+  ["get", "get!", "pack", "pack!", "unpack", "lookup"]
 
 open Cache IO Hashing Requests System in
 def main (args : List String) : IO Unit := do
@@ -102,4 +102,5 @@ def main (args : List String) : IO Unit := do
     if !(← isGitStatusClean) then IO.println "Please commit your changes first" return else
     commit hashMap true (← getToken)
   | ["collect"] => IO.println "TODO"
+  | "lookup" :: args => lookup hashMap (toPaths args)
   | _ => println help


### PR DESCRIPTION
This allows you to query information regarding the cache:
```
$ lake exe cache lookup Mathlib/MeasureTheory/Measure/FiniteMeasureProd.lean
Mathlib/MeasureTheory/Measure/FiniteMeasureProd.lean: /home/mario/.cache/mathlib/0875116721fafda8.ltar
  comment: git=mathlib4@a4d9e50aa274cb8057bf09c845de139ccd4b0164
```
This says, for a given lean file, where to find the ltar file that it is unpacked from/to, as well as the metadata contained in the file, which currently means the commit which built the file. (This is not necessarily the same as the current commit, because not every commit builds all files, many files are grandfathered from earlier commits, sometimes even builds that failed, like in this example.) This is useful for debugging [certain issues](https://github.com/leanprover-community/mathlib4/pull/8834/files#r1416613607).

The leantar version was bumped [from `0.1.9` to `0.1.10`](https://github.com/digama0/leangz/compare/v0.1.9..v0.1.10), mainly because this includes a bugfix for the `-k` option of leantar that was exposed while testing this command.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
