### PR TITLE
[Merged by Bors] - feat: lemmas about partitions of unity

### DIFF
--- a/Mathlib/Topology/PartitionOfUnity.lean
+++ b/Mathlib/Topology/PartitionOfUnity.lean
@@ -174,6 +174,52 @@ theorem le_one (i : ι) (x : X) : f i x ≤ 1 :=
   (single_le_finsum i (f.locallyFinite.point_finite x) fun j => f.nonneg j x).trans (f.sum_le_one x)
 #align partition_of_unity.le_one PartitionOfUnity.le_one
 
+section finsupport
+/-- The support of a partition of unity at a point `x₀`
+  (i.e., the set of `i` such that `f i` doesn't vanish at `x₀`), as a `Finset`. -/
+def finsupport {s : Set X} (ρ : PartitionOfUnity ι X s) (x₀ : X) : Finset ι :=
+  (ρ.locallyFinite.point_finite x₀).toFinset
+
+@[simp]
+theorem coe_finsupport {s : Set X} (ρ : PartitionOfUnity ι X s) (x₀ : X) :
+    (ρ.finsupport x₀ : Set ι) = support fun i => ρ i x₀ := by
+  dsimp only [finsupport]
+  rw [Finite.coe_toFinset]
+  rfl
+
+@[simp]
+theorem mem_finsupport {s : Set X} (ρ : PartitionOfUnity ι X s) (x₀ : X) {i} :
+    i ∈ ρ.finsupport x₀ ↔ i ∈ support fun i => ρ i x₀ := by
+  simp only [finsupport, mem_support, Finite.mem_toFinset, mem_setOf_eq]
+
+theorem sum_finsupport {s : Set X} (ρ : PartitionOfUnity ι X s) {x₀ : X}
+    (hx₀ : x₀ ∈ s := by trivial) :
+    ∑ i in ρ.finsupport x₀, ρ i x₀ = 1 := by
+  have := ρ.sum_eq_one hx₀
+  rwa [finsum_eq_sum_of_support_subset] at this
+  rw [ρ.coe_finsupport]
+
+theorem sum_finsupport' {s : Set X} (ρ : PartitionOfUnity ι X s) {x₀ : X}
+    (hx₀ : x₀ ∈ s := by trivial) {I : Finset ι} (hI : ρ.finsupport x₀ ⊆ I) :
+    ∑ i in I, ρ i x₀ = 1 := by
+  classical
+  rw [← Finset.sum_sdiff hI, ρ.sum_finsupport hx₀]
+  suffices ∑ i in I \ ρ.finsupport x₀, ρ i x₀ = 0 by rw [this, zero_add]
+  suffices : ∑ i in I \ ρ.finsupport x₀, (ρ i) x₀ = ∑ i in I \ ρ.finsupport x₀, 0
+  rw [this, Finset.sum_const_zero]
+  apply Finset.sum_congr rfl
+  rintro x hx
+  simp only [Finset.mem_sdiff, ρ.mem_finsupport, mem_support, Classical.not_not] at hx
+  exact hx.2
+
+theorem sum_finsupport_smul {s : Set X} (ρ : PartitionOfUnity ι X s) {x₀ : X}
+    {M : Type _} [AddCommGroup M] [Module ℝ M] (φ : ι → X → M) :
+    ∑ i in ρ.finsupport x₀, ρ i x₀ • φ i x₀ = ∑ᶠ i, ρ i x₀ • φ i x₀ := by
+  apply (finsum_eq_sum_of_support_subset _ _).symm
+  erw [ρ.coe_finsupport x₀, support_smul]
+  exact inter_subset_left _ _
+end finsupport
+
 /-- If `f` is a partition of unity on `s : Set X` and `g : X → E` is continuous at every point of
 the topological support of some `f i`, then `fun x ↦ f i x • g x` is continuous on the whole space.
 -/
@@ -200,6 +246,21 @@ def IsSubordinate (U : ι → Set X) : Prop :=
 #align partition_of_unity.is_subordinate PartitionOfUnity.IsSubordinate
 
 variable {f}
+
+theorem exists_finset_nhd' {s : Set X} (ρ : PartitionOfUnity ι X s) (x₀ : X) :
+    ∃ I : Finset ι, (∀ᶠ x in 𝓝[s] x₀, ∑ i in I, ρ i x = 1) ∧
+      ∀ᶠ x in 𝓝 x₀, support (ρ · x) ⊆ I := by
+  rcases ρ.locallyFinite.exists_finset_support x₀ with ⟨I, hI⟩
+  refine' ⟨I, _, hI⟩
+  refine' eventually_nhdsWithin_iff.mpr (hI.mono fun x hx x_in => _)
+  have : ∑ᶠ i : ι, ρ i x = ∑ i : ι in I, ρ i x := finsum_eq_sum_of_support_subset _ hx
+  rwa [eq_comm, ρ.sum_eq_one x_in] at this
+
+theorem exists_finset_nhd (ρ : PartitionOfUnity ι X univ) (x₀ : X) :
+    ∃ I : Finset ι, ∀ᶠ x in 𝓝 x₀, ∑ i in I, ρ i x = 1 ∧ support (ρ · x) ⊆ I := by
+  rcases ρ.exists_finset_nhd' x₀ with ⟨I, H⟩
+  use I
+  rwa [nhdsWithin_univ, ← eventually_and] at H
 
 theorem exists_finset_nhd_support_subset {U : ι → Set X} (hso : f.IsSubordinate U)
     (ho : ∀ i, IsOpen (U i)) (x : X) :

--- a/Mathlib/Topology/PartitionOfUnity.lean
+++ b/Mathlib/Topology/PartitionOfUnity.lean
@@ -182,14 +182,14 @@ def finsupport {s : Set X} (ρ : PartitionOfUnity ι X s) (x₀ : X) : Finset ι
 
 @[simp]
 theorem coe_finsupport {s : Set X} (ρ : PartitionOfUnity ι X s) (x₀ : X) :
-    (ρ.finsupport x₀ : Set ι) = support fun i => ρ i x₀ := by
+    (ρ.finsupport x₀ : Set ι) = support fun i ↦ ρ i x₀ := by
   dsimp only [finsupport]
   rw [Finite.coe_toFinset]
   rfl
 
 @[simp]
 theorem mem_finsupport {s : Set X} (ρ : PartitionOfUnity ι X s) (x₀ : X) {i} :
-    i ∈ ρ.finsupport x₀ ↔ i ∈ support fun i => ρ i x₀ := by
+    i ∈ ρ.finsupport x₀ ↔ i ∈ support fun i ↦ ρ i x₀ := by
   simp only [finsupport, mem_support, Finite.mem_toFinset, mem_setOf_eq]
 
 theorem sum_finsupport {s : Set X} (ρ : PartitionOfUnity ι X s) {x₀ : X}
@@ -251,8 +251,7 @@ theorem exists_finset_nhd' {s : Set X} (ρ : PartitionOfUnity ι X s) (x₀ : X)
     ∃ I : Finset ι, (∀ᶠ x in 𝓝[s] x₀, ∑ i in I, ρ i x = 1) ∧
       ∀ᶠ x in 𝓝 x₀, support (ρ · x) ⊆ I := by
   rcases ρ.locallyFinite.exists_finset_support x₀ with ⟨I, hI⟩
-  refine' ⟨I, _, hI⟩
-  refine' eventually_nhdsWithin_iff.mpr (hI.mono fun x hx x_in => _)
+  refine ⟨I, eventually_nhdsWithin_iff.mpr (hI.mono fun x hx x_in ↦ ?_), hI⟩
   have : ∑ᶠ i : ι, ρ i x = ∑ i : ι in I, ρ i x := finsum_eq_sum_of_support_subset _ hx
   rwa [eq_comm, ρ.sum_eq_one x_in] at this
 


### PR DESCRIPTION
- add `finsupport`: the support (the set of indices which functions are non-vanishing) at a point, as a `Finset`
- every point has a neighbourhood on which only finitely many functions are non-vanishing

From sphere-eversion; I'm just upstreaming results.
