### PR TITLE
[Merged by Bors] - feat(Algebra/Homology): the category of complexes up to quasi-isomorphisms

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -242,6 +242,7 @@ import Mathlib.Algebra.Homology.HomotopyCategory.HomComplex
 import Mathlib.Algebra.Homology.HomotopyCategory.Shift
 import Mathlib.Algebra.Homology.ImageToKernel
 import Mathlib.Algebra.Homology.LocalCohomology
+import Mathlib.Algebra.Homology.Localization
 import Mathlib.Algebra.Homology.ModuleCat
 import Mathlib.Algebra.Homology.Opposite
 import Mathlib.Algebra.Homology.QuasiIso
@@ -1140,6 +1141,7 @@ import Mathlib.CategoryTheory.Localization.CalculusOfFractions
 import Mathlib.CategoryTheory.Localization.Composition
 import Mathlib.CategoryTheory.Localization.Construction
 import Mathlib.CategoryTheory.Localization.Equivalence
+import Mathlib.CategoryTheory.Localization.HasLocalization
 import Mathlib.CategoryTheory.Localization.LocalizerMorphism
 import Mathlib.CategoryTheory.Localization.Opposite
 import Mathlib.CategoryTheory.Localization.Predicate

--- a/Mathlib/Algebra/Homology/Localization.lean
+++ b/Mathlib/Algebra/Homology/Localization.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2023 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import Mathlib.Algebra.Homology.HomotopyCategory
+import Mathlib.Algebra.Homology.QuasiIso
+import Mathlib.CategoryTheory.Localization.HasLocalization
+
+/-! The category of homological complexes up to quasi-isomorphisms
+
+Given a category `C` with homology and any complex shape `c`, we define
+the category `HomologicalComplexUpToQis C c` which is the localized
+category of `HomologicalComplex C c` with respect to quasi-isomorphisms.
+When `C` is abelian, this will be the derived category of `C` in the
+particular case of the complex shape `ComplexShape.up ℤ`.
+
+Under suitable assumptions on `c` (e.g. chain or cochain complexes),
+we shall show that `HomologicalComplexUpToQis C c` is also the
+localized category of `HomotopyCategory C c` with respect to
+the class of quasi-isomorphisms (TODO).
+
+-/
+
+open CategoryTheory Limits
+
+variable (C : Type*) [Category C] {ι : Type*} (c : ComplexShape ι) [HasZeroMorphisms C]
+  [CategoryWithHomology C] [(HomologicalComplex.qis C c).HasLocalization]
+
+/-- The category of homological complexes up to quasi-isomorphisms. -/
+abbrev HomologicalComplexUpToQis := (HomologicalComplex.qis C c).Localization'
+
+variable {C c}
+
+/-- The localization functor `HomologicalComplex C c ⥤ HomologicalComplexUpToQis C c`. -/
+abbrev HomologicalComplexUpToQis.Q :
+    HomologicalComplex C c ⥤ HomologicalComplexUpToQis C c :=
+  (HomologicalComplex.qis C c).Q'
+
+variable (C c)
+
+lemma HomologicalComplex.homologyFunctor_inverts_qis (i : ι) :
+    (qis C c).IsInvertedBy (homologyFunctor C c i) := fun _ _ _ hf => by
+      rw [qis_iff] at hf
+      dsimp
+      infer_instance
+
+namespace HomologicalComplexUpToQis
+
+/-- The homology functor `HomologicalComplexUpToQis C c ⥤ C` for each `i : ι`. -/
+noncomputable def homologyFunctor (i : ι) : HomologicalComplexUpToQis C c ⥤ C :=
+  Localization.lift _ (HomologicalComplex.homologyFunctor_inverts_qis C c i) Q
+
+/-- The homology functor on `HomologicalComplexUpToQis C c` is induced by
+the homology functor on `HomologicalComplex C c`. -/
+noncomputable def homologyFunctorFactors (i : ι) :
+    Q ⋙ homologyFunctor C c i ≅ HomologicalComplex.homologyFunctor C c i :=
+  Localization.fac _ (HomologicalComplex.homologyFunctor_inverts_qis C c i) Q
+
+end HomologicalComplexUpToQis

