### PR TITLE
[Merged by Bors] - feat: Completeness criterion for normed additive groups

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -768,6 +768,7 @@ import Mathlib.Analysis.Normed.Group.AddCircle
 import Mathlib.Analysis.Normed.Group.AddTorsor
 import Mathlib.Analysis.Normed.Group.BallSphere
 import Mathlib.Analysis.Normed.Group.Basic
+import Mathlib.Analysis.Normed.Group.Completeness
 import Mathlib.Analysis.Normed.Group.Completion
 import Mathlib.Analysis.Normed.Group.ControlledClosure
 import Mathlib.Analysis.Normed.Group.Hom

--- a/Mathlib/Analysis/Normed/Group/Completeness.lean
+++ b/Mathlib/Analysis/Normed/Group/Completeness.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2023 Frédéric Dupuis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frédéric Dupuis
+-/
+
+import Mathlib.Analysis.Normed.Group.Basic
+import Mathlib.Analysis.SpecificLimits.Basic
+
+/-!
+# Completeness of normed groups
+
+This file includes a completeness criterion for normed additive groups in terms of convergent
+series.
+
+## Main results
+
+* `NormedAddCommGroup.completeSpace_of_summable_implies_tendsto`: A normed additive group is
+complete if an absolutely convergent series converges in the space.
+
+## References
+
+* [bergh_lofstrom_1976] `completeSpace_of_summable_implies_tendsto` and
+  `summable_implies_tendsto_of_complete` correspond to the two directions of Lemma 2.2.1.
+
+## Tags
+
+CompleteSpace, CauchySeq
+-/
+
+open scoped BigOperators Topology
+open Filter Finset
+
+section Metric
+
+variable {α : Type*} [PseudoMetricSpace α]
+
+lemma Metric.exists_subseq_summable_dist_of_cauchySeq (u : ℕ → α) (hu : CauchySeq u) :
+    ∃ f : ℕ → ℕ, StrictMono f ∧ Summable fun i => dist (u (f (i+1))) (u (f i)) := by
+  obtain ⟨f, hf₁, hf₂⟩ :=
+    Metric.exists_subseq_bounded_of_cauchySeq u hu (fun n => (1 / (2:ℝ))^n) (fun n => by positivity)
+  refine ⟨f, hf₁, ?_⟩
+  refine Summable.of_nonneg_of_le (fun n => by positivity) ?_ summable_geometric_two
+  exact fun n => le_of_lt <| hf₂ n (f (n+1)) <| hf₁.monotone (Nat.le_add_right n 1)
+
+end Metric
+
+section Normed
+
+variable {E : Type*} [NormedAddCommGroup E]
+
+/-- A normed additive group is complete if an absolutely convergent series converges in the
+space.  -/
+lemma NormedAddCommGroup.completeSpace_of_summable_implies_tendsto
+    (h : ∀ u : ℕ → E,
+      Summable (‖u ·‖) → ∃ a, Tendsto (fun n => ∑ i in range n, u i) atTop (𝓝 a)) :
+    CompleteSpace E := by
+  apply Metric.complete_of_cauchySeq_tendsto
+  intro u hu
+  obtain ⟨f, hf₁, hf₂⟩ := Metric.exists_subseq_summable_dist_of_cauchySeq u hu
+  simp only [dist_eq_norm] at hf₂
+  let v n := u (f (n+1)) - u (f n)
+  have hv_sum : (fun n => (∑ i in range n, v i)) = fun n => u (f n) - u (f 0) := by
+    ext n
+    exact sum_range_sub (u ∘ f) n
+  obtain ⟨a, ha⟩ := h v hf₂
+  refine ⟨a + u (f 0), ?_⟩
+  refine tendsto_nhds_of_cauchySeq_of_subseq hu hf₁.tendsto_atTop ?_
+  rw [hv_sum] at ha
+  have h₁ : Tendsto (fun n => u (f n) - u (f 0) + u (f 0)) atTop (𝓝 (a + u (f 0))) := by
+    refine Tendsto.add_const _ ha
+  simpa only [sub_add_cancel] using h₁
+
+/-- In a complete normed additive group, an absolutely convergent series converges in the
+space.  -/
+lemma NormedAddCommGroup.summable_implies_tendsto_of_complete [CompleteSpace E] (u : ℕ → E)
+    (hu : Summable (‖u ·‖)) : ∃ a, Tendsto (fun n => ∑ i in range n, u i) atTop (𝓝 a) := by
+  have h_cauchy : CauchySeq (fun n => ∑ i in range n, u i) := by
+    refine cauchySeq_of_summable_dist ?_
+    simp [dist_eq_norm, sum_range_succ, hu]
+  exact cauchySeq_tendsto_of_complete h_cauchy
+
+end Normed

