### PR TITLE
[Merged by Bors] - feat(Analysis/NormedSpace/{ProdLp,PiLp}): add `BoundedSMul` instances

### DIFF
--- a/Mathlib/Analysis/Normed/MulAction.lean
+++ b/Mathlib/Analysis/Normed/MulAction.lean
@@ -78,6 +78,9 @@ theorem BoundedSMul.of_norm_smul_le (h : ∀ (r : α) (x : β), ‖r • x‖ �
     dist_pair_smul' := fun a₁ a₂ b => by simpa [sub_smul, dist_eq_norm] using h (a₁ - a₂) b }
 #align has_bounded_smul.of_norm_smul_le BoundedSMul.of_norm_smul_le
 
+theorem BoundedSMul.of_nnnorm_smul_le (h : ∀ (r : α) (x : β), ‖r • x‖₊ ≤ ‖r‖₊ * ‖x‖₊) :
+    BoundedSMul α β := .of_norm_smul_le h
+
 end SeminormedRing
 
 section NormedDivisionRing

--- a/Mathlib/Analysis/NormedSpace/PiLp.lean
+++ b/Mathlib/Analysis/NormedSpace/PiLp.lean
@@ -560,6 +560,12 @@ theorem nnnorm_eq_ciSup {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i
   simp [NNReal.coe_iSup, norm_eq_ciSup]
 #align pi_Lp.nnnorm_eq_csupr PiLp.nnnorm_eq_ciSup
 
+theorem nnnorm_equiv {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)] (f : PiLp ∞ β) :
+    ‖WithLp.equiv ⊤ _ f‖₊ = ‖f‖₊ := by
+  rw [nnnorm_eq_ciSup, Pi.nnnorm_def]
+  dsimp
+  rw [Finset]
+
 theorem norm_eq_of_nat {p : ℝ≥0∞} [Fact (1 ≤ p)] {β : ι → Type*}
     [∀ i, SeminormedAddCommGroup (β i)] (n : ℕ) (h : p = n) (f : PiLp p β) :
     ‖f‖ = (∑ i, ‖f i‖ ^ n) ^ (1 / (n : ℝ)) := by
@@ -607,6 +613,24 @@ theorem nndist_eq_of_L2 {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i
 theorem edist_eq_of_L2 {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)] (x y : PiLp 2 β) :
     edist x y = (∑ i, edist (x i) (y i) ^ 2) ^ (1 / 2 : ℝ) := by simp [PiLp.edist_eq_sum]
 #align pi_Lp.edist_eq_of_L2 PiLp.edist_eq_of_L2
+
+/-- The product of finitely many normed spaces is a normed space, with the `L^p` norm. -/
+instance instboundedSMul [NormedRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)] [∀ i, Module 𝕜 (β i)]
+    [∀ i, BoundedSMul 𝕜 (β i)] :
+    BoundedSMul 𝕜 (PiLp p β) :=
+  .of_norm_smul_le fun c f => by
+      rcases p.dichotomy with (rfl | hp)
+      · suffices ‖c • f‖₊ ≤ ‖c‖₊ * ‖f‖₊ from mod_cast NNReal.coe_mono this
+        rw [nnnorm_eq_ciSup, nnnorm_eq_ciSup, ←Finset.sup_univ_eq_ciSup]
+        convert nnnorm_smul_le c (WithLp.equiv ∞ (∀ i, β i) f)
+      · have : p.toReal * (1 / p.toReal) = 1 := mul_div_cancel' 1 (zero_lt_one.trans_le hp).ne'
+        -- Porting note: added to replace Pi.smul_apply
+        have smul_apply : ∀ i : ι, (c • f) i = c • (f i) := fun i => rfl
+        simp only [norm_eq_sum (zero_lt_one.trans_le hp), norm_smul, Real.mul_rpow, norm_nonneg, ←
+          Finset.mul_sum, smul_apply]
+        rw [mul_rpow (rpow_nonneg (norm_nonneg _) _), ← rpow_mul (norm_nonneg _), this,
+          Real.rpow_one]
+        exact Finset.sum_nonneg fun i _ => rpow_nonneg (norm_nonneg _) _ }
 
 variable [NormedField 𝕜] [NormedField 𝕜']
 

--- a/Mathlib/Analysis/NormedSpace/PiLp.lean
+++ b/Mathlib/Analysis/NormedSpace/PiLp.lean
@@ -562,9 +562,13 @@ theorem nnnorm_eq_ciSup {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i
 
 theorem nnnorm_equiv {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)] (f : PiLp ∞ β) :
     ‖WithLp.equiv ⊤ _ f‖₊ = ‖f‖₊ := by
-  rw [nnnorm_eq_ciSup, Pi.nnnorm_def]
-  dsimp
-  rw [Finset]
+  rw [nnnorm_eq_ciSup, Pi.nnnorm_def, Finset.sup_univ_eq_ciSup]
+  dsimp only [WithLp.equiv_pi_apply]
+
+
+theorem norm_equiv {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)] (f : PiLp ∞ β) :
+    ‖WithLp.equiv ⊤ _ f‖ = ‖f‖ :=
+  NNReal.eq <| nnnorm_equiv _
 
 theorem norm_eq_of_nat {p : ℝ≥0∞} [Fact (1 ≤ p)] {β : ι → Type*}
     [∀ i, SeminormedAddCommGroup (β i)] (n : ℕ) (h : p = n) (f : PiLp p β) :

