### PR TITLE
[Merged by Bors] - refactor(AlgebraicGeometry/EllipticCurve/*): refactor base change for ring homomorphisms

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
@@ -99,7 +99,7 @@ local macro "derivative_simp" : tactic =>
 local macro "eval_simp" : tactic =>
   `(tactic| simp only [eval_C, eval_X, eval_neg, eval_add, eval_sub, eval_mul, eval_pow])
 
-universe u v w
+universe t u v w
 
 /-! ## Weierstrass curves -/
 
@@ -637,13 +637,14 @@ section Group
 /-- A nonsingular rational point on a Weierstrass curve `W` in affine coordinates. This is either
 the unique point at infinity `WeierstrassCurve.Affine.Point.zero` or the nonsingular affine points
 `WeierstrassCurve.Affine.Point.some` $(x, y)$ satisfying the Weierstrass equation of `W`. -/
+@[pp_dot]
 inductive Point
   | zero
   | some {x y : R} (h : W.nonsingular x y)
 #align weierstrass_curve.point WeierstrassCurve.Affine.Point
 
 /-- For an algebraic extension `S` of `R`, the type of nonsingular `S`-rational points on `W`. -/
-scoped[WeierstrassCurve] notation W "⟮" S "⟯" => Affine.Point (baseChange W S)
+scoped[WeierstrassCurve] notation W "⟮" S "⟯" => Affine.Point <| baseChange W <| algebraMap _ S
 
 namespace Point
 
@@ -781,41 +782,36 @@ section BaseChange
 
 /-! ### Base changes -/
 
-variable (A : Type v) [CommRing A] [Algebra R A] (B : Type w) [CommRing B] [Algebra R B]
-  [Algebra A B] [IsScalarTower R A B]
+variable {A : Type v} [CommRing A] (φ : R →+* A) {B : Type w} [CommRing B] (ψ : A →+* B)
 
-lemma equation_iff_baseChange [Nontrivial A] [NoZeroSMulDivisors R A] (x y : R) :
-    W.equation x y ↔ (W.baseChange A).toAffine.equation (algebraMap R A x) (algebraMap R A y) := by
-  simpa only [equation_iff]
-    using ⟨fun h => by convert congr_arg (algebraMap R A) h <;> map_simp <;> rfl,
-      fun h => by apply NoZeroSMulDivisors.algebraMap_injective R A; map_simp; exact h⟩
+lemma equation_iff_baseChange {φ : R →+* A} (hφ : Function.Injective φ) (x y : R) :
+    W.equation x y ↔ (W.baseChange φ).toAffine.equation (φ x) (φ y) := by
+  simpa only [equation_iff] using
+    ⟨fun h => by convert congr_arg φ h <;> map_simp <;> rfl, fun h => hφ <| by map_simp; exact h⟩
 #align weierstrass_curve.equation_iff_base_change WeierstrassCurve.Affine.equation_iff_baseChange
 
-lemma equation_iff_baseChange_of_baseChange [Nontrivial B] [NoZeroSMulDivisors A B] (x y : A) :
-    (W.baseChange A).toAffine.equation x y ↔
-      (W.baseChange B).toAffine.equation (algebraMap A B x) (algebraMap A B y) := by
-  rw [(W.baseChange A).toAffine.equation_iff_baseChange B, baseChange_baseChange]
+lemma equation_iff_baseChange_of_baseChange {ψ : A →+* B} (hψ : Function.Injective ψ) (x y : A) :
+    (W.baseChange φ).toAffine.equation x y ↔
+      (W.baseChange <| ψ.comp φ).toAffine.equation (ψ x) (ψ y) := by
+  rw [(W.baseChange φ).toAffine.equation_iff_baseChange hψ, baseChange_baseChange]
 #align weierstrass_curve.equation_iff_base_change_of_base_change WeierstrassCurve.Affine.equation_iff_baseChange_of_baseChange
 
-lemma nonsingular_iff_baseChange [Nontrivial A] [NoZeroSMulDivisors R A] (x y : R) :
-    W.nonsingular x y ↔
-      (W.baseChange A).toAffine.nonsingular (algebraMap R A x) (algebraMap R A y) := by
-  rw [nonsingular_iff, nonsingular_iff, and_congr <| W.equation_iff_baseChange A x y]
+lemma nonsingular_iff_baseChange {φ : R →+* A} (hφ : Function.Injective φ) (x y : R) :
+    W.nonsingular x y ↔ (W.baseChange φ).toAffine.nonsingular (φ x) (φ y) := by
+  rw [nonsingular_iff, nonsingular_iff, and_congr <| W.equation_iff_baseChange hφ x y]
   refine ⟨Or.imp (not_imp_not.mpr fun h => ?_) (not_imp_not.mpr fun h => ?_),
     Or.imp (not_imp_not.mpr fun h => ?_) (not_imp_not.mpr fun h => ?_)⟩
-  any_goals apply NoZeroSMulDivisors.algebraMap_injective R A; map_simp; exact h
-  any_goals convert congr_arg (algebraMap R A) h <;> map_simp <;> rfl
+  any_goals apply hφ; map_simp; exact h
+  any_goals convert congr_arg φ h <;> map_simp <;> rfl
 #align weierstrass_curve.nonsingular_iff_base_change WeierstrassCurve.Affine.nonsingular_iff_baseChange
 
-lemma nonsingular_iff_baseChange_of_baseChange [Nontrivial B] [NoZeroSMulDivisors A B] (x y : A) :
-    (W.baseChange A).toAffine.nonsingular x y ↔
-      (W.baseChange B).toAffine.nonsingular (algebraMap A B x) (algebraMap A B y) := by
-  rw [(W.baseChange A).toAffine.nonsingular_iff_baseChange B, baseChange_baseChange]
+lemma nonsingular_iff_baseChange_of_baseChange {ψ : A →+* B} (hψ : Function.Injective ψ) (x y : A) :
+    (W.baseChange φ).toAffine.nonsingular x y ↔
+      (W.baseChange <| ψ.comp φ).toAffine.nonsingular (ψ x) (ψ y) := by
+  rw [(W.baseChange φ).toAffine.nonsingular_iff_baseChange hψ, baseChange_baseChange]
 #align weierstrass_curve.nonsingular_iff_base_change_of_base_change WeierstrassCurve.Affine.nonsingular_iff_baseChange_of_baseChange
 
-lemma baseChange_negY (x y : R) :
-    (W.baseChange A).toAffine.negY (algebraMap R A x) (algebraMap R A y) =
-      algebraMap R A (W.negY x y) := by
+lemma baseChange_negY (x y : R) : (W.baseChange φ).toAffine.negY (φ x) (φ y) = φ (W.negY x y) := by
   simp only [negY]
   map_simp
   rfl
@@ -823,15 +819,14 @@ set_option linter.uppercaseLean3 false in
 #align weierstrass_curve.base_change_neg_Y WeierstrassCurve.Affine.baseChange_negY
 
 lemma baseChange_negY_of_baseChange (x y : A) :
-    (W.baseChange B).toAffine.negY (algebraMap A B x) (algebraMap A B y) =
-      algebraMap A B ((W.baseChange A).toAffine.negY x y) := by
+    (W.baseChange <| ψ.comp φ).toAffine.negY (ψ x) (ψ y) =
+      ψ ((W.baseChange φ).toAffine.negY x y) := by
   rw [← baseChange_negY, baseChange_baseChange]
 set_option linter.uppercaseLean3 false in
 #align weierstrass_curve.base_change_neg_Y_of_base_change WeierstrassCurve.Affine.baseChange_negY_of_baseChange
 
 lemma baseChange_addX (x₁ x₂ L : R) :
-    (W.baseChange A).toAffine.addX (algebraMap R A x₁) (algebraMap R A x₂) (algebraMap R A L) =
-      algebraMap R A (W.addX x₁ x₂ L) := by
+    (W.baseChange φ).toAffine.addX (φ x₁) (φ x₂) (φ L) = φ (W.addX x₁ x₂ L) := by
   simp only [addX]
   map_simp
   rfl
@@ -839,45 +834,42 @@ set_option linter.uppercaseLean3 false in
 #align weierstrass_curve.base_change_add_X WeierstrassCurve.Affine.baseChange_addX
 
 lemma baseChange_addX_of_baseChange (x₁ x₂ L : A) :
-    (W.baseChange B).toAffine.addX (algebraMap A B x₁) (algebraMap A B x₂) (algebraMap A B L) =
-      algebraMap A B ((W.baseChange A).toAffine.addX x₁ x₂ L) := by
+    (W.baseChange <| ψ.comp φ).toAffine.addX (ψ x₁) (ψ x₂) (ψ L) =
+      ψ ((W.baseChange φ).toAffine.addX x₁ x₂ L) := by
   rw [← baseChange_addX, baseChange_baseChange]
 set_option linter.uppercaseLean3 false in
 #align weierstrass_curve.base_change_add_X_of_base_change WeierstrassCurve.Affine.baseChange_addX_of_baseChange
 
 lemma baseChange_addY' (x₁ x₂ y₁ L : R) :
-    (W.baseChange A).toAffine.addY' (algebraMap R A x₁) (algebraMap R A x₂) (algebraMap R A y₁)
-      (algebraMap R A L) = algebraMap R A (W.addY' x₁ x₂ y₁ L) := by
+    (W.baseChange φ).toAffine.addY' (φ x₁) (φ x₂) (φ y₁) (φ L) = φ (W.addY' x₁ x₂ y₁ L) := by
   simp only [addY', baseChange_addX]
   map_simp
 set_option linter.uppercaseLean3 false in
 #align weierstrass_curve.base_change_add_Y' WeierstrassCurve.Affine.baseChange_addY'
 
 lemma baseChange_addY'_of_baseChange (x₁ x₂ y₁ L : A) :
-    (W.baseChange B).toAffine.addY' (algebraMap A B x₁) (algebraMap A B x₂) (algebraMap A B y₁)
-      (algebraMap A B L) = algebraMap A B ((W.baseChange A).toAffine.addY' x₁ x₂ y₁ L) := by
+    (W.baseChange <| ψ.comp φ).toAffine.addY' (ψ x₁) (ψ x₂) (ψ y₁) (ψ L) =
+      ψ ((W.baseChange φ).toAffine.addY' x₁ x₂ y₁ L) := by
   rw [← baseChange_addY', baseChange_baseChange]
 set_option linter.uppercaseLean3 false in
 #align weierstrass_curve.base_change_add_Y'_of_base_change WeierstrassCurve.Affine.baseChange_addY'_of_baseChange
 
 lemma baseChange_addY (x₁ x₂ y₁ L : R) :
-    (W.baseChange A).toAffine.addY (algebraMap R A x₁) (algebraMap R A x₂) (algebraMap R A y₁)
-      (algebraMap R A L) = algebraMap R A (W.toAffine.addY x₁ x₂ y₁ L) := by
+    (W.baseChange φ).toAffine.addY (φ x₁) (φ x₂) (φ y₁) (φ L) = φ (W.toAffine.addY x₁ x₂ y₁ L) := by
   simp only [addY, baseChange_addY', baseChange_addX, baseChange_negY]
 set_option linter.uppercaseLean3 false in
 #align weierstrass_curve.base_change_add_Y WeierstrassCurve.Affine.baseChange_addY
 
 lemma baseChange_addY_of_baseChange (x₁ x₂ y₁ L : A) :
-    (W.baseChange B).toAffine.addY (algebraMap A B x₁) (algebraMap A B x₂) (algebraMap A B y₁)
-      (algebraMap A B L) = algebraMap A B ((W.baseChange A).toAffine.addY x₁ x₂ y₁ L) := by
+    (W.baseChange <| ψ.comp φ).toAffine.addY (ψ x₁) (ψ x₂) (ψ y₁) (ψ L) =
+      ψ ((W.baseChange φ).toAffine.addY x₁ x₂ y₁ L) := by
   rw [← baseChange_addY, baseChange_baseChange]
 set_option linter.uppercaseLean3 false in
 #align weierstrass_curve.base_change_add_Y_of_base_change WeierstrassCurve.Affine.baseChange_addY_of_baseChange
 
-lemma baseChange_slope {F : Type u} [Field F] (W : Affine F) (K : Type v) [Field K] [Algebra F K]
-    (x₁ x₂ y₁ y₂ : F) :
-    (W.baseChange K).toAffine.slope (algebraMap F K x₁) (algebraMap F K x₂) (algebraMap F K y₁)
-      (algebraMap F K y₂) = algebraMap F K (W.slope x₁ x₂ y₁ y₂) := by
+lemma baseChange_slope {F : Type u} [Field F] (W : Affine F) {K : Type v} [Field K] (φ : F →+* K)
+    (x₁ x₂ y₁ y₂ : F) : (W.baseChange φ).toAffine.slope (φ x₁) (φ x₂) (φ y₁) (φ y₂) =
+      φ (W.slope x₁ x₂ y₁ y₂) := by
   by_cases hx : x₁ = x₂
   · by_cases hy : y₁ = W.negY x₂ y₂
     · rw [slope_of_Yeq hx hy, slope_of_Yeq <| congr_arg _ hx, map_zero]
@@ -888,68 +880,69 @@ lemma baseChange_slope {F : Type u} [Field F] (W : Affine F) (K : Type v) [Field
         rfl
       · rw [baseChange_negY]
         contrapose! hy
-        exact NoZeroSMulDivisors.algebraMap_injective F K hy
+        exact φ.injective hy
   · rw [slope_of_Xne hx, slope_of_Xne]
     · map_simp
     · contrapose! hx
-      exact NoZeroSMulDivisors.algebraMap_injective F K hx
+      exact φ.injective hx
 #align weierstrass_curve.base_change_slope WeierstrassCurve.Affine.baseChange_slope
 
-lemma baseChange_slope_of_baseChange {R : Type u} [CommRing R] (W : Affine R) (F : Type v) [Field F]
-    [Algebra R F] (K : Type w) [Field K] [Algebra R K] [Algebra F K] [IsScalarTower R F K]
-    (x₁ x₂ y₁ y₂ : F) :
-    (W.baseChange K).toAffine.slope (algebraMap F K x₁) (algebraMap F K x₂) (algebraMap F K y₁)
-      (algebraMap F K y₂) = algebraMap F K ((W.baseChange F).toAffine.slope x₁ x₂ y₁ y₂) := by
+lemma baseChange_slope_of_baseChange {R : Type u} [CommRing R] (W : Affine R) {F : Type v} [Field F]
+    {K : Type w} [Field K] (φ : R →+* F) (ψ : F →+* K) (x₁ x₂ y₁ y₂ : F) :
+    (W.baseChange <| ψ.comp φ).toAffine.slope (ψ x₁) (ψ x₂) (ψ y₁) (ψ y₂) =
+      ψ ((W.baseChange φ).toAffine.slope x₁ x₂ y₁ y₂) := by
   rw [← baseChange_slope, baseChange_baseChange]
 #align weierstrass_curve.base_change_slope_of_base_change WeierstrassCurve.Affine.baseChange_slope_of_baseChange
 
 namespace Point
 
-open WeierstrassCurve
+variable [Algebra R A] {K : Type w} [Field K] [Algebra R K] [Algebra A K] [IsScalarTower R A K]
+  {L : Type t} [Field L] [Algebra R L] [Algebra A L] [IsScalarTower R A L] (φ : K →ₐ[A] L)
 
-variable {R : Type u} [CommRing R] (W : Affine R) (F : Type v) [Field F] [Algebra R F]
-  (K : Type w) [Field K] [Algebra R K] [Algebra F K] [IsScalarTower R F K]
-
-/-- The function from `W⟮F⟯` to `W⟮K⟯` induced by a base change from `F` to `K`. -/
-def ofBaseChangeFun : W⟮F⟯ → W⟮K⟯
+/-- The function from `W⟮K⟯` to `W⟮L⟯` induced by an algebra homomorphism `φ : K →ₐ[A] L`,
+where `W` is defined over a subring of a ring `A`, and `K` and `L` are field extensions of `A`. -/
+def ofBaseChangeFun : W⟮K⟯ → W⟮L⟯
   | 0 => 0
-  | Point.some h => Point.some <| (nonsingular_iff_baseChange_of_baseChange W F K ..).mp h
+  | Point.some h => Point.some <| by
+    convert (W.nonsingular_iff_baseChange_of_baseChange (algebraMap R K) φ.injective _ _).mp h
+    exact (φ.restrictScalars R).comp_algebraMap.symm
 #align weierstrass_curve.point.of_base_change_fun WeierstrassCurve.Affine.Point.ofBaseChangeFun
 
-/-- The group homomorphism from `W⟮F⟯` to `W⟮K⟯` induced by a base change from `F` to `K`. -/
+/-- The group homomorphism from `W⟮K⟯` to `W⟮L⟯` induced by an algebra homomorphism `φ : K →ₐ[A] L`,
+where `W` is defined over a subring of a ring `A`, and `K` and `L` are field extensions of `A`. -/
 @[simps]
-def ofBaseChange : W⟮F⟯ →+ W⟮K⟯ where
-  toFun := ofBaseChangeFun W F K
+def ofBaseChange : W⟮K⟯ →+ W⟮L⟯ where
+  toFun := ofBaseChangeFun W φ
   map_zero' := rfl
   map_add' := by
     rintro (_ | @⟨x₁, y₁, _⟩) (_ | @⟨x₂, y₂, _⟩)
     any_goals rfl
     by_cases hx : x₁ = x₂
-    · by_cases hy : y₁ = (W.baseChange F).toAffine.negY x₂ y₂
+    · by_cases hy : y₁ = (W.baseChange <| algebraMap R K).toAffine.negY x₂ y₂
       · simp only [some_add_some_of_Yeq hx hy, ofBaseChangeFun]
         rw [some_add_some_of_Yeq <| congr_arg _ hx]
-        · rw [hy, baseChange_negY_of_baseChange]
+        · erw [hy, ← φ.comp_algebraMap_of_tower R, baseChange_negY_of_baseChange]
+          rfl
       · simp only [some_add_some_of_Yne hx hy, ofBaseChangeFun]
         rw [some_add_some_of_Yne <| congr_arg _ hx]
-        · simp only [baseChange_addX_of_baseChange, baseChange_addY_of_baseChange,
-            baseChange_slope_of_baseChange]
-        · rw [baseChange_negY_of_baseChange]
+        · simp only [← φ.comp_algebraMap_of_tower R, ← baseChange_addX_of_baseChange,
+            ← baseChange_addY_of_baseChange, ← baseChange_slope_of_baseChange]
+        · erw [← φ.comp_algebraMap_of_tower R, baseChange_negY_of_baseChange]
           contrapose! hy
-          exact NoZeroSMulDivisors.algebraMap_injective F K hy
+          exact φ.injective hy
     · simp only [some_add_some_of_Xne hx, ofBaseChangeFun]
       rw [some_add_some_of_Xne]
-      · simp only [baseChange_addX_of_baseChange, baseChange_addY_of_baseChange,
-          baseChange_slope_of_baseChange]
+      · simp only [← φ.comp_algebraMap_of_tower R, ← baseChange_addX_of_baseChange,
+          ← baseChange_addY_of_baseChange, ← baseChange_slope_of_baseChange]
       · contrapose! hx
-        exact NoZeroSMulDivisors.algebraMap_injective F K hx
+        exact φ.injective hx
 #align weierstrass_curve.point.of_base_change WeierstrassCurve.Affine.Point.ofBaseChange
 
-lemma ofBaseChange_injective : Function.Injective <| ofBaseChange W F K := by
+lemma ofBaseChange_injective : Function.Injective <| ofBaseChange W φ := by
   rintro (_ | _) (_ | _) h
   any_goals contradiction
   · rfl
-  · simpa only [some.injEq] using ⟨NoZeroSMulDivisors.algebraMap_injective F K (some.inj h).left,
-      NoZeroSMulDivisors.algebraMap_injective F K (some.inj h).right⟩
+  · simpa only [some.injEq] using ⟨φ.injective (some.inj h).left, φ.injective (some.inj h).right⟩
 #align weierstrass_curve.point.of_base_change_injective WeierstrassCurve.Affine.Point.ofBaseChange_injective
 
 end Point

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Group.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Group.lean
@@ -138,7 +138,7 @@ lemma YClass_ne_zero [Nontrivial R] (y : R[X]) : YClass W y ≠ 0 :=
 set_option linter.uppercaseLean3 false in
 #align weierstrass_curve.coordinate_ring.Y_class_ne_zero WeierstrassCurve.Affine.CoordinateRing.YClass_ne_zero
 
-lemma C_addPolynomial (x y L : R) : mk W (C (W.addPolynomial x y L)) =
+lemma C_addPolynomial (x y L : R) : mk W (C <| W.addPolynomial x y L) =
     mk W ((Y - C (linePolynomial x y L)) * (W.negPolynomial - C (linePolynomial x y L))) :=
   AdjoinRoot.mk_eq_mk.mpr ⟨1, by rw [W.C_addPolynomial, add_sub_cancel', mul_one]⟩
 set_option linter.uppercaseLean3 false in
@@ -207,7 +207,7 @@ lemma XYIdeal_eq₂ {x₁ x₂ y₁ y₂ : F} (h₁ : W.equation x₁ y₁)
   have hy₂ : y₂ = (linePolynomial x₁ y₁ <| W.slope x₁ x₂ y₁ y₂).eval x₂ := by
     by_cases hx : x₁ = x₂
     · rcases hx, Yeq_of_Yne h₁ h₂ hx <| hxy hx with ⟨rfl, rfl⟩
-      field_simp [linePolynomial, sub_ne_zero_of_ne (hxy rfl)]
+      field_simp [linePolynomial, sub_ne_zero_of_ne <| hxy rfl]
     · field_simp [linePolynomial, slope_of_Xne hx, sub_ne_zero_of_ne hx]
       ring1
   nth_rw 1 [hy₂]
@@ -223,7 +223,7 @@ set_option linter.uppercaseLean3 false in
 
 lemma XYIdeal_neg_mul {x y : F} (h : W.nonsingular x y) :
     XYIdeal W x (C <| W.negY x y) * XYIdeal W x (C y) = XIdeal W x := by
-  have Y_rw : (Y - C (C y)) * (Y - C (C (W.negY x y))) -
+  have Y_rw : (Y - C (C y)) * (Y - C (C <| W.negY x y)) -
       C (X - C x) * (C (X ^ 2 + C (x + W.a₂) * X + C (x ^ 2 + W.a₂ * x + W.a₄)) - C (C W.a₁) * Y) =
         W.polynomial * 1 := by
     linear_combination (norm := (rw [negY, polynomial]; C_simp; ring1))
@@ -239,13 +239,13 @@ lemma XYIdeal_neg_mul {x y : F} (h : W.nonsingular x y) :
   rcases ((W.nonsingular_iff' _ _).mp h).right with hx | hy
   · let W_X := W.a₁ * y - (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄)
     refine
-      ⟨C (C W_X⁻¹ * -(X + C (2 * x + W.a₂))), C (C <| W_X⁻¹ * W.a₁), 0, C (C <| W_X⁻¹ * -1), ?_⟩
+      ⟨C <| C W_X⁻¹ * -(X + C (2 * x + W.a₂)), C <| C <| W_X⁻¹ * W.a₁, 0, C <| C <| W_X⁻¹ * -1, ?_⟩
     rw [← mul_right_inj' <| C_ne_zero.mpr <| C_ne_zero.mpr hx]
     simp only [mul_add, ← mul_assoc, ← C_mul, mul_inv_cancel hx]
     C_simp
     ring1
   · let W_Y := 2 * y + W.a₁ * x + W.a₃
-    refine ⟨0, C (C W_Y⁻¹), C (C <| W_Y⁻¹ * -1), 0, ?_⟩
+    refine ⟨0, C <| C W_Y⁻¹, C <| C <| W_Y⁻¹ * -1, 0, ?_⟩
     rw [negY, ← mul_right_inj' <| C_ne_zero.mpr <| C_ne_zero.mpr hy]
     simp only [mul_add, ← mul_assoc, ← C_mul, mul_inv_cancel hy]
     C_simp
@@ -275,22 +275,21 @@ lemma XYIdeal_mul_XYIdeal {x₁ x₂ y₁ y₂ : F} (h₁ : W.equation x₁ y₁
   simp_rw [mul_comm <| XClass W x₁, mul_assoc, ← span_singleton_mul_span_singleton, ← mul_sup]
   rw [span_singleton_mul_span_singleton, ← span_insert,
     ← span_pair_add_mul_right <| -(XClass W <| W.addX x₁ x₂ <| W.slope x₁ x₂ y₁ y₂), mul_neg,
-    ← sub_eq_add_neg, ← sub_mul, ← map_sub <| mk W, sub_sub_sub_cancel_right,
-    span_insert, ← span_singleton_mul_span_singleton, ← sup_rw, ← sup_mul, ← sup_mul]
+    ← sub_eq_add_neg, ← sub_mul, ← map_sub <| mk W, sub_sub_sub_cancel_right, span_insert,
+    ← span_singleton_mul_span_singleton, ← sup_rw, ← sup_mul, ← sup_mul]
   apply congr_arg (_ ∘ _)
   convert top_mul (_ : Ideal W.CoordinateRing)
-  simp_rw [XClass, ← @Set.image_singleton _ _ <| mk W, ← map_span, ← Ideal.map_sup,
-    eq_top_iff_one, mem_map_iff_of_surjective _ AdjoinRoot.mk_surjective, ← span_insert,
-    mem_span_insert', mem_span_singleton']
+  simp_rw [XClass, ← @Set.image_singleton _ _ <| mk W, ← map_span, ← Ideal.map_sup, eq_top_iff_one,
+    mem_map_iff_of_surjective _ AdjoinRoot.mk_surjective, ← span_insert, mem_span_insert',
+    mem_span_singleton']
   by_cases hx : x₁ = x₂
   · rcases hx, Yeq_of_Yne h₁ h₂ hx (hxy hx) with ⟨rfl, rfl⟩
     let y := (y₁ - W.negY x₁ y₁) ^ 2
-    replace hxy := pow_ne_zero 2 (sub_ne_zero_of_ne <| hxy rfl)
+    replace hxy := pow_ne_zero 2 <| sub_ne_zero_of_ne <| hxy rfl
     refine ⟨1 + C (C <| y⁻¹ * 4) * W.polynomial,
       ⟨C <| C y⁻¹ * (C 4 * X ^ 2 + C (4 * x₁ + W.b₂) * X + C (4 * x₁ ^ 2 + W.b₂ * x₁ + 2 * W.b₄)),
         0, C (C y⁻¹) * (Y - W.negPolynomial), ?_⟩, by
-      rw [map_add, map_one, _root_.map_mul <| mk W, AdjoinRoot.mk_self, mul_zero,
-        add_zero]⟩
+      rw [map_add, map_one, _root_.map_mul <| mk W, AdjoinRoot.mk_self, mul_zero, add_zero]⟩
     rw [polynomial, negPolynomial, ← mul_right_inj' <| C_ne_zero.mpr <| C_ne_zero.mpr hxy]
     simp only [mul_add, ← mul_assoc, ← C_mul, mul_inv_cancel hxy]
     linear_combination (norm := (rw [b₂, b₄, negY]; C_simp; ring1))
@@ -467,7 +466,7 @@ lemma norm_smul_basis (p q : R[X]) :
 #align weierstrass_curve.coordinate_ring.norm_smul_basis WeierstrassCurve.Affine.CoordinateRing.norm_smul_basis
 
 lemma coe_norm_smul_basis (p q : R[X]) :
-    ↑(Algebra.norm R[X] <| p • (1 : W.CoordinateRing) + q • mk W Y) =
+    Algebra.norm R[X] (p • (1 : W.CoordinateRing) + q • mk W Y) =
       mk W ((C p + C q * X) * (C p + C q * (-Y - C (C W.a₁ * X + C W.a₃)))) :=
   AdjoinRoot.mk_eq_mk.mpr
     ⟨C q ^ 2, by simp only [norm_smul_basis, polynomial]; C_simp; ring1⟩
@@ -632,9 +631,6 @@ lemma add_assoc (P Q R : W.Point) : P + Q + R = P + (Q + R) :=
 #align weierstrass_curve.point.add_assoc WeierstrassCurve.Affine.Point.add_assoc
 
 noncomputable instance instAddCommGroupPoint : AddCommGroup W.Point where
-  zero := zero
-  neg := neg
-  add := add
   zero_add := zero_add
   add_zero := add_zero
   add_left_neg := add_left_neg

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
@@ -37,7 +37,7 @@ splitting field of `R` are precisely the $X$-coordinates of the non-zero 2-torsi
  * `WeierstrassCurve.ofJ`: a Weierstrass curve whose j-invariant is neither 0 nor 1728.
  * `WeierstrassCurve.VariableChange`: a change of variables of Weierstrass curves.
  * `WeierstrassCurve.variableChange`: the Weierstrass curve induced by a change of variables.
- * `WeierstrassCurve.baseChange`: the Weierstrass curve base changed over an algebra.
+ * `WeierstrassCurve.baseChange`: the Weierstrass curve base changed over a ring homomorphism.
  * `WeierstrassCurve.twoTorsionPolynomial`: the 2-torsion polynomial of a Weierstrass curve.
  * `EllipticCurve`: an elliptic curve over a commutative ring.
  * `EllipticCurve.j`: the j-invariant of an elliptic curve.
@@ -215,16 +215,16 @@ def id : VariableChange R :=
 /-- The composition of two linear changes of variables given by matrix multiplication. -/
 def comp : VariableChange R where
   u := C.u * C'.u
-  r := C.r * ↑C'.u ^ 2 + C'.r
-  s := ↑C'.u * C.s + C'.s
-  t := C.t * ↑C'.u ^ 3 + C.r * C'.s * ↑C'.u ^ 2 + C'.t
+  r := C.r * C'.u ^ 2 + C'.r
+  s := C'.u * C.s + C'.s
+  t := C.t * C'.u ^ 3 + C.r * C'.s * C'.u ^ 2 + C'.t
 
 /-- The inverse of a linear change of variables given by matrix inversion. -/
 def inv : VariableChange R where
   u := C.u⁻¹
-  r := -C.r * ↑C.u⁻¹ ^ 2
-  s := -C.s * ↑C.u⁻¹
-  t := (C.r * C.s - C.t) * ↑C.u⁻¹ ^ 3
+  r := -C.r * C.u⁻¹ ^ 2
+  s := -C.s * C.u⁻¹
+  t := (C.r * C.s - C.t) * C.u⁻¹ ^ 3
 
 lemma id_comp (C : VariableChange R) : comp id C = C := by
   simp only [comp, id, zero_add, zero_mul, mul_zero, one_mul]
@@ -261,12 +261,12 @@ variable (C : VariableChange R)
 $(X, Y) \mapsto (u^2X + r, u^3Y + u^2sX + t)$ for some $u \in R^\times$ and some $r, s, t \in R$. -/
 @[pp_dot, simps]
 def variableChange : WeierstrassCurve R where
-  a₁ := ↑C.u⁻¹ * (W.a₁ + 2 * C.s)
-  a₂ := ↑C.u⁻¹ ^ 2 * (W.a₂ - C.s * W.a₁ + 3 * C.r - C.s ^ 2)
-  a₃ := ↑C.u⁻¹ ^ 3 * (W.a₃ + C.r * W.a₁ + 2 * C.t)
-  a₄ := ↑C.u⁻¹ ^ 4 * (W.a₄ - C.s * W.a₃ + 2 * C.r * W.a₂ - (C.t + C.r * C.s) * W.a₁ + 3 * C.r ^ 2
+  a₁ := C.u⁻¹ * (W.a₁ + 2 * C.s)
+  a₂ := C.u⁻¹ ^ 2 * (W.a₂ - C.s * W.a₁ + 3 * C.r - C.s ^ 2)
+  a₃ := C.u⁻¹ ^ 3 * (W.a₃ + C.r * W.a₁ + 2 * C.t)
+  a₄ := C.u⁻¹ ^ 4 * (W.a₄ - C.s * W.a₃ + 2 * C.r * W.a₂ - (C.t + C.r * C.s) * W.a₁ + 3 * C.r ^ 2
     - 2 * C.s * C.t)
-  a₆ := ↑C.u⁻¹ ^ 6 * (W.a₆ + C.r * W.a₄ + C.r ^ 2 * W.a₂ + C.r ^ 3 - C.t * W.a₃ - C.t ^ 2
+  a₆ := C.u⁻¹ ^ 6 * (W.a₆ + C.r * W.a₄ + C.r ^ 2 * W.a₂ + C.r ^ 3 - C.t * W.a₃ - C.t ^ 2
     - C.r * C.t * W.a₁)
 #align weierstrass_curve.variable_change WeierstrassCurve.variableChange
 
@@ -278,33 +278,29 @@ lemma variableChange_comp (C C' : VariableChange R) (W : WeierstrassCurve R) :
     W.variableChange (C.comp C') = (W.variableChange C').variableChange C := by
   simp only [VariableChange.comp, variableChange]
   ext <;> simp only [mul_inv, Units.val_mul]
-  · linear_combination (norm := ring1) ↑C.u⁻¹ * C.s * 2 * C'.u.inv_mul
+  · linear_combination (norm := ring1) C.u⁻¹ * C.s * 2 * C'.u.inv_mul
   · linear_combination (norm := ring1)
-      C.s * (-C'.s * 2 - W.a₁) * (↑C.u⁻¹ : R) ^ 2 * ↑C'.u⁻¹ * C'.u.inv_mul
-        + (C.r * 3 - C.s ^ 2) * (↑C.u⁻¹ : R) ^ 2 * pow_mul_pow_eq_one 2 C'.u.inv_mul
+      C.s * (-C'.s * 2 - W.a₁) * C.u⁻¹ ^ 2 * C'.u⁻¹ * C'.u.inv_mul
+        + (C.r * 3 - C.s ^ 2) * C.u⁻¹ ^ 2 * pow_mul_pow_eq_one 2 C'.u.inv_mul
   · linear_combination (norm := ring1)
-      C.r * (C'.s * 2 + W.a₁) * (↑C.u⁻¹ : R) ^ 3 * ↑C'.u⁻¹ * pow_mul_pow_eq_one 2 C'.u.inv_mul
-        + C.t * 2 * (↑C.u⁻¹ : R) ^ 3 * pow_mul_pow_eq_one 3 C'.u.inv_mul
+      C.r * (C'.s * 2 + W.a₁) * C.u⁻¹ ^ 3 * C'.u⁻¹ * pow_mul_pow_eq_one 2 C'.u.inv_mul
+        + C.t * 2 * C.u⁻¹ ^ 3 * pow_mul_pow_eq_one 3 C'.u.inv_mul
   · linear_combination (norm := ring1)
-      C.s * (-W.a₃ - C'.r * W.a₁ - C'.t * 2) * (↑C.u⁻¹ : R) ^ 4 * (↑C'.u⁻¹ : R) ^ 3 * C'.u.inv_mul
-        + (↑C.u⁻¹ : R) ^ 4 * (↑C'.u⁻¹ : R) ^ 2
-          * (C.r * C'.r * 6 + C.r * W.a₂ * 2 - C'.s * C.r * W.a₁ * 2 - C'.s ^ 2 * C.r * 2)
-          * pow_mul_pow_eq_one 2 C'.u.inv_mul
-        + -(↑C.u⁻¹ : R) ^ 4
-          * ↑C'.u⁻¹ * (C.s * C'.s * C.r * 2 + C.s * C.r * W.a₁ + C'.s * C.t * 2 + C.t * W.a₁)
+      C.s * (-W.a₃ - C'.r * W.a₁ - C'.t * 2) * C.u⁻¹ ^ 4 * C'.u⁻¹ ^ 3 * C'.u.inv_mul
+        + C.u⁻¹ ^ 4 * C'.u⁻¹ ^ 2 * (C.r * C'.r * 6 + C.r * W.a₂ * 2 - C'.s * C.r * W.a₁ * 2
+          - C'.s ^ 2 * C.r * 2) * pow_mul_pow_eq_one 2 C'.u.inv_mul
+        - C.u⁻¹ ^ 4 * C'.u⁻¹ * (C.s * C'.s * C.r * 2 + C.s * C.r * W.a₁ + C'.s * C.t * 2
+          + C.t * W.a₁) * pow_mul_pow_eq_one 3 C'.u.inv_mul
+        + C.u⁻¹ ^ 4 * (C.r ^ 2 * 3 - C.s * C.t * 2) * pow_mul_pow_eq_one 4 C'.u.inv_mul
+  · linear_combination (norm := ring1)
+      C.r * C.u⁻¹ ^ 6 * C'.u⁻¹ ^ 4 * (C'.r * W.a₂ * 2 - C'.r * C'.s * W.a₁ + C'.r ^ 2 * 3 + W.a₄
+          - C'.s * C'.t * 2 - C'.s * W.a₃ - C'.t * W.a₁) * pow_mul_pow_eq_one 2 C'.u.inv_mul
+        - C.u⁻¹ ^ 6 * C'.u⁻¹ ^ 3 * C.t * (C'.r * W.a₁ + C'.t * 2 + W.a₃)
           * pow_mul_pow_eq_one 3 C'.u.inv_mul
-        + (↑C.u⁻¹ : R) ^ 4 * (C.r ^ 2 * 3 - C.s * C.t * 2) * pow_mul_pow_eq_one 4 C'.u.inv_mul
-  · linear_combination (norm := ring1)
-      C.r * (↑C.u⁻¹ : R) ^ 6 * (↑C'.u⁻¹ : R) ^ 4 * (C'.r * W.a₂ * 2 - C'.r * C'.s * W.a₁
-          + C'.r ^ 2 * 3 + W.a₄ - C'.s * C'.t * 2 - C'.s * W.a₃ - C'.t * W.a₁)
-          * pow_mul_pow_eq_one 2 C'.u.inv_mul
-        + -(↑C.u⁻¹ : R) ^ 6 * (↑C'.u⁻¹ : R) ^ 3 * C.t * (C'.r * W.a₁ + C'.t * 2 + W.a₃)
-          * pow_mul_pow_eq_one 3 C'.u.inv_mul
-        + C.r ^ 2 * (↑C.u⁻¹ : R) ^ 6 * (↑C'.u⁻¹ : R) ^ 2
-          * (C'.r * 3 + W.a₂ - C'.s * W.a₁ - C'.s ^ 2) * pow_mul_pow_eq_one 4 C'.u.inv_mul
-        + -C.r * C.t * (↑C.u⁻¹ : R) ^ 6 * ↑C'.u⁻¹ * (C'.s * 2 + W.a₁)
-          * pow_mul_pow_eq_one 5 C'.u.inv_mul
-        + (↑C.u⁻¹ : R) ^ 6 * (C.r ^ 3 - C.t ^ 2) * pow_mul_pow_eq_one 6 C'.u.inv_mul
+        + C.r ^ 2 * C.u⁻¹ ^ 6 * C'.u⁻¹ ^ 2 * (C'.r * 3 + W.a₂ - C'.s * W.a₁ - C'.s ^ 2)
+          * pow_mul_pow_eq_one 4 C'.u.inv_mul
+        - C.r * C.t * C.u⁻¹ ^ 6 * C'.u⁻¹ * (C'.s * 2 + W.a₁) * pow_mul_pow_eq_one 5 C'.u.inv_mul
+        + C.u⁻¹ ^ 6 * (C.r ^ 3 - C.t ^ 2) * pow_mul_pow_eq_one 6 C'.u.inv_mul
 
 instance instMulActionVariableChange : MulAction (VariableChange R) (WeierstrassCurve R) where
   smul := fun C W => W.variableChange C
@@ -312,27 +308,27 @@ instance instMulActionVariableChange : MulAction (VariableChange R) (Weierstrass
   mul_smul := variableChange_comp
 
 @[simp]
-lemma variableChange_b₂ : (W.variableChange C).b₂ = (↑C.u⁻¹ : R) ^ 2 * (W.b₂ + 12 * C.r) := by
+lemma variableChange_b₂ : (W.variableChange C).b₂ = C.u⁻¹ ^ 2 * (W.b₂ + 12 * C.r) := by
   simp only [b₂, variableChange_a₁, variableChange_a₂]
   ring1
 #align weierstrass_curve.variable_change_b₂ WeierstrassCurve.variableChange_b₂
 
 @[simp]
 lemma variableChange_b₄ :
-    (W.variableChange C).b₄ = (↑C.u⁻¹ : R) ^ 4 * (W.b₄ + C.r * W.b₂ + 6 * C.r ^ 2) := by
+    (W.variableChange C).b₄ = C.u⁻¹ ^ 4 * (W.b₄ + C.r * W.b₂ + 6 * C.r ^ 2) := by
   simp only [b₂, b₄, variableChange_a₁, variableChange_a₃, variableChange_a₄]
   ring1
 #align weierstrass_curve.variable_change_b₄ WeierstrassCurve.variableChange_b₄
 
 @[simp]
 lemma variableChange_b₆ : (W.variableChange C).b₆ =
-    (↑C.u⁻¹ : R) ^ 6 * (W.b₆ + 2 * C.r * W.b₄ + C.r ^ 2 * W.b₂ + 4 * C.r ^ 3) := by
+    C.u⁻¹ ^ 6 * (W.b₆ + 2 * C.r * W.b₄ + C.r ^ 2 * W.b₂ + 4 * C.r ^ 3) := by
   simp only [b₂, b₄, b₆, variableChange_a₃, variableChange_a₆]
   ring1
 #align weierstrass_curve.variable_change_b₆ WeierstrassCurve.variableChange_b₆
 
 @[simp]
-lemma variableChange_b₈ : (W.variableChange C).b₈ = (↑C.u⁻¹ : R) ^ 8 *
+lemma variableChange_b₈ : (W.variableChange C).b₈ = C.u⁻¹ ^ 8 *
     (W.b₈ + 3 * C.r * W.b₆ + 3 * C.r ^ 2 * W.b₄ + C.r ^ 3 * W.b₂ + 3 * C.r ^ 4) := by
   simp only [b₂, b₄, b₆, b₈, variableChange_a₁, variableChange_a₂, variableChange_a₃,
     variableChange_a₄, variableChange_a₆]
@@ -340,19 +336,19 @@ lemma variableChange_b₈ : (W.variableChange C).b₈ = (↑C.u⁻¹ : R) ^ 8 *
 #align weierstrass_curve.variable_change_b₈ WeierstrassCurve.variableChange_b₈
 
 @[simp]
-lemma variableChange_c₄ : (W.variableChange C).c₄ = (↑C.u⁻¹ : R) ^ 4 * W.c₄ := by
+lemma variableChange_c₄ : (W.variableChange C).c₄ = C.u⁻¹ ^ 4 * W.c₄ := by
   simp only [c₄, variableChange_b₂, variableChange_b₄]
   ring1
 #align weierstrass_curve.variable_change_c₄ WeierstrassCurve.variableChange_c₄
 
 @[simp]
-lemma variableChange_c₆ : (W.variableChange C).c₆ = (↑C.u⁻¹ : R) ^ 6 * W.c₆ := by
+lemma variableChange_c₆ : (W.variableChange C).c₆ = C.u⁻¹ ^ 6 * W.c₆ := by
   simp only [c₆, variableChange_b₂, variableChange_b₄, variableChange_b₆]
   ring1
 #align weierstrass_curve.variable_change_c₆ WeierstrassCurve.variableChange_c₆
 
 @[simp]
-lemma variableChange_Δ : (W.variableChange C).Δ = (↑C.u⁻¹ : R) ^ 12 * W.Δ := by
+lemma variableChange_Δ : (W.variableChange C).Δ = C.u⁻¹ ^ 12 * W.Δ := by
   simp only [b₂, b₄, b₆, b₈, Δ, variableChange_a₁, variableChange_a₂, variableChange_a₃,
     variableChange_a₄, variableChange_a₆]
   ring1
@@ -364,111 +360,109 @@ section BaseChange
 
 /-! ### Base changes -/
 
-variable (A : Type v) [CommRing A] [Algebra R A] (B : Type w) [CommRing B] [Algebra R B]
-  [Algebra A B] [IsScalarTower R A B]
+variable {A : Type v} [CommRing A] (φ : R →+* A) {B : Type w} [CommRing B] (ψ : A →+* B)
 
-/-- The Weierstrass curve over `R` base changed to `A`. -/
+/-- The Weierstrass curve base changed over a ring homomorphism `φ : R →+* A`. -/
 @[pp_dot, simps]
 def baseChange : WeierstrassCurve A :=
-  ⟨algebraMap R A W.a₁, algebraMap R A W.a₂, algebraMap R A W.a₃, algebraMap R A W.a₄,
-    algebraMap R A W.a₆⟩
+  ⟨φ W.a₁, φ W.a₂, φ W.a₃, φ W.a₄, φ W.a₆⟩
 #align weierstrass_curve.base_change WeierstrassCurve.baseChange
 
 @[simp]
-lemma baseChange_b₂ : (W.baseChange A).b₂ = algebraMap R A W.b₂ := by
+lemma baseChange_b₂ : (W.baseChange φ).b₂ = φ W.b₂ := by
   simp only [b₂, baseChange_a₁, baseChange_a₂]
   map_simp
 #align weierstrass_curve.base_change_b₂ WeierstrassCurve.baseChange_b₂
 
 @[simp]
-lemma baseChange_b₄ : (W.baseChange A).b₄ = algebraMap R A W.b₄ := by
+lemma baseChange_b₄ : (W.baseChange φ).b₄ = φ W.b₄ := by
   simp only [b₄, baseChange_a₁, baseChange_a₃, baseChange_a₄]
   map_simp
 #align weierstrass_curve.base_change_b₄ WeierstrassCurve.baseChange_b₄
 
 @[simp]
-lemma baseChange_b₆ : (W.baseChange A).b₆ = algebraMap R A W.b₆ := by
+lemma baseChange_b₆ : (W.baseChange φ).b₆ = φ W.b₆ := by
   simp only [b₆, baseChange_a₃, baseChange_a₆]
   map_simp
 #align weierstrass_curve.base_change_b₆ WeierstrassCurve.baseChange_b₆
 
 @[simp]
-lemma baseChange_b₈ : (W.baseChange A).b₈ = algebraMap R A W.b₈ := by
+lemma baseChange_b₈ : (W.baseChange φ).b₈ = φ W.b₈ := by
   simp only [b₈, baseChange_a₁, baseChange_a₂, baseChange_a₃, baseChange_a₄, baseChange_a₆]
   map_simp
 #align weierstrass_curve.base_change_b₈ WeierstrassCurve.baseChange_b₈
 
 @[simp]
-lemma baseChange_c₄ : (W.baseChange A).c₄ = algebraMap R A W.c₄ := by
+lemma baseChange_c₄ : (W.baseChange φ).c₄ = φ W.c₄ := by
   simp only [c₄, baseChange_b₂, baseChange_b₄]
   map_simp
 #align weierstrass_curve.base_change_c₄ WeierstrassCurve.baseChange_c₄
 
 @[simp]
-lemma baseChange_c₆ : (W.baseChange A).c₆ = algebraMap R A W.c₆ := by
+lemma baseChange_c₆ : (W.baseChange φ).c₆ = φ W.c₆ := by
   simp only [c₆, baseChange_b₂, baseChange_b₄, baseChange_b₆]
   map_simp
 #align weierstrass_curve.base_change_c₆ WeierstrassCurve.baseChange_c₆
 
 @[simp]
-lemma baseChange_Δ : (W.baseChange A).Δ = algebraMap R A W.Δ := by
+lemma baseChange_Δ : (W.baseChange φ).Δ = φ W.Δ := by
   simp only [Δ, baseChange_b₂, baseChange_b₄, baseChange_b₆, baseChange_b₈]
   map_simp
 #align weierstrass_curve.base_change_Δ WeierstrassCurve.baseChange_Δ
 
-lemma baseChange_self : W.baseChange R = W := by
-  ext <;> rfl
+lemma baseChange_self : W.baseChange (RingHom.id R) = W :=
+  rfl
 #align weierstrass_curve.base_change_self WeierstrassCurve.baseChange_self
 
-lemma baseChange_baseChange : (W.baseChange A).baseChange B = W.baseChange B := by
-  ext <;> exact (IsScalarTower.algebraMap_apply R A B _).symm
+lemma baseChange_baseChange : (W.baseChange φ).baseChange ψ = W.baseChange (ψ.comp φ) :=
+  rfl
 #align weierstrass_curve.base_change_base_change WeierstrassCurve.baseChange_baseChange
 
-lemma baseChange_injective (h : Function.Injective <| algebraMap R A) :
-    Function.Injective <| baseChange (R := R) (A := A) := fun W W' h1 => by
-  rcases mk.inj h1 with ⟨_, _, _, _, _⟩
-  ext <;> apply_fun _ using h <;> assumption
+lemma baseChange_injective {φ : R →+* A} (hφ : Function.Injective φ) :
+    Function.Injective <| baseChange (φ := φ) := fun _ _ h => by
+  rcases mk.inj h with ⟨_, _, _, _, _⟩
+  ext <;> apply_fun _ using hφ <;> assumption
 
 namespace VariableChange
 
 variable (C : VariableChange R)
 
-/-- The change of variables over `R` base changed to `A`. -/
+/-- The change of variables base changed over a ring homomorphism `φ : R →+* A`. -/
 @[simps]
 def baseChange : VariableChange A :=
-  ⟨Units.map (algebraMap R A) C.u, algebraMap R A C.r, algebraMap R A C.s, algebraMap R A C.t⟩
+  ⟨Units.map φ C.u, φ C.r, φ C.s, φ C.t⟩
 
-lemma baseChange_id : baseChange A (id : VariableChange R) = id := by
+lemma baseChange_id : (id : VariableChange R).baseChange φ = id := by
   simp only [id, baseChange]
   ext <;> simp only [map_one, Units.val_one, map_zero]
 
 lemma baseChange_comp (C' : VariableChange R) :
-    baseChange A (C.comp C') = (baseChange A C).comp (baseChange A C') := by
+    (C.comp C').baseChange φ = (C.baseChange φ).comp (C'.baseChange φ) := by
   simp only [comp, baseChange]
   ext <;> map_simp <;> simp only [Units.coe_map, Units.coe_map_inv, MonoidHom.coe_coe]
 
-/-- The base change to `A` of a change of variables over `R` is a group homomorphism. -/
+/-- The base change of a change of variables over a ring homomorphism is a group homomorphism. -/
 def baseChangeMap : VariableChange R →* VariableChange A where
-  toFun := baseChange A
-  map_one' := baseChange_id A
-  map_mul' := baseChange_comp A
+  toFun := baseChange φ
+  map_one' := baseChange_id φ
+  map_mul' := baseChange_comp φ
 
-lemma baseChange_self : C.baseChange R = C :=
+lemma baseChange_self : C.baseChange (RingHom.id R) = C :=
   rfl
 
-lemma baseChange_baseChange : (C.baseChange A).baseChange B = C.baseChange B := by
-  ext <;> exact (IsScalarTower.algebraMap_apply R A B _).symm
+lemma baseChange_baseChange : (C.baseChange φ).baseChange ψ = C.baseChange (ψ.comp φ) :=
+  rfl
 
-lemma baseChange_injective (h : Function.Injective <| algebraMap R A) :
-    Function.Injective <| baseChange (R := R) A := fun C C' h1 => by
-  rcases mk.inj h1 with ⟨h1, _, _, _⟩
-  replace h1 := (Units.mk.inj h1).left
-  ext <;> apply_fun _ using h <;> assumption
+lemma baseChange_injective {φ : R →+* A} (hφ : Function.Injective φ) :
+    Function.Injective <| baseChange (φ := φ) := fun _ _ h => by
+  rcases mk.inj h with ⟨h, _, _, _⟩
+  replace h := (Units.mk.inj h).left
+  ext <;> apply_fun _ using hφ <;> assumption
 
 end VariableChange
 
 lemma baseChange_variableChange (C : VariableChange R) :
-    (W.baseChange A).variableChange (C.baseChange A) = (W.variableChange C).baseChange A := by
+    (W.baseChange φ).variableChange (C.baseChange φ) = (W.variableChange C).baseChange φ := by
   simp only [baseChange, variableChange, VariableChange.baseChange]
   ext <;> map_simp <;> simp only [Units.coe_map, Units.coe_map_inv, MonoidHom.coe_coe]
 
@@ -560,7 +554,7 @@ accurate for certain rings whose Picard group has trivial 12-torsion, such as a 
 @[ext]
 structure EllipticCurve (R : Type u) [CommRing R] extends WeierstrassCurve R where
   Δ' : Rˣ
-  coe_Δ' : ↑Δ' = toWeierstrassCurve.Δ
+  coe_Δ' : Δ' = toWeierstrassCurve.Δ
 #align elliptic_curve EllipticCurve
 
 namespace EllipticCurve
@@ -577,7 +571,7 @@ variable {R : Type u} [CommRing R] (E : EllipticCurve R)
 /-- The j-invariant `j` of an elliptic curve, which is invariant under isomorphisms over `R`. -/
 @[pp_dot]
 def j : R :=
-  ↑E.Δ'⁻¹ * E.c₄ ^ 3
+  E.Δ'⁻¹ * E.c₄ ^ 3
 #align elliptic_curve.j EllipticCurve.j
 
 lemma twoTorsionPolynomial_disc_ne_zero [Nontrivial R] [Invertible (2 : R)] :
@@ -616,21 +610,20 @@ instance instMulActionVariableChange :
   one_smul := variableChange_id
   mul_smul := variableChange_comp
 
-lemma coe_variableChange_Δ' : (↑(E.variableChange C).Δ' : R) = (↑C.u⁻¹ : R) ^ 12 * E.Δ' := by
-  rw [variableChange_Δ', Units.val_mul, Units.val_pow_eq_pow_val]
+lemma coe_variableChange_Δ' : (E.variableChange C).Δ' = C.u⁻¹ ^ 12 * E.Δ' :=
+  rfl
 #align elliptic_curve.coe_variable_change_Δ' EllipticCurve.coe_variableChange_Δ'
 
-lemma coe_inv_variableChange_Δ' :
-    (↑(E.variableChange C).Δ'⁻¹ : R) = (C.u : R) ^ 12 * ↑E.Δ'⁻¹ := by
-  rw [variableChange_Δ', mul_inv, inv_pow, inv_inv, Units.val_mul, Units.val_pow_eq_pow_val]
+lemma coe_inv_variableChange_Δ' : (E.variableChange C).Δ'⁻¹ = C.u ^ 12 * E.Δ'⁻¹ := by
+  rw [variableChange_Δ', mul_inv, inv_pow, inv_inv]
 #align elliptic_curve.coe_inv_variable_change_Δ' EllipticCurve.coe_inv_variableChange_Δ'
 
 @[simp]
 lemma variableChange_j : (E.variableChange C).j = E.j := by
-  rw [j, coe_inv_variableChange_Δ']
-  have hu : (C.u * ↑C.u⁻¹ : R) ^ 12 = 1 := by rw [C.u.mul_inv, one_pow]
-  linear_combination (norm := (rw [variableChange_toWeierstrassCurve,
-    WeierstrassCurve.variableChange_c₄, j]; ring1)) E.j * hu
+  rw [j, coe_inv_variableChange_Δ', Units.val_mul, Units.val_pow_eq_pow_val,
+    variableChange_toWeierstrassCurve, WeierstrassCurve.variableChange_c₄]
+  have hu : (C.u * C.u⁻¹ : R) ^ 12 = 1 := by rw [C.u.mul_inv, one_pow]
+  linear_combination (norm := (rw [j]; ring1)) E.j * hu
 #align elliptic_curve.variable_change_j EllipticCurve.variableChange_j
 
 end VariableChange
@@ -639,37 +632,37 @@ section BaseChange
 
 /-! ### Base changes -/
 
-variable (A : Type v) [CommRing A] [Algebra R A]
+variable {A : Type v} [CommRing A] (φ : R →+* A)
 
 -- porting note: was just `@[simps]`
-/-- The elliptic curve over `R` base changed to `A`. -/
+/-- The elliptic curve base changed over a ring homomorphism `φ : R →+* A`. -/
 @[pp_dot, simps (config := { rhsMd := .default }) a₁ a₂ a₃ a₄ a₆ Δ' toWeierstrassCurve]
 def baseChange : EllipticCurve A :=
-  ⟨E.toWeierstrassCurve.baseChange A, Units.map (↑(algebraMap R A)) E.Δ',
+  ⟨E.toWeierstrassCurve.baseChange φ, Units.map φ E.Δ',
     by simp only [Units.coe_map, coe_Δ', E.baseChange_Δ]; rfl⟩
 #align elliptic_curve.base_change EllipticCurve.baseChange
 
-lemma coeBaseChange_Δ' : ↑(E.baseChange A).Δ' = algebraMap R A E.Δ' :=
+lemma coeBaseChange_Δ' : (E.baseChange φ).Δ' = φ E.Δ' :=
   rfl
 #align elliptic_curve.coe_base_change_Δ' EllipticCurve.coeBaseChange_Δ'
 
-lemma coe_inv_baseChange_Δ' : ↑(E.baseChange A).Δ'⁻¹ = algebraMap R A ↑E.Δ'⁻¹ :=
+lemma coe_inv_baseChange_Δ' : (E.baseChange φ).Δ'⁻¹ = φ ↑E.Δ'⁻¹ :=
   rfl
 #align elliptic_curve.coe_inv_base_change_Δ' EllipticCurve.coe_inv_baseChange_Δ'
 
 @[simp]
-lemma baseChange_j : (E.baseChange A).j = algebraMap R A E.j := by
+lemma baseChange_j : (E.baseChange φ).j = φ E.j := by
   simp only [j, baseChange, E.baseChange_c₄]
   map_simp
   rfl
 #align elliptic_curve.base_change_j EllipticCurve.baseChange_j
 
-lemma baseChange_injective (h : Function.Injective <| algebraMap R A) :
-    Function.Injective <| baseChange (R := R) (A := A) := fun E E' h1 => by
-  rcases mk.inj h1 with ⟨h1, h2⟩
+lemma baseChange_injective {φ : R →+* A} (hφ : Function.Injective φ) :
+    Function.Injective <| baseChange (φ := φ) := fun _ _ h => by
+  rcases mk.inj h with ⟨h1, h2⟩
   replace h2 := (Units.mk.inj h2).left
   rcases WeierstrassCurve.mk.inj h1 with ⟨_, _, _, _, _⟩
-  ext <;> apply_fun _ using h <;> assumption
+  ext <;> apply_fun _ using hφ <;> assumption
 
 end BaseChange
 


### PR DESCRIPTION
Refactor Weierstrass curves and nonsingular rational points to allow for base changes over an arbitrary ring homomorphism `φ : K →+* L`. This generalises the natural map `algebraMap K L` and removes the necessity for `Algebra K L`, but also gives an easy way to define `DistribMulAction` for the action of `L ≃ₐ[K] L` on the nonsingular rational points over `L`, since `L ≃ₐ[K] L` restricts to `L →ₐ[K] L` that restricts to `L →+* L`. The old notation `W⟮L⟯` is preserved for base change over `algebraMap K L`.

Also remove some unnecessary coercions in the Weierstrass file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
