### PR TITLE
[Merged by Bors] - chore: bump Std to leanprover/std4#421

### DIFF
--- a/Mathlib/Lean/Meta.lean
+++ b/Mathlib/Lean/Meta.lean
@@ -121,24 +121,6 @@ def countLocalHypsUsed [Monad m] [MonadLCtx m] [MonadMCtx m] (e : Expr) : m Nat 
   let e' ← instantiateMVars e
   return (← getLocalHyps).toList.countP fun h => h.occurs e'
 
-/--
-Given a monadic function `F` that takes a type and a term of that type and produces a new term,
-lifts this to the monadic function that opens a `∀` telescope, applies `F` to the body,
-and then builds the lambda telescope term for the new term.
--/
-def mapForallTelescope' (F : Expr → Expr → MetaM Expr) (forallTerm : Expr) : MetaM Expr := do
-  forallTelescope (← Meta.inferType forallTerm) fun xs ty => do
-    Meta.mkLambdaFVars xs (← F ty (mkAppN forallTerm xs))
-
-/--
-Given a monadic function `F` that takes a term and produces a new term,
-lifts this to the monadic function that opens a `∀` telescope, applies `F` to the body,
-and then builds the lambda telescope term for the new term.
--/
-def mapForallTelescope (F : Expr → MetaM Expr) (forallTerm : Expr) : MetaM Expr := do
-  mapForallTelescope' (fun _ e => F e) forallTerm
-
-
 /-- Get the type the given metavariable after instantiating metavariables and cleaning up
 annotations. -/
 def _root_.Lean.MVarId.getType'' (mvarId : MVarId) : MetaM Expr :=

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/std4",
    "type": "git",
    "subDir": null,
-   "rev": "ca91956e8d5c311e00d6a69eb93d5eb5eef9b37d",
+   "rev": "1d85fd7db28700b28043d6370dd1ebc426de4d5d",
    "name": "std",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
This brings the new implementation of `library_search` to Mathlib. It is temporarily called `std_exact?` and `std_apply?`, but if it tests okay in Mathlib we will remove the old implementation.

There is some change in the ordering of results, so please report on your experiences!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
