### PR TITLE
[Merged by Bors] - feat(Analysis/NormedSpace/TrivSqZeroExt): generalize to topological spaces

### DIFF
--- a/Mathlib/Analysis/NormedSpace/TrivSqZeroExt.lean
+++ b/Mathlib/Analysis/NormedSpace/TrivSqZeroExt.lean
@@ -51,12 +51,16 @@ variable [Field 𝕜] [Ring R] [AddCommGroup M]
   [TopologicalSpace R] [TopologicalSpace M]
   [TopologicalRing R] [TopologicalAddGroup M] [ContinuousSMul R M] [ContinuousSMul Rᵐᵒᵖ M]
 
+theorem fst_expSeries (x : tsze R M) (n : ℕ) :
+    fst (expSeries 𝕜 (tsze R M) n fun _ => x) = expSeries 𝕜 R n fun _ => x.fst := by
+  simp [expSeries_apply_eq]
+
 /-- If `exp R x.fst` converges to `e` then `(exp R x).fst` converges to `e`,
 and vice versa. -/
 theorem hasSum_fst_expSeries (x : tsze R M) {e : R} :
     HasSum (fun n => fst (expSeries 𝕜 (tsze R M) n fun _ => x)) e ↔
       HasSum (fun n => expSeries 𝕜 R n fun _ => x.fst) e := by
-  simp [expSeries_apply_eq]
+  simp_rw [fst_expSeries]
 #align triv_sq_zero_ext.has_sum_fst_exp_series TrivSqZeroExt.hasSum_fst_expSeries
 
 /-- `(exp R x).fst` converges iff `exp R x.fst` converges. -/
@@ -74,25 +78,24 @@ variable [Field 𝕜] [CharZero 𝕜] [Ring R] [AddCommGroup M]
   [TopologicalSpace R] [TopologicalSpace M]
   [TopologicalRing R] [TopologicalAddGroup M] [ContinuousSMul R M] [ContinuousSMul Rᵐᵒᵖ M]
 
+theorem snd_expSeries_of_smul_comm
+    (x : tsze R M) (hx : MulOpposite.op x.fst • x.snd = x.fst • x.snd) (n : ℕ) :
+    snd (expSeries 𝕜 (tsze R M) (n + 1) fun _ => x) = (expSeries 𝕜 R n fun _ => x.fst) • x.snd := by
+  simp_rw [expSeries_apply_eq, snd_smul, snd_pow_of_smul_comm _ _ hx, nsmul_eq_smul_cast 𝕜 (n + 1),
+    smul_smul, smul_assoc, Nat.factorial_succ, Nat.pred_succ, Nat.cast_mul, mul_inv_rev,
+    inv_mul_cancel_right₀ ((Nat.cast_ne_zero (R := 𝕜)).mpr <| Nat.succ_ne_zero n)]
+
 /-- If `exp R x.fst` converges to `e` then `(exp R x).snd` converges to `e • x.snd`. -/
 theorem hasSum_snd_expSeries_of_smul_comm (x : tsze R M)
     (hx : MulOpposite.op x.fst • x.snd = x.fst • x.snd) {e : R}
     (h : HasSum (fun n => expSeries 𝕜 R n fun _ => x.fst) e) :
     HasSum (fun n => snd (expSeries 𝕜 (tsze R M) n fun _ => x)) (e • x.snd) := by
