### PR TITLE
[Merged by Bors] - chore: audit remaining uses of "local homeomorphism" in comments

### DIFF
--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -1899,7 +1899,7 @@ namespace PartialHomeomorph
 
 variable (𝕜)
 
-/-- Restrict a local homeomorphism to the subsets of the source and target
+/-- Restrict a partial homeomorphism to the subsets of the source and target
 that consist of points `x ∈ f.source`, `y = f x ∈ f.target`
 such that `f` is `C^n` at `x` and `f.symm` is `C^n` at `y`.
 

--- a/Mathlib/Analysis/Calculus/Deriv/Inverse.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inverse.lean
@@ -70,7 +70,7 @@ theorem HasStrictDerivAt.of_local_left_inverse {f g : 𝕜 → 𝕜} {f' a : �
   (hf.hasStrictFDerivAt_equiv hf').of_local_left_inverse hg hfg
 #align has_strict_deriv_at.of_local_left_inverse HasStrictDerivAt.of_local_left_inverse
 
-/-- If `f` is a local homeomorphism defined on a neighbourhood of `f.symm a`, and `f` has a
+/-- If `f` is a partial homeomorphism defined on a neighbourhood of `f.symm a`, and `f` has a
 nonzero derivative `f'` at `f.symm a` in the strict sense, then `f.symm` has the derivative `f'⁻¹`
 at `a` in the strict sense.
 
@@ -93,7 +93,7 @@ theorem HasDerivAt.of_local_left_inverse {f g : 𝕜 → 𝕜} {f' a : 𝕜} (hg
   (hf.hasFDerivAt_equiv hf').of_local_left_inverse hg hfg
 #align has_deriv_at.of_local_left_inverse HasDerivAt.of_local_left_inverse
 
-/-- If `f` is a local homeomorphism defined on a neighbourhood of `f.symm a`, and `f` has a
+/-- If `f` is a partial homeomorphism defined on a neighbourhood of `f.symm a`, and `f` has a
 nonzero derivative `f'` at `f.symm a`, then `f.symm` has the derivative `f'⁻¹` at `a`.
 
 This is one of the easy parts of the inverse function theorem: it assumes that we already have

--- a/Mathlib/Analysis/Calculus/FDeriv/Equiv.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Equiv.lean
@@ -404,7 +404,7 @@ theorem HasFDerivAt.of_local_left_inverse {f : E → F} {f' : E ≃L[𝕜] F} {g
     simp only [(· ∘ ·), hp, hfg.self_of_nhds]
 #align has_fderiv_at.of_local_left_inverse HasFDerivAt.of_local_left_inverse
 
-/-- If `f` is a local homeomorphism defined on a neighbourhood of `f.symm a`, and `f` has an
+/-- If `f` is a partial homeomorphism defined on a neighbourhood of `f.symm a`, and `f` has an
 invertible derivative `f'` in the sense of strict differentiability at `f.symm a`, then `f.symm` has
 the derivative `f'⁻¹` at `a`.
 
@@ -416,7 +416,7 @@ theorem PartialHomeomorph.hasStrictFDerivAt_symm (f : PartialHomeomorph E F) {f'
   htff'.of_local_left_inverse (f.symm.continuousAt ha) (f.eventually_right_inverse ha)
 #align local_homeomorph.has_strict_fderiv_at_symm PartialHomeomorph.hasStrictFDerivAt_symm
 
-/-- If `f` is a local homeomorphism defined on a neighbourhood of `f.symm a`, and `f` has an
+/-- If `f` is a partial homeomorphism defined on a neighbourhood of `f.symm a`, and `f` has an
 invertible derivative `f'` at `f.symm a`, then `f.symm` has the derivative `f'⁻¹` at `a`.
 
 This is one of the easy parts of the inverse function theorem: it assumes that we already have

--- a/Mathlib/Analysis/Calculus/Implicit.lean
+++ b/Mathlib/Analysis/Calculus/Implicit.lean
@@ -68,7 +68,7 @@ Consider two functions `f : E → F` and `g : E → G` and a point `a` such that
 * the derivatives are surjective;
 * the kernels of the derivatives are complementary subspaces of `E`.
 
-Note that the map `x ↦ (f x, g x)` has a bijective derivative, hence it is a local homeomorphism
+Note that the map `x ↦ (f x, g x)` has a bijective derivative, hence it is a partial homeomorphism
 between `E` and `F × G`. We use this fact to define a function `φ : F → G → E`
 (see `ImplicitFunctionData.implicitFunction`) such that for `(y, z)` close enough to `(f a, g a)`
 we have `f (φ y z) = y` and `g (φ y z) = z`.
@@ -141,7 +141,7 @@ protected theorem hasStrictFDerivAt :
 
 /-- Implicit function theorem. If `f : E → F` and `g : E → G` are two maps strictly differentiable
 at `a`, their derivatives `f'`, `g'` are surjective, and the kernels of these derivatives are
-complementary subspaces of `E`, then `x ↦ (f x, g x)` defines a local homeomorphism between
+complementary subspaces of `E`, then `x ↦ (f x, g x)` defines a partial homeomorphism between
 `E` and `F × G`. In particular, `{x | f x = f a}` is locally homeomorphic to `G`. -/
 def toPartialHomeomorph : PartialHomeomorph E (F × G) :=
   φ.hasStrictFDerivAt.toPartialHomeomorph _
@@ -260,7 +260,7 @@ def implicitFunctionDataOfComplemented (hf : HasStrictFDerivAt f f' a) (hf' : ra
   isCompl_ker := LinearMap.isCompl_of_proj (Classical.choose_spec hker)
 #align has_strict_fderiv_at.implicit_function_data_of_complemented HasStrictFDerivAt.implicitFunctionDataOfComplemented
 
-/-- A local homeomorphism between `E` and `F × f'.ker` sending level surfaces of `f`
+/-- A partial homeomorphism between `E` and `F × f'.ker` sending level surfaces of `f`
 to vertical subspaces. -/
 def implicitToPartialHomeomorphOfComplemented (hf : HasStrictFDerivAt f f' a) (hf' : range f' = ⊤)
     (hker : (ker f').ClosedComplemented) : PartialHomeomorph E (F × ker f') :=
@@ -392,7 +392,7 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜] {E :
   [NormedSpace 𝕜 F] [FiniteDimensional 𝕜 F] (f : E → F) (f' : E →L[𝕜] F) {a : E}
 
 /-- Given a map `f : E → F` to a finite dimensional space with a surjective derivative `f'`,
-returns a local homeomorphism between `E` and `F × ker f'`. -/
+returns a partial homeomorphism between `E` and `F × ker f'`. -/
 def implicitToPartialHomeomorph (hf : HasStrictFDerivAt f f' a) (hf' : range f' = ⊤) :
     PartialHomeomorph E (F × ker f') :=
   haveI := FiniteDimensional.complete 𝕜 F

--- a/Mathlib/Analysis/Calculus/InverseFunctionTheorem/ApproximatesLinearOn.lean
+++ b/Mathlib/Analysis/Calculus/InverseFunctionTheorem/ApproximatesLinearOn.lean
@@ -355,7 +355,7 @@ protected theorem surjective [CompleteSpace E] (hf : ApproximatesLinearOn f (f' 
     exact fun R h y hy => h hy
 #align approximates_linear_on.surjective ApproximatesLinearOn.surjective
 
-/-- A map approximating a linear equivalence on a set defines a local equivalence on this set.
+/-- A map approximating a linear equivalence on a set defines a partial equivalence on this set.
 Should not be used outside of this file, because it is superseded by `toPartialHomeomorph` below.
 
 This is a first step towards the inverse function. -/
@@ -403,7 +403,7 @@ section
 variable (f s)
 
 /-- Given a function `f` that approximates a linear equivalence on an open set `s`,
-returns a local homeomorph with `toFun = f` and `source = s`. -/
+returns a partial homeomorphism with `toFun = f` and `source = s`. -/
 def toPartialHomeomorph (hf : ApproximatesLinearOn f (f' : E →L[𝕜] F) s c)
     (hc : Subsingleton E ∨ c < N⁻¹) (hs : IsOpen s) : PartialHomeomorph E F where
   toPartialEquiv := hf.toPartialEquiv hc

--- a/Mathlib/Analysis/NormedSpace/HomeomorphBall.lean
+++ b/Mathlib/Analysis/NormedSpace/HomeomorphBall.lean
@@ -114,7 +114,7 @@ def unitBallBall (c : P) (r : ℝ) (hr : 0 < r) : PartialHomeomorph E P :=
     rw [image_comp, image_smul, smul_unitBall hr.ne', IsometryEquiv.image_ball]
     simp [abs_of_pos hr]
 
-/-- If `r > 0`, then `PartialHomeomorph.univBall c r` is a smooth local homeomorphism
+/-- If `r > 0`, then `PartialHomeomorph.univBall c r` is a smooth partial homeomorphism
 with `source = Set.univ` and `target = Metric.ball c r`.
 Otherwise, it is the translation by `c`.
 Thus in all cases, it sends `0` to `c`, see `PartialHomeomorph.univBall_apply_zero`. -/

--- a/Mathlib/Analysis/SpecialFunctions/PolarCoord.lean
+++ b/Mathlib/Analysis/SpecialFunctions/PolarCoord.lean
@@ -11,7 +11,7 @@ import Mathlib.MeasureTheory.Measure.Lebesgue.Complex
 /-!
 # Polar coordinates
 
-We define polar coordinates, as a local homeomorphism in `ℝ^2` between `ℝ^2 - (-∞, 0]` and
+We define polar coordinates, as a partial homeomorphism in `ℝ^2` between `ℝ^2 - (-∞, 0]` and
 `(0, +∞) × (-π, π)`. Its inverse is given by `(r, θ) ↦ (r cos θ, r sin θ)`.
 
 It satisfies the following change of variables formula (see `integral_comp_polarCoord_symm`):
@@ -25,7 +25,7 @@ open Real Set MeasureTheory
 
 open scoped Real Topology
 
-/-- The polar coordinates local homeomorphism in `ℝ^2`, mapping `(r cos θ, r sin θ)` to `(r, θ)`.
+/-- The polar coordinates partial homeomorphism in `ℝ^2`, mapping `(r cos θ, r sin θ)` to `(r, θ)`.
 It is a homeomorphism between `ℝ^2 - (-∞, 0]` and `(0, +∞) × (-π, π)`. -/
 @[simps]
 def polarCoord : PartialHomeomorph (ℝ × ℝ) (ℝ × ℝ) where
@@ -158,7 +158,7 @@ namespace Complex
 
 open scoped Real
 
-/-- The polar coordinates local homeomorphism in `ℂ`, mapping `r (cos θ + I * sin θ)` to `(r, θ)`.
+/-- The polar coordinates partial homeomorphism in `ℂ`, mapping `r (cos θ + I * sin θ)` to `(r, θ)`.
 It is a homeomorphism between `ℂ - ℝ≤0` and `(0, +∞) × (-π, π)`. -/
 protected noncomputable def polarCoord : PartialHomeomorph ℂ (ℝ × ℝ) :=
   equivRealProdClm.toHomeomorph.toPartialHomeomorph.trans polarCoord

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -31,22 +31,22 @@ therefore two different ingredients in a charted space:
 We separate these two parts in the definition: the charted space structure is just the set of
 charts, and then the different smoothness requirements (smooth manifold, orientable manifold,
 contact manifold, and so on) are additional properties of these charts. These properties are
-formalized through the notion of structure groupoid, i.e., a set of local homeomorphisms stable
+formalized through the notion of structure groupoid, i.e., a set of partial homeomorphisms stable
 under composition and inverse, to which the change of coordinates should belong.
 
 ## Main definitions
 
-* `StructureGroupoid H` : a subset of local homeomorphisms of `H` stable under composition,
-  inverse and restriction (ex: local diffeos).
-* `continuousGroupoid H` : the groupoid of all local homeomorphisms of `H`.
+* `StructureGroupoid H` : a subset of partial homeomorphisms of `H` stable under composition,
+  inverse and restriction (ex: local diffeomorphisms).
+* `continuousGroupoid H` : the groupoid of all partial homeomorphisms of `H`.
 * `ChartedSpace H M` : charted space structure on `M` modelled on `H`, given by an atlas of
-  local homeomorphisms from `M` to `H` whose sources cover `M`. This is a type class.
+  partial homeomorphisms from `M` to `H` whose sources cover `M`. This is a type class.
 * `HasGroupoid M G` : when `G` is a structure groupoid on `H` and `M` is a charted space
   modelled on `H`, require that all coordinate changes belong to `G`. This is a type class.
 * `atlas H M` : when `M` is a charted space modelled on `H`, the atlas of this charted
   space structure, i.e., the set of charts.
 * `G.maximalAtlas M` : when `M` is a charted space modelled on `H` and admitting `G` as a
-  structure groupoid, one can consider all the local homeomorphisms from `M` to `H` such that
+  structure groupoid, one can consider all the partial homeomorphisms from `M` to `H` such that
   changing coordinate from any chart to them belongs to `G`. This is a larger atlas, called the
   maximal atlas (for the groupoid `G`).
 * `Structomorph G M M'` : the type of diffeomorphisms between the charted spaces `M` and `M'` for

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -37,7 +37,7 @@ under composition and inverse, to which the change of coordinates should belong.
 ## Main definitions
 
 * `StructureGroupoid H` : a subset of partial homeomorphisms of `H` stable under composition,
-  inverse and restriction (ex: local diffeomorphisms).
+  inverse and restriction (ex: partial diffeomorphisms).
 * `continuousGroupoid H` : the groupoid of all partial homeomorphisms of `H`.
 * `ChartedSpace H M` : charted space structure on `M` modelled on `H`, given by an atlas of
   partial homeomorphisms from `M` to `H` whose sources cover `M`. This is a type class.
@@ -59,7 +59,7 @@ This charted space structure is compatible with any groupoid.
 
 Additional useful definitions:
 
-* `Pregroupoid H` : a subset of local maps of `H` stable under composition and
+* `Pregroupoid H` : a subset of partial maps of `H` stable under composition and
   restriction, but not inverse (ex: smooth maps)
 * `Pregroupoid.groupoid` : construct a groupoid from a pregroupoid, by requiring that a map and
   its inverse both belong to the pregroupoid (ex: construct diffeos from smooth maps)
@@ -71,9 +71,9 @@ Additional useful definitions:
   maximal atlas associated to the groupoid `G`, the composition of `e.symm` and `e'` belongs to the
   `G` if `M` admits `G` as a structure groupoid.
 * `ChartedSpaceCore.toChartedSpace`: consider a space without a topology, but endowed with a set
-  of charts (which are local equivs) for which the change of coordinates are local homeos. Then
-  one can construct a topology on the space for which the charts become local homeos, defining
-  a genuine charted space structure.
+  of charts (which are partial equivs) for which the change of coordinates are partial homeos.
+  Then one can construct a topology on the space for which the charts become partial homeos,
+  defining a genuine charted space structure.
 
 ## Implementation notes
 
@@ -98,7 +98,7 @@ otherwise, there would be an instance from manifolds to topological spaces, whic
 instance search for topological spaces would try to find manifold structures involving a yet
 unknown model space, leading to problems. However, we also introduce the latter approach,
 through a structure `ChartedSpaceCore` making it possible to construct a topology out of a set of
-local equivs with compatibility conditions (but we do not register it as an instance).
+partial equivs with compatibility conditions (but we do not register it as an instance).
 
 In the definition of a charted space, the model space is written as an explicit parameter as there
 can be several model spaces for a given topological space. For instance, a complex manifold
@@ -106,8 +106,8 @@ can be several model spaces for a given topological space. For instance, a compl
 
 ## Notations
 
-In the locale `Manifold`, we denote the composition of local homeomorphisms with `≫ₕ`, and the
-composition of local equivs with `≫`.
+In the locale `Manifold`, we denote the composition of partial homeomorphisms with `≫ₕ`, and the
+composition of partial equivs with `≫`.
 -/
 
 set_option autoImplicit true
@@ -121,7 +121,7 @@ universe u
 
 variable {H : Type u} {H' : Type*} {M : Type*} {M' : Type*} {M'' : Type*}
 
-/- Notational shortcut for the composition of local homeomorphisms and local equivs, i.e.,
+/- Notational shortcut for the composition of partial homeomorphisms and partial equivs, i.e.,
 `PartialHomeomorph.trans` and `PartialEquiv.trans`.
 Note that, as is usual for equivs, the composition is from left to right, hence the direction of
 the arrow. -/
@@ -145,13 +145,13 @@ groupoid is naturally a vector bundle) I prefer that the members of the groupoid
 defined on sets of the form `s × E`. There is a typeclass `ClosedUnderRestriction` for groupoids
 which have the restriction property.
 
-The only nontrivial requirement is locality: if a local homeomorphism belongs to the groupoid
+The only nontrivial requirement is locality: if a partial homeomorphism belongs to the groupoid
 around each point in its domain of definition, then it belongs to the groupoid. Without this
 requirement, the composition of structomorphisms does not have to be a structomorphism. Note that
-this implies that a local homeomorphism with empty source belongs to any structure groupoid, as
+this implies that a partial homeomorphism with empty source belongs to any structure groupoid, as
 it trivially satisfies this condition.
 
-There is also a technical point, related to the fact that a local homeomorphism is by definition a
+There is also a technical point, related to the fact that a partial homeomorphism is by definition a
 global map which is a homeomorphism when restricted to its source subset (and its values outside
 of the source are not relevant). Therefore, we also require that being a member of the groupoid only
 depends on the values on the source.
@@ -161,7 +161,7 @@ We use primes in the structure names as we will reformulate them below (without 
 -/
 
 
-/-- A structure groupoid is a set of local homeomorphisms of a topological space stable under
+/-- A structure groupoid is a set of partial homeomorphisms of a topological space stable under
 composition and inverse. They appear in the definition of the smoothness class of a manifold. -/
 structure StructureGroupoid (H : Type u) [TopologicalSpace H] where
   members : Set (PartialHomeomorph H H)
@@ -340,8 +340,8 @@ instance instStructureGroupoidOrderBot : OrderBot (StructureGroupoid H) where
 
 instance : Inhabited (StructureGroupoid H) := ⟨idGroupoid H⟩
 
-/-- To construct a groupoid, one may consider classes of local homeos such that both the function
-and its inverse have some property. If this property is stable under composition,
+/-- To construct a groupoid, one may consider classes of partial homeomorphisms such that
+both the function and its inverse have some property. If this property is stable under composition,
 one gets a groupoid. `Pregroupoid` bundles the properties needed for this construction, with the
 groupoid of smooth functions with smooth inverses as an application. -/
 structure Pregroupoid (H : Type*) [TopologicalSpace H] where
@@ -354,7 +354,7 @@ structure Pregroupoid (H : Type*) [TopologicalSpace H] where
   congr : ∀ {f g : H → H} {u}, IsOpen u → (∀ x ∈ u, g x = f x) → property f u → property g u
 #align pregroupoid Pregroupoid
 
-/-- Construct a groupoid of local homeos for which the map and its inverse have some property,
+/-- Construct a groupoid of partial homeos for which the map and its inverse have some property,
 from a pregroupoid asserting that this property is stable under composition. -/
 def Pregroupoid.groupoid (PG : Pregroupoid H) : StructureGroupoid H where
   members := { e : PartialHomeomorph H H | PG.property e e.source ∧ PG.property e.symm e.target }
@@ -414,7 +414,7 @@ theorem mem_pregroupoid_of_eq_on_source (PG : Pregroupoid H) {e e' : PartialHome
   exact PG.congr e.open_source he'.eqOn.symm he
 #align mem_pregroupoid_of_eq_on_source mem_pregroupoid_of_eq_on_source
 
-/-- The pregroupoid of all local maps on a topological space `H`. -/
+/-- The pregroupoid of all partial maps on a topological space `H`. -/
 @[reducible]
 def continuousPregroupoid (H : Type*) [TopologicalSpace H] : Pregroupoid H where
   property _ _ := True
@@ -427,12 +427,12 @@ def continuousPregroupoid (H : Type*) [TopologicalSpace H] : Pregroupoid H where
 instance (H : Type*) [TopologicalSpace H] : Inhabited (Pregroupoid H) :=
   ⟨continuousPregroupoid H⟩
 
-/-- The groupoid of all local homeomorphisms on a topological space `H`. -/
+/-- The groupoid of all partial homeomorphisms on a topological space `H`. -/
 def continuousGroupoid (H : Type*) [TopologicalSpace H] : StructureGroupoid H :=
   Pregroupoid.groupoid (continuousPregroupoid H)
 #align continuous_groupoid continuousGroupoid
 
-/-- Every structure groupoid is contained in the groupoid of all local homeomorphisms. -/
+/-- Every structure groupoid is contained in the groupoid of all partial homeomorphisms. -/
 instance instStructureGroupoidOrderTop : OrderTop (StructureGroupoid H) where
   top := continuousGroupoid H
   le_top _ _ _ := ⟨trivial, trivial⟩
@@ -466,8 +466,8 @@ theorem closedUnderRestriction' {G : StructureGroupoid H} [ClosedUnderRestrictio
   ClosedUnderRestriction.closedUnderRestriction he s hs
 #align closed_under_restriction' closedUnderRestriction'
 
-/-- The trivial restriction-closed groupoid, containing only local homeomorphisms equivalent to the
-restriction of the identity to the various open subsets. -/
+/-- The trivial restriction-closed groupoid, containing only partial homeomorphisms equivalent
+to the restriction of the identity to the various open subsets. -/
 def idRestrGroupoid : StructureGroupoid H where
   members := { e | ∃ (s : Set H) (h : IsOpen s), e ≈ PartialHomeomorph.ofSet s h }
   trans' := by
@@ -537,8 +537,8 @@ theorem closedUnderRestriction_iff_id_le (G : StructureGroupoid H) :
     exact idRestrGroupoid_mem hs
 #align closed_under_restriction_iff_id_le closedUnderRestriction_iff_id_le
 
-/-- The groupoid of all local homeomorphisms on a topological space `H` is closed under restriction.
--/
+/-- The groupoid of all partial homeomorphisms on a topological space `H`
+is closed under restriction. -/
 instance : ClosedUnderRestriction (continuousGroupoid H) :=
   (closedUnderRestriction_iff_id_le _).mpr le_top
 
@@ -719,7 +719,7 @@ library_note "Manifold type tags" /-- For technical reasons we introduce two typ
 * `ModelPi H` is the same as `∀ i, H i`, where `H : ι → Type*` and `ι` is a finite type.
 
 In both cases the reason is the same, so we explain it only in the case of the product. A charted
-space `M` with model `H` is a set of local charts from `M` to `H` covering the space. Every space is
+space `M` with model `H` is a set of charts from `M` to `H` covering the space. Every space is
 registered as a charted space over itself, using the only chart `id`, in `chartedSpaceSelf`. You
 can also define a product of charted space `M` and `M'` (with model space `H × H'`) by taking the
 products of the charts. Now, on `H × H'`, there are two charted space structures with model space
@@ -840,7 +840,7 @@ end ChartedSpace
 
 /-- Sometimes, one may want to construct a charted space structure on a space which does not yet
 have a topological structure, where the topology would come from the charts. For this, one needs
-charts that are only local equivs, and continuity properties for their composition.
+charts that are only partial equivs, and continuity properties for their composition.
 This is formalised in `ChartedSpaceCore`. -/
 -- @[nolint has_nonempty_instance]  -- Porting note: commented out
 structure ChartedSpaceCore (H : Type*) [TopologicalSpace H] (M : Type*) where
@@ -878,8 +878,8 @@ theorem open_target (he : e ∈ c.atlas) : IsOpen e.target := by
   simpa [PartialEquiv.trans_source, E] using c.open_source e e he he
 #align charted_space_core.open_target ChartedSpaceCore.open_target
 
-/-- An element of the atlas in a charted space without topology becomes a local homeomorphism
-for the topology constructed from this atlas. The `localHomeomorph` version is given in this
+/-- An element of the atlas in a charted space without topology becomes a partial homeomorphism
+for the topology constructed from this atlas. The `PartialHomeomorph` version is given in this
 definition. -/
 protected def localHomeomorph (e : PartialEquiv M H) (he : e ∈ c.atlas) :
     @PartialHomeomorph M H c.toTopologicalSpace _ :=
@@ -974,7 +974,7 @@ instance hasGroupoid_model_space (H : Type*) [TopologicalSpace H] (G : Structure
     simp [he, he', StructureGroupoid.id_mem]
 #align has_groupoid_model_space hasGroupoid_model_space
 
-/-- Any charted space structure is compatible with the groupoid of all local homeomorphisms. -/
+/-- Any charted space structure is compatible with the groupoid of all partial homeomorphisms. -/
 instance hasGroupoid_continuousGroupoid : HasGroupoid M (continuousGroupoid H) := by
   refine' ⟨fun _ _ ↦ _⟩
   rw [continuousGroupoid, mem_groupoid_of_pregroupoid]
@@ -986,7 +986,7 @@ section MaximalAtlas
 variable (M) (G : StructureGroupoid H)
 
 /-- Given a charted space admitting a structure groupoid, the maximal atlas associated to this
-structure groupoid is the set of all local charts that are compatible with the atlas, i.e., such
+structure groupoid is the set of all charts that are compatible with the atlas, i.e., such
 that changing coordinates with an atlas member gives an element of the groupoid. -/
 def StructureGroupoid.maximalAtlas : Set (PartialHomeomorph M H) :=
   { e | ∀ e' ∈ atlas H M, e.symm ≫ₕ e' ∈ G ∧ e'.symm ≫ₕ e ∈ G }
@@ -1061,8 +1061,8 @@ namespace PartialHomeomorph
 
 variable (e : PartialHomeomorph α H)
 
-/-- If a single local homeomorphism `e` from a space `α` into `H` has source covering the whole
-space `α`, then that local homeomorphism induces an `H`-charted space structure on `α`.
+/-- If a single partial homeomorphism `e` from a space `α` into `H` has source covering the whole
+space `α`, then that partial homeomorphism induces an `H`-charted space structure on `α`.
 (This condition is equivalent to `e` being an open embedding of `α` into `H`; see
 `OpenEmbedding.singletonChartedSpace`.) -/
 def singletonChartedSpace (h : e.source = Set.univ) : ChartedSpace H α where
@@ -1088,7 +1088,7 @@ theorem singletonChartedSpace_mem_atlas_eq (h : e.source = Set.univ) (e' : Parti
   h'
 #align local_homeomorph.singleton_charted_space_mem_atlas_eq PartialHomeomorph.singletonChartedSpace_mem_atlas_eq
 
-/-- Given a local homeomorphism `e` from a space `α` into `H`, if its source covers the whole
+/-- Given a partial homeomorphism `e` from a space `α` into `H`, if its source covers the whole
 space `α`, then the induced charted space structure on `α` is `HasGroupoid G` for any structure
 groupoid `G` which is closed under restrictions. -/
 theorem singleton_hasGroupoid (h : e.source = Set.univ) (G : StructureGroupoid H)

--- a/Mathlib/Geometry/Manifold/ConformalGroupoid.lean
+++ b/Mathlib/Geometry/Manifold/ConformalGroupoid.lean
@@ -15,7 +15,7 @@ In this file we define the groupoid of conformal maps on normed spaces.
 
 ## Main definitions
 
-* `conformalGroupoid`: the groupoid of conformal local homeomorphisms.
+* `conformalGroupoid`: the groupoid of conformal partial homeomorphisms.
 
 ## Tags
 

--- a/Mathlib/Geometry/Manifold/ContMDiff/Atlas.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Atlas.lean
@@ -226,7 +226,7 @@ theorem isLocalStructomorphOn_contDiffGroupoid_iff (f : PartialHomeomorph M M') 
       mfld_set_tac
     refine' ⟨e.symm, StructureGroupoid.symm _ he, h3e, _⟩
     rw [h2X]; exact e.mapsTo hex
-  · -- We now show the converse: a local homeomorphism `f : M → M'` which is smooth in both
+  · -- We now show the converse: a partial homeomorphism `f : M → M'` which is smooth in both
     -- directions is a local structomorphism.  We do this by proposing
     -- `((chart_at H x).symm.trans f).trans (chart_at H (f x))` as a candidate for a structomorphism
     -- of `H`.

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -23,11 +23,11 @@ it to put a smooth manifold structure on the sphere.
 ## Main results
 
 For a unit vector `v` in `E`, the definition `stereographic` gives the stereographic projection
-centred at `v`, a local homeomorphism from the sphere to `(ℝ ∙ v)ᗮ` (the orthogonal complement of
+centred at `v`, a partial homeomorphism from the sphere to `(ℝ ∙ v)ᗮ` (the orthogonal complement of
 `v`).
 
 For finite-dimensional `E`, we then construct a smooth manifold instance on the sphere; the charts
-here are obtained by composing the local homeomorphisms `stereographic` with arbitrary isometries
+here are obtained by composing the partial homeomorphisms `stereographic` with arbitrary isometries
 from `(ℝ ∙ v)ᗮ` to Euclidean space.
 
 We prove two lemmas about smooth maps:
@@ -279,8 +279,8 @@ theorem stereo_right_inv (hv : ‖v‖ = 1) (w : (ℝ ∙ v)ᗮ) : stereoToFun v
   · simp
 #align stereo_right_inv stereo_right_inv
 
-/-- Stereographic projection from the unit sphere in `E`, centred at a unit vector `v` in `E`; this
-is the version as a local homeomorphism. -/
+/-- Stereographic projection from the unit sphere in `E`, centred at a unit vector `v` in `E`;
+this is the version as a partial homeomorphism. -/
 def stereographic (hv : ‖v‖ = 1) : PartialHomeomorph (sphere (0 : E) 1) (ℝ ∙ v)ᗮ where
   toFun := stereoToFun v ∘ (↑)
   invFun := stereoInvFun hv

--- a/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
+++ b/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
@@ -636,7 +636,7 @@ theorem isLocalStructomorphWithinAt_localInvariantProp [ClosedUnderRestriction G
       · simpa only [hex, hef ⟨hx, hex⟩, mfld_simps] using hfx }
 #align structure_groupoid.is_local_structomorph_within_at_local_invariant_prop StructureGroupoid.isLocalStructomorphWithinAt_localInvariantProp
 
-/-- A slight reformulation of `IsLocalStructomorphWithinAt` when `f` is a local homeomorph.
+/-- A slight reformulation of `IsLocalStructomorphWithinAt` when `f` is a partial homeomorph.
   This gives us an `e` that is defined on a subset of `f.source`. -/
 theorem _root_.PartialHomeomorph.isLocalStructomorphWithinAt_iff {G : StructureGroupoid H}
     [ClosedUnderRestriction G] (f : PartialHomeomorph H H) {s : Set H} {x : H}
@@ -659,7 +659,7 @@ theorem _root_.PartialHomeomorph.isLocalStructomorphWithinAt_iff {G : StructureG
     exact ⟨e, he, hfe, hxe⟩
 #align local_homeomorph.is_local_structomorph_within_at_iff PartialHomeomorph.isLocalStructomorphWithinAt_iff
 
-/-- A slight reformulation of `IsLocalStructomorphWithinAt` when `f` is a local homeomorph and
+/-- A slight reformulation of `IsLocalStructomorphWithinAt` when `f` is a partial homeomorph and
   the set we're considering is a superset of `f.source`. -/
 theorem _root_.PartialHomeomorph.isLocalStructomorphWithinAt_iff' {G : StructureGroupoid H}
     [ClosedUnderRestriction G] (f : PartialHomeomorph H H) {s : Set H} {x : H} (hs : f.source ⊆ s)
@@ -673,7 +673,7 @@ theorem _root_.PartialHomeomorph.isLocalStructomorphWithinAt_iff' {G : Structure
   rw [inter_eq_right.mpr (h2e.trans hs)]
 #align local_homeomorph.is_local_structomorph_within_at_iff' PartialHomeomorph.isLocalStructomorphWithinAt_iff'
 
-/-- A slight reformulation of `IsLocalStructomorphWithinAt` when `f` is a local homeomorph and
+/-- A slight reformulation of `IsLocalStructomorphWithinAt` when `f` is a partial homeomorph and
   the set we're considering is `f.source`. -/
 theorem _root_.PartialHomeomorph.isLocalStructomorphWithinAt_source_iff {G : StructureGroupoid H}
     [ClosedUnderRestriction G] (f : PartialHomeomorph H H) {x : H} :

--- a/Mathlib/Geometry/Manifold/MFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv.lean
@@ -242,7 +242,7 @@ def MDifferentiable (f : M → M') :=
   ∀ x, MDifferentiableAt I I' f x
 #align mdifferentiable MDifferentiable
 
-/-- Prop registering if a local homeomorphism is a local diffeomorphism on its source -/
+/-- Prop registering if a partial homeomorphism is a local diffeomorphism on its source -/
 def PartialHomeomorph.MDifferentiable (f : PartialHomeomorph M M') :=
   MDifferentiableOn I I' f f.source ∧ MDifferentiableOn I' I f.symm f.target
 #align local_homeomorph.mdifferentiable PartialHomeomorph.MDifferentiable
@@ -1898,7 +1898,7 @@ end Charts
 
 end SpecificFunctions
 
-/-! ### Differentiable local homeomorphisms -/
+/-! ### Differentiable partial homeomorphisms -/
 
 namespace PartialHomeomorph.MDifferentiable
 
@@ -1944,7 +1944,7 @@ theorem comp_symm_deriv {x : M'} (hx : x ∈ e.target) :
   he.symm.symm_comp_deriv hx
 #align local_homeomorph.mdifferentiable.comp_symm_deriv PartialHomeomorph.MDifferentiable.comp_symm_deriv
 
-/-- The derivative of a differentiable local homeomorphism, as a continuous linear equivalence
+/-- The derivative of a differentiable partial homeomorphism, as a continuous linear equivalence
 between the tangent spaces at `x` and `e x`. -/
 protected def mfderiv {x : M} (hx : x ∈ e.source) : TangentSpace I x ≃L[𝕜] TangentSpace I' (e x) :=
   { mfderiv I I' e x with

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -37,7 +37,7 @@ but add these assumptions later as needed. (Quite a few results still do not req
 * `modelWithCornersSelf 𝕜 E` :
   trivial model with corners structure on the space `E` embedded in itself by the identity.
 * `contDiffGroupoid n I` :
-  when `I` is a model with corners on `(𝕜, E, H)`, this is the groupoid of local homeos of `H`
+  when `I` is a model with corners on `(𝕜, E, H)`, this is the groupoid of partial homeos of `H`
   which are of class `C^n` over the normed field `𝕜`, when read in `E`.
 * `SmoothManifoldWithCorners I M` :
   a type class saying that the charted space `M`, modelled on the space `H`, has `C^∞` changes of
@@ -46,8 +46,9 @@ but add these assumptions later as needed. (Quite a few results still do not req
 * `extChartAt I x`:
   in a smooth manifold with corners with the model `I` on `(E, H)`, the charts take values in `H`,
   but often we may want to use their `E`-valued version, obtained by composing the charts with `I`.
-  Since the target is in general not open, we can not register them as local homeomorphisms, but
-  we register them as local equivs. `extChartAt I x` is the canonical such local equiv around `x`.
+  Since the target is in general not open, we can not register them as partial homeomorphisms, but
+  we register them as `PartialEquiv`s.
+  `extChartAt I x` is the canonical such partial equiv around `x`.
 
 As specific examples of models with corners, we define (in the file `real_instances.lean`)
 * `modelWithCornersSelf ℝ (EuclideanSpace (Fin n))` for the model space used to define
@@ -177,7 +178,7 @@ switch to this behavior later, doing it mid-port will break a lot of proofs. -/
 
 instance : CoeFun (ModelWithCorners 𝕜 E H) fun _ => H → E := ⟨toFun'⟩
 
-/-- The inverse to a model with corners, only registered as a local equiv. -/
+/-- The inverse to a model with corners, only registered as a `PartialEquiv`. -/
 protected def symm : PartialEquiv E H :=
   I.toPartialEquiv.symm
 #align model_with_corners.symm ModelWithCorners.symm
@@ -374,7 +375,7 @@ section
 
 variable (𝕜 E)
 
-/-- In the trivial model with corners, the associated local equiv is the identity. -/
+/-- In the trivial model with corners, the associated `PartialEquiv` is the identity. -/
 @[simp, mfld_simps]
 theorem modelWithCornersSelf_localEquiv : 𝓘(𝕜, E).toPartialEquiv = PartialEquiv.refl E :=
   rfl
@@ -583,11 +584,11 @@ theorem contDiffGroupoid_le (h : m ≤ n) : contDiffGroupoid n I ≤ contDiffGro
 #align cont_diff_groupoid_le contDiffGroupoid_le
 
 /-- The groupoid of `0`-times continuously differentiable maps is just the groupoid of all
-local homeomorphisms -/
+partial homeomorphisms -/
 theorem contDiffGroupoid_zero_eq : contDiffGroupoid 0 I = continuousGroupoid H := by
   apply le_antisymm le_top
   intro u _
-  -- we have to check that every local homeomorphism belongs to `contDiffGroupoid 0 I`,
+  -- we have to check that every partial homeomorphism belongs to `contDiffGroupoid 0 I`,
   -- by unfolding its definition
   change u ∈ contDiffGroupoid 0 I
   rw [contDiffGroupoid, mem_groupoid_of_pregroupoid]
@@ -601,7 +602,7 @@ theorem contDiffGroupoid_zero_eq : contDiffGroupoid 0 I = continuousGroupoid H :
 
 variable (n)
 
-/-- An identity local homeomorphism belongs to the `C^n` groupoid. -/
+/-- An identity partial homeomorphism belongs to the `C^n` groupoid. -/
 theorem ofSet_mem_contDiffGroupoid {s : Set H} (hs : IsOpen s) :
     PartialHomeomorph.ofSet s hs ∈ contDiffGroupoid n I := by
   rw [contDiffGroupoid, mem_groupoid_of_pregroupoid]
@@ -611,7 +612,7 @@ theorem ofSet_mem_contDiffGroupoid {s : Set H} (hs : IsOpen s) :
   exact this.congr_mono (fun x hx => I.right_inv hx.2) (subset_univ _)
 #align of_set_mem_cont_diff_groupoid ofSet_mem_contDiffGroupoid
 
-/-- The composition of a local homeomorphism from `H` to `M` and its inverse belongs to
+/-- The composition of a partial homeomorphism from `H` to `M` and its inverse belongs to
 the `C^n` groupoid. -/
 theorem symm_trans_mem_contDiffGroupoid (e : PartialHomeomorph M H) :
     e.symm.trans e ∈ contDiffGroupoid n I :=
@@ -622,7 +623,7 @@ theorem symm_trans_mem_contDiffGroupoid (e : PartialHomeomorph M H) :
 
 variable {E' H' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] [TopologicalSpace H']
 
-/-- The product of two smooth local homeomorphisms is smooth. -/
+/-- The product of two smooth partial homeomorphisms is smooth. -/
 theorem contDiffGroupoid_prod {I : ModelWithCorners 𝕜 E H} {I' : ModelWithCorners 𝕜 E' H'}
     {e : PartialHomeomorph H H} {e' : PartialHomeomorph H' H'} (he : e ∈ contDiffGroupoid ⊤ I)
     (he' : e' ∈ contDiffGroupoid ⊤ I') : e.prod e' ∈ contDiffGroupoid ⊤ (I.prod I') := by
@@ -744,7 +745,7 @@ def analyticGroupoid : StructureGroupoid H :=
           rw [comp_apply, comp_apply, fg (I.symm y) hy.left.left] at hy
           exact hy.right }
 
-/-- An identity local homeomorphism belongs to the analytic groupoid. -/
+/-- An identity partial homeomorphism belongs to the analytic groupoid. -/
 theorem ofSet_mem_analyticGroupoid {s : Set H} (hs : IsOpen s) :
     PartialHomeomorph.ofSet s hs ∈ analyticGroupoid I := by
   rw [analyticGroupoid]
@@ -770,7 +771,7 @@ theorem ofSet_mem_analyticGroupoid {s : Set H} (hs : IsOpen s) :
     rw [← hy.right, I.right_inv (interior_subset hy.left.right)]
     exact hy.left.right
 
-/-- The composition of a local homeomorphism from `H` to `M` and its inverse belongs to
+/-- The composition of a partial homeomorphism from `H` to `M` and its inverse belongs to
 the analytic groupoid. -/
 theorem symm_trans_mem_analyticGroupoid (e : PartialHomeomorph M H) :
     e.symm.trans e ∈ analyticGroupoid I :=
@@ -788,7 +789,7 @@ instance : ClosedUnderRestriction (analyticGroupoid I) :=
       exact ofSet_mem_analyticGroupoid I hs)
 
 /-- The analytic groupoid on a boundaryless charted space modeled on a complete vector space
-consists of the local homeomorphisms which are analytic and have analytic inverse. -/
+consists of the partial homeomorphisms which are analytic and have analytic inverse. -/
 theorem mem_analyticGroupoid_of_boundaryless [CompleteSpace E] [I.Boundaryless]
     (e : PartialHomeomorph H H) :
     e ∈ analyticGroupoid I ↔ AnalyticOn 𝕜 (I ∘ e ∘ I.symm) (I '' e.source) ∧

--- a/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
@@ -20,7 +20,7 @@ is also a charted space over `H × F`.
 
 Now, we define `SmoothVectorBundle` as the `Prop` of having smooth transition functions.
 Recall the structure groupoid `smoothFiberwiseLinear` on `B × F` consisting of smooth, fiberwise
-linear local homeomorphisms.  We show that our definition of "smooth vector bundle" implies
+linear partial homeomorphisms.  We show that our definition of "smooth vector bundle" implies
 `HasGroupoid` for this groupoid, and show (by a "composition" of `HasGroupoid` instances) that
 this means that a smooth vector bundle is a smooth manifold.
 

--- a/Mathlib/Topology/FiberBundle/Basic.lean
+++ b/Mathlib/Topology/FiberBundle/Basic.lean
@@ -39,7 +39,7 @@ an implementation of this construction: starting from an object of type
 fiber bundle and projection.
 
 Similarly we implement the object `FiberPrebundle` which allows to define a topological
-fiber bundle from trivializations given as local equivalences with minimum additional properties.
+fiber bundle from trivializations given as partial equivalences with minimum additional properties.
 
 ## Main definitions
 
@@ -64,7 +64,7 @@ Let `Z : FiberBundleCore ι B F`. Then we define
                     open set in `B`.
 
 * `FiberPrebundle F E` : structure registering a cover of prebundle trivializations
-  and requiring that the relative transition maps are local homeomorphisms.
+  and requiring that the relative transition maps are partial homeomorphisms.
 * `FiberPrebundle.totalSpaceTopology a` : natural topology of the total space, making
   the prebundle into a bundle.
 
@@ -481,7 +481,7 @@ theorem mem_trivChange_source (i j : ι) (p : B × F) :
 between `proj ⁻¹ (baseSet i)` and `baseSet i × F`. As the fiber above `x` is `F` but read in the
 chart with index `index_at x`, the trivialization in the fiber above x is by definition the
 coordinate change from i to `index_at x`, so it depends on `x`.
-The local trivialization will ultimately be a local homeomorphism. For now, we only introduce the
+The local trivialization will ultimately be a partial homeomorphism. For now, we only introduce the
 partial equivalence version, denoted with a prime.
 In further developments, avoid this auxiliary version, and use `Z.local_triv` instead. -/
 def localTrivAsPartialEquiv (i : ι) : PartialEquiv Z.TotalSpace (B × F) where
@@ -759,8 +759,8 @@ variable (F) (E : B → Type*) [TopologicalSpace B] [TopologicalSpace F]
 
 /-- This structure permits to define a fiber bundle when trivializations are given as local
 equivalences but there is not yet a topology on the total space. The total space is hence given a
-topology in such a way that there is a fiber bundle structure for which the local equivalences
-are also local homeomorphism and hence local trivializations. -/
+topology in such a way that there is a fiber bundle structure for which the partial equivalences
+are also partial homeomorphisms and hence local trivializations. -/
 -- porting note: todo: was @[nolint has_nonempty_instance]
 structure FiberPrebundle where
   pretrivializationAtlas : Set (Pretrivialization F (π F E))

--- a/Mathlib/Topology/FiberBundle/Trivialization.lean
+++ b/Mathlib/Topology/FiberBundle/Trivialization.lean
@@ -16,10 +16,10 @@ import Mathlib.Topology.PartialHomeomorph
 
 ### Basic definitions
 
-* `Trivialization F p` : structure extending local homeomorphisms, defining a local
+* `Trivialization F p` : structure extending partial homeomorphisms, defining a local
   trivialization of a topological space `Z` with projection `p` and fiber `F`.
 
-* `Pretrivialization F proj` : trivialization as a local equivalence, mainly used when the
+* `Pretrivialization F proj` : trivialization as a partial equivalence, mainly used when the
   topology on the total space has not yet been defined.
 
 ### Operations on bundles
@@ -299,8 +299,8 @@ end Pretrivialization
 
 variable [TopologicalSpace Z] [TopologicalSpace (TotalSpace F E)]
 
-/-- A structure extending local homeomorphisms, defining a local trivialization of a projection
-`proj : Z → B` with fiber `F`, as a local homeomorphism between `Z` and `B × F` defined between two
+/-- A structure extending partial homeomorphisms, defining a local trivialization of a projection
+`proj : Z → B` with fiber `F`, as a partial homeomorphism between `Z` and `B × F` defined between two
 sets of the form `proj ⁻¹' baseSet` and `baseSet × F`, acting trivially on the first coordinate.
 -/
 -- porting note: todo: was @[nolint has_nonempty_instance]

--- a/Mathlib/Topology/FiberBundle/Trivialization.lean
+++ b/Mathlib/Topology/FiberBundle/Trivialization.lean
@@ -300,8 +300,8 @@ end Pretrivialization
 variable [TopologicalSpace Z] [TopologicalSpace (TotalSpace F E)]
 
 /-- A structure extending partial homeomorphisms, defining a local trivialization of a projection
-`proj : Z → B` with fiber `F`, as a partial homeomorphism between `Z` and `B × F` defined between two
-sets of the form `proj ⁻¹' baseSet` and `baseSet × F`, acting trivially on the first coordinate.
+`proj : Z → B` with fiber `F`, as a partial homeomorphism between `Z` and `B × F` defined between
+two sets of the form `proj ⁻¹' baseSet` and `baseSet × F`, acting trivially on the first coordinate.
 -/
 -- porting note: todo: was @[nolint has_nonempty_instance]
 structure Trivialization (proj : Z → B) extends PartialHomeomorph Z (B × F) where

--- a/Mathlib/Topology/VectorBundle/Basic.lean
+++ b/Mathlib/Topology/VectorBundle/Basic.lean
@@ -848,8 +848,8 @@ open VectorBundle
 /-- This structure permits to define a vector bundle when trivializations are given as local
 equivalences but there is not yet a topology on the total space or the fibers.
 The total space is hence given a topology in such a way that there is a fiber bundle structure for
-which the partial equivalences are also partial homeomorphisms and hence vector bundle trivializations.
-The topology on the fibers is induced from the one on the total space.
+which the partial equivalences are also partial homeomorphisms and hence vector bundle
+trivializations. The topology on the fibers is induced from the one on the total space.
 
 The field `exists_coordChange` is stated as an existential statement (instead of 3 separate
 fields), since it depends on propositional information (namely `e e' ∈ pretrivializationAtlas`).

--- a/Mathlib/Topology/VectorBundle/Basic.lean
+++ b/Mathlib/Topology/VectorBundle/Basic.lean
@@ -848,7 +848,7 @@ open VectorBundle
 /-- This structure permits to define a vector bundle when trivializations are given as local
 equivalences but there is not yet a topology on the total space or the fibers.
 The total space is hence given a topology in such a way that there is a fiber bundle structure for
-which the local equivalences are also local homeomorphisms and hence vector bundle trivializations.
+which the partial equivalences are also partial homeomorphisms and hence vector bundle trivializations.
 The topology on the fibers is induced from the one on the total space.
 
 The field `exists_coordChange` is stated as an existential statement (instead of 3 separate


### PR DESCRIPTION
Almost all of them should speak about partial homeomorphisms instead.
In two cases, I decided removing the "local" was clearer than adding "partial".

Follow-up to #8982; complements #9238.

---------
Best reviewed commit by commit.

