### PR TITLE
[Merged by Bors] - fix: use colGt in `#help` parser

### DIFF
--- a/Mathlib/Tactic/HelpCmd.lean
+++ b/Mathlib/Tactic/HelpCmd.lean
@@ -41,7 +41,7 @@ it will appear as a `(currently: true)` note next to the option.
 
 The form `#help option id` will show only options that begin with `id`.
 -/
-syntax withPosition("#help " &"option" (colGt ppSpace Parser.rawIdent)?) : command
+syntax withPosition("#help " colGt &"option" (colGt ppSpace Parser.rawIdent)?) : command
 
 private def elabHelpOption (id : Option Ident) : CommandElabM Unit := do
   let id := id.map (·.raw.getId.toString false)

--- a/Mathlib/Tactic/HelpCmd.lean
+++ b/Mathlib/Tactic/HelpCmd.lean
@@ -41,7 +41,9 @@ it will appear as a `(currently: true)` note next to the option.
 
 The form `#help option id` will show only options that begin with `id`.
 -/
-elab "#help " &"option" id:(ppSpace Parser.rawIdent)? : command => do
+syntax withPosition("#help " &"option" (colGt ppSpace Parser.rawIdent)?) : command
+
+private def elabHelpOption (id : Option Ident) : CommandElabM Unit := do
   let id := id.map (·.raw.getId.toString false)
   let mut decls : Lean.RBMap _ _ compare := {}
   for (name, decl) in show Lean.RBMap .. from ← getOptionDecls do
@@ -69,6 +71,8 @@ elab "#help " &"option" id:(ppSpace Parser.rawIdent)? : command => do
     msg := msg ++ .nest 2 (f!"option {name} : {msg1}" ++ .line ++ decl.descr) ++ .line ++ .line
   logInfo msg
 
+elab_rules : command | `(#help option $(id)?) => elabHelpOption id
+
 /--
 The command `#help attribute` (or the short form `#help attr`) shows all attributes that have been
 defined in the current environment.
@@ -83,7 +87,10 @@ as the docstring will be displayed here.
 
 The form `#help attr id` will show only attributes that begin with `id`.
 -/
-elab "#help " (&"attr" <|> &"attribute") id:(ppSpace Parser.rawIdent)? : command => do
+syntax withPosition("#help " colGt (&"attr" <|> &"attribute")
+    (colGt ppSpace Parser.rawIdent)?) : command
+
+private def elabHelpAttr (id : Option Ident) : CommandElabM Unit := do
   let id := id.map (·.raw.getId.toString false)
   let mut decls : Lean.RBMap _ _ compare := {}
   for (name, decl) in ← attributeMapRef.get do
@@ -104,6 +111,10 @@ elab "#help " (&"attr" <|> &"attribute") id:(ppSpace Parser.rawIdent)? : command
       msg1 := s!"{msg1}\n{doc.trim}"
     msg := msg ++ .nest 2 msg1 ++ .line ++ .line
   logInfo msg
+
+elab_rules : command
+  | `(#help attr $(id)?) => elabHelpAttr id
+  | `(#help attribute $(id)?) => elabHelpAttr id
 
 /-- Gets the initial string token in a parser description. For example, for a declaration like
 `syntax "bla" "baz" term : tactic`, it returns `some "bla"`. Returns `none` for syntax declarations
@@ -136,7 +147,9 @@ but you can click to go to the definition.) It also shows the doc string if avai
 
 The form `#help cats id` will show only syntax categories that begin with `id`.
 -/
-elab "#help " &"cats" id:(ppSpace Parser.rawIdent)? : command => do
+syntax withPosition("#help " colGt &"cats" (colGt ppSpace Parser.rawIdent)?) : command
+
+private def elabHelpCats (id : Option Ident) : CommandElabM Unit := do
   let id := id.map (·.raw.getId.toString false)
   let mut decls : Lean.RBMap _ _ compare := {}
   for (name, cat) in (Parser.parserExtension.getState (← getEnv)).categories do
@@ -158,6 +171,8 @@ elab "#help " &"cats" id:(ppSpace Parser.rawIdent)? : command => do
     msg := msg ++ .nest 2 msg1 ++ (.line ++ .line : Format)
   logInfo msg
 
+elab_rules : command | `(#help cats $(id)?) => elabHelpCats id
+
 /--
 The command `#help cat C` shows all syntaxes that have been defined in syntax category `C` in the
 current environment.
@@ -173,11 +188,11 @@ name of the syntax (which you can also click to go to the definition), and the d
 * The form `#help cat+ C` will also show information about any `macro`s and `elab`s
   associated to the listed syntaxes.
 -/
