### PR TITLE
[Merged by Bors] - feat(Data/Polynomial): irreducibility of degree-{2,3} polynomials

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1919,6 +1919,7 @@ import Mathlib.Data.Polynomial.PartialFractions
 import Mathlib.Data.Polynomial.Reverse
 import Mathlib.Data.Polynomial.RingDivision
 import Mathlib.Data.Polynomial.Smeval
+import Mathlib.Data.Polynomial.SpecificDegree
 import Mathlib.Data.Polynomial.Splits
 import Mathlib.Data.Polynomial.Taylor
 import Mathlib.Data.Polynomial.UnitTrinomial

--- a/Mathlib/Data/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Data/Polynomial/Degree/Definitions.lean
@@ -1685,6 +1685,10 @@ theorem leadingCoeff_pow (p : R[X]) (n : ℕ) : leadingCoeff (p ^ n) = leadingCo
   (leadingCoeffHom : R[X] →* R).map_pow p n
 #align polynomial.leading_coeff_pow Polynomial.leadingCoeff_pow
 
+theorem leadingCoeff_dvd_leadingCoeff {a p : R[X]} (hap : a ∣ p) :
+    a.leadingCoeff ∣ p.leadingCoeff :=
+  map_dvd leadingCoeffHom hap
+
 end NoZeroDivisors
 
 end Polynomial

--- a/Mathlib/Data/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Data/Polynomial/Degree/Lemmas.lean
@@ -439,25 +439,40 @@ theorem irreducible_mul_leadingCoeff_inv {p : K[X]} :
   IsUnit.dvd_mul_right <| isUnit_C.mpr <| IsUnit.mk0 _ <|
     inv_ne_zero <| leadingCoeff_ne_zero.mpr hp0
 
--- `simp` normal form of `degree_mul_leadingCoeff_inv`
-@[simp] lemma degree_leadingCoeff_inv {p : K[X]} (hp0 : p ≠ 0) :
-    degree (C (leadingCoeff p)⁻¹) = 0 :=
-  degree_C (inv_ne_zero <| leadingCoeff_ne_zero.mpr hp0)
-
 theorem monic_mul_leadingCoeff_inv {p : K[X]} (h : p ≠ 0) : Monic (p * C (leadingCoeff p)⁻¹) := by
   rw [Monic, leadingCoeff_mul, leadingCoeff_C,
     mul_inv_cancel (show leadingCoeff p ≠ 0 from mt leadingCoeff_eq_zero.1 h)]
 #align polynomial.monic_mul_leading_coeff_inv Polynomial.monic_mul_leadingCoeff_inv
 
+-- `simp` normal form of `degree_mul_leadingCoeff_inv`
+@[simp] lemma degree_leadingCoeff_inv {p : K[X]} (hp0 : p ≠ 0) :
+    degree (C (leadingCoeff p)⁻¹) = 0 :=
+  degree_C (inv_ne_zero <| leadingCoeff_ne_zero.mpr hp0)
+
 theorem degree_mul_leadingCoeff_inv (p : K[X]) {q : K[X]} (h : q ≠ 0) :
     degree (p * C (leadingCoeff q)⁻¹) = degree p := by
   have h₁ : (leadingCoeff q)⁻¹ ≠ 0 := inv_ne_zero (mt leadingCoeff_eq_zero.1 h)
-  rw [degree_mul, degree_C h₁, add_zero]
+  rw [degree_mul_C h₁]
 #align polynomial.degree_mul_leading_coeff_inv Polynomial.degree_mul_leadingCoeff_inv
 
 theorem natDegree_mul_leadingCoeff_inv (p : K[X]) {q : K[X]} (h : q ≠ 0) :
     natDegree (p * C (leadingCoeff q)⁻¹) = natDegree p :=
   natDegree_eq_of_degree_eq (degree_mul_leadingCoeff_inv _ h)
+
+theorem degree_mul_leadingCoeff_self_inv (p : K[X]) :
+    degree (p * C (leadingCoeff p)⁻¹) = degree p := by
+  by_cases hp : p = 0
+  · simp [hp]
+  exact degree_mul_leadingCoeff_inv _ hp
+
+theorem natDegree_mul_leadingCoeff_self_inv (p : K[X]) :
+    natDegree (p * C (leadingCoeff p)⁻¹) = natDegree p :=
+  natDegree_eq_of_degree_eq (degree_mul_leadingCoeff_self_inv _)
+
+-- `simp` normal form of `degree_mul_leadingCoeff_self_inv`
+@[simp] lemma degree_add_degree_leadingCoeff_inv (p : K[X]) :
+    degree p + degree (C (leadingCoeff p)⁻¹) = degree p := by
+  rw [← degree_mul, degree_mul_leadingCoeff_self_inv]
 
 end DivisionRing
 

--- a/Mathlib/Data/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Data/Polynomial/Degree/Lemmas.lean
@@ -421,4 +421,30 @@ theorem leadingCoeff_comp (hq : natDegree q ≠ 0) :
 
 end NoZeroDivisors
 
