### PR TITLE
[Merged by Bors] - chore: add `importGraph` to cache’s getPackageDirs

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -129,7 +129,8 @@ def getPackageDirs : IO PackageDirs := do
     ("Std", LAKEPACKAGESDIR / "std"),
     ("Cli", LAKEPACKAGESDIR / "Cli"),
     ("ProofWidgets", LAKEPACKAGESDIR / "proofwidgets"),
-    ("Qq", LAKEPACKAGESDIR / "Qq")
+    ("Qq", LAKEPACKAGESDIR / "Qq"),
+    ("ImportGraph", LAKEPACKAGESDIR / "importGraph")
   ]
 
 initialize pkgDirs : PackageDirs ← getPackageDirs


### PR DESCRIPTION
fixes
https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Imports.20are.20out.20of.20date.20even.20after.20getting.20cache.2E/near/412772807
and https://github.com/nomeata/loogle/issues/12