-elab "#help " &"cat" more:"+"? ppSpace catStx:ident
-    id:(ppSpace (Parser.rawIdent <|> str))? : command => do
-  let id := id.map fun id ↦ match id.raw with
-    | .ident _ _ v _ => v.toString false
-    | id => id.isStrLit?.get!
+syntax withPosition("#help " colGt &"cat" "+"? colGt ident
+    (colGt ppSpace (Parser.rawIdent <|> str))?) : command
+
+private def elabHelpCat (more : Option Syntax) (catStx : Ident) (id : Option String) :
+    CommandElabM Unit := do
   let mut decls : Lean.RBMap _ _ compare := {}
   let mut rest : Lean.RBMap _ _ compare := {}
   let catName := catStx.getId.eraseMacroScopes
@@ -231,30 +246,47 @@ elab "#help " &"cat" more:"+"? ppSpace catStx:ident
     msg ← addMsg k msg m!"syntax ... [{mkConst k}]"
   logInfo msg
 
+elab_rules : command
+  | `(#help cat $[+%$more]? $cat) => elabHelpCat more cat none
+  | `(#help cat $[+%$more]? $cat $id:ident) => elabHelpCat more cat (id.getId.toString false)
+  | `(#help cat $[+%$more]? $cat $id:str) => elabHelpCat more cat id.getString
+
 /--
 The command `#help term` shows all term syntaxes that have been defined in the current environment.
 See `#help cat` for more information.
 -/
-macro "#help " tk:&"term" more:"+"? id:(ppSpace (Parser.rawIdent <|> str))? : command =>
-  `(#help cat$[+%$more]? $(mkIdentFrom tk `term) $(id.map (⟨·.raw⟩))?)
+syntax withPosition("#help " colGt &"term" "+"?
+    (colGt ppSpace (Parser.rawIdent <|> str))?) : command
+macro_rules
+  | `(#help term%$tk $[+%$more]? $(id)?) =>
+    `(#help cat$[+%$more]? $(mkIdentFrom tk `term) $(id)?)
 
 /--
 The command `#help tactic` shows all tactics that have been defined in the current environment.
 See `#help cat` for more information.
 -/
-macro "#help " tk:&"tactic" more:"+"? id:(ppSpace (Parser.rawIdent <|> str))? : command => do
-  `(#help cat$[+%$more]? $(mkIdentFrom tk `tactic) $(id.map (⟨·.raw⟩))?)
+syntax withPosition("#help " colGt &"tactic" "+"?
+    (colGt ppSpace (Parser.rawIdent <|> str))?) : command
+macro_rules
+  | `(#help tactic%$tk $[+%$more]? $(id)?) =>
+    `(#help cat$[+%$more]? $(mkIdentFrom tk `tactic) $(id)?)
 
 /--
 The command `#help conv` shows all tactics that have been defined in the current environment.
 See `#help cat` for more information.
 -/
-macro "#help " tk:&"conv" more:"+"? id:(ppSpace (Parser.rawIdent <|> str))? : command =>
-  `(#help cat$[+%$more]? $(mkIdentFrom tk `conv) $(id.map (⟨·.raw⟩))?)
+syntax withPosition("#help " colGt &"conv" "+"?
+    (colGt ppSpace (Parser.rawIdent <|> str))?) : command
+macro_rules
+  | `(#help conv%$tk $[+%$more]? $(id)?) =>
+    `(#help cat$[+%$more]? $(mkIdentFrom tk `conv) $(id)?)
 
 /--
 The command `#help command` shows all commands that have been defined in the current environment.
 See `#help cat` for more information.
 -/
-macro "#help " tk:&"command" more:"+"? id:(ppSpace (Parser.rawIdent <|> str))? : command =>
-  `(#help cat$[+%$more]? $(mkIdentFrom tk `command) $(id.map (⟨·.raw⟩))?)
+syntax withPosition("#help " colGt &"command" "+"?
+    (colGt ppSpace (Parser.rawIdent <|> str))?) : command
+macro_rules
+  | `(#help command%$tk $[+%$more]? $(id)?) =>
+    `(#help cat$[+%$more]? $(mkIdentFrom tk `command) $(id)?)

--- a/test/help_cmd.lean
+++ b/test/help_cmd.lean
@@ -1,0 +1,6 @@
+import Mathlib.Tactic.HelpCmd
+import Std.Tactic.GuardMsgs
+
+#guard_msgs(error, drop info) in
+#help tactic
+def foo := 1


### PR DESCRIPTION
Fixes #9126. The parsers had to be split into a separate `syntax` declaration to allow for the `withPosition` combinator to set the position so that `colGt` works as intended.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
