### PR TITLE
[Merged by Bors] - feat: Positivity extensions for `Real.sinh`, `Real.cosh`

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -164,17 +164,6 @@ theorem pi_pos : 0 < π :=
   lt_of_lt_of_le (by norm_num) two_le_pi
 #align real.pi_pos Real.pi_pos
 
-namespace Mathlib.Meta.Positivity
-open Lean.Meta Qq
-
-/-- Extension for the `positivity` tactic: `π` is always positive. -/
-@[positivity π]
-def evalExp : Mathlib.Meta.Positivity.PositivityExt where eval {_ _} _ _ _ := do
-  pure (.positive (q(Real.pi_pos) : Lean.Expr))
-
-end Mathlib.Meta.Positivity
-
-
 theorem pi_ne_zero : π ≠ 0 :=
   ne_of_gt pi_pos
 #align real.pi_ne_zero Real.pi_ne_zero
@@ -187,6 +176,16 @@ theorem two_pi_pos : 0 < 2 * π := by linarith [pi_pos]
 #align real.two_pi_pos Real.two_pi_pos
 
 end Real
+
+namespace Mathlib.Meta.Positivity
+open Lean.Meta Qq
+
+/-- Extension for the `positivity` tactic: `π` is always positive. -/
+@[positivity Real.pi]
+def evalRealPi : Mathlib.Meta.Positivity.PositivityExt where eval {_ _} _ _ _ := do
+  pure (.positive (q(Real.pi_pos) : Lean.Expr))
+
+end Mathlib.Meta.Positivity
 
 namespace NNReal
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Deriv.lean
@@ -698,6 +698,10 @@ theorem sinh_lt_sinh : sinh x < sinh y ↔ x < y :=
   sinh_strictMono.lt_iff_lt
 #align real.sinh_lt_sinh Real.sinh_lt_sinh
 
+@[simp] lemma sinh_eq_zero : sinh x = 0 ↔ x = 0 := by rw [← @sinh_inj x, sinh_zero]
+
+lemma sinh_ne_zero : sinh x ≠ 0 ↔ x ≠ 0 := sinh_eq_zero.not
+
 @[simp]
 theorem sinh_pos_iff : 0 < sinh x ↔ 0 < x := by simpa only [sinh_zero] using @sinh_lt_sinh 0 x
 #align real.sinh_pos_iff Real.sinh_pos_iff
@@ -1183,3 +1187,34 @@ theorem ContDiffWithinAt.sinh {n} (hf : ContDiffWithinAt ℝ n f s x) :
 #align cont_diff_within_at.sinh ContDiffWithinAt.sinh
 
 end
+
+namespace Mathlib.Meta.Positivity
+open Lean Meta Qq
+
+private alias ⟨_, sinh_pos_of_pos⟩ := Real.sinh_pos_iff
+private alias ⟨_, sinh_nonneg_of_nonneg⟩ := Real.sinh_nonneg_iff
+private alias ⟨_, sinh_ne_zero_of_ne_zero⟩ := Real.sinh_ne_zero
+
+/-- Extension for the `positivity` tactic: `Real.sinh` is positive/nonnegative/nonzero if its input
+is. -/
+@[positivity Real.sinh _]
+def evalSinh : PositivityExt where eval {u α} _ _ e := do
+  let zα : Q(Zero ℝ) := q(inferInstance)
+  let pα : Q(PartialOrder ℝ) := q(inferInstance)
+  if let 0 := u then -- lean4#3060 means we can't combine this with the match below
+    match α, e with
+    | ~q(ℝ), ~q(Real.sinh $a) =>
+      assumeInstancesCommute
+      match ← core zα pα a with
+      | .positive pa => return .positive q(sinh_pos_of_pos $pa)
+      | .nonnegative pa => return .nonnegative q(sinh_nonneg_of_nonneg $pa)
+      | .nonzero pa => return .nonzero q(sinh_ne_zero_of_ne_zero $pa)
+      | _ => return .none
+    | _, _ => throwError "not Real.sinh"
+  else throwError "not Real.sinh"
+
+example (x : ℝ) (hx : 0 < x) : 0 < x.sinh := by positivity
+example (x : ℝ) (hx : 0 ≤ x) : 0 ≤ x.sinh := by positivity
+example (x : ℝ) (hx : x ≠ 0) : x.sinh ≠ 0 := by positivity
+
+end Mathlib.Meta.Positivity

--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -2026,6 +2026,19 @@ def evalExp : PositivityExt where eval {_ _} _ _ e := do
   let (.app _ (a : Q(ℝ))) ← withReducible (whnf e) | throwError "not Real.exp"
   pure (.positive (q(Real.exp_pos $a) : Lean.Expr))
 
+/-- Extension for the `positivity` tactic: `Real.cosh` is always positive. -/
+@[positivity Real.cosh _]
+def evalCosh : PositivityExt where eval {u α} _ _ e := do
+  if let 0 := u then -- lean4#3060 means we can't combine this with the match below
+    match α, e with
+    | ~q(ℝ), ~q(Real.cosh $a) =>
+      assumeInstancesCommute
+      return .positive q(Real.cosh_pos $a)
+    | _, _ => throwError "not Real.cosh"
+  else throwError "not Real.cosh"
+
+example (x : ℝ) : 0 < x.cosh := by positivity
+
 end Mathlib.Meta.Positivity
 
 namespace Complex


### PR DESCRIPTION
Also fix the name of `Real.Mathlib.Meta.Positivity.evalExp` to `Mathlib.Meta.Positivity.evalRealPi`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