--- a/Mathlib/Analysis/NormedSpace/PiLp.lean
+++ b/Mathlib/Analysis/NormedSpace/PiLp.lean
@@ -632,12 +632,12 @@ instance instboundedSMul [NormedRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)
     BoundedSMul 𝕜 (PiLp p β) :=
   .of_nnnorm_smul_le fun c f => by
     rcases p.dichotomy with (rfl | hp)
-    · rw [←nnnorm_equiv, ←nnnorm_equiv, WithLp.equiv_smul]
+    · rw [← nnnorm_equiv, ← nnnorm_equiv, WithLp.equiv_smul]
       exact nnnorm_smul_le c (WithLp.equiv ∞ (∀ i, β i) f)
     · have hp0 : 0 < p.toReal := zero_lt_one.trans_le hp
       have hpt : p ≠ ⊤ := p.toReal_pos_iff_ne_top.mp hp0
       rw [nnnorm_eq_sum hpt, nnnorm_eq_sum hpt, NNReal.rpow_one_div_le_iff hp0, NNReal.mul_rpow,
-        ←NNReal.rpow_mul, div_mul_cancel 1 hp0.ne', NNReal.rpow_one, Finset.mul_sum]
+        ← NNReal.rpow_mul, div_mul_cancel 1 hp0.ne', NNReal.rpow_one, Finset.mul_sum]
       -- Porting note: added to replace Pi.smul_apply
       have smul_apply : ∀ i : ι, (c • f) i = c • (f i) := fun i => rfl
       simp_rw [←NNReal.mul_rpow, smul_apply]
@@ -686,17 +686,9 @@ theorem neg_apply : (-x) i = -x i :=
 equivalence. -/
 def equivₗᵢ : PiLp ∞ β ≃ₗᵢ[𝕜] ∀ i, β i :=
   { WithLp.equiv ∞ (∀ i, β i) with
-    map_add' := fun f g => rfl
-    map_smul' := fun c f => rfl
-    norm_map' := fun f => by
-      suffices (Finset.univ.sup fun i => ‖f i‖₊) = ⨆ i, ‖f i‖₊ by
-        simpa only [NNReal.coe_iSup] using congr_arg ((↑) : ℝ≥0 → ℝ) this
-      refine'
-        antisymm (Finset.sup_le fun i _ => le_ciSup (Finite.bddAbove_range fun i => ‖f i‖₊) _) _
-      cases isEmpty_or_nonempty ι
-      · simp only [ciSup_of_empty, Finset.univ_eq_empty, Finset.sup_empty, le_rfl]
-      · -- Porting note: `Finset.le_sup` needed some helps
-        exact ciSup_le fun i => Finset.le_sup (f := fun k => ‖f k‖₊) (Finset.mem_univ i) }
+    map_add' := fun _f _g => rfl
+    map_smul' := fun _c _f => rfl
+    norm_map' := norm_equiv }
 #align pi_Lp.equivₗᵢ PiLp.equivₗᵢ
 
 variable {ι' : Type*}

--- a/Mathlib/Analysis/NormedSpace/PiLp.lean
+++ b/Mathlib/Analysis/NormedSpace/PiLp.lean
@@ -640,7 +640,7 @@ instance instboundedSMul [NormedRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)
         ← NNReal.rpow_mul, div_mul_cancel 1 hp0.ne', NNReal.rpow_one, Finset.mul_sum]
       -- Porting note: added to replace Pi.smul_apply
       have smul_apply : ∀ i : ι, (c • f) i = c • (f i) := fun i => rfl
-      simp_rw [←NNReal.mul_rpow, smul_apply]
+      simp_rw [← NNReal.mul_rpow, smul_apply]
       exact Finset.sum_le_sum fun i _ => NNReal.rpow_le_rpow (nnnorm_smul_le _ _) hp0.le
 
 /-- The product of finitely many normed spaces is a normed space, with the `L^p` norm. -/

--- a/Mathlib/Analysis/NormedSpace/PiLp.lean
+++ b/Mathlib/Analysis/NormedSpace/PiLp.lean
@@ -644,8 +644,8 @@ instance instboundedSMul [SeminormedRing 𝕜] [∀ i, SeminormedAddCommGroup (�
       exact Finset.sum_le_sum fun i _ => NNReal.rpow_le_rpow (nnnorm_smul_le _ _) hp0.le
 
 /-- The product of finitely many normed spaces is a normed space, with the `L^p` norm. -/
-instance normedSpace [NormedField 𝕜] [∀ i, SeminormedAddCommGroup (β i)] [∀ i, NormedSpace 𝕜 (β i)] :
-    NormedSpace 𝕜 (PiLp p β) where
+instance normedSpace [NormedField 𝕜] [∀ i, SeminormedAddCommGroup (β i)]
+    [∀ i, NormedSpace 𝕜 (β i)] : NormedSpace 𝕜 (PiLp p β) where
   norm_smul_le := norm_smul_le
 #align pi_Lp.normed_space PiLp.normedSpace
 

--- a/Mathlib/Analysis/NormedSpace/PiLp.lean
+++ b/Mathlib/Analysis/NormedSpace/PiLp.lean
@@ -554,30 +554,29 @@ theorem nnnorm_eq_sum {p : ℝ≥0∞} [Fact (1 ≤ p)] {β : ι → Type*} (hp 
   simp [NNReal.coe_sum, norm_eq_sum (p.toReal_pos_iff_ne_top.mpr hp)]
 #align pi_Lp.nnnorm_eq_sum PiLp.nnnorm_eq_sum
 
-theorem nnnorm_eq_ciSup {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)] (f : PiLp ∞ β) :
-    ‖f‖₊ = ⨆ i, ‖f i‖₊ := by
+section Linfty
+variable {β}
+variable [∀ i, SeminormedAddCommGroup (β i)]
+
+theorem nnnorm_eq_ciSup (f : PiLp ∞ β) : ‖f‖₊ = ⨆ i, ‖f i‖₊ := by
   ext
   simp [NNReal.coe_iSup, norm_eq_ciSup]
 #align pi_Lp.nnnorm_eq_csupr PiLp.nnnorm_eq_ciSup
 
-@[simp] theorem nnnorm_equiv {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)] (f : PiLp ∞ β) :
-    ‖WithLp.equiv ⊤ _ f‖₊ = ‖f‖₊ := by
+@[simp] theorem nnnorm_equiv (f : PiLp ∞ β) : ‖WithLp.equiv ⊤ _ f‖₊ = ‖f‖₊ := by
   rw [nnnorm_eq_ciSup, Pi.nnnorm_def, Finset.sup_univ_eq_ciSup]
   dsimp only [WithLp.equiv_pi_apply]
 
-@[simp] theorem nnnorm_equiv_symm {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)]
-    (f : ∀ i, β i) :
-    ‖(WithLp.equiv ⊤ _).symm f‖₊ = ‖f‖₊ :=
+@[simp] theorem nnnorm_equiv_symm (f : ∀ i, β i) : ‖(WithLp.equiv ⊤ _).symm f‖₊ = ‖f‖₊ :=
   (nnnorm_equiv _).symm
 
-@[simp] theorem norm_equiv {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)] (f : PiLp ∞ β) :
-    ‖WithLp.equiv ⊤ _ f‖ = ‖f‖ :=
+@[simp] theorem norm_equiv (f : PiLp ∞ β) : ‖WithLp.equiv ⊤ _ f‖ = ‖f‖ :=
   congr_arg NNReal.toReal <| nnnorm_equiv f
 
-@[simp] theorem norm_equiv_symm {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)]
-    (f : ∀ i, β i) :
-    ‖(WithLp.equiv ⊤ _).symm f‖ = ‖f‖ :=
+@[simp] theorem norm_equiv_symm (f : ∀ i, β i) : ‖(WithLp.equiv ⊤ _).symm f‖ = ‖f‖ :=
   (norm_equiv _).symm
