### PR TITLE
[Merged by Bors] - feat (FieldTheory/Adjoin): generalize `IntermediateField.exists_algHom_of_splits`

### DIFF
--- a/Mathlib/FieldTheory/Adjoin.lean
+++ b/Mathlib/FieldTheory/Adjoin.lean
@@ -1242,8 +1242,8 @@ theorem Lifts.exists_upper_bound (c : Set (Lifts F E K)) (hc : IsChain (· ≤ �
     exact Subalgebra.iSupLift_inclusion (K := t') (i := ⟨L, hL⟩) x (le_iSup t' ⟨L, hL⟩)
 #align intermediate_field.lifts.exists_upper_bound IntermediateField.Lifts.exists_upper_bound
 
-/-- Given an element `s : E` whose conjugates are all in `K`, any lift can be extended to one
-  whose carrier contains `s`. -/
+/-- Given a lift `x` and an integral element `s : E` over `x.carrier` whose conjugates over
+`x.carrier` are all in `K`, we can extend the lift to a lift whose carrier contains `s`. -/
 theorem Lifts.exists_lift_of_splits' (x : Lifts F E K) {s : E} (h1 : IsIntegral x.carrier s)
     (h2 : (minpoly x.carrier s).Splits x.emb.toRingHom) : ∃ y, x ≤ y ∧ s ∈ y.carrier :=
   have I2 := (minpoly.degree_pos h1).ne'
@@ -1259,6 +1259,8 @@ theorem Lifts.exists_lift_of_splits' (x : Lifts F E K) {s : E} (h1 : IsIntegral 
     ⟨fun z hz ↦ algebraMap_mem x.carrier⟮s⟯ ⟨z, hz⟩, φ.commutes⟩,
     mem_adjoin_simple_self x.carrier s⟩
 
+/-- Given an integral element `s : E` over `F` whose `F`-conjugates are all in `K`,
+any lift can be extended to one whose carrier contains `s`. -/
 theorem Lifts.exists_lift_of_splits (x : Lifts F E K) {s : E} (h1 : IsIntegral F s)
     (h2 : (minpoly F s).Splits (algebraMap F K)) : ∃ y, x ≤ y ∧ s ∈ y.carrier :=
   Lifts.exists_lift_of_splits' x h1.tower_top <| h1.minpoly_splits_tower_top' <| by

--- a/Mathlib/FieldTheory/Adjoin.lean
+++ b/Mathlib/FieldTheory/Adjoin.lean
@@ -1276,7 +1276,7 @@ private theorem exists_algHom_adjoin_of_splits'' {L : IntermediateField F E}
     adjoin_le_iff.mpr fun s h ↦ ?_), AlgHom.ext hfφ.2⟩
   letI := (inclusion hfφ.1).toAlgebra
   letI : SMul L φ.carrier := Algebra.toSMul
-  have : IsScalarTower L φ.carrier E := ⟨fun x y z ↦ smul_assoc x (y : E) z⟩
+  have : IsScalarTower L φ.carrier E := ⟨(smul_assoc · (· : E))⟩
   have := φ.exists_lift_of_splits' (hK s h).1.tower_top ((hK s h).1.minpoly_splits_tower_top' ?_)
   · obtain ⟨y, h1, h2⟩ := this; exact (hφ y h1).1 h2
   · convert (hK s h).2; ext; apply hfφ.2
@@ -1286,33 +1286,29 @@ variable {L : Type*} [Field L] [Algebra F L] [Algebra L E] [IsScalarTower F L E]
 
 theorem exists_algHom_adjoin_of_splits' :
     ∃ φ : adjoin L S →ₐ[F] K, φ.comp (IsScalarTower.toAlgHom F L _) = f := by
