### PR TITLE
[Merged by Bors] - feat: lint for large files

### DIFF
--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -51,6 +51,7 @@ ERR_TWS = 15 # trailing whitespace
 ERR_CLN = 16 # line starts with a colon
 ERR_IND = 17 # second line not correctly indented
 ERR_ARR = 18 # space after "←"
+ERR_NUM_LIN = 19 # file is too large
 
 exceptions = []
 
@@ -74,6 +75,8 @@ with SCRIPTS_DIR.joinpath("style-exceptions.txt").open(encoding="utf-8") as f:
             exceptions += [(ERR_AUT, path)]
         if errno == "ERR_TAC":
             exceptions += [(ERR_TAC, path)]
+        if errno == "ERR_NUM_LIN":
+            exceptions += [(ERR_NUM_LIN, path)]
 
 new_exceptions = False
 
@@ -377,6 +380,10 @@ def lint(path, fix=False):
             format_errors(errs)
 
         if not import_only_check(newlines, path):
+            if len(lines) > 1500:
+                if (ERR_NUM_LIN, path.resolve()) not in exceptions:
+                    new_exceptions = True
+                    output_message(path, 0, "ERR_NUM_LIN", f"file contains {len(lines)} lines, try to split it up")
             errs, newlines = regular_check(newlines, path)
             format_errors(errs)
             errs, newlines = banned_import_check(newlines, path)

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -61,22 +61,22 @@ ROOT_DIR = SCRIPTS_DIR.parent
 
 with SCRIPTS_DIR.joinpath("style-exceptions.txt").open(encoding="utf-8") as f:
     for exline in f:
-        filename, _, _, _, _, errno, *_ = exline.split()
+        filename, _, _, _, _, errno, *extra = exline.split()
         path = ROOT_DIR / filename
         if errno == "ERR_COP":
-            exceptions += [(ERR_COP, path)]
+            exceptions += [(ERR_COP, path, None)]
         if errno == "ERR_MOD":
-            exceptions += [(ERR_MOD, path)]
+            exceptions += [(ERR_MOD, path, None)]
         if errno == "ERR_LIN":
-            exceptions += [(ERR_LIN, path)]
+            exceptions += [(ERR_LIN, path, None)]
         if errno == "ERR_OPT":
-            exceptions += [(ERR_OPT, path)]
+            exceptions += [(ERR_OPT, path, None)]
         if errno == "ERR_AUT":
-            exceptions += [(ERR_AUT, path)]
+            exceptions += [(ERR_AUT, path, None)]
         if errno == "ERR_TAC":
-            exceptions += [(ERR_TAC, path)]
+            exceptions += [(ERR_TAC, path, None)]
         if errno == "ERR_NUM_LIN":
-            exceptions += [(ERR_NUM_LIN, path)]
+            exceptions += [(ERR_NUM_LIN, path, extra[1])]
 
 new_exceptions = False
 
@@ -331,7 +331,7 @@ def output_message(path, line_nr, code, msg):
 def format_errors(errors):
     global new_exceptions
     for errno, line_nr, path in errors:
-        if (errno, path.resolve()) in exceptions:
+        if (errno, path.resolve(), None) in exceptions:
             continue
         new_exceptions = True
         if errno == ERR_COP:
@@ -380,10 +380,21 @@ def lint(path, fix=False):
             format_errors(errs)
 
         if not import_only_check(newlines, path):
+            # Check for too long files: either longer than 1500 lines, or not covered by an exception.
+            # Each exception contains a "watermark". If the file is longer than that, we also complain.
             if len(lines) > 1500:
-                if (ERR_NUM_LIN, path.resolve()) not in exceptions:
+                ex = [e for e in exceptions if e[1] == path.resolve()]
+                if ex:
+                    (_ERR_NUM, _path, watermark) = list(ex)[0]
+                    assert int(watermark) > 500 # protect against parse error
+                    is_too_long = len(lines) > int(watermark)
+                else:
+                    is_too_long = True
+                if is_too_long:
                     new_exceptions = True
-                    output_message(path, 0, "ERR_NUM_LIN", f"file contains {len(lines)} lines, try to split it up")
+                    # add up to 200 lines of slack, so simple PRs don't trigger this right away
+                    watermark = 100* int(len(lines) / 100) + 200
+                    output_message(path, 1, "ERR_NUM_LIN", f"{watermark} file contains {len(lines)} lines, try to split it up")
             errs, newlines = regular_check(newlines, path)
             format_errors(errs)
             errs, newlines = banned_import_check(newlines, path)

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -393,7 +393,7 @@ def lint(path, fix=False):
                 if is_too_long:
                     new_exceptions = True
                     # add up to 200 lines of slack, so simple PRs don't trigger this right away
-                    watermark = 100* int(len(lines) / 100) + 200
+                    watermark = len(lines) // 100 * 100 + 200
                     output_message(path, 1, "ERR_NUM_LIN", f"{watermark} file contains {len(lines)} lines, try to split it up")
             errs, newlines = regular_check(newlines, path)
             format_errors(errs)

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -32,7 +32,7 @@ Mathlib/Data/ByteArray.lean : line 5 : ERR_COP : Malformed or missing copyright 
 Mathlib/Data/ByteArray.lean : line 5 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Data/Complex/Exponential.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2046 lines, try to split it up
 Mathlib/Data/DFinsupp/Basic.lean : line 1 : ERR_NUM_LIN : 2500 file contains 2395 lines, try to split it up
-Mathlib/Data/Fin/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2020 lines, try to split it up
+Mathlib/Data/Fin/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2010 lines, try to split it up
 Mathlib/Data/Finset/Basic.lean : line 1 : ERR_NUM_LIN : 4100 file contains 3992 lines, try to split it up
 Mathlib/Data/Finset/Lattice.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2240 lines, try to split it up
 Mathlib/Data/Finset/Pointwise.lean : line 1 : ERR_NUM_LIN : 2700 file contains 2550 lines, try to split it up
@@ -117,9 +117,9 @@ Mathlib/Order/LiminfLimsup.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1504
 Mathlib/Order/LocallyFinite.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1534 lines, try to split it up
 Mathlib/Order/SuccPred/Basic.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1560 lines, try to split it up
 Mathlib/Order/UpperLower/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2019 lines, try to split it up
-Mathlib/RingTheory/FractionalIdeal.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1624 lines, try to split it up
+Mathlib/RingTheory/FractionalIdeal/Basic.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1691 lines, try to split it up
 Mathlib/RingTheory/HahnSeries.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1835 lines, try to split it up
-Mathlib/RingTheory/Ideal/Operations.lean : line 1 : ERR_NUM_LIN : 2600 file contains 2410 lines, try to split it up
+Mathlib/RingTheory/Ideal/Operations.lean : line 1 : ERR_NUM_LIN : 2600 file contains 2414 lines, try to split it up
 Mathlib/RingTheory/PowerSeries/Basic.lean : line 1 : ERR_NUM_LIN : 3000 file contains 2865 lines, try to split it up
 Mathlib/RingTheory/Subring/Basic.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1546 lines, try to split it up
 Mathlib/RingTheory/UniqueFactorizationDomain.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2066 lines, try to split it up
