### PR TITLE
[Merged by Bors] - feat: Discrete measurable spaces

### DIFF
--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -964,25 +964,25 @@ end CommMonoid
 variable [MeasurableSpace α] [Mul α] [Div α] [Inv α]
 
 @[to_additive] -- See note [lower instance priority]
-instance DiscreteMeasurableSpace.toMeasurableMul [DiscreteMeasurableSpace α] :
+instance (priority := 100) DiscreteMeasurableSpace.toMeasurableMul [DiscreteMeasurableSpace α] :
     MeasurableMul α where
   measurable_const_mul _ := measurable_discrete _
   measurable_mul_const _ := measurable_discrete _
 
 @[to_additive DiscreteMeasurableSpace.toMeasurableAdd₂] -- See note [lower instance priority]
-instance DiscreteMeasurableSpace.toMeasurableMul₂ [DiscreteMeasurableSpace (α × α)] :
-    MeasurableMul₂ α := ⟨measurable_discrete _⟩
+instance (priority := 100) DiscreteMeasurableSpace.toMeasurableMul₂
+    [DiscreteMeasurableSpace (α × α)] : MeasurableMul₂ α := ⟨measurable_discrete _⟩
 
 @[to_additive] -- See note [lower instance priority]
-instance DiscreteMeasurableSpace.toMeasurableInv [DiscreteMeasurableSpace α] :
+instance (priority := 100) DiscreteMeasurableSpace.toMeasurableInv [DiscreteMeasurableSpace α] :
     MeasurableInv α := ⟨measurable_discrete _⟩
 
 @[to_additive] -- See note [lower instance priority]
-instance DiscreteMeasurableSpace.toMeasurableDiv [DiscreteMeasurableSpace α] :
+instance (priority := 100) DiscreteMeasurableSpace.toMeasurableDiv [DiscreteMeasurableSpace α] :
     MeasurableDiv α where
   measurable_const_div _ := measurable_discrete _
   measurable_div_const _ := measurable_discrete _
 
 @[to_additive DiscreteMeasurableSpace.toMeasurableSub₂] -- See note [lower instance priority]
-instance DiscreteMeasurableSpace.toMeasurableDiv₂ [DiscreteMeasurableSpace (α × α)] :
-    MeasurableDiv₂ α := ⟨measurable_discrete _⟩
+instance (priority := 100) DiscreteMeasurableSpace.toMeasurableDiv₂
+    [DiscreteMeasurableSpace (α × α)] : MeasurableDiv₂ α := ⟨measurable_discrete _⟩

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -44,12 +44,11 @@ measurable function, arithmetic operator
   in the conclusion of `MeasurableSMul`.)
 -/
 
+open MeasureTheory
+open scoped BigOperators Pointwise
 
 universe u v
-
-open BigOperators Pointwise MeasureTheory
-
-open MeasureTheory
+variable {α : Type*}
 
 /-!
 ### Binary operations: `(· + ·)`, `(· * ·)`, `(· - ·)`, `(· / ·)`
