### PR TITLE
[Merged by Bors] - feat: finite products/sums of differentiable maps into smooth commutative monoids are differentiable

### DIFF
--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -24,7 +24,12 @@ groups here are not necessarily finite dimensional.
 * `LieGroup I G` : a Lie multiplicative group where `G` is a manifold on the model with corners `I`.
 * `normedSpaceLieAddGroup` : a normed vector space over a nontrivially normed field
   is an additive Lie group.
-
+* point-wise inversion and division of maps `M → G` is smooth
+* `SmoothInv₀`: typeclass for smooth manifolds with `0` and `Inv` such that inversion is a smooth
+  map at each non-zero point. This includes complete normed fields and Lie groups.
+* if `SmoothInv₀ N`, point-wise inversion of smooth maps `f : M → N` is smooth at all points
+at which `f` doesn't vanish. If also `SmoothMul N` (i.e., `N` is a Lie group except possibly
+for smoothness of inversion at `0`), similar results hold for point-wise division.
 
 ## Implementation notes
 
@@ -68,7 +73,7 @@ class LieGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [Topolo
 /-! Let `f : M → G` be `C^n` or smooth functions into a smooth Lie group, then `f` is point-wise
   invertible with smooth inverse `f`. If `f` and `g` are two such functions, the quotient
   `f / g` (i.e., the point-wise product of `f` and the point-wise inverse of `g` is also smooth. -/
-section Division
+section PointwiseDivision
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H] {E : Type*}
   [NormedAddCommGroup E] [NormedSpace 𝕜 E] {I : ModelWithCorners 𝕜 E H} {F : Type*}
@@ -212,7 +217,7 @@ nonrec theorem Smooth.div {f g : M → G} (hf : Smooth I' I f) (hg : Smooth I' I
 #align smooth.div Smooth.div
 #align smooth.sub Smooth.sub
 
-end Division
+end PointwiseDivision
 
 -- binary product of Lie groups
 section Product
@@ -236,8 +241,10 @@ instance normedSpaceLieAddGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E
   smooth_neg := contDiff_neg.contMDiff
 #align normed_space_lie_add_group normedSpaceLieAddGroup
 
-/-! Inversion is smooth at all non-zero points. -/
-section HasSmoothInv
+/-! Typeclass for smooth manifolds with 0 and Inv such that inversion is smooth at all non-zero
+points. (This includes complete normed semifields and Lie groups.)
+Point-wise inversion and division are smooth when the function/denominator is non-zero. -/
+section SmoothInv₀
 
 -- See note [Design choices about smooth algebraic structures]
 /-- A smooth manifold with `0` and `Inv` such that `fun x ↦ x⁻¹` is smooth at all nonzero points.
@@ -307,8 +314,10 @@ theorem SmoothOn.inv₀ (hf : SmoothOn I' I f s) (h0 : ∀ x ∈ s, f x ≠ 0) :
     SmoothOn I' I (fun x => (f x)⁻¹) s :=
   ContMDiffOn.inv₀ hf h0
 
-end HasSmoothInv
+end SmoothInv₀
 
+/-! Point-wise division of smooth functions `f : M → G` where `[SmoothMul I G]` and
+`[SmoothInv₀ I N]`. (In other words, if inversion is smooth at `0`, `G` is a `LieGroup`.)-/
 section Div
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H] {E : Type*}

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -65,7 +65,10 @@ class LieGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [Topolo
   smooth_inv : Smooth I I fun a : G => a⁻¹
 #align lie_group LieGroup
 
-section LieGroup
+/-! Let `f : M → G` be `C^n` or smooth functions into a smooth Lie group, then `f` is point-wise
+  invertible with smooth inverse `f`. If `f` and `g` are two such functions, the quotient
+  `f / g` (i.e., the point-wise product of `f` and the point-wise inverse of `g` is also smooth. -/
+section Division
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H] {E : Type*}
   [NormedAddCommGroup E] [NormedSpace 𝕜 E] {I : ModelWithCorners 𝕜 E H} {F : Type*}
@@ -209,9 +212,10 @@ nonrec theorem Smooth.div {f g : M → G} (hf : Smooth I' I f) (hg : Smooth I' I
 #align smooth.div Smooth.div
 #align smooth.sub Smooth.sub
 
-end LieGroup
+end Division
 
-section ProdLieGroup
+-- binary product of Lie groups
+section Product
 
 -- Instance of product group
 @[to_additive]
@@ -223,7 +227,7 @@ instance {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalS
     [Group G'] [LieGroup I' G'] : LieGroup (I.prod I') (G × G') :=
   { SmoothMul.prod _ _ _ _ with smooth_inv := smooth_fst.inv.prod_mk smooth_snd.inv }
 
-end ProdLieGroup
+end Product
 
 /-! ### Normed spaces are Lie groups -/
 

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -24,12 +24,14 @@ groups here are not necessarily finite dimensional.
 * `LieGroup I G` : a Lie multiplicative group where `G` is a manifold on the model with corners `I`.
 * `normedSpaceLieAddGroup` : a normed vector space over a nontrivially normed field
   is an additive Lie group.
-* point-wise inversion and division of maps `M → G` is smooth
+* `ContMDiff.inv`, `ContMDiff.div` and variants: point-wise inversion and division of maps `M → G`
+  is smooth
 * `SmoothInv₀`: typeclass for smooth manifolds with `0` and `Inv` such that inversion is a smooth
   map at each non-zero point. This includes complete normed fields and Lie groups.
-* if `SmoothInv₀ N`, point-wise inversion of smooth maps `f : M → N` is smooth at all points
-at which `f` doesn't vanish. If also `SmoothMul N` (i.e., `N` is a Lie group except possibly
-for smoothness of inversion at `0`), similar results hold for point-wise division.
+* `ContMDiff.inv₀` and variants: if `SmoothInv₀ N`, point-wise inversion of smooth maps `f : M → N`
+  is smooth at all points at which `f` doesn't vanish.
+  ``ContMDiff.div₀` and variants: if also `SmoothMul N` (i.e., `N` is a Lie group except possibly
+  for smoothness of inversion at `0`), similar results hold for point-wise division.
 
 ## Implementation notes
 
@@ -70,9 +72,12 @@ class LieGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [Topolo
   smooth_inv : Smooth I I fun a : G => a⁻¹
 #align lie_group LieGroup
 
-/-! Let `f : M → G` be `C^n` or smooth functions into a smooth Lie group, then `f` is point-wise
+/-!
+  ### Smoothness of inversion, negation, division and subtraction
+
+  Let `f : M → G` be a `C^n` or smooth functions into a Lie group, then `f` is point-wise
   invertible with smooth inverse `f`. If `f` and `g` are two such functions, the quotient
-  `f / g` (i.e., the point-wise product of `f` and the point-wise inverse of `g` is also smooth. -/
+  `f / g` (i.e., the point-wise product of `f` and the point-wise inverse of `g`) is also smooth. -/
 section PointwiseDivision
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H] {E : Type*}
@@ -219,7 +224,7 @@ nonrec theorem Smooth.div {f g : M → G} (hf : Smooth I' I f) (hg : Smooth I' I
 
 end PointwiseDivision
 
--- binary product of Lie groups
+/-! Binary product of Lie groups -/
 section Product
 
 -- Instance of product group
@@ -241,9 +246,11 @@ instance normedSpaceLieAddGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E
   smooth_neg := contDiff_neg.contMDiff
 #align normed_space_lie_add_group normedSpaceLieAddGroup
 
-/-! Typeclass for smooth manifolds with 0 and Inv such that inversion is smooth at all non-zero
-points. (This includes complete normed semifields and Lie groups.)
-Point-wise inversion and division are smooth when the function/denominator is non-zero. -/
+/-! ## Smooth manifolds with smooth inversion away from zero
+
+Typeclass for smooth manifolds with `0` and `Inv` such that inversion is smooth at all non-zero
+points. (This includes Lie groups, but also complete normed semifields.)
+Point-wise inversion is smooth when the function/denominator is non-zero. -/
 section SmoothInv₀
 
 -- See note [Design choices about smooth algebraic structures]
@@ -316,8 +323,11 @@ theorem SmoothOn.inv₀ (hf : SmoothOn I' I f s) (h0 : ∀ x ∈ s, f x ≠ 0) :
 
 end SmoothInv₀
 
-/-! Point-wise division of smooth functions `f : M → G` where `[SmoothMul I G]` and
-`[SmoothInv₀ I N]`. (In other words, if inversion is smooth at `0`, `G` is a `LieGroup`.)-/
+/-! ### Point-wise division of smooth functions
+
+If `[SmoothMul I N]` and `[SmoothInv₀ I N]`, point-wise division of smooth functions `f : M → N`
+is smooth whenever the denominator is non-zero. (This includes `N` being a completely normed field.)
+-/
 section Div
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H] {E : Type*}

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -35,6 +35,8 @@ groups here are not necessarily finite dimensional.
   for smoothness of inversion at `0`), similar results hold for point-wise division.
 * `normedSpaceLieAddGroup` : a normed vector space over a nontrivially normed field
   is an additive Lie group.
+* `Instances/UnitsOfNormedAlgebra` shows that the group of units of a complete normed `𝕜`-algebra
+  is a multiplicative Lie group.
 
 ## Implementation notes
 

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -33,7 +33,6 @@ groups here are not necessarily finite dimensional.
   is smooth at all points at which `f` doesn't vanish.
   ``ContMDiff.div₀` and variants: if also `SmoothMul N` (i.e., `N` is a Lie group except possibly
   for smoothness of inversion at `0`), similar results hold for point-wise division.
-
 * `normedSpaceLieAddGroup` : a normed vector space over a nontrivially normed field
   is an additive Lie group.
 * `Instances/UnitsOfNormedAlgebra` shows that the group of units of a complete normed `𝕜`-algebra

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -18,20 +18,23 @@ Note that, since a manifold here is not second-countable and Hausdorff a Lie gro
 guaranteed to be second-countable (even though it can be proved it is Hausdorff). Note also that Lie
 groups here are not necessarily finite dimensional.
 
-## Main definitions and statements
+## Main definitions
 
 * `LieAddGroup I G` : a Lie additive group where `G` is a manifold on the model with corners `I`.
 * `LieGroup I G` : a Lie multiplicative group where `G` is a manifold on the model with corners `I`.
-* `normedSpaceLieAddGroup` : a normed vector space over a nontrivially normed field
-  is an additive Lie group.
+* `SmoothInv₀`: typeclass for smooth manifolds with `0` and `Inv` such that inversion is a smooth
+  map at each non-zero point. This includes complete normed fields and (multiplicative) Lie groups.
+
+
+## Main results
 * `ContMDiff.inv`, `ContMDiff.div` and variants: point-wise inversion and division of maps `M → G`
   is smooth
-* `SmoothInv₀`: typeclass for smooth manifolds with `0` and `Inv` such that inversion is a smooth
-  map at each non-zero point. This includes complete normed fields and Lie groups.
 * `ContMDiff.inv₀` and variants: if `SmoothInv₀ N`, point-wise inversion of smooth maps `f : M → N`
   is smooth at all points at which `f` doesn't vanish.
   ``ContMDiff.div₀` and variants: if also `SmoothMul N` (i.e., `N` is a Lie group except possibly
   for smoothness of inversion at `0`), similar results hold for point-wise division.
+* `normedSpaceLieAddGroup` : a normed vector space over a nontrivially normed field
+  is an additive Lie group.
 
 ## Implementation notes
 
@@ -52,7 +55,7 @@ noncomputable section
 open scoped Manifold
 
 -- See note [Design choices about smooth algebraic structures]
-/-- A Lie (additive) group is a group and a smooth manifold at the same time in which
+/-- An additive Lie group is a group and a smooth manifold at the same time in which
 the addition and negation operations are smooth. -/
 class LieAddGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] (I : ModelWithCorners 𝕜 E H) (G : Type*)
@@ -62,7 +65,7 @@ class LieAddGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [Top
 #align lie_add_group LieAddGroup
 
 -- See note [Design choices about smooth algebraic structures]
-/-- A Lie group is a group and a smooth manifold at the same time in which
+/-- A (multiplicative) Lie group is a group and a smooth manifold at the same time in which
 the multiplication and inverse operations are smooth. -/
 @[to_additive]
 class LieGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
@@ -249,7 +252,7 @@ instance normedSpaceLieAddGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E
 /-! ## Smooth manifolds with smooth inversion away from zero
 
 Typeclass for smooth manifolds with `0` and `Inv` such that inversion is smooth at all non-zero
-points. (This includes Lie groups, but also complete normed semifields.)
+points. (This includes multiplicative Lie groups, but also complete normed semifields.)
 Point-wise inversion is smooth when the function/denominator is non-zero. -/
 section SmoothInv₀
 

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -33,6 +33,9 @@ groups here are not necessarily finite dimensional.
   is smooth at all points at which `f` doesn't vanish.
   ``ContMDiff.div₀` and variants: if also `SmoothMul N` (i.e., `N` is a Lie group except possibly
   for smoothness of inversion at `0`), similar results hold for point-wise division.
+* `ContMDiff.prod`, `ContMDiff.sum`: finite products resp. sums of differentiable maps `M → G`
+  into an abelian (multiplicative resp. additive) Lie group are differentiable.
+
 * `normedSpaceLieAddGroup` : a normed vector space over a nontrivially normed field
   is an additive Lie group.
 * `Instances/UnitsOfNormedAlgebra` shows that the group of units of a complete normed `𝕜`-algebra
@@ -375,3 +378,65 @@ theorem Smooth.div₀ (hf : Smooth I' I f) (hg : Smooth I' I g) (h₀ : ∀ x, g
   ContMDiff.div₀ hf hg h₀
 
 end Div
+
+/-! ### Differentiability of finite point-wise sums and products
+
+  Finite point-wise products of functions `M → G` into an abelian multiplicative
+  Lie group `G` are differentiable. -/
+section FiniteSumProduct
+open Function
+open scoped BigOperators
+
+-- let `M` be a smooth manifold over `(E,H)`
+-- let `G` be an abelian Lie group modeled on `(E', H')`
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
+  {I : ModelWithCorners 𝕜 E H} {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {E' H' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] [TopologicalSpace H']
+  {I' : ModelWithCorners 𝕜 E' H'}
+  {G : Type*} [CommGroup G] [TopologicalSpace G] [ChartedSpace H' G] [LieGroup I' G]
+variable {ι : Type*} {J : Finset ι} {f : ι → M → G} {n : ℕ∞} {s : Set M} {x₀ : M}
+
+@[to_additive]
+theorem ContMDiffWithinAt.prod (h : ∀ i ∈ J, ContMDiffWithinAt I I' n (f i) s x₀) :
+    ContMDiffWithinAt I I' n (fun x ↦ ∏ i in J, f i x) s x₀ := by
+  classical
+  induction' J using Finset.induction_on with i K iK IH
+  · simp [contMDiffWithinAt_const]
+  · simp only [iK, Finset.prod_insert, not_false_iff]
+    exact (h _ (Finset.mem_insert_self i K)).mul (IH fun j hj ↦ h _ <| Finset.mem_insert_of_mem hj)
+
+@[to_additive]
+theorem ContMDiffAt.prod (h : ∀ i ∈ J, ContMDiffAt I I' n (f i) x₀) :
+    ContMDiffAt I I' n (fun x ↦ ∏ i in J, f i x) x₀ := by
+  simp only [← contMDiffWithinAt_univ] at *
+  exact ContMDiffWithinAt.prod h
+
+@[to_additive]
+theorem ContMDiff.prod (h : ∀ i ∈ J, ContMDiff I I' n (f i)) :
+    ContMDiff I I' n fun x ↦ ∏ i in J, f i x :=
+  fun x ↦ ContMDiffAt.prod fun j hj ↦ h j hj x
+
+@[to_additive]
+theorem contMDiffWithinAt_finprod (lf : LocallyFinite fun i ↦ mulSupport <| f i) {x₀ : M}
+    (h : ∀ i, ContMDiffWithinAt I I' n (f i) s x₀) :
+    ContMDiffWithinAt I I' n (fun x ↦ ∏ᶠ i, f i x) s x₀ :=
+  let ⟨_I, hI⟩ := finprod_eventually_eq_prod lf x₀
+  (ContMDiffWithinAt.prod fun i _hi ↦ h i).congr_of_eventuallyEq
+    (eventually_nhdsWithin_of_eventually_nhds hI) hI.self_of_nhds
+
+@[to_additive]
+theorem contMDiffAt_finprod
+    (lf : LocallyFinite fun i ↦ mulSupport <| f i) (h : ∀ i, ContMDiffAt I I' n (f i) x₀) :
+    ContMDiffAt I I' n (fun x ↦ ∏ᶠ i, f i x) x₀ :=
+  contMDiffWithinAt_finprod lf h
+
+@[to_additive]
+theorem smoothAt_finprod
+    (lf : LocallyFinite fun i ↦ mulSupport <| f i) (h : ∀ i, SmoothAt I I' (f i) x₀) :
+    SmoothAt I I' (fun x ↦ ∏ᶠ i, f i x) x₀ :=
+  contMDiffWithinAt_finprod lf h
+
+-- See `Algebra/Monoid.lean` for `contMDiff_finprod` and `smooth_finprod`.
+
+end FiniteSumProduct

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -33,8 +33,6 @@ groups here are not necessarily finite dimensional.
   is smooth at all points at which `f` doesn't vanish.
   ``ContMDiff.div₀` and variants: if also `SmoothMul N` (i.e., `N` is a Lie group except possibly
   for smoothness of inversion at `0`), similar results hold for point-wise division.
-* `ContMDiff.prod`, `ContMDiff.sum`: finite products resp. sums of differentiable maps `M → G`
-  into an abelian (multiplicative resp. additive) Lie group are differentiable.
 
 * `normedSpaceLieAddGroup` : a normed vector space over a nontrivially normed field
   is an additive Lie group.
@@ -375,65 +373,3 @@ theorem Smooth.div₀ (hf : Smooth I' I f) (hg : Smooth I' I g) (h₀ : ∀ x, g
   ContMDiff.div₀ hf hg h₀
 
 end Div
-
-/-! ### Differentiability of finite point-wise sums and products
-
-  Finite point-wise products of functions `M → G` into an abelian multiplicative
-  Lie group `G` are differentiable. -/
-section FiniteSumProduct
-open Function
-open scoped BigOperators
-
--- let `M` be a smooth manifold over `(E,H)`
--- let `G` be an abelian Lie group modeled on `(E', H')`
-variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
-  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
-  {I : ModelWithCorners 𝕜 E H} {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
-  {E' H' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] [TopologicalSpace H']
-  {I' : ModelWithCorners 𝕜 E' H'}
-  {G : Type*} [CommGroup G] [TopologicalSpace G] [ChartedSpace H' G] [LieGroup I' G]
-variable {ι : Type*} {J : Finset ι} {f : ι → M → G} {n : ℕ∞} {s : Set M} {x₀ : M}
-
-@[to_additive]
-theorem ContMDiffWithinAt.prod (h : ∀ i ∈ J, ContMDiffWithinAt I I' n (f i) s x₀) :
-    ContMDiffWithinAt I I' n (fun x ↦ ∏ i in J, f i x) s x₀ := by
-  classical
-  induction' J using Finset.induction_on with i K iK IH
-  · simp [contMDiffWithinAt_const]
-  · simp only [iK, Finset.prod_insert, not_false_iff]
-    exact (h _ (Finset.mem_insert_self i K)).mul (IH fun j hj ↦ h _ <| Finset.mem_insert_of_mem hj)
-
-@[to_additive]
-theorem ContMDiffAt.prod (h : ∀ i ∈ J, ContMDiffAt I I' n (f i) x₀) :
-    ContMDiffAt I I' n (fun x ↦ ∏ i in J, f i x) x₀ := by
-  simp only [← contMDiffWithinAt_univ] at *
-  exact ContMDiffWithinAt.prod h
-
-@[to_additive]
-theorem ContMDiff.prod (h : ∀ i ∈ J, ContMDiff I I' n (f i)) :
-    ContMDiff I I' n fun x ↦ ∏ i in J, f i x :=
-  fun x ↦ ContMDiffAt.prod fun j hj ↦ h j hj x
-
-@[to_additive]
-theorem contMDiffWithinAt_finprod (lf : LocallyFinite fun i ↦ mulSupport <| f i) {x₀ : M}
-    (h : ∀ i, ContMDiffWithinAt I I' n (f i) s x₀) :
-    ContMDiffWithinAt I I' n (fun x ↦ ∏ᶠ i, f i x) s x₀ :=
-  let ⟨_I, hI⟩ := finprod_eventually_eq_prod lf x₀
-  (ContMDiffWithinAt.prod fun i _hi ↦ h i).congr_of_eventuallyEq
-    (eventually_nhdsWithin_of_eventually_nhds hI) hI.self_of_nhds
-
-@[to_additive]
-theorem contMDiffAt_finprod
-    (lf : LocallyFinite fun i ↦ mulSupport <| f i) (h : ∀ i, ContMDiffAt I I' n (f i) x₀) :
-    ContMDiffAt I I' n (fun x ↦ ∏ᶠ i, f i x) x₀ :=
-  contMDiffWithinAt_finprod lf h
-
-@[to_additive]
-theorem smoothAt_finprod
-    (lf : LocallyFinite fun i ↦ mulSupport <| f i) (h : ∀ i, SmoothAt I I' (f i) x₀) :
-    SmoothAt I I' (fun x ↦ ∏ᶠ i, f i x) x₀ :=
-  contMDiffWithinAt_finprod lf h
-
--- See `Algebra/Monoid.lean` for `contMDiff_finprod` and `smooth_finprod`.
-
-end FiniteSumProduct

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -81,7 +81,8 @@ section
 
 variable (I)
 
-@[to_additive]
+/-- In a Lie group, inversion is a smooth map. -/
+@[to_additive "In an additive Lie group, inversion is a smooth map."]
 theorem smooth_inv : Smooth I I fun x : G => x⁻¹ :=
   LieGroup.smooth_inv
 #align smooth_inv smooth_inv
@@ -231,6 +232,7 @@ instance normedSpaceLieAddGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E
   smooth_neg := contDiff_neg.contMDiff
 #align normed_space_lie_add_group normedSpaceLieAddGroup
 
+/-! Inversion is smooth at all non-zero points. -/
 section HasSmoothInv
 
 -- See note [Design choices about smooth algebraic structures]

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -21,10 +21,10 @@ groups here are not necessarily finite dimensional.
 ## Main definitions and statements
 
 * `LieAddGroup I G` : a Lie additive group where `G` is a manifold on the model with corners `I`.
-* `LieGroup I G`     : a Lie multiplicative group where `G` is a manifold on the model with
-                        corners `I`.
+* `LieGroup I G` : a Lie multiplicative group where `G` is a manifold on the model with corners `I`.
 * `normedSpaceLieAddGroup` : a normed vector space over a nontrivially normed field
-                                 is an additive Lie group.
+  is an additive Lie group.
+
 
 ## Implementation notes
 

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -305,6 +305,7 @@ end Monoid
   into a commutative monoid `G` are differentiable/smooth at `x`/on `s`. -/
 section CommMonoid
 
+open Function
 open scoped BigOperators
 
 variable {ι 𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
@@ -325,7 +326,7 @@ theorem ContMDiffWithinAt.prod (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) 
     exact (h _ (Finset.mem_insert_self i K)).mul (IH fun j hj ↦ h _ <| Finset.mem_insert_of_mem hj)
 
 @[to_additive]
-theorem contMDiffWithinAt_finprod (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) {x₀ : M}
+theorem contMDiffWithinAt_finprod (lf : LocallyFinite fun i ↦ mulSupport <| f i) {x₀ : M}
     (h : ∀ i, ContMDiffWithinAt I' I n (f i) s x₀) :
     ContMDiffWithinAt I' I n (fun x ↦ ∏ᶠ i, f i x) s x₀ :=
   let ⟨_I, hI⟩ := finprod_eventually_eq_prod lf x₀
@@ -357,7 +358,7 @@ theorem ContMDiffAt.prod (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x₀) :
 
 @[to_additive]
 theorem contMDiffAt_finprod
-    (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) (h : ∀ i, ContMDiffAt I' I n (f i) x₀) :
+    (lf : LocallyFinite fun i ↦ mulSupport <| f i) (h : ∀ i, ContMDiffAt I' I n (f i) x₀) :
     ContMDiffAt I' I n (fun x ↦ ∏ᶠ i, f i x) x₀ :=
   contMDiffWithinAt_finprod lf h
 
@@ -409,7 +410,7 @@ theorem contMDiff_finset_prod (h : ∀ i ∈ t, ContMDiff I' I n (f i)) :
 
 @[to_additive]
 theorem contMDiff_finprod (h : ∀ i, ContMDiff I' I n (f i))
-    (hfin : LocallyFinite fun i => Function.mulSupport (f i)) : ContMDiff I' I n fun x => ∏ᶠ i, f i x := by
+    (hfin : LocallyFinite fun i => mulSupport (f i)) : ContMDiff I' I n fun x => ∏ᶠ i, f i x := by
   intro x
   rcases finprod_eventually_eq_prod hfin x with ⟨s, hs⟩
   exact (contMDiff_finset_prod (fun i _ => h i) x).congr_of_eventuallyEq hs
@@ -418,7 +419,7 @@ theorem contMDiff_finprod (h : ∀ i, ContMDiff I' I n (f i))
 
 @[to_additive]
 theorem contMDiff_finprod_cond (hc : ∀ i, p i → ContMDiff I' I n (f i))
-    (hf : LocallyFinite fun i => Function.mulSupport (f i)) :
+    (hf : LocallyFinite fun i => mulSupport (f i)) :
     ContMDiff I' I n fun x => ∏ᶠ (i) (_ : p i), f i x := by
   simp only [← finprod_subtype_eq_finprod_cond]
   exact contMDiff_finprod (fun i => hc i i.2) (hf.comp_injective Subtype.coe_injective)
@@ -427,7 +428,7 @@ theorem contMDiff_finprod_cond (hc : ∀ i, p i → ContMDiff I' I n (f i))
 
 @[to_additive]
 theorem smoothAt_finprod
-    (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) (h : ∀ i, SmoothAt I' I (f i) x₀) :
+    (lf : LocallyFinite fun i ↦ mulSupport <| f i) (h : ∀ i, SmoothAt I' I (f i) x₀) :
     SmoothAt I' I (fun x ↦ ∏ᶠ i, f i x) x₀ :=
   contMDiffWithinAt_finprod lf h
 
@@ -488,14 +489,14 @@ theorem smooth_finset_prod (h : ∀ i ∈ t, Smooth I' I (f i)) :
 
 @[to_additive]
 theorem smooth_finprod (h : ∀ i, Smooth I' I (f i))
-    (hfin : LocallyFinite fun i => Function.mulSupport (f i)) : Smooth I' I fun x => ∏ᶠ i, f i x :=
+    (hfin : LocallyFinite fun i => mulSupport (f i)) : Smooth I' I fun x => ∏ᶠ i, f i x :=
   contMDiff_finprod h hfin
 #align smooth_finprod smooth_finprod
 #align smooth_finsum smooth_finsum
 
 @[to_additive]
 theorem smooth_finprod_cond (hc : ∀ i, p i → Smooth I' I (f i))
-    (hf : LocallyFinite fun i => Function.mulSupport (f i)) :
+    (hf : LocallyFinite fun i => mulSupport (f i)) :
     Smooth I' I fun x => ∏ᶠ (i) (_ : p i), f i x :=
   contMDiff_finprod_cond hc hf
 #align smooth_finprod_cond smooth_finprod_cond

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -299,16 +299,30 @@ instance : ContinuousMapClass (SmoothMonoidMorphism I I' G G') G G' where
 
 end Monoid
 
+/-! ### Differentiability of finite point-wise sums and products
+
+  Finite point-wise products (resp. sums) of differentiable/smooth functions `M → G` (at `x`/on `s`)
+  into a commutative monoid `G` are differentiable/smooth at `x`/on `s`. -/
 section CommMonoid
 
 open scoped BigOperators
 
-variable {ι 𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H] {E : Type*}
-  [NormedAddCommGroup E] [NormedSpace 𝕜 E] {I : ModelWithCorners 𝕜 E H} {G : Type*} [CommMonoid G]
-  [TopologicalSpace G] [ChartedSpace H G] [SmoothMul I G] {E' : Type*} [NormedAddCommGroup E']
-  [NormedSpace 𝕜 E'] {H' : Type*} [TopologicalSpace H'] {I' : ModelWithCorners 𝕜 E' H'}
-  {M : Type*} [TopologicalSpace M] [ChartedSpace H' M] {s : Set M} {x : M} {t : Finset ι}
-  {f : ι → M → G} {n : ℕ∞} {p : ι → Prop}
+variable {ι 𝕜 : Type*} [NontriviallyNormedField 𝕜] {H : Type*} [TopologicalSpace H]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] {I : ModelWithCorners 𝕜 E H}
+  {G : Type*} [CommMonoid G] [TopologicalSpace G] [ChartedSpace H G] [SmoothMul I G]
+  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {H' : Type*} [TopologicalSpace H'] {I' : ModelWithCorners 𝕜 E' H'}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H' M]
+  {s : Set M} {x x₀ : M} {t : Finset ι} {f : ι → M → G} {n : ℕ∞} {p : ι → Prop}
+
+@[to_additive]
+theorem ContMDiffWithinAt.prod (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) s x₀) :
+    ContMDiffWithinAt I' I n (fun x ↦ ∏ i in t, f i x) s x₀ := by
+  classical
+  induction' t using Finset.induction_on with i K iK IH
+  · simp [contMDiffWithinAt_const]
+  · simp only [iK, Finset.prod_insert, not_false_iff]
+    exact (h _ (Finset.mem_insert_self i K)).mul (IH fun j hj ↦ h _ <| Finset.mem_insert_of_mem hj)
 
 @[to_additive]
 theorem contMDiffWithinAt_finset_prod' (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) s x) :
@@ -317,6 +331,12 @@ theorem contMDiffWithinAt_finset_prod' (h : ∀ i ∈ t, ContMDiffWithinAt I' I 
     contMDiffWithinAt_const h
 #align cont_mdiff_within_at_finset_prod' contMDiffWithinAt_finset_prod'
 #align cont_mdiff_within_at_finset_sum' contMDiffWithinAt_finset_sum'
+
+@[to_additive]
+theorem ContMDiffAt.prod (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x₀) :
+    ContMDiffAt I' I n (fun x ↦ ∏ i in t, f i x) x₀ := by
+  simp only [← contMDiffWithinAt_univ] at *
+  exact ContMDiffWithinAt.prod h
 
 @[to_additive]
 theorem contMDiffAt_finset_prod' (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x) :
@@ -333,10 +353,29 @@ theorem contMDiffOn_finset_prod' (h : ∀ i ∈ t, ContMDiffOn I' I n (f i) s) :
 #align cont_mdiff_on_finset_sum' contMDiffOn_finset_sum'
 
 @[to_additive]
+theorem ContMDiff.prod (h : ∀ i ∈ t, ContMDiff I' I n (f i)) :
+    ContMDiff I' I n fun x ↦ ∏ i in t, f i x :=
+  fun x ↦ ContMDiffAt.prod fun j hj ↦ h j hj x
+
+@[to_additive]
 theorem contMDiff_finset_prod' (h : ∀ i ∈ t, ContMDiff I' I n (f i)) :
     ContMDiff I' I n (∏ i in t, f i) := fun x => contMDiffAt_finset_prod' fun i hi => h i hi x
 #align cont_mdiff_finset_prod' contMDiff_finset_prod'
 #align cont_mdiff_finset_sum' contMDiff_finset_sum'
+
+@[to_additive]
+theorem contMDiffWithinAt_finprod (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) {x₀ : M}
+    (h : ∀ i, ContMDiffWithinAt I' I n (f i) s x₀) :
+    ContMDiffWithinAt I' I n (fun x ↦ ∏ᶠ i, f i x) s x₀ :=
+  let ⟨_I, hI⟩ := finprod_eventually_eq_prod lf x₀
+  (ContMDiffWithinAt.prod fun i _hi ↦ h i).congr_of_eventuallyEq
+    (eventually_nhdsWithin_of_eventually_nhds hI) hI.self_of_nhds
+
+@[to_additive]
+theorem contMDiffAt_finprod
+    (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) (h : ∀ i, ContMDiffAt I' I n (f i) x₀) :
+    ContMDiffAt I' I n (fun x ↦ ∏ᶠ i, f i x) x₀ :=
+  contMDiffWithinAt_finprod lf h
 
 @[to_additive]
 theorem contMDiffWithinAt_finset_prod (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) s x) :
@@ -380,6 +419,12 @@ theorem smoothAt_finset_prod' (h : ∀ i ∈ t, SmoothAt I' I (f i) x) :
   contMDiffAt_finset_prod' h
 #align smooth_at_finset_prod' smoothAt_finset_prod'
 #align smooth_at_finset_sum' smoothAt_finset_sum'
+
+@[to_additive]
+theorem smoothAt_finprod
+    (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) (h : ∀ i, SmoothAt I' I (f i) x₀) :
+    SmoothAt I' I (fun x ↦ ∏ᶠ i, f i x) x₀ :=
+  contMDiffWithinAt_finprod lf h
 
 @[to_additive]
 theorem smoothOn_finset_prod' (h : ∀ i ∈ t, SmoothOn I' I (f i) s) :

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -349,7 +349,6 @@ theorem contMDiffWithinAt_finset_prod (h : ∀ i ∈ t, ContMDiffWithinAt I' I n
 #align cont_mdiff_within_at_finset_prod contMDiffWithinAt_finset_prod
 #align cont_mdiff_within_at_finset_sum contMDiffWithinAt_finset_sum
 
-
 @[to_additive]
 theorem ContMDiffAt.prod (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x₀) :
     ContMDiffAt I' I n (fun x ↦ ∏ i in t, f i x) x₀ := by
@@ -375,6 +374,12 @@ theorem contMDiffAt_finset_prod (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x) :
   contMDiffWithinAt_finset_prod h
 #align cont_mdiff_at_finset_prod contMDiffAt_finset_prod
 #align cont_mdiff_at_finset_sum contMDiffAt_finset_sum
+
+@[to_additive]
+theorem contMDiffOn_finprod
+    (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) (h : ∀ i, ContMDiffOn I' I n (f i) s) :
+    ContMDiffOn I' I n (fun x ↦ ∏ᶠ i, f i x) s := fun x hx ↦
+  contMDiffWithinAt_finprod lf fun i ↦ h i x hx
 
 @[to_additive]
 theorem contMDiffOn_finset_prod' (h : ∀ i ∈ t, ContMDiffOn I' I n (f i) s) :
@@ -410,10 +415,8 @@ theorem contMDiff_finset_prod (h : ∀ i ∈ t, ContMDiff I' I n (f i)) :
 
 @[to_additive]
 theorem contMDiff_finprod (h : ∀ i, ContMDiff I' I n (f i))
-    (hfin : LocallyFinite fun i => mulSupport (f i)) : ContMDiff I' I n fun x => ∏ᶠ i, f i x := by
-  intro x
-  rcases finprod_eventually_eq_prod hfin x with ⟨s, hs⟩
-  exact (contMDiff_finset_prod (fun i _ => h i) x).congr_of_eventuallyEq hs
+    (hfin : LocallyFinite fun i => mulSupport (f i)) : ContMDiff I' I n fun x => ∏ᶠ i, f i x :=
+  fun x ↦ contMDiffAt_finprod hfin fun i ↦ h i x
 #align cont_mdiff_finprod contMDiff_finprod
 #align cont_mdiff_finsum contMDiff_finsum
 

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -325,6 +325,14 @@ theorem ContMDiffWithinAt.prod (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) 
     exact (h _ (Finset.mem_insert_self i K)).mul (IH fun j hj ↦ h _ <| Finset.mem_insert_of_mem hj)
 
 @[to_additive]
+theorem contMDiffWithinAt_finprod (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) {x₀ : M}
+    (h : ∀ i, ContMDiffWithinAt I' I n (f i) s x₀) :
+    ContMDiffWithinAt I' I n (fun x ↦ ∏ᶠ i, f i x) s x₀ :=
+  let ⟨_I, hI⟩ := finprod_eventually_eq_prod lf x₀
+  (ContMDiffWithinAt.prod fun i _hi ↦ h i).congr_of_eventuallyEq
+    (eventually_nhdsWithin_of_eventually_nhds hI) hI.self_of_nhds
+
+@[to_additive]
 theorem contMDiffWithinAt_finset_prod' (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) s x) :
     ContMDiffWithinAt I' I n (∏ i in t, f i) s x :=
   Finset.prod_induction f (fun f => ContMDiffWithinAt I' I n f s x) (fun _ _ hf hg => hf.mul hg)
@@ -333,10 +341,25 @@ theorem contMDiffWithinAt_finset_prod' (h : ∀ i ∈ t, ContMDiffWithinAt I' I 
 #align cont_mdiff_within_at_finset_sum' contMDiffWithinAt_finset_sum'
 
 @[to_additive]
+theorem contMDiffWithinAt_finset_prod (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) s x) :
+    ContMDiffWithinAt I' I n (fun x => ∏ i in t, f i x) s x := by
+  simp only [← Finset.prod_apply]
+  exact contMDiffWithinAt_finset_prod' h
+#align cont_mdiff_within_at_finset_prod contMDiffWithinAt_finset_prod
+#align cont_mdiff_within_at_finset_sum contMDiffWithinAt_finset_sum
+
+
+@[to_additive]
 theorem ContMDiffAt.prod (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x₀) :
     ContMDiffAt I' I n (fun x ↦ ∏ i in t, f i x) x₀ := by
   simp only [← contMDiffWithinAt_univ] at *
   exact ContMDiffWithinAt.prod h
+
+@[to_additive]
+theorem contMDiffAt_finprod
+    (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) (h : ∀ i, ContMDiffAt I' I n (f i) x₀) :
+    ContMDiffAt I' I n (fun x ↦ ∏ᶠ i, f i x) x₀ :=
+  contMDiffWithinAt_finprod lf h
 
 @[to_additive]
 theorem contMDiffAt_finset_prod' (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x) :
@@ -346,11 +369,25 @@ theorem contMDiffAt_finset_prod' (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x) :
 #align cont_mdiff_at_finset_sum' contMDiffAt_finset_sum'
 
 @[to_additive]
+theorem contMDiffAt_finset_prod (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x) :
+    ContMDiffAt I' I n (fun x => ∏ i in t, f i x) x :=
+  contMDiffWithinAt_finset_prod h
+#align cont_mdiff_at_finset_prod contMDiffAt_finset_prod
+#align cont_mdiff_at_finset_sum contMDiffAt_finset_sum
+
+@[to_additive]
 theorem contMDiffOn_finset_prod' (h : ∀ i ∈ t, ContMDiffOn I' I n (f i) s) :
     ContMDiffOn I' I n (∏ i in t, f i) s := fun x hx =>
   contMDiffWithinAt_finset_prod' fun i hi => h i hi x hx
 #align cont_mdiff_on_finset_prod' contMDiffOn_finset_prod'
 #align cont_mdiff_on_finset_sum' contMDiffOn_finset_sum'
+
+@[to_additive]
+theorem contMDiffOn_finset_prod (h : ∀ i ∈ t, ContMDiffOn I' I n (f i) s) :
+    ContMDiffOn I' I n (fun x => ∏ i in t, f i x) s := fun x hx =>
+  contMDiffWithinAt_finset_prod fun i hi => h i hi x hx
+#align cont_mdiff_on_finset_prod contMDiffOn_finset_prod
+#align cont_mdiff_on_finset_sum contMDiffOn_finset_sum
 
 @[to_additive]
 theorem ContMDiff.prod (h : ∀ i ∈ t, ContMDiff I' I n (f i)) :
@@ -364,47 +401,35 @@ theorem contMDiff_finset_prod' (h : ∀ i ∈ t, ContMDiff I' I n (f i)) :
 #align cont_mdiff_finset_sum' contMDiff_finset_sum'
 
 @[to_additive]
-theorem contMDiffWithinAt_finprod (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) {x₀ : M}
-    (h : ∀ i, ContMDiffWithinAt I' I n (f i) s x₀) :
-    ContMDiffWithinAt I' I n (fun x ↦ ∏ᶠ i, f i x) s x₀ :=
-  let ⟨_I, hI⟩ := finprod_eventually_eq_prod lf x₀
-  (ContMDiffWithinAt.prod fun i _hi ↦ h i).congr_of_eventuallyEq
-    (eventually_nhdsWithin_of_eventually_nhds hI) hI.self_of_nhds
-
-@[to_additive]
-theorem contMDiffAt_finprod
-    (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) (h : ∀ i, ContMDiffAt I' I n (f i) x₀) :
-    ContMDiffAt I' I n (fun x ↦ ∏ᶠ i, f i x) x₀ :=
-  contMDiffWithinAt_finprod lf h
-
-@[to_additive]
-theorem contMDiffWithinAt_finset_prod (h : ∀ i ∈ t, ContMDiffWithinAt I' I n (f i) s x) :
-    ContMDiffWithinAt I' I n (fun x => ∏ i in t, f i x) s x := by
-  simp only [← Finset.prod_apply]
-  exact contMDiffWithinAt_finset_prod' h
-#align cont_mdiff_within_at_finset_prod contMDiffWithinAt_finset_prod
-#align cont_mdiff_within_at_finset_sum contMDiffWithinAt_finset_sum
-
-@[to_additive]
-theorem contMDiffAt_finset_prod (h : ∀ i ∈ t, ContMDiffAt I' I n (f i) x) :
-    ContMDiffAt I' I n (fun x => ∏ i in t, f i x) x :=
-  contMDiffWithinAt_finset_prod h
-#align cont_mdiff_at_finset_prod contMDiffAt_finset_prod
-#align cont_mdiff_at_finset_sum contMDiffAt_finset_sum
-
-@[to_additive]
-theorem contMDiffOn_finset_prod (h : ∀ i ∈ t, ContMDiffOn I' I n (f i) s) :
-    ContMDiffOn I' I n (fun x => ∏ i in t, f i x) s := fun x hx =>
-  contMDiffWithinAt_finset_prod fun i hi => h i hi x hx
-#align cont_mdiff_on_finset_prod contMDiffOn_finset_prod
-#align cont_mdiff_on_finset_sum contMDiffOn_finset_sum
-
-@[to_additive]
 theorem contMDiff_finset_prod (h : ∀ i ∈ t, ContMDiff I' I n (f i)) :
     ContMDiff I' I n fun x => ∏ i in t, f i x := fun x =>
   contMDiffAt_finset_prod fun i hi => h i hi x
 #align cont_mdiff_finset_prod contMDiff_finset_prod
 #align cont_mdiff_finset_sum contMDiff_finset_sum
+
+@[to_additive]
+theorem contMDiff_finprod (h : ∀ i, ContMDiff I' I n (f i))
+    (hfin : LocallyFinite fun i => Function.mulSupport (f i)) : ContMDiff I' I n fun x => ∏ᶠ i, f i x := by
+  intro x
+  rcases finprod_eventually_eq_prod hfin x with ⟨s, hs⟩
+  exact (contMDiff_finset_prod (fun i _ => h i) x).congr_of_eventuallyEq hs
+#align cont_mdiff_finprod contMDiff_finprod
+#align cont_mdiff_finsum contMDiff_finsum
+
+@[to_additive]
+theorem contMDiff_finprod_cond (hc : ∀ i, p i → ContMDiff I' I n (f i))
+    (hf : LocallyFinite fun i => Function.mulSupport (f i)) :
+    ContMDiff I' I n fun x => ∏ᶠ (i) (_ : p i), f i x := by
+  simp only [← finprod_subtype_eq_finprod_cond]
+  exact contMDiff_finprod (fun i => hc i i.2) (hf.comp_injective Subtype.coe_injective)
+#align cont_mdiff_finprod_cond contMDiff_finprod_cond
+#align cont_mdiff_finsum_cond contMDiff_finsum_cond
+
+@[to_additive]
+theorem smoothAt_finprod
+    (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) (h : ∀ i, SmoothAt I' I (f i) x₀) :
+    SmoothAt I' I (fun x ↦ ∏ᶠ i, f i x) x₀ :=
+  contMDiffWithinAt_finprod lf h
 
 @[to_additive]
 theorem smoothWithinAt_finset_prod' (h : ∀ i ∈ t, SmoothWithinAt I' I (f i) s x) :
@@ -414,37 +439,18 @@ theorem smoothWithinAt_finset_prod' (h : ∀ i ∈ t, SmoothWithinAt I' I (f i) 
 #align smooth_within_at_finset_sum' smoothWithinAt_finset_sum'
 
 @[to_additive]
-theorem smoothAt_finset_prod' (h : ∀ i ∈ t, SmoothAt I' I (f i) x) :
-    SmoothAt I' I (∏ i in t, f i) x :=
-  contMDiffAt_finset_prod' h
-#align smooth_at_finset_prod' smoothAt_finset_prod'
-#align smooth_at_finset_sum' smoothAt_finset_sum'
-
-@[to_additive]
-theorem smoothAt_finprod
-    (lf : LocallyFinite fun i ↦ Function.mulSupport <| f i) (h : ∀ i, SmoothAt I' I (f i) x₀) :
-    SmoothAt I' I (fun x ↦ ∏ᶠ i, f i x) x₀ :=
-  contMDiffWithinAt_finprod lf h
-
-@[to_additive]
-theorem smoothOn_finset_prod' (h : ∀ i ∈ t, SmoothOn I' I (f i) s) :
-    SmoothOn I' I (∏ i in t, f i) s :=
-  contMDiffOn_finset_prod' h
-#align smooth_on_finset_prod' smoothOn_finset_prod'
-#align smooth_on_finset_sum' smoothOn_finset_sum'
-
-@[to_additive]
-theorem smooth_finset_prod' (h : ∀ i ∈ t, Smooth I' I (f i)) : Smooth I' I (∏ i in t, f i) :=
-  contMDiff_finset_prod' h
-#align smooth_finset_prod' smooth_finset_prod'
-#align smooth_finset_sum' smooth_finset_sum'
-
-@[to_additive]
 theorem smoothWithinAt_finset_prod (h : ∀ i ∈ t, SmoothWithinAt I' I (f i) s x) :
     SmoothWithinAt I' I (fun x => ∏ i in t, f i x) s x :=
   contMDiffWithinAt_finset_prod h
 #align smooth_within_at_finset_prod smoothWithinAt_finset_prod
 #align smooth_within_at_finset_sum smoothWithinAt_finset_sum
+
+@[to_additive]
+theorem smoothAt_finset_prod' (h : ∀ i ∈ t, SmoothAt I' I (f i) x) :
+    SmoothAt I' I (∏ i in t, f i) x :=
+  contMDiffAt_finset_prod' h
+#align smooth_at_finset_prod' smoothAt_finset_prod'
+#align smooth_at_finset_sum' smoothAt_finset_sum'
 
 @[to_additive]
 theorem smoothAt_finset_prod (h : ∀ i ∈ t, SmoothAt I' I (f i) x) :
@@ -454,11 +460,24 @@ theorem smoothAt_finset_prod (h : ∀ i ∈ t, SmoothAt I' I (f i) x) :
 #align smooth_at_finset_sum smoothAt_finset_sum
 
 @[to_additive]
+theorem smoothOn_finset_prod' (h : ∀ i ∈ t, SmoothOn I' I (f i) s) :
+    SmoothOn I' I (∏ i in t, f i) s :=
+  contMDiffOn_finset_prod' h
+#align smooth_on_finset_prod' smoothOn_finset_prod'
+#align smooth_on_finset_sum' smoothOn_finset_sum'
+
+@[to_additive]
 theorem smoothOn_finset_prod (h : ∀ i ∈ t, SmoothOn I' I (f i) s) :
     SmoothOn I' I (fun x => ∏ i in t, f i x) s :=
   contMDiffOn_finset_prod h
 #align smooth_on_finset_prod smoothOn_finset_prod
 #align smooth_on_finset_sum smoothOn_finset_sum
+
+@[to_additive]
+theorem smooth_finset_prod' (h : ∀ i ∈ t, Smooth I' I (f i)) : Smooth I' I (∏ i in t, f i) :=
+  contMDiff_finset_prod' h
+#align smooth_finset_prod' smooth_finset_prod'
+#align smooth_finset_sum' smooth_finset_sum'
 
 @[to_additive]
 theorem smooth_finset_prod (h : ∀ i ∈ t, Smooth I' I (f i)) :
@@ -467,36 +486,16 @@ theorem smooth_finset_prod (h : ∀ i ∈ t, Smooth I' I (f i)) :
 #align smooth_finset_prod smooth_finset_prod
 #align smooth_finset_sum smooth_finset_sum
 
-open Function Filter
-
-@[to_additive]
-theorem contMDiff_finprod (h : ∀ i, ContMDiff I' I n (f i))
-    (hfin : LocallyFinite fun i => mulSupport (f i)) : ContMDiff I' I n fun x => ∏ᶠ i, f i x := by
-  intro x
-  rcases finprod_eventually_eq_prod hfin x with ⟨s, hs⟩
-  exact (contMDiff_finset_prod (fun i _ => h i) x).congr_of_eventuallyEq hs
-#align cont_mdiff_finprod contMDiff_finprod
-#align cont_mdiff_finsum contMDiff_finsum
-
-@[to_additive]
-theorem contMDiff_finprod_cond (hc : ∀ i, p i → ContMDiff I' I n (f i))
-    (hf : LocallyFinite fun i => mulSupport (f i)) :
-    ContMDiff I' I n fun x => ∏ᶠ (i) (_ : p i), f i x := by
-  simp only [← finprod_subtype_eq_finprod_cond]
-  exact contMDiff_finprod (fun i => hc i i.2) (hf.comp_injective Subtype.coe_injective)
-#align cont_mdiff_finprod_cond contMDiff_finprod_cond
-#align cont_mdiff_finsum_cond contMDiff_finsum_cond
-
 @[to_additive]
 theorem smooth_finprod (h : ∀ i, Smooth I' I (f i))
-    (hfin : LocallyFinite fun i => mulSupport (f i)) : Smooth I' I fun x => ∏ᶠ i, f i x :=
+    (hfin : LocallyFinite fun i => Function.mulSupport (f i)) : Smooth I' I fun x => ∏ᶠ i, f i x :=
   contMDiff_finprod h hfin
 #align smooth_finprod smooth_finprod
 #align smooth_finsum smooth_finsum
 
 @[to_additive]
 theorem smooth_finprod_cond (hc : ∀ i, p i → Smooth I' I (f i))
-    (hf : LocallyFinite fun i => mulSupport (f i)) :
+    (hf : LocallyFinite fun i => Function.mulSupport (f i)) :
     Smooth I' I fun x => ∏ᶠ (i) (_ : p i), f i x :=
   contMDiff_finprod_cond hc hf
 #align smooth_finprod_cond smooth_finprod_cond


### PR DESCRIPTION
From sphere-eversion; I'm just upstreaming this.

--------
- [x] depends on: #9766
Commits after "move to monoid file" are best reviewed individually.