### PR TITLE
[Merged by Bors] - chore: Generalise monotonicity of multiplication lemmas to semirings

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -205,6 +205,7 @@ import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.Group.WithOne.Units
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.GroupPower.CovariantClass
+import Mathlib.Algebra.GroupPower.Hom
 import Mathlib.Algebra.GroupPower.Identities
 import Mathlib.Algebra.GroupPower.IterateHom
 import Mathlib.Algebra.GroupPower.Lemmas

--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Amelia Livingston, Yury Kudryashov,
 Neil Strickland, Aaron Anderson
 -/
-import Mathlib.Algebra.Group.Basic
+import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.Group.Hom.Defs
 
 #align_import algebra.divisibility.basic from "leanprover-community/mathlib"@"e8638a0fcaf73e4500469f368ef9494e495099b3"
@@ -115,8 +115,7 @@ end map_dvd
 end Semigroup
 
 section Monoid
-
-variable [Monoid α] {a b : α}
+variable [Monoid α] {a b : α} {m n : ℕ}
 
 @[refl, simp]
 theorem dvd_refl (a : α) : a ∣ a :=
@@ -138,6 +137,10 @@ theorem dvd_of_eq (h : a = b) : a ∣ b := by rw [h]
 
 alias Eq.dvd := dvd_of_eq
 #align eq.dvd Eq.dvd
+
+lemma pow_dvd_pow (a : α) (h : m ≤ n) : a ^ m ∣ a ^ n :=
+  ⟨a ^ (n - m), by rw [← pow_add, Nat.add_comm, Nat.sub_add_cancel h]⟩
+#align pow_dvd_pow pow_dvd_pow
 
 lemma dvd_pow (hab : a ∣ b) : ∀ {n : ℕ} (_ : n ≠ 0), a ∣ b ^ n
   | 0,     hn => (hn rfl).elim

--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -139,6 +139,16 @@ theorem dvd_of_eq (h : a = b) : a ∣ b := by rw [h]
 alias Eq.dvd := dvd_of_eq
 #align eq.dvd Eq.dvd
 
+lemma dvd_pow (hab : a ∣ b) : ∀ {n : ℕ} (_ : n ≠ 0), a ∣ b ^ n
+  | 0,     hn => (hn rfl).elim
+  | n + 1, _  => by rw [pow_succ]; exact hab.mul_right _
+#align dvd_pow dvd_pow
+
+alias Dvd.dvd.pow := dvd_pow
+
+lemma dvd_pow_self (a : α) {n : ℕ} (hn : n ≠ 0) : a ∣ a ^ n := dvd_rfl.pow hn
+#align dvd_pow_self dvd_pow_self
+
 end Monoid
 
 section CommSemigroup

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Yury Kudryashov
 -/
 import Mathlib.Data.List.BigOperators.Basic
+import Mathlib.GroupTheory.GroupAction.Defs
 
 #align_import algebra.free_monoid.basic from "leanprover-community/mathlib"@"657df4339ae6ceada048c8a2980fb10e393143ec"
 

