### PR TITLE
[Merged by Bors] - feat(CategoryTheory/SingleObj): construct equivalence of `SingleObj` categories from a monoid isomorphism

### DIFF
--- a/Mathlib/CategoryTheory/SingleObj.lean
+++ b/Mathlib/CategoryTheory/SingleObj.lean
@@ -19,19 +19,19 @@ from category theory to monoids and groups.
 
 ## Main definitions
 
-Given a type `α` with a monoid structure, `SingleObj α` is `Unit` type with `Category` structure
-such that `End (SingleObj α).star` is the monoid `α`.  This can be extended to a functor
+Given a type `M` with a monoid structure, `SingleObj M` is `Unit` type with `Category` structure
+such that `End (SingleObj M).star` is the monoid `M`.  This can be extended to a functor
 `MonCat ⥤ Cat`.
 
-If `α` is a group, then `SingleObj α` is a groupoid.
+If `M` is a group, then `SingleObj M` is a groupoid.
 
-An element `x : α` can be reinterpreted as an element of `End (SingleObj.star α)` using
+An element `x : M` can be reinterpreted as an element of `End (SingleObj.star M)` using
 `SingleObj.toEnd`.
 
 ## Implementation notes
 
-- `categoryStruct.comp` on `End (SingleObj.star α)` is `flip (*)`, not `(*)`. This way
-  multiplication on `End` agrees with the multiplication on `α`.
+- `categoryStruct.comp` on `End (SingleObj.star M)` is `flip (*)`, not `(*)`. This way
+  multiplication on `End` agrees with the multiplication on `M`.
 
 - By default, Lean puts instances into `CategoryTheory` namespace instead of
   `CategoryTheory.SingleObj`, so we give all names explicitly.
@@ -50,44 +50,46 @@ abbrev SingleObj :=
 
 namespace SingleObj
 
-variable (α : Type u)
+variable (M G : Type u)
 
 /-- One and `flip (*)` become `id` and `comp` for morphisms of the single object category. -/
-instance categoryStruct [One α] [Mul α] : CategoryStruct (SingleObj α)
+instance categoryStruct [One M] [Mul M] : CategoryStruct (SingleObj M)
     where
-  Hom _ _ := α
+  Hom _ _ := M
   comp x y := y * x
   id _ := 1
 #align category_theory.single_obj.category_struct CategoryTheory.SingleObj.categoryStruct
 
+variable [Monoid M] [Group G]
+
 /-- Monoid laws become category laws for the single object category. -/
-instance category [Monoid α] : Category (SingleObj α)
+instance category : Category (SingleObj M)
     where
   comp_id := one_mul
   id_comp := mul_one
   assoc x y z := (mul_assoc z y x).symm
 #align category_theory.single_obj.category CategoryTheory.SingleObj.category
 
-theorem id_as_one [Monoid α] (x : SingleObj α) : 𝟙 x = 1 :=
+theorem id_as_one (x : SingleObj M) : 𝟙 x = 1 :=
   rfl
 #align category_theory.single_obj.id_as_one CategoryTheory.SingleObj.id_as_one
 
-theorem comp_as_mul [Monoid α] {x y z : SingleObj α} (f : x ⟶ y) (g : y ⟶ z) : f ≫ g = g * f :=
+theorem comp_as_mul {x y z : SingleObj M} (f : x ⟶ y) (g : y ⟶ z) : f ≫ g = g * f :=
   rfl
 #align category_theory.single_obj.comp_as_mul CategoryTheory.SingleObj.comp_as_mul
 
-/-- Groupoid structure on `SingleObj α`.
+/-- Groupoid structure on `SingleObj M`.
 
 See <https://stacks.math.columbia.edu/tag/0019>.
 -/
-instance groupoid [Group α] : Groupoid (SingleObj α)
+instance groupoid : Groupoid (SingleObj G)
     where
   inv x := x⁻¹
   inv_comp := mul_right_inv
   comp_inv := mul_left_inv
 #align category_theory.single_obj.groupoid CategoryTheory.SingleObj.groupoid
 
-theorem inv_as_inv [Group α] {x y : SingleObj α} (f : x ⟶ y) : inv f = f⁻¹ := by
+theorem inv_as_inv {x y : SingleObj G} (f : x ⟶ y) : inv f = f⁻¹ := by
   apply IsIso.inv_eq_of_hom_inv_id
   rw [comp_as_mul, inv_mul_self, id_as_one]
 #align category_theory.single_obj.inv_as_inv CategoryTheory.SingleObj.inv_as_inv
