### PR TITLE
[Merged by Bors] - chore: better CI reporting to Lean repository for lean-pr-testing-NNNN branches

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -188,6 +188,7 @@ jobs:
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build -KCI | tee stdout.log"
 
       - name: check for noisy stdout lines
+        id: noisy
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
 
@@ -217,6 +218,7 @@ jobs:
           fi
 
       - name: build archive
+        id: archive
         run: |
           # Note: we should not be including `Archive` and `Countexamples` in the cache.
           # We do this for now for the sake of not rebuilding them in every CI run
@@ -233,6 +235,7 @@ jobs:
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: build counterexamples
+        id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
           lake build Counterexamples
@@ -291,9 +294,13 @@ jobs:
           TOKEN: ${{ secrets.LEAN_PR_TESTING }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
           WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Note that 'lean-pr-testing-comments.sh' is sensitive to the ordering of these steps.
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
+          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
+          COUNTEREXAMPLE_OUTCOME: ${{ steps.counterexamples.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
           CHECK_OUTCOME: ${{ steps.lean4checker.outcome }}
         run: |
           scripts/lean-pr-testing-comments.sh

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -294,7 +294,6 @@ jobs:
           TOKEN: ${{ secrets.LEAN_PR_TESTING }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
           WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          # Note that 'lean-pr-testing-comments.sh' is sensitive to the ordering of these steps.
           BUILD_OUTCOME: ${{ steps.build.outcome }}
           NOISY_OUTCOME: ${{ steps.noisy.outcome }}
           ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,6 @@ jobs:
           TOKEN: ${{ secrets.LEAN_PR_TESTING }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
           WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          # Note that 'lean-pr-testing-comments.sh' is sensitive to the ordering of these steps.
           BUILD_OUTCOME: ${{ steps.build.outcome }}
           NOISY_OUTCOME: ${{ steps.noisy.outcome }}
           ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,6 +195,7 @@ jobs:
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build -KCI | tee stdout.log"
 
       - name: check for noisy stdout lines
+        id: noisy
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
 
@@ -224,6 +225,7 @@ jobs:
           fi
 
       - name: build archive
+        id: archive
         run: |
           # Note: we should not be including `Archive` and `Countexamples` in the cache.
           # We do this for now for the sake of not rebuilding them in every CI run
@@ -240,6 +242,7 @@ jobs:
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: build counterexamples
+        id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
           lake build Counterexamples
@@ -298,9 +301,13 @@ jobs:
           TOKEN: ${{ secrets.LEAN_PR_TESTING }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
           WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Note that 'lean-pr-testing-comments.sh' is sensitive to the ordering of these steps.
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
+          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
+          COUNTEREXAMPLE_OUTCOME: ${{ steps.counterexamples.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
           CHECK_OUTCOME: ${{ steps.lean4checker.outcome }}
         run: |
           scripts/lean-pr-testing-comments.sh

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -174,6 +174,7 @@ jobs:
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build -KCI | tee stdout.log"
 
       - name: check for noisy stdout lines
+        id: noisy
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
 
@@ -203,6 +204,7 @@ jobs:
           fi
 
       - name: build archive
+        id: archive
         run: |
           # Note: we should not be including `Archive` and `Countexamples` in the cache.
           # We do this for now for the sake of not rebuilding them in every CI run
@@ -219,6 +221,7 @@ jobs:
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: build counterexamples
+        id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
           lake build Counterexamples
@@ -277,9 +280,13 @@ jobs:
           TOKEN: ${{ secrets.LEAN_PR_TESTING }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
           WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Note that 'lean-pr-testing-comments.sh' is sensitive to the ordering of these steps.
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
+          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
+          COUNTEREXAMPLE_OUTCOME: ${{ steps.counterexamples.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
           CHECK_OUTCOME: ${{ steps.lean4checker.outcome }}
         run: |
           scripts/lean-pr-testing-comments.sh

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -280,7 +280,6 @@ jobs:
           TOKEN: ${{ secrets.LEAN_PR_TESTING }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
           WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          # Note that 'lean-pr-testing-comments.sh' is sensitive to the ordering of these steps.
           BUILD_OUTCOME: ${{ steps.build.outcome }}
           NOISY_OUTCOME: ${{ steps.noisy.outcome }}
           ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -298,7 +298,6 @@ jobs:
           TOKEN: ${{ secrets.LEAN_PR_TESTING }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
           WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          # Note that 'lean-pr-testing-comments.sh' is sensitive to the ordering of these steps.
           BUILD_OUTCOME: ${{ steps.build.outcome }}
           NOISY_OUTCOME: ${{ steps.noisy.outcome }}
           ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -192,6 +192,7 @@ jobs:
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build -KCI | tee stdout.log"
 
       - name: check for noisy stdout lines
+        id: noisy
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
 
@@ -221,6 +222,7 @@ jobs:
           fi
 
       - name: build archive
+        id: archive
         run: |
           # Note: we should not be including `Archive` and `Countexamples` in the cache.
           # We do this for now for the sake of not rebuilding them in every CI run
@@ -237,6 +239,7 @@ jobs:
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: build counterexamples
+        id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
           lake build Counterexamples
@@ -295,9 +298,13 @@ jobs:
           TOKEN: ${{ secrets.LEAN_PR_TESTING }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
           WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Note that 'lean-pr-testing-comments.sh' is sensitive to the ordering of these steps.
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
+          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
+          COUNTEREXAMPLE_OUTCOME: ${{ steps.counterexamples.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
           CHECK_OUTCOME: ${{ steps.lean4checker.outcome }}
         run: |
           scripts/lean-pr-testing-comments.sh

--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -12,9 +12,12 @@ set -e
 #   TOKEN: ${{ secrets.LEAN_PR_TESTING }}
 #   GITHUB_CONTEXT: ${{ toJson(github) }}
 #   WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+#   BUILD_OUTCOME: ${{ steps.build.outcome }}
+#   NOISY_OUTCOME: ${{ steps.noisy.outcome }}
+#   ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
+#   COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
 #   LINT_OUTCOME: ${{ steps.lint.outcome }}
 #   TEST_OUTCOME: ${{ steps.test.outcome }}
-#   BUILD_OUTCOME: ${{ steps.build.outcome }}
 #   CHECK_OUTCOME: ${{ steps.lean4checker.outcome }}
 
 # Extract branch name and check if it matches the pattern.
@@ -48,7 +51,7 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
       -H "X-GitHub-Api-Version: 2022-11-28" \
       https://api.github.com/repos/leanprover/lean4/issues/$pr_number/labels \
       -d '{"labels":["builds-mathlib"]}'
-  elif [ "$CHECK_OUTCOME" == "failure" ] || [ "$LINT_OUTCOME" == "failure" ] || [ "$TEST_OUTCOME" == "failure" ] || [ "$BUILD_OUTCOME" == "failure" ]; then
+  elif [ "$CHECK_OUTCOME" == "failure" ] || [ "$LINT_OUTCOME" == "failure" ] || [ "$TEST_OUTCOME" == "failure" ] || [ "$COUNTEREXAMPLES_OUTCOME" == "failure" ] || [ "$ARCHIVE_OUTCOME" == "failure" ] || [ "$NOISY_OUTCOME" == "failure" ] || [ "$BUILD_OUTCOME" == "failure" ]; then
     echo "Removing label builds-mathlib"
     curl -L -s \
       -X DELETE \
@@ -76,17 +79,23 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
 
   branch="[lean-pr-testing-$pr_number](https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$pr_number)"
   # Depending on the success/failure, set the appropriate message
-  if [ "$LINT_OUTCOME" == "cancelled" ] || [ "$TEST_OUTCOME" == "cancelled" ] || [ "$BUILD_OUTCOME" == "cancelled" ] || [ "$CHECK_OUTCOME" == "cancelled" ]; then
+  if [ "$LINT_OUTCOME" == "cancelled" ] || [ "$TEST_OUTCOME" == "cancelled" ] || [ "$COUNTEREXAMPLES_OUTCOME" == "cancelled" ] || [ "$ARCHIVE_OUTCOME" == "cancelled" ] || [ "$NOISY_OUTCOME" == "cancelled" ] || [ "$BUILD_OUTCOME" == "cancelled" ] || [ "$CHECK_OUTCOME" == "cancelled" ]; then
     message="- 🟡 Mathlib branch $branch build against this PR was cancelled. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$CHECK_OUTCOME" == "success" ]; then
     message="- ✅ Mathlib branch $branch has successfully built against this PR. ($current_time) [View Log]($WORKFLOW_URL)"
-  elif [ "$LINT_OUTCOME" == "success" ]; then
+  elif [ "$CHECK_OUTCOME" == "failure" ]; then
     message="- ❌ Mathlib branch $branch built against this PR, but lean4checker failed. ($current_time) [View Log]($WORKFLOW_URL)"
-  elif [ "$TEST_OUTCOME" == "success" ]; then
+  elif [ "$LINT_OUTCOME" == "failure" ]; then
     message="- ❌ Mathlib branch $branch built against this PR, but linting failed. ($current_time) [View Log]($WORKFLOW_URL)"
-  elif [ "$BUILD_OUTCOME" == "success" ]; then
+  elif [ "$COUNTEREXAMPLES_OUTCOME" == "failure" ]; then
+    message="- ❌ Mathlib branch $branch built against this PR, but the counterexamples library failed. ($current_time) [View Log]($WORKFLOW_URL)"
+  elif [ "$ARCHIVE_OUTCOME" == "failure" ]; then
+    message="- ❌ Mathlib branch $branch built against this PR, but the archive failed. ($current_time) [View Log]($WORKFLOW_URL)"
+  elif [ "$NOISY_OUTCOME" == "failure" ]; then
+    message="- ❌ Mathlib branch $branch built against this PR, but was unexpectedly noisy. ($current_time) [View Log]($WORKFLOW_URL)"
+  elif [ "$TEST_OUTCOME" == "failure" ]; then
     message="- ❌ Mathlib branch $branch built against this PR, but testing failed. ($current_time) [View Log]($WORKFLOW_URL)"
-  elif [ "$CHECK_OUTCOME" == "failure" ] || [ "$LINT_OUTCOME" == "failure" ] || [ "$TEST_OUTCOME" == "failure" ] || [ "$BUILD_OUTCOME" == "failure" ]; then
+  elif [ "$BUILD_OUTCOME" == "failure" ] ; then
     message="- 💥 Mathlib branch $branch build failed against this PR. ($current_time) [View Log]($WORKFLOW_URL)"
   else
     message="- 🟡 Mathlib branch $branch build this PR didn't complete normally. ($current_time) [View Log]($WORKFLOW_URL)"


### PR DESCRIPTION
This is only relevant for lean-pr-testing-NNNN branches

Previously some failure modes (the noisy checker, the archive, counterexamples) would result in a comment on the Lean PR, but the labels wouldn't be updated.

This is more thorough, and slightly simplifies the logic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
