### PR TITLE
[Merged by Bors] - feat(NumberTheory/ZetaFunction): residue of Riemann zeta at s = 1

### DIFF
--- a/Mathlib/NumberTheory/ZetaFunction.lean
+++ b/Mathlib/NumberTheory/ZetaFunction.lean
@@ -797,3 +797,39 @@ theorem riemannZeta_neg_nat_eq_bernoulli (k : ℕ) :
     rw [inv_mul_cancel (ofReal_ne_zero.mpr <| pow_ne_zero _ pi_pos.ne'),
       inv_mul_cancel (ofReal_ne_zero.mpr <| pow_ne_zero _ two_ne_zero), one_mul, one_mul]
 #align riemann_zeta_neg_nat_eq_bernoulli riemannZeta_neg_nat_eq_bernoulli
+
+/-- The residue of `Λ(s)` at `s = 1` is equal to 1. -/
+lemma riemannCompletedZeta_residue_one :
+    Tendsto (fun s ↦ (s - 1) * riemannCompletedZeta s) (𝓝[≠] 1) (𝓝 1) := by
+  unfold riemannCompletedZeta
+  simp_rw [mul_add, mul_sub, (by simp : 𝓝 (1 : ℂ) = 𝓝 (0 - 0 + 1))]
+  refine ((Tendsto.sub ?_ ?_).mono_left nhdsWithin_le_nhds).add ?_
+  · rw [(by simp : 𝓝 (0 : ℂ) = 𝓝 ((1 - 1) * riemannCompletedZeta₀ 1))]
+    apply ((continuous_sub_right _).mul differentiable_completed_zeta₀.continuous).tendsto
+  · rw [(by simp : 𝓝 (0 : ℂ) = 𝓝 ((1 - 1)  * (1 / 1)))]
+    exact (((continuous_sub_right _).continuousAt).mul <|
+      continuousAt_const.div continuousAt_id one_ne_zero)
+  · refine (tendsto_const_nhds.mono_left nhdsWithin_le_nhds).congr' ?_
+    refine eventually_nhdsWithin_of_forall (fun s hs ↦ ?_)
+    simpa using (div_self <| sub_ne_zero_of_ne <| Set.mem_compl_singleton_iff.mpr hs).symm
+
+/-- The residue of `ζ(s)` at `s = 1` is equal to 1. -/
+lemma riemannZeta_residue_one : Tendsto (fun s ↦ (s - 1) * riemannZeta s) (𝓝[≠] 1) (𝓝 1) := by
+  suffices : Tendsto (fun s => (s - 1) *
+      (π ^ (s / 2) * riemannCompletedZeta s / Gamma (s / 2))) (𝓝[≠] 1) (𝓝 1)
+  · refine this.congr' <| (eventually_ne_nhdsWithin (one_ne_zero' ℂ)).mp (eventually_of_forall ?_)
+    intro x hx
+    simp [riemannZeta_def, Function.update_noteq hx]
+  have h0 : Tendsto (fun s ↦ π ^ (s / 2) : ℂ → ℂ) (𝓝[≠] 1) (𝓝 (π ^ (1 / 2 : ℂ)))
+  · refine ((continuousAt_id.div_const _).const_cpow ?_).tendsto.mono_left nhdsWithin_le_nhds
+    exact Or.inl <| ofReal_ne_zero.mpr pi_ne_zero
+  have h1 : Tendsto (fun s : ℂ ↦ 1 / Gamma (s / 2)) (𝓝[≠] 1) (𝓝 (1 / π ^ (1 / 2 : ℂ)))
+  · rw [← Complex.Gamma_one_half_eq]
+    refine (Continuous.tendsto ?_ _).mono_left nhdsWithin_le_nhds
+    simpa using differentiable_one_div_Gamma.continuous.comp (continuous_id.div_const _)
+  convert (riemannCompletedZeta_residue_one.mul h0).mul h1 using 2 with s
+  · ring
+  · rw [one_mul, mul_one_div, div_self]
+    rw [(by simp : (1 / 2 : ℂ) = ↑(1 / 2 : ℝ)), ← ofReal_cpow pi_pos.le, Ne.def, ofReal_eq_zero,
+      rpow_eq_zero_iff_of_nonneg pi_pos.le, not_and_or]
+    exact Or.inl pi_ne_zero

