### PR TITLE
[Merged by Bors] - fix(Data/Fin/Basic): Change definition of `predAbove` to use `castPred`

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplexCategory.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory.lean
@@ -256,16 +256,22 @@ theorem δ_comp_δ_self' {n} {i : Fin (n + 2)} {j : Fin (n + 3)} (H : j = Fin.ca
 @[reassoc]
 theorem δ_comp_σ_of_le {n} {i : Fin (n + 2)} {j : Fin (n + 1)} (H : i ≤ Fin.castSucc j) :
     δ (Fin.castSucc i) ≫ σ j.succ = σ j ≫ δ i := by
-  rcases i with ⟨i, hi⟩
-  rcases j with ⟨j, hj⟩
-  ext ⟨k, hk⟩
-  simp? at H hk says simp only [Fin.castSucc_mk, Fin.mk_le_mk, len_mk] at H hk
-  dsimp [σ, δ, Fin.predAbove, Fin.succAbove]
-  simp only [Fin.lt_iff_val_lt_val, Fin.dite_val, Fin.ite_val, Fin.coe_pred, ge_iff_le,
-    Fin.coe_castLT, dite_eq_ite, Fin.coe_castSucc, Fin.val_succ]
-  split_ifs
-  all_goals try simp <;> linarith
-  all_goals cases k <;> simp at * <;> linarith
+  ext k : 3
+  dsimp [σ, δ]
+  rcases le_or_lt i k with (hik | hik)
+  · rw [Fin.succAbove_above _ _ (Fin.castSucc_le_castSucc_iff.mpr hik),
+    Fin.succ_predAbove_succ, Fin.succAbove_above]
+    rcases le_or_lt k (j.castSucc) with (hjk | hjk)
+    · rwa [Fin.predAbove_below _ _ hjk, Fin.castSucc_castPred]
+    · rw [Fin.le_castSucc_iff, Fin.predAbove_above _ _ hjk, Fin.succ_pred]
+      exact H.trans_lt hjk
+  · rw [Fin.succAbove_below _ _ (Fin.castSucc_lt_castSucc_iff.mpr hik)]
+    have hjk := H.trans_lt' hik
+    rw [Fin.predAbove_below _ _ (Fin.castSucc_le_castSucc_iff.mpr
+      (hjk.trans (Fin.castSucc_lt_succ _)).le),
+      Fin.predAbove_below _ _ hjk.le, Fin.castPred_castSucc, Fin.succAbove_below,
+      Fin.castSucc_castPred]
+    rwa [Fin.castSucc_castPred]
 #align simplex_category.δ_comp_σ_of_le SimplexCategory.δ_comp_σ_of_le
 
 /-- The first part of the third simplicial identity -/
@@ -311,16 +317,23 @@ theorem δ_comp_σ_succ' {n} (j : Fin (n + 2)) (i : Fin (n + 1)) (H : j = i.succ
 @[reassoc]
 theorem δ_comp_σ_of_gt {n} {i : Fin (n + 2)} {j : Fin (n + 1)} (H : Fin.castSucc j < i) :
     δ i.succ ≫ σ (Fin.castSucc j) = σ j ≫ δ i := by
