### PR TITLE
[Merged by Bors] - refactor: Clean up `posPart`

### DIFF
--- a/Mathlib/Algebra/Order/Group/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Abs.lean
@@ -502,5 +502,27 @@ theorem max_zero_add_max_neg_zero_eq_abs_self (a : α) : max a 0 + max (-a) 0 = 
 
 end LinearOrderedAddCommGroup
 
+namespace LatticeOrderedAddCommGroup
+variable [Lattice α] [AddCommGroup α] {s t : Set α}
+
+/-- A set `s` in a lattice ordered group is *solid* if for all `x ∈ s` and all `y ∈ α` such that
+`|y| ≤ |x|`, then `y ∈ s`. -/
+def IsSolid (s : Set α) : Prop := ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, |y| ≤ |x| → y ∈ s
+#align lattice_ordered_add_comm_group.is_solid LatticeOrderedAddCommGroup.IsSolid
+
+/-- The solid closure of a subset `s` is the smallest superset of `s` that is solid. -/
+def solidClosure (s : Set α) : Set α := {y | ∃ x ∈ s, |y| ≤ |x|}
+#align lattice_ordered_add_comm_group.solid_closure LatticeOrderedAddCommGroup.solidClosure
+
+lemma isSolid_solidClosure (s : Set α) : IsSolid (solidClosure s) :=
+  fun _ ⟨y, hy, hxy⟩ _ hzx ↦ ⟨y, hy, hzx.trans hxy⟩
+#align lattice_ordered_add_comm_group.is_solid_solid_closure LatticeOrderedAddCommGroup.isSolid_solidClosure
+
+lemma solidClosure_min (hst : s ⊆ t) (ht : IsSolid t) : solidClosure s ⊆ t :=
+  fun _ ⟨_, hy, hxy⟩ ↦ ht (hst hy) hxy
+#align lattice_ordered_add_comm_group.solid_closure_min LatticeOrderedAddCommGroup.solidClosure_min
+
+end LatticeOrderedAddCommGroup
+
 @[deprecated] alias neg_le_abs_self := neg_le_abs
 @[deprecated] alias neg_abs_le_self := neg_abs_le

--- a/Mathlib/Algebra/Order/Group/PosPart.lean
+++ b/Mathlib/Algebra/Order/Group/PosPart.lean
@@ -1,53 +1,36 @@
 /-
 Copyright (c) 2021 Christopher Hoskin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Christopher Hoskin
+Authors: Christopher Hoskin, Yaël Dillies
 -/
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Group.Lattice
-import Mathlib.Algebra.Module.Basic
-import Mathlib.Order.Closure
+import Mathlib.Tactic.LibrarySearch
 
 #align_import algebra.order.lattice_group from "leanprover-community/mathlib"@"5dc275ec639221ca4d5f56938eb966f6ad9bc89f"
 
 /-!
-# Lattice ordered groups
+# Positive & negative parts
 
-Lattice ordered groups were introduced by [Birkhoff][birkhoff1942].
-They form the algebraic underpinnings of vector lattices, Banach lattices, AL-space, AM-space etc.
+Mathematical structures possessing an absolute value often also possess a unique decomposition of
+elements into "positive" and "negative" parts which are in some sense "disjoint" (e.g. the Jordan
+decomposition of a measure).
 
-This file develops the basic theory.
+This file defines `posPart` and `negPart`, the positive and negative parts of an element in a
+lattice ordered group.
 
 ## Main statements
 
-- `pos_div_neg`: Every element `a` of a lattice ordered group has a decomposition `a⁺-a⁻` into the
-  difference of the positive and negative component.
-- `pos_inf_neg_eq_one`: The positive and negative components are coprime.
-- `abs_triangle`: The absolute value operation satisfies the triangle inequality (stated for a
-  commutative group).
-
-It is shown that the inf and sup operations are related to the absolute value operation by a
-number of equations and inequalities.
+* `posPart_sub_negPart`: Every element `a` can be decomposed into `a⁺ - a⁻`, the difference of its
+  positive and negative parts.
+* `posPart_inf_negPart_eq_zero`: The positive and negative parts are coprime.
 
 ## Notations
 
-- `a⁺ = a ⊔ 0`: The *positive component* of an element `a` of a lattice ordered group
-- `a⁻ = (-a) ⊔ 0`: The *negative component* of an element `a` of a lattice ordered group
-- `|a|ₘ = a⊔(-a)`: The *absolute value* of an element `a` of a lattice ordered group
-
-## Implementation notes
-
-A lattice ordered group is a type `α` satisfying:
-
-* `[Lattice α]`
-* `[CommGroup α]`
-* `[CovariantClass α α (*) (≤)]`
-* `[CovariantClass α α (swap (· * ·)) (· ≤ ·)]`
-
-The remainder of the file establishes basic properties of lattice ordered groups. It is shown that
-when the group is commutative, the lattice is distributive. This also holds in the non-commutative
-case ([Birkhoff][birkhoff1942],[Fuchs][fuchs1963]) but we do not yet have the machinery to establish
-this in Mathlib.
+* `a⁺ᵐ = a ⊔ 1`: *Positive component* of an element `a` of a multiplicative lattice ordered group
+* `a⁻ᵐ = a⁻¹ ⊔ 1`: *Negative component* of an element `a` of a multiplicative lattice ordered group
+* `a⁺ = a ⊔ 0`: *Positive component* of an element `a` of a lattice ordered group
+* `a⁻ = (-a) ⊔ 0`: *Negative component* of an element `a` of a lattice ordered group
 
 ## References
 
@@ -59,7 +42,7 @@ this in Mathlib.
 
 ## Tags
 
-lattice, ordered, group
+positive part, negative part
 -/
 
 /-- The positive part of an element admitting a decomposition into positive and negative parts.
@@ -90,328 +73,193 @@ universe u v
 
 variable {α : Type u} {β : Type v}
 
+section Lattice
+variable [Lattice α]
+
 section Group
+variable [Group α] [CovariantClass α α (· * ·) (· ≤ ·)]
+  [CovariantClass α α (swap (· * ·)) (· ≤ ·)] {a : α}
 
-variable [Lattice α] [Group α]
+#noalign lattice_ordered_comm_group.has_one_lattice_has_pos_part
+#noalign lattice_ordered_comm_group.has_zero_lattice_has_pos_part
+#noalign lattice_ordered_comm_group.has_one_lattice_has_neg_part
+#noalign lattice_ordered_comm_group.has_zero_lattice_has_neg_part
 
