### PR TITLE
[Merged by Bors] - feat: case-specific equivalences for `IsROrC`

### DIFF
--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -463,16 +463,14 @@ def _root_.IsROrC.complexRingEquiv {𝕜 : Type*} [IsROrC 𝕜] (h : IsROrC.im (
   invFun x := re x + im x * IsROrC.I
   left_inv x := by simp
   right_inv x := by simp [h]
-  map_add' x y := by
-    simp only [map_add, ofReal_add]
-    ring
+  map_add' x y := by simp only [map_add, ofReal_add]; ring
   map_mul' x y := by
     simp only [IsROrC.mul_re, ofReal_sub, ofReal_mul, IsROrC.mul_im, ofReal_add]
     ring_nf
     rw [I_sq]
     ring
 
-/-- The natural continuous `ℝ`-linear equivalence between `𝕜` satisfying `IsROrC 𝕜` and `ℂ` when
+/-- The natural `ℝ`-linear isometry equivalence between `𝕜` satisfying `IsROrC 𝕜` and `ℂ` when
 `IsROrC.im IsROrC.I = 1`. -/
 @[simps]
 def _root_.IsROrC.complexLinearIsometryEquiv {𝕜 : Type*} [IsROrC 𝕜]

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -172,6 +172,9 @@ theorem norm_int_of_nonneg {n : ℤ} (hn : 0 ≤ n) : ‖(n : ℂ)‖ = n := by
   rw [norm_int, ← Int.cast_abs, _root_.abs_of_nonneg hn]
 #align complex.norm_int_of_nonneg Complex.norm_int_of_nonneg
 
+lemma normSq_eq_norm_sq (z : ℂ) : normSq z = ‖z‖ ^ 2 := by
+  rw [normSq_eq_abs, norm_eq_abs]
+
 @[continuity]
 theorem continuous_abs : Continuous abs :=
   continuous_norm
@@ -450,6 +453,36 @@ lemma exists_norm_eq_mul_self (z : ℂ) : ∃ c, ‖c‖ = 1 ∧ ‖z‖ = c * z
 
 lemma exists_norm_mul_eq_self (z : ℂ) : ∃ c, ‖c‖ = 1 ∧ c * ‖z‖ = z :=
   IsROrC.exists_norm_mul_eq_self _
+
+/-- The natural isomorphism between `𝕜` satisfying `IsROrC 𝕜` and `ℂ` when
+`IsROrC.im IsROrC.I = `. -/
+@[simps]
+def _root_.IsROrC.complexRingEquiv {𝕜 : Type*} [IsROrC 𝕜] (h : IsROrC.im (IsROrC.I : 𝕜) = 1) :
+    𝕜 ≃+* ℂ where
+  toFun x := IsROrC.re x + IsROrC.im x * I
+  invFun x := re x + im x * IsROrC.I
+  left_inv x := by simp
+  right_inv x := by simp [h]
+  map_add' x y := by
+    simp only [map_add, ofReal_add]
+    ring
+  map_mul' x y := by
+    simp only [IsROrC.mul_re, ofReal_sub, ofReal_mul, IsROrC.mul_im, ofReal_add]
+    ring_nf
+    rw [I_sq]
+    ring
+
+/-- The natural continuous `ℝ`-linear equivalence between `𝕜` satisfying `IsROrC 𝕜` and `ℂ` when
+`IsROrC.im IsROrC.I = 1`. -/
+@[simps]
+def _root_.IsROrC.complexLinearIsometryEquiv {𝕜 : Type*} [IsROrC 𝕜]
+    (h : IsROrC.im (IsROrC.I : 𝕜) = 1) : 𝕜 ≃ₗᵢ[ℝ] ℂ where
+  map_smul' _ _ := by simp [IsROrC.smul_re, IsROrC.smul_im, ofReal_mul]; ring
+  norm_map' _ := by
+    rw [← sq_eq_sq (by positivity) (by positivity), ← normSq_eq_norm_sq, ← IsROrC.normSq_eq_def',
+      IsROrC.normSq_apply]
+    simp [normSq_add]
+  __ := IsROrC.complexRingEquiv h
 
 section ComplexOrder
 

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -455,7 +455,7 @@ lemma exists_norm_mul_eq_self (z : ℂ) : ∃ c, ‖c‖ = 1 ∧ c * ‖z‖ = z
   IsROrC.exists_norm_mul_eq_self _
 
 /-- The natural isomorphism between `𝕜` satisfying `IsROrC 𝕜` and `ℂ` when
-`IsROrC.im IsROrC.I = `. -/
+`IsROrC.im IsROrC.I = 1`. -/
 @[simps]
 def _root_.IsROrC.complexRingEquiv {𝕜 : Type*} [IsROrC 𝕜] (h : IsROrC.im (IsROrC.I : 𝕜) = 1) :
     𝕜 ≃+* ℂ where

--- a/Mathlib/Data/IsROrC/Basic.lean
+++ b/Mathlib/Data/IsROrC/Basic.lean
@@ -341,6 +341,10 @@ theorem I_mul_I : (I : K) = 0 ∨ (I : K) * I = -1 :=
 set_option linter.uppercaseLean3 false in
 #align is_R_or_C.I_mul_I IsROrC.I_mul_I
 
+variable (𝕜) in
+lemma I_eq_zero_or_im_I_eq_one : (I : K) = 0 ∨ im (I : K) = 1 :=
+  I_mul_I (K := K) |>.imp_right fun h ↦ by simpa [h] using (I_mul_re (I : K)).symm
+
 @[simp, isROrC_simps]
 theorem conj_re (z : K) : re (conj z) = re z :=
   IsROrC.conj_re_ax z
@@ -1138,5 +1142,40 @@ theorem continuous_normSq : Continuous (normSq : K → ℝ) :=
 #align is_R_or_C.continuous_norm_sq IsROrC.continuous_normSq
 
 end LinearMaps
+
+/-!
+### ℝ-dependent results
+
+Here we gather results that depend on whether `K` is `ℝ`.
+-/
+section CaseSpecific
+
+lemma im_eq_zero (h : I = (0 : K)) (z : K) : im z = 0 := by
+  rw [← re_add_im z, h]
+  simp
+
+/-- The natural isomorphism between `𝕜` satisfying `IsROrC 𝕜` and `ℝ` when `IsROrC.I = 0`. -/
+@[simps]
+def IsROrC.realRingEquiv {𝕜 : Type*} [IsROrC 𝕜] (h : I = (0 : 𝕜)) :
+    𝕜 ≃+* ℝ where
+  toFun := re
+  invFun := (↑)
+  left_inv x := by nth_rw 2 [← re_add_im x]; simp [h]
+  right_inv := ofReal_re
+  map_add' := map_add re
+  map_mul' := by simp [im_eq_zero h]
+
+/-- The natural continuous `ℝ`-linear equivalence between `𝕜` satisfying `IsROrC 𝕜` and `ℝ` when
+`IsROrC.I = 0`. -/
+@[simps]
+noncomputable
+def IsROrC.realContinuousLinearEquiv {𝕜 : Type*} [IsROrC 𝕜] (h : I = (0 : 𝕜)) :
+    𝕜 ≃L[ℝ] ℝ where
+  map_smul' := smul_re
+  continuous_toFun := continuous_re
+  continuous_invFun := continuous_ofReal
+  __ := realRingEquiv h
+
+end CaseSpecific
 
 end IsROrC

--- a/Mathlib/Data/IsROrC/Basic.lean
+++ b/Mathlib/Data/IsROrC/Basic.lean
@@ -1156,8 +1156,7 @@ lemma im_eq_zero (h : I = (0 : K)) (z : K) : im z = 0 := by
 
 /-- The natural isomorphism between `𝕜` satisfying `IsROrC 𝕜` and `ℝ` when `IsROrC.I = 0`. -/
 @[simps]
-def realRingEquiv (h : I = (0 : K)) :
-    K ≃+* ℝ where
+def realRingEquiv (h : I = (0 : K)) : K ≃+* ℝ where
   toFun := re
   invFun := (↑)
   left_inv x := by nth_rw 2 [← re_add_im x]; simp [h]

--- a/Mathlib/Data/IsROrC/Basic.lean
+++ b/Mathlib/Data/IsROrC/Basic.lean
@@ -1156,8 +1156,8 @@ lemma im_eq_zero (h : I = (0 : K)) (z : K) : im z = 0 := by
 
 /-- The natural isomorphism between `𝕜` satisfying `IsROrC 𝕜` and `ℝ` when `IsROrC.I = 0`. -/
 @[simps]
-def IsROrC.realRingEquiv {𝕜 : Type*} [IsROrC 𝕜] (h : I = (0 : 𝕜)) :
-    𝕜 ≃+* ℝ where
+def realRingEquiv (h : I = (0 : K)) :
+    K ≃+* ℝ where
   toFun := re
   invFun := (↑)
   left_inv x := by nth_rw 2 [← re_add_im x]; simp [h]
@@ -1165,15 +1165,12 @@ def IsROrC.realRingEquiv {𝕜 : Type*} [IsROrC 𝕜] (h : I = (0 : 𝕜)) :
   map_add' := map_add re
   map_mul' := by simp [im_eq_zero h]
 
-/-- The natural continuous `ℝ`-linear equivalence between `𝕜` satisfying `IsROrC 𝕜` and `ℝ` when
+/-- The natural `ℝ`-linear isometry equivalence between `𝕜` satisfying `IsROrC 𝕜` and `ℝ` when
 `IsROrC.I = 0`. -/
 @[simps]
-noncomputable
-def IsROrC.realContinuousLinearEquiv {𝕜 : Type*} [IsROrC 𝕜] (h : I = (0 : 𝕜)) :
-    𝕜 ≃L[ℝ] ℝ where
+noncomputable def realLinearIsometryEquiv (h : I = (0 : K)) : K ≃ₗᵢ[ℝ] ℝ where
   map_smul' := smul_re
-  continuous_toFun := continuous_re
-  continuous_invFun := continuous_ofReal
+  norm_map' z := by rw [← re_add_im z]; simp [- re_add_im, h]
   __ := realRingEquiv h
 
 end CaseSpecific


### PR DESCRIPTION
This adds ring isomorphisms and linear isometry equivalences between `𝕜` satisfying `IsROrC 𝕜` and `ℝ` or `ℂ` depending on whether `I = 0` or `im I = 1`. Of course, the design of `IsROrC` is meant to eliminate the need for such things most of the time, but these are helpful in the rare case one actually does need to split into the two cases in the middle of a proof.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
