### PR TITLE
[Merged by Bors] - feat(GroupTheory/GroupAction/Opposite): add notation for right and left actions

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/Opposite.lean
+++ b/Mathlib/GroupTheory/GroupAction/Opposite.lean
@@ -29,7 +29,7 @@ With `open scoped RightActions`, this provides:
 -/
 
 
-variable (α : Type*)
+variable (R α : Type*)
 
 /-! ### Actions _on_ the opposite type
 
@@ -80,26 +80,11 @@ theorem unop_smul_eq_unop_smul_unop {R : Type*} [SMul R α] [SMul Rᵐᵒᵖ α]
 
 end MulOpposite
 
-/-! ### Actions _by_ the opposite type (right actions)
+/-! ### Right actions
 
-In `Mul.toSMul` in another file, we define the left action `a₁ • a₂ = a₁ * a₂`. For the
-multiplicative opposite, we define `MulOpposite.op a₁ • a₂ = a₂ * a₁`, with the multiplication
-reversed.
+In this section we establish `SMul αᵐᵒᵖ β` as the canonical spelling of right scalar multiplication
+of `β` by `α`, and provide convienient notations.
 -/
-
-
-open MulOpposite
-
-/-- Like `Mul.toSMul`, but multiplies on the right.
-
-See also `Monoid.toOppositeMulAction` and `MonoidWithZero.toOppositeMulActionWithZero`. -/
-@[to_additive "Like `Add.toVAdd`, but adds on the right.
-
-  See also `AddMonoid.to_OppositeAddAction`."]
-instance Mul.toHasOppositeSMul [Mul α] : SMul αᵐᵒᵖ α :=
-  ⟨fun c x => x * c.unop⟩
-#align has_mul.to_has_opposite_smul Mul.toHasOppositeSMul
-#align has_add.to_has_opposite_vadd Add.toHasOppositeVAdd
 
 namespace RightActions
 
@@ -123,6 +108,7 @@ scoped notation3:74 r:75 " +ᵥ> " m:74 => r +ᵥ m
 In lemma names this is still called `op_vadd`. -/
 scoped notation3:73 m:73 " <+ᵥ " r:74 => AddOpposite.op r +ᵥ m
 
+section examples
 variable {α β : Type*} [SMul α β] [SMul αᵐᵒᵖ β] [VAdd α β] [VAdd αᵃᵒᵖ β] {a a₁ a₂ a₃ a₄ : α} {b : β}
 
 -- Left and right actions are just notation around the general `•` and `+ᵥ` notations
@@ -146,7 +132,44 @@ example : a₁ •> a₂ •> b <• a₃ <• a₄ = ((a₁ •> (a₂ •> b))
 example : a₁ +ᵥ> b <+ᵥ a₂ = (a₁ +ᵥ> b) <+ᵥ a₂ := rfl
 example : a₁ +ᵥ> a₂ +ᵥ> b <+ᵥ a₃ <+ᵥ a₄ = ((a₁ +ᵥ> (a₂ +ᵥ> b)) <+ᵥ a₃) <+ᵥ a₄ := rfl
 
+end examples
+
 end RightActions
+
+section
+variable {α β : Type*}
+
+open scoped RightActions
+
+@[to_additive]
+theorem op_smul_op_smul [Monoid α] [MulAction αᵐᵒᵖ β] (b : β) (a₁ a₂ : α) :
+    b <• a₁ <• a₂ = b <• (a₁ * a₂) := smul_smul _ _ _
+
+@[to_additive]
+theorem op_smul_mul [Monoid α] [MulAction αᵐᵒᵖ β] (b : β) (a₁ a₂ : α) :
+    b <• (a₁ * a₂) = b <• a₁ <• a₂ := mul_smul _ _ _
+
+end section
+
+/-! ### Actions _by_ the opposite type (right actions)
+
+In `Mul.toSMul` in another file, we define the left action `a₁ • a₂ = a₁ * a₂`. For the
+multiplicative opposite, we define `MulOpposite.op a₁ • a₂ = a₂ * a₁`, with the multiplication
+reversed.
+-/
+
+open MulOpposite
+
+/-- Like `Mul.toSMul`, but multiplies on the right.
+
+See also `Monoid.toOppositeMulAction` and `MonoidWithZero.toOppositeMulActionWithZero`. -/
+@[to_additive "Like `Add.toVAdd`, but adds on the right.
+
+  See also `AddMonoid.to_OppositeAddAction`."]
+instance Mul.toHasOppositeSMul [Mul α] : SMul αᵐᵒᵖ α :=
+  ⟨fun c x => x * c.unop⟩
+#align has_mul.to_has_opposite_smul Mul.toHasOppositeSMul
+#align has_add.to_has_opposite_vadd Add.toHasOppositeVAdd
 
 @[to_additive]
 theorem op_smul_eq_mul [Mul α] {a a' : α} : op a • a' = a' * a :=

--- a/Mathlib/GroupTheory/GroupAction/Opposite.lean
+++ b/Mathlib/GroupTheory/GroupAction/Opposite.lean
@@ -123,6 +123,29 @@ scoped notation3:74 r:75 " +ᵥ>  " m:74 => r +ᵥ m
 In lemma names this is still called `op_vadd`. -/
 scoped notation3:73 m:73 " <+ᵥ " r:74 => AddOpposite.op r +ᵥ m
 
+variable {α β : Type*} [SMul α β] [SMul αᵐᵒᵖ β] [VAdd α β] [VAdd αᵃᵒᵖ β] {a a₁ a₂ a₃ a₄ : α} {b : β}
+
+-- Left and right actions are just notation around the general `•` and `+ᵥ` notations
+example : a •> b = a • b := rfl
+example : b <• a = MulOpposite.op a • b := rfl
+
+example : a +ᵥ> b = a +ᵥ b := rfl
+example : b <+ᵥ a = AddOpposite.op a +ᵥ b := rfl
+
+-- Left actions right-associate, right actions left-associate
+example : a₁ •> a₂ •> b = a₁ •> (a₂ •> b) := rfl
+example : b <• a₂ <• a₁ = (b <• a₂) <• a₁ := rfl
+
+example : a₁ +ᵥ> a₂ +ᵥ> b = a₁ +ᵥ> (a₂ +ᵥ> b) := rfl
+example : b <+ᵥ a₂ <+ᵥ a₁ = (b <+ᵥ a₂) <+ᵥ a₁ := rfl
+
+-- When left and right actions coexist, they associate to the left
+example : a₁ •> b <• a₂ = (a₁ •> b) <• a₂ := rfl
+example : a₁ •> a₂ •> b <• a₃ <• a₄ = ((a₁ •> (a₂ •> b)) <• a₃) <• a₄ := rfl
+
+example : a₁ +ᵥ> b <+ᵥ a₂ = (a₁ +ᵥ> b) <+ᵥ a₂ := rfl
+example : a₁ +ᵥ> a₂ +ᵥ> b <+ᵥ a₃ <+ᵥ a₄ = ((a₁ +ᵥ> (a₂ +ᵥ> b)) <+ᵥ a₃) <+ᵥ a₄ := rfl
+
 end RightActions
 
 @[to_additive]

--- a/Mathlib/GroupTheory/GroupAction/Opposite.lean
+++ b/Mathlib/GroupTheory/GroupAction/Opposite.lean
@@ -24,8 +24,8 @@ provide the `AddMonoid.nsmul` and `AddCommGroup.zsmul` fields.
 With `open scoped RightActions`, this provides:
 * `r •> m` as an alias for `r • m`
 * `m <• r` as an alias for `MulOpposite.op r • m`
-* `r +ᵥ> m` as an alias for `r +ᵥ m`
-* `m <+ᵥ r` as an alias for `AddOpposite.op r +ᵥ m`
+* `v +ᵥ> p` as an alias for `v +ᵥ p`
+* `p <+ᵥ v` as an alias for `AddOpposite.op v +ᵥ p`
 -/
 
 

--- a/Mathlib/GroupTheory/GroupAction/Opposite.lean
+++ b/Mathlib/GroupTheory/GroupAction/Opposite.lean
@@ -17,6 +17,13 @@ type, `SMul Rᵐᵒᵖ M`.
 
 Note that `MulOpposite.smul` is provided in an earlier file as it is needed to
 provide the `AddMonoid.nsmul` and `AddCommGroup.zsmul` fields.
+
+
+## Notation
+
+With `open scoped RightActions`, this provides:
+* `r ⮊ m` as an alias for `r • m`
+* `m ⮈ r` as an alias for `MulOpposite.op r • m`
 -/
 
 
@@ -91,6 +98,15 @@ instance Mul.toHasOppositeSMul [Mul α] : SMul αᵐᵒᵖ α :=
   ⟨fun c x => x * c.unop⟩
 #align has_mul.to_has_opposite_smul Mul.toHasOppositeSMul
 #align has_add.to_has_opposite_vadd Add.toHasOppositeVAdd
+
+/-- With `open scoped RightActions`, an alternative symbol for left actions.
+
+In lemma names this is still called `smul`. -/
+scoped[RightActions] notation3:73 r:73 " ⮊ " m:74 => r • m
+/-- With `open scoped RightActions`, a shorthand for right actions, `op r • m`.
+
+In lemma names this is still called `op_smul`. -/
+scoped[RightActions] notation3:73 m:74 " ⮈ " r:73 => MulOpposite.op r • m
 
 @[to_additive]
 theorem op_smul_eq_mul [Mul α] {a a' : α} : op a • a' = a' * a :=

--- a/Mathlib/GroupTheory/GroupAction/Opposite.lean
+++ b/Mathlib/GroupTheory/GroupAction/Opposite.lean
@@ -22,8 +22,10 @@ provide the `AddMonoid.nsmul` and `AddCommGroup.zsmul` fields.
 ## Notation
 
 With `open scoped RightActions`, this provides:
-* `r ⮊ m` as an alias for `r • m`
-* `m ⮈ r` as an alias for `MulOpposite.op r • m`
+* `r •> m` as an alias for `r • m`
+* `m <• r` as an alias for `MulOpposite.op r • m`
+* `r +ᵥ> m` as an alias for `r +ᵥ m`
+* `m <+ᵥ r` as an alias for `AddOpposite.op r +ᵥ m`
 -/
 
 
@@ -99,14 +101,50 @@ instance Mul.toHasOppositeSMul [Mul α] : SMul αᵐᵒᵖ α :=
 #align has_mul.to_has_opposite_smul Mul.toHasOppositeSMul
 #align has_add.to_has_opposite_vadd Add.toHasOppositeVAdd
 
-/-- With `open scoped RightActions`, an alternative symbol for left actions.
+/-- With `open scoped RightActions`, an alternative symbol for left actions, `r • m`.
 
 In lemma names this is still called `smul`. -/
-scoped[RightActions] notation3:73 r:73 " ⮊ " m:74 => r • m
+scoped[RightActions] notation3:74 r:75 " •> " m:74 => r • m
+
 /-- With `open scoped RightActions`, a shorthand for right actions, `op r • m`.
 
 In lemma names this is still called `op_smul`. -/
-scoped[RightActions] notation3:73 m:74 " ⮈ " r:73 => MulOpposite.op r • m
+scoped[RightActions] notation3:73 m:73 " <• " r:74 => MulOpposite.op r • m
+
+/-- With `open scoped RightActions`, an alternative symbol for left actions, `r • m`.
+
+In lemma names this is still called `vadd`. -/
+scoped[RightActions] notation3:74 r:75 " +ᵥ>  " m:74 => r +ᵥ m
+
+/-- With `open scoped RightActions`, a shorthand for right actions, `op r +ᵥ m`.
+
+In lemma names this is still called `op_vadd`. -/
+scoped[RightActions] notation3:73 m:73 " <+ᵥ " r:74 => AddOpposite.op r +ᵥ m
+
+namespace RightActions
+variable {α β : Type*} [SMul α β] [SMul αᵐᵒᵖ β] [VAdd α β] [VAdd αᵃᵒᵖ β] {a a₁ a₂ a₃ a₄ : α} {b : β}
+
+example : a •> b = a • b := rfl
+example : b <• a = op a • b := rfl
+
+example : a +ᵥ> b = a +ᵥ b := rfl
+example : b <+ᵥ a = AddOpposite.op a +ᵥ b := rfl
+
+-- Left actions right-associate, right actions left-associate
+example : a₁ •> a₂ •> b = a₁ •> (a₂ •> b) := rfl
+example : b <• a₂ <• a₁ = (b <• a₂) <• a₁ := rfl
+
+example : a₁ +ᵥ> a₂ +ᵥ> b = a₁ +ᵥ> (a₂ +ᵥ> b) := rfl
+example : b <+ᵥ a₂ <+ᵥ a₁ = (b <+ᵥ a₂) <+ᵥ a₁ := rfl
+
+-- When left and right actions coexist, they associate to the left
+example : a₁ •> b <• a₂ = (a₁ •> b) <• a₂ := rfl
+example : a₁ •> a₂ •> b <• a₃ <• a₄ = ((a₁ •> (a₂ •> b)) <• a₃) <• a₄ := rfl
+
+example : a₁ +ᵥ> b <+ᵥ a₂ = (a₁ +ᵥ> b) <+ᵥ a₂ := rfl
+example : a₁ +ᵥ> a₂ +ᵥ> b <+ᵥ a₃ <+ᵥ a₄ = ((a₁ +ᵥ> (a₂ +ᵥ> b)) <+ᵥ a₃) <+ᵥ a₄ := rfl
+
+end RightActions
 
 @[to_additive]
 theorem op_smul_eq_mul [Mul α] {a a' : α} : op a • a' = a' * a :=

--- a/Mathlib/GroupTheory/GroupAction/Opposite.lean
+++ b/Mathlib/GroupTheory/GroupAction/Opposite.lean
@@ -101,25 +101,29 @@ instance Mul.toHasOppositeSMul [Mul α] : SMul αᵐᵒᵖ α :=
 #align has_mul.to_has_opposite_smul Mul.toHasOppositeSMul
 #align has_add.to_has_opposite_vadd Add.toHasOppositeVAdd
 
+namespace RightActions
+
 /-- With `open scoped RightActions`, an alternative symbol for left actions, `r • m`.
 
 In lemma names this is still called `smul`. -/
-scoped[RightActions] notation3:74 r:75 " •> " m:74 => r • m
+scoped notation3:74 r:75 " •> " m:74 => r • m
 
 /-- With `open scoped RightActions`, a shorthand for right actions, `op r • m`.
 
 In lemma names this is still called `op_smul`. -/
-scoped[RightActions] notation3:73 m:73 " <• " r:74 => MulOpposite.op r • m
+scoped notation3:73 m:73 " <• " r:74 => MulOpposite.op r • m
 
 /-- With `open scoped RightActions`, an alternative symbol for left actions, `r • m`.
 
 In lemma names this is still called `vadd`. -/
-scoped[RightActions] notation3:74 r:75 " +ᵥ>  " m:74 => r +ᵥ m
+scoped notation3:74 r:75 " +ᵥ>  " m:74 => r +ᵥ m
 
 /-- With `open scoped RightActions`, a shorthand for right actions, `op r +ᵥ m`.
 
 In lemma names this is still called `op_vadd`. -/
-scoped[RightActions] notation3:73 m:73 " <+ᵥ " r:74 => AddOpposite.op r +ᵥ m
+scoped notation3:73 m:73 " <+ᵥ " r:74 => AddOpposite.op r +ᵥ m
+
+end RightActions
 
 @[to_additive]
 theorem op_smul_eq_mul [Mul α] {a a' : α} : op a • a' = a' * a :=

--- a/Mathlib/GroupTheory/GroupAction/Opposite.lean
+++ b/Mathlib/GroupTheory/GroupAction/Opposite.lean
@@ -121,31 +121,6 @@ scoped[RightActions] notation3:74 r:75 " +ᵥ>  " m:74 => r +ᵥ m
 In lemma names this is still called `op_vadd`. -/
 scoped[RightActions] notation3:73 m:73 " <+ᵥ " r:74 => AddOpposite.op r +ᵥ m
 
-namespace RightActions
-variable {α β : Type*} [SMul α β] [SMul αᵐᵒᵖ β] [VAdd α β] [VAdd αᵃᵒᵖ β] {a a₁ a₂ a₃ a₄ : α} {b : β}
-
-example : a •> b = a • b := rfl
-example : b <• a = op a • b := rfl
-
-example : a +ᵥ> b = a +ᵥ b := rfl
-example : b <+ᵥ a = AddOpposite.op a +ᵥ b := rfl
-
--- Left actions right-associate, right actions left-associate
-example : a₁ •> a₂ •> b = a₁ •> (a₂ •> b) := rfl
-example : b <• a₂ <• a₁ = (b <• a₂) <• a₁ := rfl
-
-example : a₁ +ᵥ> a₂ +ᵥ> b = a₁ +ᵥ> (a₂ +ᵥ> b) := rfl
-example : b <+ᵥ a₂ <+ᵥ a₁ = (b <+ᵥ a₂) <+ᵥ a₁ := rfl
-
--- When left and right actions coexist, they associate to the left
-example : a₁ •> b <• a₂ = (a₁ •> b) <• a₂ := rfl
-example : a₁ •> a₂ •> b <• a₃ <• a₄ = ((a₁ •> (a₂ •> b)) <• a₃) <• a₄ := rfl
-
-example : a₁ +ᵥ> b <+ᵥ a₂ = (a₁ +ᵥ> b) <+ᵥ a₂ := rfl
-example : a₁ +ᵥ> a₂ +ᵥ> b <+ᵥ a₃ <+ᵥ a₄ = ((a₁ +ᵥ> (a₂ +ᵥ> b)) <+ᵥ a₃) <+ᵥ a₄ := rfl
-
-end RightActions
-
 @[to_additive]
 theorem op_smul_eq_mul [Mul α] {a a' : α} : op a • a' = a' * a :=
   rfl

--- a/Mathlib/GroupTheory/GroupAction/Opposite.lean
+++ b/Mathlib/GroupTheory/GroupAction/Opposite.lean
@@ -116,7 +116,7 @@ scoped notation3:73 m:73 " <• " r:74 => MulOpposite.op r • m
 /-- With `open scoped RightActions`, an alternative symbol for left actions, `r • m`.
 
 In lemma names this is still called `vadd`. -/
-scoped notation3:74 r:75 " +ᵥ>  " m:74 => r +ᵥ m
+scoped notation3:74 r:75 " +ᵥ> " m:74 => r +ᵥ m
 
 /-- With `open scoped RightActions`, a shorthand for right actions, `op r +ᵥ m`.
 

--- a/Mathlib/GroupTheory/GroupAction/Opposite.lean
+++ b/Mathlib/GroupTheory/GroupAction/Opposite.lean
@@ -18,10 +18,10 @@ type, `SMul Rᵐᵒᵖ M`.
 Note that `MulOpposite.smul` is provided in an earlier file as it is needed to
 provide the `AddMonoid.nsmul` and `AddCommGroup.zsmul` fields.
 
-
 ## Notation
 
 With `open scoped RightActions`, this provides:
+
 * `r •> m` as an alias for `r • m`
 * `m <• r` as an alias for `MulOpposite.op r • m`
 * `v +ᵥ> p` as an alias for `v +ᵥ p`
@@ -29,7 +29,7 @@ With `open scoped RightActions`, this provides:
 -/
 
 
-variable (R α : Type*)
+variable (α : Type*)
 
 /-! ### Actions _on_ the opposite type
 

--- a/Mathlib/Mathport/Notation.lean
+++ b/Mathlib/Mathport/Notation.lean
@@ -587,7 +587,7 @@ elab (name := notation3) doc:(docComment)? attrs?:(Parser.Term.attributes)? attr
       let delabKeys := ms.foldr (·.1 ++ ·) []
       trace[notation3] "Adding `delab` attribute for keys {delabKeys}"
       for key in delabKeys do
-        elabCommand <| ← `(command| attribute [delab $(mkIdent key)] $(Lean.mkIdent delabName))
+        elabCommand <| ← `(command| attribute [$attrKind delab $(mkIdent key)] $(Lean.mkIdent delabName))
     else
       logWarning s!"Was not able to generate a pretty printer for this notation.{
         ""} If you do not expect it to be pretty printable, then you can use{

--- a/Mathlib/Mathport/Notation.lean
+++ b/Mathlib/Mathport/Notation.lean
@@ -587,7 +587,8 @@ elab (name := notation3) doc:(docComment)? attrs?:(Parser.Term.attributes)? attr
       let delabKeys := ms.foldr (·.1 ++ ·) []
       trace[notation3] "Adding `delab` attribute for keys {delabKeys}"
       for key in delabKeys do
-        elabCommand <| ← `(command| attribute [$attrKind delab $(mkIdent key)] $(Lean.mkIdent delabName))
+        elabCommand <|
+          ← `(command| attribute [$attrKind delab $(mkIdent key)] $(Lean.mkIdent delabName))
     else
       logWarning s!"Was not able to generate a pretty printer for this notation.{
         ""} If you do not expect it to be pretty printable, then you can use{

--- a/test/right_actions.lean
+++ b/test/right_actions.lean
@@ -5,13 +5,15 @@ open AddOpposite renaming op → aop
 
 variable {α β : Type*} [SMul α β] [SMul αᵐᵒᵖ β] [VAdd α β] [VAdd αᵃᵒᵖ β] {a a₁ a₂ a₃ a₄ : α} {b : β}
 
+section delaborators
+
 section without_scope
 
 /-- info: a • b : β -/
 #guard_msgs in
 #check a • b
 
-/-- info: mop a • b : β -/
+/-- info: MulOpposite.op a • b : β -/
 #guard_msgs in
 #check mop a • b
 
@@ -19,11 +21,34 @@ section without_scope
 #guard_msgs in
 #check a +ᵥ b
 
-/-- info: aop a +ᵥ b : β -/
+/-- info: AddOpposite.op a +ᵥ b : β -/
 #guard_msgs in
 #check aop a +ᵥ b
 
 end without_scope
+
+section with_scope
+open scoped RightActions
+
+/-- info: a •> b : β -/
+#guard_msgs in
+#check a • b
+
+/-- info: b <• a : β -/
+#guard_msgs in
+#check mop a • b
+
+/-- info: a +ᵥ> b : β -/
+#guard_msgs in
+#check a +ᵥ b
+
+/-- info: b <+ᵥ a : β -/
+#guard_msgs in
+#check aop a +ᵥ b
+
+end with_scope
+
+end delaborators
 
 open scoped RightActions
 

--- a/test/right_actions.lean
+++ b/test/right_actions.lean
@@ -52,10 +52,6 @@ end delaborators
 
 open scoped RightActions
 
-/-- info: a •> b : β -/
-#guard_msgs in
-#check a • b
-
 example : a •> b = a • b := rfl
 example : b <• a = mop a • b := rfl
 

--- a/test/right_actions.lean
+++ b/test/right_actions.lean
@@ -1,0 +1,56 @@
+import Mathlib.GroupTheory.GroupAction.Opposite
+
+open MulOpposite renaming op → mop
+open AddOpposite renaming op → aop
+
+variable {α β : Type*} [SMul α β] [SMul αᵐᵒᵖ β] [VAdd α β] [VAdd αᵃᵒᵖ β] {a a₁ a₂ a₃ a₄ : α} {b : β}
+
+section without_scope
+
+/-- info: a • b : β -/
+#guard_msgs in
+#check a • b
+
+/-- info: mop a • b : β -/
+#guard_msgs in
+#check mop a • b
+
+/-- info: a +ᵥ b : β -/
+#guard_msgs in
+#check a +ᵥ b
+
+/-- info: aop a +ᵥ b : β -/
+#guard_msgs in
+#check aop a +ᵥ b
+
+end without_scope
+
+open scoped RightActions
+
+/-- info: a •> b : β -/
+#guard_msgs in
+#check a • b
+
+example : a •> b = a • b := rfl
+example : b <• a = mop a • b := rfl
+
+example : a +ᵥ> b = a +ᵥ b := rfl
+example : b <+ᵥ a = aop a +ᵥ b := rfl
+
+-- Left actions right-associate, right actions left-associate
+example : a₁ •> a₂ •> b = a₁ •> (a₂ •> b) := rfl
+example : b <• a₂ <• a₁ = (b <• a₂) <• a₁ := rfl
+
+example : a₁ +ᵥ> a₂ +ᵥ> b = a₁ +ᵥ> (a₂ +ᵥ> b) := rfl
+example : b <+ᵥ a₂ <+ᵥ a₁ = (b <+ᵥ a₂) <+ᵥ a₁ := rfl
+
+-- When left and right actions coexist, they associate to the left
+example : a₁ •> b <• a₂ = (a₁ •> b) <• a₂ := rfl
+example : a₁ •> a₂ •> b <• a₃ <• a₄ = ((a₁ •> (a₂ •> b)) <• a₃) <• a₄ := rfl
+
+example : a₁ +ᵥ> b <+ᵥ a₂ = (a₁ +ᵥ> b) <+ᵥ a₂ := rfl
+example : a₁ +ᵥ> a₂ +ᵥ> b <+ᵥ a₃ <+ᵥ a₄ = ((a₁ +ᵥ> (a₂ +ᵥ> b)) <+ᵥ a₃) <+ᵥ a₄ := rfl
+
+-- association is choosen to match multiplication and addition
+example {M} [Mul M] {x y z : M} : x •> y <• z = x * y * z := rfl
+example {A} [Add A] {x y z : A} : x +ᵥ> y <+ᵥ z = x + y + z := rfl

--- a/test/right_actions.lean
+++ b/test/right_actions.lean
@@ -72,6 +72,6 @@ example : a₁ •> a₂ •> b <• a₃ <• a₄ = ((a₁ •> (a₂ •> b))
 example : a₁ +ᵥ> b <+ᵥ a₂ = (a₁ +ᵥ> b) <+ᵥ a₂ := rfl
 example : a₁ +ᵥ> a₂ +ᵥ> b <+ᵥ a₃ <+ᵥ a₄ = ((a₁ +ᵥ> (a₂ +ᵥ> b)) <+ᵥ a₃) <+ᵥ a₄ := rfl
 
--- association is choosen to match multiplication and addition
+-- association is chosen to match multiplication and addition
 example {M} [Mul M] {x y z : M} : x •> y <• z = x * y * z := rfl
 example {A} [Add A] {x y z : A} : x +ᵥ> y <+ᵥ z = x + y + z := rfl


### PR DESCRIPTION
The new notations (with `open scoped RightActions`) are:

* `r •> m` as an alias for `r • m`
* `m <• r` as an alias for `MulOpposite.op r • m`
* `r +ᵥ> m` as an alias for `r +ᵥ m`
* `m <+ᵥ r` as an alias for `AddOpposite.op r +ᵥ m`

An alternative proposal was to use variants of `•` with arrows inside:
* `r ⮊ m` as an alias for `r • m`
* `m ⮈ r` as an alias for `MulOpposite.op r • m`

but this doesn't have an obvious additive counterpart, and apparently has font issues.

Zulip messages:

* ["And `m <• r` would be notation for `(to_opposite r) • m`, or something like that?"](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/left.20vs.20right.20modules.20in.20tensor.20products/near/262063344)
* ["I rather like the idea of having a new piece of notation for right actions"](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Noncommutative.20ring.20things/near/390011490)
* [I like your proposed notation `<•` for the right scalar action. Maybe we should even introduce `•>` as an alias for `•`](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/ideals.20in.20non-comm.20rings/near/252156362)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
