### PR TITLE
[Merged by Bors] - chore: Move scalar compatibility instance for `ℤ` and `ℕ` on rings to their own files

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2197,6 +2197,7 @@ import Mathlib.GroupTheory.GroupAction.Option
 import Mathlib.GroupTheory.GroupAction.Pi
 import Mathlib.GroupTheory.GroupAction.Prod
 import Mathlib.GroupTheory.GroupAction.Quotient
+import Mathlib.GroupTheory.GroupAction.Ring
 import Mathlib.GroupTheory.GroupAction.Sigma
 import Mathlib.GroupTheory.GroupAction.SubMulAction
 import Mathlib.GroupTheory.GroupAction.SubMulAction.Pointwise

--- a/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
@@ -3,11 +3,10 @@ Copyright (c) 2023 Jireh Loreaux. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
-
-import Mathlib.Algebra.Algebra.NonUnitalSubalgebra
-import Mathlib.Algebra.Star.Subalgebra
 import Mathlib.Algebra.Algebra.Unitization
 import Mathlib.Algebra.Star.NonUnitalSubalgebra
+import Mathlib.Algebra.Star.Subalgebra
+import Mathlib.GroupTheory.GroupAction.Ring
 
 /-!
 # Relating unital and non-unital substructures

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -998,6 +998,10 @@ theorem zpow_ofNat (a : G) : ∀ n : ℕ, a ^ (n : ℤ) = a ^ n
 #align zpow_of_nat zpow_ofNat
 #align of_nat_zsmul ofNat_zsmul
 
+@[to_additive (attr := simp, norm_cast) coe_nat_zsmul]
+lemma zpow_coe_nat (a : G) (n : ℕ) : a ^ (Nat.cast n : ℤ) = a ^ n := zpow_ofNat ..
+#align coe_nat_zsmul coe_nat_zsmul
+
 theorem zpow_negSucc (a : G) (n : ℕ) : a ^ (Int.negSucc n) = (a ^ (n + 1))⁻¹ := by
   rw [← zpow_ofNat]
   exact DivInvMonoid.zpow_neg' n a

--- a/Mathlib/Algebra/GroupPower/Lemmas.lean
+++ b/Mathlib/Algebra/GroupPower/Lemmas.lean
@@ -10,6 +10,7 @@ import Mathlib.Algebra.Order.Monoid.WithTop
 import Mathlib.Data.Nat.Pow
 import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.Algebra.Group.Opposite
+import Mathlib.GroupTheory.GroupAction.Ring
 
 #align_import algebra.group_power.lemmas from "leanprover-community/mathlib"@"a07d750983b94c530ab69a726862c2ab6802b38c"
 
@@ -511,24 +512,6 @@ theorem nsmul_eq_mul [NonAssocSemiring R] (n : ℕ) (a : R) : n • a = n * a :=
 #align nsmul_eq_mul nsmul_eq_mulₓ
 -- typeclasses do not match up exactly.
 
-/-- Note that `AddCommMonoid.nat_smulCommClass` requires stronger assumptions on `R`. -/
-instance NonUnitalNonAssocSemiring.nat_smulCommClass [NonUnitalNonAssocSemiring R] :
-    SMulCommClass ℕ R R :=
-  ⟨fun n x y => by
-    induction' n with n ih
-    · simp [zero_nsmul]
-    · simp_rw [succ_nsmul, smul_eq_mul, mul_add, ← smul_eq_mul, ih]⟩
-#align non_unital_non_assoc_semiring.nat_smul_comm_class NonUnitalNonAssocSemiring.nat_smulCommClass
-
-/-- Note that `AddCommMonoid.nat_isScalarTower` requires stronger assumptions on `R`. -/
-instance NonUnitalNonAssocSemiring.nat_isScalarTower [NonUnitalNonAssocSemiring R] :
-    IsScalarTower ℕ R R :=
-  ⟨fun n x y => by
-    induction' n with n ih
-    · simp [zero_nsmul]
-    · simp_rw [succ_nsmul, ← ih, smul_eq_mul, add_mul]⟩
-#align non_unital_non_assoc_semiring.nat_is_scalar_tower NonUnitalNonAssocSemiring.nat_isScalarTower
-
 @[simp, norm_cast]
 theorem Nat.cast_pow [Semiring R] (n m : ℕ) : (↑(n ^ m) : R) = (↑n : R) ^ m := by
   induction' m with m ih
