### PR TITLE
[Merged by Bors] - feat(MeasureTheory/Integral/Pi): dependent types, values in R or C

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -12,38 +12,54 @@ import Mathlib.MeasureTheory.Constructions.Prod.Integral
 
 open BigOperators Fintype MeasureTheory MeasureTheory.Measure
 
-theorem MeasureTheory.integral_finset_prod_eq_prod' {E : Type*} {n : ℕ} (f : (Fin n) → E → ℝ)
-    [MeasureSpace E] [SigmaFinite (volume : Measure E)] :
-    ∫ x : (Fin n) → E, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
+variable {L : Type*} [IsROrC L]
+
+/-- A version of **Fubini's theorem** in `n` variables, for a natural number `n`. -/
+theorem MeasureTheory.integral_fin_nat_prod_eq_prod {n : ℕ} {E : Fin n → Type*}
+    [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))]
+    (f : (i : Fin n) → E i → L) : ∫ x : (i : Fin n) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
   induction n with
   | zero =>
       simp only [Nat.zero_eq, volume_pi, Finset.univ_eq_empty, Finset.prod_empty, integral_const,
-        pi_empty_univ, ENNReal.one_toReal, smul_eq_mul, mul_one, pow_zero]
+        pi_empty_univ, ENNReal.one_toReal, smul_eq_mul, mul_one, pow_zero, one_smul]
   | succ n n_ih =>
       calc
-        _ = ∫ x : E × (Fin n → E), f 0 x.1 * ∏ i : Fin n, f (Fin.succ i) (x.2 i) := by
+        _ = ∫ x : E 0 × ((i : Fin n) → E (Fin.succ i)),
+            f 0 x.1 * ∏ i : Fin n, f (Fin.succ i) (x.2 i) := by
           rw [volume_pi, ← ((measurePreserving_piFinSuccAboveEquiv
-            (fun _ => (volume : Measure E)) 0).symm).integral_comp']
-          simp_rw [MeasurableEquiv.piFinSuccAboveEquiv_symm_apply, Fin.insertNth_zero',
-            Fin.prod_univ_succ, Fin.cons_zero, Fin.cons_succ]
+            (fun i => (volume : Measure (E i))) 0).symm).integral_comp']
+          simp_rw [MeasurableEquiv.piFinSuccAboveEquiv_symm_apply,
+            Fin.prod_univ_succ, Fin.insertNth_zero, Fin.cons_succ]
           rfl
-        _ = (∫ x, f 0 x) *  ∏ i : Fin n, ∫ (x : E), f (Fin.succ i) x := by
+        _ = (∫ x, f 0 x) *  ∏ i : Fin n, ∫ (x : E (Fin.succ i)), f (Fin.succ i) x := by
           rw [← n_ih, ← integral_prod_mul, volume_eq_prod]
         _ =  ∏ i, ∫ x, f i x := by rw [Fin.prod_univ_succ]
 
-theorem MeasureTheory.integral_finset_prod_eq_prod {E : Type*} (ι : Type*) [Fintype ι]
-    (f : ι → E → ℝ) [MeasureSpace E] [SigmaFinite (volume : Measure E)] :
-    ∫ x : ι → E, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
-  let e := (equivFin ι)
-  let p := measurePreserving_piCongrLeft (fun _ => (volume : Measure E)) e
-  rw [volume_pi, ← (p.symm).integral_comp', Fintype.prod_equiv e _ (fun j => ∫ x, f (e.symm j) x)
-    (fun _ => by simp_rw [e.symm_apply_apply]), ← integral_finset_prod_eq_prod'
-    (fun j => f (e.symm j))]
-  congr!
-  rw [Fintype.prod_equiv e]
-  exact fun _ => by simp [Equiv.symm_apply_apply]; rfl
+/-- A version of **Fubini's theorem** with the variables indexed by a general finite type. -/
+theorem MeasureTheory.integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E : ι → Type*}
+    (f : (i : ι) → E i → L) [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))] :
+    ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
+  let n := Fintype.card ι
+  let e : Fin n ≃ ι := (equivFin ι).symm
+  let p := measurePreserving_piCongrLeft (fun i => (volume : Measure (E i))) e
+  have pp := @MeasurePreserving.integral_comp' ((m : Fin n) → E (e m))
+    L _ _ MeasurableSpace.pi volume ((i : ι) → E i) _ volume _ p
+    (fun v ↦  ∏ i, f i (v i))
+  rw [← pp]
+  have h0 : ∀ (x : (m : Fin n) → E (e m)) (m : Fin n),
+      (MeasurableEquiv.piCongrLeft (fun i ↦ E i) e) x (e m) = x m
+  · intro x m
+    rw [MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply]
+  suffices h1 : ∫ x, ∏ i, f i ((MeasurableEquiv.piCongrLeft (fun i ↦ E i) e) x i) =
+      ∫ (x : (m : Fin n) → E (e m)), ∏ m, f (e m) (x m)
+  · rw [h1, MeasureTheory.integral_fin_nat_prod_eq_prod]
+    exact Fintype.prod_equiv e _ _ (fun i ↦ by rfl)
+  congr 1 with v : 1
+  refine (@Fintype.prod_equiv (Fin n) ι L _ _ _ e (fun m ↦ f (e m) (v m)) _ ?_).symm
+  intro m
+  rw [h0 v m]
 
