### PR TITLE
[Merged by Bors] - chore(Algebra/AddTorsor): names with lower indices

### DIFF
--- a/Mathlib/Algebra/AddTorsor.lean
+++ b/Mathlib/Algebra/AddTorsor.lean
@@ -51,7 +51,7 @@ class AddTorsor (G : outParam (Type*)) (P : Type*) [outParam <| AddGroup G] exte
   VSub G P where
   [nonempty : Nonempty P]
   /-- Torsor subtraction and addition with the same element cancels out. -/
-  vsub_vadd' : ∀ p1 p2 : P, (p1 -ᵥ p2 : G) +ᵥ p2 = p1
+  vsub_vadd' : ∀ p₁ p₂ : P, (p₁ -ᵥ p₂ : G) +ᵥ p₂ = p₁
   /-- Torsor addition and subtraction with the same element cancels out. -/
   vadd_vsub' : ∀ (g : G) (p : P), g +ᵥ p -ᵥ p = g
 #align add_torsor AddTorsor
@@ -73,7 +73,7 @@ instance addGroupIsAddTorsor (G : Type*) [AddGroup G] : AddTorsor G G
 /-- Simplify subtraction for a torsor for an `AddGroup G` over
 itself. -/
 @[simp]
-theorem vsub_eq_sub {G : Type*} [AddGroup G] (g1 g2 : G) : g1 -ᵥ g2 = g1 - g2 :=
+theorem vsub_eq_sub {G : Type*} [AddGroup G] (g₁ g₂ : G) : g₁ -ᵥ g₂ = g₁ - g₂ :=
   rfl
 #align vsub_eq_sub vsub_eq_sub
 
@@ -84,8 +84,8 @@ variable {G : Type*} {P : Type*} [AddGroup G] [T : AddTorsor G P]
 /-- Adding the result of subtracting from another point produces that
 point. -/
 @[simp]
-theorem vsub_vadd (p1 p2 : P) : p1 -ᵥ p2 +ᵥ p2 = p1 :=
-  AddTorsor.vsub_vadd' p1 p2
+theorem vsub_vadd (p₁ p₂ : P) : p₁ -ᵥ p₂ +ᵥ p₂ = p₁ :=
+  AddTorsor.vsub_vadd' p₁ p₂
 #align vsub_vadd vsub_vadd
 
 /-- Adding a group element then subtracting the original point
@@ -97,13 +97,13 @@ theorem vadd_vsub (g : G) (p : P) : g +ᵥ p -ᵥ p = g :=
 
 /-- If the same point added to two group elements produces equal
 results, those group elements are equal. -/
-theorem vadd_right_cancel {g1 g2 : G} (p : P) (h : g1 +ᵥ p = g2 +ᵥ p) : g1 = g2 := by
+theorem vadd_right_cancel {g₁ g₂ : G} (p : P) (h : g₁ +ᵥ p = g₂ +ᵥ p) : g₁ = g₂ := by
 -- Porting note: vadd_vsub g₁ → vadd_vsub g₁ p
-  rw [← vadd_vsub g1 p, h, vadd_vsub]
+  rw [← vadd_vsub g₁ p, h, vadd_vsub]
 #align vadd_right_cancel vadd_right_cancel
 
 @[simp]
-theorem vadd_right_cancel_iff {g1 g2 : G} (p : P) : g1 +ᵥ p = g2 +ᵥ p ↔ g1 = g2 :=
+theorem vadd_right_cancel_iff {g₁ g₂ : G} (p : P) : g₁ +ᵥ p = g₂ +ᵥ p ↔ g₁ = g₂ :=
   ⟨vadd_right_cancel p, fun h => h ▸ rfl⟩
 #align vadd_right_cancel_iff vadd_right_cancel_iff
 