@@ -595,24 +578,6 @@ theorem zsmul_eq_mul [Ring R] (a : R) : ∀ n : ℤ, n • a = n * a
 theorem zsmul_eq_mul' [Ring R] (a : R) (n : ℤ) : n • a = a * n := by
   rw [zsmul_eq_mul, (n.cast_commute a).eq]
 #align zsmul_eq_mul' zsmul_eq_mul'
-
-/-- Note that `AddCommGroup.int_smulCommClass` requires stronger assumptions on `R`. -/
-instance NonUnitalNonAssocRing.int_smulCommClass [NonUnitalNonAssocRing R] :
-    SMulCommClass ℤ R R :=
-  ⟨fun n x y =>
-    match n with
-    | (n : ℕ) => by simp_rw [coe_nat_zsmul, smul_comm]
-    | -[n+1] => by simp_rw [negSucc_zsmul, smul_eq_mul, mul_neg, mul_smul_comm]⟩
-#align non_unital_non_assoc_ring.int_smul_comm_class NonUnitalNonAssocRing.int_smulCommClass
-
-/-- Note that `AddCommGroup.int_isScalarTower` requires stronger assumptions on `R`. -/
-instance NonUnitalNonAssocRing.int_isScalarTower [NonUnitalNonAssocRing R] :
-    IsScalarTower ℤ R R :=
-  ⟨fun n x y =>
-    match n with
-    | (n : ℕ) => by simp_rw [coe_nat_zsmul, smul_assoc]
-    | -[n+1] => by simp_rw [negSucc_zsmul, smul_eq_mul, neg_mul, smul_mul_assoc]⟩
-#align non_unital_non_assoc_ring.int_is_scalar_tower NonUnitalNonAssocRing.int_isScalarTower
 
 theorem zsmul_int_int (a b : ℤ) : a • b = a * b := by simp
 #align zsmul_int_int zsmul_int_int

--- a/Mathlib/Algebra/Lie/Free.lean
+++ b/Mathlib/Algebra/Lie/Free.lean
@@ -3,10 +3,10 @@ Copyright (c) 2021 Oliver Nash. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
-import Mathlib.Algebra.Lie.OfAssociative
+import Mathlib.Algebra.FreeNonUnitalNonAssocAlgebra
 import Mathlib.Algebra.Lie.NonUnitalNonAssocAlgebra
 import Mathlib.Algebra.Lie.UniversalEnveloping
-import Mathlib.Algebra.FreeNonUnitalNonAssocAlgebra
+import Mathlib.GroupTheory.GroupAction.Ring
 
 #align_import algebra.lie.free from "leanprover-community/mathlib"@"841ac1a3d9162bf51c6327812ecb6e5e71883ac4"
 

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies, Christopher Hoskin
 -/
 import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.Module.Hom
+import Mathlib.GroupTheory.GroupAction.Ring
 import Mathlib.RingTheory.NonUnitalSubsemiring.Basic
 import Mathlib.RingTheory.Subsemiring.Basic
 

--- a/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
+++ b/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
@@ -5,6 +5,7 @@ Authors: Oliver Nash
 -/
 import Mathlib.Algebra.Ring.Divisibility.Basic
 import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.GroupTheory.GroupAction.Ring
 
 /-!
 # Lemmas about divisibility in rings

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -88,11 +88,6 @@ lemma natAbs_cast (n : ℕ) : natAbs ↑n = n := rfl
 @[norm_cast]
 protected lemma coe_nat_sub {n m : ℕ} : n ≤ m → (↑(m - n) : ℤ) = ↑m - ↑n := ofNat_sub
 
-@[to_additive (attr := simp, norm_cast) coe_nat_zsmul]
-theorem _root_.zpow_coe_nat [DivInvMonoid G] (a : G) (n : ℕ) : a ^ (Nat.cast n : ℤ) = a ^ n :=
-  zpow_ofNat ..
-#align coe_nat_zsmul coe_nat_zsmul
-
 /-! ### Extra instances to short-circuit type class resolution
 
 These also prevent non-computable instances like `Int.normedCommRing` being used to construct

--- a/Mathlib/Data/Real/CauSeq.lean
+++ b/Mathlib/Data/Real/CauSeq.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Order.Group.MinMax
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Ring.Pi
 import Mathlib.GroupTheory.GroupAction.Pi
+import Mathlib.GroupTheory.GroupAction.Ring
 import Mathlib.Init.Align
 import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.Ring

