### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Galois): evaluation is injective and more basic properties

### DIFF
--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -6,6 +6,7 @@ Authors: Christian Merten
 import Mathlib.CategoryTheory.FintypeCat
 import Mathlib.CategoryTheory.Limits.Constructions.LimitsOfProductsAndEqualizers
 import Mathlib.CategoryTheory.Limits.FintypeCat
+import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Terminal
 import Mathlib.CategoryTheory.Limits.Shapes.Types
 import Mathlib.CategoryTheory.Limits.Shapes.Diagonal
 import Mathlib.CategoryTheory.SingleObj
@@ -126,73 +127,53 @@ noncomputable instance : ReflectsColimitsOfShape (Discrete PEmpty.{1}) F :=
 noncomputable instance : PreservesFiniteLimits F :=
   preservesFiniteLimitsOfPreservesTerminalAndPullbacks F
 
-instance : PreservesMonomorphisms F :=
-  preservesMonomorphisms_of_preservesLimitsOfShape F
-
-/- Fibre functors reflect monomorphisms. -/
-instance : ReflectsMonomorphisms F := ReflectsMonomorphisms.mk <| by
+/-- Fibre functors reflect monomorphisms. -/
+instance foo : ReflectsMonomorphisms F := ReflectsMonomorphisms.mk <| by
   intro X Y f _
-  have : IsIso (pullback.fst : pullback (F.map f) (F.map f) ⟶ F.obj X) :=
+  haveI : IsIso (pullback.fst : pullback (F.map f) (F.map f) ⟶ F.obj X) :=
     fst_iso_of_mono_eq (F.map f)
-  have : IsIso (F.map (pullback.fst : pullback f f ⟶ X)) := by
+  haveI : IsIso (F.map (pullback.fst : pullback f f ⟶ X)) := by
     rw [← PreservesPullback.iso_hom_fst]
     exact IsIso.comp_isIso
-  have : IsIso (pullback.fst : pullback f f ⟶ X) := isIso_of_reflects_iso pullback.fst F
+  haveI : IsIso (pullback.fst : pullback f f ⟶ X) := isIso_of_reflects_iso pullback.fst F
   exact (pullback.diagonal_isKernelPair f).mono_of_isIso_fst
 
-/- Fibre functors are faithful. -/
+/-- Fibre functors are faithful. -/
 instance : Faithful F where
-  map_injective {X Y} := by
-    intro f g h
-    have : IsIso (equalizer.ι (F.map f) (F.map g)) := equalizer.ι_of_eq h
-    have : IsIso (F.map (equalizer.ι f g)) := by
+  map_injective {X Y} f g h := by
+    haveI : IsIso (equalizer.ι (F.map f) (F.map g)) := equalizer.ι_of_eq h
+    haveI : IsIso (F.map (equalizer.ι f g)) := by
       rw [← equalizerComparison_comp_π f g F]
       exact IsIso.comp_isIso
-    have : IsIso (equalizer.ι f g) := isIso_of_reflects_iso _ F
+    haveI : IsIso (equalizer.ι f g) := isIso_of_reflects_iso _ F
     exact eq_of_epi_equalizer
 
 end FibreFunctor
 
 variable (F : C ⥤ FintypeCat.{w}) [FibreFunctor F]
 
-private lemma IsInitial.isInitial_iff_obj {D : Type v₁} [Category.{v₂} D] (G : C ⥤ D)
-    [PreservesColimitsOfShape (Discrete PEmpty.{1}) G]
-    [ReflectsColimitsOfShape (Discrete PEmpty.{1}) G] (X : C) :
-    Nonempty (IsInitial X) ↔ Nonempty (IsInitial (G.obj X)) := by
-  constructor
-  · intro ⟨h⟩
-    exact ⟨IsInitial.isInitialObj G X h⟩
-  · intro ⟨h⟩
-    exact ⟨IsInitial.isInitialOfObj G X h⟩
-
-private lemma Types.initial_iff_empty (X : Type w) : Nonempty (IsInitial X) ↔ IsEmpty X := by
-  constructor
-  · intro ⟨h⟩
-    exact Function.isEmpty (IsInitial.to h PEmpty)
-  · intro h
-    exact ⟨IsInitial.ofIso Types.isInitialPunit <| Equiv.toIso <| Equiv.equivOfIsEmpty PEmpty X⟩
-
 private lemma FintypeCat.initial_iff_empty (X : FintypeCat.{w}) :
     Nonempty (IsInitial X) ↔ IsEmpty X := by
