### PR TITLE
[Merged by Bors] - feat(RepresentationTheory/Action): add preservation of (co)limits lemmas for functors into `Action V G`

### DIFF
--- a/Mathlib/RepresentationTheory/Action/Limits.lean
+++ b/Mathlib/RepresentationTheory/Action/Limits.lean
@@ -19,7 +19,7 @@ We show:
 * When `V` is preadditive, linear, or abelian so is `Action V G`.
 -/
 
-universe u v
+universe u v w₁ w₂ t₁ t₂
 
 open CategoryTheory Limits
 
@@ -52,6 +52,96 @@ instance [HasColimits V] : HasColimits (Action V G) :=
   Adjunction.has_colimits_of_equivalence (Action.functorCategoryEquivalence _ _).functor
 
 end Limits
+
+section Preservation
+
+variable {C : Type t₁} [Category.{t₂, t₁} C]
+
+/- `F : C ⥤ SingleObj G ⥤ V` preserves the limit of some `K : J ⥤ C` if it does
+evaluated at `SingleObj.star G`.-/
+private def SingleObj.preservesLimit (F : C ⥤ SingleObj G ⥤ V)
+    {J : Type w₁} [Category.{w₂, w₁} J] (K : J ⥤ C)
+    (h : PreservesLimit K (F ⋙ (evaluation (SingleObj G) V).obj (SingleObj.star G))) :
+    PreservesLimit K F := by
+  apply preservesLimitOfEvaluation
+  intro _
+  exact h
+
+/- `F : C ⥤ Action V G` preserves the limit of some `K : J ⥤ C` if
+if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
+def Action.preservesLimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
+    [Category.{w₂, w₁} J] (K : J ⥤ C)
+    (h : PreservesLimit K (F ⋙ Action.forget V G)) : PreservesLimit K F := by
+  let F' : C ⥤ SingleObj G ⥤ V := F ⋙ (Action.functorCategoryEquivalence V G).functor
+  let i : PreservesLimit K F' := by
+    apply SingleObj.preservesLimit
+    show PreservesLimit K (F ⋙ Action.forget V G)
+    assumption
+  apply preservesLimitOfReflectsOfPreserves F (Action.functorCategoryEquivalence V G).functor
+
+/- `F : C ⥤ Action V G` preserves limits of some shape `J`
+if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
+def Action.preservesLimitsOfShapeOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
+    [Category.{w₂, w₁} J] (h : PreservesLimitsOfShape J (F ⋙ Action.forget V G)) :
+    PreservesLimitsOfShape J F := by
+  constructor
+  intro K
+  apply Action.preservesLimitOfPreserves
+  exact PreservesLimitsOfShape.preservesLimit
+
+/- `F : C ⥤ Action V G` preserves limits of some size
+if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
+def Action.preservesLimitOfSizeOfPreserves (F : C ⥤ Action V G)
+    (h : PreservesLimitsOfSize.{w₂, w₁} (F ⋙ Action.forget V G)) :
+    PreservesLimitsOfSize.{w₂, w₁} F := by
+  constructor
+  intro J _
+  apply Action.preservesLimitsOfShapeOfPreserves
+  exact PreservesLimitsOfSize.preservesLimitsOfShape
+
+/- `F : C ⥤ SingleObj G ⥤ V` preserves the colimit of some `K : J ⥤ C` if it does
+evaluated at `SingleObj.star G`.-/
+private def SingleObj.preservesColimit (F : C ⥤ SingleObj G ⥤ V)
+    {J : Type w₁} [Category.{w₂, w₁} J] (K : J ⥤ C)
+    (h : PreservesColimit K (F ⋙ (evaluation (SingleObj G) V).obj (SingleObj.star G))) :
+    PreservesColimit K F := by
+  apply preservesColimitOfEvaluation
+  intro _
+  exact h
+
+/- `F : C ⥤ Action V G` preserves the colimit of some `K : J ⥤ C` if
+if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
+def Action.preservesColimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
+    [Category.{w₂, w₁} J] (K : J ⥤ C)
+    (h : PreservesColimit K (F ⋙ Action.forget V G)) : PreservesColimit K F := by
+  let F' : C ⥤ SingleObj G ⥤ V := F ⋙ (Action.functorCategoryEquivalence V G).functor
+  let i : PreservesColimit K F' := by
+    apply SingleObj.preservesColimit
+    show PreservesColimit K (F ⋙ Action.forget V G)
+    assumption
+  apply preservesColimitOfReflectsOfPreserves F (Action.functorCategoryEquivalence V G).functor
+
+/- `F : C ⥤ Action V G` preserves colimits of some shape `J`
+if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
+def Action.preservesColimitsOfShapeOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
+    [Category.{w₂, w₁} J] (h : PreservesColimitsOfShape J (F ⋙ Action.forget V G)) :
+    PreservesColimitsOfShape J F := by
+  constructor
+  intro K
+  apply Action.preservesColimitOfPreserves
+  exact PreservesColimitsOfShape.preservesColimit
+
+/- `F : C ⥤ Action V G` preserves colimits of some size
+if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
+def Action.preservesColimitOfSizeOfPreserves (F : C ⥤ Action V G)
+    (h : PreservesColimitsOfSize.{w₂, w₁} (F ⋙ Action.forget V G)) :
+    PreservesColimitsOfSize.{w₂, w₁} F := by
+  constructor
+  intro J _
+  apply Action.preservesColimitsOfShapeOfPreserves
+  exact PreservesColimitsOfSize.preservesColimitsOfShape
+
+end Preservation
 
 section HasZeroMorphisms
 

