### PR TITLE
[Merged by Bors] - feat(Data/Real/EReal): add lemmas about intervals

### DIFF
--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -531,13 +531,6 @@ lemma preimage_coe_Ioo (x y : ℝ) : Real.toEReal ⁻¹' Ioo x y = Ioo x y := by
   simp only [WithBot.preimage_coe_Ioo, WithTop.preimage_coe_Ioo]
 
 @[simp]
-lemma preimage_coe_Icc_top (x : ℝ) : Real.toEReal ⁻¹' Icc x ⊤ = Ici x := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹'
-    (Icc (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Icc, Icc_top, WithTop.preimage_coe_Ici]
-
-@[simp]
 lemma preimage_coe_Ico_top (x : ℝ) : Real.toEReal ⁻¹' Ico x ⊤ = Ici x := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Ico (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
@@ -545,32 +538,11 @@ lemma preimage_coe_Ico_top (x : ℝ) : Real.toEReal ⁻¹' Ico x ⊤ = Ici x := 
   simp only [WithBot.preimage_coe_Ico, WithTop.preimage_coe_Ico_top]
 
 @[simp]
-lemma preimage_coe_Ioc_top (x : ℝ) : Real.toEReal ⁻¹' Ioc x ⊤ = Ioi x := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹'
-    (Ioc (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Ioc, Ioc_top, WithTop.preimage_coe_Ioi]
-
-@[simp]
 lemma preimage_coe_Ioo_top (x : ℝ) : Real.toEReal ⁻¹' Ioo x ⊤ = Ioi x := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Ioo (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Ioo, WithTop.preimage_coe_Ioo_top]
-
-@[simp]
-lemma preimage_coe_Icc_bot (y : ℝ) : Real.toEReal ⁻¹' Icc ⊥ y = Iic y := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹'
-    (Icc ⊥ (WithBot.some (WithTop.some y))) = _
-  refine preimage_comp.trans ?_
-  simp only [Icc_bot, WithBot.preimage_coe_Iic, WithTop.preimage_coe_Iic]
-
-@[simp]
-lemma preimage_coe_Ico_bot (y : ℝ) : Real.toEReal ⁻¹' Ico ⊥ y = Iio y := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹'
-    (Ico ⊥ (WithBot.some (WithTop.some y))) = _
-  refine preimage_comp.trans ?_
-  simp only [Ico_bot, WithBot.preimage_coe_Iio, WithTop.preimage_coe_Iio]
 
 @[simp]
 lemma preimage_coe_Ioc_bot (y : ℝ) : Real.toEReal ⁻¹' Ioc ⊥ y = Iic y := by
@@ -585,24 +557,6 @@ lemma preimage_coe_Ioo_bot (y : ℝ) : Real.toEReal ⁻¹' Ioo ⊥ y = Iio y := 
     (Ioo ⊥ (WithBot.some (WithTop.some y))) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Ioo_bot, WithTop.preimage_coe_Iio]
-
-@[simp]
-lemma preimage_coe_Icc_bot_top : Real.toEReal ⁻¹' Icc ⊥ ⊤ = univ := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹' (Icc ⊥ (WithBot.some ⊤)) = _
-  refine preimage_comp.trans ?_
-  simp only [Icc_bot, WithBot.preimage_coe_Iic, Iic_top, preimage_univ]
-
-@[simp]
-lemma preimage_coe_Ico_bot_top : Real.toEReal ⁻¹' Ico ⊥ ⊤ = univ := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹' (Ico ⊥ (WithBot.some ⊤)) = _
-  refine preimage_comp.trans ?_
-  simp only [Ico_bot, WithBot.preimage_coe_Iio, WithTop.preimage_coe_Iio_top]
-
-@[simp]
-lemma preimage_coe_Ioc_bot_top : Real.toEReal ⁻¹' Ioc ⊥ ⊤ = univ := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹' (Ioc ⊥ (WithBot.some ⊤)) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Ioc_bot, Iic_top, preimage_univ]
 
 @[simp]
 lemma preimage_coe_Ioo_bot_top : Real.toEReal ⁻¹' Ioo ⊥ ⊤ = univ := by
@@ -623,12 +577,6 @@ lemma preimage_coe_Ioi (x : ℝ) : Real.toEReal ⁻¹' Ioi x = Ioi x := by
   simp only [WithBot.preimage_coe_Ioi, WithTop.preimage_coe_Ioi]
 
 @[simp]
-lemma preimage_coe_Ici_bot : Real.toEReal ⁻¹' Ici ⊥ = univ := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹' (Ici ⊥) = _
-  refine preimage_comp.trans ?_
-  simp only [Ici_bot, preimage_univ]
-
-@[simp]
 lemma preimage_coe_Ioi_bot : Real.toEReal ⁻¹' Ioi ⊥ = univ := by
   change (WithBot.some ∘ WithTop.some) ⁻¹' (Ioi ⊥) = _
   refine preimage_comp.trans ?_
