### PR TITLE
[Merged by Bors] - chore: improvements to Presheaf simp lemmas

### DIFF
--- a/Mathlib/AlgebraicGeometry/Spec.lean
+++ b/Mathlib/AlgebraicGeometry/Spec.lean
@@ -117,7 +117,7 @@ theorem Spec.sheafedSpaceMap_id {R : CommRingCat} :
   AlgebraicGeometry.PresheafedSpace.Hom.ext _ _ (Spec.topMap_id R) <| by
     ext U
     dsimp
-    erw [NatTrans.comp_app, sheafedSpaceMap_c_app, PresheafedSpace.id_c_app, comap_id]; swap
+    erw [PresheafedSpace.id_c_app, comap_id]; swap
     · rw [Spec.topMap_id, TopologicalSpace.Opens.map_id_obj_unop]
     simp [eqToHom_map]
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace.lean
@@ -297,7 +297,6 @@ def isoOfComponents (H : X.1 ≅ Y.1) (α : H.hom _* X.2 ≅ Y.2) : X ≅ Y wher
     dsimp
     rw [H.inv_hom_id]
     dsimp
-    rw [NatTrans.comp_app]
     simp only [Presheaf.pushforwardObj_obj, op_obj, Opens.map_comp_obj, comp_obj,
       comp_c_app, unop_op, Presheaf.toPushforwardOfIso_app, whiskerRight_app, eqToHom_app,
       assoc, id_c_app, map_id]
@@ -319,7 +318,7 @@ def sheafIsoOfIso (H : X ≅ Y) : Y.2 ≅ H.hom.base _* X.2 where
   inv_hom_id := by
     ext U
     dsimp
-    rw [NatTrans.comp_app, NatTrans.id_app]
+    rw [NatTrans.id_app]
     simp only [Presheaf.pushforwardObj_obj, op_obj, Presheaf.pushforwardToOfIso_app,
       Iso.symm_inv, mapIso_hom, forget_map, Iso.symm_hom, mapIso_inv,
       unop_op, eqToHom_map, assoc]
