### PR TITLE
chore: remove `recursor` attributes

### DIFF
--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -154,7 +154,6 @@ theorem cons_inj_right (a : α) : ∀ {s t : Multiset α}, a ::ₘ s = a ::ₘ t
   rintro ⟨l₁⟩ ⟨l₂⟩; simp
 #align multiset.cons_inj_right Multiset.cons_inj_right
 
-@[recursor 5]
 protected theorem induction {p : Multiset α → Prop} (empty : p 0)
     (cons : ∀ ⦃a : α⦄ {s : Multiset α}, p s → p (a ::ₘ s)) : ∀ s, p s := by
   rintro ⟨l⟩; induction' l with _ _ ih <;> [exact empty; exact cons ih]

--- a/Mathlib/Data/MvPolynomial/Basic.lean
+++ b/Mathlib/Data/MvPolynomial/Basic.lean
@@ -447,7 +447,6 @@ theorem induction_on'' {M : MvPolynomial σ R → Prop} (p : MvPolynomial σ R) 
 #align mv_polynomial.induction_on'' MvPolynomial.induction_on''
 
 /-- Analog of `Polynomial.induction_on`.-/
-@[recursor 5]
 theorem induction_on {M : MvPolynomial σ R → Prop} (p : MvPolynomial σ R) (h_C : ∀ a, M (C a))
     (h_add : ∀ p q, M p → M q → M (p + q)) (h_X : ∀ p n, M p → M (p * X n)) : M p :=
   induction_on'' p h_C (fun a b f _ha _hb hf hm => h_add (monomial a b) f hm hf) h_X


### PR DESCRIPTION
while trying to understand when and where you need the `recursor` attribute, I looked for
existing uses, and in all of core, std, mathlib4 (including tests), these are the only two.

So I wondered what breaks if I remove them, and it seems, nothing breaks. 🤷🏻 