### PR TITLE
[Merged by Bors] - feat: define the composition-product of a measure and a kernel

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2928,6 +2928,7 @@ import Mathlib.Probability.Kernel.Disintegration
 import Mathlib.Probability.Kernel.IntegralCompProd
 import Mathlib.Probability.Kernel.Invariance
 import Mathlib.Probability.Kernel.MeasurableIntegral
+import Mathlib.Probability.Kernel.MeasureCompProd
 import Mathlib.Probability.Kernel.WithDensity
 import Mathlib.Probability.Martingale.Basic
 import Mathlib.Probability.Martingale.BorelCantelli

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -454,10 +454,20 @@ theorem const_apply (μβ : Measure β) (a : α) : const α μβ a = μβ :=
 lemma const_zero : kernel.const α (0 : Measure β) = 0 := by
   ext x s _; simp [kernel.const_apply]
 
+lemma sum_const [Countable ι] (μ : ι → Measure β) :
+    kernel.sum (fun n ↦ const α (μ n)) = const α (Measure.sum μ) := by
+  ext x s hs
+  rw [const_apply, Measure.sum_apply _ hs, kernel.sum_apply' _ _ hs]
+  simp only [const_apply]
+
 instance isFiniteKernel_const {μβ : Measure β} [IsFiniteMeasure μβ] :
     IsFiniteKernel (const α μβ) :=
   ⟨⟨μβ Set.univ, measure_lt_top _ _, fun _ => le_rfl⟩⟩
 #align probability_theory.kernel.is_finite_kernel_const ProbabilityTheory.kernel.isFiniteKernel_const
+
+instance isSFiniteKernel_const {μβ : Measure β} [SFinite μβ] :
+    IsSFiniteKernel (const α μβ) :=
+  ⟨fun n ↦ const α (sFiniteSeq μβ n), fun n ↦ inferInstance, by rw [sum_const, sum_sFiniteSeq]⟩
 
 instance isMarkovKernel_const {μβ : Measure β} [hμβ : IsProbabilityMeasure μβ] :
     IsMarkovKernel (const α μβ) :=

--- a/Mathlib/Probability/Kernel/CondDistrib.lean
+++ b/Mathlib/Probability/Kernel/CondDistrib.lean
@@ -109,9 +109,7 @@ end Measurability
 /-- `condDistrib` is a.e. uniquely defined as the kernel satisfying the defining property of
 `condKernel`. -/
 theorem condDistrib_ae_eq_of_measure_eq_compProd (hX : Measurable X) (hY : Measurable Y)
-    (κ : kernel β Ω) [IsFiniteKernel κ]
-    (hκ : μ.map (fun x => (X x, Y x)) =
-      (kernel.const Unit (μ.map X) ⊗ₖ kernel.prodMkLeft Unit κ) ()) :
+    (κ : kernel β Ω) [IsFiniteKernel κ] (hκ : μ.map (fun x => (X x, Y x)) = μ.map X ⊗ₘ κ) :
     ∀ᵐ x ∂μ.map X, κ x = condDistrib Y X μ x := by
   have heq : μ.map X = (μ.map (fun x => (X x, Y x))).fst
   · ext s hs

--- a/Mathlib/Probability/Kernel/Disintegration.lean
+++ b/Mathlib/Probability/Kernel/Disintegration.lean
@@ -5,7 +5,7 @@ Authors: Rémy Degenne, Kexing Ying
 -/
 import Mathlib.Probability.Kernel.CondCdf
 import Mathlib.MeasureTheory.Constructions.Polish
-import Mathlib.Probability.Kernel.IntegralCompProd
+import Mathlib.Probability.Kernel.MeasureCompProd
 
 #align_import probability.kernel.disintegration from "leanprover-community/mathlib"@"6315581f5650ffa2fbdbbbedc41243c8d7070981"
 
@@ -217,31 +217,26 @@ theorem kernel.const_eq_compProd_real (γ : Type*) [MeasurableSpace γ] (ρ : Me
   rw [lintegral_condKernelReal_mem ρ hs]
 #align probability_theory.kernel.const_eq_comp_prod_real ProbabilityTheory.kernel.const_eq_compProd_real
 
-theorem measure_eq_compProd_real :
-    ρ = (kernel.const Unit ρ.fst ⊗ₖ kernel.prodMkLeft Unit (condKernelReal ρ)) () := by
-  rw [← kernel.const_eq_compProd_real Unit ρ, kernel.const_apply]
+theorem measure_eq_compProd_real : ρ = ρ.fst ⊗ₘ condKernelReal ρ := by
+  rw [Measure.compProd, ← kernel.const_eq_compProd_real Unit ρ, kernel.const_apply]
 #align probability_theory.measure_eq_comp_prod_real ProbabilityTheory.measure_eq_compProd_real
 
 theorem lintegral_condKernelReal {f : α × ℝ → ℝ≥0∞} (hf : Measurable f) :
     ∫⁻ a, ∫⁻ y, f (a, y) ∂condKernelReal ρ a ∂ρ.fst = ∫⁻ x, f x ∂ρ := by
   nth_rw 3 [measure_eq_compProd_real ρ]
-  rw [kernel.lintegral_compProd _ _ _ hf, kernel.const_apply]
-  simp_rw [kernel.prodMkLeft_apply]
+  rw [Measure.lintegral_compProd hf]
 #align probability_theory.lintegral_cond_kernel_real ProbabilityTheory.lintegral_condKernelReal
 
 theorem ae_condKernelReal_eq_one {s : Set ℝ} (hs : MeasurableSet s) (hρ : ρ {x | x.snd ∈ sᶜ} = 0) :
     ∀ᵐ a ∂ρ.fst, condKernelReal ρ a s = 1 := by
-  have h : ρ {x | x.snd ∈ sᶜ} = (kernel.const Unit ρ.fst ⊗ₖ
-      kernel.prodMkLeft Unit (condKernelReal ρ)) () {x | x.snd ∈ sᶜ} := by
+  have h : ρ {x | x.snd ∈ sᶜ} = (ρ.fst ⊗ₘ condKernelReal ρ) {x | x.snd ∈ sᶜ} := by
     rw [← measure_eq_compProd_real]
-  rw [hρ, kernel.compProd_apply] at h
+  rw [hρ, Measure.compProd_apply] at h
   swap; · exact measurable_snd hs.compl
   rw [eq_comm, lintegral_eq_zero_iff] at h
   swap
-  · simp_rw [kernel.prodMkLeft_apply']
-    simp only [mem_compl_iff, mem_setOf_eq]
+  · simp only [mem_compl_iff, mem_setOf_eq]
     exact kernel.measurable_coe _ hs.compl
-  rw [kernel.const_apply] at h
   simp only [mem_compl_iff, mem_setOf_eq, kernel.prodMkLeft_apply'] at h
   filter_upwards [h] with a ha
   change condKernelReal ρ a sᶜ = 0 at ha
@@ -264,7 +259,7 @@ variable {Ω : Type*} [MeasurableSpace Ω] [StandardBorelSpace Ω]
 /-- Existence of a conditional kernel. Use the definition `condKernel` to get that kernel. -/
 theorem exists_cond_kernel (γ : Type*) [MeasurableSpace γ] :
     ∃ (η : kernel α Ω) (_h : IsMarkovKernel η), kernel.const γ ρ =
-      kernel.compProd (kernel.const γ ρ.fst) (kernel.prodMkLeft γ η) := by
+      (kernel.const γ ρ.fst) ⊗ₖ (kernel.prodMkLeft γ η) := by
   obtain ⟨f, hf⟩ := exists_measurableEmbedding_real Ω
   let ρ' : Measure (α × ℝ) := ρ.map (Prod.map id f)
   -- The general idea is to define `η = kernel.comapRight (condKernelReal ρ') hf`. There is
@@ -344,8 +339,7 @@ theorem exists_cond_kernel (γ : Type*) [MeasurableSpace γ] :
 #align probability_theory.exists_cond_kernel ProbabilityTheory.exists_cond_kernel
 
 /-- Conditional kernel of a measure on a product space: a Markov kernel such that
-`ρ = ((kernel.const Unit ρ.fst) ⊗ₖ (kernel.prodMkLeft Unit ρ.condKernel)) ()`
-(see `ProbabilityTheory.measure_eq_compProd`). -/
+`ρ = ρ.fst ⊗ₘ ρ.condKernel` (see `ProbabilityTheory.measure_eq_compProd`). -/
 noncomputable irreducible_def _root_.MeasureTheory.Measure.condKernel : kernel α Ω :=
   (exists_cond_kernel ρ Unit).choose
 #align measure_theory.measure.cond_kernel MeasureTheory.Measure.condKernel
@@ -366,9 +360,8 @@ theorem kernel.const_unit_eq_compProd :
 measure can be written as the composition-product of the constant kernel with value `ρ.fst`
 (marginal measure over `α`) and a Markov kernel from `α` to `Ω`. We call that Markov kernel
 `ProbabilityTheory.condKernel ρ`. -/
-theorem measure_eq_compProd :
-    ρ = (kernel.const Unit ρ.fst ⊗ₖ kernel.prodMkLeft Unit ρ.condKernel) () := by
-  rw [← kernel.const_unit_eq_compProd, kernel.const_apply]
+theorem measure_eq_compProd : ρ = ρ.fst ⊗ₘ ρ.condKernel := by
+  rw [Measure.compProd, ← kernel.const_unit_eq_compProd, kernel.const_apply]
 #align probability_theory.measure_eq_comp_prod ProbabilityTheory.measure_eq_compProd
 
 /-- **Disintegration** of constant kernels. A constant kernel on a product space `α × Ω`, where `Ω`
@@ -386,40 +379,35 @@ theorem kernel.const_eq_compProd (γ : Type*) [MeasurableSpace γ] (ρ : Measure
 theorem lintegral_condKernel_mem {s : Set (α × Ω)} (hs : MeasurableSet s) :
     ∫⁻ a, ρ.condKernel a {x | (a, x) ∈ s} ∂ρ.fst = ρ s := by
   conv_rhs => rw [measure_eq_compProd ρ]
-  simp_rw [kernel.compProd_apply _ _ _ hs, kernel.const_apply, kernel.prodMkLeft_apply]
+  simp_rw [Measure.compProd_apply hs]
+  rfl
 #align probability_theory.lintegral_cond_kernel_mem ProbabilityTheory.lintegral_condKernel_mem
 
 theorem set_lintegral_condKernel_eq_measure_prod {s : Set α} (hs : MeasurableSet s) {t : Set Ω}
     (ht : MeasurableSet t) : ∫⁻ a in s, ρ.condKernel a t ∂ρ.fst = ρ (s ×ˢ t) := by
-  have : ρ (s ×ˢ t) =
-      ((kernel.const Unit ρ.fst ⊗ₖ kernel.prodMkLeft Unit ρ.condKernel) ()) (s ×ˢ t) := by
+  have : ρ (s ×ˢ t) = (ρ.fst ⊗ₘ ρ.condKernel) (s ×ˢ t) := by
     congr; exact measure_eq_compProd ρ
-  rw [this, kernel.compProd_apply _ _ _ (hs.prod ht)]
-  simp only [prod_mk_mem_set_prod_eq, kernel.lintegral_const, kernel.prodMkLeft_apply]
-  rw [← lintegral_indicator _ hs]
-  congr
-  ext1 x
+  rw [this, Measure.compProd_apply (hs.prod ht)]
   classical
-  rw [indicator_apply]
-  split_ifs with hx
-  · simp only [hx, if_true, true_and_iff, setOf_mem_eq]
-  · simp only [hx, if_false, false_and_iff, setOf_false, measure_empty]
+  have : ∀ a, ρ.condKernel a (Prod.mk a ⁻¹' s ×ˢ t)
+      = s.indicator (fun a ↦ ρ.condKernel a t) a := by
+    intro a
+    by_cases ha : a ∈ s <;> simp [ha]
+  simp_rw [this]
+  rw [lintegral_indicator _ hs]
 #align probability_theory.set_lintegral_cond_kernel_eq_measure_prod ProbabilityTheory.set_lintegral_condKernel_eq_measure_prod
 
 theorem lintegral_condKernel {f : α × Ω → ℝ≥0∞} (hf : Measurable f) :
     ∫⁻ a, ∫⁻ ω, f (a, ω) ∂ρ.condKernel a ∂ρ.fst = ∫⁻ x, f x ∂ρ := by
   conv_rhs => rw [measure_eq_compProd ρ]
-  rw [kernel.lintegral_compProd _ _ _ hf, kernel.const_apply]
-  simp_rw [kernel.prodMkLeft_apply]
+  rw [Measure.lintegral_compProd hf]
 #align probability_theory.lintegral_cond_kernel ProbabilityTheory.lintegral_condKernel
 
 theorem set_lintegral_condKernel {f : α × Ω → ℝ≥0∞} (hf : Measurable f) {s : Set α}
     (hs : MeasurableSet s) {t : Set Ω} (ht : MeasurableSet t) :
     ∫⁻ a in s, ∫⁻ ω in t, f (a, ω) ∂ρ.condKernel a ∂ρ.fst = ∫⁻ x in s ×ˢ t, f x ∂ρ := by
   conv_rhs => rw [measure_eq_compProd ρ]
-  rw [← kernel.restrict_apply _ (hs.prod ht), ← kernel.compProd_restrict hs ht,
-    kernel.lintegral_compProd _ _ _ hf, kernel.restrict_apply]
-  conv_rhs => enter [2, b, 1]; rw [kernel.restrict_apply _ ht]
+  rw [Measure.set_lintegral_compProd hf hs ht]
 #align probability_theory.set_lintegral_cond_kernel ProbabilityTheory.set_lintegral_condKernel
 
 theorem set_lintegral_condKernel_univ_right {f : α × Ω → ℝ≥0∞} (hf : Measurable f) {s : Set α}
@@ -448,10 +436,8 @@ theorem _root_.MeasureTheory.AEStronglyMeasurable.integral_condKernel {ρ : Meas
 theorem integral_condKernel {ρ : Measure (α × Ω)} [IsFiniteMeasure ρ] {f : α × Ω → E}
     (hf : Integrable f ρ) : ∫ a, ∫ x, f (a, x) ∂ρ.condKernel a ∂ρ.fst = ∫ ω, f ω ∂ρ := by
   conv_rhs => rw [measure_eq_compProd ρ]
-  have hf': Integrable f ((kernel.const Unit ρ.fst ⊗ₖ kernel.prodMkLeft Unit ρ.condKernel) ()) := by
-    rwa [measure_eq_compProd ρ] at hf
-  rw [integral_compProd hf', kernel.const_apply]
-  simp_rw [kernel.prodMkLeft_apply]
+  have hf': Integrable f (ρ.fst ⊗ₘ ρ.condKernel) := by rwa [measure_eq_compProd ρ] at hf
+  rw [Measure.integral_compProd hf']
 #align probability_theory.integral_cond_kernel ProbabilityTheory.integral_condKernel
 
 theorem set_integral_condKernel {ρ : Measure (α × Ω)} [IsFiniteMeasure ρ] {f : α × Ω → E}
@@ -459,9 +445,8 @@ theorem set_integral_condKernel {ρ : Measure (α × Ω)} [IsFiniteMeasure ρ] {
     (hf : IntegrableOn f (s ×ˢ t) ρ) :
     ∫ a in s, ∫ ω in t, f (a, ω) ∂ρ.condKernel a ∂ρ.fst = ∫ x in s ×ˢ t, f x ∂ρ := by
   conv_rhs => rw [measure_eq_compProd ρ]
-  rw [set_integral_compProd hs ht]
-  · simp_rw [kernel.prodMkLeft_apply, kernel.const_apply]
-  · rwa [measure_eq_compProd ρ] at hf
+  rw [Measure.set_integral_compProd hs ht]
+  rwa [measure_eq_compProd ρ] at hf
 #align probability_theory.set_integral_cond_kernel ProbabilityTheory.set_integral_condKernel
 
 theorem set_integral_condKernel_univ_right {ρ : Measure (α × Ω)} [IsFiniteMeasure ρ] {f : α × Ω → E}
@@ -491,23 +476,20 @@ This theorem in the case of finite kernels is weaker than `eq_condKernel_of_meas
 which asserts that the kernels are equal almost everywhere and not just on a given measurable
 set. -/
 theorem eq_condKernel_of_measure_eq_compProd' (κ : kernel α Ω) [IsSFiniteKernel κ]
-    (hκ : ρ = (kernel.const Unit ρ.fst ⊗ₖ kernel.prodMkLeft Unit κ) ())
-    {s : Set Ω} (hs : MeasurableSet s) :
+    (hκ : ρ = ρ.fst ⊗ₘ κ) {s : Set Ω} (hs : MeasurableSet s) :
     ∀ᵐ x ∂ρ.fst, κ x s = ρ.condKernel x s := by
   refine' ae_eq_of_forall_set_lintegral_eq_of_sigmaFinite
     (kernel.measurable_coe κ hs) (kernel.measurable_coe ρ.condKernel hs) _
   intros t ht _
   conv_rhs => rw [set_lintegral_condKernel_eq_measure_prod _ ht hs, hκ]
-  simp only [kernel.compProd_apply _ _ _ (ht.prod hs), kernel.prodMkLeft_apply, Set.mem_prod,
-    kernel.lintegral_const, ← lintegral_indicator _ ht]
+  simp only [Measure.compProd_apply (ht.prod hs), Set.mem_prod, ← lintegral_indicator _ ht]
   congr; ext x
   by_cases hx : x ∈ t
   all_goals simp [hx]
 
 -- This lemma establishes uniqueness of the disintegration kernel on ℝ
 lemma eq_condKernel_of_measure_eq_compProd_real (ρ : Measure (α × ℝ)) [IsFiniteMeasure ρ]
-    (κ : kernel α ℝ) [IsFiniteKernel κ]
-    (hκ : ρ = (kernel.const Unit ρ.fst ⊗ₖ kernel.prodMkLeft Unit κ) ()) :
+    (κ : kernel α ℝ) [IsFiniteKernel κ] (hκ : ρ = ρ.fst ⊗ₘ κ) :
     ∀ᵐ x ∂ρ.fst, κ x = ρ.condKernel x := by
   have huniv : ∀ᵐ x ∂ρ.fst, κ x Set.univ = ρ.condKernel x Set.univ :=
     eq_condKernel_of_measure_eq_compProd' ρ κ hκ MeasurableSet.univ
@@ -528,7 +510,7 @@ lemma eq_condKernel_of_measure_eq_compProd_real (ρ : Measure (α × ℝ)) [IsFi
 /-- A finite kernel which satisfies the disintegration property is almost everywhere equal to the
 disintegration kernel. -/
 theorem eq_condKernel_of_measure_eq_compProd (κ : kernel α Ω) [IsFiniteKernel κ]
-    (hκ : ρ = (kernel.const Unit ρ.fst ⊗ₖ kernel.prodMkLeft Unit κ) ()) :
+    (hκ : ρ = ρ.fst ⊗ₘ κ) :
     ∀ᵐ x ∂ρ.fst, κ x = ρ.condKernel x := by
 -- The idea is to transporting the question to `ℝ` from `Ω` using `exists_measurableEmbedding_real`
 -- and then constructing a measure on `α × ℝ` using the obtained measurable embedding
@@ -544,7 +526,7 @@ theorem eq_condKernel_of_measure_eq_compProd (κ : kernel α Ω) [IsFiniteKernel
     ext s hs
     simp only [Measure.map_apply (measurable_id.prod_map hf.measurable) hs]
     conv_lhs => congr; rw [hκ]
-    rw [kernel.compProd_apply _ _ _ hs, kernel.compProd_apply _ _ _
+    rw [Measure.compProd_apply hs, Measure.compProd_apply
       (measurable_id.prod_map hf.measurable hs), (_ : (ρ.map (Prod.map id f)).fst = ρ.fst)]
     · congr
       ext x
@@ -571,24 +553,18 @@ theorem eq_condKernel_of_measure_eq_compProd (κ : kernel α Ω) [IsFiniteKernel
       ← Set.preimage_comp, Measure.fst_apply hs]
     rfl
   suffices : ρ.map (Prod.map id f) =
-    (kernel.const Unit (ρ.map (Prod.map id f)).fst ⊗ₖ
-      kernel.prodMkLeft Unit (kernel.map (Measure.condKernel ρ) f hf.measurable)) ()
+    ((ρ.map (Prod.map id f)).fst ⊗ₘ (kernel.map (Measure.condKernel ρ) f hf.measurable))
   · have heq := eq_condKernel_of_measure_eq_compProd_real _ _ this
     rw [hprod] at heq
     filter_upwards [heq] with x hx s hs
     rw [← hx, kernel.map_apply, Measure.map_apply hf.measurable hs]
   ext s hs
-  have hinteq : ∀ x, (ρ.condKernel x).map f {c | (x, c) ∈ s} =
-      ρ.condKernel x {c | (x, c) ∈ Prod.map id f ⁻¹' s}
-  · intro x
-    rw [Measure.map_apply hf.measurable]
-    · rfl
-    · exact measurable_prod_mk_left hs
-  simp only [hprod, kernel.compProd_apply _ _ _ hs, kernel.prodMkLeft_apply,
-    kernel.map_apply _ hf.measurable, hinteq, Set.mem_preimage, Prod_map, id_eq,
-    kernel.lintegral_const]
+  simp only [hprod, Measure.compProd_apply hs, kernel.map_apply _ hf.measurable]
   rw [Measure.map_apply (measurable_id.prod_map hf.measurable) hs, ← lintegral_condKernel_mem]
-  · rfl
+  · simp only [mem_preimage, Prod_map, id_eq]
+    congr with a
+    rw [Measure.map_apply hf.measurable (measurable_prod_mk_left hs)]
+    rfl
   · exact measurable_id.prod_map hf.measurable hs
 
 end Unique
@@ -616,8 +592,7 @@ theorem AEStronglyMeasurable.ae_integrable_condKernel_iff {f : α × Ω → F}
       Integrable (fun a => ∫ ω, ‖f (a, ω)‖ ∂ρ.condKernel a) ρ.fst ↔ Integrable f ρ := by
   rw [measure_eq_compProd ρ] at hf
   conv_rhs => rw [measure_eq_compProd ρ]
-  rw [integrable_compProd_iff hf]
-  simp_rw [kernel.prodMkLeft_apply, kernel.const_apply]
+  rw [Measure.integrable_compProd_iff hf]
 #align measure_theory.ae_strongly_measurable.ae_integrable_cond_kernel_iff MeasureTheory.AEStronglyMeasurable.ae_integrable_condKernel_iff
 
 theorem Integrable.condKernel_ae {f : α × Ω → F} (hf_int : Integrable f ρ) :

--- a/Mathlib/Probability/Kernel/Disintegration.lean
+++ b/Mathlib/Probability/Kernel/Disintegration.lean
@@ -20,8 +20,7 @@ Then there exists a kernel `ρ.condKernel : kernel α Ω` such that for any meas
 In terms of kernels, `ρ.condKernel` is such that for any measurable space `γ`, we
 have a disintegration of the constant kernel from `γ` with value `ρ`:
 `kernel.const γ ρ = (kernel.const γ ρ.fst) ⊗ₖ (kernel.prodMkLeft γ (condKernel ρ))`,
-where `ρ.fst` is the marginal measure of `ρ` on `α`. In particular,
-`ρ = ((kernel.const Unit ρ.fst) ⊗ₖ (kernel.prodMkLeft Unit (condKernel ρ))) ()`.
+where `ρ.fst` is the marginal measure of `ρ` on `α`. In particular, `ρ = ρ.fst ⊗ₘ ρ.condKernel`.
 
 In order to obtain a disintegration for any standard Borel space, we use that these spaces embed
 measurably into `ℝ`: it then suffices to define a suitable kernel for `Ω = ℝ`. In the real case,
@@ -40,8 +39,7 @@ function `condCdf ρ a` (the conditional cumulative distribution function).
   `∫⁻ a, ρ.condKernel a {x | (a, x) ∈ s} ∂ρ.fst = ρ s`
 * `ProbabilityTheory.kernel.const_eq_compProd`:
   `kernel.const γ ρ = (kernel.const γ ρ.fst) ⊗ₖ (kernel.prodMkLeft γ ρ.condKernel)`
-* `ProbabilityTheory.measure_eq_compProd`:
-  `ρ = ((kernel.const Unit ρ.fst) ⊗ₖ (kernel.prodMkLeft Unit ρ.condKernel)) ()`
+* `ProbabilityTheory.measure_eq_compProd`: `ρ = ρ.fst ⊗ₘ ρ.condKernel`
 * `ProbabilityTheory.eq_condKernel_of_measure_eq_compProd`: a.e. uniqueness of `condKernel`
 
 -/

--- a/Mathlib/Probability/Kernel/MeasureCompProd.lean
+++ b/Mathlib/Probability/Kernel/MeasureCompProd.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2023 Rémy Degenne. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne
+-/
+import Mathlib.Probability.Kernel.IntegralCompProd
+
+/-!
+# Composition-Product of a measure and a kernel
+
+This operation, denoted by `⊗ₘ`, takes `μ : Measure α` and `κ : kernel α β` and creates
+`μ ⊗ₘ κ : Measure (α × β)`. The integral of a function against `μ ⊗ₘ κ` is
+`∫⁻ x, f x ∂(μ ⊗ₘ κ) = ∫⁻ a, ∫⁻ b, f (a, b) ∂(κ a) ∂μ`.
+
+`μ ⊗ₘ κ` is defined as `((kernel.const Unit μ) ⊗ₖ (kernel.prodMkLeft Unit κ)) ()`.
+
+## Main definitions
+
+* `Measure.compProd`: from `μ : Measure α` and `κ : kernel α β`, get a `Measure (α × β)`.
+
+## Notations
+
+* `μ ⊗ₘ κ = μ.compProd κ`
+-/
+
+open scoped ENNReal
+
+open ProbabilityTheory
+
+namespace MeasureTheory.Measure
+
+variable {α β : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
+  {μ : Measure α} {κ η : kernel α β}
+
+/-- The composition-product of a measure and a kernel. -/
+noncomputable
+def compProd (μ : Measure α) (κ : kernel α β) : Measure (α × β) :=
+  (kernel.const Unit μ ⊗ₖ kernel.prodMkLeft Unit κ) ()
+
+/-- The composition-product of a measure and a kernel. -/
+scoped[ProbabilityTheory] infixl:100 " ⊗ₘ " => MeasureTheory.Measure.compProd
+
+@[simp] lemma compProd_zero_left (κ : kernel α β) : (0 : Measure α) ⊗ₘ κ = 0 := by simp [compProd]
+@[simp] lemma compProd_zero_right (μ : Measure α) : μ ⊗ₘ (0 : kernel α β) = 0 := by simp [compProd]
+
+lemma compProd_apply [SFinite μ] [IsSFiniteKernel κ] {s : Set (α × β)} (hs : MeasurableSet s) :
+    (μ ⊗ₘ κ) s = ∫⁻ a, κ a (Prod.mk a ⁻¹' s) ∂μ := by
+  simp_rw [compProd, kernel.compProd_apply _ _ _ hs, kernel.const_apply, kernel.prodMkLeft_apply']
+  rfl
+
+lemma compProd_congr [SFinite μ] [IsSFiniteKernel κ] [IsSFiniteKernel η]
+    (h : κ =ᵐ[μ] η) : μ ⊗ₘ κ = μ ⊗ₘ η := by
+  ext s hs
+  have : (fun a ↦ κ a (Prod.mk a ⁻¹' s)) =ᵐ[μ] fun a ↦ η a (Prod.mk a ⁻¹' s) := by
+    filter_upwards [h] with a ha using by rw [ha]
+  rw [compProd_apply hs, lintegral_congr_ae this, compProd_apply hs]
+
+lemma lintegral_compProd [SFinite μ] [IsSFiniteKernel κ]
+    {f : α × β → ℝ≥0∞} (hf : Measurable f) :
+    ∫⁻ x, f x ∂(μ ⊗ₘ κ) = ∫⁻ a, ∫⁻ b, f (a, b) ∂(κ a) ∂μ := by
+  rw [compProd, kernel.lintegral_compProd _ _ _ hf]
+  simp
+
+lemma set_lintegral_compProd [SFinite μ] [IsSFiniteKernel κ]
+    {f : α × β → ℝ≥0∞} (hf : Measurable f)
+    {s : Set α} (hs : MeasurableSet s) {t : Set β} (ht : MeasurableSet t) :
+    ∫⁻ x in s ×ˢ t, f x ∂(μ ⊗ₘ κ) = ∫⁻ a in s, ∫⁻ b in t, f (a, b) ∂(κ a) ∂μ := by
+  rw [compProd, kernel.set_lintegral_compProd _ _ _ hf hs ht]
+  simp
+
+lemma integrable_compProd_iff [SFinite μ] [IsSFiniteKernel κ] {E : Type*} [NormedAddCommGroup E]
+    {f : α × β → E} (hf : AEStronglyMeasurable f (μ ⊗ₘ κ)) :
+    Integrable f (μ ⊗ₘ κ) ↔
+      (∀ᵐ x ∂μ, Integrable (fun y => f (x, y)) (κ x)) ∧
+        Integrable (fun x => ∫ y, ‖f (x, y)‖ ∂(κ x)) μ := by
+  rw [Measure.compProd, ProbabilityTheory.integrable_compProd_iff hf]
+  rfl
+
+lemma integral_compProd [SFinite μ] [IsSFiniteKernel κ] {E : Type*}
+    [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+    {f : α × β → E} (hf : Integrable f (μ ⊗ₘ κ)) :
+    ∫ x, f x ∂(μ ⊗ₘ κ) = ∫ a, ∫ b, f (a, b) ∂(κ a) ∂μ := by
+  rw [compProd, ProbabilityTheory.integral_compProd hf]
+  simp
+
+lemma set_integral_compProd [SFinite μ] [IsSFiniteKernel κ] {E : Type*}
+    [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+    {s : Set α} (hs : MeasurableSet s) {t : Set β} (ht : MeasurableSet t)
+    {f : α × β → E} (hf : IntegrableOn f (s ×ˢ t) (μ ⊗ₘ κ))  :
+    ∫ x in s ×ˢ t, f x ∂(μ ⊗ₘ κ) = ∫ a in s, ∫ b in t, f (a, b) ∂(κ a) ∂μ := by
+  rw [compProd, ProbabilityTheory.set_integral_compProd hs ht hf]
+  simp
+
+lemma dirac_compProd_apply [MeasurableSingletonClass α] {a : α} [IsSFiniteKernel κ]
+    {s : Set (α × β)} (hs : MeasurableSet s) :
+    (Measure.dirac a ⊗ₘ κ) s = κ a (Prod.mk a ⁻¹' s) := by
+  rw [compProd_apply hs, lintegral_dirac]
+
+lemma dirac_unit_compProd (κ : kernel Unit β) [IsSFiniteKernel κ] :
+    Measure.dirac () ⊗ₘ κ = (κ ()).map (Prod.mk ()) := by
+  ext s hs; rw [dirac_compProd_apply hs, Measure.map_apply measurable_prod_mk_left hs]
+
+lemma dirac_unit_compProd_const (μ : Measure β) [IsFiniteMeasure μ] :
+    Measure.dirac () ⊗ₘ kernel.const Unit μ = μ.map (Prod.mk ()) := by
+  rw [dirac_unit_compProd, kernel.const_apply]
+
+@[simp]
+lemma snd_dirac_unit_compProd_const (μ : Measure β) [IsFiniteMeasure μ] :
+    snd (Measure.dirac () ⊗ₘ kernel.const Unit μ) = μ := by
+  rw [dirac_unit_compProd_const, snd, map_map measurable_snd measurable_prod_mk_left]
+  simp
+
+instance : SFinite (μ ⊗ₘ κ) := by rw [compProd]; infer_instance
+
+instance [IsFiniteMeasure μ] [IsFiniteKernel κ] : IsFiniteMeasure (μ ⊗ₘ κ) := by
+  rw [compProd]; infer_instance
+
+instance [IsProbabilityMeasure μ] [IsMarkovKernel κ] : IsProbabilityMeasure (μ ⊗ₘ κ) := by
+  rw [compProd]; infer_instance
+
+end MeasureTheory.Measure

--- a/Mathlib/Probability/Kernel/MeasureCompProd.lean
+++ b/Mathlib/Probability/Kernel/MeasureCompProd.lean
@@ -37,7 +37,7 @@ noncomputable
 def compProd (μ : Measure α) (κ : kernel α β) : Measure (α × β) :=
   (kernel.const Unit μ ⊗ₖ kernel.prodMkLeft Unit κ) ()
 
-/-- The composition-product of a measure and a kernel. -/
+@[inherit_doc]
 scoped[ProbabilityTheory] infixl:100 " ⊗ₘ " => MeasureTheory.Measure.compProd
 
 @[simp] lemma compProd_zero_left (κ : kernel α β) : (0 : Measure α) ⊗ₘ κ = 0 := by simp [compProd]


### PR DESCRIPTION
The composition-product of a measure and a kernel, denoted by `⊗ₘ`, takes `μ : Measure α` and `κ : kernel α β` and creates `μ ⊗ₘ κ : Measure (α × β)`. The integral of a function against `μ ⊗ₘ κ` is `∫⁻ x, f x ∂(μ ⊗ₘ κ) = ∫⁻ a, ∫⁻ b, f (a, b) ∂(κ a) ∂μ`.

This PR also modifies the Disintegration file to use the new definition.

From the PFR project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
