### PR TITLE
[Merged by Bors] - chore: uneven spacing for ⟨ ⟩

### DIFF
--- a/Mathlib/Algebra/Group/Aut.lean
+++ b/Mathlib/Algebra/Group/Aut.lean
@@ -256,7 +256,7 @@ protected theorem smul_def {A} [AddMonoid A] (f : AddAut A) (a : A) : f • a = 
 
 /-- `AddAut.applyDistribMulAction` is faithful. -/
 instance apply_faithfulSMul {A} [AddMonoid A] : FaithfulSMul (AddAut A) A :=
-  ⟨fun h => AddEquiv.ext h ⟩
+  ⟨fun h => AddEquiv.ext h⟩
 #align add_aut.apply_has_faithful_smul AddAut.apply_faithfulSMul
 
 /-- Additive group conjugation, `AddAut.conj g h = g + h - g`, as an additive monoid

--- a/Mathlib/Analysis/Calculus/Deriv/Inverse.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inverse.lean
@@ -106,7 +106,7 @@ theorem PartialHomeomorph.hasDerivAt_symm (f : PartialHomeomorph 𝕜 𝕜) {a f
 theorem HasDerivAt.eventually_ne (h : HasDerivAt f f' x) (hf' : f' ≠ 0) :
     ∀ᶠ z in 𝓝[≠] x, f z ≠ f x :=
   (hasDerivAt_iff_hasFDerivAt.1 h).eventually_ne
-    ⟨‖f'‖⁻¹, fun z => by field_simp [norm_smul, mt norm_eq_zero.1 hf'] ⟩
+    ⟨‖f'‖⁻¹, fun z => by field_simp [norm_smul, mt norm_eq_zero.1 hf']⟩
 #align has_deriv_at.eventually_ne HasDerivAt.eventually_ne
 
 theorem HasDerivAt.tendsto_punctured_nhds (h : HasDerivAt f f' x) (hf' : f' ≠ 0) :

--- a/Mathlib/Analysis/Convex/Cone/Proper.lean
+++ b/Mathlib/Analysis/Convex/Cone/Proper.lean
@@ -86,7 +86,7 @@ theorem mem_coe {x : E} {K : ProperCone 𝕜 E} : x ∈ (K : PointedCone 𝕜 E)
 instance instZero (K : ProperCone 𝕜 E) : Zero K := PointedCone.instZero (K.toSubmodule)
 
 protected theorem nonempty (K : ProperCone 𝕜 E) : (K : Set E).Nonempty :=
-  ⟨0, by { simp_rw [SetLike.mem_coe, ← ProperCone.mem_coe, Submodule.zero_mem] } ⟩
+  ⟨0, by { simp_rw [SetLike.mem_coe, ← ProperCone.mem_coe, Submodule.zero_mem] }⟩
 #align proper_cone.nonempty ProperCone.nonempty
 
 protected theorem isClosed (K : ProperCone 𝕜 E) : IsClosed (K : Set E) :=

--- a/Mathlib/Analysis/Normed/Order/Lattice.lean
+++ b/Mathlib/Analysis/Normed/Order/Lattice.lean
@@ -63,7 +63,7 @@ theorem LatticeOrderedAddCommGroup.isSolid_ball (r : ℝ) :
 
 instance : HasSolidNorm ℝ := ⟨fun _ _ => id⟩
 
-instance : HasSolidNorm ℚ := ⟨fun _ _ _ => by simpa only [norm, ← Rat.cast_abs, Rat.cast_le] ⟩
+instance : HasSolidNorm ℚ := ⟨fun _ _ _ => by simpa only [norm, ← Rat.cast_abs, Rat.cast_le]⟩
 
 end SolidNorm
 

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/SeparatingDual.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/SeparatingDual.lean
@@ -34,7 +34,7 @@ instance {E : Type*} [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGroup 
   ⟨fun x hx ↦ by
     rcases geometric_hahn_banach_point_point hx.symm with ⟨f, hf⟩
     simp only [map_zero] at hf
-    exact ⟨f, hf.ne'⟩ ⟩
+    exact ⟨f, hf.ne'⟩⟩
 
 instance {E 𝕜 : Type*} [IsROrC 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E] : SeparatingDual 𝕜 E :=
   ⟨fun x hx ↦ by

--- a/Mathlib/CategoryTheory/CofilteredSystem.lean
+++ b/Mathlib/CategoryTheory/CofilteredSystem.lean
@@ -158,7 +158,7 @@ theorem IsMittagLeffler.subset_image_eventualRange (h : F.IsMittagLeffler) (f : 
   obtain ⟨k, g, hg⟩ := F.isMittagLeffler_iff_eventualRange.1 h j
   rw [hg]; intro x hx
   obtain ⟨x, rfl⟩ := F.mem_eventualRange_iff.1 hx (g ≫ f)
-  refine' ⟨_, ⟨x, rfl⟩, by rw [map_comp_apply] ⟩
+  refine' ⟨_, ⟨x, rfl⟩, by rw [map_comp_apply]⟩
 #align category_theory.functor.is_mittag_leffler.subset_image_eventual_range CategoryTheory.Functor.IsMittagLeffler.subset_image_eventualRange
 
 theorem eventualRange_eq_range_precomp (f : i ⟶ j) (g : j ⟶ k)

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -104,7 +104,7 @@ theorem exists_bool {p : Bool → Prop} : (∃ b, p b) ↔ p false ∨ p true :=
   ⟨fun ⟨b, h⟩ ↦ by cases b; exact Or.inl h; exact Or.inr h,
   fun h ↦ match h with
   | .inl h => ⟨_, h⟩
-  | .inr h => ⟨_, h⟩ ⟩
+  | .inr h => ⟨_, h⟩⟩
 #align bool.exists_bool Bool.exists_bool
 
 /-- If `p b` is decidable for all `b : Bool`, then `∀ b, p b` is decidable -/

--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -676,7 +676,7 @@ theorem toFinset_nonempty {s : Set α} [Fintype s] : s.toFinset.Nonempty ↔ s.N
 
 @[simp]
 theorem toFinset_inj {s t : Set α} [Fintype s] [Fintype t] : s.toFinset = t.toFinset ↔ s = t :=
-  ⟨fun h => by rw [← s.coe_toFinset, h, t.coe_toFinset], fun h => by simp [h] ⟩
+  ⟨fun h => by rw [← s.coe_toFinset, h, t.coe_toFinset], fun h => by simp [h]⟩
 #align set.to_finset_inj Set.toFinset_inj
 
 @[mono]

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -227,7 +227,7 @@ class FiniteRk (M : Matroid α) : Prop where
   exists_finite_base : ∃ B, M.Base B ∧ B.Finite
 
 instance finiteRk_of_finite (M : Matroid α) [M.Finite] : FiniteRk M :=
-  ⟨ M.exists_base.imp (fun B hB ↦ ⟨hB, M.set_finite B (M.subset_ground _ hB)⟩) ⟩
+  ⟨M.exists_base.imp (fun B hB ↦ ⟨hB, M.set_finite B (M.subset_ground _ hB)⟩)⟩
 
 /-- An `InfiniteRk` matroid is one whose bases are infinite. -/
 class InfiniteRk (M : Matroid α) : Prop where
@@ -441,7 +441,7 @@ theorem base_compl_iff_mem_maximals_disjoint_base (hB : B ⊆ M.E := by aesop_ma
     M.Base (M.E \ B) ↔ B ∈ maximals (· ⊆ ·) {I | I ⊆ M.E ∧ ∃ B, M.Base B ∧ Disjoint I B} := by
   simp_rw [mem_maximals_setOf_iff, and_iff_right hB, and_imp, forall_exists_index]
   refine' ⟨fun h ↦ ⟨⟨_, h, disjoint_sdiff_right⟩,
-    fun I hI B' ⟨hB', hIB'⟩ hBI ↦ hBI.antisymm _⟩, fun ⟨⟨ B', hB', hBB'⟩,h⟩ ↦ _⟩
+    fun I hI B' ⟨hB', hIB'⟩ hBI ↦ hBI.antisymm _⟩, fun ⟨⟨B', hB', hBB'⟩,h⟩ ↦ _⟩
   · rw [hB'.eq_of_subset_base h, ← subset_compl_iff_disjoint_right, diff_eq, compl_inter,
       compl_compl] at hIB'
     · exact fun e he ↦  (hIB' he).elim (fun h' ↦ (h' (hI he)).elim) id

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -246,7 +246,7 @@ attribute [pp_dot] Indep E
       · obtain ⟨J, hJ, -, hJmax⟩ := hzorn
         exact ⟨J, hJ, fun K hK hJK ↦ (hJmax K hK hJK).subset⟩
 
-      refine fun Is hIs hchain ⟨K, hK⟩ ↦ ⟨⋃₀ Is, ⟨?_,?_,?_⟩, fun _ ↦ subset_sUnion_of_mem ⟩
+      refine fun Is hIs hchain ⟨K, hK⟩ ↦ ⟨⋃₀ Is, ⟨?_,?_,?_⟩, fun _ ↦ subset_sUnion_of_mem⟩
       · refine indep_compact _ fun J hJ hJfin ↦ ?_
         have hchoose : ∀ e, e ∈ J → ∃ I, I ∈ Is ∧ (e : α) ∈ I
         · exact fun _ he ↦ mem_sUnion.1 <| hJ he

--- a/Mathlib/Data/Nat/Cast/Order.lean
+++ b/Mathlib/Data/Nat/Cast/Order.lean
@@ -144,7 +144,7 @@ variable {R S F : Type*} [NonAssocSemiring R] [NonAssocSemiring S]
 
 theorem NeZero.nat_of_injective {n : ℕ} [h : NeZero (n : R)] [RingHomClass F R S] {f : F}
     (hf : Function.Injective f) : NeZero (n : S) :=
-  ⟨fun h ↦ NeZero.natCast_ne n R <| hf <| by simpa only [map_natCast, map_zero f] ⟩
+  ⟨fun h ↦ NeZero.natCast_ne n R <| hf <| by simpa only [map_natCast, map_zero f]⟩
 #align ne_zero.nat_of_injective NeZero.nat_of_injective
 
 end RingHomClass

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -123,7 +123,7 @@ def asSubtype (f : α →. β) (s : f.Dom) : β :=
 the type of pairs `(p : α → Prop, f : Subtype p → β)`. -/
 def equivSubtype : (α →. β) ≃ Σp : α → Prop, Subtype p → β :=
   ⟨fun f => ⟨fun a => (f a).Dom, asSubtype f⟩, fun f x => ⟨f.1 x, fun h => f.2 ⟨x, h⟩⟩, fun f =>
-    funext fun a => Part.eta _, fun ⟨p, f⟩ => by dsimp; congr ⟩
+    funext fun a => Part.eta _, fun ⟨p, f⟩ => by dsimp; congr⟩
 #align pfun.equiv_subtype PFun.equivSubtype
 
 theorem asSubtype_eq_of_mem {f : α →. β} {x : α} {y : β} (fxy : y ∈ f x) (domx : x ∈ f.Dom) :

--- a/Mathlib/Data/Polynomial/RingDivision.lean
+++ b/Mathlib/Data/Polynomial/RingDivision.lean
@@ -331,7 +331,7 @@ theorem Monic.not_irreducible_iff_exists_add_mul_eq_coeff (hm : p.Monic) (hnd : 
     simpa only [nextCoeff, hnd, add_right_cancel hda, hdb] using ha.nextCoeff_mul hb
   · rintro ⟨c₁, c₂, hmul, hadd⟩
     refine
-      ⟨X + C c₁, X + C c₂, monic_X_add_C _, monic_X_add_C _, ?_, ?_ ⟩
+      ⟨X + C c₁, X + C c₂, monic_X_add_C _, monic_X_add_C _, ?_, ?_⟩
     · rw [p.as_sum_range_C_mul_X_pow, hnd, Finset.sum_range_succ, Finset.sum_range_succ,
         Finset.sum_range_one, ← hnd, hm.coeff_natDegree, hnd, hmul, hadd, C_mul, C_add, C_1]
       ring

--- a/Mathlib/FieldTheory/Subfield.lean
+++ b/Mathlib/FieldTheory/Subfield.lean
@@ -942,7 +942,7 @@ private def commClosure (s : Set K) : Subfield K where
   neg_mem' {x} := by
     rintro ⟨y, hy, z, hz, x_eq⟩
     exact ⟨-y, Subring.neg_mem _ hy, z, hz, x_eq ▸ neg_div _ _⟩
-  inv_mem' x := by rintro ⟨y, hy, z, hz, x_eq⟩; exact ⟨z, hz, y, hy, x_eq ▸ (inv_div _ _).symm ⟩
+  inv_mem' x := by rintro ⟨y, hy, z, hz, x_eq⟩; exact ⟨z, hz, y, hy, x_eq ▸ (inv_div _ _).symm⟩
   add_mem' x_mem y_mem := by
     -- Use `id` in the next 2 `obtain`s so that assumptions stay there for the `rwa`s below
     obtain ⟨nx, hnx, dx, hdx, rfl⟩ := id x_mem

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
@@ -147,7 +147,7 @@ namespace SubMulAction
 variable [SMul R M]
 
 instance : SetLike (SubMulAction R M) M :=
-  ⟨SubMulAction.carrier, fun p q h => by cases p; cases q; congr ⟩
+  ⟨SubMulAction.carrier, fun p q h => by cases p; cases q; congr⟩
 
 instance : SMulMemClass (SubMulAction R M) R M where smul_mem := smul_mem' _
 

--- a/Mathlib/Lean/Message.lean
+++ b/Mathlib/Lean/Message.lean
@@ -13,4 +13,4 @@ set_option autoImplicit true
 
 open Lean Std Format MessageData
 instance [ToMessageData α] [ToMessageData β] : ToMessageData (α × β) :=
-  ⟨fun x => paren <| toMessageData x.1 ++ ofFormat "," ++ Format.line ++ toMessageData x.2 ⟩
+  ⟨fun x => paren <| toMessageData x.1 ++ ofFormat "," ++ Format.line ++ toMessageData x.2⟩

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -411,12 +411,12 @@ This element acts naturally on the Euclidean plane as a rotation about the origi
 This element also acts naturally on the hyperbolic plane as rotation about `i` by `π`. It
 represents the Mobiüs transformation `z ↦ -1/z` and is an involutive elliptic isometry. -/
 def S : SL(2, ℤ) :=
-  ⟨!![0, -1; 1, 0], by norm_num [Matrix.det_fin_two_of] ⟩
+  ⟨!![0, -1; 1, 0], by norm_num [Matrix.det_fin_two_of]⟩
 #align modular_group.S ModularGroup.S
 
 /-- The matrix `T = [[1, 1], [0, 1]]` as an element of `SL(2, ℤ)` -/
 def T : SL(2, ℤ) :=
-  ⟨!![1, 1; 0, 1], by norm_num [Matrix.det_fin_two_of] ⟩
+  ⟨!![1, 1; 0, 1], by norm_num [Matrix.det_fin_two_of]⟩
 #align modular_group.T ModularGroup.T
 
 theorem coe_S : ↑ₘS = !![0, -1; 1, 0] :=

--- a/Mathlib/LinearAlgebra/Span.lean
+++ b/Mathlib/LinearAlgebra/Span.lean
@@ -148,7 +148,7 @@ preserved under addition and scalar multiplication, then `p` holds for all eleme
 @[elab_as_elim]
 theorem span_induction {p : M → Prop} (h : x ∈ span R s) (Hs : ∀ x ∈ s, p x) (H0 : p 0)
     (H1 : ∀ x y, p x → p y → p (x + y)) (H2 : ∀ (a : R) (x), p x → p (a • x)) : p x :=
-  ((@span_le (p := ⟨ ⟨⟨p, by intros x y; exact H1 x y⟩, H0⟩, H2⟩)) s).2 Hs h
+  ((@span_le (p := ⟨⟨⟨p, by intros x y; exact H1 x y⟩, H0⟩, H2⟩)) s).2 Hs h
 #align submodule.span_induction Submodule.span_induction
 
 /-- An induction principle for span membership. This is a version of `Submodule.span_induction`

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -107,7 +107,7 @@ namespace Substructure
 attribute [coe] Substructure.carrier
 
 instance instSetLike : SetLike (L.Substructure M) M :=
-  ⟨Substructure.carrier, fun p q h => by cases p; cases q; congr ⟩
+  ⟨Substructure.carrier, fun p q h => by cases p; cases q; congr⟩
 #align first_order.language.substructure.set_like FirstOrder.Language.Substructure.instSetLike
 
 /-- See Note [custom simps projection] -/

--- a/Mathlib/Order/Filter/Archimedean.lean
+++ b/Mathlib/Order/Filter/Archimedean.lean
@@ -91,7 +91,7 @@ theorem Rat.comap_cast_atTop [LinearOrderedField R] [Archimedean R] :
     comap ((↑) : ℚ → R) atBot = atBot :=
   comap_embedding_atBot (fun _ _ => Rat.cast_le) fun r =>
     let ⟨n, hn⟩ := exists_nat_ge (-r)
-    ⟨-n, by simpa [neg_le] ⟩
+    ⟨-n, by simpa [neg_le]⟩
 #align rat.comap_coe_at_bot Rat.comap_cast_atBot
 
 theorem tendsto_rat_cast_atTop_iff [LinearOrderedField R] [Archimedean R] {f : α → ℚ}

--- a/Mathlib/RingTheory/ClassGroup.lean
+++ b/Mathlib/RingTheory/ClassGroup.lean
@@ -389,7 +389,7 @@ theorem ClassGroup.mk0_integralRep [IsDedekindDomain R]
 theorem ClassGroup.mk0_surjective [IsDedekindDomain R] :
     Function.Surjective (ClassGroup.mk0 : (Ideal R)⁰ → ClassGroup R) := by
   rintro ⟨I⟩
-  refine ⟨⟨ ClassGroup.integralRep I.1, ClassGroup.integralRep_mem_nonZeroDivisors I.ne_zero⟩, ?_⟩
+  refine ⟨⟨ClassGroup.integralRep I.1, ClassGroup.integralRep_mem_nonZeroDivisors I.ne_zero⟩, ?_⟩
   rw [ClassGroup.mk0_integralRep, ClassGroup.Quot_mk_eq_mk]
 #align class_group.mk0_surjective ClassGroup.mk0_surjective
 

--- a/Mathlib/Topology/Algebra/ValuedField.lean
+++ b/Mathlib/Topology/Algebra/ValuedField.lean
@@ -326,7 +326,7 @@ theorem closure_coe_completion_v_lt {γ : Γ₀ˣ} :
     · simp only [h, (Valuation.zero_iff _).mp h, mem_setOf_eq, Valuation.map_zero, Units.zero_lt,
         iff_true_iff]
       apply subset_closure
-      exact ⟨0, by simp only [mem_setOf_eq, Valuation.map_zero, Units.zero_lt, true_and_iff]; rfl ⟩
+      exact ⟨0, by simp only [mem_setOf_eq, Valuation.map_zero, Units.zero_lt, true_and_iff]; rfl⟩
     · exact this h
   intro h
   have hγ₀ : extension ⁻¹' {γ₀} ∈ 𝓝 x :=

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -109,7 +109,7 @@ Generally you should just use `limit.isLimit F`, unless you need the actual defi
 def limitConeInfiIsLimit (F : J ⥤ TopCatMax.{v, u}) : IsLimit (limitConeInfi.{v,u} F) := by
   refine IsLimit.ofFaithful forget (Types.limitConeIsLimit.{v,u} (F ⋙ forget))
     -- Porting note: previously could infer all ?_ except continuity
-    (fun s => ⟨fun v => ⟨ fun j => (Functor.mapCone forget s).π.app j v, ?_⟩, ?_⟩) fun s => ?_
+    (fun s => ⟨fun v => ⟨fun j => (Functor.mapCone forget s).π.app j v, ?_⟩, ?_⟩) fun s => ?_
   · dsimp [Functor.sections]
     intro _ _ _
     rw [← comp_apply', forget_map_eq_coe, ← s.π.naturality, forget_map_eq_coe]

--- a/Mathlib/Topology/Clopen.lean
+++ b/Mathlib/Topology/Clopen.lean
@@ -154,7 +154,7 @@ theorem continuous_boolIndicator_iff_isClopen (U : Set X) :
   constructor
   · intro hc
     rw [← U.preimage_boolIndicator_true]
-    exact ⟨(isClosed_discrete _).preimage hc, (isOpen_discrete _).preimage hc, ⟩
+    exact ⟨(isClosed_discrete _).preimage hc, (isOpen_discrete _).preimage hc⟩
   · refine' fun hU => ⟨fun s _ => _⟩
     rcases U.preimage_boolIndicator s with (h | h | h | h) <;> rw [h]
     exacts [isOpen_univ, hU.2, hU.1.isOpen_compl, isOpen_empty]

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -248,7 +248,7 @@ theorem isLindelof_of_countable_subcover
   simp only [ClusterPt, not_neBot, ← disjoint_iff, SetCoe.forall',
     (nhds_basis_opens _).disjoint_iff_left] at h
   choose fsub U hU hUf using h
-  refine ⟨s, U, fun x ↦ (hU x).2, fun x hx ↦ mem_iUnion.2 ⟨⟨x, hx⟩, (hU _).1 ⟩, ?_ ⟩
+  refine ⟨s, U, fun x ↦ (hU x).2, fun x hx ↦ mem_iUnion.2 ⟨⟨x, hx⟩, (hU _).1 ⟩, ?_⟩
   intro t ht h
   have uinf := f.sets_of_superset (le_principal_iff.1 fsub) h
   have uninf : ⋂ i ∈ t, (U i)ᶜ ∈ f := (countable_bInter_mem ht).mpr (fun _ _ ↦ hUf _)

--- a/Mathlib/Topology/StoneCech.lean
+++ b/Mathlib/Topology/StoneCech.lean
@@ -98,7 +98,7 @@ instance : TotallyDisconnectedSpace (Ultrafilter α) := by
   intro s hs
   rw [connectedComponent_eq_iInter_isClopen, Set.mem_iInter] at hB
   let Z := { F : Ultrafilter α | s ∈ F }
-  have hZ : IsClopen Z := ⟨ ultrafilter_isClosed_basic s, ultrafilter_isOpen_basic s⟩
+  have hZ : IsClopen Z := ⟨ultrafilter_isClosed_basic s, ultrafilter_isOpen_basic s⟩
   exact hB ⟨Z, hZ, hs⟩
 
 @[simp] theorem Ultrafilter.tendsto_pure_self (b : Ultrafilter α) : Tendsto pure b (𝓝 b) := by

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -271,7 +271,7 @@ class FooClass (α) : Prop where
   refle : ∀ a : α, a = a
 
 @[to_additive]
-instance FooClass_one [One α] : FooClass α := ⟨λ _ => rfl ⟩
+instance FooClass_one [One α] : FooClass α := ⟨λ _ => rfl⟩
 
 lemma one_fooClass [One α] : FooClass α := by infer_instance
 


### PR DESCRIPTION
This cleans up instances of 
```
⟨ foo, bar⟩
```
and
```
⟨foo, bar ⟩
```
where spaces a on the inside one side, but not on the other side. Fixing this by removing the extra space.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
