### PR TITLE
[Merged by Bors] - refactor(LinearAlgebra) : Remove unused commutativity hypothesis

### DIFF
--- a/Mathlib/LinearAlgebra/Basis/Bilinear.lean
+++ b/Mathlib/LinearAlgebra/Basis/Bilinear.lean
@@ -21,6 +21,7 @@ variable {R R₂ S S₂ M N P Rₗ : Type*}
 
 variable {Mₗ Nₗ Pₗ : Type*}
 
+-- Could weaken [CommSemiring Rₗ] to [SMulCommClass Rₗ Rₗ Pₗ], but might impact performance
 variable [Semiring R] [Semiring S] [Semiring R₂] [Semiring S₂] [CommSemiring Rₗ]
 
 section AddCommMonoid

--- a/Mathlib/LinearAlgebra/Basis/Bilinear.lean
+++ b/Mathlib/LinearAlgebra/Basis/Bilinear.lean
@@ -17,11 +17,11 @@ namespace LinearMap
 
 variable {ι₁ ι₂ : Type*}
 
-variable {R R₂ S S₂ M N P : Type*}
+variable {R R₂ S S₂ M N P Rₗ: Type*}
 
 variable {Mₗ Nₗ Pₗ : Type*}
 
-variable [CommSemiring R] [CommSemiring S] [CommSemiring R₂] [CommSemiring S₂]
+variable [Semiring R] [Semiring S] [Semiring R₂] [Semiring S₂] [CommSemiring Rₗ]
 
 section AddCommMonoid
 
@@ -31,13 +31,13 @@ variable [AddCommMonoid Mₗ] [AddCommMonoid Nₗ] [AddCommMonoid Pₗ]
 
 variable [Module R M] [Module S N] [Module R₂ P] [Module S₂ P]
 
-variable [Module R Mₗ] [Module R Nₗ] [Module R Pₗ]
+variable [Module Rₗ Mₗ] [Module Rₗ Nₗ] [Module Rₗ Pₗ]
 
 variable [SMulCommClass S₂ R₂ P]
 
 variable {ρ₁₂ : R →+* R₂} {σ₁₂ : S →+* S₂}
 
-variable (b₁ : Basis ι₁ R M) (b₂ : Basis ι₂ S N) (b₁' : Basis ι₁ R Mₗ) (b₂' : Basis ι₂ R Nₗ)
+variable (b₁ : Basis ι₁ R M) (b₂ : Basis ι₂ S N) (b₁' : Basis ι₁ Rₗ Mₗ) (b₂' : Basis ι₂ Rₗ Nₗ)
 
 /-- Two bilinear maps are equal when they are equal on all basis vectors. -/
 theorem ext_basis {B B' : M →ₛₗ[ρ₁₂] N →ₛₗ[σ₁₂] P} (h : ∀ i j, B (b₁ i) (b₂ j) = B' (b₁ i) (b₂ j)) :
@@ -59,7 +59,7 @@ theorem sum_repr_mul_repr_mulₛₗ {B : M →ₛₗ[ρ₁₂] N →ₛₗ[σ₁
 /-- Write out `B x y` as a sum over `B (b i) (b j)` if `b` is a basis.
 
 Version for bilinear maps, see `sum_repr_mul_repr_mulₛₗ` for the semi-bilinear version. -/
-theorem sum_repr_mul_repr_mul {B : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ} (x y) :
+theorem sum_repr_mul_repr_mul {B : Mₗ →ₗ[Rₗ] Nₗ →ₗ[Rₗ] Pₗ} (x y) :
     ((b₁'.repr x).sum fun i xi => (b₂'.repr y).sum fun j yj => xi • yj • B (b₁' i) (b₂' j)) =
       B x y := by
   conv_rhs => rw [← b₁'.total_repr x, ← b₂'.total_repr y]
@@ -70,4 +70,3 @@ theorem sum_repr_mul_repr_mul {B : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ} (x y) :
 end AddCommMonoid
 
 end LinearMap
-

--- a/Mathlib/LinearAlgebra/Basis/Bilinear.lean
+++ b/Mathlib/LinearAlgebra/Basis/Bilinear.lean
@@ -17,7 +17,7 @@ namespace LinearMap
 
 variable {ι₁ ι₂ : Type*}
 
-variable {R R₂ S S₂ M N P Rₗ: Type*}
+variable {R R₂ S S₂ M N P Rₗ : Type*}
 
 variable {Mₗ Nₗ Pₗ : Type*}
 

--- a/Mathlib/LinearAlgebra/Matrix/SesquilinearForm.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SesquilinearForm.lean
@@ -46,7 +46,7 @@ open Matrix
 
 section AuxToLinearMap
 
-variable [CommSemiring R] [CommSemiring R₁] [CommSemiring R₂]
+variable [CommSemiring R] [Semiring R₁] [Semiring R₂]
 
 variable [Fintype n] [Fintype m]
 
@@ -83,7 +83,7 @@ section AuxToMatrix
 
 section CommSemiring
 
-variable [CommSemiring R] [CommSemiring R₁] [CommSemiring R₂]
+variable [CommSemiring R] [Semiring R₁] [Semiring R₂]
 
 variable [AddCommMonoid M₁] [Module R₁ M₁] [AddCommMonoid M₂] [Module R₂ M₂]
 
@@ -110,7 +110,7 @@ end CommSemiring
 
 section CommRing
 
-variable [CommRing R] [CommRing R₁] [CommRing R₂]
+variable [CommSemiring R] [Semiring R₁] [Semiring R₂]
 
 variable [AddCommMonoid M₁] [Module R₁ M₁] [AddCommMonoid M₂] [Module R₂ M₂]
 


### PR DESCRIPTION
Remove unused commutativity hypothesis:

* Removes the requirement for the Semirings to be commutative in `LinearMap.ext_basis` and `LinearMap.sum_repr_mul_repr_mulₛₗ` in `LinearAlgebra/Basis/Bilinear`
* Remove the requirement for some Semirings to be commutative in `AuxToLinearMap`, `CommSemiring` and `CommRing` in `LinearAlgebra/Matrix/SesquilinearForm`
* In addition, the rings in `CommRing` can just be `Semiring`

No changes to the proofs are required.

It would also be possible to weaken commutativity from `Rₗ` in `LinearMap.sum_repr_mul_repr_mul` to `[SMulCommClass Rₗ Rₗ Pₗ]` in order to make `sum_repr_mul_repr_mulₛₗ` and `sum_repr_mul_repr_mul` consistent, but I have not done that in this PR because there might be a performance impact (see https://github.com/leanprover-community/mathlib4/pull/7538#pullrequestreview-1663000126).

---

Used in #9334

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