@@ -645,12 +593,6 @@ lemma preimage_coe_Iio (y : ℝ) : Real.toEReal ⁻¹' Iio y = Iio y := by
   change (WithBot.some ∘ WithTop.some) ⁻¹' (Iio (WithBot.some (WithTop.some y))) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Iio, WithTop.preimage_coe_Iio]
-
-@[simp]
-lemma preimage_coe_Iic_top : Real.toEReal ⁻¹' Iic ⊤ = univ := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹' (Iic (WithBot.some ⊤)) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Iic, Iic_top, preimage_univ]
 
 @[simp]
 lemma preimage_coe_Iio_top : Real.toEReal ⁻¹' Iio ⊤ = univ := by

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -503,84 +503,84 @@ lemma image_coe_Iio {x : ℝ} : Real.toEReal '' Iio x = Ioo ⊥ ↑x := by
   rfl
 
 @[simp]
-lemma preimage_coe_Icc {x y : ℝ} : Real.toEReal ⁻¹' Icc x y = Icc x y := by
+lemma preimage_coe_Icc (x y : ℝ) : Real.toEReal ⁻¹' Icc x y = Icc x y := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Icc (WithBot.some (WithTop.some x)) (WithBot.some (WithTop.some y))) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Icc, WithTop.preimage_coe_Icc]
 
 @[simp]
-lemma preimage_coe_Ico {x y : ℝ} : Real.toEReal ⁻¹' Ico x y = Ico x y := by
+lemma preimage_coe_Ico (x y : ℝ) : Real.toEReal ⁻¹' Ico x y = Ico x y := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Ico (WithBot.some (WithTop.some x)) (WithBot.some (WithTop.some y))) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Ico, WithTop.preimage_coe_Ico]
 
 @[simp]
-lemma preimage_coe_Ioc {x y : ℝ} : Real.toEReal ⁻¹' Ioc x y = Ioc x y := by
+lemma preimage_coe_Ioc (x y : ℝ) : Real.toEReal ⁻¹' Ioc x y = Ioc x y := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Ioc (WithBot.some (WithTop.some x)) (WithBot.some (WithTop.some y))) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Ioc, WithTop.preimage_coe_Ioc]
 
 @[simp]
-lemma preimage_coe_Ioo {x y : ℝ} : Real.toEReal ⁻¹' Ioo x y = Ioo x y := by
+lemma preimage_coe_Ioo (x y : ℝ) : Real.toEReal ⁻¹' Ioo x y = Ioo x y := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Ioo (WithBot.some (WithTop.some x)) (WithBot.some (WithTop.some y))) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Ioo, WithTop.preimage_coe_Ioo]
 
 @[simp]
-lemma preimage_coe_Icc_top {x : ℝ} : Real.toEReal ⁻¹' Icc x ⊤ = Ici x := by
+lemma preimage_coe_Icc_top (x : ℝ) : Real.toEReal ⁻¹' Icc x ⊤ = Ici x := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Icc (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Icc, Icc_top, WithTop.preimage_coe_Ici]
 
 @[simp]
-lemma preimage_coe_Ico_top {x : ℝ} : Real.toEReal ⁻¹' Ico x ⊤ = Ici x := by
+lemma preimage_coe_Ico_top (x : ℝ) : Real.toEReal ⁻¹' Ico x ⊤ = Ici x := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Ico (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Ico, WithTop.preimage_coe_Ico_top]
 
 @[simp]
-lemma preimage_coe_Ioc_top {x : ℝ} : Real.toEReal ⁻¹' Ioc x ⊤ = Ioi x := by
+lemma preimage_coe_Ioc_top (x : ℝ) : Real.toEReal ⁻¹' Ioc x ⊤ = Ioi x := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Ioc (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Ioc, Ioc_top, WithTop.preimage_coe_Ioi]
 
 @[simp]
-lemma preimage_coe_Ioo_top {x : ℝ} : Real.toEReal ⁻¹' Ioo x ⊤ = Ioi x := by
+lemma preimage_coe_Ioo_top (x : ℝ) : Real.toEReal ⁻¹' Ioo x ⊤ = Ioi x := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Ioo (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Ioo, WithTop.preimage_coe_Ioo_top]
 
 @[simp]
-lemma preimage_coe_Icc_bot {y : ℝ} : Real.toEReal ⁻¹' Icc ⊥ y = Iic y := by
+lemma preimage_coe_Icc_bot (y : ℝ) : Real.toEReal ⁻¹' Icc ⊥ y = Iic y := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Icc ⊥ (WithBot.some (WithTop.some y))) = _
   refine preimage_comp.trans ?_
   simp only [Icc_bot, WithBot.preimage_coe_Iic, WithTop.preimage_coe_Iic]
 
 @[simp]
