### PR TITLE
[Merged by Bors] - feat(Counterexamples/CliffordAlgebra_not_injective): Some quadratic forms cannot be constructed from bilinear forms

### DIFF
--- a/Counterexamples/CliffordAlgebra_not_injective.lean
+++ b/Counterexamples/CliffordAlgebra_not_injective.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.CharP.Two
 import Mathlib.Data.MvPolynomial.CommRing
 import Mathlib.Data.ZMod.Basic
 import Mathlib.LinearAlgebra.CliffordAlgebra.Basic
+import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
 import Mathlib.LinearAlgebra.Finsupp
 import Mathlib.RingTheory.MvPolynomial.Basic
 import Mathlib.RingTheory.MvPolynomial.Ideal
@@ -28,6 +29,9 @@ The outline is that we define:
 and discover that $αβγ ≠ 0$ as an element of $K$, but $αβγ = 0$ as an element of $𝒞l(Q)$.
 
 Some Zulip discussion at https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/.F0.9D.94.BD.E2.82.82.5B.CE.B1.2C.20.CE.B2.2C.20.CE.B3.5D.20.2F.20.28.CE.B1.C2.B2.2C.20.CE.B2.C2.B2.2C.20.CE.B3.C2.B2.29/near/222716333.
+
+As a bonus result, we also show `QuadraticForm.not_forall_mem_range_toQuadraticForm`: that there
+are quadratic forms that cannot be expressed via even non-symmetric bilinear forms.
 -/
 
 noncomputable section
@@ -260,6 +264,16 @@ is not injective, as it sends the non-zero `α * β * γ` to zero. -/
 theorem algebraMap_not_injective : ¬Function.Injective (algebraMap K <| CliffordAlgebra Q) :=
   fun h => αβγ_ne_zero <| h <| by rw [algebraMap_αβγ_eq_zero, RingHom.map_zero]
 
+/-- Bonus counterexample: `Q` is a quadratic form that has no bilinear form. -/
+theorem Q_not_in_range_toQuadraticForm : Q ∉ Set.range BilinForm.toQuadraticForm := by
+  rintro ⟨B, hB⟩
+  rw [←sub_zero Q] at hB
+  apply algebraMap_not_injective
+  eta_expand
+  simp_rw [←changeForm_algebraMap hB, ←changeFormEquiv_apply]
+  refine (LinearEquiv.injective _).comp ?_
+  exact (ExteriorAlgebra.algebraMap_leftInverse _).injective
+
 end Q60596
 
 open Q60596 in
@@ -276,3 +290,18 @@ theorem CliffordAlgebra.not_forall_algebraMap_injective.{v} :
     let uC := CliffordAlgebra.map f
     have := uC.congr_arg hxy
     rwa [AlgHom.commutes, AlgHom.commutes] at this
