### PR TITLE
[Merged by Bors] - feat: version of the extreme value theorem without a non-emptiness assumption

### DIFF
--- a/Mathlib/Topology/Algebra/Order/Compact.lean
+++ b/Mathlib/Topology/Algebra/Order/Compact.lean
@@ -263,8 +263,8 @@ theorem IsCompact.exists_isMinOn [ClosedIicTopology α] {s : Set β} (hs : IsCom
   rcases (hs.image_of_continuousOn hf).exists_isLeast (ne_s.image f) with ⟨_, ⟨x, hxs, rfl⟩, hx⟩
   exact ⟨x, hxs, ball_image_iff.1 hx⟩
 
-/-- The **extreme value theorem**: a continuous function realizes its minimum on a compact set `s`.
-  This variant is for functions into a `NoMaxOrder`, without the assumption `s.Nonempty`. -/
+/-- If a continuous function lies strictly above `a` on a compact set,
+  it has a lower bound strictly above `a`. -/
 theorem IsCompact.exists_forall_le' [ClosedIicTopology α] [NoMaxOrder α] {f : β → α}
     {s : Set β} (hs : IsCompact s) (hf : ContinuousOn f s) {a : α} (hf' : ∀ b ∈ s, a < f b) :
     ∃ a', a < a' ∧ ∀ b ∈ s, a' ≤ f b := by

--- a/Mathlib/Topology/Algebra/Order/Compact.lean
+++ b/Mathlib/Topology/Algebra/Order/Compact.lean
@@ -265,7 +265,7 @@ theorem IsCompact.exists_isMinOn [ClosedIicTopology α] {s : Set β} (hs : IsCom
 
 /-- The **extreme value theorem**: a continuous function realizes its minimum on a compact set `s`.
   This variant is for functions into a `NoMaxOrder`, without the assumption `s.Nonempty`. -/
-theorem IsCompact.exists_isMinOn' [ClosedIicTopology α] [NoMaxOrder α] {f : β → α}
+theorem IsCompact.exists_forall_le' [ClosedIicTopology α] [NoMaxOrder α] {f : β → α}
     {s : Set β} (hs : IsCompact s) (hf : ContinuousOn f s) {a : α} (hf' : ∀ b ∈ s, a < f b) :
     ∃ a', a < a' ∧ ∀ b ∈ s, a' ≤ f b := by
   rcases s.eq_empty_or_nonempty with (rfl | hs')

--- a/Mathlib/Topology/Algebra/Order/Compact.lean
+++ b/Mathlib/Topology/Algebra/Order/Compact.lean
@@ -263,6 +263,17 @@ theorem IsCompact.exists_isMinOn [ClosedIicTopology α] {s : Set β} (hs : IsCom
   rcases (hs.image_of_continuousOn hf).exists_isLeast (ne_s.image f) with ⟨_, ⟨x, hxs, rfl⟩, hx⟩
   exact ⟨x, hxs, ball_image_iff.1 hx⟩
 
+/-- The **extreme value theorem**: a continuous function realizes its minimum on a compact set `s`.
+  This variant is for functions into a `NoMaxOrder`, without the assumption `s.Nonempty`. -/
+theorem IsCompact.exists_isMinOn' [ClosedIicTopology α] [NoMaxOrder α] {f : β → α}
+    {s : Set β} (hs : IsCompact s) (hf : ContinuousOn f s) {a : α} (hf' : ∀ b ∈ s, a < f b) :
+    ∃ a', a < a' ∧ ∀ b ∈ s, a' ≤ f b := by
+  rcases s.eq_empty_or_nonempty with (rfl | hs')
+  · obtain ⟨a', ha'⟩ := exists_gt a
+    exact ⟨a', ha', fun _ a ↦ a.elim⟩
+  · obtain ⟨x, hx, hx'⟩ := hs.exists_isMinOn hs' hf
+    exact ⟨f x, hf' x hx, hx'⟩
+
 /-- The **extreme value theorem**: a continuous function realizes its minimum on a compact set. -/
 @[deprecated IsCompact.exists_isMinOn]
 theorem IsCompact.exists_forall_le [ClosedIicTopology α] {s : Set β} (hs : IsCompact s)


### PR DESCRIPTION
Adapted and generalised from sphere-eversion; I'm just upstreaming it.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
