### PR TITLE
[Merged by Bors] - fix: renable some slim check tests and make them pass

### DIFF
--- a/Mathlib/Tactic/SlimCheck.lean
+++ b/Mathlib/Tactic/SlimCheck.lean
@@ -168,7 +168,7 @@ elab_rules : tactic | `(tactic| slim_check $[$cfg]?) => withMainContext do
   let cfg ← elabConfig (mkOptionalNode cfg)
   let (_, g) ← (← getMainGoal).revert ((← getLocalHyps).map (Expr.fvarId!))
   let tgt ← g.getType
-  let tgt' := addDecorations tgt
+  let tgt' ← addDecorations tgt
   let cfg := { cfg with
     traceDiscarded := cfg.traceDiscarded || (← isTracingEnabledFor `slim_check.discarded),
     traceSuccesses := cfg.traceSuccesses || (← isTracingEnabledFor `slim_check.success),

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -509,14 +509,14 @@ open Lean
 quantifiers and add `NamedBinder` annotations next to them. -/
 partial def addDecorations (e : Expr) : MetaM Expr :=
   Meta.transform e $ fun expr => do
-    if not (←Meta.inferType e).isProp then
+    if not (← Meta.inferType e).isProp then
       return .continue
     else if let Expr.forallE name type body data := expr then
       let n := name.toString
       let newType ← addDecorations type
       let newBody ← addDecorations body
       let rest := Expr.forallE name newType newBody data
-      return .done $ (←Meta.mkAppM `SlimCheck.NamedBinder #[mkStrLit n, rest])
+      return .done $ (← Meta.mkAppM `SlimCheck.NamedBinder #[mkStrLit n, rest])
     else
       return .continue
 

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -388,6 +388,20 @@ where
     let finalR := addInfo s!"{var} is irrelevant (unused)" id r
     pure $ imp (· $ Classical.ofNonempty) finalR (PSum.inr $ λ x _ => x)
 
+instance (priority := 2000) subtypeVarTestable {p : α → Prop} {β : α → Prop}
+    [∀ x, PrintableProp (p x)]
+    [∀ x, Testable (β x)]
+    [SampleableExt (Subtype p)] {var'} :
+    Testable (NamedBinder var $ Π x : α, NamedBinder var' $ p x → β x) where
+  run cfg min :=
+    letI (x : Subtype p) : Testable (β x) :=
+      { run := fun cfg min => do
+          let r ← Testable.runProp (β x.val) cfg min
+          pure $ addInfo s!"guard: {printProp (p x)} (by construction)" id r (PSum.inr id) }
+    do
+      let r ← @Testable.run (∀ x : Subtype p, β x.val) (@varTestable var _ _ _ _) cfg min
+      pure $ iff Subtype.forall' r
+
 instance (priority := low) decidableTestable {p : Prop} [PrintableProp p] [Decidable p] :
     Testable p where
   run := λ _ _ =>
@@ -493,16 +507,18 @@ open Lean
 
 /-- Traverse the syntax of a proposition to find universal quantifiers
 quantifiers and add `NamedBinder` annotations next to them. -/
-partial def addDecorations (e : Expr) : Expr :=
-  e.replace $ λ expr =>
-    match expr with
-    | Expr.forallE name type body data =>
+partial def addDecorations (e : Expr) : MetaM Expr :=
+  Meta.transform e $ fun expr => do
+    if not (←Meta.inferType e).isProp then
+      return .continue
+    else if let Expr.forallE name type body data := expr then
       let n := name.toString
-      let newType := addDecorations type
-      let newBody := addDecorations body
+      let newType ← addDecorations type
+      let newBody ← addDecorations body
       let rest := Expr.forallE name newType newBody data
-      some $ mkApp2 (mkConst `SlimCheck.NamedBinder) (mkStrLit n) rest
-    | _ => none
+      return .done $ (←Meta.mkAppM `SlimCheck.NamedBinder #[mkStrLit n, rest])
+    else
+      return .continue
 
 /-- `DecorationsOf p` is used as a hint to `mk_decorations` to specify
 that the goal should be satisfied with a proposition equivalent to `p`
@@ -527,7 +543,7 @@ scoped elab "mk_decorations" : tactic => do
   let goal ← getMainGoal
   let goalType ← goal.getType
   if let .app (.const ``Decorations.DecorationsOf _) body := goalType then
-    closeMainGoal (addDecorations body)
+    closeMainGoal (← addDecorations body)
 
 end Decorations
 

--- a/test/slim_check.lean
+++ b/test/slim_check.lean
@@ -2,6 +2,7 @@ import Mathlib.Tactic.SlimCheck
 import Mathlib.Tactic.SuccessIfFailWithMsg
 import Mathlib.Data.Finsupp.Basic
 import Mathlib.Data.DFinsupp.Basic
+import Mathlib.Testing.SlimCheck.Functions
 
 -- Porting note:
 -- These are the tests from mathlib3, updated to Lean 4 syntax.
@@ -74,23 +75,22 @@ issue: 1 < 0 does not hold
 --   admit
 --   trivial
 
--- example (α : Type) (xs ys : List α) : true := by
---   have : xs ++ ys = ys ++ xs
---   success_if_fail_with_msg
---     "
--- ===================
--- Found problems!
-
--- α := ℤ
--- xs := [0]
--- ys := [1]
--- issue: [0, 1] = [1, 0] does not hold
--- (4 shrinks)
--- -------------------
--- "
---     slim_check (config := { randomSeed := some 257 })
---   admit
---   trivial
+example (α : Type) (xs ys : List α) : true := by
+  have : xs ++ ys = ys ++ xs
+  success_if_fail_with_msg
+    "
+===================
+Found problems!
+α := \"ℤ\"
+xs := [0]
+ys := [1]
+issue: [0, 1] = [1, 0] does not hold
+(4 shrinks)
+-------------------
+"
+    slim_check (config := { randomSeed := some 257 })
+  admit
+  trivial
 
 example : true := by
   have _this : ∀ x ∈ [1,2,3], x < 4
@@ -131,99 +131,97 @@ open Function SlimCheck
 --   admit
 --   trivial
 
--- example (f : ℤ → ℤ) (h : Injective f) (g : ℤ → ℤ) (h : Injective g) (i) : true := by
---   have : f i = g i
---   success_if_fail_with_msg
--- "
--- ===================
--- Found problems!
+example (f : ℤ → ℤ) (h : Injective f) (g : ℤ → ℤ) (h : Injective g) (i : ℤ) : true := by
+  have : f i = g i
+  success_if_fail_with_msg
+"
+===================
+Found problems!
+f := [x ↦ x]
+guard: ⋯ (by construction)
+g := [-2 ↦ 0, 0 ↦ -2, x ↦ x]
+guard: ⋯ (by construction)
+i := 0
+issue: 0 = -2 does not hold
+(3 shrinks)
+-------------------
+"
+    slim_check (config := { randomSeed := some 257 })
+  admit
+  trivial
 
--- f := [x ↦ x]
--- g := [1 ↦ 2, 2 ↦ 1, x ↦ x]
--- i := 1
--- issue: 1 = 2 does not hold
--- (5 shrinks)
--- -------------------
--- "
---     slim_check (config := { randomSeed := some 257 })
---   admit
---   trivial
+example (f : ℤ → ℤ) (h : Injective f) : true := by
+  have : Monotone f
+  success_if_fail_with_msg
+    "
+===================
+Found problems!
+f := [-1 ↦ -1, 0 ↦ 0, 1 ↦ 7, 2 ↦ 2, 3 ↦ 1, 4 ↦ 3, 5 ↦ 5, 6 ↦ 6, 7 ↦ 8, 8 ↦ 4, x ↦ x]
+guard: ⋯ (by construction)
+x := 1
+y := 3
+guard: ⋯
+issue: 7 ≤ 1 does not hold
+(4 shrinks)
+-------------------
+"
+    slim_check (config := { randomSeed := some 257 })
+  admit
+  trivial
 
--- example (f : ℤ → ℤ) (h : Injective f) : true := by
---   have : Monotone f
---   success_if_fail_with_msg
---     "
--- ===================
--- Found problems!
+example (f : ℤ → ℤ) : true := by
+  have : Injective f
+  success_if_fail_with_msg
+    "
+===================
+Found problems!
+f := [_ ↦ 0]
+x := 0
+y := 1
+guard: 0 = 0
+issue: 0 = 1 does not hold
+(3 shrinks)
+-------------------
+"
+    slim_check (config := { randomSeed := some 257 })
+  admit
+  trivial
 
--- f := [2 ↦ 3, 3 ↦ 9, 4 ↦ 6, 5 ↦ 4, 6 ↦ 2, 8 ↦ 5, 9 ↦ 8, x ↦ x]
--- x := 3
--- y := 4
--- guard: 3 ≤ 4 (by construction)
--- issue: 9 ≤ 6 does not hold
--- (5 shrinks)
--- -------------------
--- "
---     slim_check (config := { randomSeed := some 257 })
---   admit
---   trivial
+example (f : ℤ → ℤ) : true := by
+  have : Monotone f
+  success_if_fail_with_msg
+    "
+===================
+Found problems!
+f := [-3 ↦ 0, -4 ↦ -1, 4 ↦ 3, _ ↦ -2]
+x := -4
+y := 1
+guard: ⋯
+issue: -1 ≤ -2 does not hold
+(2 shrinks)
+-------------------
+"
+    slim_check (config := { randomSeed := some 257 })
+  admit
+  trivial
 
--- example (f : ℤ → ℤ) : true := by
---   have : Injective f
---   success_if_fail_with_msg
---     "
--- ===================
--- Found problems!
-
--- f := [_ ↦ 0]
--- x := 0
--- y := -1
--- guard: 0 = 0
--- issue: 0 = -1 does not hold
--- (0 shrinks)
--- -------------------
--- "
---     slim_check (config := { randomSeed := some 257 })
---   admit
---   trivial
-
--- example (f : ℤ → ℤ) : true := by
---   have : Monotone f
---   success_if_fail_with_msg
---     "
--- ===================
--- Found problems!
-
--- f := [-6 ↦ 97, 0 ↦ 0, _ ↦ 4]
--- x := -6
--- y := -2
--- guard: -6 ≤ -2 (by construction)
--- issue: 97 ≤ 4 does not hold
--- (5 shrinks)
--- -------------------
--- "
---     slim_check (config := { randomSeed := some 257 })
---   admit
---   trivial
-
--- Porting note: In Lean 4, we have Array.qsort, not List.qsort, so this test will need modifying.
--- example (xs ys : List ℤ) (h : xs ~ ys) : true := by
---   have : List.qsort (fun x y => x ≠ y) xs = List.qsort (fun x y => x ≠ y) ys
---   success_if_fail_with_msg
---     "
--- ===================
--- Found problems!
-
--- xs := [0, 1]
--- ys := [1, 0]
--- guard: [0, 1] ~ [1, 0] (by construction)
--- issue: [0, 1] = [1, 0] does not hold
--- (4 shrinks)
--- -------------------
--- "
---     slim_check (config := { randomSeed := some 257 })
---   admit
---   trivial
+open scoped List in
+example (xs ys : List ℤ) (h : xs ~ ys) : true := by
+  have : Array.qsort ⟨xs⟩ (fun x y => x != y) = Array.qsort ⟨ys⟩ (fun x y => x != y)
+  success_if_fail_with_msg
+    "
+===================
+Found problems!
+xs := [-2, -1]
+ys := [-1, -2]
+guard: ⋯
+issue: #[-2, -1] = #[-1, -2] does not hold
+(0 shrinks)
+-------------------
+"
+    slim_check (config := { randomSeed := some 257, maxSize := 3, numRetries := 1 })
+  admit
+  trivial
 
 example (x y : ℕ) : true := by
   have : y ≤ x → x + y < 100
@@ -300,7 +298,7 @@ example (x y : Prop) : true := by
 Found problems!
 x := true
 y := false
-guard: true ≠ true ↔ false
+guard: ¬true ↔ false
 issue: false does not hold
 (0 shrinks)
 -------------------
@@ -363,33 +361,35 @@ issue: true ≠ true does not hold
   admit
   trivial
 
--- example (f : ℕ →₀ ℕ) : true := by
---   have : f = 0
---   success_if_fail_with_msg
---     "
--- ===================
--- Found problems!
+-- TODO: fails without this line!
+attribute [-instance] Finsupp.instReprFinsupp in
 
--- f := [0 ↦ 1, _ ↦ 0]
--- issue: finsupp.single 0 1 = 0 does not hold
--- (2 shrinks)
--- -------------------
--- "
---     slim_check (config := { randomSeed := some 257 })
---   admit
---   trivial
+example (f : ℕ →₀ ℕ) : true := by
+  have : f = 0
+  success_if_fail_with_msg
+    "
+===================
+Found problems!
+f := [2 ↦ 1, _ ↦ 0]
+issue: ⋯ does not hold
+(3 shrinks)
+-------------------
+"
+    slim_check (config := { randomSeed := some 257 })
+  admit
+  trivial
 
--- example (f : Π₀ n : ℕ, ℕ) : true := by
---   have : f.update 0 0 = 0
---   success_if_fail_with_msg
---     "
--- ===================
--- Found problems!
-
--- f := [1 ↦ 1, _ ↦ 0]
--- (1 shrinks)
--- -------------------
--- "
---     slim_check (config := { randomSeed := some 257 })
---   admit
---   trivial
+example (f : Π₀ n : ℕ, ℕ) : true := by
+  have : f.update 0 0 = 0
+  success_if_fail_with_msg
+    "
+===================
+Found problems!
+f := [2 ↦ 1, _ ↦ 0]
+issue: ⋯ does not hold
+(3 shrinks)
+-------------------
+"
+    slim_check (config := { randomSeed := some 257 })
+  admit
+  trivial

--- a/test/slim_check.lean
+++ b/test/slim_check.lean
@@ -25,21 +25,21 @@ issue: 1 < 0 does not hold
   admit
   trivial
 
--- example : true := by
---   have : (∀ x : ℕ, 2 ∣ x → x < 100)
---   success_if_fail_with_msg
---   "
--- ===================
--- Found problems!
-
--- x := 104
--- issue: 104 < 100 does not hold
--- (2 shrinks)
--- -------------------
--- "
---     slim_check (config := { randomSeed := some 257 })
---   admit
---   trivial
+example : true := by
+  have : (∀ x : ℕ, 2 ∣ x → x < 100)
+  success_if_fail_with_msg
+  "
+===================
+Found problems!
+x := 116
+guard: ⋯
+issue: 116 < 100 does not hold
+(0 shrinks)
+-------------------
+"
+    slim_check (config := { randomSeed := some 257, maxSize := 200 })
+  admit
+  trivial
 
 -- example (xs : List ℕ) (w : ∃ x ∈ xs, x < 3) : true := by
 --   have : ∀ y ∈ xs, y < 5
@@ -59,21 +59,21 @@ issue: 1 < 0 does not hold
 --   admit
 --   trivial
 
--- example (x : ℕ) (h : 2 ∣ x) : true := by
---   have : x < 100
---   success_if_fail_with_msg
---     "
--- ===================
--- Found problems!
-
--- x := 104
--- issue: 104 < 100 does not hold
--- (2 shrinks)
--- -------------------
--- "
---     slim_check (config := { randomSeed := some 257 })
---   admit
---   trivial
+example (x : ℕ) (h : 2 ∣ x) : true := by
+  have : x < 100
+  success_if_fail_with_msg
+    "
+===================
+Found problems!
+x := 116
+guard: ⋯
+issue: 116 < 100 does not hold
+(0 shrinks)
+-------------------
+"
+    slim_check (config := { randomSeed := some 257, maxSize := 200 })
+  admit
+  trivial
 
 example (α : Type) (xs ys : List α) : true := by
   have : xs ++ ys = ys ++ xs


### PR DESCRIPTION
Previously `addDecorations` was creating ill-typed expressions that in the presence of function types placed a `Type` where a `Prop` was expected.

A few of the tests needed some minor fixes to make them pass.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
