### PR TITLE
[Merged by Bors] - fix: more accurate docstring

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/Refinements.lean
+++ b/Mathlib/CategoryTheory/Abelian/Refinements.lean
@@ -34,13 +34,10 @@ we get that an epimorphism is a morphism that is "surjective up to refinements".
 (This result is similar to the fact that a morphism of sheaves on
 a topological space or a site is epi iff sections can be lifted
 locally. Then, arguing "up to refinements" is very similar to
-arguing locally for a Grothendieck topology (TODO: show that it
-corresponds to arguing for the canonical topology on the abelian
-category `C` by showing that a morphism in `C` is an epi iff
-the corresponding morphisms of sheaves for the canonical
-topology is an epi, and that the criteria
-`epi_iff_surjective_up_to_refinements` could be deduced from
-this equivalence.)
+arguing locally for a Grothendieck topology (TODO: indeed,
+show that it corresponds to the "refinements" topology on an
+abelian category `C` that is defined by saying that
+a sieve is covering if it contains an epimorphism).
 
 Similarly, it is possible to show that a short complex in an abelian
 category is exact if and only if it is exact up to refinements


### PR DESCRIPTION
The statement of a TODO in `CategoryTheory.Abelian.Refinements` is fixed. Contrary to what was suggested, arguing "up to refinements" in abelian categories corresponds to arguing to a "refinements" topology on abelian categories, rather than the canonical topology.

---

(Note: the "refinements" topology is defined in this chunk of code https://github.com/leanprover-community/mathlib4/pull/4197/commits/a4b94e0a8f51476767f6321d05de93a5a8cf2349#diff-ef040edc73cc378740013507f707dff71840b87e247765124e6c1863bc76e27cR15-R27
The assertion in the TODO would become completely trivial if we had suitable characterizations of epimorphisms of sheaves of sets for general Grothendieck topology, i.e. a morphism of sheaves of sets is epi iff any section can be lifted locally.)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
