### PR TITLE
[Merged by Bors] - fix: adaptations for nightly-2024-01-24 (leanprover/lean4#3060)

### DIFF
--- a/Mathlib/Tactic/TFAE.lean
+++ b/Mathlib/Tactic/TFAE.lean
@@ -128,7 +128,8 @@ partial def proveChain (i : ℕ) (is : List ℕ) (P : Q(Prop)) (l : Q(List Prop)
   match l with
   | ~q([]) => return q(Chain.nil)
   | ~q($P' :: $l') =>
-    let i' :: is' := is | unreachable!
+    -- `id` is a workaround for https://github.com/leanprover-community/quote4/issues/30
+    let i' :: is' := id is | unreachable!
     have cl' : Q(Chain (· → ·) $P' $l') := ← proveChain i' is' q($P') q($l')
     let p ← proveImpl hyps atoms i i' P P'
     return q(Chain.cons $p $cl')
@@ -139,7 +140,8 @@ partial def proveGetLastDImpl (i i' : ℕ) (is : List ℕ) (P P' : Q(Prop)) (l :
   match l with
   | ~q([]) => proveImpl hyps atoms i' i P' P
   | ~q($P'' :: $l') =>
-    let i'' :: is' := is | unreachable!
+    -- `id` is a workaround for https://github.com/leanprover-community/quote4/issues/30
+    let i'' :: is' := id is | unreachable!
     proveGetLastDImpl i i'' is' P P'' l'
 
 /-- Attempt to prove a statement of the form `TFAE [P₁, P₂, ...]`. -/
@@ -148,7 +150,8 @@ def proveTFAE (is : List ℕ) (l : Q(List Prop)) : MetaM Q(TFAE $l) := do
   | ~q([]) => return q(tfae_nil)
   | ~q([$P]) => return q(tfae_singleton $P)
   | ~q($P :: $P' :: $l') =>
-    let i :: i' :: is' := is | unreachable!
+    -- `id` is a workaround for https://github.com/leanprover-community/quote4/issues/30
+    let i :: i' :: is' := id is | unreachable!
     let c ← proveChain hyps atoms i (i'::is') P q($P' :: $l')
     let il ← proveGetLastDImpl hyps atoms i i' is' P P' l'
     return q(tfae_of_cycle $c $il)

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-01-23
+leanprover/lean4:nightly-2024-01-24


### PR DESCRIPTION
leanprover/lean4#3060 exposed the latent https://github.com/leanprover-community/quote4/issues/30 (by propagating it from `if let` and `match` to `let`). The workaround is thankfully trivial.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I haven't adjusted the lean-toolchain yet.
