### PR TITLE
[Merged by Bors] - chore(Topology/NhdsSet): rename type variables

### DIFF
--- a/Mathlib/Topology/NhdsSet.lean
+++ b/Mathlib/Topology/NhdsSet.lean
@@ -17,8 +17,8 @@ In this file we define the filter `𝓝ˢ s` or `nhdsSet s` consisting of all ne
 
 There are a couple different notions equivalent to `s ∈ 𝓝ˢ t`:
 * `s ⊆ interior t` using `subset_interior_iff_mem_nhdsSet`
-* `∀ x : α, x ∈ t → s ∈ 𝓝 x` using `mem_nhdsSet_iff_forall`
-* `∃ U : Set α, IsOpen U ∧ t ⊆ U ∧ U ⊆ s` using `mem_nhdsSet_iff_exists`
+* `∀ x : X, x ∈ t → s ∈ 𝓝 x` using `mem_nhdsSet_iff_forall`
+* `∃ U : Set X, IsOpen U ∧ t ⊆ U ∧ U ⊆ s` using `mem_nhdsSet_iff_exists`
 
 Furthermore, we have the following results:
 * `monotone_nhdsSet`: `𝓝ˢ` is monotone
@@ -29,29 +29,29 @@ Furthermore, we have the following results:
 
 open Set Filter Topology
 
-variable {α β : Type*} [TopologicalSpace α] [TopologicalSpace β] {f : Filter α}
-  {s t s₁ s₂ t₁ t₂ : Set α} {x : α}
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {f : Filter X}
+  {s t s₁ s₂ t₁ t₂ : Set X} {x : X}
 
 /-- The filter of neighborhoods of a set in a topological space. -/
-def nhdsSet (s : Set α) : Filter α :=
+def nhdsSet (s : Set X) : Filter X :=
   sSup (nhds '' s)
 #align nhds_set nhdsSet
 
 @[inherit_doc] scoped[Topology] notation "𝓝ˢ" => nhdsSet
 
-theorem nhdsSet_diagonal (α) [TopologicalSpace (α × α)] :
-    𝓝ˢ (diagonal α) = ⨆ (x : α), 𝓝 (x, x) := by
+theorem nhdsSet_diagonal (X) [TopologicalSpace (X × X)] :
+    𝓝ˢ (diagonal X) = ⨆ (x : X), 𝓝 (x, x) := by
   rw [nhdsSet, ← range_diag, ← range_comp]
   rfl
 #align nhds_set_diagonal nhdsSet_diagonal
 
-theorem mem_nhdsSet_iff_forall : s ∈ 𝓝ˢ t ↔ ∀ x : α, x ∈ t → s ∈ 𝓝 x := by
+theorem mem_nhdsSet_iff_forall : s ∈ 𝓝ˢ t ↔ ∀ x : X, x ∈ t → s ∈ 𝓝 x := by
   simp_rw [nhdsSet, Filter.mem_sSup, ball_image_iff]
 #align mem_nhds_set_iff_forall mem_nhdsSet_iff_forall
 
 lemma nhdsSet_le : 𝓝ˢ s ≤ f ↔ ∀ a ∈ s, 𝓝 a ≤ f := by simp [nhdsSet]
 
-theorem bUnion_mem_nhdsSet {t : α → Set α} (h : ∀ x ∈ s, t x ∈ 𝓝 x) : (⋃ x ∈ s, t x) ∈ 𝓝ˢ s :=
+theorem bUnion_mem_nhdsSet {t : X → Set X} (h : ∀ x ∈ s, t x ∈ 𝓝 x) : (⋃ x ∈ s, t x) ∈ 𝓝ˢ s :=
   mem_nhdsSet_iff_forall.2 fun x hx => mem_of_superset (h x hx) <|
     subset_iUnion₂ (s := fun x _ => t x) x hx -- porting note: fails to find `s`
 #align bUnion_mem_nhds_set bUnion_mem_nhdsSet