@@ -116,8 +116,8 @@ theorem vadd_right_injective (p : P) : Function.Injective ((· +ᵥ p) : G → P
 /-- Adding a group element to a point, then subtracting another point,
 produces the same result as subtracting the points then adding the
 group element. -/
-theorem vadd_vsub_assoc (g : G) (p1 p2 : P) : g +ᵥ p1 -ᵥ p2 = g + (p1 -ᵥ p2) := by
-  apply vadd_right_cancel p2
+theorem vadd_vsub_assoc (g : G) (p₁ p₂ : P) : g +ᵥ p₁ -ᵥ p₂ = g + (p₁ -ᵥ p₂) := by
+  apply vadd_right_cancel p₂
   rw [vsub_vadd, add_vadd, vsub_vadd]
 #align vadd_vsub_assoc vadd_vsub_assoc
 
@@ -128,14 +128,14 @@ theorem vsub_self (p : P) : p -ᵥ p = (0 : G) := by
 #align vsub_self vsub_self
 
 /-- If subtracting two points produces 0, they are equal. -/
-theorem eq_of_vsub_eq_zero {p1 p2 : P} (h : p1 -ᵥ p2 = (0 : G)) : p1 = p2 := by
-  rw [← vsub_vadd p1 p2, h, zero_vadd]
+theorem eq_of_vsub_eq_zero {p₁ p₂ : P} (h : p₁ -ᵥ p₂ = (0 : G)) : p₁ = p₂ := by
+  rw [← vsub_vadd p₁ p₂, h, zero_vadd]
 #align eq_of_vsub_eq_zero eq_of_vsub_eq_zero
 
 /-- Subtracting two points produces 0 if and only if they are
 equal. -/
 @[simp]
-theorem vsub_eq_zero_iff_eq {p1 p2 : P} : p1 -ᵥ p2 = (0 : G) ↔ p1 = p2 :=
+theorem vsub_eq_zero_iff_eq {p₁ p₂ : P} : p₁ -ᵥ p₂ = (0 : G) ↔ p₁ = p₂ :=
   Iff.intro eq_of_vsub_eq_zero fun h => h ▸ vsub_self _
 #align vsub_eq_zero_iff_eq vsub_eq_zero_iff_eq
 
@@ -145,16 +145,16 @@ theorem vsub_ne_zero {p q : P} : p -ᵥ q ≠ (0 : G) ↔ p ≠ q :=
 
 /-- Cancellation adding the results of two subtractions. -/
 @[simp]
-theorem vsub_add_vsub_cancel (p1 p2 p3 : P) : p1 -ᵥ p2 + (p2 -ᵥ p3) = p1 -ᵥ p3 := by
-  apply vadd_right_cancel p3
+theorem vsub_add_vsub_cancel (p₁ p₂ p₃ : P) : p₁ -ᵥ p₂ + (p₂ -ᵥ p₃) = p₁ -ᵥ p₃ := by
+  apply vadd_right_cancel p₃
   rw [add_vadd, vsub_vadd, vsub_vadd, vsub_vadd]
 #align vsub_add_vsub_cancel vsub_add_vsub_cancel
 
 /-- Subtracting two points in the reverse order produces the negation
 of subtracting them. -/
 @[simp]
-theorem neg_vsub_eq_vsub_rev (p1 p2 : P) : -(p1 -ᵥ p2) = p2 -ᵥ p1 := by
-  refine' neg_eq_of_add_eq_zero_right (vadd_right_cancel p1 _)
+theorem neg_vsub_eq_vsub_rev (p₁ p₂ : P) : -(p₁ -ᵥ p₂) = p₂ -ᵥ p₁ := by
+  refine' neg_eq_of_add_eq_zero_right (vadd_right_cancel p₁ _)
   rw [vsub_add_vsub_cancel, vsub_self]
 #align neg_vsub_eq_vsub_rev neg_vsub_eq_vsub_rev
 
@@ -164,21 +164,21 @@ theorem vadd_vsub_eq_sub_vsub (g : G) (p q : P) : g +ᵥ p -ᵥ q = g - (q -ᵥ 
 
 /-- Subtracting the result of adding a group element produces the same result
 as subtracting the points and subtracting that group element. -/
-theorem vsub_vadd_eq_vsub_sub (p1 p2 : P) (g : G) : p1 -ᵥ (g +ᵥ p2) = p1 -ᵥ p2 - g := by
-  rw [← add_right_inj (p2 -ᵥ p1 : G), vsub_add_vsub_cancel, ← neg_vsub_eq_vsub_rev, vadd_vsub, ←
+theorem vsub_vadd_eq_vsub_sub (p₁ p₂ : P) (g : G) : p₁ -ᵥ (g +ᵥ p₂) = p₁ -ᵥ p₂ - g := by
+  rw [← add_right_inj (p₂ -ᵥ p₁ : G), vsub_add_vsub_cancel, ← neg_vsub_eq_vsub_rev, vadd_vsub, ←
     add_sub_assoc, ← neg_vsub_eq_vsub_rev, neg_add_self, zero_sub]
 #align vsub_vadd_eq_vsub_sub vsub_vadd_eq_vsub_sub
 
 /-- Cancellation subtracting the results of two subtractions. -/
 @[simp]
-theorem vsub_sub_vsub_cancel_right (p1 p2 p3 : P) : p1 -ᵥ p3 - (p2 -ᵥ p3) = p1 -ᵥ p2 := by
+theorem vsub_sub_vsub_cancel_right (p₁ p₂ p₃ : P) : p₁ -ᵥ p₃ - (p₂ -ᵥ p₃) = p₁ -ᵥ p₂ := by
   rw [← vsub_vadd_eq_vsub_sub, vsub_vadd]
 #align vsub_sub_vsub_cancel_right vsub_sub_vsub_cancel_right
 
 /-- Convert between an equality with adding a group element to a point
 and an equality of a subtraction of two points with a group
 element. -/
-theorem eq_vadd_iff_vsub_eq (p1 : P) (g : G) (p2 : P) : p1 = g +ᵥ p2 ↔ p1 -ᵥ p2 = g :=
+theorem eq_vadd_iff_vsub_eq (p₁ : P) (g : G) (p₂ : P) : p₁ = g +ᵥ p₂ ↔ p₁ -ᵥ p₂ = g :=
   ⟨fun h => h.symm ▸ vadd_vsub _ _, fun h => h ▸ (vsub_vadd _ _).symm⟩
 #align eq_vadd_iff_vsub_eq eq_vadd_iff_vsub_eq
 
@@ -206,14 +206,14 @@ theorem vadd_vsub_vadd_cancel_right (v₁ v₂ : G) (p : P) : v₁ +ᵥ p -ᵥ (
 
 /-- If the same point subtracted from two points produces equal
 results, those points are equal. -/
-theorem vsub_left_cancel {p1 p2 p : P} (h : p1 -ᵥ p = p2 -ᵥ p) : p1 = p2 := by
+theorem vsub_left_cancel {p₁ p₂ p : P} (h : p₁ -ᵥ p = p₂ -ᵥ p) : p₁ = p₂ := by
   rwa [← sub_eq_zero, vsub_sub_vsub_cancel_right, vsub_eq_zero_iff_eq] at h
 #align vsub_left_cancel vsub_left_cancel
 
 /-- The same point subtracted from two points produces equal results
 if and only if those points are equal. -/
 @[simp]
-theorem vsub_left_cancel_iff {p1 p2 p : P} : p1 -ᵥ p = p2 -ᵥ p ↔ p1 = p2 :=
+theorem vsub_left_cancel_iff {p₁ p₂ p : P} : p₁ -ᵥ p = p₂ -ᵥ p ↔ p₁ = p₂ :=
   ⟨vsub_left_cancel, fun h => h ▸ rfl⟩
 #align vsub_left_cancel_iff vsub_left_cancel_iff
 
@@ -224,15 +224,15 @@ theorem vsub_left_injective (p : P) : Function.Injective ((· -ᵥ p) : P → G)
 
 /-- If subtracting two points from the same point produces equal
 results, those points are equal. -/
-theorem vsub_right_cancel {p1 p2 p : P} (h : p -ᵥ p1 = p -ᵥ p2) : p1 = p2 := by
-  refine' vadd_left_cancel (p -ᵥ p2) _
+theorem vsub_right_cancel {p₁ p₂ p : P} (h : p -ᵥ p₁ = p -ᵥ p₂) : p₁ = p₂ := by
+  refine' vadd_left_cancel (p -ᵥ p₂) _
   rw [vsub_vadd, ← h, vsub_vadd]
 #align vsub_right_cancel vsub_right_cancel
 
 /-- Subtracting two points from the same point produces equal results
 if and only if those points are equal. -/
 @[simp]
-theorem vsub_right_cancel_iff {p1 p2 p : P} : p -ᵥ p1 = p -ᵥ p2 ↔ p1 = p2 :=
+theorem vsub_right_cancel_iff {p₁ p₂ p : P} : p -ᵥ p₁ = p -ᵥ p₂ ↔ p₁ = p₂ :=
   ⟨vsub_right_cancel, fun h => h ▸ rfl⟩
 #align vsub_right_cancel_iff vsub_right_cancel_iff
 
@@ -253,16 +253,16 @@ variable {G : Type*} {P : Type*} [AddCommGroup G] [AddTorsor G P]
 
 /-- Cancellation subtracting the results of two subtractions. -/
 @[simp]
-theorem vsub_sub_vsub_cancel_left (p1 p2 p3 : P) : p3 -ᵥ p2 - (p3 -ᵥ p1) = p1 -ᵥ p2 := by
+theorem vsub_sub_vsub_cancel_left (p₁ p₂ p₃ : P) : p₃ -ᵥ p₂ - (p₃ -ᵥ p₁) = p₁ -ᵥ p₂ := by
   rw [sub_eq_add_neg, neg_vsub_eq_vsub_rev, add_comm, vsub_add_vsub_cancel]
 #align vsub_sub_vsub_cancel_left vsub_sub_vsub_cancel_left
 
 @[simp]
-theorem vadd_vsub_vadd_cancel_left (v : G) (p1 p2 : P) : v +ᵥ p1 -ᵥ (v +ᵥ p2) = p1 -ᵥ p2 := by
+theorem vadd_vsub_vadd_cancel_left (v : G) (p₁ p₂ : P) : v +ᵥ p₁ -ᵥ (v +ᵥ p₂) = p₁ -ᵥ p₂ := by
   rw [vsub_vadd_eq_vsub_sub, vadd_vsub_assoc, add_sub_cancel']
 #align vadd_vsub_vadd_cancel_left vadd_vsub_vadd_cancel_left
 
-theorem vsub_vadd_comm (p1 p2 p3 : P) : (p1 -ᵥ p2 : G) +ᵥ p3 = p3 -ᵥ p2 +ᵥ p1 := by
+theorem vsub_vadd_comm (p₁ p₂ p₃ : P) : (p₁ -ᵥ p₂ : G) +ᵥ p₃ = p₃ -ᵥ p₂ +ᵥ p₁ := by
   rw [← @vsub_eq_zero_iff_eq G, vadd_vsub_assoc, vsub_vadd_eq_vsub_sub]
   simp
 #align vsub_vadd_comm vsub_vadd_comm


### PR DESCRIPTION
Use variable names `p₁`, `p₂` etc instead of `p1`, `p2` etc.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