-theorem MeasureTheory.integral_finset_prod_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → ℝ)
+theorem MeasureTheory.integral_finset_prod_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → L)
     [MeasureSpace E] [SigmaFinite (volume : Measure E)] :
     ∫ x : ι → E, ∏ i, f (x i) = (∫ x, f x) ^ (card ι) := by
-  rw [integral_finset_prod_eq_prod, Finset.prod_const, Fintype.card]
+  rw [integral_fintype_prod_eq_prod, Finset.prod_const, Fintype.card]

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -12,12 +12,13 @@ import Mathlib.MeasureTheory.Constructions.Prod.Integral
 
 open BigOperators Fintype MeasureTheory MeasureTheory.Measure
 
-variable {L : Type*} [IsROrC L]
+variable {𝕜 : Type*} [IsROrC 𝕜]
 
 /-- A version of **Fubini's theorem** in `n` variables, for a natural number `n`. -/
 theorem MeasureTheory.integral_fin_nat_prod_eq_prod {n : ℕ} {E : Fin n → Type*}
     [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))]
-    (f : (i : Fin n) → E i → L) : ∫ x : (i : Fin n) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
+    (f : (i : Fin n) → E i → 𝕜) :
+    ∫ x : (i : Fin n) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
   induction n with
   | zero =>
       simp only [Nat.zero_eq, volume_pi, Finset.univ_eq_empty, Finset.prod_empty, integral_const,
@@ -37,7 +38,7 @@ theorem MeasureTheory.integral_fin_nat_prod_eq_prod {n : ℕ} {E : Fin n → Typ
 
 /-- A version of **Fubini's theorem** with the variables indexed by a general finite type. -/
 theorem MeasureTheory.integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E : ι → Type*}
-    (f : (i : ι) → E i → L) [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))] :
+    (f : (i : ι) → E i → 𝕜) [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))] :
     ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
   let n := Fintype.card ι
   let e : Fin n ≃ ι := (equivFin ι).symm
@@ -54,7 +55,7 @@ theorem MeasureTheory.integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E
   rw [h1, MeasureTheory.integral_fin_nat_prod_eq_prod]
   exact Fintype.prod_equiv e _ _ (fun i ↦ by rfl)
 
