### PR TITLE
[Merged by Bors] - chore(Topology/Constructions): rename most type variables

### DIFF
--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -387,7 +387,7 @@ instance finitaryExtensive_TopCat : FinitaryExtensive TopCat.{u} := by
       refine' ⟨⟨l, _⟩, ContinuousMap.ext fun a => (hl a).symm, TopCat.isTerminalPUnit.hom_ext _ _,
         fun {l'} h₁ _ => ContinuousMap.ext fun x =>
           hl' x (l' x) (ConcreteCategory.congr_hom h₁ x).symm⟩
-      apply (embedding_inl (α := X') (β := Y')).toInducing.continuous_iff.mpr
+      apply (embedding_inl (X := X') (Y := Y')).toInducing.continuous_iff.mpr
       convert s.fst.2 using 1
       exact (funext hl).symm
     · refine' ⟨⟨hαY.symm⟩, ⟨PullbackCone.isLimitAux' _ _⟩⟩
@@ -404,7 +404,7 @@ instance finitaryExtensive_TopCat : FinitaryExtensive TopCat.{u} := by
       refine' ⟨⟨l, _⟩, ContinuousMap.ext fun a => (hl a).symm, TopCat.isTerminalPUnit.hom_ext _ _,
         fun {l'} h₁ _ =>
           ContinuousMap.ext fun x => hl' x (l' x) (ConcreteCategory.congr_hom h₁ x).symm⟩
-      apply (embedding_inr (α := X') (β := Y')).toInducing.continuous_iff.mpr
+      apply (embedding_inr (X := X') (Y := Y')).toInducing.continuous_iff.mpr
       convert s.fst.2 using 1
       exact (funext hl).symm
   · intro Z f

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -39,39 +39,39 @@ open Topology TopologicalSpace Set Filter Function Classical
 
 universe u v
 
-variable {α : Type u} {β : Type v} {γ δ ε ζ : Type*}
+variable {X : Type u} {β : Type v} {γ δ ε ζ : Type*}
 
 section Constructions
 
-instance instTopologicalSpaceSubtype {p : α → Prop} [t : TopologicalSpace α] :
+instance instTopologicalSpaceSubtype {p : X → Prop} [t : TopologicalSpace X] :
     TopologicalSpace (Subtype p) :=
   induced (↑) t
 
-instance {r : α → α → Prop} [t : TopologicalSpace α] : TopologicalSpace (Quot r) :=
+instance {r : X → X → Prop} [t : TopologicalSpace X] : TopologicalSpace (Quot r) :=
   coinduced (Quot.mk r) t
 
-instance instTopologicalSpaceQuotient {s : Setoid α} [t : TopologicalSpace α] :
+instance instTopologicalSpaceQuotient {s : Setoid X} [t : TopologicalSpace X] :
     TopologicalSpace (Quotient s) :=
   coinduced Quotient.mk' t
 
-instance instTopologicalSpaceProd [t₁ : TopologicalSpace α] [t₂ : TopologicalSpace β] :
-    TopologicalSpace (α × β) :=
+instance instTopologicalSpaceProd [t₁ : TopologicalSpace X] [t₂ : TopologicalSpace β] :
+    TopologicalSpace (X × β) :=
   induced Prod.fst t₁ ⊓ induced Prod.snd t₂
 
-instance instTopologicalSpaceSum [t₁ : TopologicalSpace α] [t₂ : TopologicalSpace β] :
-    TopologicalSpace (α ⊕ β) :=
+instance instTopologicalSpaceSum [t₁ : TopologicalSpace X] [t₂ : TopologicalSpace β] :
+    TopologicalSpace (X ⊕ β) :=
   coinduced Sum.inl t₁ ⊔ coinduced Sum.inr t₂
 
-instance instTopologicalSpaceSigma {β : α → Type v} [t₂ : ∀ a, TopologicalSpace (β a)] :
+instance instTopologicalSpaceSigma {β : X → Type v} [t₂ : ∀ a, TopologicalSpace (β a)] :
     TopologicalSpace (Sigma β) :=
   ⨆ a, coinduced (Sigma.mk a) (t₂ a)
 
-instance Pi.topologicalSpace {β : α → Type v} [t₂ : (a : α) → TopologicalSpace (β a)] :
-    TopologicalSpace ((a : α) → β a) :=
+instance Pi.topologicalSpace {β : X → Type v} [t₂ : (a : X) → TopologicalSpace (β a)] :
+    TopologicalSpace ((a : X) → β a) :=
   ⨅ a, induced (fun f => f a) (t₂ a)
 #align Pi.topological_space Pi.topologicalSpace
 
-instance ULift.topologicalSpace [t : TopologicalSpace α] : TopologicalSpace (ULift.{v, u} α) :=
+instance ULift.topologicalSpace [t : TopologicalSpace X] : TopologicalSpace (ULift.{v, u} X) :=
   t.induced ULift.down
 #align ulift.topological_space ULift.topologicalSpace
 
@@ -83,62 +83,62 @@ The topology on those type synonyms is inherited without change.
 
 section
 
-variable [TopologicalSpace α]
+variable [TopologicalSpace X]
 
 open Additive Multiplicative
 
-instance : TopologicalSpace (Additive α) := ‹TopologicalSpace α›
-instance : TopologicalSpace (Multiplicative α) := ‹TopologicalSpace α›
+instance : TopologicalSpace (Additive X) := ‹TopologicalSpace X›
+instance : TopologicalSpace (Multiplicative X) := ‹TopologicalSpace X›
 
-instance [DiscreteTopology α] : DiscreteTopology (Additive α) := ‹DiscreteTopology α›
-instance [DiscreteTopology α] : DiscreteTopology (Multiplicative α) := ‹DiscreteTopology α›
+instance [DiscreteTopology X] : DiscreteTopology (Additive X) := ‹DiscreteTopology X›
+instance [DiscreteTopology X] : DiscreteTopology (Multiplicative X) := ‹DiscreteTopology X›
 
-theorem continuous_ofMul : Continuous (ofMul : α → Additive α) := continuous_id
+theorem continuous_ofMul : Continuous (ofMul : X → Additive X) := continuous_id
 #align continuous_of_mul continuous_ofMul
 
-theorem continuous_toMul : Continuous (toMul : Additive α → α) := continuous_id
+theorem continuous_toMul : Continuous (toMul : Additive X → X) := continuous_id
 #align continuous_to_mul continuous_toMul
 
-theorem continuous_ofAdd : Continuous (ofAdd : α → Multiplicative α) := continuous_id
+theorem continuous_ofAdd : Continuous (ofAdd : X → Multiplicative X) := continuous_id
 #align continuous_of_add continuous_ofAdd
 
-theorem continuous_toAdd : Continuous (toAdd : Multiplicative α → α) := continuous_id
+theorem continuous_toAdd : Continuous (toAdd : Multiplicative X → X) := continuous_id
 #align continuous_to_add continuous_toAdd
 
-theorem isOpenMap_ofMul : IsOpenMap (ofMul : α → Additive α) := IsOpenMap.id
+theorem isOpenMap_ofMul : IsOpenMap (ofMul : X → Additive X) := IsOpenMap.id
 #align is_open_map_of_mul isOpenMap_ofMul
 
-theorem isOpenMap_toMul : IsOpenMap (toMul : Additive α → α) := IsOpenMap.id
+theorem isOpenMap_toMul : IsOpenMap (toMul : Additive X → X) := IsOpenMap.id
 #align is_open_map_to_mul isOpenMap_toMul
 
-theorem isOpenMap_ofAdd : IsOpenMap (ofAdd : α → Multiplicative α) := IsOpenMap.id
+theorem isOpenMap_ofAdd : IsOpenMap (ofAdd : X → Multiplicative X) := IsOpenMap.id
 #align is_open_map_of_add isOpenMap_ofAdd
 
-theorem isOpenMap_toAdd : IsOpenMap (toAdd : Multiplicative α → α) := IsOpenMap.id
+theorem isOpenMap_toAdd : IsOpenMap (toAdd : Multiplicative X → X) := IsOpenMap.id
 #align is_open_map_to_add isOpenMap_toAdd
 
-theorem isClosedMap_ofMul : IsClosedMap (ofMul : α → Additive α) := IsClosedMap.id
+theorem isClosedMap_ofMul : IsClosedMap (ofMul : X → Additive X) := IsClosedMap.id
 #align is_closed_map_of_mul isClosedMap_ofMul
 
-theorem isClosedMap_toMul : IsClosedMap (toMul : Additive α → α) := IsClosedMap.id
+theorem isClosedMap_toMul : IsClosedMap (toMul : Additive X → X) := IsClosedMap.id
 #align is_closed_map_to_mul isClosedMap_toMul
 
-theorem isClosedMap_ofAdd : IsClosedMap (ofAdd : α → Multiplicative α) := IsClosedMap.id
+theorem isClosedMap_ofAdd : IsClosedMap (ofAdd : X → Multiplicative X) := IsClosedMap.id
 #align is_closed_map_of_add isClosedMap_ofAdd
 
-theorem isClosedMap_toAdd : IsClosedMap (toAdd : Multiplicative α → α) := IsClosedMap.id
+theorem isClosedMap_toAdd : IsClosedMap (toAdd : Multiplicative X → X) := IsClosedMap.id
 #align is_closed_map_to_add isClosedMap_toAdd
 
-theorem nhds_ofMul (a : α) : 𝓝 (ofMul a) = map ofMul (𝓝 a) := rfl
+theorem nhds_ofMul (a : X) : 𝓝 (ofMul a) = map ofMul (𝓝 a) := rfl
 #align nhds_of_mul nhds_ofMul
 
-theorem nhds_ofAdd (a : α) : 𝓝 (ofAdd a) = map ofAdd (𝓝 a) := rfl
+theorem nhds_ofAdd (a : X) : 𝓝 (ofAdd a) = map ofAdd (𝓝 a) := rfl
 #align nhds_of_add nhds_ofAdd
 
-theorem nhds_toMul (a : Additive α) : 𝓝 (toMul a) = map toMul (𝓝 a) := rfl
+theorem nhds_toMul (a : Additive X) : 𝓝 (toMul a) = map toMul (𝓝 a) := rfl
 #align nhds_to_mul nhds_toMul
 
-theorem nhds_toAdd (a : Multiplicative α) : 𝓝 (toAdd a) = map toAdd (𝓝 a) := rfl
+theorem nhds_toAdd (a : Multiplicative X) : 𝓝 (toAdd a) = map toAdd (𝓝 a) := rfl
 #align nhds_to_add nhds_toAdd
 
 end
@@ -152,125 +152,125 @@ The topology on this type synonym is inherited without change.
 
 section
 
-variable [TopologicalSpace α]
+variable [TopologicalSpace X]
 
 open OrderDual
 
-instance : TopologicalSpace αᵒᵈ := ‹TopologicalSpace α›
-instance [DiscreteTopology α] : DiscreteTopology αᵒᵈ := ‹DiscreteTopology α›
+instance : TopologicalSpace Xᵒᵈ := ‹TopologicalSpace X›
+instance [DiscreteTopology X] : DiscreteTopology Xᵒᵈ := ‹DiscreteTopology X›
 
-theorem continuous_toDual : Continuous (toDual : α → αᵒᵈ) := continuous_id
+theorem continuous_toDual : Continuous (toDual : X → Xᵒᵈ) := continuous_id
 #align continuous_to_dual continuous_toDual
 
-theorem continuous_ofDual : Continuous (ofDual : αᵒᵈ → α) := continuous_id
+theorem continuous_ofDual : Continuous (ofDual : Xᵒᵈ → X) := continuous_id
 #align continuous_of_dual continuous_ofDual
 
-theorem isOpenMap_toDual : IsOpenMap (toDual : α → αᵒᵈ) := IsOpenMap.id
+theorem isOpenMap_toDual : IsOpenMap (toDual : X → Xᵒᵈ) := IsOpenMap.id
 #align is_open_map_to_dual isOpenMap_toDual
 
-theorem isOpenMap_ofDual : IsOpenMap (ofDual : αᵒᵈ → α) := IsOpenMap.id
+theorem isOpenMap_ofDual : IsOpenMap (ofDual : Xᵒᵈ → X) := IsOpenMap.id
 #align is_open_map_of_dual isOpenMap_ofDual
 
-theorem isClosedMap_toDual : IsClosedMap (toDual : α → αᵒᵈ) := IsClosedMap.id
+theorem isClosedMap_toDual : IsClosedMap (toDual : X → Xᵒᵈ) := IsClosedMap.id
 #align is_closed_map_to_dual isClosedMap_toDual
 
-theorem isClosedMap_ofDual : IsClosedMap (ofDual : αᵒᵈ → α) := IsClosedMap.id
+theorem isClosedMap_ofDual : IsClosedMap (ofDual : Xᵒᵈ → X) := IsClosedMap.id
 #align is_closed_map_of_dual isClosedMap_ofDual
 
-theorem nhds_toDual (a : α) : 𝓝 (toDual a) = map toDual (𝓝 a) := rfl
+theorem nhds_toDual (a : X) : 𝓝 (toDual a) = map toDual (𝓝 a) := rfl
 #align nhds_to_dual nhds_toDual
 
-theorem nhds_ofDual (a : α) : 𝓝 (ofDual a) = map ofDual (𝓝 a) := rfl
+theorem nhds_ofDual (a : X) : 𝓝 (ofDual a) = map ofDual (𝓝 a) := rfl
 #align nhds_of_dual nhds_ofDual
 
 end
 