+
+open Q60596 in
+/-- The general bonus statement: not every quadratic form is the diagonal of a bilinear form. -/
+theorem QuadraticForm.not_forall_mem_range_toQuadraticForm.{v} :
+    -- TODO: make `R` universe polymorphic
+    ¬∀ (R : Type) (M : Type v) [CommRing R] [AddCommGroup M] [Module R M] (Q : QuadraticForm R M),
+      Q ∈ Set.range BilinForm.toQuadraticForm :=
+  fun h => Q_not_in_range_toQuadraticForm <| by
+    let uU := ULift.moduleEquiv (R := K) (M := L)
+    let uQ := Q.comp uU.toLinearMap
+    let f : Q →qᵢ uQ := { uU.symm with map_app' := fun _ => rfl }
+    obtain ⟨x, hx⟩ := h K (ULift L) (Q.comp uU.toLinearMap)
+    refine ⟨x.comp uU.symm uU.symm, ?_⟩
+    ext
+    simp [toQuadraticForm_comp_same, hx]

--- a/Counterexamples/CliffordAlgebra_not_injective.lean
+++ b/Counterexamples/CliffordAlgebra_not_injective.lean
@@ -299,9 +299,7 @@ theorem QuadraticForm.not_forall_mem_range_toQuadraticForm.{v} :
       Q ∈ Set.range BilinForm.toQuadraticForm :=
   fun h => Q_not_in_range_toQuadraticForm <| by
     let uU := ULift.moduleEquiv (R := K) (M := L)
-    let uQ := Q.comp uU.toLinearMap
-    let f : Q →qᵢ uQ := { uU.symm with map_app' := fun _ => rfl }
-    obtain ⟨x, hx⟩ := h K (ULift L) (Q.comp uU.toLinearMap)
+    obtain ⟨x, hx⟩ := h K (ULift L) (Q.comp uU)
     refine ⟨x.comp uU.symm uU.symm, ?_⟩
     ext
-    simp [toQuadraticForm_comp_same, hx]
+    simp [BilinForm.toQuadraticForm_comp_same, hx]

--- a/Counterexamples/CliffordAlgebra_not_injective.lean
+++ b/Counterexamples/CliffordAlgebra_not_injective.lean
@@ -267,10 +267,10 @@ theorem algebraMap_not_injective : ¬Function.Injective (algebraMap K <| Cliffor
 /-- Bonus counterexample: `Q` is a quadratic form that has no bilinear form. -/
 theorem Q_not_in_range_toQuadraticForm : Q ∉ Set.range BilinForm.toQuadraticForm := by
   rintro ⟨B, hB⟩
-  rw [←sub_zero Q] at hB
+  rw [← sub_zero Q] at hB
   apply algebraMap_not_injective
   eta_expand
-  simp_rw [←changeForm_algebraMap hB, ←changeFormEquiv_apply]
+  simp_rw [← changeForm_algebraMap hB, ← changeFormEquiv_apply]
   refine (LinearEquiv.injective _).comp ?_
   exact (ExteriorAlgebra.algebraMap_leftInverse _).injective
 

--- a/Counterexamples/CliffordAlgebra_not_injective.lean
+++ b/Counterexamples/CliffordAlgebra_not_injective.lean
@@ -24,7 +24,7 @@ The outline is that we define:
 
 * $k$ (`Q60596.K`) as the commutative ring $𝔽₂[α, β, γ] / (α², β², γ²)$
 * $L$ (`Q60596.L`) as the $k$-module $⟨x,y,z⟩ / ⟨αx + βy + γz⟩$
-* $Q$ (`Q60596.Q`) as the quadratic form sending $Q(\overline{ax + by = cz}) = a² + b² + c²$
+* $Q$ (`Q60596.Q`) as the quadratic form sending $Q(\overline{ax + by + cz}) = a² + b² + c²$
 
 and discover that $αβγ ≠ 0$ as an element of $K$, but $αβγ = 0$ as an element of $𝒞l(Q)$.
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -79,7 +79,7 @@ universe u v w
 
 variable {S T : Type*}
 
-variable {R : Type*} {M : Type*}
+variable {R : Type*} {M N : Type*}
 
 open BigOperators
 
@@ -547,7 +547,7 @@ section Comp
 
 variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
-variable {N : Type v} [AddCommMonoid N] [Module R N]
+variable [AddCommMonoid N] [Module R N]
 
 /-- Compose the quadratic form with a linear function. -/
 def comp (Q : QuadraticForm R N) (f : M →ₗ[R] N) : QuadraticForm R M where
@@ -607,7 +607,7 @@ theorem linMulLin_add (f g h : M →ₗ[R] R) : linMulLin f (g + h) = linMulLin 
   ext fun _ => mul_add _ _ _
 #align quadratic_form.lin_mul_lin_add QuadraticForm.linMulLin_add
 
-variable {N : Type v} [AddCommMonoid N] [Module R N]
+variable [AddCommMonoid N] [Module R N]
 
 @[simp]
 theorem linMulLin_comp (f g : M →ₗ[R] R) (h : N →ₗ[R] M) :
@@ -652,7 +652,7 @@ open QuadraticForm
 
 section Semiring
 
-variable [CommSemiring R] [AddCommMonoid M] [Module R M]
+variable [CommSemiring R] [AddCommMonoid M] [AddCommMonoid N] [Module R M] [Module R N]
 
 variable {B : BilinForm R M}
 
@@ -667,6 +667,9 @@ def toQuadraticForm (B : BilinForm R M) : QuadraticForm R M where
 theorem toQuadraticForm_apply (B : BilinForm R M) (x : M) : B.toQuadraticForm x = B x x :=
   rfl
 #align bilin_form.to_quadratic_form_apply BilinForm.toQuadraticForm_apply
+
+theorem toQuadraticForm_comp_same (B : BilinForm R N) (f : M →ₗ[R] N) :
+    (B.comp f f).toQuadraticForm = B.toQuadraticForm.comp f := rfl
 
 section
 
@@ -772,7 +775,6 @@ theorem  _root_.QuadraticForm.polarBilin_injective (h : IsUnit (2 : R)) :
   fun Q₁ Q₂ h₁₂ => QuadraticForm.ext fun x => h.mul_left_cancel <| by
     simpa using FunLike.congr_fun (congr_arg toQuadraticForm h₁₂) x
 
-variable {N : Type v}
 variable [CommRing S] [Algebra S R] [Module S M] [IsScalarTower S R M]
 variable [AddCommGroup N] [Module R N]
 
@@ -837,7 +839,7 @@ theorem associated_isSymm : (associatedHom S Q).IsSymm := fun x y => by
 #align quadratic_form.associated_is_symm QuadraticForm.associated_isSymm
 
 @[simp]
-theorem associated_comp {N : Type v} [AddCommGroup N] [Module R N] (f : N →ₗ[R] M) :
+theorem associated_comp [AddCommGroup N] [Module R N] (f : N →ₗ[R] M) :
     associatedHom S (Q.comp f) = (associatedHom S Q).comp f f := by
   ext
   simp only [QuadraticForm.comp_apply, BilinForm.comp_apply, associated_apply, LinearMap.map_add]


### PR DESCRIPTION
Turns out that this follows trivially from the previous counterexample.

Perhaps there's a slicker proof that doesn't go via Clifford algebras at all, but it seemed worth recording this one anyway.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
