### PR TITLE
[Merged by Bors] - chore(Data/Polynomial): tiny proof cleanup

### DIFF
--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -823,11 +823,10 @@ theorem forall_eq_iff_forall_eq : (∀ f g : R[X], f = g) ↔ ∀ a b : R, a = b
 #align polynomial.forall_eq_iff_forall_eq Polynomial.forall_eq_iff_forall_eq
 
 theorem ext_iff {p q : R[X]} : p = q ↔ ∀ n, coeff p n = coeff q n := by
-  rcases p with ⟨⟩
-  rcases q with ⟨⟩
+  rcases p with ⟨f : ℕ →₀ R⟩
+  rcases q with ⟨g : ℕ →₀ R⟩
   -- Porting note: Was `simp [coeff, DFunLike.ext_iff]`
-  simp only [ofFinsupp.injEq, coeff._eq_1]
-  exact DFunLike.ext_iff (F := ℕ →₀ R)
+  simpa [coeff] using DFunLike.ext_iff (f := f) (g := g)
 #align polynomial.ext_iff Polynomial.ext_iff
 
 @[ext]


### PR DESCRIPTION
@kbuzzard spotted that this proof might be cleaned up with the improvements to `simp`. Sadly we can't quite go back to the pre-port simplicity. Is it still worth applying this bit of polish?

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