-lemma preimage_coe_Ico_bot {y : ℝ} : Real.toEReal ⁻¹' Ico ⊥ y = Iio y := by
+lemma preimage_coe_Ico_bot (y : ℝ) : Real.toEReal ⁻¹' Ico ⊥ y = Iio y := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Ico ⊥ (WithBot.some (WithTop.some y))) = _
   refine preimage_comp.trans ?_
   simp only [Ico_bot, WithBot.preimage_coe_Iio, WithTop.preimage_coe_Iio]
 
 @[simp]
-lemma preimage_coe_Ioc_bot {y : ℝ} : Real.toEReal ⁻¹' Ioc ⊥ y = Iic y := by
+lemma preimage_coe_Ioc_bot (y : ℝ) : Real.toEReal ⁻¹' Ioc ⊥ y = Iic y := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Ioc ⊥ (WithBot.some (WithTop.some y))) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Ioc_bot, WithTop.preimage_coe_Iic]
 
 @[simp]
-lemma preimage_coe_Ioo_bot {y : ℝ} : Real.toEReal ⁻¹' Ioo ⊥ y = Iio y := by
+lemma preimage_coe_Ioo_bot (y : ℝ) : Real.toEReal ⁻¹' Ioo ⊥ y = Iio y := by
   change (WithBot.some ∘ WithTop.some) ⁻¹'
     (Ioo ⊥ (WithBot.some (WithTop.some y))) = _
   refine preimage_comp.trans ?_
@@ -611,13 +611,13 @@ lemma preimage_coe_Ioo_bot_top : Real.toEReal ⁻¹' Ioo ⊥ ⊤ = univ := by
   simp only [WithBot.preimage_coe_Ioo_bot, WithTop.preimage_coe_Iio_top]
 
 @[simp]
-lemma preimage_coe_Ici {x : ℝ} : Real.toEReal ⁻¹' Ici x = Ici x := by
+lemma preimage_coe_Ici (x : ℝ) : Real.toEReal ⁻¹' Ici x = Ici x := by
   change (WithBot.some ∘ WithTop.some) ⁻¹' (Ici (WithBot.some (WithTop.some x))) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Ici, WithTop.preimage_coe_Ici]
 
 @[simp]
-lemma preimage_coe_Ioi {x : ℝ} : Real.toEReal ⁻¹' Ioi x = Ioi x := by
+lemma preimage_coe_Ioi (x : ℝ) : Real.toEReal ⁻¹' Ioi x = Ioi x := by
   change (WithBot.some ∘ WithTop.some) ⁻¹' (Ioi (WithBot.some (WithTop.some x))) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Ioi, WithTop.preimage_coe_Ioi]
@@ -635,13 +635,13 @@ lemma preimage_coe_Ioi_bot : Real.toEReal ⁻¹' Ioi ⊥ = univ := by
   simp only [WithBot.preimage_coe_Ioi_bot, preimage_univ]
 
 @[simp]
-lemma preimage_coe_Iic {y : ℝ} : Real.toEReal ⁻¹' Iic y = Iic y := by
+lemma preimage_coe_Iic (y : ℝ) : Real.toEReal ⁻¹' Iic y = Iic y := by
   change (WithBot.some ∘ WithTop.some) ⁻¹' (Iic (WithBot.some (WithTop.some y))) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Iic, WithTop.preimage_coe_Iic]
 
 @[simp]
-lemma preimage_coe_Iio {y : ℝ} : Real.toEReal ⁻¹' Iio y = Iio y := by
+lemma preimage_coe_Iio (y : ℝ) : Real.toEReal ⁻¹' Iio y = Iio y := by
   change (WithBot.some ∘ WithTop.some) ⁻¹' (Iio (WithBot.some (WithTop.some y))) = _
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Iio, WithTop.preimage_coe_Iio]

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -455,49 +455,49 @@ lemma exists_between_coe_real {x z : EReal} (h : x < z) : ∃ y : ℝ, x < y ∧
   · exact (not_top_lt ha₂).elim
 
 @[simp]
-lemma image_coe_Icc {x y : ℝ} : Real.toEReal '' Icc x y = Icc ↑x ↑y := by
+lemma image_coe_Icc (x y : ℝ) : Real.toEReal '' Icc x y = Icc ↑x ↑y := by
   refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Icc, WithBot.image_coe_Icc]
   rfl
 
 @[simp]
-lemma image_coe_Ico {x y : ℝ} : Real.toEReal '' Ico x y = Ico ↑x ↑y := by
+lemma image_coe_Ico (x y : ℝ) : Real.toEReal '' Ico x y = Ico ↑x ↑y := by
   refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Ico, WithBot.image_coe_Ico]
   rfl
 
 @[simp]
