### PR TITLE
[Merged by Bors] - chore: Move `Int.pow_right_injective`

### DIFF
--- a/Mathlib/Algebra/GroupPower/Lemmas.lean
+++ b/Mathlib/Algebra/GroupPower/Lemmas.lean
@@ -554,14 +554,6 @@ theorem le_self_sq (b : ℤ) : b ≤ b ^ 2 :=
 alias le_self_pow_two := le_self_sq
 #align int.le_self_pow_two Int.le_self_pow_two
 
-theorem pow_right_injective {x : ℤ} (h : 1 < x.natAbs) :
-    Function.Injective ((x ^ ·) : ℕ → ℤ) := by
-  suffices Function.Injective (natAbs ∘ (x ^ · : ℕ → ℤ)) by
-    exact Function.Injective.of_comp this
-  convert Nat.pow_right_injective h using 2
-  rw [Function.comp_apply, natAbs_pow]
-#align int.pow_right_injective Int.pow_right_injective
-
 end Int
 
 variable (M G A)

--- a/Mathlib/Data/Int/Order/Lemmas.lean
+++ b/Mathlib/Data/Int/Order/Lemmas.lean
@@ -4,20 +4,19 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
 import Mathlib.Data.Int.Order.Basic
-import Mathlib.Algebra.GroupWithZero.Divisibility
-import Mathlib.Algebra.Order.Ring.Abs
+import Mathlib.Data.Nat.Pow
 
 #align_import data.int.order.lemmas from "leanprover-community/mathlib"@"fc2ed6f838ce7c9b7c7171e58d78eaf7b438fb0e"
 
 /-!
 # Further lemmas about the integers
+
 The distinction between this file and `Data.Int.Order.Basic` is not particularly clear.
 They are separated by now to minimize the porting requirements for tactics during the transition to
-mathlib4. After `data.rat.order` has been ported, please feel free to reorganize these two files.
+mathlib4. Now that `Data.Rat.Order` has been ported, please feel free to reorganize these two files.
 -/
 
-
-open Nat
+open Function Nat
 
 namespace Int
 
@@ -50,6 +49,12 @@ theorem dvd_div_of_mul_dvd {a b c : ℤ} (h : a * b ∣ c) : b ∣ c / a := by
   refine' ⟨d, _⟩
   rw [mul_assoc, Int.mul_ediv_cancel_left _ ha]
 #align int.dvd_div_of_mul_dvd Int.dvd_div_of_mul_dvd
+
+lemma pow_right_injective (h : 1 < a.natAbs) : Injective ((a ^ ·) : ℕ → ℤ) := by
+  refine (?_ : Injective (natAbs ∘ (a ^ · : ℕ → ℤ))).of_comp
+  convert Nat.pow_right_injective h using 2
+  rw [Function.comp_apply, natAbs_pow]
+#align int.pow_right_injective Int.pow_right_injective
 
 /-! ### units -/
 

--- a/Mathlib/GroupTheory/Submonoid/Membership.lean
+++ b/Mathlib/GroupTheory/Submonoid/Membership.lean
@@ -6,6 +6,7 @@ Amelia Livingston, Yury Kudryashov
 -/
 import Mathlib.Algebra.FreeMonoid.Basic
 import Mathlib.Data.Finset.NoncommProd
+import Mathlib.Data.Int.Order.Lemmas
 import Mathlib.GroupTheory.Submonoid.Operations
 
 #align_import group_theory.submonoid.membership from "leanprover-community/mathlib"@"e655e4ea5c6d02854696f97494997ba4c31be802"


### PR DESCRIPTION
This allows more files to not depend on `Algebra.GroupPower.Lemmas`, which will soon stop existing.

Part of #9411

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