@@ -456,15 +455,13 @@ def restrictTopIso (X : PresheafedSpace C) : X.restrict (Opens.openEmbedding ⊤
   hom_inv_id := by
     ext
     · rfl
-    · dsimp
-      erw [comp_c, toRestrictTop_c, whiskerRight_id',
+    · erw [comp_c, toRestrictTop_c, whiskerRight_id',
         comp_id, ofRestrict_top_c, eqToHom_map, eqToHom_trans, eqToHom_refl]
       rfl
   inv_hom_id := by
     ext
     · rfl
-    · dsimp
-      erw [comp_c, ofRestrict_top_c, toRestrictTop_c, eqToHom_map, whiskerRight_id', comp_id,
+    · erw [comp_c, ofRestrict_top_c, toRestrictTop_c, eqToHom_map, whiskerRight_id', comp_id,
         eqToHom_trans, eqToHom_refl]
       rfl
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean
@@ -134,11 +134,11 @@ def pushforwardDiagramToColimit (F : J ⥤ PresheafedSpace.{_, _, v} C) :
         pushforwardObj_obj, op_obj, Opens.map_obj, opEquiv, Equiv.coe_fn_mk, unop_comp,
         Quiver.Hom.unop_op, unop_id]
       -- Porting note : some `simp` lemmas are not picked up
-      rw [NatTrans.comp_app, pushforwardMap_app, NatTrans.id_app]
+      rw [NatTrans.id_app]
       simp only [op_obj, unop_op, Opens.map_obj, map_id_c_app, Opens.map_id_obj',
         map_id, pushforwardEq_hom_app, eqToHom_op, id_eq, eqToHom_map, id_comp,
         TopCat.Presheaf.Pushforward.id_inv_app']
-      rw [NatTrans.comp_app, Pushforward.comp_inv_app, id_comp]
+      rw [Pushforward.comp_inv_app]
       dsimp
       simp
   map_comp {j₁ j₂ j₃} f g := by
@@ -212,13 +212,13 @@ def colimitCocone (F : J ⥤ PresheafedSpace.{_, _, v} C) : Cocone F where
         · ext x
           exact colimit.w_apply (F ⋙ PresheafedSpace.forget C) f x
         · ext ⟨U, hU⟩
-          dsimp
+          dsimp [-Presheaf.comp_app]
           rw [PresheafedSpace.id_c_app, map_id]
           erw [id_comp]
           rw [NatTrans.comp_app, PresheafedSpace.comp_c_app, whiskerRight_app, eqToHom_app,
             ← congr_arg NatTrans.app (limit.w (pushforwardDiagramToColimit F).leftOp f.op),
             NatTrans.comp_app, Functor.leftOp_map, pushforwardDiagramToColimit_map]
-          dsimp
+          dsimp [-Presheaf.comp_app]
           rw [NatTrans.comp_app, NatTrans.comp_app, pushforwardEq_hom_app, id.def, eqToHom_op,
             Pushforward.comp_inv_app, id_comp, pushforwardMap_app, ← assoc]
           congr 1 }
@@ -394,7 +394,7 @@ def colimitPresheafObjIsoComponentwiseLimit (F : J ⥤ PresheafedSpace.{_, _, v}
     simp only [Functor.op_obj, unop_op, op_inj_iff, Opens.map_coe, SetLike.ext'_iff,
       Set.preimage_preimage]
     refine congr_arg (Set.preimage . U.1) (funext fun x => ?_)
-    erw [← comp_app]
+    erw [← TopCat.comp_app]
     congr
     exact ι_preservesColimitsIso_inv (forget C) F (unop X)
   · intro X Y f

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -55,6 +55,9 @@ variable {C}
 
 namespace Presheaf
 
+@[simp] theorem comp_app {P Q R : Presheaf C X} (f : P ⟶ Q) (g : Q ⟶ R) :
+    (f ≫ g).app U = f.app U ≫ g.app U := rfl
+
 -- Porting note: added an `ext` lemma,
 -- since `NatTrans.ext` can not see through the definition of `Presheaf`.
 -- See https://github.com/leanprover-community/mathlib4/issues/5229
@@ -243,7 +246,7 @@ set_option linter.uppercaseLean3 false in
 @[simp (high)]
 theorem id_hom_app' (U) (p) : (id ℱ).hom.app (op ⟨U, p⟩) = ℱ.map (𝟙 (op ⟨U, p⟩)) := by
   dsimp [id]
-  simp [CategoryStruct.comp]
+  simp
 set_option linter.uppercaseLean3 false in
 #align Top.presheaf.pushforward.id_hom_app' TopCat.Presheaf.Pushforward.id_hom_app'
 
@@ -474,7 +477,7 @@ theorem pushforwardToOfIso_app {X Y : TopCat} (H₁ : X ≅ Y) {ℱ : Y.Presheaf
     (pushforwardToOfIso H₁ H₂).app U =
       H₂.app (op ((Opens.map H₁.inv).obj (unop U))) ≫
         𝒢.map (eqToHom (by simp [Opens.map, Set.preimage_preimage])) := by
-  simp [pushforwardToOfIso, Equivalence.toAdjunction, CategoryStruct.comp]
+  simp [pushforwardToOfIso, Equivalence.toAdjunction]
 set_option linter.uppercaseLean3 false in
 #align Top.presheaf.pushforward_to_of_iso_app TopCat.Presheaf.pushforwardToOfIso_app
 

--- a/Mathlib/Topology/Sheaves/Skyscraper.lean
+++ b/Mathlib/Topology/Sheaves/Skyscraper.lean
@@ -326,9 +326,6 @@ protected def unit : 𝟭 (Presheaf C X) ⟶ Presheaf.stalkFunctor C p₀ ⋙ sk
   app 𝓕 := toSkyscraperPresheaf _ <| 𝟙 _
   naturality 𝓕 𝓖 f := by
     ext U; dsimp
-    -- Porting note : added the following `rw` and `dsimp` to make it compile
-    rw [NatTrans.comp_app, toSkyscraperPresheaf_app, NatTrans.comp_app, toSkyscraperPresheaf_app]
-    dsimp only [skyscraperPresheaf_obj, unop_op, Eq.ndrec, SkyscraperPresheafFunctor.map'_app]
     split_ifs with h
     · simp only [Category.id_comp, ← Category.assoc]; rw [comp_eqToHom_iff]
       simp only [Category.assoc, eqToHom_trans, eqToHom_refl, Category.comp_id]


### PR DESCRIPTION
Various things break in the simpset for `Presheaf` when the simp algorithm changes in leanprover/lean4#3124. These backwards compatible fixes are, I think, improvements anyway.

One could further add a `Presheaf.id_app` lemma, and do further cleanup in the proofs which now use `dsimp [-Presheaf.comp_app]`, but I'd prefer if these are done in a followup PR in order to not hold up #9500.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