-lemma image_coe_Ici {x : ℝ} : Real.toEReal '' Ici x = Ico ↑x ⊤ := by
+lemma image_coe_Ici (x : ℝ) : Real.toEReal '' Ici x = Ico ↑x ⊤ := by
   refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Ici, WithBot.image_coe_Ico]
   rfl
 
 @[simp]
-lemma image_coe_Ioc {x y : ℝ} : Real.toEReal '' Ioc x y = Ioc ↑x ↑y := by
+lemma image_coe_Ioc (x y : ℝ) : Real.toEReal '' Ioc x y = Ioc ↑x ↑y := by
   refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Ioc, WithBot.image_coe_Ioc]
   rfl
 
 @[simp]
-lemma image_coe_Ioo {x y : ℝ} : Real.toEReal '' Ioo x y = Ioo ↑x ↑y := by
+lemma image_coe_Ioo (x y : ℝ) : Real.toEReal '' Ioo x y = Ioo ↑x ↑y := by
   refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Ioo, WithBot.image_coe_Ioo]
   rfl
 
 @[simp]
-lemma image_coe_Ioi {x : ℝ} : Real.toEReal '' Ioi x = Ioo ↑x ⊤ := by
+lemma image_coe_Ioi (x : ℝ) : Real.toEReal '' Ioi x = Ioo ↑x ⊤ := by
   refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Ioi, WithBot.image_coe_Ioo]
   rfl
 
 @[simp]
-lemma image_coe_Iic {x : ℝ} : Real.toEReal '' Iic x = Ioc ⊥ ↑x := by
+lemma image_coe_Iic (x : ℝ) : Real.toEReal '' Iic x = Ioc ⊥ ↑x := by
   refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Iic, WithBot.image_coe_Iic]
   rfl
 
 @[simp]
-lemma image_coe_Iio {x : ℝ} : Real.toEReal '' Iio x = Ioo ⊥ ↑x := by
+lemma image_coe_Iio (x : ℝ) : Real.toEReal '' Iio x = Ioo ⊥ ↑x := by
   refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Iio, WithBot.image_coe_Iio]
   rfl

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -447,59 +447,217 @@ theorem eq_bot_iff_forall_lt (x : EReal) : x = ⊥ ↔ ∀ y : ℝ, x < (y : ERe
 
 /-! ### Intervals and coercion from reals -/
 
-lemma exists_between_ofReal_left {x : EReal} {z : ℝ} (h : x < z) : ∃ y : ℝ, x < y ∧ y < z := by
+lemma exists_between_ofReal {x z : EReal} (h : x < z) : ∃ y : ℝ, x < y ∧ y < z := by
   obtain ⟨a, ha₁, ha₂⟩ := exists_between h
   induction' a using EReal.rec with a₀
-  · simp only [not_lt_bot] at ha₁
+  · exact (not_lt_bot ha₁).elim
   · exact ⟨a₀, by exact_mod_cast ha₁, by exact_mod_cast ha₂⟩
-  · simp only [not_top_lt] at ha₂
+  · exact (not_top_lt ha₂).elim
 
-lemma exists_between_ofReal_right {x : ℝ} {z : EReal} (h : x < z) : ∃ y : ℝ, x < y ∧ y < z := by
-  obtain ⟨a, ha₁, ha₂⟩ := exists_between h
-  induction' a using EReal.rec with a₀
-  · simp only [not_lt_bot] at ha₁
-  · exact ⟨a₀, by exact_mod_cast ha₁, by exact_mod_cast ha₂⟩
-  · simp only [not_top_lt] at ha₂
-
-lemma Icc_of_Real {x y : ℝ} : Real.toEReal '' Set.Icc x y = Set.Icc ↑x ↑y := by
-  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+@[simp]
+lemma image_coe_Icc {x y : ℝ} : Real.toEReal '' Icc x y = Icc ↑x ↑y := by
+  refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Icc, WithBot.image_coe_Icc]
   rfl
 
-lemma Ico_of_Real {x y : ℝ} : Real.toEReal '' Set.Ico x y = Set.Ico ↑x ↑y := by
-  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+@[simp]
+lemma image_coe_Ico {x y : ℝ} : Real.toEReal '' Ico x y = Ico ↑x ↑y := by
+  refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Ico, WithBot.image_coe_Ico]
   rfl
 
-lemma Ici_of_Real {x : ℝ} : Real.toEReal '' Set.Ici x = Set.Ico ↑x ⊤ := by
-  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+@[simp]
+lemma image_coe_Ici {x : ℝ} : Real.toEReal '' Ici x = Ico ↑x ⊤ := by
+  refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Ici, WithBot.image_coe_Ico]
   rfl
 
-lemma Ioc_of_Real {x y : ℝ} : Real.toEReal '' Set.Ioc x y = Set.Ioc ↑x ↑y := by
-  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+@[simp]
+lemma image_coe_Ioc {x y : ℝ} : Real.toEReal '' Ioc x y = Ioc ↑x ↑y := by
+  refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Ioc, WithBot.image_coe_Ioc]
   rfl
 
