### PR TITLE
[Merged by Bors] - feat(GroupTheory/GroupAction): new `FixedPoints` module with a few basic properties of `fixedBy`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2189,6 +2189,7 @@ import Mathlib.GroupTheory.GroupAction.Defs
 import Mathlib.GroupTheory.GroupAction.DomAct.ActionHom
 import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 import Mathlib.GroupTheory.GroupAction.Embedding
+import Mathlib.GroupTheory.GroupAction.FixedPoints
 import Mathlib.GroupTheory.GroupAction.FixingSubgroup
 import Mathlib.GroupTheory.GroupAction.Group
 import Mathlib.GroupTheory.GroupAction.Hom

--- a/Mathlib/Data/Set/Pointwise/SMul.lean
+++ b/Mathlib/Data/Set/Pointwise/SMul.lean
@@ -971,6 +971,10 @@ theorem smul_univ {s : Set α} (hs : s.Nonempty) : s • (univ : Set β) = univ 
 #align set.vadd_univ Set.vadd_univ
 
 @[to_additive]
+theorem smul_set_compl : a • sᶜ = (a • s)ᶜ := by
+  simp_rw [Set.compl_eq_univ_diff, smul_set_sdiff, smul_set_univ]
+
+@[to_additive]
 theorem smul_inter_ne_empty_iff {s t : Set α} {x : α} :
     x • s ∩ t ≠ ∅ ↔ ∃ a b, (a ∈ t ∧ b ∈ s) ∧ a * b⁻¹ = x := by
   rw [← nonempty_iff_ne_empty]

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -40,7 +40,8 @@ section FixedPoints
 
 variable (α) in
 /-- In a multiplicative group action, the points fixed by `g` are also fixed by `g⁻¹` -/
-@[to_additive (attr := simp) "In an additive group action, the points fixed by `g` are also fixed by `g⁻¹`"]
+@[to_additive (attr := simp)
+  "In an additive group action, the points fixed by `g` are also fixed by `g⁻¹`"]
 theorem fixedBy_inv_eq_fixedBy (g : G) : fixedBy α g⁻¹ = fixedBy α g := by
   ext x
   rw [mem_fixedBy, mem_fixedBy, inv_smul_eq_iff, eq_comm]

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -10,21 +10,22 @@ import Mathlib.Data.Set.Pointwise.SMul
 /-!
 # Properties of `fixedPoints` and `fixedBy`
 
-This module contains some useful properties of [`MulAction.fixedPoints`] and [`MulAction.fixedBy`]
+This module contains some useful properties of `MulAction.fixedPoints` and `MulAction.fixedBy`
 that don't directly belong to `Mathlib.GroupTheory.GroupAction.Basic`,
-as well as the definition of [`MulAction.movedBy`].
+as well as the definition of `MulAction.movedBy` and `AddAction.movedBy`,
+the complements of `MulAction.fixedBy` and `AddAction.fixedBy` respectively.
 
 ## Main theorems
 
-* [`MulAction.fixedBy_mul`], [`MulAction.movedBy_mul`] (and their `AddAction` equivalents),
+* `MulAction.fixedBy_mul`, `MulAction.movedBy_mul` (and their `AddAction` equivalents),
   for the different relationship between the `movedBy`/`fixedBy` sets of `g*h`.
-* [`MulAction.fixedBy_conj`] and [`MulAction.movedBy_conj`]: the pointwise group action on the sets
+* `MulAction.fixedBy_conj` and `MulAction.movedBy_conj`: the pointwise group action on the sets
   `fixedBy α g` and `movedBy α g` translates to the conjugation action on `g`.
-* [`MulAction.smul_in_set_of_movedBy_subset`] shows that if a set `s` is a superset of
+* `MulAction.smul_mem_of_movedBy_subset` shows that if a set `s` is a superset of
   `movedBy α g`, then the group action of `g` cannot send elements of `s` outside of `s`.
-* [`MulAction.not_commute_of_disjoint_movedBy_preimage`] allows one to infer that two group elements
-  do not commute from the behavior of their `movedBy` sets, which is useful in the proof of
-  Rubin's theorem.
+* `MulAction.not_commute_of_disjoint_movedBy_preimage` allows one to prove that two group elements
+  do not commute from the disjointness of the `movedBy` set and its image by the second group
+  element, which is a property used in the proof of Rubin's theorem.
 -/
 
 namespace MulAction
@@ -38,6 +39,7 @@ variable {M : Type u} [Monoid M] [MulAction M α]
 
 section FixedPoints
 
+variable (α) in
 /-- In a multiplicative group action, the points fixed by `g` are also fixed by `g⁻¹` -/
 @[to_additive "In an additive group action, the points fixed by `g` are also fixed by `g⁻¹`"]
 theorem fixedBy_eq_fixedBy_inv (g : G) : fixedBy α g = fixedBy α g⁻¹ := by
@@ -54,23 +56,36 @@ theorem smul_mem_fixedBy_iff_mem_fixedBy {a : α} {g : G} :
   rw [mem_fixedBy, smul_left_cancel_iff]
   rfl
 
-@[to_additive]
 theorem minimalPeriod_eq_one_of_fixedBy {a : α} {g : G} (a_in_fixedBy : a ∈ fixedBy α g) :
     Function.minimalPeriod (fun x => g • x) a = 1 := by
   rw [Function.minimalPeriod_eq_one_iff_isFixedPt]
   exact a_in_fixedBy
 
+section AddAction.minimalPeriod_eq_one_of_fixedBy
+variable {G : Type u} [AddGroup G] [AddAction G α]
+
+theorem _root_.AddAction.minimalPeriod_eq_one_of_fixedBy {a : α} {g : G}
+  (a_in_fixedBy : a ∈ AddAction.fixedBy α g) :
+    Function.minimalPeriod (fun x => g +ᵥ x) a = 1 := by
+  rw [Function.minimalPeriod_eq_one_iff_isFixedPt]
+  exact a_in_fixedBy
+
+end AddAction.minimalPeriod_eq_one_of_fixedBy
+
+attribute [to_additive existing AddAction.minimalPeriod_eq_one_of_fixedBy]
+  minimalPeriod_eq_one_of_fixedBy
+
+variable (α) in
 @[to_additive]
-theorem fixedBy_subset_fixedBy_pow (g : G) (j : ℤ) :
-    fixedBy α g ⊆ fixedBy α (g^j) := by
+theorem fixedBy_subset_fixedBy_zpow (g : G) (j : ℤ) :
+    fixedBy α g ⊆ fixedBy α (g ^ j) := by
   intro a a_in_fixedBy
   rw [mem_fixedBy, zpow_smul_eq_iff_minimalPeriod_dvd,
     minimalPeriod_eq_one_of_fixedBy a_in_fixedBy]
   rw [Nat.cast_one]
   exact one_dvd j
 
-variable (M)
-
+variable (M α) in
 @[to_additive (attr := simp)]
 theorem fixedBy_one_eq_univ :
     fixedBy α (1 : M) = Set.univ := by
@@ -78,13 +93,13 @@ theorem fixedBy_one_eq_univ :
   rw [mem_fixedBy, one_smul]
   exact ⟨fun _ => Set.mem_univ a, fun _ => rfl⟩
 
-variable {M} (α)
-
+variable (α) in
 @[to_additive]
 theorem fixedBy_mul (m₁ m₂ : M) : fixedBy α m₁ ∩ fixedBy α m₂ ⊆ fixedBy α (m₁ * m₂) := by
   intro a ⟨h₁, h₂⟩
   rw [mem_fixedBy, mul_smul, h₂, h₁]
 
+variable (α) in
 @[to_additive]
 theorem fixedBy_conj (g h : G) :
     fixedBy α (h * g * h⁻¹) = (fun a => h⁻¹ • a) ⁻¹' fixedBy α g := by
