### PR TITLE
[Merged by Bors] - chore: remove now-unneeded dsimp and its associated porting note

### DIFF
--- a/Mathlib/Algebra/Group/Units/Hom.lean
+++ b/Mathlib/Algebra/Group/Units/Hom.lean
@@ -156,7 +156,7 @@ this map is a monoid homomorphism too. -/
   is an AddMonoid homomorphism too."]
 def liftRight (f : M →* N) (g : M → Nˣ) (h : ∀ x, ↑(g x) = f x) : M →* Nˣ where
   toFun := g
-  map_one' := by ext; dsimp only; rw [h 1]; exact f.map_one -- Porting note: why is `dsimp` needed?
+  map_one' := by ext; rw [h 1]; exact f.map_one
   map_mul' x y := Units.ext <| by simp only [h, val_mul, f.map_mul]
 #align units.lift_right Units.liftRight
 #align add_units.lift_right AddUnits.liftRight


### PR DESCRIPTION
The `dsimp only` is no longer needed after #3222 adjusted the definition of `Units.ext`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
