### PR TITLE
chore: Replace `Function.minimalPeriod (m • ·) a` with `MulAction.period m a`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2190,6 +2190,7 @@ import Mathlib.GroupTheory.GroupAction.Defs
 import Mathlib.GroupTheory.GroupAction.DomAct.ActionHom
 import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 import Mathlib.GroupTheory.GroupAction.Embedding
+import Mathlib.GroupTheory.GroupAction.FixedPoints
 import Mathlib.GroupTheory.GroupAction.FixingSubgroup
 import Mathlib.GroupTheory.GroupAction.Group
 import Mathlib.GroupTheory.GroupAction.Hom

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2189,6 +2189,7 @@ import Mathlib.GroupTheory.GroupAction.Defs
 import Mathlib.GroupTheory.GroupAction.DomAct.ActionHom
 import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 import Mathlib.GroupTheory.GroupAction.Embedding
+import Mathlib.GroupTheory.GroupAction.FixedPoints
 import Mathlib.GroupTheory.GroupAction.FixingSubgroup
 import Mathlib.GroupTheory.GroupAction.Group
 import Mathlib.GroupTheory.GroupAction.Hom

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2195,6 +2195,7 @@ import Mathlib.GroupTheory.GroupAction.Group
 import Mathlib.GroupTheory.GroupAction.Hom
 import Mathlib.GroupTheory.GroupAction.Opposite
 import Mathlib.GroupTheory.GroupAction.Option
+import Mathlib.GroupTheory.GroupAction.Period
 import Mathlib.GroupTheory.GroupAction.Pi
 import Mathlib.GroupTheory.GroupAction.Prod
 import Mathlib.GroupTheory.GroupAction.Quotient

--- a/Mathlib/Data/ZMod/Quotient.lean
+++ b/Mathlib/Data/ZMod/Quotient.lean
@@ -86,26 +86,27 @@ open AddSubgroup AddMonoidHom AddEquiv Function
 
 variable {α β : Type*} [AddGroup α] (a : α) [AddAction α β] (b : β)
 
-/-- The quotient `(ℤ ∙ a) ⧸ (stabilizer b)` is cyclic of order `minimalPeriod (a +ᵥ ·) b`. -/
+/-- The quotient `(ℤ ∙ a) ⧸ (stabilizer b)` is cyclic of order `period a b`. -/
 noncomputable def zmultiplesQuotientStabilizerEquiv :
-    zmultiples a ⧸ stabilizer (zmultiples a) b ≃+ ZMod (minimalPeriod (a +ᵥ ·) b) :=
+    zmultiples a ⧸ stabilizer (zmultiples a) b ≃+ ZMod (period a b) :=
   (ofBijective
-          (map _ (stabilizer (zmultiples a) b) (zmultiplesHom (zmultiples a) ⟨a, mem_zmultiples a⟩)
-            (by
-              rw [zmultiples_le, mem_comap, mem_stabilizer_iff, zmultiplesHom_apply, coe_nat_zsmul]
-              simp_rw [← vadd_iterate]
-              exact isPeriodicPt_minimalPeriod (a +ᵥ ·) b))
-          ⟨by
-            rw [← ker_eq_bot_iff, eq_bot_iff]
-            refine' fun q => induction_on' q fun n hn => _
-            rw [mem_bot, eq_zero_iff, Int.mem_zmultiples_iff, ←
-              zsmul_vadd_eq_iff_minimalPeriod_dvd]
-            exact (eq_zero_iff _).mp hn, fun q =>
-            induction_on' q fun ⟨_, n, rfl⟩ => ⟨n, rfl⟩⟩).symm.trans
-    (Int.quotientZMultiplesNatEquivZMod (minimalPeriod (a +ᵥ ·) b))
+    (map _ (stabilizer (zmultiples a) b) (zmultiplesHom (zmultiples a) ⟨a, mem_zmultiples a⟩)
+      (by
+        rw [zmultiples_le, mem_comap, mem_stabilizer_iff, zmultiplesHom_apply, coe_nat_zsmul]
+        simp only [AddSubmonoidClass.mk_nsmul, AddSubmonoid.mk_vadd, vadd_nsmul_period_fixed]
+      )
+    )
+    ⟨by
+      rw [← ker_eq_bot_iff, eq_bot_iff]
+      refine' fun q => induction_on' q fun n hn => _
+      rw [mem_bot, eq_zero_iff, Int.mem_zmultiples_iff, ←
+        zsmul_vadd_eq_iff_period_dvd]
+      exact (eq_zero_iff _).mp hn, fun q =>
+      induction_on' q fun ⟨_, n, rfl⟩ => ⟨n, rfl⟩⟩).symm.trans
+    (Int.quotientZMultiplesNatEquivZMod (period a b))
 #align add_action.zmultiples_quotient_stabilizer_equiv AddAction.zmultiplesQuotientStabilizerEquiv
 
-theorem zmultiplesQuotientStabilizerEquiv_symm_apply (n : ZMod (minimalPeriod (a +ᵥ ·) b)) :
+theorem zmultiplesQuotientStabilizerEquiv_symm_apply (n : ZMod (period a b)) :
     (zmultiplesQuotientStabilizerEquiv a b).symm n =
       (n : ℤ) • (⟨a, mem_zmultiples a⟩ : zmultiples a) :=
   rfl
@@ -119,27 +120,27 @@ open AddAction Subgroup AddSubgroup Function
 
 variable {α β : Type*} [Group α] (a : α) [MulAction α β] (b : β)
 
-/-- The quotient `(a ^ ℤ) ⧸ (stabilizer b)` is cyclic of order `minimalPeriod ((•) a) b`. -/
+/-- The quotient `(a ^ ℤ) ⧸ (stabilizer b)` is cyclic of order `period a b`. -/
 noncomputable def zpowersQuotientStabilizerEquiv :
-    zpowers a ⧸ stabilizer (zpowers a) b ≃* Multiplicative (ZMod (minimalPeriod (a • ·) b)) :=
+    zpowers a ⧸ stabilizer (zpowers a) b ≃* Multiplicative (ZMod (period a b)) :=
   letI f := zmultiplesQuotientStabilizerEquiv (Additive.ofMul a) b
   AddEquiv.toMultiplicative f
 #align mul_action.zpowers_quotient_stabilizer_equiv MulAction.zpowersQuotientStabilizerEquiv
 
-theorem zpowersQuotientStabilizerEquiv_symm_apply (n : ZMod (minimalPeriod (a • ·) b)) :
+theorem zpowersQuotientStabilizerEquiv_symm_apply (n : ZMod (period a b)) :
     (zpowersQuotientStabilizerEquiv a b).symm n = (⟨a, mem_zpowers a⟩ : zpowers a) ^ (n : ℤ) :=
   rfl
 #align mul_action.zpowers_quotient_stabilizer_equiv_symm_apply MulAction.zpowersQuotientStabilizerEquiv_symm_apply
 
-/-- The orbit `(a ^ ℤ) • b` is a cycle of order `minimalPeriod ((•) a) b`. -/
-noncomputable def orbitZPowersEquiv : orbit (zpowers a) b ≃ ZMod (minimalPeriod (a • ·) b) :=
+/-- The orbit `(a ^ ℤ) • b` is a cycle of order `period a b`. -/
+noncomputable def orbitZPowersEquiv : orbit (zpowers a) b ≃ ZMod (period a b) :=
   (orbitEquivQuotientStabilizer _ b).trans (zpowersQuotientStabilizerEquiv a b).toEquiv
 #align mul_action.orbit_zpowers_equiv MulAction.orbitZPowersEquiv
 
-/-- The orbit `(ℤ • a) +ᵥ b` is a cycle of order `minimalPeriod (a +ᵥ ·) b`. -/
+/-- The orbit `(ℤ • a) +ᵥ b` is a cycle of order `period a b`. -/
 noncomputable def _root_.AddAction.orbitZMultiplesEquiv {α β : Type*} [AddGroup α] (a : α)
     [AddAction α β] (b : β) :
-    AddAction.orbit (zmultiples a) b ≃ ZMod (minimalPeriod (a +ᵥ ·) b) :=
+    AddAction.orbit (zmultiples a) b ≃ ZMod (AddAction.period a b) :=
   (AddAction.orbitEquivQuotientStabilizer (zmultiples a) b).trans
     (zmultiplesQuotientStabilizerEquiv a b).toEquiv
 #align add_action.orbit_zmultiples_equiv AddAction.orbitZMultiplesEquiv
@@ -147,7 +148,7 @@ noncomputable def _root_.AddAction.orbitZMultiplesEquiv {α β : Type*} [AddGrou
 attribute [to_additive existing AddAction.orbitZMultiplesEquiv] orbitZPowersEquiv
 
 @[to_additive orbit_zmultiples_equiv_symm_apply]
-theorem orbitZPowersEquiv_symm_apply (k : ZMod (minimalPeriod (a • ·) b)) :
+theorem orbitZPowersEquiv_symm_apply (k : ZMod (period a b)) :
     (orbitZPowersEquiv a b).symm k =
       (⟨a, mem_zpowers a⟩ : zpowers a) ^ (k : ℤ) • ⟨b, mem_orbit_self b⟩ :=
   rfl
@@ -158,7 +159,7 @@ theorem orbitZPowersEquiv_symm_apply' (k : ℤ) :
     (orbitZPowersEquiv a b).symm k =
       (⟨a, mem_zpowers a⟩ : zpowers a) ^ k • ⟨b, mem_orbit_self b⟩ := by
   rw [orbitZPowersEquiv_symm_apply, ZMod.coe_int_cast]
-  exact Subtype.ext (zpow_smul_mod_minimalPeriod _ _ k)
+  exact Subtype.ext (zpow_smul_mod_period k)
 #align mul_action.orbit_zpowers_equiv_symm_apply' MulAction.orbitZPowersEquiv_symm_apply'
 
 theorem _root_.AddAction.orbitZMultiplesEquiv_symm_apply' {α β : Type*} [AddGroup α] (a : α)
@@ -166,29 +167,39 @@ theorem _root_.AddAction.orbitZMultiplesEquiv_symm_apply' {α β : Type*} [AddGr
     (AddAction.orbitZMultiplesEquiv a b).symm k =
       k • (⟨a, mem_zmultiples a⟩ : zmultiples a) +ᵥ ⟨b, AddAction.mem_orbit_self b⟩ := by
   rw [AddAction.orbit_zmultiples_equiv_symm_apply, ZMod.coe_int_cast]
-  -- porting note: times out without `a b` explicit
-  exact Subtype.ext (zsmul_vadd_mod_minimalPeriod a b k)
+  -- Note: times out without `g` made explicit
+  exact Subtype.ext (AddAction.zsmul_vadd_mod_period (g := a) k)
 #align add_action.orbit_zmultiples_equiv_symm_apply' AddAction.orbitZMultiplesEquiv_symm_apply'
 
 attribute [to_additive existing AddAction.orbitZMultiplesEquiv_symm_apply']
   orbitZPowersEquiv_symm_apply'
 
 @[to_additive]
+theorem period_eq_card_zpowers_orbit [Fintype (orbit (zpowers a) b)] :
+    period a b = Fintype.card (orbit (zpowers a) b) := by
+  -- porting note: added `(_)` to find `Fintype` by unification
+  rw [← Fintype.ofEquiv_card (orbitZPowersEquiv a b), @ZMod.card _ (_)]
+
+@[to_additive (attr := deprecated)]
 theorem minimalPeriod_eq_card [Fintype (orbit (zpowers a) b)] :
     minimalPeriod (a • ·) b = Fintype.card (orbit (zpowers a) b) := by
   -- porting note: added `(_)` to find `Fintype` by unification
-  rw [← Fintype.ofEquiv_card (orbitZPowersEquiv a b), @ZMod.card _ (_)]
+  rw [← period_eq_minimalPeriod, period_eq_card_zpowers_orbit]
 #align mul_action.minimal_period_eq_card MulAction.minimalPeriod_eq_card
 #align add_action.minimal_period_eq_card AddAction.minimalPeriod_eq_card
 
 @[to_additive]
-instance minimalPeriod_pos [Finite <| orbit (zpowers a) b] :
-    NeZero <| minimalPeriod (a • ·) b :=
+instance period_pos_of_finite_zpowers_orbit [Finite <| orbit (zpowers a) b] :
+    NeZero (period a b) :=
   ⟨by
     cases nonempty_fintype (orbit (zpowers a) b)
     haveI : Nonempty (orbit (zpowers a) b) := (orbit_nonempty b).to_subtype
-    rw [minimalPeriod_eq_card]
+    rw [period_eq_card_zpowers_orbit]
     exact Fintype.card_ne_zero⟩
+
+@[to_additive]
+instance minimalPeriod_pos [Finite <| orbit (zpowers a) b] :
+    NeZero <| minimalPeriod (a • ·) b := by rw [← period_eq_minimalPeriod]; infer_instance
 #align mul_action.minimal_period_pos MulAction.minimalPeriod_pos
 #align add_action.minimal_period_pos AddAction.minimalPeriod_pos
 

--- a/Mathlib/Data/ZMod/Quotient.lean
+++ b/Mathlib/Data/ZMod/Quotient.lean
@@ -90,17 +90,13 @@ variable {α β : Type*} [AddGroup α] (a : α) [AddAction α β] (b : β)
 noncomputable def zmultiplesQuotientStabilizerEquiv :
     zmultiples a ⧸ stabilizer (zmultiples a) b ≃+ ZMod (period a b) :=
   (ofBijective
-    (map _ (stabilizer (zmultiples a) b) (zmultiplesHom (zmultiples a) ⟨a, mem_zmultiples a⟩)
-      (by
-        rw [zmultiples_le, mem_comap, mem_stabilizer_iff, zmultiplesHom_apply, coe_nat_zsmul]
-        simp only [AddSubmonoidClass.mk_nsmul, AddSubmonoid.mk_vadd, vadd_nsmul_period_fixed]
-      )
-    )
+    (map _ (stabilizer (zmultiples a) b) (zmultiplesHom (zmultiples a) ⟨a, mem_zmultiples a⟩) (by
+      rw [zmultiples_le, mem_comap, mem_stabilizer_iff, zmultiplesHom_apply, coe_nat_zsmul]
+      simp only [AddSubmonoidClass.mk_nsmul, AddSubmonoid.mk_vadd, vadd_nsmul_period_fixed]))
     ⟨by
       rw [← ker_eq_bot_iff, eq_bot_iff]
       refine' fun q => induction_on' q fun n hn => _
-      rw [mem_bot, eq_zero_iff, Int.mem_zmultiples_iff, ←
-        zsmul_vadd_eq_iff_period_dvd]
+      rw [mem_bot, eq_zero_iff, Int.mem_zmultiples_iff, ← zsmul_vadd_eq_iff_period_dvd]
       exact (eq_zero_iff _).mp hn, fun q =>
       induction_on' q fun ⟨_, n, rfl⟩ => ⟨n, rfl⟩⟩).symm.trans
     (Int.quotientZMultiplesNatEquivZMod (period a b))

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -706,14 +706,14 @@ theorem zpow_smul_mod_period (j : ℤ) {g : G} {a : α}:
 
 variable {a : G} {b : α}
 
-@[to_additive]
+@[to_additive (attr := deprecated)]
 theorem pow_smul_eq_iff_minimalPeriod_dvd {n : ℕ} :
     a ^ n • b = b ↔ minimalPeriod (a • ·) b ∣ n := by
   rw [← period_eq_minimalPeriod, pow_smul_eq_iff_period_dvd]
 #align mul_action.pow_smul_eq_iff_minimal_period_dvd MulAction.pow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.nsmul_vadd_eq_iff_minimal_period_dvd AddAction.nsmul_vadd_eq_iff_minimalPeriod_dvd
 
-@[to_additive]
+@[to_additive (attr := deprecated)]
 theorem zpow_smul_eq_iff_minimalPeriod_dvd {n : ℤ} :
     a ^ n • b = b ↔ (minimalPeriod (a • ·) b : ℤ) ∣ n := by
   rw [← period_eq_minimalPeriod, zpow_smul_eq_iff_period_dvd]
@@ -722,14 +722,14 @@ theorem zpow_smul_eq_iff_minimalPeriod_dvd {n : ℤ} :
 
 variable (a b)
 
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp, deprecated)]
 theorem pow_smul_mod_minimalPeriod (n : ℕ) :
     a ^ (n % minimalPeriod (a • ·) b) • b = a ^ n • b := by
   rw [← period_eq_minimalPeriod, pow_smul_mod_period]
 #align mul_action.pow_smul_mod_minimal_period MulAction.pow_smul_mod_minimalPeriod
 #align add_action.nsmul_vadd_mod_minimal_period AddAction.nsmul_vadd_mod_minimalPeriod
 
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp, deprecated)]
 theorem zpow_smul_mod_minimalPeriod (n : ℤ) :
     a ^ (n % (minimalPeriod (a • ·) b : ℤ)) • b = a ^ n • b := by
   rw [← period_eq_minimalPeriod, zpow_smul_mod_period]

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -674,7 +674,7 @@ theorem pow_smul_eq_iff_period_dvd {n : ℕ} {m : M} {a : α}:
     m ^ n • a = a ↔ period m a ∣ n := by
   rw [
     period_eq_minimalPeriod,
-    <-Function.isPeriodicPt_iff_minimalPeriod_dvd,
+    ← Function.isPeriodicPt_iff_minimalPeriod_dvd,
     fixed_iff_isPeriodicPt
   ]
 
