### PR TITLE
[Merged by Bors] - feat(FieldTheory/SeparableClosure): (relative) separable closure

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2082,6 +2082,7 @@ import Mathlib.FieldTheory.PolynomialGaloisGroup
 import Mathlib.FieldTheory.PrimitiveElement
 import Mathlib.FieldTheory.RatFunc
 import Mathlib.FieldTheory.Separable
+import Mathlib.FieldTheory.SeparableClosure
 import Mathlib.FieldTheory.SeparableDegree
 import Mathlib.FieldTheory.SplittingField.Construction
 import Mathlib.FieldTheory.SplittingField.IsSplittingField

--- a/Mathlib/FieldTheory/Adjoin.lean
+++ b/Mathlib/FieldTheory/Adjoin.lean
@@ -102,6 +102,10 @@ instance : CompleteLattice (IntermediateField F E) where
 instance : Inhabited (IntermediateField F E) :=
   ⟨⊤⟩
 
+instance : Unique (IntermediateField F F) :=
+  { inferInstanceAs (Inhabited (IntermediateField F F)) with
+    uniq := fun _ ↦ toSubalgebra_injective <| Subsingleton.elim _ _ }
+
 theorem coe_bot : ↑(⊥ : IntermediateField F E) = Set.range (algebraMap F E) := rfl
 #align intermediate_field.coe_bot IntermediateField.coe_bot
 

