### PR TITLE
[Merged by Bors] - feat(CategoryTheory): prerequisites for the existence of finite products in localized categories

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -187,6 +187,8 @@ theorem right_triangle : whiskerLeft G adj.unit ≫ whiskerRight adj.counit G = 
   simp
 #align category_theory.adjunction.right_triangle CategoryTheory.Adjunction.right_triangle
 
+variable (X Y)
+
 @[reassoc (attr := simp)]
 theorem left_triangle_components :
     F.map (adj.unit.app X) ≫ adj.counit.app (F.obj X) = 𝟙 (F.obj X) :=
@@ -194,10 +196,12 @@ theorem left_triangle_components :
 #align category_theory.adjunction.left_triangle_components CategoryTheory.Adjunction.left_triangle_components
 
 @[reassoc (attr := simp)]
-theorem right_triangle_components {Y : D} :
+theorem right_triangle_components :
     adj.unit.app (G.obj Y) ≫ G.map (adj.counit.app Y) = 𝟙 (G.obj Y) :=
   congr_arg (fun t : NatTrans _ (G ⋙ 𝟭 C) => t.app Y) adj.right_triangle
 #align category_theory.adjunction.right_triangle_components CategoryTheory.Adjunction.right_triangle_components
+
+variable {X Y}
 
 @[reassoc (attr := simp)]
 theorem counit_naturality {X Y : D} (f : X ⟶ Y) :

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -91,7 +91,7 @@ by L whiskered with the counit. -/
 @[simp]
 theorem inv_map_unit {X : C} [IsIso (h.unit.app X)] :
     inv (L.map (h.unit.app X)) = h.counit.app (L.obj X) :=
-  IsIso.inv_eq_of_hom_inv_id h.left_triangle_components
+  IsIso.inv_eq_of_hom_inv_id (h.left_triangle_components X)
 #align category_theory.inv_map_unit CategoryTheory.inv_map_unit
 
 /-- If the unit is an isomorphism, bundle one has an isomorphism `L ⋙ R ⋙ L ≅ L`. -/
@@ -106,7 +106,7 @@ by R whiskered with the unit. -/
 @[simp]
 theorem inv_counit_map {X : D} [IsIso (h.counit.app X)] :
     inv (R.map (h.counit.app X)) = h.unit.app (R.obj X) :=
-  IsIso.inv_eq_of_inv_hom_id h.right_triangle_components
+  IsIso.inv_eq_of_inv_hom_id (h.right_triangle_components X)
 #align category_theory.inv_counit_map CategoryTheory.inv_counit_map
 
 /-- If the counit of an is an isomorphism, one has an isomorphism `(R ⋙ L ⋙ R) ≅ R`. -/

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -135,12 +135,12 @@ notation A " ⟶[" C "] " B:10 => (@ihom C _ _ A _).obj B
 
 @[reassoc (attr := simp)]
 theorem ev_coev : (𝟙 A ⊗ (coev A).app B) ≫ (ev A).app (A ⊗ B) = 𝟙 (A ⊗ B) :=
-  Adjunction.left_triangle_components (ihom.adjunction A)
+  Adjunction.left_triangle_components (ihom.adjunction A) _
 #align category_theory.ihom.ev_coev CategoryTheory.ihom.ev_coev
 
 @[reassoc (attr := simp)]
 theorem coev_ev : (coev A).app (A ⟶[C] B) ≫ (ihom A).map ((ev A).app B) = 𝟙 (A ⟶[C] B) :=
-  Adjunction.right_triangle_components (ihom.adjunction A)
+  Adjunction.right_triangle_components (ihom.adjunction A) _
 #align category_theory.ihom.coev_ev CategoryTheory.ihom.coev_ev
 
 end ihom

--- a/Mathlib/CategoryTheory/DiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/DiscreteCategory.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stephen Morgan, Scott Morrison, Floris van Doorn
 -/
 import Mathlib.CategoryTheory.EqToHom
