### PR TITLE
chore: improve definitional properties of `Submodule` lattice structure

### DIFF
--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -473,7 +473,7 @@ protected theorem pow_induction_on_left' {C : ∀ (n : ℕ) (x), x ∈ M ^ n →
       (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
 #align submodule.pow_induction_on_left' Submodule.pow_induction_on_left'
 
-set_option maxHeartbeats 700000 in
+set_option maxHeartbeats 800000 in
 /-- Dependent version of `Submodule.pow_induction_on_right`. -/
 @[elab_as_elim]
 protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n → Prop}
@@ -491,8 +491,9 @@ protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n �
   revert hx
   simp_rw [pow_succ']
   intro hx
+  let C' : (x : A) → x ∈ M ^ n * M → Prop := fun y hy ↦ C (Nat.succ n) y (pow_succ' M n ▸ hy)
   exact
-    Submodule.mul_induction_on' (fun m hm x ih => hmul _ _ hm (n_ih _) _ ih)
+    Submodule.mul_induction_on' (C := C') (fun m hm x ih => hmul _ _ hm (n_ih _) _ ih)
       (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
 #align submodule.pow_induction_on_right' Submodule.pow_induction_on_right'
 

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -473,7 +473,7 @@ protected theorem pow_induction_on_left' {C : ∀ (n : ℕ) (x), x ∈ M ^ n →
       (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
 #align submodule.pow_induction_on_left' Submodule.pow_induction_on_left'
 
-set_option maxHeartbeats 700000 in
+set_option maxHeartbeats 600000 in
 /-- Dependent version of `Submodule.pow_induction_on_right`. -/
 @[elab_as_elim]
 protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n → Prop}

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -473,7 +473,7 @@ protected theorem pow_induction_on_left' {C : ∀ (n : ℕ) (x), x ∈ M ^ n →
       (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
 #align submodule.pow_induction_on_left' Submodule.pow_induction_on_left'
 
-set_option maxHeartbeats 800000 in
+set_option maxHeartbeats 700000 in
 /-- Dependent version of `Submodule.pow_induction_on_right`. -/
 @[elab_as_elim]
 protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n → Prop}
@@ -491,9 +491,8 @@ protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n �
   revert hx
   simp_rw [pow_succ']
   intro hx
-  let C' : (x : A) → x ∈ M ^ n * M → Prop := fun y hy ↦ C (Nat.succ n) y (pow_succ' M n ▸ hy)
   exact
-    Submodule.mul_induction_on' (C := C') (fun m hm x ih => hmul _ _ hm (n_ih _) _ ih)
+    Submodule.mul_induction_on' (fun m hm x ih => hmul _ _ hm (n_ih _) _ ih)
       (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
 #align submodule.pow_induction_on_right' Submodule.pow_induction_on_right'
 

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -473,7 +473,6 @@ protected theorem pow_induction_on_left' {C : ∀ (n : ℕ) (x), x ∈ M ^ n →
       (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
 #align submodule.pow_induction_on_left' Submodule.pow_induction_on_left'
 
-set_option maxHeartbeats 600000 in
 /-- Dependent version of `Submodule.pow_induction_on_right`. -/
 @[elab_as_elim]
 protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n → Prop}
@@ -488,12 +487,13 @@ protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n �
   · rw [pow_zero] at hx
     obtain ⟨r, rfl⟩ := hx
     exact hr r
-  revert hx
-  simp_rw [pow_succ']
-  intro hx
-  exact
-    Submodule.mul_induction_on' (fun m hm x ih => hmul _ _ hm (n_ih _) _ ih)
-      (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
+  replace hx : x ∈ M ^ n * M := by rwa [← pow_succ']
+  let C' := fun (x : A) (hx : x ∈ M ^ n * M) ↦ C (1 + n) x (by rwa [← n.succ_eq_one_add, pow_succ'])
+  suffices C' x hx by convert this using 1; exact n.succ_eq_one_add
+  refine Submodule.mul_induction_on' (fun m hm x ih ↦ ?_)
+    (fun x hx y hy Cx Cy ↦ hadd _ _ _ _ _ Cx Cy) hx
+  · convert hmul n m hm (n_ih hm) x ih using 1
+    rw [← n.succ_eq_one_add]
 #align submodule.pow_induction_on_right' Submodule.pow_induction_on_right'
 
 /-- To show a property on elements of `M ^ n` holds, it suffices to show that it holds for scalars,

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -473,6 +473,7 @@ protected theorem pow_induction_on_left' {C : ∀ (n : ℕ) (x), x ∈ M ^ n →
       (fun x hx y hy Cx Cy => hadd _ _ _ _ _ Cx Cy) hx
 #align submodule.pow_induction_on_left' Submodule.pow_induction_on_left'
 
+set_option maxHeartbeats 700000 in
 /-- Dependent version of `Submodule.pow_induction_on_right`. -/
 @[elab_as_elim]
 protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n → Prop}

--- a/Mathlib/Algebra/Module/Submodule/Lattice.lean
+++ b/Mathlib/Algebra/Module/Submodule/Lattice.lean
@@ -223,12 +223,6 @@ instance : InfSet (Submodule R M) :=
       add_mem' := by simp (config := { contextual := true }) [add_mem]
       smul_mem' := by simp (config := { contextual := true }) [smul_mem] }⟩
 
-private theorem sInf_le' {S : Set (Submodule R M)} {p} : p ∈ S → sInf S ≤ p :=
-  Set.biInter_subset_of_mem
-
-private theorem le_sInf' {S : Set (Submodule R M)} {p} : (∀ q ∈ S, p ≤ q) → p ≤ sInf S :=
-  Set.subset_iInter₂
-
 instance : Inf (Submodule R M) :=
   ⟨fun p q ↦
     { carrier := p ∩ q
@@ -238,7 +232,7 @@ instance : Inf (Submodule R M) :=
 
 instance : SupSet (Submodule R M) where
   sSup S :=
-    { sSup (toAddSubmonoid '' S) with
+    { toAddSubmonoid := sSup (toAddSubmonoid '' S)
       smul_mem' := fun t {m} hm ↦ by
         simp only [AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup] at hm ⊢
         rw [sSup_eq_iSup'] at hm ⊢

--- a/Mathlib/Algebra/Module/Submodule/Lattice.lean
+++ b/Mathlib/Algebra/Module/Submodule/Lattice.lean
@@ -18,11 +18,6 @@ If `p` and `q` are submodules of a module, `p ≤ q` means that `p ⊆ q`.
 Many results about operations on this lattice structure are defined in `LinearAlgebra/Basic.lean`,
 most notably those which use `span`.
 
-## Implementation notes
-
-This structure should match the `AddSubmonoid.CompleteLattice` structure, and we should try
-to unify the APIs where possible.
-
 -/
 
 universe v
@@ -286,10 +281,25 @@ theorem toAddSubmonoid_sSup' (S : Set (Submodule R M)) :
     (sSup S).toAddSubmonoid = ⨆ p ∈ S, p.toAddSubmonoid := by
   rw [toAddSubmonoid_sSup, ← Set.image, sSup_image]
 
-instance completeLattice : CompleteLattice (Submodule R M) :=
-  { toAddSubmonoid_injective.completeLattice toAddSubmonoid toAddSubmonoid_sup toAddSubmonoid_inf
-      toAddSubmonoid_sSup' toAddSubmonoid_sInf' rfl rfl with
-    toPartialOrder := SetLike.instPartialOrder }
+instance completeLattice : CompleteLattice (Submodule R M) where
+    le_top _ _ _ := trivial
+    bot_le p x hx := by rw [(mem_bot R).mp hx]; exact Submodule.zero_mem p
+    le_sup_left := fun _ _ ↦ Set.subset_iInter₂ fun _ ⟨h, _⟩ ↦ h
+    le_sup_right := fun _ _ ↦ Set.subset_iInter₂ fun _ ⟨_, h⟩ ↦ h
+    sup_le := fun _ _ _ h₁ h₂ ↦ Set.biInter_subset_of_mem ⟨h₁, h₂⟩
+    le_inf := fun _ _ _ ↦ Set.subset_inter
+    inf_le_left := fun _ _ ↦ Set.inter_subset_left _ _
+    inf_le_right := fun _ _ ↦ Set.inter_subset_right _ _
+    le_sSup := fun S p hs ↦ by
+      rw [← toAddSubmonoid_le, toAddSubmonoid_sSup]
+      exact le_sSup ⟨p, hs, rfl⟩
+    sSup_le := fun S p hs ↦ by
+      rw [← toAddSubmonoid_le, toAddSubmonoid_sSup]
+      refine sSup_le fun _ ⟨q, hq, hq'⟩ ↦ ?_
+      rw [← hq']
+      exact hs q hq
+    le_sInf := fun _ _ ↦ Set.subset_iInter₂
+    sInf_le := fun _ _ ↦ Set.biInter_subset_of_mem
 #align submodule.complete_lattice Submodule.completeLattice
 
 @[simp]

--- a/Mathlib/Algebra/Module/Submodule/Lattice.lean
+++ b/Mathlib/Algebra/Module/Submodule/Lattice.lean
@@ -281,25 +281,10 @@ theorem toAddSubmonoid_sSup' (S : Set (Submodule R M)) :
     (sSup S).toAddSubmonoid = ⨆ p ∈ S, p.toAddSubmonoid := by
   rw [toAddSubmonoid_sSup, ← Set.image, sSup_image]
 
-instance completeLattice : CompleteLattice (Submodule R M) where
-    le_top _ _ _ := trivial
-    bot_le p x hx := by rw [(mem_bot R).mp hx]; exact Submodule.zero_mem p
-    le_sup_left := fun _ _ ↦ Set.subset_iInter₂ fun _ ⟨h, _⟩ ↦ h
-    le_sup_right := fun _ _ ↦ Set.subset_iInter₂ fun _ ⟨_, h⟩ ↦ h
-    sup_le := fun _ _ _ h₁ h₂ ↦ Set.biInter_subset_of_mem ⟨h₁, h₂⟩
-    le_inf := fun _ _ _ ↦ Set.subset_inter
-    inf_le_left := fun _ _ ↦ Set.inter_subset_left _ _
-    inf_le_right := fun _ _ ↦ Set.inter_subset_right _ _
-    le_sSup := fun S p hs ↦ by
-      rw [← toAddSubmonoid_le, toAddSubmonoid_sSup]
-      exact le_sSup ⟨p, hs, rfl⟩
-    sSup_le := fun S p hs ↦ by
-      rw [← toAddSubmonoid_le, toAddSubmonoid_sSup]
-      refine sSup_le fun _ ⟨q, hq, hq'⟩ ↦ ?_
-      rw [← hq']
-      exact hs q hq
-    le_sInf := fun _ _ ↦ Set.subset_iInter₂
-    sInf_le := fun _ _ ↦ Set.biInter_subset_of_mem
+instance completeLattice : CompleteLattice (Submodule R M) :=
+  { toAddSubmonoid_injective.completeLattice toAddSubmonoid toAddSubmonoid_sup toAddSubmonoid_inf
+      toAddSubmonoid_sSup' toAddSubmonoid_sInf' rfl rfl with
+    toPartialOrder := SetLike.instPartialOrder }
 #align submodule.complete_lattice Submodule.completeLattice
 
 @[simp]

--- a/Mathlib/LinearAlgebra/AdicCompletion.lean
+++ b/Mathlib/LinearAlgebra/AdicCompletion.lean
@@ -85,7 +85,6 @@ def Hausdorffification : Type _ :=
   M ⧸ (⨅ n : ℕ, I ^ n • ⊤ : Submodule R M)
 #align Hausdorffification Hausdorffification
 
-set_option maxHeartbeats 300000 in
 /-- The completion of a module with respect to an ideal. This is not necessarily Hausdorff.
 In fact, this is only complete if the ideal is finitely generated. -/
 def adicCompletion : Submodule R (∀ n : ℕ, M ⧸ (I ^ n • ⊤ : Submodule R M)) where
@@ -213,7 +212,6 @@ def of : M →ₗ[R] adicCompletion I M where
   map_smul' _ _ := rfl
 #align adic_completion.of adicCompletion.of
 
-set_option maxHeartbeats 300000 in
 @[simp]
 theorem of_apply (x : M) (n : ℕ) : (of I M x).1 n = mkQ _ x :=
   rfl
@@ -236,7 +234,6 @@ theorem eval_apply (n : ℕ) (f : adicCompletion I M) : eval I M n f = f.1 n :=
   rfl
 #align adic_completion.eval_apply adicCompletion.eval_apply
 
-set_option maxHeartbeats 300000 in
 theorem eval_of (n : ℕ) (x : M) : eval I M n (of I M x) = mkQ _ x :=
   rfl
 #align adic_completion.eval_of adicCompletion.eval_of

--- a/Mathlib/LinearAlgebra/AdicCompletion.lean
+++ b/Mathlib/LinearAlgebra/AdicCompletion.lean
@@ -85,6 +85,7 @@ def Hausdorffification : Type _ :=
   M ⧸ (⨅ n : ℕ, I ^ n • ⊤ : Submodule R M)
 #align Hausdorffification Hausdorffification
 
+set_option maxHeartbeats 300000 in
 /-- The completion of a module with respect to an ideal. This is not necessarily Hausdorff.
 In fact, this is only complete if the ideal is finitely generated. -/
 def adicCompletion : Submodule R (∀ n : ℕ, M ⧸ (I ^ n • ⊤ : Submodule R M)) where
@@ -212,6 +213,7 @@ def of : M →ₗ[R] adicCompletion I M where
   map_smul' _ _ := rfl
 #align adic_completion.of adicCompletion.of
 
+set_option maxHeartbeats 300000 in
 @[simp]
 theorem of_apply (x : M) (n : ℕ) : (of I M x).1 n = mkQ _ x :=
   rfl
@@ -234,6 +236,7 @@ theorem eval_apply (n : ℕ) (f : adicCompletion I M) : eval I M n f = f.1 n :=
   rfl
 #align adic_completion.eval_apply adicCompletion.eval_apply
 
+set_option maxHeartbeats 300000 in
 theorem eval_of (n : ℕ) (x : M) : eval I M n (of I M x) = mkQ _ x :=
   rfl
 #align adic_completion.eval_of adicCompletion.eval_of


### PR DESCRIPTION
More precisely: ensure that the `sup` and `sSup` fields are defeq to those of `AddSubmonoid`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
