### PR TITLE
[Merged by Bors] - feat(GroupTheory/Perm/DomMulAct) : Subgroup of `Equiv.Perm α` preserving a function `p : α → ι`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2207,12 +2207,12 @@ import Mathlib.GroupTheory.NoncommPiCoprod
 import Mathlib.GroupTheory.Order.Min
 import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.GroupTheory.PGroup
-import Mathlib.GroupTheory.Perm.ArrowAction
 import Mathlib.GroupTheory.Perm.Basic
 import Mathlib.GroupTheory.Perm.Cycle.Basic
 import Mathlib.GroupTheory.Perm.Cycle.Concrete
 import Mathlib.GroupTheory.Perm.Cycle.PossibleTypes
 import Mathlib.GroupTheory.Perm.Cycle.Type
+import Mathlib.GroupTheory.Perm.DomMulAct
 import Mathlib.GroupTheory.Perm.Fin
 import Mathlib.GroupTheory.Perm.List
 import Mathlib.GroupTheory.Perm.Option

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2207,6 +2207,7 @@ import Mathlib.GroupTheory.NoncommPiCoprod
 import Mathlib.GroupTheory.Order.Min
 import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.GroupTheory.PGroup
+import Mathlib.GroupTheory.Perm.ArrowAction
 import Mathlib.GroupTheory.Perm.Basic
 import Mathlib.GroupTheory.Perm.Cycle.Basic
 import Mathlib.GroupTheory.Perm.Cycle.Concrete

--- a/Mathlib/GroupTheory/Perm/ArrowAction.lean
+++ b/Mathlib/GroupTheory/Perm/ArrowAction.lean
@@ -8,7 +8,7 @@ import Mathlib.GroupTheory.Subgroup.Basic
 import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.Data.Set.Card
 
-/-!  Subgroup of `Equiv.Perm α` preserving a fibration `p : α → ι`
+/-!  Subgroup of `Equiv.Perm α` preserving a function `p : α → ι`
 
 Let `α` and `ι` by types.
 We consider `arrowAction : MulAction (Equiv.Perm α) (α → ι)`.
@@ -71,6 +71,6 @@ def stabilizerMulEquiv : stabilizer (Perm α) p ≃* (∀ i, Perm {a | p a = i})
   map_mul' g h := rfl
 
 lemma stabilizerMulEquiv_apply (g : stabilizer (Perm α) p) {a : α} {i : ι} (h : p a = i) :
-  (stabilizerMulEquiv p) g i ⟨a, h⟩ = (g : Equiv.Perm α) a := rfl
+   ((stabilizerMulEquiv p)) g i ⟨a, h⟩ = (g : Equiv.Perm α) a := rfl
 
 end arrowAction

--- a/Mathlib/GroupTheory/Perm/ArrowAction.lean
+++ b/Mathlib/GroupTheory/Perm/ArrowAction.lean
@@ -4,21 +4,22 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Junyan Xu, Antoine Chambert-Loir
 -/
 
+import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 import Mathlib.GroupTheory.Subgroup.Basic
 import Mathlib.GroupTheory.GroupAction.Basic
-import Mathlib.Data.Set.Card
+-- import Mathlib.Data.Set.Card
 
 /-!  Subgroup of `Equiv.Perm α` preserving a function `p : α → ι`
 
 Let `α` and `ι` by types.
-We consider `arrowAction : MulAction (Equiv.Perm α) (α → ι)`.
 
-* `arrowAction.mem_stabilizer_iff` proves that the stabilizer
+* `DomMulAct.mem_stabilizer_iff` proves that the stabilizer
   of `Equiv.Perm α` of `p : α → ι` is the subgroup of `g : Equiv.Perm α`
   such that `p ∘ g = p`.
 
-* `arrowAction.stabilizerMulEquiv` is the `MulEquiv` between this stabilizer and
-  the product, for `i : ι`, of `Equiv.Perm {a | p a = i}`.
+* `DomMulAct.stabilizerMulEquiv` is the `MulEquiv` from
+  the MulOpposite of this stabilizer to the product,
+  for `i : ι`, of `Equiv.Perm {a | p a = i}`.
 
 -/
 
@@ -26,12 +27,11 @@ variable {α ι : Type*} {p : α → ι}
 
 open Equiv MulAction
 
-attribute [local instance] arrowAction
+namespace DomMulAct
 
-namespace arrowAction
-
-lemma mem_stabilizer_iff {g : Perm α} :
-    g ∈ stabilizer (Perm α) p ↔ p ∘ g = p := by rw [eq_comm, ← g.comp_symm_eq]; rfl
+lemma mem_stabilizer_iff {g : DomMulAct (Perm α)} :
+    g ∈ stabilizer (DomMulAct (Perm α)) p ↔ p ∘ (DomMulAct.mk.symm g :) = p := by
+  simp only [MulAction.mem_stabilizer_iff]; rfl
 
 /-- The `invFun` component of `MulEquiv` from `MulAction.stabilizer (Perm α) p`
   to the product of the `Equiv.Perm {a | p a = i} -/
@@ -58,19 +58,21 @@ def stabilizerEquiv_invFun_aux (g : ∀ i, Perm {a | p a = i}) : Perm α where
 
 variable (p)
 
-/-- The `MulEquiv` from `MulAction.stabilizer (Perm α) p`
+/-- The `MulEquiv` from the `MulOpposite` of `MulAction.stabilizer (DomMulAct (Perm α)) p`
   to the product of the `Equiv.Perm {a | p a = i} -/
