### PR TITLE
[Merged by Bors] - refactor: Remove `leftCoset`/`rightCoset`

### DIFF
--- a/Mathlib/Algebra/Category/GroupCat/EpiMono.lean
+++ b/Mathlib/Algebra/Category/GroupCat/EpiMono.lean
@@ -17,6 +17,8 @@ epimorphisms are surjective homomorphisms.
 
 noncomputable section
 
+open scoped Pointwise
+
 universe u v
 
 namespace MonoidHom
@@ -96,18 +98,17 @@ theorem mono_iff_injective : Mono f ↔ Function.Injective f :=
 
 namespace SurjectiveOfEpiAuxs
 
-local notation "X" => Set.range (Function.swap leftCoset f.range.carrier)
+set_option quotPrecheck false in
+local notation "X" => Set.range (· • (f.range : Set B) : B → Set B)
 
 /-- Define `X'` to be the set of all left cosets with an extra point at "infinity".
 -/
 inductive XWithInfinity
-  | fromCoset : Set.range (Function.swap leftCoset f.range.carrier) → XWithInfinity
+  | fromCoset : Set.range (· • (f.range : Set B) : B → Set B) → XWithInfinity
   | infinity : XWithInfinity
 #align Group.surjective_of_epi_auxs.X_with_infinity GroupCat.SurjectiveOfEpiAuxs.XWithInfinity
 
 open XWithInfinity Equiv.Perm
-
-open Coset
 
 local notation "X'" => XWithInfinity f
 
@@ -118,7 +119,7 @@ local notation "SX'" => Equiv.Perm X'
 instance : SMul B X' where
   smul b x :=
     match x with
-    | fromCoset y => fromCoset ⟨b *l y, by
+    | fromCoset y => fromCoset ⟨b • y, by
           rw [← y.2.choose_spec, leftCoset_assoc]
           -- Porting note: should we make `Bundled.α` reducible?
           let b' : B := y.2.choose
