### PR TITLE
[Merged by Bors] - feat(Algebra/QuaternionBasis): extensionality for algebra morphisms from quaternions

### DIFF
--- a/Mathlib/Algebra/QuaternionBasis.lean
+++ b/Mathlib/Algebra/QuaternionBasis.lean
@@ -180,4 +180,26 @@ def lift : Basis A c₁ c₂ ≃ (ℍ[R,c₁,c₂] →ₐ[R] A) where
     congr <;> simp
 #align quaternion_algebra.lift QuaternionAlgebra.lift
 
+/-- Two `R`-algebra morphisms from a quaternion algebra are equal if they agree on `i` and `j`. -/
+@[ext]
+theorem hom_ext ⦃f g : ℍ[R,c₁,c₂] →ₐ[R] A⦄
+    (hi : f (Basis.self R).i = g (Basis.self R).i) (hj : f (Basis.self R).j = g (Basis.self R).j) :
+    f = g :=
+  lift.symm.injective <| Basis.ext hi hj
+
 end QuaternionAlgebra
+
+namespace Quaternion
+
+variable {R : Type*} {A B : Type*} [CommRing R] [Ring A] [Ring B] [Algebra R A] [Algebra R B]
+
+open QuaternionAlgebra (Basis)
+
+/-- Two `R`-algebra morphisms the quaternions are equal if they agree on `i` and `j`. -/
+@[ext]
+theorem Quaternion.hom_ext ⦃f g : ℍ[R] →ₐ[R] A⦄
+    (hi : f (Basis.self R).i = g (Basis.self R).i) (hj : f (Basis.self R).j = g (Basis.self R).j) :
+    f = g :=
+  QuaternionAlgebra.hom_ext hi hj
+
+end Quaternion

--- a/Mathlib/Algebra/QuaternionBasis.lean
+++ b/Mathlib/Algebra/QuaternionBasis.lean
@@ -190,12 +190,11 @@ theorem hom_ext ⦃f g : ℍ[R,c₁,c₂] →ₐ[R] A⦄
 end QuaternionAlgebra
 
 namespace Quaternion
-
-variable {R : Type*} {A B : Type*} [CommRing R] [Ring A] [Ring B] [Algebra R A] [Algebra R B]
+variable {R A : Type*} [CommRing R] [Ring A] [Algebra R A]
 
 open QuaternionAlgebra (Basis)
 
-/-- Two `R`-algebra morphisms the quaternions are equal if they agree on `i` and `j`. -/
+/-- Two `R`-algebra morphisms from the quaternions are equal if they agree on `i` and `j`. -/
 @[ext]
 theorem Quaternion.hom_ext ⦃f g : ℍ[R] →ₐ[R] A⦄
     (hi : f (Basis.self R).i = g (Basis.self R).i) (hj : f (Basis.self R).j = g (Basis.self R).j) :

--- a/Mathlib/Algebra/QuaternionBasis.lean
+++ b/Mathlib/Algebra/QuaternionBasis.lean
@@ -196,7 +196,7 @@ open QuaternionAlgebra (Basis)
 
 /-- Two `R`-algebra morphisms from the quaternions are equal if they agree on `i` and `j`. -/
 @[ext]
-theorem Quaternion.hom_ext ⦃f g : ℍ[R] →ₐ[R] A⦄
+theorem hom_ext ⦃f g : ℍ[R] →ₐ[R] A⦄
     (hi : f (Basis.self R).i = g (Basis.self R).i) (hj : f (Basis.self R).j = g (Basis.self R).j) :
     f = g :=
   QuaternionAlgebra.hom_ext hi hj

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
@@ -357,8 +357,7 @@ theorem ofQuaternion_toQuaternion (c : CliffordAlgebra (Q c₁ c₂)) :
 @[simp]
 theorem toQuaternion_comp_ofQuaternion :
     toQuaternion.comp ofQuaternion = AlgHom.id R ℍ[R,c₁,c₂] := by
-  apply QuaternionAlgebra.lift.symm.injective
-  ext1 <;> dsimp [QuaternionAlgebra.Basis.lift] <;> simp
+  ext : 1 <;> simp
 #align clifford_algebra_quaternion.to_quaternion_comp_of_quaternion CliffordAlgebraQuaternion.toQuaternion_comp_ofQuaternion
 
 @[simp]


### PR DESCRIPTION
This result was basically already here, this just registers it with `ext`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