-def stabilizerMulEquiv : stabilizer (Perm α) p ≃* (∀ i, Perm {a | p a = i}) where
-  toFun g i := Perm.subtypePerm g fun a ↦ by
+def stabilizerMulEquiv : (stabilizer (DomMulAct (Perm α)) p)ᵐᵒᵖ ≃* (∀ i, Perm {a | p a = i}) where
+  toFun g i := Perm.subtypePerm (DomMulAct.mk.symm g.unop) fun a ↦ by
     simp only [Set.mem_setOf_eq]
-    rw [← Function.comp_apply (f := p), arrowAction.mem_stabilizer_iff.mp g.prop]
-  invFun g := ⟨stabilizerEquiv_invFun_aux g, by
-    ext a; exact comp_stabilizerEquiv_invFun (fun i ↦ (g i).symm) a⟩
+    rw [← Function.comp_apply (f := p), DomMulAct.mem_stabilizer_iff.mp g.unop.prop]
+  invFun g := ⟨DomMulAct.mk (stabilizerEquiv_invFun_aux g), by
+    ext a
+    rw [smul_apply, symm_apply_apply, Perm.smul_def]
+    apply comp_stabilizerEquiv_invFun⟩
   left_inv g := rfl
   right_inv g := by ext i a; apply stabilizerEquiv_invFun_eq
-  map_mul' g h := rfl
+  map_mul' g h := by rfl
 
-lemma stabilizerMulEquiv_apply (g : stabilizer (Perm α) p) {a : α} {i : ι} (h : p a = i) :
-    ((stabilizerMulEquiv p)) g i ⟨a, h⟩ = (g : Equiv.Perm α) a := rfl
+lemma stabilizerMulEquiv_apply (g : (stabilizer (DomMulAct (Perm α)) p)ᵐᵒᵖ) {a : α} {i : ι} (h : p a = i) :
+    ((stabilizerMulEquiv p)) g i ⟨a, h⟩ = (DomMulAct.mk.symm g.unop : Equiv.Perm α) a := rfl
 
-end arrowAction
+end DomMulAct

--- a/Mathlib/GroupTheory/Perm/ArrowAction.lean
+++ b/Mathlib/GroupTheory/Perm/ArrowAction.lean
@@ -26,8 +26,7 @@ variable {α ι : Type*} {p : α → ι}
 
 open Equiv MulAction
 
-/-- The natural `MulAction` of `Equiv.Perm α` on `α → ι` -/
-local instance  : MulAction (Equiv.Perm α) (α → ι) := arrowAction
+attribute [local instance] arrowAction
 
 namespace arrowAction
 

