### PR TITLE
[Merged by Bors] - feat(Data/Polynomial/Expand): add `leadingCoeff_expand` and `monic_expand_iff`

### DIFF
--- a/Mathlib/Data/Polynomial/Expand.lean
+++ b/Mathlib/Data/Polynomial/Expand.lean
@@ -170,9 +170,15 @@ theorem natDegree_expand (p : ℕ) (f : R[X]) : (expand R p f).natDegree = f.nat
     exact mt leadingCoeff_eq_zero.1 hf
 #align polynomial.nat_degree_expand Polynomial.natDegree_expand
 
-theorem Monic.expand {p : ℕ} {f : R[X]} (hp : 0 < p) (h : f.Monic) : (expand R p f).Monic := by
-  rw [Monic.def, Polynomial.leadingCoeff, natDegree_expand, coeff_expand hp]
-  simp [hp, h]
+theorem leadingCoeff_expand {p : ℕ} {f : R[X]} (hp : 0 < p) :
+    (expand R p f).leadingCoeff = f.leadingCoeff := by
+  simp only [leadingCoeff, natDegree_expand, coeff_expand hp, dvd_mul_left, ite_true,
+    Nat.mul_div_cancel _ hp]
+
+theorem monic_expand_iff {p : ℕ} {f : R[X]} (hp : 0 < p) : (expand R p f).Monic ↔ f.Monic := by
+  simp only [Monic, leadingCoeff_expand hp]
+
+alias ⟨_, Monic.expand⟩ := monic_expand_iff
 #align polynomial.monic.expand Polynomial.Monic.expand
 
 theorem map_expand {p : ℕ} {f : R →+* S} {q : R[X]} :

--- a/Mathlib/Data/Polynomial/Expand.lean
+++ b/Mathlib/Data/Polynomial/Expand.lean
@@ -172,8 +172,7 @@ theorem natDegree_expand (p : ℕ) (f : R[X]) : (expand R p f).natDegree = f.nat
 
 theorem leadingCoeff_expand {p : ℕ} {f : R[X]} (hp : 0 < p) :
     (expand R p f).leadingCoeff = f.leadingCoeff := by
-  simp only [leadingCoeff, natDegree_expand, coeff_expand hp, dvd_mul_left, ite_true,
-    Nat.mul_div_cancel _ hp]
+  simp_rw [leadingCoeff, natDegree_expand, coeff_expand_mul hp]
 
 theorem monic_expand_iff {p : ℕ} {f : R[X]} (hp : 0 < p) : (expand R p f).Monic ↔ f.Monic := by
   simp only [Monic, leadingCoeff_expand hp]


### PR DESCRIPTION
The first states that `expand` preserves leading coefficient; the second states that `expand` preserves monicity, hence gives a converse to `Monic.expand`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Split from #9041, existing discussions: https://github.com/leanprover-community/mathlib4/pull/9041#discussion_r1434176795 https://github.com/leanprover-community/mathlib4/pull/9041#discussion_r1434177081

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
