### PR TITLE
[Merged by Bors] - chore: Fix dead links

### DIFF
--- a/Mathlib/Algebra/Order/Module.lean
+++ b/Mathlib/Algebra/Order/Module.lean
@@ -14,7 +14,7 @@ In this file we provide lemmas about `OrderedSMul` that hold once a module struc
 
 ## References
 
-* https://en.wikipedia.org/wiki/Ordered_module
+* https://en.wikipedia.org/wiki/Ordered_vector_space
 
 ## Tags
 
@@ -25,11 +25,6 @@ ordered module, ordered scalar, ordered smul, ordered action, ordered vector spa
 open Pointwise
 
 variable {ι k M N : Type*}
-
-instance instModuleOrderDual [Semiring k] [OrderedAddCommMonoid M] [Module k M] : Module k Mᵒᵈ
-    where
-  add_smul _ _ x := OrderDual.rec (add_smul _ _) x
-  zero_smul m := OrderDual.rec (zero_smul _) m
 
 section Semiring
 

--- a/Mathlib/Algebra/Order/SMul.lean
+++ b/Mathlib/Algebra/Order/SMul.lean
@@ -33,7 +33,7 @@ In this file we define
 
 ## References
 
-* https://en.wikipedia.org/wiki/Ordered_module
+* https://en.wikipedia.org/wiki/Ordered_vector_space
 
 ## Tags
 


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Ordered_module doesn't exist but https://en.wikipedia.org/wiki/Ordered_vector_space does. Also delete `instModuleOrderDual`, which was accidentally duplicated (with a more general statement) as `OrderDual.instModule'` in #8840.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
