### PR TITLE
[Merged by Bors] - fix: use `--install` flag in `lake update` hook

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -93,7 +93,7 @@ post_update pkg do
     -/
     let exitCode ← IO.Process.spawn {
       cmd := "elan"
-      args := #["run", mathlibToolchain.trim, "lake", "exe", "cache", "get"]
+      args := #["run", "--install", mathlibToolchain.trim, "lake", "exe", "cache", "get"]
     } >>= (·.wait)
     if exitCode ≠ 0 then
       logError s!"{pkg.name}: failed to fetch cache"


### PR DESCRIPTION
Fixes an issue [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/post-update.20hook.20failure/near/409543553). Without the `--install` flag elan will not download the new toolchain if it doesn't already have it. Since this is in an update call which is already expected to download things I think this should be okay.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