@@ -67,22 +67,22 @@ theorem disjoint_principal_nhdsSet : Disjoint (𝓟 s) (𝓝ˢ t) ↔ Disjoint (
 theorem disjoint_nhdsSet_principal : Disjoint (𝓝ˢ s) (𝓟 t) ↔ Disjoint s (closure t) := by
   rw [disjoint_comm, disjoint_principal_nhdsSet, disjoint_comm]
 
-theorem mem_nhdsSet_iff_exists : s ∈ 𝓝ˢ t ↔ ∃ U : Set α, IsOpen U ∧ t ⊆ U ∧ U ⊆ s := by
+theorem mem_nhdsSet_iff_exists : s ∈ 𝓝ˢ t ↔ ∃ U : Set X, IsOpen U ∧ t ⊆ U ∧ U ⊆ s := by
   rw [← subset_interior_iff_mem_nhdsSet, subset_interior_iff]
 #align mem_nhds_set_iff_exists mem_nhdsSet_iff_exists
 
 /-- A proposition is true on a set neighborhood of `s` iff it is true on a larger open set -/
-theorem eventually_nhdsSet_iff_exists {p : α → Prop} :
+theorem eventually_nhdsSet_iff_exists {p : X → Prop} :
     (∀ᶠ x in 𝓝ˢ s, p x) ↔ ∃ t, IsOpen t ∧ s ⊆ t ∧ ∀ x, x ∈ t → p x :=
   mem_nhdsSet_iff_exists
 
 /-- A proposition is true on a set neighborhood of `s`
 iff it is eventually true near each point in the set. -/
-theorem eventually_nhdsSet_iff_forall {p : α → Prop} :
+theorem eventually_nhdsSet_iff_forall {p : X → Prop} :
     (∀ᶠ x in 𝓝ˢ s, p x) ↔ ∀ x, x ∈ s → ∀ᶠ y in 𝓝 x, p y :=
   mem_nhdsSet_iff_forall
 
-theorem hasBasis_nhdsSet (s : Set α) : (𝓝ˢ s).HasBasis (fun U => IsOpen U ∧ s ⊆ U) fun U => U :=
+theorem hasBasis_nhdsSet (s : Set X) : (𝓝ˢ s).HasBasis (fun U => IsOpen U ∧ s ⊆ U) fun U => U :=
   ⟨fun t => by simp [mem_nhdsSet_iff_exists, and_assoc]⟩
 #align has_basis_nhds_set hasBasis_nhdsSet
 
@@ -99,10 +99,10 @@ theorem principal_le_nhdsSet : 𝓟 s ≤ 𝓝ˢ s := fun _s hs =>
 
 theorem subset_of_mem_nhdsSet (h : t ∈ 𝓝ˢ s) : s ⊆ t := principal_le_nhdsSet h
 
-theorem Filter.Eventually.self_of_nhdsSet {p : α → Prop} (h : ∀ᶠ x in 𝓝ˢ s, p x) : ∀ x ∈ s, p x :=
+theorem Filter.Eventually.self_of_nhdsSet {p : X → Prop} (h : ∀ᶠ x in 𝓝ˢ s, p x) : ∀ x ∈ s, p x :=
   principal_le_nhdsSet h
 
-nonrec theorem Filter.EventuallyEq.self_of_nhdsSet {f g : α → β} (h : f =ᶠ[𝓝ˢ s] g) : EqOn f g s :=
+nonrec theorem Filter.EventuallyEq.self_of_nhdsSet {f g : X → Y} (h : f =ᶠ[𝓝ˢ s] g) : EqOn f g s :=
   h.self_of_nhdsSet
 
 @[simp]
@@ -128,14 +128,14 @@ theorem mem_nhdsSet_interior : s ∈ 𝓝ˢ (interior s) :=
 #align mem_nhds_set_interior mem_nhdsSet_interior
 
 @[simp]
-theorem nhdsSet_empty : 𝓝ˢ (∅ : Set α) = ⊥ := by rw [isOpen_empty.nhdsSet_eq, principal_empty]
+theorem nhdsSet_empty : 𝓝ˢ (∅ : Set X) = ⊥ := by rw [isOpen_empty.nhdsSet_eq, principal_empty]
 #align nhds_set_empty nhdsSet_empty
 
-theorem mem_nhdsSet_empty : s ∈ 𝓝ˢ (∅ : Set α) := by simp
+theorem mem_nhdsSet_empty : s ∈ 𝓝ˢ (∅ : Set X) := by simp
 #align mem_nhds_set_empty mem_nhdsSet_empty
 
 @[simp]
-theorem nhdsSet_univ : 𝓝ˢ (univ : Set α) = ⊤ := by rw [isOpen_univ.nhdsSet_eq, principal_univ]
+theorem nhdsSet_univ : 𝓝ˢ (univ : Set X) = ⊤ := by rw [isOpen_univ.nhdsSet_eq, principal_univ]
 #align nhds_set_univ nhdsSet_univ
 
 @[mono]
@@ -143,7 +143,7 @@ theorem nhdsSet_mono (h : s ⊆ t) : 𝓝ˢ s ≤ 𝓝ˢ t :=
   sSup_le_sSup <| image_subset _ h
 #align nhds_set_mono nhdsSet_mono
 
-theorem monotone_nhdsSet : Monotone (𝓝ˢ : Set α → Filter α) := fun _ _ => nhdsSet_mono
+theorem monotone_nhdsSet : Monotone (𝓝ˢ : Set X → Filter X) := fun _ _ => nhdsSet_mono
 #align monotone_nhds_set monotone_nhdsSet
 
 theorem nhds_le_nhdsSet (h : x ∈ s) : 𝓝 x ≤ 𝓝ˢ s :=
@@ -151,7 +151,7 @@ theorem nhds_le_nhdsSet (h : x ∈ s) : 𝓝 x ≤ 𝓝ˢ s :=
 #align nhds_le_nhds_set nhds_le_nhdsSet
 
 @[simp]
-theorem nhdsSet_union (s t : Set α) : 𝓝ˢ (s ∪ t) = 𝓝ˢ s ⊔ 𝓝ˢ t := by
+theorem nhdsSet_union (s t : Set X) : 𝓝ˢ (s ∪ t) = 𝓝ˢ s ⊔ 𝓝ˢ t := by
   simp only [nhdsSet, image_union, sSup_union]
 #align nhds_set_union nhdsSet_union
 
@@ -161,12 +161,12 @@ theorem union_mem_nhdsSet (h₁ : s₁ ∈ 𝓝ˢ t₁) (h₂ : s₂ ∈ 𝓝ˢ 
 #align union_mem_nhds_set union_mem_nhdsSet
 
 @[simp]
-theorem nhdsSet_insert (x : α) (s : Set α) : 𝓝ˢ (insert x s) = 𝓝 x ⊔ 𝓝ˢ s := by
+theorem nhdsSet_insert (x : X) (s : Set X) : 𝓝ˢ (insert x s) = 𝓝 x ⊔ 𝓝ˢ s := by
   rw [insert_eq, nhdsSet_union, nhdsSet_singleton]
 
 /-- Preimage of a set neighborhood of `t` under a continuous map `f` is a set neighborhood of `s`
 provided that `f` maps `s` to `t`.  -/
-theorem Continuous.tendsto_nhdsSet {f : α → β} {t : Set β} (hf : Continuous f)
+theorem Continuous.tendsto_nhdsSet {f : X → Y} {t : Set Y} (hf : Continuous f)
     (hst : MapsTo f s t) : Tendsto f (𝓝ˢ s) (𝓝ˢ t) :=
   ((hasBasis_nhdsSet s).tendsto_iff (hasBasis_nhdsSet t)).mpr fun U hU =>
     ⟨f ⁻¹' U, ⟨hU.1.preimage hf, hst.mono Subset.rfl hU.2⟩, fun _ => id⟩

--- a/Mathlib/Topology/NhdsSet.lean
+++ b/Mathlib/Topology/NhdsSet.lean
@@ -49,7 +49,7 @@ theorem mem_nhdsSet_iff_forall : s ∈ 𝓝ˢ t ↔ ∀ x : X, x ∈ t → s ∈
   simp_rw [nhdsSet, Filter.mem_sSup, ball_image_iff]
 #align mem_nhds_set_iff_forall mem_nhdsSet_iff_forall
 
-lemma nhdsSet_le : 𝓝ˢ s ≤ f ↔ ∀ a ∈ s, 𝓝 a ≤ f := by simp [nhdsSet]
+lemma nhdsSet_le : 𝓝ˢ s ≤ f ↔ ∀ x ∈ s, 𝓝 x ≤ f := by simp [nhdsSet]
 
 theorem bUnion_mem_nhdsSet {t : X → Set X} (h : ∀ x ∈ s, t x ∈ 𝓝 x) : (⋃ x ∈ s, t x) ∈ 𝓝ˢ s :=
   mem_nhdsSet_iff_forall.2 fun x hx => mem_of_superset (h x hx) <|

--- a/Mathlib/Topology/NhdsSet.lean
+++ b/Mathlib/Topology/NhdsSet.lean
@@ -172,8 +172,8 @@ theorem Continuous.tendsto_nhdsSet {f : X → Y} {t : Set Y} (hf : Continuous f)
     ⟨f ⁻¹' U, ⟨hU.1.preimage hf, hst.mono Subset.rfl hU.2⟩, fun _ => id⟩
 #align continuous.tendsto_nhds_set Continuous.tendsto_nhdsSet
 
-lemma Continuous.tendsto_nhdsSet_nhds {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
-    {s : Set X} {y : Y} {f : X → Y} (h : Continuous f) (h' : EqOn f (fun _ ↦ y) s) :
+lemma Continuous.tendsto_nhdsSet_nhds
+    {y : Y} {f : X → Y} (h : Continuous f) (h' : EqOn f (fun _ ↦ y) s) :
     Tendsto f (𝓝ˢ s) (𝓝 y) := by
   rw [← nhdsSet_singleton]
   exact h.tendsto_nhdsSet h'


### PR DESCRIPTION
Now we use letters X and Y for topological spaces, not Greek letters.

------------
Same procedure as my other renaming PRs. Best reviewed commit by commit.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
