### PR TITLE
[Merged by Bors] - feat: add some missing API lemmas about `Nat.properDivisors` and `Nat.primeFactors`

### DIFF
--- a/Mathlib/Data/Nat/PrimeFin.lean
+++ b/Mathlib/Data/Nat/PrimeFin.lean
@@ -69,12 +69,8 @@ lemma le_of_mem_primeFactors (h : p ∈ n.primeFactors) : p ≤ n :=
 
 @[simp]
 lemma nonempty_primeFactors {n : ℕ} : n.primeFactors.Nonempty ↔ 1 < n := by
-  rw [← not_iff_not]
-  simp only [Finset.not_nonempty_iff_eq_empty, primeFactors_eq_empty, not_lt]
-  match n with
-  | 0 => simp
-  | 1 => simp
-  | n + 2 => simp
+  rw [← not_iff_not, Finset.not_nonempty_iff_eq_empty, primeFactors_eq_empty, not_lt,
+    Nat.le_one_iff_eq_zero_or_eq_one]
 
 @[simp] protected lemma Prime.primeFactors (hp : p.Prime) : p.primeFactors = {p} := by
   simp [Nat.primeFactors, factors_prime hp]

--- a/Mathlib/Data/Nat/PrimeFin.lean
+++ b/Mathlib/Data/Nat/PrimeFin.lean
@@ -68,7 +68,7 @@ lemma le_of_mem_primeFactors (h : p ∈ n.primeFactors) : p ≤ n :=
   · rintro (rfl | rfl) <;> simp
 
 @[simp]
-lemma Nat.nonempty_primeFactors {n : ℕ} : n.primeFactors.Nonempty ↔ 1 < n := by
+lemma nonempty_primeFactors {n : ℕ} : n.primeFactors.Nonempty ↔ 1 < n := by
   rw [← not_iff_not]
   simp only [Finset.not_nonempty_iff_eq_empty, primeFactors_eq_empty, not_lt]
   match n with

--- a/Mathlib/Data/Nat/PrimeFin.lean
+++ b/Mathlib/Data/Nat/PrimeFin.lean
@@ -69,7 +69,7 @@ lemma le_of_mem_primeFactors (h : p ∈ n.primeFactors) : p ≤ n :=
 
 @[simp]
 lemma Nat.nonempty_primeFactors {n : ℕ} : n.primeFactors.Nonempty ↔ 1 < n := by
-  rw [←not_iff_not]
+  rw [← not_iff_not]
   simp only [Finset.not_nonempty_iff_eq_empty, primeFactors_eq_empty, not_lt]
   match n with
   | 0 => simp

--- a/Mathlib/Data/Nat/PrimeFin.lean
+++ b/Mathlib/Data/Nat/PrimeFin.lean
@@ -67,6 +67,15 @@ lemma le_of_mem_primeFactors (h : p ∈ n.primeFactors) : p ≤ n :=
     exact Nonempty.ne_empty $ ⟨_, mem_primeFactors.2 ⟨hp, hpn, hn.1⟩⟩
   · rintro (rfl | rfl) <;> simp
 
+@[simp]
+lemma Nat.nonempty_primeFactors {n : ℕ} : n.primeFactors.Nonempty ↔ 1 < n := by
+  rw [←not_iff_not]
+  simp only [Finset.not_nonempty_iff_eq_empty, primeFactors_eq_empty, not_lt]
+  match n with
+  | 0 => simp
+  | 1 => simp
+  | n + 2 => simp
+
 @[simp] protected lemma Prime.primeFactors (hp : p.Prime) : p.primeFactors = {p} := by
   simp [Nat.primeFactors, factors_prime hp]
 

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -172,6 +172,14 @@ theorem properDivisors_zero : properDivisors 0 = ∅ := by
   simp
 #align nat.proper_divisors_zero Nat.properDivisors_zero
 
+@[simp]
+lemma nonempty_divisors : (divisors n).Nonempty ↔ n ≠ 0 :=
+  ⟨fun ⟨m, hm⟩ hn ↦ by simp [hn] at hm, fun hn ↦ ⟨1, one_mem_divisors.2 hn⟩⟩
+
+@[simp]
+lemma divisors_eq_empty : divisors n = ∅ ↔ n = 0 :=
+  not_nonempty_iff_eq_empty.symm.trans nonempty_divisors.not_left
+
 theorem properDivisors_subset_divisors : properDivisors n ⊆ divisors n :=
   filter_subset_filter _ <| Ico_subset_Ico_right n.le_succ
 #align nat.proper_divisors_subset_divisors Nat.properDivisors_subset_divisors
@@ -209,30 +217,30 @@ lemma sup_divisors_id (n : ℕ) : n.divisors.sup id = n := by
   · exact Finset.le_sup (f := id) <| mem_divisors_self n hn
 
 lemma one_lt_of_mem_properDivisors {m n : ℕ} (h : m ∈ n.properDivisors) : 1 < n :=
