### PR TITLE
[Merged by Bors] - chore: cleanup 'import Lean'

### DIFF
--- a/Mathlib/Data/Array/Defs.lean
+++ b/Mathlib/Data/Array/Defs.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino, Floris van Doorn
 -/
 
-import Lean
-
 /-!
 ## Definitions on Arrays
 

--- a/Mathlib/Lean/CoreM.lean
+++ b/Mathlib/Lean/CoreM.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Lean
 import Mathlib.Tactic.ToExpr
 
 /-!

--- a/Mathlib/Lean/EnvExtension.lean
+++ b/Mathlib/Lean/EnvExtension.lean
@@ -3,7 +3,8 @@ Copyright (c) 2023 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
-import Lean
+import Lean.ScopedEnvExtension
+
 /-!
 # Helper function for environment extensions and attributes.
 -/

--- a/Mathlib/Lean/Exception.lean
+++ b/Mathlib/Lean/Exception.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 E.W.Ayers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: E.W.Ayers
 -/
-import Lean
+import Lean.Exception
 
 set_option autoImplicit true
 

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Simon Hudon, Scott Morrison, Keeley Hoek, Robert Y. Lewis,
 Floris van Doorn, E.W.Ayers, Arthur Paulino
 -/
-import Lean
 import Std.Lean.Expr
 import Std.Data.List.Basic
 

--- a/Mathlib/Lean/Expr/ReplaceRec.lean
+++ b/Mathlib/Lean/Expr/ReplaceRec.lean
@@ -4,11 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Simon Hudon, Scott Morrison, Keeley Hoek, Robert Y. Lewis,
 Floris van Doorn, E.W.Ayers
 -/
-import Lean
 import Lean.Meta
 import Std.Util.TermUnsafe
 import Mathlib.Lean.Expr.Traverse
 import Mathlib.Util.MemoFix
+
 namespace Lean.Expr
 /-!
 # ReplaceRec

--- a/Mathlib/Lean/Expr/Traverse.lean
+++ b/Mathlib/Lean/Expr/Traverse.lean
@@ -3,8 +3,6 @@ Copyright (c) 2022 E.W.Ayers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: E.W.Ayers
 -/
-
-import Lean
 import Mathlib.Lean.Expr.Basic
 
 /-!

--- a/Mathlib/Lean/Json.lean
+++ b/Mathlib/Lean/Json.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Lean
 import Mathlib.Mathport.Rename
 
 #align_import data.json from "leanprover-community/mathlib"@"b93a64dac6f7e8f10164b867ac329dda0747e075"

--- a/Mathlib/Lean/Meta/Simp.lean
+++ b/Mathlib/Lean/Meta/Simp.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Gabriel Ebner, Floris van Doorn
 -/
-import Lean
 import Std.Tactic.OpenPrivate
 import Std.Lean.Meta.DiscrTree
 import Std.Lean.Meta.Simp

--- a/Mathlib/Mathport/Rename.lean
+++ b/Mathlib/Mathport/Rename.lean
@@ -3,7 +3,8 @@ Copyright (c) 2021 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Daniel Selsam
 -/
-import Lean
+import Lean.Elab.Command
+import Lean.Linter.Util
 
 set_option autoImplicit true
 

--- a/Mathlib/Tactic/ApplyWith.lean
+++ b/Mathlib/Tactic/ApplyWith.lean
@@ -1,4 +1,5 @@
-import Lean
+import Lean.Elab.Eval
+import Lean.Elab.Tactic.ElabTerm
 import Std.Util.TermUnsafe
 
 namespace Mathlib.Tactic

--- a/Mathlib/Tactic/ByContra.lean
+++ b/Mathlib/Tactic/ByContra.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Kevin Buzzard
 -/
-import Lean
 import Mathlib.Tactic.PushNeg
 
 open Lean Lean.Parser Parser.Tactic Elab Command Elab.Tactic Meta

--- a/Mathlib/Tactic/Cases.lean
+++ b/Mathlib/Tactic/Cases.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Lean
+import Lean.Elab.Tactic.Induction
 import Std.Tactic.OpenPrivate
 import Std.Data.List.Basic
 import Mathlib.Lean.Expr.Basic

--- a/Mathlib/Tactic/CasesM.lean
+++ b/Mathlib/Tactic/CasesM.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Lean
+import Lean.Elab.Tactic.Conv.Pattern
 
 /-!
 # `casesm`, `cases_type`, `constructorm` tactics

--- a/Mathlib/Tactic/Clean.lean
+++ b/Mathlib/Tactic/Clean.lean
@@ -3,8 +3,7 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Michail Karatarakis, Kyle Miller
 -/
-
-import Lean
+import Lean.Elab.SyntheticMVars
 
 /-!
 # `clean%` term elaborator

--- a/Mathlib/Tactic/Clear!.lean
+++ b/Mathlib/Tactic/Clear!.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Joshua Clune. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joshua Clune
 -/
