### PR TITLE
[Merged by Bors] - chore: remove workarounds for lean4#1891

### DIFF
--- a/Mathlib/Data/Prod/Lex.lean
+++ b/Mathlib/Data/Prod/Lex.lean
@@ -108,22 +108,14 @@ section Preorder
 
 variable [PartialOrder α] [Preorder β]
 
--- porting note: type class search sees right through the type synonrm for `α ×ₗ β` and uses the
--- `Preorder` structure for `α × β` instead
--- This is hopefully the same problems as in https://github.com/leanprover/lean4/issues/1891
--- and will be fixed in nightly-2022-11-30
-theorem toLex_mono : @Monotone _ _ _ (Prod.Lex.preorder α β) (toLex : α × β → α ×ₗ β) := by
+theorem toLex_mono : Monotone (toLex : α × β → α ×ₗ β) := by
   rintro ⟨a₁, b₁⟩ ⟨a₂, b₂⟩ ⟨ha, hb⟩
   obtain rfl | ha : a₁ = a₂ ∨ _ := ha.eq_or_lt
   · exact right _ hb
   · exact left _ _ ha
 #align prod.lex.to_lex_mono Prod.Lex.toLex_mono
 
--- porting note: type class search sees right through the type synonrm for `α ×ₗ β` and uses the
--- `Preorder` structure for `α × β` instead
--- This is hopefully the same problems as in https://github.com/leanprover/lean4/issues/1891
--- and will be fixed in nightly-2022-11-30
-theorem toLex_strictMono : @StrictMono _ _ _ (Prod.Lex.preorder α β) (toLex : α × β → α ×ₗ β) := by
+theorem toLex_strictMono : StrictMono (toLex : α × β → α ×ₗ β) := by
   rintro ⟨a₁, b₁⟩ ⟨a₂, b₂⟩ h
   obtain rfl | ha : a₁ = a₂ ∨ _ := h.le.1.eq_or_lt
   · exact right _ (Prod.mk_lt_mk_iff_right.1 h)


### PR DESCRIPTION
We no longer need to explicitly specify the `Monotone` and `StrictMono` arguments, after https://github.com/leanprover/lean4/commit/069873d8e5e0e7bed18f71edb63d18da50748ec9 fixed https://github.com/leanprover/lean4/issues/1891.

Compare to the mathlib3 declarations:
https://github.com/leanprover-community/mathlib/blob/65a1391a0106c9204fe45bc73a039f056558cb83/src/data/prod/lex.lean#L93-L107

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