-lemma Ioo_of_Real {x y : ℝ} : Real.toEReal '' Set.Ioo x y = Set.Ioo ↑x ↑y := by
-  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+@[simp]
+lemma image_coe_Ioo {x y : ℝ} : Real.toEReal '' Ioo x y = Ioo ↑x ↑y := by
+  refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Ioo, WithBot.image_coe_Ioo]
   rfl
 
-lemma Ioi_ofReal {x : ℝ} : Real.toEReal '' Set.Ioi x = Set.Ioo ↑x ⊤ := by
-  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+@[simp]
+lemma image_coe_Ioi {x : ℝ} : Real.toEReal '' Ioi x = Ioo ↑x ⊤ := by
+  refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Ioi, WithBot.image_coe_Ioo]
   rfl
 
-lemma Iic_ofReal {x : ℝ} : Real.toEReal '' Set.Iic x = Set.Ioc ⊥ ↑x := by
-  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+@[simp]
+lemma image_coe_Iic {x : ℝ} : Real.toEReal '' Iic x = Ioc ⊥ ↑x := by
+  refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Iic, WithBot.image_coe_Iic]
   rfl
 
-lemma Iio_ofReal {x : ℝ} : Real.toEReal '' Set.Iio x = Set.Ioo ⊥ ↑x := by
-  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+@[simp]
+lemma image_coe_Iio {x : ℝ} : Real.toEReal '' Iio x = Ioo ⊥ ↑x := by
+  refine (image_comp WithBot.some WithTop.some _).trans ?_
   rw [WithTop.image_coe_Iio, WithBot.image_coe_Iio]
   rfl
