### PR TITLE
[Merged by Bors] - fix: add beta reduction in BigOperator norm_num extensions

### DIFF
--- a/Mathlib/Tactic/NormNum/BigOperators.lean
+++ b/Mathlib/Tactic/NormNum/BigOperators.lean
@@ -341,7 +341,7 @@ partial def evalFinsetBigop {α : Q(Type u)} {β : Q(Type v)}
     match ← Finset.proveEmptyOrCons s with
     | .empty pf => pure <| res_empty.eq_trans q(congr_fun (congr_arg _ $pf) _)
     | .cons a s' h pf => do
-      let fa : Q($β) := Expr.app f a
+      let fa : Q($β) ← Core.betaReduce (Expr.app f a)
       let res_fa ← derive fa
       let res_op_s' : Result q($op $s' $f) ← evalFinsetBigop op f res_empty @res_cons s'
       let res ← res_cons res_fa res_op_s'

--- a/Mathlib/Tactic/NormNum/BigOperators.lean
+++ b/Mathlib/Tactic/NormNum/BigOperators.lean
@@ -341,7 +341,7 @@ partial def evalFinsetBigop {α : Q(Type u)} {β : Q(Type v)}
     match ← Finset.proveEmptyOrCons s with
     | .empty pf => pure <| res_empty.eq_trans q(congr_fun (congr_arg _ $pf) _)
     | .cons a s' h pf => do
-      let fa : Q($β) ← Core.betaReduce (Expr.app f a)
+      let fa : Q($β) := Expr.betaRev f #[a]
       let res_fa ← derive fa
       let res_op_s' : Result q($op $s' $f) ← evalFinsetBigop op f res_empty @res_cons s'
       let res ← res_cons res_fa res_op_s'

--- a/test/norm_num_ext.lean
+++ b/test/norm_num_ext.lean
@@ -376,8 +376,9 @@ example (f : ℕ → α) : ∑ i in {0, 1, 2}, f i = f 0 + f 1 + f 2 := by norm_
 example (f : ℕ → α) : ∑ i in {0, 2, 2, 3, 1, 0}, f i = f 0 + f 1 + f 2 + f 3 := by norm_num; ring
 example (f : ℕ → α) : ∑ i in {0, 2, 2 - 3, 3 - 1, 1, 0}, f i = f 0 + f 1 + f 2 := by norm_num; ring
 -/
-example : (∑ i in Finset.range 10, (i^2 : ℕ)) = 285 := by norm_num1
-example : (∏ i in Finset.range 4, ((i+1)^2 : ℕ)) = 576 := by norm_num1
+example : ∑ i in Finset.range 10, i = 45 := by norm_num1
+example : ∑ i in Finset.range 10, (i^2 : ℕ) = 285 := by norm_num1
+example : ∏ i in Finset.range 4, ((i+1)^2 : ℕ) = 576 := by norm_num1
 /-
 example : (∑ i in Finset.Icc 5 10, (i^2 : ℕ)) = 355 := by norm_num
 example : (∑ i in Finset.Ico 5 10, (i^2 : ℕ)) = 255 := by norm_num


### PR DESCRIPTION
Inserts a call to `Expr.betaRev` in the `cons` case of `evalFinsetBigop`. This prevents `norm_num` from getting stuck on a beta redex applied to a nat literal, as currently happens in the third example below:

```lean
import Mathlib.Tactic.NormNum
import Mathlib.Tactic.NormNum.BigOperators

open BigOperators

-- works
example : (∑ i in Finset.range 10, (i^2 : ℕ)) = 285 := by norm_num1

-- also works (via the evalOfNat extension)
example : (∑ i in Finset.range 10, (OfNat.ofNat i)) = 45 := by norm_num1

-- does not work
example : (∑ i in Finset.range 10, i) = 45 := by norm_num1
```

Also, adds a test and removes some unnecessary parens from neighboring tests.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
