### PR TITLE
[Merged by Bors] - chore: adaptations for leanprover/lean4#3187

### DIFF
--- a/Mathlib/Combinatorics/Composition.lean
+++ b/Mathlib/Combinatorics/Composition.lean
@@ -801,7 +801,7 @@ def compositionAsSetEquiv (n : ℕ) : CompositionAsSet n ≃ Finset (Fin (n - 1)
     · simp only [or_iff_not_imp_left]
       intro i_mem i_ne_zero i_ne_last
       simp? [Fin.ext_iff] at i_ne_zero i_ne_last says
-        simp only [Fin.ext_iff, Fin.val_zero, Fin.val_last] at i_ne_zero i_ne_last
+        simp only [Fin.isValue, Fin.ext_iff, Fin.val_zero, Fin.val_last] at i_ne_zero i_ne_last
       have A : (1 + (i - 1) : ℕ) = (i : ℕ) := by
         rw [add_comm]
         exact Nat.succ_pred_eq_of_pos (pos_iff_ne_zero.mpr i_ne_zero)

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -154,7 +154,7 @@ theorem residue_eq_zero_iff_sMod_eq_zero (p : ℕ) (w : 1 < p) :
     intro h
     simp? [ZMod.int_cast_zmod_eq_zero_iff_dvd] at h says
       simp only [ZMod.int_cast_zmod_eq_zero_iff_dvd, gt_iff_lt, zero_lt_two, pow_pos, cast_pred,
-        cast_pow, cast_ofNat] at h
+        cast_pow, cast_ofNat, Int.isPosValue] at h
     apply Int.eq_zero_of_dvd_of_nonneg_of_lt _ _ h <;> clear h
     · exact sMod_nonneg _ (by positivity) _
     · exact sMod_lt _ (by positivity) _
