### PR TITLE
[Merged by Bors] - feat: Boundaryless manifold

### DIFF
--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -103,34 +103,43 @@ lemma _root_.range_mem_nhds_isInteriorPoint {x : M} (h : I.IsInteriorPoint x) :
   rw [mem_nhds_iff]
   exact ⟨interior (range I), interior_subset, isOpen_interior, h⟩
 
+/-- Type class for manifold without boundary. This differs from `ModelWithCorners.Boundaryless`,
+  which states that the `ModelWithCorners` maps to the whole model vector space. -/
 class _root_.BoundarylessManifold {𝕜 : Type*} [NontriviallyNormedField 𝕜]
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
     {H : Type*} [TopologicalSpace H] (I : ModelWithCorners 𝕜 E H)
     (M : Type*) [TopologicalSpace M] [ChartedSpace H M] : Prop where
   isInteriorPoint' : ∀ x : M, IsInteriorPoint I x
 
+variable {I} in
 lemma _root_.BoundarylessManifold.isInteriorPoint [BoundarylessManifold I M] {x : M} :
-    IsInteriorPoint I x := _root_.BoundarylessManifold.isInteriorPoint' x
+    IsInteriorPoint I x := BoundarylessManifold.isInteriorPoint' x
 
 section Boundaryless
 variable [I.Boundaryless]
 
-/-- If `I` is boundaryless, every point of `M` is an interior point. -/
-lemma isInteriorPoint {x : M} : I.IsInteriorPoint x := by
-  let r := ((chartAt H x).isOpen_extend_target I).interior_eq
-  have : extChartAt I x = (chartAt H x).extend I := rfl
-  rw [← this] at r
-  rw [ModelWithCorners.isInteriorPoint_iff, r]
-  exact PartialEquiv.map_source _ (mem_extChartAt_source _ _)
+instance : BoundarylessManifold I M where
+  isInteriorPoint' := by
+    intro x
+    let r := ((chartAt H x).isOpen_extend_target I).interior_eq
+    have : extChartAt I x = (chartAt H x).extend I := rfl
+    rw [← this] at r
+    rw [ModelWithCorners.isInteriorPoint_iff, r]
+    exact PartialEquiv.map_source _ (mem_extChartAt_source _ _)
 
-/-- If `I` is boundaryless, `M` has full interior. -/
+end Boundaryless
+
+section BoundarylessManifold
+variable [BoundarylessManifold I M]
+
+/-- Boundaryless manifolds have full interior. -/
 lemma interior_eq_univ : I.interior M = univ := by
   ext
-  refine ⟨fun _ ↦ trivial, fun _ ↦ I.isInteriorPoint⟩
+  refine ⟨fun _ ↦ trivial, fun _ ↦ BoundarylessManifold.isInteriorPoint⟩
 
-/-- If `I` is boundaryless, `M` has empty boundary. -/
+/-- Boundaryless manifolds have empty boundary. -/
 lemma Boundaryless.boundary_eq_empty : I.boundary M = ∅ := by
   rw [I.boundary_eq_complement_interior, I.interior_eq_univ, compl_empty_iff]
 
-end Boundaryless
+end BoundarylessManifold
 end ModelWithCorners

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -116,8 +116,7 @@ variable [I.Boundaryless]
 
 /-- Boundaryless `ModelWithCorners` implies boundaryless manifold. -/
 instance : BoundarylessManifold I M where
-  isInteriorPoint' := by
-    intro x
+  isInteriorPoint' x := by
     let r := ((chartAt H x).isOpen_extend_target I).interior_eq
     have : extChartAt I x = (chartAt H x).extend I := rfl
     rw [← this] at r

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -111,13 +111,10 @@ class _root_.BoundarylessManifold {𝕜 : Type*} [NontriviallyNormedField 𝕜]
     (M : Type*) [TopologicalSpace M] [ChartedSpace H M] : Prop where
   isInteriorPoint' : ∀ x : M, IsInteriorPoint I x
 
-variable {I} in
-lemma _root_.BoundarylessManifold.isInteriorPoint [BoundarylessManifold I M] {x : M} :
-    IsInteriorPoint I x := BoundarylessManifold.isInteriorPoint' x
-
 section Boundaryless
 variable [I.Boundaryless]
 
