### PR TITLE
[Merged by Bors] - chore(Topology/Support): group related lemmas using a section

### DIFF
--- a/Mathlib/Topology/Support.lean
+++ b/Mathlib/Topology/Support.lean
@@ -133,8 +133,16 @@ theorem continuous_of_mulTSupport [TopologicalSpace β] {f : α → β}
 #align continuous_of_mul_tsupport continuous_of_mulTSupport
 #align continuous_of_tsupport continuous_of_tsupport
 
+end
+
 /-! ## Functions with compact support -/
 section CompactSupport
+variable [TopologicalSpace α] [TopologicalSpace α']
+
+variable [One β] [One γ] [One δ]
+
+variable {g : β → γ} {f : α → β} {f₂ : α → γ} {m : β → γ → δ} {x : α}
+
 /-- A function `f` *has compact multiplicative support* or is *compactly supported* if the closure
 of the multiplicative support of `f` is compact. In a T₂ space this is equivalent to `f` being equal
 to `1` outside a compact set. -/
@@ -293,8 +301,6 @@ theorem continuous_extend_one [TopologicalSpace β] {U : Set α'} (hU : IsOpen U
 end HasCompactMulSupport
 
 end CompactSupport
-
-end
 
 section Monoid
 

--- a/Mathlib/Topology/Support.lean
+++ b/Mathlib/Topology/Support.lean
@@ -26,7 +26,7 @@ Furthermore, we say that `f` has compact support if the topological support of `
 
 * We write all lemmas for multiplicative functions, and use `@[to_additive]` to get the more common
   additive versions.
-* We do not put the definitions in the `function` namespace, following many other topological
+* We do not put the definitions in the `Function` namespace, following many other topological
   definitions that are in the root namespace (compare `Embedding` vs `Function.Embedding`).
 -/
 
@@ -133,6 +133,8 @@ theorem continuous_of_mulTSupport [TopologicalSpace β] {f : α → β}
 #align continuous_of_mul_tsupport continuous_of_mulTSupport
 #align continuous_of_tsupport continuous_of_tsupport
 
+/-! ## Functions with compact support -/
+section CompactSupport
 /-- A function `f` *has compact multiplicative support* or is *compactly supported* if the closure
 of the multiplicative support of `f` is compact. In a T₂ space this is equivalent to `f` being equal
 to `1` outside a compact set. -/
@@ -158,15 +160,16 @@ theorem exists_compact_iff_hasCompactMulSupport [T2Space α] :
 #align exists_compact_iff_has_compact_mul_support exists_compact_iff_hasCompactMulSupport
 #align exists_compact_iff_has_compact_support exists_compact_iff_hasCompactSupport
 
+namespace HasCompactMulSupport
 @[to_additive]
-theorem HasCompactMulSupport.intro [T2Space α] {K : Set α} (hK : IsCompact K)
+theorem intro [T2Space α] {K : Set α} (hK : IsCompact K)
     (hfK : ∀ x, x ∉ K → f x = 1) : HasCompactMulSupport f :=
   exists_compact_iff_hasCompactMulSupport.mp ⟨K, hK, hfK⟩
 #align has_compact_mul_support.intro HasCompactMulSupport.intro
 #align has_compact_support.intro HasCompactSupport.intro
 
 @[to_additive]
-theorem HasCompactMulSupport.intro' {K : Set α} (hK : IsCompact K) (h'K : IsClosed K)
+theorem intro' {K : Set α} (hK : IsCompact K) (h'K : IsClosed K)
     (hfK : ∀ x, x ∉ K → f x = 1) : HasCompactMulSupport f := by
   have : mulTSupport f ⊆ K := by
     rw [← h'K.closure_eq]
@@ -174,18 +177,18 @@ theorem HasCompactMulSupport.intro' {K : Set α} (hK : IsCompact K) (h'K : IsClo
   exact IsCompact.of_isClosed_subset hK ( isClosed_mulTSupport f) this
 
 @[to_additive]
-theorem HasCompactMulSupport.of_mulSupport_subset_isCompact [T2Space α] {K : Set α}
+theorem of_mulSupport_subset_isCompact [T2Space α] {K : Set α}
     (hK : IsCompact K) (h : mulSupport f ⊆ K) : HasCompactMulSupport f :=
   isCompact_closure_of_subset_compact hK h
 
 @[to_additive]
-theorem HasCompactMulSupport.isCompact (hf : HasCompactMulSupport f) : IsCompact (mulTSupport f) :=
+theorem isCompact (hf : HasCompactMulSupport f) : IsCompact (mulTSupport f) :=
   hf
 #align has_compact_mul_support.is_compact HasCompactMulSupport.isCompact
 #align has_compact_support.is_compact HasCompactSupport.isCompact
 
 @[to_additive]
-theorem hasCompactMulSupport_iff_eventuallyEq :
+theorem _root_.hasCompactMulSupport_iff_eventuallyEq :
     HasCompactMulSupport f ↔ f =ᶠ[coclosedCompact α] 1 :=
   ⟨fun h => mem_coclosedCompact.mpr
     ⟨mulTSupport f, isClosed_mulTSupport _, h,
@@ -197,49 +200,49 @@ theorem hasCompactMulSupport_iff_eventuallyEq :
 #align has_compact_support_iff_eventually_eq hasCompactSupport_iff_eventuallyEq
 
 @[to_additive]
-theorem isCompact_range_of_mulSupport_subset_isCompact [TopologicalSpace β]
+theorem _root_.isCompact_range_of_mulSupport_subset_isCompact [TopologicalSpace β]
     (hf : Continuous f) {k : Set α} (hk : IsCompact k) (h'f : mulSupport f ⊆ k) :
     IsCompact (range f) := by
   cases' range_eq_image_or_of_mulSupport_subset h'f with h2 h2 <;> rw [h2]
   exacts [hk.image hf, (hk.image hf).insert 1]
 
 @[to_additive]
-theorem HasCompactMulSupport.isCompact_range [TopologicalSpace β] (h : HasCompactMulSupport f)
+theorem isCompact_range [TopologicalSpace β] (h : HasCompactMulSupport f)
     (hf : Continuous f) : IsCompact (range f) :=
   isCompact_range_of_mulSupport_subset_isCompact hf h (subset_mulTSupport f)
 #align has_compact_mul_support.is_compact_range HasCompactMulSupport.isCompact_range
 #align has_compact_support.is_compact_range HasCompactSupport.isCompact_range
 
 @[to_additive]
-theorem HasCompactMulSupport.mono' {f' : α → γ} (hf : HasCompactMulSupport f)
+theorem mono' {f' : α → γ} (hf : HasCompactMulSupport f)
     (hff' : mulSupport f' ⊆ mulTSupport f) : HasCompactMulSupport f' :=
   IsCompact.of_isClosed_subset hf isClosed_closure <| closure_minimal hff' isClosed_closure
 #align has_compact_mul_support.mono' HasCompactMulSupport.mono'
 #align has_compact_support.mono' HasCompactSupport.mono'
 
 @[to_additive]
-theorem HasCompactMulSupport.mono {f' : α → γ} (hf : HasCompactMulSupport f)
+theorem mono {f' : α → γ} (hf : HasCompactMulSupport f)
     (hff' : mulSupport f' ⊆ mulSupport f) : HasCompactMulSupport f' :=
   hf.mono' <| hff'.trans subset_closure
 #align has_compact_mul_support.mono HasCompactMulSupport.mono
 #align has_compact_support.mono HasCompactSupport.mono
 
 @[to_additive]
-theorem HasCompactMulSupport.comp_left (hf : HasCompactMulSupport f) (hg : g 1 = 1) :
+theorem comp_left (hf : HasCompactMulSupport f) (hg : g 1 = 1) :
     HasCompactMulSupport (g ∘ f) :=
   hf.mono <| mulSupport_comp_subset hg f
 #align has_compact_mul_support.comp_left HasCompactMulSupport.comp_left
 #align has_compact_support.comp_left HasCompactSupport.comp_left
 
 @[to_additive]
-theorem hasCompactMulSupport_comp_left (hg : ∀ {x}, g x = 1 ↔ x = 1) :
+theorem _root_.hasCompactMulSupport_comp_left (hg : ∀ {x}, g x = 1 ↔ x = 1) :
     HasCompactMulSupport (g ∘ f) ↔ HasCompactMulSupport f := by
   simp_rw [hasCompactMulSupport_def, mulSupport_comp_eq g (@hg) f]
 #align has_compact_mul_support_comp_left hasCompactMulSupport_comp_left
 #align has_compact_support_comp_left hasCompactSupport_comp_left
 
 @[to_additive]
-theorem HasCompactMulSupport.comp_closedEmbedding (hf : HasCompactMulSupport f) {g : α' → α}
+theorem comp_closedEmbedding (hf : HasCompactMulSupport f) {g : α' → α}
     (hg : ClosedEmbedding g) : HasCompactMulSupport (f ∘ g) := by
   rw [hasCompactMulSupport_def, Function.mulSupport_comp_eq_preimage]
   refine' IsCompact.of_isClosed_subset (hg.isCompact_preimage hf) isClosed_closure _
@@ -249,15 +252,13 @@ theorem HasCompactMulSupport.comp_closedEmbedding (hf : HasCompactMulSupport f) 
 #align has_compact_support.comp_closed_embedding HasCompactSupport.comp_closedEmbedding
 
 @[to_additive]
-theorem HasCompactMulSupport.comp₂_left (hf : HasCompactMulSupport f)
+theorem comp₂_left (hf : HasCompactMulSupport f)
     (hf₂ : HasCompactMulSupport f₂) (hm : m 1 1 = 1) :
     HasCompactMulSupport fun x => m (f x) (f₂ x) := by
   rw [hasCompactMulSupport_iff_eventuallyEq] at hf hf₂ ⊢
   filter_upwards [hf, hf₂] using fun x hx hx₂ => by simp_rw [hx, hx₂, Pi.one_apply, hm]
 #align has_compact_mul_support.comp₂_left HasCompactMulSupport.comp₂_left
 #align has_compact_support.comp₂_left HasCompactSupport.comp₂_left
-
-namespace HasCompactMulSupport
 
 variable [T2Space α'] (hf : HasCompactMulSupport f) {g : α → α'} (cont : Continuous g)
 
@@ -290,6 +291,8 @@ theorem continuous_extend_one [TopologicalSpace β] {U : Set α'} (hU : IsOpen U
     exact cont.continuousAt
 
 end HasCompactMulSupport
+
+end CompactSupport
 
 end
 

--- a/Mathlib/Topology/Support.lean
+++ b/Mathlib/Topology/Support.lean
@@ -302,6 +302,8 @@ end HasCompactMulSupport
 
 end CompactSupport
 
+/-! ## Functions with compact support: algebraic operations -/
+section CompactSupport2
 section Monoid
 
 variable [TopologicalSpace α] [Monoid β]
@@ -364,6 +366,8 @@ theorem HasCompactSupport.mul_left (hf : HasCompactSupport f') : HasCompactSuppo
 #align has_compact_support.mul_left HasCompactSupport.mul_left
 
 end MulZeroClass
+
+end CompactSupport2
 
 namespace LocallyFinite
 


### PR DESCRIPTION
Only add a section; no lemmas are changed.
Open the `HasCompactSupport` namespace more, while we're at it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