@@ -427,7 +427,7 @@ theorem ω_pow_formula (p' : ℕ) (h : lucasLehmerResidue (p' + 2) = 0) :
   rw [sZMod_eq_s p'] at h
   simp? [ZMod.int_cast_zmod_eq_zero_iff_dvd] at h says
     simp only [add_tsub_cancel_right, ZMod.int_cast_zmod_eq_zero_iff_dvd, gt_iff_lt, zero_lt_two,
-      pow_pos, cast_pred, cast_pow, cast_ofNat] at h
+      pow_pos, cast_pred, cast_pow, cast_ofNat, Int.isPosValue] at h
   cases' h with k h
   use k
   replace h := congr_arg (fun n : ℤ => (n : X (q (p' + 2)))) h

--- a/Mathlib/RingTheory/Polynomial/Hermite/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/Basic.lean
@@ -172,7 +172,7 @@ theorem coeff_hermite_explicit :
       simp only
       -- Factor out (-1)'s.
       rw [mul_comm (↑k + _ : ℤ), sub_eq_add_neg]
-      nth_rw 4 [neg_eq_neg_one_mul]
+      nth_rw 3 [neg_eq_neg_one_mul]
       simp only [mul_assoc, ← mul_add, pow_succ]
       congr 2
       -- Factor out double factorials.

--- a/Mathlib/RingTheory/Polynomial/Hermite/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/Basic.lean
@@ -172,7 +172,7 @@ theorem coeff_hermite_explicit :
       simp only
       -- Factor out (-1)'s.
       rw [mul_comm (↑k + _ : ℤ), sub_eq_add_neg]
-      nth_rw 3 [neg_eq_neg_one_mul]
+      nth_rw 4 [neg_eq_neg_one_mul]
       simp only [mul_assoc, ← mul_add, pow_succ]
       congr 2
       -- Factor out double factorials.

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-01-12
+leanprover/lean4:nightly-2024-01-19

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -9,6 +9,7 @@ import Qq
 import Std.Tactic.GuardExpr
 
 open Qq
+
 variable {α β : Type} [Semiring α] [Ring β]
 
 namespace Matrix

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -9,7 +9,6 @@ import Qq
 import Std.Tactic.GuardExpr
 
 open Qq
-set_option says.verify true
 variable {α β : Type} [Semiring α] [Ring β]
 
 namespace Matrix

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -9,7 +9,7 @@ import Qq
 import Std.Tactic.GuardExpr
 
 open Qq
-
+set_option says.verify true
 variable {α β : Type} [Semiring α] [Ring β]
 
 namespace Matrix
@@ -136,26 +136,27 @@ example {a b c d e f g h : α} : ![a, b, c, d, e, f, g, h] 99 = d := by simp
 example {α : Type _} [CommRing α] {a b c d : α} :
     Matrix.det !![a, b; c, d] = a * d - b * c := by
   simp? [Matrix.det_succ_row_zero, Fin.sum_univ_succ] says
-    simp only [det_succ_row_zero, of_apply, cons_val', empty_val',
-      cons_val_fin_one, cons_val_zero, det_unique, Fin.default_eq_zero, submatrix_apply,
-      Fin.succ_zero_eq_one, cons_val_one, head_fin_const, Fin.sum_univ_succ, Fin.val_zero,
-      pow_zero, one_mul, Fin.zero_succAbove, head_cons, Finset.univ_unique,
-      Fin.val_succ, Fin.coe_fin_one, zero_add, pow_one, cons_val_succ, neg_mul,
-      Fin.succ_succAbove_zero, Finset.sum_const, Finset.card_singleton, smul_neg, one_smul]
+    simp only [det_succ_row_zero, Fin.isValue, of_apply, cons_val',
+      empty_val', cons_val_fin_one, cons_val_zero, det_unique, Fin.default_eq_zero, submatrix_apply,
+      Fin.succ_zero_eq_one, cons_val_one, head_fin_const, Fin.sum_univ_succ, Fin.val_zero, pow_zero,
+      one_mul, Fin.zero_succAbove, head_cons, Finset.univ_unique, Fin.val_succ, Fin.coe_fin_one,
+      zero_add, pow_one, cons_val_succ, neg_mul, Fin.succ_succAbove_zero, Finset.sum_const,
+      Finset.card_singleton, smul_neg, one_smul]
   ring
 
 example {α : Type _} [CommRing α] {a b c d e f g h i : α} :
     Matrix.det !![a, b, c; d, e, f; g, h, i] =
       a * e * i - a * f * h - b * d * i + b * f * g + c * d * h - c * e * g := by
   simp? [Matrix.det_succ_row_zero, Fin.sum_univ_succ] says
-    simp only [det_succ_row_zero, of_apply, cons_val', empty_val',
-      cons_val_fin_one, cons_val_zero, submatrix_apply, Fin.succ_zero_eq_one, cons_val_one,
-      head_cons, submatrix_submatrix, det_unique, Fin.default_eq_zero, Function.comp_apply,
-      Fin.succ_one_eq_two, cons_val_two, tail_cons, head_fin_const, Fin.sum_univ_succ, Fin.val_zero,
-      pow_zero, one_mul, Fin.zero_succAbove, Finset.univ_unique, Fin.val_succ, Fin.coe_fin_one,
-      zero_add, pow_one, neg_mul, Fin.succ_succAbove_zero, Finset.sum_neg_distrib,
-      Finset.sum_singleton, cons_val_succ, Fin.succ_succAbove_one, Nat.reduceAdd, even_two,
-      Even.neg_pow, one_pow, Finset.sum_const, Finset.card_singleton, one_smul]
+    simp only [det_succ_row_zero, Fin.isValue, of_apply, cons_val',
+      empty_val', cons_val_fin_one, cons_val_zero, submatrix_apply, Fin.succ_zero_eq_one,
+      cons_val_one, head_cons, submatrix_submatrix, det_unique, Fin.default_eq_zero,
+      Function.comp_apply, Fin.succ_one_eq_two, cons_val_two, tail_cons, head_fin_const,
+      Fin.sum_univ_succ, Fin.val_zero, pow_zero, one_mul, Fin.zero_succAbove, Finset.univ_unique,
+      Fin.val_succ, Fin.coe_fin_one, zero_add, pow_one, neg_mul, Fin.succ_succAbove_zero,
+      Finset.sum_neg_distrib, Finset.sum_singleton, cons_val_succ, Fin.succ_succAbove_one,
+      Nat.reduceAdd, even_two, Even.neg_pow, one_pow, Finset.sum_const, Finset.card_singleton,
+      one_smul]
   ring
 
 end Matrix


### PR DESCRIPTION
These are the adaptations for leanprover/lean4#3187 (new simp behaviour on ground terms), taken from the lean-pr-testing-3187 branch, which has now been merged into nightly-testing.

(Note this is a PR to bump/v4.6.0.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