@@ -160,7 +160,7 @@ Mathlib/Tactic/TypeCheck.lean : line 3 : ERR_COP : Malformed or missing copyrigh
 Mathlib/Tactic/TypeCheck.lean : line 3 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Topology/Algebra/Group/Basic.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2231 lines, try to split it up
 Mathlib/Topology/Algebra/InfiniteSum/Basic.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1665 lines, try to split it up
-Mathlib/Topology/Algebra/Module/Basic.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2757 lines, try to split it up
+Mathlib/Topology/Algebra/Module/Basic.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2767 lines, try to split it up
 Mathlib/Topology/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2072 lines, try to split it up
 Mathlib/Topology/Category/Profinite/Nobeling.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1831 lines, try to split it up
 Mathlib/Topology/Constructions.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1731 lines, try to split it up

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -32,6 +32,7 @@ Mathlib/Data/ByteArray.lean : line 5 : ERR_COP : Malformed or missing copyright 
 Mathlib/Data/ByteArray.lean : line 5 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Data/Complex/Exponential.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2046 lines, try to split it up
 Mathlib/Data/DFinsupp/Basic.lean : line 1 : ERR_NUM_LIN : 2500 file contains 2395 lines, try to split it up
+Mathlib/Data/ENNReal/Basic.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2716 lines, try to split it up
 Mathlib/Data/Fin/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2010 lines, try to split it up
 Mathlib/Data/Finset/Basic.lean : line 1 : ERR_NUM_LIN : 4100 file contains 3992 lines, try to split it up
 Mathlib/Data/Finset/Lattice.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2240 lines, try to split it up
@@ -48,14 +49,13 @@ Mathlib/Data/Ordmap/Ordset.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1795
 Mathlib/Data/Polynomial/Degree/Definitions.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1689 lines, try to split it up
 Mathlib/Data/Polynomial/RingDivision.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1569 lines, try to split it up
 Mathlib/Data/QPF/Multivariate/Basic.lean : line 75 : ERR_LIN : Line has more than 100 characters
-Mathlib/Data/Real/ENNReal.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2716 lines, try to split it up
 Mathlib/Data/Seq/WSeq.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1825 lines, try to split it up
-Mathlib/Data/Set/Basic.lean : line 1 : ERR_NUM_LIN : 3200 file contains 3041 lines, try to split it up
+Mathlib/Data/Set/Basic.lean : line 1 : ERR_NUM_LIN : 3100 file contains 2991 lines, try to split it up
 Mathlib/Data/Set/Finite.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1768 lines, try to split it up
-Mathlib/Data/Set/Function.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1930 lines, try to split it up
-Mathlib/Data/Set/Image.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1685 lines, try to split it up
+Mathlib/Data/Set/Function.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1858 lines, try to split it up
+Mathlib/Data/Set/Image.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1613 lines, try to split it up
 Mathlib/Data/Set/Intervals/Basic.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1970 lines, try to split it up
-Mathlib/Data/Set/Lattice.lean : line 1 : ERR_NUM_LIN : 2600 file contains 2409 lines, try to split it up
+Mathlib/Data/Set/Lattice.lean : line 1 : ERR_NUM_LIN : 2500 file contains 2388 lines, try to split it up
 Mathlib/Data/String/Lemmas.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Data/UInt.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/UInt.lean : line 1 : ERR_COP : Malformed or missing copyright header
@@ -69,7 +69,7 @@ Mathlib/Data/UInt.lean : line 8 : ERR_MOD : Module docstring missing, or too lat
 Mathlib/Data/UnionFind.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/FieldTheory/RatFunc.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1781 lines, try to split it up
 Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1607 lines, try to split it up
-Mathlib/GroupTheory/MonoidLocalization.lean : line 1 : ERR_NUM_LIN : 2300 file contains 2110 lines, try to split it up
+Mathlib/GroupTheory/MonoidLocalization.lean : line 1 : ERR_NUM_LIN : 2300 file contains 2153 lines, try to split it up
 Mathlib/GroupTheory/Perm/Cycle/Basic.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1980 lines, try to split it up
 Mathlib/GroupTheory/Subgroup/Basic.lean : line 1 : ERR_NUM_LIN : 4000 file contains 3878 lines, try to split it up
 Mathlib/GroupTheory/Submonoid/Operations.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1561 lines, try to split it up
@@ -105,9 +105,9 @@ Mathlib/MeasureTheory/MeasurableSpace/Basic.lean : line 1 : ERR_NUM_LIN : 2400 f
 Mathlib/MeasureTheory/Measure/MeasureSpace.lean : line 1 : ERR_NUM_LIN : 2300 file contains 2191 lines, try to split it up
 Mathlib/MeasureTheory/Measure/OuterMeasure.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1785 lines, try to split it up
 Mathlib/MeasureTheory/Measure/Typeclasses.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1564 lines, try to split it up
-Mathlib/Order/Basic.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1586 lines, try to split it up
+Mathlib/Order/Basic.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1547 lines, try to split it up
 Mathlib/Order/Bounds/Basic.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1714 lines, try to split it up
-Mathlib/Order/CompleteLattice.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2096 lines, try to split it up
+Mathlib/Order/CompleteLattice.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2091 lines, try to split it up
 Mathlib/Order/ConditionallyCompleteLattice/Basic.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1727 lines, try to split it up
 Mathlib/Order/Filter/AtTopBot.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2068 lines, try to split it up
 Mathlib/Order/Filter/Basic.lean : line 1 : ERR_NUM_LIN : 3500 file contains 3373 lines, try to split it up
@@ -160,15 +160,15 @@ Mathlib/Tactic/TypeCheck.lean : line 3 : ERR_COP : Malformed or missing copyrigh
 Mathlib/Tactic/TypeCheck.lean : line 3 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Topology/Algebra/Group/Basic.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2231 lines, try to split it up
 Mathlib/Topology/Algebra/InfiniteSum/Basic.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1665 lines, try to split it up
-Mathlib/Topology/Algebra/Module/Basic.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2767 lines, try to split it up
+Mathlib/Topology/Algebra/Module/Basic.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2768 lines, try to split it up
 Mathlib/Topology/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2072 lines, try to split it up
 Mathlib/Topology/Category/Profinite/Nobeling.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1831 lines, try to split it up
 Mathlib/Topology/Constructions.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1731 lines, try to split it up
 Mathlib/Topology/ContinuousFunction/Bounded.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1649 lines, try to split it up
 Mathlib/Topology/Instances/ENNReal.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1713 lines, try to split it up
 Mathlib/Topology/MetricSpace/HausdorffDistance.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1543 lines, try to split it up
-Mathlib/Topology/MetricSpace/PseudoMetric.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2227 lines, try to split it up
+Mathlib/Topology/MetricSpace/PseudoMetric.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2098 lines, try to split it up
 Mathlib/Topology/Order/Basic.lean : line 1 : ERR_NUM_LIN : 3100 file contains 2983 lines, try to split it up
 Mathlib/Topology/PartialHomeomorph.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1513 lines, try to split it up