--- a/Mathlib/GroupTheory/Perm/ArrowAction.lean
+++ b/Mathlib/GroupTheory/Perm/ArrowAction.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2023 Junyan Xu, Antoine Chambert-Loir. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Junyan Xu, Antoine Chambert-Loir
+-/
+
+import Mathlib.GroupTheory.Subgroup.Basic
+import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Data.Set.Card
+
+/-!  Subgroup of `Equiv.Perm α` preserving a fibration `p : α → ι`
+
+Let `α` and `ι` by types.
+We consider `arrowAction : MulAction (Equiv.Perm α) (α → ι)`.
+
+* `arrowAction.mem_stabilizer_iff` proves that the stabilizer
+  of `Equiv.Perm α` of `p : α → ι` is the subgroup of `g : Equiv.Perm α`
+  such that `p ∘ g = p`.
+
+* `arrowAction.stabilizerMulEquiv` is the `MulEquiv` between this stabilizer and
+  the product, for `i : ι`, of `Equiv.Perm {a | p a = i}`.
+
+-/
+
+variable {α ι : Type*} {p : α → ι}
+
+open Equiv MulAction
+
+local instance  : MulAction (Equiv.Perm α) (α → ι) := arrowAction
+
+namespace arrowAction
+
+lemma mem_stabilizer_iff {g : Perm α} :
+    g ∈ stabilizer (Perm α) p ↔ p ∘ g = p := by rw [eq_comm, ← g.comp_symm_eq]; rfl
+
+/-- The `invFun` component of `MulEquiv` from `MulAction.stabilizer (Perm α) p`
+  to the product of the `Equiv.Perm {a | p a = i} -/
+def stabilizerEquiv_invFun (g : ∀ i, Perm {a | p a = i}) (a : α) : α := g (p a) ⟨a, rfl⟩
+
+lemma stabilizerEquiv_invFun_eq (g : ∀ i, Perm {a | p a = i}) {a : α} {i : ι} (h : p a = i) :
+    stabilizerEquiv_invFun g a = g i ⟨a, h⟩ := by subst h; rfl
+
+lemma comp_stabilizerEquiv_invFun (g : ∀ i, Perm {a | p a = i}) (a : α) :
+    p (stabilizerEquiv_invFun g a) = p a :=
+  (g (p a) ⟨a, rfl⟩).prop
+
+/-- The `invFun` component of `MulEquiv` from `MulAction.stabilizer (Perm α) p`
+  to the product of the `Equiv.Perm {a | p a = i} (as an `Equiv.Perm α`) -/
+def stabilizerEquiv_invFun_aux (g : ∀ i, Perm {a | p a = i}) : Perm α where
+  toFun := stabilizerEquiv_invFun g
+  invFun := stabilizerEquiv_invFun (fun i ↦ (g i).symm)
+  left_inv a := by
+    rw [stabilizerEquiv_invFun_eq _ (comp_stabilizerEquiv_invFun g a)]
+    exact congr_arg Subtype.val ((g <| p a).left_inv _)
+  right_inv a := by
+    rw [stabilizerEquiv_invFun_eq _ (comp_stabilizerEquiv_invFun _ a)]
+    exact congr_arg Subtype.val ((g <| p a).right_inv _)
+
+variable (p)
+
+/-- The `MulEquiv` from `MulAction.stabilizer (Perm α) p`
+  to the product of the `Equiv.Perm {a | p a = i} -/
+def stabilizerMulEquiv : stabilizer (Perm α) p ≃* (∀ i, Perm {a | p a = i}) where
+  toFun g i := Perm.subtypePerm g fun a ↦ by
+    simp only [Set.mem_setOf_eq]
+    rw [← Function.comp_apply (f := p), arrowAction.mem_stabilizer_iff.mp g.prop]
+  invFun g := ⟨stabilizerEquiv_invFun_aux g, by
+    ext a; exact comp_stabilizerEquiv_invFun (fun i ↦ (g i).symm) a⟩
+  left_inv g := rfl
+  right_inv g := by ext i a; apply stabilizerEquiv_invFun_eq
+  map_mul' g h := rfl
+
+lemma stabilizerMulEquiv_apply (g : stabilizer (Perm α) p) {a : α} {i : ι} (h : p a = i) :
+  (stabilizerMulEquiv p) g i ⟨a, h⟩ = (g : Equiv.Perm α) a := rfl
+
+end arrowAction

--- a/Mathlib/GroupTheory/Perm/ArrowAction.lean
+++ b/Mathlib/GroupTheory/Perm/ArrowAction.lean
@@ -19,7 +19,7 @@ Let `α` and `ι` by types.
 
 * `DomMulAct.stabilizerMulEquiv` is the `MulEquiv` from
   the MulOpposite of this stabilizer to the product,
-  for `i : ι`, of `Equiv.Perm {a | p a = i}`.
+  for `i : ι`, of `Equiv.Perm {a // p a = i}`.
 
 -/
 
@@ -34,19 +34,19 @@ lemma mem_stabilizer_iff {g : DomMulAct (Perm α)} :
   simp only [MulAction.mem_stabilizer_iff]; rfl
 
 /-- The `invFun` component of `MulEquiv` from `MulAction.stabilizer (Perm α) p`
-  to the product of the `Equiv.Perm {a | p a = i} -/
-def stabilizerEquiv_invFun (g : ∀ i, Perm {a | p a = i}) (a : α) : α := g (p a) ⟨a, rfl⟩
+  to the product of the `Equiv.Perm {a // p a = i} -/
+def stabilizerEquiv_invFun (g : ∀ i, Perm {a // p a = i}) (a : α) : α := g (p a) ⟨a, rfl⟩
 
-lemma stabilizerEquiv_invFun_eq (g : ∀ i, Perm {a | p a = i}) {a : α} {i : ι} (h : p a = i) :
+lemma stabilizerEquiv_invFun_eq (g : ∀ i, Perm {a // p a = i}) {a : α} {i : ι} (h : p a = i) :
     stabilizerEquiv_invFun g a = g i ⟨a, h⟩ := by subst h; rfl
 
-lemma comp_stabilizerEquiv_invFun (g : ∀ i, Perm {a | p a = i}) (a : α) :
+lemma comp_stabilizerEquiv_invFun (g : ∀ i, Perm {a // p a = i}) (a : α) :
     p (stabilizerEquiv_invFun g a) = p a :=
   (g (p a) ⟨a, rfl⟩).prop
 
 /-- The `invFun` component of `MulEquiv` from `MulAction.stabilizer (Perm α) p`
   to the product of the `Equiv.Perm {a | p a = i} (as an `Equiv.Perm α`) -/
-def stabilizerEquiv_invFun_aux (g : ∀ i, Perm {a | p a = i}) : Perm α where
+def stabilizerEquiv_invFun_aux (g : ∀ i, Perm {a // p a = i}) : Perm α where
   toFun := stabilizerEquiv_invFun g
   invFun := stabilizerEquiv_invFun (fun i ↦ (g i).symm)
   left_inv a := by
@@ -59,10 +59,9 @@ def stabilizerEquiv_invFun_aux (g : ∀ i, Perm {a | p a = i}) : Perm α where
 variable (p)
 
 /-- The `MulEquiv` from the `MulOpposite` of `MulAction.stabilizer (DomMulAct (Perm α)) p`
-  to the product of the `Equiv.Perm {a | p a = i} -/
-def stabilizerMulEquiv : (stabilizer (DomMulAct (Perm α)) p)ᵐᵒᵖ ≃* (∀ i, Perm {a | p a = i}) where
+  to the product of the `Equiv.Perm {a // p a = i}` -/
+def stabilizerMulEquiv : (stabilizer (DomMulAct (Perm α)) p)ᵐᵒᵖ ≃* (∀ i, Perm {a // p a = i}) where
   toFun g i := Perm.subtypePerm (DomMulAct.mk.symm g.unop) fun a ↦ by
-    simp only [Set.mem_setOf_eq]
     rw [← Function.comp_apply (f := p), DomMulAct.mem_stabilizer_iff.mp g.unop.prop]
   invFun g := ⟨DomMulAct.mk (stabilizerEquiv_invFun_aux g), by
     ext a

--- a/Mathlib/GroupTheory/Perm/ArrowAction.lean
+++ b/Mathlib/GroupTheory/Perm/ArrowAction.lean
@@ -26,6 +26,7 @@ variable {α ι : Type*} {p : α → ι}
 
 open Equiv MulAction
 
+/-- The natural `MulAction` of `Equiv.Perm α` on `α → ι` -/
 local instance  : MulAction (Equiv.Perm α) (α → ι) := arrowAction
 
 namespace arrowAction

--- a/Mathlib/GroupTheory/Perm/ArrowAction.lean
+++ b/Mathlib/GroupTheory/Perm/ArrowAction.lean
@@ -71,6 +71,6 @@ def stabilizerMulEquiv : stabilizer (Perm α) p ≃* (∀ i, Perm {a | p a = i})
   map_mul' g h := rfl
 
 lemma stabilizerMulEquiv_apply (g : stabilizer (Perm α) p) {a : α} {i : ι} (h : p a = i) :
-   ((stabilizerMulEquiv p)) g i ⟨a, h⟩ = (g : Equiv.Perm α) a := rfl
+    ((stabilizerMulEquiv p)) g i ⟨a, h⟩ = (g : Equiv.Perm α) a := rfl
 
 end arrowAction

--- a/Mathlib/GroupTheory/Perm/ArrowAction.lean
+++ b/Mathlib/GroupTheory/Perm/ArrowAction.lean
@@ -29,8 +29,8 @@ open Equiv MulAction
 
 namespace DomMulAct
 
-lemma mem_stabilizer_iff {g : DomMulAct (Perm α)} :
-    g ∈ stabilizer (DomMulAct (Perm α)) p ↔ p ∘ (DomMulAct.mk.symm g :) = p := by
+lemma mem_stabilizer_iff {g : (Perm α)ᵈᵐᵃ} :
+    g ∈ stabilizer (Perm α)ᵈᵐᵃ p ↔ p ∘ (mk.symm g :) = p := by
   simp only [MulAction.mem_stabilizer_iff]; rfl
 
 /-- The `invFun` component of `MulEquiv` from `MulAction.stabilizer (Perm α) p`
@@ -58,12 +58,12 @@ def stabilizerEquiv_invFun_aux (g : ∀ i, Perm {a // p a = i}) : Perm α where
 
 variable (p)
 
-/-- The `MulEquiv` from the `MulOpposite` of `MulAction.stabilizer (DomMulAct (Perm α)) p`
+/-- The `MulEquiv` from the `MulOpposite` of `MulAction.stabilizer (Perm α)ᵈᵐᵃ p`
   to the product of the `Equiv.Perm {a // p a = i}` -/
-def stabilizerMulEquiv : (stabilizer (DomMulAct (Perm α)) p)ᵐᵒᵖ ≃* (∀ i, Perm {a // p a = i}) where
-  toFun g i := Perm.subtypePerm (DomMulAct.mk.symm g.unop) fun a ↦ by
-    rw [← Function.comp_apply (f := p), DomMulAct.mem_stabilizer_iff.mp g.unop.prop]
-  invFun g := ⟨DomMulAct.mk (stabilizerEquiv_invFun_aux g), by
+def stabilizerMulEquiv : (stabilizer (Perm α)ᵈᵐᵃ p)ᵐᵒᵖ ≃* (∀ i, Perm {a // p a = i}) where
+  toFun g i := Perm.subtypePerm (mk.symm g.unop) fun a ↦ by
+    rw [← Function.comp_apply (f := p), mem_stabilizer_iff.mp g.unop.prop]
+  invFun g := ⟨mk (stabilizerEquiv_invFun_aux g), by
     ext a
     rw [smul_apply, symm_apply_apply, Perm.smul_def]
     apply comp_stabilizerEquiv_invFun⟩
@@ -71,7 +71,7 @@ def stabilizerMulEquiv : (stabilizer (DomMulAct (Perm α)) p)ᵐᵒᵖ ≃* (∀
   right_inv g := by ext i a; apply stabilizerEquiv_invFun_eq
   map_mul' g h := by rfl
 
-lemma stabilizerMulEquiv_apply (g : (stabilizer (DomMulAct (Perm α)) p)ᵐᵒᵖ) {a : α} {i : ι} (h : p a = i) :
-    ((stabilizerMulEquiv p)) g i ⟨a, h⟩ = (DomMulAct.mk.symm g.unop : Equiv.Perm α) a := rfl
+lemma stabilizerMulEquiv_apply (g : (stabilizer (Perm α)ᵈᵐᵃ p)ᵐᵒᵖ) {a : α} {i : ι} (h : p a = i) :
+    ((stabilizerMulEquiv p)) g i ⟨a, h⟩ = (mk.symm g.unop : Equiv.Perm α) a := rfl
 
 end DomMulAct

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -79,7 +79,7 @@ def stabilizerMulEquiv : (stabilizer (Perm α)ᵈᵐᵃ f)ᵐᵒᵖ ≃* (∀ i,
     apply comp_stabilizerEquiv_invFun⟩
   left_inv g := rfl
   right_inv g := by ext i a; apply stabilizerEquiv_invFun_eq
-  map_mul' g h := by rfl
+  map_mul' g h := rfl
 
 variable {f}
 
@@ -98,14 +98,11 @@ variable (f)
 theorem stabilizer_card:
     Fintype.card {g : Perm α // f ∘ g = f} = ∏ i, (Fintype.card {a // f a = i})! := by
   -- rewriting via Nat.card because Fintype instance is not found
-  rw [← Nat.card_eq_fintype_card, Nat.card_congr (subtypeEquiv mk ?_),
+  rw [← Nat.card_eq_fintype_card, Nat.card_congr (subtypeEquiv mk fun _ ↦ ?_),
     Nat.card_congr MulOpposite.opEquiv,
     Nat.card_congr (DomMulAct.stabilizerMulEquiv f).toEquiv, Nat.card_pi]
-  apply Finset.prod_congr rfl
-  intro i _
-  rw [Nat.card_eq_fintype_card, Fintype.card_perm, Nat.card_eq_fintype_card.symm]
-  · intro g
-    rw [DomMulAct.mem_stabilizer_iff, symm_apply_apply]
+  · exact Finset.prod_congr rfl fun i _ ↦ by rw [Nat.card_eq_fintype_card, Fintype.card_perm]
+  · rfl
 
 end Fintype
 

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -29,8 +29,7 @@ Let `α` and `ι` by types and let `f : α → ι`
 
 * Under `Fintype α` and `Fintype ι`, `DomMulAct.stabilizer_card p` computes
   the cardinality of the type of permutations preserving `p` :
-  `Fintype.card {g : Perm α // f ∘ g = f} =
-    ∏ i, (Fintype.card {a // f a = i}).factorial `
+  `Fintype.card {g : Perm α // f ∘ g = f} = ∏ i, (Fintype.card {a // f a = i})!`.
 
 -/
 
@@ -91,14 +90,13 @@ section Fintype
 
 variable [Fintype α] [Fintype ι] [DecidableEq α] [DecidableEq ι]
 
-open BigOperators
+open BigOperators Nat
 
 variable (f)
 
 /-- The cardinality of the type of permutations preserving a function -/
 theorem stabilizer_card:
-    Fintype.card {g : Perm α // f ∘ g = f} =
-      ∏ i , (Fintype.card ({a // f a = i})).factorial := by
+    Fintype.card {g : Perm α // f ∘ g = f} = ∏ i, (Fintype.card {a // f a = i})! := by
   -- rewriting via Nat.card because Fintype instance is not found
   rw [← Nat.card_eq_fintype_card, Nat.card_congr (subtypeEquiv mk ?_),
     Nat.card_congr MulOpposite.opEquiv,

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -29,8 +29,8 @@ Let `α` and `ι` by types and let `p : α → ι`
 
 * Under `Fintype α` and `Fintype ι`, `DomMulAct.stabilizer_card p` computes
   the cardinality of the type of permutations preserving `p` :
-  `Nat.card {f : Perm α // p ∘ f = p} =
-    Finset.univ.prod fun i => (Nat.card {a // p a = i}).factorial `
+  `Fintype.card {f : Perm α // p ∘ f = p} =
+    ∏ i, (Fintype.card {a // p a = i}).factorial `
 
 -/
 
@@ -90,12 +90,15 @@ lemma stabilizerMulEquiv_apply (g : (stabilizer (Perm α)ᵈᵐᵃ p)ᵐᵒᵖ) 
 section Fintype
 
 variable [Fintype α] [Fintype ι] [DecidableEq α] [DecidableEq ι]
+open BigOperators
 
 /-- The cardinality of the type of permutations preserving a function -/
 theorem stabilizer_card:
-    Nat.card {f : Perm α // p ∘ f = p} =
-      Finset.univ.prod fun i => (Nat.card {a // p a = i}).factorial := by
-  rw [Nat.card_congr (subtypeEquiv mk ?_), Nat.card_congr MulOpposite.opEquiv,
+    Fintype.card {f : Perm α // p ∘ f = p} =
+      ∏ i , (Fintype.card ({a // p a = i})).factorial := by
+  -- rewriting via Nat.card because Fintype instance is not found
+  rw [← Nat.card_eq_fintype_card, Nat.card_congr (subtypeEquiv mk ?_),
+    Nat.card_congr MulOpposite.opEquiv,
     Nat.card_congr (DomMulAct.stabilizerMulEquiv p).toEquiv, Nat.card_pi]
   apply Finset.prod_congr rfl
   intro i _

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -15,65 +15,65 @@ import Mathlib.Data.Fintype.Perm
 
 /-!  Subgroup of `Equiv.Perm α` preserving a function
 
-Let `α` and `ι` by types and let `p : α → ι`
+Let `α` and `ι` by types and let `f : α → ι`
 
-* `DomMulAct.mem_stabilizer_iff` proves that the stabilizer of `p : α → ι`
-  in `(Equiv.Perm α)ᵈᵐᵃ` is the set of `g : (Equiv.Perm α)ᵈᵐᵃ` such that `p ∘ (mk.symm g) = p`.
+* `DomMulAct.mem_stabilizer_iff` proves that the stabilizer of `f : α → ι`
+  in `(Equiv.Perm α)ᵈᵐᵃ` is the set of `g : (Equiv.Perm α)ᵈᵐᵃ` such that `f ∘ (mk.symm g) = f`.
 
-  The natural equivalence from `stabilizer (Perm α)ᵈᵐᵃ p` to `{ g : Perm α // p ∘ g = p }`
+  The natural equivalence from `stabilizer (Perm α)ᵈᵐᵃ f` to `{ g : Perm α // p ∘ g = f }`
   can be obtained as `subtypeEquiv mk.symm (fun _ => mem_stabilizer_iff)`
 
 * `DomMulAct.stabilizerMulEquiv` is the `MulEquiv` from
   the MulOpposite of this stabilizer to the product,
-  for `i : ι`, of `Equiv.Perm {a // p a = i}`.
+  for `i : ι`, of `Equiv.Perm {a // f a = i}`.
 
 * Under `Fintype α` and `Fintype ι`, `DomMulAct.stabilizer_card p` computes
   the cardinality of the type of permutations preserving `p` :
-  `Fintype.card {f : Perm α // p ∘ f = p} =
-    ∏ i, (Fintype.card {a // p a = i}).factorial `
+  `Fintype.card {g : Perm α // f ∘ g = f} =
+    ∏ i, (Fintype.card {a // f a = i}).factorial `
 
 -/
 
-variable {α ι : Type*} {p : α → ι}
+variable {α ι : Type*} {f : α → ι}
 
 open Equiv MulAction
 
 namespace DomMulAct
 
 lemma mem_stabilizer_iff {g : (Perm α)ᵈᵐᵃ} :
-    g ∈ stabilizer (Perm α)ᵈᵐᵃ p ↔ p ∘ (mk.symm g :) = p := by
+    g ∈ stabilizer (Perm α)ᵈᵐᵃ f ↔ f ∘ (mk.symm g :) = f := by
   simp only [MulAction.mem_stabilizer_iff]; rfl
 
-/-- The `invFun` component of `MulEquiv` from `MulAction.stabilizer (Perm α) p`
-  to the product of the `Equiv.Perm {a // p a = i} -/
-def stabilizerEquiv_invFun (g : ∀ i, Perm {a // p a = i}) (a : α) : α := g (p a) ⟨a, rfl⟩
+/-- The `invFun` component of `MulEquiv` from `MulAction.stabilizer (Perm α) f`
+  to the product of the `Equiv.Perm {a // f a = i} -/
+def stabilizerEquiv_invFun (g : ∀ i, Perm {a // f a = i}) (a : α) : α := g (f a) ⟨a, rfl⟩
 
-lemma stabilizerEquiv_invFun_eq (g : ∀ i, Perm {a // p a = i}) {a : α} {i : ι} (h : p a = i) :
+lemma stabilizerEquiv_invFun_eq (g : ∀ i, Perm {a // f a = i}) {a : α} {i : ι} (h : f a = i) :
     stabilizerEquiv_invFun g a = g i ⟨a, h⟩ := by subst h; rfl
 
-lemma comp_stabilizerEquiv_invFun (g : ∀ i, Perm {a // p a = i}) (a : α) :
-    p (stabilizerEquiv_invFun g a) = p a :=
-  (g (p a) ⟨a, rfl⟩).prop
+lemma comp_stabilizerEquiv_invFun (g : ∀ i, Perm {a // f a = i}) (a : α) :
+    f (stabilizerEquiv_invFun g a) = f a :=
+  (g (f a) ⟨a, rfl⟩).prop
 
 /-- The `invFun` component of `MulEquiv` from `MulAction.stabilizer (Perm α) p`
-  to the product of the `Equiv.Perm {a | p a = i} (as an `Equiv.Perm α`) -/
-def stabilizerEquiv_invFun_aux (g : ∀ i, Perm {a // p a = i}) : Perm α where
+  to the product of the `Equiv.Perm {a | f a = i} (as an `Equiv.Perm α`) -/
+def stabilizerEquiv_invFun_aux (g : ∀ i, Perm {a // f a = i}) : Perm α where
   toFun := stabilizerEquiv_invFun g
   invFun := stabilizerEquiv_invFun (fun i ↦ (g i).symm)
   left_inv a := by
     rw [stabilizerEquiv_invFun_eq _ (comp_stabilizerEquiv_invFun g a)]
-    exact congr_arg Subtype.val ((g <| p a).left_inv _)
+    exact congr_arg Subtype.val ((g <| f a).left_inv _)
   right_inv a := by
     rw [stabilizerEquiv_invFun_eq _ (comp_stabilizerEquiv_invFun _ a)]
-    exact congr_arg Subtype.val ((g <| p a).right_inv _)
+    exact congr_arg Subtype.val ((g <| f a).right_inv _)
 
-variable (p)
+variable (f)
 
-/-- The `MulEquiv` from the `MulOpposite` of `MulAction.stabilizer (Perm α)ᵈᵐᵃ p`
-  to the product of the `Equiv.Perm {a // p a = i}` -/
-def stabilizerMulEquiv : (stabilizer (Perm α)ᵈᵐᵃ p)ᵐᵒᵖ ≃* (∀ i, Perm {a // p a = i}) where
+/-- The `MulEquiv` from the `MulOpposite` of `MulAction.stabilizer (Perm α)ᵈᵐᵃ f`
+  to the product of the `Equiv.Perm {a // f a = i}` -/
+def stabilizerMulEquiv : (stabilizer (Perm α)ᵈᵐᵃ f)ᵐᵒᵖ ≃* (∀ i, Perm {a // f a = i}) where
   toFun g i := Perm.subtypePerm (mk.symm g.unop) fun a ↦ by
-    rw [← Function.comp_apply (f := p), mem_stabilizer_iff.mp g.unop.prop]
+    rw [← Function.comp_apply (f := f), mem_stabilizer_iff.mp g.unop.prop]
   invFun g := ⟨mk (stabilizerEquiv_invFun_aux g), by
     ext a
     rw [smul_apply, symm_apply_apply, Perm.smul_def]
@@ -82,10 +82,10 @@ def stabilizerMulEquiv : (stabilizer (Perm α)ᵈᵐᵃ p)ᵐᵒᵖ ≃* (∀ i,
   right_inv g := by ext i a; apply stabilizerEquiv_invFun_eq
   map_mul' g h := by rfl
 
-variable {p}
+variable {f}
 
-lemma stabilizerMulEquiv_apply (g : (stabilizer (Perm α)ᵈᵐᵃ p)ᵐᵒᵖ) {a : α} {i : ι} (h : p a = i) :
-    ((stabilizerMulEquiv p)) g i ⟨a, h⟩ = (mk.symm g.unop : Equiv.Perm α) a := rfl
+lemma stabilizerMulEquiv_apply (g : (stabilizer (Perm α)ᵈᵐᵃ f)ᵐᵒᵖ) {a : α} {i : ι} (h : f a = i) :
+    ((stabilizerMulEquiv f)) g i ⟨a, h⟩ = (mk.symm g.unop : Equiv.Perm α) a := rfl
 
 section Fintype
 
@@ -93,16 +93,16 @@ variable [Fintype α] [Fintype ι] [DecidableEq α] [DecidableEq ι]
 
 open BigOperators
 
-variable (p)
+variable (f)
 
 /-- The cardinality of the type of permutations preserving a function -/
 theorem stabilizer_card:
-    Fintype.card {f : Perm α // p ∘ f = p} =
-      ∏ i , (Fintype.card ({a // p a = i})).factorial := by
+    Fintype.card {g : Perm α // f ∘ g = f} =
+      ∏ i , (Fintype.card ({a // f a = i})).factorial := by
   -- rewriting via Nat.card because Fintype instance is not found
   rw [← Nat.card_eq_fintype_card, Nat.card_congr (subtypeEquiv mk ?_),
     Nat.card_congr MulOpposite.opEquiv,
-    Nat.card_congr (DomMulAct.stabilizerMulEquiv p).toEquiv, Nat.card_pi]
+    Nat.card_congr (DomMulAct.stabilizerMulEquiv f).toEquiv, Nat.card_pi]
   apply Finset.prod_congr rfl
   intro i _
   rw [Nat.card_eq_fintype_card, Fintype.card_perm, Nat.card_eq_fintype_card.symm]

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -7,19 +7,31 @@ Authors: Junyan Xu, Antoine Chambert-Loir
 import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 import Mathlib.GroupTheory.Subgroup.Basic
 import Mathlib.GroupTheory.GroupAction.Basic
--- import Mathlib.Data.Set.Card
 
-/-!  Subgroup of `Equiv.Perm α` preserving a function `p : α → ι`
+import Mathlib.Data.Set.Card
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Perm
 
-Let `α` and `ι` by types.
+
+/-!  Subgroup of `Equiv.Perm α` preserving a function
+
+Let `α` and `ι` by types and let `p : α → ι`
 
 * `DomMulAct.mem_stabilizer_iff` proves that the stabilizer
   of `Equiv.Perm α` of `p : α → ι` is the subgroup of `g : Equiv.Perm α`
   such that `p ∘ g = p`.
 
+  The natural equivalence from `stabilizer (Perm α)ᵈᵐᵃ p` to `{ g : Perm α // p ∘ g = p }`
+  can be obtained as `subtypeEquiv mk.symm (fun _ => mem_stabilizer_iff)`
+
 * `DomMulAct.stabilizerMulEquiv` is the `MulEquiv` from
   the MulOpposite of this stabilizer to the product,
   for `i : ι`, of `Equiv.Perm {a // p a = i}`.
+
+* Under `Fintype α` and `Fintype ι`, `DomMulAct.stabilizer_card p` computes
+  the cardinality of the type of permutations preserving `p` :
+  `Nat.card {f : Perm α // p ∘ f = p} =
+    Finset.univ.prod fun i => (Nat.card {a // p a = i}).factorial `
 
 -/
 
@@ -71,7 +83,27 @@ def stabilizerMulEquiv : (stabilizer (Perm α)ᵈᵐᵃ p)ᵐᵒᵖ ≃* (∀ i,
   right_inv g := by ext i a; apply stabilizerEquiv_invFun_eq
   map_mul' g h := by rfl
 
+variable {p}
+
 lemma stabilizerMulEquiv_apply (g : (stabilizer (Perm α)ᵈᵐᵃ p)ᵐᵒᵖ) {a : α} {i : ι} (h : p a = i) :
     ((stabilizerMulEquiv p)) g i ⟨a, h⟩ = (mk.symm g.unop : Equiv.Perm α) a := rfl
+
+section Fintype
+
+variable [Fintype α] [Fintype ι] [DecidableEq α] [DecidableEq ι]
+
+/-- The cardinality of the type of permutations preserving a function -/
+theorem stabilizer_card:
+    Nat.card {f : Perm α // p ∘ f = p} =
+      Finset.univ.prod fun i => (Nat.card {a // p a = i}).factorial := by
+  rw [Nat.card_congr (subtypeEquiv mk ?_), Nat.card_congr MulOpposite.opEquiv,
+    Nat.card_congr (DomMulAct.stabilizerMulEquiv p).toEquiv, Nat.card_pi]
+  apply Finset.prod_congr rfl
+  intro i _
+  rw [Nat.card_eq_fintype_card, Fintype.card_perm, Nat.card_eq_fintype_card.symm]
+  · intro g
+    rw [DomMulAct.mem_stabilizer_iff, symm_apply_apply]
+
+end Fintype
 
 end DomMulAct

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -90,7 +90,10 @@ lemma stabilizerMulEquiv_apply (g : (stabilizer (Perm α)ᵈᵐᵃ p)ᵐᵒᵖ) 
 section Fintype
 
 variable [Fintype α] [Fintype ι] [DecidableEq α] [DecidableEq ι]
+
 open BigOperators
+
+variable (p)
 
 /-- The cardinality of the type of permutations preserving a function -/
 theorem stabilizer_card:

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -17,9 +17,8 @@ import Mathlib.Data.Fintype.Perm
 
 Let `α` and `ι` by types and let `p : α → ι`
 
-* `DomMulAct.mem_stabilizer_iff` proves that the stabilizer
-  of `Equiv.Perm α` of `p : α → ι` is the subgroup of `g : Equiv.Perm α`
-  such that `p ∘ g = p`.
+* `DomMulAct.mem_stabilizer_iff` proves that the stabilizer of `p : α → ι`
+  in `(Equiv.Perm α)ᵈᵐᵃ` is the set of `g : (Equiv.Perm α)ᵈᵐᵃ` such that `p ∘ (mk.symm g) = p`.
 
   The natural equivalence from `stabilizer (Perm α)ᵈᵐᵃ p` to `{ g : Perm α // p ∘ g = p }`
   can be obtained as `subtypeEquiv mk.symm (fun _ => mem_stabilizer_iff)`


### PR DESCRIPTION
Subgroup of `Equiv.Perm α` preserving a function

Let `α` and `ι` by types and let `p : α → ι`

* `DomMulAct.mem_stabilizer_iff` proves that the stabilizer of `p : α → ι`
  in `(Equiv.Perm α)ᵈᵐᵃ` is the set of `g : (Equiv.Perm α)ᵈᵐᵃ` such that `p ∘ (mk.symm g) = p`.

  The natural equivalence from `stabilizer (Perm α)ᵈᵐᵃ p` to `{ g : Perm α // p ∘ g = p }`
  can be obtained as `subtypeEquiv mk.symm (fun _ => mem_stabilizer_iff)`

* `DomMulAct.stabilizerMulEquiv` is the `MulEquiv` from
  the MulOpposite of this stabilizer to the product,
  for `i : ι`, of `Equiv.Perm {a // p a = i}`.

* Under `Fintype α` and `Fintype ι`, `DomMulAct.stabilizer_card p` computes
  the cardinality of the type of permutations preserving `p` :
  `Fintype.card {f : Perm α // p ∘ f = p} =
      ∏ i , (Fintype.card ({a // p a = i})).factorial`

Co-Authored by : Junyan Xu <junyanxu.math@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This was written by Junyan Xu after a request on Zulip, https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/permutations.20preserving.20a.20function/near/391930331

It appeared again in 
https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Cardinality.20of.20permutation/near/410241414


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