--- a/Mathlib/Analysis/Normed/Group/Completeness.lean
+++ b/Mathlib/Analysis/Normed/Group/Completeness.lean
@@ -49,7 +49,7 @@ section Normed
 
 variable {E : Type*} [NormedAddCommGroup E]
 
-/-- A normed additive group is complete if an absolutely convergent series converges in the
+/-- A normed additive group is complete if any absolutely convergent series converges in the
 space.  -/
 lemma NormedAddCommGroup.completeSpace_of_summable_implies_tendsto
     (h : ∀ u : ℕ → E,

--- a/Mathlib/Analysis/Normed/Group/Completeness.lean
+++ b/Mathlib/Analysis/Normed/Group/Completeness.lean
@@ -75,9 +75,7 @@ lemma NormedAddCommGroup.completeSpace_of_summable_implies_tendsto
 space.  -/
 lemma NormedAddCommGroup.summable_implies_tendsto_of_complete [CompleteSpace E] (u : ℕ → E)
     (hu : Summable (‖u ·‖)) : ∃ a, Tendsto (fun n => ∑ i in range n, u i) atTop (𝓝 a) := by
-  have h_cauchy : CauchySeq (fun n => ∑ i in range n, u i) := by
-    refine cauchySeq_of_summable_dist ?_
-    simp [dist_eq_norm, sum_range_succ, hu]
-  exact cauchySeq_tendsto_of_complete h_cauchy
+  refine cauchySeq_tendsto_of_complete <| cauchySeq_of_summable_dist ?_
+  simp [dist_eq_norm, sum_range_succ, hu]
 
 end Normed

--- a/Mathlib/Analysis/Normed/Group/Completeness.lean
+++ b/Mathlib/Analysis/Normed/Group/Completeness.lean
@@ -16,7 +16,7 @@ series.
 ## Main results
 
 * `NormedAddCommGroup.completeSpace_of_summable_implies_tendsto`: A normed additive group is
-complete if an absolutely convergent series converges in the space.
+complete if any absolutely convergent series converges in the space.
 
 ## References
 

--- a/Mathlib/Analysis/Normed/Group/Completeness.lean
+++ b/Mathlib/Analysis/Normed/Group/Completeness.lean
@@ -51,7 +51,7 @@ variable {E : Type*} [NormedAddCommGroup E]
 
 /-- A normed additive group is complete if any absolutely convergent series converges in the
 space.  -/
-lemma NormedAddCommGroup.completeSpace_of_summable_implies_tendsto
+lemma NormedAddCommGroup.completeSpace_of_summable_imp_tendsto
     (h : ∀ u : ℕ → E,
       Summable (‖u ·‖) → ∃ a, Tendsto (fun n => ∑ i in range n, u i) atTop (𝓝 a)) :
     CompleteSpace E := by
@@ -71,11 +71,18 @@ lemma NormedAddCommGroup.completeSpace_of_summable_implies_tendsto
     refine Tendsto.add_const _ ha
   simpa only [sub_add_cancel] using h₁
 
-/-- In a complete normed additive group, an absolutely convergent series converges in the
+/-- In a complete normed additive group, every absolutely convergent series converges in the
 space.  -/
-lemma NormedAddCommGroup.summable_implies_tendsto_of_complete [CompleteSpace E] (u : ℕ → E)
+lemma NormedAddCommGroup.summable_imp_tendsto_of_complete [CompleteSpace E] (u : ℕ → E)
     (hu : Summable (‖u ·‖)) : ∃ a, Tendsto (fun n => ∑ i in range n, u i) atTop (𝓝 a) := by
   refine cauchySeq_tendsto_of_complete <| cauchySeq_of_summable_dist ?_
   simp [dist_eq_norm, sum_range_succ, hu]
+
+/-- In a normed additive group, every absolutely convergent series converges in the
+space iff the space is complete.  -/
+lemma NormedAddCommGroup.summable_imp_tendsto_iff_completeSpace :
+    (∀ u : ℕ → E, Summable (‖u ·‖) → ∃ a, Tendsto (fun n => ∑ i in range n, u i) atTop (𝓝 a))
+     ↔ CompleteSpace E :=
+  ⟨completeSpace_of_summable_imp_tendsto, fun _ u hu => summable_imp_tendsto_of_complete u hu⟩
 
 end Normed

--- a/Mathlib/Topology/MetricSpace/Cauchy.lean
+++ b/Mathlib/Topology/MetricSpace/Cauchy.lean
@@ -156,4 +156,15 @@ theorem cauchySeq_iff_le_tendsto_0 {s : ℕ → α} :
    fun ⟨b, _, b_bound, b_lim⟩ => cauchySeq_of_le_tendsto_0 b b_bound b_lim⟩
 #align cauchy_seq_iff_le_tendsto_0 cauchySeq_iff_le_tendsto_0
 
+lemma Metric.exists_subseq_bounded_of_cauchySeq (u : ℕ → α) (hu : CauchySeq u) (b : ℕ → ℝ)
+    (hb : ∀ n, 0 < b n) :
+    ∃ f : ℕ → ℕ, StrictMono f ∧ ∀ n, ∀ m ≥ f n, dist (u m) (u (f n)) < b n := by
+  rw [cauchySeq_iff] at hu
+  have hu' : ∀ k, ∀ᶠ (n : ℕ) in atTop, ∀ m ≥ n, dist (u m) (u n) < b k := by
+    intro k
+    rw [eventually_atTop]
+    obtain ⟨N, hN⟩ := hu (b k) (hb k)
+    exact ⟨N, fun m hm r hr => hN r (hm.trans hr) m hm⟩
+  exact Filter.extraction_forall_of_eventually hu'
+
 end CauchySeq

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -699,14 +699,14 @@
                   interesting property that it constructs a ring of
                   characteristic 0 out of a ring of characteristic p > 1,
                   and it can be used more specifically to construct from a
-                  finite field containing \<int>/p\<int> the corresponding
-                  unramified field extension of the p-adic numbers \<rat>p
+                  finite field containing ℤ/pℤ the corresponding
+                  unramified field extension of the p-adic numbers ℚp
                   (which is unique up to isomorphism). We formalize the
                   notion of a Witt vector in the Lean proof assistant, along
                   with the corresponding ring operations and other algebraic
                   structure. We prove in Lean that, for prime p, the ring of
-                  Witt vectors over \<int>/p\<int> is isomorphic to the ring of
-                  p-adic integers \<int>p. In the process we develop idioms to
+                  Witt vectors over ℤ/pℤ is isomorphic to the ring of
+                  p-adic integers ℤp. In the process we develop idioms to
                   cleanly handle calculations of identities between
                   operations on the ring of Witt vectors. These calculations
                   are intractable with a naive approach, and require a proof

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -697,7 +697,7 @@
                   important tool in algebraic number theory and lies at the
                   foundations of modern p-adic Hodge theory. W R has the
                   interesting property that it constructs a ring of
-                  characteristic 0 out of a ring of characteristic p &gt; 1,
+                  characteristic 0 out of a ring of characteristic p > 1,
                   and it can be used more specifically to construct from a
                   finite field containing \<int>/p\<int> the corresponding
                   unramified field extension of the p-adic numbers \<rat>p

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -193,6 +193,14 @@
   edition       = 1
 }
 