-  ext ⟨k, hk⟩
-  rcases i with ⟨i, hi⟩
-  rcases j with ⟨j, hj⟩
-  simp? at H hk says simp only [Fin.castSucc_mk, Fin.mk_lt_mk, len_mk] at H hk
-  dsimp [δ, σ, Fin.predAbove, Fin.succAbove]
-  simp only [Fin.lt_iff_val_lt_val, Fin.dite_val, Fin.ite_val, Fin.coe_pred, ge_iff_le,
-    Fin.coe_castLT, dite_eq_ite, Fin.coe_castSucc, Fin.val_succ]
-  split_ifs
-  all_goals try simp <;> linarith
-  all_goals cases k <;> simp at * <;> linarith
+  ext k : 3
+  dsimp [δ, σ]
+  rcases le_or_lt k i with (hik | hik)
+  · rw [Fin.succAbove_below _ _ (Fin.castSucc_lt_succ_iff.mpr hik)]
+    rcases le_or_lt k (j.castSucc) with (hjk | hjk)
+    · rw [Fin.predAbove_below _ _ (Fin.castSucc_le_castSucc_iff.mpr hjk), Fin.castPred_castSucc,
+      Fin.predAbove_below _ _ hjk, Fin.succAbove_below, Fin.castSucc_castPred]
+      rw [Fin.castSucc_castPred]
+      exact hjk.trans_lt H
+    · rw [Fin.predAbove_above _ _ (Fin.castSucc_lt_castSucc_iff.mpr hjk),
+      Fin.predAbove_above _ _ hjk, Fin.succAbove_below, Fin.castSucc_pred_eq_pred_castSucc]
+      rwa [Fin.castSucc_lt_iff_succ_le, Fin.succ_pred]
+  · rw [Fin.succAbove_above _ _ (Fin.succ_le_castSucc_iff.mpr hik)]
+    have hjk := H.trans hik
+    rw [Fin.predAbove_above _ _ hjk, Fin.predAbove_above _ _ (Fin.castSucc_lt_succ_iff.mpr hjk.le),
+    Fin.pred_succ, Fin.succAbove_above, Fin.succ_pred]
+    rwa [Fin.le_castSucc_pred_iff]
 #align simplex_category.δ_comp_σ_of_gt SimplexCategory.δ_comp_σ_of_gt
 
 @[reassoc]
@@ -337,16 +350,32 @@ theorem δ_comp_σ_of_gt' {n} {i : Fin (n + 3)} {j : Fin (n + 2)} (H : j.succ < 
 @[reassoc]
 theorem σ_comp_σ {n} {i j : Fin (n + 1)} (H : i ≤ j) :
     σ (Fin.castSucc i) ≫ σ j = σ j.succ ≫ σ i := by
