### PR TITLE
[Merged by Bors] - feat: Extract a computable `Finsupp.extendDomain` from `restrictSupportEquiv`

### DIFF
--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1693,6 +1693,7 @@ end
 
 section
 variable {M : Type*} [Zero M] {P : α → Prop} [DecidablePred P]
+
 /-- Extend the domain of a `Finsupp` by using `0` where `P x` does not hold. -/
 @[simps]
 def extendDomain (f : Subtype P →₀ M) : α →₀ M where
@@ -1731,6 +1732,18 @@ theorem extendDomain_subtypeDomain (f : α →₀ M) (hf : ∀ a ∈ f.support, 
     rw [if_neg h, eq_comm, ← not_mem_support_iff]
     refine mt ?_ h
     exact @hf _
+
+@[simp]
+theorem extendDomain_single (a : Subtype P) (m : M) :
+    (single a m).extendDomain = single a.val m := by
+  ext a'
+  dsimp only [extendDomain_toFun]
+  obtain rfl | ha := eq_or_ne a.val a'
+  · simp_rw [single_eq_same, dif_pos a.prop]
+  · simp_rw [single_eq_of_ne ha, dite_eq_right_iff]
+    intro h
+    rw [single_eq_of_ne]
+    simp [Subtype.ext_iff, ha]
 
 end
 

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -1692,16 +1692,15 @@ instance uniqueOfLeft [IsEmpty α] : Unique (α →₀ R) :=
 end
 
 section
-variable {M : Type*} [Zero M]
+variable {M : Type*} [Zero M] {P : α → Prop} [DecidablePred P]
 /-- Extend the domain of a `Finsupp` by using `0` where `P x` does not hold. -/
 @[simps]
-def extendDomain {P : α → Prop} [DecidablePred P] (f : Subtype P →₀ M) :
-    α →₀ M where
+def extendDomain (f : Subtype P →₀ M) : α →₀ M where
   toFun a := if h : P a then f ⟨a, h⟩ else 0
   support := f.support.map (.subtype _)
   mem_support_toFun a := by simp
 
-theorem extendDomain_eq_embDomain_subtype {P : α → Prop} [DecidablePred P] (f : Subtype P →₀ M) :
+theorem extendDomain_eq_embDomain_subtype (f : Subtype P →₀ M) :
     extendDomain f = embDomain (.subtype _) f := by
   ext a
   by_cases h : P a
@@ -1710,7 +1709,7 @@ theorem extendDomain_eq_embDomain_subtype {P : α → Prop} [DecidablePred P] (f
   · rw [embDomain_notin_range, extendDomain_toFun, dif_neg h]
     simp [h]
 
-theorem support_extendDomain_subset {P : α → Prop} [DecidablePred P] (f : Subtype P →₀ M) :
+theorem support_extendDomain_subset (f : Subtype P →₀ M) :
     ↑(f.extendDomain).support ⊆ {x | P x} := by
   intro x
   rw [extendDomain_support, mem_coe, mem_map, Embedding.coe_subtype]
@@ -1718,13 +1717,12 @@ theorem support_extendDomain_subset {P : α → Prop} [DecidablePred P] (f : Sub
   exact x.prop
 
 @[simp]
-theorem subtypeDomain_extendDomain {P : α → Prop} [DecidablePred P] (f : Subtype P →₀ M) :
+theorem subtypeDomain_extendDomain (f : Subtype P →₀ M) :
     subtypeDomain P f.extendDomain = f :=
   Finsupp.ext fun a => dif_pos a.prop
 
 
-theorem extendDomain_subtypeDomain {P : α → Prop} [DecidablePred P] (f : α →₀ M)
-    (hf : ∀ a ∈ f.support, P a) :
+theorem extendDomain_subtypeDomain (f : α →₀ M) (hf : ∀ a ∈ f.support, P a) :
     (subtypeDomain P f).extendDomain = f := by
   ext a
   by_cases h : P a


### PR DESCRIPTION
This PR adds two constructions of finitely supported functions:
* `Finsupp.piecewise`: define a finitely supported function from two functions, according to a decidable predicate
* `Finsupp.extendDomain`: extends by 0 a finitely supported function on a subtype by 0. 
This is a computable version of `embDomain (.subtype _)`, which also has a simpler defeq.
* adjust accordingly the definition of `Finsupp.restrictSupportEquiv`.

This may be used to simplify some parts of #7904.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
