### PR TITLE
feat: Finite instances for FunLike

### DIFF
--- a/Mathlib/Data/FunLike/Fintype.lean
+++ b/Mathlib/Data/FunLike/Fintype.lean
@@ -59,16 +59,18 @@ section Sort'
 
 variable (F G : Sort*) {α γ : Sort*} {β : α → Sort*} [DFunLike F α β] [FunLike G α γ]
 
+-- see Note [lower instance priority]
 /-- All `DFunLike`s are finite if their domain and codomain are.  -/
-instance DFunLike.finite [Finite α] [∀ i, Finite (β i)] : Finite F :=
+instance (priority := 100) DFunLike.finite [Finite α] [∀ i, Finite (β i)] : Finite F :=
   Finite.of_injective _ DFunLike.coe_injective
 #align fun_like.finite DFunLike.finite
 
+-- see Note [lower instance priority]
 /-- All `FunLike`s are finite if their domain and codomain are.
 
 Non-dependent version of `DFunLike.finite` that might be easier to infer.
 -/
-instance FunLike.finite [Finite α] [Finite γ] : Finite G :=
+instance (priority := 100) FunLike.finite [Finite α] [Finite γ] : Finite G :=
   DFunLike.finite G
 #align fun_like.finite' FunLike.finite
 

--- a/Mathlib/Data/FunLike/Fintype.lean
+++ b/Mathlib/Data/FunLike/Fintype.lean
@@ -59,20 +59,16 @@ section Sort'
 
 variable (F G : Sort*) {α γ : Sort*} {β : α → Sort*} [DFunLike F α β] [FunLike G α γ]
 
-/-- All `DFunLike`s are finite if their domain and codomain are.
-
-Can't be an instance because it can cause infinite loops.
--/
-theorem DFunLike.finite [Finite α] [∀ i, Finite (β i)] : Finite F :=
+/-- All `DFunLike`s are finite if their domain and codomain are.  -/
+instance DFunLike.finite [Finite α] [∀ i, Finite (β i)] : Finite F :=
   Finite.of_injective _ DFunLike.coe_injective
 #align fun_like.finite DFunLike.finite
 
 /-- All `FunLike`s are finite if their domain and codomain are.
 
 Non-dependent version of `DFunLike.finite` that might be easier to infer.
-Can't be an instance because it can cause infinite loops.
 -/
-theorem FunLike.finite [Finite α] [Finite γ] : Finite G :=
+instance FunLike.finite [Finite α] [Finite γ] : Finite G :=
   DFunLike.finite G
 #align fun_like.finite' FunLike.finite
 


### PR DESCRIPTION
If `F` is a `FunLike F α β` type, then it is finite if `α` and `β` both are. We already had this as a theorem, but it wasn't an instance because it could cause infinite loops; this should now be OK in Lean 4.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