+/-- Boundaryless `ModelWithCorners` implies boundaryless manifold. -/
 instance : BoundarylessManifold I M where
   isInteriorPoint' := by
     intro x
@@ -132,14 +129,19 @@ end Boundaryless
 section BoundarylessManifold
 variable [BoundarylessManifold I M]
 
+lemma _root_.BoundarylessManifold.isInteriorPoint {x : M} :
+    IsInteriorPoint I x := BoundarylessManifold.isInteriorPoint' x
+
 /-- Boundaryless manifolds have full interior. -/
 lemma interior_eq_univ : I.interior M = univ := by
   ext
-  refine ⟨fun _ ↦ trivial, fun _ ↦ BoundarylessManifold.isInteriorPoint⟩
+  refine ⟨fun _ ↦ trivial, fun _ ↦ BoundarylessManifold.isInteriorPoint I⟩
 
 /-- Boundaryless manifolds have empty boundary. -/
 lemma Boundaryless.boundary_eq_empty : I.boundary M = ∅ := by
   rw [I.boundary_eq_complement_interior, I.interior_eq_univ, compl_empty_iff]
+
+def ModelWithCorners.toPartialHomeomorph : PartialHomeomorph M E := sorry
 
 end BoundarylessManifold
 end ModelWithCorners

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -103,7 +103,65 @@ lemma _root_.range_mem_nhds_isInteriorPoint {x : M} (h : I.IsInteriorPoint x) :
   rw [mem_nhds_iff]
   exact ⟨interior (range I), interior_subset, isOpen_interior, h⟩
 
