### PR TITLE
[Merged by Bors] - feat: homomorphisms are linear over Z/nZ scalars

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2005,6 +2005,7 @@ import Mathlib.Data.ZMod.Coprime
 import Mathlib.Data.ZMod.Defs
 import Mathlib.Data.ZMod.Factorial
 import Mathlib.Data.ZMod.IntUnitsPower
+import Mathlib.Data.ZMod.Module
 import Mathlib.Data.ZMod.Parity
 import Mathlib.Data.ZMod.Quotient
 import Mathlib.Data.ZMod.Units

--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -35,10 +35,8 @@ See also:
 `AddMonoidHom.toIntLinearMap`, `AddMonoidHom.toNatLinearMap`, `AddMonoidHom.toRatLinearMap` -/
 def toZModLinearMap (f : M →+ M₁) : M →ₗ[ZMod n] M₁ := { f with map_smul' := ZMod.map_smul f }
 
-theorem toZModLinearMap_injective: Function.Injective $ toZModLinearMap n (M := M) (M₁ := M₁) := by
-  intro f g h
-  ext x
-  exact LinearMap.congr_fun h x
+theorem toZModLinearMap_injective: Function.Injective <| toZModLinearMap n (M := M) (M₁ := M₁) :=
+  fun _ _ h ↦ ext fun x ↦ congr($h x)
 
 @[simp]
 theorem coe_toZModLinearMap (f : M →+ M₁) : ⇑(f.toZModLinearMap n) = f := rfl

--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2023 Lawrence Wu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lawrence Wu
+-/
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Algebra.Module.LinearMap
+
+/-!
+# The `ZMod n`-module structure on Abelian groups whose elements have order dividing `n`
+-/
+
+variable {n : ℕ} {M M₁ : Type*} [AddCommGroup M] [AddCommGroup M₁]
+  [Module (ZMod n) M] [Module (ZMod n) M₁]
+
+namespace ZMod
+
+theorem map_smul (f : M →+ M₁) (c : ZMod n) (x : M) : f (c • x) = c • f x := by
+  cases n with
+  | zero => exact map_int_cast_smul f _ _ c x
+  | succ n =>
+    induction c using Fin.induction with
+    | zero => simp_rw [zero_smul, map_zero]
+    | succ c hc => simp_rw [← Fin.coeSucc_eq_succ, add_smul, one_smul, f.map_add, hc]
+
+end ZMod
+
+namespace AddMonoidHom
+
+variable (n)
+
+/-- Reinterpret an additive homomorphism as a `ℤ/nℤ`-linear map.
+
+See also:
+`AddMonoidHom.toIntLinearMap`, `AddMonoidHom.toNatLinearMap`, `AddMonoidHom.toRatLinearMap` -/
+def toZModLinearMap (f : M →+ M₁) : M →ₗ[ZMod n] M₁ := { f with map_smul' := ZMod.map_smul f }
+
+theorem toZModLinearMap_injective: Function.Injective $ toZModLinearMap n (M := M) (M₁ := M₁) := by
+  intro f g h
+  ext x
+  exact LinearMap.congr_fun h x
+
+@[simp]
+theorem coe_toZModLinearMap (f : M →+ M₁) : ⇑(f.toZModLinearMap n) = f := rfl
+
+end AddMonoidHom


### PR DESCRIPTION
Port from PFR for using linear algebra on C_2^n, following the convention of `AddMonoidHom.to{Int,Nat,Rat}LinearMap` but in a different file to avoid circular import.

For a separate PR:
```lean
@[reducible]
def module (h : ∀ (x : M), n • x = 0) : Module (ZMod n) M
```

Co-authored-by: adamtopaz <github@adamtopaz.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
