### PR TITLE
[Merged by Bors] - refactor: Generalise archimedean lemmas to semirings

### DIFF
--- a/Mathlib/Algebra/Order/Archimedean.lean
+++ b/Mathlib/Algebra/Order/Archimedean.lean
@@ -115,10 +115,6 @@ theorem existsUnique_sub_zsmul_mem_Ioc {a : α} (ha : 0 < a) (b c : α) :
 
 end LinearOrderedAddCommGroup
 
-theorem exists_nat_gt [StrictOrderedSemiring α] [Archimedean α] (x : α) : ∃ n : ℕ, x < n :=
-  (exists_lt_nsmul zero_lt_one x).imp fun n hn ↦ by rwa [← nsmul_one]
-#align exists_nat_gt exists_nat_gt
-
 theorem exists_nat_ge [OrderedSemiring α] [Archimedean α] (x : α) : ∃ n : ℕ, x ≤ n := by
   nontriviality α
   exact (Archimedean.arch x one_pos).imp fun n h => by rwa [← nsmul_one]
@@ -130,8 +126,14 @@ instance (priority := 100) [OrderedSemiring α] [Archimedean α] : IsDirected α
     let ⟨k, hmk, hnk⟩ := exists_ge_ge m n
     ⟨k, hm.trans <| Nat.mono_cast hmk, hn.trans <| Nat.mono_cast hnk⟩⟩
 
-theorem add_one_pow_unbounded_of_pos [StrictOrderedSemiring α] [Archimedean α] (x : α) {y : α}
-    (hy : 0 < y) : ∃ n : ℕ, x < (y + 1) ^ n :=
+section StrictOrderedSemiring
+variable [StrictOrderedSemiring α] [Archimedean α] {y : α}
+
+lemma exists_nat_gt (x : α) : ∃ n : ℕ, x < n :=
+  (exists_lt_nsmul zero_lt_one x).imp fun n hn ↦ by rwa [← nsmul_one]
+#align exists_nat_gt exists_nat_gt
+
+theorem add_one_pow_unbounded_of_pos (x : α) (hy : 0 < y) : ∃ n : ℕ, x < (y + 1) ^ n :=
   have : 0 ≤ 1 + y := add_nonneg zero_le_one hy.le
   (Archimedean.arch x hy).imp fun n h ↦
     calc
@@ -144,13 +146,16 @@ theorem add_one_pow_unbounded_of_pos [StrictOrderedSemiring α] [Archimedean α]
       _ = (y + 1) ^ n := by rw [add_comm]
 #align add_one_pow_unbounded_of_pos add_one_pow_unbounded_of_pos
 
-section StrictOrderedRing
-
-variable [StrictOrderedRing α] [Archimedean α]
-
-theorem pow_unbounded_of_one_lt (x : α) {y : α} (hy1 : 1 < y) : ∃ n : ℕ, x < y ^ n :=
-  sub_add_cancel y 1 ▸ add_one_pow_unbounded_of_pos _ (sub_pos.2 hy1)
+lemma pow_unbounded_of_one_lt [ExistsAddOfLE α] (x : α) (hy1 : 1 < y) : ∃ n : ℕ, x < y ^ n := by
+  obtain ⟨z, hz, rfl⟩ := exists_pos_add_of_lt' hy1
+  rw [add_comm]
+  exact add_one_pow_unbounded_of_pos _ hz
 #align pow_unbounded_of_one_lt pow_unbounded_of_one_lt
+
+end StrictOrderedSemiring
+
+section StrictOrderedRing
+variable [StrictOrderedRing α] [Archimedean α]
 
 theorem exists_int_gt (x : α) : ∃ n : ℤ, x < n :=
   let ⟨n, h⟩ := exists_nat_gt x
@@ -177,14 +182,12 @@ theorem exists_floor (x : α) : ∃ fl : ℤ, ∀ z : ℤ, z ≤ fl ↔ (z : α)
 
 end StrictOrderedRing
 
-section LinearOrderedRing
-
-variable [LinearOrderedRing α] [Archimedean α]
+section LinearOrderedSemiring
+variable [LinearOrderedSemiring α] [Archimedean α] [ ExistsAddOfLE α] {x y : α}
 
 /-- Every x greater than or equal to 1 is between two successive
 natural-number powers of every y greater than one. -/
