### PR TITLE
feat(Algebra/Star): Non-commutative generalization of `StarModule`

### DIFF
--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -483,20 +483,39 @@ the statement only requires `[Star R] [Star A] [SMul R A]`.
 If used as `[CommRing R] [StarRing R] [Semiring A] [StarRing A] [Algebra R A]`, this represents a
 star algebra.
 -/
-
 class StarModule (R : Type u) (A : Type v) [Star R] [Star A] [SMul R A] : Prop where
   /-- `star` commutes with scalar multiplication -/
   star_smul : ∀ (r : R) (a : A), star (r • a) = star r • star a
 #align star_module StarModule
 
 export StarModule (star_smul)
-
 attribute [simp] star_smul
 
-/-- A commutative star monoid is a star module over itself via `Monoid.toMulAction`. -/
-instance StarMul.toStarModule [CommMonoid R] [StarMul R] : StarModule R R :=
-  ⟨star_mul'⟩
-#align star_semigroup.to_star_module StarMul.toStarModule
+/-- `StarModule'` is a version of `StarModule` generalized to non-commutative settings, where
+we have $(rm)^* = m^*r^*$ where $M$ is an $R$-bimodule.
+
+The second field is redundant in the presence of `StarInvolutive`. -/
+class StarModule' (R : Type u) (M : Type v) [Star R] [Star M] [SMul R M] [SMul Rᵐᵒᵖ M] : Prop where
+  star_smul' (r : R) (m : M) : star (r • m) = MulOpposite.op (star r) • star m
+  star_op_smul (r : R) (m : M) : star (MulOpposite.op r • m) = star r • star m
+
+variable {M : Type*}
+
+export StarModule' (star_smul' star_op_smul)
+attribute [simp] star_op_smul
+attribute [simp low] star_smul'
+
+/-- A star monoid is a star module over itself via `Monoid.toMulAction`. -/
+instance StarMul.toStarModule' [Monoid R] [StarMul R] : StarModule' R R :=
+  ⟨star_mul, Function.swap star_mul⟩
+
+/-- When the action commutes, the non-commutative notion of a star module agrees with the
+commutative version. -/
+instance StarModule'.toStarModule [Star R] [Star M] [SMul R M] [SMul Rᵐᵒᵖ M] [IsCentralScalar R M]
+    [StarModule' R M] : StarModule R M where
+  star_smul r m := by rw [star_smul', op_smul_eq_smul]
+
+#align star_semigroup.to_star_module StarMul.toStarModule'
 
 instance StarAddMonoid.toStarModuleNat {α} [AddCommMonoid α] [StarAddMonoid α] : StarModule ℕ α :=
   ⟨fun n a ↦ by rw [star_nsmul, star_trivial n]⟩

--- a/Mathlib/Algebra/Star/Pi.lean
+++ b/Mathlib/Algebra/Star/Pi.lean
@@ -56,6 +56,11 @@ instance {R : Type w} [∀ i, SMul R (f i)] [Star R] [∀ i, Star (f i)]
     [∀ i, StarModule R (f i)] : StarModule R (∀ i, f i) where
   star_smul r x := funext fun i => star_smul r (x i)
 
+instance {R : Type w} [∀ i, SMul R (f i)] [∀ i, SMul Rᵐᵒᵖ (f i)] [Star R] [∀ i, Star (f i)]
+    [∀ i, StarModule' R (f i)] : StarModule' R (∀ i, f i) where
+  star_smul' r x := funext fun i => star_smul' r (x i)
+  star_op_smul r x := funext fun i => star_op_smul r (x i)
+
 theorem single_star [∀ i, AddMonoid (f i)] [∀ i, StarAddMonoid (f i)] [DecidableEq I] (i : I)
     (a : f i) : Pi.single i (star a) = star (Pi.single i a) :=
   single_op (fun i => @star (f i) _) (fun _ => star_zero _) i a

--- a/Mathlib/Algebra/Star/Prod.lean
+++ b/Mathlib/Algebra/Star/Prod.lean
@@ -56,6 +56,11 @@ instance [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring S] [StarRing R
   { inferInstanceAs (StarAddMonoid (R × S)),
     inferInstanceAs (StarMul (R × S)) with }
 
+instance {α : Type w} [SMul α R] [SMul αᵐᵒᵖ R] [SMul α S] [SMul αᵐᵒᵖ S] [Star α] [Star R] [Star S]
+    [StarModule' α R] [StarModule' α S] : StarModule' α (R × S) where
+  star_smul' _ _ := Prod.ext (star_smul' _ _) (star_smul' _ _)
+  star_op_smul _ _ := Prod.ext (star_op_smul _ _) (star_op_smul _ _)
+
 instance {α : Type w} [SMul α R] [SMul α S] [Star α] [Star R] [Star S]
     [StarModule α R] [StarModule α S] : StarModule α (R × S) where
   star_smul _ _ := Prod.ext (star_smul _ _) (star_smul _ _)

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Eric Wieser
 -/
 import Mathlib.Algebra.Algebra.Basic
+import Mathlib.Algebra.Star.Prod
 import Mathlib.GroupTheory.GroupAction.BigOperators
 import Mathlib.LinearAlgebra.Prod
 
@@ -937,5 +938,35 @@ def liftEquivOfComm :
 #align triv_sq_zero_ext.lift TrivSqZeroExt.liftEquiv
 
 end Algebra
+
+section Star
+variable {R M : Type*}
+
+/-- A `star` operation that acts on `R` and `M` separately. -/
+instance [Star R] [Star M] : Star (tsze R M) := Prod.instStarProd
+
+@[simp] lemma fst_star [Star R] [Star M] (x : tsze R M) : fst (star x) = star x.fst := rfl
+@[simp] lemma snd_star [Star R] [Star M] (x : tsze R M) : snd (star x) = star x.snd := rfl
+
+instance [InvolutiveStar R] [InvolutiveStar M] : InvolutiveStar (tsze R M) :=
+  Prod.instInvolutiveStarProd
+
+instance [AddMonoid R] [AddMonoid M] [StarAddMonoid R] [StarAddMonoid M] :
+    StarAddMonoid (tsze R M) :=
+  Prod.instStarAddMonoidProdInstAddMonoid
+
+@[simp] lemma star_inl [AddMonoid R] [AddMonoid M] [StarAddMonoid R] [StarAddMonoid M] (r : R) :
+    inl (star r) = star (inl r : tsze R M) := ext rfl (star_zero _).symm
+@[simp] lemma star_inr [AddMonoid R] [AddMonoid M] [StarAddMonoid R] [StarAddMonoid M] (m : M) :
+    inr (star m) = star (inr m : tsze R M) := ext (star_zero _).symm rfl
+
+instance [Semiring R] [AddCommMonoid M] [Module R M] [Module Rᵐᵒᵖ M] [SMulCommClass R Rᵐᵒᵖ M]
+    [StarRing R] [StarAddMonoid M] [StarModule' R M] :
+    StarRing (tsze R M) where
+  __ : StarAddMonoid (tsze R M) := inferInstance
+  star_mul x y := ext (star_mul _ _) <| by
+    simp only [snd_mul, fst_star, snd_star, star_add, star_smul', star_op_smul, add_comm]
+
+end Star
 
 end TrivSqZeroExt


### PR DESCRIPTION
[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Star.20modules.20over.20non-commutative.20scalars/near/383664005).

Until we address #7152, we have to have both `StarModule` and `StarModule'`.

To prove this generalization is useful, this shows that with it as an assumption, `TrivSqZeroExt` is a `StarRing`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