@@ -97,13 +112,17 @@ end FixedPoints
 
 section MovedBy
 
-variable (α)
+/-!
+## Moved points
 
+`MulAction.movedBy` and `AddAction.movedBy` describe the sets of points `a : α` for which
+`g • a ≠ a` (resp. `g +ᵥ a ≠ a`).
+-/
+
+variable (α) in
 /-- The set of points moved by an element of the action. -/
 @[to_additive "The set of points moved by an element of the action."]
 def movedBy (m : M) : Set α := { a : α | m • a ≠ a }
-
-variable {α}
 
 @[to_additive (attr := simp)]
 theorem mem_movedBy {m : M} {a : α} : a ∈ movedBy α m ↔ m • a ≠ a :=
@@ -146,26 +165,25 @@ theorem smul_inv_mem_movedBy_iff_mem_movedBy {a : α} {g : G} :
   (movedBy_eq_movedBy_inv α g) ▸ smul_mem_movedBy_iff_mem_movedBy
 
 @[to_additive]
-theorem movedBy_pow_subset_movedBy (g : G) (j : ℤ) :
-    movedBy α (g^j) ⊆ movedBy α g := by
+theorem movedBy_zpow_subset_movedBy (g : G) (j : ℤ) :
+    movedBy α (g ^ j) ⊆ movedBy α g := by
   repeat rw [movedBy_eq_compl_fixedBy]
   rw [Set.compl_subset_compl]
-  exact fixedBy_subset_fixedBy_pow g j
+  exact fixedBy_subset_fixedBy_zpow α g j
 
-variable (M α)
-
+variable (M α) in
 @[to_additive (attr := simp)]
 theorem movedBy_one_eq_empty : movedBy α (1 : M) = ∅ := by
   rw [movedBy_eq_compl_fixedBy, fixedBy_one_eq_univ, Set.compl_univ]
 
-variable {M}
-
+variable (α) in
 @[to_additive]
 theorem movedBy_mul (m₁ m₂ : M) : movedBy α (m₁ * m₂) ⊆ movedBy α m₁ ∪ movedBy α m₂ := by
   repeat rw [movedBy_eq_compl_fixedBy]
   rw [← Set.compl_inter, Set.compl_subset_compl]
   exact fixedBy_mul α m₁ m₂
 
+variable (α) in
 @[to_additive]
 theorem movedBy_conj (g h : G) :
     movedBy α (h * g * h⁻¹) = (fun a => h⁻¹ • a) ⁻¹' movedBy α g := by
@@ -181,41 +199,64 @@ end MovedBy
 
 section Image
 
-/-- If `s` is a superset of `movedBy α g`, then `g` cannot move a point outside of `s`. -/
-@[to_additive "If `s` is a superset of `movedBy α g`, then `g` cannot move a point outside of `s`."]
-theorem smul_pow_mem_of_movedBy_subset {a : α} {s : Set α} {g : G} (s_subset : movedBy α g ⊆ s)
-    (j : ℤ) : g^j • a ∈ s ↔ a ∈ s := by
-  rcases (Classical.em (a ∈ movedBy α (g^j))) with a_moved | a_fixed
-  · constructor
+/-!
+### Images of supersets of `movedBy α g`
+
+If a set `s : Set α` is a superset of `MulAction.movedBy α g` (resp. `AddAction.movedBy α g`),
+the no point or subset of `s` can be moved outside of `s` by the group action of `g`.
+-/
+
+/-- If `movedBy α g ⊆ s`, then `g` cannot move a point of `s` outside of `s`. -/
+@[to_additive "If `movedBy α g ⊆ s`, then `g` cannot move a point of `s` outside of `s`."]
+theorem smul_zpow_mem_of_movedBy_subset {a : α} {s : Set α} {g : G} (s_subset : movedBy α g ⊆ s)
+    (j : ℤ) : g ^ j • a ∈ s ↔ a ∈ s := by
+  by_cases a ∈ movedBy α (g ^ j)
+  case pos a_moved =>
+    constructor
     all_goals (intro; apply s_subset)
-    all_goals apply movedBy_pow_subset_movedBy g j
+    all_goals apply movedBy_zpow_subset_movedBy g j
     · exact a_moved
     · rw [smul_mem_movedBy_iff_mem_movedBy]
       exact a_moved
-  · rw [not_mem_movedBy_iff_mem_fixedBy, mem_fixedBy] at a_fixed
+  case neg a_fixed =>
+    rw [not_mem_movedBy_iff_mem_fixedBy, mem_fixedBy] at a_fixed
     rw [a_fixed]
 
 @[to_additive]
 theorem smul_mem_of_movedBy_subset {a : α} {s : Set α} {g : G} (superset : movedBy α g ⊆ s) :
-    g • a ∈ s ↔ a ∈ s := (zpow_one g) ▸ smul_pow_mem_of_movedBy_subset superset 1
+    g • a ∈ s ↔ a ∈ s := (zpow_one g) ▸ smul_zpow_mem_of_movedBy_subset superset 1
 
 @[to_additive]
-theorem smul_pow_preimage_eq_of_movedBy_subset {s : Set α} {g : G} (superset : movedBy α g ⊆ s)
-    (j : ℤ) : (fun a => g^j • a) ⁻¹' s = s := by
+theorem smul_zpow_preimage_eq_of_movedBy_subset {s : Set α} {g : G} (superset : movedBy α g ⊆ s)
+    (j : ℤ) : (fun a => g ^ j • a) ⁻¹' s = s := by
   ext a
-  rw [Set.mem_preimage, smul_pow_mem_of_movedBy_subset superset]
+  rw [Set.mem_preimage, smul_zpow_mem_of_movedBy_subset superset]
 
-/-- If `movedBy α g ⊆ t`, then `g` cannot send a subset of `t` outside of `t` -/
-@[to_additive]
-theorem smul_pow_subset_of_movedBy_subset {s t : Set α} {g : G}  (t_superset : movedBy α g ⊆ t)
-    (s_ss_t : s ⊆ t) (j : ℤ): (fun a => g^j • a) ⁻¹' s ⊆ t := by
-  rw [← smul_pow_preimage_eq_of_movedBy_subset t_superset j]
+/-- If `movedBy α g ⊆ t`, then `g` cannot send a subset of `t` outside of `t`. -/
+@[to_additive "If `movedBy α g ⊆ t`, then `g` cannot send a subset of `t` outside of `t`."]
+theorem smul_zpow_subset_of_movedBy_subset {s t : Set α} {g : G}  (t_superset : movedBy α g ⊆ t)
+    (s_ss_t : s ⊆ t) (j : ℤ): (fun a => g ^ j • a) ⁻¹' s ⊆ t := by
+  rw [← smul_zpow_preimage_eq_of_movedBy_subset t_superset j]
   repeat rw [Set.preimage_smul]
   exact Set.smul_set_mono s_ss_t
 
-/-- If `g` and `h` commute, then `g` fixes `h • x` iff `g` fixes `x`. -/
-@[to_additive]
-theorem smul_pow_mem_fixedBy_of_commute {g h : G} (comm : Commute g h) (x : α) (j : ℤ):
+end Image
+
+section Commute
+
+/-!
+If two group elements `g` and `h` commute, then `g` fixes `h • x` (resp. `h +ᵥ x`)
+if and only if `g` fixes `x`.
+
+This can be extended to the more general statement that `g` fixes `h^j • x` (resp. `(j • h) +ᵥ x`)
+if and only if `g` fixes `x`.
+-/
+
+/--
+If `g` and `h` commute, then `g` fixes `h^j • x` iff `g` fixes `x`.
+-/
+@[to_additive "If `g` and `h` commute, then `g` fixes `(j • h) +ᵥ x` iff `g` fixes `x`."]
+theorem smul_zpow_mem_fixedBy_of_commute {g h : G} (comm : Commute g h) (x : α) (j : ℤ):
     x ∈ fixedBy α g ↔ h^j • x ∈ fixedBy α g := by
   suffices ∀ x : α, ∀ h : G, Commute g h → x ∈ fixedBy α g → h^j • x ∈ fixedBy α g by
     refine ⟨this x h comm, fun hx_in_fixedBy => ?x_in_fixedBy⟩
