### PR TITLE
[Merged by Bors] - chore(TFAE): migrate to `getLastD`, reduce imports

### DIFF
--- a/Mathlib/Data/List/TFAE.lean
+++ b/Mathlib/Data/List/TFAE.lean
@@ -3,8 +3,10 @@ Copyright (c) 2018 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Simon Hudon
 -/
-import Mathlib.Data.List.Basic
-import Mathlib.Init.Data.List.Basic
+import Std.Data.List.Lemmas
+import Std.Tactic.RCases
+import Mathlib.Tactic.Basic
+import Mathlib.Mathport.Rename
 
 #align_import data.list.tfae from "leanprover-community/mathlib"@"5a3e819569b0f12cbec59d740a2613018e7b8eec"
 
@@ -58,16 +60,15 @@ theorem tfae_of_forall (b : Prop) (l : List Prop) (h : ∀ a ∈ l, a ↔ b) : T
   fun _a₁ h₁ _a₂ h₂ => (h _ h₁).trans (h _ h₂).symm
 #align list.tfae_of_forall List.tfae_of_forall
 
-set_option linter.deprecated false in
-theorem tfae_of_cycle {a b} {l : List Prop} :
-    List.Chain (· → ·) a (b :: l) → (ilast' b l → a) → TFAE (a :: b :: l) := by
-  induction' l with c l IH generalizing a b <;>
-    simp only [tfae_cons_cons, tfae_singleton, and_true_iff, chain_cons, Chain.nil] at *
-  · intro a b
-    exact Iff.intro a b
-  rintro ⟨ab, ⟨bc, ch⟩⟩ la
-  have := IH ⟨bc, ch⟩ (ab ∘ la)
-  exact ⟨⟨ab, la ∘ (this.2 c (Mem.head _) _ (ilast'_mem _ _)).1 ∘ bc⟩, this⟩
+theorem tfae_of_cycle {a b} {l : List Prop} (h_chain : List.Chain (· → ·) a (b :: l))
+    (h_last : getLastD l b → a) : TFAE (a :: b :: l) := by
+  induction l generalizing a b with
+  | nil => simp_all [tfae_cons_cons, iff_def]
+  | cons c l IH =>
+    simp only [tfae_cons_cons, getLastD_cons, tfae_singleton, and_true, chain_cons, Chain.nil] at *
+    rcases h_chain with ⟨ab, ⟨bc, ch⟩⟩
+    have := IH ⟨bc, ch⟩ (ab ∘ h_last)
+    exact ⟨⟨ab, h_last ∘ (this.2 c (.head _) _ (getLastD_mem_cons _ _)).1 ∘ bc⟩, this⟩
 #align list.tfae_of_cycle List.tfae_of_cycle
 
 theorem TFAE.out {l} (h : TFAE l) (n₁ n₂) {a b} (h₁ : List.get? l n₁ = some a := by rfl)
@@ -89,7 +90,7 @@ example (P₁ P₂ P₃ : ℕ → Prop) (H : ∀ n, [P₁ n, P₂ n, P₃ n].TFA
 -/
 theorem forall_tfae {α : Type*} (l : List (α → Prop)) (H : ∀ a : α, (l.map (fun p ↦ p a)).TFAE) :
     (l.map (fun p ↦ ∀ a, p a)).TFAE := by
-  simp_rw [TFAE, List.forall_mem_map_iff]
+  simp only [TFAE, List.forall_mem_map_iff]
   intros p₁ hp₁ p₂ hp₂
   exact forall_congr' fun a ↦ H a (p₁ a) (mem_map_of_mem (fun p ↦ p a) hp₁)
     (p₂ a) (mem_map_of_mem (fun p ↦ p a) hp₂)
@@ -108,7 +109,7 @@ example (P₁ P₂ P₃ : ℕ → Prop) (H : ∀ n, [P₁ n, P₂ n, P₃ n].TFA
 -/
 theorem exists_tfae {α : Type*} (l : List (α → Prop)) (H : ∀ a : α, (l.map (fun p ↦ p a)).TFAE) :
     (l.map (fun p ↦ ∃ a, p a)).TFAE := by
-  simp_rw [TFAE, List.forall_mem_map_iff]
+  simp only [TFAE, List.forall_mem_map_iff]
   intros p₁ hp₁ p₂ hp₂
   exact exists_congr fun a ↦ H a (p₁ a) (mem_map_of_mem (fun p ↦ p a) hp₁)
     (p₂ a) (mem_map_of_mem (fun p ↦ p a) hp₂)

--- a/Mathlib/Tactic/TFAE.lean
+++ b/Mathlib/Tactic/TFAE.lean
@@ -3,6 +3,8 @@ Copyright (c) 2018 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Reid Barton, Simon Hudon, Thomas Murrills, Mario Carneiro
 -/
+import Qq
+import Mathlib.Init.Data.Nat.Notation
 import Mathlib.Util.AtomM
 import Mathlib.Data.List.TFAE
 
@@ -131,15 +133,14 @@ partial def proveChain (i : ℕ) (is : List ℕ) (P : Q(Prop)) (l : Q(List Prop)
     let p ← proveImpl hyps atoms i i' P P'
     return q(Chain.cons $p $cl')
 
-set_option linter.deprecated false in
-/-- Attempt to prove `ilast' P' l → P` given an explicit list `l`. -/
-partial def proveILast'Impl (i i' : ℕ) (is : List ℕ) (P P' : Q(Prop)) (l : Q(List Prop)) :
-    MetaM Q(ilast' $P' $l → $P) := do
+/-- Attempt to prove `getLastD l P' → P` given an explicit list `l`. -/
+partial def proveGetLastDImpl (i i' : ℕ) (is : List ℕ) (P P' : Q(Prop)) (l : Q(List Prop)) :
+    MetaM Q(getLastD $l $P' → $P) := do
   match l with
   | ~q([]) => proveImpl hyps atoms i' i P' P
   | ~q($P'' :: $l') =>
     let i'' :: is' := is | unreachable!
-    proveILast'Impl i i'' is' P P'' l'
+    proveGetLastDImpl i i'' is' P P'' l'
 
 /-- Attempt to prove a statement of the form `TFAE [P₁, P₂, ...]`. -/
 def proveTFAE (is : List ℕ) (l : Q(List Prop)) : MetaM Q(TFAE $l) := do
@@ -149,7 +150,7 @@ def proveTFAE (is : List ℕ) (l : Q(List Prop)) : MetaM Q(TFAE $l) := do
   | ~q($P :: $P' :: $l') =>
     let i :: i' :: is' := is | unreachable!
     let c ← proveChain hyps atoms i (i'::is') P q($P' :: $l')
-    let il ← proveILast'Impl hyps atoms i i' is' P P' l'
+    let il ← proveGetLastDImpl hyps atoms i i' is' P P' l'
     return q(tfae_of_cycle $c $il)
 
 /-! # `tfae_have` components -/


### PR DESCRIPTION
Since `getLastD_mem_cons` is in `Std`, we no longer have to import `Data.List.Basic`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