+
+@[simp]
+lemma preimage_coe_Icc {x y : ℝ} : Real.toEReal ⁻¹' Icc x y = Icc x y := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹'
+    (Icc (WithBot.some (WithTop.some x)) (WithBot.some (WithTop.some y))) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Icc, WithTop.preimage_coe_Icc]
+
+@[simp]
+lemma preimage_coe_Ico {x y : ℝ} : Real.toEReal ⁻¹' Ico x y = Ico x y := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹'
+    (Ico (WithBot.some (WithTop.some x)) (WithBot.some (WithTop.some y))) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ico, WithTop.preimage_coe_Ico]
+
+@[simp]
+lemma preimage_coe_Ioc {x y : ℝ} : Real.toEReal ⁻¹' Ioc x y = Ioc x y := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹'
+    (Ioc (WithBot.some (WithTop.some x)) (WithBot.some (WithTop.some y))) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ioc, WithTop.preimage_coe_Ioc]
+
+@[simp]
+lemma preimage_coe_Ioo {x y : ℝ} : Real.toEReal ⁻¹' Ioo x y = Ioo x y := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹'
+    (Ioo (WithBot.some (WithTop.some x)) (WithBot.some (WithTop.some y))) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ioo, WithTop.preimage_coe_Ioo]
+
+@[simp]
+lemma preimage_coe_Icc_top {x : ℝ} : Real.toEReal ⁻¹' Icc x ⊤ = Ici x := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹'
+    (Icc (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Icc, Icc_top, WithTop.preimage_coe_Ici]
+
+@[simp]
+lemma preimage_coe_Ico_top {x : ℝ} : Real.toEReal ⁻¹' Ico x ⊤ = Ici x := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹'
+    (Ico (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ico, WithTop.preimage_coe_Ico_top]
+
+@[simp]
+lemma preimage_coe_Ioc_top {x : ℝ} : Real.toEReal ⁻¹' Ioc x ⊤ = Ioi x := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹'
+    (Ioc (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ioc, Ioc_top, WithTop.preimage_coe_Ioi]
+
+@[simp]
+lemma preimage_coe_Ioo_top {x : ℝ} : Real.toEReal ⁻¹' Ioo x ⊤ = Ioi x := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹'
+    (Ioo (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ioo, WithTop.preimage_coe_Ioo_top]
+
+@[simp]
+lemma preimage_coe_Icc_bot {y : ℝ} : Real.toEReal ⁻¹' Icc ⊥ y = Iic y := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹'
+    (Icc ⊥ (WithBot.some (WithTop.some y))) = _
+  refine preimage_comp.trans ?_
+  simp only [Icc_bot, WithBot.preimage_coe_Iic, WithTop.preimage_coe_Iic]
+
+@[simp]
+lemma preimage_coe_Ico_bot {y : ℝ} : Real.toEReal ⁻¹' Ico ⊥ y = Iio y := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹'
+    (Ico ⊥ (WithBot.some (WithTop.some y))) = _
+  refine preimage_comp.trans ?_
+  simp only [Ico_bot, WithBot.preimage_coe_Iio, WithTop.preimage_coe_Iio]
+
+@[simp]
+lemma preimage_coe_Ioc_bot {y : ℝ} : Real.toEReal ⁻¹' Ioc ⊥ y = Iic y := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹'
+    (Ioc ⊥ (WithBot.some (WithTop.some y))) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ioc_bot, WithTop.preimage_coe_Iic]
+
+@[simp]
+lemma preimage_coe_Ioo_bot {y : ℝ} : Real.toEReal ⁻¹' Ioo ⊥ y = Iio y := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹'
+    (Ioo ⊥ (WithBot.some (WithTop.some y))) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ioo_bot, WithTop.preimage_coe_Iio]
+
+@[simp]
+lemma preimage_coe_Icc_bot_top : Real.toEReal ⁻¹' Icc ⊥ ⊤ = univ := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹' (Icc ⊥ (WithBot.some ⊤)) = _
+  refine preimage_comp.trans ?_
+  simp only [Icc_bot, WithBot.preimage_coe_Iic, Iic_top, preimage_univ]
+
+@[simp]
+lemma preimage_coe_Ico_bot_top : Real.toEReal ⁻¹' Ico ⊥ ⊤ = univ := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹' (Ico ⊥ (WithBot.some ⊤)) = _
+  refine preimage_comp.trans ?_
+  simp only [Ico_bot, WithBot.preimage_coe_Iio, WithTop.preimage_coe_Iio_top]
+
+@[simp]
+lemma preimage_coe_Ioc_bot_top : Real.toEReal ⁻¹' Ioc ⊥ ⊤ = univ := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹' (Ioc ⊥ (WithBot.some ⊤)) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ioc_bot, Iic_top, preimage_univ]
+
+@[simp]
+lemma preimage_coe_Ioo_bot_top : Real.toEReal ⁻¹' Ioo ⊥ ⊤ = univ := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹' (Ioo ⊥ (WithBot.some ⊤)) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ioo_bot, WithTop.preimage_coe_Iio_top]
+
+@[simp]
+lemma preimage_coe_Ici {x : ℝ} : Real.toEReal ⁻¹' Ici x = Ici x := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹' (Ici (WithBot.some (WithTop.some x))) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ici, WithTop.preimage_coe_Ici]
+
+@[simp]
+lemma preimage_coe_Ioi {x : ℝ} : Real.toEReal ⁻¹' Ioi x = Ioi x := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹' (Ioi (WithBot.some (WithTop.some x))) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ioi, WithTop.preimage_coe_Ioi]
+
+@[simp]
+lemma preimage_coe_Ici_bot : Real.toEReal ⁻¹' Ici ⊥ = univ := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹' (Ici ⊥) = _
+  refine preimage_comp.trans ?_
+  simp only [Ici_bot, preimage_univ]
+
+@[simp]
+lemma preimage_coe_Ioi_bot : Real.toEReal ⁻¹' Ioi ⊥ = univ := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹' (Ioi ⊥) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Ioi_bot, preimage_univ]
+
+@[simp]
+lemma preimage_coe_Iic {y : ℝ} : Real.toEReal ⁻¹' Iic y = Iic y := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹' (Iic (WithBot.some (WithTop.some y))) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Iic, WithTop.preimage_coe_Iic]
+
+@[simp]
+lemma preimage_coe_Iio {y : ℝ} : Real.toEReal ⁻¹' Iio y = Iio y := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹' (Iio (WithBot.some (WithTop.some y))) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Iio, WithTop.preimage_coe_Iio]
+
+@[simp]
+lemma preimage_coe_Iic_top : Real.toEReal ⁻¹' Iic ⊤ = univ := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹' (Iic (WithBot.some ⊤)) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Iic, Iic_top, preimage_univ]
+
+@[simp]
+lemma preimage_coe_Iio_top : Real.toEReal ⁻¹' Iio ⊤ = univ := by
+  change (WithBot.some ∘ WithTop.some) ⁻¹' (Iio (WithBot.some ⊤)) = _
+  refine preimage_comp.trans ?_
+  simp only [WithBot.preimage_coe_Iio, WithTop.preimage_coe_Iio_top]
+
 
 /-! ### ennreal coercion -/
 

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -445,6 +445,62 @@ theorem eq_bot_iff_forall_lt (x : EReal) : x = ⊥ ↔ ∀ y : ℝ, x < (y : ERe
     exact ⟨x.toReal, coe_toReal_le h⟩
 #align ereal.eq_bot_iff_forall_lt EReal.eq_bot_iff_forall_lt
 
+/-! ### Intervals and coercion from reals -/
+
+lemma exists_between_ofReal_left {x : EReal} {z : ℝ} (h : x < z) : ∃ y : ℝ, x < y ∧ y < z := by
+  obtain ⟨a, ha₁, ha₂⟩ := exists_between h
+  induction' a using EReal.rec with a₀
+  · simp only [not_lt_bot] at ha₁
+  · exact ⟨a₀, by exact_mod_cast ha₁, by exact_mod_cast ha₂⟩
+  · simp only [not_top_lt] at ha₂
+
+lemma exists_between_ofReal_right {x : ℝ} {z : EReal} (h : x < z) : ∃ y : ℝ, x < y ∧ y < z := by
+  obtain ⟨a, ha₁, ha₂⟩ := exists_between h
+  induction' a using EReal.rec with a₀
+  · simp only [not_lt_bot] at ha₁
+  · exact ⟨a₀, by exact_mod_cast ha₁, by exact_mod_cast ha₂⟩
+  · simp only [not_top_lt] at ha₂
+
+lemma Icc_of_Real {x y : ℝ} : Real.toEReal '' Set.Icc x y = Set.Icc ↑x ↑y := by
+  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+  rw [WithTop.image_coe_Icc, WithBot.image_coe_Icc]
+  rfl
+
+lemma Ico_of_Real {x y : ℝ} : Real.toEReal '' Set.Ico x y = Set.Ico ↑x ↑y := by
+  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+  rw [WithTop.image_coe_Ico, WithBot.image_coe_Ico]
+  rfl
+
+lemma Ici_of_Real {x : ℝ} : Real.toEReal '' Set.Ici x = Set.Ico ↑x ⊤ := by
+  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+  rw [WithTop.image_coe_Ici, WithBot.image_coe_Ico]
+  rfl
+
+lemma Ioc_of_Real {x y : ℝ} : Real.toEReal '' Set.Ioc x y = Set.Ioc ↑x ↑y := by
+  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+  rw [WithTop.image_coe_Ioc, WithBot.image_coe_Ioc]
+  rfl
+
+lemma Ioo_of_Real {x y : ℝ} : Real.toEReal '' Set.Ioo x y = Set.Ioo ↑x ↑y := by
+  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+  rw [WithTop.image_coe_Ioo, WithBot.image_coe_Ioo]
+  rfl
+
+lemma Ioi_ofReal {x : ℝ} : Real.toEReal '' Set.Ioi x = Set.Ioo ↑x ⊤ := by
+  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+  rw [WithTop.image_coe_Ioi, WithBot.image_coe_Ioo]
+  rfl
+
+lemma Iic_ofReal {x : ℝ} : Real.toEReal '' Set.Iic x = Set.Ioc ⊥ ↑x := by
+  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+  rw [WithTop.image_coe_Iic, WithBot.image_coe_Iic]
+  rfl
+
+lemma Iio_ofReal {x : ℝ} : Real.toEReal '' Set.Iio x = Set.Ioo ⊥ ↑x := by
+  refine (Set.image_comp WithBot.some WithTop.some _).trans ?_
+  rw [WithTop.image_coe_Iio, WithBot.image_coe_Iio]
+  rfl
+
 /-! ### ennreal coercion -/
 
 @[simp]

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -503,68 +503,6 @@ lemma image_coe_Iio {x : ℝ} : Real.toEReal '' Iio x = Ioo ⊥ ↑x := by
   rfl
 
 @[simp]
-lemma preimage_coe_Icc (x y : ℝ) : Real.toEReal ⁻¹' Icc x y = Icc x y := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹'
-    (Icc (WithBot.some (WithTop.some x)) (WithBot.some (WithTop.some y))) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Icc, WithTop.preimage_coe_Icc]
-
-@[simp]
-lemma preimage_coe_Ico (x y : ℝ) : Real.toEReal ⁻¹' Ico x y = Ico x y := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹'
-    (Ico (WithBot.some (WithTop.some x)) (WithBot.some (WithTop.some y))) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Ico, WithTop.preimage_coe_Ico]
-
-@[simp]
-lemma preimage_coe_Ioc (x y : ℝ) : Real.toEReal ⁻¹' Ioc x y = Ioc x y := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹'
-    (Ioc (WithBot.some (WithTop.some x)) (WithBot.some (WithTop.some y))) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Ioc, WithTop.preimage_coe_Ioc]
-
-@[simp]
-lemma preimage_coe_Ioo (x y : ℝ) : Real.toEReal ⁻¹' Ioo x y = Ioo x y := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹'
-    (Ioo (WithBot.some (WithTop.some x)) (WithBot.some (WithTop.some y))) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Ioo, WithTop.preimage_coe_Ioo]
-
-@[simp]
-lemma preimage_coe_Ico_top (x : ℝ) : Real.toEReal ⁻¹' Ico x ⊤ = Ici x := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹'
-    (Ico (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Ico, WithTop.preimage_coe_Ico_top]
-
-@[simp]
-lemma preimage_coe_Ioo_top (x : ℝ) : Real.toEReal ⁻¹' Ioo x ⊤ = Ioi x := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹'
-    (Ioo (WithBot.some (WithTop.some x)) (WithBot.some ⊤)) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Ioo, WithTop.preimage_coe_Ioo_top]
-
-@[simp]
-lemma preimage_coe_Ioc_bot (y : ℝ) : Real.toEReal ⁻¹' Ioc ⊥ y = Iic y := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹'
-    (Ioc ⊥ (WithBot.some (WithTop.some y))) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Ioc_bot, WithTop.preimage_coe_Iic]
-
-@[simp]
-lemma preimage_coe_Ioo_bot (y : ℝ) : Real.toEReal ⁻¹' Ioo ⊥ y = Iio y := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹'
-    (Ioo ⊥ (WithBot.some (WithTop.some y))) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Ioo_bot, WithTop.preimage_coe_Iio]
-
-@[simp]
-lemma preimage_coe_Ioo_bot_top : Real.toEReal ⁻¹' Ioo ⊥ ⊤ = univ := by
-  change (WithBot.some ∘ WithTop.some) ⁻¹' (Ioo ⊥ (WithBot.some ⊤)) = _
-  refine preimage_comp.trans ?_
-  simp only [WithBot.preimage_coe_Ioo_bot, WithTop.preimage_coe_Iio_top]
-
-@[simp]
 lemma preimage_coe_Ici (x : ℝ) : Real.toEReal ⁻¹' Ici x = Ici x := by
   change (WithBot.some ∘ WithTop.some) ⁻¹' (Ici (WithBot.some (WithTop.some x))) = _
   refine preimage_comp.trans ?_