-  match n with
-  | 0 => by simp at h
-  | 1 => by simp at h
-  | n + 2 => n.one_lt_succ_succ
+  lt_of_le_of_lt (pos_of_mem_properDivisors h) (mem_properDivisors.1 h).2
 
 lemma one_lt_div_of_mem_properDivisors {m n : ℕ} (h : m ∈ n.properDivisors) :
     1 < n / m := by
-  have hm := pos_of_mem_properDivisors h
-  apply lt_of_mul_lt_mul_right ?_ hm.le
   obtain ⟨h_dvd, h_lt⟩ := mem_properDivisors.mp h
-  simpa [Nat.div_mul_cancel h_dvd] using h_lt
+  rwa [Nat.lt_div_iff_mul_lt h_dvd, mul_one]
 
+/-- See also `Nat.mem_properDivisors`. -/
 lemma mem_properDivisors_iff_exists {m n : ℕ} (hn : n ≠ 0) :
     m ∈ n.properDivisors ↔ ∃ k > 1, n = m * k := by
   refine ⟨fun h ↦ ⟨n / m, one_lt_div_of_mem_properDivisors h, ?_⟩, ?_⟩
-  · rw [mul_comm]
-    exact (Nat.div_mul_cancel (mem_properDivisors.mp h).1).symm
-  · rintro ⟨k, hk, h⟩
-    refine mem_properDivisors.mpr ⟨⟨k, h⟩, ?_⟩
-    calc
-      m = m * 1 := (mul_one m).symm
-      _ < m * k := mul_lt_mul_of_pos_left hk <|
-        Nat.pos_of_ne_zero fun hm ↦ hn <| by simpa [hm] using h
-      _ = n     := h.symm
+  · exact (Nat.mul_div_cancel' (mem_properDivisors.mp h).1).symm
+  · rintro ⟨k, hk, rfl⟩
+    rw [mul_ne_zero_iff] at hn
+    exact mem_properDivisors.mpr ⟨⟨k, rfl⟩, lt_mul_of_one_lt_right (Nat.pos_of_ne_zero hn.1) hk⟩
+
+@[simp]
+lemma nonempty_properDivisors : n.properDivisors.Nonempty ↔ 1 < n :=
+  ⟨fun ⟨_m, hm⟩ ↦ one_lt_of_mem_properDivisors hm, fun hn ↦
+    ⟨1, one_mem_properDivisors_iff_one_lt.2 hn⟩⟩
+
+@[simp]
+lemma properDivisors_eq_empty : n.properDivisors = ∅ ↔ n ≤ 1 := by
+  rw [← not_nonempty_iff_eq_empty, nonempty_properDivisors, not_lt]
 
 @[simp]
 theorem divisorsAntidiagonal_zero : divisorsAntidiagonal 0 = ∅ := by

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -208,6 +208,32 @@ lemma sup_divisors_id (n : ℕ) : n.divisors.sup id = n := by
   · apply zero_le
   · exact Finset.le_sup (f := id) <| mem_divisors_self n hn
 
+lemma one_lt_of_mem_properDivisors {m n : ℕ} (h : m ∈ n.properDivisors) : 1 < n :=
+  match n with
+  | 0 => by simp at h
+  | 1 => by simp at h
+  | n + 2 => n.one_lt_succ_succ
+
+lemma one_lt_div_of_mem_properDivisors {m n : ℕ} (h : m ∈ n.properDivisors) :
+    1 < n / m := by
+  have hm := pos_of_mem_properDivisors h
+  apply lt_of_mul_lt_mul_right ?_ hm.le
+  obtain ⟨h_dvd, h_lt⟩ := mem_properDivisors.mp h
+  simpa [Nat.div_mul_cancel h_dvd] using h_lt
+
+lemma mem_properDivisors_iff_exists {m n : ℕ} (hn : n ≠ 0) :
+    m ∈ n.properDivisors ↔ ∃ k > 1, n = m * k := by
+  refine ⟨fun h ↦ ⟨n / m, one_lt_div_of_mem_properDivisors h, ?_⟩, ?_⟩
+  · rw [mul_comm]
+    exact (Nat.div_mul_cancel (mem_properDivisors.mp h).1).symm
+  · rintro ⟨k, hk, h⟩
+    refine mem_properDivisors.mpr ⟨⟨k, h⟩, ?_⟩
+    calc
+      m = m * 1 := (mul_one m).symm
+      _ < m * k := mul_lt_mul_of_pos_left hk <|
+        Nat.pos_of_ne_zero fun hm ↦ hn <| by simpa [hm] using h
+      _ = n     := h.symm
+
 @[simp]
 theorem divisorsAntidiagonal_zero : divisorsAntidiagonal 0 = ∅ := by
   ext


### PR DESCRIPTION
---

These arose in the context of [this thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/checking.20a.20subgroup.20of.20Int.20is.20generated.20by.20an.20element/near/406391580)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
