### PR TITLE
feat: maximum modulus principle for functions vanishing at infinity

### DIFF
--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -442,11 +442,7 @@ theorem exists_mem_frontier_isMaxOn_norm_of_zero_at_infty [FiniteDimensional ℂ
     by_cases h_triv : ∀ x ∈ closure U, f x = 0
     case pos =>
       obtain ⟨x₀, hx₀⟩ := hne
-      refine ⟨x₀, ⟨Set.mem_of_subset_of_mem subset_closure hx₀, ?_⟩⟩
-      rw [isMaxOn_iff]
-      intro x hx
-      calc ‖f x‖ = 0 := by rw [h_triv x hx, norm_zero]
-        _ ≤ ‖f x₀‖  := norm_nonneg (f x₀)
+      exact ⟨x₀, ⟨Set.mem_of_subset_of_mem subset_closure hx₀, isMaxOn_iff.mpr <| by aesop⟩⟩
     case neg =>
       push_neg at h_triv
       obtain ⟨x₀, hx₀, hx₀_ne_zero⟩ := h_triv

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -451,12 +451,7 @@ theorem exists_mem_frontier_isMaxOn_norm_of_zero_at_infty [FiniteDimensional ℂ
       exact tendsto_norm_zero.eventually (eventually_le_nhds (norm_pos_iff.mpr hx₀_ne_zero))
   rw [closure_eq_interior_union_frontier, mem_union, or_comm] at hwU
   rcases hwU with (hwU | hwU); · exact ⟨w, hwU, hle⟩
-  have hU' : interior U ≠ univ := by
-    intro h
-    have h₁ : interior U ⊆ U := interior_subset
-    have h₂ : U = univ := by rw [← Set.univ_subset_iff]; rwa [h] at h₁
-    exact False.elim <| hU h₂
-  rcases exists_mem_frontier_infDist_compl_eq_dist hwU hU' with ⟨z, hzU, hzw⟩
+  rcases exists_mem_frontier_infDist_compl_eq_dist hwU (by aesop) with ⟨z, hzU, hzw⟩
   refine ⟨z, frontier_interior_subset hzU, fun x hx => (hle hx).out.trans_eq ?_⟩
   refine (norm_eq_norm_of_isMaxOn_of_ball_subset hd (hle.on_subset subset_closure) ?_).symm
   rw [dist_comm, ← hzw]

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -464,9 +464,7 @@ theorem norm_le_of_forall_mem_frontier_norm_le_of_zero_at_infty [FiniteDimension
     {f : E → F} {U : Set E} (htendsto : Tendsto f (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
     (hU : U ≠ univ) (hd : DiffContOnCl ℂ f U) {C : ℝ} (hC : ∀ z ∈ frontier U, ‖f z‖ ≤ C) {z : E}
     (hz : z ∈ closure U) : ‖f z‖ ≤ C := by
-  have hne : U.Nonempty := by
-    rw [← closure_nonempty_iff, nonempty_def]
-    exact ⟨z, hz⟩
+  have hne : U.Nonempty := closure_nonempty_iff.mp ⟨z, hz⟩
   obtain ⟨y, ⟨hy₁, hy₂⟩⟩ := exists_mem_frontier_isMaxOn_norm_of_zero_at_infty htendsto hU hne hd
   rw [isMaxOn_iff] at hy₂
   calc ‖f z‖ ≤ ‖f y‖ := hy₂ z hz

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -436,8 +436,8 @@ infinity on a nonempty set `U ≠ univ` and is continuous on its closure, then t
 `z ∈ frontier U` such that `(‖f ·‖)` takes it maximum value on `closure U` at `z`. -/
 theorem exists_mem_frontier_isMaxOn_norm_of_zero_at_infty [FiniteDimensional ℂ E]
     {f : E → F} {U : Set E} (htendsto : Tendsto f (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
-    (hU : U ≠ univ) (hne : U.Nonempty)
-    (hd : DiffContOnCl ℂ f U) : ∃ z ∈ frontier U, IsMaxOn (norm ∘ f) (closure U) z := by
+    (hU : U ≠ univ) (hne : U.Nonempty) (hd : DiffContOnCl ℂ f U) :
+    ∃ z ∈ frontier U, IsMaxOn (norm ∘ f) (closure U) z := by
   obtain ⟨w, hwU, hle⟩ : ∃ w ∈ closure U, IsMaxOn (norm ∘ f) (closure U) w := by
     by_cases h_triv : ∀ x ∈ closure U, f x = 0
     case pos =>

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -479,12 +479,9 @@ theorem eqOn_closure_of_eqOn_frontier_of_zero_at_infty [FiniteDimensional ℂ E]
     (hfg : EqOn f g (frontier U)) : EqOn f g (closure U) := by
   suffices H : ∀ z ∈ closure U, ‖(f - g) z‖ ≤ 0; · simpa [sub_eq_zero] using H
   have htendsto : Tendsto (f - g) (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0) := by
-    have : (0 : F) = 0 - 0 := by simp
-    rw [this]
-    exact Tendsto.sub hf_tendsto hg_tendsto
-  refine' fun z hz => norm_le_of_forall_mem_frontier_norm_le_of_zero_at_infty htendsto hU
-    (hf.sub hg) (fun w hw => _) hz
-  simp [hfg hw]
+    simpa using hf_tendsto.sub hg_tendsto
+  exact fun z => norm_le_of_forall_mem_frontier_norm_le_of_zero_at_infty htendsto hU
+    (hf.sub hg) fun w hw => by simp [hfg hw]
 
 /-- If two complex differentiable functions `f g : E → F` that vanish at infinity
 are equal on the boundary of a set `U`, then they are equal on `U`. -/

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -449,8 +449,8 @@ theorem exists_mem_frontier_isMaxOn_norm_of_zero_at_infty [FiniteDimensional ℂ
       refine hd.continuousOn.norm.exists_isMaxOn' isClosed_closure hx₀ ?_
       refine htendsto.eventually (p := fun z => ‖z‖ ≤ (norm ∘ f) x₀) ?_
       exact tendsto_norm_zero.eventually (eventually_le_nhds (norm_pos_iff.mpr hx₀_ne_zero))
-  rw [closure_eq_interior_union_frontier, mem_union] at hwU
-  cases' hwU with hwU hwU; rotate_left; · exact ⟨w, hwU, hle⟩
+  rw [closure_eq_interior_union_frontier, mem_union, or_comm] at hwU
+  rcases hwU with (hwU | hwU); · exact ⟨w, hwU, hle⟩
   have hU' : interior U ≠ univ := by
     intro h
     have h₁ : interior U ⊆ U := interior_subset

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -446,7 +446,7 @@ theorem exists_mem_frontier_isMaxOn_norm_of_zero_at_infty [FiniteDimensional ℂ
     case neg =>
       push_neg at h_triv
       obtain ⟨x₀, hx₀, hx₀_ne_zero⟩ := h_triv
-      refine ContinuousOn.exists_isMaxOn'  hd.continuousOn.norm isClosed_closure hx₀ ?_
+      refine hd.continuousOn.norm.exists_isMaxOn' isClosed_closure hx₀ ?_
       refine htendsto.eventually (p := fun z => ‖z‖ ≤ (norm ∘ f) x₀) ?_
       exact tendsto_norm_zero.eventually (eventually_le_nhds (norm_pos_iff.mpr hx₀_ne_zero))
   rw [closure_eq_interior_union_frontier, mem_union] at hwU

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -73,6 +73,14 @@ are continuous on its closure. We prove the following theorems.
 - `Complex.eqOn_of_eqOn_frontier`: if `f x = g x` on the frontier of `s`, then `f x = g x`
   on `s`.
 
+We also provide versions of the above four theorems for functions that vanish at infinity on a
+potentially unbounded set in a finite-dimensional space:
+
+- `Complex.exists_mem_frontier_isMaxOn_norm_of_zero_at_infty`
+- `Complex.norm_le_of_forall_mem_frontier_norm_le_of_zero_at_infty`
+- `Complex.eqOn_closure_of_eqOn_frontier_of_zero_at_infty`
+- `Complex.eqOn_of_eqOn_frontier_of_zero_at_infty`
+
 ## Tags
 
 maximum modulus principle, complex analysis
@@ -422,5 +430,83 @@ theorem eqOn_of_eqOn_frontier {f g : E → F} {U : Set E} (hU : IsBounded U) (hf
     (hg : DiffContOnCl ℂ g U) (hfg : EqOn f g (frontier U)) : EqOn f g U :=
   (eqOn_closure_of_eqOn_frontier hU hf hg hfg).mono subset_closure
 #align complex.eq_on_of_eq_on_frontier Complex.eqOn_of_eqOn_frontier
+
+/-- **Maximum modulus principle**: if `f : E → F` is complex differentiable and vanishing at
+infinity on a nonempty set `U ≠ univ` and is continuous on its closure, then there exists a point
+`z ∈ frontier U` such that `(‖f ·‖)` takes it maximum value on `closure U` at `z`. -/
+theorem Complex.exists_mem_frontier_isMaxOn_norm_of_zero_at_infty [FiniteDimensional ℂ E]
+    {f : E → F} {U : Set E} (htendsto : Tendsto f (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
+    (hU : U ≠ univ) (hne : U.Nonempty)
+    (hd : DiffContOnCl ℂ f U) : ∃ z ∈ frontier U, IsMaxOn (norm ∘ f) (closure U) z := by
+  obtain ⟨w, hwU, hle⟩ : ∃ w ∈ closure U, IsMaxOn (norm ∘ f) (closure U) w := by
+    by_cases h_triv : ∀ x ∈ closure U, f x = 0
+    case pos =>
+      obtain ⟨x₀, hx₀⟩ := hne
+      refine ⟨x₀, ⟨Set.mem_of_subset_of_mem subset_closure hx₀, ?_⟩⟩
+      rw [isMaxOn_iff]
+      intro x hx
+      calc ‖f x‖ = 0 := by rw [h_triv x hx, norm_zero]
+        _ ≤ ‖f x₀‖  := norm_nonneg (f x₀)
+    case neg =>
+      push_neg at h_triv
+      obtain ⟨x₀, hx₀, hx₀_ne_zero⟩ := h_triv
+      refine ContinuousOn.exists_isMaxOn'  hd.continuousOn.norm isClosed_closure hx₀ ?_
+      refine htendsto.eventually (p := fun z => ‖z‖ ≤ (norm ∘ f) x₀) ?_
+      exact tendsto_norm_zero.eventually (eventually_le_nhds (norm_pos_iff.mpr hx₀_ne_zero))
+  rw [closure_eq_interior_union_frontier, mem_union] at hwU
+  cases' hwU with hwU hwU; rotate_left; · exact ⟨w, hwU, hle⟩
+  have hU' : interior U ≠ univ := by
+    intro h
+    have h₁ : interior U ⊆ U := interior_subset
+    have h₂ : U = univ := by rw [← Set.univ_subset_iff]; rwa [h] at h₁
+    exact False.elim <| hU h₂
+  rcases exists_mem_frontier_infDist_compl_eq_dist hwU hU' with ⟨z, hzU, hzw⟩
+  refine ⟨z, frontier_interior_subset hzU, fun x hx => (hle hx).out.trans_eq ?_⟩
+  refine (norm_eq_norm_of_isMaxOn_of_ball_subset hd (hle.on_subset subset_closure) ?_).symm
+  rw [dist_comm, ← hzw]
+  exact ball_infDist_compl_subset.trans interior_subset
+
+/-- **Maximum modulus principle**: if `f : E → F` is complex differentiable and vanishing at
+infinity on a set `U ≠ univ` and is continuous on its closure, and `‖f z‖ ≤ C` for any
+`z ∈ frontier U`, then the same is true for any `z ∈ closure U`. -/
+theorem Complex.norm_le_of_forall_mem_frontier_norm_le_of_zero_at_infty [FiniteDimensional ℂ E]
+    {f : E → F} {U : Set E} (htendsto : Tendsto f (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
+    (hU : U ≠ univ) (hd : DiffContOnCl ℂ f U) {C : ℝ} (hC : ∀ z ∈ frontier U, ‖f z‖ ≤ C) {z : E}
+    (hz : z ∈ closure U) : ‖f z‖ ≤ C := by
+  have hne : U.Nonempty := by
+    rw [← closure_nonempty_iff, nonempty_def]
+    exact ⟨z, hz⟩
+  obtain ⟨y, ⟨hy₁, hy₂⟩⟩ := exists_mem_frontier_isMaxOn_norm_of_zero_at_infty htendsto hU hne hd
+  rw [isMaxOn_iff] at hy₂
+  calc ‖f z‖ ≤ ‖f y‖ := hy₂ z hz
+    _ ≤ C := hC y hy₁
+
+/-- If two complex differentiable functions `f g : E → F` that vanish at infinity are equal on the
+boundary of a bounded set `U`, then they are equal on `closure U`. -/
+theorem Complex.eqOn_closure_of_eqOn_frontier_of_zero_at_infty [FiniteDimensional ℂ E]
+    [ContinuousSub F]
+    {f g : E → F} {U : Set E} (hf_tendsto : Tendsto f (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
+    (hg_tendsto : Tendsto g (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
+    (hU : U ≠ univ) (hf : DiffContOnCl ℂ f U) (hg : DiffContOnCl ℂ g U)
+    (hfg : EqOn f g (frontier U)) : EqOn f g (closure U) := by
+  suffices H : ∀ z ∈ closure U, ‖(f - g) z‖ ≤ 0; · simpa [sub_eq_zero] using H
+  have htendsto : Tendsto (f - g) (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0) := by
+    have : (0 : F) = 0 - 0 := by simp
+    rw [this]
+    exact Tendsto.sub hf_tendsto hg_tendsto
+  refine' fun z hz => norm_le_of_forall_mem_frontier_norm_le_of_zero_at_infty htendsto hU
+    (hf.sub hg) (fun w hw => _) hz
+  simp [hfg hw]
+
+/-- If two complex differentiable functions `f g : E → F` that vanish at infinity
+are equal on the boundary of a set `U`, then they are equal on `U`. -/
+theorem Complex.eqOn_of_eqOn_frontier_of_zero_at_infty [FiniteDimensional ℂ E] {f g : E → F}
+    {U : Set E}
+    (hU : U ≠ univ) (hf_tendsto : Tendsto f (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
+    (hg_tendsto : Tendsto g (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
+    (hf : DiffContOnCl ℂ f U)
+    (hg : DiffContOnCl ℂ g U) (hfg : EqOn f g (frontier U)) : EqOn f g U :=
+  (eqOn_closure_of_eqOn_frontier_of_zero_at_infty hf_tendsto hg_tendsto hU hf hg hfg).mono
+    subset_closure
 
 end Complex

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -484,7 +484,6 @@ theorem Complex.norm_le_of_forall_mem_frontier_norm_le_of_zero_at_infty [FiniteD
 /-- If two complex differentiable functions `f g : E → F` that vanish at infinity are equal on the
 boundary of a bounded set `U`, then they are equal on `closure U`. -/
 theorem Complex.eqOn_closure_of_eqOn_frontier_of_zero_at_infty [FiniteDimensional ℂ E]
-    [ContinuousSub F]
     {f g : E → F} {U : Set E} (hf_tendsto : Tendsto f (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
     (hg_tendsto : Tendsto g (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
     (hU : U ≠ univ) (hf : DiffContOnCl ℂ f U) (hg : DiffContOnCl ℂ g U)

--- a/Mathlib/Analysis/Complex/AbsMax.lean
+++ b/Mathlib/Analysis/Complex/AbsMax.lean
@@ -434,7 +434,7 @@ theorem eqOn_of_eqOn_frontier {f g : E → F} {U : Set E} (hU : IsBounded U) (hf
 /-- **Maximum modulus principle**: if `f : E → F` is complex differentiable and vanishing at
 infinity on a nonempty set `U ≠ univ` and is continuous on its closure, then there exists a point
 `z ∈ frontier U` such that `(‖f ·‖)` takes it maximum value on `closure U` at `z`. -/
-theorem Complex.exists_mem_frontier_isMaxOn_norm_of_zero_at_infty [FiniteDimensional ℂ E]
+theorem exists_mem_frontier_isMaxOn_norm_of_zero_at_infty [FiniteDimensional ℂ E]
     {f : E → F} {U : Set E} (htendsto : Tendsto f (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
     (hU : U ≠ univ) (hne : U.Nonempty)
     (hd : DiffContOnCl ℂ f U) : ∃ z ∈ frontier U, IsMaxOn (norm ∘ f) (closure U) z := by
@@ -469,7 +469,7 @@ theorem Complex.exists_mem_frontier_isMaxOn_norm_of_zero_at_infty [FiniteDimensi
 /-- **Maximum modulus principle**: if `f : E → F` is complex differentiable and vanishing at
 infinity on a set `U ≠ univ` and is continuous on its closure, and `‖f z‖ ≤ C` for any
 `z ∈ frontier U`, then the same is true for any `z ∈ closure U`. -/
-theorem Complex.norm_le_of_forall_mem_frontier_norm_le_of_zero_at_infty [FiniteDimensional ℂ E]
+theorem norm_le_of_forall_mem_frontier_norm_le_of_zero_at_infty [FiniteDimensional ℂ E]
     {f : E → F} {U : Set E} (htendsto : Tendsto f (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
     (hU : U ≠ univ) (hd : DiffContOnCl ℂ f U) {C : ℝ} (hC : ∀ z ∈ frontier U, ‖f z‖ ≤ C) {z : E}
     (hz : z ∈ closure U) : ‖f z‖ ≤ C := by
@@ -483,7 +483,7 @@ theorem Complex.norm_le_of_forall_mem_frontier_norm_le_of_zero_at_infty [FiniteD
 
 /-- If two complex differentiable functions `f g : E → F` that vanish at infinity are equal on the
 boundary of a bounded set `U`, then they are equal on `closure U`. -/
-theorem Complex.eqOn_closure_of_eqOn_frontier_of_zero_at_infty [FiniteDimensional ℂ E]
+theorem eqOn_closure_of_eqOn_frontier_of_zero_at_infty [FiniteDimensional ℂ E]
     {f g : E → F} {U : Set E} (hf_tendsto : Tendsto f (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
     (hg_tendsto : Tendsto g (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
     (hU : U ≠ univ) (hf : DiffContOnCl ℂ f U) (hg : DiffContOnCl ℂ g U)
@@ -499,7 +499,7 @@ theorem Complex.eqOn_closure_of_eqOn_frontier_of_zero_at_infty [FiniteDimensiona
 
 /-- If two complex differentiable functions `f g : E → F` that vanish at infinity
 are equal on the boundary of a set `U`, then they are equal on `U`. -/
-theorem Complex.eqOn_of_eqOn_frontier_of_zero_at_infty [FiniteDimensional ℂ E] {f g : E → F}
+theorem eqOn_of_eqOn_frontier_of_zero_at_infty [FiniteDimensional ℂ E] {f g : E → F}
     {U : Set E}
     (hU : U ≠ univ) (hf_tendsto : Tendsto f (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))
     (hg_tendsto : Tendsto g (cocompact E ⊓ 𝓟 (closure U)) (𝓝 0))


### PR DESCRIPTION
This PR adds versions of the maximum modulus principle for functions vanishing at infinity that parallel those we already had for functions over a bounded set. These will have applications in e.g. norm interpolation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