-namespace LatticeOrderedGroup
+/-- The *positive part* of an element `a` in a lattice ordered group is `a ⊔ 1`, denoted `a⁺ᵐ`. -/
+@[to_additive
+"The *positive part* of an element `a` in a lattice ordered group is `a ⊔ 0`, denoted `a⁺`."]
+def oneLePart (a : α) : α := a ⊔ 1
+#align lattice_ordered_comm_group.m_pos_part_def oneLePart
+#align lattice_ordered_comm_group.pos_part_def posPart
+#align has_pos_part.pos posPart
 
--- see Note [lower instance priority]
-/--
-Let `α` be a lattice ordered commutative group with identity `1`. For an element `a` of type `α`,
-the element `a ⊔ 1` is said to be the *positive component* of `a`, denoted `a⁺`.
+/-- The *negative part* of an element `a` in a lattice ordered group is `a⁻¹ ⊔ 1`, denoted `a⁻ᵐ `.
 -/
 @[to_additive
-      "Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type
-      `α`,the element `a ⊔ 0` is said to be the *positive component* of `a`, denoted `a⁺`."]
-instance (priority := 100) hasOneLatticeHasPosPart : PosPart α :=
-  ⟨fun a => a ⊔ 1⟩
-#align lattice_ordered_comm_group.has_one_lattice_has_pos_part LatticeOrderedGroup.hasOneLatticeHasPosPart
-#align lattice_ordered_comm_group.has_zero_lattice_has_pos_part LatticeOrderedGroup.hasZeroLatticeHasPosPart
+"The *negative part* of an element `a` in a lattice ordered group is `(-a) ⊔ 0`, denoted `a⁻`."]
+def leOnePart (a : α) : α := a⁻¹ ⊔ 1
+#align lattice_ordered_comm_group.m_neg_part_def leOnePart
+#align lattice_ordered_comm_group.neg_part_def negPart
+#align has_neg_part.neg negPart
 
-@[to_additive pos_part_def]
-theorem m_pos_part_def (a : α) : a⁺ = a ⊔ 1 :=
-  rfl
-#align lattice_ordered_comm_group.m_pos_part_def LatticeOrderedGroup.m_pos_part_def
-#align lattice_ordered_comm_group.pos_part_def LatticeOrderedGroup.pos_part_def
+@[inherit_doc] postfix:max "⁺ᵐ " => oneLePart
+@[inherit_doc] postfix:max "⁻ᵐ" => leOnePart
+@[inherit_doc] postfix:max "⁺" => posPart
+@[inherit_doc] postfix:max "⁻" => negPart
 