@@ -142,12 +143,11 @@ theorem one_smul (x : X') : (1 : B) • x = x :=
 #align Group.surjective_of_epi_auxs.one_smul GroupCat.SurjectiveOfEpiAuxs.one_smul
 
 theorem fromCoset_eq_of_mem_range {b : B} (hb : b ∈ f.range) :
-    fromCoset ⟨b *l f.range.carrier, ⟨b, rfl⟩⟩ =
-      fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩ := by
+    fromCoset ⟨b • ↑f.range, b, rfl⟩ = fromCoset ⟨f.range, 1, one_leftCoset _⟩ := by
   congr
   let b : B.α := b
-  change b *l f.range = f.range
-  nth_rw 2 [show (f.range : Set B.α) = 1 *l f.range from (one_leftCoset _).symm]
+  change b • (f.range : Set B) = f.range
+  nth_rw 2 [show (f.range : Set B.α) = (1 : B) • f.range from (one_leftCoset _).symm]
   rw [leftCoset_eq_iff, mul_one]
   exact Subgroup.inv_mem _ hb
 #align Group.surjective_of_epi_auxs.from_coset_eq_of_mem_range GroupCat.SurjectiveOfEpiAuxs.fromCoset_eq_of_mem_range
@@ -155,14 +155,13 @@ theorem fromCoset_eq_of_mem_range {b : B} (hb : b ∈ f.range) :
 example (G : Type) [Group G] (S : Subgroup G) : Set G := S
 
 theorem fromCoset_ne_of_nin_range {b : B} (hb : b ∉ f.range) :
-    fromCoset ⟨b *l f.range.carrier, ⟨b, rfl⟩⟩ ≠
-      fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩ := by
+    fromCoset ⟨b • ↑f.range, b, rfl⟩ ≠ fromCoset ⟨f.range, 1, one_leftCoset _⟩ := by
   intro r
   simp only [fromCoset.injEq, Subtype.mk.injEq] at r
   -- Porting note: annoying dance between types CoeSort.coe B, B.α, and B
   let b' : B.α := b
-  change b' *l f.range = f.range at r
-  nth_rw 2 [show (f.range : Set B.α) = 1 *l f.range from (one_leftCoset _).symm] at r
+  change b' • (f.range : Set B) = f.range at r
+  nth_rw 2 [show (f.range : Set B.α) = (1 : B) • f.range from (one_leftCoset _).symm] at r
   rw [leftCoset_eq_iff, mul_one] at r
   exact hb (inv_inv b ▸ Subgroup.inv_mem _ r)
 #align Group.surjective_of_epi_auxs.from_coset_ne_of_nin_range GroupCat.SurjectiveOfEpiAuxs.fromCoset_ne_of_nin_range
@@ -173,36 +172,35 @@ instance : DecidableEq X' :=
 /-- Let `τ` be the permutation on `X'` exchanging `f.range` and the point at infinity.
 -/
 noncomputable def tau : SX' :=
-  Equiv.swap (fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩) ∞
+  Equiv.swap (fromCoset ⟨↑f.range, ⟨1, one_leftCoset _⟩⟩) ∞
 #align Group.surjective_of_epi_auxs.tau GroupCat.SurjectiveOfEpiAuxs.tau
 
 local notation "τ" => tau f
 
-theorem τ_apply_infinity : τ ∞ = fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩ :=
+theorem τ_apply_infinity : τ ∞ = fromCoset ⟨f.range, 1, one_leftCoset _⟩ :=
   Equiv.swap_apply_right _ _
 #align Group.surjective_of_epi_auxs.τ_apply_infinity GroupCat.SurjectiveOfEpiAuxs.τ_apply_infinity
 
-theorem τ_apply_fromCoset : τ (fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩) = ∞ :=
+theorem τ_apply_fromCoset : τ (fromCoset ⟨f.range, 1, one_leftCoset _⟩) = ∞ :=
   Equiv.swap_apply_left _ _
 #align Group.surjective_of_epi_auxs.τ_apply_fromCoset GroupCat.SurjectiveOfEpiAuxs.τ_apply_fromCoset
 
 theorem τ_apply_fromCoset' (x : B) (hx : x ∈ f.range) :
-    τ (fromCoset ⟨x *l f.range.carrier, ⟨x, rfl⟩⟩) = ∞ :=
+    τ (fromCoset ⟨x • ↑f.range, ⟨x, rfl⟩⟩) = ∞ :=
   (fromCoset_eq_of_mem_range _ hx).symm ▸ τ_apply_fromCoset _
 #align Group.surjective_of_epi_auxs.τ_apply_fromCoset' GroupCat.SurjectiveOfEpiAuxs.τ_apply_fromCoset'
 
-theorem τ_symm_apply_fromCoset :
-    (Equiv.symm τ) (fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩) = ∞ := by
+theorem τ_symm_apply_fromCoset : Equiv.symm τ (fromCoset ⟨f.range, 1, one_leftCoset _⟩) = ∞ := by
   rw [tau, Equiv.symm_swap, Equiv.swap_apply_left]
 #align Group.surjective_of_epi_auxs.τ_symm_apply_fromCoset GroupCat.SurjectiveOfEpiAuxs.τ_symm_apply_fromCoset
 
 theorem τ_symm_apply_infinity :
-    (Equiv.symm τ) ∞ = fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩ := by
+    Equiv.symm τ ∞ = fromCoset ⟨f.range, 1, one_leftCoset _⟩ := by
   rw [tau, Equiv.symm_swap, Equiv.swap_apply_right]
 #align Group.surjective_of_epi_auxs.τ_symm_apply_infinity GroupCat.SurjectiveOfEpiAuxs.τ_symm_apply_infinity
 
 /-- Let `g : B ⟶ S(X')` be defined as such that, for any `β : B`, `g(β)` is the function sending
-point at infinity to point at infinity and sending coset `y` to `β *l y`.
+point at infinity to point at infinity and sending coset `y` to `β • y`.
 -/
 def g : B →* SX' where
   toFun β :=
@@ -247,8 +245,8 @@ The strategy is the following: assuming `epi f`
 -/
 
 
-theorem g_apply_fromCoset (x : B) (y : X) : (g x) (fromCoset y)
-    = fromCoset ⟨x *l y, by aesop_cat⟩ := rfl
+theorem g_apply_fromCoset (x : B) (y : Set.range (· • (f.range : Set B) : B → Set B)) :
+    g x (fromCoset y) = fromCoset ⟨x • ↑y, by aesop_cat⟩ := rfl
 #align Group.surjective_of_epi_auxs.g_apply_fromCoset GroupCat.SurjectiveOfEpiAuxs.g_apply_fromCoset
 
 theorem g_apply_infinity (x : B) : (g x) ∞ = ∞ := rfl
@@ -262,33 +260,31 @@ theorem h_apply_infinity (x : B) (hx : x ∈ f.range) : (h x) ∞ = ∞ := by
 #align Group.surjective_of_epi_auxs.h_apply_infinity GroupCat.SurjectiveOfEpiAuxs.h_apply_infinity
 
 theorem h_apply_fromCoset (x : B) :
-    (h x) (fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩) =
-      fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩ := by
+    (h x) (fromCoset ⟨f.range, 1, one_leftCoset _⟩) =
+      fromCoset ⟨f.range, 1, one_leftCoset _⟩ := by
     change ((τ).symm.trans (g x)).trans τ _ = _
-    simp [τ_symm_apply_fromCoset, g_apply_infinity, τ_apply_infinity]
+    simp [-MonoidHom.coe_range, τ_symm_apply_fromCoset, g_apply_infinity, τ_apply_infinity]
 #align Group.surjective_of_epi_auxs.h_apply_fromCoset GroupCat.SurjectiveOfEpiAuxs.h_apply_fromCoset
 
 theorem h_apply_fromCoset' (x : B) (b : B) (hb : b ∈ f.range) :
-    (h x) (fromCoset ⟨b *l f.range.carrier, ⟨b, rfl⟩⟩) =
-      fromCoset ⟨b *l f.range.carrier, ⟨b, rfl⟩⟩ :=
+    h x (fromCoset ⟨b • f.range, b, rfl⟩) = fromCoset ⟨b • ↑f.range, b, rfl⟩ :=
   (fromCoset_eq_of_mem_range _ hb).symm ▸ h_apply_fromCoset f x
 #align Group.surjective_of_epi_auxs.h_apply_fromCoset' GroupCat.SurjectiveOfEpiAuxs.h_apply_fromCoset'
 
 theorem h_apply_fromCoset_nin_range (x : B) (hx : x ∈ f.range) (b : B) (hb : b ∉ f.range) :
-    (h x) (fromCoset ⟨b *l f.range.carrier, ⟨b, rfl⟩⟩) =
-      fromCoset ⟨x * b *l f.range.carrier, ⟨x * b, rfl⟩⟩ := by
+    h x (fromCoset ⟨b • f.range, b, rfl⟩) = fromCoset ⟨(x * b) • ↑f.range, x * b, rfl⟩ := by
   change ((τ).symm.trans (g x)).trans τ _ = _
   simp only [tau, MonoidHom.coe_mk, Equiv.toFun_as_coe, Equiv.coe_trans, Function.comp_apply]
   rw [Equiv.symm_swap,
-    @Equiv.swap_apply_of_ne_of_ne X' _ (fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩) ∞
-      (fromCoset ⟨b *l f.range.carrier, ⟨b, rfl⟩⟩) (fromCoset_ne_of_nin_range _ hb) (by simp)]
+    @Equiv.swap_apply_of_ne_of_ne X' _ (fromCoset ⟨f.range, 1, one_leftCoset _⟩) ∞
+      (fromCoset ⟨b • ↑f.range, b, rfl⟩) (fromCoset_ne_of_nin_range _ hb) (by simp)]
   simp only [g_apply_fromCoset, leftCoset_assoc]
   refine' Equiv.swap_apply_of_ne_of_ne (fromCoset_ne_of_nin_range _ fun r => hb _) (by simp)
   convert Subgroup.mul_mem _ (Subgroup.inv_mem _ hx) r
   rw [← mul_assoc, mul_left_inv, one_mul]
 #align Group.surjective_of_epi_auxs.h_apply_fromCoset_nin_range GroupCat.SurjectiveOfEpiAuxs.h_apply_fromCoset_nin_range
 
