### PR TITLE
[Merged by Bors] - feat (RingTheory/Ideal/QuotientOperations) : remove commutativity assumption

### DIFF
--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -2108,6 +2108,10 @@ lemma _root_.Pi.ker_ringHom {ι : Type*} {R : ι → Type*} [∀ i, Semiring (R 
   ext x
   simp [mem_ker, Ideal.mem_iInf, Function.funext_iff]
 
+@[simp]
+theorem ker_rangeSRestrict (f : R →+* S) : ker f.rangeSRestrict = ker f :=
+  Ideal.ext fun _ ↦ Subtype.ext_iff
+
 end Semiring
 
 section Ring

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -90,11 +90,7 @@ noncomputable def quotientKerEquivOfSurjective (hf : Function.Surjective f) : R 
 
 /-- The **first isomorphism theorem** for commutative rings (Semiring target). -/
 noncomputable def quotientKerEquivRangeS (f : R →+* S) : R ⧸ ker f ≃+* f.rangeS :=
-  (Ideal.quotEquivOfEq (by
-    ext r
-    simp only [mem_ker]
-    rw [← Subtype.coe_inj, coe_rangeSRestrict, ZeroMemClass.coe_zero]
-    )).trans <|
+  (Ideal.quotEquivOfEq f.ker_rangeSRestrict.symm).trans <|
   quotientKerEquivOfSurjective f.rangeSRestrict_surjective
 
 variable {S : Type v} [Ring S] (f : R →+* S)

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -60,6 +60,7 @@ theorem kerLift_injective [Semiring S] (f : R →+* S) : Function.Injective (ker
 
 variable {f}
 
+/-- The **first isomorphism theorem for commutative rings**, computable version. -/
 def quotientKerEquivOfRightInverse {g : S → R} (hf : Function.RightInverse g f) :
     R ⧸ ker f ≃+* S :=
   { kerLift f with

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -14,6 +14,7 @@ import Mathlib.RingTheory.Ideal.Quotient
 ## Main results:
 
  - `quotientKerEquivRange` : the **first isomorphism theorem** for commutative rings.
+ - `quotientKerEquivRangeS` : the **first isomorphism theorem** for a morphism from a commutative ring to a semiring.
  - `Ideal.quotientInfRingEquivPiQuotient`: the **Chinese Remainder Theorem**, version for coprime
    ideals (see also `ZMod.prodEquivPi` in `Data.ZMod.Quotient` for elementary versions about
    `ZMod`).

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -14,7 +14,8 @@ import Mathlib.RingTheory.Ideal.Quotient
 ## Main results:
 
  - `quotientKerEquivRange` : the **first isomorphism theorem** for commutative rings.
- - `quotientKerEquivRangeS` : the **first isomorphism theorem** for a morphism from a commutative ring to a semiring.
+ - `quotientKerEquivRangeS` : the **first isomorphism theorem**
+  for a morphism from a commutative ring to a semiring.
  - `Ideal.quotientInfRingEquivPiQuotient`: the **Chinese Remainder Theorem**, version for coprime
    ideals (see also `ZMod.prodEquivPi` in `Data.ZMod.Quotient` for elementary versions about
    `ZMod`).

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -71,6 +71,7 @@ def quotientKerEquivOfRightInverse {g : S → R} (hf : Function.RightInverse g f
       simp only [Submodule.Quotient.quot_mk_eq_mk, Ideal.Quotient.mk_eq_mk, kerLift_mk,
         Function.comp_apply, hf (f x)]
     right_inv := hf }
+#align ring_hom.quotient_ker_equiv_of_right_inverse RingHom.quotientKerEquivOfRightInverse
 
 @[simp]
 theorem quotientKerEquivOfRightInverse.apply {g : S → R} (hf : Function.RightInverse g f)
@@ -89,14 +90,14 @@ noncomputable def quotientKerEquivOfSurjective (hf : Function.Surjective f) : R 
   quotientKerEquivOfRightInverse (Classical.choose_spec hf.hasRightInverse)
 #align ring_hom.quotient_ker_equiv_of_surjective RingHom.quotientKerEquivOfSurjective
 
-/-- The **first isomorphism theorem** for commutative rings (Semiring target). -/
+/-- The **first isomorphism theorem** for commutative rings (`RingHom.rangeS` version). -/
 noncomputable def quotientKerEquivRangeS (f : R →+* S) : R ⧸ ker f ≃+* f.rangeS :=
   (Ideal.quotEquivOfEq f.ker_rangeSRestrict.symm).trans <|
   quotientKerEquivOfSurjective f.rangeSRestrict_surjective
 
 variable {S : Type v} [Ring S] (f : R →+* S)
 
-/-- The **first isomorphism theorem** for commutative rings. -/
+/-- The **first isomorphism theorem** for commutative rings (`RingHom.range` version). -/
 noncomputable def quotientKerEquivRange (f : R →+* S) : R ⧸ ker f ≃+* f.range :=
   (Ideal.quotEquivOfEq f.ker_rangeRestrict.symm).trans <|
     quotientKerEquivOfSurjective f.rangeRestrict_surjective


### PR DESCRIPTION
This PR removes commutativity instances on the target of lift lemmas as well as some equivalences.

It adds two short lemmas:
* `RingHom.quotientKerEquivRangeS`, a version of the first isomorphism theorem
when the target is only a `Semiring`
* `RingHom.ker_rangeSRestrict `, a version of `RingHom.ker_rangeRestrict` when the target is only a `Semiring`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

There is almost no modification in the proofs, except for that of `RingHom.kerLift_injective` whose proof required subtraction. However that lemma was a weaker version of `RingHom.lift_injective_of_ker_le_ideal` and it is now is deduced from it.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