--- see Note [lower instance priority]
-/--
-Let `α` be a lattice ordered commutative group with identity `1`. For an element `a` of type `α`,
-the element `(-a) ⊔ 1` is said to be the *negative component* of `a`, denoted `a⁻`.
--/
-@[to_additive
-      "Let `α` be a lattice ordered commutative group with identity `0`. For an element `a` of type
-      `α`, the element `(-a) ⊔ 0` is said to be the *negative component* of `a`, denoted `a⁻`."]
-instance (priority := 100) hasOneLatticeHasNegPart : NegPart α :=
-  ⟨fun a => a⁻¹ ⊔ 1⟩
-#align lattice_ordered_comm_group.has_one_lattice_has_neg_part LatticeOrderedGroup.hasOneLatticeHasNegPart
-#align lattice_ordered_comm_group.has_zero_lattice_has_neg_part LatticeOrderedGroup.hasZeroLatticeHasNegPart
+@[to_additive] lemma oneLePart_mono : Monotone (oneLePart : α → α) :=
+  fun _a _b hab ↦ sup_le_sup_right hab _
 
-@[to_additive neg_part_def]
-theorem m_neg_part_def (a : α) : a⁻ = a⁻¹ ⊔ 1 :=
-  rfl
-#align lattice_ordered_comm_group.m_neg_part_def LatticeOrderedGroup.m_neg_part_def
-#align lattice_ordered_comm_group.neg_part_def LatticeOrderedGroup.neg_part_def
+@[to_additive] lemma leOnePart_anti : Antitone (leOnePart : α → α) :=
+  fun _a _b hab ↦ sup_le_sup_right (inv_le_inv_iff.2 hab) _
 
-@[to_additive (attr := simp)]
-theorem pos_one : (1 : α)⁺ = 1 :=
-  sup_idem
-#align lattice_ordered_comm_group.pos_one LatticeOrderedGroup.pos_one
-#align lattice_ordered_comm_group.pos_zero LatticeOrderedGroup.pos_zero
+@[to_additive (attr := simp)] lemma oneLePart_one : (1 : α)⁺ᵐ = 1 := sup_idem
+#align lattice_ordered_comm_group.pos_one oneLePart_one
+#align lattice_ordered_comm_group.pos_zero posPart_zero
 
-@[to_additive (attr := simp)]
-theorem neg_one : (1 : α)⁻ = 1 := by rw [m_neg_part_def, inv_one, sup_idem]
-#align lattice_ordered_comm_group.neg_one LatticeOrderedGroup.neg_one
-#align lattice_ordered_comm_group.neg_zero LatticeOrderedGroup.neg_zero
+@[to_additive (attr := simp)] lemma leOnePart_one : (1 : α)⁻ᵐ = 1 := by simp [leOnePart]
+#align lattice_ordered_comm_group.neg_one leOnePart_one
+#align lattice_ordered_comm_group.neg_zero negPart_zero
 
--- a⁻ = -(a ⊓ 0)
+@[to_additive posPart_nonneg] lemma one_le_oneLePart (a : α) : 1 ≤ a⁺ᵐ := le_sup_right
+#align lattice_ordered_comm_group.one_le_pos one_le_oneLePart
+#align lattice_ordered_comm_group.pos_nonneg posPart_nonneg
+
+@[to_additive negPart_nonneg] lemma one_le_leOnePart (a : α) : 1 ≤ a⁻ᵐ := le_sup_right
+#align lattice_ordered_comm_group.one_le_neg one_le_leOnePart
+#align lattice_ordered_comm_group.neg_nonneg neg_nonneg
+
+-- TODO: `to_additive` guesses `nonposPart`
+@[to_additive le_posPart] lemma le_oneLePart (a : α) : a ≤ a⁺ᵐ := le_sup_left
+#align lattice_ordered_comm_group.m_le_pos le_oneLePart
+#align lattice_ordered_comm_group.le_pos le_posPart
+
+@[to_additive] lemma inv_le_leOnePart (a : α) : a⁻¹ ≤ a⁻ᵐ := le_sup_left
+#align lattice_ordered_comm_group.inv_le_neg inv_le_leOnePart
+#align lattice_ordered_comm_group.neg_le_neg neg_le_negPart
+
+@[to_additive] lemma oneLePart_eq_self : a⁺ᵐ = a ↔ 1 ≤ a := sup_eq_left
+#align lattice_ordered_comm_group.pos_of_one_le oneLePart_eq_self
+#align lattice_ordered_comm_group.pos_of_nonneg posPart_eq_self
+
+@[to_additive] lemma oneLePart_eq_one : a⁺ᵐ = 1 ↔ a ≤ 1 := sup_eq_right
+#align lattice_ordered_comm_group.pos_eq_one_iff oneLePart_eq_one
+#align lattice_ordered_comm_group.pos_eq_zero_iff posPart_eq_zero
+#align lattice_ordered_comm_group.pos_of_le_one oneLePart_eq_one
+#align lattice_ordered_comm_group.pos_of_nonpos posPart_eq_zero
+
+@[to_additive] lemma leOnePart_eq_inv' : a⁻ᵐ = a⁻¹ ↔ 1 ≤ a⁻¹ := sup_eq_left
+@[to_additive] lemma leOnePart_eq_inv : a⁻ᵐ = a⁻¹ ↔ a ≤ 1 := by simp [leOnePart]
+#align lattice_ordered_comm_group.neg_of_le_one leOnePart_eq_inv
+#align lattice_ordered_comm_group.neg_of_nonpos negPart_eq_neg
+#align lattice_ordered_comm_group.neg_of_one_le_inv leOnePart_eq_inv
+#align lattice_ordered_comm_group.neg_of_inv_nonneg negPart_eq_neg
+
+@[to_additive] lemma leOnePart_eq_one' : a⁻ᵐ = 1 ↔ a⁻¹ ≤ 1 := sup_eq_right
+#align lattice_ordered_comm_group.neg_eq_one_iff' leOnePart_eq_one'
+#align lattice_ordered_comm_group.neg_eq_zero_iff' negPart_eq_zero'
+#align lattice_ordered_comm_group.neg_of_inv_le_one leOnePart_eq_one'
+#align lattice_ordered_comm_group.neg_of_neg_nonpos negPart_eq_zero'
+
+@[to_additive] lemma leOnePart_eq_one : a⁻ᵐ = 1 ↔ 1 ≤ a := by
+  simp [leOnePart_eq_one']
+#align lattice_ordered_comm_group.neg_eq_one_iff leOnePart_eq_one
+#align lattice_ordered_comm_group.neg_eq_zero_iff negPart_eq_zero
+#align lattice_ordered_comm_group.neg_of_one_le leOnePart_eq_one
+#align lattice_ordered_comm_group.neg_of_nonneg negPart_eq_zero
+
+@[to_additive] lemma oneLePart_le_one : a⁺ᵐ ≤ 1 ↔ a ≤ 1 := by simp [oneLePart]
+#align lattice_ordered_comm_group.pos_le_one_iff oneLePart_le_one
+#align lattice_ordered_comm_group.pos_nonpos_iff posPart_nonpos
+
+@[to_additive] lemma leOnePart_le_one' : a⁻ᵐ ≤ 1 ↔ a⁻¹ ≤ 1 := by simp [leOnePart]
+#align lattice_ordered_comm_group.neg_le_one_iff leOnePart_le_one'
+#align lattice_ordered_comm_group.neg_nonpos_iff negPart_nonpos'
+
+@[to_additive (attr := simp)] lemma oneLePart_inv (a : α) : a⁻¹⁺ᵐ = a⁻ᵐ := rfl
+#align lattice_ordered_comm_group.neg_eq_pos_inv oneLePart_inv
+#align lattice_ordered_comm_group.neg_eq_pos_neg posPart_neg
+
+@[to_additive (attr := simp)] lemma leOnePart_inv (a : α) : a⁻¹⁻ᵐ = a⁺ᵐ := by
+  simp [oneLePart, leOnePart]
+#align lattice_ordered_comm_group.pos_eq_neg_inv leOnePart_inv
+#align lattice_ordered_comm_group.pos_eq_neg_neg negPart_neg
+
+@[to_additive] lemma leOnePart_le_one : a⁻ᵐ ≤ 1 ↔ a⁻¹ ≤ 1 := by simp [leOnePart]
+
 @[to_additive]
-theorem neg_eq_inv_inf_one
-    [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a : α) :
-    a⁻ = (a ⊓ 1)⁻¹ := by
-  rw [m_neg_part_def, ← inv_inj, inv_sup, inv_inv, inv_inv, inv_one]
-#align lattice_ordered_comm_group.neg_eq_inv_inf_one LatticeOrderedGroup.neg_eq_inv_inf_one
-#align lattice_ordered_comm_group.neg_eq_neg_inf_zero LatticeOrderedGroup.neg_eq_neg_inf_zero
-
--- 0 ≤ a⁺
-@[to_additive pos_nonneg]
-theorem one_le_pos (a : α) : 1 ≤ a⁺ :=
-  le_sup_right
-#align lattice_ordered_comm_group.one_le_pos LatticeOrderedGroup.one_le_pos
-#align lattice_ordered_comm_group.pos_nonneg LatticeOrderedGroup.pos_nonneg
-
--- 0 ≤ a⁻
-@[to_additive neg_nonneg]
-theorem one_le_neg (a : α) : 1 ≤ a⁻ :=
-  le_sup_right
-#align lattice_ordered_comm_group.one_le_neg LatticeOrderedGroup.one_le_neg
-#align lattice_ordered_comm_group.neg_nonneg LatticeOrderedGroup.neg_nonneg
-
--- pos_nonpos_iff
-@[to_additive]
-theorem pos_le_one_iff {a : α} : a⁺ ≤ 1 ↔ a ≤ 1 := by
-  rw [m_pos_part_def, sup_le_iff, and_iff_left le_rfl]
-#align lattice_ordered_comm_group.pos_le_one_iff LatticeOrderedGroup.pos_le_one_iff
-#align lattice_ordered_comm_group.pos_nonpos_iff LatticeOrderedGroup.pos_nonpos_iff
-
--- neg_nonpos_iff
-@[to_additive]
-theorem neg_le_one_iff {a : α} : a⁻ ≤ 1 ↔ a⁻¹ ≤ 1 := by
-  rw [m_neg_part_def, sup_le_iff, and_iff_left le_rfl]
-#align lattice_ordered_comm_group.neg_le_one_iff LatticeOrderedGroup.neg_le_one_iff
-#align lattice_ordered_comm_group.neg_nonpos_iff LatticeOrderedGroup.neg_nonpos_iff
-
-@[to_additive]
-theorem pos_eq_one_iff {a : α} : a⁺ = 1 ↔ a ≤ 1 :=
-  sup_eq_right
-#align lattice_ordered_comm_group.pos_eq_one_iff LatticeOrderedGroup.pos_eq_one_iff
-#align lattice_ordered_comm_group.pos_eq_zero_iff LatticeOrderedGroup.pos_eq_zero_iff
-
-@[to_additive]
-theorem neg_eq_one_iff' {a : α} : a⁻ = 1 ↔ a⁻¹ ≤ 1 :=
-  sup_eq_right
-#align lattice_ordered_comm_group.neg_eq_one_iff' LatticeOrderedGroup.neg_eq_one_iff'
-#align lattice_ordered_comm_group.neg_eq_zero_iff' LatticeOrderedGroup.neg_eq_zero_iff'
-
-@[to_additive]
-theorem neg_eq_one_iff [CovariantClass α α HMul.hMul LE.le] {a : α} : a⁻ = 1 ↔ 1 ≤ a := by
-  rw [le_antisymm_iff, neg_le_one_iff, inv_le_one', and_iff_left (one_le_neg _)]
-#align lattice_ordered_comm_group.neg_eq_one_iff LatticeOrderedGroup.neg_eq_one_iff
-#align lattice_ordered_comm_group.neg_eq_zero_iff LatticeOrderedGroup.neg_eq_zero_iff
-
-@[to_additive le_pos]
-theorem m_le_pos (a : α) : a ≤ a⁺ :=
-  le_sup_left
-#align lattice_ordered_comm_group.m_le_pos LatticeOrderedGroup.m_le_pos
-#align lattice_ordered_comm_group.le_pos LatticeOrderedGroup.le_pos
-
--- -a ≤ a⁻
-@[to_additive]
-theorem inv_le_neg (a : α) : a⁻¹ ≤ a⁻ :=
-  le_sup_left
-#align lattice_ordered_comm_group.inv_le_neg LatticeOrderedGroup.inv_le_neg
-#align lattice_ordered_comm_group.neg_le_neg LatticeOrderedGroup.neg_le_neg
-
--- Bourbaki A.VI.12
---  a⁻ = (-a)⁺
-@[to_additive]
-theorem neg_eq_pos_inv (a : α) : a⁻ = a⁻¹⁺ :=
-  rfl
-#align lattice_ordered_comm_group.neg_eq_pos_inv LatticeOrderedGroup.neg_eq_pos_inv
-#align lattice_ordered_comm_group.neg_eq_pos_neg LatticeOrderedGroup.neg_eq_pos_neg
-
--- a⁺ = (-a)⁻
-@[to_additive]
-theorem pos_eq_neg_inv (a : α) : a⁺ = a⁻¹⁻ := by rw [neg_eq_pos_inv, inv_inv]
-#align lattice_ordered_comm_group.pos_eq_neg_inv LatticeOrderedGroup.pos_eq_neg_inv
-#align lattice_ordered_comm_group.pos_eq_neg_neg LatticeOrderedGroup.pos_eq_neg_neg
+lemma leOnePart_eq_inv_inf_one (a : α) : a⁻ᵐ = (a ⊓ 1)⁻¹ := by
+  rw [leOnePart, ← inv_inj, inv_sup, inv_inv, inv_inv, inv_one]
+#align lattice_ordered_comm_group.neg_eq_inv_inf_one leOnePart_eq_inv_inf_one
+#align lattice_ordered_comm_group.neg_eq_neg_inf_zero negPart_eq_neg_inf_zero
 
 -- Bourbaki A.VI.12 Prop 9 a)
--- a = a⁺ - a⁻
 @[to_additive (attr := simp)]
-theorem pos_div_neg [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) : a⁺ / a⁻ = a := by
-  symm
-  rw [div_eq_mul_inv]
-  apply eq_mul_inv_of_mul_eq
-  rw [m_neg_part_def, mul_sup, mul_one, mul_right_inv, sup_comm, m_pos_part_def]
-#align lattice_ordered_comm_group.pos_div_neg LatticeOrderedGroup.pos_div_neg
-#align lattice_ordered_comm_group.pos_sub_neg LatticeOrderedGroup.pos_sub_neg
-
--- pos_of_nonneg
-/-- If `a` is positive, then it is equal to its positive component `a⁺`. -/
-@[to_additive "If `a` is positive, then it is equal to its positive component `a⁺`."]
-theorem pos_of_one_le (a : α) (h : 1 ≤ a) : a⁺ = a := by
-  rw [m_pos_part_def]
-  exact sup_of_le_left h
-#align lattice_ordered_comm_group.pos_of_one_le LatticeOrderedGroup.pos_of_one_le
-#align lattice_ordered_comm_group.pos_of_nonneg LatticeOrderedGroup.pos_of_nonneg
-
--- 0 ≤ a implies a⁺ = a
--- pos_of_nonpos
-@[to_additive]
-theorem pos_of_le_one (a : α) (h : a ≤ 1) : a⁺ = 1 :=
-  pos_eq_one_iff.mpr h
-#align lattice_ordered_comm_group.pos_of_le_one LatticeOrderedGroup.pos_of_le_one
-#align lattice_ordered_comm_group.pos_of_nonpos LatticeOrderedGroup.pos_of_nonpos
-
-@[to_additive neg_of_inv_nonneg]
-theorem neg_of_one_le_inv (a : α) (h : 1 ≤ a⁻¹) : a⁻ = a⁻¹ := by
-  rw [neg_eq_pos_inv]
-  exact pos_of_one_le _ h
-#align lattice_ordered_comm_group.neg_of_one_le_inv LatticeOrderedGroup.neg_of_one_le_inv
-#align lattice_ordered_comm_group.neg_of_inv_nonneg LatticeOrderedGroup.neg_of_inv_nonneg
-
--- neg_of_neg_nonpos
-@[to_additive]
-theorem neg_of_inv_le_one (a : α) (h : a⁻¹ ≤ 1) : a⁻ = 1 :=
-  neg_eq_one_iff'.mpr h
-#align lattice_ordered_comm_group.neg_of_inv_le_one LatticeOrderedGroup.neg_of_inv_le_one
-#align lattice_ordered_comm_group.neg_of_neg_nonpos LatticeOrderedGroup.neg_of_neg_nonpos
-
--- neg_of_nonpos
-@[to_additive]
-theorem neg_of_le_one [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) (h : a ≤ 1) : a⁻ = a⁻¹ :=
-  sup_eq_left.2 <| one_le_inv'.2 h
-#align lattice_ordered_comm_group.neg_of_le_one LatticeOrderedGroup.neg_of_le_one
-#align lattice_ordered_comm_group.neg_of_nonpos LatticeOrderedGroup.neg_of_nonpos
-
--- pos_eq_self_of_pos_pos
-@[to_additive]
-theorem pos_eq_self_of_one_lt_pos {α} [LinearOrder α] [CommGroup α] {x : α} (hx : 1 < x⁺) :
-    x⁺ = x := by
-  rw [m_pos_part_def, right_lt_sup, not_le] at hx
-  rw [m_pos_part_def, sup_eq_left]
-  exact hx.le
-#align lattice_ordered_comm_group.pos_eq_self_of_one_lt_pos LatticeOrderedGroup.pos_eq_self_of_one_lt_pos
-#align lattice_ordered_comm_group.pos_eq_self_of_pos_pos LatticeOrderedGroup.pos_eq_self_of_pos_pos
-
--- neg_of_nonneg'
-@[to_additive]
-theorem neg_of_one_le [CovariantClass α α (· * ·) (· ≤ ·)] (a : α) (h : 1 ≤ a) : a⁻ = 1 :=
-  neg_eq_one_iff.mpr h
-#align lattice_ordered_comm_group.neg_of_one_le LatticeOrderedGroup.neg_of_one_le
-#align lattice_ordered_comm_group.neg_of_nonneg LatticeOrderedGroup.neg_of_nonneg
+lemma oneLePart_div_leOnePart (a : α) : a⁺ᵐ / a⁻ᵐ = a := by
+  rw [div_eq_mul_inv, mul_inv_eq_iff_eq_mul, leOnePart, mul_sup, mul_one, mul_right_inv, sup_comm,
+    oneLePart]
+#align lattice_ordered_comm_group.pos_div_neg oneLePart_div_leOnePart
+#align lattice_ordered_comm_group.pos_sub_neg posPart_sub_negPart
 
 -- The proof from Bourbaki A.VI.12 Prop 9 d)
--- |a|ₘ = a⁺ - a⁻
 @[to_additive]
-theorem pos_mul_neg
+lemma oneLePart_mul_leOnePart
     [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a : α) :
-    |a|ₘ = a⁺ * a⁻ := by
-  rw [m_pos_part_def, sup_mul, one_mul, m_neg_part_def, mul_sup, mul_one, mul_inv_self, sup_assoc,
+    a⁺ᵐ * a⁻ᵐ = |a|ₘ := by
+  rw [oneLePart, sup_mul, one_mul, leOnePart, mul_sup, mul_one, mul_inv_self, sup_assoc,
     ← @sup_assoc _ _ a, sup_eq_right.2 le_sup_right]
-  exact (sup_eq_left.2 <| one_le_mabs a).symm
-#align lattice_ordered_comm_group.pos_mul_neg LatticeOrderedGroup.pos_mul_neg
-#align lattice_ordered_comm_group.pos_add_neg LatticeOrderedGroup.pos_add_neg
+  exact sup_eq_left.2 <| one_le_mabs a
+#align lattice_ordered_comm_group.pos_mul_neg oneLePart_mul_leOnePart
+#align lattice_ordered_comm_group.pos_add_neg posPart_add_negPart
 
-@[to_additive pos_abs]
-theorem m_pos_abs [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)]
-    (a : α) : |a|ₘ⁺ = |a|ₘ := by
-  rw [m_pos_part_def]
-  apply sup_of_le_left
-  apply one_le_mabs
-#align lattice_ordered_comm_group.m_pos_abs LatticeOrderedGroup.m_pos_abs
-#align lattice_ordered_comm_group.pos_abs LatticeOrderedGroup.pos_abs
-
-@[to_additive neg_abs]
-theorem m_neg_abs [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)]
-    (a : α) : |a|ₘ⁻ = 1 := by
-  rw [m_neg_part_def]
-  apply sup_of_le_right
-  rw [Left.inv_le_one_iff]
-  apply one_le_mabs
-#align lattice_ordered_comm_group.m_neg_abs LatticeOrderedGroup.m_neg_abs
-#align lattice_ordered_comm_group.neg_abs LatticeOrderedGroup.neg_abs
+#noalign lattice_ordered_comm_group.m_pos_abs
+#noalign lattice_ordered_comm_group.pos_abs
+#noalign lattice_ordered_comm_group.m_neg_abs
+#noalign lattice_ordered_comm_group.neg_abs
 
 -- Bourbaki A.VI.12 Prop 9 a)