-Mathlib/Topology/Separation.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2275 lines, try to split it up
+Mathlib/Topology/Separation.lean : line 1 : ERR_NUM_LIN : 2500 file contains 2306 lines, try to split it up
 Mathlib/Topology/UniformSpace/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2018 lines, try to split it up

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -1,3 +1,24 @@
+Mathlib/Algebra/Algebra/Subalgebra/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1511 lines, try to split it up
+Mathlib/Algebra/BigOperators/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2675 lines, try to split it up
+Mathlib/Algebra/Lie/Submodule.lean : line 0 : ERR_NUM_LIN : file contains 1528 lines, try to split it up
+Mathlib/Algebra/MonoidAlgebra/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2158 lines, try to split it up
+Mathlib/Algebra/Order/Floor.lean : line 0 : ERR_NUM_LIN : file contains 1822 lines, try to split it up
+Mathlib/Algebra/Order/Monoid/Lemmas.lean : line 0 : ERR_NUM_LIN : file contains 1709 lines, try to split it up
+Mathlib/Algebra/Quaternion.lean : line 0 : ERR_NUM_LIN : file contains 1509 lines, try to split it up
+Mathlib/Analysis/Asymptotics/Asymptotics.lean : line 0 : ERR_NUM_LIN : file contains 2306 lines, try to split it up
+Mathlib/Analysis/Calculus/ContDiff/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2111 lines, try to split it up
+Mathlib/Analysis/Calculus/ContDiff/Defs.lean : line 0 : ERR_NUM_LIN : file contains 1728 lines, try to split it up
+Mathlib/Analysis/Convolution.lean : line 0 : ERR_NUM_LIN : file contains 1545 lines, try to split it up
+Mathlib/Analysis/InnerProductSpace/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2367 lines, try to split it up
+Mathlib/Analysis/Normed/Group/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2815 lines, try to split it up
+Mathlib/Analysis/NormedSpace/OperatorNorm.lean : line 0 : ERR_NUM_LIN : file contains 2033 lines, try to split it up
+Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean : line 0 : ERR_NUM_LIN : file contains 2118 lines, try to split it up
+Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean : line 0 : ERR_NUM_LIN : file contains 2728 lines, try to split it up
+Mathlib/Combinatorics/SimpleGraph/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1625 lines, try to split it up
+Mathlib/Combinatorics/SimpleGraph/Connectivity.lean : line 0 : ERR_NUM_LIN : file contains 2653 lines, try to split it up
+Mathlib/Computability/Primrec.lean : line 0 : ERR_NUM_LIN : file contains 1568 lines, try to split it up
+Mathlib/Computability/TMToPartrec.lean : line 0 : ERR_NUM_LIN : file contains 2069 lines, try to split it up
+Mathlib/Computability/TuringMachine.lean : line 0 : ERR_NUM_LIN : file contains 2821 lines, try to split it up
 Mathlib/Data/Array/Basic.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/Array/Basic.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/Array/Basic.lean : line 3 : ERR_COP : Malformed or missing copyright header
@@ -9,9 +30,32 @@ Mathlib/Data/ByteArray.lean : line 2 : ERR_COP : Malformed or missing copyright 
 Mathlib/Data/ByteArray.lean : line 3 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/ByteArray.lean : line 5 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/ByteArray.lean : line 5 : ERR_MOD : Module docstring missing, or too late
+Mathlib/Data/Complex/Exponential.lean : line 0 : ERR_NUM_LIN : file contains 2046 lines, try to split it up
+Mathlib/Data/DFinsupp/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2395 lines, try to split it up
+Mathlib/Data/Fin/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2020 lines, try to split it up
+Mathlib/Data/Finset/Basic.lean : line 0 : ERR_NUM_LIN : file contains 3992 lines, try to split it up
+Mathlib/Data/Finset/Lattice.lean : line 0 : ERR_NUM_LIN : file contains 2240 lines, try to split it up
+Mathlib/Data/Finset/Pointwise.lean : line 0 : ERR_NUM_LIN : file contains 2550 lines, try to split it up
+Mathlib/Data/Finsupp/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1956 lines, try to split it up
+Mathlib/Data/List/Basic.lean : line 0 : ERR_NUM_LIN : file contains 4457 lines, try to split it up
 Mathlib/Data/List/Card.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/List/Card.lean : line 12 : ERR_MOD : Module docstring missing, or too late
+Mathlib/Data/Matrix/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2715 lines, try to split it up
+Mathlib/Data/Multiset/Basic.lean : line 0 : ERR_NUM_LIN : file contains 3196 lines, try to split it up
+Mathlib/Data/MvPolynomial/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1705 lines, try to split it up
+Mathlib/Data/Num/Lemmas.lean : line 0 : ERR_NUM_LIN : file contains 1771 lines, try to split it up
+Mathlib/Data/Ordmap/Ordset.lean : line 0 : ERR_NUM_LIN : file contains 1795 lines, try to split it up
+Mathlib/Data/Polynomial/Degree/Definitions.lean : line 0 : ERR_NUM_LIN : file contains 1689 lines, try to split it up
+Mathlib/Data/Polynomial/RingDivision.lean : line 0 : ERR_NUM_LIN : file contains 1569 lines, try to split it up
 Mathlib/Data/QPF/Multivariate/Basic.lean : line 75 : ERR_LIN : Line has more than 100 characters
+Mathlib/Data/Real/ENNReal.lean : line 0 : ERR_NUM_LIN : file contains 2716 lines, try to split it up
+Mathlib/Data/Seq/WSeq.lean : line 0 : ERR_NUM_LIN : file contains 1825 lines, try to split it up
+Mathlib/Data/Set/Basic.lean : line 0 : ERR_NUM_LIN : file contains 3041 lines, try to split it up
+Mathlib/Data/Set/Finite.lean : line 0 : ERR_NUM_LIN : file contains 1768 lines, try to split it up
+Mathlib/Data/Set/Function.lean : line 0 : ERR_NUM_LIN : file contains 1930 lines, try to split it up
+Mathlib/Data/Set/Image.lean : line 0 : ERR_NUM_LIN : file contains 1685 lines, try to split it up
+Mathlib/Data/Set/Intervals/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1970 lines, try to split it up
+Mathlib/Data/Set/Lattice.lean : line 0 : ERR_NUM_LIN : file contains 2409 lines, try to split it up
 Mathlib/Data/String/Lemmas.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Data/UInt.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/UInt.lean : line 1 : ERR_COP : Malformed or missing copyright header
@@ -23,6 +67,12 @@ Mathlib/Data/UInt.lean : line 6 : ERR_COP : Malformed or missing copyright heade
 Mathlib/Data/UInt.lean : line 8 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/UInt.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Data/UnionFind.lean : line 8 : ERR_MOD : Module docstring missing, or too late
+Mathlib/FieldTheory/RatFunc.lean : line 0 : ERR_NUM_LIN : file contains 1781 lines, try to split it up
+Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean : line 0 : ERR_NUM_LIN : file contains 1607 lines, try to split it up
+Mathlib/GroupTheory/MonoidLocalization.lean : line 0 : ERR_NUM_LIN : file contains 2110 lines, try to split it up
+Mathlib/GroupTheory/Perm/Cycle/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1980 lines, try to split it up
+Mathlib/GroupTheory/Subgroup/Basic.lean : line 0 : ERR_NUM_LIN : file contains 3878 lines, try to split it up
+Mathlib/GroupTheory/Submonoid/Operations.lean : line 0 : ERR_NUM_LIN : file contains 1561 lines, try to split it up
 Mathlib/Init/Data/Int/Basic.lean : line 12 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Init/Data/Nat/Basic.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Init/Data/Nat/Lemmas.lean : line 12 : ERR_MOD : Module docstring missing, or too late