-theorem agree : f.range.carrier = { x | h x = g x } := by
+theorem agree : f.range = { x | h x = g x } := by
   refine' Set.ext fun b => ⟨_, fun hb : h b = g b => by_contradiction fun r => _⟩
   · rintro ⟨a, rfl⟩
     change h (f a) = g (f a)
@@ -296,21 +292,18 @@ theorem agree : f.range.carrier = { x | h x = g x } := by
     · rw [g_apply_fromCoset]
       by_cases m : y ∈ f.range
       · rw [h_apply_fromCoset' _ _ _ m, fromCoset_eq_of_mem_range _ m]
-        change fromCoset _ = fromCoset ⟨f a *l (y *l _), _⟩
-        simp only [← fromCoset_eq_of_mem_range _ (Subgroup.mul_mem _ ⟨a, rfl⟩ m)]
-        congr
-        rw [leftCoset_assoc _ (f a) y]
+        change fromCoset _ = fromCoset ⟨f a • (y • _), _⟩
+        simp only [← fromCoset_eq_of_mem_range _ (Subgroup.mul_mem _ ⟨a, rfl⟩ m), smul_smul]
       · rw [h_apply_fromCoset_nin_range f (f a) ⟨_, rfl⟩ _ m]
         simp only [leftCoset_assoc]
     · rw [g_apply_infinity, h_apply_infinity f (f a) ⟨_, rfl⟩]
-  · have eq1 : (h b) (fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩) =
-        fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩ := by
+  · have eq1 : (h b) (fromCoset ⟨f.range, 1, one_leftCoset _⟩) =
+        fromCoset ⟨f.range, 1, one_leftCoset _⟩ := by
       change ((τ).symm.trans (g b)).trans τ _ = _
       dsimp [tau]
       simp [g_apply_infinity f]
     have eq2 :
-      (g b) (fromCoset ⟨f.range.carrier, ⟨1, one_leftCoset _⟩⟩) =
-        fromCoset ⟨b *l f.range.carrier, ⟨b, rfl⟩⟩ := rfl
+      g b (fromCoset ⟨f.range, 1, one_leftCoset _⟩) = fromCoset ⟨b • ↑f.range, b, rfl⟩ := rfl
     exact (fromCoset_ne_of_nin_range _ r).symm (by rw [← eq1, ← eq2, FunLike.congr_fun hb])
 #align Group.surjective_of_epi_auxs.agree GroupCat.SurjectiveOfEpiAuxs.agree
 

--- a/Mathlib/Algebra/Category/GroupCat/EpiMono.lean
+++ b/Mathlib/Algebra/Category/GroupCat/EpiMono.lean
@@ -246,7 +246,8 @@ The strategy is the following: assuming `epi f`
 
 
 theorem g_apply_fromCoset (x : B) (y : Set.range (· • (f.range : Set B) : B → Set B)) :
-    g x (fromCoset y) = fromCoset ⟨x • ↑y, by aesop_cat⟩ := rfl
+    g x (fromCoset y) = fromCoset ⟨x • ↑y,
+      by obtain ⟨z, hz⟩ := y.2; exact ⟨x * z, by simp [← hz, smul_smul]⟩⟩ := rfl
 #align Group.surjective_of_epi_auxs.g_apply_fromCoset GroupCat.SurjectiveOfEpiAuxs.g_apply_fromCoset
 
 theorem g_apply_infinity (x : B) : (g x) ∞ = ∞ := rfl

--- a/Mathlib/FieldTheory/KrullTopology.lean
+++ b/Mathlib/FieldTheory/KrullTopology.lean
@@ -54,8 +54,7 @@ all intermediate fields `E` with `E/K` finite dimensional.
 - `krullTopology K L` is defined as an instance for type class inference.
 -/
 
-
-open scoped Classical
+open scoped Classical Pointwise
 
 /-- Mapping intermediate fields along the identity does not change them -/
 theorem IntermediateField.map_id {K L : Type*} [Field K] [Field L] [Algebra K L]
@@ -240,6 +239,7 @@ theorem krullTopology_t2 {K L : Type*} [Field K] [Field L] [Algebra K L]
         ⟨hW_open.leftCoset f, hW_open.leftCoset g, ⟨1, hW_1, mul_one _⟩, ⟨1, hW_1, mul_one _⟩, _⟩⟩
       rw [Set.disjoint_left]
       rintro σ ⟨w1, hw1, h⟩ ⟨w2, hw2, rfl⟩
+      dsimp at h
       rw [eq_inv_mul_iff_mul_eq.symm, ← mul_assoc, mul_inv_eq_iff_eq_mul.symm] at h
       have h_in_H : w1 * w2⁻¹ ∈ H := H.mul_mem (hWH hw1) (H.inv_mem (hWH hw2))
       rw [h] at h_in_H

--- a/Mathlib/FieldTheory/KrullTopology.lean
+++ b/Mathlib/FieldTheory/KrullTopology.lean
@@ -236,7 +236,7 @@ theorem krullTopology_t2 {K L : Type*} [Field K] [Field L] [Algebra K L]
       have h_nhd := GroupFilterBasis.mem_nhds_one (galGroupBasis K L) h_basis
       rw [mem_nhds_iff] at h_nhd
       rcases h_nhd with ⟨W, hWH, hW_open, hW_1⟩
-      refine' ⟨leftCoset f W, leftCoset g W,
+      refine' ⟨f • W, g • W,
         ⟨hW_open.leftCoset f, hW_open.leftCoset g, ⟨1, hW_1, mul_one _⟩, ⟨1, hW_1, mul_one _⟩, _⟩⟩
       rw [Set.disjoint_left]
       rintro σ ⟨w1, hw1, h⟩ ⟨w2, hw2, rfl⟩
@@ -266,7 +266,7 @@ theorem krullTopology_totallyDisconnected {K L : Type*} [Field K] [Field L] [Alg
   rcases FunLike.exists_ne hστ with ⟨x, hx : (σ⁻¹ * τ) x ≠ x⟩
   let E := IntermediateField.adjoin K ({x} : Set L)
   haveI := IntermediateField.adjoin.finiteDimensional (h_int x)
-  refine' ⟨leftCoset σ E.fixingSubgroup,
+  refine' ⟨σ • E.fixingSubgroup,
     ⟨E.fixingSubgroup_isOpen.leftCoset σ, E.fixingSubgroup_isClosed.leftCoset σ⟩,
     ⟨1, E.fixingSubgroup.one_mem', mul_one σ⟩, _⟩
   simp only [mem_leftCoset_iff, SetLike.mem_coe, IntermediateField.mem_fixingSubgroup_iff,

--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -436,12 +436,11 @@ theorem equiv_mul_right_of_mem {g k : G} (h : k ∈ K) :
 @[simp, nolint simpNF]
 theorem equiv_mul_left (h : H) (g : G) :
     hHT.equiv (h * g) = (h * (hHT.equiv g).fst, (hHT.equiv g).snd) := by
-  have : (hHT.equiv (h * g)).snd = (hHT.equiv g).snd :=
-    hHT.equiv_snd_eq_iff_rightCosetEquivalence.2
-      (by simp [RightCosetEquivalence, rightCoset_eq_iff])
+  have : (hHT.equiv (h * g)).2 = (hHT.equiv g).2 := hHT.equiv_snd_eq_iff_rightCosetEquivalence.2 ?_
   ext
   · rw [coe_mul, equiv_fst_eq_mul_inv, this, equiv_fst_eq_mul_inv, mul_assoc]
   · rw [this]
+  · simp [RightCosetEquivalence, ← smul_smul]
 
 theorem equiv_mul_left_of_mem {h g : G} (hh : h ∈ H) :
     hHT.equiv (h * g) = (⟨h, hh⟩ * (hHT.equiv g).fst, (hHT.equiv g).snd) :=

--- a/Mathlib/GroupTheory/Coset.lean
+++ b/Mathlib/GroupTheory/Coset.lean
@@ -17,10 +17,6 @@ This file develops the basic theory of left and right cosets.
 
 ## Main definitions
 
-* `leftCoset a s`: the left coset `a * s` for an element `a : α` and a subset `s ⊆ α`, for an
-  `AddGroup` this is `leftAddCoset a s`.
-* `rightCoset s a`: the right coset `s * a` for an element `a : α` and a subset `s ⊆ α`, for an
-  `AddGroup` this is `rightAddCoset s a`.
 * `QuotientGroup.quotient s`: the quotient type representing the left cosets with respect to a
   subgroup `s`, for an `AddGroup` this is `QuotientAddGroup.quotient s`.
 * `QuotientGroup.mk`: the canonical map from `α` to `α/s` for a subgroup `s` of `α`, for an
@@ -30,60 +26,36 @@ This file develops the basic theory of left and right cosets.
 
 ## Notation
 
-* `a *l s`: for `leftCoset a s`.
-* `a +l s`: for `leftAddCoset a s`.
-* `s *r a`: for `rightCoset s a`.
-* `s +r a`: for `rightAddCoset s a`.
-
 * `G ⧸ H` is the quotient of the (additive) group `G` by the (additive) subgroup `H`
+
+## TODO
+
+Properly merge with pointwise actions on sets.
 -/
 
 
-open Set Function
+open Function MulOpposite Set
+open scoped Pointwise
 
 variable {α : Type*}
 
-/-- The left coset `a * s` for an element `a : α` and a subset `s : Set α` -/
-@[to_additive leftAddCoset "The left coset `a+s` for an element `a : α` and a subset `s : set α`"]
-def leftCoset [Mul α] (a : α) (s : Set α) : Set α :=
-  (fun x => a * x) '' s
-#align left_coset leftCoset
-#align left_add_coset leftAddCoset
-
-/-- The right coset `s * a` for an element `a : α` and a subset `s : Set α` -/
-@[to_additive rightAddCoset
-      "The right coset `s+a` for an element `a : α` and a subset `s : set α`"]
-def rightCoset [Mul α] (s : Set α) (a : α) : Set α :=
-  (fun x => x * a) '' s
-#align right_coset rightCoset
-#align right_add_coset rightAddCoset
-
-@[inherit_doc]
-scoped[Coset] infixl:70 " *l " => leftCoset
-
-@[inherit_doc]
-scoped[Coset] infixl:70 " +l " => leftAddCoset
-
-@[inherit_doc]
-scoped[Coset] infixl:70 " *r " => rightCoset
-
-@[inherit_doc]
-scoped[Coset] infixl:70 " +r " => rightAddCoset
-
-open Coset
+#noalign left_coset
+#noalign left_add_coset
+#noalign right_coset
+#noalign right_add_coset
 
 section CosetMul
 
 variable [Mul α]
 
 @[to_additive mem_leftAddCoset]
-theorem mem_leftCoset {s : Set α} {x : α} (a : α) (hxS : x ∈ s) : a * x ∈ a *l s :=
+theorem mem_leftCoset {s : Set α} {x : α} (a : α) (hxS : x ∈ s) : a * x ∈ a • s :=
   mem_image_of_mem (fun b : α => a * b) hxS
 #align mem_left_coset mem_leftCoset
 #align mem_left_add_coset mem_leftAddCoset
 
 @[to_additive mem_rightAddCoset]
-theorem mem_rightCoset {s : Set α} {x : α} (a : α) (hxS : x ∈ s) : x * a ∈ s *r a :=
+theorem mem_rightCoset {s : Set α} {x : α} (a : α) (hxS : x ∈ s) : x * a ∈ op a • s :=
   mem_image_of_mem (fun b : α => b * a) hxS
 #align mem_right_coset mem_rightCoset
 #align mem_right_add_coset mem_rightAddCoset
@@ -91,7 +63,7 @@ theorem mem_rightCoset {s : Set α} {x : α} (a : α) (hxS : x ∈ s) : x * a �
 /-- Equality of two left cosets `a * s` and `b * s`. -/
 @[to_additive LeftAddCosetEquivalence "Equality of two left cosets `a + s` and `b + s`."]
 def LeftCosetEquivalence (s : Set α) (a b : α) :=
-  a *l s = b *l s
+  a • s = b • s
 #align left_coset_equivalence LeftCosetEquivalence
 #align left_add_coset_equivalence LeftAddCosetEquivalence
 
@@ -104,7 +76,7 @@ theorem leftCosetEquivalence_rel (s : Set α) : Equivalence (LeftCosetEquivalenc
 /-- Equality of two right cosets `s * a` and `s * b`. -/
 @[to_additive RightAddCosetEquivalence "Equality of two right cosets `s + a` and `s + b`."]
 def RightCosetEquivalence (s : Set α) (a b : α) :=
-  s *r a = s *r b
+  op a • s = op b • s
 #align right_coset_equivalence RightCosetEquivalence
 #align right_add_coset_equivalence RightAddCosetEquivalence
 
@@ -121,20 +93,20 @@ section CosetSemigroup
 variable [Semigroup α]
 
 @[to_additive (attr := simp) leftAddCoset_assoc]
-theorem leftCoset_assoc (s : Set α) (a b : α) : a *l (b *l s) = a * b *l s := by
-  simp [leftCoset, rightCoset, (image_comp _ _ _).symm, Function.comp, mul_assoc]
+theorem leftCoset_assoc (s : Set α) (a b : α) : a • (b • s) = (a * b) • s := by
+  simp [← image_smul, (image_comp _ _ _).symm, Function.comp, mul_assoc]
 #align left_coset_assoc leftCoset_assoc
 #align left_add_coset_assoc leftAddCoset_assoc
 
 @[to_additive (attr := simp) rightAddCoset_assoc]
-theorem rightCoset_assoc (s : Set α) (a b : α) : s *r a *r b = s *r (a * b) := by
-  simp [leftCoset, rightCoset, (image_comp _ _ _).symm, Function.comp, mul_assoc]
+theorem rightCoset_assoc (s : Set α) (a b : α) : op b • op a • s = op (a * b) • s := by
+  simp [← image_smul, (image_comp _ _ _).symm, Function.comp, mul_assoc]
 #align right_coset_assoc rightCoset_assoc
 #align right_add_coset_assoc rightAddCoset_assoc
 
 @[to_additive leftAddCoset_rightAddCoset]
-theorem leftCoset_rightCoset (s : Set α) (a b : α) : a *l s *r b = a *l (s *r b) := by
-  simp [leftCoset, rightCoset, (image_comp _ _ _).symm, Function.comp, mul_assoc]
+theorem leftCoset_rightCoset (s : Set α) (a b : α) : op b • a • s = a • (op b • s) := by
+  simp [← image_smul, (image_comp _ _ _).symm, Function.comp, mul_assoc]
 #align left_coset_right_coset leftCoset_rightCoset
 #align left_add_coset_right_add_coset leftAddCoset_rightAddCoset
 
@@ -144,15 +116,15 @@ section CosetMonoid
 
 variable [Monoid α] (s : Set α)
 
-@[to_additive (attr := simp) zero_leftAddCoset]
-theorem one_leftCoset : 1 *l s = s :=
-  Set.ext <| by simp [leftCoset]
+@[to_additive zero_leftAddCoset]
+theorem one_leftCoset : (1 : α) • s = s :=
+  Set.ext <| by simp [← image_smul]
 #align one_left_coset one_leftCoset
 #align zero_left_add_coset zero_leftAddCoset
 
-@[to_additive (attr := simp) rightAddCoset_zero]
-theorem rightCoset_one : s *r 1 = s :=
-  Set.ext <| by simp [rightCoset]
+@[to_additive rightAddCoset_zero]
+theorem rightCoset_one : op (1 : α) • s = s :=
+  Set.ext <| by simp [← image_smul]
 #align right_coset_one rightCoset_one
 #align right_add_coset_zero rightAddCoset_zero
 
@@ -165,27 +137,27 @@ open Submonoid
 variable [Monoid α] (s : Submonoid α)
 
 @[to_additive mem_own_leftAddCoset]
-theorem mem_own_leftCoset (a : α) : a ∈ a *l s :=
-  suffices a * 1 ∈ a *l s by simpa
+theorem mem_own_leftCoset (a : α) : a ∈ a • (s : Set α) :=
+  suffices a * 1 ∈ a • ↑s by simpa
   mem_leftCoset a (one_mem s : 1 ∈ s)
 #align mem_own_left_coset mem_own_leftCoset
 #align mem_own_left_add_coset mem_own_leftAddCoset
 
 @[to_additive mem_own_rightAddCoset]
-theorem mem_own_rightCoset (a : α) : a ∈ (s : Set α) *r a :=
-  suffices 1 * a ∈ (s : Set α) *r a by simpa
+theorem mem_own_rightCoset (a : α) : a ∈ op a • (s : Set α) :=
+  suffices 1 * a ∈ op a • (s : Set α) by simpa
   mem_rightCoset a (one_mem s : 1 ∈ s)
 #align mem_own_right_coset mem_own_rightCoset
 #align mem_own_right_add_coset mem_own_rightAddCoset
 
 @[to_additive mem_leftAddCoset_leftAddCoset]
-theorem mem_leftCoset_leftCoset {a : α} (ha : a *l s = s) : a ∈ s := by
+theorem mem_leftCoset_leftCoset {a : α} (ha : a • (s : Set α) = s) : a ∈ s := by
   rw [← SetLike.mem_coe, ← ha]; exact mem_own_leftCoset s a
 #align mem_left_coset_left_coset mem_leftCoset_leftCoset
 #align mem_left_add_coset_left_add_coset mem_leftAddCoset_leftAddCoset
 
 @[to_additive mem_rightAddCoset_rightAddCoset]
-theorem mem_rightCoset_rightCoset {a : α} (ha : (s : Set α) *r a = s) : a ∈ s := by
+theorem mem_rightCoset_rightCoset {a : α} (ha : op a • (s : Set α) = s) : a ∈ s := by
   rw [← SetLike.mem_coe, ← ha]; exact mem_own_rightCoset s a
 #align mem_right_coset_right_coset mem_rightCoset_rightCoset
 #align mem_right_add_coset_right_add_coset mem_rightAddCoset_rightAddCoset
@@ -197,13 +169,13 @@ section CosetGroup
 variable [Group α] {s : Set α} {x : α}
 
 @[to_additive mem_leftAddCoset_iff]
-theorem mem_leftCoset_iff (a : α) : x ∈ a *l s ↔ a⁻¹ * x ∈ s :=
+theorem mem_leftCoset_iff (a : α) : x ∈ a • s ↔ a⁻¹ * x ∈ s :=
   Iff.intro (fun ⟨b, hb, Eq⟩ => by simp [Eq.symm, hb]) fun h => ⟨a⁻¹ * x, h, by simp⟩
 #align mem_left_coset_iff mem_leftCoset_iff
 #align mem_left_add_coset_iff mem_leftAddCoset_iff
 
 @[to_additive mem_rightAddCoset_iff]
-theorem mem_rightCoset_iff (a : α) : x ∈ s *r a ↔ x * a⁻¹ ∈ s :=
+theorem mem_rightCoset_iff (a : α) : x ∈ op a • s ↔ x * a⁻¹ ∈ s :=
   Iff.intro (fun ⟨b, hb, Eq⟩ => by simp [Eq.symm, hb]) fun h => ⟨x * a⁻¹, h, by simp⟩
 #align mem_right_coset_iff mem_rightCoset_iff
 #align mem_right_add_coset_iff mem_rightAddCoset_iff
@@ -217,19 +189,19 @@ open Subgroup
 variable [Group α] (s : Subgroup α)
 
 @[to_additive leftAddCoset_mem_leftAddCoset]
-theorem leftCoset_mem_leftCoset {a : α} (ha : a ∈ s) : a *l s = s :=
+theorem leftCoset_mem_leftCoset {a : α} (ha : a ∈ s) : a • (s : Set α) = s :=
   Set.ext <| by simp [mem_leftCoset_iff, mul_mem_cancel_left (s.inv_mem ha)]
 #align left_coset_mem_left_coset leftCoset_mem_leftCoset
 #align left_add_coset_mem_left_add_coset leftAddCoset_mem_leftAddCoset
 
 @[to_additive rightAddCoset_mem_rightAddCoset]
-theorem rightCoset_mem_rightCoset {a : α} (ha : a ∈ s) : (s : Set α) *r a = s :=
+theorem rightCoset_mem_rightCoset {a : α} (ha : a ∈ s) : op a • (s : Set α) = s :=
   Set.ext fun b => by simp [mem_rightCoset_iff, mul_mem_cancel_right (s.inv_mem ha)]
 #align right_coset_mem_right_coset rightCoset_mem_rightCoset
 #align right_add_coset_mem_right_add_coset rightAddCoset_mem_rightAddCoset
 
 @[to_additive]
-theorem orbit_subgroup_eq_rightCoset (a : α) : MulAction.orbit s a = s *r a :=
+theorem orbit_subgroup_eq_rightCoset (a : α) : MulAction.orbit s a = op a • s :=
   Set.ext fun _b => ⟨fun ⟨c, d⟩ => ⟨c, c.2, d⟩, fun ⟨c, d, e⟩ => ⟨⟨c, d⟩, e⟩⟩
 #align orbit_subgroup_eq_right_coset orbit_subgroup_eq_rightCoset
 #align orbit_add_subgroup_eq_right_coset orbit_addSubgroup_eq_rightCoset
@@ -247,26 +219,26 @@ theorem orbit_subgroup_one_eq_self : MulAction.orbit s (1 : α) = s :=
 #align orbit_add_subgroup_zero_eq_self orbit_addSubgroup_zero_eq_self
 
 @[to_additive eq_addCosets_of_normal]
-theorem eq_cosets_of_normal (N : s.Normal) (g : α) : g *l s = s *r g :=
+theorem eq_cosets_of_normal (N : s.Normal) (g : α) : g • (s : Set α) = op g • s :=
   Set.ext fun a => by simp [mem_leftCoset_iff, mem_rightCoset_iff]; rw [N.mem_comm_iff]
 #align eq_cosets_of_normal eq_cosets_of_normal
 #align eq_add_cosets_of_normal eq_addCosets_of_normal
 
 @[to_additive normal_of_eq_addCosets]
-theorem normal_of_eq_cosets (h : ∀ g : α, g *l s = s *r g) : s.Normal :=
+theorem normal_of_eq_cosets (h : ∀ g : α, g • (s : Set α) = op g • s) : s.Normal :=
   ⟨fun a ha g =>
     show g * a * g⁻¹ ∈ (s : Set α) by rw [← mem_rightCoset_iff, ← h]; exact mem_leftCoset g ha⟩
 #align normal_of_eq_cosets normal_of_eq_cosets
 #align normal_of_eq_add_cosets normal_of_eq_addCosets
 
 @[to_additive normal_iff_eq_addCosets]
-theorem normal_iff_eq_cosets : s.Normal ↔ ∀ g : α, g *l s = s *r g :=
+theorem normal_iff_eq_cosets : s.Normal ↔ ∀ g : α, g • (s : Set α) = op g • s :=
   ⟨@eq_cosets_of_normal _ _ s, normal_of_eq_cosets s⟩
 #align normal_iff_eq_cosets normal_iff_eq_cosets
 #align normal_iff_eq_add_cosets normal_iff_eq_addCosets
 
 @[to_additive leftAddCoset_eq_iff]
-theorem leftCoset_eq_iff {x y : α} : leftCoset x s = leftCoset y s ↔ x⁻¹ * y ∈ s := by
+theorem leftCoset_eq_iff {x y : α} : x • (s : Set α) = y • s ↔ x⁻¹ * y ∈ s := by
   rw [Set.ext_iff]
   simp_rw [mem_leftCoset_iff, SetLike.mem_coe]
   constructor
@@ -282,7 +254,7 @@ theorem leftCoset_eq_iff {x y : α} : leftCoset x s = leftCoset y s ↔ x⁻¹ *
 #align left_add_coset_eq_iff leftAddCoset_eq_iff
 
 @[to_additive rightAddCoset_eq_iff]
-theorem rightCoset_eq_iff {x y : α} : rightCoset (↑s) x = rightCoset s y ↔ y * x⁻¹ ∈ s := by
+theorem rightCoset_eq_iff {x y : α} : op x • (s : Set α) = op y • s ↔ y * x⁻¹ ∈ s := by
   rw [Set.ext_iff]
   simp_rw [mem_rightCoset_iff, SetLike.mem_coe]
   constructor
@@ -553,7 +525,7 @@ theorem mk_mul_of_mem (a : α) (hb : b ∈ s) : (mk (a * b) : α ⧸ s) = mk a :
 
 @[to_additive]
 theorem eq_class_eq_leftCoset (s : Subgroup α) (g : α) :
-    { x : α | (x : α ⧸ s) = g } = leftCoset g s :=
+    { x : α | (x : α ⧸ s) = g } = g • s :=
   Set.ext fun z => by
     rw [mem_leftCoset_iff, Set.mem_setOf_eq, eq_comm, QuotientGroup.eq, SetLike.mem_coe]
 #align quotient_group.eq_class_eq_left_coset QuotientGroup.eq_class_eq_leftCoset
@@ -587,7 +559,7 @@ variable [Group α] {s : Subgroup α}
 
 /-- The natural bijection between a left coset `g * s` and `s`. -/
 @[to_additive "The natural bijection between the cosets `g + s` and `s`."]
-def leftCosetEquivSubgroup (g : α) : leftCoset g s ≃ s :=
+def leftCosetEquivSubgroup (g : α) : (g • s : Set α) ≃ s :=
   ⟨fun x => ⟨g⁻¹ * x.1, (mem_leftCoset_iff _).1 x.2⟩, fun x => ⟨g * x.1, x.1, x.2, rfl⟩,
     fun ⟨x, hx⟩ => Subtype.eq <| by simp, fun ⟨g, hg⟩ => Subtype.eq <| by simp⟩
 #align subgroup.left_coset_equiv_subgroup Subgroup.leftCosetEquivSubgroup
@@ -595,7 +567,7 @@ def leftCosetEquivSubgroup (g : α) : leftCoset g s ≃ s :=
 
 /-- The natural bijection between a right coset `s * g` and `s`. -/
 @[to_additive "The natural bijection between the cosets `s + g` and `s`."]
-def rightCosetEquivSubgroup (g : α) : rightCoset (↑s) g ≃ s :=
+def rightCosetEquivSubgroup (g : α) : (op g • s : Set α) ≃ s :=
   ⟨fun x => ⟨x.1 * g⁻¹, (mem_rightCoset_iff _).1 x.2⟩, fun x => ⟨x.1 * g, x.1, x.2, rfl⟩,
     fun ⟨x, hx⟩ => Subtype.eq <| by simp, fun ⟨g, hg⟩ => Subtype.eq <| by simp⟩
 #align subgroup.right_coset_equiv_subgroup Subgroup.rightCosetEquivSubgroup
@@ -607,7 +579,7 @@ def rightCosetEquivSubgroup (g : α) : rightCoset (↑s) g ≃ s :=
 noncomputable def groupEquivQuotientProdSubgroup : α ≃ (α ⧸ s) × s :=
   calc
     α ≃ ΣL : α ⧸ s, { x : α // (x : α ⧸ s) = L } := (Equiv.sigmaFiberEquiv QuotientGroup.mk).symm
-    _ ≃ ΣL : α ⧸ s, leftCoset (Quotient.out' L) s :=
+    _ ≃ ΣL : α ⧸ s, (Quotient.out' L • s : Set α) :=
       Equiv.sigmaCongrRight fun L => by
         rw [← eq_class_eq_leftCoset]
         show

--- a/Mathlib/GroupTheory/Coset.lean
+++ b/Mathlib/GroupTheory/Coset.lean
@@ -15,6 +15,10 @@ import Mathlib.GroupTheory.Subgroup.MulOpposite
 
 This file develops the basic theory of left and right cosets.
 
+When `G` is a group and `a : G`, `s : Set G`, the left coset of `s` by `a` is written `a • s` and
+the right coset is written `MulOpposite.op a • s` (can be shortened to `op a • s` using
+`open MulOpposite`). One needs to use `open scoped Pointwise` to access both notations.
+
 ## Main definitions
 
 * `QuotientGroup.quotient s`: the quotient type representing the left cosets with respect to a
@@ -30,7 +34,7 @@ This file develops the basic theory of left and right cosets.
 
 ## TODO
 
-Properly merge with pointwise actions on sets.
+Properly merge with pointwise actions on sets, by renaming and deduplicating lemmas as appropriate.
 -/
 
 
@@ -39,8 +43,8 @@ open scoped Pointwise
 
 variable {α : Type*}
 
-#noalign left_coset
-#noalign left_add_coset
+#align left_coset HSMul.hSMul
+#align left_add_coset HVAdd.hVAdd
 #noalign right_coset
 #noalign right_add_coset
 

--- a/Mathlib/GroupTheory/Coset.lean
+++ b/Mathlib/GroupTheory/Coset.lean
@@ -15,9 +15,13 @@ import Mathlib.GroupTheory.Subgroup.MulOpposite
 
 This file develops the basic theory of left and right cosets.
 
-When `G` is a group and `a : G`, `s : Set G`, the left coset of `s` by `a` is written `a • s` and
-the right coset is written `MulOpposite.op a • s` (can be shortened to `op a • s` using
-`open MulOpposite`). One needs to use `open scoped Pointwise` to access both notations.
+When `G` is a group and `a : G`, `s : Set G`, with  `open scoped Pointwise` we can write:
+* the left coset of `s` by `a` as `a • s`
+* the right coset of `s` by `a` as `MulOpposite.op a • s` (or `op a • s` with `open MulOpposite`)
+
+If instead `G` is an additive group, we can write (with  `open scoped Pointwise` still)
+* the left coset of `s` by `a` as `a +ᵥ s`
+* the right coset of `s` by `a` as `AddOpposite.op a +ᵥ s` (or `op a • s` with `open AddOpposite`)
 
 ## Main definitions
 

--- a/Mathlib/GroupTheory/Coset.lean
+++ b/Mathlib/GroupTheory/Coset.lean
@@ -92,13 +92,13 @@ section CosetSemigroup
 
 variable [Semigroup α]
 
-@[to_additive (attr := simp) leftAddCoset_assoc]
+@[to_additive leftAddCoset_assoc]
 theorem leftCoset_assoc (s : Set α) (a b : α) : a • (b • s) = (a * b) • s := by
   simp [← image_smul, (image_comp _ _ _).symm, Function.comp, mul_assoc]
 #align left_coset_assoc leftCoset_assoc
 #align left_add_coset_assoc leftAddCoset_assoc
 
-@[to_additive (attr := simp) rightAddCoset_assoc]
+@[to_additive rightAddCoset_assoc]
 theorem rightCoset_assoc (s : Set α) (a b : α) : op b • op a • s = op (a * b) • s := by
   simp [← image_smul, (image_comp _ _ _).symm, Function.comp, mul_assoc]
 #align right_coset_assoc rightCoset_assoc

--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -29,9 +29,10 @@ this is the usual left or right quotient of a group by a subgroup.
 
 variable {G : Type*} [Group G] {α : Type*} [Mul α] (J : Subgroup G) (g : G)
 
-namespace Doset
+open MulOpposite
+open scoped Pointwise
 
-open Pointwise
+namespace Doset
 
 /-- The double coset as an element of `Set α` corresponding to `s a t` -/
 def doset (a : α) (s t : Set α) : Set α :=
@@ -168,7 +169,7 @@ theorem union_quotToDoset (H K : Subgroup G) : ⋃ q, quotToDoset H K q = Set.un
 #align doset.union_quot_to_doset Doset.union_quotToDoset
 
 theorem doset_union_rightCoset (H K : Subgroup G) (a : G) :
-    ⋃ k : K, rightCoset (↑H) (a * k) = doset a H K := by
+    ⋃ k : K, op (a * k) • ↑H = doset a H K := by
   ext x
   simp only [mem_rightCoset_iff, exists_prop, mul_inv_rev, Set.mem_iUnion, mem_doset,
     Subgroup.mem_carrier, SetLike.mem_coe]
@@ -182,7 +183,7 @@ theorem doset_union_rightCoset (H K : Subgroup G) (a : G) :
 #align doset.doset_union_right_coset Doset.doset_union_rightCoset
 
 theorem doset_union_leftCoset (H K : Subgroup G) (a : G) :
-    ⋃ h : H, leftCoset (h * a : G) K = doset a H K := by
+    ⋃ h : H, (h * a : G) • ↑K = doset a H K := by
   ext x
   simp only [mem_leftCoset_iff, mul_inv_rev, Set.mem_iUnion, mem_doset]
   constructor

--- a/Mathlib/GroupTheory/Subgroup/Pointwise.lean
+++ b/Mathlib/GroupTheory/Subgroup/Pointwise.lean
@@ -39,6 +39,16 @@ theorem inv_coe_set [InvolutiveInv G] [SetLike S G] [InvMemClass S G] {H : S} : 
 #align inv_coe_set inv_coe_set
 #align neg_coe_set neg_coe_set
 
+@[to_additive (attr := simp)]
+lemma smul_coe_set [Group G] [SetLike S G] [SubgroupClass S G] {s : S} {a : G} (ha : a ∈ s) :
+    a • (s : Set G) = s := by
+  ext; simp [Set.mem_smul_set_iff_inv_smul_mem, mul_mem_cancel_left, ha]
+
+@[to_additive (attr := simp)]
+lemma op_smul_coe_set [Group G] [SetLike S G] [SubgroupClass S G] {s : S} {a : G} (ha : a ∈ s) :
+    MulOpposite.op a • (s : Set G) = s := by
+  ext; simp [Set.mem_smul_set_iff_inv_smul_mem, mul_mem_cancel_right, ha]
+
 variable [Group G] [AddGroup A] {s : Set G}
 
 namespace Subgroup

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -80,7 +80,7 @@ theorem isOpenMap_mul_left (a : G) : IsOpenMap fun x => a * x :=
 #align is_open_map_add_left isOpenMap_add_left
 
 @[to_additive IsOpen.left_addCoset]
-theorem IsOpen.leftCoset {U : Set G} (h : IsOpen U) (x : G) : IsOpen (leftCoset x U) :=
+theorem IsOpen.leftCoset {U : Set G} (h : IsOpen U) (x : G) : IsOpen (x • U) :=
   isOpenMap_mul_left x _ h
 #align is_open.left_coset IsOpen.leftCoset
 #align is_open.left_add_coset IsOpen.left_addCoset
@@ -92,7 +92,7 @@ theorem isClosedMap_mul_left (a : G) : IsClosedMap fun x => a * x :=
 #align is_closed_map_add_left isClosedMap_add_left
 
 @[to_additive IsClosed.left_addCoset]
-theorem IsClosed.leftCoset {U : Set G} (h : IsClosed U) (x : G) : IsClosed (leftCoset x U) :=
+theorem IsClosed.leftCoset {U : Set G} (h : IsClosed U) (x : G) : IsClosed (x • U) :=
   isClosedMap_mul_left x _ h
 #align is_closed.left_coset IsClosed.leftCoset
 #align is_closed.left_add_coset IsClosed.left_addCoset
@@ -127,7 +127,7 @@ theorem isOpenMap_mul_right (a : G) : IsOpenMap fun x => x * a :=
 #align is_open_map_add_right isOpenMap_add_right
 
 @[to_additive IsOpen.right_addCoset]
-theorem IsOpen.rightCoset {U : Set G} (h : IsOpen U) (x : G) : IsOpen (rightCoset U x) :=
+theorem IsOpen.rightCoset {U : Set G} (h : IsOpen U) (x : G) : IsOpen (op x • U) :=
   isOpenMap_mul_right x _ h
 #align is_open.right_coset IsOpen.rightCoset
 #align is_open.right_add_coset IsOpen.right_addCoset
@@ -139,7 +139,7 @@ theorem isClosedMap_mul_right (a : G) : IsClosedMap fun x => x * a :=
 #align is_closed_map_add_right isClosedMap_add_right
 
 @[to_additive IsClosed.right_addCoset]
-theorem IsClosed.rightCoset {U : Set G} (h : IsClosed U) (x : G) : IsClosed (rightCoset U x) :=
+theorem IsClosed.rightCoset {U : Set G} (h : IsClosed U) (x : G) : IsClosed (op x • U) :=
   isClosedMap_mul_right x _ h
 #align is_closed.right_coset IsClosed.rightCoset
 #align is_closed.right_add_coset IsClosed.right_addCoset


### PR DESCRIPTION
Those two definitions are completely obsolete now that we have the pointwise API. This PR removes them but not the corresponding API. A much more tedious subsequent PR will be needed to merge the two API.

Note that I need to tweak simp lemmas to keep confluence since I'm merging two pairs of head keys together.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
