### PR TITLE
[Merged by Bors] - refactor(Control/ULiftable): use `outParam` and adjust universe orders

### DIFF
--- a/Mathlib/Control/Random.lean
+++ b/Mathlib/Control/Random.lean
@@ -97,7 +97,7 @@ instance : Random Bool where
   random := randBool
 
 instance {α : Type u} [Random α] : Random (ULift.{v} α) where
-  random {g} := ULiftable.up (random : RandG g α)
+  random := ULiftable.up random
 
 instance : BoundedRandom Nat where
   randomR := λ lo hi h _ => do
@@ -123,10 +123,9 @@ instance {n : Nat} : BoundedRandom (Fin n) where
     pure ⟨⟨r, Nat.lt_of_le_of_lt h2 hi.isLt⟩, h1, h2⟩
 
 instance {α : Type u} [Preorder α] [BoundedRandom α] : BoundedRandom (ULift.{v} α) where
-  randomR {g} lo hi h := do
-    let ⟨v⟩
-      ← (ULiftable.up (BoundedRandom.randomR lo.down hi.down h : RandG g _) : RandG g (ULift.{v} _))
-    pure ⟨ULift.up v.val, v.prop⟩
+  randomR lo hi h := do
+    let ⟨x⟩ ← ULiftable.up.{v} (BoundedRandom.randomR lo.down hi.down h)
+    pure ⟨ULift.up x.val, x.prop⟩
 
 end Random
 

--- a/Mathlib/Control/ULiftable.lean
+++ b/Mathlib/Control/ULiftable.lean
@@ -37,20 +37,26 @@ universe polymorphism functor
 -/
 
 