--- a/Mathlib/GroupTheory/GroupAction/Ring.lean
+++ b/Mathlib/GroupTheory/GroupAction/Ring.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2022 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.Algebra.Ring.Defs
+import Mathlib.GroupTheory.GroupAction.Defs
+
+/-!
+# Commutativity and associativity of action of integers on rings
+
+This file proves that `ℕ` and `ℤ` act commutatively and associatively on (semi)rings.
+
+## TODO
+
+Those instances are in their own file only because they require much less imports than any existing
+file they could go to. This is unfortunate and should be fixed by reorganising files.
+-/
+
+open scoped Int
+
+variable {α : Type*}
+
+/-- Note that `AddCommMonoid.nat_smulCommClass` requires stronger assumptions on `α`. -/
+instance NonUnitalNonAssocSemiring.nat_smulCommClass [NonUnitalNonAssocSemiring α] :
+    SMulCommClass ℕ α α where
+  smul_comm n x y := by
+    induction' n with n ih
+    · simp [zero_nsmul]
+    · simp_rw [succ_nsmul, smul_eq_mul, mul_add, ← smul_eq_mul, ih]
+#align non_unital_non_assoc_semiring.nat_smul_comm_class NonUnitalNonAssocSemiring.nat_smulCommClass
+
+/-- Note that `AddCommMonoid.nat_isScalarTower` requires stronger assumptions on `α`. -/
+instance NonUnitalNonAssocSemiring.nat_isScalarTower [NonUnitalNonAssocSemiring α] :
+    IsScalarTower ℕ α α where
+  smul_assoc n x y := by
+    induction' n with n ih
+    · simp [zero_nsmul]
+    · simp_rw [succ_nsmul, ← ih, smul_eq_mul, add_mul]
+#align non_unital_non_assoc_semiring.nat_is_scalar_tower NonUnitalNonAssocSemiring.nat_isScalarTower
+
+/-- Note that `AddCommGroup.int_smulCommClass` requires stronger assumptions on `α`. -/
+instance NonUnitalNonAssocRing.int_smulCommClass [NonUnitalNonAssocRing α] :
+    SMulCommClass ℤ α α where
+  smul_comm n x y :=
+    match n with
+    | (n : ℕ) => by simp_rw [coe_nat_zsmul, smul_comm]
+    | -[n+1] => by simp_rw [negSucc_zsmul, smul_eq_mul, mul_neg, mul_smul_comm]
+#align non_unital_non_assoc_ring.int_smul_comm_class NonUnitalNonAssocRing.int_smulCommClass
+
+/-- Note that `AddCommGroup.int_isScalarTower` requires stronger assumptions on `α`. -/
+instance NonUnitalNonAssocRing.int_isScalarTower [NonUnitalNonAssocRing α] :
+    IsScalarTower ℤ α α where
+  smul_assoc n x y :=
+    match n with
+    | (n : ℕ) => by simp_rw [coe_nat_zsmul, smul_assoc]
+    | -[n+1] => by simp_rw [negSucc_zsmul, smul_eq_mul, neg_mul, smul_mul_assoc]
+#align non_unital_non_assoc_ring.int_is_scalar_tower NonUnitalNonAssocRing.int_isScalarTower

--- a/Mathlib/GroupTheory/GroupAction/Ring.lean
+++ b/Mathlib/GroupTheory/GroupAction/Ring.lean
@@ -21,7 +21,7 @@ open scoped Int
 
 variable {α : Type*}
 
-/-- Note that `AddCommMonoid.nat_smulCommClass` requires stronger assumptions on `α`. -/
+/-- Note that `AddMonoid.nat_smulCommClass` requires stronger assumptions on `α`. -/
 instance NonUnitalNonAssocSemiring.nat_smulCommClass [NonUnitalNonAssocSemiring α] :
     SMulCommClass ℕ α α where
   smul_comm n x y := by
@@ -39,7 +39,7 @@ instance NonUnitalNonAssocSemiring.nat_isScalarTower [NonUnitalNonAssocSemiring 
     · simp_rw [succ_nsmul, ← ih, smul_eq_mul, add_mul]
 #align non_unital_non_assoc_semiring.nat_is_scalar_tower NonUnitalNonAssocSemiring.nat_isScalarTower
 
-/-- Note that `AddCommGroup.int_smulCommClass` requires stronger assumptions on `α`. -/
+/-- Note that `AddGroup.int_smulCommClass` requires stronger assumptions on `α`. -/
 instance NonUnitalNonAssocRing.int_smulCommClass [NonUnitalNonAssocRing α] :
     SMulCommClass ℤ α α where
   smul_comm n x y :=


### PR DESCRIPTION
Part of #9411.

Also corrects some instance names in the docstrings.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