-theorem MeasureTheory.integral_fintype_prod_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → L)
+theorem MeasureTheory.integral_fintype_prod_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → 𝕜)
     [MeasureSpace E] [SigmaFinite (volume : Measure E)] :
     ∫ x : ι → E, ∏ i, f (x i) = (∫ x, f x) ^ (card ι) := by
   rw [integral_fintype_prod_eq_prod, Finset.prod_const, Fintype.card]

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -45,11 +45,11 @@ theorem MeasureTheory.integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E
   rw [← (volume_measurePreserving_piCongrLeft _ e).integral_comp']
   have h0 (x : (m : Fin n) → E (e m)) (m : Fin n) : MeasurableEquiv.piCongrLeft E e x (e m) = x m
   · rw [MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply]
-  have h1 : ∫ x, ∏ i, f i ((MeasurableEquiv.piCongrLeft E e) x i) =
+  have : ∫ x, ∏ i, f i ((MeasurableEquiv.piCongrLeft E e) x i) =
       ∫ x : (m : Fin n) → E (e m), ∏ m, f (e m) (x m)
   · congr 1 with v : 1
     exact (Fintype.prod_equiv e _ _ (fun m ↦ by rw [h0 v m])).symm
-  rw [h1, MeasureTheory.integral_fin_nat_prod_eq_prod]
+  rw [this, MeasureTheory.integral_fin_nat_prod_eq_prod]
   exact Fintype.prod_equiv e _ _ (fun i ↦ by rfl)
 
 theorem MeasureTheory.integral_fintype_prod_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → 𝕜)

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -45,10 +45,10 @@ theorem MeasureTheory.integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E
   rw [← MeasurePreserving.integral_comp' (μ := volume) (ν := volume)
     (measurePreserving_piCongrLeft (fun i => (volume : Measure (E i))) e)]
   have h0 : ∀ (x : (m : Fin n) → E (e m)) (m : Fin n),
-      (MeasurableEquiv.piCongrLeft (fun i ↦ E i) e) x (e m) = x m
+      (MeasurableEquiv.piCongrLeft E e) x (e m) = x m
   · intro x m
     rw [MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply]