--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -184,6 +184,15 @@ theorem algebraMap_surjective_of_isAlgebraic {k K : Type*} [Field k] [Ring K] [I
 
 end IsAlgClosed
 
+/-- If `k` is algebraically closed, `K / k` is a field extension, `L / k` is an intermediate field
+which is algebraic, then `L` is equal to `k`. A corollary of
+`IsAlgClosed.algebraMap_surjective_of_isAlgebraic`. -/
+theorem IntermediateField.eq_bot_of_isAlgClosed_of_isAlgebraic {k K : Type*} [Field k] [Field K]
+    [IsAlgClosed k] [Algebra k K] (L : IntermediateField k K) (hf : Algebra.IsAlgebraic k L) :
+    L = ⊥ := bot_unique fun x hx ↦ by
+  obtain ⟨y, hy⟩ := IsAlgClosed.algebraMap_surjective_of_isAlgebraic hf ⟨x, hx⟩
+  exact ⟨y, congr_arg (algebraMap L K) hy⟩
+
 /-- Typeclass for an extension being an algebraic closure. -/
 class IsAlgClosure (R : Type u) (K : Type v) [CommRing R] [Field K] [Algebra R K]
     [NoZeroSMulDivisors R K] : Prop where

--- a/Mathlib/FieldTheory/IsSepClosed.lean
+++ b/Mathlib/FieldTheory/IsSepClosed.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jz Pan
 -/
 import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
+import Mathlib.FieldTheory.Galois
 
 /-!
 # Separably Closed Field
@@ -194,8 +195,9 @@ namespace IsSepClosure
 instance isSeparable [Algebra k K] [IsSepClosure k K] : IsSeparable k K :=
   IsSepClosure.separable
 
-instance (priority := 100) normal [Algebra k K] [IsSepClosure k K] : Normal k K :=
-  ⟨fun x ↦ (IsSeparable.isIntegral k x).isAlgebraic,
+instance (priority := 100) isGalois [Algebra k K] [IsSepClosure k K] : IsGalois k K where
+  to_isSeparable := IsSepClosure.separable
+  to_normal := ⟨fun x ↦ (IsSeparable.isIntegral k x).isAlgebraic,
     fun x ↦ (IsSepClosure.sep_closed k).splits_codomain _ (IsSeparable.separable k x)⟩
 
 end IsSepClosure

--- a/Mathlib/FieldTheory/IsSepClosed.lean
+++ b/Mathlib/FieldTheory/IsSepClosed.lean
@@ -29,15 +29,17 @@ and prove some of their properties.
 
 separable closure, separably closed
 
+## Related
+
+- `separableClosure`: maximal separable subextension of `K/k`, consisting of all elements of `K`
+  which are separable over `k`.
+
+- `separableClosure.isSepClosure`: if `K` is a separably closed field containing `k`, then the
+  maximal separable subextension of `K/k` is a separable closure of `k`.
+
+- In particular, a separable closure (`SeparableClosure`) exists.
+
 ## TODO
-
-- Maximal separable subextension of `K/k`, consisting of all elements of `K` which are separable
-  over `k`.
-
-- If `K` is a separably closed field containing `k`, then the maximal separable subextension
-  of `K/k` is a separable closure of `k`.
-
-- In particular, a separable closure exists.
 
 - If `k` is a perfect field, then its separable closure coincides with its algebraic closure.
 

--- a/Mathlib/FieldTheory/IsSepClosed.lean
+++ b/Mathlib/FieldTheory/IsSepClosed.lean
@@ -156,7 +156,7 @@ theorem degree_eq_one_of_irreducible [IsSepClosed k] {p : k[X]}
     (hp : Irreducible p) (hsep : p.Separable) : p.degree = 1 :=
   degree_eq_one_of_irreducible_of_splits hp (IsSepClosed.splits_codomain p hsep)
 
-variable {k}
+variable (K)
 
 theorem algebraMap_surjective
     [IsSepClosed k] [Algebra k K] [IsSeparable k K] :
@@ -172,6 +172,13 @@ theorem algebraMap_surjective
   exact (RingHom.map_neg (algebraMap k K) ((minpoly k x).coeff 0)).symm ▸ this.symm
 
 end IsSepClosed
+
+/-- If `k` is separably closed, `K / k` is a field extension, `L / k` is an intermediate field
+which is separable, then `L` is equal to `k`. A corollary of `IsSepClosed.algebraMap_surjective`. -/
+theorem IntermediateField.eq_bot_of_isSepClosed_of_isSeparable [IsSepClosed k] [Algebra k K]
+    (L : IntermediateField k K) [IsSeparable k L] : L = ⊥ := bot_unique fun x hx ↦ by
+  obtain ⟨y, hy⟩ := IsSepClosed.algebraMap_surjective k L ⟨x, hx⟩
+  exact ⟨y, congr_arg (algebraMap L K) hy⟩
 
 variable (k) (K)
 

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -255,7 +255,9 @@ def insepDegree := Module.rank (separableClosure F E) E
 /-- The (finite) inseparable degree for a general field extension `E / F` is defined
 to be the degree of `E / separableClosure F E` as a natural number. It is defined to be zero
 if such field extension is infinite. -/
-def finInsepDegree : ℕ := Cardinal.toNat (insepDegree F E)
+def finInsepDegree : ℕ := finrank (separableClosure F E) E
+
+theorem finInsepDegree_def' : finInsepDegree F E = Cardinal.toNat (insepDegree F E) := rfl
 
 instance instNeZeroSepDegree : NeZero (sepDegree F E) := ⟨rank_pos.ne'⟩
 
@@ -308,7 +310,7 @@ theorem insepDegree_self : insepDegree F F = 1 := by
 
 @[simp]
 theorem finInsepDegree_self : finInsepDegree F F = 1 := by
-  simp only [finInsepDegree, insepDegree_self, Cardinal.one_toNat]
+  rw [finInsepDegree_def', insepDegree_self, Cardinal.one_toNat]
 
 end Field
 
@@ -357,7 +359,7 @@ theorem insepDegree_top : insepDegree F (⊤ : IntermediateField E K) = insepDeg
 
 @[simp]
 theorem finInsepDegree_top : finInsepDegree F (⊤ : IntermediateField E K) = finInsepDegree F K := by
-  simp only [finInsepDegree, insepDegree_top]
+  rw [finInsepDegree_def', insepDegree_top, ← finInsepDegree_def']
 
 variable (K : Type v) [Field K] [Algebra F K] [Algebra E K] [IsScalarTower F E K]
 

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -77,12 +77,12 @@ of `E / F`, is defined to be the intermediate field of `E / F` consisting of all
 elements. The previous results prove that these elements are closed under field operations. -/
 def separableClosure : IntermediateField F E where
   carrier := {x | (minpoly F x).Separable}
-  mul_mem' := separable_mul F E
-  one_mem' := (map_one (algebraMap F E)) ▸ separable_algebraMap F E 1
-  add_mem' := separable_add F E
-  zero_mem' := (map_zero (algebraMap F E)) ▸ separable_algebraMap F E 0
-  algebraMap_mem' := separable_algebraMap F E
-  inv_mem' := separable_inv F E
+  mul_mem' := separable_mul
+  one_mem' := map_one (algebraMap F E) ▸ separable_algebraMap E 1
+  add_mem' := separable_add
+  zero_mem' := map_zero (algebraMap F E) ▸ separable_algebraMap E 0
+  algebraMap_mem' := separable_algebraMap E
+  inv_mem' := separable_inv
 
 /-- An element is contained in the (relative) separable closure of `E / F` if and only if
 it is a separable element. -/

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -1,0 +1,379 @@
+/-
+Copyright (c) 2023 Jz Pan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jz Pan
+-/
+import Mathlib.FieldTheory.SeparableDegree
+import Mathlib.FieldTheory.IsSepClosed
+
+/-!
+
+# Separable closure
+
+This file contains basics about the (relative) separable closure of a field extension.
+
+## Main definitions
+
+- `separableClosure`: the (relative) separable closure of `E / F`, or called maximal separable
+  subextension of `E / F`, is defined to be the intermediate field of `E / F` consisting of all
+  separable elements.
+
+- `Field.sepDegree F E`: the (infinite) separable degree $[E:F]_s$ of an algebraic extension
+  `E / F` of fields, defined to be the degree of `separableClosure F E / F`. Later we will show
+  that (`Field.finSepDegree_eq`, not in this file), if `Field.Emb F E` is finite, then this
+  coincides with `Field.finSepDegree F E`.
+
+- `Field.insepDegree F E`: the (infinite) inseparable degree $[E:F]_i$ of an algebraic extension
+  `E / F` of fields, defined to be the degree of `E / separableClosure F E`.
+
+- `Field.finInsepDegree F E`: the (finite) inseparable degree $[E:F]_i$ of an algebraic extension
+  `E / F` of fields, defined to be the degree of `E / separableClosure F E` as a natural number.
+  It is zero if such field extension is not finite.
+
+## Main results
+
+- `le_separableClosure_iff`: an intermediate field of `E / F` is contained in the (relative)
+  separable closure of `E / F` if and only if it is separable over `F`.
+
+- `separableClosure.normalClosure_eq_self`: the normal closure of the (relative) separable
+  closure of `E / F` is equal to itself.
+
+- `separableClosure.normal`: the (relative) separable closure of a normal extension is normal.
+
+- `separableClosure.isSepClosure`: the (relative) separable closure of a separably closed extension
+  is a separable closure of the base field.
+
+- `IntermediateField.isSeparable_adjoin_iff_separable`: `F(S) / F` is a separable extension if and
+  only if all elements of `S` are separable elements.
+
+- `separableClosure.eq_top_iff`: the (relative) separable closure of `E / F` is equal to `E`
+  if and only if `E / F` is separable.
+
+## Tags
+
+separable degree, degree, separable closure
+
+-/
+
+open scoped Classical Polynomial
+
+open FiniteDimensional Polynomial IntermediateField Field
+
+noncomputable section
+
+universe u v w
+
+variable (F : Type u) (E : Type v) [Field F] [Field E] [Algebra F E]
+
+variable (K : Type w) [Field K] [Algebra F K]
+
+section separableClosure
+
+/-- The (relative) separable closure of `E / F`, or called maximal separable subextension
+of `E / F`, is defined to be the intermediate field of `E / F` consisting of all separable
+elements. The previous results prove that these elements are closed under field operations. -/
+def separableClosure : IntermediateField F E where
+  carrier := {x | (minpoly F x).Separable}
+  mul_mem' := separable_mul F E
+  one_mem' := (map_one (algebraMap F E)) ▸ separable_algebraMap F E 1
+  add_mem' := separable_add F E
+  zero_mem' := (map_zero (algebraMap F E)) ▸ separable_algebraMap F E 0
+  algebraMap_mem' := separable_algebraMap F E
+  inv_mem' := separable_inv F E
+
+/-- An element is contained in the (relative) separable closure of `E / F` if and only if
+it is a separable element. -/
+theorem mem_separableClosure_iff {x : E} :
+    x ∈ separableClosure F E ↔ (minpoly F x).Separable := Iff.rfl
+
+/-- If `i` is an `F`-algebra homomorphism from `E` to `K`, then `i x` is contained in
+`separableClosure F K` if and only if `x` is contained in `separableClosure F E`. -/
+theorem map_mem_separableClosure_iff (i : E →ₐ[F] K) {x : E} :
+    i x ∈ separableClosure F K ↔ x ∈ separableClosure F E := by
+  simp_rw [mem_separableClosure_iff, minpoly.algHom_eq i i.injective]
+
+/-- If `i` is an `F`-algebra homomorphism from `E` to `K`, then `separableClosure F E` is equal to
+the preimage of `separableClosure F K` under the map `i`. -/
+theorem separableClosure.eq_comap_of_algHom (i : E →ₐ[F] K) :
+    separableClosure F E = (separableClosure F K).comap i := by
+  ext x
+  exact (map_mem_separableClosure_iff F E K i).symm
+
+/-- If `i` is an `F`-algebra homomorphism from `E` to `K`, then `separableClosure F K` contains
+the image of `separableClosure F E` under the map `i`. -/
+theorem separableClosure.map_le_of_algHom (i : E →ₐ[F] K) :
+    (separableClosure F E).map i ≤ separableClosure F K := fun x hx ↦ by
+  change x ∈ (_ : Set K) at hx
+  rw [coe_map, Set.mem_image] at hx
+  obtain ⟨y, hy, rfl⟩ := hx
+  exact (map_mem_separableClosure_iff F E K i).2 hy
+
+/-- If `K / E / F` is a field extension tower, such that `K / E` has no non-trivial separable
+subextensions (when `K / E` is algebraic, this means that it is purely inseparable),
+then `separableClosure F K` is equal to `separableClosure F E`. -/
+theorem separableClosure.eq_map_of_separableClosure_eq_bot [Algebra E K] [IsScalarTower F E K]
+    (h : separableClosure E K = ⊥) :
+    separableClosure F K = (separableClosure F E).map (IsScalarTower.toAlgHom F E K) := by
+  refine le_antisymm (fun x hx ↦ ?_) (map_le_of_algHom F E K _)
+  rw [mem_separableClosure_iff] at hx
+  obtain ⟨y, hy⟩ := mem_bot.1 <| h ▸ (mem_separableClosure_iff E K).2 (hx.map_minpoly E)
+  rw [← hy, minpoly.algebraMap_eq (algebraMap E K).injective, ← mem_separableClosure_iff] at hx
+  exact ⟨y, hx, hy⟩
+
+/-- If `i` is an `F`-algebra isomorphism of `E` and `K`, then `separableClosure F K` is equal to
+the image of `separableClosure F E` under the map `i`. -/
+theorem separableClosure.eq_map_of_algEquiv (i : E ≃ₐ[F] K) :
+    separableClosure F K = (separableClosure F E).map i.toAlgHom := by
+  refine le_antisymm (fun x hx ↦ ?_) (map_le_of_algHom F E K i.toAlgHom)
+  change x ∈ (_ : Set K)
+  rw [coe_map, Set.mem_image]
+  exact ⟨i.symm.toAlgHom x,
+    (map_mem_separableClosure_iff F K E i.symm.toAlgHom).2 hx, i.apply_symm_apply x⟩
+
+/-- If `E` and `K` are isomorphic as `F`-algebras, then `separableClosure F E` and
+`separableClosure F K` are also isomorphic as `F`-algebras. -/
+def separableClosure.algEquivOfAlgEquiv (i : E ≃ₐ[F] K) :
+    separableClosure F E ≃ₐ[F] separableClosure F K :=
+  ((separableClosure F E).intermediateFieldMap i).trans
+    (equivOfEq (eq_map_of_algEquiv F E K i).symm)
+
+/-- The (relative) separable closure of `E / F` is algebraic over `F`. -/
+theorem separableClosure.isAlgebraic : Algebra.IsAlgebraic F (separableClosure F E) :=
+  fun x ↦ isAlgebraic_iff.2 x.2.isIntegral.isAlgebraic
+
+/-- The (relative) separable closure of `E / F` is separable over `F`. -/
+instance separableClosure.isSeparable : IsSeparable F (separableClosure F E) :=
+  ⟨fun x ↦ by simpa only [minpoly_eq] using x.2⟩
+
+/-- An intermediate field of `E / F` is contained in the (relative) separable closure of `E / F`
+if all of its elements are separable over `F`. -/
+theorem le_separableClosure' {L : IntermediateField F E} (hs : ∀ x : L, (minpoly F x).Separable) :
+    L ≤ separableClosure F E := fun x h ↦ by simpa only [minpoly_eq] using hs ⟨x, h⟩
+
+/-- An intermediate field of `E / F` is contained in the (relative) separable closure of `E / F`
+if it is separable over `F`. -/
+theorem le_separableClosure (L : IntermediateField F E) [IsSeparable F L] :
+    L ≤ separableClosure F E := le_separableClosure' F E (IsSeparable.separable F)
+
+/-- An intermediate field of `E / F` is contained in the (relative) separable closure of `E / F`
+if and only if it is separable over `F`. -/
+theorem le_separableClosure_iff (L : IntermediateField F E) :
+    L ≤ separableClosure F E ↔ IsSeparable F L :=
+  ⟨fun h ↦ (isSeparable_def _ _).2 fun x ↦ by simpa only [minpoly_eq] using h x.2,
+    fun _ ↦ le_separableClosure _ _ _⟩
+
+/-- The (relative) separable closure of the (relative) separable closure of `E / F` is equal to
+itself. -/
+theorem separableClosure.separableClosure_eq_bot :
+    separableClosure (separableClosure F E) E = ⊥ := bot_unique fun x hx ↦ by
+  rw [mem_separableClosure_iff, ← isSeparable_adjoin_simple_iff_separable] at hx
+  set L := separableClosure F E
+  haveI : IsSeparable F (L⟮x⟯.restrictScalars F) := IsSeparable.trans F L L⟮x⟯
+  exact mem_bot.2 ⟨⟨x, (mem_separableClosure_iff F E).2 (separable_of_mem_isSeparable F E <|
+    show x ∈ L⟮x⟯.restrictScalars F from mem_adjoin_simple_self L x)⟩, rfl⟩
+
+/-- The normal closure of the (relative) separable closure of `E / F` is equal to itself. -/
+theorem separableClosure.normalClosure_eq_self :
+    normalClosure F (separableClosure F E) E = separableClosure F E := by
+  apply le_antisymm (normalClosure_le_iff.2 fun i ↦ ?_) (le_normalClosure _)
+  let i' : (separableClosure F E) ≃ₐ[F] i.fieldRange := AlgEquiv.ofInjectiveField i
+  haveI := i'.isSeparable
+  exact le_separableClosure F E _
+
+/-- If `E` is normal over `F`, then the (relative) separable closure of `E / F` is also normal
+over `F`. -/
+instance separableClosure.normal [Normal F E] : Normal F (separableClosure F E) := by
+  rw [← separableClosure.normalClosure_eq_self]
+  exact normalClosure.normal F _ E
+
+/-- If `E` is separably closed, then the (relative) separable closure of `E / F` is a
+separable closure of `F`. -/
+instance separableClosure.isSepClosure [IsSepClosed E] : IsSepClosure F (separableClosure F E) := by
+  refine ⟨IsSepClosed.of_exists_root _ fun p _ hirr hsep ↦ ?_, isSeparable F E⟩
+  obtain ⟨x, hx⟩ := IsSepClosed.exists_aeval_eq_zero E p (degree_pos_of_irreducible hirr).ne' hsep
+  haveI := (isSeparable_adjoin_simple_iff_separable _ E).2 <| hsep.of_dvd <| minpoly.dvd _ x hx
+  let L := separableClosure F E
+  haveI : IsSeparable F (restrictScalars F L⟮x⟯) := IsSeparable.trans F L L⟮x⟯
+  have : x ∈ restrictScalars F L⟮x⟯ := mem_adjoin_simple_self _ x
+  use ⟨x, le_separableClosure F E (restrictScalars F L⟮x⟯) this⟩
+  apply_fun algebraMap L E using (algebraMap L E).injective
+  rwa [map_zero, ← aeval_algebraMap_apply_eq_algebraMap_eval]
+
+/-- `F(S) / F` is a separable extension if and only if all elements of `S` are
+separable elements. -/
+theorem IntermediateField.isSeparable_adjoin_iff_separable {S : Set E} :
+    IsSeparable F (adjoin F S) ↔ ∀ x ∈ S, (minpoly F x).Separable := by
+  simp only [← le_separableClosure_iff, ← mem_separableClosure_iff]
+  exact ⟨fun h x hx ↦ (adjoin.mono F _ _ <| Set.singleton_subset_iff.2 hx).trans h <|
+    mem_adjoin_simple_self F x, adjoin_le_iff.2⟩
+
+/-- The (relative) separable closure of `E / F` is equal to `E` if and only if `E / F` is
+separable. -/
+theorem separableClosure.eq_top_iff : separableClosure F E = ⊤ ↔ IsSeparable F E :=
+  ⟨fun h ↦ (isSeparable_def _ _).2 fun _ ↦ (mem_separableClosure_iff F E).1 (h ▸ mem_top),
+    fun h ↦ top_unique fun x _ ↦ (mem_separableClosure_iff F E).2 (((isSeparable_def _ _).1 h) x)⟩
+
+/-- If `K / E / F` is a field extension tower, then `separableClosure F K` is contained in
+`separableClosure E K`. -/
+theorem separableClosure.le_restrictScalars [Algebra E K] [IsScalarTower F E K] :
+    separableClosure F K ≤ (separableClosure E K).restrictScalars F := fun x hx ↦ by
+  simp only [mem_restrictScalars, mem_separableClosure_iff] at hx ⊢
+  exact hx.map_minpoly E
+
+/-- If `K / E / F` is a field extension tower, such that `E / F` is separable, then
+`separableClosure F K` is equal to `separableClosure E K`. -/
+theorem separableClosure.eq_restrictScalars_of_isSeparable [Algebra E K] [IsScalarTower F E K]
+    [IsSeparable F E] : separableClosure F K = (separableClosure E K).restrictScalars F := by
+  refine le_antisymm (separableClosure.le_restrictScalars F E K) fun x hx ↦ ?_
+  rw [mem_restrictScalars, mem_separableClosure_iff,
+    ← isSeparable_adjoin_simple_iff_separable] at hx
+  haveI : IsSeparable F (E⟮x⟯.restrictScalars F) := IsSeparable.trans F E E⟮x⟯
+  have h : x ∈ E⟮x⟯.restrictScalars F := mem_adjoin_simple_self E x
+  exact (mem_separableClosure_iff F _).2 <| separable_of_mem_isSeparable F _ h
+
+/-- If `K / E / F` is a field extension tower, then `E` adjoin `separableClosure F K` is contained
+in `separableClosure E K`. -/
+theorem separableClosure.adjoin_le [Algebra E K] [IsScalarTower F E K] :
+    adjoin E (separableClosure F K) ≤ separableClosure E K :=
+  adjoin_le_iff.2 <| le_restrictScalars F E K
+
+/-- A compositum of two separable extensions is separable. -/
+instance IntermediateField.isSeparable_sup (L1 L2 : IntermediateField F E)
+    [h1 : IsSeparable F L1] [h2 : IsSeparable F L2] :
+    IsSeparable F (L1 ⊔ L2 : IntermediateField F E) := by
+  rw [← le_separableClosure_iff] at h1 h2 ⊢
+  exact sup_le h1 h2
+
+/-- A compositum of separable extensions is separable. -/
+instance IntermediateField.isSeparable_iSup {ι : Type*} {t : ι → IntermediateField F E}
+    [h : ∀ i, IsSeparable F (t i)] : IsSeparable F (⨆ i, t i : IntermediateField F E) := by
+  simp_rw [← le_separableClosure_iff] at h ⊢
+  exact iSup_le h
+
+end separableClosure
+
+namespace Field
+
+/-- The (infinite) separable degree for a general field extension `E / F` is defined
+to be the degree of `(separableClosure F E) / F`. -/
+def sepDegree := Module.rank F (separableClosure F E)
+
+/-- The (infinite) inseparable degree for a general field extension `E / F` is defined
+to be the degree of `E / (separableClosure F E)`. -/
+def insepDegree := Module.rank (separableClosure F E) E
+
+/-- The (finite) inseparable degree for a general field extension `E / F` is defined
+to be the degree of `E / (separableClosure F E)` as a natural number. It is defined to be zero
+if such field extension is infinite. -/
+def finInsepDegree : ℕ := Cardinal.toNat (insepDegree F E)
+
+instance instNeZeroSepDegree : NeZero (sepDegree F E) := ⟨rank_pos.ne'⟩
+
+instance instNeZeroInsepDegree : NeZero (insepDegree F E) := ⟨rank_pos.ne'⟩
+
+instance instNeZeroFinInsepDegree [FiniteDimensional F E] :
+    NeZero (finInsepDegree F E) := ⟨finrank_pos.ne'⟩
+
+/-- If `E` and `K` are isomorphic as `F`-algebras, then they have the same (infinite)
+separable degree over `F`. -/
+theorem sepDegree_eq_of_equiv (i : E ≃ₐ[F] K) :
+    Cardinal.lift.{w} (sepDegree F E) = Cardinal.lift.{v} (sepDegree F K) :=
+  (separableClosure.algEquivOfAlgEquiv F E K i).toLinearEquiv.lift_rank_eq
+
+/-- The (infinite) separable degree multiply by the (infinite) inseparable degree is equal
+to the (infinite) field extension degree. -/
+theorem sepDegree_mul_insepDegree : sepDegree F E * insepDegree F E = Module.rank F E :=
+  rank_mul_rank F (separableClosure F E) E
+
+/-- If `E` and `K` are isomorphic as `F`-algebras, then they have the same (infinite)
+inseparable degree over `F`. -/
+theorem insepDegree_eq_of_equiv (i : E ≃ₐ[F] K) :
+    Cardinal.lift.{w} (insepDegree F E) = Cardinal.lift.{v} (insepDegree F K) :=
+  Algebra.lift_rank_eq_of_equiv_equiv (separableClosure.algEquivOfAlgEquiv F E K i).toRingEquiv
+    i.toRingEquiv (by rfl)
+
+/-- If `E` and `K` are isomorphic as `F`-algebras, then they have the same (finite)
+inseparable degree over `F`. -/
+theorem finInsepDegree_eq_of_equiv (i : E ≃ₐ[F] K) :
+    finInsepDegree F E = finInsepDegree F K := by
+  simpa only [Cardinal.toNat_lift] using congr_arg Cardinal.toNat
+    (insepDegree_eq_of_equiv F E K i)
+
+@[simp]
+theorem sepDegree_self : sepDegree F F = 1 := by
+  have : separableClosure F F = ⊥ := toSubalgebra_injective <| Subsingleton.elim _ _
+  rw [sepDegree, this, IntermediateField.rank_bot]
+
+@[simp]
+theorem insepDegree_self : insepDegree F F = 1 := by
+  have : separableClosure F F = ⊤ := toSubalgebra_injective <| Subsingleton.elim _ _
+  rw [insepDegree, this, IntermediateField.rank_top]
+
+@[simp]
+theorem finInsepDegree_self : finInsepDegree F F = 1 := by
+  simp only [finInsepDegree, insepDegree_self, Cardinal.one_toNat]
+
+end Field
+
+namespace IntermediateField
+
+@[simp]
+theorem sepDegree_bot : sepDegree F (⊥ : IntermediateField F E) = 1 := by
+  have := sepDegree_eq_of_equiv _ _ _ (botEquiv F E)
+  rwa [sepDegree_self, Cardinal.lift_one, ← Cardinal.lift_one.{u, v}, Cardinal.lift_inj] at this
+
+@[simp]
+theorem insepDegree_bot : insepDegree F (⊥ : IntermediateField F E) = 1 := by
+  have := insepDegree_eq_of_equiv _ _ _ (botEquiv F E)
+  rwa [insepDegree_self, Cardinal.lift_one, ← Cardinal.lift_one.{u, v}, Cardinal.lift_inj] at this
+
+@[simp]
+theorem finInsepDegree_bot : finInsepDegree F (⊥ : IntermediateField F E) = 1 := by
+  rw [finInsepDegree_eq_of_equiv _ _ _ (botEquiv F E), finInsepDegree_self]
+
+section Tower
+
+variable [Algebra E K] [IsScalarTower F E K]
+
+theorem lift_sepDegree_bot' : Cardinal.lift.{v} (sepDegree F (⊥ : IntermediateField E K)) =
+    Cardinal.lift.{w} (sepDegree F E) :=
+  sepDegree_eq_of_equiv _ _ _ ((botEquiv E K).restrictScalars F)
+
+theorem lift_insepDegree_bot' : Cardinal.lift.{v} (insepDegree F (⊥ : IntermediateField E K)) =
+    Cardinal.lift.{w} (insepDegree F E) :=
+  insepDegree_eq_of_equiv _ _ _ ((botEquiv E K).restrictScalars F)
+
+variable {F}
+
+@[simp]
+theorem finInsepDegree_bot' :
+    finInsepDegree F (⊥ : IntermediateField E K) = finInsepDegree F E := by
+  simpa only [Cardinal.toNat_lift] using congr_arg Cardinal.toNat (lift_insepDegree_bot' F E K)
+
+@[simp]
+theorem sepDegree_top : sepDegree F (⊤ : IntermediateField E K) = sepDegree F K := by
+  simpa only [Cardinal.lift_id] using sepDegree_eq_of_equiv _ _ _
+    ((topEquiv (F := E) (E := K)).restrictScalars F)
+
+@[simp]
+theorem insepDegree_top : insepDegree F (⊤ : IntermediateField E K) = insepDegree F K := by
+  simpa only [Cardinal.lift_id] using insepDegree_eq_of_equiv _ _ _
+    ((topEquiv (F := E) (E := K)).restrictScalars F)
+
+@[simp]
+theorem finInsepDegree_top : finInsepDegree F (⊤ : IntermediateField E K) = finInsepDegree F K := by
+  simp only [finInsepDegree, insepDegree_top]
+
+variable (K : Type v) [Field K] [Algebra F K] [Algebra E K] [IsScalarTower F E K]
+
+@[simp]
+theorem sepDegree_bot' : sepDegree F (⊥ : IntermediateField E K) = sepDegree F E := by
+  simpa only [Cardinal.lift_id] using lift_sepDegree_bot' F E K
+
+@[simp]
+theorem insepDegree_bot' : insepDegree F (⊥ : IntermediateField E K) = insepDegree F E := by
+  simpa only [Cardinal.lift_id] using lift_insepDegree_bot' F E K
+
+end Tower
+
+end IntermediateField

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -41,7 +41,8 @@ This file contains basics about the (relative) separable closure of a field exte
 - `separableClosure.normalClosure_eq_self`: the normal closure of the (relative) separable
   closure of `E / F` is equal to itself.
 
-- `separableClosure.normal`: the (relative) separable closure of a normal extension is normal.
+- `separableClosure.isGalois`: the (relative) separable closure of a normal extension is Galois
+  (namely, normal and separable).
 
 - `separableClosure.isSepClosure`: the (relative) separable closure of a separably closed extension
   is a separable closure of the base field.
@@ -170,11 +171,13 @@ theorem separableClosure.normalClosure_eq_self :
     haveI : IsSeparable F i.fieldRange := (AlgEquiv.ofInjectiveField i).isSeparable
     le_separableClosure F E _) (le_normalClosure _)
 
-/-- If `E` is normal over `F`, then the (relative) separable closure of `E / F` is also normal
-over `F`. -/
-instance separableClosure.normal [Normal F E] : Normal F (separableClosure F E) := by
-  rw [← separableClosure.normalClosure_eq_self]
-  exact normalClosure.normal F _ E
+/-- If `E` is normal over `F`, then the (relative) separable closure of `E / F` is Galois (i.e.
+normal and separable) over `F`. -/
+instance separableClosure.isGalois [Normal F E] : IsGalois F (separableClosure F E) where
+  to_isSeparable := separableClosure.isSeparable F E
+  to_normal := by
+    rw [← separableClosure.normalClosure_eq_self]
+    exact normalClosure.normal F _ E
 
 /-- If `E` is separably closed, then the (relative) separable closure of `E / F` is a
 separable closure of `F`. -/

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -18,6 +18,9 @@ This file contains basics about the (relative) separable closure of a field exte
   subextension of `E / F`, is defined to be the intermediate field of `E / F` consisting of all
   separable elements.
 
+- `SeparableClosure`: the (absolute) separable closure, defined to be the (relative) separable
+  closure inside the algebraic closure.
+
 - `Field.sepDegree F E`: the (infinite) separable degree $[E:F]_s$ of an algebraic extension
   `E / F` of fields, defined to be the degree of `separableClosure F E / F`. Later we will show
   that (`Field.finSepDegree_eq`, not in this file), if `Field.Emb F E` is finite, then this
@@ -198,6 +201,10 @@ instance separableClosure.isSepClosure [IsSepClosed E] : IsSepClosure F (separab
   use ⟨x, le_separableClosure F E (restrictScalars F L⟮x⟯) this⟩
   apply_fun algebraMap L E using (algebraMap L E).injective
   rwa [map_zero, ← aeval_algebraMap_apply_eq_algebraMap_eval]
+
+/-- The (absolute) separable closure is defined to be the (relative) separable closure inside the
+algebraic closure. -/
+abbrev SeparableClosure : Type _ := separableClosure F (AlgebraicClosure F)
 
 /-- `F(S) / F` is a separable extension if and only if all elements of `S` are
 separable elements. -/

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -160,12 +160,8 @@ theorem le_separableClosure_iff (L : IntermediateField F E) :
 /-- The (relative) separable closure of the (relative) separable closure of `E / F` is equal to
 itself. -/
 theorem separableClosure.separableClosure_eq_bot :
-    separableClosure (separableClosure F E) E = ⊥ := bot_unique fun x hx ↦ by
-  rw [mem_separableClosure_iff, ← isSeparable_adjoin_simple_iff_separable] at hx
-  set L := separableClosure F E
-  haveI : IsSeparable F (L⟮x⟯.restrictScalars F) := IsSeparable.trans F L L⟮x⟯
-  exact mem_bot.2 ⟨⟨x, (mem_separableClosure_iff F E).2 (separable_of_mem_isSeparable F E <|
-    show x ∈ L⟮x⟯.restrictScalars F from mem_adjoin_simple_self L x)⟩, rfl⟩
+    separableClosure (separableClosure F E) E = ⊥ := bot_unique fun x hx ↦
+  mem_bot.2 ⟨⟨x, (mem_separableClosure_iff _ E).1 hx |>.comap_minpoly_of_isSeparable F⟩, rfl⟩
 
 /-- The normal closure of the (relative) separable closure of `E / F` is equal to itself. -/
 theorem separableClosure.normalClosure_eq_self :
@@ -217,13 +213,8 @@ theorem separableClosure.le_restrictScalars [Algebra E K] [IsScalarTower F E K] 
 /-- If `K / E / F` is a field extension tower, such that `E / F` is separable, then
 `separableClosure F K` is equal to `separableClosure E K`. -/
 theorem separableClosure.eq_restrictScalars_of_isSeparable [Algebra E K] [IsScalarTower F E K]
-    [IsSeparable F E] : separableClosure F K = (separableClosure E K).restrictScalars F := by
-  refine le_antisymm (separableClosure.le_restrictScalars F E K) fun x hx ↦ ?_
-  rw [mem_restrictScalars, mem_separableClosure_iff,
-    ← isSeparable_adjoin_simple_iff_separable] at hx
-  haveI : IsSeparable F (E⟮x⟯.restrictScalars F) := IsSeparable.trans F E E⟮x⟯
-  have h : x ∈ E⟮x⟯.restrictScalars F := mem_adjoin_simple_self E x
-  exact (mem_separableClosure_iff F _).2 <| separable_of_mem_isSeparable F _ h
+    [IsSeparable F E] : separableClosure F K = (separableClosure E K).restrictScalars F :=
+  (separableClosure.le_restrictScalars F E K).antisymm fun _ h ↦ h.comap_minpoly_of_isSeparable F
 
 /-- If `K / E / F` is a field extension tower, then `E` adjoin `separableClosure F K` is contained
 in `separableClosure E K`. -/

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -85,6 +85,8 @@ def separableClosure : IntermediateField F E where
   algebraMap_mem' := separable_algebraMap E
   inv_mem' := separable_inv
 
+variable {F E K}
+
 /-- An element is contained in the (relative) separable closure of `E / F` if and only if
 it is a separable element. -/
 theorem mem_separableClosure_iff {x : E} :
@@ -101,38 +103,43 @@ the preimage of `separableClosure F K` under the map `i`. -/
 theorem separableClosure.eq_comap_of_algHom (i : E →ₐ[F] K) :
     separableClosure F E = (separableClosure F K).comap i := by
   ext x
-  exact (map_mem_separableClosure_iff F E K i).symm
+  exact (map_mem_separableClosure_iff i).symm
 
 /-- If `i` is an `F`-algebra homomorphism from `E` to `K`, then `separableClosure F K` contains
 the image of `separableClosure F E` under the map `i`. -/
 theorem separableClosure.map_le_of_algHom (i : E →ₐ[F] K) :
     (separableClosure F E).map i ≤ separableClosure F K :=
-  map_le_iff_le_comap.2 (eq_comap_of_algHom F E K i).le
+  map_le_iff_le_comap.2 (eq_comap_of_algHom i).le
 
+variable (F) in
 /-- If `K / E / F` is a field extension tower, such that `K / E` has no non-trivial separable
 subextensions (when `K / E` is algebraic, this means that it is purely inseparable),
 then `separableClosure F K` is equal to `separableClosure F E`. -/
 theorem separableClosure.eq_map_of_separableClosure_eq_bot [Algebra E K] [IsScalarTower F E K]
     (h : separableClosure E K = ⊥) :
     separableClosure F K = (separableClosure F E).map (IsScalarTower.toAlgHom F E K) := by
-  refine le_antisymm (fun x hx ↦ ?_) (map_le_of_algHom F E K _)
-  obtain ⟨y, rfl⟩ := mem_bot.1 <| h ▸ (mem_separableClosure_iff E K).2
-    (mem_separableClosure_iff _ _ |>.mp hx |>.map_minpoly E)
-  exact ⟨y, (map_mem_separableClosure_iff _ _ _ <| IsScalarTower.toAlgHom F E K).mp hx, rfl⟩
+  refine le_antisymm (fun x hx ↦ ?_) (map_le_of_algHom _)
+  obtain ⟨y, rfl⟩ := mem_bot.1 <| h ▸ mem_separableClosure_iff.2
+    (mem_separableClosure_iff.1 hx |>.map_minpoly E)
+  exact ⟨y, (map_mem_separableClosure_iff <| IsScalarTower.toAlgHom F E K).mp hx, rfl⟩
 
 /-- If `i` is an `F`-algebra isomorphism of `E` and `K`, then `separableClosure F K` is equal to
 the image of `separableClosure F E` under the map `i`. -/
 theorem separableClosure.eq_map_of_algEquiv (i : E ≃ₐ[F] K) :
     separableClosure F K = (separableClosure F E).map i :=
-  le_antisymm (fun x h ↦ ⟨_, (map_mem_separableClosure_iff F K E i.symm).2 h, i.right_inv x⟩)
-    (map_le_of_algHom F E K i)
+  le_antisymm (fun x h ↦ ⟨_, (map_mem_separableClosure_iff i.symm).2 h, by simp⟩)
+    (map_le_of_algHom i.toAlgHom)
 
 /-- If `E` and `K` are isomorphic as `F`-algebras, then `separableClosure F E` and
 `separableClosure F K` are also isomorphic as `F`-algebras. -/
 def separableClosure.algEquivOfAlgEquiv (i : E ≃ₐ[F] K) :
     separableClosure F E ≃ₐ[F] separableClosure F K :=
   ((separableClosure F E).intermediateFieldMap i).trans
-    (equivOfEq (eq_map_of_algEquiv F E K i).symm)
+    (equivOfEq (eq_map_of_algEquiv i).symm)
+
+alias AlgEquiv.separableClosure := separableClosure.algEquivOfAlgEquiv
+
+variable (F E K)
 
 /-- The (relative) separable closure of `E / F` is algebraic over `F`. -/
 theorem separableClosure.isAlgebraic : Algebra.IsAlgebraic F (separableClosure F E) :=
@@ -162,7 +169,7 @@ theorem le_separableClosure_iff (L : IntermediateField F E) :
 itself. -/
 theorem separableClosure.separableClosure_eq_bot :
     separableClosure (separableClosure F E) E = ⊥ := bot_unique fun x hx ↦
-  mem_bot.2 ⟨⟨x, (mem_separableClosure_iff _ E).1 hx |>.comap_minpoly_of_isSeparable F⟩, rfl⟩
+  mem_bot.2 ⟨⟨x, mem_separableClosure_iff.1 hx |>.comap_minpoly_of_isSeparable F⟩, rfl⟩
 
 /-- The normal closure of the (relative) separable closure of `E / F` is equal to itself. -/
 theorem separableClosure.normalClosure_eq_self :
@@ -207,8 +214,8 @@ theorem IntermediateField.isSeparable_adjoin_iff_separable {S : Set E} :
 /-- The (relative) separable closure of `E / F` is equal to `E` if and only if `E / F` is
 separable. -/
 theorem separableClosure.eq_top_iff : separableClosure F E = ⊤ ↔ IsSeparable F E :=
-  ⟨fun h ↦ ⟨fun _ ↦ (mem_separableClosure_iff F E).1 (h ▸ mem_top)⟩,
-    fun _ ↦ top_unique fun x _ ↦ (mem_separableClosure_iff F E).2 (IsSeparable.separable _ x)⟩
+  ⟨fun h ↦ ⟨fun _ ↦ mem_separableClosure_iff.1 (h ▸ mem_top)⟩,
+    fun _ ↦ top_unique fun x _ ↦ mem_separableClosure_iff.2 (IsSeparable.separable _ x)⟩
 
 /-- If `K / E / F` is a field extension tower, then `separableClosure F K` is contained in
 `separableClosure E K`. -/
@@ -270,12 +277,12 @@ instance instNeZeroFinInsepDegree [FiniteDimensional F E] :
 separable degree over `F`. -/
 theorem lift_sepDegree_eq_of_equiv (i : E ≃ₐ[F] K) :
     Cardinal.lift.{w} (sepDegree F E) = Cardinal.lift.{v} (sepDegree F K) :=
-  (separableClosure.algEquivOfAlgEquiv F E K i).toLinearEquiv.lift_rank_eq
+  i.separableClosure.toLinearEquiv.lift_rank_eq
 
 /-- The same-universe version of `Field.lift_sepDegree_eq_of_equiv`. -/
 theorem sepDegree_eq_of_equiv (K : Type v) [Field K] [Algebra F K] (i : E ≃ₐ[F] K) :
     sepDegree F E = sepDegree F K :=
-  (separableClosure.algEquivOfAlgEquiv F E K i).toLinearEquiv.rank_eq
+  i.separableClosure.toLinearEquiv.rank_eq
 
 /-- The (infinite) separable degree multiply by the (infinite) inseparable degree is equal
 to the (infinite) field extension degree. -/
@@ -286,12 +293,12 @@ theorem sepDegree_mul_insepDegree : sepDegree F E * insepDegree F E = Module.ran
 inseparable degree over `F`. -/
 theorem lift_insepDegree_eq_of_equiv (i : E ≃ₐ[F] K) :
     Cardinal.lift.{w} (insepDegree F E) = Cardinal.lift.{v} (insepDegree F K) :=
-  Algebra.lift_rank_eq_of_equiv_equiv (separableClosure.algEquivOfAlgEquiv F E K i) i rfl
+  Algebra.lift_rank_eq_of_equiv_equiv i.separableClosure i rfl
 
 /-- The same-universe version of `Field.lift_insepDegree_eq_of_equiv`. -/
 theorem insepDegree_eq_of_equiv (K : Type v) [Field K] [Algebra F K] (i : E ≃ₐ[F] K) :
     insepDegree F E = insepDegree F K :=
-  Algebra.rank_eq_of_equiv_equiv (separableClosure.algEquivOfAlgEquiv F E K i) i rfl
+  Algebra.rank_eq_of_equiv_equiv i.separableClosure i rfl
 
 /-- If `E` and `K` are isomorphic as `F`-algebras, then they have the same (finite)
 inseparable degree over `F`. -/

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -105,11 +105,8 @@ theorem separableClosure.eq_comap_of_algHom (i : E →ₐ[F] K) :
 /-- If `i` is an `F`-algebra homomorphism from `E` to `K`, then `separableClosure F K` contains
 the image of `separableClosure F E` under the map `i`. -/
 theorem separableClosure.map_le_of_algHom (i : E →ₐ[F] K) :
-    (separableClosure F E).map i ≤ separableClosure F K := fun x hx ↦ by
-  change x ∈ (_ : Set K) at hx
-  rw [coe_map, Set.mem_image] at hx
-  obtain ⟨y, hy, rfl⟩ := hx
-  exact (map_mem_separableClosure_iff F E K i).2 hy
+    (separableClosure F E).map i ≤ separableClosure F K :=
+  map_le_iff_le_comap.2 (eq_comap_of_algHom F E K i).le
 
 /-- If `K / E / F` is a field extension tower, such that `K / E` has no non-trivial separable
 subextensions (when `K / E` is algebraic, this means that it is purely inseparable),
@@ -177,11 +174,10 @@ theorem separableClosure.separableClosure_eq_bot :
 
 /-- The normal closure of the (relative) separable closure of `E / F` is equal to itself. -/
 theorem separableClosure.normalClosure_eq_self :
-    normalClosure F (separableClosure F E) E = separableClosure F E := by
-  apply le_antisymm (normalClosure_le_iff.2 fun i ↦ ?_) (le_normalClosure _)
-  let i' : (separableClosure F E) ≃ₐ[F] i.fieldRange := AlgEquiv.ofInjectiveField i
-  haveI := i'.isSeparable
-  exact le_separableClosure F E _
+    normalClosure F (separableClosure F E) E = separableClosure F E :=
+  le_antisymm (normalClosure_le_iff.2 fun i ↦
+    haveI : IsSeparable F i.fieldRange := (AlgEquiv.ofInjectiveField i).isSeparable
+    le_separableClosure F E _) (le_normalClosure _)
 
 /-- If `E` is normal over `F`, then the (relative) separable closure of `E / F` is also normal
 over `F`. -/
@@ -262,15 +258,15 @@ end separableClosure
 namespace Field
 
 /-- The (infinite) separable degree for a general field extension `E / F` is defined
-to be the degree of `(separableClosure F E) / F`. -/
+to be the degree of `separableClosure F E / F`. -/
 def sepDegree := Module.rank F (separableClosure F E)
 
 /-- The (infinite) inseparable degree for a general field extension `E / F` is defined
-to be the degree of `E / (separableClosure F E)`. -/
+to be the degree of `E / separableClosure F E`. -/
 def insepDegree := Module.rank (separableClosure F E) E
 
 /-- The (finite) inseparable degree for a general field extension `E / F` is defined
-to be the degree of `E / (separableClosure F E)` as a natural number. It is defined to be zero
+to be the degree of `E / separableClosure F E` as a natural number. It is defined to be zero
 if such field extension is infinite. -/
 def finInsepDegree : ℕ := Cardinal.toNat (insepDegree F E)
 
@@ -308,13 +304,11 @@ theorem finInsepDegree_eq_of_equiv (i : E ≃ₐ[F] K) :
 
 @[simp]
 theorem sepDegree_self : sepDegree F F = 1 := by
-  have : separableClosure F F = ⊥ := toSubalgebra_injective <| Subsingleton.elim _ _
-  rw [sepDegree, this, IntermediateField.rank_bot]
+  rw [sepDegree, Subsingleton.elim (separableClosure F F) ⊥, IntermediateField.rank_bot]
 
 @[simp]
 theorem insepDegree_self : insepDegree F F = 1 := by
-  have : separableClosure F F = ⊤ := toSubalgebra_injective <| Subsingleton.elim _ _
-  rw [insepDegree, this, IntermediateField.rank_top]
+  rw [insepDegree, Subsingleton.elim (separableClosure F F) ⊤, IntermediateField.rank_top]
 
 @[simp]
 theorem finInsepDegree_self : finInsepDegree F F = 1 := by

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -186,18 +186,21 @@ instance separableClosure.isGalois [Normal F E] : IsGalois F (separableClosure F
     rw [← separableClosure.normalClosure_eq_self]
     exact normalClosure.normal F _ E
 
+/-- If `E / F` is a field extension, `E` is separably closed, then the (relative) separable closure
+of `E / F` is equal to `F` if and only if `F` is separably closed. -/
+theorem IsSepClosed.separableClosure_eq_bot_iff [IsSepClosed E] :
+    separableClosure F E = ⊥ ↔ IsSepClosed F := by
+  refine ⟨fun h ↦ IsSepClosed.of_exists_root _ fun p _ hirr hsep ↦ ?_,
+    fun _ ↦ IntermediateField.eq_bot_of_isSepClosed_of_isSeparable _⟩
+  obtain ⟨x, hx⟩ := IsSepClosed.exists_aeval_eq_zero E p (degree_pos_of_irreducible hirr).ne' hsep
+  obtain ⟨x, rfl⟩ := h ▸ mem_separableClosure_iff.2 (hsep.of_dvd <| minpoly.dvd _ x hx)
+  exact ⟨x, by simpa [Algebra.ofId_apply] using hx⟩
+
 /-- If `E` is separably closed, then the (relative) separable closure of `E / F` is a
 separable closure of `F`. -/
-instance separableClosure.isSepClosure [IsSepClosed E] : IsSepClosure F (separableClosure F E) := by
-  refine ⟨IsSepClosed.of_exists_root _ fun p _ hirr hsep ↦ ?_, isSeparable F E⟩
-  obtain ⟨x, hx⟩ := IsSepClosed.exists_aeval_eq_zero E p (degree_pos_of_irreducible hirr).ne' hsep
-  haveI := (isSeparable_adjoin_simple_iff_separable _ E).2 <| hsep.of_dvd <| minpoly.dvd _ x hx
-  let L := separableClosure F E
-  haveI : IsSeparable F (restrictScalars F L⟮x⟯) := IsSeparable.trans F L L⟮x⟯
-  have : x ∈ restrictScalars F L⟮x⟯ := mem_adjoin_simple_self _ x
-  use ⟨x, le_separableClosure F E (restrictScalars F L⟮x⟯) this⟩
-  apply_fun algebraMap L E using (algebraMap L E).injective
-  rwa [map_zero, ← aeval_algebraMap_apply_eq_algebraMap_eval]
+instance separableClosure.isSepClosure [IsSepClosed E] : IsSepClosure F (separableClosure F E) :=
+  ⟨(IsSepClosed.separableClosure_eq_bot_iff _ E).mp (separableClosure.separableClosure_eq_bot F E),
+    isSeparable F E⟩
 
 /-- The (absolute) separable closure is defined to be the (relative) separable closure inside the
 algebraic closure. It is indeed a separable closure (`IsSepClosure`) by

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -270,9 +270,14 @@ instance instNeZeroFinInsepDegree [FiniteDimensional F E] :
 
 /-- If `E` and `K` are isomorphic as `F`-algebras, then they have the same (infinite)
 separable degree over `F`. -/
-theorem sepDegree_eq_of_equiv (i : E ≃ₐ[F] K) :
+theorem lift_sepDegree_eq_of_equiv (i : E ≃ₐ[F] K) :
     Cardinal.lift.{w} (sepDegree F E) = Cardinal.lift.{v} (sepDegree F K) :=
   (separableClosure.algEquivOfAlgEquiv F E K i).toLinearEquiv.lift_rank_eq
+
+/-- The same-universe version of `Field.lift_sepDegree_eq_of_equiv`. -/
+theorem sepDegree_eq_of_equiv (K : Type v) [Field K] [Algebra F K] (i : E ≃ₐ[F] K) :
+    sepDegree F E = sepDegree F K :=
+  (separableClosure.algEquivOfAlgEquiv F E K i).toLinearEquiv.rank_eq
 
 /-- The (infinite) separable degree multiply by the (infinite) inseparable degree is equal
 to the (infinite) field extension degree. -/
@@ -281,16 +286,21 @@ theorem sepDegree_mul_insepDegree : sepDegree F E * insepDegree F E = Module.ran
 
 /-- If `E` and `K` are isomorphic as `F`-algebras, then they have the same (infinite)
 inseparable degree over `F`. -/
-theorem insepDegree_eq_of_equiv (i : E ≃ₐ[F] K) :
+theorem lift_insepDegree_eq_of_equiv (i : E ≃ₐ[F] K) :
     Cardinal.lift.{w} (insepDegree F E) = Cardinal.lift.{v} (insepDegree F K) :=
   Algebra.lift_rank_eq_of_equiv_equiv (separableClosure.algEquivOfAlgEquiv F E K i) i rfl
+
+/-- The same-universe version of `Field.lift_insepDegree_eq_of_equiv`. -/
+theorem insepDegree_eq_of_equiv (K : Type v) [Field K] [Algebra F K] (i : E ≃ₐ[F] K) :
+    insepDegree F E = insepDegree F K :=
+  Algebra.rank_eq_of_equiv_equiv (separableClosure.algEquivOfAlgEquiv F E K i) i rfl
 
 /-- If `E` and `K` are isomorphic as `F`-algebras, then they have the same (finite)
 inseparable degree over `F`. -/
 theorem finInsepDegree_eq_of_equiv (i : E ≃ₐ[F] K) :
     finInsepDegree F E = finInsepDegree F K := by
   simpa only [Cardinal.toNat_lift] using congr_arg Cardinal.toNat
-    (insepDegree_eq_of_equiv F E K i)
+    (lift_insepDegree_eq_of_equiv F E K i)
 
 @[simp]
 theorem sepDegree_self : sepDegree F F = 1 := by
@@ -310,12 +320,12 @@ namespace IntermediateField
 
 @[simp]
 theorem sepDegree_bot : sepDegree F (⊥ : IntermediateField F E) = 1 := by
-  have := sepDegree_eq_of_equiv _ _ _ (botEquiv F E)
+  have := lift_sepDegree_eq_of_equiv _ _ _ (botEquiv F E)
   rwa [sepDegree_self, Cardinal.lift_one, ← Cardinal.lift_one.{u, v}, Cardinal.lift_inj] at this
 
 @[simp]
 theorem insepDegree_bot : insepDegree F (⊥ : IntermediateField F E) = 1 := by
-  have := insepDegree_eq_of_equiv _ _ _ (botEquiv F E)
+  have := lift_insepDegree_eq_of_equiv _ _ _ (botEquiv F E)
   rwa [insepDegree_self, Cardinal.lift_one, ← Cardinal.lift_one.{u, v}, Cardinal.lift_inj] at this
 
 @[simp]
@@ -328,11 +338,11 @@ variable [Algebra E K] [IsScalarTower F E K]
 
 theorem lift_sepDegree_bot' : Cardinal.lift.{v} (sepDegree F (⊥ : IntermediateField E K)) =
     Cardinal.lift.{w} (sepDegree F E) :=
-  sepDegree_eq_of_equiv _ _ _ ((botEquiv E K).restrictScalars F)
+  lift_sepDegree_eq_of_equiv _ _ _ ((botEquiv E K).restrictScalars F)
 
 theorem lift_insepDegree_bot' : Cardinal.lift.{v} (insepDegree F (⊥ : IntermediateField E K)) =
     Cardinal.lift.{w} (insepDegree F E) :=
-  insepDegree_eq_of_equiv _ _ _ ((botEquiv E K).restrictScalars F)
+  lift_insepDegree_eq_of_equiv _ _ _ ((botEquiv E K).restrictScalars F)
 
 variable {F}
 
@@ -342,14 +352,12 @@ theorem finInsepDegree_bot' :
   simpa only [Cardinal.toNat_lift] using congr_arg Cardinal.toNat (lift_insepDegree_bot' F E K)
 
 @[simp]
-theorem sepDegree_top : sepDegree F (⊤ : IntermediateField E K) = sepDegree F K := by
-  simpa only [Cardinal.lift_id] using sepDegree_eq_of_equiv _ _ _
-    ((topEquiv (F := E) (E := K)).restrictScalars F)
+theorem sepDegree_top : sepDegree F (⊤ : IntermediateField E K) = sepDegree F K :=
+  sepDegree_eq_of_equiv _ _ _ ((topEquiv (F := E) (E := K)).restrictScalars F)
 
 @[simp]
-theorem insepDegree_top : insepDegree F (⊤ : IntermediateField E K) = insepDegree F K := by
-  simpa only [Cardinal.lift_id] using insepDegree_eq_of_equiv _ _ _
-    ((topEquiv (F := E) (E := K)).restrictScalars F)
+theorem insepDegree_top : insepDegree F (⊤ : IntermediateField E K) = insepDegree F K :=
+  insepDegree_eq_of_equiv _ _ _ ((topEquiv (F := E) (E := K)).restrictScalars F)
 
 @[simp]
 theorem finInsepDegree_top : finInsepDegree F (⊤ : IntermediateField E K) = finInsepDegree F K := by
@@ -358,12 +366,12 @@ theorem finInsepDegree_top : finInsepDegree F (⊤ : IntermediateField E K) = fi
 variable (K : Type v) [Field K] [Algebra F K] [Algebra E K] [IsScalarTower F E K]
 
 @[simp]
-theorem sepDegree_bot' : sepDegree F (⊥ : IntermediateField E K) = sepDegree F E := by
-  simpa only [Cardinal.lift_id] using lift_sepDegree_bot' F E K
+theorem sepDegree_bot' : sepDegree F (⊥ : IntermediateField E K) = sepDegree F E :=
+  sepDegree_eq_of_equiv _ _ _ ((botEquiv E K).restrictScalars F)
 
 @[simp]
-theorem insepDegree_bot' : insepDegree F (⊥ : IntermediateField E K) = insepDegree F E := by
-  simpa only [Cardinal.lift_id] using lift_insepDegree_bot' F E K
+theorem insepDegree_bot' : insepDegree F (⊥ : IntermediateField E K) = insepDegree F E :=
+  insepDegree_eq_of_equiv _ _ _ ((botEquiv E K).restrictScalars F)
 
 end Tower
 

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -193,7 +193,9 @@ instance separableClosure.isSepClosure [IsSepClosed E] : IsSepClosure F (separab
   rwa [map_zero, ← aeval_algebraMap_apply_eq_algebraMap_eval]
 
 /-- The (absolute) separable closure is defined to be the (relative) separable closure inside the
-algebraic closure. -/
+algebraic closure. It is indeed a separable closure (`IsSepClosure`) by
+`separableClosure.isSepClosure`, and it is Galois (`IsGalois`) by `separableClosure.isGalois`
+or `IsSepClosure.isGalois`, and every separable extension embeds into it (`IsSepClosed.lift`). -/
 abbrev SeparableClosure : Type _ := separableClosure F (AlgebraicClosure F)
 
 /-- `F(S) / F` is a separable extension if and only if all elements of `S` are

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -672,7 +672,15 @@ theorem IntermediateField.isSeparable_adjoin_pair_of_separable {x y : E}
 
 namespace Field
 
-variable {F E} in
+variable {F}
+
+/-- Any element `x` of `F` is a separable element of `E / F` when embedded into `E`. -/
+theorem separable_algebraMap (x : F) : (minpoly F ((algebraMap F E) x)).Separable := by
+  rw [minpoly.algebraMap_eq (algebraMap F E).injective]
+  exact IsSeparable.separable F x
+
+variable {E}
+
 /-- If `x` and `y` are both separable elements, then `x * y` is also a separable element. -/
 theorem separable_mul {x y : E} (hx : (minpoly F x).Separable) (hy : (minpoly F y).Separable) :
     (minpoly F (x * y)).Separable :=
@@ -680,7 +688,6 @@ theorem separable_mul {x y : E} (hx : (minpoly F x).Separable) (hy : (minpoly F 
   separable_of_mem_isSeparable F E <| F⟮x, y⟯.mul_mem (subset_adjoin F _ (.inl rfl))
     (subset_adjoin F _ (.inr rfl))
 
-variable {F E} in
 /-- If `x` and `y` are both separable elements, then `x + y` is also a separable element. -/
 theorem separable_add {x y : E} (hx : (minpoly F x).Separable) (hy : (minpoly F y).Separable) :
     (minpoly F (x + y)).Separable :=
@@ -688,13 +695,6 @@ theorem separable_add {x y : E} (hx : (minpoly F x).Separable) (hy : (minpoly F 
   separable_of_mem_isSeparable F E <| F⟮x, y⟯.add_mem (subset_adjoin F _ (.inl rfl))
     (subset_adjoin F _ (.inr rfl))
 
-variable {F} in
-/-- Any element `x` of `F` is a separable element of `E / F` when embedded into `E`. -/
-theorem separable_algebraMap (x : F) : (minpoly F ((algebraMap F E) x)).Separable := by
-  rw [minpoly.algebraMap_eq (algebraMap F E).injective]
-  exact IsSeparable.separable F x
-
-variable {F E} in
 /-- If `x` is a separable element, then `x⁻¹` is also a separable element. -/
 theorem separable_inv (x : E) (hx : (minpoly F x).Separable) : (minpoly F x⁻¹).Separable :=
   haveI := (isSeparable_adjoin_simple_iff_separable F E).2 hx

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -625,9 +625,11 @@ theorem IntermediateField.isSeparable_adjoin_simple_iff_separable {x : E} :
     rwa [← finSepDegree_eq_finrank_iff,
       finSepDegree_adjoin_simple_eq_finrank_iff F E x h.isAlgebraic]
 
-/-- If `E / F` and `K / E` are both separable extensions, then `K / F` is also separable. -/
-theorem IsSeparable.trans [Algebra E K] [IsScalarTower F E K]
-    [IsSeparable F E] [IsSeparable E K] : IsSeparable F K := (isSeparable_def F K).2 fun x ↦ by
+variable {E K} in
+/-- If `K / E / F` is an extension tower such that `E / F` is separable,
+`x : K` is separable over `E`, then it's also separable over `F`. -/
+theorem Polynomial.Separable.comap_minpoly_of_isSeparable [Algebra E K] [IsScalarTower F E K]
+    [IsSeparable F E] {x : K} (hsep : (minpoly E x).Separable) : (minpoly F x).Separable := by
   let f := minpoly E x
   let E' : IntermediateField F E := adjoin F f.frange
   haveI : FiniteDimensional F E' := finiteDimensional_adjoin fun x _ ↦ IsSeparable.isIntegral F x
@@ -637,10 +639,9 @@ theorem IsSeparable.trans [Algebra E K] [IsScalarTower F E K]
   have hx : x ∈ restrictScalars F E'⟮x⟯ := mem_adjoin_simple_self _ x
   have hzero : aeval x g = 0 := by
     simpa only [← h, aeval_map_algebraMap] using minpoly.aeval E x
-  have halg : IsIntegral E' x := (IsSeparable.isAlgebraic F E).trans
-    (IsSeparable.isAlgebraic E K) x |>.isIntegral.tower_top
-  have hsep : f.Separable := IsSeparable.separable E x
-  rw [← h, separable_map] at hsep
+  have halg : IsIntegral E' x :=
+    isIntegral_trans (IsSeparable.isAlgebraic F E).isIntegral _ hsep.isIntegral |>.tower_top
+  simp_rw [← h, separable_map] at hsep
   replace hsep := hsep.of_dvd <| minpoly.dvd _ _ hzero
   haveI : IsSeparable F E' := isSeparable_tower_bot_of_isSeparable F E' E
   haveI := (isSeparable_adjoin_simple_iff_separable _ _).2 hsep
@@ -653,6 +654,11 @@ theorem IsSeparable.trans [Algebra E K] [IsScalarTower F E K]
     eq_comm, finSepDegree_eq_finrank_iff F E'⟮x⟯] at this
   change IsSeparable F (restrictScalars F E'⟮x⟯) at this
   exact separable_of_mem_isSeparable F K hx
+
+/-- If `E / F` and `K / E` are both separable extensions, then `K / F` is also separable. -/
+theorem IsSeparable.trans [Algebra E K] [IsScalarTower F E K]
+    [IsSeparable F E] [IsSeparable E K] : IsSeparable F K :=
+  ⟨fun x ↦ (IsSeparable.separable E x).comap_minpoly_of_isSeparable F⟩
 
 /-- If `x` and `y` are both separable elements, then `F⟮x, y⟯ / F` is a separable extension.
 As a consequence, any rational function of `x` and `y` is also a separable element. -/

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -666,6 +666,7 @@ theorem IntermediateField.isSeparable_adjoin_pair_of_separable {x y : E}
 
 namespace Field
 
+variable {F E} in
 /-- If `x` and `y` are both separable elements, then `x * y` is also a separable element. -/
 theorem separable_mul {x y : E} (hx : (minpoly F x).Separable) (hy : (minpoly F y).Separable) :
     (minpoly F (x * y)).Separable :=
@@ -673,6 +674,7 @@ theorem separable_mul {x y : E} (hx : (minpoly F x).Separable) (hy : (minpoly F 
   separable_of_mem_isSeparable F E <| F⟮x, y⟯.mul_mem (subset_adjoin F _ (.inl rfl))
     (subset_adjoin F _ (.inr rfl))
 
+variable {F E} in
 /-- If `x` and `y` are both separable elements, then `x + y` is also a separable element. -/
 theorem separable_add {x y : E} (hx : (minpoly F x).Separable) (hy : (minpoly F y).Separable) :
     (minpoly F (x + y)).Separable :=
@@ -680,11 +682,13 @@ theorem separable_add {x y : E} (hx : (minpoly F x).Separable) (hy : (minpoly F 
   separable_of_mem_isSeparable F E <| F⟮x, y⟯.add_mem (subset_adjoin F _ (.inl rfl))
     (subset_adjoin F _ (.inr rfl))
 
+variable {F} in
 /-- Any element `x` of `F` is a separable element of `E / F` when embedded into `E`. -/
 theorem separable_algebraMap (x : F) : (minpoly F ((algebraMap F E) x)).Separable := by
   rw [minpoly.algebraMap_eq (algebraMap F E).injective]
   exact IsSeparable.separable F x
 
+variable {F E} in
 /-- If `x` is a separable element, then `x⁻¹` is also a separable element. -/
 theorem separable_inv (x : E) (hx : (minpoly F x).Separable) : (minpoly F x⁻¹).Separable :=
   haveI := (isSeparable_adjoin_simple_iff_separable F E).2 hx


### PR DESCRIPTION
Main definitions:

- `separableClosure`: the (relative) separable closure of `E / F`, or called maximal separable subextension of `E / F`, is defined to be the intermediate field of `E / F` consisting of all separable elements.
- `Field.sepDegree F E`: the (infinite) separable degree `[E:F]_s` of an algebraic extension `E / F` of fields, defined to be the degree of `separableClosure F E / F`.
- `Field.insepDegree F E`: the (infinite) inseparable degree `[E:F]_i` of an algebraic extension `E / F` of fields, defined to be the degree of `E / separableClosure F E`.
- `Field.finInsepDegree F E`: the (finite) inseparable degree `[E:F]_i` of an algebraic extension `E / F` of fields, defined to be the degree of `E / separableClosure F E` as a natural number. It is zero if such field extension is not finite.

Main results:

- `le_separableClosure_iff`: an intermediate field of `E / F` is contained in the (relative) separable closure of `E / F` if and only if it is separable over `F`.
- `separableClosure.normalClosure_eq_self`: the normal closure of the (relative) separable closure of `E / F` is equal to itself.
- `separableClosure.normal`: the (relative) separable closure of a normal extension is normal.
- `separableClosure.isSepClosure`: the (relative) separable closure of a separably closed extension is a separable closure of the base field.
- `IntermediateField.isSeparable_adjoin_iff_separable`: `F(S) / F` is a separable extension if and only if all elements of `S` are separable elements.
- `separableClosure.eq_top_iff`: the (relative) separable closure of `E / F` is equal to `E` if and only if `E / F` is separable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
