### PR TITLE
[Merged by Bors] - fix: generalize DivisionRing.toOfScientific

### DIFF
--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -159,7 +159,7 @@ end DivisionRing
 
 section OfScientific
 
-instance DivisionRing.toOfScientific [DivisionRing K] : OfScientific K where
+instance RatCast.toOfScientific [RatCast K] : OfScientific K where
   ofScientific (m : ℕ) (b : Bool) (d : ℕ) := Rat.ofScientific m b d
 
 end OfScientific


### PR DESCRIPTION
If you can cast a rat to a type, then we probably want decimal notation to work there too.

This has the benefit of making the instance computable even in cases where some parts of the division ring structure are not.
It also means that this could apply to matrices of rational numbers, which are not a division ring, but could have a rat cast.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
