### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/CliffordAlgebra): move results about inversion to a new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2355,6 +2355,7 @@ import Mathlib.LinearAlgebra.CliffordAlgebra.Even
 import Mathlib.LinearAlgebra.CliffordAlgebra.EvenEquiv
 import Mathlib.LinearAlgebra.CliffordAlgebra.Fold
 import Mathlib.LinearAlgebra.CliffordAlgebra.Grading
+import Mathlib.LinearAlgebra.CliffordAlgebra.Inversion
 import Mathlib.LinearAlgebra.CliffordAlgebra.Star
 import Mathlib.LinearAlgebra.Coevaluation
 import Mathlib.LinearAlgebra.Contraction

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -367,44 +367,6 @@ theorem equivOfIsometry_refl :
 
 end Map
 
-variable (Q)
-
-/-- If the quadratic form of a vector is invertible, then so is that vector. -/
-def invertibleιOfInvertible (m : M) [Invertible (Q m)] : Invertible (ι Q m) where
-  invOf := ι Q (⅟ (Q m) • m)
-  invOf_mul_self := by
-    rw [map_smul, smul_mul_assoc, ι_sq_scalar, Algebra.smul_def, ← map_mul, invOf_mul_self, map_one]
-  mul_invOf_self := by
-    rw [map_smul, mul_smul_comm, ι_sq_scalar, Algebra.smul_def, ← map_mul, invOf_mul_self, map_one]
-#align clifford_algebra.invertible_ι_of_invertible CliffordAlgebra.invertibleιOfInvertible
-
-/-- For a vector with invertible quadratic form, $v^{-1} = \frac{v}{Q(v)}$ -/
-theorem invOf_ι (m : M) [Invertible (Q m)] [Invertible (ι Q m)] :
-    ⅟ (ι Q m) = ι Q (⅟ (Q m) • m) := by
-  letI := invertibleιOfInvertible Q m
-  convert (rfl : ⅟ (ι Q m) = _)
-#align clifford_algebra.inv_of_ι CliffordAlgebra.invOf_ι
-
-theorem isUnit_ι_of_isUnit {m : M} (h : IsUnit (Q m)) : IsUnit (ι Q m) := by
-  cases h.nonempty_invertible
-  letI := invertibleιOfInvertible Q m
-  exact isUnit_of_invertible (ι Q m)
-#align clifford_algebra.is_unit_ι_of_is_unit CliffordAlgebra.isUnit_ι_of_isUnit
-
-/-- $aba^{-1}$ is a vector. -/
-theorem ι_mul_ι_mul_invOf_ι (a b : M) [Invertible (ι Q a)] [Invertible (Q a)] :
-    ι Q a * ι Q b * ⅟ (ι Q a) = ι Q ((⅟ (Q a) * QuadraticForm.polar Q a b) • a - b) := by
-  rw [invOf_ι, map_smul, mul_smul_comm, ι_mul_ι_mul_ι, ← map_smul, smul_sub, smul_smul, smul_smul,
-    invOf_mul_self, one_smul]
-#align clifford_algebra.ι_mul_ι_mul_inv_of_ι CliffordAlgebra.ι_mul_ι_mul_invOf_ι
-
-/-- $a^{-1}ba$ is a vector. -/
-theorem invOf_ι_mul_ι_mul_ι (a b : M) [Invertible (ι Q a)] [Invertible (Q a)] :
-    ⅟ (ι Q a) * ι Q b * ι Q a = ι Q ((⅟ (Q a) * QuadraticForm.polar Q a b) • a - b) := by
-  rw [invOf_ι, map_smul, smul_mul_assoc, smul_mul_assoc, ι_mul_ι_mul_ι, ← map_smul, smul_sub,
-    smul_smul, smul_smul, invOf_mul_self, one_smul]
-#align clifford_algebra.inv_of_ι_mul_ι_mul_ι CliffordAlgebra.invOf_ι_mul_ι_mul_ι
-
 end CliffordAlgebra
 
 namespace TensorAlgebra

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Inversion.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Inversion.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2022 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.LinearAlgebra.CliffordAlgebra.Basic
+
+/-! # Results about inverses in Clifford algebras -/
+
+variable {R M : Type*}
+variable [CommRing R] [AddCommGroup M] {Q : QuadraticForm R M}
+
+namespace CliffordAlgebra
+
+variable (Q)
+
+/-- If the quadratic form of a vector is invertible, then so is that vector. -/
+def invertibleιOfInvertible (m : M) [Invertible (Q m)] : Invertible (ι Q m) where
+  invOf := ι Q (⅟ (Q m) • m)
+  invOf_mul_self := by
+    rw [map_smul, smul_mul_assoc, ι_sq_scalar, Algebra.smul_def, ← map_mul, invOf_mul_self, map_one]
+  mul_invOf_self := by
+    rw [map_smul, mul_smul_comm, ι_sq_scalar, Algebra.smul_def, ← map_mul, invOf_mul_self, map_one]
+#align clifford_algebra.invertible_ι_of_invertible CliffordAlgebra.invertibleιOfInvertible
+
+/-- For a vector with invertible quadratic form, $v^{-1} = \frac{v}{Q(v)}$ -/
+theorem invOf_ι (m : M) [Invertible (Q m)] [Invertible (ι Q m)] :
+    ⅟ (ι Q m) = ι Q (⅟ (Q m) • m) := by
+  letI := invertibleιOfInvertible Q m
+  convert (rfl : ⅟ (ι Q m) = _)
+#align clifford_algebra.inv_of_ι CliffordAlgebra.invOf_ι
+
+theorem isUnit_ι_of_isUnit {m : M} (h : IsUnit (Q m)) : IsUnit (ι Q m) := by
+  cases h.nonempty_invertible
+  letI := invertibleιOfInvertible Q m
+  exact isUnit_of_invertible (ι Q m)
+#align clifford_algebra.is_unit_ι_of_is_unit CliffordAlgebra.isUnit_ι_of_isUnit
+
+/-- $aba^{-1}$ is a vector. -/
+theorem ι_mul_ι_mul_invOf_ι (a b : M) [Invertible (ι Q a)] [Invertible (Q a)] :
+    ι Q a * ι Q b * ⅟ (ι Q a) = ι Q ((⅟ (Q a) * QuadraticForm.polar Q a b) • a - b) := by
+  rw [invOf_ι, map_smul, mul_smul_comm, ι_mul_ι_mul_ι, ← map_smul, smul_sub, smul_smul, smul_smul,
+    invOf_mul_self, one_smul]
+#align clifford_algebra.ι_mul_ι_mul_inv_of_ι CliffordAlgebra.ι_mul_ι_mul_invOf_ι
+
+/-- $a^{-1}ba$ is a vector. -/
+theorem invOf_ι_mul_ι_mul_ι (a b : M) [Invertible (ι Q a)] [Invertible (Q a)] :
+    ⅟ (ι Q a) * ι Q b * ι Q a = ι Q ((⅟ (Q a) * QuadraticForm.polar Q a b) • a - b) := by
+  rw [invOf_ι, map_smul, smul_mul_assoc, smul_mul_assoc, ι_mul_ι_mul_ι, ← map_smul, smul_sub,
+    smul_smul, smul_smul, invOf_mul_self, one_smul]
+#align clifford_algebra.inv_of_ι_mul_ι_mul_ι CliffordAlgebra.invOf_ι_mul_ι_mul_ι
+
+end CliffordAlgebra

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Inversion.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Inversion.lean
@@ -12,7 +12,7 @@ $ι(m)^{-1} = \frac{ι(m)}{Q(m)}$.
 -/
 
 variable {R M : Type*}
-variable [CommRing R] [AddCommGroup M] {Q : QuadraticForm R M}
+variable [CommRing R] [AddCommGroup M] [Module R M] {Q : QuadraticForm R M}
 
 namespace CliffordAlgebra
 

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Inversion.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Inversion.lean
@@ -5,7 +5,11 @@ Authors: Eric Wieser
 -/
 import Mathlib.LinearAlgebra.CliffordAlgebra.Basic
 
-/-! # Results about inverses in Clifford algebras -/
+/-! # Results about inverses in Clifford algebras
+
+This contains some basic results about the inversion of vectors, related to the fact that
+$ι(m)^{-1} = \frac{ι(m)}{Q(m)}$.
+-/
 
 variable {R M : Type*}
 variable [CommRing R] [AddCommGroup M] {Q : QuadraticForm R M}


### PR DESCRIPTION
I plan to contribute a few more of these, and this provides a better place for them to live.
No lemma statements or proofs have changed.

These were originally contributed in leanprover-community/mathlib#16077.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
