### PR TITLE
[Merged by Bors] - feat(Data/Set/Finite): Induction principle for `Set`

### DIFF
--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1211,17 +1211,13 @@ theorem Finite.dinduction_on {C : ∀ s : Set α, s.Finite → Prop} (s : Set α
 theorem Finite.induction_to {C : Set α → Prop} {S : Set α} (h : S.Finite)
     (S0 : Set α) (hS0 : S0 ⊆ S) (H0 : C S0) (H1 : ∀ s ⊂ S, C s → ∃ a ∈ S \ s, C (insert a s)) :
     C S := by
-  let M := {T : Set α // T ⊆ S}
   have : Finite S := Finite.to_subtype h
-  have : Finite M := Finite.of_equiv (Set S) (Equiv.Set.powerset S).symm
-  let P : M → Prop := C ∘ Subtype.val
-  change P ⟨S, le_rfl⟩
-  replace H0 : P ⟨S0, hS0⟩ := H0
-  refine' Finite.to_wellFoundedGT.wf.induction_bot' (fun s hs hs' ↦ _) H0
+  have : Finite {T : Set α // T ⊆ S} := Finite.of_equiv (Set S) (Equiv.Set.powerset S).symm
+  rw [← Subtype.coe_mk (p := (· ⊆ S)) _ le_rfl]
+  rw [← Subtype.coe_mk (p := (· ⊆ S)) _ hS0] at H0
+  refine Finite.to_wellFoundedGT.wf.induction_bot' (fun s hs hs' ↦ ?_) H0
   obtain ⟨a, ⟨ha1, ha2⟩, ha'⟩ := H1 s (ssubset_of_ne_of_subset hs s.2) hs'
-  rw [show insert a s.1 = Subtype.val (⟨insert a s.1, insert_subset ha1 s.2⟩ : M) from rfl] at ha'
-  refine' ⟨_, Set.ssubset_insert _, ha'⟩
-  exact ha2
+  exact ⟨⟨insert a s.1, insert_subset ha1 s.2⟩, Set.ssubset_insert ha2, ha'⟩
 
 /-- Induction up to `univ`. -/
 theorem Finite.induction_to_univ [Finite α] {C : Set α → Prop} (S0 : Set α)

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1208,7 +1208,7 @@ theorem Finite.dinduction_on {C : ∀ s : Set α, s.Finite → Prop} (s : Set α
 #align set.finite.dinduction_on Set.Finite.dinduction_on
 
 theorem Finite.induction_univ [Finite α] (C : Set α → Prop) (S0 : Set α)
-    (H0 : C S0) (ih : ∀ S ≠ Set.univ, C S → ∃ a ∉ S, C ({a} ∪ S)) : C Set.univ := by
+    (H0 : C S0) (ih : ∀ S ≠ Set.univ, C S → ∃ a ∉ S, C (insert a S)) : C Set.univ := by
   refine' Finite.to_wellFoundedGT.wf.induction_bot' (fun S hS hS' ↦ _) H0
   obtain ⟨a, ha, ha'⟩ := ih S hS hS'
   exact ⟨_, Set.ssubset_insert ha, ha'⟩

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1207,6 +1207,12 @@ theorem Finite.dinduction_on {C : ∀ s : Set α, s.Finite → Prop} (s : Set α
   this h
 #align set.finite.dinduction_on Set.Finite.dinduction_on
 
+theorem Finite.induction_univ [Finite α] (C : Set α → Prop) (S0 : Set α)
+    (H0 : C S0) (ih : ∀ S ≠ Set.univ, C S → ∃ a ∉ S, C ({a} ∪ S)) : C Set.univ := by
+  refine' Finite.to_wellFoundedGT.wf.induction_bot' (fun S hS hS' ↦ _) H0
+  obtain ⟨a, ha, ha'⟩ := ih S hS hS'
+  exact ⟨_, Set.ssubset_insert ha, ha'⟩
+
 section
 
 attribute [local instance] Nat.fintypeIio


### PR DESCRIPTION
This PR adds another induction principle for `Set` where you prove that a property `C` holds of `Set.univ` by proving the inductive step `C S → ∃ a ∉ S, C (insert a S)` (the key being exists the use of exists rather than forall).

---

This was included in a resolved comment below: My motivation for the `∃ a` version is that it's needed to prove that a transitive subgroup generated by transpositions must be the whole symmetric group.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