@@ -33,8 +83,52 @@ Mathlib/Lean/Exception.lean : line 4 : ERR_AUT : Authors line should look like: 
 Mathlib/Lean/Exception.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Lean/Expr/ReplaceRec.lean : line 12 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Lean/LocalContext.lean : line 8 : ERR_MOD : Module docstring missing, or too late
+Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean : line 0 : ERR_NUM_LIN : file contains 1900 lines, try to split it up
+Mathlib/LinearAlgebra/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1522 lines, try to split it up
+Mathlib/LinearAlgebra/Basis.lean : line 0 : ERR_NUM_LIN : file contains 1646 lines, try to split it up
+Mathlib/LinearAlgebra/Dual.lean : line 0 : ERR_NUM_LIN : file contains 1847 lines, try to split it up
+Mathlib/LinearAlgebra/LinearIndependent.lean : line 0 : ERR_NUM_LIN : file contains 1537 lines, try to split it up
+Mathlib/LinearAlgebra/Multilinear/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1819 lines, try to split it up
+Mathlib/Logic/Equiv/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2065 lines, try to split it up
 Mathlib/Mathport/Attributes.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Mathport/Rename.lean : line 9 : ERR_MOD : Module docstring missing, or too late
+Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2362 lines, try to split it up
+Mathlib/MeasureTheory/Function/L1Space.lean : line 0 : ERR_NUM_LIN : file contains 1549 lines, try to split it up
+Mathlib/MeasureTheory/Function/LpSeminorm.lean : line 0 : ERR_NUM_LIN : file contains 1708 lines, try to split it up
+Mathlib/MeasureTheory/Function/LpSpace.lean : line 0 : ERR_NUM_LIN : file contains 1956 lines, try to split it up
+Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2148 lines, try to split it up
+Mathlib/MeasureTheory/Integral/Bochner.lean : line 0 : ERR_NUM_LIN : file contains 2010 lines, try to split it up
+Mathlib/MeasureTheory/Integral/FundThmCalculus.lean : line 0 : ERR_NUM_LIN : file contains 1550 lines, try to split it up
+Mathlib/MeasureTheory/Integral/Lebesgue.lean : line 0 : ERR_NUM_LIN : file contains 1851 lines, try to split it up
+Mathlib/MeasureTheory/Integral/SetToL1.lean : line 0 : ERR_NUM_LIN : file contains 1817 lines, try to split it up
+Mathlib/MeasureTheory/MeasurableSpace/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2250 lines, try to split it up
+Mathlib/MeasureTheory/Measure/MeasureSpace.lean : line 0 : ERR_NUM_LIN : file contains 2191 lines, try to split it up
+Mathlib/MeasureTheory/Measure/OuterMeasure.lean : line 0 : ERR_NUM_LIN : file contains 1785 lines, try to split it up
+Mathlib/MeasureTheory/Measure/Typeclasses.lean : line 0 : ERR_NUM_LIN : file contains 1564 lines, try to split it up
+Mathlib/Order/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1586 lines, try to split it up
+Mathlib/Order/Bounds/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1714 lines, try to split it up
+Mathlib/Order/CompleteLattice.lean : line 0 : ERR_NUM_LIN : file contains 2096 lines, try to split it up
+Mathlib/Order/ConditionallyCompleteLattice/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1727 lines, try to split it up
+Mathlib/Order/Filter/AtTopBot.lean : line 0 : ERR_NUM_LIN : file contains 2068 lines, try to split it up
+Mathlib/Order/Filter/Basic.lean : line 0 : ERR_NUM_LIN : file contains 3373 lines, try to split it up
+Mathlib/Order/Hom/Lattice.lean : line 0 : ERR_NUM_LIN : file contains 1840 lines, try to split it up
+Mathlib/Order/Lattice.lean : line 0 : ERR_NUM_LIN : file contains 1541 lines, try to split it up
+Mathlib/Order/LiminfLimsup.lean : line 0 : ERR_NUM_LIN : file contains 1504 lines, try to split it up
+Mathlib/Order/LocallyFinite.lean : line 0 : ERR_NUM_LIN : file contains 1534 lines, try to split it up
+Mathlib/Order/SuccPred/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1560 lines, try to split it up
+Mathlib/Order/UpperLower/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2019 lines, try to split it up
+Mathlib/RingTheory/FractionalIdeal.lean : line 0 : ERR_NUM_LIN : file contains 1624 lines, try to split it up
+Mathlib/RingTheory/HahnSeries.lean : line 0 : ERR_NUM_LIN : file contains 1835 lines, try to split it up
+Mathlib/RingTheory/Ideal/Operations.lean : line 0 : ERR_NUM_LIN : file contains 2410 lines, try to split it up
+Mathlib/RingTheory/PowerSeries/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2865 lines, try to split it up
+Mathlib/RingTheory/Subring/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1546 lines, try to split it up
+Mathlib/RingTheory/UniqueFactorizationDomain.lean : line 0 : ERR_NUM_LIN : file contains 2066 lines, try to split it up
+Mathlib/SetTheory/Cardinal/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2551 lines, try to split it up
+Mathlib/SetTheory/Cardinal/Ordinal.lean : line 0 : ERR_NUM_LIN : file contains 1649 lines, try to split it up
+Mathlib/SetTheory/Game/PGame.lean : line 0 : ERR_NUM_LIN : file contains 1926 lines, try to split it up
+Mathlib/SetTheory/Ordinal/Arithmetic.lean : line 0 : ERR_NUM_LIN : file contains 2593 lines, try to split it up
+Mathlib/SetTheory/Ordinal/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1606 lines, try to split it up
+Mathlib/SetTheory/ZFC/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1805 lines, try to split it up
 Mathlib/Tactic/ApplyWith.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Tactic/ApplyWith.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Tactic/ApplyWith.lean : line 2 : ERR_COP : Malformed or missing copyright header
@@ -64,3 +158,17 @@ Mathlib/Tactic/TypeCheck.lean : line 1 : ERR_COP : Malformed or missing copyrigh
 Mathlib/Tactic/TypeCheck.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Tactic/TypeCheck.lean : line 3 : ERR_COP : Malformed or missing copyright header
 Mathlib/Tactic/TypeCheck.lean : line 3 : ERR_MOD : Module docstring missing, or too late