+section Field
+
+variable {K : Type*} [Field K]
+
+/-! Useful lemmas for the "monicization" of a nonzero polynomial `p`. -/
+@[simp] lemma irreducible_mul_C_leadingCoeff_inv {p : K[X]} (hp0 : p ≠ 0) :
+    Irreducible (p * C (leadingCoeff p)⁻¹) ↔ Irreducible p :=
+  irreducible_mul_isUnit <| isUnit_C.mpr <| IsUnit.mk0 _ <|
+    inv_ne_zero <| leadingCoeff_ne_zero.mpr hp0
+
+@[simp] lemma dvd_mul_C_leadingCoeff_inv {p q : K[X]} (hp0 : p ≠ 0) :
+    q ∣ p * C (leadingCoeff p)⁻¹ ↔ q ∣ p :=
+  IsUnit.dvd_mul_right <| isUnit_C.mpr <| IsUnit.mk0 _ <|
+    inv_ne_zero <| leadingCoeff_ne_zero.mpr hp0
+
+-- `simp` normal form of `degree_mul_C_leadingCoeff_inv`
+@[simp] lemma degree_C_leadingCoeff_inv {p : K[X]} (hp0 : p ≠ 0) :
+    degree (C (leadingCoeff p)⁻¹) = 0 :=
+  degree_C (inv_ne_zero <| leadingCoeff_ne_zero.mpr hp0)
+
+lemma degree_mul_C_leadingCoeff_inv {p : K[X]} (hp0 : p ≠ 0) :
+    degree (p * C (leadingCoeff p)⁻¹) = degree p := by
+  simp [degree_C_leadingCoeff_inv hp0]
+
+end Field
+
 end Polynomial

--- a/Mathlib/Data/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Data/Polynomial/Degree/Lemmas.lean
@@ -421,9 +421,9 @@ theorem leadingCoeff_comp (hq : natDegree q ≠ 0) :
 
 end NoZeroDivisors
 
-section Field
+section DivisionRing
 
-variable {K : Type*} [Field K]
+variable {K : Type*} [DivisionRing K]
 
 /-! Useful lemmas for the "monicization" of a nonzero polynomial `p`. -/
 @[simp]
@@ -459,6 +459,6 @@ theorem natDegree_mul_leadingCoeff_inv (p : K[X]) {q : K[X]} (h : q ≠ 0) :
     natDegree (p * C (leadingCoeff q)⁻¹) = natDegree p :=
   natDegree_eq_of_degree_eq (degree_mul_leadingCoeff_inv _ h)
 
-end Field
+end DivisionRing
 
 end Polynomial

--- a/Mathlib/Data/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Data/Polynomial/Degree/Lemmas.lean
@@ -426,24 +426,38 @@ section Field
 variable {K : Type*} [Field K]
 
 /-! Useful lemmas for the "monicization" of a nonzero polynomial `p`. -/
-@[simp] lemma irreducible_mul_C_leadingCoeff_inv {p : K[X]} (hp0 : p ≠ 0) :
-    Irreducible (p * C (leadingCoeff p)⁻¹) ↔ Irreducible p :=
-  irreducible_mul_isUnit <| isUnit_C.mpr <| IsUnit.mk0 _ <|
-    inv_ne_zero <| leadingCoeff_ne_zero.mpr hp0
+@[simp]
+theorem irreducible_mul_leadingCoeff_inv {p : K[X]} :
+    Irreducible (p * C (leadingCoeff p)⁻¹) ↔ Irreducible p := by
+  by_cases hp0 : p = 0
+  · simp [hp0]
+  exact irreducible_mul_isUnit
+    (isUnit_C.mpr (IsUnit.mk0 _ (inv_ne_zero (leadingCoeff_ne_zero.mpr hp0))))
 
-@[simp] lemma dvd_mul_C_leadingCoeff_inv {p q : K[X]} (hp0 : p ≠ 0) :
+@[simp] lemma dvd_mul_leadingCoeff_inv {p q : K[X]} (hp0 : p ≠ 0) :
     q ∣ p * C (leadingCoeff p)⁻¹ ↔ q ∣ p :=
   IsUnit.dvd_mul_right <| isUnit_C.mpr <| IsUnit.mk0 _ <|
     inv_ne_zero <| leadingCoeff_ne_zero.mpr hp0
 
--- `simp` normal form of `degree_mul_C_leadingCoeff_inv`
-@[simp] lemma degree_C_leadingCoeff_inv {p : K[X]} (hp0 : p ≠ 0) :
+-- `simp` normal form of `degree_mul_leadingCoeff_inv`
+@[simp] lemma degree_leadingCoeff_inv {p : K[X]} (hp0 : p ≠ 0) :
     degree (C (leadingCoeff p)⁻¹) = 0 :=
   degree_C (inv_ne_zero <| leadingCoeff_ne_zero.mpr hp0)
 