--- a/Mathlib/Algebra/GroupPower/Basic.lean
+++ b/Mathlib/Algebra/GroupPower/Basic.lean
@@ -429,10 +429,6 @@ theorem inv_pow_sub (a : G) {m n : ℕ} (h : n ≤ m) : a⁻¹ ^ (m - n) = (a ^ 
 
 end Group
 
-theorem pow_dvd_pow [Monoid R] (a : R) {m n : ℕ} (h : m ≤ n) : a ^ m ∣ a ^ n :=
-  ⟨a ^ (n - m), by rw [← pow_add, Nat.add_comm, Nat.sub_add_cancel h]⟩
-#align pow_dvd_pow pow_dvd_pow
-
 @[to_additive (attr := simp)]
 theorem SemiconjBy.zpow_right [Group G] {a x y : G} (h : SemiconjBy a x y) :
     ∀ m : ℤ, SemiconjBy a (x ^ m) (y ^ m)

--- a/Mathlib/Algebra/GroupPower/Basic.lean
+++ b/Mathlib/Algebra/GroupPower/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2015 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis
 -/
-import Mathlib.Algebra.Divisibility.Basic
 import Mathlib.Algebra.Group.Commute.Units
 import Mathlib.Algebra.Group.TypeTags
 
@@ -229,19 +228,6 @@ theorem pow_mul_pow_eq_one {a b : M} (n : ℕ) (h : a * b = 1) : a ^ n * b ^ n =
       _ = 1 := by simp [h, hn]
 #align pow_mul_pow_eq_one pow_mul_pow_eq_one
 #align nsmul_add_nsmul_eq_zero nsmul_add_nsmul_eq_zero
-
-theorem dvd_pow {x y : M} (hxy : x ∣ y) : ∀ {n : ℕ} (_ : n ≠ 0), x ∣ y ^ n
-  | 0,     hn => (hn rfl).elim
-  | n + 1, _  => by
-    rw [pow_succ]
-    exact hxy.mul_right _
-#align dvd_pow dvd_pow
-
-alias Dvd.dvd.pow := dvd_pow
-
-theorem dvd_pow_self (a : M) {n : ℕ} (hn : n ≠ 0) : a ∣ a ^ n :=
-  dvd_rfl.pow hn
-#align dvd_pow_self dvd_pow_self
 
 end Monoid
 

--- a/Mathlib/Algebra/GroupPower/Basic.lean
+++ b/Mathlib/Algebra/GroupPower/Basic.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis
 -/
 import Mathlib.Algebra.Group.Commute.Units
-import Mathlib.Algebra.Group.TypeTags
+import Mathlib.Algebra.GroupWithZero.Defs
+import Mathlib.Tactic.Convert
 
 #align_import algebra.group_power.basic from "leanprover-community/mathlib"@"9b2660e1b25419042c8da10bf411aa3c67f14383"
 
@@ -240,28 +241,13 @@ lemma eq_zero_or_one_of_sq_eq_self [CancelMonoidWithZero M] {x : M} (hx : x ^ 2 
 -/
 
 section CommMonoid
-
-variable [CommMonoid M] [AddCommMonoid A]
+variable [CommMonoid M]
 
 @[to_additive nsmul_add]
 theorem mul_pow (a b : M) (n : ℕ) : (a * b) ^ n = a ^ n * b ^ n :=
   (Commute.all a b).mul_pow n
 #align mul_pow mul_pow
 #align nsmul_add nsmul_add
-
-/-- The `n`th power map on a commutative monoid for a natural `n`, considered as a morphism of
-monoids. -/
-@[to_additive (attr := simps)
-      "Multiplication by a natural `n` on a commutative additive
-       monoid, considered as a morphism of additive monoids."]
-def powMonoidHom (n : ℕ) : M →* M where
-  toFun := (· ^ n)
-  map_one' := one_pow _
-  map_mul' a b := mul_pow a b n
-#align pow_monoid_hom powMonoidHom
-#align nsmul_add_monoid_hom nsmulAddMonoidHom
-#align pow_monoid_hom_apply powMonoidHom_apply
-#align nsmul_add_monoid_hom_apply nsmulAddMonoidHom_apply
 
 end CommMonoid
 
@@ -388,20 +374,6 @@ theorem div_zpow (a b : α) (n : ℤ) : (a / b) ^ n = a ^ n / b ^ n := by
   simp only [div_eq_mul_inv, mul_zpow, inv_zpow]
 #align div_zpow div_zpow
 #align zsmul_sub zsmul_sub
-
-/-- The `n`-th power map (for an integer `n`) on a commutative group, considered as a group
-homomorphism. -/
-@[to_additive (attr := simps)
-      "Multiplication by an integer `n` on a commutative additive group, considered as an
-       additive group homomorphism."]
-def zpowGroupHom (n : ℤ) : α →* α where
-  toFun := (· ^ n)
-  map_one' := one_zpow n
-  map_mul' a b := mul_zpow a b n
-#align zpow_group_hom zpowGroupHom
-#align zsmul_add_group_hom zsmulAddGroupHom
-#align zpow_group_hom_apply zpowGroupHom_apply
-#align zsmul_add_group_hom_apply zsmulAddGroupHom_apply
 
 end DivisionCommMonoid
 

--- a/Mathlib/Algebra/GroupPower/Hom.lean
+++ b/Mathlib/Algebra/GroupPower/Hom.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2021 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+import Mathlib.Algebra.GroupPower.Basic
+import Mathlib.Algebra.Group.Hom.Defs
+
+/-!
+# Power as a monoid hom
+-/
+
+variable {α : Type*}
+
+section CommMonoid
+variable [CommMonoid α]
+
+/-- The `n`th power map on a commutative monoid for a natural `n`, considered as a morphism of
+monoids. -/
+@[to_additive (attr := simps) "Multiplication by a natural `n` on a commutative additive monoid,
+considered as a morphism of additive monoids."]
+def powMonoidHom (n : ℕ) : α →* α where
+  toFun := (· ^ n)
+  map_one' := one_pow _
+  map_mul' a b := mul_pow a b n
+#align pow_monoid_hom powMonoidHom
+#align nsmul_add_monoid_hom nsmulAddMonoidHom
+#align pow_monoid_hom_apply powMonoidHom_apply
+#align nsmul_add_monoid_hom_apply nsmulAddMonoidHom_apply
+
+end CommMonoid
+
+section DivisionCommMonoid
+variable [DivisionCommMonoid α]
+
+/-- The `n`-th power map (for an integer `n`) on a commutative group, considered as a group
+homomorphism. -/
+@[to_additive (attr := simps) "Multiplication by an integer `n` on a commutative additive group,
+considered as an additive group homomorphism."]
+def zpowGroupHom (n : ℤ) : α →* α where
+  toFun := (· ^ n)
+  map_one' := one_zpow n
+  map_mul' a b := mul_zpow a b n
+#align zpow_group_hom zpowGroupHom
+#align zsmul_add_group_hom zsmulAddGroupHom
+#align zpow_group_hom_apply zpowGroupHom_apply
+#align zsmul_add_group_hom_apply zsmulAddGroupHom_apply
+
+end DivisionCommMonoid

--- a/Mathlib/Algebra/GroupPower/Order.lean
+++ b/Mathlib/Algebra/GroupPower/Order.lean
@@ -167,9 +167,7 @@ theorem pow_lt_self_of_lt_one (h₀ : 0 < a) (h₁ : a < 1) (hn : 1 < n) : a ^ n
   simpa only [pow_one] using pow_lt_pow_right_of_lt_one h₀ h₁ hn
 #align pow_lt_self_of_lt_one pow_lt_self_of_lt_one
 
-theorem sq_pos_of_pos (ha : 0 < a) : 0 < a ^ 2 := by
-  rw [sq]
-  exact mul_pos ha ha
+theorem sq_pos_of_pos (ha : 0 < a) : 0 < a ^ 2 := pow_pos ha _
 #align sq_pos_of_pos sq_pos_of_pos
 
 end StrictOrderedSemiring
@@ -296,10 +294,6 @@ theorem pow_bit0_nonneg (a : R) (n : ℕ) : 0 ≤ a ^ bit0 n := by
   rw [pow_bit0]
   exact mul_self_nonneg _
 #align pow_bit0_nonneg pow_bit0_nonneg
-
-theorem sq_nonneg (a : R) : 0 ≤ a ^ 2 :=
-  pow_bit0_nonneg a 1
-#align sq_nonneg sq_nonneg
 
 alias pow_two_nonneg := sq_nonneg
 #align pow_two_nonneg pow_two_nonneg

--- a/Mathlib/Algebra/GroupPower/Order.lean
+++ b/Mathlib/Algebra/GroupPower/Order.lean
@@ -402,20 +402,6 @@ theorem pow_four_le_pow_two_of_pow_two_le {x y : R} (h : x ^ 2 ≤ y) : x ^ 4 �
 
 end LinearOrderedRing
 
-section LinearOrderedCommRing
-
-variable [LinearOrderedCommRing R]
-
-/-- Arithmetic mean-geometric mean (AM-GM) inequality for linearly ordered commutative rings. -/
-theorem two_mul_le_add_sq (a b : R) : 2 * a * b ≤ a ^ 2 + b ^ 2 :=
-  sub_nonneg.mp ((sub_add_eq_add_sub _ _ _).subst ((sub_sq a b).subst (sq_nonneg _)))
-#align two_mul_le_add_sq two_mul_le_add_sq
-
-alias two_mul_le_add_pow_two := two_mul_le_add_sq
-#align two_mul_le_add_pow_two two_mul_le_add_pow_two
-
-end LinearOrderedCommRing
-
 section LinearOrderedCommMonoidWithZero
 
 variable [LinearOrderedCommMonoidWithZero M] [NoZeroDivisors M] {a : M} {n : ℕ}

--- a/Mathlib/Algebra/GroupPower/Ring.lean
+++ b/Mathlib/Algebra/GroupPower/Ring.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad, Robert Y. Lewis
 -/
 
 import Mathlib.Algebra.Group.Units.Hom
-import Mathlib.Algebra.GroupPower.Basic
+import Mathlib.Algebra.GroupPower.Hom
 import Mathlib.Algebra.GroupWithZero.Commute
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.Ring.Commute

--- a/Mathlib/Algebra/Order/Monoid/MinMax.lean
+++ b/Mathlib/Algebra/Order/Monoid/MinMax.lean
@@ -20,19 +20,28 @@ variable {α β : Type*}
 /-! Some lemmas about types that have an ordering and a binary operation, with no
   rules relating them. -/
 
+section CommSemigroup
+variable[LinearOrder α] [CommSemigroup α] [CommSemigroup β]
 
 @[to_additive]
-theorem fn_min_mul_fn_max [LinearOrder α] [CommSemigroup β] (f : α → β) (n m : α) :
-    f (min n m) * f (max n m) = f n * f m := by
-  rcases le_total n m with h | h <;> simp [h, mul_comm]
+lemma fn_min_mul_fn_max  (f : α → β) (a b : α) : f (min a b) * f (max a b) = f a * f b := by
+  obtain h | h := le_total a b <;> simp [h, mul_comm]
 #align fn_min_mul_fn_max fn_min_mul_fn_max
 #align fn_min_add_fn_max fn_min_add_fn_max
 
 @[to_additive]
-theorem min_mul_max [LinearOrder α] [CommSemigroup α] (n m : α) : min n m * max n m = n * m :=
-  fn_min_mul_fn_max id n m
+lemma fn_max_mul_fn_min (f : α → β) (a b : α) : f (max a b) * f (min a b) = f a * f b := by
+  obtain h | h := le_total a b <;> simp [h, mul_comm]
+
+@[to_additive (attr := simp)]
+lemma min_mul_max (a b : α) : min a b * max a b = a * b := fn_min_mul_fn_max id _ _
 #align min_mul_max min_mul_max
 #align min_add_max min_add_max
+
+@[to_additive (attr := simp)]
+lemma max_mul_min (a b : α) : max a b * min a b = a * b := fn_max_mul_fn_min id _ _
+
+end CommSemigroup
 
 section CovariantClassMulLe
 

--- a/Mathlib/Algebra/Order/Ring/Canonical.lean
+++ b/Mathlib/Algebra/Order/Ring/Canonical.lean
@@ -5,7 +5,6 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
 -/
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Algebra.Order.Sub.Canonical
-import Mathlib.GroupTheory.GroupAction.Defs
 
 #align_import algebra.order.ring.canonical from "leanprover-community/mathlib"@"824f9ae93a4f5174d2ea948e2d75843dd83447bb"
 
@@ -38,64 +37,6 @@ class CanonicallyOrderedCommSemiring (α : Type*) extends CanonicallyOrderedAddC
   /-- No zero divisors. -/
   protected eq_zero_or_eq_zero_of_mul_eq_zero : ∀ {a b : α}, a * b = 0 → a = 0 ∨ b = 0
 #align canonically_ordered_comm_semiring CanonicallyOrderedCommSemiring
-
-section StrictOrderedSemiring
-
-variable [StrictOrderedSemiring α] {a b c d : α}
-
-section ExistsAddOfLE
-
-variable [ExistsAddOfLE α]
-
-/-- Binary **rearrangement inequality**. -/
-theorem mul_add_mul_le_mul_add_mul (hab : a ≤ b) (hcd : c ≤ d) : a * d + b * c ≤ a * c + b * d := by
-  obtain ⟨b, rfl⟩ := exists_add_of_le hab
-  obtain ⟨d, rfl⟩ := exists_add_of_le hcd
-  rw [mul_add, add_right_comm, mul_add, ← add_assoc]
-  exact add_le_add_left (mul_le_mul_of_nonneg_right hab <| (le_add_iff_nonneg_right _).1 hcd) _
-#align mul_add_mul_le_mul_add_mul mul_add_mul_le_mul_add_mul
-
-/-- Binary **rearrangement inequality**. -/
-theorem mul_add_mul_le_mul_add_mul' (hba : b ≤ a) (hdc : d ≤ c) :
-    a • d + b • c ≤ a • c + b • d := by
-  rw [add_comm (a • d), add_comm (a • c)]
-  exact mul_add_mul_le_mul_add_mul hba hdc
-#align mul_add_mul_le_mul_add_mul' mul_add_mul_le_mul_add_mul'
-
-/-- Binary strict **rearrangement inequality**. -/
-theorem mul_add_mul_lt_mul_add_mul (hab : a < b) (hcd : c < d) : a * d + b * c < a * c + b * d := by
-  obtain ⟨b, rfl⟩ := exists_add_of_le hab.le
-  obtain ⟨d, rfl⟩ := exists_add_of_le hcd.le
-  rw [mul_add, add_right_comm, mul_add, ← add_assoc]
-  exact add_lt_add_left (mul_lt_mul_of_pos_right hab <| (lt_add_iff_pos_right _).1 hcd) _
-#align mul_add_mul_lt_mul_add_mul mul_add_mul_lt_mul_add_mul
-
-/-- Binary **rearrangement inequality**. -/
-theorem mul_add_mul_lt_mul_add_mul' (hba : b < a) (hdc : d < c) :
-    a • d + b • c < a • c + b • d := by
-  rw [add_comm (a • d), add_comm (a • c)]
-  exact mul_add_mul_lt_mul_add_mul hba hdc
-#align mul_add_mul_lt_mul_add_mul' mul_add_mul_lt_mul_add_mul'
-
-end ExistsAddOfLE
-
-end StrictOrderedSemiring
-
-section LinearOrderedCommSemiring
-variable [LinearOrderedCommSemiring α] [ExistsAddOfLE α] {a b : α}
-
-lemma add_sq_le : (a + b) ^ 2 ≤ 2 * (a ^ 2 + b ^ 2) := by
-  calc
-    (a + b) ^ 2 = a ^ 2 + b ^ 2 + (a * b + b * a) := by
-        simp_rw [pow_succ, pow_zero, mul_one, add_mul_self_eq, mul_assoc, two_mul,
-          add_right_comm _ (_ + _), mul_comm]
-    _ ≤ a ^ 2 + b ^ 2 + (a * a + b * b) := add_le_add_left ?_ _
-    _ = _ := by simp_rw [pow_succ, pow_zero, mul_one, two_mul]
-  cases le_total a b
-  · exact mul_add_mul_le_mul_add_mul ‹_› ‹_›
-  · exact mul_add_mul_le_mul_add_mul' ‹_› ‹_›
-
-end LinearOrderedCommSemiring
 
 namespace CanonicallyOrderedCommSemiring
 

--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -1320,3 +1320,5 @@ Those lemmas have been deprecated on 2023/12/23
 @[deprecated] alias zero_le_mul_right := mul_nonneg_iff_of_pos_right
 @[deprecated] alias zero_lt_mul_left := mul_pos_iff_of_pos_left
 @[deprecated] alias zero_lt_mul_right := mul_pos_iff_of_pos_right
+
+assert_not_exists MonoidHom

--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -4,16 +4,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Yaël Dillies
 -/
 import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.GroupWithZero.NeZero
 import Mathlib.Algebra.Order.Group.Defs
-import Mathlib.Algebra.Order.Monoid.Defs
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
+import Mathlib.Algebra.Order.Monoid.MinMax
 import Mathlib.Algebra.Order.Monoid.NatCast
 import Mathlib.Algebra.Order.Monoid.WithZero.Defs
 import Mathlib.Algebra.Order.Ring.Lemmas
-import Mathlib.Algebra.Ring.Defs
 import Mathlib.Data.Pi.Algebra
-import Mathlib.Order.MinMax
+import Mathlib.Tactic.ByContra
 import Mathlib.Tactic.Nontriviality
 import Mathlib.Tactic.Tauto
 
@@ -333,27 +333,24 @@ theorem mul_lt_one_of_nonneg_of_lt_one_right (ha : a ≤ 1) (hb₀ : 0 ≤ b) (h
   (mul_le_of_le_one_left hb₀ ha).trans_lt hb
 #align mul_lt_one_of_nonneg_of_lt_one_right mul_lt_one_of_nonneg_of_lt_one_right
 
-end OrderedSemiring
-
-section OrderedRing
-
-variable [OrderedRing α] {a b c d : α}
-
--- see Note [lower instance priority]
-instance (priority := 100) OrderedRing.toOrderedSemiring : OrderedSemiring α :=
-  { ‹OrderedRing α›, (Ring.toSemiring : Semiring α) with
-    mul_le_mul_of_nonneg_left := fun a b c h hc => by
-      simpa only [mul_sub, sub_nonneg] using OrderedRing.mul_nonneg _ _ hc (sub_nonneg.2 h),
-    mul_le_mul_of_nonneg_right := fun a b c h hc => by
-      simpa only [sub_mul, sub_nonneg] using OrderedRing.mul_nonneg _ _ (sub_nonneg.2 h) hc }
-#align ordered_ring.to_ordered_semiring OrderedRing.toOrderedSemiring
+variable [ExistsAddOfLE α] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
 
 theorem mul_le_mul_of_nonpos_left (h : b ≤ a) (hc : c ≤ 0) : c * a ≤ c * b := by
-  simpa only [neg_mul, neg_le_neg_iff] using mul_le_mul_of_nonneg_left h (neg_nonneg.2 hc)
+  obtain ⟨d, hcd⟩ := exists_add_of_le hc
+  refine le_of_add_le_add_right (a := d * b + d * a) ?_
+  calc
+    _ = d * b := by rw [add_left_comm, ← add_mul, ← hcd, zero_mul, add_zero]
+    _ ≤ d * a := mul_le_mul_of_nonneg_left h $ hcd.trans_le $ add_le_of_nonpos_left hc
+    _ = _ := by rw [← add_assoc, ← add_mul, ← hcd, zero_mul, zero_add]
 #align mul_le_mul_of_nonpos_left mul_le_mul_of_nonpos_left
 
 theorem mul_le_mul_of_nonpos_right (h : b ≤ a) (hc : c ≤ 0) : a * c ≤ b * c := by
-  simpa only [mul_neg, neg_le_neg_iff] using mul_le_mul_of_nonneg_right h (neg_nonneg.2 hc)
+  obtain ⟨d, hcd⟩ := exists_add_of_le hc
+  refine le_of_add_le_add_right (a := b * d + a * d) ?_
+  calc
+    _ = b * d := by rw [add_left_comm, ← mul_add, ← hcd, mul_zero, add_zero]
+    _ ≤ a * d := mul_le_mul_of_nonneg_right h $ hcd.trans_le $ add_le_of_nonpos_left hc
+    _ = _ := by rw [← add_assoc, ← mul_add, ← hcd, mul_zero, zero_add]
 #align mul_le_mul_of_nonpos_right mul_le_mul_of_nonpos_right
 
 theorem mul_nonneg_of_nonpos_of_nonpos (ha : a ≤ 0) (hb : b ≤ 0) : 0 ≤ a * b := by
@@ -454,11 +451,30 @@ theorem Antitone.mul (hf : Antitone f) (hg : Antitone g) (hf₀ : ∀ x, f x ≤
 
 end Monotone
 
-theorem le_iff_exists_nonneg_add (a b : α) : a ≤ b ↔ ∃ c ≥ 0, b = a + c :=
-  ⟨fun h => ⟨b - a, sub_nonneg.mpr h, by simp⟩, fun ⟨c, hc, h⟩ => by
-    rw [h, le_add_iff_nonneg_right]
-    exact hc⟩
+variable [ContravariantClass α α (· + ·) (· ≤ ·)]
+
+lemma le_iff_exists_nonneg_add (a b : α) : a ≤ b ↔ ∃ c ≥ 0, b = a + c := by
+  refine ⟨fun h ↦ ?_, ?_⟩
+  · obtain ⟨c, rfl⟩ := exists_add_of_le h
+    exact ⟨c, nonneg_of_le_add_right h, rfl⟩
+  · rintro ⟨c, hc, rfl⟩
+    exact le_add_of_nonneg_right hc
 #align le_iff_exists_nonneg_add le_iff_exists_nonneg_add
+
+end OrderedSemiring
+
+section OrderedRing
+
+variable [OrderedRing α] {a b c d : α}
+
+-- see Note [lower instance priority]
+instance (priority := 100) OrderedRing.toOrderedSemiring : OrderedSemiring α :=
+  { ‹OrderedRing α›, (Ring.toSemiring : Semiring α) with
+    mul_le_mul_of_nonneg_left := fun a b c h hc => by
+      simpa only [mul_sub, sub_nonneg] using OrderedRing.mul_nonneg _ _ hc (sub_nonneg.2 h),
+    mul_le_mul_of_nonneg_right := fun a b c h hc => by
+      simpa only [sub_mul, sub_nonneg] using OrderedRing.mul_nonneg _ _ (sub_nonneg.2 h) hc }
+#align ordered_ring.to_ordered_semiring OrderedRing.toOrderedSemiring
 
 end OrderedRing
 
@@ -628,71 +644,24 @@ instance (priority := 100) StrictOrderedSemiring.toNoMaxOrder : NoMaxOrder α :=
   ⟨fun a => ⟨a + 1, lt_add_of_pos_right _ one_pos⟩⟩
 #align strict_ordered_semiring.to_no_max_order StrictOrderedSemiring.toNoMaxOrder
 
-end StrictOrderedSemiring
-
-section StrictOrderedCommSemiring
-
-variable [StrictOrderedCommSemiring α]
-
--- See note [reducible non-instances]
-/-- A choice-free version of `StrictOrderedCommSemiring.toOrderedCommSemiring'` to avoid using
-choice in basic `Nat` lemmas. -/
-@[reducible]
-def StrictOrderedCommSemiring.toOrderedCommSemiring' [@DecidableRel α (· ≤ ·)] :
-    OrderedCommSemiring α :=
-  { ‹StrictOrderedCommSemiring α›, StrictOrderedSemiring.toOrderedSemiring' with }
-#align strict_ordered_comm_semiring.to_ordered_comm_semiring' StrictOrderedCommSemiring.toOrderedCommSemiring'
-
--- see Note [lower instance priority]
-instance (priority := 100) StrictOrderedCommSemiring.toOrderedCommSemiring :
-    OrderedCommSemiring α :=
-  { ‹StrictOrderedCommSemiring α›, StrictOrderedSemiring.toOrderedSemiring with }
-#align strict_ordered_comm_semiring.to_ordered_comm_semiring StrictOrderedCommSemiring.toOrderedCommSemiring
-
-end StrictOrderedCommSemiring
-
-section StrictOrderedRing
-
-variable [StrictOrderedRing α] {a b c : α}
-
--- see Note [lower instance priority]
-instance (priority := 100) StrictOrderedRing.toStrictOrderedSemiring : StrictOrderedSemiring α :=
-  { ‹StrictOrderedRing α›, (Ring.toSemiring : Semiring α) with
-    le_of_add_le_add_left := @le_of_add_le_add_left α _ _ _,
-    mul_lt_mul_of_pos_left := fun a b c h hc => by
-      simpa only [mul_sub, sub_pos] using StrictOrderedRing.mul_pos _ _ hc (sub_pos.2 h),
-    mul_lt_mul_of_pos_right := fun a b c h hc => by
-      simpa only [sub_mul, sub_pos] using StrictOrderedRing.mul_pos _ _ (sub_pos.2 h) hc }
-#align strict_ordered_ring.to_strict_ordered_semiring StrictOrderedRing.toStrictOrderedSemiring
-
--- See note [reducible non-instances]
-/-- A choice-free version of `StrictOrderedRing.toOrderedRing` to avoid using choice in basic
-`Int` lemmas. -/
-@[reducible]
-def StrictOrderedRing.toOrderedRing' [@DecidableRel α (· ≤ ·)] : OrderedRing α :=
-  { ‹StrictOrderedRing α›, (Ring.toSemiring : Semiring α) with
-    mul_nonneg := fun a b ha hb => by
-      obtain ha | ha := Decidable.eq_or_lt_of_le ha
-      · rw [← ha, zero_mul]
-      obtain hb | hb := Decidable.eq_or_lt_of_le hb
-      · rw [← hb, mul_zero]
-      · exact (StrictOrderedRing.mul_pos _ _ ha hb).le }
-#align strict_ordered_ring.to_ordered_ring' StrictOrderedRing.toOrderedRing'
-
--- see Note [lower instance priority]
-instance (priority := 100) StrictOrderedRing.toOrderedRing : OrderedRing α :=
-  { ‹StrictOrderedRing α› with
-    mul_nonneg := fun a b =>
-      letI := @StrictOrderedRing.toOrderedRing' α _ (Classical.decRel _)
-      mul_nonneg }
-#align strict_ordered_ring.to_ordered_ring StrictOrderedRing.toOrderedRing
+variable [ExistsAddOfLE α]
 
 theorem mul_lt_mul_of_neg_left (h : b < a) (hc : c < 0) : c * a < c * b := by
-  simpa only [neg_mul, neg_lt_neg_iff] using mul_lt_mul_of_pos_left h (neg_pos_of_neg hc)
+  obtain ⟨d, hcd⟩ := exists_add_of_le hc.le
+  refine (add_lt_add_iff_right (d * b + d * a)).1 ?_
+  calc
+    _ = d * b := by rw [add_left_comm, ← add_mul, ← hcd, zero_mul, add_zero]
+    _ < d * a := mul_lt_mul_of_pos_left h $ hcd.trans_lt $ add_lt_of_neg_left _ hc
+    _ = _ := by rw [← add_assoc, ← add_mul, ← hcd, zero_mul, zero_add]
 #align mul_lt_mul_of_neg_left mul_lt_mul_of_neg_left
 
 theorem mul_lt_mul_of_neg_right (h : b < a) (hc : c < 0) : a * c < b * c := by
-  simpa only [mul_neg, neg_lt_neg_iff] using mul_lt_mul_of_pos_right h (neg_pos_of_neg hc)
+  obtain ⟨d, hcd⟩ := exists_add_of_le hc.le
+  refine (add_lt_add_iff_right (b * d + a * d)).1 ?_
+  calc
+    _ = b * d := by rw [add_left_comm, ← mul_add, ← hcd, mul_zero, add_zero]
+    _ < a * d := mul_lt_mul_of_pos_right h $ hcd.trans_lt $ add_lt_of_neg_left _ hc
+    _ = _ := by rw [← add_assoc, ← mul_add, ← hcd, mul_zero, zero_add]
 #align mul_lt_mul_of_neg_right mul_lt_mul_of_neg_right
 
 theorem mul_pos_of_neg_of_neg {a b : α} (ha : a < 0) (hb : b < 0) : 0 < a * b := by
@@ -752,6 +721,90 @@ theorem StrictAnti.mul_const_of_neg (hf : StrictAnti f) (ha : a < 0) :
 #align strict_anti.mul_const_of_neg StrictAnti.mul_const_of_neg
 
 end Monotone
+
+/-- Binary **rearrangement inequality**. -/
+lemma mul_add_mul_le_mul_add_mul (hab : a ≤ b) (hcd : c ≤ d) : a * d + b * c ≤ a * c + b * d := by
+  obtain ⟨b, rfl⟩ := exists_add_of_le hab
+  obtain ⟨d, rfl⟩ := exists_add_of_le hcd
+  rw [mul_add, add_right_comm, mul_add, ← add_assoc]
+  exact add_le_add_left (mul_le_mul_of_nonneg_right hab <| (le_add_iff_nonneg_right _).1 hcd) _
+#align mul_add_mul_le_mul_add_mul mul_add_mul_le_mul_add_mul
+
+/-- Binary **rearrangement inequality**. -/
+lemma mul_add_mul_le_mul_add_mul' (hba : b ≤ a) (hdc : d ≤ c) : a * d + b * c ≤ a * c + b * d := by
+  rw [add_comm (a * d), add_comm (a * c)]; exact mul_add_mul_le_mul_add_mul hba hdc
+#align mul_add_mul_le_mul_add_mul' mul_add_mul_le_mul_add_mul'
+
+/-- Binary strict **rearrangement inequality**. -/
+lemma mul_add_mul_lt_mul_add_mul (hab : a < b) (hcd : c < d) : a * d + b * c < a * c + b * d := by
+  obtain ⟨b, rfl⟩ := exists_add_of_le hab.le
+  obtain ⟨d, rfl⟩ := exists_add_of_le hcd.le
+  rw [mul_add, add_right_comm, mul_add, ← add_assoc]
+  exact add_lt_add_left (mul_lt_mul_of_pos_right hab <| (lt_add_iff_pos_right _).1 hcd) _
+#align mul_add_mul_lt_mul_add_mul mul_add_mul_lt_mul_add_mul
+
+/-- Binary **rearrangement inequality**. -/
+lemma mul_add_mul_lt_mul_add_mul' (hba : b < a) (hdc : d < c) : a * d + b * c < a * c + b * d := by
+  rw [add_comm (a * d), add_comm (a * c)]
+  exact mul_add_mul_lt_mul_add_mul hba hdc
+#align mul_add_mul_lt_mul_add_mul' mul_add_mul_lt_mul_add_mul'
+
+end StrictOrderedSemiring
+
+section StrictOrderedCommSemiring
+variable [StrictOrderedCommSemiring α]
+
+-- See note [reducible non-instances]
+/-- A choice-free version of `StrictOrderedCommSemiring.toOrderedCommSemiring'` to avoid using
+choice in basic `Nat` lemmas. -/
+@[reducible]
+def StrictOrderedCommSemiring.toOrderedCommSemiring' [@DecidableRel α (· ≤ ·)] :
+    OrderedCommSemiring α :=
+  { ‹StrictOrderedCommSemiring α›, StrictOrderedSemiring.toOrderedSemiring' with }
+#align strict_ordered_comm_semiring.to_ordered_comm_semiring' StrictOrderedCommSemiring.toOrderedCommSemiring'
+
+-- see Note [lower instance priority]
+instance (priority := 100) StrictOrderedCommSemiring.toOrderedCommSemiring :
+    OrderedCommSemiring α :=
+  { ‹StrictOrderedCommSemiring α›, StrictOrderedSemiring.toOrderedSemiring with }
+#align strict_ordered_comm_semiring.to_ordered_comm_semiring StrictOrderedCommSemiring.toOrderedCommSemiring
+
+end StrictOrderedCommSemiring
+
+section StrictOrderedRing
+variable [StrictOrderedRing α] {a b c : α}
+
+-- see Note [lower instance priority]
+instance (priority := 100) StrictOrderedRing.toStrictOrderedSemiring : StrictOrderedSemiring α :=
+  { ‹StrictOrderedRing α›, (Ring.toSemiring : Semiring α) with
+    le_of_add_le_add_left := @le_of_add_le_add_left α _ _ _,
+    mul_lt_mul_of_pos_left := fun a b c h hc => by
+      simpa only [mul_sub, sub_pos] using StrictOrderedRing.mul_pos _ _ hc (sub_pos.2 h),
+    mul_lt_mul_of_pos_right := fun a b c h hc => by
+      simpa only [sub_mul, sub_pos] using StrictOrderedRing.mul_pos _ _ (sub_pos.2 h) hc }
+#align strict_ordered_ring.to_strict_ordered_semiring StrictOrderedRing.toStrictOrderedSemiring
+
+-- See note [reducible non-instances]
+/-- A choice-free version of `StrictOrderedRing.toOrderedRing` to avoid using choice in basic
+`Int` lemmas. -/
+@[reducible]
+def StrictOrderedRing.toOrderedRing' [@DecidableRel α (· ≤ ·)] : OrderedRing α :=
+  { ‹StrictOrderedRing α›, (Ring.toSemiring : Semiring α) with
+    mul_nonneg := fun a b ha hb => by
+      obtain ha | ha := Decidable.eq_or_lt_of_le ha
+      · rw [← ha, zero_mul]
+      obtain hb | hb := Decidable.eq_or_lt_of_le hb
+      · rw [← hb, mul_zero]
+      · exact (StrictOrderedRing.mul_pos _ _ ha hb).le }
+#align strict_ordered_ring.to_ordered_ring' StrictOrderedRing.toOrderedRing'
+
+-- see Note [lower instance priority]
+instance (priority := 100) StrictOrderedRing.toOrderedRing : OrderedRing α :=
+  { ‹StrictOrderedRing α› with
+    mul_nonneg := fun a b =>
+      letI := @StrictOrderedRing.toOrderedRing' α _ (Classical.decRel _)
+      mul_nonneg }
+#align strict_ordered_ring.to_ordered_ring StrictOrderedRing.toOrderedRing
 
 end StrictOrderedRing
 
@@ -995,62 +1048,32 @@ theorem mul_self_inj {a b : α} (h1 : 0 ≤ a) (h2 : 0 ≤ b) : a * a = b * b �
   (@strictMonoOn_mul_self α _).eq_iff_eq h1 h2
 #align mul_self_inj mul_self_inj
 
-end LinearOrderedSemiring
+variable [ExistsAddOfLE α]
 
 -- See note [lower instance priority]
-instance (priority := 100) LinearOrderedCommSemiring.toLinearOrderedCancelAddCommMonoid
-    [LinearOrderedCommSemiring α] : LinearOrderedCancelAddCommMonoid α :=
-  { ‹LinearOrderedCommSemiring α› with }
-#align linear_ordered_comm_semiring.to_linear_ordered_cancel_add_comm_monoid LinearOrderedCommSemiring.toLinearOrderedCancelAddCommMonoid
+instance (priority := 100) LinearOrderedSemiring.noZeroDivisors : NoZeroDivisors α where
+  eq_zero_or_eq_zero_of_mul_eq_zero {a b} hab := by
+    contrapose! hab
+    obtain ha | ha := hab.1.lt_or_lt <;> obtain hb | hb := hab.2.lt_or_lt
+    exacts [(mul_pos_of_neg_of_neg ha hb).ne', (mul_neg_of_neg_of_pos ha hb).ne,
+      (mul_neg_of_pos_of_neg ha hb).ne, (mul_pos ha hb).ne']
+#align linear_ordered_ring.no_zero_divisors LinearOrderedSemiring.noZeroDivisors
 
-section LinearOrderedRing
-
-variable [LinearOrderedRing α] {a b c : α}
-
-attribute [local instance] LinearOrderedRing.decidableLE LinearOrderedRing.decidableLT
-
--- see Note [lower instance priority]
-instance (priority := 100) LinearOrderedRing.toLinearOrderedSemiring : LinearOrderedSemiring α :=
-  { ‹LinearOrderedRing α›, StrictOrderedRing.toStrictOrderedSemiring with }
-#align linear_ordered_ring.to_linear_ordered_semiring LinearOrderedRing.toLinearOrderedSemiring
-
--- see Note [lower instance priority]
-instance (priority := 100) LinearOrderedRing.toLinearOrderedAddCommGroup :
-    LinearOrderedAddCommGroup α :=
-  { ‹LinearOrderedRing α› with }
-#align linear_ordered_ring.to_linear_ordered_add_comm_group LinearOrderedRing.toLinearOrderedAddCommGroup
-
--- see Note [lower instance priority]
-instance (priority := 100) LinearOrderedRing.noZeroDivisors : NoZeroDivisors α :=
-  { ‹LinearOrderedRing α› with
-    eq_zero_or_eq_zero_of_mul_eq_zero := by
-      intro a b hab
-      refine' Decidable.or_iff_not_and_not.2 fun h => _; revert hab
-      cases' lt_or_gt_of_ne h.1 with ha ha <;> cases' lt_or_gt_of_ne h.2 with hb hb
-      exacts [(mul_pos_of_neg_of_neg ha hb).ne.symm, (mul_neg_of_neg_of_pos ha hb).ne,
-        (mul_neg_of_pos_of_neg ha hb).ne, (mul_pos ha hb).ne.symm] }
-#align linear_ordered_ring.no_zero_divisors LinearOrderedRing.noZeroDivisors
-
--- see Note [lower instance priority]
---We don't want to import `Algebra.Ring.Basic`, so we cannot use `NoZeroDivisors.to_isDomain`.
-instance (priority := 100) LinearOrderedRing.isDomain : IsDomain α :=
-  { (inferInstance : Nontrivial α) with
-    mul_left_cancel_of_ne_zero := fun {a b c} ha h => by
-      rw [← sub_eq_zero, ← mul_sub] at h
-      exact sub_eq_zero.1 ((eq_zero_or_eq_zero_of_mul_eq_zero h).resolve_left ha),
-    mul_right_cancel_of_ne_zero := fun {a b c} hb h => by
-      rw [← sub_eq_zero, ← sub_mul] at h
-      exact sub_eq_zero.1 ((eq_zero_or_eq_zero_of_mul_eq_zero h).resolve_right hb) }
+-- Note that we can't use `NoZeroDivisors.to_isDomain` since we are merely in a semiring.
+-- See note [lower instance priority]
+instance (priority := 100) LinearOrderedRing.isDomain : IsDomain α where
+  mul_left_cancel_of_ne_zero {a b c} ha h := by
+    obtain ha | ha := ha.lt_or_lt
+    exacts [(strictAnti_mul_left ha).injective h, (strictMono_mul_left_of_pos ha).injective h]
+  mul_right_cancel_of_ne_zero {b a c} ha h := by
+    obtain ha | ha := ha.lt_or_lt
+    exacts [(strictAnti_mul_right ha).injective h, (strictMono_mul_right_of_pos ha).injective h]
 #align linear_ordered_ring.is_domain LinearOrderedRing.isDomain
 
 theorem mul_pos_iff : 0 < a * b ↔ 0 < a ∧ 0 < b ∨ a < 0 ∧ b < 0 :=
   ⟨pos_and_pos_or_neg_and_neg_of_mul_pos, fun h =>
     h.elim (and_imp.2 mul_pos) (and_imp.2 mul_pos_of_neg_of_neg)⟩
 #align mul_pos_iff mul_pos_iff
-
-theorem mul_neg_iff : a * b < 0 ↔ 0 < a ∧ b < 0 ∨ a < 0 ∧ 0 < b := by
-  rw [← neg_pos, neg_mul_eq_mul_neg, mul_pos_iff, neg_pos, neg_lt_zero]
-#align mul_neg_iff mul_neg_iff
 
 theorem mul_nonneg_iff : 0 ≤ a * b ↔ 0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 :=
   ⟨nonneg_and_nonneg_or_nonpos_and_nonpos_of_mul_nonneg, fun h =>
@@ -1083,33 +1106,12 @@ theorem mul_nonneg_of_three (a b c : α) : 0 ≤ a * b ∨ 0 ≤ b * c ∨ 0 ≤
               (fun (h6 : a ≤ 0) => Or.inl (Or.inr ⟨h6, h4⟩))))
 #align mul_nonneg_of_three mul_nonneg_of_three
 
-theorem mul_nonpos_iff : a * b ≤ 0 ↔ 0 ≤ a ∧ b ≤ 0 ∨ a ≤ 0 ∧ 0 ≤ b := by
-  rw [← neg_nonneg, neg_mul_eq_mul_neg, mul_nonneg_iff, neg_nonneg, neg_nonpos]
-#align mul_nonpos_iff mul_nonpos_iff
-
 lemma mul_nonneg_iff_pos_imp_nonneg : 0 ≤ a * b ↔ (0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a) := by
   refine mul_nonneg_iff.trans ?_
   simp_rw [← not_le, ← or_iff_not_imp_left]
   have := le_total a 0
   have := le_total b 0
   tauto
-
-lemma mul_nonneg_iff_neg_imp_nonpos : 0 ≤ a * b ↔ (a < 0 → b ≤ 0) ∧ (b < 0 → a ≤ 0) := by
-  rw [← neg_mul_neg, mul_nonneg_iff_pos_imp_nonneg]; simp only [neg_pos, neg_nonneg]
-
-lemma mul_nonpos_iff_pos_imp_nonpos : a * b ≤ 0 ↔ (0 < a → b ≤ 0) ∧ (b < 0 → 0 ≤ a) := by
-  rw [← neg_nonneg, ← mul_neg, mul_nonneg_iff_pos_imp_nonneg]; simp only [neg_pos, neg_nonneg]
-
-lemma mul_nonpos_iff_neg_imp_nonneg : a * b ≤ 0 ↔ (a < 0 → 0 ≤ b) ∧ (0 < b → a ≤ 0) := by
-  rw [← neg_nonneg, ← neg_mul, mul_nonneg_iff_pos_imp_nonneg]; simp only [neg_pos, neg_nonneg]
-
-theorem mul_self_nonneg (a : α) : 0 ≤ a * a :=
-  (le_total 0 a).elim (fun h => mul_nonneg h h) fun h => mul_nonneg_of_nonpos_of_nonpos h h
-#align mul_self_nonneg mul_self_nonneg
-
-theorem neg_one_lt_zero : -1 < (0 : α) :=
-  neg_lt_zero.2 zero_lt_one
-#align neg_one_lt_zero neg_one_lt_zero
 
 @[simp]
 theorem mul_le_mul_left_of_neg {a b c : α} (h : c < 0) : c * a ≤ c * b ↔ b ≤ a :=
@@ -1132,11 +1134,11 @@ theorem mul_lt_mul_right_of_neg {a b c : α} (h : c < 0) : a * c < b * c ↔ b <
 #align mul_lt_mul_right_of_neg mul_lt_mul_right_of_neg
 
 theorem lt_of_mul_lt_mul_of_nonpos_left (h : c * a < c * b) (hc : c ≤ 0) : b < a :=
-  lt_of_mul_lt_mul_left (by rwa [neg_mul, neg_mul, neg_lt_neg_iff]) <| neg_nonneg.2 hc
+  (antitone_mul_left hc).reflect_lt h
 #align lt_of_mul_lt_mul_of_nonpos_left lt_of_mul_lt_mul_of_nonpos_left
 
 theorem lt_of_mul_lt_mul_of_nonpos_right (h : a * c < b * c) (hc : c ≤ 0) : b < a :=
-  lt_of_mul_lt_mul_right (by rwa [mul_neg, mul_neg, neg_lt_neg_iff]) <| neg_nonneg.2 hc
+  (antitone_mul_right hc).reflect_lt h
 #align lt_of_mul_lt_mul_of_nonpos_right lt_of_mul_lt_mul_of_nonpos_right
 
 theorem cmp_mul_neg_left {a : α} (ha : a < 0) (b c : α) : cmp (a * b) (a * c) = cmp c b :=
@@ -1146,10 +1148,6 @@ theorem cmp_mul_neg_left {a : α} (ha : a < 0) (b c : α) : cmp (a * b) (a * c) 
 theorem cmp_mul_neg_right {a : α} (ha : a < 0) (b c : α) : cmp (b * a) (c * a) = cmp c b :=
   (strictAnti_mul_right ha).cmp_map_eq b c
 #align cmp_mul_neg_right cmp_mul_neg_right
-
-theorem sub_one_lt (a : α) : a - 1 < a :=
-  sub_lt_iff_lt_add.2 (lt_add_one a)
-#align sub_one_lt sub_one_lt
 
 @[simp]
 theorem mul_self_pos {a : α} : 0 < a * a ↔ a ≠ 0 := by
@@ -1161,12 +1159,6 @@ theorem mul_self_pos {a : α} : 0 < a * a ↔ a ≠ 0 := by
     cases' h.lt_or_lt with h h
     exacts [mul_pos_of_neg_of_neg h h, mul_pos h h]
 #align mul_self_pos mul_self_pos
-
-theorem mul_self_le_mul_self_of_le_of_neg_le {x y : α} (h₁ : x ≤ y) (h₂ : -x ≤ y) : x * x ≤ y * y :=
-  (le_total 0 x).elim (fun h => mul_le_mul h₁ h₁ h (h.trans h₁)) fun h =>
-    le_of_eq_of_le (neg_mul_neg x x).symm
-      (mul_le_mul h₂ h₂ (neg_nonneg.mpr h) ((neg_nonneg.mpr h).trans h₂))
-#align mul_self_le_mul_self_of_le_of_neg_le mul_self_le_mul_self_of_le_of_neg_le
 
 theorem nonneg_of_mul_nonpos_left {a b : α} (h : a * b ≤ 0) (hb : b < 0) : 0 ≤ a :=
   le_of_not_gt fun ha => absurd h (mul_pos_of_neg_of_neg ha hb).not_le
@@ -1192,14 +1184,117 @@ theorem pos_iff_neg_of_mul_neg (hab : a * b < 0) : 0 < a ↔ b < 0 :=
   ⟨neg_of_mul_neg_right hab ∘ le_of_lt, pos_of_mul_neg_left hab ∘ le_of_lt⟩
 #align pos_iff_neg_of_mul_neg pos_iff_neg_of_mul_neg
 
+lemma sq_nonneg (a : α) : 0 ≤ a ^ 2 := by
+  obtain ha | ha := le_total 0 a
+  · exact pow_nonneg ha _
+  obtain ⟨b, hab⟩ := exists_add_of_le ha
+  calc
+    0 ≤ b ^ 2 := pow_nonneg (not_lt.1 fun hb ↦ hab.not_gt $ add_neg_of_nonpos_of_neg ha hb) _
+    _ = a ^ 2 := add_left_injective (a * b) ?_
+  calc
+    b ^ 2 + a * b = (a + b) * b := by rw [add_comm, sq, add_mul]
+    _ = a * (a + b) := by simp [← hab]
+    _ = a ^ 2 + a * b := by rw [sq, mul_add]
+
+lemma mul_self_nonneg (a : α) : 0 ≤ a * a := by simpa only [sq] using sq_nonneg a
+
 /-- The sum of two squares is zero iff both elements are zero. -/
-theorem mul_self_add_mul_self_eq_zero {x y : α} : x * x + y * y = 0 ↔ x = 0 ∧ y = 0 := by
+lemma mul_self_add_mul_self_eq_zero : a * a + b * b = 0 ↔ a = 0 ∧ b = 0 := by
   rw [add_eq_zero_iff', mul_self_eq_zero, mul_self_eq_zero] <;> apply mul_self_nonneg
 #align mul_self_add_mul_self_eq_zero mul_self_add_mul_self_eq_zero
 
-theorem eq_zero_of_mul_self_add_mul_self_eq_zero (h : a * a + b * b = 0) : a = 0 :=
+lemma eq_zero_of_mul_self_add_mul_self_eq_zero (h : a * a + b * b = 0) : a = 0 :=
   (mul_self_add_mul_self_eq_zero.mp h).left
 #align eq_zero_of_mul_self_add_mul_self_eq_zero eq_zero_of_mul_self_add_mul_self_eq_zero
+
+lemma add_sq_le : (a + b) ^ 2 ≤ 2 * (a ^ 2 + b ^ 2) := by
+  calc
+    (a + b) ^ 2 = a ^ 2 + b ^ 2 + (a * b + b * a) := by
+        simp_rw [pow_succ, pow_zero, mul_one, add_mul, mul_add, add_comm (b * a), add_add_add_comm]
+    _ ≤ a ^ 2 + b ^ 2 + (a * a + b * b) := add_le_add_left ?_ _
+    _ = _ := by simp_rw [pow_succ, pow_zero, mul_one, two_mul]
+  cases le_total a b
+  · exact mul_add_mul_le_mul_add_mul ‹_› ‹_›
+  · exact mul_add_mul_le_mul_add_mul' ‹_› ‹_›
+
+end LinearOrderedSemiring
+
+section LinearOrderedCommSemiring
+variable [LinearOrderedCommSemiring α] {a b c d : α}
+
+-- See note [lower instance priority]
+instance (priority := 100) LinearOrderedCommSemiring.toLinearOrderedCancelAddCommMonoid :
+    LinearOrderedCancelAddCommMonoid α where __ := ‹LinearOrderedCommSemiring α›
+#align linear_ordered_comm_semiring.to_linear_ordered_cancel_add_comm_monoid LinearOrderedCommSemiring.toLinearOrderedCancelAddCommMonoid
+
+lemma max_mul_mul_le_max_mul_max (b c : α) (ha : 0 ≤ a) (hd : 0 ≤ d) :
+    max (a * b) (d * c) ≤ max a c * max d b :=
+  have ba : b * a ≤ max d b * max c a :=
+    mul_le_mul (le_max_right d b) (le_max_right c a) ha (le_trans hd (le_max_left d b))
+  have cd : c * d ≤ max a c * max b d :=
+    mul_le_mul (le_max_right a c) (le_max_right b d) hd (le_trans ha (le_max_left a c))
+  max_le (by simpa [mul_comm, max_comm] using ba) (by simpa [mul_comm, max_comm] using cd)
+#align max_mul_mul_le_max_mul_max max_mul_mul_le_max_mul_max
+
+variable [ExistsAddOfLE α]
+
+/-- Binary **arithmetic mean-geometric mean inequality** (aka AM-GM inequality) for linearly ordered
+commutative semirings. -/
+lemma two_mul_le_add_sq (a b : α) : 2 * a * b ≤ a ^ 2 + b ^ 2 := by
+  simpa [fn_min_add_fn_max (fun x ↦ x * x), sq, two_mul, add_mul]
+    using mul_add_mul_le_mul_add_mul (@min_le_max _ _ a b) (@min_le_max _ _ a b)
+#align two_mul_le_add_sq two_mul_le_add_sq
+
+alias two_mul_le_add_pow_two := two_mul_le_add_sq
+#align two_mul_le_add_pow_two two_mul_le_add_pow_two
+
+end LinearOrderedCommSemiring
+
+section LinearOrderedRing
+variable [LinearOrderedRing α] {a b c : α}
+
+attribute [local instance] LinearOrderedRing.decidableLE LinearOrderedRing.decidableLT
+
+-- see Note [lower instance priority]
+instance (priority := 100) LinearOrderedRing.toLinearOrderedSemiring : LinearOrderedSemiring α :=
+  { ‹LinearOrderedRing α›, StrictOrderedRing.toStrictOrderedSemiring with }
+#align linear_ordered_ring.to_linear_ordered_semiring LinearOrderedRing.toLinearOrderedSemiring
+
+-- see Note [lower instance priority]
+instance (priority := 100) LinearOrderedRing.toLinearOrderedAddCommGroup :
+    LinearOrderedAddCommGroup α where __ := ‹LinearOrderedRing α›
+#align linear_ordered_ring.to_linear_ordered_add_comm_group LinearOrderedRing.toLinearOrderedAddCommGroup
+
+-- TODO: Can the following five lemmas be generalised to
+-- `[LinearOrderedSemiring α] [ExistsAddOfLE α]`?
+
+lemma mul_neg_iff : a * b < 0 ↔ 0 < a ∧ b < 0 ∨ a < 0 ∧ 0 < b := by
+  rw [← neg_pos, neg_mul_eq_mul_neg, mul_pos_iff, neg_pos, neg_lt_zero]
+#align mul_neg_iff mul_neg_iff
+
+lemma mul_nonpos_iff : a * b ≤ 0 ↔ 0 ≤ a ∧ b ≤ 0 ∨ a ≤ 0 ∧ 0 ≤ b := by
+  rw [← neg_nonneg, neg_mul_eq_mul_neg, mul_nonneg_iff, neg_nonneg, neg_nonpos]
+#align mul_nonpos_iff mul_nonpos_iff
+
+lemma mul_nonneg_iff_neg_imp_nonpos : 0 ≤ a * b ↔ (a < 0 → b ≤ 0) ∧ (b < 0 → a ≤ 0) := by
+  rw [← neg_mul_neg, mul_nonneg_iff_pos_imp_nonneg]; simp only [neg_pos, neg_nonneg]
+
+lemma mul_nonpos_iff_pos_imp_nonpos : a * b ≤ 0 ↔ (0 < a → b ≤ 0) ∧ (b < 0 → 0 ≤ a) := by
+  rw [← neg_nonneg, ← mul_neg, mul_nonneg_iff_pos_imp_nonneg]; simp only [neg_pos, neg_nonneg]
+
+lemma mul_nonpos_iff_neg_imp_nonneg : a * b ≤ 0 ↔ (a < 0 → 0 ≤ b) ∧ (0 < b → a ≤ 0) := by
+  rw [← neg_nonneg, ← neg_mul, mul_nonneg_iff_pos_imp_nonneg]; simp only [neg_pos, neg_nonneg]
+
+lemma neg_one_lt_zero : -1 < (0 : α) := neg_lt_zero.2 zero_lt_one
+#align neg_one_lt_zero neg_one_lt_zero
+
+lemma sub_one_lt (a : α) : a - 1 < a := sub_lt_iff_lt_add.2 $ lt_add_one a
+#align sub_one_lt sub_one_lt
+
+lemma mul_self_le_mul_self_of_le_of_neg_le (h₁ : a ≤ b) (h₂ : -a ≤ b) : a * a ≤ b * b :=
+  (le_total 0 a).elim (mul_self_le_mul_self · h₁) fun h ↦
+    (neg_mul_neg a a).symm.trans_le $ mul_le_mul h₂ h₂ (neg_nonneg.2 h) $ (neg_nonneg.2 h).trans h₂
+#align mul_self_le_mul_self_of_le_of_neg_le mul_self_le_mul_self_of_le_of_neg_le
 
 end LinearOrderedRing
 
@@ -1214,21 +1309,6 @@ instance (priority := 100) LinearOrderedCommRing.toLinearOrderedCommSemiring
     [d : LinearOrderedCommRing α] : LinearOrderedCommSemiring α :=
   { d, LinearOrderedRing.toLinearOrderedSemiring with }
 #align linear_ordered_comm_ring.to_linear_ordered_comm_semiring LinearOrderedCommRing.toLinearOrderedCommSemiring
-
-section LinearOrderedCommRing
-
-variable [LinearOrderedCommRing α] {a b c d : α}
-
-theorem max_mul_mul_le_max_mul_max (b c : α) (ha : 0 ≤ a) (hd : 0 ≤ d) :
-    max (a * b) (d * c) ≤ max a c * max d b :=
-  have ba : b * a ≤ max d b * max c a :=
-    mul_le_mul (le_max_right d b) (le_max_right c a) ha (le_trans hd (le_max_left d b))
-  have cd : c * d ≤ max a c * max b d :=
-    mul_le_mul (le_max_right a c) (le_max_right b d) hd (le_trans ha (le_max_left a c))
-  max_le (by simpa [mul_comm, max_comm] using ba) (by simpa [mul_comm, max_comm] using cd)
-#align max_mul_mul_le_max_mul_max max_mul_mul_le_max_mul_max
-
-end LinearOrderedCommRing
 
 /-!
 ### Deprecated lemmas

--- a/Mathlib/Algebra/Ring/Idempotents.lean
+++ b/Mathlib/Algebra/Ring/Idempotents.lean
@@ -5,6 +5,7 @@ Authors: Christopher Hoskin
 -/
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.Ring.Defs
+import Mathlib.Order.Basic
 import Mathlib.Tactic.Conv
 
 #align_import algebra.ring.idempotents from "leanprover-community/mathlib"@"655994e298904d7e5bbd1e18c95defd7b543eb94"

--- a/Mathlib/Algebra/Ring/Idempotents.lean
+++ b/Mathlib/Algebra/Ring/Idempotents.lean
@@ -3,9 +3,9 @@ Copyright (c) 2022 Christopher Hoskin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christopher Hoskin
 -/
-import Mathlib.Order.Basic
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.Ring.Defs
+import Mathlib.Tactic.Conv
 
 #align_import algebra.ring.idempotents from "leanprover-community/mathlib"@"655994e298904d7e5bbd1e18c95defd7b543eb94"
 

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Mathlib.Algebra.Group.TypeTags
 import Mathlib.Algebra.Ring.Hom.Basic
 import Mathlib.Data.Int.Order.Basic
 import Mathlib.Data.Nat.Cast.Commute

--- a/Mathlib/Data/Multiset/Bind.lean
+++ b/Mathlib/Data/Multiset/Bind.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Algebra.BigOperators.Multiset.Basic
+import Mathlib.GroupTheory.GroupAction.Defs
 
 #align_import data.multiset.bind from "leanprover-community/mathlib"@"f694c7dead66f5d4c80f446c796a5aad14707f0e"
 

--- a/Mathlib/Data/Set/Pointwise/Basic.lean
+++ b/Mathlib/Data/Set/Pointwise/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Group.Units.Hom
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.GroupWithZero.Basic
+import Mathlib.Algebra.Opposites
 import Mathlib.Data.Nat.Order.Basic
 import Mathlib.Data.Set.Lattice
 import Mathlib.Tactic.Common


### PR DESCRIPTION
Many lemmas about `BlahOrderedRing α` did not mention negation. I could generalise almost all those lemmas to `BlahOrderedSemiring α` + `ExistsAddOfLE α` except for a series of five lemmas (left a TODO about them).

Now those lemmas apply to things like the naturals. This is not very useful on its own, because those lemmas are trivially true on canonically ordered semirings (they are about multiplication by negative elements, of which there are none, or nonnegativity of squares, but we already know everything is nonnegative), except that I will soon add more complicated inequalities that are based on those, and it would be a shame having to write two versions of each: one for ordered rings, one for canonically ordered semirings.

A similar refactor could be made for scalar multiplication, but this PR is big enough already.

From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
