### PR TITLE
[Merged by Bors] - chore: correct hypothesis order in dot notation lemma

### DIFF
--- a/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
@@ -490,7 +490,8 @@ theorem ContMDiffOn.contMDiffOn_tangentMapWithin (hf : ContMDiffOn I I' n f s) (
         tangentMapWithin I' I' r r.source (tangentMapWithin I I' f s' q) =
           tangentMap I' I' r (tangentMapWithin I I' f s' q) := by
         apply tangentMapWithin_eq_tangentMap
-        · apply IsOpen.uniqueMDiffWithinAt _ r.open_source; simp [hq]
+        · apply r.open_source.uniqueMDiffWithinAt _
+          simp [hq]
         · exact mdifferentiableAt_atlas I' (chart_mem_atlas H' (f p.proj)) hq.1.1
       have : f p.proj = (tangentMapWithin I I' f s p).1 := rfl
       rw [A]

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -82,7 +82,7 @@ theorem UniqueMDiffWithinAt.inter (hs : UniqueMDiffWithinAt I s x) (ht : t ∈ �
   hs.inter' (nhdsWithin_le_nhds ht)
 #align unique_mdiff_within_at.inter UniqueMDiffWithinAt.inter
 
-theorem IsOpen.uniqueMDiffWithinAt (xs : x ∈ s) (hs : IsOpen s) : UniqueMDiffWithinAt I s x :=
+theorem IsOpen.uniqueMDiffWithinAt (hs : IsOpen s) (xs : x ∈ s) : UniqueMDiffWithinAt I s x :=
   (uniqueMDiffWithinAt_univ I).mono_of_mem <| nhdsWithin_le_nhds <| hs.mem_nhds xs
 #align is_open.unique_mdiff_within_at IsOpen.uniqueMDiffWithinAt
 
@@ -90,8 +90,8 @@ theorem UniqueMDiffOn.inter (hs : UniqueMDiffOn I s) (ht : IsOpen t) : UniqueMDi
   fun _x hx => UniqueMDiffWithinAt.inter (hs _ hx.1) (ht.mem_nhds hx.2)
 #align unique_mdiff_on.inter UniqueMDiffOn.inter
 
-theorem IsOpen.uniqueMDiffOn (hs : IsOpen s) : UniqueMDiffOn I s := fun _x hx =>
-  IsOpen.uniqueMDiffWithinAt hx hs
+theorem IsOpen.uniqueMDiffOn (hs : IsOpen s) : UniqueMDiffOn I s :=
+  fun _x hx => hs.uniqueMDiffWithinAt hx
 #align is_open.unique_mdiff_on IsOpen.uniqueMDiffOn
 
 theorem uniqueMDiffOn_univ : UniqueMDiffOn I (univ : Set M) :=


### PR DESCRIPTION
Following a [comment](https://github.com/leanprover-community/mathlib4/pull/8736#discussion_r1433085328) by @sgouezel, the hypothesis `IsOpen s` should be the first explicit argument.

---

- [x] depends on: #9565