### PR TITLE
[Merged by Bors] - feat: Lemmas about `ZMod`

### DIFF
--- a/Mathlib/Algebra/Ring/Units.lean
+++ b/Mathlib/Algebra/Ring/Units.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Neil Strickland
 -/
 import Mathlib.Algebra.Ring.InjSurj
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Hom
+import Mathlib.Algebra.Ring.Hom.Defs
 
 #align_import algebra.ring.units from "leanprover-community/mathlib"@"2ed7e4aec72395b6a7c3ac4ac7873a7a43ead17c"
 
@@ -87,6 +88,16 @@ theorem divp_sub (a b : α) (u : αˣ) : a /ₚ u - b = (a - b * u) /ₚ u := by
   simp only [divp, sub_mul, sub_right_inj]
   rw [mul_assoc, Units.mul_inv, mul_one]
 #align units.divp_sub Units.divp_sub
+
+@[simp]
+protected theorem map_neg {F : Type*} [Ring β] [RingHomClass F α β] (f : F) (u : αˣ) :
+    map (f : α →* β) (-u) = -map (f : α →* β) u :=
+  ext (by simp only [coe_map, Units.val_neg, MonoidHom.coe_coe, map_neg])
+
+@[simp]
+protected theorem map_neg_one {F : Type*} [Ring β] [RingHomClass F α β] (f : F) :
+    map (f : α →* β) (-1) = -1 :=
+  by simp only [Units.map_neg, map_one]
 
 end Ring
 

--- a/Mathlib/Algebra/Ring/Units.lean
+++ b/Mathlib/Algebra/Ring/Units.lean
@@ -94,7 +94,6 @@ protected theorem map_neg {F : Type*} [Ring β] [RingHomClass F α β] (f : F) (
     map (f : α →* β) (-u) = -map (f : α →* β) u :=
   ext (by simp only [coe_map, Units.val_neg, MonoidHom.coe_coe, map_neg])
 
-@[simp]
 protected theorem map_neg_one {F : Type*} [Ring β] [RingHomClass F α β] (f : F) :
     map (f : α →* β) (-1) = -1 :=
   by simp only [Units.map_neg, map_one]

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -569,21 +569,21 @@ theorem ker_int_castRingHom (n : ℕ) :
   rw [Ideal.mem_span_singleton, RingHom.mem_ker, Int.coe_castRingHom, int_cast_zmod_eq_zero_iff_dvd]
 #align zmod.ker_int_cast_ring_hom ZMod.ker_int_castRingHom
 
-theorem cast_injective_of_lt {m n : ℕ} [nzm : NeZero m] (h : m < n) :
+theorem cast_injective_of_le {m n : ℕ} [nzm : NeZero m] (h : m ≤ n) :
     Function.Injective (@cast (ZMod n) _ m) := by
   cases m with
   | zero => cases nzm; simp_all
   | succ m =>
     rintro ⟨x, hx⟩ ⟨y, hy⟩ f
     simp only [cast, val, nat_cast_eq_nat_cast_iff',
-      Nat.mod_eq_of_lt (lt_trans hx h), Nat.mod_eq_of_lt (lt_trans hy h)] at f
+      Nat.mod_eq_of_lt (hx.trans_le h), Nat.mod_eq_of_lt (hy.trans_le h)] at f
     apply Fin.ext
     exact f
 
-theorem cast_zmod_eq_zero_iff_of_lt {m n : ℕ} [NeZero m] (h : m < n) (a : ZMod m) :
+theorem cast_zmod_eq_zero_iff_of_le {m n : ℕ} [NeZero m] (h : m ≤ n) (a : ZMod m) :
     (a : ZMod n) = 0 ↔ a = 0 := by
   rw [← ZMod.cast_zero (n := m)]
-  exact Injective.eq_iff' (cast_injective_of_lt h) rfl
+  exact Injective.eq_iff' (cast_injective_of_le h) rfl
 
 --Porting note: commented
 -- attribute [local semireducible] Int.NonNeg
