### PR TITLE
[Merged by Bors] - feat(Mathlib/Algebra/Ring/Basic): Subsingleton, NoZeroDivisors and IsDomain 

### DIFF
--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -222,10 +222,10 @@ lemma isCancelMulZero_iff_isDomain_or_subsingleton [Semiring α] :
 
 lemma isDomain_iff_noZeroDivisors_and_nontrivial [Ring α] :
     IsDomain α ↔ NoZeroDivisors α ∧ Nontrivial α := by
-  rw [←isCancelMulZero_iff_noZeroDivisors, isDomain_iff_cancelMulZero_and_nontrivial]
+  rw [← isCancelMulZero_iff_noZeroDivisors, isDomain_iff_cancelMulZero_and_nontrivial]
 
 lemma noZeroDivisors_iff_isDomain_or_subsingleton [Ring α] :
     NoZeroDivisors α ↔ IsDomain α ∨ Subsingleton α := by
-  rw [←isCancelMulZero_iff_noZeroDivisors, isCancelMulZero_iff_isDomain_or_subsingleton]
+  rw [← isCancelMulZero_iff_noZeroDivisors, isCancelMulZero_iff_isDomain_or_subsingleton]
 
 end NoZeroDivisors

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -205,7 +205,7 @@ instance Subsingleton.to_noZeroDivisors [Ring α] [Subsingleton α] : NoZeroDivi
 
 
 lemma NoZeroDivisors_iff_IsDomain_or_Subsingleton [Ring α]:
-      NoZeroDivisors α ↔ (IsDomain α ∨ Subsingleton α) := by
+    NoZeroDivisors α ↔ (IsDomain α ∨ Subsingleton α) := by
   refine ⟨fun t ↦ ?_, fun h ↦ h.elim (fun _ ↦ inferInstance)
     (fun _ ↦ inferInstance)⟩
   rw [or_iff_not_imp_right, not_subsingleton_iff_nontrivial]

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -188,6 +188,11 @@ instance (priority := 100) NoZeroDivisors.to_isCancelMulZero [Ring α] [NoZeroDi
       exact sub_eq_zero.1 ((eq_zero_or_eq_zero_of_mul_eq_zero h).resolve_right hb) }
 #align no_zero_divisors.to_is_cancel_mul_zero NoZeroDivisors.to_isCancelMulZero
 
+/-- In a ring, `IsCancelMulZero` and `NoZeroDivisors` are equivalent. -/
+lemma isCancelMulZero_iff_noZeroDivisors [Ring α] :
+    IsCancelMulZero α ↔ NoZeroDivisors α :=
+  ⟨fun _ => IsRightCancelMulZero.to_noZeroDivisors _, fun _ => inferInstance⟩
+
 lemma NoZeroDivisors.to_isDomain [Ring α] [h : Nontrivial α] [NoZeroDivisors α] :
     IsDomain α :=
   { NoZeroDivisors.to_isCancelMulZero α, h with .. }
@@ -198,18 +203,29 @@ instance (priority := 100) IsDomain.to_noZeroDivisors [Ring α] [IsDomain α] :
   IsRightCancelMulZero.to_noZeroDivisors α
 #align is_domain.to_no_zero_divisors IsDomain.to_noZeroDivisors
 
-instance Subsingleton.to_noZeroDivisors [Mul α] [Zero α] [Subsingleton α] : NoZeroDivisors α :=
-  NoZeroDivisors.mk (fun _ => Or.inl (Subsingleton.eq_zero _))
+instance Subsingleton.to_isCancelMulZero [Mul α] [Zero α] [Subsingleton α] : IsCancelMulZero α where
+  mul_right_cancel_of_ne_zero hb := (hb <| Subsingleton.eq_zero _).elim
+  mul_left_cancel_of_ne_zero hb := (hb <| Subsingleton.eq_zero _).elim
 
-lemma NoZeroDivisors_iff_IsDomain_or_Subsingleton [Ring α]:
-    NoZeroDivisors α ↔ (IsDomain α ∨ Subsingleton α) := by
-  refine ⟨fun t ↦ ?_, fun h ↦ h.elim (fun _ ↦ inferInstance)
-    (fun _ ↦ inferInstance)⟩
-  rw [or_iff_not_imp_right, not_subsingleton_iff_nontrivial]
-  exact fun _ ↦ t.to_isDomain
+instance Subsingleton.to_noZeroDivisors [Mul α] [Zero α] [Subsingleton α] : NoZeroDivisors α where
+  eq_zero_or_eq_zero_of_mul_eq_zero _ := .inl (Subsingleton.eq_zero _)
 
-lemma isDomain_iff_noZeroDivisors_and_nontrivial [Ring α]:
-    IsDomain α ↔ (NoZeroDivisors α ∧ Nontrivial α) :=
+lemma isDomain_iff_cancelMulZero_and_nontrivial [Semiring α] :
+    IsDomain α ↔ IsCancelMulZero α ∧ Nontrivial α :=
   ⟨fun _ => ⟨inferInstance, inferInstance⟩, fun ⟨_, _⟩ => {}⟩
