### PR TITLE
[Merged by Bors] - feat(LinearAlgebra, Cardinal): new cardinal lemmas to generalize some results about `Module.rank` in #9151

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -266,7 +266,7 @@ variable [Nontrivial R]
 variable (R M M')
 
 open LinearMap in
-theorem lift_rank_add_lift_rank_le_rank_prod [Nontrivial R] :
+theorem lift_rank_add_lift_rank_le_rank_prod :
     lift.{v'} (Module.rank R M) + lift.{v} (Module.rank R M') ≤ Module.rank R (M × M') := by
   convert rank_quotient_add_rank_le (ker <| LinearMap.fst R M M')
   · refine Eq.trans ?_ (lift_id'.{v, v'} _)

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -564,7 +564,7 @@ lemma rank_eq_zero_iff_isTorsion {R M} [CommRing R] [IsDomain R] [AddCommGroup M
   rw [Module.IsTorsion, rank_eq_zero_iff]
   simp [mem_nonZeroDivisors_iff_ne_zero]
 
-theorem rank_quotient_eq_of_le_torsion {R} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+theorem rank_quotient_eq_of_le_torsion {R M} [CommRing R] [AddCommGroup M] [Module R M]
     {N : Submodule R M} (hN : N ≤ torsion R M) : Module.rank R (M ⧸ N) = Module.rank R M :=
   (rank_quotient_le N).antisymm <| by
     nontriviality R

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -108,7 +108,7 @@ protected irreducible_def Module.rank : Cardinal :=
   ⨆ ι : { s : Set V // LinearIndependent K ((↑) : s → V) }, (#ι.1)
 #align module.rank Module.rank
 
-instance : Nonempty { s : Set V // LinearIndependent K ((↑) : s → V) } :=
+lemma nonempty_linearIndependent_set : Nonempty {s : Set V // LinearIndependent K ((↑) : s → V)} :=
   ⟨⟨∅, linearIndependent_empty _ _⟩⟩
 
 end
@@ -151,6 +151,8 @@ theorem rank_le {n : ℕ}
 theorem rank_quotient_add_rank_le [Nontrivial R] (M' : Submodule R M) :
     Module.rank R (M ⧸ M') + Module.rank R M' ≤ Module.rank R M := by
   simp_rw [Module.rank_def]
+  have := nonempty_linearIndependent_set R (M ⧸ M')
+  have := nonempty_linearIndependent_set R M'
   rw [Cardinal.ciSup_add_ciSup _ (bddAbove_range.{v, v} _) _ (bddAbove_range.{v, v} _)]
   refine ciSup_le fun ⟨s, hs⟩ ↦ ciSup_le fun ⟨t, ht⟩ ↦ ?_
   choose f hf using Quotient.mk_surjective M'
@@ -567,6 +569,7 @@ theorem rank_quotient_eq_of_le_torsion {R} {M : Type v} [CommRing R] [AddCommGro
   (rank_quotient_le N).antisymm <| by
     nontriviality R
     rw [Module.rank]
+    have := nonempty_linearIndependent_set R M
     refine ciSup_le fun ⟨s, hs⟩ ↦ cardinal_le_rank_of_linearIndependent (v := (N.mkQ ·)) ?_
     rw [linearIndependent_iff'] at hs ⊢
     simp_rw [← map_smul, ← map_sum, mkQ_apply, Quotient.mk_eq_zero]

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -108,6 +108,9 @@ protected irreducible_def Module.rank : Cardinal :=
   ⨆ ι : { s : Set V // LinearIndependent K ((↑) : s → V) }, (#ι.1)
 #align module.rank Module.rank
 
+instance : Nonempty { s : Set V // LinearIndependent K ((↑) : s → V) } :=
+  ⟨⟨∅, linearIndependent_empty _ _⟩⟩
+
 end
 
 section
@@ -145,16 +148,27 @@ theorem rank_le {n : ℕ}
   exact linearIndependent_bounded_of_finset_linearIndependent_bounded H _ li
 #align rank_le rank_le
 
-theorem rank_quotient_add_rank_le (M' : Submodule R M) :
+theorem rank_quotient_add_rank_le [Nontrivial R] (M' : Submodule R M) :
     Module.rank R (M ⧸ M') + Module.rank R M' ≤ Module.rank R M := by
   simp_rw [Module.rank_def]
-  sorry --convert ciSup_add_ciSup_le _
+  rw [Cardinal.ciSup_add_ciSup _ (bddAbove_range.{v, v} _) _ (bddAbove_range.{v, v} _)]
+  refine ciSup_le fun ⟨s, hs⟩ ↦ ciSup_le fun ⟨t, ht⟩ ↦ ?_
+  choose f hf using Quotient.mk_surjective M'
+  let g : s ⊕ t → M := Sum.elim (f ·) (·)
+  suffices : LinearIndependent R g
+  · refine le_trans ?_ (le_ciSup (bddAbove_range.{v, v} _) ⟨_, this.to_subtype_range⟩)
+    rw [mk_range_eq _ this.injective, mk_sum, lift_id, lift_id]
+  refine .sum_type (.of_comp M'.mkQ ?_) (ht.map' M'.subtype M'.ker_subtype) ?_
+  · convert hs; ext x; exact hf x
+  refine disjoint_def.mpr fun x h₁ h₂ ↦ ?_
+  have : x ∈ M' := span_le.mpr (Set.range_subset_iff.mpr fun i ↦ i.1.2) h₂
+  obtain ⟨c, rfl⟩ := Finsupp.mem_span_range_iff_exists_finsupp.mp h₁
+  simp_rw [← Quotient.mk_eq_zero, ← mkQ_apply, map_finsupp_sum, map_smul, mkQ_apply, hf] at this
+  rw [linearIndependent_iff.mp hs _ this, Finsupp.sum_zero_index]
 
-/-
+theorem lift_rank_add_lift_rank_le_rank_prod :
     lift.{v'} (Module.rank R M) + lift.{v} (Module.rank R M') ≤ Module.rank R (M × M') := by
-  -/
-
-
+  sorry
 
 /-- The rank of the range of a linear map is at most the rank of the source. -/
 -- The proof is: a free submodule of the range lifts to a free submodule of the

--- a/Mathlib/LinearAlgebra/Dimension.lean
+++ b/Mathlib/LinearAlgebra/Dimension.lean
@@ -145,6 +145,16 @@ theorem rank_le {n : ℕ}
   exact linearIndependent_bounded_of_finset_linearIndependent_bounded H _ li
 #align rank_le rank_le
 
+theorem rank_quotient_add_rank_le (M' : Submodule R M) :
+    Module.rank R (M ⧸ M') + Module.rank R M' ≤ Module.rank R M := by
+  simp_rw [Module.rank_def]
+  sorry --convert ciSup_add_ciSup_le _
+
+/-
+    lift.{v'} (Module.rank R M) + lift.{v} (Module.rank R M') ≤ Module.rank R (M × M') := by
+  -/
+
+
 
 /-- The rank of the range of a linear map is at most the rank of the source. -/
 -- The proof is: a free submodule of the range lifts to a free submodule of the
@@ -491,18 +501,6 @@ theorem rank_pos [Nontrivial M] : 0 < Module.rank R M := by
 
 variable [Nontrivial R]
 
-theorem rank_zero_iff_forall_zero : Module.rank R M = 0 ↔ ∀ x : M, x = 0 := by
-  refine' ⟨fun h => _, fun h => _⟩
-  · contrapose! h
-    obtain ⟨x, hx⟩ := h
-    letI : Nontrivial M := nontrivial_of_ne _ _ hx
-    exact rank_pos.ne'
-  · have : (⊤ : Submodule R M) = ⊥ := by
-      ext x
-      simp [h x]
-    rw [← rank_top, this, rank_bot]
-#align rank_zero_iff_forall_zero rank_zero_iff_forall_zero
-
 /-- See `rank_zero_iff` for a stronger version with `NoZeroSMulDivisor R M`. -/
 lemma rank_eq_zero_iff {R M} [Ring R] [AddCommGroup M] [Module R M] :
     Module.rank R M = 0 ↔ ∀ x : M, ∃ a : R, a ≠ 0 ∧ a • x = 0 := by
@@ -524,6 +522,11 @@ lemma rank_eq_zero_iff {R M} [Ring R] [AddCommGroup M] [Module R M] :
     obtain ⟨a, ha, ha'⟩ := h i
     apply ha
     simpa using FunLike.congr_fun (linearIndependent_iff.mp hs (Finsupp.single i a) (by simpa)) i
+
+theorem rank_zero_iff_forall_zero : Module.rank R M = 0 ↔ ∀ x : M, x = 0 := by
+  simp_rw [rank_eq_zero_iff, smul_eq_zero, and_or_left, not_and_self_iff, false_or,
+    exists_and_right, and_iff_right (exists_ne (0 : R))]
+#align rank_zero_iff_forall_zero rank_zero_iff_forall_zero
 
 lemma rank_eq_zero_iff_isTorsion {R M} [CommRing R] [IsDomain R] [AddCommGroup M] [Module R M] :
     Module.rank R M = 0 ↔ Module.IsTorsion R M := by

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -1013,20 +1013,23 @@ protected theorem iSup_of_empty {ι} (f : ι → Cardinal) [IsEmpty ι] : iSup f
 #align cardinal.supr_of_empty Cardinal.iSup_of_empty
 
 lemma exists_eq_of_iSup_eq_of_not_isSuccLimit
-    {ι : Type u} (f : ι → Cardinal.{max u v}) (ω : Cardinal.{max u v})
+    {ι : Type u} (f : ι → Cardinal.{v}) (ω : Cardinal.{v})
     (hω : ¬ Order.IsSuccLimit ω)
     (h : ⨆ i : ι, f i = ω) : ∃ i, f i = ω :=
-  IsLUB.exists_of_not_isSuccLimit (h ▸ isLUB_csSup' (bddAbove_range.{u, v} f)) hω
+  (Classical.em <| BddAbove <| range f).elim
+    (fun hf ↦ IsLUB.exists_of_not_isSuccLimit (h ▸ isLUB_csSup' hf) hω) fun hf ↦ by
+      rw [iSup, csSup_of_not_bddAbove hf, csSup_empty] at h
+      exact (hω <| h ▸ Order.isSuccLimit_bot).elim
 
 lemma exists_eq_of_iSup_eq_of_not_isLimit
-    {ι : Type u} [hι : Nonempty ι] (f : ι → Cardinal.{max u v}) (ω : Cardinal.{max u v})
-    (hω : ¬ ω.IsLimit)
+    {ι : Type u} [hι : Nonempty ι] (f : ι → Cardinal.{v}) (hf : BddAbove (range f))
+    (ω : Cardinal.{v}) (hω : ¬ ω.IsLimit)
     (h : ⨆ i : ι, f i = ω) : ∃ i, f i = ω := by
   refine (not_and_or.mp hω).elim (fun e ↦ ⟨hι.some, ?_⟩)
     (Cardinal.exists_eq_of_iSup_eq_of_not_isSuccLimit.{u, v} f ω · h)
   cases not_not.mp e
   rw [← le_zero_iff] at h ⊢
-  exact (le_ciSup (Cardinal.bddAbove_range.{u, v} f) _).trans h
+  exact (le_ciSup hf _).trans h
 
 -- Portin note: simpNF is not happy with universe levels.
 @[simp, nolint simpNF]
@@ -1475,9 +1478,9 @@ theorem IsLimit.aleph0_le {c : Cardinal} (h : IsLimit c) : ℵ₀ ≤ c := by
   rcases lt_aleph0.1 h' with ⟨n, rfl⟩
   exact not_isLimit_natCast n h
 
-lemma exists_eq_natCast_of_iSup_eq {ι : Type u} [Nonempty ι] (f : ι → Cardinal.{max u v})
-    (n : ℕ) (h : ⨆ i, f i = n) : ∃ i, f i = n :=
-  exists_eq_of_iSup_eq_of_not_isLimit.{u, v} f _ (not_isLimit_natCast n) h
+lemma exists_eq_natCast_of_iSup_eq {ι : Type u} [Nonempty ι] (f : ι → Cardinal.{v})
+    (hf : BddAbove (range f)) (n : ℕ) (h : ⨆ i, f i = n) : ∃ i, f i = n :=
+  exists_eq_of_iSup_eq_of_not_isLimit.{u, v} f hf _ (not_isLimit_natCast n) h
 
 @[simp]
 theorem range_natCast : range ((↑) : ℕ → Cardinal) = Iio ℵ₀ :=

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -851,10 +851,13 @@ protected theorem eq_of_add_eq_add_right {a b c : Cardinal} (h : a + b = c + b) 
 
 section ciSup
 
-variable {ι : Type u} [Nonempty ι] {ι' : Type w} [Nonempty ι']
-variable (f : ι → Cardinal.{v}) (hf : BddAbove (range f)) (c : Cardinal.{v})
+variable {ι : Type u} {ι' : Type w} (f : ι → Cardinal.{v})
 
-protected theorem ciSup_add : (⨆ i, f i) + c = ⨆ i, f i + c := by
+section add
+
+variable [Nonempty ι] [Nonempty ι'] (hf : BddAbove (range f))
+
+protected theorem ciSup_add (c : Cardinal.{v}) : (⨆ i, f i) + c = ⨆ i, f i + c := by
   have : ∀ i, f i + c ≤ (⨆ i, f i) + c := fun i ↦ add_le_add_right (le_ciSup hf i) c
   refine le_antisymm ?_ (ciSup_le' this)
   have bdd : BddAbove (range (f · + c)) := ⟨_, forall_range_iff.mpr this⟩
@@ -866,14 +869,22 @@ protected theorem ciSup_add : (⨆ i, f i) + c = ⨆ i, f i + c := by
   exact ⟨ciSup_mono bdd fun i ↦ self_le_add_right _ c,
     (self_le_add_left _ _).trans (le_ciSup bdd <| Classical.arbitrary ι)⟩
 
-protected theorem add_ciSup : c + (⨆ i, f i) = ⨆ i, c + f i := by
+protected theorem add_ciSup (c : Cardinal.{v}) : c + (⨆ i, f i) = ⨆ i, c + f i := by
   rw [add_comm, Cardinal.ciSup_add f hf]; simp_rw [add_comm]
 
 protected theorem ciSup_add_ciSup (g : ι' → Cardinal.{v}) (hg : BddAbove (range g)) :
     (⨆ i, f i) + (⨆ j, g j) = ⨆ (i) (j), f i + g j := by
   simp_rw [Cardinal.ciSup_add f hf, Cardinal.add_ciSup g hg]
 
-protected theorem ciSup_mul : (⨆ i, f i) * c = ⨆ i, f i * c := by
+end add
+
+protected theorem ciSup_mul (c : Cardinal.{v}) : (⨆ i, f i) * c = ⨆ i, f i * c := by
+  cases isEmpty_or_nonempty ι; · simp
+  obtain rfl | h0 := eq_or_ne c 0; · simp
+  by_cases hf : BddAbove (range f); swap
+  · have hfc : ¬ BddAbove (range (f · * c)) := fun bdd ↦ hf
+      ⟨⨆ i, f i * c, forall_range_iff.mpr fun i ↦ (le_mul_right h0).trans (le_ciSup bdd i)⟩
+    simp [iSup, csSup_of_not_bddAbove, hf, hfc]
   have : ∀ i, f i * c ≤ (⨆ i, f i) * c := fun i ↦ mul_le_mul_right' (le_ciSup hf i) c
   refine le_antisymm ?_ (ciSup_le' this)
   have bdd : BddAbove (range (f · * c)) := ⟨_, forall_range_iff.mpr this⟩
@@ -881,19 +892,17 @@ protected theorem ciSup_mul : (⨆ i, f i) * c = ⨆ i, f i * c := by
   · obtain ⟨i, hi⟩ := exists_eq_of_iSup_eq_of_not_isLimit
       f hf _ (fun h ↦ hs.not_le h.aleph0_le) rfl
     exact hi ▸ le_ciSup bdd i
-  obtain rfl | h0 := eq_or_ne c 0
-  · simp_rw [mul_zero, ciSup_const, le_rfl]
   rw [mul_eq_max_of_aleph0_le_left hs h0, max_le_iff]
   obtain ⟨i, hi⟩ := exists_lt_of_lt_ciSup' (one_lt_aleph0.trans_le hs)
   exact ⟨ciSup_mono bdd fun i ↦ le_mul_right h0,
     (le_mul_left (zero_lt_one.trans hi).ne').trans (le_ciSup bdd i)⟩
 
-protected theorem mul_ciSup : c * (⨆ i, f i) = ⨆ i, c * f i := by
-  rw [mul_comm, Cardinal.ciSup_mul f hf]; simp_rw [mul_comm]
+protected theorem mul_ciSup (c : Cardinal.{v}) : c * (⨆ i, f i) = ⨆ i, c * f i := by
+  rw [mul_comm, Cardinal.ciSup_mul f]; simp_rw [mul_comm]
 
-protected theorem ciSup_mul_ciSup (g : ι' → Cardinal.{v}) (hg : BddAbove (range g)) :
+protected theorem ciSup_mul_ciSup (g : ι' → Cardinal.{v}) :
     (⨆ i, f i) * (⨆ j, g j) = ⨆ (i) (j), f i * g j := by
-  simp_rw [Cardinal.ciSup_mul f hf, Cardinal.mul_ciSup g hg]
+  simp_rw [Cardinal.ciSup_mul f, Cardinal.mul_ciSup g]
 
 end ciSup
 

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -851,38 +851,49 @@ protected theorem eq_of_add_eq_add_right {a b c : Cardinal} (h : a + b = c + b) 
 
 section ciSup
 
-variable {ι : Type u} [Nonempty ι]
+variable {ι : Type u} [Nonempty ι] {ι' : Type w} [Nonempty ι']
 variable (f : ι → Cardinal.{v}) (hf : BddAbove (range f)) (c : Cardinal.{v})
 
 protected theorem ciSup_add : (⨆ i, f i) + c = ⨆ i, f i + c := by
-  have this : ∀ i, f i + c ≤ (⨆ i, f i) + c := fun i ↦ add_le_add_right (le_ciSup hf i) c
+  have : ∀ i, f i + c ≤ (⨆ i, f i) + c := fun i ↦ add_le_add_right (le_ciSup hf i) c
   refine le_antisymm ?_ (ciSup_le' this)
-  have bdd : BddAbove (range (f · + c)) := ⟨_, Set.forall_range_iff.mpr this⟩
+  have bdd : BddAbove (range (f · + c)) := ⟨_, forall_range_iff.mpr this⟩
   obtain hs | hs := lt_or_le (⨆ i, f i) ℵ₀
   · obtain ⟨i, hi⟩ := exists_eq_of_iSup_eq_of_not_isLimit
       f hf _ (fun h ↦ hs.not_le h.aleph0_le) rfl
     exact hi ▸ le_ciSup bdd i
-  obtain hc | hc := lt_or_le c (⨆ i, f i)
-  · exact (add_eq_left hs hc.le).trans_le (ciSup_mono bdd fun i ↦ self_le_add_right _ c)
-  · exact (add_eq_right (hs.trans hc) hc).trans_le
-      ((self_le_add_left _ _).trans <| le_ciSup bdd <| Classical.arbitrary ι)
+  rw [add_eq_max hs, max_le_iff]
+  exact ⟨ciSup_mono bdd fun i ↦ self_le_add_right _ c,
+    (self_le_add_left _ _).trans (le_ciSup bdd <| Classical.arbitrary ι)⟩
 
 protected theorem add_ciSup : c + (⨆ i, f i) = ⨆ i, c + f i := by
   rw [add_comm, Cardinal.ciSup_add f hf]; simp_rw [add_comm]
 
-protected theorem ciSup_add_ciSup (g : ι → Cardinal.{v}) (hg : BddAbove (range g)) :
+protected theorem ciSup_add_ciSup (g : ι' → Cardinal.{v}) (hg : BddAbove (range g)) :
     (⨆ i, f i) + (⨆ j, g j) = ⨆ (i) (j), f i + g j := by
   simp_rw [Cardinal.ciSup_add f hf, Cardinal.add_ciSup g hg]
 
 protected theorem ciSup_mul : (⨆ i, f i) * c = ⨆ i, f i * c := by
-  sorry
+  have : ∀ i, f i * c ≤ (⨆ i, f i) * c := fun i ↦ mul_le_mul_right' (le_ciSup hf i) c
+  refine le_antisymm ?_ (ciSup_le' this)
+  have bdd : BddAbove (range (f · * c)) := ⟨_, forall_range_iff.mpr this⟩
+  obtain hs | hs := lt_or_le (⨆ i, f i) ℵ₀
+  · obtain ⟨i, hi⟩ := exists_eq_of_iSup_eq_of_not_isLimit
+      f hf _ (fun h ↦ hs.not_le h.aleph0_le) rfl
+    exact hi ▸ le_ciSup bdd i
+  obtain rfl | h0 := eq_or_ne c 0
+  · simp_rw [mul_zero, ciSup_const, le_rfl]
+  rw [mul_eq_max_of_aleph0_le_left hs h0, max_le_iff]
+  obtain ⟨i, hi⟩ := exists_lt_of_lt_ciSup' (one_lt_aleph0.trans_le hs)
+  exact ⟨ciSup_mono bdd fun i ↦ le_mul_right h0,
+    (le_mul_left (zero_lt_one.trans hi).ne').trans (le_ciSup bdd i)⟩
 
 protected theorem mul_ciSup : c * (⨆ i, f i) = ⨆ i, c * f i := by
-  sorry
+  rw [mul_comm, Cardinal.ciSup_mul f hf]; simp_rw [mul_comm]
 
-protected theorem ciSup_mul_ciSup (g : ι → Cardinal.{v}) (hg : BddAbove (range g)) :
+protected theorem ciSup_mul_ciSup (g : ι' → Cardinal.{v}) (hg : BddAbove (range g)) :
     (⨆ i, f i) * (⨆ j, g j) = ⨆ (i) (j), f i * g j := by
-  sorry
+  simp_rw [Cardinal.ciSup_mul f hf, Cardinal.mul_ciSup g hg]
 
 end ciSup
 

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -849,12 +849,15 @@ protected theorem eq_of_add_eq_add_right {a b c : Cardinal} (h : a + b = c + b) 
   exact Cardinal.eq_of_add_eq_add_left h hb
 #align cardinal.eq_of_add_eq_add_right Cardinal.eq_of_add_eq_add_right
 
-theorem ciSup_add {ι : Type*} [Nonempty ι] (f : ι → Cardinal) (hf : BddAbove (range f))
-    (c : Cardinal) : (⨆ i, f i) + c = ⨆ i, f i + c := by
-  refine le_antisymm ?_ (ciSup_le' fun i ↦ add_le_add_right (le_ciSup hf i) c)
-  have bdd : BddAbove (range (f · + c))
-  · obtain ⟨b, hb⟩ := hf; use b + c
-    rintro _ ⟨i, rfl⟩; exact add_le_add_right (hb ⟨i, rfl⟩) c
+section ciSup
+
+variable {ι : Type u} [Nonempty ι]
+variable (f : ι → Cardinal.{v}) (hf : BddAbove (range f)) (c : Cardinal.{v})
+
+protected theorem ciSup_add : (⨆ i, f i) + c = ⨆ i, f i + c := by
+  have this : ∀ i, f i + c ≤ (⨆ i, f i) + c := fun i ↦ add_le_add_right (le_ciSup hf i) c
+  refine le_antisymm ?_ (ciSup_le' this)
+  have bdd : BddAbove (range (f · + c)) := ⟨_, Set.forall_range_iff.mpr this⟩
   obtain hs | hs := lt_or_le (⨆ i, f i) ℵ₀
   · obtain ⟨i, hi⟩ := exists_eq_of_iSup_eq_of_not_isLimit
       f hf _ (fun h ↦ hs.not_le h.aleph0_le) rfl
@@ -863,6 +866,25 @@ theorem ciSup_add {ι : Type*} [Nonempty ι] (f : ι → Cardinal) (hf : BddAbov
   · exact (add_eq_left hs hc.le).trans_le (ciSup_mono bdd fun i ↦ self_le_add_right _ c)
   · exact (add_eq_right (hs.trans hc) hc).trans_le
       ((self_le_add_left _ _).trans <| le_ciSup bdd <| Classical.arbitrary ι)
+
+protected theorem add_ciSup : c + (⨆ i, f i) = ⨆ i, c + f i := by
+  rw [add_comm, Cardinal.ciSup_add f hf]; simp_rw [add_comm]
+
+protected theorem ciSup_add_ciSup (g : ι → Cardinal.{v}) (hg : BddAbove (range g)) :
+    (⨆ i, f i) + (⨆ j, g j) = ⨆ (i) (j), f i + g j := by
+  simp_rw [Cardinal.ciSup_add f hf, Cardinal.add_ciSup g hg]
+
+protected theorem ciSup_mul : (⨆ i, f i) * c = ⨆ i, f i * c := by
+  sorry
+
+protected theorem mul_ciSup : c * (⨆ i, f i) = ⨆ i, c * f i := by
+  sorry
+
+protected theorem ciSup_mul_ciSup (g : ι → Cardinal.{v}) (hg : BddAbove (range g)) :
+    (⨆ i, f i) * (⨆ j, g j) = ⨆ (i) (j), f i * g j := by
+  sorry
+
+end ciSup
 
 @[simp]
 theorem aleph_add_aleph (o₁ o₂ : Ordinal) : aleph o₁ + aleph o₂ = aleph (max o₁ o₂) := by

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -849,6 +849,21 @@ protected theorem eq_of_add_eq_add_right {a b c : Cardinal} (h : a + b = c + b) 
   exact Cardinal.eq_of_add_eq_add_left h hb
 #align cardinal.eq_of_add_eq_add_right Cardinal.eq_of_add_eq_add_right
 
+theorem ciSup_add {ι : Type*} [Nonempty ι] (f : ι → Cardinal) (hf : BddAbove (range f))
+    (c : Cardinal) : (⨆ i, f i) + c = ⨆ i, f i + c := by
+  refine le_antisymm ?_ (ciSup_le' fun i ↦ add_le_add_right (le_ciSup hf i) c)
+  have bdd : BddAbove (range (f · + c))
+  · obtain ⟨b, hb⟩ := hf; use b + c
+    rintro _ ⟨i, rfl⟩; exact add_le_add_right (hb ⟨i, rfl⟩) c
+  obtain hs | hs := lt_or_le (⨆ i, f i) ℵ₀
+  · obtain ⟨i, hi⟩ := exists_eq_of_iSup_eq_of_not_isLimit
+      f hf _ (fun h ↦ hs.not_le h.aleph0_le) rfl
+    exact hi ▸ le_ciSup bdd i
+  obtain hc | hc := lt_or_le c (⨆ i, f i)
+  · exact (add_eq_left hs hc.le).trans_le (ciSup_mono bdd fun i ↦ self_le_add_right _ c)
+  · exact (add_eq_right (hs.trans hc) hc).trans_le
+      ((self_le_add_left _ _).trans <| le_ciSup bdd <| Classical.arbitrary ι)
+
 @[simp]
 theorem aleph_add_aleph (o₁ o₂ : Ordinal) : aleph o₁ + aleph o₂ = aleph (max o₁ o₂) := by
   rw [Cardinal.add_eq_max (aleph0_le_aleph o₁), max_aleph_eq]


### PR DESCRIPTION
+ Proves that `Sup` (ciSup) commutes with cardinal addition (`ciSup_add_ciSup`) and multiplication. Generalize results in Cardinal/Basic introduced in #8842 to achieve this.

+ Use `ciSup_add_ciSup` to prove that the rank of a module is always at least the rank of a submodule plus the rank of the quotient by the submodule. Deduce that the rank of a product module is at least the sum of the ranks of the two factors.

+ Show that quotienting by a torsion submodule preserves the rank.

+ Golf `rank_zero_iff_forall_zero` using a recently added lemma.

Co-authored-by: Andrew Yang <the.erd.one@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
