### PR TITLE
[Merged by Bors] - feat(Analysis/Analytic): define meromorphic functions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -565,6 +565,7 @@ import Mathlib.Analysis.Analytic.Constructions
 import Mathlib.Analysis.Analytic.Inverse
 import Mathlib.Analysis.Analytic.IsolatedZeros
 import Mathlib.Analysis.Analytic.Linear
+import Mathlib.Analysis.Analytic.Meromorphic
 import Mathlib.Analysis.Analytic.Polynomial
 import Mathlib.Analysis.Analytic.RadiusLiminf
 import Mathlib.Analysis.Analytic.Uniqueness

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Vincent Beffara
 -/
 import Mathlib.Analysis.Analytic.Basic
+import Mathlib.Analysis.Analytic.Constructions
 import Mathlib.Analysis.Calculus.Dslope
 import Mathlib.Analysis.Calculus.FDeriv.Analytic
 import Mathlib.Analysis.Calculus.FormalMultilinearSeries
@@ -153,6 +154,75 @@ theorem frequently_eq_iff_eventually_eq (hf : AnalyticAt 𝕜 f z₀) (hg : Anal
     (∃ᶠ z in 𝓝[≠] z₀, f z = g z) ↔ ∀ᶠ z in 𝓝 z₀, f z = g z := by
   simpa [sub_eq_zero] using frequently_zero_iff_eventually_zero (hf.sub hg)
 #align analytic_at.frequently_eq_iff_eventually_eq AnalyticAt.frequently_eq_iff_eventually_eq
+
+/-- There exists at most one `n` such that locally around `z₀` we have `f z = (z - z₀) ^ n • g z`,
+with `g` analytic and nonvanishing at `z₀`. -/
+lemma unique_eventuallyEq_pow_smul_nonzero {m n : ℕ}
+    (hm : ∃ g, AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ m • g z)
+    (hn : ∃ g, AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z) :
+    m = n := by
+  wlog h_le : n ≤ m generalizing m n
+  · exact ((this hn hm) (not_le.mp h_le).le).symm
+  let ⟨g, hg_an, _, hg_eq⟩ := hm
+  let ⟨j, hj_an, hj_ne, hj_eq⟩ := hn
+  contrapose! hj_ne
+  have : ∃ᶠ z in 𝓝[≠] z₀, j z = (z - z₀) ^ (m - n) • g z
+  · refine (eventually_nhdsWithin_iff.mpr ?_).frequently
+    filter_upwards [hg_eq, hj_eq] with z hfz hfz' hz
+    rwa [← Nat.add_sub_cancel' h_le, pow_add, mul_smul, hfz', smul_right_inj] at hfz
+    exact pow_ne_zero _ <| sub_ne_zero.mpr hz
+  rw [frequently_eq_iff_eventually_eq hj_an] at this
+  rw [EventuallyEq.eq_of_nhds this, sub_self, zero_pow, zero_smul]
+  · apply Nat.zero_lt_sub_of_lt (Nat.lt_of_le_of_ne h_le hj_ne.symm)
+  · exact (((analyticAt_id 𝕜 _).sub analyticAt_const).pow _).smul hg_an
+
+/-- If `f` is analytic at `z₀`, then exactly one of the following two possibilities occurs: either
+`f` vanishes identically near `z₀`, or locally around `z₀` it has the form `z ↦ (z - z₀) ^ n • g z`
+for some `n` and some `g` which is analytic and non-vanishing at `z₀`. -/
+theorem exists_eventuallyEq_pow_smul_nonzero_iff (hf : AnalyticAt 𝕜 f z₀) :
+    (∃ (n : ℕ), ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧
+    ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z) ↔ (¬∀ᶠ z in 𝓝 z₀, f z = 0) := by
+  constructor
+  · rintro ⟨n, g, hg_an, hg_ne, hg_eq⟩
+    contrapose! hg_ne
+    apply EventuallyEq.eq_of_nhds
+    rw [EventuallyEq, ← AnalyticAt.frequently_eq_iff_eventually_eq hg_an analyticAt_const]
+    refine (eventually_nhdsWithin_iff.mpr ?_).frequently
+    filter_upwards [hg_eq, hg_ne] with z hf_eq hf0 hz
+    rwa [hf0, eq_comm, smul_eq_zero_iff_right] at hf_eq
+    exact pow_ne_zero _ (sub_ne_zero.mpr hz)
+  · intro hf_ne
+    rcases hf with ⟨p, hp⟩
+    exact ⟨p.order, _, ⟨_, hp.has_fpower_series_iterate_dslope_fslope p.order⟩,
+      hp.iterate_dslope_fslope_ne_zero (hf_ne.imp hp.locally_zero_iff.mpr),
+      hp.eq_pow_order_mul_iterate_dslope⟩
+
+/-- The order of vanishing of `f` at `z₀`, as an element of `ℕ∞`.
+
+This is defined to be `∞` if `f` is identically 0 on a neighbourhood of `z₀`, and otherwise the
+unique `n` such that `f z = (z - z₀) ^ n • g z` with `g` analytic and non-vanishing at `z₀`. See
+`AnalyticAt.order_eq_top_iff` and `AnalyticAt.order_eq_nat_iff` for these equivalences. -/
+noncomputable def order (hf : AnalyticAt 𝕜 f z₀) : ENat :=
+  if h : ∀ᶠ z in 𝓝 z₀, f z = 0 then ⊤
+  else ↑(hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h).choose
+
+lemma order_eq_top_iff (hf : AnalyticAt 𝕜 f z₀) : hf.order = ⊤ ↔ ∀ᶠ z in 𝓝 z₀, f z = 0 := by
+  unfold order
+  split_ifs with h
+  · rwa [eq_self, true_iff]
+  · simpa only [ne_eq, ENat.coe_ne_top, false_iff] using h
+
+lemma order_eq_nat_iff (hf : AnalyticAt 𝕜 f z₀) (n : ℕ) : hf.order = ↑n ↔
+    ∃ (g : 𝕜 → E), AnalyticAt 𝕜 g z₀ ∧ g z₀ ≠ 0 ∧ ∀ᶠ z in 𝓝 z₀, f z = (z - z₀) ^ n • g z := by
+  unfold order
+  split_ifs with h
+  · simp only [ENat.top_ne_coe, false_iff]
+    contrapose! h
+    rw [← hf.exists_eventuallyEq_pow_smul_nonzero_iff]
+    exact ⟨n, h⟩
+  · rw [← hf.exists_eventuallyEq_pow_smul_nonzero_iff] at h
+    refine ⟨fun hn ↦ (WithTop.coe_inj.mp hn : h.choose = n) ▸ h.choose_spec, fun h' ↦ ?_⟩
+    rw [unique_eventuallyEq_pow_smul_nonzero h.choose_spec h']
 
 end AnalyticAt
 

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -3,11 +3,9 @@ Copyright (c) 2022 Vincent Beffara. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Vincent Beffara
 -/
-import Mathlib.Analysis.Analytic.Basic
 import Mathlib.Analysis.Analytic.Constructions
 import Mathlib.Analysis.Calculus.Dslope
 import Mathlib.Analysis.Calculus.FDeriv.Analytic
-import Mathlib.Analysis.Calculus.FormalMultilinearSeries
 import Mathlib.Analysis.Analytic.Uniqueness
 
 #align_import analysis.analytic.isolated_zeros from "leanprover-community/mathlib"@"a3209ddf94136d36e5e5c624b10b2a347cc9d090"

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -63,8 +63,8 @@ lemma neg {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicAt (
 
 @[simp]
 lemma neg_iff {f : 𝕜 → E} {x : 𝕜} :
-    MeromorphicAt f x ↔ MeromorphicAt (-f) x :=
-  ⟨MeromorphicAt.neg, fun h ↦ by simpa only [neg_neg] using h.neg⟩
+    MeromorphicAt (-f) x ↔ MeromorphicAt f x :=
+  ⟨fun h ↦ by simpa only [neg_neg] using h.neg, MeromorphicAt.neg⟩
 
 lemma sub {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     MeromorphicAt (f - g) x := by
@@ -115,8 +115,8 @@ lemma inv {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicA
 
 @[simp]
 lemma inv_iff {f : 𝕜 → 𝕜} {x : 𝕜} :
-    MeromorphicAt f x ↔ MeromorphicAt f⁻¹ x :=
-  ⟨MeromorphicAt.inv, fun h ↦ by simpa only [inv_inv] using h.inv⟩
+    MeromorphicAt f⁻¹ x ↔ MeromorphicAt f x :=
+  ⟨fun h ↦ by simpa only [inv_inv] using h.inv, MeromorphicAt.inv⟩
 
 lemma div {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     MeromorphicAt (f / g) x :=

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -61,6 +61,11 @@ lemma neg {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicAt (
   ext1 z
   simp only [Pi.neg_apply, Pi.smul_apply', neg_smul, one_smul]
 
+@[simp]
+lemma neg_iff {f : 𝕜 → E} {x : 𝕜} :
+    MeromorphicAt f x ↔ MeromorphicAt (-f) x :=
+  ⟨MeromorphicAt.neg, fun h ↦ by simpa only [neg_neg] using h.neg⟩
+
 lemma sub {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     MeromorphicAt (f - g) x := by
   convert hf.add hg.neg using 1
@@ -107,6 +112,11 @@ lemma inv {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicA
       field_simp [sub_ne_zero.mpr hz_ne]
       rw [pow_succ, mul_assoc, hfg]
       ring
+
+@[simp]
+lemma inv_iff {f : 𝕜 → 𝕜} {x : 𝕜} :
+    MeromorphicAt f x ↔ MeromorphicAt f⁻¹ x :=
+  ⟨MeromorphicAt.inv, fun h ↦ by simpa only [inv_inv] using h.inv⟩
 
 lemma div {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     MeromorphicAt (f / g) x :=

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2024 David Loeffler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Loeffler
 -/
-import Mathlib.Analysis.Analytic.Constructions
 import Mathlib.Analysis.Analytic.IsolatedZeros
 
 /-!
@@ -112,6 +111,5 @@ lemma inv {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicA
 lemma div {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     MeromorphicAt (f / g) x :=
   (div_eq_mul_inv f g).symm ▸ (hf.mul hg.inv)
-
 
 end MeromorphicAt

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2024 David Loeffler. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David Loeffler
+-/
+import Mathlib.Analysis.Analytic.Constructions
+import Mathlib.Analysis.Analytic.IsolatedZeros
+
+open scoped Topology
+
+/-!
+# Meromorphic functions
+-/
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+
+/-- Meromorphy of `f` at `x` (more precisely, on a punctured neighbourhood of `x`; the value at
+`x` itself is irrelevant). -/
+def MeromorphicAt (f : 𝕜 → E) (x : 𝕜) :=
+  ∃ (n : ℕ), AnalyticAt 𝕜 (fun z ↦ (z - x) ^ n • f z) x
+
+lemma AnalyticAt.meromorphicAt {f : 𝕜 → E} {x : 𝕜} (hf : AnalyticAt 𝕜 f x) :
+    MeromorphicAt f x :=
+  ⟨0, by simpa only [pow_zero, one_smul]⟩
+
+lemma meromorphicAt_id (x : 𝕜) : MeromorphicAt id x := (analyticAt_id 𝕜 x).meromorphicAt
+
+lemma meromorphicAt_const (e : E) (x : 𝕜) : MeromorphicAt (fun _ ↦ e) x :=
+  analyticAt_const.meromorphicAt
+
+namespace MeromorphicAt
+
+lemma add {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    MeromorphicAt (f + g) x := by
+  rcases hf with ⟨m, hf⟩
+  rcases hg with ⟨n, hg⟩
+  refine ⟨max m n, ?_⟩
+  have : (fun z ↦ (z - x) ^ max m n • (f + g) z) = fun z ↦ (z - x) ^ (max m n - m) •
+    ((z - x) ^ m • f z) + (z - x) ^ (max m n - n) • ((z - x) ^ n • g z)
+  · simp_rw [← mul_smul, ← pow_add, Nat.sub_add_cancel (Nat.le_max_left _ _),
+      Nat.sub_add_cancel (Nat.le_max_right _ _), Pi.add_apply, smul_add]
+  rw [this]
+  exact ((((analyticAt_id 𝕜 x).sub analyticAt_const).pow _).smul hf).add
+   ((((analyticAt_id 𝕜 x).sub analyticAt_const).pow _).smul hg)
+
+lemma smul {f : 𝕜 → 𝕜} {g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    MeromorphicAt (f • g) x := by
+  rcases hf with ⟨m, hf⟩
+  rcases hg with ⟨n, hg⟩
+  refine ⟨m + n, ?_⟩
+  convert hf.smul hg using 2 with z
+  rw [smul_eq_mul, ← mul_smul, mul_assoc, mul_comm (f z), ← mul_assoc, pow_add,
+    ← smul_eq_mul (a' := f z), smul_assoc, Pi.smul_apply']
+
+lemma mul {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    MeromorphicAt (f * g) x :=
+  hf.smul hg
+
+lemma neg {f : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicAt (-f) x := by
+  convert (meromorphicAt_const (-1 : 𝕜) x).smul hf using 1
+  ext1 z
+  simp only [Pi.neg_apply, Pi.smul_apply', neg_smul, one_smul]
+
+lemma sub {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    MeromorphicAt (f - g) x := by
+  convert hf.add hg.neg using 1
+  ext1 z
+  simp_rw [Pi.sub_apply, Pi.add_apply, Pi.neg_apply, sub_eq_add_neg]
+
+/-- With our definitions, `MeromorphicAt f x` depends only on the values of `f` on a punctured
+neighbourhood of `x` (not on `f x`) -/
+lemma congr {f g : 𝕜 → E} {x : 𝕜} (hf : MeromorphicAt f x) (hfg : f =ᶠ[𝓝[≠] x] g) :
+    MeromorphicAt g x := by
+  rcases hf with ⟨m, hf⟩
+  refine ⟨m + 1, ?_⟩
+  have : AnalyticAt 𝕜 (fun z ↦ z - x) x := (analyticAt_id 𝕜 x).sub analyticAt_const
+  refine (this.smul hf).congr ?_
+  rw [eventuallyEq_nhdsWithin_iff] at hfg
+  filter_upwards [hfg] with z hz
+  rcases eq_or_ne z x with rfl | hn
+  · simp
+  · rw [hz (Set.mem_compl_singleton_iff.mp hn), pow_succ, mul_smul]
+
+lemma inv {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) : MeromorphicAt f⁻¹ x := by
+  rcases hf with ⟨m, hf⟩
+  by_cases h_eq : (fun z ↦ (z - x) ^ m • f z) =ᶠ[𝓝 x] 0
+  · -- silly case: f locally 0 near x
+    apply (meromorphicAt_const 0 x).congr
+    rw [eventuallyEq_nhdsWithin_iff]
+    filter_upwards [h_eq] with z hfz hz
+    rw [Pi.inv_apply, (smul_eq_zero_iff_right <| pow_ne_zero _ (sub_ne_zero.mpr hz)).mp hfz,
+      inv_zero]
+  · -- interesting case: use local formula for `f`
+    obtain ⟨n, g, hg_an, hg_ne, hg_eq⟩ := hf.exists_eventuallyEq_pow_smul_nonzero_iff.mpr h_eq
+    have : AnalyticAt 𝕜 (fun z ↦ (z - x) ^ (m + 1)) x :=
+      ((analyticAt_id 𝕜 x).sub analyticAt_const).pow _
+    -- use `m + 1` rather than `m` to damp out any silly issues with the value at `z = x`
+    refine ⟨n + 1, (this.smul <| hg_an.inv hg_ne).congr ?_⟩
+    filter_upwards [hg_eq, hg_an.continuousAt.eventually_ne hg_ne] with z hfg hg_ne'
+    rcases eq_or_ne z x with rfl | hz_ne
+    · simp only [sub_self, pow_succ, zero_mul, zero_smul]
+    · simp_rw [smul_eq_mul] at hfg ⊢
+      have aux1 : f z ≠ 0
+      · have : (z - x) ^ n * g z ≠ 0 := mul_ne_zero (pow_ne_zero _ (sub_ne_zero.mpr hz_ne)) hg_ne'
+        rw [← hfg, mul_ne_zero_iff] at this
+        exact this.2
+      field_simp [sub_ne_zero.mpr hz_ne]
+      rw [pow_succ, mul_assoc, hfg]
+      ring
+
+lemma div {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
+    MeromorphicAt (f / g) x :=
+  (div_eq_mul_inv f g).symm ▸ (hf.mul hg.inv)
+
+
+end MeromorphicAt

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -6,11 +6,11 @@ Authors: David Loeffler
 import Mathlib.Analysis.Analytic.Constructions
 import Mathlib.Analysis.Analytic.IsolatedZeros
 
-open scoped Topology
-
 /-!
 # Meromorphic functions
 -/
+
+open scoped Topology
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]


### PR DESCRIPTION
This patch defines `MeromorphicAt`, for functions on nontrivially normed fields, and prove it is preserved by sums and products (routine) and inverses (much less trivial). Along the way, we define "order of vanishing" for a function analytic at a point (as an `ENat`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