-  rw [IsInitial.isInitial_iff_obj FintypeCat.incl, Types.initial_iff_empty]
+  rw [(IsInitial.isInitialIffObj FintypeCat.incl X).nonempty_congr, Types.initial_iff_empty]
   rfl
 
-/- An object is initial if and only if fibre is empty. -/
+/-- An object is initial if and only if its fibre is empty. -/
 lemma initial_iff_fibre_empty (X : C) : Nonempty (IsInitial X) ↔ IsEmpty (F.obj X) := by
-  rw [IsInitial.isInitial_iff_obj F X]
+  rw [(IsInitial.isInitialIffObj F X).nonempty_congr]
   exact FintypeCat.initial_iff_empty (F.obj X)
 
-/- An object is not initial, if fibre is nonempty. -/
+/-- An object is not initial, if its fibre is inhabited. -/
 lemma not_initial_of_inhabited {X : C} (x : F.obj X) (h : IsInitial X) : False :=
   ((initial_iff_fibre_empty F X).mp ⟨h⟩).false x
 
-/- Fibre of connected object is nonempty. -/
+/-- The fibre of a connected object is nonempty. -/
 lemma nonempty_fibre_of_connected (X : C) [ConnectedObject X] : Nonempty (F.obj X) := by
   by_contra h
   have ⟨hin⟩ : Nonempty (IsInitial X) := (initial_iff_fibre_empty F X).mpr (not_nonempty_iff.mp h)
   exact ConnectedObject.notInitial hin
 
