### PR TITLE
[Merged by Bors] - chore(*): rename `FunLike` to `DFunLike`

### DIFF
--- a/Archive/Hairer.lean
+++ b/Archive/Hairer.lean
@@ -46,7 +46,7 @@ namespace SmoothSupportedOn
 
 variable {n : ℕ∞} {s : Set E}
 
-instance : FunLike (SmoothSupportedOn 𝕜 E F n s) E (fun _ ↦ F) where
+instance : DFunLike (SmoothSupportedOn 𝕜 E F n s) E (fun _ ↦ F) where
   coe := Subtype.val
   coe_injective' := Subtype.coe_injective
 

--- a/Counterexamples/DirectSumIsInternal.lean
+++ b/Counterexamples/DirectSumIsInternal.lean
@@ -87,7 +87,7 @@ theorem withSign.not_injective :
     intro h
     -- porting note: `DFinsupp.singleAddHom_apply` doesn't work so we have to unfold
     dsimp [DirectSum.lof_eq_of, DirectSum.of, DFinsupp.singleAddHom] at h
-    replace h := FunLike.congr_fun h 1
+    replace h := DFunLike.congr_fun h 1
     -- This used to be `rw`, but we need `erw` after leanprover/lean4#2644
     erw [DFinsupp.zero_apply, DFinsupp.add_apply, DFinsupp.single_eq_same,
       DFinsupp.single_eq_of_ne UnitsInt.one_ne_neg_one.symm, add_zero, Subtype.ext_iff,

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -315,7 +315,7 @@ it suffices to check the `algebraMap`s agree.
 theorem algebra_ext {R : Type*} [CommSemiring R] {A : Type*} [Semiring A] (P Q : Algebra R A)
     (h : ∀ r : R, (haveI := P; algebraMap R A r) = haveI := Q; algebraMap R A r) :
     P = Q := by
-  replace h : P.toRingHom = Q.toRingHom := FunLike.ext _ _ h
+  replace h : P.toRingHom = Q.toRingHom := DFunLike.ext _ _ h
   have h' : (haveI := P; (· • ·) : R → A → A) = (haveI := Q; (· • ·) : R → A → A) := by
     funext r a
     rw [P.smul_def', Q.smul_def', h]

--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -196,7 +196,7 @@ theorem _root_.Algebra.coe_lmul_eq_mul : ⇑(Algebra.lmul R A) = mul R A :=
 #align algebra.coe_lmul_eq_mul Algebra.coe_lmul_eq_mul
 
 theorem _root_.Algebra.lmul_injective : Function.Injective (Algebra.lmul R A) :=
-  fun a₁ a₂ h ↦ by simpa using FunLike.congr_fun h 1
+  fun a₁ a₂ h ↦ by simpa using DFunLike.congr_fun h 1
 
 theorem _root_.Algebra.lmul_isUnit_iff {x : A} :
     IsUnit (Algebra.lmul R A x) ↔ IsUnit x := by

--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -61,7 +61,7 @@ instance (priority := 100) toAlgHomClass (F R A B : Type*) [CommSemiring R] [Sem
     AlgHomClass F R A B :=
   { h with
     coe := (⇑)
-    coe_injective' := FunLike.coe_injective
+    coe_injective' := DFunLike.coe_injective
     map_zero := map_zero
     map_one := map_one }
 #align alg_equiv_class.to_alg_hom_class AlgEquivClass.toAlgHomClass
@@ -130,7 +130,7 @@ instance : EquivLike (A₁ ≃ₐ[R] A₂) A₁ A₂ where
     obtain ⟨⟨g,_⟩,_⟩ := g
     congr
 
--- Porting note: the default simps projection was `e.toEquiv.toFun`, it should be `FunLike.coe`
+-- Porting note: the default simps projection was `e.toEquiv.toFun`, it should be `DFunLike.coe`
 /-- See Note [custom simps projection] -/
 def Simps.apply (e : A₁ ≃ₐ[R] A₂) : A₁ → A₂ :=
   e
@@ -149,23 +149,23 @@ protected theorem coe_coe {F : Type*} [AlgEquivClass F R A₁ A₂] (f : F) :
 
 @[ext]
 theorem ext {f g : A₁ ≃ₐ[R] A₂} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align alg_equiv.ext AlgEquiv.ext
 
 protected theorem congr_arg {f : A₁ ≃ₐ[R] A₂} {x x' : A₁} : x = x' → f x = f x' :=
-  FunLike.congr_arg f
+  DFunLike.congr_arg f
 #align alg_equiv.congr_arg AlgEquiv.congr_arg
 
 protected theorem congr_fun {f g : A₁ ≃ₐ[R] A₂} (h : f = g) (x : A₁) : f x = g x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align alg_equiv.congr_fun AlgEquiv.congr_fun
 
 protected theorem ext_iff {f g : A₁ ≃ₐ[R] A₂} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align alg_equiv.ext_iff AlgEquiv.ext_iff
 
 theorem coe_fun_injective : @Function.Injective (A₁ ≃ₐ[R] A₂) (A₁ → A₂) fun e => (e : A₁ → A₂) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align alg_equiv.coe_fun_injective AlgEquiv.coe_fun_injective
 
 -- Porting note: Made to CoeOut instance from Coe, not dangerous anymore
@@ -270,7 +270,7 @@ theorem toAlgHom_eq_coe : e.toAlgHom = e :=
 #align alg_equiv.to_alg_hom_eq_coe AlgEquiv.toAlgHom_eq_coe
 
 @[simp, norm_cast]
-theorem coe_algHom : FunLike.coe (e.toAlgHom) = FunLike.coe e :=
+theorem coe_algHom : DFunLike.coe (e.toAlgHom) = DFunLike.coe e :=
   rfl
 #align alg_equiv.coe_alg_hom AlgEquiv.coe_algHom
 

--- a/Mathlib/Algebra/Algebra/Hom.lean
+++ b/Mathlib/Algebra/Algebra/Hom.lean
@@ -97,7 +97,7 @@ variable [CommSemiring R] [Semiring A] [Semiring B] [Semiring C] [Semiring D]
 
 variable [Algebra R A] [Algebra R B] [Algebra R C] [Algebra R D]
 
--- Porting note: we don't port specialized `CoeFun` instances if there is `FunLike` instead
+-- Porting note: we don't port specialized `CoeFun` instances if there is `DFunLike` instead
 #noalign alg_hom.has_coe_to_fun
 
 -- Porting note: This instance is moved.
@@ -192,11 +192,11 @@ theorem coe_toAddMonoidHom (f : A →ₐ[R] B) : ⇑(f : A →+ B) = f :=
 variable (φ : A →ₐ[R] B)
 
 theorem coe_fn_injective : @Function.Injective (A →ₐ[R] B) (A → B) (↑) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align alg_hom.coe_fn_injective AlgHom.coe_fn_injective
 
 theorem coe_fn_inj {φ₁ φ₂ : A →ₐ[R] B} : (φ₁ : A → B) = φ₂ ↔ φ₁ = φ₂ :=
-  FunLike.coe_fn_eq
+  DFunLike.coe_fn_eq
 #align alg_hom.coe_fn_inj AlgHom.coe_fn_inj
 
 theorem coe_ringHom_injective : Function.Injective ((↑) : (A →ₐ[R] B) → A →+* B) := fun φ₁ φ₂ H =>
@@ -212,20 +212,20 @@ theorem coe_addMonoidHom_injective : Function.Injective ((↑) : (A →ₐ[R] B)
 #align alg_hom.coe_add_monoid_hom_injective AlgHom.coe_addMonoidHom_injective
 
 protected theorem congr_fun {φ₁ φ₂ : A →ₐ[R] B} (H : φ₁ = φ₂) (x : A) : φ₁ x = φ₂ x :=
-  FunLike.congr_fun H x
+  DFunLike.congr_fun H x
 #align alg_hom.congr_fun AlgHom.congr_fun
 
 protected theorem congr_arg (φ : A →ₐ[R] B) {x y : A} (h : x = y) : φ x = φ y :=
-  FunLike.congr_arg φ h
+  DFunLike.congr_arg φ h
 #align alg_hom.congr_arg AlgHom.congr_arg
 
 @[ext]
 theorem ext {φ₁ φ₂ : A →ₐ[R] B} (H : ∀ x, φ₁ x = φ₂ x) : φ₁ = φ₂ :=
-  FunLike.ext _ _ H
+  DFunLike.ext _ _ H
 #align alg_hom.ext AlgHom.ext
 
 theorem ext_iff {φ₁ φ₂ : A →ₐ[R] B} : φ₁ = φ₂ ↔ ∀ x, φ₁ x = φ₂ x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align alg_hom.ext_iff AlgHom.ext_iff
 
 @[simp]
@@ -511,7 +511,7 @@ def toIntAlgHom [Ring R] [Ring S] [Algebra ℤ R] [Algebra ℤ S] (f : R →+* S
 
 lemma toIntAlgHom_injective [Ring R] [Ring S] [Algebra ℤ R] [Algebra ℤ S] :
     Function.Injective (RingHom.toIntAlgHom : (R →+* S) → _) :=
-  fun _ _ e ↦ FunLike.ext _ _ (fun x ↦ FunLike.congr_fun e x)
+  fun _ _ e ↦ DFunLike.ext _ _ (fun x ↦ DFunLike.congr_fun e x)
 
 /-- Reinterpret a `RingHom` as a `ℚ`-algebra homomorphism. This actually yields an equivalence,
 see `RingHom.equivRatAlgHom`. -/

--- a/Mathlib/Algebra/Algebra/NonUnitalHom.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalHom.lean
@@ -119,12 +119,12 @@ variable [NonUnitalNonAssocSemiring B] [DistribMulAction R B]
 
 variable [NonUnitalNonAssocSemiring C] [DistribMulAction R C]
 
--- Porting note: Replaced with FunLike instance
+-- Porting note: Replaced with DFunLike instance
 -- /-- see Note [function coercion] -/
 -- instance : CoeFun (A →ₙₐ[R] B) fun _ => A → B :=
 --   ⟨toFun⟩
 
-instance : FunLike (A →ₙₐ[R] B) A fun _ => B where
+instance : DFunLike (A →ₙₐ[R] B) A fun _ => B where
   coe f := f.toFun
   coe_injective' := by rintro ⟨⟨⟨f, _⟩, _⟩, _⟩ ⟨⟨⟨g, _⟩, _⟩, _⟩ h; congr
 
@@ -217,7 +217,7 @@ theorem to_distribMulActionHom_injective {f g : A →ₙₐ[R] B}
 
 theorem to_mulHom_injective {f g : A →ₙₐ[R] B} (h : (f : A →ₙ* B) = (g : A →ₙ* B)) : f = g := by
   ext a
-  exact FunLike.congr_fun h a
+  exact DFunLike.congr_fun h a
 #align non_unital_alg_hom.to_mul_hom_injective NonUnitalAlgHom.to_mulHom_injective
 
 @[norm_cast]

--- a/Mathlib/Algebra/Algebra/Prod.lean
+++ b/Mathlib/Algebra/Algebra/Prod.lean
@@ -93,7 +93,7 @@ theorem snd_prod (f : A →ₐ[R] B) (g : A →ₐ[R] C) : (snd R B C).comp (pro
 
 @[simp]
 theorem prod_fst_snd : prod (fst R A B) (snd R A B) = 1 :=
-  FunLike.coe_injective Pi.prod_fst_snd
+  DFunLike.coe_injective Pi.prod_fst_snd
 #align alg_hom.prod_fst_snd AlgHom.prod_fst_snd
 
 /-- Taking the product of two maps with the same domain is equivalent to taking the product of

--- a/Mathlib/Algebra/Algebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Unitization.lean
@@ -674,7 +674,7 @@ theorem algHom_ext {F : Type*} [AlgHomClass F S (Unitization R A) B] {φ ψ : F}
     (h : ∀ a : A, φ a = ψ a)
     (h' : ∀ r, φ (algebraMap R (Unitization R A) r) = ψ (algebraMap R (Unitization R A) r)) :
     φ = ψ := by
-  refine FunLike.ext φ ψ (fun x ↦ ?_)
+  refine DFunLike.ext φ ψ (fun x ↦ ?_)
   induction x using Unitization.ind
   simp only [map_add, ← algebraMap_eq_inl, h, h']
 #align unitization.alg_hom_ext Unitization.algHom_ext
@@ -759,7 +759,7 @@ theorem starAlgHom_ext {φ ψ : Unitization R A →⋆ₐ[R] C}
     (h : (φ : Unitization R A →⋆ₙₐ[R] C).comp (Unitization.inrNonUnitalStarAlgHom R A) =
       (ψ : Unitization R A →⋆ₙₐ[R] C).comp (Unitization.inrNonUnitalStarAlgHom R A)) :
     φ = ψ :=
-  Unitization.algHom_ext'' <| FunLike.congr_fun h
+  Unitization.algHom_ext'' <| DFunLike.congr_fun h
 
 /-- Non-unital star algebra homomorphisms from `A` into a unital star `R`-algebra `C` lift uniquely
 to `Unitization R A →⋆ₐ[R] C`. This is the universal property of the unitization. -/

--- a/Mathlib/Algebra/BigOperators/Finsupp.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp.lean
@@ -480,7 +480,7 @@ theorem liftAddHom_singleAddHom [AddCommMonoid M] :
 
 @[simp]
 theorem sum_single [AddCommMonoid M] (f : α →₀ M) : f.sum single = f :=
-  FunLike.congr_fun liftAddHom_singleAddHom f
+  DFunLike.congr_fun liftAddHom_singleAddHom f
 #align finsupp.sum_single Finsupp.sum_single
 
 /-- The `Finsupp` version of `Finset.univ_sum_single` -/
@@ -488,7 +488,7 @@ theorem sum_single [AddCommMonoid M] (f : α →₀ M) : f.sum single = f :=
 theorem univ_sum_single [Fintype α] [AddCommMonoid M] (f : α →₀ M) :
     ∑ a : α, single a (f a) = f := by
   classical
-  refine FunLike.coe_injective ?_
+  refine DFunLike.coe_injective ?_
   simp_rw [coe_finset_sum, single_eq_pi_single, Finset.univ_sum_single]
 
 @[simp]

--- a/Mathlib/Algebra/BigOperators/Pi.lean
+++ b/Mathlib/Algebra/BigOperators/Pi.lean
@@ -106,7 +106,7 @@ note [partially-applied ext lemmas]. -/
       explained in note [partially-applied ext lemmas]."]
 theorem MonoidHom.functions_ext' [Finite I] (M : Type*) [CommMonoid M] (g h : (∀ i, Z i) →* M)
     (H : ∀ i, g.comp (MonoidHom.single Z i) = h.comp (MonoidHom.single Z i)) : g = h :=
-  g.functions_ext M h fun i => FunLike.congr_fun (H i)
+  g.functions_ext M h fun i => DFunLike.congr_fun (H i)
 #align monoid_hom.functions_ext' MonoidHom.functions_ext'
 #align add_monoid_hom.functions_ext' AddMonoidHom.functions_ext'
 

--- a/Mathlib/Algebra/Category/AlgebraCat/Limits.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Limits.lean
@@ -100,7 +100,7 @@ def limitConeIsLimit (F : J ⥤ AlgebraCatMax.{v, w} R) : IsLimit (limitCone.{v,
          _⟩, _⟩, _, _⟩, _⟩)
       (fun s => _)
   · intro j j' f
-    exact FunLike.congr_fun (Cone.w s f) v
+    exact DFunLike.congr_fun (Cone.w s f) v
   · -- Porting note: we could add a custom `ext` lemma here.
     apply Subtype.ext
     ext j

--- a/Mathlib/Algebra/Category/GroupCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Adjunctions.lean
@@ -91,7 +91,7 @@ the monomorphisms in `AddCommGroup` are just the injective functions.
 -/
 -- Porting note: had to elaborate instance of Mono rather than just using `apply_instance`.
 example {G H : AddCommGroupCat.{u}} (f : G ⟶ H) [Mono f] : Function.Injective f :=
-  (mono_iff_injective (FunLike.coe f)).mp (Functor.map_mono (forget AddCommGroupCat) f)
+  (mono_iff_injective (DFunLike.coe f)).mp (Functor.map_mono (forget AddCommGroupCat) f)
 
 
 end AddCommGroupCat

--- a/Mathlib/Algebra/Category/GroupCat/Basic.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Basic.lean
@@ -65,8 +65,8 @@ instance {X Y : GroupCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe (f : X →* Y) := f
 
 @[to_additive]
-instance FunLike_instance (X Y : GroupCat) : FunLike (X ⟶ Y) X (fun _ => Y) :=
-  show FunLike (X →* Y) X (fun _ => Y) from inferInstance
+instance DFunLike_instance (X Y : GroupCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+  show DFunLike (X →* Y) X (fun _ => Y) from inferInstance
 
 -- porting note: added
 @[to_additive (attr := simp)]
@@ -214,8 +214,8 @@ instance {X Y : CommGroupCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe (f : X →* Y) := f
 
 @[to_additive]
-instance FunLike_instance (X Y : CommGroupCat) : FunLike (X ⟶ Y) X (fun _ => Y) :=
-  show FunLike (X →* Y) X (fun _ => Y) from inferInstance
+instance DFunLike_instance (X Y : CommGroupCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+  show DFunLike (X →* Y) X (fun _ => Y) from inferInstance
 
 -- porting note: added
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Category/GroupCat/Colimits.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Colimits.lean
@@ -202,7 +202,7 @@ def descFun (s : Cocone F) : ColimitType.{w} F → s.pt := by
     | symm _ _ _ r_ih => exact r_ih.symm
     | trans _ _ _ _ _ r_ih_h r_ih_k => exact Eq.trans r_ih_h r_ih_k
     | map j j' f x => simpa only [descFunLift, Functor.const_obj_obj] using
-      FunLike.congr_fun (s.ι.naturality f) x
+      DFunLike.congr_fun (s.ι.naturality f) x
     | zero => simp
     | neg => simp
     | add => simp
@@ -227,10 +227,10 @@ def descMorphism (s : Cocone F) : colimit.{w} F ⟶ s.pt where
 /-- Evidence that the proposed colimit is the colimit. -/
 def colimitCoconeIsColimit : IsColimit (colimitCocone.{w} F) where
   desc s := descMorphism F s
-  uniq s m w := FunLike.ext _ _ fun x => Quot.inductionOn x fun x => by
+  uniq s m w := DFunLike.ext _ _ fun x => Quot.inductionOn x fun x => by
     change (m : ColimitType F →+ s.pt) _ = (descMorphism F s : ColimitType F →+ s.pt) _
     induction x using Prequotient.recOn with
-    | of j x => exact FunLike.congr_fun (w j) x
+    | of j x => exact DFunLike.congr_fun (w j) x
     | zero =>
       dsimp only [quot_zero]
       rw [map_zero, map_zero]

--- a/Mathlib/Algebra/Category/GroupCat/EpiMono.lean
+++ b/Mathlib/Algebra/Category/GroupCat/EpiMono.lean
@@ -305,7 +305,7 @@ theorem agree : f.range = { x | h x = g x } := by
       simp [g_apply_infinity f]
     have eq2 :
       g b (fromCoset ⟨f.range, 1, one_leftCoset _⟩) = fromCoset ⟨b • ↑f.range, b, rfl⟩ := rfl
-    exact (fromCoset_ne_of_nin_range _ r).symm (by rw [← eq1, ← eq2, FunLike.congr_fun hb])
+    exact (fromCoset_ne_of_nin_range _ r).symm (by rw [← eq1, ← eq2, DFunLike.congr_fun hb])
 #align Group.surjective_of_epi_auxs.agree GroupCat.SurjectiveOfEpiAuxs.agree
 
 theorem comp_eq : (f ≫ show B ⟶ GroupCat.of SX' from g) = f ≫ show B ⟶ GroupCat.of SX' from h := by
@@ -320,7 +320,7 @@ theorem comp_eq : (f ≫ show B ⟶ GroupCat.of SX' from g) = f ≫ show B ⟶ G
 theorem g_ne_h (x : B) (hx : x ∉ f.range) : g ≠ h := by
   intro r
   replace r :=
-    FunLike.congr_fun (FunLike.congr_fun r x) (fromCoset ⟨f.range, ⟨1, one_leftCoset _⟩⟩)
+    DFunLike.congr_fun (DFunLike.congr_fun r x) (fromCoset ⟨f.range, ⟨1, one_leftCoset _⟩⟩)
   change _ = ((τ).symm.trans (g x)).trans τ _ at r
   rw [g_apply_fromCoset, MonoidHom.coe_mk] at r
   simp only [MonoidHom.coe_range, Subtype.coe_mk, Equiv.symm_swap, Equiv.toFun_as_coe,

--- a/Mathlib/Algebra/Category/GroupCat/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/GroupCat/FilteredColimits.lean
@@ -146,14 +146,14 @@ def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
     MonCat.FilteredColimits.colimitDesc.{v, u} (F ⋙ forget₂ GroupCat MonCat.{max v u})
       ((forget₂ GroupCat MonCat).mapCocone t)
   fac t j :=
-    FunLike.coe_injective <|
+    DFunLike.coe_injective <|
       (Types.colimitCoconeIsColimit.{v, u} (F ⋙ forget GroupCat)).fac
       ((forget GroupCat).mapCocone t) j
   uniq t _ h :=
-    FunLike.coe_injective' <|
+    DFunLike.coe_injective' <|
       (Types.colimitCoconeIsColimit.{v, u} (F ⋙ forget GroupCat)).uniq
       ((forget GroupCat).mapCocone t) _
-        fun j => funext fun x => FunLike.congr_fun (h j) x
+        fun j => funext fun x => DFunLike.congr_fun (h j) x
 #align Group.filtered_colimits.colimit_cocone_is_colimit GroupCat.FilteredColimits.colimitCoconeIsColimit
 #align AddGroup.filtered_colimits.colimit_cocone_is_colimit AddGroupCat.FilteredColimits.colimitCoconeIsColimit
 
@@ -230,13 +230,13 @@ def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
           (F ⋙ forget₂ CommGroupCat GroupCat.{max v u})).desc
       ((forget₂ CommGroupCat GroupCat.{max v u}).mapCocone t)
   fac t j :=
-    FunLike.coe_injective <|
+    DFunLike.coe_injective <|
       (Types.colimitCoconeIsColimit.{v, u} (F ⋙ forget CommGroupCat)).fac
         ((forget CommGroupCat).mapCocone t) j
   uniq t _ h :=
-    FunLike.coe_injective <|
+    DFunLike.coe_injective <|
       (Types.colimitCoconeIsColimit.{v, u} (F ⋙ forget CommGroupCat)).uniq
-        ((forget CommGroupCat).mapCocone t) _ fun j => funext fun x => FunLike.congr_fun (h j) x
+        ((forget CommGroupCat).mapCocone t) _ fun j => funext fun x => DFunLike.congr_fun (h j) x
 #align CommGroup.filtered_colimits.colimit_cocone_is_colimit CommGroupCat.FilteredColimits.colimitCoconeIsColimit
 #align AddCommGroup.filtered_colimits.colimit_cocone_is_colimit AddCommGroupCat.FilteredColimits.colimitCoconeIsColimit
 

--- a/Mathlib/Algebra/Category/GroupCat/Injective.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Injective.lean
@@ -160,7 +160,7 @@ lemma toNext_inj : Function.Injective <| toNext A_ :=
         AddMonoidHom.comp ⟨⟨ULift.up, rfl⟩, fun _ _ ↦ rfl⟩ toRatCircle.toAddMonoidHom
       let g : of (ℤ ∙ a) ⟶ A_ := AddSubgroupClass.subtype _
       have : Mono g := (mono_iff_injective _).mpr Subtype.val_injective
-      (FunLike.congr_fun (Injective.comp_factorThru f g) _).symm.trans (congr_fun h0 _)
+      (DFunLike.congr_fun (Injective.comp_factorThru f g) _).symm.trans (congr_fun h0 _)
 
 /-- An injective presentation of `A`: `A → ∏_{A →+ ℚ/ℤ}, ℚ/ℤ`. -/
 @[simps] def presentation : InjectivePresentation A_ where

--- a/Mathlib/Algebra/Category/GroupCat/Kernels.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Kernels.lean
@@ -27,9 +27,9 @@ def kernelCone : KernelFork f :=
 def kernelIsLimit : IsLimit <| kernelCone f :=
   Fork.IsLimit.mk _
     (fun s => (by exact Fork.ι s : _ →+ G).codRestrict _ fun c => f.mem_ker.mpr <|
-      by exact FunLike.congr_fun s.condition c)
+      by exact DFunLike.congr_fun s.condition c)
     (fun _ => by rfl)
-    (fun _ _ h => ext fun x => Subtype.ext_iff_val.mpr <| by exact FunLike.congr_fun h x)
+    (fun _ _ h => ext fun x => Subtype.ext_iff_val.mpr <| by exact DFunLike.congr_fun h x)
 
 /-- The cokernel cocone induced by the projection onto the quotient. -/
 def cokernelCocone : CokernelCofork f :=

--- a/Mathlib/Algebra/Category/GroupCat/Limits.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Limits.lean
@@ -404,7 +404,7 @@ agrees with the usual group-theoretical kernel.
 def kernelIsoKer {G H : AddCommGroupCat.{u}} (f : G ⟶ H) :
     kernel f ≅ AddCommGroupCat.of f.ker where
   hom :=
-    { toFun := fun g => ⟨kernel.ι f g, FunLike.congr_fun (kernel.condition f) g⟩
+    { toFun := fun g => ⟨kernel.ι f g, DFunLike.congr_fun (kernel.condition f) g⟩
       map_zero' := by
         refine Subtype.ext ?_
         simp [(AddSubgroup.coe_zero _).symm]
@@ -415,7 +415,7 @@ def kernelIsoKer {G H : AddCommGroupCat.{u}} (f : G ⟶ H) :
         simp }
   inv := kernel.lift f (AddSubgroup.subtype f.ker) <| by
     -- porting note : used to be `tidy`, but `aesop` can't do it
-    refine FunLike.ext _ _ ?_
+    refine DFunLike.ext _ _ ?_
     rintro ⟨x, (hx : f _ = 0)⟩
     exact hx
   hom_inv_id := by
@@ -425,7 +425,7 @@ def kernelIsoKer {G H : AddCommGroupCat.{u}} (f : G ⟶ H) :
     ext x
     dsimp
     generalize_proofs _ h1 h2
-    erw [FunLike.congr_fun (kernel.lift_ι f _ h1) ⟨_, h2⟩]
+    erw [DFunLike.congr_fun (kernel.lift_ι f _ h1) ⟨_, h2⟩]
     rfl
   inv_hom_id := by
     apply AddCommGroupCat.ext
@@ -434,7 +434,7 @@ def kernelIsoKer {G H : AddCommGroupCat.{u}} (f : G ⟶ H) :
     refine Subtype.ext ?_
     simp only [ZeroHom.coe_mk, Function.comp_apply, id_eq]
     generalize_proofs _ h1 h2
-    erw [FunLike.congr_fun (kernel.lift_ι f _ h1) ⟨_, mem⟩]
+    erw [DFunLike.congr_fun (kernel.lift_ι f _ h1) ⟨_, mem⟩]
     rfl
 set_option linter.uppercaseLean3 false in
 #align AddCommGroup.kernel_iso_ker AddCommGroupCat.kernelIsoKer

--- a/Mathlib/Algebra/Category/GroupWithZeroCat.lean
+++ b/Mathlib/Algebra/Category/GroupWithZeroCat.lean
@@ -53,12 +53,12 @@ instance : LargeCategory.{u} GroupWithZeroCat where
   assoc _ _ _ := MonoidWithZeroHom.comp_assoc _ _ _
 
 -- porting note: was not necessary in mathlib
-instance {M N : GroupWithZeroCat} : FunLike (M ⟶ N) M (fun _ => N) :=
+instance {M N : GroupWithZeroCat} : DFunLike (M ⟶ N) M (fun _ => N) :=
   ⟨fun f => f.toFun, fun f g h => by
     cases f
     cases g
     congr
-    apply FunLike.coe_injective'
+    apply DFunLike.coe_injective'
     exact h⟩
 
 -- porting note: added
@@ -71,7 +71,7 @@ instance groupWithZeroConcreteCategory : ConcreteCategory GroupWithZeroCat where
   forget :=
   { obj := fun G => G
     map := fun f => f.toFun }
-  forget_faithful := ⟨fun h => FunLike.coe_injective h⟩
+  forget_faithful := ⟨fun h => DFunLike.coe_injective h⟩
 
 -- porting note: added
 @[simp] lemma forget_map (f : X ⟶ Y) : (forget GroupWithZeroCat).map f = f := rfl

--- a/Mathlib/Algebra/Category/ModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Basic.lean
@@ -123,7 +123,7 @@ instance {M : ModuleCat.{v} R} : Module R ((forget (ModuleCat R)).obj M) :=
 -- porting note: added to ease automation
 @[ext]
 lemma ext {M N : ModuleCat.{v} R} {f₁ f₂ : M ⟶ N} (h : ∀ (x : M), f₁ x = f₂ x) : f₁ = f₂ :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 
 instance hasForgetToAddCommGroup : HasForget₂ (ModuleCat R) AddCommGroupCat where
   forget₂ :=

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -87,7 +87,7 @@ def restrictScalars {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] (f : R →
 instance {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] (f : R →+* S) :
     CategoryTheory.Faithful (restrictScalars.{v} f) where
   map_injective h :=
-    LinearMap.ext fun x => by simpa only using FunLike.congr_fun h x
+    LinearMap.ext fun x => by simpa only using DFunLike.congr_fun h x
 
 instance {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] (f : R →+* S) :
     (restrictScalars.{v} f).PreservesMonomorphisms where

--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Closed.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Closed.lean
@@ -64,10 +64,10 @@ set_option linter.uppercaseLean3 false in
 
 open MonoidalCategory
 
--- porting note: `CoeFun` was replaced by `FunLike`
--- I can't seem to express the function coercion here without writing `@FunLike.coe`.
+-- porting note: `CoeFun` was replaced by `DFunLike`
+-- I can't seem to express the function coercion here without writing `@DFunLike.coe`.
 theorem monoidalClosed_curry {M N P : ModuleCat.{u} R} (f : M ⊗ N ⟶ P) (x : M) (y : N) :
-    @FunLike.coe _ _ _ LinearMap.instFunLike
+    @DFunLike.coe _ _ _ LinearMap.instFunLike
       ((MonoidalClosed.curry f : N →ₗ[R] M →ₗ[R] P) y) x = f (x ⊗ₜ[R] y) :=
   rfl
 set_option linter.uppercaseLean3 false in
@@ -77,7 +77,7 @@ set_option linter.uppercaseLean3 false in
 theorem monoidalClosed_uncurry
     {M N P : ModuleCat.{u} R} (f : N ⟶ M ⟶[ModuleCat.{u} R] P) (x : M) (y : N) :
     MonoidalClosed.uncurry f (x ⊗ₜ[R] y) =
-      @FunLike.coe _ _ _ LinearMap.instFunLike (f y) x :=
+      @DFunLike.coe _ _ _ LinearMap.instFunLike (f y) x :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align Module.monoidal_closed_uncurry ModuleCat.monoidalClosed_uncurry

--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Closed.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Closed.lean
@@ -67,7 +67,7 @@ open MonoidalCategory
 -- porting note: `CoeFun` was replaced by `DFunLike`
 -- I can't seem to express the function coercion here without writing `@DFunLike.coe`.
 theorem monoidalClosed_curry {M N P : ModuleCat.{u} R} (f : M ⊗ N ⟶ P) (x : M) (y : N) :
-    @DFunLike.coe _ _ _ LinearMap.instFunLike
+    @DFunLike.coe _ _ _ LinearMap.instDFunLike
       ((MonoidalClosed.curry f : N →ₗ[R] M →ₗ[R] P) y) x = f (x ⊗ₜ[R] y) :=
   rfl
 set_option linter.uppercaseLean3 false in
@@ -77,7 +77,7 @@ set_option linter.uppercaseLean3 false in
 theorem monoidalClosed_uncurry
     {M N P : ModuleCat.{u} R} (f : N ⟶ M ⟶[ModuleCat.{u} R] P) (x : M) (y : N) :
     MonoidalClosed.uncurry f (x ⊗ₜ[R] y) =
-      @DFunLike.coe _ _ _ LinearMap.instFunLike (f y) x :=
+      @DFunLike.coe _ _ _ LinearMap.instDFunLike (f y) x :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align Module.monoidal_closed_uncurry ModuleCat.monoidalClosed_uncurry

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -86,8 +86,8 @@ instance {X Y : MonCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe (f : X →* Y) := f
 
 @[to_additive]
-instance Hom_FunLike (X Y : MonCat) : FunLike (X ⟶ Y) X (fun _ => Y) :=
-  show FunLike (X →* Y) X (fun _ => Y) by infer_instance
+instance Hom_FunLike (X Y : MonCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+  show DFunLike (X →* Y) X (fun _ => Y) by infer_instance
 
 -- porting note: added
 @[to_additive (attr := simp)]
@@ -208,8 +208,8 @@ instance {X Y : CommMonCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe (f : X →* Y) := f
 
 @[to_additive]
-instance Hom_FunLike (X Y : CommMonCat) : FunLike (X ⟶ Y) X (fun _ => Y) :=
-  show FunLike (X →* Y) X (fun _ => Y) by infer_instance
+instance Hom_FunLike (X Y : CommMonCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+  show DFunLike (X →* Y) X (fun _ => Y) by infer_instance
 
 -- porting note: added
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -86,7 +86,7 @@ instance {X Y : MonCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe (f : X →* Y) := f
 
 @[to_additive]
-instance Hom_FunLike (X Y : MonCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+instance Hom_DFunLike (X Y : MonCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
   show DFunLike (X →* Y) X (fun _ => Y) by infer_instance
 
 -- porting note: added
@@ -208,7 +208,7 @@ instance {X Y : CommMonCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe (f : X →* Y) := f
 
 @[to_additive]
-instance Hom_FunLike (X Y : CommMonCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+instance Hom_DFunLike (X Y : CommMonCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
   show DFunLike (X →* Y) X (fun _ => Y) by infer_instance
 
 -- porting note: added

--- a/Mathlib/Algebra/Category/MonCat/Colimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Colimits.lean
@@ -254,7 +254,7 @@ def colimitIsColimit : IsColimit (colimitCocone F) where
     · rw [quot_one, map_one]
       rfl
     · rw [quot_mul, map_mul, hx, hy]
-      dsimp [descMorphism, FunLike.coe, descFun]
+      dsimp [descMorphism, DFunLike.coe, descFun]
       simp only [← quot_mul, descFunLift]
 set_option linter.uppercaseLean3 false in
 #align Mon.colimits.colimit_is_colimit MonCat.Colimits.colimitIsColimit

--- a/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
@@ -330,7 +330,7 @@ def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
   uniq t m h := MonoidHom.ext fun y => congr_fun
       ((Types.colimitCoconeIsColimit (F ⋙ forget MonCat)).uniq ((forget MonCat).mapCocone t)
         ((forget MonCat).map m)
-        fun j => funext fun x => FunLike.congr_fun (i := MonCat.Hom_FunLike _ _) (h j) x) y
+        fun j => funext fun x => DFunLike.congr_fun (i := MonCat.Hom_FunLike _ _) (h j) x) y
 #align Mon.filtered_colimits.colimit_cocone_is_colimit MonCat.FilteredColimits.colimitCoconeIsColimit
 #align AddMon.filtered_colimits.colimit_cocone_is_colimit AddMonCat.FilteredColimits.colimitCoconeIsColimit
 
@@ -405,15 +405,15 @@ def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
     MonCat.FilteredColimits.colimitDesc.{v, u} (F ⋙ forget₂ CommMonCat MonCat.{max v u})
       ((forget₂ CommMonCat MonCat.{max v u}).mapCocone t)
   fac t j :=
-    FunLike.coe_injective (i := CommMonCat.Hom_FunLike _ _) <|
+    DFunLike.coe_injective (i := CommMonCat.Hom_FunLike _ _) <|
       (Types.colimitCoconeIsColimit.{v, u} (F ⋙ forget CommMonCat.{max v u})).fac
         ((forget CommMonCat).mapCocone t) j
   uniq t m h :=
-    FunLike.coe_injective (i := CommMonCat.Hom_FunLike _ _) <|
+    DFunLike.coe_injective (i := CommMonCat.Hom_FunLike _ _) <|
       (Types.colimitCoconeIsColimit.{v, u} (F ⋙ forget CommMonCat.{max v u})).uniq
         ((forget CommMonCat.{max v u}).mapCocone t)
         ((forget CommMonCat.{max v u}).map m) fun j => funext fun x =>
-          FunLike.congr_fun (i := CommMonCat.Hom_FunLike _ _) (h j) x
+          DFunLike.congr_fun (i := CommMonCat.Hom_FunLike _ _) (h j) x
 #align CommMon.filtered_colimits.colimit_cocone_is_colimit CommMonCat.FilteredColimits.colimitCoconeIsColimit
 #align AddCommMon.filtered_colimits.colimit_cocone_is_colimit AddCommMonCat.FilteredColimits.colimitCoconeIsColimit
 

--- a/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
@@ -330,7 +330,7 @@ def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
   uniq t m h := MonoidHom.ext fun y => congr_fun
       ((Types.colimitCoconeIsColimit (F ⋙ forget MonCat)).uniq ((forget MonCat).mapCocone t)
         ((forget MonCat).map m)
-        fun j => funext fun x => DFunLike.congr_fun (i := MonCat.Hom_FunLike _ _) (h j) x) y
+        fun j => funext fun x => DFunLike.congr_fun (i := MonCat.Hom_DFunLike _ _) (h j) x) y
 #align Mon.filtered_colimits.colimit_cocone_is_colimit MonCat.FilteredColimits.colimitCoconeIsColimit
 #align AddMon.filtered_colimits.colimit_cocone_is_colimit AddMonCat.FilteredColimits.colimitCoconeIsColimit
 
@@ -405,15 +405,15 @@ def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
     MonCat.FilteredColimits.colimitDesc.{v, u} (F ⋙ forget₂ CommMonCat MonCat.{max v u})
       ((forget₂ CommMonCat MonCat.{max v u}).mapCocone t)
   fac t j :=
-    DFunLike.coe_injective (i := CommMonCat.Hom_FunLike _ _) <|
+    DFunLike.coe_injective (i := CommMonCat.Hom_DFunLike _ _) <|
       (Types.colimitCoconeIsColimit.{v, u} (F ⋙ forget CommMonCat.{max v u})).fac
         ((forget CommMonCat).mapCocone t) j
   uniq t m h :=
-    DFunLike.coe_injective (i := CommMonCat.Hom_FunLike _ _) <|
+    DFunLike.coe_injective (i := CommMonCat.Hom_DFunLike _ _) <|
       (Types.colimitCoconeIsColimit.{v, u} (F ⋙ forget CommMonCat.{max v u})).uniq
         ((forget CommMonCat.{max v u}).mapCocone t)
         ((forget CommMonCat.{max v u}).map m) fun j => funext fun x =>
-          DFunLike.congr_fun (i := CommMonCat.Hom_FunLike _ _) (h j) x
+          DFunLike.congr_fun (i := CommMonCat.Hom_DFunLike _ _) (h j) x
 #align CommMon.filtered_colimits.colimit_cocone_is_colimit CommMonCat.FilteredColimits.colimitCoconeIsColimit
 #align AddCommMon.filtered_colimits.colimit_cocone_is_colimit AddCommMonCat.FilteredColimits.colimitCoconeIsColimit
 

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -106,7 +106,7 @@ set_option linter.uppercaseLean3 false in
 
 @[simp]
 lemma RingEquiv_coe_eq {X Y : Type _} [Semiring X] [Semiring Y] (e : X ≃+* Y) :
-    (@FunLike.coe (SemiRingCat.of X ⟶ SemiRingCat.of Y) _ (fun _ => (forget SemiRingCat).obj _)
+    (@DFunLike.coe (SemiRingCat.of X ⟶ SemiRingCat.of Y) _ (fun _ => (forget SemiRingCat).obj _)
       ConcreteCategory.funLike (e : X →+* Y) : X → Y) = ↑e :=
   rfl
 
@@ -245,7 +245,7 @@ set_option linter.uppercaseLean3 false in
 
 @[simp]
 lemma RingEquiv_coe_eq {X Y : Type _} [Ring X] [Ring Y] (e : X ≃+* Y) :
-    (@FunLike.coe (RingCat.of X ⟶ RingCat.of Y) _ (fun _ => (forget RingCat).obj _)
+    (@DFunLike.coe (RingCat.of X ⟶ RingCat.of Y) _ (fun _ => (forget RingCat).obj _)
       ConcreteCategory.funLike (e : X →+* Y) : X → Y) = ↑e :=
   rfl
 
@@ -328,7 +328,7 @@ set_option linter.uppercaseLean3 false in
 
 @[simp]
 lemma RingEquiv_coe_eq {X Y : Type _} [CommSemiring X] [CommSemiring Y] (e : X ≃+* Y) :
-    (@FunLike.coe (CommSemiRingCat.of X ⟶ CommSemiRingCat.of Y) _
+    (@DFunLike.coe (CommSemiRingCat.of X ⟶ CommSemiRingCat.of Y) _
       (fun _ => (forget CommSemiRingCat).obj _)
       ConcreteCategory.funLike (e : X →+* Y) : X → Y) = ↑e :=
   rfl
@@ -444,7 +444,7 @@ set_option linter.uppercaseLean3 false in
 
 @[simp]
 lemma RingEquiv_coe_eq {X Y : Type _} [CommRing X] [CommRing Y] (e : X ≃+* Y) :
-    (@FunLike.coe (CommRingCat.of X ⟶ CommRingCat.of Y) _ (fun _ => (forget CommRingCat).obj _)
+    (@DFunLike.coe (CommRingCat.of X ⟶ CommRingCat.of Y) _ (fun _ => (forget CommRingCat).obj _)
       ConcreteCategory.funLike (e : X →+* Y) : X → Y) = ↑e :=
   rfl
 

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -107,7 +107,7 @@ set_option linter.uppercaseLean3 false in
 @[simp]
 lemma RingEquiv_coe_eq {X Y : Type _} [Semiring X] [Semiring Y] (e : X ≃+* Y) :
     (@DFunLike.coe (SemiRingCat.of X ⟶ SemiRingCat.of Y) _ (fun _ => (forget SemiRingCat).obj _)
-      ConcreteCategory.funLike (e : X →+* Y) : X → Y) = ↑e :=
+      ConcreteCategory.instDFunLike (e : X →+* Y) : X → Y) = ↑e :=
   rfl
 
 instance : Inhabited SemiRingCat :=
@@ -246,7 +246,7 @@ set_option linter.uppercaseLean3 false in
 @[simp]
 lemma RingEquiv_coe_eq {X Y : Type _} [Ring X] [Ring Y] (e : X ≃+* Y) :
     (@DFunLike.coe (RingCat.of X ⟶ RingCat.of Y) _ (fun _ => (forget RingCat).obj _)
-      ConcreteCategory.funLike (e : X →+* Y) : X → Y) = ↑e :=
+      ConcreteCategory.instDFunLike (e : X →+* Y) : X → Y) = ↑e :=
   rfl
 
 instance hasForgetToSemiRingCat : HasForget₂ RingCat SemiRingCat :=
@@ -330,7 +330,7 @@ set_option linter.uppercaseLean3 false in
 lemma RingEquiv_coe_eq {X Y : Type _} [CommSemiring X] [CommSemiring Y] (e : X ≃+* Y) :
     (@DFunLike.coe (CommSemiRingCat.of X ⟶ CommSemiRingCat.of Y) _
       (fun _ => (forget CommSemiRingCat).obj _)
-      ConcreteCategory.funLike (e : X →+* Y) : X → Y) = ↑e :=
+      ConcreteCategory.instDFunLike (e : X →+* Y) : X → Y) = ↑e :=
   rfl
 
 -- Porting note: I think this is now redundant.
@@ -445,7 +445,7 @@ set_option linter.uppercaseLean3 false in
 @[simp]
 lemma RingEquiv_coe_eq {X Y : Type _} [CommRing X] [CommRing Y] (e : X ≃+* Y) :
     (@DFunLike.coe (CommRingCat.of X ⟶ CommRingCat.of Y) _ (fun _ => (forget CommRingCat).obj _)
-      ConcreteCategory.funLike (e : X →+* Y) : X → Y) = ↑e :=
+      ConcreteCategory.instDFunLike (e : X →+* Y) : X → Y) = ↑e :=
   rfl
 
 -- Porting note: I think this is now redundant.

--- a/Mathlib/Algebra/Category/SemigroupCat/Basic.lean
+++ b/Mathlib/Algebra/Category/SemigroupCat/Basic.lean
@@ -51,7 +51,7 @@ namespace MagmaCat
 instance bundledHom : BundledHom @MulHom :=
   ⟨@MulHom.toFun, @MulHom.id, @MulHom.comp,
     --Porting note : was `@MulHom.coe_inj` which is deprecated
-    by intros; apply @FunLike.coe_injective, by aesop_cat, by aesop_cat⟩
+    by intros; apply @DFunLike.coe_injective, by aesop_cat, by aesop_cat⟩
 #align Magma.bundled_hom MagmaCat.bundledHom
 #align AddMagma.bundled_hom AddMagmaCat.bundledHom
 
@@ -98,7 +98,7 @@ theorem coe_of (R : Type u) [Mul R] : (MagmaCat.of R : Type u) = R :=
 
 @[to_additive (attr := simp)]
 lemma mulEquiv_coe_eq {X Y : Type _} [Mul X] [Mul Y] (e : X ≃* Y) :
-    (@FunLike.coe (MagmaCat.of X ⟶ MagmaCat.of Y) _ (fun _ => (forget MagmaCat).obj _)
+    (@DFunLike.coe (MagmaCat.of X ⟶ MagmaCat.of Y) _ (fun _ => (forget MagmaCat).obj _)
       ConcreteCategory.funLike (e : X →ₙ* Y) : X → Y) = ↑e :=
   rfl
 
@@ -183,7 +183,7 @@ theorem coe_of (R : Type u) [Semigroup R] : (SemigroupCat.of R : Type u) = R :=
 
 @[to_additive (attr := simp)]
 lemma mulEquiv_coe_eq {X Y : Type _} [Semigroup X] [Semigroup Y] (e : X ≃* Y) :
-    (@FunLike.coe (SemigroupCat.of X ⟶ SemigroupCat.of Y) _ (fun _ => (forget SemigroupCat).obj _)
+    (@DFunLike.coe (SemigroupCat.of X ⟶ SemigroupCat.of Y) _ (fun _ => (forget SemigroupCat).obj _)
       ConcreteCategory.funLike (e : X →ₙ* Y) : X → Y) = ↑e :=
   rfl
 

--- a/Mathlib/Algebra/Category/SemigroupCat/Basic.lean
+++ b/Mathlib/Algebra/Category/SemigroupCat/Basic.lean
@@ -99,7 +99,7 @@ theorem coe_of (R : Type u) [Mul R] : (MagmaCat.of R : Type u) = R :=
 @[to_additive (attr := simp)]
 lemma mulEquiv_coe_eq {X Y : Type _} [Mul X] [Mul Y] (e : X ≃* Y) :
     (@DFunLike.coe (MagmaCat.of X ⟶ MagmaCat.of Y) _ (fun _ => (forget MagmaCat).obj _)
-      ConcreteCategory.funLike (e : X →ₙ* Y) : X → Y) = ↑e :=
+      ConcreteCategory.instDFunLike (e : X →ₙ* Y) : X → Y) = ↑e :=
   rfl
 
 /-- Typecheck a `MulHom` as a morphism in `MagmaCat`. -/
@@ -184,7 +184,7 @@ theorem coe_of (R : Type u) [Semigroup R] : (SemigroupCat.of R : Type u) = R :=
 @[to_additive (attr := simp)]
 lemma mulEquiv_coe_eq {X Y : Type _} [Semigroup X] [Semigroup Y] (e : X ≃* Y) :
     (@DFunLike.coe (SemigroupCat.of X ⟶ SemigroupCat.of Y) _ (fun _ => (forget SemigroupCat).obj _)
-      ConcreteCategory.funLike (e : X →ₙ* Y) : X → Y) = ↑e :=
+      ConcreteCategory.instDFunLike (e : X →ₙ* Y) : X → Y) = ↑e :=
   rfl
 
 /-- Typecheck a `MulHom` as a morphism in `SemigroupCat`. -/

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -213,7 +213,7 @@ def map (g : (i : ι) → G i →ₗ[R] G' i) (hg : ∀ i j h, g j ∘ₗ f i j 
 
 @[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
     map (fun i ↦ LinearMap.id) (fun _ _ _ ↦ rfl) = LinearMap.id (R := R) (M := DirectLimit G f) :=
-  FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
+  DFunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
     x.induction_on fun i g ↦ by simp
 
 lemma map_comp [IsDirected ι (· ≤ ·)]
@@ -225,7 +225,7 @@ lemma map_comp [IsDirected ι (· ≤ ·)]
     (map (fun i ↦ g₂ i ∘ₗ g₁ i) fun i j h ↦ by
         rw [LinearMap.comp_assoc, hg₁ i, ← LinearMap.comp_assoc, hg₂ i, LinearMap.comp_assoc] :
       DirectLimit G f →ₗ[R] DirectLimit G'' f'') :=
-  FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
+  DFunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
     x.induction_on fun i g ↦ by simp
 
 open LinearEquiv LinearMap in
@@ -474,7 +474,7 @@ def map (g : (i : ι) → G i →+ G' i)
   lift _ _ _ (fun i ↦ (of _ _ _).comp (g i)) fun i j h g ↦ by
     cases isEmpty_or_nonempty ι
     · exact Subsingleton.elim _ _
-    · have eq1 := FunLike.congr_fun (hg i j h) g
+    · have eq1 := DFunLike.congr_fun (hg i j h) g
       simp only [AddMonoidHom.coe_comp, Function.comp_apply] at eq1 ⊢
       rw [eq1, of_f]
 
@@ -486,7 +486,7 @@ def map (g : (i : ι) → G i →+ G' i)
 
 @[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
     map (fun i ↦ AddMonoidHom.id _) (fun _ _ _ ↦ rfl) = AddMonoidHom.id (DirectLimit G f) :=
-  FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
+  DFunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
     x.induction_on fun i g ↦ by simp
 
 lemma map_comp [IsDirected ι (· ≤ ·)]
@@ -499,7 +499,7 @@ lemma map_comp [IsDirected ι (· ≤ ·)]
       rw [AddMonoidHom.comp_assoc, hg₁ i, ← AddMonoidHom.comp_assoc, hg₂ i,
         AddMonoidHom.comp_assoc] :
       DirectLimit G f →+ DirectLimit G'' f'') :=
-  FunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
+  DFunLike.ext _ _ fun x ↦ (isEmpty_or_nonempty ι).elim (fun _ ↦ Subsingleton.elim _ _) fun _ ↦
     x.induction_on fun i g ↦ by simp
 
 /--
@@ -512,8 +512,8 @@ def congr [IsDirected ι (· ≤ ·)]
     (he : ∀ i j h, (e j).toAddMonoidHom.comp (f i j h) = (f' i j h).comp (e i)) :
     DirectLimit G f ≃+ DirectLimit G' f' :=
   AddMonoidHom.toAddEquiv (map (e ·) he)
-    (map (fun i ↦ (e i).symm) fun i j h ↦ FunLike.ext _ _ fun x ↦ by
-      have eq1 := FunLike.congr_fun (he i j h) ((e i).symm x)
+    (map (fun i ↦ (e i).symm) fun i j h ↦ DFunLike.ext _ _ fun x ↦ by
+      have eq1 := DFunLike.congr_fun (he i j h) ((e i).symm x)
       simp only [AddMonoidHom.coe_comp, AddEquiv.coe_toAddMonoidHom, Function.comp_apply,
         AddMonoidHom.coe_coe, AddEquiv.apply_symm_apply] at eq1 ⊢
       simp [← eq1, of_f])
@@ -863,7 +863,7 @@ theorem lift_of (i x) : lift G f P g Hg (of G f i x) = g i x :=
 theorem lift_unique [IsDirected ι (· ≤ ·)] (F : DirectLimit G f →+* P) (x) :
     F x = lift G f P (fun i => F.comp <| of G f i) (fun i j hij x => by simp [of_f]) x := by
   cases isEmpty_or_nonempty ι
-  · apply FunLike.congr_fun
+  · apply DFunLike.congr_fun
     apply Ideal.Quotient.ringHom_ext
     refine FreeCommRing.hom_ext fun ⟨i, _⟩ ↦ ?_
     exact IsEmpty.elim' inferInstance i
@@ -898,7 +898,7 @@ def map (g : (i : ι) → G i →+* G' i)
     (hg : ∀ i j h, (g j).comp (f i j h) = (f' i j h).comp (g i)) :
     DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G' fun _ _ h ↦ f' _ _ h :=
   lift _ _ _ (fun i ↦ (of _ _ _).comp (g i)) fun i j h g ↦ by
-      have eq1 := FunLike.congr_fun (hg i j h) g
+      have eq1 := DFunLike.congr_fun (hg i j h) g
       simp only [RingHom.coe_comp, Function.comp_apply] at eq1 ⊢
       rw [eq1, of_f]
 
@@ -911,7 +911,7 @@ def map (g : (i : ι) → G i →+* G' i)
 @[simp] lemma map_id [IsDirected ι (· ≤ ·)] :
     map (fun i ↦ RingHom.id _) (fun _ _ _ ↦ rfl) =
     RingHom.id (DirectLimit G fun _ _ h ↦ f _ _ h) :=
-  FunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp
+  DFunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp
 
 lemma map_comp [IsDirected ι (· ≤ ·)]
     (g₁ : (i : ι) → G i →+* G' i) (g₂ : (i : ι) → G' i →+* G'' i)
@@ -922,7 +922,7 @@ lemma map_comp [IsDirected ι (· ≤ ·)]
     (map (fun i ↦ (g₂ i).comp (g₁ i)) fun i j h ↦ by
       rw [RingHom.comp_assoc, hg₁ i, ← RingHom.comp_assoc, hg₂ i, RingHom.comp_assoc] :
       DirectLimit G (fun _ _ h ↦ f _ _ h) →+* DirectLimit G'' fun _ _ h ↦ f'' _ _ h) :=
-  FunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp
+  DFunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ by simp
 
 /--
 Consider direct limits `lim G` and `lim G'` with direct system `f` and `f'` respectively, any
@@ -935,13 +935,13 @@ def congr [IsDirected ι (· ≤ ·)]
     DirectLimit G (fun _ _ h ↦ f _ _ h) ≃+* DirectLimit G' fun _ _ h ↦ f' _ _ h :=
   RingEquiv.ofHomInv
     (map (e ·) he)
-    (map (fun i ↦ (e i).symm) fun i j h ↦ FunLike.ext _ _ fun x ↦ by
-      have eq1 := FunLike.congr_fun (he i j h) ((e i).symm x)
+    (map (fun i ↦ (e i).symm) fun i j h ↦ DFunLike.ext _ _ fun x ↦ by
+      have eq1 := DFunLike.congr_fun (he i j h) ((e i).symm x)
       simp only [RingEquiv.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply,
         RingEquiv.apply_symm_apply] at eq1 ⊢
       simp [← eq1, of_f])
-    (FunLike.ext _ _ fun x ↦ x.induction_on <| by simp)
-    (FunLike.ext _ _ fun x ↦ x.induction_on <| by simp)
+    (DFunLike.ext _ _ fun x ↦ x.induction_on <| by simp)
+    (DFunLike.ext _ _ fun x ↦ x.induction_on <| by simp)
 
 lemma congr_apply_of [IsDirected ι (· ≤ ·)]
     (e : (i : ι) → G i ≃+* G' i)

--- a/Mathlib/Algebra/DirectSum/Algebra.lean
+++ b/Mathlib/Algebra/DirectSum/Algebra.lean
@@ -81,14 +81,14 @@ instance : Algebra R (⨁ i, A i) where
     apply DFinsupp.single_eq_of_sigma_eq (GAlgebra.map_mul a b)
   commutes' r x := by
     change AddMonoidHom.mul (DirectSum.of _ _ _) x = AddMonoidHom.mul.flip (DirectSum.of _ _ _) x
-    apply FunLike.congr_fun _ x
+    apply DFunLike.congr_fun _ x
     ext i xi : 2
     dsimp only [AddMonoidHom.comp_apply, AddMonoidHom.mul_apply, AddMonoidHom.flip_apply]
     rw [of_mul_of, of_mul_of]
     apply DFinsupp.single_eq_of_sigma_eq (GAlgebra.commutes r ⟨i, xi⟩)
   smul_def' r x := by
     change DistribMulAction.toAddMonoidHom _ r x = AddMonoidHom.mul (DirectSum.of _ _ _) x
-    apply FunLike.congr_fun _ x
+    apply DFunLike.congr_fun _ x
     ext i xi : 2
     dsimp only [AddMonoidHom.comp_apply, DistribMulAction.toAddMonoidHom_apply,
       AddMonoidHom.mul_apply]

--- a/Mathlib/Algebra/DirectSum/Basic.lean
+++ b/Mathlib/Algebra/DirectSum/Basic.lean
@@ -48,8 +48,8 @@ instance [∀ i, AddCommMonoid (β i)] : Inhabited (DirectSum ι β) :=
 instance [∀ i, AddCommMonoid (β i)] : AddCommMonoid (DirectSum ι β) :=
   inferInstanceAs (AddCommMonoid (Π₀ i, β i))
 
-instance [∀ i, AddCommMonoid (β i)] : FunLike (DirectSum ι β) _ fun i : ι => β i :=
-  inferInstanceAs (FunLike (Π₀ i, β i) _ _)
+instance [∀ i, AddCommMonoid (β i)] : DFunLike (DirectSum ι β) _ fun i : ι => β i :=
+  inferInstanceAs (DFunLike (Π₀ i, β i) _ _)
 
 instance [∀ i, AddCommMonoid (β i)] : CoeFun (DirectSum ι β) fun _ => ∀ i : ι, β i :=
   inferInstanceAs (CoeFun (Π₀ i, β i) fun _ => ∀ i : ι, β i)
@@ -184,7 +184,7 @@ See note [partially-applied ext lemmas]. -/
 @[ext high]
 theorem addHom_ext' {γ : Type*} [AddMonoid γ] ⦃f g : (⨁ i, β i) →+ γ⦄
     (H : ∀ i : ι, f.comp (of _ i) = g.comp (of _ i)) : f = g :=
-  addHom_ext fun i => FunLike.congr_fun <| H i
+  addHom_ext fun i => DFunLike.congr_fun <| H i
 #align direct_sum.add_hom_ext' DirectSum.addHom_ext'
 
 variable {γ : Type u₁} [AddCommMonoid γ]

--- a/Mathlib/Algebra/DirectSum/Decomposition.lean
+++ b/Mathlib/Algebra/DirectSum/Decomposition.lean
@@ -72,8 +72,8 @@ abbrev Decomposition.ofAddHom (decompose : M →+ ⨁ i, ℳ i)
     (h_left_inv : (DirectSum.coeAddMonoidHom ℳ).comp decompose = .id _)
     (h_right_inv : decompose.comp (DirectSum.coeAddMonoidHom ℳ) = .id _) : Decomposition ℳ where
   decompose' := decompose
-  left_inv := FunLike.congr_fun h_left_inv
-  right_inv := FunLike.congr_fun h_right_inv
+  left_inv := DFunLike.congr_fun h_left_inv
+  right_inv := DFunLike.congr_fun h_right_inv
 
 /-- Noncomputably conjure a decomposition instance from a `DirectSum.IsInternal` proof. -/
 noncomputable def IsInternal.chooseDecomposition (h : IsInternal ℳ) :
@@ -259,8 +259,8 @@ abbrev Decomposition.ofLinearMap (decompose : M →ₗ[R] ⨁ i, ℳ i)
     (h_left_inv : DirectSum.coeLinearMap ℳ ∘ₗ decompose = .id)
     (h_right_inv : decompose ∘ₗ DirectSum.coeLinearMap ℳ = .id) : Decomposition ℳ where
   decompose' := decompose
-  left_inv := FunLike.congr_fun h_left_inv
-  right_inv := FunLike.congr_fun h_right_inv
+  left_inv := DFunLike.congr_fun h_left_inv
+  right_inv := DFunLike.congr_fun h_right_inv
 
 variable [Decomposition ℳ]
 
@@ -294,7 +294,7 @@ theorem decompose_lhom_ext {N} [AddCommMonoid N] [Module R N] ⦃f g : M →ₗ[
   LinearMap.ext <| (decomposeLinearEquiv ℳ).symm.surjective.forall.mpr <|
     suffices f ∘ₗ (decomposeLinearEquiv ℳ).symm
            = (g ∘ₗ (decomposeLinearEquiv ℳ).symm : (⨁ i, ℳ i) →ₗ[R] N) from
-      FunLike.congr_fun this
+      DFunLike.congr_fun this
     linearMap_ext _ fun i => by
       simp_rw [LinearMap.comp_assoc, decomposeLinearEquiv_symm_comp_lof ℳ i, h]
 

--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -103,7 +103,7 @@ variable (R ι N)
 
 /-- The linear map constructed using the universal property of the coproduct. -/
 def toModule : (⨁ i, M i) →ₗ[R] N :=
-  FunLike.coe (DFinsupp.lsum ℕ) φ
+  DFunLike.coe (DFinsupp.lsum ℕ) φ
 #align direct_sum.to_module DirectSum.toModule
 
 /-- Coproducts in the categories of modules and additive monoids commute with the forgetful functor

--- a/Mathlib/Algebra/DirectSum/Ring.lean
+++ b/Mathlib/Algebra/DirectSum/Ring.lean
@@ -226,7 +226,7 @@ variable [∀ i, AddCommMonoid (A i)] [AddMonoid ι] [GSemiring A]
 open AddMonoidHom (flipHom coe_comp compHom flip_apply)
 
 private nonrec theorem one_mul (x : ⨁ i, A i) : 1 * x = x := by
-  suffices mulHom A One.one = AddMonoidHom.id (⨁ i, A i) from FunLike.congr_fun this x
+  suffices mulHom A One.one = AddMonoidHom.id (⨁ i, A i) from DFunLike.congr_fun this x
   apply addHom_ext; intro i xi
   simp only [One.one]
   rw [mulHom_of_of]
@@ -235,7 +235,7 @@ private nonrec theorem one_mul (x : ⨁ i, A i) : 1 * x = x := by
 
 -- Porting note: `suffices` is very slow here.
 private nonrec theorem mul_one (x : ⨁ i, A i) : x * 1 = x := by
-  suffices (mulHom A).flip One.one = AddMonoidHom.id (⨁ i, A i) from FunLike.congr_fun this x
+  suffices (mulHom A).flip One.one = AddMonoidHom.id (⨁ i, A i) from DFunLike.congr_fun this x
   apply addHom_ext; intro i xi
   simp only [One.one]
   rw [flip_apply, mulHom_of_of]
@@ -248,7 +248,7 @@ private theorem mul_assoc (a b c : ⨁ i, A i) : a * b * c = a * (b * c) := by
   -- (`fun a b c => a * b * c` as a bundled hom) = (`fun a b c => a * (b * c)` as a bundled hom)
   suffices (mulHom A).compHom.comp (mulHom A) =
       (AddMonoidHom.compHom flipHom <| (mulHom A).flip.compHom.comp (mulHom A)).flip by
-      have sol := FunLike.congr_fun (FunLike.congr_fun (FunLike.congr_fun this a) b) c
+      have sol := DFunLike.congr_fun (DFunLike.congr_fun (DFunLike.congr_fun this a) b) c
       have aux : ∀ a b, (mulHom A) a b = a * b := fun _ _ ↦ rfl
       simp only [coe_comp, Function.comp_apply, AddMonoidHom.compHom_apply_apply, aux, flip_apply,
         AddMonoidHom.flipHom_apply] at sol

--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -108,7 +108,7 @@ nonrec theorem algHom_ext' ⦃f g : A[ε] →ₐ[R] B⦄
   algHom_ext' hinl (by
     ext a
     show f (inr a) = g (inr a)
-    simpa only [inr_eq_smul_eps] using FunLike.congr_fun hinr a)
+    simpa only [inr_eq_smul_eps] using DFunLike.congr_fun hinr a)
 
 /-- For two `R`-algebra morphisms out of `R[ε]` to agree, it suffices for them to agree on `ε`. -/
 @[ext 1200]

--- a/Mathlib/Algebra/Exact.lean
+++ b/Mathlib/Algebra/Exact.lean
@@ -60,7 +60,7 @@ lemma LinearMap.exact_iff : Exact f g ↔ LinearMap.ker g = LinearMap.range f :=
   Iff.symm <| SetLike.ext_iff
 
 lemma Exact.linearMap_comp_eq_zero (h : Exact f g) : g.comp f = 0 :=
-  FunLike.coe_injective h.comp_eq_zero
+  DFunLike.coe_injective h.comp_eq_zero
 
 end LinearMap
 

--- a/Mathlib/Algebra/Free.lean
+++ b/Mathlib/Algebra/Free.lean
@@ -81,7 +81,7 @@ def recOnMul {C : FreeMagma α → Sort l} (x) (ih1 : ∀ x, C (of x))
 
 @[to_additive (attr := ext 1100)]
 theorem hom_ext {β : Type v} [Mul β] {f g : FreeMagma α →ₙ* β} (h : f ∘ of = g ∘ of) : f = g :=
-  (FunLike.ext _ _) fun x ↦ recOnMul x (congr_fun h) <| by intros; simp only [map_mul, *]
+  (DFunLike.ext _ _) fun x ↦ recOnMul x (congr_fun h) <| by intros; simp only [map_mul, *]
 #align free_magma.hom_ext FreeMagma.hom_ext
 
 end FreeMagma
@@ -390,7 +390,7 @@ variable {β : Type v} [Semigroup β] (f : α →ₙ* β)
 
 @[to_additive (attr := ext 1100)]
 theorem hom_ext {f g : AssocQuotient α →ₙ* β} (h : f.comp of = g.comp of) : f = g :=
-  (FunLike.ext _ _) fun x => AssocQuotient.induction_on x <| FunLike.congr_fun h
+  (DFunLike.ext _ _) fun x => AssocQuotient.induction_on x <| DFunLike.congr_fun h
 #align magma.assoc_quotient.hom_ext Magma.AssocQuotient.hom_ext
 
 /-- Lifts a magma homomorphism `α → β` to a semigroup homomorphism `Magma.AssocQuotient α → β`
@@ -403,8 +403,8 @@ def lift : (α →ₙ* β) ≃ (AssocQuotient α →ₙ* β) where
       Quot.liftOn x f <| by rintro a b (⟨c, d, e⟩ | ⟨c, d, e, f⟩) <;> simp only [map_mul, mul_assoc]
     map_mul' := fun x y ↦ Quot.induction_on₂ x y (map_mul f) }
   invFun f := f.comp of
-  left_inv f := (FunLike.ext _ _) fun x ↦ rfl
-  right_inv f := hom_ext <| (FunLike.ext _ _) fun x ↦ rfl
+  left_inv f := (DFunLike.ext _ _) fun x ↦ rfl
+  right_inv f := hom_ext <| (DFunLike.ext _ _) fun x ↦ rfl
 #align magma.assoc_quotient.lift Magma.AssocQuotient.lift
 
 @[to_additive (attr := simp)]
@@ -511,7 +511,7 @@ protected def recOnMul {C : FreeSemigroup α → Sort l} (x) (ih1 : ∀ x, C (of
 
 @[to_additive (attr := ext 1100)]
 theorem hom_ext {β : Type v} [Mul β] {f g : FreeSemigroup α →ₙ* β} (h : f ∘ of = g ∘ of) : f = g :=
-  (FunLike.ext _ _) fun x ↦
+  (DFunLike.ext _ _) fun x ↦
     FreeSemigroup.recOnMul x (congr_fun h) fun x y hx hy ↦ by simp only [map_mul, *]
 #align free_semigroup.hom_ext FreeSemigroup.hom_ext
 
@@ -731,7 +731,7 @@ theorem toFreeSemigroup_comp_map (f : α → β) :
 @[to_additive]
 theorem toFreeSemigroup_map (f : α → β) (x : FreeMagma α) :
     toFreeSemigroup (map f x) = FreeSemigroup.map f (toFreeSemigroup x) :=
-  FunLike.congr_fun (toFreeSemigroup_comp_map f) x
+  DFunLike.congr_fun (toFreeSemigroup_comp_map f) x
 #align free_magma.to_free_semigroup_map FreeMagma.toFreeSemigroup_map
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -271,7 +271,7 @@ theorem comp_lift (g : M →* N) (f : α → M) : g.comp (lift f) = lift (g ∘ 
 
 @[to_additive]
 theorem hom_map_lift (g : M →* N) (f : α → M) (x : FreeMonoid α) : g (lift f x) = lift (g ∘ f) x :=
-  FunLike.ext_iff.1 (comp_lift g f) x
+  DFunLike.ext_iff.1 (comp_lift g f) x
 #align free_monoid.hom_map_lift FreeMonoid.hom_map_lift
 #align free_add_monoid.hom_map_lift FreeAddMonoid.hom_map_lift
 
@@ -351,7 +351,7 @@ theorem map_id : map (@id α) = MonoidHom.id (FreeMonoid α) := hom_eq fun _ ↦
 @[to_additive]
 instance uniqueUnits : Unique (FreeMonoid α)ˣ where
   uniq u := Units.ext <| toList.injective <|
-    have : toList u.val ++ toList u.inv = [] := FunLike.congr_arg toList u.val_inv
+    have : toList u.val ++ toList u.inv = [] := DFunLike.congr_arg toList u.val_inv
     (List.append_eq_nil.mp this).1
 
 end FreeMonoid

--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -128,7 +128,7 @@ variable (F)
 @[to_additive]
 instance (priority := 100) instMulHomClass (F : Type*)
     [Mul M] [Mul N] [h : MulEquivClass F M N] : MulHomClass F M N :=
-  { h with coe := h.coe, coe_injective' := FunLike.coe_injective' }
+  { h with coe := h.coe, coe_injective' := DFunLike.coe_injective' }
 
 -- See note [lower instance priority]
 @[to_additive]
@@ -195,7 +195,7 @@ instance [Mul α] [Mul β] [MulEquivClass F α β] : CoeTC F (α ≃* β) :=
 @[to_additive]
 theorem MulEquivClass.toMulEquiv_injective [Mul α] [Mul β] [MulEquivClass F α β] :
     Function.Injective ((↑) : F → α ≃* β) :=
-  fun _ _ e ↦ FunLike.ext _ _ fun a ↦ congr_arg (fun e : α ≃* β ↦ e.toFun a) e
+  fun _ _ e ↦ DFunLike.ext _ _ fun a ↦ congr_arg (fun e : α ≃* β ↦ e.toFun a) e
 
 namespace MulEquiv
 
@@ -482,13 +482,13 @@ theorem symm_comp_eq {α : Type*} (e : M ≃* N) (f : α → M) (g : α → N) :
 
 @[to_additive (attr := simp)]
 theorem symm_trans_self (e : M ≃* N) : e.symm.trans e = refl N :=
-  FunLike.ext _ _ e.apply_symm_apply
+  DFunLike.ext _ _ e.apply_symm_apply
 #align mul_equiv.symm_trans_self MulEquiv.symm_trans_self
 #align add_equiv.symm_trans_self AddEquiv.symm_trans_self
 
 @[to_additive (attr := simp)]
 theorem self_trans_symm (e : M ≃* N) : e.trans e.symm = refl M :=
-  FunLike.ext _ _ e.symm_apply_apply
+  DFunLike.ext _ _ e.symm_apply_apply
 #align mul_equiv.self_trans_symm MulEquiv.self_trans_symm
 #align add_equiv.self_trans_symm AddEquiv.self_trans_symm
 
@@ -511,13 +511,13 @@ same underlying function. -/
 @[to_additive (attr := ext)
   "Two additive isomorphisms agree if they are defined by the same underlying function."]
 theorem ext {f g : MulEquiv M N} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align mul_equiv.ext MulEquiv.ext
 #align add_equiv.ext AddEquiv.ext
 
 @[to_additive]
 theorem ext_iff {f g : MulEquiv M N} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align mul_equiv.ext_iff MulEquiv.ext_iff
 #align add_equiv.ext_iff AddEquiv.ext_iff
 
@@ -535,13 +535,13 @@ theorem mk_coe' (e : M ≃* N) (f h₁ h₂ h₃) : (MulEquiv.mk ⟨f, e, h₁, 
 
 @[to_additive]
 protected theorem congr_arg {f : MulEquiv M N} {x x' : M} : x = x' → f x = f x' :=
-  FunLike.congr_arg f
+  DFunLike.congr_arg f
 #align mul_equiv.congr_arg MulEquiv.congr_arg
 #align add_equiv.congr_arg AddEquiv.congr_arg
 
 @[to_additive]
 protected theorem congr_fun {f g : MulEquiv M N} (h : f = g) (x : M) : f x = g x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align mul_equiv.congr_fun MulEquiv.congr_fun
 #align add_equiv.congr_fun AddEquiv.congr_fun
 
@@ -762,8 +762,8 @@ def MulHom.toMulEquiv [Mul M] [Mul N] (f : M →ₙ* N) (g : N →ₙ* M) (h₁ 
     (h₂ : f.comp g = MulHom.id _) : M ≃* N where
   toFun := f
   invFun := g
-  left_inv := FunLike.congr_fun h₁
-  right_inv := FunLike.congr_fun h₂
+  left_inv := DFunLike.congr_fun h₁
+  right_inv := DFunLike.congr_fun h₂
   map_mul' := f.map_mul
 #align mul_hom.to_mul_equiv MulHom.toMulEquiv
 #align add_hom.to_add_equiv AddHom.toAddEquiv
@@ -798,8 +798,8 @@ def MonoidHom.toMulEquiv [MulOneClass M] [MulOneClass N] (f : M →* N) (g : N �
     (h₁ : g.comp f = MonoidHom.id _) (h₂ : f.comp g = MonoidHom.id _) : M ≃* N where
   toFun := f
   invFun := g
-  left_inv := FunLike.congr_fun h₁
-  right_inv := FunLike.congr_fun h₂
+  left_inv := DFunLike.congr_fun h₁
+  right_inv := DFunLike.congr_fun h₂
   map_mul' := f.map_mul
 #align monoid_hom.to_mul_equiv MonoidHom.toMulEquiv
 #align add_monoid_hom.to_add_equiv AddMonoidHom.toAddEquiv

--- a/Mathlib/Algebra/Group/Freiman.lean
+++ b/Mathlib/Algebra/Group/Freiman.lean
@@ -167,7 +167,7 @@ instance freimanHomClass : FreimanHomClass (A →*[n] β) A β n where
 #align add_freiman_hom.freiman_hom_class AddFreimanHom.addFreimanHomClass
 
 -- porting note: not helpful in lean4
--- /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+-- /-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 -- directly. -/
 -- @[to_additive
 --       "Helper instance for when there's too many metavariables to apply

--- a/Mathlib/Algebra/Group/Freiman.lean
+++ b/Mathlib/Algebra/Group/Freiman.lean
@@ -154,11 +154,11 @@ theorem map_mul_map_eq_map_mul_map [FreimanHomClass F A β 2] (f : F) (ha : a �
 namespace FreimanHom
 
 @[to_additive]
-instance funLike : DFunLike (A →*[n] β) α fun _ => β where
+instance instDFunLike : DFunLike (A →*[n] β) α fun _ => β where
   coe := toFun
   coe_injective' f g h := by cases f; cases g; congr
-#align freiman_hom.fun_like FreimanHom.funLike
-#align add_freiman_hom.fun_like AddFreimanHom.funLike
+#align freiman_hom.fun_like FreimanHom.instDFunLike
+#align add_freiman_hom.fun_like AddFreimanHom.instDFunLike
 
 @[to_additive addFreimanHomClass]
 instance freimanHomClass : FreimanHomClass (A →*[n] β) A β n where

--- a/Mathlib/Algebra/Group/Freiman.lean
+++ b/Mathlib/Algebra/Group/Freiman.lean
@@ -88,7 +88,7 @@ notation:25 (name := «FreimanHomLocal≺») A " →*[" n:25 "] " β:0 => Freima
 /-- `AddFreimanHomClass F A β n` states that `F` is a type of `n`-ary sums-preserving morphisms.
 You should extend this class when you extend `AddFreimanHom`. -/
 class AddFreimanHomClass (F : Type*) (A : outParam <| Set α) (β : outParam <| Type*)
-  [AddCommMonoid α] [AddCommMonoid β] (n : ℕ) [FunLike F α fun _ => β] : Prop where
+  [AddCommMonoid α] [AddCommMonoid β] (n : ℕ) [DFunLike F α fun _ => β] : Prop where
   /-- An additive `n`-Freiman homomorphism preserves sums of `n` elements. -/
   map_sum_eq_map_sum' (f : F) {s t : Multiset α} (hsA : ∀ ⦃x⦄, x ∈ s → x ∈ A)
     (htA : ∀ ⦃x⦄, x ∈ t → x ∈ A) (hs : Multiset.card s = n) (ht : Multiset.card t = n)
@@ -102,7 +102,7 @@ You should extend this class when you extend `FreimanHom`. -/
       "`AddFreimanHomClass F A β n` states that `F` is a type of `n`-ary
       sums-preserving morphisms. You should extend this class when you extend `AddFreimanHom`."]
 class FreimanHomClass (F : Type*) (A : outParam <| Set α) (β : outParam <| Type*) [CommMonoid α]
-  [CommMonoid β] (n : ℕ) [FunLike F α fun _ => β] : Prop where
+  [CommMonoid β] (n : ℕ) [DFunLike F α fun _ => β] : Prop where
   /-- An `n`-Freiman homomorphism preserves products of `n` elements. -/
   map_prod_eq_map_prod' (f : F) {s t : Multiset α} (hsA : ∀ ⦃x⦄, x ∈ s → x ∈ A)
     (htA : ∀ ⦃x⦄, x ∈ t → x ∈ A) (hs : Multiset.card s = n) (ht : Multiset.card t = n)
@@ -110,7 +110,7 @@ class FreimanHomClass (F : Type*) (A : outParam <| Set α) (β : outParam <| Typ
     (s.map f).prod = (t.map f).prod
 #align freiman_hom_class FreimanHomClass
 
-variable [FunLike F α fun _ => β]
+variable [DFunLike F α fun _ => β]
 
 section CommMonoid
 
@@ -125,7 +125,7 @@ see also Algebra.Hom.Group for similar -/
     " Turn an element of a type `F` satisfying `AddFreimanHomClass F A β n` into an actual
     `AddFreimanHom`. This is declared as the default coercion from `F` to `AddFreimanHom A β n`."]
 def _root_.FreimanHomClass.toFreimanHom [FreimanHomClass F A β n] (f : F) : A →*[n] β where
-  toFun := FunLike.coe f
+  toFun := DFunLike.coe f
   map_prod_eq_map_prod' := FreimanHomClass.map_prod_eq_map_prod' f
 
 /-- Any type satisfying `SMulHomClass` can be cast into `MulActionHom` via
@@ -154,7 +154,7 @@ theorem map_mul_map_eq_map_mul_map [FreimanHomClass F A β 2] (f : F) (ha : a �
 namespace FreimanHom
 
 @[to_additive]
-instance funLike : FunLike (A →*[n] β) α fun _ => β where
+instance funLike : DFunLike (A →*[n] β) α fun _ => β where
   coe := toFun
   coe_injective' f g h := by cases f; cases g; congr
 #align freiman_hom.fun_like FreimanHom.funLike
@@ -186,7 +186,7 @@ theorem toFun_eq_coe (f : A →*[n] β) : f.toFun = f :=
 
 @[to_additive (attr := ext)]
 theorem ext ⦃f g : A →*[n] β⦄ (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align freiman_hom.ext FreimanHom.ext
 #align add_freiman_hom.ext AddFreimanHom.ext
 
@@ -254,7 +254,7 @@ theorem comp_assoc (f : A →*[n] β) (g : B →*[n] γ) (h : C →*[n] δ) {hf 
 @[to_additive (attr := simp)]
 theorem cancel_right {g₁ g₂ : B →*[n] γ} {f : A →*[n] β} (hf : Function.Surjective f) {hg₁ hg₂} :
     g₁.comp f hg₁ = g₂.comp f hg₂ ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, fun h => h ▸ rfl⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun h => h ▸ rfl⟩
 #align freiman_hom.cancel_right FreimanHom.cancel_right
 #align add_freiman_hom.cancel_right AddFreimanHom.cancel_right
 
@@ -477,7 +477,7 @@ theorem MonoidHom.toFreimanHom_coe (f : α →* β) : (f.toFreimanHom A n : α �
 @[to_additive AddMonoidHom.toAddFreimanHom_injective]
 theorem MonoidHom.toFreimanHom_injective :
     Function.Injective (MonoidHom.toFreimanHom A n : (α →* β) → A →*[n] β) := fun f g h =>
-   by rwa [toFreimanHom, toFreimanHom, FreimanHom.mk.injEq, FunLike.coe_fn_eq] at h
+   by rwa [toFreimanHom, toFreimanHom, FreimanHom.mk.injEq, DFunLike.coe_fn_eq] at h
 #align monoid_hom.to_freiman_hom_injective MonoidHom.toFreimanHom_injective
 #align add_monoid_hom.to_freiman_hom_injective AddMonoidHom.toAddFreimanHom_injective
 
@@ -553,7 +553,7 @@ theorem FreimanHom.toFreimanHom_coe (h : m ≤ n) (f : A →*[n] β) :
 @[to_additive AddFreimanHom.toAddFreimanHom_injective]
 theorem FreimanHom.toFreimanHom_injective (h : m ≤ n) :
     Function.Injective (FreimanHom.toFreimanHom h : (A →*[n] β) → A →*[m] β) := fun f g hfg =>
-  FreimanHom.ext <| by convert FunLike.ext_iff.1 hfg using 0
+  FreimanHom.ext <| by convert DFunLike.ext_iff.1 hfg using 0
 #align freiman_hom.to_freiman_hom_injective FreimanHom.toFreimanHom_injective
 #align add_freiman_hom.to_freiman_hom_injective AddFreimanHom.toAddFreimanHom_injective
 

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -91,7 +91,7 @@ structure ZeroHom (M : Type*) (N : Type*) [Zero M] [Zero N] where
 You should extend this typeclass when you extend `ZeroHom`.
 -/
 class ZeroHomClass (F : Type*) (M N : outParam (Type*)) [Zero M] [Zero N]
-  extends FunLike F M fun _ => N where
+  extends DFunLike F M fun _ => N where
   /-- The proposition that the function preserves 0 -/
   map_zero : ∀ f : F, f 0 = 0
 #align zero_hom_class ZeroHomClass
@@ -120,7 +120,7 @@ structure AddHom (M : Type*) (N : Type*) [Add M] [Add N] where
 You should declare an instance of this typeclass when you extend `AddHom`.
 -/
 class AddHomClass (F : Type*) (M N : outParam (Type*)) [Add M] [Add N]
-  extends FunLike F M fun _ => N where
+  extends DFunLike F M fun _ => N where
   /-- The proposition that the function preserves addition -/
   map_add : ∀ (f : F) (x y : M), f (x + y) = f x + f y
 #align add_hom_class AddHomClass
@@ -185,7 +185,7 @@ You should extend this typeclass when you extend `OneHom`.
 -/
 @[to_additive]
 class OneHomClass (F : Type*) (M N : outParam (Type*)) [One M] [One N]
-  extends FunLike F M fun _ => N where
+  extends DFunLike F M fun _ => N where
   /-- The proposition that the function preserves 1 -/
   map_one : ∀ f : F, f 1 = 1
 #align one_hom_class OneHomClass
@@ -208,7 +208,7 @@ theorem map_one [OneHomClass F M N] (f : F) : f 1 = 1 :=
 @[to_additive]
 theorem Subsingleton.of_oneHomClass [Subsingleton M] [OneHomClass F M N] :
     Subsingleton F where
-  allEq f g := FunLike.ext _ _ fun x ↦ by simp [Subsingleton.elim x 1]
+  allEq f g := DFunLike.ext _ _ fun x ↦ by simp [Subsingleton.elim x 1]
 
 @[to_additive] instance [Subsingleton M] : Subsingleton (OneHom M N) := .of_oneHomClass
 
@@ -281,7 +281,7 @@ You should declare an instance of this typeclass when you extend `MulHom`.
 -/
 @[to_additive]
 class MulHomClass (F : Type*) (M N : outParam (Type*)) [Mul M] [Mul N]
-  extends FunLike F M fun _ => N where
+  extends DFunLike F M fun _ => N where
   /-- The proposition that the function preserves multiplication -/
   map_mul : ∀ (f : F) (x y : M), f (x * y) = f x * f y
 #align mul_hom_class MulHomClass
@@ -363,7 +363,7 @@ instance MonoidHom.monoidHomClass : MonoidHomClass (M →* N) M N where
     cases f
     cases g
     congr
-    apply FunLike.coe_injective'
+    apply DFunLike.coe_injective'
     exact h
   map_mul := MonoidHom.map_mul'
   map_one f := f.toOneHom.map_one'
@@ -496,7 +496,7 @@ instance MonoidWithZeroHom.monoidWithZeroHomClass : MonoidWithZeroHomClass (M �
     cases f
     cases g
     congr
-    apply FunLike.coe_injective'
+    apply DFunLike.coe_injective'
     exact h
   map_mul := MonoidWithZeroHom.map_mul'
   map_one := MonoidWithZeroHom.map_one'
@@ -630,25 +630,25 @@ theorem MonoidWithZeroHom.toMonoidHom_coe [MulZeroOneClass M] [MulZeroOneClass N
 
 @[to_additive (attr := ext)]
 theorem OneHom.ext [One M] [One N] ⦃f g : OneHom M N⦄ (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align one_hom.ext OneHom.ext
 #align zero_hom.ext ZeroHom.ext
 
 @[to_additive (attr := ext)]
 theorem MulHom.ext [Mul M] [Mul N] ⦃f g : M →ₙ* N⦄ (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align mul_hom.ext MulHom.ext
 #align add_hom.ext AddHom.ext
 
 @[to_additive (attr := ext)]
 theorem MonoidHom.ext [MulOneClass M] [MulOneClass N] ⦃f g : M →* N⦄ (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align monoid_hom.ext MonoidHom.ext
 #align add_monoid_hom.ext AddMonoidHom.ext
 
 @[ext]
 theorem MonoidWithZeroHom.ext [MulZeroOneClass M] [MulZeroOneClass N] ⦃f g : M →*₀ N⦄
-    (h : ∀ x, f x = g x) : f = g := FunLike.ext _ _ h
+    (h : ∀ x, f x = g x) : f = g := DFunLike.ext _ _ h
 #align monoid_with_zero_hom.ext MonoidWithZeroHom.ext
 
 
@@ -673,112 +673,112 @@ end MonoidHom
 
 section Deprecated
 
-/-- Deprecated: use `FunLike.congr_fun` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `FunLike.congr_fun` instead."]
+/-- Deprecated: use `DFunLike.congr_fun` instead. -/
+@[to_additive (attr := deprecated) "Deprecated: use `DFunLike.congr_fun` instead."]
 theorem OneHom.congr_fun [One M] [One N] {f g : OneHom M N} (h : f = g) (x : M) : f x = g x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align one_hom.congr_fun OneHom.congr_fun
 #align zero_hom.congr_fun ZeroHom.congr_fun
 
-/-- Deprecated: use `FunLike.congr_fun` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `FunLike.congr_fun` instead."]
+/-- Deprecated: use `DFunLike.congr_fun` instead. -/
+@[to_additive (attr := deprecated) "Deprecated: use `DFunLike.congr_fun` instead."]
 theorem MulHom.congr_fun [Mul M] [Mul N] {f g : M →ₙ* N} (h : f = g) (x : M) : f x = g x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align mul_hom.congr_fun MulHom.congr_fun
 #align add_hom.congr_fun AddHom.congr_fun
 
-/-- Deprecated: use `FunLike.congr_fun` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `FunLike.congr_fun` instead."]
+/-- Deprecated: use `DFunLike.congr_fun` instead. -/
+@[to_additive (attr := deprecated) "Deprecated: use `DFunLike.congr_fun` instead."]
 theorem MonoidHom.congr_fun [MulOneClass M] [MulOneClass N] {f g : M →* N} (h : f = g) (x : M) :
-    f x = g x := FunLike.congr_fun h x
+    f x = g x := DFunLike.congr_fun h x
 #align monoid_hom.congr_fun MonoidHom.congr_fun
 #align add_monoid_hom.congr_fun AddMonoidHom.congr_fun
 
-/-- Deprecated: use `FunLike.congr_fun` instead. -/
+/-- Deprecated: use `DFunLike.congr_fun` instead. -/
 @[deprecated]
 theorem MonoidWithZeroHom.congr_fun [MulZeroOneClass M] [MulZeroOneClass N] {f g : M →*₀ N}
-    (h : f = g) (x : M) : f x = g x := FunLike.congr_fun h x
+    (h : f = g) (x : M) : f x = g x := DFunLike.congr_fun h x
 #align monoid_with_zero_hom.congr_fun MonoidWithZeroHom.congr_fun
 
-/-- Deprecated: use `FunLike.congr_arg` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `FunLike.congr_arg` instead."]
+/-- Deprecated: use `DFunLike.congr_arg` instead. -/
+@[to_additive (attr := deprecated) "Deprecated: use `DFunLike.congr_arg` instead."]
 theorem OneHom.congr_arg [One M] [One N] (f : OneHom M N) {x y : M} (h : x = y) : f x = f y :=
-  FunLike.congr_arg f h
+  DFunLike.congr_arg f h
 #align one_hom.congr_arg OneHom.congr_arg
 #align zero_hom.congr_arg ZeroHom.congr_arg
 
-/-- Deprecated: use `FunLike.congr_arg` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `FunLike.congr_arg` instead."]
+/-- Deprecated: use `DFunLike.congr_arg` instead. -/
+@[to_additive (attr := deprecated) "Deprecated: use `DFunLike.congr_arg` instead."]
 theorem MulHom.congr_arg [Mul M] [Mul N] (f : M →ₙ* N) {x y : M} (h : x = y) : f x = f y :=
-  FunLike.congr_arg f h
+  DFunLike.congr_arg f h
 #align mul_hom.congr_arg MulHom.congr_arg
 #align add_hom.congr_arg AddHom.congr_arg
 
-/-- Deprecated: use `FunLike.congr_arg` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `FunLike.congr_arg` instead."]
+/-- Deprecated: use `DFunLike.congr_arg` instead. -/
+@[to_additive (attr := deprecated) "Deprecated: use `DFunLike.congr_arg` instead."]
 theorem MonoidHom.congr_arg [MulOneClass M] [MulOneClass N] (f : M →* N) {x y : M} (h : x = y) :
-    f x = f y := FunLike.congr_arg f h
+    f x = f y := DFunLike.congr_arg f h
 #align monoid_hom.congr_arg MonoidHom.congr_arg
 #align add_monoid_hom.congr_arg AddMonoidHom.congr_arg
 
-/-- Deprecated: use `FunLike.congr_arg` instead. -/
+/-- Deprecated: use `DFunLike.congr_arg` instead. -/
 @[deprecated]
 theorem MonoidWithZeroHom.congr_arg [MulZeroOneClass M] [MulZeroOneClass N] (f : M →*₀ N) {x y : M}
-    (h : x = y) : f x = f y := FunLike.congr_arg f h
+    (h : x = y) : f x = f y := DFunLike.congr_arg f h
 #align monoid_with_zero_hom.congr_arg MonoidWithZeroHom.congr_arg
 
-/-- Deprecated: use `FunLike.coe_injective` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `FunLike.coe_injective` instead."]
+/-- Deprecated: use `DFunLike.coe_injective` instead. -/
+@[to_additive (attr := deprecated) "Deprecated: use `DFunLike.coe_injective` instead."]
 theorem OneHom.coe_inj [One M] [One N] ⦃f g : OneHom M N⦄ (h : (f : M → N) = g) : f = g :=
-  FunLike.coe_injective h
+  DFunLike.coe_injective h
 #align one_hom.coe_inj OneHom.coe_inj
 #align zero_hom.coe_inj ZeroHom.coe_inj
 
-/-- Deprecated: use `FunLike.coe_injective` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `FunLike.coe_injective` instead."]
+/-- Deprecated: use `DFunLike.coe_injective` instead. -/
+@[to_additive (attr := deprecated) "Deprecated: use `DFunLike.coe_injective` instead."]
 theorem MulHom.coe_inj [Mul M] [Mul N] ⦃f g : M →ₙ* N⦄ (h : (f : M → N) = g) : f = g :=
-  FunLike.coe_injective h
+  DFunLike.coe_injective h
 #align mul_hom.coe_inj MulHom.coe_inj
 #align add_hom.coe_inj AddHom.coe_inj
 
-/-- Deprecated: use `FunLike.coe_injective` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `FunLike.coe_injective` instead."]
+/-- Deprecated: use `DFunLike.coe_injective` instead. -/
+@[to_additive (attr := deprecated) "Deprecated: use `DFunLike.coe_injective` instead."]
 theorem MonoidHom.coe_inj [MulOneClass M] [MulOneClass N] ⦃f g : M →* N⦄ (h : (f : M → N) = g) :
-    f = g := FunLike.coe_injective h
+    f = g := DFunLike.coe_injective h
 #align monoid_hom.coe_inj MonoidHom.coe_inj
 #align add_monoid_hom.coe_inj AddMonoidHom.coe_inj
 
-/-- Deprecated: use `FunLike.coe_injective` instead. -/
+/-- Deprecated: use `DFunLike.coe_injective` instead. -/
 @[deprecated]
 theorem MonoidWithZeroHom.coe_inj [MulZeroOneClass M] [MulZeroOneClass N] ⦃f g : M →*₀ N⦄
-    (h : (f : M → N) = g) : f = g := FunLike.coe_injective h
+    (h : (f : M → N) = g) : f = g := DFunLike.coe_injective h
 #align monoid_with_zero_hom.coe_inj MonoidWithZeroHom.coe_inj
 
-/-- Deprecated: use `FunLike.ext_iff` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `FunLike.ext_iff` instead."]
+/-- Deprecated: use `DFunLike.ext_iff` instead. -/
+@[to_additive (attr := deprecated) "Deprecated: use `DFunLike.ext_iff` instead."]
 theorem OneHom.ext_iff [One M] [One N] {f g : OneHom M N} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align one_hom.ext_iff OneHom.ext_iff
 #align zero_hom.ext_iff ZeroHom.ext_iff
 
-/-- Deprecated: use `FunLike.ext_iff` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `FunLike.ext_iff` instead."]
+/-- Deprecated: use `DFunLike.ext_iff` instead. -/
+@[to_additive (attr := deprecated) "Deprecated: use `DFunLike.ext_iff` instead."]
 theorem MulHom.ext_iff [Mul M] [Mul N] {f g : M →ₙ* N} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align mul_hom.ext_iff MulHom.ext_iff
 #align add_hom.ext_iff AddHom.ext_iff
 
-/-- Deprecated: use `FunLike.ext_iff` instead. -/
-@[to_additive (attr := deprecated) "Deprecated: use `FunLike.ext_iff` instead."]
+/-- Deprecated: use `DFunLike.ext_iff` instead. -/
+@[to_additive (attr := deprecated) "Deprecated: use `DFunLike.ext_iff` instead."]
 theorem MonoidHom.ext_iff [MulOneClass M] [MulOneClass N] {f g : M →* N} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align monoid_hom.ext_iff MonoidHom.ext_iff
 #align add_monoid_hom.ext_iff AddMonoidHom.ext_iff
 
-/-- Deprecated: use `FunLike.ext_iff` instead. -/
+/-- Deprecated: use `DFunLike.ext_iff` instead. -/
 @[deprecated]
 theorem MonoidWithZeroHom.ext_iff [MulZeroOneClass M] [MulZeroOneClass N] {f g : M →*₀ N} :
-    f = g ↔ ∀ x, f x = g x := FunLike.ext_iff
+    f = g ↔ ∀ x, f x = g x := DFunLike.ext_iff
 #align monoid_with_zero_hom.ext_iff MonoidWithZeroHom.ext_iff
 
 end Deprecated
@@ -830,7 +830,7 @@ theorem OneHom.coe_copy {_ : One M} {_ : One N} (f : OneHom M N) (f' : M → N) 
 @[to_additive]
 theorem OneHom.coe_copy_eq {_ : One M} {_ : One N} (f : OneHom M N) (f' : M → N) (h : f' = f) :
     f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align one_hom.coe_copy_eq OneHom.coe_copy_eq
 #align zero_hom.coe_copy_eq ZeroHom.coe_copy_eq
 
@@ -856,7 +856,7 @@ theorem MulHom.coe_copy {_ : Mul M} {_ : Mul N} (f : M →ₙ* N) (f' : M → N)
 @[to_additive]
 theorem MulHom.coe_copy_eq {_ : Mul M} {_ : Mul N} (f : M →ₙ* N) (f' : M → N) (h : f' = f) :
     f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align mul_hom.coe_copy_eq MulHom.coe_copy_eq
 #align add_hom.coe_copy_eq AddHom.coe_copy_eq
 
@@ -881,7 +881,7 @@ theorem MonoidHom.coe_copy {_ : MulOneClass M} {_ : MulOneClass N} (f : M →* N
 @[to_additive]
 theorem MonoidHom.copy_eq {_ : MulOneClass M} {_ : MulOneClass N} (f : M →* N) (f' : M → N)
     (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align monoid_hom.copy_eq MonoidHom.copy_eq
 #align add_monoid_hom.copy_eq AddMonoidHom.copy_eq
 
@@ -900,7 +900,7 @@ theorem MonoidWithZeroHom.coe_copy {_ : MulZeroOneClass M} {_ : MulZeroOneClass 
 
 theorem MonoidWithZeroHom.copy_eq {_ : MulZeroOneClass M} {_ : MulZeroOneClass N} (f : M →*₀ N)
     (f' : M → N) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align monoid_with_zero_hom.copy_eq MonoidWithZeroHom.copy_eq
 
 @[to_additive]
@@ -1144,14 +1144,14 @@ theorem MonoidWithZeroHom.comp_assoc {Q : Type*} [MulZeroOneClass M] [MulZeroOne
 @[to_additive]
 theorem OneHom.cancel_right [One M] [One N] [One P] {g₁ g₂ : OneHom N P} {f : OneHom M N}
     (hf : Function.Surjective f) : g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => OneHom.ext <| hf.forall.2 (FunLike.ext_iff.1 h), fun h => h ▸ rfl⟩
+  ⟨fun h => OneHom.ext <| hf.forall.2 (DFunLike.ext_iff.1 h), fun h => h ▸ rfl⟩
 #align one_hom.cancel_right OneHom.cancel_right
 #align zero_hom.cancel_right ZeroHom.cancel_right
 
 @[to_additive]
 theorem MulHom.cancel_right [Mul M] [Mul N] [Mul P] {g₁ g₂ : N →ₙ* P} {f : M →ₙ* N}
     (hf : Function.Surjective f) : g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => MulHom.ext <| hf.forall.2 (FunLike.ext_iff.1 h), fun h => h ▸ rfl⟩
+  ⟨fun h => MulHom.ext <| hf.forall.2 (DFunLike.ext_iff.1 h), fun h => h ▸ rfl⟩
 #align mul_hom.cancel_right MulHom.cancel_right
 #align add_hom.cancel_right AddHom.cancel_right
 
@@ -1159,14 +1159,14 @@ theorem MulHom.cancel_right [Mul M] [Mul N] [Mul P] {g₁ g₂ : N →ₙ* P} {f
 theorem MonoidHom.cancel_right [MulOneClass M] [MulOneClass N] [MulOneClass P]
     {g₁ g₂ : N →* P} {f : M →* N} (hf : Function.Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => MonoidHom.ext <| hf.forall.2 (FunLike.ext_iff.1 h), fun h => h ▸ rfl⟩
+  ⟨fun h => MonoidHom.ext <| hf.forall.2 (DFunLike.ext_iff.1 h), fun h => h ▸ rfl⟩
 #align monoid_hom.cancel_right MonoidHom.cancel_right
 #align add_monoid_hom.cancel_right AddMonoidHom.cancel_right
 
 theorem MonoidWithZeroHom.cancel_right [MulZeroOneClass M] [MulZeroOneClass N] [MulZeroOneClass P]
     {g₁ g₂ : N →*₀ P} {f : M →*₀ N} (hf : Function.Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => MonoidWithZeroHom.ext <| hf.forall.2 (FunLike.ext_iff.1 h), fun h => h ▸ rfl⟩
+  ⟨fun h => MonoidWithZeroHom.ext <| hf.forall.2 (DFunLike.ext_iff.1 h), fun h => h ▸ rfl⟩
 #align monoid_with_zero_hom.cancel_right MonoidWithZeroHom.cancel_right
 
 @[to_additive]
@@ -1227,7 +1227,7 @@ end
 
 theorem MonoidWithZeroHom.toZeroHom_injective [MulZeroOneClass M] [MulZeroOneClass N] :
     Function.Injective (MonoidWithZeroHom.toZeroHom : (M →*₀ N) → ZeroHom M N) :=
-  fun _ _ h => MonoidWithZeroHom.ext <| (FunLike.ext_iff (F := ZeroHom M N)).mp h
+  fun _ _ h => MonoidWithZeroHom.ext <| (DFunLike.ext_iff (F := ZeroHom M N)).mp h
 #align monoid_with_zero_hom.to_zero_hom_injective MonoidWithZeroHom.toZeroHom_injective
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Group/Hom/Instances.lean
+++ b/Mathlib/Algebra/Group/Hom/Instances.lean
@@ -122,7 +122,7 @@ namespace MonoidHom
 @[to_additive]
 theorem ext_iff₂ {_ : MulOneClass M} {_ : MulOneClass N} {_ : CommMonoid P} {f g : M →* N →* P} :
     f = g ↔ ∀ x y, f x y = g x y :=
-  FunLike.ext_iff.trans <| forall_congr' fun _ => FunLike.ext_iff
+  DFunLike.ext_iff.trans <| forall_congr' fun _ => DFunLike.ext_iff
 #align monoid_hom.ext_iff₂ MonoidHom.ext_iff₂
 #align add_monoid_hom.ext_iff₂ AddMonoidHom.ext_iff₂
 
@@ -333,11 +333,11 @@ theorem AddMonoidHom.map_mul_iff (f : R →+ S) :
 
 lemma AddMonoidHom.mulLeft_eq_mulRight_iff_forall_commute {a : R} :
     mulLeft a = mulRight a ↔ ∀ b, Commute a b :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 
 lemma AddMonoidHom.mulRight_eq_mulLeft_iff_forall_commute {b : R} :
     mulRight b = mulLeft b ↔ ∀ a, Commute a b :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 
 /-- The left multiplication map: `(a, b) ↦ a * b`. See also `AddMonoidHom.mulLeft`. -/
 @[simps!]

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -695,7 +695,7 @@ theorem AddMonoidHom.mul_op_ext {α β} [AddZeroClass α] [AddZeroClass β] (f g
       f.comp (opAddEquiv : α ≃+ αᵐᵒᵖ).toAddMonoidHom =
         g.comp (opAddEquiv : α ≃+ αᵐᵒᵖ).toAddMonoidHom) :
     f = g :=
-  AddMonoidHom.ext <| MulOpposite.rec' fun x => (FunLike.congr_fun h : _) x
+  AddMonoidHom.ext <| MulOpposite.rec' fun x => (DFunLike.congr_fun h : _) x
 #align add_monoid_hom.mul_op_ext AddMonoidHom.mul_op_ext
 
 end Ext

--- a/Mathlib/Algebra/Group/UniqueProds.lean
+++ b/Mathlib/Algebra/Group/UniqueProds.lean
@@ -472,11 +472,11 @@ end UniqueProds
 instance {ι} (G : ι → Type*) [∀ i, AddZeroClass (G i)] [∀ i, UniqueSums (G i)] :
     UniqueSums (Π₀ i, G i) :=
   UniqueSums.addHom_image_of_injective
-    DFinsupp.coeFnAddMonoidHom.toAddHom FunLike.coe_injective inferInstance
+    DFinsupp.coeFnAddMonoidHom.toAddHom DFunLike.coe_injective inferInstance
 
 instance {ι G} [AddZeroClass G] [UniqueSums G] : UniqueSums (ι →₀ G) :=
   UniqueSums.addHom_image_of_injective
-    Finsupp.coeFnAddHom.toAddHom FunLike.coe_injective inferInstance
+    Finsupp.coeFnAddHom.toAddHom DFunLike.coe_injective inferInstance
 
 namespace TwoUniqueProds
 
@@ -611,11 +611,11 @@ end TwoUniqueProds
 instance {ι} (G : ι → Type*) [∀ i, AddZeroClass (G i)] [∀ i, TwoUniqueSums (G i)] :
     TwoUniqueSums (Π₀ i, G i) :=
   TwoUniqueSums.addHom_image_of_injective
-    DFinsupp.coeFnAddMonoidHom.toAddHom FunLike.coe_injective inferInstance
+    DFinsupp.coeFnAddMonoidHom.toAddHom DFunLike.coe_injective inferInstance
 
 instance {ι G} [AddZeroClass G] [TwoUniqueSums G] : TwoUniqueSums (ι →₀ G) :=
   TwoUniqueSums.addHom_image_of_injective
-    Finsupp.coeFnAddHom.toAddHom FunLike.coe_injective inferInstance
+    Finsupp.coeFnAddHom.toAddHom DFunLike.coe_injective inferInstance
 
 /-- Any `ℚ`-vector space has `TwoUniqueSums`, because it is isomorphic to some
   `(Basis.ofVectorSpaceIndex ℚ G) →₀ ℚ` by choosing a basis, and `ℚ` already has

--- a/Mathlib/Algebra/Homology/ImageToKernel.lean
+++ b/Mathlib/Algebra/Homology/ImageToKernel.lean
@@ -64,7 +64,7 @@ theorem subobject_ofLE_as_imageToKernel (w : f ≫ g = 0) (h) :
   rfl
 #align subobject_of_le_as_image_to_kernel subobject_ofLE_as_imageToKernel
 
-attribute [local instance] ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.instDFunLike
 
 -- porting note: removed elementwise attribute which does not seem to be helpful here
 -- a more suitable lemma is added below
@@ -303,7 +303,7 @@ theorem homology'.π_map (p : α.right = β.left) :
 
 section
 
-attribute [local instance] ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.instDFunLike
 
 @[simp]
 lemma homology'.π_map_apply [ConcreteCategory.{w} V] (p : α.right = β.left)

--- a/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
@@ -142,7 +142,7 @@ lemma δ_apply (x₃ : D.L₀.X₃) (x₂ : D.L₁.X₂) (x₁ : D.L₂.X₁)
     (Limits.Concrete.pullbackMk D.L₁.g D.v₀₁.τ₃ x₂ x₃ h₂)
   have eq₁ := Concrete.pullbackMk_fst D.L₁.g D.v₀₁.τ₃ x₂ x₃ h₂
   have eq₂ := Concrete.pullbackMk_snd D.L₁.g D.v₀₁.τ₃ x₂ x₃ h₂
-  dsimp [FunLike.coe] at eq₁ eq₂
+  dsimp [DFunLike.coe] at eq₁ eq₂
   rw [Functor.map_comp, types_comp_apply, FunctorToTypes.map_comp_apply] at eq
   rw [eq₂] at eq
   refine' eq.trans (congr_arg ((forget C).map D.v₂₃.τ₁) _)

--- a/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
@@ -121,7 +121,7 @@ section abelian
 variable {C : Type u} [Category.{v} C] [ConcreteCategory.{v} C] [HasForget₂ C Ab]
   [Abelian C] [(forget₂ C Ab).Additive] [(forget₂ C Ab).PreservesHomology]
 
-attribute [local instance] ConcreteCategory.funLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
 
 namespace ShortComplex
 

--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -307,7 +307,7 @@ attribute [coe] LieHom.toLinearMap
 instance : Coe (L₁ →ₗ⁅R⁆ L₂) (L₁ →ₗ[R] L₂) :=
   ⟨LieHom.toLinearMap⟩
 
-instance : FunLike (L₁ →ₗ⁅R⁆ L₂) L₁ (fun _ => L₂) :=
+instance : DFunLike (L₁ →ₗ⁅R⁆ L₂) L₁ (fun _ => L₂) :=
   { coe := fun f => f.toFun,
     coe_injective' := fun x y h =>
       by cases x; cases y; simp at h; simp [h] }
@@ -736,7 +736,7 @@ attribute [coe] LieModuleHom.toLinearMap
 instance : CoeOut (M →ₗ⁅R,L⁆ N) (M →ₗ[R] N) :=
   ⟨LieModuleHom.toLinearMap⟩
 
-instance : FunLike (M →ₗ⁅R, L⁆ N) M (fun _ => N) :=
+instance : DFunLike (M →ₗ⁅R, L⁆ N) M (fun _ => N) :=
   { coe := fun f => f.toFun,
     coe_injective' := fun x y h =>
       by cases x; cases y; simp at h; simp [h] }

--- a/Mathlib/Algebra/Module/Basic.lean
+++ b/Mathlib/Algebra/Module/Basic.lean
@@ -403,7 +403,7 @@ theorem zsmul_eq_smul_cast (n : ℤ) (b : M) : n • b = (n : R) • b :=
   have : (smulAddHom ℤ M).flip b = ((smulAddHom R M).flip b).comp (Int.castAddHom R) := by
     apply AddMonoidHom.ext_int
     simp
-  FunLike.congr_fun this n
+  DFunLike.congr_fun this n
 #align zsmul_eq_smul_cast zsmul_eq_smul_cast
 
 end

--- a/Mathlib/Algebra/Module/DirectLimitAndTensorProduct.lean
+++ b/Mathlib/Algebra/Module/DirectLimitAndTensorProduct.lean
@@ -61,7 +61,7 @@ noncomputable def toDirectLimit : DirectLimit G f ⊗[R] M →ₗ[R] DirectLimit
   TensorProduct.lift <| DirectLimit.lift _ _ _ _
     (fun i ↦
       (TensorProduct.mk R _ _).compr₂ (of R ι _ (fun _i _j h ↦ (f _ _ h).rTensor M) i))
-    fun _ _ _ g ↦ FunLike.ext _ _ (of_f (G := (G · ⊗[R] M)) (x := g ⊗ₜ ·))
+    fun _ _ _ g ↦ DFunLike.ext _ _ (of_f (G := (G · ⊗[R] M)) (x := g ⊗ₜ ·))
 
 variable {M} in
 @[simp] lemma toDirectLimit_tmul_of
@@ -80,9 +80,9 @@ noncomputable def directLimitLeft :
   refine LinearEquiv.ofLinear (toDirectLimit f M) (fromDirectLimit f M) ?_ ?_
     <;> cases isEmpty_or_nonempty ι
   · ext; apply Subsingleton.elim
-  · refine FunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ g.induction_on ?_ ?_ ?_ <;> aesop
+  · refine DFunLike.ext _ _ fun x ↦ x.induction_on fun i g ↦ g.induction_on ?_ ?_ ?_ <;> aesop
   · ext; apply Subsingleton.elim
-  · exact ext (FunLike.ext _ _ fun g ↦ FunLike.ext _ _ fun _ ↦ g.induction_on <| by aesop)
+  · exact ext (DFunLike.ext _ _ fun g ↦ DFunLike.ext _ _ fun _ ↦ g.induction_on <| by aesop)
 
 @[simp] lemma directLimitLeft_tmul_of {i : ι} (g : G i) (m : M) :
     directLimitLeft f M (of _ _ _ _ _ g ⊗ₜ m) = of _ _ _ (f ▷ M) _ (g ⊗ₜ m) :=
@@ -99,7 +99,7 @@ noncomputable def directLimitRight :
     M ⊗[R] DirectLimit G f ≃ₗ[R] DirectLimit (M ⊗[R] G ·) (M ◁ f) :=
   TensorProduct.comm _ _ _ ≪≫ₗ directLimitLeft f M ≪≫ₗ
     Module.DirectLimit.congr (fun i ↦ TensorProduct.comm _ _ _)
-      (fun i j h ↦ TensorProduct.ext <| FunLike.ext _ _ <| by aesop)
+      (fun i j h ↦ TensorProduct.ext <| DFunLike.ext _ _ <| by aesop)
 
 @[simp] lemma directLimitRight_tmul_of {i : ι} (m : M) (g : G i):
     directLimitRight f M (m ⊗ₜ of _ _ _ _ _ g) = of _ _ _ _ i (m ⊗ₜ g) := by

--- a/Mathlib/Algebra/Module/Equiv.lean
+++ b/Mathlib/Algebra/Module/Equiv.lean
@@ -123,7 +123,7 @@ instance (priority := 100) [RingHomInvPair σ σ'] [RingHomInvPair σ' σ]
   [s : SemilinearEquivClass F σ M M₂] : SemilinearMapClass F σ M M₂ :=
   { s with
     coe := (s.coe : F → M → M₂)
-    coe_injective' := @FunLike.coe_injective F _ _ _ }
+    coe_injective' := @DFunLike.coe_injective F _ _ _ }
 
 end SemilinearEquivClass
 
@@ -173,7 +173,7 @@ theorem toLinearMap_inj {e₁ e₂ : M ≃ₛₗ[σ] M₂} : (↑e₁ : M →ₛ
 
 instance : SemilinearEquivClass (M ≃ₛₗ[σ] M₂) σ M M₂ where
   inv := LinearEquiv.invFun
-  coe_injective' _ _ h _ := toLinearMap_injective (FunLike.coe_injective h)
+  coe_injective' _ _ h _ := toLinearMap_injective (DFunLike.coe_injective h)
   left_inv := LinearEquiv.left_inv
   right_inv := LinearEquiv.right_inv
   map_add := (·.map_add') --map_add' Porting note: TODO why did I need to change this?
@@ -186,7 +186,7 @@ theorem coe_mk {to_fun inv_fun map_add map_smul left_inv right_inv} :
 #align linear_equiv.coe_mk LinearEquiv.coe_mk
 
 theorem coe_injective : @Injective (M ≃ₛₗ[σ] M₂) (M → M₂) CoeFun.coe :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align linear_equiv.coe_injective LinearEquiv.coe_injective
 
 end
@@ -232,19 +232,19 @@ variable {e e'}
 
 @[ext]
 theorem ext (h : ∀ x, e x = e' x) : e = e' :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align linear_equiv.ext LinearEquiv.ext
 
 theorem ext_iff : e = e' ↔ ∀ x, e x = e' x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align linear_equiv.ext_iff LinearEquiv.ext_iff
 
 protected theorem congr_arg {x x'} : x = x' → e x = e x' :=
-  FunLike.congr_arg e
+  DFunLike.congr_arg e
 #align linear_equiv.congr_arg LinearEquiv.congr_arg
 
 protected theorem congr_fun (h : e = e') (x : M) : e x = e' x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align linear_equiv.congr_fun LinearEquiv.congr_fun
 
 end
@@ -837,7 +837,7 @@ theorem toNatLinearEquiv_toAddEquiv : ↑e.toNatLinearEquiv = e := by
 @[simp]
 theorem _root_.LinearEquiv.toAddEquiv_toNatLinearEquiv (e : M ≃ₗ[ℕ] M₂) :
     AddEquiv.toNatLinearEquiv ↑e = e :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align linear_equiv.to_add_equiv_to_nat_linear_equiv LinearEquiv.toAddEquiv_toNatLinearEquiv
 
 @[simp]
@@ -884,7 +884,7 @@ theorem toIntLinearEquiv_toAddEquiv : ↑e.toIntLinearEquiv = e := by
 @[simp]
 theorem _root_.LinearEquiv.toAddEquiv_toIntLinearEquiv (e : M ≃ₗ[ℤ] M₂) :
     AddEquiv.toIntLinearEquiv (e : M ≃+ M₂) = e :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align linear_equiv.to_add_equiv_to_int_linear_equiv LinearEquiv.toAddEquiv_toIntLinearEquiv
 
 @[simp]

--- a/Mathlib/Algebra/Module/GradedModule.lean
+++ b/Mathlib/Algebra/Module/GradedModule.lean
@@ -116,7 +116,7 @@ open AddMonoidHom
 private theorem one_smul' [DecidableEq ιA] [DecidableEq ιB] [GMonoid A] [Gmodule A M]
     (x : ⨁ i, M i) :
     (1 : ⨁ i, A i) • x = x := by
-  suffices smulAddMonoidHom A M 1 = AddMonoidHom.id (⨁ i, M i) from FunLike.congr_fun this x
+  suffices smulAddMonoidHom A M 1 = AddMonoidHom.id (⨁ i, M i) from DFunLike.congr_fun this x
   apply DirectSum.addHom_ext; intro i xi
   rw [show (1 : DirectSum ιA fun i => A i) = (of A 0) GOne.one by rfl]
   rw [smulAddMonoidHom_apply_of_of]
@@ -135,7 +135,7 @@ private theorem mul_smul' [DecidableEq ιA] [DecidableEq ιB] [GSemiring A] [Gmo
       (AddMonoidHom.compHom AddMonoidHom.flipHom <|
           (smulAddMonoidHom A M).flip.compHom.comp <| smulAddMonoidHom A M).flip
     from-- `fun a b c ↦ a • (b • c)` as a bundled hom
-      FunLike.congr_fun (FunLike.congr_fun (FunLike.congr_fun this a) b) c
+      DFunLike.congr_fun (DFunLike.congr_fun (DFunLike.congr_fun this a) b) c
   ext ai ax bi bx ci cx : 6
   dsimp only [coe_comp, Function.comp_apply, compHom_apply_apply, flip_apply, flipHom_apply]
   rw [smulAddMonoidHom_apply_of_of, smulAddMonoidHom_apply_of_of, DirectSum.mulHom_of_of,

--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -209,18 +209,18 @@ instance semilinearMapClass : SemilinearMapClass (M →ₛₗ[σ] M₃) σ M M�
     cases f
     cases g
     congr
-    apply FunLike.coe_injective'
+    apply DFunLike.coe_injective'
     exact h
   map_add f := f.map_add'
   map_smulₛₗ := LinearMap.map_smul'
 #align linear_map.semilinear_map_class LinearMap.semilinearMapClass
 
--- Porting note: we don't port specialized `CoeFun` instances if there is `FunLike` instead
+-- Porting note: we don't port specialized `CoeFun` instances if there is `DFunLike` instead
 #noalign LinearMap.has_coe_to_fun
 
 -- Porting note: adding this instance prevents a timeout in `ext_ring_op`
-instance instFunLike {σ : R →+* S} : FunLike (M →ₛₗ[σ] M₃) M (λ _ ↦ M₃) :=
-  { AddHomClass.toFunLike with }
+instance instFunLike {σ : R →+* S} : DFunLike (M →ₛₗ[σ] M₃) M (λ _ ↦ M₃) :=
+  { AddHomClass.toDFunLike with }
 
 /-- The `DistribMulActionHom` underlying a `LinearMap`. -/
 def toDistribMulActionHom (f : M →ₗ[R] M₂) : DistribMulActionHom R M M₂ :=
@@ -236,7 +236,7 @@ theorem toFun_eq_coe {f : M →ₛₗ[σ] M₃} : f.toFun = (f : M → M₃) := 
 
 @[ext]
 theorem ext {f g : M →ₛₗ[σ] M₃} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align linear_map.ext LinearMap.ext
 
 /-- Copy of a `LinearMap` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -253,7 +253,7 @@ theorem coe_copy (f : M →ₛₗ[σ] M₃) (f' : M → M₃) (h : f' = ⇑f) : 
 #align linear_map.coe_copy LinearMap.coe_copy
 
 theorem copy_eq (f : M →ₛₗ[σ] M₃) (f' : M → M₃) (h : f' = ⇑f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align linear_map.copy_eq LinearMap.copy_eq
 
 initialize_simps_projections LinearMap (toFun → apply)
@@ -319,21 +319,21 @@ theorem isLinear : IsLinearMap R fₗ :=
 
 variable {fₗ gₗ f g σ}
 
-theorem coe_injective : Injective (FunLike.coe : (M →ₛₗ[σ] M₃) → _) :=
-  FunLike.coe_injective
+theorem coe_injective : Injective (DFunLike.coe : (M →ₛₗ[σ] M₃) → _) :=
+  DFunLike.coe_injective
 #align linear_map.coe_injective LinearMap.coe_injective
 
 protected theorem congr_arg {x x' : M} : x = x' → f x = f x' :=
-  FunLike.congr_arg f
+  DFunLike.congr_arg f
 #align linear_map.congr_arg LinearMap.congr_arg
 
 /-- If two linear maps are equal, they are equal at each point. -/
 protected theorem congr_fun (h : f = g) (x : M) : f x = g x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align linear_map.congr_fun LinearMap.congr_fun
 
 theorem ext_iff : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align linear_map.ext_iff LinearMap.ext_iff
 
 @[simp]
@@ -519,7 +519,7 @@ end RestrictScalars
 
 theorem toAddMonoidHom_injective :
     Function.Injective (toAddMonoidHom : (M →ₛₗ[σ] M₃) → M →+ M₃) := fun fₗ gₗ h ↦
-  ext <| (FunLike.congr_fun h : ∀ x, fₗ.toAddMonoidHom x = gₗ.toAddMonoidHom x)
+  ext <| (DFunLike.congr_fun h : ∀ x, fₗ.toAddMonoidHom x = gₗ.toAddMonoidHom x)
 #align linear_map.to_add_monoid_hom_injective LinearMap.toAddMonoidHom_injective
 
 /-- If two `σ`-linear maps from `R` are equal on `1`, then they are equal. -/
@@ -955,7 +955,7 @@ theorem comp_add (f g : M →ₛₗ[σ₁₂] M₂) (h : M₂ →ₛₗ[σ₂₃
 
 /-- The type of linear maps is an additive monoid. -/
 instance addCommMonoid : AddCommMonoid (M →ₛₗ[σ₁₂] M₂) :=
-  FunLike.coe_injective.addCommMonoid _ rfl (fun _ _ ↦ rfl) fun _ _ ↦ rfl
+  DFunLike.coe_injective.addCommMonoid _ rfl (fun _ _ ↦ rfl) fun _ _ ↦ rfl
 
 /-- The negation of a linear map is linear. -/
 instance : Neg (M →ₛₗ[σ₁₂] N₂) :=
@@ -1003,7 +1003,7 @@ theorem comp_sub (f g : M →ₛₗ[σ₁₂] N₂) (h : N₂ →ₛₗ[σ₂₃
 
 /-- The type of linear maps is an additive group. -/
 instance addCommGroup : AddCommGroup (M →ₛₗ[σ₁₂] N₂) :=
-  FunLike.coe_injective.addCommGroup _ rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
+  DFunLike.coe_injective.addCommGroup _ rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
     (fun _ _ ↦ rfl) fun _ _ ↦ rfl
 
 end Arithmetic

--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -219,7 +219,7 @@ instance semilinearMapClass : SemilinearMapClass (M →ₛₗ[σ] M₃) σ M M�
 #noalign LinearMap.has_coe_to_fun
 
 -- Porting note: adding this instance prevents a timeout in `ext_ring_op`
-instance instFunLike {σ : R →+* S} : DFunLike (M →ₛₗ[σ] M₃) M (λ _ ↦ M₃) :=
+instance instDFunLike {σ : R →+* S} : DFunLike (M →ₛₗ[σ] M₃) M (λ _ ↦ M₃) :=
   { AddHomClass.toDFunLike with }
 
 /-- The `DistribMulActionHom` underlying a `LinearMap`. -/

--- a/Mathlib/Algebra/Module/LocalizedModule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule.lean
@@ -741,9 +741,9 @@ instance localizedModuleIsLocalizedModule : IsLocalizedModule S (LocalizedModule
     where
   map_units s :=
     ⟨⟨algebraMap R (Module.End R (LocalizedModule S M)) s, LocalizedModule.divBy s,
-        FunLike.ext _ _ <| LocalizedModule.mul_by_divBy s,
-        FunLike.ext _ _ <| LocalizedModule.divBy_mul_by s⟩,
-      FunLike.ext _ _ fun p =>
+        DFunLike.ext _ _ <| LocalizedModule.mul_by_divBy s,
+        DFunLike.ext _ _ <| LocalizedModule.divBy_mul_by s⟩,
+      DFunLike.ext _ _ fun p =>
         p.induction_on <| by
           intros
           rfl⟩

--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -90,7 +90,7 @@ theorem projective_def :
 
 theorem projective_def' :
     Projective R P ↔ ∃ s : P →ₗ[R] P →₀ R, Finsupp.total P P R id ∘ₗ s = .id :=
-  by simp_rw [projective_def, FunLike.ext_iff, Function.LeftInverse, comp_apply, id_apply]
+  by simp_rw [projective_def, DFunLike.ext_iff, Function.LeftInverse, comp_apply, id_apply]
 #align module.projective_def' Module.projective_def'
 
 /-- A projective R-module has the property that maps from it lift along surjections. -/
@@ -140,7 +140,7 @@ instance [h : ∀ i : ι, Projective R (A i)] : Projective R (Π₀ i, A i) :=
   .of_lifting_property'' fun f hf ↦ by
     classical
       choose g hg using fun i ↦ projective_lifting_property f (DFinsupp.lsingle i) hf
-      replace hg : ∀ i x, f (g i x) = DFinsupp.single i x := fun i ↦ FunLike.congr_fun (hg i)
+      replace hg : ∀ i x, f (g i x) = DFinsupp.single i x := fun i ↦ DFunLike.congr_fun (hg i)
       refine ⟨DFinsupp.coprodMap g, ?_⟩
       ext i x j
       simp only [comp_apply, id_apply, DFinsupp.lsingle_apply, DFinsupp.coprodMap_apply_single, hg]

--- a/Mathlib/Algebra/Module/Submodule/LinearMap.lean
+++ b/Mathlib/Algebra/Module/Submodule/LinearMap.lean
@@ -253,7 +253,7 @@ theorem coeFn_sum {ι : Type*} (t : Finset ι) (f : ι → M →ₛₗ[σ₁₂]
     ⇑(∑ i in t, f i) = ∑ i in t, (f i : M → M₂) :=
   _root_.map_sum
     (show AddMonoidHom (M →ₛₗ[σ₁₂] M₂) (M → M₂)
-      from { toFun := FunLike.coe,
+      from { toFun := DFunLike.coe,
              map_zero' := rfl
              map_add' := fun _ _ => rfl }) _ _
 #align linear_map.coe_fn_sum LinearMap.coeFn_sum

--- a/Mathlib/Algebra/MonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Basic.lean
@@ -459,7 +459,7 @@ theorem single_commute_single [Mul G] {a₁ a₂ : G} {b₁ b₂ : k}
 theorem single_commute [Mul G] {a : G} {b : k} (ha : ∀ a', Commute a a') (hb : ∀ b', Commute b b') :
     ∀ f : MonoidAlgebra k G, Commute (single a b) f :=
   suffices AddMonoidHom.mulLeft (single a b) = AddMonoidHom.mulRight (single a b) from
-    FunLike.congr_fun this
+    DFunLike.congr_fun this
   addHom_ext' fun a' => AddMonoidHom.ext fun b' => single_commute_single (ha a') (hb b')
 
 @[simp]
@@ -612,7 +612,7 @@ theorem liftNC_smul [MulOneClass G] {R : Type*} [Semiring R] (f : k →+* R) (g 
   suffices :
     (liftNC (↑f) g).comp (smulAddHom k (MonoidAlgebra k G) c) =
       (AddMonoidHom.mulLeft (f c)).comp (liftNC (↑f) g)
-  exact FunLike.congr_fun this φ
+  exact DFunLike.congr_fun this φ
   -- Porting note: `ext` couldn't a find appropriate theorem.
   refine addHom_ext' fun a => AddMonoidHom.ext fun b => ?_
   -- Porting note: `reducible` cannot be `local` so the proof gets more complex.
@@ -685,7 +685,7 @@ theorem nonUnitalAlgHom_ext [DistribMulAction k A] {φ₁ φ₂ : MonoidAlgebra 
 @[ext high]
 theorem nonUnitalAlgHom_ext' [DistribMulAction k A] {φ₁ φ₂ : MonoidAlgebra k G →ₙₐ[k] A}
     (h : φ₁.toMulHom.comp (ofMagma k G) = φ₂.toMulHom.comp (ofMagma k G)) : φ₁ = φ₂ :=
-  nonUnitalAlgHom_ext k <| FunLike.congr_fun h
+  nonUnitalAlgHom_ext k <| DFunLike.congr_fun h
 #align monoid_algebra.non_unital_alg_hom_ext' MonoidAlgebra.nonUnitalAlgHom_ext'
 
 /-- The functor `G ↦ MonoidAlgebra k G`, from the category of magmas to the category of non-unital,
@@ -792,7 +792,7 @@ theorem ringHom_ext' {R} [Semiring k] [MulOneClass G] [Semiring R] {f g : Monoid
     (h_of :
       (f : MonoidAlgebra k G →* R).comp (of k G) = (g : MonoidAlgebra k G →* R).comp (of k G)) :
     f = g :=
-  ringHom_ext (RingHom.congr_fun h₁) (FunLike.congr_fun h_of)
+  ringHom_ext (RingHom.congr_fun h₁) (DFunLike.congr_fun h_of)
 #align monoid_algebra.ring_hom_ext' MonoidAlgebra.ringHom_ext'
 
 /-- The instance `Algebra k (MonoidAlgebra A G)` whenever we have `Algebra k A`.
@@ -879,7 +879,7 @@ theorem algHom_ext' ⦃φ₁ φ₂ : MonoidAlgebra k G →ₐ[k] A⦄
     (h :
       (φ₁ : MonoidAlgebra k G →* A).comp (of k G) = (φ₂ : MonoidAlgebra k G →* A).comp (of k G)) :
     φ₁ = φ₂ :=
-  algHom_ext <| FunLike.congr_fun h
+  algHom_ext <| DFunLike.congr_fun h
 #align monoid_algebra.alg_hom_ext' MonoidAlgebra.algHom_ext'
 
 variable (k G A)
@@ -1875,7 +1875,7 @@ theorem ringHom_ext' {R} [Semiring k] [AddMonoid G] [Semiring R] {f g : k[G] →
     (h₁ : f.comp singleZeroRingHom = g.comp singleZeroRingHom)
     (h_of : (f : k[G] →* R).comp (of k G) = (g : k[G] →* R).comp (of k G)) :
     f = g :=
-  ringHom_ext (RingHom.congr_fun h₁) (FunLike.congr_fun h_of)
+  ringHom_ext (RingHom.congr_fun h₁) (DFunLike.congr_fun h_of)
 #align add_monoid_algebra.ring_hom_ext' AddMonoidAlgebra.ringHom_ext'
 
 section Opposite
@@ -1987,7 +1987,7 @@ theorem algHom_ext ⦃φ₁ φ₂ : k[G] →ₐ[k] A⦄
 theorem algHom_ext' ⦃φ₁ φ₂ : k[G] →ₐ[k] A⦄
     (h : (φ₁ : k[G] →* A).comp (of k G) = (φ₂ : k[G] →* A).comp (of k G)) :
     φ₁ = φ₂ :=
-  algHom_ext <| FunLike.congr_fun h
+  algHom_ext <| DFunLike.congr_fun h
 #align add_monoid_algebra.alg_hom_ext' AddMonoidAlgebra.algHom_ext'
 
 variable (k G A)

--- a/Mathlib/Algebra/Order/AbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue.lean
@@ -74,7 +74,7 @@ theorem coe_mk (f : R →ₙ* S) {h₁ h₂ h₃} : (AbsoluteValue.mk f h₁ h�
 
 @[ext]
 theorem ext ⦃f g : AbsoluteValue R S⦄ : (∀ x, f x = g x) → f = g :=
-  FunLike.ext _ _
+  DFunLike.ext _ _
 #align absolute_value.ext AbsoluteValue.ext
 
 /-- See Note [custom simps projection]. -/
@@ -84,10 +84,10 @@ def Simps.apply (f : AbsoluteValue R S) : R → S :=
 
 initialize_simps_projections AbsoluteValue (toMulHom_toFun → apply)
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.has_coe_to_fun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.has_coe_to_fun`
 directly. -/
 instance : CoeFun (AbsoluteValue R S) fun _ => R → S :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 @[simp]
 theorem coe_toMulHom : ⇑abv.toMulHom = abv :=

--- a/Mathlib/Algebra/Order/Hom/Basic.lean
+++ b/Mathlib/Algebra/Order/Hom/Basic.lean
@@ -77,14 +77,14 @@ variable {ι F α β γ δ : Type*}
 
 /-- `NonnegHomClass F α β` states that `F` is a type of nonnegative morphisms. -/
 class NonnegHomClass (F : Type*) (α β : outParam (Type*)) [Zero β] [LE β] extends
-  FunLike F α fun _ => β where
+  DFunLike F α fun _ => β where
   /-- the image of any element is non negative. -/
   map_nonneg (f : F) : ∀ a, 0 ≤ f a
 #align nonneg_hom_class NonnegHomClass
 
 /-- `SubadditiveHomClass F α β` states that `F` is a type of subadditive morphisms. -/
 class SubadditiveHomClass (F : Type*) (α β : outParam (Type*)) [Add α] [Add β] [LE β] extends
-  FunLike F α fun _ => β where
+  DFunLike F α fun _ => β where
   /-- the image of a sum is less or equal than the sum of the images. -/
   map_add_le_add (f : F) : ∀ a b, f (a + b) ≤ f a + f b
 #align subadditive_hom_class SubadditiveHomClass
@@ -92,7 +92,7 @@ class SubadditiveHomClass (F : Type*) (α β : outParam (Type*)) [Add α] [Add �
 /-- `SubmultiplicativeHomClass F α β` states that `F` is a type of submultiplicative morphisms. -/
 @[to_additive SubadditiveHomClass]
 class SubmultiplicativeHomClass (F : Type*) (α β : outParam (Type*)) [Mul α] [Mul β] [LE β]
-  extends FunLike F α fun _ => β where
+  extends DFunLike F α fun _ => β where
   /-- the image of a product is less or equal than the product of the images. -/
   map_mul_le_mul (f : F) : ∀ a b, f (a * b) ≤ f a * f b
 #align submultiplicative_hom_class SubmultiplicativeHomClass
@@ -100,14 +100,14 @@ class SubmultiplicativeHomClass (F : Type*) (α β : outParam (Type*)) [Mul α] 
 /-- `MulLEAddHomClass F α β` states that `F` is a type of subadditive morphisms. -/
 @[to_additive SubadditiveHomClass]
 class MulLEAddHomClass (F : Type*) (α β : outParam (Type*)) [Mul α] [Add β] [LE β]
-  extends FunLike F α fun _ => β where
+  extends DFunLike F α fun _ => β where
   /-- the image of a product is less or equal than the sum of the images. -/
   map_mul_le_add (f : F) : ∀ a b, f (a * b) ≤ f a + f b
 #align mul_le_add_hom_class MulLEAddHomClass
 
 /-- `NonarchimedeanHomClass F α β` states that `F` is a type of non-archimedean morphisms. -/
 class NonarchimedeanHomClass (F : Type*) (α β : outParam (Type*)) [Add α] [LinearOrder β]
-  extends FunLike F α fun _ => β where
+  extends DFunLike F α fun _ => β where
   /-- the image of a sum is less or equal than the maximum of the images. -/
   map_add_le_max (f : F) : ∀ a b, f (a + b) ≤ max (f a) (f b)
 #align nonarchimedean_hom_class NonarchimedeanHomClass
@@ -157,7 +157,7 @@ namespace Mathlib.Meta.Positivity
 open Lean Meta Qq Function
 
 /-- Extension for the `positivity` tactic: nonnegative maps take nonnegative values. -/
-@[positivity FunLike.coe _ _]
+@[positivity DFunLike.coe _ _]
 def evalMap : PositivityExt where eval {_ β} _ _ e := do
   let .app (.app _ f) a ← whnfR e
     | throwError "not ↑f · where f is of NonnegHomClass"

--- a/Mathlib/Algebra/Order/Hom/Monoid.lean
+++ b/Mathlib/Algebra/Order/Hom/Monoid.lean
@@ -295,17 +295,17 @@ variable [Preorder α] [Preorder β] [Preorder γ] [Preorder δ] [MulOneClass α
 
 -- Porting note:
 -- These helper instances are unhelpful in Lean 4, so omitting:
--- /-- Helper instance for when there's too many metavariables to apply `FunLike.instCoeFunForAll`
+-- /-- Helper instance for when there's too many metavariables to apply `DFunLike.instCoeFunForAll`
 -- directly. -/
 -- @[to_additive "Helper instance for when there's too many metavariables to apply
--- `FunLike.instCoeFunForAll` directly."]
+-- `DFunLike.instCoeFunForAll` directly."]
 -- instance : CoeFun (α →*o β) fun _ => α → β :=
---   FunLike.instCoeFunForAll
+--   DFunLike.instCoeFunForAll
 
--- Other lemmas should be accessed through the `FunLike` API
+-- Other lemmas should be accessed through the `DFunLike` API
 @[to_additive (attr := ext)]
 theorem ext (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align order_monoid_hom.ext OrderMonoidHom.ext
 #align order_add_monoid_hom.ext OrderAddMonoidHom.ext
 
@@ -349,13 +349,13 @@ theorem coe_orderHom (f : α →*o β) : ((f : α →o β) : α → β) = f :=
 
 @[to_additive]
 theorem toMonoidHom_injective : Injective (toMonoidHom : _ → α →* β) := fun f g h =>
-  ext <| by convert FunLike.ext_iff.1 h using 0
+  ext <| by convert DFunLike.ext_iff.1 h using 0
 #align order_monoid_hom.to_monoid_hom_injective OrderMonoidHom.toMonoidHom_injective
 #align order_add_monoid_hom.to_add_monoid_hom_injective OrderAddMonoidHom.toAddMonoidHom_injective
 
 @[to_additive]
 theorem toOrderHom_injective : Injective (toOrderHom : _ → α →o β) := fun f g h =>
-  ext <| by convert FunLike.ext_iff.1 h using 0
+  ext <| by convert DFunLike.ext_iff.1 h using 0
 #align order_monoid_hom.to_order_hom_injective OrderMonoidHom.toOrderHom_injective
 #align order_add_monoid_hom.to_order_hom_injective OrderAddMonoidHom.toOrderHom_injective
 
@@ -376,7 +376,7 @@ theorem coe_copy (f : α →*o β) (f' : α → β) (h : f' = f) : ⇑(f.copy f'
 
 @[to_additive]
 theorem copy_eq (f : α →*o β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align order_monoid_hom.copy_eq OrderMonoidHom.copy_eq
 #align order_add_monoid_hom.copy_eq OrderAddMonoidHom.copy_eq
 
@@ -456,7 +456,7 @@ theorem id_comp (f : α →*o β) : (OrderMonoidHom.id β).comp f = f :=
 @[to_additive (attr := simp)]
 theorem cancel_right {g₁ g₂ : β →*o γ} {f : α →*o β} (hf : Function.Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, fun _ => by congr⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun _ => by congr⟩
 #align order_monoid_hom.cancel_right OrderMonoidHom.cancel_right
 #align order_add_monoid_hom.cancel_right OrderAddMonoidHom.cancel_right
 
@@ -590,15 +590,15 @@ instance : OrderMonoidWithZeroHomClass (α →*₀o β) α β where
 
 -- Porting note:
 -- These helper instances are unhelpful in Lean 4, so omitting:
---/-- Helper instance for when there's too many metavariables to apply `FunLike.instCoeFunForAll`
+--/-- Helper instance for when there's too many metavariables to apply `DFunLike.instCoeFunForAll`
 --directly. -/
 --instance : CoeFun (α →*₀o β) fun _ => α → β :=
---  FunLike.instCoeFunForAll
+--  DFunLike.instCoeFunForAll
 
--- Other lemmas should be accessed through the `FunLike` API
+-- Other lemmas should be accessed through the `DFunLike` API
 @[ext]
 theorem ext (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align order_monoid_with_zero_hom.ext OrderMonoidWithZeroHom.ext
 
 theorem toFun_eq_coe (f : α →*₀o β) : f.toFun = (f : α → β) :=
@@ -630,11 +630,11 @@ theorem coe_orderMonoidHom (f : α →*₀o β) : ⇑(f : α →*o β) = f :=
 #align order_monoid_with_zero_hom.coe_order_monoid_hom OrderMonoidWithZeroHom.coe_orderMonoidHom
 
 theorem toOrderMonoidHom_injective : Injective (toOrderMonoidHom : _ → α →*o β) := fun f g h =>
-  ext <| by convert FunLike.ext_iff.1 h using 0
+  ext <| by convert DFunLike.ext_iff.1 h using 0
 #align order_monoid_with_zero_hom.to_order_monoid_hom_injective OrderMonoidWithZeroHom.toOrderMonoidHom_injective
 
 theorem toMonoidWithZeroHom_injective : Injective (toMonoidWithZeroHom : _ → α →*₀ β) :=
-  fun f g h => ext <| by convert FunLike.ext_iff.1 h using 0
+  fun f g h => ext <| by convert DFunLike.ext_iff.1 h using 0
 #align order_monoid_with_zero_hom.to_monoid_with_zero_hom_injective OrderMonoidWithZeroHom.toMonoidWithZeroHom_injective
 
 /-- Copy of an `OrderMonoidWithZeroHom` with a new `toFun` equal to the old one. Useful to fix
@@ -649,7 +649,7 @@ theorem coe_copy (f : α →*₀o β) (f' : α → β) (h : f' = f) : ⇑(f.copy
 #align order_monoid_with_zero_hom.coe_copy OrderMonoidWithZeroHom.coe_copy
 
 theorem copy_eq (f : α →*₀o β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align order_monoid_with_zero_hom.copy_eq OrderMonoidWithZeroHom.copy_eq
 
 variable (α)
@@ -711,7 +711,7 @@ theorem id_comp (f : α →*₀o β) : (OrderMonoidWithZeroHom.id β).comp f = f
 @[simp]
 theorem cancel_right {g₁ g₂ : β →*₀o γ} {f : α →*₀o β} (hf : Function.Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, fun _ => by congr⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun _ => by congr⟩
 #align order_monoid_with_zero_hom.cancel_right OrderMonoidWithZeroHom.cancel_right
 
 @[simp]

--- a/Mathlib/Algebra/Order/Hom/Ring.lean
+++ b/Mathlib/Algebra/Order/Hom/Ring.lean
@@ -184,7 +184,7 @@ instance : OrderRingHomClass (α →+*o β) α β
   monotone f := f.monotone'
 
 -- porting note: These helper instances are unhelpful in Lean 4, so omitting:
--- /-- Helper instance for when there's too many metavariables to apply `FunLike.has_coe_to_fun`
+-- /-- Helper instance for when there's too many metavariables to apply `DFunLike.has_coe_to_fun`
 -- directly. -/
 -- instance : CoeFun (α →+*o β) fun _ => α → β :=
 --   ⟨fun f => f.toFun⟩
@@ -195,7 +195,7 @@ theorem toFun_eq_coe (f : α →+*o β) : f.toFun = f :=
 
 @[ext]
 theorem ext {f g : α →+*o β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align order_ring_hom.ext OrderRingHom.ext
 
 @[simp]
@@ -255,7 +255,7 @@ theorem coe_copy (f : α →+*o β) (f' : α → β) (h : f' = f) : ⇑(f.copy f
 #align order_ring_hom.coe_copy OrderRingHom.coe_copy
 
 theorem copy_eq (f : α →+*o β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align order_ring_hom.copy_eq OrderRingHom.copy_eq
 
 variable (α)
@@ -329,7 +329,7 @@ theorem id_comp (f : α →+*o β) : (OrderRingHom.id β).comp f = f :=
 @[simp]
 theorem cancel_right {f₁ f₂ : β →+*o γ} {g : α →+*o β} (hg : Surjective g) :
     f₁.comp g = f₂.comp g ↔ f₁ = f₂ :=
-  ⟨fun h => ext <| hg.forall.2 <| FunLike.ext_iff.1 h, fun h => by rw [h]⟩
+  ⟨fun h => ext <| hg.forall.2 <| DFunLike.ext_iff.1 h, fun h => by rw [h]⟩
 #align order_ring_hom.cancel_right OrderRingHom.cancel_right
 
 @[simp]
@@ -346,7 +346,7 @@ instance [Preorder β] : Preorder (OrderRingHom α β) :=
   Preorder.lift ((⇑) : _ → α → β)
 
 instance [PartialOrder β] : PartialOrder (OrderRingHom α β) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 end OrderRingHom
 
@@ -381,10 +381,10 @@ instance : OrderRingIsoClass (α ≃+*o β) α β
   right_inv f := f.right_inv
 
 -- porting note: These helper instances are unhelpful in Lean 4, so omitting:
-/-- Helper instance for when there's too many metavariables to apply `FunLike.has_coe_to_fun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.has_coe_to_fun`
 directly. -/
 -- instance : CoeFun (α ≃+*o β) fun _ => α → β :=
---   FunLike.has_coe_to_fun
+--   DFunLike.has_coe_to_fun
 
 theorem toFun_eq_coe (f : α ≃+*o β) : f.toFun = f :=
   rfl
@@ -392,7 +392,7 @@ theorem toFun_eq_coe (f : α ≃+*o β) : f.toFun = f :=
 
 @[ext]
 theorem ext {f g : α ≃+*o β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align order_ring_iso.ext OrderRingIso.ext
 
 @[simp]
@@ -420,9 +420,9 @@ theorem coe_toRingEquiv (f : α ≃+*o β) : ⇑(f : α ≃+* β) = f :=
   rfl
 #align order_ring_iso.coe_to_ring_equiv OrderRingIso.coe_toRingEquiv
 
--- Porting note: needed to add FunLike.coe on the lhs, bad Equiv coercion otherwise
+-- Porting note: needed to add DFunLike.coe on the lhs, bad Equiv coercion otherwise
 @[simp, norm_cast]
-theorem coe_toOrderIso (f : α ≃+*o β) : FunLike.coe (f : α ≃o β) = f :=
+theorem coe_toOrderIso (f : α ≃+*o β) : DFunLike.coe (f : α ≃o β) = f :=
   rfl
 #align order_ring_iso.coe_to_order_iso OrderRingIso.coe_toOrderIso
 
@@ -537,7 +537,7 @@ theorem coe_toOrderRingHom_refl : (OrderRingIso.refl α : α →+*o α) = OrderR
 #align order_ring_iso.coe_to_order_ring_hom_refl OrderRingIso.coe_toOrderRingHom_refl
 
 theorem toOrderRingHom_injective : Injective (toOrderRingHom : α ≃+*o β → α →+*o β) :=
-  fun f g h => FunLike.coe_injective <| by convert FunLike.ext'_iff.1 h using 0
+  fun f g h => DFunLike.coe_injective <| by convert DFunLike.ext'_iff.1 h using 0
 #align order_ring_iso.to_order_ring_hom_injective OrderRingIso.toOrderRingHom_injective
 
 end NonAssocSemiring

--- a/Mathlib/Algebra/Polynomial/GroupRingAction.lean
+++ b/Mathlib/Algebra/Polynomial/GroupRingAction.lean
@@ -34,7 +34,7 @@ theorem smul_eq_map [MulSemiringAction M R] (m : M) :
   suffices DistribMulAction.toAddMonoidHom R[X] m =
       (mapRingHom (MulSemiringAction.toRingHom M R m)).toAddMonoidHom by
     ext1 r
-    exact FunLike.congr_fun this r
+    exact DFunLike.congr_fun this r
   ext n r : 2
   change m • monomial n r = map (MulSemiringAction.toRingHom M R m) (monomial n r)
   rw [Polynomial.map_monomial, Polynomial.smul_monomial, MulSemiringAction.toRingHom_apply]

--- a/Mathlib/Algebra/Quandle.lean
+++ b/Mathlib/Algebra/Quandle.lean
@@ -358,7 +358,7 @@ namespace ShelfHom
 
 variable {S₁ : Type*} {S₂ : Type*} {S₃ : Type*} [Shelf S₁] [Shelf S₂] [Shelf S₃]
 
-instance : FunLike (S₁ →◃ S₂) S₁ fun _ => S₂ where
+instance : DFunLike (S₁ →◃ S₂) S₁ fun _ => S₂ where
   coe := toFun
   coe_injective' | ⟨_, _⟩, ⟨_, _⟩, rfl => rfl
 

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -23,7 +23,7 @@ $$
 In mathlib we call elements of the centroid "centroid homomorphisms" (`CentroidHom`) in keeping
 with `AddMonoidHom` etc.
 
-We use the `FunLike` design, so each type of morphisms has a companion typeclass which is meant to
+We use the `DFunLike` design, so each type of morphisms has a companion typeclass which is meant to
 be satisfied by itself and all stricter types.
 
 ## Types of morphisms
@@ -101,9 +101,9 @@ instance : CentroidHomClass (CentroidHom α) α where
   map_mul_right f := f.map_mul_right'
 
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.CoeFun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.CoeFun`
 directly. -/
-/- Porting note: Lean gave me `unknown constant 'FunLike.CoeFun'` and says `CoeFun` is a type
+/- Porting note: Lean gave me `unknown constant 'DFunLike.CoeFun'` and says `CoeFun` is a type
 mismatch, so I used `library_search`. -/
 instance : CoeFun (CentroidHom α) fun _ ↦ α → α :=
   inferInstanceAs (CoeFun (CentroidHom α) fun _ ↦ α → α)
@@ -115,7 +115,7 @@ theorem toFun_eq_coe {f : CentroidHom α} : f.toFun = f := rfl
 
 @[ext]
 theorem ext {f g : CentroidHom α} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align centroid_hom.ext CentroidHom.ext
 
 @[simp, norm_cast]
@@ -130,7 +130,7 @@ theorem toAddMonoidHom_eq_coe (f : CentroidHom α) : f.toAddMonoidHom = f :=
 
 theorem coe_toAddMonoidHom_injective : Injective ((↑) : CentroidHom α → α →+ α) :=
   fun _f _g h => ext fun a ↦
-    haveI := FunLike.congr_fun h a
+    haveI := DFunLike.congr_fun h a
     this
 #align centroid_hom.coe_to_add_monoid_hom_injective CentroidHom.coe_toAddMonoidHom_injective
 
@@ -158,7 +158,7 @@ theorem coe_copy (f : CentroidHom α) (f' : α → α) (h : f' = f) : ⇑(f.copy
 #align centroid_hom.coe_copy CentroidHom.coe_copy
 
 theorem copy_eq (f : CentroidHom α) (f' : α → α) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align centroid_hom.copy_eq CentroidHom.copy_eq
 
 variable (α)
@@ -231,7 +231,7 @@ theorem id_comp (f : CentroidHom α) : (CentroidHom.id α).comp f = f :=
 @[simp]
 theorem cancel_right {g₁ g₂ f : CentroidHom α} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h ↦ ext <| hf.forall.2 <| FunLike.ext_iff.1 h, fun a ↦ congrFun (congrArg comp a) f⟩
+  ⟨fun h ↦ ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun a ↦ congrFun (congrArg comp a) f⟩
 #align centroid_hom.cancel_right CentroidHom.cancel_right
 
 @[simp]

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -102,7 +102,7 @@ instance (priority := 100) toRingHomClass [NonAssocSemiring R] [NonAssocSemiring
     [h : RingEquivClass F R S] : RingHomClass F R S :=
   { h with
     coe := h.coe
-    coe_injective' := FunLike.coe_injective
+    coe_injective' := DFunLike.coe_injective
     map_zero := map_zero
     map_one := map_one }
 #align ring_equiv_class.to_ring_hom_class RingEquivClass.toRingHomClass
@@ -112,7 +112,7 @@ instance (priority := 100) toNonUnitalRingHomClass [NonUnitalNonAssocSemiring R]
     [NonUnitalNonAssocSemiring S] [h : RingEquivClass F R S] : NonUnitalRingHomClass F R S :=
   { h with
     coe := h.coe
-    coe_injective' := FunLike.coe_injective
+    coe_injective' := DFunLike.coe_injective
     map_zero := map_zero }
 #align ring_equiv_class.to_non_unital_ring_hom_class RingEquivClass.toNonUnitalRingHomClass
 
@@ -176,7 +176,7 @@ protected theorem map_add (e : R ≃+* S) (x y : R) : e (x + y) = e x + e y :=
     same underlying function. -/
 @[ext]
 theorem ext {f g : R ≃+* S} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align ring_equiv.ext RingEquiv.ext
 
 @[simp]
@@ -193,15 +193,15 @@ theorem mk_coe (e : R ≃+* S) (e' h₁ h₂ h₃ h₄) : (⟨⟨e, e', h₁, h�
 #align ring_equiv.mk_coe RingEquiv.mk_coe
 
 protected theorem congr_arg {f : R ≃+* S} {x x' : R} : x = x' → f x = f x' :=
-  FunLike.congr_arg f
+  DFunLike.congr_arg f
 #align ring_equiv.congr_arg RingEquiv.congr_arg
 
 protected theorem congr_fun {f g : R ≃+* S} (h : f = g) (x : R) : f x = g x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align ring_equiv.congr_fun RingEquiv.congr_fun
 
 protected theorem ext_iff {f g : R ≃+* S} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align ring_equiv.ext_iff RingEquiv.ext_iff
 
 @[simp]
@@ -798,8 +798,8 @@ def ofHomInv' {R S F G : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssoc
     R ≃+* S where
   toFun := hom
   invFun := inv
-  left_inv := FunLike.congr_fun hom_inv_id
-  right_inv := FunLike.congr_fun inv_hom_id
+  left_inv := DFunLike.congr_fun hom_inv_id
+  right_inv := DFunLike.congr_fun inv_hom_id
   map_mul' := map_mul hom
   map_add' := map_add hom
 #align ring_equiv.of_hom_inv' RingEquiv.ofHomInv'
@@ -817,8 +817,8 @@ def ofHomInv {R S F G : Type*} [NonAssocSemiring R] [NonAssocSemiring S] [RingHo
     R ≃+* S where
   toFun := hom
   invFun := inv
-  left_inv := FunLike.congr_fun hom_inv_id
-  right_inv := FunLike.congr_fun inv_hom_id
+  left_inv := DFunLike.congr_fun hom_inv_id
+  right_inv := DFunLike.congr_fun inv_hom_id
   map_mul' := map_mul hom
   map_add' := map_add hom
 #align ring_equiv.of_hom_inv RingEquiv.ofHomInv

--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -115,7 +115,7 @@ instance : NonUnitalRingHomClass (α →ₙ+* β) α β where
 
 -- Porting note:
 -- These helper instances are unhelpful in Lean 4, so omitting:
--- /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+-- /-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 -- directly. -/
 -- instance : CoeFun (α →ₙ+* β) fun _ => α → β :=
 --   ⟨fun f => f.toFun⟩
@@ -428,7 +428,7 @@ instance instRingHomClass : RingHomClass (α →+* β) α β where
 
 -- Porting note:
 -- These helper instances are unhelpful in Lean 4, so omitting:
--- /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+-- /-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 -- directly.
 -- -/
 -- instance : CoeFun (α →+* β) fun _ => α → β :=

--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -107,7 +107,7 @@ instance : NonUnitalRingHomClass (α →ₙ+* β) α β where
     cases f
     cases g
     congr
-    apply FunLike.coe_injective'
+    apply DFunLike.coe_injective'
     exact h
   map_add := NonUnitalRingHom.map_add'
   map_zero := NonUnitalRingHom.map_zero'
@@ -159,7 +159,7 @@ theorem coe_copy (f : α →ₙ+* β) (f' : α → β) (h : f' = f) : ⇑(f.copy
 #align non_unital_ring_hom.coe_copy NonUnitalRingHom.coe_copy
 
 theorem copy_eq (f : α →ₙ+* β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align non_unital_ring_hom.copy_eq NonUnitalRingHom.copy_eq
 
 end coe
@@ -171,11 +171,11 @@ variable (f : α →ₙ+* β) {x y : α}
 
 @[ext]
 theorem ext ⦃f g : α →ₙ+* β⦄ : (∀ x, f x = g x) → f = g :=
-  FunLike.ext _ _
+  DFunLike.ext _ _
 #align non_unital_ring_hom.ext NonUnitalRingHom.ext
 
 theorem ext_iff {f g : α →ₙ+* β} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align non_unital_ring_hom.ext_iff NonUnitalRingHom.ext_iff
 
 @[simp]
@@ -184,7 +184,7 @@ theorem mk_coe (f : α →ₙ+* β) (h₁ h₂ h₃) : NonUnitalRingHom.mk (MulH
 #align non_unital_ring_hom.mk_coe NonUnitalRingHom.mk_coe
 
 theorem coe_addMonoidHom_injective : Injective fun f : α →ₙ+* β => (f : α →+ β) :=
-  fun _ _ h => ext <| FunLike.congr_fun (F := α →+ β) h
+  fun _ _ h => ext <| DFunLike.congr_fun (F := α →+ β) h
 #align non_unital_ring_hom.coe_add_monoid_hom_injective NonUnitalRingHom.coe_addMonoidHom_injective
 
 set_option linter.deprecated false in
@@ -419,7 +419,7 @@ instance instRingHomClass : RingHomClass (α →+* β) α β where
     cases f
     cases g
     congr
-    apply FunLike.coe_injective'
+    apply DFunLike.coe_injective'
     exact h
   map_add := RingHom.map_add'
   map_zero := RingHom.map_zero'
@@ -506,7 +506,7 @@ theorem coe_copy (f : α →+* β) (f' : α → β) (h : f' = f) : ⇑(f.copy f'
 #align ring_hom.coe_copy RingHom.coe_copy
 
 theorem copy_eq (f : α →+* β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align ring_hom.copy_eq RingHom.copy_eq
 
 end coe
@@ -516,24 +516,24 @@ section
 variable {_ : NonAssocSemiring α} {_ : NonAssocSemiring β} (f : α →+* β) {x y : α}
 
 theorem congr_fun {f g : α →+* β} (h : f = g) (x : α) : f x = g x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align ring_hom.congr_fun RingHom.congr_fun
 
 theorem congr_arg (f : α →+* β) {x y : α} (h : x = y) : f x = f y :=
-  FunLike.congr_arg f h
+  DFunLike.congr_arg f h
 #align ring_hom.congr_arg RingHom.congr_arg
 
 theorem coe_inj ⦃f g : α →+* β⦄ (h : (f : α → β) = g) : f = g :=
-  FunLike.coe_injective h
+  DFunLike.coe_injective h
 #align ring_hom.coe_inj RingHom.coe_inj
 
 @[ext]
 theorem ext ⦃f g : α →+* β⦄ : (∀ x, f x = g x) → f = g :=
-  FunLike.ext _ _
+  DFunLike.ext _ _
 #align ring_hom.ext RingHom.ext
 
 theorem ext_iff {f g : α →+* β} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align ring_hom.ext_iff RingHom.ext_iff
 
 @[simp]
@@ -542,7 +542,7 @@ theorem mk_coe (f : α →+* β) (h₁ h₂ h₃ h₄) : RingHom.mk ⟨⟨f, h�
 #align ring_hom.mk_coe RingHom.mk_coe
 
 theorem coe_addMonoidHom_injective : Injective (fun f : α →+* β => (f : α →+ β)) := fun _ _ h =>
-  ext <| FunLike.congr_fun (F := α →+ β) h
+  ext <| DFunLike.congr_fun (F := α →+ β) h
 #align ring_hom.coe_add_monoid_hom_injective RingHom.coe_addMonoidHom_injective
 
 set_option linter.deprecated false in

--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -516,7 +516,7 @@ section
 
 /-- `StarHomClass F R S` states that `F` is a type of `star`-preserving maps from `R` to `S`. -/
 class StarHomClass (F : Type*) (R S : outParam (Type*)) [Star R] [Star S] extends
-  FunLike F R fun _ => S where
+  DFunLike F R fun _ => S where
   /-- the maps preserve star -/
   map_star : ∀ (f : F) (r : R), f (star r) = star (f r)
 #align star_hom_class StarHomClass

--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -121,10 +121,10 @@ instance : NonUnitalStarAlgHomClass (A →⋆ₙₐ[R] B) R A B
   map_star f := f.map_star'
 
 -- Porting note: this is no longer useful
---/-- Helper instance for when there's too many metavariables to apply `FunLike.CoeFun`
+--/-- Helper instance for when there's too many metavariables to apply `DFunLike.CoeFun`
 --directly. -/
 --instance : CoeFun (A →⋆ₙₐ[R] B) fun _ => A → B :=
---  FunLike.hasCoeToFun
+--  DFunLike.hasCoeToFun
 
 -- Porting note: in mathlib3 we didn't need the `Simps.apply` hint.
 /-- See Note [custom simps projection] -/
@@ -145,7 +145,7 @@ theorem coe_toNonUnitalAlgHom {f : A →⋆ₙₐ[R] B} : (f.toNonUnitalAlgHom :
 
 @[ext]
 theorem ext {f g : A →⋆ₙₐ[R] B} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align non_unital_star_alg_hom.ext NonUnitalStarAlgHom.ext
 
 /-- Copy of a `NonUnitalStarAlgHom` with a new `toFun` equal to the old one. Useful
@@ -166,7 +166,7 @@ theorem coe_copy (f : A →⋆ₙₐ[R] B) (f' : A → B) (h : f' = f) : ⇑(f.c
 #align non_unital_star_alg_hom.coe_copy NonUnitalStarAlgHom.coe_copy
 
 theorem copy_eq (f : A →⋆ₙₐ[R] B) (f' : A → B) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align non_unital_star_alg_hom.copy_eq NonUnitalStarAlgHom.copy_eq
 
 -- porting note: doesn't align with Mathlib 3 because `NonUnitalStarAlgHom.mk` has a new signature
@@ -390,7 +390,7 @@ theorem coe_toAlgHom {f : A →⋆ₐ[R] B} : (f.toAlgHom : A → B) = f :=
 
 @[ext]
 theorem ext {f g : A →⋆ₐ[R] B} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align star_alg_hom.ext StarAlgHom.ext
 
 /-- Copy of a `StarAlgHom` with a new `toFun` equal to the old one. Useful
@@ -412,7 +412,7 @@ theorem coe_copy (f : A →⋆ₐ[R] B) (f' : A → B) (h : f' = f) : ⇑(f.copy
 #align star_alg_hom.coe_copy StarAlgHom.coe_copy
 
 theorem copy_eq (f : A →⋆ₐ[R] B) (f' : A → B) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align star_alg_hom.copy_eq StarAlgHom.copy_eq
 
 -- porting note: doesn't align with Mathlib 3 because `StarAlgHom.mk` has a new signature
@@ -568,7 +568,7 @@ theorem snd_prod (f : A →⋆ₙₐ[R] B) (g : A →⋆ₙₐ[R] C) : (snd R B 
 
 @[simp]
 theorem prod_fst_snd : prod (fst R A B) (snd R A B) = 1 :=
-  FunLike.coe_injective Pi.prod_fst_snd
+  DFunLike.coe_injective Pi.prod_fst_snd
 #align non_unital_star_alg_hom.prod_fst_snd NonUnitalStarAlgHom.prod_fst_snd
 
 /-- Taking the product of two maps with the same domain is equivalent to taking the product of
@@ -665,7 +665,7 @@ theorem snd_prod (f : A →⋆ₐ[R] B) (g : A →⋆ₐ[R] C) : (snd R B C).com
 
 @[simp]
 theorem prod_fst_snd : prod (fst R A B) (snd R A B) = 1 :=
-  FunLike.coe_injective Pi.prod_fst_snd
+  DFunLike.coe_injective Pi.prod_fst_snd
 #align star_alg_hom.prod_fst_snd StarAlgHom.prod_fst_snd
 
 /-- Taking the product of two maps with the same domain is equivalent to taking the product of
@@ -731,7 +731,7 @@ instance (priority := 50) {F R A B : Type*} [Add A] [Mul A] [SMul R A] [Star A]
     StarHomClass F A B :=
   { hF with
     coe := fun f => f
-    coe_injective' := FunLike.coe_injective }
+    coe_injective' := DFunLike.coe_injective }
 
 -- Porting note: no longer needed
 ---- `R` becomes a metavariable but that's fine because it's an `outParam`
@@ -743,7 +743,7 @@ instance (priority := 50) {F R A B : Type*} [Add A] [Mul A] [Star A] [SMul R A]
     SMulHomClass F R A B :=
   { hF with
     coe := fun f => f
-    coe_injective' := FunLike.coe_injective }
+    coe_injective' := DFunLike.coe_injective }
 
 -- Porting note: no longer needed
 ---- `R` becomes a metavariable but that's fine because it's an `outParam`
@@ -756,7 +756,7 @@ instance (priority := 100) {F R A B : Type*} [Monoid R] [NonUnitalNonAssocSemiri
     NonUnitalStarAlgHomClass F R A B :=
   { hF with
     coe := fun f => f
-    coe_injective' := FunLike.coe_injective
+    coe_injective' := DFunLike.coe_injective
     map_zero := map_zero }
 
 -- See note [lower instance priority]
@@ -765,7 +765,7 @@ instance (priority := 100) instStarAlgHomClass (F R A B : Type*) [CommSemiring R
     [hF : StarAlgEquivClass F R A B] : StarAlgHomClass F R A B :=
   { hF with
     coe := fun f => f
-    coe_injective' := FunLike.coe_injective
+    coe_injective' := DFunLike.coe_injective
     map_one := map_one
     map_zero := map_zero
     commutes := fun f r => by simp only [Algebra.algebraMap_eq_smul_one, map_smul, map_one] }
@@ -809,17 +809,17 @@ theorem toRingEquiv_eq_coe (e : A ≃⋆ₐ[R] B) : e.toRingEquiv = e :=
 
 -- Porting note: this is no longer useful
 --/-- Helper instance for when there's too many metavariables to apply
---`FunLike.CoeFun` directly. -/
+--`DFunLike.CoeFun` directly. -/
 --instance : CoeFun (A ≃⋆ₐ[R] B) fun _ => A → B :=
 --  ⟨StarAlgEquiv.toFun⟩
 
 @[ext]
 theorem ext {f g : A ≃⋆ₐ[R] B} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align star_alg_equiv.ext StarAlgEquiv.ext
 
 theorem ext_iff {f g : A ≃⋆ₐ[R] B} : f = g ↔ ∀ a, f a = g a :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align star_alg_equiv.ext_iff StarAlgEquiv.ext_iff
 
 /-- Star algebra equivalences are reflexive. -/

--- a/Mathlib/Algebra/Star/Subalgebra.lean
+++ b/Mathlib/Algebra/Star/Subalgebra.lean
@@ -750,7 +750,7 @@ theorem adjoin_le_equalizer {s : Set A} (h : s.EqOn f g) : adjoin R s ≤ StarAl
 #align star_alg_hom.adjoin_le_equalizer StarAlgHom.adjoin_le_equalizer
 
 theorem ext_of_adjoin_eq_top {s : Set A} (h : adjoin R s = ⊤) ⦃f g : F⦄ (hs : s.EqOn f g) : f = g :=
-  FunLike.ext f g fun _x => StarAlgHom.adjoin_le_equalizer f g hs <| h.symm ▸ trivial
+  DFunLike.ext f g fun _x => StarAlgHom.adjoin_le_equalizer f g hs <| h.symm ▸ trivial
 #align star_alg_hom.ext_of_adjoin_eq_top StarAlgHom.ext_of_adjoin_eq_top
 
 theorem map_adjoin [StarModule R B] (f : A →⋆ₐ[R] B) (s : Set A) :
@@ -761,7 +761,7 @@ theorem map_adjoin [StarModule R B] (f : A →⋆ₐ[R] B) (s : Set A) :
 
 theorem ext_adjoin {s : Set A} [StarAlgHomClass F R (adjoin R s) B] {f g : F}
     (h : ∀ x : adjoin R s, (x : A) ∈ s → f x = g x) : f = g := by
-  refine' FunLike.ext f g fun a =>
+  refine' DFunLike.ext f g fun a =>
     adjoin_induction' (p := fun y => f y = g y) a (fun x hx => _) (fun r => _)
     (fun x y hx hy => _) (fun x y hx hy => _) fun x hx => _
   · exact h ⟨x, subset_adjoin R s hx⟩ hx
@@ -838,7 +838,7 @@ def StarAlgHom.restrictScalars (f : A →⋆ₐ[S] B) : A →⋆ₐ[R] B where
 theorem StarAlgHom.restrictScalars_injective :
     Function.Injective (StarAlgHom.restrictScalars R : (A →⋆ₐ[S] B) → A →⋆ₐ[R] B) :=
   fun f g h => StarAlgHom.ext fun x =>
-    show f.restrictScalars R x = g.restrictScalars R x from FunLike.congr_fun h x
+    show f.restrictScalars R x = g.restrictScalars R x from DFunLike.congr_fun h x
 
 @[simps]
 def StarAlgEquiv.restrictScalars (f : A ≃⋆ₐ[S] B) : A ≃⋆ₐ[R] B :=
@@ -849,6 +849,6 @@ def StarAlgEquiv.restrictScalars (f : A ≃⋆ₐ[S] B) : A ≃⋆ₐ[R] B :=
 theorem StarAlgEquiv.restrictScalars_injective :
     Function.Injective (StarAlgEquiv.restrictScalars R : (A ≃⋆ₐ[S] B) → A ≃⋆ₐ[R] B) :=
   fun f g h => StarAlgEquiv.ext fun x =>
-    show f.restrictScalars R x = g.restrictScalars R x from FunLike.congr_fun h x
+    show f.restrictScalars R x = g.restrictScalars R x from DFunLike.congr_fun h x
 
 end RestrictScalars

--- a/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
+++ b/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
@@ -25,7 +25,7 @@ namespace SimplexCategory
 
 open Simplicial NNReal BigOperators Classical CategoryTheory
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
 
 -- porting note: added, should be moved
 instance (x : SimplexCategory) : Fintype (ConcreteCategory.forget.obj x) :=

--- a/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
@@ -58,7 +58,7 @@ open Box Prepartition Finset
 variable {N : Type*} [AddCommMonoid M] [AddCommMonoid N] {I₀ : WithTop (Box ι)} {I J : Box ι}
   {i : ι}
 
-instance : FunLike (ι →ᵇᵃ[I₀] M) (Box ι) (fun _ ↦ M) where
+instance : DFunLike (ι →ᵇᵃ[I₀] M) (Box ι) (fun _ ↦ M) where
   coe := toFun
   coe_injective' f g h := by cases f; cases g; congr
 
@@ -71,11 +71,11 @@ theorem coe_mk (f h) : ⇑(mk f h : ι →ᵇᵃ[I₀] M) = f := rfl
 #align box_integral.box_additive_map.coe_mk BoxIntegral.BoxAdditiveMap.coe_mk
 
 theorem coe_injective : Injective fun (f : ι →ᵇᵃ[I₀] M) x => f x :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align box_integral.box_additive_map.coe_injective BoxIntegral.BoxAdditiveMap.coe_injective
 
 -- porting note: was @[simp], now can be proved by `simp`
-theorem coe_inj {f g : ι →ᵇᵃ[I₀] M} : (f : Box ι → M) = g ↔ f = g := FunLike.coe_fn_eq
+theorem coe_inj {f g : ι →ᵇᵃ[I₀] M} : (f : Box ι → M) = g ↔ f = g := DFunLike.coe_fn_eq
 #align box_integral.box_additive_map.coe_inj BoxIntegral.BoxAdditiveMap.coe_inj
 
 theorem sum_partition_boxes (f : ι →ᵇᵃ[I₀] M) (hI : ↑I ≤ I₀) {π : Prepartition I}

--- a/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
@@ -891,7 +891,7 @@ theorem iteratedFDerivWithin_one_apply (h : UniqueDiffWithinAt 𝕜 s x) (m : Fi
 theorem Filter.EventuallyEq.iteratedFDerivWithin' (h : f₁ =ᶠ[𝓝[s] x] f) (ht : t ⊆ s) (n : ℕ) :
     iteratedFDerivWithin 𝕜 n f₁ t =ᶠ[𝓝[s] x] iteratedFDerivWithin 𝕜 n f t := by
   induction' n with n ihn
-  · exact h.mono fun y hy => FunLike.ext _ _ fun _ => hy
+  · exact h.mono fun y hy => DFunLike.ext _ _ fun _ => hy
   · have : fderivWithin 𝕜 _ t =ᶠ[𝓝[s] x] fderivWithin 𝕜 _ t := ihn.fderivWithin' ht
     apply this.mono
     intro y hy

--- a/Mathlib/Analysis/Calculus/Deriv/Star.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Star.lean
@@ -52,11 +52,11 @@ protected nonrec theorem HasStrictDerivAt.star (h : HasStrictDerivAt f f' x) :
 
 protected theorem derivWithin.star (hxs : UniqueDiffWithinAt 𝕜 s x) :
     derivWithin (fun y => star (f y)) s x = star (derivWithin f s x) :=
-  FunLike.congr_fun (fderivWithin_star hxs) _
+  DFunLike.congr_fun (fderivWithin_star hxs) _
 #align deriv_within.star derivWithin.star
 
 protected theorem deriv.star : deriv (fun y => star (f y)) x = star (deriv f x) :=
-  FunLike.congr_fun fderiv_star _
+  DFunLike.congr_fun fderiv_star _
 #align deriv.star deriv.star
 
 @[simp]

--- a/Mathlib/Analysis/Calculus/LocalExtr/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LocalExtr/Basic.lean
@@ -230,7 +230,7 @@ variable {f : ℝ → ℝ} {f' : ℝ} {a b : ℝ}
 
 /-- **Fermat's Theorem**: the derivative of a function at a local minimum equals zero. -/
 theorem IsLocalMin.hasDerivAt_eq_zero (h : IsLocalMin f a) (hf : HasDerivAt f f' a) : f' = 0 := by
-  simpa using FunLike.congr_fun (h.hasFDerivAt_eq_zero (hasDerivAt_iff_hasFDerivAt.1 hf)) 1
+  simpa using DFunLike.congr_fun (h.hasFDerivAt_eq_zero (hasDerivAt_iff_hasFDerivAt.1 hf)) 1
 #align is_local_min.has_deriv_at_eq_zero IsLocalMin.hasDerivAt_eq_zero
 
 /-- **Fermat's Theorem**: the derivative of a function at a local minimum equals zero. -/

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -359,7 +359,7 @@ theorem continuous_conj : Continuous (conj : ℂ → ℂ) :=
 conjugation. -/
 theorem ringHom_eq_id_or_conj_of_continuous {f : ℂ →+* ℂ} (hf : Continuous f) :
     f = RingHom.id ℂ ∨ f = conj := by
-  simpa only [FunLike.ext_iff] using real_algHom_eq_id_or_conj (AlgHom.mk' f (map_real_smul f hf))
+  simpa only [DFunLike.ext_iff] using real_algHom_eq_id_or_conj (AlgHom.mk' f (map_real_smul f hf))
 #align complex.ring_hom_eq_id_or_conj_of_continuous Complex.ringHom_eq_id_or_conj_of_continuous
 
 /-- Continuous linear equiv version of the conj function, from `ℂ` to `ℂ`. -/

--- a/Mathlib/Analysis/Convex/Gauge.lean
+++ b/Mathlib/Analysis/Convex/Gauge.lean
@@ -519,7 +519,7 @@ protected theorem Seminorm.gauge_ball (p : Seminorm ℝ E) : gauge (p.ball 0 1) 
 theorem Seminorm.gaugeSeminorm_ball (p : Seminorm ℝ E) :
     gaugeSeminorm (p.balanced_ball_zero 1) (p.convex_ball 0 1) (p.absorbent_ball_zero zero_lt_one) =
       p :=
-  FunLike.coe_injective p.gauge_ball
+  DFunLike.coe_injective p.gauge_ball
 #align seminorm.gauge_seminorm_ball Seminorm.gaugeSeminorm_ball
 
 end AddCommGroup

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -92,10 +92,10 @@ open SchwartzSpace
 -- porting note: removed
 -- instance : Coe 𝓢(E, F) (E → F) := ⟨toFun⟩
 
-instance instFunLike : DFunLike 𝓢(E, F) E fun _ => F where
+instance instDFunLike : DFunLike 𝓢(E, F) E fun _ => F where
   coe f := f.toFun
   coe_injective' f g h := by cases f; cases g; congr
-#align schwartz_map.fun_like SchwartzMap.instFunLike
+#align schwartz_map.fun_like SchwartzMap.instDFunLike
 
 /-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`. -/
 instance instCoeFun : CoeFun 𝓢(E, F) fun _ => E → F :=

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -92,14 +92,14 @@ open SchwartzSpace
 -- porting note: removed
 -- instance : Coe 𝓢(E, F) (E → F) := ⟨toFun⟩
 
-instance instFunLike : FunLike 𝓢(E, F) E fun _ => F where
+instance instFunLike : DFunLike 𝓢(E, F) E fun _ => F where
   coe f := f.toFun
   coe_injective' f g h := by cases f; cases g; congr
 #align schwartz_map.fun_like SchwartzMap.instFunLike
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`. -/
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`. -/
 instance instCoeFun : CoeFun 𝓢(E, F) fun _ => E → F :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 #align schwartz_map.has_coe_to_fun SchwartzMap.instCoeFun
 
 /-- All derivatives of a Schwartz function are rapidly decaying. -/
@@ -132,7 +132,7 @@ protected theorem differentiableAt (f : 𝓢(E, F)) {x : E} : DifferentiableAt �
 
 @[ext]
 theorem ext {f g : 𝓢(E, F)} (h : ∀ x, (f : E → F) x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align schwartz_map.ext SchwartzMap.ext
 
 section IsBigO
@@ -323,7 +323,7 @@ instance instInhabited : Inhabited 𝓢(E, F) :=
   ⟨0⟩
 #align schwartz_map.inhabited SchwartzMap.instInhabited
 
-theorem coe_zero : FunLike.coe (0 : 𝓢(E, F)) = (0 : E → F) :=
+theorem coe_zero : DFunLike.coe (0 : 𝓢(E, F)) = (0 : E → F) :=
   rfl
 #align schwartz_map.coe_zero SchwartzMap.coe_zero
 
@@ -403,7 +403,7 @@ end Sub
 section AddCommGroup
 
 instance instAddCommGroup : AddCommGroup 𝓢(E, F) :=
-  FunLike.coe_injective.addCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
+  DFunLike.coe_injective.addCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 #align schwartz_map.add_comm_group SchwartzMap.instAddCommGroup
 
@@ -418,13 +418,13 @@ def coeHom : 𝓢(E, F) →+ E → F where
 
 variable {E F}
 
-theorem coe_coeHom : (coeHom E F : 𝓢(E, F) → E → F) = FunLike.coe :=
+theorem coe_coeHom : (coeHom E F : 𝓢(E, F) → E → F) = DFunLike.coe :=
   rfl
 #align schwartz_map.coe_coe_hom SchwartzMap.coe_coeHom
 
 theorem coeHom_injective : Function.Injective (coeHom E F) := by
   rw [coe_coeHom]
-  exact FunLike.coe_injective
+  exact DFunLike.coe_injective
 #align schwartz_map.coe_hom_injective SchwartzMap.coeHom_injective
 
 end AddCommGroup

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -356,9 +356,9 @@ theorem repr_injective :
   cases g
   congr
 
--- Porting note: `CoeFun` → `FunLike`
+-- Porting note: `CoeFun` → `DFunLike`
 /-- `b i` is the `i`th basis vector. -/
-instance instFunLike : FunLike (OrthonormalBasis ι 𝕜 E) ι fun _ => E where
+instance instFunLike : DFunLike (OrthonormalBasis ι 𝕜 E) ι fun _ => E where
   coe b i := by classical exact b.repr.symm (EuclideanSpace.single i (1 : 𝕜))
   coe_injective' b b' h := repr_injective <| LinearIsometryEquiv.toLinearEquiv_injective <|
     LinearEquiv.symm_bijective.injective <| LinearEquiv.toLinearMap_injective <| by
@@ -380,7 +380,7 @@ instance instFunLike : FunLike (OrthonormalBasis ι 𝕜 E) ι fun _ => E where
 theorem coe_ofRepr [DecidableEq ι] (e : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 ι) :
     ⇑(OrthonormalBasis.ofRepr e) = fun i => e.symm (EuclideanSpace.single i (1 : 𝕜)) := by
   -- Porting note: simplified with `congr!`
-  dsimp only [FunLike.coe]
+  dsimp only [DFunLike.coe]
   funext
   congr!
 #align orthonormal_basis.coe_of_repr OrthonormalBasis.coe_ofRepr
@@ -389,7 +389,7 @@ theorem coe_ofRepr [DecidableEq ι] (e : E ≃ₗᵢ[𝕜] EuclideanSpace 𝕜 �
 protected theorem repr_symm_single [DecidableEq ι] (b : OrthonormalBasis ι 𝕜 E) (i : ι) :
     b.repr.symm (EuclideanSpace.single i (1 : 𝕜)) = b i := by
   -- Porting note: simplified with `congr!`
-  dsimp only [FunLike.coe]
+  dsimp only [DFunLike.coe]
   congr!
 #align orthonormal_basis.repr_symm_single OrthonormalBasis.repr_symm_single
 

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -358,7 +358,7 @@ theorem repr_injective :
 
 -- Porting note: `CoeFun` → `DFunLike`
 /-- `b i` is the `i`th basis vector. -/
-instance instFunLike : DFunLike (OrthonormalBasis ι 𝕜 E) ι fun _ => E where
+instance instDFunLike : DFunLike (OrthonormalBasis ι 𝕜 E) ι fun _ => E where
   coe b i := by classical exact b.repr.symm (EuclideanSpace.single i (1 : 𝕜))
   coe_injective' b b' h := repr_injective <| LinearIsometryEquiv.toLinearEquiv_injective <|
     LinearEquiv.symm_bijective.injective <| LinearEquiv.toLinearMap_injective <| by

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -893,7 +893,7 @@ theorem orthogonalProjection_comp_subtypeL_eq_zero_iff {U V : Submodule 𝕜 E}
     [HasOrthogonalProjection U] : orthogonalProjection U ∘L V.subtypeL = 0 ↔ U ⟂ V :=
   ⟨fun h u hu v hv => by
     convert orthogonalProjection_inner_eq_zero v u hu using 2
-    have : orthogonalProjection U v = 0 := FunLike.congr_fun h (⟨_, hv⟩ : V)
+    have : orthogonalProjection U v = 0 := DFunLike.congr_fun h (⟨_, hv⟩ : V)
     rw [this, Submodule.coe_zero, sub_zero], Submodule.IsOrtho.orthogonalProjection_comp_subtypeL⟩
 set_option linter.uppercaseLean3 false in
 #align orthogonal_projection_comp_subtypeL_eq_zero_iff orthogonalProjection_comp_subtypeL_eq_zero_iff

--- a/Mathlib/Analysis/Normed/Group/Hom.lean
+++ b/Mathlib/Analysis/Normed/Group/Hom.lean
@@ -92,7 +92,9 @@ instance toAddMonoidHomClass : AddMonoidHomClass (NormedAddGroupHom V₁ V₂) V
   map_add f := f.map_add'
   map_zero f := (AddMonoidHom.mk' f.toFun f.map_add').map_zero
 
-/-- Helper instance for when there are too many metavariables to apply `DFunLike.coeFun` directly. -/
+/--
+Helper instance for when there are too many metavariables to apply `DFunLike.coeFun` directly.
+-/
 instance coeFun : CoeFun (NormedAddGroupHom V₁ V₂) fun _ => V₁ → V₂ :=
   ⟨DFunLike.coe⟩
 

--- a/Mathlib/Analysis/Normed/Group/Hom.lean
+++ b/Mathlib/Analysis/Normed/Group/Hom.lean
@@ -85,16 +85,16 @@ variable {f g : NormedAddGroupHom V₁ V₂}
 def ofLipschitz (f : V₁ →+ V₂) {K : ℝ≥0} (h : LipschitzWith K f) : NormedAddGroupHom V₁ V₂ :=
   f.mkNormedAddGroupHom K fun x ↦ by simpa only [map_zero, dist_zero_right] using h.dist_le_mul x 0
 
--- porting note: moved this declaration up so we could get a `FunLike` instance sooner.
+-- porting note: moved this declaration up so we could get a `DFunLike` instance sooner.
 instance toAddMonoidHomClass : AddMonoidHomClass (NormedAddGroupHom V₁ V₂) V₁ V₂ where
   coe := toFun
   coe_injective' := fun f g h => by cases f; cases g; congr
   map_add f := f.map_add'
   map_zero f := (AddMonoidHom.mk' f.toFun f.map_add').map_zero
 
-/-- Helper instance for when there are too many metavariables to apply `FunLike.coeFun` directly. -/
+/-- Helper instance for when there are too many metavariables to apply `DFunLike.coeFun` directly. -/
 instance coeFun : CoeFun (NormedAddGroupHom V₁ V₂) fun _ => V₁ → V₂ :=
-  ⟨FunLike.coe⟩
+  ⟨DFunLike.coe⟩
 
 initialize_simps_projections NormedAddGroupHom (toFun → apply)
 
@@ -611,7 +611,7 @@ instance toNormedAddCommGroup {V₁ V₂ : Type*} [NormedAddCommGroup V₁] [Nor
 /-- Coercion of a `NormedAddGroupHom` is an `AddMonoidHom`. Similar to `AddMonoidHom.coeFn`.  -/
 @[simps]
 def coeAddHom : NormedAddGroupHom V₁ V₂ →+ V₁ → V₂ where
-  toFun := FunLike.coe
+  toFun := DFunLike.coe
   map_zero' := coe_zero
   map_add' := coe_add
 #align normed_add_group_hom.coe_fn_add_hom NormedAddGroupHom.coeAddHom

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGroupCat.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGroupCat.lean
@@ -68,7 +68,7 @@ instance toAddMonoidHomClass {V W : SemiNormedGroupCat} : AddMonoidHomClass (V �
 -- Porting note: added to ease automation
 @[ext]
 lemma ext {M N : SemiNormedGroupCat} {f₁ f₂ : M ⟶ N} (h : ∀ (x : M), f₁ x = f₂ x) : f₁ = f₂ :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 
 @[simp]
 theorem coe_of (V : Type u) [SeminormedAddCommGroup V] : (SemiNormedGroupCat.of V : Type u) = V :=
@@ -147,7 +147,7 @@ instance : LargeCategory.{u} SemiNormedGroupCat₁ where
   comp {X Y Z} f g := ⟨g.1.comp f.1, g.2.comp f.2⟩
 
 -- Porting Note: Added
-instance instFunLike (X Y : SemiNormedGroupCat₁) : FunLike (X ⟶ Y) X (fun _ => Y) where
+instance instFunLike (X Y : SemiNormedGroupCat₁) : DFunLike (X ⟶ Y) X (fun _ => Y) where
   coe f := f.1.toFun
   coe_injective' _ _ h := Subtype.val_inj.mp (NormedAddGroupHom.coe_injective h)
 

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGroupCat.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGroupCat.lean
@@ -147,7 +147,7 @@ instance : LargeCategory.{u} SemiNormedGroupCat₁ where
   comp {X Y Z} f g := ⟨g.1.comp f.1, g.2.comp f.2⟩
 
 -- Porting Note: Added
-instance instFunLike (X Y : SemiNormedGroupCat₁) : DFunLike (X ⟶ Y) X (fun _ => Y) where
+instance instDFunLike (X Y : SemiNormedGroupCat₁) : DFunLike (X ⟶ Y) X (fun _ => Y) where
   coe f := f.1.toFun
   coe_injective' _ _ h := Subtype.val_inj.mp (NormedAddGroupHom.coe_injective h)
 

--- a/Mathlib/Analysis/Normed/Group/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Group/Seminorm.lean
@@ -195,11 +195,11 @@ instance groupSeminormClass : GroupSeminormClass (GroupSeminorm E) E ℝ
 #align group_seminorm.group_seminorm_class GroupSeminorm.groupSeminormClass
 #align add_group_seminorm.add_group_seminorm_class AddGroupSeminorm.addGroupSeminormClass
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`. -/
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`. -/
 @[to_additive "Helper instance for when there's too many metavariables to apply
-`FunLike.hasCoeToFun`. "]
+`DFunLike.hasCoeToFun`. "]
 instance : CoeFun (GroupSeminorm E) fun _ => E → ℝ :=
-  ⟨FunLike.coe⟩
+  ⟨DFunLike.coe⟩
 
 @[to_additive (attr := simp)]
 theorem toFun_eq_coe : p.toFun = p :=
@@ -209,13 +209,13 @@ theorem toFun_eq_coe : p.toFun = p :=
 
 @[to_additive (attr := ext)]
 theorem ext : (∀ x, p x = q x) → p = q :=
-  FunLike.ext p q
+  DFunLike.ext p q
 #align group_seminorm.ext GroupSeminorm.ext
 #align add_group_seminorm.ext AddGroupSeminorm.ext
 
 @[to_additive]
 instance : PartialOrder (GroupSeminorm E) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 @[to_additive]
 theorem le_def : p ≤ q ↔ (p : E → ℝ) ≤ q :=
@@ -315,7 +315,7 @@ theorem sup_apply (x : E) : (p ⊔ q) x = p x ⊔ q x :=
 
 @[to_additive]
 instance semilatticeSup : SemilatticeSup (GroupSeminorm E) :=
-  FunLike.coe_injective.semilatticeSup _ coe_sup
+  DFunLike.coe_injective.semilatticeSup _ coe_sup
 
 /-- Composition of a group seminorm with a monoid homomorphism as a group seminorm. -/
 @[to_additive "Composition of an additive group seminorm with an additive monoid homomorphism as an
@@ -513,9 +513,9 @@ instance nonarchAddGroupSeminormClass : NonarchAddGroupSeminormClass (NonarchAdd
   map_neg_eq_map' f := f.neg'
 #align nonarch_add_group_seminorm.nonarch_add_group_seminorm_class NonarchAddGroupSeminorm.nonarchAddGroupSeminormClass
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`. -/
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`. -/
 instance : CoeFun (NonarchAddGroupSeminorm E) fun _ => E → ℝ :=
-  ⟨FunLike.coe⟩
+  ⟨DFunLike.coe⟩
 
 -- porting note: `simpNF` said the left hand side simplified to this
 @[simp]
@@ -525,11 +525,11 @@ theorem toZeroHom_eq_coe : ⇑p.toZeroHom = p := by
 
 @[ext]
 theorem ext : (∀ x, p x = q x) → p = q :=
-  FunLike.ext p q
+  DFunLike.ext p q
 #align nonarch_add_group_seminorm.ext NonarchAddGroupSeminorm.ext
 
 noncomputable instance : PartialOrder (NonarchAddGroupSeminorm E) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 theorem le_def : p ≤ q ↔ (p : E → ℝ) ≤ q :=
   Iff.rfl
@@ -592,7 +592,7 @@ theorem sup_apply (x : E) : (p ⊔ q) x = p x ⊔ q x :=
 #align nonarch_add_group_seminorm.sup_apply NonarchAddGroupSeminorm.sup_apply
 
 noncomputable instance : SemilatticeSup (NonarchAddGroupSeminorm E) :=
-  FunLike.coe_injective.semilatticeSup _ coe_sup
+  DFunLike.coe_injective.semilatticeSup _ coe_sup
 
 end AddGroup
 
@@ -752,12 +752,12 @@ instance groupNormClass : GroupNormClass (GroupNorm E) E ℝ
 #align group_norm.group_norm_class GroupNorm.groupNormClass
 #align add_group_norm.add_group_norm_class AddGroupNorm.addGroupNormClass
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 @[to_additive "Helper instance for when there's too many metavariables to apply
-`FunLike.hasCoeToFun` directly. "]
+`DFunLike.hasCoeToFun` directly. "]
 instance : CoeFun (GroupNorm E) fun _ => E → ℝ :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 -- porting note: `simpNF` told me the left-hand side simplified to this
 @[to_additive (attr := simp)]
@@ -768,13 +768,13 @@ theorem toGroupSeminorm_eq_coe : ⇑p.toGroupSeminorm = p :=
 
 @[to_additive (attr := ext)]
 theorem ext : (∀ x, p x = q x) → p = q :=
-  FunLike.ext p q
+  DFunLike.ext p q
 #align group_norm.ext GroupNorm.ext
 #align add_group_norm.ext AddGroupNorm.ext
 
 @[to_additive]
 instance : PartialOrder (GroupNorm E) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 @[to_additive]
 theorem le_def : p ≤ q ↔ (p : E → ℝ) ≤ q :=
@@ -843,7 +843,7 @@ theorem sup_apply (x : E) : (p ⊔ q) x = p x ⊔ q x :=
 
 @[to_additive]
 instance : SemilatticeSup (GroupNorm E) :=
-  FunLike.coe_injective.semilatticeSup _ coe_sup
+  DFunLike.coe_injective.semilatticeSup _ coe_sup
 
 end Group
 
@@ -906,9 +906,9 @@ instance nonarchAddGroupNormClass : NonarchAddGroupNormClass (NonarchAddGroupNor
   eq_zero_of_map_eq_zero f := f.eq_zero_of_map_eq_zero' _
 #align nonarch_add_group_norm.nonarch_add_group_norm_class NonarchAddGroupNorm.nonarchAddGroupNormClass
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`. -/
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`. -/
 noncomputable instance : CoeFun (NonarchAddGroupNorm E) fun _ => E → ℝ :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 -- porting note: `simpNF` told me the left-hand side simplified to this
 @[simp]
@@ -918,11 +918,11 @@ theorem toNonarchAddGroupSeminorm_eq_coe : ⇑p.toNonarchAddGroupSeminorm = p :=
 
 @[ext]
 theorem ext : (∀ x, p x = q x) → p = q :=
-  FunLike.ext p q
+  DFunLike.ext p q
 #align nonarch_add_group_norm.ext NonarchAddGroupNorm.ext
 
 noncomputable instance : PartialOrder (NonarchAddGroupNorm E) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 theorem le_def : p ≤ q ↔ (p : E → ℝ) ≤ q :=
   Iff.rfl
@@ -961,7 +961,7 @@ theorem sup_apply (x : E) : (p ⊔ q) x = p x ⊔ q x :=
 #align nonarch_add_group_norm.sup_apply NonarchAddGroupNorm.sup_apply
 
 noncomputable instance : SemilatticeSup (NonarchAddGroupNorm E) :=
-  FunLike.coe_injective.semilatticeSup _ coe_sup
+  DFunLike.coe_injective.semilatticeSup _ coe_sup
 
 instance [DecidableEq E] : One (NonarchAddGroupNorm E) :=
   ⟨{ (1 : NonarchAddGroupSeminorm E) with

--- a/Mathlib/Analysis/Normed/Ring/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Ring/Seminorm.lean
@@ -92,9 +92,9 @@ instance ringSeminormClass : RingSeminormClass (RingSeminorm R) R ℝ where
   map_neg_eq_map f := f.neg'
 #align ring_seminorm.ring_seminorm_class RingSeminorm.ringSeminormClass
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`. -/
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`. -/
 instance : CoeFun (RingSeminorm R) fun _ => R → ℝ :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 @[simp]
 theorem toFun_eq_coe (p : RingSeminorm R) : (p.toAddGroupSeminorm : R → ℝ) = p :=
@@ -103,7 +103,7 @@ theorem toFun_eq_coe (p : RingSeminorm R) : (p.toAddGroupSeminorm : R → ℝ) =
 
 @[ext]
 theorem ext {p q : RingSeminorm R} : (∀ x, p x = q x) → p = q :=
-  FunLike.ext p q
+  DFunLike.ext p q
 #align ring_seminorm.ext RingSeminorm.ext
 
 instance : Zero (RingSeminorm R) :=
@@ -111,7 +111,7 @@ instance : Zero (RingSeminorm R) :=
     fun _ _ => (zero_mul _).ge }⟩
 
 theorem eq_zero_iff {p : RingSeminorm R} : p = 0 ↔ ∀ x, p x = 0 :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align ring_seminorm.eq_zero_iff RingSeminorm.eq_zero_iff
 
 theorem ne_zero_iff {p : RingSeminorm R} : p ≠ 0 ↔ ∃ x, p x ≠ 0 := by simp [eq_zero_iff]
@@ -191,7 +191,7 @@ instance ringNormClass : RingNormClass (RingNorm R) R ℝ where
   eq_zero_of_map_eq_zero f := f.eq_zero_of_map_eq_zero' _
 #align ring_norm.ring_norm_class RingNorm.ringNormClass
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`. -/
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`. -/
 instance : CoeFun (RingNorm R) fun _ => R → ℝ :=
   ⟨fun p => p.toFun⟩
 
@@ -202,7 +202,7 @@ instance : CoeFun (RingNorm R) fun _ => R → ℝ :=
 
 @[ext]
 theorem ext {p q : RingNorm R} : (∀ x, p x = q x) → p = q :=
-  FunLike.ext p q
+  DFunLike.ext p q
 #align ring_norm.ext RingNorm.ext
 
 variable (R)
@@ -241,9 +241,9 @@ instance mulRingSeminormClass : MulRingSeminormClass (MulRingSeminorm R) R ℝ w
   map_neg_eq_map f := f.neg'
 #align mul_ring_seminorm.mul_ring_seminorm_class MulRingSeminorm.mulRingSeminormClass
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`. -/
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`. -/
 instance : CoeFun (MulRingSeminorm R) fun _ => R → ℝ :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 @[simp]
 theorem toFun_eq_coe (p : MulRingSeminorm R) : (p.toAddGroupSeminorm : R → ℝ) = p :=
@@ -252,7 +252,7 @@ theorem toFun_eq_coe (p : MulRingSeminorm R) : (p.toAddGroupSeminorm : R → ℝ
 
 @[ext]
 theorem ext {p q : MulRingSeminorm R} : (∀ x, p x = q x) → p = q :=
-  FunLike.ext p q
+  DFunLike.ext p q
 #align mul_ring_seminorm.ext MulRingSeminorm.ext
 
 variable [DecidableEq R] [NoZeroDivisors R] [Nontrivial R]
@@ -299,7 +299,7 @@ instance mulRingNormClass : MulRingNormClass (MulRingNorm R) R ℝ where
   eq_zero_of_map_eq_zero f := f.eq_zero_of_map_eq_zero' _
 #align mul_ring_norm.mul_ring_norm_class MulRingNorm.mulRingNormClass
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`. -/
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`. -/
 instance : CoeFun (MulRingNorm R) fun _ => R → ℝ :=
   ⟨fun p => p.toFun⟩
 
@@ -310,7 +310,7 @@ instance : CoeFun (MulRingNorm R) fun _ => R → ℝ :=
 
 @[ext]
 theorem ext {p q : MulRingNorm R} : (∀ x, p x = q x) → p = q :=
-  FunLike.ext p q
+  DFunLike.ext p q
 #align mul_ring_norm.ext MulRingNorm.ext
 
 variable (R)

--- a/Mathlib/Analysis/NormedSpace/AffineIsometry.lean
+++ b/Mathlib/Analysis/NormedSpace/AffineIsometry.lean
@@ -71,7 +71,7 @@ theorem linear_eq_linearIsometry : f.linear = f.linearIsometry.toLinearMap := by
   rfl
 #align affine_isometry.linear_eq_linear_isometry AffineIsometry.linear_eq_linearIsometry
 
-instance : FunLike (P →ᵃⁱ[𝕜] P₂) P fun _ => P₂ :=
+instance : DFunLike (P →ᵃⁱ[𝕜] P₂) P fun _ => P₂ :=
   { coe := fun f => f.toFun,
     coe_injective' := fun f g => by cases f; cases g; simp }
 
@@ -337,7 +337,7 @@ instance : EquivLike (P ≃ᵃⁱ[𝕜] P₂) P P₂ :=
       cases f
       cases g
       congr
-      simpa [FunLike.coe_injective.eq_iff] using h }
+      simpa [DFunLike.coe_injective.eq_iff] using h }
 
 @[simp]
 theorem coe_mk (e : P ≃ᵃ[𝕜] P₂) (he : ∀ x, ‖e.linear x‖ = ‖x‖) : ⇑(mk e he) = e :=

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
@@ -134,7 +134,7 @@ lemma ContinuousLinearMap.exist_extension_of_finiteDimensional_range {p : Submod
 lemma Submodule.ClosedComplemented.of_finiteDimensional (p : Submodule 𝕜 F)
     [FiniteDimensional 𝕜 p] : p.ClosedComplemented :=
   let ⟨g, hg⟩ := (ContinuousLinearMap.id 𝕜 p).exist_extension_of_finiteDimensional_range
-  ⟨g, FunLike.congr_fun hg.symm⟩
+  ⟨g, DFunLike.congr_fun hg.symm⟩
 
 end IsROrC
 

--- a/Mathlib/Analysis/NormedSpace/LinearIsometry.lean
+++ b/Mathlib/Analysis/NormedSpace/LinearIsometry.lean
@@ -144,13 +144,13 @@ theorem toLinearMap_inj {f g : E →ₛₗᵢ[σ₁₂] E₂} : f.toLinearMap = 
 
 instance : SemilinearIsometryClass (E →ₛₗᵢ[σ₁₂] E₂) σ₁₂ E E₂ where
   coe f := f.toFun
-  coe_injective' _ _ h := toLinearMap_injective (FunLike.coe_injective h)
+  coe_injective' _ _ h := toLinearMap_injective (DFunLike.coe_injective h)
   map_add f := map_add f.toLinearMap
   map_smulₛₗ f := map_smulₛₗ f.toLinearMap
   norm_map f := f.norm_map'
 
 -- porting note: These helper instances are unhelpful in Lean 4, so omitting:
--- /-- Helper instance for when there's too many metavariables to apply `FunLike.has_coe_to_fun`
+-- /-- Helper instance for when there's too many metavariables to apply `DFunLike.has_coe_to_fun`
 -- directly.
 -- -/
 -- instance : CoeFun (E →ₛₗᵢ[σ₁₂] E₂) fun _ => E → E₂ :=
@@ -526,7 +526,7 @@ instance (priority := 100) [s : SemilinearIsometryEquivClass 𝓕 σ₁₂ E E�
     SemilinearIsometryClass 𝓕 σ₁₂ E E₂ :=
   { s with
     coe := ((↑) : 𝓕 → E → E₂)
-    coe_injective' := @FunLike.coe_injective 𝓕 _ _ _ }
+    coe_injective' := @DFunLike.coe_injective 𝓕 _ _ _ }
 
 end SemilinearIsometryEquivClass
 
@@ -551,7 +551,7 @@ instance : SemilinearIsometryEquivClass (E ≃ₛₗᵢ[σ₁₂] E₂) σ₁₂
     cases' g with g' _
     cases f'
     cases g'
-    simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, FunLike.coe_fn_eq] at h₁
+    simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, DFunLike.coe_fn_eq] at h₁
     congr
   left_inv e := e.left_inv
   right_inv e := e.right_inv
@@ -559,14 +559,14 @@ instance : SemilinearIsometryEquivClass (E ≃ₛₗᵢ[σ₁₂] E₂) σ₁₂
   map_smulₛₗ e := map_smulₛₗ e.toLinearEquiv
   norm_map e := e.norm_map'
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly.
 -/
 instance : CoeFun (E ≃ₛₗᵢ[σ₁₂] E₂) fun _ => E → E₂ :=
-  ⟨FunLike.coe⟩
+  ⟨DFunLike.coe⟩
 
 theorem coe_injective : @Function.Injective (E ≃ₛₗᵢ[σ₁₂] E₂) (E → E₂) (↑) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align linear_isometry_equiv.coe_injective LinearIsometryEquiv.coe_injective
 
 @[simp]

--- a/Mathlib/Analysis/NormedSpace/Star/Spectrum.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Spectrum.lean
@@ -170,7 +170,7 @@ variable {F A : Type*} [NormedRing A] [NormedAlgebra ℂ A] [CompleteSpace A] [S
 See note [lower instance priority] -/
 noncomputable instance (priority := 100) Complex.instStarHomClass : StarHomClass F A ℂ where
   coe φ := φ
-  coe_injective' := FunLike.coe_injective'
+  coe_injective' := DFunLike.coe_injective'
   map_star φ a := by
     suffices hsa : ∀ s : selfAdjoint A, (φ s)⋆ = φ s
     · rw [← realPart_add_I_smul_imaginaryPart a]

--- a/Mathlib/Analysis/NormedSpace/WeakDual.lean
+++ b/Mathlib/Analysis/NormedSpace/WeakDual.lean
@@ -216,7 +216,7 @@ theorem isClosed_image_coe_of_bounded_of_closed {s : Set (WeakDual 𝕜 E)}
 
 theorem isCompact_of_bounded_of_closed [ProperSpace 𝕜] {s : Set (WeakDual 𝕜 E)}
     (hb : IsBounded (Dual.toWeakDual ⁻¹' s)) (hc : IsClosed s) : IsCompact s :=
-  (Embedding.isCompact_iff FunLike.coe_injective.embedding_induced).mpr <|
+  (Embedding.isCompact_iff DFunLike.coe_injective.embedding_induced).mpr <|
     ContinuousLinearMap.isCompact_image_coe_of_bounded_of_closed_image hb <|
       isClosed_image_coe_of_bounded_of_closed hb hc
 #align weak_dual.is_compact_of_bounded_of_closed WeakDual.isCompact_of_bounded_of_closed

--- a/Mathlib/Analysis/Seminorm.lean
+++ b/Mathlib/Analysis/Seminorm.lean
@@ -126,13 +126,13 @@ instance instSeminormClass : SeminormClass (Seminorm 𝕜 E) 𝕜 E where
   map_smul_eq_mul f := f.smul'
 #align seminorm.seminorm_class Seminorm.instSeminormClass
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`. -/
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`. -/
 instance instCoeFun : CoeFun (Seminorm 𝕜 E) fun _ => E → ℝ :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 @[ext]
 theorem ext {p q : Seminorm 𝕜 E} (h : ∀ x, (p : E → ℝ) x = q x) : p = q :=
-  FunLike.ext p q h
+  DFunLike.ext p q h
 #align seminorm.ext Seminorm.ext
 
 instance instZero : Zero (Seminorm 𝕜 E) :=
@@ -195,14 +195,14 @@ theorem add_apply (p q : Seminorm 𝕜 E) (x : E) : (p + q) x = p x + q x :=
 #align seminorm.add_apply Seminorm.add_apply
 
 instance instAddMonoid : AddMonoid (Seminorm 𝕜 E) :=
-  FunLike.coe_injective.addMonoid _ rfl coe_add fun _ _ => by rfl
+  DFunLike.coe_injective.addMonoid _ rfl coe_add fun _ _ => by rfl
 
 instance instOrderedCancelAddCommMonoid : OrderedCancelAddCommMonoid (Seminorm 𝕜 E) :=
-  FunLike.coe_injective.orderedCancelAddCommMonoid _ rfl coe_add fun _ _ => rfl
+  DFunLike.coe_injective.orderedCancelAddCommMonoid _ rfl coe_add fun _ _ => rfl
 
 instance instMulAction [Monoid R] [MulAction R ℝ] [SMul R ℝ≥0] [IsScalarTower R ℝ≥0 ℝ] :
     MulAction R (Seminorm 𝕜 E) :=
-  FunLike.coe_injective.mulAction _ (by intros; rfl)
+  DFunLike.coe_injective.mulAction _ (by intros; rfl)
 
 variable (𝕜 E)
 
@@ -215,7 +215,7 @@ def coeFnAddMonoidHom : AddMonoidHom (Seminorm 𝕜 E) (E → ℝ) where
 #align seminorm.coe_fn_add_monoid_hom Seminorm.coeFnAddMonoidHom
 
 theorem coeFnAddMonoidHom_injective : Function.Injective (coeFnAddMonoidHom 𝕜 E) :=
-  show @Function.Injective (Seminorm 𝕜 E) (E → ℝ) (↑) from FunLike.coe_injective
+  show @Function.Injective (Seminorm 𝕜 E) (E → ℝ) (↑) from DFunLike.coe_injective
 #align seminorm.coe_fn_add_monoid_hom_injective Seminorm.coeFnAddMonoidHom_injective
 
 variable {𝕜 E}
@@ -254,7 +254,7 @@ theorem smul_sup [SMul R ℝ] [SMul R ℝ≥0] [IsScalarTower R ℝ≥0 ℝ] (r 
 #align seminorm.smul_sup Seminorm.smul_sup
 
 instance instPartialOrder : PartialOrder (Seminorm 𝕜 E) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 @[simp, norm_cast]
 theorem coe_le_coe {p q : Seminorm 𝕜 E} : (p : E → ℝ) ≤ q ↔ p ≤ q :=
@@ -275,7 +275,7 @@ theorem lt_def {p q : Seminorm 𝕜 E} : p < q ↔ p ≤ q ∧ ∃ x, p x < q x 
 #align seminorm.lt_def Seminorm.lt_def
 
 instance instSemilatticeSup : SemilatticeSup (Seminorm 𝕜 E) :=
-  Function.Injective.semilatticeSup _ FunLike.coe_injective coe_sup
+  Function.Injective.semilatticeSup _ DFunLike.coe_injective coe_sup
 
 end SMul
 

--- a/Mathlib/Analysis/SpecialFunctions/Bernstein.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Bernstein.lean
@@ -75,7 +75,7 @@ namespace Mathlib.Meta.Positivity
 
 open Lean Meta Qq Function
 
-@[positivity FunLike.coe _ _]
+@[positivity DFunLike.coe _ _]
 def evalBernstein : PositivityExt where eval {_ _} _zα _pα e := do
   let .app (.app _coe (.app (.app _ n) ν)) x ← whnfR e | throwError "not bernstein polynomial"
   let p ← mkAppOptM ``bernstein_nonneg #[n, ν, x]

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -98,10 +98,10 @@ variable {C : Type u} [Category.{v} C] [ConcreteCategory.{w} C]
 #noalign category_theory.forget_obj_eq_coe
 
 @[reducible]
-def ConcreteCategory.funLike {X Y : C} : DFunLike (X ⟶ Y) X (fun _ => Y) where
+def ConcreteCategory.instDFunLike {X Y : C} : DFunLike (X ⟶ Y) X (fun _ => Y) where
   coe f := (forget C).map f
   coe_injective' _ _ h := (forget C).map_injective h
-attribute [local instance] ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.instDFunLike
 
 /-- In any concrete category, we can test equality of morphisms by pointwise evaluations.-/
 @[ext low] -- Porting note: lowered priority
@@ -212,7 +212,7 @@ def forget₂ (C : Type u) (D : Type u') [Category.{v} C] [ConcreteCategory.{w} 
   HasForget₂.forget₂
 #align category_theory.forget₂ CategoryTheory.forget₂
 
-attribute [local instance] ConcreteCategory.funLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
 
 lemma forget₂_comp_apply {C : Type u} {D : Type u'} [Category.{v} C] [ConcreteCategory.{w} C]
     [Category.{v'} D] [ConcreteCategory.{w} D] [HasForget₂ C D] {X Y Z : C}

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -98,7 +98,7 @@ variable {C : Type u} [Category.{v} C] [ConcreteCategory.{w} C]
 #noalign category_theory.forget_obj_eq_coe
 
 @[reducible]
-def ConcreteCategory.funLike {X Y : C} : FunLike (X ⟶ Y) X (fun _ => Y) where
+def ConcreteCategory.funLike {X Y : C} : DFunLike (X ⟶ Y) X (fun _ => Y) where
   coe f := (forget C).map f
   coe_injective' _ _ h := (forget C).map_injective h
 attribute [local instance] ConcreteCategory.funLike

--- a/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
@@ -86,7 +86,7 @@ instance concreteCategory : ConcreteCategory.{u} (Bundled c)
 
 variable {hom}
 
-attribute [local instance] ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.instDFunLike
 
 /-- A version of `HasForget₂.mk'` for categories defined using `@BundledHom`. -/
 def mkHasForget₂ {d : Type u → Type u} {hom_d : ∀ ⦃α β : Type u⦄ (_ : d α) (_ : d β), Type u}

--- a/Mathlib/CategoryTheory/Limits/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/ConcreteCategory.lean
@@ -21,7 +21,7 @@ open CategoryTheory
 
 namespace CategoryTheory.Limits
 
-attribute [local instance] ConcreteCategory.funLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
 
 section Limits
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -33,7 +33,7 @@ universe w v u
 
 namespace CategoryTheory.Limits.Concrete
 
-attribute [local instance] ConcreteCategory.funLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
 
 variable {C : Type u} [Category.{v} C]
 

--- a/Mathlib/CategoryTheory/MorphismProperty.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty.lean
@@ -807,7 +807,7 @@ variable [ConcreteCategory C]
 
 open Function
 
-attribute [local instance] ConcreteCategory.funLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
 
 variable (C)
 

--- a/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
@@ -37,7 +37,7 @@ section
 
 variable [ConcreteCategory.{max v u} D]
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
 
 -- porting note: removed @[nolint has_nonempty_instance]
 /-- A concrete version of the multiequalizer, to be used below. -/
@@ -52,7 +52,7 @@ namespace Meq
 
 variable [ConcreteCategory.{max v u} D]
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
 
 instance {X} (P : Cᵒᵖ ⥤ D) (S : J.Cover X) :
     CoeFun (Meq P S) fun _ => ∀ I : S.Arrow, P.obj (op I.Y) :=
@@ -145,7 +145,7 @@ namespace Plus
 
 variable [ConcreteCategory.{max v u} D]
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
 
 variable [PreservesLimits (forget D)]
 

--- a/Mathlib/CategoryTheory/Sites/Surjective.lean
+++ b/Mathlib/CategoryTheory/Sites/Surjective.lean
@@ -32,7 +32,7 @@ namespace CategoryTheory
 
 variable {C : Type u} [Category.{v} C] (J : GrothendieckTopology C)
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
 
 variable {A : Type u'} [Category.{v'} A] [ConcreteCategory.{w'} A]
 

--- a/Mathlib/Combinatorics/Additive/SalemSpencer.lean
+++ b/Mathlib/Combinatorics/Additive/SalemSpencer.lean
@@ -118,7 +118,7 @@ section CommMonoid
 variable [CommMonoid α] [CommMonoid β] {s : Set α} {a : α}
 
 @[to_additive]
-theorem MulSalemSpencer.of_image [FunLike F α fun _ => β] [FreimanHomClass F s β 2] (f : F)
+theorem MulSalemSpencer.of_image [DFunLike F α fun _ => β] [FreimanHomClass F s β 2] (f : F)
     (hf : s.InjOn f) (h : MulSalemSpencer (f '' s)) : MulSalemSpencer s :=
   fun _ _ _ ha hb hc habc => hf ha hb <|
     h (mem_image_of_mem _ ha) (mem_image_of_mem _ hb) (mem_image_of_mem _ hc) <|

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -252,7 +252,7 @@ protected abbrev id : G →g G :=
 @[simp, norm_cast] lemma coe_id : ⇑(Hom.id : G →g G) = id := rfl
 #align simple_graph.hom.coe_id SimpleGraph.Hom.coe_id
 
-instance [Subsingleton (V → W)] : Subsingleton (G →g H) := FunLike.coe_injective.subsingleton
+instance [Subsingleton (V → W)] : Subsingleton (G →g H) := DFunLike.coe_injective.subsingleton
 
 instance [IsEmpty V] : Unique (G →g H) where
   default := ⟨isEmptyElim, fun {a} ↦ isEmptyElim a⟩
@@ -264,7 +264,7 @@ instance instFintype [DecidableEq V] [Fintype V] [Fintype W] [DecidableRel G.Adj
     { toFun := fun f ↦ ⟨f.1, f.2⟩, invFun := fun f ↦ ⟨f.1, f.2⟩,
       left_inv := fun _ ↦ rfl, right_inv := fun _ ↦ rfl }
 
-instance [Finite V] [Finite W] : Finite (G →g H) := FunLike.finite _
+instance [Finite V] [Finite W] : Finite (G →g H) := DFunLike.finite _
 
 theorem map_adj {v w : V} (h : G.Adj v w) : G'.Adj (f v) (f w) :=
   f.map_rel' h

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -720,7 +720,7 @@ def inclusion {x y : Subgraph G} (h : x ≤ y) : x.coe →g y.coe where
 
 theorem inclusion.injective {x y : Subgraph G} (h : x ≤ y) : Function.Injective (inclusion h) := by
   intro v w h
-  rw [inclusion, FunLike.coe, Subtype.mk_eq_mk] at h
+  rw [inclusion, DFunLike.coe, Subtype.mk_eq_mk] at h
   exact Subtype.ext h
 #align simple_graph.subgraph.inclusion.injective SimpleGraph.Subgraph.inclusion.injective
 

--- a/Mathlib/Combinatorics/Young/SemistandardTableau.lean
+++ b/Mathlib/Combinatorics/Young/SemistandardTableau.lean
@@ -63,13 +63,13 @@ structure Ssyt (μ : YoungDiagram) where
 
 namespace Ssyt
 
-instance funLike {μ : YoungDiagram} : DFunLike (Ssyt μ) ℕ fun _ ↦ ℕ → ℕ where
+instance instDFunLike {μ : YoungDiagram} : DFunLike (Ssyt μ) ℕ fun _ ↦ ℕ → ℕ where
   coe := Ssyt.entry
   coe_injective' T T' h := by
     cases T
     cases T'
     congr
-#align ssyt.fun_like Ssyt.funLike
+#align ssyt.fun_like Ssyt.instDFunLike
 
 /-- Helper instance for when there's too many metavariables to apply `CoeFun.coe` directly. -/
 instance {μ : YoungDiagram} : CoeFun (Ssyt μ) fun _ ↦ ℕ → ℕ → ℕ :=

--- a/Mathlib/Combinatorics/Young/SemistandardTableau.lean
+++ b/Mathlib/Combinatorics/Young/SemistandardTableau.lean
@@ -63,7 +63,7 @@ structure Ssyt (μ : YoungDiagram) where
 
 namespace Ssyt
 
-instance funLike {μ : YoungDiagram} : FunLike (Ssyt μ) ℕ fun _ ↦ ℕ → ℕ where
+instance funLike {μ : YoungDiagram} : DFunLike (Ssyt μ) ℕ fun _ ↦ ℕ → ℕ where
   coe := Ssyt.entry
   coe_injective' T T' h := by
     cases T
@@ -82,7 +82,7 @@ theorem to_fun_eq_coe {μ : YoungDiagram} {T : Ssyt μ} : T.entry = (T : ℕ →
 
 @[ext]
 theorem ext {μ : YoungDiagram} {T T' : Ssyt μ} (h : ∀ i j, T i j = T' i j) : T = T' :=
-  FunLike.ext T T' fun _ ↦ by
+  DFunLike.ext T T' fun _ ↦ by
     funext
     apply h
 #align ssyt.ext Ssyt.ext
@@ -105,7 +105,7 @@ theorem coe_copy {μ : YoungDiagram} (T : Ssyt μ) (entry' : ℕ → ℕ → ℕ
 
 theorem copy_eq {μ : YoungDiagram} (T : Ssyt μ) (entry' : ℕ → ℕ → ℕ) (h : entry' = T) :
     T.copy entry' h = T :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align ssyt.copy_eq Ssyt.copy_eq
 
 theorem row_weak {μ : YoungDiagram} (T : Ssyt μ) {i j1 j2 : ℕ} (hj : j1 < j2)

--- a/Mathlib/Data/Analysis/Filter.lean
+++ b/Mathlib/Data/Analysis/Filter.lean
@@ -53,7 +53,7 @@ instance : CoeFun (CFilter α σ) fun _ ↦ σ → α :=
   ⟨CFilter.f⟩
 
 /- Porting note: Due to the CoeFun instance, the lhs of this lemma has a variable (f) as its head
-symbol (simpnf linter problem). Replacing it with a FunLike instance would not be mathematically
+symbol (simpnf linter problem). Replacing it with a DFunLike instance would not be mathematically
 meaningful here, since the coercion to f cannot be injective, hence need to remove @[simp]. -/
 -- @[simp]
 theorem coe_mk (f pt inf h₁ h₂ a) : (@CFilter.mk α σ _ f pt inf h₁ h₂) a = f a :=

--- a/Mathlib/Data/DFinsupp/Basic.lean
+++ b/Mathlib/Data/DFinsupp/Basic.lean
@@ -82,12 +82,12 @@ section Basic
 
 variable [∀ i, Zero (β i)] [∀ i, Zero (β₁ i)] [∀ i, Zero (β₂ i)]
 
-instance funLike : DFunLike (Π₀ i, β i) ι β :=
+instance instDFunLike : DFunLike (Π₀ i, β i) ι β :=
   ⟨fun f => f.toFun, fun ⟨f₁, s₁⟩ ⟨f₂, s₁⟩ ↦ fun (h : f₁ = f₂) ↦ by
     subst h
     congr
     apply Subsingleton.elim ⟩
-#align dfinsupp.fun_like DFinsupp.funLike
+#align dfinsupp.fun_like DFinsupp.instDFunLike
 
 /-- Helper instance for when there are too many metavariables to apply `DFunLike.coeFunForall`
 directly. -/

--- a/Mathlib/Data/DFinsupp/Basic.lean
+++ b/Mathlib/Data/DFinsupp/Basic.lean
@@ -82,14 +82,14 @@ section Basic
 
 variable [∀ i, Zero (β i)] [∀ i, Zero (β₁ i)] [∀ i, Zero (β₂ i)]
 
-instance funLike : FunLike (Π₀ i, β i) ι β :=
+instance funLike : DFunLike (Π₀ i, β i) ι β :=
   ⟨fun f => f.toFun, fun ⟨f₁, s₁⟩ ⟨f₂, s₁⟩ ↦ fun (h : f₁ = f₂) ↦ by
     subst h
     congr
     apply Subsingleton.elim ⟩
 #align dfinsupp.fun_like DFinsupp.funLike
 
-/-- Helper instance for when there are too many metavariables to apply `FunLike.coeFunForall`
+/-- Helper instance for when there are too many metavariables to apply `DFunLike.coeFunForall`
 directly. -/
 instance : CoeFun (Π₀ i, β i) fun _ => ∀ i, β i :=
   inferInstance
@@ -101,19 +101,19 @@ theorem toFun_eq_coe (f : Π₀ i, β i) : f.toFun = f :=
 
 @[ext]
 theorem ext {f g : Π₀ i, β i} (h : ∀ i, f i = g i) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align dfinsupp.ext DFinsupp.ext
 
-@[deprecated FunLike.ext_iff]
+@[deprecated DFunLike.ext_iff]
 theorem ext_iff {f g : Π₀ i, β i} : f = g ↔ ∀ i, f i = g i :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align dfinsupp.ext_iff DFinsupp.ext_iff
 
-lemma ne_iff {f g : Π₀ i, β i} : f ≠ g ↔ ∃ i, f i ≠ g i := FunLike.ne_iff
+lemma ne_iff {f g : Π₀ i, β i} : f ≠ g ↔ ∃ i, f i ≠ g i := DFunLike.ne_iff
 
-@[deprecated FunLike.coe_injective]
+@[deprecated DFunLike.coe_injective]
 theorem coeFn_injective : @Function.Injective (Π₀ i, β i) (∀ i, β i) (⇑) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align dfinsupp.coe_fn_injective DFinsupp.coeFn_injective
 
 instance : Zero (Π₀ i, β i) :=
@@ -243,15 +243,15 @@ theorem coe_add [∀ i, AddZeroClass (β i)] (g₁ g₂ : Π₀ i, β i) : ⇑(g
 #align dfinsupp.coe_add DFinsupp.coe_add
 
 instance addZeroClass [∀ i, AddZeroClass (β i)] : AddZeroClass (Π₀ i, β i) :=
-  FunLike.coe_injective.addZeroClass _ coe_zero coe_add
+  DFunLike.coe_injective.addZeroClass _ coe_zero coe_add
 
 instance instIsLeftCancelAdd [∀ i, AddZeroClass (β i)] [∀ i, IsLeftCancelAdd (β i)] :
     IsLeftCancelAdd (Π₀ i, β i) where
-  add_left_cancel _ _ _ h := ext fun x => add_left_cancel <| FunLike.congr_fun h x
+  add_left_cancel _ _ _ h := ext fun x => add_left_cancel <| DFunLike.congr_fun h x
 
 instance instIsRightCancelAdd [∀ i, AddZeroClass (β i)] [∀ i, IsRightCancelAdd (β i)] :
     IsRightCancelAdd (Π₀ i, β i) where
-  add_right_cancel _ _ _ h := ext fun x => add_right_cancel <| FunLike.congr_fun h x
+  add_right_cancel _ _ _ h := ext fun x => add_right_cancel <| DFunLike.congr_fun h x
 
 instance instIsCancelAdd [∀ i, AddZeroClass (β i)] [∀ i, IsCancelAdd (β i)] :
     IsCancelAdd (Π₀ i, β i) where
@@ -272,7 +272,7 @@ theorem coe_nsmul [∀ i, AddMonoid (β i)] (b : ℕ) (v : Π₀ i, β i) : ⇑(
 #align dfinsupp.coe_nsmul DFinsupp.coe_nsmul
 
 instance [∀ i, AddMonoid (β i)] : AddMonoid (Π₀ i, β i) :=
-  FunLike.coe_injective.addMonoid _ coe_zero coe_add fun _ _ => coe_nsmul _ _
+  DFunLike.coe_injective.addMonoid _ coe_zero coe_add fun _ _ => coe_nsmul _ _
 
 /-- Coercion from a `DFinsupp` to a pi type is an `AddMonoidHom`. -/
 def coeFnAddMonoidHom [∀ i, AddZeroClass (β i)] : (Π₀ i, β i) →+ ∀ i, β i
@@ -289,7 +289,7 @@ def evalAddMonoidHom [∀ i, AddZeroClass (β i)] (i : ι) : (Π₀ i, β i) →
 #align dfinsupp.eval_add_monoid_hom DFinsupp.evalAddMonoidHom
 
 instance addCommMonoid [∀ i, AddCommMonoid (β i)] : AddCommMonoid (Π₀ i, β i) :=
-  FunLike.coe_injective.addCommMonoid _ coe_zero coe_add fun _ _ => coe_nsmul _ _
+  DFunLike.coe_injective.addCommMonoid _ coe_zero coe_add fun _ _ => coe_nsmul _ _
 
 @[simp, norm_cast]
 theorem coe_finset_sum {α} [∀ i, AddCommMonoid (β i)] (s : Finset α) (g : α → Π₀ i, β i) :
@@ -341,11 +341,11 @@ theorem coe_zsmul [∀ i, AddGroup (β i)] (b : ℤ) (v : Π₀ i, β i) : ⇑(b
 #align dfinsupp.coe_zsmul DFinsupp.coe_zsmul
 
 instance [∀ i, AddGroup (β i)] : AddGroup (Π₀ i, β i) :=
-  FunLike.coe_injective.addGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => coe_nsmul _ _)
+  DFunLike.coe_injective.addGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => coe_nsmul _ _)
     fun _ _ => coe_zsmul _ _
 
 instance addCommGroup [∀ i, AddCommGroup (β i)] : AddCommGroup (Π₀ i, β i) :=
-  FunLike.coe_injective.addCommGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => coe_nsmul _ _)
+  DFunLike.coe_injective.addCommGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => coe_nsmul _ _)
     fun _ _ => coe_zsmul _ _
 
 /-- Dependent functions with finite support inherit a semiring action from an action on each
@@ -383,7 +383,7 @@ instance isCentralScalar [Monoid γ] [∀ i, AddMonoid (β i)] [∀ i, DistribMu
 structure on each coordinate. -/
 instance distribMulAction [Monoid γ] [∀ i, AddMonoid (β i)] [∀ i, DistribMulAction γ (β i)] :
     DistribMulAction γ (Π₀ i, β i) :=
-  Function.Injective.distribMulAction coeFnAddMonoidHom FunLike.coe_injective coe_smul
+  Function.Injective.distribMulAction coeFnAddMonoidHom DFunLike.coe_injective coe_smul
 
 /-- Dependent functions with finite support inherit a module structure from such a structure on
 each coordinate. -/
@@ -511,14 +511,14 @@ theorem subtypeDomain_apply [∀ i, Zero (β i)] {p : ι → Prop} [DecidablePre
 @[simp]
 theorem subtypeDomain_add [∀ i, AddZeroClass (β i)] {p : ι → Prop} [DecidablePred p]
     (v v' : Π₀ i, β i) : (v + v').subtypeDomain p = v.subtypeDomain p + v'.subtypeDomain p :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align dfinsupp.subtype_domain_add DFinsupp.subtypeDomain_add
 
 @[simp]
 theorem subtypeDomain_smul [Monoid γ] [∀ i, AddMonoid (β i)] [∀ i, DistribMulAction γ (β i)]
     {p : ι → Prop} [DecidablePred p] (r : γ) (f : Π₀ i, β i) :
     (r • f).subtypeDomain p = r • f.subtypeDomain p :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align dfinsupp.subtype_domain_smul DFinsupp.subtypeDomain_smul
 
 variable (γ β)
@@ -550,13 +550,13 @@ variable {γ β}
 @[simp]
 theorem subtypeDomain_neg [∀ i, AddGroup (β i)] {p : ι → Prop} [DecidablePred p] {v : Π₀ i, β i} :
     (-v).subtypeDomain p = -v.subtypeDomain p :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align dfinsupp.subtype_domain_neg DFinsupp.subtypeDomain_neg
 
 @[simp]
 theorem subtypeDomain_sub [∀ i, AddGroup (β i)] {p : ι → Prop} [DecidablePred p]
     {v v' : Π₀ i, β i} : (v - v').subtypeDomain p = v.subtypeDomain p - v'.subtypeDomain p :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align dfinsupp.subtype_domain_sub DFinsupp.subtypeDomain_sub
 
 end FilterAndSubtypeDomain
@@ -606,11 +606,11 @@ theorem mk_injective (s : Finset ι) : Function.Injective (@mk ι β _ _ s) := b
 #align dfinsupp.mk_injective DFinsupp.mk_injective
 
 instance unique [∀ i, Subsingleton (β i)] : Unique (Π₀ i, β i) :=
-  FunLike.coe_injective.unique
+  DFunLike.coe_injective.unique
 #align dfinsupp.unique DFinsupp.unique
 
 instance uniqueOfIsEmpty [IsEmpty ι] : Unique (Π₀ i, β i) :=
-  FunLike.coe_injective.unique
+  DFunLike.coe_injective.unique
 #align dfinsupp.unique_of_is_empty DFinsupp.uniqueOfIsEmpty
 
 /-- Given `Fintype ι`, `equivFunOnFintype` is the `Equiv` between `Π₀ i, β i` and `Π i, β i`.
@@ -620,7 +620,7 @@ def equivFunOnFintype [Fintype ι] : (Π₀ i, β i) ≃ ∀ i, β i
     where
   toFun := (⇑)
   invFun f := ⟨f, Trunc.mk ⟨Finset.univ.1, fun _ => Or.inl <| Finset.mem_univ_val _⟩⟩
-  left_inv _ := FunLike.coe_injective rfl
+  left_inv _ := DFunLike.coe_injective rfl
   right_inv _ := rfl
 #align dfinsupp.equiv_fun_on_fintype DFinsupp.equivFunOnFintype
 #align dfinsupp.equiv_fun_on_fintype_apply DFinsupp.equivFunOnFintype_apply
@@ -650,7 +650,7 @@ theorem single_apply {i i' b} :
 
 @[simp]
 theorem single_zero (i) : (single i 0 : Π₀ i, β i) = 0 :=
-  FunLike.coe_injective <| Pi.single_zero _
+  DFunLike.coe_injective <| Pi.single_zero _
 #align dfinsupp.single_zero DFinsupp.single_zero
 
 -- @[simp] -- Porting note: simp can prove this
@@ -663,7 +663,7 @@ theorem single_eq_of_ne {i i' b} (h : i ≠ i') : (single i b : Π₀ i, β i) i
 #align dfinsupp.single_eq_of_ne DFinsupp.single_eq_of_ne
 
 theorem single_injective {i} : Function.Injective (single i : β i → Π₀ i, β i) := fun _ _ H =>
-  Pi.single_injective β i <| FunLike.coe_injective.eq_iff.mpr H
+  Pi.single_injective β i <| DFunLike.coe_injective.eq_iff.mpr H
 #align dfinsupp.single_injective DFinsupp.single_injective
 
 /-- Like `Finsupp.single_eq_single_iff`, but with a `HEq` due to dependent types -/
@@ -1040,7 +1040,7 @@ See note [partially-applied ext lemmas]. -/
 @[ext]
 theorem addHom_ext' {γ : Type w} [AddZeroClass γ] ⦃f g : (Π₀ i, β i) →+ γ⦄
     (H : ∀ x, f.comp (singleAddHom β x) = g.comp (singleAddHom β x)) : f = g :=
-  addHom_ext fun x => FunLike.congr_fun (H x)
+  addHom_ext fun x => DFunLike.congr_fun (H x)
 #align dfinsupp.add_hom_ext' DFinsupp.addHom_ext'
 
 end AddMonoid
@@ -1584,7 +1584,7 @@ theorem sigmaUncurry_add [∀ i j, AddZeroClass (δ i j)]
     [∀ i, DecidableEq (α i)] [∀ i j (x : δ i j), Decidable (x ≠ 0)]
     (f g : Π₀ (i) (j), δ i j) :
     sigmaUncurry (f + g) = sigmaUncurry f + sigmaUncurry g :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align dfinsupp.sigma_uncurry_add DFinsupp.sigmaUncurry_add
 
 /- ./././Mathport/Syntax/Translate/Expr.lean:107:6: warning: expanding binder group (i j) -/
@@ -1593,7 +1593,7 @@ theorem sigmaUncurry_smul [Monoid γ] [∀ i j, AddMonoid (δ i j)]
     [∀ i, DecidableEq (α i)] [∀ i j (x : δ i j), Decidable (x ≠ 0)]
     [∀ i j, DistribMulAction γ (δ i j)]
     (r : γ) (f : Π₀ (i) (j), δ i j) : sigmaUncurry (r • f) = r • sigmaUncurry f :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align dfinsupp.sigma_uncurry_smul DFinsupp.sigmaUncurry_smul
 
 @[simp]
@@ -2143,7 +2143,7 @@ theorem prod_sum_index {ι₁ : Type u₁} [DecidableEq ι₁] {β₁ : ι₁ �
 @[simp]
 theorem sum_single [∀ i, AddCommMonoid (β i)] [∀ (i) (x : β i), Decidable (x ≠ 0)] {f : Π₀ i, β i} :
     f.sum single = f := by
-  have := FunLike.congr_fun (liftAddHom_singleAddHom (β := β)) f
+  have := DFunLike.congr_fun (liftAddHom_singleAddHom (β := β)) f
   rw [liftAddHom_apply, sumAddHom_apply] at this
   exact this
 #align dfinsupp.sum_single DFinsupp.sum_single
@@ -2315,7 +2315,7 @@ open DFinsupp
 theorem map_dfinsupp_sumAddHom [AddCommMonoid R] [AddCommMonoid S] [∀ i, AddZeroClass (β i)]
     (h : R →+ S) (f : Π₀ i, β i) (g : ∀ i, β i →+ R) :
     h (sumAddHom g f) = sumAddHom (fun i => h.comp (g i)) f :=
-  FunLike.congr_fun (comp_liftAddHom h g) f
+  DFunLike.congr_fun (comp_liftAddHom h g) f
 #align add_monoid_hom.map_dfinsupp_sum_add_hom AddMonoidHom.map_dfinsupp_sumAddHom
 
 theorem dfinsupp_sumAddHom_apply [AddZeroClass R] [AddCommMonoid S] [∀ i, AddZeroClass (β i)]
@@ -2343,7 +2343,7 @@ open DFinsupp
 theorem map_dfinsupp_sumAddHom [NonAssocSemiring R] [NonAssocSemiring S] [∀ i, AddZeroClass (β i)]
     (h : R →+* S) (f : Π₀ i, β i) (g : ∀ i, β i →+ R) :
     h (sumAddHom g f) = sumAddHom (fun i => h.toAddMonoidHom.comp (g i)) f :=
-  FunLike.congr_fun (comp_liftAddHom h.toAddMonoidHom g) f
+  DFunLike.congr_fun (comp_liftAddHom h.toAddMonoidHom g) f
 #align ring_hom.map_dfinsupp_sum_add_hom RingHom.map_dfinsupp_sumAddHom
 
 end RingHom
@@ -2358,7 +2358,7 @@ open DFinsupp
 theorem map_dfinsupp_sumAddHom [AddCommMonoid R] [AddCommMonoid S] [∀ i, AddZeroClass (β i)]
     (h : R ≃+ S) (f : Π₀ i, β i) (g : ∀ i, β i →+ R) :
     h (sumAddHom g f) = sumAddHom (fun i => h.toAddMonoidHom.comp (g i)) f :=
-  FunLike.congr_fun (comp_liftAddHom h.toAddMonoidHom g) f
+  DFunLike.congr_fun (comp_liftAddHom h.toAddMonoidHom g) f
 #align add_equiv.map_dfinsupp_sum_add_hom AddEquiv.map_dfinsupp_sumAddHom
 
 end AddEquiv

--- a/Mathlib/Data/DFinsupp/Lex.lean
+++ b/Mathlib/Data/DFinsupp/Lex.lean
@@ -78,7 +78,7 @@ instance Lex.partialOrder [∀ i, PartialOrder (α i)] : PartialOrder (Lex (Π�
   lt := (· < ·)
   le x y := ⇑(ofLex x) = ⇑(ofLex y) ∨ x < y
   __ := PartialOrder.lift (fun x : Lex (Π₀ i, α i) ↦ toLex (⇑(ofLex x)))
-    (FunLike.coe_injective (F := DFinsupp α))
+    (DFunLike.coe_injective (F := DFinsupp α))
 #align dfinsupp.lex.partial_order DFinsupp.Lex.partialOrder
 
 section LinearOrder

--- a/Mathlib/Data/DFinsupp/Order.lean
+++ b/Mathlib/Data/DFinsupp/Order.lean
@@ -47,13 +47,13 @@ lemma le_def : f ≤ g ↔ ∀ i, f i ≤ g i := Iff.rfl
 
 /-- The order on `DFinsupp`s over a partial order embeds into the order on functions -/
 def orderEmbeddingToFun : (Π₀ i, α i) ↪o ∀ i, α i where
-  toFun := FunLike.coe
-  inj' := FunLike.coe_injective
+  toFun := DFunLike.coe
+  inj' := DFunLike.coe_injective
   map_rel_iff' := by rfl
 #align dfinsupp.order_embedding_to_fun DFinsupp.orderEmbeddingToFun
 
 @[simp, norm_cast]
-lemma coe_orderEmbeddingToFun : ⇑(orderEmbeddingToFun (α := α)) = FunLike.coe := rfl
+lemma coe_orderEmbeddingToFun : ⇑(orderEmbeddingToFun (α := α)) = DFunLike.coe := rfl
 
 -- Porting note: we added implicit arguments here in #3414.
 theorem orderEmbeddingToFun_apply {f : Π₀ i, α i} {i : ι} :
@@ -205,7 +205,7 @@ protected theorem bot_eq_zero : (⊥ : Π₀ i, α i) = 0 :=
 
 @[simp]
 theorem add_eq_zero_iff (f g : Π₀ i, α i) : f + g = 0 ↔ f = 0 ∧ g = 0 := by
-  simp [FunLike.ext_iff, forall_and]
+  simp [DFunLike.ext_iff, forall_and]
 #align dfinsupp.add_eq_zero_iff DFinsupp.add_eq_zero_iff
 
 section LE

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -168,7 +168,7 @@ theorem eq_sort_iff' : σ = sort f ↔ StrictMono (σ.trans <| graphEquiv₁ f) 
     exact (graphEquiv₂ f).strictMono
   · have := Subsingleton.elim (graphEquiv₂ f) (h.orderIsoOfSurjective _ <| Equiv.surjective _)
     ext1 x
-    exact (graphEquiv₁ f).apply_eq_iff_eq_symm_apply.1 (FunLike.congr_fun this x).symm
+    exact (graphEquiv₁ f).apply_eq_iff_eq_symm_apply.1 (DFunLike.congr_fun this x).symm
 #align tuple.eq_sort_iff' Tuple.eq_sort_iff'
 
 /-- A permutation `σ` equals `sort f` if and only if `f ∘ σ` is monotone and whenever `i < j`

--- a/Mathlib/Data/Finite/Basic.lean
+++ b/Mathlib/Data/Finite/Basic.lean
@@ -140,12 +140,12 @@ instance Function.Embedding.finite {α β : Sort*} [Finite β] : Finite (α ↪ 
 
   · refine' h.elim fun f => _
     haveI : Finite α := Finite.of_injective _ f.injective
-    exact Finite.of_injective _ FunLike.coe_injective
+    exact Finite.of_injective _ DFunLike.coe_injective
 #align function.embedding.finite Function.Embedding.finite
 
 instance Equiv.finite_right {α β : Sort*} [Finite β] : Finite (α ≃ β) :=
   Finite.of_injective Equiv.toEmbedding fun e₁ e₂ h => Equiv.ext <| by
-    convert FunLike.congr_fun h using 0
+    convert DFunLike.congr_fun h using 0
 #align equiv.finite_right Equiv.finite_right
 
 instance Equiv.finite_left {α β : Sort*} [Finite α] : Finite (α ≃ β) :=

--- a/Mathlib/Data/Finset/PiAntidiagonal.lean
+++ b/Mathlib/Data/Finset/PiAntidiagonal.lean
@@ -96,12 +96,12 @@ def finAntidiagonal₀ (d : ℕ) (n : μ) : Finset (Fin d →₀ μ) :=
     { toFun := fun f =>
         -- this is `Finsupp.onFinset`, but computable
         { toFun := f, support := univ.filter (f · ≠ 0), mem_support_toFun := fun x => by simp }
-      inj' := fun _ _ h => FunLike.coe_fn_eq.mpr h }
+      inj' := fun _ _ h => DFunLike.coe_fn_eq.mpr h }
 
 lemma mem_finAntidiagonal₀' (d : ℕ) (n : μ) (f : Fin d →₀ μ) :
     f ∈ finAntidiagonal₀ d n ↔ ∑ i, f i = n := by
   simp only [finAntidiagonal₀, mem_map, Embedding.coeFn_mk, ← mem_finAntidiagonal,
-    ← FunLike.coe_injective.eq_iff, Finsupp.coe_mk, exists_eq_right]
+    ← DFunLike.coe_injective.eq_iff, Finsupp.coe_mk, exists_eq_right]
 
 lemma mem_finAntidiagonal₀ (d : ℕ) (n : μ) (f : Fin d →₀ μ) :
     f ∈ finAntidiagonal₀ d n ↔ sum f (fun _ x => x) = n := by
@@ -220,7 +220,7 @@ theorem piAntidiagonal_insert [DecidableEq ι] [DecidableEq μ] {a : ι} {s : Fi
         ⟨fun f => Finsupp.update f.val a p.fst,
         (fun ⟨f, hf⟩ ⟨g, hg⟩ hfg => Subtype.ext <| by
           simp only [mem_val, mem_piAntidiagonal] at hf hg
-          simp only [FunLike.ext_iff] at hfg ⊢
+          simp only [DFunLike.ext_iff] at hfg ⊢
           intro x
           obtain rfl | hx := eq_or_ne x a
           · replace hf := mt (hf.1 ·) h
@@ -270,7 +270,7 @@ theorem piAntidiagonal_zero (s : Finset ι) :
     piAntidiagonal s (0 : μ) = {(0 : ι →₀ μ)} := by
   ext f
   simp_rw [mem_piAntidiagonal', mem_singleton, sum_eq_zero_iff, Finset.subset_iff,
-    mem_support_iff, not_imp_comm, ← forall_and, ← or_imp, FunLike.ext_iff, zero_apply, or_comm,
+    mem_support_iff, not_imp_comm, ← forall_and, ← or_imp, DFunLike.ext_iff, zero_apply, or_comm,
     or_not, true_imp_iff]
 
 end CanonicallyOrderedAddCommMonoid

--- a/Mathlib/Data/Finsupp/Antidiagonal.lean
+++ b/Mathlib/Data/Finsupp/Antidiagonal.lean
@@ -69,10 +69,10 @@ theorem antidiagonal_single (a : α) (n : ℕ) :
     Function.Embedding.coeFn_mk, Prod_map, Prod.mk.injEq, Prod.exists]
   constructor
   · intro h
-    refine ⟨x a, y a, FunLike.congr_fun h a |>.trans single_eq_same, ?_⟩
-    simp_rw [FunLike.ext_iff, ← forall_and]
+    refine ⟨x a, y a, DFunLike.congr_fun h a |>.trans single_eq_same, ?_⟩
+    simp_rw [DFunLike.ext_iff, ← forall_and]
     intro i
-    replace h := FunLike.congr_fun h i
+    replace h := DFunLike.congr_fun h i
     simp_rw [single_apply, Finsupp.add_apply] at h ⊢
     obtain rfl | hai := Decidable.eq_or_ne a i
     · exact ⟨if_pos rfl, if_pos rfl⟩

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -647,7 +647,7 @@ theorem mapDomain_mapRange [AddCommMonoid N] (f : α → β) (v : α →₀ M) (
     { toFun := g
       map_zero' := h0
       map_add' := hadd }
-  FunLike.congr_fun (mapDomain.addMonoidHom_comp_mapRange f g') v
+  DFunLike.congr_fun (mapDomain.addMonoidHom_comp_mapRange f g') v
 #align finsupp.map_domain_map_range Finsupp.mapDomain_mapRange
 
 theorem sum_update_add [AddCommMonoid α] [AddCommMonoid β] (f : ι →₀ α) (i : ι) (a : α)
@@ -903,12 +903,12 @@ theorem filter_eq_indicator : ⇑(f.filter p) = Set.indicator { x | p x } f :=
 #align finsupp.filter_eq_indicator Finsupp.filter_eq_indicator
 
 theorem filter_eq_zero_iff : f.filter p = 0 ↔ ∀ x, p x → f x = 0 := by
-  simp only [FunLike.ext_iff, filter_eq_indicator, zero_apply, Set.indicator_apply_eq_zero,
+  simp only [DFunLike.ext_iff, filter_eq_indicator, zero_apply, Set.indicator_apply_eq_zero,
     Set.mem_setOf_eq]
 #align finsupp.filter_eq_zero_iff Finsupp.filter_eq_zero_iff
 
 theorem filter_eq_self_iff : f.filter p = f ↔ ∀ x, f x ≠ 0 → p x := by
-  simp only [FunLike.ext_iff, filter_eq_indicator, Set.indicator_apply_eq_self, Set.mem_setOf_eq,
+  simp only [DFunLike.ext_iff, filter_eq_indicator, Set.indicator_apply_eq_self, Set.mem_setOf_eq,
     not_imp_comm]
 #align finsupp.filter_eq_self_iff Finsupp.filter_eq_self_iff
 
@@ -969,7 +969,7 @@ end Zero
 
 theorem filter_pos_add_filter_neg [AddZeroClass M] (f : α →₀ M) (p : α → Prop) :
     (f.filter p + f.filter fun a => ¬p a) = f :=
-  FunLike.coe_injective <| Set.indicator_self_add_compl { x | p x } f
+  DFunLike.coe_injective <| Set.indicator_self_add_compl { x | p x } f
 #align finsupp.filter_pos_add_filter_neg Finsupp.filter_pos_add_filter_neg
 
 end Filter
@@ -1091,7 +1091,7 @@ def filterAddHom (p : α → Prop) : (α →₀ M) →+ α →₀ M
     where
   toFun := filter p
   map_zero' := filter_zero p
-  map_add' f g := FunLike.coe_injective <| Set.indicator_add { x | p x } f g
+  map_add' f g := DFunLike.coe_injective <| Set.indicator_add { x | p x } f g
 #align finsupp.filter_add_hom Finsupp.filterAddHom
 
 @[simp]
@@ -1504,14 +1504,14 @@ theorem smul_apply [Zero M] [SMulZeroClass R M] (b : R) (v : α →₀ M) (a : �
 
 theorem _root_.IsSMulRegular.finsupp [Zero M] [SMulZeroClass R M] {k : R}
     (hk : IsSMulRegular M k) : IsSMulRegular (α →₀ M) k :=
-  fun _ _ h => ext fun i => hk (FunLike.congr_fun h i)
+  fun _ _ h => ext fun i => hk (DFunLike.congr_fun h i)
 #align is_smul_regular.finsupp IsSMulRegular.finsupp
 
 instance faithfulSMul [Nonempty α] [Zero M] [SMulZeroClass R M] [FaithfulSMul R M] :
     FaithfulSMul R (α →₀ M) where
   eq_of_smul_eq_smul h :=
     let ⟨a⟩ := ‹Nonempty α›
-    eq_of_smul_eq_smul fun m : M => by simpa using FunLike.congr_fun (h (single a m)) a
+    eq_of_smul_eq_smul fun m : M => by simpa using DFunLike.congr_fun (h (single a m)) a
 #align finsupp.faithful_smul Finsupp.faithfulSMul
 
 instance instSMulWithZero [Zero R] [Zero M] [SMulWithZero R M] : SMulWithZero R (α →₀ M) where
@@ -1573,7 +1573,7 @@ variable {p : α → Prop}
 @[simp]
 theorem filter_smul {_ : Monoid R} [AddMonoid M] [DistribMulAction R M] {b : R} {v : α →₀ M} :
     (b • v).filter p = b • v.filter p :=
-  FunLike.coe_injective <| Set.indicator_const_smul { x | p x } b v
+  DFunLike.coe_injective <| Set.indicator_const_smul { x | p x } b v
 #align finsupp.filter_smul Finsupp.filter_smul
 
 end
@@ -1647,7 +1647,7 @@ instance noZeroSMulDivisors [Semiring R] [AddCommMonoid M] [Module R M] {ι : Ty
     [NoZeroSMulDivisors R M] : NoZeroSMulDivisors R (ι →₀ M) :=
   ⟨fun h =>
     or_iff_not_imp_left.mpr fun hc =>
-      Finsupp.ext fun i => (smul_eq_zero.mp (FunLike.ext_iff.mp h i)).resolve_left hc⟩
+      Finsupp.ext fun i => (smul_eq_zero.mp (DFunLike.ext_iff.mp h i)).resolve_left hc⟩
 #align finsupp.no_zero_smul_divisors Finsupp.noZeroSMulDivisors
 
 section DistribMulActionHom
@@ -1690,12 +1690,12 @@ variable [Zero R]
 
 /-- The `Finsupp` version of `Pi.unique`. -/
 instance uniqueOfRight [Subsingleton R] : Unique (α →₀ R) :=
-  FunLike.coe_injective.unique
+  DFunLike.coe_injective.unique
 #align finsupp.unique_of_right Finsupp.uniqueOfRight
 
 /-- The `Finsupp` version of `Pi.uniqueOfIsEmpty`. -/
 instance uniqueOfLeft [IsEmpty α] : Unique (α →₀ R) :=
-  FunLike.coe_injective.unique
+  DFunLike.coe_injective.unique
 #align finsupp.unique_of_left Finsupp.uniqueOfLeft
 
 end

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -117,7 +117,7 @@ section Basic
 
 variable [Zero M]
 
-instance funLike : FunLike (α →₀ M) α fun _ => M :=
+instance funLike : DFunLike (α →₀ M) α fun _ => M :=
   ⟨toFun, by
     rintro ⟨s, f, hf⟩ ⟨t, g, hg⟩ (rfl : f = g)
     congr
@@ -125,7 +125,7 @@ instance funLike : FunLike (α →₀ M) α fun _ => M :=
     exact (hf _).trans (hg _).symm⟩
 #align finsupp.fun_like Finsupp.funLike
 
-/-- Helper instance for when there are too many metavariables to apply the `FunLike` instance
+/-- Helper instance for when there are too many metavariables to apply the `DFunLike` instance
 directly. -/
 instance coeFun : CoeFun (α →₀ M) fun _ => α → M :=
   inferInstance
@@ -133,29 +133,29 @@ instance coeFun : CoeFun (α →₀ M) fun _ => α → M :=
 
 @[ext]
 theorem ext {f g : α →₀ M} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align finsupp.ext Finsupp.ext
 
-@[deprecated FunLike.ext_iff]
+@[deprecated DFunLike.ext_iff]
 theorem ext_iff {f g : α →₀ M} : f = g ↔ ∀ a, f a = g a :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align finsupp.ext_iff Finsupp.ext_iff
 
-lemma ne_iff {f g : α →₀ M} : f ≠ g ↔ ∃ a, f a ≠ g a := FunLike.ne_iff
+lemma ne_iff {f g : α →₀ M} : f ≠ g ↔ ∃ a, f a ≠ g a := DFunLike.ne_iff
 
-@[deprecated FunLike.coe_fn_eq]
+@[deprecated DFunLike.coe_fn_eq]
 theorem coeFn_inj {f g : α →₀ M} : (f : α → M) = g ↔ f = g :=
-  FunLike.coe_fn_eq
+  DFunLike.coe_fn_eq
 #align finsupp.coe_fn_inj Finsupp.coeFn_inj
 
-@[deprecated FunLike.coe_injective]
+@[deprecated DFunLike.coe_injective]
 theorem coeFn_injective : @Function.Injective (α →₀ M) (α → M) (⇑) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align finsupp.coe_fn_injective Finsupp.coeFn_injective
 
-@[deprecated FunLike.congr_fun]
+@[deprecated DFunLike.congr_fun]
 theorem congr_fun {f g : α →₀ M} (h : f = g) (a : α) : f a = g a :=
-  FunLike.congr_fun h _
+  DFunLike.congr_fun h _
 #align finsupp.congr_fun Finsupp.congr_fun
 
 @[simp, norm_cast]
@@ -198,7 +198,7 @@ theorem not_mem_support_iff {f : α →₀ M} {a} : a ∉ f.support ↔ f a = 0 
 #align finsupp.not_mem_support_iff Finsupp.not_mem_support_iff
 
 @[simp, norm_cast]
-theorem coe_eq_zero {f : α →₀ M} : (f : α → M) = 0 ↔ f = 0 := by rw [← coe_zero, FunLike.coe_fn_eq]
+theorem coe_eq_zero {f : α →₀ M} : (f : α → M) = 0 ↔ f = 0 := by rw [← coe_zero, DFunLike.coe_fn_eq]
 #align finsupp.coe_eq_zero Finsupp.coe_eq_zero
 
 theorem ext_iff' {f g : α →₀ M} : f = g ↔ f.support = g.support ∧ ∀ x ∈ f.support, f x = g x :=
@@ -340,7 +340,7 @@ theorem single_eq_pi_single [DecidableEq α] (a : α) (b : M) : ⇑(single a b) 
 
 @[simp]
 theorem single_zero (a : α) : (single a 0 : α →₀ M) = 0 :=
-  FunLike.coe_injective <| by
+  DFunLike.coe_injective <| by
     classical simpa only [single_eq_update, coe_zero] using Function.update_eq_self a (0 : α → M)
 #align finsupp.single_zero Finsupp.single_zero
 
@@ -404,7 +404,7 @@ theorem single_eq_single_iff (a₁ a₂ : α) (b₁ b₂ : M) :
     by_cases h : a₁ = a₂
     · refine' Or.inl ⟨h, _⟩
       rwa [h, (single_injective a₂).eq_iff] at eq
-    · rw [FunLike.ext_iff] at eq
+    · rw [DFunLike.ext_iff] at eq
       have h₁ := eq a₁
       have h₂ := eq a₂
       simp only [single_eq_same, single_eq_of_ne h, single_eq_of_ne (Ne.symm h)] at h₁ h₂
@@ -435,7 +435,7 @@ theorem support_single_disjoint {b' : M} (hb : b ≠ 0) (hb' : b' ≠ 0) {i j : 
 
 @[simp]
 theorem single_eq_zero : single a b = 0 ↔ b = 0 := by
-  simp [FunLike.ext_iff, single_eq_set_indicator]
+  simp [DFunLike.ext_iff, single_eq_set_indicator]
 #align finsupp.single_eq_zero Finsupp.single_eq_zero
 
 theorem single_swap (a₁ a₂ : α) (b : M) : single a₁ b a₂ = single a₂ b a₁ := by
@@ -610,12 +610,12 @@ theorem support_update_subset [DecidableEq α] [DecidableEq M] :
 theorem update_comm (f : α →₀ M) {a₁ a₂ : α} (h : a₁ ≠ a₂) (m₁ m₂ : M) :
     update (update f a₁ m₁) a₂ m₂ = update (update f a₂ m₂) a₁ m₁ :=
   letI := Classical.decEq α
-  FunLike.coe_injective <| Function.update_comm h _ _ _
+  DFunLike.coe_injective <| Function.update_comm h _ _ _
 
 @[simp] theorem update_idem (f : α →₀ M) (a : α) (b c : M) :
     update (update f a b) a c = update f a c :=
   letI := Classical.decEq α
-  FunLike.coe_injective <| Function.update_idem _ _ _
+  DFunLike.coe_injective <| Function.update_idem _ _ _
 
 end Update
 
@@ -905,7 +905,7 @@ theorem embDomain_notin_range (f : α ↪ β) (v : α →₀ M) (a : β) (h : a 
 #align finsupp.emb_domain_notin_range Finsupp.embDomain_notin_range
 
 theorem embDomain_injective (f : α ↪ β) : Function.Injective (embDomain f : (α →₀ M) → β →₀ M) :=
-  fun l₁ l₂ h => ext fun a => by simpa only [embDomain_apply] using FunLike.ext_iff.1 h (f a)
+  fun l₁ l₂ h => ext fun a => by simpa only [embDomain_apply] using DFunLike.ext_iff.1 h (f a)
 #align finsupp.emb_domain_injective Finsupp.embDomain_injective
 
 @[simp]
@@ -1045,11 +1045,11 @@ theorem single_add (a : α) (b₁ b₂ : M) : single a (b₁ + b₂) = single a 
 #align finsupp.single_add Finsupp.single_add
 
 instance addZeroClass : AddZeroClass (α →₀ M) :=
-  FunLike.coe_injective.addZeroClass _ coe_zero coe_add
+  DFunLike.coe_injective.addZeroClass _ coe_zero coe_add
 #align finsupp.add_zero_class Finsupp.addZeroClass
 
 instance instIsLeftCancelAdd [IsLeftCancelAdd M] : IsLeftCancelAdd (α →₀ M) where
-  add_left_cancel _ _ _ h := ext fun x => add_left_cancel <| FunLike.congr_fun h x
+  add_left_cancel _ _ _ h := ext fun x => add_left_cancel <| DFunLike.congr_fun h x
 
 /-- When ι is finite and M is an AddMonoid,
   then Finsupp.equivFunOnFinite gives an AddEquiv -/
@@ -1065,7 +1065,7 @@ noncomputable def _root_.AddEquiv.finsuppUnique {ι : Type*} [Unique ι] :
   map_add' _ _ := rfl
 
 instance instIsRightCancelAdd [IsRightCancelAdd M] : IsRightCancelAdd (α →₀ M) where
-  add_right_cancel _ _ _ h := ext fun x => add_right_cancel <| FunLike.congr_fun h x
+  add_right_cancel _ _ _ h := ext fun x => add_right_cancel <| DFunLike.congr_fun h x
 
 instance instIsCancelAdd [IsCancelAdd M] : IsCancelAdd (α →₀ M) where
 
@@ -1204,18 +1204,18 @@ verify `f (single a 1) = g (single a 1)`. -/
 @[ext high]
 theorem addHom_ext' [AddZeroClass N] ⦃f g : (α →₀ M) →+ N⦄
     (H : ∀ x, f.comp (singleAddHom x) = g.comp (singleAddHom x)) : f = g :=
-  addHom_ext fun x => FunLike.congr_fun (H x)
+  addHom_ext fun x => DFunLike.congr_fun (H x)
 #align finsupp.add_hom_ext' Finsupp.addHom_ext'
 
 theorem mulHom_ext [MulOneClass N] ⦃f g : Multiplicative (α →₀ M) →* N⦄
     (H : ∀ x y, f (Multiplicative.ofAdd <| single x y) = g (Multiplicative.ofAdd <| single x y)) :
     f = g :=
   MonoidHom.ext <|
-    FunLike.congr_fun <| by
+    DFunLike.congr_fun <| by
       have := @addHom_ext α M (Additive N) _ _
         (MonoidHom.toAdditive'' f) (MonoidHom.toAdditive'' g) H
       ext
-      rw [FunLike.ext_iff] at this
+      rw [DFunLike.ext_iff] at this
       apply this
 #align finsupp.mul_hom_ext Finsupp.mulHom_ext
 
@@ -1224,7 +1224,7 @@ theorem mulHom_ext' [MulOneClass N] {f g : Multiplicative (α →₀ M) →* N}
     (H : ∀ x, f.comp (AddMonoidHom.toMultiplicative (singleAddHom x)) =
               g.comp (AddMonoidHom.toMultiplicative (singleAddHom x))) :
     f = g :=
-  mulHom_ext fun x => FunLike.congr_fun (H x)
+  mulHom_ext fun x => DFunLike.congr_fun (H x)
 #align finsupp.mul_hom_ext' Finsupp.mulHom_ext'
 
 theorem mapRange_add [AddZeroClass N] {f : M → N} {hf : f 0 = 0}
@@ -1271,14 +1271,14 @@ instance hasNatScalar : SMul ℕ (α →₀ M) :=
 #align finsupp.has_nat_scalar Finsupp.hasNatScalar
 
 instance addMonoid : AddMonoid (α →₀ M) :=
-  FunLike.coe_injective.addMonoid _ coe_zero coe_add fun _ _ => rfl
+  DFunLike.coe_injective.addMonoid _ coe_zero coe_add fun _ _ => rfl
 #align finsupp.add_monoid Finsupp.addMonoid
 
 end AddMonoid
 
 instance addCommMonoid [AddCommMonoid M] : AddCommMonoid (α →₀ M) :=
   --TODO: add reference to library note in PR #7432
-  { FunLike.coe_injective.addCommMonoid (↑) coe_zero coe_add (fun _ _ => rfl) with
+  { DFunLike.coe_injective.addCommMonoid (↑) coe_zero coe_add (fun _ _ => rfl) with
     toAddMonoid := Finsupp.addMonoid }
 #align finsupp.add_comm_monoid Finsupp.addCommMonoid
 
@@ -1334,14 +1334,14 @@ instance hasIntScalar [AddGroup G] : SMul ℤ (α →₀ G) :=
 
 instance addGroup [AddGroup G] : AddGroup (α →₀ G) :=
   --TODO: add reference to library note in PR #7432
-  { FunLike.coe_injective.addGroup (↑) coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl)
+  { DFunLike.coe_injective.addGroup (↑) coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl)
       fun _ _ => rfl with
     toAddMonoid := Finsupp.addMonoid }
 #align finsupp.add_group Finsupp.addGroup
 
 instance addCommGroup [AddCommGroup G] : AddCommGroup (α →₀ G) :=
   --TODO: add reference to library note in PR #7432
-  { FunLike.coe_injective.addCommGroup (↑) coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl)
+  { DFunLike.coe_injective.addCommGroup (↑) coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl)
       fun _ _ => rfl with
     toAddGroup := Finsupp.addGroup }
 #align finsupp.add_comm_group Finsupp.addCommGroup
@@ -1351,7 +1351,7 @@ theorem single_add_single_eq_single_add_single [AddCommMonoid M] {k l m n : α} 
     single k u + single l v = single m u + single n v ↔
       (k = m ∧ l = n) ∨ (u = v ∧ k = n ∧ l = m) ∨ (u + v = 0 ∧ k = l ∧ m = n) := by
   classical
-    simp_rw [FunLike.ext_iff, coe_add, single_eq_pi_single, ← funext_iff]
+    simp_rw [DFunLike.ext_iff, coe_add, single_eq_pi_single, ← funext_iff]
     exact Pi.single_add_single_eq_single_add_single hu hv
 #align finsupp.single_add_single_eq_single_add_single Finsupp.single_add_single_eq_single_add_single
 

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -117,13 +117,13 @@ section Basic
 
 variable [Zero M]
 
-instance funLike : DFunLike (α →₀ M) α fun _ => M :=
+instance instDFunLike : DFunLike (α →₀ M) α fun _ => M :=
   ⟨toFun, by
     rintro ⟨s, f, hf⟩ ⟨t, g, hg⟩ (rfl : f = g)
     congr
     ext a
     exact (hf _).trans (hg _).symm⟩
-#align finsupp.fun_like Finsupp.funLike
+#align finsupp.fun_like Finsupp.instDFunLike
 
 /-- Helper instance for when there are too many metavariables to apply the `DFunLike` instance
 directly. -/

--- a/Mathlib/Data/Finsupp/Indicator.lean
+++ b/Mathlib/Data/Finsupp/Indicator.lean
@@ -61,7 +61,7 @@ theorem indicator_injective : Injective fun f : ∀ i ∈ s, α => indicator s f
   intro a b h
   ext i hi
   rw [← indicator_of_mem hi a, ← indicator_of_mem hi b]
-  exact FunLike.congr_fun h i
+  exact DFunLike.congr_fun h i
 #align finsupp.indicator_injective Finsupp.indicator_injective
 
 theorem support_indicator_subset : ((indicator s f).support : Set ι) ⊆ s := by

--- a/Mathlib/Data/Finsupp/Lex.lean
+++ b/Mathlib/Data/Finsupp/Lex.lean
@@ -77,7 +77,7 @@ instance Lex.partialOrder [PartialOrder N] : PartialOrder (Lex (α →₀ N)) wh
   lt := (· < ·)
   le x y := ⇑(ofLex x) = ⇑(ofLex y) ∨ x < y
   __ := PartialOrder.lift (fun x : Lex (α →₀ N) ↦ toLex (⇑(ofLex x)))
-    (FunLike.coe_injective (F := Finsupp α N))
+    (DFunLike.coe_injective (F := Finsupp α N))
 #align finsupp.lex.partial_order Finsupp.Lex.partialOrder
 
 /-- The linear order on `Finsupp`s obtained by the lexicographic ordering. -/

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -197,7 +197,7 @@ protected theorem bot_eq_zero : (⊥ : ι →₀ α) = 0 :=
 
 @[simp]
 theorem add_eq_zero_iff (f g : ι →₀ α) : f + g = 0 ↔ f = 0 ∧ g = 0 := by
-  simp [FunLike.ext_iff, forall_and]
+  simp [DFunLike.ext_iff, forall_and]
 #align finsupp.add_eq_zero_iff Finsupp.add_eq_zero_iff
 
 theorem le_iff' (f g : ι →₀ α) {s : Finset ι} (hf : f.support ⊆ s) : f ≤ g ↔ ∀ i ∈ s, f i ≤ g i :=

--- a/Mathlib/Data/Finsupp/Pointwise.lean
+++ b/Mathlib/Data/Finsupp/Pointwise.lean
@@ -66,32 +66,32 @@ theorem support_mul [DecidableEq α] {g₁ g₂ : α →₀ β} :
 #align finsupp.support_mul Finsupp.support_mul
 
 instance : MulZeroClass (α →₀ β) :=
-  FunLike.coe_injective.mulZeroClass _ coe_zero coe_mul
+  DFunLike.coe_injective.mulZeroClass _ coe_zero coe_mul
 
 end
 
 instance [SemigroupWithZero β] : SemigroupWithZero (α →₀ β) :=
-  FunLike.coe_injective.semigroupWithZero _ coe_zero coe_mul
+  DFunLike.coe_injective.semigroupWithZero _ coe_zero coe_mul
 
 instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →₀ β) :=
-  FunLike.coe_injective.nonUnitalNonAssocSemiring _ coe_zero coe_add coe_mul fun _ _ ↦ rfl
+  DFunLike.coe_injective.nonUnitalNonAssocSemiring _ coe_zero coe_add coe_mul fun _ _ ↦ rfl
 
 instance [NonUnitalSemiring β] : NonUnitalSemiring (α →₀ β) :=
-  FunLike.coe_injective.nonUnitalSemiring _ coe_zero coe_add coe_mul fun _ _ ↦ rfl
+  DFunLike.coe_injective.nonUnitalSemiring _ coe_zero coe_add coe_mul fun _ _ ↦ rfl
 
 instance [NonUnitalCommSemiring β] : NonUnitalCommSemiring (α →₀ β) :=
-  FunLike.coe_injective.nonUnitalCommSemiring _ coe_zero coe_add coe_mul fun _ _ ↦ rfl
+  DFunLike.coe_injective.nonUnitalCommSemiring _ coe_zero coe_add coe_mul fun _ _ ↦ rfl
 
 instance [NonUnitalNonAssocRing β] : NonUnitalNonAssocRing (α →₀ β) :=
-  FunLike.coe_injective.nonUnitalNonAssocRing _ coe_zero coe_add coe_mul coe_neg coe_sub
+  DFunLike.coe_injective.nonUnitalNonAssocRing _ coe_zero coe_add coe_mul coe_neg coe_sub
     (fun _ _ ↦ rfl) fun _ _ ↦ rfl
 
 instance [NonUnitalRing β] : NonUnitalRing (α →₀ β) :=
-  FunLike.coe_injective.nonUnitalRing _ coe_zero coe_add coe_mul coe_neg coe_sub (fun _ _ ↦ rfl)
+  DFunLike.coe_injective.nonUnitalRing _ coe_zero coe_add coe_mul coe_neg coe_sub (fun _ _ ↦ rfl)
     fun _ _ ↦ rfl
 
 instance [NonUnitalCommRing β] : NonUnitalCommRing (α →₀ β) :=
-  FunLike.coe_injective.nonUnitalCommRing _ coe_zero coe_add coe_mul coe_neg coe_sub
+  DFunLike.coe_injective.nonUnitalCommRing _ coe_zero coe_add coe_mul coe_neg coe_sub
     (fun _ _ ↦ rfl) fun _ _ ↦ rfl
 
 -- TODO can this be generalized in the direction of `Pi.smul'`
@@ -115,7 +115,7 @@ theorem coe_pointwise_smul [Semiring β] (f : α → β) (g : α →₀ β) : �
 
 /-- The pointwise multiplicative action of functions on finitely supported functions -/
 instance pointwiseModule [Semiring β] : Module (α → β) (α →₀ β) :=
-  Function.Injective.module _ coeFnAddHom FunLike.coe_injective coe_pointwise_smul
+  Function.Injective.module _ coeFnAddHom DFunLike.coe_injective coe_pointwise_smul
 #align finsupp.pointwise_module Finsupp.pointwiseModule
 
 end Finsupp

--- a/Mathlib/Data/Finsupp/ToDFinsupp.lean
+++ b/Mathlib/Data/Finsupp/ToDFinsupp.lean
@@ -128,12 +128,12 @@ theorem DFinsupp.toFinsupp_single (i : ι) (m : M) :
 
 @[simp]
 theorem Finsupp.toDFinsupp_toFinsupp (f : ι →₀ M) : f.toDFinsupp.toFinsupp = f :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align finsupp.to_dfinsupp_to_finsupp Finsupp.toDFinsupp_toFinsupp
 
 @[simp]
 theorem DFinsupp.toFinsupp_toDFinsupp (f : Π₀ _ : ι, M) : f.toFinsupp.toDFinsupp = f :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align dfinsupp.to_finsupp_to_dfinsupp DFinsupp.toFinsupp_toDFinsupp
 
 end
@@ -149,30 +149,30 @@ namespace Finsupp
 
 @[simp]
 theorem toDFinsupp_zero [Zero M] : (0 : ι →₀ M).toDFinsupp = 0 :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align finsupp.to_dfinsupp_zero Finsupp.toDFinsupp_zero
 
 @[simp]
 theorem toDFinsupp_add [AddZeroClass M] (f g : ι →₀ M) :
     (f + g).toDFinsupp = f.toDFinsupp + g.toDFinsupp :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align finsupp.to_dfinsupp_add Finsupp.toDFinsupp_add
 
 @[simp]
 theorem toDFinsupp_neg [AddGroup M] (f : ι →₀ M) : (-f).toDFinsupp = -f.toDFinsupp :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align finsupp.to_dfinsupp_neg Finsupp.toDFinsupp_neg
 
 @[simp]
 theorem toDFinsupp_sub [AddGroup M] (f g : ι →₀ M) :
     (f - g).toDFinsupp = f.toDFinsupp - g.toDFinsupp :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align finsupp.to_dfinsupp_sub Finsupp.toDFinsupp_sub
 
 @[simp]
 theorem toDFinsupp_smul [Monoid R] [AddMonoid M] [DistribMulAction R M] (r : R) (f : ι →₀ M) :
     (r • f).toDFinsupp = r • f.toDFinsupp :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align finsupp.to_dfinsupp_smul Finsupp.toDFinsupp_smul
 
 end Finsupp
@@ -183,31 +183,31 @@ variable [DecidableEq ι]
 
 @[simp]
 theorem toFinsupp_zero [Zero M] [∀ m : M, Decidable (m ≠ 0)] : toFinsupp 0 = (0 : ι →₀ M) :=
-  FunLike.coe_injective rfl
+  DFunLike.coe_injective rfl
 #align dfinsupp.to_finsupp_zero DFinsupp.toFinsupp_zero
 
 @[simp]
 theorem toFinsupp_add [AddZeroClass M] [∀ m : M, Decidable (m ≠ 0)] (f g : Π₀ _ : ι, M) :
     (toFinsupp (f + g) : ι →₀ M) = toFinsupp f + toFinsupp g :=
-  FunLike.coe_injective <| DFinsupp.coe_add _ _
+  DFunLike.coe_injective <| DFinsupp.coe_add _ _
 #align dfinsupp.to_finsupp_add DFinsupp.toFinsupp_add
 
 @[simp]
 theorem toFinsupp_neg [AddGroup M] [∀ m : M, Decidable (m ≠ 0)] (f : Π₀ _ : ι, M) :
     (toFinsupp (-f) : ι →₀ M) = -toFinsupp f :=
-  FunLike.coe_injective <| DFinsupp.coe_neg _
+  DFunLike.coe_injective <| DFinsupp.coe_neg _
 #align dfinsupp.to_finsupp_neg DFinsupp.toFinsupp_neg
 
 @[simp]
 theorem toFinsupp_sub [AddGroup M] [∀ m : M, Decidable (m ≠ 0)] (f g : Π₀ _ : ι, M) :
     (toFinsupp (f - g) : ι →₀ M) = toFinsupp f - toFinsupp g :=
-  FunLike.coe_injective <| DFinsupp.coe_sub _ _
+  DFunLike.coe_injective <| DFinsupp.coe_sub _ _
 #align dfinsupp.to_finsupp_sub DFinsupp.toFinsupp_sub
 
 @[simp]
 theorem toFinsupp_smul [Monoid R] [AddMonoid M] [DistribMulAction R M] [∀ m : M, Decidable (m ≠ 0)]
     (r : R) (f : Π₀ _ : ι, M) : (toFinsupp (r • f) : ι →₀ M) = r • toFinsupp f :=
-  FunLike.coe_injective <| DFinsupp.coe_smul _ _
+  DFunLike.coe_injective <| DFinsupp.coe_smul _ _
 #align dfinsupp.to_finsupp_smul DFinsupp.toFinsupp_smul
 
 end DFinsupp

--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -386,27 +386,27 @@ instance decidableEqEmbeddingFintype [DecidableEq β] [Fintype α] : DecidableEq
 @[to_additive]
 instance decidableEqOneHomFintype [DecidableEq β] [Fintype α] [One α] [One β] :
     DecidableEq (OneHom α β) := fun a b =>
-  decidable_of_iff ((a : α → β) = b) (Injective.eq_iff FunLike.coe_injective)
+  decidable_of_iff ((a : α → β) = b) (Injective.eq_iff DFunLike.coe_injective)
 #align fintype.decidable_eq_one_hom_fintype Fintype.decidableEqOneHomFintype
 #align fintype.decidable_eq_zero_hom_fintype Fintype.decidableEqZeroHomFintype
 
 @[to_additive]
 instance decidableEqMulHomFintype [DecidableEq β] [Fintype α] [Mul α] [Mul β] :
     DecidableEq (α →ₙ* β) := fun a b =>
-  decidable_of_iff ((a : α → β) = b) (Injective.eq_iff FunLike.coe_injective)
+  decidable_of_iff ((a : α → β) = b) (Injective.eq_iff DFunLike.coe_injective)
 #align fintype.decidable_eq_mul_hom_fintype Fintype.decidableEqMulHomFintype
 #align fintype.decidable_eq_add_hom_fintype Fintype.decidableEqAddHomFintype
 
 @[to_additive]
 instance decidableEqMonoidHomFintype [DecidableEq β] [Fintype α] [MulOneClass α] [MulOneClass β] :
     DecidableEq (α →* β) := fun a b =>
-  decidable_of_iff ((a : α → β) = b) (Injective.eq_iff FunLike.coe_injective)
+  decidable_of_iff ((a : α → β) = b) (Injective.eq_iff DFunLike.coe_injective)
 #align fintype.decidable_eq_monoid_hom_fintype Fintype.decidableEqMonoidHomFintype
 #align fintype.decidable_eq_add_monoid_hom_fintype Fintype.decidableEqAddMonoidHomFintype
 
 instance decidableEqMonoidWithZeroHomFintype [DecidableEq β] [Fintype α] [MulZeroOneClass α]
     [MulZeroOneClass β] : DecidableEq (α →*₀ β) := fun a b =>
-  decidable_of_iff ((a : α → β) = b) (Injective.eq_iff FunLike.coe_injective)
+  decidable_of_iff ((a : α → β) = b) (Injective.eq_iff DFunLike.coe_injective)
 #align fintype.decidable_eq_monoid_with_zero_hom_fintype Fintype.decidableEqMonoidWithZeroHomFintype
 
 instance decidableEqRingHomFintype [DecidableEq β] [Fintype α] [Semiring α] [Semiring β] :

--- a/Mathlib/Data/Fintype/CardEmbedding.lean
+++ b/Mathlib/Data/Fintype/CardEmbedding.lean
@@ -42,7 +42,7 @@ theorem card_embedding_eq {α β : Type*} [Fintype α] [Fintype β] [emb : Finty
   · letI := Fintype.ofEquiv _ e.symm
     rw [← card_congr (Equiv.embeddingCongr e (Equiv.refl β)), ih, card_congr e]
   · rw [card_pempty, Nat.descFactorial_zero, card_eq_one_iff]
-    exact ⟨Embedding.ofIsEmpty, fun x ↦ FunLike.ext _ _ isEmptyElim⟩
+    exact ⟨Embedding.ofIsEmpty, fun x ↦ DFunLike.ext _ _ isEmptyElim⟩
   · classical
     dsimp only at ih
     rw [card_option, Nat.descFactorial_succ, card_congr (Embedding.optionEmbeddingEquiv γ β),

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -120,7 +120,7 @@ instead of linearly increasing the work per `MyHom`-related declaration.
 -- attribute [instance, priority 10] coe_fn_trans
 
 /-- The class `DFunLike F α β` expresses that terms of type `F` have an
-injective coercion to functions from `α` to `β`.
+injective coercion to (dependent) functions from `α` to `β`.
 
 This typeclass is used in the definition of the homomorphism typeclasses,
 such as `ZeroHomClass`, `MulHomClass`, `MonoidHomClass`, ....

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -13,7 +13,7 @@ import Mathlib.Util.CompileInductive
 
 This typeclass is primarily for use by homomorphisms like `MonoidHom` and `LinearMap`.
 
-## Basic usage of `FunLike`
+## Basic usage of `DFunLike`
 
 A typical type of morphisms should be declared as:
 ```
@@ -26,14 +26,14 @@ namespace MyHom
 variables (A B : Type*) [MyClass A] [MyClass B]
 
 -- This instance is optional if you follow the "morphism class" design below:
-instance : FunLike (MyHom A B) A (λ _, B) :=
+instance : DFunLike (MyHom A B) A (λ _, B) :=
   { coe := MyHom.toFun, coe_injective' := λ f g h, by cases f; cases g; congr' }
 
 /-- Helper instance for when there's too many metavariables to apply
-`FunLike.coe` directly. -/
+`DFunLike.coe` directly. -/
 instance : CoeFun (MyHom A B) (λ _, A → B) := ⟨MyHom.toFun⟩
 
-@[ext] theorem ext {f g : MyHom A B} (h : ∀ x, f x = g x) : f = g := FunLike.ext f g h
+@[ext] theorem ext {f g : MyHom A B} (h : ∀ x, f x = g x) : f = g := DFunLike.ext f g h
 
 /-- Copy of a `MyHom` with a new `toFun` equal to the old one. Useful to fix definitional
 equalities. -/
@@ -47,10 +47,10 @@ end MyHom
 This file will then provide a `CoeFun` instance and various
 extensionality and simp lemmas.
 
-## Morphism classes extending `FunLike`
+## Morphism classes extending `DFunLike`
 
-The `FunLike` design provides further benefits if you put in a bit more work.
-The first step is to extend `FunLike` to create a class of those types satisfying
+The `DFunLike` design provides further benefits if you put in a bit more work.
+The first step is to extend `DFunLike` to create a class of those types satisfying
 the axioms of your new type of morphisms.
 Continuing the example above:
 
@@ -58,14 +58,14 @@ Continuing the example above:
 /-- `MyHomClass F A B` states that `F` is a type of `MyClass.op`-preserving morphisms.
 You should extend this class when you extend `MyHom`. -/
 class MyHomClass (F : Type*) (A B : outParam <| Type*) [MyClass A] [MyClass B]
-  extends FunLike F A (λ _, B) :=
+  extends DFunLike F A (λ _, B) :=
 (map_op : ∀ (f : F) (x y : A), f (MyClass.op x y) = MyClass.op (f x) (f y))
 
 @[simp] lemma map_op {F A B : Type*} [MyClass A] [MyClass B] [MyHomClass F A B]
   (f : F) (x y : A) : f (MyClass.op x y) = MyClass.op (f x) (f y) :=
 MyHomClass.map_op
 
--- You can replace `MyHom.FunLike` with the below instance:
+-- You can replace `MyHom.DFunLike` with the below instance:
 instance : MyHomClass (MyHom A B) A B :=
   { coe := MyHom.toFun,
     coe_injective' := λ f g h, by cases f; cases g; congr',
@@ -90,7 +90,7 @@ class CoolerHomClass (F : Type*) (A B : outParam <| Type*) [CoolClass A] [CoolCl
   (f : F) : f CoolClass.cool = CoolClass.cool :=
 MyHomClass.map_op
 
--- You can also replace `MyHom.FunLike` with the below instance:
+-- You can also replace `MyHom.DFunLike` with the below instance:
 instance : CoolerHomClass (CoolHom A B) A B :=
   { coe := CoolHom.toFun,
     coe_injective' := λ f g h, by cases f; cases g; congr',
@@ -114,111 +114,111 @@ instead of linearly increasing the work per `MyHom`-related declaration.
 -/
 
 -- This instance should have low priority, to ensure we follow the chain
--- `FunLike → CoeFun`
+-- `DFunLike → CoeFun`
 -- Porting note: this is an elaboration detail from Lean 3, we are going to disable it
 -- until it is clearer what the Lean 4 elaborator needs.
 -- attribute [instance, priority 10] coe_fn_trans
 
-/-- The class `FunLike F α β` expresses that terms of type `F` have an
+/-- The class `DFunLike F α β` expresses that terms of type `F` have an
 injective coercion to functions from `α` to `β`.
 
 This typeclass is used in the definition of the homomorphism typeclasses,
 such as `ZeroHomClass`, `MulHomClass`, `MonoidHomClass`, ....
 -/
 @[notation_class * toFun Simps.findCoercionArgs]
-class FunLike (F : Sort*) (α : outParam (Sort*)) (β : outParam <| α → Sort*) where
+class DFunLike (F : Sort*) (α : outParam (Sort*)) (β : outParam <| α → Sort*) where
   /-- The coercion from `F` to a function. -/
   coe : F → ∀ a : α, β a
   /-- The coercion to functions must be injective. -/
   coe_injective' : Function.Injective coe
-#align fun_like FunLike
+#align fun_like DFunLike
 
 -- https://github.com/leanprover/lean4/issues/2096
-compile_def% FunLike.coe
+compile_def% DFunLike.coe
 
 section Dependent
 
-/-! ### `FunLike F α β` where `β` depends on `a : α` -/
+/-! ### `DFunLike F α β` where `β` depends on `a : α` -/
 
 variable (F α : Sort*) (β : α → Sort*)
 
-namespace FunLike
+namespace DFunLike
 
-variable {F α β} [i : FunLike F α β]
+variable {F α β} [i : DFunLike F α β]
 
 instance (priority := 100) hasCoeToFun : CoeFun F (fun _ ↦ ∀ a : α, β a) where
-  coe := @FunLike.coe _ _ β _ -- need to make explicit to beta reduce for non-dependent functions
+  coe := @DFunLike.coe _ _ β _ -- need to make explicit to beta reduce for non-dependent functions
 
 #eval Lean.Elab.Command.liftTermElabM do
-  Std.Tactic.Coe.registerCoercion ``FunLike.coe
+  Std.Tactic.Coe.registerCoercion ``DFunLike.coe
     (some { numArgs := 5, coercee := 4, type := .coeFun })
 
 -- @[simp] -- porting note: this loops in lean 4
-theorem coe_eq_coe_fn : (FunLike.coe (F := F)) = (fun f => ↑f) := rfl
-#align fun_like.coe_eq_coe_fn FunLike.coe_eq_coe_fn
+theorem coe_eq_coe_fn : (DFunLike.coe (F := F)) = (fun f => ↑f) := rfl
+#align fun_like.coe_eq_coe_fn DFunLike.coe_eq_coe_fn
 
 theorem coe_injective : Function.Injective (fun f : F ↦ (f : ∀ a : α, β a)) :=
-  FunLike.coe_injective'
-#align fun_like.coe_injective FunLike.coe_injective
+  DFunLike.coe_injective'
+#align fun_like.coe_injective DFunLike.coe_injective
 
 @[simp]
 theorem coe_fn_eq {f g : F} : (f : ∀ a : α, β a) = (g : ∀ a : α, β a) ↔ f = g :=
-  ⟨fun h ↦ FunLike.coe_injective' h, fun h ↦ by cases h; rfl⟩
-#align fun_like.coe_fn_eq FunLike.coe_fn_eq
+  ⟨fun h ↦ DFunLike.coe_injective' h, fun h ↦ by cases h; rfl⟩
+#align fun_like.coe_fn_eq DFunLike.coe_fn_eq
 
 theorem ext' {f g : F} (h : (f : ∀ a : α, β a) = (g : ∀ a : α, β a)) : f = g :=
-  FunLike.coe_injective' h
-#align fun_like.ext' FunLike.ext'
+  DFunLike.coe_injective' h
+#align fun_like.ext' DFunLike.ext'
 
 theorem ext'_iff {f g : F} : f = g ↔ (f : ∀ a : α, β a) = (g : ∀ a : α, β a) :=
   coe_fn_eq.symm
-#align fun_like.ext'_iff FunLike.ext'_iff
+#align fun_like.ext'_iff DFunLike.ext'_iff
 
 theorem ext (f g : F) (h : ∀ x : α, f x = g x) : f = g :=
-  FunLike.coe_injective' (funext h)
-#align fun_like.ext FunLike.ext
+  DFunLike.coe_injective' (funext h)
+#align fun_like.ext DFunLike.ext
 
 theorem ext_iff {f g : F} : f = g ↔ ∀ x, f x = g x :=
   coe_fn_eq.symm.trans Function.funext_iff
-#align fun_like.ext_iff FunLike.ext_iff
+#align fun_like.ext_iff DFunLike.ext_iff
 
 protected theorem congr_fun {f g : F} (h₁ : f = g) (x : α) : f x = g x :=
   congr_fun (congr_arg _ h₁) x
-#align fun_like.congr_fun FunLike.congr_fun
+#align fun_like.congr_fun DFunLike.congr_fun
 
 theorem ne_iff {f g : F} : f ≠ g ↔ ∃ a, f a ≠ g a :=
   ext_iff.not.trans not_forall
-#align fun_like.ne_iff FunLike.ne_iff
+#align fun_like.ne_iff DFunLike.ne_iff
 
 theorem exists_ne {f g : F} (h : f ≠ g) : ∃ x, f x ≠ g x :=
   ne_iff.mp h
-#align fun_like.exists_ne FunLike.exists_ne
+#align fun_like.exists_ne DFunLike.exists_ne
 
 /-- This is not an instance to avoid slowing down every single `Subsingleton` typeclass search.-/
 lemma subsingleton_cod [∀ a, Subsingleton (β a)] : Subsingleton F :=
   ⟨fun _ _ ↦ coe_injective <| Subsingleton.elim _ _⟩
-#align fun_like.subsingleton_cod FunLike.subsingleton_cod
+#align fun_like.subsingleton_cod DFunLike.subsingleton_cod
 
-end FunLike
+end DFunLike
 
 end Dependent
 
 section NonDependent
 
-/-! ### `FunLike F α (λ _, β)` where `β` does not depend on `a : α` -/
+/-! ### `DFunLike F α (λ _, β)` where `β` does not depend on `a : α` -/
 
-variable {F α β : Sort*} [i : FunLike F α fun _ ↦ β]
+variable {F α β : Sort*} [i : DFunLike F α fun _ ↦ β]
 
-namespace FunLike
+namespace DFunLike
 
 protected theorem congr {f g : F} {x y : α} (h₁ : f = g) (h₂ : x = y) : f x = g y :=
   congr (congr_arg _ h₁) h₂
-#align fun_like.congr FunLike.congr
+#align fun_like.congr DFunLike.congr
 
 protected theorem congr_arg (f : F) {x y : α} (h₂ : x = y) : f x = f y :=
   congr_arg _ h₂
-#align fun_like.congr_arg FunLike.congr_arg
+#align fun_like.congr_arg DFunLike.congr_arg
 
-end FunLike
+end DFunLike
 
 end NonDependent

--- a/Mathlib/Data/FunLike/Embedding.lean
+++ b/Mathlib/Data/FunLike/Embedding.lean
@@ -34,7 +34,7 @@ instance : EmbeddingLike (MyEmbedding A B) A B :=
 /-- Helper instance for when there's too many metavariables to `EmbeddingLike.coe` directly. -/
 instance : CoeFun (MyEmbedding A B) (λ _, A → B) := ⟨MyEmbedding.toFun⟩
 
-@[ext] theorem ext {f g : MyEmbedding A B} (h : ∀ x, f x = g x) : f = g := FunLike.ext f g h
+@[ext] theorem ext {f g : MyEmbedding A B} (h : ∀ x, f x = g x) : f = g := DFunLike.ext f g h
 
 /-- Copy of a `MyEmbedding` with a new `toFun` equal to the old one. Useful to fix definitional
 equalities. -/
@@ -131,7 +131,7 @@ instead of linearly increasing the work per `MyEmbedding`-related declaration.
 /-- The class `EmbeddingLike F α β` expresses that terms of type `F` have an
 injective coercion to injective functions `α ↪ β`.
 -/
-class EmbeddingLike (F : Sort*) (α β : outParam (Sort*)) extends FunLike F α fun _ ↦ β where
+class EmbeddingLike (F : Sort*) (α β : outParam (Sort*)) extends DFunLike F α fun _ ↦ β where
   /-- The coercion to functions must produce injective functions. -/
   injective' : ∀ f : F, Function.Injective (coe f)
 #align embedding_like EmbeddingLike

--- a/Mathlib/Data/FunLike/Equiv.lean
+++ b/Mathlib/Data/FunLike/Equiv.lean
@@ -33,9 +33,9 @@ instance : EquivLike (MyIso A B) A (λ _, B) :=
     coe_injective' := λ f g h, by cases f; cases g; congr' }
 
 /-- Helper instance for when there's too many metavariables to apply `EquivLike.coe` directly. -/
-instance : CoeFun (MyIso A B) := FunLike.instCoeFunForAll
+instance : CoeFun (MyIso A B) := DFunLike.instCoeFunForAll
 
-@[ext] theorem ext {f g : MyIso A B} (h : ∀ x, f x = g x) : f = g := FunLike.ext f g h
+@[ext] theorem ext {f g : MyIso A B} (h : ∀ x, f x = g x) : f = g := DFunLike.ext f g h
 
 /-- Copy of a `MyIso` with a new `toFun` equal to the old one. Useful to fix definitional
 equalities. -/
@@ -228,7 +228,7 @@ theorem comp_bijective (f : α → β) (e : F) : Function.Bijective (e ∘ f) �
 
 /-- This is not an instance to avoid slowing down every single `Subsingleton` typeclass search.-/
 lemma subsingleton_dom [Subsingleton β] : Subsingleton F :=
-  ⟨fun f g ↦ FunLike.ext f g fun _ ↦ (right_inv f).injective <| Subsingleton.elim _ _⟩
+  ⟨fun f g ↦ DFunLike.ext f g fun _ ↦ (right_inv f).injective <| Subsingleton.elim _ _⟩
 #align equiv_like.subsingleton_dom EquivLike.subsingleton_dom
 
 end EquivLike

--- a/Mathlib/Data/FunLike/Fintype.lean
+++ b/Mathlib/Data/FunLike/Fintype.lean
@@ -10,20 +10,20 @@ import Mathlib.Data.FunLike.Basic
 #align_import data.fun_like.fintype from "leanprover-community/mathlib"@"f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c"
 
 /-!
-# Finiteness of `FunLike` types
+# Finiteness of `DFunLike` types
 
-We show a type `F` with a `FunLike F α β` is finite if both `α` and `β` are finite.
+We show a type `F` with a `DFunLike F α β` is finite if both `α` and `β` are finite.
 This corresponds to the following two pairs of declarations:
 
- * `FunLike.fintype` is a definition stating all `FunLike`s are finite if their domain and
+ * `DFunLike.fintype` is a definition stating all `DFunLike`s are finite if their domain and
    codomain are.
- * `FunLike.finite` is a lemma stating all `FunLike`s are finite if their domain and
+ * `DFunLike.finite` is a lemma stating all `DFunLike`s are finite if their domain and
    codomain are.
- * `FunLike.fintype'` is a non-dependent version of `FunLike.fintype` and
- * `FunLike.finite` is a non-dependent version of `FunLike.finite`, because dependent instances
+ * `DFunLike.fintype'` is a non-dependent version of `DFunLike.fintype` and
+ * `DFunLike.finite` is a non-dependent version of `DFunLike.finite`, because dependent instances
    are harder to infer.
 
-You can use these to produce instances for specific `FunLike` types.
+You can use these to produce instances for specific `DFunLike` types.
 (Although there might be options for `Fintype` instances with better definitional behaviour.)
 They can't be instances themselves since they can cause loops.
 -/
@@ -31,49 +31,49 @@ They can't be instances themselves since they can cause loops.
 -- porting notes: `Type` is a reserved word, switched to `Type'`
 section Type'
 
-variable (F G : Type*) {α γ : Type*} {β : α → Type*} [FunLike F α β] [FunLike G α fun _ => γ]
+variable (F G : Type*) {α γ : Type*} {β : α → Type*} [DFunLike F α β] [DFunLike G α fun _ => γ]
 
-/-- All `FunLike`s are finite if their domain and codomain are.
+/-- All `DFunLike`s are finite if their domain and codomain are.
 
-This is not an instance because specific `FunLike` types might have a better-suited definition.
+This is not an instance because specific `DFunLike` types might have a better-suited definition.
 
-See also `FunLike.finite`.
+See also `DFunLike.finite`.
 -/
-noncomputable def FunLike.fintype [DecidableEq α] [Fintype α] [∀ i, Fintype (β i)] : Fintype F :=
-  Fintype.ofInjective _ FunLike.coe_injective
-#align fun_like.fintype FunLike.fintype
+noncomputable def DFunLike.fintype [DecidableEq α] [Fintype α] [∀ i, Fintype (β i)] : Fintype F :=
+  Fintype.ofInjective _ DFunLike.coe_injective
+#align fun_like.fintype DFunLike.fintype
 
-/-- All `FunLike`s are finite if their domain and codomain are.
+/-- All `DFunLike`s are finite if their domain and codomain are.
 
-Non-dependent version of `FunLike.fintype` that might be easier to infer.
-This is not an instance because specific `FunLike` types might have a better-suited definition.
+Non-dependent version of `DFunLike.fintype` that might be easier to infer.
+This is not an instance because specific `DFunLike` types might have a better-suited definition.
 -/
-noncomputable def FunLike.fintype' [DecidableEq α] [Fintype α] [Fintype γ] : Fintype G :=
-  FunLike.fintype G
-#align fun_like.fintype' FunLike.fintype'
+noncomputable def DFunLike.fintype' [DecidableEq α] [Fintype α] [Fintype γ] : Fintype G :=
+  DFunLike.fintype G
+#align fun_like.fintype' DFunLike.fintype'
 
 end Type'
 
 -- porting notes: `Sort` is a reserved word, switched to `Sort'`
 section Sort'
 
-variable (F G : Sort*) {α γ : Sort*} {β : α → Sort*} [FunLike F α β] [FunLike G α fun _ => γ]
+variable (F G : Sort*) {α γ : Sort*} {β : α → Sort*} [DFunLike F α β] [DFunLike G α fun _ => γ]
 
-/-- All `FunLike`s are finite if their domain and codomain are.
+/-- All `DFunLike`s are finite if their domain and codomain are.
 
 Can't be an instance because it can cause infinite loops.
 -/
-theorem FunLike.finite [Finite α] [∀ i, Finite (β i)] : Finite F :=
-  Finite.of_injective _ FunLike.coe_injective
-#align fun_like.finite FunLike.finite
+theorem DFunLike.finite [Finite α] [∀ i, Finite (β i)] : Finite F :=
+  Finite.of_injective _ DFunLike.coe_injective
+#align fun_like.finite DFunLike.finite
 
-/-- All `FunLike`s are finite if their domain and codomain are.
+/-- All `DFunLike`s are finite if their domain and codomain are.
 
-Non-dependent version of `FunLike.finite` that might be easier to infer.
+Non-dependent version of `DFunLike.finite` that might be easier to infer.
 Can't be an instance because it can cause infinite loops.
 -/
-theorem FunLike.finite' [Finite α] [Finite γ] : Finite G :=
-  FunLike.finite G
-#align fun_like.finite' FunLike.finite'
+theorem DFunLike.finite' [Finite α] [Finite γ] : Finite G :=
+  DFunLike.finite G
+#align fun_like.finite' DFunLike.finite'
 
 end Sort'

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -311,7 +311,7 @@ if `f 1 = g 1`. -/
 @[ext high]
 theorem ext_int [AddMonoid A] {f g : ℤ →+ A} (h1 : f 1 = g 1) : f = g :=
   have : f.comp (Int.ofNatHom : ℕ →+ ℤ) = g.comp (Int.ofNatHom : ℕ →+ ℤ) := ext_nat' _ _ h1
-  have this' : ∀ n : ℕ, f n = g n := FunLike.ext_iff.1 this
+  have this' : ∀ n : ℕ, f n = g n := DFunLike.ext_iff.1 this
   ext fun n => match n with
   | (n : ℕ) => this' n
   | .negSucc n => eq_on_neg _ _ (this' <| n + 1)
@@ -327,7 +327,7 @@ end AddMonoidHom
 
 theorem eq_intCast' [AddGroupWithOne α] [AddMonoidHomClass F ℤ α] (f : F) (h₁ : f 1 = 1) :
     ∀ n : ℤ, f n = n :=
-  FunLike.ext_iff.1 <| (f : ℤ →+ α).eq_int_castAddHom h₁
+  DFunLike.ext_iff.1 <| (f : ℤ →+ α).eq_int_castAddHom h₁
 #align eq_int_cast' eq_intCast'
 
 @[simp] lemma zsmul_one [AddGroupWithOne α] (n : ℤ) : n • (1 : α) = n := by cases n <;> simp
@@ -354,10 +354,10 @@ theorem ext_mint {f g : Multiplicative ℤ →* M} (h1 : f (ofAdd 1) = g (ofAdd 
 theorem ext_int {f g : ℤ →* M} (h_neg_one : f (-1) = g (-1))
     (h_nat : f.comp Int.ofNatHom.toMonoidHom = g.comp Int.ofNatHom.toMonoidHom) : f = g := by
   ext (x | x)
-  · exact (FunLike.congr_fun h_nat x : _)
+  · exact (DFunLike.congr_fun h_nat x : _)
   · rw [Int.negSucc_eq, ← neg_one_mul, f.map_mul, g.map_mul]
     congr 1
-    exact mod_cast (FunLike.congr_fun h_nat (x + 1) : _)
+    exact mod_cast (DFunLike.congr_fun h_nat (x + 1) : _)
 #align monoid_hom.ext_int MonoidHom.ext_int
 
 end MonoidHom
@@ -372,7 +372,7 @@ theorem ext_int {f g : ℤ →*₀ M} (h_neg_one : f (-1) = g (-1))
     (h_nat : f.comp Int.ofNatHom.toMonoidWithZeroHom = g.comp Int.ofNatHom.toMonoidWithZeroHom) :
     f = g :=
   toMonoidHom_injective <| MonoidHom.ext_int h_neg_one <|
-    MonoidHom.ext (FunLike.congr_fun h_nat : _)
+    MonoidHom.ext (DFunLike.congr_fun h_nat : _)
 #align monoid_with_zero_hom.ext_int MonoidWithZeroHom.ext_int
 
 end MonoidWithZeroHom
@@ -380,9 +380,9 @@ end MonoidWithZeroHom
 /-- If two `MonoidWithZeroHom`s agree on `-1` and the _positive_ naturals then they are equal. -/
 theorem ext_int' [MonoidWithZero α] [MonoidWithZeroHomClass F ℤ α] {f g : F}
     (h_neg_one : f (-1) = g (-1)) (h_pos : ∀ n : ℕ, 0 < n → f n = g n) : f = g :=
-  (FunLike.ext _ _) fun n =>
+  (DFunLike.ext _ _) fun n =>
     haveI :=
-      FunLike.congr_fun
+      DFunLike.congr_fun
         (@MonoidWithZeroHom.ext_int _ _ (f : ℤ →*₀ α) (g : ℤ →*₀ α) h_neg_one <|
           MonoidWithZeroHom.ext_nat (h_pos _))
         n

--- a/Mathlib/Data/MvPolynomial/Basic.lean
+++ b/Mathlib/Data/MvPolynomial/Basic.lean
@@ -574,7 +574,7 @@ section Coeff
 
 /-- The coefficient of the monomial `m` in the multi-variable polynomial `p`. -/
 def coeff (m : σ →₀ ℕ) (p : MvPolynomial σ R) : R :=
-  @FunLike.coe ((σ →₀ ℕ) →₀ R) _ _ _ p m
+  @DFunLike.coe ((σ →₀ ℕ) →₀ R) _ _ _ p m
   -- porting note: I changed this from `@CoeFun.coe _ _ (MonoidAlgebra.coeFun _ _) p m` because
   -- I think it should work better syntactically. They are defeq.
 #align mv_polynomial.coeff MvPolynomial.coeff
@@ -1413,7 +1413,7 @@ def mapAlgHom [CommSemiring S₂] [Algebra R S₁] [Algebra R S₂] (f : S₁ �
       have h₂ : algebraMap R (MvPolynomial σ S₂) r = C (algebraMap R S₂ r) := rfl
       simp_rw [OneHom.toFun_eq_coe]
       -- porting note: we're missing some `simp` lemmas like `MonoidHom.coe_toOneHom`
-      change @FunLike.coe (_ →+* _) _ _ _ _ _ = _
+      change @DFunLike.coe (_ →+* _) _ _ _ _ _ = _
       rw [h₁, h₂, map, eval₂Hom_C, RingHom.comp_apply, AlgHom.coe_toRingHom, AlgHom.commutes] }
 #align mv_polynomial.map_alg_hom MvPolynomial.mapAlgHom
 

--- a/Mathlib/Data/Nat/Cast/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Basic.lean
@@ -96,7 +96,7 @@ section AddMonoidHomClass
 variable {A B F : Type*} [AddMonoidWithOne B]
 
 theorem ext_nat' [AddMonoid A] [AddMonoidHomClass F ℕ A] (f g : F) (h : f 1 = g 1) : f = g :=
-  FunLike.ext f g <| by
+  DFunLike.ext f g <| by
     intro n
     induction n with
     | zero => simp_rw [Nat.zero_eq, map_zero f, map_zero g]
@@ -141,7 +141,7 @@ variable {A F : Type*} [MulZeroOneClass A]
 /-- If two `MonoidWithZeroHom`s agree on the positive naturals they are equal. -/
 theorem ext_nat'' [MonoidWithZeroHomClass F ℕ A] (f g : F) (h_pos : ∀ {n : ℕ}, 0 < n → f n = g n) :
     f = g := by
-  apply FunLike.ext
+  apply DFunLike.ext
   rintro (_ | n)
   · simp [map_zero f, map_zero g]
   · exact h_pos n.succ_pos

--- a/Mathlib/Data/PEquiv.lean
+++ b/Mathlib/Data/PEquiv.lean
@@ -65,7 +65,7 @@ variable {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
 
 open Function Option
 
-instance : FunLike (α ≃. β) α fun _ => Option β :=
+instance : DFunLike (α ≃. β) α fun _ => Option β :=
   { coe := toFun
     coe_injective' := by
       rintro ⟨f₁, f₂, hf⟩ ⟨g₁, g₂, hg⟩ (rfl : f₁ = g₁)
@@ -81,11 +81,11 @@ theorem coe_mk_apply (f₁ : α → Option β) (f₂ : β → Option α) (h) (x 
 #align pequiv.coe_mk_apply PEquiv.coe_mk_apply
 
 @[ext] theorem ext {f g : α ≃. β} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align pequiv.ext PEquiv.ext
 
 theorem ext_iff {f g : α ≃. β} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align pequiv.ext_iff PEquiv.ext_iff
 
 /-- The identity map as a partial equivalence. -/

--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -673,7 +673,7 @@ theorem coeff_ofFinsupp (p) : coeff (⟨p⟩ : R[X]) = p := by rw [coeff]
 theorem coeff_injective : Injective (coeff : R[X] → ℕ → R) := by
   rintro ⟨p⟩ ⟨q⟩
   -- Porting note: `ofFinsupp.injEq` is required.
-  simp only [coeff, FunLike.coe_fn_eq, imp_self, ofFinsupp.injEq]
+  simp only [coeff, DFunLike.coe_fn_eq, imp_self, ofFinsupp.injEq]
 #align polynomial.coeff_injective Polynomial.coeff_injective
 
 @[simp]
@@ -825,9 +825,9 @@ theorem forall_eq_iff_forall_eq : (∀ f g : R[X], f = g) ↔ ∀ a b : R, a = b
 theorem ext_iff {p q : R[X]} : p = q ↔ ∀ n, coeff p n = coeff q n := by
   rcases p with ⟨⟩
   rcases q with ⟨⟩
-  -- Porting note: Was `simp [coeff, FunLike.ext_iff]`
+  -- Porting note: Was `simp [coeff, DFunLike.ext_iff]`
   simp only [ofFinsupp.injEq, coeff._eq_1]
-  exact FunLike.ext_iff (F := ℕ →₀ R)
+  exact DFunLike.ext_iff (F := ℕ →₀ R)
 #align polynomial.ext_iff Polynomial.ext_iff
 
 @[ext]
@@ -856,7 +856,7 @@ theorem addHom_ext {M : Type*} [AddMonoid M] {f g : R[X] →+ M}
 @[ext high]
 theorem addHom_ext' {M : Type*} [AddMonoid M] {f g : R[X] →+ M}
     (h : ∀ n, f.comp (monomial n).toAddMonoidHom = g.comp (monomial n).toAddMonoidHom) : f = g :=
-  addHom_ext fun n => FunLike.congr_fun (h n)
+  addHom_ext fun n => DFunLike.congr_fun (h n)
 #align polynomial.add_hom_ext' Polynomial.addHom_ext'
 
 @[ext high]

--- a/Mathlib/Data/Polynomial/Eval.lean
+++ b/Mathlib/Data/Polynomial/Eval.lean
@@ -1092,7 +1092,7 @@ theorem coe_evalRingHom (r : R) : (evalRingHom r : R[X] → R) = eval r :=
 #align polynomial.coe_eval_ring_hom Polynomial.coe_evalRingHom
 
 theorem evalRingHom_zero : evalRingHom 0 = constantCoeff :=
-  FunLike.ext _ _ fun p => p.coeff_zero_eq_eval_zero.symm
+  DFunLike.ext _ _ fun p => p.coeff_zero_eq_eval_zero.symm
 #align polynomial.eval_ring_hom_zero Polynomial.evalRingHom_zero
 
 @[simp]

--- a/Mathlib/Data/Polynomial/Module.lean
+++ b/Mathlib/Data/Polynomial/Module.lean
@@ -202,8 +202,8 @@ namespace PolynomialModule
 noncomputable instance : Module S (PolynomialModule R M) :=
   Finsupp.module ℕ M
 
-instance funLike : DFunLike (PolynomialModule R M) ℕ fun _ => M :=
-  Finsupp.funLike
+instance instDFunLike : DFunLike (PolynomialModule R M) ℕ fun _ => M :=
+  Finsupp.instDFunLike
 
 instance : CoeFun (PolynomialModule R M) fun _ => ℕ → M :=
   Finsupp.coeFun

--- a/Mathlib/Data/Polynomial/Module.lean
+++ b/Mathlib/Data/Polynomial/Module.lean
@@ -202,7 +202,7 @@ namespace PolynomialModule
 noncomputable instance : Module S (PolynomialModule R M) :=
   Finsupp.module ℕ M
 
-instance funLike : FunLike (PolynomialModule R M) ℕ fun _ => M :=
+instance funLike : DFunLike (PolynomialModule R M) ℕ fun _ => M :=
   Finsupp.funLike
 
 instance : CoeFun (PolynomialModule R M) fun _ => ℕ → M :=

--- a/Mathlib/Data/Rat/Cast/Defs.lean
+++ b/Mathlib/Data/Rat/Cast/Defs.lean
@@ -199,7 +199,7 @@ variable {M₀ : Type*} [MonoidWithZero M₀] [MonoidWithZeroHomClass F ℚ M₀
 
 /-- If `f` and `g` agree on the integers then they are equal `φ`. -/
 theorem ext_rat' (h : ∀ m : ℤ, f m = g m) : f = g :=
-  (FunLike.ext f g) fun r => by
+  (DFunLike.ext f g) fun r => by
     rw [← r.num_div_den, div_eq_mul_inv, map_mul, map_mul, h, ← Int.cast_ofNat,
       eq_on_inv₀ f g]
     apply h
@@ -211,14 +211,14 @@ See note [partially-applied ext lemmas] for why `comp` is used here. -/
 @[ext]
 theorem ext_rat {f g : ℚ →*₀ M₀}
     (h : f.comp (Int.castRingHom ℚ : ℤ →*₀ ℚ) = g.comp (Int.castRingHom ℚ)) : f = g :=
-  ext_rat' <| FunLike.congr_fun h
+  ext_rat' <| DFunLike.congr_fun h
 #align monoid_with_zero_hom.ext_rat MonoidWithZeroHom.ext_rat
 
 /-- Positive integer values of a morphism `φ` and its value on `-1` completely determine `φ`. -/
 theorem ext_rat_on_pnat (same_on_neg_one : f (-1) = g (-1))
     (same_on_pnat : ∀ n : ℕ, 0 < n → f n = g n) : f = g :=
   ext_rat' <|
-    FunLike.congr_fun <|
+    DFunLike.congr_fun <|
       show
         (f : ℚ →*₀ M₀).comp (Int.castRingHom ℚ : ℤ →*₀ ℚ) =
           (g : ℚ →*₀ M₀).comp (Int.castRingHom ℚ : ℤ →*₀ ℚ)

--- a/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
+++ b/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
@@ -164,15 +164,15 @@ theorem map_add_one : ∀ x, f (x + 1) = f x + 1 :=
 theorem map_one_add (x : ℝ) : f (1 + x) = 1 + f x := by rw [add_comm, map_add_one, add_comm 1]
 #align circle_deg1_lift.map_one_add CircleDeg1Lift.map_one_add
 
-#noalign circle_deg1_lift.coe_inj -- Use `FunLike.coe_inj`
+#noalign circle_deg1_lift.coe_inj -- Use `DFunLike.coe_inj`
 
 @[ext]
 theorem ext ⦃f g : CircleDeg1Lift⦄ (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align circle_deg1_lift.ext CircleDeg1Lift.ext
 
 theorem ext_iff {f g : CircleDeg1Lift} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align circle_deg1_lift.ext_iff CircleDeg1Lift.ext_iff
 
 instance : Monoid CircleDeg1Lift where
@@ -182,7 +182,7 @@ instance : Monoid CircleDeg1Lift where
   one := ⟨.id, fun _ => rfl⟩
   mul_one f := rfl
   one_mul f := rfl
-  mul_assoc f₁ f₂ f₃ := FunLike.coe_injective rfl
+  mul_assoc f₁ f₂ f₃ := DFunLike.coe_injective rfl
 
 instance : Inhabited CircleDeg1Lift := ⟨1⟩
 

--- a/Mathlib/FieldTheory/Extension.lean
+++ b/Mathlib/FieldTheory/Extension.lean
@@ -175,7 +175,7 @@ theorem exists_algHom_adjoin_of_splits_of_aeval : ∃ φ : adjoin F S →ₐ[F] 
   rw [isAlgebraic_iff_isIntegral, isIntegral_iff] at ix
   obtain ⟨φ, hφ⟩ := exists_algHom_adjoin_of_splits hK ((algHomAdjoinIntegralEquiv F ix).symm
     ⟨y, mem_aroots.mpr ⟨minpoly.ne_zero ix, hy⟩⟩) (adjoin_simple_le_iff.mpr hx)
-  exact ⟨φ, (FunLike.congr_fun hφ <| AdjoinSimple.gen F x).trans <|
+  exact ⟨φ, (DFunLike.congr_fun hφ <| AdjoinSimple.gen F x).trans <|
     algHomAdjoinIntegralEquiv_symm_apply_gen F ix _⟩
 
 theorem exists_algHom_of_adjoin_splits_of_aeval : ∃ φ : E →ₐ[F] K, φ x = y :=

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -299,7 +299,7 @@ theorem sum_pow_units [DecidableEq K] (i : ℕ) :
           · rw [Fintype.card_units, Nat.cast_sub,
               cast_card_eq_zero, Nat.cast_one, zero_sub]
             show 1 ≤ q; exact Fintype.card_pos_iff.mpr ⟨0⟩
-        rw [← forall_pow_eq_one_iff, FunLike.ext_iff]
+        rw [← forall_pow_eq_one_iff, DFunLike.ext_iff]
         apply forall_congr'; intro x; simp [Units.ext_iff]
 #align finite_field.sum_pow_units FiniteField.sum_pow_units
 

--- a/Mathlib/FieldTheory/Fixed.lean
+++ b/Mathlib/FieldTheory/Fixed.lean
@@ -314,7 +314,7 @@ theorem linearIndependent_toLinearMap (R : Type u) (A : Type v) (B : Type w) [Co
     LinearIndependent B (AlgHom.toLinearMap : (A →ₐ[R] B) → A →ₗ[R] B) :=
   have : LinearIndependent B (LinearMap.ltoFun R A B ∘ AlgHom.toLinearMap) :=
     ((linearIndependent_monoidHom A B).comp ((↑) : (A →ₐ[R] B) → A →* B) fun _ _ hfg =>
-        AlgHom.ext fun _ => FunLike.ext_iff.1 hfg _ :
+        AlgHom.ext fun _ => DFunLike.ext_iff.1 hfg _ :
       _)
   this.of_comp _
 #align linear_independent_to_linear_map linearIndependent_toLinearMap

--- a/Mathlib/FieldTheory/KrullTopology.lean
+++ b/Mathlib/FieldTheory/KrullTopology.lean
@@ -222,7 +222,7 @@ theorem krullTopology_t2 {K L : Type*} [Field K] [Field L] [Algebra K L]
     (h_int : Algebra.IsIntegral K L) : T2Space (L ≃ₐ[K] L) :=
   { t2 := fun f g hfg => by
       let φ := f⁻¹ * g
-      cases' FunLike.exists_ne hfg with x hx
+      cases' DFunLike.exists_ne hfg with x hx
       have hφx : φ x ≠ x := by
         apply ne_of_apply_ne f
         change f (f.symm (g x)) ≠ f x
@@ -263,7 +263,7 @@ theorem krullTopology_totallyDisconnected {K L : Type*} [Field K] [Field L] [Alg
   apply isTotallyDisconnected_of_isClopen_set
   intro σ τ h_diff
   have hστ : σ⁻¹ * τ ≠ 1 := by rwa [Ne.def, inv_mul_eq_one]
-  rcases FunLike.exists_ne hστ with ⟨x, hx : (σ⁻¹ * τ) x ≠ x⟩
+  rcases DFunLike.exists_ne hστ with ⟨x, hx : (σ⁻¹ * τ) x ≠ x⟩
   let E := IntermediateField.adjoin K ({x} : Set L)
   haveI := IntermediateField.adjoin.finiteDimensional (h_int x)
   refine' ⟨σ • E.fixingSubgroup,

--- a/Mathlib/FieldTheory/Minpoly/Field.lean
+++ b/Mathlib/FieldTheory/Minpoly/Field.lean
@@ -167,7 +167,7 @@ def rootsOfMinPolyPiType (φ : E →ₐ[F] K)
 
 theorem aux_inj_roots_of_min_poly : Injective (rootsOfMinPolyPiType F E K) := by
   intro f g h
-  suffices (f : E →ₗ[F] K) = g by rwa [FunLike.ext'_iff] at this ⊢
+  suffices (f : E →ₗ[F] K) = g by rwa [DFunLike.ext'_iff] at this ⊢
   rw [funext_iff] at h
   exact LinearMap.ext_on (FiniteDimensional.finBasis F E).span_eq fun e he =>
     Subtype.ext_iff.mp (h ⟨e, he⟩)

--- a/Mathlib/FieldTheory/Normal.lean
+++ b/Mathlib/FieldTheory/Normal.lean
@@ -273,7 +273,7 @@ theorem AlgHom.fieldRange_of_normal [Algebra F K] {E : IntermediateField F K} [N
 -- Porting note: this was `IsScalarTower F E E := by infer_instance`.
   letI : Algebra E E := Algebra.id E
   let g := f.restrictNormal' E
-  rw [← show E.val.comp ↑g = f from FunLike.ext_iff.mpr (f.restrictNormal_commutes E),
+  rw [← show E.val.comp ↑g = f from DFunLike.ext_iff.mpr (f.restrictNormal_commutes E),
     ← AlgHom.map_fieldRange, AlgEquiv.fieldRange_eq_top g, ← AlgHom.fieldRange_eq_map,
     IntermediateField.fieldRange_val]
 #align alg_hom.field_range_of_normal AlgHom.fieldRange_of_normal

--- a/Mathlib/FieldTheory/NormalClosure.lean
+++ b/Mathlib/FieldTheory/NormalClosure.lean
@@ -216,7 +216,7 @@ noncomputable def Algebra.IsAlgebraic.algHomEmbeddingOfSplits (alg : IsAlgebraic
   { toFun := (φ.comp <| inclusion <| normalClosure_le_iSup_adjoin alg).comp ∘
       (normalClosure.algHomEquiv F K L').symm
     inj' := fun _ _ h ↦ (normalClosure.algHomEquiv F K L').symm.injective <| by
-      rw [FunLike.ext'_iff] at h ⊢
+      rw [DFunLike.ext'_iff] at h ⊢
       exact (φ.comp _).injective.comp_left h }
 
 namespace IntermediateField

--- a/Mathlib/FieldTheory/RatFunc.lean
+++ b/Mathlib/FieldTheory/RatFunc.lean
@@ -690,7 +690,7 @@ theorem coe_mapRingHom_eq_coe_map [RingHomClass F R[X] S[X]] (φ : F) (hφ : R[X
 #align ratfunc.coe_map_ring_hom_eq_coe_map RatFunc.coe_mapRingHom_eq_coe_map
 
 set_option maxHeartbeats 300000 in
--- TODO: Generalize to `FunLike` classes,
+-- TODO: Generalize to `DFunLike` classes,
 /-- Lift a monoid with zero homomorphism `R[X] →*₀ G₀` to a `RatFunc R →*₀ G₀`
 on the condition that `φ` maps non zero divisors to non zero divisors,
 by mapping both the numerator and denominator and quotienting them. -/

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -636,7 +636,7 @@ lemma IsSeparable.of_equiv_equiv {A₁ B₁ A₂ B₂ : Type*} [Field A₁] [Fie
   haveI : IsScalarTower A₁ A₂ B₁ := IsScalarTower.of_algebraMap_eq
     (fun x ↦ by simp [RingHom.algebraMap_toAlgebra])
   let e : B₁ ≃ₐ[A₂] B₂ := { e₂ with commutes' := fun r ↦ by simpa [RingHom.algebraMap_toAlgebra]
-                                                  using FunLike.congr_fun he.symm (e₁.symm r) }
+                                                  using DFunLike.congr_fun he.symm (e₁.symm r) }
   haveI := isSeparable_tower_top_of_isSeparable A₁ A₂ B₁
   exact IsSeparable.of_algHom _ _ e.symm.toAlgHom
 

--- a/Mathlib/Geometry/Manifold/Algebra/LeftInvariantDerivation.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LeftInvariantDerivation.lean
@@ -62,12 +62,12 @@ theorem toDerivation_injective :
 
 instance : LinearMapClass (LeftInvariantDerivation I G) 𝕜 C^∞⟮I, G; 𝕜⟯ C^∞⟮I, G; 𝕜⟯ where
   coe f := f.toDerivation
-  coe_injective' _ _ h := toDerivation_injective <| FunLike.ext' h
+  coe_injective' _ _ h := toDerivation_injective <| DFunLike.ext' h
   map_add f := map_add f.1
   map_smulₛₗ f := map_smul f.1.1
 
 instance : CoeFun (LeftInvariantDerivation I G) fun _ => C^∞⟮I, G; 𝕜⟯ → C^∞⟮I, G; 𝕜⟯ :=
-  ⟨FunLike.coe⟩
+  ⟨DFunLike.coe⟩
 
 variable {M : Type*} [TopologicalSpace M] [ChartedSpace H M] {x : M} {r : 𝕜}
   {X Y : LeftInvariantDerivation I G} {f f' : C^∞⟮I, G; 𝕜⟯}
@@ -82,12 +82,12 @@ theorem toFun_eq_coe : X.toFun = ⇑X :=
 #noalign left_invariant_derivation.to_derivation_eq_coe
 
 theorem coe_injective :
-    @Function.Injective (LeftInvariantDerivation I G) (_ → C^∞⟮I, G; 𝕜⟯) FunLike.coe :=
-  FunLike.coe_injective
+    @Function.Injective (LeftInvariantDerivation I G) (_ → C^∞⟮I, G; 𝕜⟯) DFunLike.coe :=
+  DFunLike.coe_injective
 #align left_invariant_derivation.coe_injective LeftInvariantDerivation.coe_injective
 
 @[ext]
-theorem ext (h : ∀ f, X f = Y f) : X = Y := FunLike.ext _ _ h
+theorem ext (h : ∀ f, X f = Y f) : X = Y := DFunLike.ext _ _ h
 #align left_invariant_derivation.ext LeftInvariantDerivation.ext
 
 variable (X Y f)
@@ -215,7 +215,7 @@ variable (I G)
 /-- The coercion to function is a monoid homomorphism. -/
 @[simps]
 def coeFnAddMonoidHom : LeftInvariantDerivation I G →+ C^∞⟮I, G; 𝕜⟯ → C^∞⟮I, G; 𝕜⟯ :=
-  ⟨⟨FunLike.coe, coe_zero⟩, coe_add⟩
+  ⟨⟨DFunLike.coe, coe_zero⟩, coe_add⟩
 #align left_invariant_derivation.coe_fn_add_monoid_hom LeftInvariantDerivation.coeFnAddMonoidHom
 
 variable {I G}

--- a/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/Monoid.lean
@@ -289,7 +289,7 @@ instance : Inhabited (SmoothMonoidMorphism I I' G G') :=
 @[to_additive]
 instance : MonoidHomClass (SmoothMonoidMorphism I I' G G') G G' where
   coe a := a.toFun
-  coe_injective' f g h := by cases f; cases g; congr; exact FunLike.ext' h
+  coe_injective' f g h := by cases f; cases g; congr; exact DFunLike.ext' h
   map_one f := f.map_one
   map_mul f := f.map_mul
 

--- a/Mathlib/Geometry/Manifold/Algebra/SmoothFunctions.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/SmoothFunctions.lean
@@ -91,14 +91,14 @@ under pointwise multiplication.
 @[to_additive]
 instance semigroup {G : Type*} [Semigroup G] [TopologicalSpace G] [ChartedSpace H' G]
     [SmoothMul I' G] : Semigroup C^∞⟮I, N; I', G⟯ :=
-  FunLike.coe_injective.semigroup _ coe_mul
+  DFunLike.coe_injective.semigroup _ coe_mul
 #align smooth_map.semigroup SmoothMap.semigroup
 #align smooth_map.add_semigroup SmoothMap.addSemigroup
 
 @[to_additive]
 instance monoid {G : Type*} [Monoid G] [TopologicalSpace G] [ChartedSpace H' G]
     [SmoothMul I' G] : Monoid C^∞⟮I, N; I', G⟯ :=
-  FunLike.coe_injective.monoid _ coe_one coe_mul coe_pow
+  DFunLike.coe_injective.monoid _ coe_one coe_mul coe_pow
 #align smooth_map.monoid SmoothMap.monoid
 #align smooth_map.add_monoid SmoothMap.addMonoid
 
@@ -107,7 +107,7 @@ instance monoid {G : Type*} [Monoid G] [TopologicalSpace G] [ChartedSpace H' G]
   Similar to `AddMonoidHom.coeFn`."]
 def coeFnMonoidHom {G : Type*} [Monoid G] [TopologicalSpace G] [ChartedSpace H' G]
     [SmoothMul I' G] : C^∞⟮I, N; I', G⟯ →* N → G where
-  toFun := FunLike.coe
+  toFun := DFunLike.coe
   map_one' := coe_one
   map_mul' := coe_mul
 #align smooth_map.coe_fn_monoid_hom SmoothMap.coeFnMonoidHom
@@ -150,7 +150,7 @@ variable {I I'}
 @[to_additive]
 instance commMonoid {G : Type*} [CommMonoid G] [TopologicalSpace G] [ChartedSpace H' G]
     [SmoothMul I' G] : CommMonoid C^∞⟮I, N; I', G⟯ :=
-  FunLike.coe_injective.commMonoid _ coe_one coe_mul coe_pow
+  DFunLike.coe_injective.commMonoid _ coe_one coe_mul coe_pow
 #align smooth_map.comm_monoid SmoothMap.commMonoid
 #align smooth_map.add_comm_monoid SmoothMap.addCommMonoid
 

--- a/Mathlib/Geometry/Manifold/ContMDiffMap.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMap.lean
@@ -48,7 +48,7 @@ namespace ContMDiffMap
 
 variable {I} {I'} {M} {M'} {n}
 
-instance funLike : FunLike C^n⟮I, M; I', M'⟯ M fun _ => M' where
+instance funLike : DFunLike C^n⟮I, M; I', M'⟯ M fun _ => M' where
   coe := Subtype.val
   coe_injective' := Subtype.coe_injective
 #align cont_mdiff_map.fun_like ContMDiffMap.funLike
@@ -71,16 +71,16 @@ variable {f g : C^n⟮I, M; I', M'⟯}
 
 @[simp]
 theorem coeFn_mk (f : M → M') (hf : ContMDiff I I' n f) :
-    FunLike.coe (F := C^n⟮I, M; I', M'⟯) ⟨f, hf⟩ = f :=
+    DFunLike.coe (F := C^n⟮I, M; I', M'⟯) ⟨f, hf⟩ = f :=
   rfl
 #align cont_mdiff_map.coe_fn_mk ContMDiffMap.coeFn_mk
 
 theorem coe_injective ⦃f g : C^n⟮I, M; I', M'⟯⦄ (h : (f : M → M') = g) : f = g :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align cont_mdiff_map.coe_inj ContMDiffMap.coe_injective
 
 @[ext]
-theorem ext (h : ∀ x, f x = g x) : f = g := FunLike.ext _ _ h
+theorem ext (h : ∀ x, f x = g x) : f = g := DFunLike.ext _ _ h
 #align cont_mdiff_map.ext ContMDiffMap.ext
 
 instance : ContinuousMapClass C^n⟮I, M; I', M'⟯ M M' where

--- a/Mathlib/Geometry/Manifold/ContMDiffMap.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMap.lean
@@ -48,10 +48,10 @@ namespace ContMDiffMap
 
 variable {I} {I'} {M} {M'} {n}
 
-instance funLike : DFunLike C^n⟮I, M; I', M'⟯ M fun _ => M' where
+instance instDFunLike : DFunLike C^n⟮I, M; I', M'⟯ M fun _ => M' where
   coe := Subtype.val
   coe_injective' := Subtype.coe_injective
-#align cont_mdiff_map.fun_like ContMDiffMap.funLike
+#align cont_mdiff_map.fun_like ContMDiffMap.instDFunLike
 
 protected theorem contMDiff (f : C^n⟮I, M; I', M'⟯) : ContMDiff I I' n f :=
   f.prop
@@ -65,7 +65,7 @@ protected theorem smooth (f : C^∞⟮I, M; I', M'⟯) : Smooth I I' f :=
 -- instance : Coe C^n⟮I, M; I', M'⟯ C(M, M') :=
 --   ⟨fun f => ⟨f, f.contMDiff.continuous⟩⟩
 
-attribute [to_additive_ignore_args 21] ContMDiffMap ContMDiffMap.funLike
+attribute [to_additive_ignore_args 21] ContMDiffMap ContMDiffMap.instDFunLike
 
 variable {f g : C^n⟮I, M; I', M'⟯}
 

--- a/Mathlib/Geometry/Manifold/DerivationBundle.lean
+++ b/Mathlib/Geometry/Manifold/DerivationBundle.lean
@@ -50,9 +50,9 @@ namespace PointedSmoothMap
 
 open scoped Derivation
 
-instance funLike {x : M} : DFunLike C^∞⟮I, M; 𝕜⟯⟨x⟩ M fun _ => 𝕜 :=
-  ContMDiffMap.funLike
-#align pointed_smooth_map.fun_like PointedSmoothMap.funLike
+instance instDFunLike {x : M} : DFunLike C^∞⟮I, M; 𝕜⟯⟨x⟩ M fun _ => 𝕜 :=
+  ContMDiffMap.instDFunLike
+#align pointed_smooth_map.fun_like PointedSmoothMap.instDFunLike
 
 instance {x : M} : CommRing C^∞⟮I, M; 𝕜⟯⟨x⟩ :=
   SmoothMap.commRing

--- a/Mathlib/Geometry/Manifold/DerivationBundle.lean
+++ b/Mathlib/Geometry/Manifold/DerivationBundle.lean
@@ -50,7 +50,7 @@ namespace PointedSmoothMap
 
 open scoped Derivation
 
-instance funLike {x : M} : FunLike C^∞⟮I, M; 𝕜⟯⟨x⟩ M fun _ => 𝕜 :=
+instance funLike {x : M} : DFunLike C^∞⟮I, M; 𝕜⟯⟨x⟩ M fun _ => 𝕜 :=
   ContMDiffMap.funLike
 #align pointed_smooth_map.fun_like PointedSmoothMap.funLike
 

--- a/Mathlib/Geometry/Manifold/Diffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/Diffeomorph.lean
@@ -99,7 +99,7 @@ instance : EquivLike (M ≃ₘ^n⟮I, I'⟯ M') M M' where
   inv Φ := Φ.toEquiv.symm
   left_inv Φ := Φ.left_inv
   right_inv Φ := Φ.right_inv
-  coe_injective' _ _ h _ := toEquiv_injective <| FunLike.ext' h
+  coe_injective' _ _ h _ := toEquiv_injective <| DFunLike.ext' h
 
 /-- Interpret a diffeomorphism as a `ContMDiffMap`. -/
 @[coe]
@@ -160,7 +160,7 @@ theorem toEquiv_inj {h h' : M ≃ₘ^n⟮I, I'⟯ M'} : h.toEquiv = h'.toEquiv �
 
 /-- Coercion to function `λ h : M ≃ₘ^n⟮I, I'⟯ M', (h : M → M')` is injective. -/
 theorem coeFn_injective : Injective ((↑) : (M ≃ₘ^n⟮I, I'⟯ M') → (M → M')) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align diffeomorph.coe_fn_injective Diffeomorph.coeFn_injective
 
 @[ext]

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -568,7 +568,7 @@ theorem mfderiv_coe_sphere_injective {n : ℕ} [Fact (finrank ℝ E = n + 1)] (v
       (ℝ ∙ (↑(-v) : E))ᗮ.subtypeL (U.symm 0) := by
     convert hasFDerivAt_stereoInvFunAux_comp_coe (-v : E)
     simp
-  have := congr_arg FunLike.coe <| (this.comp 0 U.symm.toContinuousLinearEquiv.hasFDerivAt).fderiv
+  have := congr_arg DFunLike.coe <| (this.comp 0 U.symm.toContinuousLinearEquiv.hasFDerivAt).fderiv
   refine Eq.subst this.symm ?_
   rw [ContinuousLinearMap.coe_comp', ContinuousLinearEquiv.coe_coe]
   simpa using Subtype.coe_injective

--- a/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
@@ -77,7 +77,7 @@ structure PartialDiffeomorph extends PartialEquiv M N where
   contMDiffOn_invFun : ContMDiffOn J I n invFun target
 
 /-- Coercion of a `PartialDiffeomorph` to function.
-Note that a `PartialDiffeomorph` is not `FunLike` (like `PartialHomeomorph`),
+Note that a `PartialDiffeomorph` is not `DFunLike` (like `PartialHomeomorph`),
 as `toFun` doesn't determine `invFun` outside of `target`. -/
 instance : CoeFun (PartialDiffeomorph I J M N n) fun _ => M → N :=
   ⟨fun Φ => Φ.toFun⟩

--- a/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
+++ b/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
@@ -139,7 +139,7 @@ namespace SmoothPartitionOfUnity
 
 variable {s : Set M} (f : SmoothPartitionOfUnity ι I M s) {n : ℕ∞}
 
-instance {s : Set M} : FunLike (SmoothPartitionOfUnity ι I M s) ι fun _ => C^∞⟮I, M; 𝓘(ℝ), ℝ⟯ where
+instance {s : Set M} : DFunLike (SmoothPartitionOfUnity ι I M s) ι fun _ => C^∞⟮I, M; 𝓘(ℝ), ℝ⟯ where
   coe := toFun
   coe_injective' f g h := by cases f; cases g; congr
 

--- a/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
+++ b/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
@@ -292,7 +292,7 @@ def smoothSheafCommRing.forgetStalk (x : TopCat.of M) :
 @[simp, reassoc, elementwise] lemma smoothSheafCommRing.ι_forgetStalk_hom (x : TopCat.of M) (U) :
     CategoryStruct.comp
       (Z := (smoothSheaf IM I M R).presheaf.stalk x)
-      (FunLike.coe
+      (DFunLike.coe
         (α := ((forget CommRingCat).obj ((smoothSheafCommRing IM I M R).presheaf.obj
           (op ((OpenNhds.inclusion x).obj U.unop)))))
         (colimit.ι ((OpenNhds.inclusion x).op ⋙ (smoothSheafCommRing IM I M R).presheaf) U))
@@ -343,7 +343,7 @@ def smoothSheafCommRing.eval (x : M) : (smoothSheafCommRing IM I M R).presheaf.s
 @[simp, reassoc, elementwise] lemma smoothSheafCommRing.forgetStalk_inv_comp_eval
     (x : TopCat.of M) :
     (smoothSheafCommRing.forgetStalk IM I M R x).inv ≫
-     (FunLike.coe (smoothSheafCommRing.evalHom IM I M R x)) =
+     (DFunLike.coe (smoothSheafCommRing.evalHom IM I M R x)) =
     smoothSheaf.evalHom _ _ _ _ := by
   apply Limits.colimit.hom_ext
   intro U

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -59,7 +59,7 @@ namespace ContMDiffSection
 
 variable {I} {I'} {n} {F} {V}
 
-instance : FunLike Cₛ^n⟮I; F, V⟯ M V where
+instance : DFunLike Cₛ^n⟮I; F, V⟯ M V where
   coe := ContMDiffSection.toFun
   coe_injective' := by rintro ⟨⟩ ⟨⟩ h; congr
 
@@ -98,7 +98,7 @@ protected theorem mdifferentiableAt (s : Cₛ^∞⟮I; F, V⟯) {x} :
 #align cont_mdiff_section.mdifferentiable_at ContMDiffSection.mdifferentiableAt
 
 theorem coe_inj ⦃s t : Cₛ^n⟮I; F, V⟯⦄ (h : (s : ∀ x, V x) = t) : s = t :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align cont_mdiff_section.coe_inj ContMDiffSection.coe_inj
 
 theorem coe_injective : Injective ((↑) : Cₛ^n⟮I; F, V⟯ → ∀ x, V x) :=
@@ -106,7 +106,7 @@ theorem coe_injective : Injective ((↑) : Cₛ^n⟮I; F, V⟯ → ∀ x, V x) :
 #align cont_mdiff_section.coe_injective ContMDiffSection.coe_injective
 
 @[ext]
-theorem ext (h : ∀ x, s x = t x) : s = t := FunLike.ext _ _ h
+theorem ext (h : ∀ x, s x = t x) : s = t := DFunLike.ext _ _ h
 #align cont_mdiff_section.ext ContMDiffSection.ext
 
 instance instAdd : Add Cₛ^n⟮I; F, V⟯ := by

--- a/Mathlib/GroupTheory/Abelianization.lean
+++ b/Mathlib/GroupTheory/Abelianization.lean
@@ -168,7 +168,7 @@ variable {A : Type v} [Monoid A]
 /-- See note [partially-applied ext lemmas]. -/
 @[ext]
 theorem hom_ext (φ ψ : Abelianization G →* A) (h : φ.comp of = ψ.comp of) : φ = ψ :=
-  MonoidHom.ext fun x => QuotientGroup.induction_on x <| FunLike.congr_fun h
+  MonoidHom.ext fun x => QuotientGroup.induction_on x <| DFunLike.congr_fun h
 #align abelianization.hom_ext Abelianization.hom_ext
 
 section Map
@@ -198,7 +198,7 @@ theorem map_comp {I : Type w} [Group I] (g : H →* I) : (map g).comp (map f) = 
 @[simp]
 theorem map_map_apply {I : Type w} [Group I] {g : H →* I} {x : Abelianization G} :
     map g (map f x) = map (g.comp f) x :=
-  FunLike.congr_fun (map_comp _ _) x
+  DFunLike.congr_fun (map_comp _ _) x
 #align abelianization.map_map_apply Abelianization.map_map_apply
 
 end Map

--- a/Mathlib/GroupTheory/Congruence.lean
+++ b/Mathlib/GroupTheory/Congruence.lean
@@ -118,10 +118,10 @@ variable [Mul M] [Mul N] [Mul P] (c : Con M)
 instance : Inhabited (Con M) :=
   ⟨conGen EmptyRelation⟩
 
---Porting note: upgraded to FunLike
+--Porting note: upgraded to DFunLike
 /-- A coercion from a congruence relation to its underlying binary relation. -/
 @[to_additive "A coercion from an additive congruence relation to its underlying binary relation."]
-instance : FunLike (Con M) M (fun _ => M → Prop) where
+instance : DFunLike (Con M) M (fun _ => M → Prop) where
   coe c := c.r
   coe_injective' := fun x y h => by
     rcases x with ⟨⟨x, _⟩, _⟩
@@ -178,7 +178,7 @@ variable {c}
 /-- The map sending a congruence relation to its underlying binary relation is injective. -/
 @[to_additive "The map sending an additive congruence relation to its underlying binary relation
 is injective."]
-theorem ext' {c d : Con M} (H : ⇑c = ⇑d) : c = d := FunLike.coe_injective H
+theorem ext' {c d : Con M} (H : ⇑c = ⇑d) : c = d := DFunLike.coe_injective H
 #align con.ext' Con.ext'
 #align add_con.ext' AddCon.ext'
 
@@ -207,7 +207,7 @@ theorem ext_iff {c d : Con M} : (∀ x y, c x y ↔ d x y) ↔ c = d :=
 /-- Two congruence relations are equal iff their underlying binary relations are equal. -/
 @[to_additive "Two additive congruence relations are equal iff their underlying binary relations
 are equal."]
-theorem coe_inj {c d : Con M} : ⇑c = ⇑d ↔ c = d := FunLike.coe_injective.eq_iff
+theorem coe_inj {c d : Con M} : ⇑c = ⇑d ↔ c = d := DFunLike.coe_injective.eq_iff
 #align con.ext'_iff Con.coe_inj
 #align add_con.ext'_iff AddCon.coe_inj
 
@@ -606,7 +606,7 @@ variable (M)
     binary relations on `M`. -/
 @[to_additive "There is a Galois insertion of additive congruence relations on a type with
 an addition `M` into binary relations on `M`."]
-protected def gi : @GaloisInsertion (M → M → Prop) (Con M) _ _ conGen FunLike.coe
+protected def gi : @GaloisInsertion (M → M → Prop) (Con M) _ _ conGen DFunLike.coe
     where
   choice r _ := conGen r
   gc _ c := ⟨fun H _ _ h => H <| ConGen.Rel.of _ _ h, @fun H => conGen_of_con c ▸ conGen_mono H⟩
@@ -950,7 +950,7 @@ are equal if they are equal on elements that are coercions from the `AddMonoid`.
 theorem lift_funext (f g : c.Quotient →* P) (h : ∀ a : M, f a = g a) : f = g := by
   rw [← lift_apply_mk' f, ← lift_apply_mk' g]
   congr 1
-  exact FunLike.ext_iff.2 h
+  exact DFunLike.ext_iff.2 h
 #align con.lift_funext Con.lift_funext
 #align add_con.lift_funext AddCon.lift_funext
 

--- a/Mathlib/GroupTheory/Coprod/Basic.lean
+++ b/Mathlib/GroupTheory/Coprod/Basic.lean
@@ -242,7 +242,7 @@ theorem clift_apply_mk (f : FreeMonoid (M ⊕ N) →* P) (hM₁ hN₁ hM hN w) :
 @[to_additive (attr := simp)]
 theorem clift_comp_mk (f : FreeMonoid (M ⊕ N) →* P) (hM₁ hN₁ hM hN) :
     (clift f hM₁ hN₁ hM hN).comp mk = f :=
-  FunLike.ext' rfl
+  DFunLike.ext' rfl
 
 @[to_additive (attr := simp)]
 theorem mclosure_range_inl_union_inr :
@@ -275,7 +275,7 @@ then they are equal. -/
 theorem hom_ext {f g : M ∗ N →* P} (h₁ : f.comp inl = g.comp inl) (h₂ : f.comp inr = g.comp inr) :
     f = g :=
   MonoidHom.eq_of_eqOn_denseM mclosure_range_inl_union_inr <| eqOn_union.2
-    ⟨eqOn_range.2 <| FunLike.ext'_iff.1 h₁, eqOn_range.2 <| FunLike.ext'_iff.1 h₂⟩
+    ⟨eqOn_range.2 <| DFunLike.ext'_iff.1 h₁, eqOn_range.2 <| DFunLike.ext'_iff.1 h₂⟩
 
 @[to_additive (attr := simp)]
 theorem clift_mk :
@@ -322,7 +322,7 @@ theorem map_comp_map {M'' N''} [MulOneClass M''] [MulOneClass N''] (f' : M' →*
 theorem map_map {M'' N''} [MulOneClass M''] [MulOneClass N''] (f' : M' →* M'') (g' : N' →* N'')
     (f : M →* M') (g : N →* N') (x : M ∗ N) :
     map f' g' (map f g x) = map (f'.comp f) (g'.comp g) x :=
-  FunLike.congr_fun (map_comp_map f' g' f g) x
+  DFunLike.congr_fun (map_comp_map f' g' f g) x
 
 variable (M N)
 
@@ -347,7 +347,7 @@ variable {M N}
 
 @[to_additive (attr := simp)]
 theorem swap_swap (x : M ∗ N) : swap N M (swap M N x) = x :=
-  FunLike.congr_fun (swap_comp_swap _ _) x
+  DFunLike.congr_fun (swap_comp_swap _ _) x
 
 @[to_additive]
 theorem swap_comp_map (f : M →* M') (g : N →* N') :
@@ -357,7 +357,7 @@ theorem swap_comp_map (f : M →* M') (g : N →* N') :
 @[to_additive]
 theorem swap_map (f : M →* M') (g : N →* N') (x : M ∗ N) :
     swap M' N' (map f g x) = map g f (swap M N x) :=
-  FunLike.congr_fun (swap_comp_map f g) x
+  DFunLike.congr_fun (swap_comp_map f g) x
 
 @[to_additive (attr := simp)] theorem swap_comp_inl : (swap M N).comp inl = inr := rfl
 @[to_additive (attr := simp)] theorem swap_inl (x : M) : swap M N (inl x) = inr x := rfl
@@ -436,7 +436,7 @@ theorem lift_comp_swap (f : M →* P) (g : N →* P) : (lift f g).comp (swap N M
 
 @[to_additive (attr := simp)]
 theorem lift_swap (f : M →* P) (g : N →* P) (x : N ∗ M) : lift f g (swap N M x) = lift g f x :=
-  FunLike.congr_fun (lift_comp_swap f g) x
+  DFunLike.congr_fun (lift_comp_swap f g) x
 
 @[to_additive]
 theorem comp_lift {P' : Type*} [Monoid P'] (f : P →* P') (g₁ : M →* P) (g₂ : N →* P) :

--- a/Mathlib/GroupTheory/FreeAbelianGroup.lean
+++ b/Mathlib/GroupTheory/FreeAbelianGroup.lean
@@ -117,7 +117,7 @@ protected theorem of (x : α) : lift f (of x) = f x := by
 
 protected theorem unique (g : FreeAbelianGroup α →+ β) (hg : ∀ x, g (of x) = f x) {x} :
     g x = lift f x :=
-  FunLike.congr_fun (lift.symm_apply_eq.mp (funext hg : g ∘ of = f)) _
+  DFunLike.congr_fun (lift.symm_apply_eq.mp (funext hg : g ∘ of = f)) _
 #align free_abelian_group.lift.unique FreeAbelianGroup.lift.unique
 
 /-- See note [partially-applied ext lemmas]. -/

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -737,7 +737,7 @@ theorem lift.of {x} : lift f (of x) = f x :=
 @[to_additive]
 theorem lift.unique (g : FreeGroup α →* β) (hg : ∀ x, g (FreeGroup.of x) = f x) {x} :
     g x = FreeGroup.lift f x :=
-  FunLike.congr_fun (lift.symm_apply_eq.mp (funext hg : g ∘ FreeGroup.of = f)) x
+  DFunLike.congr_fun (lift.symm_apply_eq.mp (funext hg : g ∘ FreeGroup.of = f)) x
 #align free_group.lift.unique FreeGroup.lift.unique
 #align free_add_group.lift.unique FreeAddGroup.lift.unique
 
@@ -754,7 +754,7 @@ theorem ext_hom {G : Type*} [Group G] (f g : FreeGroup α →* G) (h : ∀ a, f 
 
 @[to_additive]
 theorem lift.of_eq (x : FreeGroup α) : lift FreeGroup.of x = x :=
-  FunLike.congr_fun (lift.apply_symm_apply (MonoidHom.id _)) x
+  DFunLike.congr_fun (lift.apply_symm_apply (MonoidHom.id _)) x
 #align free_group.lift.of_eq FreeGroup.lift.of_eq
 #align free_add_group.lift.of_eq FreeAddGroup.lift.of_eq
 

--- a/Mathlib/GroupTheory/FreeGroup/IsFreeGroup.lean
+++ b/Mathlib/GroupTheory/FreeGroup/IsFreeGroup.lean
@@ -48,7 +48,7 @@ noncomputable section
 
 /-- A free group basis `FreeGroupBasis ι G` is a structure recording the isomorphism between a
 group `G` and the free group over `ι`. One may think of such a basis as a function from `ι` to `G`
-(which is registered through a `FunLike` instance) together with the fact that the morphism induced
+(which is registered through a `DFunLike` instance) together with the fact that the morphism induced
 by this function from `FreeGroup ι` to `G` is an isomorphism. -/
 structure FreeGroupBasis (ι : Type*) (G : Type*) [Group G] where
   /-- `FreeGroupBasis.ofRepr` constructs a basis given an equivalence with a free group. -/
@@ -68,13 +68,13 @@ variable {ι ι' G H : Type*} [Group G] [Group H]
 
 /-- A free group basis for `G` over `ι` is associated to a map `ι → G` recording the images of
 the generators. -/
-instance funLike : FunLike (FreeGroupBasis ι G) ι (fun _ ↦ G) where
+instance funLike : DFunLike (FreeGroupBasis ι G) ι (fun _ ↦ G) where
   coe b := fun i ↦ b.repr.symm (FreeGroup.of i)
   coe_injective' := by
     rintro ⟨b⟩  ⟨b'⟩ hbb'
     have H : (b.symm : FreeGroup ι →* G) = (b'.symm : FreeGroup ι →* G) := by
       ext i; exact congr_fun hbb' i
-    have : b.symm = b'.symm := by ext x; exact FunLike.congr_fun H x
+    have : b.symm = b'.symm := by ext x; exact DFunLike.congr_fun H x
     rw [ofRepr.injEq, ← MulEquiv.symm_symm b, ← MulEquiv.symm_symm b', this]
 
 @[simp] lemma repr_apply_coe (b : FreeGroupBasis ι G) (i : ι) : b.repr (b i) = FreeGroup.of i := by

--- a/Mathlib/GroupTheory/FreeGroup/IsFreeGroup.lean
+++ b/Mathlib/GroupTheory/FreeGroup/IsFreeGroup.lean
@@ -68,7 +68,7 @@ variable {ι ι' G H : Type*} [Group G] [Group H]
 
 /-- A free group basis for `G` over `ι` is associated to a map `ι → G` recording the images of
 the generators. -/
-instance funLike : DFunLike (FreeGroupBasis ι G) ι (fun _ ↦ G) where
+instance instDFunLike : DFunLike (FreeGroupBasis ι G) ι (fun _ ↦ G) where
   coe b := fun i ↦ b.repr.symm (FreeGroup.of i)
   coe_injective' := by
     rintro ⟨b⟩  ⟨b'⟩ hbb'

--- a/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
+++ b/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
@@ -120,7 +120,7 @@ instance actionGroupoidIsFree {G A : Type u} [Group G] [IsFreeGroup G] [MulActio
     refine' ⟨uncurry F' _, _, _⟩
     · suffices SemidirectProduct.rightHom.comp F' = MonoidHom.id _ by
         -- Porting note: `MonoidHom.ext_iff` has been deprecated.
-        exact FunLike.ext_iff.mp this
+        exact DFunLike.ext_iff.mp this
       apply IsFreeGroup.ext_hom (fun x ↦ ?_)
       rw [MonoidHom.comp_apply, hF']
       rfl

--- a/Mathlib/GroupTheory/GroupAction/DomAct/ActionHom.lean
+++ b/Mathlib/GroupTheory/GroupAction/DomAct/ActionHom.lean
@@ -33,7 +33,7 @@ instance : SMul Mᵈᵐᵃ (α →[N] β) where
 
 instance [SMul M' α] [SMulCommClass M' N α] [SMulCommClass M M' α] :
     SMulCommClass Mᵈᵐᵃ M'ᵈᵐᵃ (α →[N] β) :=
-  FunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+  DFunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 theorem smul_mulActionHom_apply (c : Mᵈᵐᵃ) (f : α →[N] β) (a : α) :
     (c • f) a = f (mk.symm c • a) :=
@@ -46,7 +46,7 @@ end SMul
 
 instance [Monoid M] [MulAction M α] [SMul N α] [SMulCommClass M N α] [SMul N β] :
     MulAction Mᵈᵐᵃ (α →[N] β) :=
-  FunLike.coe_injective.mulAction _ fun _ _ ↦ rfl
+  DFunLike.coe_injective.mulAction _ fun _ _ ↦ rfl
 
 end MulActionHom
 
@@ -62,7 +62,7 @@ instance : SMul Mᵈᵐᵃ (A →+[N] B) where
 
 instance [DistribSMul M' A] [SMulCommClass M' N A] [SMulCommClass M M' A] :
     SMulCommClass Mᵈᵐᵃ M'ᵈᵐᵃ (A →+[N] B) :=
-  FunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+  DFunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 theorem smul_mulDistribActionHom_apply (c : Mᵈᵐᵃ) (f : A →+[N] B) (a : A) :
     (c • f) a = f (mk.symm c • a) :=
@@ -77,7 +77,7 @@ end SMul
 instance [Monoid M] [AddMonoid A] [DistribMulAction M A] [Monoid N] [AddMonoid B]
     [DistribMulAction N A] [SMulCommClass M N A] [DistribMulAction N B] :
     MulAction Mᵈᵐᵃ (A →+[N] B) :=
-  FunLike.coe_injective.mulAction _ fun _ _ ↦ rfl
+  DFunLike.coe_injective.mulAction _ fun _ _ ↦ rfl
 
 end DistribMulActionHom
 

--- a/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
@@ -203,7 +203,7 @@ instance : SMul Mᵈᵐᵃ (A →* B) where
 
 instance [Monoid M'] [MulDistribMulAction M' A] [SMulCommClass M M' A] :
     SMulCommClass Mᵈᵐᵃ M'ᵈᵐᵃ (A →* B) :=
-  FunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+  DFunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 theorem smul_monoidHom_apply (c : Mᵈᵐᵃ) (f : A →* B) (a : A) : (c • f) a = f (mk.symm c • a) :=
   rfl
@@ -211,7 +211,7 @@ theorem smul_monoidHom_apply (c : Mᵈᵐᵃ) (f : A →* B) (a : A) : (c • f)
 @[simp]
 theorem mk_smul_monoidHom_apply (c : M) (f : A →* B) (a : A) : (mk c • f) a = f (c • a) := rfl
 
-instance : MulAction Mᵈᵐᵃ (A →* B) := FunLike.coe_injective.mulAction (⇑) fun _ _ ↦ rfl
+instance : MulAction Mᵈᵐᵃ (A →* B) := DFunLike.coe_injective.mulAction (⇑) fun _ _ ↦ rfl
 
 end MonoidHom
 
@@ -225,10 +225,10 @@ instance : SMul Mᵈᵐᵃ (A →+ B) where
   smul c f := f.comp (DistribSMul.toAddMonoidHom _ (mk.symm c))
 
 instance [DistribSMul M' A] [SMulCommClass M M' A] : SMulCommClass Mᵈᵐᵃ M'ᵈᵐᵃ (A →+ B) :=
-  FunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+  DFunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 instance [DistribSMul M' B] : SMulCommClass Mᵈᵐᵃ M' (A →+ B) :=
-  FunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+  DFunLike.coe_injective.smulCommClass (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 theorem smul_addMonoidHom_apply (c : Mᵈᵐᵃ) (f : A →+ B) (a : A) : (c • f) a = f (mk.symm c • a) :=
   rfl
@@ -239,10 +239,10 @@ theorem mk_smul_addMonoidHom_apply (c : M) (f : A →+ B) (a : A) : (mk c • f)
 end DistribSMul
 
 instance [Monoid M] [AddMonoid A] [DistribMulAction M A] [AddZeroClass B] :
-    MulAction Mᵈᵐᵃ (A →+ B) := FunLike.coe_injective.mulAction (⇑) fun _ _ ↦ rfl
+    MulAction Mᵈᵐᵃ (A →+ B) := DFunLike.coe_injective.mulAction (⇑) fun _ _ ↦ rfl
 
 instance [Monoid M] [AddMonoid A] [DistribMulAction M A] [AddCommMonoid B] :
     DistribMulAction Mᵈᵐᵃ (A →+ B) :=
-  FunLike.coe_injective.distribMulAction (AddMonoidHom.coeFn A B) fun _ _ ↦ rfl
+  DFunLike.coe_injective.distribMulAction (AddMonoidHom.coeFn A B) fun _ _ ↦ rfl
 
 end AddMonoidHom

--- a/Mathlib/GroupTheory/GroupAction/Embedding.lean
+++ b/Mathlib/GroupTheory/GroupAction/Embedding.lean
@@ -62,6 +62,6 @@ instance [Group G] [MulAction G β] [MulAction Gᵐᵒᵖ β] [IsCentralScalar G
 
 @[to_additive]
 instance [Group G] [MulAction G β] : MulAction G (α ↪ β) :=
-  FunLike.coe_injective.mulAction _ coe_smul
+  DFunLike.coe_injective.mulAction _ coe_smul
 
 end Function.Embedding

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -76,7 +76,7 @@ scalar multiplication by `M`.
 
 You should extend this class when you extend `MulActionHom`. -/
 class SMulHomClass (F : Type*) (M X Y : outParam <| Type*) [SMul M X] [SMul M Y] extends
-  FunLike F X fun _ => Y where
+  DFunLike F X fun _ => Y where
   /-- The proposition that the function preserves the action. -/
   map_smul : ∀ (f : F) (c : M) (x : X), f (c • x) = c • f x
 #align smul_hom_class SMulHomClass
@@ -109,7 +109,7 @@ see also Algebra.Hom.Group -/
 @[coe]
 def _root_.SMulHomClass.toMulActionHom [SMul M X] [SMul M Y] [SMulHomClass F M X Y] (f : F) :
     X →[M] Y where
-   toFun := FunLike.coe f
+   toFun := DFunLike.coe f
    map_smul' := map_smul f
 
 /-- Any type satisfying `SMulHomClass` can be cast into `MulActionHom` via
@@ -130,15 +130,15 @@ protected theorem map_smul (f : X →[M'] Y) (m : M') (x : X) : f (m • x) = m 
 
 @[ext]
 theorem ext {f g : X →[M'] Y} : (∀ x, f x = g x) → f = g :=
-  FunLike.ext f g
+  DFunLike.ext f g
 #align mul_action_hom.ext MulActionHom.ext
 
 theorem ext_iff {f g : X →[M'] Y} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align mul_action_hom.ext_iff MulActionHom.ext_iff
 
 protected theorem congr_fun {f g : X →[M'] Y} (h : f = g) (x : X) : f x = g x :=
-  FunLike.congr_fun h _
+  DFunLike.congr_fun h _
 #align mul_action_hom.congr_fun MulActionHom.congr_fun
 
 variable (M M')
@@ -293,15 +293,15 @@ theorem coe_fn_coe' (f : A →+[M] B) : ⇑(f : A →[M] B) = f :=
 
 @[ext]
 theorem ext {f g : A →+[M] B} : (∀ x, f x = g x) → f = g :=
-  FunLike.ext f g
+  DFunLike.ext f g
 #align distrib_mul_action_hom.ext DistribMulActionHom.ext
 
 theorem ext_iff {f g : A →+[M] B} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align distrib_mul_action_hom.ext_iff DistribMulActionHom.ext_iff
 
 protected theorem congr_fun {f g : A →+[M] B} (h : f = g) (x : A) : f x = g x :=
-  FunLike.congr_fun h _
+  DFunLike.congr_fun h _
 #align distrib_mul_action_hom.congr_fun DistribMulActionHom.congr_fun
 
 theorem toMulActionHom_injective {f g : A →+[M] B} (h : (f : A →[M] B) = (g : A →[M] B)) :
@@ -312,7 +312,7 @@ theorem toMulActionHom_injective {f g : A →+[M] B} (h : (f : A →[M] B) = (g 
 
 theorem toAddMonoidHom_injective {f g : A →+[M] B} (h : (f : A →+ B) = (g : A →+ B)) : f = g := by
   ext a
-  exact FunLike.congr_fun h a
+  exact DFunLike.congr_fun h a
 #align distrib_mul_action_hom.to_add_monoid_hom_injective DistribMulActionHom.toAddMonoidHom_injective
 
 protected theorem map_zero (f : A →+[M] B) : f 0 = 0 :=
@@ -525,11 +525,11 @@ theorem coe_fn_coe' (f : R →+*[M] S) : ⇑(f : R →+[M] S) = f :=
 
 @[ext]
 theorem ext {f g : R →+*[M] S} : (∀ x, f x = g x) → f = g :=
-  FunLike.ext f g
+  DFunLike.ext f g
 #align mul_semiring_action_hom.ext MulSemiringActionHom.ext
 
 theorem ext_iff {f g : R →+*[M] S} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align mul_semiring_action_hom.ext_iff MulSemiringActionHom.ext_iff
 
 protected theorem map_zero (f : R →+*[M] S) : f 0 = 0 :=

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -568,7 +568,7 @@ theorem ext_iff {f g : LocalizationMap S N} : f = g ↔ ∀ x, f.toMap x = g.toM
 
 @[to_additive]
 theorem toMap_injective : Function.Injective (@LocalizationMap.toMap _ _ S N _) :=
-  fun _ _ h ↦ ext <| FunLike.ext_iff.1 h
+  fun _ _ h ↦ ext <| DFunLike.ext_iff.1 h
 #align submonoid.localization_map.to_map_injective Submonoid.LocalizationMap.toMap_injective
 #align add_submonoid.localization_map.to_map_injective AddSubmonoid.LocalizationMap.toMap_injective
 
@@ -1061,7 +1061,7 @@ theorem lift_unique {j : N →* P} (hj : ∀ x, j (f.toMap x) = g x) : f.lift hg
 
 @[to_additive (attr := simp)]
 theorem lift_id (x) : f.lift f.map_units x = x :=
-  FunLike.ext_iff.1 (f.lift_of_comp <| MonoidHom.id N) x
+  DFunLike.ext_iff.1 (f.lift_of_comp <| MonoidHom.id N) x
 #align submonoid.localization_map.lift_id Submonoid.LocalizationMap.lift_id
 #align add_submonoid.localization_map.lift_id AddSubmonoid.LocalizationMap.lift_id
 
@@ -1460,7 +1460,7 @@ theorem mulEquivOfLocalizations_right_inv_apply {k : LocalizationMap S P} {x} :
 @[to_additive]
 theorem mulEquivOfLocalizations_left_inv (k : N ≃* P) :
     f.mulEquivOfLocalizations (f.ofMulEquivOfLocalizations k) = k :=
-  FunLike.ext _ _ fun x ↦ FunLike.ext_iff.1 (f.lift_of_comp k.toMonoidHom) x
+  DFunLike.ext _ _ fun x ↦ DFunLike.ext_iff.1 (f.lift_of_comp k.toMonoidHom) x
 #align submonoid.localization_map.mul_equiv_of_localizations_left_inv Submonoid.LocalizationMap.mulEquivOfLocalizations_left_inv
 #align add_submonoid.localization_map.add_equiv_of_localizations_left_neg AddSubmonoid.LocalizationMap.addEquivOfLocalizations_left_neg
 

--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -678,7 +678,7 @@ theorem IsCycle.pow_eq_one_iff [Finite β] {f : Perm β} (hf : IsCycle f) {n : �
 -- TODO: Define a `Set`-valued support to get rid of the `Finite β` assumption
 theorem IsCycle.pow_eq_one_iff' [Finite β] {f : Perm β} (hf : IsCycle f) {n : ℕ} {x : β}
     (hx : f x ≠ x) : f ^ n = 1 ↔ (f ^ n) x = x :=
-  ⟨fun h => FunLike.congr_fun h x, fun h => hf.pow_eq_one_iff.2 ⟨x, hx, h⟩⟩
+  ⟨fun h => DFunLike.congr_fun h x, fun h => hf.pow_eq_one_iff.2 ⟨x, hx, h⟩⟩
 #align equiv.perm.is_cycle.pow_eq_one_iff' Equiv.Perm.IsCycle.pow_eq_one_iff'
 
 -- TODO: Define a `Set`-valued support to get rid of the `Finite β` assumption

--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -340,7 +340,7 @@ theorem card_fixedPoints_modEq [DecidableEq α] {f : Function.End α} {p n : ℕ
     leftInverse_iff_comp.mpr ((pow_sub_mul_pow f (Nat.one_le_pow n p hp.out.pos)).trans hf),
     leftInverse_iff_comp.mpr ((pow_mul_pow_sub f (Nat.one_le_pow n p hp.out.pos)).trans hf)⟩
   have hσ : σ ^ p ^ n = 1
-  · rw [FunLike.ext'_iff, coe_pow]
+  · rw [DFunLike.ext'_iff, coe_pow]
     exact (hom_coe_pow (fun g : Function.End α ↦ g) rfl (fun g h ↦ rfl) f (p ^ n)).symm.trans hf
   suffices : Fintype.card f.fixedPoints = (support σ)ᶜ.card
   · exact this ▸ (card_compl_support_modEq hσ).symm

--- a/Mathlib/GroupTheory/PushoutI.lean
+++ b/Mathlib/GroupTheory/PushoutI.lean
@@ -104,7 +104,7 @@ def lift (f : ∀ i, G i →* K) (k : H →* K)
   Con.lift _ (Coprod.lift (CoprodI.lift f) k) <| by
     apply Con.conGen_le fun x y => ?_
     rintro ⟨i, x', rfl, rfl⟩
-    simp only [FunLike.ext_iff, MonoidHom.coe_comp, comp_apply] at hf
+    simp only [DFunLike.ext_iff, MonoidHom.coe_comp, comp_apply] at hf
     simp [hf]
 
 @[simp]
@@ -151,9 +151,9 @@ def homEquiv :
   { toFun := fun f => ⟨(fun i => f.comp (of i), f.comp (base φ)),
       fun i => by rw [MonoidHom.comp_assoc, of_comp_eq_base]⟩
     invFun := fun f => lift f.1.1 f.1.2 f.2,
-    left_inv := fun _ => hom_ext (by simp [FunLike.ext_iff])
-      (by simp [FunLike.ext_iff])
-    right_inv := fun ⟨⟨_, _⟩, _⟩ => by simp [FunLike.ext_iff, Function.funext_iff] }
+    left_inv := fun _ => hom_ext (by simp [DFunLike.ext_iff])
+      (by simp [DFunLike.ext_iff])
+    right_inv := fun ⟨⟨_, _⟩, _⟩ => by simp [DFunLike.ext_iff, Function.funext_iff] }
 
 /-- The map from the coproduct into the pushout -/
 def ofCoprodI : CoprodI G →* PushoutI φ :=
@@ -442,7 +442,7 @@ noncomputable instance mulAction [DecidableEq ι] [∀ i, DecidableEq (G i)] :
       (fun i => MulAction.toEndHom)
       MulAction.toEndHom <| by
     intro i
-    simp only [MulAction.toEndHom, FunLike.ext_iff, MonoidHom.coe_comp, MonoidHom.coe_mk,
+    simp only [MulAction.toEndHom, DFunLike.ext_iff, MonoidHom.coe_comp, MonoidHom.coe_mk,
       OneHom.coe_mk, comp_apply]
     intro h
     funext w

--- a/Mathlib/GroupTheory/QuotientGroup.lean
+++ b/Mathlib/GroupTheory/QuotientGroup.lean
@@ -112,7 +112,7 @@ See note [partially-applied ext lemmas]. -/
 
  See note [partially-applied ext lemmas]. "]
 theorem monoidHom_ext ⦃f g : G ⧸ N →* M⦄ (h : f.comp (mk' N) = g.comp (mk' N)) : f = g :=
-  MonoidHom.ext fun x => QuotientGroup.induction_on x <| (FunLike.congr_fun h : _)
+  MonoidHom.ext fun x => QuotientGroup.induction_on x <| (DFunLike.congr_fun h : _)
 #align quotient_group.monoid_hom_ext QuotientGroup.monoidHom_ext
 #align quotient_add_group.add_monoid_hom_ext QuotientAddGroup.addMonoidHom_ext
 
@@ -127,7 +127,7 @@ theorem eq_one_iff {N : Subgroup G} [nN : N.Normal] (x : G) : (x : G ⧸ N) = 1 
 theorem ker_le_range_iff {I : Type w} [Group I] (f : G →* H) [f.range.Normal] (g : H →* I) :
     g.ker ≤ f.range ↔ (mk' f.range).comp g.ker.subtype = 1 :=
   ⟨fun h => MonoidHom.ext fun ⟨_, hx⟩ => (eq_one_iff _).mpr <| h hx,
-    fun h x hx => (eq_one_iff _).mp <| by exact FunLike.congr_fun h ⟨x, hx⟩⟩
+    fun h x hx => (eq_one_iff _).mp <| by exact DFunLike.congr_fun h ⟨x, hx⟩⟩
 
 @[to_additive (attr := simp)]
 theorem ker_mk' : MonoidHom.ker (QuotientGroup.mk' N : G →* G ⧸ N) = N :=

--- a/Mathlib/GroupTheory/SemidirectProduct.lean
+++ b/Mathlib/GroupTheory/SemidirectProduct.lean
@@ -219,7 +219,7 @@ def lift (f₁ : N →* H) (f₂ : G →* H)
   toFun a := f₁ a.1 * f₂ a.2
   map_one' := by simp
   map_mul' a b := by
-    have := fun n g ↦ FunLike.ext_iff.1 (h n) g
+    have := fun n g ↦ DFunLike.ext_iff.1 (h n) g
     simp only [MulAut.conj_apply, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom] at this
     simp only [mul_left, mul_right, map_mul, this, mul_assoc, inv_mul_cancel_left]
 #align semidirect_product.lift SemidirectProduct.lift
@@ -242,7 +242,7 @@ theorem lift_comp_inr : (lift f₁ f₂ h).comp inr = f₂ := by ext; simp
 
 theorem lift_unique (F : N ⋊[φ] G →* H) :
     F = lift (F.comp inl) (F.comp inr) fun _ ↦ by ext; simp [inl_aut] := by
-  rw [FunLike.ext_iff]
+  rw [DFunLike.ext_iff]
   simp only [lift, MonoidHom.comp_apply, MonoidHom.coe_mk, OneHom.coe_mk, ← map_mul,
     inl_left_mul_inr_right, forall_const]
 #align semidirect_product.lift_unique SemidirectProduct.lift_unique
@@ -269,7 +269,7 @@ def map (f₁ : N →* N₁) (f₂ : G →* G₁)
   toFun x := ⟨f₁ x.1, f₂ x.2⟩
   map_one' := by simp
   map_mul' x y := by
-    replace h := FunLike.ext_iff.1 (h x.right) y.left
+    replace h := DFunLike.ext_iff.1 (h x.right) y.left
     ext <;> simp_all
 #align semidirect_product.map SemidirectProduct.map
 

--- a/Mathlib/GroupTheory/Subgroup/Basic.lean
+++ b/Mathlib/GroupTheory/Subgroup/Basic.lean
@@ -2970,7 +2970,7 @@ theorem ker_prodMap {G' : Type*} {N' : Type*} [Group G'] [Group N'] (f : G →* 
 
 @[to_additive]
 theorem range_le_ker_iff (f : G →* G') (g : G' →* G'') : f.range ≤ g.ker ↔ g.comp f = 1 :=
-  ⟨fun h => ext fun x => h ⟨x, rfl⟩, by rintro h _ ⟨y, rfl⟩; exact FunLike.congr_fun h y⟩
+  ⟨fun h => ext fun x => h ⟨x, rfl⟩, by rintro h _ ⟨y, rfl⟩; exact DFunLike.congr_fun h y⟩
 
 @[to_additive]
 instance (priority := 100) normal_ker (f : G →* M) : f.ker.Normal :=

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineEquiv.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineEquiv.lean
@@ -93,11 +93,11 @@ instance equivLike : EquivLike (P₁ ≃ᵃ[k] P₂) P₁ P₂ where
   inv f := f.invFun
   left_inv f := f.left_inv
   right_inv f := f.right_inv
-  coe_injective' _ _ h _ := toAffineMap_injective (FunLike.coe_injective h)
+  coe_injective' _ _ h _ := toAffineMap_injective (DFunLike.coe_injective h)
 #align affine_equiv.equiv_like AffineEquiv.equivLike
 
 instance : CoeFun (P₁ ≃ᵃ[k] P₂) fun _ => P₁ → P₂ :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 instance : CoeOut (P₁ ≃ᵃ[k] P₂) (P₁ ≃ P₂) :=
   ⟨AffineEquiv.toEquiv⟩
@@ -132,15 +132,15 @@ theorem coe_linear (e : P₁ ≃ᵃ[k] P₂) : (e : P₁ →ᵃ[k] P₂).linear 
 
 @[ext]
 theorem ext {e e' : P₁ ≃ᵃ[k] P₂} (h : ∀ x, e x = e' x) : e = e' :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align affine_equiv.ext AffineEquiv.ext
 
 theorem coeFn_injective : @Injective (P₁ ≃ᵃ[k] P₂) (P₁ → P₂) (⇑) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align affine_equiv.coe_fn_injective AffineEquiv.coeFn_injective
 
 @[norm_cast]
--- Porting note: removed `simp`: proof is `simp only [FunLike.coe_fn_eq]`
+-- Porting note: removed `simp`: proof is `simp only [DFunLike.coe_fn_eq]`
 theorem coeFn_inj {e e' : P₁ ≃ᵃ[k] P₂} : (e : P₁ → P₂) = e' ↔ e = e' :=
   coeFn_injective.eq_iff
 #align affine_equiv.coe_fn_inj AffineEquiv.coeFn_inj

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -61,7 +61,7 @@ notation:25 P1 " →ᵃ[" k:25 "] " P2:0 => AffineMap k P1 P2
 
 instance AffineMap.funLike (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*} (P2 : Type*)
     [Ring k] [AddCommGroup V1] [Module k V1] [AffineSpace V1 P1] [AddCommGroup V2] [Module k V2]
-    [AffineSpace V2 P2] : FunLike (P1 →ᵃ[k] P2) P1 fun _ => P2
+    [AffineSpace V2 P2] : DFunLike (P1 →ᵃ[k] P2) P1 fun _ => P2
     where
   coe := AffineMap.toFun
   coe_injective' := fun ⟨f, f_linear, f_add⟩ ⟨g, g_linear, g_add⟩ => fun (h : f = g) => by
@@ -74,7 +74,7 @@ instance AffineMap.funLike (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*} (P
 instance AffineMap.hasCoeToFun (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*} (P2 : Type*)
     [Ring k] [AddCommGroup V1] [Module k V1] [AffineSpace V1 P1] [AddCommGroup V2] [Module k V2]
     [AffineSpace V2 P2] : CoeFun (P1 →ᵃ[k] P2) fun _ => P1 → P2 :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 #align affine_map.has_coe_to_fun AffineMap.hasCoeToFun
 
 namespace LinearMap
@@ -140,7 +140,7 @@ theorem linearMap_vsub (f : P1 →ᵃ[k] P2) (p1 p2 : P1) : f.linear (p1 -ᵥ p2
 /-- Two affine maps are equal if they coerce to the same function. -/
 @[ext]
 theorem ext {f g : P1 →ᵃ[k] P2} (h : ∀ p, f p = g p) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align affine_map.ext AffineMap.ext
 
 theorem ext_iff {f g : P1 →ᵃ[k] P2} : f = g ↔ ∀ p, f p = g p :=
@@ -148,7 +148,7 @@ theorem ext_iff {f g : P1 →ᵃ[k] P2} : f = g ↔ ∀ p, f p = g p :=
 #align affine_map.ext_iff AffineMap.ext_iff
 
 theorem coeFn_injective : @Function.Injective (P1 →ᵃ[k] P2) (P1 → P2) (⇑) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align affine_map.coe_fn_injective AffineMap.coeFn_injective
 
 protected theorem congr_arg (f : P1 →ᵃ[k] P2) {x y : P1} (h : x = y) : f x = f y :=

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -59,7 +59,7 @@ structure AffineMap (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*} (P2 : Typ
 induces a corresponding linear map from `V1` to `V2`. -/
 notation:25 P1 " →ᵃ[" k:25 "] " P2:0 => AffineMap k P1 P2
 
-instance AffineMap.funLike (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*} (P2 : Type*)
+instance AffineMap.instDFunLike (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*} (P2 : Type*)
     [Ring k] [AddCommGroup V1] [Module k V1] [AffineSpace V1 P1] [AddCommGroup V2] [Module k V2]
     [AffineSpace V2 P2] : DFunLike (P1 →ᵃ[k] P2) P1 fun _ => P2
     where
@@ -69,7 +69,7 @@ instance AffineMap.funLike (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*} (P
     congr with v
     apply vadd_right_cancel (f p)
     erw [← f_add, h, ← g_add]
-#align affine_map.fun_like AffineMap.funLike
+#align affine_map.fun_like AffineMap.instDFunLike
 
 instance AffineMap.hasCoeToFun (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*} (P2 : Type*)
     [Ring k] [AddCommGroup V1] [Module k V1] [AffineSpace V1 P1] [AddCommGroup V2] [Module k V2]

--- a/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
@@ -67,14 +67,14 @@ variable [Ring k] [Module k V] (b : AffineBasis ι k P) {s : Finset ι} {i j : �
 instance : Inhabited (AffineBasis PUnit k PUnit) :=
   ⟨⟨id, affineIndependent_of_subsingleton k id, by simp⟩⟩
 
-instance funLike : FunLike (AffineBasis ι k P) ι fun _ => P where
+instance funLike : DFunLike (AffineBasis ι k P) ι fun _ => P where
   coe := AffineBasis.toFun
   coe_injective' f g h := by cases f; cases g; congr
 #align affine_basis.fun_like AffineBasis.funLike
 
 @[ext]
 theorem ext {b₁ b₂ : AffineBasis ι k P} (h : (b₁ : ι → P) = b₂) : b₁ = b₂ :=
-  FunLike.coe_injective h
+  DFunLike.coe_injective h
 #align affine_basis.ext AffineBasis.ext
 
 theorem ind : AffineIndependent k b :=

--- a/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
@@ -67,10 +67,10 @@ variable [Ring k] [Module k V] (b : AffineBasis ι k P) {s : Finset ι} {i j : �
 instance : Inhabited (AffineBasis PUnit k PUnit) :=
   ⟨⟨id, affineIndependent_of_subsingleton k id, by simp⟩⟩
 
-instance funLike : DFunLike (AffineBasis ι k P) ι fun _ => P where
+instance instDFunLike : DFunLike (AffineBasis ι k P) ι fun _ => P where
   coe := AffineBasis.toFun
   coe_injective' f g h := by cases f; cases g; congr
-#align affine_basis.fun_like AffineBasis.funLike
+#align affine_basis.fun_like AffineBasis.instDFunLike
 
 @[ext]
 theorem ext {b₁ b₂ : AffineBasis ι k P} (h : (b₁ : ι → P) = b₂) : b₁ = b₂ :=

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -96,13 +96,13 @@ open Function
 
 section Coercions
 
-instance funLike : DFunLike (M [Λ^ι]→ₗ[R] N) (ι → M) (fun _ => N) where
+instance instDFunLike : DFunLike (M [Λ^ι]→ₗ[R] N) (ι → M) (fun _ => N) where
   coe f := f.toFun
   coe_injective' := fun f g h ↦ by
     rcases f with ⟨⟨_, _, _⟩, _⟩
     rcases g with ⟨⟨_, _, _⟩, _⟩
     congr
-#align alternating_map.fun_like AlternatingMap.funLike
+#align alternating_map.fun_like AlternatingMap.instDFunLike
 
 -- shortcut instance
 instance coeFun : CoeFun (M [Λ^ι]→ₗ[R] N) fun _ => (ι → M) → N :=

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -96,7 +96,7 @@ open Function
 
 section Coercions
 
-instance funLike : FunLike (M [Λ^ι]→ₗ[R] N) (ι → M) (fun _ => N) where
+instance funLike : DFunLike (M [Λ^ι]→ₗ[R] N) (ι → M) (fun _ => N) where
   coe f := f.toFun
   coe_injective' := fun f g h ↦ by
     rcases f with ⟨⟨_, _, _⟩, _⟩
@@ -106,7 +106,7 @@ instance funLike : FunLike (M [Λ^ι]→ₗ[R] N) (ι → M) (fun _ => N) where
 
 -- shortcut instance
 instance coeFun : CoeFun (M [Λ^ι]→ₗ[R] N) fun _ => (ι → M) → N :=
-  ⟨FunLike.coe⟩
+  ⟨DFunLike.coe⟩
 #align alternating_map.has_coe_to_fun AlternatingMap.coeFun
 
 initialize_simps_projections AlternatingMap (toFun → apply)
@@ -132,7 +132,7 @@ theorem congr_arg (f : M [Λ^ι]→ₗ[R] N) {x y : ι → M} (h : x = y) : f x 
 #align alternating_map.congr_arg AlternatingMap.congr_arg
 
 theorem coe_injective : Injective ((↑) : M [Λ^ι]→ₗ[R] N → (ι → M) → N) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align alternating_map.coe_injective AlternatingMap.coe_injective
 
 @[norm_cast] -- @[simp] -- Porting note: simp can prove this
@@ -142,7 +142,7 @@ theorem coe_inj {f g : M [Λ^ι]→ₗ[R] N} : (f : (ι → M) → N) = g ↔ f 
 
 @[ext]
 theorem ext {f f' : M [Λ^ι]→ₗ[R] N} (H : ∀ x, f x = f' x) : f = f' :=
-  FunLike.ext _ _ H
+  DFunLike.ext _ _ H
 #align alternating_map.ext AlternatingMap.ext
 
 theorem ext_iff {f g : M [Λ^ι]→ₗ[R] N} : f = g ↔ ∀ x, f x = g x :=

--- a/Mathlib/LinearAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basic.lean
@@ -233,7 +233,7 @@ theorem eqLocus_toAddSubmonoid (f g : F) :
 
 @[simp]
 theorem eqLocus_eq_top {f g : F} : eqLocus f g = ⊤ ↔ f = g := by
-  simp [SetLike.ext_iff, FunLike.ext_iff]
+  simp [SetLike.ext_iff, DFunLike.ext_iff]
 
 @[simp]
 theorem eqLocus_same (f : F) : eqLocus f f = ⊤ := eqLocus_eq_top.2 rfl
@@ -248,7 +248,7 @@ theorem eqOn_sup {f g : F} {S T : Submodule R M} (hS : Set.EqOn f g S) (hT : Set
 
 theorem ext_on_codisjoint {f g : F} {S T : Submodule R M} (hST : Codisjoint S T)
     (hS : Set.EqOn f g S) (hT : Set.EqOn f g T) : f = g :=
-  FunLike.ext _ _ fun _ ↦ eqOn_sup hS hT <| hST.eq_top.symm ▸ trivial
+  DFunLike.ext _ _ fun _ ↦ eqOn_sup hS hT <| hST.eq_top.symm ▸ trivial
 
 end
 
@@ -1356,8 +1356,8 @@ def congrLeft {R} (S) [Semiring R] [Semiring S] [Module R M₂] [Module R M₃] 
   invFun f := f.comp e.toLinearMap
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
-  left_inv f := by dsimp only; apply FunLike.ext; exact (congr_arg f <| e.left_inv ·)
-  right_inv f := by dsimp only; apply FunLike.ext; exact (congr_arg f <| e.right_inv ·)
+  left_inv f := by dsimp only; apply DFunLike.ext; exact (congr_arg f <| e.left_inv ·)
+  right_inv f := by dsimp only; apply DFunLike.ext; exact (congr_arg f <| e.right_inv ·)
 
 end CommSemiring
 

--- a/Mathlib/LinearAlgebra/Basis.lean
+++ b/Mathlib/LinearAlgebra/Basis.lean
@@ -119,11 +119,11 @@ theorem repr_injective : Injective (repr : Basis ι R M → M ≃ₗ[R] ι →�
 #align basis.repr_injective Basis.repr_injective
 
 /-- `b i` is the `i`th basis vector. -/
-instance funLike : DFunLike (Basis ι R M) ι fun _ => M where
+instance instDFunLike : DFunLike (Basis ι R M) ι fun _ => M where
   coe b i := b.repr.symm (Finsupp.single i 1)
   coe_injective' f g h := repr_injective <| LinearEquiv.symm_bijective.injective <|
     LinearEquiv.toLinearMap_injective <| by ext; exact congr_fun h _
-#align basis.fun_like Basis.funLike
+#align basis.fun_like Basis.instDFunLike
 
 @[simp]
 theorem coe_ofRepr (e : M ≃ₗ[R] ι →₀ R) : ⇑(ofRepr e) = fun i => e.symm (Finsupp.single i 1) :=

--- a/Mathlib/LinearAlgebra/Basis.lean
+++ b/Mathlib/LinearAlgebra/Basis.lean
@@ -84,7 +84,7 @@ variable (ι R M)
 
 /-- A `Basis ι R M` for a module `M` is the type of `ι`-indexed `R`-bases of `M`.
 
-The basis vectors are available as `FunLike.coe (b : Basis ι R M) : ι → M`.
+The basis vectors are available as `DFunLike.coe (b : Basis ι R M) : ι → M`.
 To turn a linear independent family of vectors spanning `M` into a basis, use `Basis.mk`.
 They are internally represented as linear equivs `M ≃ₗ[R] (ι →₀ R)`,
 available as `Basis.repr`.
@@ -119,7 +119,7 @@ theorem repr_injective : Injective (repr : Basis ι R M → M ≃ₗ[R] ι →�
 #align basis.repr_injective Basis.repr_injective
 
 /-- `b i` is the `i`th basis vector. -/
-instance funLike : FunLike (Basis ι R M) ι fun _ => M where
+instance funLike : DFunLike (Basis ι R M) ι fun _ => M where
   coe b i := b.repr.symm (Finsupp.single i 1)
   coe_injective' f g h := repr_injective <| LinearEquiv.symm_bijective.injective <|
     LinearEquiv.toLinearMap_injective <| by ext; exact congr_fun h _
@@ -218,7 +218,7 @@ def coord : M →ₗ[R] R :=
 #align basis.coord Basis.coord
 
 theorem forall_coord_eq_zero_iff {x : M} : (∀ i, b.coord i x = 0) ↔ x = 0 :=
-  Iff.trans (by simp only [b.coord_apply, FunLike.ext_iff, Finsupp.zero_apply])
+  Iff.trans (by simp only [b.coord_apply, DFunLike.ext_iff, Finsupp.zero_apply])
     b.repr.map_eq_zero_iff
 #align basis.forall_coord_eq_zero_iff Basis.forall_coord_eq_zero_iff
 
@@ -289,7 +289,7 @@ theorem ext' {f₁ f₂ : M ≃ₛₗ[σ] M₁} (h : ∀ i, f₁ (b i) = f₂ (b
 
 /-- Two elements are equal iff their coordinates are equal. -/
 theorem ext_elem_iff {x y : M} : x = y ↔ ∀ i, b.repr x i = b.repr y i := by
-  simp only [← FunLike.ext_iff, EmbeddingLike.apply_eq_iff_eq]
+  simp only [← DFunLike.ext_iff, EmbeddingLike.apply_eq_iff_eq]
 #align basis.ext_elem_iff Basis.ext_elem_iff
 
 alias ⟨_, _root_.Basis.ext_elem⟩ := ext_elem_iff
@@ -337,7 +337,7 @@ theorem eq_ofRepr_eq_repr {b₁ b₂ : Basis ι R M} (h : ∀ x i, b₁.repr x i
 /-- Two bases are equal if their basis vectors are the same. -/
 @[ext]
 theorem eq_of_apply_eq {b₁ b₂ : Basis ι R M} : (∀ i, b₁ i = b₂ i) → b₁ = b₂ :=
-  FunLike.ext _ _
+  DFunLike.ext _ _
 #align basis.eq_of_apply_eq Basis.eq_of_apply_eq
 
 end Ext
@@ -436,7 +436,7 @@ theorem repr_reindex_apply (i' : ι') : (b.reindex e).repr x i' = b.repr x (e.sy
 
 @[simp]
 theorem repr_reindex : (b.reindex e).repr x = (b.repr x).mapDomain e :=
-  FunLike.ext _ _ <| by simp [repr_reindex_apply]
+  DFunLike.ext _ _ <| by simp [repr_reindex_apply]
 #align basis.repr_reindex Basis.repr_reindex
 
 @[simp]
@@ -1470,7 +1470,7 @@ theorem Basis.restrictScalars_repr_apply (m : span R (Set.range b)) (i : ι) :
   suffices
     Finsupp.mapRange.linearMap (Algebra.linearMap R S) ∘ₗ (b.restrictScalars R).repr.toLinearMap =
       ((b.repr : M →ₗ[S] ι →₀ S).restrictScalars R).domRestrict _
-    by exact FunLike.congr_fun (LinearMap.congr_fun this m) i
+    by exact DFunLike.congr_fun (LinearMap.congr_fun this m) i
   refine Basis.ext (b.restrictScalars R) fun _ => ?_
   simp only [LinearMap.coe_comp, LinearEquiv.coe_toLinearMap, Function.comp_apply, map_one,
     Basis.repr_self, Finsupp.mapRange.linearMap_apply, Finsupp.mapRange_single,
@@ -1601,7 +1601,7 @@ theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b 
       apply_fun fun x => b.repr x b' at z
       simp only [repr_self, LinearEquiv.map_smul, mul_one, Finsupp.single_eq_same, Pi.neg_apply,
         Finsupp.smul_single', LinearEquiv.map_neg, Finsupp.coe_neg] at z
-      erw [FunLike.congr_fun (Finsupp.apply_total R (b.repr : M →ₗ[R] ι →₀ R) v l.some) b'] at z
+      erw [DFunLike.congr_fun (Finsupp.apply_total R (b.repr : M →ₗ[R] ι →₀ R) v l.some) b'] at z
       simpa [Finsupp.total_apply, w] using z
     -- Then all the other coefficients are zero, because `v` is linear independent.
     have l₁ : l.some = 0 := by
@@ -1610,7 +1610,7 @@ theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b 
     -- Finally we put those facts together to show the linear combination is trivial.
     ext (_ | a)
     · simp only [l₀, Finsupp.coe_zero, Pi.zero_apply]
-    · erw [FunLike.congr_fun l₁ a]
+    · erw [DFunLike.congr_fun l₁ a]
       simp only [Finsupp.coe_zero, Pi.zero_apply]
   rw [LinearIndependent.Maximal] at m
   specialize m (range v') i' r

--- a/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
@@ -149,7 +149,7 @@ lemma smul_right_of_tower (r : S) (x y : M) : B x (r • y) = r • B x y := by
 
 variable {D : BilinForm R M} {D₁ : BilinForm R₁ M₁}
 
--- TODO: instantiate `DFunLike`
+-- TODO: instantiate `FunLike`
 theorem coe_injective : Function.Injective ((↑) : BilinForm R M → M → M → R) := fun B D h => by
   cases B
   cases D

--- a/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
@@ -149,7 +149,7 @@ lemma smul_right_of_tower (r : S) (x y : M) : B x (r • y) = r • B x y := by
 
 variable {D : BilinForm R M} {D₁ : BilinForm R₁ M₁}
 
--- TODO: instantiate `FunLike`
+-- TODO: instantiate `DFunLike`
 theorem coe_injective : Function.Injective ((↑) : BilinForm R M → M → M → R) := fun B D h => by
   cases B
   cases D

--- a/Mathlib/LinearAlgebra/BilinearForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/TensorProduct.lean
@@ -144,7 +144,7 @@ theorem tensorDistribEquiv_toLinearMap :
 @[simp]
 theorem tensorDistribEquiv_apply (B : BilinForm R M₁ ⊗ BilinForm R M₂) :
     tensorDistribEquiv R (M₁ := M₁) (M₂ := M₂) B = tensorDistrib R R B :=
-  FunLike.congr_fun (tensorDistribEquiv_toLinearMap R M₁ M₂) B
+  DFunLike.congr_fun (tensorDistribEquiv_toLinearMap R M₁ M₂) B
 #align bilin_form.tensor_distrib_equiv_apply BilinForm.tensorDistribEquiv_apply
 
 end CommRing

--- a/Mathlib/LinearAlgebra/Charpoly/ToMatrix.lean
+++ b/Mathlib/LinearAlgebra/Charpoly/ToMatrix.lean
@@ -39,7 +39,7 @@ section Basic
 attribute [-instance] instCoeOut
 
 attribute [local instance 2000] RingHomClass.toNonUnitalRingHomClass
-attribute [local instance 2000] NonUnitalRingHomClass.toMulHomClass MulHomClass.toFunLike
+attribute [local instance 2000] NonUnitalRingHomClass.toMulHomClass MulHomClass.toDFunLike
 
 /-- `charpoly f` is the characteristic polynomial of the matrix of `f` in any basis. -/
 @[simp]

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/BaseChange.lean
@@ -117,7 +117,7 @@ theorem toBaseChange_comp_involute (Q : QuadraticForm R V) :
 theorem toBaseChange_involute (Q : QuadraticForm R V) (x : CliffordAlgebra (Q.baseChange A)) :
     toBaseChange A Q (involute x) =
       TensorProduct.map LinearMap.id (involute.toLinearMap) (toBaseChange A Q x) :=
-  FunLike.congr_fun (toBaseChange_comp_involute A Q) x
+  DFunLike.congr_fun (toBaseChange_comp_involute A Q) x
 
 open MulOpposite
 
@@ -141,7 +141,7 @@ theorem toBaseChange_comp_reverseOp (Q : QuadraticForm R V) :
 theorem toBaseChange_reverse (Q : QuadraticForm R V) (x : CliffordAlgebra (Q.baseChange A)) :
     toBaseChange A Q (reverse x) =
       TensorProduct.map LinearMap.id reverse (toBaseChange A Q x) := by
-  have := FunLike.congr_fun (toBaseChange_comp_reverseOp A Q) x
+  have := DFunLike.congr_fun (toBaseChange_comp_reverseOp A Q) x
   refine (congr_arg unop this).trans ?_; clear this
   refine (LinearMap.congr_fun (TensorProduct.AlgebraTensorModule.map_comp _ _ _ _).symm _).trans ?_
   rw [reverse, ← AlgEquiv.toLinearMap, ← AlgEquiv.toLinearEquiv_toLinearMap,

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -250,7 +250,7 @@ theorem forall_mul_self_eq_iff {A : Type*} [Ring A] [Algebra R A] (h2 : IsUnit (
     (∀ x, f x * f x = algebraMap _ _ (Q x)) ↔
       (LinearMap.mul R A).compl₂ f ∘ₗ f + (LinearMap.mul R A).flip.compl₂ f ∘ₗ f =
         Q.polarBilin.toLin.compr₂ (Algebra.linearMap R A) := by
-  simp_rw [FunLike.ext_iff]
+  simp_rw [DFunLike.ext_iff]
   refine ⟨mul_add_swap_eq_polar_of_forall_mul_self_eq _, fun h x => ?_⟩
   change ∀ x y : M, f x * f y + f y * f x = algebraMap R A (QuadraticForm.polar Q x y) at h
   apply h2.mul_left_cancel

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Fold.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Fold.lean
@@ -100,7 +100,7 @@ def foldl (f : M →ₗ[R] N →ₗ[R] N) (hf : ∀ m x, f m (f m x) = Q m • x
 @[simp]
 theorem foldl_reverse (f : M →ₗ[R] N →ₗ[R] N) (hf) (n : N) (x : CliffordAlgebra Q) :
     foldl Q f hf n (reverse x) = foldr Q f hf n x :=
-  FunLike.congr_arg (foldr Q f hf n) <| reverse_reverse _
+  DFunLike.congr_arg (foldr Q f hf n) <| reverse_reverse _
 #align clifford_algebra.foldl_reverse CliffordAlgebra.foldl_reverse
 
 @[simp]

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -449,7 +449,7 @@ theorem independent_of_dfinsupp_lsum_injective (p : ι → Submodule R N)
     lsum ℕ (M := fun i ↦ ↥(p i)) (fun i => (p i).subtype) (erase i v) =
       lsum ℕ (M := fun i ↦ ↥(p i)) (fun i => (p i).subtype) (single i x)
   · simpa only [lsum_single] using hv
-  have := FunLike.ext_iff.mp (h hv) i
+  have := DFunLike.ext_iff.mp (h hv) i
   simpa [eq_comm] using this
 #align complete_lattice.independent_of_dfinsupp_lsum_injective CompleteLattice.independent_of_dfinsupp_lsum_injective
 

--- a/Mathlib/LinearAlgebra/Dimension/DivisionRing.lean
+++ b/Mathlib/LinearAlgebra/Dimension/DivisionRing.lean
@@ -467,7 +467,7 @@ variable [DivisionRing K]
 /-- Key lemma towards the Erdős-Kaplansky theorem from https://mathoverflow.net/a/168624 -/
 theorem max_aleph0_card_le_rank_fun_nat : max ℵ₀ #K ≤ Module.rank K (ℕ → K) := by
   have aleph0_le : ℵ₀ ≤ Module.rank K (ℕ → K) := (rank_finsupp_self K ℕ).symm.trans_le
-    (Finsupp.lcoeFun.rank_le_of_injective <| by exact FunLike.coe_injective)
+    (Finsupp.lcoeFun.rank_le_of_injective <| by exact DFunLike.coe_injective)
   refine max_le aleph0_le ?_
   obtain card_K | card_K := le_or_lt #K ℵ₀
   · exact card_K.trans aleph0_le

--- a/Mathlib/LinearAlgebra/Dimension/Finite.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finite.lean
@@ -64,7 +64,7 @@ lemma rank_eq_zero_iff :
     rintro ⟨i : s⟩
     obtain ⟨a, ha, ha'⟩ := h i
     apply ha
-    simpa using FunLike.congr_fun (linearIndependent_iff.mp hs (Finsupp.single i a) (by simpa)) i
+    simpa using DFunLike.congr_fun (linearIndependent_iff.mp hs (Finsupp.single i a) (by simpa)) i
 
 variable [Nontrivial R]
 

--- a/Mathlib/LinearAlgebra/Dual.lean
+++ b/Mathlib/LinearAlgebra/Dual.lean
@@ -345,7 +345,7 @@ theorem toDual_eq_equivFun [Fintype ι] (m : M) (i : ι) : b.toDual m (b i) = b.
 #align basis.to_dual_eq_equiv_fun Basis.toDual_eq_equivFun
 
 theorem toDual_injective : Injective b.toDual := fun x y h ↦ b.ext_elem_iff.mpr fun i ↦ by
-  simp_rw [← toDual_eq_repr]; exact FunLike.congr_fun h _
+  simp_rw [← toDual_eq_repr]; exact DFunLike.congr_fun h _
 
 theorem toDual_inj (m : M) (a : b.toDual m = 0) : m = 0 :=
   b.toDual_injective (by rwa [_root_.map_zero])
@@ -687,7 +687,7 @@ lemma equiv [IsReflexive R M] (e : M ≃ₗ[R] N) : IsReflexive R N where
     let ed : Dual R (Dual R N) ≃ₗ[R] Dual R (Dual R M) := e.symm.dualMap.dualMap
     have : Dual.eval R N = ed.symm.comp ((Dual.eval R M).comp e.symm.toLinearMap) := by
       ext m f
-      exact FunLike.congr_arg f (e.apply_symm_apply m).symm
+      exact DFunLike.congr_arg f (e.apply_symm_apply m).symm
     simp only [this, LinearEquiv.trans_symm, LinearEquiv.symm_symm, LinearEquiv.dualMap_symm,
       coe_comp, LinearEquiv.coe_coe, EquivLike.comp_bijective]
     exact Bijective.comp (bijective_dual_eval R M) (LinearEquiv.bijective _)
@@ -1106,7 +1106,7 @@ variable {W : Subspace K V}
 
 @[simp]
 theorem dualLift_of_subtype {φ : Module.Dual K W} (w : W) : W.dualLift φ (w : V) = φ w :=
-  congr_arg φ <| FunLike.congr_fun
+  congr_arg φ <| DFunLike.congr_fun
     (Classical.choose_spec <| W.subtype.exists_leftInverse_of_injective W.ker_subtype) w
 #align subspace.dual_lift_of_subtype Subspace.dualLift_of_subtype
 
@@ -1295,7 +1295,7 @@ def dualCopairing (W : Submodule R M) : W.dualAnnihilator →ₗ[R] M ⧸ W →�
 #align submodule.dual_copairing Submodule.dualCopairing
 
 -- Porting note: helper instance
-instance (W : Submodule R M) : FunLike (W.dualAnnihilator) M fun _ => R :=
+instance (W : Submodule R M) : DFunLike (W.dualAnnihilator) M fun _ => R :=
   { coe := fun φ => φ.val,
     coe_injective' := fun φ ψ h => by
       ext
@@ -1390,7 +1390,7 @@ theorem quotDualCoannihilatorToDual_injective (W : Submodule R (Dual R M)) :
 
 theorem flip_quotDualCoannihilatorToDual_injective (W : Submodule R (Dual R M)) :
     Function.Injective W.quotDualCoannihilatorToDual.flip :=
-  fun _ _ he ↦ Subtype.ext <| LinearMap.ext fun m ↦ FunLike.congr_fun he ⟦m⟧
+  fun _ _ he ↦ Subtype.ext <| LinearMap.ext fun m ↦ DFunLike.congr_fun he ⟦m⟧
 
 open LinearMap in
 theorem quotDualCoannihilatorToDual_nondegenerate (W : Submodule R (Dual R M)) :

--- a/Mathlib/LinearAlgebra/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional.lean
@@ -1078,7 +1078,7 @@ theorem surjective_of_nonzero_of_finrank_eq_one {W A : Type*} [Semiring A] [Modu
     [AddCommGroup W] [Module K W] [Module A W] [LinearMap.CompatibleSMul V W K A]
     (h : finrank K W = 1) {f : V →ₗ[A] W} (w : f ≠ 0) : Surjective f := by
   change Surjective (f.restrictScalars K)
-  obtain ⟨v, n⟩ := FunLike.ne_iff.mp w
+  obtain ⟨v, n⟩ := DFunLike.ne_iff.mp w
   intro z
   obtain ⟨c, rfl⟩ := (finrank_eq_one_iff_of_nonzero' (f v) n).mp h z
   exact ⟨c • v, by simp⟩

--- a/Mathlib/LinearAlgebra/FinsuppVectorSpace.lean
+++ b/Mathlib/LinearAlgebra/FinsuppVectorSpace.lean
@@ -79,7 +79,8 @@ protected def basis {φ : ι → Type*} (b : ∀ i, Basis (φ i) R M) : Basis (�
             (b i).repr.symm (g.comapDomain _ (Set.injOn_of_injective sigma_mk_injective _))
           support := g.support.image Sigma.fst
           mem_support_toFun := fun i => by
-            rw [Ne.def, ← (b i).repr.injective.eq_iff, (b i).repr.apply_symm_apply, DFunLike.ext_iff]
+            rw [Ne.def, ← (b i).repr.injective.eq_iff, (b i).repr.apply_symm_apply,
+                DFunLike.ext_iff]
             simp only [exists_prop, LinearEquiv.map_zero, comapDomain_apply, zero_apply,
               exists_and_right, mem_support_iff, exists_eq_right, Sigma.exists, Finset.mem_image,
               not_forall] }

--- a/Mathlib/LinearAlgebra/FinsuppVectorSpace.lean
+++ b/Mathlib/LinearAlgebra/FinsuppVectorSpace.lean
@@ -79,7 +79,7 @@ protected def basis {φ : ι → Type*} (b : ∀ i, Basis (φ i) R M) : Basis (�
             (b i).repr.symm (g.comapDomain _ (Set.injOn_of_injective sigma_mk_injective _))
           support := g.support.image Sigma.fst
           mem_support_toFun := fun i => by
-            rw [Ne.def, ← (b i).repr.injective.eq_iff, (b i).repr.apply_symm_apply, FunLike.ext_iff]
+            rw [Ne.def, ← (b i).repr.injective.eq_iff, (b i).repr.apply_symm_apply, DFunLike.ext_iff]
             simp only [exists_prop, LinearEquiv.map_zero, comapDomain_apply, zero_apply,
               exists_and_right, mem_support_iff, exists_eq_right, Sigma.exists, Finset.mem_image,
               not_forall] }

--- a/Mathlib/LinearAlgebra/Isomorphisms.lean
+++ b/Mathlib/LinearAlgebra/Isomorphisms.lean
@@ -106,7 +106,7 @@ noncomputable def quotientInfEquivSupQuotient (p p' : Submodule R M) :
 #align linear_map.quotient_inf_equiv_sup_quotient LinearMap.quotientInfEquivSupQuotient
 
 -- @[simp]
--- Porting note: `simp` affects the type arguments of `FunLike.coe`, so this theorem can't be
+-- Porting note: `simp` affects the type arguments of `DFunLike.coe`, so this theorem can't be
 --               a simp theorem anymore, even if it has high priority.
 theorem coe_quotientInfToSupQuotient (p p' : Submodule R M) :
     ⇑(quotientInfToSupQuotient p p') = quotientInfEquivSupQuotient p p' :=

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -144,7 +144,7 @@ theorem linearIndependent_iff' :
               (fun j _hjs hji => by rw [Finsupp.lapply_apply, Finsupp.single_eq_of_ne hji])
               fun hnis => hnis.elim his
         _ = (∑ j in s, Finsupp.single j (g j)) i := (map_sum ..).symm
-        _ = 0 := FunLike.ext_iff.1 h i,
+        _ = 0 := DFunLike.ext_iff.1 h i,
       fun hf l hl =>
       Finsupp.ext fun i =>
         _root_.by_contradiction fun hni => hni <| hf _ _ hl _ <| Finsupp.mem_support_iff.2 hni⟩
@@ -1204,7 +1204,7 @@ lemma linearIndependent_algHom_toLinearMap
   apply LinearIndependent.of_comp (LinearMap.ltoFun K M L)
   exact (linearIndependent_monoidHom M L).comp
     (RingHom.toMonoidHom ∘ AlgHom.toRingHom)
-    (fun _ _ e ↦ AlgHom.ext (FunLike.congr_fun e : _))
+    (fun _ _ e ↦ AlgHom.ext (DFunLike.congr_fun e : _))
 
 lemma linearIndependent_algHom_toLinearMap' (K M L) [CommRing K]
     [Semiring M] [Algebra K M] [CommRing L] [IsDomain L] [Algebra K L] [NoZeroSMulDivisors K L] :

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
@@ -163,7 +163,7 @@ theorem matPolyEquiv_symm_map_eval (M : (Matrix n n R)[X]) (r : R) :
   suffices ((aeval r).mapMatrix.comp matPolyEquiv.symm.toAlgHom : (Matrix n n R)[X] →ₐ[R] _) =
       (eval₂AlgHom' (AlgHom.id R _) (scalar n r)
         fun x => (scalar_commute _ (Commute.all _) _).symm) from
-    FunLike.congr_fun this M
+    DFunLike.congr_fun this M
   ext : 1
   · ext M : 1
     simp [Function.comp]

--- a/Mathlib/LinearAlgebra/Matrix/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant.lean
@@ -658,7 +658,7 @@ theorem det_fromBlocks_zero₂₁ (A : Matrix m m R) (B : Matrix m n R) (D : Mat
       dsimp only
       intro h
       have h2 : ∀ x, Perm.sumCongr σ₁.fst σ₁.snd x = Perm.sumCongr σ₂.fst σ₂.snd x :=
-        FunLike.congr_fun h
+        DFunLike.congr_fun h
       simp only [Sum.map_inr, Sum.map_inl, Perm.sumCongr_apply, Sum.forall, Sum.inl.injEq,
         Sum.inr.injEq] at h2
       ext x

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -107,8 +107,8 @@ variable [Semiring R] [∀ i, AddCommMonoid (M i)] [∀ i, AddCommMonoid (M₁ i
   [AddCommMonoid M₃] [AddCommMonoid M'] [∀ i, Module R (M i)] [∀ i, Module R (M₁ i)] [Module R M₂]
   [Module R M₃] [Module R M'] (f f' : MultilinearMap R M₁ M₂)
 
--- Porting note: Replaced CoeFun with FunLike instance
-instance : FunLike (MultilinearMap R M₁ M₂) (∀ i, M₁ i) (fun _ ↦ M₂) where
+-- Porting note: Replaced CoeFun with DFunLike instance
+instance : DFunLike (MultilinearMap R M₁ M₂) (∀ i, M₁ i) (fun _ ↦ M₂) where
   coe f := f.toFun
   coe_injective' := fun f g h ↦ by cases f; cases g; cases h; rfl
 
@@ -125,29 +125,29 @@ theorem coe_mk (f : (∀ i, M₁ i) → M₂) (h₁ h₂) : ⇑(⟨f, h₁, h₂
 #align multilinear_map.coe_mk MultilinearMap.coe_mk
 
 theorem congr_fun {f g : MultilinearMap R M₁ M₂} (h : f = g) (x : ∀ i, M₁ i) : f x = g x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align multilinear_map.congr_fun MultilinearMap.congr_fun
 
 nonrec theorem congr_arg (f : MultilinearMap R M₁ M₂) {x y : ∀ i, M₁ i} (h : x = y) : f x = f y :=
-  FunLike.congr_arg f h
+  DFunLike.congr_arg f h
 #align multilinear_map.congr_arg MultilinearMap.congr_arg
 
 theorem coe_injective : Injective ((↑) : MultilinearMap R M₁ M₂ → (∀ i, M₁ i) → M₂) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align multilinear_map.coe_injective MultilinearMap.coe_injective
 
 @[norm_cast] -- Porting note: Removed simp attribute, simp can prove this
 theorem coe_inj {f g : MultilinearMap R M₁ M₂} : (f : (∀ i, M₁ i) → M₂) = g ↔ f = g :=
-  FunLike.coe_fn_eq
+  DFunLike.coe_fn_eq
 #align multilinear_map.coe_inj MultilinearMap.coe_inj
 
 @[ext]
 theorem ext {f f' : MultilinearMap R M₁ M₂} (H : ∀ x, f x = f' x) : f = f' :=
-  FunLike.ext _ _ H
+  DFunLike.ext _ _ H
 #align multilinear_map.ext MultilinearMap.ext
 
 theorem ext_iff {f g : MultilinearMap R M₁ M₂} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align multilinear_map.ext_iff MultilinearMap.ext_iff
 
 @[simp]
@@ -232,7 +232,7 @@ instance addCommMonoid : AddCommMonoid (MultilinearMap R M₁ M₂) :=
 
 /-- Coercion of a multilinear map to a function as an additive monoid homomorphism. -/
 @[simps] def coeAddMonoidHom : MultilinearMap R M₁ M₂ →+ (((i : ι) → M₁ i) → M₂) where
-  toFun := FunLike.coe; map_zero' := rfl; map_add' _ _ := rfl
+  toFun := DFunLike.coe; map_zero' := rfl; map_add' _ _ := rfl
 
 @[simp]
 theorem coe_sum {α : Type*} (f : α → MultilinearMap R M₁ M₂) (s : Finset α) :
@@ -309,7 +309,7 @@ def constOfIsEmpty [IsEmpty ι] (m : M₂) : MultilinearMap R M₁ M₂ where
 
 end
 
--- Porting note: Included `FunLike.coe` to avoid strange CoeFun instance for Equiv
+-- Porting note: Included `DFunLike.coe` to avoid strange CoeFun instance for Equiv
 /-- Given a multilinear map `f` on `n` variables (parameterized by `Fin n`) and a subset `s` of `k`
 of these variables, one gets a new multilinear map on `Fin k` by varying these variables, and fixing
 the other ones equal to a given value `z`. It is denoted by `f.restr s hk z`, where `hk` is a
@@ -317,18 +317,18 @@ proof that the cardinality of `s` is `k`. The implicit identification between `F
 we use is the canonical (increasing) bijection. -/
 def restr {k n : ℕ} (f : MultilinearMap R (fun _ : Fin n => M') M₂) (s : Finset (Fin n))
     (hk : s.card = k) (z : M') : MultilinearMap R (fun _ : Fin k => M') M₂ where
-  toFun v := f fun j => if h : j ∈ s then v ((FunLike.coe (s.orderIsoOfFin hk).symm) ⟨j, h⟩) else z
+  toFun v := f fun j => if h : j ∈ s then v ((DFunLike.coe (s.orderIsoOfFin hk).symm) ⟨j, h⟩) else z
   /- Porting note: The proofs of the following two lemmas used to only use `erw` followed by `simp`,
   but it seems `erw` no longer unfolds or unifies well enough to work without more help. -/
   map_add' v i x y := by
-    have : FunLike.coe (s.orderIsoOfFin hk).symm = (s.orderIsoOfFin hk).toEquiv.symm := rfl
+    have : DFunLike.coe (s.orderIsoOfFin hk).symm = (s.orderIsoOfFin hk).toEquiv.symm := rfl
     simp only [this]
     erw [dite_comp_equiv_update (s.orderIsoOfFin hk).toEquiv,
       dite_comp_equiv_update (s.orderIsoOfFin hk).toEquiv,
       dite_comp_equiv_update (s.orderIsoOfFin hk).toEquiv]
     simp
   map_smul' v i c x := by
-    have : FunLike.coe (s.orderIsoOfFin hk).symm = (s.orderIsoOfFin hk).toEquiv.symm := rfl
+    have : DFunLike.coe (s.orderIsoOfFin hk).symm = (s.orderIsoOfFin hk).toEquiv.symm := rfl
     simp only [this]
     erw [dite_comp_equiv_update (s.orderIsoOfFin hk).toEquiv,
       dite_comp_equiv_update (s.orderIsoOfFin hk).toEquiv]

--- a/Mathlib/LinearAlgebra/PerfectPairing.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing.lean
@@ -43,7 +43,7 @@ variable {R M N}
 
 namespace PerfectPairing
 
-instance instFunLike : FunLike (PerfectPairing R M N) M (fun _  ↦ N →ₗ[R] R) where
+instance instFunLike : DFunLike (PerfectPairing R M N) M (fun _  ↦ N →ₗ[R] R) where
   coe f := f.toLin
   coe_injective' x y h := by cases x; cases y; simpa using h
 

--- a/Mathlib/LinearAlgebra/PerfectPairing.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing.lean
@@ -43,7 +43,7 @@ variable {R M N}
 
 namespace PerfectPairing
 
-instance instFunLike : DFunLike (PerfectPairing R M N) M (fun _  ↦ N →ₗ[R] R) where
+instance instDFunLike : DFunLike (PerfectPairing R M N) M (fun _  ↦ N →ₗ[R] R) where
   coe f := f.toLin
   coe_injective' x y h := by cases x; cases y; simpa using h
 

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -370,10 +370,10 @@ open Submodule
 /--
 A linear endomorphism of a module `E` is a projection onto a submodule `p` if it sends every element
 of `E` to `p` and fixes every element of `p`.
-The definition allow more generally any `FunLike` type and not just linear maps, so that it can be
+The definition allow more generally any `DFunLike` type and not just linear maps, so that it can be
 used for example with `ContinuousLinearMap` or `Matrix`.
 -/
-structure IsProj {F : Type*} [FunLike F M fun _ => M] (f : F) : Prop where
+structure IsProj {F : Type*} [DFunLike F M fun _ => M] (f : F) : Prop where
   map_mem : ∀ x, f x ∈ m
   map_id : ∀ x ∈ m, f x = x
 #align linear_map.is_proj LinearMap.IsProj

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -147,25 +147,25 @@ structure QuadraticForm (R : Type u) (M : Type v) [CommSemiring R] [AddCommMonoi
 
 namespace QuadraticForm
 
-section FunLike
+section DFunLike
 
 variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 variable {Q Q' : QuadraticForm R M}
 
-instance funLike : FunLike (QuadraticForm R M) M fun _ => R where
+instance funLike : DFunLike (QuadraticForm R M) M fun _ => R where
   coe := toFun
   coe_injective' x y h := by cases x; cases y; congr
 #align quadratic_form.fun_like QuadraticForm.funLike
 
 /-- Helper instance for when there's too many metavariables to apply
-`FunLike.hasCoeToFun` directly. -/
+`DFunLike.hasCoeToFun` directly. -/
 instance : CoeFun (QuadraticForm R M) fun _ => M → R :=
-  ⟨FunLike.coe⟩
+  ⟨DFunLike.coe⟩
 
 variable (Q)
 
-/-- The `simp` normal form for a quadratic form is `FunLike.coe`, not `toFun`. -/
+/-- The `simp` normal form for a quadratic form is `DFunLike.coe`, not `toFun`. -/
 @[simp]
 theorem toFun_eq_coe : Q.toFun = ⇑Q :=
   rfl
@@ -178,15 +178,15 @@ variable {Q}
 
 @[ext]
 theorem ext (H : ∀ x : M, Q x = Q' x) : Q = Q' :=
-  FunLike.ext _ _ H
+  DFunLike.ext _ _ H
 #align quadratic_form.ext QuadraticForm.ext
 
 theorem congr_fun (h : Q = Q') (x : M) : Q x = Q' x :=
-  FunLike.congr_fun h _
+  DFunLike.congr_fun h _
 #align quadratic_form.congr_fun QuadraticForm.congr_fun
 
 theorem ext_iff : Q = Q' ↔ ∀ x, Q x = Q' x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align quadratic_form.ext_iff QuadraticForm.ext_iff
 
 /-- Copy of a `QuadraticForm` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -203,10 +203,10 @@ theorem coe_copy (Q : QuadraticForm R M) (Q' : M → R) (h : Q' = ⇑Q) : ⇑(Q.
 #align quadratic_form.coe_copy QuadraticForm.coe_copy
 
 theorem copy_eq (Q : QuadraticForm R M) (Q' : M → R) (h : Q' = ⇑Q) : Q.copy Q' h = Q :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align quadratic_form.copy_eq QuadraticForm.copy_eq
 
-end FunLike
+end DFunLike
 
 section CommSemiring
 
@@ -447,14 +447,14 @@ theorem add_apply (Q Q' : QuadraticForm R M) (x : M) : (Q + Q') x = Q x + Q' x :
 #align quadratic_form.add_apply QuadraticForm.add_apply
 
 instance : AddCommMonoid (QuadraticForm R M) :=
-  FunLike.coe_injective.addCommMonoid _ coeFn_zero coeFn_add fun _ _ => coeFn_smul _ _
+  DFunLike.coe_injective.addCommMonoid _ coeFn_zero coeFn_add fun _ _ => coeFn_smul _ _
 
 /-- `@CoeFn (QuadraticForm R M)` as an `AddMonoidHom`.
 
 This API mirrors `AddMonoidHom.coeFn`. -/
 @[simps apply]
 def coeFnAddMonoidHom : QuadraticForm R M →+ M → R where
-  toFun := FunLike.coe
+  toFun := DFunLike.coe
   map_zero' := coeFn_zero
   map_add' := coeFn_add
 #align quadratic_form.coe_fn_add_monoid_hom QuadraticForm.coeFnAddMonoidHom
@@ -538,7 +538,7 @@ theorem sub_apply (Q Q' : QuadraticForm R M) (x : M) : (Q - Q') x = Q x - Q' x :
 #align quadratic_form.sub_apply QuadraticForm.sub_apply
 
 instance : AddCommGroup (QuadraticForm R M) :=
-  FunLike.coe_injective.addCommGroup _ coeFn_zero coeFn_add coeFn_neg coeFn_sub
+  DFunLike.coe_injective.addCommGroup _ coeFn_zero coeFn_add coeFn_neg coeFn_sub
     (fun _ _ => coeFn_smul _ _) fun _ _ => coeFn_smul _ _
 
 end RingOperators
@@ -770,7 +770,7 @@ theorem polarBilin_toQuadraticForm : polarBilin (toQuadraticForm B) = B + flip' 
 theorem  _root_.QuadraticForm.polarBilin_injective (h : IsUnit (2 : R)) :
     Function.Injective (polarBilin : QuadraticForm R M → _) :=
   fun Q₁ Q₂ h₁₂ => QuadraticForm.ext fun x => h.mul_left_cancel <| by
-    simpa using FunLike.congr_fun (congr_arg toQuadraticForm h₁₂) x
+    simpa using DFunLike.congr_fun (congr_arg toQuadraticForm h₁₂) x
 
 variable {N : Type v}
 variable [CommRing S] [Algebra S R] [Module S M] [IsScalarTower S R M]

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -153,10 +153,10 @@ variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 variable {Q Q' : QuadraticForm R M}
 
-instance funLike : DFunLike (QuadraticForm R M) M fun _ => R where
+instance instDFunLike : DFunLike (QuadraticForm R M) M fun _ => R where
   coe := toFun
   coe_injective' x y h := by cases x; cases y; congr
-#align quadratic_form.fun_like QuadraticForm.funLike
+#align quadratic_form.fun_like QuadraticForm.instDFunLike
 
 /-- Helper instance for when there's too many metavariables to apply
 `DFunLike.hasCoeToFun` directly. -/
@@ -241,7 +241,7 @@ theorem map_zero : Q 0 = 0 := by
 #align quadratic_form.map_zero QuadraticForm.map_zero
 
 instance zeroHomClass : ZeroHomClass (QuadraticForm R M) M R :=
-  { QuadraticForm.funLike with map_zero := map_zero }
+  { QuadraticForm.instDFunLike with map_zero := map_zero }
 #align quadratic_form.zero_hom_class QuadraticForm.zeroHomClass
 
 theorem map_smul_of_tower [CommSemiring S] [Algebra S R] [Module S M] [IsScalarTower S R M] (a : S)

--- a/Mathlib/LinearAlgebra/QuadraticForm/Dual.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Dual.lean
@@ -113,7 +113,7 @@ variable {R M N}
 @[simps!]
 def dualProdIsometry (f : M ≃ₗ[R] N) : (dualProd R M).IsometryEquiv (dualProd R N) where
   toLinearEquiv := f.dualMap.symm.prod f
-  map_app' x := FunLike.congr_arg x.fst <| f.symm_apply_apply _
+  map_app' x := DFunLike.congr_arg x.fst <| f.symm_apply_apply _
 #align quadratic_form.dual_prod_isometry QuadraticForm.dualProdIsometry
 
 /-- `QuadraticForm.dualProd` commutes (isometrically) with `QuadraticForm.prod`. -/
@@ -124,7 +124,7 @@ def dualProdProdIsometry : (dualProd R (M × N)).IsometryEquiv ((dualProd R M).p
     (Module.dualProdDualEquivDual R M N).symm.prod (LinearEquiv.refl R (M × N)) ≪≫ₗ
       LinearEquiv.prodProdProdComm R _ _ M N
   map_app' m :=
-    (m.fst.map_add _ _).symm.trans <| FunLike.congr_arg m.fst <| Prod.ext (add_zero _) (zero_add _)
+    (m.fst.map_add _ _).symm.trans <| DFunLike.congr_arg m.fst <| Prod.ext (add_zero _) (zero_add _)
 #align quadratic_form.dual_prod_prod_isometry QuadraticForm.dualProdProdIsometry
 
 end Semiring

--- a/Mathlib/LinearAlgebra/QuadraticForm/Isometry.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Isometry.lean
@@ -42,17 +42,17 @@ variable {Q₃ : QuadraticForm R M₃} {Q₄ : QuadraticForm R M₄}
 
 instance instLinearMapClass : LinearMapClass (Q₁ →qᵢ Q₂) R M₁ M₂ where
   coe f := f.toLinearMap
-  coe_injective' f g h := by cases f; cases g; congr; exact FunLike.coe_injective h
+  coe_injective' f g h := by cases f; cases g; congr; exact DFunLike.coe_injective h
   map_add f := f.toLinearMap.map_add
   map_smulₛₗ f := f.toLinearMap.map_smul
 
 theorem toLinearMap_injective :
     Function.Injective (Isometry.toLinearMap : (Q₁ →qᵢ Q₂) → M₁ →ₗ[R] M₂) := fun _f _g h =>
-  FunLike.coe_injective (congr_arg FunLike.coe h : _)
+  DFunLike.coe_injective (congr_arg DFunLike.coe h : _)
 
 @[ext]
 theorem ext ⦃f g : Q₁ →qᵢ Q₂⦄ (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 
 /-- See Note [custom simps projection]. -/
 protected def Simps.apply (f : Q₁ →qᵢ Q₂) : M₁ → M₂ := f

--- a/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat.lean
@@ -80,7 +80,7 @@ instance concreteCategory : ConcreteCategory.{v} (QuadraticModuleCat.{v} R) wher
     { obj := fun M => M
       map := @fun M N f => f.toIsometry }
   forget_faithful :=
-    { map_injective := @fun M N => FunLike.coe_injective.comp <| Hom.toIsometry_injective _ _ }
+    { map_injective := @fun M N => DFunLike.coe_injective.comp <| Hom.toIsometry_injective _ _ }
 
 instance hasForgetToModule : HasForget₂ (QuadraticModuleCat R) (ModuleCat R) where
   forget₂ :=
@@ -107,8 +107,8 @@ variable {Q₁ : QuadraticForm R X} {Q₂ : QuadraticForm R Y} {Q₃ : Quadratic
 def ofIso (e : Q₁.IsometryEquiv Q₂) : QuadraticModuleCat.of Q₁ ≅ QuadraticModuleCat.of Q₂ where
   hom := ⟨e.toIsometry⟩
   inv := ⟨e.symm.toIsometry⟩
-  hom_inv_id := Hom.ext _ _ <| FunLike.ext _ _ e.left_inv
-  inv_hom_id := Hom.ext _ _ <| FunLike.ext _ _ e.right_inv
+  hom_inv_id := Hom.ext _ _ <| DFunLike.ext _ _ e.left_inv
+  inv_hom_id := Hom.ext _ _ <| DFunLike.ext _ _ e.right_inv
 
 @[simp] theorem ofIso_refl : ofIso (IsometryEquiv.refl Q₁) = .refl _ :=
   rfl

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
@@ -51,7 +51,7 @@ theorem tmul_tensorMap_apply
     {Q₃ : QuadraticForm R M₃} {Q₄ : QuadraticForm R M₄}
     (f : Q₁ →qᵢ Q₂) (g : Q₃ →qᵢ Q₄) (x : M₁ ⊗[R] M₃) :
     Q₂.tmul Q₄ (TensorProduct.map f.toLinearMap g.toLinearMap x) = Q₁.tmul Q₃ x :=
-  FunLike.congr_fun (tmul_comp_tensorMap f g) x
+  DFunLike.congr_fun (tmul_comp_tensorMap f g) x
 
 namespace Isometry
 
@@ -89,7 +89,7 @@ theorem tmul_comp_tensorComm (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm
 theorem tmul_tensorComm_apply
     (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (x : M₁ ⊗[R] M₂) :
     Q₂.tmul Q₁ (TensorProduct.comm R M₁ M₂ x) = Q₁.tmul Q₂ x :=
-  FunLike.congr_fun (tmul_comp_tensorComm Q₁ Q₂) x
+  DFunLike.congr_fun (tmul_comp_tensorComm Q₁ Q₂) x
 
 /-- `TensorProduct.comm` preserves tensor products of quadratic forms. -/
 @[simps toLinearEquiv]
@@ -127,7 +127,7 @@ theorem tmul_tensorAssoc_apply
     (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃)
     (x : (M₁ ⊗[R] M₂) ⊗[R] M₃):
     Q₁.tmul (Q₂.tmul Q₃) (TensorProduct.assoc R M₁ M₂ M₃ x) = (Q₁.tmul Q₂).tmul Q₃ x :=
-  FunLike.congr_fun (tmul_comp_tensorAssoc Q₁ Q₂ Q₃) x
+  DFunLike.congr_fun (tmul_comp_tensorAssoc Q₁ Q₂ Q₃) x
 
 /-- `TensorProduct.assoc` preserves tensor products of quadratic forms. -/
 @[simps toLinearEquiv]
@@ -165,7 +165,7 @@ theorem comp_tensorRId_eq (Q₁ : QuadraticForm R M₁) :
 theorem tmul_tensorRId_apply
     (Q₁ : QuadraticForm R M₁) (x : M₁ ⊗[R] R) :
     Q₁ (TensorProduct.rid R M₁ x) = Q₁.tmul (sq (R := R)) x :=
-  FunLike.congr_fun (comp_tensorRId_eq Q₁) x
+  DFunLike.congr_fun (comp_tensorRId_eq Q₁) x
 
 /-- `TensorProduct.rid` preserves tensor products of quadratic forms. -/
 @[simps toLinearEquiv]
@@ -199,7 +199,7 @@ theorem comp_tensorLId_eq (Q₂ : QuadraticForm R M₂) :
 theorem tmul_tensorLId_apply
     (Q₂ : QuadraticForm R M₂) (x : R ⊗[R] M₂) :
     Q₂ (TensorProduct.lid R M₂ x) = (sq (R := R)).tmul Q₂ x :=
-  FunLike.congr_fun (comp_tensorLId_eq Q₂) x
+  DFunLike.congr_fun (comp_tensorLId_eq Q₂) x
 
 /-- `TensorProduct.lid` preserves tensor products of quadratic forms. -/
 @[simps toLinearEquiv]

--- a/Mathlib/LinearAlgebra/Span.lean
+++ b/Mathlib/LinearAlgebra/Span.lean
@@ -1032,7 +1032,7 @@ theorem eqOn_span {s : Set M} {f g : F} (H : Set.EqOn f g s) ⦃x⦄ (h : x ∈ 
 /-- If `s` generates the whole module and linear maps `f`, `g` are equal on `s`, then they are
 equal. -/
 theorem ext_on {s : Set M} {f g : F} (hv : span R s = ⊤) (h : Set.EqOn f g s) : f = g :=
-  FunLike.ext _ _ fun _ => eqOn_span h (eq_top_iff'.1 hv _)
+  DFunLike.ext _ _ fun _ => eqOn_span h (eq_top_iff'.1 hv _)
 #align linear_map.ext_on LinearMap.ext_on
 
 /-- If the range of `v : ι → M` generates the whole module and linear maps `f`, `g` are equal at

--- a/Mathlib/LinearAlgebra/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct.lean
@@ -805,7 +805,7 @@ lemma map_comp_comm_eq (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
 
 lemma map_comm (f : M →ₗ[R] P) (g : N →ₗ[R] Q) (x : N ⊗[R] M):
     map f g (TensorProduct.comm R N M x) = TensorProduct.comm R Q P (map g f x) :=
-  FunLike.congr_fun (map_comp_comm_eq _ _) _
+  DFunLike.congr_fun (map_comp_comm_eq _ _) _
 
 /-- Given linear maps `f : M → Q`, `g : N → S`, and `h : P → T`, if we identify `(M ⊗ N) ⊗ P`
 with `M ⊗ (N ⊗ P)` and `(Q ⊗ S) ⊗ T` with `Q ⊗ (S ⊗ T)`, then this lemma states that
@@ -818,7 +818,7 @@ lemma map_map_comp_assoc_eq (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P →�
 lemma map_map_assoc (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P →ₗ[R] T) (x : (M ⊗[R] N) ⊗[R] P) :
     map f (map g h) (TensorProduct.assoc R M N P x) =
       TensorProduct.assoc R Q S T (map (map f g) h x) :=
-  FunLike.congr_fun (map_map_comp_assoc_eq _ _ _) _
+  DFunLike.congr_fun (map_map_comp_assoc_eq _ _ _) _
 
 /-- Given linear maps `f : M → Q`, `g : N → S`, and `h : P → T`, if we identify `M ⊗ (N ⊗ P)`
 with `(M ⊗ N) ⊗ P` and `Q ⊗ (S ⊗ T)` with `(Q ⊗ S) ⊗ T`, then this lemma states that
@@ -831,7 +831,7 @@ lemma map_map_comp_assoc_symm_eq (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P 
 lemma map_map_assoc_symm (f : M →ₗ[R] Q) (g : N →ₗ[R] S) (h : P →ₗ[R] T) (x : M ⊗[R] (N ⊗[R] P)) :
     map (map f g) h ((TensorProduct.assoc R M N P).symm x) =
       (TensorProduct.assoc R Q S T).symm (map f (map g h) x) :=
-  FunLike.congr_fun (map_map_comp_assoc_symm_eq _ _ _) _
+  DFunLike.congr_fun (map_map_comp_assoc_symm_eq _ _ _) _
 
 theorem map_range_eq_span_tmul (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
     range (map f g) = Submodule.span R { t | ∃ m n, f m ⊗ₜ g n = t } := by

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
@@ -128,7 +128,7 @@ theorem gradedComm_tmul_of_zero (a : ⨁ i, 𝒜 i) (b : ℬ 0) :
     (gradedComm R 𝒜 ℬ).toLinearMap ∘ₗ
         (TensorProduct.mk R (⨁ i, 𝒜 i) (⨁ i, ℬ i)).flip (lof R _ ℬ 0 b) =
       TensorProduct.mk R _ _ (lof R _ ℬ 0 b) from
-    FunLike.congr_fun this a
+    DFunLike.congr_fun this a
   ext i a
   dsimp
   rw [gradedComm_of_tmul_of, zero_mul, uzpow_zero, one_smul]
@@ -138,7 +138,7 @@ theorem gradedComm_of_zero_tmul (a : 𝒜 0) (b : ⨁ i, ℬ i) :
   suffices
     (gradedComm R 𝒜 ℬ).toLinearMap ∘ₗ (TensorProduct.mk R (⨁ i, 𝒜 i) (⨁ i, ℬ i)) (lof R _ 𝒜 0 a) =
       (TensorProduct.mk R _ _).flip (lof R _ 𝒜 0 a) from
-    FunLike.congr_fun this b
+    DFunLike.congr_fun this b
   ext i b
   dsimp
   rw [gradedComm_of_tmul_of, mul_zero, uzpow_zero, one_smul]
@@ -198,7 +198,7 @@ variable {R}
 theorem algebraMap_gradedMul (r : R) (x : (⨁ i, 𝒜 i) ⊗[R] (⨁ i, ℬ i)) :
     gradedMul R 𝒜 ℬ (algebraMap R _ r ⊗ₜ 1) x = r • x := by
   suffices gradedMul R 𝒜 ℬ (algebraMap R _ r ⊗ₜ 1) = DistribMulAction.toLinearMap R _ r by
-    exact FunLike.congr_fun this x
+    exact DFunLike.congr_fun this x
   ext ia a ib b
   dsimp
   erw [tmul_of_gradedMul_of_tmul]
@@ -212,7 +212,7 @@ theorem one_gradedMul (x : (⨁ i, 𝒜 i) ⊗[R] (⨁ i, ℬ i)) :
 theorem gradedMul_algebraMap (x : (⨁ i, 𝒜 i) ⊗[R] (⨁ i, ℬ i)) (r : R) :
     gradedMul R 𝒜 ℬ x (algebraMap R _ r ⊗ₜ 1) = r • x := by
   suffices (gradedMul R 𝒜 ℬ).flip (algebraMap R _ r ⊗ₜ 1) = DistribMulAction.toLinearMap R _ r by
-    exact FunLike.congr_fun this x
+    exact DFunLike.congr_fun this x
   ext
   dsimp
   erw [tmul_of_gradedMul_of_tmul]
@@ -230,7 +230,7 @@ theorem gradedMul_assoc (x y z : DirectSum _ 𝒜 ⊗[R] DirectSum _ ℬ) :
     -- restate as an equality of morphisms so that we can use `ext`
   suffices LinearMap.llcomp R _ _ _ mA ∘ₗ mA =
       (LinearMap.llcomp R _ _ _ LinearMap.lflip <| LinearMap.llcomp R _ _ _ mA.flip ∘ₗ mA).flip by
-    exact FunLike.congr_fun (FunLike.congr_fun (FunLike.congr_fun this x) y) z
+    exact DFunLike.congr_fun (DFunLike.congr_fun (DFunLike.congr_fun this x) y) z
   ext ixa xa ixb xb iya ya iyb yb iza za izb zb
   dsimp
   simp_rw [tmul_of_gradedMul_of_tmul, Units.smul_def, zsmul_eq_smul_cast R,

--- a/Mathlib/Logic/Embedding/Basic.lean
+++ b/Mathlib/Logic/Embedding/Basic.lean
@@ -80,7 +80,7 @@ theorem Equiv.toEmbedding_apply (a : α) : f.toEmbedding a = f a :=
 #align equiv.to_embedding_apply Equiv.toEmbedding_apply
 
 theorem Equiv.toEmbedding_injective : Function.Injective (Equiv.toEmbedding : (α ≃ β) → (α ↪ β)) :=
-  fun _ _ h ↦ by rwa [FunLike.ext'_iff] at h ⊢
+  fun _ _ h ↦ by rwa [DFunLike.ext'_iff] at h ⊢
 
 instance Equiv.coeEmbedding : Coe (α ≃ β) (α ↪ β) :=
   ⟨Equiv.toEmbedding⟩
@@ -101,17 +101,17 @@ namespace Function
 namespace Embedding
 
 theorem coe_injective {α β} : @Injective (α ↪ β) (α → β) (λ f => ↑f) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align function.embedding.coe_injective Function.Embedding.coe_injective
 
 @[ext]
 theorem ext {α β} {f g : Embedding α β} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align function.embedding.ext Function.Embedding.ext
 
--- port note : in Lean 3 `FunLike.ext_iff.symm` works
+-- port note : in Lean 3 `DFunLike.ext_iff.symm` works
 theorem ext_iff {α β} {f g : Embedding α β} : (∀ x, f x = g x) ↔ f = g :=
-  Iff.symm (FunLike.ext_iff)
+  Iff.symm (DFunLike.ext_iff)
 #align function.embedding.ext_iff Function.Embedding.ext_iff
 
 @[simp]

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -102,9 +102,9 @@ instance : EquivLike (α ≃ β) α β where
   coe_injective' e₁ e₂ h₁ h₂ := by cases e₁; cases e₂; congr
 
 /-- Helper instance when inference gets stuck on following the normal chain
-`EquivLike → EmbeddingLike → FunLike → CoeFun`. -/
-instance : FunLike (α ≃ β) α (fun _ => β) :=
-  EmbeddingLike.toFunLike
+`EquivLike → EmbeddingLike → DFunLike → CoeFun`. -/
+instance : DFunLike (α ≃ β) α (fun _ => β) :=
+  EmbeddingLike.toDFunLike
 
 @[simp, norm_cast]
 lemma _root_.EquivLike.coe_coe {F} [EquivLike F α β] (e : F) :
@@ -116,25 +116,25 @@ lemma _root_.EquivLike.coe_coe {F} [EquivLike F α β] (e : F) :
 
 /-- The map `(r ≃ s) → (r → s)` is injective. -/
 theorem coe_fn_injective : @Function.Injective (α ≃ β) (α → β) (fun e => e) :=
-  FunLike.coe_injective'
+  DFunLike.coe_injective'
 #align equiv.coe_fn_injective Equiv.coe_fn_injective
 
 protected theorem coe_inj {e₁ e₂ : α ≃ β} : (e₁ : α → β) = e₂ ↔ e₁ = e₂ :=
-  @FunLike.coe_fn_eq _ _ _ _ e₁ e₂
+  @DFunLike.coe_fn_eq _ _ _ _ e₁ e₂
 #align equiv.coe_inj Equiv.coe_inj
 
-@[ext] theorem ext {f g : Equiv α β} (H : ∀ x, f x = g x) : f = g := FunLike.ext f g H
+@[ext] theorem ext {f g : Equiv α β} (H : ∀ x, f x = g x) : f = g := DFunLike.ext f g H
 #align equiv.ext Equiv.ext
 
 protected theorem congr_arg {f : Equiv α β} {x x' : α} : x = x' → f x = f x' :=
-  FunLike.congr_arg f
+  DFunLike.congr_arg f
 #align equiv.congr_arg Equiv.congr_arg
 
 protected theorem congr_fun {f g : Equiv α β} (h : f = g) (x : α) : f x = g x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align equiv.congr_fun Equiv.congr_fun
 
-theorem ext_iff {f g : Equiv α β} : f = g ↔ ∀ x, f x = g x := FunLike.ext_iff
+theorem ext_iff {f g : Equiv α β} : f = g ↔ ∀ x, f x = g x := DFunLike.ext_iff
 #align equiv.ext_iff Equiv.ext_iff
 
 @[ext] theorem Perm.ext {σ τ : Equiv.Perm α} (H : ∀ x, σ x = τ x) : σ = τ := Equiv.ext H
@@ -186,7 +186,7 @@ instance : Trans Equiv Equiv Equiv where
   trans := Equiv.trans
 
 -- porting note: this is not a syntactic tautology any more because
--- the coercion from `e` to a function is now `FunLike.coe` not `e.toFun`
+-- the coercion from `e` to a function is now `DFunLike.coe` not `e.toFun`
 @[simp, mfld_simps] theorem toFun_as_coe (e : α ≃ β) : e.toFun = e := rfl
 #align equiv.to_fun_as_coe Equiv.toFun_as_coe
 

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -1818,7 +1818,7 @@ theorem toLp_norm_le [NontriviallyNormedField 𝕜] [NormedSpace 𝕜 E] :
 theorem toLp_inj {f g : α →ᵇ E} [μ.IsOpenPosMeasure] [NormedField 𝕜] [NormedSpace 𝕜 E] :
     toLp (E := E) p μ 𝕜 f = toLp (E := E) p μ 𝕜 g ↔ f = g := by
   refine' ⟨fun h => _, by tauto⟩
-  rw [← FunLike.coe_fn_eq, ← (map_continuous f).ae_eq_iff_eq μ (map_continuous g)]
+  rw [← DFunLike.coe_fn_eq, ← (map_continuous f).ae_eq_iff_eq μ (map_continuous g)]
   refine' (coeFn_toLp p μ 𝕜 f).symm.trans (EventuallyEq.trans _ <| coeFn_toLp p μ 𝕜 g)
   rw [h]
 #align bounded_continuous_function.to_Lp_inj BoundedContinuousFunction.toLp_inj

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -1368,7 +1368,7 @@ instance instEquivLike : EquivLike (α ≃ᵐ β) α β where
   inv e := e.toEquiv.symm
   left_inv e := e.toEquiv.left_inv
   right_inv e := e.toEquiv.right_inv
-  coe_injective' _ _ he _ := toEquiv_injective <| FunLike.ext' he
+  coe_injective' _ _ he _ := toEquiv_injective <| DFunLike.ext' he
 
 @[simp]
 theorem coe_toEquiv (e : α ≃ᵐ β) : (e.toEquiv : α → β) = e :=
@@ -1429,7 +1429,7 @@ def Simps.symm_apply (h : α ≃ᵐ β) : β → α := h.symm
 
 initialize_simps_projections MeasurableEquiv (toFun → apply, invFun → symm_apply)
 
-@[ext] theorem ext {e₁ e₂ : α ≃ᵐ β} (h : (e₁ : α → β) = e₂) : e₁ = e₂ := FunLike.ext' h
+@[ext] theorem ext {e₁ e₂ : α ≃ᵐ β} (h : (e₁ : α → β) = e₂) : e₁ = e₂ := DFunLike.ext' h
 #align measurable_equiv.ext MeasurableEquiv.ext
 
 @[simp]

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -571,7 +571,7 @@ lemma injective_toWeakDualBCNN :
   intro μ ν hμν
   apply ext_of_forall_lintegral_eq
   intro f
-  have key := congr_fun (congrArg FunLike.coe hμν) f
+  have key := congr_fun (congrArg DFunLike.coe hμν) f
   apply (ENNReal.toNNReal_eq_toNNReal_iff' ?_ ?_).mp key
   · exact (lintegral_lt_top_of_nnreal μ f).ne
   · exact (lintegral_lt_top_of_nnreal ν f).ne

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -498,10 +498,10 @@ attribute [inherit_doc FirstOrder.Language.Hom.map_rel'] FirstOrder.Language.Emb
 
 namespace Hom
 
-instance funLike : DFunLike (M →[L] N) M fun _ => N where
+instance instDFunLike : DFunLike (M →[L] N) M fun _ => N where
   coe := Hom.toFun
   coe_injective' f g h := by cases f; cases g; cases h; rfl
-#align first_order.language.hom.fun_like FirstOrder.Language.Hom.funLike
+#align first_order.language.hom.fun_like FirstOrder.Language.Hom.instDFunLike
 
 instance homClass : HomClass L (M →[L] N) M N where
   map_fun := map_fun'

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -456,7 +456,7 @@ end Structure
 /-- `HomClass L F M N` states that `F` is a type of `L`-homomorphisms. You should extend this
   typeclass when you extend `FirstOrder.Language.Hom`. -/
 class HomClass (L : outParam Language) (F : Type*) (M N : outParam <| Type*)
-  [FunLike F M fun _ => N] [L.Structure M] [L.Structure N] : Prop where
+  [DFunLike F M fun _ => N] [L.Structure M] [L.Structure N] : Prop where
   map_fun : ∀ (φ : F) {n} (f : L.Functions n) (x), φ (funMap f x) = funMap f (φ ∘ x)
   map_rel : ∀ (φ : F) {n} (r : L.Relations n) (x), RelMap r x → RelMap r (φ ∘ x)
 #align first_order.language.hom_class FirstOrder.Language.HomClass
@@ -464,26 +464,26 @@ class HomClass (L : outParam Language) (F : Type*) (M N : outParam <| Type*)
 /-- `StrongHomClass L F M N` states that `F` is a type of `L`-homomorphisms which preserve
   relations in both directions. -/
 class StrongHomClass (L : outParam Language) (F : Type*) (M N : outParam <| Type*)
-  [FunLike F M fun _ => N] [L.Structure M] [L.Structure N] : Prop where
+  [DFunLike F M fun _ => N] [L.Structure M] [L.Structure N] : Prop where
   map_fun : ∀ (φ : F) {n} (f : L.Functions n) (x), φ (funMap f x) = funMap f (φ ∘ x)
   map_rel : ∀ (φ : F) {n} (r : L.Relations n) (x), RelMap r (φ ∘ x) ↔ RelMap r x
 #align first_order.language.strong_hom_class FirstOrder.Language.StrongHomClass
 
 --Porting note: using implicit brackets for `Structure` arguments
 instance (priority := 100) StrongHomClass.homClass [L.Structure M]
-    [L.Structure N] [FunLike F M fun _ => N] [StrongHomClass L F M N] : HomClass L F M N where
+    [L.Structure N] [DFunLike F M fun _ => N] [StrongHomClass L F M N] : HomClass L F M N where
   map_fun := StrongHomClass.map_fun
   map_rel φ _ R x := (StrongHomClass.map_rel φ R x).2
 #align first_order.language.strong_hom_class.hom_class FirstOrder.Language.StrongHomClass.homClass
 
 /-- Not an instance to avoid a loop. -/
 theorem HomClass.strongHomClassOfIsAlgebraic [L.IsAlgebraic] {F M N} [L.Structure M] [L.Structure N]
-    [FunLike F M fun _ => N] [HomClass L F M N] : StrongHomClass L F M N where
+    [DFunLike F M fun _ => N] [HomClass L F M N] : StrongHomClass L F M N where
   map_fun := HomClass.map_fun
   map_rel _ n R _ := (IsAlgebraic.empty_relations n).elim R
 #align first_order.language.hom_class.strong_hom_class_of_is_algebraic FirstOrder.Language.HomClass.strongHomClassOfIsAlgebraic
 
-theorem HomClass.map_constants {F M N} [L.Structure M] [L.Structure N] [FunLike F M fun _ => N]
+theorem HomClass.map_constants {F M N} [L.Structure M] [L.Structure N] [DFunLike F M fun _ => N]
     [HomClass L F M N] (φ : F) (c : L.Constants) : φ c = c :=
   (HomClass.map_fun φ c default).trans (congr rfl (funext default))
 #align first_order.language.hom_class.map_constants FirstOrder.Language.HomClass.map_constants
@@ -498,7 +498,7 @@ attribute [inherit_doc FirstOrder.Language.Hom.map_rel'] FirstOrder.Language.Emb
 
 namespace Hom
 
-instance funLike : FunLike (M →[L] N) M fun _ => N where
+instance funLike : DFunLike (M →[L] N) M fun _ => N where
   coe := Hom.toFun
   coe_injective' f g h := by cases f; cases g; cases h; rfl
 #align first_order.language.hom.fun_like FirstOrder.Language.Hom.funLike
@@ -512,7 +512,7 @@ instance [L.IsAlgebraic] : StrongHomClass L (M →[L] N) M N :=
   HomClass.strongHomClassOfIsAlgebraic
 
 instance hasCoeToFun : CoeFun (M →[L] N) fun _ => M → N :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 #align first_order.language.hom.has_coe_to_fun FirstOrder.Language.Hom.hasCoeToFun
 
 @[simp]
@@ -522,11 +522,11 @@ theorem toFun_eq_coe {f : M →[L] N} : f.toFun = (f : M → N) :=
 
 @[ext]
 theorem ext ⦃f g : M →[L] N⦄ (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align first_order.language.hom.ext FirstOrder.Language.Hom.ext
 
 theorem ext_iff {f g : M →[L] N} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align first_order.language.hom.ext_iff FirstOrder.Language.Hom.ext_iff
 
 @[simp]
@@ -588,7 +588,7 @@ theorem comp_assoc (f : M →[L] N) (g : N →[L] P) (h : P →[L] Q) :
 end Hom
 
 /-- Any element of a `HomClass` can be realized as a first_order homomorphism. -/
-def HomClass.toHom {F M N} [L.Structure M] [L.Structure N] [FunLike F M fun _ => N]
+def HomClass.toHom {F M N} [L.Structure M] [L.Structure N] [DFunLike F M fun _ => N]
     [HomClass L F M N] : F → M →[L] N := fun φ =>
   ⟨φ, HomClass.map_fun φ, HomClass.map_rel φ⟩
 #align first_order.language.hom_class.to_hom FirstOrder.Language.HomClass.toHom
@@ -612,7 +612,7 @@ instance strongHomClass : StrongHomClass L (M ↪[L] N) M N where
 #align first_order.language.embedding.strong_hom_class FirstOrder.Language.Embedding.strongHomClass
 
 instance hasCoeToFun : CoeFun (M ↪[L] N) fun _ => M → N :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 #align first_order.language.embedding.has_coe_to_fun FirstOrder.Language.Embedding.hasCoeToFun
 
 @[simp]
@@ -772,7 +772,7 @@ def symm (f : M ≃[L] N) : N ≃[L] M :=
 #align first_order.language.equiv.symm FirstOrder.Language.Equiv.symm
 
 instance hasCoeToFun : CoeFun (M ≃[L] N) fun _ => M → N :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 #align first_order.language.equiv.has_coe_to_fun FirstOrder.Language.Equiv.hasCoeToFun
 
 @[simp]
@@ -828,7 +828,7 @@ theorem coe_toEmbedding (f : M ≃[L] N) : (f.toEmbedding : M → N) = (f : M �
 #align first_order.language.equiv.coe_to_embedding FirstOrder.Language.Equiv.coe_toEmbedding
 
 theorem coe_injective : @Function.Injective (M ≃[L] N) (M → N) (↑) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align first_order.language.equiv.coe_injective FirstOrder.Language.Equiv.coe_injective
 
 @[ext]
@@ -968,7 +968,7 @@ instance : Unique (Language.empty.Structure M) :=
   ⟨⟨Language.emptyStructure⟩, fun a => by
     ext _ f <;> exact Empty.elim f⟩
 
-instance (priority := 100) strongHomClassEmpty {F M N} [FunLike F M fun _ => N] :
+instance (priority := 100) strongHomClassEmpty {F M N} [DFunLike F M fun _ => N] :
     StrongHomClass Language.empty F M N :=
   ⟨fun _ _ f => Empty.elim f, fun _ _ r => Empty.elim r⟩
 #align first_order.language.strong_hom_class_empty FirstOrder.Language.strongHomClassEmpty
@@ -1043,14 +1043,14 @@ theorem toEquiv_inducedStructureEquiv (e : M ≃ N) :
 
 @[simp]
 theorem toFun_inducedStructureEquiv (e : M ≃ N) :
-    FunLike.coe (@inducedStructureEquiv L M N _ e) = e :=
+    DFunLike.coe (@inducedStructureEquiv L M N _ e) = e :=
   rfl
 
 @[simp]
 theorem toFun_inducedStructureEquiv_Symm (e : M ≃ N) :
     (by
     letI : L.Structure N := inducedStructure e
-    exact FunLike.coe (@inducedStructureEquiv L M N _ e).symm) = (e.symm : N → M) :=
+    exact DFunLike.coe (@inducedStructureEquiv L M N _ e).symm) = (e.symm : N → M) :=
   rfl
 
 end Equiv

--- a/Mathlib/ModelTheory/ElementaryMaps.lean
+++ b/Mathlib/ModelTheory/ElementaryMaps.lean
@@ -63,7 +63,7 @@ namespace ElementaryEmbedding
 
 attribute [coe] toFun
 
-instance funLike : FunLike (M ↪ₑ[L] N) M fun _ => N where
+instance funLike : DFunLike (M ↪ₑ[L] N) M fun _ => N where
   coe f := f.toFun
   coe_injective' f g h := by
     cases f
@@ -74,7 +74,7 @@ instance funLike : FunLike (M ↪ₑ[L] N) M fun _ => N where
 #align first_order.language.elementary_embedding.fun_like FirstOrder.Language.ElementaryEmbedding.funLike
 
 instance : CoeFun (M ↪ₑ[L] N) fun _ => M → N :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 @[simp]
 theorem map_boundedFormula (f : M ↪ₑ[L] N) {α : Type*} {n : ℕ} (φ : L.BoundedFormula α n)
@@ -127,7 +127,7 @@ theorem injective (φ : M ↪ₑ[L] N) : Function.Injective φ := by
 #align first_order.language.elementary_embedding.injective FirstOrder.Language.ElementaryEmbedding.injective
 
 instance embeddingLike : EmbeddingLike (M ↪ₑ[L] N) M N :=
-  { show FunLike (M ↪ₑ[L] N) M fun _ => N from inferInstance with injective' := injective }
+  { show DFunLike (M ↪ₑ[L] N) M fun _ => N from inferInstance with injective' := injective }
 #align first_order.language.elementary_embedding.embedding_like FirstOrder.Language.ElementaryEmbedding.embeddingLike
 
 @[simp]
@@ -186,16 +186,16 @@ theorem coe_toEmbedding (f : M ↪ₑ[L] N) : (f.toEmbedding : M → N) = (f : M
 #align first_order.language.elementary_embedding.coe_to_embedding FirstOrder.Language.ElementaryEmbedding.coe_toEmbedding
 
 theorem coe_injective : @Function.Injective (M ↪ₑ[L] N) (M → N) (↑) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align first_order.language.elementary_embedding.coe_injective FirstOrder.Language.ElementaryEmbedding.coe_injective
 
 @[ext]
 theorem ext ⦃f g : M ↪ₑ[L] N⦄ (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align first_order.language.elementary_embedding.ext FirstOrder.Language.ElementaryEmbedding.ext
 
 theorem ext_iff {f g : M ↪ₑ[L] N} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align first_order.language.elementary_embedding.ext_iff FirstOrder.Language.ElementaryEmbedding.ext_iff
 
 variable (L) (M)

--- a/Mathlib/ModelTheory/ElementaryMaps.lean
+++ b/Mathlib/ModelTheory/ElementaryMaps.lean
@@ -63,7 +63,7 @@ namespace ElementaryEmbedding
 
 attribute [coe] toFun
 
-instance funLike : DFunLike (M ↪ₑ[L] N) M fun _ => N where
+instance instDFunLike : DFunLike (M ↪ₑ[L] N) M fun _ => N where
   coe f := f.toFun
   coe_injective' f g h := by
     cases f
@@ -71,7 +71,7 @@ instance funLike : DFunLike (M ↪ₑ[L] N) M fun _ => N where
     simp only [ElementaryEmbedding.mk.injEq]
     ext x
     exact Function.funext_iff.1 h x
-#align first_order.language.elementary_embedding.fun_like FirstOrder.Language.ElementaryEmbedding.funLike
+#align first_order.language.elementary_embedding.fun_like FirstOrder.Language.ElementaryEmbedding.instDFunLike
 
 instance : CoeFun (M ↪ₑ[L] N) fun _ => M → N :=
   DFunLike.hasCoeToFun

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -88,15 +88,15 @@ section Zero
 variable [Zero R]
 
 --  porting note: used to be `CoeFun`
-instance : FunLike (ArithmeticFunction R) ℕ fun _ ↦ R :=
-  inferInstanceAs (FunLike (ZeroHom ℕ R) ℕ fun _ ↦ R)
+instance : DFunLike (ArithmeticFunction R) ℕ fun _ ↦ R :=
+  inferInstanceAs (DFunLike (ZeroHom ℕ R) ℕ fun _ ↦ R)
 
 @[simp]
 theorem toFun_eq (f : ArithmeticFunction R) : f.toFun = f := rfl
 #align nat.arithmetic_function.to_fun_eq Nat.ArithmeticFunction.toFun_eq
 
 @[simp]
-theorem coe_mk (f : ℕ → R) (hf) : @FunLike.coe (ArithmeticFunction R) _ _ _
+theorem coe_mk (f : ℕ → R) (hf) : @DFunLike.coe (ArithmeticFunction R) _ _ _
     (ZeroHom.mk f hf) = f := rfl
 
 @[simp]
@@ -105,7 +105,7 @@ theorem map_zero {f : ArithmeticFunction R} : f 0 = 0 :=
 #align nat.arithmetic_function.map_zero Nat.ArithmeticFunction.map_zero
 
 theorem coe_inj {f g : ArithmeticFunction R} : (f : ℕ → R) = g ↔ f = g :=
-  FunLike.coe_fn_eq
+  DFunLike.coe_fn_eq
 #align nat.arithmetic_function.coe_inj Nat.ArithmeticFunction.coe_inj
 
 @[simp]
@@ -119,7 +119,7 @@ theorem ext ⦃f g : ArithmeticFunction R⦄ (h : ∀ x, f x = g x) : f = g :=
 #align nat.arithmetic_function.ext Nat.ArithmeticFunction.ext
 
 theorem ext_iff {f g : ArithmeticFunction R} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align nat.arithmetic_function.ext_iff Nat.ArithmeticFunction.ext_iff
 
 section One

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -98,9 +98,9 @@ namespace Poly
 
 section
 
-instance funLike : DFunLike (Poly α) (α → ℕ) fun _ => ℤ :=
+instance instDFunLike : DFunLike (Poly α) (α → ℕ) fun _ => ℤ :=
   ⟨Subtype.val, Subtype.val_injective⟩
-#align poly.fun_like Poly.funLike
+#align poly.fun_like Poly.instDFunLike
 
 -- Porting note: This instance is not necessary anymore
 -- /-- Helper instance for when there are too many metavariables to apply `DFunLike.hasCoeToFun`

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -98,14 +98,14 @@ namespace Poly
 
 section
 
-instance funLike : FunLike (Poly α) (α → ℕ) fun _ => ℤ :=
+instance funLike : DFunLike (Poly α) (α → ℕ) fun _ => ℤ :=
   ⟨Subtype.val, Subtype.val_injective⟩
 #align poly.fun_like Poly.funLike
 
 -- Porting note: This instance is not necessary anymore
 -- /-- Helper instance for when there are too many metavariables to apply `fun_like.has_coe_to_fun`
 -- directly. -/
--- instance : CoeFun (Poly α) fun _ => (α → ℕ) → ℤ := FunLike.hasCoeToFun
+-- instance : CoeFun (Poly α) fun _ => (α → ℕ) → ℤ := DFunLike.hasCoeToFun
 
 /-- The underlying function of a `Poly` is a polynomial -/
 protected theorem isPoly (f : Poly α) : IsPoly f := f.2
@@ -113,7 +113,7 @@ protected theorem isPoly (f : Poly α) : IsPoly f := f.2
 
 /-- Extensionality for `Poly α` -/
 @[ext]
-theorem ext {f g : Poly α} : (∀ x, f x = g x) → f = g := FunLike.ext _ _
+theorem ext {f g : Poly α} : (∀ x, f x = g x) → f = g := DFunLike.ext _ _
 #align poly.ext Poly.ext
 
 /-- The `i`th projection function, `x_i`. -/

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -103,7 +103,7 @@ instance funLike : DFunLike (Poly α) (α → ℕ) fun _ => ℤ :=
 #align poly.fun_like Poly.funLike
 
 -- Porting note: This instance is not necessary anymore
--- /-- Helper instance for when there are too many metavariables to apply `fun_like.has_coe_to_fun`
+-- /-- Helper instance for when there are too many metavariables to apply `DFunLike.hasCoeToFun`
 -- directly. -/
 -- instance : CoeFun (Poly α) fun _ => (α → ℕ) → ℤ := DFunLike.hasCoeToFun
 

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -98,7 +98,7 @@ open Multiplicative
 /-- Define coercion to a function so that it includes the move from `R` to `Multiplicative R`.
 After we have proved the API lemmas below, we don't need to worry about writing `ofAdd a`
 when we want to apply an additive character. -/
-instance instFunLike : DFunLike (AddChar R R') R fun _ ↦ R' :=
+instance instDFunLike : DFunLike (AddChar R R') R fun _ ↦ R' :=
   inferInstanceAs (DFunLike (Multiplicative R →* R') R fun _ ↦ R')
 #noalign add_char.has_coe_to_fun
 
@@ -114,7 +114,7 @@ theorem mul_apply (ψ φ : AddChar R R') (a : R) : (ψ * φ) a = ψ a * φ a :=
 @[simp]
 theorem one_apply (a : R) : (1 : AddChar R R') a = 1 := rfl
 
--- this instance was a bad idea and conflicted with `instFunLike` above
+-- this instance was a bad idea and conflicted with `instDFunLike` above
 #noalign add_char.monoid_hom_class
 
 -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5229): added.

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -98,8 +98,8 @@ open Multiplicative
 /-- Define coercion to a function so that it includes the move from `R` to `Multiplicative R`.
 After we have proved the API lemmas below, we don't need to worry about writing `ofAdd a`
 when we want to apply an additive character. -/
-instance instFunLike : FunLike (AddChar R R') R fun _ ↦ R' :=
-  inferInstanceAs (FunLike (Multiplicative R →* R') R fun _ ↦ R')
+instance instFunLike : DFunLike (AddChar R R') R fun _ ↦ R' :=
+  inferInstanceAs (DFunLike (Multiplicative R →* R') R fun _ ↦ R')
 #noalign add_char.has_coe_to_fun
 
 theorem coe_to_fun_apply (ψ : AddChar R R') (a : R) : ψ a = ψ.toMonoidHom (ofAdd a) :=
@@ -190,7 +190,7 @@ def IsNontrivial (ψ : AddChar R R') : Prop :=
 /-- An additive character is nontrivial iff it is not the trivial character. -/
 theorem isNontrivial_iff_ne_trivial (ψ : AddChar R R') : IsNontrivial ψ ↔ ψ ≠ 1 := by
   refine' not_forall.symm.trans (Iff.not _)
-  rw [FunLike.ext_iff]
+  rw [DFunLike.ext_iff]
   rfl
 #align add_char.is_nontrivial_iff_ne_trivial AddChar.isNontrivial_iff_ne_trivial
 

--- a/Mathlib/NumberTheory/LegendreSymbol/MulCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/MulCharacter.lean
@@ -71,7 +71,7 @@ structure MulChar extends MonoidHom R R' where
   map_nonunit' : ∀ a : R, ¬IsUnit a → toFun a = 0
 #align mul_char MulChar
 
-instance MulChar.instFunLike : FunLike (MulChar R R') R (fun _ => R') :=
+instance MulChar.instFunLike : DFunLike (MulChar R R') R (fun _ => R') :=
   ⟨fun χ => χ.toFun,
     fun χ₀ χ₁ h => by cases χ₀; cases χ₁; congr; apply MonoidHom.ext (fun _ => congr_fun h _)⟩
 

--- a/Mathlib/NumberTheory/LegendreSymbol/MulCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/MulCharacter.lean
@@ -71,7 +71,7 @@ structure MulChar extends MonoidHom R R' where
   map_nonunit' : ∀ a : R, ¬IsUnit a → toFun a = 0
 #align mul_char MulChar
 
-instance MulChar.instFunLike : DFunLike (MulChar R R') R (fun _ => R') :=
+instance MulChar.instDFunLike : DFunLike (MulChar R R') R (fun _ => R') :=
   ⟨fun χ => χ.toFun,
     fun χ₀ χ₁ h => by cases χ₀; cases χ₁; congr; apply MonoidHom.ext (fun _ => congr_fun h _)⟩
 

--- a/Mathlib/NumberTheory/ModularForms/Basic.lean
+++ b/Mathlib/NumberTheory/ModularForms/Basic.lean
@@ -79,7 +79,7 @@ class CuspFormClass (F : Type*) (Γ : outParam <| Subgroup (SL(2, ℤ))) (k : ou
 instance (priority := 100) ModularFormClass.modularForm :
     ModularFormClass (ModularForm Γ k) Γ k where
   coe f := f.toFun
-  coe_injective' f g h := by cases f; cases g; congr; exact FunLike.ext' h
+  coe_injective' f g h := by cases f; cases g; congr; exact DFunLike.ext' h
   slash_action_eq f := f.slash_action_eq'
   holo := ModularForm.holo'
   bdd_at_infty := ModularForm.bdd_at_infty'
@@ -87,7 +87,7 @@ instance (priority := 100) ModularFormClass.modularForm :
 
 instance (priority := 100) CuspFormClass.cuspForm : CuspFormClass (CuspForm Γ k) Γ k where
   coe f := f.toFun
-  coe_injective' f g h := by cases f; cases g; congr; exact FunLike.ext' h
+  coe_injective' f g h := by cases f; cases g; congr; exact DFunLike.ext' h
   slash_action_eq f := f.slash_action_eq'
   holo := CuspForm.holo'
   zero_at_infty := CuspForm.zero_at_infty'
@@ -112,12 +112,12 @@ theorem CuspForm.toSlashInvariantForm_coe (f : CuspForm Γ k) : ⇑f.1 = f := rf
 
 @[ext]
 theorem ModularForm.ext {f g : ModularForm Γ k} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align modular_form.ext ModularForm.ext
 
 @[ext]
 theorem CuspForm.ext {f g : CuspForm Γ k} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align cusp_form.ext CuspForm.ext
 
 /-- Copy of a `ModularForm` with a new `toFun` equal to the old one. Useful to fix
@@ -233,7 +233,7 @@ theorem sub_apply (f g : ModularForm Γ k) (z : ℍ) : (f - g) z = f z - g z :=
 #align modular_form.sub_apply ModularForm.sub_apply
 
 instance : AddCommGroup (ModularForm Γ k) :=
-  FunLike.coe_injective.addCommGroup _ rfl coe_add coe_neg coe_sub coe_smul coe_smul
+  DFunLike.coe_injective.addCommGroup _ rfl coe_add coe_neg coe_sub coe_smul coe_smul
 
 /-- Additive coercion from `ModularForm` to `ℍ → ℂ`. -/
 @[simps]
@@ -244,7 +244,7 @@ def coeHom : ModularForm Γ k →+ ℍ → ℂ where
 #align modular_form.coe_hom ModularForm.coeHom
 
 instance : Module ℂ (ModularForm Γ k) :=
-  Function.Injective.module ℂ coeHom FunLike.coe_injective fun _ _ => rfl
+  Function.Injective.module ℂ coeHom DFunLike.coe_injective fun _ _ => rfl
 
 instance : Inhabited (ModularForm Γ k) :=
   ⟨0⟩
@@ -401,7 +401,7 @@ theorem sub_apply (f g : CuspForm Γ k) (z : ℍ) : (f - g) z = f z - g z :=
 #align cusp_form.sub_apply CuspForm.sub_apply
 
 instance : AddCommGroup (CuspForm Γ k) :=
-  FunLike.coe_injective.addCommGroup _ rfl coe_add coe_neg coe_sub coe_smul coe_smul
+  DFunLike.coe_injective.addCommGroup _ rfl coe_add coe_neg coe_sub coe_smul coe_smul
 
 /-- Additive coercion from `CuspForm` to `ℍ → ℂ`. -/
 @[simps]
@@ -412,14 +412,14 @@ def coeHom : CuspForm Γ k →+ ℍ → ℂ where
 #align cusp_form.coe_hom CuspForm.coeHom
 
 instance : Module ℂ (CuspForm Γ k) :=
-  Function.Injective.module ℂ coeHom FunLike.coe_injective fun _ _ => rfl
+  Function.Injective.module ℂ coeHom DFunLike.coe_injective fun _ _ => rfl
 
 instance : Inhabited (CuspForm Γ k) :=
   ⟨0⟩
 
 instance (priority := 99) [CuspFormClass F Γ k] : ModularFormClass F Γ k where
-  coe := FunLike.coe
-  coe_injective' := FunLike.coe_injective'
+  coe := DFunLike.coe
+  coe_injective' := DFunLike.coe_injective'
   slash_action_eq := SlashInvariantFormClass.slash_action_eq
   holo := CuspFormClass.holo
   bdd_at_infty _ _ := (CuspFormClass.zero_at_infty _ _).boundedAtFilter

--- a/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
@@ -46,7 +46,7 @@ structure SlashInvariantForm where
 
 /-- `SlashInvariantFormClass F Γ k` asserts `F` is a type of bundled functions that are invariant
 under the `SlashAction`. -/
-class SlashInvariantFormClass extends FunLike F ℍ fun _ => ℂ where
+class SlashInvariantFormClass extends DFunLike F ℍ fun _ => ℂ where
   slash_action_eq : ∀ (f : F) (γ : Γ), (f : ℍ → ℂ) ∣[k] γ = f
 #align slash_invariant_form_class SlashInvariantFormClass
 
@@ -60,7 +60,7 @@ instance (priority := 100) SlashInvariantFormClass.slashInvariantForm :
 variable {F Γ k}
 
 instance : CoeFun (SlashInvariantForm Γ k) fun _ => ℍ → ℂ :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 @[simp]
 theorem SlashInvariantForm.toFun_eq_coe {f : SlashInvariantForm Γ k} : f.toFun = (f : ℍ → ℂ) :=
@@ -72,7 +72,7 @@ theorem SlashInvariantForm.coe_mk (f : ℍ → ℂ) (hf : ∀ γ : Γ, f ∣[k] 
 
 @[ext]
 theorem SlashInvariantForm.ext {f g : SlashInvariantForm Γ k} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align slash_invariant_form_ext SlashInvariantForm.ext
 
 /-- Copy of a `SlashInvariantForm` with a new `toFun` equal to the old one.
@@ -192,7 +192,7 @@ theorem sub_apply (f g : SlashInvariantForm Γ k) (z : ℍ) : (f - g) z = f z - 
 #align slash_invariant_form.sub_apply SlashInvariantForm.sub_apply
 
 instance : AddCommGroup (SlashInvariantForm Γ k) :=
-  FunLike.coe_injective.addCommGroup _ rfl coe_add coe_neg coe_sub coe_smul coe_smul
+  DFunLike.coe_injective.addCommGroup _ rfl coe_add coe_neg coe_sub coe_smul coe_smul
 
 /-- Additive coercion from `SlashInvariantForm` to `ℍ → ℂ`.-/
 def coeHom : SlashInvariantForm Γ k →+ ℍ → ℂ where
@@ -202,7 +202,7 @@ def coeHom : SlashInvariantForm Γ k →+ ℍ → ℂ where
 #align slash_invariant_form.coe_hom SlashInvariantForm.coeHom
 
 theorem coeHom_injective : Function.Injective (@coeHom Γ k) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align slash_invariant_form.coe_hom_injective SlashInvariantForm.coeHom_injective
 
 instance : Module ℂ (SlashInvariantForm Γ k) :=

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -278,7 +278,7 @@ namespace NumberField.InfinitePlace
 
 open NumberField
 
-instance {K : Type*} [Field K] : FunLike (InfinitePlace K) K (fun _ => ℝ) :=
+instance {K : Type*} [Field K] : DFunLike (InfinitePlace K) K (fun _ => ℝ) :=
 { coe := fun w x => w.1 x
   coe_injective' := fun _ _ h => Subtype.eq (AbsoluteValue.ext fun x => congr_fun h x)}
 
@@ -308,7 +308,7 @@ theorem mk_embedding (w : InfinitePlace K) : mk (embedding w) = w := Subtype.ext
 
 @[simp]
 theorem mk_conjugate_eq (φ : K →+* ℂ) : mk (ComplexEmbedding.conjugate φ) = mk φ := by
-  refine FunLike.ext _ _ (fun x => ?_)
+  refine DFunLike.ext _ _ (fun x => ?_)
   rw [apply, apply, ComplexEmbedding.conjugate_coe_eq, Complex.abs_conj]
 #align number_field.infinite_place.mk_conjugate_eq NumberField.InfinitePlace.mk_conjugate_eq
 

--- a/Mathlib/Order/Category/BddLat.lean
+++ b/Mathlib/Order/Category/BddLat.lean
@@ -64,7 +64,7 @@ instance : LargeCategory.{u} BddLat where
   assoc _ _ _ := BoundedLatticeHom.comp_assoc _ _ _
 
 -- Porting note: added.
-instance instFunLike (X Y : BddLat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+instance instDFunLike (X Y : BddLat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
   show DFunLike (BoundedLatticeHom X Y) X (fun _ => Y) from inferInstance
 
 instance : ConcreteCategory BddLat where

--- a/Mathlib/Order/Category/BddLat.lean
+++ b/Mathlib/Order/Category/BddLat.lean
@@ -64,14 +64,14 @@ instance : LargeCategory.{u} BddLat where
   assoc _ _ _ := BoundedLatticeHom.comp_assoc _ _ _
 
 -- Porting note: added.
-instance instFunLike (X Y : BddLat) : FunLike (X ⟶ Y) X (fun _ => Y) :=
-  show FunLike (BoundedLatticeHom X Y) X (fun _ => Y) from inferInstance
+instance instFunLike (X Y : BddLat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+  show DFunLike (BoundedLatticeHom X Y) X (fun _ => Y) from inferInstance
 
 instance : ConcreteCategory BddLat where
   forget :=
   { obj := (↑)
-    map := FunLike.coe }
-  forget_faithful := ⟨(FunLike.coe_injective ·)⟩
+    map := DFunLike.coe }
+  forget_faithful := ⟨(DFunLike.coe_injective ·)⟩
 
 instance hasForgetToBddOrd : HasForget₂ BddLat BddOrd where
   forget₂ :=

--- a/Mathlib/Order/Category/BddOrd.lean
+++ b/Mathlib/Order/Category/BddOrd.lean
@@ -63,7 +63,7 @@ instance largeCategory : LargeCategory.{u} BddOrd where
 
 -- Porting note: added.
 -- see https://github.com/leanprover-community/mathlib4/issues/5017
-instance instFunLike (X Y : BddOrd) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+instance instDFunLike (X Y : BddOrd) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
   show DFunLike (BoundedOrderHom X Y) X (fun _ => Y) from inferInstance
 
 instance concreteCategory : ConcreteCategory BddOrd where

--- a/Mathlib/Order/Category/BddOrd.lean
+++ b/Mathlib/Order/Category/BddOrd.lean
@@ -63,14 +63,14 @@ instance largeCategory : LargeCategory.{u} BddOrd where
 
 -- Porting note: added.
 -- see https://github.com/leanprover-community/mathlib4/issues/5017
-instance instFunLike (X Y : BddOrd) : FunLike (X ⟶ Y) X (fun _ => Y) :=
-  show FunLike (BoundedOrderHom X Y) X (fun _ => Y) from inferInstance
+instance instFunLike (X Y : BddOrd) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+  show DFunLike (BoundedOrderHom X Y) X (fun _ => Y) from inferInstance
 
 instance concreteCategory : ConcreteCategory BddOrd where
   forget :=
     { obj := (↥)
-      map := FunLike.coe }
-  forget_faithful := ⟨(FunLike.coe_injective ·)⟩
+      map := DFunLike.coe }
+  forget_faithful := ⟨(DFunLike.coe_injective ·)⟩
 #align BddOrd.concrete_category BddOrd.concreteCategory
 
 instance hasForgetToPartOrd : HasForget₂ BddOrd PartOrd where

--- a/Mathlib/Order/Category/CompleteLat.lean
+++ b/Mathlib/Order/Category/CompleteLat.lean
@@ -50,7 +50,7 @@ instance : BundledHom @CompleteLatticeHom where
   toFun _ _ f := f.toFun
   id := @CompleteLatticeHom.id
   comp := @CompleteLatticeHom.comp
-  hom_ext _ _ _ _ h := FunLike.coe_injective h
+  hom_ext _ _ _ _ h := DFunLike.coe_injective h
 
 deriving instance LargeCategory for CompleteLat
 

--- a/Mathlib/Order/Category/FinBoolAlg.lean
+++ b/Mathlib/Order/Category/FinBoolAlg.lean
@@ -113,12 +113,12 @@ instance forgetToFinPartOrdFaithful : Faithful (forget₂ FinBoolAlg FinPartOrd)
   -- Porting note: original code
   -- ⟨fun {X Y} f g h =>
   --   haveI := congr_arg (coeFn : _ → X → Y) h
-  --   FunLike.coe_injective this⟩
+  --   DFunLike.coe_injective this⟩
   -- Porting note: the coercions to functions for the various bundled order categories
   -- are quite inconsistent. We need to go back through and make all these files uniform.
   ⟨fun {X Y} f g h => by
     dsimp at *
-    apply FunLike.coe_injective
+    apply DFunLike.coe_injective
     dsimp
     ext x
     apply_fun (fun f => f x) at h

--- a/Mathlib/Order/Category/Frm.lean
+++ b/Mathlib/Order/Category/Frm.lean
@@ -62,7 +62,7 @@ instance bundledHom : BundledHom Hom where
   toFun {α β} _ _ := ((↑) : FrameHom α β → α → β)
   id {α} _ := FrameHom.id α
   comp _ _ _ := FrameHom.comp
-  hom_ext _ _ := FunLike.coe_injective
+  hom_ext _ _ := DFunLike.coe_injective
 #align Frm.bundled_hom Frm.bundledHom
 
 -- Porting note: Originally `deriving instance LargeCategory, ConcreteCategory for Frm`

--- a/Mathlib/Order/Category/HeytAlg.lean
+++ b/Mathlib/Order/Category/HeytAlg.lean
@@ -47,10 +47,10 @@ instance : Inhabited HeytAlg :=
   ⟨of PUnit⟩
 
 instance bundledHom : BundledHom HeytingHom where
-  toFun α β [HeytingAlgebra α] [HeytingAlgebra β] := (FunLike.coe : HeytingHom α β → α → β)
+  toFun α β [HeytingAlgebra α] [HeytingAlgebra β] := (DFunLike.coe : HeytingHom α β → α → β)
   id := @HeytingHom.id
   comp := @HeytingHom.comp
-  hom_ext α β [HeytingAlgebra α] [HeytingAlgebra β] := FunLike.coe_injective
+  hom_ext α β [HeytingAlgebra α] [HeytingAlgebra β] := DFunLike.coe_injective
 #align HeytAlg.bundled_hom HeytAlg.bundledHom
 
 deriving instance LargeCategory for HeytAlg

--- a/Mathlib/Order/Category/Lat.lean
+++ b/Mathlib/Order/Category/Lat.lean
@@ -58,7 +58,7 @@ instance : BundledHom @LatticeHom where
   toFun _ _ f := f.toFun
   id := @LatticeHom.id
   comp := @LatticeHom.comp
-  hom_ext _ _ _ _ h := FunLike.coe_injective h
+  hom_ext _ _ _ _ h := DFunLike.coe_injective h
 
 instance : LargeCategory.{u} Lat :=
   BundledHom.category LatticeHom

--- a/Mathlib/Order/Category/NonemptyFinLinOrd.lean
+++ b/Mathlib/Order/Category/NonemptyFinLinOrd.lean
@@ -201,7 +201,7 @@ theorem epi_iff_surjective {A B : NonemptyFinLinOrd.{u}} (f : A ⟶ B) :
         exact h₂ (le_of_lt h₁)
       · exfalso
         exact hm a (eq_of_le_of_not_lt h₂ h₁)
-    simp [FunLike.coe] at h
+    simp [DFunLike.coe] at h
   · intro h
     exact ConcreteCategory.epi_of_surjective f h
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/Order/Category/Semilat.lean
+++ b/Mathlib/Order/Category/Semilat.lean
@@ -69,14 +69,14 @@ instance : LargeCategory.{u} SemilatSupCat where
 
 -- Porting note: added
 -- see https://github.com/leanprover-community/mathlib4/issues/5017
-instance instFunLike (X Y : SemilatSupCat) : FunLike (X ⟶ Y) X (fun _ => Y) :=
-  show FunLike (SupBotHom X Y) X (fun _ => Y) from inferInstance
+instance instFunLike (X Y : SemilatSupCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+  show DFunLike (SupBotHom X Y) X (fun _ => Y) from inferInstance
 
 instance : ConcreteCategory SemilatSupCat where
   forget :=
     { obj := SemilatSupCat.X
-      map := FunLike.coe }
-  forget_faithful := ⟨(FunLike.coe_injective ·)⟩
+      map := DFunLike.coe }
+  forget_faithful := ⟨(DFunLike.coe_injective ·)⟩
 
 instance hasForgetToPartOrd : HasForget₂ SemilatSupCat PartOrd where
   forget₂ :=
@@ -123,14 +123,14 @@ instance : LargeCategory.{u} SemilatInfCat where
   assoc _ _ _ := InfTopHom.comp_assoc _ _ _
 
 -- Porting note: added
-instance instFunLike (X Y : SemilatInfCat) : FunLike (X ⟶ Y) X (fun _ => Y) :=
-  show FunLike (InfTopHom X Y) X (fun _ => Y) from inferInstance
+instance instFunLike (X Y : SemilatInfCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+  show DFunLike (InfTopHom X Y) X (fun _ => Y) from inferInstance
 
 instance : ConcreteCategory SemilatInfCat where
   forget :=
     { obj := SemilatInfCat.X
-      map := FunLike.coe }
-  forget_faithful := ⟨(FunLike.coe_injective ·)⟩
+      map := DFunLike.coe }
+  forget_faithful := ⟨(DFunLike.coe_injective ·)⟩
 
 instance hasForgetToPartOrd : HasForget₂ SemilatInfCat PartOrd where
   forget₂ :=

--- a/Mathlib/Order/Category/Semilat.lean
+++ b/Mathlib/Order/Category/Semilat.lean
@@ -69,7 +69,7 @@ instance : LargeCategory.{u} SemilatSupCat where
 
 -- Porting note: added
 -- see https://github.com/leanprover-community/mathlib4/issues/5017
-instance instFunLike (X Y : SemilatSupCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+instance instDFunLike (X Y : SemilatSupCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
   show DFunLike (SupBotHom X Y) X (fun _ => Y) from inferInstance
 
 instance : ConcreteCategory SemilatSupCat where
@@ -123,7 +123,7 @@ instance : LargeCategory.{u} SemilatInfCat where
   assoc _ _ _ := InfTopHom.comp_assoc _ _ _
 
 -- Porting note: added
-instance instFunLike (X Y : SemilatInfCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
+instance instDFunLike (X Y : SemilatInfCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
   show DFunLike (InfTopHom X Y) X (fun _ => Y) from inferInstance
 
 instance : ConcreteCategory SemilatInfCat where

--- a/Mathlib/Order/Closure.lean
+++ b/Mathlib/Order/Closure.lean
@@ -73,7 +73,7 @@ namespace ClosureOperator
 
 instance [Preorder α] : OrderHomClass (ClosureOperator α) α α where
   coe c := c.1
-  coe_injective' := by rintro ⟨⟩ ⟨⟩ h; obtain rfl := FunLike.ext' h; congr with x; simp [*]
+  coe_injective' := by rintro ⟨⟩ ⟨⟩ h; obtain rfl := DFunLike.ext' h; congr with x; simp [*]
   map_rel f _ _ h := f.mono h
 
 initialize_simps_projections ClosureOperator (toFun → apply, IsClosed → isClosed)
@@ -101,7 +101,7 @@ variable {α} [PartialOrder α] (c : ClosureOperator α)
 
 @[ext]
 theorem ext : ∀ c₁ c₂ : ClosureOperator α, (c₁ : α → α) = (c₂ : α → α) → c₁ = c₂ :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align closure_operator.ext ClosureOperator.ext
 
 /-- Constructor for a closure operator using the weaker idempotency axiom: `f (f x) ≤ f x`. -/

--- a/Mathlib/Order/GameAdd.lean
+++ b/Mathlib/Order/GameAdd.lean
@@ -230,7 +230,7 @@ def GameAdd.fix {C : α → α → Sort*} (hr : WellFounded rα)
     C a b := by
   -- Porting note: this was refactored for #3414 (reenableeta), and could perhaps be cleaned up.
   have := hr.sym2_gameAdd
-  dsimp only [GameAdd, lift₂, FunLike.coe, EquivLike.coe] at this
+  dsimp only [GameAdd, lift₂, DFunLike.coe, EquivLike.coe] at this
   exact @WellFounded.fix (α × α) (fun x => C x.1 x.2) _ this.of_quotient_lift₂
     (fun ⟨x₁, x₂⟩ IH' => IH x₁ x₂ fun a' b' => IH' ⟨a', b'⟩) (a, b)
 #align sym2.game_add.fix Sym2.GameAdd.fix

--- a/Mathlib/Order/Heyting/Hom.lean
+++ b/Mathlib/Order/Heyting/Hom.lean
@@ -13,7 +13,7 @@ import Mathlib.Order.Hom.Lattice
 A Heyting homomorphism between two Heyting algebras is a bounded lattice homomorphism that preserves
 Heyting implication.
 
-We use the `FunLike` design, so each type of morphisms has a companion typeclass which is meant to
+We use the `DFunLike` design, so each type of morphisms has a companion typeclass which is meant to
 be satisfied by itself and all stricter types.
 
 ## Types of morphisms
@@ -251,10 +251,10 @@ instance instHeytingHomClass : HeytingHomClass (HeytingHom α β) α β where
 
 
 -- Porting note: CoeFun undesired here in lean 4
--- /-- Helper instance for when there's too many metavariables to apply `FunLike.CoeFun`
+-- /-- Helper instance for when there's too many metavariables to apply `DFunLike.CoeFun`
 -- directly. -/
 -- instance : CoeFun (HeytingHom α β) fun _ => α → β :=
---   FunLike.hasCoeToFun
+--   DFunLike.hasCoeToFun
 
 -- @[simp] -- Porting note: not in simp-nf, simp can simplify lhs. Added aux simp lemma
 theorem toFun_eq_coe {f : HeytingHom α β} : f.toFun = ⇑f :=
@@ -267,7 +267,7 @@ theorem toFun_eq_coe_aux {f : HeytingHom α β} : (↑f.toLatticeHom) = ⇑f :=
 
 @[ext]
 theorem ext {f g : HeytingHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align heyting_hom.ext HeytingHom.ext
 
 /-- Copy of a `HeytingHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -286,7 +286,7 @@ theorem coe_copy (f : HeytingHom α β) (f' : α → β) (h : f' = f) : ⇑(f.co
 #align heyting_hom.coe_copy HeytingHom.coe_copy
 
 theorem copy_eq (f : HeytingHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align heyting_hom.copy_eq HeytingHom.copy_eq
 
 variable (α)
@@ -314,7 +314,7 @@ instance : Inhabited (HeytingHom α α) :=
   ⟨HeytingHom.id _⟩
 
 instance : PartialOrder (HeytingHom α β) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 /-- Composition of `HeytingHom`s as a `HeytingHom`. -/
 def comp (f : HeytingHom β γ) (g : HeytingHom α β) : HeytingHom α γ :=
@@ -354,7 +354,7 @@ theorem id_comp (f : HeytingHom α β) : (HeytingHom.id β).comp f = f :=
 
 @[simp]
 theorem cancel_right (hf : Surjective f) : g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
 #align heyting_hom.cancel_right HeytingHom.cancel_right
 
 @[simp]
@@ -377,10 +377,10 @@ instance : CoheytingHomClass (CoheytingHom α β) α β where
   map_sdiff := CoheytingHom.map_sdiff'
 
 -- Porting note: CoeFun undesired here in lean 4
--- /-- Helper instance for when there's too many metavariables to apply `FunLike.CoeFun`
+-- /-- Helper instance for when there's too many metavariables to apply `DFunLike.CoeFun`
 -- directly. -/
 -- instance : CoeFun (CoheytingHom α β) fun _ => α → β :=
---   FunLike.hasCoeToFun
+--   DFunLike.hasCoeToFun
 
 
 -- @[simp] -- Porting note: not in simp-nf, simp can simplify lhs. Added aux simp lemma
@@ -394,7 +394,7 @@ theorem toFun_eq_coe_aux {f : CoheytingHom α β} : (↑f.toLatticeHom) = ⇑f :
 
 @[ext]
 theorem ext {f g : CoheytingHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align coheyting_hom.ext CoheytingHom.ext
 
 /-- Copy of a `CoheytingHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -413,7 +413,7 @@ theorem coe_copy (f : CoheytingHom α β) (f' : α → β) (h : f' = f) : ⇑(f.
 #align coheyting_hom.coe_copy CoheytingHom.coe_copy
 
 theorem copy_eq (f : CoheytingHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align coheyting_hom.copy_eq CoheytingHom.copy_eq
 
 variable (α)
@@ -441,7 +441,7 @@ instance : Inhabited (CoheytingHom α α) :=
   ⟨CoheytingHom.id _⟩
 
 instance : PartialOrder (CoheytingHom α β) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 /-- Composition of `CoheytingHom`s as a `CoheytingHom`. -/
 def comp (f : CoheytingHom β γ) (g : CoheytingHom α β) : CoheytingHom α γ :=
@@ -481,7 +481,7 @@ theorem id_comp (f : CoheytingHom α β) : (CoheytingHom.id β).comp f = f :=
 
 @[simp]
 theorem cancel_right (hf : Surjective f) : g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
 #align coheyting_hom.cancel_right CoheytingHom.cancel_right
 
 @[simp]
@@ -504,10 +504,10 @@ instance : BiheytingHomClass (BiheytingHom α β) α β where
   map_sdiff f := f.map_sdiff'
 
 -- Porting note: CoeFun undesired here in lean 4
--- /-- Helper instance for when there's too many metavariables to apply `FunLike.CoeFun`
+-- /-- Helper instance for when there's too many metavariables to apply `DFunLike.CoeFun`
 -- directly. -/
 -- instance : CoeFun (BiheytingHom α β) fun _ => α → β :=
---   FunLike.hasCoeToFun
+--   DFunLike.hasCoeToFun
 
 -- @[simp] -- Porting note: not in simp-nf, simp can simplify lhs. Added aux simp lemma
 theorem toFun_eq_coe {f : BiheytingHom α β} : f.toFun = (f : α → β) :=
@@ -520,7 +520,7 @@ theorem toFun_eq_coe_aux {f : BiheytingHom α β} : (↑f.toLatticeHom) = ⇑f :
 
 @[ext]
 theorem ext {f g : BiheytingHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align biheyting_hom.ext BiheytingHom.ext
 
 /-- Copy of a `BiheytingHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -539,7 +539,7 @@ theorem coe_copy (f : BiheytingHom α β) (f' : α → β) (h : f' = f) : ⇑(f.
 #align biheyting_hom.coe_copy BiheytingHom.coe_copy
 
 theorem copy_eq (f : BiheytingHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align biheyting_hom.copy_eq BiheytingHom.copy_eq
 
 variable (α)
@@ -565,7 +565,7 @@ instance : Inhabited (BiheytingHom α α) :=
   ⟨BiheytingHom.id _⟩
 
 instance : PartialOrder (BiheytingHom α β) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 /-- Composition of `BiheytingHom`s as a `BiheytingHom`. -/
 def comp (f : BiheytingHom β γ) (g : BiheytingHom α β) : BiheytingHom α γ :=
@@ -605,7 +605,7 @@ theorem id_comp (f : BiheytingHom α β) : (BiheytingHom.id β).comp f = f :=
 
 @[simp]
 theorem cancel_right (hf : Surjective f) : g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
 #align biheyting_hom.cancel_right BiheytingHom.cancel_right
 
 @[simp]

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -220,10 +220,10 @@ instance : OrderHomClass (α →o β) α β where
   coe_injective' f g h := by cases f; cases g; congr
   map_rel f _ _ h := f.monotone' h
 
-/-- Helper instance for when there's too many metavariables to apply the coercion via `FunLike`
+/-- Helper instance for when there's too many metavariables to apply the coercion via `DFunLike`
 directly. -/
 instance : CoeFun (α →o β) fun _ => α → β :=
-  ⟨FunLike.coe⟩
+  ⟨DFunLike.coe⟩
 
 @[simp] theorem coe_mk (f : α → β) (hf : Monotone f) : ⇑(mk f hf) = f := rfl
 #align order_hom.coe_fun_mk OrderHom.coe_mk
@@ -240,7 +240,7 @@ protected theorem mono (f : α →o β) : Monotone f :=
 projection directly instead. -/
 def Simps.coe (f : α →o β) : α → β := f
 
-/- Porting note: TODO: all other FunLike classes use `apply` instead of `coe`
+/- Porting note: TODO: all other DFunLike classes use `apply` instead of `coe`
 for the projection names. Maybe we should change this. -/
 initialize_simps_projections OrderHom (toFun → coe)
 
@@ -250,7 +250,7 @@ initialize_simps_projections OrderHom (toFun → coe)
 -- See library note [partially-applied ext lemmas]
 @[ext]
 theorem ext (f g : α →o β) (h : (f : α → β) = g) : f = g :=
-  FunLike.coe_injective h
+  DFunLike.coe_injective h
 #align order_hom.ext OrderHom.ext
 
 @[simp] theorem coe_eq (f : α →o β) : OrderHomClass.toOrderHom f = f := rfl
@@ -276,7 +276,7 @@ theorem coe_copy (f : α →o β) (f' : α → β) (h : f' = f) : (f.copy f' h) 
 #align order_hom.coe_copy OrderHom.coe_copy
 
 theorem copy_eq (f : α →o β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align order_hom.copy_eq OrderHom.copy_eq
 
 /-- The identity function as bundled monotone function. -/
@@ -802,7 +802,7 @@ theorem toFun_eq_coe {f : α ≃o β} : f.toFun = f :=
 -- See note [partially-applied ext lemmas]
 @[ext]
 theorem ext {f g : α ≃o β} (h : (f : α → β) = g) : f = g :=
-  FunLike.coe_injective h
+  DFunLike.coe_injective h
 #align order_iso.ext OrderIso.ext
 
 /-- Reinterpret an order isomorphism as an order embedding. -/
@@ -1093,8 +1093,8 @@ def ofHomInv {F G : Type*} [OrderHomClass F α β] [OrderHomClass G β α] (f : 
     α ≃o β where
   toFun := f
   invFun := g
-  left_inv := FunLike.congr_fun h₂
-  right_inv := FunLike.congr_fun h₁
+  left_inv := DFunLike.congr_fun h₂
+  right_inv := DFunLike.congr_fun h₁
   map_rel_iff' := @fun a b =>
     ⟨fun h => by
       replace h := map_rel g h

--- a/Mathlib/Order/Hom/Bounded.lean
+++ b/Mathlib/Order/Hom/Bounded.lean
@@ -13,7 +13,7 @@ import Mathlib.Order.BoundedOrder
 
 This file defines (bounded) order homomorphisms.
 
-We use the `FunLike` design, so each type of morphisms has a companion typeclass which is meant to
+We use the `DFunLike` design, so each type of morphisms has a companion typeclass which is meant to
 be satisfied by itself and all stricter types.
 
 ## Types of morphisms
@@ -36,7 +36,7 @@ variable {F α β γ δ : Type*}
 
 /-- The type of `⊤`-preserving functions from `α` to `β`. -/
 structure TopHom (α β : Type*) [Top α] [Top β] where
-  /-- The underlying function. The preferred spelling is `FunLike.coe`. -/
+  /-- The underlying function. The preferred spelling is `DFunLike.coe`. -/
   toFun : α → β
   /-- The function preserves the top element. The preferred spelling is `map_top`. -/
   map_top' : toFun ⊤ = ⊤
@@ -44,7 +44,7 @@ structure TopHom (α β : Type*) [Top α] [Top β] where
 
 /-- The type of `⊥`-preserving functions from `α` to `β`. -/
 structure BotHom (α β : Type*) [Bot α] [Bot β] where
-  /-- The underlying function. The preferred spelling is `FunLike.coe`. -/
+  /-- The underlying function. The preferred spelling is `DFunLike.coe`. -/
   toFun : α → β
   /-- The function preserves the bottom element. The preferred spelling is `map_bot`. -/
   map_bot' : toFun ⊥ = ⊥
@@ -65,7 +65,7 @@ section
 
 You should extend this class when you extend `TopHom`. -/
 class TopHomClass (F : Type*) (α β : outParam <| Type*) [Top α] [Top β] extends
-  FunLike F α fun _ => β where
+  DFunLike F α fun _ => β where
   /-- A `TopHomClass` morphism preserves the top element. -/
   map_top (f : F) : f ⊤ = ⊤
 #align top_hom_class TopHomClass
@@ -74,7 +74,7 @@ class TopHomClass (F : Type*) (α β : outParam <| Type*) [Top α] [Top β] exte
 
 You should extend this class when you extend `BotHom`. -/
 class BotHomClass (F : Type*) (α β : outParam <| Type*) [Bot α] [Bot β] extends
-  FunLike F α fun _ => β where
+  DFunLike F α fun _ => β where
   /-- A `BotHomClass` morphism preserves the bottom element. -/
   map_bot (f : F) : f ⊥ = ⊥
 #align bot_hom_class BotHomClass
@@ -205,7 +205,7 @@ initialize_simps_projections TopHom (toFun → apply)
 
 @[ext]
 theorem ext {f g : TopHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align top_hom.ext TopHom.ext
 
 /-- Copy of a `TopHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -222,7 +222,7 @@ theorem coe_copy (f : TopHom α β) (f' : α → β) (h : f' = f) : ⇑(f.copy f
 #align top_hom.coe_copy TopHom.coe_copy
 
 theorem copy_eq (f : TopHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align top_hom.copy_eq TopHom.copy_eq
 
 instance : Inhabited (TopHom α β) :=
@@ -283,7 +283,7 @@ theorem id_comp (f : TopHom α β) : (TopHom.id β).comp f = f :=
 @[simp]
 theorem cancel_right {g₁ g₂ : TopHom β γ} {f : TopHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => TopHom.ext <| hf.forall.2 <| FunLike.ext_iff.1 h, congr_arg (fun g => comp g f)⟩
+  ⟨fun h => TopHom.ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, congr_arg (fun g => comp g f)⟩
 #align top_hom.cancel_right TopHom.cancel_right
 
 @[simp]
@@ -296,10 +296,10 @@ theorem cancel_left {g : TopHom β γ} {f₁ f₂ : TopHom α β} (hg : Injectiv
 end Top
 
 instance [Preorder β] [Top β] : Preorder (TopHom α β) :=
-  Preorder.lift (FunLike.coe : TopHom α β → α → β)
+  Preorder.lift (DFunLike.coe : TopHom α β → α → β)
 
 instance [PartialOrder β] [Top β] : PartialOrder (TopHom α β) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 section OrderTop
 
@@ -329,7 +329,7 @@ instance : Inf (TopHom α β) :=
   ⟨fun f g => ⟨f ⊓ g, by rw [Pi.inf_apply, map_top, map_top, inf_top_eq]⟩⟩
 
 instance : SemilatticeInf (TopHom α β) :=
-  (FunLike.coe_injective.semilatticeInf _) fun _ _ => rfl
+  (DFunLike.coe_injective.semilatticeInf _) fun _ _ => rfl
 
 @[simp]
 theorem coe_inf : ⇑(f ⊓ g) = ⇑f ⊓ ⇑g :=
@@ -351,7 +351,7 @@ instance : Sup (TopHom α β) :=
   ⟨fun f g => ⟨f ⊔ g, by rw [Pi.sup_apply, map_top, map_top, sup_top_eq]⟩⟩
 
 instance : SemilatticeSup (TopHom α β) :=
-  (FunLike.coe_injective.semilatticeSup _) fun _ _ => rfl
+  (DFunLike.coe_injective.semilatticeSup _) fun _ _ => rfl
 
 @[simp]
 theorem coe_sup : ⇑(f ⊔ g) = ⇑f ⊔ ⇑g :=
@@ -366,10 +366,10 @@ theorem sup_apply (a : α) : (f ⊔ g) a = f a ⊔ g a :=
 end SemilatticeSup
 
 instance [Lattice β] [OrderTop β] : Lattice (TopHom α β) :=
-  FunLike.coe_injective.lattice _ (fun _ _ => rfl) fun _ _ => rfl
+  DFunLike.coe_injective.lattice _ (fun _ _ => rfl) fun _ _ => rfl
 
 instance [DistribLattice β] [OrderTop β] : DistribLattice (TopHom α β) :=
-  FunLike.coe_injective.distribLattice _ (fun _ _ => rfl) fun _ _ => rfl
+  DFunLike.coe_injective.distribLattice _ (fun _ _ => rfl) fun _ _ => rfl
 
 end TopHom
 
@@ -397,7 +397,7 @@ initialize_simps_projections BotHom (toFun → apply)
 
 @[ext]
 theorem ext {f g : BotHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align bot_hom.ext BotHom.ext
 
 /-- Copy of a `BotHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -414,7 +414,7 @@ theorem coe_copy (f : BotHom α β) (f' : α → β) (h : f' = f) : ⇑(f.copy f
 #align bot_hom.coe_copy BotHom.coe_copy
 
 theorem copy_eq (f : BotHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align bot_hom.copy_eq BotHom.copy_eq
 
 instance : Inhabited (BotHom α β) :=
@@ -475,7 +475,7 @@ theorem id_comp (f : BotHom α β) : (BotHom.id β).comp f = f :=
 @[simp]
 theorem cancel_right {g₁ g₂ : BotHom β γ} {f : BotHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => BotHom.ext <| hf.forall.2 <| FunLike.ext_iff.1 h, congr_arg (comp · f)⟩
+  ⟨fun h => BotHom.ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, congr_arg (comp · f)⟩
 #align bot_hom.cancel_right BotHom.cancel_right
 
 @[simp]
@@ -488,10 +488,10 @@ theorem cancel_left {g : BotHom β γ} {f₁ f₂ : BotHom α β} (hg : Injectiv
 end Bot
 
 instance [Preorder β] [Bot β] : Preorder (BotHom α β) :=
-  Preorder.lift (FunLike.coe : BotHom α β → α → β)
+  Preorder.lift (DFunLike.coe : BotHom α β → α → β)
 
 instance [PartialOrder β] [Bot β] : PartialOrder (BotHom α β) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 section OrderBot
 
@@ -521,7 +521,7 @@ instance : Inf (BotHom α β) :=
   ⟨fun f g => ⟨f ⊓ g, by rw [Pi.inf_apply, map_bot, map_bot, inf_bot_eq]⟩⟩
 
 instance : SemilatticeInf (BotHom α β) :=
-  (FunLike.coe_injective.semilatticeInf _) fun _ _ => rfl
+  (DFunLike.coe_injective.semilatticeInf _) fun _ _ => rfl
 
 @[simp]
 theorem coe_inf : ⇑(f ⊓ g) = ⇑f ⊓ ⇑g :=
@@ -543,7 +543,7 @@ instance : Sup (BotHom α β) :=
   ⟨fun f g => ⟨f ⊔ g, by rw [Pi.sup_apply, map_bot, map_bot, sup_bot_eq]⟩⟩
 
 instance : SemilatticeSup (BotHom α β) :=
-  (FunLike.coe_injective.semilatticeSup _) fun _ _ => rfl
+  (DFunLike.coe_injective.semilatticeSup _) fun _ _ => rfl
 
 @[simp]
 theorem coe_sup : ⇑(f ⊔ g) = ⇑f ⊔ ⇑g :=
@@ -558,10 +558,10 @@ theorem sup_apply (a : α) : (f ⊔ g) a = f a ⊔ g a :=
 end SemilatticeSup
 
 instance [Lattice β] [OrderBot β] : Lattice (BotHom α β) :=
-  FunLike.coe_injective.lattice _ (fun _ _ => rfl) fun _ _ => rfl
+  DFunLike.coe_injective.lattice _ (fun _ _ => rfl) fun _ _ => rfl
 
 instance [DistribLattice β] [OrderBot β] : DistribLattice (BotHom α β) :=
-  FunLike.coe_injective.distribLattice _ (fun _ _ => rfl) fun _ _ => rfl
+  DFunLike.coe_injective.distribLattice _ (fun _ _ => rfl) fun _ _ => rfl
 
 end BotHom
 
@@ -598,7 +598,7 @@ instance : BoundedOrderHomClass (BoundedOrderHom α β) α
 
 @[ext]
 theorem ext {f g : BoundedOrderHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align bounded_order_hom.ext BoundedOrderHom.ext
 
 /-- Copy of a `BoundedOrderHom` with a new `toFun` equal to the old one. Useful to fix
@@ -613,7 +613,7 @@ theorem coe_copy (f : BoundedOrderHom α β) (f' : α → β) (h : f' = f) : ⇑
 #align bounded_order_hom.coe_copy BoundedOrderHom.coe_copy
 
 theorem copy_eq (f : BoundedOrderHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align bounded_order_hom.copy_eq BoundedOrderHom.copy_eq
 
 variable (α)
@@ -691,7 +691,7 @@ theorem id_comp (f : BoundedOrderHom α β) : (BoundedOrderHom.id β).comp f = f
 @[simp]
 theorem cancel_right {g₁ g₂ : BoundedOrderHom β γ} {f : BoundedOrderHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => BoundedOrderHom.ext <| hf.forall.2 <| FunLike.ext_iff.1 h,
+  ⟨fun h => BoundedOrderHom.ext <| hf.forall.2 <| DFunLike.ext_iff.1 h,
    congr_arg (fun g => comp g f)⟩
 #align bounded_order_hom.cancel_right BoundedOrderHom.cancel_right
 

--- a/Mathlib/Order/Hom/CompleteLattice.lean
+++ b/Mathlib/Order/Hom/CompleteLattice.lean
@@ -256,7 +256,7 @@ instance : sSupHomClass (sSupHom α β) α β
   map_sSup := sSupHom.map_sSup'
 
 -- Porting note: We do not want CoeFun for this in lean 4
--- /-- Helper instance for when there's too many metavariables to apply `funLike.has_coe_toFun`
+-- /-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 -- directly. -/
 -- instance : CoeFun (sSupHom α β) fun _ => α → β :=
 --   DFunLike.hasCoeToFun

--- a/Mathlib/Order/Hom/CompleteLattice.lean
+++ b/Mathlib/Order/Hom/CompleteLattice.lean
@@ -13,7 +13,7 @@ import Mathlib.Order.Hom.Lattice
 
 This file defines frame homomorphisms and complete lattice homomorphisms.
 
-We use the `FunLike` design, so each type of morphisms has a companion typeclass which is meant to
+We use the `DFunLike` design, so each type of morphisms has a companion typeclass which is meant to
 be satisfied by itself and all stricter types.
 
 ## Types of morphisms
@@ -84,7 +84,7 @@ section
 
 You should extend this class when you extend `sSupHom`. -/
 class sSupHomClass (F : Type*) (α β : outParam <| Type*) [SupSet α] [SupSet β] extends
-  FunLike F α fun _ => β where
+  DFunLike F α fun _ => β where
   /-- The proposition that members of `sSupHomClass`s commute with arbitrary suprema/joins. -/
   map_sSup (f : F) (s : Set α) : f (sSup s) = sSup (f '' s)
 #align Sup_hom_class sSupHomClass
@@ -93,7 +93,7 @@ class sSupHomClass (F : Type*) (α β : outParam <| Type*) [SupSet α] [SupSet �
 
 You should extend this class when you extend `sInfHom`. -/
 class sInfHomClass (F : Type*) (α β : outParam <| Type*) [InfSet α] [InfSet β] extends
-  FunLike F α fun _ => β where
+  DFunLike F α fun _ => β where
   /-- The proposition that members of `sInfHomClass`s commute with arbitrary infima/meets. -/
   map_sInf (f : F) (s : Set α) : f (sInf s) = sInf (f '' s)
 #align Inf_hom_class sInfHomClass
@@ -259,7 +259,7 @@ instance : sSupHomClass (sSupHom α β) α β
 -- /-- Helper instance for when there's too many metavariables to apply `funLike.has_coe_toFun`
 -- directly. -/
 -- instance : CoeFun (sSupHom α β) fun _ => α → β :=
---   FunLike.hasCoeToFun
+--   DFunLike.hasCoeToFun
 
 @[simp] lemma toFun_eq_coe (f : sSupHom α β) : f.toFun = f := rfl
 #align Sup_hom.to_fun_eq_coe sSupHom.toFun_eq_coe
@@ -268,7 +268,7 @@ instance : sSupHomClass (sSupHom α β) α β
 
 @[ext]
 theorem ext {f g : sSupHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align Sup_hom.ext sSupHom.ext
 
 /-- Copy of a `sSupHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -285,7 +285,7 @@ theorem coe_copy (f : sSupHom α β) (f' : α → β) (h : f' = f) : ⇑(f.copy 
 #align Sup_hom.coe_copy sSupHom.coe_copy
 
 theorem copy_eq (f : sSupHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align Sup_hom.copy_eq sSupHom.copy_eq
 
 variable (α)
@@ -346,7 +346,7 @@ theorem id_comp (f : sSupHom α β) : (sSupHom.id β).comp f = f :=
 @[simp]
 theorem cancel_right {g₁ g₂ : sSupHom β γ} {f : sSupHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
 #align Sup_hom.cancel_right sSupHom.cancel_right
 
 @[simp]
@@ -360,7 +360,7 @@ end SupSet
 variable { _ : CompleteLattice β}
 
 instance : PartialOrder (sSupHom α β) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 instance : Bot (sSupHom α β) :=
   ⟨⟨fun _ => ⊥, fun s => by
@@ -405,7 +405,7 @@ instance : sInfHomClass (sInfHom α β) α β
 -- /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_toFun`
 -- directly. -/
 -- instance : CoeFun (sInfHom α β) fun _ => α → β :=
---   FunLike.hasCoeToFun
+--   DFunLike.hasCoeToFun
 
 @[simp] lemma toFun_eq_coe (f : sInfHom α β) : f.toFun = f := rfl
 #align Inf_hom.to_fun_eq_coe sInfHom.toFun_eq_coe
@@ -414,7 +414,7 @@ instance : sInfHomClass (sInfHom α β) α β
 
 @[ext]
 theorem ext {f g : sInfHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align Inf_hom.ext sInfHom.ext
 
 /-- Copy of a `sInfHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -431,7 +431,7 @@ theorem coe_copy (f : sInfHom α β) (f' : α → β) (h : f' = f) : ⇑(f.copy 
 #align Inf_hom.coe_copy sInfHom.coe_copy
 
 theorem copy_eq (f : sInfHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align Inf_hom.copy_eq sInfHom.copy_eq
 
 variable (α)
@@ -492,7 +492,7 @@ theorem id_comp (f : sInfHom α β) : (sInfHom.id β).comp f = f :=
 @[simp]
 theorem cancel_right {g₁ g₂ : sInfHom β γ} {f : sInfHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
 #align Inf_hom.cancel_right sInfHom.cancel_right
 
 @[simp]
@@ -506,7 +506,7 @@ end InfSet
 variable [CompleteLattice β]
 
 instance : PartialOrder (sInfHom α β) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 instance : Top (sInfHom α β) :=
   ⟨⟨fun _ => ⊤, fun s => by
@@ -552,7 +552,7 @@ instance : FrameHomClass (FrameHom α β) α β
 -- /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_toFun`
 -- directly. -/
 -- instance : CoeFun (FrameHom α β) fun _ => α → β :=
---   FunLike.hasCoeToFun
+--   DFunLike.hasCoeToFun
 
 /-- Reinterpret a `FrameHom` as a `LatticeHom`. -/
 def toLatticeHom (f : FrameHom α β) : LatticeHom α β :=
@@ -568,7 +568,7 @@ lemma toFun_eq_coe (f : FrameHom α β) : f.toFun = f := rfl
 
 @[ext]
 theorem ext {f g : FrameHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align frame_hom.ext FrameHom.ext
 
 /-- Copy of a `FrameHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -583,7 +583,7 @@ theorem coe_copy (f : FrameHom α β) (f' : α → β) (h : f' = f) : ⇑(f.copy
 #align frame_hom.coe_copy FrameHom.coe_copy
 
 theorem copy_eq (f : FrameHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align frame_hom.copy_eq FrameHom.copy_eq
 
 variable (α)
@@ -643,7 +643,7 @@ theorem id_comp (f : FrameHom α β) : (FrameHom.id β).comp f = f :=
 @[simp]
 theorem cancel_right {g₁ g₂ : FrameHom β γ} {f : FrameHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
 #align frame_hom.cancel_right FrameHom.cancel_right
 
 @[simp]
@@ -653,7 +653,7 @@ theorem cancel_left {g : FrameHom β γ} {f₁ f₂ : FrameHom α β} (hg : Inje
 #align frame_hom.cancel_left FrameHom.cancel_left
 
 instance : PartialOrder (FrameHom α β) :=
-  PartialOrder.lift _ FunLike.coe_injective
+  PartialOrder.lift _ DFunLike.coe_injective
 
 end FrameHom
 
@@ -685,7 +685,7 @@ def toBoundedLatticeHom (f : CompleteLatticeHom α β) : BoundedLatticeHom α β
 -- /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_toFun`
 -- directly. -/
 -- instance : CoeFun (CompleteLatticeHom α β) fun _ => α → β :=
---   FunLike.hasCoeToFun
+--   DFunLike.hasCoeToFun
 
 lemma toFun_eq_coe (f : CompleteLatticeHom α β) : f.toFun = f := rfl
 #align complete_lattice_hom.to_fun_eq_coe CompleteLatticeHom.toFun_eq_coe
@@ -698,7 +698,7 @@ rfl
 
 @[ext]
 theorem ext {f g : CompleteLatticeHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align complete_lattice_hom.ext CompleteLatticeHom.ext
 
 /-- Copy of a `CompleteLatticeHom` with a new `toFun` equal to the old one. Useful to fix
@@ -714,7 +714,7 @@ theorem coe_copy (f : CompleteLatticeHom α β) (f' : α → β) (h : f' = f) : 
 #align complete_lattice_hom.coe_copy CompleteLatticeHom.coe_copy
 
 theorem copy_eq (f : CompleteLatticeHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align complete_lattice_hom.copy_eq CompleteLatticeHom.copy_eq
 
 variable (α)
@@ -773,7 +773,7 @@ theorem id_comp (f : CompleteLatticeHom α β) : (CompleteLatticeHom.id β).comp
 @[simp]
 theorem cancel_right {g₁ g₂ : CompleteLatticeHom β γ} {f : CompleteLatticeHom α β}
     (hf : Surjective f) : g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, congr_arg (fun a ↦ comp a f)⟩
 #align complete_lattice_hom.cancel_right CompleteLatticeHom.cancel_right
 
 @[simp]

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -339,7 +339,7 @@ instance : SupHomClass (SupHom α β) α β where
   coe_injective' f g h := by cases f; cases g; congr
   map_sup := SupHom.map_sup'
 
-/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 -- porting note: replaced `CoeFun` with `DFunLike` so that we use `DFunLike.coe` instead of `toFun`
 instance : DFunLike (SupHom α β) α fun _ => β :=
@@ -527,7 +527,7 @@ instance : InfHomClass (InfHom α β) α β where
   coe_injective' f g h := by cases f; cases g; congr
   map_inf := InfHom.map_inf'
 
-/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 instance : DFunLike (InfHom α β) α fun _ => β :=
   InfHomClass.toDFunLike
@@ -879,7 +879,7 @@ instance : InfTopHomClass (InfTopHom α β) α β
   map_inf f := f.map_inf'
   map_top f := f.map_top'
 
-/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 instance : DFunLike (InfTopHom α β) α fun _ => β :=
   InfHomClass.toDFunLike
@@ -1028,7 +1028,7 @@ instance : LatticeHomClass (LatticeHom α β) α β
   map_sup f := f.map_sup'
   map_inf f := f.map_inf'
 
-/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 instance : DFunLike (LatticeHom α β) α fun _ => β :=
   SupHomClass.toDFunLike

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -13,7 +13,7 @@ import Mathlib.Order.SymmDiff
 
 This file defines (bounded) lattice homomorphisms.
 
-We use the `FunLike` design, so each type of morphisms has a companion typeclass which is meant to
+We use the `DFunLike` design, so each type of morphisms has a companion typeclass which is meant to
 be satisfied by itself and all stricter types.
 
 ## Types of morphisms
@@ -100,7 +100,7 @@ section
 
 You should extend this class when you extend `SupHom`. -/
 class SupHomClass (F : Type*) (α β : outParam <| Type*) [Sup α] [Sup β] extends
-  FunLike F α fun _ => β where
+  DFunLike F α fun _ => β where
   /-- A `SupHomClass` morphism preserves suprema. -/
   map_sup (f : F) (a b : α) : f (a ⊔ b) = f a ⊔ f b
 #align sup_hom_class SupHomClass
@@ -109,7 +109,7 @@ class SupHomClass (F : Type*) (α β : outParam <| Type*) [Sup α] [Sup β] exte
 
 You should extend this class when you extend `InfHom`. -/
 class InfHomClass (F : Type*) (α β : outParam <| Type*) [Inf α] [Inf β] extends
-  FunLike F α fun _ => β where
+  DFunLike F α fun _ => β where
   /-- An `InfHomClass` morphism preserves infima. -/
   map_inf (f : F) (a b : α) : f (a ⊓ b) = f a ⊓ f b
 #align inf_hom_class InfHomClass
@@ -341,9 +341,9 @@ instance : SupHomClass (SupHom α β) α β where
 
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
--- porting note: replaced `CoeFun` with `FunLike` so that we use `FunLike.coe` instead of `toFun`
-instance : FunLike (SupHom α β) α fun _ => β :=
-  SupHomClass.toFunLike
+-- porting note: replaced `CoeFun` with `DFunLike` so that we use `DFunLike.coe` instead of `toFun`
+instance : DFunLike (SupHom α β) α fun _ => β :=
+  SupHomClass.toDFunLike
 
 @[simp] lemma toFun_eq_coe (f : SupHom α β) : f.toFun = f := rfl
 #align sup_hom.to_fun_eq_coe SupHom.toFun_eq_coe
@@ -352,7 +352,7 @@ instance : FunLike (SupHom α β) α fun _ => β :=
 
 @[ext]
 theorem ext {f g : SupHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align sup_hom.ext SupHom.ext
 
 /-- Copy of a `SupHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -368,7 +368,7 @@ theorem coe_copy (f : SupHom α β) (f' : α → β) (h : f' = f) : ⇑(f.copy f
 #align sup_hom.coe_copy SupHom.coe_copy
 
 theorem copy_eq (f : SupHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align sup_hom.copy_eq SupHom.copy_eq
 
 variable (α)
@@ -424,7 +424,7 @@ theorem comp_assoc (f : SupHom γ δ) (g : SupHom β γ) (h : SupHom α β) :
 @[simp]
 theorem cancel_right {g₁ g₂ : SupHom β γ} {f : SupHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => SupHom.ext <| hf.forall.2 <| FunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
+  ⟨fun h => SupHom.ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
 #align sup_hom.cancel_right SupHom.cancel_right
 
 @[simp]
@@ -462,7 +462,7 @@ instance : Sup (SupHom α β) :=
       exact sup_sup_sup_comm _ _ _ _⟩⟩
 
 instance : SemilatticeSup (SupHom α β) :=
-  (FunLike.coe_injective.semilatticeSup _) fun _ _ => rfl
+  (DFunLike.coe_injective.semilatticeSup _) fun _ _ => rfl
 
 instance [Bot β] : Bot (SupHom α β) :=
   ⟨SupHom.const α ⊥⟩
@@ -480,7 +480,7 @@ instance [BoundedOrder β] : BoundedOrder (SupHom α β) :=
   BoundedOrder.lift ((↑) : _ → α → β) (fun _ _ => id) rfl rfl
 
 @[simp]
-theorem coe_sup (f g : SupHom α β) : FunLike.coe (f ⊔ g) = f ⊔ g :=
+theorem coe_sup (f g : SupHom α β) : DFunLike.coe (f ⊔ g) = f ⊔ g :=
   rfl
 #align sup_hom.coe_sup SupHom.coe_sup
 
@@ -529,8 +529,8 @@ instance : InfHomClass (InfHom α β) α β where
 
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
-instance : FunLike (InfHom α β) α fun _ => β :=
-  InfHomClass.toFunLike
+instance : DFunLike (InfHom α β) α fun _ => β :=
+  InfHomClass.toDFunLike
 
 @[simp] lemma toFun_eq_coe (f : InfHom α β) : f.toFun = (f : α → β) := rfl
 #align inf_hom.to_fun_eq_coe InfHom.toFun_eq_coe
@@ -539,7 +539,7 @@ instance : FunLike (InfHom α β) α fun _ => β :=
 
 @[ext]
 theorem ext {f g : InfHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align inf_hom.ext InfHom.ext
 
 /-- Copy of an `InfHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -556,7 +556,7 @@ theorem coe_copy (f : InfHom α β) (f' : α → β) (h : f' = f) : ⇑(f.copy f
 #align inf_hom.coe_copy InfHom.coe_copy
 
 theorem copy_eq (f : InfHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align inf_hom.copy_eq InfHom.copy_eq
 
 variable (α)
@@ -612,7 +612,7 @@ theorem comp_assoc (f : InfHom γ δ) (g : InfHom β γ) (h : InfHom α β) :
 @[simp]
 theorem cancel_right {g₁ g₂ : InfHom β γ} {f : InfHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => InfHom.ext <| hf.forall.2 <| FunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
+  ⟨fun h => InfHom.ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
 #align inf_hom.cancel_right InfHom.cancel_right
 
 @[simp]
@@ -650,7 +650,7 @@ instance : Inf (InfHom α β) :=
       exact inf_inf_inf_comm _ _ _ _⟩⟩
 
 instance : SemilatticeInf (InfHom α β) :=
-  (FunLike.coe_injective.semilatticeInf _) fun _ _ => rfl
+  (DFunLike.coe_injective.semilatticeInf _) fun _ _ => rfl
 
 instance [Bot β] : Bot (InfHom α β) :=
   ⟨InfHom.const α ⊥⟩
@@ -668,7 +668,7 @@ instance [BoundedOrder β] : BoundedOrder (InfHom α β) :=
   BoundedOrder.lift ((↑) : _ → α → β) (fun _ _ => id) rfl rfl
 
 @[simp]
-theorem coe_inf (f g : InfHom α β) : FunLike.coe (f ⊓ g) = f ⊓ g :=
+theorem coe_inf (f g : InfHom α β) : DFunLike.coe (f ⊓ g) = f ⊓ g :=
   rfl
 #align inf_hom.coe_inf InfHom.coe_inf
 
@@ -724,9 +724,9 @@ instance : SupBotHomClass (SupBotHom α β) α β
   map_sup f := f.map_sup'
   map_bot f := f.map_bot'
 
--- porting note: replaced `CoeFun` instance with `FunLike` instance
-instance : FunLike (SupBotHom α β) α fun _ => β :=
-  SupHomClass.toFunLike
+-- porting note: replaced `CoeFun` instance with `DFunLike` instance
+instance : DFunLike (SupBotHom α β) α fun _ => β :=
+  SupHomClass.toDFunLike
 
 lemma toFun_eq_coe (f : SupBotHom α β) : f.toFun = f := rfl
 #align sup_bot_hom.to_fun_eq_coe SupBotHom.toFun_eq_coe
@@ -737,7 +737,7 @@ lemma toFun_eq_coe (f : SupBotHom α β) : f.toFun = f := rfl
 
 @[ext]
 theorem ext {f g : SupBotHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align sup_bot_hom.ext SupBotHom.ext
 
 /-- Copy of a `SupBotHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -752,7 +752,7 @@ theorem coe_copy (f : SupBotHom α β) (f' : α → β) (h : f' = f) : ⇑(f.cop
 #align sup_bot_hom.coe_copy SupBotHom.coe_copy
 
 theorem copy_eq (f : SupBotHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align sup_bot_hom.copy_eq SupBotHom.copy_eq
 
 variable (α)
@@ -808,7 +808,7 @@ theorem comp_assoc (f : SupBotHom γ δ) (g : SupBotHom β γ) (h : SupBotHom α
 @[simp]
 theorem cancel_right {g₁ g₂ : SupBotHom β γ} {f : SupBotHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
 #align sup_bot_hom.cancel_right SupBotHom.cancel_right
 
 @[simp]
@@ -825,14 +825,14 @@ instance : Sup (SupBotHom α β) :=
   ⟨fun f g => { f.toBotHom ⊔ g.toBotHom with toSupHom := f.toSupHom ⊔ g.toSupHom }⟩
 
 instance : SemilatticeSup (SupBotHom α β) :=
-  (FunLike.coe_injective.semilatticeSup _) fun _ _ => rfl
+  (DFunLike.coe_injective.semilatticeSup _) fun _ _ => rfl
 
 instance : OrderBot (SupBotHom α β) where
   bot := ⟨⊥, rfl⟩
   bot_le _ _ := bot_le
 
 @[simp]
-theorem coe_sup (f g : SupBotHom α β) : FunLike.coe (f ⊔ g) = f ⊔ g :=
+theorem coe_sup (f g : SupBotHom α β) : DFunLike.coe (f ⊔ g) = f ⊔ g :=
   rfl
 #align sup_bot_hom.coe_sup SupBotHom.coe_sup
 
@@ -881,8 +881,8 @@ instance : InfTopHomClass (InfTopHom α β) α β
 
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
-instance : FunLike (InfTopHom α β) α fun _ => β :=
-  InfHomClass.toFunLike
+instance : DFunLike (InfTopHom α β) α fun _ => β :=
+  InfHomClass.toDFunLike
 
 theorem toFun_eq_coe (f : InfTopHom α β) : f.toFun = f := rfl
 #align inf_top_hom.to_fun_eq_coe InfTopHom.toFun_eq_coe
@@ -893,7 +893,7 @@ theorem toFun_eq_coe (f : InfTopHom α β) : f.toFun = f := rfl
 
 @[ext]
 theorem ext {f g : InfTopHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align inf_top_hom.ext InfTopHom.ext
 
 /-- Copy of an `InfTopHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -908,7 +908,7 @@ theorem coe_copy (f : InfTopHom α β) (f' : α → β) (h : f' = f) : ⇑(f.cop
 #align inf_top_hom.coe_copy InfTopHom.coe_copy
 
 theorem copy_eq (f : InfTopHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align inf_top_hom.copy_eq InfTopHom.copy_eq
 
 variable (α)
@@ -964,7 +964,7 @@ theorem comp_assoc (f : InfTopHom γ δ) (g : InfTopHom β γ) (h : InfTopHom α
 @[simp]
 theorem cancel_right {g₁ g₂ : InfTopHom β γ} {f : InfTopHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
 #align inf_top_hom.cancel_right InfTopHom.cancel_right
 
 @[simp]
@@ -981,14 +981,14 @@ instance : Inf (InfTopHom α β) :=
   ⟨fun f g => { f.toTopHom ⊓ g.toTopHom with toInfHom := f.toInfHom ⊓ g.toInfHom }⟩
 
 instance : SemilatticeInf (InfTopHom α β) :=
-  (FunLike.coe_injective.semilatticeInf _) fun _ _ => rfl
+  (DFunLike.coe_injective.semilatticeInf _) fun _ _ => rfl
 
 instance : OrderTop (InfTopHom α β) where
   top := ⟨⊤, rfl⟩
   le_top _ _ := le_top
 
 @[simp]
-theorem coe_inf (f g : InfTopHom α β) : FunLike.coe (f ⊓ g) = f ⊓ g :=
+theorem coe_inf (f g : InfTopHom α β) : DFunLike.coe (f ⊓ g) = f ⊓ g :=
   rfl
 #align inf_top_hom.coe_inf InfTopHom.coe_inf
 
@@ -1030,8 +1030,8 @@ instance : LatticeHomClass (LatticeHom α β) α β
 
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
-instance : FunLike (LatticeHom α β) α fun _ => β :=
-  SupHomClass.toFunLike
+instance : DFunLike (LatticeHom α β) α fun _ => β :=
+  SupHomClass.toDFunLike
 
 lemma toFun_eq_coe (f : LatticeHom α β) : f.toFun = f := rfl
 #align lattice_hom.to_fun_eq_coe LatticeHom.toFun_eq_coe
@@ -1042,7 +1042,7 @@ lemma toFun_eq_coe (f : LatticeHom α β) : f.toFun = f := rfl
 
 @[ext]
 theorem ext {f g : LatticeHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align lattice_hom.ext LatticeHom.ext
 
 /-- Copy of a `LatticeHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -1057,7 +1057,7 @@ theorem coe_copy (f : LatticeHom α β) (f' : α → β) (h : f' = f) : ⇑(f.co
 #align lattice_hom.coe_copy LatticeHom.coe_copy
 
 theorem copy_eq (f : LatticeHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align lattice_hom.copy_eq LatticeHom.copy_eq
 
 variable (α)
@@ -1140,7 +1140,7 @@ theorem id_comp (f : LatticeHom α β) : (LatticeHom.id β).comp f = f :=
 @[simp]
 theorem cancel_right {g₁ g₂ : LatticeHom β γ} {f : LatticeHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => LatticeHom.ext <| hf.forall.2 <| FunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
+  ⟨fun h => LatticeHom.ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
 #align lattice_hom.cancel_right LatticeHom.cancel_right
 
 @[simp]
@@ -1229,7 +1229,7 @@ instance instBoundedLatticeHomClass : BoundedLatticeHomClass (BoundedLatticeHom 
 
 @[ext]
 theorem ext {f g : BoundedLatticeHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align bounded_lattice_hom.ext BoundedLatticeHom.ext
 
 /-- Copy of a `BoundedLatticeHom` with a new `toFun` equal to the old one. Useful to fix
@@ -1244,7 +1244,7 @@ theorem coe_copy (f : BoundedLatticeHom α β) (f' : α → β) (h : f' = f) : �
 #align bounded_lattice_hom.coe_copy BoundedLatticeHom.coe_copy
 
 theorem copy_eq (f : BoundedLatticeHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align bounded_lattice_hom.copy_eq BoundedLatticeHom.copy_eq
 
 variable (α)
@@ -1335,7 +1335,7 @@ theorem comp_assoc (f : BoundedLatticeHom γ δ) (g : BoundedLatticeHom β γ)
 @[simp]
 theorem cancel_right {g₁ g₂ : BoundedLatticeHom β γ} {f : BoundedLatticeHom α β}
     (hf : Surjective f) : g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => BoundedLatticeHom.ext <| hf.forall.2 <| FunLike.ext_iff.1 h,
+  ⟨fun h => BoundedLatticeHom.ext <| hf.forall.2 <| DFunLike.ext_iff.1 h,
     fun h => congr_arg₂ _ h rfl⟩
 #align bounded_lattice_hom.cancel_right BoundedLatticeHom.cancel_right
 
@@ -1597,14 +1597,14 @@ protected def withTop (f : SupHom α β) : SupHom (WithTop α) (WithTop β) wher
 #align sup_hom.with_top SupHom.withTop
 
 @[simp]
-theorem withTop_id : (SupHom.id α).withTop = SupHom.id _ := FunLike.coe_injective Option.map_id
+theorem withTop_id : (SupHom.id α).withTop = SupHom.id _ := DFunLike.coe_injective Option.map_id
 #align sup_hom.with_top_id SupHom.withTop_id
 
 @[simp]
 theorem withTop_comp (f : SupHom β γ) (g : SupHom α β) :
     (f.comp g).withTop = f.withTop.comp g.withTop :=
--- porting note: Proof was `FunLike.coe_injective (Option.map_comp_map _ _).symm`
-  FunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
+-- porting note: Proof was `DFunLike.coe_injective (Option.map_comp_map _ _).symm`
+  DFunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
 #align sup_hom.with_top_comp SupHom.withTop_comp
 
 /-- Adjoins a `⊥` to the domain and codomain of a `SupHom`. -/
@@ -1621,14 +1621,14 @@ protected def withBot (f : SupHom α β) : SupBotHom (WithBot α) (WithBot β) w
 #align sup_hom.with_bot SupHom.withBot
 
 @[simp]
-theorem withBot_id : (SupHom.id α).withBot = SupBotHom.id _ := FunLike.coe_injective Option.map_id
+theorem withBot_id : (SupHom.id α).withBot = SupBotHom.id _ := DFunLike.coe_injective Option.map_id
 #align sup_hom.with_bot_id SupHom.withBot_id
 
 @[simp]
 theorem withBot_comp (f : SupHom β γ) (g : SupHom α β) :
     (f.comp g).withBot = f.withBot.comp g.withBot :=
--- porting note: Proof was `FunLike.coe_injective (Option.map_comp_map _ _).symm`
-  FunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
+-- porting note: Proof was `DFunLike.coe_injective (Option.map_comp_map _ _).symm`
+  DFunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
 #align sup_hom.with_bot_comp SupHom.withBot_comp
 
 /-- Adjoins a `⊤` to the codomain of a `SupHom`. -/
@@ -1676,14 +1676,14 @@ protected def withTop (f : InfHom α β) : InfTopHom (WithTop α) (WithTop β) w
 #align inf_hom.with_top InfHom.withTop
 
 @[simp]
-theorem withTop_id : (InfHom.id α).withTop = InfTopHom.id _ := FunLike.coe_injective Option.map_id
+theorem withTop_id : (InfHom.id α).withTop = InfTopHom.id _ := DFunLike.coe_injective Option.map_id
 #align inf_hom.with_top_id InfHom.withTop_id
 
 @[simp]
 theorem withTop_comp (f : InfHom β γ) (g : InfHom α β) :
     (f.comp g).withTop = f.withTop.comp g.withTop :=
--- porting note: Proof was `FunLike.coe_injective (Option.map_comp_map _ _).symm`
-  FunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
+-- porting note: Proof was `DFunLike.coe_injective (Option.map_comp_map _ _).symm`
+  DFunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
 #align inf_hom.with_top_comp InfHom.withTop_comp
 
 /-- Adjoins a `⊥` to the domain and codomain of an `InfHom`. -/
@@ -1699,14 +1699,14 @@ protected def withBot (f : InfHom α β) : InfHom (WithBot α) (WithBot β) wher
 #align inf_hom.with_bot InfHom.withBot
 
 @[simp]
-theorem withBot_id : (InfHom.id α).withBot = InfHom.id _ := FunLike.coe_injective Option.map_id
+theorem withBot_id : (InfHom.id α).withBot = InfHom.id _ := DFunLike.coe_injective Option.map_id
 #align inf_hom.with_bot_id InfHom.withBot_id
 
 @[simp]
 theorem withBot_comp (f : InfHom β γ) (g : InfHom α β) :
     (f.comp g).withBot = f.withBot.comp g.withBot :=
--- porting note: Proof was `FunLike.coe_injective (Option.map_comp_map _ _).symm`
-  FunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
+-- porting note: Proof was `DFunLike.coe_injective (Option.map_comp_map _ _).symm`
+  DFunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
 #align inf_hom.with_bot_comp InfHom.withBot_comp
 
 /-- Adjoins a `⊤` to the codomain of an `InfHom`. -/
@@ -1754,14 +1754,14 @@ lemma withTop_apply (f : LatticeHom α β) (a : WithTop α) : f.withTop a = a.ma
 
 @[simp]
 theorem withTop_id : (LatticeHom.id α).withTop = LatticeHom.id _ :=
-  FunLike.coe_injective Option.map_id
+  DFunLike.coe_injective Option.map_id
 #align lattice_hom.with_top_id LatticeHom.withTop_id
 
 @[simp]
 theorem withTop_comp (f : LatticeHom β γ) (g : LatticeHom α β) :
     (f.comp g).withTop = f.withTop.comp g.withTop :=
--- porting note: Proof was `FunLike.coe_injective (Option.map_comp_map _ _).symm`
-  FunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
+-- porting note: Proof was `DFunLike.coe_injective (Option.map_comp_map _ _).symm`
+  DFunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
 #align lattice_hom.with_top_comp LatticeHom.withTop_comp
 
 /-- Adjoins a `⊥` to the domain and codomain of a `LatticeHom`. -/
@@ -1778,14 +1778,14 @@ lemma withBot_apply (f : LatticeHom α β) (a : WithBot α) : f.withBot a = a.ma
 
 @[simp]
 theorem withBot_id : (LatticeHom.id α).withBot = LatticeHom.id _ :=
-  FunLike.coe_injective Option.map_id
+  DFunLike.coe_injective Option.map_id
 #align lattice_hom.with_bot_id LatticeHom.withBot_id
 
 @[simp]
 theorem withBot_comp (f : LatticeHom β γ) (g : LatticeHom α β) :
     (f.comp g).withBot = f.withBot.comp g.withBot :=
--- porting note: Proof was `FunLike.coe_injective (Option.map_comp_map _ _).symm`
-  FunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
+-- porting note: Proof was `DFunLike.coe_injective (Option.map_comp_map _ _).symm`
+  DFunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
 #align lattice_hom.with_bot_comp LatticeHom.withBot_comp
 
 /-- Adjoins a `⊤` and `⊥` to the domain and codomain of a `LatticeHom`. -/
@@ -1804,7 +1804,7 @@ lemma withTopWithBot_apply (f : LatticeHom α β) (a : WithTop <| WithBot α) :
 
 @[simp]
 theorem withTopWithBot_id : (LatticeHom.id α).withTopWithBot = BoundedLatticeHom.id _ :=
-  FunLike.coe_injective <| by
+  DFunLike.coe_injective <| by
     refine' (congr_arg Option.map _).trans Option.map_id
     rw [withBot_id]
     rfl

--- a/Mathlib/Order/InitialSeg.lean
+++ b/Mathlib/Order/InitialSeg.lean
@@ -75,7 +75,7 @@ instance : EmbeddingLike (r ≼i s) α β :=
     injective' := fun f => f.inj' }
 
 @[ext] lemma ext {f g : r ≼i s} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align initial_seg.ext InitialSeg.ext
 
 @[simp]

--- a/Mathlib/Order/LiminfLimsup.lean
+++ b/Mathlib/Order/LiminfLimsup.lean
@@ -1025,10 +1025,10 @@ theorem bliminf_or_le_inf_aux_left : (bliminf u f fun x => p x ∨ q x) ≤ blim
 theorem bliminf_or_le_inf_aux_right : (bliminf u f fun x => p x ∨ q x) ≤ bliminf u f q :=
   bliminf_or_le_inf.trans inf_le_right
 
-/- Porting note: Replaced `e` with `FunLike.coe e` to override the strange
+/- Porting note: Replaced `e` with `DFunLike.coe e` to override the strange
  coercion to `↑(RelIso.toRelEmbedding e).toEmbedding`.-/
 theorem OrderIso.apply_blimsup [CompleteLattice γ] (e : α ≃o γ) :
-    FunLike.coe e (blimsup u f p) = blimsup ((FunLike.coe e) ∘ u) f p := by
+    DFunLike.coe e (blimsup u f p) = blimsup ((DFunLike.coe e) ∘ u) f p := by
   simp only [blimsup_eq, map_sInf, Function.comp_apply]
   congr
   ext c

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -96,7 +96,7 @@ variable {α : Type u} {β : Type v} {γ : Type*}
 variable [Preorder α] [Preorder β] [Preorder γ]
 
 instance : OrderHomClass (Chain α) ℕ α := inferInstanceAs <| OrderHomClass (ℕ →o α) ℕ α
-instance : CoeFun (Chain α) fun _ => ℕ → α := ⟨FunLike.coe⟩
+instance : CoeFun (Chain α) fun _ => ℕ → α := ⟨DFunLike.coe⟩
 
 instance [Inhabited α] : Inhabited (Chain α) :=
   ⟨⟨default, fun _ _ _ => le_rfl⟩⟩
@@ -624,7 +624,7 @@ attribute [nolint docBlame] ContinuousHom.toOrderHom
 
 instance : OrderHomClass (α →𝒄 β) α β where
   coe f := f.toFun
-  coe_injective' := by rintro ⟨⟩ ⟨⟩ h; congr; exact FunLike.ext' h
+  coe_injective' := by rintro ⟨⟩ ⟨⟩ h; congr; exact DFunLike.ext' h
   map_rel f _ _ h := f.mono h
 
 -- Porting note: removed to avoid conflict with the generic instance
@@ -643,7 +643,7 @@ theorem toOrderHom_eq_coe (f : α →𝒄 β) : f.1 = f := rfl
 @[simp] theorem coe_mk (f : α →o β) (hf : Continuous f) : ⇑(mk f hf) = f := rfl
 @[simp] theorem coe_toOrderHom (f : α →𝒄 β) : ⇑f.1 = f := rfl
 
-/-- See Note [custom simps projection]. We specify this explicitly because we don't have a FunLike
+/-- See Note [custom simps projection]. We specify this explicitly because we don't have a DFunLike
 instance.
 -/
 def Simps.apply (h : α →𝒄 β) : α → β :=
@@ -652,7 +652,7 @@ def Simps.apply (h : α →𝒄 β) : α → β :=
 initialize_simps_projections ContinuousHom (toFun → apply)
 
 theorem congr_fun {f g : α →𝒄 β} (h : f = g) (x : α) : f x = g x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align omega_complete_partial_order.continuous_hom.congr_fun OmegaCompletePartialOrder.ContinuousHom.congr_fun
 
 theorem congr_arg (f : α →𝒄 β) {x y : α} (h : x = y) : f x = f y :=
@@ -752,11 +752,11 @@ def comp (f : β →𝒄 γ) (g : α →𝒄 β) : α →𝒄 γ := ⟨.comp f.1
 #align omega_complete_partial_order.continuous_hom.comp_apply OmegaCompletePartialOrder.ContinuousHom.comp_apply
 
 @[ext]
-protected theorem ext (f g : α →𝒄 β) (h : ∀ x, f x = g x) : f = g := FunLike.ext f g h
+protected theorem ext (f g : α →𝒄 β) (h : ∀ x, f x = g x) : f = g := DFunLike.ext f g h
 #align omega_complete_partial_order.continuous_hom.ext OmegaCompletePartialOrder.ContinuousHom.ext
 
 protected theorem coe_inj (f g : α →𝒄 β) (h : (f : α → β) = g) : f = g :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align omega_complete_partial_order.continuous_hom.coe_inj OmegaCompletePartialOrder.ContinuousHom.coe_inj
 
 @[simp]

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -65,7 +65,7 @@ The relations `r` and `s` are `outParam`s since figuring them out from a goal is
 matching problem that Lean usually can't do unaided.
 -/
 class RelHomClass (F : Type*) {α β : outParam <| Type*} (r : outParam <| α → α → Prop)
-  (s : outParam <| β → β → Prop) extends FunLike F α fun _ => β where
+  (s : outParam <| β → β → Prop) extends DFunLike F α fun _ => β where
   /-- A `RelHomClass` sends related elements to related elements -/
   map_rel : ∀ (f : F) {a b}, r a b → s (f a) (f b)
 #align rel_hom_class RelHomClass
@@ -123,16 +123,16 @@ theorem coe_fn_toFun (f : r →r s) : f.toFun = (f : α → β) :=
 
 /-- The map `coe_fn : (r →r s) → (α → β)` is injective. -/
 theorem coe_fn_injective : Injective fun (f : r →r s) => (f : α → β) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align rel_hom.coe_fn_injective RelHom.coe_fn_injective
 
 @[ext]
 theorem ext ⦃f g : r →r s⦄ (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align rel_hom.ext RelHom.ext
 
 theorem ext_iff {f g : r →r s} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align rel_hom.ext_iff RelHom.ext_iff
 
 /-- Identity map is a relation homomorphism. -/
@@ -271,16 +271,16 @@ theorem coe_mk : ⇑(⟨f, h⟩ : r ↪r s) = f :=
 
 /-- The map `coe_fn : (r ↪r s) → (α → β)` is injective. -/
 theorem coe_fn_injective : Injective fun f : r ↪r s => (f : α → β) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align rel_embedding.coe_fn_injective RelEmbedding.coe_fn_injective
 
 @[ext]
 theorem ext ⦃f g : r ↪r s⦄ (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align rel_embedding.ext RelEmbedding.ext
 
 theorem ext_iff {f g : r ↪r s} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align rel_embedding.ext_iff RelEmbedding.ext_iff
 
 /-- Identity map is a relation embedding. -/
@@ -630,7 +630,7 @@ theorem toEquiv_injective : Injective (toEquiv : r ≃r s → α ≃ β)
 instance : CoeOut (r ≃r s) (r ↪r s) :=
   ⟨toRelEmbedding⟩
 
--- Porting note: moved to after `RelHomClass` instance and redefined as `FunLike.coe`
+-- Porting note: moved to after `RelHomClass` instance and redefined as `DFunLike.coe`
 -- instance : CoeFun (r ≃r s) fun _ => α → β :=
 --   ⟨fun f => f⟩
 
@@ -645,12 +645,12 @@ instance : EquivLike (r ≃r s) α β where
   inv f := f.toEquiv.symm
   left_inv f := f.left_inv
   right_inv f := f.right_inv
-  coe_injective' _ _ hf _ := FunLike.ext' hf
+  coe_injective' _ _ hf _ := DFunLike.ext' hf
 
 --Porting note: helper instance
 -- see Note [function coercion]
 instance : CoeFun (r ≃r s) fun _ => α → β :=
-  ⟨FunLike.coe⟩
+  ⟨DFunLike.coe⟩
 
 @[simp]
 theorem coe_toRelEmbedding (f : r ≃r s) : (f.toRelEmbedding : α → β) = f :=
@@ -678,16 +678,16 @@ theorem coe_fn_toEquiv (f : r ≃r s) : (f.toEquiv : α → β) = f :=
 /-- The map `coe_fn : (r ≃r s) → (α → β)` is injective. Lean fails to parse
 `function.injective (λ e : r ≃r s, (e : α → β))`, so we use a trick to say the same. -/
 theorem coe_fn_injective : Injective fun f : r ≃r s => (f : α → β) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align rel_iso.coe_fn_injective RelIso.coe_fn_injective
 
 @[ext]
 theorem ext ⦃f g : r ≃r s⦄ (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align rel_iso.ext RelIso.ext
 
 theorem ext_iff {f g : r ≃r s} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align rel_iso.ext_iff RelIso.ext_iff
 
 /-- Inverse map of a relation isomorphism is a relation isomorphism. -/
@@ -696,7 +696,7 @@ protected def symm (f : r ≃r s) : s ≃r r :=
 #align rel_iso.symm RelIso.symm
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
-  because `RelIso` defines custom coercions other than the ones given by `FunLike`. -/
+  because `RelIso` defines custom coercions other than the ones given by `DFunLike`. -/
 def Simps.apply (h : r ≃r s) : α → β :=
   h
 #align rel_iso.simps.apply RelIso.Simps.apply

--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -1045,7 +1045,7 @@ def map (f : α ≃o β) : UpperSet α ≃o UpperSet β where
 
 @[simp]
 theorem symm_map (f : α ≃o β) : (map f).symm = map f.symm :=
-  FunLike.ext _ _ fun s => ext <| by convert Set.preimage_equiv_eq_image_symm s f.toEquiv
+  DFunLike.ext _ _ fun s => ext <| by convert Set.preimage_equiv_eq_image_symm s f.toEquiv
 #align upper_set.symm_map UpperSet.symm_map
 
 @[simp]
@@ -1090,7 +1090,7 @@ def map (f : α ≃o β) : LowerSet α ≃o LowerSet β where
 
 @[simp]
 theorem symm_map (f : α ≃o β) : (map f).symm = map f.symm :=
-  FunLike.ext _ _ fun s => ext <| by convert Set.preimage_equiv_eq_image_symm s f.toEquiv
+  DFunLike.ext _ _ fun s => ext <| by convert Set.preimage_equiv_eq_image_symm s f.toEquiv
 #align lower_set.symm_map LowerSet.symm_map
 
 @[simp]

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -64,9 +64,9 @@ noncomputable def kernel (α β : Type*) [MeasurableSpace α] [MeasurableSpace �
   add_mem' hf hg := Measurable.add hf hg
 #align probability_theory.kernel ProbabilityTheory.kernel
 
--- Porting note: using `FunLike` instead of `CoeFun` to use `FunLike.coe`
+-- Porting note: using `DFunLike` instead of `CoeFun` to use `DFunLike.coe`
 instance {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
-    FunLike (kernel α β) α fun _ => Measure β where
+    DFunLike (kernel α β) α fun _ => Measure β where
   coe := Subtype.val
   coe_injective' := Subtype.val_injective
 
@@ -177,10 +177,10 @@ instance (priority := 100) IsMarkovKernel.isFiniteKernel [IsMarkovKernel κ] :
 namespace kernel
 
 @[ext]
-theorem ext {η : kernel α β} (h : ∀ a, κ a = η a) : κ = η := FunLike.ext _ _ h
+theorem ext {η : kernel α β} (h : ∀ a, κ a = η a) : κ = η := DFunLike.ext _ _ h
 #align probability_theory.kernel.ext ProbabilityTheory.kernel.ext
 
-theorem ext_iff {η : kernel α β} : κ = η ↔ ∀ a, κ a = η a := FunLike.ext_iff
+theorem ext_iff {η : kernel α β} : κ = η ↔ ∀ a, κ a = η a := DFunLike.ext_iff
 #align probability_theory.kernel.ext_iff ProbabilityTheory.kernel.ext_iff
 
 theorem ext_iff' {η : kernel α β} :

--- a/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
@@ -46,10 +46,10 @@ def PMF.{u} (α : Type u) : Type u :=
 
 namespace PMF
 
-instance funLike : DFunLike (PMF α) α fun _ => ℝ≥0∞ where
+instance instDFunLike : DFunLike (PMF α) α fun _ => ℝ≥0∞ where
   coe p a := p.1 a
   coe_injective' _ _ h := Subtype.eq h
-#align pmf.fun_like PMF.funLike
+#align pmf.fun_like PMF.instDFunLike
 
 @[ext]
 protected theorem ext {p q : PMF α} (h : ∀ x, p x = q x) : p = q :=

--- a/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
@@ -46,18 +46,18 @@ def PMF.{u} (α : Type u) : Type u :=
 
 namespace PMF
 
-instance funLike : FunLike (PMF α) α fun _ => ℝ≥0∞ where
+instance funLike : DFunLike (PMF α) α fun _ => ℝ≥0∞ where
   coe p a := p.1 a
   coe_injective' _ _ h := Subtype.eq h
 #align pmf.fun_like PMF.funLike
 
 @[ext]
 protected theorem ext {p q : PMF α} (h : ∀ x, p x = q x) : p = q :=
-  FunLike.ext p q h
+  DFunLike.ext p q h
 #align pmf.ext PMF.ext
 
 theorem ext_iff {p q : PMF α} : p = q ↔ ∀ x, p x = q x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align pmf.ext_iff PMF.ext_iff
 
 theorem hasSum_coe_one (p : PMF α) : HasSum p 1 :=

--- a/Mathlib/RepresentationTheory/GroupCohomology/Hilbert90.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Hilbert90.lean
@@ -61,10 +61,10 @@ linear independence of characters -/
   have : LinearIndependent L (fun (f : L ≃ₐ[K] L) => (f : L → L)) :=
     LinearIndependent.comp (ι' := L ≃ₐ[K] L)
       (linearIndependent_monoidHom L L) (fun f => f)
-      (fun x y h => by ext; exact FunLike.ext_iff.1 h _)
+      (fun x y h => by ext; exact DFunLike.ext_iff.1 h _)
   have h := linearIndependent_iff.1 this
     (Finsupp.equivFunOnFinite.symm (fun φ => (f φ : L)))
-  fun H => Units.ne_zero (f 1) (FunLike.ext_iff.1 (h H) 1)
+  fun H => Units.ne_zero (f 1) (DFunLike.ext_iff.1 (h H) 1)
 
 end Hilbert90
 section

--- a/Mathlib/RepresentationTheory/Maschke.lean
+++ b/Mathlib/RepresentationTheory/Maschke.lean
@@ -155,8 +155,8 @@ theorem exists_leftInverse_of_injective (f : V →ₗ[MonoidAlgebra k G] W)
     ∃ g : W →ₗ[MonoidAlgebra k G] V, g.comp f = LinearMap.id := by
   obtain ⟨φ, hφ⟩ := (f.restrictScalars k).exists_leftInverse_of_injective <| by
     simp only [hf, Submodule.restrictScalars_bot, LinearMap.ker_restrictScalars]
-  refine ⟨φ.equivariantProjection G, FunLike.ext _ _ ?_⟩
-  exact φ.equivariantProjection_condition G _ <| FunLike.congr_fun hφ
+  refine ⟨φ.equivariantProjection G, DFunLike.ext _ _ ?_⟩
+  exact φ.equivariantProjection_condition G _ <| DFunLike.congr_fun hφ
 #align monoid_algebra.exists_left_inverse_of_injective MonoidAlgebra.exists_leftInverse_of_injective
 
 namespace Submodule
@@ -166,7 +166,7 @@ theorem exists_isCompl (p : Submodule (MonoidAlgebra k G) V) :
   have : IsScalarTower k (MonoidAlgebra k G) p := p.isScalarTower'
   rcases MonoidAlgebra.exists_leftInverse_of_injective p.subtype p.ker_subtype with ⟨f, hf⟩
   refine ⟨LinearMap.ker f, LinearMap.isCompl_of_proj ?_⟩
-  exact FunLike.congr_fun hf
+  exact DFunLike.congr_fun hf
 #align monoid_algebra.submodule.exists_is_compl MonoidAlgebra.Submodule.exists_isCompl
 
 /-- This also implies an instance `IsSemisimpleModule (MonoidAlgebra k G) V`. -/

--- a/Mathlib/RingTheory/Congruence.lean
+++ b/Mathlib/RingTheory/Congruence.lean
@@ -72,9 +72,9 @@ section Basic
 
 variable [Add R] [Mul R] (c : RingCon R)
 
---Porting note: upgrade to `FunLike`
+--Porting note: upgrade to `DFunLike`
 /-- A coercion from a congruence relation to its underlying binary relation. -/
-instance : FunLike (RingCon R) R fun _ => R → Prop :=
+instance : DFunLike (RingCon R) R fun _ => R → Prop :=
   { coe := fun c => c.r,
     coe_injective' := fun x y h => by
       rcases x with ⟨⟨x, _⟩, _⟩
@@ -119,7 +119,7 @@ theorem rel_mk {s : Con R} {h a b} : RingCon.mk s h a b ↔ s a b :=
   Iff.rfl
 
 /-- The map sending a congruence relation to its underlying binary relation is injective. -/
-theorem ext' {c d : RingCon R} (H : ⇑c = ⇑d) : c = d := FunLike.coe_injective H
+theorem ext' {c d : RingCon R} (H : ⇑c = ⇑d) : c = d := DFunLike.coe_injective H
 
 /-- Extensionality rule for congruence relations. -/
 theorem ext {c d : RingCon R} (H : ∀ x y, c x y ↔ d x y) : c = d :=

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -68,7 +68,7 @@ instance : AddMonoidHomClass (Derivation R A M) A M where
   map_add D := D.toLinearMap.map_add'
   map_zero D := D.toLinearMap.map_zero
 
-/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 instance : CoeFun (Derivation R A M) fun _ => A → M :=
   ⟨DFunLike.coe⟩

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -64,14 +64,14 @@ variable (D : Derivation R A M) {D1 D2 : Derivation R A M} (r : R) (a b : A)
 
 instance : AddMonoidHomClass (Derivation R A M) A M where
   coe D := D.toFun
-  coe_injective' D1 D2 h := by cases D1; cases D2; congr; exact FunLike.coe_injective h
+  coe_injective' D1 D2 h := by cases D1; cases D2; congr; exact DFunLike.coe_injective h
   map_add D := D.toLinearMap.map_add'
   map_zero D := D.toLinearMap.map_zero
 
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
 instance : CoeFun (Derivation R A M) fun _ => A → M :=
-  ⟨FunLike.coe⟩
+  ⟨DFunLike.coe⟩
 
 -- Not a simp lemma because it can be proved via `coeFn_coe` + `toLinearMap_eq_coe`
 theorem toFun_eq_coe : D.toFun = ⇑D :=
@@ -101,17 +101,17 @@ theorem coeFn_coe (f : Derivation R A M) : ⇑(f : A →ₗ[R] M) = f :=
   rfl
 #align derivation.coe_fn_coe Derivation.coeFn_coe
 
-theorem coe_injective : @Function.Injective (Derivation R A M) (A → M) FunLike.coe :=
-  FunLike.coe_injective
+theorem coe_injective : @Function.Injective (Derivation R A M) (A → M) DFunLike.coe :=
+  DFunLike.coe_injective
 #align derivation.coe_injective Derivation.coe_injective
 
 @[ext]
 theorem ext (H : ∀ a, D1 a = D2 a) : D1 = D2 :=
-  FunLike.ext _ _ H
+  DFunLike.ext _ _ H
 #align derivation.ext Derivation.ext
 
 theorem congr_fun (h : D1 = D2) (a : A) : D1 a = D2 a :=
-  FunLike.congr_fun h a
+  DFunLike.congr_fun h a
 #align derivation.congr_fun Derivation.congr_fun
 
 protected theorem map_add : D (a + b) = D a + D b :=

--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -696,7 +696,7 @@ lemma of_equiv_equiv {A₁ B₁ A₂ B₂ : Type*} [CommRing A₁] [CommRing B�
   haveI : IsScalarTower A₁ A₂ B₁ := IsScalarTower.of_algebraMap_eq
     (fun x ↦ by simp [RingHom.algebraMap_toAlgebra])
   let e : B₁ ≃ₐ[A₂] B₂ := { e₂ with commutes' := fun r ↦ by simpa [RingHom.algebraMap_toAlgebra]
-                                                  using FunLike.congr_fun he.symm (e₁.symm r) }
+                                                  using DFunLike.congr_fun he.symm (e₁.symm r) }
   haveI := Module.Finite.of_restrictScalars_finite A₁ A₂ B₁
   exact Module.Finite.equiv e.toLinearEquiv
 

--- a/Mathlib/RingTheory/HahnSeries.lean
+++ b/Mathlib/RingTheory/HahnSeries.lean
@@ -1367,7 +1367,7 @@ section AddCommMonoid
 
 variable [PartialOrder Γ] [AddCommMonoid R] {α : Type*}
 
-instance : FunLike (SummableFamily Γ R α) α fun _ => HahnSeries Γ R where
+instance : DFunLike (SummableFamily Γ R α) α fun _ => HahnSeries Γ R where
   coe := toFun
   coe_injective' | ⟨_, _, _⟩, ⟨_, _, _⟩, rfl => rfl
 
@@ -1381,12 +1381,12 @@ theorem finite_co_support (s : SummableFamily Γ R α) (g : Γ) :
 #align hahn_series.summable_family.finite_co_support HahnSeries.SummableFamily.finite_co_support
 
 theorem coe_injective : @Function.Injective (SummableFamily Γ R α) (α → HahnSeries Γ R) (⇑) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align hahn_series.summable_family.coe_injective HahnSeries.SummableFamily.coe_injective
 
 @[ext]
 theorem ext {s t : SummableFamily Γ R α} (h : ∀ a : α, s a = t a) : s = t :=
-  FunLike.ext s t h
+  DFunLike.ext s t h
 #align hahn_series.summable_family.ext HahnSeries.SummableFamily.ext
 
 instance : Add (SummableFamily Γ R α) :=

--- a/Mathlib/RingTheory/Ideal/LocalRing.lean
+++ b/Mathlib/RingTheory/Ideal/LocalRing.lean
@@ -434,13 +434,13 @@ theorem map_residue (f : R →+* S) [IsLocalRingHom f] (r : R) :
 #align local_ring.residue_field.map_residue LocalRing.ResidueField.map_residue
 
 theorem map_id_apply (x : ResidueField R) : map (RingHom.id R) x = x :=
-  FunLike.congr_fun map_id x
+  DFunLike.congr_fun map_id x
 #align local_ring.residue_field.map_id_apply LocalRing.ResidueField.map_id_apply
 
 @[simp]
 theorem map_map (f : R →+* S) (g : S →+* T) (x : ResidueField R) [IsLocalRingHom f]
     [IsLocalRingHom g] : map g (map f x) = map (g.comp f) x :=
-  FunLike.congr_fun (map_comp f g).symm x
+  DFunLike.congr_fun (map_comp f g).symm x
 #align local_ring.residue_field.map_map LocalRing.ResidueField.map_map
 
 /-- A ring isomorphism defines an isomorphism of residue fields. -/

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -600,7 +600,8 @@ def quotientEquivAlg (I : Ideal A) (J : Ideal B) (f : A ≃ₐ[R₁] B) (hIJ : J
   { quotientEquiv I J (f : A ≃+* B) hIJ with
     commutes' := fun r => by
       -- Porting note: Needed to add the below lemma because Equivs coerce weird
-      have : ∀ (e : RingEquiv (A ⧸ I) (B ⧸ J)), Equiv.toFun e.toEquiv = DFunLike.coe e := fun _ ↦ rfl
+      have : ∀ (e : RingEquiv (A ⧸ I) (B ⧸ J)), Equiv.toFun e.toEquiv = DFunLike.coe e :=
+        fun _ ↦ rfl
       rw [this]
       simp only [quotientEquiv_apply, RingHom.toFun_eq_coe, quotientMap_algebraMap,
       RingEquiv.coe_toRingHom, AlgEquiv.coe_ringEquiv, AlgEquiv.commutes, Quotient.mk_algebraMap]}

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -600,7 +600,7 @@ def quotientEquivAlg (I : Ideal A) (J : Ideal B) (f : A ≃ₐ[R₁] B) (hIJ : J
   { quotientEquiv I J (f : A ≃+* B) hIJ with
     commutes' := fun r => by
       -- Porting note: Needed to add the below lemma because Equivs coerce weird
-      have : ∀ (e : RingEquiv (A ⧸ I) (B ⧸ J)), Equiv.toFun e.toEquiv = FunLike.coe e := fun _ ↦ rfl
+      have : ∀ (e : RingEquiv (A ⧸ I) (B ⧸ J)), Equiv.toFun e.toEquiv = DFunLike.coe e := fun _ ↦ rfl
       rw [this]
       simp only [quotientEquiv_apply, RingHom.toFun_eq_coe, quotientMap_algebraMap,
       RingEquiv.coe_toRingHom, AlgEquiv.coe_ringEquiv, AlgEquiv.commutes, Quotient.mk_algebraMap]}

--- a/Mathlib/RingTheory/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralRestrict.lean
@@ -51,7 +51,7 @@ def galLift (σ : B →ₐ[A] B) : L →ₐ[K] L :=
     simp only [RingHom.coe_comp, Function.comp_apply, ← IsScalarTower.algebraMap_apply A K L,
       IsScalarTower.algebraMap_apply A B L, IsLocalization.lift_eq,
       RingHom.coe_coe, AlgHom.commutes]
-  { IsLocalization.lift (S := L) H with commutes' := FunLike.congr_fun H_eq }
+  { IsLocalization.lift (S := L) H with commutes' := DFunLike.congr_fun H_eq }
 
 /-- The restriction `End(L/K) → End(B/A)` in an AKLB setup.
 Also see `galRestrict` for the `AlgEquiv` version. -/

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -277,7 +277,7 @@ theorem IsBaseChange.of_lift_unique
           TensorProduct.induction_on x _ (fun s' y => smul_assoc s s' _) fun x y hx hy => _ }
     · dsimp; rw [map_zero, smul_zero, map_zero, smul_zero]
     · dsimp at *; rw [smul_add, map_add, map_add, smul_add, hx, hy]
-  simp_rw [FunLike.ext_iff, LinearMap.comp_apply, LinearMap.restrictScalars_apply] at hg
+  simp_rw [DFunLike.ext_iff, LinearMap.comp_apply, LinearMap.restrictScalars_apply] at hg
   let fe : S ⊗[R] M ≃ₗ[S] N :=
     LinearEquiv.ofLinear f'' (ULift.moduleEquiv.toLinearMap.comp g) ?_ ?_
   · exact fe.bijective

--- a/Mathlib/RingTheory/Kaehler.lean
+++ b/Mathlib/RingTheory/Kaehler.lean
@@ -482,8 +482,8 @@ noncomputable def KaehlerDifferential.kerTotal : Submodule S (S →₀ S) :=
 
 unsuppress_compilation in
 -- Porting note: was `local notation x "𝖣" y => (KaehlerDifferential.kerTotal R S).mkQ (single y x)`
--- but not having `FunLike.coe` leads to `kerTotal_mkQ_single_smul` failing.
-local notation3 x "𝖣" y => FunLike.coe (KaehlerDifferential.kerTotal R S).mkQ (single y x)
+-- but not having `DFunLike.coe` leads to `kerTotal_mkQ_single_smul` failing.
+local notation3 x "𝖣" y => DFunLike.coe (KaehlerDifferential.kerTotal R S).mkQ (single y x)
 
 theorem KaehlerDifferential.kerTotal_mkQ_single_add (x y z) : (z𝖣x + y) = (z𝖣x) + z𝖣y := by
   rw [← map_add, eq_comm, ← sub_eq_zero, ← map_sub (Submodule.mkQ (kerTotal R S)),

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -537,12 +537,12 @@ theorem lift_eq_iff {x y : R × M} :
 
 @[simp]
 theorem lift_comp : (lift hg).comp (algebraMap R S) = g :=
-  RingHom.ext <| (FunLike.ext_iff (F := MonoidHom _ _)).1 <| (toLocalizationMap M S).lift_comp _
+  RingHom.ext <| (DFunLike.ext_iff (F := MonoidHom _ _)).1 <| (toLocalizationMap M S).lift_comp _
 #align is_localization.lift_comp IsLocalization.lift_comp
 
 @[simp]
 theorem lift_of_comp (j : S →+* P) : lift (isUnit_comp M j) = j :=
-  RingHom.ext <| (FunLike.ext_iff (F := MonoidHom _ _)).1 <|
+  RingHom.ext <| (DFunLike.ext_iff (F := MonoidHom _ _)).1 <|
     (toLocalizationMap M S).lift_of_comp j.toMonoidHom
 #align is_localization.lift_of_comp IsLocalization.lift_of_comp
 
@@ -551,7 +551,7 @@ variable (M)
 /-- See note [partially-applied ext lemmas] -/
 theorem monoidHom_ext ⦃j k : S →* P⦄
     (h : j.comp (algebraMap R S : R →* S) = k.comp (algebraMap R S)) : j = k :=
-  Submonoid.LocalizationMap.epic_of_localizationMap (toLocalizationMap M S) <| FunLike.congr_fun h
+  Submonoid.LocalizationMap.epic_of_localizationMap (toLocalizationMap M S) <| DFunLike.congr_fun h
 #align is_localization.monoid_hom_ext IsLocalization.monoidHom_ext
 
 /-- See note [partially-applied ext lemmas] -/
@@ -585,7 +585,7 @@ variable {M}
 
 theorem lift_unique {j : S →+* P} (hj : ∀ x, j ((algebraMap R S) x) = g x) : lift hg = j :=
   RingHom.ext <|
-    (FunLike.ext_iff (F := MonoidHom _ _)).1 <|
+    (DFunLike.ext_iff (F := MonoidHom _ _)).1 <|
       Submonoid.LocalizationMap.lift_unique (toLocalizationMap M S) (g := g.toMonoidHom) hg
         (j := j.toMonoidHom) hj
 #align is_localization.lift_unique IsLocalization.lift_unique
@@ -1418,7 +1418,7 @@ theorem IsLocalization.algebraMap_apply_eq_map_map_submonoid (x) :
     algebraMap Rₘ Sₘ x =
       map Sₘ (algebraMap R S)
         (show _ ≤ (Algebra.algebraMapSubmonoid S M).comap _ from M.le_comap_map) x :=
-  FunLike.congr_fun (IsLocalization.algebraMap_eq_map_map_submonoid _ _ _ _) x
+  DFunLike.congr_fun (IsLocalization.algebraMap_eq_map_map_submonoid _ _ _ _) x
 #align is_localization.algebra_map_apply_eq_map_map_submonoid IsLocalization.algebraMap_apply_eq_map_map_submonoid
 
 theorem IsLocalization.lift_algebraMap_eq_algebraMap :

--- a/Mathlib/RingTheory/Localization/Module.lean
+++ b/Mathlib/RingTheory/Localization/Module.lean
@@ -107,7 +107,7 @@ theorem Basis.ofIsLocalizedModule_repr_apply (m : M) (i : ι) :
     ((b.ofIsLocalizedModule Rₛ S f).repr (f m)) i = algebraMap R Rₛ (b.repr m i) := by
   suffices ((b.ofIsLocalizedModule Rₛ S f).repr.toLinearMap.restrictScalars R) ∘ₗ f =
       Finsupp.mapRange.linearMap (Algebra.linearMap R Rₛ) ∘ₗ b.repr.toLinearMap by
-    exact FunLike.congr_fun (LinearMap.congr_fun this m) i
+    exact DFunLike.congr_fun (LinearMap.congr_fun this m) i
   refine Basis.ext b fun i ↦ ?_
   rw [LinearMap.coe_comp, Function.comp_apply, LinearMap.coe_restrictScalars,
     LinearEquiv.coe_coe, ← b.ofIsLocalizedModule_apply Rₛ S f, repr_self, LinearMap.coe_comp,

--- a/Mathlib/RingTheory/MvPolynomial/Basic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Basic.lean
@@ -151,7 +151,7 @@ set_option linter.uppercaseLean3 false in
 
 private lemma finite_setOf_bounded (α) [Finite α] (n : ℕ) : Finite {f : α →₀ ℕ | ∀ a, f a ≤ n} :=
   ((Set.Finite.pi' fun _ ↦ Set.finite_le_nat _).preimage <|
-    FunLike.coe_injective.injOn _).to_subtype
+    DFunLike.coe_injective.injOn _).to_subtype
 
 instance [Finite σ] (N : ℕ) : Module.Finite R (restrictDegree σ R N) :=
   have := finite_setOf_bounded σ N

--- a/Mathlib/RingTheory/MvPolynomial/Homogeneous.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Homogeneous.lean
@@ -276,7 +276,7 @@ theorem homogeneousComponent_zero : homogeneousComponent 0 φ = C (coeff 0 φ) :
   · simp only [coeff_homogeneousComponent, sum_eq_zero_iff, Finsupp.zero_apply, if_true, coeff_C,
       eq_self_iff_true, forall_true_iff]
   · rw [coeff_homogeneousComponent, if_neg, coeff_C, if_neg (Ne.symm hd)]
-    simp only [FunLike.ext_iff, Finsupp.zero_apply] at hd
+    simp only [DFunLike.ext_iff, Finsupp.zero_apply] at hd
     simp [hd]
 #align mv_polynomial.homogeneous_component_zero MvPolynomial.homogeneousComponent_zero
 

--- a/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
+++ b/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
@@ -458,7 +458,7 @@ theorem weightedHomogeneousComponent_zero [NoZeroSMulDivisors ℕ M] (hw : ∀ i
     simp only [weightedDegree', LinearMap.toAddMonoidHom_coe, Finsupp.total_apply, Finsupp.sum,
       sum_eq_zero_iff, Finsupp.mem_support_iff, Ne.def, smul_eq_zero, not_forall, not_or,
       and_self_left, exists_prop]
-    simp only [FunLike.ext_iff, Finsupp.coe_zero, Pi.zero_apply, not_forall] at hd
+    simp only [DFunLike.ext_iff, Finsupp.coe_zero, Pi.zero_apply, not_forall] at hd
     obtain ⟨i, hi⟩ := hd
     exact ⟨i, hi, hw i⟩
 #align mv_polynomial.weighted_homogeneous_component_zero MvPolynomial.weightedHomogeneousComponent_zero

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
@@ -504,7 +504,7 @@ lemma _root_.Set.mem_center_iff_addMonoidHom (a : R) :
       AddMonoidHom.comp .mul (.mulRight a) = .compl₂ .mul (.mulLeft a) ∧
       AddMonoidHom.compr₂ .mul (.mulRight a) = .compl₂ .mul (.mulRight a) := by
   rw [Set.mem_center_iff, isMulCentral_iff]
-  simp_rw [FunLike.ext_iff]
+  simp_rw [DFunLike.ext_iff]
   rfl
 
 end NonUnitalNonAssocSemiring
@@ -941,7 +941,7 @@ theorem eqOn_sclosure {f g : F} {s : Set R} (h : Set.EqOn (f : R → S) (g : R �
 
 theorem eq_of_eqOn_stop {f g : F}
     (h : Set.EqOn (f : R → S) (g : R → S) (⊤ : NonUnitalSubsemiring R)) : f = g :=
-  FunLike.ext _ _ fun _ => h trivial
+  DFunLike.ext _ _ fun _ => h trivial
 #align non_unital_ring_hom.eq_of_eq_on_stop NonUnitalRingHom.eq_of_eqOn_stop
 
 theorem eq_of_eqOn_sdense {s : Set R} (hs : closure s = ⊤) {f g : F}

--- a/Mathlib/RingTheory/Perfection.lean
+++ b/Mathlib/RingTheory/Perfection.lean
@@ -177,8 +177,8 @@ variable (R p)
 instance perfectRing : PerfectRing (Ring.Perfection R p) p where
   bijective_frobenius := Function.bijective_iff_has_inverse.mpr
     ⟨pthRoot R p,
-     FunLike.congr_fun <| @frobenius_pthRoot R _ p _ _,
-     FunLike.congr_fun <| @pthRoot_frobenius R _ p _ _⟩
+     DFunLike.congr_fun <| @frobenius_pthRoot R _ p _ _,
+     DFunLike.congr_fun <| @pthRoot_frobenius R _ p _ _⟩
 #align perfection.perfect_ring Perfection.perfectRing
 
 /-- Given rings `R` and `S` of characteristic `p`, with `R` being perfect,

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -322,7 +322,7 @@ protected theorem mul_assoc (x y z : A ⊗[R] B) : mul (mul x y) z = mul x (mul 
   -- restate as an equality of morphisms so that we can use `ext`
   suffices LinearMap.llcomp R _ _ _ mul ∘ₗ mul =
       (LinearMap.llcomp R _ _ _ LinearMap.lflip <| LinearMap.llcomp R _ _ _ mul.flip ∘ₗ mul).flip by
-    exact FunLike.congr_fun (FunLike.congr_fun (FunLike.congr_fun this x) y) z
+    exact DFunLike.congr_fun (DFunLike.congr_fun (DFunLike.congr_fun this x) y) z
   ext xa xb ya yb za zb
   exact congr_arg₂ (· ⊗ₜ ·) (mul_assoc xa ya za) (mul_assoc xb yb zb)
 #align algebra.tensor_product.mul_assoc Algebra.TensorProduct.mul_assoc

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -56,7 +56,7 @@ In the `DiscreteValuation` locale:
 
 ## TODO
 
-If ever someone extends `Valuation`, we should fully comply to the `FunLike` by migrating the
+If ever someone extends `Valuation`, we should fully comply to the `DFunLike` by migrating the
 boilerplate lemmas to `ValuationClass`.
 -/
 
@@ -128,10 +128,10 @@ instance : ValuationClass (Valuation R Γ₀) R Γ₀ where
   map_add_le_max f := f.map_add_le_max'
 
 -- porting note: is this still helpful? Let's find out!!
-/- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`
+/- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 -- instance : CoeFun (Valuation R Γ₀) fun _ => R → Γ₀ :=
-  -- FunLike.hasCoeToFun
+  -- DFunLike.hasCoeToFun
 
 theorem toFun_eq_coe (v : Valuation R Γ₀) : v.toFun = v := rfl
 #align valuation.to_fun_eq_coe Valuation.toFun_eq_coe
@@ -142,7 +142,7 @@ theorem toMonoidWithZeroHom_coe_eq_coe (v : Valuation R Γ₀) :
 
 @[ext]
 theorem ext {v₁ v₂ : Valuation R Γ₀} (h : ∀ r, v₁ r = v₂ r) : v₁ = v₂ :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align valuation.ext Valuation.ext
 
 variable (v : Valuation R Γ₀) {x y z : R}
@@ -213,10 +213,10 @@ theorem map_pow : ∀ (x) (n : ℕ), v (x ^ n) = v x ^ n :=
   v.toMonoidWithZeroHom.toMonoidHom.map_pow
 #align valuation.map_pow Valuation.map_pow
 
-/-- Deprecated. Use `FunLike.ext_iff`. -/
--- @[deprecated] Porting note: using `FunLike.ext_iff` is not viable below for now
+/-- Deprecated. Use `DFunLike.ext_iff`. -/
+-- @[deprecated] Porting note: using `DFunLike.ext_iff` is not viable below for now
 theorem ext_iff {v₁ v₂ : Valuation R Γ₀} : v₁ = v₂ ↔ ∀ r, v₁ r = v₂ r :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align valuation.ext_iff Valuation.ext_iff
 
 -- The following definition is not an instance, because we have more than one `v` on a given `R`.
@@ -614,7 +614,7 @@ section Monoid
 
 /-- A valuation is coerced to the underlying function `R → Γ₀`. -/
 instance (R) (Γ₀) [Ring R] [LinearOrderedAddCommMonoidWithTop Γ₀] :
-    FunLike (AddValuation R Γ₀) R fun _ => Γ₀ where
+    DFunLike (AddValuation R Γ₀) R fun _ => Γ₀ where
   coe v := v.toMonoidWithZeroHom.toFun
   coe_injective' f g := by cases f; cases g; simp (config := {contextual := true})
 

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -926,7 +926,7 @@ theorem lift_mk_le_lift_mk_mul_of_lift_mk_preimage_le {α : Type u} {β : Type v
                   rw [Equiv.image_eq_preimage]
                   /- Porting note: Need to insert the following `have` b/c bad fun coercion
                    behaviour for Equivs -/
-                  have : FunLike.coe (Equiv.symm (Equiv.ulift (α := α))) = ULift.up (α := α) := rfl
+                  have : DFunLike.coe (Equiv.symm (Equiv.ulift (α := α))) = ULift.up (α := α) := rfl
                   rw [this]
                   simp only [preimage, mem_singleton_iff, ULift.up_inj, mem_setOf_eq, coe_setOf]
                   exact Equiv.refl _)

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -1080,7 +1080,7 @@ variable (α β')
 
 theorem mk_equiv_le_embedding : #(α ≃ β') ≤ #(α ↪ β') := ⟨⟨_, Equiv.toEmbedding_injective⟩⟩
 
-theorem mk_embedding_le_arrow : #(α ↪ β') ≤ #(α → β') := ⟨⟨_, FunLike.coe_injective⟩⟩
+theorem mk_embedding_le_arrow : #(α ↪ β') ≤ #(α → β') := ⟨⟨_, DFunLike.coe_injective⟩⟩
 
 variable [Infinite α] {α β'}
 

--- a/Mathlib/Tactic/CategoryTheory/Elementwise.lean
+++ b/Mathlib/Tactic/CategoryTheory/Elementwise.lean
@@ -47,7 +47,7 @@ theorem forall_congr_forget_Type (α : Type u) (p : α → Prop) :
 
 attribute [local instance] ConcreteCategory.funLike ConcreteCategory.hasCoeToSort
 
-theorem forget_hom_Type (α β : Type u) (f : α ⟶ β) : FunLike.coe f = f := rfl
+theorem forget_hom_Type (α β : Type u) (f : α ⟶ β) : DFunLike.coe f = f := rfl
 
 theorem hom_elementwise [Category C] [ConcreteCategory C]
     {X Y : C} {f g : X ⟶ Y} (h : f = g) (x : X) : f x = g x := by rw [h]

--- a/Mathlib/Tactic/CategoryTheory/Elementwise.lean
+++ b/Mathlib/Tactic/CategoryTheory/Elementwise.lean
@@ -45,7 +45,7 @@ section theorems
 theorem forall_congr_forget_Type (α : Type u) (p : α → Prop) :
     (∀ (x : (forget (Type u)).obj α), p x) ↔ ∀ (x : α), p x := Iff.rfl
 
-attribute [local instance] ConcreteCategory.funLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
 
 theorem forget_hom_Type (α β : Type u) (f : α ⟶ β) : DFunLike.coe f = f := rfl
 

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -221,7 +221,7 @@ def twoHeadsArgs (e : Expr) : Name × Name × Sum Name Name × List Bool := Id.r
     | some 1 => .inl `one
     | some _ => .inl `many
     | none => match pol.getAppFnArgs with
-      | (``FunLike.coe, #[_, _, _, _, polFun, _]) =>
+      | (``DFunLike.coe, #[_, _, _, _, polFun, _]) =>
         let na := polFun.getAppFn.constName
         if na ∈ [``Polynomial.monomial, ``Polynomial.C] then
           .inr na

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -302,10 +302,10 @@ This command specifies custom names and custom projections for the simp attribut
 
 Some common uses:
 * If you define a new homomorphism-like structure (like `MulHom`) you can just run
-  `initialize_simps_projections` after defining the `FunLike` instance (or instance that implies
-  a `FunLike` instance).
+  `initialize_simps_projections` after defining the `DFunLike` instance (or instance that implies
+  a `DFunLike` instance).
   ```
-    instance {mM : Mul M} {mN : Mul N} : FunLike (MulHom M N) M N := ...
+    instance {mM : Mul M} {mN : Mul N} : DFunLike (MulHom M N) M N := ...
     initialize_simps_projections MulHom (toFun → apply)
   ```
   This will generate `foo_apply` lemmas for each declaration `foo`.
@@ -322,7 +322,7 @@ Some common uses:
   In the first case, you can get both lemmas using `@[simps, simps (config := .asFn) coe]` and in
   the second case you can get both lemmas using `@[simps (config := .asFn), simps apply]`.
 * If you declare a new homomorphism-like structure (like `RelEmbedding`),
-  then `initialize_simps_projections` will automatically find any `FunLike` coercions
+  then `initialize_simps_projections` will automatically find any `DFunLike` coercions
   that will be used as the default projection for the `toFun` field.
   ```
     initialize_simps_projections relEmbedding (toFun → apply)
@@ -680,7 +680,7 @@ def findAutomaticProjectionsAux (str : Name) (proj : ParsedProjectionData) (args
 
 /-- Auxiliary function for `getRawProjections`.
 Find custom projections, automatically found by simps.
-These come from `FunLike` and `SetLike` instances. -/
+These come from `DFunLike` and `SetLike` instances. -/
 def findAutomaticProjections (str : Name) (projs : Array ParsedProjectionData) :
     CoreM (Array ParsedProjectionData) := do
   let strDecl ← getConstInfo str

--- a/Mathlib/Tactic/Simps/NotationClass.lean
+++ b/Mathlib/Tactic/Simps/NotationClass.lean
@@ -26,7 +26,7 @@ in the file where we declare `@[simps]`. For further documentation, see `Tactic.
     We also add it to non-heterogenous notation classes, like `Neg`, but it doesn't do much for any
     class that extends `Neg`.
   * `@[notation_class * <projName> Simps.findCoercionArgs]` is used to configure the
-    `SetLike` and `FunLike` coercions.
+    `SetLike` and `DFunLike` coercions.
   * The first name argument is the projection name we use as the key to search for this class
     (default: name of first projection of the class).
   * The second argument is the name of a declaration that has type
@@ -78,7 +78,7 @@ def findZeroArgs : findArgType := λ _ _ args =>
 def findOneArgs : findArgType := λ _ _ args =>
   return #[some <| args[0]?.getD default, some <| mkRawNatLit 1]
 
-/-- Find arguments of a coercion class (`FunLike` or `SetLike`) -/
+/-- Find arguments of a coercion class (`DFunLike` or `SetLike`) -/
 def findCoercionArgs : findArgType := λ str className args => do
   let some classExpr := (← getEnv).find? className | throwError "no such class {className}"
   let arity := classExpr.type.forallArity
@@ -92,7 +92,7 @@ structure AutomaticProjectionData where
   /-- `className` is the name of the class we are looking for. -/
   className : Name
   /-- `isNotation` is a boolean that specifies whether this is notation
-    (false for the coercions `FunLike` and `SetLike`). If this is set to true, we add the current
+    (false for the coercions `DFunLike` and `SetLike`). If this is set to true, we add the current
     class as hypothesis during type-class synthesis. -/
   isNotation := true
   /-- The method to find the arguments of the class. -/

--- a/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
+++ b/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
@@ -61,32 +61,32 @@ theorem to_affineMap_injective {f g : P →A[R] Q} (h : (f : P →ᵃ[R] Q) = (g
 
 instance : ContinuousMapClass (P →A[R] Q) P Q where
   coe f := f.toAffineMap
-  coe_injective' _ _ h := to_affineMap_injective <| FunLike.coe_injective h
+  coe_injective' _ _ h := to_affineMap_injective <| DFunLike.coe_injective h
   map_continuous := cont
 
 /-- Helper instance for when there's too many metavariables to apply
-`FunLike.hasCoeToFun` directly. -/
+`DFunLike.hasCoeToFun` directly. -/
 instance : CoeFun (P →A[R] Q) fun _ ↦ P → Q :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 theorem toFun_eq_coe (f : P →A[R] Q) : f.toFun = ⇑f := rfl
 #align continuous_affine_map.to_fun_eq_coe ContinuousAffineMap.toFun_eq_coe
 
 theorem coe_injective : @Function.Injective (P →A[R] Q) (P → Q) (⇑) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align continuous_affine_map.coe_injective ContinuousAffineMap.coe_injective
 
 @[ext]
 theorem ext {f g : P →A[R] Q} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align continuous_affine_map.ext ContinuousAffineMap.ext
 
 theorem ext_iff {f g : P →A[R] Q} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align continuous_affine_map.ext_iff ContinuousAffineMap.ext_iff
 
 theorem congr_fun {f g : P →A[R] Q} (h : f = g) (x : P) : f x = g x :=
-  FunLike.congr_fun h _
+  DFunLike.congr_fun h _
 #align continuous_affine_map.congr_fun ContinuousAffineMap.congr_fun
 
 /-- Forgetting its algebraic properties, a continuous affine map is a continuous map. -/

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -109,16 +109,16 @@ instance ContinuousMonoidHom.ContinuousMonoidHomClass :
   map_one f := f.map_one'
   map_continuous f := f.continuous_toFun
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 @[to_additive
-      "Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`."]
+      "Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`."]
 instance : CoeFun (ContinuousMonoidHom A B) fun _ => A → B :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 @[to_additive (attr := ext)]
 theorem ext {f g : ContinuousMonoidHom A B} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align continuous_monoid_hom.ext ContinuousMonoidHom.ext
 #align continuous_add_monoid_hom.ext ContinuousAddMonoidHom.ext
 
@@ -131,7 +131,7 @@ def toContinuousMap (f : ContinuousMonoidHom A B) : C(A, B) :=
 
 @[to_additive]
 theorem toContinuousMap_injective : Injective (toContinuousMap : _ → C(A, B)) := fun f g h =>
-  ext <| by convert FunLike.ext_iff.1 h
+  ext <| by convert DFunLike.ext_iff.1 h
 #align continuous_monoid_hom.to_continuous_map_injective ContinuousMonoidHom.toContinuousMap_injective
 #align continuous_add_monoid_hom.to_continuous_map_injective ContinuousAddMonoidHom.toContinuousMap_injective
 

--- a/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
@@ -68,7 +68,7 @@ theorem range_toContinuousMultilinearMap :
 
 instance continuousMapClass : ContinuousMapClass (M [Λ^ι]→L[R] N) (ι → M) N where
   coe f := f.toFun
-  coe_injective' _ _ h := toContinuousMultilinearMap_injective <| FunLike.ext' h
+  coe_injective' _ _ h := toContinuousMultilinearMap_injective <| DFunLike.ext' h
   map_continuous f := f.cont
 
 initialize_simps_projections ContinuousAlternatingMap (toFun → apply)
@@ -90,20 +90,20 @@ theorem coe_toAlternatingMap : ⇑f.toAlternatingMap = f := rfl
 
 @[ext]
 theorem ext {f g : M [Λ^ι]→L[R] N} (H : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ H
+  DFunLike.ext _ _ H
 
 theorem ext_iff {f g : M [Λ^ι]→L[R] N} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 
 theorem toAlternatingMap_injective :
     Injective (toAlternatingMap : (M [Λ^ι]→L[R] N) → (M [Λ^ι]→ₗ[R] N)) := fun f g h =>
-  FunLike.ext' <| by convert FunLike.ext'_iff.1 h
+  DFunLike.ext' <| by convert DFunLike.ext'_iff.1 h
 
 @[simp]
 theorem range_toAlternatingMap :
     Set.range (toAlternatingMap : M [Λ^ι]→L[R] N → (M [Λ^ι]→ₗ[R] N)) =
       {f : M [Λ^ι]→ₗ[R] N | Continuous f} :=
-  Set.ext fun f => ⟨fun ⟨g, hg⟩ => hg ▸ g.cont, fun h => ⟨{ f with cont := h }, FunLike.ext' rfl⟩⟩
+  Set.ext fun f => ⟨fun ⟨g, hg⟩ => hg ▸ g.cont, fun h => ⟨{ f with cont := h }, DFunLike.ext' rfl⟩⟩
 
 @[simp]
 theorem map_add [DecidableEq ι] (m : ι → M) (i : ι) (x y : M) :

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -710,7 +710,8 @@ theorem one_apply (x : M₁) : (1 : M₁ →L[R₁] M₁) x = x :=
 #align continuous_linear_map.one_apply ContinuousLinearMap.one_apply
 
 instance [Nontrivial M₁] : Nontrivial (M₁ →L[R₁] M₁) :=
-  ⟨0, 1, fun e ↦ have ⟨x, hx⟩ := exists_ne (0 : M₁); hx (by simpa using DFunLike.congr_fun e.symm x)⟩
+  ⟨0, 1, fun e ↦
+    have ⟨x, hx⟩ := exists_ne (0 : M₁); hx (by simpa using DFunLike.congr_fun e.symm x)⟩
 
 section Add
 

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -346,7 +346,7 @@ instance (priority := 100) continuousSemilinearMapClass
     [s : ContinuousSemilinearEquivClass F σ M M₂] : ContinuousSemilinearMapClass F σ M M₂ :=
   { s with
     coe := ((↑) : F → M → M₂)
-    coe_injective' := @FunLike.coe_injective F _ _ _ }
+    coe_injective' := @DFunLike.coe_injective F _ _ _ }
 #align continuous_semilinear_equiv_class.continuous_semilinear_map_class ContinuousSemilinearEquivClass.continuousSemilinearMapClass
 
 end ContinuousSemilinearEquivClass
@@ -419,7 +419,7 @@ theorem coe_injective : Function.Injective ((↑) : (M₁ →SL[σ₁₂] M₂) 
 instance continuousSemilinearMapClass :
     ContinuousSemilinearMapClass (M₁ →SL[σ₁₂] M₂) σ₁₂ M₁ M₂ where
   coe f := f.toLinearMap
-  coe_injective' _ _ h := coe_injective (FunLike.coe_injective h)
+  coe_injective' _ _ h := coe_injective (DFunLike.coe_injective h)
   map_add f := map_add f.toLinearMap
   map_continuous f := f.2
   map_smulₛₗ f := f.toLinearMap.map_smul'
@@ -427,7 +427,7 @@ instance continuousSemilinearMapClass :
 
 -- see Note [function coercion]
 /-- Coerce continuous linear maps to functions. -/
---instance toFun' : CoeFun (M₁ →SL[σ₁₂] M₂) fun _ => M₁ → M₂ := ⟨FunLike.coe⟩
+--instance toFun' : CoeFun (M₁ →SL[σ₁₂] M₂) fun _ => M₁ → M₂ := ⟨DFunLike.coe⟩
 
 -- porting note: was `simp`, now `simp only` proves it
 theorem coe_mk (f : M₁ →ₛₗ[σ₁₂] M₂) (h) : (mk f h : M₁ →ₛₗ[σ₁₂] M₂) = f :=
@@ -456,7 +456,7 @@ theorem coe_inj {f g : M₁ →SL[σ₁₂] M₂} : (f : M₁ →ₛₗ[σ₁₂
 #align continuous_linear_map.coe_inj ContinuousLinearMap.coe_inj
 
 theorem coeFn_injective : @Function.Injective (M₁ →SL[σ₁₂] M₂) (M₁ → M₂) (↑) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align continuous_linear_map.coe_fn_injective ContinuousLinearMap.coeFn_injective
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
@@ -474,11 +474,11 @@ initialize_simps_projections ContinuousLinearMap (toLinearMap_toFun → apply, t
 
 @[ext]
 theorem ext {f g : M₁ →SL[σ₁₂] M₂} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align continuous_linear_map.ext ContinuousLinearMap.ext
 
 theorem ext_iff {f g : M₁ →SL[σ₁₂] M₂} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align continuous_linear_map.ext_iff ContinuousLinearMap.ext_iff
 
 /-- Copy of a `ContinuousLinearMap` with a new `toFun` equal to the old one. Useful to fix
@@ -494,7 +494,7 @@ theorem coe_copy (f : M₁ →SL[σ₁₂] M₂) (f' : M₁ → M₂) (h : f' = 
 #align continuous_linear_map.coe_copy ContinuousLinearMap.coe_copy
 
 theorem copy_eq (f : M₁ →SL[σ₁₂] M₂) (f' : M₁ → M₂) (h : f' = ⇑f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align continuous_linear_map.copy_eq ContinuousLinearMap.copy_eq
 
 -- make some straightforward lemmas available to `simp`.
@@ -710,7 +710,7 @@ theorem one_apply (x : M₁) : (1 : M₁ →L[R₁] M₁) x = x :=
 #align continuous_linear_map.one_apply ContinuousLinearMap.one_apply
 
 instance [Nontrivial M₁] : Nontrivial (M₁ →L[R₁] M₁) :=
-  ⟨0, 1, fun e ↦ have ⟨x, hx⟩ := exists_ne (0 : M₁); hx (by simpa using FunLike.congr_fun e.symm x)⟩
+  ⟨0, 1, fun e ↦ have ⟨x, hx⟩ := exists_ne (0 : M₁); hx (by simpa using DFunLike.congr_fun e.symm x)⟩
 
 section Add
 

--- a/Mathlib/Topology/Algebra/Module/CharacterSpace.lean
+++ b/Mathlib/Topology/Algebra/Module/CharacterSpace.lean
@@ -57,12 +57,12 @@ variable [CommSemiring 𝕜] [TopologicalSpace 𝕜] [ContinuousAdd 𝕜] [Conti
 /-- Elements of the character space are continuous linear maps. -/
 instance instContinuousLinearMapClass : ContinuousLinearMapClass (characterSpace 𝕜 A) 𝕜 A 𝕜 where
   coe φ := ((φ : WeakDual 𝕜 A) : A → 𝕜)
-  coe_injective' φ ψ h := by ext1; apply FunLike.ext; exact congr_fun h
+  coe_injective' φ ψ h := by ext1; apply DFunLike.ext; exact congr_fun h
   map_smulₛₗ φ := (φ : WeakDual 𝕜 A).map_smul
   map_add φ := (φ : WeakDual 𝕜 A).map_add
   map_continuous φ := (φ : WeakDual 𝕜 A).cont
 
--- porting note: moved because Lean 4 doesn't see the `FunLike` instance on `characterSpace 𝕜 A`
+-- porting note: moved because Lean 4 doesn't see the `DFunLike` instance on `characterSpace 𝕜 A`
 -- until the `ContinuousLinearMapClass` instance is declared
 @[simp, norm_cast]
 protected theorem coe_coe (φ : characterSpace 𝕜 A) : ⇑(φ : WeakDual 𝕜 A) = (φ : A → 𝕜) :=
@@ -71,7 +71,7 @@ protected theorem coe_coe (φ : characterSpace 𝕜 A) : ⇑(φ : WeakDual 𝕜 
 
 @[ext]
 theorem ext {φ ψ : characterSpace 𝕜 A} (h : ∀ x, φ x = ψ x) : φ = ψ :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align weak_dual.character_space.ext WeakDual.CharacterSpace.ext
 
 /-- An element of the character space, as a continuous linear map. -/

--- a/Mathlib/Topology/Algebra/Module/Multilinear/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Multilinear/Basic.lean
@@ -107,7 +107,7 @@ theorem coe_coe : (f.toMultilinearMap : (∀ i, M₁ i) → M₂) = f :=
 
 @[ext]
 theorem ext {f f' : ContinuousMultilinearMap R M₁ M₂} (H : ∀ x, f x = f' x) : f = f' :=
-  FunLike.ext _ _ H
+  DFunLike.ext _ _ H
 #align continuous_multilinear_map.ext ContinuousMultilinearMap.ext
 
 theorem ext_iff {f f' : ContinuousMultilinearMap R M₁ M₂} : f = f' ↔ ∀ x, f x = f' x := by

--- a/Mathlib/Topology/Algebra/Module/StrongTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/StrongTopology.lean
@@ -75,7 +75,7 @@ topological vector space. -/
 def strongTopology [TopologicalSpace F] [TopologicalAddGroup F] (𝔖 : Set (Set E)) :
     TopologicalSpace (E →SL[σ] F) :=
   (@UniformOnFun.topologicalSpace E F (TopologicalAddGroup.toUniformSpace F) 𝔖).induced
-    (FunLike.coe : (E →SL[σ] F) → (E →ᵤ[𝔖] F))
+    (DFunLike.coe : (E →SL[σ] F) → (E →ᵤ[𝔖] F))
 #align continuous_linear_map.strong_topology ContinuousLinearMap.strongTopology
 
 /-- The uniform structure associated with `ContinuousLinearMap.strongTopology`. We make sure
@@ -83,7 +83,7 @@ that this has nice definitional properties. -/
 def strongUniformity [UniformSpace F] [UniformAddGroup F] (𝔖 : Set (Set E)) :
     UniformSpace (E →SL[σ] F) :=
   @UniformSpace.replaceTopology _ (strongTopology σ F 𝔖)
-    ((UniformOnFun.uniformSpace E F 𝔖).comap (FunLike.coe : (E →SL[σ] F) → (E →ᵤ[𝔖] F)))
+    ((UniformOnFun.uniformSpace E F 𝔖).comap (DFunLike.coe : (E →SL[σ] F) → (E →ᵤ[𝔖] F)))
     (by rw [strongTopology, UniformAddGroup.toUniformSpace_eq]; rfl)
 #align continuous_linear_map.strong_uniformity ContinuousLinearMap.strongUniformity
 
@@ -96,14 +96,14 @@ theorem strongUniformity_topology_eq [UniformSpace F] [UniformAddGroup F] (𝔖 
 theorem strongUniformity.uniformEmbedding_coeFn [UniformSpace F] [UniformAddGroup F]
     (𝔖 : Set (Set E)) :
     @UniformEmbedding (E →SL[σ] F) (E →ᵤ[𝔖] F) (strongUniformity σ F 𝔖)
-      (UniformOnFun.uniformSpace E F 𝔖) FunLike.coe :=
+      (UniformOnFun.uniformSpace E F 𝔖) DFunLike.coe :=
   letI : UniformSpace (E →SL[σ] F) := strongUniformity σ F 𝔖
-  ⟨⟨rfl⟩, FunLike.coe_injective⟩
+  ⟨⟨rfl⟩, DFunLike.coe_injective⟩
 #align continuous_linear_map.strong_uniformity.uniform_embedding_coe_fn ContinuousLinearMap.strongUniformity.uniformEmbedding_coeFn
 
 theorem strongTopology.embedding_coeFn [UniformSpace F] [UniformAddGroup F] (𝔖 : Set (Set E)) :
     @Embedding (E →SL[σ] F) (E →ᵤ[𝔖] F) (strongTopology σ F 𝔖)
-    (UniformOnFun.topologicalSpace E F 𝔖) (UniformOnFun.ofFun 𝔖 ∘ FunLike.coe) :=
+    (UniformOnFun.topologicalSpace E F 𝔖) (UniformOnFun.ofFun 𝔖 ∘ DFunLike.coe) :=
   @UniformEmbedding.embedding _ _ (_root_.id _) _ _ (strongUniformity.uniformEmbedding_coeFn _ _ _)
 #align continuous_linear_map.strong_topology.embedding_coe_fn ContinuousLinearMap.strongTopology.embedding_coeFn
 
@@ -111,7 +111,7 @@ theorem strongUniformity.uniformAddGroup [UniformSpace F] [UniformAddGroup F] (�
     @UniformAddGroup (E →SL[σ] F) (strongUniformity σ F 𝔖) _ := by
   letI : UniformSpace (E →SL[σ] F) := strongUniformity σ F 𝔖
   let φ : (E →SL[σ] F) →+ E →ᵤ[𝔖] F :=
-    ⟨⟨(FunLike.coe : (E →SL[σ] F) → E →ᵤ[𝔖] F), rfl⟩, fun _ _ => rfl⟩
+    ⟨⟨(DFunLike.coe : (E →SL[σ] F) → E →ᵤ[𝔖] F), rfl⟩, fun _ _ => rfl⟩
   exact (strongUniformity.uniformEmbedding_coeFn _ _ _).uniformAddGroup φ
 #align continuous_linear_map.strong_uniformity.uniform_add_group ContinuousLinearMap.strongUniformity.uniformAddGroup
 
@@ -142,7 +142,7 @@ theorem strongTopology.continuousSMul [RingHomSurjective σ] [RingHomIsometric �
   haveI : UniformAddGroup F := comm_topologicalAddGroup_is_uniform
   letI : TopologicalSpace (E →SL[σ] F) := strongTopology σ F 𝔖
   let φ : (E →SL[σ] F) →ₗ[𝕜₂] E →ᵤ[𝔖] F :=
-    ⟨⟨(FunLike.coe : (E →SL[σ] F) → E → F), fun _ _ => rfl⟩, fun _ _ => rfl⟩
+    ⟨⟨(DFunLike.coe : (E →SL[σ] F) → E → F), fun _ _ => rfl⟩, fun _ _ => rfl⟩
   exact
     UniformOnFun.continuousSMul_induced_of_image_bounded 𝕜₂ E F (E →SL[σ] F) h𝔖₁ h𝔖₂ φ ⟨rfl⟩
       fun u s hs => (h𝔖₃ s hs).image u
@@ -160,7 +160,7 @@ theorem strongTopology.hasBasis_nhds_zero_of_basis [TopologicalSpace F] [Topolog
   -- `letI`) so that Lean doesn't try to use the product topology
   letI : TopologicalSpace (E →SL[σ] F) := strongTopology σ F 𝔖
   rw [(strongTopology.embedding_coeFn σ F 𝔖).toInducing.nhds_eq_comap]
-  exact (UniformOnFun.hasBasis_nhds_zero_of_basis 𝔖 h𝔖₁ h𝔖₂ h).comap FunLike.coe
+  exact (UniformOnFun.hasBasis_nhds_zero_of_basis 𝔖 h𝔖₁ h𝔖₂ h).comap DFunLike.coe
 #align continuous_linear_map.strong_topology.has_basis_nhds_zero_of_basis ContinuousLinearMap.strongTopology.hasBasis_nhds_zero_of_basis
 
 theorem strongTopology.hasBasis_nhds_zero [TopologicalSpace F] [TopologicalAddGroup F]
@@ -271,7 +271,7 @@ def precomp [TopologicalAddGroup G] [ContinuousConstSMul 𝕜₃ G] [RingHomSurj
     haveI : UniformAddGroup G := comm_topologicalAddGroup_is_uniform
     rw [(strongTopology.embedding_coeFn _ _ _).continuous_iff]
     -- Porting note: without this, the following doesn't work
-    change Continuous ((λ f ↦ UniformOnFun.ofFun _ (f ∘ L)) ∘ FunLike.coe)
+    change Continuous ((λ f ↦ UniformOnFun.ofFun _ (f ∘ L)) ∘ DFunLike.coe)
     exact (UniformOnFun.precomp_uniformContinuous fun S hS => hS.image L).continuous.comp
         (strongTopology.embedding_coeFn _ _ _).continuous
 #align continuous_linear_map.precomp ContinuousLinearMap.precomp

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -237,10 +237,10 @@ instance instContinuousLinearMapClass : ContinuousLinearMapClass (WeakDual 𝕜 
   ContinuousLinearMap.continuousSemilinearMapClass
 #align weak_dual.weak_dual.continuous_linear_map_class WeakDual.instContinuousLinearMapClass
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 instance : CoeFun (WeakDual 𝕜 E) fun _ => E → 𝕜 :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 /-- If a monoid `M` distributively continuously acts on `𝕜` and this action commutes with
 multiplication on `𝕜`, then it acts on `WeakDual 𝕜 E`. -/

--- a/Mathlib/Topology/Algebra/StarSubalgebra.lean
+++ b/Mathlib/Topology/Algebra/StarSubalgebra.lean
@@ -151,7 +151,7 @@ theorem _root_.StarAlgHom.ext_topologicalClosure [T2Space B] {S : StarSubalgebra
     (h :
       φ.comp (inclusion (le_topologicalClosure S)) = ψ.comp (inclusion (le_topologicalClosure S))) :
     φ = ψ := by
-  rw [FunLike.ext'_iff]
+  rw [DFunLike.ext'_iff]
   have : Dense (Set.range <| inclusion (le_topologicalClosure S)) := by
     refine' embedding_subtype_val.toInducing.dense_iff.2 fun x => _
     convert show ↑x ∈ closure (S : Set A) from x.prop
@@ -163,7 +163,7 @@ theorem _root_.StarAlgHom.ext_topologicalClosure [T2Space B] {S : StarSubalgebra
           exact y.prop, fun hy => ⟨⟨y, hy⟩, rfl⟩⟩
   refine' Continuous.ext_on this hφ hψ _
   rintro _ ⟨x, rfl⟩
-  simpa only using FunLike.congr_fun h x
+  simpa only using DFunLike.congr_fun h x
 #align star_alg_hom.ext_topological_closure StarAlgHom.ext_topologicalClosure
 
 theorem _root_.StarAlgHomClass.ext_topologicalClosure [T2Space B] {F : Type*}
@@ -175,7 +175,7 @@ theorem _root_.StarAlgHomClass.ext_topologicalClosure [T2Space B] {F : Type*}
   have : (φ : S.topologicalClosure →⋆ₐ[R] B) = (ψ : S.topologicalClosure →⋆ₐ[R] B) := by
     refine StarAlgHom.ext_topologicalClosure (R := R) (A := A) (B := B) hφ hψ (StarAlgHom.ext ?_)
     simpa only [StarAlgHom.coe_comp, StarAlgHom.coe_coe] using h
-  rw [FunLike.ext'_iff, ← StarAlgHom.coe_coe]
+  rw [DFunLike.ext'_iff, ← StarAlgHom.coe_coe]
   apply congrArg _ this
 #align star_alg_hom_class.ext_topological_closure StarAlgHomClass.ext_topologicalClosure
 

--- a/Mathlib/Topology/Bornology/Hom.lean
+++ b/Mathlib/Topology/Bornology/Hom.lean
@@ -12,7 +12,7 @@ import Mathlib.Topology.Bornology.Basic
 
 This file defines locally bounded maps between bornologies.
 
-We use the `FunLike` design, so each type of morphisms has a companion typeclass which is meant to
+We use the `DFunLike` design, so each type of morphisms has a companion typeclass which is meant to
 be satisfied by itself and all stricter types.
 
 ## Types of morphisms
@@ -44,7 +44,7 @@ section
 
 You should extend this class when you extend `LocallyBoundedMap`. -/
 class LocallyBoundedMapClass (F : Type*) (α β : outParam <| Type*) [Bornology α]
-    [Bornology β] extends FunLike F α fun _ => β where
+    [Bornology β] extends DFunLike F α fun _ => β where
   /-- The pullback of the `Bornology.cobounded` filter under the function is contained in the
   cobounded filter. Equivalently, the function maps bounded sets to bounded sets. -/
   comap_cobounded_le (f : F) : (cobounded β).comap f ≤ cobounded α
@@ -85,7 +85,7 @@ instance : LocallyBoundedMapClass (LocallyBoundedMap α β) α β where
   comap_cobounded_le f := f.comap_cobounded_le'
 
 /- omitting helper instance because it is not needed in Lean 4.
-/-- Helper instance for when there's too many metavariables to apply the coercion via `FunLike`
+/-- Helper instance for when there's too many metavariables to apply the coercion via `DFunLike`
 directly.
 instance : CoeFun (LocallyBoundedMap α β) fun _ => α → β where
   coe := LocallyBoundedMap.toFun -/ -/
@@ -95,7 +95,7 @@ instance : CoeFun (LocallyBoundedMap α β) fun _ => α → β where
 
 @[ext]
 theorem ext {f g : LocallyBoundedMap α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align locally_bounded_map.ext LocallyBoundedMap.ext
 
 /-- Copy of a `LocallyBoundedMap` with a new `toFun` equal to the old one. Useful to fix
@@ -110,7 +110,7 @@ theorem coe_copy (f : LocallyBoundedMap α β) (f' : α → β) (h : f' = f) : �
 #align locally_bounded_map.coe_copy LocallyBoundedMap.coe_copy
 
 theorem copy_eq (f : LocallyBoundedMap α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align locally_bounded_map.copy_eq LocallyBoundedMap.copy_eq
 
 /-- Construct a `LocallyBoundedMap` from the fact that the function maps bounded sets to bounded
@@ -191,7 +191,7 @@ theorem id_comp (f : LocallyBoundedMap α β) : (LocallyBoundedMap.id β).comp f
 @[simp]
 theorem cancel_right {g₁ g₂ : LocallyBoundedMap β γ} {f : LocallyBoundedMap α β}
     (hf : Surjective f) : g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, congrArg (fun x => comp x f)⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, congrArg (fun x => comp x f)⟩
 -- porting note: unification was not strong enough to do `congrArg _`.
 #align locally_bounded_map.cancel_right LocallyBoundedMap.cancel_right
 

--- a/Mathlib/Topology/Category/Born.lean
+++ b/Mathlib/Topology/Category/Born.lean
@@ -45,7 +45,7 @@ instance : Inhabited Born :=
 instance : BundledHom @LocallyBoundedMap where
   id := @LocallyBoundedMap.id
   comp := @LocallyBoundedMap.comp
-  hom_ext _ _ := FunLike.coe_injective
+  hom_ext _ _ := DFunLike.coe_injective
 
 instance : LargeCategory.{u} Born :=
   BundledHom.category LocallyBoundedMap

--- a/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
@@ -54,8 +54,9 @@ def struct {B X : CompHaus.{u}} (π : X ⟶ B) (hπ : Function.Surjective π) :
     (by ext; exact hab)) a)
   uniq e h g hm := by
     suffices g = (QuotientMap.of_surjective_continuous hπ π.continuous).liftEquiv ⟨e,
-      fun a b hab ↦ DFunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
-      (by ext; exact hab)) a⟩ by assumption
+      fun a b hab ↦ DFunLike.congr_fun
+        (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩ (by ext; exact hab))
+        a⟩ by assumption
     rw [← Equiv.symm_apply_eq (QuotientMap.of_surjective_continuous hπ π.continuous).liftEquiv]
     ext
     simp only [QuotientMap.liftEquiv_symm_apply_coe, ContinuousMap.comp_apply, ← hm]

--- a/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/CompHaus/EffectiveEpi.lean
@@ -47,14 +47,14 @@ noncomputable
 def struct {B X : CompHaus.{u}} (π : X ⟶ B) (hπ : Function.Surjective π) :
     EffectiveEpiStruct π where
   desc e h := (QuotientMap.of_surjective_continuous hπ π.continuous).lift e fun a b hab ↦
-    FunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
+    DFunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
     (by ext; exact hab)) a
   fac e h := ((QuotientMap.of_surjective_continuous hπ π.continuous).lift_comp e
-    fun a b hab ↦ FunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
+    fun a b hab ↦ DFunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
     (by ext; exact hab)) a)
   uniq e h g hm := by
     suffices g = (QuotientMap.of_surjective_continuous hπ π.continuous).liftEquiv ⟨e,
-      fun a b hab ↦ FunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
+      fun a b hab ↦ DFunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
       (by ext; exact hab)) a⟩ by assumption
     rw [← Equiv.symm_apply_eq (QuotientMap.of_surjective_continuous hπ π.continuous).liftEquiv]
     ext

--- a/Mathlib/Topology/Category/CompHaus/Projective.lean
+++ b/Mathlib/Topology/Category/CompHaus/Projective.lean
@@ -35,7 +35,7 @@ open CategoryTheory Function
 
 namespace CompHaus
 
-attribute [local instance] ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.instDFunLike
 
 instance projective_ultrafilter (X : Type*) : Projective (of <| Ultrafilter X)
     where

--- a/Mathlib/Topology/Category/Profinite/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/Profinite/EffectiveEpi.lean
@@ -45,14 +45,14 @@ noncomputable
 def struct {B X : Profinite.{u}} (π : X ⟶ B) (hπ : Function.Surjective π) :
     EffectiveEpiStruct π where
   desc e h := (QuotientMap.of_surjective_continuous hπ π.continuous).lift e fun a b hab ↦
-    FunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
+    DFunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
     (by ext; exact hab)) a
   fac e h := ((QuotientMap.of_surjective_continuous hπ π.continuous).lift_comp e
-    fun a b hab ↦ FunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
+    fun a b hab ↦ DFunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
     (by ext; exact hab)) a)
   uniq e h g hm := by
     suffices g = (QuotientMap.of_surjective_continuous hπ π.continuous).liftEquiv ⟨e,
-      fun a b hab ↦ FunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
+      fun a b hab ↦ DFunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
       (by ext; exact hab)) a⟩ by assumption
     rw [← Equiv.symm_apply_eq (QuotientMap.of_surjective_continuous hπ π.continuous).liftEquiv]
     ext

--- a/Mathlib/Topology/Category/Profinite/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/Profinite/EffectiveEpi.lean
@@ -52,8 +52,9 @@ def struct {B X : Profinite.{u}} (π : X ⟶ B) (hπ : Function.Surjective π) :
     (by ext; exact hab)) a)
   uniq e h g hm := by
     suffices g = (QuotientMap.of_surjective_continuous hπ π.continuous).liftEquiv ⟨e,
-      fun a b hab ↦ DFunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
-      (by ext; exact hab)) a⟩ by assumption
+      fun a b hab ↦ DFunLike.congr_fun
+        (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩ (by ext; exact hab))
+        a⟩ by assumption
     rw [← Equiv.symm_apply_eq (QuotientMap.of_surjective_continuous hπ π.continuous).liftEquiv]
     ext
     simp only [QuotientMap.liftEquiv_symm_apply_coe, ContinuousMap.comp_apply, ← hm]

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -802,7 +802,7 @@ theorem Products.lt_nil_empty : { m : Products I | m < Products.nil } = ∅ := b
 instance {α : Type*} [TopologicalSpace α] [Inhabited α] : Nontrivial (LocallyConstant α ℤ) := by
   refine ⟨0, 1, fun h ↦ ?_⟩
   apply @zero_ne_one ℤ
-  exact FunLike.congr_fun h default
+  exact DFunLike.congr_fun h default
 
 theorem Products.isGood_nil : Products.isGood ({fun _ ↦ false} : Set (I → Bool)) Products.nil := by
   intro h

--- a/Mathlib/Topology/Category/Stonean/Basic.lean
+++ b/Mathlib/Topology/Category/Stonean/Basic.lean
@@ -105,7 +105,7 @@ instance : ConcreteCategory Stonean where
   forget := toCompHaus ⋙ forget _
 
 instance : CoeSort Stonean.{u} (Type u) := ConcreteCategory.hasCoeToSort _
-instance {X Y : Stonean.{u}} : FunLike (X ⟶ Y) X (fun _ => Y) := ConcreteCategory.funLike
+instance {X Y : Stonean.{u}} : DFunLike (X ⟶ Y) X (fun _ => Y) := ConcreteCategory.funLike
 
 /-- Stonean spaces are topological spaces. -/
 instance instTopologicalSpace (X : Stonean.{u}) : TopologicalSpace X :=

--- a/Mathlib/Topology/Category/Stonean/Basic.lean
+++ b/Mathlib/Topology/Category/Stonean/Basic.lean
@@ -105,7 +105,7 @@ instance : ConcreteCategory Stonean where
   forget := toCompHaus ⋙ forget _
 
 instance : CoeSort Stonean.{u} (Type u) := ConcreteCategory.hasCoeToSort _
-instance {X Y : Stonean.{u}} : DFunLike (X ⟶ Y) X (fun _ => Y) := ConcreteCategory.funLike
+instance {X Y : Stonean.{u}} : DFunLike (X ⟶ Y) X (fun _ => Y) := ConcreteCategory.instDFunLike
 
 /-- Stonean spaces are topological spaces. -/
 instance instTopologicalSpace (X : Stonean.{u}) : TopologicalSpace X :=

--- a/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
@@ -44,14 +44,14 @@ The theorem `Stonean.effectiveEpi_tfae` should be used instead.
 noncomputable
 def struct {B X : Stonean.{u}} (π : X ⟶ B) (hπ : Function.Surjective π) : EffectiveEpiStruct π where
   desc e h := (QuotientMap.of_surjective_continuous hπ π.continuous).lift e fun a b hab ↦
-    FunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
+    DFunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
     (by ext; exact hab)) a
   fac e h := ((QuotientMap.of_surjective_continuous hπ π.continuous).lift_comp e
-    fun a b hab ↦ FunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
+    fun a b hab ↦ DFunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
     (by ext; exact hab)) a)
   uniq e h g hm := by
     suffices g = (QuotientMap.of_surjective_continuous hπ π.continuous).liftEquiv ⟨e,
-      fun a b hab ↦ FunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
+      fun a b hab ↦ DFunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
       (by ext; exact hab)) a⟩ by assumption
     rw [← Equiv.symm_apply_eq (QuotientMap.of_surjective_continuous hπ π.continuous).liftEquiv]
     ext

--- a/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
@@ -51,8 +51,9 @@ def struct {B X : Stonean.{u}} (π : X ⟶ B) (hπ : Function.Surjective π) : E
     (by ext; exact hab)) a)
   uniq e h g hm := by
     suffices g = (QuotientMap.of_surjective_continuous hπ π.continuous).liftEquiv ⟨e,
-      fun a b hab ↦ DFunLike.congr_fun (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩
-      (by ext; exact hab)) a⟩ by assumption
+      fun a b hab ↦ DFunLike.congr_fun
+        (h ⟨fun _ ↦ a, continuous_const⟩ ⟨fun _ ↦ b, continuous_const⟩ (by ext; exact hab))
+        a⟩ by assumption
     rw [← Equiv.symm_apply_eq (QuotientMap.of_surjective_continuous hπ π.continuous).liftEquiv]
     ext
     simp only [QuotientMap.liftEquiv_symm_apply_coe, ContinuousMap.comp_apply, ← hm]

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -218,7 +218,7 @@ def pullback.lift {X Y Z W : Stonean} (f : X ⟶ Z) {i : Y ⟶ Z} (hi : OpenEmbe
   toFun := fun z => ⟨a z, by
     simp only [Set.mem_preimage]
     use (b z)
-    exact congr_fun (FunLike.ext'_iff.mp w.symm) z⟩
+    exact congr_fun (DFunLike.ext'_iff.mp w.symm) z⟩
   continuous_toFun := by
     apply Continuous.subtype_mk
     exact a.continuous
@@ -248,7 +248,7 @@ lemma pullback.lift_snd {X Y Z W : Stonean} (f : X ⟶ Z) {i : Y ⟶ Z} (hi : Op
     pullback.lift f hi a b w ≫ Stonean.pullback.snd f hi = b := by
   congr
   ext z
-  have := congr_fun (FunLike.ext'_iff.mp w.symm) z
+  have := congr_fun (DFunLike.ext'_iff.mp w.symm) z
   have h : i (b z) = f (a z) := this
   suffices : b z = (Homeomorph.ofEmbedding i hi.toEmbedding).symm (⟨f (a z), by rw [← h]; simp⟩)
   · exact this.symm

--- a/Mathlib/Topology/Category/TopCat/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Basic.lean
@@ -59,7 +59,7 @@ set_option linter.uppercaseLean3 false in
 #align Top.topological_space_unbundled TopCat.topologicalSpaceUnbundled
 
 -- Porting note: cannot find a coercion to function otherwise
-attribute [instance] ConcreteCategory.funLike in
+attribute [instance] ConcreteCategory.instDFunLike in
 instance (X Y : TopCat.{u}) : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe f := f
 

--- a/Mathlib/Topology/CompactOpen.lean
+++ b/Mathlib/Topology/CompactOpen.lean
@@ -219,13 +219,13 @@ lemma isClopen_setOf_mapsTo (hK : IsCompact K) (hU : IsClopen U) :
   ⟨isOpen_setOf_mapsTo hK hU.isOpen, isClosed_setOf_mapsTo hU.isClosed K⟩
 
 instance [T0Space Y] : T0Space C(X, Y) :=
-  t0Space_of_injective_of_continuous FunLike.coe_injective continuous_coe
+  t0Space_of_injective_of_continuous DFunLike.coe_injective continuous_coe
 
 instance [T1Space Y] : T1Space C(X, Y) :=
-  t1Space_of_injective_of_continuous FunLike.coe_injective continuous_coe
+  t1Space_of_injective_of_continuous DFunLike.coe_injective continuous_coe
 
 instance [T2Space Y] : T2Space C(X, Y) :=
-  .of_injective_continuous FunLike.coe_injective continuous_coe
+  .of_injective_continuous DFunLike.coe_injective continuous_coe
 
 end Ev
 

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -202,7 +202,7 @@ theorem symm_range {a b : X} (γ : Path a b) : range γ.symm = range γ := by
 
 open ContinuousMap
 
-/- porting note: because of the new `DFunLike` instance, we already have a coercion to `C(I, X)`
+/- porting note: because of the `DFunLike` instance, we already have a coercion to `C(I, X)`
 so we avoid adding another.
 --instance : Coe (Path x y) C(I, X) :=
   --⟨fun γ => γ.1⟩

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -78,12 +78,12 @@ structure Path (x y : X) extends C(I, X) where
   target' : toFun 1 = y
 #align path Path
 
--- porting note: added this instance so that we can use `FunLike.coe` for `CoeFun`
+-- porting note: added this instance so that we can use `DFunLike.coe` for `CoeFun`
 -- this also fixed very strange `simp` timeout issues
 instance Path.continuousMapClass : ContinuousMapClass (Path x y) I X where
   coe := fun γ ↦ ⇑γ.toContinuousMap
   coe_injective' := fun γ₁ γ₂ h => by
-    simp only [FunLike.coe_fn_eq] at h
+    simp only [DFunLike.coe_fn_eq] at h
     cases γ₁; cases γ₂; congr
   map_continuous := fun γ => by continuity
 
@@ -190,7 +190,7 @@ theorem refl_symm {a : X} : (Path.refl a).symm = Path.refl a := by
 @[simp]
 theorem symm_range {a b : X} (γ : Path a b) : range γ.symm = range γ := by
   ext x
-  simp only [mem_range, Path.symm, FunLike.coe, unitInterval.symm, SetCoe.exists, comp_apply,
+  simp only [mem_range, Path.symm, DFunLike.coe, unitInterval.symm, SetCoe.exists, comp_apply,
     Subtype.coe_mk]
   constructor <;> rintro ⟨y, hy, hxy⟩ <;> refine' ⟨1 - y, mem_iff_one_sub_mem.mp hy, _⟩ <;>
     convert hxy
@@ -202,7 +202,7 @@ theorem symm_range {a b : X} (γ : Path a b) : range γ.symm = range γ := by
 
 open ContinuousMap
 
-/- porting note: because of the new `FunLike` instance, we already have a coercion to `C(I, X)`
+/- porting note: because of the new `DFunLike` instance, we already have a coercion to `C(I, X)`
 so we avoid adding another.
 --instance : Coe (Path x y) C(I, X) :=
   --⟨fun γ => γ.1⟩
@@ -646,7 +646,7 @@ theorem truncate_range {a b : X} (γ : Path a b) {t₀ t₁ : ℝ} :
   rw [← γ.extend_range]
   simp only [range_subset_iff, SetCoe.exists, SetCoe.forall]
   intro x _hx
-  simp only [FunLike.coe, Path.truncate, mem_range_self]
+  simp only [DFunLike.coe, Path.truncate, mem_range_self]
 #align path.truncate_range Path.truncate_range
 
 /-- For a path `γ`, `γ.truncate` gives a "continuous family of paths", by which we
@@ -671,7 +671,7 @@ theorem truncate_self {a b : X} (γ : Path a b) (t : ℝ) :
     γ.truncate t t = (Path.refl <| γ.extend t).cast (by rw [min_self]) rfl := by
   ext x
   rw [cast_coe]
-  simp only [truncate, FunLike.coe, refl, min_def, max_def]
+  simp only [truncate, DFunLike.coe, refl, min_def, max_def]
   split_ifs with h₁ h₂ <;> congr
 #align path.truncate_self Path.truncate_self
 

--- a/Mathlib/Topology/ContinuousFunction/Algebra.lean
+++ b/Mathlib/Topology/ContinuousFunction/Algebra.lean
@@ -854,7 +854,7 @@ instance ContinuousMap.subsingleton_subalgebra (α : Type*) [TopologicalSpace α
     Subsingleton (Subalgebra R C(α, R)) :=
   ⟨fun s₁ s₂ => by
     cases isEmpty_or_nonempty α
-    · haveI : Subsingleton C(α, R) := FunLike.coe_injective.subsingleton
+    · haveI : Subsingleton C(α, R) := DFunLike.coe_injective.subsingleton
       exact Subsingleton.elim _ _
     · inhabit α
       ext f

--- a/Mathlib/Topology/ContinuousFunction/Basic.lean
+++ b/Mathlib/Topology/ContinuousFunction/Basic.lean
@@ -13,7 +13,7 @@ import Mathlib.Topology.Homeomorph
 
 In this file we define the type `ContinuousMap` of continuous bundled maps.
 
-We use the `FunLike` design, so each type of morphisms has a companion typeclass which is meant to
+We use the `DFunLike` design, so each type of morphisms has a companion typeclass which is meant to
 be satisfied by itself and all stricter types.
 -/
 
@@ -42,7 +42,7 @@ section
 
 You should extend this class when you extend `ContinuousMap`. -/
 class ContinuousMapClass (F : Type*) (α β : outParam <| Type*) [TopologicalSpace α]
-  [TopologicalSpace β] extends FunLike F α fun _ => β where
+  [TopologicalSpace β] extends DFunLike F α fun _ => β where
   /-- Continuity -/
   map_continuous (f : F) : Continuous f
 #align continuous_map_class ContinuousMapClass
@@ -89,14 +89,14 @@ instance toContinuousMapClass : ContinuousMapClass C(α, β) α β where
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
 instance : CoeFun C(α, β) fun _ => α → β :=
-  FunLike.hasCoeToFun-/
+  DFunLike.hasCoeToFun-/
 
 @[simp]
 theorem toFun_eq_coe {f : C(α, β)} : f.toFun = (f : α → β) :=
   rfl
 #align continuous_map.to_fun_eq_coe ContinuousMap.toFun_eq_coe
 
-instance : CanLift (α → β) C(α, β) FunLike.coe Continuous := ⟨fun f hf ↦ ⟨⟨f, hf⟩, rfl⟩⟩
+instance : CanLift (α → β) C(α, β) DFunLike.coe Continuous := ⟨fun f hf ↦ ⟨⟨f, hf⟩, rfl⟩⟩
 
 /-- See note [custom simps projection]. -/
 def Simps.apply (f : C(α, β)) : α → β := f
@@ -111,7 +111,7 @@ protected theorem coe_coe {F : Type*} [ContinuousMapClass F α β] (f : F) : ⇑
 
 @[ext]
 theorem ext {f g : C(α, β)} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align continuous_map.ext ContinuousMap.ext
 
 /-- Copy of a `ContinuousMap` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -127,7 +127,7 @@ theorem coe_copy (f : C(α, β)) (f' : α → β) (h : f' = f) : ⇑(f.copy f' h
 #align continuous_map.coe_copy ContinuousMap.coe_copy
 
 theorem copy_eq (f : C(α, β)) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align continuous_map.copy_eq ContinuousMap.copy_eq
 
 variable {f g : C(α, β)}
@@ -147,12 +147,12 @@ protected theorem continuousAt (f : C(α, β)) (x : α) : ContinuousAt f x :=
   f.continuous.continuousAt
 #align continuous_map.continuous_at ContinuousMap.continuousAt
 
-/-- Deprecated. Use `FunLike.congr_fun` instead. -/
+/-- Deprecated. Use `DFunLike.congr_fun` instead. -/
 protected theorem congr_fun {f g : C(α, β)} (H : f = g) (x : α) : f x = g x :=
   H ▸ rfl
 #align continuous_map.congr_fun ContinuousMap.congr_fun
 
-/-- Deprecated. Use `FunLike.congr_arg` instead. -/
+/-- Deprecated. Use `DFunLike.congr_arg` instead. -/
 protected theorem congr_arg (f : C(α, β)) {x y : α} (h : x = y) : f x = f y :=
   h ▸ rfl
 #align continuous_map.congr_arg ContinuousMap.congr_arg
@@ -273,7 +273,7 @@ theorem comp_const (f : C(β, γ)) (b : β) : f.comp (const α b) = const α (f 
 @[simp]
 theorem cancel_right {f₁ f₂ : C(β, γ)} {g : C(α, β)} (hg : Surjective g) :
     f₁.comp g = f₂.comp g ↔ f₁ = f₂ :=
-  ⟨fun h => ext <| hg.forall.2 <| FunLike.ext_iff.1 h, congr_arg (ContinuousMap.comp · g)⟩
+  ⟨fun h => ext <| hg.forall.2 <| DFunLike.ext_iff.1 h, congr_arg (ContinuousMap.comp · g)⟩
 #align continuous_map.cancel_right ContinuousMap.cancel_right
 
 @[simp]
@@ -284,7 +284,7 @@ theorem cancel_left {f : C(β, γ)} {g₁ g₂ : C(α, β)} (hf : Injective f) :
 
 instance [Nonempty α] [Nontrivial β] : Nontrivial C(α, β) :=
   ⟨let ⟨b₁, b₂, hb⟩ := exists_pair_ne β
-  ⟨const _ b₁, const _ b₂, fun h => hb <| FunLike.congr_fun h <| Classical.arbitrary α⟩⟩
+  ⟨const _ b₁, const _ b₂, fun h => hb <| DFunLike.congr_fun h <| Classical.arbitrary α⟩⟩
 
 section Prod
 
@@ -427,8 +427,8 @@ theorem restrict_apply_mk (f : C(α, β)) (s : Set α) (x : α) (hx : x ∈ s) :
 
 theorem injective_restrict [T2Space β] {s : Set α} (hs : Dense s) :
     Injective (restrict s : C(α, β) → C(s, β)) := fun f g h ↦
-  FunLike.ext' <| f.continuous.ext_on hs g.continuous <| Set.restrict_eq_restrict_iff.1 <|
-    congr_arg FunLike.coe h
+  DFunLike.ext' <| f.continuous.ext_on hs g.continuous <| Set.restrict_eq_restrict_iff.1 <|
+    congr_arg DFunLike.coe h
 
 /-- The restriction of a continuous map to the preimage of a set. -/
 @[simps]

--- a/Mathlib/Topology/ContinuousFunction/Basic.lean
+++ b/Mathlib/Topology/ContinuousFunction/Basic.lean
@@ -86,7 +86,7 @@ instance toContinuousMapClass : ContinuousMapClass C(α, β) α β where
   map_continuous := ContinuousMap.continuous_toFun
 
 /- Porting note: Probably not needed anymore
-/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 instance : CoeFun C(α, β) fun _ => α → β :=
   DFunLike.hasCoeToFun-/

--- a/Mathlib/Topology/ContinuousFunction/Bounded.lean
+++ b/Mathlib/Topology/ContinuousFunction/Bounded.lean
@@ -79,10 +79,10 @@ instance : BoundedContinuousMapClass (α →ᵇ β) α β where
   map_continuous f := f.continuous_toFun
   map_bounded f := f.map_bounded'
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 instance : CoeFun (α →ᵇ β) fun _ => α → β :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 instance [BoundedContinuousMapClass F α β] : CoeTC F (α →ᵇ β) :=
   ⟨fun f =>
@@ -111,7 +111,7 @@ protected theorem continuous (f : α →ᵇ β) : Continuous f :=
 
 @[ext]
 theorem ext (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align bounded_continuous_function.ext BoundedContinuousFunction.ext
 
 theorem isBounded_range (f : α →ᵇ β) : IsBounded (range f) :=
@@ -475,7 +475,7 @@ nonrec theorem extend_apply' {f : α ↪ δ} {x : δ} (hx : x ∉ range f) (g : 
 #align bounded_continuous_function.extend_apply' BoundedContinuousFunction.extend_apply'
 
 theorem extend_of_empty [IsEmpty α] (f : α ↪ δ) (g : α →ᵇ β) (h : δ →ᵇ β) : extend f g h = h :=
-  FunLike.coe_injective <| Function.extend_of_isEmpty f g h
+  DFunLike.coe_injective <| Function.extend_of_isEmpty f g h
 #align bounded_continuous_function.extend_of_empty BoundedContinuousFunction.extend_of_empty
 
 @[simp]
@@ -635,7 +635,7 @@ theorem mkOfCompact_one [CompactSpace α] : mkOfCompact (1 : C(α, β)) = 1 := r
 
 @[to_additive]
 theorem forall_coe_one_iff_one (f : α →ᵇ β) : (∀ x, f x = 1) ↔ f = 1 :=
-  (@FunLike.ext_iff _ _ _ _ f 1).symm
+  (@DFunLike.ext_iff _ _ _ _ f 1).symm
 #align bounded_continuous_function.forall_coe_one_iff_one BoundedContinuousFunction.forall_coe_one_iff_one
 #align bounded_continuous_function.forall_coe_zero_iff_zero BoundedContinuousFunction.forall_coe_zero_iff_zero
 
@@ -716,7 +716,7 @@ theorem nsmul_apply (r : ℕ) (f : α →ᵇ β) (v : α) : (r • f) v = r • 
 #align bounded_continuous_function.nsmul_apply BoundedContinuousFunction.nsmul_apply
 
 instance addMonoid : AddMonoid (α →ᵇ β) :=
-  FunLike.coe_injective.addMonoid _ coe_zero coe_add fun _ _ => coe_nsmul _ _
+  DFunLike.coe_injective.addMonoid _ coe_zero coe_add fun _ _ => coe_nsmul _ _
 
 instance : LipschitzAdd (α →ᵇ β) where
   lipschitz_add :=
@@ -991,7 +991,7 @@ theorem zsmul_apply (r : ℤ) (f : α →ᵇ β) (v : α) : (r • f) v = r • 
 #align bounded_continuous_function.zsmul_apply BoundedContinuousFunction.zsmul_apply
 
 instance : AddCommGroup (α →ᵇ β) :=
-  FunLike.coe_injective.addCommGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => coe_nsmul _ _)
+  DFunLike.coe_injective.addCommGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => coe_nsmul _ _)
     fun _ _ => coe_zsmul _ _
 
 instance seminormedAddCommGroup : SeminormedAddCommGroup (α →ᵇ β) where
@@ -1108,7 +1108,7 @@ section MulAction
 variable [MonoidWithZero 𝕜] [Zero β] [MulAction 𝕜 β] [BoundedSMul 𝕜 β]
 
 instance : MulAction 𝕜 (α →ᵇ β) :=
-  FunLike.coe_injective.mulAction _ coe_smul
+  DFunLike.coe_injective.mulAction _ coe_smul
 
 end MulAction
 
@@ -1119,7 +1119,7 @@ variable [MonoidWithZero 𝕜] [AddMonoid β] [DistribMulAction 𝕜 β] [Bounde
 variable [LipschitzAdd β]
 
 instance : DistribMulAction 𝕜 (α →ᵇ β) :=
-  Function.Injective.distribMulAction ⟨⟨_, coe_zero⟩, coe_add⟩ FunLike.coe_injective coe_smul
+  Function.Injective.distribMulAction ⟨⟨_, coe_zero⟩, coe_add⟩ DFunLike.coe_injective coe_smul
 
 end DistribMulAction
 
@@ -1132,7 +1132,7 @@ variable {f g : α →ᵇ β} {x : α} {C : ℝ}
 variable [LipschitzAdd β]
 
 instance module : Module 𝕜 (α →ᵇ β) :=
-  Function.Injective.module _ ⟨⟨_, coe_zero⟩, coe_add⟩ FunLike.coe_injective coe_smul
+  Function.Injective.module _ ⟨⟨_, coe_zero⟩, coe_add⟩ DFunLike.coe_injective coe_smul
 
 variable (𝕜)
 
@@ -1244,7 +1244,7 @@ theorem mul_apply (f g : α →ᵇ R) (x : α) : (f * g) x = f x * g x := rfl
 #align bounded_continuous_function.mul_apply BoundedContinuousFunction.mul_apply
 
 instance : NonUnitalRing (α →ᵇ R) :=
-  FunLike.coe_injective.nonUnitalRing _ coe_zero coe_add coe_mul coe_neg coe_sub
+  DFunLike.coe_injective.nonUnitalRing _ coe_zero coe_add coe_mul coe_neg coe_sub
     (fun _ _ => coe_nsmul _ _) fun _ _ => coe_zsmul _ _
 
 instance nonUnitalSeminormedRing : NonUnitalSeminormedRing (α →ᵇ R) :=
@@ -1301,7 +1301,7 @@ theorem coe_intCast (n : ℤ) : ((n : α →ᵇ R) : α → R) = n := rfl
 #align bounded_continuous_function.coe_int_cast BoundedContinuousFunction.coe_intCast
 
 instance ring : Ring (α →ᵇ R) :=
-  FunLike.coe_injective.ring _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub
+  DFunLike.coe_injective.ring _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub
     (fun _ _ => coe_nsmul _ _) (fun _ _ => coe_zsmul _ _) (fun _ _ => coe_pow _ _) coe_natCast
     coe_intCast
 

--- a/Mathlib/Topology/ContinuousFunction/CocompactMap.lean
+++ b/Mathlib/Topology/ContinuousFunction/CocompactMap.lean
@@ -84,7 +84,7 @@ instance : CocompactMapClass (CocompactMap α β) α β where
   cocompact_tendsto f := f.cocompact_tendsto'
 
 /- Porting note: not needed anymore
-/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 instance : CoeFun (CocompactMap α β) fun _ => α → β :=
   DFunLike.hasCoeToFun-/

--- a/Mathlib/Topology/ContinuousFunction/CocompactMap.lean
+++ b/Mathlib/Topology/ContinuousFunction/CocompactMap.lean
@@ -87,7 +87,7 @@ instance : CocompactMapClass (CocompactMap α β) α β where
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
 instance : CoeFun (CocompactMap α β) fun _ => α → β :=
-  FunLike.hasCoeToFun-/
+  DFunLike.hasCoeToFun-/
 
 @[simp]
 theorem coe_toContinuousMap {f : CocompactMap α β} : (f.toContinuousMap : α → β) = f :=
@@ -96,7 +96,7 @@ theorem coe_toContinuousMap {f : CocompactMap α β} : (f.toContinuousMap : α �
 
 @[ext]
 theorem ext {f g : CocompactMap α β} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align cocompact_map.ext CocompactMap.ext
 
 /-- Copy of a `CocompactMap` with a new `toFun` equal to the old one. Useful
@@ -117,7 +117,7 @@ theorem coe_copy (f : CocompactMap α β) (f' : α → β) (h : f' = f) : ⇑(f.
 #align cocompact_map.coe_copy CocompactMap.coe_copy
 
 theorem copy_eq (f : CocompactMap α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align cocompact_map.copy_eq CocompactMap.copy_eq
 
 @[simp]

--- a/Mathlib/Topology/ContinuousFunction/Ideals.lean
+++ b/Mathlib/Topology/ContinuousFunction/Ideals.lean
@@ -149,7 +149,7 @@ theorem setOfTop_eq_univ [Nontrivial R] : setOfIdeal (⊤ : Ideal C(X, R)) = Set
 theorem idealOfEmpty_eq_bot : idealOfSet R (∅ : Set X) = ⊥ :=
   Ideal.ext fun f => by
     simp only [mem_idealOfSet, Set.compl_empty, Set.mem_univ, forall_true_left, Ideal.mem_bot,
-      FunLike.ext_iff, zero_apply]
+      DFunLike.ext_iff, zero_apply]
 #align continuous_map.ideal_of_empty_eq_bot ContinuousMap.idealOfEmpty_eq_bot
 
 @[simp]
@@ -438,7 +438,7 @@ theorem continuousMapEval_bijective : Bijective (continuousMapEval X 𝕜) := by
     rcases exists_continuous_zero_one_of_isClosed (isClosed_singleton : _root_.IsClosed {x})
         (isClosed_singleton : _root_.IsClosed {y}) (Set.disjoint_singleton.mpr hxy) with
       ⟨f, fx, fy, -⟩
-    rw [FunLike.ne_iff]
+    rw [DFunLike.ne_iff]
     use (⟨fun (x : ℝ) => (x : 𝕜), IsROrC.continuous_ofReal⟩ : C(ℝ, 𝕜)).comp f
     simpa only [continuousMapEval_apply_apply, ContinuousMap.comp_apply, coe_mk, Ne.def,
       IsROrC.ofReal_inj] using

--- a/Mathlib/Topology/ContinuousFunction/Ordered.lean
+++ b/Mathlib/Topology/ContinuousFunction/Ordered.lean
@@ -53,7 +53,7 @@ instance sup : Sup C(α, β) where sup f g := { toFun := fun a ↦ f a ⊔ g a }
 #align continuous_map.sup_apply ContinuousMap.sup_apply
 
 instance semilatticeSup : SemilatticeSup C(α, β) :=
-  FunLike.coe_injective.semilatticeSup _ fun _ _ ↦ rfl
+  DFunLike.coe_injective.semilatticeSup _ fun _ _ ↦ rfl
 
 lemma sup'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C(α, β)) (a : α) :
     s.sup' H f a = s.sup' H fun i ↦ f i a :=
@@ -80,7 +80,7 @@ instance inf : Inf C(α, β) where inf f g := { toFun := fun a ↦ f a ⊓ g a }
 #align continuous_map.inf_apply ContinuousMap.inf_apply
 
 instance semilatticeInf : SemilatticeInf C(α, β) :=
-  FunLike.coe_injective.semilatticeInf _ fun _ _ ↦ rfl
+  DFunLike.coe_injective.semilatticeInf _ fun _ _ ↦ rfl
 
 lemma inf'_apply {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C(α, β)) (a : α) :
     s.inf' H f a = s.inf' H fun i ↦ f i a :=
@@ -95,7 +95,7 @@ lemma coe_inf' {ι : Type*} {s : Finset ι} (H : s.Nonempty) (f : ι → C(α, �
 end SemilatticeInf
 
 instance [Lattice β] [TopologicalLattice β] : Lattice C(α, β) :=
-  FunLike.coe_injective.lattice _ (fun _ _ ↦ rfl) fun _ _ ↦ rfl
+  DFunLike.coe_injective.lattice _ (fun _ _ ↦ rfl) fun _ _ ↦ rfl
 
 -- TODO transfer this lattice structure to `BoundedContinuousFunction`
 

--- a/Mathlib/Topology/ContinuousFunction/Polynomial.lean
+++ b/Mathlib/Topology/ContinuousFunction/Polynomial.lean
@@ -170,7 +170,7 @@ theorem polynomialFunctions.comap_compRightAlgHom_iccHomeoI (a b : ℝ) (h : a <
   ext f
   fconstructor
   · rintro ⟨p, ⟨-, w⟩⟩
-    rw [FunLike.ext_iff] at w
+    rw [DFunLike.ext_iff] at w
     dsimp at w
     let q := p.comp ((b - a)⁻¹ • Polynomial.X + Polynomial.C (-a * (b - a)⁻¹))
     refine' ⟨q, ⟨_, _⟩⟩

--- a/Mathlib/Topology/ContinuousFunction/Sigma.lean
+++ b/Mathlib/Topology/ContinuousFunction/Sigma.lean
@@ -50,7 +50,7 @@ theorem embedding_sigmaMk_comp [Nonempty X] :
   inj := by
     · rintro ⟨i, g⟩ ⟨i', g'⟩ h
       obtain ⟨rfl, hg⟩ : i = i' ∧ HEq (⇑g) (⇑g') :=
-        Function.eq_of_sigmaMk_comp <| congr_arg FunLike.coe h
+        Function.eq_of_sigmaMk_comp <| congr_arg DFunLike.coe h
       simpa using hg
 
 section ConnectedSpace
@@ -64,7 +64,7 @@ with unbundled functions and `ContinuousMap.sigmaCodHomeomorph` for a homeomorph
 this fact. -/
 theorem exists_lift_sigma (f : C(X, Σ i, Y i)) : ∃ i g, f = (sigmaMk i).comp g :=
   let ⟨i, g, hg, hfg⟩ := f.continuous.exists_lift_sigma
-  ⟨i, ⟨g, hg⟩, FunLike.ext' hfg⟩
+  ⟨i, ⟨g, hg⟩, DFunLike.ext' hfg⟩
 
 variable (X Y)
 

--- a/Mathlib/Topology/ContinuousFunction/ZeroAtInfty.lean
+++ b/Mathlib/Topology/ContinuousFunction/ZeroAtInfty.lean
@@ -84,10 +84,10 @@ instance instZeroAtInftyContinuousMapClass : ZeroAtInftyContinuousMapClass C₀(
   map_continuous f := f.continuous_toFun
   zero_at_infty f := f.zero_at_infty'
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 instance instCoeFun : CoeFun C₀(α, β) fun _ => α → β :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 instance instCoeTC : CoeTC F C₀(α, β) :=
   ⟨fun f =>
@@ -102,7 +102,7 @@ theorem coe_toContinuousMap (f : C₀(α, β)) : (f.toContinuousMap : α → β)
 
 @[ext]
 theorem ext {f g : C₀(α, β)} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align zero_at_infty_continuous_map.ext ZeroAtInftyContinuousMap.ext
 
 /-- Copy of a `ZeroAtInftyContinuousMap` with a new `toFun` equal to the old one. Useful
@@ -123,7 +123,7 @@ theorem coe_copy (f : C₀(α, β)) (f' : α → β) (h : f' = f) : ⇑(f.copy f
 #align zero_at_infty_continuous_map.coe_copy ZeroAtInftyContinuousMap.coe_copy
 
 theorem copy_eq (f : C₀(α, β)) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align zero_at_infty_continuous_map.copy_eq ZeroAtInftyContinuousMap.copy_eq
 
 theorem eq_of_empty [IsEmpty α] (f g : C₀(α, β)) : f = g :=
@@ -152,7 +152,7 @@ infinity. This is not an instance to avoid type class loops. -/
 def zeroAtInftyContinuousMapClass.ofCompact {G : Type*} [ContinuousMapClass G α β]
     [CompactSpace α] : ZeroAtInftyContinuousMapClass G α β where
   coe g := g
-  coe_injective' f g h := FunLike.coe_fn_eq.mp h
+  coe_injective' f g h := DFunLike.coe_fn_eq.mp h
   map_continuous := map_continuous
   zero_at_infty := by simp
 #align zero_at_infty_continuous_map.zero_at_infty_continuous_map_class.of_compact ZeroAtInftyContinuousMap.zeroAtInftyContinuousMapClass.ofCompact
@@ -200,11 +200,11 @@ theorem mul_apply [MulZeroClass β] [ContinuousMul β] (f g : C₀(α, β)) : (f
 #align zero_at_infty_continuous_map.mul_apply ZeroAtInftyContinuousMap.mul_apply
 
 instance instMulZeroClass [MulZeroClass β] [ContinuousMul β] : MulZeroClass C₀(α, β) :=
-  FunLike.coe_injective.mulZeroClass _ coe_zero coe_mul
+  DFunLike.coe_injective.mulZeroClass _ coe_zero coe_mul
 
 instance instSemigroupWithZero [SemigroupWithZero β] [ContinuousMul β] :
     SemigroupWithZero C₀(α, β) :=
-  FunLike.coe_injective.semigroupWithZero _ coe_zero coe_mul
+  DFunLike.coe_injective.semigroupWithZero _ coe_zero coe_mul
 
 instance instAdd [AddZeroClass β] [ContinuousAdd β] : Add C₀(α, β) :=
   ⟨fun f g => ⟨f + g, by simpa only [add_zero] using (zero_at_infty f).add (zero_at_infty g)⟩⟩
@@ -219,7 +219,7 @@ theorem add_apply [AddZeroClass β] [ContinuousAdd β] (f g : C₀(α, β)) : (f
 #align zero_at_infty_continuous_map.add_apply ZeroAtInftyContinuousMap.add_apply
 
 instance instAddZeroClass [AddZeroClass β] [ContinuousAdd β] : AddZeroClass C₀(α, β) :=
-  FunLike.coe_injective.addZeroClass _ coe_zero coe_add
+  DFunLike.coe_injective.addZeroClass _ coe_zero coe_add
 
 section AddMonoid
 
@@ -237,12 +237,12 @@ instance instNatSMul : SMul ℕ C₀(α, β) :=
 #align zero_at_infty_continuous_map.has_nat_scalar ZeroAtInftyContinuousMap.instNatSMul
 
 instance instAddMonoid : AddMonoid C₀(α, β) :=
-  FunLike.coe_injective.addMonoid _ coe_zero coe_add fun _ _ => rfl
+  DFunLike.coe_injective.addMonoid _ coe_zero coe_add fun _ _ => rfl
 
 end AddMonoid
 
 instance instAddCommMonoid [AddCommMonoid β] [ContinuousAdd β] : AddCommMonoid C₀(α, β) :=
-  FunLike.coe_injective.addCommMonoid _ coe_zero coe_add fun _ _ => rfl
+  DFunLike.coe_injective.addCommMonoid _ coe_zero coe_add fun _ _ => rfl
 
 section AddGroup
 
@@ -285,12 +285,12 @@ instance instIntSMul : SMul ℤ C₀(α, β) :=
 #align zero_at_infty_continuous_map.has_int_scalar ZeroAtInftyContinuousMap.instIntSMul
 
 instance instAddGroup : AddGroup C₀(α, β) :=
-  FunLike.coe_injective.addGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl) fun _ _ => rfl
+  DFunLike.coe_injective.addGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl) fun _ _ => rfl
 
 end AddGroup
 
 instance instAddCommGroup [AddCommGroup β] [TopologicalAddGroup β] : AddCommGroup C₀(α, β) :=
-  FunLike.coe_injective.addCommGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl) fun _ _ =>
+  DFunLike.coe_injective.addCommGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl) fun _ _ =>
     rfl
 
 instance instSMul [Zero β] {R : Type*} [Zero R] [SMulWithZero R β] [ContinuousConstSMul R β] :
@@ -316,40 +316,40 @@ instance instIsCentralScalar [Zero β] {R : Type*} [Zero R] [SMulWithZero R β] 
 
 instance instSMulWithZero [Zero β] {R : Type*} [Zero R] [SMulWithZero R β]
     [ContinuousConstSMul R β] : SMulWithZero R C₀(α, β) :=
-  Function.Injective.smulWithZero ⟨_, coe_zero⟩ FunLike.coe_injective coe_smul
+  Function.Injective.smulWithZero ⟨_, coe_zero⟩ DFunLike.coe_injective coe_smul
 
 instance instMulActionWithZero [Zero β] {R : Type*} [MonoidWithZero R] [MulActionWithZero R β]
     [ContinuousConstSMul R β] : MulActionWithZero R C₀(α, β) :=
-  Function.Injective.mulActionWithZero ⟨_, coe_zero⟩ FunLike.coe_injective coe_smul
+  Function.Injective.mulActionWithZero ⟨_, coe_zero⟩ DFunLike.coe_injective coe_smul
 
 instance instModule [AddCommMonoid β] [ContinuousAdd β] {R : Type*} [Semiring R] [Module R β]
     [ContinuousConstSMul R β] : Module R C₀(α, β) :=
-  Function.Injective.module R ⟨⟨_, coe_zero⟩, coe_add⟩ FunLike.coe_injective coe_smul
+  Function.Injective.module R ⟨⟨_, coe_zero⟩, coe_add⟩ DFunLike.coe_injective coe_smul
 
 instance instNonUnitalNonAssocSemiring [NonUnitalNonAssocSemiring β] [TopologicalSemiring β] :
     NonUnitalNonAssocSemiring C₀(α, β) :=
-  FunLike.coe_injective.nonUnitalNonAssocSemiring _ coe_zero coe_add coe_mul fun _ _ => rfl
+  DFunLike.coe_injective.nonUnitalNonAssocSemiring _ coe_zero coe_add coe_mul fun _ _ => rfl
 
 instance instNonUnitalSemiring [NonUnitalSemiring β] [TopologicalSemiring β] :
     NonUnitalSemiring C₀(α, β) :=
-  FunLike.coe_injective.nonUnitalSemiring _ coe_zero coe_add coe_mul fun _ _ => rfl
+  DFunLike.coe_injective.nonUnitalSemiring _ coe_zero coe_add coe_mul fun _ _ => rfl
 
 instance instNonUnitalCommSemiring [NonUnitalCommSemiring β] [TopologicalSemiring β] :
     NonUnitalCommSemiring C₀(α, β) :=
-  FunLike.coe_injective.nonUnitalCommSemiring _ coe_zero coe_add coe_mul fun _ _ => rfl
+  DFunLike.coe_injective.nonUnitalCommSemiring _ coe_zero coe_add coe_mul fun _ _ => rfl
 
 instance instNonUnitalNonAssocRing [NonUnitalNonAssocRing β] [TopologicalRing β] :
     NonUnitalNonAssocRing C₀(α, β) :=
-  FunLike.coe_injective.nonUnitalNonAssocRing _ coe_zero coe_add coe_mul coe_neg coe_sub
+  DFunLike.coe_injective.nonUnitalNonAssocRing _ coe_zero coe_add coe_mul coe_neg coe_sub
     (fun _ _ => rfl) fun _ _ => rfl
 
 instance instNonUnitalRing [NonUnitalRing β] [TopologicalRing β] : NonUnitalRing C₀(α, β) :=
-  FunLike.coe_injective.nonUnitalRing _ coe_zero coe_add coe_mul coe_neg coe_sub (fun _ _ => rfl)
+  DFunLike.coe_injective.nonUnitalRing _ coe_zero coe_add coe_mul coe_neg coe_sub (fun _ _ => rfl)
     fun _ _ => rfl
 
 instance instNonUnitalCommRing [NonUnitalCommRing β] [TopologicalRing β] :
     NonUnitalCommRing C₀(α, β) :=
-  FunLike.coe_injective.nonUnitalCommRing _ coe_zero coe_add coe_mul coe_neg coe_sub
+  DFunLike.coe_injective.nonUnitalCommRing _ coe_zero coe_add coe_mul coe_neg coe_sub
     (fun _ _ => rfl) fun _ _ => rfl
 
 instance instIsScalarTower {R : Type*} [Semiring R] [NonUnitalNonAssocSemiring β]
@@ -433,7 +433,7 @@ variable (α) (β)
 
 theorem toBCF_injective : Function.Injective (toBCF : C₀(α, β) → α →ᵇ β) := fun f g h => by
   ext x
-  simpa only using FunLike.congr_fun h x
+  simpa only using DFunLike.congr_fun h x
 #align zero_at_infty_continuous_map.to_bcf_injective ZeroAtInftyContinuousMap.toBCF_injective
 
 end

--- a/Mathlib/Topology/Hom/Open.lean
+++ b/Mathlib/Topology/Hom/Open.lean
@@ -12,7 +12,7 @@ import Mathlib.Topology.ContinuousFunction.Basic
 
 This file defines bundled continuous open maps.
 
-We use the `FunLike` design, so each type of morphisms has a companion typeclass which is meant to
+We use the `DFunLike` design, so each type of morphisms has a companion typeclass which is meant to
 be satisfied by itself and all stricter types.
 
 ## Types of morphisms
@@ -80,7 +80,7 @@ theorem coe_toContinuousMap (f : α →CO β) : (f.toContinuousMap : α → β) 
 
 @[ext]
 theorem ext {f g : α →CO β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align continuous_open_map.ext ContinuousOpenMap.ext
 
 /-- Copy of a `ContinuousOpenMap` with a new `ContinuousMap` equal to the old one. Useful to fix
@@ -95,7 +95,7 @@ theorem coe_copy (f : α →CO β) (f' : α → β) (h : f' = f) : ⇑(f.copy f'
 #align continuous_open_map.coe_copy ContinuousOpenMap.coe_copy
 
 theorem copy_eq (f : α →CO β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align continuous_open_map.copy_eq ContinuousOpenMap.copy_eq
 
 variable (α)
@@ -154,7 +154,7 @@ theorem id_comp (f : α →CO β) : (ContinuousOpenMap.id β).comp f = f :=
 @[simp]
 theorem cancel_right {g₁ g₂ : β →CO γ} {f : α →CO β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
 #align continuous_open_map.cancel_right ContinuousOpenMap.cancel_right
 
 @[simp]

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -61,9 +61,9 @@ instance : EquivLike (X ≃ₜ Y) X Y where
   inv := fun h => h.toEquiv.symm
   left_inv := fun h => h.left_inv
   right_inv := fun h => h.right_inv
-  coe_injective' := fun _ _ H _ => toEquiv_injective <| FunLike.ext' H
+  coe_injective' := fun _ _ H _ => toEquiv_injective <| DFunLike.ext' H
 
-instance : CoeFun (X ≃ₜ Y) fun _ ↦ X → Y := ⟨FunLike.coe⟩
+instance : CoeFun (X ≃ₜ Y) fun _ ↦ X → Y := ⟨DFunLike.coe⟩
 
 @[simp] theorem homeomorph_mk_coe (a : X ≃ Y) (b c) : (Homeomorph.mk a b c : X → Y) = a :=
   rfl
@@ -106,7 +106,7 @@ theorem coe_symm_toEquiv (h : X ≃ₜ Y) : ⇑h.toEquiv.symm = h.symm :=
 
 @[ext]
 theorem ext {h h' : X ≃ₜ Y} (H : ∀ x, h x = h' x) : h = h' :=
-  FunLike.ext _ _ H
+  DFunLike.ext _ _ H
 #align homeomorph.ext Homeomorph.ext
 
 /-- Identity map as a homeomorphism. -/

--- a/Mathlib/Topology/Homotopy/Basic.lean
+++ b/Mathlib/Topology/Homotopy/Basic.lean
@@ -115,14 +115,14 @@ instance : HomotopyLike (Homotopy f₀ f₁) f₀ f₁ where
   map_one_left f := f.map_one_left
 
 /- porting note: probably not needed anymore
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 instance : CoeFun (Homotopy f₀ f₁) fun _ => I × X → Y :=
-  FunLike.hasCoeToFun -/
+  DFunLike.hasCoeToFun -/
 
 @[ext]
 theorem ext {F G : Homotopy f₀ f₁} (h : ∀ x, F x = G x) : F = G :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align continuous_map.homotopy.ext ContinuousMap.Homotopy.ext
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
@@ -431,11 +431,11 @@ instance : HomotopyLike (HomotopyWith f₀ f₁ P) f₀ f₁ where
   map_one_left F := F.map_one_left
 
 theorem coeFn_injective : @Function.Injective (HomotopyWith f₀ f₁ P) (I × X → Y) (⇑) :=
-  FunLike.coe_injective'
+  DFunLike.coe_injective'
 #align continuous_map.homotopy_with.coe_fn_injective ContinuousMap.HomotopyWith.coeFn_injective
 
 @[ext]
-theorem ext {F G : HomotopyWith f₀ f₁ P} (h : ∀ x, F x = G x) : F = G := FunLike.ext F G h
+theorem ext {F G : HomotopyWith f₀ f₁ P} (h : ∀ x, F x = G x) : F = G := DFunLike.ext F G h
 #align continuous_map.homotopy_with.ext ContinuousMap.HomotopyWith.ext
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,

--- a/Mathlib/Topology/Homotopy/HomotopyGroup.lean
+++ b/Mathlib/Topology/Homotopy/HomotopyGroup.lean
@@ -112,14 +112,14 @@ variable {N X x}
 
 namespace GenLoop
 
-instance funLike : FunLike (Ω^ N X x) (I^N) fun _ => X where
+instance funLike : DFunLike (Ω^ N X x) (I^N) fun _ => X where
   coe f := f.1
   coe_injective' := fun ⟨⟨f, _⟩, _⟩ ⟨⟨g, _⟩, _⟩ _ => by congr
 #align gen_loop.fun_like GenLoop.funLike
 
 @[ext]
 theorem ext (f g : Ω^ N X x) (H : ∀ y, f y = g y) : f = g :=
-  FunLike.coe_injective' (funext H)
+  DFunLike.coe_injective' (funext H)
 #align gen_loop.ext GenLoop.ext
 
 @[simp]

--- a/Mathlib/Topology/Homotopy/HomotopyGroup.lean
+++ b/Mathlib/Topology/Homotopy/HomotopyGroup.lean
@@ -112,10 +112,10 @@ variable {N X x}
 
 namespace GenLoop
 
-instance funLike : DFunLike (Ω^ N X x) (I^N) fun _ => X where
+instance instDFunLike : DFunLike (Ω^ N X x) (I^N) fun _ => X where
   coe f := f.1
   coe_injective' := fun ⟨⟨f, _⟩, _⟩ ⟨⟨g, _⟩, _⟩ _ => by congr
-#align gen_loop.fun_like GenLoop.funLike
+#align gen_loop.fun_like GenLoop.instDFunLike
 
 @[ext]
 theorem ext (f g : Ω^ N X x) (H : ∀ y, f y = g y) : f = g :=
@@ -133,7 +133,7 @@ def copy (f : Ω^ N X x) (g : (I^N) → X) (h : g = f) : Ω^ N X x :=
   ⟨⟨g, h.symm ▸ f.1.2⟩, by convert f.2⟩
 #align gen_loop.copy GenLoop.copy
 
-/- porting note: this now requires the `funLike` instance,
+/- porting note: this now requires the `instDFunLike` instance,
   so the instance is now put before `copy`. -/
 theorem coe_copy (f : Ω^ N X x) {g : (I^N) → X} (h : g = f) : ⇑(copy f g h) = g :=
   rfl

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -57,7 +57,7 @@ section
 variable {p₀ p₁ : Path x₀ x₁}
 
 theorem coeFn_injective : @Function.Injective (Homotopy p₀ p₁) (I × I → X) (⇑) :=
-  FunLike.coe_injective
+  DFunLike.coe_injective
 #align path.homotopy.coe_fn_injective Path.Homotopy.coeFn_injective
 
 @[simp]

--- a/Mathlib/Topology/Instances/NNReal.lean
+++ b/Mathlib/Topology/Instances/NNReal.lean
@@ -99,7 +99,7 @@ def _root_.ContinuousMap.coeNNRealReal : C(ℝ≥0, ℝ) :=
 
 instance ContinuousMap.canLift {X : Type*} [TopologicalSpace X] :
     CanLift C(X, ℝ) C(X, ℝ≥0) ContinuousMap.coeNNRealReal.comp fun f => ∀ x, 0 ≤ f x where
-  prf f hf := ⟨⟨fun x => ⟨f x, hf x⟩, f.2.subtype_mk _⟩, FunLike.ext' rfl⟩
+  prf f hf := ⟨⟨fun x => ⟨f x, hf x⟩, f.2.subtype_mk _⟩, DFunLike.ext' rfl⟩
 #align nnreal.continuous_map.can_lift NNReal.ContinuousMap.canLift
 
 @[simp, norm_cast]

--- a/Mathlib/Topology/LocallyConstant/Algebra.lean
+++ b/Mathlib/Topology/LocallyConstant/Algebra.lean
@@ -71,12 +71,12 @@ theorem mul_apply [Mul Y] (f g : LocallyConstant X Y) (x : X) : (f * g) x = f x 
 
 @[to_additive]
 instance [MulOneClass Y] : MulOneClass (LocallyConstant X Y) :=
-  Function.Injective.mulOneClass FunLike.coe FunLike.coe_injective' rfl fun _ _ => rfl
+  Function.Injective.mulOneClass DFunLike.coe DFunLike.coe_injective' rfl fun _ _ => rfl
 
-/-- `FunLike.coe` as a `MonoidHom`. -/
-@[to_additive (attr := simps) "`FunLike.coe` as an `AddMonoidHom`."]
+/-- `DFunLike.coe` as a `MonoidHom`. -/
+@[to_additive (attr := simps) "`DFunLike.coe` as an `AddMonoidHom`."]
 def coeFnMonoidHom [MulOneClass Y] : LocallyConstant X Y →* X → Y where
-  toFun := FunLike.coe
+  toFun := DFunLike.coe
   map_one' := rfl
   map_mul' _ _ := rfl
 #align locally_constant.coe_fn_monoid_hom LocallyConstant.coeFnMonoidHom
@@ -92,10 +92,10 @@ def constMonoidHom [MulOneClass Y] : Y →* LocallyConstant X Y where
 #align locally_constant.const_add_monoid_hom LocallyConstant.constAddMonoidHom
 
 instance [MulZeroClass Y] : MulZeroClass (LocallyConstant X Y) :=
-  Function.Injective.mulZeroClass FunLike.coe FunLike.coe_injective' rfl fun _ _ => rfl
+  Function.Injective.mulZeroClass DFunLike.coe DFunLike.coe_injective' rfl fun _ _ => rfl
 
 instance [MulZeroOneClass Y] : MulZeroOneClass (LocallyConstant X Y) :=
-  Function.Injective.mulZeroOneClass FunLike.coe FunLike.coe_injective' rfl rfl fun _ _ => rfl
+  Function.Injective.mulZeroOneClass DFunLike.coe DFunLike.coe_injective' rfl rfl fun _ _ => rfl
 
 section CharFn
 
@@ -144,14 +144,14 @@ theorem div_apply [Div Y] (f g : LocallyConstant X Y) (x : X) : (f / g) x = f x 
 
 @[to_additive]
 instance [Semigroup Y] : Semigroup (LocallyConstant X Y) :=
-  Function.Injective.semigroup FunLike.coe FunLike.coe_injective' fun _ _ => rfl
+  Function.Injective.semigroup DFunLike.coe DFunLike.coe_injective' fun _ _ => rfl
 
 instance [SemigroupWithZero Y] : SemigroupWithZero (LocallyConstant X Y) :=
-  Function.Injective.semigroupWithZero FunLike.coe FunLike.coe_injective' rfl fun _ _ => rfl
+  Function.Injective.semigroupWithZero DFunLike.coe DFunLike.coe_injective' rfl fun _ _ => rfl
 
 @[to_additive]
 instance [CommSemigroup Y] : CommSemigroup (LocallyConstant X Y) :=
-  Function.Injective.commSemigroup FunLike.coe FunLike.coe_injective' fun _ _ => rfl
+  Function.Injective.commSemigroup DFunLike.coe DFunLike.coe_injective' fun _ _ => rfl
 
 @[to_additive]
 instance smul [SMul α Y] : SMul α (LocallyConstant X Y) where
@@ -173,7 +173,7 @@ instance [Pow Y α] : Pow (LocallyConstant X Y) α where
 
 @[to_additive]
 instance [Monoid Y] : Monoid (LocallyConstant X Y) :=
-  Function.Injective.monoid FunLike.coe FunLike.coe_injective' rfl (fun _ _ => rfl) fun _ _ => rfl
+  Function.Injective.monoid DFunLike.coe DFunLike.coe_injective' rfl (fun _ _ => rfl) fun _ _ => rfl
 
 instance [NatCast Y] : NatCast (LocallyConstant X Y) where
   natCast n := const X n
@@ -182,37 +182,37 @@ instance [IntCast Y] : IntCast (LocallyConstant X Y) where
   intCast n := const X n
 
 instance [AddMonoidWithOne Y] : AddMonoidWithOne (LocallyConstant X Y) :=
-  Function.Injective.addMonoidWithOne FunLike.coe FunLike.coe_injective' rfl rfl (fun _ _ => rfl)
+  Function.Injective.addMonoidWithOne DFunLike.coe DFunLike.coe_injective' rfl rfl (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ => rfl
 
 @[to_additive]
 instance [CommMonoid Y] : CommMonoid (LocallyConstant X Y) :=
-  Function.Injective.commMonoid FunLike.coe FunLike.coe_injective' rfl (fun _ _ => rfl)
+  Function.Injective.commMonoid DFunLike.coe DFunLike.coe_injective' rfl (fun _ _ => rfl)
     fun _ _ => rfl
 
 @[to_additive]
 instance [Group Y] : Group (LocallyConstant X Y) :=
-  Function.Injective.group FunLike.coe FunLike.coe_injective' rfl (fun _ _ => rfl)
+  Function.Injective.group DFunLike.coe DFunLike.coe_injective' rfl (fun _ _ => rfl)
     (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
 
 @[to_additive]
 instance [CommGroup Y] : CommGroup (LocallyConstant X Y) :=
-  Function.Injective.commGroup FunLike.coe FunLike.coe_injective' rfl (fun _ _ => rfl)
+  Function.Injective.commGroup DFunLike.coe DFunLike.coe_injective' rfl (fun _ _ => rfl)
     (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
 
 instance [Distrib Y] : Distrib (LocallyConstant X Y) :=
-  Function.Injective.distrib FunLike.coe FunLike.coe_injective' (fun _ _ => rfl) fun _ _ => rfl
+  Function.Injective.distrib DFunLike.coe DFunLike.coe_injective' (fun _ _ => rfl) fun _ _ => rfl
 
 instance [NonUnitalNonAssocSemiring Y] : NonUnitalNonAssocSemiring (LocallyConstant X Y) :=
-  Function.Injective.nonUnitalNonAssocSemiring FunLike.coe FunLike.coe_injective' rfl
+  Function.Injective.nonUnitalNonAssocSemiring DFunLike.coe DFunLike.coe_injective' rfl
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
 
 instance [NonUnitalSemiring Y] : NonUnitalSemiring (LocallyConstant X Y) :=
-  Function.Injective.nonUnitalSemiring FunLike.coe FunLike.coe_injective' rfl
+  Function.Injective.nonUnitalSemiring DFunLike.coe DFunLike.coe_injective' rfl
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
 
 instance [NonAssocSemiring Y] : NonAssocSemiring (LocallyConstant X Y) :=
-  Function.Injective.nonAssocSemiring FunLike.coe FunLike.coe_injective' rfl rfl
+  Function.Injective.nonAssocSemiring DFunLike.coe DFunLike.coe_injective' rfl rfl
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 
 /-- The constant-function embedding, as a ring hom.  -/
@@ -222,41 +222,41 @@ def constRingHom [NonAssocSemiring Y] : Y →+* LocallyConstant X Y :=
 #align locally_constant.const_ring_hom LocallyConstant.constRingHom
 
 instance [Semiring Y] : Semiring (LocallyConstant X Y) :=
-  Function.Injective.semiring FunLike.coe FunLike.coe_injective' rfl rfl
+  Function.Injective.semiring DFunLike.coe DFunLike.coe_injective' rfl rfl
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 
 instance [NonUnitalCommSemiring Y] : NonUnitalCommSemiring (LocallyConstant X Y) :=
-  Function.Injective.nonUnitalCommSemiring FunLike.coe FunLike.coe_injective' rfl
+  Function.Injective.nonUnitalCommSemiring DFunLike.coe DFunLike.coe_injective' rfl
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
 
 instance [CommSemiring Y] : CommSemiring (LocallyConstant X Y) :=
-  Function.Injective.commSemiring FunLike.coe FunLike.coe_injective' rfl rfl
+  Function.Injective.commSemiring DFunLike.coe DFunLike.coe_injective' rfl rfl
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 
 instance [NonUnitalNonAssocRing Y] : NonUnitalNonAssocRing (LocallyConstant X Y) :=
-  Function.Injective.nonUnitalNonAssocRing FunLike.coe FunLike.coe_injective' rfl (fun _ _ => rfl)
+  Function.Injective.nonUnitalNonAssocRing DFunLike.coe DFunLike.coe_injective' rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
 
 instance [NonUnitalRing Y] : NonUnitalRing (LocallyConstant X Y) :=
-  Function.Injective.nonUnitalRing FunLike.coe FunLike.coe_injective' rfl (fun _ _ => rfl)
+  Function.Injective.nonUnitalRing DFunLike.coe DFunLike.coe_injective' rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
 
 instance [NonAssocRing Y] : NonAssocRing (LocallyConstant X Y) :=
-  Function.Injective.nonAssocRing FunLike.coe FunLike.coe_injective' rfl rfl (fun _ _ => rfl)
+  Function.Injective.nonAssocRing DFunLike.coe DFunLike.coe_injective' rfl rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ => rfl) (fun _ => rfl)
 
 instance [Ring Y] : Ring (LocallyConstant X Y) :=
-  Function.Injective.ring FunLike.coe FunLike.coe_injective' rfl rfl (fun _ _ => rfl)
+  Function.Injective.ring DFunLike.coe DFunLike.coe_injective' rfl rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) fun _ => rfl
 
 instance [NonUnitalCommRing Y] : NonUnitalCommRing (LocallyConstant X Y) :=
-  Function.Injective.nonUnitalCommRing FunLike.coe FunLike.coe_injective' rfl (fun _ _ => rfl)
+  Function.Injective.nonUnitalCommRing DFunLike.coe DFunLike.coe_injective' rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
 
 instance [CommRing Y] : CommRing (LocallyConstant X Y) :=
-  Function.Injective.commRing FunLike.coe FunLike.coe_injective' rfl rfl (fun _ _ => rfl)
+  Function.Injective.commRing DFunLike.coe DFunLike.coe_injective' rfl rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) fun _ => rfl
 
@@ -296,18 +296,18 @@ end Algebra
 
 section coeFn
 
-/-- `FunLike.coe` as a `RingHom`. -/
+/-- `DFunLike.coe` as a `RingHom`. -/
 @[simps!] def coeFnRingHom [Semiring Y] : LocallyConstant X Y →+* X → Y where
   toMonoidHom := coeFnMonoidHom
   __ := coeFnAddMonoidHom
 
-/-- `FunLike.coe` as a linear map. -/
+/-- `DFunLike.coe` as a linear map. -/
 @[simps!] def coeFnₗ (R : Type*) [Semiring R] [AddCommMonoid Y]
     [Module R Y] : LocallyConstant X Y →ₗ[R] X → Y where
   toAddHom := coeFnAddMonoidHom.toAddHom
   map_smul' _ _ := rfl
 
-/-- `FunLike.coe` as an `AlgHom`. -/
+/-- `DFunLike.coe` as an `AlgHom`. -/
 @[simps!] def coeFnAlgHom (R : Type*) [CommSemiring R] [Semiring Y] [Algebra R Y] :
     LocallyConstant X Y →ₐ[R] X → Y where
   toRingHom := coeFnRingHom

--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -250,7 +250,7 @@ namespace LocallyConstant
 instance [Inhabited Y] : Inhabited (LocallyConstant X Y) :=
   ⟨⟨_, IsLocallyConstant.const default⟩⟩
 
-instance : FunLike (LocallyConstant X Y) X (fun _ => Y) where
+instance : DFunLike (LocallyConstant X Y) X (fun _ => Y) where
   coe := LocallyConstant.toFun
   coe_injective' := by rintro ⟨_, _⟩ ⟨_, _⟩ _; congr
 
@@ -270,15 +270,15 @@ theorem coe_mk (f : X → Y) (h) : ⇑(⟨f, h⟩ : LocallyConstant X Y) = f :=
 #align locally_constant.coe_mk LocallyConstant.coe_mk
 
 theorem congr_fun {f g : LocallyConstant X Y} (h : f = g) (x : X) : f x = g x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align locally_constant.congr_fun LocallyConstant.congr_fun
 
 theorem congr_arg (f : LocallyConstant X Y) {x y : X} (h : x = y) : f x = f y :=
-  FunLike.congr_arg f h
+  DFunLike.congr_arg f h
 #align locally_constant.congr_arg LocallyConstant.congr_arg
 
 theorem coe_injective : @Function.Injective (LocallyConstant X Y) (X → Y) (↑) := fun _ _ =>
-  FunLike.ext'
+  DFunLike.ext'
 #align locally_constant.coe_injective LocallyConstant.coe_injective
 
 @[norm_cast]
@@ -288,10 +288,10 @@ theorem coe_inj {f g : LocallyConstant X Y} : (f : X → Y) = g ↔ f = g :=
 
 @[ext]
 theorem ext ⦃f g : LocallyConstant X Y⦄ (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 #align locally_constant.ext LocallyConstant.ext
 
-theorem ext_iff {f g : LocallyConstant X Y} : f = g ↔ ∀ x, f x = g x := FunLike.ext_iff
+theorem ext_iff {f g : LocallyConstant X Y} : f = g ↔ ∀ x, f x = g x := DFunLike.ext_iff
 #align locally_constant.ext_iff LocallyConstant.ext_iff
 
 section CodomainTopologicalSpace

--- a/Mathlib/Topology/MetricSpace/Dilation.lean
+++ b/Mathlib/Topology/MetricSpace/Dilation.lean
@@ -71,7 +71,7 @@ infixl:25 " →ᵈ " => Dilation
 /-- `DilationClass F α β r` states that `F` is a type of `r`-dilations.
 You should extend this typeclass when you extend `Dilation`. -/
 class DilationClass (F : Type*) (α β : outParam <| Type*) [PseudoEMetricSpace α]
-    [PseudoEMetricSpace β] extends FunLike F α fun _ => β where
+    [PseudoEMetricSpace β] extends DFunLike F α fun _ => β where
   edist_eq' : ∀ f : F, ∃ r : ℝ≥0, r ≠ 0 ∧ ∀ x y : α, edist (f x) (f y) = r * edist x y
 #align dilation_class DilationClass
 
@@ -92,7 +92,7 @@ instance toDilationClass : DilationClass (α →ᵈ β) α β where
 #align dilation.to_dilation_class Dilation.toDilationClass
 
 instance : CoeFun (α →ᵈ β) fun _ => α → β :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 @[simp]
 theorem toFun_eq_coe {f : α →ᵈ β} : f.toFun = (f : α → β) :=
@@ -105,20 +105,20 @@ theorem coe_mk (f : α → β) (h) : ⇑(⟨f, h⟩ : α →ᵈ β) = f :=
 #align dilation.coe_mk Dilation.coe_mk
 
 theorem congr_fun {f g : α →ᵈ β} (h : f = g) (x : α) : f x = g x :=
-  FunLike.congr_fun h x
+  DFunLike.congr_fun h x
 #align dilation.congr_fun Dilation.congr_fun
 
 theorem congr_arg (f : α →ᵈ β) {x y : α} (h : x = y) : f x = f y :=
-  FunLike.congr_arg f h
+  DFunLike.congr_arg f h
 #align dilation.congr_arg Dilation.congr_arg
 
 @[ext]
 theorem ext {f g : α →ᵈ β} (h : ∀ x, f x = g x) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align dilation.ext Dilation.ext
 
 theorem ext_iff {f g : α →ᵈ β} : f = g ↔ ∀ x, f x = g x :=
-  FunLike.ext_iff
+  DFunLike.ext_iff
 #align dilation.ext_iff Dilation.ext_iff
 
 @[simp]
@@ -135,7 +135,7 @@ protected def copy (f : α →ᵈ β) (f' : α → β) (h : f' = ⇑f) : α →�
 #align dilation.copy Dilation.copy
 
 theorem copy_eq_self (f : α →ᵈ β) {f' : α → β} (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align dilation.copy_eq_self Dilation.copy_eq_self
 
 /-- The ratio of a dilation `f`. If the ratio is undefined (i.e., the distance between any two

--- a/Mathlib/Topology/MetricSpace/DilationEquiv.lean
+++ b/Mathlib/Topology/MetricSpace/DilationEquiv.lean
@@ -33,7 +33,7 @@ class DilationEquivClass extends EquivLike F X Y where
   edist_eq' : ∀ f : F, ∃ r : ℝ≥0, r ≠ 0 ∧ ∀ x y : X, edist (f x) (f y) = r * edist x y
 
 instance (priority := 100) [DilationEquivClass F X Y] : DilationClass F X Y :=
-  { inferInstanceAs (FunLike F X fun _ ↦ Y), ‹DilationEquivClass F X Y› with }
+  { inferInstanceAs (DFunLike F X fun _ ↦ Y), ‹DilationEquivClass F X Y› with }
 
 end Class
 
@@ -55,7 +55,7 @@ instance : DilationEquivClass (X ≃ᵈ Y) X Y where
   inv f := f.1.symm
   left_inv f := f.left_inv'
   right_inv f := f.right_inv'
-  coe_injective' := by rintro ⟨⟩ ⟨⟩ h -; congr; exact FunLike.ext' h
+  coe_injective' := by rintro ⟨⟩ ⟨⟩ h -; congr; exact DFunLike.ext' h
   edist_eq' f := f.edist_eq'
 
 instance : CoeFun (X ≃ᵈ Y) fun _ ↦ (X → Y) where
@@ -65,7 +65,7 @@ instance : CoeFun (X ≃ᵈ Y) fun _ ↦ (X → Y) where
 
 @[ext]
 protected theorem ext {e e' : X ≃ᵈ Y} (h : ∀ x, e x = e' x) : e = e' :=
-  FunLike.ext _ _ h
+  DFunLike.ext _ _ h
 
 /-- Inverse `DilationEquiv`. -/
 def symm (e : X ≃ᵈ Y) : Y ≃ᵈ X where

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -317,7 +317,7 @@ instance : EquivLike (α ≃ᵢ β) α β where
   inv e := e.toEquiv.symm
   left_inv e := e.left_inv
   right_inv e := e.right_inv
-  coe_injective' _ _ h _ := toEquiv_injective <| FunLike.ext' h
+  coe_injective' _ _ h _ := toEquiv_injective <| DFunLike.ext' h
 
 theorem coe_eq_toEquiv (h : α ≃ᵢ β) (a : α) : h a = h.toEquiv a := rfl
 #align isometry_equiv.coe_eq_to_equiv IsometryEquiv.coe_eq_toEquiv
@@ -368,7 +368,7 @@ theorem ediam_image (h : α ≃ᵢ β) (s : Set α) : EMetric.diam (h '' s) = EM
 
 @[ext]
 theorem ext ⦃h₁ h₂ : α ≃ᵢ β⦄ (H : ∀ x, h₁ x = h₂ x) : h₁ = h₂ :=
-  FunLike.ext _ _ H
+  DFunLike.ext _ _ H
 #align isometry_equiv.ext IsometryEquiv.ext
 
 /-- Alternative constructor for isometric bijections,

--- a/Mathlib/Topology/Order/Category/AlexDisc.lean
+++ b/Mathlib/Topology/Order/Category/AlexDisc.lean
@@ -50,8 +50,8 @@ def of (α : Type*) [TopologicalSpace α] [AlexandrovDiscrete α] : AlexDisc := 
 def Iso.mk {α β : AlexDisc} (e : α ≃ₜ β) : α ≅ β where
   hom := (e : ContinuousMap α β)
   inv := (e.symm : ContinuousMap β α)
-  hom_inv_id := FunLike.ext _ _ e.symm_apply_apply
-  inv_hom_id := FunLike.ext _ _ e.apply_symm_apply
+  hom_inv_id := DFunLike.ext _ _ e.symm_apply_apply
+  inv_hom_id := DFunLike.ext _ _ e.apply_symm_apply
 
 end AlexDisc
 

--- a/Mathlib/Topology/Order/Hom/Basic.lean
+++ b/Mathlib/Topology/Order/Hom/Basic.lean
@@ -15,7 +15,7 @@ This file defines continuous order homomorphisms, that is maps which are both co
 monotone. They are also called Priestley homomorphisms because they are the morphisms of the
 category of Priestley spaces.
 
-We use the `FunLike` design, so each type of morphisms has a companion typeclass which is meant to
+We use the `DFunLike` design, so each type of morphisms has a companion typeclass which is meant to
 be satisfied by itself and all stricter types.
 
 ## Types of morphisms
@@ -115,7 +115,7 @@ theorem toFun_eq_coe {f : α →Co β} : f.toFun = (f : α → β) := rfl
 
 @[ext]
 theorem ext {f g : α →Co β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align continuous_order_hom.ext ContinuousOrderHom.ext
 
 /-- Copy of a `ContinuousOrderHom` with a new `ContinuousMap` equal to the old one. Useful to fix
@@ -130,7 +130,7 @@ theorem coe_copy (f : α →Co β) (f' : α → β) (h : f' = f) : ⇑(f.copy f'
 #align continuous_order_hom.coe_copy ContinuousOrderHom.coe_copy
 
 theorem copy_eq (f : α →Co β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align continuous_order_hom.copy_eq ContinuousOrderHom.copy_eq
 
 variable (α)
@@ -189,7 +189,7 @@ theorem id_comp (f : α →Co β) : (ContinuousOrderHom.id β).comp f = f :=
 @[simp]
 theorem cancel_right {g₁ g₂ : β →Co γ} {f : α →Co β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, fun h => congr_arg₂ _ h rfl⟩
 #align continuous_order_hom.cancel_right ContinuousOrderHom.cancel_right
 
 @[simp]
@@ -204,6 +204,6 @@ instance : Preorder (α →Co β) :=
 end Preorder
 
 instance [PartialOrder β] : PartialOrder (α →Co β) :=
-  PartialOrder.lift ((↑) : (α →Co β) → α → β) FunLike.coe_injective
+  PartialOrder.lift ((↑) : (α →Co β) → α → β) DFunLike.coe_injective
 
 end ContinuousOrderHom

--- a/Mathlib/Topology/Order/Hom/Esakia.lean
+++ b/Mathlib/Topology/Order/Hom/Esakia.lean
@@ -13,7 +13,7 @@ import Mathlib.Topology.Order.Hom.Basic
 
 This file defines pseudo-epimorphisms and Esakia morphisms.
 
-We use the `FunLike` design, so each type of morphisms has a companion typeclass which is meant to
+We use the `DFunLike` design, so each type of morphisms has a companion typeclass which is meant to
 be satisfied by itself and all stricter types.
 
 ## Types of morphisms
@@ -116,10 +116,10 @@ instance : PseudoEpimorphismClass (PseudoEpimorphism α β) α β where
   map_rel f _ _ h := f.monotone' h
   exists_map_eq_of_map_le := PseudoEpimorphism.exists_map_eq_of_map_le'
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 instance : CoeFun (PseudoEpimorphism α β) fun _ => α → β :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 @[simp]
 theorem toOrderHom_eq_coe (f : PseudoEpimorphism α β) : ⇑f.toOrderHom = f := rfl
@@ -129,7 +129,7 @@ theorem toFun_eq_coe {f : PseudoEpimorphism α β} : f.toFun = (f : α → β) :
 
 @[ext]
 theorem ext {f g : PseudoEpimorphism α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align pseudo_epimorphism.ext PseudoEpimorphism.ext
 
 /-- Copy of a `PseudoEpimorphism` with a new `toFun` equal to the old one. Useful to fix
@@ -143,7 +143,7 @@ theorem coe_copy (f : PseudoEpimorphism α β) (f' : α → β) (h : f' = f) : �
 #align pseudo_epimorphism.coe_copy PseudoEpimorphism.coe_copy
 
 theorem copy_eq (f : PseudoEpimorphism α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align pseudo_epimorphism.copy_eq PseudoEpimorphism.copy_eq
 
 variable (α)
@@ -211,7 +211,7 @@ theorem id_comp (f : PseudoEpimorphism α β) : (PseudoEpimorphism.id β).comp f
 @[simp]
 theorem cancel_right {g₁ g₂ : PseudoEpimorphism β γ} {f : PseudoEpimorphism α β}
     (hf : Surjective f) : g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, congr_arg (comp · f)⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, congr_arg (comp · f)⟩
 #align pseudo_epimorphism.cancel_right PseudoEpimorphism.cancel_right
 
 @[simp]
@@ -244,10 +244,10 @@ instance : EsakiaHomClass (EsakiaHom α β) α β where
   map_continuous f := f.continuous_toFun
   exists_map_eq_of_map_le f := f.exists_map_eq_of_map_le'
 
-/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`
+/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
 instance : CoeFun (EsakiaHom α β) fun _ => α → β :=
-  FunLike.hasCoeToFun
+  DFunLike.hasCoeToFun
 
 -- Porting note: introduced this to appease simpNF linter with `toFun_eq_coe`
 @[simp]
@@ -260,7 +260,7 @@ theorem toFun_eq_coe {f : EsakiaHom α β} : f.toFun = (f : α → β) := rfl
 
 @[ext]
 theorem ext {f g : EsakiaHom α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align esakia_hom.ext EsakiaHom.ext
 
 /-- Copy of an `EsakiaHom` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -275,7 +275,7 @@ theorem coe_copy (f : EsakiaHom α β) (f' : α → β) (h : f' = f) : ⇑(f.cop
 #align esakia_hom.coe_copy EsakiaHom.coe_copy
 
 theorem copy_eq (f : EsakiaHom α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align esakia_hom.copy_eq EsakiaHom.copy_eq
 
 variable (α)
@@ -351,7 +351,7 @@ theorem id_comp (f : EsakiaHom α β) : (EsakiaHom.id β).comp f = f :=
 @[simp]
 theorem cancel_right {g₁ g₂ : EsakiaHom β γ} {f : EsakiaHom α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h, congr_arg (comp · f)⟩
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h, congr_arg (comp · f)⟩
 #align esakia_hom.cancel_right EsakiaHom.cancel_right
 
 @[simp]

--- a/Mathlib/Topology/PartialHomeomorph.lean
+++ b/Mathlib/Topology/PartialHomeomorph.lean
@@ -71,7 +71,7 @@ While we may want to switch to this behavior later, doing it mid-port will break
 @[coe] def toFun' : α → β := e.toFun
 
 /-- Coercion of a `PartialHomeomorph` to function.
-Note that a `PartialHomeomorph` is not `FunLike`. -/
+Note that a `PartialHomeomorph` is not `DFunLike`. -/
 instance : CoeFun (PartialHomeomorph α β) fun _ => α → β :=
   ⟨fun e => e.toFun'⟩
 

--- a/Mathlib/Topology/PartitionOfUnity.lean
+++ b/Mathlib/Topology/PartitionOfUnity.lean
@@ -135,7 +135,7 @@ namespace PartitionOfUnity
 variable {E : Type*} [AddCommMonoid E] [SMulWithZero ℝ E] [TopologicalSpace E] [ContinuousSMul ℝ E]
   {s : Set X} (f : PartitionOfUnity ι X s)
 
-instance : FunLike (PartitionOfUnity ι X s) ι fun _ ↦ C(X, ℝ) where
+instance : DFunLike (PartitionOfUnity ι X s) ι fun _ ↦ C(X, ℝ) where
   coe := toFun
   coe_injective' := fun f g h ↦ by cases f; cases g; congr
 
@@ -281,7 +281,7 @@ namespace BumpCovering
 
 variable {s : Set X} (f : BumpCovering ι X s)
 
-instance : FunLike (BumpCovering ι X s) ι fun _ ↦ C(X, ℝ) where
+instance : DFunLike (BumpCovering ι X s) ι fun _ ↦ C(X, ℝ) where
   coe := toFun
   coe_injective' := fun f g h ↦ by cases f; cases g; congr
 

--- a/Mathlib/Topology/Separation/NotNormal.lean
+++ b/Mathlib/Topology/Separation/NotNormal.lean
@@ -46,7 +46,7 @@ theorem IsClosed.mk_lt_continuum [NormalSpace X] {s : Set X} (hs : IsClosed s)
       exact mk_le_of_injective hfi
     -- Since `t` is dense, restriction `C(X, ℝ) → C(t, ℝ)` is injective, hence `#C(X, ℝ) ≤ #C(t, ℝ)`
     _ ≤ #C(t, ℝ) := mk_le_of_injective <| ContinuousMap.injective_restrict htd
-    _ ≤ #(t → ℝ) := mk_le_of_injective FunLike.coe_injective
+    _ ≤ #(t → ℝ) := mk_le_of_injective DFunLike.coe_injective
     -- Since `t` is countable, we have `#(t → ℝ) ≤ 𝔠`
     _ ≤ 𝔠 := by
       rw [mk_arrow, mk_real, lift_uzero, lift_continuum, continuum, ← power_mul]

--- a/Mathlib/Topology/Sets/Opens.lean
+++ b/Mathlib/Topology/Sets/Opens.lean
@@ -396,7 +396,7 @@ theorem comap_injective [T0Space β] : Injective (comap : C(α, β) → FrameHom
   ContinuousMap.ext fun a =>
     Inseparable.eq <|
       inseparable_iff_forall_open.2 fun s hs =>
-        have : comap f ⟨s, hs⟩ = comap g ⟨s, hs⟩ := FunLike.congr_fun h ⟨_, hs⟩
+        have : comap f ⟨s, hs⟩ = comap g ⟨s, hs⟩ := DFunLike.congr_fun h ⟨_, hs⟩
         show a ∈ f ⁻¹' s ↔ a ∈ g ⁻¹' s from Set.ext_iff.1 (coe_inj.2 this) a
 #align topological_space.opens.comap_injective TopologicalSpace.Opens.comap_injective
 

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -70,7 +70,7 @@ lemma ext {P Q : Presheaf C X} {f g : P ⟶ Q} (w : ∀ U : Opens X, f.app (op U
   apply w
 
 attribute [local instance] CategoryTheory.ConcreteCategory.hasCoeToSort
-  CategoryTheory.ConcreteCategory.funLike
+  CategoryTheory.ConcreteCategory.instDFunLike
 
 /-- attribute `sheaf_restrict` to mark lemmas related to restricting sheaves -/
 macro "sheaf_restrict" : attr =>

--- a/Mathlib/Topology/Sheaves/SheafCondition/UniqueGluing.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/UniqueGluing.lean
@@ -50,7 +50,7 @@ namespace Presheaf
 
 section
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
 
 variable {X : TopCat.{x}} (F : Presheaf C X) {ι : Type x} (U : ι → Opens X)
 
@@ -152,7 +152,7 @@ end TypeValued
 
 section
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
 
 variable [HasLimits C] [ReflectsIsomorphisms (forget C)] [PreservesLimits (forget C)]
 
@@ -179,7 +179,7 @@ open CategoryTheory
 
 section
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.funLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
 
 variable [HasLimits C] [ReflectsIsomorphisms (ConcreteCategory.forget (C := C))]
 

--- a/Mathlib/Topology/Spectral/Hom.lean
+++ b/Mathlib/Topology/Spectral/Hom.lean
@@ -76,7 +76,7 @@ section
 
 You should extend this class when you extend `SpectralMap`. -/
 class SpectralMapClass (F : Type*) (α β : outParam <| Type*) [TopologicalSpace α]
-  [TopologicalSpace β] extends FunLike F α fun _ => β where
+  [TopologicalSpace β] extends DFunLike F α fun _ => β where
   /-- statement that `F` is a type of spectral maps-/
   map_spectral (f : F) : IsSpectralMap f
 #align spectral_map_class SpectralMapClass
@@ -116,10 +116,10 @@ instance : SpectralMapClass (SpectralMap α β) α β
   map_spectral f := f.spectral'
 
 -- Porting note: These CoeFun instances are not desirable in Lean 4.
---/-- Helper instance for when there's too many metavariables to apply `FunLike.hasCoeToFun`
+--/-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 --directly. -/
 --instance : CoeFun (SpectralMap α β) fun _ => α → β :=
---  FunLike.hasCoeToFun
+--  DFunLike.hasCoeToFun
 
 @[simp]
 theorem toFun_eq_coe {f : SpectralMap α β} : f.toFun = (f : α → β) :=
@@ -128,7 +128,7 @@ theorem toFun_eq_coe {f : SpectralMap α β} : f.toFun = (f : α → β) :=
 
 @[ext]
 theorem ext {f g : SpectralMap α β} (h : ∀ a, f a = g a) : f = g :=
-  FunLike.ext f g h
+  DFunLike.ext f g h
 #align spectral_map.ext SpectralMap.ext
 
 /-- Copy of a `SpectralMap` with a new `toFun` equal to the old one. Useful to fix definitional
@@ -143,7 +143,7 @@ theorem coe_copy (f : SpectralMap α β) (f' : α → β) (h : f' = f) : ⇑(f.c
 #align spectral_map.coe_copy SpectralMap.coe_copy
 
 theorem copy_eq (f : SpectralMap α β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
-  FunLike.ext' h
+  DFunLike.ext' h
 #align spectral_map.copy_eq SpectralMap.copy_eq
 
 variable (α)
@@ -213,7 +213,7 @@ theorem id_comp (f : SpectralMap α β) : (SpectralMap.id β).comp f = f :=
 @[simp]
 theorem cancel_right {g₁ g₂ : SpectralMap β γ} {f : SpectralMap α β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h => ext <| hf.forall.2 <| FunLike.ext_iff.1 h,
+  ⟨fun h => ext <| hf.forall.2 <| DFunLike.ext_iff.1 h,
    fun a => of_eq (congrFun (congrArg comp a) f)⟩
 #align spectral_map.cancel_right SpectralMap.cancel_right
 

--- a/Mathlib/Topology/TietzeExtension.lean
+++ b/Mathlib/Topology/TietzeExtension.lean
@@ -333,7 +333,7 @@ theorem exists_forall_mem_restrict_eq_of_closed {s : Set Y} (f : s →ᵇ ℝ) (
   rcases exists_extension_forall_mem_of_closedEmbedding f hf hne
       (closedEmbedding_subtype_val hs) with
     ⟨g, hg, hgf⟩
-  exact ⟨g, hg, FunLike.coe_injective hgf⟩
+  exact ⟨g, hg, DFunLike.coe_injective hgf⟩
 #align bounded_continuous_function.exists_forall_mem_restrict_eq_of_closed BoundedContinuousFunction.exists_forall_mem_restrict_eq_of_closed
 
 end BoundedContinuousFunction

--- a/Mathlib/Topology/UniformSpace/Equicontinuity.lean
+++ b/Mathlib/Topology/UniformSpace/Equicontinuity.lean
@@ -441,7 +441,7 @@ theorem UniformInducing.uniformEquicontinuous_iff {F : ι → β → α} {u : α
 
 /-- A version of `EquicontinuousAt.closure` applicable to subsets of types which embed continuously
 into `X → α` with the product topology. It turns out we don't need any other condition on the
-embedding than continuity, but in practice this will mostly be applied to `FunLike` types where
+embedding than continuity, but in practice this will mostly be applied to `DFunLike` types where
 the coercion is injective. -/
 theorem EquicontinuousAt.closure' {A : Set Y} {u : Y → X → α} {x₀ : X}
     (hA : EquicontinuousAt (u ∘ (↑) : A → X → α) x₀) (hu : Continuous u) :
@@ -473,7 +473,7 @@ theorem Filter.Tendsto.continuousAt_of_equicontinuousAt {l : Filter ι} [l.NeBot
 
 /-- A version of `Equicontinuous.closure` applicable to subsets of types which embed continuously
 into `X → α` with the product topology. It turns out we don't need any other condition on the
-embedding than continuity, but in practice this will mostly be applied to `FunLike` types where
+embedding than continuity, but in practice this will mostly be applied to `DFunLike` types where
 the coercion is injective. -/
 theorem Equicontinuous.closure' {A : Set Y} {u : Y → X → α}
     (hA : Equicontinuous (u ∘ (↑) : A → X → α)) (hu : Continuous u) :
@@ -495,7 +495,7 @@ theorem Filter.Tendsto.continuous_of_equicontinuousAt {l : Filter ι} [l.NeBot] 
 
 /-- A version of `UniformEquicontinuous.closure` applicable to subsets of types which embed
 continuously into `β → α` with the product topology. It turns out we don't need any other condition
-on the embedding than continuity, but in practice this will mostly be applied to `FunLike` types
+on the embedding than continuity, but in practice this will mostly be applied to `DFunLike` types
 where the coercion is injective. -/
 theorem UniformEquicontinuous.closure' {A : Set Y} {u : Y → β → α}
     (hA : UniformEquicontinuous (u ∘ (↑) : A → β → α)) (hu : Continuous u) :

--- a/Mathlib/Topology/UniformSpace/Equiv.lean
+++ b/Mathlib/Topology/UniformSpace/Equiv.lean
@@ -57,7 +57,7 @@ instance : EquivLike (α ≃ᵤ β) α β where
   inv := fun h => h.toEquiv.symm
   left_inv := fun h => h.left_inv
   right_inv := fun h => h.right_inv
-  coe_injective' := fun _ _ H _ => toEquiv_injective <| FunLike.ext' H
+  coe_injective' := fun _ _ H _ => toEquiv_injective <| DFunLike.ext' H
 
 @[simp]
 theorem uniformEquiv_mk_coe (a : Equiv α β) (b c) : (UniformEquiv.mk a b c : α → β) = a :=

--- a/test/CategoryTheory/Elementwise.lean
+++ b/test/CategoryTheory/Elementwise.lean
@@ -10,7 +10,7 @@ open CategoryTheory
 set_option linter.existingAttributeWarning false in
 attribute [simp] Iso.hom_inv_id Iso.inv_hom_id IsIso.hom_inv_id IsIso.inv_hom_id
 
-attribute [local instance] ConcreteCategory.funLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
 
 @[elementwise]
 theorem ex1 [Category C] [ConcreteCategory C] (X : C) (f g h : X ⟶ X) (h' : g ≫ h = h ≫ g) :

--- a/test/FunLike.lean
+++ b/test/FunLike.lean
@@ -1,6 +1,6 @@
 import Mathlib.Data.FunLike.Basic
 
-variable {F α β : Sort*} [i : FunLike F α fun _ ↦ β] (f : F) (a : α)
+variable {F α β : Sort*} [i : DFunLike F α fun _ ↦ β] (f : F) (a : α)
 
 /-- info: f a : β -/
 #guard_msgs in #check f a

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -150,7 +150,7 @@ example {k : Type _} [Semiring k] [Nontrivial k] :
     (Finsupp.comapSMul : SMul k (k →₀ k)) ≠ Finsupp.smulZeroClass.toSMul := by
   obtain ⟨u : k, hu⟩ := exists_ne (1 : k)
   intro h
-  simp only [SMul.ext_iff, @SMul.smul_eq_hSMul _ _ (_), Function.funext_iff, FunLike.ext_iff] at h
+  simp only [SMul.ext_iff, @SMul.smul_eq_hSMul _ _ (_), Function.funext_iff, DFunLike.ext_iff] at h
   replace h := h u (Finsupp.single 1 1) u
   classical
   rw [comapSMul_single, smul_apply, smul_eq_mul, mul_one, single_eq_same, smul_eq_mul,
@@ -164,7 +164,7 @@ example {k : Type _} [Semiring k] [Nontrivial kˣ] :
   obtain ⟨u : kˣ, hu⟩ := exists_ne (1 : kˣ)
   haveI : Nontrivial k := ⟨⟨u, 1, Units.ext.ne hu⟩⟩
   intro h
-  simp only [SMul.ext_iff, @SMul.smul_eq_hSMul _ _ (_), Function.funext_iff, FunLike.ext_iff] at h
+  simp only [SMul.ext_iff, @SMul.smul_eq_hSMul _ _ (_), Function.funext_iff, DFunLike.ext_iff] at h
   replace h := h u (Finsupp.single 1 1) u
   classical
   rw [comapSMul_single, smul_apply, Units.smul_def, smul_eq_mul, mul_one, single_eq_same,


### PR DESCRIPTION
This prepares for the introduction of a non-dependent synonym of FunLike, which helps a lot with keeping #8386 readable.

This is entirely search-and-replace in [680197f](https://github.com/leanprover-community/mathlib4/pull/9785/commits/680197facd83904c603e7b8bc2eecbd9eeaf0787) combined with manual fixes in [4145626](https://github.com/leanprover-community/mathlib4/pull/9785/commits/414562627a8d287559068ff02cc811c262a1d6c8), [e900597](https://github.com/leanprover-community/mathlib4/pull/9785/commits/e900597f6895dd14d4a60dcf83b596965717c35d) and [b8428f8](https://github.com/leanprover-community/mathlib4/pull/9785/commits/b8428f88f3e07f9be6b673266af8b0795bb3427d). The commands that generated this change:
```bash
sed -i 's/\bFunLike\b/DFunLike/g' {Archive,Counterexamples,Mathlib,test}/**/*.lean
sed -i 's/\btoFunLike\b/toDFunLike/g' {Archive,Counterexamples,Mathlib,test}/**/*.lean
sed -i 's/import Mathlib.Data.DFunLike/import Mathlib.Data.FunLike/g' {Archive,Counterexamples,Mathlib,test}/**/*.lean
sed -i 's/\bHom_FunLike\b/Hom_DFunLike/g' {Archive,Counterexamples,Mathlib,test}/**/*.lean     
sed -i 's/\binstFunLike\b/instDFunLike/g' {Archive,Counterexamples,Mathlib,test}/**/*.lean
sed -i 's/\bfunLike\b/instDFunLike/g' {Archive,Counterexamples,Mathlib,test}/**/*.lean
sed -i 's/\btoo many metavariables to apply `fun_like.has_coe_to_fun`/too many metavariables to apply `DFunLike.hasCoeToFun`/g' {Archive,Counterexamples,Mathlib,test}/**/*.lean
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
