### PR TITLE
[Merged by Bors] - feat: Existence of tranversals of a subgroup

### DIFF
--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -28,8 +28,8 @@ In this file we define the complement of a subgroup.
 - `isComplement'_of_coprime` : Subgroups of coprime order are complements.
 -/
 
-
-open BigOperators Pointwise
+open Set
+open scoped BigOperators Pointwise
 
 namespace Subgroup
 
@@ -107,32 +107,32 @@ theorem isComplement'_comm : IsComplement' H K ↔ IsComplement' K H :=
 #align add_subgroup.is_complement'_comm AddSubgroup.isComplement'_comm
 
 @[to_additive]
-theorem isComplement_top_singleton {g : G} : IsComplement (⊤ : Set G) {g} :=
+theorem isComplement_univ_singleton {g : G} : IsComplement (univ : Set G) {g} :=
   ⟨fun ⟨_, _, rfl⟩ ⟨_, _, rfl⟩ h => Prod.ext (Subtype.ext (mul_right_cancel h)) rfl, fun x =>
     ⟨⟨⟨x * g⁻¹, ⟨⟩⟩, g, rfl⟩, inv_mul_cancel_right x g⟩⟩
-#align subgroup.is_complement_top_singleton Subgroup.isComplement_top_singleton
-#align add_subgroup.is_complement_top_singleton AddSubgroup.isComplement_top_singleton
+#align subgroup.is_complement_top_singleton Subgroup.isComplement_univ_singleton
+#align add_subgroup.is_complement_top_singleton AddSubgroup.isComplement_univ_singleton
 
 @[to_additive]
-theorem isComplement_singleton_top {g : G} : IsComplement ({g} : Set G) ⊤ :=
+theorem isComplement_singleton_univ {g : G} : IsComplement ({g} : Set G) univ :=
   ⟨fun ⟨⟨_, rfl⟩, _⟩ ⟨⟨_, rfl⟩, _⟩ h => Prod.ext rfl (Subtype.ext (mul_left_cancel h)), fun x =>
     ⟨⟨⟨g, rfl⟩, g⁻¹ * x, ⟨⟩⟩, mul_inv_cancel_left g x⟩⟩
-#align subgroup.is_complement_singleton_top Subgroup.isComplement_singleton_top
-#align add_subgroup.is_complement_singleton_top AddSubgroup.isComplement_singleton_top
+#align subgroup.is_complement_singleton_top Subgroup.isComplement_singleton_univ
+#align add_subgroup.is_complement_singleton_top AddSubgroup.isComplement_singleton_univ
 
 @[to_additive]
-theorem isComplement_singleton_left {g : G} : IsComplement {g} S ↔ S = ⊤ := by
+theorem isComplement_singleton_left {g : G} : IsComplement {g} S ↔ S = univ := by
   refine'
-    ⟨fun h => top_le_iff.mp fun x _ => _, fun h => (congr_arg _ h).mpr isComplement_singleton_top⟩
+    ⟨fun h => top_le_iff.mp fun x _ => _, fun h => (congr_arg _ h).mpr isComplement_singleton_univ⟩
   obtain ⟨⟨⟨z, rfl : z = g⟩, y, _⟩, hy⟩ := h.2 (g * x)
   rwa [← mul_left_cancel hy]
 #align subgroup.is_complement_singleton_left Subgroup.isComplement_singleton_left
 #align add_subgroup.is_complement_singleton_left AddSubgroup.isComplement_singleton_left
 
 @[to_additive]
-theorem isComplement_singleton_right {g : G} : IsComplement S {g} ↔ S = ⊤ := by
+theorem isComplement_singleton_right {g : G} : IsComplement S {g} ↔ S = univ := by
   refine'
-    ⟨fun h => top_le_iff.mp fun x _ => _, fun h => h ▸ isComplement_top_singleton⟩
+    ⟨fun h => top_le_iff.mp fun x _ => _, fun h => h ▸ isComplement_univ_singleton⟩
   obtain ⟨y, hy⟩ := h.2 (x * g)
   conv_rhs at hy => rw [← show y.2.1 = g from y.2.2]
   rw [← mul_right_cancel hy]