@@ -228,35 +269,39 @@ theorem smul_pow_mem_fixedBy_of_commute {g h : G} (comm : Commute g h) (x : α) 
   rw [mul_smul, smul_left_cancel_iff]
   exact x_in_fixedBy
 
-/-- If `g` and `h` commute, then `g` moves `h • x` iff `g` moves `x`. -/
-@[to_additive]
-theorem smul_pow_mem_movedBy_of_commute {g h : G} (comm : Commute g h) (a : α) (j : ℤ):
+/--
+If `g` and `h` commute, then `g` moves `h^j • x` iff `g` moves `x`.
+-/
+@[to_additive "If `g` and `h` commute, then `g` moves `(j • h) +ᵥ x` iff `g` moves `x`."]
+theorem smul_zpow_mem_movedBy_of_commute {g h : G} (comm : Commute g h) (a : α) (j : ℤ):
     a ∈ movedBy α g ↔ h^j • a ∈ movedBy α g := by
   repeat rw [movedBy_eq_compl_fixedBy]
   repeat rw [Set.mem_compl_iff]
-  rw [smul_pow_mem_fixedBy_of_commute comm]
+  rw [smul_zpow_mem_fixedBy_of_commute comm]
 
 @[to_additive]
-theorem movedBy_eq_smul_pow_movedBy_of_commute {g h : G} (comm : Commute g h) (j : ℤ):
+theorem movedBy_eq_smul_zpow_movedBy_of_commute {g h : G} (comm : Commute g h) (j : ℤ):
     movedBy α g = (fun a => h^j • a) ⁻¹' movedBy α g := by
   ext a
-  rw [Set.mem_preimage, smul_pow_mem_movedBy_of_commute comm]
+  rw [Set.mem_preimage, smul_zpow_mem_movedBy_of_commute comm]
 
 @[to_additive]
 theorem movedBy_eq_smul_movedBy_of_commute {g h : G} (comm : Commute g h):
     movedBy α g = (fun a => h • a) ⁻¹' movedBy α g := by
-  nth_rw 1 [movedBy_eq_smul_pow_movedBy_of_commute comm 1]
+  nth_rw 1 [movedBy_eq_smul_zpow_movedBy_of_commute comm 1]
   rw [zpow_one]
 
-end Image
+end Commute
 
 section Faithful
 
 variable [FaithfulSMul G α]
 variable [FaithfulSMul M α]
 
