### PR TITLE
feat(GroupTheory/GroupAction): `MulAction.movedBy` and a few basic properties of `fixedBy` and `movedBy`

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -198,9 +198,8 @@ theorem smul_pow_mem_of_movedBy_subset {a : α} {s : Set α} {g : G} (s_subset :
   · rw [not_mem_movedBy_iff_mem_fixedBy, mem_fixedBy] at a_fixed
     rw [a_fixed]
 
--- TODO: rename to smul_mem
 @[to_additive]
-theorem smul_in_set_of_movedBy_subset {a : α} {s : Set α} {g : G} (superset : movedBy α g ⊆ s) :
+theorem smul_mem_of_movedBy_subset {a : α} {s : Set α} {g : G} (superset : movedBy α g ⊆ s) :
     g • a ∈ s ↔ a ∈ s := (zpow_one g) ▸ smul_pow_mem_of_movedBy_subset superset 1
 
 @[to_additive]

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2024 Emilie Burgun. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Emilie Burgun
+-/
+import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Dynamics.PeriodicPts
+
+/-!
+# Properties of `fixedPoints` and `fixedBy`
+
+This module contains some useful properties of `MulAction.fixedPoints` and `MulAction.fixedBy`
+that don't directly belong to `Mathlib.GroupTheory.GroupAction.Basic`,
+as well as the definition of `MulAction.movedBy`.
+-/
+
+namespace MulAction
+
+universe u v
+variable {α : Type v}
+variable {G : Type u} [Group G] [MulAction G α]
+variable {M : Type u} [Monoid M] [MulAction M α]
+
+
+section FixedPoints
+
+/-- In a multiplicative group action, the points fixed by `g` are also fixed by `g⁻¹` -/
+@[to_additive "In an additive group action, the points fixed by `g` are also fixed by `g⁻¹`"]
+theorem fixedBy_eq_fixedBy_inv (g : G) : fixedBy α g = fixedBy α g⁻¹ := by
+  ext x
+  repeat rw [mem_fixedBy]
+  constructor
+  all_goals (intro gx_eq_x; nth_rw 1 [<-gx_eq_x])
+  · exact inv_smul_smul g x
+  · rw [<-mul_smul, mul_right_inv, one_smul]
+
+@[to_additive]
+theorem smul_mem_fixedBy_iff_mem_fixedBy {a : α} {g : G} :
+    g • a ∈ fixedBy α g ↔ a ∈ fixedBy α g := by
+  rw [mem_fixedBy, smul_left_cancel_iff]
+  rfl
+
+@[to_additive]
+theorem minimalPeriod_eq_one_of_fixedBy {a : α} {g : G} (a_in_fixedBy : a ∈ fixedBy α g) :
+    Function.minimalPeriod (fun x => g • x) a = 1 := by
+  rw [Function.minimalPeriod_eq_one_iff_isFixedPt]
+  exact a_in_fixedBy
+
+@[to_additive]
+theorem fixedBy_subset_fixedBy_pow (g : G) (j : ℤ) :
+    fixedBy α g ⊆ fixedBy α (g^j) := by
+  intro a a_in_fixedBy
+  rw [
+    mem_fixedBy,
+    zpow_smul_eq_iff_minimalPeriod_dvd,
+    minimalPeriod_eq_one_of_fixedBy a_in_fixedBy
+  ]
+  rw [Nat.cast_one]
+  exact one_dvd j
+
+variable (M)
+
+@[to_additive (attr := simp)]
+theorem fixedBy_one_eq_univ :
+    fixedBy α (1 : M) = Set.univ := by
+  ext a
+  rw [mem_fixedBy, one_smul]
+  exact ⟨fun _ => Set.mem_univ a, fun _ => rfl⟩
+
+end FixedPoints
+
+section MovedBy
+
+variable (α)
+
+/-- The set of points moved by an element of the action. -/
+@[to_additive "The set of points moved by an element of the action."]
+def movedBy (m : M) : Set α := { a : α | m • a ≠ a }
+
+variable {α}
+
+@[to_additive (attr := simp)]
+theorem mem_movedBy {m : M} {a : α} : a ∈ movedBy α m ↔ m • a ≠ a :=
+  Iff.rfl
+
+@[to_additive]
+theorem movedBy_eq_compl_fixedBy {m : M} : movedBy α m = (fixedBy α m)ᶜ := rfl
+
+@[to_additive]
+theorem fixedBy_eq_compl_movedBy {m : M} : fixedBy α m = (movedBy α m)ᶜ := by
+  rw [<-compl_compl (fixedBy α m), movedBy_eq_compl_fixedBy]
+
+@[to_additive]
+theorem not_mem_fixedBy_iff_mem_movedBy {m : M} {a : α} : a ∉ fixedBy α m ↔ a ∈ movedBy α m :=
+  Iff.rfl
+
+@[to_additive]
+theorem not_mem_movedBy_iff_mem_fixedBy {m : M} {a : α} : a ∉ movedBy α m ↔ a ∈ fixedBy α m := by
+  rw [movedBy_eq_compl_fixedBy, Set.not_mem_compl_iff]
+
+/-- In a multiplicative group action, the points moved by `g` are also moved by `g⁻¹` -/
+@[to_additive "In an additive group action, the points moved by `g` are also moved by `g⁻¹`"]
+theorem movedBy_eq_movedBy_inv (g : G) : movedBy α g = movedBy α g⁻¹ := by
+  repeat rw [movedBy_eq_compl_fixedBy]
+  rw [fixedBy_eq_fixedBy_inv]
+
+@[to_additive]
+theorem smul_mem_movedBy_iff_mem_movedBy {a : α} {g : G} :
+    g • a ∈ movedBy α g ↔ a ∈ movedBy α g := by
+  repeat rw [<-not_mem_fixedBy_iff_mem_movedBy]
+  rw [smul_mem_fixedBy_iff_mem_fixedBy]
+
+@[to_additive]
+theorem movedBy_pow_subset_movedBy (g : G) (j : ℤ) :
+    movedBy α (g^j) ⊆ movedBy α g := by
+  repeat rw [movedBy_eq_compl_fixedBy]
+  rw [Set.compl_subset_compl]
+  exact fixedBy_subset_fixedBy_pow g j
+
+@[to_additive (attr := simp)]
+theorem movedBy_one_eq_empty (α) (M : Type u) [Monoid M] [MulAction M α] :
+    movedBy α (1 : M) = ∅ := by
+  rw [movedBy_eq_compl_fixedBy, fixedBy_one_eq_univ, Set.compl_univ]
+
+/-- If `s` is a superset of `movedBy α g`, then `g` cannot move a point outside of `s`. -/
+@[to_additive "If `s` is a superset of `movedBy α g`, then `g` cannot move a point outside of `s`."]
+theorem smul_pow_in_set_of_movedBy_subset {a : α} {s : Set α} {g : G} (s_subset : movedBy α g ⊆ s)
+    (j : ℤ) : g^j • a ∈ s ↔ a ∈ s := by
+  rcases (Classical.em (a ∈ movedBy α (g^j))) with a_moved | a_fixed
+  · constructor
+    all_goals (intro; apply s_subset)
+    all_goals apply movedBy_pow_subset_movedBy g j
+    · exact a_moved
+    · rw [smul_mem_movedBy_iff_mem_movedBy]
+      exact a_moved
+  · rw [not_mem_movedBy_iff_mem_fixedBy, mem_fixedBy] at a_fixed
+    rw [a_fixed]
+
+@[to_additive]
+theorem smul_in_set_of_movedBy_subset {a : α} {s : Set α} {g : G} (s_subset : movedBy α g ⊆ s) :
+    g • a ∈ s ↔ a ∈ s := (zpow_one g) ▸ smul_pow_in_set_of_movedBy_subset s_subset 1
+
+end MovedBy
+
+section Faithful
+
+variable [FaithfulSMul G α]
+variable [FaithfulSMul M α]
+
+/-- If the action is faithful, then an empty `movedBy` set implies that `m = 1` -/
+@[to_additive]
+theorem movedBy_empty_iff_eq_one {m : M} : movedBy α m = ∅ ↔ m = 1 := ⟨
+  (by
+    intro moved_empty
+    apply FaithfulSMul.eq_of_smul_eq_smul (α := α)
+    intro a
+    rw [one_smul]
+    by_contra ma_ne_a
+    rwa [<-ne_eq, <-mem_movedBy, moved_empty] at ma_ne_a
+  ),
+  fun eq_one => eq_one.symm ▸ movedBy_one_eq_empty α M
+⟩
+
+end Faithful
+
+end MulAction

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -5,6 +5,7 @@ Authors: Antoine Chambert-Loir
 -/
 import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.GroupTheory.GroupAction.FixedPoints
 
 #align_import group_theory.group_action.fixing_subgroup from "leanprover-community/mathlib"@"f93c11933efbc3c2f0299e47b8ff83e9b539cbf6"
 
@@ -35,6 +36,10 @@ TODO :
 * Maybe other lemmas are useful
 
 * Treat semigroups ?
+
+* add `to_additive` for the various lemmas
+
+* `movingSubgroup`
 
 -/
 
@@ -120,6 +125,15 @@ theorem mem_fixingSubgroup_iff {s : Set α} {m : M} : m ∈ fixingSubgroup M s �
   ⟨fun hg y hy => hg ⟨y, hy⟩, fun h ⟨y, hy⟩ => h y hy⟩
 #align mem_fixing_subgroup_iff mem_fixingSubgroup_iff
 
+theorem mem_fixingSubgroup_iff_subset_fixedBy {s : Set α} {m : M} :
+    m ∈ fixingSubgroup M s ↔ s ⊆ fixedBy α m := by
+  rw [mem_fixingSubgroup_iff, Set.subset_def]
+  simp only [mem_fixedBy]
+
+theorem mem_fixingSubgroup_compl_iff_movedBy_subset {s : Set α} {m : M} :
+    m ∈ fixingSubgroup M sᶜ ↔ movedBy α m ⊆ s := by
+  rw [mem_fixingSubgroup_iff_subset_fixedBy, fixedBy_eq_compl_movedBy, Set.compl_subset_compl]
+
 variable (α)
 
 /-- The Galois connection between fixing subgroups and fixed points of a group action -/
@@ -160,5 +174,14 @@ theorem fixedPoints_subgroup_iSup {ι : Sort*} {P : ι → Subgroup M} :
     fixedPoints (↥(iSup P)) α = ⋂ i, fixedPoints (P i) α :=
   (fixingSubgroup_fixedPoints_gc M α).u_iInf
 #align fixed_points_subgroup_supr fixedPoints_subgroup_iSup
+
+/-- The orbit of the moving subgroup of `s` is a subset of `s` -/
+theorem orbit_fixingSubgroup_compl_subset {s : Set α}
+    {a : α} (a_in_s : a ∈ s) : MulAction.orbit (fixingSubgroup M sᶜ) a ⊆ s := by
+  intro b b_in_orbit
+  let ⟨⟨g, g_fixing⟩, g_eq⟩ := MulAction.mem_orbit_iff.mp b_in_orbit
+  rw [Submonoid.mk_smul] at g_eq
+  rw [mem_fixingSubgroup_compl_iff_movedBy_subset] at g_fixing
+  rwa [<-g_eq, smul_in_set_of_movedBy_subset g_fixing]
 
 end Group

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -175,13 +175,13 @@ theorem fixedPoints_subgroup_iSup {ι : Sort*} {P : ι → Subgroup M} :
   (fixingSubgroup_fixedPoints_gc M α).u_iInf
 #align fixed_points_subgroup_supr fixedPoints_subgroup_iSup
 
-/-- The orbit of the moving subgroup of `s` is a subset of `s` -/
+/-- The orbit of the fixing subgroup of `sᶜ` (ie. the moving subgroup of `s`) is a subset of `s` -/
 theorem orbit_fixingSubgroup_compl_subset {s : Set α}
     {a : α} (a_in_s : a ∈ s) : MulAction.orbit (fixingSubgroup M sᶜ) a ⊆ s := by
   intro b b_in_orbit
   let ⟨⟨g, g_fixing⟩, g_eq⟩ := MulAction.mem_orbit_iff.mp b_in_orbit
   rw [Submonoid.mk_smul] at g_eq
   rw [mem_fixingSubgroup_compl_iff_movedBy_subset] at g_fixing
-  rwa [<-g_eq, smul_in_set_of_movedBy_subset g_fixing]
+  rwa [<-g_eq, smul_mem_of_movedBy_subset g_fixing]
 
 end Group


### PR DESCRIPTION
Introduces a new module, `Mathlib.GroupTheory.GroupAction.FixedPoints`,
which contains some properties of `MulAction.fixedBy` and `MulAction.movedBy`,
that wouldn't quite belong to `Mathlib.GroupTheory.GroupAction.Basic`.

---

This is my first contribution in a series of contributions to eventually merge [my formalization of Rubin's theorem](https://github.com/adri326/rubin-lean4/) into Lean.

I have a few questions around the design decisions that I took:

- should `movedBy` be defined in `Mathlib.GroupTheory.GroupAction.Basic` instead?
- `Mathlib.GroupTheory.GroupAction.FixingSubgroup` uses `M` for a group, would it be out-of-scope for this PR to also replace it with `G`?
- should I try to further minimize the usage of tactic groups?
- I'm trying to translate the properties that I will need later for the formalization of Rubin's theorem, so I wonder if `not_commute_of_disjoint_movedBy_preimage` might be too out-of-scope

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
