### PR TITLE
refactor(CategoryTheory/Monoidal): add `LaxMonoidalStruct`

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
@@ -196,7 +196,7 @@ instance : LaxMonoidal.{u} (free R).obj where
   right_unitality := right_unitality R
   associativity := associativity R
 
-instance : IsIso (@LaxMonoidal.ε _ _ _ _ _ _ (free R).obj _ _) := by
+instance : IsIso (@LaxMonoidalStruct.ε _ _ _ _ _ _ (free R).obj _ _) := by
   refine' ⟨⟨Finsupp.lapply PUnit.unit, ⟨_, _⟩⟩⟩
   · -- Porting note: broken ext
     apply LinearMap.ext_ring
@@ -225,7 +225,7 @@ variable [CommRing R]
 def monoidalFree : MonoidalFunctor (Type u) (ModuleCat.{u} R) :=
   { LaxMonoidalFunctor.of (free R).obj with
     -- Porting note: used to be dsimp
-    ε_isIso := (by infer_instance : IsIso (@LaxMonoidal.ε _ _ _ _ _ _ (free R).obj _ _))
+    ε_isIso := (by infer_instance : IsIso (@LaxMonoidalStruct.ε _ _ _ _ _ _ (free R).obj _ _))
     μ_isIso := fun X Y => by dsimp; infer_instance }
 #align Module.monoidal_free ModuleCat.monoidalFree
 

--- a/Mathlib/CategoryTheory/Monoidal/Functorial.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functorial.lean
@@ -44,17 +44,28 @@ namespace CategoryTheory
 
 open MonoidalCategory
 
+section
+
+variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategoryStruct.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+  [MonoidalCategoryStruct.{v₂} D]
+
+/-- An unbundled description of lax monoidal functors without axioms. See `LaxMonoidal` for
+the full description. -/
+class LaxMonoidalStruct (F : C → D) [Functorial.{v₁, v₂} F] where
+  /-- unit morphism -/
+  ε : 𝟙_ D ⟶ F (𝟙_ C)
+  /-- tensorator -/
+  μ : ∀ X Y : C, F X ⊗ F Y ⟶ F (X ⊗ Y)
+
+end
+
 variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategory.{v₁} C] {D : Type u₂} [Category.{v₂} D]
   [MonoidalCategory.{v₂} D]
 
 -- Perhaps in the future we'll redefine `LaxMonoidalFunctor` in terms of this,
 -- but that isn't the immediate plan.
 /-- An unbundled description of lax monoidal functors. -/
-class LaxMonoidal (F : C → D) [Functorial.{v₁, v₂} F] where
-  /-- unit morphism -/
-  ε : 𝟙_ D ⟶ F (𝟙_ C)
-  /-- tensorator -/
-  μ : ∀ X Y : C, F X ⊗ F Y ⟶ F (X ⊗ Y)
+class LaxMonoidal (F : C → D) [Functorial.{v₁, v₂} F] extends LaxMonoidalStruct F where
   /-- naturality -/
   μ_natural :
     ∀ {X Y X' Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y'),

--- a/Mathlib/CategoryTheory/Monoidal/Functorial.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functorial.lean
@@ -46,8 +46,8 @@ open MonoidalCategory
 
 section
 
-variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategoryStruct.{v₁} C] {D : Type u₂} [Category.{v₂} D]
-  [MonoidalCategoryStruct.{v₂} D]
+variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategoryStruct.{v₁} C]
+  {D : Type u₂} [Category.{v₂} D] [MonoidalCategoryStruct.{v₂} D]
 
 /-- An unbundled description of lax monoidal functors without axioms. See `LaxMonoidal` for
 the full description. -/

--- a/Mathlib/CategoryTheory/Monoidal/Limits.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Limits.lean
@@ -47,7 +47,7 @@ theorem limitFunctorial_map {F G : J ⥤ C} (α : F ⟶ G) :
 variable [MonoidalCategory.{v} C]
 
 @[simps]
-instance limitLaxMonoidal : LaxMonoidal fun F : J ⥤ C => limit F where
+instance limitLaxMonoidalStruct : LaxMonoidalStruct fun F : J ⥤ C => limit F where
   ε :=
     limit.lift _
       { pt := _
@@ -60,6 +60,8 @@ instance limitLaxMonoidal : LaxMonoidal fun F : J ⥤ C => limit F where
             naturality := fun j j' f => by
               dsimp
               simp only [Category.id_comp, ← tensor_comp, limit.w] } }
+
+instance limitLaxMonoidal : LaxMonoidal fun F : J ⥤ C => limit F where
   μ_natural f g := by
     ext; dsimp
     simp only [limit.lift_π, Cones.postcompose_obj_π, Monoidal.tensorHom_app, limit.lift_map,


### PR DESCRIPTION
Add a `LaxMonoidalStruct` with only the unit morphism `ε` and the tensorator `μ`. This is used in #6307 to provide two different constructors for `LaxMonoidal` that have common `ε` and `μ` but use the tensor of morphisms or the whiskerings.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
