### PR TITLE
[Merged by Bors] - chore(MeasureTheory/Function): fix duplicated assumption in L2Space

### DIFF
--- a/Mathlib/MeasureTheory/Function/L2Space.lean
+++ b/Mathlib/MeasureTheory/Function/L2Space.lean
@@ -280,7 +280,7 @@ end L2
 
 section InnerContinuous
 
-variable {α : Type*} [TopologicalSpace α] [MeasureSpace α] [BorelSpace α] {𝕜 : Type*} [IsROrC 𝕜]
+variable {α : Type*} [TopologicalSpace α] [MeasurableSpace α] [BorelSpace α] {𝕜 : Type*} [IsROrC 𝕜]
 
 variable (μ : Measure α) [IsFiniteMeasure μ]
 


### PR DESCRIPTION
This fixes a tiny glitch in the instance arguments in the L2Space file: if you invoke some of these lemmas with `@` then you find you need to give a measure twice over, once for the `[MeasureSpace α]` instance and once for the explicit argument.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