-import Lean
+import Lean.Elab.Tactic.ElabTerm
 
 /-! # `clear!` tactic -/
 

--- a/Mathlib/Tactic/ClearExcept.lean
+++ b/Mathlib/Tactic/ClearExcept.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Joshua Clune. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joshua Clune
 -/
-import Lean
+import Lean.Elab.Tactic.ElabTerm
 
 open Lean.Meta
 

--- a/Mathlib/Tactic/Clear_.lean
+++ b/Mathlib/Tactic/Clear_.lean
@@ -3,7 +3,8 @@ Copyright (c) 2022 Joshua Clune. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joshua Clune
 -/
-import Lean
+import Lean.Meta.Tactic.Clear
+import Lean.Elab.Tactic.Basic
 
 /-! # `clear_` tactic -/
 

--- a/Mathlib/Tactic/Coe.lean
+++ b/Mathlib/Tactic/Coe.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner
 -/
-import Lean
+import Lean.Elab.ElabRules
 
 open Lean Elab Term Meta
 

--- a/Mathlib/Tactic/Congr!.lean
+++ b/Mathlib/Tactic/Congr!.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import Lean
 import Mathlib.Lean.Meta.CongrTheorems
 import Mathlib.Tactic.Relation.Rfl
 import Std.Logic

--- a/Mathlib/Tactic/Convert.lean
+++ b/Mathlib/Tactic/Convert.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Lean
 import Mathlib.Tactic.Congr!
 
 /-!

--- a/Mathlib/Tactic/Core.lean
+++ b/Mathlib/Tactic/Core.lean
@@ -3,6 +3,8 @@ Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino, Aurélien Saue, Mario Carneiro
 -/
+import Lean.Elab.PreDefinition.Basic
+import Lean.Util.Paths
 import Std.Tactic.Simpa
 import Mathlib.Lean.Expr
 

--- a/Mathlib/Tactic/DeriveToExpr.lean
+++ b/Mathlib/Tactic/DeriveToExpr.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import Lean
 import Mathlib.Tactic.ToLevel
 
 /-!

--- a/Mathlib/Tactic/Explode.lean
+++ b/Mathlib/Tactic/Explode.lean
@@ -3,7 +3,8 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Evgenia Karunus, Kyle Miller
 -/
-import Lean
+import Lean.Elab.Command
+import Lean.PrettyPrinter
 import Mathlib.Tactic.Explode.Datatypes
 import Mathlib.Tactic.Explode.Pretty
 

--- a/Mathlib/Tactic/Explode/Datatypes.lean
+++ b/Mathlib/Tactic/Explode/Datatypes.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Evgenia Karunus, Kyle Miller
 -/
-import Lean
+import Lean.Util.Trace
 
 /-!
 # Explode command: datatypes

--- a/Mathlib/Tactic/Explode/Pretty.lean
+++ b/Mathlib/Tactic/Explode/Pretty.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Evgenia Karunus, Kyle Miller
 -/
-import Lean
+import Lean.Meta.Basic
 import Mathlib.Tactic.Explode.Datatypes
 
 /-!

--- a/Mathlib/Tactic/FailIfNoProgress.lean
+++ b/Mathlib/Tactic/FailIfNoProgress.lean
@@ -3,7 +3,8 @@ Copyright (c) 2023 Thomas Murrills. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Murrills
 -/
-import Lean
+import Lean.Elab.Tactic.Basic
+import Lean.Meta.Tactic.Util
 
 /-!
 # Fail if no progress

--- a/Mathlib/Tactic/Find.lean
+++ b/Mathlib/Tactic/Find.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Sebastian Ullrich. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Ullrich
 -/
-import Lean
 import Std.Util.Cache
 
 /-!

--- a/Mathlib/Tactic/GeneralizeProofs.lean
+++ b/Mathlib/Tactic/GeneralizeProofs.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Alex J. Best. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex J. Best
 -/
-import Lean
 import Mathlib.Lean.Expr.Basic
 
 /-!

--- a/Mathlib/Tactic/GuardGoalNums.lean
+++ b/Mathlib/Tactic/GuardGoalNums.lean
@@ -3,8 +3,7 @@ Copyright (c) 2022 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
-
-import Lean
+import Lean.Elab.Tactic.Basic
 
 /-!
 

--- a/Mathlib/Tactic/GuardHypNums.lean
+++ b/Mathlib/Tactic/GuardHypNums.lean
@@ -3,8 +3,7 @@ Copyright (c) 2022 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
-
-import Lean
+import Lean.Elab.Tactic.Basic
 
 /-!
 A tactic stub file for the `guard_hyp_nums` tactic.

--- a/Mathlib/Tactic/Have.lean
+++ b/Mathlib/Tactic/Have.lean
@@ -3,7 +3,9 @@ Copyright (c) 2022 Arthur Paulino. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino, Edward Ayers, Mario Carneiro
 -/
