### PR TITLE
[Merged by Bors] - feat: add multiplicative versions of `equivOfFullyFaithful` and `isoEquivOfFullyFaithful`

### DIFF
--- a/Mathlib/CategoryTheory/Endomorphism.lean
+++ b/Mathlib/CategoryTheory/Endomorphism.lean
@@ -200,6 +200,20 @@ def mapAut : Aut X →* Aut (f.obj X) where
 set_option linter.uppercaseLean3 false in
 #align category_theory.functor.map_Aut CategoryTheory.Functor.mapAut
 
+/-- `equivOfFullyFaithful f` as an isomorphism between endomorphism monoids. -/
+@[simps!]
+def mulEquivOfFullyFaithful [Full f] [Faithful f] :
+    End X ≃* End (f.obj X) where
+  toEquiv := equivOfFullyFaithful f
+  __ := mapEnd X f
+
+/-- `isoEquivOfFullyFaithful f` as an isomorphism between automorphism groups. -/
+@[simps!]
+def autMulEquivOfFullyFaithful [Full f] [Faithful f] :
+    Aut X ≃* Aut (f.obj X) where
+  toEquiv := isoEquivOfFullyFaithful f
+  __ := mapAut X f
+
 end Functor
 
 end CategoryTheory


### PR DESCRIPTION
Adds multiplicative versions of `equivOfFullyFaithful` and `isoEquivOfFullyFaithful`.

Co-authored-by: Yury G. Kudryashov <urkud@urkud.name>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
