### PR TITLE
[Merged by Bors] - feat: `AddCommGroup` is `ZMod n` module if `n • x = 0` for all `x`

### DIFF
--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -18,10 +18,10 @@ namespace ZMod
 /-- The `ZMod n`-module structure on Abelian groups whose elements have order dividing `n`.
 See note [reducible non-instances]. -/
 @[reducible]
-def module {n : ℕ} {G : Type*} [AddCommGroup G] (h : ∀ (x : G), n • x = 0) : Module (ZMod n) G := by
+def module {G : Type*} [AddCommGroup G] (h : ∀ (x : G), n • x = 0) : Module (ZMod n) G := by
   have h_mod (c : ℕ) (x : G) : (c % n) • x = c • x := by
-    apply add_right_cancel (b := ((c / n) * n) • x)
-    rw [← add_nsmul, mul_nsmul, h, add_zero, Nat.mod_add_div']
+    apply add_right_cancel (b := (c / n * n) • x)
+    rw [← add_nsmul, Nat.mod_add_div', mul_nsmul, h, add_zero]
   exact match n with
   | 0 => AddCommGroup.intModule G
   | n + 1 => {

--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -18,12 +18,12 @@ namespace ZMod
 /-- The `ZMod n`-module structure on Abelian groups whose elements have order dividing `n`.
 See note [reducible non-instances]. -/
 @[reducible]
-def module {n : ℕ} {M : Type*} [AddCommGroup M] (h : ∀ (x : M), n • x = 0) : Module (ZMod n) M := by
-  have h_mod (c : ℕ) (x : M) : (c % n) • x = c • x := by
+def module {n : ℕ} {G : Type*} [AddCommGroup G] (h : ∀ (x : G), n • x = 0) : Module (ZMod n) G := by
+  have h_mod (c : ℕ) (x : G) : (c % n) • x = c • x := by
     apply add_right_cancel (b := ((c / n) * n) • x)
     rw [← add_nsmul, mul_nsmul, h, add_zero, Nat.mod_add_div']
   exact match n with
-  | 0 => AddCommGroup.intModule M
+  | 0 => AddCommGroup.intModule G
   | n + 1 => {
       smul := fun (c : Fin (n + 1)) x ↦ c.val • x
       smul_zero := fun _ ↦ nsmul_zero _

--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -15,6 +15,8 @@ variable {n : ℕ} {M M₁ : Type*} [AddCommGroup M] [AddCommGroup M₁]
 
 namespace ZMod
 
+/-- The `ZMod n`-module structure on Abelian groups whose elements have order dividing `n`.
+See note [reducible non-instances]. -/
 @[reducible]
 def module {n : ℕ} {M : Type*} [AddCommGroup M] (h : ∀ (x : M), n • x = 0) : Module (ZMod n) M := by
   have h_mod (c : ℕ) (x : M) : (c % n) • x = c • x := by

--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -16,7 +16,7 @@ variable {n : ℕ} {M M₁ : Type*}
 Also implies a group structure via `Module.addCommMonoidToAddCommGroup`.
 See note [reducible non-instances]. -/
 @[reducible]
-def AddCommMonoid.ZModModule [NeZero n] [AddCommMonoid M] (h : ∀ (x : M), n • x = 0) :
+def AddCommMonoid.zmodModule [NeZero n] [AddCommMonoid M] (h : ∀ (x : M), n • x = 0) :
     Module (ZMod n) M := by
   have h_mod (c : ℕ) (x : M) : (c % n) • x = c • x := by
     suffices (c % n + c / n * n) • x = c • x by rwa [add_nsmul, mul_nsmul, h, add_zero] at this
@@ -35,11 +35,11 @@ def AddCommMonoid.ZModModule [NeZero n] [AddCommMonoid M] (h : ∀ (x : M), n �
 /-- The `ZMod n`-module structure on Abelian groups whose elements have order dividing `n`.
 See note [reducible non-instances]. -/
 @[reducible]
-def AddCommGroup.ZModModule {G : Type*} [AddCommGroup G] (h : ∀ (x : G), n • x = 0) :
+def AddCommGroup.zmodModule {G : Type*} [AddCommGroup G] (h : ∀ (x : G), n • x = 0) :
     Module (ZMod n) G :=
   match n with
   | 0 => AddCommGroup.intModule G
-  | _ + 1 => AddCommMonoid.ZModModule h
+  | _ + 1 => AddCommMonoid.zmodModule h
 
 variable {F S : Type*} [AddCommGroup M] [AddCommGroup M₁] [AddMonoidHomClass F M M₁]
   [Module (ZMod n) M] [Module (ZMod n) M₁] [SetLike S M] [AddSubgroupClass S M] {x : M} {K : S}

--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -15,6 +15,23 @@ variable {n : ℕ} {M M₁ : Type*} [AddCommGroup M] [AddCommGroup M₁]
 
 namespace ZMod
 
+@[reducible]
+def module {n : ℕ} {M : Type*} [AddCommGroup M] (h : ∀ (x : M), n • x = 0) : Module (ZMod n) M := by
+  have h_mod (c : ℕ) (x : M) : (c % n) • x = c • x := by
+    apply add_right_cancel (b := ((c / n) * n) • x)
+    rw [← add_nsmul, mul_nsmul, h, add_zero, Nat.mod_add_div']
+  exact match n with
+  | 0 => AddCommGroup.intModule M
+  | n + 1 => {
+      smul := fun (c : Fin (n + 1)) x ↦ c.val • x
+      smul_zero := fun _ ↦ nsmul_zero _
+      zero_smul := fun _ ↦ zero_nsmul _
+      smul_add := fun _ _ _ ↦ nsmul_add _ _ _
+      one_smul := fun _ ↦ (h_mod _ _).trans <| one_nsmul _
+      add_smul := fun _ _ _ ↦ (h_mod _ _).trans <| add_nsmul _ _ _
+      mul_smul := fun _ _ _ ↦ (h_mod _ _).trans <| mul_nsmul' _ _ _
+    }
+
 theorem map_smul (f : M →+ M₁) (c : ZMod n) (x : M) : f (c • x) = c • f x := by
   cases n with
   | zero => exact map_int_cast_smul f _ _ c x


### PR DESCRIPTION
Generalization of content from PFR for doing linear algebra over $C_2^n$.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
