### PR TITLE
[Merged by Bors] - feat: BinomialRing instance for integers

### DIFF
--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -72,6 +72,8 @@ theorem factorial_nsmul_multichoose_eq_eval_ascPochhammer (r : R) (n : ℕ) :
     n.factorial • multichoose r n = Polynomial.eval r (ascPochhammer R n) :=
   BinomialRing.factorial_nsmul_multichoose r n
 
+end Ring
+
 instance Nat.instBinomialRing : BinomialRing ℕ where
   nsmul_right_injective n hn r s hrs := Nat.eq_of_mul_eq_mul_left (Nat.pos_of_ne_zero hn) hrs
   multichoose := Nat.multichoose
@@ -79,6 +81,22 @@ instance Nat.instBinomialRing : BinomialRing ℕ where
     rw [Nat.multichoose_eq, smul_eq_mul, ← Nat.descFactorial_eq_factorial_mul_choose,
     ascPochhammer_nat_eq_descFactorial]
 
-end Ring
+instance Int.instBinomialRing : BinomialRing ℤ where
+  nsmul_right_injective n hn r s hrs := Int.eq_of_mul_eq_mul_left (Int.ofNat_ne_zero.mpr hn) hrs
+  multichoose r k := by
+    cases r with
+    | ofNat n =>
+      use ((Nat.choose (n + k - 1) k):ℤ)
+    | negSucc n => use (-1)^k * Nat.choose n.succ k
+  factorial_nsmul_multichoose r k := by
+    cases r with
+    | ofNat n =>
+      simp only [nsmul_eq_mul, Int.ofNat_eq_coe, Int.ofNat_mul_out]
+      rw [← Nat.descFactorial_eq_factorial_mul_choose, ← ascPochhammer_nat_eq_descFactorial,
+        ascPochhammer_eval_cast]
+    | negSucc n =>
+      rw [nsmul_eq_mul, mul_comm, mul_assoc, ← Nat.cast_mul, mul_comm _ (k.factorial),
+        ← Nat.descFactorial_eq_factorial_mul_choose, ← descPochhammer_int_eq_descFactorial,
+        ← Int.neg_ofNat_succ, ascPochhammer_eval_neg_eq_descPochhammer]
 
 end Binomial

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -81,21 +81,23 @@ instance Nat.instBinomialRing : BinomialRing ℕ where
     rw [Nat.multichoose_eq, smul_eq_mul, ← Nat.descFactorial_eq_factorial_mul_choose,
     ascPochhammer_nat_eq_descFactorial]
 
+def Int.multichoose (n : ℤ) (k : ℕ) : ℤ := by
+  cases n with
+  | ofNat n => use ((Nat.choose (n + k - 1) k) : ℤ)
+  | negSucc n => use (-1) ^ k * Nat.choose n.succ k
+
 instance Int.instBinomialRing : BinomialRing ℤ where
   nsmul_right_injective n hn r s hrs := Int.eq_of_mul_eq_mul_left (Int.ofNat_ne_zero.mpr hn) hrs
-  multichoose r k := by
-    cases r with
-    | ofNat n =>
-      use ((Nat.choose (n + k - 1) k):ℤ)
-    | negSucc n => use (-1)^k * Nat.choose n.succ k
+  multichoose := Int.multichoose
   factorial_nsmul_multichoose r k := by
+    rw [Int.multichoose, nsmul_eq_mul]
     cases r with
     | ofNat n =>
-      simp only [nsmul_eq_mul, Int.ofNat_eq_coe, Int.ofNat_mul_out]
+      simp only [Int.ofNat_eq_coe, Int.ofNat_mul_out]
       rw [← Nat.descFactorial_eq_factorial_mul_choose, ← ascPochhammer_nat_eq_descFactorial,
         ascPochhammer_eval_cast]
     | negSucc n =>