@@ -95,55 +97,60 @@ theorem inv_as_inv [Group α] {x y : SingleObj α} (f : x ⟶ y) : inv f = f⁻�
 /-- Abbreviation that allows writing `CategoryTheory.SingleObj.star` rather than
 `Quiver.SingleObj.star`.
 -/
-abbrev star : SingleObj α :=
-  Quiver.SingleObj.star α
+abbrev star : SingleObj M :=
+  Quiver.SingleObj.star M
 #align category_theory.single_obj.star CategoryTheory.SingleObj.star
 
-/-- The endomorphisms monoid of the only object in `SingleObj α` is equivalent to the original
-     monoid α. -/
-def toEnd [Monoid α] : α ≃* End (SingleObj.star α) :=
-  { Equiv.refl α with map_mul' := fun _ _ => rfl }
+/-- The endomorphisms monoid of the only object in `SingleObj M` is equivalent to the original
+     monoid M. -/
+def toEnd : M ≃* End (SingleObj.star M) :=
+  { Equiv.refl M with map_mul' := fun _ _ => rfl }
 #align category_theory.single_obj.to_End CategoryTheory.SingleObj.toEnd
 
-theorem toEnd_def [Monoid α] (x : α) : toEnd α x = x :=
+theorem toEnd_def (x : M) : toEnd M x = x :=
   rfl
 #align category_theory.single_obj.to_End_def CategoryTheory.SingleObj.toEnd_def
 
-/-- There is a 1-1 correspondence between monoid homomorphisms `α → β` and functors between the
+variable (N : Type v) [Monoid N]
+
+/-- There is a 1-1 correspondence between monoid homomorphisms `M → N` and functors between the
     corresponding single-object categories. It means that `SingleObj` is a fully faithful
     functor.
 
 See <https://stacks.math.columbia.edu/tag/001F> --
 although we do not characterize when the functor is full or faithful.
 -/
-def mapHom (α : Type u) (β : Type v) [Monoid α] [Monoid β] :
-    (α →* β) ≃ SingleObj α ⥤ SingleObj β where
+def mapHom : (M →* N) ≃ SingleObj M ⥤ SingleObj N where
   toFun f :=
     { obj := id
       map := ⇑f
       map_id := fun _ => f.map_one
       map_comp := fun x y => f.map_mul y x }
   invFun f :=
-    { toFun := fun x => f.map ((toEnd α) x)
+    { toFun := fun x => f.map ((toEnd M) x)
       map_one' := f.map_id _
       map_mul' := fun x y => f.map_comp y x }
   left_inv := by aesop_cat
   right_inv := by aesop_cat
 #align category_theory.single_obj.map_hom CategoryTheory.SingleObj.mapHom
 
-theorem mapHom_id (α : Type u) [Monoid α] : mapHom α α (MonoidHom.id α) = 𝟭 _ :=
+theorem mapHom_id : mapHom M M (MonoidHom.id M) = 𝟭 _ :=
   rfl
 #align category_theory.single_obj.map_hom_id CategoryTheory.SingleObj.mapHom_id
 
-theorem mapHom_comp {α : Type u} {β : Type v} [Monoid α] [Monoid β] (f : α →* β) {γ : Type w}
-    [Monoid γ] (g : β →* γ) : mapHom α γ (g.comp f) = mapHom α β f ⋙ mapHom β γ g :=
+variable {M N G}
+
+theorem mapHom_comp (f : M →* N) {P : Type w} [Monoid P] (g : N →* P) :
+    mapHom M P (g.comp f) = mapHom M N f ⋙ mapHom N P g :=
   rfl
 #align category_theory.single_obj.map_hom_comp CategoryTheory.SingleObj.mapHom_comp
+
+variable {C : Type v} [Category.{w} C]
 
 /-- Given a function `f : C → G` from a category to a group, we get a functor
     `C ⥤ G` sending any morphism `x ⟶ y` to `f y * (f x)⁻¹`. -/
 @[simps]
-def differenceFunctor {C G} [Category C] [Group G] (f : C → G) : C ⥤ SingleObj G
+def differenceFunctor (f : C → G) : C ⥤ SingleObj G
     where
   obj _ := ()
   map {x y} _ := f y * (f x)⁻¹
@@ -156,22 +163,20 @@ def differenceFunctor {C G} [Category C] [Group G] (f : C → G) : C ⥤ SingleO
     rw [SingleObj.comp_as_mul, ← mul_assoc, mul_left_inj, mul_assoc, inv_mul_self, mul_one]
 #align category_theory.single_obj.difference_functor CategoryTheory.SingleObj.differenceFunctor
 
-/-- A monoid homomorphism `f: α → End X` into the endomorphisms of an object `X` of a category `C`
-induces a functor `SingleObj α ⥤ C`. -/
+/-- A monoid homomorphism `f: M → End X` into the endomorphisms of an object `X` of a category `C`
+induces a functor `SingleObj M ⥤ C`. -/
 @[simps]
-def functor {α : Type u} [Monoid α] {C : Type w} [Category.{v} C] {X : C} (f : α →* End X) :
-    SingleObj α ⥤ C where
+def functor {X : C} (f : M →* End X) : SingleObj M ⥤ C where
   obj _ := X
   map a := f a
   map_id _ := MonoidHom.map_one f
   map_comp a b := MonoidHom.map_mul f b a
 
-/-- Construct a natural transformation between functors `SingleObj α ⥤ C` by
-giving a compatible morphism `SingleObj.star α`. -/
+/-- Construct a natural transformation between functors `SingleObj M ⥤ C` by
+giving a compatible morphism `SingleObj.star M`. -/
 @[simps]
-def natTrans {α : Type w} {C : Type w} [Category.{v} C] [Monoid α] {F G : SingleObj α ⥤ C}
-    (u : F.obj (SingleObj.star α) ⟶ G.obj (SingleObj.star α))
-    (h : ∀ a : α, F.map a ≫ u = u ≫ G.map a) : F ⟶ G where
+def natTrans {F G : SingleObj M ⥤ C} (u : F.obj (SingleObj.star M) ⟶ G.obj (SingleObj.star M))
+    (h : ∀ a : M, F.map a ≫ u = u ≫ G.map a) : F ⟶ G where
   app _ := u
   naturality _ _ a := h a
 
@@ -183,49 +188,52 @@ open CategoryTheory
 
 namespace MonoidHom
 
-/-- Reinterpret a monoid homomorphism `f : α → β` as a functor `(single_obj α) ⥤ (single_obj β)`.
+variable {M : Type u} {N : Type v} [Monoid M] [Monoid N]
+
+/-- Reinterpret a monoid homomorphism `f : M → N` as a functor `(single_obj M) ⥤ (single_obj N)`.
 See also `CategoryTheory.SingleObj.mapHom` for an equivalence between these types. -/
 @[reducible]
-def toFunctor {α : Type u} {β : Type v} [Monoid α] [Monoid β] (f : α →* β) :
-    SingleObj α ⥤ SingleObj β :=
-  SingleObj.mapHom α β f
+def toFunctor (f : M →* N) : SingleObj M ⥤ SingleObj N :=
+  SingleObj.mapHom M N f
 #align monoid_hom.to_functor MonoidHom.toFunctor
 
 @[simp]
-theorem id_toFunctor (α : Type u) [Monoid α] : (id α).toFunctor = 𝟭 _ :=
-  rfl
-#align monoid_hom.id_to_functor MonoidHom.id_toFunctor
-
-@[simp]
-theorem comp_toFunctor {α : Type u} {β : Type v} [Monoid α] [Monoid β] (f : α →* β) {γ : Type w}
-    [Monoid γ] (g : β →* γ) : (g.comp f).toFunctor = f.toFunctor ⋙ g.toFunctor :=
+theorem comp_toFunctor (f : M →* N) {P : Type w} [Monoid P] (g : N →* P) :
+    (g.comp f).toFunctor = f.toFunctor ⋙ g.toFunctor :=
   rfl
 #align monoid_hom.comp_to_functor MonoidHom.comp_toFunctor
+
+variable (M)
+
+@[simp]
+theorem id_toFunctor : (id M).toFunctor = 𝟭 _ :=
+  rfl
+#align monoid_hom.id_to_functor MonoidHom.id_toFunctor
 
 end MonoidHom
 
 namespace Units
 
-variable (α : Type u) [Monoid α]
+variable (M : Type u) [Monoid M]
 
 -- porting note: it was necessary to add `by exact` in this definition, presumably
--- so that Lean4 is not confused by the fact that `α` has two opposite multiplications
+-- so that Lean4 is not confused by the fact that `M` has two opposite multiplications
 /-- The units in a monoid are (multiplicatively) equivalent to
 the automorphisms of `star` when we think of the monoid as a single-object category. -/
-def toAut : αˣ ≃* Aut (SingleObj.star α) :=
-  MulEquiv.trans (Units.mapEquiv (by exact SingleObj.toEnd α))
-    (Aut.unitsEndEquivAut (SingleObj.star α))
+def toAut : Mˣ ≃* Aut (SingleObj.star M) :=
+  MulEquiv.trans (Units.mapEquiv (by exact SingleObj.toEnd M))
+    (Aut.unitsEndEquivAut (SingleObj.star M))
 set_option linter.uppercaseLean3 false in
 #align units.to_Aut Units.toAut
 
 @[simp]
-theorem toAut_hom (x : αˣ) : (toAut α x).hom = SingleObj.toEnd α x :=
+theorem toAut_hom (x : Mˣ) : (toAut M x).hom = SingleObj.toEnd M x :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align units.to_Aut_hom Units.toAut_hom
 
 @[simp]
-theorem toAut_inv (x : αˣ) : (toAut α x).inv = SingleObj.toEnd α (x⁻¹ : αˣ) :=
+theorem toAut_inv (x : Mˣ) : (toAut M x).inv = SingleObj.toEnd M (x⁻¹ : Mˣ) :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align units.to_Aut_inv Units.toAut_inv

--- a/Mathlib/CategoryTheory/SingleObj.lean
+++ b/Mathlib/CategoryTheory/SingleObj.lean
@@ -212,25 +212,25 @@ theorem id_toFunctor : (id M).toFunctor = 𝟭 _ :=
 
 end MonoidHom
 
-namespace SingleObj
+namespace MulEquiv
 
 variable {M : Type u} {N : Type v} [Monoid M] [Monoid N]
 
 /-- Reinterpret a monoid isomorphism `f : M ≃* N` as an equivalence `SingleObj M ≌ SingleObj N`. -/
 @[simps!]
-def toSingleObjEquiv (e : M ≃* N) : SingleObj M ≌ SingleObj N := by
-  apply CategoryTheory.Equivalence.mk
-  show _ ≅ MonoidHom.toFunctor e.toMonoidHom ⋙ MonoidHom.toFunctor e.symm.toMonoidHom
-  dsimp [MonoidHom.toFunctor, SingleObj.mapHom, Functor.comp]
-  apply eqToIso
-  simp only [MulEquiv.symm_apply_apply]
-  rfl
-  dsimp [MonoidHom.toFunctor, SingleObj.mapHom, Functor.comp]
-  apply eqToIso
-  simp only [MulEquiv.apply_symm_apply]
-  rfl
+def toSingleObjEquiv (e : M ≃* N) : SingleObj M ≌ SingleObj N where
+  functor := e.toMonoidHom.toFunctor
+  inverse := e.symm.toMonoidHom.toFunctor
+  unitIso := eqToIso (by
+    rw [← MonoidHom.comp_toFunctor, ← MonoidHom.id_toFunctor]
+    congr 1
+    aesop_cat)
+  counitIso := eqToIso (by
+    rw [← MonoidHom.comp_toFunctor, ← MonoidHom.id_toFunctor]
+    congr 1
+    aesop_cat)
 
-end SingleObj
+end MulEquiv
 
 namespace Units
 

--- a/Mathlib/CategoryTheory/SingleObj.lean
+++ b/Mathlib/CategoryTheory/SingleObj.lean
@@ -212,6 +212,26 @@ theorem id_toFunctor : (id M).toFunctor = 𝟭 _ :=
 
 end MonoidHom
 
+namespace SingleObj
+
+variable {M : Type u} {N : Type v} [Monoid M] [Monoid N]
+
+/-- Reinterpret a monoid isomorphism `f : M ≃* N` as an equivalence `SingleObj M ≌ SingleObj N`. -/
+@[simps!]
+def toSingleObjEquiv (e : M ≃* N) : SingleObj M ≌ SingleObj N := by
+  apply CategoryTheory.Equivalence.mk
+  show _ ≅ MonoidHom.toFunctor e.toMonoidHom ⋙ MonoidHom.toFunctor e.symm.toMonoidHom
+  dsimp [MonoidHom.toFunctor, SingleObj.mapHom, Functor.comp]
+  apply eqToIso
+  simp only [MulEquiv.symm_apply_apply]
+  rfl
+  dsimp [MonoidHom.toFunctor, SingleObj.mapHom, Functor.comp]
+  apply eqToIso
+  simp only [MulEquiv.apply_symm_apply]
+  rfl
+
+end SingleObj
+
 namespace Units
 
 variable (M : Type u) [Monoid M]


### PR DESCRIPTION
Construct `SingleObj M ≌ SingleObj N` from `M ≃* N`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Note that this definition can't be moved up into the first `namespace SingleObj` block, because the `MonoidHom.toFunctor` needs to come first.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