--- a⁺ ⊓ a⁻ = 0 (`a⁺` and `a⁻` are co-prime, and, since they are positive, disjoint)
-@[to_additive]
-theorem pos_inf_neg_eq_one
-    [CovariantClass α α (· * ·) (· ≤ ·)] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a : α) :
-    a⁺ ⊓ a⁻ = 1 := by
-  rw [← mul_left_inj (a⁻)⁻¹, inf_mul, one_mul, mul_right_inv, ← div_eq_mul_inv,
-    pos_div_neg, neg_eq_inv_inf_one, inv_inv]
-#align lattice_ordered_comm_group.pos_inf_neg_eq_one LatticeOrderedGroup.pos_inf_neg_eq_one
-#align lattice_ordered_comm_group.pos_inf_neg_eq_zero LatticeOrderedGroup.pos_inf_neg_eq_zero
-
-end LatticeOrderedGroup
+-- a⁺ᵐ ⊓ a⁻ᵐ = 0 (`a⁺` and `a⁻` are co-prime, and, since they are positive, disjoint)
+@[to_additive] lemma oneLePart_inf_leOnePart_eq_one (a : α) : a⁺ᵐ ⊓ a⁻ᵐ = 1 := by
+  rw [← mul_left_inj a⁻ᵐ⁻¹, inf_mul, one_mul, mul_right_inv, ← div_eq_mul_inv,
+    oneLePart_div_leOnePart, leOnePart_eq_inv_inf_one, inv_inv]
+#align lattice_ordered_comm_group.pos_inf_neg_eq_one oneLePart_inf_leOnePart_eq_one
+#align lattice_ordered_comm_group.pos_inf_neg_eq_zero posPart_inf_negPart_eq_zero
 
 end Group
 