+@Book{            bergh_lofstrom_1976,
+  author        = {Bergh, Jöran and Löfström, Jörgen},
+  title         = {Interpolation Spaces},
+  publisher     = {Springer Berlin},
+  year          = 1976,
+  issn          = {0072-7830}
+}
+
 @Article{         bernstein1912,
   author        = {Bernstein, S.},
   year          = {1912},
@@ -691,14 +699,14 @@
                   interesting property that it constructs a ring of
                   characteristic 0 out of a ring of characteristic p &gt; 1,
                   and it can be used more specifically to construct from a
-                  finite field containing ℤ/pℤ the corresponding
-                  unramified field extension of the p-adic numbers ℚp
+                  finite field containing \<int>/p\<int> the corresponding
+                  unramified field extension of the p-adic numbers \<rat>p
                   (which is unique up to isomorphism). We formalize the
                   notion of a Witt vector in the Lean proof assistant, along
                   with the corresponding ring operations and other algebraic
                   structure. We prove in Lean that, for prime p, the ring of
-                  Witt vectors over ℤ/pℤ is isomorphic to the ring of
-                  p-adic integers ℤp. In the process we develop idioms to
+                  Witt vectors over \<int>/p\<int> is isomorphic to the ring of
+                  p-adic integers \<int>p. In the process we develop idioms to
                   cleanly handle calculations of identities between
                   operations on the ring of Witt vectors. These calculations
                   are intractable with a naive approach, and require a proof

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -697,7 +697,7 @@
                   important tool in algebraic number theory and lies at the
                   foundations of modern p-adic Hodge theory. W R has the
                   interesting property that it constructs a ring of
-                  characteristic 0 out of a ring of characteristic p > 1,
+                  characteristic 0 out of a ring of characteristic p &gt; 1,
                   and it can be used more specifically to construct from a
                   finite field containing ℤ/pℤ the corresponding
                   unramified field extension of the p-adic numbers ℚp


### PR DESCRIPTION
This PR adds a proof that a normed additive group is complete iff every absolutely convergent series converges in the space.

This is Lemma 2.2.1 from the book "Interpolation Spaces" by Bergh and Löfström.

I wasn't too sure where to put `Metric.exists_subseq_summable_dist_of_cauchySeq` -- I would be happy to move it somewhere else.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
