### PR TITLE
perf: add `extends flat` to all hom classes

### DIFF
--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -46,7 +46,7 @@ notation:50 A " ≃ₐ[" R "] " A' => AlgEquiv R A A'
 /-- `AlgEquivClass F R A B` states that `F` is a type of algebra structure preserving
   equivalences. You should extend this class when you extend `AlgEquiv`. -/
 class AlgEquivClass (F : Type*) (R A B : outParam (Type*)) [CommSemiring R] [Semiring A]
-  [Semiring B] [Algebra R A] [Algebra R B] extends RingEquivClass F A B where
+  [Semiring B] [Algebra R A] [Algebra R B] extends flat RingEquivClass F A B where
   /-- An equivalence of algebras commutes with the action of scalars. -/
   commutes : ∀ (f : F) (r : R), f (algebraMap R A r) = algebraMap R B r
 #align alg_equiv_class AlgEquivClass

--- a/Mathlib/Algebra/Algebra/Hom.lean
+++ b/Mathlib/Algebra/Algebra/Hom.lean
@@ -54,6 +54,9 @@ class AlgHomClass (F : Type*) (R : outParam (Type*)) (A : outParam (Type*))
   commutes : ∀ (f : F) (r : R), f (algebraMap R A r) = algebraMap R B r
 #align alg_hom_class AlgHomClass
 
+-- lean4#2905
+attribute [-instance] AlgHomClass.toFunLike
+
 -- Porting note: `dangerousInstance` linter has become smarter about `outParam`s
 -- attribute [nolint dangerousInstance] AlgHomClass.toRingHomClass
 

--- a/Mathlib/Algebra/Algebra/Hom.lean
+++ b/Mathlib/Algebra/Algebra/Hom.lean
@@ -50,7 +50,7 @@ notation:25 A " →ₐ[" R "] " B => AlgHom R A B
 from `A` to `B`.  -/
 class AlgHomClass (F : Type*) (R : outParam (Type*)) (A : outParam (Type*))
   (B : outParam (Type*)) [CommSemiring R] [Semiring A] [Semiring B] [Algebra R A]
-  [Algebra R B] extends RingHomClass F A B where
+  [Algebra R B] extends flat RingHomClass F A B where
   commutes : ∀ (f : F) (r : R), f (algebraMap R A r) = algebraMap R B r
 #align alg_hom_class AlgHomClass
 