+Mathlib/Topology/Algebra/Group/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2231 lines, try to split it up
+Mathlib/Topology/Algebra/InfiniteSum/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1665 lines, try to split it up
+Mathlib/Topology/Algebra/Module/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2757 lines, try to split it up
+Mathlib/Topology/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2072 lines, try to split it up
+Mathlib/Topology/Category/Profinite/Nobeling.lean : line 0 : ERR_NUM_LIN : file contains 1831 lines, try to split it up
+Mathlib/Topology/Constructions.lean : line 0 : ERR_NUM_LIN : file contains 1731 lines, try to split it up
+Mathlib/Topology/ContinuousFunction/Bounded.lean : line 0 : ERR_NUM_LIN : file contains 1649 lines, try to split it up
+Mathlib/Topology/Instances/ENNReal.lean : line 0 : ERR_NUM_LIN : file contains 1713 lines, try to split it up
+Mathlib/Topology/MetricSpace/HausdorffDistance.lean : line 0 : ERR_NUM_LIN : file contains 1543 lines, try to split it up
+Mathlib/Topology/MetricSpace/PseudoMetric.lean : line 0 : ERR_NUM_LIN : file contains 2227 lines, try to split it up
+Mathlib/Topology/Order/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2983 lines, try to split it up
+Mathlib/Topology/PartialHomeomorph.lean : line 0 : ERR_NUM_LIN : file contains 1513 lines, try to split it up
+Mathlib/Topology/Separation.lean : line 0 : ERR_NUM_LIN : file contains 2275 lines, try to split it up
+Mathlib/Topology/UniformSpace/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2018 lines, try to split it up

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -1,24 +1,24 @@
-Mathlib/Algebra/Algebra/Subalgebra/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1511 lines, try to split it up
-Mathlib/Algebra/BigOperators/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2675 lines, try to split it up
-Mathlib/Algebra/Lie/Submodule.lean : line 0 : ERR_NUM_LIN : file contains 1528 lines, try to split it up
-Mathlib/Algebra/MonoidAlgebra/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2158 lines, try to split it up
-Mathlib/Algebra/Order/Floor.lean : line 0 : ERR_NUM_LIN : file contains 1822 lines, try to split it up
-Mathlib/Algebra/Order/Monoid/Lemmas.lean : line 0 : ERR_NUM_LIN : file contains 1709 lines, try to split it up
-Mathlib/Algebra/Quaternion.lean : line 0 : ERR_NUM_LIN : file contains 1509 lines, try to split it up
-Mathlib/Analysis/Asymptotics/Asymptotics.lean : line 0 : ERR_NUM_LIN : file contains 2306 lines, try to split it up
-Mathlib/Analysis/Calculus/ContDiff/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2111 lines, try to split it up
-Mathlib/Analysis/Calculus/ContDiff/Defs.lean : line 0 : ERR_NUM_LIN : file contains 1728 lines, try to split it up
-Mathlib/Analysis/Convolution.lean : line 0 : ERR_NUM_LIN : file contains 1545 lines, try to split it up
-Mathlib/Analysis/InnerProductSpace/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2367 lines, try to split it up
-Mathlib/Analysis/Normed/Group/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2815 lines, try to split it up
-Mathlib/Analysis/NormedSpace/OperatorNorm.lean : line 0 : ERR_NUM_LIN : file contains 2033 lines, try to split it up
-Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean : line 0 : ERR_NUM_LIN : file contains 2118 lines, try to split it up
-Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean : line 0 : ERR_NUM_LIN : file contains 2728 lines, try to split it up
-Mathlib/Combinatorics/SimpleGraph/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1625 lines, try to split it up
-Mathlib/Combinatorics/SimpleGraph/Connectivity.lean : line 0 : ERR_NUM_LIN : file contains 2653 lines, try to split it up
-Mathlib/Computability/Primrec.lean : line 0 : ERR_NUM_LIN : file contains 1568 lines, try to split it up
-Mathlib/Computability/TMToPartrec.lean : line 0 : ERR_NUM_LIN : file contains 2069 lines, try to split it up
-Mathlib/Computability/TuringMachine.lean : line 0 : ERR_NUM_LIN : file contains 2821 lines, try to split it up
+Mathlib/Algebra/Algebra/Subalgebra/Basic.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1511 lines, try to split it up
+Mathlib/Algebra/BigOperators/Basic.lean : line 1 : ERR_NUM_LIN : 2800 file contains 2675 lines, try to split it up
+Mathlib/Algebra/Lie/Submodule.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1528 lines, try to split it up
+Mathlib/Algebra/MonoidAlgebra/Basic.lean : line 1 : ERR_NUM_LIN : 2300 file contains 2158 lines, try to split it up
+Mathlib/Algebra/Order/Floor.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1822 lines, try to split it up
+Mathlib/Algebra/Order/Monoid/Lemmas.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1709 lines, try to split it up
+Mathlib/Algebra/Quaternion.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1509 lines, try to split it up
+Mathlib/Analysis/Asymptotics/Asymptotics.lean : line 1 : ERR_NUM_LIN : 2500 file contains 2306 lines, try to split it up
+Mathlib/Analysis/Calculus/ContDiff/Basic.lean : line 1 : ERR_NUM_LIN : 2300 file contains 2111 lines, try to split it up
+Mathlib/Analysis/Calculus/ContDiff/Defs.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1728 lines, try to split it up
+Mathlib/Analysis/Convolution.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1545 lines, try to split it up
+Mathlib/Analysis/InnerProductSpace/Basic.lean : line 1 : ERR_NUM_LIN : 2500 file contains 2367 lines, try to split it up
+Mathlib/Analysis/Normed/Group/Basic.lean : line 1 : ERR_NUM_LIN : 3000 file contains 2815 lines, try to split it up
+Mathlib/Analysis/NormedSpace/OperatorNorm.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2033 lines, try to split it up
+Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean : line 1 : ERR_NUM_LIN : 2300 file contains 2118 lines, try to split it up
+Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2728 lines, try to split it up
+Mathlib/Combinatorics/SimpleGraph/Basic.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1625 lines, try to split it up
+Mathlib/Combinatorics/SimpleGraph/Connectivity.lean : line 1 : ERR_NUM_LIN : 2800 file contains 2653 lines, try to split it up
+Mathlib/Computability/Primrec.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1568 lines, try to split it up
+Mathlib/Computability/TMToPartrec.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2069 lines, try to split it up
+Mathlib/Computability/TuringMachine.lean : line 1 : ERR_NUM_LIN : 3000 file contains 2821 lines, try to split it up
 Mathlib/Data/Array/Basic.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/Array/Basic.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/Array/Basic.lean : line 3 : ERR_COP : Malformed or missing copyright header
@@ -30,32 +30,32 @@ Mathlib/Data/ByteArray.lean : line 2 : ERR_COP : Malformed or missing copyright 
 Mathlib/Data/ByteArray.lean : line 3 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/ByteArray.lean : line 5 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/ByteArray.lean : line 5 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Data/Complex/Exponential.lean : line 0 : ERR_NUM_LIN : file contains 2046 lines, try to split it up
