### PR TITLE
refactor(FieldTheory/PolynomialGaloisGroup): Make `Polynomial.Gal` an `abbrev`

### DIFF
--- a/Mathlib/FieldTheory/PolynomialGaloisGroup.lean
+++ b/Mathlib/FieldTheory/PolynomialGaloisGroup.lean
@@ -52,26 +52,12 @@ namespace Polynomial
 variable {F : Type*} [Field F] (p q : F[X]) (E : Type*) [Field E] [Algebra F E]
 
 /-- The Galois group of a polynomial. -/
-def Gal :=
-  p.SplittingField ≃ₐ[F] p.SplittingField
+abbrev Gal := p.SplittingField ≃ₐ[F] p.SplittingField
 -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5020):
 -- deriving Group, Fintype
 #align polynomial.gal Polynomial.Gal
 
 namespace Gal
-
-instance instGroup : Group (Gal p) :=
-  inferInstanceAs (Group (p.SplittingField ≃ₐ[F] p.SplittingField))
-instance instFintype : Fintype (Gal p) :=
-  inferInstanceAs (Fintype (p.SplittingField ≃ₐ[F] p.SplittingField))
-
-instance : CoeFun p.Gal fun _ => p.SplittingField → p.SplittingField :=
-  -- Porting note: was AlgEquiv.hasCoeToFun
-  inferInstanceAs (CoeFun (p.SplittingField ≃ₐ[F] p.SplittingField) _)
-
-instance applyMulSemiringAction : MulSemiringAction p.Gal p.SplittingField :=
-  AlgEquiv.applyMulSemiringAction
-#align polynomial.gal.apply_mul_semiring_action Polynomial.Gal.applyMulSemiringAction
 
 @[ext]
 theorem ext {σ τ : p.Gal} (h : ∀ x ∈ p.rootSet p.SplittingField, σ x = τ x) : σ = τ := by


### PR DESCRIPTION
This PR makes `Polynomial.Gal` an `abbrev` since `p.Gal` is basically just used as a shorthand for the much more unwieldy expression `p.SplittingField ≃ₐ[F] p.SplittingField`. This also solves the problem of having to redefine instances on `Polynomial.Gal`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