+
+end Linfty
 
 theorem norm_eq_of_nat {p : ℝ≥0∞} [Fact (1 ≤ p)] {β : ι → Type*}
     [∀ i, SeminormedAddCommGroup (β i)] (n : ℕ) (h : p = n) (f : PiLp p β) :

--- a/Mathlib/Analysis/NormedSpace/PiLp.lean
+++ b/Mathlib/Analysis/NormedSpace/PiLp.lean
@@ -627,7 +627,7 @@ theorem edist_eq_of_L2 {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)
     edist x y = (∑ i, edist (x i) (y i) ^ 2) ^ (1 / 2 : ℝ) := by simp [PiLp.edist_eq_sum]
 #align pi_Lp.edist_eq_of_L2 PiLp.edist_eq_of_L2
 
-instance instboundedSMul [NormedRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)] [∀ i, Module 𝕜 (β i)]
+instance instboundedSMul [SeminormedRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)] [∀ i, Module 𝕜 (β i)]
     [∀ i, BoundedSMul 𝕜 (β i)] :
     BoundedSMul 𝕜 (PiLp p β) :=
   .of_nnnorm_smul_le fun c f => by
@@ -652,7 +652,7 @@ instance normedSpace [NormedField 𝕜] [∀ i, SeminormedAddCommGroup (β i)] [
 /- Register simplification lemmas for the applications of `PiLp` elements, as the usual lemmas
 for Pi types will not trigger. -/
 variable {𝕜 p α}
-variable [NormedCommRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)]
+variable [SeminormedRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)]
 variable [∀ i, Module 𝕜 (β i)] [∀ i, BoundedSMul 𝕜 (β i)] (c : 𝕜)
 
 variable (x y : PiLp p β) (x' y' : ∀ i, β i) (i : ι)