-section boundaryless
+variable (M) in
+/-- Property ensuring that the model with corners `I` defines manifolds without boundary. -/
+class _root_.Boundaryless : Prop where
+  isInteriorPoint : ∀ x : M, IsInteriorPoint I x
+-- #align model_with_corners.boundaryless ModelWithCorners.Boundaryless
+
+theorem Boundaryless.isInteriorPoint [_root_.Boundaryless I M] {x : M} :
+    IsInteriorPoint I x := _root_.Boundaryless.isInteriorPoint x
+
+/-- If `I` is a `ModelWithCorners.Boundaryless` model, then it is a homeomorphism. -/
+@[simps (config := {simpRhs := true})]
+def toHomeomorph {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*}
+    [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
+    (I : ModelWithCorners 𝕜 E H) [I.Boundaryless] : H ≃ₜ E where
+  __ := I
+  left_inv := I.left_inv
+  right_inv _ := I.right_inv <| I.range_eq_univ.symm ▸ mem_univ _
+
+/-- The trivial model with corners has no boundary -/
+instance _root_.modelWithCornersSelf_boundaryless (𝕜 : Type*) [NontriviallyNormedField 𝕜] (E : Type*)
+    [NormedAddCommGroup E] [NormedSpace 𝕜 E] : (modelWithCornersSelf 𝕜 E).Boundaryless :=
+  ⟨by simp⟩
+#align model_with_corners_self_boundaryless modelWithCornersSelf_boundaryless
+
+/-- If two model with corners are boundaryless, their product also is -/
+instance range_eq_univ_prod {𝕜 : Type u} [NontriviallyNormedField 𝕜] {E : Type v}
+    [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type w} [TopologicalSpace H]
+    (I : ModelWithCorners 𝕜 E H) [I.Boundaryless] {E' : Type v'} [NormedAddCommGroup E']
+    [NormedSpace 𝕜 E'] {H' : Type w'} [TopologicalSpace H'] (I' : ModelWithCorners 𝕜 E' H')
+    [I'.Boundaryless] : (I.prod I').Boundaryless := by
+  constructor
+  dsimp [ModelWithCorners.prod, ModelProd]
+  rw [← prod_range_range_eq, ModelWithCorners.Boundaryless.range_eq_univ,
+    ModelWithCorners.Boundaryless.range_eq_univ, univ_prod_univ]
+#align model_with_corners.range_eq_univ_prod ModelWithCorners.range_eq_univ_prod
+
+/-- The analytic groupoid on a boundaryless charted space modeled on a complete vector space
+consists of the partial homeomorphisms which are analytic and have analytic inverse. -/
+theorem _root_.mem_analyticGroupoid_of_boundaryless [CompleteSpace E] [I.Boundaryless]
+    (e : PartialHomeomorph H H) :
+    e ∈ analyticGroupoid I ↔ AnalyticOn 𝕜 (I ∘ e ∘ I.symm) (I '' e.source) ∧
+    AnalyticOn 𝕜 (I ∘ e.symm ∘ I.symm) (I '' e.target) := by
+  apply Iff.intro
+  · intro he
+    have := mem_groupoid_of_pregroupoid.mp he.right
+    simp only [I.image_eq, I.range_eq_univ, interior_univ, subset_univ, and_true] at this ⊢
+    exact this
+  · intro he
+    apply And.intro
+    all_goals apply mem_groupoid_of_pregroupoid.mpr; simp only [I.image_eq, I.range_eq_univ,
+      interior_univ, subset_univ, and_true] at he ⊢
+    · exact ⟨he.left.contDiffOn, he.right.contDiffOn⟩
+    · exact he
+
+lemma _root_.PartialHomeomorph.isOpen_extend_target [I.Boundaryless] : IsOpen (f.extend I).target := by
+  rw [extend_target, I.range_eq_univ, inter_univ]
+  exact I.continuous_symm.isOpen_preimage _ f.open_target
+
+section Boundaryless
 variable [I.Boundaryless]
 
 /-- If `I` is boundaryless, every point of `M` is an interior point. -/
@@ -123,5 +181,5 @@ lemma interior_eq_univ : I.interior M = univ := by
 lemma Boundaryless.boundary_eq_empty : I.boundary M = ∅ := by
   rw [I.boundary_eq_complement_interior, I.interior_eq_univ, compl_empty_iff]
 
-end boundaryless
+end Boundaryless
 end ModelWithCorners

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -103,7 +103,16 @@ lemma _root_.range_mem_nhds_isInteriorPoint {x : M} (h : I.IsInteriorPoint x) :
   rw [mem_nhds_iff]
   exact ⟨interior (range I), interior_subset, isOpen_interior, h⟩
 
-section boundaryless
+class _root_.BoundarylessManifold {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+    {H : Type*} [TopologicalSpace H] (I : ModelWithCorners 𝕜 E H)
+    (M : Type*) [TopologicalSpace M] [ChartedSpace H M] : Prop where
+  isInteriorPoint' : ∀ x : M, IsInteriorPoint I x
+
+lemma _root_.BoundarylessManifold.isInteriorPoint [BoundarylessManifold I M] {x : M} :
+    IsInteriorPoint I x := _root_.BoundarylessManifold.isInteriorPoint' x
+
+section Boundaryless
 variable [I.Boundaryless]
 
 /-- If `I` is boundaryless, every point of `M` is an interior point. -/
@@ -123,5 +132,5 @@ lemma interior_eq_univ : I.interior M = univ := by
 lemma Boundaryless.boundary_eq_empty : I.boundary M = ∅ := by
   rw [I.boundary_eq_complement_interior, I.interior_eq_univ, compl_empty_iff]
 
-end boundaryless
+end Boundaryless
 end ModelWithCorners

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -103,6 +103,40 @@ lemma _root_.range_mem_nhds_isInteriorPoint {x : M} (h : I.IsInteriorPoint x) :
   rw [mem_nhds_iff]
   exact ⟨interior (range I), interior_subset, isOpen_interior, h⟩
 
+@[reducible] def toPartialHomeomorph_partialEquiv (x : M) : PartialEquiv M E :=
+  ((extChartAt I x).symm.restr (interior (range I))).symm
+
+lemma toPartialHomeomorph_invFun {x : M} :
+    (I.toPartialHomeomorph_partialEquiv x).invFun =
+      (extChartAt I x).symm.restr (interior (range I)) := rfl
+
+lemma toPartialHomeomorph_source {x : M} :
+    (I.toPartialHomeomorph_partialEquiv x).source =
+      (extChartAt I x).source ∩ (extChartAt I x) ⁻¹' interior (range I) := rfl
+
+lemma toPartialHomeomorph_target {x : M} :
+    (I.toPartialHomeomorph_partialEquiv x).target =
+      (extChartAt I x).target ∩ interior (range I) := rfl
+
+/-- Every interior point defines a partial homeomorphism between the manifold and the model vector
+  space. -/
+@[reducible] def toPartialHomeomorph (x : M) : PartialHomeomorph M E where
+  __ := I.toPartialHomeomorph_partialEquiv x
+  open_source := (continuousOn_open_iff (isOpen_extChartAt_source ..)).mp
+    (continuousOn_extChartAt I x) _ isOpen_interior
+  open_target := by
+    rw [toPartialHomeomorph_target, extChartAt_target, inter_assoc,
+      inter_eq_self_of_subset_right interior_subset, inter_comm]
+    exact isOpen_interior.inter <| I.continuous_symm.isOpen_preimage _ <|
+      PartialHomeomorph.open_target _
+  continuousOn_toFun := (continuousOn_extChartAt I x).congr_mono
+    (fun _ _ ↦ rfl) (inter_subset_left ..)
+  continuousOn_invFun := (continuousOn_extChartAt_symm I x).congr_mono
+    (fun _ _ ↦ rfl) (inter_subset_left ..)
+
+lemma mem_toPartialHomeomorph_source {x : M} (h : I.IsInteriorPoint x) :
+    x ∈ (I.toPartialHomeomorph x).source := ⟨mem_extChartAt_source .., h⟩
+
 /-- Type class for manifold without boundary. This differs from `ModelWithCorners.Boundaryless`,
   which states that the `ModelWithCorners` maps to the whole model vector space. -/
 class _root_.BoundarylessManifold {𝕜 : Type*} [NontriviallyNormedField 𝕜]
@@ -140,8 +174,6 @@ lemma interior_eq_univ : I.interior M = univ := by
 /-- Boundaryless manifolds have empty boundary. -/
 lemma Boundaryless.boundary_eq_empty : I.boundary M = ∅ := by
   rw [I.boundary_eq_complement_interior, I.interior_eq_univ, compl_empty_iff]
-
-def ModelWithCorners.toPartialHomeomorph : PartialHomeomorph M E := sorry
 
 end BoundarylessManifold
 end ModelWithCorners

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -103,40 +103,6 @@ lemma _root_.range_mem_nhds_isInteriorPoint {x : M} (h : I.IsInteriorPoint x) :
   rw [mem_nhds_iff]
   exact ⟨interior (range I), interior_subset, isOpen_interior, h⟩
 
-@[reducible] def toPartialHomeomorph_partialEquiv (x : M) : PartialEquiv M E :=
-  ((extChartAt I x).symm.restr (interior (range I))).symm
-
-lemma toPartialHomeomorph_invFun {x : M} :
-    (I.toPartialHomeomorph_partialEquiv x).invFun =
-      (extChartAt I x).symm.restr (interior (range I)) := rfl
-
-lemma toPartialHomeomorph_source {x : M} :
-    (I.toPartialHomeomorph_partialEquiv x).source =
-      (extChartAt I x).source ∩ (extChartAt I x) ⁻¹' interior (range I) := rfl
-
-lemma toPartialHomeomorph_target {x : M} :
-    (I.toPartialHomeomorph_partialEquiv x).target =
-      (extChartAt I x).target ∩ interior (range I) := rfl
-
-/-- Every interior point defines a partial homeomorphism between the manifold and the model vector
-  space. -/
-@[reducible] def toPartialHomeomorph (x : M) : PartialHomeomorph M E where
-  __ := I.toPartialHomeomorph_partialEquiv x
-  open_source := (continuousOn_open_iff (isOpen_extChartAt_source ..)).mp
-    (continuousOn_extChartAt I x) _ isOpen_interior
-  open_target := by
-    rw [toPartialHomeomorph_target, extChartAt_target, inter_assoc,
-      inter_eq_self_of_subset_right interior_subset, inter_comm]
-    exact isOpen_interior.inter <| I.continuous_symm.isOpen_preimage _ <|
-      PartialHomeomorph.open_target _
-  continuousOn_toFun := (continuousOn_extChartAt I x).congr_mono
-    (fun _ _ ↦ rfl) (inter_subset_left ..)
-  continuousOn_invFun := (continuousOn_extChartAt_symm I x).congr_mono
-    (fun _ _ ↦ rfl) (inter_subset_left ..)
-
-lemma mem_toPartialHomeomorph_source {x : M} (h : I.IsInteriorPoint x) :
-    x ∈ (I.toPartialHomeomorph x).source := ⟨mem_extChartAt_source .., h⟩
-
 /-- Type class for manifold without boundary. This differs from `ModelWithCorners.Boundaryless`,
   which states that the `ModelWithCorners` maps to the whole model vector space. -/
 class _root_.BoundarylessManifold {𝕜 : Type*} [NontriviallyNormedField 𝕜]

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -478,7 +478,9 @@ end ModelWithCornersProd
 
 section Boundaryless
 
-/-- Property ensuring that the model with corners `I` defines manifolds without boundary. -/
+/-- Property ensuring that the model with corners `I` defines manifolds without boundary. This
+  differs from the more general `BoundarylessManifold`, which requires every point on the manifold
+  to be an interior point.  -/
 class ModelWithCorners.Boundaryless {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*}
     [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
     (I : ModelWithCorners 𝕜 E H) : Prop where

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -476,49 +476,6 @@ theorem ModelWithCorners.range_prod : range (I.prod J) = range I ×ˢ range J :=
 
 end ModelWithCornersProd
 
-section Boundaryless
-
-/-- Property ensuring that the model with corners `I` defines manifolds without boundary. -/
-class ModelWithCorners.Boundaryless {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*}
-    [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
-    (I : ModelWithCorners 𝕜 E H) : Prop where
-  range_eq_univ : range I = univ
-#align model_with_corners.boundaryless ModelWithCorners.Boundaryless
-
-theorem ModelWithCorners.range_eq_univ {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*}
-    [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
-    (I : ModelWithCorners 𝕜 E H) [I.Boundaryless] :
-    range I = univ := ModelWithCorners.Boundaryless.range_eq_univ
-
-/-- If `I` is a `ModelWithCorners.Boundaryless` model, then it is a homeomorphism. -/
-@[simps (config := {simpRhs := true})]
-def ModelWithCorners.toHomeomorph {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*}
-    [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
-    (I : ModelWithCorners 𝕜 E H) [I.Boundaryless] : H ≃ₜ E where
-  __ := I
-  left_inv := I.left_inv
-  right_inv _ := I.right_inv <| I.range_eq_univ.symm ▸ mem_univ _
-
-/-- The trivial model with corners has no boundary -/
-instance modelWithCornersSelf_boundaryless (𝕜 : Type*) [NontriviallyNormedField 𝕜] (E : Type*)
-    [NormedAddCommGroup E] [NormedSpace 𝕜 E] : (modelWithCornersSelf 𝕜 E).Boundaryless :=
-  ⟨by simp⟩
-#align model_with_corners_self_boundaryless modelWithCornersSelf_boundaryless
-
-/-- If two model with corners are boundaryless, their product also is -/
-instance ModelWithCorners.range_eq_univ_prod {𝕜 : Type u} [NontriviallyNormedField 𝕜] {E : Type v}
-    [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type w} [TopologicalSpace H]
-    (I : ModelWithCorners 𝕜 E H) [I.Boundaryless] {E' : Type v'} [NormedAddCommGroup E']
-    [NormedSpace 𝕜 E'] {H' : Type w'} [TopologicalSpace H'] (I' : ModelWithCorners 𝕜 E' H')
-    [I'.Boundaryless] : (I.prod I').Boundaryless := by
-  constructor
-  dsimp [ModelWithCorners.prod, ModelProd]
-  rw [← prod_range_range_eq, ModelWithCorners.Boundaryless.range_eq_univ,
-    ModelWithCorners.Boundaryless.range_eq_univ, univ_prod_univ]
-#align model_with_corners.range_eq_univ_prod ModelWithCorners.range_eq_univ_prod
-
-end Boundaryless
-
 section contDiffGroupoid
 
 /-! ### Smooth functions on models with corners -/
@@ -788,24 +745,6 @@ instance : ClosedUnderRestriction (analyticGroupoid I) :=
       apply (analyticGroupoid I).eq_on_source' _ _ _ hes
       exact ofSet_mem_analyticGroupoid I hs)
 
-/-- The analytic groupoid on a boundaryless charted space modeled on a complete vector space
-consists of the partial homeomorphisms which are analytic and have analytic inverse. -/
-theorem mem_analyticGroupoid_of_boundaryless [CompleteSpace E] [I.Boundaryless]
-    (e : PartialHomeomorph H H) :
-    e ∈ analyticGroupoid I ↔ AnalyticOn 𝕜 (I ∘ e ∘ I.symm) (I '' e.source) ∧
-    AnalyticOn 𝕜 (I ∘ e.symm ∘ I.symm) (I '' e.target) := by
-  apply Iff.intro
-  · intro he
-    have := mem_groupoid_of_pregroupoid.mp he.right
-    simp only [I.image_eq, I.range_eq_univ, interior_univ, subset_univ, and_true] at this ⊢
-    exact this
-  · intro he
-    apply And.intro
-    all_goals apply mem_groupoid_of_pregroupoid.mpr; simp only [I.image_eq, I.range_eq_univ,
-      interior_univ, subset_univ, and_true] at he ⊢
-    · exact ⟨he.left.contDiffOn, he.right.contDiffOn⟩
-    · exact he
-
 end analyticGroupoid
 
 section SmoothManifoldWithCorners
@@ -976,10 +915,6 @@ theorem isOpen_extend_source : IsOpen (f.extend I).source := by
 theorem extend_target : (f.extend I).target = I.symm ⁻¹' f.target ∩ range I := by
   simp_rw [extend, PartialEquiv.trans_target, I.target_eq, I.toPartialEquiv_coe_symm, inter_comm]
 #align local_homeomorph.extend_target PartialHomeomorph.extend_target
-
-lemma isOpen_extend_target [I.Boundaryless] : IsOpen (f.extend I).target := by
-  rw [extend_target, I.range_eq_univ, inter_univ]
-  exact I.continuous_symm.isOpen_preimage _ f.open_target
 
 theorem mapsTo_extend (hs : s ⊆ f.source) :
     MapsTo (f.extend I) s ((f.extend I).symm ⁻¹' s ∩ range I) := by

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -476,6 +476,49 @@ theorem ModelWithCorners.range_prod : range (I.prod J) = range I ×ˢ range J :=
 
 end ModelWithCornersProd
 
+section Boundaryless
+
+/-- Property ensuring that the model with corners `I` defines manifolds without boundary. -/
+class ModelWithCorners.Boundaryless {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*}
+    [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
+    (I : ModelWithCorners 𝕜 E H) : Prop where
+  range_eq_univ : range I = univ
+#align model_with_corners.boundaryless ModelWithCorners.Boundaryless
+
+theorem ModelWithCorners.range_eq_univ {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*}
+    [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
+    (I : ModelWithCorners 𝕜 E H) [I.Boundaryless] :
+    range I = univ := ModelWithCorners.Boundaryless.range_eq_univ
+
+/-- If `I` is a `ModelWithCorners.Boundaryless` model, then it is a homeomorphism. -/
+@[simps (config := {simpRhs := true})]
+def ModelWithCorners.toHomeomorph {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*}
+    [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
+    (I : ModelWithCorners 𝕜 E H) [I.Boundaryless] : H ≃ₜ E where
+  __ := I
+  left_inv := I.left_inv
+  right_inv _ := I.right_inv <| I.range_eq_univ.symm ▸ mem_univ _
+
+/-- The trivial model with corners has no boundary -/
+instance modelWithCornersSelf_boundaryless (𝕜 : Type*) [NontriviallyNormedField 𝕜] (E : Type*)
+    [NormedAddCommGroup E] [NormedSpace 𝕜 E] : (modelWithCornersSelf 𝕜 E).Boundaryless :=
+  ⟨by simp⟩
+#align model_with_corners_self_boundaryless modelWithCornersSelf_boundaryless
+
+/-- If two model with corners are boundaryless, their product also is -/
+instance ModelWithCorners.range_eq_univ_prod {𝕜 : Type u} [NontriviallyNormedField 𝕜] {E : Type v}
+    [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type w} [TopologicalSpace H]
+    (I : ModelWithCorners 𝕜 E H) [I.Boundaryless] {E' : Type v'} [NormedAddCommGroup E']
+    [NormedSpace 𝕜 E'] {H' : Type w'} [TopologicalSpace H'] (I' : ModelWithCorners 𝕜 E' H')
+    [I'.Boundaryless] : (I.prod I').Boundaryless := by
+  constructor
+  dsimp [ModelWithCorners.prod, ModelProd]
+  rw [← prod_range_range_eq, ModelWithCorners.Boundaryless.range_eq_univ,
+    ModelWithCorners.Boundaryless.range_eq_univ, univ_prod_univ]
+#align model_with_corners.range_eq_univ_prod ModelWithCorners.range_eq_univ_prod
+
+end Boundaryless
+
 section contDiffGroupoid
 
 /-! ### Smooth functions on models with corners -/
@@ -745,6 +788,24 @@ instance : ClosedUnderRestriction (analyticGroupoid I) :=
       apply (analyticGroupoid I).eq_on_source' _ _ _ hes
       exact ofSet_mem_analyticGroupoid I hs)
 
+/-- The analytic groupoid on a boundaryless charted space modeled on a complete vector space
+consists of the partial homeomorphisms which are analytic and have analytic inverse. -/
+theorem mem_analyticGroupoid_of_boundaryless [CompleteSpace E] [I.Boundaryless]
+    (e : PartialHomeomorph H H) :
+    e ∈ analyticGroupoid I ↔ AnalyticOn 𝕜 (I ∘ e ∘ I.symm) (I '' e.source) ∧
+    AnalyticOn 𝕜 (I ∘ e.symm ∘ I.symm) (I '' e.target) := by
+  apply Iff.intro
+  · intro he
+    have := mem_groupoid_of_pregroupoid.mp he.right
+    simp only [I.image_eq, I.range_eq_univ, interior_univ, subset_univ, and_true] at this ⊢
+    exact this
+  · intro he
+    apply And.intro
+    all_goals apply mem_groupoid_of_pregroupoid.mpr; simp only [I.image_eq, I.range_eq_univ,
+      interior_univ, subset_univ, and_true] at he ⊢
+    · exact ⟨he.left.contDiffOn, he.right.contDiffOn⟩
+    · exact he
+
 end analyticGroupoid
 
 section SmoothManifoldWithCorners
@@ -915,6 +976,10 @@ theorem isOpen_extend_source : IsOpen (f.extend I).source := by
 theorem extend_target : (f.extend I).target = I.symm ⁻¹' f.target ∩ range I := by
   simp_rw [extend, PartialEquiv.trans_target, I.target_eq, I.toPartialEquiv_coe_symm, inter_comm]
 #align local_homeomorph.extend_target PartialHomeomorph.extend_target
+
+lemma isOpen_extend_target [I.Boundaryless] : IsOpen (f.extend I).target := by
+  rw [extend_target, I.range_eq_univ, inter_univ]
+  exact I.continuous_symm.isOpen_preimage _ f.open_target
 
 theorem mapsTo_extend (hs : s ⊆ f.source) :
     MapsTo (f.extend I) s ((f.extend I).symm ⁻¹' s ∩ range I) := by


### PR DESCRIPTION
This is a more general notion of boundaryless manifold than `ModelWithCorners.Boundaryless`, which requires the `ModelWithCorners` to map to the whole model vector space.

To justify this new type class, consider the interior of a manifold with non-empty boundary. It inherits a manifold structure via its embedding, and it would be convenient to use the same `ModelWithCorners` for the interior as for the whole space. Even though the interior is boundaryless, its inherited `ModelWithCorners` doesn't satisfy `ModelWithCorners.Boundaryless`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