-namespace LatticeOrderedCommGroup
-variable [Lattice α] [CommGroup α]
-
-open LatticeOrderedGroup
+section CommGroup
+variable [Lattice α] [CommGroup α] [CovariantClass α α (· * ·) (· ≤ ·)]
 
 -- Bourbaki A.VI.12 (with a and b swapped)
--- a⊔b = b + (a - b)⁺
-@[to_additive]
-theorem sup_eq_mul_pos_div [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) : a ⊔ b = b * (a / b)⁺ :=
-  calc
-    a ⊔ b = b * (a / b) ⊔ b * 1 :=
-      by rw [mul_one b, div_eq_mul_inv, mul_comm a, mul_inv_cancel_left]
-    _ = b * (a / b ⊔ 1) := by rw [← mul_sup (a / b) 1 b]
-#align lattice_ordered_comm_group.sup_eq_mul_pos_div LatticeOrderedCommGroup.sup_eq_mul_pos_div
-#align lattice_ordered_comm_group.sup_eq_add_pos_sub LatticeOrderedCommGroup.sup_eq_add_pos_sub
+@[to_additive] lemma sup_eq_mul_oneLePart_div (a b : α) : a ⊔ b = b * (a / b)⁺ᵐ := by
+  simp [oneLePart, mul_sup]
+#align lattice_ordered_comm_group.sup_eq_mul_pos_div sup_eq_mul_oneLePart_div
+#align lattice_ordered_comm_group.sup_eq_add_pos_sub sup_eq_add_posPart_sub
 
 -- Bourbaki A.VI.12 (with a and b swapped)