-lemma degree_mul_C_leadingCoeff_inv {p : K[X]} (hp0 : p ≠ 0) :
-    degree (p * C (leadingCoeff p)⁻¹) = degree p := by
-  simp [degree_C_leadingCoeff_inv hp0]
+theorem monic_mul_leadingCoeff_inv {p : K[X]} (h : p ≠ 0) : Monic (p * C (leadingCoeff p)⁻¹) := by
+  rw [Monic, leadingCoeff_mul, leadingCoeff_C,
+    mul_inv_cancel (show leadingCoeff p ≠ 0 from mt leadingCoeff_eq_zero.1 h)]
+#align polynomial.monic_mul_leading_coeff_inv Polynomial.monic_mul_leadingCoeff_inv
+
+theorem degree_mul_leadingCoeff_inv (p : K[X]) {q : K[X]} (h : q ≠ 0) :
+    degree (p * C (leadingCoeff q)⁻¹) = degree p := by
+  have h₁ : (leadingCoeff q)⁻¹ ≠ 0 := inv_ne_zero (mt leadingCoeff_eq_zero.1 h)
+  rw [degree_mul, degree_C h₁, add_zero]
+#align polynomial.degree_mul_leading_coeff_inv Polynomial.degree_mul_leadingCoeff_inv
+
+theorem natDegree_mul_leadingCoeff_inv (p : K[X]) {q : K[X]} (h : q ≠ 0) :
+    natDegree (p * C (leadingCoeff q)⁻¹) = natDegree p :=
+  natDegree_eq_of_degree_eq (degree_mul_leadingCoeff_inv _ h)
 
 end Field
 

--- a/Mathlib/Data/Polynomial/FieldDivision.lean
+++ b/Mathlib/Data/Polynomial/FieldDivision.lean
@@ -236,6 +236,13 @@ theorem degree_mul_leadingCoeff_inv (p : R[X]) (h : q ≠ 0) :
   rw [degree_mul, degree_C h₁, add_zero]
 #align polynomial.degree_mul_leading_coeff_inv Polynomial.degree_mul_leadingCoeff_inv
 
+theorem natDegree_mul_leadingCoeff_inv (p : R[X]) (h : q ≠ 0) :
+    natDegree (p * C (leadingCoeff q)⁻¹) = natDegree p := by
+  by_cases hp : p = 0
+  · simp [hp]
+  have h₁ : (leadingCoeff q)⁻¹ ≠ 0 := inv_ne_zero (mt leadingCoeff_eq_zero.1 h)
+  rw [natDegree_mul hp (C_ne_zero.mpr h₁), natDegree_C, add_zero]
+
 @[simp]
 theorem map_eq_zero [Semiring S] [Nontrivial S] (f : R →+* S) : p.map f = 0 ↔ p = 0 := by
   simp only [Polynomial.ext_iff]
@@ -661,10 +668,10 @@ divisors that have smaller degree.
 See also: `Polynomial.Monic.irreducible_iff_natDegree`.
 -/
 theorem irreducible_iff_degree_lt (p : R[X]) (hp0 : p ≠ 0) (hpu : ¬ IsUnit p) :
-    Irreducible p ↔ ∀ q, q.degree < degree p → q ∣ p → IsUnit q := by
+    Irreducible p ↔ ∀ q, q.degree ≤ ↑(natDegree p / 2) → q ∣ p → IsUnit q := by
   rw [← irreducible_mul_C_leadingCoeff_inv hp0,
       (monic_mul_leadingCoeff_inv hp0).irreducible_iff_degree_lt]
-  simp [hp0]
+  simp [hp0, natDegree_mul_leadingCoeff_inv]
   · contrapose! hpu
     exact isUnit_of_mul_eq_one _ _ hpu
 
@@ -674,29 +681,15 @@ divisors of degree `0 < d ≤ degree p / 2`.
 See also: `Polynomial.Monic.irreducible_iff_natDegree'`.
 -/
 theorem irreducible_iff_lt_natDegree_lt {p : R[X]} (hp0 : p ≠ 0) (hpu : ¬ IsUnit p) :
