### PR TITLE
[Merged by Bors] - doc(Algebra/Group/Defs): add note on names `SMul`, `VAdd`; typo fix

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -33,8 +33,7 @@ actions and register the following instances:
 - `SMul ℕ M` for additive monoids `M`, and `SMul ℤ G` for additive groups `G`.
 
 `SMul` is typically, but not exclusively, used for scalar multiplication-like operators.
-An informal motivating example for the name `VAdd` (vector addition) is the action of a
-vector space by translation.
+See the module `Algebra.AddTorsor` for a motivating example for the name `VAdd` (vector addition)`.
 
 ## Notation
 

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -33,8 +33,8 @@ actions and register the following instances:
 - `SMul ℕ M` for additive monoids `M`, and `SMul ℤ G` for additive groups `G`.
 
 `SMul` is typically, but not exclusively, used for scalar multiplication-like operators.
-A motivating example for the name `VAdd` (vector addition) is the action of a vector space
-on a Euclidean space, where the result of adding a vector to a point is a point.
+An informal motivating example for the name `VAdd` (vector addition) is the action of a
+vector space by translation.
 
 ## Notation
 

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -26,11 +26,15 @@ The file does not contain any lemmas except for
 
 For basic lemmas about these classes see `Algebra.Group.Basic`.
 
-We also introduce notation classes `lul` and `VAdd` for multiplicative and additive
+We also introduce notation classes `SMul` and `VAdd` for multiplicative and additive
 actions and register the following instances:
 
 - `Pow M ℕ`, for monoids `M`, and `Pow G ℤ` for groups `G`;
 - `SMul ℕ M` for additive monoids `M`, and `SMul ℤ G` for additive groups `G`.
+
+`SMul` is typically, but not exclusively, used for scalar multiplication-like operators.
+A motivating example for the name `VAdd` (vector addition) is the action of a vector space
+on a Euclidean space, where the result of adding a vector to a point is a point.
 
 ## Notation
 


### PR DESCRIPTION
Edited module docstring:
* Fixed recent accidental damage
* Added a note about the motivation for the names `SMul` and `VAdd`
[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/.60SMul.60.20and.20.60VAdd.60)
