### PR TITLE
feat: add Continuous{At}.eventually

### DIFF
--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -1751,7 +1751,20 @@ theorem continuous_iff_continuousAt : Continuous f ↔ ∀ x, ContinuousAt f x :
     hf x <| hU.mem_nhds hx⟩
 #align continuous_iff_continuous_at continuous_iff_continuousAt
 
-theorem continuousAt_const : ContinuousAt (fun _ : X => y) x :=
+theorem ContinuousAt.eventually {x₀ : X} (hf : ContinuousAt f x₀) (P : Y → Prop)
+    (hP : IsOpen {y | P y}) (hx₀ : P (f x₀)) : ∀ᶠ x in 𝓝 x₀, P (f x) :=
+  hf (isOpen_iff_mem_nhds.mp hP _ hx₀)
+
+theorem ContinuousAt.eventually' {x₀ : X} (hf : ContinuousAt f x₀) (P : Y → Prop)
+    (hP : ∀ᶠ y in 𝓝 (f x₀), P y) : ∀ᶠ x in 𝓝 x₀, P (f x) := by
+  rw [ContinuousAt, tendsto_iff_comap] at hf
+  exact Eventually.filter_mono hf (hP.comap f)
+
+theorem Continuous.eventually {x₀ : X} (hf : Continuous f) (P : Y → Prop)
+    (hP : IsOpen {y | P y}) (hx₀ : P (f x₀)) : ∀ᶠ x in 𝓝 x₀, P (f x) :=
+  hf.continuousAt.eventually P hP hx₀
+
+theorem continuousAt_const {x : X} {b : Y} : ContinuousAt (fun _ : X => b) x :=
   tendsto_const_nhds
 #align continuous_at_const continuousAt_const
 

--- a/Mathlib/Topology/DenseEmbedding.lean
+++ b/Mathlib/Topology/DenseEmbedding.lean
@@ -180,7 +180,7 @@ theorem extend_unique_at [T2Space γ] {b : β} {f : α → γ} {g : β → γ} (
   suffices : ∀ᶠ x : α in comap i (𝓝 b), g (i x) ∈ s
   exact hf.mp (this.mono fun x hgx hfx => hfx ▸ hgx)
   clear hf f
-  refine' eventually_comap.2 ((hg.eventually hs).mono _)
+  refine eventually_comap.2 ((Tendsto.eventually hg hs).mono ?_)
   rintro _ hxs x rfl
   exact hxs
 #align dense_inducing.extend_unique_at DenseInducing.extend_unique_at

--- a/Mathlib/Topology/DenseEmbedding.lean
+++ b/Mathlib/Topology/DenseEmbedding.lean
@@ -27,9 +27,7 @@ has to be `DenseInducing` (not necessarily injective).
 
 noncomputable section
 
-open Set Filter
-
-open Classical Topology Filter
+open Set Topology Filter
 
 variable {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
 
@@ -100,7 +98,7 @@ protected theorem prod [TopologicalSpace γ] [TopologicalSpace δ] {e₁ : α �
   dense := de₁.dense.prod_map de₂.dense
 #align dense_inducing.prod DenseInducing.prod
 
-open TopologicalSpace
+open TopologicalSpace (SeparableSpace)
 
 /-- If the domain of a `DenseInducing` map is a separable space, then so is the codomain. -/
 protected theorem separableSpace [SeparableSpace α] : SeparableSpace β :=


### PR DESCRIPTION
From sphere-eversion; I'm just submitting this.

-------
This causes an unfortunate name shadowing (conflicts with Filter.Tendsto.eventually): I'm not sure what the best fix is.
Update: this conflict occurs in a bunch of files. Hm.

Suggestions for a better home for these lemmas are also welcome.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
