### PR TITLE
[Merged by Bors] - feat: define `QuadraticForm.IsOrtho` as `Q (x + y) = Q x + Q y`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2358,7 +2358,6 @@ import Mathlib.LinearAlgebra.CliffordAlgebra.EvenEquiv
 import Mathlib.LinearAlgebra.CliffordAlgebra.Fold
 import Mathlib.LinearAlgebra.CliffordAlgebra.Grading
 import Mathlib.LinearAlgebra.CliffordAlgebra.Inversion
-import Mathlib.LinearAlgebra.CliffordAlgebra.Prod
 import Mathlib.LinearAlgebra.CliffordAlgebra.Star
 import Mathlib.LinearAlgebra.Coevaluation
 import Mathlib.LinearAlgebra.Contraction

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2358,6 +2358,7 @@ import Mathlib.LinearAlgebra.CliffordAlgebra.EvenEquiv
 import Mathlib.LinearAlgebra.CliffordAlgebra.Fold
 import Mathlib.LinearAlgebra.CliffordAlgebra.Grading
 import Mathlib.LinearAlgebra.CliffordAlgebra.Inversion
+import Mathlib.LinearAlgebra.CliffordAlgebra.Prod
 import Mathlib.LinearAlgebra.CliffordAlgebra.Star
 import Mathlib.LinearAlgebra.Coevaluation
 import Mathlib.LinearAlgebra.Contraction

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -262,15 +262,36 @@ theorem ι_mul_ι_add_swap (a b : M) :
   mul_add_swap_eq_polar_of_forall_mul_self_eq _ (ι_sq_scalar _) _ _
 #align clifford_algebra.ι_mul_ι_add_swap CliffordAlgebra.ι_mul_ι_add_swap
 
-theorem ι_mul_comm (a b : M) :
+theorem ι_mul_ι_comm (a b : M) :
     ι Q a * ι Q b = algebraMap R _ (QuadraticForm.polar Q a b) - ι Q b * ι Q a :=
   eq_sub_of_add_eq (ι_mul_ι_add_swap a b)
-#align clifford_algebra.ι_mul_comm CliffordAlgebra.ι_mul_comm
+#align clifford_algebra.ι_mul_comm CliffordAlgebra.ι_mul_ι_comm
+
+section isOrtho
+
+@[simp] theorem ι_mul_ι_add_swap_of_isOrtho {a b : M} (h : Q.IsOrtho a b) :
+    ι Q a * ι Q b + ι Q b * ι Q a = 0 := by
+  rw [ι_mul_ι_add_swap, h.polar_eq_zero]
+  simp
+
+theorem ι_mul_ι_comm_of_isOrtho {a b : M} (h : Q.IsOrtho a b) :
+    ι Q a * ι Q b = -(ι Q b * ι Q a) :=
+  eq_neg_of_add_eq_zero_left <| ι_mul_ι_add_swap_of_isOrtho h
+
+theorem mul_ι_mul_ι_of_isOrtho (x : CliffordAlgebra Q) {a b : M} (h : Q.IsOrtho a b) :
+    x * ι Q a * ι Q b = -(x * ι Q b * ι Q a) := by
+  rw [mul_assoc, ι_mul_ι_comm_of_isOrtho h, mul_neg, mul_assoc]
+
+theorem ι_mul_ι_mul_of_isOrtho (x : CliffordAlgebra Q) {a b : M} (h : Q.IsOrtho a b) :
+    ι Q a * (ι Q b * x) = -(ι Q b * (ι Q a * x)) := by
+  rw [← mul_assoc, ι_mul_ι_comm_of_isOrtho h, neg_mul, mul_assoc]
+
+end isOrtho
 
 /-- $aba$ is a vector. -/
 theorem ι_mul_ι_mul_ι (a b : M) :
     ι Q a * ι Q b * ι Q a = ι Q (QuadraticForm.polar Q a b • a - Q a • b) := by
