### PR TITLE
[Merged by Bors] - feat: allow pattern matching in set-builder notation

### DIFF
--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -125,6 +125,7 @@ macro (name := macroPattSetBuilder) (priority := low-1)
 macro (priority := low-1) "{" pat:term " | " p:term "}" : term =>
   `({ x | match x with | $pat => $p })
 
+/-- Pretty printing for set-builder notation with pattern matching. -/
 @[app_unexpander setOf]
 def setOfPatternMatchUnexpander : Lean.PrettyPrinter.Unexpander
   | `($_ fun $x:ident ↦ match $y:ident with | $pat => $p) =>

--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -109,6 +109,10 @@ make `p` come out true.  If `X` can be inferred, then `{ pat | p }` can be used.
 
 For example, `{ (m, n) : ℕ × ℕ | m * n = 12 }` denotes the set of all ordered pairs of
 natural numbers whose product is 12.
+
+Note that if the type ascription is left out and `p` can be interpreted as an extended binder,
+then the extended binder interpretation will be used.  For example, `{ n + 1 | n < 3 }` will
+be interpreted as `{ x : Nat | ∃ n < 3, n + 1 = x }` rather than `{ x | match x with | n + 1 => n < 3 }`.
 -/
 macro (name := macroPattSetBuilder) (priority := low-1) "{" pat:term " : " t:term " | " p:term "}" : term =>
   `({ x : $t | match x with | $pat => $p })

--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -102,10 +102,13 @@ for instance, `{(x) | (x : Nat) (y : Nat) (_hxy : x = y^2)}`.
 macro (priority := low) "{" t:term " | " bs:extBinders "}" : term =>
   `({x | ∃ᵉ $bs:extBinders, $t = x})
 
-/-- Pattern matching in set-builder notation
-If `pat` is a pattern that is matched by all objects of type `X`, then `{ pat : X | p }` is
-notation for the set of all objects of type `X` which, when matched with the pattern `pat`,
-make `p` come out true.  If `X` can be inferred, then `{ pat | p }` can be used.
+/--
+* `{ pat : X | p }` is notation for pattern matching in set-builder notation,
+  where `pat` is a pattern that is matched by all objects of type `X`
+  and `p` is a proposition that can refer to variables in the pattern.
+  It is the set of all objects of type `X` which, when matched with the pattern `pat`,
+  make `p` come out true.
+* `{ pat | p }` is the same, but in the case when the type `X` can be inferred.
 
 For example, `{ (m, n) : ℕ × ℕ | m * n = 12 }` denotes the set of all ordered pairs of
 natural numbers whose product is 12.

--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -110,9 +110,10 @@ make `p` come out true.  If `X` can be inferred, then `{ pat | p }` can be used.
 For example, `{ (m, n) : ℕ × ℕ | m * n = 12 }` denotes the set of all ordered pairs of
 natural numbers whose product is 12.
 -/
-macro (priority := low-1) "{" pat:term " : " t:term " | " p:term "}" : term =>
+macro (name := macroPattSetBuilder) (priority := low-1) "{" pat:term " : " t:term " | " p:term "}" : term =>
   `({ x : $t | match x with | $pat => $p })
 
+@[inherit_doc macroPattSetBuilder]
 macro (priority := low-1) "{" pat:term " | " p:term "}" : term =>
   `({ x | match x with | $pat => $p })
 

--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -112,9 +112,11 @@ natural numbers whose product is 12.
 
 Note that if the type ascription is left out and `p` can be interpreted as an extended binder,
 then the extended binder interpretation will be used.  For example, `{ n + 1 | n < 3 }` will
-be interpreted as `{ x : Nat | ∃ n < 3, n + 1 = x }` rather than `{ x | match x with | n + 1 => n < 3 }`.
+be interpreted as `{ x : Nat | ∃ n < 3, n + 1 = x }` rather than
+`{ x | match x with | n + 1 => n < 3 }`.
 -/
-macro (name := macroPattSetBuilder) (priority := low-1) "{" pat:term " : " t:term " | " p:term "}" : term =>
+macro (name := macroPattSetBuilder) (priority := low-1)
+  "{" pat:term " : " t:term " | " p:term "}" : term =>
   `({ x : $t | match x with | $pat => $p })
 
 @[inherit_doc macroPattSetBuilder]

--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -112,8 +112,7 @@ natural numbers whose product is 12.
 
 Note that if the type ascription is left out and `p` can be interpreted as an extended binder,
 then the extended binder interpretation will be used.  For example, `{ n + 1 | n < 3 }` will
-be interpreted as `{ x : Nat | ∃ n < 3, n + 1 = x }` rather than
-`{ x | match x with | n + 1 => n < 3 }`.
+be interpreted as `{ x : Nat | ∃ n < 3, n + 1 = x }` rather than using pattern matching.
 -/
 macro (name := macroPattSetBuilder) (priority := low-1)
   "{" pat:term " : " t:term " | " p:term "}" : term =>


### PR DESCRIPTION
Allow the use of pattern matching in set-builder notation.  For example, `{ (m, n) : ℕ × ℕ | m * n = 12 }` denotes the set of all ordered pairs of natural numbers whose product is 12.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