-Mathlib/Data/DFinsupp/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2395 lines, try to split it up
-Mathlib/Data/Fin/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2020 lines, try to split it up
-Mathlib/Data/Finset/Basic.lean : line 0 : ERR_NUM_LIN : file contains 3992 lines, try to split it up
-Mathlib/Data/Finset/Lattice.lean : line 0 : ERR_NUM_LIN : file contains 2240 lines, try to split it up
-Mathlib/Data/Finset/Pointwise.lean : line 0 : ERR_NUM_LIN : file contains 2550 lines, try to split it up
-Mathlib/Data/Finsupp/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1956 lines, try to split it up
-Mathlib/Data/List/Basic.lean : line 0 : ERR_NUM_LIN : file contains 4457 lines, try to split it up
+Mathlib/Data/Complex/Exponential.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2046 lines, try to split it up
+Mathlib/Data/DFinsupp/Basic.lean : line 1 : ERR_NUM_LIN : 2500 file contains 2395 lines, try to split it up
+Mathlib/Data/Fin/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2020 lines, try to split it up
+Mathlib/Data/Finset/Basic.lean : line 1 : ERR_NUM_LIN : 4100 file contains 3992 lines, try to split it up
+Mathlib/Data/Finset/Lattice.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2240 lines, try to split it up
+Mathlib/Data/Finset/Pointwise.lean : line 1 : ERR_NUM_LIN : 2700 file contains 2550 lines, try to split it up
+Mathlib/Data/Finsupp/Basic.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1956 lines, try to split it up
+Mathlib/Data/List/Basic.lean : line 1 : ERR_NUM_LIN : 4600 file contains 4457 lines, try to split it up
 Mathlib/Data/List/Card.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/List/Card.lean : line 12 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Data/Matrix/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2715 lines, try to split it up
-Mathlib/Data/Multiset/Basic.lean : line 0 : ERR_NUM_LIN : file contains 3196 lines, try to split it up
-Mathlib/Data/MvPolynomial/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1705 lines, try to split it up
-Mathlib/Data/Num/Lemmas.lean : line 0 : ERR_NUM_LIN : file contains 1771 lines, try to split it up
-Mathlib/Data/Ordmap/Ordset.lean : line 0 : ERR_NUM_LIN : file contains 1795 lines, try to split it up
-Mathlib/Data/Polynomial/Degree/Definitions.lean : line 0 : ERR_NUM_LIN : file contains 1689 lines, try to split it up
-Mathlib/Data/Polynomial/RingDivision.lean : line 0 : ERR_NUM_LIN : file contains 1569 lines, try to split it up
+Mathlib/Data/Matrix/Basic.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2715 lines, try to split it up
+Mathlib/Data/Multiset/Basic.lean : line 1 : ERR_NUM_LIN : 3300 file contains 3196 lines, try to split it up
+Mathlib/Data/MvPolynomial/Basic.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1705 lines, try to split it up
+Mathlib/Data/Num/Lemmas.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1771 lines, try to split it up
+Mathlib/Data/Ordmap/Ordset.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1795 lines, try to split it up
+Mathlib/Data/Polynomial/Degree/Definitions.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1689 lines, try to split it up
+Mathlib/Data/Polynomial/RingDivision.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1569 lines, try to split it up
 Mathlib/Data/QPF/Multivariate/Basic.lean : line 75 : ERR_LIN : Line has more than 100 characters
-Mathlib/Data/Real/ENNReal.lean : line 0 : ERR_NUM_LIN : file contains 2716 lines, try to split it up
-Mathlib/Data/Seq/WSeq.lean : line 0 : ERR_NUM_LIN : file contains 1825 lines, try to split it up
-Mathlib/Data/Set/Basic.lean : line 0 : ERR_NUM_LIN : file contains 3041 lines, try to split it up
-Mathlib/Data/Set/Finite.lean : line 0 : ERR_NUM_LIN : file contains 1768 lines, try to split it up
-Mathlib/Data/Set/Function.lean : line 0 : ERR_NUM_LIN : file contains 1930 lines, try to split it up
-Mathlib/Data/Set/Image.lean : line 0 : ERR_NUM_LIN : file contains 1685 lines, try to split it up
-Mathlib/Data/Set/Intervals/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1970 lines, try to split it up
-Mathlib/Data/Set/Lattice.lean : line 0 : ERR_NUM_LIN : file contains 2409 lines, try to split it up
+Mathlib/Data/Real/ENNReal.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2716 lines, try to split it up
+Mathlib/Data/Seq/WSeq.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1825 lines, try to split it up
+Mathlib/Data/Set/Basic.lean : line 1 : ERR_NUM_LIN : 3200 file contains 3041 lines, try to split it up
+Mathlib/Data/Set/Finite.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1768 lines, try to split it up
+Mathlib/Data/Set/Function.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1930 lines, try to split it up
+Mathlib/Data/Set/Image.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1685 lines, try to split it up
+Mathlib/Data/Set/Intervals/Basic.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1970 lines, try to split it up
+Mathlib/Data/Set/Lattice.lean : line 1 : ERR_NUM_LIN : 2600 file contains 2409 lines, try to split it up
 Mathlib/Data/String/Lemmas.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Data/UInt.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/UInt.lean : line 1 : ERR_COP : Malformed or missing copyright header
@@ -67,12 +67,12 @@ Mathlib/Data/UInt.lean : line 6 : ERR_COP : Malformed or missing copyright heade
 Mathlib/Data/UInt.lean : line 8 : ERR_COP : Malformed or missing copyright header
 Mathlib/Data/UInt.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Data/UnionFind.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-Mathlib/FieldTheory/RatFunc.lean : line 0 : ERR_NUM_LIN : file contains 1781 lines, try to split it up
-Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean : line 0 : ERR_NUM_LIN : file contains 1607 lines, try to split it up
-Mathlib/GroupTheory/MonoidLocalization.lean : line 0 : ERR_NUM_LIN : file contains 2110 lines, try to split it up
-Mathlib/GroupTheory/Perm/Cycle/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1980 lines, try to split it up
-Mathlib/GroupTheory/Subgroup/Basic.lean : line 0 : ERR_NUM_LIN : file contains 3878 lines, try to split it up
-Mathlib/GroupTheory/Submonoid/Operations.lean : line 0 : ERR_NUM_LIN : file contains 1561 lines, try to split it up
+Mathlib/FieldTheory/RatFunc.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1781 lines, try to split it up
+Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1607 lines, try to split it up
+Mathlib/GroupTheory/MonoidLocalization.lean : line 1 : ERR_NUM_LIN : 2300 file contains 2110 lines, try to split it up
+Mathlib/GroupTheory/Perm/Cycle/Basic.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1980 lines, try to split it up
+Mathlib/GroupTheory/Subgroup/Basic.lean : line 1 : ERR_NUM_LIN : 4000 file contains 3878 lines, try to split it up
+Mathlib/GroupTheory/Submonoid/Operations.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1561 lines, try to split it up
 Mathlib/Init/Data/Int/Basic.lean : line 12 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Init/Data/Nat/Basic.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Init/Data/Nat/Lemmas.lean : line 12 : ERR_MOD : Module docstring missing, or too late
@@ -83,52 +83,52 @@ Mathlib/Lean/Exception.lean : line 4 : ERR_AUT : Authors line should look like: 
 Mathlib/Lean/Exception.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Lean/Expr/ReplaceRec.lean : line 12 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Lean/LocalContext.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean : line 0 : ERR_NUM_LIN : file contains 1900 lines, try to split it up
