### PR TITLE
[Merged by Bors] - feat(GroupTheory/GroupAction): define MulAction.period and create GroupTheory/GroupAction/Period

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2284,6 +2284,7 @@ import Mathlib.GroupTheory.GroupAction.Group
 import Mathlib.GroupTheory.GroupAction.Hom
 import Mathlib.GroupTheory.GroupAction.Opposite
 import Mathlib.GroupTheory.GroupAction.Option
+import Mathlib.GroupTheory.GroupAction.Period
 import Mathlib.GroupTheory.GroupAction.Pi
 import Mathlib.GroupTheory.GroupAction.Prod
 import Mathlib.GroupTheory.GroupAction.Quotient

--- a/Mathlib/Algebra/GroupPower/IterateHom.lean
+++ b/Mathlib/Algebra/GroupPower/IterateHom.lean
@@ -174,6 +174,10 @@ theorem smul_iterate [MulAction G H] : (a • · : H → H)^[n] = (a ^ n • ·)
 #align smul_iterate smul_iterate
 #align vadd_iterate vadd_iterate
 
+@[to_additive]
+lemma smul_iterate_apply [MulAction G H] {b : H} : (a • ·)^[n] b = a ^ n • b := by
+  rw [smul_iterate]
+
 @[to_additive (attr := simp)]
 theorem mul_left_iterate : (a * ·)^[n] = (a ^ n * ·) :=
   smul_iterate a n

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -674,7 +674,7 @@ theorem pow_smul_eq_iff_period_dvd {n : ℕ} {m : M} {a : α}:
     m ^ n • a = a ↔ period m a ∣ n := by
   rw [
     period_eq_minimalPeriod,
-    <-Function.isPeriodicPt_iff_minimalPeriod_dvd,
+    ← Function.isPeriodicPt_iff_minimalPeriod_dvd,
     fixed_iff_isPeriodicPt
   ]
 
