### PR TITLE
feat: immersions and submersions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2160,6 +2160,7 @@ import Mathlib.Geometry.Manifold.InteriorBoundary
 import Mathlib.Geometry.Manifold.LocalDiffeomorph
 import Mathlib.Geometry.Manifold.LocalInvariantProperties
 import Mathlib.Geometry.Manifold.MFDeriv
+import Mathlib.Geometry.Manifold.Maps
 import Mathlib.Geometry.Manifold.Metrizable
 import Mathlib.Geometry.Manifold.PartitionOfUnity
 import Mathlib.Geometry.Manifold.Sheaf.Basic

--- a/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
@@ -55,7 +55,7 @@ local diffeomorphism, manifold
 
 -/
 
-open Manifold Set TopologicalSpace
+open Function Manifold Set TopologicalSpace
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
@@ -269,3 +269,70 @@ noncomputable def IslocalDiffeomorph.diffeomorph_of_bijective
       exact this ▸ (Φ x).map_source hx }
 
 end Basic
+
+/-! ## The differential of a local diffeomorphism is an isomorphism -/
+section Differential
+variable {I J n} {f : M → N} {x : M} (hn : 1 ≤ n)
+  [SmoothManifoldWithCorners I M] [SmoothManifoldWithCorners J N]
+  [hE: CompleteSpace E] [hF: CompleteSpace F]
+
+/-- A local diffeomorphism `f` at `x` has injective differential `mfderiv I J n f x`. -/
+lemma IsLocalDiffeomorphAt.mfderiv_injective (hf : IsLocalDiffeomorphAt I J n f x) (hn : 1 ≤ n) :
+    LinearMap.ker (mfderiv I J f x) = ⊥ := by
+  choose Φ hyp using hf
+  rcases hyp with ⟨hxU, heq⟩
+  let A := mfderiv I J f x
+  have hA : A = mfderiv I J Φ x := calc A
+    _ = mfderivWithin I J f Φ.source x := (mfderivWithin_of_isOpen Φ.open_source hxU).symm
+    _ = mfderivWithin I J Φ Φ.source x :=
+      mfderivWithin_congr (Φ.open_source.uniqueMDiffWithinAt hxU) heq (heq hxU)
+    _ = mfderiv I J Φ x := mfderivWithin_of_isOpen Φ.open_source hxU
+  let B := mfderiv J I Φ.invFun (Φ x)
+  have : B.comp A = ContinuousLinearMap.id 𝕜 (TangentSpace I x) := calc B.comp A
+    _ = B.comp (mfderiv I J Φ x) := by rw [hA]
+    _ = mfderiv I I (Φ.invFun ∘ Φ) x :=
+      (mfderiv_comp x (Φ.symm.mdifferentiableAt hn (Φ.map_source hxU))
+        (Φ.mdifferentiableAt hn hxU)).symm
+    _ = mfderivWithin I I (Φ.invFun ∘ Φ) Φ.source x :=
+      (mfderivWithin_of_isOpen Φ.open_source hxU).symm
+    _ = mfderivWithin I I id Φ.source x := by
+      have : EqOn (Φ.invFun ∘ Φ) id Φ.source := fun _ hx ↦ Φ.left_inv' hx
+      apply mfderivWithin_congr (Φ.open_source.uniqueMDiffWithinAt hxU) this (this hxU)
+    _ = mfderiv I I id x := mfderivWithin_of_isOpen Φ.open_source hxU
+    _ = ContinuousLinearMap.id 𝕜 (TangentSpace I x) := mfderiv_id I
+  have : LeftInverse B A := ContinuousLinearMap.congr_fun this
+  exact (LinearMapClass.ker_eq_bot _).mpr this.injective
+
+/-- A local diffeomorphism `f` at `x` has surjective differential `mfderiv I J n f x`. -/
+lemma IsLocalDiffeomorphAt.mfderiv_surjective (hf : IsLocalDiffeomorphAt I J n f x) (hn : 1 ≤ n) :
+    LinearMap.range (mfderiv I J f x) = ⊤ := by
+  choose Φ hyp using hf
+  rcases hyp with ⟨hxU, heq⟩
+  let A := mfderiv I J f x
+  have hA : A = mfderiv I J Φ x := calc A
+    _ = mfderivWithin I J f Φ.source x := (mfderivWithin_of_isOpen Φ.open_source hxU).symm
+    _ = mfderivWithin I J Φ Φ.source x :=
+      mfderivWithin_congr (Φ.open_source.uniqueMDiffWithinAt hxU) heq (heq hxU)
+    _ = mfderiv I J Φ x := mfderivWithin_of_isOpen Φ.open_source hxU
+  let B := mfderiv J I Φ.invFun (Φ x)
+  have : A.comp B = ContinuousLinearMap.id 𝕜 (TangentSpace J (Φ x)) := calc A.comp B
+    _ = (mfderiv I J Φ x).comp B := by rw [hA]
+    _ = mfderiv J J (Φ ∘ Φ.invFun) (Φ x) := by
+        -- Use the chain rule: need to rewrite both the base point Φ (Φ.invFun x)
+        -- and the map Φ.invFun ∘ Φ.
+        have hΦ : MDifferentiableAt I J Φ x := Φ.mdifferentiableAt hn hxU
+        rw [← (Φ.left_inv hxU)] at hΦ
+        let r := mfderiv_comp (Φ x) hΦ (Φ.symm.mdifferentiableAt hn (Φ.map_source hxU))
+        rw [(Φ.left_inv hxU)] at r
+        exact r.symm
+    _ = mfderivWithin J J (Φ ∘ Φ.invFun) Φ.target (Φ x) :=
+      (mfderivWithin_of_isOpen Φ.open_target (Φ.map_source hxU)).symm
+    _ = mfderivWithin J J id Φ.target (Φ x) := by
+      have : EqOn (Φ ∘ Φ.invFun) id Φ.target := fun _ hx ↦ Φ.right_inv' hx
+      apply mfderivWithin_congr ?_ this (this (Φ.map_source hxU))
+      exact (Φ.open_target.uniqueMDiffWithinAt (Φ.map_source hxU))
+    _ = mfderiv J J id (Φ x) := mfderivWithin_of_isOpen Φ.open_target (Φ.map_source hxU)
+    _ = ContinuousLinearMap.id 𝕜 (TangentSpace J (Φ x)) := mfderiv_id J
+  have : RightInverse B A := ContinuousLinearMap.congr_fun this
+  exact LinearMap.range_eq_top.mpr this.surjective
+end Differential

