### PR TITLE
[Merged by Bors] - chore(Algebra.Basic): override `toFun` and `smul` in `Algebra.id`

### DIFF
--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -441,7 +441,7 @@ theorem coe_linearMap : ⇑(Algebra.linearMap R A) = algebraMap R A :=
   see library note [reducible non-instances]. -/
 instance id : Algebra R R where
     toFun x := x
-    smul r x := r * x
+    toSMul := Mul.toSMul _
     __ := (RingHom.id R).toAlgebra
 #align algebra.id Algebra.id
 

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -436,10 +436,11 @@ theorem coe_linearMap : ⇑(Algebra.linearMap R A) = algebraMap R A :=
   rfl
 #align algebra.coe_linear_map Algebra.coe_linearMap
 
-/- The identity map inducing an `Algebra` structure. We override the data fields
-  `toFun` and `smul` because `RingHom.id` is not reducible.
-  see library note [reducible non-instances]. -/
+/- The identity map inducing an `Algebra` structure. -/
 instance id : Algebra R R where
+  -- We override `toFun` and `toSMul` because `RingHom.id` is not reducible and cannot
+  -- be made so without a significant performance hit.
+  -- see library note [reducible non-instances].
   toFun x := x
   toSMul := Mul.toSMul _
   __ := (RingHom.id R).toAlgebra

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -436,10 +436,13 @@ theorem coe_linearMap : ⇑(Algebra.linearMap R A) = algebraMap R A :=
   rfl
 #align algebra.coe_linear_map Algebra.coe_linearMap
 
-instance id : Algebra R R :=
-  { (RingHom.id R).toAlgebra with
+/- The identity map inducing an `Algebra` structure. We override the data fields
+  `toFun` and `smul` because `RingHom.id` is not reducible.
+  see library note [reducible non-instances]. -/
+instance id : Algebra R R where
     toFun := fun x => x
-    smul := fun r x => r*x }
+    smul := fun r x => r * x
+    __ := (RingHom.id R).toAlgebra
 #align algebra.id Algebra.id
 
 variable {R A}

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -248,6 +248,7 @@ end FieldDivisionRing
 end algebraMap
 
 /-- Creating an algebra from a morphism to the center of a semiring. -/
+@[reducible]
 def RingHom.toAlgebra' {R S} [CommSemiring R] [Semiring S] (i : R →+* S)
     (h : ∀ c x, i c * x = x * i c) : Algebra R S where
   smul c x := i c * x
@@ -257,6 +258,7 @@ def RingHom.toAlgebra' {R S} [CommSemiring R] [Semiring S] (i : R →+* S)
 #align ring_hom.to_algebra' RingHom.toAlgebra'
 
 /-- Creating an algebra from a morphism to a commutative semiring. -/
+@[reducible]
 def RingHom.toAlgebra {R S} [CommSemiring R] [CommSemiring S] (i : R →+* S) : Algebra R S :=
   i.toAlgebra' fun _ => mul_comm _
 #align ring_hom.to_algebra RingHom.toAlgebra
@@ -437,7 +439,9 @@ theorem coe_linearMap : ⇑(Algebra.linearMap R A) = algebraMap R A :=
 #align algebra.coe_linear_map Algebra.coe_linearMap
 
 instance id : Algebra R R :=
-  (RingHom.id R).toAlgebra
+  { (RingHom.id R).toAlgebra with
+    toFun := fun x => x
+    smul := fun r x => r*x }
 #align algebra.id Algebra.id
 
 variable {R A}

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -248,7 +248,6 @@ end FieldDivisionRing
 end algebraMap
 
 /-- Creating an algebra from a morphism to the center of a semiring. -/
-@[reducible]
 def RingHom.toAlgebra' {R S} [CommSemiring R] [Semiring S] (i : R →+* S)
     (h : ∀ c x, i c * x = x * i c) : Algebra R S where
   smul c x := i c * x
@@ -258,7 +257,6 @@ def RingHom.toAlgebra' {R S} [CommSemiring R] [Semiring S] (i : R →+* S)
 #align ring_hom.to_algebra' RingHom.toAlgebra'
 
 /-- Creating an algebra from a morphism to a commutative semiring. -/
-@[reducible]
 def RingHom.toAlgebra {R S} [CommSemiring R] [CommSemiring S] (i : R →+* S) : Algebra R S :=
   i.toAlgebra' fun _ => mul_comm _
 #align ring_hom.to_algebra RingHom.toAlgebra

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -440,8 +440,8 @@ theorem coe_linearMap : ⇑(Algebra.linearMap R A) = algebraMap R A :=
   `toFun` and `smul` because `RingHom.id` is not reducible.
   see library note [reducible non-instances]. -/
 instance id : Algebra R R where
-    toFun := fun x => x
-    smul := fun r x => r * x
+    toFun x := x
+    smul r x := r * x
     __ := (RingHom.id R).toAlgebra
 #align algebra.id Algebra.id
 

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -440,9 +440,9 @@ theorem coe_linearMap : ⇑(Algebra.linearMap R A) = algebraMap R A :=
   `toFun` and `smul` because `RingHom.id` is not reducible.
   see library note [reducible non-instances]. -/
 instance id : Algebra R R where
