### PR TITLE
chore: remove proofwidgets from Tactic.Common to solve caching issues on windows

### DIFF
--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -103,9 +103,10 @@ import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.UnsetOption
 import Mathlib.Tactic.Use
 import Mathlib.Tactic.Variable
-import Mathlib.Tactic.Widget.Calc
-import Mathlib.Tactic.Widget.Congrm
-import Mathlib.Tactic.Widget.Conv
+/- Import of widgets disabled temporarily, as they break cache on windows. TODO: fix properly. -/
+-- import Mathlib.Tactic.Widget.Calc
+-- import Mathlib.Tactic.Widget.Congrm
+-- import Mathlib.Tactic.Widget.Conv
 import Mathlib.Tactic.WLOG
 import Mathlib.Util.AssertExists
 import Mathlib.Util.CountHeartbeats

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -103,7 +103,7 @@ import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.UnsetOption
 import Mathlib.Tactic.Use
 import Mathlib.Tactic.Variable
-/- Import of widgets disabled temporarily, as they break cache on windows. TODO: fix properly. -/
+-- Import of widgets disabled temporarily, as they break cache on windows. TODO: fix properly.
 -- import Mathlib.Tactic.Widget.Calc
 -- import Mathlib.Tactic.Widget.Congrm
 -- import Mathlib.Tactic.Widget.Conv


### PR DESCRIPTION
Revert #8794, to solve caching issues on windows. See discussion at https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Mathlib.20cache.20not.20working.20Windows.20as.20of.201.20hour.20ago/near/407171039

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
