### PR TITLE
[Merged by Bors] - doc: Example use case of `Finset.filter`

### DIFF
--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -2712,7 +2712,7 @@ variable (p q : α → Prop) [DecidablePred p] [DecidablePred q] {s : Finset α}
 
 /-- `Finset.filter p s` is the set of elements of `s` that satisfy `p`.
 
-For example, one can use `s.filter (· ∈ t)` to get the intersection of `s` with a `t : Set α`
+For example, one can use `s.filter (· ∈ t)` to get the intersection of `s` with `t : Set α`
 as a `Finset α` (when a `DecidablePred (· ∈ t)` instance is available). -/
 def filter (s : Finset α) : Finset α :=
   ⟨_, s.2.filter p⟩

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -2713,7 +2713,7 @@ variable (p q : α → Prop) [DecidablePred p] [DecidablePred q] {s : Finset α}
 /-- `Finset.filter p s` is the set of elements of `s` that satisfy `p`.
 
 For example, one can use `s.filter (· ∈ t)` to get the intersection of `s` with a `t : Set α`
-as a `Finset α`. -/
+as a `Finset α` (when a `DecidablePred (· ∈ t)` instance is available). -/
 def filter (s : Finset α) : Finset α :=
   ⟨_, s.2.filter p⟩
 #align finset.filter Finset.filter

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -2710,7 +2710,9 @@ section Filter
 
 variable (p q : α → Prop) [DecidablePred p] [DecidablePred q] {s : Finset α}
 
-/-- `Finset.filter p s` is the set of elements of `s` that satisfy `p`. -/
+/-- `Finset.filter p s` is the set of elements of `s` that satisfy `p`.
+For example, one can use `s.filter (· ∈ t)` to get the intersection of `s` with a `t : Set α`
+as a `Finset α`. -/
 def filter (s : Finset α) : Finset α :=
   ⟨_, s.2.filter p⟩
 #align finset.filter Finset.filter

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -2711,6 +2711,7 @@ section Filter
 variable (p q : α → Prop) [DecidablePred p] [DecidablePred q] {s : Finset α}
 
 /-- `Finset.filter p s` is the set of elements of `s` that satisfy `p`.
+
 For example, one can use `s.filter (· ∈ t)` to get the intersection of `s` with a `t : Set α`
 as a `Finset α`. -/
 def filter (s : Finset α) : Finset α :=


### PR DESCRIPTION
Mention the spelling `s.filter (· ∈ t)` for the intersection of `s : Finset α` and `t : Set α` as a `Finset α` in the docstring of `Finset.filter`.

See [here](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Intersection.20of.20a.20Finset.20and.20a.20Set.20as.20a.20Finset.3F/near/409632763) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
