### PR TITLE
ci: enable mergify

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - staging
+      - mergify/merge_queue/*
 
 name: continuous integration (staging)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ on:
       - 'nolints'
       # ignore staging branch used by bors, this is handled by bors.yml
       - 'staging'
+      # ignore mergify branches
+      - 'mergify/merge_queue/*'
   merge_group:
 
 name: continuous integration

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -9,6 +9,8 @@
 on:
   push:
     branches-ignore:
+      # ignore mergify branches
+      - 'mergify/merge_queue/*'
       # ignore tmp branches used by bors
       - 'staging.tmp*'
       - 'trying.tmp*'

--- a/.github/workflows/mk_build_yml.sh
+++ b/.github/workflows/mk_build_yml.sh
@@ -28,6 +28,8 @@ on:
       - 'nolints'
       # ignore staging branch used by bors, this is handled by bors.yml
       - 'staging'
+      # ignore mergify branches
+      - 'mergify/merge_queue/*'
   merge_group:
 
 name: continuous integration
@@ -44,6 +46,7 @@ on:
   push:
     branches:
       - staging
+      - mergify/merge_queue/*
 
 name: continuous integration (staging)
 EOF
@@ -58,6 +61,8 @@ build_fork_yml() {
 on:
   push:
     branches-ignore:
+      # ignore mergify branches
+      - 'mergify/merge_queue/*'
       # ignore tmp branches used by bors
       - 'staging.tmp*'
       - 'trying.tmp*'

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,60 @@
+shared:
+    # These can possibly be replaced with a regex match (=~)
+    mathlib_ci: &mathlib_ci
+        - check-success=Build
+        - check-success=Lint style
+        - check-success=Check all files imported
+    bad_labels: &no_bad_labels
+        - label!=not-ready-to-merge
+        - label!=WIP
+        - label!=blocked-by-other-PR
+        - label!=merge-conflict
+        - label!=awaiting-CI
+
+
+# Note that this is not the only way to add a PR to the queue; for when maintainers need to put one in urgently, they can use `@Mergifyio queue`.
+# If the `urgent` tag is on the PR, it will interrupt anything currently on the queue and run on its own (no batching).
+
+# Nicety: this will _not_ put something in the queue until CI has passed. Therefore, you can (equivalent of) `bors r+` before CI has run and said stuff is ok.
+pull_request_rules:
+  - name: add to queue on CI success + approval
+    conditions:
+        - and: *mathlib_ci # CI passes
+        - and: *no_bad_labels # we have none of the bad labels"
+        - base=master # Base branch is `master`
+        - approved-reviews-by=@leanprover-community/mathlib-maintainers # Approval from maintainers
+        - label=ready-to-merge # `ready-to-merge` label has been put on
+        # - "#changes-requested-reviews-by=0" - this was in the original file - I don't think this is relevant.
+        # it means that no reviews have requested changes, which in theory should rarely happen but it may still do, and I'm not sure if it should always block.
+
+        # I saw these three on a Mozilla configuration - do we want this? This basically says that all CI checks are passed, and are not pending etc.
+        # I have seen this be ignored before, though.
+        # - "#check-pending=0"
+        # - "#check-stale=0"
+        # - "#check-failure=0"
+    actions:
+        queue: # Add to the appropriate pull-request queue.
+            allow_merging_configuration_change: true # This doesn't need to be on on anything except `urgent`, imo, but I don't think this can be done in the `merge_rules` and I don't want to duplicate.
+
+queue_rules:
+    # Any PR with the `urgent` label will take priority over all others, even interrupting CI. This queue does not use batching.
+    - name: urgent
+      queue_conditions:
+        - label = urgent
+      merge_conditions:
+        - and: *mathlib_ci
+      merge_method: squash
+      allow_inplace_checks: false # We want the checks to be run on `mergify/*` branches.
+      commit_message_template: |-
+        {{ title }} (#{{ number }})
+        {{ body.split('---')[0] }}
+    - name: default
+      batch_size: 20
+      batch_max_wait_time: 5 min # Wait 5 minutes before starting the batch - if there's rapid fire approvals it's more efficient, although I'm not sure if necessary.
+      merge_conditions:
+        - and: *mathlib_ci
+      merge_method: squash
+      allow_inplace_checks: false
+      commit_message_template: |-
+        {{ title }} (#{{ number }})
+        {{ body.split('---')[0] }}


### PR DESCRIPTION
This enables [Mergify](mergify.io) on mathlib4. This should hopefully be our main way of merging pull requests from the future on.

For now, this is a minimalist change, and we explicitly do _not_ remove bors, but we do encourage that all merges are done this way; we will remove bors later if needed.

A PR will be put on the merge queue to attempt to merge if:
* CI passes
* A maintainer has Github-approved the PR 
* The `ready-to-merge` label is on.

One nice bonus about this method: there is now no need to `bors d+` as opposed to `r+` to make sure CI passes; if CI fails, mergify will not put it on the queue.

Replacements for current commands:
* `bors r+`: approve + add `ready-to-merge` label.
* `bors d+`: approve. `ready-to-merge` label can be added by contributor later.
* High priority: add the `urgent` label (which I just took the liberty to create). This will _remove everything else from CI_, so take care.

There is many more nice-to-haves that can be added later, but for now this should get us started.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