@@ -141,7 +141,7 @@ theorem isComplement_singleton_right {g : G} : IsComplement S {g} ↔ S = ⊤ :=
 #align add_subgroup.is_complement_singleton_right AddSubgroup.isComplement_singleton_right
 
 @[to_additive]
-theorem isComplement_top_left : IsComplement ⊤ S ↔ ∃ g : G, S = {g} := by
+theorem isComplement_univ_left : IsComplement univ S ↔ ∃ g : G, S = {g} := by
   refine'
     ⟨fun h => Set.exists_eq_singleton_iff_nonempty_subsingleton.mpr ⟨_, fun a ha b hb => _⟩, _⟩
   · obtain ⟨a, _⟩ := h.2 1
@@ -150,12 +150,12 @@ theorem isComplement_top_left : IsComplement ⊤ S ↔ ∃ g : G, S = {g} := by
       h.1 ((inv_mul_self a).trans (inv_mul_self b).symm)
     exact Subtype.ext_iff.mp (Prod.ext_iff.mp this).2
   · rintro ⟨g, rfl⟩
-    exact isComplement_top_singleton
-#align subgroup.is_complement_top_left Subgroup.isComplement_top_left
-#align add_subgroup.is_complement_top_left AddSubgroup.isComplement_top_left
+    exact isComplement_univ_singleton
+#align subgroup.is_complement_top_left Subgroup.isComplement_univ_left
+#align add_subgroup.is_complement_top_left AddSubgroup.isComplement_univ_left
 
 @[to_additive]
-theorem isComplement_top_right : IsComplement S ⊤ ↔ ∃ g : G, S = {g} := by
+theorem isComplement_univ_right : IsComplement S univ ↔ ∃ g : G, S = {g} := by
   refine'
     ⟨fun h => Set.exists_eq_singleton_iff_nonempty_subsingleton.mpr ⟨_, fun a ha b hb => _⟩, _⟩
   · obtain ⟨a, _⟩ := h.2 1
@@ -164,19 +164,27 @@ theorem isComplement_top_right : IsComplement S ⊤ ↔ ∃ g : G, S = {g} := by
       h.1 ((mul_inv_self a).trans (mul_inv_self b).symm)
     exact Subtype.ext_iff.mp (Prod.ext_iff.mp this).1
   · rintro ⟨g, rfl⟩
-    exact isComplement_singleton_top
-#align subgroup.is_complement_top_right Subgroup.isComplement_top_right
-#align add_subgroup.is_complement_top_right AddSubgroup.isComplement_top_right
+    exact isComplement_singleton_univ
+#align subgroup.is_complement_top_right Subgroup.isComplement_univ_right
+#align add_subgroup.is_complement_top_right AddSubgroup.isComplement_univ_right
+
+@[to_additive]
+lemma IsComplement.mul_eq (h : IsComplement S T) : S * T = univ :=
+  eq_univ_of_forall fun x ↦ by simpa [mem_mul] using (h.existsUnique x).exists
+
+@[to_additive AddSubgroup.IsComplement.card_mul_card]
+lemma IsComplement.card_mul_card (h : IsComplement S T) : Nat.card S * Nat.card T = Nat.card G :=
+  (Nat.card_prod _ _).symm.trans $ Nat.card_congr $ Equiv.ofBijective _ h
 
 @[to_additive]
 theorem isComplement'_top_bot : IsComplement' (⊤ : Subgroup G) ⊥ :=
-  isComplement_top_singleton
+  isComplement_univ_singleton
 #align subgroup.is_complement'_top_bot Subgroup.isComplement'_top_bot
 #align add_subgroup.is_complement'_top_bot AddSubgroup.isComplement'_top_bot
 
 @[to_additive]
 theorem isComplement'_bot_top : IsComplement' (⊥ : Subgroup G) ⊤ :=
-  isComplement_singleton_top
+  isComplement_singleton_univ
 #align subgroup.is_complement'_bot_top Subgroup.isComplement'_bot_top
 #align add_subgroup.is_complement'_bot_top AddSubgroup.isComplement'_bot_top
 