--- a/Mathlib/RepresentationTheory/Action/Limits.lean
+++ b/Mathlib/RepresentationTheory/Action/Limits.lean
@@ -57,7 +57,7 @@ section Preservation
 
 variable {C : Type t₁} [Category.{t₂, t₁} C]
 
-/- `F : C ⥤ SingleObj G ⥤ V` preserves the limit of some `K : J ⥤ C` if it does
+/-- `F : C ⥤ SingleObj G ⥤ V` preserves the limit of some `K : J ⥤ C` if it does
 evaluated at `SingleObj.star G`.-/
 private def SingleObj.preservesLimit (F : C ⥤ SingleObj G ⥤ V)
     {J : Type w₁} [Category.{w₂, w₁} J] (K : J ⥤ C)
@@ -67,9 +67,9 @@ private def SingleObj.preservesLimit (F : C ⥤ SingleObj G ⥤ V)
   intro _
   exact h
 
-/- `F : C ⥤ Action V G` preserves the limit of some `K : J ⥤ C` if
+/-- `F : C ⥤ Action V G` preserves the limit of some `K : J ⥤ C` if
 if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
-def Action.preservesLimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
+def preservesLimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
     [Category.{w₂, w₁} J] (K : J ⥤ C)
     (h : PreservesLimit K (F ⋙ Action.forget V G)) : PreservesLimit K F := by
   let F' : C ⥤ SingleObj G ⥤ V := F ⋙ (Action.functorCategoryEquivalence V G).functor
@@ -79,9 +79,9 @@ def Action.preservesLimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
     assumption
   apply preservesLimitOfReflectsOfPreserves F (Action.functorCategoryEquivalence V G).functor
 
-/- `F : C ⥤ Action V G` preserves limits of some shape `J`
+/-- `F : C ⥤ Action V G` preserves limits of some shape `J`
 if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
-def Action.preservesLimitsOfShapeOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
+def preservesLimitsOfShapeOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
     [Category.{w₂, w₁} J] (h : PreservesLimitsOfShape J (F ⋙ Action.forget V G)) :
     PreservesLimitsOfShape J F := by
   constructor
