### PR TITLE
[Merged by Bors] - fix(Data/Option/Defs): Remove `Option.rel` and `Option.maybe`, superceded by std4

### DIFF
--- a/Mathlib/Data/Option/Defs.lean
+++ b/Mathlib/Data/Option/Defs.lean
@@ -21,14 +21,7 @@ namespace Option
 
 #align option.lift_or_get Option.liftOrGet
 
-/-- Lifts a relation `α → β → Prop` to a relation `Option α → Option β → Prop` by just adding
-`none ~ none`. -/
-inductive rel (r : α → β → Prop) : Option α → Option β → Prop
-  | /-- If `a ~ b`, then `some a ~ some b` -/
-    some {a b} : r a b → rel r (some a) (some b)
-  | /-- `none ~ none` -/
-    none : rel r none none
-#align option.rel Option.rel
+#align option.rel Option.Rel
 
 /-- Traverse an object of `Option α` with a function `f : α → F β` for an applicative `F`. -/
 protected def traverse.{u, v}
@@ -38,13 +31,7 @@ protected def traverse.{u, v}
   | some x => some <$> f x
 #align option.traverse Option.traverse
 
-/-- If you maybe have a monadic computation in a `[Monad m]` which produces a term of type `α`,
-then there is a naturally associated way to always perform a computation in `m` which maybe
-produces a result. -/
-def maybe.{u, v} {m : Type u → Type v} [Monad m] {α : Type u} : Option (m α) → m (Option α)
-  | none => pure none
-  | some fn => some <$> fn
-#align option.maybe Option.maybe
+#align option.maybe Option.sequence
 
 #align option.mmap Option.mapM
 #align option.melim Option.elimM

--- a/Mathlib/Data/Option/Defs.lean
+++ b/Mathlib/Data/Option/Defs.lean
@@ -21,8 +21,6 @@ namespace Option
 
 #align option.lift_or_get Option.liftOrGet
 
-#align option.rel Option.Rel
-
 /-- Traverse an object of `Option α` with a function `f : α → F β` for an applicative `F`. -/
 protected def traverse.{u, v}
     {F : Type u → Type v} [Applicative F] {α : Type*} {β : Type u} (f : α → F β) :


### PR DESCRIPTION
Remove `Option.rel` and `Option.maybe`, which have identical definitions to `Option.Rel` and `Option.sequence`, and aren't used anywhere.

---
<!-- 

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
