### PR TITLE
[Merged by Bors] - Add `Lattice ℤ` instance for computability

### DIFF
--- a/Mathlib/Data/Int/ConditionallyCompleteOrder.lean
+++ b/Mathlib/Data/Int/ConditionallyCompleteOrder.lean
@@ -109,5 +109,6 @@ end Int
 
 end
 
---  this example tests that the `Lattice ℤ` instance is computable.
+--  this example tests that the `Lattice ℤ` instance is computable;
+-- i.e., that is is not found via the noncomputable instance in this file.
 example : Lattice ℤ := inferInstance

--- a/Mathlib/Data/Int/ConditionallyCompleteOrder.lean
+++ b/Mathlib/Data/Int/ConditionallyCompleteOrder.lean
@@ -17,9 +17,9 @@ The integers form a conditionally complete linear order.
 
 open Int
 
-open Classical
 
 noncomputable section
+open Classical
 
 instance : ConditionallyCompleteLinearOrder ℤ :=
   { Int.linearOrderedCommRing,
@@ -106,3 +106,8 @@ theorem csInf_mem {s : Set ℤ} (h1 : s.Nonempty) (h2 : BddBelow s) : sInf s ∈
 #align int.cInf_mem Int.csInf_mem
 
 end Int
+
+end
+
+--  this example tests that the `Lattice ℤ` instance is computable.
+example : Lattice ℤ := inferInstance

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -934,6 +934,7 @@ instance (priority := 100) {α : Type u} [LinearOrder α] :
     | Or.inr h => inf_le_of_right_le <| sup_le_sup_left (le_inf h (le_refl c)) _
 
 instance : DistribLattice ℕ := inferInstance
+instance : Lattice ℤ := inferInstance
 
 /-! ### Dual order -/
 


### PR DESCRIPTION
The file `Data.Int.ConditionallyCompleteOrder` defines a noncomputable instance of `ConditionallyCompleteLinearOrder` on `ℤ`.

This noncomputable instance is picked up by the typeclass search when looking for a `Lattice` instance on `ℤ`, making, for instance, `abs` noncomputable on `ℤ`.

This PR restores the computability of `Lattice ℤ`.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/No.20more.20.60Abs.60.3F/near/417546479)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
