### PR TITLE
[Merged by Bors] - feat: add trans assoc type lemmas for `(Partial)Equiv` and `(Partial)Homeomorph`

### DIFF
--- a/Mathlib/Logic/Equiv/PartialEquiv.lean
+++ b/Mathlib/Logic/Equiv/PartialEquiv.lean
@@ -788,22 +788,6 @@ theorem mem_symm_trans_source {e' : PartialEquiv α γ} {x : α} (he : x ∈ e.s
   ⟨e.mapsTo he, by rwa [mem_preimage, PartialEquiv.symm_symm, e.left_inv he]⟩
 #align local_equiv.mem_symm_trans_source PartialEquiv.mem_symm_trans_source
 
-/-- Postcompose a partial equivalence with an equivalence.
-We modify the source and target to have better definitional behavior. -/
-@[simps!]
-def transEquiv (e' : β ≃ γ) : PartialEquiv α γ :=
-  (e.trans e'.toPartialEquiv).copy _ rfl _ rfl e.source (inter_univ _) (e'.symm ⁻¹' e.target)
-    (univ_inter _)
-#align local_equiv.trans_equiv PartialEquiv.transEquiv
-#align local_equiv.trans_equiv_source PartialEquiv.transEquiv_source
-#align local_equiv.trans_equiv_apply PartialEquiv.transEquiv_apply
-#align local_equiv.trans_equiv_target PartialEquiv.transEquiv_target
-#align local_equiv.trans_equiv_symm_apply PartialEquiv.transEquiv_symm_apply
-
-theorem transEquiv_eq_trans (e' : β ≃ γ) : e.transEquiv e' = e.trans e'.toPartialEquiv :=
-  copy_eq ..
-#align local_equiv.trans_equiv_eq_trans PartialEquiv.transEquiv_eq_trans
-
 /-- `EqOnSource e e'` means that `e` and `e'` have the same source, and coincide there. Then `e`
 and `e'` should really be considered the same partial equiv. -/
 def EqOnSource (e e' : PartialEquiv α β) : Prop :=
@@ -1152,3 +1136,34 @@ theorem trans_transPartialEquiv (e : α ≃ β) (e' : β ≃ γ) (f'' : PartialE
   simp only [transPartialEquiv_eq_trans, PartialEquiv.trans_assoc, trans_toPartialEquiv]
 
 end Equiv
+
+namespace PartialEquiv
+
+/-- Postcompose a partial equivalence with an equivalence.
+We modify the source and target to have better definitional behavior. -/
+@[simps!]
+def transEquiv (e : PartialEquiv α β) (e' : β ≃ γ) : PartialEquiv α γ :=
+  (e.trans e'.toPartialEquiv).copy _ rfl _ rfl e.source (inter_univ _) (e'.symm ⁻¹' e.target)
+    (univ_inter _)
+#align local_equiv.trans_equiv PartialEquiv.transEquiv
+#align local_equiv.trans_equiv_source PartialEquiv.transEquiv_source
+#align local_equiv.trans_equiv_apply PartialEquiv.transEquiv_apply
+#align local_equiv.trans_equiv_target PartialEquiv.transEquiv_target
+#align local_equiv.trans_equiv_symm_apply PartialEquiv.transEquiv_symm_apply
+
+theorem transEquiv_eq_trans (e : PartialEquiv α β) (e' : β ≃ γ) :
+    e.transEquiv e' = e.trans e'.toPartialEquiv :=
+  copy_eq ..
+#align local_equiv.trans_equiv_eq_trans PartialEquiv.transEquiv_eq_trans
+
+@[simp, mfld_simps]
+theorem transEquiv_transEquiv (e : PartialEquiv α β) (f' : β ≃ γ) (f'' : γ ≃ δ) :
+    (e.transEquiv f').transEquiv f'' = e.transEquiv (f'.trans f'') := by
+  simp only [transEquiv_eq_trans, trans_assoc, Equiv.trans_toPartialEquiv]
+
+@[simp, mfld_simps]
+theorem trans_transEquiv (e : PartialEquiv α β) (e' : PartialEquiv β γ) (f'' : γ ≃ δ) :
+    (e.trans e').transEquiv f'' = e.trans (e'.transEquiv f'') := by
+  simp only [transEquiv_eq_trans, trans_assoc, Equiv.trans_toPartialEquiv]
+
+end PartialEquiv

--- a/Mathlib/Logic/Equiv/PartialEquiv.lean
+++ b/Mathlib/Logic/Equiv/PartialEquiv.lean
@@ -1142,8 +1142,8 @@ namespace PartialEquiv
 /-- Postcompose a partial equivalence with an equivalence.
 We modify the source and target to have better definitional behavior. -/
 @[simps!]
-def transEquiv (e : PartialEquiv α β) (e' : β ≃ γ) : PartialEquiv α γ :=
-  (e.trans e'.toPartialEquiv).copy _ rfl _ rfl e.source (inter_univ _) (e'.symm ⁻¹' e.target)
+def transEquiv (e : PartialEquiv α β) (f' : β ≃ γ) : PartialEquiv α γ :=
+  (e.trans f'.toPartialEquiv).copy _ rfl _ rfl e.source (inter_univ _) (f'.symm ⁻¹' e.target)
     (univ_inter _)
 #align local_equiv.trans_equiv PartialEquiv.transEquiv
 #align local_equiv.trans_equiv_source PartialEquiv.transEquiv_source

--- a/Mathlib/Logic/Equiv/PartialEquiv.lean
+++ b/Mathlib/Logic/Equiv/PartialEquiv.lean
@@ -804,23 +804,6 @@ theorem transEquiv_eq_trans (e' : β ≃ γ) : e.transEquiv e' = e.trans e'.toPa
   copy_eq ..
 #align local_equiv.trans_equiv_eq_trans PartialEquiv.transEquiv_eq_trans
 
-/-- Precompose a partial equivalence with an equivalence.
-We modify the source and target to have better definitional behavior. -/
-@[simps!]
-def _root_.Equiv.transPartialEquiv (e : α ≃ β) : PartialEquiv α γ :=
-  (e.toPartialEquiv.trans e').copy _ rfl _ rfl (e ⁻¹' e'.source) (univ_inter _) e'.target
-    (inter_univ _)
-#align equiv.trans_local_equiv Equiv.transPartialEquiv
-#align equiv.trans_local_equiv_target Equiv.transPartialEquiv_target
-#align equiv.trans_local_equiv_apply Equiv.transPartialEquiv_apply
-#align equiv.trans_local_equiv_source Equiv.transPartialEquiv_source
-#align equiv.trans_local_equiv_symm_apply Equiv.transPartialEquiv_symm_apply
-
-theorem _root_.Equiv.transPartialEquiv_eq_trans (e : α ≃ β) :
-    e.transPartialEquiv e' = e.toPartialEquiv.trans e' :=
-  copy_eq ..
-#align equiv.trans_local_equiv_eq_trans Equiv.transPartialEquiv_eq_trans
-
 /-- `EqOnSource e e'` means that `e` and `e'` have the same source, and coincide there. Then `e`
 and `e'` should really be considered the same partial equiv. -/
 def EqOnSource (e e' : PartialEquiv α β) : Prop :=
@@ -907,7 +890,7 @@ theorem self_trans_symm : e.trans e.symm ≈ ofSet e.source := by
 
 /-- Composition of the inverse of a partial equivalence and this partial equivalence is equivalent
 to the restriction of the identity to the target. -/
-theorem symm_trans_self : e.symm.trans e ≈ PartialEquiv.ofSet e.target :=
+theorem symm_trans_self : e.symm.trans e ≈ ofSet e.target :=
   self_trans_symm e.symm
 #align local_equiv.symm_trans_self PartialEquiv.symm_trans_self
 
@@ -1140,5 +1123,32 @@ theorem trans_toPartialEquiv :
   PartialEquiv.ext (fun x => rfl) (fun x => rfl)
     (by simp [PartialEquiv.trans_source, Equiv.toPartialEquiv])
 #align equiv.trans_to_local_equiv Equiv.trans_toPartialEquiv
+
+/-- Precompose a partial equivalence with an equivalence.
+We modify the source and target to have better definitional behavior. -/
+@[simps!]
+def transPartialEquiv (e : α ≃ β) (f' : PartialEquiv β γ) : PartialEquiv α γ :=
+  (e.toPartialEquiv.trans f').copy _ rfl _ rfl (e ⁻¹' f'.source) (univ_inter _) f'.target
+    (inter_univ _)
+#align equiv.trans_local_equiv Equiv.transPartialEquiv
+#align equiv.trans_local_equiv_target Equiv.transPartialEquiv_target
+#align equiv.trans_local_equiv_apply Equiv.transPartialEquiv_apply
+#align equiv.trans_local_equiv_source Equiv.transPartialEquiv_source
+#align equiv.trans_local_equiv_symm_apply Equiv.transPartialEquiv_symm_apply
+
+theorem transPartialEquiv_eq_trans (e : α ≃ β) (f' : PartialEquiv β γ) :
+    e.transPartialEquiv f' = e.toPartialEquiv.trans f' :=
+  PartialEquiv.copy_eq ..
+#align equiv.trans_local_equiv_eq_trans Equiv.transPartialEquiv_eq_trans
+
+@[simp, mfld_simps]
+theorem transPartialEquiv_trans (e : α ≃ β) (f' : PartialEquiv β γ) (f'' : PartialEquiv γ δ) :
+    (e.transPartialEquiv f').trans f'' = e.transPartialEquiv (f'.trans f'') := by
+  simp only [transPartialEquiv_eq_trans, PartialEquiv.trans_assoc]
+
+@[simp, mfld_simps]
+theorem trans_transPartialEquiv (e : α ≃ β) (e' : β ≃ γ) (f'' : PartialEquiv γ δ) :
+    (e.trans e').transPartialEquiv f'' = e.transPartialEquiv (e'.transPartialEquiv f'') := by
+  simp only [transPartialEquiv_eq_trans, PartialEquiv.trans_assoc, trans_toPartialEquiv]
 
 end Equiv

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -925,38 +925,6 @@ theorem restr_trans (s : Set α) : (e.restr s).trans e' = (e.trans e').restr s :
     PartialEquiv.restr_trans e.toPartialEquiv e'.toPartialEquiv (interior s)
 #align local_homeomorph.restr_trans PartialHomeomorph.restr_trans
 
-/-- Postcompose a partial homeomorphism with a homeomorphism.
-We modify the source and target to have better definitional behavior. -/
-@[simps! (config := .asFn)]
-def transHomeomorph (e' : β ≃ₜ γ) : PartialHomeomorph α γ where
-  toPartialEquiv := e.toPartialEquiv.transEquiv e'.toEquiv
-  open_source := e.open_source
-  open_target := e.open_target.preimage e'.symm.continuous
-  continuousOn_toFun := e'.continuous.comp_continuousOn e.continuousOn
-  continuousOn_invFun := e.symm.continuousOn.comp e'.symm.continuous.continuousOn fun _ => id
-#align local_homeomorph.trans_homeomorph PartialHomeomorph.transHomeomorph
-
-theorem transHomeomorph_eq_trans (e' : β ≃ₜ γ) :
-    e.transHomeomorph e' = e.trans e'.toPartialHomeomorph :=
-  toPartialEquiv_injective <| PartialEquiv.transEquiv_eq_trans _ _
-#align local_homeomorph.trans_equiv_eq_trans PartialHomeomorph.transHomeomorph_eq_trans
-
-/-- Precompose a partial homeomorphism with a homeomorphism.
-We modify the source and target to have better definitional behavior. -/
-@[simps! (config := .asFn)]
-def _root_.Homeomorph.transPartialHomeomorph (e : α ≃ₜ β) : PartialHomeomorph α γ where
-  toPartialEquiv := e.toEquiv.transPartialEquiv e'.toPartialEquiv
-  open_source := e'.open_source.preimage e.continuous
-  open_target := e'.open_target
-  continuousOn_toFun := e'.continuousOn.comp e.continuous.continuousOn fun _ => id
-  continuousOn_invFun := e.symm.continuous.comp_continuousOn e'.symm.continuousOn
-#align homeomorph.trans_local_homeomorph Homeomorph.transPartialHomeomorph
-
-theorem _root_.Homeomorph.transPartialHomeomorph_eq_trans (e : α ≃ₜ β) :
-    e.transPartialHomeomorph e' = e.toPartialHomeomorph.trans e' :=
-  toPartialEquiv_injective <| Equiv.transPartialEquiv_eq_trans _ _
-#align homeomorph.trans_local_homeomorph_eq_trans Homeomorph.transPartialHomeomorph_eq_trans
-
 /-- `EqOnSource e e'` means that `e` and `e'` have the same source, and coincide there. They
 should really be considered the same partial equivalence. -/
 def EqOnSource (e e' : PartialHomeomorph α β) : Prop :=
@@ -1335,6 +1303,35 @@ theorem trans_toPartialHomeomorph :
   PartialHomeomorph.toPartialEquiv_injective <| Equiv.trans_toPartialEquiv _ _
 #align homeomorph.trans_to_local_homeomorph Homeomorph.trans_toPartialHomeomorph
 
+/-- Precompose a partial homeomorphism with a homeomorphism.
+We modify the source and target to have better definitional behavior. -/
+@[simps! (config := .asFn)]
+def transPartialHomeomorph (e : α ≃ₜ β) (f' : PartialHomeomorph β γ) : PartialHomeomorph α γ where
+  toPartialEquiv := e.toEquiv.transPartialEquiv f'.toPartialEquiv
+  open_source := f'.open_source.preimage e.continuous
+  open_target := f'.open_target
+  continuousOn_toFun := f'.continuousOn.comp e.continuous.continuousOn fun _ => id
+  continuousOn_invFun := e.symm.continuous.comp_continuousOn f'.symm.continuousOn
+#align homeomorph.trans_local_homeomorph Homeomorph.transPartialHomeomorph
+
+theorem transPartialHomeomorph_eq_trans (e : α ≃ₜ β) (f' : PartialHomeomorph β γ) :
+    e.transPartialHomeomorph f' = e.toPartialHomeomorph.trans f' :=
+  PartialHomeomorph.toPartialEquiv_injective <| Equiv.transPartialEquiv_eq_trans _ _
+#align homeomorph.trans_local_homeomorph_eq_trans Homeomorph.transPartialHomeomorph_eq_trans
+
+@[simp, mfld_simps]
+theorem transPartialHomeomorph_trans (e : α ≃ₜ β) (f : PartialHomeomorph β γ)
+    (f' : PartialHomeomorph γ δ) :
+    (e.transPartialHomeomorph f).trans f' = e.transPartialHomeomorph (f.trans f') := by
+  simp only [transPartialHomeomorph_eq_trans, PartialHomeomorph.trans_assoc]
+
+@[simp, mfld_simps]
+theorem trans_transPartialHomeomorph (e : α ≃ₜ β) (e' : β ≃ₜ γ) (f'' : PartialHomeomorph γ δ) :
+    (e.trans e').transPartialHomeomorph f'' =
+      e.transPartialHomeomorph (e'.transPartialHomeomorph f'') := by
+  simp only [transPartialHomeomorph_eq_trans, PartialHomeomorph.trans_assoc,
+    trans_toPartialHomeomorph]
+
 end Homeomorph
 
 namespace OpenEmbedding
@@ -1393,6 +1390,33 @@ theorem localHomeomorphSubtypeCoe_target : s.localHomeomorphSubtypeCoe.target = 
 end TopologicalSpace.Opens
 
 namespace PartialHomeomorph
+
+/-- Postcompose a partial homeomorphism with a homeomorphism.
+We modify the source and target to have better definitional behavior. -/
+@[simps! (config := .asFn)]
+def transHomeomorph (e : PartialHomeomorph α β) (f' : β ≃ₜ γ) : PartialHomeomorph α γ where
+  toPartialEquiv := e.toPartialEquiv.transEquiv f'.toEquiv
+  open_source := e.open_source
+  open_target := e.open_target.preimage f'.symm.continuous
+  continuousOn_toFun := f'.continuous.comp_continuousOn e.continuousOn
+  continuousOn_invFun := e.symm.continuousOn.comp f'.symm.continuous.continuousOn fun _ => id
+#align local_homeomorph.trans_homeomorph PartialHomeomorph.transHomeomorph
+
+theorem transHomeomorph_eq_trans (e : PartialHomeomorph α β) (f' : β ≃ₜ γ) :
+    e.transHomeomorph f' = e.trans f'.toPartialHomeomorph :=
+  toPartialEquiv_injective <| PartialEquiv.transEquiv_eq_trans _ _
+#align local_homeomorph.trans_equiv_eq_trans PartialHomeomorph.transHomeomorph_eq_trans
+
+@[simp, mfld_simps]
+theorem transHomeomorph_transHomeomorph (e : PartialHomeomorph α β) (f' : β ≃ₜ γ) (f'' : γ ≃ₜ δ) :
+    (e.transHomeomorph f').transHomeomorph f'' = e.transHomeomorph (f'.trans f'') := by
+  simp only [transHomeomorph_eq_trans, trans_assoc, Homeomorph.trans_toPartialHomeomorph]
+
+@[simp, mfld_simps]
+theorem trans_transHomeomorph (e : PartialHomeomorph α β) (e' : PartialHomeomorph β γ)
+    (f'' : γ ≃ₜ δ) :
+    (e.trans e').transHomeomorph f'' = e.trans (e'.transHomeomorph f'') := by
+  simp only [transHomeomorph_eq_trans, trans_assoc, Homeomorph.trans_toPartialHomeomorph]
 
 open TopologicalSpace
 


### PR DESCRIPTION
Let `e`s denote `Equiv`s and `f`s denote `PartialEquiv`s. Let `>` denote `Equiv.trans`, `PartialEquiv.trans`, `Equiv.transPartialEquiv`, or `PartialEquiv.transEquiv`. We want to simplify expressions like `e1 > e2 > f3 > f4 > e5 > e6` to `(e1 > e2) > (f3 > f4) > (e5 > e6)`, so that simp lemmas about `Equiv.trans` and `PartialEquiv.trans` may apply. This means adding four lemmas:
1. `e1 > e2 > f3 = (e1 > e2) > f3`
2. `(e1 > f2) > f3 = e1 > (f2 > f3)`
3. (1) with `e` and `f` flipped
4. (2) with `e` and `f` flipped

The definitions `Equiv.transPartialEquiv` and `PartialEquiv.transEquiv` are moved to later in the document, so that they stay together with these lemmas. The argument order of these two definitions has also been reversed so as to match `Equiv.trans` and `PartialEquiv.trans`.

The same is done for `Homeomorph`/`PartialHomeomorph`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