@@ -600,6 +538,50 @@ lemma preimage_coe_Iio_top : Real.toEReal ⁻¹' Iio ⊤ = univ := by
   refine preimage_comp.trans ?_
   simp only [WithBot.preimage_coe_Iio, WithTop.preimage_coe_Iio_top]
 
+@[simp]
+lemma preimage_coe_Icc (x y : ℝ) : Real.toEReal ⁻¹' Icc x y = Icc x y := by
+  simp_rw [← Ici_inter_Iic]
+  simp
+
+@[simp]
+lemma preimage_coe_Ico (x y : ℝ) : Real.toEReal ⁻¹' Ico x y = Ico x y := by
+  simp_rw [← Ici_inter_Iio]
+  simp
+
+@[simp]
+lemma preimage_coe_Ioc (x y : ℝ) : Real.toEReal ⁻¹' Ioc x y = Ioc x y := by
+  simp_rw [← Ioi_inter_Iic]
+  simp
+
+@[simp]
+lemma preimage_coe_Ioo (x y : ℝ) : Real.toEReal ⁻¹' Ioo x y = Ioo x y := by
+  simp_rw [← Ioi_inter_Iio]
+  simp
+
+@[simp]
+lemma preimage_coe_Ico_top (x : ℝ) : Real.toEReal ⁻¹' Ico x ⊤ = Ici x := by
+  rw [← Ici_inter_Iio]
+  simp
+
+@[simp]
+lemma preimage_coe_Ioo_top (x : ℝ) : Real.toEReal ⁻¹' Ioo x ⊤ = Ioi x := by
+  rw [← Ioi_inter_Iio]
+  simp
+
+@[simp]
+lemma preimage_coe_Ioc_bot (y : ℝ) : Real.toEReal ⁻¹' Ioc ⊥ y = Iic y := by
+  rw [← Ioi_inter_Iic]
+  simp
+
+@[simp]
+lemma preimage_coe_Ioo_bot (y : ℝ) : Real.toEReal ⁻¹' Ioo ⊥ y = Iio y := by
+  rw [← Ioi_inter_Iio]
+  simp
+
+@[simp]
+lemma preimage_coe_Ioo_bot_top : Real.toEReal ⁻¹' Ioo ⊥ ⊤ = univ := by
+  rw [← Ioi_inter_Iio]
+  simp
 
 /-! ### ennreal coercion -/
 

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -447,7 +447,7 @@ theorem eq_bot_iff_forall_lt (x : EReal) : x = ⊥ ↔ ∀ y : ℝ, x < (y : ERe
 
 /-! ### Intervals and coercion from reals -/
 
-lemma exists_between_ofReal {x z : EReal} (h : x < z) : ∃ y : ℝ, x < y ∧ y < z := by
+lemma exists_between_coe_real {x z : EReal} (h : x < z) : ∃ y : ℝ, x < y ∧ y < z := by
   obtain ⟨a, ha₁, ha₂⟩ := exists_between h
   induction' a using EReal.rec with a₀
   · exact (not_lt_bot ha₁).elim


### PR DESCRIPTION
This adds statements like `lemma Ici_of_Real {x : ℝ} : Real.toEReal '' Set.Ici x = Set.Ico ↑x ⊤` for the eight kinds of intervals (plus versions of `exists_between` when one endpoint is a real number).

See [here](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/sInf.20.28Real.2EtoEReal.20'.20'.20.2E.2E.2E.29/near/410765558) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
