### PR TITLE
[Merged by Bors] - feat: injective continuous linear map with closed range is a continuous linear equivalence

### DIFF
--- a/Mathlib/Analysis/NormedSpace/Banach.lean
+++ b/Mathlib/Analysis/NormedSpace/Banach.lean
@@ -360,10 +360,7 @@ variable [CompleteSpace E]
 noncomputable def toContinuousLinearEquivOfInjectiveOfIsClosed
     (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
     E ≃L[𝕜] LinearMap.range f :=
-  have cs : CompleteSpace (LinearMap.range f) := by
-    apply IsClosed.completeSpace_coe
-    rw [LinearMap.range_coe]
-    exact hclo
+  have : CompleteSpace (LinearMap.range f) := hclo.completeSpace_coe
   LinearEquiv.toContinuousLinearEquivOfContinuous (LinearEquiv.ofInjective f.toLinearMap hinj) <|
     (f.continuous.codRestrict fun x ↦ LinearMap.mem_range_self f x).congr fun _ ↦ rfl
 

--- a/Mathlib/Analysis/NormedSpace/Banach.lean
+++ b/Mathlib/Analysis/NormedSpace/Banach.lean
@@ -359,17 +359,20 @@ variable [CompleteSpace E]
 
 /-- An injective continuous linear map with a closed range defines a continuous linear equivalence
 between its domain and its range. -/
-noncomputable def toContinuousLinearEquivOfInjectiveOfIsClosed
-    (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+noncomputable def rangeEquiv (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
     E ≃L[𝕜] LinearMap.range f :=
   have : CompleteSpace (LinearMap.range f) := hclo.completeSpace_coe
   LinearEquiv.toContinuousLinearEquivOfContinuous (LinearEquiv.ofInjective f.toLinearMap hinj) <|
     (f.continuous.codRestrict fun x ↦ LinearMap.mem_range_self f x).congr fun _ ↦ rfl
 
 @[simp]
-theorem toContinuousLinearEquivOfInjectiveOfIsClosed_apply
-    (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) (x : E) :
-    f.toContinuousLinearEquivOfInjectiveOfIsClosed hinj hclo x = f x :=
+theorem rangeEquiv_apply (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) (x : E) :
+    f.rangeEquiv hinj hclo x = f x :=
+  rfl
+
+@[simp]
+theorem rangeEquiv_eq (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+    (f.rangeEquiv hinj hclo).toContinuousLinearMap = f.rangeRestrict :=
   rfl
 
 end ContinuousLinearMap

--- a/Mathlib/Analysis/NormedSpace/Banach.lean
+++ b/Mathlib/Analysis/NormedSpace/Banach.lean
@@ -353,6 +353,21 @@ theorem coeFn_toContinuousLinearEquivOfContinuous_symm (e : E ≃ₗ[𝕜] F) (h
 
 end LinearEquiv
 
+namespace ContinuousLinearMap
+
+noncomputable def ContinuousLinearEquiv.ofInjectiveOfIsClosed
+    [CompleteSpace E] (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+    E ≃L[𝕜] LinearMap.range f :=
+  haveI cs : CompleteSpace (LinearMap.range f) := by
+    apply IsClosed.completeSpace_coe
+    rw [LinearMap.range_coe]
+    exact hclo
+  @LinearEquiv.toContinuousLinearEquivOfContinuous _ _ _ _ _ _ _ _ cs _
+    (LinearEquiv.ofInjective f.toLinearMap hinj) <|
+    (f.continuous.codRestrict fun x ↦ LinearMap.mem_range_self f x).congr fun _ ↦ rfl
+
+end ContinuousLinearMap
+
 namespace ContinuousLinearEquiv
 
 variable [CompleteSpace E]

--- a/Mathlib/Analysis/NormedSpace/Banach.lean
+++ b/Mathlib/Analysis/NormedSpace/Banach.lean
@@ -359,20 +359,20 @@ variable [CompleteSpace E]
 
 /-- An injective continuous linear map with a closed range defines a continuous linear equivalence
 between its domain and its range. -/
-noncomputable def rangeEquiv (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+noncomputable def equivRange (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
     E ≃L[𝕜] LinearMap.range f :=
   have : CompleteSpace (LinearMap.range f) := hclo.completeSpace_coe
   LinearEquiv.toContinuousLinearEquivOfContinuous (LinearEquiv.ofInjective f.toLinearMap hinj) <|
     (f.continuous.codRestrict fun x ↦ LinearMap.mem_range_self f x).congr fun _ ↦ rfl
 
 @[simp]
-theorem rangeEquiv_eq (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
-    f.rangeEquiv hinj hclo = f.rangeRestrict :=
+theorem coe_linearMap_equivRange (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+    f.equivRange hinj hclo = f.rangeRestrict :=
   rfl
 
 @[simp]
-theorem coe_rangeEquiv (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
-    (f.rangeEquiv hinj hclo : E → LinearMap.range f) = f.rangeRestrict :=
+theorem coe_equivRange (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+    (f.equivRange hinj hclo : E → LinearMap.range f) = f.rangeRestrict :=
   rfl
 
 end ContinuousLinearMap

--- a/Mathlib/Analysis/NormedSpace/Banach.lean
+++ b/Mathlib/Analysis/NormedSpace/Banach.lean
@@ -366,13 +366,13 @@ noncomputable def rangeEquiv (f : E →L[𝕜] F) (hinj : Injective f) (hclo : I
     (f.continuous.codRestrict fun x ↦ LinearMap.mem_range_self f x).congr fun _ ↦ rfl
 
 @[simp]
-theorem rangeEquiv_apply (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) (x : E) :
-    f.rangeEquiv hinj hclo x = f x :=
+theorem rangeEquiv_eq (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+    f.rangeEquiv hinj hclo = f.rangeRestrict :=
   rfl
 
 @[simp]
-theorem rangeEquiv_eq (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
-    (f.rangeEquiv hinj hclo).toContinuousLinearMap = f.rangeRestrict :=
+theorem coe_rangeEquiv (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+    (f.rangeEquiv hinj hclo : E → LinearMap.range f) = f.rangeRestrict :=
   rfl
 
 end ContinuousLinearMap

--- a/Mathlib/Analysis/NormedSpace/Banach.lean
+++ b/Mathlib/Analysis/NormedSpace/Banach.lean
@@ -357,6 +357,8 @@ namespace ContinuousLinearMap
 
 variable [CompleteSpace E]
 
+/-- An injective continuous linear map with a closed range defines a continuous linear equivalence
+between its domain and its range. -/
 noncomputable def toContinuousLinearEquivOfInjectiveOfIsClosed
     (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
     E ≃L[𝕜] LinearMap.range f :=

--- a/Mathlib/Analysis/NormedSpace/Banach.lean
+++ b/Mathlib/Analysis/NormedSpace/Banach.lean
@@ -360,12 +360,11 @@ variable [CompleteSpace E]
 noncomputable def toContinuousLinearEquivOfInjectiveOfIsClosed
     (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
     E ≃L[𝕜] LinearMap.range f :=
-  haveI cs : CompleteSpace (LinearMap.range f) := by
+  have cs : CompleteSpace (LinearMap.range f) := by
     apply IsClosed.completeSpace_coe
     rw [LinearMap.range_coe]
     exact hclo
-  @LinearEquiv.toContinuousLinearEquivOfContinuous _ _ _ _ _ _ _ _ cs _
-    (LinearEquiv.ofInjective f.toLinearMap hinj) <|
+  LinearEquiv.toContinuousLinearEquivOfContinuous (LinearEquiv.ofInjective f.toLinearMap hinj) <|
     (f.continuous.codRestrict fun x ↦ LinearMap.mem_range_self f x).congr fun _ ↦ rfl
 
 @[simp]

--- a/Mathlib/Analysis/NormedSpace/Banach.lean
+++ b/Mathlib/Analysis/NormedSpace/Banach.lean
@@ -355,8 +355,10 @@ end LinearEquiv
 
 namespace ContinuousLinearMap
 
-noncomputable def ContinuousLinearEquiv.ofInjectiveOfIsClosed
-    [CompleteSpace E] (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
+variable [CompleteSpace E]
+
+noncomputable def toContinuousLinearEquivOfInjectiveOfIsClosed
+    (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) :
     E ≃L[𝕜] LinearMap.range f :=
   haveI cs : CompleteSpace (LinearMap.range f) := by
     apply IsClosed.completeSpace_coe
@@ -365,6 +367,12 @@ noncomputable def ContinuousLinearEquiv.ofInjectiveOfIsClosed
   @LinearEquiv.toContinuousLinearEquivOfContinuous _ _ _ _ _ _ _ _ cs _
     (LinearEquiv.ofInjective f.toLinearMap hinj) <|
     (f.continuous.codRestrict fun x ↦ LinearMap.mem_range_self f x).congr fun _ ↦ rfl
+
+@[simp]
+theorem toContinuousLinearEquivOfInjectiveOfIsClosed_apply
+    (f : E →L[𝕜] F) (hinj : Injective f) (hclo : IsClosed (range f)) (x : E) :
+    f.toContinuousLinearEquivOfInjectiveOfIsClosed hinj hclo x = f x :=
+  rfl
 
 end ContinuousLinearMap
 

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -1265,7 +1265,7 @@ variable [Nonempty α] {s : Set α} {f : α → β} {a : α} {b : β}
 attribute [local instance] Classical.propDecidable
 
 /-- Construct the inverse for a function `f` on domain `s`. This function is a right inverse of `f`
-on `f '' s`. For a computable version, see `Function.Injective.inv_of_mem_range`. -/
+on `f '' s`. For a computable version, see `Function.Embedding.invOfMemRange`. -/
 noncomputable def invFunOn (f : α → β) (s : Set α) (b : β) : α :=
   if h : ∃ a, a ∈ s ∧ f a = b then Classical.choose h else Classical.choice ‹Nonempty α›
 #align function.inv_fun_on Function.invFunOn

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -1060,6 +1060,11 @@ theorem ker_codRestrict (f : M₁ →SL[σ₁₂] M₂) (p : Submodule R₂ M₂
   (f : M₁ →ₛₗ[σ₁₂] M₂).ker_codRestrict p h
 #align continuous_linear_map.ker_cod_restrict ContinuousLinearMap.ker_codRestrict
 
+/-- Restrict the codomain of a continuous linear map `f` to `f.range`. -/
+@[reducible]
+def rangeRestrict [RingHomSurjective σ₁₂] (f : M₁ →SL[σ₁₂] M₂) :=
+  f.codRestrict (LinearMap.range f) (LinearMap.mem_range_self f)
+
 /-- `Submodule.subtype` as a `ContinuousLinearMap`. -/
 def _root_.Submodule.subtypeL (p : Submodule R₁ M₁) : p →L[R₁] M₁ where
   cont := continuous_subtype_val

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -1065,6 +1065,11 @@ theorem ker_codRestrict (f : M₁ →SL[σ₁₂] M₂) (p : Submodule R₂ M₂
 def rangeRestrict [RingHomSurjective σ₁₂] (f : M₁ →SL[σ₁₂] M₂) :=
   f.codRestrict (LinearMap.range f) (LinearMap.mem_range_self f)
 
+@[simp]
+theorem coe_rangeRestrict [RingHomSurjective σ₁₂] (f : M₁ →SL[σ₁₂] M₂) :
+    (f.rangeRestrict : M₁ →ₛₗ[σ₁₂] LinearMap.range f) = (f : M₁ →ₛₗ[σ₁₂] M₂).rangeRestrict :=
+  rfl
+
 /-- `Submodule.subtype` as a `ContinuousLinearMap`. -/
 def _root_.Submodule.subtypeL (p : Submodule R₁ M₁) : p →L[R₁] M₁ where
   cont := continuous_subtype_val


### PR DESCRIPTION
Added analogue of [LinearEquiv.ofInjective](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Basic.html#LinearEquiv.ofInjective) but for `ContinuousLinearEquiv` on Banach spaces.

Added analogue of [LinearMap.rangeRestrict](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Basic.html#LinearMap.rangeRestrict) but for `ContinuousLinearMap`.

Also I updated a docstring that had the old name of a theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
