### PR TITLE
[Merged by Bors] - feat: subgroups of Z/nZ-modules are submodules

### DIFF
--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -25,9 +25,9 @@ theorem smul_mem (hx : x ∈ K) (c : ZMod n) : c • x ∈ K := by
 
 end ZMod
 
-namespace AddMonoidHom
-
 variable (n)
+
+namespace AddMonoidHom
 
 /-- Reinterpret an additive homomorphism as a `ℤ/nℤ`-linear map.
 

--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -55,4 +55,23 @@ def toZModSubmodule : AddSubgroup M ≃o Submodule (ZMod n) M where
   right_inv _ := rfl
   map_rel_iff' := Iff.rfl
 
+@[simp]
+theorem toZModSubmodule_symm :
+    ⇑((AddSubgroup.toZModSubmodule n).symm : _ ≃o AddSubgroup M) = Submodule.toAddSubgroup :=
+  rfl
+
+@[simp]
+theorem coe_toZModSubmodule (S : AddSubgroup M) : (AddSubgroup.toZModSubmodule n S : Set M) = S :=
+  rfl
+
+@[simp]
+theorem toZModSubmodule_toAddSubgroup (S : AddSubgroup M) :
+    (AddSubgroup.toZModSubmodule n S).toAddSubgroup = S :=
+  rfl
+
+@[simp]
+theorem _root_.ZMod.Submodule.toAddSubgroup_toZModSubmodule (S : Submodule (ZMod n) M) :
+    AddSubgroup.toZModSubmodule n S.toAddSubgroup = S :=
+  rfl
+
 end AddSubgroup

--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Module.LinearMap
 -/
 
 variable {n : ℕ} {M M₁ F S : Type*} [AddCommGroup M] [AddCommGroup M₁] [AddMonoidHomClass F M M₁]
-  [Module (ZMod n) M] [Module (ZMod n) M₁] { x : M } [SetLike S M] [AddSubgroupClass S M] {K : S}
+  [Module (ZMod n) M] [Module (ZMod n) M₁] [SetLike S M] [AddSubgroupClass S M] {x : M} {K : S}
 
 namespace ZMod
 

--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -10,12 +10,12 @@ import Mathlib.Algebra.Module.LinearMap
 # The `ZMod n`-module structure on Abelian groups whose elements have order dividing `n`
 -/
 
-variable {n : ℕ} {G G₁ F S : Type*} [AddCommGroup G] [AddCommGroup G₁] [AddMonoidHomClass F G G₁]
-  [Module (ZMod n) G] [Module (ZMod n) G₁] { x : G } [SetLike S G] [AddSubgroupClass S G] {K : S}
+variable {n : ℕ} {M M₁ F S : Type*} [AddCommGroup M] [AddCommGroup M₁] [AddMonoidHomClass F M M₁]
+  [Module (ZMod n) M] [Module (ZMod n) M₁] { x : M } [SetLike S M] [AddSubgroupClass S M] {K : S}
 
 namespace ZMod
 
-theorem map_smul (f : F) (c : ZMod n) (x : G) : f (c • x) = c • f x := by
+theorem map_smul (f : F) (c : ZMod n) (x : M) : f (c • x) = c • f x := by
   rw [← ZMod.int_cast_zmod_cast c]
   exact map_int_cast_smul f _ _ c x
 
@@ -33,13 +33,13 @@ namespace AddMonoidHom
 
 See also:
 `AddMonoidHom.toIntLinearMap`, `AddMonoidHom.toNatLinearMap`, `AddMonoidHom.toRatLinearMap` -/
-def toZModLinearMap (f : G →+ G₁) : G →ₗ[ZMod n] G₁ := { f with map_smul' := ZMod.map_smul f }
+def toZModLinearMap (f : M →+ M₁) : M →ₗ[ZMod n] M₁ := { f with map_smul' := ZMod.map_smul f }
 
-theorem toZModLinearMap_injective: Function.Injective <| toZModLinearMap n (G := G) (G₁ := G₁) :=
+theorem toZModLinearMap_injective: Function.Injective <| toZModLinearMap n (M := M) (M₁ := M₁) :=
   fun _ _ h ↦ ext fun x ↦ congr($h x)
 
 @[simp]
-theorem coe_toZModLinearMap (f : G →+ G₁) : ⇑(f.toZModLinearMap n) = f := rfl
+theorem coe_toZModLinearMap (f : M →+ M₁) : ⇑(f.toZModLinearMap n) = f := rfl
 
 end AddMonoidHom
 
@@ -48,7 +48,7 @@ namespace AddSubgroup
 /-- Reinterpret an additive subgroup of a `ℤ/nℤ`-module as a `ℤ/nℤ`-submodule.
 
 See also: `AddSubgroup.toIntSubmodule`, `AddSubmonoid.toNatSubmodule`. -/
-def toZModSubmodule : AddSubgroup G ≃o Submodule (ZMod n) G where
+def toZModSubmodule : AddSubgroup M ≃o Submodule (ZMod n) M where
   toFun S := { S with smul_mem' := fun c _ h ↦ ZMod.smul_mem (K := S) h c }
   invFun := Submodule.toAddSubgroup
   left_inv _ := rfl

--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -57,21 +57,21 @@ def toZModSubmodule : AddSubgroup M ≃o Submodule (ZMod n) M where
 
 @[simp]
 theorem toZModSubmodule_symm :
-    ⇑((AddSubgroup.toZModSubmodule n).symm : _ ≃o AddSubgroup M) = Submodule.toAddSubgroup :=
+    ⇑((toZModSubmodule n).symm : _ ≃o AddSubgroup M) = Submodule.toAddSubgroup :=
   rfl
 
 @[simp]
-theorem coe_toZModSubmodule (S : AddSubgroup M) : (AddSubgroup.toZModSubmodule n S : Set M) = S :=
+theorem coe_toZModSubmodule (S : AddSubgroup M) : (toZModSubmodule n S : Set M) = S :=
   rfl
 
 @[simp]
 theorem toZModSubmodule_toAddSubgroup (S : AddSubgroup M) :
-    (AddSubgroup.toZModSubmodule n S).toAddSubgroup = S :=
+    (toZModSubmodule n S).toAddSubgroup = S :=
   rfl
 
 @[simp]
-theorem _root_.ZMod.Submodule.toAddSubgroup_toZModSubmodule (S : Submodule (ZMod n) M) :
-    AddSubgroup.toZModSubmodule n S.toAddSubgroup = S :=
+theorem _root_.Submodule.toAddSubgroup_toZModSubmodule (S : Submodule (ZMod n) M) :
+    toZModSubmodule n S.toAddSubgroup = S :=
   rfl
 
 end AddSubgroup

--- a/Mathlib/Data/ZMod/Module.lean
+++ b/Mathlib/Data/ZMod/Module.lean
@@ -45,7 +45,7 @@ end AddMonoidHom
 
 namespace AddSubgroup
 
-/-- Reinterpret an additive subgroup as a `ℤ/nℤ`-submodule.
+/-- Reinterpret an additive subgroup of a `ℤ/nℤ`-module as a `ℤ/nℤ`-submodule.
 
 See also: `AddSubgroup.toIntSubmodule`, `AddSubmonoid.toNatSubmodule`. -/
 def toZModSubmodule : AddSubgroup G ≃o Submodule (ZMod n) G where


### PR DESCRIPTION
Together with #9017 and #8965 we can convert group theory problems to linear algebra problems as in the
[homomorphism form of PFR](https://teorth.github.io/pfr/blueprint/sect0008.html).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
