### PR TITLE
[Merged by Bors] - chore: also install neovim in gitpod to enable lean.nvim use

### DIFF
--- a/.docker/gitpod/Dockerfile
+++ b/.docker/gitpod/Dockerfile
@@ -25,7 +25,10 @@ RUN curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -
 # install whichever toolchain mathlib is currently using
 RUN . ~/.profile && elan toolchain install $(curl https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain)
 
-ENV PATH="/home/gitpod/.local/bin:/home/gitpod/.elan/bin:${PATH}"
+# install neovim (for any lean.nvim user), via tarball since the appimage doesn't work for some reason, and jammy's version is ancient
+RUN curl -s -L https://github.com/neovim/neovim/releases/download/stable/nvim-linux64.tar.gz | tar xzf - && sudo mv nvim-linux64 /opt/nvim
+
+ENV PATH="/home/gitpod/.local/bin:/home/gitpod/.elan/bin:/opt/nvim/bin:${PATH}"
 
 # fix the infoview when the container is used on gitpod:
 ENV VSCODE_API_VERSION="1.50.0"


### PR DESCRIPTION
This doesn't actually *install* [`lean.nvim`](https://github.com/Julian/lean.nvim), it leaves that to each user's dotfiles, but it does install neovim, meaning if one does do so (have dotfiles which tell neovim to use lean.nvim), that it works the same as VSCode in Gitpod.

Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/lean.2Envim/near/404290395

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
