### PR TITLE
[Merged by Bors] - chore: Move `a ^ m = b ^ n ↔ ∃ c, a = c ^ n ∧ b = c ^ m`

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Bitwise.lean
+++ b/Mathlib/Algebra/GroupWithZero/Bitwise.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
+import Mathlib.Algebra.GroupPower.Lemmas
 import Mathlib.Algebra.GroupWithZero.Power
 import Mathlib.Data.Int.Bitwise
 

--- a/Mathlib/Algebra/GroupWithZero/Power.lean
+++ b/Mathlib/Algebra/GroupWithZero/Power.lean
@@ -3,9 +3,9 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import Mathlib.Algebra.GroupPower.Lemmas
-import Mathlib.Util.AssertExists
-import Mathlib.Data.Int.GCD
+import Mathlib.Algebra.GroupPower.Ring
+import Mathlib.Algebra.GroupWithZero.Units.Lemmas
+import Mathlib.Data.Int.Order.Basic
 
 #align_import algebra.group_with_zero.power from "leanprover-community/mathlib"@"46a64b5b4268c594af770c44d9e502afc6a515cb"
 
@@ -172,24 +172,6 @@ theorem zpow_neg_mul_zpow_self (n : ℤ) {x : G₀} (h : x ≠ 0) : x ^ (-n) * x
   exact inv_mul_cancel (zpow_ne_zero n h)
 #align zpow_neg_mul_zpow_self zpow_neg_mul_zpow_self
 
-lemma Commute.exists_eq_pow_of_pow_eq_pow_of_coprime {a b : G₀} (h : Commute a b) {m n : ℕ}
-    (hmn : m.Coprime n) (hab : a ^ m = b ^ n) :
-    ∃ c, a = c ^ n ∧ b = c ^ m := by
-  by_cases hn : n = 0; · aesop
-  by_cases hm : m = 0; · aesop
-  by_cases hb : b = 0; exact ⟨0, by aesop⟩
-  by_cases ha : a = 0; exact ⟨0, by have := hab.symm; aesop⟩
-  use a ^ (Nat.gcdB m n) * b ^ (Nat.gcdA m n)
-  constructor
-  all_goals
-    refine (pow_one _).symm.trans ?_
-    conv_lhs => rw [← zpow_ofNat, ← hmn, Nat.gcd_eq_gcd_ab]
-    simp only [zpow_add₀ ha, zpow_add₀ hb, ← zpow_ofNat, (h.zpow_zpow₀ _ _).mul_zpow, ← zpow_mul,
-      mul_comm (Nat.gcdB m n), mul_comm (Nat.gcdA m n)]
-    simp only [zpow_mul, zpow_ofNat, hab]
-    refine ((Commute.pow_pow ?_ _ _).zpow_zpow₀ _ _).symm
-    aesop
-
 end ZPow
 
 section
@@ -202,16 +184,9 @@ theorem div_sq_cancel (a b : G₀) : a ^ 2 * b / a = a * b := by
   rw [sq, mul_assoc, mul_div_cancel_left _ ha]
 #align div_sq_cancel div_sq_cancel
 
-theorem pow_mem_range_pow_of_coprime {m n : ℕ} (hmn : m.Coprime n) (a : G₀) :
-    a ^ m ∈ Set.range (· ^ n : G₀ → G₀) ↔ a ∈ Set.range (· ^ n : G₀ → G₀) := by
-  constructor
-  · intro ⟨x, hx⟩
-    obtain ⟨c, rfl, rfl⟩ := (Commute.all x a).exists_eq_pow_of_pow_eq_pow_of_coprime hmn.symm hx
-    exact ⟨c, rfl⟩
-  · rintro ⟨x, rfl⟩
-    exact ⟨x ^ m, by simp [← pow_mul, mul_comm m n]⟩
-
 end
 
 -- Guard against import creep regression.
 assert_not_exists Int.bitwise_or
+assert_not_exists Set.range
+assert_not_exists Nat.gcdA

--- a/Mathlib/Data/Int/GCD.lean
+++ b/Mathlib/Data/Int/GCD.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Guy Leroy. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sangwoo Jo (aka Jason), Guy Leroy, Johannes Hölzl, Mario Carneiro
 -/
-import Mathlib.Algebra.Group.Commute.Units
 import Mathlib.Algebra.GroupPower.Lemmas
 import Mathlib.Algebra.GroupWithZero.Power
 import Mathlib.Algebra.Ring.Regular
