### PR TITLE
[Merged by Bors] - fix(Cache): don't check stderr for shell commands

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -157,8 +157,7 @@ where
 /-- Runs a terminal command and retrieves its output -/
 def runCmd (cmd : String) (args : Array String) (throwFailure := true) : IO String := do
   let out ← IO.Process.output { cmd := cmd, args := args }
-  if (out.exitCode != 0 || !out.stderr.isEmpty) && throwFailure then
-    throw $ IO.userError out.stderr
+  if out.exitCode != 0 && throwFailure then throw $ IO.userError out.stderr
   else return out.stdout
 
 def runCurl (args : Array String) (throwFailure := true) : IO String := do


### PR DESCRIPTION
#9419 caused `lean exe cache unpack` to fail with this error:

```
installing leantar 0.1.10
uncaught exception:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  954k  100  954k    0     0  1608k      0 --:--:-- --:--:-- --:--:-- 1608k
```

This is because `Cache.IO.runCmd` was changed to check `!stderr.isEmpty`, but by default `curl` prints a progress bar which fails this check.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
