### PR TITLE
[Merged by Bors] - chore(SpecialFunctions/Gamma): golf a proof

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
@@ -532,26 +532,21 @@ theorem one_div_Gamma_eq_self_mul_one_div_Gamma_add_one (s : ℂ) :
   · rw [zero_add, Gamma_zero, inv_zero, zero_mul]
 #align complex.one_div_Gamma_eq_self_mul_one_div_Gamma_add_one Complex.one_div_Gamma_eq_self_mul_one_div_Gamma_add_one
 
-/-- The reciprocal of the Gamma function is differentiable everywhere (including the points where
-Gamma itself is not). -/
-theorem differentiable_one_div_Gamma : Differentiable ℂ fun s : ℂ => (Gamma s)⁻¹ := by
-  suffices : ∀ n : ℕ, ∀ (s : ℂ) (_ : -s.re < n), DifferentiableAt ℂ (fun u : ℂ => (Gamma u)⁻¹) s
-  exact fun s =>
-    let ⟨n, h⟩ := exists_nat_gt (-s.re)
-    this n s h
-  intro n
-  induction' n with m hm
-  · intro s hs
+/-- The reciprocal of the Gamma function is differentiable everywhere
+(including the points where Gamma itself is not). -/
+theorem differentiable_one_div_Gamma : Differentiable ℂ fun s : ℂ => (Gamma s)⁻¹ := fun s ↦ by
+  rcases exists_nat_gt (-s.re) with ⟨n, hs⟩
+  induction n generalizing s with
+  | zero =>
     rw [Nat.cast_zero, neg_lt_zero] at hs
     suffices : ∀ m : ℕ, s ≠ -↑m; exact (differentiableAt_Gamma _ this).inv (Gamma_ne_zero this)
-    contrapose! hs
-    rcases hs with ⟨m, rfl⟩
-    simpa only [neg_re, ← ofReal_nat_cast, ofReal_re, neg_nonpos] using Nat.cast_nonneg m
-  · intro s hs
+    rintro m rfl
+    apply hs.not_le
+    simp
+  | succ n ihn =>
     rw [funext one_div_Gamma_eq_self_mul_one_div_Gamma_add_one]
-    specialize hm (s + 1) (by rwa [add_re, one_re, neg_add', sub_lt_iff_lt_add, ← Nat.cast_succ])
-    refine' differentiableAt_id.mul (hm.comp s _)
-    exact differentiableAt_id.add (differentiableAt_const _)
+    specialize ihn (s + 1) (by rwa [add_re, one_re, neg_add', sub_lt_iff_lt_add, ← Nat.cast_succ])
+    exact differentiableAt_id.mul (ihn.comp s <| differentiableAt_id.add_const _)
 #align complex.differentiable_one_div_Gamma Complex.differentiable_one_div_Gamma
 
 end Complex


### PR DESCRIPTION
Use `induction .. generalizing` instead of `suffices`.

---

Should this and nearby lemmas use `inv` instead of `one_div` in their names?
Or use `1 / Gamma s` in the formal statements?
@loefflerd :arrow_up: 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)