### PR TITLE
[Merged by Bors] - feat(Algebra/InfiniteSum/Module): smul of two infinite sums

### DIFF
--- a/Mathlib/Topology/Algebra/InfiniteSum/Module.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Module.lean
@@ -32,6 +32,10 @@ theorem tsum_smul_const [T2Space M] (hf : Summable f) (a : M) : ∑' z, f z • 
 
 end SMulConst
 
+/-!
+Note we cannot derive the `mul` lemmas from these `smul` lemmas, as the `mul` versions do not
+require associativity, but `Module` does.
+-/
 section tsum_smul_tsum
 
 variable [Semiring R] [AddCommMonoid M] [Module R M]

--- a/Mathlib/Topology/Algebra/InfiniteSum/Module.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Module.lean
@@ -11,7 +11,7 @@ import Mathlib.Topology.Algebra.Module.Basic
 /-! # Infinite sums in topological vector spaces -/
 
 
-variable {ι R R₂ M M₂ : Type*}
+variable {ι κ R R₂ M M₂ : Type*}
 
 section SMulConst
 
@@ -31,6 +31,34 @@ theorem tsum_smul_const [T2Space M] (hf : Summable f) (a : M) : ∑' z, f z • 
 #align tsum_smul_const tsum_smul_const
 
 end SMulConst
+
+section tsum_smul_tsum
+
+variable [Semiring R] [AddCommMonoid M] [Module R M]
+variable [TopologicalSpace R] [TopologicalSpace M] [T3Space M]
+variable [ContinuousAdd M] [ContinuousSMul R M]
+variable {f : ι → R} {g : κ → M} {s : R} {t u : M}
+
+theorem HasSum.smul_eq (hf : HasSum f s) (hg : HasSum g t)
+    (hfg : HasSum (fun x : ι × κ => f x.1 • g x.2) u) : s • t = u :=
+  have key₁ : HasSum (fun i => f i • t) (s • t) := hf.smul_const t
+  have this : ∀ i : ι, HasSum (fun c : κ => f i • g c) (f i • t) := fun i => hg.const_smul (f i)
+  have key₂ : HasSum (fun i => f i • t) u := HasSum.prod_fiberwise hfg this
+  key₁.unique key₂
+
+theorem HasSum.smul (hf : HasSum f s) (hg : HasSum g t)
+    (hfg : Summable fun x : ι × κ => f x.1 • g x.2) :
+    HasSum (fun x : ι × κ => f x.1 • g x.2) (s • t) :=
+  let ⟨_u, hu⟩ := hfg
+  (hf.smul_eq hg hu).symm ▸ hu
+
+/-- Scalar product of two infinites sums indexed by arbitrary types. -/
+theorem tsum_smul_tsum (hf : Summable f) (hg : Summable g)
+    (hfg : Summable fun x : ι × κ => f x.1 • g x.2) :
+    ((∑' x, f x) • ∑' y, g y) = ∑' z : ι × κ, f z.1 • g z.2 :=
+  hf.hasSum.smul_eq hg.hasSum hfg.hasSum
+
+end tsum_smul_tsum
 
 section HasSum
 


### PR DESCRIPTION
These proofs and statements are copied from the `mul` proofs.
We can't prove the `mul` lemmas in terms of `smul` since `Module` doesn't work for non-associative rings.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