@@ -946,6 +946,11 @@ theorem val_cast_eq_val_of_lt {m n : ℕ} [nzm : NeZero m] {a : ZMod m}
     cases n with
     | zero => cases nzn; simp_all
     | succ n => exact Fin.val_cast_of_lt h
+
+theorem cast_cast_zmod_of_le {m n : ℕ} [hm : NeZero m] (h : m ≤ n) (a : ZMod m) :
+    ((a : ZMod n) : ZMod m) = a := by
+  have : NeZero n := ⟨((Nat.zero_lt_of_ne_zero hm.out).trans_le h).ne'⟩
+  rw [cast_eq_val, val_cast_eq_val_of_lt (a.val_lt.trans_le h), nat_cast_zmod_val]
 
 /-- `valMinAbs x` returns the integer in the same equivalence class as `x` that is closest to `0`,
   The result will be in the interval `(-n/2, n/2]`. -/

--- a/Mathlib/Data/ZMod/Units.lean
+++ b/Mathlib/Data/ZMod/Units.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Moritz Firsching, Ashvni Narayanan, Michael Stoll
 -/
 import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.Nat.PrimeFin
+import Mathlib.Algebra.BigOperators.Associated
 
 
 /-!
@@ -32,5 +34,32 @@ lemma unitsMap_self (n : ℕ) : unitsMap (dvd_refl n) = MonoidHom.id _ := by
 
 lemma IsUnit_cast_of_dvd (hm : n ∣ m) (a : Units (ZMod m)) : IsUnit ((a : ZMod m) : ZMod n) :=
   Units.isUnit (unitsMap hm a)
+
+theorem unitsMap_surjective [hm : NeZero m] (h : n ∣ m) :
+    Function.Surjective (unitsMap h) := by
+  suffices ∀ x : ℕ, x.Coprime n → ∃ k : ℕ, (x + k * n).Coprime m by
+    intro x
+    have ⟨k, hk⟩ := this x.val.val (val_coe_unit_coprime x)
+    refine ⟨unitOfCoprime _ hk, Units.ext ?_⟩
+    have : NeZero n := ⟨fun hn ↦ hm.out (eq_zero_of_zero_dvd (hn ▸ h))⟩
+    simp [unitsMap_def]
+  intro x hx
+  let ps := m.primeFactors.filter (fun p ↦ ¬p ∣ x)
+  use ps.prod id
+  apply Nat.coprime_of_dvd
+  intro p pp hp hpn
+  by_cases hpx : p ∣ x
+  · have h := Nat.dvd_sub' hp hpx
+    rw [add_comm, Nat.add_sub_cancel] at h
+    rcases pp.dvd_mul.mp h with h | h
+    · have ⟨q, hq, hq'⟩ := (pp.prime.dvd_finset_prod_iff id).mp h
+      rw [Finset.mem_filter, Nat.mem_primeFactors,
+        ← (Nat.prime_dvd_prime_iff_eq pp hq.1.1).mp hq'] at hq
+      exact hq.2 hpx
+    · exact Nat.Prime.not_coprime_iff_dvd.mpr ⟨p, pp, hpx, h⟩ hx
+  · have pps : p ∈ ps := Finset.mem_filter.mpr ⟨Nat.mem_primeFactors.mpr ⟨pp, hpn, hm.out⟩, hpx⟩
+    have h := Nat.dvd_sub' hp ((Finset.dvd_prod_of_mem id pps).mul_right n)
+    rw [Nat.add_sub_cancel] at h
+    contradiction
 
 end ZMod


### PR DESCRIPTION
Added some lemmas about `ZMod` and its units:
* Generalized `lt` to `le` in two lemmas
* `((a : ZMod n) : ZMod m) = a` if `m ≤ n`
* `unitsMap` is surjective
* `Units.map f (-a) = -Units.map f a` (which can be applied to `unitsMap`)
* `Units.map (-1) = -1` (which can be applied to `unitsMap`)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
