### PR TITLE
[Merged by Bors] - chore(FieldTheory/SeparableDegree): add `Separable.natSepDegree_eq_natDegree` and golf

### DIFF
--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -321,8 +321,13 @@ theorem natSepDegree_eq_natDegree_iff (hf : f ≠ 0) :
 
 /-- If a polynomial is separable, then its separable degree is equal to its degree. -/
 theorem natSepDegree_eq_natDegree_of_separable (h : f.Separable) :
-    f.natSepDegree = f.natDegree :=
-  (natSepDegree_eq_natDegree_iff f h.ne_zero).2 h
+    f.natSepDegree = f.natDegree := (natSepDegree_eq_natDegree_iff f h.ne_zero).2 h
+
+variable {f} in
+/-- Same as `Polynomial.natSepDegree_eq_natDegree_of_separable`, but enables the use of
+dot notation. -/
+theorem Separable.natSepDegree_eq_natDegree (h : f.Separable) :
+    f.natSepDegree = f.natDegree := natSepDegree_eq_natDegree_of_separable f h
 
 /-- If a polynomial splits over `E`, then its separable degree is equal to
 the number of distinct roots of it over `E`. -/
@@ -402,7 +407,7 @@ the degree of `g`. -/
 theorem IsSeparableContraction.natSepDegree_eq {g : Polynomial F} {q : ℕ} [ExpChar F q]
     (h : IsSeparableContraction q f g) : f.natSepDegree = g.natDegree := by
   obtain ⟨h1, m, h2⟩ := h
-  rw [← h2, natSepDegree_expand, natSepDegree_eq_natDegree_of_separable g h1]
+  rw [← h2, natSepDegree_expand, h1.natSepDegree_eq_natDegree]
 
 variable {f} in
 /-- If a polynomial has separable contraction, then its separable degree is equal to the degree of
@@ -436,7 +441,7 @@ theorem natSepDegree_eq_one_iff_of_monic' (q : ℕ) [ExpChar F q] (hm : f.Monic)
   refine ⟨fun h ↦ ?_, fun ⟨n, y, h⟩ ↦ ?_⟩
   · obtain ⟨g, h1, n, rfl⟩ := hi.hasSeparableContraction q
     have h2 : g.natDegree = 1 := by
-      rwa [natSepDegree_expand _ q, natSepDegree_eq_natDegree_of_separable g h1] at h
+      rwa [natSepDegree_expand _ q, h1.natSepDegree_eq_natDegree] at h
     rw [((monic_expand_iff <| expChar_pow_pos F q n).mp hm).eq_X_add_C h2]
     exact ⟨n, -(g.coeff 0), by rw [map_neg, sub_neg_eq_add]⟩
   rw [h, natSepDegree_expand _ q, natSepDegree_X_sub_C]


### PR DESCRIPTION
... which is the same as `Polynomial.natSepDegree_eq_natDegree_of_separable`, but enables the use of dot notation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