--- a/Mathlib/Analysis/NormedSpace/PiLp.lean
+++ b/Mathlib/Analysis/NormedSpace/PiLp.lean
@@ -85,7 +85,7 @@ protected theorem PiLp.ext {p : ℝ≥0∞} {ι : Type*} {α : ι → Type*} {x 
 
 namespace PiLp
 
-variable (p : ℝ≥0∞) (𝕜 𝕜' : Type*) {ι : Type*} (α : ι → Type*) (β : ι → Type*)
+variable (p : ℝ≥0∞) (𝕜 : Type*) {ι : Type*} (α : ι → Type*) (β : ι → Type*)
 
 /-! Note that the unapplied versions of these lemmas are deliberately omitted, as they break
 the use of the type synonym. -/
@@ -560,15 +560,24 @@ theorem nnnorm_eq_ciSup {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i
   simp [NNReal.coe_iSup, norm_eq_ciSup]
 #align pi_Lp.nnnorm_eq_csupr PiLp.nnnorm_eq_ciSup
 
-theorem nnnorm_equiv {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)] (f : PiLp ∞ β) :
+@[simp] theorem nnnorm_equiv {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)] (f : PiLp ∞ β) :
     ‖WithLp.equiv ⊤ _ f‖₊ = ‖f‖₊ := by
   rw [nnnorm_eq_ciSup, Pi.nnnorm_def, Finset.sup_univ_eq_ciSup]
   dsimp only [WithLp.equiv_pi_apply]
 
+@[simp] theorem nnnorm_equiv_symm {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)]
+    (f : ∀ i, β i) :
+    ‖(WithLp.equiv ⊤ _).symm f‖₊ = ‖f‖₊ :=
+  (nnnorm_equiv _).symm
 
-theorem norm_equiv {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)] (f : PiLp ∞ β) :
+@[simp] theorem norm_equiv {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)] (f : PiLp ∞ β) :
     ‖WithLp.equiv ⊤ _ f‖ = ‖f‖ :=
-  NNReal.eq <| nnnorm_equiv _
+  congr_arg NNReal.toReal <| nnnorm_equiv f
+
+@[simp] theorem norm_equiv_symm {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)]
+    (f : ∀ i, β i) :
+    ‖(WithLp.equiv ⊤ _).symm f‖ = ‖f‖ :=
+  (norm_equiv _).symm
 
 theorem norm_eq_of_nat {p : ℝ≥0∞} [Fact (1 ≤ p)] {β : ι → Type*}
     [∀ i, SeminormedAddCommGroup (β i)] (n : ℕ) (h : p = n) (f : PiLp p β) :
@@ -618,50 +627,33 @@ theorem edist_eq_of_L2 {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)
     edist x y = (∑ i, edist (x i) (y i) ^ 2) ^ (1 / 2 : ℝ) := by simp [PiLp.edist_eq_sum]
 #align pi_Lp.edist_eq_of_L2 PiLp.edist_eq_of_L2
 
-/-- The product of finitely many normed spaces is a normed space, with the `L^p` norm. -/
 instance instboundedSMul [NormedRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)] [∀ i, Module 𝕜 (β i)]
     [∀ i, BoundedSMul 𝕜 (β i)] :
     BoundedSMul 𝕜 (PiLp p β) :=