-  ext ⟨k, hk⟩
-  rcases i with ⟨i, hi⟩
-  rcases j with ⟨j, hj⟩
-  simp? at H hk says simp only [Fin.mk_le_mk, len_mk] at H hk
-  dsimp [σ, Fin.predAbove]
-  simp only [Fin.lt_iff_val_lt_val, Fin.ite_val, Fin.coe_pred, ge_iff_le, dite_eq_ite,
-    Fin.coe_castLT]
-  split_ifs
-  all_goals try linarith
-  all_goals cases k <;> simp at *; linarith
+  ext k : 3
+  dsimp [σ]
+  cases' k using Fin.lastCases with k
+  · simp only [len_mk, Fin.predAbove_right_last]
+  · cases' k using Fin.cases with k
+    · rw [Fin.castSucc_zero, Fin.predAbove_below _ 0 (Fin.zero_le _),
+      Fin.predAbove_below _ _ (Fin.zero_le _), Fin.castPred_zero,
+      Fin.predAbove_below _ 0 (Fin.zero_le _), Fin.predAbove_below _ _ (Fin.zero_le _)]
+    · rcases le_or_lt i k with (h | h)
+      · simp_rw [Fin.predAbove_above i.castSucc _ (Fin.castSucc_lt_castSucc_iff.mpr
+        (Fin.castSucc_lt_succ_iff.mpr h)), ← Fin.succ_castSucc, Fin.pred_succ,
+        Fin.succ_predAbove_succ]
+        rw [Fin.predAbove_above i _ (Fin.castSucc_lt_succ_iff.mpr _), Fin.pred_succ]
+        rcases le_or_lt k j with (hkj | hkj)
+        · rwa [Fin.predAbove_below _ _ (Fin.castSucc_le_castSucc_iff.mpr hkj),
+          Fin.castPred_castSucc]
+        · rw [Fin.predAbove_above _ _ (Fin.castSucc_lt_castSucc_iff.mpr hkj), Fin.le_pred_iff,
+          Fin.succ_le_castSucc_iff]
+          exact H.trans_lt hkj
+      · simp_rw [Fin.predAbove_below i.castSucc _ (Fin.castSucc_le_castSucc_iff.mpr
+        (Fin.succ_le_castSucc_iff.mpr h)), Fin.castPred_castSucc, ← Fin.succ_castSucc,
+        Fin.succ_predAbove_succ]
+        rw [Fin.predAbove_below _ k.castSucc (Fin.castSucc_le_castSucc_iff.mpr (h.le.trans H)),
+        Fin.castPred_castSucc, Fin.predAbove_below _ k.succ
+        (Fin.succ_le_castSucc_iff.mpr (H.trans_lt' h)), Fin.predAbove_below _ k.succ
+        (Fin.succ_le_castSucc_iff.mpr h)]
 #align simplex_category.σ_comp_σ SimplexCategory.σ_comp_σ
 
 /--
@@ -362,18 +391,29 @@ open Fin in
 lemma factor_δ_spec {m n : ℕ} (f : ([m] : SimplexCategory) ⟶ [n+1]) (j : Fin (n+2))
     (hj : ∀ (k : Fin (m+1)), f.toOrderHom k ≠ j) :
     factor_δ f j ≫ δ j = f := by
-  apply Hom.ext
-  ext k : 2
+  ext k : 3
   specialize hj k
-  rw [Ne.def, ext_iff] at hj
-  dsimp [factor_δ, δ, σ, succAbove, predAbove]
-  split <;> rename_i h0j
-  all_goals
-  · split <;> rename_i hjk <;>
-    simp only [← val_fin_lt,
-      coe_castSucc, coe_pred, coe_castLT, succ_pred, castSucc_castLT] at h0j hjk ⊢
-    · rw [if_neg]; omega
-    · rw [if_pos]; omega
+  dsimp [factor_δ, δ, σ]
+  cases' j using cases with j
+  · rw [predAbove_below _ _ (zero_le _), castPred_zero, predAbove_above 0 _
+    (castSucc_zero ▸ pos_of_ne_zero hj),
+    zero_succAbove, succ_pred]
+  · rw [predAbove_above 0 _ (castSucc_zero ▸ succ_pos _), pred_succ]
+    rcases hj.lt_or_lt with (hj | hj)
+    · rw [predAbove_below j _]
+      swap
+      · exact (le_castSucc_iff.mpr hj)
+      · rw [succAbove_below]
+        swap
+        · rwa [castSucc_lt_succ_iff, castPred_le_iff, le_castSucc_iff]
+        rw [castSucc_castPred]
+    · rw [predAbove_above]
+      swap
+      · exact (castSucc_lt_succ _).trans hj
+      rw [succAbove_above]
+      swap
+      · rwa [succ_le_castSucc_iff, lt_pred_iff]
+      rw [succ_pred]
 
 end Generators
 

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1251,7 +1251,7 @@ theorem rev_castPred (h : i ≠ last n) (h' := rev_ne_iff.mpr ((rev_zero _).symm
 
 theorem succ_castPred_eq_castPred_succ {a : Fin (n + 1)} (ha : a ≠ last n)
     (ha' := a.succ_ne_last_iff.mpr ha) :
-    succ (a.castPred ha) = (succ a).castPred (ha') := rfl
+    succ (a.castPred ha) = (succ a).castPred ha' := rfl
 
 theorem le_castPred_succ_iff {a b : Fin (n + 1)} (ha : succ a ≠ last (n + 1)) :
     (succ a).castPred ha ≤ b ↔ a < b := by

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1625,6 +1625,8 @@ theorem succAbove_lt_ge (p : Fin (n + 1)) (i : Fin n) : castSucc i < p ∨ p ≤
   lt_or_ge (castSucc i) p
 #align fin.succ_above_lt_ge Fin.succAbove_lt_ge
 
+@[deprecated castSucc_lt_or_lt_succ] alias succAbove_lt_gt := castSucc_lt_or_lt_succ
+
 /-- Embedding `i : Fin n` into `Fin (n + 1)` using a pivot `p` that is greater
 results in a value that is less than `p`. -/
 @[simp]

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -958,6 +958,10 @@ theorem castSucc_lt_succ_iff : castSucc a < succ b ↔ a ≤ b :=
 theorem le_of_castSucc_lt_of_succ_lt {a b : Fin (n + 1)} {i : Fin n}
     (hl : castSucc i < a) (hu : b < succ i) : b < a := (castSucc_lt_iff_succ_le.mp hl).trans_lt' hu
 
+theorem castSucc_lt_or_lt_succ (p : Fin (n + 1)) (i : Fin n) : castSucc i < p ∨ p < i.succ :=
+  (lt_or_le (castSucc i) p).imp id (fun h => le_castSucc_iff.mp h)
+#align fin.succ_above_lt_gt Fin.castSucc_lt_or_lt_succ
+
 theorem castSucc_injective (n : ℕ) : Injective (@Fin.castSucc n) :=
   (castSuccEmb : Fin n ↪o _).injective
 #align fin.cast_succ_injective Fin.castSucc_injective
@@ -1247,7 +1251,7 @@ theorem rev_castPred (h : i ≠ last n) (h' := rev_ne_iff.mpr ((rev_zero _).symm
 
 theorem succ_castPred_eq_castPred_succ {a : Fin (n + 1)} (ha : a ≠ last n)
     (ha' := a.succ_ne_last_iff.mpr ha) :
-    succ (a.castPred ha) = (succ a).castPred ha' := rfl
+    succ (a.castPred ha) = (succ a).castPred (ha') := rfl
 
 theorem le_castPred_succ_iff {a b : Fin (n + 1)} (ha : succ a ≠ last (n + 1)) :
     (succ a).castPred ha ≤ b ↔ a < b := by
@@ -1621,12 +1625,6 @@ theorem succAbove_lt_ge (p : Fin (n + 1)) (i : Fin n) : castSucc i < p ∨ p ≤
   lt_or_ge (castSucc i) p
 #align fin.succ_above_lt_ge Fin.succAbove_lt_ge
 
-/-- Embedding `i : Fin n` into `Fin (n + 1)` is always about some hole `p`. -/
-theorem succAbove_lt_gt (p : Fin (n + 1)) (i : Fin n) : castSucc i < p ∨ p < i.succ :=
-  Or.casesOn (succAbove_lt_ge p i) (fun h => Or.inl h) fun h =>
-    Or.inr (lt_of_le_of_lt h (castSucc_lt_succ i))
-#align fin.succ_above_lt_gt Fin.succAbove_lt_gt
-
 /-- Embedding `i : Fin n` into `Fin (n + 1)` using a pivot `p` that is greater
 results in a value that is less than `p`. -/
 @[simp]
@@ -1812,8 +1810,8 @@ section PredAbove
 
 /-- `predAbove p i` embeds `i : Fin (n+1)` into `Fin n` by subtracting one if `p < i`. -/
 def predAbove (p : Fin n) (i : Fin (n + 1)) : Fin n :=
-  if h : castSucc p < i then i.pred ((ne_iff_vne i 0).mpr (Nat.not_eq_zero_of_lt h))
-  else i.castLT (Nat.lt_of_le_of_lt (Nat.ge_of_not_lt h) p.2)
+  if h : castSucc p < i then pred i ((zero_le _).trans_lt h).ne'
+  else castPred i ((le_of_not_lt h).trans_lt (castSucc_lt_last _)).ne
 #align fin.pred_above Fin.predAbove
 
 theorem predAbove_right_monotone (p : Fin n) : Monotone p.predAbove := fun a b H => by
@@ -1847,14 +1845,14 @@ theorem predAbove_zero {i : Fin (n + 2)} (hi : i ≠ 0) : predAbove 0 i = i.pred
   exact pos_iff_ne_zero.mpr hi
 #align fin.pred_above_zero Fin.predAbove_zero
 
-theorem predAbove_below (p : Fin n) (i : Fin (n + 1)) (h : i ≤ castSucc p) :
-    p.predAbove i = i.castLT (h.trans_lt (castSucc_lt_last _)) := by
-  simp [predAbove, h.not_lt]
+theorem predAbove_below (p : Fin n) (i : Fin (n + 1)) (h : i ≤ castSucc p)
+    (hi := (h.trans_lt (castSucc_lt_last _)).ne) :
+    p.predAbove i = i.castPred hi := dif_neg h.not_lt
 #align fin.pred_above_below Fin.predAbove_below
 
-theorem predAbove_above (p : Fin n) (i : Fin (n + 1)) (h : castSucc p < i) :
-    p.predAbove i = i.pred ((zero_le <| castSucc p).trans_lt h).ne.symm := by
-  simp [predAbove, h]
+theorem predAbove_above (p : Fin n) (i : Fin (n + 1)) (h : castSucc p < i)
+    (hi := ((zero_le _).trans_lt h).ne') :
+    p.predAbove i = i.pred hi := dif_pos h
 #align fin.pred_above_above Fin.predAbove_above
 
 @[simp]
@@ -1863,7 +1861,7 @@ theorem predAbove_right_last : predAbove (i : Fin (n + 1)) (Fin.last (n + 1)) = 
 @[simp]
 theorem predAbove_last_castSucc {i : Fin (n + 1)} :
     predAbove (Fin.last n) (i.castSucc) = i := by
-  rw [predAbove_below _ _ ((castSucc_le_castSucc_iff).mpr (le_last _)), castLT_castSucc]
+  rw [predAbove_below _ _ ((castSucc_le_castSucc_iff).mpr (le_last _)), castPred_castSucc]
 @[simp]
 theorem predAbove_last_of_ne_last {i : Fin (n + 2)} (hi : i ≠ last (n + 1)):
     predAbove (Fin.last n) i = castPred i hi := by
@@ -1923,7 +1921,6 @@ theorem pred_succAbove_pred {a : Fin (n + 2)} {b : Fin (n + 1)} (ha : a ≠ 0) (
     (hk := succAbove_ne_zero ha hb) :
     (a.pred ha).succAbove (b.pred hb) = (a.succAbove b).pred hk := by
   obtain hbelow | habove := lt_or_le (castSucc b) a
-  -- `rwa` uses them
   · rw [Fin.succAbove_below]
     · rwa [castSucc_pred_eq_pred_castSucc, Fin.pred_inj, Fin.succAbove_below]
     · rwa [castSucc_pred_eq_pred_castSucc, pred_lt_pred_iff]
@@ -1937,20 +1934,11 @@ theorem pred_succAbove_pred {a : Fin (n + 2)} {b : Fin (n + 1)} (ha : a ≠ 0) (
 @[simp]
 theorem succ_predAbove_succ {n : ℕ} (a : Fin n) (b : Fin (n + 1)) :
     a.succ.predAbove b.succ = (a.predAbove b).succ := by
-  obtain h₁ | h₂ := lt_or_le (castSucc a) b
-  · rw [Fin.predAbove_above _ _ h₁, Fin.succ_pred, Fin.predAbove_above, Fin.pred_succ]
-    simpa only [lt_iff_val_lt_val, coe_castSucc, val_succ, add_lt_add_iff_right] using
-      h₁
-  · cases' n with n
-    · exfalso
-      exact not_lt_zero' a.is_lt
-    · rw [Fin.predAbove_below a b h₂,
-        Fin.predAbove_below a.succ b.succ
-          (by
-            simpa only [le_iff_val_le_val, val_succ, coe_castSucc, add_le_add_iff_right]
-              using h₂)]
-      ext
-      simp only [val_last, coe_castLT, val_succ]
+  obtain h | h := (lt_or_le (castSucc a) b)
+  · rw [Fin.predAbove_above _ _ h, succ_pred, Fin.predAbove_above, pred_succ]
+    rwa [castSucc_lt_succ_iff, ← castSucc_lt_iff_succ_le]
+  · rw [Fin.predAbove_below _ _ h, Fin.predAbove_below, succ_castPred_eq_castPred_succ]
+    rwa [succ_le_castSucc_iff, ← le_castSucc_iff]
 #align fin.succ_pred_above_succ Fin.succ_predAbove_succ
 
 end PredAbove


### PR DESCRIPTION
`predAbove` and `castPred` are no longer directly related. This patch makes it so that they are, removing `castLT` from the definition of `predAbove` and thus making it more directly analogous to `succAbove`.

---
`succAbove` also needs its definition changing. This will happen in a future patch. To prepare for this, a lemma that is currently in the `succAbove` section but independent of it has been moved out here.

#9780 and #9145 relates: this builds on the work of #9780 as part of breaking up #9145 into much smaller PRs.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
