### PR TITLE
[Merged by Bors] - feat: Add `Module.Free` and `Module.Finite` instances for ideals

### DIFF
--- a/Mathlib/LinearAlgebra/FreeModule/PID.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/PID.lean
@@ -684,13 +684,6 @@ instance [Module.Free R S] [Module.Finite R S] (I : Ideal S) :
     exact Module.Free.of_subsingleton R I
   · exact Module.Free.of_basis (I.selfBasis (Module.Free.chooseBasis R S) hI)
 
-instance [Module.Free R S] [Module.Finite R S] (I : Ideal S) :
-    Module.Finite R I := by
-  by_cases hI : I = ⊥
-  · have : Subsingleton I := Submodule.subsingleton_iff_eq_bot.mpr hI
-    exact Module.IsNoetherian.finite R I
-  · exact Module.Finite.of_basis (I.selfBasis (Module.Free.chooseBasis R S) hI)
-
 end Ideal
 
 end SmithNormal

--- a/Mathlib/LinearAlgebra/FreeModule/PID.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/PID.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
-import Mathlib.LinearAlgebra.FreeModule.Basic
+import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
 
 #align_import linear_algebra.free_module.pid from "leanprover-community/mathlib"@"d87199d51218d36a0a42c66c82d147b5a7ff87b3"
 
@@ -676,6 +676,20 @@ theorem Ideal.smithCoeffs_ne_zero (b : Basis ι R S) (I : Ideal S) (hI : I ≠ �
 
 -- porting note: can be inferred in Lean 4 so no longer necessary
 #noalign has_quotient.quotient.module
+
+instance [Module.Free R S] [Module.Finite R S] (I : Ideal S) :
+    Module.Free R I := by
+  by_cases hI : I = ⊥
+  · have : Subsingleton I := Submodule.subsingleton_iff_eq_bot.mpr hI
+    exact Module.Free.of_subsingleton R I
+  · exact Module.Free.of_basis (I.selfBasis (Module.Free.chooseBasis R S) hI)
+
+instance [Module.Free R S] [Module.Finite R S] (I : Ideal S) :
+    Module.Finite R I := by
+  by_cases hI : I = ⊥
+  · have : Subsingleton I := Submodule.subsingleton_iff_eq_bot.mpr hI
+    exact Module.IsNoetherian.finite R I
+  · exact Module.Finite.of_basis (I.selfBasis (Module.Free.chooseBasis R S) hI)
 
 end Ideal
 

--- a/Mathlib/LinearAlgebra/FreeModule/PID.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/PID.lean
@@ -413,6 +413,13 @@ instance Module.free_of_finite_type_torsion_free' [Module.Finite R M] [NoZeroSMu
   exact Module.Free.of_basis b
 #align module.free_of_finite_type_torsion_free' Module.free_of_finite_type_torsion_free'
 
+instance {S : Type*} [CommRing S] [Algebra R S] {I : Ideal S} [hI₁ : Module.Finite R I]
+    [hI₂ : NoZeroSMulDivisors R I] : Module.Free R I := by
+  have : Module.Finite R (restrictScalars R I) := hI₁
+  have : NoZeroSMulDivisors R (restrictScalars R I) := hI₂
+  change Module.Free R (restrictScalars R I)
+  exact Module.free_of_finite_type_torsion_free'
+
 theorem Module.free_iff_noZeroSMulDivisors [Module.Finite R M] :
     Module.Free R M ↔ NoZeroSMulDivisors R M :=
   ⟨fun _ ↦ inferInstance, fun _ ↦ inferInstance⟩
@@ -676,13 +683,6 @@ theorem Ideal.smithCoeffs_ne_zero (b : Basis ι R S) (I : Ideal S) (hI : I ≠ �
 
 -- porting note: can be inferred in Lean 4 so no longer necessary
 #noalign has_quotient.quotient.module
-
-instance [Module.Free R S] [Module.Finite R S] (I : Ideal S) :
-    Module.Free R I := by
-  by_cases hI : I = ⊥
-  · have : Subsingleton I := Submodule.subsingleton_iff_eq_bot.mpr hI
-    exact Module.Free.of_subsingleton R I
-  · exact Module.Free.of_basis (I.selfBasis (Module.Free.chooseBasis R S) hI)
 
 end Ideal
 

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -829,6 +829,10 @@ theorem mul_eq_bot {R : Type*} [CommSemiring R] [NoZeroDivisors R] {I J : Ideal 
 instance {R : Type*} [CommSemiring R] [NoZeroDivisors R] : NoZeroDivisors (Ideal R) where
   eq_zero_or_eq_zero_of_mul_eq_zero := mul_eq_bot.1
 
+instance {R : Type*} [CommSemiring R] {S : Type*} [CommRing S] [Algebra R S]
+    [NoZeroSMulDivisors R S] {I : Ideal S} : NoZeroSMulDivisors R I :=
+  Submodule.noZeroSMulDivisors (Submodule.restrictScalars R I)
+
 /-- A product of ideals in an integral domain is zero if and only if one of the terms is zero. -/
 @[simp]
 lemma multiset_prod_eq_bot {R : Type*} [CommRing R] [IsDomain R] {s : Multiset (Ideal R)} :

--- a/Mathlib/RingTheory/Noetherian.lean
+++ b/Mathlib/RingTheory/Noetherian.lean
@@ -157,6 +157,10 @@ instance (priority := 100) IsNoetherian.finite [IsNoetherian R M] : Finite R M :
   ⟨IsNoetherian.noetherian ⊤⟩
 #align module.is_noetherian.finite Module.IsNoetherian.finite
 
+instance {R₁ S : Type*} [CommSemiring R₁] [Semiring S] [Algebra R₁ S]
+    [IsNoetherian R₁ S] (I : Ideal S) : Module.Finite R₁ I :=
+  Module.IsNoetherian.finite R₁ ((I : Submodule S S).restrictScalars R₁)
+
 variable {R M}
 
 theorem Finite.of_injective [IsNoetherian R N] (f : M →ₗ[R] N) (hf : Function.Injective f) :

--- a/Mathlib/RingTheory/Noetherian.lean
+++ b/Mathlib/RingTheory/Noetherian.lean
@@ -158,8 +158,8 @@ instance (priority := 100) IsNoetherian.finite [IsNoetherian R M] : Finite R M :
 #align module.is_noetherian.finite Module.IsNoetherian.finite
 
 instance {R₁ S : Type*} [CommSemiring R₁] [Semiring S] [Algebra R₁ S]
-    [IsNoetherian R₁ S] (I : Ideal S) : Module.Finite R₁ I :=
-  Module.IsNoetherian.finite R₁ ((I : Submodule S S).restrictScalars R₁)
+    [IsNoetherian R₁ S] (I : Ideal S) : Finite R₁ I :=
+  IsNoetherian.finite R₁ ((I : Submodule S S).restrictScalars R₁)
 
 variable {R M}
 


### PR DESCRIPTION
Add also a `NoZeroSMulDivisors` instance.

These instances, in particular, imply directly that integral ideals of number fields are free and finite $\mathbb{Z}$-modules. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
