### PR TITLE
chore (Pi.Algebra): Change a binder from instance implicit to implicit 

### DIFF
--- a/Mathlib/Data/Pi/Algebra.lean
+++ b/Mathlib/Data/Pi/Algebra.lean
@@ -114,7 +114,7 @@ instance instPow [∀ i, Pow (f i) β] : Pow (∀ i, f i) β :=
   ⟨fun x b i => x i ^ b⟩
 
 @[to_additive (attr := simp, to_additive) (reorder := 5 6) smul_apply]
-theorem pow_apply [∀ i, Pow (f i) β] (x : ∀ i, f i) (b : β) (i : I) : (x ^ b) i = x i ^ b :=
+theorem pow_apply {_ : ∀ i, Pow (f i) β} (x : ∀ i, f i) (b : β) (i : I) : (x ^ b) i = x i ^ b :=
   rfl
 #align pi.pow_apply Pi.pow_apply
 #align pi.smul_apply Pi.smul_apply


### PR DESCRIPTION
Following @kmill's suggestion on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Simp.20claims.20not.20defeq.20but.20rfl.20works/near/407603153), we change the instance implicit binder on the troublesome `Pi.smul_apply` to implicit.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
