### PR TITLE
[Merged by Bors] - feat: Injectivity of monoid localization

### DIFF
--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1909,48 +1909,43 @@ theorem leftCancelMulZero_of_le_isLeftRegular
     (h : ∀ ⦃x⦄, x ∈ S → IsLeftRegular x) : IsLeftCancelMulZero N := by
   let fl := f.toLocalizationMap
   let g := f.toMap
-  --- We prove the property to be left cancellative.
-  have mul_cancel (a z w : N): a ≠ 0 → a * z = a * w → z = w := by
-      intro ha hazw
-      --- Using `LocalizationMap.surj` we find an equality in M that
-      --- imply the goal.
-      obtain ⟨b, hb ⟩ := LocalizationMap.surj fl a
-      obtain ⟨x, hx ⟩ := LocalizationMap.surj fl z
-      obtain ⟨y, hy ⟩ := LocalizationMap.surj fl w
-      rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hx]
-      rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hy]
-      rw [LocalizationMap.eq]
-      use 1
-      simp_rw [OneMemClass.coe_one, one_mul]
-      --- The hypothesis `a ≠ 0` in `P` is equivalent to this
-      have b1ne0 : b.1 ≠ 0 := by
-        intro hb1
-        have m0 : (LocalizationMap.toMap fl) 0 = 0 := f.map_zero'
-        have a0 : a * (LocalizationMap.toMap fl) b.2 = 0 ↔ a = 0 :=
-          (f.toLocalizationMap.map_units' b.2).mul_left_eq_zero
-        rw [hb1, m0, a0] at hb
-        exact ha hb
-      --- Main equality that is deduced from `a * z = a * w`
-      have : g (b.1 * (y.1 * x.2)) = g (b.1 * (x.1 * y.2)) :=
-      calc
-        g (b.1 * (y.1 * x.2)) = g b.1 * g (y.1 * x.2) := map_mul g _ _
-        _ = a * g b.2 * (w * g y.2 * g x.2) := by rw[map_mul g,hb,hy]
-        _ = a * w * g b.2 * (g y.2 * g x.2) := by
-          rw[← mul_assoc _ _ _,← mul_assoc _ w _,mul_assoc a _ w,
-            mul_comm _ w,mul_assoc,← mul_assoc a w _]
-        _ = a * z * g b.2 * (g y.2 * g x.2) := by rw [hazw]
-        _ = a * g b.2 * (z * g x.2 *g y.2) := by
-          rw [mul_comm (g y.2),mul_assoc a z,mul_comm z,
-            ← mul_assoc a,mul_assoc _ z,mul_assoc z]
-        _ = g (b.1 * (x.1 * y.2)) := by rw[hx,hb,map_mul g,← map_mul g]
-      --- The hypothesis `h` gives that `f` (so, `g`) is injective.
-      have : b.1 * (y.1 * x.2) =  b.1 * (x.1 * y.2) :=
-        (LocalizationMap.toMap_injective_iff fl).mpr h this
-      --- The hypothesis to be left cancellative allows us to cancel `b.1`
-      have : (y.1 * x.2) =  (x.1 * y.2) :=
-        IsLeftCancelMulZero.mul_left_cancel_of_ne_zero b1ne0 this
-      rw [mul_comm,← this,mul_comm]
-  exact { mul_left_cancel_of_ne_zero := @mul_cancel }
+  constructor
+  intro a z w ha hazw
+  obtain ⟨b, hb⟩ := LocalizationMap.surj fl a
+  obtain ⟨x, hx⟩ := LocalizationMap.surj fl z
+  obtain ⟨y, hy⟩ := LocalizationMap.surj fl w
+  rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hx,
+    (LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hy, LocalizationMap.eq]
+  use 1
+  rw [OneMemClass.coe_one, one_mul, one_mul]
+  -- The hypothesis `a ≠ 0` in `P` is equivalent to this
+  have b1ne0 : b.1 ≠ 0 := by
+    intro hb1
+    have m0 : (LocalizationMap.toMap fl) 0 = 0 := f.map_zero'
+    have a0 : a * (LocalizationMap.toMap fl) b.2 = 0 ↔ a = 0 :=
+      (f.toLocalizationMap.map_units' b.2).mul_left_eq_zero
+    rw [hb1, m0, a0] at hb
+    exact ha hb
+  -- Main equality that is deduced from `a * z = a * w`
+  have : g (b.1 * (y.1 * x.2)) = g (b.1 * (x.1 * y.2)) :=
+    calc
+      g (b.1 * (y.1 * x.2)) = g b.1 * g (y.1 * x.2) := map_mul g _ _
+      _ = a * g b.2 * (w * g y.2 * g x.2) := by rw[map_mul g,hb,hy]
+      _ = a * w * g b.2 * (g y.2 * g x.2) := by
+        rw[← mul_assoc _ _ _,← mul_assoc _ w _,mul_assoc a _ w,
+          mul_comm _ w,mul_assoc,← mul_assoc a w _]
+      _ = a * z * g b.2 * (g y.2 * g x.2) := by rw [hazw]
+      _ = a * g b.2 * (z * g x.2 *g y.2) := by
+        rw [mul_comm (g y.2), mul_assoc a z, mul_comm z,
+          ← mul_assoc a, mul_assoc _ z, mul_assoc z]
+      _ = g (b.1 * (x.1 * y.2)) := by rw [hx, hb, map_mul g, ← map_mul g]
+    -- The hypothesis `h` gives that `f` (so, `g`) is injective.
+  have : b.1 * (y.1 * x.2) =  b.1 * (x.1 * y.2) :=
+      (LocalizationMap.toMap_injective_iff fl).mpr h this
+  -- The hypothesis to be left cancellative allows us to cancel `b.1`
+  have : (y.1 * x.2) = (x.1 * y.2) :=
+    IsLeftCancelMulZero.mul_left_cancel_of_ne_zero b1ne0 this
+  rw [mul_comm, ← this, mul_comm]
 
 /-- Given a Localization map `f : M →*₀ N` for a Submonoid `S ⊆ M`,
 if `M` is a cancellative monoid with zero, and all elements of `S` are

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1926,26 +1926,21 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       (f.toLocalizationMap.map_units' b.2).mul_left_eq_zero
     rw [hb1, m0, a0] at hb
     exact ha hb
-  -- Main equality that is deduced from `a * z = a * w`
-  have : g (b.1 * (y.1 * x.2)) = g (b.1 * (x.1 * y.2)) :=
+  have main : g (b.1 * (x.2 * y.1)) = g (b.1 * (y.2 * x.1)) :=
     calc
-      g (b.1 * (y.1 * x.2)) = g b.1 * g (y.1 * x.2) := map_mul g _ _
-      _ = a * g b.2 * (w * g y.2 * g x.2) := by rw[map_mul g,hb,hy]
-      _ = a * w * g b.2 * (g y.2 * g x.2) := by
-        rw[← mul_assoc _ _ _,← mul_assoc _ w _,mul_assoc a _ w,
-          mul_comm _ w,mul_assoc,← mul_assoc a w _]
-      _ = a * z * g b.2 * (g y.2 * g x.2) := by rw [hazw]
-      _ = a * g b.2 * (z * g x.2 *g y.2) := by
-        rw [mul_comm (g y.2), mul_assoc a z, mul_comm z,
-          ← mul_assoc a, mul_assoc _ z, mul_assoc z]
-      _ = g (b.1 * (x.1 * y.2)) := by rw [hx, hb, map_mul g, ← map_mul g]
-    -- The hypothesis `h` gives that `f` (so, `g`) is injective.
-  have : b.1 * (y.1 * x.2) =  b.1 * (x.1 * y.2) :=
-      (LocalizationMap.toMap_injective_iff fl).mpr h this
-  -- The hypothesis to be left cancellative allows us to cancel `b.1`
-  have : (y.1 * x.2) = (x.1 * y.2) :=
-    IsLeftCancelMulZero.mul_left_cancel_of_ne_zero b1ne0 this
-  rw [mul_comm, ← this, mul_comm]
+      g (b.1 * (x.2 * y.1)) = g b.1 * (g x.2 * g y.1) := by rw[map_mul g,map_mul g]
+      _ = a * g b.2 * (g x.2 * (w * g y.2)) := by rw[hb, hy]
+      _ = a * w * g b.2 * (g x.2 * g y.2) := by
+        rw [← mul_assoc, ← mul_assoc _ w, mul_comm _ w, mul_assoc w, mul_assoc,
+          ← mul_assoc w, ← mul_assoc w, mul_comm w]
+      _ = a * z * g b.2 * (g x.2 * g y.2) := by rw [hazw]
+      _ = a * g b.2 * (z * g x.2 * g y.2) := by
+        rw[mul_assoc a, mul_comm z, ← mul_assoc a, mul_assoc, mul_assoc z] 
+      _ = g b.1 * g (y.2 * x.1) := by rw [hx, hb, mul_comm (g x.1), ← map_mul g] 
+      _ = g (b.1 * (y.2 * x.1)):= by rw [←map_mul g]
+ -- The hypothesis `h` gives that `f` (so, `g`) is injective, and we can cancel out `b.1`.
+  exact (IsLeftCancelMulZero.mul_left_cancel_of_ne_zero b1ne0 
+      ((LocalizationMap.toMap_injective_iff fl).mpr h main)).symm
 
 /-- Given a Localization map `f : M →*₀ N` for a Submonoid `S ⊆ M`,
 if `M` is a cancellative monoid with zero, and all elements of `S` are

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1935,11 +1935,11 @@ theorem leftCancelMulZero_of_le_isLeftRegular
           ← mul_assoc w, ← mul_assoc w, mul_comm w]
       _ = a * z * g b.2 * (g x.2 * g y.2) := by rw [hazw]
       _ = a * g b.2 * (z * g x.2 * g y.2) := by
-        rw[mul_assoc a, mul_comm z, ← mul_assoc a, mul_assoc, mul_assoc z] 
-      _ = g b.1 * g (y.2 * x.1) := by rw [hx, hb, mul_comm (g x.1), ← map_mul g] 
-      _ = g (b.1 * (y.2 * x.1)):= by rw [←map_mul g]
+        rw[mul_assoc a, mul_comm z, ← mul_assoc a, mul_assoc, mul_assoc z]
+      _ = g b.1 * g (y.2 * x.1) := by rw [hx, hb, mul_comm (g x.1), ← map_mul g]
+      _ = g (b.1 * (y.2 * x.1)):= by rw [← map_mul g]
  -- The hypothesis `h` gives that `f` (so, `g`) is injective, and we can cancel out `b.1`.
-  exact (IsLeftCancelMulZero.mul_left_cancel_of_ne_zero b1ne0 
+  exact (IsLeftCancelMulZero.mul_left_cancel_of_ne_zero b1ne0
       ((LocalizationMap.toMap_injective_iff fl).mpr h main)).symm
 
 /-- Given a Localization map `f : M →*₀ N` for a Submonoid `S ⊆ M`,

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1610,7 +1610,7 @@ theorem of_mulEquivOfMulEquiv {k : LocalizationMap T Q} {j : M ≃* P} (H : S.ma
 #align add_submonoid.localization_map.of_add_equiv_of_add_equiv AddSubmonoid.LocalizationMap.of_addEquivOfAddEquiv
 
 @[to_additive]
-theorem injective_iff (f : LocalizationMap S N) :
+theorem toMap_injective_iff (f : LocalizationMap S N) :
     Injective (LocalizationMap.toMap f) ↔ ∀ ⦃x⦄, x ∈ S → IsLeftRegular x := by
   rw [Injective]
   constructor <;> intro h
@@ -1901,14 +1901,6 @@ noncomputable def lift (f : LocalizationWithZeroMap S N) (g : M →*₀ P)
       exact f.toMonoidWithZeroHom.map_zero.symm }
 #align submonoid.localization_with_zero_map.lift Submonoid.LocalizationWithZeroMap.lift
 
-/-- Given a localization map `f : M →*₀ N` for a submonoid `S ⊆ M`,
-`f 0 * (f y)⁻¹ = 0` for any `y : M` -/
-theorem eq_zero_of_fst_eq_zero (f : LocalizationWithZeroMap S N)
-    {z x} {y : S} (h : z * f.toFun y = f.toFun x)
-  (hx : x = 0) : z = 0 := by
-  rw [hx, f.map_zero'] at h
-  exact (IsUnit.mul_left_eq_zero (LocalizationMap.map_units' f.toLocalizationMap y)).1 h
-
 /-- Given a Localization map `f : M →*₀ N` for a Submonoid `S ⊆ M`,
 if `M` is left cancellative monoid with zero, and all elements of `S` are
 left regular, then N is a left cancellative monoid with zero. This result
@@ -1935,7 +1927,11 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       --- The hypothesis `a ≠ 0` in `P` is equivalent to this
       have b1ne0 : b.1 ≠ 0 := by
         by_contra hb1
-        exact ha (LocalizationWithZeroMap.eq_zero_of_fst_eq_zero f hb hb1)
+        have m0: (LocalizationMap.toMap fl) 0 = 0 := f.map_zero'
+        have a0: a * (LocalizationMap.toMap fl) b.2 = 0 ↔ a = 0 := 
+          (f.toLocalizationMap.map_units' b.2).mul_left_eq_zero
+        rw [hb1, m0, a0] at hb
+        exact ha hb
       --- Main equality that is deduced from `a * z = a * w`
       have : g (b.1 * (y.1 * x.2)) = g (b.1 * (x.1 * y.2)) :=
       calc
@@ -1956,7 +1952,7 @@ theorem leftCancelMulZero_of_le_isLeftRegular
         _ = g (b.1 * (x.1 * y.2)) := by rw[← map_mul g]
       --- The hypothesis `h` gives that `f` (so, `f`) is injective.
       have : b.1 * (y.1 * x.2) =  b.1 * (x.1 * y.2) :=
-        (LocalizationMap.injective_iff fl).mpr h this
+        (LocalizationMap.toMap_injective_iff fl).mpr h this
       --- The hypothesis to be left cancellative allows us to cancel `b.1`
       have : (y.1 * x.2) =  (x.1 * y.2):=
         IsLeftCancelMulZero.mul_left_cancel_of_ne_zero b1ne0 this

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1950,7 +1950,7 @@ theorem leftCancelMulZero_of_le_isLeftRegular
         _ = g b.1 * (g x.1 * g y.2) := by rw[hb]
         _ = g b.1 * g (x.1 * y.2) := by rw[map_mul g]
         _ = g (b.1 * (x.1 * y.2)) := by rw[← map_mul g]
-      --- The hypothesis `h` gives that `f` (so, `f`) is injective.
+      --- The hypothesis `h` gives that `f` (so, `g`) is injective.
       have : b.1 * (y.1 * x.2) =  b.1 * (x.1 * y.2) :=
         (LocalizationMap.toMap_injective_iff fl).mpr h this
       --- The hypothesis to be left cancellative allows us to cancel `b.1`

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1924,7 +1924,7 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       simp_rw [OneMemClass.coe_one, one_mul]
       --- The hypothesis `a ≠ 0` in `P` is equivalent to this
       have b1ne0 : b.1 ≠ 0 := by
-        by_contra hb1
+        intro hb1
         have m0 : (LocalizationMap.toMap fl) 0 = 0 := f.map_zero'
         have a0 : a * (LocalizationMap.toMap fl) b.2 = 0 ↔ a = 0 :=
           (f.toLocalizationMap.map_units' b.2).mul_left_eq_zero

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1622,7 +1622,7 @@ theorem injective_iff (f : LocalizationMap S N) :
     apply (fun y z _ => h) y z x
     have : ∃(x' : S), x' = x := (CanLift.prf x hx)
     obtain ⟨x',hx'⟩ := this
-    rw [←hx'] at hyz
+    rw [← hx'] at hyz
     use x'
   · intro a b hab
     rw [LocalizationMap.eq_iff_exists] at hab
@@ -1910,7 +1910,7 @@ noncomputable def lift (f : LocalizationWithZeroMap S N) (g : M →*₀ P)
 /-- Given a Localization map `f : M →*₀ N` for a Submonoid `S ⊆ M`,
 `f 0 * (f y)⁻¹ = 0` for any `y : M` -/
 theorem eq_zero_of_fst_eq_zero (f : LocalizationWithZeroMap S N)
-  {z x} {y : S} (h : z * f.toFun y = f.toFun x)
+    {z x} {y : S} (h : z * f.toFun y = f.toFun x)
   (hx : x = 0) : z = 0 := by
   rw [hx, f.map_zero'] at h
   exact (IsUnit.mul_left_eq_zero (LocalizationMap.map_units' f.toLocalizationMap y)).1 h
@@ -1950,8 +1950,8 @@ theorem leftCancelMulZero_of_le_isLeftRegular
         _ = a * g b.2 * (g y.1 * g x.2) :=by rw[hb]
         _ = a * g b.2 * (w * g y.2 * g x.2) :=by rw[hy]
         _ = a * w * g b.2 * (g y.2 * g x.2) :=by
-          rw[←mul_assoc _ _ _,←mul_assoc _ w _,mul_assoc a _ w,
-            mul_comm _ w,mul_assoc,←mul_assoc a w _]
+          rw[← mul_assoc _ _ _,← mul_assoc _ w _,mul_assoc a _ w,
+            mul_comm _ w,mul_assoc,← mul_assoc a w _]
         _ = a * z * g b.2 * (g y.2 * g x.2) :=by rw [hazw]
         _ = a * g b.2 * (z * g x.2 *g y.2 ) :=by
           rw [mul_comm (g y.2),mul_assoc a z,mul_comm z,
@@ -1959,14 +1959,14 @@ theorem leftCancelMulZero_of_le_isLeftRegular
         _ = a * g b.2 * (g x.1 * g y.2) :=by rw[hx]
         _ = g b.1 * (g x.1 * g y.2) :=by rw[hb]
         _ = g b.1 * g (x.1 * y.2) :=by rw[map_mul g]
-        _ = g (b.1 * (x.1 * y.2)) := by rw[←map_mul g]
+        _ = g (b.1 * (x.1 * y.2)) := by rw[← map_mul g]
       --- The hypothesis `h` gives that `f` (so, `f`) is injective.
       have : b.1 * (y.1 * x.2) =  b.1 * (x.1 * y.2) :=
         (LocalizationMap.injective_iff fl).mpr h this
       --- The hypothesis to be left cancellative allows us to cancel `b.1`
       have : (y.1 * x.2) =  (x.1 * y.2):=
         IsLeftCancelMulZero.mul_left_cancel_of_ne_zero b1ne0 this
-      rw [mul_comm,←this,mul_comm]
+      rw [mul_comm,← this,mul_comm]
   exact { mul_left_cancel_of_ne_zero := @mul_cancel }
 
 

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1909,8 +1909,8 @@ when it is injective, is a Domain -/
 theorem leftCancelMulZero_of_le_isLeftRegular
     (f : LocalizationWithZeroMap S N) [IsLeftCancelMulZero M]
     (h : ∀ ⦃x⦄, x ∈ S → IsLeftRegular x) : IsLeftCancelMulZero N := by
-  let fl:=f.toLocalizationMap
-  let g:=f.toMap
+  let fl := f.toLocalizationMap
+  let g := f.toMap
   --- We prove the property to be left cancellative.
   have mul_cancel (a z w : N): a ≠ 0 → a * z = a * w → z = w := by
       intro ha hazw
@@ -1927,8 +1927,8 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       --- The hypothesis `a ≠ 0` in `P` is equivalent to this
       have b1ne0 : b.1 ≠ 0 := by
         by_contra hb1
-        have m0: (LocalizationMap.toMap fl) 0 = 0 := f.map_zero'
-        have a0: a * (LocalizationMap.toMap fl) b.2 = 0 ↔ a = 0 :=
+        have m0 : (LocalizationMap.toMap fl) 0 = 0 := f.map_zero'
+        have a0 : a * (LocalizationMap.toMap fl) b.2 = 0 ↔ a = 0 :=
           (f.toLocalizationMap.map_units' b.2).mul_left_eq_zero
         rw [hb1, m0, a0] at hb
         exact ha hb
@@ -1936,25 +1936,25 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       have : g (b.1 * (y.1 * x.2)) = g (b.1 * (x.1 * y.2)) :=
       calc
         g (b.1 * (y.1 * x.2)) = g b.1 * g (y.1 * x.2) := map_mul g _ _
-        _ = g b.1 * (g y.1 * g x.2) :=by rw[map_mul g]
-        _ = a * g b.2 * (g y.1 * g x.2) :=by rw[hb]
-        _ = a * g b.2 * (w * g y.2 * g x.2) :=by rw[hy]
-        _ = a * w * g b.2 * (g y.2 * g x.2) :=by
+        _ = g b.1 * (g y.1 * g x.2) := by rw[map_mul g]
+        _ = a * g b.2 * (g y.1 * g x.2) := by rw[hb]
+        _ = a * g b.2 * (w * g y.2 * g x.2) := by rw[hy]
+        _ = a * w * g b.2 * (g y.2 * g x.2) := by
           rw[← mul_assoc _ _ _,← mul_assoc _ w _,mul_assoc a _ w,
             mul_comm _ w,mul_assoc,← mul_assoc a w _]
-        _ = a * z * g b.2 * (g y.2 * g x.2) :=by rw [hazw]
-        _ = a * g b.2 * (z * g x.2 *g y.2 ) :=by
+        _ = a * z * g b.2 * (g y.2 * g x.2) := by rw [hazw]
+        _ = a * g b.2 * (z * g x.2 *g y.2) := by
           rw [mul_comm (g y.2),mul_assoc a z,mul_comm z,
             ← mul_assoc a,mul_assoc _ z,mul_assoc z]
-        _ = a * g b.2 * (g x.1 * g y.2) :=by rw[hx]
-        _ = g b.1 * (g x.1 * g y.2) :=by rw[hb]
-        _ = g b.1 * g (x.1 * y.2) :=by rw[map_mul g]
+        _ = a * g b.2 * (g x.1 * g y.2) := by rw[hx]
+        _ = g b.1 * (g x.1 * g y.2) := by rw[hb]
+        _ = g b.1 * g (x.1 * y.2) := by rw[map_mul g]
         _ = g (b.1 * (x.1 * y.2)) := by rw[← map_mul g]
       --- The hypothesis `h` gives that `f` (so, `f`) is injective.
       have : b.1 * (y.1 * x.2) =  b.1 * (x.1 * y.2) :=
         (LocalizationMap.toMap_injective_iff fl).mpr h this
       --- The hypothesis to be left cancellative allows us to cancel `b.1`
-      have : (y.1 * x.2) =  (x.1 * y.2):=
+      have : (y.1 * x.2) =  (x.1 * y.2) :=
         IsLeftCancelMulZero.mul_left_cancel_of_ne_zero b1ne0 this
       rw [mul_comm,← this,mul_comm]
   exact { mul_left_cancel_of_ne_zero := @mul_cancel }

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1922,7 +1922,7 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hx]
       rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hy]
       rw [LocalizationMap.eq]
-      use 1 
+      use 1
       simp_rw [OneMemClass.coe_one, one_mul]
       --- The hypothesis `a ≠ 0` in `P` is equivalent to this
       have b1ne0 : b.1 ≠ 0 := by

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1914,9 +1914,9 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       intro ha hazw
       --- Using `LocalizationMap.surj` we find an equality in M that
       --- imply the goal.
-      cases' LocalizationMap.surj fl a with b hb
-      cases' LocalizationMap.surj fl z with x hx
-      cases' LocalizationMap.surj fl w with y hy
+      obtain ⟨b, hb ⟩ := LocalizationMap.surj fl a 
+      obtain ⟨x, hx ⟩ := LocalizationMap.surj fl z 
+      obtain ⟨y, hy ⟩ := LocalizationMap.surj fl w 
       rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hx]
       rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hy]
       rw [LocalizationMap.eq]

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1617,9 +1617,7 @@ theorem injective_iff (f : LocalizationMap S N) :
   · intro x hx y z hyz
     simp_rw [LocalizationMap.eq_iff_exists] at h
     apply (fun y z _ => h) y z x
-    have : ∃(x' : S), x' = x := (CanLift.prf x hx)
-    obtain ⟨x',hx'⟩ := this
-    rw [← hx'] at hyz
+    lift x to S using hx
     use x'
   · intro a b hab
     rw [LocalizationMap.eq_iff_exists] at hab
@@ -1903,7 +1901,7 @@ noncomputable def lift (f : LocalizationWithZeroMap S N) (g : M →*₀ P)
       exact f.toMonoidWithZeroHom.map_zero.symm }
 #align submonoid.localization_with_zero_map.lift Submonoid.LocalizationWithZeroMap.lift
 
-/-- Given a Localization map `f : M →*₀ N` for a Submonoid `S ⊆ M`,
+/-- Given a localization map `f : M →*₀ N` for a submonoid `S ⊆ M`,
 `f 0 * (f y)⁻¹ = 0` for any `y : M` -/
 theorem eq_zero_of_fst_eq_zero (f : LocalizationWithZeroMap S N)
     {z x} {y : S} (h : z * f.toFun y = f.toFun x)

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1959,9 +1959,8 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       rw [mul_comm,← this,mul_comm]
   exact { mul_left_cancel_of_ne_zero := @mul_cancel }
 
-
 /-- Given a Localization map `f : M →*₀ N` for a Submonoid `S ⊆ M`,
-if `M` is cancellative monoid with zero, and all elements of `S` are
+if `M` is a cancellative monoid with zero, and all elements of `S` are
 regular, then N is a cancellative monoid with zero.  -/
 theorem isLeftRegular_of_le_IsCancelMulZero (f : LocalizationWithZeroMap S N)
     [IsCancelMulZero M] (h : ∀ ⦃x⦄, x ∈ S → IsRegular x): IsCancelMulZero N := by

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1903,9 +1903,7 @@ noncomputable def lift (f : LocalizationWithZeroMap S N) (g : M →*₀ P)
 
 /-- Given a Localization map `f : M →*₀ N` for a Submonoid `S ⊆ M`,
 if `M` is left cancellative monoid with zero, and all elements of `S` are
-left regular, then N is a left cancellative monoid with zero. This result
-can be used for CommSemirings to show that the localization of a Domain,
-when it is injective, is a Domain -/
+left regular, then N is a left cancellative monoid with zero. -/
 theorem leftCancelMulZero_of_le_isLeftRegular
     (f : LocalizationWithZeroMap S N) [IsLeftCancelMulZero M]
     (h : ∀ ⦃x⦄, x ∈ S → IsLeftRegular x) : IsLeftCancelMulZero N := by

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1974,8 +1974,7 @@ theorem leftCancelMulZero_of_le_isLeftRegular
 if `M` is cancellative monoid with zero, and all elements of `S` are
 regular, then N is a cancellative monoid with zero.  -/
 theorem isLeftRegular_of_le_IsCancelMulZero (f : LocalizationWithZeroMap S N)
-    [IsCancelMulZero M] (h : ∀ ⦃x⦄, x ∈ S → IsRegular x)
-    : IsCancelMulZero N := by
+    [IsCancelMulZero M] (h : ∀ ⦃x⦄, x ∈ S → IsRegular x): IsCancelMulZero N := by
   have:IsLeftCancelMulZero N:=
     leftCancelMulZero_of_le_isLeftRegular f (fun x h' => (h h').left)
   exact IsLeftCancelMulZero.to_isCancelMulZero

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1922,8 +1922,7 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hx]
       rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hy]
       rw [LocalizationMap.eq]
-      use 1
-      simp
+      simp_rw [OneMemClass.coe_one, one_mul]
       --- The hypothesis `a ≠ 0` in `P` is equivalent to this
       have b1ne0 : b.1 ≠ 0 := by
         by_contra hb1

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1914,9 +1914,9 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       intro ha hazw
       --- Using `LocalizationMap.surj` we find an equality in M that
       --- imply the goal.
-      obtain ⟨b, hb ⟩ := LocalizationMap.surj fl a 
-      obtain ⟨x, hx ⟩ := LocalizationMap.surj fl z 
-      obtain ⟨y, hy ⟩ := LocalizationMap.surj fl w 
+      obtain ⟨b, hb ⟩ := LocalizationMap.surj fl a
+      obtain ⟨x, hx ⟩ := LocalizationMap.surj fl z
+      obtain ⟨y, hy ⟩ := LocalizationMap.surj fl w
       rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hx]
       rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hy]
       rw [LocalizationMap.eq]

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1609,16 +1609,13 @@ theorem of_mulEquivOfMulEquiv {k : LocalizationMap T Q} {j : M ≃* P} (H : S.ma
 #align submonoid.localization_map.of_mul_equiv_of_mul_equiv Submonoid.LocalizationMap.of_mulEquivOfMulEquiv
 #align add_submonoid.localization_map.of_add_equiv_of_add_equiv AddSubmonoid.LocalizationMap.of_addEquivOfAddEquiv
 
-
 @[to_additive]
 theorem injective_iff (f : LocalizationMap S N) :
     Injective (LocalizationMap.toMap f) ↔ ∀ ⦃x⦄, x ∈ S → IsLeftRegular x := by
   rw [Injective]
   constructor <;> intro h
-  · intro x hx
-    rw [IsLeftRegular,Injective]
+  · intro x hx y z hyz
     simp_rw [LocalizationMap.eq_iff_exists] at h
-    intro y z hyz
     apply (fun y z _ => h) y z x
     have : ∃(x' : S), x' = x := (CanLift.prf x hx)
     obtain ⟨x',hx'⟩ := this
@@ -1628,7 +1625,6 @@ theorem injective_iff (f : LocalizationMap S N) :
     rw [LocalizationMap.eq_iff_exists] at hab
     obtain ⟨c,hc⟩ := hab
     apply (fun x a => h a) c (SetLike.coe_mem c) hc
-
 
 end LocalizationMap
 
@@ -1922,7 +1918,7 @@ can be used for CommSemirings to show that the localization of a Domain,
 when it is injective, is a Domain -/
 theorem leftCancelMulZero_of_le_isLeftRegular
     (f : LocalizationWithZeroMap S N) [IsLeftCancelMulZero M]
-    (h : ∀ ⦃x⦄, x ∈ S → IsLeftRegular x): IsLeftCancelMulZero N := by
+    (h : ∀ ⦃x⦄, x ∈ S → IsLeftRegular x) : IsLeftCancelMulZero N := by
   let fl:=f.toLocalizationMap
   let g:=f.toMap
   --- We prove the property to be left cancellative.
@@ -1978,8 +1974,6 @@ theorem isLeftRegular_of_le_IsCancelMulZero (f : LocalizationWithZeroMap S N)
   have:IsLeftCancelMulZero N:=
     leftCancelMulZero_of_le_isLeftRegular f (fun x h' => (h h').left)
   exact IsLeftCancelMulZero.to_isCancelMulZero
-
-
 
 end LocalizationWithZeroMap
 

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1955,7 +1955,7 @@ theorem leftCancelMulZero_of_le_isLeftRegular
         _ = a * z * g b.2 * (g y.2 * g x.2) :=by rw [hazw]
         _ = a * g b.2 * (z * g x.2 *g y.2 ) :=by
           rw [mul_comm (g y.2),mul_assoc a z,mul_comm z,
-            ←mul_assoc a,mul_assoc _ z,mul_assoc z]
+            ← mul_assoc a,mul_assoc _ z,mul_assoc z]
         _ = a * g b.2 * (g x.1 * g y.2) :=by rw[hx]
         _ = g b.1 * (g x.1 * g y.2) :=by rw[hb]
         _ = g b.1 * g (x.1 * y.2) :=by rw[map_mul g]

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1618,7 +1618,7 @@ theorem injective_iff (f : LocalizationMap S N) :
     simp_rw [LocalizationMap.eq_iff_exists] at h
     apply (fun y z _ => h) y z x
     lift x to S using hx
-    use x'
+    use x
   · intro a b hab
     rw [LocalizationMap.eq_iff_exists] at hab
     obtain ⟨c,hc⟩ := hab

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1922,6 +1922,7 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hx]
       rw [(LocalizationMap.eq_mk'_iff_mul_eq fl).mpr hy]
       rw [LocalizationMap.eq]
+      use 1 
       simp_rw [OneMemClass.coe_one, one_mul]
       --- The hypothesis `a ≠ 0` in `P` is equivalent to this
       have b1ne0 : b.1 ≠ 0 := by
@@ -1935,9 +1936,7 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       have : g (b.1 * (y.1 * x.2)) = g (b.1 * (x.1 * y.2)) :=
       calc
         g (b.1 * (y.1 * x.2)) = g b.1 * g (y.1 * x.2) := map_mul g _ _
-        _ = g b.1 * (g y.1 * g x.2) := by rw[map_mul g]
-        _ = a * g b.2 * (g y.1 * g x.2) := by rw[hb]
-        _ = a * g b.2 * (w * g y.2 * g x.2) := by rw[hy]
+        _ = a * g b.2 * (w * g y.2 * g x.2) := by rw[map_mul g,hb,hy]
         _ = a * w * g b.2 * (g y.2 * g x.2) := by
           rw[← mul_assoc _ _ _,← mul_assoc _ w _,mul_assoc a _ w,
             mul_comm _ w,mul_assoc,← mul_assoc a w _]
@@ -1945,10 +1944,7 @@ theorem leftCancelMulZero_of_le_isLeftRegular
         _ = a * g b.2 * (z * g x.2 *g y.2) := by
           rw [mul_comm (g y.2),mul_assoc a z,mul_comm z,
             ← mul_assoc a,mul_assoc _ z,mul_assoc z]
-        _ = a * g b.2 * (g x.1 * g y.2) := by rw[hx]
-        _ = g b.1 * (g x.1 * g y.2) := by rw[hb]
-        _ = g b.1 * g (x.1 * y.2) := by rw[map_mul g]
-        _ = g (b.1 * (x.1 * y.2)) := by rw[← map_mul g]
+        _ = g (b.1 * (x.1 * y.2)) := by rw[hx,hb,map_mul g,← map_mul g]
       --- The hypothesis `h` gives that `f` (so, `g`) is injective.
       have : b.1 * (y.1 * x.2) =  b.1 * (x.1 * y.2) :=
         (LocalizationMap.toMap_injective_iff fl).mpr h this

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1928,7 +1928,7 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       have b1ne0 : b.1 ≠ 0 := by
         by_contra hb1
         have m0: (LocalizationMap.toMap fl) 0 = 0 := f.map_zero'
-        have a0: a * (LocalizationMap.toMap fl) b.2 = 0 ↔ a = 0 := 
+        have a0: a * (LocalizationMap.toMap fl) b.2 = 0 ↔ a = 0 :=
           (f.toLocalizationMap.map_units' b.2).mul_left_eq_zero
         rw [hb1, m0, a0] at hb
         exact ha hb


### PR DESCRIPTION
Adds two results on the Localization for CommMonoids: one, describes exactly when the localization map is injective, the 
other essentially says that the localization of a cancellative Monoid is cancellative if the localization is injective. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