-  have h1 : ∫ x, ∏ i, f i ((MeasurableEquiv.piCongrLeft (fun i ↦ E i) e) x i) =
+  have h1 : ∫ x, ∏ i, f i ((MeasurableEquiv.piCongrLeft E e) x i) =
       ∫ (x : (m : Fin n) → E (e m)), ∏ m, f (e m) (x m)
   · congr 1 with v : 1
     exact (Fintype.prod_equiv e _ _ (fun m ↦ by rw [h0 v m])).symm

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -42,7 +42,7 @@ theorem MeasureTheory.integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E
     ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
   let e := (equivFin ι).symm
   rw [← (volume_measurePreserving_piCongrLeft _ e).integral_comp']
-  simp_rw [←e.prod_comp, MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply,
+  simp_rw [← e.prod_comp, MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply,
     MeasureTheory.integral_fin_nat_prod_eq_prod]
 
 theorem MeasureTheory.integral_fintype_prod_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → 𝕜)

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -43,12 +43,10 @@ theorem MeasureTheory.integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E
   let n := Fintype.card ι
   let e : Fin n ≃ ι := (equivFin ι).symm
   rw [← (volume_measurePreserving_piCongrLeft _ e).integral_comp']
-  have h0 : ∀ (x : (m : Fin n) → E (e m)) (m : Fin n),
-      (MeasurableEquiv.piCongrLeft E e) x (e m) = x m
-  · intro x m
-    rw [MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply]
+  have h0 (x : (m : Fin n) → E (e m)) (m : Fin n) : MeasurableEquiv.piCongrLeft E e x (e m) = x m
+  · rw [MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply]
   have h1 : ∫ x, ∏ i, f i ((MeasurableEquiv.piCongrLeft E e) x i) =
-      ∫ (x : (m : Fin n) → E (e m)), ∏ m, f (e m) (x m)
+      ∫ x : (m : Fin n) → E (e m), ∏ m, f (e m) (x m)
   · congr 1 with v : 1
     exact (Fintype.prod_equiv e _ _ (fun m ↦ by rw [h0 v m])).symm
   rw [h1, MeasureTheory.integral_fin_nat_prod_eq_prod]

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -42,13 +42,8 @@ theorem MeasureTheory.integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E
     ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
   let e := (equivFin ι).symm
   rw [← (volume_measurePreserving_piCongrLeft _ e).integral_comp']
-  have : ∫ x, ∏ i, f i ((MeasurableEquiv.piCongrLeft E e) x i) =
-      ∫ x : (m : Fin (card ι)) → E (e m), ∏ m, f (e m) (x m)
-  · congr 1 with v : 1
-    refine (prod_equiv e _ _ fun m ↦ ?_).symm
-    rw [MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply]
-  rw [this, MeasureTheory.integral_fin_nat_prod_eq_prod]
-  exact prod_equiv e _ _ (fun i ↦ by rfl)
+  simp_rw [←e.prod_comp, MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply,
+    MeasureTheory.integral_fin_nat_prod_eq_prod]
 
 theorem MeasureTheory.integral_fintype_prod_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → 𝕜)
     [MeasureSpace E] [SigmaFinite (volume : Measure E)] :

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -41,25 +41,20 @@ theorem MeasureTheory.integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E
     ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
   let n := Fintype.card ι
   let e : Fin n ≃ ι := (equivFin ι).symm
-  let p := measurePreserving_piCongrLeft (fun i => (volume : Measure (E i))) e
-  have pp := @MeasurePreserving.integral_comp' ((m : Fin n) → E (e m))
-    L _ _ MeasurableSpace.pi volume ((i : ι) → E i) _ volume _ p
-    (fun v ↦  ∏ i, f i (v i))
-  rw [← pp]
+  rw [← MeasurePreserving.integral_comp' (μ := volume) (ν := volume)
+    (measurePreserving_piCongrLeft (fun i => (volume : Measure (E i))) e)]
   have h0 : ∀ (x : (m : Fin n) → E (e m)) (m : Fin n),
       (MeasurableEquiv.piCongrLeft (fun i ↦ E i) e) x (e m) = x m
   · intro x m
     rw [MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply]
-  suffices h1 : ∫ x, ∏ i, f i ((MeasurableEquiv.piCongrLeft (fun i ↦ E i) e) x i) =
+  have h1 : ∫ x, ∏ i, f i ((MeasurableEquiv.piCongrLeft (fun i ↦ E i) e) x i) =
       ∫ (x : (m : Fin n) → E (e m)), ∏ m, f (e m) (x m)
-  · rw [h1, MeasureTheory.integral_fin_nat_prod_eq_prod]
-    exact Fintype.prod_equiv e _ _ (fun i ↦ by rfl)
-  congr 1 with v : 1
-  refine (@Fintype.prod_equiv (Fin n) ι L _ _ _ e (fun m ↦ f (e m) (v m)) _ ?_).symm
-  intro m
-  rw [h0 v m]
+  · congr 1 with v : 1
+    exact (Fintype.prod_equiv e _ _ (fun m ↦ by rw [h0 v m])).symm
+  rw [h1, MeasureTheory.integral_fin_nat_prod_eq_prod]
+  exact Fintype.prod_equiv e _ _ (fun i ↦ by rfl)
 
-theorem MeasureTheory.integral_finset_prod_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → L)
+theorem MeasureTheory.integral_fintype_prod_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → L)
     [MeasureSpace E] [SigmaFinite (volume : Measure E)] :
     ∫ x : ι → E, ∏ i, f (x i) = (∫ x, f x) ^ (card ι) := by
   rw [integral_fintype_prod_eq_prod, Finset.prod_const, Fintype.card]

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -42,8 +42,7 @@ theorem MeasureTheory.integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E
     ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
   let n := Fintype.card ι
   let e : Fin n ≃ ι := (equivFin ι).symm
-  rw [← MeasurePreserving.integral_comp' (μ := volume) (ν := volume)
-    (measurePreserving_piCongrLeft (fun i => (volume : Measure (E i))) e)]
+  rw [← (volume_measurePreserving_piCongrLeft _ e).integral_comp']
   have h0 : ∀ (x : (m : Fin n) → E (e m)) (m : Fin n),
       (MeasurableEquiv.piCongrLeft E e) x (e m) = x m
   · intro x m

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -40,18 +40,17 @@ theorem MeasureTheory.integral_fin_nat_prod_eq_prod {n : ℕ} {E : Fin n → Typ
 theorem MeasureTheory.integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E : ι → Type*}
     (f : (i : ι) → E i → 𝕜) [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))] :
     ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