-theorem Quotient.preimage_mem_nhds [TopologicalSpace α] [s : Setoid α] {V : Set <| Quotient s}
-    {a : α} (hs : V ∈ 𝓝 (Quotient.mk' a)) : Quotient.mk' ⁻¹' V ∈ 𝓝 a :=
+theorem Quotient.preimage_mem_nhds [TopologicalSpace X] [s : Setoid X] {V : Set <| Quotient s}
+    {a : X} (hs : V ∈ 𝓝 (Quotient.mk' a)) : Quotient.mk' ⁻¹' V ∈ 𝓝 a :=
   preimage_nhds_coinduced hs
 #align quotient.preimage_mem_nhds Quotient.preimage_mem_nhds
 
 /-- The image of a dense set under `Quotient.mk'` is a dense set. -/
-theorem Dense.quotient [Setoid α] [TopologicalSpace α] {s : Set α} (H : Dense s) :
+theorem Dense.quotient [Setoid X] [TopologicalSpace X] {s : Set X} (H : Dense s) :
     Dense (Quotient.mk' '' s) :=
   Quotient.surjective_Quotient_mk''.denseRange.dense_image continuous_coinduced_rng H
 #align dense.quotient Dense.quotient
 
 /-- The composition of `Quotient.mk'` and a function with dense range has dense range. -/
-theorem DenseRange.quotient [Setoid α] [TopologicalSpace α] {f : β → α} (hf : DenseRange f) :
+theorem DenseRange.quotient [Setoid X] [TopologicalSpace X] {f : β → X} (hf : DenseRange f) :
     DenseRange (Quotient.mk' ∘ f) :=
   Quotient.surjective_Quotient_mk''.denseRange.comp hf continuous_coinduced_rng
 #align dense_range.quotient DenseRange.quotient
 
-instance {p : α → Prop} [TopologicalSpace α] [DiscreteTopology α] : DiscreteTopology (Subtype p) :=
+instance {p : X → Prop} [TopologicalSpace X] [DiscreteTopology X] : DiscreteTopology (Subtype p) :=
   ⟨bot_unique fun s _ => ⟨(↑) '' s, isOpen_discrete _, preimage_image_eq _ Subtype.val_injective⟩⟩
 
-instance Sum.discreteTopology [TopologicalSpace α] [TopologicalSpace β] [hα : DiscreteTopology α]
-    [hβ : DiscreteTopology β] : DiscreteTopology (Sum α β) :=
-  ⟨sup_eq_bot_iff.2 <| by simp [hα.eq_bot, hβ.eq_bot]⟩
+instance Sum.discreteTopology [TopologicalSpace X] [TopologicalSpace β] [h : DiscreteTopology X]
+    [hβ : DiscreteTopology β] : DiscreteTopology (Sum X β) :=
+  ⟨sup_eq_bot_iff.2 <| by simp [h.eq_bot, hβ.eq_bot]⟩
 #align sum.discrete_topology Sum.discreteTopology
 
-instance Sigma.discreteTopology {β : α → Type v} [∀ a, TopologicalSpace (β a)]
+instance Sigma.discreteTopology {β : X → Type v} [∀ a, TopologicalSpace (β a)]
     [h : ∀ a, DiscreteTopology (β a)] : DiscreteTopology (Sigma β) :=
   ⟨iSup_eq_bot.2 fun _ => by simp only [(h _).eq_bot, coinduced_bot]⟩
 #align sigma.discrete_topology Sigma.discreteTopology
 
-section Topα
+section Top
 
-variable [TopologicalSpace α]
+variable [TopologicalSpace X]
 
 /-
 The 𝓝 filter and the subspace topology.
 -/
-theorem mem_nhds_subtype (s : Set α) (a : { x // x ∈ s }) (t : Set { x // x ∈ s }) :
-    t ∈ 𝓝 a ↔ ∃ u ∈ 𝓝 (a : α), Subtype.val ⁻¹' u ⊆ t :=
+theorem mem_nhds_subtype (s : Set X) (a : { x // x ∈ s }) (t : Set { x // x ∈ s }) :
+    t ∈ 𝓝 a ↔ ∃ u ∈ 𝓝 (a : X), Subtype.val ⁻¹' u ⊆ t :=
   mem_nhds_induced _ a t
 #align mem_nhds_subtype mem_nhds_subtype
 
-theorem nhds_subtype (s : Set α) (a : { x // x ∈ s }) : 𝓝 a = comap (↑) (𝓝 (a : α)) :=
+theorem nhds_subtype (s : Set X) (a : { x // x ∈ s }) : 𝓝 a = comap (↑) (𝓝 (a : X)) :=
   nhds_induced _ a
 #align nhds_subtype nhds_subtype
 
-theorem nhdsWithin_subtype_eq_bot_iff {s t : Set α} {x : s} :
-    𝓝[((↑) : s → α) ⁻¹' t] x = ⊥ ↔ 𝓝[t] (x : α) ⊓ 𝓟 s = ⊥ := by
+theorem nhdsWithin_subtype_eq_bot_iff {s t : Set X} {x : s} :
+    𝓝[((↑) : s → X) ⁻¹' t] x = ⊥ ↔ 𝓝[t] (x : X) ⊓ 𝓟 s = ⊥ := by
   rw [inf_principal_eq_bot_iff_comap, nhdsWithin, nhdsWithin, comap_inf, comap_principal,
     nhds_induced]
 #align nhds_within_subtype_eq_bot_iff nhdsWithin_subtype_eq_bot_iff
 
-theorem nhds_ne_subtype_eq_bot_iff {S : Set α} {x : S} :
-    𝓝[≠] x = ⊥ ↔ 𝓝[≠] (x : α) ⊓ 𝓟 S = ⊥ := by
+theorem nhds_ne_subtype_eq_bot_iff {S : Set X} {x : S} :
+    𝓝[≠] x = ⊥ ↔ 𝓝[≠] (x : X) ⊓ 𝓟 S = ⊥ := by
   rw [← nhdsWithin_subtype_eq_bot_iff, preimage_compl, ← image_singleton,
     Subtype.coe_injective.preimage_image]
 #align nhds_ne_subtype_eq_bot_iff nhds_ne_subtype_eq_bot_iff
 
-theorem nhds_ne_subtype_neBot_iff {S : Set α} {x : S} :
-    (𝓝[≠] x).NeBot ↔ (𝓝[≠] (x : α) ⊓ 𝓟 S).NeBot := by
+theorem nhds_ne_subtype_neBot_iff {S : Set X} {x : S} :
+    (𝓝[≠] x).NeBot ↔ (𝓝[≠] (x : X) ⊓ 𝓟 S).NeBot := by
   rw [neBot_iff, neBot_iff, not_iff_not, nhds_ne_subtype_eq_bot_iff]
 #align nhds_ne_subtype_ne_bot_iff nhds_ne_subtype_neBot_iff
 
-theorem discreteTopology_subtype_iff {S : Set α} :
+theorem discreteTopology_subtype_iff {S : Set X} :
     DiscreteTopology S ↔ ∀ x ∈ S, 𝓝[≠] x ⊓ 𝓟 S = ⊥ := by
   simp_rw [discreteTopology_iff_nhds_ne, SetCoe.forall', nhds_ne_subtype_eq_bot_iff]
 #align discrete_topology_subtype_iff discreteTopology_subtype_iff
 
-end Topα
+end Top
 
 /-- A type synonym equipped with the topology whose open sets are the empty set and the sets with
 finite complements. -/
-def CofiniteTopology (α : Type*) :=
-  α
+def CofiniteTopology (X : Type*) := X
+
 #align cofinite_topology CofiniteTopology
 
 namespace CofiniteTopology
 
-/-- The identity equivalence between `α` and `CofiniteTopology α`. -/
-def of : α ≃ CofiniteTopology α :=
-  Equiv.refl α
+/-- The identity equivalence between `` and `CofiniteTopology `. -/
+def of : X ≃ CofiniteTopology X :=
+  Equiv.refl X
 #align cofinite_topology.of CofiniteTopology.of
 
-instance [Inhabited α] : Inhabited (CofiniteTopology α) where default := of default
+instance [Inhabited X] : Inhabited (CofiniteTopology X) where default := of default
 
-instance : TopologicalSpace (CofiniteTopology α) where
+instance : TopologicalSpace (CofiniteTopology X) where
   IsOpen s := s.Nonempty → Set.Finite sᶜ
   isOpen_univ := by simp
   isOpen_inter s t := by
@@ -282,19 +282,19 @@ instance : TopologicalSpace (CofiniteTopology α) where
     rw [Set.compl_sUnion]
     exact Set.Finite.sInter (mem_image_of_mem _ hts) (h t hts ⟨x, hzt⟩)
 
-theorem isOpen_iff {s : Set (CofiniteTopology α)} : IsOpen s ↔ s.Nonempty → sᶜ.Finite :=
+theorem isOpen_iff {s : Set (CofiniteTopology X)} : IsOpen s ↔ s.Nonempty → sᶜ.Finite :=
   Iff.rfl
 #align cofinite_topology.is_open_iff CofiniteTopology.isOpen_iff
 
-theorem isOpen_iff' {s : Set (CofiniteTopology α)} : IsOpen s ↔ s = ∅ ∨ sᶜ.Finite := by
+theorem isOpen_iff' {s : Set (CofiniteTopology X)} : IsOpen s ↔ s = ∅ ∨ sᶜ.Finite := by
   simp only [isOpen_iff, nonempty_iff_ne_empty, or_iff_not_imp_left]
 #align cofinite_topology.is_open_iff' CofiniteTopology.isOpen_iff'
 
-theorem isClosed_iff {s : Set (CofiniteTopology α)} : IsClosed s ↔ s = univ ∨ s.Finite := by
+theorem isClosed_iff {s : Set (CofiniteTopology X)} : IsClosed s ↔ s = univ ∨ s.Finite := by
   simp only [← isOpen_compl_iff, isOpen_iff', compl_compl, compl_empty_iff]
 #align cofinite_topology.is_closed_iff CofiniteTopology.isClosed_iff
 
-theorem nhds_eq (a : CofiniteTopology α) : 𝓝 a = pure a ⊔ cofinite := by
+theorem nhds_eq (a : CofiniteTopology X) : 𝓝 a = pure a ⊔ cofinite := by
   ext U
   rw [mem_nhds_iff]
   constructor
@@ -304,7 +304,7 @@ theorem nhds_eq (a : CofiniteTopology α) : 𝓝 a = pure a ⊔ cofinite := by
     exact ⟨U, Subset.rfl, fun _ => hU', hU⟩
 #align cofinite_topology.nhds_eq CofiniteTopology.nhds_eq
 
-theorem mem_nhds_iff {a : CofiniteTopology α} {s : Set (CofiniteTopology α)} :
+theorem mem_nhds_iff {a : CofiniteTopology X} {s : Set (CofiniteTopology X)} :
     s ∈ 𝓝 a ↔ a ∈ s ∧ sᶜ.Finite := by simp [nhds_eq]
 #align cofinite_topology.mem_nhds_iff CofiniteTopology.mem_nhds_iff
 
@@ -314,141 +314,141 @@ end Constructions
 
 section Prod
 
-variable [TopologicalSpace α] [TopologicalSpace β] [TopologicalSpace γ] [TopologicalSpace δ]
+variable [TopologicalSpace X] [TopologicalSpace β] [TopologicalSpace γ] [TopologicalSpace δ]
   [TopologicalSpace ε] [TopologicalSpace ζ]
 
 -- porting note: todo: Lean 4 fails to deduce implicit args
-@[simp] theorem continuous_prod_mk {f : α → β} {g : α → γ} :
+@[simp] theorem continuous_prod_mk {f : X → β} {g : X → γ} :
     (Continuous fun x => (f x, g x)) ↔ Continuous f ∧ Continuous g :=
-  (@continuous_inf_rng α (β × γ) _ _ (TopologicalSpace.induced Prod.fst _)
+  (@continuous_inf_rng X (β × γ) _ _ (TopologicalSpace.induced Prod.fst _)
     (TopologicalSpace.induced Prod.snd _)).trans <|
     continuous_induced_rng.and continuous_induced_rng
 #align continuous_prod_mk continuous_prod_mk
 
 @[continuity]
-theorem continuous_fst : Continuous (@Prod.fst α β) :=
+theorem continuous_fst : Continuous (@Prod.fst X β) :=
   (continuous_prod_mk.1 continuous_id).1
 #align continuous_fst continuous_fst
 
 /-- Postcomposing `f` with `Prod.fst` is continuous -/
-theorem Continuous.fst {f : α → β × γ} (hf : Continuous f) : Continuous fun a : α => (f a).1 :=
+theorem Continuous.fst {f : X → β × γ} (hf : Continuous f) : Continuous fun a : X => (f a).1 :=
   continuous_fst.comp hf
 #align continuous.fst Continuous.fst
 
 /-- Precomposing `f` with `Prod.fst` is continuous -/
-theorem Continuous.fst' {f : α → γ} (hf : Continuous f) : Continuous fun x : α × β => f x.fst :=
+theorem Continuous.fst' {f : X → γ} (hf : Continuous f) : Continuous fun x : X × β => f x.fst :=
   hf.comp continuous_fst
 #align continuous.fst' Continuous.fst'
 
-theorem continuousAt_fst {p : α × β} : ContinuousAt Prod.fst p :=
+theorem continuousAt_fst {p : X × β} : ContinuousAt Prod.fst p :=
   continuous_fst.continuousAt
 #align continuous_at_fst continuousAt_fst
 
 /-- Postcomposing `f` with `Prod.fst` is continuous at `x` -/
-theorem ContinuousAt.fst {f : α → β × γ} {x : α} (hf : ContinuousAt f x) :
-    ContinuousAt (fun a : α => (f a).1) x :=
+theorem ContinuousAt.fst {f : X → β × γ} {x : X} (hf : ContinuousAt f x) :
+    ContinuousAt (fun a : X => (f a).1) x :=
   continuousAt_fst.comp hf
 #align continuous_at.fst ContinuousAt.fst
 
 /-- Precomposing `f` with `Prod.fst` is continuous at `(x, y)` -/
-theorem ContinuousAt.fst' {f : α → γ} {x : α} {y : β} (hf : ContinuousAt f x) :
-    ContinuousAt (fun x : α × β => f x.fst) (x, y) :=
+theorem ContinuousAt.fst' {f : X → γ} {x : X} {y : β} (hf : ContinuousAt f x) :
+    ContinuousAt (fun x : X × β => f x.fst) (x, y) :=
   ContinuousAt.comp hf continuousAt_fst
 #align continuous_at.fst' ContinuousAt.fst'
 
-/-- Precomposing `f` with `Prod.fst` is continuous at `x : α × β` -/
-theorem ContinuousAt.fst'' {f : α → γ} {x : α × β} (hf : ContinuousAt f x.fst) :
-    ContinuousAt (fun x : α × β => f x.fst) x :=
+/-- Precomposing `f` with `Prod.fst` is continuous at `x :  × β` -/
+theorem ContinuousAt.fst'' {f : X → γ} {x : X × β} (hf : ContinuousAt f x.fst) :
+    ContinuousAt (fun x : X × β => f x.fst) x :=
   hf.comp continuousAt_fst
 #align continuous_at.fst'' ContinuousAt.fst''
 
 @[continuity]
-theorem continuous_snd : Continuous (@Prod.snd α β) :=
+theorem continuous_snd : Continuous (@Prod.snd X β) :=
   (continuous_prod_mk.1 continuous_id).2
 #align continuous_snd continuous_snd
 
 /-- Postcomposing `f` with `Prod.snd` is continuous -/
-theorem Continuous.snd {f : α → β × γ} (hf : Continuous f) : Continuous fun a : α => (f a).2 :=
+theorem Continuous.snd {f : X → β × γ} (hf : Continuous f) : Continuous fun a : X => (f a).2 :=
   continuous_snd.comp hf
 #align continuous.snd Continuous.snd
 
 /-- Precomposing `f` with `Prod.snd` is continuous -/
-theorem Continuous.snd' {f : β → γ} (hf : Continuous f) : Continuous fun x : α × β => f x.snd :=
+theorem Continuous.snd' {f : β → γ} (hf : Continuous f) : Continuous fun x : X × β => f x.snd :=
   hf.comp continuous_snd
 #align continuous.snd' Continuous.snd'
 
-theorem continuousAt_snd {p : α × β} : ContinuousAt Prod.snd p :=
+theorem continuousAt_snd {p : X × β} : ContinuousAt Prod.snd p :=
   continuous_snd.continuousAt
 #align continuous_at_snd continuousAt_snd
 
 /-- Postcomposing `f` with `Prod.snd` is continuous at `x` -/
-theorem ContinuousAt.snd {f : α → β × γ} {x : α} (hf : ContinuousAt f x) :
-    ContinuousAt (fun a : α => (f a).2) x :=
+theorem ContinuousAt.snd {f : X → β × γ} {x : X} (hf : ContinuousAt f x) :
+    ContinuousAt (fun a : X => (f a).2) x :=
   continuousAt_snd.comp hf
 #align continuous_at.snd ContinuousAt.snd
 
 /-- Precomposing `f` with `Prod.snd` is continuous at `(x, y)` -/
-theorem ContinuousAt.snd' {f : β → γ} {x : α} {y : β} (hf : ContinuousAt f y) :
-    ContinuousAt (fun x : α × β => f x.snd) (x, y) :=
+theorem ContinuousAt.snd' {f : β → γ} {x : X} {y : β} (hf : ContinuousAt f y) :
+    ContinuousAt (fun x : X × β => f x.snd) (x, y) :=
   ContinuousAt.comp hf continuousAt_snd
 #align continuous_at.snd' ContinuousAt.snd'
 
-/-- Precomposing `f` with `Prod.snd` is continuous at `x : α × β` -/
-theorem ContinuousAt.snd'' {f : β → γ} {x : α × β} (hf : ContinuousAt f x.snd) :
-    ContinuousAt (fun x : α × β => f x.snd) x :=
+/-- Precomposing `f` with `Prod.snd` is continuous at `x :  × β` -/
+theorem ContinuousAt.snd'' {f : β → γ} {x : X × β} (hf : ContinuousAt f x.snd) :
+    ContinuousAt (fun x : X × β => f x.snd) x :=
   hf.comp continuousAt_snd
 #align continuous_at.snd'' ContinuousAt.snd''
 
 @[continuity]
-theorem Continuous.prod_mk {f : γ → α} {g : γ → β} (hf : Continuous f) (hg : Continuous g) :
+theorem Continuous.prod_mk {f : γ → X} {g : γ → β} (hf : Continuous f) (hg : Continuous g) :
     Continuous fun x => (f x, g x) :=
   continuous_prod_mk.2 ⟨hf, hg⟩
 #align continuous.prod_mk Continuous.prod_mk
 
 @[continuity]
-theorem Continuous.Prod.mk (a : α) : Continuous fun b : β => (a, b) :=
+theorem Continuous.Prod.mk (a : X) : Continuous fun b : β => (a, b) :=
   continuous_const.prod_mk continuous_id
 #align continuous.prod.mk Continuous.Prod.mk
 
 @[continuity]
-theorem Continuous.Prod.mk_left (b : β) : Continuous fun a : α => (a, b) :=
+theorem Continuous.Prod.mk_left (b : β) : Continuous fun a : X => (a, b) :=
   continuous_id.prod_mk continuous_const
 #align continuous.prod.mk_left Continuous.Prod.mk_left
 
 /-- If `f x y` is continuous in `x` for all `y ∈ s`,
 then the set of `x` such that `f x` maps `s` to `t` is closed. -/
-lemma IsClosed.setOf_mapsTo {f : α → β → γ} {s : Set β} {t : Set γ} (ht : IsClosed t)
+lemma IsClosed.setOf_mapsTo {f : X → β → γ} {s : Set β} {t : Set γ} (ht : IsClosed t)
     (hf : ∀ y ∈ s, Continuous (f · y)) : IsClosed {x | MapsTo (f x) s t} := by
   simpa only [MapsTo, setOf_forall] using isClosed_biInter fun y hy ↦ ht.preimage (hf y hy)
 
-theorem Continuous.comp₂ {g : α × β → γ} (hg : Continuous g) {e : δ → α} (he : Continuous e)
+theorem Continuous.comp₂ {g : X × β → γ} (hg : Continuous g) {e : δ → X} (he : Continuous e)
     {f : δ → β} (hf : Continuous f) : Continuous fun x => g (e x, f x) :=
   hg.comp <| he.prod_mk hf
 #align continuous.comp₂ Continuous.comp₂
 
-theorem Continuous.comp₃ {g : α × β × γ → ε} (hg : Continuous g) {e : δ → α} (he : Continuous e)
+theorem Continuous.comp₃ {g : X × β × γ → ε} (hg : Continuous g) {e : δ → X} (he : Continuous e)
     {f : δ → β} (hf : Continuous f) {k : δ → γ} (hk : Continuous k) :
     Continuous fun x => g (e x, f x, k x) :=
   hg.comp₂ he <| hf.prod_mk hk
 #align continuous.comp₃ Continuous.comp₃
 
-theorem Continuous.comp₄ {g : α × β × γ × ζ → ε} (hg : Continuous g) {e : δ → α} (he : Continuous e)
+theorem Continuous.comp₄ {g : X × β × γ × ζ → ε} (hg : Continuous g) {e : δ → X} (he : Continuous e)
     {f : δ → β} (hf : Continuous f) {k : δ → γ} (hk : Continuous k) {l : δ → ζ}
     (hl : Continuous l) : Continuous fun x => g (e x, f x, k x, l x) :=
   hg.comp₃ he hf <| hk.prod_mk hl
 #align continuous.comp₄ Continuous.comp₄
 
 @[continuity]
-theorem Continuous.prod_map {f : γ → α} {g : δ → β} (hf : Continuous f) (hg : Continuous g) :
+theorem Continuous.prod_map {f : γ → X} {g : δ → β} (hf : Continuous f) (hg : Continuous g) :
     Continuous fun x : γ × δ => (f x.1, g x.2) :=
   hf.fst'.prod_mk hg.snd'
 #align continuous.prod_map Continuous.prod_map
 
 /-- A version of `continuous_inf_dom_left` for binary functions -/
-theorem continuous_inf_dom_left₂ {α β γ} {f : α → β → γ} {ta1 ta2 : TopologicalSpace α}
+theorem continuous_inf_dom_left₂ { β γ} {f : X → β → γ} {ta1 ta2 : TopologicalSpace X}
     {tb1 tb2 : TopologicalSpace β} {tc1 : TopologicalSpace γ}
-    (h : by haveI := ta1; haveI := tb1; exact Continuous fun p : α × β => f p.1 p.2) : by
-    haveI := ta1 ⊓ ta2; haveI := tb1 ⊓ tb2; exact Continuous fun p : α × β => f p.1 p.2 := by
+    (h : by haveI := ta1; haveI := tb1; exact Continuous fun p : X × β => f p.1 p.2) : by
+    haveI := ta1 ⊓ ta2; haveI := tb1 ⊓ tb2; exact Continuous fun p : X × β => f p.1 p.2 := by
   have ha := @continuous_inf_dom_left _ _ id ta1 ta2 ta1 (@continuous_id _ (id _))
   have hb := @continuous_inf_dom_left _ _ id tb1 tb2 tb1 (@continuous_id _ (id _))
   have h_continuous_id := @Continuous.prod_map _ _ _ _ ta1 tb1 (ta1 ⊓ ta2) (tb1 ⊓ tb2) _ _ ha hb
@@ -456,10 +456,10 @@ theorem continuous_inf_dom_left₂ {α β γ} {f : α → β → γ} {ta1 ta2 : 
 #align continuous_inf_dom_left₂ continuous_inf_dom_left₂
 
 /-- A version of `continuous_inf_dom_right` for binary functions -/
-theorem continuous_inf_dom_right₂ {α β γ} {f : α → β → γ} {ta1 ta2 : TopologicalSpace α}
+theorem continuous_inf_dom_right₂ { β γ} {f : X → β → γ} {ta1 ta2 : TopologicalSpace X}
     {tb1 tb2 : TopologicalSpace β} {tc1 : TopologicalSpace γ}
-    (h : by haveI := ta2; haveI := tb2; exact Continuous fun p : α × β => f p.1 p.2) : by
-    haveI := ta1 ⊓ ta2; haveI := tb1 ⊓ tb2; exact Continuous fun p : α × β => f p.1 p.2 := by
+    (h : by haveI := ta2; haveI := tb2; exact Continuous fun p : X × β => f p.1 p.2) : by
+    haveI := ta1 ⊓ ta2; haveI := tb1 ⊓ tb2; exact Continuous fun p : X × β => f p.1 p.2 := by
   have ha := @continuous_inf_dom_right _ _ id ta1 ta2 ta2 (@continuous_id _ (id _))
   have hb := @continuous_inf_dom_right _ _ id tb1 tb2 tb2 (@continuous_id _ (id _))
   have h_continuous_id := @Continuous.prod_map _ _ _ _ ta2 tb2 (ta1 ⊓ ta2) (tb1 ⊓ tb2) _ _ ha hb
@@ -467,85 +467,85 @@ theorem continuous_inf_dom_right₂ {α β γ} {f : α → β → γ} {ta1 ta2 :
 #align continuous_inf_dom_right₂ continuous_inf_dom_right₂
 
 /-- A version of `continuous_sInf_dom` for binary functions -/
-theorem continuous_sInf_dom₂ {α β γ} {f : α → β → γ} {tas : Set (TopologicalSpace α)}
-    {tbs : Set (TopologicalSpace β)} {ta : TopologicalSpace α} {tb : TopologicalSpace β}
+theorem continuous_sInf_dom₂ { β γ} {f : X → β → γ} {tas : Set (TopologicalSpace X)}
+    {tbs : Set (TopologicalSpace β)} {ta : TopologicalSpace X} {tb : TopologicalSpace β}
     {tc : TopologicalSpace γ} (ha : ta ∈ tas) (hb : tb ∈ tbs)
-    (hf : Continuous fun p : α × β => f p.1 p.2) : by
+    (hf : Continuous fun p : X × β => f p.1 p.2) : by
     haveI := sInf tas; haveI := sInf tbs;
-      exact @Continuous _ _ _ tc fun p : α × β => f p.1 p.2 := by
+      exact @Continuous _ _ _ tc fun p : X × β => f p.1 p.2 := by
   have ha := continuous_sInf_dom ha continuous_id
   have hb := continuous_sInf_dom hb continuous_id
   have h_continuous_id := @Continuous.prod_map _ _ _ _ ta tb (sInf tas) (sInf tbs) _ _ ha hb
   exact @Continuous.comp _ _ _ (id _) (id _) _ _ _ hf h_continuous_id
 #align continuous_Inf_dom₂ continuous_sInf_dom₂
 
-theorem Filter.Eventually.prod_inl_nhds {p : α → Prop} {a : α} (h : ∀ᶠ x in 𝓝 a, p x) (b : β) :
-    ∀ᶠ x in 𝓝 (a, b), p (x : α × β).1 :=
+theorem Filter.Eventually.prod_inl_nhds {p : X → Prop} {a : X} (h : ∀ᶠ x in 𝓝 a, p x) (b : β) :
+    ∀ᶠ x in 𝓝 (a, b), p (x : X × β).1 :=
   continuousAt_fst h
 #align filter.eventually.prod_inl_nhds Filter.Eventually.prod_inl_nhds
 
-theorem Filter.Eventually.prod_inr_nhds {p : β → Prop} {b : β} (h : ∀ᶠ x in 𝓝 b, p x) (a : α) :
-    ∀ᶠ x in 𝓝 (a, b), p (x : α × β).2 :=
+theorem Filter.Eventually.prod_inr_nhds {p : β → Prop} {b : β} (h : ∀ᶠ x in 𝓝 b, p x) (a : X) :
+    ∀ᶠ x in 𝓝 (a, b), p (x : X × β).2 :=
   continuousAt_snd h
 #align filter.eventually.prod_inr_nhds Filter.Eventually.prod_inr_nhds
 
-theorem Filter.Eventually.prod_mk_nhds {pa : α → Prop} {a} (ha : ∀ᶠ x in 𝓝 a, pa x) {pb : β → Prop}
-    {b} (hb : ∀ᶠ y in 𝓝 b, pb y) : ∀ᶠ p in 𝓝 (a, b), pa (p : α × β).1 ∧ pb p.2 :=
+theorem Filter.Eventually.prod_mk_nhds {pa : X → Prop} {a} (ha : ∀ᶠ x in 𝓝 a, pa x) {pb : β → Prop}
+    {b} (hb : ∀ᶠ y in 𝓝 b, pb y) : ∀ᶠ p in 𝓝 (a, b), pa (p : X × β).1 ∧ pb p.2 :=
   (ha.prod_inl_nhds b).and (hb.prod_inr_nhds a)
 #align filter.eventually.prod_mk_nhds Filter.Eventually.prod_mk_nhds
 
-theorem continuous_swap : Continuous (Prod.swap : α × β → β × α) :=
+theorem continuous_swap : Continuous (Prod.swap : X × β → β × X) :=
   continuous_snd.prod_mk continuous_fst
 #align continuous_swap continuous_swap
 
-lemma isClosedMap_swap : IsClosedMap (Prod.swap : α × β → β × α) := fun s hs ↦ by
+lemma isClosedMap_swap : IsClosedMap (Prod.swap : X × β → β × X) := fun s hs ↦ by
   rw [image_swap_eq_preimage_swap]
   exact hs.preimage continuous_swap
 
-theorem continuous_uncurry_left {f : α → β → γ} (a : α) (h : Continuous (uncurry f)) :
+theorem continuous_uncurry_left {f : X → β → γ} (a : X) (h : Continuous (uncurry f)) :
     Continuous (f a) :=
   h.comp (Continuous.Prod.mk _)
 #align continuous_uncurry_left continuous_uncurry_left
 
-theorem continuous_uncurry_right {f : α → β → γ} (b : β) (h : Continuous (uncurry f)) :
+theorem continuous_uncurry_right {f : X → β → γ} (b : β) (h : Continuous (uncurry f)) :
     Continuous fun a => f a b :=
   h.comp (Continuous.Prod.mk_left _)
 #align continuous_uncurry_right continuous_uncurry_right
 
-theorem continuous_curry {g : α × β → γ} (a : α) (h : Continuous g) : Continuous (curry g a) :=
+theorem continuous_curry {g : X × β → γ} (a : X) (h : Continuous g) : Continuous (curry g a) :=
   continuous_uncurry_left a h
 #align continuous_curry continuous_curry
 
-theorem IsOpen.prod {s : Set α} {t : Set β} (hs : IsOpen s) (ht : IsOpen t) : IsOpen (s ×ˢ t) :=
+theorem IsOpen.prod {s : Set X} {t : Set β} (hs : IsOpen s) (ht : IsOpen t) : IsOpen (s ×ˢ t) :=
   (hs.preimage continuous_fst).inter (ht.preimage continuous_snd)
 #align is_open.prod IsOpen.prod
 
 -- porting note: todo: Lean fails to find `t₁` and `t₂` by unification
-theorem nhds_prod_eq {a : α} {b : β} : 𝓝 (a, b) = 𝓝 a ×ˢ 𝓝 b := by
+theorem nhds_prod_eq {a : X} {b : β} : 𝓝 (a, b) = 𝓝 a ×ˢ 𝓝 b := by
   dsimp only [SProd.sprod]
   rw [Filter.prod, instTopologicalSpaceProd, nhds_inf (t₁ := TopologicalSpace.induced Prod.fst _)
     (t₂ := TopologicalSpace.induced Prod.snd _), nhds_induced, nhds_induced]
 #align nhds_prod_eq nhds_prod_eq
 
 -- porting note: moved from `topology.continuous_on`
-theorem nhdsWithin_prod_eq (a : α) (b : β) (s : Set α) (t : Set β) :
+theorem nhdsWithin_prod_eq (a : X) (b : β) (s : Set X) (t : Set β) :
     𝓝[s ×ˢ t] (a, b) = 𝓝[s] a ×ˢ 𝓝[t] b := by
   simp only [nhdsWithin, nhds_prod_eq, ← prod_inf_prod, prod_principal_principal]
 #align nhds_within_prod_eq nhdsWithin_prod_eq
 
 #noalign continuous_uncurry_of_discrete_topology
 
-theorem mem_nhds_prod_iff {a : α} {b : β} {s : Set (α × β)} :
+theorem mem_nhds_prod_iff {a : X} {b : β} {s : Set (X × β)} :
     s ∈ 𝓝 (a, b) ↔ ∃ u ∈ 𝓝 a, ∃ v ∈ 𝓝 b, u ×ˢ v ⊆ s := by rw [nhds_prod_eq, mem_prod_iff]
 #align mem_nhds_prod_iff mem_nhds_prod_iff
 
-theorem mem_nhdsWithin_prod_iff {a : α} {b : β} {s : Set (α × β)} {ta : Set α} {tb : Set β} :
+theorem mem_nhdsWithin_prod_iff {a : X} {b : β} {s : Set (X × β)} {ta : Set X} {tb : Set β} :
     s ∈ 𝓝[ta ×ˢ tb] (a, b) ↔ ∃ u ∈ 𝓝[ta] a, ∃ v ∈ 𝓝[tb] b, u ×ˢ v ⊆ s := by
   rw [nhdsWithin_prod_eq, mem_prod_iff]
 
 -- porting note: moved up
 theorem Filter.HasBasis.prod_nhds {ιa ιb : Type*} {pa : ιa → Prop} {pb : ιb → Prop}
-    {sa : ιa → Set α} {sb : ιb → Set β} {a : α} {b : β} (ha : (𝓝 a).HasBasis pa sa)
+    {sa : ιa → Set X} {sb : ιb → Set β} {a : X} {b : β} (ha : (𝓝 a).HasBasis pa sa)
     (hb : (𝓝 b).HasBasis pb sb) :
     (𝓝 (a, b)).HasBasis (fun i : ιa × ιb => pa i.1 ∧ pb i.2) fun i => sa i.1 ×ˢ sb i.2 := by
   rw [nhds_prod_eq]
@@ -554,78 +554,78 @@ theorem Filter.HasBasis.prod_nhds {ιa ιb : Type*} {pa : ιa → Prop} {pb : ι
 
 -- porting note: moved up
 theorem Filter.HasBasis.prod_nhds' {ιa ιb : Type*} {pa : ιa → Prop} {pb : ιb → Prop}
-    {sa : ιa → Set α} {sb : ιb → Set β} {ab : α × β} (ha : (𝓝 ab.1).HasBasis pa sa)
+    {sa : ιa → Set X} {sb : ιb → Set β} {ab : X × β} (ha : (𝓝 ab.1).HasBasis pa sa)
     (hb : (𝓝 ab.2).HasBasis pb sb) :
     (𝓝 ab).HasBasis (fun i : ιa × ιb => pa i.1 ∧ pb i.2) fun i => sa i.1 ×ˢ sb i.2 :=
   ha.prod_nhds hb
 #align filter.has_basis.prod_nhds' Filter.HasBasis.prod_nhds'
 
-theorem mem_nhds_prod_iff' {a : α} {b : β} {s : Set (α × β)} :
+theorem mem_nhds_prod_iff' {a : X} {b : β} {s : Set (X × β)} :
     s ∈ 𝓝 (a, b) ↔ ∃ u v, IsOpen u ∧ a ∈ u ∧ IsOpen v ∧ b ∈ v ∧ u ×ˢ v ⊆ s :=
   ((nhds_basis_opens a).prod_nhds (nhds_basis_opens b)).mem_iff.trans <| by
     simp only [Prod.exists, and_comm, and_assoc, and_left_comm]
 #align mem_nhds_prod_iff' mem_nhds_prod_iff'
 
-theorem Prod.tendsto_iff {α} (seq : α → β × γ) {f : Filter α} (x : β × γ) :
+theorem Prod.tendsto_iff {X} (seq : X → β × γ) {f : Filter X} (x : β × γ) :
     Tendsto seq f (𝓝 x) ↔
       Tendsto (fun n => (seq n).fst) f (𝓝 x.fst) ∧ Tendsto (fun n => (seq n).snd) f (𝓝 x.snd) := by
   rw [nhds_prod_eq, Filter.tendsto_prod_iff']
 #align prod.tendsto_iff Prod.tendsto_iff
 
-instance [DiscreteTopology α] [DiscreteTopology β] : DiscreteTopology (α × β) :=
+instance [DiscreteTopology X] [DiscreteTopology β] : DiscreteTopology (X × β) :=
   discreteTopology_iff_nhds.2 fun (a, b) => by
-    rw [nhds_prod_eq, nhds_discrete α, nhds_discrete β, prod_pure_pure]
+    rw [nhds_prod_eq, nhds_discrete X, nhds_discrete β, prod_pure_pure]
 
-theorem prod_mem_nhds_iff {s : Set α} {t : Set β} {a : α} {b : β} :
+theorem prod_mem_nhds_iff {s : Set X} {t : Set β} {a : X} {b : β} :
     s ×ˢ t ∈ 𝓝 (a, b) ↔ s ∈ 𝓝 a ∧ t ∈ 𝓝 b := by rw [nhds_prod_eq, prod_mem_prod_iff]
 #align prod_mem_nhds_iff prod_mem_nhds_iff
 
-theorem prod_mem_nhds {s : Set α} {t : Set β} {a : α} {b : β} (ha : s ∈ 𝓝 a) (hb : t ∈ 𝓝 b) :
+theorem prod_mem_nhds {s : Set X} {t : Set β} {a : X} {b : β} (ha : s ∈ 𝓝 a) (hb : t ∈ 𝓝 b) :
     s ×ˢ t ∈ 𝓝 (a, b) :=
   prod_mem_nhds_iff.2 ⟨ha, hb⟩
 #align prod_mem_nhds prod_mem_nhds
 
-theorem Filter.Eventually.prod_nhds {p : α → Prop} {q : β → Prop} {a : α} {b : β}
-    (ha : ∀ᶠ x in 𝓝 a, p x) (hb : ∀ᶠ y in 𝓝 b, q y) : ∀ᶠ z : α × β in 𝓝 (a, b), p z.1 ∧ q z.2 :=
+theorem Filter.Eventually.prod_nhds {p : X → Prop} {q : β → Prop} {a : X} {b : β}
+    (ha : ∀ᶠ x in 𝓝 a, p x) (hb : ∀ᶠ y in 𝓝 b, q y) : ∀ᶠ z : X × β in 𝓝 (a, b), p z.1 ∧ q z.2 :=
   prod_mem_nhds ha hb
 #align filter.eventually.prod_nhds Filter.Eventually.prod_nhds
 
-theorem nhds_swap (a : α) (b : β) : 𝓝 (a, b) = (𝓝 (b, a)).map Prod.swap := by
+theorem nhds_swap (a : X) (b : β) : 𝓝 (a, b) = (𝓝 (b, a)).map Prod.swap := by
   rw [nhds_prod_eq, Filter.prod_comm, nhds_prod_eq]; rfl
 #align nhds_swap nhds_swap
 
-theorem Filter.Tendsto.prod_mk_nhds {γ} {a : α} {b : β} {f : Filter γ} {ma : γ → α} {mb : γ → β}
+theorem Filter.Tendsto.prod_mk_nhds {γ} {a : X} {b : β} {f : Filter γ} {ma : γ → X} {mb : γ → β}
     (ha : Tendsto ma f (𝓝 a)) (hb : Tendsto mb f (𝓝 b)) :
     Tendsto (fun c => (ma c, mb c)) f (𝓝 (a, b)) := by
   rw [nhds_prod_eq]; exact Filter.Tendsto.prod_mk ha hb
 #align filter.tendsto.prod_mk_nhds Filter.Tendsto.prod_mk_nhds
 
-theorem Filter.Eventually.curry_nhds {p : α × β → Prop} {x : α} {y : β}
+theorem Filter.Eventually.curry_nhds {p : X × β → Prop} {x : X} {y : β}
     (h : ∀ᶠ x in 𝓝 (x, y), p x) : ∀ᶠ x' in 𝓝 x, ∀ᶠ y' in 𝓝 y, p (x', y') := by
   rw [nhds_prod_eq] at h
   exact h.curry
 #align filter.eventually.curry_nhds Filter.Eventually.curry_nhds
 
-theorem ContinuousAt.prod {f : α → β} {g : α → γ} {x : α} (hf : ContinuousAt f x)
+theorem ContinuousAt.prod {f : X → β} {g : X → γ} {x : X} (hf : ContinuousAt f x)
     (hg : ContinuousAt g x) : ContinuousAt (fun x => (f x, g x)) x :=
   hf.prod_mk_nhds hg
 #align continuous_at.prod ContinuousAt.prod
 
-theorem ContinuousAt.prod_map {f : α → γ} {g : β → δ} {p : α × β} (hf : ContinuousAt f p.fst)
-    (hg : ContinuousAt g p.snd) : ContinuousAt (fun p : α × β => (f p.1, g p.2)) p :=
+theorem ContinuousAt.prod_map {f : X → γ} {g : β → δ} {p : X × β} (hf : ContinuousAt f p.fst)
+    (hg : ContinuousAt g p.snd) : ContinuousAt (fun p : X × β => (f p.1, g p.2)) p :=
   hf.fst''.prod hg.snd''
 #align continuous_at.prod_map ContinuousAt.prod_map
 
-theorem ContinuousAt.prod_map' {f : α → γ} {g : β → δ} {x : α} {y : β} (hf : ContinuousAt f x)
-    (hg : ContinuousAt g y) : ContinuousAt (fun p : α × β => (f p.1, g p.2)) (x, y) :=
+theorem ContinuousAt.prod_map' {f : X → γ} {g : β → δ} {x : X} {y : β} (hf : ContinuousAt f x)
+    (hg : ContinuousAt g y) : ContinuousAt (fun p : X × β => (f p.1, g p.2)) (x, y) :=
   hf.fst'.prod hg.snd'
 #align continuous_at.prod_map' ContinuousAt.prod_map'
 
 -- todo: reformulate using `Set.image2`
 -- todo: prove a version of `generateFrom_union` with `image2 (∩) s t` in the LHS and use it here
-theorem prod_generateFrom_generateFrom_eq {α β : Type*} {s : Set (Set α)} {t : Set (Set β)}
+theorem prod_generateFrom_generateFrom_eq { β : Type*} {s : Set (Set X)} {t : Set (Set β)}
     (hs : ⋃₀ s = univ) (ht : ⋃₀ t = univ) :
-    @instTopologicalSpaceProd α β (generateFrom s) (generateFrom t) =
+    @instTopologicalSpaceProd X β (generateFrom s) (generateFrom t) =
       generateFrom { g | ∃ u ∈ s, ∃ v ∈ t, g = u ×ˢ v } :=
   let G := generateFrom { g | ∃ u ∈ s, ∃ v ∈ t, g = u ×ˢ v }
   le_antisymm
@@ -657,7 +657,7 @@ theorem prod_generateFrom_generateFrom_eq {α β : Type*} {s : Set (Set α)} {t 
 -- todo: use the previous lemma?
 theorem prod_eq_generateFrom :
     instTopologicalSpaceProd =
-      generateFrom { g | ∃ (s : Set α) (t : Set β), IsOpen s ∧ IsOpen t ∧ g = s ×ˢ t } :=
+      generateFrom { g | ∃ (s : Set X) (t : Set β), IsOpen s ∧ IsOpen t ∧ g = s ×ˢ t } :=
   le_antisymm (le_generateFrom fun g ⟨s, t, hs, ht, g_eq⟩ => g_eq.symm ▸ hs.prod ht)
     (le_inf
       (ball_image_of_ball fun t ht =>
@@ -667,15 +667,15 @@ theorem prod_eq_generateFrom :
 #align prod_eq_generate_from prod_eq_generateFrom
 
 -- porting note: todo: align with `mem_nhds_prod_iff'`
-theorem isOpen_prod_iff {s : Set (α × β)} :
+theorem isOpen_prod_iff {s : Set (X × β)} :
     IsOpen s ↔ ∀ a b, (a, b) ∈ s →
       ∃ u v, IsOpen u ∧ IsOpen v ∧ a ∈ u ∧ b ∈ v ∧ u ×ˢ v ⊆ s :=
   isOpen_iff_mem_nhds.trans <| by simp_rw [Prod.forall, mem_nhds_prod_iff', and_left_comm]
 #align is_open_prod_iff isOpen_prod_iff
 
 /-- A product of induced topologies is induced by the product map -/
-theorem prod_induced_induced (f : α → β) (g : γ → δ) :
-    @instTopologicalSpaceProd α γ (induced f ‹_›) (induced g ‹_›) =
+theorem prod_induced_induced (f : X → β) (g : γ → δ) :
+    @instTopologicalSpaceProd X γ (induced f ‹_›) (induced g ‹_›) =
       induced (fun p => (f p.1, g p.2)) instTopologicalSpaceProd := by
   delta instTopologicalSpaceProd
   simp_rw [induced_inf, induced_compose]
@@ -686,14 +686,14 @@ theorem prod_induced_induced (f : α → β) (g : γ → δ) :
 
 /-- Given a neighborhood `s` of `(x, x)`, then `(x, x)` has a square open neighborhood
   that is a subset of `s`. -/
-theorem exists_nhds_square {s : Set (α × α)} {x : α} (hx : s ∈ 𝓝 (x, x)) :
-    ∃ U : Set α, IsOpen U ∧ x ∈ U ∧ U ×ˢ U ⊆ s := by
+theorem exists_nhds_square {s : Set (X × X)} {x : X} (hx : s ∈ 𝓝 (x, x)) :
+    ∃ U : Set X, IsOpen U ∧ x ∈ U ∧ U ×ˢ U ⊆ s := by
   simpa [nhds_prod_eq, (nhds_basis_opens x).prod_self.mem_iff, and_assoc, and_left_comm] using hx
 #align exists_nhds_square exists_nhds_square
 
-/-- `Prod.fst` maps neighborhood of `x : α × β` within the section `Prod.snd ⁻¹' {x.2}`
+/-- `Prod.fst` maps neighborhood of `x :  × β` within the section `Prod.snd ⁻¹' {x.2}`
 to `𝓝 x.1`. -/
-theorem map_fst_nhdsWithin (x : α × β) : map Prod.fst (𝓝[Prod.snd ⁻¹' {x.2}] x) = 𝓝 x.1 := by
+theorem map_fst_nhdsWithin (x : X × β) : map Prod.fst (𝓝[Prod.snd ⁻¹' {x.2}] x) = 𝓝 x.1 := by
   refine' le_antisymm (continuousAt_fst.mono_left inf_le_left) fun s hs => _
   rcases x with ⟨x, y⟩
   rw [mem_map, nhdsWithin, mem_inf_principal, mem_nhds_prod_iff] at hs
@@ -703,18 +703,18 @@ theorem map_fst_nhdsWithin (x : α × β) : map Prod.fst (𝓝[Prod.snd ⁻¹' {
 #align map_fst_nhds_within map_fst_nhdsWithin
 
 @[simp]
-theorem map_fst_nhds (x : α × β) : map Prod.fst (𝓝 x) = 𝓝 x.1 :=
+theorem map_fst_nhds (x : X × β) : map Prod.fst (𝓝 x) = 𝓝 x.1 :=
   le_antisymm continuousAt_fst <| (map_fst_nhdsWithin x).symm.trans_le (map_mono inf_le_left)
 #align map_fst_nhds map_fst_nhds
 
 /-- The first projection in a product of topological spaces sends open sets to open sets. -/
-theorem isOpenMap_fst : IsOpenMap (@Prod.fst α β) :=
+theorem isOpenMap_fst : IsOpenMap (@Prod.fst X β) :=
   isOpenMap_iff_nhds_le.2 fun x => (map_fst_nhds x).ge
 #align is_open_map_fst isOpenMap_fst
 
-/-- `Prod.snd` maps neighborhood of `x : α × β` within the section `Prod.fst ⁻¹' {x.1}`
+/-- `Prod.snd` maps neighborhood of `x :  × β` within the section `Prod.fst ⁻¹' {x.1}`
 to `𝓝 x.2`. -/
-theorem map_snd_nhdsWithin (x : α × β) : map Prod.snd (𝓝[Prod.fst ⁻¹' {x.1}] x) = 𝓝 x.2 := by
+theorem map_snd_nhdsWithin (x : X × β) : map Prod.snd (𝓝[Prod.fst ⁻¹' {x.1}] x) = 𝓝 x.2 := by
   refine' le_antisymm (continuousAt_snd.mono_left inf_le_left) fun s hs => _
   rcases x with ⟨x, y⟩
   rw [mem_map, nhdsWithin, mem_inf_principal, mem_nhds_prod_iff] at hs
@@ -724,18 +724,18 @@ theorem map_snd_nhdsWithin (x : α × β) : map Prod.snd (𝓝[Prod.fst ⁻¹' {
 #align map_snd_nhds_within map_snd_nhdsWithin
 
 @[simp]
-theorem map_snd_nhds (x : α × β) : map Prod.snd (𝓝 x) = 𝓝 x.2 :=
+theorem map_snd_nhds (x : X × β) : map Prod.snd (𝓝 x) = 𝓝 x.2 :=
   le_antisymm continuousAt_snd <| (map_snd_nhdsWithin x).symm.trans_le (map_mono inf_le_left)
 #align map_snd_nhds map_snd_nhds
 
 /-- The second projection in a product of topological spaces sends open sets to open sets. -/
-theorem isOpenMap_snd : IsOpenMap (@Prod.snd α β) :=
+theorem isOpenMap_snd : IsOpenMap (@Prod.snd X β) :=
   isOpenMap_iff_nhds_le.2 fun x => (map_snd_nhds x).ge
 #align is_open_map_snd isOpenMap_snd
 
 /-- A product set is open in a product space if and only if each factor is open, or one of them is
 empty -/
-theorem isOpen_prod_iff' {s : Set α} {t : Set β} :
+theorem isOpen_prod_iff' {s : Set X} {t : Set β} :
     IsOpen (s ×ˢ t) ↔ IsOpen s ∧ IsOpen t ∨ s = ∅ ∨ t = ∅ := by
   rcases (s ×ˢ t).eq_empty_or_nonempty with h | h
   · simp [h, prod_eq_empty_iff.1 h]
@@ -754,33 +754,33 @@ theorem isOpen_prod_iff' {s : Set α} {t : Set β} :
       exact H.1.prod H.2
 #align is_open_prod_iff' isOpen_prod_iff'
 
-theorem closure_prod_eq {s : Set α} {t : Set β} : closure (s ×ˢ t) = closure s ×ˢ closure t :=
+theorem closure_prod_eq {s : Set X} {t : Set β} : closure (s ×ˢ t) = closure s ×ˢ closure t :=
   Set.ext fun ⟨a, b⟩ => by
     simp_rw [mem_prod, mem_closure_iff_nhdsWithin_neBot, nhdsWithin_prod_eq, prod_neBot]
 #align closure_prod_eq closure_prod_eq
 
-theorem interior_prod_eq (s : Set α) (t : Set β) : interior (s ×ˢ t) = interior s ×ˢ interior t :=
+theorem interior_prod_eq (s : Set X) (t : Set β) : interior (s ×ˢ t) = interior s ×ˢ interior t :=
   Set.ext fun ⟨a, b⟩ => by simp only [mem_interior_iff_mem_nhds, mem_prod, prod_mem_nhds_iff]
 #align interior_prod_eq interior_prod_eq
 
-theorem frontier_prod_eq (s : Set α) (t : Set β) :
+theorem frontier_prod_eq (s : Set X) (t : Set β) :
     frontier (s ×ˢ t) = closure s ×ˢ frontier t ∪ frontier s ×ˢ closure t := by
   simp only [frontier, closure_prod_eq, interior_prod_eq, prod_diff_prod]
 #align frontier_prod_eq frontier_prod_eq
 
 @[simp]
-theorem frontier_prod_univ_eq (s : Set α) :
+theorem frontier_prod_univ_eq (s : Set X) :
     frontier (s ×ˢ (univ : Set β)) = frontier s ×ˢ univ := by
   simp [frontier_prod_eq]
 #align frontier_prod_univ_eq frontier_prod_univ_eq
 
 @[simp]
 theorem frontier_univ_prod_eq (s : Set β) :
-    frontier ((univ : Set α) ×ˢ s) = univ ×ˢ frontier s := by
+    frontier ((univ : Set X) ×ˢ s) = univ ×ˢ frontier s := by
   simp [frontier_prod_eq]
 #align frontier_univ_prod_eq frontier_univ_prod_eq
 
-theorem map_mem_closure₂ {f : α → β → γ} {a : α} {b : β} {s : Set α} {t : Set β} {u : Set γ}
+theorem map_mem_closure₂ {f : X → β → γ} {a : X} {b : β} {s : Set X} {t : Set β} {u : Set γ}
     (hf : Continuous (uncurry f)) (ha : a ∈ closure s) (hb : b ∈ closure t)
     (h : ∀ a ∈ s, ∀ b ∈ t, f a b ∈ u) : f a b ∈ closure u :=
   have H₁ : (a, b) ∈ closure (s ×ˢ t) := by simpa only [closure_prod_eq] using mk_mem_prod ha hb
@@ -788,13 +788,13 @@ theorem map_mem_closure₂ {f : α → β → γ} {a : α} {b : β} {s : Set α}
   H₂.closure hf H₁
 #align map_mem_closure₂ map_mem_closure₂
 
-theorem IsClosed.prod {s₁ : Set α} {s₂ : Set β} (h₁ : IsClosed s₁) (h₂ : IsClosed s₂) :
+theorem IsClosed.prod {s₁ : Set X} {s₂ : Set β} (h₁ : IsClosed s₁) (h₂ : IsClosed s₂) :
     IsClosed (s₁ ×ˢ s₂) :=
   closure_eq_iff_isClosed.mp <| by simp only [h₁.closure_eq, h₂.closure_eq, closure_prod_eq]
 #align is_closed.prod IsClosed.prod
 
 /-- The product of two dense sets is a dense set. -/
-theorem Dense.prod {s : Set α} {t : Set β} (hs : Dense s) (ht : Dense t) : Dense (s ×ˢ t) :=
+theorem Dense.prod {s : Set X} {t : Set β} (hs : Dense s) (ht : Dense t) : Dense (s ×ˢ t) :=
   fun x => by
   rw [closure_prod_eq]
   exact ⟨hs x.1, ht x.2⟩
@@ -806,48 +806,48 @@ theorem DenseRange.prod_map {ι : Type*} {κ : Type*} {f : ι → β} {g : κ �
   simpa only [DenseRange, prod_range_range_eq] using hf.prod hg
 #align dense_range.prod_map DenseRange.prod_map
 
-theorem Inducing.prod_map {f : α → β} {g : γ → δ} (hf : Inducing f) (hg : Inducing g) :
+theorem Inducing.prod_map {f : X → β} {g : γ → δ} (hf : Inducing f) (hg : Inducing g) :
     Inducing (Prod.map f g) :=
   inducing_iff_nhds.2 fun (a, b) => by simp_rw [Prod.map_def, nhds_prod_eq, hf.nhds_eq_comap,
     hg.nhds_eq_comap, prod_comap_comap_eq]
 #align inducing.prod_mk Inducing.prod_map
 
 @[simp]
-theorem inducing_const_prod {a : α} {f : β → γ} : (Inducing fun x => (a, f x)) ↔ Inducing f := by
+theorem inducing_const_prod {a : X} {f : β → γ} : (Inducing fun x => (a, f x)) ↔ Inducing f := by
   simp_rw [inducing_iff, instTopologicalSpaceProd, induced_inf, induced_compose, Function.comp,
     induced_const, top_inf_eq]
 #align inducing_const_prod inducing_const_prod
 
 @[simp]
-theorem inducing_prod_const {b : β} {f : α → γ} : (Inducing fun x => (f x, b)) ↔ Inducing f := by
+theorem inducing_prod_const {b : β} {f : X → γ} : (Inducing fun x => (f x, b)) ↔ Inducing f := by
   simp_rw [inducing_iff, instTopologicalSpaceProd, induced_inf, induced_compose, Function.comp,
     induced_const, inf_top_eq]
 #align inducing_prod_const inducing_prod_const
 
-theorem Embedding.prod_map {f : α → β} {g : γ → δ} (hf : Embedding f) (hg : Embedding g) :
+theorem Embedding.prod_map {f : X → β} {g : γ → δ} (hf : Embedding f) (hg : Embedding g) :
     Embedding (Prod.map f g) :=
   { hf.toInducing.prod_map hg.toInducing with
     inj := fun ⟨x₁, x₂⟩ ⟨y₁, y₂⟩ => by simp [hf.inj.eq_iff, hg.inj.eq_iff] }
 #align embedding.prod_mk Embedding.prod_map
 
-protected theorem IsOpenMap.prod {f : α → β} {g : γ → δ} (hf : IsOpenMap f) (hg : IsOpenMap g) :
-    IsOpenMap fun p : α × γ => (f p.1, g p.2) := by
+protected theorem IsOpenMap.prod {f : X → β} {g : γ → δ} (hf : IsOpenMap f) (hg : IsOpenMap g) :
+    IsOpenMap fun p : X × γ => (f p.1, g p.2) := by
   rw [isOpenMap_iff_nhds_le]
   rintro ⟨a, b⟩
   rw [nhds_prod_eq, nhds_prod_eq, ← Filter.prod_map_map_eq]
   exact Filter.prod_mono (hf.nhds_le a) (hg.nhds_le b)
 #align is_open_map.prod IsOpenMap.prod
 
-protected theorem OpenEmbedding.prod {f : α → β} {g : γ → δ} (hf : OpenEmbedding f)
-    (hg : OpenEmbedding g) : OpenEmbedding fun x : α × γ => (f x.1, g x.2) :=
+protected theorem OpenEmbedding.prod {f : X → β} {g : γ → δ} (hf : OpenEmbedding f)
+    (hg : OpenEmbedding g) : OpenEmbedding fun x : X × γ => (f x.1, g x.2) :=
   openEmbedding_of_embedding_open (hf.1.prod_map hg.1) (hf.isOpenMap.prod hg.isOpenMap)
 #align open_embedding.prod OpenEmbedding.prod
 
-theorem embedding_graph {f : α → β} (hf : Continuous f) : Embedding fun x => (x, f x) :=
+theorem embedding_graph {f : X → β} (hf : Continuous f) : Embedding fun x => (x, f x) :=
   embedding_of_embedding_compose (continuous_id.prod_mk hf) continuous_fst embedding_id
 #align embedding_graph embedding_graph
 
-theorem embedding_prod_mk (x : α) : Embedding (Prod.mk x : β → α × β) :=
+theorem embedding_prod_mk (x : X) : Embedding (Prod.mk x : β → X × β) :=
   embedding_of_embedding_compose (Continuous.Prod.mk x) continuous_snd embedding_id
 
 end Prod
@@ -856,136 +856,136 @@ section Sum
 
 open Sum
 
-variable [TopologicalSpace α] [TopologicalSpace β] [TopologicalSpace γ] [TopologicalSpace δ]
+variable [TopologicalSpace X] [TopologicalSpace β] [TopologicalSpace γ] [TopologicalSpace δ]
 
-theorem continuous_sum_dom {f : α ⊕ β → γ} :
+theorem continuous_sum_dom {f : X ⊕ β → γ} :
     Continuous f ↔ Continuous (f ∘ Sum.inl) ∧ Continuous (f ∘ Sum.inr) :=
   (continuous_sup_dom (t₁ := TopologicalSpace.coinduced Sum.inl _)
     (t₂ := TopologicalSpace.coinduced Sum.inr _)).trans <|
     continuous_coinduced_dom.and continuous_coinduced_dom
 #align continuous_sum_dom continuous_sum_dom
 
-theorem continuous_sum_elim {f : α → γ} {g : β → γ} :
+theorem continuous_sum_elim {f : X → γ} {g : β → γ} :
     Continuous (Sum.elim f g) ↔ Continuous f ∧ Continuous g :=
   continuous_sum_dom
 #align continuous_sum_elim continuous_sum_elim
 
 @[continuity]
-theorem Continuous.sum_elim {f : α → γ} {g : β → γ} (hf : Continuous f) (hg : Continuous g) :
+theorem Continuous.sum_elim {f : X → γ} {g : β → γ} (hf : Continuous f) (hg : Continuous g) :
     Continuous (Sum.elim f g) :=
   continuous_sum_elim.2 ⟨hf, hg⟩
 #align continuous.sum_elim Continuous.sum_elim
 
 @[continuity]
-theorem continuous_isLeft : Continuous (isLeft : α ⊕ β → Bool) :=
+theorem continuous_isLeft : Continuous (isLeft : X ⊕ β → Bool) :=
   continuous_sum_dom.2 ⟨continuous_const, continuous_const⟩
 
 @[continuity]
-theorem continuous_isRight : Continuous (isRight : α ⊕ β → Bool) :=
+theorem continuous_isRight : Continuous (isRight : X ⊕ β → Bool) :=
   continuous_sum_dom.2 ⟨continuous_const, continuous_const⟩
 
 @[continuity]
 -- porting note: the proof was `continuous_sup_rng_left continuous_coinduced_rng`
-theorem continuous_inl : Continuous (@inl α β) := ⟨fun _ => And.left⟩
+theorem continuous_inl : Continuous (@inl X β) := ⟨fun _ => And.left⟩
 #align continuous_inl continuous_inl
 
 @[continuity]
 -- porting note: the proof was `continuous_sup_rng_right continuous_coinduced_rng`
-theorem continuous_inr : Continuous (@inr α β) := ⟨fun _ => And.right⟩
+theorem continuous_inr : Continuous (@inr X β) := ⟨fun _ => And.right⟩
 #align continuous_inr continuous_inr
 
-theorem isOpen_sum_iff {s : Set (Sum α β)} : IsOpen s ↔ IsOpen (inl ⁻¹' s) ∧ IsOpen (inr ⁻¹' s) :=
+theorem isOpen_sum_iff {s : Set (Sum X β)} : IsOpen s ↔ IsOpen (inl ⁻¹' s) ∧ IsOpen (inr ⁻¹' s) :=
   Iff.rfl
 #align is_open_sum_iff isOpen_sum_iff
 
 -- porting note: new theorem
-theorem isClosed_sum_iff {s : Set (α ⊕ β)} :
+theorem isClosed_sum_iff {s : Set (X ⊕ β)} :
     IsClosed s ↔ IsClosed (inl ⁻¹' s) ∧ IsClosed (inr ⁻¹' s) := by
   simp only [← isOpen_compl_iff, isOpen_sum_iff, preimage_compl]
 
-theorem isOpenMap_inl : IsOpenMap (@inl α β) := fun u hu => by
+theorem isOpenMap_inl : IsOpenMap (@inl X β) := fun u hu => by
   simpa [isOpen_sum_iff, preimage_image_eq u Sum.inl_injective]
 #align is_open_map_inl isOpenMap_inl
 
-theorem isOpenMap_inr : IsOpenMap (@inr α β) := fun u hu => by
+theorem isOpenMap_inr : IsOpenMap (@inr X β) := fun u hu => by
   simpa [isOpen_sum_iff, preimage_image_eq u Sum.inr_injective]
 #align is_open_map_inr isOpenMap_inr
 
-theorem openEmbedding_inl : OpenEmbedding (@inl α β) :=
+theorem openEmbedding_inl : OpenEmbedding (@inl X β) :=
   openEmbedding_of_continuous_injective_open continuous_inl inl_injective isOpenMap_inl
 #align open_embedding_inl openEmbedding_inl
 
-theorem openEmbedding_inr : OpenEmbedding (@inr α β) :=
+theorem openEmbedding_inr : OpenEmbedding (@inr X β) :=
   openEmbedding_of_continuous_injective_open continuous_inr inr_injective isOpenMap_inr
 #align open_embedding_inr openEmbedding_inr
 
-theorem embedding_inl : Embedding (@inl α β) :=
+theorem embedding_inl : Embedding (@inl X β) :=
   openEmbedding_inl.1
 #align embedding_inl embedding_inl
 
-theorem embedding_inr : Embedding (@inr α β) :=
+theorem embedding_inr : Embedding (@inr X β) :=
   openEmbedding_inr.1
 #align embedding_inr embedding_inr
 
-theorem isOpen_range_inl : IsOpen (range (inl : α → Sum α β)) :=
+theorem isOpen_range_inl : IsOpen (range (inl : X → Sum X β)) :=
   openEmbedding_inl.2
 #align is_open_range_inl isOpen_range_inl
 
-theorem isOpen_range_inr : IsOpen (range (inr : β → Sum α β)) :=
+theorem isOpen_range_inr : IsOpen (range (inr : β → Sum X β)) :=
   openEmbedding_inr.2
 #align is_open_range_inr isOpen_range_inr
 
-theorem isClosed_range_inl : IsClosed (range (inl : α → Sum α β)) := by
+theorem isClosed_range_inl : IsClosed (range (inl : X → Sum X β)) := by
   rw [← isOpen_compl_iff, compl_range_inl]
   exact isOpen_range_inr
 #align is_closed_range_inl isClosed_range_inl
 
-theorem isClosed_range_inr : IsClosed (range (inr : β → Sum α β)) := by
+theorem isClosed_range_inr : IsClosed (range (inr : β → Sum X β)) := by
   rw [← isOpen_compl_iff, compl_range_inr]
   exact isOpen_range_inl
 #align is_closed_range_inr isClosed_range_inr
 
-theorem closedEmbedding_inl : ClosedEmbedding (inl : α → Sum α β) :=
+theorem closedEmbedding_inl : ClosedEmbedding (inl : X → Sum X β) :=
   ⟨embedding_inl, isClosed_range_inl⟩
 #align closed_embedding_inl closedEmbedding_inl
 
-theorem closedEmbedding_inr : ClosedEmbedding (inr : β → Sum α β) :=
+theorem closedEmbedding_inr : ClosedEmbedding (inr : β → Sum X β) :=
   ⟨embedding_inr, isClosed_range_inr⟩
 #align closed_embedding_inr closedEmbedding_inr
 
-theorem nhds_inl (x : α) : 𝓝 (inl x : Sum α β) = map inl (𝓝 x) :=
+theorem nhds_inl (x : X) : 𝓝 (inl x : Sum X β) = map inl (𝓝 x) :=
   (openEmbedding_inl.map_nhds_eq _).symm
 #align nhds_inl nhds_inl
 
-theorem nhds_inr (x : β) : 𝓝 (inr x : Sum α β) = map inr (𝓝 x) :=
+theorem nhds_inr (x : β) : 𝓝 (inr x : Sum X β) = map inr (𝓝 x) :=
   (openEmbedding_inr.map_nhds_eq _).symm
 #align nhds_inr nhds_inr
 
 @[simp]
-theorem continuous_sum_map {f : α → β} {g : γ → δ} :
+theorem continuous_sum_map {f : X → β} {g : γ → δ} :
     Continuous (Sum.map f g) ↔ Continuous f ∧ Continuous g :=
   continuous_sum_elim.trans <|
     embedding_inl.continuous_iff.symm.and embedding_inr.continuous_iff.symm
 #align continuous_sum_map continuous_sum_map
 
 @[continuity]
-theorem Continuous.sum_map {f : α → β} {g : γ → δ} (hf : Continuous f) (hg : Continuous g) :
+theorem Continuous.sum_map {f : X → β} {g : γ → δ} (hf : Continuous f) (hg : Continuous g) :
     Continuous (Sum.map f g) :=
   continuous_sum_map.2 ⟨hf, hg⟩
 #align continuous.sum_map Continuous.sum_map
 
-theorem isOpenMap_sum {f : Sum α β → γ} :
+theorem isOpenMap_sum {f : Sum X β → γ} :
     IsOpenMap f ↔ (IsOpenMap fun a => f (inl a)) ∧ IsOpenMap fun b => f (inr b) := by
   simp only [isOpenMap_iff_nhds_le, Sum.forall, nhds_inl, nhds_inr, Filter.map_map, comp]
 #align is_open_map_sum isOpenMap_sum
 
 @[simp]
-theorem isOpenMap_sum_elim {f : α → γ} {g : β → γ} :
+theorem isOpenMap_sum_elim {f : X → γ} {g : β → γ} :
     IsOpenMap (Sum.elim f g) ↔ IsOpenMap f ∧ IsOpenMap g := by
   simp only [isOpenMap_sum, elim_inl, elim_inr]
 #align is_open_map_sum_elim isOpenMap_sum_elim
 
-theorem IsOpenMap.sum_elim {f : α → γ} {g : β → γ} (hf : IsOpenMap f) (hg : IsOpenMap g) :
+theorem IsOpenMap.sum_elim {f : X → γ} {g : β → γ} (hf : IsOpenMap f) (hg : IsOpenMap g) :
     IsOpenMap (Sum.elim f g) :=
   isOpenMap_sum_elim.2 ⟨hf, hg⟩
 #align is_open_map.sum_elim IsOpenMap.sum_elim
@@ -994,51 +994,51 @@ end Sum
 
 section Subtype
 
-variable [TopologicalSpace α] [TopologicalSpace β] [TopologicalSpace γ] {p : α → Prop}
+variable [TopologicalSpace X] [TopologicalSpace β] [TopologicalSpace γ] {p : X → Prop}
 
 theorem inducing_subtype_val {b : Set β} : Inducing ((↑) : b → β) := ⟨rfl⟩
 #align inducing_coe inducing_subtype_val
 
-theorem Inducing.of_codRestrict {f : α → β} {b : Set β} (hb : ∀ a, f a ∈ b)
+theorem Inducing.of_codRestrict {f : X → β} {b : Set β} (hb : ∀ a, f a ∈ b)
     (h : Inducing (b.codRestrict f hb)) : Inducing f :=
   inducing_subtype_val.comp h
 #align inducing.of_cod_restrict Inducing.of_codRestrict
 
-theorem embedding_subtype_val : Embedding ((↑) : Subtype p → α) :=
+theorem embedding_subtype_val : Embedding ((↑) : Subtype p → X) :=
   ⟨inducing_subtype_val, Subtype.coe_injective⟩
 #align embedding_subtype_coe embedding_subtype_val
 
 theorem closedEmbedding_subtype_val (h : IsClosed { a | p a }) :
-    ClosedEmbedding ((↑) : Subtype p → α) :=
+    ClosedEmbedding ((↑) : Subtype p → X) :=
   ⟨embedding_subtype_val, by rwa [Subtype.range_coe_subtype]⟩
 #align closed_embedding_subtype_coe closedEmbedding_subtype_val
 
 @[continuity]
-theorem continuous_subtype_val : Continuous (@Subtype.val α p) :=
+theorem continuous_subtype_val : Continuous (@Subtype.val X p) :=
   continuous_induced_dom
 #align continuous_subtype_val continuous_subtype_val
 #align continuous_subtype_coe continuous_subtype_val
 
 theorem Continuous.subtype_val {f : β → Subtype p} (hf : Continuous f) :
-    Continuous fun x => (f x : α) :=
+    Continuous fun x => (f x : X) :=
   continuous_subtype_val.comp hf
 #align continuous.subtype_coe Continuous.subtype_val
 
-theorem IsOpen.openEmbedding_subtype_val {s : Set α} (hs : IsOpen s) :
-    OpenEmbedding ((↑) : s → α) :=
+theorem IsOpen.openEmbedding_subtype_val {s : Set X} (hs : IsOpen s) :
+    OpenEmbedding ((↑) : s → X) :=
   ⟨embedding_subtype_val, (@Subtype.range_coe _ s).symm ▸ hs⟩
 #align is_open.open_embedding_subtype_coe IsOpen.openEmbedding_subtype_val
 
-theorem IsOpen.isOpenMap_subtype_val {s : Set α} (hs : IsOpen s) : IsOpenMap ((↑) : s → α) :=
+theorem IsOpen.isOpenMap_subtype_val {s : Set X} (hs : IsOpen s) : IsOpenMap ((↑) : s → X) :=
   hs.openEmbedding_subtype_val.isOpenMap
 #align is_open.is_open_map_subtype_coe IsOpen.isOpenMap_subtype_val
 
-theorem IsOpenMap.restrict {f : α → β} (hf : IsOpenMap f) {s : Set α} (hs : IsOpen s) :
+theorem IsOpenMap.restrict {f : X → β} (hf : IsOpenMap f) {s : Set X} (hs : IsOpen s) :
     IsOpenMap (s.restrict f) :=
   hf.comp hs.isOpenMap_subtype_val
 #align is_open_map.restrict IsOpenMap.restrict
 
-lemma IsClosedMap.restrictPreimage {f : α → β} (hcl : IsClosedMap f) (T : Set β) :
+lemma IsClosedMap.restrictPreimage {f : X → β} (hcl : IsClosedMap f) (T : Set β) :
     IsClosedMap (T.restrictPreimage f) := by
   rw [isClosedMap_iff_clusterPt] at hcl ⊢
   intro A ⟨y, hyT⟩ hy
@@ -1049,61 +1049,61 @@ lemma IsClosedMap.restrictPreimage {f : α → β} (hcl : IsClosedMap f) (T : Se
   refine ⟨⟨x, hxT⟩, Subtype.ext hxy, ?_⟩
   rwa [← inducing_subtype_val.mapClusterPt_iff, MapClusterPt, map_principal]
 
-nonrec theorem IsClosed.closedEmbedding_subtype_val {s : Set α} (hs : IsClosed s) :
-    ClosedEmbedding ((↑) : s → α) :=
+nonrec theorem IsClosed.closedEmbedding_subtype_val {s : Set X} (hs : IsClosed s) :
+    ClosedEmbedding ((↑) : s → X) :=
   closedEmbedding_subtype_val hs
 #align is_closed.closed_embedding_subtype_coe IsClosed.closedEmbedding_subtype_val
 
 @[continuity]
-theorem Continuous.subtype_mk {f : β → α} (h : Continuous f) (hp : ∀ x, p (f x)) :
+theorem Continuous.subtype_mk {f : β → X} (h : Continuous f) (hp : ∀ x, p (f x)) :
     Continuous fun x => (⟨f x, hp x⟩ : Subtype p) :=
   continuous_induced_rng.2 h
 #align continuous.subtype_mk Continuous.subtype_mk
 
-theorem Continuous.subtype_map {f : α → β} (h : Continuous f) {q : β → Prop}
+theorem Continuous.subtype_map {f : X → β} (h : Continuous f) {q : β → Prop}
     (hpq : ∀ x, p x → q (f x)) : Continuous (Subtype.map f hpq) :=
   (h.comp continuous_subtype_val).subtype_mk _
 #align continuous.subtype_map Continuous.subtype_map
 
-theorem continuous_inclusion {s t : Set α} (h : s ⊆ t) : Continuous (inclusion h) :=
+theorem continuous_inclusion {s t : Set X} (h : s ⊆ t) : Continuous (inclusion h) :=
   continuous_id.subtype_map h
 #align continuous_inclusion continuous_inclusion
 
-theorem continuousAt_subtype_val {p : α → Prop} {a : Subtype p} :
-    ContinuousAt ((↑) : Subtype p → α) a :=
+theorem continuousAt_subtype_val {p : X → Prop} {a : Subtype p} :
+    ContinuousAt ((↑) : Subtype p → X) a :=
   continuous_subtype_val.continuousAt
 #align continuous_at_subtype_coe continuousAt_subtype_val
 
-theorem Subtype.dense_iff {s : Set α} {t : Set s} : Dense t ↔ s ⊆ closure ((↑) '' t) := by
+theorem Subtype.dense_iff {s : Set X} {t : Set s} : Dense t ↔ s ⊆ closure ((↑) '' t) := by
   rw [inducing_subtype_val.dense_iff, SetCoe.forall]
   rfl
 #align subtype.dense_iff Subtype.dense_iff
 
 -- porting note: new lemma
-theorem map_nhds_subtype_val {s : Set α} (a : s) : map ((↑) : s → α) (𝓝 a) = 𝓝[s] ↑a := by
+theorem map_nhds_subtype_val {s : Set X} (a : s) : map ((↑) : s → X) (𝓝 a) = 𝓝[s] ↑a := by
   rw [inducing_subtype_val.map_nhds_eq, Subtype.range_val]
 
-theorem map_nhds_subtype_coe_eq_nhds {a : α} (ha : p a) (h : ∀ᶠ x in 𝓝 a, p x) :
-    map ((↑) : Subtype p → α) (𝓝 ⟨a, ha⟩) = 𝓝 a :=
+theorem map_nhds_subtype_coe_eq_nhds {a : X} (ha : p a) (h : ∀ᶠ x in 𝓝 a, p x) :
+    map ((↑) : Subtype p → X) (𝓝 ⟨a, ha⟩) = 𝓝 a :=
   map_nhds_induced_of_mem <| by rw [Subtype.range_val]; exact h
 #align map_nhds_subtype_coe_eq map_nhds_subtype_coe_eq_nhds
 
-theorem nhds_subtype_eq_comap {a : α} {h : p a} : 𝓝 (⟨a, h⟩ : Subtype p) = comap (↑) (𝓝 a) :=
+theorem nhds_subtype_eq_comap {a : X} {h : p a} : 𝓝 (⟨a, h⟩ : Subtype p) = comap (↑) (𝓝 a) :=
   nhds_induced _ _
 #align nhds_subtype_eq_comap nhds_subtype_eq_comap
 
-theorem tendsto_subtype_rng {β : Type*} {p : α → Prop} {b : Filter β} {f : β → Subtype p} :
-    ∀ {a : Subtype p}, Tendsto f b (𝓝 a) ↔ Tendsto (fun x => (f x : α)) b (𝓝 (a : α))
+theorem tendsto_subtype_rng {β : Type*} {p : X → Prop} {b : Filter β} {f : β → Subtype p} :
+    ∀ {a : Subtype p}, Tendsto f b (𝓝 a) ↔ Tendsto (fun x => (f x : X)) b (𝓝 (a : X))
   | ⟨a, ha⟩ => by rw [nhds_subtype_eq_comap, tendsto_comap_iff]; rfl
 #align tendsto_subtype_rng tendsto_subtype_rng
 
 theorem closure_subtype {x : { a // p a }} {s : Set { a // p a }} :
-    x ∈ closure s ↔ (x : α) ∈ closure (((↑) : _ → α) '' s) :=
+    x ∈ closure s ↔ (x : X) ∈ closure (((↑) : _ → X) '' s) :=
   closure_induced
 #align closure_subtype closure_subtype
 
 @[simp]
-theorem continuousAt_codRestrict_iff {f : α → β} {t : Set β} (h1 : ∀ x, f x ∈ t) {x : α} :
+theorem continuousAt_codRestrict_iff {f : X → β} {t : Set β} (h1 : ∀ x, f x ∈ t) {x : X} :
     ContinuousAt (codRestrict f t h1) x ↔ ContinuousAt f x :=
   inducing_subtype_val.continuousAt_iff
 #align continuous_at_cod_restrict_iff continuousAt_codRestrict_iff
@@ -1111,43 +1111,43 @@ theorem continuousAt_codRestrict_iff {f : α → β} {t : Set β} (h1 : ∀ x, f
 alias ⟨_, ContinuousAt.codRestrict⟩ := continuousAt_codRestrict_iff
 #align continuous_at.cod_restrict ContinuousAt.codRestrict
 
-theorem ContinuousAt.restrict {f : α → β} {s : Set α} {t : Set β} (h1 : MapsTo f s t) {x : s}
+theorem ContinuousAt.restrict {f : X → β} {s : Set X} {t : Set β} (h1 : MapsTo f s t) {x : s}
     (h2 : ContinuousAt f x) : ContinuousAt (h1.restrict f s t) x :=
   (h2.comp continuousAt_subtype_val).codRestrict _
 #align continuous_at.restrict ContinuousAt.restrict
 
-theorem ContinuousAt.restrictPreimage {f : α → β} {s : Set β} {x : f ⁻¹' s} (h : ContinuousAt f x) :
+theorem ContinuousAt.restrictPreimage {f : X → β} {s : Set β} {x : f ⁻¹' s} (h : ContinuousAt f x) :
     ContinuousAt (s.restrictPreimage f) x :=
   h.restrict _
 #align continuous_at.restrict_preimage ContinuousAt.restrictPreimage
 
 @[continuity]
-theorem Continuous.codRestrict {f : α → β} {s : Set β} (hf : Continuous f) (hs : ∀ a, f a ∈ s) :
+theorem Continuous.codRestrict {f : X → β} {s : Set β} (hf : Continuous f) (hs : ∀ a, f a ∈ s) :
     Continuous (s.codRestrict f hs) :=
   hf.subtype_mk hs
 #align continuous.cod_restrict Continuous.codRestrict
 
 @[continuity]
-theorem Continuous.restrict {f : α → β} {s : Set α} {t : Set β} (h1 : MapsTo f s t)
+theorem Continuous.restrict {f : X → β} {s : Set X} {t : Set β} (h1 : MapsTo f s t)
     (h2 : Continuous f) : Continuous (h1.restrict f s t) :=
   (h2.comp continuous_subtype_val).codRestrict _
 
 @[continuity]
-theorem Continuous.restrictPreimage {f : α → β} {s : Set β} (h : Continuous f) :
+theorem Continuous.restrictPreimage {f : X → β} {s : Set β} (h : Continuous f) :
     Continuous (s.restrictPreimage f) :=
   h.restrict _
 
-theorem Inducing.codRestrict {e : α → β} (he : Inducing e) {s : Set β} (hs : ∀ x, e x ∈ s) :
+theorem Inducing.codRestrict {e : X → β} (he : Inducing e) {s : Set β} (hs : ∀ x, e x ∈ s) :
     Inducing (codRestrict e s hs) :=
   inducing_of_inducing_compose (he.continuous.codRestrict hs) continuous_subtype_val he
 #align inducing.cod_restrict Inducing.codRestrict
 
-theorem Embedding.codRestrict {e : α → β} (he : Embedding e) (s : Set β) (hs : ∀ x, e x ∈ s) :
+theorem Embedding.codRestrict {e : X → β} (he : Embedding e) (s : Set β) (hs : ∀ x, e x ∈ s) :
     Embedding (codRestrict e s hs) :=
   embedding_of_embedding_compose (he.continuous.codRestrict hs) continuous_subtype_val he
 #align embedding.cod_restrict Embedding.codRestrict
 
-theorem embedding_inclusion {s t : Set α} (h : s ⊆ t) : Embedding (Set.inclusion h) :=
+theorem embedding_inclusion {s t : Set X} (h : s ⊆ t) : Embedding (Set.inclusion h) :=
   embedding_subtype_val.codRestrict _ _
 #align embedding_inclusion embedding_inclusion
 
@@ -1162,45 +1162,45 @@ end Subtype
 
 section Quotient
 
-variable [TopologicalSpace α] [TopologicalSpace β] [TopologicalSpace γ]
+variable [TopologicalSpace X] [TopologicalSpace β] [TopologicalSpace γ]
 
-variable {r : α → α → Prop} {s : Setoid α}
+variable {r : X → X → Prop} {s : Setoid X}
 
-theorem quotientMap_quot_mk : QuotientMap (@Quot.mk α r) :=
+theorem quotientMap_quot_mk : QuotientMap (@Quot.mk X r) :=
   ⟨Quot.exists_rep, rfl⟩
 #align quotient_map_quot_mk quotientMap_quot_mk
 
 @[continuity]
-theorem continuous_quot_mk : Continuous (@Quot.mk α r) :=
+theorem continuous_quot_mk : Continuous (@Quot.mk X r) :=
   continuous_coinduced_rng
 #align continuous_quot_mk continuous_quot_mk
 
 @[continuity]
-theorem continuous_quot_lift {f : α → β} (hr : ∀ a b, r a b → f a = f b) (h : Continuous f) :
+theorem continuous_quot_lift {f : X → β} (hr : ∀ a b, r a b → f a = f b) (h : Continuous f) :
     Continuous (Quot.lift f hr : Quot r → β) :=
   continuous_coinduced_dom.2 h
 #align continuous_quot_lift continuous_quot_lift
 
-theorem quotientMap_quotient_mk' : QuotientMap (@Quotient.mk' α s) :=
+theorem quotientMap_quotient_mk' : QuotientMap (@Quotient.mk' X s) :=
   quotientMap_quot_mk
 #align quotient_map_quotient_mk quotientMap_quotient_mk'
 
-theorem continuous_quotient_mk' : Continuous (@Quotient.mk' α s) :=
+theorem continuous_quotient_mk' : Continuous (@Quotient.mk' X s) :=
   continuous_coinduced_rng
 #align continuous_quotient_mk continuous_quotient_mk'
 
-theorem Continuous.quotient_lift {f : α → β} (h : Continuous f) (hs : ∀ a b, a ≈ b → f a = f b) :
+theorem Continuous.quotient_lift {f : X → β} (h : Continuous f) (hs : ∀ a b, a ≈ b → f a = f b) :
     Continuous (Quotient.lift f hs : Quotient s → β) :=
   continuous_coinduced_dom.2 h
 #align continuous.quotient_lift Continuous.quotient_lift
 
-theorem Continuous.quotient_liftOn' {f : α → β} (h : Continuous f)
+theorem Continuous.quotient_liftOn' {f : X → β} (h : Continuous f)
     (hs : ∀ a b, @Setoid.r _ s a b → f a = f b) :
     Continuous (fun x => Quotient.liftOn' x f hs : Quotient s → β) :=
   h.quotient_lift hs
 #align continuous.quotient_lift_on' Continuous.quotient_liftOn'
 
-@[continuity] theorem Continuous.quotient_map' {t : Setoid β} {f : α → β} (hf : Continuous f)
+@[continuity] theorem Continuous.quotient_map' {t : Setoid β} {f : X → β} (hf : Continuous f)
     (H : (s.r ⇒ t.r) f f) : Continuous (Quotient.map' f H) :=
   (continuous_quotient_mk'.comp hf).quotient_lift _
 #align continuous.quotient_map' Continuous.quotient_map'
@@ -1209,8 +1209,8 @@ end Quotient
 
 section Pi
 
-variable {ι : Type*} {π : ι → Type*} {κ : Type*} [TopologicalSpace α]
-  [T : ∀ i, TopologicalSpace (π i)] {f : α → ∀ i : ι, π i}
+variable {ι : Type*} {π : ι → Type*} {κ : Type*} [TopologicalSpace X]
+  [T : ∀ i, TopologicalSpace (π i)] {f : X → ∀ i : ι, π i}
 
 theorem continuous_pi_iff : Continuous f ↔ ∀ i, Continuous fun a => f a i := by
   simp only [continuous_iInf_rng, continuous_induced_rng, comp]
@@ -1250,7 +1250,7 @@ theorem tendsto_pi_nhds {f : β → ∀ i, π i} {g : ∀ i, π i} {u : Filter �
   rw [nhds_pi, Filter.tendsto_pi]
 #align tendsto_pi_nhds tendsto_pi_nhds
 
-theorem continuousAt_pi {f : α → ∀ i, π i} {x : α} :
+theorem continuousAt_pi {f : X → ∀ i, π i} {x : X} :
     ContinuousAt f x ↔ ∀ i, ContinuousAt (fun y => f y i) x :=
   tendsto_pi_nhds
 #align continuous_at_pi continuousAt_pi
@@ -1260,7 +1260,7 @@ theorem Pi.continuous_precomp' {ι' : Type*} (φ : ι' → ι) :
   continuous_pi fun j ↦ continuous_apply (φ j)
 
 theorem Pi.continuous_precomp {ι' : Type*} (φ : ι' → ι) :
-    Continuous (· ∘ φ : (ι → α) → (ι' → α)) :=
+    Continuous (· ∘ φ : (ι → X) → (ι' → X)) :=
   Pi.continuous_precomp' φ
 
 theorem Pi.continuous_postcomp' {ρ : ι → Type*} [∀ i, TopologicalSpace (ρ i)]
@@ -1268,8 +1268,8 @@ theorem Pi.continuous_postcomp' {ρ : ι → Type*} [∀ i, TopologicalSpace (ρ
     Continuous (fun (f : (∀ i, π i)) (i : ι) ↦ g i (f i)) :=
   continuous_pi fun i ↦ (hg i).comp <| continuous_apply i
 
-theorem Pi.continuous_postcomp [TopologicalSpace β] {g : α → β} (hg : Continuous g) :
-    Continuous (g ∘ · : (ι → α) → (ι → β)) :=
+theorem Pi.continuous_postcomp [TopologicalSpace β] {g : X → β} (hg : Continuous g) :
+    Continuous (g ∘ · : (ι → X) → (ι → β)) :=
   Pi.continuous_postcomp' fun _ ↦ hg
 
 lemma Pi.induced_precomp' {ι' : Type*} (φ : ι' → ι) :
@@ -1298,12 +1298,12 @@ theorem Filter.Tendsto.update [DecidableEq ι] {l : Filter β} {f : β → ∀ i
   tendsto_pi_nhds.2 fun j => by rcases eq_or_ne j i with (rfl | hj) <;> simp [*, hf.apply]
 #align filter.tendsto.update Filter.Tendsto.update
 
-theorem ContinuousAt.update [DecidableEq ι] {a : α} (hf : ContinuousAt f a) (i : ι) {g : α → π i}
+theorem ContinuousAt.update [DecidableEq ι] {a : X} (hf : ContinuousAt f a) (i : ι) {g : X → π i}
     (hg : ContinuousAt g a) : ContinuousAt (fun a => update (f a) i (g a)) a :=
   hf.tendsto.update i hg
 #align continuous_at.update ContinuousAt.update
 
-theorem Continuous.update [DecidableEq ι] (hf : Continuous f) (i : ι) {g : α → π i}
+theorem Continuous.update [DecidableEq ι] (hf : Continuous f) (i : ι) {g : X → π i}
     (hg : Continuous g) : Continuous fun a => update (f a) i (g a) :=
   continuous_iff_continuousAt.2 fun _ => hf.continuousAt.update i hg.continuousAt
 #align continuous.update Continuous.update
@@ -1332,14 +1332,14 @@ theorem Filter.Tendsto.fin_insertNth {n} {π : Fin (n + 1) → Type*} [∀ i, To
 #align filter.tendsto.fin_insert_nth Filter.Tendsto.fin_insertNth
 
 theorem ContinuousAt.fin_insertNth {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
-    (i : Fin (n + 1)) {f : α → π i} {a : α} (hf : ContinuousAt f a)
-    {g : α → ∀ j : Fin n, π (i.succAbove j)} (hg : ContinuousAt g a) :
+    (i : Fin (n + 1)) {f : X → π i} {a : X} (hf : ContinuousAt f a)
+    {g : X → ∀ j : Fin n, π (i.succAbove j)} (hg : ContinuousAt g a) :
     ContinuousAt (fun a => i.insertNth (f a) (g a)) a :=
   hf.tendsto.fin_insertNth i hg
 #align continuous_at.fin_insert_nth ContinuousAt.fin_insertNth
 
 theorem Continuous.fin_insertNth {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
-    (i : Fin (n + 1)) {f : α → π i} (hf : Continuous f) {g : α → ∀ j : Fin n, π (i.succAbove j)}
+    (i : Fin (n + 1)) {f : X → π i} (hf : Continuous f) {g : X → ∀ j : Fin n, π (i.succAbove j)}
     (hg : Continuous g) : Continuous fun a => i.insertNth (f a) (g a) :=
   continuous_iff_continuousAt.2 fun _ => hf.continuousAt.fin_insertNth i hg.continuousAt
 #align continuous.fin_insert_nth Continuous.fin_insertNth
@@ -1502,7 +1502,7 @@ end Pi
 section Sigma
 
 variable {ι κ : Type*} {σ : ι → Type*} {τ : κ → Type*} [∀ i, TopologicalSpace (σ i)]
-  [∀ k, TopologicalSpace (τ k)] [TopologicalSpace α]
+  [∀ k, TopologicalSpace (τ k)] [TopologicalSpace X]
 
 @[continuity]
 theorem continuous_sigmaMk {i : ι} : Continuous (@Sigma.mk ι σ i) :=
@@ -1583,7 +1583,7 @@ theorem isOpen_sigma_fst_preimage (s : Set ι) : IsOpen (Sigma.fst ⁻¹' s : Se
 
 /-- A map out of a sum type is continuous iff its restriction to each summand is. -/
 @[simp]
-theorem continuous_sigma_iff {f : Sigma σ → α} :
+theorem continuous_sigma_iff {f : Sigma σ → X} :
     Continuous f ↔ ∀ i, Continuous fun a => f ⟨i, a⟩ := by
   delta instTopologicalSpaceSigma
   rw [continuous_iSup_dom]
@@ -1592,7 +1592,7 @@ theorem continuous_sigma_iff {f : Sigma σ → α} :
 
 /-- A map out of a sum type is continuous if its restriction to each summand is. -/
 @[continuity]
-theorem continuous_sigma {f : Sigma σ → α} (hf : ∀ i, Continuous fun a => f ⟨i, a⟩) :
+theorem continuous_sigma {f : Sigma σ → X} (hf : ∀ i, Continuous fun a => f ⟨i, a⟩) :
     Continuous f :=
   continuous_sigma_iff.2 hf
 #align continuous_sigma continuous_sigma
@@ -1600,7 +1600,7 @@ theorem continuous_sigma {f : Sigma σ → α} (hf : ∀ i, Continuous fun a => 
 /-- A map defined on a sigma type (a.k.a. the disjoint union of an indexed family of topological
 spaces) is inducing iff its restriction to each component is inducing and each the image of each
 component under `f` can be separated from the images of all other components by an open set. -/
-theorem inducing_sigma {f : Sigma σ → α} :
+theorem inducing_sigma {f : Sigma σ → X} :
     Inducing f ↔ (∀ i, Inducing (f ∘ Sigma.mk i)) ∧
       (∀ i, ∃ U, IsOpen U ∧ ∀ x, f x ∈ U ↔ x.1 = i) := by
   refine ⟨fun h ↦ ⟨fun i ↦ h.comp embedding_sigmaMk.1, fun i ↦ ?_⟩, ?_⟩
@@ -1625,7 +1625,7 @@ theorem Continuous.sigma_map {f₁ : ι → κ} {f₂ : ∀ i, σ i → τ (f₁
   continuous_sigma_map.2 hf
 #align continuous.sigma_map Continuous.sigma_map
 
-theorem isOpenMap_sigma {f : Sigma σ → α} : IsOpenMap f ↔ ∀ i, IsOpenMap fun a => f ⟨i, a⟩ := by
+theorem isOpenMap_sigma {f : Sigma σ → X} : IsOpenMap f ↔ ∀ i, IsOpenMap fun a => f ⟨i, a⟩ := by
   simp only [isOpenMap_iff_nhds_le, Sigma.forall, Sigma.nhds_eq, map_map, comp]
 #align is_open_map_sigma isOpenMap_sigma
 
@@ -1656,50 +1656,50 @@ end Sigma
 
 section ULift
 
-theorem ULift.isOpen_iff [TopologicalSpace α] {s : Set (ULift.{v} α)} :
+theorem ULift.isOpen_iff [TopologicalSpace X] {s : Set (ULift.{v} X)} :
     IsOpen s ↔ IsOpen (ULift.up ⁻¹' s) := by
   unfold ULift.topologicalSpace
   erw [← Equiv.ulift.coinduced_symm]
   rfl
 
-theorem ULift.isClosed_iff [TopologicalSpace α] {s : Set (ULift.{v} α)} :
+theorem ULift.isClosed_iff [TopologicalSpace X] {s : Set (ULift.{v} X)} :
     IsClosed s ↔ IsClosed (ULift.up ⁻¹' s) := by
   rw [← isOpen_compl_iff, ← isOpen_compl_iff, isOpen_iff, preimage_compl]
 
 @[continuity]
-theorem continuous_uLift_down [TopologicalSpace α] : Continuous (ULift.down : ULift.{v, u} α → α) :=
+theorem continuous_uLift_down [TopologicalSpace X] : Continuous (ULift.down : ULift.{v, u} X → X) :=
   continuous_induced_dom
 #align continuous_ulift_down continuous_uLift_down
 
 @[continuity]
-theorem continuous_uLift_up [TopologicalSpace α] : Continuous (ULift.up : α → ULift.{v, u} α) :=
+theorem continuous_uLift_up [TopologicalSpace X] : Continuous (ULift.up : X → ULift.{v, u} X) :=
   continuous_induced_rng.2 continuous_id
 #align continuous_ulift_up continuous_uLift_up
 
-theorem embedding_uLift_down [TopologicalSpace α] : Embedding (ULift.down : ULift.{v, u} α → α) :=
+theorem embedding_uLift_down [TopologicalSpace X] : Embedding (ULift.down : ULift.{v, u} X → X) :=
   ⟨⟨rfl⟩, ULift.down_injective⟩
 #align embedding_ulift_down embedding_uLift_down
 
-theorem ULift.closedEmbedding_down [TopologicalSpace α] :
-    ClosedEmbedding (ULift.down : ULift.{v, u} α → α) :=
+theorem ULift.closedEmbedding_down [TopologicalSpace X] :
+    ClosedEmbedding (ULift.down : ULift.{v, u} X → X) :=
   ⟨embedding_uLift_down, by simp only [ULift.down_surjective.range_eq, isClosed_univ]⟩
 #align ulift.closed_embedding_down ULift.closedEmbedding_down
 
-instance [TopologicalSpace α] [DiscreteTopology α] : DiscreteTopology (ULift α) :=
+instance [TopologicalSpace X] [DiscreteTopology X] : DiscreteTopology (ULift X) :=
   embedding_uLift_down.discreteTopology
 
 end ULift
 
 section Monad
 
-variable [TopologicalSpace α] {β : Set α} {γ : Set β}
+variable [TopologicalSpace X] {β : Set X} {γ : Set β}
 
-theorem IsOpen.trans (hγ : IsOpen γ) (hβ : IsOpen β) : IsOpen (γ : Set α) := by
+theorem IsOpen.trans (hγ : IsOpen γ) (hβ : IsOpen β) : IsOpen (γ : Set X) := by
   rcases isOpen_induced_iff.mp hγ with ⟨δ, hδ, rfl⟩
   rw [Subtype.image_preimage_coe]
   exact IsOpen.inter hδ hβ
 
-theorem IsClosed.trans (hγ : IsClosed γ) (hβ : IsClosed β) : IsClosed (γ : Set α) := by
+theorem IsClosed.trans (hγ : IsClosed γ) (hβ : IsClosed β) : IsClosed (γ : Set X) := by
   rcases isClosed_induced_iff.mp hγ with ⟨δ, hδ, rfl⟩
   rw [Subtype.image_preimage_coe]
   convert IsClosed.inter hδ hβ

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -39,7 +39,7 @@ open Topology TopologicalSpace Set Filter Function Classical
 
 universe u v
 
-variable {X : Type u} {Y : Type v} {Z δ ε ζ : Type*}
+variable {X : Type u} {Y : Type v} {Z W ε ζ : Type*}
 
 section Constructions
 
@@ -314,7 +314,7 @@ end Constructions
 
 section Prod
 
-variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] [TopologicalSpace δ]
+variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] [TopologicalSpace W]
   [TopologicalSpace ε] [TopologicalSpace ζ]
 
 -- porting note: todo: Lean 4 fails to deduce implicit args
@@ -417,30 +417,30 @@ theorem Continuous.Prod.mk_left (b : Y) : Continuous fun a : X => (a, b) :=
 
 /-- If `f x y` is continuous in `x` for all `y ∈ s`,
 then the set of `x` such that `f x` maps `s` to `t` is closed. -/
-lemma IsClosed.setOf_mapsTo {f : X → Y → Z} {s : Set Y} {t : Set Z} (ht : IsClosed t)
-    (hf : ∀ y ∈ s, Continuous (f · y)) : IsClosed {x | MapsTo (f x) s t} := by
+lemma IsClosed.setOf_mapsTo {α : Type*} {f : X → α → Z} {s : Set α} {t : Set Z} (ht : IsClosed t)
+    (hf : ∀ a ∈ s, Continuous (f · a)) : IsClosed {x | MapsTo (f x) s t} := by
   simpa only [MapsTo, setOf_forall] using isClosed_biInter fun y hy ↦ ht.preimage (hf y hy)
 
-theorem Continuous.comp₂ {g : X × Y → Z} (hg : Continuous g) {e : δ → X} (he : Continuous e)
-    {f : δ → Y} (hf : Continuous f) : Continuous fun x => g (e x, f x) :=
+theorem Continuous.comp₂ {g : X × Y → Z} (hg : Continuous g) {e : W → X} (he : Continuous e)
+    {f : W → Y} (hf : Continuous f) : Continuous fun w => g (e w, f w) :=
   hg.comp <| he.prod_mk hf
 #align continuous.comp₂ Continuous.comp₂
 
-theorem Continuous.comp₃ {g : X × Y × Z → ε} (hg : Continuous g) {e : δ → X} (he : Continuous e)
-    {f : δ → Y} (hf : Continuous f) {k : δ → Z} (hk : Continuous k) :
-    Continuous fun x => g (e x, f x, k x) :=
+theorem Continuous.comp₃ {g : X × Y × Z → ε} (hg : Continuous g) {e : W → X} (he : Continuous e)
+    {f : W → Y} (hf : Continuous f) {k : W → Z} (hk : Continuous k) :
+    Continuous fun w => g (e w, f w, k w) :=
   hg.comp₂ he <| hf.prod_mk hk
 #align continuous.comp₃ Continuous.comp₃
 
-theorem Continuous.comp₄ {g : X × Y × Z × ζ → ε} (hg : Continuous g) {e : δ → X} (he : Continuous e)
-    {f : δ → Y} (hf : Continuous f) {k : δ → Z} (hk : Continuous k) {l : δ → ζ}
-    (hl : Continuous l) : Continuous fun x => g (e x, f x, k x, l x) :=
+theorem Continuous.comp₄ {g : X × Y × Z × ζ → ε} (hg : Continuous g) {e : W → X} (he : Continuous e)
+    {f : W → Y} (hf : Continuous f) {k : W → Z} (hk : Continuous k) {l : W → ζ}
+    (hl : Continuous l) : Continuous fun w => g (e w, f w, k w, l w) :=
   hg.comp₃ he hf <| hk.prod_mk hl
 #align continuous.comp₄ Continuous.comp₄
 
 @[continuity]
-theorem Continuous.prod_map {f : Z → X} {g : δ → Y} (hf : Continuous f) (hg : Continuous g) :
-    Continuous fun x : Z × δ => (f x.1, g x.2) :=
+theorem Continuous.prod_map {f : Z → X} {g : W → Y} (hf : Continuous f) (hg : Continuous g) :
+    Continuous fun a : Z × W => (f a.1, g a.2) :=
   hf.fst'.prod_mk hg.snd'
 #align continuous.prod_map Continuous.prod_map
 
@@ -611,12 +611,12 @@ theorem ContinuousAt.prod {f : X → Y} {g : X → Z} {x : X} (hf : ContinuousAt
   hf.prod_mk_nhds hg
 #align continuous_at.prod ContinuousAt.prod
 
-theorem ContinuousAt.prod_map {f : X → Z} {g : Y → δ} {p : X × Y} (hf : ContinuousAt f p.fst)
+theorem ContinuousAt.prod_map {f : X → Z} {g : Y → W} {p : X × Y} (hf : ContinuousAt f p.fst)
     (hg : ContinuousAt g p.snd) : ContinuousAt (fun p : X × Y => (f p.1, g p.2)) p :=
   hf.fst''.prod hg.snd''
 #align continuous_at.prod_map ContinuousAt.prod_map
 
-theorem ContinuousAt.prod_map' {f : X → Z} {g : Y → δ} {x : X} {y : Y} (hf : ContinuousAt f x)
+theorem ContinuousAt.prod_map' {f : X → Z} {g : Y → W} {x : X} {y : Y} (hf : ContinuousAt f x)
     (hg : ContinuousAt g y) : ContinuousAt (fun p : X × Y => (f p.1, g p.2)) (x, y) :=
   hf.fst'.prod hg.snd'
 #align continuous_at.prod_map' ContinuousAt.prod_map'
@@ -674,7 +674,7 @@ theorem isOpen_prod_iff {s : Set (X × Y)} :
 #align is_open_prod_iff isOpen_prod_iff
 
 /-- A product of induced topologies is induced by the product map -/
-theorem prod_induced_induced (f : X → Y) (g : Z → δ) :
+theorem prod_induced_induced (f : X → Y) (g : Z → W) :
     @instTopologicalSpaceProd X Z (induced f ‹_›) (induced g ‹_›) =
       induced (fun p => (f p.1, g p.2)) instTopologicalSpaceProd := by
   delta instTopologicalSpaceProd
@@ -806,9 +806,9 @@ theorem DenseRange.prod_map {ι : Type*} {κ : Type*} {f : ι → Y} {g : κ →
   simpa only [DenseRange, prod_range_range_eq] using hf.prod hg
 #align dense_range.prod_map DenseRange.prod_map
 
-theorem Inducing.prod_map {f : X → Y} {g : Z → δ} (hf : Inducing f) (hg : Inducing g) :
+theorem Inducing.prod_map {f : X → Y} {g : Z → W} (hf : Inducing f) (hg : Inducing g) :
     Inducing (Prod.map f g) :=
-  inducing_iff_nhds.2 fun (a, b) => by simp_rw [Prod.map_def, nhds_prod_eq, hf.nhds_eq_comap,
+  inducing_iff_nhds.2 fun (x, z) => by simp_rw [Prod.map_def, nhds_prod_eq, hf.nhds_eq_comap,
     hg.nhds_eq_comap, prod_comap_comap_eq]
 #align inducing.prod_mk Inducing.prod_map
 
@@ -824,13 +824,13 @@ theorem inducing_prod_const {b : Y} {f : X → Z} : (Inducing fun x => (f x, b))
     induced_const, inf_top_eq]
 #align inducing_prod_const inducing_prod_const
 
-theorem Embedding.prod_map {f : X → Y} {g : Z → δ} (hf : Embedding f) (hg : Embedding g) :
+theorem Embedding.prod_map {f : X → Y} {g : Z → W} (hf : Embedding f) (hg : Embedding g) :
     Embedding (Prod.map f g) :=
   { hf.toInducing.prod_map hg.toInducing with
-    inj := fun ⟨x₁, x₂⟩ ⟨y₁, y₂⟩ => by simp [hf.inj.eq_iff, hg.inj.eq_iff] }
+    inj := fun ⟨x₁, z₁⟩ ⟨x₂, z₂⟩ => by simp [hf.inj.eq_iff, hg.inj.eq_iff] }
 #align embedding.prod_mk Embedding.prod_map
 
-protected theorem IsOpenMap.prod {f : X → Y} {g : Z → δ} (hf : IsOpenMap f) (hg : IsOpenMap g) :
+protected theorem IsOpenMap.prod {f : X → Y} {g : Z → W} (hf : IsOpenMap f) (hg : IsOpenMap g) :
     IsOpenMap fun p : X × Z => (f p.1, g p.2) := by
   rw [isOpenMap_iff_nhds_le]
   rintro ⟨a, b⟩
@@ -838,7 +838,7 @@ protected theorem IsOpenMap.prod {f : X → Y} {g : Z → δ} (hf : IsOpenMap f)
   exact Filter.prod_mono (hf.nhds_le a) (hg.nhds_le b)
 #align is_open_map.prod IsOpenMap.prod
 
-protected theorem OpenEmbedding.prod {f : X → Y} {g : Z → δ} (hf : OpenEmbedding f)
+protected theorem OpenEmbedding.prod {f : X → Y} {g : Z → W} (hf : OpenEmbedding f)
     (hg : OpenEmbedding g) : OpenEmbedding fun x : X × Z => (f x.1, g x.2) :=
   openEmbedding_of_embedding_open (hf.1.prod_map hg.1) (hf.isOpenMap.prod hg.isOpenMap)
 #align open_embedding.prod OpenEmbedding.prod
@@ -856,7 +856,7 @@ section Sum
 
 open Sum
 
-variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] [TopologicalSpace δ]
+variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] [TopologicalSpace W]
 
 theorem continuous_sum_dom {f : X ⊕ Y → Z} :
     Continuous f ↔ Continuous (f ∘ Sum.inl) ∧ Continuous (f ∘ Sum.inr) :=
@@ -962,14 +962,14 @@ theorem nhds_inr (x : Y) : 𝓝 (inr x : X ⊕ Y) = map inr (𝓝 x) :=
 #align nhds_inr nhds_inr
 
 @[simp]
-theorem continuous_sum_map {f : X → Y} {g : Z → δ} :
+theorem continuous_sum_map {f : X → Y} {g : Z → W} :
     Continuous (Sum.map f g) ↔ Continuous f ∧ Continuous g :=
   continuous_sum_elim.trans <|
     embedding_inl.continuous_iff.symm.and embedding_inr.continuous_iff.symm
 #align continuous_sum_map continuous_sum_map
 
 @[continuity]
-theorem Continuous.sum_map {f : X → Y} {g : Z → δ} (hf : Continuous f) (hg : Continuous g) :
+theorem Continuous.sum_map {f : X → Y} {g : Z → W} (hf : Continuous f) (hg : Continuous g) :
     Continuous (Sum.map f g) :=
   continuous_sum_map.2 ⟨hf, hg⟩
 #align continuous.sum_map Continuous.sum_map
@@ -1695,14 +1695,14 @@ section Monad
 variable [TopologicalSpace X] {s : Set X} {t : Set s}
 
 theorem IsOpen.trans (ht : IsOpen t) (hs : IsOpen s) : IsOpen (t : Set X) := by
-  rcases isOpen_induced_iff.mp ht with ⟨δ, hδ, rfl⟩
+  rcases isOpen_induced_iff.mp ht with ⟨s', hs', rfl⟩
   rw [Subtype.image_preimage_coe]
-  exact IsOpen.inter hδ hs
+  exact hs'.inter hs
 
 theorem IsClosed.trans (ht : IsClosed t) (hs : IsClosed s) : IsClosed (t : Set X) := by
-  rcases isClosed_induced_iff.mp ht with ⟨δ, hδ, rfl⟩
+  rcases isClosed_induced_iff.mp ht with ⟨s', hs', rfl⟩
   rw [Subtype.image_preimage_coe]
-  convert IsClosed.inter hδ hs
+  convert hs'.inter hs
 
 end Monad
 

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -39,7 +39,7 @@ open Topology TopologicalSpace Set Filter Function Classical
 
 universe u v
 
-variable {X : Type u} {β : Type v} {γ δ ε ζ : Type*}
+variable {X : Type u} {Y : Type v} {γ δ ε ζ : Type*}
 
 section Constructions
 
@@ -54,12 +54,12 @@ instance instTopologicalSpaceQuotient {s : Setoid X} [t : TopologicalSpace X] :
     TopologicalSpace (Quotient s) :=
   coinduced Quotient.mk' t
 
-instance instTopologicalSpaceProd [t₁ : TopologicalSpace X] [t₂ : TopologicalSpace β] :
-    TopologicalSpace (X × β) :=
+instance instTopologicalSpaceProd [t₁ : TopologicalSpace X] [t₂ : TopologicalSpace Y] :
+    TopologicalSpace (X × Y) :=
   induced Prod.fst t₁ ⊓ induced Prod.snd t₂
 
-instance instTopologicalSpaceSum [t₁ : TopologicalSpace X] [t₂ : TopologicalSpace β] :
-    TopologicalSpace (X ⊕ β) :=
+instance instTopologicalSpaceSum [t₁ : TopologicalSpace X] [t₂ : TopologicalSpace Y] :
+    TopologicalSpace (X ⊕ Y) :=
   coinduced Sum.inl t₁ ⊔ coinduced Sum.inr t₂
 
 instance instTopologicalSpaceSigma {β : X → Type v} [t₂ : ∀ a, TopologicalSpace (β a)] :
@@ -197,7 +197,7 @@ theorem Dense.quotient [Setoid X] [TopologicalSpace X] {s : Set X} (H : Dense s)
 #align dense.quotient Dense.quotient
 
 /-- The composition of `Quotient.mk'` and a function with dense range has dense range. -/
-theorem DenseRange.quotient [Setoid X] [TopologicalSpace X] {f : β → X} (hf : DenseRange f) :
+theorem DenseRange.quotient [Setoid X] [TopologicalSpace X] {f : Y → X} (hf : DenseRange f) :
     DenseRange (Quotient.mk' ∘ f) :=
   Quotient.surjective_Quotient_mk''.denseRange.comp hf continuous_coinduced_rng
 #align dense_range.quotient DenseRange.quotient
@@ -205,8 +205,8 @@ theorem DenseRange.quotient [Setoid X] [TopologicalSpace X] {f : β → X} (hf :
 instance {p : X → Prop} [TopologicalSpace X] [DiscreteTopology X] : DiscreteTopology (Subtype p) :=
   ⟨bot_unique fun s _ => ⟨(↑) '' s, isOpen_discrete _, preimage_image_eq _ Subtype.val_injective⟩⟩
 
-instance Sum.discreteTopology [TopologicalSpace X] [TopologicalSpace β] [h : DiscreteTopology X]
-    [hβ : DiscreteTopology β] : DiscreteTopology (Sum X β) :=
+instance Sum.discreteTopology [TopologicalSpace X] [TopologicalSpace Y] [h : DiscreteTopology X]
+    [hβ : DiscreteTopology Y] : DiscreteTopology (Sum X Y) :=
   ⟨sup_eq_bot_iff.2 <| by simp [h.eq_bot, hβ.eq_bot]⟩
 #align sum.discrete_topology Sum.discreteTopology
 
@@ -314,132 +314,132 @@ end Constructions
 
 section Prod
 
-variable [TopologicalSpace X] [TopologicalSpace β] [TopologicalSpace γ] [TopologicalSpace δ]
+variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace γ] [TopologicalSpace δ]
   [TopologicalSpace ε] [TopologicalSpace ζ]
 
 -- porting note: todo: Lean 4 fails to deduce implicit args
-@[simp] theorem continuous_prod_mk {f : X → β} {g : X → γ} :
+@[simp] theorem continuous_prod_mk {f : X → Y} {g : X → γ} :
     (Continuous fun x => (f x, g x)) ↔ Continuous f ∧ Continuous g :=
-  (@continuous_inf_rng X (β × γ) _ _ (TopologicalSpace.induced Prod.fst _)
+  (@continuous_inf_rng X (Y × γ) _ _ (TopologicalSpace.induced Prod.fst _)
     (TopologicalSpace.induced Prod.snd _)).trans <|
     continuous_induced_rng.and continuous_induced_rng
 #align continuous_prod_mk continuous_prod_mk
 
 @[continuity]
-theorem continuous_fst : Continuous (@Prod.fst X β) :=
+theorem continuous_fst : Continuous (@Prod.fst X Y) :=
   (continuous_prod_mk.1 continuous_id).1
 #align continuous_fst continuous_fst
 
 /-- Postcomposing `f` with `Prod.fst` is continuous -/
-theorem Continuous.fst {f : X → β × γ} (hf : Continuous f) : Continuous fun a : X => (f a).1 :=
+theorem Continuous.fst {f : X → Y × γ} (hf : Continuous f) : Continuous fun a : X => (f a).1 :=
   continuous_fst.comp hf
 #align continuous.fst Continuous.fst
 
 /-- Precomposing `f` with `Prod.fst` is continuous -/
-theorem Continuous.fst' {f : X → γ} (hf : Continuous f) : Continuous fun x : X × β => f x.fst :=
+theorem Continuous.fst' {f : X → γ} (hf : Continuous f) : Continuous fun x : X × Y => f x.fst :=
   hf.comp continuous_fst
 #align continuous.fst' Continuous.fst'
 
-theorem continuousAt_fst {p : X × β} : ContinuousAt Prod.fst p :=
+theorem continuousAt_fst {p : X × Y} : ContinuousAt Prod.fst p :=
   continuous_fst.continuousAt
 #align continuous_at_fst continuousAt_fst
 
 /-- Postcomposing `f` with `Prod.fst` is continuous at `x` -/
-theorem ContinuousAt.fst {f : X → β × γ} {x : X} (hf : ContinuousAt f x) :
+theorem ContinuousAt.fst {f : X → Y × γ} {x : X} (hf : ContinuousAt f x) :
     ContinuousAt (fun a : X => (f a).1) x :=
   continuousAt_fst.comp hf
 #align continuous_at.fst ContinuousAt.fst
 
 /-- Precomposing `f` with `Prod.fst` is continuous at `(x, y)` -/
-theorem ContinuousAt.fst' {f : X → γ} {x : X} {y : β} (hf : ContinuousAt f x) :
-    ContinuousAt (fun x : X × β => f x.fst) (x, y) :=
+theorem ContinuousAt.fst' {f : X → γ} {x : X} {y : Y} (hf : ContinuousAt f x) :
+    ContinuousAt (fun x : X × Y => f x.fst) (x, y) :=
   ContinuousAt.comp hf continuousAt_fst
 #align continuous_at.fst' ContinuousAt.fst'
 
 /-- Precomposing `f` with `Prod.fst` is continuous at `x :  × β` -/
-theorem ContinuousAt.fst'' {f : X → γ} {x : X × β} (hf : ContinuousAt f x.fst) :
-    ContinuousAt (fun x : X × β => f x.fst) x :=
+theorem ContinuousAt.fst'' {f : X → γ} {x : X × Y} (hf : ContinuousAt f x.fst) :
+    ContinuousAt (fun x : X × Y => f x.fst) x :=
   hf.comp continuousAt_fst
 #align continuous_at.fst'' ContinuousAt.fst''
 
 @[continuity]
-theorem continuous_snd : Continuous (@Prod.snd X β) :=
+theorem continuous_snd : Continuous (@Prod.snd X Y) :=
   (continuous_prod_mk.1 continuous_id).2
 #align continuous_snd continuous_snd
 
 /-- Postcomposing `f` with `Prod.snd` is continuous -/
-theorem Continuous.snd {f : X → β × γ} (hf : Continuous f) : Continuous fun a : X => (f a).2 :=
+theorem Continuous.snd {f : X → Y × γ} (hf : Continuous f) : Continuous fun a : X => (f a).2 :=
   continuous_snd.comp hf
 #align continuous.snd Continuous.snd
 
 /-- Precomposing `f` with `Prod.snd` is continuous -/
-theorem Continuous.snd' {f : β → γ} (hf : Continuous f) : Continuous fun x : X × β => f x.snd :=
+theorem Continuous.snd' {f : Y → γ} (hf : Continuous f) : Continuous fun x : X × Y => f x.snd :=
   hf.comp continuous_snd
 #align continuous.snd' Continuous.snd'
 
-theorem continuousAt_snd {p : X × β} : ContinuousAt Prod.snd p :=
+theorem continuousAt_snd {p : X × Y} : ContinuousAt Prod.snd p :=
   continuous_snd.continuousAt
 #align continuous_at_snd continuousAt_snd
 
 /-- Postcomposing `f` with `Prod.snd` is continuous at `x` -/
-theorem ContinuousAt.snd {f : X → β × γ} {x : X} (hf : ContinuousAt f x) :
+theorem ContinuousAt.snd {f : X → Y × γ} {x : X} (hf : ContinuousAt f x) :
     ContinuousAt (fun a : X => (f a).2) x :=
   continuousAt_snd.comp hf
 #align continuous_at.snd ContinuousAt.snd
 
 /-- Precomposing `f` with `Prod.snd` is continuous at `(x, y)` -/
-theorem ContinuousAt.snd' {f : β → γ} {x : X} {y : β} (hf : ContinuousAt f y) :
-    ContinuousAt (fun x : X × β => f x.snd) (x, y) :=
+theorem ContinuousAt.snd' {f : Y → γ} {x : X} {y : Y} (hf : ContinuousAt f y) :
+    ContinuousAt (fun x : X × Y => f x.snd) (x, y) :=
   ContinuousAt.comp hf continuousAt_snd
 #align continuous_at.snd' ContinuousAt.snd'
 
 /-- Precomposing `f` with `Prod.snd` is continuous at `x :  × β` -/
-theorem ContinuousAt.snd'' {f : β → γ} {x : X × β} (hf : ContinuousAt f x.snd) :
-    ContinuousAt (fun x : X × β => f x.snd) x :=
+theorem ContinuousAt.snd'' {f : Y → γ} {x : X × Y} (hf : ContinuousAt f x.snd) :
+    ContinuousAt (fun x : X × Y => f x.snd) x :=
   hf.comp continuousAt_snd
 #align continuous_at.snd'' ContinuousAt.snd''
 
 @[continuity]
-theorem Continuous.prod_mk {f : γ → X} {g : γ → β} (hf : Continuous f) (hg : Continuous g) :
+theorem Continuous.prod_mk {f : γ → X} {g : γ → Y} (hf : Continuous f) (hg : Continuous g) :
     Continuous fun x => (f x, g x) :=
   continuous_prod_mk.2 ⟨hf, hg⟩
 #align continuous.prod_mk Continuous.prod_mk
 
 @[continuity]
-theorem Continuous.Prod.mk (a : X) : Continuous fun b : β => (a, b) :=
+theorem Continuous.Prod.mk (a : X) : Continuous fun b : Y => (a, b) :=
   continuous_const.prod_mk continuous_id
 #align continuous.prod.mk Continuous.Prod.mk
 
 @[continuity]
-theorem Continuous.Prod.mk_left (b : β) : Continuous fun a : X => (a, b) :=
+theorem Continuous.Prod.mk_left (b : Y) : Continuous fun a : X => (a, b) :=
   continuous_id.prod_mk continuous_const
 #align continuous.prod.mk_left Continuous.Prod.mk_left
 
 /-- If `f x y` is continuous in `x` for all `y ∈ s`,
 then the set of `x` such that `f x` maps `s` to `t` is closed. -/
-lemma IsClosed.setOf_mapsTo {f : X → β → γ} {s : Set β} {t : Set γ} (ht : IsClosed t)
+lemma IsClosed.setOf_mapsTo {f : X → Y → γ} {s : Set Y} {t : Set γ} (ht : IsClosed t)
     (hf : ∀ y ∈ s, Continuous (f · y)) : IsClosed {x | MapsTo (f x) s t} := by
   simpa only [MapsTo, setOf_forall] using isClosed_biInter fun y hy ↦ ht.preimage (hf y hy)
 
-theorem Continuous.comp₂ {g : X × β → γ} (hg : Continuous g) {e : δ → X} (he : Continuous e)
-    {f : δ → β} (hf : Continuous f) : Continuous fun x => g (e x, f x) :=
+theorem Continuous.comp₂ {g : X × Y → γ} (hg : Continuous g) {e : δ → X} (he : Continuous e)
+    {f : δ → Y} (hf : Continuous f) : Continuous fun x => g (e x, f x) :=
   hg.comp <| he.prod_mk hf
 #align continuous.comp₂ Continuous.comp₂
 
-theorem Continuous.comp₃ {g : X × β × γ → ε} (hg : Continuous g) {e : δ → X} (he : Continuous e)
-    {f : δ → β} (hf : Continuous f) {k : δ → γ} (hk : Continuous k) :
+theorem Continuous.comp₃ {g : X × Y × γ → ε} (hg : Continuous g) {e : δ → X} (he : Continuous e)
+    {f : δ → Y} (hf : Continuous f) {k : δ → γ} (hk : Continuous k) :
     Continuous fun x => g (e x, f x, k x) :=
   hg.comp₂ he <| hf.prod_mk hk
 #align continuous.comp₃ Continuous.comp₃
 
-theorem Continuous.comp₄ {g : X × β × γ × ζ → ε} (hg : Continuous g) {e : δ → X} (he : Continuous e)
-    {f : δ → β} (hf : Continuous f) {k : δ → γ} (hk : Continuous k) {l : δ → ζ}
+theorem Continuous.comp₄ {g : X × Y × γ × ζ → ε} (hg : Continuous g) {e : δ → X} (he : Continuous e)
+    {f : δ → Y} (hf : Continuous f) {k : δ → γ} (hk : Continuous k) {l : δ → ζ}
     (hl : Continuous l) : Continuous fun x => g (e x, f x, k x, l x) :=
   hg.comp₃ he hf <| hk.prod_mk hl
 #align continuous.comp₄ Continuous.comp₄
 
 @[continuity]
-theorem Continuous.prod_map {f : γ → X} {g : δ → β} (hf : Continuous f) (hg : Continuous g) :
+theorem Continuous.prod_map {f : γ → X} {g : δ → Y} (hf : Continuous f) (hg : Continuous g) :
     Continuous fun x : γ × δ => (f x.1, g x.2) :=
   hf.fst'.prod_mk hg.snd'
 #align continuous.prod_map Continuous.prod_map
@@ -479,73 +479,73 @@ theorem continuous_sInf_dom₂ { β γ} {f : X → β → γ} {tas : Set (Topolo
   exact @Continuous.comp _ _ _ (id _) (id _) _ _ _ hf h_continuous_id
 #align continuous_Inf_dom₂ continuous_sInf_dom₂
 
-theorem Filter.Eventually.prod_inl_nhds {p : X → Prop} {a : X} (h : ∀ᶠ x in 𝓝 a, p x) (b : β) :
-    ∀ᶠ x in 𝓝 (a, b), p (x : X × β).1 :=
+theorem Filter.Eventually.prod_inl_nhds {p : X → Prop} {a : X} (h : ∀ᶠ x in 𝓝 a, p x) (b : Y) :
+    ∀ᶠ x in 𝓝 (a, b), p (x : X × Y).1 :=
   continuousAt_fst h
 #align filter.eventually.prod_inl_nhds Filter.Eventually.prod_inl_nhds
 
-theorem Filter.Eventually.prod_inr_nhds {p : β → Prop} {b : β} (h : ∀ᶠ x in 𝓝 b, p x) (a : X) :
-    ∀ᶠ x in 𝓝 (a, b), p (x : X × β).2 :=
+theorem Filter.Eventually.prod_inr_nhds {p : Y → Prop} {b : Y} (h : ∀ᶠ x in 𝓝 b, p x) (a : X) :
+    ∀ᶠ x in 𝓝 (a, b), p (x : X × Y).2 :=
   continuousAt_snd h
 #align filter.eventually.prod_inr_nhds Filter.Eventually.prod_inr_nhds
 
-theorem Filter.Eventually.prod_mk_nhds {pa : X → Prop} {a} (ha : ∀ᶠ x in 𝓝 a, pa x) {pb : β → Prop}
-    {b} (hb : ∀ᶠ y in 𝓝 b, pb y) : ∀ᶠ p in 𝓝 (a, b), pa (p : X × β).1 ∧ pb p.2 :=
+theorem Filter.Eventually.prod_mk_nhds {pa : X → Prop} {a} (ha : ∀ᶠ x in 𝓝 a, pa x) {pb : Y → Prop}
+    {b} (hb : ∀ᶠ y in 𝓝 b, pb y) : ∀ᶠ p in 𝓝 (a, b), pa (p : X × Y).1 ∧ pb p.2 :=
   (ha.prod_inl_nhds b).and (hb.prod_inr_nhds a)
 #align filter.eventually.prod_mk_nhds Filter.Eventually.prod_mk_nhds
 
-theorem continuous_swap : Continuous (Prod.swap : X × β → β × X) :=
+theorem continuous_swap : Continuous (Prod.swap : X × Y → Y × X) :=
   continuous_snd.prod_mk continuous_fst
 #align continuous_swap continuous_swap
 
-lemma isClosedMap_swap : IsClosedMap (Prod.swap : X × β → β × X) := fun s hs ↦ by
+lemma isClosedMap_swap : IsClosedMap (Prod.swap : X × Y → Y × X) := fun s hs ↦ by
   rw [image_swap_eq_preimage_swap]
   exact hs.preimage continuous_swap
 
-theorem continuous_uncurry_left {f : X → β → γ} (a : X) (h : Continuous (uncurry f)) :
+theorem continuous_uncurry_left {f : X → Y → γ} (a : X) (h : Continuous (uncurry f)) :
     Continuous (f a) :=
   h.comp (Continuous.Prod.mk _)
 #align continuous_uncurry_left continuous_uncurry_left
 
-theorem continuous_uncurry_right {f : X → β → γ} (b : β) (h : Continuous (uncurry f)) :
+theorem continuous_uncurry_right {f : X → Y → γ} (b : Y) (h : Continuous (uncurry f)) :
     Continuous fun a => f a b :=
   h.comp (Continuous.Prod.mk_left _)
 #align continuous_uncurry_right continuous_uncurry_right
 
-theorem continuous_curry {g : X × β → γ} (a : X) (h : Continuous g) : Continuous (curry g a) :=
+theorem continuous_curry {g : X × Y → γ} (a : X) (h : Continuous g) : Continuous (curry g a) :=
   continuous_uncurry_left a h
 #align continuous_curry continuous_curry
 
-theorem IsOpen.prod {s : Set X} {t : Set β} (hs : IsOpen s) (ht : IsOpen t) : IsOpen (s ×ˢ t) :=
+theorem IsOpen.prod {s : Set X} {t : Set Y} (hs : IsOpen s) (ht : IsOpen t) : IsOpen (s ×ˢ t) :=
   (hs.preimage continuous_fst).inter (ht.preimage continuous_snd)
 #align is_open.prod IsOpen.prod
 
 -- porting note: todo: Lean fails to find `t₁` and `t₂` by unification
-theorem nhds_prod_eq {a : X} {b : β} : 𝓝 (a, b) = 𝓝 a ×ˢ 𝓝 b := by
+theorem nhds_prod_eq {a : X} {b : Y} : 𝓝 (a, b) = 𝓝 a ×ˢ 𝓝 b := by
   dsimp only [SProd.sprod]
   rw [Filter.prod, instTopologicalSpaceProd, nhds_inf (t₁ := TopologicalSpace.induced Prod.fst _)
     (t₂ := TopologicalSpace.induced Prod.snd _), nhds_induced, nhds_induced]
 #align nhds_prod_eq nhds_prod_eq
 
 -- porting note: moved from `topology.continuous_on`
-theorem nhdsWithin_prod_eq (a : X) (b : β) (s : Set X) (t : Set β) :
+theorem nhdsWithin_prod_eq (a : X) (b : Y) (s : Set X) (t : Set Y) :
     𝓝[s ×ˢ t] (a, b) = 𝓝[s] a ×ˢ 𝓝[t] b := by
   simp only [nhdsWithin, nhds_prod_eq, ← prod_inf_prod, prod_principal_principal]
 #align nhds_within_prod_eq nhdsWithin_prod_eq
 
 #noalign continuous_uncurry_of_discrete_topology
 
-theorem mem_nhds_prod_iff {a : X} {b : β} {s : Set (X × β)} :
+theorem mem_nhds_prod_iff {a : X} {b : Y} {s : Set (X × Y)} :
     s ∈ 𝓝 (a, b) ↔ ∃ u ∈ 𝓝 a, ∃ v ∈ 𝓝 b, u ×ˢ v ⊆ s := by rw [nhds_prod_eq, mem_prod_iff]
 #align mem_nhds_prod_iff mem_nhds_prod_iff
 
-theorem mem_nhdsWithin_prod_iff {a : X} {b : β} {s : Set (X × β)} {ta : Set X} {tb : Set β} :
+theorem mem_nhdsWithin_prod_iff {a : X} {b : Y} {s : Set (X × Y)} {ta : Set X} {tb : Set Y} :
     s ∈ 𝓝[ta ×ˢ tb] (a, b) ↔ ∃ u ∈ 𝓝[ta] a, ∃ v ∈ 𝓝[tb] b, u ×ˢ v ⊆ s := by
   rw [nhdsWithin_prod_eq, mem_prod_iff]
 
 -- porting note: moved up
 theorem Filter.HasBasis.prod_nhds {ιa ιb : Type*} {pa : ιa → Prop} {pb : ιb → Prop}
-    {sa : ιa → Set X} {sb : ιb → Set β} {a : X} {b : β} (ha : (𝓝 a).HasBasis pa sa)
+    {sa : ιa → Set X} {sb : ιb → Set Y} {a : X} {b : Y} (ha : (𝓝 a).HasBasis pa sa)
     (hb : (𝓝 b).HasBasis pb sb) :
     (𝓝 (a, b)).HasBasis (fun i : ιa × ιb => pa i.1 ∧ pb i.2) fun i => sa i.1 ×ˢ sb i.2 := by
   rw [nhds_prod_eq]
@@ -554,70 +554,70 @@ theorem Filter.HasBasis.prod_nhds {ιa ιb : Type*} {pa : ιa → Prop} {pb : ι
 
 -- porting note: moved up
 theorem Filter.HasBasis.prod_nhds' {ιa ιb : Type*} {pa : ιa → Prop} {pb : ιb → Prop}
-    {sa : ιa → Set X} {sb : ιb → Set β} {ab : X × β} (ha : (𝓝 ab.1).HasBasis pa sa)
+    {sa : ιa → Set X} {sb : ιb → Set Y} {ab : X × Y} (ha : (𝓝 ab.1).HasBasis pa sa)
     (hb : (𝓝 ab.2).HasBasis pb sb) :
     (𝓝 ab).HasBasis (fun i : ιa × ιb => pa i.1 ∧ pb i.2) fun i => sa i.1 ×ˢ sb i.2 :=
   ha.prod_nhds hb
 #align filter.has_basis.prod_nhds' Filter.HasBasis.prod_nhds'
 
-theorem mem_nhds_prod_iff' {a : X} {b : β} {s : Set (X × β)} :
+theorem mem_nhds_prod_iff' {a : X} {b : Y} {s : Set (X × Y)} :
     s ∈ 𝓝 (a, b) ↔ ∃ u v, IsOpen u ∧ a ∈ u ∧ IsOpen v ∧ b ∈ v ∧ u ×ˢ v ⊆ s :=
   ((nhds_basis_opens a).prod_nhds (nhds_basis_opens b)).mem_iff.trans <| by
     simp only [Prod.exists, and_comm, and_assoc, and_left_comm]
 #align mem_nhds_prod_iff' mem_nhds_prod_iff'
 
-theorem Prod.tendsto_iff {X} (seq : X → β × γ) {f : Filter X} (x : β × γ) :
+theorem Prod.tendsto_iff {X} (seq : X → Y × γ) {f : Filter X} (x : Y × γ) :
     Tendsto seq f (𝓝 x) ↔
       Tendsto (fun n => (seq n).fst) f (𝓝 x.fst) ∧ Tendsto (fun n => (seq n).snd) f (𝓝 x.snd) := by
   rw [nhds_prod_eq, Filter.tendsto_prod_iff']
 #align prod.tendsto_iff Prod.tendsto_iff
 
-instance [DiscreteTopology X] [DiscreteTopology β] : DiscreteTopology (X × β) :=
+instance [DiscreteTopology X] [DiscreteTopology Y] : DiscreteTopology (X × Y) :=
   discreteTopology_iff_nhds.2 fun (a, b) => by
-    rw [nhds_prod_eq, nhds_discrete X, nhds_discrete β, prod_pure_pure]
+    rw [nhds_prod_eq, nhds_discrete X, nhds_discrete Y, prod_pure_pure]
 
-theorem prod_mem_nhds_iff {s : Set X} {t : Set β} {a : X} {b : β} :
+theorem prod_mem_nhds_iff {s : Set X} {t : Set Y} {a : X} {b : Y} :
     s ×ˢ t ∈ 𝓝 (a, b) ↔ s ∈ 𝓝 a ∧ t ∈ 𝓝 b := by rw [nhds_prod_eq, prod_mem_prod_iff]
 #align prod_mem_nhds_iff prod_mem_nhds_iff
 
-theorem prod_mem_nhds {s : Set X} {t : Set β} {a : X} {b : β} (ha : s ∈ 𝓝 a) (hb : t ∈ 𝓝 b) :
+theorem prod_mem_nhds {s : Set X} {t : Set Y} {a : X} {b : Y} (ha : s ∈ 𝓝 a) (hb : t ∈ 𝓝 b) :
     s ×ˢ t ∈ 𝓝 (a, b) :=
   prod_mem_nhds_iff.2 ⟨ha, hb⟩
 #align prod_mem_nhds prod_mem_nhds
 
-theorem Filter.Eventually.prod_nhds {p : X → Prop} {q : β → Prop} {a : X} {b : β}
-    (ha : ∀ᶠ x in 𝓝 a, p x) (hb : ∀ᶠ y in 𝓝 b, q y) : ∀ᶠ z : X × β in 𝓝 (a, b), p z.1 ∧ q z.2 :=
+theorem Filter.Eventually.prod_nhds {p : X → Prop} {q : Y → Prop} {a : X} {b : Y}
+    (ha : ∀ᶠ x in 𝓝 a, p x) (hb : ∀ᶠ y in 𝓝 b, q y) : ∀ᶠ z : X × Y in 𝓝 (a, b), p z.1 ∧ q z.2 :=
   prod_mem_nhds ha hb
 #align filter.eventually.prod_nhds Filter.Eventually.prod_nhds
 
-theorem nhds_swap (a : X) (b : β) : 𝓝 (a, b) = (𝓝 (b, a)).map Prod.swap := by
+theorem nhds_swap (a : X) (b : Y) : 𝓝 (a, b) = (𝓝 (b, a)).map Prod.swap := by
   rw [nhds_prod_eq, Filter.prod_comm, nhds_prod_eq]; rfl
 #align nhds_swap nhds_swap
 
-theorem Filter.Tendsto.prod_mk_nhds {γ} {a : X} {b : β} {f : Filter γ} {ma : γ → X} {mb : γ → β}
+theorem Filter.Tendsto.prod_mk_nhds {γ} {a : X} {b : Y} {f : Filter γ} {ma : γ → X} {mb : γ → Y}
     (ha : Tendsto ma f (𝓝 a)) (hb : Tendsto mb f (𝓝 b)) :
     Tendsto (fun c => (ma c, mb c)) f (𝓝 (a, b)) := by
   rw [nhds_prod_eq]; exact Filter.Tendsto.prod_mk ha hb
 #align filter.tendsto.prod_mk_nhds Filter.Tendsto.prod_mk_nhds
 
-theorem Filter.Eventually.curry_nhds {p : X × β → Prop} {x : X} {y : β}
+theorem Filter.Eventually.curry_nhds {p : X × Y → Prop} {x : X} {y : Y}
     (h : ∀ᶠ x in 𝓝 (x, y), p x) : ∀ᶠ x' in 𝓝 x, ∀ᶠ y' in 𝓝 y, p (x', y') := by
   rw [nhds_prod_eq] at h
   exact h.curry
 #align filter.eventually.curry_nhds Filter.Eventually.curry_nhds
 
-theorem ContinuousAt.prod {f : X → β} {g : X → γ} {x : X} (hf : ContinuousAt f x)
+theorem ContinuousAt.prod {f : X → Y} {g : X → γ} {x : X} (hf : ContinuousAt f x)
     (hg : ContinuousAt g x) : ContinuousAt (fun x => (f x, g x)) x :=
   hf.prod_mk_nhds hg
 #align continuous_at.prod ContinuousAt.prod
 
-theorem ContinuousAt.prod_map {f : X → γ} {g : β → δ} {p : X × β} (hf : ContinuousAt f p.fst)
-    (hg : ContinuousAt g p.snd) : ContinuousAt (fun p : X × β => (f p.1, g p.2)) p :=
+theorem ContinuousAt.prod_map {f : X → γ} {g : Y → δ} {p : X × Y} (hf : ContinuousAt f p.fst)
+    (hg : ContinuousAt g p.snd) : ContinuousAt (fun p : X × Y => (f p.1, g p.2)) p :=
   hf.fst''.prod hg.snd''
 #align continuous_at.prod_map ContinuousAt.prod_map
 
-theorem ContinuousAt.prod_map' {f : X → γ} {g : β → δ} {x : X} {y : β} (hf : ContinuousAt f x)
-    (hg : ContinuousAt g y) : ContinuousAt (fun p : X × β => (f p.1, g p.2)) (x, y) :=
+theorem ContinuousAt.prod_map' {f : X → γ} {g : Y → δ} {x : X} {y : Y} (hf : ContinuousAt f x)
+    (hg : ContinuousAt g y) : ContinuousAt (fun p : X × Y => (f p.1, g p.2)) (x, y) :=
   hf.fst'.prod hg.snd'
 #align continuous_at.prod_map' ContinuousAt.prod_map'
 
@@ -657,7 +657,7 @@ theorem prod_generateFrom_generateFrom_eq { β : Type*} {s : Set (Set X)} {t : S
 -- todo: use the previous lemma?
 theorem prod_eq_generateFrom :
     instTopologicalSpaceProd =
-      generateFrom { g | ∃ (s : Set X) (t : Set β), IsOpen s ∧ IsOpen t ∧ g = s ×ˢ t } :=
+      generateFrom { g | ∃ (s : Set X) (t : Set Y), IsOpen s ∧ IsOpen t ∧ g = s ×ˢ t } :=
   le_antisymm (le_generateFrom fun g ⟨s, t, hs, ht, g_eq⟩ => g_eq.symm ▸ hs.prod ht)
     (le_inf
       (ball_image_of_ball fun t ht =>
@@ -667,14 +667,14 @@ theorem prod_eq_generateFrom :
 #align prod_eq_generate_from prod_eq_generateFrom
 
 -- porting note: todo: align with `mem_nhds_prod_iff'`
-theorem isOpen_prod_iff {s : Set (X × β)} :
+theorem isOpen_prod_iff {s : Set (X × Y)} :
     IsOpen s ↔ ∀ a b, (a, b) ∈ s →
       ∃ u v, IsOpen u ∧ IsOpen v ∧ a ∈ u ∧ b ∈ v ∧ u ×ˢ v ⊆ s :=
   isOpen_iff_mem_nhds.trans <| by simp_rw [Prod.forall, mem_nhds_prod_iff', and_left_comm]
 #align is_open_prod_iff isOpen_prod_iff
 
 /-- A product of induced topologies is induced by the product map -/
-theorem prod_induced_induced (f : X → β) (g : γ → δ) :
+theorem prod_induced_induced (f : X → Y) (g : γ → δ) :
     @instTopologicalSpaceProd X γ (induced f ‹_›) (induced g ‹_›) =
       induced (fun p => (f p.1, g p.2)) instTopologicalSpaceProd := by
   delta instTopologicalSpaceProd
@@ -693,7 +693,7 @@ theorem exists_nhds_square {s : Set (X × X)} {x : X} (hx : s ∈ 𝓝 (x, x)) :
 
 /-- `Prod.fst` maps neighborhood of `x :  × β` within the section `Prod.snd ⁻¹' {x.2}`
 to `𝓝 x.1`. -/
-theorem map_fst_nhdsWithin (x : X × β) : map Prod.fst (𝓝[Prod.snd ⁻¹' {x.2}] x) = 𝓝 x.1 := by
+theorem map_fst_nhdsWithin (x : X × Y) : map Prod.fst (𝓝[Prod.snd ⁻¹' {x.2}] x) = 𝓝 x.1 := by
   refine' le_antisymm (continuousAt_fst.mono_left inf_le_left) fun s hs => _
   rcases x with ⟨x, y⟩
   rw [mem_map, nhdsWithin, mem_inf_principal, mem_nhds_prod_iff] at hs
@@ -703,18 +703,18 @@ theorem map_fst_nhdsWithin (x : X × β) : map Prod.fst (𝓝[Prod.snd ⁻¹' {x
 #align map_fst_nhds_within map_fst_nhdsWithin
 
 @[simp]
-theorem map_fst_nhds (x : X × β) : map Prod.fst (𝓝 x) = 𝓝 x.1 :=
+theorem map_fst_nhds (x : X × Y) : map Prod.fst (𝓝 x) = 𝓝 x.1 :=
   le_antisymm continuousAt_fst <| (map_fst_nhdsWithin x).symm.trans_le (map_mono inf_le_left)
 #align map_fst_nhds map_fst_nhds
 
 /-- The first projection in a product of topological spaces sends open sets to open sets. -/
-theorem isOpenMap_fst : IsOpenMap (@Prod.fst X β) :=
+theorem isOpenMap_fst : IsOpenMap (@Prod.fst X Y) :=
   isOpenMap_iff_nhds_le.2 fun x => (map_fst_nhds x).ge
 #align is_open_map_fst isOpenMap_fst
 
 /-- `Prod.snd` maps neighborhood of `x :  × β` within the section `Prod.fst ⁻¹' {x.1}`
 to `𝓝 x.2`. -/
-theorem map_snd_nhdsWithin (x : X × β) : map Prod.snd (𝓝[Prod.fst ⁻¹' {x.1}] x) = 𝓝 x.2 := by
+theorem map_snd_nhdsWithin (x : X × Y) : map Prod.snd (𝓝[Prod.fst ⁻¹' {x.1}] x) = 𝓝 x.2 := by
   refine' le_antisymm (continuousAt_snd.mono_left inf_le_left) fun s hs => _
   rcases x with ⟨x, y⟩
   rw [mem_map, nhdsWithin, mem_inf_principal, mem_nhds_prod_iff] at hs
@@ -724,18 +724,18 @@ theorem map_snd_nhdsWithin (x : X × β) : map Prod.snd (𝓝[Prod.fst ⁻¹' {x
 #align map_snd_nhds_within map_snd_nhdsWithin
 
 @[simp]
-theorem map_snd_nhds (x : X × β) : map Prod.snd (𝓝 x) = 𝓝 x.2 :=
+theorem map_snd_nhds (x : X × Y) : map Prod.snd (𝓝 x) = 𝓝 x.2 :=
   le_antisymm continuousAt_snd <| (map_snd_nhdsWithin x).symm.trans_le (map_mono inf_le_left)
 #align map_snd_nhds map_snd_nhds
 
 /-- The second projection in a product of topological spaces sends open sets to open sets. -/
-theorem isOpenMap_snd : IsOpenMap (@Prod.snd X β) :=
+theorem isOpenMap_snd : IsOpenMap (@Prod.snd X Y) :=
   isOpenMap_iff_nhds_le.2 fun x => (map_snd_nhds x).ge
 #align is_open_map_snd isOpenMap_snd
 
 /-- A product set is open in a product space if and only if each factor is open, or one of them is
 empty -/
-theorem isOpen_prod_iff' {s : Set X} {t : Set β} :
+theorem isOpen_prod_iff' {s : Set X} {t : Set Y} :
     IsOpen (s ×ˢ t) ↔ IsOpen s ∧ IsOpen t ∨ s = ∅ ∨ t = ∅ := by
   rcases (s ×ˢ t).eq_empty_or_nonempty with h | h
   · simp [h, prod_eq_empty_iff.1 h]
@@ -754,33 +754,33 @@ theorem isOpen_prod_iff' {s : Set X} {t : Set β} :
       exact H.1.prod H.2
 #align is_open_prod_iff' isOpen_prod_iff'
 
-theorem closure_prod_eq {s : Set X} {t : Set β} : closure (s ×ˢ t) = closure s ×ˢ closure t :=
+theorem closure_prod_eq {s : Set X} {t : Set Y} : closure (s ×ˢ t) = closure s ×ˢ closure t :=
   Set.ext fun ⟨a, b⟩ => by
     simp_rw [mem_prod, mem_closure_iff_nhdsWithin_neBot, nhdsWithin_prod_eq, prod_neBot]
 #align closure_prod_eq closure_prod_eq
 
-theorem interior_prod_eq (s : Set X) (t : Set β) : interior (s ×ˢ t) = interior s ×ˢ interior t :=
+theorem interior_prod_eq (s : Set X) (t : Set Y) : interior (s ×ˢ t) = interior s ×ˢ interior t :=
   Set.ext fun ⟨a, b⟩ => by simp only [mem_interior_iff_mem_nhds, mem_prod, prod_mem_nhds_iff]
 #align interior_prod_eq interior_prod_eq
 
-theorem frontier_prod_eq (s : Set X) (t : Set β) :
+theorem frontier_prod_eq (s : Set X) (t : Set Y) :
     frontier (s ×ˢ t) = closure s ×ˢ frontier t ∪ frontier s ×ˢ closure t := by
   simp only [frontier, closure_prod_eq, interior_prod_eq, prod_diff_prod]
 #align frontier_prod_eq frontier_prod_eq
 
 @[simp]
 theorem frontier_prod_univ_eq (s : Set X) :
-    frontier (s ×ˢ (univ : Set β)) = frontier s ×ˢ univ := by
+    frontier (s ×ˢ (univ : Set Y)) = frontier s ×ˢ univ := by
   simp [frontier_prod_eq]
 #align frontier_prod_univ_eq frontier_prod_univ_eq
 
 @[simp]
-theorem frontier_univ_prod_eq (s : Set β) :
+theorem frontier_univ_prod_eq (s : Set Y) :
     frontier ((univ : Set X) ×ˢ s) = univ ×ˢ frontier s := by
   simp [frontier_prod_eq]
 #align frontier_univ_prod_eq frontier_univ_prod_eq
 
-theorem map_mem_closure₂ {f : X → β → γ} {a : X} {b : β} {s : Set X} {t : Set β} {u : Set γ}
+theorem map_mem_closure₂ {f : X → Y → γ} {a : X} {b : Y} {s : Set X} {t : Set Y} {u : Set γ}
     (hf : Continuous (uncurry f)) (ha : a ∈ closure s) (hb : b ∈ closure t)
     (h : ∀ a ∈ s, ∀ b ∈ t, f a b ∈ u) : f a b ∈ closure u :=
   have H₁ : (a, b) ∈ closure (s ×ˢ t) := by simpa only [closure_prod_eq] using mk_mem_prod ha hb
@@ -788,49 +788,49 @@ theorem map_mem_closure₂ {f : X → β → γ} {a : X} {b : β} {s : Set X} {t
   H₂.closure hf H₁
 #align map_mem_closure₂ map_mem_closure₂
 
-theorem IsClosed.prod {s₁ : Set X} {s₂ : Set β} (h₁ : IsClosed s₁) (h₂ : IsClosed s₂) :
+theorem IsClosed.prod {s₁ : Set X} {s₂ : Set Y} (h₁ : IsClosed s₁) (h₂ : IsClosed s₂) :
     IsClosed (s₁ ×ˢ s₂) :=
   closure_eq_iff_isClosed.mp <| by simp only [h₁.closure_eq, h₂.closure_eq, closure_prod_eq]
 #align is_closed.prod IsClosed.prod
 
 /-- The product of two dense sets is a dense set. -/
-theorem Dense.prod {s : Set X} {t : Set β} (hs : Dense s) (ht : Dense t) : Dense (s ×ˢ t) :=
+theorem Dense.prod {s : Set X} {t : Set Y} (hs : Dense s) (ht : Dense t) : Dense (s ×ˢ t) :=
   fun x => by
   rw [closure_prod_eq]
   exact ⟨hs x.1, ht x.2⟩
 #align dense.prod Dense.prod
 
 /-- If `f` and `g` are maps with dense range, then `Prod.map f g` has dense range. -/
-theorem DenseRange.prod_map {ι : Type*} {κ : Type*} {f : ι → β} {g : κ → γ} (hf : DenseRange f)
+theorem DenseRange.prod_map {ι : Type*} {κ : Type*} {f : ι → Y} {g : κ → γ} (hf : DenseRange f)
     (hg : DenseRange g) : DenseRange (Prod.map f g) := by
   simpa only [DenseRange, prod_range_range_eq] using hf.prod hg
 #align dense_range.prod_map DenseRange.prod_map
 
-theorem Inducing.prod_map {f : X → β} {g : γ → δ} (hf : Inducing f) (hg : Inducing g) :
+theorem Inducing.prod_map {f : X → Y} {g : γ → δ} (hf : Inducing f) (hg : Inducing g) :
     Inducing (Prod.map f g) :=
   inducing_iff_nhds.2 fun (a, b) => by simp_rw [Prod.map_def, nhds_prod_eq, hf.nhds_eq_comap,
     hg.nhds_eq_comap, prod_comap_comap_eq]
 #align inducing.prod_mk Inducing.prod_map
 
 @[simp]
-theorem inducing_const_prod {a : X} {f : β → γ} : (Inducing fun x => (a, f x)) ↔ Inducing f := by
+theorem inducing_const_prod {a : X} {f : Y → γ} : (Inducing fun x => (a, f x)) ↔ Inducing f := by
   simp_rw [inducing_iff, instTopologicalSpaceProd, induced_inf, induced_compose, Function.comp,
     induced_const, top_inf_eq]
 #align inducing_const_prod inducing_const_prod
 
 @[simp]
-theorem inducing_prod_const {b : β} {f : X → γ} : (Inducing fun x => (f x, b)) ↔ Inducing f := by
+theorem inducing_prod_const {b : Y} {f : X → γ} : (Inducing fun x => (f x, b)) ↔ Inducing f := by
   simp_rw [inducing_iff, instTopologicalSpaceProd, induced_inf, induced_compose, Function.comp,
     induced_const, inf_top_eq]
 #align inducing_prod_const inducing_prod_const
 
-theorem Embedding.prod_map {f : X → β} {g : γ → δ} (hf : Embedding f) (hg : Embedding g) :
+theorem Embedding.prod_map {f : X → Y} {g : γ → δ} (hf : Embedding f) (hg : Embedding g) :
     Embedding (Prod.map f g) :=
   { hf.toInducing.prod_map hg.toInducing with
     inj := fun ⟨x₁, x₂⟩ ⟨y₁, y₂⟩ => by simp [hf.inj.eq_iff, hg.inj.eq_iff] }
 #align embedding.prod_mk Embedding.prod_map
 
-protected theorem IsOpenMap.prod {f : X → β} {g : γ → δ} (hf : IsOpenMap f) (hg : IsOpenMap g) :
+protected theorem IsOpenMap.prod {f : X → Y} {g : γ → δ} (hf : IsOpenMap f) (hg : IsOpenMap g) :
     IsOpenMap fun p : X × γ => (f p.1, g p.2) := by
   rw [isOpenMap_iff_nhds_le]
   rintro ⟨a, b⟩
@@ -838,16 +838,16 @@ protected theorem IsOpenMap.prod {f : X → β} {g : γ → δ} (hf : IsOpenMap 
   exact Filter.prod_mono (hf.nhds_le a) (hg.nhds_le b)
 #align is_open_map.prod IsOpenMap.prod
 
-protected theorem OpenEmbedding.prod {f : X → β} {g : γ → δ} (hf : OpenEmbedding f)
+protected theorem OpenEmbedding.prod {f : X → Y} {g : γ → δ} (hf : OpenEmbedding f)
     (hg : OpenEmbedding g) : OpenEmbedding fun x : X × γ => (f x.1, g x.2) :=
   openEmbedding_of_embedding_open (hf.1.prod_map hg.1) (hf.isOpenMap.prod hg.isOpenMap)
 #align open_embedding.prod OpenEmbedding.prod
 
-theorem embedding_graph {f : X → β} (hf : Continuous f) : Embedding fun x => (x, f x) :=
+theorem embedding_graph {f : X → Y} (hf : Continuous f) : Embedding fun x => (x, f x) :=
   embedding_of_embedding_compose (continuous_id.prod_mk hf) continuous_fst embedding_id
 #align embedding_graph embedding_graph
 
-theorem embedding_prod_mk (x : X) : Embedding (Prod.mk x : β → X × β) :=
+theorem embedding_prod_mk (x : X) : Embedding (Prod.mk x : Y → X × Y) :=
   embedding_of_embedding_compose (Continuous.Prod.mk x) continuous_snd embedding_id
 
 end Prod
@@ -856,136 +856,136 @@ section Sum
 
 open Sum
 
-variable [TopologicalSpace X] [TopologicalSpace β] [TopologicalSpace γ] [TopologicalSpace δ]
+variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace γ] [TopologicalSpace δ]
 
-theorem continuous_sum_dom {f : X ⊕ β → γ} :
+theorem continuous_sum_dom {f : X ⊕ Y → γ} :
     Continuous f ↔ Continuous (f ∘ Sum.inl) ∧ Continuous (f ∘ Sum.inr) :=
   (continuous_sup_dom (t₁ := TopologicalSpace.coinduced Sum.inl _)
     (t₂ := TopologicalSpace.coinduced Sum.inr _)).trans <|
     continuous_coinduced_dom.and continuous_coinduced_dom
 #align continuous_sum_dom continuous_sum_dom
 
-theorem continuous_sum_elim {f : X → γ} {g : β → γ} :
+theorem continuous_sum_elim {f : X → γ} {g : Y → γ} :
     Continuous (Sum.elim f g) ↔ Continuous f ∧ Continuous g :=
   continuous_sum_dom
 #align continuous_sum_elim continuous_sum_elim
 
 @[continuity]
-theorem Continuous.sum_elim {f : X → γ} {g : β → γ} (hf : Continuous f) (hg : Continuous g) :
+theorem Continuous.sum_elim {f : X → γ} {g : Y → γ} (hf : Continuous f) (hg : Continuous g) :
     Continuous (Sum.elim f g) :=
   continuous_sum_elim.2 ⟨hf, hg⟩
 #align continuous.sum_elim Continuous.sum_elim
 
 @[continuity]
-theorem continuous_isLeft : Continuous (isLeft : X ⊕ β → Bool) :=
+theorem continuous_isLeft : Continuous (isLeft : X ⊕ Y → Bool) :=
   continuous_sum_dom.2 ⟨continuous_const, continuous_const⟩
 
 @[continuity]
-theorem continuous_isRight : Continuous (isRight : X ⊕ β → Bool) :=
+theorem continuous_isRight : Continuous (isRight : X ⊕ Y → Bool) :=
   continuous_sum_dom.2 ⟨continuous_const, continuous_const⟩
 
 @[continuity]
 -- porting note: the proof was `continuous_sup_rng_left continuous_coinduced_rng`
-theorem continuous_inl : Continuous (@inl X β) := ⟨fun _ => And.left⟩
+theorem continuous_inl : Continuous (@inl X Y) := ⟨fun _ => And.left⟩
 #align continuous_inl continuous_inl
 
 @[continuity]
 -- porting note: the proof was `continuous_sup_rng_right continuous_coinduced_rng`
-theorem continuous_inr : Continuous (@inr X β) := ⟨fun _ => And.right⟩
+theorem continuous_inr : Continuous (@inr X Y) := ⟨fun _ => And.right⟩
 #align continuous_inr continuous_inr
 
-theorem isOpen_sum_iff {s : Set (Sum X β)} : IsOpen s ↔ IsOpen (inl ⁻¹' s) ∧ IsOpen (inr ⁻¹' s) :=
+theorem isOpen_sum_iff {s : Set (Sum X Y)} : IsOpen s ↔ IsOpen (inl ⁻¹' s) ∧ IsOpen (inr ⁻¹' s) :=
   Iff.rfl
 #align is_open_sum_iff isOpen_sum_iff
 
 -- porting note: new theorem
-theorem isClosed_sum_iff {s : Set (X ⊕ β)} :
+theorem isClosed_sum_iff {s : Set (X ⊕ Y)} :
     IsClosed s ↔ IsClosed (inl ⁻¹' s) ∧ IsClosed (inr ⁻¹' s) := by
   simp only [← isOpen_compl_iff, isOpen_sum_iff, preimage_compl]
 
-theorem isOpenMap_inl : IsOpenMap (@inl X β) := fun u hu => by
+theorem isOpenMap_inl : IsOpenMap (@inl X Y) := fun u hu => by
   simpa [isOpen_sum_iff, preimage_image_eq u Sum.inl_injective]
 #align is_open_map_inl isOpenMap_inl
 
-theorem isOpenMap_inr : IsOpenMap (@inr X β) := fun u hu => by
+theorem isOpenMap_inr : IsOpenMap (@inr X Y) := fun u hu => by
   simpa [isOpen_sum_iff, preimage_image_eq u Sum.inr_injective]
 #align is_open_map_inr isOpenMap_inr
 
-theorem openEmbedding_inl : OpenEmbedding (@inl X β) :=
+theorem openEmbedding_inl : OpenEmbedding (@inl X Y) :=
   openEmbedding_of_continuous_injective_open continuous_inl inl_injective isOpenMap_inl
 #align open_embedding_inl openEmbedding_inl
 
-theorem openEmbedding_inr : OpenEmbedding (@inr X β) :=
+theorem openEmbedding_inr : OpenEmbedding (@inr X Y) :=
   openEmbedding_of_continuous_injective_open continuous_inr inr_injective isOpenMap_inr
 #align open_embedding_inr openEmbedding_inr
 
-theorem embedding_inl : Embedding (@inl X β) :=
+theorem embedding_inl : Embedding (@inl X Y) :=
   openEmbedding_inl.1
 #align embedding_inl embedding_inl
 
-theorem embedding_inr : Embedding (@inr X β) :=
+theorem embedding_inr : Embedding (@inr X Y) :=
   openEmbedding_inr.1
 #align embedding_inr embedding_inr
 
-theorem isOpen_range_inl : IsOpen (range (inl : X → Sum X β)) :=
+theorem isOpen_range_inl : IsOpen (range (inl : X → Sum X Y)) :=
   openEmbedding_inl.2
 #align is_open_range_inl isOpen_range_inl
 
-theorem isOpen_range_inr : IsOpen (range (inr : β → Sum X β)) :=
+theorem isOpen_range_inr : IsOpen (range (inr : Y → Sum X Y)) :=
   openEmbedding_inr.2
 #align is_open_range_inr isOpen_range_inr
 
-theorem isClosed_range_inl : IsClosed (range (inl : X → Sum X β)) := by
+theorem isClosed_range_inl : IsClosed (range (inl : X → Sum X Y)) := by
   rw [← isOpen_compl_iff, compl_range_inl]
   exact isOpen_range_inr
 #align is_closed_range_inl isClosed_range_inl
 
-theorem isClosed_range_inr : IsClosed (range (inr : β → Sum X β)) := by
+theorem isClosed_range_inr : IsClosed (range (inr : Y → Sum X Y)) := by
   rw [← isOpen_compl_iff, compl_range_inr]
   exact isOpen_range_inl
 #align is_closed_range_inr isClosed_range_inr
 
-theorem closedEmbedding_inl : ClosedEmbedding (inl : X → Sum X β) :=
+theorem closedEmbedding_inl : ClosedEmbedding (inl : X → Sum X Y) :=
   ⟨embedding_inl, isClosed_range_inl⟩
 #align closed_embedding_inl closedEmbedding_inl
 
-theorem closedEmbedding_inr : ClosedEmbedding (inr : β → Sum X β) :=
+theorem closedEmbedding_inr : ClosedEmbedding (inr : Y → Sum X Y) :=
   ⟨embedding_inr, isClosed_range_inr⟩
 #align closed_embedding_inr closedEmbedding_inr
 
-theorem nhds_inl (x : X) : 𝓝 (inl x : Sum X β) = map inl (𝓝 x) :=
+theorem nhds_inl (x : X) : 𝓝 (inl x : Sum X Y) = map inl (𝓝 x) :=
   (openEmbedding_inl.map_nhds_eq _).symm
 #align nhds_inl nhds_inl
 
-theorem nhds_inr (x : β) : 𝓝 (inr x : Sum X β) = map inr (𝓝 x) :=
+theorem nhds_inr (x : Y) : 𝓝 (inr x : Sum X Y) = map inr (𝓝 x) :=
   (openEmbedding_inr.map_nhds_eq _).symm
 #align nhds_inr nhds_inr
 
 @[simp]
-theorem continuous_sum_map {f : X → β} {g : γ → δ} :
+theorem continuous_sum_map {f : X → Y} {g : γ → δ} :
     Continuous (Sum.map f g) ↔ Continuous f ∧ Continuous g :=
   continuous_sum_elim.trans <|
     embedding_inl.continuous_iff.symm.and embedding_inr.continuous_iff.symm
 #align continuous_sum_map continuous_sum_map
 
 @[continuity]
-theorem Continuous.sum_map {f : X → β} {g : γ → δ} (hf : Continuous f) (hg : Continuous g) :
+theorem Continuous.sum_map {f : X → Y} {g : γ → δ} (hf : Continuous f) (hg : Continuous g) :
     Continuous (Sum.map f g) :=
   continuous_sum_map.2 ⟨hf, hg⟩
 #align continuous.sum_map Continuous.sum_map
 
-theorem isOpenMap_sum {f : Sum X β → γ} :
+theorem isOpenMap_sum {f : Sum X Y → γ} :
     IsOpenMap f ↔ (IsOpenMap fun a => f (inl a)) ∧ IsOpenMap fun b => f (inr b) := by
   simp only [isOpenMap_iff_nhds_le, Sum.forall, nhds_inl, nhds_inr, Filter.map_map, comp]
 #align is_open_map_sum isOpenMap_sum
 
 @[simp]
-theorem isOpenMap_sum_elim {f : X → γ} {g : β → γ} :
+theorem isOpenMap_sum_elim {f : X → γ} {g : Y → γ} :
     IsOpenMap (Sum.elim f g) ↔ IsOpenMap f ∧ IsOpenMap g := by
   simp only [isOpenMap_sum, elim_inl, elim_inr]
 #align is_open_map_sum_elim isOpenMap_sum_elim
 
-theorem IsOpenMap.sum_elim {f : X → γ} {g : β → γ} (hf : IsOpenMap f) (hg : IsOpenMap g) :
+theorem IsOpenMap.sum_elim {f : X → γ} {g : Y → γ} (hf : IsOpenMap f) (hg : IsOpenMap g) :
     IsOpenMap (Sum.elim f g) :=
   isOpenMap_sum_elim.2 ⟨hf, hg⟩
 #align is_open_map.sum_elim IsOpenMap.sum_elim
@@ -994,12 +994,12 @@ end Sum
 
 section Subtype
 
-variable [TopologicalSpace X] [TopologicalSpace β] [TopologicalSpace γ] {p : X → Prop}
+variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace γ] {p : X → Prop}
 
-theorem inducing_subtype_val {b : Set β} : Inducing ((↑) : b → β) := ⟨rfl⟩
+theorem inducing_subtype_val {b : Set Y} : Inducing ((↑) : b → Y) := ⟨rfl⟩
 #align inducing_coe inducing_subtype_val
 
-theorem Inducing.of_codRestrict {f : X → β} {b : Set β} (hb : ∀ a, f a ∈ b)
+theorem Inducing.of_codRestrict {f : X → Y} {b : Set Y} (hb : ∀ a, f a ∈ b)
     (h : Inducing (b.codRestrict f hb)) : Inducing f :=
   inducing_subtype_val.comp h
 #align inducing.of_cod_restrict Inducing.of_codRestrict
@@ -1019,7 +1019,7 @@ theorem continuous_subtype_val : Continuous (@Subtype.val X p) :=
 #align continuous_subtype_val continuous_subtype_val
 #align continuous_subtype_coe continuous_subtype_val
 
-theorem Continuous.subtype_val {f : β → Subtype p} (hf : Continuous f) :
+theorem Continuous.subtype_val {f : Y → Subtype p} (hf : Continuous f) :
     Continuous fun x => (f x : X) :=
   continuous_subtype_val.comp hf
 #align continuous.subtype_coe Continuous.subtype_val
@@ -1033,12 +1033,12 @@ theorem IsOpen.isOpenMap_subtype_val {s : Set X} (hs : IsOpen s) : IsOpenMap ((�
   hs.openEmbedding_subtype_val.isOpenMap
 #align is_open.is_open_map_subtype_coe IsOpen.isOpenMap_subtype_val
 
-theorem IsOpenMap.restrict {f : X → β} (hf : IsOpenMap f) {s : Set X} (hs : IsOpen s) :
+theorem IsOpenMap.restrict {f : X → Y} (hf : IsOpenMap f) {s : Set X} (hs : IsOpen s) :
     IsOpenMap (s.restrict f) :=
   hf.comp hs.isOpenMap_subtype_val
 #align is_open_map.restrict IsOpenMap.restrict
 
-lemma IsClosedMap.restrictPreimage {f : X → β} (hcl : IsClosedMap f) (T : Set β) :
+lemma IsClosedMap.restrictPreimage {f : X → Y} (hcl : IsClosedMap f) (T : Set Y) :
     IsClosedMap (T.restrictPreimage f) := by
   rw [isClosedMap_iff_clusterPt] at hcl ⊢
   intro A ⟨y, hyT⟩ hy
@@ -1055,12 +1055,12 @@ nonrec theorem IsClosed.closedEmbedding_subtype_val {s : Set X} (hs : IsClosed s
 #align is_closed.closed_embedding_subtype_coe IsClosed.closedEmbedding_subtype_val
 
 @[continuity]
-theorem Continuous.subtype_mk {f : β → X} (h : Continuous f) (hp : ∀ x, p (f x)) :
+theorem Continuous.subtype_mk {f : Y → X} (h : Continuous f) (hp : ∀ x, p (f x)) :
     Continuous fun x => (⟨f x, hp x⟩ : Subtype p) :=
   continuous_induced_rng.2 h
 #align continuous.subtype_mk Continuous.subtype_mk
 
-theorem Continuous.subtype_map {f : X → β} (h : Continuous f) {q : β → Prop}
+theorem Continuous.subtype_map {f : X → Y} (h : Continuous f) {q : Y → Prop}
     (hpq : ∀ x, p x → q (f x)) : Continuous (Subtype.map f hpq) :=
   (h.comp continuous_subtype_val).subtype_mk _
 #align continuous.subtype_map Continuous.subtype_map
@@ -1103,7 +1103,7 @@ theorem closure_subtype {x : { a // p a }} {s : Set { a // p a }} :
 #align closure_subtype closure_subtype
 
 @[simp]
-theorem continuousAt_codRestrict_iff {f : X → β} {t : Set β} (h1 : ∀ x, f x ∈ t) {x : X} :
+theorem continuousAt_codRestrict_iff {f : X → Y} {t : Set Y} (h1 : ∀ x, f x ∈ t) {x : X} :
     ContinuousAt (codRestrict f t h1) x ↔ ContinuousAt f x :=
   inducing_subtype_val.continuousAt_iff
 #align continuous_at_cod_restrict_iff continuousAt_codRestrict_iff
@@ -1111,38 +1111,38 @@ theorem continuousAt_codRestrict_iff {f : X → β} {t : Set β} (h1 : ∀ x, f 
 alias ⟨_, ContinuousAt.codRestrict⟩ := continuousAt_codRestrict_iff
 #align continuous_at.cod_restrict ContinuousAt.codRestrict
 
-theorem ContinuousAt.restrict {f : X → β} {s : Set X} {t : Set β} (h1 : MapsTo f s t) {x : s}
+theorem ContinuousAt.restrict {f : X → Y} {s : Set X} {t : Set Y} (h1 : MapsTo f s t) {x : s}
     (h2 : ContinuousAt f x) : ContinuousAt (h1.restrict f s t) x :=
   (h2.comp continuousAt_subtype_val).codRestrict _
 #align continuous_at.restrict ContinuousAt.restrict
 
-theorem ContinuousAt.restrictPreimage {f : X → β} {s : Set β} {x : f ⁻¹' s} (h : ContinuousAt f x) :
+theorem ContinuousAt.restrictPreimage {f : X → Y} {s : Set Y} {x : f ⁻¹' s} (h : ContinuousAt f x) :
     ContinuousAt (s.restrictPreimage f) x :=
   h.restrict _
 #align continuous_at.restrict_preimage ContinuousAt.restrictPreimage
 
 @[continuity]
-theorem Continuous.codRestrict {f : X → β} {s : Set β} (hf : Continuous f) (hs : ∀ a, f a ∈ s) :
+theorem Continuous.codRestrict {f : X → Y} {s : Set Y} (hf : Continuous f) (hs : ∀ a, f a ∈ s) :
     Continuous (s.codRestrict f hs) :=
   hf.subtype_mk hs
 #align continuous.cod_restrict Continuous.codRestrict
 
 @[continuity]
-theorem Continuous.restrict {f : X → β} {s : Set X} {t : Set β} (h1 : MapsTo f s t)
+theorem Continuous.restrict {f : X → Y} {s : Set X} {t : Set Y} (h1 : MapsTo f s t)
     (h2 : Continuous f) : Continuous (h1.restrict f s t) :=
   (h2.comp continuous_subtype_val).codRestrict _
 
 @[continuity]
-theorem Continuous.restrictPreimage {f : X → β} {s : Set β} (h : Continuous f) :
+theorem Continuous.restrictPreimage {f : X → Y} {s : Set Y} (h : Continuous f) :
     Continuous (s.restrictPreimage f) :=
   h.restrict _
 
-theorem Inducing.codRestrict {e : X → β} (he : Inducing e) {s : Set β} (hs : ∀ x, e x ∈ s) :
+theorem Inducing.codRestrict {e : X → Y} (he : Inducing e) {s : Set Y} (hs : ∀ x, e x ∈ s) :
     Inducing (codRestrict e s hs) :=
   inducing_of_inducing_compose (he.continuous.codRestrict hs) continuous_subtype_val he
 #align inducing.cod_restrict Inducing.codRestrict
 
-theorem Embedding.codRestrict {e : X → β} (he : Embedding e) (s : Set β) (hs : ∀ x, e x ∈ s) :
+theorem Embedding.codRestrict {e : X → Y} (he : Embedding e) (s : Set Y) (hs : ∀ x, e x ∈ s) :
     Embedding (codRestrict e s hs) :=
   embedding_of_embedding_compose (he.continuous.codRestrict hs) continuous_subtype_val he
 #align embedding.cod_restrict Embedding.codRestrict
@@ -1162,7 +1162,7 @@ end Subtype
 
 section Quotient
 
-variable [TopologicalSpace X] [TopologicalSpace β] [TopologicalSpace γ]
+variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace γ]
 
 variable {r : X → X → Prop} {s : Setoid X}
 
@@ -1176,8 +1176,8 @@ theorem continuous_quot_mk : Continuous (@Quot.mk X r) :=
 #align continuous_quot_mk continuous_quot_mk
 
 @[continuity]
-theorem continuous_quot_lift {f : X → β} (hr : ∀ a b, r a b → f a = f b) (h : Continuous f) :
-    Continuous (Quot.lift f hr : Quot r → β) :=
+theorem continuous_quot_lift {f : X → Y} (hr : ∀ a b, r a b → f a = f b) (h : Continuous f) :
+    Continuous (Quot.lift f hr : Quot r → Y) :=
   continuous_coinduced_dom.2 h
 #align continuous_quot_lift continuous_quot_lift
 
@@ -1189,18 +1189,18 @@ theorem continuous_quotient_mk' : Continuous (@Quotient.mk' X s) :=
   continuous_coinduced_rng
 #align continuous_quotient_mk continuous_quotient_mk'
 
-theorem Continuous.quotient_lift {f : X → β} (h : Continuous f) (hs : ∀ a b, a ≈ b → f a = f b) :
-    Continuous (Quotient.lift f hs : Quotient s → β) :=
+theorem Continuous.quotient_lift {f : X → Y} (h : Continuous f) (hs : ∀ a b, a ≈ b → f a = f b) :
+    Continuous (Quotient.lift f hs : Quotient s → Y) :=
   continuous_coinduced_dom.2 h
 #align continuous.quotient_lift Continuous.quotient_lift
 
-theorem Continuous.quotient_liftOn' {f : X → β} (h : Continuous f)
+theorem Continuous.quotient_liftOn' {f : X → Y} (h : Continuous f)
     (hs : ∀ a b, @Setoid.r _ s a b → f a = f b) :
-    Continuous (fun x => Quotient.liftOn' x f hs : Quotient s → β) :=
+    Continuous (fun x => Quotient.liftOn' x f hs : Quotient s → Y) :=
   h.quotient_lift hs
 #align continuous.quotient_lift_on' Continuous.quotient_liftOn'
 
-@[continuity] theorem Continuous.quotient_map' {t : Setoid β} {f : X → β} (hf : Continuous f)
+@[continuity] theorem Continuous.quotient_map' {t : Setoid Y} {f : X → Y} (hf : Continuous f)
     (H : (s.r ⇒ t.r) f f) : Continuous (Quotient.map' f H) :=
   (continuous_quotient_mk'.comp hf).quotient_lift _
 #align continuous.quotient_map' Continuous.quotient_map'
@@ -1236,7 +1236,7 @@ theorem continuousAt_apply (i : ι) (x : ∀ i, π i) : ContinuousAt (fun p : �
   (continuous_apply i).continuousAt
 #align continuous_at_apply continuousAt_apply
 
-theorem Filter.Tendsto.apply {l : Filter β} {f : β → ∀ i, π i} {x : ∀ i, π i}
+theorem Filter.Tendsto.apply {l : Filter Y} {f : Y → ∀ i, π i} {x : ∀ i, π i}
     (h : Tendsto f l (𝓝 x)) (i : ι) : Tendsto (fun a => f a i) l (𝓝 <| x i) :=
   (continuousAt_apply i _).tendsto.comp h
 #align filter.tendsto.apply Filter.Tendsto.apply
@@ -1245,7 +1245,7 @@ theorem nhds_pi {a : ∀ i, π i} : 𝓝 a = pi fun i => 𝓝 (a i) := by
   simp only [nhds_iInf, nhds_induced, Filter.pi]
 #align nhds_pi nhds_pi
 
-theorem tendsto_pi_nhds {f : β → ∀ i, π i} {g : ∀ i, π i} {u : Filter β} :
+theorem tendsto_pi_nhds {f : Y → ∀ i, π i} {g : ∀ i, π i} {u : Filter Y} :
     Tendsto f u (𝓝 g) ↔ ∀ x, Tendsto (fun i => f i x) u (𝓝 (g x)) := by
   rw [nhds_pi, Filter.tendsto_pi]
 #align tendsto_pi_nhds tendsto_pi_nhds
@@ -1268,8 +1268,8 @@ theorem Pi.continuous_postcomp' {ρ : ι → Type*} [∀ i, TopologicalSpace (ρ
     Continuous (fun (f : (∀ i, π i)) (i : ι) ↦ g i (f i)) :=
   continuous_pi fun i ↦ (hg i).comp <| continuous_apply i
 
-theorem Pi.continuous_postcomp [TopologicalSpace β] {g : X → β} (hg : Continuous g) :
-    Continuous (g ∘ · : (ι → X) → (ι → β)) :=
+theorem Pi.continuous_postcomp [TopologicalSpace Y] {g : X → Y} (hg : Continuous g) :
+    Continuous (g ∘ · : (ι → X) → (ι → Y)) :=
   Pi.continuous_postcomp' fun _ ↦ hg
 
 lemma Pi.induced_precomp' {ι' : Type*} (φ : ι' → ι) :
@@ -1277,7 +1277,7 @@ lemma Pi.induced_precomp' {ι' : Type*} (φ : ι' → ι) :
     ⨅ i', induced (eval (φ i')) (T (φ i')) := by
   simp [Pi.topologicalSpace, induced_iInf, induced_compose, comp]
 
-lemma Pi.induced_precomp [TopologicalSpace β] {ι' : Type*} (φ : ι' → ι) :
+lemma Pi.induced_precomp [TopologicalSpace Y] {ι' : Type*} (φ : ι' → ι) :
     induced (· ∘ φ) Pi.topologicalSpace =
     ⨅ i', induced (eval (φ i')) ‹TopologicalSpace β› :=
   induced_precomp' φ
@@ -1292,8 +1292,8 @@ lemma Pi.induced_restrict (S : Set ι) :
   simp (config := { unfoldPartialApp := true }) [← iInf_subtype'', ← induced_precomp' ((↑) : S → ι),
     Set.restrict]
 
-theorem Filter.Tendsto.update [DecidableEq ι] {l : Filter β} {f : β → ∀ i, π i} {x : ∀ i, π i}
-    (hf : Tendsto f l (𝓝 x)) (i : ι) {g : β → π i} {xi : π i} (hg : Tendsto g l (𝓝 xi)) :
+theorem Filter.Tendsto.update [DecidableEq ι] {l : Filter Y} {f : Y → ∀ i, π i} {x : ∀ i, π i}
+    (hf : Tendsto f l (𝓝 x)) (i : ι) {g : Y → π i} {xi : π i} (hg : Tendsto g l (𝓝 xi)) :
     Tendsto (fun a => update (f a) i (g a)) l (𝓝 <| update x i xi) :=
   tendsto_pi_nhds.2 fun j => by rcases eq_or_ne j i with (rfl | hj) <;> simp [*, hf.apply]
 #align filter.tendsto.update Filter.Tendsto.update
@@ -1325,8 +1325,8 @@ theorem continuous_mulSingle [∀ i, One (π i)] [DecidableEq ι] (i : ι) :
 #align continuous_single continuous_single
 
 theorem Filter.Tendsto.fin_insertNth {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
-    (i : Fin (n + 1)) {f : β → π i} {l : Filter β} {x : π i} (hf : Tendsto f l (𝓝 x))
-    {g : β → ∀ j : Fin n, π (i.succAbove j)} {y : ∀ j, π (i.succAbove j)} (hg : Tendsto g l (𝓝 y)) :
+    (i : Fin (n + 1)) {f : Y → π i} {l : Filter Y} {x : π i} (hf : Tendsto f l (𝓝 x))
+    {g : Y → ∀ j : Fin n, π (i.succAbove j)} {y : ∀ j, π (i.succAbove j)} (hg : Tendsto g l (𝓝 y)) :
     Tendsto (fun a => i.insertNth (f a) (g a)) l (𝓝 <| i.insertNth x y) :=
   tendsto_pi_nhds.2 fun j => Fin.succAboveCases i (by simpa) (by simpa using tendsto_pi_nhds.1 hg) j
 #align filter.tendsto.fin_insert_nth Filter.Tendsto.fin_insertNth

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -445,8 +445,8 @@ theorem Continuous.prod_map {f : Z → X} {g : δ → Y} (hf : Continuous f) (hg
 #align continuous.prod_map Continuous.prod_map
 
 /-- A version of `continuous_inf_dom_left` for binary functions -/
-theorem continuous_inf_dom_left₂ {X Y γ} {f : X → Y → γ} {ta1 ta2 : TopologicalSpace X}
-    {tb1 tb2 : TopologicalSpace Y} {tc1 : TopologicalSpace γ}
+theorem continuous_inf_dom_left₂ {X Y Z} {f : X → Y → Z} {ta1 ta2 : TopologicalSpace X}
+    {tb1 tb2 : TopologicalSpace Y} {tc1 : TopologicalSpace Z}
     (h : by haveI := ta1; haveI := tb1; exact Continuous fun p : X × Y => f p.1 p.2) : by
     haveI := ta1 ⊓ ta2; haveI := tb1 ⊓ tb2; exact Continuous fun p : X × Y => f p.1 p.2 := by
   have ha := @continuous_inf_dom_left _ _ id ta1 ta2 ta1 (@continuous_id _ (id _))
@@ -456,8 +456,8 @@ theorem continuous_inf_dom_left₂ {X Y γ} {f : X → Y → γ} {ta1 ta2 : Topo
 #align continuous_inf_dom_left₂ continuous_inf_dom_left₂
 
 /-- A version of `continuous_inf_dom_right` for binary functions -/
-theorem continuous_inf_dom_right₂ {X Y γ} {f : X → Y → γ} {ta1 ta2 : TopologicalSpace X}
-    {tb1 tb2 : TopologicalSpace Y} {tc1 : TopologicalSpace γ}
+theorem continuous_inf_dom_right₂ {X Y Z} {f : X → Y → Z} {ta1 ta2 : TopologicalSpace X}
+    {tb1 tb2 : TopologicalSpace Y} {tc1 : TopologicalSpace Z}
     (h : by haveI := ta2; haveI := tb2; exact Continuous fun p : X × Y => f p.1 p.2) : by
     haveI := ta1 ⊓ ta2; haveI := tb1 ⊓ tb2; exact Continuous fun p : X × Y => f p.1 p.2 := by
   have ha := @continuous_inf_dom_right _ _ id ta1 ta2 ta2 (@continuous_id _ (id _))
@@ -467,9 +467,9 @@ theorem continuous_inf_dom_right₂ {X Y γ} {f : X → Y → γ} {ta1 ta2 : Top
 #align continuous_inf_dom_right₂ continuous_inf_dom_right₂
 
 /-- A version of `continuous_sInf_dom` for binary functions -/
-theorem continuous_sInf_dom₂ {X Y γ} {f : X → Y → γ} {tas : Set (TopologicalSpace X)}
+theorem continuous_sInf_dom₂ {X Y Z} {f : X → Y → Z} {tas : Set (TopologicalSpace X)}
     {tbs : Set (TopologicalSpace Y)} {ta : TopologicalSpace X} {tb : TopologicalSpace Y}
-    {tc : TopologicalSpace γ} (ha : ta ∈ tas) (hb : tb ∈ tbs)
+    {tc : TopologicalSpace Z} (ha : ta ∈ tas) (hb : tb ∈ tbs)
     (hf : Continuous fun p : X × Y => f p.1 p.2) : by
     haveI := sInf tas; haveI := sInf tbs;
       exact @Continuous _ _ _ tc fun p : X × Y => f p.1 p.2 := by

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -894,7 +894,7 @@ theorem continuous_inl : Continuous (@inl X Y) := ⟨fun _ => And.left⟩
 theorem continuous_inr : Continuous (@inr X Y) := ⟨fun _ => And.right⟩
 #align continuous_inr continuous_inr
 
-theorem isOpen_sum_iff {s : Set (Sum X Y)} : IsOpen s ↔ IsOpen (inl ⁻¹' s) ∧ IsOpen (inr ⁻¹' s) :=
+theorem isOpen_sum_iff {s : Set (X ⊕ Y)} : IsOpen s ↔ IsOpen (inl ⁻¹' s) ∧ IsOpen (inr ⁻¹' s) :=
   Iff.rfl
 #align is_open_sum_iff isOpen_sum_iff
 
@@ -927,37 +927,37 @@ theorem embedding_inr : Embedding (@inr X Y) :=
   openEmbedding_inr.1
 #align embedding_inr embedding_inr
 
-theorem isOpen_range_inl : IsOpen (range (inl : X → Sum X Y)) :=
+theorem isOpen_range_inl : IsOpen (range (inl : X → X ⊕ Y)) :=
   openEmbedding_inl.2
 #align is_open_range_inl isOpen_range_inl
 
-theorem isOpen_range_inr : IsOpen (range (inr : Y → Sum X Y)) :=
+theorem isOpen_range_inr : IsOpen (range (inr : Y → X ⊕ Y)) :=
   openEmbedding_inr.2
 #align is_open_range_inr isOpen_range_inr
 
-theorem isClosed_range_inl : IsClosed (range (inl : X → Sum X Y)) := by
+theorem isClosed_range_inl : IsClosed (range (inl : X → X ⊕ Y)) := by
   rw [← isOpen_compl_iff, compl_range_inl]
   exact isOpen_range_inr
 #align is_closed_range_inl isClosed_range_inl
 
-theorem isClosed_range_inr : IsClosed (range (inr : Y → Sum X Y)) := by
+theorem isClosed_range_inr : IsClosed (range (inr : Y → X ⊕ Y)) := by
   rw [← isOpen_compl_iff, compl_range_inr]
   exact isOpen_range_inl
 #align is_closed_range_inr isClosed_range_inr
 
-theorem closedEmbedding_inl : ClosedEmbedding (inl : X → Sum X Y) :=
+theorem closedEmbedding_inl : ClosedEmbedding (inl : X → X ⊕ Y) :=
   ⟨embedding_inl, isClosed_range_inl⟩
 #align closed_embedding_inl closedEmbedding_inl
 
-theorem closedEmbedding_inr : ClosedEmbedding (inr : Y → Sum X Y) :=
+theorem closedEmbedding_inr : ClosedEmbedding (inr : Y → X ⊕ Y) :=
   ⟨embedding_inr, isClosed_range_inr⟩
 #align closed_embedding_inr closedEmbedding_inr
 
-theorem nhds_inl (x : X) : 𝓝 (inl x : Sum X Y) = map inl (𝓝 x) :=
+theorem nhds_inl (x : X) : 𝓝 (inl x : X ⊕ Y) = map inl (𝓝 x) :=
   (openEmbedding_inl.map_nhds_eq _).symm
 #align nhds_inl nhds_inl
 
-theorem nhds_inr (x : Y) : 𝓝 (inr x : Sum X Y) = map inr (𝓝 x) :=
+theorem nhds_inr (x : Y) : 𝓝 (inr x : X ⊕ Y) = map inr (𝓝 x) :=
   (openEmbedding_inr.map_nhds_eq _).symm
 #align nhds_inr nhds_inr
 
@@ -974,7 +974,7 @@ theorem Continuous.sum_map {f : X → Y} {g : Z → δ} (hf : Continuous f) (hg 
   continuous_sum_map.2 ⟨hf, hg⟩
 #align continuous.sum_map Continuous.sum_map
 
-theorem isOpenMap_sum {f : Sum X Y → Z} :
+theorem isOpenMap_sum {f : X ⊕ Y → Z} :
     IsOpenMap f ↔ (IsOpenMap fun a => f (inl a)) ∧ IsOpenMap fun b => f (inr b) := by
   simp only [isOpenMap_iff_nhds_le, Sum.forall, nhds_inl, nhds_inr, Filter.map_map, comp]
 #align is_open_map_sum isOpenMap_sum

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -62,13 +62,13 @@ instance instTopologicalSpaceSum [t₁ : TopologicalSpace X] [t₂ : Topological
     TopologicalSpace (X ⊕ Y) :=
   coinduced Sum.inl t₁ ⊔ coinduced Sum.inr t₂
 
-instance instTopologicalSpaceSigma {X : X → Type v} [t₂ : ∀ a, TopologicalSpace (X a)] :
+instance instTopologicalSpaceSigma {ι : Type*} {X : ι → Type v} [t₂ : ∀ i, TopologicalSpace (X i)] :
     TopologicalSpace (Sigma X) :=
-  ⨆ a, coinduced (Sigma.mk a) (t₂ a)
+  ⨆ i, coinduced (Sigma.mk i) (t₂ i)
 
-instance Pi.topologicalSpace {Y : X → Type v} [t₂ : (a : X) → TopologicalSpace (Y a)] :
-    TopologicalSpace ((a : X) → Y a) :=
-  ⨅ a, induced (fun f => f a) (t₂ a)
+instance Pi.topologicalSpace {ι : Type*} {Y : ι → Type v} [t₂ : (i : ι) → TopologicalSpace (Y i)] :
+    TopologicalSpace ((i : ι) → Y i) :=
+  ⨅ i, induced (fun f => f i) (t₂ i)
 #align Pi.topological_space Pi.topologicalSpace
 
 instance ULift.topologicalSpace [t : TopologicalSpace X] : TopologicalSpace (ULift.{v, u} X) :=
@@ -206,12 +206,12 @@ instance {p : X → Prop} [TopologicalSpace X] [DiscreteTopology X] : DiscreteTo
   ⟨bot_unique fun s _ => ⟨(↑) '' s, isOpen_discrete _, preimage_image_eq _ Subtype.val_injective⟩⟩
 
 instance Sum.discreteTopology [TopologicalSpace X] [TopologicalSpace Y] [h : DiscreteTopology X]
-    [hY : DiscreteTopology Y] : DiscreteTopology (Sum X Y) :=
+    [hY : DiscreteTopology Y] : DiscreteTopology (X ⊕ Y) :=
   ⟨sup_eq_bot_iff.2 <| by simp [h.eq_bot, hY.eq_bot]⟩
 #align sum.discrete_topology Sum.discreteTopology
 
-instance Sigma.discreteTopology {Y : X → Type v} [∀ a, TopologicalSpace (Y a)]
-    [h : ∀ a, DiscreteTopology (Y a)] : DiscreteTopology (Sigma Y) :=
+instance Sigma.discreteTopology {ι : Type*} {Y : ι → Type v} [∀ i, TopologicalSpace (Y i)]
+    [h : ∀ i, DiscreteTopology (Y i)] : DiscreteTopology (Sigma Y) :=
   ⟨iSup_eq_bot.2 fun _ => by simp only [(h _).eq_bot, coinduced_bot]⟩
 #align sigma.discrete_topology Sigma.discreteTopology
 

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -39,7 +39,7 @@ open Topology TopologicalSpace Set Filter Function Classical
 
 universe u v
 
-variable {X : Type u} {Y : Type v} {γ δ ε ζ : Type*}
+variable {X : Type u} {Y : Type v} {Z δ ε ζ : Type*}
 
 section Constructions
 
@@ -314,13 +314,13 @@ end Constructions
 
 section Prod
 
-variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace γ] [TopologicalSpace δ]
+variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] [TopologicalSpace δ]
   [TopologicalSpace ε] [TopologicalSpace ζ]
 
 -- porting note: todo: Lean 4 fails to deduce implicit args
-@[simp] theorem continuous_prod_mk {f : X → Y} {g : X → γ} :
+@[simp] theorem continuous_prod_mk {f : X → Y} {g : X → Z} :
     (Continuous fun x => (f x, g x)) ↔ Continuous f ∧ Continuous g :=
-  (@continuous_inf_rng X (Y × γ) _ _ (TopologicalSpace.induced Prod.fst _)
+  (@continuous_inf_rng X (Y × Z) _ _ (TopologicalSpace.induced Prod.fst _)
     (TopologicalSpace.induced Prod.snd _)).trans <|
     continuous_induced_rng.and continuous_induced_rng
 #align continuous_prod_mk continuous_prod_mk
@@ -331,12 +331,12 @@ theorem continuous_fst : Continuous (@Prod.fst X Y) :=
 #align continuous_fst continuous_fst
 
 /-- Postcomposing `f` with `Prod.fst` is continuous -/
-theorem Continuous.fst {f : X → Y × γ} (hf : Continuous f) : Continuous fun a : X => (f a).1 :=
+theorem Continuous.fst {f : X → Y × Z} (hf : Continuous f) : Continuous fun a : X => (f a).1 :=
   continuous_fst.comp hf
 #align continuous.fst Continuous.fst
 
 /-- Precomposing `f` with `Prod.fst` is continuous -/
-theorem Continuous.fst' {f : X → γ} (hf : Continuous f) : Continuous fun x : X × Y => f x.fst :=
+theorem Continuous.fst' {f : X → Z} (hf : Continuous f) : Continuous fun x : X × Y => f x.fst :=
   hf.comp continuous_fst
 #align continuous.fst' Continuous.fst'
 
@@ -345,19 +345,19 @@ theorem continuousAt_fst {p : X × Y} : ContinuousAt Prod.fst p :=
 #align continuous_at_fst continuousAt_fst
 
 /-- Postcomposing `f` with `Prod.fst` is continuous at `x` -/
-theorem ContinuousAt.fst {f : X → Y × γ} {x : X} (hf : ContinuousAt f x) :
+theorem ContinuousAt.fst {f : X → Y × Z} {x : X} (hf : ContinuousAt f x) :
     ContinuousAt (fun a : X => (f a).1) x :=
   continuousAt_fst.comp hf
 #align continuous_at.fst ContinuousAt.fst
 
 /-- Precomposing `f` with `Prod.fst` is continuous at `(x, y)` -/
-theorem ContinuousAt.fst' {f : X → γ} {x : X} {y : Y} (hf : ContinuousAt f x) :
+theorem ContinuousAt.fst' {f : X → Z} {x : X} {y : Y} (hf : ContinuousAt f x) :
     ContinuousAt (fun x : X × Y => f x.fst) (x, y) :=
   ContinuousAt.comp hf continuousAt_fst
 #align continuous_at.fst' ContinuousAt.fst'
 
 /-- Precomposing `f` with `Prod.fst` is continuous at `x : X × Y` -/
-theorem ContinuousAt.fst'' {f : X → γ} {x : X × Y} (hf : ContinuousAt f x.fst) :
+theorem ContinuousAt.fst'' {f : X → Z} {x : X × Y} (hf : ContinuousAt f x.fst) :
     ContinuousAt (fun x : X × Y => f x.fst) x :=
   hf.comp continuousAt_fst
 #align continuous_at.fst'' ContinuousAt.fst''
@@ -368,12 +368,12 @@ theorem continuous_snd : Continuous (@Prod.snd X Y) :=
 #align continuous_snd continuous_snd
 
 /-- Postcomposing `f` with `Prod.snd` is continuous -/
-theorem Continuous.snd {f : X → Y × γ} (hf : Continuous f) : Continuous fun a : X => (f a).2 :=
+theorem Continuous.snd {f : X → Y × Z} (hf : Continuous f) : Continuous fun a : X => (f a).2 :=
   continuous_snd.comp hf
 #align continuous.snd Continuous.snd
 
 /-- Precomposing `f` with `Prod.snd` is continuous -/
-theorem Continuous.snd' {f : Y → γ} (hf : Continuous f) : Continuous fun x : X × Y => f x.snd :=
+theorem Continuous.snd' {f : Y → Z} (hf : Continuous f) : Continuous fun x : X × Y => f x.snd :=
   hf.comp continuous_snd
 #align continuous.snd' Continuous.snd'
 
@@ -382,25 +382,25 @@ theorem continuousAt_snd {p : X × Y} : ContinuousAt Prod.snd p :=
 #align continuous_at_snd continuousAt_snd
 
 /-- Postcomposing `f` with `Prod.snd` is continuous at `x` -/
-theorem ContinuousAt.snd {f : X → Y × γ} {x : X} (hf : ContinuousAt f x) :
+theorem ContinuousAt.snd {f : X → Y × Z} {x : X} (hf : ContinuousAt f x) :
     ContinuousAt (fun a : X => (f a).2) x :=
   continuousAt_snd.comp hf
 #align continuous_at.snd ContinuousAt.snd
 
 /-- Precomposing `f` with `Prod.snd` is continuous at `(x, y)` -/
-theorem ContinuousAt.snd' {f : Y → γ} {x : X} {y : Y} (hf : ContinuousAt f y) :
+theorem ContinuousAt.snd' {f : Y → Z} {x : X} {y : Y} (hf : ContinuousAt f y) :
     ContinuousAt (fun x : X × Y => f x.snd) (x, y) :=
   ContinuousAt.comp hf continuousAt_snd
 #align continuous_at.snd' ContinuousAt.snd'
 
 /-- Precomposing `f` with `Prod.snd` is continuous at `x : X × Y` -/
-theorem ContinuousAt.snd'' {f : Y → γ} {x : X × Y} (hf : ContinuousAt f x.snd) :
+theorem ContinuousAt.snd'' {f : Y → Z} {x : X × Y} (hf : ContinuousAt f x.snd) :
     ContinuousAt (fun x : X × Y => f x.snd) x :=
   hf.comp continuousAt_snd
 #align continuous_at.snd'' ContinuousAt.snd''
 
 @[continuity]
-theorem Continuous.prod_mk {f : γ → X} {g : γ → Y} (hf : Continuous f) (hg : Continuous g) :
+theorem Continuous.prod_mk {f : Z → X} {g : Z → Y} (hf : Continuous f) (hg : Continuous g) :
     Continuous fun x => (f x, g x) :=
   continuous_prod_mk.2 ⟨hf, hg⟩
 #align continuous.prod_mk Continuous.prod_mk
@@ -417,30 +417,30 @@ theorem Continuous.Prod.mk_left (b : Y) : Continuous fun a : X => (a, b) :=
 
 /-- If `f x y` is continuous in `x` for all `y ∈ s`,
 then the set of `x` such that `f x` maps `s` to `t` is closed. -/
-lemma IsClosed.setOf_mapsTo {f : X → Y → γ} {s : Set Y} {t : Set γ} (ht : IsClosed t)
+lemma IsClosed.setOf_mapsTo {f : X → Y → Z} {s : Set Y} {t : Set Z} (ht : IsClosed t)
     (hf : ∀ y ∈ s, Continuous (f · y)) : IsClosed {x | MapsTo (f x) s t} := by
   simpa only [MapsTo, setOf_forall] using isClosed_biInter fun y hy ↦ ht.preimage (hf y hy)
 
-theorem Continuous.comp₂ {g : X × Y → γ} (hg : Continuous g) {e : δ → X} (he : Continuous e)
+theorem Continuous.comp₂ {g : X × Y → Z} (hg : Continuous g) {e : δ → X} (he : Continuous e)
     {f : δ → Y} (hf : Continuous f) : Continuous fun x => g (e x, f x) :=
   hg.comp <| he.prod_mk hf
 #align continuous.comp₂ Continuous.comp₂
 
-theorem Continuous.comp₃ {g : X × Y × γ → ε} (hg : Continuous g) {e : δ → X} (he : Continuous e)
-    {f : δ → Y} (hf : Continuous f) {k : δ → γ} (hk : Continuous k) :
+theorem Continuous.comp₃ {g : X × Y × Z → ε} (hg : Continuous g) {e : δ → X} (he : Continuous e)
+    {f : δ → Y} (hf : Continuous f) {k : δ → Z} (hk : Continuous k) :
     Continuous fun x => g (e x, f x, k x) :=
   hg.comp₂ he <| hf.prod_mk hk
 #align continuous.comp₃ Continuous.comp₃
 
-theorem Continuous.comp₄ {g : X × Y × γ × ζ → ε} (hg : Continuous g) {e : δ → X} (he : Continuous e)
-    {f : δ → Y} (hf : Continuous f) {k : δ → γ} (hk : Continuous k) {l : δ → ζ}
+theorem Continuous.comp₄ {g : X × Y × Z × ζ → ε} (hg : Continuous g) {e : δ → X} (he : Continuous e)
+    {f : δ → Y} (hf : Continuous f) {k : δ → Z} (hk : Continuous k) {l : δ → ζ}
     (hl : Continuous l) : Continuous fun x => g (e x, f x, k x, l x) :=
   hg.comp₃ he hf <| hk.prod_mk hl
 #align continuous.comp₄ Continuous.comp₄
 
 @[continuity]
-theorem Continuous.prod_map {f : γ → X} {g : δ → Y} (hf : Continuous f) (hg : Continuous g) :
-    Continuous fun x : γ × δ => (f x.1, g x.2) :=
+theorem Continuous.prod_map {f : Z → X} {g : δ → Y} (hf : Continuous f) (hg : Continuous g) :
+    Continuous fun x : Z × δ => (f x.1, g x.2) :=
   hf.fst'.prod_mk hg.snd'
 #align continuous.prod_map Continuous.prod_map
 
@@ -502,17 +502,17 @@ lemma isClosedMap_swap : IsClosedMap (Prod.swap : X × Y → Y × X) := fun s hs
   rw [image_swap_eq_preimage_swap]
   exact hs.preimage continuous_swap
 
-theorem continuous_uncurry_left {f : X → Y → γ} (a : X) (h : Continuous (uncurry f)) :
+theorem continuous_uncurry_left {f : X → Y → Z} (a : X) (h : Continuous (uncurry f)) :
     Continuous (f a) :=
   h.comp (Continuous.Prod.mk _)
 #align continuous_uncurry_left continuous_uncurry_left
 
-theorem continuous_uncurry_right {f : X → Y → γ} (b : Y) (h : Continuous (uncurry f)) :
+theorem continuous_uncurry_right {f : X → Y → Z} (b : Y) (h : Continuous (uncurry f)) :
     Continuous fun a => f a b :=
   h.comp (Continuous.Prod.mk_left _)
 #align continuous_uncurry_right continuous_uncurry_right
 
-theorem continuous_curry {g : X × Y → γ} (a : X) (h : Continuous g) : Continuous (curry g a) :=
+theorem continuous_curry {g : X × Y → Z} (a : X) (h : Continuous g) : Continuous (curry g a) :=
   continuous_uncurry_left a h
 #align continuous_curry continuous_curry
 
@@ -566,7 +566,7 @@ theorem mem_nhds_prod_iff' {a : X} {b : Y} {s : Set (X × Y)} :
     simp only [Prod.exists, and_comm, and_assoc, and_left_comm]
 #align mem_nhds_prod_iff' mem_nhds_prod_iff'
 
-theorem Prod.tendsto_iff {X} (seq : X → Y × γ) {f : Filter X} (x : Y × γ) :
+theorem Prod.tendsto_iff {X} (seq : X → Y × Z) {f : Filter X} (x : Y × Z) :
     Tendsto seq f (𝓝 x) ↔
       Tendsto (fun n => (seq n).fst) f (𝓝 x.fst) ∧ Tendsto (fun n => (seq n).snd) f (𝓝 x.snd) := by
   rw [nhds_prod_eq, Filter.tendsto_prod_iff']
@@ -606,17 +606,17 @@ theorem Filter.Eventually.curry_nhds {p : X × Y → Prop} {x : X} {y : Y}
   exact h.curry
 #align filter.eventually.curry_nhds Filter.Eventually.curry_nhds
 
-theorem ContinuousAt.prod {f : X → Y} {g : X → γ} {x : X} (hf : ContinuousAt f x)
+theorem ContinuousAt.prod {f : X → Y} {g : X → Z} {x : X} (hf : ContinuousAt f x)
     (hg : ContinuousAt g x) : ContinuousAt (fun x => (f x, g x)) x :=
   hf.prod_mk_nhds hg
 #align continuous_at.prod ContinuousAt.prod
 
-theorem ContinuousAt.prod_map {f : X → γ} {g : Y → δ} {p : X × Y} (hf : ContinuousAt f p.fst)
+theorem ContinuousAt.prod_map {f : X → Z} {g : Y → δ} {p : X × Y} (hf : ContinuousAt f p.fst)
     (hg : ContinuousAt g p.snd) : ContinuousAt (fun p : X × Y => (f p.1, g p.2)) p :=
   hf.fst''.prod hg.snd''
 #align continuous_at.prod_map ContinuousAt.prod_map
 
-theorem ContinuousAt.prod_map' {f : X → γ} {g : Y → δ} {x : X} {y : Y} (hf : ContinuousAt f x)
+theorem ContinuousAt.prod_map' {f : X → Z} {g : Y → δ} {x : X} {y : Y} (hf : ContinuousAt f x)
     (hg : ContinuousAt g y) : ContinuousAt (fun p : X × Y => (f p.1, g p.2)) (x, y) :=
   hf.fst'.prod hg.snd'
 #align continuous_at.prod_map' ContinuousAt.prod_map'
@@ -674,8 +674,8 @@ theorem isOpen_prod_iff {s : Set (X × Y)} :
 #align is_open_prod_iff isOpen_prod_iff
 
 /-- A product of induced topologies is induced by the product map -/
-theorem prod_induced_induced (f : X → Y) (g : γ → δ) :
-    @instTopologicalSpaceProd X γ (induced f ‹_›) (induced g ‹_›) =
+theorem prod_induced_induced (f : X → Y) (g : Z → δ) :
+    @instTopologicalSpaceProd X Z (induced f ‹_›) (induced g ‹_›) =
       induced (fun p => (f p.1, g p.2)) instTopologicalSpaceProd := by
   delta instTopologicalSpaceProd
   simp_rw [induced_inf, induced_compose]
@@ -780,7 +780,7 @@ theorem frontier_univ_prod_eq (s : Set Y) :
   simp [frontier_prod_eq]
 #align frontier_univ_prod_eq frontier_univ_prod_eq
 
-theorem map_mem_closure₂ {f : X → Y → γ} {a : X} {b : Y} {s : Set X} {t : Set Y} {u : Set γ}
+theorem map_mem_closure₂ {f : X → Y → Z} {a : X} {b : Y} {s : Set X} {t : Set Y} {u : Set Z}
     (hf : Continuous (uncurry f)) (ha : a ∈ closure s) (hb : b ∈ closure t)
     (h : ∀ a ∈ s, ∀ b ∈ t, f a b ∈ u) : f a b ∈ closure u :=
   have H₁ : (a, b) ∈ closure (s ×ˢ t) := by simpa only [closure_prod_eq] using mk_mem_prod ha hb
@@ -801,45 +801,45 @@ theorem Dense.prod {s : Set X} {t : Set Y} (hs : Dense s) (ht : Dense t) : Dense
 #align dense.prod Dense.prod
 
 /-- If `f` and `g` are maps with dense range, then `Prod.map f g` has dense range. -/
-theorem DenseRange.prod_map {ι : Type*} {κ : Type*} {f : ι → Y} {g : κ → γ} (hf : DenseRange f)
+theorem DenseRange.prod_map {ι : Type*} {κ : Type*} {f : ι → Y} {g : κ → Z} (hf : DenseRange f)
     (hg : DenseRange g) : DenseRange (Prod.map f g) := by
   simpa only [DenseRange, prod_range_range_eq] using hf.prod hg
 #align dense_range.prod_map DenseRange.prod_map
 
-theorem Inducing.prod_map {f : X → Y} {g : γ → δ} (hf : Inducing f) (hg : Inducing g) :
+theorem Inducing.prod_map {f : X → Y} {g : Z → δ} (hf : Inducing f) (hg : Inducing g) :
     Inducing (Prod.map f g) :=
   inducing_iff_nhds.2 fun (a, b) => by simp_rw [Prod.map_def, nhds_prod_eq, hf.nhds_eq_comap,
     hg.nhds_eq_comap, prod_comap_comap_eq]
 #align inducing.prod_mk Inducing.prod_map
 
 @[simp]
-theorem inducing_const_prod {a : X} {f : Y → γ} : (Inducing fun x => (a, f x)) ↔ Inducing f := by
+theorem inducing_const_prod {a : X} {f : Y → Z} : (Inducing fun x => (a, f x)) ↔ Inducing f := by
   simp_rw [inducing_iff, instTopologicalSpaceProd, induced_inf, induced_compose, Function.comp,
     induced_const, top_inf_eq]
 #align inducing_const_prod inducing_const_prod
 
 @[simp]
-theorem inducing_prod_const {b : Y} {f : X → γ} : (Inducing fun x => (f x, b)) ↔ Inducing f := by
+theorem inducing_prod_const {b : Y} {f : X → Z} : (Inducing fun x => (f x, b)) ↔ Inducing f := by
   simp_rw [inducing_iff, instTopologicalSpaceProd, induced_inf, induced_compose, Function.comp,
     induced_const, inf_top_eq]
 #align inducing_prod_const inducing_prod_const
 
-theorem Embedding.prod_map {f : X → Y} {g : γ → δ} (hf : Embedding f) (hg : Embedding g) :
+theorem Embedding.prod_map {f : X → Y} {g : Z → δ} (hf : Embedding f) (hg : Embedding g) :
     Embedding (Prod.map f g) :=
   { hf.toInducing.prod_map hg.toInducing with
     inj := fun ⟨x₁, x₂⟩ ⟨y₁, y₂⟩ => by simp [hf.inj.eq_iff, hg.inj.eq_iff] }
 #align embedding.prod_mk Embedding.prod_map
 
-protected theorem IsOpenMap.prod {f : X → Y} {g : γ → δ} (hf : IsOpenMap f) (hg : IsOpenMap g) :
-    IsOpenMap fun p : X × γ => (f p.1, g p.2) := by
+protected theorem IsOpenMap.prod {f : X → Y} {g : Z → δ} (hf : IsOpenMap f) (hg : IsOpenMap g) :
+    IsOpenMap fun p : X × Z => (f p.1, g p.2) := by
   rw [isOpenMap_iff_nhds_le]
   rintro ⟨a, b⟩
   rw [nhds_prod_eq, nhds_prod_eq, ← Filter.prod_map_map_eq]
   exact Filter.prod_mono (hf.nhds_le a) (hg.nhds_le b)
 #align is_open_map.prod IsOpenMap.prod
 
-protected theorem OpenEmbedding.prod {f : X → Y} {g : γ → δ} (hf : OpenEmbedding f)
-    (hg : OpenEmbedding g) : OpenEmbedding fun x : X × γ => (f x.1, g x.2) :=
+protected theorem OpenEmbedding.prod {f : X → Y} {g : Z → δ} (hf : OpenEmbedding f)
+    (hg : OpenEmbedding g) : OpenEmbedding fun x : X × Z => (f x.1, g x.2) :=
   openEmbedding_of_embedding_open (hf.1.prod_map hg.1) (hf.isOpenMap.prod hg.isOpenMap)
 #align open_embedding.prod OpenEmbedding.prod
 
@@ -856,22 +856,22 @@ section Sum
 
 open Sum
 
-variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace γ] [TopologicalSpace δ]
+variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] [TopologicalSpace δ]
 
-theorem continuous_sum_dom {f : X ⊕ Y → γ} :
+theorem continuous_sum_dom {f : X ⊕ Y → Z} :
     Continuous f ↔ Continuous (f ∘ Sum.inl) ∧ Continuous (f ∘ Sum.inr) :=
   (continuous_sup_dom (t₁ := TopologicalSpace.coinduced Sum.inl _)
     (t₂ := TopologicalSpace.coinduced Sum.inr _)).trans <|
     continuous_coinduced_dom.and continuous_coinduced_dom
 #align continuous_sum_dom continuous_sum_dom
 
-theorem continuous_sum_elim {f : X → γ} {g : Y → γ} :
+theorem continuous_sum_elim {f : X → Z} {g : Y → Z} :
     Continuous (Sum.elim f g) ↔ Continuous f ∧ Continuous g :=
   continuous_sum_dom
 #align continuous_sum_elim continuous_sum_elim
 
 @[continuity]
-theorem Continuous.sum_elim {f : X → γ} {g : Y → γ} (hf : Continuous f) (hg : Continuous g) :
+theorem Continuous.sum_elim {f : X → Z} {g : Y → Z} (hf : Continuous f) (hg : Continuous g) :
     Continuous (Sum.elim f g) :=
   continuous_sum_elim.2 ⟨hf, hg⟩
 #align continuous.sum_elim Continuous.sum_elim
@@ -962,30 +962,30 @@ theorem nhds_inr (x : Y) : 𝓝 (inr x : Sum X Y) = map inr (𝓝 x) :=
 #align nhds_inr nhds_inr
 
 @[simp]
-theorem continuous_sum_map {f : X → Y} {g : γ → δ} :
+theorem continuous_sum_map {f : X → Y} {g : Z → δ} :
     Continuous (Sum.map f g) ↔ Continuous f ∧ Continuous g :=
   continuous_sum_elim.trans <|
     embedding_inl.continuous_iff.symm.and embedding_inr.continuous_iff.symm
 #align continuous_sum_map continuous_sum_map
 
 @[continuity]
-theorem Continuous.sum_map {f : X → Y} {g : γ → δ} (hf : Continuous f) (hg : Continuous g) :
+theorem Continuous.sum_map {f : X → Y} {g : Z → δ} (hf : Continuous f) (hg : Continuous g) :
     Continuous (Sum.map f g) :=
   continuous_sum_map.2 ⟨hf, hg⟩
 #align continuous.sum_map Continuous.sum_map
 
-theorem isOpenMap_sum {f : Sum X Y → γ} :
+theorem isOpenMap_sum {f : Sum X Y → Z} :
     IsOpenMap f ↔ (IsOpenMap fun a => f (inl a)) ∧ IsOpenMap fun b => f (inr b) := by
   simp only [isOpenMap_iff_nhds_le, Sum.forall, nhds_inl, nhds_inr, Filter.map_map, comp]
 #align is_open_map_sum isOpenMap_sum
 
 @[simp]
-theorem isOpenMap_sum_elim {f : X → γ} {g : Y → γ} :
+theorem isOpenMap_sum_elim {f : X → Z} {g : Y → Z} :
     IsOpenMap (Sum.elim f g) ↔ IsOpenMap f ∧ IsOpenMap g := by
   simp only [isOpenMap_sum, elim_inl, elim_inr]
 #align is_open_map_sum_elim isOpenMap_sum_elim
 
-theorem IsOpenMap.sum_elim {f : X → γ} {g : Y → γ} (hf : IsOpenMap f) (hg : IsOpenMap g) :
+theorem IsOpenMap.sum_elim {f : X → Z} {g : Y → Z} (hf : IsOpenMap f) (hg : IsOpenMap g) :
     IsOpenMap (Sum.elim f g) :=
   isOpenMap_sum_elim.2 ⟨hf, hg⟩
 #align is_open_map.sum_elim IsOpenMap.sum_elim
@@ -994,7 +994,7 @@ end Sum
 
 section Subtype
 
-variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace γ] {p : X → Prop}
+variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] {p : X → Prop}
 
 theorem inducing_subtype_val {b : Set Y} : Inducing ((↑) : b → Y) := ⟨rfl⟩
 #align inducing_coe inducing_subtype_val
@@ -1162,7 +1162,7 @@ end Subtype
 
 section Quotient
 
-variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace γ]
+variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z]
 
 variable {r : X → X → Prop} {s : Setoid X}
 

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1692,15 +1692,15 @@ end ULift
 
 section Monad
 
-variable [TopologicalSpace X] {s : Set X} {γ : Set s}
+variable [TopologicalSpace X] {s : Set X} {t : Set s}
 
-theorem IsOpen.trans (hγ : IsOpen γ) (hs : IsOpen s) : IsOpen (γ : Set X) := by
-  rcases isOpen_induced_iff.mp hγ with ⟨δ, hδ, rfl⟩
+theorem IsOpen.trans (ht : IsOpen t) (hs : IsOpen s) : IsOpen (t : Set X) := by
+  rcases isOpen_induced_iff.mp ht with ⟨δ, hδ, rfl⟩
   rw [Subtype.image_preimage_coe]
   exact IsOpen.inter hδ hs
 
-theorem IsClosed.trans (hγ : IsClosed γ) (hs : IsClosed s) : IsClosed (γ : Set X) := by
-  rcases isClosed_induced_iff.mp hγ with ⟨δ, hδ, rfl⟩
+theorem IsClosed.trans (ht : IsClosed t) (hs : IsClosed s) : IsClosed (t : Set X) := by
+  rcases isClosed_induced_iff.mp ht with ⟨δ, hδ, rfl⟩
   rw [Subtype.image_preimage_coe]
   convert IsClosed.inter hδ hs
 

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1263,8 +1263,8 @@ theorem Pi.continuous_precomp {ι' : Type*} (φ : ι' → ι) :
     Continuous (· ∘ φ : (ι → X) → (ι' → X)) :=
   Pi.continuous_precomp' φ
 
-theorem Pi.continuous_postcomp' {ρ : ι → Type*} [∀ i, TopologicalSpace (ρ i)]
-    {g : ∀ i, π i → ρ i} (hg : ∀ i, Continuous (g i)) :
+theorem Pi.continuous_postcomp' {X : ι → Type*} [∀ i, TopologicalSpace (X i)]
+    {g : ∀ i, π i → X i} (hg : ∀ i, Continuous (g i)) :
     Continuous (fun (f : (∀ i, π i)) (i : ι) ↦ g i (f i)) :=
   continuous_pi fun i ↦ (hg i).comp <| continuous_apply i
 

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -129,16 +129,16 @@ theorem isClosedMap_ofAdd : IsClosedMap (ofAdd : X → Multiplicative X) := IsCl
 theorem isClosedMap_toAdd : IsClosedMap (toAdd : Multiplicative X → X) := IsClosedMap.id
 #align is_closed_map_to_add isClosedMap_toAdd
 
-theorem nhds_ofMul (a : X) : 𝓝 (ofMul a) = map ofMul (𝓝 a) := rfl
+theorem nhds_ofMul (x : X) : 𝓝 (ofMul x) = map ofMul (𝓝 x) := rfl
 #align nhds_of_mul nhds_ofMul
 
-theorem nhds_ofAdd (a : X) : 𝓝 (ofAdd a) = map ofAdd (𝓝 a) := rfl
+theorem nhds_ofAdd (x : X) : 𝓝 (ofAdd x) = map ofAdd (𝓝 x) := rfl
 #align nhds_of_add nhds_ofAdd
 
-theorem nhds_toMul (a : Additive X) : 𝓝 (toMul a) = map toMul (𝓝 a) := rfl
+theorem nhds_toMul (x : Additive X) : 𝓝 (toMul x) = map toMul (𝓝 x) := rfl
 #align nhds_to_mul nhds_toMul
 
-theorem nhds_toAdd (a : Multiplicative X) : 𝓝 (toAdd a) = map toAdd (𝓝 a) := rfl
+theorem nhds_toAdd (x : Multiplicative X) : 𝓝 (toAdd x) = map toAdd (𝓝 x) := rfl
 #align nhds_to_add nhds_toAdd
 
 end
@@ -177,16 +177,16 @@ theorem isClosedMap_toDual : IsClosedMap (toDual : X → Xᵒᵈ) := IsClosedMap
 theorem isClosedMap_ofDual : IsClosedMap (ofDual : Xᵒᵈ → X) := IsClosedMap.id
 #align is_closed_map_of_dual isClosedMap_ofDual
 
-theorem nhds_toDual (a : X) : 𝓝 (toDual a) = map toDual (𝓝 a) := rfl
+theorem nhds_toDual (x : X) : 𝓝 (toDual x) = map toDual (𝓝 x) := rfl
 #align nhds_to_dual nhds_toDual
 
-theorem nhds_ofDual (a : X) : 𝓝 (ofDual a) = map ofDual (𝓝 a) := rfl
+theorem nhds_ofDual (x : X) : 𝓝 (ofDual x) = map ofDual (𝓝 x) := rfl
 #align nhds_of_dual nhds_ofDual
 
 end
 
 theorem Quotient.preimage_mem_nhds [TopologicalSpace X] [s : Setoid X] {V : Set <| Quotient s}
-    {a : X} (hs : V ∈ 𝓝 (Quotient.mk' a)) : Quotient.mk' ⁻¹' V ∈ 𝓝 a :=
+    {x : X} (hs : V ∈ 𝓝 (Quotient.mk' x)) : Quotient.mk' ⁻¹' V ∈ 𝓝 x :=
   preimage_nhds_coinduced hs
 #align quotient.preimage_mem_nhds Quotient.preimage_mem_nhds
 
@@ -222,13 +222,13 @@ variable [TopologicalSpace X]
 /-
 The 𝓝 filter and the subspace topology.
 -/
-theorem mem_nhds_subtype (s : Set X) (a : { x // x ∈ s }) (t : Set { x // x ∈ s }) :
-    t ∈ 𝓝 a ↔ ∃ u ∈ 𝓝 (a : X), Subtype.val ⁻¹' u ⊆ t :=
-  mem_nhds_induced _ a t
+theorem mem_nhds_subtype (s : Set X) (x : { x // x ∈ s }) (t : Set { x // x ∈ s }) :
+    t ∈ 𝓝 x ↔ ∃ u ∈ 𝓝 (x : X), Subtype.val ⁻¹' u ⊆ t :=
+  mem_nhds_induced _ x t
 #align mem_nhds_subtype mem_nhds_subtype
 
-theorem nhds_subtype (s : Set X) (a : { x // x ∈ s }) : 𝓝 a = comap (↑) (𝓝 (a : X)) :=
-  nhds_induced _ a
+theorem nhds_subtype (s : Set X) (x : { x // x ∈ s }) : 𝓝 x = comap (↑) (𝓝 (x : X)) :=
+  nhds_induced _ x
 #align nhds_subtype nhds_subtype
 
 theorem nhdsWithin_subtype_eq_bot_iff {s t : Set X} {x : s} :
@@ -294,18 +294,18 @@ theorem isClosed_iff {s : Set (CofiniteTopology X)} : IsClosed s ↔ s = univ �
   simp only [← isOpen_compl_iff, isOpen_iff', compl_compl, compl_empty_iff]
 #align cofinite_topology.is_closed_iff CofiniteTopology.isClosed_iff
 
-theorem nhds_eq (a : CofiniteTopology X) : 𝓝 a = pure a ⊔ cofinite := by
+theorem nhds_eq (x : CofiniteTopology X) : 𝓝 x = pure x ⊔ cofinite := by
   ext U
   rw [mem_nhds_iff]
   constructor
   · rintro ⟨V, hVU, V_op, haV⟩
     exact mem_sup.mpr ⟨hVU haV, mem_of_superset (V_op ⟨_, haV⟩) hVU⟩
-  · rintro ⟨hU : a ∈ U, hU' : Uᶜ.Finite⟩
+  · rintro ⟨hU : x ∈ U, hU' : Uᶜ.Finite⟩
     exact ⟨U, Subset.rfl, fun _ => hU', hU⟩
 #align cofinite_topology.nhds_eq CofiniteTopology.nhds_eq
 
-theorem mem_nhds_iff {a : CofiniteTopology X} {s : Set (CofiniteTopology X)} :
-    s ∈ 𝓝 a ↔ a ∈ s ∧ sᶜ.Finite := by simp [nhds_eq]
+theorem mem_nhds_iff {x : CofiniteTopology X} {s : Set (CofiniteTopology X)} :
+    s ∈ 𝓝 x ↔ x ∈ s ∧ sᶜ.Finite := by simp [nhds_eq]
 #align cofinite_topology.mem_nhds_iff CofiniteTopology.mem_nhds_iff
 
 end CofiniteTopology
@@ -331,7 +331,7 @@ theorem continuous_fst : Continuous (@Prod.fst X Y) :=
 #align continuous_fst continuous_fst
 
 /-- Postcomposing `f` with `Prod.fst` is continuous -/
-theorem Continuous.fst {f : X → Y × Z} (hf : Continuous f) : Continuous fun a : X => (f a).1 :=
+theorem Continuous.fst {f : X → Y × Z} (hf : Continuous f) : Continuous fun x : X => (f x).1 :=
   continuous_fst.comp hf
 #align continuous.fst Continuous.fst
 
@@ -346,7 +346,7 @@ theorem continuousAt_fst {p : X × Y} : ContinuousAt Prod.fst p :=
 
 /-- Postcomposing `f` with `Prod.fst` is continuous at `x` -/
 theorem ContinuousAt.fst {f : X → Y × Z} {x : X} (hf : ContinuousAt f x) :
-    ContinuousAt (fun a : X => (f a).1) x :=
+    ContinuousAt (fun x : X => (f x).1) x :=
   continuousAt_fst.comp hf
 #align continuous_at.fst ContinuousAt.fst
 
@@ -368,7 +368,7 @@ theorem continuous_snd : Continuous (@Prod.snd X Y) :=
 #align continuous_snd continuous_snd
 
 /-- Postcomposing `f` with `Prod.snd` is continuous -/
-theorem Continuous.snd {f : X → Y × Z} (hf : Continuous f) : Continuous fun a : X => (f a).2 :=
+theorem Continuous.snd {f : X → Y × Z} (hf : Continuous f) : Continuous fun x : X => (f x).2 :=
   continuous_snd.comp hf
 #align continuous.snd Continuous.snd
 
@@ -383,7 +383,7 @@ theorem continuousAt_snd {p : X × Y} : ContinuousAt Prod.snd p :=
 
 /-- Postcomposing `f` with `Prod.snd` is continuous at `x` -/
 theorem ContinuousAt.snd {f : X → Y × Z} {x : X} (hf : ContinuousAt f x) :
-    ContinuousAt (fun a : X => (f a).2) x :=
+    ContinuousAt (fun x : X => (f x).2) x :=
   continuousAt_snd.comp hf
 #align continuous_at.snd ContinuousAt.snd
 
@@ -406,12 +406,12 @@ theorem Continuous.prod_mk {f : Z → X} {g : Z → Y} (hf : Continuous f) (hg :
 #align continuous.prod_mk Continuous.prod_mk
 
 @[continuity]
-theorem Continuous.Prod.mk (a : X) : Continuous fun b : Y => (a, b) :=
+theorem Continuous.Prod.mk (x : X) : Continuous fun y : Y => (x, y) :=
   continuous_const.prod_mk continuous_id
 #align continuous.prod.mk Continuous.Prod.mk
 
 @[continuity]
-theorem Continuous.Prod.mk_left (b : Y) : Continuous fun a : X => (a, b) :=
+theorem Continuous.Prod.mk_left (y : Y) : Continuous fun x : X => (x, y) :=
   continuous_id.prod_mk continuous_const
 #align continuous.prod.mk_left Continuous.Prod.mk_left
 
@@ -440,7 +440,7 @@ theorem Continuous.comp₄ {g : X × Y × Z × ζ → ε} (hg : Continuous g) {e
 
 @[continuity]
 theorem Continuous.prod_map {f : Z → X} {g : W → Y} (hf : Continuous f) (hg : Continuous g) :
-    Continuous fun a : Z × W => (f a.1, g a.2) :=
+    Continuous fun p : Z × W => (f p.1, g p.2) :=
   hf.fst'.prod_mk hg.snd'
 #align continuous.prod_map Continuous.prod_map
 
@@ -468,30 +468,30 @@ theorem continuous_inf_dom_right₂ {X Y Z} {f : X → Y → Z} {ta1 ta2 : Topol
 
 /-- A version of `continuous_sInf_dom` for binary functions -/
 theorem continuous_sInf_dom₂ {X Y Z} {f : X → Y → Z} {tas : Set (TopologicalSpace X)}
-    {tbs : Set (TopologicalSpace Y)} {ta : TopologicalSpace X} {tb : TopologicalSpace Y}
-    {tc : TopologicalSpace Z} (ha : ta ∈ tas) (hb : tb ∈ tbs)
+    {tbs : Set (TopologicalSpace Y)} {tX : TopologicalSpace X} {tY : TopologicalSpace Y}
+    {tc : TopologicalSpace Z} (hX : tX ∈ tas) (hY : tY ∈ tbs)
     (hf : Continuous fun p : X × Y => f p.1 p.2) : by
     haveI := sInf tas; haveI := sInf tbs;
       exact @Continuous _ _ _ tc fun p : X × Y => f p.1 p.2 := by
-  have ha := continuous_sInf_dom ha continuous_id
-  have hb := continuous_sInf_dom hb continuous_id
-  have h_continuous_id := @Continuous.prod_map _ _ _ _ ta tb (sInf tas) (sInf tbs) _ _ ha hb
+  have hX := continuous_sInf_dom hX continuous_id
+  have hY := continuous_sInf_dom hY continuous_id
+  have h_continuous_id := @Continuous.prod_map _ _ _ _ tX tY (sInf tas) (sInf tbs) _ _ hX hY
   exact @Continuous.comp _ _ _ (id _) (id _) _ _ _ hf h_continuous_id
 #align continuous_Inf_dom₂ continuous_sInf_dom₂
 
-theorem Filter.Eventually.prod_inl_nhds {p : X → Prop} {a : X} (h : ∀ᶠ x in 𝓝 a, p x) (b : Y) :
-    ∀ᶠ x in 𝓝 (a, b), p (x : X × Y).1 :=
+theorem Filter.Eventually.prod_inl_nhds {p : X → Prop} {x : X} (h : ∀ᶠ x in 𝓝 x, p x) (y : Y) :
+    ∀ᶠ x in 𝓝 (x, y), p (x : X × Y).1 :=
   continuousAt_fst h
 #align filter.eventually.prod_inl_nhds Filter.Eventually.prod_inl_nhds
 
-theorem Filter.Eventually.prod_inr_nhds {p : Y → Prop} {b : Y} (h : ∀ᶠ x in 𝓝 b, p x) (a : X) :
-    ∀ᶠ x in 𝓝 (a, b), p (x : X × Y).2 :=
+theorem Filter.Eventually.prod_inr_nhds {p : Y → Prop} {y : Y} (h : ∀ᶠ x in 𝓝 y, p x) (x : X) :
+    ∀ᶠ x in 𝓝 (x, y), p (x : X × Y).2 :=
   continuousAt_snd h
 #align filter.eventually.prod_inr_nhds Filter.Eventually.prod_inr_nhds
 
-theorem Filter.Eventually.prod_mk_nhds {pa : X → Prop} {a} (ha : ∀ᶠ x in 𝓝 a, pa x) {pb : Y → Prop}
-    {b} (hb : ∀ᶠ y in 𝓝 b, pb y) : ∀ᶠ p in 𝓝 (a, b), pa (p : X × Y).1 ∧ pb p.2 :=
-  (ha.prod_inl_nhds b).and (hb.prod_inr_nhds a)
+theorem Filter.Eventually.prod_mk_nhds {px : X → Prop} {x} (hx : ∀ᶠ x in 𝓝 x, px x) {py : Y → Prop}
+    {y} (hy : ∀ᶠ y in 𝓝 y, py y) : ∀ᶠ p in 𝓝 (x, y), px (p : X × Y).1 ∧ py p.2 :=
+  (hx.prod_inl_nhds y).and (hy.prod_inr_nhds x)
 #align filter.eventually.prod_mk_nhds Filter.Eventually.prod_mk_nhds
 
 theorem continuous_swap : Continuous (Prod.swap : X × Y → Y × X) :=
@@ -502,18 +502,18 @@ lemma isClosedMap_swap : IsClosedMap (Prod.swap : X × Y → Y × X) := fun s hs
   rw [image_swap_eq_preimage_swap]
   exact hs.preimage continuous_swap
 
-theorem continuous_uncurry_left {f : X → Y → Z} (a : X) (h : Continuous (uncurry f)) :
-    Continuous (f a) :=
+theorem continuous_uncurry_left {f : X → Y → Z} (x : X) (h : Continuous (uncurry f)) :
+    Continuous (f x) :=
   h.comp (Continuous.Prod.mk _)
 #align continuous_uncurry_left continuous_uncurry_left
 
-theorem continuous_uncurry_right {f : X → Y → Z} (b : Y) (h : Continuous (uncurry f)) :
-    Continuous fun a => f a b :=
+theorem continuous_uncurry_right {f : X → Y → Z} (y : Y) (h : Continuous (uncurry f)) :
+    Continuous fun a => f a y :=
   h.comp (Continuous.Prod.mk_left _)
 #align continuous_uncurry_right continuous_uncurry_right
 
-theorem continuous_curry {g : X × Y → Z} (a : X) (h : Continuous g) : Continuous (curry g a) :=
-  continuous_uncurry_left a h
+theorem continuous_curry {g : X × Y → Z} (x : X) (h : Continuous g) : Continuous (curry g x) :=
+  continuous_uncurry_left x h
 #align continuous_curry continuous_curry
 
 theorem IsOpen.prod {s : Set X} {t : Set Y} (hs : IsOpen s) (ht : IsOpen t) : IsOpen (s ×ˢ t) :=
@@ -521,54 +521,54 @@ theorem IsOpen.prod {s : Set X} {t : Set Y} (hs : IsOpen s) (ht : IsOpen t) : Is
 #align is_open.prod IsOpen.prod
 
 -- porting note: todo: Lean fails to find `t₁` and `t₂` by unification
-theorem nhds_prod_eq {a : X} {b : Y} : 𝓝 (a, b) = 𝓝 a ×ˢ 𝓝 b := by
+theorem nhds_prod_eq {x : X} {y : Y} : 𝓝 (x, y) = 𝓝 x ×ˢ 𝓝 y := by
   dsimp only [SProd.sprod]
   rw [Filter.prod, instTopologicalSpaceProd, nhds_inf (t₁ := TopologicalSpace.induced Prod.fst _)
     (t₂ := TopologicalSpace.induced Prod.snd _), nhds_induced, nhds_induced]
 #align nhds_prod_eq nhds_prod_eq
 
 -- porting note: moved from `topology.continuous_on`
-theorem nhdsWithin_prod_eq (a : X) (b : Y) (s : Set X) (t : Set Y) :
-    𝓝[s ×ˢ t] (a, b) = 𝓝[s] a ×ˢ 𝓝[t] b := by
+theorem nhdsWithin_prod_eq (x : X) (y : Y) (s : Set X) (t : Set Y) :
+    𝓝[s ×ˢ t] (x, y) = 𝓝[s] x ×ˢ 𝓝[t] y := by
   simp only [nhdsWithin, nhds_prod_eq, ← prod_inf_prod, prod_principal_principal]
 #align nhds_within_prod_eq nhdsWithin_prod_eq
 
 #noalign continuous_uncurry_of_discrete_topology
 
-theorem mem_nhds_prod_iff {a : X} {b : Y} {s : Set (X × Y)} :
-    s ∈ 𝓝 (a, b) ↔ ∃ u ∈ 𝓝 a, ∃ v ∈ 𝓝 b, u ×ˢ v ⊆ s := by rw [nhds_prod_eq, mem_prod_iff]
+theorem mem_nhds_prod_iff {x : X} {y : Y} {s : Set (X × Y)} :
+    s ∈ 𝓝 (x, y) ↔ ∃ u ∈ 𝓝 x, ∃ v ∈ 𝓝 y, u ×ˢ v ⊆ s := by rw [nhds_prod_eq, mem_prod_iff]
 #align mem_nhds_prod_iff mem_nhds_prod_iff
 
-theorem mem_nhdsWithin_prod_iff {a : X} {b : Y} {s : Set (X × Y)} {ta : Set X} {tb : Set Y} :
-    s ∈ 𝓝[ta ×ˢ tb] (a, b) ↔ ∃ u ∈ 𝓝[ta] a, ∃ v ∈ 𝓝[tb] b, u ×ˢ v ⊆ s := by
+theorem mem_nhdsWithin_prod_iff {x : X} {y : Y} {s : Set (X × Y)} {tx : Set X} {ty : Set Y} :
+    s ∈ 𝓝[tx ×ˢ ty] (x, y) ↔ ∃ u ∈ 𝓝[tx] x, ∃ v ∈ 𝓝[ty] y, u ×ˢ v ⊆ s := by
   rw [nhdsWithin_prod_eq, mem_prod_iff]
 
 -- porting note: moved up
-theorem Filter.HasBasis.prod_nhds {ιa ιb : Type*} {pa : ιa → Prop} {pb : ιb → Prop}
-    {sa : ιa → Set X} {sb : ιb → Set Y} {a : X} {b : Y} (ha : (𝓝 a).HasBasis pa sa)
-    (hb : (𝓝 b).HasBasis pb sb) :
-    (𝓝 (a, b)).HasBasis (fun i : ιa × ιb => pa i.1 ∧ pb i.2) fun i => sa i.1 ×ˢ sb i.2 := by
+theorem Filter.HasBasis.prod_nhds {ιX ιY : Type*} {px : ιX → Prop} {py : ιY → Prop}
+    {sx : ιX → Set X} {sy : ιY → Set Y} {x : X} {y : Y} (hx : (𝓝 x).HasBasis px sx)
+    (hy : (𝓝 y).HasBasis py sy) :
+    (𝓝 (x, y)).HasBasis (fun i : ιX × ιY => px i.1 ∧ py i.2) fun i => sx i.1 ×ˢ sy i.2 := by
   rw [nhds_prod_eq]
-  exact ha.prod hb
+  exact hx.prod hy
 #align filter.has_basis.prod_nhds Filter.HasBasis.prod_nhds
 
 -- porting note: moved up
-theorem Filter.HasBasis.prod_nhds' {ιa ιb : Type*} {pa : ιa → Prop} {pb : ιb → Prop}
-    {sa : ιa → Set X} {sb : ιb → Set Y} {ab : X × Y} (ha : (𝓝 ab.1).HasBasis pa sa)
-    (hb : (𝓝 ab.2).HasBasis pb sb) :
-    (𝓝 ab).HasBasis (fun i : ιa × ιb => pa i.1 ∧ pb i.2) fun i => sa i.1 ×ˢ sb i.2 :=
-  ha.prod_nhds hb
+theorem Filter.HasBasis.prod_nhds' {ιX ιY : Type*} {pX : ιX → Prop} {pY : ιY → Prop}
+    {sx : ιX → Set X} {sy : ιY → Set Y} {p : X × Y} (hx : (𝓝 p.1).HasBasis pX sx)
+    (hy : (𝓝 p.2).HasBasis pY sy) :
+    (𝓝 p).HasBasis (fun i : ιX × ιY => pX i.1 ∧ pY i.2) fun i => sx i.1 ×ˢ sy i.2 :=
+  hx.prod_nhds hy
 #align filter.has_basis.prod_nhds' Filter.HasBasis.prod_nhds'
 
-theorem mem_nhds_prod_iff' {a : X} {b : Y} {s : Set (X × Y)} :
-    s ∈ 𝓝 (a, b) ↔ ∃ u v, IsOpen u ∧ a ∈ u ∧ IsOpen v ∧ b ∈ v ∧ u ×ˢ v ⊆ s :=
-  ((nhds_basis_opens a).prod_nhds (nhds_basis_opens b)).mem_iff.trans <| by
+theorem mem_nhds_prod_iff' {x : X} {y : Y} {s : Set (X × Y)} :
+    s ∈ 𝓝 (x, y) ↔ ∃ u v, IsOpen u ∧ x ∈ u ∧ IsOpen v ∧ y ∈ v ∧ u ×ˢ v ⊆ s :=
+  ((nhds_basis_opens x).prod_nhds (nhds_basis_opens y)).mem_iff.trans <| by
     simp only [Prod.exists, and_comm, and_assoc, and_left_comm]
 #align mem_nhds_prod_iff' mem_nhds_prod_iff'
 
-theorem Prod.tendsto_iff {X} (seq : X → Y × Z) {f : Filter X} (x : Y × Z) :
-    Tendsto seq f (𝓝 x) ↔
-      Tendsto (fun n => (seq n).fst) f (𝓝 x.fst) ∧ Tendsto (fun n => (seq n).snd) f (𝓝 x.snd) := by
+theorem Prod.tendsto_iff {X} (seq : X → Y × Z) {f : Filter X} (p : Y × Z) :
+    Tendsto seq f (𝓝 p) ↔
+      Tendsto (fun n => (seq n).fst) f (𝓝 p.fst) ∧ Tendsto (fun n => (seq n).snd) f (𝓝 p.snd) := by
   rw [nhds_prod_eq, Filter.tendsto_prod_iff']
 #align prod.tendsto_iff Prod.tendsto_iff
 
@@ -576,28 +576,28 @@ instance [DiscreteTopology X] [DiscreteTopology Y] : DiscreteTopology (X × Y) :
   discreteTopology_iff_nhds.2 fun (a, b) => by
     rw [nhds_prod_eq, nhds_discrete X, nhds_discrete Y, prod_pure_pure]
 
-theorem prod_mem_nhds_iff {s : Set X} {t : Set Y} {a : X} {b : Y} :
-    s ×ˢ t ∈ 𝓝 (a, b) ↔ s ∈ 𝓝 a ∧ t ∈ 𝓝 b := by rw [nhds_prod_eq, prod_mem_prod_iff]
+theorem prod_mem_nhds_iff {s : Set X} {t : Set Y} {x : X} {y : Y} :
+    s ×ˢ t ∈ 𝓝 (x, y) ↔ s ∈ 𝓝 x ∧ t ∈ 𝓝 y := by rw [nhds_prod_eq, prod_mem_prod_iff]
 #align prod_mem_nhds_iff prod_mem_nhds_iff
 
-theorem prod_mem_nhds {s : Set X} {t : Set Y} {a : X} {b : Y} (ha : s ∈ 𝓝 a) (hb : t ∈ 𝓝 b) :
-    s ×ˢ t ∈ 𝓝 (a, b) :=
-  prod_mem_nhds_iff.2 ⟨ha, hb⟩
+theorem prod_mem_nhds {s : Set X} {t : Set Y} {x : X} {y : Y} (hx : s ∈ 𝓝 x) (hy : t ∈ 𝓝 y) :
+    s ×ˢ t ∈ 𝓝 (x, y) :=
+  prod_mem_nhds_iff.2 ⟨hx, hy⟩
 #align prod_mem_nhds prod_mem_nhds
 
-theorem Filter.Eventually.prod_nhds {p : X → Prop} {q : Y → Prop} {a : X} {b : Y}
-    (ha : ∀ᶠ x in 𝓝 a, p x) (hb : ∀ᶠ y in 𝓝 b, q y) : ∀ᶠ z : X × Y in 𝓝 (a, b), p z.1 ∧ q z.2 :=
-  prod_mem_nhds ha hb
+theorem Filter.Eventually.prod_nhds {p : X → Prop} {q : Y → Prop} {x : X} {y : Y}
+    (hx : ∀ᶠ x in 𝓝 x, p x) (hy : ∀ᶠ y in 𝓝 y, q y) : ∀ᶠ z : X × Y in 𝓝 (x, y), p z.1 ∧ q z.2 :=
+  prod_mem_nhds hx hy
 #align filter.eventually.prod_nhds Filter.Eventually.prod_nhds
 
-theorem nhds_swap (a : X) (b : Y) : 𝓝 (a, b) = (𝓝 (b, a)).map Prod.swap := by
+theorem nhds_swap (x : X) (y : Y) : 𝓝 (x, y) = (𝓝 (y, x)).map Prod.swap := by
   rw [nhds_prod_eq, Filter.prod_comm, nhds_prod_eq]; rfl
 #align nhds_swap nhds_swap
 
-theorem Filter.Tendsto.prod_mk_nhds {γ} {a : X} {b : Y} {f : Filter γ} {ma : γ → X} {mb : γ → Y}
-    (ha : Tendsto ma f (𝓝 a)) (hb : Tendsto mb f (𝓝 b)) :
-    Tendsto (fun c => (ma c, mb c)) f (𝓝 (a, b)) := by
-  rw [nhds_prod_eq]; exact Filter.Tendsto.prod_mk ha hb
+theorem Filter.Tendsto.prod_mk_nhds {γ} {x : X} {y : Y} {f : Filter γ} {mx : γ → X} {my : γ → Y}
+    (hx : Tendsto mx f (𝓝 x)) (hy : Tendsto my f (𝓝 y)) :
+    Tendsto (fun c => (mx c, my c)) f (𝓝 (x, y)) := by
+  rw [nhds_prod_eq]; exact Filter.Tendsto.prod_mk hx hy
 #align filter.tendsto.prod_mk_nhds Filter.Tendsto.prod_mk_nhds
 
 theorem Filter.Eventually.curry_nhds {p : X × Y → Prop} {x : X} {y : Y}
@@ -780,10 +780,10 @@ theorem frontier_univ_prod_eq (s : Set Y) :
   simp [frontier_prod_eq]
 #align frontier_univ_prod_eq frontier_univ_prod_eq
 
-theorem map_mem_closure₂ {f : X → Y → Z} {a : X} {b : Y} {s : Set X} {t : Set Y} {u : Set Z}
-    (hf : Continuous (uncurry f)) (ha : a ∈ closure s) (hb : b ∈ closure t)
-    (h : ∀ a ∈ s, ∀ b ∈ t, f a b ∈ u) : f a b ∈ closure u :=
-  have H₁ : (a, b) ∈ closure (s ×ˢ t) := by simpa only [closure_prod_eq] using mk_mem_prod ha hb
+theorem map_mem_closure₂ {f : X → Y → Z} {x : X} {y : Y} {s : Set X} {t : Set Y} {u : Set Z}
+    (hf : Continuous (uncurry f)) (hx : x ∈ closure s) (hy : y ∈ closure t)
+    (h : ∀ a ∈ s, ∀ b ∈ t, f a b ∈ u) : f x y ∈ closure u :=
+  have H₁ : (x, y) ∈ closure (s ×ˢ t) := by simpa only [closure_prod_eq] using mk_mem_prod hx hy
   have H₂ : MapsTo (uncurry f) (s ×ˢ t) u := forall_prod_set.2 h
   H₂.closure hf H₁
 #align map_mem_closure₂ map_mem_closure₂
@@ -813,13 +813,13 @@ theorem Inducing.prod_map {f : X → Y} {g : Z → W} (hf : Inducing f) (hg : In
 #align inducing.prod_mk Inducing.prod_map
 
 @[simp]
-theorem inducing_const_prod {a : X} {f : Y → Z} : (Inducing fun x => (a, f x)) ↔ Inducing f := by
+theorem inducing_const_prod {x : X} {f : Y → Z} : (Inducing fun x' => (x, f x')) ↔ Inducing f := by
   simp_rw [inducing_iff, instTopologicalSpaceProd, induced_inf, induced_compose, Function.comp,
     induced_const, top_inf_eq]
 #align inducing_const_prod inducing_const_prod
 
 @[simp]
-theorem inducing_prod_const {b : Y} {f : X → Z} : (Inducing fun x => (f x, b)) ↔ Inducing f := by
+theorem inducing_prod_const {y : Y} {f : X → Z} : (Inducing fun x => (f x, y)) ↔ Inducing f := by
   simp_rw [inducing_iff, instTopologicalSpaceProd, induced_inf, induced_compose, Function.comp,
     induced_const, inf_top_eq]
 #align inducing_prod_const inducing_prod_const
@@ -957,7 +957,7 @@ theorem nhds_inl (x : X) : 𝓝 (inl x : X ⊕ Y) = map inl (𝓝 x) :=
   (openEmbedding_inl.map_nhds_eq _).symm
 #align nhds_inl nhds_inl
 
-theorem nhds_inr (x : Y) : 𝓝 (inr x : X ⊕ Y) = map inr (𝓝 x) :=
+theorem nhds_inr (y : Y) : 𝓝 (inr y : X ⊕ Y) = map inr (𝓝 y) :=
   (openEmbedding_inr.map_nhds_eq _).symm
 #align nhds_inr nhds_inr
 
@@ -996,11 +996,11 @@ section Subtype
 
 variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] {p : X → Prop}
 
-theorem inducing_subtype_val {b : Set Y} : Inducing ((↑) : b → Y) := ⟨rfl⟩
+theorem inducing_subtype_val {t : Set Y} : Inducing ((↑) : t → Y) := ⟨rfl⟩
 #align inducing_coe inducing_subtype_val
 
-theorem Inducing.of_codRestrict {f : X → Y} {b : Set Y} (hb : ∀ a, f a ∈ b)
-    (h : Inducing (b.codRestrict f hb)) : Inducing f :=
+theorem Inducing.of_codRestrict {f : X → Y} {t : Set Y} (ht : ∀ x, f x ∈ t)
+    (h : Inducing (t.codRestrict f ht)) : Inducing f :=
   inducing_subtype_val.comp h
 #align inducing.of_cod_restrict Inducing.of_codRestrict
 
@@ -1069,8 +1069,8 @@ theorem continuous_inclusion {s t : Set X} (h : s ⊆ t) : Continuous (inclusion
   continuous_id.subtype_map h
 #align continuous_inclusion continuous_inclusion
 
-theorem continuousAt_subtype_val {p : X → Prop} {a : Subtype p} :
-    ContinuousAt ((↑) : Subtype p → X) a :=
+theorem continuousAt_subtype_val {p : X → Prop} {x : Subtype p} :
+    ContinuousAt ((↑) : Subtype p → X) x :=
   continuous_subtype_val.continuousAt
 #align continuous_at_subtype_coe continuousAt_subtype_val
 
@@ -1080,20 +1080,20 @@ theorem Subtype.dense_iff {s : Set X} {t : Set s} : Dense t ↔ s ⊆ closure ((
 #align subtype.dense_iff Subtype.dense_iff
 
 -- porting note: new lemma
-theorem map_nhds_subtype_val {s : Set X} (a : s) : map ((↑) : s → X) (𝓝 a) = 𝓝[s] ↑a := by
+theorem map_nhds_subtype_val {s : Set X} (x : s) : map ((↑) : s → X) (𝓝 x) = 𝓝[s] ↑x := by
   rw [inducing_subtype_val.map_nhds_eq, Subtype.range_val]
 
-theorem map_nhds_subtype_coe_eq_nhds {a : X} (ha : p a) (h : ∀ᶠ x in 𝓝 a, p x) :
-    map ((↑) : Subtype p → X) (𝓝 ⟨a, ha⟩) = 𝓝 a :=
+theorem map_nhds_subtype_coe_eq_nhds {x : X} (hx : p x) (h : ∀ᶠ x in 𝓝 x, p x) :
+    map ((↑) : Subtype p → X) (𝓝 ⟨x, hx⟩) = 𝓝 x :=
   map_nhds_induced_of_mem <| by rw [Subtype.range_val]; exact h
 #align map_nhds_subtype_coe_eq map_nhds_subtype_coe_eq_nhds
 
-theorem nhds_subtype_eq_comap {a : X} {h : p a} : 𝓝 (⟨a, h⟩ : Subtype p) = comap (↑) (𝓝 a) :=
+theorem nhds_subtype_eq_comap {x : X} {h : p x} : 𝓝 (⟨x, h⟩ : Subtype p) = comap (↑) (𝓝 x) :=
   nhds_induced _ _
 #align nhds_subtype_eq_comap nhds_subtype_eq_comap
 
-theorem tendsto_subtype_rng {Y : Type*} {p : X → Prop} {b : Filter Y} {f : Y → Subtype p} :
-    ∀ {a : Subtype p}, Tendsto f b (𝓝 a) ↔ Tendsto (fun x => (f x : X)) b (𝓝 (a : X))
+theorem tendsto_subtype_rng {Y : Type*} {p : X → Prop} {l : Filter Y} {f : Y → Subtype p} :
+    ∀ {x : Subtype p}, Tendsto f l (𝓝 x) ↔ Tendsto (fun x => (f x : X)) l (𝓝 (x : X))
   | ⟨a, ha⟩ => by rw [nhds_subtype_eq_comap, tendsto_comap_iff]; rfl
 #align tendsto_subtype_rng tendsto_subtype_rng
 
@@ -1298,8 +1298,8 @@ theorem Filter.Tendsto.update [DecidableEq ι] {l : Filter Y} {f : Y → ∀ i, 
   tendsto_pi_nhds.2 fun j => by rcases eq_or_ne j i with (rfl | hj) <;> simp [*, hf.apply]
 #align filter.tendsto.update Filter.Tendsto.update
 
-theorem ContinuousAt.update [DecidableEq ι] {a : X} (hf : ContinuousAt f a) (i : ι) {g : X → π i}
-    (hg : ContinuousAt g a) : ContinuousAt (fun a => update (f a) i (g a)) a :=
+theorem ContinuousAt.update [DecidableEq ι] {x : X} (hf : ContinuousAt f x) (i : ι) {g : X → π i}
+    (hg : ContinuousAt g x) : ContinuousAt (fun a => update (f a) i (g a)) x :=
   hf.tendsto.update i hg
 #align continuous_at.update ContinuousAt.update
 
@@ -1332,9 +1332,9 @@ theorem Filter.Tendsto.fin_insertNth {n} {π : Fin (n + 1) → Type*} [∀ i, To
 #align filter.tendsto.fin_insert_nth Filter.Tendsto.fin_insertNth
 
 theorem ContinuousAt.fin_insertNth {n} {π : Fin (n + 1) → Type*} [∀ i, TopologicalSpace (π i)]
-    (i : Fin (n + 1)) {f : X → π i} {a : X} (hf : ContinuousAt f a)
-    {g : X → ∀ j : Fin n, π (i.succAbove j)} (hg : ContinuousAt g a) :
-    ContinuousAt (fun a => i.insertNth (f a) (g a)) a :=
+    (i : Fin (n + 1)) {f : X → π i} {x : X} (hf : ContinuousAt f x)
+    {g : X → ∀ j : Fin n, π (i.succAbove j)} (hg : ContinuousAt g x) :
+    ContinuousAt (fun a => i.insertNth (f a) (g a)) x :=
   hf.tendsto.fin_insertNth i hg
 #align continuous_at.fin_insert_nth ContinuousAt.fin_insertNth
 
@@ -1438,8 +1438,8 @@ theorem pi_generateFrom_eq {π : ι → Type*} {g : ∀ a, Set (Set (π a))} :
     rintro _ ⟨s, i, hi, rfl⟩
     letI := fun a => generateFrom (g a)
     exact isOpen_set_pi i.finite_toSet (fun a ha => GenerateOpen.basic _ (hi a ha))
-  · refine le_iInf fun a => coinduced_le_iff_le_induced.1 <| le_generateFrom fun s hs => ?_
-    refine GenerateOpen.basic _ ⟨update (fun a => univ) a s, {a}, ?_⟩
+  · refine le_iInf fun i => coinduced_le_iff_le_induced.1 <| le_generateFrom fun s hs => ?_
+    refine GenerateOpen.basic _ ⟨update (fun i => univ) i s, {i}, ?_⟩
     simp [hs]
 #align pi_generate_from_eq pi_generateFrom_eq
 
@@ -1719,13 +1719,13 @@ theorem nhdsSet_prod_le (s : Set X) (t : Set Y) : 𝓝ˢ (s ×ˢ t) ≤ 𝓝ˢ s
 theorem Filter.eventually_nhdsSet_prod_iff {p : X × Y → Prop} :
     (∀ᶠ q in 𝓝ˢ (s ×ˢ t), p q) ↔
       ∀ x ∈ s, ∀ y ∈ t,
-          ∃ pa : X → Prop, (∀ᶠ x' in 𝓝 x, pa x') ∧ ∃ pb : Y → Prop, (∀ᶠ y' in 𝓝 y, pb y') ∧
-            ∀ {x : X}, pa x → ∀ {y : Y}, pb y → p (x, y) :=
+          ∃ px : X → Prop, (∀ᶠ x' in 𝓝 x, px x') ∧ ∃ py : Y → Prop, (∀ᶠ y' in 𝓝 y, py y') ∧
+            ∀ {x : X}, px x → ∀ {y : Y}, py y → p (x, y) :=
   by simp_rw [eventually_nhdsSet_iff_forall, Set.forall_prod_set, nhds_prod_eq, eventually_prod_iff]
 
-theorem Filter.Eventually.prod_nhdsSet {p : X × Y → Prop} {pa : X → Prop} {pb : Y → Prop}
-    (hp : ∀ {x : X}, pa x → ∀ {y : Y}, pb y → p (x, y)) (hs : ∀ᶠ x in 𝓝ˢ s, pa x)
-    (ht : ∀ᶠ y in 𝓝ˢ t, pb y) : ∀ᶠ q in 𝓝ˢ (s ×ˢ t), p q :=
+theorem Filter.Eventually.prod_nhdsSet {p : X × Y → Prop} {px : X → Prop} {py : Y → Prop}
+    (hp : ∀ {x : X}, px x → ∀ {y : Y}, py y → p (x, y)) (hs : ∀ᶠ x in 𝓝ˢ s, px x)
+    (ht : ∀ᶠ y in 𝓝ˢ t, py y) : ∀ᶠ q in 𝓝ˢ (s ×ˢ t), p q :=
   nhdsSet_prod_le _ _ (mem_of_superset (prod_mem_prod hs ht) fun _ ⟨hx, hy⟩ ↦ hp hx hy)
 
 end NhdsSet

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -62,12 +62,12 @@ instance instTopologicalSpaceSum [t₁ : TopologicalSpace X] [t₂ : Topological
     TopologicalSpace (X ⊕ Y) :=
   coinduced Sum.inl t₁ ⊔ coinduced Sum.inr t₂
 
-instance instTopologicalSpaceSigma {β : X → Type v} [t₂ : ∀ a, TopologicalSpace (β a)] :
-    TopologicalSpace (Sigma β) :=
+instance instTopologicalSpaceSigma {X : X → Type v} [t₂ : ∀ a, TopologicalSpace (X a)] :
+    TopologicalSpace (Sigma X) :=
   ⨆ a, coinduced (Sigma.mk a) (t₂ a)
 
-instance Pi.topologicalSpace {β : X → Type v} [t₂ : (a : X) → TopologicalSpace (β a)] :
-    TopologicalSpace ((a : X) → β a) :=
+instance Pi.topologicalSpace {Y : X → Type v} [t₂ : (a : X) → TopologicalSpace (Y a)] :
+    TopologicalSpace ((a : X) → Y a) :=
   ⨅ a, induced (fun f => f a) (t₂ a)
 #align Pi.topological_space Pi.topologicalSpace
 
@@ -206,12 +206,12 @@ instance {p : X → Prop} [TopologicalSpace X] [DiscreteTopology X] : DiscreteTo
   ⟨bot_unique fun s _ => ⟨(↑) '' s, isOpen_discrete _, preimage_image_eq _ Subtype.val_injective⟩⟩
 
 instance Sum.discreteTopology [TopologicalSpace X] [TopologicalSpace Y] [h : DiscreteTopology X]
-    [hβ : DiscreteTopology Y] : DiscreteTopology (Sum X Y) :=
-  ⟨sup_eq_bot_iff.2 <| by simp [h.eq_bot, hβ.eq_bot]⟩
+    [hY : DiscreteTopology Y] : DiscreteTopology (Sum X Y) :=
+  ⟨sup_eq_bot_iff.2 <| by simp [h.eq_bot, hY.eq_bot]⟩
 #align sum.discrete_topology Sum.discreteTopology
 
-instance Sigma.discreteTopology {β : X → Type v} [∀ a, TopologicalSpace (β a)]
-    [h : ∀ a, DiscreteTopology (β a)] : DiscreteTopology (Sigma β) :=
+instance Sigma.discreteTopology {Y : X → Type v} [∀ a, TopologicalSpace (Y a)]
+    [h : ∀ a, DiscreteTopology (Y a)] : DiscreteTopology (Sigma Y) :=
   ⟨iSup_eq_bot.2 fun _ => by simp only [(h _).eq_bot, coinduced_bot]⟩
 #align sigma.discrete_topology Sigma.discreteTopology
 
@@ -356,7 +356,7 @@ theorem ContinuousAt.fst' {f : X → γ} {x : X} {y : Y} (hf : ContinuousAt f x)
   ContinuousAt.comp hf continuousAt_fst
 #align continuous_at.fst' ContinuousAt.fst'
 
-/-- Precomposing `f` with `Prod.fst` is continuous at `x :  × β` -/
+/-- Precomposing `f` with `Prod.fst` is continuous at `x : X × Y` -/
 theorem ContinuousAt.fst'' {f : X → γ} {x : X × Y} (hf : ContinuousAt f x.fst) :
     ContinuousAt (fun x : X × Y => f x.fst) x :=
   hf.comp continuousAt_fst
@@ -393,7 +393,7 @@ theorem ContinuousAt.snd' {f : Y → γ} {x : X} {y : Y} (hf : ContinuousAt f y)
   ContinuousAt.comp hf continuousAt_snd
 #align continuous_at.snd' ContinuousAt.snd'
 
-/-- Precomposing `f` with `Prod.snd` is continuous at `x :  × β` -/
+/-- Precomposing `f` with `Prod.snd` is continuous at `x : X × Y` -/
 theorem ContinuousAt.snd'' {f : Y → γ} {x : X × Y} (hf : ContinuousAt f x.snd) :
     ContinuousAt (fun x : X × Y => f x.snd) x :=
   hf.comp continuousAt_snd
@@ -445,10 +445,10 @@ theorem Continuous.prod_map {f : γ → X} {g : δ → Y} (hf : Continuous f) (h
 #align continuous.prod_map Continuous.prod_map
 
 /-- A version of `continuous_inf_dom_left` for binary functions -/
-theorem continuous_inf_dom_left₂ { β γ} {f : X → β → γ} {ta1 ta2 : TopologicalSpace X}
-    {tb1 tb2 : TopologicalSpace β} {tc1 : TopologicalSpace γ}
-    (h : by haveI := ta1; haveI := tb1; exact Continuous fun p : X × β => f p.1 p.2) : by
-    haveI := ta1 ⊓ ta2; haveI := tb1 ⊓ tb2; exact Continuous fun p : X × β => f p.1 p.2 := by
+theorem continuous_inf_dom_left₂ {X Y γ} {f : X → Y → γ} {ta1 ta2 : TopologicalSpace X}
+    {tb1 tb2 : TopologicalSpace Y} {tc1 : TopologicalSpace γ}
+    (h : by haveI := ta1; haveI := tb1; exact Continuous fun p : X × Y => f p.1 p.2) : by
+    haveI := ta1 ⊓ ta2; haveI := tb1 ⊓ tb2; exact Continuous fun p : X × Y => f p.1 p.2 := by
   have ha := @continuous_inf_dom_left _ _ id ta1 ta2 ta1 (@continuous_id _ (id _))
   have hb := @continuous_inf_dom_left _ _ id tb1 tb2 tb1 (@continuous_id _ (id _))
   have h_continuous_id := @Continuous.prod_map _ _ _ _ ta1 tb1 (ta1 ⊓ ta2) (tb1 ⊓ tb2) _ _ ha hb
@@ -456,10 +456,10 @@ theorem continuous_inf_dom_left₂ { β γ} {f : X → β → γ} {ta1 ta2 : Top
 #align continuous_inf_dom_left₂ continuous_inf_dom_left₂
 
 /-- A version of `continuous_inf_dom_right` for binary functions -/
-theorem continuous_inf_dom_right₂ { β γ} {f : X → β → γ} {ta1 ta2 : TopologicalSpace X}
-    {tb1 tb2 : TopologicalSpace β} {tc1 : TopologicalSpace γ}
-    (h : by haveI := ta2; haveI := tb2; exact Continuous fun p : X × β => f p.1 p.2) : by
-    haveI := ta1 ⊓ ta2; haveI := tb1 ⊓ tb2; exact Continuous fun p : X × β => f p.1 p.2 := by
+theorem continuous_inf_dom_right₂ {X Y γ} {f : X → Y → γ} {ta1 ta2 : TopologicalSpace X}
+    {tb1 tb2 : TopologicalSpace Y} {tc1 : TopologicalSpace γ}
+    (h : by haveI := ta2; haveI := tb2; exact Continuous fun p : X × Y => f p.1 p.2) : by
+    haveI := ta1 ⊓ ta2; haveI := tb1 ⊓ tb2; exact Continuous fun p : X × Y => f p.1 p.2 := by
   have ha := @continuous_inf_dom_right _ _ id ta1 ta2 ta2 (@continuous_id _ (id _))
   have hb := @continuous_inf_dom_right _ _ id tb1 tb2 tb2 (@continuous_id _ (id _))
   have h_continuous_id := @Continuous.prod_map _ _ _ _ ta2 tb2 (ta1 ⊓ ta2) (tb1 ⊓ tb2) _ _ ha hb
@@ -467,12 +467,12 @@ theorem continuous_inf_dom_right₂ { β γ} {f : X → β → γ} {ta1 ta2 : To
 #align continuous_inf_dom_right₂ continuous_inf_dom_right₂
 
 /-- A version of `continuous_sInf_dom` for binary functions -/
-theorem continuous_sInf_dom₂ { β γ} {f : X → β → γ} {tas : Set (TopologicalSpace X)}
-    {tbs : Set (TopologicalSpace β)} {ta : TopologicalSpace X} {tb : TopologicalSpace β}
+theorem continuous_sInf_dom₂ {X Y γ} {f : X → Y → γ} {tas : Set (TopologicalSpace X)}
+    {tbs : Set (TopologicalSpace Y)} {ta : TopologicalSpace X} {tb : TopologicalSpace Y}
     {tc : TopologicalSpace γ} (ha : ta ∈ tas) (hb : tb ∈ tbs)
-    (hf : Continuous fun p : X × β => f p.1 p.2) : by
+    (hf : Continuous fun p : X × Y => f p.1 p.2) : by
     haveI := sInf tas; haveI := sInf tbs;
-      exact @Continuous _ _ _ tc fun p : X × β => f p.1 p.2 := by
+      exact @Continuous _ _ _ tc fun p : X × Y => f p.1 p.2 := by
   have ha := continuous_sInf_dom ha continuous_id
   have hb := continuous_sInf_dom hb continuous_id
   have h_continuous_id := @Continuous.prod_map _ _ _ _ ta tb (sInf tas) (sInf tbs) _ _ ha hb
@@ -623,9 +623,9 @@ theorem ContinuousAt.prod_map' {f : X → γ} {g : Y → δ} {x : X} {y : Y} (hf
 
 -- todo: reformulate using `Set.image2`
 -- todo: prove a version of `generateFrom_union` with `image2 (∩) s t` in the LHS and use it here
-theorem prod_generateFrom_generateFrom_eq { β : Type*} {s : Set (Set X)} {t : Set (Set β)}
+theorem prod_generateFrom_generateFrom_eq {X Y : Type*} {s : Set (Set X)} {t : Set (Set Y)}
     (hs : ⋃₀ s = univ) (ht : ⋃₀ t = univ) :
-    @instTopologicalSpaceProd X β (generateFrom s) (generateFrom t) =
+    @instTopologicalSpaceProd X Y (generateFrom s) (generateFrom t) =
       generateFrom { g | ∃ u ∈ s, ∃ v ∈ t, g = u ×ˢ v } :=
   let G := generateFrom { g | ∃ u ∈ s, ∃ v ∈ t, g = u ×ˢ v }
   le_antisymm
@@ -691,7 +691,7 @@ theorem exists_nhds_square {s : Set (X × X)} {x : X} (hx : s ∈ 𝓝 (x, x)) :
   simpa [nhds_prod_eq, (nhds_basis_opens x).prod_self.mem_iff, and_assoc, and_left_comm] using hx
 #align exists_nhds_square exists_nhds_square
 
-/-- `Prod.fst` maps neighborhood of `x :  × β` within the section `Prod.snd ⁻¹' {x.2}`
+/-- `Prod.fst` maps neighborhood of `x : X × Y` within the section `Prod.snd ⁻¹' {x.2}`
 to `𝓝 x.1`. -/
 theorem map_fst_nhdsWithin (x : X × Y) : map Prod.fst (𝓝[Prod.snd ⁻¹' {x.2}] x) = 𝓝 x.1 := by
   refine' le_antisymm (continuousAt_fst.mono_left inf_le_left) fun s hs => _
@@ -712,7 +712,7 @@ theorem isOpenMap_fst : IsOpenMap (@Prod.fst X Y) :=
   isOpenMap_iff_nhds_le.2 fun x => (map_fst_nhds x).ge
 #align is_open_map_fst isOpenMap_fst
 
-/-- `Prod.snd` maps neighborhood of `x :  × β` within the section `Prod.fst ⁻¹' {x.1}`
+/-- `Prod.snd` maps neighborhood of `x : X × Y` within the section `Prod.fst ⁻¹' {x.1}`
 to `𝓝 x.2`. -/
 theorem map_snd_nhdsWithin (x : X × Y) : map Prod.snd (𝓝[Prod.fst ⁻¹' {x.1}] x) = 𝓝 x.2 := by
   refine' le_antisymm (continuousAt_snd.mono_left inf_le_left) fun s hs => _
@@ -1092,7 +1092,7 @@ theorem nhds_subtype_eq_comap {a : X} {h : p a} : 𝓝 (⟨a, h⟩ : Subtype p) 
   nhds_induced _ _
 #align nhds_subtype_eq_comap nhds_subtype_eq_comap
 
-theorem tendsto_subtype_rng {β : Type*} {p : X → Prop} {b : Filter β} {f : β → Subtype p} :
+theorem tendsto_subtype_rng {Y : Type*} {p : X → Prop} {b : Filter Y} {f : Y → Subtype p} :
     ∀ {a : Subtype p}, Tendsto f b (𝓝 a) ↔ Tendsto (fun x => (f x : X)) b (𝓝 (a : X))
   | ⟨a, ha⟩ => by rw [nhds_subtype_eq_comap, tendsto_comap_iff]; rfl
 #align tendsto_subtype_rng tendsto_subtype_rng
@@ -1279,7 +1279,7 @@ lemma Pi.induced_precomp' {ι' : Type*} (φ : ι' → ι) :
 
 lemma Pi.induced_precomp [TopologicalSpace Y] {ι' : Type*} (φ : ι' → ι) :
     induced (· ∘ φ) Pi.topologicalSpace =
-    ⨅ i', induced (eval (φ i')) ‹TopologicalSpace β› :=
+    ⨅ i', induced (eval (φ i')) ‹TopologicalSpace Y› :=
   induced_precomp' φ
 
 lemma Pi.continuous_restrict (S : Set ι) :
@@ -1692,17 +1692,17 @@ end ULift
 
 section Monad
 
-variable [TopologicalSpace X] {β : Set X} {γ : Set β}
+variable [TopologicalSpace X] {s : Set X} {γ : Set s}
 
-theorem IsOpen.trans (hγ : IsOpen γ) (hβ : IsOpen β) : IsOpen (γ : Set X) := by
+theorem IsOpen.trans (hγ : IsOpen γ) (hs : IsOpen s) : IsOpen (γ : Set X) := by
   rcases isOpen_induced_iff.mp hγ with ⟨δ, hδ, rfl⟩
   rw [Subtype.image_preimage_coe]
-  exact IsOpen.inter hδ hβ
+  exact IsOpen.inter hδ hs
 
-theorem IsClosed.trans (hγ : IsClosed γ) (hβ : IsClosed β) : IsClosed (γ : Set X) := by
+theorem IsClosed.trans (hγ : IsClosed γ) (hs : IsClosed s) : IsClosed (γ : Set X) := by
   rcases isClosed_induced_iff.mp hγ with ⟨δ, hδ, rfl⟩
   rw [Subtype.image_preimage_coe]
-  convert IsClosed.inter hδ hβ
+  convert IsClosed.inter hδ hs
 
 end Monad
 


### PR DESCRIPTION
Now we use letters X, Y, Z and W for topological spaces, not Greek letters.

Also rename associated variables (a : X) to (x : X), etc., and hypotheses.
I didn't replace all letters; some lemmas need a large number of different letters. Volunteers for the last instances welcome.

---

Best reviewed commit by commit.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