-Mathlib/LinearAlgebra/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1522 lines, try to split it up
-Mathlib/LinearAlgebra/Basis.lean : line 0 : ERR_NUM_LIN : file contains 1646 lines, try to split it up
-Mathlib/LinearAlgebra/Dual.lean : line 0 : ERR_NUM_LIN : file contains 1847 lines, try to split it up
-Mathlib/LinearAlgebra/LinearIndependent.lean : line 0 : ERR_NUM_LIN : file contains 1537 lines, try to split it up
-Mathlib/LinearAlgebra/Multilinear/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1819 lines, try to split it up
-Mathlib/Logic/Equiv/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2065 lines, try to split it up
+Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1900 lines, try to split it up
+Mathlib/LinearAlgebra/Basic.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1522 lines, try to split it up
+Mathlib/LinearAlgebra/Basis.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1646 lines, try to split it up
+Mathlib/LinearAlgebra/Dual.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1847 lines, try to split it up
+Mathlib/LinearAlgebra/LinearIndependent.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1537 lines, try to split it up
+Mathlib/LinearAlgebra/Multilinear/Basic.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1819 lines, try to split it up
+Mathlib/Logic/Equiv/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2065 lines, try to split it up
 Mathlib/Mathport/Attributes.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Mathport/Rename.lean : line 9 : ERR_MOD : Module docstring missing, or too late
-Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2362 lines, try to split it up
-Mathlib/MeasureTheory/Function/L1Space.lean : line 0 : ERR_NUM_LIN : file contains 1549 lines, try to split it up
-Mathlib/MeasureTheory/Function/LpSeminorm.lean : line 0 : ERR_NUM_LIN : file contains 1708 lines, try to split it up
-Mathlib/MeasureTheory/Function/LpSpace.lean : line 0 : ERR_NUM_LIN : file contains 1956 lines, try to split it up
-Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2148 lines, try to split it up
-Mathlib/MeasureTheory/Integral/Bochner.lean : line 0 : ERR_NUM_LIN : file contains 2010 lines, try to split it up
-Mathlib/MeasureTheory/Integral/FundThmCalculus.lean : line 0 : ERR_NUM_LIN : file contains 1550 lines, try to split it up
-Mathlib/MeasureTheory/Integral/Lebesgue.lean : line 0 : ERR_NUM_LIN : file contains 1851 lines, try to split it up
-Mathlib/MeasureTheory/Integral/SetToL1.lean : line 0 : ERR_NUM_LIN : file contains 1817 lines, try to split it up
-Mathlib/MeasureTheory/MeasurableSpace/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2250 lines, try to split it up
-Mathlib/MeasureTheory/Measure/MeasureSpace.lean : line 0 : ERR_NUM_LIN : file contains 2191 lines, try to split it up
-Mathlib/MeasureTheory/Measure/OuterMeasure.lean : line 0 : ERR_NUM_LIN : file contains 1785 lines, try to split it up
-Mathlib/MeasureTheory/Measure/Typeclasses.lean : line 0 : ERR_NUM_LIN : file contains 1564 lines, try to split it up
-Mathlib/Order/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1586 lines, try to split it up
-Mathlib/Order/Bounds/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1714 lines, try to split it up
-Mathlib/Order/CompleteLattice.lean : line 0 : ERR_NUM_LIN : file contains 2096 lines, try to split it up
-Mathlib/Order/ConditionallyCompleteLattice/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1727 lines, try to split it up
-Mathlib/Order/Filter/AtTopBot.lean : line 0 : ERR_NUM_LIN : file contains 2068 lines, try to split it up
-Mathlib/Order/Filter/Basic.lean : line 0 : ERR_NUM_LIN : file contains 3373 lines, try to split it up
-Mathlib/Order/Hom/Lattice.lean : line 0 : ERR_NUM_LIN : file contains 1840 lines, try to split it up
-Mathlib/Order/Lattice.lean : line 0 : ERR_NUM_LIN : file contains 1541 lines, try to split it up
-Mathlib/Order/LiminfLimsup.lean : line 0 : ERR_NUM_LIN : file contains 1504 lines, try to split it up
-Mathlib/Order/LocallyFinite.lean : line 0 : ERR_NUM_LIN : file contains 1534 lines, try to split it up
-Mathlib/Order/SuccPred/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1560 lines, try to split it up
-Mathlib/Order/UpperLower/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2019 lines, try to split it up
-Mathlib/RingTheory/FractionalIdeal.lean : line 0 : ERR_NUM_LIN : file contains 1624 lines, try to split it up
-Mathlib/RingTheory/HahnSeries.lean : line 0 : ERR_NUM_LIN : file contains 1835 lines, try to split it up
-Mathlib/RingTheory/Ideal/Operations.lean : line 0 : ERR_NUM_LIN : file contains 2410 lines, try to split it up
-Mathlib/RingTheory/PowerSeries/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2865 lines, try to split it up
-Mathlib/RingTheory/Subring/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1546 lines, try to split it up
-Mathlib/RingTheory/UniqueFactorizationDomain.lean : line 0 : ERR_NUM_LIN : file contains 2066 lines, try to split it up
-Mathlib/SetTheory/Cardinal/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2551 lines, try to split it up
-Mathlib/SetTheory/Cardinal/Ordinal.lean : line 0 : ERR_NUM_LIN : file contains 1649 lines, try to split it up
-Mathlib/SetTheory/Game/PGame.lean : line 0 : ERR_NUM_LIN : file contains 1926 lines, try to split it up
-Mathlib/SetTheory/Ordinal/Arithmetic.lean : line 0 : ERR_NUM_LIN : file contains 2593 lines, try to split it up
-Mathlib/SetTheory/Ordinal/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1606 lines, try to split it up
-Mathlib/SetTheory/ZFC/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1805 lines, try to split it up
+Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean : line 1 : ERR_NUM_LIN : 2500 file contains 2362 lines, try to split it up
+Mathlib/MeasureTheory/Function/L1Space.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1549 lines, try to split it up
+Mathlib/MeasureTheory/Function/LpSeminorm.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1708 lines, try to split it up
+Mathlib/MeasureTheory/Function/LpSpace.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1956 lines, try to split it up
+Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean : line 1 : ERR_NUM_LIN : 2300 file contains 2148 lines, try to split it up
+Mathlib/MeasureTheory/Integral/Bochner.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2010 lines, try to split it up
+Mathlib/MeasureTheory/Integral/FundThmCalculus.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1550 lines, try to split it up
+Mathlib/MeasureTheory/Integral/Lebesgue.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1851 lines, try to split it up
+Mathlib/MeasureTheory/Integral/SetToL1.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1817 lines, try to split it up
+Mathlib/MeasureTheory/MeasurableSpace/Basic.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2250 lines, try to split it up
+Mathlib/MeasureTheory/Measure/MeasureSpace.lean : line 1 : ERR_NUM_LIN : 2300 file contains 2191 lines, try to split it up
+Mathlib/MeasureTheory/Measure/OuterMeasure.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1785 lines, try to split it up
+Mathlib/MeasureTheory/Measure/Typeclasses.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1564 lines, try to split it up
+Mathlib/Order/Basic.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1586 lines, try to split it up
+Mathlib/Order/Bounds/Basic.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1714 lines, try to split it up
+Mathlib/Order/CompleteLattice.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2096 lines, try to split it up
+Mathlib/Order/ConditionallyCompleteLattice/Basic.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1727 lines, try to split it up
+Mathlib/Order/Filter/AtTopBot.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2068 lines, try to split it up
+Mathlib/Order/Filter/Basic.lean : line 1 : ERR_NUM_LIN : 3500 file contains 3373 lines, try to split it up
+Mathlib/Order/Hom/Lattice.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1840 lines, try to split it up
+Mathlib/Order/Lattice.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1541 lines, try to split it up
+Mathlib/Order/LiminfLimsup.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1504 lines, try to split it up
+Mathlib/Order/LocallyFinite.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1534 lines, try to split it up
+Mathlib/Order/SuccPred/Basic.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1560 lines, try to split it up
+Mathlib/Order/UpperLower/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2019 lines, try to split it up
+Mathlib/RingTheory/FractionalIdeal.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1624 lines, try to split it up
+Mathlib/RingTheory/HahnSeries.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1835 lines, try to split it up
+Mathlib/RingTheory/Ideal/Operations.lean : line 1 : ERR_NUM_LIN : 2600 file contains 2410 lines, try to split it up
+Mathlib/RingTheory/PowerSeries/Basic.lean : line 1 : ERR_NUM_LIN : 3000 file contains 2865 lines, try to split it up
+Mathlib/RingTheory/Subring/Basic.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1546 lines, try to split it up
+Mathlib/RingTheory/UniqueFactorizationDomain.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2066 lines, try to split it up
+Mathlib/SetTheory/Cardinal/Basic.lean : line 1 : ERR_NUM_LIN : 2700 file contains 2551 lines, try to split it up
+Mathlib/SetTheory/Cardinal/Ordinal.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1649 lines, try to split it up
+Mathlib/SetTheory/Game/PGame.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1926 lines, try to split it up
+Mathlib/SetTheory/Ordinal/Arithmetic.lean : line 1 : ERR_NUM_LIN : 2700 file contains 2593 lines, try to split it up
+Mathlib/SetTheory/Ordinal/Basic.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1606 lines, try to split it up
+Mathlib/SetTheory/ZFC/Basic.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1805 lines, try to split it up
 Mathlib/Tactic/ApplyWith.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Tactic/ApplyWith.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Tactic/ApplyWith.lean : line 2 : ERR_COP : Malformed or missing copyright header
