### PR TITLE
[Merged by Bors] - chore: Lean PR bot adds full-ci label on failure

### DIFF
--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -56,14 +56,15 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
       -H "Authorization: Bearer $TOKEN" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       https://api.github.com/repos/leanprover/lean4/issues/$pr_number/labels/builds-mathlib
-    echo "Adding label breaks-mathlib"
+    echo "Adding labels breaks-mathlib and full-ci"
+    # We also add the 'full-ci' label, as fixing a Mathlib breakage may require toolchains for all OSes
     curl -L -s \
       -X POST \
       -H "Accept: application/vnd.github+json" \
       -H "Authorization: Bearer $TOKEN" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       https://api.github.com/repos/leanprover/lean4/issues/$pr_number/labels \
-      -d '{"labels":["breaks-mathlib"]}'
+      -d '{"labels":["breaks-mathlib", "full-ci"]}'
   fi
 
   # Use GitHub API to check if a comment already exists


### PR DESCRIPTION
If a `lean-pr-testing-NNNN` branch fails, add the label `full-ci` to leanprover/lean4#NNNN (we already add the `breaks-mathlib` label), so that when a human arrives to diagnose the problem toolchains for all OSs are available.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
