### PR TITLE
perf: add presimps to Data.....Basic

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1245,7 +1245,7 @@ theorem eq_zero (n : Fin 1) : n = 0 := Subsingleton.elim _ _
 instance uniqueFinOne : Unique (Fin 1) where
   uniq _ := Subsingleton.elim _ _
 
-@[simp]
+@[simp↓]
 theorem coe_fin_one (a : Fin 1) : (a : ℕ) = 0 := by simp [Subsingleton.elim a 0]
 #align fin.coe_fin_one Fin.coe_fin_one
 

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -548,7 +548,7 @@ theorem empty_val : (∅ : Finset α).1 = 0 :=
   rfl
 #align finset.empty_val Finset.empty_val
 
-@[simp]
+@[simp↓]
 theorem not_mem_empty (a : α) : a ∉ (∅ : Finset α) := by
   -- Porting note: was `id`. `a ∈ List.nil` is no longer definitionally equal to `False`
   simp only [mem_def, empty_val, not_mem_zero, not_false_iff]
@@ -571,7 +571,7 @@ theorem Nonempty.ne_empty {s : Finset α} (h : s.Nonempty) : s ≠ ∅ :=
   (Exists.elim h) fun _a => ne_empty_of_mem
 #align finset.nonempty.ne_empty Finset.Nonempty.ne_empty
 
-@[simp]
+@[simp↓]
 theorem empty_subset (s : Finset α) : ∅ ⊆ s :=
   zero_subset _
 #align finset.empty_subset Finset.empty_subset
@@ -594,7 +594,7 @@ theorem subset_empty {s : Finset α} : s ⊆ ∅ ↔ s = ∅ :=
   subset_zero.trans val_eq_zero
 #align finset.subset_empty Finset.subset_empty
 
-@[simp]
+@[simp↓]
 theorem not_ssubset_empty (s : Finset α) : ¬s ⊂ ∅ := fun h =>
   let ⟨_, he, _⟩ := exists_of_ssubset h
   -- Porting note: was `he`
@@ -716,7 +716,7 @@ theorem singleton_nonempty (a : α) : ({a} : Finset α).Nonempty :=
   ⟨a, mem_singleton_self a⟩
 #align finset.singleton_nonempty Finset.singleton_nonempty
 
-@[simp]
+@[simp↓]
 theorem singleton_ne_empty (a : α) : ({a} : Finset α) ≠ ∅ :=
   (singleton_nonempty a).ne_empty
 #align finset.singleton_ne_empty Finset.singleton_ne_empty
@@ -794,7 +794,7 @@ theorem subset_singleton_iff' {s : Finset α} {a : α} : s ⊆ {a} ↔ ∀ b ∈
   forall₂_congr fun _ _ => mem_singleton
 #align finset.subset_singleton_iff' Finset.subset_singleton_iff'
 
-@[simp]
+@[simp↓]
 theorem ssubset_singleton_iff {s : Finset α} {a : α} : s ⊂ {a} ↔ s = ∅ := by
   rw [← coe_ssubset, coe_singleton, Set.ssubset_singleton_iff, coe_eq_empty]
 #align finset.ssubset_singleton_iff Finset.ssubset_singleton_iff
@@ -812,7 +812,7 @@ protected def Nontrivial (s : Finset α) : Prop := (s : Set α).Nontrivial
 theorem not_nontrivial_empty : ¬ (∅ : Finset α).Nontrivial := by simp [Finset.Nontrivial]
 #align finset.not_nontrivial_empty Finset.not_nontrivial_empty
 
-@[simp]
+@[simp↓]
 theorem not_nontrivial_singleton : ¬ ({a} : Finset α).Nontrivial := by simp [Finset.Nontrivial]
 #align finset.not_nontrivial_singleton Finset.not_nontrivial_singleton
 
@@ -1192,12 +1192,12 @@ theorem insert_idem (a : α) (s : Finset α) : insert a (insert a s) = insert a 
   ext fun x => by simp only [mem_insert, ← or_assoc, or_self_iff]
 #align finset.insert_idem Finset.insert_idem
 