@@ -158,17 +158,17 @@ Mathlib/Tactic/TypeCheck.lean : line 1 : ERR_COP : Malformed or missing copyrigh
 Mathlib/Tactic/TypeCheck.lean : line 1 : ERR_COP : Malformed or missing copyright header
 Mathlib/Tactic/TypeCheck.lean : line 3 : ERR_COP : Malformed or missing copyright header
 Mathlib/Tactic/TypeCheck.lean : line 3 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Topology/Algebra/Group/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2231 lines, try to split it up
-Mathlib/Topology/Algebra/InfiniteSum/Basic.lean : line 0 : ERR_NUM_LIN : file contains 1665 lines, try to split it up
-Mathlib/Topology/Algebra/Module/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2757 lines, try to split it up
-Mathlib/Topology/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2072 lines, try to split it up
-Mathlib/Topology/Category/Profinite/Nobeling.lean : line 0 : ERR_NUM_LIN : file contains 1831 lines, try to split it up
-Mathlib/Topology/Constructions.lean : line 0 : ERR_NUM_LIN : file contains 1731 lines, try to split it up
-Mathlib/Topology/ContinuousFunction/Bounded.lean : line 0 : ERR_NUM_LIN : file contains 1649 lines, try to split it up
-Mathlib/Topology/Instances/ENNReal.lean : line 0 : ERR_NUM_LIN : file contains 1713 lines, try to split it up
-Mathlib/Topology/MetricSpace/HausdorffDistance.lean : line 0 : ERR_NUM_LIN : file contains 1543 lines, try to split it up
-Mathlib/Topology/MetricSpace/PseudoMetric.lean : line 0 : ERR_NUM_LIN : file contains 2227 lines, try to split it up
-Mathlib/Topology/Order/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2983 lines, try to split it up
-Mathlib/Topology/PartialHomeomorph.lean : line 0 : ERR_NUM_LIN : file contains 1513 lines, try to split it up
-Mathlib/Topology/Separation.lean : line 0 : ERR_NUM_LIN : file contains 2275 lines, try to split it up
-Mathlib/Topology/UniformSpace/Basic.lean : line 0 : ERR_NUM_LIN : file contains 2018 lines, try to split it up
+Mathlib/Topology/Algebra/Group/Basic.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2231 lines, try to split it up
+Mathlib/Topology/Algebra/InfiniteSum/Basic.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1665 lines, try to split it up
+Mathlib/Topology/Algebra/Module/Basic.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2757 lines, try to split it up
+Mathlib/Topology/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2072 lines, try to split it up
+Mathlib/Topology/Category/Profinite/Nobeling.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1831 lines, try to split it up
+Mathlib/Topology/Constructions.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1731 lines, try to split it up
+Mathlib/Topology/ContinuousFunction/Bounded.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1649 lines, try to split it up
+Mathlib/Topology/Instances/ENNReal.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1713 lines, try to split it up
+Mathlib/Topology/MetricSpace/HausdorffDistance.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1543 lines, try to split it up
+Mathlib/Topology/MetricSpace/PseudoMetric.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2227 lines, try to split it up
+Mathlib/Topology/Order/Basic.lean : line 1 : ERR_NUM_LIN : 3100 file contains 2983 lines, try to split it up
+Mathlib/Topology/PartialHomeomorph.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1513 lines, try to split it up
+Mathlib/Topology/Separation.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2275 lines, try to split it up
+Mathlib/Topology/UniformSpace/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2018 lines, try to split it up


### PR DESCRIPTION
This adds a style linter for files with more than 1500 lines. [zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Linter.20for.20large.20files.3F)

Files which are longer are added as style exceptions. For these files, we also add a "high watermark": if such a file grows more than 100-200 lines compared to its current state, we still error.

The style exceptions can be updated by running `./scripts/update-style-exceptions.py`;
this regenerates the watermarks correctly.

----

The implementation is a mild hack ---- we write the watermark before the error message and parse it manually, but this works well.

Questions and answers.
Q. What if a long file gets split? Must I update the file?
A. That would be nice. This is as simple as running `./scripts/update-style-exceptions.py` locally. Enjoy the satisfaction from removing entries from this file. :-)

Q. Is the file updated automatically? 
A. Currently not. If we really care about this, we can set up a cronjob to run this once every two weeks (or month, or so). 

Q. The error message contains the current number of lines: does that mean the style exceptions must be updated on every change of a large file? Isn't that onerous?
A. Not quite, only if the watermark (100-200 lines added) was exceeded. If that happens in a single PR, I consider this small nudge to reconsider the location a feature. If a small PR pushes it over, just update the file (see above).

Q. This should have been written in Lean instead!
A. Yes, it should. Yours truly doesn't know where such Lean linters are located and has not *programmed* in Lean before. Help rewriting this welcome. (Note, however, that this linter is *quick* --- it doesn't iterate over the lines in the file --- and rewriting other linters first might be more useful.)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