@@ -89,9 +89,9 @@ def Action.preservesLimitsOfShapeOfPreserves (F : C ⥤ Action V G) {J : Type w�
   apply Action.preservesLimitOfPreserves
   exact PreservesLimitsOfShape.preservesLimit
 
-/- `F : C ⥤ Action V G` preserves limits of some size
+/-- `F : C ⥤ Action V G` preserves limits of some size
 if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
-def Action.preservesLimitOfSizeOfPreserves (F : C ⥤ Action V G)
+def preservesLimitOfSizeOfPreserves (F : C ⥤ Action V G)
     (h : PreservesLimitsOfSize.{w₂, w₁} (F ⋙ Action.forget V G)) :
     PreservesLimitsOfSize.{w₂, w₁} F := by
   constructor
@@ -99,7 +99,7 @@ def Action.preservesLimitOfSizeOfPreserves (F : C ⥤ Action V G)
   apply Action.preservesLimitsOfShapeOfPreserves
   exact PreservesLimitsOfSize.preservesLimitsOfShape
 
-/- `F : C ⥤ SingleObj G ⥤ V` preserves the colimit of some `K : J ⥤ C` if it does
+/-- `F : C ⥤ SingleObj G ⥤ V` preserves the colimit of some `K : J ⥤ C` if it does
 evaluated at `SingleObj.star G`.-/
 private def SingleObj.preservesColimit (F : C ⥤ SingleObj G ⥤ V)
     {J : Type w₁} [Category.{w₂, w₁} J] (K : J ⥤ C)
@@ -109,9 +109,9 @@ private def SingleObj.preservesColimit (F : C ⥤ SingleObj G ⥤ V)
   intro _
   exact h
 
-/- `F : C ⥤ Action V G` preserves the colimit of some `K : J ⥤ C` if
+/-- `F : C ⥤ Action V G` preserves the colimit of some `K : J ⥤ C` if
 if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
-def Action.preservesColimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
+def preservesColimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
     [Category.{w₂, w₁} J] (K : J ⥤ C)
     (h : PreservesColimit K (F ⋙ Action.forget V G)) : PreservesColimit K F := by
   let F' : C ⥤ SingleObj G ⥤ V := F ⋙ (Action.functorCategoryEquivalence V G).functor
@@ -121,9 +121,9 @@ def Action.preservesColimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
     assumption
   apply preservesColimitOfReflectsOfPreserves F (Action.functorCategoryEquivalence V G).functor
 
-/- `F : C ⥤ Action V G` preserves colimits of some shape `J`
+/-- `F : C ⥤ Action V G` preserves colimits of some shape `J`
 if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
-def Action.preservesColimitsOfShapeOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
+def preservesColimitsOfShapeOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
     [Category.{w₂, w₁} J] (h : PreservesColimitsOfShape J (F ⋙ Action.forget V G)) :
     PreservesColimitsOfShape J F := by
   constructor
@@ -131,9 +131,9 @@ def Action.preservesColimitsOfShapeOfPreserves (F : C ⥤ Action V G) {J : Type 
   apply Action.preservesColimitOfPreserves
   exact PreservesColimitsOfShape.preservesColimit
 
-/- `F : C ⥤ Action V G` preserves colimits of some size
+/-- `F : C ⥤ Action V G` preserves colimits of some size
 if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
-def Action.preservesColimitOfSizeOfPreserves (F : C ⥤ Action V G)
+def preservesColimitOfSizeOfPreserves (F : C ⥤ Action V G)
     (h : PreservesColimitsOfSize.{w₂, w₁} (F ⋙ Action.forget V G)) :
     PreservesColimitsOfSize.{w₂, w₁} F := by
   constructor

--- a/Mathlib/RepresentationTheory/Action/Limits.lean
+++ b/Mathlib/RepresentationTheory/Action/Limits.lean
@@ -91,7 +91,7 @@ def preservesLimitsOfShapeOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
 
 /-- `F : C ⥤ Action V G` preserves limits of some size
 if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
-def preservesLimitOfSizeOfPreserves (F : C ⥤ Action V G)
+def preservesLimitsOfSizeOfPreserves (F : C ⥤ Action V G)
     (h : PreservesLimitsOfSize.{w₂, w₁} (F ⋙ Action.forget V G)) :
     PreservesLimitsOfSize.{w₂, w₁} F := by
   constructor
@@ -133,7 +133,7 @@ def preservesColimitsOfShapeOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
 
 /-- `F : C ⥤ Action V G` preserves colimits of some size
 if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
-def preservesColimitOfSizeOfPreserves (F : C ⥤ Action V G)
+def preservesColimitsOfSizeOfPreserves (F : C ⥤ Action V G)
     (h : PreservesColimitsOfSize.{w₂, w₁} (F ⋙ Action.forget V G)) :
     PreservesColimitsOfSize.{w₂, w₁} F := by
   constructor

--- a/Mathlib/RepresentationTheory/Action/Limits.lean
+++ b/Mathlib/RepresentationTheory/Action/Limits.lean
@@ -60,7 +60,7 @@ variable {C : Type t₁} [Category.{t₂} C]
 /-- `F : C ⥤ SingleObj G ⥤ V` preserves the limit of some `K : J ⥤ C` if it does
 evaluated at `SingleObj.star G`.-/
 private def SingleObj.preservesLimit (F : C ⥤ SingleObj G ⥤ V)
-    {J : Type w₁} [Category.{w₂, w₁} J] (K : J ⥤ C)
+    {J : Type w₁} [Category.{w₂} J] (K : J ⥤ C)
     (h : PreservesLimit K (F ⋙ (evaluation (SingleObj G) V).obj (SingleObj.star G))) :
     PreservesLimit K F := by
   apply preservesLimitOfEvaluation
@@ -70,7 +70,7 @@ private def SingleObj.preservesLimit (F : C ⥤ SingleObj G ⥤ V)
 /-- `F : C ⥤ Action V G` preserves the limit of some `K : J ⥤ C` if
 if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
 def preservesLimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
-    [Category.{w₂, w₁} J] (K : J ⥤ C)
+    [Category.{w₂} J] (K : J ⥤ C)
     (h : PreservesLimit K (F ⋙ Action.forget V G)) : PreservesLimit K F := by
   let F' : C ⥤ SingleObj G ⥤ V := F ⋙ (Action.functorCategoryEquivalence V G).functor
   have : PreservesLimit K F' := SingleObj.preservesLimit _ _ h
@@ -79,7 +79,7 @@ def preservesLimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
 /-- `F : C ⥤ Action V G` preserves limits of some shape `J`
 if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
 def preservesLimitsOfShapeOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
-    [Category.{w₂, w₁} J] (h : PreservesLimitsOfShape J (F ⋙ Action.forget V G)) :
+    [Category.{w₂} J] (h : PreservesLimitsOfShape J (F ⋙ Action.forget V G)) :
     PreservesLimitsOfShape J F := by
   constructor
   intro K
@@ -99,7 +99,7 @@ def preservesLimitsOfSizeOfPreserves (F : C ⥤ Action V G)
 /-- `F : C ⥤ SingleObj G ⥤ V` preserves the colimit of some `K : J ⥤ C` if it does
 evaluated at `SingleObj.star G`.-/
 private def SingleObj.preservesColimit (F : C ⥤ SingleObj G ⥤ V)
-    {J : Type w₁} [Category.{w₂, w₁} J] (K : J ⥤ C)
+    {J : Type w₁} [Category.{w₂} J] (K : J ⥤ C)
     (h : PreservesColimit K (F ⋙ (evaluation (SingleObj G) V).obj (SingleObj.star G))) :
     PreservesColimit K F := by
   apply preservesColimitOfEvaluation
@@ -109,7 +109,7 @@ private def SingleObj.preservesColimit (F : C ⥤ SingleObj G ⥤ V)
 /-- `F : C ⥤ Action V G` preserves the colimit of some `K : J ⥤ C` if
 if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
 def preservesColimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
-    [Category.{w₂, w₁} J] (K : J ⥤ C)
+    [Category.{w₂} J] (K : J ⥤ C)
     (h : PreservesColimit K (F ⋙ Action.forget V G)) : PreservesColimit K F := by
   let F' : C ⥤ SingleObj G ⥤ V := F ⋙ (Action.functorCategoryEquivalence V G).functor
   have : PreservesColimit K F' := SingleObj.preservesColimit _ _ h
@@ -118,7 +118,7 @@ def preservesColimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
 /-- `F : C ⥤ Action V G` preserves colimits of some shape `J`
 if it does after postcomposing with the forgetful functor `Action V G ⥤ V`. -/
 def preservesColimitsOfShapeOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
-    [Category.{w₂, w₁} J] (h : PreservesColimitsOfShape J (F ⋙ Action.forget V G)) :
+    [Category.{w₂} J] (h : PreservesColimitsOfShape J (F ⋙ Action.forget V G)) :
     PreservesColimitsOfShape J F := by
   constructor
   intro K

--- a/Mathlib/RepresentationTheory/Action/Limits.lean
+++ b/Mathlib/RepresentationTheory/Action/Limits.lean
@@ -55,7 +55,7 @@ end Limits
 
 section Preservation
 
-variable {C : Type t₁} [Category.{t₂, t₁} C]
+variable {C : Type t₁} [Category.{t₂} C]
 
 /-- `F : C ⥤ SingleObj G ⥤ V` preserves the limit of some `K : J ⥤ C` if it does
 evaluated at `SingleObj.star G`.-/
@@ -73,10 +73,7 @@ def preservesLimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
     [Category.{w₂, w₁} J] (K : J ⥤ C)
     (h : PreservesLimit K (F ⋙ Action.forget V G)) : PreservesLimit K F := by
   let F' : C ⥤ SingleObj G ⥤ V := F ⋙ (Action.functorCategoryEquivalence V G).functor
-  let i : PreservesLimit K F' := by
-    apply SingleObj.preservesLimit
-    show PreservesLimit K (F ⋙ Action.forget V G)
-    assumption
+  have : PreservesLimit K F' := SingleObj.preservesLimit _ _ h
   apply preservesLimitOfReflectsOfPreserves F (Action.functorCategoryEquivalence V G).functor
 
 /-- `F : C ⥤ Action V G` preserves limits of some shape `J`
@@ -115,10 +112,7 @@ def preservesColimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
     [Category.{w₂, w₁} J] (K : J ⥤ C)
     (h : PreservesColimit K (F ⋙ Action.forget V G)) : PreservesColimit K F := by
   let F' : C ⥤ SingleObj G ⥤ V := F ⋙ (Action.functorCategoryEquivalence V G).functor
-  let i : PreservesColimit K F' := by
-    apply SingleObj.preservesColimit
-    show PreservesColimit K (F ⋙ Action.forget V G)
-    assumption
+  have : PreservesColimit K F' := SingleObj.preservesColimit _ _ h
   apply preservesColimitOfReflectsOfPreserves F (Action.functorCategoryEquivalence V G).functor
 
 /-- `F : C ⥤ Action V G` preserves colimits of some shape `J`


### PR DESCRIPTION
Shows that a functor into `Action V G` preserves a given (co)limit if it does after postcomposing with the forgetful functor to `V`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
