### PR TITLE
[Merged by Bors] - feat(Algebra/Group): Add commute_iff_eq and a few lemmas on conjugation

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -768,6 +768,15 @@ theorem inv_mul_eq_one : a⁻¹ * b = 1 ↔ a = b := by rw [mul_eq_one_iff_eq_in
 #align inv_mul_eq_one inv_mul_eq_one
 #align neg_add_eq_zero neg_add_eq_zero
 
+@[to_additive (attr := simp)]
+theorem conj_mul_eq_one_iff (f g : G) : f * g * f⁻¹ = 1 ↔ g = 1 := by
+  rw [mul_inv_eq_iff_eq_mul, one_mul]
+  conv => {
+    lhs; rhs
+    rw [← mul_one f]
+  }
+  rw [mul_left_cancel_iff]
+
 @[to_additive]
 theorem div_left_injective : Function.Injective fun a ↦ a / b := by
   -- FIXME this could be by `simpa`, but it fails. This is probably a bug in `simpa`.

--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -769,13 +769,8 @@ theorem inv_mul_eq_one : a⁻¹ * b = 1 ↔ a = b := by rw [mul_eq_one_iff_eq_in
 #align neg_add_eq_zero neg_add_eq_zero
 
 @[to_additive (attr := simp)]
-theorem conj_mul_eq_one_iff (f g : G) : f * g * f⁻¹ = 1 ↔ g = 1 := by
-  rw [mul_inv_eq_iff_eq_mul, one_mul]
-  conv => {
-    lhs; rhs
-    rw [← mul_one f]
-  }
-  rw [mul_left_cancel_iff]
+theorem conj_mul_eq_one_iff : a * b * a⁻¹ = 1 ↔ b = 1 := by
+  rw [mul_inv_eq_one, mul_right_eq_self]
 
 @[to_additive]
 theorem div_left_injective : Function.Injective fun a ↦ a / b := by

--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -769,7 +769,7 @@ theorem inv_mul_eq_one : a⁻¹ * b = 1 ↔ a = b := by rw [mul_eq_one_iff_eq_in
 #align neg_add_eq_zero neg_add_eq_zero
 
 @[to_additive (attr := simp)]
-theorem conj_mul_eq_one_iff : a * b * a⁻¹ = 1 ↔ b = 1 := by
+theorem conj_eq_one_iff : a * b * a⁻¹ = 1 ↔ b = 1 := by
   rw [mul_inv_eq_one, mul_right_eq_self]
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/Commute/Basic.lean
+++ b/Mathlib/Algebra/Group/Commute/Basic.lean
@@ -91,19 +91,14 @@ lemma inv_mul_cancel_assoc (h : Commute a b) : a⁻¹ * (b * a) = b := by
 #align commute.inv_mul_cancel_assoc Commute.inv_mul_cancel_assoc
 #align add_commute.neg_add_cancel_assoc AddCommute.neg_add_cancel_assoc
 
-@[to_additive]
-protected theorem conj (comm : Commute a b) (h : G) : Commute (h * a * h⁻¹) (h * b * h⁻¹) := by
-  rw [commute_iff_eq]
-  repeat rw [← mul_assoc]
-  simp only [inv_mul_cancel_right]
-  rw [mul_assoc _ a, comm, ← mul_assoc h]
-
 @[to_additive (attr := simp)]
 protected theorem conj_iff (h : G) : Commute (h * a * h⁻¹) (h * b * h⁻¹) ↔ Commute a b := by
-  refine ⟨fun comm => ?comm, fun comm => comm.conj h⟩
-  have res := comm.conj h⁻¹
-  simp only [← mul_assoc, mul_left_inv, one_mul, inv_inv, inv_mul_cancel_right] at res
-  exact res
+  simp_rw [commute_iff_eq, mul_assoc, inv_mul_cancel_left, mul_right_inj, ← mul_assoc,
+    mul_left_inj]
+
+@[to_additive]
+protected theorem conj (comm : Commute a b) (h : G) : Commute (h * a * h⁻¹) (h * b * h⁻¹) :=
+  (Commute.conj_iff h).mpr comm
 
 end Group
 end Commute

--- a/Mathlib/Algebra/Group/Commute/Basic.lean
+++ b/Mathlib/Algebra/Group/Commute/Basic.lean
@@ -91,5 +91,19 @@ lemma inv_mul_cancel_assoc (h : Commute a b) : a⁻¹ * (b * a) = b := by
 #align commute.inv_mul_cancel_assoc Commute.inv_mul_cancel_assoc
 #align add_commute.neg_add_cancel_assoc AddCommute.neg_add_cancel_assoc
 
+@[to_additive]
+protected theorem conj (comm : Commute a b) (h : G) : Commute (h * a * h⁻¹) (h * b * h⁻¹) := by
+  rw [commute_iff_eq]
+  repeat rw [← mul_assoc]
+  simp only [inv_mul_cancel_right]
+  rw [mul_assoc _ a, comm, ← mul_assoc h]
+
+@[to_additive (attr := simp)]
+protected theorem conj_iff (h : G) : Commute (h * a * h⁻¹) (h * b * h⁻¹) ↔ Commute a b := by
+  refine ⟨fun comm => ?comm, fun comm => comm.conj h⟩
+  have res := comm.conj h⁻¹
+  simp only [← mul_assoc, mul_left_inv, one_mul, inv_inv, inv_mul_cancel_right] at res
+  exact res
+
 end Group
 end Commute

--- a/Mathlib/Algebra/Group/Commute/Basic.lean
+++ b/Mathlib/Algebra/Group/Commute/Basic.lean
@@ -92,9 +92,8 @@ lemma inv_mul_cancel_assoc (h : Commute a b) : a⁻¹ * (b * a) = b := by
 #align add_commute.neg_add_cancel_assoc AddCommute.neg_add_cancel_assoc
 
 @[to_additive (attr := simp)]
-protected theorem conj_iff (h : G) : Commute (h * a * h⁻¹) (h * b * h⁻¹) ↔ Commute a b := by
-  simp_rw [commute_iff_eq, mul_assoc, inv_mul_cancel_left, mul_right_inj, ← mul_assoc,
-    mul_left_inj]
+protected theorem conj_iff (h : G) : Commute (h * a * h⁻¹) (h * b * h⁻¹) ↔ Commute a b :=
+  SemiconjBy.conj_iff
 
 @[to_additive]
 protected theorem conj (comm : Commute a b) (h : G) : Commute (h * a * h⁻¹) (h * b * h⁻¹) :=

--- a/Mathlib/Algebra/Group/Commute/Defs.lean
+++ b/Mathlib/Algebra/Group/Commute/Defs.lean
@@ -38,6 +38,12 @@ def Commute {S : Type*} [Mul S] (a b : S) : Prop :=
 #align commute Commute
 #align add_commute AddCommute
 
+/--
+Two elements `a` and `b` commute if `a * b = b * a`.
+-/
+@[to_additive]
+theorem commute_iff_eq {S : Type*} [Mul S] (a b : S) : Commute a b ↔ a * b = b * a := Iff.rfl
+
 namespace Commute
 
 section Mul

--- a/Mathlib/Algebra/Group/Semiconj/Defs.lean
+++ b/Mathlib/Algebra/Group/Semiconj/Defs.lean
@@ -140,6 +140,14 @@ theorem conj_mk (a x : G) : SemiconjBy a x (a * x * a⁻¹) := by
 #align semiconj_by.conj_mk SemiconjBy.conj_mk
 #align add_semiconj_by.conj_mk AddSemiconjBy.conj_mk
 
+@[to_additive (attr := simp)]
+theorem conj_iff {a x y b : G} :
+    SemiconjBy (b * a * b⁻¹) (b * x * b⁻¹) (b * y * b⁻¹) ↔ SemiconjBy a x y := by
+  unfold SemiconjBy
+  simp only [← mul_assoc, inv_mul_cancel_right]
+  repeat rw [mul_assoc]
+  rw [mul_left_cancel_iff, ← mul_assoc, ← mul_assoc, mul_right_cancel_iff]
+
 end Group
 
 end SemiconjBy


### PR DESCRIPTION
This introduces some helpful, small lemmas around conjugation in groups, as well as `commute_iff_eq`,
which removes the need to use `show` or `unfold` to get an expression of the form `a * b = b * a` to prove.

---

- `Commute.conj_iff` is strictly decreasing (turning things of the form `Commute (f * a * f⁻¹) (f * b * f⁻¹)` to `Commute a b`), so it has been marked as `simp`
- the same reasoning was applied to `conj_mul_eq_one_iff`, which turns expressions of the form `f * g * f⁻¹ = 1` into `g = 1`

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