@@ -704,14 +704,14 @@ theorem zpow_smul_plus_period (i j : ℤ) (g : G) (a : α):
 theorem pow_smul_mod_period (n : ℕ) {m : M} {a : α}:
     m ^ (n % period m a) • a = m ^ n • a := by
   conv_rhs => {
-    rw [<-Nat.mod_add_div n (period m a), pow_smul_plus_period]
+    rw [← Nat.mod_add_div n (period m a), pow_smul_plus_period]
   }
 
 @[to_additive (attr := simp)]
 theorem zpow_smul_mod_period (j : ℤ) {g : G} {a : α}:
     g ^ (j % (period g a : ℤ)) • a = g ^ j • a := by
   conv_rhs => {
-    rw [<-Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
+    rw [← Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
   }
 
 variable {a : G} {b : α}
@@ -719,14 +719,14 @@ variable {a : G} {b : α}
 @[to_additive]
 theorem pow_smul_eq_iff_minimalPeriod_dvd {n : ℕ} :
     a ^ n • b = b ↔ Function.minimalPeriod (a • ·) b ∣ n := by
-  rw [<-period_eq_minimalPeriod, pow_smul_eq_iff_period_dvd]
+  rw [← period_eq_minimalPeriod, pow_smul_eq_iff_period_dvd]
 #align mul_action.pow_smul_eq_iff_minimal_period_dvd MulAction.pow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.nsmul_vadd_eq_iff_minimal_period_dvd AddAction.nsmul_vadd_eq_iff_minimalPeriod_dvd
 
 @[to_additive]
 theorem zpow_smul_eq_iff_minimalPeriod_dvd {n : ℤ} :
     a ^ n • b = b ↔ (Function.minimalPeriod (a • ·) b : ℤ) ∣ n := by
-  rw [<-period_eq_minimalPeriod, zpow_smul_eq_iff_period_dvd]
+  rw [← period_eq_minimalPeriod, zpow_smul_eq_iff_period_dvd]
 #align mul_action.zpow_smul_eq_iff_minimal_period_dvd MulAction.zpow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.zsmul_vadd_eq_iff_minimal_period_dvd AddAction.zsmul_vadd_eq_iff_minimalPeriod_dvd
 
@@ -735,14 +735,14 @@ variable (a b)
 @[to_additive (attr := simp)]
 theorem pow_smul_mod_minimalPeriod (n : ℕ) :
     a ^ (n % Function.minimalPeriod (a • ·) b) • b = a ^ n • b := by
-  rw [<-period_eq_minimalPeriod, pow_smul_mod_period]
+  rw [← period_eq_minimalPeriod, pow_smul_mod_period]
 #align mul_action.pow_smul_mod_minimal_period MulAction.pow_smul_mod_minimalPeriod
 #align add_action.nsmul_vadd_mod_minimal_period AddAction.nsmul_vadd_mod_minimalPeriod
 
 @[to_additive (attr := simp)]
 theorem zpow_smul_mod_minimalPeriod (n : ℤ) :
     a ^ (n % (Function.minimalPeriod (a • ·) b : ℤ)) • b = a ^ n • b := by
-  rw [<-period_eq_minimalPeriod, zpow_smul_mod_period]
+  rw [← period_eq_minimalPeriod, zpow_smul_mod_period]
 #align mul_action.zpow_smul_mod_minimal_period MulAction.zpow_smul_mod_minimalPeriod
 #align add_action.zsmul_vadd_mod_minimal_period AddAction.zsmul_vadd_mod_minimalPeriod
 

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -27,7 +27,8 @@ A point `x : α` is a periodic point of `f : α → α` of period `n` if `f^[n] 
 * `minimalPeriod f x` : the minimal period of a point `x` under an endomorphism `f` or zero
   if `x` is not a periodic point of `f`.
 * `orbit f x`: the cycle `[x, f x, f (f x), ...]` for a periodic point.
-* `MulAction.period g x` : the minimal period of a point `x` under the multiplicative action of `g`.
+* `MulAction.period g x` : the minimal period of a point `x` under the multiplicative action of `g`;
+  an equivalent `AddAction.period g x` is defined for additive actions.
 
 ## Main statements
 
@@ -638,7 +639,8 @@ variable {M : Type u} [Monoid M] [MulAction M α]
 The period of a multiplicative action of `g` on `a` is the smallest `n` such that `g ^ n • a = a`,
 or `0` if such an `n` does not exist.
 -/
-@[to_additive "The period of an additive action of `g` on `a` is the smallest `n` such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
+@[to_additive "The period of an additive action of `g` on `a` is the smallest `n`
+such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
 noncomputable def period (m : M) (a : α) : ℕ := Function.minimalPeriod (fun x => m • x) a
 
 /-- `MulAction.period m a` is definitionally equal to `Function.minimalPeriod (m • ·) a`. -/

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -27,6 +27,7 @@ A point `x : α` is a periodic point of `f : α → α` of period `n` if `f^[n] 
 * `minimalPeriod f x` : the minimal period of a point `x` under an endomorphism `f` or zero
   if `x` is not a periodic point of `f`.
 * `orbit f x`: the cycle `[x, f x, f (f x), ...]` for a periodic point.
+* `MulAction.period g x` : the minimal period of a point `x` under the multiplicative action of `g`.
 
 ## Main statements
 
@@ -628,22 +629,104 @@ namespace MulAction
 
 open Function
 
-variable {α β : Type*} [Group α] [MulAction α β] {a : α} {b : β}
+universe u v
+variable {α : Type v}
+variable {G : Type u} [Group G] [MulAction G α]
+variable {M : Type u} [Monoid M] [MulAction M α]
+
+/--
+The period of a multiplicative action of `g` on `a` is the smallest `n` such that `g ^ n • a = a`,
+or `0` if such an `n` does not exist.
+-/
+@[to_additive "The period of an additive action of `g` on `a` is the smallest `n` such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
+noncomputable def period (m : M) (a : α) : ℕ := Function.minimalPeriod (fun x => m • x) a
+
+/-- `MulAction.period m a` is definitionally equal to `Function.minimalPeriod (m • ·) a`. -/
+@[to_additive]
+theorem period_eq_minimalPeriod {m : M} {a : α} :
+    MulAction.period m a = Function.minimalPeriod (fun x => m • x) a := rfl
+
+@[to_additive]
+lemma smul_pow_eq_function_pow (m : M) (a : α) (n : ℕ): m ^ n • a = (fun x => m • x)^[n] a := by
+  rw [smul_iterate]
+
+/-- `m ^ (period m a)` fixes `a` -/
+@[to_additive (attr := simp) "`(period m a) • m` fixes `a`"]
+theorem smul_pow_period_fixed (m : M) (a : α) : m ^ (period m a) • a = a := by
+  rw [period_eq_minimalPeriod, smul_pow_eq_function_pow, Function.iterate_minimalPeriod]
+
+@[to_additive]
+lemma fixed_iff_isPeriodicPt {m : M} {a : α} {n : ℕ} :
+    m ^ n • a = a ↔ Function.IsPeriodicPt (fun x => m • x) n a := by
+  rw [smul_pow_eq_function_pow]
+  rfl
+
+/-! ### Multiples of `MulAction.period`
+
+It is easy to convince onself that if `g ^ n • a = a` (resp. `(n • g) +ᵥ a = a`),
+then `n` must be a multiple of `period g a`.
+
+This also holds for negative powers/multiples.
+-/
+
+@[to_additive]
+theorem pow_smul_eq_iff_period_dvd {n : ℕ} {m : M} {a : α}:
+    m ^ n • a = a ↔ period m a ∣ n := by
+  rw [
+    period_eq_minimalPeriod,
+    <-Function.isPeriodicPt_iff_minimalPeriod_dvd,
+    fixed_iff_isPeriodicPt
+  ]
+
+@[to_additive]
+theorem zpow_smul_eq_iff_period_dvd {j : ℤ} {g : G} {a : α}:
+    g ^ j • a = a ↔ (period g a : ℤ) ∣ j := by
+  rcases j with n | n
+  · rw [Int.ofNat_eq_coe, zpow_ofNat, Int.coe_nat_dvd, pow_smul_eq_iff_period_dvd]
+  · rw [
+      Int.negSucc_coe, zpow_neg, zpow_ofNat,
+      inv_smul_eq_iff, eq_comm,
+      dvd_neg, Int.coe_nat_dvd,
+      pow_smul_eq_iff_period_dvd
+    ]
+
+@[to_additive (attr := simp)]
+theorem pow_smul_plus_period (n o : ℕ) (m : M) (a : α):
+    m ^ (n + (period m a) * o) • a = m ^ n • a := by
+  rw [pow_add, mul_smul, pow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
+
+@[to_additive (attr := simp)]
+theorem zpow_smul_plus_period (i j : ℤ) (g : G) (a : α):
+    g ^ (i + (period g a : ℤ) * j) • a = g ^ i • a := by
+  rw [zpow_add, mul_smul, zpow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
+
+@[to_additive (attr := simp)]
+theorem pow_smul_mod_period (n : ℕ) {m : M} {a : α}:
+    m ^ (n % period m a) • a = m ^ n • a := by
+  conv_rhs => {
+    rw [<-Nat.mod_add_div n (period m a), pow_smul_plus_period]
+  }
+
+@[to_additive (attr := simp)]
+theorem zpow_smul_mod_period (j : ℤ) {g : G} {a : α}:
+    g ^ (j % (period g a : ℤ)) • a = g ^ j • a := by
+  conv_rhs => {
+    rw [<-Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
+  }
+
+variable {a : G} {b : α}
 
 @[to_additive]
 theorem pow_smul_eq_iff_minimalPeriod_dvd {n : ℕ} :
     a ^ n • b = b ↔ Function.minimalPeriod (a • ·) b ∣ n := by
-  rw [← isPeriodicPt_iff_minimalPeriod_dvd, IsPeriodicPt, IsFixedPt, smul_iterate]
+  rw [<-period_eq_minimalPeriod, pow_smul_eq_iff_period_dvd]
 #align mul_action.pow_smul_eq_iff_minimal_period_dvd MulAction.pow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.nsmul_vadd_eq_iff_minimal_period_dvd AddAction.nsmul_vadd_eq_iff_minimalPeriod_dvd
 
 @[to_additive]
 theorem zpow_smul_eq_iff_minimalPeriod_dvd {n : ℤ} :
     a ^ n • b = b ↔ (Function.minimalPeriod (a • ·) b : ℤ) ∣ n := by
-  cases n
-  · rw [Int.ofNat_eq_coe, zpow_ofNat, Int.coe_nat_dvd, pow_smul_eq_iff_minimalPeriod_dvd]
-  · rw [Int.negSucc_coe, zpow_neg, zpow_ofNat, inv_smul_eq_iff, eq_comm, dvd_neg, Int.coe_nat_dvd,
-      pow_smul_eq_iff_minimalPeriod_dvd]
+  rw [<-period_eq_minimalPeriod, zpow_smul_eq_iff_period_dvd]
 #align mul_action.zpow_smul_eq_iff_minimal_period_dvd MulAction.zpow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.zsmul_vadd_eq_iff_minimal_period_dvd AddAction.zsmul_vadd_eq_iff_minimalPeriod_dvd
 
@@ -652,18 +735,14 @@ variable (a b)
 @[to_additive (attr := simp)]
 theorem pow_smul_mod_minimalPeriod (n : ℕ) :
     a ^ (n % Function.minimalPeriod (a • ·) b) • b = a ^ n • b := by
-  conv_rhs =>
-    rw [← Nat.mod_add_div n (minimalPeriod (a • ·) b), pow_add, mul_smul,
-      pow_smul_eq_iff_minimalPeriod_dvd.mpr (dvd_mul_right _ _)]
+  rw [<-period_eq_minimalPeriod, pow_smul_mod_period]
 #align mul_action.pow_smul_mod_minimal_period MulAction.pow_smul_mod_minimalPeriod
 #align add_action.nsmul_vadd_mod_minimal_period AddAction.nsmul_vadd_mod_minimalPeriod
 
 @[to_additive (attr := simp)]
 theorem zpow_smul_mod_minimalPeriod (n : ℤ) :
     a ^ (n % (Function.minimalPeriod (a • ·) b : ℤ)) • b = a ^ n • b := by
-  conv_rhs =>
-    rw [← Int.emod_add_ediv n (minimalPeriod ((a • ·)) b), zpow_add, mul_smul,
-      zpow_smul_eq_iff_minimalPeriod_dvd.mpr (dvd_mul_right _ _)]
+  rw [<-period_eq_minimalPeriod, zpow_smul_mod_period]
 #align mul_action.zpow_smul_mod_minimal_period MulAction.zpow_smul_mod_minimalPeriod
 #align add_action.zsmul_vadd_mod_minimal_period AddAction.zsmul_vadd_mod_minimalPeriod
 

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -641,12 +641,12 @@ or `0` if such an `n` does not exist.
 -/
 @[to_additive "The period of an additive action of `g` on `a` is the smallest `n`
 such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
-noncomputable def period (m : M) (a : α) : ℕ := Function.minimalPeriod (fun x => m • x) a
+noncomputable def period (m : M) (a : α) : ℕ := minimalPeriod (fun x => m • x) a
 
 /-- `MulAction.period m a` is definitionally equal to `Function.minimalPeriod (m • ·) a`. -/
 @[to_additive]
 theorem period_eq_minimalPeriod {m : M} {a : α} :
-    MulAction.period m a = Function.minimalPeriod (fun x => m • x) a := rfl
+    MulAction.period m a = minimalPeriod (fun x => m • x) a := rfl
 
 @[to_additive]
 lemma smul_pow_eq_function_pow (m : M) (a : α) (n : ℕ): m ^ n • a = (fun x => m • x)^[n] a := by
@@ -655,11 +655,11 @@ lemma smul_pow_eq_function_pow (m : M) (a : α) (n : ℕ): m ^ n • a = (fun x 
 /-- `m ^ (period m a)` fixes `a` -/
 @[to_additive (attr := simp) "`(period m a) • m` fixes `a`"]
 theorem smul_pow_period_fixed (m : M) (a : α) : m ^ (period m a) • a = a := by
-  rw [period_eq_minimalPeriod, smul_pow_eq_function_pow, Function.iterate_minimalPeriod]
+  rw [period_eq_minimalPeriod, smul_pow_eq_function_pow, iterate_minimalPeriod]
 
 @[to_additive]
 lemma fixed_iff_isPeriodicPt {m : M} {a : α} {n : ℕ} :
-    m ^ n • a = a ↔ Function.IsPeriodicPt (fun x => m • x) n a := by
+    m ^ n • a = a ↔ IsPeriodicPt (fun x => m • x) n a := by
   rw [smul_pow_eq_function_pow]
   rfl
 
@@ -674,23 +674,15 @@ This also holds for negative powers/multiples.
 @[to_additive]
 theorem pow_smul_eq_iff_period_dvd {n : ℕ} {m : M} {a : α}:
     m ^ n • a = a ↔ period m a ∣ n := by
-  rw [
-    period_eq_minimalPeriod,
-    ← Function.isPeriodicPt_iff_minimalPeriod_dvd,
-    fixed_iff_isPeriodicPt
-  ]
+  rw [period_eq_minimalPeriod, ← isPeriodicPt_iff_minimalPeriod_dvd, fixed_iff_isPeriodicPt]
 
 @[to_additive]
 theorem zpow_smul_eq_iff_period_dvd {j : ℤ} {g : G} {a : α}:
     g ^ j • a = a ↔ (period g a : ℤ) ∣ j := by
   rcases j with n | n
   · rw [Int.ofNat_eq_coe, zpow_ofNat, Int.coe_nat_dvd, pow_smul_eq_iff_period_dvd]
-  · rw [
-      Int.negSucc_coe, zpow_neg, zpow_ofNat,
-      inv_smul_eq_iff, eq_comm,
-      dvd_neg, Int.coe_nat_dvd,
-      pow_smul_eq_iff_period_dvd
-    ]
+  · rw [Int.negSucc_coe, zpow_neg, zpow_ofNat, inv_smul_eq_iff, eq_comm, dvd_neg, Int.coe_nat_dvd,
+      pow_smul_eq_iff_period_dvd]
 
 @[to_additive (attr := simp)]
 theorem pow_smul_plus_period (n o : ℕ) (m : M) (a : α):
@@ -705,29 +697,25 @@ theorem zpow_smul_plus_period (i j : ℤ) (g : G) (a : α):
 @[to_additive (attr := simp)]
 theorem pow_smul_mod_period (n : ℕ) {m : M} {a : α}:
     m ^ (n % period m a) • a = m ^ n • a := by
-  conv_rhs => {
-    rw [← Nat.mod_add_div n (period m a), pow_smul_plus_period]
-  }
+  conv_rhs => rw [← Nat.mod_add_div n (period m a), pow_smul_plus_period]
 
 @[to_additive (attr := simp)]
 theorem zpow_smul_mod_period (j : ℤ) {g : G} {a : α}:
     g ^ (j % (period g a : ℤ)) • a = g ^ j • a := by
-  conv_rhs => {
-    rw [← Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
-  }
+  conv_rhs => rw [← Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
 
 variable {a : G} {b : α}
 
 @[to_additive]
 theorem pow_smul_eq_iff_minimalPeriod_dvd {n : ℕ} :
-    a ^ n • b = b ↔ Function.minimalPeriod (a • ·) b ∣ n := by
+    a ^ n • b = b ↔ minimalPeriod (a • ·) b ∣ n := by
   rw [← period_eq_minimalPeriod, pow_smul_eq_iff_period_dvd]
 #align mul_action.pow_smul_eq_iff_minimal_period_dvd MulAction.pow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.nsmul_vadd_eq_iff_minimal_period_dvd AddAction.nsmul_vadd_eq_iff_minimalPeriod_dvd
 
 @[to_additive]
 theorem zpow_smul_eq_iff_minimalPeriod_dvd {n : ℤ} :
-    a ^ n • b = b ↔ (Function.minimalPeriod (a • ·) b : ℤ) ∣ n := by
+    a ^ n • b = b ↔ (minimalPeriod (a • ·) b : ℤ) ∣ n := by
   rw [← period_eq_minimalPeriod, zpow_smul_eq_iff_period_dvd]
 #align mul_action.zpow_smul_eq_iff_minimal_period_dvd MulAction.zpow_smul_eq_iff_minimalPeriod_dvd
 #align add_action.zsmul_vadd_eq_iff_minimal_period_dvd AddAction.zsmul_vadd_eq_iff_minimalPeriod_dvd
@@ -736,14 +724,14 @@ variable (a b)
 
 @[to_additive (attr := simp)]
 theorem pow_smul_mod_minimalPeriod (n : ℕ) :
-    a ^ (n % Function.minimalPeriod (a • ·) b) • b = a ^ n • b := by
+    a ^ (n % minimalPeriod (a • ·) b) • b = a ^ n • b := by
   rw [← period_eq_minimalPeriod, pow_smul_mod_period]
 #align mul_action.pow_smul_mod_minimal_period MulAction.pow_smul_mod_minimalPeriod
 #align add_action.nsmul_vadd_mod_minimal_period AddAction.nsmul_vadd_mod_minimalPeriod
 
 @[to_additive (attr := simp)]
 theorem zpow_smul_mod_minimalPeriod (n : ℤ) :
-    a ^ (n % (Function.minimalPeriod (a • ·) b : ℤ)) • b = a ^ n • b := by
+    a ^ (n % (minimalPeriod (a • ·) b : ℤ)) • b = a ^ n • b := by
   rw [← period_eq_minimalPeriod, zpow_smul_mod_period]
 #align mul_action.zpow_smul_mod_minimal_period MulAction.zpow_smul_mod_minimalPeriod
 #align add_action.zsmul_vadd_mod_minimal_period AddAction.zsmul_vadd_mod_minimalPeriod

--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -760,13 +760,13 @@ variable {G : Type u} [Group G] (H : Subgroup G) (g : G)
 
 /-- Partition `G ⧸ H` into orbits of the action of `g : G`. -/
 noncomputable def quotientEquivSigmaZMod :
-    G ⧸ H ≃ Σq : orbitRel.Quotient (zpowers g) (G ⧸ H), ZMod (minimalPeriod (g • ·) q.out') :=
+    G ⧸ H ≃ Σq : orbitRel.Quotient (zpowers g) (G ⧸ H), ZMod (period g q.out') :=
   (selfEquivSigmaOrbits (zpowers g) (G ⧸ H)).trans
     (sigmaCongrRight fun q => orbitZPowersEquiv g q.out')
 #align subgroup.quotient_equiv_sigma_zmod Subgroup.quotientEquivSigmaZMod
 
 theorem quotientEquivSigmaZMod_symm_apply (q : orbitRel.Quotient (zpowers g) (G ⧸ H))
-    (k : ZMod (minimalPeriod (g • ·) q.out')) :
+    (k : ZMod (period g q.out')) :
     (quotientEquivSigmaZMod H g).symm ⟨q, k⟩ = g ^ (k : ℤ) • q.out' :=
   rfl
 #align subgroup.quotient_equiv_sigma_zmod_symm_apply Subgroup.quotientEquivSigmaZMod_symm_apply
@@ -774,7 +774,7 @@ theorem quotientEquivSigmaZMod_symm_apply (q : orbitRel.Quotient (zpowers g) (G 
 theorem quotientEquivSigmaZMod_apply (q : orbitRel.Quotient (zpowers g) (G ⧸ H)) (k : ℤ) :
     quotientEquivSigmaZMod H g (g ^ k • q.out') = ⟨q, k⟩ := by
   rw [apply_eq_iff_eq_symm_apply, quotientEquivSigmaZMod_symm_apply, ZMod.coe_int_cast,
-    zpow_smul_mod_minimalPeriod]
+    zpow_smul_mod_period]
 #align subgroup.quotient_equiv_sigma_zmod_apply Subgroup.quotientEquivSigmaZMod_apply
 
 /-- The transfer transversal as a function. Given a `⟨g⟩`-orbit `q₀, g • q₀, ..., g ^ (m - 1) • q₀`
@@ -817,16 +817,16 @@ theorem transferTransversal_apply (q : G ⧸ H) :
 #align subgroup.transfer_transversal_apply Subgroup.transferTransversal_apply
 
 theorem transferTransversal_apply' (q : orbitRel.Quotient (zpowers g) (G ⧸ H))
-    (k : ZMod (minimalPeriod (g • ·) q.out')) :
+    (k : ZMod (period g q.out')) :
     ↑(toEquiv (transferTransversal H g).2 (g ^ (k : ℤ) • q.out')) = g ^ (k : ℤ) * q.out'.out' := by
   rw [transferTransversal_apply, transferFunction_apply, ← quotientEquivSigmaZMod_symm_apply,
     apply_symm_apply]
 #align subgroup.transfer_transversal_apply' Subgroup.transferTransversal_apply'
 
 theorem transferTransversal_apply'' (q : orbitRel.Quotient (zpowers g) (G ⧸ H))
-    (k : ZMod (minimalPeriod (g • ·) q.out')) :
+    (k : ZMod (period g q.out')) :
     ↑(toEquiv (g • transferTransversal H g).2 (g ^ (k : ℤ) • q.out')) =
-      if k = 0 then g ^ minimalPeriod (g • ·) q.out' * q.out'.out'
+      if k = 0 then g ^ period g q.out' * q.out'.out'
       else g ^ (k : ℤ) * q.out'.out' := by
   rw [smul_apply_eq_smul_apply_inv_smul, transferTransversal_apply, transferFunction_apply, ←
     mul_smul, ← zpow_neg_one, ← zpow_add, quotientEquivSigmaZMod_apply, smul_eq_mul, ← mul_assoc,

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -44,9 +44,9 @@ theorem fixedBy_eq_fixedBy_inv (g : G) : fixedBy α g = fixedBy α g⁻¹ := by
   ext x
   repeat rw [mem_fixedBy]
   constructor
-  all_goals (intro gx_eq_x; nth_rw 1 [<-gx_eq_x])
+  all_goals (intro gx_eq_x; nth_rw 1 [← gx_eq_x])
   · exact inv_smul_smul g x
-  · rw [<-mul_smul, mul_right_inv, one_smul]
+  · rw [← mul_smul, mul_right_inv, one_smul]
 
 @[to_additive]
 theorem smul_mem_fixedBy_iff_mem_fixedBy {a : α} {g : G} :
@@ -117,7 +117,7 @@ theorem movedBy_eq_compl_fixedBy {m : M} : movedBy α m = (fixedBy α m)ᶜ := r
 
 @[to_additive]
 theorem fixedBy_eq_compl_movedBy {m : M} : fixedBy α m = (movedBy α m)ᶜ := by
-  rw [<-compl_compl (fixedBy α m), movedBy_eq_compl_fixedBy]
+  rw [← compl_compl (fixedBy α m), movedBy_eq_compl_fixedBy]
 
 @[to_additive]
 theorem not_mem_fixedBy_iff_mem_movedBy {m : M} {a : α} : a ∉ fixedBy α m ↔ a ∈ movedBy α m :=
@@ -140,7 +140,7 @@ variable {α}
 @[to_additive]
 theorem smul_mem_movedBy_iff_mem_movedBy {a : α} {g : G} :
     g • a ∈ movedBy α g ↔ a ∈ movedBy α g := by
-  repeat rw [<-not_mem_fixedBy_iff_mem_movedBy]
+  repeat rw [← not_mem_fixedBy_iff_mem_movedBy]
   rw [smul_mem_fixedBy_iff_mem_fixedBy]
 
 @[to_additive]
@@ -166,7 +166,7 @@ variable {M}
 @[to_additive]
 theorem movedBy_mul (m₁ m₂ : M) : movedBy α (m₁ * m₂) ⊆ movedBy α m₁ ∪ movedBy α m₂ := by
   repeat rw [movedBy_eq_compl_fixedBy]
-  rw [<-Set.compl_inter, Set.compl_subset_compl]
+  rw [← Set.compl_inter, Set.compl_subset_compl]
   exact fixedBy_mul α m₁ m₂
 
 @[to_additive]
@@ -212,7 +212,7 @@ theorem smul_pow_preimage_eq_of_movedBy_subset {s : Set α} {g : G} (superset : 
 @[to_additive]
 theorem smul_pow_subset_of_movedBy_subset {s t : Set α} {g : G}  (t_superset : movedBy α g ⊆ t)
     (s_ss_t : s ⊆ t) (j : ℤ): (fun a => g^j • a) ⁻¹' s ⊆ t := by
-  rw [<-smul_pow_preimage_eq_of_movedBy_subset t_superset j]
+  rw [← smul_pow_preimage_eq_of_movedBy_subset t_superset j]
   repeat rw [Set.preimage_smul]
   exact Set.smul_set_mono s_ss_t
 
@@ -222,11 +222,11 @@ theorem smul_pow_mem_fixedBy_of_commute {g h : G} (comm : Commute g h) (x : α) 
     x ∈ fixedBy α g ↔ h^j • x ∈ fixedBy α g := by
   suffices ∀ x : α, ∀ h : G, Commute g h → x ∈ fixedBy α g → h^j • x ∈ fixedBy α g by
     refine ⟨this x h comm, fun hx_in_fixedBy => ?x_in_fixedBy⟩
-    have h₁ : x = h⁻¹^j • h^j • x := by rw [<-mul_smul, inv_zpow', zpow_neg, mul_left_inv, one_smul]
+    have h₁ : x = h⁻¹^j • h^j • x := by rw [← mul_smul, inv_zpow', zpow_neg, mul_left_inv, one_smul]
     rw [h₁]
     exact this _ _ comm.inv_right hx_in_fixedBy
   intro x h comm x_in_fixedBy
-  rw [mem_fixedBy, <-mul_smul]
+  rw [mem_fixedBy, ← mul_smul]
   rw [Commute.zpow_right comm j]
   rw [mul_smul, smul_left_cancel_iff]
   exact x_in_fixedBy
@@ -267,7 +267,7 @@ theorem movedBy_empty_iff_eq_one {m : M} : movedBy α m = ∅ ↔ m = 1 := ⟨
     intro a
     rw [one_smul]
     by_contra ma_ne_a
-    rwa [<-ne_eq, <-mem_movedBy, moved_empty] at ma_ne_a
+    rwa [← ne_eq, ← mem_movedBy, moved_empty] at ma_ne_a
   ),
   fun eq_one => eq_one.symm ▸ movedBy_one_eq_empty α M
 ⟩

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -6,6 +6,7 @@ Authors: Emilie Burgun
 import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.Dynamics.PeriodicPts
 import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.GroupTheory.GroupAction.Period
 
 /-!
 # Properties of `fixedPoints` and `fixedBy`
@@ -55,10 +56,8 @@ theorem smul_mem_fixedBy_iff_mem_fixedBy {a : α} {g : G} :
   rfl
 
 @[to_additive]
-theorem minimalPeriod_eq_one_of_fixedBy {a : α} {g : G} (a_in_fixedBy : a ∈ fixedBy α g) :
-    Function.minimalPeriod (fun x => g • x) a = 1 := by
-  rw [Function.minimalPeriod_eq_one_iff_isFixedPt]
-  exact a_in_fixedBy
+theorem period_eq_one_of_fixedBy {a : α} {g : G} (a_in_fixedBy : a ∈ fixedBy α g) :
+    period g a = 1 := period_eq_one_of_fixed a_in_fixedBy
 
 @[to_additive]
 theorem fixedBy_subset_fixedBy_pow (g : G) (j : ℤ) :
@@ -66,10 +65,10 @@ theorem fixedBy_subset_fixedBy_pow (g : G) (j : ℤ) :
   intro a a_in_fixedBy
   rw [
     mem_fixedBy,
-    zpow_smul_eq_iff_minimalPeriod_dvd,
-    minimalPeriod_eq_one_of_fixedBy a_in_fixedBy
+    zpow_smul_eq_iff_period_dvd,
+    period_eq_one_of_fixedBy a_in_fixedBy,
+    Nat.cast_one
   ]
-  rw [Nat.cast_one]
   exact one_dvd j
 
 variable (M)

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -64,11 +64,8 @@ theorem minimalPeriod_eq_one_of_fixedBy {a : α} {g : G} (a_in_fixedBy : a ∈ f
 theorem fixedBy_subset_fixedBy_pow (g : G) (j : ℤ) :
     fixedBy α g ⊆ fixedBy α (g^j) := by
   intro a a_in_fixedBy
-  rw [
-    mem_fixedBy,
-    zpow_smul_eq_iff_minimalPeriod_dvd,
-    minimalPeriod_eq_one_of_fixedBy a_in_fixedBy
-  ]
+  rw [mem_fixedBy, zpow_smul_eq_iff_minimalPeriod_dvd,
+    minimalPeriod_eq_one_of_fixedBy a_in_fixedBy]
   rw [Nat.cast_one]
   exact one_dvd j
 
@@ -260,17 +257,17 @@ variable [FaithfulSMul M α]
 
 /-- If the action is faithful, then an empty `movedBy` set implies that `m = 1` -/
 @[to_additive]
-theorem movedBy_empty_iff_eq_one {m : M} : movedBy α m = ∅ ↔ m = 1 := ⟨
-  (by
-    intro moved_empty
+theorem movedBy_empty_iff_eq_one {m : M} : movedBy α m = ∅ ↔ m = 1 := by
+  constructor
+  · intro moved_empty
     apply FaithfulSMul.eq_of_smul_eq_smul (α := α)
     intro a
     rw [one_smul]
     by_contra ma_ne_a
     rwa [← ne_eq, ← mem_movedBy, moved_empty] at ma_ne_a
-  ),
-  fun eq_one => eq_one.symm ▸ movedBy_one_eq_empty α M
-⟩
+  · intro eq_one
+    rw [eq_one]
+    exact movedBy_one_eq_empty α M
 
 /--
 This theorem allows to deduce the non-commutativity of `g` and `h`

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -1,0 +1,289 @@
+/-
+Copyright (c) 2024 Emilie Burgun. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Emilie Burgun
+-/
+import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Dynamics.PeriodicPts
+import Mathlib.Data.Set.Pointwise.SMul
+
+/-!
+# Properties of `fixedPoints` and `fixedBy`
+
+This module contains some useful properties of [`MulAction.fixedPoints`] and [`MulAction.fixedBy`]
+that don't directly belong to `Mathlib.GroupTheory.GroupAction.Basic`,
+as well as the definition of [`MulAction.movedBy`].
+
+## Main theorems
+
+* [`MulAction.fixedBy_mul`], [`MulAction.movedBy_mul`] (and their `AddAction` equivalents),
+  for the different relationship between the `movedBy`/`fixedBy` sets of `g*h`.
+* [`MulAction.fixedBy_conj`] and [`MulAction.movedBy_conj`]: the pointwise group action on the sets
+  `fixedBy α g` and `movedBy α g` translates to the conjugation action on `g`.
+* [`MulAction.smul_in_set_of_movedBy_subset`] shows that if a set `s` is a superset of
+  `movedBy α g`, then the group action of `g` cannot send elements of `s` outside of `s`.
+* [`MulAction.not_commute_of_disjoint_movedBy_preimage`] allows one to infer that two group elements
+  do not commute from the behavior of their `movedBy` sets, which is useful in the proof of
+  Rubin's theorem.
+-/
+
+namespace MulAction
+open Pointwise
+
+universe u v
+variable {α : Type v}
+variable {G : Type u} [Group G] [MulAction G α]
+variable {M : Type u} [Monoid M] [MulAction M α]
+
+
+section FixedPoints
+
+/-- In a multiplicative group action, the points fixed by `g` are also fixed by `g⁻¹` -/
+@[to_additive "In an additive group action, the points fixed by `g` are also fixed by `g⁻¹`"]
+theorem fixedBy_eq_fixedBy_inv (g : G) : fixedBy α g = fixedBy α g⁻¹ := by
+  ext x
+  repeat rw [mem_fixedBy]
+  constructor
+  all_goals (intro gx_eq_x; nth_rw 1 [<-gx_eq_x])
+  · exact inv_smul_smul g x
+  · rw [<-mul_smul, mul_right_inv, one_smul]
+
+@[to_additive]
+theorem smul_mem_fixedBy_iff_mem_fixedBy {a : α} {g : G} :
+    g • a ∈ fixedBy α g ↔ a ∈ fixedBy α g := by
+  rw [mem_fixedBy, smul_left_cancel_iff]
+  rfl
+
+@[to_additive]
+theorem minimalPeriod_eq_one_of_fixedBy {a : α} {g : G} (a_in_fixedBy : a ∈ fixedBy α g) :
+    Function.minimalPeriod (fun x => g • x) a = 1 := by
+  rw [Function.minimalPeriod_eq_one_iff_isFixedPt]
+  exact a_in_fixedBy
+
+@[to_additive]
+theorem fixedBy_subset_fixedBy_pow (g : G) (j : ℤ) :
+    fixedBy α g ⊆ fixedBy α (g^j) := by
+  intro a a_in_fixedBy
+  rw [
+    mem_fixedBy,
+    zpow_smul_eq_iff_minimalPeriod_dvd,
+    minimalPeriod_eq_one_of_fixedBy a_in_fixedBy
+  ]
+  rw [Nat.cast_one]
+  exact one_dvd j
+
+variable (M)
+
+@[to_additive (attr := simp)]
+theorem fixedBy_one_eq_univ :
+    fixedBy α (1 : M) = Set.univ := by
+  ext a
+  rw [mem_fixedBy, one_smul]
+  exact ⟨fun _ => Set.mem_univ a, fun _ => rfl⟩
+
+variable {M} (α)
+
+@[to_additive]
+theorem fixedBy_mul (m₁ m₂ : M) : fixedBy α m₁ ∩ fixedBy α m₂ ⊆ fixedBy α (m₁ * m₂) := by
+  intro a ⟨h₁, h₂⟩
+  rw [mem_fixedBy, mul_smul, h₂, h₁]
+
+@[to_additive]
+theorem fixedBy_conj (g h : G) :
+    fixedBy α (h * g * h⁻¹) = (fun a => h⁻¹ • a) ⁻¹' fixedBy α g := by
+  ext a
+  rw [Set.mem_preimage, mem_fixedBy, mem_fixedBy]
+  repeat rw [mul_smul]
+  exact smul_eq_iff_eq_inv_smul h
+
+end FixedPoints
+
+section MovedBy
+
+variable (α)
+
+/-- The set of points moved by an element of the action. -/
+@[to_additive "The set of points moved by an element of the action."]
+def movedBy (m : M) : Set α := { a : α | m • a ≠ a }
+
+variable {α}
+
+@[to_additive (attr := simp)]
+theorem mem_movedBy {m : M} {a : α} : a ∈ movedBy α m ↔ m • a ≠ a :=
+  Iff.rfl
+
+@[to_additive]
+theorem movedBy_eq_compl_fixedBy {m : M} : movedBy α m = (fixedBy α m)ᶜ := rfl
+
+@[to_additive]
+theorem fixedBy_eq_compl_movedBy {m : M} : fixedBy α m = (movedBy α m)ᶜ := by
+  rw [<-compl_compl (fixedBy α m), movedBy_eq_compl_fixedBy]
+
+@[to_additive]
+theorem not_mem_fixedBy_iff_mem_movedBy {m : M} {a : α} : a ∉ fixedBy α m ↔ a ∈ movedBy α m :=
+  Iff.rfl
+
+@[to_additive]
+theorem not_mem_movedBy_iff_mem_fixedBy {m : M} {a : α} : a ∉ movedBy α m ↔ a ∈ fixedBy α m := by
+  rw [movedBy_eq_compl_fixedBy, Set.not_mem_compl_iff]
+
+variable (α)
+
+/-- In a multiplicative group action, the points moved by `g` are also moved by `g⁻¹` -/
+@[to_additive "In an additive group action, the points moved by `g` are also moved by `g⁻¹`"]
+theorem movedBy_eq_movedBy_inv (g : G) : movedBy α g = movedBy α g⁻¹ := by
+  repeat rw [movedBy_eq_compl_fixedBy]
+  rw [fixedBy_eq_fixedBy_inv]
+
+variable {α}
+
+@[to_additive]
+theorem smul_mem_movedBy_iff_mem_movedBy {a : α} {g : G} :
+    g • a ∈ movedBy α g ↔ a ∈ movedBy α g := by
+  repeat rw [<-not_mem_fixedBy_iff_mem_movedBy]
+  rw [smul_mem_fixedBy_iff_mem_fixedBy]
+
+@[to_additive]
+theorem smul_inv_mem_movedBy_iff_mem_movedBy {a : α} {g : G} :
+    g⁻¹ • a ∈ movedBy α g ↔ a ∈ movedBy α g :=
+  (movedBy_eq_movedBy_inv α g) ▸ smul_mem_movedBy_iff_mem_movedBy
+
+@[to_additive]
+theorem movedBy_pow_subset_movedBy (g : G) (j : ℤ) :
+    movedBy α (g^j) ⊆ movedBy α g := by
+  repeat rw [movedBy_eq_compl_fixedBy]
+  rw [Set.compl_subset_compl]
+  exact fixedBy_subset_fixedBy_pow g j
+
+variable (M α)
+
+@[to_additive (attr := simp)]
+theorem movedBy_one_eq_empty : movedBy α (1 : M) = ∅ := by
+  rw [movedBy_eq_compl_fixedBy, fixedBy_one_eq_univ, Set.compl_univ]
+
+variable {M}
+
+@[to_additive]
+theorem movedBy_mul (m₁ m₂ : M) : movedBy α (m₁ * m₂) ⊆ movedBy α m₁ ∪ movedBy α m₂ := by
+  repeat rw [movedBy_eq_compl_fixedBy]
+  rw [<-Set.compl_inter, Set.compl_subset_compl]
+  exact fixedBy_mul α m₁ m₂
+
+@[to_additive]
+theorem movedBy_conj (g h : G) :
+    movedBy α (h * g * h⁻¹) = (fun a => h⁻¹ • a) ⁻¹' movedBy α g := by
+  repeat rw [movedBy_eq_compl_fixedBy]
+  rw [Set.preimage_compl, fixedBy_conj]
+
+@[to_additive]
+theorem movedBy_conj' {g h : G} :
+    h • movedBy α g = movedBy α (h * g * h⁻¹) := by
+  rw [movedBy_conj, Set.preimage_smul, inv_inv]
+
+end MovedBy
+
+section Image
+
+/-- If `s` is a superset of `movedBy α g`, then `g` cannot move a point outside of `s`. -/
+@[to_additive "If `s` is a superset of `movedBy α g`, then `g` cannot move a point outside of `s`."]
+theorem smul_pow_mem_of_movedBy_subset {a : α} {s : Set α} {g : G} (s_subset : movedBy α g ⊆ s)
+    (j : ℤ) : g^j • a ∈ s ↔ a ∈ s := by
+  rcases (Classical.em (a ∈ movedBy α (g^j))) with a_moved | a_fixed
+  · constructor
+    all_goals (intro; apply s_subset)
+    all_goals apply movedBy_pow_subset_movedBy g j
+    · exact a_moved
+    · rw [smul_mem_movedBy_iff_mem_movedBy]
+      exact a_moved
+  · rw [not_mem_movedBy_iff_mem_fixedBy, mem_fixedBy] at a_fixed
+    rw [a_fixed]
+
+@[to_additive]
+theorem smul_mem_of_movedBy_subset {a : α} {s : Set α} {g : G} (superset : movedBy α g ⊆ s) :
+    g • a ∈ s ↔ a ∈ s := (zpow_one g) ▸ smul_pow_mem_of_movedBy_subset superset 1
+
+@[to_additive]
+theorem smul_pow_preimage_eq_of_movedBy_subset {s : Set α} {g : G} (superset : movedBy α g ⊆ s)
+    (j : ℤ) : (fun a => g^j • a) ⁻¹' s = s := by
+  ext a
+  rw [Set.mem_preimage, smul_pow_mem_of_movedBy_subset superset]
+
+/-- If `movedBy α g ⊆ t`, then `g` cannot send a subset of `t` outside of `t` -/
+@[to_additive]
+theorem smul_pow_subset_of_movedBy_subset {s t : Set α} {g : G}  (t_superset : movedBy α g ⊆ t)
+    (s_ss_t : s ⊆ t) (j : ℤ): (fun a => g^j • a) ⁻¹' s ⊆ t := by
+  rw [<-smul_pow_preimage_eq_of_movedBy_subset t_superset j]
+  repeat rw [Set.preimage_smul]
+  exact Set.smul_set_mono s_ss_t
+
+/-- If `g` and `h` commute, then `g` fixes `h • x` iff `g` fixes `x`. -/
+@[to_additive]
+theorem smul_pow_mem_fixedBy_of_commute {g h : G} (comm : Commute g h) (x : α) (j : ℤ):
+    x ∈ fixedBy α g ↔ h^j • x ∈ fixedBy α g := by
+  suffices ∀ x : α, ∀ h : G, Commute g h → x ∈ fixedBy α g → h^j • x ∈ fixedBy α g by
+    refine ⟨this x h comm, fun hx_in_fixedBy => ?x_in_fixedBy⟩
+    have h₁ : x = h⁻¹^j • h^j • x := by rw [<-mul_smul, inv_zpow', zpow_neg, mul_left_inv, one_smul]
+    rw [h₁]
+    exact this _ _ comm.inv_right hx_in_fixedBy
+  intro x h comm x_in_fixedBy
+  rw [mem_fixedBy, <-mul_smul]
+  rw [Commute.zpow_right comm j]
+  rw [mul_smul, smul_left_cancel_iff]
+  exact x_in_fixedBy
+
+/-- If `g` and `h` commute, then `g` moves `h • x` iff `g` moves `x`. -/
+@[to_additive]
+theorem smul_pow_mem_movedBy_of_commute {g h : G} (comm : Commute g h) (a : α) (j : ℤ):
+    a ∈ movedBy α g ↔ h^j • a ∈ movedBy α g := by
+  repeat rw [movedBy_eq_compl_fixedBy]
+  repeat rw [Set.mem_compl_iff]
+  rw [smul_pow_mem_fixedBy_of_commute comm]
+
+@[to_additive]
+theorem movedBy_eq_smul_pow_movedBy_of_commute {g h : G} (comm : Commute g h) (j : ℤ):
+    movedBy α g = (fun a => h^j • a) ⁻¹' movedBy α g := by
+  ext a
+  rw [Set.mem_preimage, smul_pow_mem_movedBy_of_commute comm]
+
+@[to_additive]
+theorem movedBy_eq_smul_movedBy_of_commute {g h : G} (comm : Commute g h):
+    movedBy α g = (fun a => h • a) ⁻¹' movedBy α g := by
+  nth_rw 1 [movedBy_eq_smul_pow_movedBy_of_commute comm 1]
+  rw [zpow_one]
+
+end Image
+
+section Faithful
+
+variable [FaithfulSMul G α]
+variable [FaithfulSMul M α]
+
+/-- If the action is faithful, then an empty `movedBy` set implies that `m = 1` -/
+@[to_additive]
+theorem movedBy_empty_iff_eq_one {m : M} : movedBy α m = ∅ ↔ m = 1 := ⟨
+  (by
+    intro moved_empty
+    apply FaithfulSMul.eq_of_smul_eq_smul (α := α)
+    intro a
+    rw [one_smul]
+    by_contra ma_ne_a
+    rwa [<-ne_eq, <-mem_movedBy, moved_empty] at ma_ne_a
+  ),
+  fun eq_one => eq_one.symm ▸ movedBy_one_eq_empty α M
+⟩
+
+/--
+This theorem allows to deduce the non-commutativity of `g` and `h`
+from the `movedBy` set of a faithful group action.
+--/
+theorem not_commute_of_disjoint_movedBy_preimage {g h : G} (ne_one : g ≠ 1)
+    (disjoint : Disjoint (movedBy α g) ((fun a => h • a) ⁻¹' movedBy α g)) : ¬Commute g h := by
+  intro h₁
+  apply ne_one
+  nth_rw 1 [movedBy_eq_smul_movedBy_of_commute h₁] at disjoint
+  rw [disjoint_self, Set.bot_eq_empty, Set.preimage_smul, Set.smul_set_eq_empty] at disjoint
+  rwa [movedBy_empty_iff_eq_one] at disjoint
+
+end Faithful
+
+end MulAction

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -198,9 +198,8 @@ theorem smul_pow_mem_of_movedBy_subset {a : α} {s : Set α} {g : G} (s_subset :
   · rw [not_mem_movedBy_iff_mem_fixedBy, mem_fixedBy] at a_fixed
     rw [a_fixed]
 
--- TODO: rename to smul_mem
 @[to_additive]
-theorem smul_in_set_of_movedBy_subset {a : α} {s : Set α} {g : G} (superset : movedBy α g ⊆ s) :
+theorem smul_mem_of_movedBy_subset {a : α} {s : Set α} {g : G} (superset : movedBy α g ⊆ s) :
     g • a ∈ s ↔ a ∈ s := (zpow_one g) ▸ smul_pow_mem_of_movedBy_subset superset 1
 
 @[to_additive]

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2024 Emilie Burgun. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Emilie Burgun
+-/
+import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Dynamics.PeriodicPts
+
+/-!
+# Properties of `fixedPoints` and `fixedBy`
+
+This module contains some useful properties of `MulAction.fixedPoints` and `MulAction.fixedBy`
+that don't directly belong to `Mathlib.GroupTheory.GroupAction.Basic`,
+as well as the definition of `MulAction.movedBy`.
+-/
+
+namespace MulAction
+
+universe u v
+variable {α : Type v}
+variable {G : Type u} [Group G] [MulAction G α]
+variable {M : Type u} [Monoid M] [MulAction M α]
+
+
+section FixedPoints
+
+/-- In a multiplicative group action, the points fixed by `g` are also fixed by `g⁻¹` -/
+@[to_additive "In an additive group action, the points fixed by `g` are also fixed by `g⁻¹`"]
+theorem fixedBy_eq_fixedBy_inv (g : G) : fixedBy α g = fixedBy α g⁻¹ := by
+  ext x
+  repeat rw [mem_fixedBy]
+  constructor
+  all_goals (intro gx_eq_x; nth_rw 1 [<-gx_eq_x])
+  · exact inv_smul_smul g x
+  · rw [<-mul_smul, mul_right_inv, one_smul]
+
+@[to_additive]
+theorem smul_mem_fixedBy_iff_mem_fixedBy {a : α} {g : G} :
+    g • a ∈ fixedBy α g ↔ a ∈ fixedBy α g := by
+  rw [mem_fixedBy, smul_left_cancel_iff]
+  rfl
+
+@[to_additive]
+theorem minimalPeriod_eq_one_of_fixedBy {a : α} {g : G} (a_in_fixedBy : a ∈ fixedBy α g) :
+    Function.minimalPeriod (fun x => g • x) a = 1 := by
+  rw [Function.minimalPeriod_eq_one_iff_isFixedPt]
+  exact a_in_fixedBy
+
+@[to_additive]
+theorem fixedBy_subset_fixedBy_pow (g : G) (j : ℤ) :
+    fixedBy α g ⊆ fixedBy α (g^j) := by
+  intro a a_in_fixedBy
+  rw [
+    mem_fixedBy,
+    zpow_smul_eq_iff_minimalPeriod_dvd,
+    minimalPeriod_eq_one_of_fixedBy a_in_fixedBy
+  ]
+  rw [Nat.cast_one]
+  exact one_dvd j
+
+variable (M)
+
+@[to_additive (attr := simp)]
+theorem fixedBy_one_eq_univ :
+    fixedBy α (1 : M) = Set.univ := by
+  ext a
+  rw [mem_fixedBy, one_smul]
+  exact ⟨fun _ => Set.mem_univ a, fun _ => rfl⟩
+
+end FixedPoints
+
+section MovedBy
+
+variable (α)
+
+/-- The set of points moved by an element of the action. -/
+@[to_additive "The set of points moved by an element of the action."]
+def movedBy (m : M) : Set α := { a : α | m • a ≠ a }
+
+variable {α}
+
+@[to_additive (attr := simp)]
+theorem mem_movedBy {m : M} {a : α} : a ∈ movedBy α m ↔ m • a ≠ a :=
+  Iff.rfl
+
+@[to_additive]
+theorem movedBy_eq_compl_fixedBy {m : M} : movedBy α m = (fixedBy α m)ᶜ := rfl
+
+@[to_additive]
+theorem fixedBy_eq_compl_movedBy {m : M} : fixedBy α m = (movedBy α m)ᶜ := by
+  rw [<-compl_compl (fixedBy α m), movedBy_eq_compl_fixedBy]
+
+@[to_additive]
+theorem not_mem_fixedBy_iff_mem_movedBy {m : M} {a : α} : a ∉ fixedBy α m ↔ a ∈ movedBy α m :=
+  Iff.rfl
+
+@[to_additive]
+theorem not_mem_movedBy_iff_mem_fixedBy {m : M} {a : α} : a ∉ movedBy α m ↔ a ∈ fixedBy α m := by
+  rw [movedBy_eq_compl_fixedBy, Set.not_mem_compl_iff]
+
+/-- In a multiplicative group action, the points moved by `g` are also moved by `g⁻¹` -/
+@[to_additive "In an additive group action, the points moved by `g` are also moved by `g⁻¹`"]
+theorem movedBy_eq_movedBy_inv (g : G) : movedBy α g = movedBy α g⁻¹ := by
+  repeat rw [movedBy_eq_compl_fixedBy]
+  rw [fixedBy_eq_fixedBy_inv]
+
+@[to_additive]
+theorem smul_mem_movedBy_iff_mem_movedBy {a : α} {g : G} :
+    g • a ∈ movedBy α g ↔ a ∈ movedBy α g := by
+  repeat rw [<-not_mem_fixedBy_iff_mem_movedBy]
+  rw [smul_mem_fixedBy_iff_mem_fixedBy]
+
+@[to_additive]
+theorem movedBy_pow_subset_movedBy (g : G) (j : ℤ) :
+    movedBy α (g^j) ⊆ movedBy α g := by
+  repeat rw [movedBy_eq_compl_fixedBy]
+  rw [Set.compl_subset_compl]
+  exact fixedBy_subset_fixedBy_pow g j
+
+@[to_additive (attr := simp)]
+theorem movedBy_one_eq_empty (α) (M : Type u) [Monoid M] [MulAction M α] :
+    movedBy α (1 : M) = ∅ := by
+  rw [movedBy_eq_compl_fixedBy, fixedBy_one_eq_univ, Set.compl_univ]
+
+/-- If `s` is a superset of `movedBy α g`, then `g` cannot move a point outside of `s`. -/
+@[to_additive "If `s` is a superset of `movedBy α g`, then `g` cannot move a point outside of `s`."]
+theorem smul_pow_in_set_of_movedBy_subset {a : α} {s : Set α} {g : G} (s_subset : movedBy α g ⊆ s)
+    (j : ℤ) : g^j • a ∈ s ↔ a ∈ s := by
+  rcases (Classical.em (a ∈ movedBy α (g^j))) with a_moved | a_fixed
+  · constructor
+    all_goals (intro; apply s_subset)
+    all_goals apply movedBy_pow_subset_movedBy g j
+    · exact a_moved
+    · rw [smul_mem_movedBy_iff_mem_movedBy]
+      exact a_moved
+  · rw [not_mem_movedBy_iff_mem_fixedBy, mem_fixedBy] at a_fixed
+    rw [a_fixed]
+
+@[to_additive]
+theorem smul_in_set_of_movedBy_subset {a : α} {s : Set α} {g : G} (s_subset : movedBy α g ⊆ s) :
+    g • a ∈ s ↔ a ∈ s := (zpow_one g) ▸ smul_pow_in_set_of_movedBy_subset s_subset 1
+
+end MovedBy
+
+section Faithful
+
+variable [FaithfulSMul G α]
+variable [FaithfulSMul M α]
+
+/-- If the action is faithful, then an empty `movedBy` set implies that `m = 1` -/
+@[to_additive]
+theorem movedBy_empty_iff_eq_one {m : M} : movedBy α m = ∅ ↔ m = 1 := ⟨
+  (by
+    intro moved_empty
+    apply FaithfulSMul.eq_of_smul_eq_smul (α := α)
+    intro a
+    rw [one_smul]
+    by_contra ma_ne_a
+    rwa [<-ne_eq, <-mem_movedBy, moved_empty] at ma_ne_a
+  ),
+  fun eq_one => eq_one.symm ▸ movedBy_one_eq_empty α M
+⟩
+
+end Faithful
+
+end MulAction

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -20,8 +20,8 @@ as well as the definition of [`MulAction.movedBy`].
   for the different relationship between the `movedBy`/`fixedBy` sets of `g*h`.
 * [`MulAction.fixedBy_conj`] and [`MulAction.movedBy_conj`]: the pointwise group action on the sets
   `fixedBy α g` and `movedBy α g` translates to the conjugation action on `g`.
-* [`MulAction.smul_in_set_of_movedBy_subset`] shows that if a set `s` is a superset of `movedBy α g`,
-  then the group action of `g` cannot send elements of `s` outside of `s`.
+* [`MulAction.smul_in_set_of_movedBy_subset`] shows that if a set `s` is a superset of
+  `movedBy α g`, then the group action of `g` cannot send elements of `s` outside of `s`.
 * [`MulAction.not_commute_of_disjoint_movedBy_preimage`] allows one to infer that two group elements
   do not commute from the behavior of their `movedBy` sets, which is useful in the proof of
   Rubin's theorem.

--- a/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixedPoints.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Emilie Burgun
 -/
 import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.GroupTheory.GroupAction.Period
 import Mathlib.Dynamics.PeriodicPts
 import Mathlib.Data.Set.Pointwise.SMul
 
@@ -55,17 +56,15 @@ theorem smul_mem_fixedBy_iff_mem_fixedBy {a : α} {g : G} :
   rfl
 
 @[to_additive]
-theorem minimalPeriod_eq_one_of_fixedBy {a : α} {g : G} (a_in_fixedBy : a ∈ fixedBy α g) :
-    Function.minimalPeriod (fun x => g • x) a = 1 := by
-  rw [Function.minimalPeriod_eq_one_iff_isFixedPt]
-  exact a_in_fixedBy
+theorem period_eq_one_of_fixedBy {a : α} {g : G} (a_in_fixedBy : a ∈ fixedBy α g) :
+    period g a = 1 := period_eq_one_of_fixed a_in_fixedBy
 
 @[to_additive]
 theorem fixedBy_subset_fixedBy_pow (g : G) (j : ℤ) :
     fixedBy α g ⊆ fixedBy α (g^j) := by
   intro a a_in_fixedBy
-  rw [mem_fixedBy, zpow_smul_eq_iff_minimalPeriod_dvd,
-    minimalPeriod_eq_one_of_fixedBy a_in_fixedBy]
+  rw [mem_fixedBy, zpow_smul_eq_iff_period_dvd,
+    period_eq_one_of_fixed a_in_fixedBy]
   rw [Nat.cast_one]
   exact one_dvd j
 

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -5,6 +5,7 @@ Authors: Antoine Chambert-Loir
 -/
 import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.GroupTheory.GroupAction.FixedPoints
 
 #align_import group_theory.group_action.fixing_subgroup from "leanprover-community/mathlib"@"f93c11933efbc3c2f0299e47b8ff83e9b539cbf6"
 
@@ -35,6 +36,10 @@ TODO :
 * Maybe other lemmas are useful
 
 * Treat semigroups ?
+
+* add `to_additive` for the various lemmas
+
+* `movingSubgroup`
 
 -/
 
@@ -120,6 +125,15 @@ theorem mem_fixingSubgroup_iff {s : Set α} {m : M} : m ∈ fixingSubgroup M s �
   ⟨fun hg y hy => hg ⟨y, hy⟩, fun h ⟨y, hy⟩ => h y hy⟩
 #align mem_fixing_subgroup_iff mem_fixingSubgroup_iff
 
+theorem mem_fixingSubgroup_iff_subset_fixedBy {s : Set α} {m : M} :
+    m ∈ fixingSubgroup M s ↔ s ⊆ fixedBy α m := by
+  rw [mem_fixingSubgroup_iff, Set.subset_def]
+  simp only [mem_fixedBy]
+
+theorem mem_fixingSubgroup_compl_iff_movedBy_subset {s : Set α} {m : M} :
+    m ∈ fixingSubgroup M sᶜ ↔ movedBy α m ⊆ s := by
+  rw [mem_fixingSubgroup_iff_subset_fixedBy, fixedBy_eq_compl_movedBy, Set.compl_subset_compl]
+
 variable (α)
 
 /-- The Galois connection between fixing subgroups and fixed points of a group action -/
@@ -160,5 +174,14 @@ theorem fixedPoints_subgroup_iSup {ι : Sort*} {P : ι → Subgroup M} :
     fixedPoints (↥(iSup P)) α = ⋂ i, fixedPoints (P i) α :=
   (fixingSubgroup_fixedPoints_gc M α).u_iInf
 #align fixed_points_subgroup_supr fixedPoints_subgroup_iSup
+
+/-- The orbit of the moving subgroup of `s` is a subset of `s` -/
+theorem orbit_fixingSubgroup_compl_subset {s : Set α}
+    {a : α} (a_in_s : a ∈ s) : MulAction.orbit (fixingSubgroup M sᶜ) a ⊆ s := by
+  intro b b_in_orbit
+  let ⟨⟨g, g_fixing⟩, g_eq⟩ := MulAction.mem_orbit_iff.mp b_in_orbit
+  rw [Submonoid.mk_smul] at g_eq
+  rw [mem_fixingSubgroup_compl_iff_movedBy_subset] at g_fixing
+  rwa [<-g_eq, smul_in_set_of_movedBy_subset g_fixing]
 
 end Group

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -5,6 +5,7 @@ Authors: Antoine Chambert-Loir
 -/
 import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.GroupTheory.GroupAction.FixedPoints
 
 #align_import group_theory.group_action.fixing_subgroup from "leanprover-community/mathlib"@"f93c11933efbc3c2f0299e47b8ff83e9b539cbf6"
 
@@ -35,6 +36,10 @@ TODO :
 * Maybe other lemmas are useful
 
 * Treat semigroups ?
+
+* add `to_additive` for the various lemmas
+
+* `movingSubgroup`
 
 -/
 
@@ -120,6 +125,15 @@ theorem mem_fixingSubgroup_iff {s : Set α} {m : M} : m ∈ fixingSubgroup M s �
   ⟨fun hg y hy => hg ⟨y, hy⟩, fun h ⟨y, hy⟩ => h y hy⟩
 #align mem_fixing_subgroup_iff mem_fixingSubgroup_iff
 
+theorem mem_fixingSubgroup_iff_subset_fixedBy {s : Set α} {m : M} :
+    m ∈ fixingSubgroup M s ↔ s ⊆ fixedBy α m := by
+  rw [mem_fixingSubgroup_iff, Set.subset_def]
+  simp only [mem_fixedBy]
+
+theorem mem_fixingSubgroup_compl_iff_movedBy_subset {s : Set α} {m : M} :
+    m ∈ fixingSubgroup M sᶜ ↔ movedBy α m ⊆ s := by
+  rw [mem_fixingSubgroup_iff_subset_fixedBy, fixedBy_eq_compl_movedBy, Set.compl_subset_compl]
+
 variable (α)
 
 /-- The Galois connection between fixing subgroups and fixed points of a group action -/
@@ -160,5 +174,14 @@ theorem fixedPoints_subgroup_iSup {ι : Sort*} {P : ι → Subgroup M} :
     fixedPoints (↥(iSup P)) α = ⋂ i, fixedPoints (P i) α :=
   (fixingSubgroup_fixedPoints_gc M α).u_iInf
 #align fixed_points_subgroup_supr fixedPoints_subgroup_iSup
+
+/-- The orbit of the fixing subgroup of `sᶜ` (ie. the moving subgroup of `s`) is a subset of `s` -/
+theorem orbit_fixingSubgroup_compl_subset {s : Set α}
+    {a : α} (a_in_s : a ∈ s) : MulAction.orbit (fixingSubgroup M sᶜ) a ⊆ s := by
+  intro b b_in_orbit
+  let ⟨⟨g, g_fixing⟩, g_eq⟩ := MulAction.mem_orbit_iff.mp b_in_orbit
+  rw [Submonoid.mk_smul] at g_eq
+  rw [mem_fixingSubgroup_compl_iff_movedBy_subset] at g_fixing
+  rwa [<-g_eq, smul_mem_of_movedBy_subset g_fixing]
 
 end Group

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -182,6 +182,6 @@ theorem orbit_fixingSubgroup_compl_subset {s : Set α}
   let ⟨⟨g, g_fixing⟩, g_eq⟩ := MulAction.mem_orbit_iff.mp b_in_orbit
   rw [Submonoid.mk_smul] at g_eq
   rw [mem_fixingSubgroup_compl_iff_movedBy_subset] at g_fixing
-  rwa [<-g_eq, smul_mem_of_movedBy_subset g_fixing]
+  rwa [← g_eq, smul_mem_of_movedBy_subset g_fixing]
 
 end Group

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -175,13 +175,13 @@ theorem fixedPoints_subgroup_iSup {ι : Sort*} {P : ι → Subgroup M} :
   (fixingSubgroup_fixedPoints_gc M α).u_iInf
 #align fixed_points_subgroup_supr fixedPoints_subgroup_iSup
 
-/-- The orbit of the moving subgroup of `s` is a subset of `s` -/
+/-- The orbit of the fixing subgroup of `sᶜ` (ie. the moving subgroup of `s`) is a subset of `s` -/
 theorem orbit_fixingSubgroup_compl_subset {s : Set α}
     {a : α} (a_in_s : a ∈ s) : MulAction.orbit (fixingSubgroup M sᶜ) a ⊆ s := by
   intro b b_in_orbit
   let ⟨⟨g, g_fixing⟩, g_eq⟩ := MulAction.mem_orbit_iff.mp b_in_orbit
   rw [Submonoid.mk_smul] at g_eq
   rw [mem_fixingSubgroup_compl_iff_movedBy_subset] at g_fixing
-  rwa [<-g_eq, smul_in_set_of_movedBy_subset g_fixing]
+  rwa [<-g_eq, smul_mem_of_movedBy_subset g_fixing]
 
 end Group

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -49,6 +49,14 @@ theorem period_pos_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : 
   rw [period_eq_minimalPeriod]
   exact Function.IsPeriodicPt.minimalPeriod_pos n_pos fixed
 
+@[to_additive]
+theorem period_eq_one_of_fixed {m : M} {a : α} (fixed : m • a = a) : period m a = 1 := by
+  symm
+  rw [← pow_one m] at fixed
+  refine Nat.eq_of_le_of_lt_succ (period_le_of_fixed Nat.one_pos fixed) ?pos
+  rw [Nat.lt_add_left_iff_pos]
+  exact period_pos_of_fixed Nat.one_pos fixed
+
 /-- For any non-zero `n` less than the period, `a` is moved by `m^n`. -/
 @[to_additive]
 theorem moved_of_lt_period {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (n_lt_period : n < period m a) :

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2024 Emilie Burgun. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Emilie Burgun
+-/
+
+import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Dynamics.PeriodicPts
+import Mathlib.GroupTheory.Exponent
+
+/-!
+# Period of a group action
+
+This module defines the period of a group action ([`MulAction.period`] and [`AddAction.period`]),
+which is the smallest `m` such that `g ^ m • a = a` (resp. `(m • g) +ᵥ a = a`) for a given `g : G` and `a : α`.
+
+If such an `m` does not exist, then by convention `MulAction.period` and `AddAction.period` return 0.
+-/
+
+namespace MulAction
+
+universe u v
+variable {α : Type v}
+variable {G : Type u} [Group G] [MulAction G α]
+variable {M : Type u} [Monoid M] [MulAction M α]
+
+/--
+The period of a multiplicative action of `g` on `a` is the smallest `n` such that `g ^ n • a = a`,
+or `0` if such an `n` does not exist.
+-/
+@[to_additive "The period of an additive action of `g` on `a` is the smallest `n` such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
+noncomputable def period (m : M) (a : α) : ℕ := Function.minimalPeriod (fun x => m • x) a
+
+@[to_additive]
+theorem period_eq_minimalPeriod {m : M} {a : α} :
+    MulAction.period m a = Function.minimalPeriod (fun x => m • x) a := rfl
+
+@[to_additive]
+lemma smul_pow_eq_function_pow (m : M) (a : α) (n : ℕ): m ^ n • a = (fun x => m • x)^[n] a := by
+  rw [smul_iterate]
+
+/-- `m ^ (period m a)` fixes `a` -/
+@[to_additive (attr := simp) "`(period m a) • m` fixes `a`"]
+theorem smul_pow_period_fixed (m : M) (a : α) : m ^ (period m a) • a = a := by
+  rw [period_eq_minimalPeriod, smul_pow_eq_function_pow, Function.iterate_minimalPeriod]
+
+/-- If the action is periodic, then a lower bound for its period can be computed. -/
+@[to_additive]
+theorem period_gt_of_moved {m : M} {a : α} {n : ℕ} (period_pos : 0 < period m a)
+    (moved : ∀ k, 0 < k → k < n → m^k • a ≠ a) : n ≤ period m a := by
+  by_contra period_le_n
+  rw [not_le] at period_le_n
+  apply moved _ period_pos period_le_n
+  exact smul_pow_period_fixed m a
+
+@[to_additive]
+lemma fixed_iff_isPeriodicPt {m : M} {a : α} {n : ℕ} :
+    m ^ n • a = a ↔ Function.IsPeriodicPt (fun x => m • x) n a := by
+  rw [smul_pow_eq_function_pow]
+  rfl
+
+/-- If for some `n`, `m ^ n • a = a`, then `period m a ≤ n`. -/
+@[to_additive]
+theorem period_le_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : m ^ n • a = a) :
+    period m a ≤ n := by
+  rw [period_eq_minimalPeriod]
+  rw [fixed_iff_isPeriodicPt] at fixed
+  exact Function.IsPeriodicPt.minimalPeriod_le n_pos fixed
+
+/-- If for some `n`, `m ^ n • a = a`, then `0 < period m a`. -/
+@[to_additive]
+theorem period_pos_of_fixed {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (fixed : m ^ n • a = a) :
+    0 < period m a := by
+  rw [fixed_iff_isPeriodicPt] at fixed
+  rw [period_eq_minimalPeriod]
+  exact Function.IsPeriodicPt.minimalPeriod_pos n_pos fixed
+
+/-- For any non-zero `n` less than the period, `a` is moved by `m^n`. -/
+@[to_additive]
+theorem moved_of_lt_period {m : M} {a : α} {n : ℕ} (n_pos : 0 < n) (n_lt_period : n < period m a) :
+    m^n • a ≠ a := by
+  intro a_fixed
+  apply Nat.not_le.mpr n_lt_period
+  exact period_le_of_fixed n_pos a_fixed
+
+section MonoidExponent
+
+/-! ## `MulAction.period` and group exponents
+
+The period of a given element `m : M` can be bounded by the `Monoid.exponent M` or `orderOf m`.
+-/
+
+theorem period_pos_of_orderOf_pos {m : M} (order_pos : 0 < orderOf m) (a : α):
+    0 < period m a := by
+  apply period_pos_of_fixed order_pos
+  rw [pow_orderOf_eq_one, one_smul]
+
+theorem period_le_orderOf {m : M} (order_pos : 0 < orderOf m) (a : α):
+    period m a ≤ orderOf m := by
+  apply period_le_of_fixed order_pos
+  rw [pow_orderOf_eq_one, one_smul]
+
+theorem period_pos_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M) (a : α) :
+    0 < period m a := by
+  apply period_pos_of_fixed exp_pos
+  rw [Monoid.pow_exponent_eq_one, one_smul]
+
+theorem period_le_exponent (exp_pos : 0 < Monoid.exponent M) (m : M) (a : α) :
+    period m a ≤ Monoid.exponent M := by
+  apply period_le_of_fixed exp_pos
+  rw [Monoid.pow_exponent_eq_one, one_smul]
+
+variable (α)
+
+theorem period_bounded_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M) :
+    BddAbove (Set.range (fun a : α => period m a)) := by
+  use Monoid.exponent M
+  simp [upperBounds]
+  apply period_le_exponent exp_pos
+
+end MonoidExponent
+
+end MulAction

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -12,9 +12,11 @@ import Mathlib.GroupTheory.Exponent
 # Period of a group action
 
 This module defines some helpful lemmas around [`MulAction.period`] and [`AddAction.period`].
-The period of a point `a` by a group element `g` is the smallest `m` such that `g ^ m • a = a` (resp. `(m • g) +ᵥ a = a`) for a given `g : G` and `a : α`.
+The period of a point `a` by a group element `g` is the smallest `m` such that `g ^ m • a = a`
+(resp. `(m • g) +ᵥ a = a`) for a given `g : G` and `a : α`.
 
-If such an `m` does not exist, then by convention `MulAction.period` and `AddAction.period` return 0.
+If such an `m` does not exist,
+then by convention `MulAction.period` and `AddAction.period` return 0.
 -/
 
 namespace MulAction

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -127,35 +127,56 @@ end MonoidExponent
 
 section Divides
 
-/-! ## Multiples of `MulAction.period` in groups
+/-! ## Multiples of `MulAction.period`
 
-In a group, all exponents/multiples `n` will be a multiple of `period g a`
-if `g ^ n • a = a` (resp. `(n • g) +ᵥ a = a`).
+It is easy to convince onself that if `g ^ n • a = a` (resp. `(n • g) +ᵥ a = a`),
+then `n` must be a multiple of `period g a`.
 -/
 
--- TODO: actually move the implementations of `pow_smul_eq_iff_minimalPeriod_dvd` & others here
-
 @[to_additive]
-theorem pow_smul_eq_iff_period_dvd {n : ℕ} {g : G} {a : α}:
-    g ^ n • a = a ↔ period g a ∣ n := by
-  rw [pow_smul_eq_iff_minimalPeriod_dvd]
-  rfl
+theorem pow_smul_eq_iff_period_dvd {n : ℕ} {m : M} {a : α}:
+    m ^ n • a = a ↔ period m a ∣ n := by
+  rw [
+    period_eq_minimalPeriod,
+    <-Function.isPeriodicPt_iff_minimalPeriod_dvd,
+    fixed_iff_isPeriodicPt
+  ]
 
 @[to_additive]
 theorem zpow_smul_eq_iff_period_dvd {j : ℤ} {g : G} {a : α}:
     g ^ j • a = a ↔ (period g a : ℤ) ∣ j := by
-  rw [zpow_smul_eq_iff_minimalPeriod_dvd]
-  rfl
+  rcases j with n | n
+  · rw [Int.ofNat_eq_coe, zpow_ofNat, Int.coe_nat_dvd, pow_smul_eq_iff_period_dvd]
+  · rw [
+      Int.negSucc_coe, zpow_neg, zpow_ofNat,
+      inv_smul_eq_iff, eq_comm,
+      dvd_neg, Int.coe_nat_dvd,
+      pow_smul_eq_iff_period_dvd
+    ]
 
 @[to_additive (attr := simp)]
-theorem pow_smul_mod_period (n : ℕ) {g : G} {a : α}:
-    g ^ (n % period g a) • a = g ^ n • a := by
-  rw [period_eq_minimalPeriod, pow_smul_mod_minimalPeriod]
+theorem pow_smul_plus_period (n o : ℕ) (m : M) (a : α):
+    m ^ (n + (period m a) * o) • a = m ^ n • a := by
+  rw [pow_add, mul_smul, pow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
 
 @[to_additive (attr := simp)]
-theorem zpow_smul_mod_period (n : ℤ) {g : G} {a : α}:
-    g ^ (n % (period g a : ℤ)) • a = g ^ n • a := by
-  rw [period_eq_minimalPeriod, zpow_smul_mod_minimalPeriod]
+theorem zpow_smul_plus_period (i j : ℤ) (g : G) (a : α):
+    g ^ (i + (period g a : ℤ) * j) • a = g ^ i • a := by
+  rw [zpow_add, mul_smul, zpow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
+
+@[to_additive (attr := simp)]
+theorem pow_smul_mod_period (n : ℕ) {m : M} {a : α}:
+    m ^ (n % period m a) • a = m ^ n • a := by
+  conv_rhs => {
+    rw [<-Nat.mod_add_div n (period m a), pow_smul_plus_period]
+  }
+
+@[to_additive (attr := simp)]
+theorem zpow_smul_mod_period (j : ℤ) {g : G} {a : α}:
+    g ^ (j % (period g a : ℤ)) • a = g ^ j • a := by
+  conv_rhs => {
+    rw [<-Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
+  }
 
 end Divides
 

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -11,8 +11,8 @@ import Mathlib.GroupTheory.Exponent
 /-!
 # Period of a group action
 
-This module defines the period of a group action ([`MulAction.period`] and [`AddAction.period`]),
-which is the smallest `m` such that `g ^ m • a = a` (resp. `(m • g) +ᵥ a = a`) for a given `g : G` and `a : α`.
+This module defines some helpful lemmas around [`MulAction.period`] and [`AddAction.period`].
+The period of a point `a` by a group element `g` is the smallest `m` such that `g ^ m • a = a` (resp. `(m • g) +ᵥ a = a`) for a given `g : G` and `a : α`.
 
 If such an `m` does not exist, then by convention `MulAction.period` and `AddAction.period` return 0.
 -/
@@ -24,26 +24,6 @@ variable {α : Type v}
 variable {G : Type u} [Group G] [MulAction G α]
 variable {M : Type u} [Monoid M] [MulAction M α]
 
-/--
-The period of a multiplicative action of `g` on `a` is the smallest `n` such that `g ^ n • a = a`,
-or `0` if such an `n` does not exist.
--/
-@[to_additive "The period of an additive action of `g` on `a` is the smallest `n` such that `(n • g) +ᵥ a = a`, or `0` if such an `n` does not exist."]
-noncomputable def period (m : M) (a : α) : ℕ := Function.minimalPeriod (fun x => m • x) a
-
-@[to_additive]
-theorem period_eq_minimalPeriod {m : M} {a : α} :
-    MulAction.period m a = Function.minimalPeriod (fun x => m • x) a := rfl
-
-@[to_additive]
-lemma smul_pow_eq_function_pow (m : M) (a : α) (n : ℕ): m ^ n • a = (fun x => m • x)^[n] a := by
-  rw [smul_iterate]
-
-/-- `m ^ (period m a)` fixes `a` -/
-@[to_additive (attr := simp) "`(period m a) • m` fixes `a`"]
-theorem smul_pow_period_fixed (m : M) (a : α) : m ^ (period m a) • a = a := by
-  rw [period_eq_minimalPeriod, smul_pow_eq_function_pow, Function.iterate_minimalPeriod]
-
 /-- If the action is periodic, then a lower bound for its period can be computed. -/
 @[to_additive]
 theorem period_gt_of_moved {m : M} {a : α} {n : ℕ} (period_pos : 0 < period m a)
@@ -52,12 +32,6 @@ theorem period_gt_of_moved {m : M} {a : α} {n : ℕ} (period_pos : 0 < period m
   rw [not_le] at period_le_n
   apply moved _ period_pos period_le_n
   exact smul_pow_period_fixed m a
-
-@[to_additive]
-lemma fixed_iff_isPeriodicPt {m : M} {a : α} {n : ℕ} :
-    m ^ n • a = a ↔ Function.IsPeriodicPt (fun x => m • x) n a := by
-  rw [smul_pow_eq_function_pow]
-  rfl
 
 /-- If for some `n`, `m ^ n • a = a`, then `period m a ≤ n`. -/
 @[to_additive]
@@ -125,59 +99,5 @@ theorem period_bounded_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M)
 
 end MonoidExponent
 
-section Divides
-
-/-! ## Multiples of `MulAction.period`
-
-It is easy to convince onself that if `g ^ n • a = a` (resp. `(n • g) +ᵥ a = a`),
-then `n` must be a multiple of `period g a`.
--/
-
-@[to_additive]
-theorem pow_smul_eq_iff_period_dvd {n : ℕ} {m : M} {a : α}:
-    m ^ n • a = a ↔ period m a ∣ n := by
-  rw [
-    period_eq_minimalPeriod,
-    <-Function.isPeriodicPt_iff_minimalPeriod_dvd,
-    fixed_iff_isPeriodicPt
-  ]
-
-@[to_additive]
-theorem zpow_smul_eq_iff_period_dvd {j : ℤ} {g : G} {a : α}:
-    g ^ j • a = a ↔ (period g a : ℤ) ∣ j := by
-  rcases j with n | n
-  · rw [Int.ofNat_eq_coe, zpow_ofNat, Int.coe_nat_dvd, pow_smul_eq_iff_period_dvd]
-  · rw [
-      Int.negSucc_coe, zpow_neg, zpow_ofNat,
-      inv_smul_eq_iff, eq_comm,
-      dvd_neg, Int.coe_nat_dvd,
-      pow_smul_eq_iff_period_dvd
-    ]
-
-@[to_additive (attr := simp)]
-theorem pow_smul_plus_period (n o : ℕ) (m : M) (a : α):
-    m ^ (n + (period m a) * o) • a = m ^ n • a := by
-  rw [pow_add, mul_smul, pow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
-
-@[to_additive (attr := simp)]
-theorem zpow_smul_plus_period (i j : ℤ) (g : G) (a : α):
-    g ^ (i + (period g a : ℤ) * j) • a = g ^ i • a := by
-  rw [zpow_add, mul_smul, zpow_smul_eq_iff_period_dvd.mpr (dvd_mul_right _ _)]
-
-@[to_additive (attr := simp)]
-theorem pow_smul_mod_period (n : ℕ) {m : M} {a : α}:
-    m ^ (n % period m a) • a = m ^ n • a := by
-  conv_rhs => {
-    rw [<-Nat.mod_add_div n (period m a), pow_smul_plus_period]
-  }
-
-@[to_additive (attr := simp)]
-theorem zpow_smul_mod_period (j : ℤ) {g : G} {a : α}:
-    g ^ (j % (period g a : ℤ)) • a = g ^ j • a := by
-  conv_rhs => {
-    rw [<-Int.emod_add_ediv j (period g a), zpow_smul_plus_period]
-  }
-
-end Divides
 
 end MulAction

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -90,21 +90,25 @@ section MonoidExponent
 The period of a given element `m : M` can be bounded by the `Monoid.exponent M` or `orderOf m`.
 -/
 
+@[to_additive]
 theorem period_pos_of_orderOf_pos {m : M} (order_pos : 0 < orderOf m) (a : α):
     0 < period m a := by
   apply period_pos_of_fixed order_pos
   rw [pow_orderOf_eq_one, one_smul]
 
+@[to_additive]
 theorem period_le_orderOf {m : M} (order_pos : 0 < orderOf m) (a : α):
     period m a ≤ orderOf m := by
   apply period_le_of_fixed order_pos
   rw [pow_orderOf_eq_one, one_smul]
 
+@[to_additive]
 theorem period_pos_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M) (a : α) :
     0 < period m a := by
   apply period_pos_of_fixed exp_pos
   rw [Monoid.pow_exponent_eq_one, one_smul]
 
+@[to_additive]
 theorem period_le_exponent (exp_pos : 0 < Monoid.exponent M) (m : M) (a : α) :
     period m a ≤ Monoid.exponent M := by
   apply period_le_of_fixed exp_pos
@@ -112,6 +116,7 @@ theorem period_le_exponent (exp_pos : 0 < Monoid.exponent M) (m : M) (a : α) :
 
 variable (α)
 
+@[to_additive]
 theorem period_bounded_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M) :
     BddAbove (Set.range (fun a : α => period m a)) := by
   use Monoid.exponent M
@@ -119,5 +124,39 @@ theorem period_bounded_of_exponent_pos (exp_pos : 0 < Monoid.exponent M) (m : M)
   apply period_le_exponent exp_pos
 
 end MonoidExponent
+
+section Divides
+
+/-! ## Multiples of `MulAction.period` in groups
+
+In a group, all exponents/multiples `n` will be a multiple of `period g a`
+if `g ^ n • a = a` (resp. `(n • g) +ᵥ a = a`).
+-/
+
+-- TODO: actually move the implementations of `pow_smul_eq_iff_minimalPeriod_dvd` & others here
+
+@[to_additive]
+theorem pow_smul_eq_iff_period_dvd {n : ℕ} {g : G} {a : α}:
+    g ^ n • a = a ↔ period g a ∣ n := by
+  rw [pow_smul_eq_iff_minimalPeriod_dvd]
+  rfl
+
+@[to_additive]
+theorem zpow_smul_eq_iff_period_dvd {j : ℤ} {g : G} {a : α}:
+    g ^ j • a = a ↔ (period g a : ℤ) ∣ j := by
+  rw [zpow_smul_eq_iff_minimalPeriod_dvd]
+  rfl
+
+@[to_additive (attr := simp)]
+theorem pow_smul_mod_period (n : ℕ) {g : G} {a : α}:
+    g ^ (n % period g a) • a = g ^ n • a := by
+  rw [period_eq_minimalPeriod, pow_smul_mod_minimalPeriod]
+
+@[to_additive (attr := simp)]
+theorem zpow_smul_mod_period (n : ℤ) {g : G} {a : α}:
+    g ^ (n % (period g a : ℤ)) • a = g ^ n • a := by
+  rw [period_eq_minimalPeriod, zpow_smul_mod_minimalPeriod]
+
+end Divides
 
 end MulAction

--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -120,9 +120,9 @@ theorem Quotient.coe_smul_out' [QuotientAction β H] (b : β) (q : α ⧸ H) : �
 #align add_action.quotient.coe_vadd_out' AddAction.Quotient.coe_vadd_out'
 
 theorem _root_.QuotientGroup.out'_conj_pow_minimalPeriod_mem (a : α) (q : α ⧸ H) :
-    q.out'⁻¹ * a ^ Function.minimalPeriod (a • ·) q * q.out' ∈ H := by
+    q.out'⁻¹ * a ^ MulAction.period a q * q.out' ∈ H := by
   rw [mul_assoc, ← QuotientGroup.eq', QuotientGroup.out_eq', ← smul_eq_mul, Quotient.mk_smul_out',
-    eq_comm, pow_smul_eq_iff_minimalPeriod_dvd]
+    eq_comm, smul_pow_period_fixed]
 #align quotient_group.out'_conj_pow_minimal_period_mem QuotientGroup.out'_conj_pow_minimalPeriod_mem
 
 end QuotientAction

--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -119,11 +119,15 @@ theorem Quotient.coe_smul_out' [QuotientAction β H] (b : β) (q : α ⧸ H) : �
 #align mul_action.quotient.coe_smul_out' MulAction.Quotient.coe_smul_out'
 #align add_action.quotient.coe_vadd_out' AddAction.Quotient.coe_vadd_out'
 
-theorem _root_.QuotientGroup.out'_conj_pow_minimalPeriod_mem (a : α) (q : α ⧸ H) :
+theorem _root_.QuotientGroup.out'_conj_pow_period_mem (a : α) (q : α ⧸ H) :
     q.out'⁻¹ * a ^ MulAction.period a q * q.out' ∈ H := by
   rw [mul_assoc, ← QuotientGroup.eq', QuotientGroup.out_eq', ← smul_eq_mul, Quotient.mk_smul_out',
     eq_comm, smul_pow_period_fixed]
-#align quotient_group.out'_conj_pow_minimal_period_mem QuotientGroup.out'_conj_pow_minimalPeriod_mem
+#align quotient_group.out'_conj_pow_minimal_period_mem QuotientGroup.out'_conj_pow_period_mem
+
+@[deprecated]
+alias _root_.QuotientGroup.out'_conj_pow_minimalPeriod_mem :=
+  _root_.QuotientGroup.out'_conj_pow_period_mem
 
 end QuotientAction
 

--- a/Mathlib/GroupTheory/Transfer.lean
+++ b/Mathlib/GroupTheory/Transfer.lean
@@ -119,7 +119,7 @@ theorem transfer_eq_prod_quotient_orbitRel_zpowers_quot [FiniteIndex H] (g : G)
     transfer ϕ g =
       ∏ q : Quotient (orbitRel (zpowers g) (G ⧸ H)),
         ϕ
-          ⟨q.out'.out'⁻¹ * g ^ Function.minimalPeriod (g • ·) q.out' * q.out'.out',
+          ⟨q.out'.out'⁻¹ * g ^ period g q.out' * q.out'.out',
             QuotientGroup.out'_conj_pow_minimalPeriod_mem H g q.out'⟩ := by
   classical
     letI := H.fintypeQuotientOfFiniteIndex
@@ -131,7 +131,7 @@ theorem transfer_eq_prod_quotient_orbitRel_zpowers_quot [FiniteIndex H] (g : G)
         refine' Fintype.prod_congr _ _ (fun q => _)
         simp only [quotientEquivSigmaZMod_symm_apply, transferTransversal_apply',
           transferTransversal_apply'']
-        rw [Fintype.prod_eq_single (0 : ZMod (Function.minimalPeriod (g • ·) q.out')) _]
+        rw [Fintype.prod_eq_single (0 : ZMod (period g q.out')) _]
         · simp only [if_pos, ZMod.cast_zero, zpow_zero, one_mul, mul_assoc]
         · intro k hk
           simp only [if_neg hk, inv_mul_self]
@@ -149,15 +149,15 @@ theorem transfer_eq_pow_aux (g : G)
   classical
     replace key : ∀ (k : ℕ) (g₀ : G), g₀⁻¹ * g ^ k * g₀ ∈ H → g ^ k ∈ H := fun k g₀ hk =>
       (_root_.congr_arg (· ∈ H) (key k g₀ hk)).mp hk
-    replace key : ∀ q : G ⧸ H, g ^ Function.minimalPeriod (g • ·) q ∈ H := fun q =>
-      key (Function.minimalPeriod (g • ·) q) q.out'
+    replace key : ∀ q : G ⧸ H, g ^ period g q ∈ H := fun q =>
+      key (period g q) q.out'
         (QuotientGroup.out'_conj_pow_minimalPeriod_mem H g q)
     let f : Quotient (orbitRel (zpowers g) (G ⧸ H)) → zpowers g := fun q =>
-      (⟨g, mem_zpowers g⟩ : zpowers g) ^ Function.minimalPeriod (g • ·) q.out'
+      (⟨g, mem_zpowers g⟩ : zpowers g) ^ period g q.out'
     have hf : ∀ q, f q ∈ H.subgroupOf (zpowers g) := fun q => key q.out'
     replace key :=
       Subgroup.prod_mem (H.subgroupOf (zpowers g)) fun q (_ : q ∈ Finset.univ) => hf q
-    simpa only [minimalPeriod_eq_card, Finset.prod_pow_eq_pow_sum, Fintype.card_sigma,
+    simpa only [period_eq_card_zpowers_orbit, Finset.prod_pow_eq_pow_sum, Fintype.card_sigma,
       Fintype.card_congr (selfEquivSigmaOrbits (zpowers g) (G ⧸ H)), index_eq_card] using key
 #align monoid_hom.transfer_eq_pow_aux MonoidHom.transfer_eq_pow_aux
 
@@ -174,7 +174,7 @@ theorem transfer_eq_pow [FiniteIndex H] (g : G)
     rw [H.coe_mk, ← (zpowers g).coe_mk g (mem_zpowers g), ← (zpowers g).coe_pow,
       index_eq_card, Fintype.card_congr (selfEquivSigmaOrbits (zpowers g) (G ⧸ H)),
       Fintype.card_sigma, ← Finset.prod_pow_eq_pow_sum, ← Finset.prod_to_list]
-    simp only [Subgroup.val_list_prod, List.map_map, ← minimalPeriod_eq_card]
+    simp only [Subgroup.val_list_prod, List.map_map, ← period_eq_card_zpowers_orbit]
     congr
     funext
     apply key

--- a/Mathlib/GroupTheory/Transfer.lean
+++ b/Mathlib/GroupTheory/Transfer.lean
@@ -120,7 +120,7 @@ theorem transfer_eq_prod_quotient_orbitRel_zpowers_quot [FiniteIndex H] (g : G)
       ∏ q : Quotient (orbitRel (zpowers g) (G ⧸ H)),
         ϕ
           ⟨q.out'.out'⁻¹ * g ^ period g q.out' * q.out'.out',
-            QuotientGroup.out'_conj_pow_minimalPeriod_mem H g q.out'⟩ := by
+            QuotientGroup.out'_conj_pow_period_mem H g q.out'⟩ := by
   classical
     letI := H.fintypeQuotientOfFiniteIndex
     calc
@@ -151,7 +151,7 @@ theorem transfer_eq_pow_aux (g : G)
       (_root_.congr_arg (· ∈ H) (key k g₀ hk)).mp hk
     replace key : ∀ q : G ⧸ H, g ^ period g q ∈ H := fun q =>
       key (period g q) q.out'
-        (QuotientGroup.out'_conj_pow_minimalPeriod_mem H g q)
+        (QuotientGroup.out'_conj_pow_period_mem H g q)
     let f : Quotient (orbitRel (zpowers g) (G ⧸ H)) → zpowers g := fun q =>
       (⟨g, mem_zpowers g⟩ : zpowers g) ^ period g q.out'
     have hf : ∀ q, f q ∈ H.subgroupOf (zpowers g) := fun q => key q.out'


### PR DESCRIPTION
Replaces occurences of `minimalPeriod (m • ·) a` with `period m a`, and leaves some major theorems using `minimalPeriod (m • ·) a` as deprecated.

Few changes had to be done to the proof themselves, since it's just a matter of changing the lemma names. `zmultiplesQuotientStabilizerEquiv` was given some love in the process, while some lemmas were renamed to be less generic (namely `MulAction.minimalPeriod_pos` was renamed to `MulAction.period_pos_of_finite_zpowers_orbit`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Diff is hard to read since it includes changes from both PRs this depends on:

- [ ] depends on: #9490
- [ ] depends on: #9477

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
