### PR TITLE
[Merged by Bors] - chore: make nightly-testing-YYYY-MM-DD a tag, not a branch

### DIFF
--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -41,7 +41,15 @@ jobs:
         if [[ $toolchain =~ leanprover/lean4:nightly-([a-zA-Z0-9_-]+) ]]; then
           version=${BASH_REMATCH[1]}
           echo "NIGHTLY=$version" >> $GITHUB_ENV
-          git push origin refs/heads/nightly-testing:refs/heads/nightly-testing-$version
+          # Check if the remote tag exists
+          if git ls-remote --tags origin refs/tags/nightly-testing-$version | grep -q 'refs/tags/nightly-testing-$version'; then
+              echo "Tag nightly-testing-$version already exists on the remote."
+          else
+              # If the tag does not exist, create and push the tag to remote
+              echo "Creating tag nightly-testing-$version from the current state of the nightly-testing branch."
+              git tag nightly-testing-$version
+              git push origin nightly-testing-$version
+          fi
         else
           echo "Error: The file lean-toolchain does not contain the expected pattern."
           exit 1

--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -42,7 +42,7 @@ jobs:
           version=${BASH_REMATCH[1]}
           echo "NIGHTLY=$version" >> $GITHUB_ENV
           # Check if the remote tag exists
-          if git ls-remote --tags origin refs/tags/nightly-testing-$version | grep -q 'refs/tags/nightly-testing-$version'; then
+          if git ls-remote --tags --exit-code origin "nightly-testing-$version" >/dev/null; then
               echo "Tag nightly-testing-$version already exists on the remote."
           else
               # If the tag does not exist, create and push the tag to remote


### PR DESCRIPTION
Previously we continued to push updates through the day, if later commits on `nightly-testing` continued to pass CI.

There seems to be little benefit from doing this, but there are some benefits from having a single tag:
* all Lean PRs based off a particular Lean nightly will be tested against the same Mathlib commit
* we can request that the speedcenter processes the nightly-testing-YYYY-MM-DD tags, so we can run `!bench` in all lean-pr-testing-NNNN PRs, and have a reliable base for the comparison

This should not be merged until the Lean CI has been updated in https://github.com/leanprover/lean4/pull/3199, so it is agnostic about whether to expect a branch or tag here.

- [x] depends on: https://github.com/leanprover/lean4/pull/3199

When this is approved/merged I will follow up with:
* an update to https://leanprover-community.github.io/contribute/tags_and_branches.html to describe the change
* investigating a mechanism to ask the speedcenter to process these commits.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