@@ -194,13 +202,13 @@ theorem isComplement'_bot_right : IsComplement' H ⊥ ↔ H = ⊤ :=
 
 @[to_additive (attr := simp)]
 theorem isComplement'_top_left : IsComplement' ⊤ H ↔ H = ⊥ :=
-  isComplement_top_left.trans coe_eq_singleton
+  isComplement_univ_left.trans coe_eq_singleton
 #align subgroup.is_complement'_top_left Subgroup.isComplement'_top_left
 #align add_subgroup.is_complement'_top_left AddSubgroup.isComplement'_top_left
 
 @[to_additive (attr := simp)]
 theorem isComplement'_top_right : IsComplement' H ⊤ ↔ H = ⊥ :=
-  isComplement_top_right.trans coe_eq_singleton
+  isComplement_univ_right.trans coe_eq_singleton
 #align subgroup.is_complement'_top_right Subgroup.isComplement'_top_right
 #align add_subgroup.is_complement'_top_right AddSubgroup.isComplement'_top_right
 
@@ -309,7 +317,8 @@ theorem range_mem_rightTransversals {f : Quotient (QuotientGroup.rightRel H) →
 #align add_subgroup.range_mem_right_transversals AddSubgroup.range_mem_rightTransversals
 
 @[to_additive]
-theorem exists_left_transversal (g : G) : ∃ S ∈ leftTransversals (H : Set G), g ∈ S := by
+lemma exists_left_transversal (H : Subgroup G) (g : G) :
+    ∃ S ∈ leftTransversals (H : Set G), g ∈ S := by
   classical
     refine'
       ⟨Set.range (Function.update Quotient.out' _ g), range_mem_leftTransversals fun q => _,
@@ -322,7 +331,8 @@ theorem exists_left_transversal (g : G) : ∃ S ∈ leftTransversals (H : Set G)
 #align add_subgroup.exists_left_transversal AddSubgroup.exists_left_transversal
 
 @[to_additive]
-theorem exists_right_transversal (g : G) : ∃ S ∈ rightTransversals (H : Set G), g ∈ S := by
+lemma exists_right_transversal (H : Subgroup G) (g : G) :
+    ∃ S ∈ rightTransversals (H : Set G), g ∈ S := by
   classical
     refine'
       ⟨Set.range (Function.update Quotient.out' _ g), range_mem_rightTransversals fun q => _,
@@ -332,6 +342,39 @@ theorem exists_right_transversal (g : G) : ∃ S ∈ rightTransversals (H : Set 
     · exact Eq.trans (congr_arg _ (Function.update_noteq hq g Quotient.out')) q.out_eq'
 #align subgroup.exists_right_transversal Subgroup.exists_right_transversal
 #align add_subgroup.exists_right_transversal AddSubgroup.exists_right_transversal
+
+/-- Given two subgroups `H' ⊆ H`, there exists a left transversal to `H'` inside `H`. -/
+@[to_additive "Given two subgroups `H' ⊆ H`, there exists a transversal to `H'` inside `H`"]
+lemma exists_left_transversal_of_le {H' H : Subgroup G} (h : H' ≤ H) :
+    ∃ S : Set G, S * H' = H ∧ Nat.card S * Nat.card H' = Nat.card H := by
+  let H'' : Subgroup H := H'.comap H.subtype
+  have : H' = H''.map H.subtype := by simp [h]
+  rw [this]
+  obtain ⟨S, cmem, -⟩ := H''.exists_left_transversal 1
+  refine ⟨H.subtype '' S, ?_, ?_⟩
+  · have : H.subtype '' (S * H'') = H.subtype '' S * H''.map H.subtype := image_mul H.subtype
+    rw [← this, cmem.mul_eq]
+    simp [Set.ext_iff]
+  · rw [← cmem.card_mul_card]
+    refine congr_arg₂ (· * ·) ?_ ?_ <;>
+      exact Nat.card_congr (Equiv.Set.image _ _ $ subtype_injective H).symm
+
+/-- Given two subgroups `H' ⊆ H`, there exists a right transversal to `H'` inside `H`. -/
+@[to_additive "Given two subgroups `H' ⊆ H`, there exists a transversal to `H'` inside `H`"]
+lemma exists_right_transversal_of_le {H' H : Subgroup G} (h : H' ≤ H) :
+    ∃ S : Set G, H' * S = H ∧ Nat.card H' * Nat.card S = Nat.card H := by
+  let H'' : Subgroup H := H'.comap H.subtype
+  have : H' = H''.map H.subtype := by simp [h]
+  rw [this]
+  obtain ⟨S, cmem, -⟩ := H''.exists_right_transversal 1
+  refine ⟨H.subtype '' S, ?_, ?_⟩
+  · have : H.subtype '' (H'' * S) = H''.map H.subtype * H.subtype '' S := image_mul H.subtype
+    rw [← this, cmem.mul_eq]
+    simp [Set.ext_iff]
+  · have : Nat.card H'' * Nat.card S = Nat.card H := cmem.card_mul_card
+    rw [← this]
+    refine congr_arg₂ (· * ·) ?_ ?_ <;>
+      exact Nat.card_congr (Equiv.Set.image _ _ $ subtype_injective H).symm
 
 namespace IsComplement
 

--- a/Mathlib/GroupTheory/HNNExtension.lean
+++ b/Mathlib/GroupTheory/HNNExtension.lean
@@ -181,13 +181,8 @@ structure TransversalPair : Type _ :=
   compl : ∀ u, IsComplement (toSubgroup A B u : Subgroup G) (set u)
 
 instance TransversalPair.nonempty : Nonempty (TransversalPair G A B) := by
-  have := fun u => exists_right_transversal (H := toSubgroup A B u) (1 : G)
-  simp only [Classical.skolem] at this
-  rcases this with ⟨t, ht⟩
-  apply Nonempty.intro
-  exact
-    { set := t
-      compl := fun i => (ht i).1 }
+  choose t ht using fun u ↦ (toSubgroup A B u).exists_right_transversal 1
+  exact ⟨⟨t, fun i ↦ (ht i).1⟩⟩
 
 /-- A reduced word is a `head`, which is an element of `G`, followed by the product list of pairs.
 There should also be no sequences of the form `t^u * g * t^-u`, where `g` is in

--- a/Mathlib/GroupTheory/PushoutI.lean
+++ b/Mathlib/GroupTheory/PushoutI.lean
@@ -229,9 +229,7 @@ structure Transversal : Type _ where
   compl : ∀ i, IsComplement (φ i).range (set i)
 
 theorem transversal_nonempty (hφ : ∀ i, Injective (φ i)) : Nonempty (Transversal φ) := by
-  have := fun i => exists_right_transversal (H := (φ i).range) 1
-  simp only [Classical.skolem] at this
-  rcases this with ⟨t, ht⟩
+  choose t ht using fun i => (φ i).range.exists_right_transversal 1
   apply Nonempty.intro
   exact
     { injective := hφ

--- a/Mathlib/GroupTheory/Schreier.lean
+++ b/Mathlib/GroupTheory/Schreier.lean
@@ -106,7 +106,7 @@ theorem exists_finset_card_le_mul [FiniteIndex H] {S : Finset G} (hS : closure (
     ∃ T : Finset H, T.card ≤ H.index * S.card ∧ closure (T : Set H) = ⊤ := by
   letI := H.fintypeQuotientOfFiniteIndex
   haveI : DecidableEq G := Classical.decEq G
-  obtain ⟨R₀, hR : R₀ ∈ rightTransversals (H : Set G), hR1⟩ := exists_right_transversal (1 : G)
+  obtain ⟨R₀, hR, hR1⟩ := H.exists_right_transversal 1
   haveI : Fintype R₀ := Fintype.ofEquiv _ (toEquiv hR)
   let R : Finset G := Set.toFinset R₀
   replace hR : (R : Set G) ∈ rightTransversals (H : Set G) := by rwa [Set.coe_toFinset]


### PR DESCRIPTION
Specialises the existence of tranversals to the case where one subgroup is contained in another.

Also replace `⊤ : Set G` by `Set.univ` and modify the lemma names accordingly.

From PFR


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