-  let f' : (IsScalarTower.toAlgHom F L E).fieldRange →ₐ[F] K :=
-    f.comp (AlgEquiv.ofInjectiveField _).symm.toAlgHom
-  --have := adjoin L S = adjoin (↥(AlgHom.fieldRange (IsScalarTower.toAlgHom F L E))) S
-  have := exists_algHom_adjoin_of_splits'' f' (S := S) ?_
-  · obtain ⟨φ, hφ⟩ := this; refine ⟨?_, ?_⟩
-    · change (adjoin L S).restrictScalars F →ₐ[F] K
-      rw [restrictScalars_adjoin]
-      rw [← coe_restrictScalars F (E := adjoin L S)]
-    --restrictScalars_adjoin
-  obtain ⟨φ, hfφ, hφ⟩ := zorn_nonempty_Ici₀ _ (fun c _ hc _ _ ↦ Lifts.exists_upper_bound c hc)
-    ⟨(IsScalarTower.toAlgHom F L E).fieldRange, f.comp (AlgEquiv.ofInjectiveField _).symm.toAlgHom⟩
-    le_rfl
-  have : (adjoin L S).restrictScalars F ≤ φ.carrier
+  let L' := (IsScalarTower.toAlgHom F L E).fieldRange
+  let f' : L' →ₐ[F] K := f.comp (AlgEquiv.ofInjectiveField _).symm.toAlgHom
+  have := exists_algHom_adjoin_of_splits'' f' (S := S) fun s hs ↦ ?_
+  · obtain ⟨φ, hφ⟩ := this; refine ⟨φ.comp <|
+      inclusion (?_ : (adjoin L S).restrictScalars F ≤ (adjoin L' S).restrictScalars F), ?_⟩
+    · simp_rw [← SetLike.coe_subset_coe, coe_restrictScalars, adjoin_subset_adjoin_iff]
+      refine ⟨subset_adjoin_of_subset_left S (F := L'.toSubfield) le_rfl, subset_adjoin _ _⟩
+    · ext x; exact congr($hφ _).trans (congr_arg f <| AlgEquiv.symm_apply_apply _ _)
+  letI : Algebra L L' := (AlgEquiv.ofInjectiveField _).toRingEquiv.toRingHom.toAlgebra
+  have : IsScalarTower L L' E := IsScalarTower.of_algebraMap_eq' rfl
+  refine ⟨(hK s hs).1.tower_top, (hK s hs).1.minpoly_splits_tower_top' ?_⟩
+  convert (hK s hs).2; ext; exact congr_arg f (AlgEquiv.symm_apply_apply _ _)
 
-    --apply adjoin_le_iff.mpr fun s hs ↦ ?_
-  let x : (IsScalarTower.toAlgHom F L E).fieldRange →ₐ[F] K :=
-    f.comp (AlgEquiv.ofInjectiveField _).symm.toAlgHom
+theorem exists_algHom_of_adjoin_splits' (hS : adjoin L S = ⊤) :
+    ∃ φ : E →ₐ[F] K, φ.comp (IsScalarTower.toAlgHom F L E) = f :=
+  have ⟨φ, hφ⟩ := exists_algHom_adjoin_of_splits' f hK
+  ⟨φ.comp (((equivOfEq hS).trans topEquiv).symm.toAlgHom.restrictScalars F), hφ⟩
+
+theorem exists_algHom_of_splits' (hK : ∀ s : E, IsIntegral L s ∧ (minpoly L s).Splits f.toRingHom) :
+    ∃ φ : E →ₐ[F] K, φ.comp (IsScalarTower.toAlgHom F L E) = f :=
+  exists_algHom_of_adjoin_splits' f (fun x _ ↦ hK x) (adjoin_univ L E)
 
 end
-
-/- theorem algHom_comp_surjective_of_splits {L : IntermediateField F E} (f : L →ₐ[F] K)
-    (h : ∀ s : E, IsIntegral L s ∧ (minpoly L s).Splits f) :
-    ∃ φ : E →ₐ[F] K, φ.comp L.val = f := by
-  rfl -/
-
---theorem  :
-
 
 variable (hK : ∀ s ∈ S, IsIntegral F s ∧ (minpoly F s).Splits (algebraMap F K))
         (hK' : ∀ s : E, IsIntegral F s ∧ (minpoly F s).Splits (algebraMap F K))

--- a/Mathlib/FieldTheory/Adjoin.lean
+++ b/Mathlib/FieldTheory/Adjoin.lean
@@ -1244,25 +1244,75 @@ theorem Lifts.exists_upper_bound (c : Set (Lifts F E K)) (hc : IsChain (· ≤ �
 
 /-- Given an element `s : E` whose conjugates are all in `K`, any lift can be extended to one
   whose carrier contains `s`. -/
-theorem Lifts.exists_lift_of_splits (x : Lifts F E K) {s : E} (h1 : IsIntegral F s)
-    (h2 : (minpoly F s).Splits (algebraMap F K)) : ∃ y, x ≤ y ∧ s ∈ y.carrier :=
-  have I1 : IsIntegral x.carrier s := h1.tower_top
-  have I2 := (minpoly.degree_pos I1).ne'
-  have key : (minpoly x.carrier s).Splits x.emb.toRingHom :=
-    splits_of_splits_of_dvd _ (map_ne_zero (minpoly.ne_zero h1))
-      ((splits_map_iff _ _).2 (x.emb.comp_algebraMap ▸ h2)) (minpoly.dvd_map_of_isScalarTower _ _ _)
+theorem Lifts.exists_lift_of_splits' (x : Lifts F E K) {s : E} (h1 : IsIntegral x.carrier s)
+    (h2 : (minpoly x.carrier s).Splits x.emb.toRingHom) : ∃ y, x ≤ y ∧ s ∈ y.carrier :=
+  have I2 := (minpoly.degree_pos h1).ne'
   letI : Algebra x.carrier K := x.emb.toRingHom.toAlgebra
   let carrier := x.carrier⟮s⟯.restrictScalars F
   letI : Algebra x.carrier carrier := x.carrier⟮s⟯.toSubalgebra.algebra
-  let φ : carrier →ₐ[x.carrier] K := ((algHomAdjoinIntegralEquiv x.carrier I1).symm
-    ⟨rootOfSplits x.emb.toRingHom key I2, by
-      rw [mem_aroots, and_iff_right (minpoly.ne_zero I1)]
-      exact map_rootOfSplits x.emb.toRingHom key I2⟩)
+  let φ : carrier →ₐ[x.carrier] K := ((algHomAdjoinIntegralEquiv x.carrier h1).symm
+    ⟨rootOfSplits x.emb.toRingHom h2 I2, by
+      rw [mem_aroots, and_iff_right (minpoly.ne_zero h1)]
+      exact map_rootOfSplits x.emb.toRingHom h2 I2⟩)
   ⟨⟨carrier, (@algHomEquivSigma F x.carrier carrier K _ _ _ _ _ _ _ _
       (IsScalarTower.of_algebraMap_eq fun _ ↦ rfl)).symm ⟨x.emb, φ⟩⟩,
     ⟨fun z hz ↦ algebraMap_mem x.carrier⟮s⟯ ⟨z, hz⟩, φ.commutes⟩,
     mem_adjoin_simple_self x.carrier s⟩
+
+theorem Lifts.exists_lift_of_splits (x : Lifts F E K) {s : E} (h1 : IsIntegral F s)
+    (h2 : (minpoly F s).Splits (algebraMap F K)) : ∃ y, x ≤ y ∧ s ∈ y.carrier :=
+  Lifts.exists_lift_of_splits' x h1.tower_top <| h1.minpoly_splits_tower_top' <| by
+    rwa [← x.emb.comp_algebraMap] at h2
 #align intermediate_field.lifts.exists_lift_of_splits IntermediateField.Lifts.exists_lift_of_splits
+
+section
+
+private theorem exists_algHom_adjoin_of_splits'' {L : IntermediateField F E}
+     (f : L →ₐ[F] K) (hK : ∀ s ∈ S, IsIntegral L s ∧ (minpoly L s).Splits f.toRingHom) :
+    ∃ φ : adjoin L S →ₐ[F] K, φ.comp (IsScalarTower.toAlgHom F L _) = f := by
+  obtain ⟨φ, hfφ, hφ⟩ := zorn_nonempty_Ici₀ _
+    (fun c _ hc _ _ ↦ Lifts.exists_upper_bound c hc) ⟨L, f⟩ le_rfl
+  refine ⟨φ.emb.comp (inclusion <| (le_extendScalars_iff hfφ.1 <| adjoin L S).mp <|
+    adjoin_le_iff.mpr fun s h ↦ ?_), AlgHom.ext hfφ.2⟩
+  letI := (inclusion hfφ.1).toAlgebra
+  letI : SMul L φ.carrier := Algebra.toSMul
+  have : IsScalarTower L φ.carrier E := ⟨fun x y z ↦ smul_assoc x (y : E) z⟩
+  have := φ.exists_lift_of_splits' (hK s h).1.tower_top ((hK s h).1.minpoly_splits_tower_top' ?_)
+  · obtain ⟨y, h1, h2⟩ := this; exact (hφ y h1).1 h2
+  · convert (hK s h).2; ext; apply hfφ.2
+
+variable {L : Type*} [Field L] [Algebra F L] [Algebra L E] [IsScalarTower F L E]
+  (f : L →ₐ[F] K) (hK : ∀ s ∈ S, IsIntegral L s ∧ (minpoly L s).Splits f.toRingHom)
+
+theorem exists_algHom_adjoin_of_splits' :
+    ∃ φ : adjoin L S →ₐ[F] K, φ.comp (IsScalarTower.toAlgHom F L _) = f := by
+  let f' : (IsScalarTower.toAlgHom F L E).fieldRange →ₐ[F] K :=
+    f.comp (AlgEquiv.ofInjectiveField _).symm.toAlgHom
+  --have := adjoin L S = adjoin (↥(AlgHom.fieldRange (IsScalarTower.toAlgHom F L E))) S
+  have := exists_algHom_adjoin_of_splits'' f' (S := S) ?_
+  · obtain ⟨φ, hφ⟩ := this; refine ⟨?_, ?_⟩
+    · change (adjoin L S).restrictScalars F →ₐ[F] K
+      rw [restrictScalars_adjoin]
+      rw [← coe_restrictScalars F (E := adjoin L S)]
+    --restrictScalars_adjoin
+  obtain ⟨φ, hfφ, hφ⟩ := zorn_nonempty_Ici₀ _ (fun c _ hc _ _ ↦ Lifts.exists_upper_bound c hc)
+    ⟨(IsScalarTower.toAlgHom F L E).fieldRange, f.comp (AlgEquiv.ofInjectiveField _).symm.toAlgHom⟩
+    le_rfl
+  have : (adjoin L S).restrictScalars F ≤ φ.carrier
+
+    --apply adjoin_le_iff.mpr fun s hs ↦ ?_
+  let x : (IsScalarTower.toAlgHom F L E).fieldRange →ₐ[F] K :=
+    f.comp (AlgEquiv.ofInjectiveField _).symm.toAlgHom
+
+end
+
+/- theorem algHom_comp_surjective_of_splits {L : IntermediateField F E} (f : L →ₐ[F] K)
+    (h : ∀ s : E, IsIntegral L s ∧ (minpoly L s).Splits f) :
+    ∃ φ : E →ₐ[F] K, φ.comp L.val = f := by
+  rfl -/
+
+--theorem  :
+
 
 variable (hK : ∀ s ∈ S, IsIntegral F s ∧ (minpoly F s).Splits (algebraMap F K))
         (hK' : ∀ s : E, IsIntegral F s ∧ (minpoly F s).Splits (algebraMap F K))

--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -212,6 +212,9 @@ namespace IsAlgClosed
 variable {K : Type u} [Field K] {L : Type v} {M : Type w} [Field L] [Algebra K L] [Field M]
   [Algebra K M] [IsAlgClosed M]
 
+/-- If E/L/K is a tower of field extensions with E/L algebraic, and if M is an algebraically
+  closed extension of K, then any embedding of L/K into M/K extends to an embedding of E/K.
+  Known as the extension lemma in https://math.stackexchange.com/a/687914. -/
 theorem surjective_comp_algebraMap_of_isAlgebraic {E : Type*}
     [Field E] [Algebra K E] [Algebra L E] [IsScalarTower K L E] (hE : Algebra.IsAlgebraic L E) :
     Function.Surjective fun φ : E →ₐ[K] M ↦ φ.comp (IsScalarTower.toAlgHom K L E) :=

--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -209,8 +209,16 @@ instance (priority := 100) IsAlgClosure.separable (R K : Type*) [Field R] [Field
 
 namespace IsAlgClosed
 
-variable (K : Type u) [Field K] (L : Type v) (M : Type w) [Field L] [Algebra K L] [Field M]
-  [Algebra K M] [IsAlgClosed M] (hL : Algebra.IsAlgebraic K L)
+variable {K : Type u} [Field K] {L : Type v} {M : Type w} [Field L] [Algebra K L] [Field M]
+  [Algebra K M] [IsAlgClosed M]
+
+theorem surjective_comp_algebraMap_of_isAlgebraic {E : Type*}
+    [Field E] [Algebra K E] [Algebra L E] [IsScalarTower K L E] (hE : Algebra.IsAlgebraic L E) :
+    Function.Surjective fun φ : E →ₐ[K] M ↦ φ.comp (IsScalarTower.toAlgHom K L E) :=
+  fun f ↦ IntermediateField.exists_algHom_of_splits'
+    (E := E) f fun s ↦ ⟨(hE s).isIntegral, IsAlgClosed.splits_codomain _⟩
+
+variable (hL : Algebra.IsAlgebraic K L) (K L M)
 
 /-- Less general version of `lift`. -/
 private noncomputable irreducible_def lift_aux : L →ₐ[K] M :=

--- a/Mathlib/FieldTheory/IsSepClosed.lean
+++ b/Mathlib/FieldTheory/IsSepClosed.lean
@@ -200,8 +200,16 @@ end IsSepClosure
 
 namespace IsSepClosed
 
-variable {K : Type u} {L : Type v} {M : Type w} [Field K] [Field L] [Algebra K L] [Field M]
-  [Algebra K M] [IsSepClosed M] [IsSeparable K L]
+variable {K : Type u} (L : Type v) {M : Type w} [Field K] [Field L] [Algebra K L] [Field M]
+  [Algebra K M] [IsSepClosed M]
+
+theorem surjective_comp_algebraMap_of_isSeparable {E : Type*}
+    [Field E] [Algebra K E] [Algebra L E] [IsScalarTower K L E] [IsSeparable L E] :
+    Function.Surjective fun φ : E →ₐ[K] M ↦ φ.comp (IsScalarTower.toAlgHom K L E) :=
+  fun f ↦ IntermediateField.exists_algHom_of_splits' (E := E) f
+    fun s ↦ ⟨IsSeparable.isIntegral L s, IsSepClosed.splits_codomain _ <| IsSeparable.separable L s⟩
+
+variable [IsSeparable K L] {L}
 
 /-- A (random) homomorphism from a separable extension L of K into a separably
   closed extension M of K. -/

--- a/Mathlib/RingTheory/Adjoin/Field.lean
+++ b/Mathlib/RingTheory/Adjoin/Field.lean
@@ -95,10 +95,16 @@ theorem IsIntegral.mem_range_algebraMap_of_minpoly_splits [Algebra K L] [IsScala
     x ∈ (algebraMap K L).range :=
   int.mem_range_algHom_of_minpoly_splits h (IsScalarTower.toAlgHom R K L)
 
-theorem IsIntegral.minpoly_splits_tower_top
-    [Algebra K L] [IsScalarTower R K L] [Algebra K M] [IsScalarTower R K M]
-    {x : M} (int : IsIntegral R x) (h : Splits (algebraMap R L) (minpoly R x)) :
+variable [Algebra K M] [IsScalarTower R K M] {x : M} (int : IsIntegral R x)
+
+theorem IsIntegral.minpoly_splits_tower_top' {f : K →+* L}
+    (h : Splits (f.comp <| algebraMap R K) (minpoly R x)) :
+    Splits f (minpoly K x) :=
+  splits_of_splits_of_dvd _ ((minpoly.monic int).map _).ne_zero
+    ((splits_map_iff _ _).mpr h) (minpoly.dvd_map_of_isScalarTower R _ x)
+
+theorem IsIntegral.minpoly_splits_tower_top [Algebra K L] [IsScalarTower R K L]
+    (h : Splits (algebraMap R L) (minpoly R x)) :
     Splits (algebraMap K L) (minpoly K x) := by
   rw [IsScalarTower.algebraMap_eq R K L] at h
-  exact splits_of_splits_of_dvd _ ((minpoly.monic int).map _).ne_zero
-    ((splits_map_iff _ _).mpr h) (minpoly.dvd_map_of_isScalarTower R _ x)
+  exact int.minpoly_splits_tower_top' h


### PR DESCRIPTION
+ Extract from `Lifts.exists_lift_of_splits` a version that assumes integrality and splitting of minimal polynomial over an intermediate field (either actual IntermediateField or middle of IsScalarTower) rather than the base field

+ Generalize `exists_algHom_adjoin_of_splits`, `exists_algHom_of_adjoin_splits`, `exists_algHom_of_splits` to the same setting

+ Prove the [extension lemma](https://math.stackexchange.com/a/687914/12932) `surjective_comp_algebraMap_of_isAlgebraic/isSeparable` to be used in the proof that an epimorphism in the category of fields is a purely inseparable extension.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