--- a⊓b = a - (a - b)⁺
-@[to_additive]
-theorem inf_eq_div_pos_div [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) : a ⊓ b = a / (a / b)⁺ :=
-  calc
-    a ⊓ b = a * 1 ⊓ a * (b / a) :=
-      by rw [mul_one a, div_eq_mul_inv, mul_comm b, mul_inv_cancel_left]
-    _ = a * (1 ⊓ b / a) := by rw [← mul_inf 1 (b / a) a]
-    _ = a * (b / a ⊓ 1) := by rw [inf_comm]
-    _ = a * ((a / b)⁻¹ ⊓ 1) := by
-      rw [div_eq_mul_inv]
-      nth_rw 1 [← inv_inv b]
-      rw [← mul_inv, mul_comm b⁻¹, ← div_eq_mul_inv]
-    _ = a * ((a / b)⁻¹ ⊓ 1⁻¹) := by rw [inv_one]
-    _ = a / (a / b ⊔ 1) := by rw [← inv_sup, ← div_eq_mul_inv]
-#align lattice_ordered_comm_group.inf_eq_div_pos_div LatticeOrderedCommGroup.inf_eq_div_pos_div
-#align lattice_ordered_comm_group.inf_eq_sub_pos_sub LatticeOrderedCommGroup.inf_eq_sub_pos_sub
+@[to_additive] lemma inf_eq_div_oneLePart_div (a b : α) : a ⊓ b = a / (a / b)⁺ᵐ := by
+  simp [oneLePart, div_sup, inf_comm]
+#align lattice_ordered_comm_group.inf_eq_div_pos_div inf_eq_div_oneLePart_div
+#align lattice_ordered_comm_group.inf_eq_sub_pos_sub inf_eq_sub_posPart_sub
 
 -- Bourbaki A.VI.12 Prop 9 c)
-@[to_additive le_iff_pos_le_neg_ge]
-theorem m_le_iff_pos_le_neg_ge [CovariantClass α α (· * ·) (· ≤ ·)] (a b : α) :
-    a ≤ b ↔ a⁺ ≤ b⁺ ∧ b⁻ ≤ a⁻ := by
-  constructor <;> intro h
-  · constructor
-    · exact sup_le (h.trans (m_le_pos b)) (one_le_pos b)
-    · rw [← inv_le_inv_iff] at h
-      exact sup_le (h.trans (inv_le_neg a)) (one_le_neg a)
-  · rw [← pos_div_neg a, ← pos_div_neg b]
-    exact div_le_div'' h.1 h.2
-#align lattice_ordered_comm_group.m_le_iff_pos_le_neg_ge LatticeOrderedCommGroup.m_le_iff_pos_le_neg_ge
-#align lattice_ordered_comm_group.le_iff_pos_le_neg_ge LatticeOrderedCommGroup.le_iff_pos_le_neg_ge
+@[to_additive] lemma le_iff_oneLePart_leOnePart (a b : α) : a ≤ b ↔ a⁺ᵐ ≤ b⁺ᵐ ∧ b⁻ᵐ ≤ a⁻ᵐ := by
+  refine ⟨fun h ↦ ⟨oneLePart_mono h, leOnePart_anti h⟩, fun h ↦ ?_⟩
+  rw [← oneLePart_div_leOnePart a, ← oneLePart_div_leOnePart b]
+  exact div_le_div'' h.1 h.2
+#align lattice_ordered_comm_group.m_le_iff_pos_le_neg_ge le_iff_oneLePart_leOnePart
+#align lattice_ordered_comm_group.le_iff_pos_le_neg_ge le_iff_posPart_negPart
 
-end LatticeOrderedCommGroup
+end CommGroup
+end Lattice
 
-namespace LatticeOrderedAddCommGroup
+section LinearOrder
+variable [LinearOrder α] [CommGroup α] {a : α}
 