-import Lean
+import Lean.Elab.Binders
+import Lean.Elab.SyntheticMVars
+import Lean.Meta.Tactic.Assert
 import Mathlib.Data.Array.Defs
 
 /-!

--- a/Mathlib/Tactic/InferParam.lean
+++ b/Mathlib/Tactic/InferParam.lean
@@ -3,7 +3,8 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Mario Carneiro
 -/
-import Lean
+import Lean.Elab.Tactic.Basic
+import Lean.Meta.Tactic.Replace
 
 /-!
 # Infer an optional parameter

--- a/Mathlib/Tactic/SudoSetOption.lean
+++ b/Mathlib/Tactic/SudoSetOption.lean
@@ -3,8 +3,7 @@ Copyright (c) 2021 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner
 -/
-
-import Lean
+import Lean.Elab.ElabRules
 
 /-!
 # Defines the `sudo set_option` command.

--- a/Mathlib/Tactic/SuppressCompilation.lean
+++ b/Mathlib/Tactic/SuppressCompilation.lean
@@ -3,7 +3,8 @@ Copyright (c) 2023 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex J. Best, Mac Malone
 -/
-import Lean
+import Lean.Elab.Declaration
+import Lean.Elab.Notation
 
 /-!
 # Supressing compilation to executable code in a file or in a section

--- a/Mathlib/Tactic/Tauto.lean
+++ b/Mathlib/Tactic/Tauto.lean
@@ -3,8 +3,6 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, David Renshaw
 -/
-
-import Lean
 import Mathlib.Tactic.CasesM
 import Mathlib.Tactic.Classical
 import Mathlib.Tactic.Core

--- a/Mathlib/Tactic/ToLevel.lean
+++ b/Mathlib/Tactic/ToLevel.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import Lean
 import Mathlib.Mathport.Rename
 import Mathlib.Tactic.PPWithUniv
 

--- a/Mathlib/Tactic/Use.lean
+++ b/Mathlib/Tactic/Use.lean
@@ -3,8 +3,6 @@ Copyright (c) 2022 Arthur Paulino. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino, Gabriel Ebner, Kyle Miller
 -/
-
-import Lean
 import Std.Logic
 
 /-!

--- a/Mathlib/Tactic/Variable.lean
+++ b/Mathlib/Tactic/Variable.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import Lean
 import Std.Tactic.TryThis
 
 /-!

--- a/Mathlib/Tactic/WLOG.lean
+++ b/Mathlib/Tactic/WLOG.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Johan Commelin, Reid Barton, Thomas Murrills
 -/
-import Lean
 import Mathlib.Tactic.Core
 
 /-!

--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot
 -/
-
+import Lean.Elab.Tactic.Calc
 import Std.CodeAction
 
 import Mathlib.Data.String.Defs

--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -3,7 +3,8 @@ Copyright (c) 2023 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Floris van Doorn
 -/
-import Lean
+import Lean.Elab.DeclarationRange
+import Lean.Elab.Term
 
 /-!
 # `addRelatedDecl`

--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Scott Morrison
 -/
-import Lean
+import Lean.Elab.Command
 
 /-!
 # User commands for assert the (non-)existence of declaration or instances.

--- a/Mathlib/Util/Export.lean
+++ b/Mathlib/Util/Export.lean
@@ -3,7 +3,8 @@ Copyright (c) 2021 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Lean
+import Lean.CoreM
+import Lean.Util.FoldConsts
 
 /-!
 A rudimentary export format, adapted from

--- a/Mathlib/Util/SleepHeartbeats.lean
+++ b/Mathlib/Util/SleepHeartbeats.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Alex J. Best. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex J. Best
 -/
-import Lean
+import Lean.Elab.Tactic.Basic
 
 /-!
 # Defines `sleep_heartbeats` tactic.

--- a/Mathlib/Util/Syntax.lean
+++ b/Mathlib/Util/Syntax.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner
 -/
-import Lean
+import Lean.Syntax
 
 /-!
 # Helper functions for working with typed syntaxes.

--- a/Mathlib/Util/SynthesizeUsing.lean
+++ b/Mathlib/Util/SynthesizeUsing.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Lean
+import Lean.Elab.Tactic.Basic
 
 /-!
 # `SynthesizeUsing`

--- a/Mathlib/Util/TermBeta.lean
+++ b/Mathlib/Util/TermBeta.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import Lean
+import Lean.Elab.Term
 
 /-! `beta%` term elaborator
 


### PR DESCRIPTION
Removes superfluous `import Lean`, and replaces many `import Lean`s with finer imports.

Not complete, as there is more than I expected, but happy to merge this first and get to the rest later.

---

Std requires this, but I'm not suggesting a rule change for Mathlib.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
