### PR TITLE
[Merged by Bors] - doc: remove stray 'a' in doc comment about PMOD

### DIFF
--- a/Mathlib/Algebra/ModEq.lean
+++ b/Mathlib/Algebra/ModEq.lean
@@ -16,7 +16,7 @@ This file defines equality modulo an element in a commutative group.
 
 ## Main definitions
 
-* `a ≡ b [PMOD p]`: `a` and `b` are congruent modulo a`p`.
+* `a ≡ b [PMOD p]`: `a` and `b` are congruent modulo `p`.
 
 ## See also
 


### PR DESCRIPTION
"congruent modulo a\`p\`" -> "congruent modulo \`p\`"

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