--- a/Mathlib/NumberTheory/ZetaFunction.lean
+++ b/Mathlib/NumberTheory/ZetaFunction.lean
@@ -829,5 +829,5 @@ lemma riemannZeta_residue_one : Tendsto (fun s ↦ (s - 1) * riemannZeta s) (�
     simpa using differentiable_one_div_Gamma.continuous.comp (continuous_id.div_const _)
   convert (riemannCompletedZeta_residue_one.mul h0).mul h1 using 2 with s
   · ring
-  · haveI := fun h ↦ ofReal_ne_zero.mpr pi_ne_zero ((cpow_eq_zero_iff _ (1 / 2)).mp h).1
+  · have := fun h ↦ ofReal_ne_zero.mpr pi_ne_zero ((cpow_eq_zero_iff _ (1 / 2)).mp h).1
     field_simp

--- a/Mathlib/NumberTheory/ZetaFunction.lean
+++ b/Mathlib/NumberTheory/ZetaFunction.lean
@@ -829,7 +829,5 @@ lemma riemannZeta_residue_one : Tendsto (fun s ↦ (s - 1) * riemannZeta s) (�
     simpa using differentiable_one_div_Gamma.continuous.comp (continuous_id.div_const _)
   convert (riemannCompletedZeta_residue_one.mul h0).mul h1 using 2 with s
   · ring
-  · rw [one_mul, mul_one_div, div_self]
-    rw [(by simp : (1 / 2 : ℂ) = ↑(1 / 2 : ℝ)), ← ofReal_cpow pi_pos.le, Ne.def, ofReal_eq_zero,
-      rpow_eq_zero_iff_of_nonneg pi_pos.le, not_and_or]
-    exact Or.inl pi_ne_zero
+  · haveI := fun h ↦ ofReal_ne_zero.mpr pi_ne_zero ((cpow_eq_zero_iff _ (1 / 2)).mp h).1
+    field_simp

--- a/Mathlib/NumberTheory/ZetaFunction.lean
+++ b/Mathlib/NumberTheory/ZetaFunction.lean
@@ -806,7 +806,7 @@ lemma riemannCompletedZeta_residue_one :
   refine ((Tendsto.sub ?_ ?_).mono_left nhdsWithin_le_nhds).add ?_
   · rw [(by simp : 𝓝 (0 : ℂ) = 𝓝 ((1 - 1) * riemannCompletedZeta₀ 1))]
     apply ((continuous_sub_right _).mul differentiable_completed_zeta₀.continuous).tendsto
-  · rw [(by simp : 𝓝 (0 : ℂ) = 𝓝 ((1 - 1)  * (1 / 1)))]
+  · rw [(by simp : 𝓝 (0 : ℂ) = 𝓝 ((1 - 1) * (1 / 1)))]
     exact (((continuous_sub_right _).continuousAt).mul <|
       continuousAt_const.div continuousAt_id one_ne_zero)
   · refine (tendsto_const_nhds.mono_left nhdsWithin_le_nhds).congr' ?_
@@ -817,7 +817,7 @@ lemma riemannCompletedZeta_residue_one :
 lemma riemannZeta_residue_one : Tendsto (fun s ↦ (s - 1) * riemannZeta s) (𝓝[≠] 1) (𝓝 1) := by
   suffices : Tendsto (fun s => (s - 1) *
       (π ^ (s / 2) * riemannCompletedZeta s / Gamma (s / 2))) (𝓝[≠] 1) (𝓝 1)
-  · refine this.congr' <| (eventually_ne_nhdsWithin (one_ne_zero' ℂ)).mp (eventually_of_forall ?_)
+  · refine this.congr' <| (eventually_ne_nhdsWithin one_ne_zero).mp (eventually_of_forall ?_)
     intro x hx
     simp [riemannZeta_def, Function.update_noteq hx]
   have h0 : Tendsto (fun s ↦ π ^ (s / 2) : ℂ → ℂ) (𝓝[≠] 1) (𝓝 (π ^ (1 / 2 : ℂ)))


### PR DESCRIPTION
We add the computation of the residue of the completed and non-completed Riemann zeta functions at `s = 1`. 

---

See [this zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Residue.20of.20the.20Riemann.20zeta.20function).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
