### PR TITLE
[Merged by Bors] - chore: Move Bernoulli's inequality

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -416,6 +416,7 @@ import Mathlib.Algebra.Order.Ring.Cone
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Algebra.Order.Ring.InjSurj
 import Mathlib.Algebra.Order.Ring.Lemmas
+import Mathlib.Algebra.Order.Ring.Pow
 import Mathlib.Algebra.Order.Ring.Star
 import Mathlib.Algebra.Order.Ring.WithTop
 import Mathlib.Algebra.Order.Sub.Basic

--- a/Mathlib/Algebra/GroupPower/Lemmas.lean
+++ b/Mathlib/Algebra/GroupPower/Lemmas.lean
@@ -636,29 +636,6 @@ section OrderedSemiring
 
 variable [OrderedSemiring R] {a : R}
 
-/-- Bernoulli's inequality. This version works for semirings but requires
-additional hypotheses `0 ≤ a * a` and `0 ≤ (1 + a) * (1 + a)`. -/
-theorem one_add_mul_le_pow' (Hsq : 0 ≤ a * a) (Hsq' : 0 ≤ (1 + a) * (1 + a)) (H : 0 ≤ 2 + a) :
-    ∀ n : ℕ, 1 + (n : R) * a ≤ (1 + a) ^ n
-  | 0 => by simp
-  | 1 => by simp
-  | n + 2 =>
-    have : 0 ≤ (n : R) * (a * a * (2 + a)) + a * a :=
-      add_nonneg (mul_nonneg n.cast_nonneg (mul_nonneg Hsq H)) Hsq
-    calc
-      1 + (↑(n + 2) : R) * a ≤ 1 + ↑(n + 2) * a + (n * (a * a * (2 + a)) + a * a) :=
-        le_add_of_nonneg_right this
-      _ = (1 + a) * (1 + a) * (1 + n * a) := by {
-          simp only [Nat.cast_add, add_mul, mul_add, one_mul, mul_one, ← one_add_one_eq_two,
-            Nat.cast_one, add_assoc, add_right_inj]
-          simp only [← add_assoc, add_comm _ (↑n * a)]
-          simp only [add_assoc, (n.cast_commute (_ : R)).left_comm]
-          simp only [add_comm, add_left_comm] }
-      _ ≤ (1 + a) * (1 + a) * (1 + a) ^ n :=
-        mul_le_mul_of_nonneg_left (one_add_mul_le_pow' Hsq Hsq' H _) Hsq'
-      _ = (1 + a) ^ (n + 2) := by simp only [pow_succ, mul_assoc]
-#align one_add_mul_le_pow' one_add_mul_le_pow'
-
 theorem pow_le_pow_of_le_one_aux (h : 0 ≤ a) (ha : a ≤ 1) (i : ℕ) :
     ∀ k : ℕ, a ^ (i + k) ≤ a ^ i
   | 0 => by simp
@@ -752,19 +729,6 @@ theorem strictMono_pow_bit1 (n : ℕ) : StrictMono fun a : R => a ^ bit1 n := by
 #align strict_mono_pow_bit1 strictMono_pow_bit1
 
 end bit1
