### PR TITLE
[Merged by Bors] - feat(RingTheory/Coalgebra): generalize the `Finsupp` instance

### DIFF
--- a/Mathlib/LinearAlgebra/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Finsupp.lean
@@ -218,7 +218,7 @@ theorem lapply_comp_lsingle_same (a : α) : lapply a ∘ₗ lsingle a = (.id : M
 
 @[simp]
 theorem lapply_comp_lsingle_of_ne (a a' : α) (h : a ≠ a') :
-  lapply a ∘ₗ lsingle a' = (0 : M →ₗ[R] M) := by ext; simp [h.symm]
+    lapply a ∘ₗ lsingle a' = (0 : M →ₗ[R] M) := by ext; simp [h.symm]
 
 @[simp]
 theorem ker_lsingle (a : α) : ker (lsingle a : M →ₗ[R] α →₀ M) = ⊥ :=

--- a/Mathlib/LinearAlgebra/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Finsupp.lean
@@ -214,6 +214,13 @@ theorem lapply_apply (a : α) (f : α →₀ M) : (lapply a : (α →₀ M) →�
 #align finsupp.lapply_apply Finsupp.lapply_apply
 
 @[simp]
+theorem lapply_comp_lsingle_same (a : α) : lapply a ∘ₗ lsingle a = (.id : M →ₗ[R] M) := by ext; simp
+
+@[simp]
+theorem lapply_comp_lsingle_of_ne (a a' : α) (h : a ≠ a') :
+  lapply a ∘ₗ lsingle a' = (0 : M →ₗ[R] M) := by ext; simp [h.symm]
+
+@[simp]
 theorem ker_lsingle (a : α) : ker (lsingle a : M →ₗ[R] α →₀ M) = ⊥ :=
   ker_eq_bot_of_injective (single_injective a)
 #align finsupp.ker_lsingle Finsupp.ker_lsingle
@@ -466,6 +473,9 @@ theorem lsum_single (f : α → M →ₗ[R] N) (i : α) (m : M) :
     Finsupp.lsum S f (Finsupp.single i m) = f i m :=
   Finsupp.sum_single_index (f i).map_zero
 #align finsupp.lsum_single Finsupp.lsum_single
+
+@[simp] theorem lsum_comp_lsingle (f : α → M →ₗ[R] N) (i : α) :
+    Finsupp.lsum S f ∘ₗ lsingle i = f i := by ext; simp
 
 theorem lsum_symm_apply (f : (α →₀ M) →ₗ[R] N) (x : α) : (lsum S).symm f x = f.comp (lsingle x) :=
   rfl

--- a/Mathlib/RingTheory/Coalgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra.lean
@@ -82,11 +82,11 @@ theorem lTensor_counit_comul (a : A) : counit.lTensor A (comul a) = a ⊗ₜ[R] 
 
 end Coalgebra
 section CommSemiring
-variable (R : Type u) [CommSemiring R]
 
 open Coalgebra
 
 namespace CommSemiring
+variable (R : Type u) [CommSemiring R]
 
 /-- Every commutative (semi)ring is a coalgebra over itself, with `Δ r = 1 ⊗ₜ r`. -/
 instance toCoalgebra : Coalgebra R R where
@@ -182,29 +182,60 @@ instance instCoalgebra : Coalgebra R (A × B) where
 end Prod
 
 namespace Finsupp
-variable (ι : Type v)
+variable (R : Type u) (ι : Type v) (A : Type w)
+variable [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A]
 
-/-- The `R`-module whose elements are functions `ι → R` which are zero on all but finitely many
-elements of `ι` has a coalgebra structure. The coproduct `Δ` is given by `Δ(fᵢ) = fᵢ ⊗ fᵢ` and the
-counit `ε` by `ε(fᵢ) =  1`, where `fᵢ` is the function sending `i` to `1` and all other elements of
-`ι` to zero. -/
-noncomputable
-instance instCoalgebra : Coalgebra R (ι →₀ R) where
-  comul := Finsupp.total ι ((ι →₀ R) ⊗[R] (ι →₀ R)) R (fun i ↦ .single i 1 ⊗ₜ .single i 1)
-  counit := Finsupp.total ι R R (fun _ ↦ 1)
-  coassoc := by ext; simp
-  rTensor_counit_comp_comul := by ext; simp
-  lTensor_counit_comp_comul := by ext; simp
+open LinearMap
+
+instance instCoalgebraStruct : CoalgebraStruct R (ι →₀ A) where
+  comul := Finsupp.lsum R fun i => TensorProduct.map (Finsupp.lsingle i) (Finsupp.lsingle i) ∘ₗ comul
+  counit := Finsupp.lsum R fun _ => counit
 
 @[simp]
-theorem comul_single (i : ι) (r : R) :
-    comul (Finsupp.single i r) = (Finsupp.single i r) ⊗ₜ[R] (Finsupp.single i 1) := by
-  unfold comul instCoalgebra toCoalgebraStruct
-  rw [total_single, TensorProduct.smul_tmul', smul_single_one i r]
+theorem comul_single (i : ι) (a : A) :
+    comul (R := R) (Finsupp.single i a) =
+      (TensorProduct.map (Finsupp.lsingle i) (Finsupp.lsingle i) : _ →ₗ[R] _) (comul a) :=
+  lsum_single _ _ _ _
 
 @[simp]
-theorem counit_single (i : ι) (r : R) : counit (Finsupp.single i r) = r := by
-  unfold counit instCoalgebra; simp
+theorem counit_single (i : ι) (a : A) : counit (Finsupp.single i a) = counit (R := R) a :=
+  lsum_single _ _ _ _
+
+theorem comul_comp_lsingle (i : ι) :
+    comul ∘ₗ (lsingle i : A →ₗ[R] _) = TensorProduct.map (lsingle i) (lsingle i) ∘ₗ comul := by
+  ext; simp
+
+theorem comul_comp_lapply (i : ι) :
+    comul ∘ₗ (lapply i : _ →ₗ[R] A) = TensorProduct.map (lapply i) (lapply i) ∘ₗ comul := by
+  ext j : 1
+  conv_rhs => rw [comp_assoc, comul_comp_lsingle, ←comp_assoc, ← TensorProduct.map_comp]
+  obtain rfl | hij := eq_or_ne i j
+  · rw [comp_assoc, lapply_comp_lsingle_same, comp_id,  TensorProduct.map_id, id_comp]
+  · rw [comp_assoc, lapply_comp_lsingle_of_ne _ _ hij, comp_zero, TensorProduct.map_zero_left,
+      zero_comp]
+
+@[simp] theorem counit_comp_lsingle (i : ι) : counit ∘ₗ (lsingle i : A →ₗ[R] _) = counit := by
+  ext; simp
+
+/-- The `R`-module whose elements are functions `ι → A` which are zero on all but finitely many
+elements of `ι` has a coalgebra structure. The coproduct `Δ` is given by `Δ(fᵢ a) = fᵢ a₁ ⊗ fᵢ a₂`
+where `Δ(a) = a₁ ⊗ a₂` and the counit `ε` by `ε(fᵢ a) = ε(a)`, where `fᵢ a` is the function sending
+`i` to `a` and all other elements of `ι` to zero. -/
+instance instCoalgebra : Coalgebra R (ι →₀ A) where
+  rTensor_counit_comp_comul := by
+    ext : 1
+    rw [comp_assoc, comul_comp_lsingle, ← comp_assoc, rTensor_comp_map, counit_comp_lsingle,
+      ← lTensor_comp_rTensor, comp_assoc, rTensor_counit_comp_comul, lTensor_comp_mk]
+  lTensor_counit_comp_comul := by
+    ext : 1
+    rw [comp_assoc, comul_comp_lsingle, ← comp_assoc, lTensor_comp_map, counit_comp_lsingle,
+      ← rTensor_comp_lTensor, comp_assoc, lTensor_counit_comp_comul, rTensor_comp_flip_mk]
+  coassoc := by
+    ext i : 1
+    simp_rw [comp_assoc, comul_comp_lsingle, ←comp_assoc, lTensor_comp_map, comul_comp_lsingle,
+      comp_assoc, ←comp_assoc comul, rTensor_comp_map, comul_comp_lsingle, ←map_comp_rTensor,
+      ←map_comp_lTensor, comp_assoc, ←coassoc, ←comp_assoc comul, ←comp_assoc,
+        TensorProduct.map_map_comp_assoc_eq]
 
 end Finsupp
 

--- a/Mathlib/RingTheory/Coalgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra.lean
@@ -208,7 +208,7 @@ theorem comul_comp_lsingle (i : ι) :
 theorem comul_comp_lapply (i : ι) :
     comul ∘ₗ (lapply i : _ →ₗ[R] A) = TensorProduct.map (lapply i) (lapply i) ∘ₗ comul := by
   ext j : 1
-  conv_rhs => rw [comp_assoc, comul_comp_lsingle, ←comp_assoc, ← TensorProduct.map_comp]
+  conv_rhs => rw [comp_assoc, comul_comp_lsingle, ← comp_assoc, ← TensorProduct.map_comp]
   obtain rfl | hij := eq_or_ne i j
   · rw [comp_assoc, lapply_comp_lsingle_same, comp_id,  TensorProduct.map_id, id_comp]
   · rw [comp_assoc, lapply_comp_lsingle_of_ne _ _ hij, comp_zero, TensorProduct.map_zero_left,
@@ -232,9 +232,9 @@ instance instCoalgebra : Coalgebra R (ι →₀ A) where
       ← rTensor_comp_lTensor, comp_assoc, lTensor_counit_comp_comul, rTensor_comp_flip_mk]
   coassoc := by
     ext i : 1
-    simp_rw [comp_assoc, comul_comp_lsingle, ←comp_assoc, lTensor_comp_map, comul_comp_lsingle,
-      comp_assoc, ←comp_assoc comul, rTensor_comp_map, comul_comp_lsingle, ←map_comp_rTensor,
-      ←map_comp_lTensor, comp_assoc, ←coassoc, ←comp_assoc comul, ←comp_assoc,
+    simp_rw [comp_assoc, comul_comp_lsingle, ← comp_assoc, lTensor_comp_map, comul_comp_lsingle,
+      comp_assoc, ← comp_assoc comul, rTensor_comp_map, comul_comp_lsingle, ← map_comp_rTensor,
+      ← map_comp_lTensor, comp_assoc, ← coassoc, ← comp_assoc comul, ← comp_assoc,
         TensorProduct.map_map_comp_assoc_eq]
 
 end Finsupp

--- a/Mathlib/RingTheory/Coalgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra.lean
@@ -188,7 +188,8 @@ variable [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A]
 open LinearMap
 
 instance instCoalgebraStruct : CoalgebraStruct R (ι →₀ A) where
-  comul := Finsupp.lsum R fun i => TensorProduct.map (Finsupp.lsingle i) (Finsupp.lsingle i) ∘ₗ comul
+  comul := Finsupp.lsum R fun i =>
+    TensorProduct.map (Finsupp.lsingle i) (Finsupp.lsingle i) ∘ₗ comul
   counit := Finsupp.lsum R fun _ => counit
 
 @[simp]

--- a/Mathlib/RingTheory/Coalgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Ali Ramsey. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Ali Ramsey
+Authors: Ali Ramsey, Eric Wieser
 -/
 import Mathlib.LinearAlgebra.Finsupp
 import Mathlib.LinearAlgebra.Prod


### PR DESCRIPTION
The original `Coalgebra R (ι →₀ R)` is now recovered from `[Coalgebra R A] : Coalgebra R (ι →₀ A)` as a special case.

Salvaged from https://github.com/leanprover-community/mathlib4/pull/8621#discussion_r1408532458

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