@@ -704,14 +704,14 @@ theorem zpow_smul_plus_period (i j : ℤ) (g : G) (a : α):
 theorem pow_smul_mod_period (n : ℕ) {m : M} {a : α}:
     m ^ (n % period m a) • a = m ^ n • a := by
   conv_rhs => {
-    rw [<-Nat.mod_add_div n (period m a), pow_smul_plus_period]
+    rw [← Nat.mod_add_div n (period m a), pow_smul_plus_period]
   }
 
 @[to_additive (attr := simp)]
 theorem zpow_smul_mod_period (j : ℤ) {g : G} {a : α}:
     g ^ (j % (period g a : ℤ)) • a = g ^ j • a := by
   conv_rhs => {
-    rw [<-Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
+    rw [← Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
   }
 
 variable {a : G} {b : α}
@@ -719,14 +719,14 @@ variable {a : G} {b : α}
 @[to_additive]
 theorem pow_smul_eq_iff_minimalPeriod_dvd {n : ℕ} :
     a ^ n • b = b ↔ Function.minimalPeriod (a • ·) b ∣ n := by
-  rw [<-period_eq_minimalPeriod, pow_smul_eq_iff_period_dvd]
+  rw [← period_eq_minimalPeriod, pow_smul_eq_iff_period_dvd]
 #align mul_action.pow_smul_eq_iff_minimal_period_dvd MulAction.pow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.nsmul_vadd_eq_iff_minimal_period_dvd AddAction.nsmul_vadd_eq_iff_minimalPeriod_dvd
 
 @[to_additive]
 theorem zpow_smul_eq_iff_minimalPeriod_dvd {n : ℤ} :
     a ^ n • b = b ↔ (Function.minimalPeriod (a • ·) b : ℤ) ∣ n := by
-  rw [<-period_eq_minimalPeriod, zpow_smul_eq_iff_period_dvd]
+  rw [← period_eq_minimalPeriod, zpow_smul_eq_iff_period_dvd]
 #align mul_action.zpow_smul_eq_iff_minimal_period_dvd MulAction.zpow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.zsmul_vadd_eq_iff_minimal_period_dvd AddAction.zsmul_vadd_eq_iff_minimalPeriod_dvd
 
@@ -735,14 +735,14 @@ variable (a b)
 @[to_additive (attr := simp)]
 theorem pow_smul_mod_minimalPeriod (n : ℕ) :
     a ^ (n % Function.minimalPeriod (a • ·) b) • b = a ^ n • b := by
-  rw [<-period_eq_minimalPeriod, pow_smul_mod_period]
+  rw [← period_eq_minimalPeriod, pow_smul_mod_period]
 #align mul_action.pow_smul_mod_minimal_period MulAction.pow_smul_mod_minimalPeriod
 #align add_action.nsmul_vadd_mod_minimal_period AddAction.nsmul_vadd_mod_minimalPeriod
 
 @[to_additive (attr := simp)]
 theorem zpow_smul_mod_minimalPeriod (n : ℤ) :
     a ^ (n % (Function.minimalPeriod (a • ·) b : ℤ)) • b = a ^ n • b := by
-  rw [<-period_eq_minimalPeriod, zpow_smul_mod_period]
+  rw [← period_eq_minimalPeriod, zpow_smul_mod_period]
 #align mul_action.zpow_smul_mod_minimal_period MulAction.zpow_smul_mod_minimalPeriod
 #align add_action.zsmul_vadd_mod_minimal_period AddAction.zsmul_vadd_mod_minimalPeriod
 

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -27,7 +27,8 @@ A point `x : α` is a periodic point of `f : α → α` of period `n` if `f^[n] 
 * `minimalPeriod f x` : the minimal period of a point `x` under an endomorphism `f` or zero
   if `x` is not a periodic point of `f`.
 * `orbit f x`: the cycle `[x, f x, f (f x), ...]` for a periodic point.
-* `MulAction.period g x` : the minimal period of a point `x` under the multiplicative action of `g`.
+* `MulAction.period g x` : the minimal period of a point `x` under the multiplicative action of `g`;
+  an equivalent `AddAction.period g x` is defined for additive actions.
 
 ## Main statements
 
@@ -638,7 +639,8 @@ variable {M : Type u} [Monoid M] [MulAction M α]
 The period of a multiplicative action of `g` on `a` is the smallest `n` such that `g ^ n • a = a`,
 or `0` if such an `n` does not exist.
 -/
-@[to_additive "The period of an additive action of `g` on `a` is the smallest `n` such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
+@[to_additive "The period of an additive action of `g` on `a` is the smallest `n`
+such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
 noncomputable def period (m : M) (a : α) : ℕ := Function.minimalPeriod (fun x => m • x) a
 
 /-- `MulAction.period m a` is definitionally equal to `Function.minimalPeriod (m • ·) a`. -/

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -27,6 +27,7 @@ A point `x : α` is a periodic point of `f : α → α` of period `n` if `f^[n] 
 * `minimalPeriod f x` : the minimal period of a point `x` under an endomorphism `f` or zero
   if `x` is not a periodic point of `f`.
 * `orbit f x`: the cycle `[x, f x, f (f x), ...]` for a periodic point.
+* `MulAction.period g x` : the minimal period of a point `x` under the multiplicative action of `g`.
 
 ## Main statements
 
@@ -628,22 +629,104 @@ namespace MulAction
 
 open Function
 
-variable {α β : Type*} [Group α] [MulAction α β] {a : α} {b : β}
+universe u v
+variable {α : Type v}
+variable {G : Type u} [Group G] [MulAction G α]
+variable {M : Type u} [Monoid M] [MulAction M α]
+
+/--
+The period of a multiplicative action of `g` on `a` is the smallest `n` such that `g ^ n • a = a`,
+or `0` if such an `n` does not exist.
+-/
+@[to_additive "The period of an additive action of `g` on `a` is the smallest `n` such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
+noncomputable def period (m : M) (a : α) : ℕ := Function.minimalPeriod (fun x => m • x) a
+
+/-- `MulAction.period m a` is definitionally equal to `Function.minimalPeriod (m • ·) a`. -/
+@[to_additive]
+theorem period_eq_minimalPeriod {m : M} {a : α} :
+    MulAction.period m a = Function.minimalPeriod (fun x => m • x) a := rfl
+
+@[to_additive]
+lemma smul_pow_eq_function_pow (m : M) (a : α) (n : ℕ): m ^ n • a = (fun x => m • x)^[n] a := by
+  rw [smul_iterate]
+
+/-- `m ^ (period m a)` fixes `a` -/
+@[to_additive (attr := simp) "`(period m a) • m` fixes `a`"]
+theorem smul_pow_period_fixed (m : M) (a : α) : m ^ (period m a) • a = a := by
+  rw [period_eq_minimalPeriod, smul_pow_eq_function_pow, Function.iterate_minimalPeriod]
+
+@[to_additive]
+lemma fixed_iff_isPeriodicPt {m : M} {a : α} {n : ℕ} :
+    m ^ n • a = a ↔ Function.IsPeriodicPt (fun x => m • x) n a := by
+  rw [smul_pow_eq_function_pow]
+  rfl
+
+/-! ### Multiples of `MulAction.period`
+
+It is easy to convince onself that if `g ^ n • a = a` (resp. `(n • g) +ᵥ a = a`),
+then `n` must be a multiple of `period g a`.
+
+This also holds for negative powers/multiples.
+-/
+
+@[to_additive]
+theorem pow_smul_eq_iff_period_dvd {n : ℕ} {m : M} {a : α}:
+    m ^ n • a = a ↔ period m a ∣ n := by
+  rw [
+    period_eq_minimalPeriod,
+    <-Function.isPeriodicPt_iff_minimalPeriod_dvd,
+    fixed_iff_isPeriodicPt
+  ]
+
+@[to_additive]
+theorem zpow_smul_eq_iff_period_dvd {j : ℤ} {g : G} {a : α}:
+    g ^ j • a = a ↔ (period g a : ℤ) ∣ j := by
+  rcases j with n | n
+  · rw [Int.ofNat_eq_coe, zpow_ofNat, Int.coe_nat_dvd, pow_smul_eq_iff_period_dvd]
+  · rw [
+      Int.negSucc_coe, zpow_neg, zpow_ofNat,
+      inv_smul_eq_iff, eq_comm,
+      dvd_neg, Int.coe_nat_dvd,
+      pow_smul_eq_iff_period_dvd
+    ]
+
+@[to_additive (attr := simp)]
+theorem pow_smul_plus_period (n o : ℕ) (m : M) (a : α):
+    m ^ (n + (period m a) * o) • a = m ^ n • a := by
+  rw [pow_add, mul_smul, pow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
+
+@[to_additive (attr := simp)]
+theorem zpow_smul_plus_period (i j : ℤ) (g : G) (a : α):
+    g ^ (i + (period g a : ℤ) * j) • a = g ^ i • a := by
+  rw [zpow_add, mul_smul, zpow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
+
+@[to_additive (attr := simp)]
+theorem pow_smul_mod_period (n : ℕ) {m : M} {a : α}:
+    m ^ (n % period m a) • a = m ^ n • a := by
+  conv_rhs => {
+    rw [<-Nat.mod_add_div n (period m a), pow_smul_plus_period]
+  }
+
+@[to_additive (attr := simp)]
+theorem zpow_smul_mod_period (j : ℤ) {g : G} {a : α}:
+    g ^ (j % (period g a : ℤ)) • a = g ^ j • a := by
+  conv_rhs => {
+    rw [<-Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
+  }
+
+variable {a : G} {b : α}
 
 @[to_additive]
 theorem pow_smul_eq_iff_minimalPeriod_dvd {n : ℕ} :
     a ^ n • b = b ↔ Function.minimalPeriod (a • ·) b ∣ n := by
-  rw [← isPeriodicPt_iff_minimalPeriod_dvd, IsPeriodicPt, IsFixedPt, smul_iterate]
+  rw [<-period_eq_minimalPeriod, pow_smul_eq_iff_period_dvd]
 #align mul_action.pow_smul_eq_iff_minimal_period_dvd MulAction.pow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.nsmul_vadd_eq_iff_minimal_period_dvd AddAction.nsmul_vadd_eq_iff_minimalPeriod_dvd
 
 @[to_additive]
 theorem zpow_smul_eq_iff_minimalPeriod_dvd {n : ℤ} :
     a ^ n • b = b ↔ (Function.minimalPeriod (a • ·) b : ℤ) ∣ n := by
-  cases n
-  · rw [Int.ofNat_eq_coe, zpow_ofNat, Int.coe_nat_dvd, pow_smul_eq_iff_minimalPeriod_dvd]
-  · rw [Int.negSucc_coe, zpow_neg, zpow_ofNat, inv_smul_eq_iff, eq_comm, dvd_neg, Int.coe_nat_dvd,
-      pow_smul_eq_iff_minimalPeriod_dvd]
+  rw [<-period_eq_minimalPeriod, zpow_smul_eq_iff_period_dvd]
 #align mul_action.zpow_smul_eq_iff_minimal_period_dvd MulAction.zpow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.zsmul_vadd_eq_iff_minimal_period_dvd AddAction.zsmul_vadd_eq_iff_minimalPeriod_dvd
 
@@ -652,18 +735,14 @@ variable (a b)
 @[to_additive (attr := simp)]
 theorem pow_smul_mod_minimalPeriod (n : ℕ) :
     a ^ (n % Function.minimalPeriod (a • ·) b) • b = a ^ n • b := by
-  conv_rhs =>
-    rw [← Nat.mod_add_div n (minimalPeriod (a • ·) b), pow_add, mul_smul,
-      pow_smul_eq_iff_minimalPeriod_dvd.mpr (dvd_mul_right _ _)]
+  rw [<-period_eq_minimalPeriod, pow_smul_mod_period]
 #align mul_action.pow_smul_mod_minimal_period MulAction.pow_smul_mod_minimalPeriod
 #align add_action.nsmul_vadd_mod_minimal_period AddAction.nsmul_vadd_mod_minimalPeriod
 
 @[to_additive (attr := simp)]
 theorem zpow_smul_mod_minimalPeriod (n : ℤ) :
     a ^ (n % (Function.minimalPeriod (a • ·) b : ℤ)) • b = a ^ n • b := by
-  conv_rhs =>
-    rw [← Int.emod_add_ediv n (minimalPeriod ((a • ·)) b), zpow_add, mul_smul,
-      zpow_smul_eq_iff_minimalPeriod_dvd.mpr (dvd_mul_right _ _)]
+  rw [<-period_eq_minimalPeriod, zpow_smul_mod_period]
 #align mul_action.zpow_smul_mod_minimal_period MulAction.zpow_smul_mod_minimalPeriod
 #align add_action.zsmul_vadd_mod_minimal_period AddAction.zsmul_vadd_mod_minimalPeriod
 

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -641,12 +641,12 @@ or `0` if such an `n` does not exist.
 -/
 @[to_additive "The period of an additive action of `g` on `a` is the smallest `n`
 such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
-noncomputable def period (m : M) (a : α) : ℕ := Function.minimalPeriod (fun x => m • x) a
+noncomputable def period (m : M) (a : α) : ℕ := minimalPeriod (fun x => m • x) a
 
 /-- `MulAction.period m a` is definitionally equal to `Function.minimalPeriod (m • ·) a`. -/
 @[to_additive]
 theorem period_eq_minimalPeriod {m : M} {a : α} :
-    MulAction.period m a = Function.minimalPeriod (fun x => m • x) a := rfl
+    MulAction.period m a = minimalPeriod (fun x => m • x) a := rfl
 
 @[to_additive]
 lemma smul_pow_eq_function_pow (m : M) (a : α) (n : ℕ): m ^ n • a = (fun x => m • x)^[n] a := by
@@ -655,11 +655,11 @@ lemma smul_pow_eq_function_pow (m : M) (a : α) (n : ℕ): m ^ n • a = (fun x 
 /-- `m ^ (period m a)` fixes `a` -/
 @[to_additive (attr := simp) "`(period m a) • m` fixes `a`"]
 theorem smul_pow_period_fixed (m : M) (a : α) : m ^ (period m a) • a = a := by
-  rw [period_eq_minimalPeriod, smul_pow_eq_function_pow, Function.iterate_minimalPeriod]
+  rw [period_eq_minimalPeriod, smul_pow_eq_function_pow, iterate_minimalPeriod]
 
 @[to_additive]
 lemma fixed_iff_isPeriodicPt {m : M} {a : α} {n : ℕ} :
-    m ^ n • a = a ↔ Function.IsPeriodicPt (fun x => m • x) n a := by
+    m ^ n • a = a ↔ IsPeriodicPt (fun x => m • x) n a := by
   rw [smul_pow_eq_function_pow]
   rfl
 
@@ -674,23 +674,15 @@ This also holds for negative powers/multiples.
 @[to_additive]
 theorem pow_smul_eq_iff_period_dvd {n : ℕ} {m : M} {a : α}:
     m ^ n • a = a ↔ period m a ∣ n := by
-  rw [
-    period_eq_minimalPeriod,
-    ← Function.isPeriodicPt_iff_minimalPeriod_dvd,
-    fixed_iff_isPeriodicPt
-  ]
+  rw [period_eq_minimalPeriod, ← isPeriodicPt_iff_minimalPeriod_dvd, fixed_iff_isPeriodicPt]
 
 @[to_additive]
 theorem zpow_smul_eq_iff_period_dvd {j : ℤ} {g : G} {a : α}:
     g ^ j • a = a ↔ (period g a : ℤ) ∣ j := by
   rcases j with n | n
   · rw [Int.ofNat_eq_coe, zpow_ofNat, Int.coe_nat_dvd, pow_smul_eq_iff_period_dvd]
-  · rw [
-      Int.negSucc_coe, zpow_neg, zpow_ofNat,
-      inv_smul_eq_iff, eq_comm,
-      dvd_neg, Int.coe_nat_dvd,
-      pow_smul_eq_iff_period_dvd
-    ]
+  · rw [Int.negSucc_coe, zpow_neg, zpow_ofNat, inv_smul_eq_iff, eq_comm, dvd_neg, Int.coe_nat_dvd,
+      pow_smul_eq_iff_period_dvd]
 
 @[to_additive (attr := simp)]
 theorem pow_smul_plus_period (n o : ℕ) (m : M) (a : α):
@@ -705,29 +697,25 @@ theorem zpow_smul_plus_period (i j : ℤ) (g : G) (a : α):
 @[to_additive (attr := simp)]
 theorem pow_smul_mod_period (n : ℕ) {m : M} {a : α}:
     m ^ (n % period m a) • a = m ^ n • a := by
-  conv_rhs => {
-    rw [← Nat.mod_add_div n (period m a), pow_smul_plus_period]
-  }
+  conv_rhs => rw [← Nat.mod_add_div n (period m a), pow_smul_plus_period]
 
 @[to_additive (attr := simp)]
 theorem zpow_smul_mod_period (j : ℤ) {g : G} {a : α}:
     g ^ (j % (period g a : ℤ)) • a = g ^ j • a := by
-  conv_rhs => {
-    rw [← Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
-  }
+  conv_rhs => rw [← Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
 
 variable {a : G} {b : α}
 
 @[to_additive]
 theorem pow_smul_eq_iff_minimalPeriod_dvd {n : ℕ} :
-    a ^ n • b = b ↔ Function.minimalPeriod (a • ·) b ∣ n := by
+    a ^ n • b = b ↔ minimalPeriod (a • ·) b ∣ n := by
   rw [← period_eq_minimalPeriod, pow_smul_eq_iff_period_dvd]
 #align mul_action.pow_smul_eq_iff_minimal_period_dvd MulAction.pow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.nsmul_vadd_eq_iff_minimal_period_dvd AddAction.nsmul_vadd_eq_iff_minimalPeriod_dvd
 
 @[to_additive]
 theorem zpow_smul_eq_iff_minimalPeriod_dvd {n : ℤ} :
-    a ^ n • b = b ↔ (Function.minimalPeriod (a • ·) b : ℤ) ∣ n := by
+    a ^ n • b = b ↔ (minimalPeriod (a • ·) b : ℤ) ∣ n := by
   rw [← period_eq_minimalPeriod, zpow_smul_eq_iff_period_dvd]
 #align mul_action.zpow_smul_eq_iff_minimal_period_dvd MulAction.zpow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.zsmul_vadd_eq_iff_minimal_period_dvd AddAction.zsmul_vadd_eq_iff_minimalPeriod_dvd
@@ -736,14 +724,14 @@ variable (a b)
 
 @[to_additive (attr := simp)]
 theorem pow_smul_mod_minimalPeriod (n : ℕ) :
-    a ^ (n % Function.minimalPeriod (a • ·) b) • b = a ^ n • b := by
+    a ^ (n % minimalPeriod (a • ·) b) • b = a ^ n • b := by
   rw [← period_eq_minimalPeriod, pow_smul_mod_period]
 #align mul_action.pow_smul_mod_minimal_period MulAction.pow_smul_mod_minimalPeriod
 #align add_action.nsmul_vadd_mod_minimal_period AddAction.nsmul_vadd_mod_minimalPeriod
 
 @[to_additive (attr := simp)]
 theorem zpow_smul_mod_minimalPeriod (n : ℤ) :
-    a ^ (n % (Function.minimalPeriod (a • ·) b : ℤ)) • b = a ^ n • b := by
+    a ^ (n % (minimalPeriod (a • ·) b : ℤ)) • b = a ^ n • b := by
   rw [← period_eq_minimalPeriod, zpow_smul_mod_period]
 #align mul_action.zpow_smul_mod_minimal_period MulAction.zpow_smul_mod_minimalPeriod
 #align add_action.zsmul_vadd_mod_minimal_period AddAction.zsmul_vadd_mod_minimalPeriod

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -644,7 +644,7 @@ such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
 noncomputable def period (m : M) (a : α) : ℕ := minimalPeriod (fun x => m • x) a
 
 /-- `MulAction.period m a` is definitionally equal to `Function.minimalPeriod (m • ·) a`. -/
-@[to_additive]
+@[to_additive "`AddAction.period m a` is definitionally equal to `Function.minimalPeriod (m +ᵥ ·) a`"]
 theorem period_eq_minimalPeriod {m : M} {a : α} :
     MulAction.period m a = minimalPeriod (fun x => m • x) a := rfl
 

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -636,10 +636,10 @@ variable {G : Type u} [Group G] [MulAction G α]
 variable {M : Type u} [Monoid M] [MulAction M α]
 
 /--
-The period of a multiplicative action of `g` on `a` is the smallest `n` such that `g ^ n • a = a`,
-or `0` if such an `n` does not exist.
+The period of a multiplicative action of `g` on `a` is the smallest positive `n` such that
+`g ^ n • a = a`, or `0` if such an `n` does not exist.
 -/
-@[to_additive "The period of an additive action of `g` on `a` is the smallest `n`
+@[to_additive "The period of an additive action of `g` on `a` is the smallest positive `n`
 such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
 noncomputable def period (m : M) (a : α) : ℕ := minimalPeriod (fun x => m • x) a
 
@@ -648,36 +648,31 @@ noncomputable def period (m : M) (a : α) : ℕ := minimalPeriod (fun x => m •
 theorem period_eq_minimalPeriod {m : M} {a : α} :
     MulAction.period m a = minimalPeriod (fun x => m • x) a := rfl
 
-@[to_additive]
-lemma smul_pow_eq_function_pow (m : M) (a : α) (n : ℕ): m ^ n • a = (fun x => m • x)^[n] a := by
-  rw [smul_iterate]
-
-/-- `m ^ (period m a)` fixes `a` -/
-@[to_additive (attr := simp) "`(period m a) • m` fixes `a`"]
-theorem smul_pow_period_fixed (m : M) (a : α) : m ^ (period m a) • a = a := by
-  rw [period_eq_minimalPeriod, smul_pow_eq_function_pow, iterate_minimalPeriod]
+/-- `m ^ (period m a)` fixes `a`. -/
+@[to_additive (attr := simp) "`(period m a) • m` fixes `a`."]
+theorem pow_period_smul (m : M) (a : α) : m ^ (period m a) • a = a := by
+  rw [period_eq_minimalPeriod, ← smul_iterate_apply, iterate_minimalPeriod]
 
 @[to_additive]
 lemma fixed_iff_isPeriodicPt {m : M} {a : α} {n : ℕ} :
-    m ^ n • a = a ↔ IsPeriodicPt (fun x => m • x) n a := by
-  rw [smul_pow_eq_function_pow]
-  rfl
+    IsPeriodicPt (m • ·) n a ↔ m ^ n • a = a := by
+  rw [← smul_iterate_apply, IsPeriodicPt, IsFixedPt]
 
 /-! ### Multiples of `MulAction.period`
 
-It is easy to convince onself that if `g ^ n • a = a` (resp. `(n • g) +ᵥ a = a`),
+It is easy to convince oneself that if `g ^ n • a = a` (resp. `(n • g) +ᵥ a = a`),
 then `n` must be a multiple of `period g a`.
 
 This also holds for negative powers/multiples.
 -/
 
 @[to_additive]
-theorem pow_smul_eq_iff_period_dvd {n : ℕ} {m : M} {a : α}:
+theorem pow_smul_eq_iff_period_dvd {n : ℕ} {m : M} {a : α} :
     m ^ n • a = a ↔ period m a ∣ n := by
   rw [period_eq_minimalPeriod, ← isPeriodicPt_iff_minimalPeriod_dvd, fixed_iff_isPeriodicPt]
 
 @[to_additive]
-theorem zpow_smul_eq_iff_period_dvd {j : ℤ} {g : G} {a : α}:
+theorem zpow_smul_eq_iff_period_dvd {j : ℤ} {g : G} {a : α} :
     g ^ j • a = a ↔ (period g a : ℤ) ∣ j := by
   rcases j with n | n
   · rw [Int.ofNat_eq_coe, zpow_ofNat, Int.coe_nat_dvd, pow_smul_eq_iff_period_dvd]
@@ -685,22 +680,22 @@ theorem zpow_smul_eq_iff_period_dvd {j : ℤ} {g : G} {a : α}:
       pow_smul_eq_iff_period_dvd]
 
 @[to_additive (attr := simp)]
-theorem pow_smul_plus_period (n o : ℕ) (m : M) (a : α):
+theorem pow_smul_plus_period (n o : ℕ) (m : M) (a : α) :
     m ^ (n + (period m a) * o) • a = m ^ n • a := by
   rw [pow_add, mul_smul, pow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
 
 @[to_additive (attr := simp)]
-theorem zpow_smul_plus_period (i j : ℤ) (g : G) (a : α):
+theorem zpow_smul_plus_period (i j : ℤ) (g : G) (a : α) :
     g ^ (i + (period g a : ℤ) * j) • a = g ^ i • a := by
   rw [zpow_add, mul_smul, zpow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
 
 @[to_additive (attr := simp)]
-theorem pow_smul_mod_period (n : ℕ) {m : M} {a : α}:
+theorem pow_smul_mod_period (n : ℕ) {m : M} {a : α} :
     m ^ (n % period m a) • a = m ^ n • a := by
   conv_rhs => rw [← Nat.mod_add_div n (period m a), pow_smul_plus_period]
 
 @[to_additive (attr := simp)]
-theorem zpow_smul_mod_period (j : ℤ) {g : G} {a : α}:
+theorem zpow_smul_mod_period (j : ℤ) {g : G} {a : α} :
     g ^ (j % (period g a : ℤ)) • a = g ^ j • a := by
   conv_rhs => rw [← Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
 

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -644,7 +644,8 @@ such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
 noncomputable def period (m : M) (a : α) : ℕ := minimalPeriod (fun x => m • x) a
 
 /-- `MulAction.period m a` is definitionally equal to `Function.minimalPeriod (m • ·) a`. -/
-@[to_additive "`AddAction.period m a` is definitionally equal to `Function.minimalPeriod (m +ᵥ ·) a`"]
+@[to_additive "`AddAction.period m a` is definitionally equal to
+`Function.minimalPeriod (m +ᵥ ·) a`"]
 theorem period_eq_minimalPeriod {m : M} {a : α} :
     MulAction.period m a = minimalPeriod (fun x => m • x) a := rfl
 

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -654,7 +654,7 @@ theorem pow_period_smul (m : M) (a : α) : m ^ (period m a) • a = a := by
   rw [period_eq_minimalPeriod, ← smul_iterate_apply, iterate_minimalPeriod]
 
 @[to_additive]
-lemma fixed_iff_isPeriodicPt {m : M} {a : α} {n : ℕ} :
+lemma isPeriodicPt_smul_iff {m : M} {a : α} {n : ℕ} :
     IsPeriodicPt (m • ·) n a ↔ m ^ n • a = a := by
   rw [← smul_iterate_apply, IsPeriodicPt, IsFixedPt]
 
@@ -669,7 +669,7 @@ This also holds for negative powers/multiples.
 @[to_additive]
 theorem pow_smul_eq_iff_period_dvd {n : ℕ} {m : M} {a : α} :
     m ^ n • a = a ↔ period m a ∣ n := by
-  rw [period_eq_minimalPeriod, ← isPeriodicPt_iff_minimalPeriod_dvd, fixed_iff_isPeriodicPt]
+  rw [period_eq_minimalPeriod, ← isPeriodicPt_iff_minimalPeriod_dvd, isPeriodicPt_smul_iff]
 
 @[to_additive]
 theorem zpow_smul_eq_iff_period_dvd {j : ℤ} {g : G} {a : α} :

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -680,24 +680,36 @@ theorem zpow_smul_eq_iff_period_dvd {j : ℤ} {g : G} {a : α} :
       pow_smul_eq_iff_period_dvd]
 
 @[to_additive (attr := simp)]
-theorem pow_smul_plus_period (n o : ℕ) (m : M) (a : α) :
-    m ^ (n + (period m a) * o) • a = m ^ n • a := by
-  rw [pow_add, mul_smul, pow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
-
-@[to_additive (attr := simp)]
-theorem zpow_smul_plus_period (i j : ℤ) (g : G) (a : α) :
-    g ^ (i + (period g a : ℤ) * j) • a = g ^ i • a := by
-  rw [zpow_add, mul_smul, zpow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
-
-@[to_additive (attr := simp)]
-theorem pow_smul_mod_period (n : ℕ) {m : M} {a : α} :
+theorem pow_mod_period_smul (n : ℕ) {m : M} {a : α} :
     m ^ (n % period m a) • a = m ^ n • a := by
-  conv_rhs => rw [← Nat.mod_add_div n (period m a), pow_smul_plus_period]
+  conv_rhs => rw [← Nat.mod_add_div n (period m a), pow_add, mul_smul,
+    pow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
 
 @[to_additive (attr := simp)]
-theorem zpow_smul_mod_period (j : ℤ) {g : G} {a : α} :
+theorem zpow_mod_period_smul (j : ℤ) {g : G} {a : α} :
     g ^ (j % (period g a : ℤ)) • a = g ^ j • a := by
-  conv_rhs => rw [← Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
+  conv_rhs => rw [← Int.emod_add_ediv j (period g a), zpow_add, mul_smul,
+    zpow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
+
+@[to_additive (attr := simp)]
+theorem pow_add_period_smul (n : ℕ) (m : M) (a : α) :
+    m ^ (n + period m a) • a = m ^ n • a := by
+  rw [← pow_mod_period_smul, Nat.add_mod_right, pow_mod_period_smul]
+
+@[to_additive (attr := simp)]
+theorem pow_period_add_smul (n : ℕ) (m : M) (a : α) :
+    m ^ (period m a + n) • a = m ^ n • a := by
+  rw [← pow_mod_period_smul, Nat.add_mod_left, pow_mod_period_smul]
+
+@[to_additive (attr := simp)]
+theorem zpow_add_period_smul (i : ℤ) (g : G) (a : α) :
+    g ^ (i + period g a) • a = g ^ i • a := by
+  rw [← zpow_mod_period_smul, Int.add_emod_self, zpow_mod_period_smul]
+
+@[to_additive (attr := simp)]
+theorem zpow_period_add_smul (i : ℤ) (g : G) (a : α) :
+    g ^ (period g a + i) • a = g ^ i • a := by
+  rw [← zpow_mod_period_smul, Int.add_emod_self_left, zpow_mod_period_smul]
 
 variable {a : G} {b : α}
 
@@ -720,14 +732,14 @@ variable (a b)
 @[to_additive (attr := simp)]
 theorem pow_smul_mod_minimalPeriod (n : ℕ) :
     a ^ (n % minimalPeriod (a • ·) b) • b = a ^ n • b := by
-  rw [← period_eq_minimalPeriod, pow_smul_mod_period]
+  rw [← period_eq_minimalPeriod, pow_mod_period_smul]
 #align mul_action.pow_smul_mod_minimal_period MulAction.pow_smul_mod_minimalPeriod
 #align add_action.nsmul_vadd_mod_minimal_period AddAction.nsmul_vadd_mod_minimalPeriod
 
 @[to_additive (attr := simp)]
 theorem zpow_smul_mod_minimalPeriod (n : ℤ) :
     a ^ (n % (minimalPeriod (a • ·) b : ℤ)) • b = a ^ n • b := by
-  rw [← period_eq_minimalPeriod, zpow_smul_mod_period]
+  rw [← period_eq_minimalPeriod, zpow_mod_period_smul]
 #align mul_action.zpow_smul_mod_minimal_period MulAction.zpow_smul_mod_minimalPeriod
 #align add_action.zsmul_vadd_mod_minimal_period AddAction.zsmul_vadd_mod_minimalPeriod
 

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2024 Emilie Burgun. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Emilie Burgun
+-/
+
+import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Dynamics.PeriodicPts
+import Mathlib.GroupTheory.Exponent
+
+/-!
+# Period of a group action
+
+This module defines the period of a group action ([`MulAction.period`] and [`AddAction.period`]),
+which is the smallest `m` such that `g ^ m • a = a` (resp. `(m • g) +ᵥ a = a`) for a given `g : G` and `a : α`.
+
+If such an `m` does not exist, then by convention `MulAction.period` and `AddAction.period` return 0.
+-/
+
+namespace MulAction
+
+universe u v
+variable {α : Type v}
+variable {G : Type u} [Group G] [MulAction G α]
+variable {M : Type u} [Monoid M] [MulAction M α]
+
+/--
+The period of a multiplicative action of `g` on `a` is the smallest `n` such that `g ^ n • a = a`,
+or `0` if such an `n` does not exist.
+-/
+@[to_additive "The period of an additive action of `g` on `a` is the smallest `n` such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
+noncomputable def period (m : M) (a : α) : ℕ := Function.minimalPeriod (fun x => m • x) a
+
+@[to_additive]
+theorem period_eq_minimalPeriod {m : M} {a : α} :
+    MulAction.period m a = Function.minimalPeriod (fun x => m • x) a := rfl
+
+@[to_additive]
+lemma smul_pow_eq_function_pow (m : M) (a : α) (n : ℕ): m ^ n • a = (fun x => m • x)^[n] a := by
+  rw [smul_iterate]
+
+/-- `m ^ (period m a)` fixes `a` -/
+@[to_additive (attr := simp) "`(period m a) • m` fixes `a`"]
+theorem smul_pow_period_fixed (m : M) (a : α) : m ^ (period m a) • a = a := by
+  rw [period_eq_minimalPeriod, smul_pow_eq_function_pow, Function.iterate_minimalPeriod]
+
+/-- If the action is periodic, then a lower bound for its period can be computed. -/
+@[to_additive]
+theorem period_gt_of_moved {m : M} {a : α} {n : ℕ} (period_pos : 0 < period m a)
+    (moved : ∀ k, 0 < k → k < n → m^k • a ≠ a) : n ≤ period m a := by
+  by_contra period_le_n
+  rw [not_le] at period_le_n
+  apply moved _ period_pos period_le_n
+  exact smul_pow_period_fixed m a
+
+@[to_additive]
+lemma fixed_iff_isPeriodicPt {m : M} {a : α} {n : ℕ} :
+    m ^ n • a = a ↔ Function.IsPeriodicPt (fun x => m • x) n a := by
+  rw [smul_pow_eq_function_pow]
+  rfl
+
+/-- If for some `n`, `m ^ n • a = a`, then `period m a ≤ n`. -/
+@[to_additive]
+theorem period_le_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : m ^ n • a = a) :
+    period m a ≤ n := by
+  rw [period_eq_minimalPeriod]
+  rw [fixed_iff_isPeriodicPt] at fixed
+  exact Function.IsPeriodicPt.minimalPeriod_le n_pos fixed
+
+/-- If for some `n`, `m ^ n • a = a`, then `0 < period m a`. -/
+@[to_additive]
+theorem period_pos_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : m ^ n • a = a) :
+    0 < period m a := by
+  rw [fixed_iff_isPeriodicPt] at fixed
+  rw [period_eq_minimalPeriod]
+  exact Function.IsPeriodicPt.minimalPeriod_pos n_pos fixed
+
+/-- For any non-zero `n` less than the period, `a` is moved by `m^n`. -/
+@[to_additive]
+theorem moved_of_lt_period {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (n_lt_period : n < period m a) :
+    m^n • a ≠ a := by
+  intro a_fixed
+  apply Nat.not_le.mpr n_lt_period
+  exact period_le_of_fixed n_pos a_fixed
+
+section MonoidExponent
+
+/-! ## `MulAction.period` and group exponents
+
+The period of a given element `m : M` can be bounded by the `Monoid.exponent M` or `orderOf m`.
+-/
+
+theorem period_pos_of_orderOf_pos {m : M} (order_pos : 0 < orderOf m) (a : α):
+    0 < period m a := by
+  apply period_pos_of_fixed order_pos
+  rw [pow_orderOf_eq_one, one_smul]
+
+theorem period_le_orderOf {m : M} (order_pos : 0 < orderOf m) (a : α):
+    period m a ≤ orderOf m := by
+  apply period_le_of_fixed order_pos
+  rw [pow_orderOf_eq_one, one_smul]
+
+theorem period_pos_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M) (a : α) :
+    0 < period m a := by
+  apply period_pos_of_fixed exp_pos
+  rw [Monoid.pow_exponent_eq_one, one_smul]
+
+theorem period_le_exponent (exp_pos : 0 < Monoid.exponent M) (m : M) (a : α) :
+    period m a ≤ Monoid.exponent M := by
+  apply period_le_of_fixed exp_pos
+  rw [Monoid.pow_exponent_eq_one, one_smul]
+
+variable (α)
+
+theorem period_bounded_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M) :
+    BddAbove (Set.range (fun a : α => period m a)) := by
+  use Monoid.exponent M
+  simp [upperBounds]
+  apply period_le_exponent exp_pos
+
+end MonoidExponent
+
+end MulAction

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -27,20 +27,20 @@ variable {G : Type u} [Group G] [MulAction G α]
 variable {M : Type u} [Monoid M] [MulAction M α]
 
 /-- If the action is periodic, then a lower bound for its period can be computed. -/
-@[to_additive]
+@[to_additive "If the action is periodic, then a lower bound for its period can be computed."]
 theorem le_period {m : M} {a : α} {n : ℕ} (period_pos : 0 < period m a)
     (moved : ∀ k, 0 < k → k < n → m ^ k • a ≠ a) : n ≤ period m a :=
   le_of_not_gt fun period_lt_n =>
     moved _ period_pos period_lt_n <| pow_period_smul m a
 
 /-- If for some `n`, `m ^ n • a = a`, then `period m a ≤ n`. -/
-@[to_additive]
+@[to_additive "If for some `n`, `(n • m) +ᵥ a = a`, then `period m a ≤ n`."]
 theorem period_le_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : m ^ n • a = a) :
     period m a ≤ n :=
   (isPeriodicPt_smul_iff.mpr fixed).minimalPeriod_le n_pos
 
 /-- If for some `n`, `m ^ n • a = a`, then `0 < period m a`. -/
-@[to_additive]
+@[to_additive "If for some `n`, `(n • m) +ᵥ a = a`, then `0 < period m a`."]
 theorem period_pos_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : m ^ n • a = a) :
     0 < period m a :=
   (isPeriodicPt_smul_iff.mpr fixed).minimalPeriod_pos n_pos
@@ -52,10 +52,10 @@ theorem period_eq_one_iff {m : M} {a : α} : period m a = 1 ↔ m • a = a := �
     (period_le_of_fixed one_pos (by simpa))
     (period_pos_of_fixed one_pos (by simpa))⟩
 
-/-- For any non-zero `n` less than the period, `a` is moved by `m ^ n`. -/
-@[to_additive]
-theorem moved_of_lt_period {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (n_lt_period : n < period m a) :
-    m ^ n • a ≠ a := fun a_fixed =>
+/-- For any non-zero `n` less than the period of `m` on `a`, `a` is moved by `m ^ n`. -/
+@[to_additive "For any non-zero `n` less than the period of `m` on `a`, `a` is moved by `n • m`."]
+theorem pow_smul_ne_of_lt_period {m : M} {a : α} {n : ℕ} (n_pos : 0 < n)
+    (n_lt_period : n < period m a) : m ^ n • a ≠ a := fun a_fixed =>
   not_le_of_gt n_lt_period <| period_le_of_fixed n_pos a_fixed
 
 section Identities

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -33,7 +33,7 @@ theorem period_gt_of_moved {m : M} {a : α} {n : ℕ} (period_pos : 0 < period m
   by_contra period_le_n
   rw [not_le] at period_le_n
   apply moved _ period_pos period_le_n
-  exact smul_pow_period_fixed m a
+  exact pow_period_smul m a
 
 /-- If for some `n`, `m ^ n • a = a`, then `period m a ≤ n`. -/
 @[to_additive]

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -40,14 +40,14 @@ theorem period_gt_of_moved {m : M} {a : α} {n : ℕ} (period_pos : 0 < period m
 theorem period_le_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : m ^ n • a = a) :
     period m a ≤ n := by
   rw [period_eq_minimalPeriod]
-  rw [fixed_iff_isPeriodicPt] at fixed
+  rw [← isPeriodicPt_smul_iff] at fixed
   exact Function.IsPeriodicPt.minimalPeriod_le n_pos fixed
 
 /-- If for some `n`, `m ^ n • a = a`, then `0 < period m a`. -/
 @[to_additive]
 theorem period_pos_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : m ^ n • a = a) :
     0 < period m a := by
-  rw [fixed_iff_isPeriodicPt] at fixed
+  rw [← isPeriodicPt_smul_iff] at fixed
   rw [period_eq_minimalPeriod]
   exact Function.IsPeriodicPt.minimalPeriod_pos n_pos fixed
 

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -46,9 +46,9 @@ theorem period_pos_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : 
   (isPeriodicPt_smul_iff.mpr fixed).minimalPeriod_pos n_pos
 
 @[to_additive]
-theorem period_eq_one_iff {m : M} {a : α} : period m a = 1 ↔ m • a = a := ⟨
-  fun eq_one => pow_one m ▸ eq_one ▸ pow_period_smul m a,
-  fun fixed => le_antisymm
+theorem period_eq_one_iff {m : M} {a : α} : period m a = 1 ↔ m • a = a :=
+  ⟨fun eq_one => pow_one m ▸ eq_one ▸ pow_period_smul m a,
+   fun fixed => le_antisymm
     (period_le_of_fixed one_pos (by simpa))
     (period_pos_of_fixed one_pos (by simpa))⟩
 

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -11,8 +11,8 @@ import Mathlib.GroupTheory.Exponent
 /-!
 # Period of a group action
 
-This module defines the period of a group action ([`MulAction.period`] and [`AddAction.period`]),
-which is the smallest `m` such that `g ^ m • a = a` (resp. `(m • g) +ᵥ a = a`) for a given `g : G` and `a : α`.
+This module defines some helpful lemmas around [`MulAction.period`] and [`AddAction.period`].
+The period of a point `a` by a group element `g` is the smallest `m` such that `g ^ m • a = a` (resp. `(m • g) +ᵥ a = a`) for a given `g : G` and `a : α`.
 
 If such an `m` does not exist, then by convention `MulAction.period` and `AddAction.period` return 0.
 -/
@@ -24,26 +24,6 @@ variable {α : Type v}
 variable {G : Type u} [Group G] [MulAction G α]
 variable {M : Type u} [Monoid M] [MulAction M α]
 
-/--
-The period of a multiplicative action of `g` on `a` is the smallest `n` such that `g ^ n • a = a`,
-or `0` if such an `n` does not exist.
--/
-@[to_additive "The period of an additive action of `g` on `a` is the smallest `n` such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
-noncomputable def period (m : M) (a : α) : ℕ := Function.minimalPeriod (fun x => m • x) a
-
-@[to_additive]
-theorem period_eq_minimalPeriod {m : M} {a : α} :
-    MulAction.period m a = Function.minimalPeriod (fun x => m • x) a := rfl
-
-@[to_additive]
-lemma smul_pow_eq_function_pow (m : M) (a : α) (n : ℕ): m ^ n • a = (fun x => m • x)^[n] a := by
-  rw [smul_iterate]
-
-/-- `m ^ (period m a)` fixes `a` -/
-@[to_additive (attr := simp) "`(period m a) • m` fixes `a`"]
-theorem smul_pow_period_fixed (m : M) (a : α) : m ^ (period m a) • a = a := by
-  rw [period_eq_minimalPeriod, smul_pow_eq_function_pow, Function.iterate_minimalPeriod]
-
 /-- If the action is periodic, then a lower bound for its period can be computed. -/
 @[to_additive]
 theorem period_gt_of_moved {m : M} {a : α} {n : ℕ} (period_pos : 0 < period m a)
@@ -52,12 +32,6 @@ theorem period_gt_of_moved {m : M} {a : α} {n : ℕ} (period_pos : 0 < period m
   rw [not_le] at period_le_n
   apply moved _ period_pos period_le_n
   exact smul_pow_period_fixed m a
-
-@[to_additive]
-lemma fixed_iff_isPeriodicPt {m : M} {a : α} {n : ℕ} :
-    m ^ n • a = a ↔ Function.IsPeriodicPt (fun x => m • x) n a := by
-  rw [smul_pow_eq_function_pow]
-  rfl
 
 /-- If for some `n`, `m ^ n • a = a`, then `period m a ≤ n`. -/
 @[to_additive]
@@ -90,21 +64,25 @@ section MonoidExponent
 The period of a given element `m : M` can be bounded by the `Monoid.exponent M` or `orderOf m`.
 -/
 
+@[to_additive]
 theorem period_pos_of_orderOf_pos {m : M} (order_pos : 0 < orderOf m) (a : α):
     0 < period m a := by
   apply period_pos_of_fixed order_pos
   rw [pow_orderOf_eq_one, one_smul]
 
+@[to_additive]
 theorem period_le_orderOf {m : M} (order_pos : 0 < orderOf m) (a : α):
     period m a ≤ orderOf m := by
   apply period_le_of_fixed order_pos
   rw [pow_orderOf_eq_one, one_smul]
 
+@[to_additive]
 theorem period_pos_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M) (a : α) :
     0 < period m a := by
   apply period_pos_of_fixed exp_pos
   rw [Monoid.pow_exponent_eq_one, one_smul]
 
+@[to_additive]
 theorem period_le_exponent (exp_pos : 0 < Monoid.exponent M) (m : M) (a : α) :
     period m a ≤ Monoid.exponent M := by
   apply period_le_of_fixed exp_pos
@@ -112,6 +90,7 @@ theorem period_le_exponent (exp_pos : 0 < Monoid.exponent M) (m : M) (a : α) :
 
 variable (α)
 
+@[to_additive]
 theorem period_bounded_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M) :
     BddAbove (Set.range (fun a : α => period m a)) := by
   use Monoid.exponent M
@@ -119,5 +98,6 @@ theorem period_bounded_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M)
   apply period_le_exponent exp_pos
 
 end MonoidExponent
+
 
 end MulAction

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -12,9 +12,11 @@ import Mathlib.GroupTheory.Exponent
 # Period of a group action
 
 This module defines some helpful lemmas around [`MulAction.period`] and [`AddAction.period`].
-The period of a point `a` by a group element `g` is the smallest `m` such that `g ^ m • a = a` (resp. `(m • g) +ᵥ a = a`) for a given `g : G` and `a : α`.
+The period of a point `a` by a group element `g` is the smallest `m` such that `g ^ m • a = a`
+(resp. `(m • g) +ᵥ a = a`) for a given `g : G` and `a : α`.
 
-If such an `m` does not exist, then by convention `MulAction.period` and `AddAction.period` return 0.
+If such an `m` does not exist,
+then by convention `MulAction.period` and `AddAction.period` return 0.
 -/
 
 namespace MulAction
@@ -48,6 +50,14 @@ theorem period_pos_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : 
   rw [fixed_iff_isPeriodicPt] at fixed
   rw [period_eq_minimalPeriod]
   exact Function.IsPeriodicPt.minimalPeriod_pos n_pos fixed
+
+@[to_additive]
+theorem period_eq_one_of_fixed {m : M} {a : α} (fixed : m • a = a) : period m a = 1 := by
+  symm
+  rw [← pow_one m] at fixed
+  refine Nat.eq_of_le_of_lt_succ (period_le_of_fixed Nat.one_pos fixed) ?pos
+  rw [Nat.lt_add_left_iff_pos]
+  exact period_pos_of_fixed Nat.one_pos fixed
 
 /-- For any non-zero `n` less than the period, `a` is moved by `m^n`. -/
 @[to_additive]

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -46,10 +46,11 @@ theorem period_pos_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : 
   (isPeriodicPt_smul_iff.mpr fixed).minimalPeriod_pos n_pos
 
 @[to_additive]
-theorem period_eq_one_of_fixed {m : M} {a : α} (fixed : m • a = a) : period m a = 1 :=
-  le_antisymm
+theorem period_eq_one_iff {m : M} {a : α} : period m a = 1 ↔ m • a = a := ⟨
+  fun eq_one => pow_one m ▸ eq_one ▸ pow_period_smul m a,
+  fun fixed => le_antisymm
     (period_le_of_fixed one_pos (by simpa))
-    (period_pos_of_fixed one_pos (by simpa))
+    (period_pos_of_fixed one_pos (by simpa))⟩
 
 /-- For any non-zero `n` less than the period, `a` is moved by `m ^ n`. -/
 @[to_additive]
@@ -57,36 +58,58 @@ theorem moved_of_lt_period {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (n_lt_peri
     m ^ n • a ≠ a := fun a_fixed =>
   not_le_of_gt n_lt_period <| period_le_of_fixed n_pos a_fixed
 
+section Identities
+
+/-! ### `MulAction.period` for common group elements
+-/
+
+variable (M) in
+@[to_additive (attr := simp)]
+theorem period_one (a : α) : period (1 : M) a = 1 := period_eq_one_iff.mpr (one_smul M a)
+
+@[to_additive (attr := simp)]
+theorem period_inv (g : G) (a : α) : period g⁻¹ a = period g a := by
+  simp only [period_eq_minimalPeriod, Function.minimalPeriod_eq_minimalPeriod_iff,
+    isPeriodicPt_smul_iff]
+  intro n
+  rw [smul_eq_iff_eq_inv_smul, eq_comm, ← zpow_ofNat, inv_zpow, inv_inv, zpow_ofNat]
+
+end Identities
+
 section MonoidExponent
 
-/-! ## `MulAction.period` and group exponents
+/-! ### `MulAction.period` and group exponents
 
 The period of a given element `m : M` can be bounded by the `Monoid.exponent M` or `orderOf m`.
 -/
 
 @[to_additive]
+theorem period_dvd_orderOf (m : M) (a : α) : period m a ∣ orderOf m := by
+  rw [← pow_smul_eq_iff_period_dvd, pow_orderOf_eq_one, one_smul]
+
+@[to_additive]
 theorem period_pos_of_orderOf_pos {m : M} (order_pos : 0 < orderOf m) (a : α) :
-    0 < period m a := by
-  apply period_pos_of_fixed order_pos
-  rw [pow_orderOf_eq_one, one_smul]
+    0 < period m a :=
+  Nat.pos_of_dvd_of_pos (period_dvd_orderOf m a) order_pos
 
 @[to_additive]
 theorem period_le_orderOf {m : M} (order_pos : 0 < orderOf m) (a : α) :
-    period m a ≤ orderOf m := by
-  apply period_le_of_fixed order_pos
-  rw [pow_orderOf_eq_one, one_smul]
+    period m a ≤ orderOf m :=
+  Nat.le_of_dvd order_pos (period_dvd_orderOf m a)
+
+@[to_additive]
+theorem period_dvd_exponent (m : M) (a : α) : period m a ∣ Monoid.exponent M := by
+  rw [← pow_smul_eq_iff_period_dvd, Monoid.pow_exponent_eq_one, one_smul]
 
 @[to_additive]
 theorem period_pos_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M) (a : α) :
-    0 < period m a := by
-  apply period_pos_of_fixed exp_pos
-  rw [Monoid.pow_exponent_eq_one, one_smul]
+    0 < period m a :=
+  Nat.pos_of_dvd_of_pos (period_dvd_exponent m a) exp_pos
 
 @[to_additive]
 theorem period_le_exponent (exp_pos : 0 < Monoid.exponent M) (m : M) (a : α) :
-    period m a ≤ Monoid.exponent M := by
-  apply period_le_of_fixed exp_pos
-  rw [Monoid.pow_exponent_eq_one, one_smul]
+    period m a ≤ Monoid.exponent M :=
+  Nat.le_of_dvd exp_pos (period_dvd_exponent m a)
 
 variable (α)
 

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Emilie Burgun
 -/
 
-import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.Dynamics.PeriodicPts
 import Mathlib.GroupTheory.Exponent
+import Mathlib.GroupTheory.GroupAction.Basic
 
 /-!
 # Period of a group action
@@ -28,44 +28,34 @@ variable {M : Type u} [Monoid M] [MulAction M α]
 
 /-- If the action is periodic, then a lower bound for its period can be computed. -/
 @[to_additive]
-theorem period_gt_of_moved {m : M} {a : α} {n : ℕ} (period_pos : 0 < period m a)
-    (moved : ∀ k, 0 < k → k < n → m^k • a ≠ a) : n ≤ period m a := by
-  by_contra period_le_n
-  rw [not_le] at period_le_n
-  apply moved _ period_pos period_le_n
-  exact pow_period_smul m a
+theorem le_period {m : M} {a : α} {n : ℕ} (period_pos : 0 < period m a)
+    (moved : ∀ k, 0 < k → k < n → m ^ k • a ≠ a) : n ≤ period m a :=
+  le_of_not_gt fun period_lt_n =>
+    moved _ period_pos period_lt_n <| pow_period_smul m a
 
 /-- If for some `n`, `m ^ n • a = a`, then `period m a ≤ n`. -/
 @[to_additive]
 theorem period_le_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : m ^ n • a = a) :
-    period m a ≤ n := by
-  rw [period_eq_minimalPeriod]
-  rw [← isPeriodicPt_smul_iff] at fixed
-  exact Function.IsPeriodicPt.minimalPeriod_le n_pos fixed
+    period m a ≤ n :=
+  (isPeriodicPt_smul_iff.mpr fixed).minimalPeriod_le n_pos
 
 /-- If for some `n`, `m ^ n • a = a`, then `0 < period m a`. -/
 @[to_additive]
 theorem period_pos_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : m ^ n • a = a) :
-    0 < period m a := by
-  rw [← isPeriodicPt_smul_iff] at fixed
-  rw [period_eq_minimalPeriod]
-  exact Function.IsPeriodicPt.minimalPeriod_pos n_pos fixed
+    0 < period m a :=
+  (isPeriodicPt_smul_iff.mpr fixed).minimalPeriod_pos n_pos
 
 @[to_additive]
-theorem period_eq_one_of_fixed {m : M} {a : α} (fixed : m • a = a) : period m a = 1 := by
-  symm
-  rw [← pow_one m] at fixed
-  refine Nat.eq_of_le_of_lt_succ (period_le_of_fixed Nat.one_pos fixed) ?pos
-  rw [Nat.lt_add_left_iff_pos]
-  exact period_pos_of_fixed Nat.one_pos fixed
+theorem period_eq_one_of_fixed {m : M} {a : α} (fixed : m • a = a) : period m a = 1 :=
+  le_antisymm
+    (period_le_of_fixed one_pos (by simpa))
+    (period_pos_of_fixed one_pos (by simpa))
 
-/-- For any non-zero `n` less than the period, `a` is moved by `m^n`. -/
+/-- For any non-zero `n` less than the period, `a` is moved by `m ^ n`. -/
 @[to_additive]
 theorem moved_of_lt_period {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (n_lt_period : n < period m a) :
-    m^n • a ≠ a := by
-  intro a_fixed
-  apply Nat.not_le.mpr n_lt_period
-  exact period_le_of_fixed n_pos a_fixed
+    m ^ n • a ≠ a := fun a_fixed =>
+  not_le_of_gt n_lt_period <| period_le_of_fixed n_pos a_fixed
 
 section MonoidExponent
 
@@ -75,13 +65,13 @@ The period of a given element `m : M` can be bounded by the `Monoid.exponent M` 
 -/
 
 @[to_additive]
-theorem period_pos_of_orderOf_pos {m : M} (order_pos : 0 < orderOf m) (a : α):
+theorem period_pos_of_orderOf_pos {m : M} (order_pos : 0 < orderOf m) (a : α) :
     0 < period m a := by
   apply period_pos_of_fixed order_pos
   rw [pow_orderOf_eq_one, one_smul]
 
 @[to_additive]
-theorem period_le_orderOf {m : M} (order_pos : 0 < orderOf m) (a : α):
+theorem period_le_orderOf {m : M} (order_pos : 0 < orderOf m) (a : α) :
     period m a ≤ orderOf m := by
   apply period_le_of_fixed order_pos
   rw [pow_orderOf_eq_one, one_smul]
@@ -104,8 +94,7 @@ variable (α)
 theorem period_bounded_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M) :
     BddAbove (Set.range (fun a : α => period m a)) := by
   use Monoid.exponent M
-  simp [upperBounds]
-  apply period_le_exponent exp_pos
+  simpa [upperBounds] using period_le_exponent exp_pos _
 
 end MonoidExponent
 


### PR DESCRIPTION
Defines `MulAction.period g a` as a wrapper around `Function.minimalPeriod (fun x => g • x) a`,
allowing for some cleaner proofs involving the period of a group action.
The existing `MulAction.*_minimalPeriod_*` lemmas are changed to be defined using their now-preferred `MulAction.*_period_*` counterparts,
although they will only be made deprecated in another pull request.
The `Mathlib.GroupTheory.GroupAction.Period` module is also created, for additional lemmas around `MulAction.period`.

Some core lemmas need to remain in `Mathlib.Dynamics.PeriodicPts`, as they are needed for `ZMod` and the quotient group.

---

Note that the linter fails on `Mathlib.Dynamic.PeriodicPts`, since I do not know how to split the `to_additive` description on multiples lines :/

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
