### PR TITLE
[Merged by Bors] - refactor(*): abbreviation for non-dependent `FunLike`

### DIFF
--- a/Archive/Hairer.lean
+++ b/Archive/Hairer.lean
@@ -46,7 +46,7 @@ namespace SmoothSupportedOn
 
 variable {n : ℕ∞} {s : Set E}
 
-instance : DFunLike (SmoothSupportedOn 𝕜 E F n s) E (fun _ ↦ F) where
+instance : FunLike (SmoothSupportedOn 𝕜 E F n s) E F where
   coe := Subtype.val
   coe_injective' := Subtype.coe_injective
 

--- a/Mathlib/Algebra/Algebra/NonUnitalHom.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalHom.lean
@@ -124,7 +124,7 @@ variable [NonUnitalNonAssocSemiring C] [DistribMulAction R C]
 -- instance : CoeFun (A →ₙₐ[R] B) fun _ => A → B :=
 --   ⟨toFun⟩
 
-instance : DFunLike (A →ₙₐ[R] B) A fun _ => B where
+instance : FunLike (A →ₙₐ[R] B) A B where
   coe f := f.toFun
   coe_injective' := by rintro ⟨⟨⟨f, _⟩, _⟩, _⟩ ⟨⟨⟨g, _⟩, _⟩, _⟩ h; congr
 