+
+lemma isCancelMulZero_iff_isDomain_or_subsingleton [Semiring α] :
+    IsCancelMulZero α ↔ IsDomain α ∨ Subsingleton α := by
+  refine ⟨fun t ↦ ?_, fun h ↦ h.elim (fun _ ↦ inferInstance) (fun _ ↦ inferInstance)⟩
+  rw [or_iff_not_imp_right, not_subsingleton_iff_nontrivial]
+  exact fun _ ↦ {}
+
+lemma isDomain_iff_noZeroDivisors_and_nontrivial [Ring α] :
+    IsDomain α ↔ NoZeroDivisors α ∧ Nontrivial α := by
+  rw [←isCancelMulZero_iff_noZeroDivisors, isDomain_iff_cancelMulZero_and_nontrivial]
+
+lemma noZeroDivisors_iff_isDomain_or_subsingleton [Ring α] :
+    NoZeroDivisors α ↔ IsDomain α ∨ Subsingleton α := by
+  rw [←isCancelMulZero_iff_noZeroDivisors, isCancelMulZero_iff_isDomain_or_subsingleton]
 
 end NoZeroDivisors

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -193,8 +193,6 @@ lemma NoZeroDivisors.to_isDomain [Ring α] [h : Nontrivial α] [NoZeroDivisors �
   { NoZeroDivisors.to_isCancelMulZero α, h with .. }
 #align no_zero_divisors.to_is_domain NoZeroDivisors.to_isDomain
 
-
-
 instance (priority := 100) IsDomain.to_noZeroDivisors [Ring α] [IsDomain α] :
     NoZeroDivisors α :=
   IsRightCancelMulZero.to_noZeroDivisors α
@@ -202,7 +200,6 @@ instance (priority := 100) IsDomain.to_noZeroDivisors [Ring α] [IsDomain α] :
 
 instance Subsingleton.to_noZeroDivisors [Ring α] [Subsingleton α] : NoZeroDivisors α :=
   NoZeroDivisors.mk (fun _ => Or.inl (Subsingleton.eq_zero _))
-
 
 lemma NoZeroDivisors_iff_IsDomain_or_Subsingleton [Ring α]:
     NoZeroDivisors α ↔ (IsDomain α ∨ Subsingleton α) := by
@@ -214,6 +211,5 @@ lemma NoZeroDivisors_iff_IsDomain_or_Subsingleton [Ring α]:
 lemma isDomain_iff_noZeroDivisors_and_nontrivial [Ring α]:
     IsDomain α ↔ (NoZeroDivisors α ∧ Nontrivial α) :=
   ⟨fun _ => ⟨inferInstance, inferInstance⟩, fun ⟨_, _⟩ => {}⟩
-
 
 end NoZeroDivisors

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -198,7 +198,7 @@ instance (priority := 100) IsDomain.to_noZeroDivisors [Ring α] [IsDomain α] :
   IsRightCancelMulZero.to_noZeroDivisors α
 #align is_domain.to_no_zero_divisors IsDomain.to_noZeroDivisors
 
-instance Subsingleton.to_noZeroDivisors [Ring α] [Subsingleton α] : NoZeroDivisors α :=
+instance Subsingleton.to_noZeroDivisors [Mul α] [Zero α] [Subsingleton α] : NoZeroDivisors α :=
   NoZeroDivisors.mk (fun _ => Or.inl (Subsingleton.eq_zero _))
 
 lemma NoZeroDivisors_iff_IsDomain_or_Subsingleton [Ring α]:

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -193,9 +193,27 @@ lemma NoZeroDivisors.to_isDomain [Ring α] [h : Nontrivial α] [NoZeroDivisors �
   { NoZeroDivisors.to_isCancelMulZero α, h with .. }
 #align no_zero_divisors.to_is_domain NoZeroDivisors.to_isDomain
 
+
+
 instance (priority := 100) IsDomain.to_noZeroDivisors [Ring α] [IsDomain α] :
     NoZeroDivisors α :=
   IsRightCancelMulZero.to_noZeroDivisors α
 #align is_domain.to_no_zero_divisors IsDomain.to_noZeroDivisors
+
+instance Subsingleton.to_noZeroDivisors [Ring α] [Subsingleton α] : NoZeroDivisors α :=
+  NoZeroDivisors.mk (fun _ => Or.inl (Subsingleton.eq_zero _))
+
+
+lemma NoZeroDivisors_iff_IsDomain_or_Subsingleton [Ring α]:
+      NoZeroDivisors α ↔ (IsDomain α ∨ Subsingleton α) := by
+  refine ⟨fun t ↦ ?_, fun h ↦ h.elim (fun _ ↦ inferInstance)
+    (fun _ ↦ inferInstance)⟩
+  rw [or_iff_not_imp_right, not_subsingleton_iff_nontrivial]
+  exact fun _ ↦ t.to_isDomain
+
+lemma isDomain_iff_noZeroDivisors_and_nontrivial [Ring α]:
+    IsDomain α ↔ (NoZeroDivisors α ∧ Nontrivial α) :=
+  ⟨fun _ => ⟨inferInstance, inferInstance⟩, fun ⟨_, _⟩ => {}⟩
+
 
 end NoZeroDivisors


### PR DESCRIPTION
Added some results relating NoZeroDivisors and IsDomain for Ring.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

See [https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/NoZeroDivisors.20iff.20IsDomain.20or.20Subsingleton](url)
 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