--- a/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
@@ -28,7 +28,7 @@ at every `x ∈ s`, and a **local diffeomorphism** iff it is a local diffeomorph
 * `IsLocalDiffeomorph.isLocalHomeomorph`: a local diffeomorphisms is a local homeomorphism,
   similarly for local diffeomorphism on `s`
 * `IsLocalDiffeomorph.isOpen_range`: the image of a local diffeomorphism is open
-* `IslocalDiffeomorph.diffeomorph_of_bijective`:
+* `IsLocalDiffeomorph.diffeomorph_of_bijective`:
   a bijective local diffeomorphism is a diffeomorphism
 
 ## TODO
@@ -240,7 +240,7 @@ lemma IsLocalDiffeomorph.image_coe (hf : IsLocalDiffeomorph I J n f) : hf.image.
 -- This argument implies a `LocalDiffeomorphOn f s` for `s` open is a `PartialDiffeomorph`
 
 /-- A bijective local diffeomorphism is a diffeomorphism. -/
-noncomputable def IslocalDiffeomorph.diffeomorph_of_bijective
+noncomputable def IsLocalDiffeomorph.diffeomorph_of_bijective
     (hf : IsLocalDiffeomorph I J n f) (hf' : Function.Bijective f) : Diffeomorph I J M N n := by
   -- Choose a right inverse `g` of `f`.
   choose g hgInverse using (Function.bijective_iff_has_inverse).mp hf'
@@ -278,7 +278,7 @@ variable {I J n} {f : M → N} {x : M} (hn : 1 ≤ n)
 
 /-- A local diffeomorphism `f` at `x` has injective differential `mfderiv I J n f x`. -/
 lemma IsLocalDiffeomorphAt.mfderiv_injective (hf : IsLocalDiffeomorphAt I J n f x) (hn : 1 ≤ n) :
-    LinearMap.ker (mfderiv I J f x) = ⊥ := by
+    Injective (mfderiv I J f x) := by
   choose Φ hyp using hf
   rcases hyp with ⟨hxU, heq⟩
   let A := mfderiv I J f x
@@ -301,11 +301,11 @@ lemma IsLocalDiffeomorphAt.mfderiv_injective (hf : IsLocalDiffeomorphAt I J n f 
     _ = mfderiv I I id x := mfderivWithin_of_isOpen Φ.open_source hxU
     _ = ContinuousLinearMap.id 𝕜 (TangentSpace I x) := mfderiv_id I
   have : LeftInverse B A := ContinuousLinearMap.congr_fun this
-  exact (LinearMapClass.ker_eq_bot _).mpr this.injective
+  exact this.injective
 
 /-- A local diffeomorphism `f` at `x` has surjective differential `mfderiv I J n f x`. -/
 lemma IsLocalDiffeomorphAt.mfderiv_surjective (hf : IsLocalDiffeomorphAt I J n f x) (hn : 1 ≤ n) :
-    LinearMap.range (mfderiv I J f x) = ⊤ := by
+    Surjective (mfderiv I J f x) := by
   choose Φ hyp using hf
   rcases hyp with ⟨hxU, heq⟩
   let A := mfderiv I J f x
@@ -334,5 +334,5 @@ lemma IsLocalDiffeomorphAt.mfderiv_surjective (hf : IsLocalDiffeomorphAt I J n f
     _ = mfderiv J J id (Φ x) := mfderivWithin_of_isOpen Φ.open_target (Φ.map_source hxU)
     _ = ContinuousLinearMap.id 𝕜 (TangentSpace J (Φ x)) := mfderiv_id J
   have : RightInverse B A := ContinuousLinearMap.congr_fun this
-  exact LinearMap.range_eq_top.mpr this.surjective
+  exact this.surjective
 end Differential

--- a/Mathlib/Geometry/Manifold/Maps.lean
+++ b/Mathlib/Geometry/Manifold/Maps.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2024 Michael Rothgang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Rothgang
+-/
+import Mathlib.Geometry.Manifold.LocalDiffeomorph
+
+/-! ## Smooth immersions, submersions and embeddings
+
+In this file, we define immersions, submersions and smooth embeddings,
+and prove their various relations and basic properties.
+
+## Main definitions (xxx flesh out)
+* `Immersion`: a differentiable immersion
+* `InjImmersion`
+* `Submersion`
+
+## Main results
+* `IsLocalDiffeomorph.toImmersion`: a `C^n` local diffeomorphism (`n≥1`) is an immersion
+* `IsLocalDiffeomorph.toSubmersion`: a `C^n` local diffeomorphism (`n≥1`) is a submersion
+* `Diffeomorph.toImmersion`: a `C^n` diffeomorphism (`n≥1`) is an immersion
+* `Diffeomorph.toSubmersion`: a `C^n` diffeomorphism (`n≥1`) is a submersion
+
+## TODO
+- If `f` is both an immersion and submersion, it is a local diffeomorphism.
+(This requires the inverse function theorem: an invertible differential at `x` implies
+ being a local diffeomorphism at `x`. This may also require working in a complete space.)
+- If `f` is bijective, an immersion and submersion, it is a diffeomorphism.
+- A submersion has open range (by the inverse function theorem).
+- `f` is a diffeomorphism iff it is an immersion, submersion and proper
+
+- Define smooth embeddings; show smooth embeddings are injective immersions,
+  surjective embeddings are diffeomorphisms (and vice versa).
+
+implementation notes: bundled
+omit differentiability for immersions, following sphere-eversion?
+
+## Tags
+manifold, immersion, submersion, smooth embedding
+
+-/
+noncomputable section
+
+open Set Function
+
+open scoped Manifold
+
+-- Let `M` be a manifold with corners over the pair `(E, H)`.
+-- Let `M'` be a manifold with corners over the pair `(E', H')`.
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] (I : ModelWithCorners 𝕜 E H)
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  [SmoothManifoldWithCorners I M]
+  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {H' : Type*} [TopologicalSpace H'] (I' : ModelWithCorners 𝕜 E' H')
+  {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
+  [SmoothManifoldWithCorners I' M']
+
+section Definitions
+
+-- for reference: design from sphere-eversion -- unbundled; omitted differentiability
+/-- A map between manifolds is an immersion if it is differentiable and its differential at
+any point is injective. Note the formalized definition doesn't require differentiability.
+If `f` is not differentiable at `m` then, by definition, `mfderiv I I' f m` is zero, which
+is not injective unless the source dimension is zero, which implies differentiability. -/
+def Immersion' (f : M → M') : Prop :=
+  ∀ p, Injective (mfderiv I I' f p)
+
+/-- A `C^n` immersion `f : M → M` is a `C^n` map whose differential is injective at any point. -/
+-- We don't require immersions to be injective: for instance, the figure eight shall be an immersed
+-- manifold, whose most natural parametrisation is non-injective.
+structure Immersion (f : M → M') (n : ℕ∞) : Prop :=
+  differentiable : ContMDiff I I' n f
+  diff_injective : ∀ p, Injective (mfderiv I I' f p)
+
+/-- An injective `C^n immersion -/
+structure InjImmersion (f : M → M') (n : ℕ∞) extends
+  Immersion I I' f n : Prop :=
+  injective : Injective f
+
+/-- A `C^n` submersion `f : M → M` is a `C^n` map whose differential is surjective at any point.
+We don't ask for a submersion to be surjective. -/
+structure Submersion (f : M → M') (n : ℕ∞) : Prop :=
+  differentiable : ContMDiff I I' n f
+  diff_surjective : ∀ p, Surjective (mfderiv I I' f p)
+
+end Definitions
+
+section LocalDiffeo
+variable {f : M → M'} {n : ℕ∞}
+variable {I I'}
+
+/-- A `C^n` local diffeomorphism (`n≥1`) is an immersion. -/
+lemma IsLocalDiffeomorph.toImmersion (hf : IsLocalDiffeomorph I I' n f) (hn : 1 ≤ n) :
+    Immersion I I' f n where
+  differentiable := hf.contMDiff
+  diff_injective x := (hf x).mfderiv_injective hn
+
+/-- A `C^n` local diffeomorphism (`n≥1`) is a submersion. -/
+lemma IsLocalDiffeomorph.toSubmersion (hf : IsLocalDiffeomorph I I' n f) (hn : 1 ≤ n) :
+    Submersion I I' f n where
+  differentiable := hf.contMDiff
+  diff_surjective x := (hf x).mfderiv_surjective hn
+
+/-- A `C^n` diffeomorphism (`n≥1`) is an immersion. -/
+lemma Diffeomorph.toImmersion (h : Diffeomorph I I' M M' n) (hn : 1 ≤ n) : Immersion I I' h n where
+  differentiable := h.contMDiff_toFun
+  diff_injective x := (h.isLocalDiffeomorph x).mfderiv_injective hn
+
+/-- A `C^n` diffeomorphism (`n≥1`) is an injective immersion. -/
+lemma Diffeomorph.toInjImmersion (h : Diffeomorph I I' M M' n) (hn : 1 ≤ n) :
+    InjImmersion I I' h n where
+  toImmersion := h.toImmersion hn
+  injective := h.injective
+
+/-- A `C^n` diffeomorphism (`n≥1`) is a submersion. -/
+lemma Diffeomorph.toSubmersion (h : Diffeomorph I I' M M' n) (hn : 1 ≤ n) :
+    Submersion I I' h n where
+  differentiable := h.contMDiff_toFun
+  diff_surjective x := (h.isLocalDiffeomorph x).mfderiv_surjective hn
+
+end LocalDiffeo

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -464,6 +464,13 @@ theorem coeFn_injective : @Function.Injective (M₁ →SL[σ₁₂] M₂) (M₁ 
   FunLike.coe_injective
 #align continuous_linear_map.coe_fn_injective ContinuousLinearMap.coeFn_injective
 
+protected theorem congr_arg {f : M₁ →SL[σ₁₂] M₂} {x x' : M₁} : x = x' → f x = f x' :=
+  FunLike.congr_arg f
+
+/-- If two continuous linear maps are equal, they are equal at each point. -/
+protected theorem congr_fun {f g : M₁ →SL[σ₁₂] M₂} (h : f = g) (x : M₁) : f x = g x :=
+  FunLike.congr_fun h x
+
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
   because it is a composition of multiple projections. -/
 def Simps.apply (h : M₁ →SL[σ₁₂] M₂) : M₁ → M₂ :=


### PR DESCRIPTION
Update: this is only the correct definition in finite dimensions; needs generalisation to infinite-dimensional manifolds.

Using that local diffeomorphisms have bijective differential (cherry-picked from #8738).

Note that sphere-eversion used a different design for immersions (no differentiability required); I'm open to considering their design.

------------

Reviewer question: what's the best argument order for immersions and submersions: `I I' n f` or `I I' f n`

Future possibilities:
- define smooth embeddings (done locally)
- show that being both an immersion and a submersion is a local diffeomorphism: this requires the inverse function theorem
- show: a diffeomorphism is precisely a proper map which is an immersion and a submersion