-@[simp]
+@[simp↓]
 theorem insert_nonempty (a : α) (s : Finset α) : (insert a s).Nonempty :=
   ⟨a, mem_insert_self a s⟩
 #align finset.insert_nonempty Finset.insert_nonempty
 
-@[simp]
+@[simp↓]
 theorem insert_ne_empty (a : α) (s : Finset α) : insert a s ≠ ∅ :=
   (insert_nonempty a s).ne_empty
 #align finset.insert_ne_empty Finset.insert_ne_empty
@@ -1693,12 +1693,12 @@ theorem inter_self (s : Finset α) : s ∩ s = s :=
   ext fun _ => mem_inter.trans <| and_self_iff
 #align finset.inter_self Finset.inter_self
 
-@[simp]
+@[simp↓]
 theorem inter_empty (s : Finset α) : s ∩ ∅ = ∅ :=
   ext fun _ => mem_inter.trans <| by simp
 #align finset.inter_empty Finset.inter_empty
 
-@[simp]
+@[simp↓]
 theorem empty_inter (s : Finset α) : ∅ ∩ s = ∅ :=
   ext fun _ => mem_inter.trans <| by simp
 #align finset.empty_inter Finset.empty_inter
@@ -2237,7 +2237,7 @@ theorem sdiff_nonempty : (s \ t).Nonempty ↔ ¬s ⊆ t :=
   nonempty_iff_ne_empty.trans sdiff_eq_empty_iff_subset.not
 #align finset.sdiff_nonempty Finset.sdiff_nonempty
 
-@[simp]
+@[simp↓]
 theorem empty_sdiff (s : Finset α) : ∅ \ s = ∅ :=
   bot_sdiff
 #align finset.empty_sdiff Finset.empty_sdiff
@@ -3642,7 +3642,7 @@ theorem biUnion_val (s : Finset α) (t : α → Finset β) :
   rfl
 #align finset.bUnion_val Finset.biUnion_val
 