-      rw [nsmul_eq_mul, mul_comm, mul_assoc, ← Nat.cast_mul, mul_comm _ (k.factorial),
+      rw [mul_comm, mul_assoc, ← Nat.cast_mul, mul_comm _ (k.factorial),
         ← Nat.descFactorial_eq_factorial_mul_choose, ← descPochhammer_int_eq_descFactorial,
         ← Int.neg_ofNat_succ, ascPochhammer_eval_neg_eq_descPochhammer]
 

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -30,7 +30,6 @@ Pochhammer polynomial `X(X+1)⋯(X+(k-1))` at any element is divisible by `k!`. 
 ## TODO
 
 * Replace `Nat.multichoose` with `Ring.multichoose`.
-* `Int.instBinomialRing`
 * `Ring.choose` for binomial rings.
 * Generalize to the power-associative case, when power-associativity is implemented.
 
@@ -81,6 +80,7 @@ instance Nat.instBinomialRing : BinomialRing ℕ where
     rw [Nat.multichoose_eq, smul_eq_mul, ← Nat.descFactorial_eq_factorial_mul_choose,
     ascPochhammer_nat_eq_descFactorial]
 
+/-- The multichoose function for integers. -/
 def Int.multichoose (n : ℤ) (k : ℕ) : ℤ := by
   cases n with
   | ofNat n => use ((Nat.choose (n + k - 1) k) : ℤ)

--- a/Mathlib/RingTheory/Polynomial/Pochhammer.lean
+++ b/Mathlib/RingTheory/Polynomial/Pochhammer.lean
@@ -343,7 +343,7 @@ theorem descPochhammer_mul (n m : ℕ) :
   · rw [descPochhammer_succ_right, Polynomial.mul_X_sub_int_cast_comp, ← mul_assoc, ih,
       Nat.succ_eq_add_one, ← add_assoc, descPochhammer_succ_right, Nat.cast_add, sub_add_eq_sub_sub]
 
-theorem ascPochhammer_eval_neg_eq_descPochhammer (r : R) : ∀(k : ℕ),
+theorem ascPochhammer_eval_neg_eq_descPochhammer (r : R) : ∀ (k : ℕ),
     (ascPochhammer R k).eval (-r) = (-1)^k * (descPochhammer R k).eval r
   | 0 => by
     rw [ascPochhammer_zero, descPochhammer_zero]

--- a/Mathlib/RingTheory/Polynomial/Pochhammer.lean
+++ b/Mathlib/RingTheory/Polynomial/Pochhammer.lean
@@ -343,6 +343,18 @@ theorem descPochhammer_mul (n m : ℕ) :
   · rw [descPochhammer_succ_right, Polynomial.mul_X_sub_int_cast_comp, ← mul_assoc, ih,
       Nat.succ_eq_add_one, ← add_assoc, descPochhammer_succ_right, Nat.cast_add, sub_add_eq_sub_sub]
 
+theorem ascPochhammer_eval_neg_eq_descPochhammer (r : R) : ∀(k : ℕ),
+    (ascPochhammer R k).eval (-r) = (-1)^k * (descPochhammer R k).eval r
+  | 0 => by
+    rw [ascPochhammer_zero, descPochhammer_zero]
+    simp only [eval_one, pow_zero, mul_one]
+  | (k+1) => by
+    rw [ascPochhammer_succ_right, mul_add, eval_add, eval_mul_X, ← Nat.cast_comm, eval_nat_cast_mul,
+      Nat.cast_comm, ← mul_add, ascPochhammer_eval_neg_eq_descPochhammer r k, mul_assoc,
+      descPochhammer_succ_right, mul_sub, eval_sub, eval_mul_X, ← Nat.cast_comm, eval_nat_cast_mul,
+      pow_add, pow_one, mul_assoc ((-1)^k) (-1), mul_sub, neg_one_mul, neg_mul_eq_mul_neg,
+      Nat.cast_comm, sub_eq_add_neg, neg_one_mul, neg_neg, ← mul_add]
+
 theorem descPochhammer_int_eq_descFactorial (n : ℕ) :
     ∀ k, (descPochhammer ℤ k).eval (n : ℤ) = n.descFactorial k
   | 0 => by


### PR DESCRIPTION
We add a binomial ring instance for integers.  To prove the necessary identity for negative integers, we add a lemma comparing evaluations of ascending and descending Pochhammer polynomials.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
