### PR TITLE
[Merged by Bors] - chore: bump std

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Marginal.lean
+++ b/Mathlib/MeasureTheory/Integral/Marginal.lean
@@ -103,7 +103,9 @@ theorem _root_.Measurable.lmarginal (hf : Measurable f) : Measurable (∫⋯∫�
 
 /-- The marginal distribution is independent of the variables in `s`. -/
 theorem lmarginal_congr {x y : ∀ i, π i} (f : (∀ i, π i) → ℝ≥0∞)
-    (h : ∀ i ∉ s, x i = y i) :
+    -- TODO: change back from `∀ i, i ∉ s →` to `∀ i ∉ s,` after bumping past
+    -- https://github.com/leanprover/std4/pull/427
+    (h : ∀ i, i ∉ s → x i = y i) :
     (∫⋯∫⁻_s, f ∂μ) x = (∫⋯∫⁻_s, f ∂μ) y := by
   dsimp [lmarginal, updateFinset_def]; rcongr; exact h _ ‹_›
 

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/std4",
    "type": "git",
    "subDir": null,
-   "rev": "b88aedb3f61a0dff32c2edc12dc8fcdde8dfdd40",
+   "rev": "ddcb08633f442f1af91cad299d6ed114434b54b2",
    "name": "std",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/std4",
    "type": "git",
    "subDir": null,
-   "rev": "baf6defee1fe881ae535519c0776f37f6ef08603",
+   "rev": "b88aedb3f61a0dff32c2edc12dc8fcdde8dfdd40",
    "name": "std",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/test/delaborators.lean
+++ b/test/delaborators.lean
@@ -45,9 +45,11 @@ variable (P : Nat → Prop) (α : Nat → Type) (s : Set ℕ)
 #guard_msgs in
 #check ∀ x, x ∈ s → P x
 
-/-- info: ∀ x ∉ s, P x : Prop -/
-#guard_msgs in
-#check ∀ x ∉ s,P x
+-- TODO: uncomment after bumping past
+-- https://github.com/leanprover/std4/pull/427
+-- /-- info: ∀ x ∉ s, P x : Prop -/
+-- #guard_msgs in
+-- #check ∀ x ∉ s,P x
 
 /-- info: ∀ x ∉ s, P x : Prop -/
 #guard_msgs in
@@ -147,9 +149,11 @@ section existential
 
 variable (s : Set ℕ) (P : ℕ → Prop) (Q : Set ℕ → Prop)
 
-/-- info: ∃ x ∉ s, P x : Prop -/
-#guard_msgs in
-#check ∃ x ∉ s, P x
+-- TODO: uncomment after bumping past
+-- https://github.com/leanprover/std4/pull/427
+-- /-- info: ∃ x ∉ s, P x : Prop -/
+-- #guard_msgs in
+-- #check ∃ x ∉ s, P x
 
 /-- info: ∃ x ∉ s, P x : Prop -/
 #guard_msgs in


### PR DESCRIPTION
Since this bump does not include https://github.com/leanprover/std4/pull/427 (in order to avoid having to handle the intermediate commits all at once), we temporarily remove the single use of a `∀ i ∉ s,` binder, and the two tests of it.

We can revert these changes in a later Std bump, once we've address the other awkward bumps inbetween.

This unblocks #8711.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
