### PR TITLE
[Merged by Bors] - fix(Tactic/MoveAdd): add missing `withContext`

### DIFF
--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -358,7 +358,7 @@ operation and a list of "instructions" `instr` that it passes to `permuteExpr`.
   `op`-analogues of `add_comm, add_assoc, add_left_comm`.
 -/
 def reorderAndSimp (mv : MVarId) (instr : List (Expr × Bool)) :
-    MetaM (List MVarId) := do
+    MetaM (List MVarId) := mv.withContext do
   let permExpr ← permuteExpr op (← mv.getType'') instr
   -- generate the implication `permutedMv → mv = permutedMv → mv`
   let eqmpr ← mkAppM ``Eq.mpr #[← mkFreshExprMVar (← mkEq (← mv.getType) permExpr)]

--- a/test/MoveAdd.lean
+++ b/test/MoveAdd.lean
@@ -88,6 +88,13 @@ example {a b c d e : Prop} (h : a ∨ b ∨ c ∨ d ∨ e) : a ∨ c ∨ e ∨ b
 
 end left_assoc
 
+example (k : ℕ) (h0 : 0 + 2 = 9 + 0) (h9 : k + 2 = k + 9) : k + 2 = 9 + k := by
+  induction' k with k _ih
+  · exact h0
+  · move_add [9]
+    exact h9
+
+
 -- Testing internals of the tactic `move_add`.
 section tactic
 open Mathlib.MoveAdd

--- a/test/MoveAdd.lean
+++ b/test/MoveAdd.lean
@@ -94,7 +94,6 @@ example (k : ℕ) (h0 : 0 + 2 = 9 + 0) (h9 : k + 2 = k + 9) : k + 2 = 9 + k := b
   · move_add [9]
     exact h9
 
-
 -- Testing internals of the tactic `move_add`.
 section tactic
 open Mathlib.MoveAdd


### PR DESCRIPTION
Adds a missing `withContext`, as mentioned in this [Zulip message](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2313483.20.60move_add.60/near/409960750).

I also added the relevant test.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
