### PR TITLE
[Merged by Bors] - chore: improve proof of  discr_prime_pow

### DIFF
--- a/Mathlib/NumberTheory/Cyclotomic/Discriminant.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Discriminant.lean
@@ -159,22 +159,32 @@ theorem discr_prime_pow [hcycl : IsCyclotomicExtension {p ^ k} K L] [hp : Fact (
         replace hk :=
           eq_of_prime_pow_eq (prime_iff.1 hp.out) (prime_iff.1 Nat.prime_two) (succ_pos _) hk
         rwa [coe_two, PNat.coe_inj] at hk
-      rw [hp, ← PNat.coe_inj, PNat.pow_coe] at hk
+      subst hp
+      rw [← PNat.coe_inj, PNat.pow_coe] at hk
       nth_rw 2 [← pow_one 2] at hk
       replace hk := Nat.pow_right_injective rfl.le hk
       rw [add_left_eq_self] at hk
-      rw [hp, hk] at hζ; norm_num at hζ; rw [← coe_two] at hζ
-      rw [coe_basis, powerBasis_gen]; simp only [hp, hk]; norm_num
-      -- Porting note: the goal at this point is `(discr K fun i ↦ ζ ^ ↑i) = 1`.
-      -- This `simp_rw` is needed so the next `rw` can rewrite the type of `i` from
-      -- `Fin (natDegree (minpoly K ζ))` to `Fin 1`
+      subst hk
+      rw [←Nat.one_eq_succ_zero, pow_one] at hζ hcycl
+      have : natDegree (minpoly K ζ) = 1 := by
+        rw [hζ.eq_neg_one_of_two_right, show (-1 : L) = algebraMap K L (-1) by simp,
+          minpoly.eq_X_sub_C_of_algebraMap_inj _ (NoZeroSMulDivisors.algebraMap_injective K L)]
+        exact natDegree_X_sub_C (-1)
+      rcases Fin.equiv_iff_eq.2 this with ⟨e⟩
+      rw [←Algebra.discr_reindex K (hζ.powerBasis K).basis e, coe_basis, powerBasis_gen]; norm_num
       simp_rw [hζ.eq_neg_one_of_two_right, show (-1 : L) = algebraMap K L (-1) by simp]
-      rw [hζ.eq_neg_one_of_two_right, show (-1 : L) = algebraMap K L (-1) by simp,
-        minpoly.eq_X_sub_C_of_algebraMap_inj _ (algebraMap K L).injective, natDegree_X_sub_C]
-      simp only [discr, traceMatrix_apply, Matrix.det_unique, Fin.default_eq_zero, Fin.val_zero,
-        _root_.pow_zero, traceForm_apply, mul_one]
-      rw [← (algebraMap K L).map_one, trace_algebraMap, finrank _ hirr, hp, hk]; norm_num
-      simp [← coe_two, Even.neg_pow (by decide : Even (1 / 2))]
+      convert_to (discr K fun i : Fin 1 ↦ (algebraMap K L) (-1) ^ ↑i) = _
+      · congr
+        ext i
+        simp only [map_neg, map_one, Function.comp_apply, Fin.coe_fin_one, _root_.pow_zero]
+        suffices (e.symm i : ℕ) = 0 by simp [this]
+        rw [←Nat.lt_one_iff]
+        convert (e.symm i).2
+        rw [this]
+      · simp only [discr, traceMatrix_apply, Matrix.det_unique, Fin.default_eq_zero, Fin.val_zero,
+          _root_.pow_zero, traceForm_apply, mul_one]
+        rw [← (algebraMap K L).map_one, trace_algebraMap, finrank _ hirr]; norm_num
+        simp [← coe_two, Even.neg_pow (by decide : Even (1 / 2))]
     · exact discr_prime_pow_ne_two hζ hirr hk
 #align is_cyclotomic_extension.discr_prime_pow IsCyclotomicExtension.discr_prime_pow
 

--- a/Mathlib/NumberTheory/Cyclotomic/Discriminant.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Discriminant.lean
@@ -165,20 +165,20 @@ theorem discr_prime_pow [hcycl : IsCyclotomicExtension {p ^ k} K L] [hp : Fact (
       replace hk := Nat.pow_right_injective rfl.le hk
       rw [add_left_eq_self] at hk
       subst hk
-      rw [←Nat.one_eq_succ_zero, pow_one] at hζ hcycl
+      rw [← Nat.one_eq_succ_zero, pow_one] at hζ hcycl
       have : natDegree (minpoly K ζ) = 1 := by
         rw [hζ.eq_neg_one_of_two_right, show (-1 : L) = algebraMap K L (-1) by simp,
           minpoly.eq_X_sub_C_of_algebraMap_inj _ (NoZeroSMulDivisors.algebraMap_injective K L)]
         exact natDegree_X_sub_C (-1)
       rcases Fin.equiv_iff_eq.2 this with ⟨e⟩
-      rw [←Algebra.discr_reindex K (hζ.powerBasis K).basis e, coe_basis, powerBasis_gen]; norm_num
+      rw [← Algebra.discr_reindex K (hζ.powerBasis K).basis e, coe_basis, powerBasis_gen]; norm_num
       simp_rw [hζ.eq_neg_one_of_two_right, show (-1 : L) = algebraMap K L (-1) by simp]
       convert_to (discr K fun i : Fin 1 ↦ (algebraMap K L) (-1) ^ ↑i) = _
       · congr
         ext i
         simp only [map_neg, map_one, Function.comp_apply, Fin.coe_fin_one, _root_.pow_zero]
         suffices (e.symm i : ℕ) = 0 by simp [this]
-        rw [←Nat.lt_one_iff]
+        rw [← Nat.lt_one_iff]
         convert (e.symm i).2
         rw [this]
       · simp only [discr, traceMatrix_apply, Matrix.det_unique, Fin.default_eq_zero, Fin.val_zero,


### PR DESCRIPTION
The new proof is more robust and does not rewrite a type equality.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