@@ -528,7 +527,8 @@ variable [GroupWithZero α] {a b : α} {m n : ℕ}
 protected lemma Commute.pow_eq_pow_iff_of_coprime (hab : Commute a b) (hmn : m.Coprime n) :
     a ^ m = b ^ n ↔ ∃ c, a = c ^ n ∧ b = c ^ m := by
   refine ⟨fun h ↦ ?_, by rintro ⟨c, rfl, rfl⟩; rw [← pow_mul, ← pow_mul']⟩
-  by_cases hn : n = 0; · aesop
+  by_cases m = 0; · aesop
+  by_cases n = 0; · aesop
   by_cases hb : b = 0; exact ⟨0, by aesop⟩
   by_cases ha : a = 0; exact ⟨0, by have := h.symm; aesop⟩
   refine ⟨a ^ Nat.gcdB m n * b ^ Nat.gcdA m n, ?_, ?_⟩

--- a/Mathlib/Data/Int/GCD.lean
+++ b/Mathlib/Data/Int/GCD.lean
@@ -3,10 +3,12 @@ Copyright (c) 2018 Guy Leroy. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sangwoo Jo (aka Jason), Guy Leroy, Johannes Hölzl, Mario Carneiro
 -/
-import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Algebra.Group.Commute.Units
 import Mathlib.Algebra.GroupPower.Lemmas
+import Mathlib.Algebra.GroupWithZero.Power
 import Mathlib.Algebra.Ring.Regular
 import Mathlib.Data.Int.Dvd.Basic
+import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Order.Bounds.Basic
 
 #align_import data.int.gcd from "leanprover-community/mathlib"@"47a1a73351de8dd6c8d3d32b569c8e434b03ca47"
@@ -517,3 +519,37 @@ theorem pow_gcd_eq_one {M : Type*} [Monoid M] (x : M) {m n : ℕ} (hm : x ^ m = 
   simp only [Nat.gcd_eq_gcd_ab, zpow_add, zpow_mul, hm, hn, one_zpow, one_mul]
 #align pow_gcd_eq_one pow_gcd_eq_one
 #align gcd_nsmul_eq_zero gcd_nsmul_eq_zero
+
+variable {α : Type*}
+
+section GroupWithZero
+variable [GroupWithZero α] {a b : α} {m n : ℕ}
+
+protected lemma Commute.pow_eq_pow_iff_of_coprime (hab : Commute a b) (hmn : m.Coprime n) :
+    a ^ m = b ^ n ↔ ∃ c, a = c ^ n ∧ b = c ^ m := by
+  refine ⟨fun h ↦ ?_, by rintro ⟨c, rfl, rfl⟩; rw [← pow_mul, ← pow_mul']⟩
+  by_cases hn : n = 0; · aesop
+  by_cases hb : b = 0; exact ⟨0, by aesop⟩
+  by_cases ha : a = 0; exact ⟨0, by have := h.symm; aesop⟩
+  refine ⟨a ^ Nat.gcdB m n * b ^ Nat.gcdA m n, ?_, ?_⟩
+  all_goals
+    refine (pow_one _).symm.trans ?_
+    conv_lhs => rw [← zpow_ofNat, ← hmn, Nat.gcd_eq_gcd_ab]
+    simp only [zpow_add₀ ha, zpow_add₀ hb, ← zpow_ofNat, (hab.zpow_zpow₀ _ _).mul_zpow, ← zpow_mul,
+      mul_comm (Nat.gcdB m n), mul_comm (Nat.gcdA m n)]
+    simp only [zpow_mul, zpow_ofNat, h]
+    exact ((Commute.pow_pow (by aesop) _ _).zpow_zpow₀ _ _).symm
+
+end GroupWithZero
+
+section CommGroupWithZero
+variable [CommGroupWithZero α] {a b : α} {m n : ℕ}
+
+lemma pow_eq_pow_iff_of_coprime (hmn : m.Coprime n) : a ^ m = b ^ n ↔ ∃ c, a = c ^ n ∧ b = c ^ m :=
+  (Commute.all _ _).pow_eq_pow_iff_of_coprime hmn
+
+lemma pow_mem_range_pow_of_coprime (hmn : m.Coprime n) (a : α) :
+    a ^ m ∈ Set.range (· ^ n : α → α) ↔ a ∈ Set.range (· ^ n : α → α) := by
+  simp [pow_eq_pow_iff_of_coprime hmn.symm]; aesop
+
+end CommGroupWithZero

--- a/Mathlib/NumberTheory/NumberField/Norm.lean
+++ b/Mathlib/NumberTheory/NumberField/Norm.lean
@@ -101,6 +101,7 @@ theorem norm_norm [IsSeparable K L] [Algebra F L] [IsSeparable F L] [FiniteDimen
 
 variable {F}
 
+set_option synthInstance.maxHeartbeats 60000 in
 theorem isUnit_norm [CharZero K] {x : 𝓞 F} : IsUnit (norm K x) ↔ IsUnit x := by
   letI : Algebra K (AlgebraicClosure K) := AlgebraicClosure.instAlgebra K
   let L := normalClosure K F (AlgebraicClosure F)


### PR DESCRIPTION
Those lemmas were very recently added in #9397. Also make them iffs and golf.

Part of #9411


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
