### PR TITLE
[Merged by Bors] - chore(Geometry/Manifold/ChartedSpace): remove autoImplicit true

### DIFF
--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -110,9 +110,6 @@ In the locale `Manifold`, we denote the composition of partial homeomorphisms wi
 composition of partial equivs with `≫`.
 -/
 
-set_option autoImplicit true
-
-
 noncomputable section
 
 open Classical Topology Filter
@@ -792,7 +789,7 @@ instance prodChartedSpace (H : Type*) [TopologicalSpace H] (M : Type*) [Topologi
 section prodChartedSpace
 
 @[ext]
-theorem ModelProd.ext {x y : ModelProd α β} (h₁ : x.1 = y.1) (h₂ : x.2 = y.2) : x = y :=
+theorem ModelProd.ext {α β : Type*} {x y : ModelProd α β} (h₁ : x.1 = y.1) (h₂ : x.2 = y.2) : x = y :=
   Prod.ext h₁ h₂
 
 variable [TopologicalSpace H] [TopologicalSpace M] [ChartedSpace H M] [TopologicalSpace H']

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -112,7 +112,7 @@ composition of partial equivs with `≫`.
 
 noncomputable section
 
-open Classical Topology Filter
+open Topology
 
 universe u
 
@@ -789,7 +789,7 @@ instance prodChartedSpace (H : Type*) [TopologicalSpace H] (M : Type*) [Topologi
 section prodChartedSpace
 
 @[ext]
-theorem ModelProd.ext {α β : Type*} {x y : ModelProd α β} (h₁ : x.1 = y.1) (h₂ : x.2 = y.2) : x = y :=
+theorem ModelProd.ext {x y : ModelProd H H'} (h₁ : x.1 = y.1) (h₂ : x.2 = y.2) : x = y :=
   Prod.ext h₁ h₂
 
 variable [TopologicalSpace H] [TopologicalSpace M] [ChartedSpace H M] [TopologicalSpace H']


### PR DESCRIPTION
It's just used once for one declaration.
While at it, also remove two `open`s which are unused.

---------
The types `H` and `H'` are used elsewhere for `ModelProd`; no assumptions on them were made at this point.