### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Dimension): add various `surjective_injective` results

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -560,8 +560,8 @@ multiplications on `M` and `M'` are compatible, then the rank of `M / R` is smal
 the rank of `M' / R'`. As a special case, taking `R = R'` it is
 `LinearMap.lift_rank_le_of_injective`. -/
 theorem lift_rank_le_of_injective_injective (i : R' → R) (j : M →+ M')
-    (hi : ∀ s, i s = 0 → s = 0) (hj : Injective j)
-    (hc : ∀ (s : R') (x : M), j (i s • x) = s • j x) :
+    (hi : ∀ r, i r = 0 → r = 0) (hj : Injective j)
+    (hc : ∀ (r : R') (m : M), j (i r • m) = r • j m) :
     lift.{v'} (Module.rank R M) ≤ lift.{v} (Module.rank R' M') := by
   simp_rw [Module.rank, lift_iSup (bddAbove_range.{v', v'} _), lift_iSup (bddAbove_range.{v, v} _)]
   exact ciSup_mono' (bddAbove_range.{v', v} _) fun ⟨s, h⟩ ↦ ⟨⟨j '' s,
@@ -573,44 +573,44 @@ theorem lift_rank_le_of_injective_injective (i : R' → R) (j : M →+ M')
 `M'` are compatible, then the rank of `M / R` is smaller than or equal to the rank of `M' / R'`.
 As a special case, taking `R = R'` it is `LinearMap.lift_rank_le_of_injective`. -/
 theorem lift_rank_le_of_surjective_injective (i : ZeroHom R R') (j : M →+ M')
-    (hi : Surjective i) (hj : Injective j) (hc : ∀ (s : R) (x : M), j (s • x) = i s • j x) :
+    (hi : Surjective i) (hj : Injective j) (hc : ∀ (r : R) (m : M), j (r • m) = i r • j m) :
     lift.{v'} (Module.rank R M) ≤ lift.{v} (Module.rank R' M') := by
   obtain ⟨i', hi'⟩ := hi.hasRightInverse
-  refine lift_rank_le_of_injective_injective i' j (fun _ h ↦ ?_) hj fun s x ↦ ?_
+  refine lift_rank_le_of_injective_injective i' j (fun _ h ↦ ?_) hj fun r m ↦ ?_
   · apply_fun i at h
     rwa [hi', i.map_zero] at h
-  rw [hc (i' s) x, hi']
+  rw [hc (i' r) m, hi']
 
 /-- If `M / R` and `M' / R'` are modules, `i : R → R'` is a bijective map which maps zero to zero,
 `j : M ≃+ M'` is a group isomorphism, such that the scalar multiplications on `M` and `M'` are
 compatible, then the rank of `M / R` is equal to the rank of `M' / R'`.
 As a special case, taking `R = R'` it is `LinearEquiv.lift_rank_eq`. -/
 theorem lift_rank_eq_of_equiv_equiv (i : ZeroHom R R') (j : M ≃+ M')
-    (hi : Bijective i) (hc : ∀ (s : R) (x : M), j (s • x) = i s • j x) :
+    (hi : Bijective i) (hc : ∀ (r : R) (m : M), j (r • m) = i r • j m) :
     lift.{v'} (Module.rank R M) = lift.{v} (Module.rank R' M') :=
   (lift_rank_le_of_surjective_injective i j hi.2 j.injective hc).antisymm <|
     lift_rank_le_of_injective_injective i j.symm (fun _ _ ↦ hi.1 <| by rwa [i.map_zero])
-      j.symm.injective fun s x ↦ j.symm_apply_eq.2 <| by erw [hc, j.apply_symm_apply]
+      j.symm.injective fun _ _ ↦ j.symm_apply_eq.2 <| by erw [hc, j.apply_symm_apply]
 
 variable {M' : Type v} [Ring R'] [AddCommGroup M'] [Module R' M']
 
 /-- The same-universe version of `lift_rank_le_of_injective_injective`. -/
 theorem rank_le_of_injective_injective (i : R' → R) (j : M →+ M')
-    (hi : ∀ s, i s = 0 → s = 0) (hj : Injective j)
-    (hc : ∀ (s : R') (x : M), j (i s • x) = s • j x) :
+    (hi : ∀ r, i r = 0 → r = 0) (hj : Injective j)
+    (hc : ∀ (r : R') (m : M), j (i r • m) = r • j m) :
     Module.rank R M ≤ Module.rank R' M' := by
   simpa only [lift_id] using lift_rank_le_of_injective_injective i j hi hj hc
 
 /-- The same-universe version of `lift_rank_le_of_surjective_injective`. -/
 theorem rank_le_of_surjective_injective (i : ZeroHom R R') (j : M →+ M')
     (hi : Surjective i) (hj : Injective j)
-    (hc : ∀ (s : R) (x : M), j (s • x) = i s • j x) :
+    (hc : ∀ (r : R) (m : M), j (r • m) = i r • j m) :
     Module.rank R M ≤ Module.rank R' M' := by
   simpa only [lift_id] using lift_rank_le_of_surjective_injective i j hi hj hc
 
 /-- The same-universe version of `lift_rank_eq_of_equiv_equiv`. -/
 theorem rank_eq_of_equiv_equiv (i : ZeroHom R R') (j : M ≃+ M')
-    (hi : Bijective i) (hc : ∀ (s : R) (x : M), j (s • x) = i s • j x) :
+    (hi : Bijective i) (hc : ∀ (r : R) (m : M), j (r • m) = i r • j m) :
     Module.rank R M = Module.rank R' M' := by
   simpa only [lift_id] using lift_rank_eq_of_equiv_equiv i j hi hc
 
@@ -629,8 +629,8 @@ theorem lift_rank_le_of_injective_injective
     (hc : (j.comp (algebraMap R S)).comp i = algebraMap R' S') :
     lift.{v'} (Module.rank R S) ≤ lift.{v} (Module.rank R' S') := by
   refine _root_.lift_rank_le_of_injective_injective i j
-    (fun _ _ ↦ hi <| by rwa [i.map_zero]) hj fun s x ↦ ?_
-  have := congr($hc s)
+    (fun _ _ ↦ hi <| by rwa [i.map_zero]) hj fun r _ ↦ ?_
+  have := congr($hc r)
   simp only [RingHom.coe_comp, comp_apply] at this
   simp_rw [smul_def, AddMonoidHom.coe_coe, map_mul, this]
 
@@ -641,8 +641,8 @@ theorem lift_rank_le_of_surjective_injective
     (i : R →+* R') (j : S →+* S') (hi : Surjective i) (hj : Injective j)
     (hc : (algebraMap R' S').comp i = j.comp (algebraMap R S)) :
     lift.{v'} (Module.rank R S) ≤ lift.{v} (Module.rank R' S') := by
-  refine _root_.lift_rank_le_of_surjective_injective i j hi hj fun s x ↦ ?_
-  have := congr($hc s)
+  refine _root_.lift_rank_le_of_surjective_injective i j hi hj fun r _ ↦ ?_
+  have := congr($hc r)
   simp only [RingHom.coe_comp, comp_apply] at this
   simp only [smul_def, AddMonoidHom.coe_coe, map_mul, ZeroHom.coe_coe, this]
 
@@ -652,8 +652,8 @@ then the rank of `S / R` is equal to the rank of `S' / R'`. -/
 theorem lift_rank_eq_of_equiv_equiv (i : R ≃+* R') (j : S ≃+* S')
     (hc : (algebraMap R' S').comp i.toRingHom = j.toRingHom.comp (algebraMap R S)) :
     lift.{v'} (Module.rank R S) = lift.{v} (Module.rank R' S') := by
-  refine _root_.lift_rank_eq_of_equiv_equiv i j i.bijective fun s x ↦ ?_
-  have := congr($hc s)
+  refine _root_.lift_rank_eq_of_equiv_equiv i j i.bijective fun r _ ↦ ?_
+  have := congr($hc r)
   simp only [RingEquiv.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, comp_apply] at this
   simp only [smul_def, RingEquiv.coe_toAddEquiv, map_mul, ZeroHom.coe_coe, this]
 

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -563,17 +563,10 @@ theorem lift_rank_le_of_injective_injective (i : R' → R) (j : M →+ M')
     (hi : ∀ s, i s = 0 → s = 0) (hj : Injective j)
     (hc : ∀ (s : R') (x : M), j (i s • x) = s • j x) :
     lift.{v'} (Module.rank R M) ≤ lift.{v} (Module.rank R' M') := by
-  cases subsingleton_or_nontrivial R'
-  · nontriviality R
-    haveI := Module.subsingleton R' M'
-    haveI := hj.subsingleton
-    have : Module.rank R M = 0 := rank_eq_zero_iff.2 fun _ ↦ ⟨1, one_ne_zero, Subsingleton.elim _ _⟩
-    simp only [rank_subsingleton, this, lift_zero, lift_one, zero_le]
-  rw [Module.rank_def R M]
-  refine lift_iSup_le (bddAbove_range.{v, v} _) fun S ↦ ?_
-  obtain ⟨_, h⟩ := S
-  exact cardinal_lift_le_rank_of_linearIndependent (h.map_of_injective_injective i j hi
-    (fun x ↦ by rw [← _root_.map_zero (f := j)]; exact hj (a₁ := x) (a₂ := 0)) hc)
+  simp_rw [Module.rank, lift_iSup (bddAbove_range.{v', v'} _), lift_iSup (bddAbove_range.{v, v} _)]
+  exact ciSup_mono' (bddAbove_range.{v', v} _) fun ⟨s, h⟩ ↦ ⟨⟨j '' s,
+    (h.map_of_injective_injective i j hi (fun _ _ ↦ hj <| by rwa [j.map_zero]) hc).image⟩,
+      lift_mk_le'.mpr ⟨(Equiv.Set.image j s hj).toEmbedding⟩⟩
 
 /-- If `M / R` and `M' / R'` are modules, `i : R → R'` is a surjective map which maps zero to zero,
 `j : M →+ M'` is an injective group homomorphism, such that the scalar multiplications on `M` and
@@ -583,11 +576,10 @@ theorem lift_rank_le_of_surjective_injective (i : ZeroHom R R') (j : M →+ M')
     (hi : Surjective i) (hj : Injective j) (hc : ∀ (s : R) (x : M), j (s • x) = i s • j x) :
     lift.{v'} (Module.rank R M) ≤ lift.{v} (Module.rank R' M') := by
   obtain ⟨i', hi'⟩ := hi.hasRightInverse
-  refine lift_rank_le_of_injective_injective i' j (fun s h ↦ ?_) hj fun s x ↦ ?_
+  refine lift_rank_le_of_injective_injective i' j (fun _ h ↦ ?_) hj fun s x ↦ ?_
   · apply_fun i at h
-    rwa [hi', _root_.map_zero] at h
-  have h := hc (i' s) x
-  rwa [hi'] at h
+    rwa [hi', i.map_zero] at h
+  rw [hc (i' s) x, hi']
 
 /-- If `M / R` and `M' / R'` are modules, `i : R → R'` is a bijective map which maps zero to zero,
 `j : M ≃+ M'` is a group isomorphism, such that the scalar multiplications on `M` and `M'` are
@@ -595,15 +587,10 @@ compatible, then the rank of `M / R` is equal to the rank of `M' / R'`.
 As a special case, taking `R = R'` it is `LinearEquiv.lift_rank_eq`. -/
 theorem lift_rank_eq_of_equiv_equiv (i : ZeroHom R R') (j : M ≃+ M')
     (hi : Bijective i) (hc : ∀ (s : R) (x : M), j (s • x) = i s • j x) :
-    lift.{v'} (Module.rank R M) = lift.{v} (Module.rank R' M') := by
-  refine le_antisymm (lift_rank_le_of_surjective_injective i j hi.surjective j.injective hc) ?_
-  obtain ⟨i', h1, h2⟩ := Function.bijective_iff_has_inverse.1 hi
-  let I' : ZeroHom R' R := ⟨i', by apply_fun i using hi.injective; rw [h2, _root_.map_zero]⟩
-  refine lift_rank_le_of_surjective_injective I' j.symm h1.surjective j.symm.injective fun s x ↦ ?_
-  apply_fun j using j.injective
-  simp only [AddMonoidHom.coe_coe, AddEquiv.apply_symm_apply, hc]
-  change _ = i (i' s) • x
-  rw [h2]
+    lift.{v'} (Module.rank R M) = lift.{v} (Module.rank R' M') :=
+  (lift_rank_le_of_surjective_injective i j hi.2 j.injective hc).antisymm <|
+    lift_rank_le_of_injective_injective i j.symm (fun _ _ ↦ hi.1 <| by rwa [i.map_zero])
+      j.symm.injective fun s x ↦ j.symm_apply_eq.2 <| by erw [hc, j.apply_symm_apply]
 
 variable {M' : Type v} [Ring R'] [AddCommGroup M'] [Module R' M']
 
@@ -641,12 +628,11 @@ theorem lift_rank_le_of_injective_injective
     (i : R' →+* R) (j : S →+* S') (hi : Injective i) (hj : Injective j)
     (hc : (j.comp (algebraMap R S)).comp i = algebraMap R' S') :
     lift.{v'} (Module.rank R S) ≤ lift.{v} (Module.rank R' S') := by
-  refine _root_.lift_rank_le_of_injective_injective i j (fun s ↦ ?_) hj fun s x ↦ ?_
-  · rw [← _root_.map_zero (f := i)]
-    exact hi (a₁ := s) (a₂ := 0)
-  have := FunLike.congr_fun hc s
+  refine _root_.lift_rank_le_of_injective_injective i j
+    (fun _ _ ↦ hi <| by rwa [i.map_zero]) hj fun s x ↦ ?_
+  have := congr($hc s)
   simp only [RingHom.coe_comp, comp_apply] at this
-  simp only [smul_def, AddMonoidHom.coe_coe, map_mul, ZeroHom.coe_coe, this]
+  simp_rw [smul_def, AddMonoidHom.coe_coe, map_mul, this]
 
 /-- If `S / R` and `S' / R'` are algebras, `i : R →+* R'` is a surjective ring homomorphism,
 `j : S →+* S'` is an injective ring homorphism, such that `R → R' → S'` and `R → S → S'` commute,
@@ -656,7 +642,7 @@ theorem lift_rank_le_of_surjective_injective
     (hc : (algebraMap R' S').comp i = j.comp (algebraMap R S)) :
     lift.{v'} (Module.rank R S) ≤ lift.{v} (Module.rank R' S') := by
   refine _root_.lift_rank_le_of_surjective_injective i j hi hj fun s x ↦ ?_
-  have := FunLike.congr_fun hc s
+  have := congr($hc s)
   simp only [RingHom.coe_comp, comp_apply] at this
   simp only [smul_def, AddMonoidHom.coe_coe, map_mul, ZeroHom.coe_coe, this]
 
@@ -667,7 +653,7 @@ theorem lift_rank_eq_of_equiv_equiv (i : R ≃+* R') (j : S ≃+* S')
     (hc : (algebraMap R' S').comp i.toRingHom = j.toRingHom.comp (algebraMap R S)) :
     lift.{v'} (Module.rank R S) = lift.{v} (Module.rank R' S') := by
   refine _root_.lift_rank_eq_of_equiv_equiv i j i.bijective fun s x ↦ ?_
-  have := FunLike.congr_fun hc s
+  have := congr($hc s)
   simp only [RingEquiv.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, comp_apply] at this
   simp only [smul_def, RingEquiv.coe_toAddEquiv, map_mul, ZeroHom.coe_coe, this]
 

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -301,9 +301,8 @@ theorem LinearIndependent.map_of_surjective_injective {R' : Type*} {M' : Type*}
   obtain ⟨i', hi'⟩ := hi.hasRightInverse
   refine hv.map_of_injective_injective i' j (fun s h ↦ ?_) hj fun s x ↦ ?_
   · apply_fun i at h
-    rwa [hi', _root_.map_zero] at h
-  have h := hc (i' s) x
-  rwa [hi'] at h
+    rwa [hi', i.map_zero] at h
+  rw [hc (i' s) x, hi']
 
 /-- If the image of a family of vectors under a linear map is linearly independent, then so is
 the original family. -/

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -282,8 +282,8 @@ linearly independent families of vectors. As a special case, taking `R = R'`
 it is `LinearIndependent.map'`. -/
 theorem LinearIndependent.map_of_injective_injective {R' : Type*} {M' : Type*}
     [Semiring R'] [AddCommMonoid M'] [Module R' M'] (hv : LinearIndependent R v)
-    (i : R' → R) (j : M →+ M') (hi : ∀ s, i s = 0 → s = 0) (hj : ∀ x, j x = 0 → x = 0)
-    (hc : ∀ (s : R') (x : M), j (i s • x) = s • j x) : LinearIndependent R' (j ∘ v) := by
+    (i : R' → R) (j : M →+ M') (hi : ∀ r, i r = 0 → r = 0) (hj : ∀ m, j m = 0 → m = 0)
+    (hc : ∀ (r : R') (m : M), j (i r • m) = r • j m) : LinearIndependent R' (j ∘ v) := by
   rw [linearIndependent_iff'] at hv ⊢
   intro S r' H s hs
   simp_rw [comp_apply, ← hc, ← map_sum] at H
@@ -296,13 +296,13 @@ of vectors to linearly independent families of vectors. As a special case, takin
 it is `LinearIndependent.map'`. -/
 theorem LinearIndependent.map_of_surjective_injective {R' : Type*} {M' : Type*}
     [Semiring R'] [AddCommMonoid M'] [Module R' M'] (hv : LinearIndependent R v)
-    (i : ZeroHom R R') (j : M →+ M') (hi : Surjective i) (hj : ∀ x, j x = 0 → x = 0)
-    (hc : ∀ (s : R) (x : M), j (s • x) = i s • j x) : LinearIndependent R' (j ∘ v) := by
+    (i : ZeroHom R R') (j : M →+ M') (hi : Surjective i) (hj : ∀ m, j m = 0 → m = 0)
+    (hc : ∀ (r : R) (m : M), j (r • m) = i r • j m) : LinearIndependent R' (j ∘ v) := by
   obtain ⟨i', hi'⟩ := hi.hasRightInverse
-  refine hv.map_of_injective_injective i' j (fun s h ↦ ?_) hj fun s x ↦ ?_
+  refine hv.map_of_injective_injective i' j (fun _ h ↦ ?_) hj fun r m ↦ ?_
   · apply_fun i at h
     rwa [hi', i.map_zero] at h
-  rw [hc (i' s) x, hi']
+  rw [hc (i' r) m, hi']
 
 /-- If the image of a family of vectors under a linear map is linearly independent, then so is
 the original family. -/

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -275,21 +275,35 @@ theorem LinearIndependent.map' (hv : LinearIndependent R v) (f : M →ₗ[R] M')
   hv.map <| by simp [hf_inj]
 #align linear_independent.map' LinearIndependent.map'
 
-/-- If `M / R` and `M' / R'` are modules, `i : R → R'` is a surjective map which maps zero to zero,
-`j : M →+ M'` is an injective monoid map, such that the scalar multiplications on `M` and `M'` are
-compatible, then `j` sends linearly independent families of vectors to linearly independent
-families of vectors. As a special case, taking `R = R'` it is `LinearIndependent.map'`. -/
-theorem LinearIndependent.map_of_surjective_injective {R' : Type*} {M' : Type*}
+/-- If `M / R` and `M' / R'` are modules, `i : R' → R` is a map, `j : M →+ M'` is a monoid map,
+such that they send non-zero elements to non-zero elements, and compatible with the scalar
+multiplications on `M` and `M'`, then `j` sends linearly independent families of vectors to
+linearly independent families of vectors. As a special case, taking `R = R'`
+it is `LinearIndependent.map'`. -/
+theorem LinearIndependent.map_of_injective_injective {R' : Type*} {M' : Type*}
     [Semiring R'] [AddCommMonoid M'] [Module R' M'] (hv : LinearIndependent R v)
-    (i : ZeroHom R R') (j : M →+ M') (hi : Surjective i) (hj : Injective j)
-    (hc : ∀ (s : R) (x : M), j (s • x) = i s • j x) : LinearIndependent R' (j ∘ v) := by
-  obtain ⟨i', hi'⟩ := hi.hasRightInverse
+    (i : R' → R) (j : M →+ M') (hi : ∀ s, i s = 0 → s = 0) (hj : ∀ x, j x = 0 → x = 0)
+    (hc : ∀ (s : R') (x : M), j (i s • x) = s • j x) : LinearIndependent R' (j ∘ v) := by
   rw [linearIndependent_iff'] at hv ⊢
   intro S r' H s hs
-  have h1 (s : ι) : r' s • (j ∘ v) s = j (i' (r' s) • v s) := by rw [hc, hi', comp_apply]
-  simp_rw [h1, ← map_sum, ← map_zero (f := j)] at H
-  replace H := congr_arg i <| hv _ _ (hj H) s hs
-  rwa [hi', _root_.map_zero] at H
+  simp_rw [comp_apply, ← hc, ← map_sum] at H
+  exact hi _ <| hv _ _ (hj _ H) s hs
+
+/-- If `M / R` and `M' / R'` are modules, `i : R → R'` is a surjective map which maps zero to zero,
+`j : M →+ M'` is a monoid map which sends non-zero elements to non-zero elements, such that the
+scalar multiplications on `M` and `M'` are compatible, then `j` sends linearly independent families
+of vectors to linearly independent families of vectors. As a special case, taking `R = R'`
+it is `LinearIndependent.map'`. -/
+theorem LinearIndependent.map_of_surjective_injective {R' : Type*} {M' : Type*}
+    [Semiring R'] [AddCommMonoid M'] [Module R' M'] (hv : LinearIndependent R v)
+    (i : ZeroHom R R') (j : M →+ M') (hi : Surjective i) (hj : ∀ x, j x = 0 → x = 0)
+    (hc : ∀ (s : R) (x : M), j (s • x) = i s • j x) : LinearIndependent R' (j ∘ v) := by
+  obtain ⟨i', hi'⟩ := hi.hasRightInverse
+  refine hv.map_of_injective_injective i' j (fun s h ↦ ?_) hj fun s x ↦ ?_
+  · apply_fun i at h
+    rwa [hi', _root_.map_zero] at h
+  have h := hc (i' s) x
+  rwa [hi'] at h
 
 /-- If the image of a family of vectors under a linear map is linearly independent, then so is
 the original family. -/

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -275,6 +275,22 @@ theorem LinearIndependent.map' (hv : LinearIndependent R v) (f : M →ₗ[R] M')
   hv.map <| by simp [hf_inj]
 #align linear_independent.map' LinearIndependent.map'
 
+/-- If `M / R` and `M' / R'` are modules, `i : R → R'` is a surjective map which maps zero to zero,
+`j : M →+ M'` is an injective monoid map, such that the scalar multiplications on `M` and `M'` are
+compatible, then `j` sends linearly independent families of vectors to linearly independent
+families of vectors. As a special case, taking `R = R'` it is `LinearIndependent.map'`. -/
+theorem LinearIndependent.map_of_surjective_injective {R' : Type*} {M' : Type*}
+    [Semiring R'] [AddCommMonoid M'] [Module R' M'] (hv : LinearIndependent R v)
+    (i : ZeroHom R R') (j : M →+ M') (hi : Surjective i) (hj : Injective j)
+    (hc : ∀ (s : R) (x : M), j (s • x) = i s • j x) : LinearIndependent R' (j ∘ v) := by
+  obtain ⟨i', hi'⟩ := hi.hasRightInverse
+  rw [linearIndependent_iff'] at hv ⊢
+  intro S r' H s hs
+  have h1 (s : ι) : r' s • (j ∘ v) s = j (i' (r' s) • v s) := by rw [hc, hi', comp_apply]
+  simp_rw [h1, ← map_sum, ← map_zero (f := j)] at H
+  replace H := congr_arg i <| hv _ _ (hj H) s hs
+  rwa [hi', _root_.map_zero] at H
+
 /-- If the image of a family of vectors under a linear map is linearly independent, then so is
 the original family. -/
 theorem LinearIndependent.of_comp (f : M →ₗ[R] M') (hfv : LinearIndependent R (f ∘ v)) :


### PR DESCRIPTION
Add various results concerning modules `M / R` and `M' / R'` with maps `i : R -> R'` and `j : M -> M'` which are compatible with scalar multiplications on `M` and `M'`.

- if `i : R' -> R` is injective and `j` is injective, then:
  - `LinearIndependent.map_of_injective_injective`: `j` preserves linear independent subsets.
  - `[lift_]rank_le_of_injective_injective`: rank of `M / R` is smaller than or equal to the rank of `M' / R'`.
- if `i` is surjective and `j` is injective, then:
  - `LinearIndependent.map_of_surjective_injective`: `j` preserves linear independent subsets.
  - `[lift_]rank_le_of_surjective_injective`: rank of `M / R` is smaller than or equal to the rank of `M' / R'`.
- if `i` and `j` are both bijective, then `[lift_]rank_eq_of_equiv_equiv`: rank of `M / R` is equal to the rank of `M' / R'`.

Also add the `Algebra` versions of these results.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Discussion thread: https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/.E2.9C.94.20.60E.2FL.2FF.60.20and.20.60K.2FL'.2FF.60.20isomorphic.20.3D.3E.20.60.5BE.3AL.5D.3D.5BK.3AL'.5D.60/near/408072594

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