-/-- If the action is faithful, then an empty `movedBy` set implies that `m = 1` -/
-@[to_additive]
+/-- If the multiplicative action of `M` on `α` is faithful,
+then an empty `movedBy α m` set implies that `m = 1`. -/
+@[to_additive "If the additive action of `M` on `α` is faithful,
+then an empty `movedBy α m` set implies that `m = 1`."]
 theorem movedBy_empty_iff_eq_one {m : M} : movedBy α m = ∅ ↔ m = 1 := by
   constructor
   · intro moved_empty
@@ -270,9 +315,9 @@ theorem movedBy_empty_iff_eq_one {m : M} : movedBy α m = ∅ ↔ m = 1 := by
     exact movedBy_one_eq_empty α M
 
 /--
-This theorem allows to deduce the non-commutativity of `g` and `h`
-from the `movedBy` set of a faithful group action.
---/
+If the image of the `movedBy α g` set by the multiplicative action of `h: G`
+is disjoint from `movedBy α g`, then `g` and `h` cannot commute.
+-/
 theorem not_commute_of_disjoint_movedBy_preimage {g h : G} (ne_one : g ≠ 1)
     (disjoint : Disjoint (movedBy α g) ((fun a => h • a) ⁻¹' movedBy α g)) : ¬Commute g h := by
   intro h₁

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -65,7 +65,7 @@ section AddAction.minimalPeriod_eq_one_of_fixedBy
 variable {G : Type u} [AddGroup G] [AddAction G α]
 
 theorem _root_.AddAction.minimalPeriod_eq_one_of_fixedBy {a : α} {g : G}
-  (a_in_fixedBy : a ∈ AddAction.fixedBy α g) :
+    (a_in_fixedBy : a ∈ AddAction.fixedBy α g) :
     Function.minimalPeriod (fun x => g +ᵥ x) a = 1 := by
   rw [Function.minimalPeriod_eq_one_iff_isFixedPt]
   exact a_in_fixedBy

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -44,9 +44,9 @@ theorem fixedBy_eq_fixedBy_inv (g : G) : fixedBy α g = fixedBy α g⁻¹ := by
   ext x
   repeat rw [mem_fixedBy]
   constructor
-  all_goals (intro gx_eq_x; nth_rw 1 [<-gx_eq_x])
+  all_goals (intro gx_eq_x; nth_rw 1 [← gx_eq_x])
   · exact inv_smul_smul g x
-  · rw [<-mul_smul, mul_right_inv, one_smul]
+  · rw [← mul_smul, mul_right_inv, one_smul]
 
 @[to_additive]
 theorem smul_mem_fixedBy_iff_mem_fixedBy {a : α} {g : G} :
@@ -117,7 +117,7 @@ theorem movedBy_eq_compl_fixedBy {m : M} : movedBy α m = (fixedBy α m)ᶜ := r
 
 @[to_additive]
 theorem fixedBy_eq_compl_movedBy {m : M} : fixedBy α m = (movedBy α m)ᶜ := by
-  rw [<-compl_compl (fixedBy α m), movedBy_eq_compl_fixedBy]
+  rw [← compl_compl (fixedBy α m), movedBy_eq_compl_fixedBy]
 
 @[to_additive]
 theorem not_mem_fixedBy_iff_mem_movedBy {m : M} {a : α} : a ∉ fixedBy α m ↔ a ∈ movedBy α m :=
@@ -140,7 +140,7 @@ variable {α}
 @[to_additive]
 theorem smul_mem_movedBy_iff_mem_movedBy {a : α} {g : G} :
     g • a ∈ movedBy α g ↔ a ∈ movedBy α g := by
-  repeat rw [<-not_mem_fixedBy_iff_mem_movedBy]
+  repeat rw [← not_mem_fixedBy_iff_mem_movedBy]
   rw [smul_mem_fixedBy_iff_mem_fixedBy]
 
 @[to_additive]
@@ -166,7 +166,7 @@ variable {M}
 @[to_additive]
 theorem movedBy_mul (m₁ m₂ : M) : movedBy α (m₁ * m₂) ⊆ movedBy α m₁ ∪ movedBy α m₂ := by
   repeat rw [movedBy_eq_compl_fixedBy]
-  rw [<-Set.compl_inter, Set.compl_subset_compl]
+  rw [← Set.compl_inter, Set.compl_subset_compl]
   exact fixedBy_mul α m₁ m₂
 
 @[to_additive]
@@ -212,7 +212,7 @@ theorem smul_pow_preimage_eq_of_movedBy_subset {s : Set α} {g : G} (superset : 
 @[to_additive]
 theorem smul_pow_subset_of_movedBy_subset {s t : Set α} {g : G}  (t_superset : movedBy α g ⊆ t)
     (s_ss_t : s ⊆ t) (j : ℤ): (fun a => g^j • a) ⁻¹' s ⊆ t := by
-  rw [<-smul_pow_preimage_eq_of_movedBy_subset t_superset j]
+  rw [← smul_pow_preimage_eq_of_movedBy_subset t_superset j]
   repeat rw [Set.preimage_smul]
   exact Set.smul_set_mono s_ss_t
 
@@ -222,11 +222,11 @@ theorem smul_pow_mem_fixedBy_of_commute {g h : G} (comm : Commute g h) (x : α) 
     x ∈ fixedBy α g ↔ h^j • x ∈ fixedBy α g := by
   suffices ∀ x : α, ∀ h : G, Commute g h → x ∈ fixedBy α g → h^j • x ∈ fixedBy α g by
     refine ⟨this x h comm, fun hx_in_fixedBy => ?x_in_fixedBy⟩
-    have h₁ : x = h⁻¹^j • h^j • x := by rw [<-mul_smul, inv_zpow', zpow_neg, mul_left_inv, one_smul]
+    have h₁ : x = h⁻¹^j • h^j • x := by rw [← mul_smul, inv_zpow', zpow_neg, mul_left_inv, one_smul]
     rw [h₁]
     exact this _ _ comm.inv_right hx_in_fixedBy
   intro x h comm x_in_fixedBy
-  rw [mem_fixedBy, <-mul_smul]
+  rw [mem_fixedBy, ← mul_smul]
   rw [Commute.zpow_right comm j]
   rw [mul_smul, smul_left_cancel_iff]
   exact x_in_fixedBy
@@ -267,7 +267,7 @@ theorem movedBy_empty_iff_eq_one {m : M} : movedBy α m = ∅ ↔ m = 1 := ⟨
     intro a
     rw [one_smul]
     by_contra ma_ne_a
-    rwa [<-ne_eq, <-mem_movedBy, moved_empty] at ma_ne_a
+    rwa [← ne_eq, ← mem_movedBy, moved_empty] at ma_ne_a
   ),
   fun eq_one => eq_one.symm ▸ movedBy_one_eq_empty α M
 ⟩

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -64,11 +64,8 @@ theorem minimalPeriod_eq_one_of_fixedBy {a : α} {g : G} (a_in_fixedBy : a ∈ f
 theorem fixedBy_subset_fixedBy_pow (g : G) (j : ℤ) :
     fixedBy α g ⊆ fixedBy α (g^j) := by
   intro a a_in_fixedBy
-  rw [
-    mem_fixedBy,
-    zpow_smul_eq_iff_minimalPeriod_dvd,
-    minimalPeriod_eq_one_of_fixedBy a_in_fixedBy
-  ]
+  rw [mem_fixedBy, zpow_smul_eq_iff_minimalPeriod_dvd,
+    minimalPeriod_eq_one_of_fixedBy a_in_fixedBy]
   rw [Nat.cast_one]
   exact one_dvd j
 
@@ -260,17 +257,17 @@ variable [FaithfulSMul M α]
 
 /-- If the action is faithful, then an empty `movedBy` set implies that `m = 1` -/
 @[to_additive]
-theorem movedBy_empty_iff_eq_one {m : M} : movedBy α m = ∅ ↔ m = 1 := ⟨
-  (by
-    intro moved_empty
+theorem movedBy_empty_iff_eq_one {m : M} : movedBy α m = ∅ ↔ m = 1 := by
+  constructor
+  · intro moved_empty
     apply FaithfulSMul.eq_of_smul_eq_smul (α := α)
     intro a
     rw [one_smul]
     by_contra ma_ne_a
     rwa [← ne_eq, ← mem_movedBy, moved_empty] at ma_ne_a
-  ),
-  fun eq_one => eq_one.symm ▸ movedBy_one_eq_empty α M
-⟩
+  · intro eq_one
+    rw [eq_one]
+    exact movedBy_one_eq_empty α M
 
 /--
 This theorem allows to deduce the non-commutativity of `g` and `h`

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -198,9 +198,8 @@ theorem smul_pow_mem_of_movedBy_subset {a : α} {s : Set α} {g : G} (s_subset :
   · rw [not_mem_movedBy_iff_mem_fixedBy, mem_fixedBy] at a_fixed
     rw [a_fixed]
 
--- TODO: rename to smul_mem
 @[to_additive]
-theorem smul_in_set_of_movedBy_subset {a : α} {s : Set α} {g : G} (superset : movedBy α g ⊆ s) :
+theorem smul_mem_of_movedBy_subset {a : α} {s : Set α} {g : G} (superset : movedBy α g ⊆ s) :
     g • a ∈ s ↔ a ∈ s := (zpow_one g) ▸ smul_pow_mem_of_movedBy_subset superset 1
 
 @[to_additive]

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2024 Emilie Burgun. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Emilie Burgun
+-/
+import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Dynamics.PeriodicPts
+
+/-!
+# Properties of `fixedPoints` and `fixedBy`
+
+This module contains some useful properties of `MulAction.fixedPoints` and `MulAction.fixedBy`
+that don't directly belong to `Mathlib.GroupTheory.GroupAction.Basic`,
+as well as the definition of `MulAction.movedBy`.
+-/
+
+namespace MulAction
+
+universe u v
+variable {α : Type v}
+variable {G : Type u} [Group G] [MulAction G α]
+variable {M : Type u} [Monoid M] [MulAction M α]
+
+
+section FixedPoints
+
+/-- In a multiplicative group action, the points fixed by `g` are also fixed by `g⁻¹` -/
+@[to_additive "In an additive group action, the points fixed by `g` are also fixed by `g⁻¹`"]
+theorem fixedBy_eq_fixedBy_inv (g : G) : fixedBy α g = fixedBy α g⁻¹ := by
+  ext x
+  repeat rw [mem_fixedBy]
+  constructor
+  all_goals (intro gx_eq_x; nth_rw 1 [<-gx_eq_x])
+  · exact inv_smul_smul g x
+  · rw [<-mul_smul, mul_right_inv, one_smul]
+
+@[to_additive]
+theorem smul_mem_fixedBy_iff_mem_fixedBy {a : α} {g : G} :
+    g • a ∈ fixedBy α g ↔ a ∈ fixedBy α g := by
+  rw [mem_fixedBy, smul_left_cancel_iff]
+  rfl
+
+@[to_additive]
+theorem minimalPeriod_eq_one_of_fixedBy {a : α} {g : G} (a_in_fixedBy : a ∈ fixedBy α g) :
+    Function.minimalPeriod (fun x => g • x) a = 1 := by
+  rw [Function.minimalPeriod_eq_one_iff_isFixedPt]
+  exact a_in_fixedBy
+
+@[to_additive]
+theorem fixedBy_subset_fixedBy_pow (g : G) (j : ℤ) :
+    fixedBy α g ⊆ fixedBy α (g^j) := by
+  intro a a_in_fixedBy
+  rw [
+    mem_fixedBy,
+    zpow_smul_eq_iff_minimalPeriod_dvd,
+    minimalPeriod_eq_one_of_fixedBy a_in_fixedBy
+  ]
+  rw [Nat.cast_one]
+  exact one_dvd j
+
+variable (M)
+
+@[to_additive (attr := simp)]
+theorem fixedBy_one_eq_univ :
+    fixedBy α (1 : M) = Set.univ := by
+  ext a
+  rw [mem_fixedBy, one_smul]
+  exact ⟨fun _ => Set.mem_univ a, fun _ => rfl⟩
+
+end FixedPoints
+
+section MovedBy
+
+variable (α)
+
+/-- The set of points moved by an element of the action. -/
+@[to_additive "The set of points moved by an element of the action."]
+def movedBy (m : M) : Set α := { a : α | m • a ≠ a }
+
+variable {α}
+
+@[to_additive (attr := simp)]
+theorem mem_movedBy {m : M} {a : α} : a ∈ movedBy α m ↔ m • a ≠ a :=
+  Iff.rfl
+
+@[to_additive]
+theorem movedBy_eq_compl_fixedBy {m : M} : movedBy α m = (fixedBy α m)ᶜ := rfl
+
+@[to_additive]
+theorem fixedBy_eq_compl_movedBy {m : M} : fixedBy α m = (movedBy α m)ᶜ := by
+  rw [<-compl_compl (fixedBy α m), movedBy_eq_compl_fixedBy]
+
+@[to_additive]
+theorem not_mem_fixedBy_iff_mem_movedBy {m : M} {a : α} : a ∉ fixedBy α m ↔ a ∈ movedBy α m :=
+  Iff.rfl
+
+@[to_additive]
+theorem not_mem_movedBy_iff_mem_fixedBy {m : M} {a : α} : a ∉ movedBy α m ↔ a ∈ fixedBy α m := by
+  rw [movedBy_eq_compl_fixedBy, Set.not_mem_compl_iff]
+
+/-- In a multiplicative group action, the points moved by `g` are also moved by `g⁻¹` -/
+@[to_additive "In an additive group action, the points moved by `g` are also moved by `g⁻¹`"]
+theorem movedBy_eq_movedBy_inv (g : G) : movedBy α g = movedBy α g⁻¹ := by
+  repeat rw [movedBy_eq_compl_fixedBy]
+  rw [fixedBy_eq_fixedBy_inv]
+
+@[to_additive]
+theorem smul_mem_movedBy_iff_mem_movedBy {a : α} {g : G} :
+    g • a ∈ movedBy α g ↔ a ∈ movedBy α g := by
+  repeat rw [<-not_mem_fixedBy_iff_mem_movedBy]
+  rw [smul_mem_fixedBy_iff_mem_fixedBy]
+
+@[to_additive]
+theorem movedBy_pow_subset_movedBy (g : G) (j : ℤ) :
+    movedBy α (g^j) ⊆ movedBy α g := by
+  repeat rw [movedBy_eq_compl_fixedBy]
+  rw [Set.compl_subset_compl]
+  exact fixedBy_subset_fixedBy_pow g j
+
+@[to_additive (attr := simp)]
+theorem movedBy_one_eq_empty (α) (M : Type u) [Monoid M] [MulAction M α] :
+    movedBy α (1 : M) = ∅ := by
+  rw [movedBy_eq_compl_fixedBy, fixedBy_one_eq_univ, Set.compl_univ]
+
+/-- If `s` is a superset of `movedBy α g`, then `g` cannot move a point outside of `s`. -/
+@[to_additive "If `s` is a superset of `movedBy α g`, then `g` cannot move a point outside of `s`."]
+theorem smul_pow_in_set_of_movedBy_subset {a : α} {s : Set α} {g : G} (s_subset : movedBy α g ⊆ s)
+    (j : ℤ) : g^j • a ∈ s ↔ a ∈ s := by
+  rcases (Classical.em (a ∈ movedBy α (g^j))) with a_moved | a_fixed
+  · constructor
+    all_goals (intro; apply s_subset)
+    all_goals apply movedBy_pow_subset_movedBy g j
+    · exact a_moved
+    · rw [smul_mem_movedBy_iff_mem_movedBy]
+      exact a_moved
+  · rw [not_mem_movedBy_iff_mem_fixedBy, mem_fixedBy] at a_fixed
+    rw [a_fixed]
+
+@[to_additive]
+theorem smul_in_set_of_movedBy_subset {a : α} {s : Set α} {g : G} (s_subset : movedBy α g ⊆ s) :
+    g • a ∈ s ↔ a ∈ s := (zpow_one g) ▸ smul_pow_in_set_of_movedBy_subset s_subset 1
+
+end MovedBy
+
+section Faithful
+
+variable [FaithfulSMul G α]
+variable [FaithfulSMul M α]
+
+/-- If the action is faithful, then an empty `movedBy` set implies that `m = 1` -/
+@[to_additive]
+theorem movedBy_empty_iff_eq_one {m : M} : movedBy α m = ∅ ↔ m = 1 := ⟨
+  (by
+    intro moved_empty
+    apply FaithfulSMul.eq_of_smul_eq_smul (α := α)
+    intro a
+    rw [one_smul]
+    by_contra ma_ne_a
+    rwa [<-ne_eq, <-mem_movedBy, moved_empty] at ma_ne_a
+  ),
+  fun eq_one => eq_one.symm ▸ movedBy_one_eq_empty α M
+⟩
+
+end Faithful
+
+end MulAction

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -20,8 +20,8 @@ as well as the definition of [`MulAction.movedBy`].
   for the different relationship between the `movedBy`/`fixedBy` sets of `g*h`.
 * [`MulAction.fixedBy_conj`] and [`MulAction.movedBy_conj`]: the pointwise group action on the sets
   `fixedBy α g` and `movedBy α g` translates to the conjugation action on `g`.
-* [`MulAction.smul_in_set_of_movedBy_subset`] shows that if a set `s` is a superset of `movedBy α g`,
-  then the group action of `g` cannot send elements of `s` outside of `s`.
+* [`MulAction.smul_in_set_of_movedBy_subset`] shows that if a set `s` is a superset of
+  `movedBy α g`, then the group action of `g` cannot send elements of `s` outside of `s`.
 * [`MulAction.not_commute_of_disjoint_movedBy_preimage`] allows one to infer that two group elements
   do not commute from the behavior of their `movedBy` sets, which is useful in the proof of
   Rubin's theorem.

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -56,8 +56,8 @@ variable (α) in
 /-- In a multiplicative group action, the points fixed by `g` are also fixed by `g⁻¹` -/
 @[to_additive (attr := simp)
   "In an additive group action, the points fixed by `g` are also fixed by `g⁻¹`"]
-theorem fixedBy_inv_eq_fixedBy (g : G) : fixedBy α g⁻¹ = fixedBy α g := by
-  ext x
+theorem fixedBy_inv (g : G) : fixedBy α g⁻¹ = fixedBy α g := by
+  ext
   rw [mem_fixedBy, mem_fixedBy, inv_smul_eq_iff, eq_comm]
 
 @[to_additive]
@@ -69,12 +69,12 @@ theorem smul_mem_fixedBy_iff_mem_fixedBy {a : α} {g : G} :
 @[to_additive]
 theorem smul_inv_mem_fixedBy_iff_mem_fixedBy {a : α} {g : G} :
     g⁻¹ • a ∈ fixedBy α g ↔ a ∈ fixedBy α g := by
-  rw [← fixedBy_inv_eq_fixedBy, smul_mem_fixedBy_iff_mem_fixedBy, fixedBy_inv_eq_fixedBy]
+  rw [← fixedBy_inv, smul_mem_fixedBy_iff_mem_fixedBy, fixedBy_inv]
 
-@[to_additive minimalPeriod_eq_one_of_fixedBy]
-theorem minimalPeriod_eq_one_of_fixedBy {a : α} {g : G} (a_in_fixedBy : a ∈ fixedBy α g) :
-    Function.minimalPeriod (fun x => g • x) a = 1 := by
-  rwa [Function.minimalPeriod_eq_one_iff_isFixedPt]
+@[to_additive minimalPeriod_eq_one_iff_fixedBy]
+theorem minimalPeriod_eq_one_iff_fixedBy {a : α} {g : G} :
+    Function.minimalPeriod (fun x => g • x) a = 1 ↔ a ∈ fixedBy α g :=
+  Function.minimalPeriod_eq_one_iff_isFixedPt
 
 variable (α) in
 @[to_additive]
@@ -82,13 +82,13 @@ theorem fixedBy_subset_fixedBy_zpow (g : G) (j : ℤ) :
     fixedBy α g ⊆ fixedBy α (g ^ j) := by
   intro a a_in_fixedBy
   rw [mem_fixedBy, zpow_smul_eq_iff_minimalPeriod_dvd,
-    minimalPeriod_eq_one_of_fixedBy a_in_fixedBy, Nat.cast_one]
+    minimalPeriod_eq_one_iff_fixedBy.mpr a_in_fixedBy, Nat.cast_one]
   exact one_dvd j
 
 variable (M α) in
 @[to_additive (attr := simp)]
 theorem fixedBy_one_eq_univ : fixedBy α (1 : M) = Set.univ :=
-  Set.eq_univ_iff_forall.mpr (fun a => one_smul M a)
+  Set.eq_univ_iff_forall.mpr <| one_smul M
 
 variable (α) in
 @[to_additive]
@@ -98,18 +98,10 @@ theorem fixedBy_mul (m₁ m₂ : M) : fixedBy α m₁ ∩ fixedBy α m₂ ⊆ fi
 
 variable (α) in
 @[to_additive]
-theorem fixedBy_conj (g h : G) :
-    fixedBy α (h * g * h⁻¹) = (fun a => h⁻¹ • a) ⁻¹' fixedBy α g := by
-  ext a
-  rw [Set.mem_preimage, mem_fixedBy, mem_fixedBy]
-  repeat rw [mul_smul]
-  exact smul_eq_iff_eq_inv_smul h
-
-variable (α) in
-@[to_additive]
 theorem smul_fixedBy (g h: G) :
     h • fixedBy α g = fixedBy α (h * g * h⁻¹) := by
-  rw [fixedBy_conj, Set.preimage_smul, inv_inv]
+  ext a
+  simp_rw [Set.mem_smul_set_iff_inv_smul_mem, mem_fixedBy, mul_smul, smul_eq_iff_eq_inv_smul h]
 
 end FixedPoints
 
@@ -129,21 +121,11 @@ moved by `g`.
 @[to_additive "If a set `s : Set α` is in `fixedBy (Set α) g`, then all points of `s` will stay in
 `s` after being moved by `g`."]
 theorem set_mem_fixedBy_iff (s : Set α) (g : G) :
-    s ∈ fixedBy (Set α) g ↔ ∀ x, x ∈ s ↔ g • x ∈ s := by
-  constructor
-  · intro fixed x
-    refine ⟨
-      fun x_in_s => fixed ▸ Set.smul_mem_smul_set x_in_s,
-      fun gx_in_s => ?inv_in_set⟩
-    rwa [← fixed, Set.smul_mem_smul_set_iff] at gx_in_s
-  · intro closed
-    rw [← fixedBy_inv_eq_fixedBy]
-    ext x
-    rw [Set.mem_inv_smul_set_iff]
-    exact ⟨fun gxs => (closed x).mpr gxs, fun xs => (closed x).mp xs⟩
+    s ∈ fixedBy (Set α) g ↔ ∀ x, g • x ∈ s ↔ x ∈ s := by
+  simp_rw [mem_fixedBy, ← eq_inv_smul_iff, Set.ext_iff, Set.mem_inv_smul_set_iff, Iff.comm]
 
 theorem smul_mem_of_set_mem_fixedBy {s : Set α} {g : G} (s_in_fixedBy : s ∈ fixedBy (Set α) g)
-    {x : α} : x ∈ s ↔ g • x ∈ s := (set_mem_fixedBy_iff s g).mp s_in_fixedBy x
+    {x : α} : g • x ∈ s ↔ x ∈ s := (set_mem_fixedBy_iff s g).mp s_in_fixedBy x
 
 /--
 If `s ⊆ fixedBy α g`, then `g • s = s`, which means that `s ∈ fixedBy (Set α) g`.
@@ -157,22 +139,19 @@ Note that the reverse implication is in general not true, as `s ∈ fixedBy (Set
 weaker statement (it allows for points `x ∈ s` for which `g +ᵥ x ≠ x` and `g +ᵥ x ∈ s`)."]
 theorem set_mem_fixedBy_of_subset_fixedBy {s : Set α} {g : G} (s_ss_fixedBy : s ⊆ fixedBy α g) :
     s ∈ fixedBy (Set α) g := by
-  rw [← fixedBy_inv_eq_fixedBy]
+  rw [← fixedBy_inv]
   ext x
   rw [Set.mem_inv_smul_set_iff]
-  constructor
-  · intro gxs
-    rw [← fixedBy_inv_eq_fixedBy] at s_ss_fixedBy
-    rwa [← s_ss_fixedBy gxs, inv_smul_smul] at gxs
-  · intro xs
-    rwa [← s_ss_fixedBy xs] at xs
+  refine ⟨fun gxs => ?xs, fun xs => (s_ss_fixedBy xs).symm ▸ xs⟩
+  rw [← fixedBy_inv] at s_ss_fixedBy
+  rwa [← s_ss_fixedBy gxs, inv_smul_smul] at gxs
 
 theorem smul_subset_of_set_mem_fixedBy {s t : Set α} {g : G} (t_ss_s : t ⊆ s)
     (s_in_fixedBy : s ∈ fixedBy (Set α) g) : g • t ⊆ s := by
   intro x x_in_gt
   rw [Set.mem_smul_set_iff_inv_smul_mem] at x_in_gt
   apply t_ss_s at x_in_gt
-  rw [← fixedBy_inv_eq_fixedBy] at s_in_fixedBy
+  rw [← fixedBy_inv] at s_in_fixedBy
   rwa [← s_in_fixedBy, Set.smul_mem_smul_set_iff] at x_in_gt
 
 /-!
@@ -184,15 +163,14 @@ then no point or subset of `s` can be moved outside of `s` by the group action o
 @[to_additive "If `(fixedBy α g)ᶜ ⊆ s`, then `g` cannot move a point of `s` outside of `s`."]
 theorem set_mem_fixedBy_of_movedBy_subset {s : Set α} {g : G} (s_subset : (fixedBy α g)ᶜ ⊆ s) :
     s ∈ fixedBy (Set α) g := by
-  rw [← fixedBy_inv_eq_fixedBy]
+  rw [← fixedBy_inv]
   ext a
   rw [Set.mem_inv_smul_set_iff]
   by_cases a ∈ fixedBy α g
   case pos a_fixed =>
     rw [a_fixed]
   case neg a_moved =>
-    constructor
-    all_goals (intro; apply s_subset)
+    constructor <;> (intro; apply s_subset)
     · exact a_moved
     · rwa [Set.mem_compl_iff, smul_mem_fixedBy_iff_mem_fixedBy]
 
@@ -262,17 +240,13 @@ then `fixedBy α m = Set.univ` implies that `m = 1`. -/
 @[to_additive "If the additive action of `M` on `α` is faithful,
 then `fixedBy α m = Set.univ` implies that `m = 1`."]
 theorem fixedBy_eq_univ_iff_eq_one {m : M} : fixedBy α m = Set.univ ↔ m = 1 := by
-  constructor
-  · intro moved_empty
-    apply FaithfulSMul.eq_of_smul_eq_smul (α := α)
-    intro a
-    rw [one_smul]
-    by_contra ma_ne_a
-    rw [← mem_fixedBy, moved_empty] at ma_ne_a
-    exact ma_ne_a (Set.mem_univ a)
-  · intro eq_one
-    rw [eq_one]
-    exact fixedBy_one_eq_univ α M
+  refine ⟨fun moved_empty => ?eq_one, fun eq_one => eq_one ▸ fixedBy_one_eq_univ α M⟩
+  apply FaithfulSMul.eq_of_smul_eq_smul (α := α)
+  intro a
+  rw [one_smul]
+  by_contra ma_ne_a
+  rw [← mem_fixedBy, moved_empty] at ma_ne_a
+  exact ma_ne_a (Set.mem_univ a)
 
 /--
 If the image of the `(fixedBy α g)ᶜ` set by the pointwise action of `h: G`

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -147,12 +147,8 @@ theorem set_mem_fixedBy_of_subset_fixedBy {s : Set α} {g : G} (s_ss_fixedBy : s
   rwa [← s_ss_fixedBy gxs, inv_smul_smul] at gxs
 
 theorem smul_subset_of_set_mem_fixedBy {s t : Set α} {g : G} (t_ss_s : t ⊆ s)
-    (s_in_fixedBy : s ∈ fixedBy (Set α) g) : g • t ⊆ s := by
-  intro x x_in_gt
-  rw [Set.mem_smul_set_iff_inv_smul_mem] at x_in_gt
-  apply t_ss_s at x_in_gt
-  rw [← fixedBy_inv] at s_in_fixedBy
-  rwa [← s_in_fixedBy, Set.smul_mem_smul_set_iff] at x_in_gt
+    (s_in_fixedBy : s ∈ fixedBy (Set α) g) : g • t ⊆ s :=
+  (Set.set_smul_subset_set_smul_iff.mpr t_ss_s).trans s_in_fixedBy.subset
 
 /-!
 If a set `s : Set α` is a superset of `(MulAction.fixedBy α g)ᶜ` (resp. `(AddAction.fixedBy α g)ᶜ`),
@@ -202,11 +198,11 @@ theorem fixedBy_mem_fixedBy_of_commute {g h : G} (comm: Commute g h) :
     smul_left_cancel_iff, mem_fixedBy]
 
 /--
-If `g` and `h` commute, then `g` fixes `(h^j) • x` iff `g` fixes `x`.
+If `g` and `h` commute, then `g` fixes `(h ^ j) • x` iff `g` fixes `x`.
 -/
 @[to_additive "If `g` and `h` commute, then `g` fixes `(j • h) +ᵥ x` iff `g` fixes `x`."]
-theorem smul_zpow_fixedBy_eq_of_commute {g h : G} (comm : Commute g h) (j : ℤ):
-    h^j • fixedBy α g = fixedBy α g :=
+theorem smul_zpow_fixedBy_eq_of_commute {g h : G} (comm : Commute g h) (j : ℤ) :
+    h ^ j • fixedBy α g = fixedBy α g :=
   fixedBy_subset_fixedBy_zpow (Set α) h j (fixedBy_mem_fixedBy_of_commute comm)
 
 /--
@@ -217,14 +213,13 @@ This is equivalent to say that the set `(fixedBy α g)ᶜ` is fixed by `h`.
 This is equivalent to say that the set `(fixedBy α g)ᶜ` is fixed by `h`."]
 theorem movedBy_mem_fixedBy_of_commute {g h : G} (comm: Commute g h) :
     (fixedBy α g)ᶜ ∈ fixedBy (Set α) h := by
-  rw [mem_fixedBy, Set.compl_eq_univ_diff, Set.smul_set_sdiff,
-    Set.smul_set_univ, fixedBy_mem_fixedBy_of_commute comm]
+  rw [mem_fixedBy, Set.smul_set_compl, fixedBy_mem_fixedBy_of_commute comm]
 
 /--
-If `g` and `h` commute, then `g` moves `h^j • x` iff `g` moves `x`.
+If `g` and `h` commute, then `g` moves `h ^ j • x` iff `g` moves `x`.
 -/
 @[to_additive "If `g` and `h` commute, then `g` moves `(j • h) +ᵥ x` iff `g` moves `x`."]
-theorem smul_zpow_movedBy_eq_of_commute {g h : G} (comm : Commute g h) (j : ℤ):
+theorem smul_zpow_movedBy_eq_of_commute {g h : G} (comm : Commute g h) (j : ℤ) :
     h ^ j • (fixedBy α g)ᶜ = (fixedBy α g)ᶜ :=
   fixedBy_subset_fixedBy_zpow (Set α) h j (movedBy_mem_fixedBy_of_commute comm)
 
@@ -240,13 +235,8 @@ then `fixedBy α m = Set.univ` implies that `m = 1`. -/
 @[to_additive "If the additive action of `M` on `α` is faithful,
 then `fixedBy α m = Set.univ` implies that `m = 1`."]
 theorem fixedBy_eq_univ_iff_eq_one {m : M} : fixedBy α m = Set.univ ↔ m = 1 := by
-  refine ⟨fun moved_empty => ?eq_one, fun eq_one => eq_one ▸ fixedBy_one_eq_univ α M⟩
-  apply FaithfulSMul.eq_of_smul_eq_smul (α := α)
-  intro a
-  rw [one_smul]
-  by_contra ma_ne_a
-  rw [← mem_fixedBy, moved_empty] at ma_ne_a
-  exact ma_ne_a (Set.mem_univ a)
+  rw [← (smul_left_injective' (M := M) (α := α)).eq_iff, Set.eq_univ_iff_forall]
+  simp_rw [Function.funext_iff, one_smul, mem_fixedBy]
 
 /--
 If the image of the `(fixedBy α g)ᶜ` set by the pointwise action of `h: G`
@@ -256,10 +246,9 @@ is disjoint from `(fixedBy α g)ᶜ`, then `g` and `h` cannot commute.
 is disjoint from `(fixedBy α g)ᶜ`, then `g` and `h` cannot commute."]
 theorem not_commute_of_disjoint_movedBy_preimage {g h : G} (ne_one : g ≠ 1)
     (disjoint : Disjoint (fixedBy α g)ᶜ (h • (fixedBy α g)ᶜ)) : ¬Commute g h := by
-  intro comm
-  rw [movedBy_mem_fixedBy_of_commute comm, disjoint_self, Set.bot_eq_empty, ← Set.compl_univ,
+  contrapose! ne_one with comm
+  rwa [movedBy_mem_fixedBy_of_commute comm, disjoint_self, Set.bot_eq_empty, ← Set.compl_univ,
     compl_inj_iff, fixedBy_eq_univ_iff_eq_one] at disjoint
-  exact ne_one disjoint
 
 end Faithful
 

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -131,8 +131,9 @@ theorem mem_fixingSubgroup_iff_subset_fixedBy {s : Set α} {m : M} :
   simp only [mem_fixedBy]
 
 theorem mem_fixingSubgroup_compl_iff_movedBy_subset {s : Set α} {m : M} :
-    m ∈ fixingSubgroup M sᶜ ↔ movedBy α m ⊆ s := by
-  rw [mem_fixingSubgroup_iff_subset_fixedBy, fixedBy_eq_compl_movedBy, Set.compl_subset_compl]
+    m ∈ fixingSubgroup M sᶜ ↔ (fixedBy α m)ᶜ ⊆ s := by
+  rw [mem_fixingSubgroup_iff_subset_fixedBy]
+  exact Set.compl_subset_comm
 
 variable (α)
 
@@ -182,6 +183,6 @@ theorem orbit_fixingSubgroup_compl_subset {s : Set α}
   let ⟨⟨g, g_fixing⟩, g_eq⟩ := MulAction.mem_orbit_iff.mp b_in_orbit
   rw [Submonoid.mk_smul] at g_eq
   rw [mem_fixingSubgroup_compl_iff_movedBy_subset] at g_fixing
-  rwa [← g_eq, smul_mem_of_movedBy_subset g_fixing]
+  rwa [← g_eq, ← smul_mem_of_set_mem_fixedBy (set_mem_fixedBy_of_movedBy_subset g_fixing)]
 
 end Group

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -5,6 +5,7 @@ Authors: Antoine Chambert-Loir
 -/
 import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.GroupTheory.GroupAction.FixedPoints
 
 #align_import group_theory.group_action.fixing_subgroup from "leanprover-community/mathlib"@"f93c11933efbc3c2f0299e47b8ff83e9b539cbf6"
 
@@ -35,6 +36,10 @@ TODO :
 * Maybe other lemmas are useful
 
 * Treat semigroups ?
+
+* add `to_additive` for the various lemmas
+
+* `movingSubgroup`
 
 -/
 
@@ -120,6 +125,15 @@ theorem mem_fixingSubgroup_iff {s : Set α} {m : M} : m ∈ fixingSubgroup M s �
   ⟨fun hg y hy => hg ⟨y, hy⟩, fun h ⟨y, hy⟩ => h y hy⟩
 #align mem_fixing_subgroup_iff mem_fixingSubgroup_iff
 
+theorem mem_fixingSubgroup_iff_subset_fixedBy {s : Set α} {m : M} :
+    m ∈ fixingSubgroup M s ↔ s ⊆ fixedBy α m := by
+  rw [mem_fixingSubgroup_iff, Set.subset_def]
+  simp only [mem_fixedBy]
+
+theorem mem_fixingSubgroup_compl_iff_movedBy_subset {s : Set α} {m : M} :
+    m ∈ fixingSubgroup M sᶜ ↔ movedBy α m ⊆ s := by
+  rw [mem_fixingSubgroup_iff_subset_fixedBy, fixedBy_eq_compl_movedBy, Set.compl_subset_compl]
+
 variable (α)
 
 /-- The Galois connection between fixing subgroups and fixed points of a group action -/
@@ -160,5 +174,14 @@ theorem fixedPoints_subgroup_iSup {ι : Sort*} {P : ι → Subgroup M} :
     fixedPoints (↥(iSup P)) α = ⋂ i, fixedPoints (P i) α :=
   (fixingSubgroup_fixedPoints_gc M α).u_iInf
 #align fixed_points_subgroup_supr fixedPoints_subgroup_iSup
+
+/-- The orbit of the moving subgroup of `s` is a subset of `s` -/
+theorem orbit_fixingSubgroup_compl_subset {s : Set α}
+    {a : α} (a_in_s : a ∈ s) : MulAction.orbit (fixingSubgroup M sᶜ) a ⊆ s := by
+  intro b b_in_orbit
+  let ⟨⟨g, g_fixing⟩, g_eq⟩ := MulAction.mem_orbit_iff.mp b_in_orbit
+  rw [Submonoid.mk_smul] at g_eq
+  rw [mem_fixingSubgroup_compl_iff_movedBy_subset] at g_fixing
+  rwa [<-g_eq, smul_in_set_of_movedBy_subset g_fixing]
 
 end Group

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -182,6 +182,6 @@ theorem orbit_fixingSubgroup_compl_subset {s : Set α}
   let ⟨⟨g, g_fixing⟩, g_eq⟩ := MulAction.mem_orbit_iff.mp b_in_orbit
   rw [Submonoid.mk_smul] at g_eq
   rw [mem_fixingSubgroup_compl_iff_movedBy_subset] at g_fixing
-  rwa [<-g_eq, smul_mem_of_movedBy_subset g_fixing]
+  rwa [← g_eq, smul_mem_of_movedBy_subset g_fixing]
 
 end Group

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -175,13 +175,13 @@ theorem fixedPoints_subgroup_iSup {ι : Sort*} {P : ι → Subgroup M} :
   (fixingSubgroup_fixedPoints_gc M α).u_iInf
 #align fixed_points_subgroup_supr fixedPoints_subgroup_iSup
 
-/-- The orbit of the moving subgroup of `s` is a subset of `s` -/
+/-- The orbit of the fixing subgroup of `sᶜ` (ie. the moving subgroup of `s`) is a subset of `s` -/
 theorem orbit_fixingSubgroup_compl_subset {s : Set α}
     {a : α} (a_in_s : a ∈ s) : MulAction.orbit (fixingSubgroup M sᶜ) a ⊆ s := by
   intro b b_in_orbit
   let ⟨⟨g, g_fixing⟩, g_eq⟩ := MulAction.mem_orbit_iff.mp b_in_orbit
   rw [Submonoid.mk_smul] at g_eq
   rw [mem_fixingSubgroup_compl_iff_movedBy_subset] at g_fixing
-  rwa [<-g_eq, smul_in_set_of_movedBy_subset g_fixing]
+  rwa [<-g_eq, smul_mem_of_movedBy_subset g_fixing]
 
 end Group

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -183,6 +183,6 @@ theorem orbit_fixingSubgroup_compl_subset {s : Set α}
   let ⟨⟨g, g_fixing⟩, g_eq⟩ := MulAction.mem_orbit_iff.mp b_in_orbit
   rw [Submonoid.mk_smul] at g_eq
   rw [mem_fixingSubgroup_compl_iff_movedBy_subset] at g_fixing
-  rwa [← g_eq, ← smul_mem_of_set_mem_fixedBy (set_mem_fixedBy_of_movedBy_subset g_fixing)]
+  rwa [← g_eq, smul_mem_of_set_mem_fixedBy (set_mem_fixedBy_of_movedBy_subset g_fixing)]
 
 end Group

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -125,13 +125,11 @@ theorem mem_fixingSubgroup_iff {s : Set α} {m : M} : m ∈ fixingSubgroup M s �
 
 theorem mem_fixingSubgroup_iff_subset_fixedBy {s : Set α} {m : M} :
     m ∈ fixingSubgroup M s ↔ s ⊆ fixedBy α m := by
-  rw [mem_fixingSubgroup_iff, Set.subset_def]
-  simp only [mem_fixedBy]
+  simp_rw [mem_fixingSubgroup_iff, Set.subset_def, mem_fixedBy]
 
 theorem mem_fixingSubgroup_compl_iff_movedBy_subset {s : Set α} {m : M} :
     m ∈ fixingSubgroup M sᶜ ↔ (fixedBy α m)ᶜ ⊆ s := by
-  rw [mem_fixingSubgroup_iff_subset_fixedBy]
-  exact Set.compl_subset_comm
+  rw [mem_fixingSubgroup_iff_subset_fixedBy, Set.compl_subset_comm]
 
 variable (α)
 
@@ -175,8 +173,8 @@ theorem fixedPoints_subgroup_iSup {ι : Sort*} {P : ι → Subgroup M} :
 #align fixed_points_subgroup_supr fixedPoints_subgroup_iSup
 
 /-- The orbit of the fixing subgroup of `sᶜ` (ie. the moving subgroup of `s`) is a subset of `s` -/
-theorem orbit_fixingSubgroup_compl_subset {s : Set α}
-    {a : α} (a_in_s : a ∈ s) : MulAction.orbit (fixingSubgroup M sᶜ) a ⊆ s := by
+theorem orbit_fixingSubgroup_compl_subset {s : Set α} {a : α} (a_in_s : a ∈ s) :
+    MulAction.orbit (fixingSubgroup M sᶜ) a ⊆ s := by
   intro b b_in_orbit
   let ⟨⟨g, g_fixing⟩, g_eq⟩ := MulAction.mem_orbit_iff.mp b_in_orbit
   rw [Submonoid.mk_smul] at g_eq

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -39,8 +39,6 @@ TODO :
 
 * add `to_additive` for the various lemmas
 
-* `movingSubgroup`
-
 -/
 
 


### PR DESCRIPTION
Introduces a new module, `Mathlib.GroupTheory.GroupAction.FixedPoints`,
which contains some properties of `MulAction.fixedBy` that wouldn't quite belong to `Mathlib.GroupTheory.GroupAction.Basic`.

---

This is my first contribution ever to Mathlib, and the first contribution in a series of contributions to eventually merge [my formalization of Rubin's theorem](https://github.com/adri326/rubin-lean4/) into Lean.

I have a few questions around the design decisions that I took:

- ~~should `movedBy` be defined in `Mathlib.GroupTheory.GroupAction.Basic` instead?~~
- `Mathlib.GroupTheory.GroupAction.FixingSubgroup` uses `M` for a group, would it be out-of-scope for this PR to also replace it with `G`?
- should I try to further minimize the usage of tactic groups?
- I'm trying to translate the properties that I will need later for the formalization of Rubin's theorem, so I wonder if `not_commute_of_disjoint_movedBy_preimage` might be too out-of-scope

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