-variable [Lattice β] [AddCommGroup β]
+@[to_additive posPart_eq_of_posPart_pos]
+lemma oneLePart_of_one_lt_oneLePart (ha : 1 < a⁺ᵐ) : a⁺ᵐ = a := by
+  rw [oneLePart, right_lt_sup, not_le] at ha; exact oneLePart_eq_self.2 ha.le
+#align lattice_ordered_comm_group.pos_eq_self_of_one_lt_pos oneLePart_of_one_lt_oneLePart
+#align lattice_ordered_comm_group.pos_eq_self_of_pos_pos posPart_eq_of_posPart_pos
 
-section solid
-
-/-- A subset `s ⊆ β`, with `β` an `AddCommGroup` with a `Lattice` structure, is solid if for
-all `x ∈ s` and all `y ∈ β` such that `|y| ≤ |x|`, then `y ∈ s`. -/
-def IsSolid (s : Set β) : Prop := ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, |y| ≤ |x| → y ∈ s
-#align lattice_ordered_add_comm_group.is_solid LatticeOrderedAddCommGroup.IsSolid
-
-/-- The solid closure of a subset `s` is the smallest superset of `s` that is solid. -/
-def solidClosure (s : Set β) : Set β := { y | ∃ x ∈ s, |y| ≤ |x| }
-#align lattice_ordered_add_comm_group.solid_closure LatticeOrderedAddCommGroup.solidClosure
-
-theorem isSolid_solidClosure (s : Set β) : IsSolid (solidClosure s) :=
-  fun _ ⟨y, hy, hxy⟩ _ hzx => ⟨y, hy, hzx.trans hxy⟩
-#align lattice_ordered_add_comm_group.is_solid_solid_closure LatticeOrderedAddCommGroup.isSolid_solidClosure
-
-theorem solidClosure_min (s t : Set β) (h1 : s ⊆ t) (h2 : IsSolid t) : solidClosure s ⊆ t :=
-  fun _ ⟨_, hy, hxy⟩ => h2 (h1 hy) hxy
-#align lattice_ordered_add_comm_group.solid_closure_min LatticeOrderedAddCommGroup.solidClosure_min
-
-end solid
-
-end LatticeOrderedAddCommGroup
+end LinearOrder

--- a/Mathlib/Algebra/Order/Module/OrderedSMul.lean
+++ b/Mathlib/Algebra/Order/Module/OrderedSMul.lean
@@ -45,8 +45,6 @@ This file is now mostly useless. We should try deleting `OrderedSMul`
 ordered module, ordered scalar, ordered smul, ordered action, ordered vector space
 -/
 
-open LatticeOrderedCommGroup
-
 /-- The ordered scalar product property is when an ordered additive commutative monoid
 with a partial order has a scalar multiplication which is compatible with the order.
 -/