-    Irreducible p ↔ ∀ q, q ∣ p → natDegree q ∉ Finset.Ioc 0 (natDegree p / 2) := by
-  rw [← irreducible_mul_C_leadingCoeff_inv hp0,
-      (monic_mul_leadingCoeff_inv hp0).irreducible_iff_natDegree']
+    Irreducible p ↔ ∀ q, Monic q → natDegree q ∈ Finset.Ioc 0 (natDegree p / 2) → ¬ q ∣ p := by
   have : p * C (leadingCoeff p)⁻¹ ≠ 1
   · contrapose! hpu
     exact isUnit_of_mul_eq_one _ _ hpu
-  simp only [ne_eq, this, not_false_eq_true, Finset.mem_Ioc, not_and, not_le, true_and]
-  constructor
-  · rintro h f ⟨g, rfl⟩ hf
-    obtain ⟨hf0, hg0⟩ := mul_ne_zero_iff.mp hp0
-    convert h (g * C (leadingCoeff g)⁻¹) (f * C (leadingCoeff f)⁻¹)
-      (monic_mul_leadingCoeff_inv hg0) (monic_mul_leadingCoeff_inv hf0)
-      ?_
-      ?_ using 1
-    · rw [natDegree_mul_C_leadingCoeff_inv hp0]
-    · rw [natDegree_mul_C_leadingCoeff_inv hf0]
-    · simp; ring
-    · rwa [natDegree_mul_C_leadingCoeff_inv hf0]
-  · rintro h f g _ _ hfg hdeg
-    convert h g ⟨f * C (leadingCoeff p), ?_⟩ hdeg using 2
-    · rw [natDegree_mul_C_leadingCoeff_inv hp0]
-    · rw [mul_left_comm, ← mul_assoc, hfg, mul_assoc, ← map_mul, inv_mul_cancel, map_one, mul_one]
-      exact leadingCoeff_ne_zero.mpr hp0
+  rw [← irreducible_mul_C_leadingCoeff_inv hp0,
+      (monic_mul_leadingCoeff_inv hp0).irreducible_iff_lt_natDegree_lt this,
+      natDegree_mul_leadingCoeff_inv _ hp0]
+  simp only [IsUnit.dvd_mul_right
+    (isUnit_C.mpr (IsUnit.mk0 (leadingCoeff p)⁻¹ (inv_ne_zero (leadingCoeff_ne_zero.mpr hp0))))]
 
 end Field
 

--- a/Mathlib/Data/Polynomial/FieldDivision.lean
+++ b/Mathlib/Data/Polynomial/FieldDivision.lean
@@ -655,6 +655,49 @@ theorem isCoprime_of_is_root_of_eval_derivative_ne_zero {K : Type*} [Field K] (f
   rwa [← C_inj, C_0]
 #align polynomial.is_coprime_of_is_root_of_eval_derivative_ne_zero Polynomial.isCoprime_of_is_root_of_eval_derivative_ne_zero
 
+/-- To check a polynomial over a field is irreducible, it suffices to check only for
+divisors that have smaller degree.
+
+See also: `Polynomial.Monic.irreducible_iff_natDegree`.
+-/
+theorem irreducible_iff_degree_lt (p : R[X]) (hp0 : p ≠ 0) (hpu : ¬ IsUnit p) :
+    Irreducible p ↔ ∀ q, q.degree < degree p → q ∣ p → IsUnit q := by
+  rw [← irreducible_mul_C_leadingCoeff_inv hp0,
+      (monic_mul_leadingCoeff_inv hp0).irreducible_iff_degree_lt]
+  simp [hp0]
+  · contrapose! hpu
+    exact isUnit_of_mul_eq_one _ _ hpu
+
+/-- To check a polynomial `p` over a field is irreducible, it suffices to check there are no
+divisors of degree `0 < d ≤ degree p / 2`.
+
+See also: `Polynomial.Monic.irreducible_iff_natDegree'`.
+-/
+theorem irreducible_iff_lt_natDegree_lt {p : R[X]} (hp0 : p ≠ 0) (hpu : ¬ IsUnit p) :
+    Irreducible p ↔ ∀ q, q ∣ p → natDegree q ∉ Finset.Ioc 0 (natDegree p / 2) := by
+  rw [← irreducible_mul_C_leadingCoeff_inv hp0,
+      (monic_mul_leadingCoeff_inv hp0).irreducible_iff_natDegree']
+  have : p * C (leadingCoeff p)⁻¹ ≠ 1
+  · contrapose! hpu
+    exact isUnit_of_mul_eq_one _ _ hpu
+  simp only [ne_eq, this, not_false_eq_true, Finset.mem_Ioc, not_and, not_le, true_and]
+  constructor
+  · rintro h f ⟨g, rfl⟩ hf
+    obtain ⟨hf0, hg0⟩ := mul_ne_zero_iff.mp hp0
+    convert h (g * C (leadingCoeff g)⁻¹) (f * C (leadingCoeff f)⁻¹)
+      (monic_mul_leadingCoeff_inv hg0) (monic_mul_leadingCoeff_inv hf0)
+      ?_
+      ?_ using 1
+    · rw [natDegree_mul_C_leadingCoeff_inv hp0]
+    · rw [natDegree_mul_C_leadingCoeff_inv hf0]
+    · simp; ring
+    · rwa [natDegree_mul_C_leadingCoeff_inv hf0]
+  · rintro h f g _ _ hfg hdeg
+    convert h g ⟨f * C (leadingCoeff p), ?_⟩ hdeg using 2
+    · rw [natDegree_mul_C_leadingCoeff_inv hp0]
+    · rw [mul_left_comm, ← mul_assoc, hfg, mul_assoc, ← map_mul, inv_mul_cancel, map_one, mul_one]
+      exact leadingCoeff_ne_zero.mpr hp0
+
 end Field
 
 end Polynomial

--- a/Mathlib/Data/Polynomial/FieldDivision.lean
+++ b/Mathlib/Data/Polynomial/FieldDivision.lean
@@ -225,32 +225,6 @@ theorem degree_pos_of_ne_zero_of_nonunit (hp0 : p ≠ 0) (hp : ¬IsUnit p) : 0 <
     exact hp (IsUnit.map C (IsUnit.mk0 (coeff p 0) (mt C_inj.2 (by simpa using hp0))))
 #align polynomial.degree_pos_of_ne_zero_of_nonunit Polynomial.degree_pos_of_ne_zero_of_nonunit
 
-theorem monic_mul_leadingCoeff_inv (h : p ≠ 0) : Monic (p * C (leadingCoeff p)⁻¹) := by
-  rw [Monic, leadingCoeff_mul, leadingCoeff_C,
-    mul_inv_cancel (show leadingCoeff p ≠ 0 from mt leadingCoeff_eq_zero.1 h)]
-#align polynomial.monic_mul_leading_coeff_inv Polynomial.monic_mul_leadingCoeff_inv
-
-theorem degree_mul_leadingCoeff_inv (p : R[X]) (h : q ≠ 0) :
-    degree (p * C (leadingCoeff q)⁻¹) = degree p := by
-  have h₁ : (leadingCoeff q)⁻¹ ≠ 0 := inv_ne_zero (mt leadingCoeff_eq_zero.1 h)
-  rw [degree_mul, degree_C h₁, add_zero]
-#align polynomial.degree_mul_leading_coeff_inv Polynomial.degree_mul_leadingCoeff_inv
-
-theorem natDegree_mul_leadingCoeff_inv (p : R[X]) (h : q ≠ 0) :
-    natDegree (p * C (leadingCoeff q)⁻¹) = natDegree p := by
-  by_cases hp : p = 0
-  · simp [hp]
-  have h₁ : (leadingCoeff q)⁻¹ ≠ 0 := inv_ne_zero (mt leadingCoeff_eq_zero.1 h)
-  rw [natDegree_mul hp (C_ne_zero.mpr h₁), natDegree_C, add_zero]
-
-@[simp]
-theorem irreducible_mul_leadingCoeff_inv {p : R[X]} :
-    Irreducible (p * C (leadingCoeff p)⁻¹) ↔ Irreducible p := by
-  by_cases hp0 : p = 0
-  · simp [hp0]
-  exact irreducible_mul_isUnit
-    (isUnit_C.mpr (IsUnit.mk0 _ (inv_ne_zero (leadingCoeff_ne_zero.mpr hp0))))
-
 @[simp]
 theorem map_eq_zero [Semiring S] [Nontrivial S] (f : R →+* S) : p.map f = 0 ↔ p = 0 := by
   simp only [Polynomial.ext_iff]
@@ -677,7 +651,7 @@ See also: `Polynomial.Monic.irreducible_iff_natDegree`.
 -/
 theorem irreducible_iff_degree_lt (p : R[X]) (hp0 : p ≠ 0) (hpu : ¬ IsUnit p) :
     Irreducible p ↔ ∀ q, q.degree ≤ ↑(natDegree p / 2) → q ∣ p → IsUnit q := by
-  rw [← irreducible_mul_C_leadingCoeff_inv hp0,
+  rw [← irreducible_mul_leadingCoeff_inv,
       (monic_mul_leadingCoeff_inv hp0).irreducible_iff_degree_lt]
   simp [hp0, natDegree_mul_leadingCoeff_inv]
   · contrapose! hpu
@@ -693,7 +667,7 @@ theorem irreducible_iff_lt_natDegree_lt {p : R[X]} (hp0 : p ≠ 0) (hpu : ¬ IsU
   have : p * C (leadingCoeff p)⁻¹ ≠ 1
   · contrapose! hpu
     exact isUnit_of_mul_eq_one _ _ hpu
-  rw [← irreducible_mul_C_leadingCoeff_inv hp0,
+  rw [← irreducible_mul_leadingCoeff_inv,
       (monic_mul_leadingCoeff_inv hp0).irreducible_iff_lt_natDegree_lt this,
       natDegree_mul_leadingCoeff_inv _ hp0]
   simp only [IsUnit.dvd_mul_right

--- a/Mathlib/Data/Polynomial/FieldDivision.lean
+++ b/Mathlib/Data/Polynomial/FieldDivision.lean
@@ -244,6 +244,14 @@ theorem natDegree_mul_leadingCoeff_inv (p : R[X]) (h : q ≠ 0) :
   rw [natDegree_mul hp (C_ne_zero.mpr h₁), natDegree_C, add_zero]
 
 @[simp]
+theorem irreducible_mul_leadingCoeff_inv {p : R[X]} :
+    Irreducible (p * C (leadingCoeff p)⁻¹) ↔ Irreducible p := by
+  by_cases hp0 : p = 0
+  · simp [hp0]
+  exact irreducible_mul_isUnit
+    (isUnit_C.mpr (IsUnit.mk0 _ (inv_ne_zero (leadingCoeff_ne_zero.mpr hp0))))
+
+@[simp]
 theorem map_eq_zero [Semiring S] [Nontrivial S] (f : R →+* S) : p.map f = 0 ↔ p = 0 := by
   simp only [Polynomial.ext_iff]
   congr!

--- a/Mathlib/Data/Polynomial/RingDivision.lean
+++ b/Mathlib/Data/Polynomial/RingDivision.lean
@@ -433,6 +433,14 @@ theorem natDegree_pos_of_not_isUnit_of_dvd_monic {a p : R[X]} (ha : ¬ IsUnit a)
     0 < natDegree a :=
   natDegree_pos_iff_degree_pos.mpr <| degree_pos_of_not_isUnit_of_dvd_monic ha hap hp
 
+theorem degree_pos_of_monic_of_not_isUnit {a : R[X]} (hu : ¬ IsUnit a) (ha : Monic a) :
+    0 < degree a :=
+  degree_pos_of_not_isUnit_of_dvd_monic hu dvd_rfl ha
+
+theorem natDegree_pos_of_monic_of_not_isUnit {a : R[X]} (hu : ¬ IsUnit a) (ha : Monic a) :
+    0 < natDegree a :=
+  natDegree_pos_iff_degree_pos.mpr <| degree_pos_of_monic_of_not_isUnit hu ha
+
 theorem rootMultiplicity_eq_rootMultiplicity {p : R[X]} {t : R} :
     p.rootMultiplicity t = (p.comp (X + C t)).rootMultiplicity 0 := by
   classical

--- a/Mathlib/Data/Polynomial/RingDivision.lean
+++ b/Mathlib/Data/Polynomial/RingDivision.lean
@@ -239,12 +239,14 @@ theorem isUnit_iff : IsUnit p ↔ ∃ r : R, IsUnit r ∧ C r = p :=
     fun ⟨_, hr, hrp⟩ => hrp ▸ isUnit_C.2 hr⟩
 #align polynomial.is_unit_iff Polynomial.isUnit_iff
 
-theorem not_isUnit_of_degree_pos [IsDomain R] (p : R[X])
+theorem not_isUnit_of_degree_pos (p : R[X])
     (hpl : 0 < p.degree) : ¬ IsUnit p := by
+  cases subsingleton_or_nontrivial R
+  · simp [Subsingleton.elim p 0] at hpl
   intro h
   simp [degree_eq_zero_of_isUnit h] at hpl
 
-theorem not_isUnit_of_natDegree_pos [IsDomain R] (p : R[X])
+theorem not_isUnit_of_natDegree_pos (p : R[X])
     (hpl : 0 < p.natDegree) : ¬ IsUnit p :=
   not_isUnit_of_degree_pos _ (natDegree_pos_iff_degree_pos.mp hpl)
 

--- a/Mathlib/Data/Polynomial/RingDivision.lean
+++ b/Mathlib/Data/Polynomial/RingDivision.lean
@@ -430,7 +430,7 @@ theorem Monic.C_dvd_iff_isUnit {p : R[X]} (hp : Monic p) {a : R} :
     C a ∣ p ↔ IsUnit a :=
   ⟨fun h => isUnit_iff_dvd_one.mpr <|
       hp.coeff_natDegree ▸ (C_dvd_iff_dvd_coeff _ _).mp h p.natDegree,
-   fun ha => IsUnit.dvd (ha.map C)⟩
+   (·.map C).dvd⟩
 
 theorem degree_pos_of_not_isUnit_of_dvd_monic {a p : R[X]} (ha : ¬ IsUnit a)
     (hap : a ∣ p) (hp : Monic p) :

--- a/Mathlib/Data/Polynomial/RingDivision.lean
+++ b/Mathlib/Data/Polynomial/RingDivision.lean
@@ -382,6 +382,38 @@ instance : IsDomain R[X] :=
 
 end Ring
 
+section CommSemiring
+
+variable [CommSemiring R]
+
+theorem Monic.C_dvd_iff_isUnit {p : R[X]} (hp : Monic p) {a : R} :
+    C a ∣ p ↔ IsUnit a :=
+  ⟨fun h => isUnit_iff_dvd_one.mpr <|
+      hp.coeff_natDegree ▸ (C_dvd_iff_dvd_coeff _ _).mp h p.natDegree,
+   fun ha => (ha.map C).dvd⟩
+
+theorem degree_pos_of_not_isUnit_of_dvd_monic {a p : R[X]} (ha : ¬ IsUnit a)
+    (hap : a ∣ p) (hp : Monic p) :
+    0 < degree a :=
+  lt_of_not_ge <| fun h => ha <| by
+    rw [Polynomial.eq_C_of_degree_le_zero h] at hap ⊢
+    simpa [hp.C_dvd_iff_isUnit, isUnit_C] using hap
+
+theorem natDegree_pos_of_not_isUnit_of_dvd_monic {a p : R[X]} (ha : ¬ IsUnit a)
+    (hap : a ∣ p) (hp : Monic p) :
+    0 < natDegree a :=
+  natDegree_pos_iff_degree_pos.mpr <| degree_pos_of_not_isUnit_of_dvd_monic ha hap hp
+
+theorem degree_pos_of_monic_of_not_isUnit {a : R[X]} (hu : ¬ IsUnit a) (ha : Monic a) :
+    0 < degree a :=
+  degree_pos_of_not_isUnit_of_dvd_monic hu dvd_rfl ha
+
+theorem natDegree_pos_of_monic_of_not_isUnit {a : R[X]} (hu : ¬ IsUnit a) (ha : Monic a) :
+    0 < natDegree a :=
+  natDegree_pos_iff_degree_pos.mpr <| degree_pos_of_monic_of_not_isUnit hu ha
+
+end CommSemiring
+
 section CommRing
 
 variable [CommRing R]
@@ -425,32 +457,6 @@ theorem comp_X_add_C_eq_zero_iff {p : R[X]} (t : R) :
 
 theorem comp_X_add_C_ne_zero_iff {p : R[X]} (t : R) :
     p.comp (X + C t) ≠ 0 ↔ p ≠ 0 := Iff.not <| comp_X_add_C_eq_zero_iff t
-
-theorem Monic.C_dvd_iff_isUnit {p : R[X]} (hp : Monic p) {a : R} :
-    C a ∣ p ↔ IsUnit a :=
-  ⟨fun h => isUnit_iff_dvd_one.mpr <|
-      hp.coeff_natDegree ▸ (C_dvd_iff_dvd_coeff _ _).mp h p.natDegree,
-   (·.map C).dvd⟩
-
-theorem degree_pos_of_not_isUnit_of_dvd_monic {a p : R[X]} (ha : ¬ IsUnit a)
-    (hap : a ∣ p) (hp : Monic p) :
-    0 < degree a :=
-  lt_of_not_ge <| fun h => ha <| by
-    rw [Polynomial.eq_C_of_degree_le_zero h] at hap ⊢
-    simpa [hp.C_dvd_iff_isUnit, isUnit_C] using hap
-
-theorem natDegree_pos_of_not_isUnit_of_dvd_monic {a p : R[X]} (ha : ¬ IsUnit a)
-    (hap : a ∣ p) (hp : Monic p) :
-    0 < natDegree a :=
-  natDegree_pos_iff_degree_pos.mpr <| degree_pos_of_not_isUnit_of_dvd_monic ha hap hp
-
-theorem degree_pos_of_monic_of_not_isUnit {a : R[X]} (hu : ¬ IsUnit a) (ha : Monic a) :
-    0 < degree a :=
-  degree_pos_of_not_isUnit_of_dvd_monic hu dvd_rfl ha
-
-theorem natDegree_pos_of_monic_of_not_isUnit {a : R[X]} (hu : ¬ IsUnit a) (ha : Monic a) :
-    0 < natDegree a :=
-  natDegree_pos_iff_degree_pos.mpr <| degree_pos_of_monic_of_not_isUnit hu ha
 
 theorem rootMultiplicity_eq_rootMultiplicity {p : R[X]} {t : R} :
     p.rootMultiplicity t = (p.comp (X + C t)).rootMultiplicity 0 := by

--- a/Mathlib/Data/Polynomial/RingDivision.lean
+++ b/Mathlib/Data/Polynomial/RingDivision.lean
@@ -250,10 +250,6 @@ theorem not_isUnit_of_natDegree_pos (p : R[X])
     (hpl : 0 < p.natDegree) : ¬ IsUnit p :=
   not_isUnit_of_degree_pos _ (natDegree_pos_iff_degree_pos.mp hpl)
 
-lemma natDegree_mul_C_leadingCoeff_inv {K} [Field K] {p : K[X]} (hp0 : p ≠ 0) :
-    natDegree (p * C (leadingCoeff p)⁻¹) = natDegree p := by
-  simp [natDegree_mul hp0 (C_ne_zero.mpr (inv_ne_zero <| leadingCoeff_ne_zero.mpr hp0))]
-
 variable [CharZero R]
 
 -- Porting note: bit0/bit1 are deprecated

--- a/Mathlib/Data/Polynomial/RingDivision.lean
+++ b/Mathlib/Data/Polynomial/RingDivision.lean
@@ -422,14 +422,14 @@ theorem Monic.C_dvd_iff_isUnit {p : R[X]} (hp : Monic p) {a : R} :
    fun ha => IsUnit.dvd (ha.map C)⟩
 
 theorem degree_pos_of_not_isUnit_of_dvd_monic {a p : R[X]} (ha : ¬ IsUnit a)
-    (hap : a ∣ p) (hp : Monic p):
+    (hap : a ∣ p) (hp : Monic p) :
     0 < degree a :=
   lt_of_not_ge <| fun h => ha <| by
     rw [Polynomial.eq_C_of_degree_le_zero h] at hap ⊢
     simpa [hp.C_dvd_iff_isUnit, isUnit_C] using hap
 
 theorem natDegree_pos_of_not_isUnit_of_dvd_monic {a p : R[X]} (ha : ¬ IsUnit a)
-    (hap : a ∣ p) (hp : Monic p):
+    (hap : a ∣ p) (hp : Monic p) :
     0 < natDegree a :=
   natDegree_pos_iff_degree_pos.mpr <| degree_pos_of_not_isUnit_of_dvd_monic ha hap hp
 

--- a/Mathlib/Data/Polynomial/RingDivision.lean
+++ b/Mathlib/Data/Polynomial/RingDivision.lean
@@ -1503,7 +1503,7 @@ divisors that have smaller degree.
 
 See also: `Polynomial.Monic.irreducible_iff_natDegree`.
 -/
-theorem Monic.irreducible_iff_degree_lt (p : R[X]) (p_monic : Monic p) (p_1 : p ≠ 1) :
+theorem Monic.irreducible_iff_degree_lt {p : R[X]} (p_monic : Monic p) (p_1 : p ≠ 1) :
     Irreducible p ↔ ∀ q, degree q ≤ ↑(p.natDegree / 2) → q ∣ p → IsUnit q := by
   simp only [p_monic.irreducible_iff_lt_natDegree_lt p_1, mem_Ioc, and_imp,
     natDegree_pos_iff_degree_pos, natDegree_le_iff_degree_le]

--- a/Mathlib/Data/Polynomial/SpecificDegree.lean
+++ b/Mathlib/Data/Polynomial/SpecificDegree.lean
@@ -19,8 +19,7 @@ section IsDomain
 variable {R : Type*} [CommRing R] [IsDomain R]
 
 /-- A polynomial of degree 2 or 3 is irreducible iff it doesn't have roots. -/
-theorem Monic.irreducible_iff_roots_eq_zero_of_degree_le_three {R} [CommRing R] [IsDomain R]
-    {p : R[X]} (hp : p.Monic)
+theorem Monic.irreducible_iff_roots_eq_zero_of_degree_le_three {p : R[X]} (hp : p.Monic)
     (hp2 : 2 ≤ p.natDegree) (hp3 : p.natDegree ≤ 3) : Irreducible p ↔ p.roots = 0 := by
   have hp0 : p ≠ 0 := hp.ne_zero
   have hp1 : p ≠ 1 := by rintro rfl; rw [natDegree_one] at hp2; cases hp2

--- a/Mathlib/Data/Polynomial/SpecificDegree.lean
+++ b/Mathlib/Data/Polynomial/SpecificDegree.lean
@@ -3,7 +3,8 @@ Copyright (c) 2024 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen, Alex J. Best
 -/
-import Mathlib.Data.Polynomial.FieldDivision
+import Mathlib.Algebra.EuclideanDomain.Instances
+import Mathlib.Data.Polynomial.RingDivision
 import Mathlib.Tactic.IntervalCases
 
 /-!

--- a/Mathlib/Data/Polynomial/SpecificDegree.lean
+++ b/Mathlib/Data/Polynomial/SpecificDegree.lean
@@ -3,7 +3,6 @@ Copyright (c) 2024 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen, Alex J. Best
 -/
-import Mathlib.Algebra.EuclideanDomain.Instances
 import Mathlib.Data.Polynomial.RingDivision
 import Mathlib.Tactic.IntervalCases
 

--- a/Mathlib/Data/Polynomial/SpecificDegree.lean
+++ b/Mathlib/Data/Polynomial/SpecificDegree.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2024 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen, Alex J. Best
+-/
+import Mathlib.Data.Polynomial.FieldDivision
+import Mathlib.Tactic.IntervalCases
+
+/-!
+# Polynomials of specific degree
+
+Facts about polynomials that have a specific integer degree.
+-/
+
+namespace Polynomial
+
+variable {K : Type*} [Field K]
+
+/-- A polynomial of degree 2 or 3 is irreducible iff it doesn't have roots. -/
+theorem irreducible_iff_roots_eq_zero_of_degree_le_three
+    {p : K[X]} (hpl : 2 ≤ p.natDegree) (hp : p.natDegree ≤ 3) : Irreducible p ↔ p.roots = 0 := by
+  have hp0 : p ≠ 0 := ne_zero_of_natDegree_gt hpl
+  have hpu : ¬ IsUnit p := p.not_isUnit_of_natDegree_pos (pos_of_gt hpl)
+
+  -- Since the degree is at most three, the only divisors should be of degree one.
+  -- (We take the contrapositive for ease of proving.)
+  suffices : (∃ x, x ∣ p ∧ natDegree x = 1) ↔ ¬roots p = 0
+  · rw [irreducible_iff_lt_natDegree_lt hp0 hpu, ← not_iff_not, ← this]
+    have : (natDegree p) / 2 = 1
+    · interval_cases natDegree p
+      · rfl
+      · rfl
+    simp [this]
+  constructor
+  · rintro ⟨q, hdvd, hdeg⟩ hroots
+    have hndeg := (degree_eq_iff_natDegree_eq (ne_zero_of_dvd_ne_zero hp0 hdvd)).mpr hdeg
+    obtain ⟨r, hr⟩ := exists_root_of_degree_eq_one hndeg
+    simpa [hroots] using (mem_roots hp0).mpr (hr.dvd hdvd)
+  · intro h
+    obtain ⟨r, hr⟩ := Multiset.exists_mem_of_ne_zero h
+    exact ⟨X - C r,
+      ⟨p /ₘ (X - C r), (mul_divByMonic_eq_iff_isRoot.mpr (isRoot_of_mem_roots hr)).symm⟩,
+      natDegree_X_sub_C _⟩
+
+end Polynomial

--- a/Mathlib/RingTheory/Polynomial/Nilpotent.lean
+++ b/Mathlib/RingTheory/Polynomial/Nilpotent.lean
@@ -169,6 +169,20 @@ lemma isUnit_iff' :
   conv_lhs => rw [← modByMonic_add_div P monic_X]
   simp [modByMonic_X]
 
+theorem not_isUnit_of_natDegree_pos_of_isReduced [IsReduced R] (p : R[X])
+    (hpl : 0 < p.natDegree) : ¬ IsUnit p := by
+  simp only [ne_eq, isNilpotent_iff_eq_zero, not_and, not_forall, exists_prop,
+    Polynomial.isUnit_iff_coeff_isUnit_isNilpotent]
+  intro _
+  refine ⟨p.natDegree, hpl.ne', ?_⟩
+  contrapose! hpl
+  simp only [coeff_natDegree, leadingCoeff_eq_zero] at hpl
+  simp [hpl]
+
+theorem not_isUnit_of_degree_pos_of_isReduced [IsReduced R] (p : R[X])
+    (hpl : 0 < p.degree) : ¬ IsUnit p :=
+  not_isUnit_of_natDegree_pos_of_isReduced _ (natDegree_pos_iff_degree_pos.mpr hpl)
+
 end CommRing
 
 section CommAlgebra


### PR DESCRIPTION
The goal is to show that a degree 2 or 3 polynomial is irreducible iff it doesn't have roots. We already have `Polynomial.Monic.irreducible_iff_natDegree'` and some existing results in Lean 3: https://github.com/lean-forward/class-group-and-mordell-equation/blob/main/src/number_theory/assorted_lemmas.lean#L254 and the main work is to connect these bits together.

I added a few helper lemmas about the "monicization" of a polynomial `p`, `p * C (leadingCoeff p)⁻¹`. Then I used these to show the `Polynomial.Monic.irreducible_iff ...` statements could be translated to (not necessarily monic) polynomials over a field, then I specialized these results to the degree-{2,3} case.

I created a new file because I couldn't find an obvious place that imported both `Polynomial.FieldDivision` and `Tactic.IntervalCases`.

Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Polynomial.20irreducible


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
