### PR TITLE
[Merged by Bors] - chore(Subfield): use `rintro`

### DIFF
--- a/Mathlib/FieldTheory/Subfield.lean
+++ b/Mathlib/FieldTheory/Subfield.lean
@@ -674,6 +674,7 @@ def closure (s : Set K) : Subfield K where
     exact ⟨-y, Subring.neg_mem _ hy, z, hz, x_eq ▸ neg_div _ _⟩
   inv_mem' x := by rintro ⟨y, hy, z, hz, x_eq⟩; exact ⟨z, hz, y, hy, x_eq ▸ (inv_div _ _).symm ⟩
   add_mem' x_mem y_mem := by
+    -- Use `id` in the next 2 `obtain`s so that assumptions stay there for the `rwa`s below
     obtain ⟨nx, hnx, dx, hdx, rfl⟩ := id x_mem
     obtain ⟨ny, hny, dy, hdy, rfl⟩ := id y_mem
     by_cases hx0 : dx = 0; · rwa [hx0, div_zero, zero_add]
@@ -681,12 +682,10 @@ def closure (s : Set K) : Subfield K where
     exact
       ⟨nx * dy + dx * ny, Subring.add_mem _ (Subring.mul_mem _ hnx hdy) (Subring.mul_mem _ hdx hny),
         dx * dy, Subring.mul_mem _ hdx hdy, (div_add_div nx ny hx0 hy0).symm⟩
-  mul_mem' x_mem y_mem := by
-    obtain ⟨nx, hnx, dx, hdx, rfl⟩ := id x_mem
-    obtain ⟨ny, hny, dy, hdy, rfl⟩ := id y_mem
-    exact
-      ⟨nx * ny, Subring.mul_mem _ hnx hny, dx * dy, Subring.mul_mem _ hdx hdy,
-        (div_mul_div_comm _ _ _ _).symm⟩
+  mul_mem' := by
+    rintro _ _ ⟨nx, hnx, dx, hdx, rfl⟩ ⟨ny, hny, dy, hdy, rfl⟩
+    exact ⟨nx * ny, Subring.mul_mem _ hnx hny, dx * dy, Subring.mul_mem _ hdx hdy,
+      (div_mul_div_comm _ _ _ _).symm⟩
 #align subfield.closure Subfield.closure
 
 theorem mem_closure_iff {s : Set K} {x} :


### PR DESCRIPTION
Also explain why it can't be used in another field

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)