### PR TITLE
feat: assumption?

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3419,6 +3419,7 @@ import Mathlib.Tactic.ToAdditive
 import Mathlib.Tactic.ToExpr
 import Mathlib.Tactic.ToLevel
 import Mathlib.Tactic.Trace
+import Mathlib.Tactic.TryAssumption
 import Mathlib.Tactic.TryThis
 import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.UnsetOption

--- a/Mathlib/Algebra/Homology/ExactSequence.lean
+++ b/Mathlib/Algebra/Homology/ExactSequence.lean
@@ -235,7 +235,7 @@ for a use of this lemma. -/
 lemma exact_of_δ₀ {S : ComposableArrows C (n + 2)}
     (h : (mk₂ (S.map' 0 1) (S.map' 1 2)).Exact) (h₀ : S.δ₀.Exact) : S.Exact := by
   rw [exact_iff_δ₀]
-  constructor <;> assumption?
+  constructor <;> assumption
 
 lemma exact_iff_δlast {n : ℕ} (S : ComposableArrows C (n + 2)) :
     S.Exact ↔ S.δlast.Exact ∧ (mk₂ (S.map' n (n + 1)) (S.map' (n + 1) (n + 2))).Exact := by

--- a/Mathlib/Algebra/Homology/ExactSequence.lean
+++ b/Mathlib/Algebra/Homology/ExactSequence.lean
@@ -235,7 +235,7 @@ for a use of this lemma. -/
 lemma exact_of_δ₀ {S : ComposableArrows C (n + 2)}
     (h : (mk₂ (S.map' 0 1) (S.map' 1 2)).Exact) (h₀ : S.δ₀.Exact) : S.Exact := by
   rw [exact_iff_δ₀]
-  constructor <;> assumption
+  constructor <;> assumption?
 
 lemma exact_iff_δlast {n : ℕ} (S : ComposableArrows C (n + 2)) :
     S.Exact ↔ S.δlast.Exact ∧ (mk₂ (S.map' n (n + 1)) (S.map' (n + 1) (n + 2))).Exact := by

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -169,6 +169,7 @@ import Mathlib.Tactic.ToAdditive
 import Mathlib.Tactic.ToExpr
 import Mathlib.Tactic.ToLevel
 import Mathlib.Tactic.Trace
+import Mathlib.Tactic.TryAssumption
 import Mathlib.Tactic.TryThis
 import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.UnsetOption

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -98,6 +98,7 @@ import Mathlib.Tactic.TermCongr
 import Mathlib.Tactic.ToExpr
 import Mathlib.Tactic.ToLevel
 import Mathlib.Tactic.Trace
+import Mathlib.Tactic.TryAssumption
 import Mathlib.Tactic.TryThis
 import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.UnsetOption

--- a/Mathlib/Tactic/TryAssumption.lean
+++ b/Mathlib/Tactic/TryAssumption.lean
@@ -5,5 +5,17 @@ Authors: Alex J. Best
 -/
 import Std.Tactic.ShowTerm
 
+/-!
+# A helper macro for replacing assumptions with exact statements
+
+## Summary
+
+This file adds a `assumption?` macro that expands to `show_term assumption`
+the goal is to make it more efficient to clean up proofs with `assumption`s in by making them
+more explicit.
+
+-/
+
+
 /-- `assumption?` is equivalent to `show_term assumption` -/
 macro "assumption?" : tactic => `(tactic| show_term assumption)

--- a/Mathlib/Tactic/TryAssumption.lean
+++ b/Mathlib/Tactic/TryAssumption.lean
@@ -1,0 +1,9 @@
+/-
+Copyright (c) 2023 Alex J. Best. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex J. Best
+-/
+import Std.Tactic.ShowTerm
+
+/-- `assumption?` is equivalent to `show_term assumption` -/
+macro "assumption?" : tactic => `(tactic| show_term assumption)


### PR DESCRIPTION
A little helper for replacing `assumption`s with `exact` statements quickly

---
If this is approved I will add tests

This begs the question of whether it might simply be better to add some sort of code action for "replace with trythis output"

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
