### PR TITLE
[Merged by Bors] - fix: `apply ... at` with field notation

### DIFF
--- a/Mathlib/Tactic/ApplyAt.lean
+++ b/Mathlib/Tactic/ApplyAt.lean
@@ -38,5 +38,3 @@ elab "apply" t:term "at" i:ident : tactic => withMainContext do
     (← mkAppOptM' f (mvs.pop.push ldecl.toExpr |>.map fun e => some e))
   let (_, mainGoal) ← mainGoal.intro1P
   replaceMainGoal <| [mainGoal] ++ mvs.pop.toList.map fun e => e.mvarId!
-
-#check elabTermForApply

--- a/Mathlib/Tactic/ApplyAt.lean
+++ b/Mathlib/Tactic/ApplyAt.lean
@@ -24,7 +24,7 @@ then replace the type of `i` with `αᵢ₊₁ → ⋯ → αₙ` by applying th
 original `i`.
 -/
 elab "apply" t:term "at" i:ident : tactic => withMainContext do
-  let f ← Term.elabTerm (← `(@$t)) none
+  let f ← elabTermForApply t
   let some ldecl := (← getLCtx).findFromUserName? i.getId
     | throwErrorAt i m!"Identifier {i} not found"
   let (mvs, bis, tp) ← forallMetaTelescopeReducingUntilDefEq (← inferType f) ldecl.type
@@ -38,3 +38,5 @@ elab "apply" t:term "at" i:ident : tactic => withMainContext do
     (← mkAppOptM' f (mvs.pop.push ldecl.toExpr |>.map fun e => some e))
   let (_, mainGoal) ← mainGoal.intro1P
   replaceMainGoal <| [mainGoal] ++ mvs.pop.toList.map fun e => e.mvarId!
+
+#check elabTermForApply

--- a/test/ApplyAt.lean
+++ b/test/ApplyAt.lean
@@ -91,7 +91,7 @@ example {α β : Type*} (a : α) (b : β) : α × β := by
   fail_if_success apply a at b
   exact (a, b)
 
--- testing dot notation
+-- testing field notation
 example (A B : Prop) (h : A ↔ B) : A → B := by
   intro hA
   apply h.mp at hA

--- a/test/ApplyAt.lean
+++ b/test/ApplyAt.lean
@@ -90,3 +90,9 @@ example {α β : Type*} (a : α) (b : β) : α × β := by
 example {α β : Type*} (a : α) (b : β) : α × β := by
   fail_if_success apply a at b
   exact (a, b)
+
+-- testing dot notation
+example (A B : Prop) (h : A ↔ B) : A → B := by
+  intro hA
+  apply h.mp at hA
+  assumption

--- a/test/ApplyAt.lean
+++ b/test/ApplyAt.lean
@@ -92,7 +92,7 @@ example {α β : Type*} (a : α) (b : β) : α × β := by
   exact (a, b)
 
 -- testing field notation
-example (A B : Prop) (h : A ↔ B) : A → B := by
+example {A B : Prop} (h : A ↔ B) : A → B := by
   intro hA
   apply h.mp at hA
   assumption


### PR DESCRIPTION
add a test to make sure `apply h.mp at` can be parsed and fix it.

---

See [Zulip question](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/apply.20at.20fails.20with.20h.2Emp)


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
