### PR TITLE
[Merged by Bors] - feat(RingTheory/Polynomial/Basic): add thms on degree of span and non-finiteness of polynomial ring as module

### DIFF
--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -189,7 +189,8 @@ theorem degreeLT_succ_eq_degreeLE {n : ℕ} : degreeLT R (n + 1) = degreeLE R n 
 
 /-- For every polynomial `p` in the span of a set `s : Set R[X]`, there exists a polynomial of
   `p' ∈ s` with higher degree. See also `Polynomial.exists_degree_le_of_mem_span_of_finite`. -/
-theorem exists_degree_le_of_mem_span {s : Set R[X]} {p : R[X]} (hs : s.Nonempty) (hp : p ∈ Submodule.span R s) :
+theorem exists_degree_le_of_mem_span {s : Set R[X]} {p : R[X]}
+    (hs : s.Nonempty) (hp : p ∈ Submodule.span R s) :
     ∃ p' ∈ s, degree p ≤ degree p' := by
   by_contra! h
   by_cases hp_zero : p = 0

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -698,9 +698,7 @@ theorem _root_.Polynomial.coeff_prod_mem_ideal_pow_tsub {ι : Type*} (s : Finset
 
 end CommSemiring
 
-section Ring
-
-variable [Ring R]
+section Semiring
 
 /-- If `R` is a nontrivial ring, the polynomials `R[X]` are not finite as an `R`-module. When `R` is
 a field, this is equivalent to `R[X]` being an infinite-dimensional vector space over `R`.  -/
@@ -715,6 +713,11 @@ theorem polynomial_not_module_finite {R : Type u} [Semiring R] [Nontrivial R]:
     exact hn Submodule.mem_top
   rw [mem_degreeLE, degree_X_pow, Nat.cast_le, add_le_iff_nonpos_right, nonpos_iff_eq_zero] at this
   exact one_ne_zero this
+end Semiring
+
+section Ring
+
+variable [Ring R]
 
 /-- `R[X]` is never a field for any ring `R`. -/
 theorem polynomial_not_isField : ¬IsField R[X] := by

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -180,16 +180,16 @@ theorem eval_eq_sum_degreeLTEquiv {n : ℕ} {p : R[X]} (hp : p ∈ degreeLT R n)
   exact (sum_fin _ (by simp_rw [zero_mul, forall_const]) (mem_degreeLT.mp hp)).symm
 #align polynomial.eval_eq_sum_degree_lt_equiv Polynomial.eval_eq_sum_degreeLTEquiv
 
-theorem degreeLT_eq_degreeLE {n : ℕ} : degreeLT R (n + 1) = degreeLE R n := by
+theorem degreeLT_succ_eq_degreeLE {n : ℕ} : degreeLT R (n + 1) = degreeLE R n := by
   ext x
   by_cases x_zero : x = 0
   · simp_rw [x_zero, Submodule.zero_mem]
   · rw [mem_degreeLT, mem_degreeLE, ← natDegree_lt_iff_degree_lt (by rwa [ne_eq]),
       ← natDegree_le_iff_degree_le, Nat.lt_succ]
 
-/-- For every polynomial `p` in the span of a set `s : K[X]`, there exists a polynomial of `p' ∈ s`
-  with higher degree. See also `degree_span'` -/
-theorem degree_span {s : Set R[X]} {p : R[X]} (hs : s.Nonempty) (hp : p ∈ Submodule.span R s) :
+/-- For every polynomial `p` in the span of a set `s : Set R[X]`, there exists a polynomial of
+  `p' ∈ s` with higher degree. See also `Polynomial.exists_degree_le_of_mem_span_of_finite`. -/
+theorem exists_degree_le_of_mem_span {s : Set R[X]} {p : R[X]} (hs : s.Nonempty) (hp : p ∈ Submodule.span R s) :
     ∃ p' ∈ s, degree p ≤ degree p' := by
   by_contra! h
   by_cases hp_zero : p = 0
@@ -203,14 +203,14 @@ theorem degree_span {s : Set R[X]} {p : R[X]} (hs : s.Nonempty) (hp : p ∈ Subm
     rwa [mem_degreeLT, Nat.cast_withBot, degree_eq_natDegree hp_zero,
       Nat.cast_withBot, lt_self_iff_false] at this
 
-/-- A stronger version of `degree_span` under the assumption that the set `s : R[X]` is finite.
-  There exists a polynomial `p' ∈ s` whose degree dominates the degree of every element of
-  `p ∈ span R s`-/
-theorem degree_span' {s : Set R[X]} (s_fin : s.Finite) (hs : s.Nonempty) :
+/-- A stronger version of `Polynomial.exists_degree_le_of_mem_span` under the assumption that the
+  set `s : R[X]` is finite. There exists a polynomial `p' ∈ s` whose degree dominates the degree of
+  every element of `p ∈ span R s`-/
+theorem exists_degree_le_of_mem_span_of_finite {s : Set R[X]} (s_fin : s.Finite) (hs : s.Nonempty) :
     ∃ p' ∈ s, ∀ (p : R[X]), p ∈ Submodule.span R s → degree p ≤ degree p' := by
   rcases Set.Finite.exists_maximal_wrt degree s s_fin hs with ⟨a, has, hmax⟩
   refine ⟨a, has, fun p hp => ?_⟩
-  rcases degree_span hs hp with ⟨p', hp'⟩
+  rcases exists_degree_le_of_mem_span hs hp with ⟨p', hp'⟩
   have p'max := hmax p' hp'.left
   by_cases h : degree a ≤ degree p'
   · rw [← p'max h] at hp'; exact hp'.right
@@ -220,7 +220,7 @@ theorem degree_span' {s : Set R[X]} (s_fin : s.Finite) (hs : s.Nonempty) :
 theorem span_of_finite_le_degreeLE {s : Set R[X]} (s_fin : s.Finite) :
     ∃ n : ℕ, Submodule.span R s ≤ degreeLE R n := by
   by_cases s_emp : s.Nonempty
-  · rcases degree_span' s_fin s_emp with ⟨p', _, hp'max⟩
+  · rcases exists_degree_le_of_mem_span_of_finite s_fin s_emp with ⟨p', _, hp'max⟩
     exact ⟨natDegree p', fun p hp => mem_degreeLE.mpr ((hp'max _ hp).trans degree_le_natDegree)⟩
   · rw [Set.not_nonempty_iff_eq_empty] at s_emp
     rw [s_emp, Submodule.span_empty]
@@ -230,7 +230,7 @@ theorem span_of_finite_le_degreeLE {s : Set R[X]} (s_fin : s.Finite) :
 theorem span_of_finite_le_degreeLT {s : Set R[X]} (s_fin : s.Finite) :
     ∃ n : ℕ, Submodule.span R s ≤ degreeLT R n := by
   rcases span_of_finite_le_degreeLE s_fin with ⟨n, _⟩
-  exact ⟨n + 1, by rwa [degreeLT_eq_degreeLE]⟩
+  exact ⟨n + 1, by rwa [degreeLT_succ_eq_degreeLE]⟩
 
 /-- If `R` is a nontrivial ring, the polynomials `R[X]` are not finite as an `R`-module. When `R` is
 a field, this is equivalent to `R[X]` being an infinite-dimensional vector space over `R`.  -/

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -232,6 +232,19 @@ theorem span_of_finite_le_degreeLT {s : Set R[X]} (s_fin : s.Finite) :
   rcases span_of_finite_le_degreeLE s_fin with ⟨n, _⟩
   exact ⟨n + 1, by rwa [degreeLT_eq_degreeLE]⟩
 
+/-- If `R` is a nontrivial ring, the polynomials `R[X]` are not finite as an `R`-module. When `R` is
+a field, this is equivalent to `R[X]` being an infinite-dimensional vector space over `R`.  -/
+theorem not_finite [Nontrivial R] : ¬ Module.Finite R R[X] := by
+  rw [Module.finite_def, Submodule.fg_def]
+  push_neg
+  intro s hs contra
+  rcases span_of_finite_le_degreeLE hs with ⟨n,hn⟩
+  have : ((X : R[X]) ^ (n + 1)) ∈ Polynomial.degreeLE R ↑n := by
+    rw [contra] at hn
+    exact hn Submodule.mem_top
+  rw [mem_degreeLE, degree_X_pow, Nat.cast_le, add_le_iff_nonpos_right, nonpos_iff_eq_zero] at this
+  exact one_ne_zero this
+
 /-- The finset of nonzero coefficients of a polynomial. -/
 def frange (p : R[X]) : Finset R :=
   letI := Classical.decEq R
@@ -692,23 +705,6 @@ theorem _root_.Polynomial.coeff_prod_mem_ideal_pow_tsub {ι : Type*} (s : Finset
 #align polynomial.coeff_prod_mem_ideal_pow_tsub Polynomial.coeff_prod_mem_ideal_pow_tsub
 
 end CommSemiring
-
-section Semiring
-
-/-- If `R` is a nontrivial ring, the polynomials `R[X]` are not finite as an `R`-module. When `R` is
-a field, this is equivalent to `R[X]` being an infinite-dimensional vector space over `R`.  -/
-theorem polynomial_not_module_finite {R : Type u} [Semiring R] [Nontrivial R] :
-    ¬ (Module.Finite R R[X]) := by
-  rw [Module.finite_def, Submodule.fg_def]
-  push_neg
-  intro s hs contra
-  rcases span_of_finite_le_degreeLE hs with ⟨n,hn⟩
-  have : ((X : R[X]) ^ (n + 1)) ∈ Polynomial.degreeLE R ↑n := by
-    rw [contra] at hn
-    exact hn Submodule.mem_top
-  rw [mem_degreeLE, degree_X_pow, Nat.cast_le, add_le_iff_nonpos_right, nonpos_iff_eq_zero] at this
-  exact one_ne_zero this
-end Semiring
 
 section Ring
 

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -704,7 +704,7 @@ variable [Ring R]
 
 /-- If `R` is a nontrivial ring, the polynomials `R[X]` are not finite as an `R`-module. When `R` is
 a field, this is equivalent to `R[X]` being an infinite-dimensional vector space over `R`.  -/
-theorem polynomials_infinite_dimensional {R : Type u} [Semiring R] [Nontrivial R]:
+theorem polynomial_not_module_finite {R : Type u} [Semiring R] [Nontrivial R]:
     ¬ (Module.Finite R R[X]) := by
   rw [Module.finite_def, Submodule.fg_def]
   push_neg

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -218,7 +218,7 @@ theorem exists_degree_le_of_mem_span_of_finite {s : Set R[X]} (s_fin : s.Finite)
   · exact le_trans hp'.right (not_le.mp h).le
 
 /-- The span of every finite set of polynomials is contained in a `degreeLE n` for some `n`. -/
-theorem span_of_finite_le_degreeLE {s : Set R[X]} (s_fin : s.Finite) :
+theorem span_le_degreeLE_of_finite {s : Set R[X]} (s_fin : s.Finite) :
     ∃ n : ℕ, Submodule.span R s ≤ degreeLE R n := by
   by_cases s_emp : s.Nonempty
   · rcases exists_degree_le_of_mem_span_of_finite s_fin s_emp with ⟨p', _, hp'max⟩
@@ -230,7 +230,7 @@ theorem span_of_finite_le_degreeLE {s : Set R[X]} (s_fin : s.Finite) :
 /-- The span of every finite set of polynomials is contained in a `degreeLT n` for some `n`. -/
 theorem span_of_finite_le_degreeLT {s : Set R[X]} (s_fin : s.Finite) :
     ∃ n : ℕ, Submodule.span R s ≤ degreeLT R n := by
-  rcases span_of_finite_le_degreeLE s_fin with ⟨n, _⟩
+  rcases span_le_degreeLE_of_finite s_fin with ⟨n, _⟩
   exact ⟨n + 1, by rwa [degreeLT_succ_eq_degreeLE]⟩
 
 /-- If `R` is a nontrivial ring, the polynomials `R[X]` are not finite as an `R`-module. When `R` is
@@ -239,7 +239,7 @@ theorem not_finite [Nontrivial R] : ¬ Module.Finite R R[X] := by
   rw [Module.finite_def, Submodule.fg_def]
   push_neg
   intro s hs contra
-  rcases span_of_finite_le_degreeLE hs with ⟨n,hn⟩
+  rcases span_le_degreeLE_of_finite hs with ⟨n,hn⟩
   have : ((X : R[X]) ^ (n + 1)) ∈ Polynomial.degreeLE R ↑n := by
     rw [contra] at hn
     exact hn Submodule.mem_top

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -229,8 +229,8 @@ theorem span_of_finite_le_degreeLE {s : Set R[X]} (s_fin : s.Finite) :
 /-- The span of every finite set of polynomials is contained in a `degreeLT n` for some `n`. -/
 theorem span_of_finite_le_degreeLT {s : Set R[X]} (s_fin : s.Finite) :
     ∃ n : ℕ, Submodule.span R s ≤ degreeLT R n := by
-  rcases span_of_finite_le_degreeLE s_fin with ⟨n,_⟩
-  exact ⟨n+1, by rwa [degreeLT_eq_degreeLE]⟩
+  rcases span_of_finite_le_degreeLE s_fin with ⟨n, _⟩
+  exact ⟨n + 1, by rwa [degreeLT_eq_degreeLE]⟩
 
 /-- The finset of nonzero coefficients of a polynomial. -/
 def frange (p : R[X]) : Finset R :=

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -220,13 +220,8 @@ theorem degree_span' {s : Set R[X]} (s_fin : s.Finite) (hs : s.Nonempty) :
 theorem span_of_finite_le_degreeLE {s : Set R[X]} (s_fin : s.Finite) :
     ∃ n : ℕ, Submodule.span R s ≤ degreeLE R n := by
   by_cases s_emp : s.Nonempty
-  · by_contra!
-    rcases degree_span' s_fin s_emp with ⟨p', _, hp'max⟩
-    rcases SetLike.not_le_iff_exists.mp (this (natDegree p' + 1)) with ⟨p, hp, hp2⟩
-    apply hp2
-    rw [mem_degreeLE, Nat.cast_add, Nat.cast_one, ← Nat.cast_succ]
-    refine le_trans (le_trans (hp'max p hp) degree_le_natDegree) ?_
-    exact Nat.cast_le.mpr (Nat.le_succ (natDegree p'))
+  · rcases degree_span' s_fin s_emp with ⟨p', _, hp'max⟩
+    exact ⟨natDegree p', fun p hp => mem_degreeLE.mpr ((hp'max _ hp).trans degree_le_natDegree)⟩
   · rw [Set.not_nonempty_iff_eq_empty] at s_emp
     rw [s_emp, Submodule.span_empty]
     exact ⟨0, bot_le⟩
@@ -702,7 +697,7 @@ section Semiring
 
 /-- If `R` is a nontrivial ring, the polynomials `R[X]` are not finite as an `R`-module. When `R` is
 a field, this is equivalent to `R[X]` being an infinite-dimensional vector space over `R`.  -/
-theorem polynomial_not_module_finite {R : Type u} [Semiring R] [Nontrivial R]:
+theorem polynomial_not_module_finite {R : Type u} [Semiring R] [Nontrivial R] :
     ¬ (Module.Finite R R[X]) := by
   rw [Module.finite_def, Submodule.fg_def]
   push_neg


### PR DESCRIPTION
This shows with minimal requirements on `R`, that the `R`-module `R[X]` is not finite, or if `R` is a field, that equivalently `R[X]` is infinite-dimensional. On the way, some theorems are proven on how the `R`-span of a set of polynomials in `R[X]` interacts with the degree of the elements, and that the span of finitely many polynomials is always contained in some `Polynomial.degreeLE n` and some `Polynomial.degreeLT n`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