+import Mathlib.CategoryTheory.Pi.Basic
 import Mathlib.Data.ULift
 
 #align_import category_theory.discrete_category from "leanprover-community/mathlib"@"369525b73f229ccd76a6ec0e0e0bf2be57599768"
@@ -295,5 +296,23 @@ theorem functor_map_id (F : Discrete J ⥤ C) {j : Discrete J} (f : j ⟶ j) :
 #align category_theory.discrete.functor_map_id CategoryTheory.Discrete.functor_map_id
 
 end Discrete
+
+/-- The equivalence of categories `(J → C) ≌ (Discrete J ⥤ C)`. -/
+@[simps]
+def piEquivalenceFunctorDiscrete (J : Type u₂) (C : Type u₁) [Category.{v₁} C] :
+    (J → C) ≌ (Discrete J ⥤ C) where
+  functor :=
+    { obj := fun F => Discrete.functor F
+      map := fun f => Discrete.natTrans (fun j => f j.as) }
+  inverse :=
+    { obj := fun F j => F.obj ⟨j⟩
+      map := fun f j => f.app ⟨j⟩ }
+  unitIso := Iso.refl _
+  counitIso := NatIso.ofComponents (fun F => (NatIso.ofComponents (fun j => Iso.refl _)
+    (by
+      rintro ⟨x⟩ ⟨y⟩ f
+      obtain rfl : x = y := Discrete.eq_of_hom f
+      obtain rfl : f = 𝟙 _ := rfl
+      simp))) (by aesop_cat)
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Functor/Const.lean
+++ b/Mathlib/CategoryTheory/Functor/Const.lean
@@ -104,6 +104,15 @@ def constComp (X : C) (F : C ⥤ D) : (const J).obj X ⋙ F ≅ (const J).obj (F
 instance [Nonempty J] : Faithful (const J : C ⥤ J ⥤ C) where
   map_injective e := NatTrans.congr_app e (Classical.arbitrary J)
 
+/-- The canonical isomorphism
+`F ⋙ Functor.const J ≅ Functor.const F ⋙ (whiskeringRight J _ _).obj L`. -/
+@[simps!]
+def compConstIso (F : C ⥤ D) :
+    F ⋙ Functor.const J ≅ Functor.const J ⋙ (whiskeringRight J C D).obj F :=
+  NatIso.ofComponents
+    (fun X => NatIso.ofComponents (fun j => Iso.refl _) (by aesop_cat))
+    (by aesop_cat)
+
 end
 
 end CategoryTheory.Functor

--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -607,6 +607,37 @@ instance limMap_mono {F G : J ⥤ C} [HasLimit F] [HasLimit G] (α : F ⟶ G) [�
     limit.hom_ext fun j => (cancel_mono (α.app j)).1 <| by simpa using h =≫ limit.π _ j⟩
 #align category_theory.limits.lim_map_mono CategoryTheory.Limits.limMap_mono
 
+section Adjunction
+
+variable {L : (J ⥤ C) ⥤ C} (adj : Functor.const _ ⊣ L)
+
+/- The fact that the existence of limits of shape `J` is equivalent to the existence
+of a right adjoint to the constant functor `C ⥤ (J ⥤ C)` is obtained in
+the file `Mathlib.CategoryTheory.Limits.ConeCategory`: see the lemma
+`hasLimitsOfShape_iff_isLeftAdjoint_const`. In the definitions below, given an
+adjunction `adj : Functor.const _ ⊣ (L : (J ⥤ C) ⥤ C)`, we directly construct
+a limit cone for any `F : J ⥤ C`. -/
+
+/-- The limit cone obtained from a right adjoint of the constant functor. -/
+@[simps]
+noncomputable def coneOfAdj (F : J ⥤ C) : Cone F where
+  pt := L.obj F
+  π := adj.counit.app F
+
+/-- The cones defined by `coneOfAdj` are limit cones. -/
+@[simps]
+def isLimitConeOfAdj (F : J ⥤ C) :
+    IsLimit (coneOfAdj adj F) where
+  lift s := adj.homEquiv _ _ s.π
+  fac s j := by
+    have eq := NatTrans.congr_app (adj.counit.naturality s.π) j
+    have eq' := NatTrans.congr_app (adj.left_triangle_components s.pt) j
+    dsimp at eq eq' ⊢
+    rw [Adjunction.homEquiv_unit, assoc, eq, reassoc_of% eq']
+  uniq s m hm := (adj.homEquiv _ _).symm.injective (by ext j; simpa using hm j)
+
+end Adjunction
+
 /-- We can transport limits of shape `J` along an equivalence `J ≌ J'`.
 -/
 theorem hasLimitsOfShape_of_equivalence {J' : Type u₂} [Category.{v₂} J'] (e : J ≌ J')

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -340,6 +340,50 @@ abbrev Pi.mapIso {f g : β → C} [HasProductsOfShape β C] (p : ∀ b, f b ≅ 
   lim.mapIso (Discrete.natIso fun X => p X.as)
 #align category_theory.limits.pi.map_iso CategoryTheory.Limits.Pi.mapIso
 
+section
+
+/- In this section, we provide some API for products when we are given a functor
+`Discrete α ⥤ C` instead of a map `α → C`. -/
+
+variable (X : Discrete α ⥤ C) [HasProduct (fun j => X.obj (Discrete.mk j))]
+
+/-- A limit cone for `X : Discrete α ⥤ C` that is given
+by `∏ (fun j => X.obj (Discrete.mk j))`. -/
+@[simps]
+def Pi.cone : Cone X where
+  pt := ∏ (fun j => X.obj (Discrete.mk j))
+  π := Discrete.natTrans (fun _ => Pi.π _ _)
+
+/-- The cone `Pi.cone X` is a limit cone. -/
+def productIsProduct' :
+    IsLimit (Pi.cone X) where
+  lift s := Pi.lift (fun j => s.π.app ⟨j⟩)
+  fac s := by simp
+  uniq s m hm := by
+    dsimp
+    ext
+    simp only [limit.lift_π, Fan.mk_pt, Fan.mk_π_app]
+    apply hm
+
+variable [HasLimit X]
+
+/-- The isomorphism `∏ (fun j => X.obj (Discrete.mk j)) ≅ limit X`. -/
+def Pi.isoLimit :
+    ∏ (fun j => X.obj (Discrete.mk j)) ≅ limit X :=
+  IsLimit.conePointUniqueUpToIso (productIsProduct' X) (limit.isLimit X)
+
+@[reassoc (attr := simp)]
+lemma Pi.isoLimit_inv_π (j : α) :
+    (Pi.isoLimit X).inv ≫ Pi.π _ j = limit.π _ (Discrete.mk j) :=
+  IsLimit.conePointUniqueUpToIso_inv_comp _ _ _
+
+@[reassoc (attr := simp)]
+lemma Pi.isoLimit_hom_π (j : α) :
+    (Pi.isoLimit X).hom ≫ limit.π _ (Discrete.mk j) = Pi.π _ j :=
+  IsLimit.conePointUniqueUpToIso_hom_comp _ _ _
+
+end
+
 /-- Construct a morphism between categorical coproducts (indexed by the same type)
 from a family of morphisms between the factors.
 -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Reflexive.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Reflexive.lean
@@ -129,7 +129,7 @@ instance (B : D) :
     (by
       rw [← F.map_comp, adj.right_triangle_components]
       apply F.map_id)
-    adj.left_triangle_components
+    (adj.left_triangle_components _)
 
 namespace Limits
 

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -318,7 +318,7 @@ theorem IsUniversalColimit.map_reflective
   have hadj : ∀ X, Gl.map (adj.unit.app X) = inv (adj.counit.app _)
   · intro X
     apply IsIso.eq_inv_of_inv_hom_id
-    exact adj.left_triangle_components
+    exact adj.left_triangle_components _
   haveI : ∀ X, IsIso (Gl.map (adj.unit.app X)) := by
     simp_rw [hadj]
     infer_instance

--- a/Mathlib/CategoryTheory/MorphismProperty.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty.lean
@@ -963,6 +963,61 @@ lemma IsInvertedBy.pi (F : ∀ j, C j ⥤ D j) (hF : ∀ j, (W j).IsInvertedBy (
 
 end
 
+section
+
+variable (W : MorphismProperty C)
+
+/-- The morphism property on `J ⥤ C` which is defined objectwise
+from `W : MorphismProperty C`. -/
+def functorCategory (J : Type*) [Category J] : MorphismProperty (J ⥤ C) :=
+  fun _ _ f => ∀ (j : J), W (f.app j)
+
+/-- The property that a morphism property `W` is stable under limits
+indexed by a category `J`. -/
+def IsStableUnderLimitsOfShape (J : Type*) [Category J] : Prop :=
+  ∀ (X₁ X₂ : J ⥤ C) (c₁ : Cone X₁) (c₂ : Cone X₂)
+    (_ : IsLimit c₁) (h₂ : IsLimit c₂) (f : X₁ ⟶ X₂) (_ : W.functorCategory J f),
+      W (h₂.lift (Cone.mk _ (c₁.π ≫ f)))
+
+variable {W}
+
+lemma IsStableUnderLimitsOfShape.lim_map {J : Type*} [Category J]
+    (hW : W.IsStableUnderLimitsOfShape J) {X Y : J ⥤ C}
+    (f : X ⟶ Y) [HasLimitsOfShape J C] (hf : W.functorCategory _ f) :
+    W (lim.map f) :=
+  hW X Y _ _ (limit.isLimit X) (limit.isLimit Y) f hf
+
+variable (W)
+
+/-- The property that a morphism property `W` is stable under products indexed by a type `J`. -/
+abbrev IsStableUnderProductsOfShape (J : Type*) := W.IsStableUnderLimitsOfShape (Discrete J)
+
+lemma IsStableUnderProductsOfShape.mk (J : Type*)
+    (hW₀ : W.RespectsIso) [HasProductsOfShape J C]
+    (hW : ∀ (X₁ X₂ : J → C) (f : ∀ j, X₁ j ⟶ X₂ j) (_ : ∀ (j : J), W (f j)),
+      W (Pi.map f)) : W.IsStableUnderProductsOfShape J := by
+  intro X₁ X₂ c₁ c₂ hc₁ hc₂ f hf
+  let φ := fun j => f.app (Discrete.mk j)
+  have hf' := hW _ _ φ (fun j => hf (Discrete.mk j))
+  refine' (hW₀.arrow_mk_iso_iff _).2 hf'
+  refine' Arrow.isoMk
+    (IsLimit.conePointUniqueUpToIso hc₁ (limit.isLimit X₁) ≪≫ (Pi.isoLimit _).symm)
+    (IsLimit.conePointUniqueUpToIso hc₂ (limit.isLimit X₂) ≪≫ (Pi.isoLimit _).symm) _
+  apply limit.hom_ext
+  rintro ⟨j⟩
+  simp
+
+/-- The condition that a property of morphisms is stable by finite products. -/
+class IsStableUnderFiniteProducts : Prop :=
+  isStableUnderProductsOfShape (J : Type) [Finite J] : W.IsStableUnderProductsOfShape J
+
+lemma isStableUnderProductsOfShape_of_isStableUnderFiniteProducts
+    (J : Type) [Finite J] [W.IsStableUnderFiniteProducts] :
+    W.IsStableUnderProductsOfShape J :=
+  IsStableUnderFiniteProducts.isStableUnderProductsOfShape J
+
+end
+
 end MorphismProperty
 
 end CategoryTheory


### PR DESCRIPTION
This PR contains various prerequisites in order to show that under suitable assumptions, a localized category of a category that has finite products also has finite products:
* the equivalence of categories `(J → C) ≌ (Discrete J ⥤ C)`
* more API for the existence of limits as a consequence of a right adjoint to the constant functor `C ⥤ (J ⥤ C)`.
* the typeclass `MorphismProperty.IsStableUnderFiniteProducts`

---

The following PR is #9692.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