-universe u₀ u₁ v₀ v₁ v₂ w w₀ w₁
+universe v u₀ u₁ v₀ v₁ v₂ w w₀ w₁
 
 variable {s : Type u₀} {s' : Type u₁} {r r' w w' : Type*}
 
 /-- Given a universe polymorphic type family `M.{u} : Type u₁ → Type
 u₂`, this class convert between instantiations, from
-`M.{u} : Type u₁ → Type u₂` to `M.{v} : Type v₁ → Type v₂` and back -/
-class ULiftable (f : Type u₀ → Type u₁) (g : Type v₀ → Type v₁) where
+`M.{u} : Type u₁ → Type u₂` to `M.{v} : Type v₁ → Type v₂` and back.
+
+`f` is an outParam, because `g` can almost always be inferred from the current monad.
+At any rate, the lift should be unique, as the intent is to only lift the same constants with
+different universe parameters. -/
+class ULiftable (f : outParam (Type u₀ → Type u₁)) (g : Type v₀ → Type v₁) where
   congr {α β} : α ≃ β → f α ≃ g β
 #align uliftable ULiftable
 
 namespace ULiftable
 
-instance symm (f : Type u₀ → Type u₁) (g : Type v₀ → Type v₁) [ULiftable f g] : ULiftable g f where
+/-- Not an instance as it is incompatible with `outParam`. In practice it seems not to be needed
+anyway. -/
+abbrev symm (f : Type u₀ → Type u₁) (g : Type v₀ → Type v₁) [ULiftable f g] : ULiftable g f where
   congr e := (ULiftable.congr e.symm).symm
 
 instance refl (f : Type u₀ → Type u₁) [Functor f] [LawfulFunctor f] : ULiftable f f where
@@ -58,19 +64,19 @@ instance refl (f : Type u₀ → Type u₁) [Functor f] [LawfulFunctor f] : ULif
 
 example : ULiftable IO IO := inferInstance
 
-/-- The most common practical use `ULiftable` (together with `down`), this function takes
+/-- The most common practical use `ULiftable` (together with `down`), the function `up.{v}` takes
 `x : M.{u} α` and lifts it to `M.{max u v} (ULift.{v} α)` -/
 @[reducible]
-def up {f : Type u₀ → Type u₁} {g : Type max u₀ v₀ → Type v₁} [ULiftable f g] {α} :
-    f α → g (ULift.{v₀} α) :=
+def up {f : Type u₀ → Type u₁} {g : Type max u₀ v → Type v₁} [ULiftable f g] {α} :
+    f α → g (ULift.{v} α) :=
   (ULiftable.congr Equiv.ulift.symm).toFun
 #align uliftable.up ULiftable.up
 
-/-- The most common practical use of `ULiftable` (together with `up`), this function takes
+/-- The most common practical use of `ULiftable` (together with `up`), the function `down.{v}` takes
 `x : M.{max u v} (ULift.{v} α)` and lowers it to `M.{u} α` -/
 @[reducible]
-def down {f : Type u₀ → Type u₁} {g : Type max u₀ v₀ → Type v₁} [ULiftable f g] {α} :
-    g (ULift.{v₀} α) → f α :=
+def down {f : Type u₀ → Type u₁} {g : Type max u₀ v → Type v₁} [ULiftable f g] {α} :
+    g (ULift.{v} α) → f α :=
   (ULiftable.congr Equiv.ulift.symm).invFun
 #align uliftable.down ULiftable.down
 
@@ -83,7 +89,7 @@ def adaptUp (F : Type v₀ → Type v₁) (G : Type max v₀ u₀ → Type u₁)
 /-- convenient shortcut to avoid manipulating `ULift` -/
 def adaptDown {F : Type max u₀ v₀ → Type u₁} {G : Type v₀ → Type v₁} [L : ULiftable G F] [Monad F]
     {α β} (x : F α) (f : α → G β) : G β :=
-  @down.{v₀, v₁, max u₀ v₀} G F L β <| x >>= @up.{v₀, v₁, max u₀ v₀} G F L β ∘ f
+  @down.{max u₀ v₀} G F L β <| x >>= @up.{max u₀ v₀} G F L β ∘ f
 #align uliftable.adapt_down ULiftable.adaptDown
 
 /-- map function that moves up universes -/

--- a/Mathlib/Testing/SlimCheck/Functions.lean
+++ b/Mathlib/Testing/SlimCheck/Functions.lean
@@ -146,7 +146,7 @@ instance Pi.sampleableExt : SampleableExt (α → β) where
   interp f := SampleableExt.interp ∘ f.apply
   sample := do
     let xs : List (_ × _) ← (SampleableExt.sample (α := List (α × β)))
-    let ⟨x⟩ ← (ULiftable.up.{max u ub} <| SampleableExt.sample : Gen (ULift _))
+    let ⟨x⟩ ← ULiftable.up.{max u ub} <| (SampleableExt.sample : Gen (SampleableExt.proxy β))
     pure <| TotalFunction.withDefault (List.toFinmap' <| xs.map <|
       Prod.map SampleableExt.interp id) x
   -- note: no way of shrinking the domain without an inverse to `interp`

--- a/Mathlib/Testing/SlimCheck/Functions.lean
+++ b/Mathlib/Testing/SlimCheck/Functions.lean
@@ -146,8 +146,7 @@ instance Pi.sampleableExt : SampleableExt (α → β) where
   interp f := SampleableExt.interp ∘ f.apply
   sample := do
     let xs : List (_ × _) ← (SampleableExt.sample (α := List (α × β)))
-    let ⟨x⟩ ← (ULiftable.up <|
-      SampleableExt.sample : Gen (ULift.{max u ub} (SampleableExt.proxy β)))
+    let ⟨x⟩ ← (ULiftable.up.{max u ub} <| SampleableExt.sample : Gen (ULift _))
     pure <| TotalFunction.withDefault (List.toFinmap' <| xs.map <|
       Prod.map SampleableExt.interp id) x
   -- note: no way of shrinking the domain without an inverse to `interp`

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -78,7 +78,7 @@ variable {α : Type u}
 /-- Create an `Array` of examples using `x`. The size is controlled
 by the size parameter of `Gen`. -/
 def arrayOf (x : Gen α) : Gen (Array α) := do
-  let ⟨sz⟩ ← (ULiftable.up <| do choose Nat 0 (← getSize) (Nat.zero_le _) : Gen (ULift ℕ))
+  let (⟨sz⟩ : ULift ℕ) ← ULiftable.up do choose Nat 0 (← getSize) (Nat.zero_le _)
   let mut res := #[]
   for _ in [0:sz] do
     res := res.push (← x)
@@ -110,8 +110,8 @@ def permutationOf : (xs : List α) → Gen { ys // xs ~ ys }
 
 /-- Given two generators produces a tuple consisting out of the result of both -/
 def prodOf {α : Type u} {β : Type v} (x : Gen α) (y : Gen β) : Gen (α × β) := do
-  let ⟨a⟩ ← (ULiftable.up x : Gen (ULift.{max u v} α))
-  let ⟨b⟩ ← (ULiftable.up y : Gen (ULift.{max u v} β))
+  let ⟨a⟩ ← ULiftable.up.{max u v} x
+  let ⟨b⟩ ← ULiftable.up.{max u v} y
   pure (a, b)
 
 end Gen


### PR DESCRIPTION
The most useful universe argument to `up` and `down` (the one in the `ULift` type) is now first.

Combined with the `outParam`, this makes using `ULiftable.up` more ergonomic downstream, removing a handful of type annotations.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
