### PR TITLE
[Merged by Bors] - feat(Analysis/Matrix): `linfty_op_nnnorm` agrees with the operator norm

### DIFF
--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -390,7 +390,8 @@ protected def linftyOpNormedAlgebra [NormedField R] [SeminormedRing α] [NormedA
 section
 variable [NormedDivisionRing α] [NormedAlgebra ℝ α] [CompleteSpace α]
 
-private def unitOf (a : α) := by classical exact if a = 0 then 1 else ‖a‖ • a⁻¹
+/-- Auxiliary construction; an element of norm 1 such that `a * unitOf a = ‖a‖`. -/
+private def unitOf (a : α) : α := by classical exact if a = 0 then 1 else ‖a‖ • a⁻¹
 
 private theorem norm_unitOf (a : α) : ‖unitOf a‖₊ = 1 := by
   rw [unitOf]
@@ -415,28 +416,26 @@ section
 variable [NontriviallyNormedField α] [NormedAlgebra ℝ α]
 
 lemma linfty_op_nnnorm_eq_op_nnnorm (A : Matrix m n α) :
-    ‖A‖₊ = ‖ContinuousLinearMap.mk
-      (Matrix.mulVecLin A) (continuous_const.matrix_mulVec continuous_id)‖₊ := by
+    ‖A‖₊ = ‖ContinuousLinearMap.mk (Matrix.mulVecLin A)‖₊ := by
   rw [ContinuousLinearMap.op_nnnorm_eq_of_bounds _ (linfty_op_nnnorm_mulVec _) fun N hN => ?_]
   rw [linfty_op_nnnorm_def]
   refine Finset.sup_le fun i _ => ?_
   cases isEmpty_or_nonempty n
   · simp
   classical
-  set x := fun j => unitOf (A i j)
-  replace hxn : ‖x‖₊ = 1 := by
+  let x : n → α := fun j => unitOf (A i j)
+  have hxn : ‖x‖₊ = 1 := by
     simp_rw [Pi.nnnorm_def, norm_unitOf, Finset.sup_const Finset.univ_nonempty]
-  have := hN x
-  rw [hxn, mul_one, Pi.nnnorm_def] at this
-  simp [mulVec, dotProduct] at this
-  specialize this i
-  refine le_trans ?_ this
-  simp_rw [mul_unitOf, ← map_sum, nnnorm_algebraMap, ← NNReal.coe_sum]
-  simp only [NNReal.nnnorm_eq, nnnorm_one, mul_one, le_refl]
+  specialize hN x
+  rw [hxn, mul_one, Pi.nnnorm_def, Finset.sup_le_iff] at hN
+  replace hN := hN i (Finset.mem_univ _)
+  dsimp [mulVec, dotProduct] at hN
+  simp_rw [mul_unitOf, ← map_sum, nnnorm_algebraMap, ← NNReal.coe_sum, NNReal.nnnorm_eq, nnnorm_one,
+    mul_one] at hN
+  exact hN
 
 lemma linfty_op_norm_eq_op_norm (A : Matrix m n α) :
-    ‖A‖ = ‖ContinuousLinearMap.mk
-      (Matrix.mulVecLin A) (continuous_const.matrix_mulVec continuous_id)‖ :=
+    ‖A‖ = ‖ContinuousLinearMap.mk (Matrix.mulVecLin A)‖ :=
   congr_arg NNReal.toReal (linfty_op_nnnorm_eq_op_nnnorm A)
 
 variable [DecidableEq n]

--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -386,6 +386,72 @@ protected def linftyOpNormedAlgebra [NormedField R] [SeminormedRing α] [NormedA
   { Matrix.linftyOpNormedSpace, Matrix.instAlgebra with }
 #align matrix.linfty_op_normed_algebra Matrix.linftyOpNormedAlgebra
 
+
+section
+variable [NormedDivisionRing α] [NormedAlgebra ℝ α] [CompleteSpace α]
+
+private def unitOf (a : α) := by classical exact if a = 0 then 1 else ‖a‖ • a⁻¹
+
+private theorem norm_unitOf (a : α) : ‖unitOf a‖₊ = 1 := by
+  rw [unitOf]
+  split_ifs with h
+  · simp
+  · rw [←nnnorm_eq_zero] at h
+    rw [nnnorm_smul, nnnorm_inv, nnnorm_norm, mul_inv_cancel h]
+
+private theorem mul_unitOf (a : α) : a * unitOf a = algebraMap _ _ (‖a‖₊ : ℝ)  := by
+  simp [unitOf]
+  split_ifs with h
+  · simp [h]
+  · rw [mul_smul_comm, mul_inv_cancel h, Algebra.algebraMap_eq_smul_one]
+
+end
+
+/-!
+For a matrix over a field, the norm defined in this section agrees with the operator norm on
+`ContinuousLinearMap`s between function types (which have the infinity norm).
+-/
+section
+variable [NontriviallyNormedField α] [NormedAlgebra ℝ α]
+
+lemma linfty_op_nnnorm_eq_op_nnnorm (A : Matrix m n α) :
+    ‖A‖₊ = ‖ContinuousLinearMap.mk
+      (Matrix.mulVecLin A) (continuous_const.matrix_mulVec continuous_id)‖₊ := by
+  rw [ContinuousLinearMap.op_nnnorm_eq_of_bounds _ (linfty_op_nnnorm_mulVec _) fun N hN => ?_]
+  rw [linfty_op_nnnorm_def]
+  refine Finset.sup_le fun i _ => ?_
+  cases isEmpty_or_nonempty n
+  · simp
+  classical
+  set x := fun j => unitOf (A i j)
+  replace hxn : ‖x‖₊ = 1 := by
+    simp_rw [Pi.nnnorm_def, norm_unitOf, Finset.sup_const Finset.univ_nonempty]
+  have := hN x
+  rw [hxn, mul_one, Pi.nnnorm_def] at this
+  simp [mulVec, dotProduct] at this
+  specialize this i
+  refine le_trans ?_ this
+  simp_rw [mul_unitOf, ←map_sum, nnnorm_algebraMap, ←NNReal.coe_sum]
+  simp only [NNReal.nnnorm_eq, nnnorm_one, mul_one, le_refl]
+
+lemma linfty_op_norm_eq_op_norm (A : Matrix m n α) :
+    ‖A‖ = ‖ContinuousLinearMap.mk
+      (Matrix.mulVecLin A) (continuous_const.matrix_mulVec continuous_id)‖ :=
+  congr_arg NNReal.toReal (linfty_op_nnnorm_eq_op_nnnorm A)
+
+variable [DecidableEq n]
+
+@[simp] lemma linfty_op_nnnorm_toMatrix (f : (n → α) →L[α] (m → α)) :
+    ‖LinearMap.toMatrix' (↑f : (n → α) →ₗ[α] (m → α))‖₊ = ‖f‖₊ := by
+  rw [linfty_op_nnnorm_eq_op_nnnorm]
+  simp only [← toLin'_apply', toLin'_toMatrix']
+
+@[simp] lemma linfty_op_norm_toMatrix (f : (n → α) →L[α] (m → α)) :
+    ‖LinearMap.toMatrix' (↑f : (n → α) →ₗ[α] (m → α))‖ = ‖f‖ :=
+  congr_arg NNReal.toReal (linfty_op_nnnorm_toMatrix f)
+
+end
+
 end LinftyOp
 
 /-! ### The Frobenius norm

--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -396,7 +396,7 @@ private theorem norm_unitOf (a : α) : ‖unitOf a‖₊ = 1 := by
   rw [unitOf]
   split_ifs with h
   · simp
-  · rw [←nnnorm_eq_zero] at h
+  · rw [← nnnorm_eq_zero] at h
     rw [nnnorm_smul, nnnorm_inv, nnnorm_norm, mul_inv_cancel h]
 
 private theorem mul_unitOf (a : α) : a * unitOf a = algebraMap _ _ (‖a‖₊ : ℝ)  := by
@@ -431,7 +431,7 @@ lemma linfty_op_nnnorm_eq_op_nnnorm (A : Matrix m n α) :
   simp [mulVec, dotProduct] at this
   specialize this i
   refine le_trans ?_ this
-  simp_rw [mul_unitOf, ←map_sum, nnnorm_algebraMap, ←NNReal.coe_sum]
+  simp_rw [mul_unitOf, ← map_sum, nnnorm_algebraMap, ← NNReal.coe_sum]
   simp only [NNReal.nnnorm_eq, nnnorm_one, mul_one, le_refl]
 
 lemma linfty_op_norm_eq_op_norm (A : Matrix m n α) :

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -370,7 +370,7 @@ theorem op_nnnorm_le_of_lipschitz {f : E →SL[σ₁₂] F} {K : ℝ≥0} (hf : 
   op_norm_le_of_lipschitz hf
 #align continuous_linear_map.op_nnnorm_le_of_lipschitz ContinuousLinearMap.op_nnnorm_le_of_lipschitz
 
-theorem op_nnnorm_eq_of_bounds {φ : E →SL[σ₁₂] F} (M : ℝ≥0) (h_above : ∀ x, ‖φ x‖ ≤ M * ‖x‖)
+theorem op_nnnorm_eq_of_bounds {φ : E →SL[σ₁₂] F} (M : ℝ≥0) (h_above : ∀ x, ‖φ x‖₊ ≤ M * ‖x‖₊)
     (h_below : ∀ N, (∀ x, ‖φ x‖₊ ≤ N * ‖x‖₊) → M ≤ N) : ‖φ‖₊ = M :=
   Subtype.ext <| op_norm_eq_of_bounds (zero_le M) h_above <| Subtype.forall'.mpr h_below
 #align continuous_linear_map.op_nnnorm_eq_of_bounds ContinuousLinearMap.op_nnnorm_eq_of_bounds


### PR DESCRIPTION
The witness used in the proof is inspired by https://math.stackexchange.com/a/1119933/1896.
Trying to weaken the field assumption used in the proof is largely meaningless, since we can't even state the theorem without it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [ ] depends on: #9473

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
