### PR TITLE
[Merged by Bors] - feat: function is differentiable outside of its tsupport

### DIFF
--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -340,14 +340,25 @@ theorem smoothWithinAt_one [One M'] : SmoothWithinAt I I' (1 : M → M') s x :=
 
 end id
 
+/-- `f` is continuously differentiable if it is cont. differentiable at each `x ∈ tsupport f`. -/
 theorem contMDiff_of_support {f : M → F} (hf : ∀ x ∈ tsupport f, ContMDiffAt I 𝓘(𝕜, F) n f x) :
     ContMDiff I 𝓘(𝕜, F) n f := by
   intro x
   by_cases hx : x ∈ tsupport f
   · exact hf x hx
-  · refine' ContMDiffAt.congr_of_eventuallyEq _ (eventuallyEq_zero_nhds.2 hx)
-    exact contMDiffAt_const
+  · exact ContMDiffAt.congr_of_eventuallyEq contMDiffAt_const (eventuallyEq_zero_nhds.2 hx)
 #align cont_mdiff_of_support contMDiff_of_support
+
+theorem contMDiffWithinAt_of_not_mem {f : M → F} {x : M} (hx : x ∉ tsupport f) (n : ℕ∞)
+    (s : Set M) : ContMDiffWithinAt I 𝓘(𝕜, F) n f s x :=
+  contMDiffWithinAt_const.congr_of_eventuallyEq
+    (eventually_nhdsWithin_of_eventually_nhds <| not_mem_tsupport_iff_eventuallyEq.mp hx)
+    (image_eq_zero_of_nmem_tsupport hx)
+
+/-- `f` is continuously differentiable at each point outside of its `tsupport`. -/
+theorem contMDiffAt_of_not_mem {f : M → F} {x : M} (hx : x ∉ tsupport f) (n : ℕ∞) :
+    ContMDiffAt I 𝓘(𝕜, F) n f x :=
+  contMDiffWithinAt_of_not_mem hx n univ
 
 /-! ### The inclusion map from one open set to another is smooth -/
 


### PR DESCRIPTION
From sphere-eversion; I'm just submitting it.

Also golf the proof of the preceding lemma slightly and add a docstring.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