@@ -524,6 +523,11 @@ instance (priority := 100) measurableDiv₂_of_mul_inv (G : Type*) [MeasurableSp
 #align has_measurable_div₂_of_mul_inv measurableDiv₂_of_mul_inv
 #align has_measurable_div₂_of_add_neg measurableDiv₂_of_add_neg
 
+-- See note [lower instance priority]
+instance (priority := 100) MeasurableDiv.toMeasurableInv [MeasurableSpace α] [Group α]
+    [MeasurableDiv α] : MeasurableInv α where
+  measurable_inv := by simpa using measurable_const_div (1 : α)
+
 /-- We say that the action of `M` on `α` has `MeasurableVAdd` if for each `c` the map `x ↦ c +ᵥ x`
 is a measurable function and for each `x` the map `c ↦ c +ᵥ x` is a measurable function. -/
 class MeasurableVAdd (M α : Type*) [VAdd M α] [MeasurableSpace M] [MeasurableSpace α] :
@@ -957,33 +961,28 @@ theorem Finset.aemeasurable_prod (s : Finset ι) (hf : ∀ i ∈ s, AEMeasurable
 
 end CommMonoid
 
-section DiscreteMeasurableSpace
+variable [MeasurableSpace α] [Mul α] [Div α] [Inv α]
 
-variable {α : Type*} [MeasurableSpace α] [DiscreteMeasurableSpace α]
+@[to_additive] -- See note [lower instance priority]
+instance DiscreteMeasurableSpace.toMeasurableMul [DiscreteMeasurableSpace α] :
+    MeasurableMul α where
+  measurable_const_mul _ := measurable_discrete _
+  measurable_mul_const _ := measurable_discrete _
 
-@[to_additive]
-instance [Mul α] : MeasurableMul α :=
-  ⟨fun _ ↦ DiscreteMeasurableSpace.measurable _, fun _ ↦ DiscreteMeasurableSpace.measurable _⟩
+@[to_additive DiscreteMeasurableSpace.toMeasurableAdd₂] -- See note [lower instance priority]
+instance DiscreteMeasurableSpace.toMeasurableMul₂ [DiscreteMeasurableSpace (α × α)] :
+    MeasurableMul₂ α := ⟨measurable_discrete _⟩
 
-@[to_additive]
-instance [Div α] : MeasurableDiv α :=
-  ⟨fun _ ↦ DiscreteMeasurableSpace.measurable _, fun _ ↦ DiscreteMeasurableSpace.measurable _⟩
+@[to_additive] -- See note [lower instance priority]
+instance DiscreteMeasurableSpace.toMeasurableInv [DiscreteMeasurableSpace α] :
+    MeasurableInv α := ⟨measurable_discrete _⟩
 
-@[to_additive]
-instance [Inv α] : MeasurableInv α := ⟨DiscreteMeasurableSpace.measurable _⟩
+@[to_additive] -- See note [lower instance priority]
+instance DiscreteMeasurableSpace.toMeasurableDiv [DiscreteMeasurableSpace α] :
+    MeasurableDiv α where
+  measurable_const_div _ := measurable_discrete _
+  measurable_div_const _ := measurable_discrete _
 
-end DiscreteMeasurableSpace
-
-section Countable
-
-variable {α : Type*} [MeasurableSpace α] [Countable α] [MeasurableSingletonClass α]
-
-instance [Add α] : MeasurableAdd₂ α := ⟨DiscreteMeasurableSpace.measurable _⟩
-
-instance [Mul α] : MeasurableMul₂ α := ⟨DiscreteMeasurableSpace.measurable _⟩
-
-instance [Sub α] : MeasurableSub₂ α := ⟨DiscreteMeasurableSpace.measurable _⟩
-
-instance [Div α] : MeasurableDiv₂ α := ⟨DiscreteMeasurableSpace.measurable _⟩
-
-end Countable
+@[to_additive DiscreteMeasurableSpace.toMeasurableSub₂] -- See note [lower instance priority]
+instance DiscreteMeasurableSpace.toMeasurableDiv₂ [DiscreteMeasurableSpace (α × α)] :
+    MeasurableDiv₂ α := ⟨measurable_discrete _⟩

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -956,3 +956,34 @@ theorem Finset.aemeasurable_prod (s : Finset ι) (hf : ∀ i ∈ s, AEMeasurable
 #align finset.ae_measurable_sum Finset.aemeasurable_sum
 
 end CommMonoid
+
+section DiscreteMeasurableSpace
+
+variable {α : Type*} [MeasurableSpace α] [DiscreteMeasurableSpace α]
+
+@[to_additive]
+instance [Mul α] : MeasurableMul α :=
+  ⟨fun _ ↦ DiscreteMeasurableSpace.measurable _, fun _ ↦ DiscreteMeasurableSpace.measurable _⟩
+
+@[to_additive]
+instance [Div α] : MeasurableDiv α :=
+  ⟨fun _ ↦ DiscreteMeasurableSpace.measurable _, fun _ ↦ DiscreteMeasurableSpace.measurable _⟩
+
+@[to_additive]
+instance [Inv α] : MeasurableInv α := ⟨DiscreteMeasurableSpace.measurable _⟩
+
+end DiscreteMeasurableSpace
+
+section Countable
+
+variable {α : Type*} [MeasurableSpace α] [Countable α] [MeasurableSingletonClass α]
+
+instance [Add α] : MeasurableAdd₂ α := ⟨DiscreteMeasurableSpace.measurable _⟩
+
+instance [Mul α] : MeasurableMul₂ α := ⟨DiscreteMeasurableSpace.measurable _⟩
+
+instance [Sub α] : MeasurableSub₂ α := ⟨DiscreteMeasurableSpace.measurable _⟩
+
+instance [Div α] : MeasurableDiv₂ α := ⟨DiscreteMeasurableSpace.measurable _⟩
+
+end Countable

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -1431,13 +1431,6 @@ theorem set_lintegral_subtype {s : Set α} (hs : MeasurableSet s) (t : Set s) (f
     restrict_restrict hs, inter_eq_right.2 (Subtype.coe_image_subset _ _)]
 
 section DiracAndCount
-
-instance (priority := 10) _root_.MeasurableSpace.Top.measurableSingletonClass {α : Type*} :
-    @MeasurableSingletonClass α (⊤ : MeasurableSpace α) :=
-  @MeasurableSingletonClass.mk α (⊤ : MeasurableSpace α) <|
-    fun _ => MeasurableSpace.measurableSet_top
-#align measurable_space.top.measurable_singleton_class MeasurableSpace.Top.measurableSingletonClass
-
 variable [MeasurableSpace α]
 
 theorem lintegral_dirac' (a : α) {f : α → ℝ≥0∞} (hf : Measurable f) : ∫⁻ a, f a ∂dirac a = f a :=

--- a/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
@@ -318,6 +318,23 @@ theorem Set.Countable.measurableSet {s : Set α} (hs : s.Countable) : Measurable
 
 end MeasurableSingletonClass
 
+/-- A typeclass mixin for `MeasurableSpace`s such that all sets are measurable. -/
+class DiscreteMeasurableSpace (α : Type*) [MeasurableSpace α] : Prop where
+  /-- Any set of a discrete measurable space is measurable. -/
+  measurableSet : ∀ (s : Set α), MeasurableSet s
+
+attribute [simp, measurability] DiscreteMeasurableSpace.measurableSet
+
+section DiscreteMeasurableSpace
+
+instance [MeasurableSpace α] [MeasurableSingletonClass α] [Countable α] :
+    DiscreteMeasurableSpace α := ⟨fun _ ↦ Set.Countable.measurableSet (Set.to_countable _)⟩
+
+instance [MeasurableSpace α] [DiscreteMeasurableSpace α] :
+    MeasurableSingletonClass α := ⟨fun _ ↦ DiscreteMeasurableSpace.measurableSet _⟩
+
+end DiscreteMeasurableSpace
+
 namespace MeasurableSpace
 
 /-- Copy of a `MeasurableSpace` with a new `MeasurableSet` equal to the old one. Useful to fix
@@ -526,6 +543,10 @@ theorem generateFrom_iUnion_measurableSet (m : ι → MeasurableSpace α) :
   (@giGenerateFrom α).l_iSup_u m
 #align measurable_space.generate_from_Union_measurable_set MeasurableSpace.generateFrom_iUnion_measurableSet
 
+instance : @DiscreteMeasurableSpace α ⊤ := by
+  letI : MeasurableSpace α := ⊤
+  exact ⟨fun s ↦ measurableSet_top⟩
+
 end CompleteLattice
 
 end MeasurableSpace
@@ -575,8 +596,13 @@ theorem Measurable.le {α} {m m0 : MeasurableSpace α} {_ : MeasurableSpace β} 
     {f : α → β} (hf : Measurable[m] f) : Measurable[m0] f := fun _ hs => hm _ (hf hs)
 #align measurable.le Measurable.le
 
+@[measurability]
+theorem DiscreteMeasurableSpace.measurable {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+    [DiscreteMeasurableSpace α] (f : α → β) : Measurable f :=
+  fun _ _ => DiscreteMeasurableSpace.measurableSet _
+
 theorem MeasurableSpace.Top.measurable {α β : Type*} [MeasurableSpace β] (f : α → β) :
-    Measurable[⊤] f := fun _ _ => MeasurableSpace.measurableSet_top
+    Measurable[⊤] f := @DiscreteMeasurableSpace.measurable α β ⊤ _ _ f
 #align measurable_space.top.measurable MeasurableSpace.Top.measurable
 
 end MeasurableFunctions

--- a/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
@@ -585,7 +585,8 @@ class DiscreteMeasurableSpace (α : Type*) [MeasurableSpace α] : Prop where
 instance : @DiscreteMeasurableSpace α ⊤ :=
   @DiscreteMeasurableSpace.mk _ (_) fun _ ↦ MeasurableSpace.measurableSet_top
 
-instance MeasurableSingletonClass.toDiscreteMeasurableSpace [MeasurableSpace α]
+-- See note [lower instance priority]
+instance (priority := 100) MeasurableSingletonClass.toDiscreteMeasurableSpace [MeasurableSpace α]
     [MeasurableSingletonClass α] [Countable α] : DiscreteMeasurableSpace α where
   forall_measurableSet _ := (Set.to_countable _).measurableSet
 
@@ -601,7 +602,9 @@ lemma measurable_discrete (f : α → β) : Measurable f := fun _ _ ↦ measurab
 
 /-- Warning: Creates a typeclass loop with `MeasurableSingletonClass.toDiscreteMeasurableSpace`.
 To be monitored. -/
-instance DiscreteMeasurableSpace.toMeasurableSingletonClass : MeasurableSingletonClass α where
+-- See note [lower instance priority]
+instance (priority := 100) DiscreteMeasurableSpace.toMeasurableSingletonClass :
+    MeasurableSingletonClass α where
   measurableSet_singleton _ := measurableSet_discrete _
 
 end DiscreteMeasurableSpace

--- a/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
@@ -323,7 +323,7 @@ class DiscreteMeasurableSpace (α : Type*) [MeasurableSpace α] : Prop where
   /-- Any set of a discrete measurable space is measurable. -/
   measurableSet : ∀ (s : Set α), MeasurableSet s
 
-attribute [simp, measurability] DiscreteMeasurableSpace.measurableSet
+attribute [measurability] DiscreteMeasurableSpace.measurableSet
 
 section DiscreteMeasurableSpace
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
@@ -592,7 +592,7 @@ instance MeasurableSingletonClass.toDiscreteMeasurableSpace [MeasurableSpace α]
 section DiscreteMeasurableSpace
 variable [MeasurableSpace α] [MeasurableSpace β] [DiscreteMeasurableSpace α]
 
-@[simp, measurability] lemma measurableSet_discrete (s : Set α) : MeasurableSet s :=
+@[measurability] lemma measurableSet_discrete (s : Set α) : MeasurableSet s :=
   DiscreteMeasurableSpace.forall_measurableSet _
 
 @[measurability]

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -88,7 +88,7 @@ theorem restrict_singleton (μ : Measure α) (a : α) : μ.restrict {a} = μ {a}
 /-- If `f` is a map with countable codomain, then `μ.map f` is a sum of Dirac measures. -/
 theorem map_eq_sum [Countable β] [MeasurableSingletonClass β] (μ : Measure α) (f : α → β)
     (hf : Measurable f) : μ.map f = sum fun b : β => μ (f ⁻¹' {b}) • dirac b := by
-  ext1 s hs
+  ext s
   have : ∀ y ∈ s, MeasurableSet (f ⁻¹' {y}) := fun y _ => hf (measurableSet_singleton _)
   simp [← tsum_measure_preimage_singleton (to_countable s) this, *,
     tsum_subtype s fun b => μ (f ⁻¹' {b}), ← indicator_mul_right s fun b => μ (f ⁻¹' {b})]


### PR DESCRIPTION
Adds a typeclass for measurable spaces where all sets are measurable
Proves several instances relating these to other classes

---

Inspired by requiring an instance of `MeasurableSub₂` on such a measure space in the Polynomial Freiman-Ruzsa project.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