-  let n := Fintype.card ι
-  let e : Fin n ≃ ι := (equivFin ι).symm
+  let e := (equivFin ι).symm
   rw [← (volume_measurePreserving_piCongrLeft _ e).integral_comp']
   have : ∫ x, ∏ i, f i ((MeasurableEquiv.piCongrLeft E e) x i) =
-      ∫ x : (m : Fin n) → E (e m), ∏ m, f (e m) (x m)
+      ∫ x : (m : Fin (card ι)) → E (e m), ∏ m, f (e m) (x m)
   · congr 1 with v : 1
-    refine (Fintype.prod_equiv e _ _ fun m ↦ ?_).symm
+    refine (prod_equiv e _ _ fun m ↦ ?_).symm
     rw [MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply]
   rw [this, MeasureTheory.integral_fin_nat_prod_eq_prod]
-  exact Fintype.prod_equiv e _ _ (fun i ↦ by rfl)
+  exact prod_equiv e _ _ (fun i ↦ by rfl)
 
 theorem MeasureTheory.integral_fintype_prod_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → 𝕜)
     [MeasureSpace E] [SigmaFinite (volume : Measure E)] :
     ∫ x : ι → E, ∏ i, f (x i) = (∫ x, f x) ^ (card ι) := by
-  rw [integral_fintype_prod_eq_prod, Finset.prod_const, Fintype.card]
+  rw [integral_fintype_prod_eq_prod, Finset.prod_const, card]

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -43,12 +43,11 @@ theorem MeasureTheory.integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E
   let n := Fintype.card ι
   let e : Fin n ≃ ι := (equivFin ι).symm
   rw [← (volume_measurePreserving_piCongrLeft _ e).integral_comp']
-  have h0 (x : (m : Fin n) → E (e m)) (m : Fin n) : MeasurableEquiv.piCongrLeft E e x (e m) = x m
-  · rw [MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply]
   have : ∫ x, ∏ i, f i ((MeasurableEquiv.piCongrLeft E e) x i) =
       ∫ x : (m : Fin n) → E (e m), ∏ m, f (e m) (x m)
   · congr 1 with v : 1
-    exact (Fintype.prod_equiv e _ _ (fun m ↦ by rw [h0 v m])).symm
+    refine (Fintype.prod_equiv e _ _ fun m ↦ ?_).symm
+    rw [MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply]
   rw [this, MeasureTheory.integral_fin_nat_prod_eq_prod]
   exact Fintype.prod_equiv e _ _ (fun i ↦ by rfl)
 

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -190,7 +190,7 @@ theorem MeasureTheory.volume_sum_rpow_lt_one :
     exact Finset.sum_nonneg' (fun _ => rpow_nonneg_of_nonneg (abs_nonneg _) _)
   · simp_rw [← rpow_mul (h₂ _), div_mul_cancel _ (ne_of_gt h₁), Real.rpow_one,
       ← Finset.sum_neg_distrib, exp_sum]
-    rw [integral_finset_prod_eq_pow ι fun x : ℝ => exp (- |x| ^ p), integral_comp_abs
+    rw [integral_fintype_prod_eq_pow ι fun x : ℝ => exp (- |x| ^ p), integral_comp_abs
       (f := fun x => exp (- x ^ p)), integral_exp_neg_rpow h₁]
   · rw [finrank_fintype_fun_eq_card]
 
@@ -264,7 +264,7 @@ theorem Complex.volume_sum_rpow_lt_one {p : ℝ} (hp : 1 ≤ p) :
     exact Finset.sum_nonneg' (fun _ => rpow_nonneg_of_nonneg (norm_nonneg _) _)
   · simp_rw [← rpow_mul (h₂ _), div_mul_cancel _ (ne_of_gt h₁), Real.rpow_one,
       ← Finset.sum_neg_distrib, Real.exp_sum]
-    rw [integral_finset_prod_eq_pow ι fun x : ℂ => Real.exp (- ‖x‖ ^ p),
+    rw [integral_fintype_prod_eq_pow ι fun x : ℂ => Real.exp (- ‖x‖ ^ p),
       Complex.integral_exp_neg_rpow hp]
   · rw [finrank_pi_fintype, Complex.finrank_real_complex, Finset.sum_const, smul_eq_mul,
        Nat.cast_mul, Nat.cast_ofNat, Fintype.card, mul_comm]


### PR DESCRIPTION
This is a generalisation of the lemmas in `MeasureTheory.Integral.Pi` to consider functions on products `(i : ι) → E i`, rather than just products of multiple copies of the same type. I also allowed complex-valued functions, and renamed some lemmas slightly (since the lemmas had `finset` in their names but were about fintypes, not finsets).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