--- a/Mathlib/CategoryTheory/Localization/HasLocalization.lean
+++ b/Mathlib/CategoryTheory/Localization/HasLocalization.lean
@@ -9,7 +9,7 @@ import Mathlib.CategoryTheory.Localization.Predicate
 
 If `C : Type u` is a category (with `[Category.{v} C]`), and
 `W : MorphismProperty C`, then the constructed localized
-category `W.Localization` is `Type u` (the objects are
+category `W.Localization` is in `Type u` (the objects are
 essentially the same as that of `C`), but the morphisms
 are in `Type (max u v)`. In particular situations, it
 may happen that there is a localized category for `W`

--- a/Mathlib/CategoryTheory/Localization/HasLocalization.lean
+++ b/Mathlib/CategoryTheory/Localization/HasLocalization.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2023 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Localization.Predicate
+
+/-! Morphism properties equipped with a localized category
+
+If `C : Type u` is a category (with `[Category.{v} C]`), and
+`W : MorphismProperty C`, then the constructed localized
+category `W.Localization` is `Type u` (the objects are
+essentially the same as that of `C`), but the morphisms
+are in `Type (max u v)`. In particular situations, it
+may happen that there is a localized category for `W`
+whose morphisms are in a lower universe like `v`: it shall
+be so for the homotopy categories of model categories (TODO),
+and it should also be so for the derived categories of
+Grothendieck abelian categories (TODO: but this shall be
+very technical).
+
+Then, in order to allow the user to provide a localized
+category with specific universe parameters when it exists,
+we introduce a typeclass `MorphismProperty.HasLocalization.{w} W`
+which contains the data of a localized category `D` for `W`
+with `D : Type u` and `[Category.{w} D]`. Then, all
+definitions which involve "the" localized category
+for `W` should contain a `[MorphismProperty.HasLocalization.{w} W]`
+assumption for a suitable `w`. The functor `W.Q' : C ⥤ W.Localization'`
+shall be the localization functor for this fixed choice of the
+localized category. If the statement of a theorem does not
+involve the localized category, but the proof does,
+it is no longer necessary to use a `HasLocalization`
+assumption, but one may use
+`HasLocalization.standard` in the proof instead.
+
+-/
+
+universe w v u
+
+namespace CategoryTheory
+
+variable {C : Type u} [Category.{v} C]
+
+variable (W : MorphismProperty C)
+
+namespace MorphismProperty
+
+/-- The data of a localized category with a given universe
+for the morphisms.  -/
+class HasLocalization where
+  /-- the objects of the localized category. -/
+  {D : Type u}
+  /-- the category structure. -/
+  [hD : Category.{w} D]
+  /-- the localization functor. -/
+  L : C ⥤ D
+  [hL : L.IsLocalization W]
+
+variable [HasLocalization.{w} W]
+
+/-- The localized category for `W : MorphismProperty C`
+that is fixed by the `[HasLocalization W]` instance. -/
+def Localization' := HasLocalization.D W
+
+instance : Category W.Localization' := HasLocalization.hD
+
+/-- The localization functor `C ⥤ W.Localization'`
+that is fixed by the `[HasLocalization W]` instance. -/
+def Q' : C ⥤ W.Localization' := HasLocalization.L
+
+instance : W.Q'.IsLocalization W := HasLocalization.hL
+
+/-- The constructed localized category. -/
+def HasLocalization.standard : HasLocalization.{max u v} W where
+  L := W.Q
+
+end MorphismProperty
+
+end CategoryTheory


### PR DESCRIPTION
In this PR, we define the category of homological complexes up to quasi-isomorphisms. The derived category of an abelian category shall be a particular case on this construction, but the additional structures on the derived category will require more work.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