-@[simp]
+@[simp↓]
 theorem biUnion_empty : Finset.biUnion ∅ t = ∅ :=
   rfl
 #align finset.bUnion_empty Finset.biUnion_empty

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -485,7 +485,7 @@ theorem mapDomain_single {f : α → β} {a : α} {b : M} : mapDomain f (single 
   sum_single_index <| single_zero _
 #align finsupp.map_domain_single Finsupp.mapDomain_single
 
-@[simp]
+@[simp↓]
 theorem mapDomain_zero {f : α → β} : mapDomain f (0 : α →₀ M) = (0 : β →₀ M) :=
   sum_zero_index
 #align finsupp.map_domain_zero Finsupp.mapDomain_zero
@@ -818,7 +818,7 @@ theorem some_add [AddCommMonoid M] (f g : Option α →₀ M) : (f + g).some = f
   simp
 #align finsupp.some_add Finsupp.some_add
 
-@[simp]
+@[simp↓]
 theorem some_single_none [Zero M] (m : M) : (single none m : Option α →₀ M).some = 0 := by
   ext
   simp
@@ -1031,7 +1031,7 @@ theorem subtypeDomain_apply {a : Subtype p} {v : α →₀ M} : (subtypeDomain p
   rfl
 #align finsupp.subtype_domain_apply Finsupp.subtypeDomain_apply
 
-@[simp]
+@[simp↓]
 theorem subtypeDomain_zero : subtypeDomain p (0 : α →₀ M) = 0 :=
   rfl
 #align finsupp.subtype_domain_zero Finsupp.subtypeDomain_zero

--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -120,7 +120,7 @@ theorem univ_unique [Unique α] : (univ : Finset α) = {default} :=
   Finset.ext fun x => iff_of_true (mem_univ _) <| mem_singleton.2 <| Subsingleton.elim x default
 #align finset.univ_unique Finset.univ_unique
 
-@[simp]
+@[simp↓]
 theorem subset_univ (s : Finset α) : s ⊆ univ := fun a _ => mem_univ a
 #align finset.subset_univ Finset.subset_univ
 
@@ -262,7 +262,7 @@ theorem image_univ_of_surjective [Fintype β] {f : β → α} (hf : Surjective f
   eq_univ_of_forall <| hf.forall.2 fun _ => mem_image_of_mem _ <| mem_univ _
 #align finset.image_univ_of_surjective Finset.image_univ_of_surjective
 
-@[simp]
+@[simp↓]
 theorem image_univ_equiv [Fintype β] (f : β ≃ α) : univ.image f = univ :=
   Finset.image_univ_of_surjective f.surjective
 
@@ -280,7 +280,7 @@ theorem map_univ_of_surjective [Fintype β] {f : β ↪ α} (hf : Surjective f) 
   eq_univ_of_forall <| hf.forall.2 fun _ => mem_map_of_mem _ <| mem_univ _
 #align finset.map_univ_of_surjective Finset.map_univ_of_surjective
 
-@[simp]
+@[simp↓]
 theorem map_univ_equiv [Fintype β] (f : β ≃ α) : univ.map f.toEmbedding = univ :=
   map_univ_of_surjective f.surjective
 #align finset.map_univ_equiv Finset.map_univ_equiv
@@ -331,7 +331,7 @@ theorem coe_filter_univ (p : α → Prop) [DecidablePred p] : (univ.filter p : S
 @[simp] lemma subtype_eq_univ {p : α → Prop} [DecidablePred p] [Fintype {a // p a}] :
     s.subtype p = univ ↔ ∀ ⦃a⦄, p a → a ∈ s := by simp [ext_iff]
 
-@[simp] lemma subtype_univ [Fintype α] (p : α → Prop) [DecidablePred p] [Fintype {a // p a}] :
+@[simp↓] lemma subtype_univ [Fintype α] (p : α → Prop) [DecidablePred p] [Fintype {a // p a}] :
     univ.subtype p = univ := by simp
 
 end Finset
@@ -1219,12 +1219,12 @@ namespace Multiset
 
 variable [Fintype α] [Fintype β]
 
-@[simp]
+@[simp↓]
 theorem count_univ [DecidableEq α] (a : α) : count a Finset.univ.val = 1 :=
   count_eq_one_of_mem Finset.univ.nodup (Finset.mem_univ _)
 #align multiset.count_univ Multiset.count_univ
 
-@[simp]
+@[simp↓]
 theorem map_univ_val_equiv (e : α ≃ β) :
     map e univ.val = univ.val := by
   rw [← congr_arg Finset.val (Finset.map_univ_equiv e), Finset.map_val, Equiv.coe_toEmbedding]

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -135,12 +135,12 @@ theorem coe_nat_nonneg (n : ℕ) : 0 ≤ (n : ℤ) := ofNat_le.2 (Nat.zero_le _)
 #align int.neg_of_nat_ne_zero Int.negSucc_ne_zero
 #align int.zero_ne_neg_of_nat Int.zero_ne_negSucc
 
-@[simp]
+@[simp↓]
 theorem sign_coe_add_one (n : ℕ) : Int.sign (n + 1) = 1 :=
   rfl
 #align int.sign_coe_add_one Int.sign_coe_add_one
 
-@[simp]
+@[simp↓]
 theorem sign_negSucc (n : ℕ) : Int.sign -[n+1] = -1 :=
   rfl
 #align int.sign_neg_succ_of_nat Int.sign_negSucc

--- a/Mathlib/Data/LazyList/Basic.lean
+++ b/Mathlib/Data/LazyList/Basic.lean
@@ -224,7 +224,7 @@ instance Mem.decidable {α} [DecidableEq α] (x : α) : ∀ xs : LazyList α, De
       exact decidable_of_decidable_of_iff this
 #align lazy_list.mem.decidable LazyList.Mem.decidable
 
-@[simp]
+@[simp↓]
 theorem mem_nil {α} (x : α) : x ∈ @LazyList.nil α ↔ False :=
   Iff.rfl
 #align lazy_list.mem_nil LazyList.mem_nil

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -55,7 +55,7 @@ instance : IsAssociative (List α) Append.append :=
 #align list.head_eq_of_cons_eq List.head_eq_of_cons_eqₓ -- implicits order
 #align list.tail_eq_of_cons_eq List.tail_eq_of_cons_eqₓ -- implicits order
 
-@[simp] theorem cons_injective {a : α} : Injective (cons a) := fun _ _ => tail_eq_of_cons_eq
+@[simp↓] theorem cons_injective {a : α} : Injective (cons a) := fun _ _ => tail_eq_of_cons_eq
 #align list.cons_injective List.cons_injective
 
 #align list.cons_inj List.cons_inj
@@ -415,7 +415,7 @@ theorem append_left_injective (t : List α) : Injective fun s ↦ s ++ t :=
 
 /-! ### replicate -/
 
-@[simp] lemma replicate_zero (a : α) : replicate 0 a = [] := rfl
+@[simp↓] lemma replicate_zero (a : α) : replicate 0 a = [] := rfl
 #align list.replicate_zero List.replicate_zero
 
 attribute [simp] replicate_succ
@@ -462,7 +462,7 @@ theorem subset_singleton_iff {a : α} {L : List α} : L ⊆ [a] ↔ ∃ n, L = r
     tail (replicate n a) = replicate (n - 1) a := by cases n <;> rfl
 #align list.tail_replicate List.tail_replicate
 
-@[simp] theorem join_replicate_nil (n : ℕ) : join (replicate n []) = @nil α := by
+@[simp↓] theorem join_replicate_nil (n : ℕ) : join (replicate n []) = @nil α := by
   induction n <;> [rfl; simp only [*, replicate, join, append_nil]]
 #align list.join_replicate_nil List.join_replicate_nil
 
@@ -720,7 +720,7 @@ theorem getLast?_singleton (a : α) :
     getLast? [a] = a := rfl
 
 -- Porting note: Moved earlier in file, for use in subsequent lemmas.
-@[simp]
+@[simp↓]
 theorem getLast?_cons_cons (a b : α) (l : List α) :
     getLast? (a :: b :: l) = getLast? (b :: l) := rfl
 
@@ -835,7 +835,7 @@ theorem mem_of_mem_head? {x : α} {l : List α} (h : x ∈ l.head?) : x ∈ l :=
   (eq_cons_of_mem_head? h).symm ▸ mem_cons_self _ _
 #align list.mem_of_mem_head' List.mem_of_mem_head?
 
-@[simp] theorem head!_cons [Inhabited α] (a : α) (l : List α) : head! (a :: l) = a := rfl
+@[simp↓] theorem head!_cons [Inhabited α] (a : α) (l : List α) : head! (a :: l) = a := rfl
 #align list.head_cons List.head!_cons
 
 #align list.tail_nil List.tail_nil
@@ -1531,7 +1531,7 @@ theorem insertNth_zero (s : List α) (x : α) : insertNth 0 x s = x :: s :=
   rfl
 #align list.insert_nth_zero List.insertNth_zero
 
-@[simp]
+@[simp↓]
 theorem insertNth_succ_nil (n : ℕ) (a : α) : insertNth (n + 1) a [] = [] :=
   rfl
 #align list.insert_nth_succ_nil List.insertNth_succ_nil
@@ -2286,7 +2286,7 @@ theorem reverse_take {α} {xs : List α} (n : ℕ) (h : n ≤ xs.length) :
     rfl
 #align list.reverse_take List.reverse_take
 
-@[simp]
+@[simp↓]
 theorem set_eq_nil (l : List α) (n : ℕ) (a : α) : l.set n a = [] ↔ l = [] := by
   cases l <;> cases n <;> simp only [set]
 #align list.update_nth_eq_nil List.set_eq_nil
@@ -2544,7 +2544,7 @@ theorem length_scanl : ∀ a l, length (scanl f a l) = l.length + 1
     exact length_scanl _ _
 #align list.length_scanl List.length_scanl
 
-@[simp]
+@[simp↓]
 theorem scanl_nil (b : β) : scanl f b nil = [b] :=
   rfl
 #align list.scanl_nil List.scanl_nil
@@ -2617,7 +2617,7 @@ attribute [deprecated get_succ_scanl] nthLe_succ_scanl
 end Scanl
 
 -- scanr
-@[simp]
+@[simp↓]
 theorem scanr_nil (f : α → β → β) (b : β) : scanr f b [] = [b] :=
   rfl
 #align list.scanr_nil List.scanr_nil

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -273,7 +273,7 @@ instance module [Semiring R] [AddCommMonoid α] [Module R α] : Module R (Matrix
 -- (e.g. `Pi.zero_apply` used on `OfNat.ofNat 0 i j`)
 section
 
-@[simp]
+@[simp↓]
 theorem zero_apply [Zero α] (i : m) (j : n) : (0 : Matrix m n α) i j = 0 := rfl
 
 @[simp]
@@ -321,7 +321,7 @@ theorem smul_of [SMul R α] (r : R) (f : m → n → α) : r • of f = of (r �
   rfl
 #align matrix.smul_of Matrix.smul_of
 
-@[simp]
+@[simp↓]
 protected theorem map_zero [Zero α] [Zero β] (f : α → β) (h : f 0 = 0) :
     (0 : Matrix m n α).map f = 0 := by
   ext
@@ -788,7 +788,7 @@ section NonUnitalNonAssocSemiring
 
 variable [NonUnitalNonAssocSemiring α] (u v w : m → α) (x y : n → α)
 
-@[simp]
+@[simp↓]
 theorem dotProduct_zero : v ⬝ᵥ 0 = 0 := by simp [dotProduct]
 #align matrix.dot_product_zero Matrix.dotProduct_zero
 
@@ -797,7 +797,7 @@ theorem dotProduct_zero' : (v ⬝ᵥ fun _ => 0) = 0 :=
   dotProduct_zero v
 #align matrix.dot_product_zero' Matrix.dotProduct_zero'
 
-@[simp]
+@[simp↓]
 theorem zero_dotProduct : 0 ⬝ᵥ v = 0 := by simp [dotProduct]
 #align matrix.zero_dot_product Matrix.zero_dotProduct
 
@@ -1018,13 +1018,13 @@ section NonUnitalNonAssocSemiring
 
 variable [NonUnitalNonAssocSemiring α]
 
-@[simp]
+@[simp↓]
 protected theorem mul_zero [Fintype n] (M : Matrix m n α) : M * (0 : Matrix n o α) = 0 := by
   ext
   apply dotProduct_zero
 #align matrix.mul_zero Matrix.mul_zero
 
-@[simp]
+@[simp↓]
 protected theorem zero_mul [Fintype m] (M : Matrix m n α) : (0 : Matrix l m α) * M = 0 := by
   ext
   apply zero_dotProduct
@@ -1720,25 +1720,25 @@ theorem dotProduct_mulVec [Fintype n] [Fintype m] [NonUnitalSemiring R] (v : m �
   exact Finset.sum_comm
 #align matrix.dot_product_mul_vec Matrix.dotProduct_mulVec
 
-@[simp]
+@[simp↓]
 theorem mulVec_zero [Fintype n] (A : Matrix m n α) : mulVec A 0 = 0 := by
   ext
   simp [mulVec]
 #align matrix.mul_vec_zero Matrix.mulVec_zero
 
-@[simp]
+@[simp↓]
 theorem zero_vecMul [Fintype m] (A : Matrix m n α) : vecMul 0 A = 0 := by
   ext
   simp [vecMul]
 #align matrix.zero_vec_mul Matrix.zero_vecMul
 
-@[simp]
+@[simp↓]
 theorem zero_mulVec [Fintype n] (v : n → α) : mulVec (0 : Matrix m n α) v = 0 := by
   ext
   simp [mulVec]
 #align matrix.zero_mul_vec Matrix.zero_mulVec
 
-@[simp]
+@[simp↓]
 theorem vecMul_zero [Fintype m] (v : m → α) : vecMul v (0 : Matrix m n α) = 0 := by
   ext
   simp [vecMul]

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -260,7 +260,7 @@ theorem exists_cons_of_mem {s : Multiset α} {a : α} : a ∈ s → ∃ t, s = a
     e.symm ▸ ⟨(l₁ ++ l₂ : List α), Quot.sound perm_middle⟩
 #align multiset.exists_cons_of_mem Multiset.exists_cons_of_mem
 
-@[simp]
+@[simp↓]
 theorem not_mem_zero (a : α) : a ∉ (0 : Multiset α) :=
   List.not_mem_nil _
 #align multiset.not_mem_zero Multiset.not_mem_zero
@@ -290,7 +290,7 @@ theorem zero_ne_cons {a : α} {m : Multiset α} : 0 ≠ a ::ₘ m := fun h =>
   not_mem_zero _ this
 #align multiset.zero_ne_cons Multiset.zero_ne_cons
 
-@[simp]
+@[simp↓]
 theorem cons_ne_zero {a : α} {m : Multiset α} : a ::ₘ m ≠ 0 :=
   zero_ne_cons.symm
 #align multiset.cons_ne_zero Multiset.cons_ne_zero
@@ -408,7 +408,7 @@ theorem mem_of_subset {s t : Multiset α} {a : α} (h : s ⊆ t) : a ∈ s → a
   @h _
 #align multiset.mem_of_subset Multiset.mem_of_subset
 
-@[simp]
+@[simp↓]
 theorem zero_subset (s : Multiset α) : 0 ⊆ s := fun a => (not_mem_nil a).elim
 #align multiset.zero_subset Multiset.zero_subset
 
@@ -594,7 +594,7 @@ theorem le_cons_of_not_mem (m : a ∉ s) : s ≤ a ::ₘ t ↔ s ≤ t := by
       ((subperm_cons _).2 <| ((sublist_or_mem_of_sublist s).resolve_right m₁).subperm)
 #align multiset.le_cons_of_not_mem Multiset.le_cons_of_not_mem
 
-@[simp]
+@[simp↓]
 theorem singleton_ne_zero (a : α) : ({a} : Multiset α) ≠ 0 :=
   ne_of_gt (lt_cons_self _ _)
 #align multiset.singleton_ne_zero Multiset.singleton_ne_zero
@@ -743,12 +743,12 @@ theorem card_nsmul (s : Multiset α) (n : ℕ) : card (n • s) = n * card s := 
   rw [card.map_nsmul s n, Nat.nsmul_eq_mul]
 #align multiset.card_nsmul Multiset.card_nsmul
 
-@[simp]
+@[simp↓]
 theorem card_cons (a : α) (s : Multiset α) : card (a ::ₘ s) = card s + 1 :=
   Quot.inductionOn s fun _l => rfl
 #align multiset.card_cons Multiset.card_cons
 
-@[simp]
+@[simp↓]
 theorem card_singleton (a : α) : card ({a} : Multiset α) = 1 := by
   simp only [← cons_zero, card_zero, eq_self_iff_true, zero_add, card_cons]
 #align multiset.card_singleton Multiset.card_singleton
@@ -890,7 +890,7 @@ def replicate (n : ℕ) (a : α) : Multiset α :=
 theorem coe_replicate (n : ℕ) (a : α) : (List.replicate n a : Multiset α) = replicate n a := rfl
 #align multiset.coe_replicate Multiset.coe_replicate
 
-@[simp] theorem replicate_zero (a : α) : replicate 0 a = 0 := rfl
+@[simp↓] theorem replicate_zero (a : α) : replicate 0 a = 0 := rfl
 #align multiset.replicate_zero Multiset.replicate_zero
 
 @[simp] theorem replicate_succ (a : α) (n) : replicate (n + 1) a = a ::ₘ replicate n a := rfl
@@ -912,7 +912,7 @@ def replicateAddMonoidHom (a : α) : ℕ →+ Multiset α where
 theorem replicate_one (a : α) : replicate 1 a = {a} := rfl
 #align multiset.replicate_one Multiset.replicate_one
 
-@[simp] theorem card_replicate (n) (a : α) : card (replicate n a) = n :=
+@[simp↓] theorem card_replicate (n) (a : α) : card (replicate n a) = n :=
   length_replicate n a
 #align multiset.card_replicate Multiset.card_replicate
 
@@ -1175,7 +1175,7 @@ theorem coe_map (f : α → β) (l : List α) : map f ↑l = l.map f :=
   rfl
 #align multiset.coe_map Multiset.coe_map
 
-@[simp]
+@[simp↓]
 theorem map_zero (f : α → β) : map f 0 = 0 :=
   rfl
 #align multiset.map_zero Multiset.map_zero
@@ -1237,12 +1237,12 @@ theorem mem_map {f : α → β} {b : β} {s : Multiset α} : b ∈ map f s ↔ �
   Quot.inductionOn s fun _l => List.mem_map
 #align multiset.mem_map Multiset.mem_map
 
-@[simp]
+@[simp↓]
 theorem card_map (f : α → β) (s) : card (map f s) = card s :=
   Quot.inductionOn s fun _l => length_map _ _
 #align multiset.card_map Multiset.card_map
 
-@[simp]
+@[simp↓]
 theorem map_eq_zero {s : Multiset α} {f : α → β} : s.map f = 0 ↔ s = 0 := by
   rw [← Multiset.card_eq_zero, Multiset.card_map, Multiset.card_eq_zero]
 #align multiset.map_eq_zero Multiset.map_eq_zero
@@ -1377,7 +1377,7 @@ def foldl (f : β → α → β) (H : RightCommutative f) (b : β) (s : Multiset
   Quot.liftOn s (fun l => List.foldl f b l) fun _l₁ _l₂ p => p.foldl_eq H b
 #align multiset.foldl Multiset.foldl
 
-@[simp]
+@[simp↓]
 theorem foldl_zero (f : β → α → β) (H b) : foldl f H b 0 = b :=
   rfl
 #align multiset.foldl_zero Multiset.foldl_zero
@@ -1399,7 +1399,7 @@ def foldr (f : α → β → β) (H : LeftCommutative f) (b : β) (s : Multiset 
   Quot.liftOn s (fun l => List.foldr f b l) fun _l₁ _l₂ p => p.foldr_eq H b
 #align multiset.foldr Multiset.foldr
 
-@[simp]
+@[simp↓]
 theorem foldr_zero (f : α → β → β) (H b) : foldr f H b 0 = b :=
   rfl
 #align multiset.foldr_zero Multiset.foldr_zero
@@ -1768,12 +1768,12 @@ def inter (s t : Multiset α) : Multiset α :=
 instance : Inter (Multiset α) :=
   ⟨inter⟩
 
-@[simp]
+@[simp↓]
 theorem inter_zero (s : Multiset α) : s ∩ 0 = 0 :=
   Quot.inductionOn s fun l => congr_arg ofList l.bagInter_nil
 #align multiset.inter_zero Multiset.inter_zero
 
-@[simp]
+@[simp↓]
 theorem zero_inter (s : Multiset α) : 0 ∩ s = 0 :=
   Quot.inductionOn s fun l => congr_arg ofList l.nil_bagInter
 #align multiset.zero_inter Multiset.zero_inter
@@ -1943,7 +1943,7 @@ theorem coe_filter (l : List α) : filter p ↑l = l.filter p :=
   rfl
 #align multiset.coe_filter Multiset.coe_filter
 
-@[simp]
+@[simp↓]
 theorem filter_zero : filter p 0 = 0 :=
   rfl
 #align multiset.filter_zero Multiset.filter_zero
@@ -2139,7 +2139,7 @@ theorem coe_filterMap (f : α → Option β) (l : List α) : filterMap f l = l.f
   rfl
 #align multiset.coe_filter_map Multiset.coe_filterMap
 
-@[simp]
+@[simp↓]
 theorem filterMap_zero (f : α → Option β) : filterMap f 0 = 0 :=
   rfl
 #align multiset.filter_map_zero Multiset.filterMap_zero
@@ -2228,7 +2228,7 @@ theorem coe_countP (l : List α) : countP p l = l.countP p :=
   rfl
 #align multiset.coe_countp Multiset.coe_countP
 
-@[simp]
+@[simp↓]
 theorem countP_zero : countP p 0 = 0 :=
   rfl
 #align multiset.countp_zero Multiset.countP_zero
@@ -2313,7 +2313,7 @@ theorem countP_True {s : Multiset α} : countP (fun _ => True) s = card s :=
   Quot.inductionOn s fun _l => List.countP_true
 #align multiset.countp_true Multiset.countP_True
 
-@[simp]
+@[simp↓]
 theorem countP_False {s : Multiset α} : countP (fun _ => False) s = 0 :=
   Quot.inductionOn s fun _l => List.countP_false
 #align multiset.countp_false Multiset.countP_False
@@ -2754,11 +2754,11 @@ theorem rel_flip_eq {s t : Multiset α} : Rel (fun a b => b = a) s t ↔ s = t :
   show Rel (flip (· = ·)) s t ↔ s = t by rw [rel_flip, rel_eq, eq_comm]
 #align multiset.rel_flip_eq Multiset.rel_flip_eq
 
-@[simp]
+@[simp↓]
 theorem rel_zero_left {b : Multiset β} : Rel r 0 b ↔ b = 0 := by rw [Rel_iff]; simp
 #align multiset.rel_zero_left Multiset.rel_zero_left
 
-@[simp]
+@[simp↓]
 theorem rel_zero_right {a : Multiset α} : Rel r a 0 ↔ a = 0 := by rw [Rel_iff]; simp
 #align multiset.rel_zero_right Multiset.rel_zero_right
 
@@ -2986,7 +2986,7 @@ theorem disjoint_of_le_right {s t u : Multiset α} (h : t ≤ u) : Disjoint s u 
   disjoint_of_subset_right (subset_of_le h)
 #align multiset.disjoint_of_le_right Multiset.disjoint_of_le_right
 
-@[simp]
+@[simp↓]
 theorem zero_disjoint (l : Multiset α) : Disjoint 0 l
   | a => (not_mem_nil a).elim
 #align multiset.zero_disjoint Multiset.zero_disjoint
@@ -3055,7 +3055,7 @@ def Pairwise (r : α → α → Prop) (m : Multiset α) : Prop :=
   ∃ l : List α, m = l ∧ l.Pairwise r
 #align multiset.pairwise Multiset.Pairwise
 
-@[simp]
+@[simp↓]
 theorem pairwise_zero (r : α → α → Prop) : Multiset.Pairwise r 0 :=
   ⟨[], rfl, List.Pairwise.nil⟩
 #align multiset.pairwise_zero Multiset.pairwise_zero

--- a/Mathlib/Data/MvPolynomial/Basic.lean
+++ b/Mathlib/Data/MvPolynomial/Basic.lean
@@ -354,7 +354,7 @@ theorem monomial_zero' : (monomial (0 : σ →₀ ℕ) : R → MvPolynomial σ R
   rfl
 #align mv_polynomial.monomial_zero' MvPolynomial.monomial_zero'
 
-@[simp]
+@[simp↓]
 theorem monomial_eq_zero {s : σ →₀ ℕ} {b : R} : monomial s b = 0 ↔ b = 0 :=
   Finsupp.single_eq_zero
 #align mv_polynomial.monomial_eq_zero MvPolynomial.monomial_eq_zero
@@ -621,7 +621,7 @@ theorem coeff_smul {S₁ : Type*} [SMulZeroClass S₁ R] (m : σ →₀ ℕ) (C 
   smul_apply C p m
 #align mv_polynomial.coeff_smul MvPolynomial.coeff_smul
 
-@[simp]
+@[simp↓]
 theorem coeff_zero (m : σ →₀ ℕ) : coeff m (0 : MvPolynomial σ R) = 0 :=
   rfl
 #align mv_polynomial.coeff_zero MvPolynomial.coeff_zero
@@ -897,7 +897,7 @@ variable {σ}
 
 variable (R)
 
-@[simp]
+@[simp↓]
 theorem constantCoeff_X (i : σ) : constantCoeff (X i : MvPolynomial σ R) = 0 := by
   simp [constantCoeff_eq]
 #align mv_polynomial.constant_coeff_X MvPolynomial.constantCoeff_X


### PR DESCRIPTION
Marks some simp lemmas as presimp. This means that these lemmas are simplified before their subexpressions are. For the lemmas we mark, this has the potential to remove subexpressions entirely before they are simplified.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