--- a/Mathlib/Analysis/Normed/Order/Lattice.lean
+++ b/Mathlib/Analysis/Normed/Order/Lattice.lean
@@ -91,7 +91,7 @@ instance (priority := 100) NormedLatticeAddCommGroup.toOrderedAddCommGroup {α :
 
 variable {α : Type*} [NormedLatticeAddCommGroup α]
 
-open LatticeOrderedGroup LatticeOrderedCommGroup HasSolidNorm
+open HasSolidNorm
 
 theorem dual_solid (a b : α) (h : b ⊓ -b ≤ a ⊓ -a) : ‖a‖ ≤ ‖b‖ := by
   apply solid
@@ -197,28 +197,23 @@ theorem lipschitzWith_sup_right (z : α) : LipschitzWith 1 fun x => x ⊔ z :=
     exact norm_sup_sub_sup_le_norm x y z
 #align lipschitz_with_sup_right lipschitzWith_sup_right
 
-theorem lipschitzWith_pos : LipschitzWith 1 (PosPart.pos : α → α) :=
+lemma lipschitzWith_posPart : LipschitzWith 1 (posPart : α → α) :=
   lipschitzWith_sup_right 0
-#align lipschitz_with_pos lipschitzWith_pos
+#align lipschitz_with_pos lipschitzWith_posPart
 
-theorem continuous_pos : Continuous (PosPart.pos : α → α) :=
-  LipschitzWith.continuous lipschitzWith_pos
-#align continuous_pos continuous_pos
+lemma lipschitzWith_negPart : LipschitzWith 1 (negPart : α → α) := by
+  simpa [Function.comp] using lipschitzWith_posPart.comp LipschitzWith.id.neg
 
-theorem continuous_neg' : Continuous (NegPart.neg : α → α) := by
-  refine continuous_pos.comp <| @continuous_neg _ _ _ TopologicalAddGroup.toContinuousNeg
-  -- porting note: see the [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/can't.20infer.20.60ContinuousNeg.60)
-#align continuous_neg' continuous_neg'
+lemma continuous_posPart : Continuous (posPart : α → α) := lipschitzWith_posPart.continuous
+#align continuous_pos continuous_posPart
 
-theorem isClosed_nonneg {E} [NormedLatticeAddCommGroup E] : IsClosed { x : E | 0 ≤ x } := by
-  suffices { x : E | 0 ≤ x } = NegPart.neg ⁻¹' {(0 : E)} by
-    rw [this]
-    exact IsClosed.preimage continuous_neg' isClosed_singleton
-  ext1 x
-  simp only [Set.mem_preimage, Set.mem_singleton_iff, Set.mem_setOf_eq,
-    @neg_eq_zero_iff E _ _ (OrderedAddCommGroup.to_covariantClass_left_le E)]
-  -- porting note: I'm not sure why Lean couldn't synthesize this instance because it works with
-  -- `have : CovariantClass E E (· + ·) (· ≤ ·) := inferInstance`
+lemma continuous_negPart : Continuous (negPart : α → α) := lipschitzWith_negPart.continuous
+#align continuous_neg' continuous_negPart
+
+lemma isClosed_nonneg : IsClosed {x : α | 0 ≤ x} := by
+  have : {x : α | 0 ≤ x} = negPart ⁻¹' {0} := by ext; simp [negPart_eq_zero]
+  rw [this]
+  exact isClosed_singleton.preimage continuous_negPart
 #align is_closed_nonneg isClosed_nonneg
 
 theorem isClosed_le_of_isClosed_nonneg {G} [OrderedAddCommGroup G] [TopologicalSpace G]

--- a/Mathlib/MeasureTheory/Function/LpOrder.lean
+++ b/Mathlib/MeasureTheory/Function/LpOrder.lean
@@ -25,8 +25,7 @@ import Mathlib.MeasureTheory.Function.LpSpace
 
 set_option linter.uppercaseLean3 false
 
-open TopologicalSpace MeasureTheory LatticeOrderedCommGroup
-
+open TopologicalSpace MeasureTheory
 open scoped ENNReal
 
 variable {α E : Type*} {m : MeasurableSpace α} {μ : Measure α} {p : ℝ≥0∞}

--- a/Mathlib/Probability/Martingale/Convergence.lean
+++ b/Mathlib/Probability/Martingale/Convergence.lean
@@ -175,9 +175,8 @@ theorem Submartingale.upcrossings_ae_lt_top' [IsFiniteMeasure μ] (hf : Submarti
       refine' lintegral_mono fun ω => _
       rw [ENNReal.ofReal_le_iff_le_toReal, ENNReal.coe_toReal, coe_nnnorm]
       by_cases hnonneg : 0 ≤ f n ω - a
-      · rw [LatticeOrderedGroup.pos_of_nonneg _ hnonneg, Real.norm_eq_abs,
-          abs_of_nonneg hnonneg]
-      · rw [LatticeOrderedGroup.pos_of_nonpos _ (not_le.1 hnonneg).le]
+      · rw [posPart_eq_self.2 hnonneg, Real.norm_eq_abs, abs_of_nonneg hnonneg]
+      · rw [posPart_eq_zero.2 (not_le.1 hnonneg).le]
         exact norm_nonneg _
       · simp only [Ne.def, ENNReal.coe_ne_top, not_false_iff]
     · simp only [hab, Ne.def, ENNReal.ofReal_eq_zero, sub_nonpos, not_le]

--- a/Mathlib/Probability/Martingale/Upcrossing.lean
+++ b/Mathlib/Probability/Martingale/Upcrossing.lean
@@ -675,12 +675,10 @@ theorem crossing_pos_eq (hab : a < b) :
     intro i ω
     refine' ⟨fun h => _, fun h => _⟩
     · rwa [← sub_le_sub_iff_right a, ←
-        LatticeOrderedGroup.pos_eq_self_of_pos_pos (lt_of_lt_of_le hab' h)]
+        posPart_eq_of_posPart_pos (lt_of_lt_of_le hab' h)]
     · rw [← sub_le_sub_iff_right a] at h
-      rwa [LatticeOrderedGroup.pos_of_nonneg _ (le_trans hab'.le h)]
-  have hf' : ∀ ω i, (f i ω - a)⁺ ≤ 0 ↔ f i ω ≤ a := by
-    intro ω i
-    rw [LatticeOrderedGroup.pos_nonpos_iff, sub_nonpos]
+      rwa [posPart_eq_self.2 (le_trans hab'.le h)]
+  have hf' (ω i) : (f i ω - a)⁺ ≤ 0 ↔ f i ω ≤ a := by rw [posPart_nonpos, sub_nonpos]
   induction' n with k ih
   · refine' ⟨rfl, _⟩
     simp (config := { unfoldPartialApp := true }) only [lowerCrossingTime_zero, hitting,
@@ -726,8 +724,8 @@ theorem mul_integral_upcrossingsBefore_le_integral_pos_part_aux [IsFiniteMeasure
     (b - a) * μ[upcrossingsBefore a b f N] ≤ μ[fun ω => (f N ω - a)⁺] := by
   refine' le_trans (le_of_eq _)
     (integral_mul_upcrossingsBefore_le_integral (hf.sub_martingale (martingale_const _ _ _)).pos
-      (fun ω => LatticeOrderedGroup.pos_nonneg _)
-      (fun ω => LatticeOrderedGroup.pos_nonneg _) (sub_pos.2 hab))
+      (fun ω => posPart_nonneg _)
+      (fun ω => posPart_nonneg _) (sub_pos.2 hab))
   simp_rw [sub_zero, ← upcrossingsBefore_pos_eq hab]
   rfl
 #align measure_theory.mul_integral_upcrossings_before_le_integral_pos_part_aux MeasureTheory.mul_integral_upcrossingsBefore_le_integral_pos_part_aux
@@ -743,7 +741,7 @@ theorem Submartingale.mul_integral_upcrossingsBefore_le_integral_pos_part [IsFin
   · exact mul_integral_upcrossingsBefore_le_integral_pos_part_aux hf hab
   · rw [not_lt, ← sub_nonpos] at hab
     exact le_trans (mul_nonpos_of_nonpos_of_nonneg hab (integral_nonneg fun ω => Nat.cast_nonneg _))
-      (integral_nonneg fun ω => LatticeOrderedGroup.pos_nonneg _)
+      (integral_nonneg fun ω => posPart_nonneg _)
 #align measure_theory.submartingale.mul_integral_upcrossings_before_le_integral_pos_part MeasureTheory.Submartingale.mul_integral_upcrossingsBefore_le_integral_pos_part
 
 /-!
@@ -859,7 +857,7 @@ theorem Submartingale.mul_lintegral_upcrossings_le_lintegral_pos_part [IsFiniteM
       intro N
       rw [ofReal_integral_eq_lintegral_ofReal]
       · exact (hf.sub_martingale (martingale_const _ _ _)).pos.integrable _
-      · exact eventually_of_forall fun ω => LatticeOrderedGroup.pos_nonneg _
+      · exact eventually_of_forall fun ω => posPart_nonneg _
     rw [lintegral_iSup']
     · simp_rw [this, ENNReal.mul_iSup, iSup_le_iff]
       intro N

--- a/Mathlib/Topology/ContinuousFunction/Bounded.lean
+++ b/Mathlib/Topology/ContinuousFunction/Bounded.lean
@@ -1591,7 +1591,7 @@ variable [TopologicalSpace α]
 /-- The nonnegative part of a bounded continuous `ℝ`-valued function as a bounded
 continuous `ℝ≥0`-valued function. -/
 def nnrealPart (f : α →ᵇ ℝ) : α →ᵇ ℝ≥0 :=
-  BoundedContinuousFunction.comp _ (show LipschitzWith 1 Real.toNNReal from lipschitzWith_pos) f
+  BoundedContinuousFunction.comp _ (show LipschitzWith 1 Real.toNNReal from lipschitzWith_posPart) f
 #align bounded_continuous_function.nnreal_part BoundedContinuousFunction.nnrealPart
 
 @[simp]


### PR DESCRIPTION
This changes the typeclass notation approach with plain functions.

Followup to #9553. Part of #9411


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