-
-/-- Bernoulli's inequality for `n : ℕ`, `-2 ≤ a`. -/
-theorem one_add_mul_le_pow (H : -2 ≤ a) (n : ℕ) : 1 + (n : R) * a ≤ (1 + a) ^ n :=
-  one_add_mul_le_pow' (mul_self_nonneg _) (mul_self_nonneg _) (neg_le_iff_add_nonneg'.1 H) _
-#align one_add_mul_le_pow one_add_mul_le_pow
-
-/-- Bernoulli's inequality reformulated to estimate `a^n`. -/
-theorem one_add_mul_sub_le_pow (H : -1 ≤ a) (n : ℕ) : 1 + (n : R) * (a - 1) ≤ a ^ n := by
-  have : -2 ≤ a - 1 := by
-    rwa [← one_add_one_eq_two, neg_add, ← sub_eq_add_neg, sub_le_sub_iff_right]
-  simpa only [add_sub_cancel'_right] using one_add_mul_le_pow this n
-#align one_add_mul_sub_le_pow one_add_mul_sub_le_pow
-
 end LinearOrderedRing
 
 namespace Int

--- a/Mathlib/Algebra/Order/Field/Power.lean
+++ b/Mathlib/Algebra/Order/Field/Power.lean
@@ -219,8 +219,56 @@ theorem zpow_bit0_abs (a : α) (p : ℤ) : |a| ^ bit0 p = a ^ bit0 p :=
   (even_bit0 _).zpow_abs _
 #align zpow_bit0_abs zpow_bit0_abs
 
-/-! ### Miscellaneous lemmmas -/
+end LinearOrderedField
 
+/-! ### Bernoulli's inequality -/
+
+section OrderedSemiring
+variable [OrderedSemiring α] {a : α}
+
+/-- **Bernoulli's inequality**. This version works for semirings but requires
+additional hypotheses `0 ≤ a * a` and `0 ≤ (1 + a) * (1 + a)`. -/
+lemma one_add_mul_le_pow' (Hsq : 0 ≤ a * a) (Hsq' : 0 ≤ (1 + a) * (1 + a)) (H : 0 ≤ 2 + a) :
+    ∀ n : ℕ, 1 + n * a ≤ (1 + a) ^ n
+  | 0 => by simp
+  | 1 => by simp
+  | n + 2 =>
+    have : 0 ≤ n * (a * a * (2 + a)) + a * a :=
+      add_nonneg (mul_nonneg n.cast_nonneg (mul_nonneg Hsq H)) Hsq
+    calc
+      _ ≤ 1 + ↑(n + 2) * a + (n * (a * a * (2 + a)) + a * a) := le_add_of_nonneg_right this
+      _ = (1 + a) * (1 + a) * (1 + n * a) := by
+          simp only [Nat.cast_add, add_mul, mul_add, one_mul, mul_one, ← one_add_one_eq_two,
+            Nat.cast_one, add_assoc, add_right_inj]
+          simp only [← add_assoc, add_comm _ (↑n * a)]
+          simp only [add_assoc, (n.cast_commute (_ : α)).left_comm]
+          simp only [add_comm, add_left_comm]
+      _ ≤ (1 + a) * (1 + a) * (1 + a) ^ n :=
+        mul_le_mul_of_nonneg_left (one_add_mul_le_pow' Hsq Hsq' H _) Hsq'
+      _ = (1 + a) ^ (n + 2) := by simp only [pow_succ, mul_assoc]
+#align one_add_mul_le_pow' one_add_mul_le_pow'
+
+end OrderedSemiring
+
+section LinearOrderedRing
+variable [LinearOrderedRing α] {a : α} {n : ℕ}
+
+/-- **Bernoulli's inequality** for `n : ℕ`, `-2 ≤ a`. -/
+lemma one_add_mul_le_pow (H : -2 ≤ a) (n : ℕ) : 1 + n * a ≤ (1 + a) ^ n :=
+  one_add_mul_le_pow' (mul_self_nonneg _) (mul_self_nonneg _) (neg_le_iff_add_nonneg'.1 H) _
+#align one_add_mul_le_pow one_add_mul_le_pow
+
+/-- **Bernoulli's inequality** reformulated to estimate `a^n`. -/
+lemma one_add_mul_sub_le_pow (H : -1 ≤ a) (n : ℕ) : 1 + n * (a - 1) ≤ a ^ n := by
+  have : -2 ≤ a - 1 := by
+    rwa [← one_add_one_eq_two, neg_add, ← sub_eq_add_neg, sub_le_sub_iff_right]
+  simpa only [add_sub_cancel'_right] using one_add_mul_le_pow this n
+#align one_add_mul_sub_le_pow one_add_mul_sub_le_pow
+
+end LinearOrderedRing
+
+section LinearOrderedField
+variable [LinearOrderedField α] {a : α}
 
 /-- Bernoulli's inequality reformulated to estimate `(n : α)`. -/
 theorem Nat.cast_le_pow_sub_div_sub (H : 1 < a) (n : ℕ) : (n : α) ≤ (a ^ n - 1) / (a - 1) :=

--- a/Mathlib/Algebra/Order/Field/Power.lean
+++ b/Mathlib/Algebra/Order/Field/Power.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Parity
 import Mathlib.Algebra.CharZero.Lemmas
 import Mathlib.Algebra.GroupWithZero.Power
 import Mathlib.Algebra.Order.Field.Basic
+import Mathlib.Algebra.Order.Ring.Pow
 import Mathlib.Data.Int.Bitwise
 
 #align_import algebra.order.field.power from "leanprover-community/mathlib"@"acb3d204d4ee883eb686f45d486a2a6811a01329"
@@ -219,56 +220,7 @@ theorem zpow_bit0_abs (a : α) (p : ℤ) : |a| ^ bit0 p = a ^ bit0 p :=
   (even_bit0 _).zpow_abs _
 #align zpow_bit0_abs zpow_bit0_abs
 
-end LinearOrderedField
-
 /-! ### Bernoulli's inequality -/
-
-section OrderedSemiring
-variable [OrderedSemiring α] {a : α}
-
-/-- **Bernoulli's inequality**. This version works for semirings but requires
-additional hypotheses `0 ≤ a * a` and `0 ≤ (1 + a) * (1 + a)`. -/
-lemma one_add_mul_le_pow' (Hsq : 0 ≤ a * a) (Hsq' : 0 ≤ (1 + a) * (1 + a)) (H : 0 ≤ 2 + a) :
-    ∀ n : ℕ, 1 + n * a ≤ (1 + a) ^ n
-  | 0 => by simp
-  | 1 => by simp
-  | n + 2 =>
-    have : 0 ≤ n * (a * a * (2 + a)) + a * a :=
-      add_nonneg (mul_nonneg n.cast_nonneg (mul_nonneg Hsq H)) Hsq
-    calc
-      _ ≤ 1 + ↑(n + 2) * a + (n * (a * a * (2 + a)) + a * a) := le_add_of_nonneg_right this
-      _ = (1 + a) * (1 + a) * (1 + n * a) := by
-          simp only [Nat.cast_add, add_mul, mul_add, one_mul, mul_one, ← one_add_one_eq_two,
-            Nat.cast_one, add_assoc, add_right_inj]
-          simp only [← add_assoc, add_comm _ (↑n * a)]
-          simp only [add_assoc, (n.cast_commute (_ : α)).left_comm]
-          simp only [add_comm, add_left_comm]
-      _ ≤ (1 + a) * (1 + a) * (1 + a) ^ n :=
-        mul_le_mul_of_nonneg_left (one_add_mul_le_pow' Hsq Hsq' H _) Hsq'
-      _ = (1 + a) ^ (n + 2) := by simp only [pow_succ, mul_assoc]
-#align one_add_mul_le_pow' one_add_mul_le_pow'
-
-end OrderedSemiring
-
-section LinearOrderedRing
-variable [LinearOrderedRing α] {a : α} {n : ℕ}
-
-/-- **Bernoulli's inequality** for `n : ℕ`, `-2 ≤ a`. -/
-lemma one_add_mul_le_pow (H : -2 ≤ a) (n : ℕ) : 1 + n * a ≤ (1 + a) ^ n :=
-  one_add_mul_le_pow' (mul_self_nonneg _) (mul_self_nonneg _) (neg_le_iff_add_nonneg'.1 H) _
-#align one_add_mul_le_pow one_add_mul_le_pow
-
-/-- **Bernoulli's inequality** reformulated to estimate `a^n`. -/
-lemma one_add_mul_sub_le_pow (H : -1 ≤ a) (n : ℕ) : 1 + n * (a - 1) ≤ a ^ n := by
-  have : -2 ≤ a - 1 := by
-    rwa [← one_add_one_eq_two, neg_add, ← sub_eq_add_neg, sub_le_sub_iff_right]
-  simpa only [add_sub_cancel'_right] using one_add_mul_le_pow this n
-#align one_add_mul_sub_le_pow one_add_mul_sub_le_pow
-
-end LinearOrderedRing
-
-section LinearOrderedField
-variable [LinearOrderedField α] {a : α}
 
 /-- Bernoulli's inequality reformulated to estimate `(n : α)`. -/
 theorem Nat.cast_le_pow_sub_div_sub (H : 1 < a) (n : ℕ) : (n : α) ≤ (a ^ n - 1) / (a - 1) :=

--- a/Mathlib/Algebra/Order/Ring/Pow.lean
+++ b/Mathlib/Algebra/Order/Ring/Pow.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2019 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+import Mathlib.Data.Nat.Cast.Commute
+import Mathlib.Data.Nat.Cast.Order
+
+/-! # Bernoulli's inequality -/
+
+variable {α : Type*}
+
+section OrderedSemiring
+variable [OrderedSemiring α] {a : α}
+
+/-- **Bernoulli's inequality**. This version works for semirings but requires
+additional hypotheses `0 ≤ a * a` and `0 ≤ (1 + a) * (1 + a)`. -/
+lemma one_add_mul_le_pow' (Hsq : 0 ≤ a * a) (Hsq' : 0 ≤ (1 + a) * (1 + a)) (H : 0 ≤ 2 + a) :
+    ∀ n : ℕ, 1 + n * a ≤ (1 + a) ^ n
+  | 0 => by simp
+  | 1 => by simp
+  | n + 2 =>
+    have : 0 ≤ n * (a * a * (2 + a)) + a * a :=
+      add_nonneg (mul_nonneg n.cast_nonneg (mul_nonneg Hsq H)) Hsq
+    calc
+      _ ≤ 1 + ↑(n + 2) * a + (n * (a * a * (2 + a)) + a * a) := le_add_of_nonneg_right this
+      _ = (1 + a) * (1 + a) * (1 + n * a) := by
+          simp only [Nat.cast_add, add_mul, mul_add, one_mul, mul_one, ← one_add_one_eq_two,
+            Nat.cast_one, add_assoc, add_right_inj]
+          simp only [← add_assoc, add_comm _ (↑n * a)]
+          simp only [add_assoc, (n.cast_commute (_ : α)).left_comm]
+          simp only [add_comm, add_left_comm]
+      _ ≤ (1 + a) * (1 + a) * (1 + a) ^ n :=
+        mul_le_mul_of_nonneg_left (one_add_mul_le_pow' Hsq Hsq' H _) Hsq'
+      _ = (1 + a) ^ (n + 2) := by simp only [pow_succ, mul_assoc]
+#align one_add_mul_le_pow' one_add_mul_le_pow'
+
+end OrderedSemiring
+
+section LinearOrderedRing
+variable [LinearOrderedRing α] {a : α} {n : ℕ}
+
+/-- **Bernoulli's inequality** for `n : ℕ`, `-2 ≤ a`. -/
+lemma one_add_mul_le_pow (H : -2 ≤ a) (n : ℕ) : 1 + n * a ≤ (1 + a) ^ n :=
+  one_add_mul_le_pow' (mul_self_nonneg _) (mul_self_nonneg _) (neg_le_iff_add_nonneg'.1 H) _
+#align one_add_mul_le_pow one_add_mul_le_pow
+
+/-- **Bernoulli's inequality** reformulated to estimate `a^n`. -/
+lemma one_add_mul_sub_le_pow (H : -1 ≤ a) (n : ℕ) : 1 + n * (a - 1) ≤ a ^ n := by
+  have : -2 ≤ a - 1 := by
+    rwa [← one_add_one_eq_two, neg_add, ← sub_eq_add_neg, sub_le_sub_iff_right]
+  simpa only [add_sub_cancel'_right] using one_add_mul_le_pow this n
+#align one_add_mul_sub_le_pow one_add_mul_sub_le_pow
+
+end LinearOrderedRing


### PR DESCRIPTION
The first versions for ordered semirings do not need to import so much but:
* they have no obvious place to go
* nobody needs them that early (in particular, it seems nobody needs them without also needing the ordered field version)

Part of #9411


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
