### PR TITLE
[Merged by Bors] - feat(CategoryTheory/SingleObj): add functor and NatTrans constructors for `SingleObj`

### DIFF
--- a/Mathlib/CategoryTheory/SingleObj.lean
+++ b/Mathlib/CategoryTheory/SingleObj.lean
@@ -156,6 +156,23 @@ def differenceFunctor {C G} [Category C] [Group G] (f : C → G) : C ⥤ SingleO
     rw [SingleObj.comp_as_mul, ← mul_assoc, mul_left_inj, mul_assoc, inv_mul_self, mul_one]
 #align category_theory.single_obj.difference_functor CategoryTheory.SingleObj.differenceFunctor
 
+/-- A monoid homomorphism `f: α → End X` into the endomorphisms of an object `X` of a category `C`
+induces a functor `SingleObj α ⥤ C`. -/
+def functor {α : Type u} [Monoid α] {C : Type w} [Category.{v} C] {X : C} (f : α →* End X) :
+    SingleObj α ⥤ C where
+  obj _ := X
+  map a := f a
+  map_id _ := MonoidHom.map_one f
+  map_comp a b := MonoidHom.map_mul f b a
+
+/-- Construct a natural transformation between functors `SingleObj α ⥤ C` by
+giving a compatible morphism `SingleObj.star α`. -/
+def natTrans {α : Type w} {C : Type w} [Category.{v} C] [Monoid α] {F G : SingleObj α ⥤ C}
+    (u : F.obj (SingleObj.star α) ⟶ G.obj (SingleObj.star α))
+    (h : ∀ a : α, F.map a ≫ u = u ≫ G.map a) : F ⟶ G where
+  app _ := u
+  naturality _ _ a := h a
+
 end SingleObj
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/SingleObj.lean
+++ b/Mathlib/CategoryTheory/SingleObj.lean
@@ -158,6 +158,7 @@ def differenceFunctor {C G} [Category C] [Group G] (f : C → G) : C ⥤ SingleO
 
 /-- A monoid homomorphism `f: α → End X` into the endomorphisms of an object `X` of a category `C`
 induces a functor `SingleObj α ⥤ C`. -/
+@[simps]
 def functor {α : Type u} [Monoid α] {C : Type w} [Category.{v} C] {X : C} (f : α →* End X) :
     SingleObj α ⥤ C where
   obj _ := X
@@ -167,6 +168,7 @@ def functor {α : Type u} [Monoid α] {C : Type w} [Category.{v} C] {X : C} (f :
 
 /-- Construct a natural transformation between functors `SingleObj α ⥤ C` by
 giving a compatible morphism `SingleObj.star α`. -/
+@[simps]
 def natTrans {α : Type w} {C : Type w} [Category.{v} C] [Monoid α] {F G : SingleObj α ⥤ C}
     (u : F.obj (SingleObj.star α) ⟶ G.obj (SingleObj.star α))
     (h : ∀ a : α, F.map a ≫ u = u ≫ G.map a) : F ⟶ G where


### PR DESCRIPTION
Adds constructors for functors of type `SingleObj α ⥤ C` and natural transformations of functors `SingleObj α ⥤ C`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