--- a/Mathlib/Algebra/Category/GroupCat/Basic.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Basic.lean
@@ -65,8 +65,8 @@ instance {X Y : GroupCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe (f : X →* Y) := f
 
 @[to_additive]
-instance DFunLike_instance (X Y : GroupCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
-  show DFunLike (X →* Y) X (fun _ => Y) from inferInstance
+instance FunLike_instance (X Y : GroupCat) : FunLike (X ⟶ Y) X Y :=
+  show FunLike (X →* Y) X Y from inferInstance
 
 -- porting note: added
 @[to_additive (attr := simp)]
@@ -214,8 +214,8 @@ instance {X Y : CommGroupCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe (f : X →* Y) := f
 
 @[to_additive]
-instance DFunLike_instance (X Y : CommGroupCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
-  show DFunLike (X →* Y) X (fun _ => Y) from inferInstance
+instance FunLike_instance (X Y : CommGroupCat) : FunLike (X ⟶ Y) X (fun _ => Y) :=
+  show FunLike (X →* Y) X Y from inferInstance
 
 -- porting note: added
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Category/GroupCat/Basic.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Basic.lean
@@ -214,7 +214,7 @@ instance {X Y : CommGroupCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe (f : X →* Y) := f
 
 @[to_additive]
-instance FunLike_instance (X Y : CommGroupCat) : FunLike (X ⟶ Y) X (fun _ => Y) :=
+instance FunLike_instance (X Y : CommGroupCat) : FunLike (X ⟶ Y) X Y :=
   show FunLike (X →* Y) X Y from inferInstance
 
 -- porting note: added

--- a/Mathlib/Algebra/Category/GroupWithZeroCat.lean
+++ b/Mathlib/Algebra/Category/GroupWithZeroCat.lean
@@ -53,7 +53,7 @@ instance : LargeCategory.{u} GroupWithZeroCat where
   assoc _ _ _ := MonoidWithZeroHom.comp_assoc _ _ _
 
 -- porting note: was not necessary in mathlib
-instance {M N : GroupWithZeroCat} : DFunLike (M ⟶ N) M (fun _ => N) :=
+instance {M N : GroupWithZeroCat} : FunLike (M ⟶ N) M N :=
   ⟨fun f => f.toFun, fun f g h => by
     cases f
     cases g

--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Closed.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Closed.lean
@@ -67,7 +67,7 @@ open MonoidalCategory
 -- porting note: `CoeFun` was replaced by `DFunLike`
 -- I can't seem to express the function coercion here without writing `@DFunLike.coe`.
 theorem monoidalClosed_curry {M N P : ModuleCat.{u} R} (f : M ⊗ N ⟶ P) (x : M) (y : N) :
-    @DFunLike.coe _ _ _ LinearMap.instDFunLike
+    @DFunLike.coe _ _ _ LinearMap.instFunLike
       ((MonoidalClosed.curry f : N →ₗ[R] M →ₗ[R] P) y) x = f (x ⊗ₜ[R] y) :=
   rfl
 set_option linter.uppercaseLean3 false in
@@ -77,7 +77,7 @@ set_option linter.uppercaseLean3 false in
 theorem monoidalClosed_uncurry
     {M N P : ModuleCat.{u} R} (f : N ⟶ M ⟶[ModuleCat.{u} R] P) (x : M) (y : N) :
     MonoidalClosed.uncurry f (x ⊗ₜ[R] y) =
-      @DFunLike.coe _ _ _ LinearMap.instDFunLike (f y) x :=
+      @DFunLike.coe _ _ _ LinearMap.instFunLike (f y) x :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align Module.monoidal_closed_uncurry ModuleCat.monoidalClosed_uncurry

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -86,8 +86,8 @@ instance {X Y : MonCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe (f : X →* Y) := f
 
 @[to_additive]
-instance Hom_DFunLike (X Y : MonCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
-  show DFunLike (X →* Y) X (fun _ => Y) by infer_instance
+instance Hom_FunLike (X Y : MonCat) : FunLike (X ⟶ Y) X Y :=
+  show FunLike (X →* Y) X Y by infer_instance
 
 -- porting note: added
 @[to_additive (attr := simp)]
@@ -208,8 +208,8 @@ instance {X Y : CommMonCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe (f : X →* Y) := f
 
 @[to_additive]
-instance Hom_DFunLike (X Y : CommMonCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
-  show DFunLike (X →* Y) X (fun _ => Y) by infer_instance
+instance Hom_FunLike (X Y : CommMonCat) : FunLike (X ⟶ Y) X Y :=
+  show FunLike (X →* Y) X Y by infer_instance
 
 -- porting note: added
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
@@ -330,7 +330,7 @@ def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
   uniq t m h := MonoidHom.ext fun y => congr_fun
       ((Types.colimitCoconeIsColimit (F ⋙ forget MonCat)).uniq ((forget MonCat).mapCocone t)
         ((forget MonCat).map m)
-        fun j => funext fun x => DFunLike.congr_fun (i := MonCat.Hom_DFunLike _ _) (h j) x) y
+        fun j => funext fun x => DFunLike.congr_fun (i := MonCat.Hom_FunLike _ _) (h j) x) y
 #align Mon.filtered_colimits.colimit_cocone_is_colimit MonCat.FilteredColimits.colimitCoconeIsColimit
 #align AddMon.filtered_colimits.colimit_cocone_is_colimit AddMonCat.FilteredColimits.colimitCoconeIsColimit
 
@@ -405,15 +405,15 @@ def colimitCoconeIsColimit : IsColimit (colimitCocone.{v, u} F) where
     MonCat.FilteredColimits.colimitDesc.{v, u} (F ⋙ forget₂ CommMonCat MonCat.{max v u})
       ((forget₂ CommMonCat MonCat.{max v u}).mapCocone t)
   fac t j :=
-    DFunLike.coe_injective (i := CommMonCat.Hom_DFunLike _ _) <|
+    DFunLike.coe_injective (i := CommMonCat.Hom_FunLike _ _) <|
       (Types.colimitCoconeIsColimit.{v, u} (F ⋙ forget CommMonCat.{max v u})).fac
         ((forget CommMonCat).mapCocone t) j
   uniq t m h :=
-    DFunLike.coe_injective (i := CommMonCat.Hom_DFunLike _ _) <|
+    DFunLike.coe_injective (i := CommMonCat.Hom_FunLike _ _) <|
       (Types.colimitCoconeIsColimit.{v, u} (F ⋙ forget CommMonCat.{max v u})).uniq
         ((forget CommMonCat.{max v u}).mapCocone t)
         ((forget CommMonCat.{max v u}).map m) fun j => funext fun x =>
-          DFunLike.congr_fun (i := CommMonCat.Hom_DFunLike _ _) (h j) x
+          DFunLike.congr_fun (i := CommMonCat.Hom_FunLike _ _) (h j) x
 #align CommMon.filtered_colimits.colimit_cocone_is_colimit CommMonCat.FilteredColimits.colimitCoconeIsColimit
 #align AddCommMon.filtered_colimits.colimit_cocone_is_colimit AddCommMonCat.FilteredColimits.colimitCoconeIsColimit
 

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -107,7 +107,7 @@ set_option linter.uppercaseLean3 false in
 @[simp]
 lemma RingEquiv_coe_eq {X Y : Type _} [Semiring X] [Semiring Y] (e : X ≃+* Y) :
     (@DFunLike.coe (SemiRingCat.of X ⟶ SemiRingCat.of Y) _ (fun _ => (forget SemiRingCat).obj _)
-      ConcreteCategory.instDFunLike (e : X →+* Y) : X → Y) = ↑e :=
+      ConcreteCategory.instFunLike (e : X →+* Y) : X → Y) = ↑e :=
   rfl
 
 instance : Inhabited SemiRingCat :=
@@ -246,7 +246,7 @@ set_option linter.uppercaseLean3 false in
 @[simp]
 lemma RingEquiv_coe_eq {X Y : Type _} [Ring X] [Ring Y] (e : X ≃+* Y) :
     (@DFunLike.coe (RingCat.of X ⟶ RingCat.of Y) _ (fun _ => (forget RingCat).obj _)
-      ConcreteCategory.instDFunLike (e : X →+* Y) : X → Y) = ↑e :=
+      ConcreteCategory.instFunLike (e : X →+* Y) : X → Y) = ↑e :=
   rfl
 
 instance hasForgetToSemiRingCat : HasForget₂ RingCat SemiRingCat :=
@@ -330,7 +330,7 @@ set_option linter.uppercaseLean3 false in
 lemma RingEquiv_coe_eq {X Y : Type _} [CommSemiring X] [CommSemiring Y] (e : X ≃+* Y) :
     (@DFunLike.coe (CommSemiRingCat.of X ⟶ CommSemiRingCat.of Y) _
       (fun _ => (forget CommSemiRingCat).obj _)
-      ConcreteCategory.instDFunLike (e : X →+* Y) : X → Y) = ↑e :=
+      ConcreteCategory.instFunLike (e : X →+* Y) : X → Y) = ↑e :=
   rfl
 
 -- Porting note: I think this is now redundant.
@@ -445,7 +445,7 @@ set_option linter.uppercaseLean3 false in
 @[simp]
 lemma RingEquiv_coe_eq {X Y : Type _} [CommRing X] [CommRing Y] (e : X ≃+* Y) :
     (@DFunLike.coe (CommRingCat.of X ⟶ CommRingCat.of Y) _ (fun _ => (forget CommRingCat).obj _)
-      ConcreteCategory.instDFunLike (e : X →+* Y) : X → Y) = ↑e :=
+      ConcreteCategory.instFunLike (e : X →+* Y) : X → Y) = ↑e :=
   rfl
 
 -- Porting note: I think this is now redundant.

--- a/Mathlib/Algebra/Category/SemigroupCat/Basic.lean
+++ b/Mathlib/Algebra/Category/SemigroupCat/Basic.lean
@@ -99,7 +99,7 @@ theorem coe_of (R : Type u) [Mul R] : (MagmaCat.of R : Type u) = R :=
 @[to_additive (attr := simp)]
 lemma mulEquiv_coe_eq {X Y : Type _} [Mul X] [Mul Y] (e : X ≃* Y) :
     (@DFunLike.coe (MagmaCat.of X ⟶ MagmaCat.of Y) _ (fun _ => (forget MagmaCat).obj _)
-      ConcreteCategory.instDFunLike (e : X →ₙ* Y) : X → Y) = ↑e :=
+      ConcreteCategory.instFunLike (e : X →ₙ* Y) : X → Y) = ↑e :=
   rfl
 
 /-- Typecheck a `MulHom` as a morphism in `MagmaCat`. -/
@@ -184,7 +184,7 @@ theorem coe_of (R : Type u) [Semigroup R] : (SemigroupCat.of R : Type u) = R :=
 @[to_additive (attr := simp)]
 lemma mulEquiv_coe_eq {X Y : Type _} [Semigroup X] [Semigroup Y] (e : X ≃* Y) :
     (@DFunLike.coe (SemigroupCat.of X ⟶ SemigroupCat.of Y) _ (fun _ => (forget SemigroupCat).obj _)
-      ConcreteCategory.instDFunLike (e : X →ₙ* Y) : X → Y) = ↑e :=
+      ConcreteCategory.instFunLike (e : X →ₙ* Y) : X → Y) = ↑e :=
   rfl
 
 /-- Typecheck a `MulHom` as a morphism in `SemigroupCat`. -/

--- a/Mathlib/Algebra/Group/Freiman.lean
+++ b/Mathlib/Algebra/Group/Freiman.lean
@@ -88,7 +88,7 @@ notation:25 (name := «FreimanHomLocal≺») A " →*[" n:25 "] " β:0 => Freima
 /-- `AddFreimanHomClass F A β n` states that `F` is a type of `n`-ary sums-preserving morphisms.
 You should extend this class when you extend `AddFreimanHom`. -/
 class AddFreimanHomClass (F : Type*) (A : outParam <| Set α) (β : outParam <| Type*)
-  [AddCommMonoid α] [AddCommMonoid β] (n : ℕ) [DFunLike F α fun _ => β] : Prop where
+  [AddCommMonoid α] [AddCommMonoid β] (n : ℕ) [FunLike F α β] : Prop where
   /-- An additive `n`-Freiman homomorphism preserves sums of `n` elements. -/
   map_sum_eq_map_sum' (f : F) {s t : Multiset α} (hsA : ∀ ⦃x⦄, x ∈ s → x ∈ A)
     (htA : ∀ ⦃x⦄, x ∈ t → x ∈ A) (hs : Multiset.card s = n) (ht : Multiset.card t = n)
@@ -102,7 +102,7 @@ You should extend this class when you extend `FreimanHom`. -/
       "`AddFreimanHomClass F A β n` states that `F` is a type of `n`-ary
       sums-preserving morphisms. You should extend this class when you extend `AddFreimanHom`."]
 class FreimanHomClass (F : Type*) (A : outParam <| Set α) (β : outParam <| Type*) [CommMonoid α]
-  [CommMonoid β] (n : ℕ) [DFunLike F α fun _ => β] : Prop where
+  [CommMonoid β] (n : ℕ) [FunLike F α β] : Prop where
   /-- An `n`-Freiman homomorphism preserves products of `n` elements. -/
   map_prod_eq_map_prod' (f : F) {s t : Multiset α} (hsA : ∀ ⦃x⦄, x ∈ s → x ∈ A)
     (htA : ∀ ⦃x⦄, x ∈ t → x ∈ A) (hs : Multiset.card s = n) (ht : Multiset.card t = n)
@@ -110,7 +110,7 @@ class FreimanHomClass (F : Type*) (A : outParam <| Set α) (β : outParam <| Typ
     (s.map f).prod = (t.map f).prod
 #align freiman_hom_class FreimanHomClass
 
-variable [DFunLike F α fun _ => β]
+variable [FunLike F α β]
 
 section CommMonoid
 
@@ -154,11 +154,11 @@ theorem map_mul_map_eq_map_mul_map [FreimanHomClass F A β 2] (f : F) (ha : a �
 namespace FreimanHom
 
 @[to_additive]
-instance instDFunLike : DFunLike (A →*[n] β) α fun _ => β where
+instance instFunLike : FunLike (A →*[n] β) α β where
   coe := toFun
   coe_injective' f g h := by cases f; cases g; congr
-#align freiman_hom.fun_like FreimanHom.instDFunLike
-#align add_freiman_hom.fun_like AddFreimanHom.instDFunLike
+#align freiman_hom.fun_like FreimanHom.instFunLike
+#align add_freiman_hom.fun_like AddFreimanHom.instFunLike
 
 @[to_additive addFreimanHomClass]
 instance freimanHomClass : FreimanHomClass (A →*[n] β) A β n where

--- a/Mathlib/Algebra/Homology/ImageToKernel.lean
+++ b/Mathlib/Algebra/Homology/ImageToKernel.lean
@@ -64,7 +64,7 @@ theorem subobject_ofLE_as_imageToKernel (w : f ≫ g = 0) (h) :
   rfl
 #align subobject_of_le_as_image_to_kernel subobject_ofLE_as_imageToKernel
 
-attribute [local instance] ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.instFunLike
 
 -- porting note: removed elementwise attribute which does not seem to be helpful here
 -- a more suitable lemma is added below
@@ -303,7 +303,7 @@ theorem homology'.π_map (p : α.right = β.left) :
 
 section
 
-attribute [local instance] ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.instFunLike
 
 @[simp]
 lemma homology'.π_map_apply [ConcreteCategory.{w} V] (p : α.right = β.left)

--- a/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
@@ -121,7 +121,7 @@ section abelian
 variable {C : Type u} [Category.{v} C] [ConcreteCategory.{v} C] [HasForget₂ C Ab]
   [Abelian C] [(forget₂ C Ab).Additive] [(forget₂ C Ab).PreservesHomology]
 
-attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
 
 namespace ShortComplex
 

--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -307,7 +307,7 @@ attribute [coe] LieHom.toLinearMap
 instance : Coe (L₁ →ₗ⁅R⁆ L₂) (L₁ →ₗ[R] L₂) :=
   ⟨LieHom.toLinearMap⟩
 
-instance : DFunLike (L₁ →ₗ⁅R⁆ L₂) L₁ (fun _ => L₂) :=
+instance : FunLike (L₁ →ₗ⁅R⁆ L₂) L₁ L₂ :=
   { coe := fun f => f.toFun,
     coe_injective' := fun x y h =>
       by cases x; cases y; simp at h; simp [h] }
@@ -736,7 +736,7 @@ attribute [coe] LieModuleHom.toLinearMap
 instance : CoeOut (M →ₗ⁅R,L⁆ N) (M →ₗ[R] N) :=
   ⟨LieModuleHom.toLinearMap⟩
 
-instance : DFunLike (M →ₗ⁅R, L⁆ N) M (fun _ => N) :=
+instance : FunLike (M →ₗ⁅R, L⁆ N) M N :=
   { coe := fun f => f.toFun,
     coe_injective' := fun x y h =>
       by cases x; cases y; simp at h; simp [h] }

--- a/Mathlib/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Algebra/Module/LinearMap.lean
@@ -219,7 +219,7 @@ instance semilinearMapClass : SemilinearMapClass (M →ₛₗ[σ] M₃) σ M M�
 #noalign LinearMap.has_coe_to_fun
 
 -- Porting note: adding this instance prevents a timeout in `ext_ring_op`
-instance instDFunLike {σ : R →+* S} : DFunLike (M →ₛₗ[σ] M₃) M (λ _ ↦ M₃) :=
+instance instFunLike {σ : R →+* S} : FunLike (M →ₛₗ[σ] M₃) M M₃ :=
   { AddHomClass.toDFunLike with }
 
 /-- The `DistribMulActionHom` underlying a `LinearMap`. -/

--- a/Mathlib/Algebra/Order/Hom/Basic.lean
+++ b/Mathlib/Algebra/Order/Hom/Basic.lean
@@ -77,14 +77,14 @@ variable {ι F α β γ δ : Type*}
 
 /-- `NonnegHomClass F α β` states that `F` is a type of nonnegative morphisms. -/
 class NonnegHomClass (F : Type*) (α β : outParam (Type*)) [Zero β] [LE β] extends
-  DFunLike F α fun _ => β where
+  FunLike F α β where
   /-- the image of any element is non negative. -/
   map_nonneg (f : F) : ∀ a, 0 ≤ f a
 #align nonneg_hom_class NonnegHomClass
 
 /-- `SubadditiveHomClass F α β` states that `F` is a type of subadditive morphisms. -/
 class SubadditiveHomClass (F : Type*) (α β : outParam (Type*)) [Add α] [Add β] [LE β] extends
-  DFunLike F α fun _ => β where
+  FunLike F α β where
   /-- the image of a sum is less or equal than the sum of the images. -/
   map_add_le_add (f : F) : ∀ a b, f (a + b) ≤ f a + f b
 #align subadditive_hom_class SubadditiveHomClass
@@ -92,7 +92,7 @@ class SubadditiveHomClass (F : Type*) (α β : outParam (Type*)) [Add α] [Add �
 /-- `SubmultiplicativeHomClass F α β` states that `F` is a type of submultiplicative morphisms. -/
 @[to_additive SubadditiveHomClass]
 class SubmultiplicativeHomClass (F : Type*) (α β : outParam (Type*)) [Mul α] [Mul β] [LE β]
-  extends DFunLike F α fun _ => β where
+  extends FunLike F α β where
   /-- the image of a product is less or equal than the product of the images. -/
   map_mul_le_mul (f : F) : ∀ a b, f (a * b) ≤ f a * f b
 #align submultiplicative_hom_class SubmultiplicativeHomClass
@@ -100,14 +100,14 @@ class SubmultiplicativeHomClass (F : Type*) (α β : outParam (Type*)) [Mul α] 
 /-- `MulLEAddHomClass F α β` states that `F` is a type of subadditive morphisms. -/
 @[to_additive SubadditiveHomClass]
 class MulLEAddHomClass (F : Type*) (α β : outParam (Type*)) [Mul α] [Add β] [LE β]
-  extends DFunLike F α fun _ => β where
+  extends FunLike F α β where
   /-- the image of a product is less or equal than the sum of the images. -/
   map_mul_le_add (f : F) : ∀ a b, f (a * b) ≤ f a + f b
 #align mul_le_add_hom_class MulLEAddHomClass
 
 /-- `NonarchimedeanHomClass F α β` states that `F` is a type of non-archimedean morphisms. -/
 class NonarchimedeanHomClass (F : Type*) (α β : outParam (Type*)) [Add α] [LinearOrder β]
-  extends DFunLike F α fun _ => β where
+  extends FunLike F α β where
   /-- the image of a sum is less or equal than the maximum of the images. -/
   map_add_le_max (f : F) : ∀ a b, f (a + b) ≤ max (f a) (f b)
 #align nonarchimedean_hom_class NonarchimedeanHomClass

--- a/Mathlib/Algebra/Order/Hom/Basic.lean
+++ b/Mathlib/Algebra/Order/Hom/Basic.lean
@@ -77,14 +77,14 @@ variable {ι F α β γ δ : Type*}
 
 /-- `NonnegHomClass F α β` states that `F` is a type of nonnegative morphisms. -/
 class NonnegHomClass (F : Type*) (α β : outParam (Type*)) [Zero β] [LE β] extends
-  FunLike F α β where
+  DFunLike F α (fun _ => β) where
   /-- the image of any element is non negative. -/
   map_nonneg (f : F) : ∀ a, 0 ≤ f a
 #align nonneg_hom_class NonnegHomClass
 
 /-- `SubadditiveHomClass F α β` states that `F` is a type of subadditive morphisms. -/
 class SubadditiveHomClass (F : Type*) (α β : outParam (Type*)) [Add α] [Add β] [LE β] extends
-  FunLike F α β where
+  DFunLike F α (fun _ => β) where
   /-- the image of a sum is less or equal than the sum of the images. -/
   map_add_le_add (f : F) : ∀ a b, f (a + b) ≤ f a + f b
 #align subadditive_hom_class SubadditiveHomClass
@@ -92,7 +92,7 @@ class SubadditiveHomClass (F : Type*) (α β : outParam (Type*)) [Add α] [Add �
 /-- `SubmultiplicativeHomClass F α β` states that `F` is a type of submultiplicative morphisms. -/
 @[to_additive SubadditiveHomClass]
 class SubmultiplicativeHomClass (F : Type*) (α β : outParam (Type*)) [Mul α] [Mul β] [LE β]
-  extends FunLike F α β where
+  extends DFunLike F α (fun _ => β) where
   /-- the image of a product is less or equal than the product of the images. -/
   map_mul_le_mul (f : F) : ∀ a b, f (a * b) ≤ f a * f b
 #align submultiplicative_hom_class SubmultiplicativeHomClass
@@ -100,14 +100,14 @@ class SubmultiplicativeHomClass (F : Type*) (α β : outParam (Type*)) [Mul α] 
 /-- `MulLEAddHomClass F α β` states that `F` is a type of subadditive morphisms. -/
 @[to_additive SubadditiveHomClass]
 class MulLEAddHomClass (F : Type*) (α β : outParam (Type*)) [Mul α] [Add β] [LE β]
-  extends FunLike F α β where
+  extends DFunLike F α (fun _ => β) where
   /-- the image of a product is less or equal than the sum of the images. -/
   map_mul_le_add (f : F) : ∀ a b, f (a * b) ≤ f a + f b
 #align mul_le_add_hom_class MulLEAddHomClass
 
 /-- `NonarchimedeanHomClass F α β` states that `F` is a type of non-archimedean morphisms. -/
 class NonarchimedeanHomClass (F : Type*) (α β : outParam (Type*)) [Add α] [LinearOrder β]
-  extends FunLike F α β where
+  extends DFunLike F α (fun _ => β) where
   /-- the image of a sum is less or equal than the maximum of the images. -/
   map_add_le_max (f : F) : ∀ a b, f (a + b) ≤ max (f a) (f b)
 #align nonarchimedean_hom_class NonarchimedeanHomClass

--- a/Mathlib/Algebra/Quandle.lean
+++ b/Mathlib/Algebra/Quandle.lean
@@ -358,7 +358,7 @@ namespace ShelfHom
 
 variable {S₁ : Type*} {S₂ : Type*} {S₃ : Type*} [Shelf S₁] [Shelf S₂] [Shelf S₃]
 
-instance : DFunLike (S₁ →◃ S₂) S₁ fun _ => S₂ where
+instance : FunLike (S₁ →◃ S₂) S₁ S₂ where
   coe := toFun
   coe_injective' | ⟨_, _⟩, ⟨_, _⟩, rfl => rfl
 

--- a/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
+++ b/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
@@ -25,7 +25,7 @@ namespace SimplexCategory
 
 open Simplicial NNReal BigOperators Classical CategoryTheory
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
 
 -- porting note: added, should be moved
 instance (x : SimplexCategory) : Fintype (ConcreteCategory.forget.obj x) :=

--- a/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
@@ -58,7 +58,7 @@ open Box Prepartition Finset
 variable {N : Type*} [AddCommMonoid M] [AddCommMonoid N] {I₀ : WithTop (Box ι)} {I J : Box ι}
   {i : ι}
 
-instance : DFunLike (ι →ᵇᵃ[I₀] M) (Box ι) (fun _ ↦ M) where
+instance : FunLike (ι →ᵇᵃ[I₀] M) (Box ι) M where
   coe := toFun
   coe_injective' f g h := by cases f; cases g; congr
 

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -92,10 +92,10 @@ open SchwartzSpace
 -- porting note: removed
 -- instance : Coe 𝓢(E, F) (E → F) := ⟨toFun⟩
 
-instance instDFunLike : DFunLike 𝓢(E, F) E fun _ => F where
+instance instFunLike : FunLike 𝓢(E, F) E F where
   coe f := f.toFun
   coe_injective' f g h := by cases f; cases g; congr
-#align schwartz_map.fun_like SchwartzMap.instDFunLike
+#align schwartz_map.fun_like SchwartzMap.instFunLike
 
 /-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`. -/
 instance instCoeFun : CoeFun 𝓢(E, F) fun _ => E → F :=

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -356,9 +356,9 @@ theorem repr_injective :
   cases g
   congr
 
--- Porting note: `CoeFun` → `DFunLike`
+-- Porting note: `CoeFun` → `FunLike`
 /-- `b i` is the `i`th basis vector. -/
-instance instDFunLike : DFunLike (OrthonormalBasis ι 𝕜 E) ι fun _ => E where
+instance instFunLike : FunLike (OrthonormalBasis ι 𝕜 E) ι E where
   coe b i := by classical exact b.repr.symm (EuclideanSpace.single i (1 : 𝕜))
   coe_injective' b b' h := repr_injective <| LinearIsometryEquiv.toLinearEquiv_injective <|
     LinearEquiv.symm_bijective.injective <| LinearEquiv.toLinearMap_injective <| by

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGroupCat.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGroupCat.lean
@@ -147,7 +147,7 @@ instance : LargeCategory.{u} SemiNormedGroupCat₁ where
   comp {X Y Z} f g := ⟨g.1.comp f.1, g.2.comp f.2⟩
 
 -- Porting Note: Added
-instance instDFunLike (X Y : SemiNormedGroupCat₁) : DFunLike (X ⟶ Y) X (fun _ => Y) where
+instance instFunLike (X Y : SemiNormedGroupCat₁) : FunLike (X ⟶ Y) X Y where
   coe f := f.1.toFun
   coe_injective' _ _ h := Subtype.val_inj.mp (NormedAddGroupHom.coe_injective h)
 

--- a/Mathlib/Analysis/NormedSpace/AffineIsometry.lean
+++ b/Mathlib/Analysis/NormedSpace/AffineIsometry.lean
@@ -71,7 +71,7 @@ theorem linear_eq_linearIsometry : f.linear = f.linearIsometry.toLinearMap := by
   rfl
 #align affine_isometry.linear_eq_linear_isometry AffineIsometry.linear_eq_linearIsometry
 
-instance : DFunLike (P →ᵃⁱ[𝕜] P₂) P fun _ => P₂ :=
+instance : FunLike (P →ᵃⁱ[𝕜] P₂) P P₂ :=
   { coe := fun f => f.toFun,
     coe_injective' := fun f g => by cases f; cases g; simp }
 

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -98,7 +98,7 @@ variable {C : Type u} [Category.{v} C] [ConcreteCategory.{w} C]
 #noalign category_theory.forget_obj_eq_coe
 
 @[reducible]
-def ConcreteCategory.instDFunLike {X Y : C} : DFunLike (X ⟶ Y) X (fun _ => Y) where
+def ConcreteCategory.instFunLike {X Y : C} : FunLike (X ⟶ Y) X Y where
   coe f := (forget C).map f
   coe_injective' _ _ h := (forget C).map_injective h
 attribute [local instance] ConcreteCategory.instDFunLike

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -101,7 +101,7 @@ variable {C : Type u} [Category.{v} C] [ConcreteCategory.{w} C]
 def ConcreteCategory.instFunLike {X Y : C} : FunLike (X ⟶ Y) X Y where
   coe f := (forget C).map f
   coe_injective' _ _ h := (forget C).map_injective h
-attribute [local instance] ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.instFunLike
 
 /-- In any concrete category, we can test equality of morphisms by pointwise evaluations.-/
 @[ext low] -- Porting note: lowered priority
@@ -212,7 +212,7 @@ def forget₂ (C : Type u) (D : Type u') [Category.{v} C] [ConcreteCategory.{w} 
   HasForget₂.forget₂
 #align category_theory.forget₂ CategoryTheory.forget₂
 
-attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
 
 lemma forget₂_comp_apply {C : Type u} {D : Type u'} [Category.{v} C] [ConcreteCategory.{w} C]
     [Category.{v'} D] [ConcreteCategory.{w} D] [HasForget₂ C D] {X Y Z : C}

--- a/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
@@ -86,7 +86,7 @@ instance concreteCategory : ConcreteCategory.{u} (Bundled c)
 
 variable {hom}
 
-attribute [local instance] ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.instFunLike
 
 /-- A version of `HasForget₂.mk'` for categories defined using `@BundledHom`. -/
 def mkHasForget₂ {d : Type u → Type u} {hom_d : ∀ ⦃α β : Type u⦄ (_ : d α) (_ : d β), Type u}

--- a/Mathlib/CategoryTheory/Limits/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/ConcreteCategory.lean
@@ -21,7 +21,7 @@ open CategoryTheory
 
 namespace CategoryTheory.Limits
 
-attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
 
 section Limits
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -33,7 +33,7 @@ universe w v u
 
 namespace CategoryTheory.Limits.Concrete
 
-attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
 
 variable {C : Type u} [Category.{v} C]
 

--- a/Mathlib/CategoryTheory/MorphismProperty.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty.lean
@@ -807,7 +807,7 @@ variable [ConcreteCategory C]
 
 open Function
 
-attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
 
 variable (C)
 

--- a/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
@@ -37,7 +37,7 @@ section
 
 variable [ConcreteCategory.{max v u} D]
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
 
 -- porting note: removed @[nolint has_nonempty_instance]
 /-- A concrete version of the multiequalizer, to be used below. -/
@@ -52,7 +52,7 @@ namespace Meq
 
 variable [ConcreteCategory.{max v u} D]
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
 
 instance {X} (P : Cᵒᵖ ⥤ D) (S : J.Cover X) :
     CoeFun (Meq P S) fun _ => ∀ I : S.Arrow, P.obj (op I.Y) :=
@@ -145,7 +145,7 @@ namespace Plus
 
 variable [ConcreteCategory.{max v u} D]
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
 
 variable [PreservesLimits (forget D)]
 

--- a/Mathlib/CategoryTheory/Sites/Surjective.lean
+++ b/Mathlib/CategoryTheory/Sites/Surjective.lean
@@ -32,7 +32,7 @@ namespace CategoryTheory
 
 variable {C : Type u} [Category.{v} C] (J : GrothendieckTopology C)
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
 
 variable {A : Type u'} [Category.{v'} A] [ConcreteCategory.{w'} A]
 

--- a/Mathlib/Combinatorics/Additive/SalemSpencer.lean
+++ b/Mathlib/Combinatorics/Additive/SalemSpencer.lean
@@ -118,7 +118,7 @@ section CommMonoid
 variable [CommMonoid α] [CommMonoid β] {s : Set α} {a : α}
 
 @[to_additive]
-theorem MulSalemSpencer.of_image [DFunLike F α fun _ => β] [FreimanHomClass F s β 2] (f : F)
+theorem MulSalemSpencer.of_image [FunLike F α β] [FreimanHomClass F s β 2] (f : F)
     (hf : s.InjOn f) (h : MulSalemSpencer (f '' s)) : MulSalemSpencer s :=
   fun _ _ _ ha hb hc habc => hf ha hb <|
     h (mem_image_of_mem _ ha) (mem_image_of_mem _ hb) (mem_image_of_mem _ hc) <|

--- a/Mathlib/Combinatorics/Young/SemistandardTableau.lean
+++ b/Mathlib/Combinatorics/Young/SemistandardTableau.lean
@@ -63,13 +63,13 @@ structure Ssyt (μ : YoungDiagram) where
 
 namespace Ssyt
 
-instance instDFunLike {μ : YoungDiagram} : DFunLike (Ssyt μ) ℕ fun _ ↦ ℕ → ℕ where
+instance instFunLike {μ : YoungDiagram} : FunLike (Ssyt μ) ℕ (ℕ → ℕ) where
   coe := Ssyt.entry
   coe_injective' T T' h := by
     cases T
     cases T'
     congr
-#align ssyt.fun_like Ssyt.instDFunLike
+#align ssyt.fun_like Ssyt.instFunLike
 
 /-- Helper instance for when there's too many metavariables to apply `CoeFun.coe` directly. -/
 instance {μ : YoungDiagram} : CoeFun (Ssyt μ) fun _ ↦ ℕ → ℕ → ℕ :=

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -117,13 +117,13 @@ section Basic
 
 variable [Zero M]
 
-instance instDFunLike : DFunLike (α →₀ M) α fun _ => M :=
+instance instFunLike : FunLike (α →₀ M) α M :=
   ⟨toFun, by
     rintro ⟨s, f, hf⟩ ⟨t, g, hg⟩ (rfl : f = g)
     congr
     ext a
     exact (hf _).trans (hg _).symm⟩
-#align finsupp.fun_like Finsupp.instDFunLike
+#align finsupp.fun_like Finsupp.instFunLike
 
 /-- Helper instance for when there are too many metavariables to apply the `DFunLike` instance
 directly. -/

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -122,6 +122,8 @@ instead of linearly increasing the work per `MyHom`-related declaration.
 /-- The class `DFunLike F α β` expresses that terms of type `F` have an
 injective coercion to (dependent) functions from `α` to `β`.
 
+For non-dependent functions you can also use the abbreviation `FunLike`.
+
 This typeclass is used in the definition of the homomorphism typeclasses,
 such as `ZeroHomClass`, `MulHomClass`, `MonoidHomClass`, ....
 -/
@@ -135,6 +137,14 @@ class DFunLike (F : Sort*) (α : outParam (Sort*)) (β : outParam <| α → Sort
 
 -- https://github.com/leanprover/lean4/issues/2096
 compile_def% DFunLike.coe
+
+/-- The class `FunLike F α β` (`Fun`ction-`Like`) expresses that terms of type `F`
+have an injective coercion to functions from `α` to `β`.
+`FunLike` is the non-dependent version of `DFunLike`.
+This typeclass is used in the definition of the homomorphism typeclasses,
+such as `ZeroHomClass`, `MulHomClass`, `MonoidHomClass`, ....
+-/
+abbrev FunLike F α β := DFunLike F α fun _ => β
 
 section Dependent
 
@@ -205,9 +215,9 @@ end Dependent
 
 section NonDependent
 
-/-! ### `DFunLike F α (λ _, β)` where `β` does not depend on `a : α` -/
+/-! ### `FunLike F α β` where `β` does not depend on `a : α` -/
 
-variable {F α β : Sort*} [i : DFunLike F α fun _ ↦ β]
+variable {F α β : Sort*} [i : FunLike F α β]
 
 namespace DFunLike
 

--- a/Mathlib/Data/FunLike/Fintype.lean
+++ b/Mathlib/Data/FunLike/Fintype.lean
@@ -73,7 +73,7 @@ Non-dependent version of `DFunLike.finite` that might be easier to infer.
 Can't be an instance because it can cause infinite loops.
 -/
 theorem FunLike.finite [Finite α] [Finite γ] : Finite G :=
-  FunLike.finite G
+  DFunLike.finite G
 #align fun_like.finite' FunLike.finite
 
 end Sort'

--- a/Mathlib/Data/FunLike/Fintype.lean
+++ b/Mathlib/Data/FunLike/Fintype.lean
@@ -31,7 +31,7 @@ They can't be instances themselves since they can cause loops.
 -- porting notes: `Type` is a reserved word, switched to `Type'`
 section Type'
 
-variable (F G : Type*) {α γ : Type*} {β : α → Type*} [DFunLike F α β] [DFunLike G α fun _ => γ]
+variable (F G : Type*) {α γ : Type*} {β : α → Type*} [DFunLike F α β] [FunLike G α γ]
 
 /-- All `DFunLike`s are finite if their domain and codomain are.
 
@@ -43,21 +43,21 @@ noncomputable def DFunLike.fintype [DecidableEq α] [Fintype α] [∀ i, Fintype
   Fintype.ofInjective _ DFunLike.coe_injective
 #align fun_like.fintype DFunLike.fintype
 
-/-- All `DFunLike`s are finite if their domain and codomain are.
+/-- All `FunLike`s are finite if their domain and codomain are.
 
 Non-dependent version of `DFunLike.fintype` that might be easier to infer.
-This is not an instance because specific `DFunLike` types might have a better-suited definition.
+This is not an instance because specific `FunLike` types might have a better-suited definition.
 -/
-noncomputable def DFunLike.fintype' [DecidableEq α] [Fintype α] [Fintype γ] : Fintype G :=
+noncomputable def FunLike.fintype [DecidableEq α] [Fintype α] [Fintype γ] : Fintype G :=
   DFunLike.fintype G
-#align fun_like.fintype' DFunLike.fintype'
+#align fun_like.fintype' FunLike.fintype
 
 end Type'
 
 -- porting notes: `Sort` is a reserved word, switched to `Sort'`
 section Sort'
 
-variable (F G : Sort*) {α γ : Sort*} {β : α → Sort*} [DFunLike F α β] [DFunLike G α fun _ => γ]
+variable (F G : Sort*) {α γ : Sort*} {β : α → Sort*} [DFunLike F α β] [FunLike G α γ]
 
 /-- All `DFunLike`s are finite if their domain and codomain are.
 
@@ -67,13 +67,13 @@ theorem DFunLike.finite [Finite α] [∀ i, Finite (β i)] : Finite F :=
   Finite.of_injective _ DFunLike.coe_injective
 #align fun_like.finite DFunLike.finite
 
-/-- All `DFunLike`s are finite if their domain and codomain are.
+/-- All `FunLike`s are finite if their domain and codomain are.
 
 Non-dependent version of `DFunLike.finite` that might be easier to infer.
 Can't be an instance because it can cause infinite loops.
 -/
-theorem DFunLike.finite' [Finite α] [Finite γ] : Finite G :=
-  DFunLike.finite G
-#align fun_like.finite' DFunLike.finite'
+theorem FunLike.finite [Finite α] [Finite γ] : Finite G :=
+  FunLike.finite G
+#align fun_like.finite' FunLike.finite
 
 end Sort'

--- a/Mathlib/Data/PEquiv.lean
+++ b/Mathlib/Data/PEquiv.lean
@@ -65,7 +65,7 @@ variable {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
 
 open Function Option
 
-instance : DFunLike (α ≃. β) α fun _ => Option β :=
+instance : FunLike (α ≃. β) α (Option β) :=
   { coe := toFun
     coe_injective' := by
       rintro ⟨f₁, f₂, hf⟩ ⟨g₁, g₂, hg⟩ (rfl : f₁ = g₁)

--- a/Mathlib/Data/Polynomial/Module.lean
+++ b/Mathlib/Data/Polynomial/Module.lean
@@ -202,8 +202,8 @@ namespace PolynomialModule
 noncomputable instance : Module S (PolynomialModule R M) :=
   Finsupp.module ℕ M
 
-instance instDFunLike : DFunLike (PolynomialModule R M) ℕ fun _ => M :=
-  Finsupp.instDFunLike
+instance instFunLike : FunLike (PolynomialModule R M) ℕ M :=
+  Finsupp.instFunLike
 
 instance : CoeFun (PolynomialModule R M) fun _ => ℕ → M :=
   Finsupp.coeFun

--- a/Mathlib/Geometry/Manifold/ContMDiffMap.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMap.lean
@@ -48,10 +48,10 @@ namespace ContMDiffMap
 
 variable {I} {I'} {M} {M'} {n}
 
-instance instDFunLike : DFunLike C^n⟮I, M; I', M'⟯ M fun _ => M' where
+instance instFunLike : FunLike C^n⟮I, M; I', M'⟯ M M' where
   coe := Subtype.val
   coe_injective' := Subtype.coe_injective
-#align cont_mdiff_map.fun_like ContMDiffMap.instDFunLike
+#align cont_mdiff_map.fun_like ContMDiffMap.instFunLike
 
 protected theorem contMDiff (f : C^n⟮I, M; I', M'⟯) : ContMDiff I I' n f :=
   f.prop
@@ -65,7 +65,7 @@ protected theorem smooth (f : C^∞⟮I, M; I', M'⟯) : Smooth I I' f :=
 -- instance : Coe C^n⟮I, M; I', M'⟯ C(M, M') :=
 --   ⟨fun f => ⟨f, f.contMDiff.continuous⟩⟩
 
-attribute [to_additive_ignore_args 21] ContMDiffMap ContMDiffMap.instDFunLike
+attribute [to_additive_ignore_args 21] ContMDiffMap ContMDiffMap.instFunLike
 
 variable {f g : C^n⟮I, M; I', M'⟯}
 

--- a/Mathlib/Geometry/Manifold/DerivationBundle.lean
+++ b/Mathlib/Geometry/Manifold/DerivationBundle.lean
@@ -50,9 +50,9 @@ namespace PointedSmoothMap
 
 open scoped Derivation
 
-instance instDFunLike {x : M} : DFunLike C^∞⟮I, M; 𝕜⟯⟨x⟩ M fun _ => 𝕜 :=
-  ContMDiffMap.instDFunLike
-#align pointed_smooth_map.fun_like PointedSmoothMap.instDFunLike
+instance instFunLike {x : M} : FunLike C^∞⟮I, M; 𝕜⟯⟨x⟩ M 𝕜 :=
+  ContMDiffMap.instFunLike
+#align pointed_smooth_map.fun_like PointedSmoothMap.instFunLike
 
 instance {x : M} : CommRing C^∞⟮I, M; 𝕜⟯⟨x⟩ :=
   SmoothMap.commRing

--- a/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
+++ b/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
@@ -139,7 +139,7 @@ namespace SmoothPartitionOfUnity
 
 variable {s : Set M} (f : SmoothPartitionOfUnity ι I M s) {n : ℕ∞}
 
-instance {s : Set M} : DFunLike (SmoothPartitionOfUnity ι I M s) ι fun _ => C^∞⟮I, M; 𝓘(ℝ), ℝ⟯ where
+instance {s : Set M} : FunLike (SmoothPartitionOfUnity ι I M s) ι C^∞⟮I, M; 𝓘(ℝ), ℝ⟯ where
   coe := toFun
   coe_injective' f g h := by cases f; cases g; congr
 

--- a/Mathlib/GroupTheory/Congruence.lean
+++ b/Mathlib/GroupTheory/Congruence.lean
@@ -118,10 +118,10 @@ variable [Mul M] [Mul N] [Mul P] (c : Con M)
 instance : Inhabited (Con M) :=
   ⟨conGen EmptyRelation⟩
 
---Porting note: upgraded to DFunLike
+--Porting note: upgraded to FunLike
 /-- A coercion from a congruence relation to its underlying binary relation. -/
 @[to_additive "A coercion from an additive congruence relation to its underlying binary relation."]
-instance : DFunLike (Con M) M (fun _ => M → Prop) where
+instance : FunLike (Con M) M (M → Prop) where
   coe c := c.r
   coe_injective' := fun x y h => by
     rcases x with ⟨⟨x, _⟩, _⟩

--- a/Mathlib/GroupTheory/FreeGroup/IsFreeGroup.lean
+++ b/Mathlib/GroupTheory/FreeGroup/IsFreeGroup.lean
@@ -48,7 +48,7 @@ noncomputable section
 
 /-- A free group basis `FreeGroupBasis ι G` is a structure recording the isomorphism between a
 group `G` and the free group over `ι`. One may think of such a basis as a function from `ι` to `G`
-(which is registered through a `DFunLike` instance) together with the fact that the morphism induced
+(which is registered through a `FunLike` instance) together with the fact that the morphism induced
 by this function from `FreeGroup ι` to `G` is an isomorphism. -/
 structure FreeGroupBasis (ι : Type*) (G : Type*) [Group G] where
   /-- `FreeGroupBasis.ofRepr` constructs a basis given an equivalence with a free group. -/
@@ -68,7 +68,7 @@ variable {ι ι' G H : Type*} [Group G] [Group H]
 
 /-- A free group basis for `G` over `ι` is associated to a map `ι → G` recording the images of
 the generators. -/
-instance instDFunLike : DFunLike (FreeGroupBasis ι G) ι (fun _ ↦ G) where
+instance instFunLike : FunLike (FreeGroupBasis ι G) ι G where
   coe b := fun i ↦ b.repr.symm (FreeGroup.of i)
   coe_injective' := by
     rintro ⟨b⟩  ⟨b'⟩ hbb'

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -69,7 +69,7 @@ instance AffineMap.instFunLike (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*
     congr with v
     apply vadd_right_cancel (f p)
     erw [← f_add, h, ← g_add]
-#align affine_map.fun_like AffineMap.instDFunLike
+#align affine_map.fun_like AffineMap.instFunLike
 
 instance AffineMap.hasCoeToFun (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*} (P2 : Type*)
     [Ring k] [AddCommGroup V1] [Module k V1] [AffineSpace V1 P1] [AddCommGroup V2] [Module k V2]

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -59,9 +59,9 @@ structure AffineMap (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*} (P2 : Typ
 induces a corresponding linear map from `V1` to `V2`. -/
 notation:25 P1 " →ᵃ[" k:25 "] " P2:0 => AffineMap k P1 P2
 
-instance AffineMap.instDFunLike (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*} (P2 : Type*)
+instance AffineMap.instFunLike (k : Type*) {V1 : Type*} (P1 : Type*) {V2 : Type*} (P2 : Type*)
     [Ring k] [AddCommGroup V1] [Module k V1] [AffineSpace V1 P1] [AddCommGroup V2] [Module k V2]
-    [AffineSpace V2 P2] : DFunLike (P1 →ᵃ[k] P2) P1 fun _ => P2
+    [AffineSpace V2 P2] : FunLike (P1 →ᵃ[k] P2) P1 P2
     where
   coe := AffineMap.toFun
   coe_injective' := fun ⟨f, f_linear, f_add⟩ ⟨g, g_linear, g_add⟩ => fun (h : f = g) => by

--- a/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
@@ -67,7 +67,7 @@ variable [Ring k] [Module k V] (b : AffineBasis ι k P) {s : Finset ι} {i j : �
 instance : Inhabited (AffineBasis PUnit k PUnit) :=
   ⟨⟨id, affineIndependent_of_subsingleton k id, by simp⟩⟩
 
-instance instDFunLike : DFunLike (AffineBasis ι k P) ι fun _ => P where
+instance instFunLike : FunLike (AffineBasis ι k P) ι P where
   coe := AffineBasis.toFun
   coe_injective' f g h := by cases f; cases g; congr
 #align affine_basis.fun_like AffineBasis.instDFunLike

--- a/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
@@ -70,7 +70,7 @@ instance : Inhabited (AffineBasis PUnit k PUnit) :=
 instance instFunLike : FunLike (AffineBasis ι k P) ι P where
   coe := AffineBasis.toFun
   coe_injective' f g h := by cases f; cases g; congr
-#align affine_basis.fun_like AffineBasis.instDFunLike
+#align affine_basis.fun_like AffineBasis.instFunLike
 
 @[ext]
 theorem ext {b₁ b₂ : AffineBasis ι k P} (h : (b₁ : ι → P) = b₂) : b₁ = b₂ :=

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -96,7 +96,7 @@ open Function
 
 section Coercions
 
-instance instDFunLike : DFunLike (M [Λ^ι]→ₗ[R] N) (ι → M) (fun _ => N) where
+instance instFunLike : FunLike (M [Λ^ι]→ₗ[R] N) (ι → M) N where
   coe f := f.toFun
   coe_injective' := fun f g h ↦ by
     rcases f with ⟨⟨_, _, _⟩, _⟩

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -102,7 +102,7 @@ instance instFunLike : FunLike (M [Λ^ι]→ₗ[R] N) (ι → M) N where
     rcases f with ⟨⟨_, _, _⟩, _⟩
     rcases g with ⟨⟨_, _, _⟩, _⟩
     congr
-#align alternating_map.fun_like AlternatingMap.instDFunLike
+#align alternating_map.fun_like AlternatingMap.instFunLike
 
 -- shortcut instance
 instance coeFun : CoeFun (M [Λ^ι]→ₗ[R] N) fun _ => (ι → M) → N :=

--- a/Mathlib/LinearAlgebra/Basis.lean
+++ b/Mathlib/LinearAlgebra/Basis.lean
@@ -119,7 +119,7 @@ theorem repr_injective : Injective (repr : Basis ι R M → M ≃ₗ[R] ι →�
 #align basis.repr_injective Basis.repr_injective
 
 /-- `b i` is the `i`th basis vector. -/
-instance instDFunLike : DFunLike (Basis ι R M) ι fun _ => M where
+instance instFunLike : FunLike (Basis ι R M) ι M where
   coe b i := b.repr.symm (Finsupp.single i 1)
   coe_injective' f g h := repr_injective <| LinearEquiv.symm_bijective.injective <|
     LinearEquiv.toLinearMap_injective <| by ext; exact congr_fun h _

--- a/Mathlib/LinearAlgebra/Basis.lean
+++ b/Mathlib/LinearAlgebra/Basis.lean
@@ -123,7 +123,7 @@ instance instFunLike : FunLike (Basis ι R M) ι M where
   coe b i := b.repr.symm (Finsupp.single i 1)
   coe_injective' f g h := repr_injective <| LinearEquiv.symm_bijective.injective <|
     LinearEquiv.toLinearMap_injective <| by ext; exact congr_fun h _
-#align basis.fun_like Basis.instDFunLike
+#align basis.fun_like Basis.instFunLike
 
 @[simp]
 theorem coe_ofRepr (e : M ≃ₗ[R] ι →₀ R) : ⇑(ofRepr e) = fun i => e.symm (Finsupp.single i 1) :=

--- a/Mathlib/LinearAlgebra/Dual.lean
+++ b/Mathlib/LinearAlgebra/Dual.lean
@@ -1295,7 +1295,7 @@ def dualCopairing (W : Submodule R M) : W.dualAnnihilator →ₗ[R] M ⧸ W →�
 #align submodule.dual_copairing Submodule.dualCopairing
 
 -- Porting note: helper instance
-instance (W : Submodule R M) : DFunLike (W.dualAnnihilator) M fun _ => R :=
+instance (W : Submodule R M) : FunLike (W.dualAnnihilator) M R :=
   { coe := fun φ => φ.val,
     coe_injective' := fun φ ψ h => by
       ext

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -107,8 +107,8 @@ variable [Semiring R] [∀ i, AddCommMonoid (M i)] [∀ i, AddCommMonoid (M₁ i
   [AddCommMonoid M₃] [AddCommMonoid M'] [∀ i, Module R (M i)] [∀ i, Module R (M₁ i)] [Module R M₂]
   [Module R M₃] [Module R M'] (f f' : MultilinearMap R M₁ M₂)
 
--- Porting note: Replaced CoeFun with DFunLike instance
-instance : DFunLike (MultilinearMap R M₁ M₂) (∀ i, M₁ i) (fun _ ↦ M₂) where
+-- Porting note: Replaced CoeFun with FunLike instance
+instance : FunLike (MultilinearMap R M₁ M₂) (∀ i, M₁ i) M₂ where
   coe f := f.toFun
   coe_injective' := fun f g h ↦ by cases f; cases g; cases h; rfl
 

--- a/Mathlib/LinearAlgebra/PerfectPairing.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing.lean
@@ -43,7 +43,7 @@ variable {R M N}
 
 namespace PerfectPairing
 
-instance instDFunLike : DFunLike (PerfectPairing R M N) M (fun _  ↦ N →ₗ[R] R) where
+instance instFunLike : FunLike (PerfectPairing R M N) M (N →ₗ[R] R) where
   coe f := f.toLin
   coe_injective' x y h := by cases x; cases y; simpa using h
 

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -370,10 +370,10 @@ open Submodule
 /--
 A linear endomorphism of a module `E` is a projection onto a submodule `p` if it sends every element
 of `E` to `p` and fixes every element of `p`.
-The definition allow more generally any `DFunLike` type and not just linear maps, so that it can be
+The definition allow more generally any `FunLike` type and not just linear maps, so that it can be
 used for example with `ContinuousLinearMap` or `Matrix`.
 -/
-structure IsProj {F : Type*} [DFunLike F M fun _ => M] (f : F) : Prop where
+structure IsProj {F : Type*} [FunLike F M M] (f : F) : Prop where
   map_mem : ∀ x, f x ∈ m
   map_id : ∀ x ∈ m, f x = x
 #align linear_map.is_proj LinearMap.IsProj

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -153,7 +153,7 @@ variable [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 variable {Q Q' : QuadraticForm R M}
 
-instance instDFunLike : DFunLike (QuadraticForm R M) M fun _ => R where
+instance instFunLike : FunLike (QuadraticForm R M) M R where
   coe := toFun
   coe_injective' x y h := by cases x; cases y; congr
 #align quadratic_form.fun_like QuadraticForm.instDFunLike

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -156,7 +156,7 @@ variable {Q Q' : QuadraticForm R M}
 instance instFunLike : FunLike (QuadraticForm R M) M R where
   coe := toFun
   coe_injective' x y h := by cases x; cases y; congr
-#align quadratic_form.fun_like QuadraticForm.instDFunLike
+#align quadratic_form.fun_like QuadraticForm.instFunLike
 
 /-- Helper instance for when there's too many metavariables to apply
 `DFunLike.hasCoeToFun` directly. -/
@@ -241,7 +241,7 @@ theorem map_zero : Q 0 = 0 := by
 #align quadratic_form.map_zero QuadraticForm.map_zero
 
 instance zeroHomClass : ZeroHomClass (QuadraticForm R M) M R :=
-  { QuadraticForm.instDFunLike with map_zero := map_zero }
+  { QuadraticForm.instFunLike with map_zero := map_zero }
 #align quadratic_form.zero_hom_class QuadraticForm.zeroHomClass
 
 theorem map_smul_of_tower [CommSemiring S] [Algebra S R] [Module S M] [IsScalarTower S R M] (a : S)

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -102,8 +102,8 @@ instance : EquivLike (α ≃ β) α β where
   coe_injective' e₁ e₂ h₁ h₂ := by cases e₁; cases e₂; congr
 
 /-- Helper instance when inference gets stuck on following the normal chain
-`EquivLike → EmbeddingLike → DFunLike → CoeFun`. -/
-instance : DFunLike (α ≃ β) α (fun _ => β) :=
+`EquivLike → EmbeddingLike → FunLike → CoeFun`. -/
+instance : FunLike (α ≃ β) α β :=
   EmbeddingLike.toDFunLike
 
 @[simp, norm_cast]

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -456,7 +456,7 @@ end Structure
 /-- `HomClass L F M N` states that `F` is a type of `L`-homomorphisms. You should extend this
   typeclass when you extend `FirstOrder.Language.Hom`. -/
 class HomClass (L : outParam Language) (F : Type*) (M N : outParam <| Type*)
-  [DFunLike F M fun _ => N] [L.Structure M] [L.Structure N] : Prop where
+  [FunLike F M N] [L.Structure M] [L.Structure N] : Prop where
   map_fun : ∀ (φ : F) {n} (f : L.Functions n) (x), φ (funMap f x) = funMap f (φ ∘ x)
   map_rel : ∀ (φ : F) {n} (r : L.Relations n) (x), RelMap r x → RelMap r (φ ∘ x)
 #align first_order.language.hom_class FirstOrder.Language.HomClass
@@ -464,26 +464,26 @@ class HomClass (L : outParam Language) (F : Type*) (M N : outParam <| Type*)
 /-- `StrongHomClass L F M N` states that `F` is a type of `L`-homomorphisms which preserve
   relations in both directions. -/
 class StrongHomClass (L : outParam Language) (F : Type*) (M N : outParam <| Type*)
-  [DFunLike F M fun _ => N] [L.Structure M] [L.Structure N] : Prop where
+  [FunLike F M N] [L.Structure M] [L.Structure N] : Prop where
   map_fun : ∀ (φ : F) {n} (f : L.Functions n) (x), φ (funMap f x) = funMap f (φ ∘ x)
   map_rel : ∀ (φ : F) {n} (r : L.Relations n) (x), RelMap r (φ ∘ x) ↔ RelMap r x
 #align first_order.language.strong_hom_class FirstOrder.Language.StrongHomClass
 
 --Porting note: using implicit brackets for `Structure` arguments
 instance (priority := 100) StrongHomClass.homClass [L.Structure M]
-    [L.Structure N] [DFunLike F M fun _ => N] [StrongHomClass L F M N] : HomClass L F M N where
+    [L.Structure N] [FunLike F M N] [StrongHomClass L F M N] : HomClass L F M N where
   map_fun := StrongHomClass.map_fun
   map_rel φ _ R x := (StrongHomClass.map_rel φ R x).2
 #align first_order.language.strong_hom_class.hom_class FirstOrder.Language.StrongHomClass.homClass
 
 /-- Not an instance to avoid a loop. -/
 theorem HomClass.strongHomClassOfIsAlgebraic [L.IsAlgebraic] {F M N} [L.Structure M] [L.Structure N]
-    [DFunLike F M fun _ => N] [HomClass L F M N] : StrongHomClass L F M N where
+    [FunLike F M N] [HomClass L F M N] : StrongHomClass L F M N where
   map_fun := HomClass.map_fun
   map_rel _ n R _ := (IsAlgebraic.empty_relations n).elim R
 #align first_order.language.hom_class.strong_hom_class_of_is_algebraic FirstOrder.Language.HomClass.strongHomClassOfIsAlgebraic
 
-theorem HomClass.map_constants {F M N} [L.Structure M] [L.Structure N] [DFunLike F M fun _ => N]
+theorem HomClass.map_constants {F M N} [L.Structure M] [L.Structure N] [FunLike F M N]
     [HomClass L F M N] (φ : F) (c : L.Constants) : φ c = c :=
   (HomClass.map_fun φ c default).trans (congr rfl (funext default))
 #align first_order.language.hom_class.map_constants FirstOrder.Language.HomClass.map_constants
@@ -498,10 +498,10 @@ attribute [inherit_doc FirstOrder.Language.Hom.map_rel'] FirstOrder.Language.Emb
 
 namespace Hom
 
-instance instDFunLike : DFunLike (M →[L] N) M fun _ => N where
+instance instFunLike : FunLike (M →[L] N) M N where
   coe := Hom.toFun
   coe_injective' f g h := by cases f; cases g; cases h; rfl
-#align first_order.language.hom.fun_like FirstOrder.Language.Hom.instDFunLike
+#align first_order.language.hom.fun_like FirstOrder.Language.Hom.instFunLike
 
 instance homClass : HomClass L (M →[L] N) M N where
   map_fun := map_fun'
@@ -588,7 +588,7 @@ theorem comp_assoc (f : M →[L] N) (g : N →[L] P) (h : P →[L] Q) :
 end Hom
 
 /-- Any element of a `HomClass` can be realized as a first_order homomorphism. -/
-def HomClass.toHom {F M N} [L.Structure M] [L.Structure N] [DFunLike F M fun _ => N]
+def HomClass.toHom {F M N} [L.Structure M] [L.Structure N] [FunLike F M N]
     [HomClass L F M N] : F → M →[L] N := fun φ =>
   ⟨φ, HomClass.map_fun φ, HomClass.map_rel φ⟩
 #align first_order.language.hom_class.to_hom FirstOrder.Language.HomClass.toHom
@@ -968,7 +968,7 @@ instance : Unique (Language.empty.Structure M) :=
   ⟨⟨Language.emptyStructure⟩, fun a => by
     ext _ f <;> exact Empty.elim f⟩
 
-instance (priority := 100) strongHomClassEmpty {F M N} [DFunLike F M fun _ => N] :
+instance (priority := 100) strongHomClassEmpty {F M N} [FunLike F M N] :
     StrongHomClass Language.empty F M N :=
   ⟨fun _ _ f => Empty.elim f, fun _ _ r => Empty.elim r⟩
 #align first_order.language.strong_hom_class_empty FirstOrder.Language.strongHomClassEmpty

--- a/Mathlib/ModelTheory/ElementaryMaps.lean
+++ b/Mathlib/ModelTheory/ElementaryMaps.lean
@@ -63,7 +63,7 @@ namespace ElementaryEmbedding
 
 attribute [coe] toFun
 
-instance instDFunLike : DFunLike (M ↪ₑ[L] N) M fun _ => N where
+instance instFunLike : FunLike (M ↪ₑ[L] N) M N where
   coe f := f.toFun
   coe_injective' f g h := by
     cases f
@@ -71,7 +71,7 @@ instance instDFunLike : DFunLike (M ↪ₑ[L] N) M fun _ => N where
     simp only [ElementaryEmbedding.mk.injEq]
     ext x
     exact Function.funext_iff.1 h x
-#align first_order.language.elementary_embedding.fun_like FirstOrder.Language.ElementaryEmbedding.instDFunLike
+#align first_order.language.elementary_embedding.fun_like FirstOrder.Language.ElementaryEmbedding.instFunLike
 
 instance : CoeFun (M ↪ₑ[L] N) fun _ => M → N :=
   DFunLike.hasCoeToFun
@@ -127,7 +127,7 @@ theorem injective (φ : M ↪ₑ[L] N) : Function.Injective φ := by
 #align first_order.language.elementary_embedding.injective FirstOrder.Language.ElementaryEmbedding.injective
 
 instance embeddingLike : EmbeddingLike (M ↪ₑ[L] N) M N :=
-  { show DFunLike (M ↪ₑ[L] N) M fun _ => N from inferInstance with injective' := injective }
+  { show FunLike (M ↪ₑ[L] N) M N from inferInstance with injective' := injective }
 #align first_order.language.elementary_embedding.embedding_like FirstOrder.Language.ElementaryEmbedding.embeddingLike
 
 @[simp]

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -88,8 +88,8 @@ section Zero
 variable [Zero R]
 
 --  porting note: used to be `CoeFun`
-instance : DFunLike (ArithmeticFunction R) ℕ fun _ ↦ R :=
-  inferInstanceAs (DFunLike (ZeroHom ℕ R) ℕ fun _ ↦ R)
+instance : FunLike (ArithmeticFunction R) ℕ R :=
+  inferInstanceAs (FunLike (ZeroHom ℕ R) ℕ R)
 
 @[simp]
 theorem toFun_eq (f : ArithmeticFunction R) : f.toFun = f := rfl

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -98,9 +98,9 @@ namespace Poly
 
 section
 
-instance instDFunLike : DFunLike (Poly α) (α → ℕ) fun _ => ℤ :=
+instance instFunLike : FunLike (Poly α) (α → ℕ) ℤ :=
   ⟨Subtype.val, Subtype.val_injective⟩
-#align poly.fun_like Poly.instDFunLike
+#align poly.fun_like Poly.instFunLike
 
 -- Porting note: This instance is not necessary anymore
 -- /-- Helper instance for when there are too many metavariables to apply `DFunLike.hasCoeToFun`

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -98,8 +98,8 @@ open Multiplicative
 /-- Define coercion to a function so that it includes the move from `R` to `Multiplicative R`.
 After we have proved the API lemmas below, we don't need to worry about writing `ofAdd a`
 when we want to apply an additive character. -/
-instance instDFunLike : DFunLike (AddChar R R') R fun _ ↦ R' :=
-  inferInstanceAs (DFunLike (Multiplicative R →* R') R fun _ ↦ R')
+instance instFunLike : FunLike (AddChar R R') R R' :=
+  inferInstanceAs (FunLike (Multiplicative R →* R') R R')
 #noalign add_char.has_coe_to_fun
 
 theorem coe_to_fun_apply (ψ : AddChar R R') (a : R) : ψ a = ψ.toMonoidHom (ofAdd a) :=
@@ -114,7 +114,7 @@ theorem mul_apply (ψ φ : AddChar R R') (a : R) : (ψ * φ) a = ψ a * φ a :=
 @[simp]
 theorem one_apply (a : R) : (1 : AddChar R R') a = 1 := rfl
 
--- this instance was a bad idea and conflicted with `instDFunLike` above
+-- this instance was a bad idea and conflicted with `instFunLike` above
 #noalign add_char.monoid_hom_class
 
 -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5229): added.

--- a/Mathlib/NumberTheory/LegendreSymbol/MulCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/MulCharacter.lean
@@ -71,7 +71,7 @@ structure MulChar extends MonoidHom R R' where
   map_nonunit' : ∀ a : R, ¬IsUnit a → toFun a = 0
 #align mul_char MulChar
 
-instance MulChar.instDFunLike : DFunLike (MulChar R R') R (fun _ => R') :=
+instance MulChar.instFunLike : FunLike (MulChar R R') R R' :=
   ⟨fun χ => χ.toFun,
     fun χ₀ χ₁ h => by cases χ₀; cases χ₁; congr; apply MonoidHom.ext (fun _ => congr_fun h _)⟩
 

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -278,7 +278,7 @@ namespace NumberField.InfinitePlace
 
 open NumberField
 
-instance {K : Type*} [Field K] : DFunLike (InfinitePlace K) K (fun _ => ℝ) :=
+instance {K : Type*} [Field K] : FunLike (InfinitePlace K) K ℝ :=
 { coe := fun w x => w.1 x
   coe_injective' := fun _ _ h => Subtype.eq (AbsoluteValue.ext fun x => congr_fun h x)}
 

--- a/Mathlib/Order/Category/BddLat.lean
+++ b/Mathlib/Order/Category/BddLat.lean
@@ -64,8 +64,8 @@ instance : LargeCategory.{u} BddLat where
   assoc _ _ _ := BoundedLatticeHom.comp_assoc _ _ _
 
 -- Porting note: added.
-instance instDFunLike (X Y : BddLat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
-  show DFunLike (BoundedLatticeHom X Y) X (fun _ => Y) from inferInstance
+instance instFunLike (X Y : BddLat) : FunLike (X ⟶ Y) X Y :=
+  show FunLike (BoundedLatticeHom X Y) X Y from inferInstance
 
 instance : ConcreteCategory BddLat where
   forget :=

--- a/Mathlib/Order/Category/BddOrd.lean
+++ b/Mathlib/Order/Category/BddOrd.lean
@@ -63,8 +63,8 @@ instance largeCategory : LargeCategory.{u} BddOrd where
 
 -- Porting note: added.
 -- see https://github.com/leanprover-community/mathlib4/issues/5017
-instance instDFunLike (X Y : BddOrd) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
-  show DFunLike (BoundedOrderHom X Y) X (fun _ => Y) from inferInstance
+instance instFunLike (X Y : BddOrd) : FunLike (X ⟶ Y) X Y :=
+  show FunLike (BoundedOrderHom X Y) X Y from inferInstance
 
 instance concreteCategory : ConcreteCategory BddOrd where
   forget :=

--- a/Mathlib/Order/Category/Semilat.lean
+++ b/Mathlib/Order/Category/Semilat.lean
@@ -69,8 +69,8 @@ instance : LargeCategory.{u} SemilatSupCat where
 
 -- Porting note: added
 -- see https://github.com/leanprover-community/mathlib4/issues/5017
-instance instDFunLike (X Y : SemilatSupCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
-  show DFunLike (SupBotHom X Y) X (fun _ => Y) from inferInstance
+instance instFunLike (X Y : SemilatSupCat) : FunLike (X ⟶ Y) X Y :=
+  show FunLike (SupBotHom X Y) X Y from inferInstance
 
 instance : ConcreteCategory SemilatSupCat where
   forget :=
@@ -123,8 +123,8 @@ instance : LargeCategory.{u} SemilatInfCat where
   assoc _ _ _ := InfTopHom.comp_assoc _ _ _
 
 -- Porting note: added
-instance instDFunLike (X Y : SemilatInfCat) : DFunLike (X ⟶ Y) X (fun _ => Y) :=
-  show DFunLike (InfTopHom X Y) X (fun _ => Y) from inferInstance
+instance instFunLike (X Y : SemilatInfCat) : FunLike (X ⟶ Y) X Y :=
+  show FunLike (InfTopHom X Y) X Y from inferInstance
 
 instance : ConcreteCategory SemilatInfCat where
   forget :=

--- a/Mathlib/Order/Hom/Lattice.lean
+++ b/Mathlib/Order/Hom/Lattice.lean
@@ -341,8 +341,8 @@ instance : SupHomClass (SupHom α β) α β where
 
 /-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
--- porting note: replaced `CoeFun` with `DFunLike` so that we use `DFunLike.coe` instead of `toFun`
-instance : DFunLike (SupHom α β) α fun _ => β :=
+-- porting note: replaced `CoeFun` with `FunLike` so that we use `DFunLike.coe` instead of `toFun`
+instance : FunLike (SupHom α β) α β :=
   SupHomClass.toDFunLike
 
 @[simp] lemma toFun_eq_coe (f : SupHom α β) : f.toFun = f := rfl
@@ -529,7 +529,7 @@ instance : InfHomClass (InfHom α β) α β where
 
 /-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
-instance : DFunLike (InfHom α β) α fun _ => β :=
+instance : FunLike (InfHom α β) α β :=
   InfHomClass.toDFunLike
 
 @[simp] lemma toFun_eq_coe (f : InfHom α β) : f.toFun = (f : α → β) := rfl
@@ -725,7 +725,7 @@ instance : SupBotHomClass (SupBotHom α β) α β
   map_bot f := f.map_bot'
 
 -- porting note: replaced `CoeFun` instance with `DFunLike` instance
-instance : DFunLike (SupBotHom α β) α fun _ => β :=
+instance : FunLike (SupBotHom α β) α β :=
   SupHomClass.toDFunLike
 
 lemma toFun_eq_coe (f : SupBotHom α β) : f.toFun = f := rfl
@@ -881,7 +881,7 @@ instance : InfTopHomClass (InfTopHom α β) α β
 
 /-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
-instance : DFunLike (InfTopHom α β) α fun _ => β :=
+instance : FunLike (InfTopHom α β) α β :=
   InfHomClass.toDFunLike
 
 theorem toFun_eq_coe (f : InfTopHom α β) : f.toFun = f := rfl
@@ -1030,7 +1030,7 @@ instance : LatticeHomClass (LatticeHom α β) α β
 
 /-- Helper instance for when there's too many metavariables to apply `DFunLike.hasCoeToFun`
 directly. -/
-instance : DFunLike (LatticeHom α β) α fun _ => β :=
+instance : FunLike (LatticeHom α β) α β :=
   SupHomClass.toDFunLike
 
 lemma toFun_eq_coe (f : LatticeHom α β) : f.toFun = f := rfl

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -64,9 +64,9 @@ noncomputable def kernel (α β : Type*) [MeasurableSpace α] [MeasurableSpace �
   add_mem' hf hg := Measurable.add hf hg
 #align probability_theory.kernel ProbabilityTheory.kernel
 
--- Porting note: using `DFunLike` instead of `CoeFun` to use `DFunLike.coe`
+-- Porting note: using `FunLike` instead of `CoeFun` to use `DFunLike.coe`
 instance {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
-    DFunLike (kernel α β) α fun _ => Measure β where
+    FunLike (kernel α β) α (Measure β) where
   coe := Subtype.val
   coe_injective' := Subtype.val_injective
 

--- a/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
@@ -46,10 +46,10 @@ def PMF.{u} (α : Type u) : Type u :=
 
 namespace PMF
 
-instance instDFunLike : DFunLike (PMF α) α fun _ => ℝ≥0∞ where
+instance instFunLike : FunLike (PMF α) α ℝ≥0∞ where
   coe p a := p.1 a
   coe_injective' _ _ h := Subtype.eq h
-#align pmf.fun_like PMF.instDFunLike
+#align pmf.fun_like PMF.instFunLike
 
 @[ext]
 protected theorem ext {p q : PMF α} (h : ∀ x, p x = q x) : p = q :=

--- a/Mathlib/RingTheory/Congruence.lean
+++ b/Mathlib/RingTheory/Congruence.lean
@@ -72,9 +72,9 @@ section Basic
 
 variable [Add R] [Mul R] (c : RingCon R)
 
---Porting note: upgrade to `DFunLike`
+--Porting note: upgrade to `FunLike`
 /-- A coercion from a congruence relation to its underlying binary relation. -/
-instance : DFunLike (RingCon R) R fun _ => R → Prop :=
+instance : FunLike (RingCon R) R (R → Prop) :=
   { coe := fun c => c.r,
     coe_injective' := fun x y h => by
       rcases x with ⟨⟨x, _⟩, _⟩

--- a/Mathlib/RingTheory/HahnSeries.lean
+++ b/Mathlib/RingTheory/HahnSeries.lean
@@ -1367,7 +1367,7 @@ section AddCommMonoid
 
 variable [PartialOrder Γ] [AddCommMonoid R] {α : Type*}
 
-instance : DFunLike (SummableFamily Γ R α) α fun _ => HahnSeries Γ R where
+instance : FunLike (SummableFamily Γ R α) α (HahnSeries Γ R) where
   coe := toFun
   coe_injective' | ⟨_, _, _⟩, ⟨_, _, _⟩, rfl => rfl
 

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -614,7 +614,7 @@ section Monoid
 
 /-- A valuation is coerced to the underlying function `R → Γ₀`. -/
 instance (R) (Γ₀) [Ring R] [LinearOrderedAddCommMonoidWithTop Γ₀] :
-    DFunLike (AddValuation R Γ₀) R fun _ => Γ₀ where
+    FunLike (AddValuation R Γ₀) R Γ₀ where
   coe v := v.toMonoidWithZeroHom.toFun
   coe_injective' f g := by cases f; cases g; simp (config := {contextual := true})
 

--- a/Mathlib/Tactic/CategoryTheory/Elementwise.lean
+++ b/Mathlib/Tactic/CategoryTheory/Elementwise.lean
@@ -45,7 +45,7 @@ section theorems
 theorem forall_congr_forget_Type (α : Type u) (p : α → Prop) :
     (∀ (x : (forget (Type u)).obj α), p x) ↔ ∀ (x : α), p x := Iff.rfl
 
-attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
 
 theorem forget_hom_Type (α β : Type u) (f : α ⟶ β) : DFunLike.coe f = f := rfl
 

--- a/Mathlib/Topology/Bornology/Hom.lean
+++ b/Mathlib/Topology/Bornology/Hom.lean
@@ -44,7 +44,7 @@ section
 
 You should extend this class when you extend `LocallyBoundedMap`. -/
 class LocallyBoundedMapClass (F : Type*) (α β : outParam <| Type*) [Bornology α]
-    [Bornology β] extends DFunLike F α fun _ => β where
+    [Bornology β] extends FunLike F α β where
   /-- The pullback of the `Bornology.cobounded` filter under the function is contained in the
   cobounded filter. Equivalently, the function maps bounded sets to bounded sets. -/
   comap_cobounded_le (f : F) : (cobounded β).comap f ≤ cobounded α

--- a/Mathlib/Topology/Bornology/Hom.lean
+++ b/Mathlib/Topology/Bornology/Hom.lean
@@ -44,7 +44,7 @@ section
 
 You should extend this class when you extend `LocallyBoundedMap`. -/
 class LocallyBoundedMapClass (F : Type*) (α β : outParam <| Type*) [Bornology α]
-    [Bornology β] extends FunLike F α β where
+    [Bornology β] extends DFunLike F α (fun _ => β) where
   /-- The pullback of the `Bornology.cobounded` filter under the function is contained in the
   cobounded filter. Equivalently, the function maps bounded sets to bounded sets. -/
   comap_cobounded_le (f : F) : (cobounded β).comap f ≤ cobounded α

--- a/Mathlib/Topology/Category/CompHaus/Projective.lean
+++ b/Mathlib/Topology/Category/CompHaus/Projective.lean
@@ -35,7 +35,7 @@ open CategoryTheory Function
 
 namespace CompHaus
 
-attribute [local instance] ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.instFunLike
 
 instance projective_ultrafilter (X : Type*) : Projective (of <| Ultrafilter X)
     where

--- a/Mathlib/Topology/Category/Stonean/Basic.lean
+++ b/Mathlib/Topology/Category/Stonean/Basic.lean
@@ -105,7 +105,7 @@ instance : ConcreteCategory Stonean where
   forget := toCompHaus ⋙ forget _
 
 instance : CoeSort Stonean.{u} (Type u) := ConcreteCategory.hasCoeToSort _
-instance {X Y : Stonean.{u}} : DFunLike (X ⟶ Y) X (fun _ => Y) := ConcreteCategory.instDFunLike
+instance {X Y : Stonean.{u}} : FunLike (X ⟶ Y) X Y := ConcreteCategory.instFunLike
 
 /-- Stonean spaces are topological spaces. -/
 instance instTopologicalSpace (X : Stonean.{u}) : TopologicalSpace X :=

--- a/Mathlib/Topology/Category/TopCat/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Basic.lean
@@ -59,7 +59,7 @@ set_option linter.uppercaseLean3 false in
 #align Top.topological_space_unbundled TopCat.topologicalSpaceUnbundled
 
 -- Porting note: cannot find a coercion to function otherwise
-attribute [instance] ConcreteCategory.instDFunLike in
+attribute [instance] ConcreteCategory.instFunLike in
 instance (X Y : TopCat.{u}) : CoeFun (X ⟶ Y) fun _ => X → Y where
   coe f := f
 

--- a/Mathlib/Topology/ContinuousFunction/Basic.lean
+++ b/Mathlib/Topology/ContinuousFunction/Basic.lean
@@ -42,7 +42,7 @@ section
 
 You should extend this class when you extend `ContinuousMap`. -/
 class ContinuousMapClass (F : Type*) (α β : outParam <| Type*) [TopologicalSpace α]
-  [TopologicalSpace β] extends DFunLike F α fun _ => β where
+  [TopologicalSpace β] extends FunLike F α β where
   /-- Continuity -/
   map_continuous (f : F) : Continuous f
 #align continuous_map_class ContinuousMapClass

--- a/Mathlib/Topology/ContinuousFunction/Basic.lean
+++ b/Mathlib/Topology/ContinuousFunction/Basic.lean
@@ -42,7 +42,7 @@ section
 
 You should extend this class when you extend `ContinuousMap`. -/
 class ContinuousMapClass (F : Type*) (α β : outParam <| Type*) [TopologicalSpace α]
-  [TopologicalSpace β] extends FunLike F α β where
+  [TopologicalSpace β] extends DFunLike F α (fun _ => β) where
   /-- Continuity -/
   map_continuous (f : F) : Continuous f
 #align continuous_map_class ContinuousMapClass

--- a/Mathlib/Topology/Homotopy/HomotopyGroup.lean
+++ b/Mathlib/Topology/Homotopy/HomotopyGroup.lean
@@ -112,10 +112,10 @@ variable {N X x}
 
 namespace GenLoop
 
-instance instDFunLike : DFunLike (Ω^ N X x) (I^N) fun _ => X where
+instance instFunLike : FunLike (Ω^ N X x) (I^N) X where
   coe f := f.1
   coe_injective' := fun ⟨⟨f, _⟩, _⟩ ⟨⟨g, _⟩, _⟩ _ => by congr
-#align gen_loop.fun_like GenLoop.instDFunLike
+#align gen_loop.fun_like GenLoop.instFunLike
 
 @[ext]
 theorem ext (f g : Ω^ N X x) (H : ∀ y, f y = g y) : f = g :=
@@ -133,7 +133,7 @@ def copy (f : Ω^ N X x) (g : (I^N) → X) (h : g = f) : Ω^ N X x :=
   ⟨⟨g, h.symm ▸ f.1.2⟩, by convert f.2⟩
 #align gen_loop.copy GenLoop.copy
 
-/- porting note: this now requires the `instDFunLike` instance,
+/- porting note: this now requires the `instFunLike` instance,
   so the instance is now put before `copy`. -/
 theorem coe_copy (f : Ω^ N X x) {g : (I^N) → X} (h : g = f) : ⇑(copy f g h) = g :=
   rfl

--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -250,7 +250,7 @@ namespace LocallyConstant
 instance [Inhabited Y] : Inhabited (LocallyConstant X Y) :=
   ⟨⟨_, IsLocallyConstant.const default⟩⟩
 
-instance : DFunLike (LocallyConstant X Y) X (fun _ => Y) where
+instance : FunLike (LocallyConstant X Y) X Y where
   coe := LocallyConstant.toFun
   coe_injective' := by rintro ⟨_, _⟩ ⟨_, _⟩ _; congr
 

--- a/Mathlib/Topology/MetricSpace/DilationEquiv.lean
+++ b/Mathlib/Topology/MetricSpace/DilationEquiv.lean
@@ -33,7 +33,7 @@ class DilationEquivClass extends EquivLike F X Y where
   edist_eq' : ∀ f : F, ∃ r : ℝ≥0, r ≠ 0 ∧ ∀ x y : X, edist (f x) (f y) = r * edist x y
 
 instance (priority := 100) [DilationEquivClass F X Y] : DilationClass F X Y :=
-  { inferInstanceAs (DFunLike F X fun _ ↦ Y), ‹DilationEquivClass F X Y› with }
+  { inferInstanceAs (FunLike F X Y), ‹DilationEquivClass F X Y› with }
 
 end Class
 

--- a/Mathlib/Topology/PartitionOfUnity.lean
+++ b/Mathlib/Topology/PartitionOfUnity.lean
@@ -135,7 +135,7 @@ namespace PartitionOfUnity
 variable {E : Type*} [AddCommMonoid E] [SMulWithZero ℝ E] [TopologicalSpace E] [ContinuousSMul ℝ E]
   {s : Set X} (f : PartitionOfUnity ι X s)
 
-instance : DFunLike (PartitionOfUnity ι X s) ι fun _ ↦ C(X, ℝ) where
+instance : FunLike (PartitionOfUnity ι X s) ι C(X, ℝ) where
   coe := toFun
   coe_injective' := fun f g h ↦ by cases f; cases g; congr
 
@@ -281,7 +281,7 @@ namespace BumpCovering
 
 variable {s : Set X} (f : BumpCovering ι X s)
 
-instance : DFunLike (BumpCovering ι X s) ι fun _ ↦ C(X, ℝ) where
+instance : FunLike (BumpCovering ι X s) ι C(X, ℝ) where
   coe := toFun
   coe_injective' := fun f g h ↦ by cases f; cases g; congr
 

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -70,7 +70,7 @@ lemma ext {P Q : Presheaf C X} {f g : P ⟶ Q} (w : ∀ U : Opens X, f.app (op U
   apply w
 
 attribute [local instance] CategoryTheory.ConcreteCategory.hasCoeToSort
-  CategoryTheory.ConcreteCategory.instDFunLike
+  CategoryTheory.ConcreteCategory.instFunLike
 
 /-- attribute `sheaf_restrict` to mark lemmas related to restricting sheaves -/
 macro "sheaf_restrict" : attr =>

--- a/Mathlib/Topology/Sheaves/SheafCondition/UniqueGluing.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/UniqueGluing.lean
@@ -50,7 +50,7 @@ namespace Presheaf
 
 section
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
 
 variable {X : TopCat.{x}} (F : Presheaf C X) {ι : Type x} (U : ι → Opens X)
 
@@ -152,7 +152,7 @@ end TypeValued
 
 section
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
 
 variable [HasLimits C] [ReflectsIsomorphisms (forget C)] [PreservesLimits (forget C)]
 
@@ -179,7 +179,7 @@ open CategoryTheory
 
 section
 
-attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instDFunLike
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
 
 variable [HasLimits C] [ReflectsIsomorphisms (ConcreteCategory.forget (C := C))]
 

--- a/test/CategoryTheory/Elementwise.lean
+++ b/test/CategoryTheory/Elementwise.lean
@@ -10,7 +10,7 @@ open CategoryTheory
 set_option linter.existingAttributeWarning false in
 attribute [simp] Iso.hom_inv_id Iso.inv_hom_id IsIso.hom_inv_id IsIso.inv_hom_id
 
-attribute [local instance] ConcreteCategory.instDFunLike ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
 
 @[elementwise]
 theorem ex1 [Category C] [ConcreteCategory C] (X : C) (f g h : X ⟶ X) (h' : g ≫ h = h ≫ g) :

--- a/test/FunLike.lean
+++ b/test/FunLike.lean
@@ -1,6 +1,6 @@
 import Mathlib.Data.FunLike.Basic
 
-variable {F α β : Sort*} [i : DFunLike F α fun _ ↦ β] (f : F) (a : α)
+variable {F α β : Sort*} [i : FunLike F α β] (f : F) (a : α)
 
 /-- info: f a : β -/
 #guard_msgs in #check f a


### PR DESCRIPTION
This follows up from #9785, which renamed `FunLike` to `DFunLike`, by introducing a new abbreviation `FunLike F α β := DFunLike F α (fun _ => β)`, to make the non-dependent use of `FunLike` easier.

I searched for the pattern `DFunLike.*fun` and `DFunLike.*λ` in all files to replace expressions of the form `DFunLike F α (fun _ => β)` with `FunLike F α β`. I did this everywhere except for `extends` clauses for two reasons: it would conflict with #8386, and more importantly `extends` must directly refer to a structure with no unfolding of `def`s or `abbrev`s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