-/- Fibre of equalizer of `f g : X ⟶ Y` is equivalent to set of agreement of `f` and `g`. -/
+/-- The fibre of the equalizer of `f g : X ⟶ Y` is equivalent to the set of agreement of `f`
+and `g`. -/
 private noncomputable def fibreEqualizerEquiv {X Y : C} (f g : X ⟶ Y) :
     F.obj (equalizer f g) ≃ { x : F.obj X // F.map f x = F.map g x } := by
   apply Iso.toEquiv
@@ -200,22 +181,22 @@ private noncomputable def fibreEqualizerEquiv {X Y : C} (f g : X ⟶ Y) :
   · exact PreservesEqualizer.iso (F ⋙ FintypeCat.incl) f g
   · exact Types.equalizerIso (F.map f) (F.map g)
 
-/- The evaluation map is injective for connected objects. -/
+/-- The evaluation map is injective for connected objects. -/
 lemma evaluationInjective_of_connected (A X : C) [ConnectedObject A] (a : F.obj A) :
-    Function.Injective (fun (f : A ⟶ X) => F.map f a) := by
+    Function.Injective (fun (f : A ⟶ X) ↦ F.map f a) := by
   intro f g (h : F.map f a = F.map g a)
-  have : IsIso (equalizer.ι f g) := by
+  haveI : IsIso (equalizer.ι f g) := by
     apply ConnectedObject.noTrivialComponent _ (equalizer.ι f g)
     exact not_initial_of_inhabited F ((fibreEqualizerEquiv F f g).symm ⟨a, h⟩)
   exact eq_of_epi_equalizer
 
-/- The evaluation map on automorphisms is injective for connected objects. -/
+/-- The evaluation map on automorphisms is injective for connected objects. -/
 lemma evaluation_aut_injective_of_connected (A : C) [ConnectedObject A] (a : F.obj A) :
-    Function.Injective (fun f : Aut A => F.map (f.hom) a) := by
-  show Function.Injective ((fun f : A ⟶ A => F.map f a) ∘ (fun f : Aut A => f.hom))
+    Function.Injective (fun f : Aut A ↦ F.map (f.hom) a) := by
+  show Function.Injective ((fun f : A ⟶ A ↦ F.map f a) ∘ (fun f : Aut A ↦ f.hom))
   apply Function.Injective.comp
-  exact evaluationInjective_of_connected F A A a
-  exact @Aut.ext _ _ A
+  · exact evaluationInjective_of_connected F A A a
+  · exact @Aut.ext _ _ A
 
 end PreGaloisCategory
 

--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -8,6 +8,7 @@ import Mathlib.CategoryTheory.Limits.Constructions.LimitsOfProductsAndEqualizers
 import Mathlib.CategoryTheory.Limits.FintypeCat
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Terminal
 import Mathlib.CategoryTheory.Limits.Shapes.Types
+import Mathlib.CategoryTheory.Limits.Shapes.ConcreteCategory
 import Mathlib.CategoryTheory.Limits.Shapes.Diagonal
 import Mathlib.CategoryTheory.SingleObj
 
@@ -152,15 +153,16 @@ end FibreFunctor
 
 variable (F : C ⥤ FintypeCat.{w}) [FibreFunctor F]
 
-private lemma FintypeCat.initial_iff_empty (X : FintypeCat.{w}) :
-    Nonempty (IsInitial X) ↔ IsEmpty X := by
-  rw [(IsInitial.isInitialIffObj FintypeCat.incl X).nonempty_congr, Types.initial_iff_empty]
-  rfl
-
 /-- An object is initial if and only if its fibre is empty. -/
 lemma initial_iff_fibre_empty (X : C) : Nonempty (IsInitial X) ↔ IsEmpty (F.obj X) := by
   rw [(IsInitial.isInitialIffObj F X).nonempty_congr]
-  exact FintypeCat.initial_iff_empty (F.obj X)
+  haveI : PreservesFiniteColimits (forget FintypeCat) := by
+    show PreservesFiniteColimits FintypeCat.incl
+    infer_instance
+  haveI : ReflectsColimit (Functor.empty.{0} _) (forget FintypeCat) := by
+    show ReflectsColimit (Functor.empty.{0} _) FintypeCat.incl
+    infer_instance
+  exact Concrete.initial_iff_empty_of_preserves_of_reflects (F.obj X)
 
 /-- An object whose fibre is inhabited is not initial. -/
 lemma not_initial_of_inhabited {X : C} (x : F.obj X) (h : IsInitial X) : False :=

--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -5,6 +5,9 @@ Authors: Christian Merten
 -/
 import Mathlib.CategoryTheory.FintypeCat
 import Mathlib.CategoryTheory.Limits.Constructions.LimitsOfProductsAndEqualizers
+import Mathlib.CategoryTheory.Limits.FintypeCat
+import Mathlib.CategoryTheory.Limits.Shapes.Types
+import Mathlib.CategoryTheory.Limits.Shapes.Diagonal
 import Mathlib.CategoryTheory.SingleObj
 
 /-!
@@ -123,7 +126,95 @@ noncomputable instance : ReflectsColimitsOfShape (Discrete PEmpty.{1}) F :=
 noncomputable instance : PreservesFiniteLimits F :=
   preservesFiniteLimitsOfPreservesTerminalAndPullbacks F
 
+instance : PreservesMonomorphisms F :=
+  preservesMonomorphisms_of_preservesLimitsOfShape F
+
+/- Fibre functors reflect monomorphisms. -/
+instance : ReflectsMonomorphisms F := ReflectsMonomorphisms.mk <| by
+  intro X Y f _
+  have : IsIso (pullback.fst : pullback (F.map f) (F.map f) ⟶ F.obj X) :=
+    fst_iso_of_mono_eq (F.map f)
+  have : IsIso (F.map (pullback.fst : pullback f f ⟶ X)) := by
+    rw [← PreservesPullback.iso_hom_fst]
+    exact IsIso.comp_isIso
+  have : IsIso (pullback.fst : pullback f f ⟶ X) := isIso_of_reflects_iso pullback.fst F
+  exact (pullback.diagonal_isKernelPair f).mono_of_isIso_fst
+
+/- Fibre functors are faithful. -/
+instance : Faithful F where
+  map_injective {X Y} := by
+    intro f g h
+    have : IsIso (equalizer.ι (F.map f) (F.map g)) := equalizer.ι_of_eq h
+    have : IsIso (F.map (equalizer.ι f g)) := by
+      rw [←equalizerComparison_comp_π f g F]
+      exact IsIso.comp_isIso
+    have : IsIso (equalizer.ι f g) := isIso_of_reflects_iso _ F
+    exact eq_of_epi_equalizer
+
 end FibreFunctor
+
+variable (F : C ⥤ FintypeCat.{w}) [FibreFunctor F]
+
+private lemma IsInitial.isInitial_iff_obj {D : Type v₁} [Category.{v₂} D] (G : C ⥤ D)
+    [PreservesColimitsOfShape (Discrete PEmpty.{1}) G]
+    [ReflectsColimitsOfShape (Discrete PEmpty.{1}) G] (X : C) :
+    Nonempty (IsInitial X) ↔ Nonempty (IsInitial (G.obj X)) := by
+  constructor
+  · intro ⟨h⟩
+    exact ⟨IsInitial.isInitialObj G X h⟩
+  · intro ⟨h⟩
+    exact ⟨IsInitial.isInitialOfObj G X h⟩
+
+private lemma Types.initial_iff_empty (X : Type w) : Nonempty (IsInitial X) ↔ IsEmpty X := by
+  constructor
+  · intro ⟨h⟩
+    exact Function.isEmpty (IsInitial.to h PEmpty)
+  · intro h
+    exact ⟨IsInitial.ofIso Types.isInitialPunit <| Equiv.toIso <| Equiv.equivOfIsEmpty PEmpty X⟩
+
+private lemma FintypeCat.initial_iff_empty (X : FintypeCat.{w}) : Nonempty (IsInitial X) ↔ IsEmpty X := by
+  rw [IsInitial.isInitial_iff_obj FintypeCat.incl, Types.initial_iff_empty]
+  rfl
+
+/- An object is initial if and only if fibre is empty. -/
+lemma initial_iff_fibre_empty (X : C) : Nonempty (IsInitial X) ↔ IsEmpty (F.obj X) := by
+  rw [IsInitial.isInitial_iff_obj F X]
+  exact FintypeCat.initial_iff_empty (F.obj X)
+
+/- An object is not initial, if fibre is nonempty. -/
+lemma not_initial_of_inhabited {X : C} (x : F.obj X) (h : IsInitial X) : False :=
+  ((initial_iff_fibre_empty F X).mp ⟨h⟩).false x
+
+/- Fibre of connected object is nonempty. -/
+lemma nonempty_fibre_of_connected (X : C) [ConnectedObject X] : Nonempty (F.obj X) := by
+  by_contra h
+  have ⟨hin⟩ : Nonempty (IsInitial X) := (initial_iff_fibre_empty F X).mpr (not_nonempty_iff.mp h)
+  exact ConnectedObject.notInitial hin
+
+/- Fibre of equalizer of `f g : X ⟶ Y` is equivalent to set of agreement of `f` and `g`. -/
+private noncomputable def fibreEqualizerEquiv {X Y : C} (f g : X ⟶ Y) :
+    F.obj (equalizer f g) ≃ { x : F.obj X // F.map f x = F.map g x } := by
+  apply Iso.toEquiv
+  trans
+  · exact PreservesEqualizer.iso (F ⋙ FintypeCat.incl) f g
+  · exact Types.equalizerIso (F.map f) (F.map g)
+
+/- The evaluation map is injective for connected objects. -/
+lemma evaluationInjective_of_connected (A X : C) [ConnectedObject A] (a : F.obj A) :
+    Function.Injective (fun (f : A ⟶ X) => F.map f a) := by
+  intro f g (h : F.map f a = F.map g a)
+  have : IsIso (equalizer.ι f g) := by
+    apply ConnectedObject.noTrivialComponent _ (equalizer.ι f g)
+    exact not_initial_of_inhabited F ((fibreEqualizerEquiv F f g).symm ⟨a, h⟩)
+  exact eq_of_epi_equalizer
+
+/- The evaluation map on automorphisms is injective for connected objects. -/
+lemma evaluation_aut_injective_of_connected (A : C) [ConnectedObject A] (a : F.obj A) :
+    Function.Injective (fun f : Aut A => F.map (f.hom) a) := by
+  show Function.Injective ((fun f : A ⟶ A => F.map f a) ∘ (fun f : Aut A => f.hom))
+  apply Function.Injective.comp
+  exact evaluationInjective_of_connected F A A a
+  exact @Aut.ext _ _ A
 
 end PreGaloisCategory
 

--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -146,7 +146,7 @@ instance : Faithful F where
     intro f g h
     have : IsIso (equalizer.ι (F.map f) (F.map g)) := equalizer.ι_of_eq h
     have : IsIso (F.map (equalizer.ι f g)) := by
-      rw [←equalizerComparison_comp_π f g F]
+      rw [← equalizerComparison_comp_π f g F]
       exact IsIso.comp_isIso
     have : IsIso (equalizer.ι f g) := isIso_of_reflects_iso _ F
     exact eq_of_epi_equalizer
@@ -172,7 +172,8 @@ private lemma Types.initial_iff_empty (X : Type w) : Nonempty (IsInitial X) ↔ 
   · intro h
     exact ⟨IsInitial.ofIso Types.isInitialPunit <| Equiv.toIso <| Equiv.equivOfIsEmpty PEmpty X⟩
 
-private lemma FintypeCat.initial_iff_empty (X : FintypeCat.{w}) : Nonempty (IsInitial X) ↔ IsEmpty X := by
+private lemma FintypeCat.initial_iff_empty (X : FintypeCat.{w}) :
+    Nonempty (IsInitial X) ↔ IsEmpty X := by
   rw [IsInitial.isInitial_iff_obj FintypeCat.incl, Types.initial_iff_empty]
   rfl
 

--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -128,7 +128,7 @@ noncomputable instance : PreservesFiniteLimits F :=
   preservesFiniteLimitsOfPreservesTerminalAndPullbacks F
 
 /-- Fibre functors reflect monomorphisms. -/
-instance foo : ReflectsMonomorphisms F := ReflectsMonomorphisms.mk <| by
+instance : ReflectsMonomorphisms F := ReflectsMonomorphisms.mk <| by
   intro X Y f _
   haveI : IsIso (pullback.fst : pullback (F.map f) (F.map f) ⟶ F.obj X) :=
     fst_iso_of_mono_eq (F.map f)
@@ -162,7 +162,7 @@ lemma initial_iff_fibre_empty (X : C) : Nonempty (IsInitial X) ↔ IsEmpty (F.ob
   rw [(IsInitial.isInitialIffObj F X).nonempty_congr]
   exact FintypeCat.initial_iff_empty (F.obj X)
 
-/-- An object is not initial, if its fibre is inhabited. -/
+/-- An object whose fibre is inhabited is not initial. -/
 lemma not_initial_of_inhabited {X : C} (x : F.obj X) (h : IsInitial X) : False :=
   ((initial_iff_fibre_empty F X).mp ⟨h⟩).false x
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Terminal.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Terminal.lean
@@ -66,7 +66,6 @@ def IsTerminal.isTerminalIffObj [PreservesLimit (Functor.empty.{0} C) G]
   left_inv := by aesop_cat
   right_inv := by aesop_cat
 
-
 /-- Preserving the terminal object implies preserving all limits of the empty diagram. -/
 def preservesLimitsOfShapePemptyOfPreservesTerminal [PreservesLimit (Functor.empty.{0} C) G] :
     PreservesLimitsOfShape (Discrete PEmpty) G where

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Terminal.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Terminal.lean
@@ -56,6 +56,17 @@ def IsTerminal.isTerminalOfObj [ReflectsLimit (Functor.empty.{0} C) G] (l : IsTe
   ReflectsLimit.reflects ((isLimitMapConeEmptyConeEquiv G X).symm l)
 #align category_theory.limits.is_terminal.is_terminal_of_obj CategoryTheory.Limits.IsTerminal.isTerminalOfObj
 
+/-- A functor that preserves and reflects terminal objects induces an equivalence on
+`IsTerminal`. -/
+def IsTerminal.isTerminalIffObj [PreservesLimit (Functor.empty.{0} C) G]
+    [ReflectsLimit (Functor.empty.{0} C) G] (X : C) :
+    IsTerminal X ≃ IsTerminal (G.obj X) where
+  toFun := IsTerminal.isTerminalObj G X
+  invFun := IsTerminal.isTerminalOfObj G X
+  left_inv := by aesop_cat
+  right_inv := by aesop_cat
+
+
 /-- Preserving the terminal object implies preserving all limits of the empty diagram. -/
 def preservesLimitsOfShapePemptyOfPreservesTerminal [PreservesLimit (Functor.empty.{0} C) G] :
     PreservesLimitsOfShape (Discrete PEmpty) G where
@@ -148,6 +159,15 @@ def IsInitial.isInitialOfObj [ReflectsColimit (Functor.empty.{0} C) G] (l : IsIn
     IsInitial X :=
   ReflectsColimit.reflects ((isColimitMapCoconeEmptyCoconeEquiv G X).symm l)
 #align category_theory.limits.is_initial.is_initial_of_obj CategoryTheory.Limits.IsInitial.isInitialOfObj
+
+/-- A functor that preserves and reflects initial objects induces an equivalence on `IsInitial`. -/
+def IsInitial.isInitialIffObj [PreservesColimit (Functor.empty.{0} C) G]
+    [ReflectsColimit (Functor.empty.{0} C) G] (X : C) :
+    IsInitial X ≃ IsInitial (G.obj X) where
+  toFun := IsInitial.isInitialObj G X
+  invFun := IsInitial.isInitialOfObj G X
+  left_inv := by aesop_cat
+  right_inv := by aesop_cat
 
 /-- Preserving the initial object implies preserving all colimits of the empty diagram. -/
 def preservesColimitsOfShapePemptyOfPreservesInitial [PreservesColimit (Functor.empty.{0} C) G] :

--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -99,13 +99,13 @@ section Initial
 variable [ConcreteCategory.{w} C]
 
 /-- If `forget C` preserves initials and `X` is initial, then `(forget C).obj X` is empty. -/
-def emptyOfInitialOfPreserves [PreservesColimit (Functor.empty.{0} C) (forget C)] (X : C)
+lemma empty_of_initial_of_preserves [PreservesColimit (Functor.empty.{0} C) (forget C)] (X : C)
     (h : Nonempty (IsInitial X)) : IsEmpty ((forget C).obj X) := by
   rw [← Types.initial_iff_empty]
   exact Nonempty.map (IsInitial.isInitialObj (forget C) _) h
 
 /-- If `forget C` reflects initials and `(forget C).obj X` is empty, then `X` is initial. -/
-def initialOfEmptyOfReflects [ReflectsColimit (Functor.empty.{0} C) (forget C)] (X : C)
+lemma initial_of_empty_of_reflects [ReflectsColimit (Functor.empty.{0} C) (forget C)] (X : C)
     (h : IsEmpty ((forget C).obj X)) : Nonempty (IsInitial X) :=
   Nonempty.map (IsInitial.isInitialOfObj (forget C) _) <|
     (Types.initial_iff_empty ((forget C).obj X)).mpr h

--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -99,13 +99,13 @@ section Initial
 variable [ConcreteCategory.{w} C]
 
 /-- If `forget C` preserves initials and `X` is initial, then `(forget C).obj X` is empty. -/
-instance [PreservesColimit (Functor.empty.{0} C) (forget C)] (X : C) (h : Nonempty (IsInitial X)) :
-    IsEmpty ((forget C).obj X) := by
+def emptyOfInitialOfPreserves [PreservesColimit (Functor.empty.{0} C) (forget C)] (X : C)
+    (h : Nonempty (IsInitial X)) : IsEmpty ((forget C).obj X) := by
   rw [← Types.initial_iff_empty]
   exact Nonempty.map (IsInitial.isInitialObj (forget C) _) h
 
 /-- If `forget C` reflects initials and `(forget C).obj X` is empty, then `X` is initial. -/
-instance [ReflectsColimit (Functor.empty.{0} C) (forget C)] (X : C)
+def initialOfEmptyOfReflects [ReflectsColimit (Functor.empty.{0} C) (forget C)] (X : C)
     (h : IsEmpty ((forget C).obj X)) : Nonempty (IsInitial X) :=
   Nonempty.map (IsInitial.isInitialOfObj (forget C) _) <|
     (Types.initial_iff_empty ((forget C).obj X)).mpr h

--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -61,9 +61,28 @@ end Products
 
 section Terminal
 
+variable [ConcreteCategory.{w} C]
+
+/-- If `forget C` preserves terminals and `X` is terminal, then `(forget C).obj X` is a
+singleton. -/
+noncomputable instance [PreservesLimit (Functor.empty.{0} C) (forget C)] (X : C)
+    (h : IsTerminal X) : Unique ((forget C).obj X) :=
+  Types.isTerminalEquivUnique ((forget C).obj X) <| IsTerminal.isTerminalObj (forget C) X h
+
+/-- If `forget C` reflects terminals and `(forget C).obj X` is a singleton, then `X` is terminal. -/
+noncomputable instance [ReflectsLimit (Functor.empty.{0} C) (forget C)] (X : C)
+    (h : Unique ((forget C).obj X)) : IsTerminal X :=
+  IsTerminal.isTerminalOfObj (forget C) X <| (Types.isTerminalEquivUnique ((forget C).obj X)).symm h
+
+/-- The equivalence `IsTerminal X ≃ Unique ((forget C).obj X)` if the forgetful functor
+preserves and reflects terminals. -/
+noncomputable def terminalIffUnique [PreservesLimit (Functor.empty.{0} C) (forget C)]
+    [ReflectsLimit (Functor.empty.{0} C) (forget C)] (X : C) :
+    IsTerminal X ≃ Unique ((forget C).obj X) :=
+  (IsTerminal.isTerminalIffObj (forget C) X).trans <| Types.isTerminalEquivUnique _
+
 variable (C)
-variable [ConcreteCategory.{w} C] [HasTerminal C]
-  [PreservesLimit (Functor.empty.{0} C) (forget C)]
+variable [HasTerminal C] [PreservesLimit (Functor.empty.{0} C) (forget C)]
 
 /-- The equivalence `(forget C).obj (⊤_ C) ≃ PUnit` when `C` is a concrete category. -/
 noncomputable def terminalEquiv : (forget C).obj (⊤_ C) ≃ PUnit :=
@@ -74,6 +93,31 @@ noncomputable instance : Unique ((forget C).obj (⊤_ C)) where
   uniq _ := (terminalEquiv C).injective (Subsingleton.elim _ _)
 
 end Terminal
+
+section Initial
+
+variable [ConcreteCategory.{w} C]
+
+/-- If `forget C` preserves initials and `X` is initial, then `(forget C).obj X` is empty. -/
+instance [PreservesColimit (Functor.empty.{0} C) (forget C)] (X : C) (h : Nonempty (IsInitial X)) :
+    IsEmpty ((forget C).obj X) := by
+  rw [← Types.initial_iff_empty]
+  exact Nonempty.map (IsInitial.isInitialObj (forget C) _) h
+
+/-- If `forget C` reflects initials and `(forget C).obj X` is empty, then `X` is initial. -/
+instance [ReflectsColimit (Functor.empty.{0} C) (forget C)] (X : C)
+    (h : IsEmpty ((forget C).obj X)) : Nonempty (IsInitial X) :=
+  Nonempty.map (IsInitial.isInitialOfObj (forget C) _) <|
+    (Types.initial_iff_empty ((forget C).obj X)).mpr h
+
+/-- If `forget C` preserves and reflects initials, then `X` is initial if and only if
+`(forget C).obj X` is empty. -/
+lemma initial_iff_empty_of_preserves_of_reflects [PreservesColimit (Functor.empty.{0} C) (forget C)]
+    [ReflectsColimit (Functor.empty.{0} C) (forget C)] (X : C) :
+    Nonempty (IsInitial X) ↔ IsEmpty ((forget C).obj X) := by
+  rw [← Types.initial_iff_empty, (IsInitial.isInitialIffObj (forget C) X).nonempty_congr]
+
+end Initial
 
 section BinaryProducts
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -65,13 +65,13 @@ variable [ConcreteCategory.{w} C]
 
 /-- If `forget C` preserves terminals and `X` is terminal, then `(forget C).obj X` is a
 singleton. -/
-noncomputable instance [PreservesLimit (Functor.empty.{0} C) (forget C)] (X : C)
-    (h : IsTerminal X) : Unique ((forget C).obj X) :=
+noncomputable def uniqueOfTerminalOfPreserves [PreservesLimit (Functor.empty.{0} C) (forget C)]
+    (X : C) (h : IsTerminal X) : Unique ((forget C).obj X) :=
   Types.isTerminalEquivUnique ((forget C).obj X) <| IsTerminal.isTerminalObj (forget C) X h
 
 /-- If `forget C` reflects terminals and `(forget C).obj X` is a singleton, then `X` is terminal. -/
-noncomputable instance [ReflectsLimit (Functor.empty.{0} C) (forget C)] (X : C)
-    (h : Unique ((forget C).obj X)) : IsTerminal X :=
+noncomputable def terminalOfUniqueOfReflects [ReflectsLimit (Functor.empty.{0} C) (forget C)]
+    (X : C) (h : Unique ((forget C).obj X)) : IsTerminal X :=
   IsTerminal.isTerminalOfObj (forget C) X <| (Types.isTerminalEquivUnique ((forget C).obj X)).symm h
 
 /-- The equivalence `IsTerminal X ≃ Unique ((forget C).obj X)` if the forgetful functor

--- a/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
@@ -153,6 +153,14 @@ noncomputable def isInitialPunit : IsInitial (PEmpty : Type u) :=
   initialIsInitial.ofIso initialIso
 #align category_theory.limits.types.is_initial_punit CategoryTheory.Limits.Types.isInitialPunit
 
+/-- An object in `Type u` is initial if and only if it is empty. -/
+lemma initial_iff_empty (X : Type u) : Nonempty (IsInitial X) ↔ IsEmpty X := by
+  constructor
+  · intro ⟨h⟩
+    exact Function.isEmpty (IsInitial.to h PEmpty)
+  · intro h
+    exact ⟨IsInitial.ofIso Types.isInitialPunit <| Equiv.toIso <| Equiv.equivOfIsEmpty PEmpty X⟩
+
 open CategoryTheory.Limits.WalkingPair
 
 -- We manually generate the other projection lemmas since the simp-normal form for the legs is


### PR DESCRIPTION
Shows one of the key technical lemmas about Galois categories, namely that evaluation on a point of the fibre of morphisms out of a connected object is injective.

Also adds some more basic properties on when objects are initial and preservation and reflection of monomorphisms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