-  simp_rw [expSeries_apply_eq] at *
-  conv =>
-    congr
-    ext n
-    rw [snd_smul, snd_pow_of_smul_comm _ _ hx, nsmul_eq_smul_cast 𝕜 n, smul_smul, inv_mul_eq_div, ←
-      inv_div, ← smul_assoc]
-  apply HasSum.smul_const
   rw [← hasSum_nat_add_iff' 1]
-  rw [Finset.range_one, Finset.sum_singleton, Nat.cast_zero, div_zero, inv_zero, zero_smul,
-    sub_zero]
-  simp_rw [← Nat.succ_eq_add_one, Nat.pred_succ, Nat.factorial_succ, Nat.cast_mul, ←
-    Nat.succ_eq_add_one,
-    mul_div_cancel_left _ ((@Nat.cast_ne_zero 𝕜 _ _ _).mpr <| Nat.succ_ne_zero _)]
-  exact h
+  simp_rw [snd_expSeries_of_smul_comm _ _ hx]
+  simp_rw [expSeries_apply_eq] at *
+  rw [Finset.range_one, Finset.sum_singleton, Nat.factorial_zero, Nat.cast_one, pow_zero,
+    inv_one, one_smul, snd_one, sub_zero]
+  exact h.smul_const _
 #align triv_sq_zero_ext.has_sum_snd_exp_series_of_smul_comm TrivSqZeroExt.hasSum_snd_expSeries_of_smul_comm
 
 /-- If `exp R x.fst` converges to `e` then `exp R x` converges to `inl e + inr (e • x.snd)`. -/

--- a/Mathlib/Analysis/NormedSpace/TrivSqZeroExt.lean
+++ b/Mathlib/Analysis/NormedSpace/TrivSqZeroExt.lean
@@ -51,23 +51,9 @@ variable [Field 𝕜] [Ring R] [AddCommGroup M]
   [TopologicalSpace R] [TopologicalSpace M]
   [TopologicalRing R] [TopologicalAddGroup M] [ContinuousSMul R M] [ContinuousSMul Rᵐᵒᵖ M]
 
-theorem fst_expSeries (x : tsze R M) (n : ℕ) :
+@[simp] theorem fst_expSeries (x : tsze R M) (n : ℕ) :
     fst (expSeries 𝕜 (tsze R M) n fun _ => x) = expSeries 𝕜 R n fun _ => x.fst := by
   simp [expSeries_apply_eq]
-
-/-- If `exp R x.fst` converges to `e` then `(exp R x).fst` converges to `e`,
-and vice versa. -/
-theorem hasSum_fst_expSeries (x : tsze R M) {e : R} :
-    HasSum (fun n => fst (expSeries 𝕜 (tsze R M) n fun _ => x)) e ↔
-      HasSum (fun n => expSeries 𝕜 R n fun _ => x.fst) e := by
-  simp_rw [fst_expSeries]
-#align triv_sq_zero_ext.has_sum_fst_exp_series TrivSqZeroExt.hasSum_fst_expSeries
-
-/-- `(exp R x).fst` converges iff `exp R x.fst` converges. -/
-theorem summable_fst_expSeries (x : tsze R M) :
-    Summable (fun n => fst (expSeries 𝕜 (tsze R M) n fun _ => x)) ↔
-      Summable (fun n => expSeries 𝕜 R n fun _ => x.fst) :=
-  Function.surjective_id.summable_iff_of_hasSum_iff <| hasSum_fst_expSeries _ _
 
 end not_charZero
 
@@ -103,9 +89,10 @@ theorem hasSum_expSeries_of_smul_comm
     (x : tsze R M) (hx : MulOpposite.op x.fst • x.snd = x.fst • x.snd)
     {e : R} (h : HasSum (fun n => expSeries 𝕜 R n fun _ => x.fst) e) :
     HasSum (fun n => expSeries 𝕜 (tsze R M) n fun _ => x) (inl e + inr (e • x.snd)) := by
+  have : HasSum (fun n => fst (expSeries 𝕜 (tsze R M) n fun _ => x)) e := by
+    simpa [fst_expSeries] using h
   simpa only [inl_fst_add_inr_snd_eq] using
-    (hasSum_inl _ <| (hasSum_fst_expSeries 𝕜 x).mpr h).add
-      (hasSum_inr _ <| hasSum_snd_expSeries_of_smul_comm 𝕜 x hx h)
+    (hasSum_inl _ <| this).add (hasSum_inr _ <| hasSum_snd_expSeries_of_smul_comm 𝕜 x hx h)
 #align triv_sq_zero_ext.has_sum_exp_series_of_smul_comm TrivSqZeroExt.hasSum_expSeries_of_smul_comm
 
 variable [T2Space R] [T2Space M]
@@ -118,7 +105,7 @@ theorem exp_def_of_smul_comm (x : tsze R M) (hx : MulOpposite.op x.fst • x.snd
     exact h.hasSum
   · rw [tsum_eq_zero_of_not_summable h, zero_smul, inr_zero, inl_zero, zero_add,
       tsum_eq_zero_of_not_summable]
-    rw [←summable_fst_expSeries] at h
+    simp_rw [← fst_expSeries] at h
     refine mt ?_ h
     exact (Summable.map · (TrivSqZeroExt.fstHom 𝕜 R M).toLinearMap continuous_fst)
 

--- a/Mathlib/Analysis/NormedSpace/TrivSqZeroExt.lean
+++ b/Mathlib/Analysis/NormedSpace/TrivSqZeroExt.lean
@@ -44,23 +44,38 @@ namespace TrivSqZeroExt
 
 section Topology
 
-variable [TopologicalSpace R] [TopologicalSpace M]
+section not_charZero
+variable [Field 𝕜] [Ring R] [AddCommGroup M]
+  [Algebra 𝕜 R] [Module 𝕜 M] [Module R M] [Module Rᵐᵒᵖ M]
+  [SMulCommClass R Rᵐᵒᵖ M] [IsScalarTower 𝕜 R M] [IsScalarTower 𝕜 Rᵐᵒᵖ M]
+  [TopologicalSpace R] [TopologicalSpace M]
+  [TopologicalRing R] [TopologicalAddGroup M] [ContinuousSMul R M] [ContinuousSMul Rᵐᵒᵖ M]
 
-/-- If `exp R x.fst` converges to `e` then `(exp R x).fst` converges to `e`. -/
-theorem hasSum_fst_expSeries [Field 𝕜] [Ring R] [AddCommGroup M] [Algebra 𝕜 R] [Module R M]
-    [Module Rᵐᵒᵖ M] [SMulCommClass R Rᵐᵒᵖ M] [Module 𝕜 M] [IsScalarTower 𝕜 R M]
-    [IsScalarTower 𝕜 Rᵐᵒᵖ M] [TopologicalRing R] [TopologicalAddGroup M] [ContinuousSMul R M]
-    [ContinuousSMul Rᵐᵒᵖ M] (x : tsze R M) {e : R}
-    (h : HasSum (fun n => expSeries 𝕜 R n fun _ => x.fst) e) :
-    HasSum (fun n => fst (expSeries 𝕜 (tsze R M) n fun _ => x)) e := by
-  simpa [expSeries_apply_eq] using h
+/-- If `exp R x.fst` converges to `e` then `(exp R x).fst` converges to `e`,
+and vice versa. -/
+theorem hasSum_fst_expSeries (x : tsze R M) {e : R} :
+    HasSum (fun n => fst (expSeries 𝕜 (tsze R M) n fun _ => x)) e ↔
+      HasSum (fun n => expSeries 𝕜 R n fun _ => x.fst) e := by
+  simp [expSeries_apply_eq]
 #align triv_sq_zero_ext.has_sum_fst_exp_series TrivSqZeroExt.hasSum_fst_expSeries
 
+/-- `(exp R x).fst` converges iff `exp R x.fst` converges. -/
+theorem summable_fst_expSeries (x : tsze R M) :
+    Summable (fun n => fst (expSeries 𝕜 (tsze R M) n fun _ => x)) ↔
+      Summable (fun n => expSeries 𝕜 R n fun _ => x.fst) :=
+  Function.surjective_id.summable_iff_of_hasSum_iff <| hasSum_fst_expSeries _ _
+
+end not_charZero
+
+section Ring
+variable [Field 𝕜] [CharZero 𝕜] [Ring R] [AddCommGroup M]
+  [Algebra 𝕜 R] [Module 𝕜 M] [Module R M] [Module Rᵐᵒᵖ M]
+  [SMulCommClass R Rᵐᵒᵖ M] [IsScalarTower 𝕜 R M] [IsScalarTower 𝕜 Rᵐᵒᵖ M]
+  [TopologicalSpace R] [TopologicalSpace M]
+  [TopologicalRing R] [TopologicalAddGroup M] [ContinuousSMul R M] [ContinuousSMul Rᵐᵒᵖ M]
+
 /-- If `exp R x.fst` converges to `e` then `(exp R x).snd` converges to `e • x.snd`. -/
-theorem hasSum_snd_expSeries_of_smul_comm [Field 𝕜] [CharZero 𝕜] [Ring R] [AddCommGroup M]
-    [Algebra 𝕜 R] [Module R M] [Module Rᵐᵒᵖ M] [SMulCommClass R Rᵐᵒᵖ M] [Module 𝕜 M]
-    [IsScalarTower 𝕜 R M] [IsScalarTower 𝕜 Rᵐᵒᵖ M] [TopologicalRing R] [TopologicalAddGroup M]
-    [ContinuousSMul R M] [ContinuousSMul Rᵐᵒᵖ M] (x : tsze R M)
+theorem hasSum_snd_expSeries_of_smul_comm (x : tsze R M)
     (hx : MulOpposite.op x.fst • x.snd = x.fst • x.snd) {e : R}
     (h : HasSum (fun n => expSeries 𝕜 R n fun _ => x.fst) e) :
     HasSum (fun n => snd (expSeries 𝕜 (tsze R M) n fun _ => x)) (e • x.snd) := by
@@ -81,39 +96,28 @@ theorem hasSum_snd_expSeries_of_smul_comm [Field 𝕜] [CharZero 𝕜] [Ring R] 
 #align triv_sq_zero_ext.has_sum_snd_exp_series_of_smul_comm TrivSqZeroExt.hasSum_snd_expSeries_of_smul_comm
 
 /-- If `exp R x.fst` converges to `e` then `exp R x` converges to `inl e + inr (e • x.snd)`. -/
-theorem hasSum_expSeries_of_smul_comm [Field 𝕜] [CharZero 𝕜] [Ring R] [AddCommGroup M] [Algebra 𝕜 R]
-    [Module R M] [Module Rᵐᵒᵖ M] [SMulCommClass R Rᵐᵒᵖ M] [Module 𝕜 M] [IsScalarTower 𝕜 R M]
-    [IsScalarTower 𝕜 Rᵐᵒᵖ M] [TopologicalRing R] [TopologicalAddGroup M] [ContinuousSMul R M]
-    [ContinuousSMul Rᵐᵒᵖ M] (x : tsze R M) (hx : MulOpposite.op x.fst • x.snd = x.fst • x.snd)
+theorem hasSum_expSeries_of_smul_comm
+    (x : tsze R M) (hx : MulOpposite.op x.fst • x.snd = x.fst • x.snd)
     {e : R} (h : HasSum (fun n => expSeries 𝕜 R n fun _ => x.fst) e) :
     HasSum (fun n => expSeries 𝕜 (tsze R M) n fun _ => x) (inl e + inr (e • x.snd)) := by
   simpa only [inl_fst_add_inr_snd_eq] using
-    (hasSum_inl _ <| hasSum_fst_expSeries 𝕜 x h).add
+    (hasSum_inl _ <| (hasSum_fst_expSeries 𝕜 x).mpr h).add
       (hasSum_inr _ <| hasSum_snd_expSeries_of_smul_comm 𝕜 x hx h)
 #align triv_sq_zero_ext.has_sum_exp_series_of_smul_comm TrivSqZeroExt.hasSum_expSeries_of_smul_comm
 
-end Topology
-
-section NormedRing
-
-variable [IsROrC 𝕜] [NormedRing R] [AddCommGroup M]
-
-variable [NormedAlgebra 𝕜 R] [Module R M] [Module Rᵐᵒᵖ M] [SMulCommClass R Rᵐᵒᵖ M]
-
-variable [Module 𝕜 M] [IsScalarTower 𝕜 R M] [IsScalarTower 𝕜 Rᵐᵒᵖ M]
-
-variable [TopologicalSpace M] [TopologicalRing R]
-
-variable [TopologicalAddGroup M] [ContinuousSMul R M] [ContinuousSMul Rᵐᵒᵖ M]
-
-variable [CompleteSpace R] [T2Space R] [T2Space M]
+variable [T2Space R] [T2Space M]
 
 theorem exp_def_of_smul_comm (x : tsze R M) (hx : MulOpposite.op x.fst • x.snd = x.fst • x.snd) :
     exp 𝕜 x = inl (exp 𝕜 x.fst) + inr (exp 𝕜 x.fst • x.snd) := by
   simp_rw [exp, FormalMultilinearSeries.sum]
-  refine' (hasSum_expSeries_of_smul_comm 𝕜 x hx _).tsum_eq
-  exact expSeries_hasSum_exp _
-#align triv_sq_zero_ext.exp_def_of_smul_comm TrivSqZeroExt.exp_def_of_smul_comm
+  by_cases h : Summable (fun (n : ℕ) => (expSeries 𝕜 R n) fun x_1 ↦ fst x)
+  · refine (hasSum_expSeries_of_smul_comm 𝕜 x hx ?_).tsum_eq
+    exact h.hasSum
+  · rw [tsum_eq_zero_of_not_summable h, zero_smul, inr_zero, inl_zero, zero_add,
+      tsum_eq_zero_of_not_summable]
+    rw [←summable_fst_expSeries] at h
+    refine mt ?_ h
+    exact (Summable.map · (TrivSqZeroExt.fstHom 𝕜 R M).toLinearMap continuous_fst)
 
 @[simp]
 theorem exp_inl (x : R) : exp 𝕜 (inl x : tsze R M) = inl (exp 𝕜 x) := by
@@ -127,21 +131,16 @@ theorem exp_inr (m : M) : exp 𝕜 (inr m : tsze R M) = 1 + inr m := by
   · rw [snd_inr, fst_inr, MulOpposite.op_zero, zero_smul, zero_smul]
 #align triv_sq_zero_ext.exp_inr TrivSqZeroExt.exp_inr
 
-end NormedRing
+end Ring
 
-section NormedCommRing
+section CommRing
+variable [Field 𝕜] [CharZero 𝕜] [CommRing R] [AddCommGroup M]
+  [Algebra 𝕜 R] [Module 𝕜 M] [Module R M] [Module Rᵐᵒᵖ M]
+  [IsCentralScalar R M] [IsScalarTower 𝕜 R M]
+  [TopologicalSpace R] [TopologicalSpace M]
+  [TopologicalRing R] [TopologicalAddGroup M] [ContinuousSMul R M] [ContinuousSMul Rᵐᵒᵖ M]
 
-variable [IsROrC 𝕜] [NormedCommRing R] [AddCommGroup M]
-
-variable [NormedAlgebra 𝕜 R] [Module R M] [Module Rᵐᵒᵖ M] [IsCentralScalar R M]
-
-variable [Module 𝕜 M] [IsScalarTower 𝕜 R M]
-
-variable [TopologicalSpace M] [TopologicalRing R]
-
-variable [TopologicalAddGroup M] [ContinuousSMul R M]
-
-variable [CompleteSpace R] [T2Space R] [T2Space M]
+variable [T2Space R] [T2Space M]
 
 theorem exp_def (x : tsze R M) : exp 𝕜 x = inl (exp 𝕜 x.fst) + inr (exp 𝕜 x.fst • x.snd) :=
   exp_def_of_smul_comm 𝕜 x (op_smul_eq_smul _ _)
@@ -164,21 +163,16 @@ theorem eq_smul_exp_of_invertible (x : tsze R M) [Invertible x.fst] :
     smul_smul, mul_invOf_self, one_smul, inl_fst_add_inr_snd_eq]
 #align triv_sq_zero_ext.eq_smul_exp_of_invertible TrivSqZeroExt.eq_smul_exp_of_invertible
 
-end NormedCommRing
+end CommRing
 
-section NormedField
+section Field
+variable [Field 𝕜] [CharZero 𝕜] [Field R] [AddCommGroup M]
+  [Algebra 𝕜 R] [Module 𝕜 M] [Module R M] [Module Rᵐᵒᵖ M]
+  [IsCentralScalar R M] [IsScalarTower 𝕜 R M]
+  [TopologicalSpace R] [TopologicalSpace M]
+  [TopologicalRing R] [TopologicalAddGroup M] [ContinuousSMul R M] [ContinuousSMul Rᵐᵒᵖ M]
 
-variable [IsROrC 𝕜] [NormedField R] [AddCommGroup M]
-
-variable [NormedAlgebra 𝕜 R] [Module R M] [Module Rᵐᵒᵖ M] [IsCentralScalar R M]
-
-variable [Module 𝕜 M] [IsScalarTower 𝕜 R M]
-
-variable [TopologicalSpace M] [TopologicalRing R]
-
-variable [TopologicalAddGroup M] [ContinuousSMul R M]
-
-variable [CompleteSpace R] [T2Space R] [T2Space M]
+variable [T2Space R] [T2Space M]
 
 /-- More convenient version of `TrivSqZeroExt.eq_smul_exp_of_invertible` for when `R` is a
 field. -/
@@ -188,6 +182,8 @@ theorem eq_smul_exp_of_ne_zero (x : tsze R M) (hx : x.fst ≠ 0) :
   eq_smul_exp_of_invertible _ _
 #align triv_sq_zero_ext.eq_smul_exp_of_ne_zero TrivSqZeroExt.eq_smul_exp_of_ne_zero
 
-end NormedField
+end Field
+
+end Topology
 
 end TrivSqZeroExt


### PR DESCRIPTION
These results are still true even if the exponential does not converge, because in those cases all the terms are zero.

The `hasSum_fst_expSeries` lemma has been dropped because it's a trivial consequence of the new `fst_expSeries`; the fact that the series are elementwise equal.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