-theorem exists_nat_pow_near {x : α} {y : α} (hx : 1 ≤ x) (hy : 1 < y) :
-    ∃ n : ℕ, y ^ n ≤ x ∧ x < y ^ (n + 1) := by
+theorem exists_nat_pow_near (hx : 1 ≤ x) (hy : 1 < y) : ∃ n : ℕ, y ^ n ≤ x ∧ x < y ^ (n + 1) := by
   have h : ∃ n : ℕ, x < y ^ n := pow_unbounded_of_one_lt _ hy
   classical exact
       let n := Nat.find h
@@ -196,11 +199,10 @@ theorem exists_nat_pow_near {x : α} {y : α} (hx : 1 ≤ x) (hy : 1 < y) :
       ⟨Nat.pred n, le_of_not_lt (Nat.find_min h hltn), by rwa [hnsp]⟩
 #align exists_nat_pow_near exists_nat_pow_near
 
-end LinearOrderedRing
+end LinearOrderedSemiring
 
-section LinearOrderedField
-
-variable [LinearOrderedField α] [Archimedean α] {x y ε : α}
+section LinearOrderedSemifield
+variable [LinearOrderedSemifield α] [Archimedean α] [ExistsAddOfLE α] {x y ε : α}
 
 /-- Every positive `x` is between two successive integer powers of
 another `y` greater than one. This is the same as `exists_mem_Ioc_zpow`,
@@ -239,7 +241,7 @@ theorem exists_pow_lt_of_lt_one (hx : 0 < x) (hy : y < 1) : ∃ n : ℕ, y ^ n <
   by_cases y_pos : y ≤ 0
   · use 1
     simp only [pow_one]
-    linarith
+    exact y_pos.trans_lt hx
   rw [not_le] at y_pos
   rcases pow_unbounded_of_one_lt x⁻¹ (one_lt_inv y_pos hy) with ⟨q, hq⟩
   exact ⟨q, by rwa [inv_pow, inv_lt_inv hx (pow_pos y_pos _)] at hq⟩
@@ -255,6 +257,20 @@ theorem exists_nat_pow_near_of_lt_one (xpos : 0 < x) (hx : x ≤ 1) (ypos : 0 < 
   · rwa [inv_pow, inv_lt_inv xpos (pow_pos ypos _)] at h'n
   · rwa [inv_pow, inv_le_inv (pow_pos ypos _) xpos] at hn
 #align exists_nat_pow_near_of_lt_one exists_nat_pow_near_of_lt_one
+
+lemma exists_nat_one_div_lt (hε : 0 < ε) : ∃ n : ℕ, 1 / (n + 1 : α) < ε := by
+  cases' exists_nat_gt (1 / ε) with n hn
+  use n
+  rw [div_lt_iff, ← div_lt_iff' hε]
+  · apply hn.trans
+    simp [zero_lt_one]
+  · exact n.cast_add_one_pos
+#align exists_nat_one_div_lt exists_nat_one_div_lt
+
+end LinearOrderedSemifield
+
+section LinearOrderedField
+variable [LinearOrderedField α] [Archimedean α] {x y ε : α}
 
 theorem exists_rat_gt (x : α) : ∃ q : ℚ, x < q :=
   let ⟨n, h⟩ := exists_nat_gt x
@@ -314,15 +330,6 @@ theorem eq_of_forall_lt_rat_iff_lt (h : ∀ q : ℚ, x < q ↔ y < q) : x = y :=
   (le_of_forall_lt_rat_imp_le fun q hq => ((h q).2 hq).le).antisymm <|
     le_of_forall_lt_rat_imp_le fun q hq => ((h q).1 hq).le
 #align eq_of_forall_lt_rat_iff_lt eq_of_forall_lt_rat_iff_lt
-
-theorem exists_nat_one_div_lt {ε : α} (hε : 0 < ε) : ∃ n : ℕ, 1 / (n + 1 : α) < ε := by
-  cases' exists_nat_gt (1 / ε) with n hn
-  use n
-  rw [div_lt_iff, ← div_lt_iff' hε]
-  · apply hn.trans
-    simp [zero_lt_one]
-  · exact n.cast_add_one_pos
-#align exists_nat_one_div_lt exists_nat_one_div_lt
 
 theorem exists_pos_rat_lt {x : α} (x0 : 0 < x) : ∃ q : ℚ, 0 < q ∧ (q : α) < x := by
   simpa only [Rat.cast_pos] using exists_rat_btwn x0


### PR DESCRIPTION
A bunch of lemmas are true in `ℕ` but previously did not apply there.

Co-authored-by: Sébastien Gouëzel <sebastien.gouezel@univ-rennes1.fr>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
