### PR TITLE
[Merged by Bors] - perf (Preadditive.FunctorCategory): use `dsimp` before `ext`

### DIFF
--- a/Mathlib/CategoryTheory/Preadditive/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Preadditive/FunctorCategory.lean
@@ -15,8 +15,6 @@ then `C ⥤ D` is also preadditive.
 
 -/
 
-set_option profiler true
-
 open BigOperators
 
 namespace CategoryTheory

--- a/Mathlib/CategoryTheory/Preadditive/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Preadditive/FunctorCategory.lean
@@ -15,6 +15,7 @@ then `C ⥤ D` is also preadditive.
 
 -/
 
+set_option profiler true
 
 open BigOperators
 
@@ -37,30 +38,37 @@ instance functorCategoryPreadditive : Preadditive (C ⥤ D)
         apply add_assoc
       zero_add := by
         intros
+        dsimp
         ext
         apply zero_add
       add_zero := by
         intros
+        dsimp
         ext
         apply add_zero
       add_comm := by
         intros
+        dsimp
         ext
         apply add_comm
       sub_eq_add_neg := by
         intros
+        dsimp
         ext
         apply sub_eq_add_neg
       add_left_neg := by
         intros
+        dsimp
         ext
         apply add_left_neg }
   add_comp := by
     intros
+    dsimp
     ext
     apply add_comp
   comp_add := by
     intros
+    dsimp
     ext
     apply comp_add
 #align category_theory.functor_category_preadditive CategoryTheory.functorCategoryPreadditive


### PR DESCRIPTION
`dsimp` seems to significantly improve the performance of `ext` here and elsewhere.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