-  .of_norm_smul_le fun c f => by
-      rcases p.dichotomy with (rfl | hp)
-      · suffices ‖c • f‖₊ ≤ ‖c‖₊ * ‖f‖₊ from mod_cast NNReal.coe_mono this
-        rw [nnnorm_eq_ciSup, nnnorm_eq_ciSup, ←Finset.sup_univ_eq_ciSup]
-        convert nnnorm_smul_le c (WithLp.equiv ∞ (∀ i, β i) f)
-      · have : p.toReal * (1 / p.toReal) = 1 := mul_div_cancel' 1 (zero_lt_one.trans_le hp).ne'
-        -- Porting note: added to replace Pi.smul_apply
-        have smul_apply : ∀ i : ι, (c • f) i = c • (f i) := fun i => rfl
-        simp only [norm_eq_sum (zero_lt_one.trans_le hp), norm_smul, Real.mul_rpow, norm_nonneg, ←
-          Finset.mul_sum, smul_apply]
-        rw [mul_rpow (rpow_nonneg (norm_nonneg _) _), ← rpow_mul (norm_nonneg _), this,
-          Real.rpow_one]
-        exact Finset.sum_nonneg fun i _ => rpow_nonneg (norm_nonneg _) _ }
-
-variable [NormedField 𝕜] [NormedField 𝕜']
+  .of_nnnorm_smul_le fun c f => by
+    rcases p.dichotomy with (rfl | hp)
+    · rw [←nnnorm_equiv, ←nnnorm_equiv, WithLp.equiv_smul]
+      exact nnnorm_smul_le c (WithLp.equiv ∞ (∀ i, β i) f)
+    · have hp0 : 0 < p.toReal := zero_lt_one.trans_le hp
+      have hpt : p ≠ ⊤ := p.toReal_pos_iff_ne_top.mp hp0
+      rw [nnnorm_eq_sum hpt, nnnorm_eq_sum hpt, NNReal.rpow_one_div_le_iff hp0, NNReal.mul_rpow,
+        ←NNReal.rpow_mul, div_mul_cancel 1 hp0.ne', NNReal.rpow_one, Finset.mul_sum]
+      -- Porting note: added to replace Pi.smul_apply
+      have smul_apply : ∀ i : ι, (c • f) i = c • (f i) := fun i => rfl
+      simp_rw [←NNReal.mul_rpow, smul_apply]
+      exact Finset.sum_le_sum fun i _ => NNReal.rpow_le_rpow (nnnorm_smul_le _ _) hp0.le
 
 /-- The product of finitely many normed spaces is a normed space, with the `L^p` norm. -/
-instance normedSpace [∀ i, SeminormedAddCommGroup (β i)] [∀ i, NormedSpace 𝕜 (β i)] :
-    NormedSpace 𝕜 (PiLp p β) :=
-  { norm_smul_le := fun c f => by
-      rcases p.dichotomy with (rfl | hp)
-      · letI : Module 𝕜 (PiLp ∞ β) := Pi.module ι β 𝕜
-        suffices ‖c • f‖₊ = ‖c‖₊ * ‖f‖₊ from mod_cast NNReal.coe_mono this.le
-        simp only [nnnorm_eq_ciSup, NNReal.mul_iSup, ← nnnorm_smul]
-        -- Porting note: added
-        congr
-      · have : p.toReal * (1 / p.toReal) = 1 := mul_div_cancel' 1 (zero_lt_one.trans_le hp).ne'
-        -- Porting note: added to replace Pi.smul_apply
-        have smul_apply : ∀ i : ι, (c • f) i = c • (f i) := fun i => rfl
-        simp only [norm_eq_sum (zero_lt_one.trans_le hp), norm_smul, Real.mul_rpow, norm_nonneg, ←
-          Finset.mul_sum, smul_apply]
-        rw [mul_rpow (rpow_nonneg (norm_nonneg _) _), ← rpow_mul (norm_nonneg _), this,
-          Real.rpow_one]
-        exact Finset.sum_nonneg fun i _ => rpow_nonneg (norm_nonneg _) _ }
+instance normedSpace [NormedField 𝕜] [∀ i, SeminormedAddCommGroup (β i)] [∀ i, NormedSpace 𝕜 (β i)] :
+    NormedSpace 𝕜 (PiLp p β) where
+  norm_smul_le := norm_smul_le
 #align pi_Lp.normed_space PiLp.normedSpace
 
 /- Register simplification lemmas for the applications of `PiLp` elements, as the usual lemmas
 for Pi types will not trigger. -/
-variable {𝕜 𝕜' p α}
-variable [∀ i, SeminormedAddCommGroup (β i)] [∀ i, NormedSpace 𝕜 (β i)] (c : 𝕜)
+variable {𝕜 p α}
+variable [NormedCommRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)]
+variable [∀ i, Module 𝕜 (β i)] [∀ i, BoundedSMul 𝕜 (β i)] (c : 𝕜)
 
 variable (x y : PiLp p β) (x' y' : ∀ i, β i) (i : ι)
 
@@ -712,7 +704,7 @@ variable {ι' : Type*}
 variable [Fintype ι']
 
 variable (p 𝕜)
-variable (E : Type*) [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+variable (E : Type*) [NormedAddCommGroup E] [Module 𝕜 E] [BoundedSMul 𝕜 E]
 
 /-- An equivalence of finite domains induces a linearly isometric equivalence of finitely supported
 functions-/

--- a/Mathlib/Analysis/NormedSpace/PiLp.lean
+++ b/Mathlib/Analysis/NormedSpace/PiLp.lean
@@ -627,8 +627,8 @@ theorem edist_eq_of_L2 {β : ι → Type*} [∀ i, SeminormedAddCommGroup (β i)
     edist x y = (∑ i, edist (x i) (y i) ^ 2) ^ (1 / 2 : ℝ) := by simp [PiLp.edist_eq_sum]
 #align pi_Lp.edist_eq_of_L2 PiLp.edist_eq_of_L2
 
-instance instboundedSMul [SeminormedRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)] [∀ i, Module 𝕜 (β i)]
-    [∀ i, BoundedSMul 𝕜 (β i)] :
+instance instboundedSMul [SeminormedRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)]
+    [∀ i, Module 𝕜 (β i)] [∀ i, BoundedSMul 𝕜 (β i)] :
     BoundedSMul 𝕜 (PiLp p β) :=
   .of_nnnorm_smul_le fun c f => by
     rcases p.dichotomy with (rfl | hp)

--- a/Mathlib/Analysis/NormedSpace/PiLp.lean
+++ b/Mathlib/Analysis/NormedSpace/PiLp.lean
@@ -921,7 +921,8 @@ theorem basisFun_map :
 
 open Matrix
 
-nonrec theorem basis_toMatrix_basisFun_mul (b : Basis ι 𝕜 (PiLp p fun _ : ι => 𝕜))
+nonrec theorem basis_toMatrix_basisFun_mul
+    {𝕜} [SeminormedCommRing 𝕜] (b : Basis ι 𝕜 (PiLp p fun _ : ι => 𝕜))
     (A : Matrix ι ι 𝕜) :
     b.toMatrix (PiLp.basisFun _ _ _) * A =
       Matrix.of fun i j => b.repr ((WithLp.equiv _ _).symm (Aᵀ j)) i := by

--- a/Mathlib/Analysis/NormedSpace/ProdLp.lean
+++ b/Mathlib/Analysis/NormedSpace/ProdLp.lean
@@ -752,13 +752,13 @@ variable [SeminormedCommRing 𝕜] [Module 𝕜 α] [Module 𝕜 β] [BoundedSMu
 instance instProdBoundedSMul : BoundedSMul 𝕜 (WithLp p (α × β)) :=
   .of_nnnorm_smul_le fun c f => by
     rcases p.dichotomy with (rfl | hp)
-    · simp only [←prod_nnnorm_equiv, WithLp.equiv_smul]
+    · simp only [← prod_nnnorm_equiv, WithLp.equiv_smul]
       exact norm_smul_le _ _
     · have hp0 : 0 < p.toReal := zero_lt_one.trans_le hp
       have hpt : p ≠ ⊤ := p.toReal_pos_iff_ne_top.mp hp0
       rw [prod_nnnorm_eq_add hpt, prod_nnnorm_eq_add hpt, NNReal.rpow_one_div_le_iff hp0,
         NNReal.mul_rpow, ← NNReal.rpow_mul, div_mul_cancel 1 hp0.ne', NNReal.rpow_one, mul_add,
-        ←NNReal.mul_rpow, ←NNReal.mul_rpow]
+        ← NNReal.mul_rpow, ← NNReal.mul_rpow]
       exact add_le_add
         (NNReal.rpow_le_rpow (nnnorm_smul_le _ _) hp0.le)
         (NNReal.rpow_le_rpow (nnnorm_smul_le _ _) hp0.le)

--- a/Mathlib/Analysis/NormedSpace/ProdLp.lean
+++ b/Mathlib/Analysis/NormedSpace/ProdLp.lean
@@ -624,21 +624,16 @@ theorem prod_nnnorm_eq_sup (f : WithLp ∞ (α × β)) : ‖f‖₊ = ‖f.fst�
   ext
   norm_cast
 
-@[simp] theorem prod_nnnorm_equiv (f : WithLp ∞ (α × β)) :
-    ‖WithLp.equiv ⊤ _ f‖₊ = ‖f‖₊ := by
-  rw [prod_nnnorm_eq_sup, Prod.nnnorm_def', _root_.sup_eq_max]
-  rfl
+@[simp] theorem prod_nnnorm_equiv (f : WithLp ∞ (α × β)) : ‖WithLp.equiv ⊤ _ f‖₊ = ‖f‖₊ := by
+  rw [prod_nnnorm_eq_sup, Prod.nnnorm_def', _root_.sup_eq_max, equiv_fst, equiv_snd]
 
-@[simp] theorem prod_nnnorm_equiv_symm (f : α × β) :
-    ‖(WithLp.equiv ⊤ _).symm f‖₊ = ‖f‖₊ :=
+@[simp] theorem prod_nnnorm_equiv_symm (f : α × β) : ‖(WithLp.equiv ⊤ _).symm f‖₊ = ‖f‖₊ :=
   (prod_nnnorm_equiv _).symm
 
-@[simp] theorem prod_norm_equiv (f : WithLp ∞ (α × β)) :
-    ‖WithLp.equiv ⊤ _ f‖ = ‖f‖ :=
+@[simp] theorem prod_norm_equiv (f : WithLp ∞ (α × β)) : ‖WithLp.equiv ⊤ _ f‖ = ‖f‖ :=
   congr_arg NNReal.toReal <| prod_nnnorm_equiv f
 
-@[simp] theorem prod_norm_equiv_symm (f : α × β) :
-    ‖(WithLp.equiv ⊤ _).symm f‖ = ‖f‖ :=
+@[simp] theorem prod_norm_equiv_symm (f : α × β) : ‖(WithLp.equiv ⊤ _).symm f‖ = ‖f‖ :=
   (prod_norm_equiv _).symm
 
 theorem prod_norm_eq_of_L2 (x : WithLp 2 (α × β)) :

--- a/Mathlib/Analysis/NormedSpace/ProdLp.lean
+++ b/Mathlib/Analysis/NormedSpace/ProdLp.lean
@@ -624,6 +624,23 @@ theorem prod_nnnorm_eq_sup (f : WithLp ∞ (α × β)) : ‖f‖₊ = ‖f.fst�
   ext
   norm_cast
 
+@[simp] theorem prod_nnnorm_equiv (f : WithLp ∞ (α × β)) :
+    ‖WithLp.equiv ⊤ _ f‖₊ = ‖f‖₊ := by
+  rw [prod_nnnorm_eq_sup, Prod.nnnorm_def', _root_.sup_eq_max]
+  rfl
+
+@[simp] theorem prod_nnnorm_equiv_symm (f : α × β) :
+    ‖(WithLp.equiv ⊤ _).symm f‖₊ = ‖f‖₊ :=
+  (prod_nnnorm_equiv _).symm
+
+@[simp] theorem prod_norm_equiv (f : WithLp ∞ (α × β)) :
+    ‖WithLp.equiv ⊤ _ f‖ = ‖f‖ :=
+  congr_arg NNReal.toReal <| prod_nnnorm_equiv f
+
+@[simp] theorem prod_norm_equiv_symm (f : α × β) :
+    ‖(WithLp.equiv ⊤ _).symm f‖ = ‖f‖ :=
+  (prod_norm_equiv _).symm
+
 theorem prod_norm_eq_of_L2 (x : WithLp 2 (α × β)) :
     ‖x‖ = Real.sqrt (‖x.fst‖ ^ 2 + ‖x.snd‖ ^ 2) := by
   rw [prod_norm_eq_of_nat 2 (by norm_cast) _, Real.sqrt_eq_rpow]
@@ -729,25 +746,22 @@ theorem edist_equiv_symm_snd (y₁ y₂ : β) :
 
 end Single
 
-section NormedSpace
+section BoundedSMul
+variable [SeminormedCommRing 𝕜] [Module 𝕜 α] [Module 𝕜 β] [BoundedSMul 𝕜 α] [BoundedSMul 𝕜 β]
 
-variable [NormedField 𝕜] [NormedSpace 𝕜 α] [NormedSpace 𝕜 β]
-
-/-- The product of two normed spaces is a normed space, with the `L^p` norm. -/
-instance instProdNormedSpace : NormedSpace 𝕜 (WithLp p (α × β)) where
-  norm_smul_le c f := by
+instance instProdBoundedSMul : BoundedSMul 𝕜 (WithLp p (α × β)) :=
+  .of_nnnorm_smul_le fun c f => by
     rcases p.dichotomy with (rfl | hp)
-    · suffices ‖c • f‖₊ = ‖c‖₊ * ‖f‖₊ from mod_cast NNReal.coe_mono this.le
-      simp only [prod_nnnorm_eq_sup, NNReal.mul_sup, ← nnnorm_smul]
-      rfl
-    · have : p.toReal * (1 / p.toReal) = 1 := mul_div_cancel' 1 (zero_lt_one.trans_le hp).ne'
-      have smul_fst : (c • f).fst = c • f.fst := rfl
-      have smul_snd : (c • f).snd = c • f.snd := rfl
-      simp only [prod_norm_eq_add (zero_lt_one.trans_le hp), norm_smul, Real.mul_rpow,
-        norm_nonneg, smul_fst, smul_snd]
-      rw [← mul_add, mul_rpow (rpow_nonneg (norm_nonneg _) _),
-        ← rpow_mul (norm_nonneg _), this, Real.rpow_one]
-      positivity
+    · simp only [←prod_nnnorm_equiv, WithLp.equiv_smul]
+      exact norm_smul_le _ _
+    · have hp0 : 0 < p.toReal := zero_lt_one.trans_le hp
+      have hpt : p ≠ ⊤ := p.toReal_pos_iff_ne_top.mp hp0
+      rw [prod_nnnorm_eq_add hpt, prod_nnnorm_eq_add hpt, NNReal.rpow_one_div_le_iff hp0,
+        NNReal.mul_rpow, ← NNReal.rpow_mul, div_mul_cancel 1 hp0.ne', NNReal.rpow_one, mul_add,
+        ←NNReal.mul_rpow, ←NNReal.mul_rpow]
+      exact add_le_add
+        (NNReal.rpow_le_rpow (nnnorm_smul_le _ _) hp0.le)
+        (NNReal.rpow_le_rpow (nnnorm_smul_le _ _) hp0.le)
 
 variable {𝕜 p α β}
 
@@ -755,9 +769,18 @@ variable {𝕜 p α β}
 equivalence. -/
 def prodEquivₗᵢ : WithLp ∞ (α × β) ≃ₗᵢ[𝕜] α × β where
   __ := WithLp.equiv ∞ (α × β)
-  map_add' f g := rfl
-  map_smul' c f := rfl
-  norm_map' f := by simp [Norm.norm]
+  map_add' _f _g := rfl
+  map_smul' _c _f := rfl
+  norm_map' := prod_norm_equiv
+
+end BoundedSMul
+
+section NormedSpace
+
+/-- The product of two normed spaces is a normed space, with the `L^p` norm. -/
+instance instProdNormedSpace [NormedField 𝕜] [NormedSpace 𝕜 α] [NormedSpace 𝕜 β] :
+    NormedSpace 𝕜 (WithLp p (α × β)) where
+  norm_smul_le := norm_smul_le
 
 end NormedSpace
 

--- a/Mathlib/Analysis/NormedSpace/ProdLp.lean
+++ b/Mathlib/Analysis/NormedSpace/ProdLp.lean
@@ -747,7 +747,7 @@ theorem edist_equiv_symm_snd (y₁ y₂ : β) :
 end Single
 
 section BoundedSMul
-variable [SeminormedCommRing 𝕜] [Module 𝕜 α] [Module 𝕜 β] [BoundedSMul 𝕜 α] [BoundedSMul 𝕜 β]
+variable [SeminormedRing 𝕜] [Module 𝕜 α] [Module 𝕜 β] [BoundedSMul 𝕜 α] [BoundedSMul 𝕜 β]
 
 instance instProdBoundedSMul : BoundedSMul 𝕜 (WithLp p (α × β)) :=
   .of_nnnorm_smul_le fun c f => by

--- a/Mathlib/Order/ConditionallyCompleteLattice/Finset.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Finset.lean
@@ -16,7 +16,7 @@ import Mathlib.Data.Set.Finite
 
 open Set
 
-variable {α β γ : Type*}
+variable {ι α β γ : Type*}
 
 section ConditionallyCompleteLattice
 
@@ -74,6 +74,16 @@ theorem Set.Finite.lt_cInf_iff (hs : s.Finite) (h : s.Nonempty) : a < sInf s ↔
 #align set.finite.lt_cInf_iff Set.Finite.lt_cInf_iff
 
 end ConditionallyCompleteLinearOrder
+
+section ConditionallyCompleteLinearOrderBot
+variable [ConditionallyCompleteLinearOrderBot α]
+
+lemma Finset.sup_univ_eq_ciSup [Fintype ι] (f : ι → α) : univ.sup f = ⨆ i, f i :=
+  le_antisymm
+    (Finset.sup_le fun _ _ => le_ciSup (finite_range _).bddAbove _)
+    (ciSup_le' fun _ => Finset.le_sup (mem_univ _))
+
+end ConditionallyCompleteLinearOrderBot
 
 /-!
 ### Relation between `Sup` / `Inf` and `Finset.sup'` / `Finset.inf'`


### PR DESCRIPTION
Also adds:
* Lemmas linking the $L^\infty$ norm via `WithLp` to the standard one on products
* A new `BoundedSMul.of_nnnorm_smul_le` which eliminates all the positivity juggling.

In theory we could generalize even further to non-unital rings, but that would require more generalization of `WithLp`, and is trivial for someone to do later; the proofs here will still work.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