-    toFun x := x
-    toSMul := Mul.toSMul _
-    __ := (RingHom.id R).toAlgebra
+  toFun x := x
+  toSMul := Mul.toSMul _
+  __ := (RingHom.id R).toAlgebra
 #align algebra.id Algebra.id
 
 variable {R A}

--- a/Mathlib/Analysis/NormedSpace/Star/GelfandDuality.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/GelfandDuality.lean
@@ -116,7 +116,7 @@ theorem WeakDual.CharacterSpace.mem_spectrum_iff_exists {a : A} {z : ℂ} :
   refine' ⟨fun hz => _, _⟩
   · obtain ⟨f, hf⟩ := WeakDual.CharacterSpace.exists_apply_eq_zero hz
     simp only [map_sub, sub_eq_zero, AlgHomClass.commutes] at hf
-    exact ⟨_, hf.symm ⟩
+    exact ⟨_, hf.symm⟩
   · rintro ⟨f, rfl⟩
     exact AlgHom.apply_mem_spectrum f a
 #align weak_dual.character_space.mem_spectrum_iff_exists WeakDual.CharacterSpace.mem_spectrum_iff_exists

--- a/Mathlib/Analysis/NormedSpace/Star/GelfandDuality.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/GelfandDuality.lean
@@ -115,11 +115,8 @@ theorem WeakDual.CharacterSpace.mem_spectrum_iff_exists {a : A} {z : ℂ} :
     z ∈ spectrum ℂ a ↔ ∃ f : characterSpace ℂ A, f a = z := by
   refine' ⟨fun hz => _, _⟩
   · obtain ⟨f, hf⟩ := WeakDual.CharacterSpace.exists_apply_eq_zero hz
-    simp only [map_sub, sub_eq_zero, AlgHomClass.commutes, Algebra.id.map_eq_id,
-      RingHom.id_apply] at hf
-    refine ⟨f, ?_⟩
-    rw [AlgHomClass.commutes, Algebra.id.map_eq_id, RingHom.id_apply] at hf
-    exact hf.symm
+    simp only [map_sub, sub_eq_zero, AlgHomClass.commutes] at hf
+    exact ⟨_, hf.symm ⟩
   · rintro ⟨f, rfl⟩
     exact AlgHom.apply_mem_spectrum f a
 #align weak_dual.character_space.mem_spectrum_iff_exists WeakDual.CharacterSpace.mem_spectrum_iff_exists

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
@@ -295,7 +295,7 @@ def toQuaternion : CliffordAlgebra (Q c₁ c₂) →ₐ[R] ℍ[R,c₁,c₂] :=
   CliffordAlgebra.lift (Q c₁ c₂)
     ⟨{  toFun := fun v => (⟨0, v.1, v.2, 0⟩ : ℍ[R,c₁,c₂])
         map_add' := fun v₁ v₂ => by simp
-        map_smul' := fun r v => by dsimp; rw [mul_zero]; rfl }, fun v => by
+        map_smul' := fun r v => by dsimp; rw [mul_zero] }, fun v => by
       dsimp
       ext
       all_goals dsimp; ring⟩

--- a/Mathlib/RingTheory/Kaehler.lean
+++ b/Mathlib/RingTheory/Kaehler.lean
@@ -268,8 +268,7 @@ def Derivation.liftKaehlerDifferential (D : Derivation R S M) : Ω[S⁄R] →ₗ
     refine Submodule.smul_induction_on hx ?_ ?_
     · rintro x (hx : _ = _) y -
       dsimp
-      rw [show ↑(x • y) = x * ↑y by rfl, Derivation.tensorProductTo_mul, hx, y.prop, zero_smul,
-        zero_smul, zero_add]
+      rw [Derivation.tensorProductTo_mul, hx, y.prop, zero_smul, zero_smul, zero_add]
     · intro x y ex ey; rw [map_add, ex, ey, zero_add]
 #align derivation.lift_kaehler_differential Derivation.liftKaehlerDifferential
 

--- a/test/Simp.lean
+++ b/test/Simp.lean
@@ -1,0 +1,20 @@
+import Mathlib.Algebra.Algebra.Pi
+import Mathlib.Algebra.Algebra.Basic
+
+/-!
+Tests for the behavior of `simp`.
+--/
+
+/- Taken from [Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/
+  topic/simp.20.5BX.5D.20fails.2C.20rw.20.5BX.5D.20works) -/
+-- Example 1: succeeds
+example {α R : Type*} [CommRing R] (f : α → R) (r : R) (a : α) :
+    (r • f) a = r • (f a) := by
+  simp only [Pi.smul_apply] -- succeeds
+
+-- Example 2: used to fail, now succeeds!
+example {α R : Type*} [CommRing R] (f : α → R) (r : R) (a : α) :
+    (r • f) a = r • (f a) := by
+  let _ : SMul R R := SMulZeroClass.toSMul
+  simp only [Pi.smul_apply]
+


### PR DESCRIPTION
The current definition of `Algebra.id` is `(RingHom.id _).toAlgebra`. The problem with this is that `RingHom.id` is a `def` and is not reducible. Thus Lean will often refuse to unfold it causing unification to fail unecessarily in typeclass searches. This overrides the data fields from `RingHom.id`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
