### PR TITLE
[Merged by Bors] - chore(Init/Function): deprecate 3 definitions

### DIFF
--- a/Mathlib/Init/Function.lean
+++ b/Mathlib/Init/Function.lean
@@ -39,11 +39,11 @@ def dcomp {β : α → Sort u₂} {φ : ∀ {x : α}, β x → Sort u₃} (f : �
 
 infixr:80 " ∘' " => Function.dcomp
 
-@[reducible]
+@[reducible, deprecated] -- Deprecated since 13 January 2024
 def compRight (f : β → β → β) (g : α → β) : β → α → β := fun b a => f b (g a)
 #align function.comp_right Function.compRight
 
-@[reducible]
+@[reducible, deprecated] -- Deprecated since 13 January 2024
 def compLeft (f : β → β → β) (g : α → β) : α → β → β := fun a b => f (g a) b
 #align function.comp_left Function.compLeft
 
@@ -54,13 +54,16 @@ from `β` to `α`. -/
 def onFun (f : β → β → φ) (g : α → β) : α → α → φ := fun x y => f (g x) (g y)
 #align function.on_fun Function.onFun
 
+@[inherit_doc onFun]
+infixl:2 " on " => onFun
+
 /-- Given functions `f : α → β → φ`, `g : α → β → δ` and a binary operator `op : φ → δ → ζ`,
 produce a function `α → β → ζ` that applies `f` and `g` on each argument and then applies
 `op` to the results.
 -/
 -- Porting note: the ζ variable was originally constrained to `Sort u₁`, but this seems to
 -- have been an oversight.
-@[reducible]
+@[reducible, deprecated] -- Deprecated since 13 January 2024
 def combine (f : α → β → φ) (op : φ → δ → ζ) (g : α → β → δ) : α → β → ζ := fun x y =>
   op (f x y) (g x y)
 #align function.combine Function.combine
@@ -71,13 +74,10 @@ def combine (f : α → β → φ) (op : φ → δ → ζ) (g : α → β → δ
 def swap {φ : α → β → Sort u₃} (f : ∀ x y, φ x y) : ∀ y x, φ x y := fun y x => f x y
 #align function.swap Function.swap
 
-@[reducible]
+@[reducible, deprecated] -- Deprecated since 13 January 2024
 def app {β : α → Sort u₂} (f : ∀ x, β x) (x : α) : β x :=
   f x
 #align function.app Function.app
-
-@[inherit_doc onFun]
-infixl:2 " on " => onFun
 
 -- porting note: removed, it was never used
 -- notation f " -[" op "]- " g => combine f op g


### PR DESCRIPTION
Deprecate `Function.compLeft`, `Function.compRight`,
and `Function.combine`.

None of them are used anywhere in Mathlib,
and for the first two it's easier to use `(· ∘ f)` or `(f ∘ ·)`.

Also move notation ` on ` closer to the definition of `Function.onFun`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)