-  rw [ι_mul_comm, sub_mul, mul_assoc, ι_sq_scalar, ← Algebra.smul_def, ← Algebra.commutes, ←
+  rw [ι_mul_ι_comm, sub_mul, mul_assoc, ι_sq_scalar, ← Algebra.smul_def, ← Algebra.commutes, ←
     Algebra.smul_def, ← map_smul, ← map_smul, ← map_sub]
 #align clifford_algebra.ι_mul_ι_mul_ι CliffordAlgebra.ι_mul_ι_mul_ι
 

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
@@ -252,9 +252,7 @@ theorem ι_range_disjoint_one :
 
 @[simp]
 theorem ι_add_mul_swap (x y : M) : ι R x * ι R y + ι R y * ι R x = 0 :=
-  calc
-    _ = ι R (y + x) * ι R (y + x) := by simp [mul_add, add_mul]
-    _ = _ := ι_sq_zero _
+  CliffordAlgebra.ι_mul_ι_add_swap_of_isOrtho <| .all _ _
 #align exterior_algebra.ι_add_mul_swap ExteriorAlgebra.ι_add_mul_swap
 
 theorem ι_mul_prod_list {n : ℕ} (f : Fin n → M) (i : Fin n) :

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -37,6 +37,7 @@ and composition with linear maps `f`, `Q.comp f x = Q (f x)`.
  * `QuadraticForm.PosDef`: positive definite quadratic forms
  * `QuadraticForm.Anisotropic`: anisotropic quadratic forms
  * `QuadraticForm.discr`: discriminant of a quadratic form
+ * `QuadraticForm.IsOrtho`: orthogonality of vectors with respect to a quadratic form.
 
 ## Main statements
 
@@ -932,6 +933,62 @@ lemma associated_sq : associated (R := R) sq = LinearMap.toBilin (LinearMap.mul 
     by simp only [smul_add, invOf_two_smul_add_invOf_two_smul]; rfl
 
 end Associated
+
+section IsOrtho
+
+/-! ### Orthogonality -/
+
+section CommSemiring
+variable [CommSemiring R] [AddCommMonoid M] [Module R M] {Q : QuadraticForm R M}
+
+/-- The proposition that two elements of a quadratic form space are orthogonal. -/
+def IsOrtho (Q : QuadraticForm R M) (x y : M) : Prop :=
+  Q (x + y) = Q x + Q y
+
+theorem isOrtho_def {Q : QuadraticForm R M} {x y : M} : Q.IsOrtho x y ↔ Q (x + y) = Q x + Q y :=
+  Iff.rfl
+
+theorem IsOrtho.zero_left (x : M) : IsOrtho Q (0 : M) x := by simp [isOrtho_def]
+
+theorem IsOrtho.zero_right (x : M) : IsOrtho Q x (0 : M) := by simp [isOrtho_def]
+
+theorem ne_zero_of_not_isOrtho_self {Q : QuadraticForm R M} (x : M) (hx₁ : ¬Q.IsOrtho x x) :
+    x ≠ 0 :=
+  fun hx₂ => hx₁ (hx₂.symm ▸ .zero_left _)
+
+theorem isOrtho_comm {x y : M} : IsOrtho Q x y ↔ IsOrtho Q y x := by simp_rw [isOrtho_def, add_comm]
+
+alias ⟨IsOrtho.symm, _⟩ := isOrtho_comm
+
+theorem _root_.BilinForm.toQuadraticForm_isOrtho [IsCancelAdd R]
+    [NoZeroDivisors R] [CharZero R] {B : BilinForm R M} {x y : M} (h : B.IsSymm):
+    B.toQuadraticForm.IsOrtho x y ↔ B.IsOrtho x y := by
+  letI : AddCancelMonoid R := { ‹IsCancelAdd R›, (inferInstanceAs <| AddCommMonoid R) with }
+  simp_rw [isOrtho_def, BilinForm.isOrtho_def, toQuadraticForm_apply, bilin_add_left,
+    bilin_add_right, add_comm _ (B y y), add_add_add_comm _ _ (B y y), add_comm (B y y)]
+  rw [add_right_eq_self (a := B x x + B y y), h, add_self_eq_zero (R := R)]
+
+end CommSemiring
+
+section CommRing
+variable [CommRing R] [AddCommGroup M] [Module R M] {Q : QuadraticForm R M}
+
+@[simp]
+theorem isOrtho_polarBilin {x y : M} : Q.polarBilin.IsOrtho x y ↔ IsOrtho Q x y := by
+  simp_rw [isOrtho_def, BilinForm.isOrtho_def, polarBilin_apply, polar, sub_sub, sub_eq_zero]
+
+theorem IsOrtho.polar_eq_zero {x y : M} (h : IsOrtho Q x y) : polar Q x y = 0 :=
+  isOrtho_polarBilin.mpr h
+
+@[simp]
+theorem associated_isOrtho [Invertible (2 : R)] {x y : M} :
+    Q.associated.IsOrtho x y ↔ Q.IsOrtho x y := by
+  simp_rw [isOrtho_def, BilinForm.isOrtho_def, associated_apply, invOf_mul_eq_iff_eq_mul_left,
+    mul_zero, sub_sub, sub_eq_zero]
+
+end CommRing
+
+end IsOrtho
 
 section Anisotropic
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -948,6 +948,8 @@ def IsOrtho (Q : QuadraticForm R M) (x y : M) : Prop :=
 theorem isOrtho_def {Q : QuadraticForm R M} {x y : M} : Q.IsOrtho x y ↔ Q (x + y) = Q x + Q y :=
   Iff.rfl
 
+theorem IsOrtho.all (x y : M) : IsOrtho (0 : QuadraticForm R M) x y := (zero_add _).symm
+
 theorem IsOrtho.zero_left (x : M) : IsOrtho Q (0 : M) x := by simp [isOrtho_def]
 
 theorem IsOrtho.zero_right (x : M) : IsOrtho Q x (0 : M) := by simp [isOrtho_def]

--- a/Mathlib/LinearAlgebra/QuadraticForm/IsometryEquiv.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/IsometryEquiv.lean
@@ -174,7 +174,7 @@ theorem equivalent_weightedSumSquares_units_of_nondegenerate' (Q : QuadraticForm
     ∃ w : Fin (FiniteDimensional.finrank K V) → Kˣ, Equivalent Q (weightedSumSquares K w) := by
   obtain ⟨v, hv₁⟩ := exists_orthogonal_basis (associated_isSymm K Q)
   have hv₂ := hv₁.not_isOrtho_basis_self_of_nondegenerate hQ
-  simp_rw [IsOrtho, associated_eq_self_apply] at hv₂
+  simp_rw [BilinForm.IsOrtho, associated_eq_self_apply] at hv₂
   exact ⟨fun i => Units.mk0 _ (hv₂ i), ⟨Q.isometryEquivWeightedSumSquares v hv₁⟩⟩
 #align quadratic_form.equivalent_weighted_sum_squares_units_of_nondegenerate' QuadraticForm.equivalent_weightedSumSquares_units_of_nondegenerate'
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Prod.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Prod.lean
@@ -147,6 +147,29 @@ theorem PosDef.prod {R} [OrderedCommRing R] [Module R M₁] [Module R M₂]
   posDef_prod_iff.mpr ⟨h₁, h₂⟩
 #align quadratic_form.pos_def.prod QuadraticForm.PosDef.prod
 
+theorem IsOrtho.prod {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂}
+    {v w : M₁ × M₂} (h₁ : Q₁.IsOrtho v.1 w.1) (h₂ : Q₂.IsOrtho v.2 w.2) :
+    (Q₁.prod Q₂).IsOrtho v w :=
+  (congr_arg₂ HAdd.hAdd h₁ h₂).trans <| add_add_add_comm _ _ _ _
+
+@[simp] theorem IsOrtho.inl_inr {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂}
+    (m₁ : M₁) (m₂ : M₂) :
+    (Q₁.prod Q₂).IsOrtho (m₁, 0) (0, m₂) := .prod (.zero_right _) (.zero_left _)
+
+@[simp] theorem IsOrtho.inr_inl {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂}
+    (m₁ : M₁) (m₂ : M₂) :
+    (Q₁.prod Q₂).IsOrtho (0, m₂) (m₁, 0) := (IsOrtho.inl_inr _ _).symm
+
+@[simp] theorem isOrtho_inl_inl_iff {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂}
+    (m₁ m₁' : M₁) :
+    (Q₁.prod Q₂).IsOrtho (m₁, 0) (m₁', 0) ↔ Q₁.IsOrtho m₁ m₁' := by
+  simp [isOrtho_def]
+
+@[simp] theorem isOrtho_inr_inr_iff {Q₁ : QuadraticForm R M₁} {Q₂ : QuadraticForm R M₂}
+    (m₂ m₂' : M₂) :
+    (Q₁.prod Q₂).IsOrtho (0, m₂) (0, m₂') ↔ Q₂.IsOrtho m₂ m₂' := by
+  simp [isOrtho_def]
+
 end Semiring
 
 section Ring


### PR DESCRIPTION
This includes some basic API, and the connection with `BilinForm.IsOrtho`.

The motivation for this definition are the results about vectors commuting in a clifford algebra.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