--- a/Mathlib/Algebra/Algebra/NonUnitalHom.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalHom.lean
@@ -72,6 +72,9 @@ class NonUnitalAlgHomClass (F : Type*) (R : outParam (Type*)) (A : outParam (Typ
   flat MulHomClass F A B
 #align non_unital_alg_hom_class NonUnitalAlgHomClass
 
+-- lean4#2905
+attribute [-instance] NonUnitalAlgHomClass.toFunLike
+
 -- Porting note: commented out, not dangerous
 -- attribute [nolint dangerousInstance] NonUnitalAlgHomClass.toMulHomClass
 

--- a/Mathlib/Algebra/Algebra/NonUnitalHom.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalHom.lean
@@ -68,8 +68,8 @@ attribute [nolint docBlame] NonUnitalAlgHom.toMulHom
 from `A` to `B`.  -/
 class NonUnitalAlgHomClass (F : Type*) (R : outParam (Type*)) (A : outParam (Type*))
   (B : outParam (Type*)) [Monoid R] [NonUnitalNonAssocSemiring A] [NonUnitalNonAssocSemiring B]
-  [DistribMulAction R A] [DistribMulAction R B] extends DistribMulActionHomClass F R A B,
-  MulHomClass F A B
+  [DistribMulAction R A] [DistribMulAction R B] extends flat DistribMulActionHomClass F R A B,
+  flat MulHomClass F A B
 #align non_unital_alg_hom_class NonUnitalAlgHomClass
 
 -- Porting note: commented out, not dangerous

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -158,6 +158,9 @@ class AddMonoidHomClass (F : Type*) (M N : outParam (Type*)) [AddZeroClass M] [A
   extends flat AddHomClass F M N, flat ZeroHomClass F M N
 #align add_monoid_hom_class AddMonoidHomClass
 
+-- lean4#2905
+attribute [-instance] AddMonoidHomClass.toFunLike
+
 -- Instances and lemmas are defined below through `@[to_additive]`.
 end add_zero
 
@@ -356,6 +359,9 @@ class MonoidHomClass (F : Type*) (M N : outParam (Type*)) [MulOneClass M] [MulOn
   extends flat MulHomClass F M N, flat OneHomClass F M N
 #align monoid_hom_class MonoidHomClass
 
+-- lean4#2905
+attribute [-instance] MonoidHomClass.toFunLike
+
 @[to_additive]
 instance MonoidHom.monoidHomClass : MonoidHomClass (M →* N) M N where
   coe f := f.toFun
@@ -490,6 +496,9 @@ You should also extend this typeclass when you extend `MonoidWithZeroHom`.
 class MonoidWithZeroHomClass (F : Type*) (M N : outParam (Type*)) [MulZeroOneClass M]
   [MulZeroOneClass N] extends flat MonoidHomClass F M N, flat ZeroHomClass F M N
 #align monoid_with_zero_hom_class MonoidWithZeroHomClass
+
+-- lean4#2905
+attribute [-instance] MonoidWithZeroHomClass.toFunLike
 
 instance MonoidWithZeroHom.monoidWithZeroHomClass : MonoidWithZeroHomClass (M →*₀ N) M N where
   coe f := f.toFun

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -373,6 +373,7 @@ instance MonoidHom.monoidHomClass : MonoidHomClass (M →* N) M N where
 -- Porting note: we need to add an extra `to_additive`.
 -- This is waiting on https://github.com/leanprover-community/mathlib4/issues/660
 attribute [to_additive existing] MonoidHomClass.toOneHomClass
+attribute [to_additive existing] MonoidHomClass.toMulHomClass
 
 @[to_additive] instance [Subsingleton M] : Subsingleton (M →* N) := .of_oneHomClass
 

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -155,7 +155,7 @@ homomorphisms.
 You should also extend this typeclass when you extend `AddMonoidHom`.
 -/
 class AddMonoidHomClass (F : Type*) (M N : outParam (Type*)) [AddZeroClass M] [AddZeroClass N]
-  extends AddHomClass F M N, ZeroHomClass F M N
+  extends flat AddHomClass F M N, flat ZeroHomClass F M N
 #align add_monoid_hom_class AddMonoidHomClass
 
 -- Instances and lemmas are defined below through `@[to_additive]`.
@@ -353,7 +353,7 @@ infixr:25 " →* " => MonoidHom
 You should also extend this typeclass when you extend `MonoidHom`. -/
 @[to_additive]
 class MonoidHomClass (F : Type*) (M N : outParam (Type*)) [MulOneClass M] [MulOneClass N]
-  extends MulHomClass F M N, OneHomClass F M N
+  extends flat MulHomClass F M N, flat OneHomClass F M N
 #align monoid_hom_class MonoidHomClass
 
 @[to_additive]
@@ -487,7 +487,7 @@ infixr:25 " →*₀ " => MonoidWithZeroHom
 You should also extend this typeclass when you extend `MonoidWithZeroHom`.
 -/
 class MonoidWithZeroHomClass (F : Type*) (M N : outParam (Type*)) [MulZeroOneClass M]
-  [MulZeroOneClass N] extends MonoidHomClass F M N, ZeroHomClass F M N
+  [MulZeroOneClass N] extends flat MonoidHomClass F M N, flat ZeroHomClass F M N
 #align monoid_with_zero_hom_class MonoidWithZeroHomClass
 
 instance MonoidWithZeroHom.monoidWithZeroHomClass : MonoidWithZeroHomClass (M →*₀ N) M N where

--- a/Mathlib/Algebra/Order/Hom/Monoid.lean
+++ b/Mathlib/Algebra/Order/Hom/Monoid.lean
@@ -126,6 +126,9 @@ class OrderMonoidHomClass (F : Type*) (α β : outParam <| Type*) [Preorder α] 
   monotone (f : F) : Monotone f
 #align order_monoid_hom_class OrderMonoidHomClass
 
+-- This is waiting on https://github.com/leanprover-community/mathlib4/issues/660
+attribute [to_additive existing] OrderMonoidHomClass.toMonoidHomClass
+
 end
 
 variable {_ : Preorder α} {_ : Preorder β} {_ : MulOneClass α} {_ : MulOneClass β}

--- a/Mathlib/Algebra/Order/Hom/Monoid.lean
+++ b/Mathlib/Algebra/Order/Hom/Monoid.lean
@@ -89,6 +89,9 @@ class OrderAddMonoidHomClass (F : Type*) (α β : outParam <| Type*) [Preorder �
   monotone (f : F) : Monotone f
 #align order_add_monoid_hom_class OrderAddMonoidHomClass
 
+-- lean4#2905
+attribute [-instance] OrderAddMonoidHomClass.toFunLike
+
 end
 
 -- Instances and lemmas are defined below through `@[to_additive]`.
@@ -125,6 +128,9 @@ class OrderMonoidHomClass (F : Type*) (α β : outParam <| Type*) [Preorder α] 
   /-- An `OrderMonoidHom` is a monotone function. -/
   monotone (f : F) : Monotone f
 #align order_monoid_hom_class OrderMonoidHomClass
+
+-- lean4#2905
+attribute [-instance] OrderMonoidHomClass.toFunLike
 
 -- This is waiting on https://github.com/leanprover-community/mathlib4/issues/660
 attribute [to_additive existing] OrderMonoidHomClass.toMonoidHomClass
@@ -191,6 +197,9 @@ class OrderMonoidWithZeroHomClass (F : Type*) (α β : outParam <| Type*) [Preor
   /-- An `OrderMonoidWithZeroHom` is a monotone function. -/
   monotone (f : F) : Monotone f
 #align order_monoid_with_zero_hom_class OrderMonoidWithZeroHomClass
+
+-- lean4#2905
+attribute [-instance] MonoidWithZeroHomClass.toFunLike
 
 /-- Turn an element of a type `F` satisfying `OrderMonoidWithZeroHomClass F α β` into an actual
 `OrderMonoidWithZeroHom`. This is declared as the default coercion from `F` to `α →+*₀o β`. -/

--- a/Mathlib/Algebra/Order/Hom/Monoid.lean
+++ b/Mathlib/Algebra/Order/Hom/Monoid.lean
@@ -84,7 +84,7 @@ section
 
 You should also extend this typeclass when you extend `OrderAddMonoidHom`. -/
 class OrderAddMonoidHomClass (F : Type*) (α β : outParam <| Type*) [Preorder α] [Preorder β]
-  [AddZeroClass α] [AddZeroClass β] extends AddMonoidHomClass F α β where
+  [AddZeroClass α] [AddZeroClass β] extends flat AddMonoidHomClass F α β where
   /-- An `OrderAddMonoidHom` is a monotone function. -/
   monotone (f : F) : Monotone f
 #align order_add_monoid_hom_class OrderAddMonoidHomClass
@@ -121,7 +121,7 @@ section
 You should also extend this typeclass when you extend `OrderMonoidHom`. -/
 @[to_additive]
 class OrderMonoidHomClass (F : Type*) (α β : outParam <| Type*) [Preorder α] [Preorder β]
-  [MulOneClass α] [MulOneClass β] extends MonoidHomClass F α β where
+  [MulOneClass α] [MulOneClass β] extends flat MonoidHomClass F α β where
   /-- An `OrderMonoidHom` is a monotone function. -/
   monotone (f : F) : Monotone f
 #align order_monoid_hom_class OrderMonoidHomClass
@@ -184,7 +184,7 @@ ordered monoid with zero homomorphisms.
 
 You should also extend this typeclass when you extend `OrderMonoidWithZeroHom`. -/
 class OrderMonoidWithZeroHomClass (F : Type*) (α β : outParam <| Type*) [Preorder α] [Preorder β]
-  [MulZeroOneClass α] [MulZeroOneClass β] extends MonoidWithZeroHomClass F α β where
+  [MulZeroOneClass α] [MulZeroOneClass β] extends flat MonoidWithZeroHomClass F α β where
   /-- An `OrderMonoidWithZeroHom` is a monotone function. -/
   monotone (f : F) : Monotone f
 #align order_monoid_with_zero_hom_class OrderMonoidWithZeroHomClass

--- a/Mathlib/Algebra/Order/Hom/Ring.lean
+++ b/Mathlib/Algebra/Order/Hom/Ring.lean
@@ -83,6 +83,9 @@ class OrderRingHomClass (F : Type*) (α β : outParam <| Type*) [NonAssocSemirin
   monotone (f : F) : Monotone f
 #align order_ring_hom_class OrderRingHomClass
 
+-- lean4#2905
+attribute [-instance] OrderRingHomClass.toFunLike
+
 /-- `OrderRingIsoClass F α β` states that `F` is a type of ordered semiring isomorphisms.
 You should extend this class when you extend `OrderRingIso`. -/
 class OrderRingIsoClass (F : Type*) (α β : outParam (Type*)) [Mul α] [Add α] [LE α] [Mul β]

--- a/Mathlib/Algebra/Order/Hom/Ring.lean
+++ b/Mathlib/Algebra/Order/Hom/Ring.lean
@@ -115,7 +115,8 @@ instance (priority := 100) OrderRingIsoClass.toOrderIsoClass [Mul α] [Add α] [
 instance (priority := 100) OrderRingIsoClass.toOrderRingHomClass [NonAssocSemiring α]
   [Preorder α] [NonAssocSemiring β] [Preorder β] [OrderRingIsoClass F α β] :
     OrderRingHomClass F α β :=
-  { monotone := fun f _ _ => (map_le_map_iff f).2
+  { RingEquivClass.toRingHomClass with
+    monotone := fun f _ _ => (map_le_map_iff f).2
     -- porting note: used to be the following which times out
     --‹OrderRingIsoClass F α β› with monotone := fun f => OrderHomClass.mono f
     }

--- a/Mathlib/Algebra/Order/Hom/Ring.lean
+++ b/Mathlib/Algebra/Order/Hom/Ring.lean
@@ -78,7 +78,7 @@ infixl:25 " ≃+*o " => OrderRingIso
 /-- `OrderRingHomClass F α β` states that `F` is a type of ordered semiring homomorphisms.
 You should extend this typeclass when you extend `OrderRingHom`. -/
 class OrderRingHomClass (F : Type*) (α β : outParam <| Type*) [NonAssocSemiring α] [Preorder α]
-  [NonAssocSemiring β] [Preorder β] extends RingHomClass F α β where
+  [NonAssocSemiring β] [Preorder β] extends flat RingHomClass F α β where
   /-- The proposition that the function preserves the order. -/
   monotone (f : F) : Monotone f
 #align order_ring_hom_class OrderRingHomClass

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -60,7 +60,7 @@ attribute [nolint docBlame] CentroidHom.toAddMonoidHom
 
 You should extend this class when you extend `CentroidHom`. -/
 class CentroidHomClass (F : Type*) (α : outParam <| Type*) [NonUnitalNonAssocSemiring α] extends
-  AddMonoidHomClass F α α where
+  flat AddMonoidHomClass F α α where
   /-- Commutativity of centroid homomorphims with left multiplication. -/
   map_mul_left (f : F) (a b : α) : f (a * b) = a * f b
   /-- Commutativity of centroid homomorphims with right multiplication. -/

--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -80,6 +80,9 @@ class NonUnitalRingHomClass (F : Type*) (α β : outParam (Type*)) [NonUnitalNon
   [NonUnitalNonAssocSemiring β] extends flat MulHomClass F α β, flat AddMonoidHomClass F α β
 #align non_unital_ring_hom_class NonUnitalRingHomClass
 
+-- lean4#2905
+attribute [-instance] NonUnitalRingHomClass.toFunLike
+
 variable [NonUnitalNonAssocSemiring α] [NonUnitalNonAssocSemiring β] [NonUnitalRingHomClass F α β]
 
 /-- Turn an element of a type `F` satisfying `NonUnitalRingHomClass F α β` into an actual
@@ -376,6 +379,9 @@ class RingHomClass (F : Type*) (α β : outParam (Type*)) [NonAssocSemiring α]
   [NonAssocSemiring β] extends flat MonoidHomClass F α β, flat AddMonoidHomClass F α β,
   MonoidWithZeroHomClass F α β
 #align ring_hom_class RingHomClass
+
+-- lean4#2905
+attribute [-instance] MonoidWithZeroHomClass.toFunLike
 
 set_option linter.deprecated false in
 /-- Ring homomorphisms preserve `bit1`. -/

--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -77,7 +77,7 @@ section NonUnitalRingHomClass
 /-- `NonUnitalRingHomClass F α β` states that `F` is a type of non-unital (semi)ring
 homomorphisms. You should extend this class when you extend `NonUnitalRingHom`. -/
 class NonUnitalRingHomClass (F : Type*) (α β : outParam (Type*)) [NonUnitalNonAssocSemiring α]
-  [NonUnitalNonAssocSemiring β] extends MulHomClass F α β, AddMonoidHomClass F α β
+  [NonUnitalNonAssocSemiring β] extends flat MulHomClass F α β, flat AddMonoidHomClass F α β
 #align non_unital_ring_hom_class NonUnitalRingHomClass
 
 variable [NonUnitalNonAssocSemiring α] [NonUnitalNonAssocSemiring β] [NonUnitalRingHomClass F α β]
@@ -373,7 +373,7 @@ This extends from both `MonoidHomClass` and `MonoidWithZeroHomClass` in
 order to put the fields in a sensible order, even though
 `MonoidWithZeroHomClass` already extends `MonoidHomClass`. -/
 class RingHomClass (F : Type*) (α β : outParam (Type*)) [NonAssocSemiring α]
-  [NonAssocSemiring β] extends MonoidHomClass F α β, AddMonoidHomClass F α β,
+  [NonAssocSemiring β] extends flat MonoidHomClass F α β, flat AddMonoidHomClass F α β,
   MonoidWithZeroHomClass F α β
 #align ring_hom_class RingHomClass
 

--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -322,6 +322,9 @@ class StarAlgHomClass (F : Type*) (R : outParam (Type*)) (A : outParam (Type*))
   [Algebra R B] [Star B] extends flat AlgHomClass F R A B, flat StarHomClass F A B
 #align star_alg_hom_class StarAlgHomClass
 
+-- lean4#2905
+attribute [-instance] StarAlgHomClass.toFunLike
+
 -- Porting note: no longer needed
 ---- `R` becomes a metavariable but that's fine because it's an `outParam`
 --attribute [nolint dangerousInstance] StarAlgHomClass.toStarHomClass

--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -69,7 +69,7 @@ homomorphisms from `A` to `B`. -/
 class NonUnitalStarAlgHomClass (F : Type*) (R : outParam (Type*)) (A : outParam (Type*))
   (B : outParam (Type*)) [Monoid R] [Star A] [Star B] [NonUnitalNonAssocSemiring A]
   [NonUnitalNonAssocSemiring B] [DistribMulAction R A] [DistribMulAction R B] extends
-  NonUnitalAlgHomClass F R A B, StarHomClass F A B
+  flat NonUnitalAlgHomClass F R A B, flat StarHomClass F A B
 #align non_unital_star_alg_hom_class NonUnitalStarAlgHomClass
 
 -- Porting note: no longer needed
@@ -319,7 +319,7 @@ add_decl_doc StarAlgHom.toAlgHom
 You should also extend this typeclass when you extend `StarAlgHom`. -/
 class StarAlgHomClass (F : Type*) (R : outParam (Type*)) (A : outParam (Type*))
   (B : outParam (Type*)) [CommSemiring R] [Semiring A] [Algebra R A] [Star A] [Semiring B]
-  [Algebra R B] [Star B] extends AlgHomClass F R A B, StarHomClass F A B
+  [Algebra R B] [Star B] extends flat AlgHomClass F R A B, flat StarHomClass F A B
 #align star_alg_hom_class StarAlgHomClass
 
 -- Porting note: no longer needed

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -83,7 +83,7 @@ structure CoolerHom (A B : Type*) [CoolClass A] [CoolClass B]
 (map_cool' : toFun CoolClass.cool = CoolClass.cool)
 
 class CoolerHomClass (F : Type*) (A B : outParam <| Type*) [CoolClass A] [CoolClass B]
-  extends MyHomClass F A B :=
+  extends flat MyHomClass F A B :=
 (map_cool : ∀ (f : F), f CoolClass.cool = CoolClass.cool)
 
 @[simp] lemma map_cool {F A B : Type*} [CoolClass A] [CoolClass B] [CoolerHomClass F A B]

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -223,6 +223,9 @@ class DistribMulActionHomClass (F : Type*) (M A B : outParam <| Type*) [Monoid M
   flat AddMonoidHomClass F A B
 #align distrib_mul_action_hom_class DistribMulActionHomClass
 
+-- lean4#2905
+attribute [-instance] DistribMulActionHomClass.toFunLike
+
 /- porting note: Removed a @[nolint dangerousInstance] for
 DistribMulActionHomClass.toAddMonoidHomClass not dangerous due to `outParam`s -/
 

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -219,8 +219,8 @@ the additive monoid structure and scalar multiplication by `M`.
 
 You should extend this class when you extend `DistribMulActionHom`. -/
 class DistribMulActionHomClass (F : Type*) (M A B : outParam <| Type*) [Monoid M] [AddMonoid A]
-  [AddMonoid B] [DistribMulAction M A] [DistribMulAction M B] extends SMulHomClass F M A B,
-  AddMonoidHomClass F A B
+  [AddMonoid B] [DistribMulAction M A] [DistribMulAction M B] extends flat SMulHomClass F M A B,
+  flat AddMonoidHomClass F A B
 #align distrib_mul_action_hom_class DistribMulActionHomClass
 
 /- porting note: Removed a @[nolint dangerousInstance] for
@@ -450,7 +450,7 @@ the ring structure and scalar multiplication by `M`.
 You should extend this class when you extend `MulSemiringActionHom`. -/
 class MulSemiringActionHomClass (F : Type*) (M R S : outParam <| Type*) [Monoid M] [Semiring R]
   [Semiring S] [DistribMulAction M R] [DistribMulAction M S] extends
-  DistribMulActionHomClass F M R S, RingHomClass F R S
+  flat DistribMulActionHomClass F M R S, flat RingHomClass F R S
 #align mul_semiring_action_hom_class MulSemiringActionHomClass
 
 /- porting note: Removed a @[nolint dangerousInstance] for MulSemiringActionHomClass.toRingHomClass

--- a/Mathlib/Order/Heyting/Hom.lean
+++ b/Mathlib/Order/Heyting/Hom.lean
@@ -75,6 +75,9 @@ class HeytingHomClass (F : Type*) (α β : outParam <| Type*) [HeytingAlgebra α
   map_himp (f : F) : ∀ a b, f (a ⇨ b) = f a ⇨ f b
 #align heyting_hom_class HeytingHomClass
 
+-- lean4#2905
+attribute [-instance] HeytingHomClass.toFunLike
+
 /-- `CoheytingHomClass F α β` states that `F` is a type of co-Heyting homomorphisms.
 
 You should extend this class when you extend `CoheytingHom`. -/
@@ -86,6 +89,9 @@ class CoheytingHomClass (F : Type*) (α β : outParam <| Type*) [CoheytingAlgebr
   map_sdiff (f : F) : ∀ a b, f (a \ b) = f a \ f b
 #align coheyting_hom_class CoheytingHomClass
 
+-- lean4#2905
+attribute [-instance] CoheytingHomClass.toFunLike
+
 /-- `BiheytingHomClass F α β` states that `F` is a type of bi-Heyting homomorphisms.
 
 You should extend this class when you extend `BiheytingHom`. -/
@@ -96,6 +102,9 @@ class BiheytingHomClass (F : Type*) (α β : outParam <| Type*) [BiheytingAlgebr
   /-- The proposition that a bi-Heyting homomorphism preserves the difference operation.-/
   map_sdiff (f : F) : ∀ a b, f (a \ b) = f a \ f b
 #align biheyting_hom_class BiheytingHomClass
+
+-- lean4#2905
+attribute [-instance] BiheytingHomClass.toFunLike
 
 export HeytingHomClass (map_himp)
 

--- a/Mathlib/Order/Heyting/Hom.lean
+++ b/Mathlib/Order/Heyting/Hom.lean
@@ -68,7 +68,7 @@ structure BiheytingHom (α β : Type*) [BiheytingAlgebra α] [BiheytingAlgebra �
 
 You should extend this class when you extend `HeytingHom`. -/
 class HeytingHomClass (F : Type*) (α β : outParam <| Type*) [HeytingAlgebra α]
-  [HeytingAlgebra β] extends LatticeHomClass F α β where
+  [HeytingAlgebra β] extends flat LatticeHomClass F α β where
   /-- The proposition that a Heyting homomorphism preserves the bottom element.-/
   map_bot (f : F) : f ⊥ = ⊥
   /-- The proposition that a Heyting homomorphism preserves the Heyting implication.-/
@@ -79,7 +79,7 @@ class HeytingHomClass (F : Type*) (α β : outParam <| Type*) [HeytingAlgebra α
 
 You should extend this class when you extend `CoheytingHom`. -/
 class CoheytingHomClass (F : Type*) (α β : outParam <| Type*) [CoheytingAlgebra α]
-  [CoheytingAlgebra β] extends LatticeHomClass F α β where
+  [CoheytingAlgebra β] extends flat LatticeHomClass F α β where
   /-- The proposition that a co-Heyting homomorphism preserves the top element.-/
   map_top (f : F) : f ⊤ = ⊤
   /-- The proposition that a co-Heyting homomorphism preserves the difference operation.-/
@@ -90,7 +90,7 @@ class CoheytingHomClass (F : Type*) (α β : outParam <| Type*) [CoheytingAlgebr
 
 You should extend this class when you extend `BiheytingHom`. -/
 class BiheytingHomClass (F : Type*) (α β : outParam <| Type*) [BiheytingAlgebra α]
-  [BiheytingAlgebra β] extends LatticeHomClass F α β where
+  [BiheytingAlgebra β] extends flat LatticeHomClass F α β where
   /-- The proposition that a bi-Heyting homomorphism preserves the Heyting implication.-/
   map_himp (f : F) : ∀ a b, f (a ⇨ b) = f a ⇨ f b
   /-- The proposition that a bi-Heyting homomorphism preserves the difference operation.-/

--- a/Mathlib/Order/Hom/Bounded.lean
+++ b/Mathlib/Order/Hom/Bounded.lean
@@ -83,7 +83,8 @@ class BotHomClass (F : Type*) (α β : outParam <| Type*) [Bot α] [Bot β] exte
 
 You should extend this class when you extend `BoundedOrderHom`. -/
 class BoundedOrderHomClass (F : Type*) (α β : outParam <| Type*) [LE α] [LE β] [BoundedOrder α]
-  [BoundedOrder β] extends flat RelHomClass F ((· ≤ ·) : α → α → Prop) ((· ≤ ·) : β → β → Prop) where
+    [BoundedOrder β]
+    extends flat RelHomClass F ((· ≤ ·) : α → α → Prop) ((· ≤ ·) : β → β → Prop) where
   /-- Morphisms preserve the top element. The preferred spelling is `_root_.map_top`. -/
   map_top (f : F) : f ⊤ = ⊤
   /-- Morphisms preserve the bottom element. The preferred spelling is `_root_.map_bot`. -/

--- a/Mathlib/Order/Hom/Bounded.lean
+++ b/Mathlib/Order/Hom/Bounded.lean
@@ -91,6 +91,9 @@ class BoundedOrderHomClass (F : Type*) (α β : outParam <| Type*) [LE α] [LE �
   map_bot (f : F) : f ⊥ = ⊥
 #align bounded_order_hom_class BoundedOrderHomClass
 
+-- lean4#2905
+attribute [-instance] BoundedOrderHomClass.toFunLike
+
 end
 
 export TopHomClass (map_top)

--- a/Mathlib/Order/Hom/Bounded.lean
+++ b/Mathlib/Order/Hom/Bounded.lean
@@ -83,7 +83,7 @@ class BotHomClass (F : Type*) (α β : outParam <| Type*) [Bot α] [Bot β] exte
 
 You should extend this class when you extend `BoundedOrderHom`. -/
 class BoundedOrderHomClass (F : Type*) (α β : outParam <| Type*) [LE α] [LE β] [BoundedOrder α]
-  [BoundedOrder β] extends RelHomClass F ((· ≤ ·) : α → α → Prop) ((· ≤ ·) : β → β → Prop) where
+  [BoundedOrder β] extends flat RelHomClass F ((· ≤ ·) : α → α → Prop) ((· ≤ ·) : β → β → Prop) where
   /-- Morphisms preserve the top element. The preferred spelling is `_root_.map_top`. -/
   map_top (f : F) : f ⊤ = ⊤
   /-- Morphisms preserve the bottom element. The preferred spelling is `_root_.map_bot`. -/

--- a/Mathlib/Order/Hom/CompleteLattice.lean
+++ b/Mathlib/Order/Hom/CompleteLattice.lean
@@ -107,6 +107,9 @@ class FrameHomClass (F : Type*) (α β : outParam <| Type*) [CompleteLattice α]
   map_sSup (f : F) (s : Set α) : f (sSup s) = sSup (f '' s)
 #align frame_hom_class FrameHomClass
 
+-- lean4#2905
+attribute [-instance] FrameHomClass.toFunLike
+
 /-- `CompleteLatticeHomClass F α β` states that `F` is a type of complete lattice morphisms.
 
 You should extend this class when you extend `CompleteLatticeHom`. -/
@@ -116,6 +119,9 @@ class CompleteLatticeHomClass (F : Type*) (α β : outParam <| Type*) [CompleteL
   suprema/joins. -/
   map_sSup (f : F) (s : Set α) : f (sSup s) = sSup (f '' s)
 #align complete_lattice_hom_class CompleteLatticeHomClass
+
+-- lean4#2905
+attribute [-instance] CompleteLatticeHomClass.toFunLike
 
 end
 

--- a/Mathlib/Order/Hom/CompleteLattice.lean
+++ b/Mathlib/Order/Hom/CompleteLattice.lean
@@ -102,7 +102,7 @@ class sInfHomClass (F : Type*) (α β : outParam <| Type*) [InfSet α] [InfSet �
 
 You should extend this class when you extend `FrameHom`. -/
 class FrameHomClass (F : Type*) (α β : outParam <| Type*) [CompleteLattice α]
-  [CompleteLattice β] extends InfTopHomClass F α β where
+  [CompleteLattice β] extends flat InfTopHomClass F α β where
   /-- The proposition that members of `FrameHomClass` commute with arbitrary suprema/joins. -/
   map_sSup (f : F) (s : Set α) : f (sSup s) = sSup (f '' s)
 #align frame_hom_class FrameHomClass
@@ -111,7 +111,7 @@ class FrameHomClass (F : Type*) (α β : outParam <| Type*) [CompleteLattice α]
 
 You should extend this class when you extend `CompleteLatticeHom`. -/
 class CompleteLatticeHomClass (F : Type*) (α β : outParam <| Type*) [CompleteLattice α]
-  [CompleteLattice β] extends sInfHomClass F α β where
+  [CompleteLattice β] extends flat sInfHomClass F α β where
   /-- The proposition that members of `CompleteLatticeHomClass` commute with arbitrary
   suprema/joins. -/
   map_sSup (f : F) (s : Set α) : f (sSup s) = sSup (f '' s)

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -123,6 +123,9 @@ class SupBotHomClass (F : Type*) (α β : outParam <| Type*) [Sup α] [Sup β] [
   map_bot (f : F) : f ⊥ = ⊥
 #align sup_bot_hom_class SupBotHomClass
 
+-- lean4#2905
+attribute [-instance] SupBotHomClass.toFunLike
+
 /-- `InfTopHomClass F α β` states that `F` is a type of finitary infimum-preserving morphisms.
 
 You should extend this class when you extend `SupBotHom`. -/
@@ -132,6 +135,9 @@ class InfTopHomClass (F : Type*) (α β : outParam <| Type*) [Inf α] [Inf β] [
   map_top (f : F) : f ⊤ = ⊤
 #align inf_top_hom_class InfTopHomClass
 
+-- lean4#2905
+attribute [-instance] InfTopHomClass.toFunLike
+
 /-- `LatticeHomClass F α β` states that `F` is a type of lattice morphisms.
 
 You should extend this class when you extend `LatticeHom`. -/
@@ -140,6 +146,8 @@ class LatticeHomClass (F : Type*) (α β : outParam <| Type*) [Lattice α] [Latt
   /-- A `LatticeHomClass` morphism preserves infima. -/
   map_inf (f : F) (a b : α) : f (a ⊓ b) = f a ⊓ f b
 #align lattice_hom_class LatticeHomClass
+
+attribute [-instance] LatticeHomClass.toFunLike
 
 /-- `BoundedLatticeHomClass F α β` states that `F` is a type of bounded lattice morphisms.
 

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -118,7 +118,7 @@ class InfHomClass (F : Type*) (α β : outParam <| Type*) [Inf α] [Inf β] exte
 
 You should extend this class when you extend `SupBotHom`. -/
 class SupBotHomClass (F : Type*) (α β : outParam <| Type*) [Sup α] [Sup β] [Bot α]
-  [Bot β] extends SupHomClass F α β where
+  [Bot β] extends flat SupHomClass F α β where
   /-- A `SupBotHomClass` morphism preserves the bottom element. -/
   map_bot (f : F) : f ⊥ = ⊥
 #align sup_bot_hom_class SupBotHomClass
@@ -127,7 +127,7 @@ class SupBotHomClass (F : Type*) (α β : outParam <| Type*) [Sup α] [Sup β] [
 
 You should extend this class when you extend `SupBotHom`. -/
 class InfTopHomClass (F : Type*) (α β : outParam <| Type*) [Inf α] [Inf β] [Top α]
-  [Top β] extends InfHomClass F α β where
+  [Top β] extends flat InfHomClass F α β where
   /-- An `InfTopHomClass` morphism preserves the top element. -/
   map_top (f : F) : f ⊤ = ⊤
 #align inf_top_hom_class InfTopHomClass
@@ -136,7 +136,7 @@ class InfTopHomClass (F : Type*) (α β : outParam <| Type*) [Inf α] [Inf β] [
 
 You should extend this class when you extend `LatticeHom`. -/
 class LatticeHomClass (F : Type*) (α β : outParam <| Type*) [Lattice α] [Lattice β] extends
-  SupHomClass F α β where
+  flat SupHomClass F α β where
   /-- A `LatticeHomClass` morphism preserves infima. -/
   map_inf (f : F) (a b : α) : f (a ⊓ b) = f a ⊓ f b
 #align lattice_hom_class LatticeHomClass
@@ -145,7 +145,7 @@ class LatticeHomClass (F : Type*) (α β : outParam <| Type*) [Lattice α] [Latt
 
 You should extend this class when you extend `BoundedLatticeHom`. -/
 class BoundedLatticeHomClass (F : Type*) (α β : outParam <| Type*) [Lattice α] [Lattice β]
-  [BoundedOrder α] [BoundedOrder β] extends LatticeHomClass F α β where
+  [BoundedOrder α] [BoundedOrder β] extends flat LatticeHomClass F α β where
   /-- A `BoundedLatticeHomClass` morphism preserves the top element. -/
   map_top (f : F) : f ⊤ = ⊤
   /-- A `BoundedLatticeHomClass` morphism preserves the bottom element. -/

--- a/Mathlib/RingTheory/Jacobson.lean
+++ b/Mathlib/RingTheory/Jacobson.lean
@@ -448,7 +448,7 @@ theorem isJacobson_polynomial_of_isJacobson (hR : IsJacobson R) : IsJacobson R[X
   let J := map (mapRingHom i) I
   -- Porting note: moved ↓ this up a few lines, so that it can be used in the `have`
   have h_surj : Function.Surjective (mapRingHom i) := Polynomial.map_surjective i hi
-  have : IsPrime J := map_isPrime_of_surjective h_surj hi'
+  have : IsPrime J := (map_isPrime_of_surjective (f := mapRingHom i) :) h_surj hi'
   suffices h : J.jacobson = J
   · replace h := congrArg (comap (Polynomial.mapRingHom i)) h
     rw [← map_jacobson_of_surjective h_surj hi', comap_map_of_surjective _ h_surj,

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -76,6 +76,9 @@ class ContinuousMonoidHomClass (A B : outParam (Type*)) [Monoid A] [Monoid B]
   map_continuous (f : F) : Continuous f
 #align continuous_monoid_hom_class ContinuousMonoidHomClass
 
+-- This is waiting on https://github.com/leanprover-community/mathlib4/issues/660
+attribute [to_additive existing] ContinuousMonoidHomClass.toMonoidHomClass
+
 end
 
 /-- Reinterpret a `ContinuousMonoidHom` as a `MonoidHom`. -/

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -64,6 +64,9 @@ class ContinuousAddMonoidHomClass (A B : outParam (Type*)) [AddMonoid A] [AddMon
   map_continuous (f : F) : Continuous f
 #align continuous_add_monoid_hom_class ContinuousAddMonoidHomClass
 
+-- lean4#2905
+attribute [-instance] ContinuousAddMonoidHomClass.toFunLike
+
 /-- `ContinuousMonoidHomClass F A B` states that `F` is a type of continuous additive monoid
 homomorphisms.
 
@@ -75,6 +78,9 @@ class ContinuousMonoidHomClass (A B : outParam (Type*)) [Monoid A] [Monoid B]
   /-- Proof of the continuity of the map. -/
   map_continuous (f : F) : Continuous f
 #align continuous_monoid_hom_class ContinuousMonoidHomClass
+
+-- lean4#2905
+attribute [-instance] ContinuousMonoidHomClass.toFunLike
 
 -- This is waiting on https://github.com/leanprover-community/mathlib4/issues/660
 attribute [to_additive existing] ContinuousMonoidHomClass.toMonoidHomClass

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -59,7 +59,7 @@ homomorphisms.
 You should also extend this typeclass when you extend `ContinuousAddMonoidHom`. -/
 -- porting note : Changed A B to outParam to help synthesizing order
 class ContinuousAddMonoidHomClass (A B : outParam (Type*)) [AddMonoid A] [AddMonoid B]
-  [TopologicalSpace A] [TopologicalSpace B] extends AddMonoidHomClass F A B where
+  [TopologicalSpace A] [TopologicalSpace B] extends flat AddMonoidHomClass F A B where
   /-- Proof of the continuity of the map. -/
   map_continuous (f : F) : Continuous f
 #align continuous_add_monoid_hom_class ContinuousAddMonoidHomClass
@@ -71,7 +71,7 @@ You should also extend this typeclass when you extend `ContinuousMonoidHom`. -/
 -- porting note : Changed A B to outParam to help synthesizing order
 @[to_additive]
 class ContinuousMonoidHomClass (A B : outParam (Type*)) [Monoid A] [Monoid B]
-    [TopologicalSpace A] [TopologicalSpace B] extends MonoidHomClass F A B where
+    [TopologicalSpace A] [TopologicalSpace B] extends flat MonoidHomClass F A B where
   /-- Proof of the continuity of the map. -/
   map_continuous (f : F) : Continuous f
 #align continuous_monoid_hom_class ContinuousMonoidHomClass

--- a/Mathlib/Topology/Order/Hom/Basic.lean
+++ b/Mathlib/Topology/Order/Hom/Basic.lean
@@ -49,7 +49,7 @@ section
 You should extend this class when you extend `ContinuousOrderHom`. -/
 class ContinuousOrderHomClass (F : Type*) (α β : outParam <| Type*) [Preorder α] [Preorder β]
     [TopologicalSpace α] [TopologicalSpace β] extends
-    ContinuousMapClass F α β where
+    flat ContinuousMapClass F α β where
   map_monotone (f : F) : Monotone f
 #align continuous_order_hom_class ContinuousOrderHomClass
 

--- a/Mathlib/Topology/Order/Hom/Esakia.lean
+++ b/Mathlib/Topology/Order/Hom/Esakia.lean
@@ -66,6 +66,9 @@ class EsakiaHomClass (F : Type*) (α β : outParam <| Type*) [TopologicalSpace �
   exists_map_eq_of_map_le (f : F) ⦃a : α⦄ ⦃b : β⦄ : f a ≤ b → ∃ c, a ≤ c ∧ f c = b
 #align esakia_hom_class EsakiaHomClass
 
+-- lean4#2905
+attribute [-instance] EsakiaHomClass.toFunLike
+
 end
 
 export PseudoEpimorphismClass (exists_map_eq_of_map_le)

--- a/Mathlib/Topology/Order/Hom/Esakia.lean
+++ b/Mathlib/Topology/Order/Hom/Esakia.lean
@@ -62,7 +62,7 @@ class PseudoEpimorphismClass (F : Type*) (α β : outParam <| Type*) [Preorder �
 
 You should extend this class when you extend `EsakiaHom`. -/
 class EsakiaHomClass (F : Type*) (α β : outParam <| Type*) [TopologicalSpace α] [Preorder α]
-    [TopologicalSpace β] [Preorder β] extends ContinuousOrderHomClass F α β where
+    [TopologicalSpace β] [Preorder β] extends flat ContinuousOrderHomClass F α β where
   exists_map_eq_of_map_le (f : F) ⦃a : α⦄ ⦃b : β⦄ : f a ≤ b → ∃ c, a ≤ c ∧ f c = b
 #align esakia_hom_class EsakiaHomClass
 


### PR DESCRIPTION
I expect that [lean4#2905](https://github.com/leanprover/lean4/pull/2905) will cause this to have worse performance.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [ ] depends on: #8977

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
