### PR TITLE
[Merged by Bors] - fix: `Clm` -> `CLM`, `Cle` -> `CLE`

### DIFF
--- a/Counterexamples/Phillips.lean
+++ b/Counterexamples/Phillips.lean
@@ -439,16 +439,16 @@ def _root_.ContinuousLinearMap.toBoundedAdditiveMeasure [TopologicalSpace α] [D
 #align continuous_linear_map.to_bounded_additive_measure ContinuousLinearMap.toBoundedAdditiveMeasure
 
 @[simp]
-theorem continuousPart_evalClm_eq_zero [TopologicalSpace α] [DiscreteTopology α] (s : Set α)
-    (x : α) : (evalClm ℝ x).toBoundedAdditiveMeasure.continuousPart s = 0 :=
-  let f := (evalClm ℝ x).toBoundedAdditiveMeasure
+theorem continuousPart_evalCLM_eq_zero [TopologicalSpace α] [DiscreteTopology α] (s : Set α)
+    (x : α) : (evalCLM ℝ x).toBoundedAdditiveMeasure.continuousPart s = 0 :=
+  let f := (evalCLM ℝ x).toBoundedAdditiveMeasure
   calc
     f.continuousPart s = f.continuousPart (s \ {x}) :=
       (continuousPart_apply_diff _ _ _ (countable_singleton x)).symm
     _ = f (univ \ f.discreteSupport ∩ (s \ {x})) := rfl
     _ = indicator (univ \ f.discreteSupport ∩ (s \ {x})) 1 x := rfl
     _ = 0 := by simp
-#align counterexample.phillips_1940.continuous_part_eval_clm_eq_zero Counterexample.Phillips1940.continuousPart_evalClm_eq_zero
+#align counterexample.phillips_1940.continuous_part_eval_clm_eq_zero Counterexample.Phillips1940.continuousPart_evalCLM_eq_zero
 
 theorem toFunctions_toMeasure [MeasurableSpace α] (μ : Measure α) [IsFiniteMeasure μ] (s : Set α)
     (hs : MeasurableSet s) :
@@ -638,7 +638,7 @@ theorem no_pettis_integral (Hcont : #ℝ = aleph 1) :
   simp only [integral_comp] at h
   have : g = 0 := by
     ext x
-    have : g x = evalClm ℝ x g := rfl
+    have : g x = evalCLM ℝ x g := rfl
     rw [this, ← h]
     simp
   simp only [this, ContinuousLinearMap.map_zero] at h

--- a/Mathlib/Analysis/Calculus/Deriv/Mul.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Mul.lean
@@ -334,7 +334,7 @@ theorem deriv_div_const (d : 𝕜') : deriv (fun x => c x / d) x = deriv c x / d
 
 end Div
 
-section ClmCompApply
+section CLMCompApply
 
 /-! ### Derivative of the pointwise composition/application of continuous linear maps -/
 
@@ -410,4 +410,4 @@ theorem deriv_clm_apply (hc : DifferentiableAt 𝕜 c x) (hu : DifferentiableAt 
   (hc.hasDerivAt.clm_apply hu.hasDerivAt).deriv
 #align deriv_clm_apply deriv_clm_apply
 
-end ClmCompApply
+end CLMCompApply

--- a/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
@@ -49,7 +49,7 @@ variable {s t : Set E}
 
 variable {L L₁ L₂ : Filter E}
 
-section ClmCompApply
+section CLMCompApply
 
 /-! ### Derivative of the pointwise composition/application of continuous linear maps -/
 
@@ -157,7 +157,7 @@ theorem fderiv_clm_apply (hc : DifferentiableAt 𝕜 c x) (hu : DifferentiableAt
   (hc.hasFDerivAt.clm_apply hu.hasFDerivAt).fderiv
 #align fderiv_clm_apply fderiv_clm_apply
 
-end ClmCompApply
+end CLMCompApply
 
 section SMul
 

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -23,10 +23,10 @@ This file registers `ℂ` as a normed field, expresses basic properties of the n
 tools on the real vector space structure of `ℂ`. Notably, in the namespace `Complex`,
 it defines functions:
 
-* `reClm`
-* `imClm`
-* `ofRealClm`
-* `conjCle`
+* `reCLM`
+* `imCLM`
+* `ofRealCLM`
+* `conjCLE`
 
 They are bundled versions of the real part, the imaginary part, the embedding of `ℝ` in `ℂ`, and
 the complex conjugate as continuous `ℝ`-linear maps. The last two are also bundled as linear
@@ -234,16 +234,16 @@ instance : CompleteSpace ℂ :=
 
 /-- The natural `ContinuousLinearEquiv` from `ℂ` to `ℝ × ℝ`. -/
 @[simps! (config := { simpRhs := true }) apply symm_apply_re symm_apply_im]
-def equivRealProdClm : ℂ ≃L[ℝ] ℝ × ℝ :=
+def equivRealProdCLM : ℂ ≃L[ℝ] ℝ × ℝ :=
   equivRealProdLm.toContinuousLinearEquivOfBounds 1 (Real.sqrt 2) equivRealProd_apply_le' fun p =>
     abs_le_sqrt_two_mul_max (equivRealProd.symm p)
-#align complex.equiv_real_prod_clm Complex.equivRealProdClm
+#align complex.equiv_real_prod_clm Complex.equivRealProdCLM
 
-theorem equivRealProdClm_symm_apply (p : ℝ × ℝ) :
-    Complex.equivRealProdClm.symm p = p.1 + p.2 * Complex.I := Complex.equivRealProd_symm_apply p
+theorem equivRealProdCLM_symm_apply (p : ℝ × ℝ) :
+    Complex.equivRealProdCLM.symm p = p.1 + p.2 * Complex.I := Complex.equivRealProd_symm_apply p
 
 instance : ProperSpace ℂ :=
-  (id lipschitz_equivRealProd : LipschitzWith 1 equivRealProdClm.toHomeomorph).properSpace
+  (id lipschitz_equivRealProd : LipschitzWith 1 equivRealProdCLM.toHomeomorph).properSpace
 
 /-- The `abs` function on `ℂ` is proper. -/
 theorem tendsto_abs_cocompact_atTop : Tendsto abs (cocompact ℂ) atTop :=
@@ -259,48 +259,48 @@ theorem tendsto_normSq_cocompact_atTop : Tendsto normSq (cocompact ℂ) atTop :=
 open ContinuousLinearMap
 
 /-- Continuous linear map version of the real part function, from `ℂ` to `ℝ`. -/
-def reClm : ℂ →L[ℝ] ℝ :=
+def reCLM : ℂ →L[ℝ] ℝ :=
   reLm.mkContinuous 1 fun x => by simp [abs_re_le_abs]
-#align complex.re_clm Complex.reClm
+#align complex.re_clm Complex.reCLM
 
 @[continuity]
 theorem continuous_re : Continuous re :=
-  reClm.continuous
+  reCLM.continuous
 #align complex.continuous_re Complex.continuous_re
 
 @[simp]
-theorem reClm_coe : (reClm : ℂ →ₗ[ℝ] ℝ) = reLm :=
+theorem reCLM_coe : (reCLM : ℂ →ₗ[ℝ] ℝ) = reLm :=
   rfl
-#align complex.re_clm_coe Complex.reClm_coe
+#align complex.re_clm_coe Complex.reCLM_coe
 
 @[simp]
-theorem reClm_apply (z : ℂ) : (reClm : ℂ → ℝ) z = z.re :=
+theorem reCLM_apply (z : ℂ) : (reCLM : ℂ → ℝ) z = z.re :=
   rfl
-#align complex.re_clm_apply Complex.reClm_apply
+#align complex.re_clm_apply Complex.reCLM_apply
 
 /-- Continuous linear map version of the imaginary part function, from `ℂ` to `ℝ`. -/
-def imClm : ℂ →L[ℝ] ℝ :=
+def imCLM : ℂ →L[ℝ] ℝ :=
   imLm.mkContinuous 1 fun x => by simp [abs_im_le_abs]
-#align complex.im_clm Complex.imClm
+#align complex.im_clm Complex.imCLM
 
 @[continuity]
 theorem continuous_im : Continuous im :=
-  imClm.continuous
+  imCLM.continuous
 #align complex.continuous_im Complex.continuous_im
 
 @[simp]
-theorem imClm_coe : (imClm : ℂ →ₗ[ℝ] ℝ) = imLm :=
+theorem imCLM_coe : (imCLM : ℂ →ₗ[ℝ] ℝ) = imLm :=
   rfl
-#align complex.im_clm_coe Complex.imClm_coe
+#align complex.im_clm_coe Complex.imCLM_coe
 
 @[simp]
-theorem imClm_apply (z : ℂ) : (imClm : ℂ → ℝ) z = z.im :=
+theorem imCLM_apply (z : ℂ) : (imCLM : ℂ → ℝ) z = z.im :=
   rfl
-#align complex.im_clm_apply Complex.imClm_apply
+#align complex.im_clm_apply Complex.imCLM_apply
 
 theorem restrictScalars_one_smulRight' (x : E) :
     ContinuousLinearMap.restrictScalars ℝ ((1 : ℂ →L[ℂ] ℂ).smulRight x : ℂ →L[ℂ] E) =
-      reClm.smulRight x + I • imClm.smulRight x := by
+      reCLM.smulRight x + I • imCLM.smulRight x := by
   ext ⟨a, b⟩
   simp [mk_eq_add_mul_I, mul_smul, smul_comm I b x]
 #align complex.restrict_scalars_one_smul_right' Complex.restrictScalars_one_smulRight'
@@ -366,17 +366,17 @@ theorem ringHom_eq_id_or_conj_of_continuous {f : ℂ →+* ℂ} (hf : Continuous
 #align complex.ring_hom_eq_id_or_conj_of_continuous Complex.ringHom_eq_id_or_conj_of_continuous
 
 /-- Continuous linear equiv version of the conj function, from `ℂ` to `ℂ`. -/
-def conjCle : ℂ ≃L[ℝ] ℂ :=
+def conjCLE : ℂ ≃L[ℝ] ℂ :=
   conjLie
-#align complex.conj_cle Complex.conjCle
+#align complex.conj_cle Complex.conjCLE
 
 @[simp]
-theorem conjCle_coe : conjCle.toLinearEquiv = conjAe.toLinearEquiv :=
+theorem conjCLE_coe : conjCLE.toLinearEquiv = conjAe.toLinearEquiv :=
   rfl
 #align complex.conj_cle_coe Complex.conjCle_coe
 
 @[simp]
-theorem conjCle_apply (z : ℂ) : conjCle z = conj z :=
+theorem conjCLE_apply (z : ℂ) : conjCLE z = conj z :=
   rfl
 #align complex.conj_cle_apply Complex.conjCle_apply
 
@@ -401,19 +401,19 @@ theorem ringHom_eq_ofReal_of_continuous {f : ℝ →+* ℂ} (h : Continuous f) :
 #align complex.ring_hom_eq_of_real_of_continuous Complex.ringHom_eq_ofReal_of_continuous
 
 /-- Continuous linear map version of the canonical embedding of `ℝ` in `ℂ`. -/
-def ofRealClm : ℝ →L[ℝ] ℂ :=
+def ofRealCLM : ℝ →L[ℝ] ℂ :=
   ofRealLi.toContinuousLinearMap
-#align complex.of_real_clm Complex.ofRealClm
+#align complex.of_real_clm Complex.ofRealCLM
 
 @[simp]
-theorem ofRealClm_coe : (ofRealClm : ℝ →ₗ[ℝ] ℂ) = ofRealAm.toLinearMap :=
+theorem ofRealCLM_coe : (ofRealCLM : ℝ →ₗ[ℝ] ℂ) = ofRealAm.toLinearMap :=
   rfl
-#align complex.of_real_clm_coe Complex.ofRealClm_coe
+#align complex.of_real_clm_coe Complex.ofRealCLM_coe
 
 @[simp]
-theorem ofRealClm_apply (x : ℝ) : ofRealClm x = x :=
+theorem ofRealCLM_apply (x : ℝ) : ofRealCLM x = x :=
   rfl
-#align complex.of_real_clm_apply Complex.ofRealClm_apply
+#align complex.of_real_clm_apply Complex.ofRealCLM_apply
 
 noncomputable instance : IsROrC ℂ where
   re := ⟨⟨Complex.re, Complex.zero_re⟩, Complex.add_re⟩
@@ -531,11 +531,11 @@ variable {α : Type*} (𝕜 : Type*) [IsROrC 𝕜]
 
 @[simp]
 theorem hasSum_conj {f : α → 𝕜} {x : 𝕜} : HasSum (fun x => conj (f x)) x ↔ HasSum f (conj x) :=
-  conjCle.hasSum
+  conjCLE.hasSum
 #align is_R_or_C.has_sum_conj IsROrC.hasSum_conj
 
 theorem hasSum_conj' {f : α → 𝕜} {x : 𝕜} : HasSum (fun x => conj (f x)) (conj x) ↔ HasSum f x :=
-  conjCle.hasSum'
+  conjCLE.hasSum'
 #align is_R_or_C.has_sum_conj' IsROrC.hasSum_conj'
 
 @[simp]
@@ -553,38 +553,38 @@ variable (𝕜)
 
 @[simp, norm_cast]
 theorem hasSum_ofReal {f : α → ℝ} {x : ℝ} : HasSum (fun x => (f x : 𝕜)) x ↔ HasSum f x :=
-  ⟨fun h => by simpa only [IsROrC.reClm_apply, IsROrC.ofReal_re] using reClm.hasSum h,
-    ofRealClm.hasSum⟩
+  ⟨fun h => by simpa only [IsROrC.reCLM_apply, IsROrC.ofReal_re] using reCLM.hasSum h,
+    ofRealCLM.hasSum⟩
 #align is_R_or_C.has_sum_of_real IsROrC.hasSum_ofReal
 
 @[simp, norm_cast]
 theorem summable_ofReal {f : α → ℝ} : (Summable fun x => (f x : 𝕜)) ↔ Summable f :=
-  ⟨fun h => by simpa only [IsROrC.reClm_apply, IsROrC.ofReal_re] using reClm.summable h,
-    ofRealClm.summable⟩
+  ⟨fun h => by simpa only [IsROrC.reCLM_apply, IsROrC.ofReal_re] using reCLM.summable h,
+    ofRealCLM.summable⟩
 #align is_R_or_C.summable_of_real IsROrC.summable_ofReal
 
 @[norm_cast]
 theorem ofReal_tsum (f : α → ℝ) : (↑(∑' a, f a) : 𝕜) = ∑' a, (f a : 𝕜) := by
   by_cases h : Summable f
-  · exact ContinuousLinearMap.map_tsum ofRealClm h
+  · exact ContinuousLinearMap.map_tsum ofRealCLM h
   · rw [tsum_eq_zero_of_not_summable h,
       tsum_eq_zero_of_not_summable ((summable_ofReal _).not.mpr h), ofReal_zero]
 #align is_R_or_C.of_real_tsum IsROrC.ofReal_tsum
 
 theorem hasSum_re {f : α → 𝕜} {x : 𝕜} (h : HasSum f x) : HasSum (fun x => re (f x)) (re x) :=
-  reClm.hasSum h
+  reCLM.hasSum h
 #align is_R_or_C.has_sum_re IsROrC.hasSum_re
 
 theorem hasSum_im {f : α → 𝕜} {x : 𝕜} (h : HasSum f x) : HasSum (fun x => im (f x)) (im x) :=
-  imClm.hasSum h
+  imCLM.hasSum h
 #align is_R_or_C.has_sum_im IsROrC.hasSum_im
 
 theorem re_tsum {f : α → 𝕜} (h : Summable f) : re (∑' a, f a) = ∑' a, re (f a) :=
-  reClm.map_tsum h
+  reCLM.map_tsum h
 #align is_R_or_C.re_tsum IsROrC.re_tsum
 
 theorem im_tsum {f : α → 𝕜} (h : Summable f) : im (∑' a, f a) = ∑' a, im (f a) :=
-  imClm.map_tsum h
+  imCLM.map_tsum h
 #align is_R_or_C.im_tsum IsROrC.im_tsum
 
 variable {𝕜}

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -30,7 +30,7 @@ it defines functions:
 
 They are bundled versions of the real part, the imaginary part, the embedding of `ℝ` in `ℂ`, and
 the complex conjugate as continuous `ℝ`-linear maps. The last two are also bundled as linear
-isometries in `ofRealLi` and `conjLie`.
+isometries in `ofRealLI` and `conjLIE`.
 
 We also register the fact that `ℂ` is an `IsROrC` field.
 -/
@@ -314,22 +314,22 @@ theorem restrictScalars_one_smulRight (x : ℂ) :
 #align complex.restrict_scalars_one_smul_right Complex.restrictScalars_one_smulRight
 
 /-- The complex-conjugation function from `ℂ` to itself is an isometric linear equivalence. -/
-def conjLie : ℂ ≃ₗᵢ[ℝ] ℂ :=
+def conjLIE : ℂ ≃ₗᵢ[ℝ] ℂ :=
   ⟨conjAe.toLinearEquiv, abs_conj⟩
-#align complex.conj_lie Complex.conjLie
+#align complex.conj_lie Complex.conjLIE
 
 @[simp]
-theorem conjLie_apply (z : ℂ) : conjLie z = conj z :=
+theorem conjLIE_apply (z : ℂ) : conjLIE z = conj z :=
   rfl
-#align complex.conj_lie_apply Complex.conjLie_apply
+#align complex.conj_lie_apply Complex.conjLIE_apply
 
 @[simp]
-theorem conjLie_symm : conjLie.symm = conjLie :=
+theorem conjLIE_symm : conjLIE.symm = conjLIE :=
   rfl
-#align complex.conj_lie_symm Complex.conjLie_symm
+#align complex.conj_lie_symm Complex.conjLIE_symm
 
 theorem isometry_conj : Isometry (conj : ℂ → ℂ) :=
-  conjLie.isometry
+  conjLIE.isometry
 #align complex.isometry_conj Complex.isometry_conj
 
 @[simp]
@@ -351,7 +351,7 @@ theorem nndist_conj_comm (z w : ℂ) : nndist (conj z) w = nndist z (conj w) :=
 #align complex.nndist_conj_comm Complex.nndist_conj_comm
 
 instance : ContinuousStar ℂ :=
-  ⟨conjLie.continuous⟩
+  ⟨conjLIE.continuous⟩
 
 @[continuity]
 theorem continuous_conj : Continuous (conj : ℂ → ℂ) :=
@@ -367,7 +367,7 @@ theorem ringHom_eq_id_or_conj_of_continuous {f : ℂ →+* ℂ} (hf : Continuous
 
 /-- Continuous linear equiv version of the conj function, from `ℂ` to `ℂ`. -/
 def conjCLE : ℂ ≃L[ℝ] ℂ :=
-  conjLie
+  conjLIE
 #align complex.conj_cle Complex.conjCLE
 
 @[simp]
@@ -381,17 +381,17 @@ theorem conjCLE_apply (z : ℂ) : conjCLE z = conj z :=
 #align complex.conj_cle_apply Complex.conjCLE_apply
 
 /-- Linear isometry version of the canonical embedding of `ℝ` in `ℂ`. -/
-def ofRealLi : ℝ →ₗᵢ[ℝ] ℂ :=
+def ofRealLI : ℝ →ₗᵢ[ℝ] ℂ :=
   ⟨ofRealAm.toLinearMap, norm_real⟩
-#align complex.of_real_li Complex.ofRealLi
+#align complex.of_real_li Complex.ofRealLI
 
 theorem isometry_ofReal : Isometry ((↑) : ℝ → ℂ) :=
-  ofRealLi.isometry
+  ofRealLI.isometry
 #align complex.isometry_of_real Complex.isometry_ofReal
 
 @[continuity]
 theorem continuous_ofReal : Continuous ((↑) : ℝ → ℂ) :=
-  ofRealLi.continuous
+  ofRealLI.continuous
 #align complex.continuous_of_real Complex.continuous_ofReal
 
 /-- The only continuous ring homomorphism from `ℝ` to `ℂ` is the identity. -/
@@ -402,7 +402,7 @@ theorem ringHom_eq_ofReal_of_continuous {f : ℝ →+* ℂ} (h : Continuous f) :
 
 /-- Continuous linear map version of the canonical embedding of `ℝ` in `ℂ`. -/
 def ofRealCLM : ℝ →L[ℝ] ℂ :=
-  ofRealLi.toContinuousLinearMap
+  ofRealLI.toContinuousLinearMap
 #align complex.of_real_clm Complex.ofRealCLM
 
 @[simp]

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -373,12 +373,12 @@ def conjCLE : ℂ ≃L[ℝ] ℂ :=
 @[simp]
 theorem conjCLE_coe : conjCLE.toLinearEquiv = conjAe.toLinearEquiv :=
   rfl
-#align complex.conj_cle_coe Complex.conjCle_coe
+#align complex.conj_cle_coe Complex.conjCLE_coe
 
 @[simp]
 theorem conjCLE_apply (z : ℂ) : conjCLE z = conj z :=
   rfl
-#align complex.conj_cle_apply Complex.conjCle_apply
+#align complex.conj_cle_apply Complex.conjCLE_apply
 
 /-- Linear isometry version of the canonical embedding of `ℝ` in `ℂ`. -/
 def ofRealLi : ℝ →ₗᵢ[ℝ] ℂ :=

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -173,7 +173,7 @@ theorem integral_boundary_rect_of_hasFDerivAt_real_off_countable (f : ℂ → E)
       I • (∫ y : ℝ in z.im..w.im, f (re w + y * I)) -
       I • ∫ y : ℝ in z.im..w.im, f (re z + y * I) =
       ∫ x : ℝ in z.re..w.re, ∫ y : ℝ in z.im..w.im, I • f' (x + y * I) 1 - f' (x + y * I) I := by
-  set e : (ℝ × ℝ) ≃L[ℝ] ℂ := equivRealProdClm.symm
+  set e : (ℝ × ℝ) ≃L[ℝ] ℂ := equivRealProdCLM.symm
   have he : ∀ x y : ℝ, ↑x + ↑y * I = e (x, y) := fun x y => (mk_eq_add_mul_I x y).symm
   have he₁ : e (1, 0) = 1 := rfl; have he₂ : e (0, 1) = I := rfl
   simp only [he] at *

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -97,7 +97,7 @@ theorem IsConformalMap.is_complex_or_conj_linear (h : IsConformalMap g) :
     rw [coe_restrictScalars', smul_apply, smul_apply, comp_apply, smul_apply,
       LinearIsometry.coe_toContinuousLinearMap, LinearIsometryEquiv.coe_toLinearIsometry,
       LinearIsometryEquiv.trans_apply, rotation_apply, id_apply, smul_eq_mul,
-      ContinuousLinearEquiv.coe_coe, conjCle_apply, conjLie_apply, conj_conj]
+      ContinuousLinearEquiv.coe_coe, conjCLE_apply, conjLie_apply, conj_conj]
 #align is_conformal_map.is_complex_or_conj_linear IsConformalMap.is_complex_or_conj_linear
 
 /-- A real continuous linear map on the complex plane is conformal if and only if the map or its
@@ -116,7 +116,7 @@ theorem isConformalMap_iff_is_complex_or_conj_linear :
     · have minor₁ : g = map.restrictScalars ℝ ∘L ↑conjCLE := by
         ext1
         simp only [hmap, coe_comp', ContinuousLinearEquiv.coe_coe, Function.comp_apply,
-          conjCle_apply, starRingEnd_self_apply]
+          conjCLE_apply, starRingEnd_self_apply]
       rw [minor₁] at h₂ ⊢
       refine' isConformalMap_complex_linear_conj _
       contrapose! h₂ with w

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -37,8 +37,8 @@ noncomputable section
 
 open Complex ContinuousLinearMap ComplexConjugate
 
-theorem isConformalMap_conj : IsConformalMap (conjLie : ℂ →L[ℝ] ℂ) :=
-  conjLie.toLinearIsometry.isConformalMap
+theorem isConformalMap_conj : IsConformalMap (conjLIE : ℂ →L[ℝ] ℂ) :=
+  conjLIE.toLinearIsometry.isConformalMap
 #align is_conformal_map_conj isConformalMap_conj
 
 section ConformalIntoComplexNormed
@@ -97,7 +97,7 @@ theorem IsConformalMap.is_complex_or_conj_linear (h : IsConformalMap g) :
     rw [coe_restrictScalars', smul_apply, smul_apply, comp_apply, smul_apply,
       LinearIsometry.coe_toContinuousLinearMap, LinearIsometryEquiv.coe_toLinearIsometry,
       LinearIsometryEquiv.trans_apply, rotation_apply, id_apply, smul_eq_mul,
-      ContinuousLinearEquiv.coe_coe, conjCLE_apply, conjLie_apply, conj_conj]
+      ContinuousLinearEquiv.coe_coe, conjCLE_apply, conjLIE_apply, conj_conj]
 #align is_conformal_map.is_complex_or_conj_linear IsConformalMap.is_complex_or_conj_linear
 
 /-- A real continuous linear map on the complex plane is conformal if and only if the map or its

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -65,7 +65,7 @@ theorem isConformalMap_complex_linear {map : ℂ →L[ℂ] E} (nonzero : map ≠
 #align is_conformal_map_complex_linear isConformalMap_complex_linear
 
 theorem isConformalMap_complex_linear_conj {map : ℂ →L[ℂ] E} (nonzero : map ≠ 0) :
-    IsConformalMap ((map.restrictScalars ℝ).comp (conjCle : ℂ →L[ℝ] ℂ)) :=
+    IsConformalMap ((map.restrictScalars ℝ).comp (conjCLE : ℂ →L[ℝ] ℂ)) :=
   (isConformalMap_complex_linear nonzero).comp isConformalMap_conj
 #align is_conformal_map_complex_linear_conj isConformalMap_complex_linear_conj
 
@@ -79,7 +79,7 @@ variable {f : ℂ → ℂ} {z : ℂ} {g : ℂ →L[ℝ] ℂ}
 
 theorem IsConformalMap.is_complex_or_conj_linear (h : IsConformalMap g) :
     (∃ map : ℂ →L[ℂ] ℂ, map.restrictScalars ℝ = g) ∨
-      ∃ map : ℂ →L[ℂ] ℂ, map.restrictScalars ℝ = g ∘L ↑conjCle := by
+      ∃ map : ℂ →L[ℂ] ℂ, map.restrictScalars ℝ = g ∘L ↑conjCLE := by
   rcases h with ⟨c, -, li, rfl⟩
   obtain ⟨li, rfl⟩ : ∃ li' : ℂ ≃ₗᵢ[ℝ] ℂ, li'.toLinearIsometry = li :=
     ⟨li.toLinearIsometryEquiv rfl, by ext1; rfl⟩
@@ -105,7 +105,7 @@ theorem IsConformalMap.is_complex_or_conj_linear (h : IsConformalMap g) :
 theorem isConformalMap_iff_is_complex_or_conj_linear :
     IsConformalMap g ↔
       ((∃ map : ℂ →L[ℂ] ℂ, map.restrictScalars ℝ = g) ∨
-          ∃ map : ℂ →L[ℂ] ℂ, map.restrictScalars ℝ = g ∘L ↑conjCle) ∧
+          ∃ map : ℂ →L[ℂ] ℂ, map.restrictScalars ℝ = g ∘L ↑conjCLE) ∧
         g ≠ 0 := by
   constructor
   · exact fun h => ⟨h.is_complex_or_conj_linear, h.ne_zero⟩
@@ -113,7 +113,7 @@ theorem isConformalMap_iff_is_complex_or_conj_linear :
     · refine' isConformalMap_complex_linear _
       contrapose! h₂ with w
       simp only [w, restrictScalars_zero]
-    · have minor₁ : g = map.restrictScalars ℝ ∘L ↑conjCle := by
+    · have minor₁ : g = map.restrictScalars ℝ ∘L ↑conjCLE := by
         ext1
         simp only [hmap, coe_comp', ContinuousLinearEquiv.coe_coe, Function.comp_apply,
           conjCle_apply, starRingEnd_self_apply]

--- a/Mathlib/Analysis/Complex/Isometry.lean
+++ b/Mathlib/Analysis/Complex/Isometry.lean
@@ -62,14 +62,14 @@ theorem rotation_trans (a b : circle) : (rotation a).trans (rotation b) = rotati
   simp
 #align rotation_trans rotation_trans
 
-theorem rotation_ne_conjLie (a : circle) : rotation a ≠ conjLie := by
+theorem rotation_ne_conjLIE (a : circle) : rotation a ≠ conjLIE := by
   intro h
   have h1 : rotation a 1 = conj 1 := LinearIsometryEquiv.congr_fun h 1
   have hI : rotation a I = conj I := LinearIsometryEquiv.congr_fun h I
   rw [rotation_apply, RingHom.map_one, mul_one] at h1
   rw [rotation_apply, conj_I, ← neg_one_mul, mul_left_inj' I_ne_zero, h1, eq_neg_self_iff] at hI
   exact one_ne_zero hI
-#align rotation_ne_conj_lie rotation_ne_conjLie
+#align rotation_ne_conj_lie rotation_ne_conjLIE
 
 /-- Takes an element of `ℂ ≃ₗᵢ[ℝ] ℂ` and checks if it is a rotation, returns an element of the
 unit circle. -/
@@ -123,7 +123,7 @@ theorem LinearIsometry.re_apply_eq_re {f : ℂ →ₗᵢ[ℝ] ℂ} (h : f 1 = 1)
 #align linear_isometry.re_apply_eq_re LinearIsometry.re_apply_eq_re
 
 theorem linear_isometry_complex_aux {f : ℂ ≃ₗᵢ[ℝ] ℂ} (h : f 1 = 1) :
-    f = LinearIsometryEquiv.refl ℝ ℂ ∨ f = conjLie := by
+    f = LinearIsometryEquiv.refl ℝ ℂ ∨ f = conjLIE := by
   have h0 : f I = I ∨ f I = -I := by
     simp only [ext_iff, ← and_or_left, neg_re, I_re, neg_im, neg_zero]
     constructor
@@ -140,7 +140,7 @@ theorem linear_isometry_complex_aux {f : ℂ ≃ₗᵢ[ℝ] ℂ} (h : f 1 = 1) :
 #align linear_isometry_complex_aux linear_isometry_complex_aux
 
 theorem linear_isometry_complex (f : ℂ ≃ₗᵢ[ℝ] ℂ) :
-    ∃ a : circle, f = rotation a ∨ f = conjLie.trans (rotation a) := by
+    ∃ a : circle, f = rotation a ∨ f = conjLIE.trans (rotation a) := by
   let a : circle := ⟨f 1, by rw [mem_circle_iff_abs, ← Complex.norm_eq_abs, f.norm_map, norm_one]⟩
   use a
   have : (f.trans (rotation a).symm) 1 = 1 := by simpa using rotation_apply a⁻¹ (f 1)

--- a/Mathlib/Analysis/Complex/OperatorNorm.lean
+++ b/Mathlib/Analysis/Complex/OperatorNorm.lean
@@ -11,10 +11,10 @@ import Mathlib.Data.Complex.Determinant
 
 /-! # The basic continuous linear maps associated to `ℂ`
 
-The continuous linear maps `Complex.reClm` (real part), `Complex.imClm` (imaginary part),
-`Complex.conjCle` (conjugation), and `Complex.ofRealClm` (inclusion of `ℝ`) were introduced in
+The continuous linear maps `Complex.reCLM` (real part), `Complex.imCLM` (imaginary part),
+`Complex.conjCLE` (conjugation), and `Complex.ofRealCLM` (inclusion of `ℝ`) were introduced in
 `Analysis.Complex.Basic`. This file contains a few calculations requiring more imports:
-the operator norm and (for `Complex.conjCle`) the determinant.
+the operator norm and (for `Complex.conjCLE`) the determinant.
 -/
 
 
@@ -35,49 +35,49 @@ theorem linearEquiv_det_conjLie : LinearEquiv.det conjLie.toLinearEquiv = -1 :=
 #align complex.linear_equiv_det_conj_lie Complex.linearEquiv_det_conjLie
 
 @[simp]
-theorem reClm_norm : ‖reClm‖ = 1 :=
+theorem reCLM_norm : ‖reCLM‖ = 1 :=
   le_antisymm (LinearMap.mkContinuous_norm_le _ zero_le_one _) <|
     calc
-      1 = ‖reClm 1‖ := by simp
-      _ ≤ ‖reClm‖ := unit_le_op_norm _ _ (by simp)
-#align complex.re_clm_norm Complex.reClm_norm
+      1 = ‖reCLM 1‖ := by simp
+      _ ≤ ‖reCLM‖ := unit_le_op_norm _ _ (by simp)
+#align complex.re_clm_norm Complex.reCLM_norm
 
 @[simp]
-theorem reClm_nnnorm : ‖reClm‖₊ = 1 :=
-  Subtype.ext reClm_norm
-#align complex.re_clm_nnnorm Complex.reClm_nnnorm
+theorem reCLM_nnnorm : ‖reCLM‖₊ = 1 :=
+  Subtype.ext reCLM_norm
+#align complex.re_clm_nnnorm Complex.reCLM_nnnorm
 
 @[simp]
-theorem imClm_norm : ‖imClm‖ = 1 :=
+theorem imCLM_norm : ‖imCLM‖ = 1 :=
   le_antisymm (LinearMap.mkContinuous_norm_le _ zero_le_one _) <|
     calc
-      1 = ‖imClm I‖ := by simp
-      _ ≤ ‖imClm‖ := unit_le_op_norm _ _ (by simp)
-#align complex.im_clm_norm Complex.imClm_norm
+      1 = ‖imCLM I‖ := by simp
+      _ ≤ ‖imCLM‖ := unit_le_op_norm _ _ (by simp)
+#align complex.im_clm_norm Complex.imCLM_norm
 
 @[simp]
-theorem imClm_nnnorm : ‖imClm‖₊ = 1 :=
-  Subtype.ext imClm_norm
-#align complex.im_clm_nnnorm Complex.imClm_nnnorm
+theorem imCLM_nnnorm : ‖imCLM‖₊ = 1 :=
+  Subtype.ext imCLM_norm
+#align complex.im_clm_nnnorm Complex.imCLM_nnnorm
 
 @[simp]
-theorem conjCle_norm : ‖(conjCle : ℂ →L[ℝ] ℂ)‖ = 1 :=
+theorem conjCLE_norm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖ = 1 :=
   conjLie.toLinearIsometry.norm_toContinuousLinearMap
 #align complex.conj_cle_norm Complex.conjCle_norm
 
 @[simp]
-theorem conjCle_nnorm : ‖(conjCle : ℂ →L[ℝ] ℂ)‖₊ = 1 :=
+theorem conjCLE_nnorm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖₊ = 1 :=
   Subtype.ext conjCle_norm
 #align complex.conj_cle_nnorm Complex.conjCle_nnorm
 
 @[simp]
-theorem ofRealClm_norm : ‖ofRealClm‖ = 1 :=
+theorem ofRealCLM_norm : ‖ofRealCLM‖ = 1 :=
   ofRealLi.norm_toContinuousLinearMap
-#align complex.of_real_clm_norm Complex.ofRealClm_norm
+#align complex.of_real_clm_norm Complex.ofRealCLM_norm
 
 @[simp]
-theorem ofRealClm_nnnorm : ‖ofRealClm‖₊ = 1 :=
-  Subtype.ext <| ofRealClm_norm
-#align complex.of_real_clm_nnnorm Complex.ofRealClm_nnnorm
+theorem ofRealCLM_nnnorm : ‖ofRealCLM‖₊ = 1 :=
+  Subtype.ext <| ofRealCLM_norm
+#align complex.of_real_clm_nnnorm Complex.ofRealCLM_nnnorm
 
 end Complex

--- a/Mathlib/Analysis/Complex/OperatorNorm.lean
+++ b/Mathlib/Analysis/Complex/OperatorNorm.lean
@@ -63,12 +63,12 @@ theorem imCLM_nnnorm : ‖imCLM‖₊ = 1 :=
 @[simp]
 theorem conjCLE_norm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖ = 1 :=
   conjLie.toLinearIsometry.norm_toContinuousLinearMap
-#align complex.conj_cle_norm Complex.conjCle_norm
+#align complex.conj_cle_norm Complex.conjCLE_norm
 
 @[simp]
 theorem conjCLE_nnorm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖₊ = 1 :=
-  Subtype.ext conjCle_norm
-#align complex.conj_cle_nnorm Complex.conjCle_nnorm
+  Subtype.ext conjCLE_norm
+#align complex.conj_cle_nnorm Complex.conjCLE_nnorm
 
 @[simp]
 theorem ofRealCLM_norm : ‖ofRealCLM‖ = 1 :=

--- a/Mathlib/Analysis/Complex/OperatorNorm.lean
+++ b/Mathlib/Analysis/Complex/OperatorNorm.lean
@@ -22,17 +22,17 @@ open ContinuousLinearMap
 
 namespace Complex
 
-/-- The determinant of `conjLie`, as a linear map. -/
+/-- The determinant of `conjLIE`, as a linear map. -/
 @[simp]
-theorem det_conjLie : LinearMap.det (conjLie.toLinearEquiv : ℂ →ₗ[ℝ] ℂ) = -1 :=
+theorem det_conjLIE : LinearMap.det (conjLIE.toLinearEquiv : ℂ →ₗ[ℝ] ℂ) = -1 :=
   det_conjAe
-#align complex.det_conj_lie Complex.det_conjLie
+#align complex.det_conj_lie Complex.det_conjLIE
 
-/-- The determinant of `conjLie`, as a linear equiv. -/
+/-- The determinant of `conjLIE`, as a linear equiv. -/
 @[simp]
-theorem linearEquiv_det_conjLie : LinearEquiv.det conjLie.toLinearEquiv = -1 :=
+theorem linearEquiv_det_conjLIE : LinearEquiv.det conjLIE.toLinearEquiv = -1 :=
   linearEquiv_det_conjAe
-#align complex.linear_equiv_det_conj_lie Complex.linearEquiv_det_conjLie
+#align complex.linear_equiv_det_conj_lie Complex.linearEquiv_det_conjLIE
 
 @[simp]
 theorem reCLM_norm : ‖reCLM‖ = 1 :=
@@ -62,7 +62,7 @@ theorem imCLM_nnnorm : ‖imCLM‖₊ = 1 :=
 
 @[simp]
 theorem conjCLE_norm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖ = 1 :=
-  conjLie.toLinearIsometry.norm_toContinuousLinearMap
+  conjLIE.toLinearIsometry.norm_toContinuousLinearMap
 #align complex.conj_cle_norm Complex.conjCLE_norm
 
 @[simp]
@@ -72,7 +72,7 @@ theorem conjCLE_nnorm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖₊ = 1 :=
 
 @[simp]
 theorem ofRealCLM_norm : ‖ofRealCLM‖ = 1 :=
-  ofRealLi.norm_toContinuousLinearMap
+  ofRealLI.norm_toContinuousLinearMap
 #align complex.of_real_clm_norm Complex.ofRealCLM_norm
 
 @[simp]

--- a/Mathlib/Analysis/Complex/ReImTopology.lean
+++ b/Mathlib/Analysis/Complex/ReImTopology.lean
@@ -42,12 +42,12 @@ namespace Complex
 
 /-- `Complex.re` turns `ℂ` into a trivial topological fiber bundle over `ℝ`. -/
 theorem isHomeomorphicTrivialFiberBundle_re : IsHomeomorphicTrivialFiberBundle ℝ re :=
-  ⟨equivRealProdClm.toHomeomorph, fun _ => rfl⟩
+  ⟨equivRealProdCLM.toHomeomorph, fun _ => rfl⟩
 #align complex.is_homeomorphic_trivial_fiber_bundle_re Complex.isHomeomorphicTrivialFiberBundle_re
 
 /-- `Complex.im` turns `ℂ` into a trivial topological fiber bundle over `ℝ`. -/
 theorem isHomeomorphicTrivialFiberBundle_im : IsHomeomorphicTrivialFiberBundle ℝ im :=
-  ⟨equivRealProdClm.toHomeomorph.trans (Homeomorph.prodComm ℝ ℝ), fun _ => rfl⟩
+  ⟨equivRealProdCLM.toHomeomorph.trans (Homeomorph.prodComm ℝ ℝ), fun _ => rfl⟩
 #align complex.is_homeomorphic_trivial_fiber_bundle_im Complex.isHomeomorphicTrivialFiberBundle_im
 
 theorem isOpenMap_re : IsOpenMap re :=
@@ -171,8 +171,8 @@ theorem frontier_setOf_lt_im (a : ℝ) : frontier { z : ℂ | a < z.im } = { z |
 #align complex.frontier_set_of_lt_im Complex.frontier_setOf_lt_im
 
 theorem closure_reProdIm (s t : Set ℝ) : closure (s ×ℂ t) = closure s ×ℂ closure t := by
-  simpa only [← preimage_eq_preimage equivRealProdClm.symm.toHomeomorph.surjective,
-    equivRealProdClm.symm.toHomeomorph.preimage_closure] using @closure_prod_eq _ _ _ _ s t
+  simpa only [← preimage_eq_preimage equivRealProdCLM.symm.toHomeomorph.surjective,
+    equivRealProdCLM.symm.toHomeomorph.preimage_closure] using @closure_prod_eq _ _ _ _ s t
 #align complex.closure_re_prod_im Complex.closure_reProdIm
 
 theorem interior_reProdIm (s t : Set ℝ) : interior (s ×ℂ t) = interior s ×ℂ interior t := by
@@ -181,8 +181,8 @@ theorem interior_reProdIm (s t : Set ℝ) : interior (s ×ℂ t) = interior s ×
 
 theorem frontier_reProdIm (s t : Set ℝ) :
     frontier (s ×ℂ t) = closure s ×ℂ frontier t ∪ frontier s ×ℂ closure t := by
-  simpa only [← preimage_eq_preimage equivRealProdClm.symm.toHomeomorph.surjective,
-    equivRealProdClm.symm.toHomeomorph.preimage_frontier] using frontier_prod_eq s t
+  simpa only [← preimage_eq_preimage equivRealProdCLM.symm.toHomeomorph.surjective,
+    equivRealProdCLM.symm.toHomeomorph.preimage_frontier] using frontier_prod_eq s t
 #align complex.frontier_re_prod_im Complex.frontier_reProdIm
 
 theorem frontier_setOf_le_re_and_le_im (a b : ℝ) :

--- a/Mathlib/Analysis/Complex/RealDeriv.lean
+++ b/Mathlib/Analysis/Complex/RealDeriv.lean
@@ -48,12 +48,12 @@ variable {e : ℂ → ℂ} {e' : ℂ} {z : ℝ}
 differentiable at this point, with a derivative equal to the real part of the complex derivative. -/
 theorem HasStrictDerivAt.real_of_complex (h : HasStrictDerivAt e e' z) :
     HasStrictDerivAt (fun x : ℝ => (e x).re) e'.re z := by
-  have A : HasStrictFDerivAt ((↑) : ℝ → ℂ) ofRealClm z := ofRealClm.hasStrictFDerivAt
+  have A : HasStrictFDerivAt ((↑) : ℝ → ℂ) ofRealCLM z := ofRealCLM.hasStrictFDerivAt
   have B :
     HasStrictFDerivAt e ((ContinuousLinearMap.smulRight 1 e' : ℂ →L[ℂ] ℂ).restrictScalars ℝ)
-      (ofRealClm z) :=
+      (ofRealCLM z) :=
     h.hasStrictFDerivAt.restrictScalars ℝ
-  have C : HasStrictFDerivAt re reClm (e (ofRealClm z)) := reClm.hasStrictFDerivAt
+  have C : HasStrictFDerivAt re reCLM (e (ofRealCLM z)) := reCLM.hasStrictFDerivAt
   -- Porting note: this should be by:
   -- simpa using (C.comp z (B.comp z A)).hasStrictDerivAt
   -- but for some reason simp can not use `ContinuousLinearMap.comp_apply`
@@ -67,12 +67,12 @@ the real part of `e` is also differentiable at this point, with a derivative equ
 of the complex derivative. -/
 theorem HasDerivAt.real_of_complex (h : HasDerivAt e e' z) :
     HasDerivAt (fun x : ℝ => (e x).re) e'.re z := by
-  have A : HasFDerivAt ((↑) : ℝ → ℂ) ofRealClm z := ofRealClm.hasFDerivAt
+  have A : HasFDerivAt ((↑) : ℝ → ℂ) ofRealCLM z := ofRealCLM.hasFDerivAt
   have B :
     HasFDerivAt e ((ContinuousLinearMap.smulRight 1 e' : ℂ →L[ℂ] ℂ).restrictScalars ℝ)
-      (ofRealClm z) :=
+      (ofRealCLM z) :=
     h.hasFDerivAt.restrictScalars ℝ
-  have C : HasFDerivAt re reClm (e (ofRealClm z)) := reClm.hasFDerivAt
+  have C : HasFDerivAt re reCLM (e (ofRealCLM z)) := reCLM.hasFDerivAt
   -- Porting note: this should be by:
   -- simpa using (C.comp z (B.comp z A)).hasStrictDerivAt
   -- but for some reason simp can not use `ContinuousLinearMap.comp_apply`
@@ -83,9 +83,9 @@ theorem HasDerivAt.real_of_complex (h : HasDerivAt e e' z) :
 
 theorem ContDiffAt.real_of_complex {n : ℕ∞} (h : ContDiffAt ℂ n e z) :
     ContDiffAt ℝ n (fun x : ℝ => (e x).re) z := by
-  have A : ContDiffAt ℝ n ((↑) : ℝ → ℂ) z := ofRealClm.contDiff.contDiffAt
+  have A : ContDiffAt ℝ n ((↑) : ℝ → ℂ) z := ofRealCLM.contDiff.contDiffAt
   have B : ContDiffAt ℝ n e z := h.restrict_scalars ℝ
-  have C : ContDiffAt ℝ n re (e z) := reClm.contDiff.contDiffAt
+  have C : ContDiffAt ℝ n re (e z) := reCLM.contDiff.contDiffAt
   exact C.comp z (B.comp z A)
 #align cont_diff_at.real_of_complex ContDiffAt.real_of_complex
 
@@ -98,19 +98,19 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
 
 theorem HasStrictDerivAt.complexToReal_fderiv' {f : ℂ → E} {x : ℂ} {f' : E}
     (h : HasStrictDerivAt f f' x) :
-    HasStrictFDerivAt f (reClm.smulRight f' + I • imClm.smulRight f') x := by
+    HasStrictFDerivAt f (reCLM.smulRight f' + I • imCLM.smulRight f') x := by
   simpa only [Complex.restrictScalars_one_smulRight'] using
     h.hasStrictFDerivAt.restrictScalars ℝ
 #align has_strict_deriv_at.complex_to_real_fderiv' HasStrictDerivAt.complexToReal_fderiv'
 
 theorem HasDerivAt.complexToReal_fderiv' {f : ℂ → E} {x : ℂ} {f' : E} (h : HasDerivAt f f' x) :
-    HasFDerivAt f (reClm.smulRight f' + I • imClm.smulRight f') x := by
+    HasFDerivAt f (reCLM.smulRight f' + I • imCLM.smulRight f') x := by
   simpa only [Complex.restrictScalars_one_smulRight'] using h.hasFDerivAt.restrictScalars ℝ
 #align has_deriv_at.complex_to_real_fderiv' HasDerivAt.complexToReal_fderiv'
 
 theorem HasDerivWithinAt.complexToReal_fderiv' {f : ℂ → E} {s : Set ℂ} {x : ℂ} {f' : E}
     (h : HasDerivWithinAt f f' s x) :
-    HasFDerivWithinAt f (reClm.smulRight f' + I • imClm.smulRight f') s x := by
+    HasFDerivWithinAt f (reCLM.smulRight f' + I • imCLM.smulRight f') s x := by
   simpa only [Complex.restrictScalars_one_smulRight'] using
     h.hasFDerivWithinAt.restrictScalars ℝ
 #align has_deriv_within_at.complex_to_real_fderiv' HasDerivWithinAt.complexToReal_fderiv'
@@ -133,15 +133,15 @@ theorem HasDerivWithinAt.complexToReal_fderiv {f : ℂ → ℂ} {s : Set ℂ} {f
 /-- If a complex function `e` is differentiable at a real point, then its restriction to `ℝ` is
 differentiable there as a function `ℝ → ℂ`, with the same derivative. -/
 theorem HasDerivAt.comp_ofReal (hf : HasDerivAt e e' ↑z) : HasDerivAt (fun y : ℝ => e ↑y) e' z :=
-  by simpa only [ofRealClm_apply, ofReal_one, mul_one] using hf.comp z ofRealClm.hasDerivAt
+  by simpa only [ofRealCLM_apply, ofReal_one, mul_one] using hf.comp z ofRealCLM.hasDerivAt
 #align has_deriv_at.comp_of_real HasDerivAt.comp_ofReal
 
 /-- If a function `f : ℝ → ℝ` is differentiable at a (real) point `x`, then it is also
 differentiable as a function `ℝ → ℂ`. -/
 theorem HasDerivAt.ofReal_comp {f : ℝ → ℝ} {u : ℝ} (hf : HasDerivAt f u z) :
     HasDerivAt (fun y : ℝ => ↑(f y) : ℝ → ℂ) u z := by
-  simpa only [ofRealClm_apply, ofReal_one, real_smul, mul_one] using
-    ofRealClm.hasDerivAt.scomp z hf
+  simpa only [ofRealCLM_apply, ofReal_one, real_smul, mul_one] using
+    ofRealCLM.hasDerivAt.scomp z hf
 #align has_deriv_at.of_real_comp HasDerivAt.ofReal_comp
 
 end RealDerivOfComplex
@@ -179,10 +179,10 @@ theorem conformalAt_iff_differentiableAt_or_differentiableAt_comp_conj {f : ℂ 
   apply or_congr
   · rw [differentiableAt_iff_restrictScalars ℝ h_diff]
   rw [← conj_conj z] at h_diff
-  rw [differentiableAt_iff_restrictScalars ℝ (h_diff.comp _ conjCle.differentiableAt)]
+  rw [differentiableAt_iff_restrictScalars ℝ (h_diff.comp _ conjCLE.differentiableAt)]
   refine' exists_congr fun g => rfl.congr _
-  have : fderiv ℝ conj (conj z) = _ := conjCle.fderiv
-  simp [fderiv.comp _ h_diff conjCle.differentiableAt, this, conj_conj]
+  have : fderiv ℝ conj (conj z) = _ := conjCLE.fderiv
+  simp [fderiv.comp _ h_diff conjCLE.differentiableAt, this, conj_conj]
 #align conformal_at_iff_differentiable_at_or_differentiable_at_comp_conj conformalAt_iff_differentiableAt_or_differentiableAt_comp_conj
 
 end Conformality

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -1029,7 +1029,7 @@ variable {E}
 
 /-- The Dirac delta distribution -/
 def delta (x : E) : 𝓢(E, F) →L[𝕜] F :=
-  (BoundedContinuousFunction.evalClm 𝕜 x).comp (toBoundedContinuousFunctionCLM 𝕜 E F)
+  (BoundedContinuousFunction.evalCLM 𝕜 x).comp (toBoundedContinuousFunctionCLM 𝕜 E F)
 #align schwartz_map.delta SchwartzMap.delta
 
 @[simp]

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -511,7 +511,7 @@ theorem hasSum_fourier_series_of_summable (h : Summable (fourierCoeff f)) :
 converges everywhere pointwise to `f`. -/
 theorem has_pointwise_sum_fourier_series_of_summable (h : Summable (fourierCoeff f))
     (x : AddCircle T) : HasSum (fun i => fourierCoeff f i • fourier i x) (f x) := by
-  convert (ContinuousMap.evalClm ℂ x).hasSum (hasSum_fourier_series_of_summable h)
+  convert (ContinuousMap.evalCLM ℂ x).hasSum (hasSum_fourier_series_of_summable h)
 #align has_pointwise_sum_fourier_series_of_summable has_pointwise_sum_fourier_series_of_summable
 
 end Convergence

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -373,18 +373,18 @@ theorem adjoint_toContinuousLinearMap (A : E →ₗ[𝕜] F) :
   rfl
 #align linear_map.adjoint_to_continuous_linear_map LinearMap.adjoint_toContinuousLinearMap
 
-theorem adjoint_eq_toClm_adjoint (A : E →ₗ[𝕜] F) :
+theorem adjoint_eq_toCLM_adjoint (A : E →ₗ[𝕜] F) :
     haveI := FiniteDimensional.complete 𝕜 E
     haveI := FiniteDimensional.complete 𝕜 F
     LinearMap.adjoint A = ContinuousLinearMap.adjoint (LinearMap.toContinuousLinearMap A) :=
   rfl
-#align linear_map.adjoint_eq_to_clm_adjoint LinearMap.adjoint_eq_toClm_adjoint
+#align linear_map.adjoint_eq_to_clm_adjoint LinearMap.adjoint_eq_toCLM_adjoint
 
 /-- The fundamental property of the adjoint. -/
 theorem adjoint_inner_left (A : E →ₗ[𝕜] F) (x : E) (y : F) : ⟪adjoint A y, x⟫ = ⟪y, A x⟫ := by
   haveI := FiniteDimensional.complete 𝕜 E
   haveI := FiniteDimensional.complete 𝕜 F
-  rw [← coe_toContinuousLinearMap A, adjoint_eq_toClm_adjoint]
+  rw [← coe_toContinuousLinearMap A, adjoint_eq_toCLM_adjoint]
   exact ContinuousLinearMap.adjoint_inner_left _ x y
 #align linear_map.adjoint_inner_left LinearMap.adjoint_inner_left
 
@@ -392,7 +392,7 @@ theorem adjoint_inner_left (A : E →ₗ[𝕜] F) (x : E) (y : F) : ⟪adjoint A
 theorem adjoint_inner_right (A : E →ₗ[𝕜] F) (x : E) (y : F) : ⟪x, adjoint A y⟫ = ⟪A x, y⟫ := by
   haveI := FiniteDimensional.complete 𝕜 E
   haveI := FiniteDimensional.complete 𝕜 F
-  rw [← coe_toContinuousLinearMap A, adjoint_eq_toClm_adjoint]
+  rw [← coe_toContinuousLinearMap A, adjoint_eq_toCLM_adjoint]
   exact ContinuousLinearMap.adjoint_inner_right _ x y
 #align linear_map.adjoint_inner_right LinearMap.adjoint_inner_right
 

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -2289,7 +2289,7 @@ theorem ContinuousLinearMap.reApplyInnerSelf_apply (T : E →L[𝕜] E) (x : E) 
 
 theorem ContinuousLinearMap.reApplyInnerSelf_continuous (T : E →L[𝕜] E) :
     Continuous T.reApplyInnerSelf :=
-  reClm.continuous.comp <| T.continuous.inner continuous_id
+  reCLM.continuous.comp <| T.continuous.inner continuous_id
 #align continuous_linear_map.re_apply_inner_self_continuous ContinuousLinearMap.reApplyInnerSelf_continuous
 
 theorem ContinuousLinearMap.reApplyInnerSelf_smul (T : E →L[𝕜] E) (x : E) {c : 𝕜} :

--- a/Mathlib/Analysis/InnerProductSpace/Calculus.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Calculus.lean
@@ -45,14 +45,14 @@ local notation "⟪" x ", " y "⟫" => @inner 𝕜 _ _ x y
 variable (𝕜) [NormedSpace ℝ E]
 
 /-- Derivative of the inner product. -/
-def fderivInnerClm (p : E × E) : E × E →L[ℝ] 𝕜 :=
+def fderivInnerCLM (p : E × E) : E × E →L[ℝ] 𝕜 :=
   isBoundedBilinearMap_inner.deriv p
-#align fderiv_inner_clm fderivInnerClm
+#align fderiv_inner_clm fderivInnerCLM
 
 @[simp]
-theorem fderivInnerClm_apply (p x : E × E) : fderivInnerClm 𝕜 p x = ⟪p.1, x.2⟫ + ⟪x.1, p.2⟫ :=
+theorem fderivInnerCLM_apply (p x : E × E) : fderivInnerCLM 𝕜 p x = ⟪p.1, x.2⟫ + ⟪x.1, p.2⟫ :=
   rfl
-#align fderiv_inner_clm_apply fderivInnerClm_apply
+#align fderiv_inner_clm_apply fderivInnerCLM_apply
 
 variable {𝕜} -- porting note: Lean 3 magically switches back to `{𝕜}` here
 
@@ -93,18 +93,18 @@ theorem ContDiff.inner (hf : ContDiff ℝ n f) (hg : ContDiff ℝ n g) :
 
 theorem HasFDerivWithinAt.inner (hf : HasFDerivWithinAt f f' s x)
     (hg : HasFDerivWithinAt g g' s x) :
-    HasFDerivWithinAt (fun t => ⟪f t, g t⟫) ((fderivInnerClm 𝕜 (f x, g x)).comp <| f'.prod g') s
+    HasFDerivWithinAt (fun t => ⟪f t, g t⟫) ((fderivInnerCLM 𝕜 (f x, g x)).comp <| f'.prod g') s
       x :=
   (isBoundedBilinearMap_inner.hasFDerivAt (f x, g x)).comp_hasFDerivWithinAt x (hf.prod hg)
 #align has_fderiv_within_at.inner HasFDerivWithinAt.inner
 
 theorem HasStrictFDerivAt.inner (hf : HasStrictFDerivAt f f' x) (hg : HasStrictFDerivAt g g' x) :
-    HasStrictFDerivAt (fun t => ⟪f t, g t⟫) ((fderivInnerClm 𝕜 (f x, g x)).comp <| f'.prod g') x :=
+    HasStrictFDerivAt (fun t => ⟪f t, g t⟫) ((fderivInnerCLM 𝕜 (f x, g x)).comp <| f'.prod g') x :=
   (isBoundedBilinearMap_inner.hasStrictFDerivAt (f x, g x)).comp x (hf.prod hg)
 #align has_strict_fderiv_at.inner HasStrictFDerivAt.inner
 
 theorem HasFDerivAt.inner (hf : HasFDerivAt f f' x) (hg : HasFDerivAt g g' x) :
-    HasFDerivAt (fun t => ⟪f t, g t⟫) ((fderivInnerClm 𝕜 (f x, g x)).comp <| f'.prod g') x :=
+    HasFDerivAt (fun t => ⟪f t, g t⟫) ((fderivInnerCLM 𝕜 (f x, g x)).comp <| f'.prod g') x :=
   (isBoundedBilinearMap_inner.hasFDerivAt (f x, g x)).comp x (hf.prod hg)
 #align has_fderiv_at.inner HasFDerivAt.inner
 
@@ -151,7 +151,7 @@ theorem deriv_inner_apply {f g : ℝ → E} {x : ℝ} (hf : DifferentiableAt ℝ
 #align deriv_inner_apply deriv_inner_apply
 
 theorem contDiff_norm_sq : ContDiff ℝ n fun x : E => ‖x‖ ^ 2 := by
-  convert (reClm : 𝕜 →L[ℝ] ℝ).contDiff.comp ((contDiff_id (E := E)).inner 𝕜 (contDiff_id (E := E)))
+  convert (reCLM : 𝕜 →L[ℝ] ℝ).contDiff.comp ((contDiff_id (E := E)).inner 𝕜 (contDiff_id (E := E)))
   exact (inner_self_eq_norm_sq _).symm
 #align cont_diff_norm_sq contDiff_norm_sq
 

--- a/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
+++ b/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
@@ -97,30 +97,30 @@ def adjointDomain : Submodule 𝕜 F where
 
 /-- The operator `λ x, ⟪y, T x⟫` considered as a continuous linear operator from `T.adjointDomain`
 to `𝕜`. -/
-def adjointDomainMkClm (y : T.adjointDomain) : T.domain →L[𝕜] 𝕜 :=
+def adjointDomainMkCLM (y : T.adjointDomain) : T.domain →L[𝕜] 𝕜 :=
   ⟨(innerₛₗ 𝕜 (y : F)).comp T.toFun, y.prop⟩
-#align linear_pmap.adjoint_domain_mk_clm LinearPMap.adjointDomainMkClm
+#align linear_pmap.adjoint_domain_mk_clm LinearPMap.adjointDomainMkCLM
 
-theorem adjointDomainMkClm_apply (y : T.adjointDomain) (x : T.domain) :
-    adjointDomainMkClm T y x = ⟪(y : F), T x⟫ :=
+theorem adjointDomainMkCLM_apply (y : T.adjointDomain) (x : T.domain) :
+    adjointDomainMkCLM T y x = ⟪(y : F), T x⟫ :=
   rfl
-#align linear_pmap.adjoint_domain_mk_clm_apply LinearPMap.adjointDomainMkClm_apply
+#align linear_pmap.adjoint_domain_mk_clm_apply LinearPMap.adjointDomainMkCLM_apply
 
 variable {T}
 
 variable (hT : Dense (T.domain : Set E))
 
-/-- The unique continuous extension of the operator `adjointDomainMkClm` to `E`. -/
-def adjointDomainMkClmExtend (y : T.adjointDomain) : E →L[𝕜] 𝕜 :=
-  (T.adjointDomainMkClm y).extend (Submodule.subtypeL T.domain) hT.denseRange_val
+/-- The unique continuous extension of the operator `adjointDomainMkCLM` to `E`. -/
+def adjointDomainMkCLMExtend (y : T.adjointDomain) : E →L[𝕜] 𝕜 :=
+  (T.adjointDomainMkCLM y).extend (Submodule.subtypeL T.domain) hT.denseRange_val
     uniformEmbedding_subtype_val.toUniformInducing
-#align linear_pmap.adjoint_domain_mk_clm_extend LinearPMap.adjointDomainMkClmExtend
+#align linear_pmap.adjoint_domain_mk_clm_extend LinearPMap.adjointDomainMkCLMExtend
 
 @[simp]
-theorem adjointDomainMkClmExtend_apply (y : T.adjointDomain) (x : T.domain) :
-    adjointDomainMkClmExtend hT y (x : E) = ⟪(y : F), T x⟫ :=
+theorem adjointDomainMkCLMExtend_apply (y : T.adjointDomain) (x : T.domain) :
+    adjointDomainMkCLMExtend hT y (x : E) = ⟪(y : F), T x⟫ :=
   ContinuousLinearMap.extend_eq _ _ _ _ _
-#align linear_pmap.adjoint_domain_mk_clm_extend_apply LinearPMap.adjointDomainMkClmExtend_apply
+#align linear_pmap.adjoint_domain_mk_clm_extend_apply LinearPMap.adjointDomainMkCLMExtend_apply
 
 variable [CompleteSpace E]
 
@@ -129,25 +129,25 @@ variable [CompleteSpace E]
 This is an auxiliary definition needed to define the adjoint operator as a `LinearPMap` without
 the assumption that `T.domain` is dense. -/
 def adjointAux : T.adjointDomain →ₗ[𝕜] E where
-  toFun y := (InnerProductSpace.toDual 𝕜 E).symm (adjointDomainMkClmExtend hT y)
+  toFun y := (InnerProductSpace.toDual 𝕜 E).symm (adjointDomainMkCLMExtend hT y)
   map_add' x y :=
     hT.eq_of_inner_left fun _ => by
       simp only [inner_add_left, Submodule.coe_add, InnerProductSpace.toDual_symm_apply,
-        adjointDomainMkClmExtend_apply]
+        adjointDomainMkCLMExtend_apply]
   map_smul' _ _ :=
     hT.eq_of_inner_left fun _ => by
       simp only [inner_smul_left, Submodule.coe_smul_of_tower, RingHom.id_apply,
-        InnerProductSpace.toDual_symm_apply, adjointDomainMkClmExtend_apply]
+        InnerProductSpace.toDual_symm_apply, adjointDomainMkCLMExtend_apply]
 #align linear_pmap.adjoint_aux LinearPMap.adjointAux
 
 theorem adjointAux_inner (y : T.adjointDomain) (x : T.domain) :
     ⟪adjointAux hT y, x⟫ = ⟪(y : F), T x⟫ := by
   simp only [adjointAux, LinearMap.coe_mk, InnerProductSpace.toDual_symm_apply,
-    adjointDomainMkClmExtend_apply]
+    adjointDomainMkCLMExtend_apply]
   -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5026):
   -- mathlib3 was finished here
   simp only [AddHom.coe_mk, InnerProductSpace.toDual_symm_apply]
-  rw [adjointDomainMkClmExtend_apply]
+  rw [adjointDomainMkCLMExtend_apply]
 #align linear_pmap.adjoint_aux_inner LinearPMap.adjointAux_inner
 
 theorem adjointAux_unique (y : T.adjointDomain) {x₀ : E}

--- a/Mathlib/Analysis/InnerProductSpace/Rayleigh.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Rayleigh.lean
@@ -110,7 +110,7 @@ theorem _root_.LinearMap.IsSymmetric.hasStrictFDerivAt_reApplyInnerSelf {T : F �
     HasStrictFDerivAt T.reApplyInnerSelf (2 • (innerSL ℝ (T x₀))) x₀ := by
   convert T.hasStrictFDerivAt.inner ℝ (hasStrictFDerivAt_id x₀) using 1
   ext y
-  rw [ContinuousLinearMap.smul_apply, ContinuousLinearMap.comp_apply, fderivInnerClm_apply,
+  rw [ContinuousLinearMap.smul_apply, ContinuousLinearMap.comp_apply, fderivInnerCLM_apply,
     ContinuousLinearMap.prod_apply, innerSL_apply, id.def, ContinuousLinearMap.id_apply,
     hT.apply_clm x₀ y, real_inner_comm _ x₀, two_smul]
 #align linear_map.is_symmetric.has_strict_fderiv_at_re_apply_inner_self LinearMap.IsSymmetric.hasStrictFDerivAt_reApplyInnerSelf

--- a/Mathlib/Analysis/InnerProductSpace/TwoDim.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TwoDim.lean
@@ -472,7 +472,7 @@ real part is the inner product and its imaginary part is `Orientation.areaForm`.
 
 On `ℂ` with the standard orientation, `kahler w z = conj w * z`; see `Complex.kahler`. -/
 def kahler : E →ₗ[ℝ] E →ₗ[ℝ] ℂ :=
-  LinearMap.llcomp ℝ E ℝ ℂ Complex.ofRealClm ∘ₗ innerₛₗ ℝ +
+  LinearMap.llcomp ℝ E ℝ ℂ Complex.ofRealCLM ∘ₗ innerₛₗ ℝ +
     LinearMap.llcomp ℝ E ℝ ℂ ((LinearMap.lsmul ℝ ℂ).flip Complex.I) ∘ₗ ω
 #align orientation.kahler Orientation.kahler
 

--- a/Mathlib/Analysis/InnerProductSpace/l2Space.lean
+++ b/Mathlib/Analysis/InnerProductSpace/l2Space.lean
@@ -129,13 +129,13 @@ instance instInnerProductSpace : InnerProductSpace 𝕜 (lp G 2) :=
           funext i
           rw [norm_sq_eq_inner (𝕜 := 𝕜)]
           -- porting note: `simp` couldn't do this anymore
-        _ = re (∑' i, ⟪f i, f i⟫) := (IsROrC.reClm.map_tsum ?_).symm
+        _ = re (∑' i, ⟪f i, f i⟫) := (IsROrC.reCLM.map_tsum ?_).symm
       · norm_num
       · exact summable_inner f f
     conj_symm := fun f g => by
       calc
         conj _ = conj (∑' i, ⟪g i, f i⟫) := by congr
-        _ = ∑' i, conj ⟪g i, f i⟫ := IsROrC.conjCle.map_tsum
+        _ = ∑' i, conj ⟪g i, f i⟫ := IsROrC.conjCLE.map_tsum
         _ = ∑' i, ⟪f i, g i⟫ := by simp only [inner_conj_symm]
         _ = _ := by congr
     add_left := fun f₁ f₂ g => by

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
@@ -76,7 +76,7 @@ theorem exists_extension_norm_eq (p : Subspace 𝕜 E) (f : p →L[𝕜] 𝕜) :
   letI : IsScalarTower ℝ 𝕜 E := RestrictScalars.isScalarTower _ _ _
   letI : NormedSpace ℝ E := NormedSpace.restrictScalars _ 𝕜 _
   -- Let `fr: p →L[ℝ] ℝ` be the real part of `f`.
-  let fr := reClm.comp (f.restrictScalars ℝ)
+  let fr := reCLM.comp (f.restrictScalars ℝ)
   -- Use the real version to get a norm-preserving extension of `fr`, which
   -- we'll call `g : E →L[ℝ] ℝ`.
   rcases Real.exists_extension_norm_eq (p.restrictScalars ℝ) fr with ⟨g, ⟨hextends, hnormeq⟩⟩
@@ -103,8 +103,8 @@ theorem exists_extension_norm_eq (p : Subspace 𝕜 E) (f : p →L[𝕜] 𝕜) :
   · calc
       ‖g.extendTo𝕜‖ = ‖g‖ := g.norm_extendTo𝕜
       _ = ‖fr‖ := hnormeq
-      _ ≤ ‖reClm‖ * ‖f‖ := (ContinuousLinearMap.op_norm_comp_le _ _)
-      _ = ‖f‖ := by rw [reClm_norm, one_mul]
+      _ ≤ ‖reCLM‖ * ‖f‖ := (ContinuousLinearMap.op_norm_comp_le _ _)
+      _ = ‖f‖ := by rw [reCLM_norm, one_mul]
   · exact f.op_norm_le_bound g.extendTo𝕜.op_norm_nonneg fun x => h x ▸ g.extendTo𝕜.le_op_norm x
 #align exists_extension_norm_eq exists_extension_norm_eq
 

--- a/Mathlib/Analysis/NormedSpace/Star/Matrix.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Matrix.lean
@@ -106,26 +106,26 @@ of Euclidean space induced by the orthonormal basis `EuclideanSpace.basisFun`.
 
 This is a more-bundled version of `Matrix.toEuclideanLin`, for the special case of square matrices,
 followed by a more-bundled version of `LinearMap.toContinuousLinearMap`. -/
-def toEuclideanClm :
+def toEuclideanCLM :
     Matrix n n 𝕜 ≃⋆ₐ[𝕜] (EuclideanSpace 𝕜 n →L[𝕜] EuclideanSpace 𝕜 n) :=
   toMatrixOrthonormal (EuclideanSpace.basisFun n 𝕜) |>.symm.trans <|
     { toContinuousLinearMap with
       map_mul' := fun _ _ ↦ rfl
       map_star' := adjoint_toContinuousLinearMap }
 
-lemma coe_toEuclideanClm_eq_toEuclideanLin (A : Matrix n n 𝕜) :
-    (toEuclideanClm (n := n) (𝕜 := 𝕜) A : _ →ₗ[𝕜] _) = toEuclideanLin A :=
+lemma coe_toEuclideanCLM_eq_toEuclideanLin (A : Matrix n n 𝕜) :
+    (toEuclideanCLM (n := n) (𝕜 := 𝕜) A : _ →ₗ[𝕜] _) = toEuclideanLin A :=
   rfl
 
 @[simp]
-lemma toEuclideanClm_piLp_equiv_symm (A : Matrix n n 𝕜) (x : n → 𝕜) :
-    toEuclideanClm (n := n) (𝕜 := 𝕜) A ((WithLp.equiv _ _).symm x) =
+lemma toEuclideanCLM_piLp_equiv_symm (A : Matrix n n 𝕜) (x : n → 𝕜) :
+    toEuclideanCLM (n := n) (𝕜 := 𝕜) A ((WithLp.equiv _ _).symm x) =
       (WithLp.equiv _ _).symm (toLin' A x) :=
   rfl
 
 @[simp]
-lemma piLp_equiv_toEuclideanClm (A : Matrix n n 𝕜) (x : EuclideanSpace 𝕜 n) :
-    WithLp.equiv _ _ (toEuclideanClm (n := n) (𝕜 := 𝕜) A x) =
+lemma piLp_equiv_toEuclideanCLM (A : Matrix n n 𝕜) (x : EuclideanSpace 𝕜 n) :
+    WithLp.equiv _ _ (toEuclideanCLM (n := n) (𝕜 := 𝕜) A x) =
       toLin' A (WithLp.equiv _ _ x) :=
   rfl
 
@@ -140,7 +140,7 @@ def l2OpNormedAddCommGroupAux : NormedAddCommGroup (Matrix m n 𝕜) :=
 provided by `Matrix.instMetricSpaceL2Op` and `Matrix.instNormedRingL2Op`.  -/
 def l2OpNormedRingAux : NormedRing (Matrix n n 𝕜) :=
   @NormedRing.induced ((Matrix n n 𝕜) ≃⋆ₐ[𝕜] (EuclideanSpace 𝕜 n →L[𝕜] EuclideanSpace 𝕜 n))
-    _ _ _ ContinuousLinearMap.toNormedRing _ _ toEuclideanClm.injective
+    _ _ _ ContinuousLinearMap.toNormedRing _ _ toEuclideanCLM.injective
 
 open Bornology Filter
 open scoped Topology Uniformity
@@ -234,11 +234,11 @@ def instL2OpNormedRing : NormedRing (Matrix n n 𝕜) where
 scoped[Matrix.L2OpNorm] attribute [instance] Matrix.instL2OpNormedRing
 
 /-- This is the same as `Matrix.l2_op_norm_def`, but with a more bundled RHS for square matrices. -/
-lemma cstar_norm_def (A : Matrix n n 𝕜) : ‖A‖ = ‖toEuclideanClm (n := n) (𝕜 := 𝕜) A‖ := rfl
+lemma cstar_norm_def (A : Matrix n n 𝕜) : ‖A‖ = ‖toEuclideanCLM (n := n) (𝕜 := 𝕜) A‖ := rfl
 
 /-- This is the same as `Matrix.l2_op_nnnorm_def`, but with a more bundled RHS for square
 matrices. -/
-lemma cstar_nnnorm_def (A : Matrix n n 𝕜) : ‖A‖₊ = ‖toEuclideanClm (n := n) (𝕜 := 𝕜) A‖₊ := rfl
+lemma cstar_nnnorm_def (A : Matrix n n 𝕜) : ‖A‖₊ = ‖toEuclideanCLM (n := n) (𝕜 := 𝕜) A‖₊ := rfl
 
 /-- The normed algebra structure on `Matrix n n 𝕜` arising from the operator norm given by the
 identification with (continuous) linear endmorphisms of `EuclideanSpace 𝕜 n`. -/

--- a/Mathlib/Analysis/SpecialFunctions/PolarCoord.lean
+++ b/Mathlib/Analysis/SpecialFunctions/PolarCoord.lean
@@ -89,7 +89,7 @@ def polarCoord : PartialHomeomorph (ℝ × ℝ) (ℝ × ℝ) where
     refine' ContinuousOn.comp (f := Complex.equivRealProd.symm)
       (g := Complex.arg) (fun z hz => _) _ A
     · exact (Complex.continuousAt_arg hz).continuousWithinAt
-    · exact Complex.equivRealProdClm.symm.continuous.continuousOn
+    · exact Complex.equivRealProdCLM.symm.continuous.continuousOn
 #align polar_coord polarCoord
 
 theorem hasFDerivAt_polarCoord_symm (p : ℝ × ℝ) :
@@ -162,7 +162,7 @@ open scoped Real
 /-- The polar coordinates partial homeomorphism in `ℂ`, mapping `r (cos θ + I * sin θ)` to `(r, θ)`.
 It is a homeomorphism between `ℂ - ℝ≤0` and `(0, +∞) × (-π, π)`. -/
 protected noncomputable def polarCoord : PartialHomeomorph ℂ (ℝ × ℝ) :=
-  equivRealProdClm.toHomeomorph.transPartialHomeomorph polarCoord
+  equivRealProdCLM.toHomeomorph.transPartialHomeomorph polarCoord
 
 protected theorem polarCoord_apply (a : ℂ) :
     Complex.polarCoord a = (Complex.abs a, Complex.arg a) := by
@@ -177,7 +177,7 @@ protected theorem polarCoord_target :
 @[simp]
 protected theorem polarCoord_symm_apply (p : ℝ × ℝ) :
     Complex.polarCoord.symm p = p.1 * (Real.cos p.2 + Real.sin p.2 * Complex.I) := by
-  simp [Complex.polarCoord, equivRealProdClm_symm_apply, mul_add, mul_assoc]
+  simp [Complex.polarCoord, equivRealProdCLM_symm_apply, mul_add, mul_assoc]
 
 theorem polardCoord_symm_abs (p : ℝ × ℝ) :
     Complex.abs (Complex.polarCoord.symm p) = |p.1| := by simp

--- a/Mathlib/Data/IsROrC/Basic.lean
+++ b/Mathlib/Data/IsROrC/Basic.lean
@@ -1067,18 +1067,18 @@ theorem conjAe_coe : (conjAe : K → K) = conj :=
 #align is_R_or_C.conj_ae_coe IsROrC.conjAe_coe
 
 /-- Conjugate as a linear isometry -/
-noncomputable def conjLie : K ≃ₗᵢ[ℝ] K :=
+noncomputable def conjLIE : K ≃ₗᵢ[ℝ] K :=
   ⟨conjAe.toLinearEquiv, fun _ => norm_conj⟩
-#align is_R_or_C.conj_lie IsROrC.conjLie
+#align is_R_or_C.conj_lie IsROrC.conjLIE
 
 @[simp, isROrC_simps]
-theorem conjLie_apply : (conjLie : K → K) = conj :=
+theorem conjLIE_apply : (conjLIE : K → K) = conj :=
   rfl
-#align is_R_or_C.conj_lie_apply IsROrC.conjLie_apply
+#align is_R_or_C.conj_lie_apply IsROrC.conjLIE_apply
 
 /-- Conjugate as a continuous linear equivalence -/
 noncomputable def conjCLE : K ≃L[ℝ] K :=
-  @conjLie K _
+  @conjLIE K _
 #align is_R_or_C.conj_cle IsROrC.conjCLE
 
 @[simp, isROrC_simps]
@@ -1092,7 +1092,7 @@ theorem conjCLE_apply : (conjCLE : K → K) = conj :=
 #align is_R_or_C.conj_cle_apply IsROrC.conjCLE_apply
 
 instance (priority := 100) : ContinuousStar K :=
-  ⟨conjLie.continuous⟩
+  ⟨conjLIE.continuous⟩
 
 @[continuity]
 theorem continuous_conj : Continuous (conj : K → K) :=
@@ -1110,19 +1110,19 @@ theorem ofRealAm_coe : (ofRealAm : ℝ → K) = ofReal :=
 #align is_R_or_C.of_real_am_coe IsROrC.ofRealAm_coe
 
 /-- The ℝ → K coercion, as a linear isometry -/
-noncomputable def ofRealLi : ℝ →ₗᵢ[ℝ] K where
+noncomputable def ofRealLI : ℝ →ₗᵢ[ℝ] K where
   toLinearMap := ofRealAm.toLinearMap
   norm_map' := norm_ofReal
-#align is_R_or_C.of_real_li IsROrC.ofRealLi
+#align is_R_or_C.of_real_li IsROrC.ofRealLI
 
 @[simp, isROrC_simps]
-theorem ofRealLi_apply : (ofRealLi : ℝ → K) = ofReal :=
+theorem ofRealLI_apply : (ofRealLI : ℝ → K) = ofReal :=
   rfl
-#align is_R_or_C.of_real_li_apply IsROrC.ofRealLi_apply
+#align is_R_or_C.of_real_li_apply IsROrC.ofRealLI_apply
 
 /-- The `ℝ → K` coercion, as a continuous linear map -/
 noncomputable def ofRealCLM : ℝ →L[ℝ] K :=
-  ofRealLi.toContinuousLinearMap
+  ofRealLI.toContinuousLinearMap
 #align is_R_or_C.of_real_clm IsROrC.ofRealCLM
 
 @[simp, isROrC_simps]
@@ -1137,7 +1137,7 @@ theorem ofRealCLM_apply : (ofRealCLM : ℝ → K) = ofReal :=
 
 @[continuity]
 theorem continuous_ofReal : Continuous (ofReal : ℝ → K) :=
-  ofRealLi.continuous
+  ofRealLI.continuous
 #align is_R_or_C.continuous_of_real IsROrC.continuous_ofReal
 
 @[continuity]

--- a/Mathlib/Data/IsROrC/Basic.lean
+++ b/Mathlib/Data/IsROrC/Basic.lean
@@ -999,25 +999,25 @@ theorem reLm_coe : (reLm : K → ℝ) = re :=
 #align is_R_or_C.re_lm_coe IsROrC.reLm_coe
 
 /-- The real part in an `IsROrC` field, as a continuous linear map. -/
-noncomputable def reClm : K →L[ℝ] ℝ :=
+noncomputable def reCLM : K →L[ℝ] ℝ :=
   reLm.mkContinuous 1 fun x => by
     rw [one_mul]
     exact abs_re_le_norm x
-#align is_R_or_C.re_clm IsROrC.reClm
+#align is_R_or_C.re_clm IsROrC.reCLM
 
 @[simp, isROrC_simps, norm_cast]
-theorem reClm_coe : ((reClm : K →L[ℝ] ℝ) : K →ₗ[ℝ] ℝ) = reLm :=
+theorem reCLM_coe : ((reCLM : K →L[ℝ] ℝ) : K →ₗ[ℝ] ℝ) = reLm :=
   rfl
-#align is_R_or_C.re_clm_coe IsROrC.reClm_coe
+#align is_R_or_C.re_clm_coe IsROrC.reCLM_coe
 
 @[simp, isROrC_simps]
-theorem reClm_apply : ((reClm : K →L[ℝ] ℝ) : K → ℝ) = re :=
+theorem reCLM_apply : ((reCLM : K →L[ℝ] ℝ) : K → ℝ) = re :=
   rfl
-#align is_R_or_C.re_clm_apply IsROrC.reClm_apply
+#align is_R_or_C.re_clm_apply IsROrC.reCLM_apply
 
 @[continuity]
 theorem continuous_re : Continuous (re : K → ℝ) :=
-  reClm.continuous
+  reCLM.continuous
 #align is_R_or_C.continuous_re IsROrC.continuous_re
 
 /-- The imaginary part in an `IsROrC` field, as a linear map. -/
@@ -1031,25 +1031,25 @@ theorem imLm_coe : (imLm : K → ℝ) = im :=
 #align is_R_or_C.im_lm_coe IsROrC.imLm_coe
 
 /-- The imaginary part in an `IsROrC` field, as a continuous linear map. -/
-noncomputable def imClm : K →L[ℝ] ℝ :=
+noncomputable def imCLM : K →L[ℝ] ℝ :=
   imLm.mkContinuous 1 fun x => by
     rw [one_mul]
     exact abs_im_le_norm x
-#align is_R_or_C.im_clm IsROrC.imClm
+#align is_R_or_C.im_clm IsROrC.imCLM
 
 @[simp, isROrC_simps, norm_cast]
-theorem imClm_coe : ((imClm : K →L[ℝ] ℝ) : K →ₗ[ℝ] ℝ) = imLm :=
+theorem imCLM_coe : ((imCLM : K →L[ℝ] ℝ) : K →ₗ[ℝ] ℝ) = imLm :=
   rfl
-#align is_R_or_C.im_clm_coe IsROrC.imClm_coe
+#align is_R_or_C.im_clm_coe IsROrC.imCLM_coe
 
 @[simp, isROrC_simps]
-theorem imClm_apply : ((imClm : K →L[ℝ] ℝ) : K → ℝ) = im :=
+theorem imCLM_apply : ((imCLM : K →L[ℝ] ℝ) : K → ℝ) = im :=
   rfl
-#align is_R_or_C.im_clm_apply IsROrC.imClm_apply
+#align is_R_or_C.im_clm_apply IsROrC.imCLM_apply
 
 @[continuity]
 theorem continuous_im : Continuous (im : K → ℝ) :=
-  imClm.continuous
+  imCLM.continuous
 #align is_R_or_C.continuous_im IsROrC.continuous_im
 
 /-- Conjugate as an `ℝ`-algebra equivalence -/
@@ -1077,17 +1077,17 @@ theorem conjLie_apply : (conjLie : K → K) = conj :=
 #align is_R_or_C.conj_lie_apply IsROrC.conjLie_apply
 
 /-- Conjugate as a continuous linear equivalence -/
-noncomputable def conjCle : K ≃L[ℝ] K :=
+noncomputable def conjCLE : K ≃L[ℝ] K :=
   @conjLie K _
-#align is_R_or_C.conj_cle IsROrC.conjCle
+#align is_R_or_C.conj_cle IsROrC.conjCLE
 
 @[simp, isROrC_simps]
-theorem conjCle_coe : (@conjCle K _).toLinearEquiv = conjAe.toLinearEquiv :=
+theorem conjCLE_coe : (@conjCLE K _).toLinearEquiv = conjAe.toLinearEquiv :=
   rfl
 #align is_R_or_C.conj_cle_coe IsROrC.conjCle_coe
 
 @[simp, isROrC_simps]
-theorem conjCle_apply : (conjCle : K → K) = conj :=
+theorem conjCLE_apply : (conjCLE : K → K) = conj :=
   rfl
 #align is_R_or_C.conj_cle_apply IsROrC.conjCle_apply
 
@@ -1121,19 +1121,19 @@ theorem ofRealLi_apply : (ofRealLi : ℝ → K) = ofReal :=
 #align is_R_or_C.of_real_li_apply IsROrC.ofRealLi_apply
 
 /-- The `ℝ → K` coercion, as a continuous linear map -/
-noncomputable def ofRealClm : ℝ →L[ℝ] K :=
+noncomputable def ofRealCLM : ℝ →L[ℝ] K :=
   ofRealLi.toContinuousLinearMap
-#align is_R_or_C.of_real_clm IsROrC.ofRealClm
+#align is_R_or_C.of_real_clm IsROrC.ofRealCLM
 
 @[simp, isROrC_simps]
-theorem ofRealClm_coe : (@ofRealClm K _ : ℝ →ₗ[ℝ] K) = ofRealAm.toLinearMap :=
+theorem ofRealCLM_coe : (@ofRealCLM K _ : ℝ →ₗ[ℝ] K) = ofRealAm.toLinearMap :=
   rfl
-#align is_R_or_C.of_real_clm_coe IsROrC.ofRealClm_coe
+#align is_R_or_C.of_real_clm_coe IsROrC.ofRealCLM_coe
 
 @[simp, isROrC_simps]
-theorem ofRealClm_apply : (ofRealClm : ℝ → K) = ofReal :=
+theorem ofRealCLM_apply : (ofRealCLM : ℝ → K) = ofReal :=
   rfl
-#align is_R_or_C.of_real_clm_apply IsROrC.ofRealClm_apply
+#align is_R_or_C.of_real_clm_apply IsROrC.ofRealCLM_apply
 
 @[continuity]
 theorem continuous_ofReal : Continuous (ofReal : ℝ → K) :=

--- a/Mathlib/Data/IsROrC/Basic.lean
+++ b/Mathlib/Data/IsROrC/Basic.lean
@@ -1084,12 +1084,12 @@ noncomputable def conjCLE : K ≃L[ℝ] K :=
 @[simp, isROrC_simps]
 theorem conjCLE_coe : (@conjCLE K _).toLinearEquiv = conjAe.toLinearEquiv :=
   rfl
-#align is_R_or_C.conj_cle_coe IsROrC.conjCle_coe
+#align is_R_or_C.conj_cle_coe IsROrC.conjCLE_coe
 
 @[simp, isROrC_simps]
 theorem conjCLE_apply : (conjCLE : K → K) = conj :=
   rfl
-#align is_R_or_C.conj_cle_apply IsROrC.conjCle_apply
+#align is_R_or_C.conj_cle_apply IsROrC.conjCLE_apply
 
 instance (priority := 100) : ContinuousStar K :=
   ⟨conjLie.continuous⟩

--- a/Mathlib/Data/IsROrC/Lemmas.lean
+++ b/Mathlib/Data/IsROrC/Lemmas.lean
@@ -77,7 +77,7 @@ theorem reCLM_norm : ‖(reCLM : K →L[ℝ] ℝ)‖ = 1 := by
 @[simp, isROrC_simps]
 theorem conjCLE_norm : ‖(@conjCLE K _ : K →L[ℝ] K)‖ = 1 :=
   (@conjLie K _).toLinearIsometry.norm_toContinuousLinearMap
-#align is_R_or_C.conj_cle_norm IsROrC.conjCle_norm
+#align is_R_or_C.conj_cle_norm IsROrC.conjCLE_norm
 
 @[simp, isROrC_simps]
 theorem ofRealCLM_norm : ‖(ofRealCLM : ℝ →L[ℝ] K)‖ = 1 :=

--- a/Mathlib/Data/IsROrC/Lemmas.lean
+++ b/Mathlib/Data/IsROrC/Lemmas.lean
@@ -76,13 +76,13 @@ theorem reCLM_norm : ‖(reCLM : K →L[ℝ] ℝ)‖ = 1 := by
 
 @[simp, isROrC_simps]
 theorem conjCLE_norm : ‖(@conjCLE K _ : K →L[ℝ] K)‖ = 1 :=
-  (@conjLie K _).toLinearIsometry.norm_toContinuousLinearMap
+  (@conjLIE K _).toLinearIsometry.norm_toContinuousLinearMap
 #align is_R_or_C.conj_cle_norm IsROrC.conjCLE_norm
 
 @[simp, isROrC_simps]
 theorem ofRealCLM_norm : ‖(ofRealCLM : ℝ →L[ℝ] K)‖ = 1 :=
   -- Porting note: the following timed out
-  -- LinearIsometry.norm_toContinuousLinearMap ofRealLi
+  -- LinearIsometry.norm_toContinuousLinearMap ofRealLI
   LinearIsometry.norm_toContinuousLinearMap _
 #align is_R_or_C.of_real_clm_norm IsROrC.ofRealCLM_norm
 

--- a/Mathlib/Data/IsROrC/Lemmas.lean
+++ b/Mathlib/Data/IsROrC/Lemmas.lean
@@ -68,22 +68,22 @@ end FiniteDimensional
 namespace IsROrC
 
 @[simp, isROrC_simps]
-theorem reClm_norm : ‖(reClm : K →L[ℝ] ℝ)‖ = 1 := by
+theorem reCLM_norm : ‖(reCLM : K →L[ℝ] ℝ)‖ = 1 := by
   apply le_antisymm (LinearMap.mkContinuous_norm_le _ zero_le_one _)
-  convert ContinuousLinearMap.ratio_le_op_norm (reClm : K →L[ℝ] ℝ) (1 : K)
+  convert ContinuousLinearMap.ratio_le_op_norm (reCLM : K →L[ℝ] ℝ) (1 : K)
   simp
-#align is_R_or_C.re_clm_norm IsROrC.reClm_norm
+#align is_R_or_C.re_clm_norm IsROrC.reCLM_norm
 
 @[simp, isROrC_simps]
-theorem conjCle_norm : ‖(@conjCle K _ : K →L[ℝ] K)‖ = 1 :=
+theorem conjCLE_norm : ‖(@conjCLE K _ : K →L[ℝ] K)‖ = 1 :=
   (@conjLie K _).toLinearIsometry.norm_toContinuousLinearMap
 #align is_R_or_C.conj_cle_norm IsROrC.conjCle_norm
 
 @[simp, isROrC_simps]
-theorem ofRealClm_norm : ‖(ofRealClm : ℝ →L[ℝ] K)‖ = 1 :=
+theorem ofRealCLM_norm : ‖(ofRealCLM : ℝ →L[ℝ] K)‖ = 1 :=
   -- Porting note: the following timed out
   -- LinearIsometry.norm_toContinuousLinearMap ofRealLi
   LinearIsometry.norm_toContinuousLinearMap _
-#align is_R_or_C.of_real_clm_norm IsROrC.ofRealClm_norm
+#align is_R_or_C.of_real_clm_norm IsROrC.ofRealCLM_norm
 
 end IsROrC

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -610,7 +610,7 @@ instance : LieGroup (𝓡 1) circle where
   smooth_inv := by
     apply ContMDiff.codRestrict_sphere
     simp only [← coe_inv_circle, coe_inv_circle_eq_conj]
-    exact Complex.conjCle.contDiff.contMDiff.comp contMDiff_coe_sphere
+    exact Complex.conjCLE.contDiff.contMDiff.comp contMDiff_coe_sphere
 
 /-- The map `fun t ↦ exp (t * I)` from `ℝ` to the unit circle in `ℂ` is smooth. -/
 theorem contMDiff_expMapCircle : ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) ∞ expMapCircle :=

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -22,11 +22,11 @@ The construction is done in four steps:
   is integrable and define a map `Set α → (E →L[ℝ] (α →₁[μ] E))` which to a set associates a linear
   map. That linear map sends `x ∈ E` to the conditional expectation of the indicator of the set
   with value `x`.
-* Extend that map to `condexpL1Clm : (α →₁[μ] E) →L[ℝ] (α →₁[μ] E)`. This is done using the same
+* Extend that map to `condexpL1CLM : (α →₁[μ] E) →L[ℝ] (α →₁[μ] E)`. This is done using the same
   construction as the Bochner integral (see the file `MeasureTheory/Integral/SetToL1`).
 * Define the conditional expectation of a function `f : α → E`, which is an integrable function
   `α → E` equal to 0 if `f` is not integrable, and equal to an `m`-measurable representative of
-  `condexpL1Clm` applied to `[f]`, the equivalence class of `f` in `L¹`.
+  `condexpL1CLM` applied to `[f]`, the equivalence class of `f` in `L¹`.
 
 The first step is done in `MeasureTheory.Function.ConditionalExpectation.CondexpL2`, the two
 next steps in `MeasureTheory.Function.ConditionalExpectation.CondexpL1` and the final step is
@@ -45,7 +45,7 @@ The conditional expectation and its properties
   `∫ x in s, condexp m μ f x ∂μ = ∫ x in s, f x ∂μ` for any `m`-measurable set `s`.
 
 While `condexp` is function-valued, we also define `condexpL1` with value in `L1` and a continuous
-linear map `condexpL1Clm` from `L1` to `L1`. `condexp` should be used in most cases.
+linear map `condexpL1CLM` from `L1` to `L1`. `condexp` should be used in most cases.
 
 Uniqueness of the conditional expectation
 
@@ -149,12 +149,12 @@ theorem condexp_ae_eq_condexpL1 (hm : m ≤ m0) [hμm : SigmaFinite (μ.trim hm)
 set_option linter.uppercaseLean3 false in
 #align measure_theory.condexp_ae_eq_condexp_L1 MeasureTheory.condexp_ae_eq_condexpL1
 
-theorem condexp_ae_eq_condexpL1Clm (hm : m ≤ m0) [SigmaFinite (μ.trim hm)] (hf : Integrable f μ) :
-    μ[f|m] =ᵐ[μ] condexpL1Clm F' hm μ (hf.toL1 f) := by
+theorem condexp_ae_eq_condexpL1CLM (hm : m ≤ m0) [SigmaFinite (μ.trim hm)] (hf : Integrable f μ) :
+    μ[f|m] =ᵐ[μ] condexpL1CLM F' hm μ (hf.toL1 f) := by
   refine' (condexp_ae_eq_condexpL1 hm f).trans (eventually_of_forall fun x => _)
   rw [condexpL1_eq hf]
 set_option linter.uppercaseLean3 false in
-#align measure_theory.condexp_ae_eq_condexp_L1_clm MeasureTheory.condexp_ae_eq_condexpL1Clm
+#align measure_theory.condexp_ae_eq_condexp_L1_clm MeasureTheory.condexp_ae_eq_condexpL1CLM
 
 theorem condexp_undef (hf : ¬Integrable f μ) : μ[f|m] = 0 := by
   by_cases hm : m ≤ m0

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL1.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL1.lean
@@ -19,7 +19,7 @@ The contitional expectation of an `L²` function is defined in
   is integrable and define a map `Set α → (E →L[ℝ] (α →₁[μ] E))` which to a set associates a linear
   map. That linear map sends `x ∈ E` to the conditional expectation of the indicator of the set
   with value `x`.
-* Extend that map to `condexpL1Clm : (α →₁[μ] E) →L[ℝ] (α →₁[μ] E)`. This is done using the same
+* Extend that map to `condexpL1CLM : (α →₁[μ] E) →L[ℝ] (α →₁[μ] E)`. This is done using the same
   construction as the Bochner integral (see the file `MeasureTheory/Integral/SetToL1`).
 
 ## Main definitions
@@ -372,63 +372,63 @@ set_option linter.uppercaseLean3 false
 variable {m m0 : MeasurableSpace α} {μ : Measure α} {hm : m ≤ m0} [SigmaFinite (μ.trim hm)]
   {f g : α → F'} {s : Set α}
 
--- Porting note: `F'` is not automatically inferred in `condexpL1Clm` in Lean 4;
+-- Porting note: `F'` is not automatically inferred in `condexpL1CLM` in Lean 4;
 -- to avoid repeatedly typing `(F' := ...)` it is made explicit.
 variable (F')
 
 /-- Conditional expectation of a function as a linear map from `α →₁[μ] F'` to itself. -/
-def condexpL1Clm (hm : m ≤ m0) (μ : Measure α) [SigmaFinite (μ.trim hm)] :
+def condexpL1CLM (hm : m ≤ m0) (μ : Measure α) [SigmaFinite (μ.trim hm)] :
     (α →₁[μ] F') →L[ℝ] α →₁[μ] F' :=
   L1.setToL1 (dominatedFinMeasAdditive_condexpInd F' hm μ)
-#align measure_theory.condexp_L1_clm MeasureTheory.condexpL1Clm
+#align measure_theory.condexp_L1_clm MeasureTheory.condexpL1CLM
 
 variable {F'}
 
-theorem condexpL1Clm_smul (c : 𝕜) (f : α →₁[μ] F') :
-    condexpL1Clm F' hm μ (c • f) = c • condexpL1Clm F' hm μ f := by
+theorem condexpL1CLM_smul (c : 𝕜) (f : α →₁[μ] F') :
+    condexpL1CLM F' hm μ (c • f) = c • condexpL1CLM F' hm μ f := by
   refine' L1.setToL1_smul (dominatedFinMeasAdditive_condexpInd F' hm μ) _ c f
   exact fun c s x => condexpInd_smul' c x
-#align measure_theory.condexp_L1_clm_smul MeasureTheory.condexpL1Clm_smul
+#align measure_theory.condexp_L1_clm_smul MeasureTheory.condexpL1CLM_smul
 
-theorem condexpL1Clm_indicatorConstLp (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x : F') :
-    (condexpL1Clm F' hm μ) (indicatorConstLp 1 hs hμs x) = condexpInd F' hm μ s x :=
+theorem condexpL1CLM_indicatorConstLp (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x : F') :
+    (condexpL1CLM F' hm μ) (indicatorConstLp 1 hs hμs x) = condexpInd F' hm μ s x :=
   L1.setToL1_indicatorConstLp (dominatedFinMeasAdditive_condexpInd F' hm μ) hs hμs x
-#align measure_theory.condexp_L1_clm_indicator_const_Lp MeasureTheory.condexpL1Clm_indicatorConstLp
+#align measure_theory.condexp_L1_clm_indicator_const_Lp MeasureTheory.condexpL1CLM_indicatorConstLp
 
-theorem condexpL1Clm_indicatorConst (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x : F') :
-    (condexpL1Clm F' hm μ) ↑(simpleFunc.indicatorConst 1 hs hμs x) = condexpInd F' hm μ s x := by
-  rw [Lp.simpleFunc.coe_indicatorConst]; exact condexpL1Clm_indicatorConstLp hs hμs x
-#align measure_theory.condexp_L1_clm_indicator_const MeasureTheory.condexpL1Clm_indicatorConst
+theorem condexpL1CLM_indicatorConst (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x : F') :
+    (condexpL1CLM F' hm μ) ↑(simpleFunc.indicatorConst 1 hs hμs x) = condexpInd F' hm μ s x := by
+  rw [Lp.simpleFunc.coe_indicatorConst]; exact condexpL1CLM_indicatorConstLp hs hμs x
+#align measure_theory.condexp_L1_clm_indicator_const MeasureTheory.condexpL1CLM_indicatorConst
 
-/-- Auxiliary lemma used in the proof of `set_integral_condexpL1Clm`. -/
-theorem set_integral_condexpL1Clm_of_measure_ne_top (f : α →₁[μ] F') (hs : MeasurableSet[m] s)
-    (hμs : μ s ≠ ∞) : ∫ x in s, condexpL1Clm F' hm μ f x ∂μ = ∫ x in s, f x ∂μ := by
+/-- Auxiliary lemma used in the proof of `set_integral_condexpL1CLM`. -/
+theorem set_integral_condexpL1CLM_of_measure_ne_top (f : α →₁[μ] F') (hs : MeasurableSet[m] s)
+    (hμs : μ s ≠ ∞) : ∫ x in s, condexpL1CLM F' hm μ f x ∂μ = ∫ x in s, f x ∂μ := by
   refine' @Lp.induction _ _ _ _ _ _ _ ENNReal.one_ne_top
-    (fun f : α →₁[μ] F' => ∫ x in s, condexpL1Clm F' hm μ f x ∂μ = ∫ x in s, f x ∂μ) _ _
+    (fun f : α →₁[μ] F' => ∫ x in s, condexpL1CLM F' hm μ f x ∂μ = ∫ x in s, f x ∂μ) _ _
     (isClosed_eq _ _) f
   · intro x t ht hμt
-    simp_rw [condexpL1Clm_indicatorConst ht hμt.ne x]
+    simp_rw [condexpL1CLM_indicatorConst ht hμt.ne x]
     rw [Lp.simpleFunc.coe_indicatorConst, set_integral_indicatorConstLp (hm _ hs)]
     exact set_integral_condexpInd hs ht hμs hμt.ne x
   · intro f g hf_Lp hg_Lp _ hf hg
-    simp_rw [(condexpL1Clm F' hm μ).map_add]
-    rw [set_integral_congr_ae (hm s hs) ((Lp.coeFn_add (condexpL1Clm F' hm μ (hf_Lp.toLp f))
-      (condexpL1Clm F' hm μ (hg_Lp.toLp g))).mono fun x hx _ => hx)]
+    simp_rw [(condexpL1CLM F' hm μ).map_add]
+    rw [set_integral_congr_ae (hm s hs) ((Lp.coeFn_add (condexpL1CLM F' hm μ (hf_Lp.toLp f))
+      (condexpL1CLM F' hm μ (hg_Lp.toLp g))).mono fun x hx _ => hx)]
     rw [set_integral_congr_ae (hm s hs)
       ((Lp.coeFn_add (hf_Lp.toLp f) (hg_Lp.toLp g)).mono fun x hx _ => hx)]
     simp_rw [Pi.add_apply]
     rw [integral_add (L1.integrable_coeFn _).integrableOn (L1.integrable_coeFn _).integrableOn,
       integral_add (L1.integrable_coeFn _).integrableOn (L1.integrable_coeFn _).integrableOn, hf,
       hg]
-  · exact (continuous_set_integral s).comp (condexpL1Clm F' hm μ).continuous
+  · exact (continuous_set_integral s).comp (condexpL1CLM F' hm μ).continuous
   · exact continuous_set_integral s
-#align measure_theory.set_integral_condexp_L1_clm_of_measure_ne_top MeasureTheory.set_integral_condexpL1Clm_of_measure_ne_top
+#align measure_theory.set_integral_condexp_L1_clm_of_measure_ne_top MeasureTheory.set_integral_condexpL1CLM_of_measure_ne_top
 
-/-- The integral of the conditional expectation `condexpL1Clm` over an `m`-measurable set is equal
+/-- The integral of the conditional expectation `condexpL1CLM` over an `m`-measurable set is equal
 to the integral of `f` on that set. See also `set_integral_condexp`, the similar statement for
 `condexp`. -/
-theorem set_integral_condexpL1Clm (f : α →₁[μ] F') (hs : MeasurableSet[m] s) :
-    ∫ x in s, condexpL1Clm F' hm μ f x ∂μ = ∫ x in s, f x ∂μ := by
+theorem set_integral_condexpL1CLM (f : α →₁[μ] F') (hs : MeasurableSet[m] s) :
+    ∫ x in s, condexpL1CLM F' hm μ f x ∂μ = ∫ x in s, f x ∂μ := by
   let S := spanningSets (μ.trim hm)
   have hS_meas : ∀ i, MeasurableSet[m] (S i) := measurable_spanningSets (μ.trim hm)
   have hS_meas0 : ∀ i, MeasurableSet (S i) := fun i => hm _ (hS_meas i)
@@ -444,70 +444,70 @@ theorem set_integral_condexpL1Clm (f : α →₁[μ] F') (hs : MeasurableSet[m] 
     simp_rw [Set.mem_inter_iff]
     exact fun h => ⟨monotone_spanningSets (μ.trim hm) hij h.1, h.2⟩
   have h_eq_forall :
-    (fun i => ∫ x in S i ∩ s, condexpL1Clm F' hm μ f x ∂μ) = fun i => ∫ x in S i ∩ s, f x ∂μ :=
+    (fun i => ∫ x in S i ∩ s, condexpL1CLM F' hm μ f x ∂μ) = fun i => ∫ x in S i ∩ s, f x ∂μ :=
     funext fun i =>
-      set_integral_condexpL1Clm_of_measure_ne_top f (@MeasurableSet.inter α m _ _ (hS_meas i) hs)
+      set_integral_condexpL1CLM_of_measure_ne_top f (@MeasurableSet.inter α m _ _ (hS_meas i) hs)
         (hS_finite i).ne
   have h_right : Tendsto (fun i => ∫ x in S i ∩ s, f x ∂μ) atTop (𝓝 (∫ x in s, f x ∂μ)) := by
     have h :=
       tendsto_set_integral_of_monotone (fun i => (hS_meas0 i).inter (hm s hs)) h_mono
         (L1.integrable_coeFn f).integrableOn
     rwa [← hs_eq] at h
-  have h_left : Tendsto (fun i => ∫ x in S i ∩ s, condexpL1Clm F' hm μ f x ∂μ) atTop
-      (𝓝 (∫ x in s, condexpL1Clm F' hm μ f x ∂μ)) := by
+  have h_left : Tendsto (fun i => ∫ x in S i ∩ s, condexpL1CLM F' hm μ f x ∂μ) atTop
+      (𝓝 (∫ x in s, condexpL1CLM F' hm μ f x ∂μ)) := by
     have h := tendsto_set_integral_of_monotone (fun i => (hS_meas0 i).inter (hm s hs)) h_mono
-      (L1.integrable_coeFn (condexpL1Clm F' hm μ f)).integrableOn
+      (L1.integrable_coeFn (condexpL1CLM F' hm μ f)).integrableOn
     rwa [← hs_eq] at h
   rw [h_eq_forall] at h_left
   exact tendsto_nhds_unique h_left h_right
-#align measure_theory.set_integral_condexp_L1_clm MeasureTheory.set_integral_condexpL1Clm
+#align measure_theory.set_integral_condexp_L1_clm MeasureTheory.set_integral_condexpL1CLM
 
-theorem aestronglyMeasurable'_condexpL1Clm (f : α →₁[μ] F') :
-    AEStronglyMeasurable' m (condexpL1Clm F' hm μ f) μ := by
+theorem aestronglyMeasurable'_condexpL1CLM (f : α →₁[μ] F') :
+    AEStronglyMeasurable' m (condexpL1CLM F' hm μ f) μ := by
   refine' @Lp.induction _ _ _ _ _ _ _ ENNReal.one_ne_top
-    (fun f : α →₁[μ] F' => AEStronglyMeasurable' m (condexpL1Clm F' hm μ f) μ) _ _ _ f
+    (fun f : α →₁[μ] F' => AEStronglyMeasurable' m (condexpL1CLM F' hm μ f) μ) _ _ _ f
   · intro c s hs hμs
-    rw [condexpL1Clm_indicatorConst hs hμs.ne c]
+    rw [condexpL1CLM_indicatorConst hs hμs.ne c]
     exact aestronglyMeasurable'_condexpInd hs hμs.ne c
   · intro f g hf hg _ hfm hgm
-    rw [(condexpL1Clm F' hm μ).map_add]
+    rw [(condexpL1CLM F' hm μ).map_add]
     refine' AEStronglyMeasurable'.congr _ (coeFn_add _ _).symm
     exact AEStronglyMeasurable'.add hfm hgm
-  · have : {f : Lp F' 1 μ | AEStronglyMeasurable' m (condexpL1Clm F' hm μ f) μ} =
-        condexpL1Clm F' hm μ ⁻¹' {f | AEStronglyMeasurable' m f μ} := rfl
+  · have : {f : Lp F' 1 μ | AEStronglyMeasurable' m (condexpL1CLM F' hm μ f) μ} =
+        condexpL1CLM F' hm μ ⁻¹' {f | AEStronglyMeasurable' m f μ} := rfl
     rw [this]
-    refine' IsClosed.preimage (condexpL1Clm F' hm μ).continuous _
+    refine' IsClosed.preimage (condexpL1CLM F' hm μ).continuous _
     exact isClosed_aeStronglyMeasurable' hm
-#align measure_theory.ae_strongly_measurable'_condexp_L1_clm MeasureTheory.aestronglyMeasurable'_condexpL1Clm
+#align measure_theory.ae_strongly_measurable'_condexp_L1_clm MeasureTheory.aestronglyMeasurable'_condexpL1CLM
 
-theorem condexpL1Clm_lpMeas (f : lpMeas F' ℝ m 1 μ) :
-    condexpL1Clm F' hm μ (f : α →₁[μ] F') = ↑f := by
+theorem condexpL1CLM_lpMeas (f : lpMeas F' ℝ m 1 μ) :
+    condexpL1CLM F' hm μ (f : α →₁[μ] F') = ↑f := by
   let g := lpMeasToLpTrimLie F' ℝ 1 μ hm f
   have hfg : f = (lpMeasToLpTrimLie F' ℝ 1 μ hm).symm g := by
     simp only [LinearIsometryEquiv.symm_apply_apply]
   rw [hfg]
   refine' @Lp.induction α F' m _ 1 (μ.trim hm) _ ENNReal.coe_ne_top (fun g : α →₁[μ.trim hm] F' =>
-    condexpL1Clm F' hm μ ((lpMeasToLpTrimLie F' ℝ 1 μ hm).symm g : α →₁[μ] F') =
+    condexpL1CLM F' hm μ ((lpMeasToLpTrimLie F' ℝ 1 μ hm).symm g : α →₁[μ] F') =
     ↑((lpMeasToLpTrimLie F' ℝ 1 μ hm).symm g)) _ _ _ g
   · intro c s hs hμs
     rw [@Lp.simpleFunc.coe_indicatorConst _ _ m, lpMeasToLpTrimLie_symm_indicator hs hμs.ne c,
-      condexpL1Clm_indicatorConstLp]
+      condexpL1CLM_indicatorConstLp]
     exact condexpInd_of_measurable hs ((le_trim hm).trans_lt hμs).ne c
   · intro f g hf hg _ hf_eq hg_eq
     rw [LinearIsometryEquiv.map_add]
     push_cast
     rw [map_add, hf_eq, hg_eq]
   · refine' isClosed_eq _ _
-    · refine' (condexpL1Clm F' hm μ).continuous.comp (continuous_induced_dom.comp _)
+    · refine' (condexpL1CLM F' hm μ).continuous.comp (continuous_induced_dom.comp _)
       exact LinearIsometryEquiv.continuous _
     · refine' continuous_induced_dom.comp _
       exact LinearIsometryEquiv.continuous _
-#align measure_theory.condexp_L1_clm_Lp_meas MeasureTheory.condexpL1Clm_lpMeas
+#align measure_theory.condexp_L1_clm_Lp_meas MeasureTheory.condexpL1CLM_lpMeas
 
-theorem condexpL1Clm_of_aestronglyMeasurable' (f : α →₁[μ] F') (hfm : AEStronglyMeasurable' m f μ) :
-    condexpL1Clm F' hm μ f = f :=
-  condexpL1Clm_lpMeas (⟨f, hfm⟩ : lpMeas F' ℝ m 1 μ)
-#align measure_theory.condexp_L1_clm_of_ae_strongly_measurable' MeasureTheory.condexpL1Clm_of_aestronglyMeasurable'
+theorem condexpL1CLM_of_aestronglyMeasurable' (f : α →₁[μ] F') (hfm : AEStronglyMeasurable' m f μ) :
+    condexpL1CLM F' hm μ f = f :=
+  condexpL1CLM_lpMeas (⟨f, hfm⟩ : lpMeas F' ℝ m 1 μ)
+#align measure_theory.condexp_L1_clm_of_ae_strongly_measurable' MeasureTheory.condexpL1CLM_of_aestronglyMeasurable'
 
 /-- Conditional expectation of a function, in L1. Its value is 0 if the function is not
 integrable. The function-valued `condexp` should be used instead in most cases. -/
@@ -519,7 +519,7 @@ theorem condexpL1_undef (hf : ¬Integrable f μ) : condexpL1 hm μ f = 0 :=
   setToFun_undef (dominatedFinMeasAdditive_condexpInd F' hm μ) hf
 #align measure_theory.condexp_L1_undef MeasureTheory.condexpL1_undef
 
-theorem condexpL1_eq (hf : Integrable f μ) : condexpL1 hm μ f = condexpL1Clm F' hm μ (hf.toL1 f) :=
+theorem condexpL1_eq (hf : Integrable f μ) : condexpL1 hm μ f = condexpL1CLM F' hm μ (hf.toL1 f) :=
   setToFun_eq (dominatedFinMeasAdditive_condexpInd F' hm μ) hf
 #align measure_theory.condexp_L1_eq MeasureTheory.condexpL1_eq
 
@@ -537,7 +537,7 @@ theorem aestronglyMeasurable'_condexpL1 {f : α → F'} :
     AEStronglyMeasurable' m (condexpL1 hm μ f) μ := by
   by_cases hf : Integrable f μ
   · rw [condexpL1_eq hf]
-    exact aestronglyMeasurable'_condexpL1Clm _
+    exact aestronglyMeasurable'_condexpL1CLM _
   · rw [condexpL1_undef hf]
     refine AEStronglyMeasurable'.congr ?_ (coeFn_zero _ _ _).symm
     exact StronglyMeasurable.aeStronglyMeasurable' (@stronglyMeasurable_zero _ _ m _ _)
@@ -558,7 +558,7 @@ the integral of `f` on that set. See also `set_integral_condexp`, the similar st
 theorem set_integral_condexpL1 (hf : Integrable f μ) (hs : MeasurableSet[m] s) :
     ∫ x in s, condexpL1 hm μ f x ∂μ = ∫ x in s, f x ∂μ := by
   simp_rw [condexpL1_eq hf]
-  rw [set_integral_condexpL1Clm (hf.toL1 f) hs]
+  rw [set_integral_condexpL1CLM (hf.toL1 f) hs]
   exact set_integral_congr_ae (hm s hs) (hf.coeFn_toL1.mono fun x hx _ => hx)
 #align measure_theory.set_integral_condexp_L1 MeasureTheory.set_integral_condexpL1
 
@@ -585,7 +585,7 @@ theorem condexpL1_of_aestronglyMeasurable' (hfm : AEStronglyMeasurable' m f μ)
     (hfi : Integrable f μ) : condexpL1 hm μ f =ᵐ[μ] f := by
   rw [condexpL1_eq hfi]
   refine' EventuallyEq.trans _ (Integrable.coeFn_toL1 hfi)
-  rw [condexpL1Clm_of_aestronglyMeasurable']
+  rw [condexpL1CLM_of_aestronglyMeasurable']
   exact AEStronglyMeasurable'.congr hfm (Integrable.coeFn_toL1 hfi).symm
 #align measure_theory.condexp_L1_of_ae_strongly_measurable' MeasureTheory.condexpL1_of_aestronglyMeasurable'
 

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -1127,7 +1127,7 @@ variable {K : Type*} [IsROrC K]
 
 theorem _root_.MeasureTheory.Memℒp.ofReal {f : α → ℝ} (hf : Memℒp f p μ) :
     Memℒp (fun x => (f x : K)) p μ :=
-  (@IsROrC.ofRealClm K _).comp_memℒp' hf
+  (@IsROrC.ofRealCLM K _).comp_memℒp' hf
 #align measure_theory.mem_ℒp.of_real MeasureTheory.Memℒp.ofReal
 
 theorem _root_.MeasureTheory.memℒp_re_im_iff {f : α → K} :

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -169,8 +169,8 @@ theorem circleMap_ne_center {c : ℂ} {R : ℝ} (hR : R ≠ 0) {θ : ℝ} : circ
 
 theorem hasDerivAt_circleMap (c : ℂ) (R : ℝ) (θ : ℝ) :
     HasDerivAt (circleMap c R) (circleMap 0 R θ * I) θ := by
-  simpa only [mul_assoc, one_mul, ofRealClm_apply, circleMap, ofReal_one, zero_add]
-    using (((ofRealClm.hasDerivAt (x := θ)).mul_const I).cexp.const_mul (R : ℂ)).const_add c
+  simpa only [mul_assoc, one_mul, ofRealCLM_apply, circleMap, ofReal_one, zero_add]
+    using (((ofRealCLM.hasDerivAt (x := θ)).mul_const I).cexp.const_mul (R : ℂ)).const_add c
 #align has_deriv_at_circle_map hasDerivAt_circleMap
 
 /- TODO: prove `ContDiff ℝ (circleMap c R)`. This needs a version of `ContDiff.mul`

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -1190,7 +1190,7 @@ end ContinuousLinearEquiv
 
 @[norm_cast]
 theorem integral_ofReal {f : α → ℝ} : (∫ a, (f a : 𝕜) ∂μ) = ↑(∫ a, f a ∂μ) :=
-  (@IsROrC.ofRealLi 𝕜 _).integral_comp_comm f
+  (@IsROrC.ofRealLI 𝕜 _).integral_comp_comm f
 #align integral_of_real integral_ofReal
 
 theorem integral_re {f : α → 𝕜} (hf : Integrable f μ) :
@@ -1204,7 +1204,7 @@ theorem integral_im {f : α → 𝕜} (hf : Integrable f μ) :
 #align integral_im integral_im
 
 theorem integral_conj {f : α → 𝕜} : (∫ a, conj (f a) ∂μ) = conj (∫ a, f a ∂μ) :=
-  (@IsROrC.conjLie 𝕜 _).toLinearIsometry.integral_comp_comm f
+  (@IsROrC.conjLIE 𝕜 _).toLinearIsometry.integral_comp_comm f
 #align integral_conj integral_conj
 
 theorem integral_coe_re_add_coe_im {f : α → 𝕜} (hf : Integrable f μ) :

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -1195,12 +1195,12 @@ theorem integral_ofReal {f : α → ℝ} : (∫ a, (f a : 𝕜) ∂μ) = ↑(∫
 
 theorem integral_re {f : α → 𝕜} (hf : Integrable f μ) :
     (∫ a, IsROrC.re (f a) ∂μ) = IsROrC.re (∫ a, f a ∂μ) :=
-  (@IsROrC.reClm 𝕜 _).integral_comp_comm hf
+  (@IsROrC.reCLM 𝕜 _).integral_comp_comm hf
 #align integral_re integral_re
 
 theorem integral_im {f : α → 𝕜} (hf : Integrable f μ) :
     (∫ a, IsROrC.im (f a) ∂μ) = IsROrC.im (∫ a, f a ∂μ) :=
-  (@IsROrC.imClm 𝕜 _).integral_comp_comm hf
+  (@IsROrC.imCLM 𝕜 _).integral_comp_comm hf
 #align integral_im integral_im
 
 theorem integral_conj {f : α → 𝕜} : (∫ a, conj (f a) ∂μ) = conj (∫ a, f a ∂μ) :=

--- a/Mathlib/MeasureTheory/Measure/Complex.lean
+++ b/Mathlib/MeasureTheory/Measure/Complex.lean
@@ -49,13 +49,13 @@ namespace ComplexMeasure
 /-- The real part of a complex measure is a signed measure. -/
 @[simps! apply]
 def re : ComplexMeasure α →ₗ[ℝ] SignedMeasure α :=
-  mapRangeₗ Complex.reClm Complex.continuous_re
+  mapRangeₗ Complex.reCLM Complex.continuous_re
 #align measure_theory.complex_measure.re MeasureTheory.ComplexMeasure.re
 
 /-- The imaginary part of a complex measure is a signed measure. -/
 @[simps! apply]
 def im : ComplexMeasure α →ₗ[ℝ] SignedMeasure α :=
-  mapRangeₗ Complex.imClm Complex.continuous_im
+  mapRangeₗ Complex.imCLM Complex.continuous_im
 #align measure_theory.complex_measure.im MeasureTheory.ComplexMeasure.im
 
 /-- Given `s` and `t` signed measures, `s + it` is a complex measure-/

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -30,7 +30,7 @@ The main definitions are
    topology of weak convergence.
  * `MeasureTheory.FiniteMeasure.map`: The push-forward `f* μ` of a finite measure `μ` on `Ω`
    along a measurable function `f : Ω → Ω'`.
- * `MeasureTheory.FiniteMeasure.mapClm`: The push-forward along a given continuous `f : Ω → Ω'`
+ * `MeasureTheory.FiniteMeasure.mapCLM`: The push-forward along a given continuous `f : Ω → Ω'`
    as a continuous linear map `f* : FiniteMeasure Ω →L[ℝ≥0] FiniteMeasure Ω'`.
 
 ## Main results
@@ -809,7 +809,7 @@ lemma continuous_map {f : Ω → Ω'} (f_cont : Continuous f) :
 
 /-- The push-forward of a finite measure by a continuous function between Borel spaces as
 a continuous linear map. -/
-noncomputable def mapClm {f : Ω → Ω'} (f_cont : Continuous f) :
+noncomputable def mapCLM {f : Ω → Ω'} (f_cont : Continuous f) :
     FiniteMeasure Ω →L[ℝ≥0] FiniteMeasure Ω' where
   toFun := fun ν ↦ ν.map f
   map_add' := map_add f_cont.measurable

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Complex.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Complex.lean
@@ -40,7 +40,7 @@ theorem measurableEquivPi_symm_apply (p : (Fin 2) → ℝ) :
 
 /-- Measurable equivalence between `ℂ` and `ℝ × ℝ`. -/
 def measurableEquivRealProd : ℂ ≃ᵐ ℝ × ℝ :=
-  equivRealProdClm.toHomeomorph.toMeasurableEquiv
+  equivRealProdCLM.toHomeomorph.toMeasurableEquiv
 #align complex.measurable_equiv_real_prod Complex.measurableEquivRealProd
 
 @[simp]

--- a/Mathlib/Topology/Algebra/Algebra.lean
+++ b/Mathlib/Topology/Algebra/Algebra.lean
@@ -61,19 +61,19 @@ variable [ContinuousSMul R A]
 
 /-- The inclusion of the base ring in a topological algebra as a continuous linear map. -/
 @[simps]
-def algebraMapClm : R →L[R] A :=
+def algebraMapCLM : R →L[R] A :=
   { Algebra.linearMap R A with
     toFun := algebraMap R A
     cont := continuous_algebraMap R A }
-#align algebra_map_clm algebraMapClm
+#align algebra_map_clm algebraMapCLM
 
-theorem algebraMapClm_coe : ⇑(algebraMapClm R A) = algebraMap R A :=
+theorem algebraMapCLM_coe : ⇑(algebraMapCLM R A) = algebraMap R A :=
   rfl
-#align algebra_map_clm_coe algebraMapClm_coe
+#align algebra_map_clm_coe algebraMapCLM_coe
 
-theorem algebraMapClm_toLinearMap : (algebraMapClm R A).toLinearMap = Algebra.linearMap R A :=
+theorem algebraMapCLM_toLinearMap : (algebraMapCLM R A).toLinearMap = Algebra.linearMap R A :=
   rfl
-#align algebra_map_clm_to_linear_map algebraMapClm_toLinearMap
+#align algebra_map_clm_to_linear_map algebraMapCLM_toLinearMap
 
 end TopologicalAlgebra
 

--- a/Mathlib/Topology/Algebra/Module/CharacterSpace.lean
+++ b/Mathlib/Topology/Algebra/Module/CharacterSpace.lean
@@ -23,7 +23,7 @@ C⋆-algebras.
 
 We define `WeakDual.characterSpace 𝕜 A` as a subset of the weak dual, which automatically puts the
 correct topology on the space. We then define `WeakDual.CharacterSpace.toAlgHom` which provides the
-algebra homomorphism corresponding to any element. We also provide `WeakDual.CharacterSpace.toClm`
+algebra homomorphism corresponding to any element. We also provide `WeakDual.CharacterSpace.toCLM`
 which provides the element as a continuous linear map. (Even though `WeakDual 𝕜 A` is a type copy of
 `A →L[𝕜] 𝕜`, this is often more convenient.)
 
@@ -75,14 +75,14 @@ theorem ext {φ ψ : characterSpace 𝕜 A} (h : ∀ x, φ x = ψ x) : φ = ψ :
 #align weak_dual.character_space.ext WeakDual.CharacterSpace.ext
 
 /-- An element of the character space, as a continuous linear map. -/
-def toClm (φ : characterSpace 𝕜 A) : A →L[𝕜] 𝕜 :=
+def toCLM (φ : characterSpace 𝕜 A) : A →L[𝕜] 𝕜 :=
   (φ : WeakDual 𝕜 A)
-#align weak_dual.character_space.to_clm WeakDual.CharacterSpace.toClm
+#align weak_dual.character_space.to_clm WeakDual.CharacterSpace.toCLM
 
 @[simp]
-theorem coe_toClm (φ : characterSpace 𝕜 A) : ⇑(toClm φ) = φ :=
+theorem coe_toCLM (φ : characterSpace 𝕜 A) : ⇑(toCLM φ) = φ :=
   rfl
-#align weak_dual.character_space.coe_to_clm WeakDual.CharacterSpace.coe_toClm
+#align weak_dual.character_space.coe_to_clm WeakDual.CharacterSpace.coe_toCLM
 
 /-- Elements of the character space are non-unital algebra homomorphisms. -/
 instance instNonUnitalAlgHomClass : NonUnitalAlgHomClass (characterSpace 𝕜 A) 𝕜 A 𝕜 :=

--- a/Mathlib/Topology/ContinuousFunction/Bounded.lean
+++ b/Mathlib/Topology/ContinuousFunction/Bounded.lean
@@ -1137,15 +1137,15 @@ instance module : Module 𝕜 (α →ᵇ β) :=
 variable (𝕜)
 
 /-- The evaluation at a point, as a continuous linear map from `α →ᵇ β` to `β`. -/
-def evalClm (x : α) : (α →ᵇ β) →L[𝕜] β where
+def evalCLM (x : α) : (α →ᵇ β) →L[𝕜] β where
   toFun f := f x
   map_add' f g := add_apply _ _
   map_smul' c f := smul_apply _ _ _
-#align bounded_continuous_function.eval_clm BoundedContinuousFunction.evalClm
+#align bounded_continuous_function.eval_clm BoundedContinuousFunction.evalCLM
 
 @[simp]
-theorem evalClm_apply (x : α) (f : α →ᵇ β) : evalClm 𝕜 x f = f x := rfl
-#align bounded_continuous_function.eval_clm_apply BoundedContinuousFunction.evalClm_apply
+theorem evalCLM_apply (x : α) (f : α →ᵇ β) : evalCLM 𝕜 x f = f x := rfl
+#align bounded_continuous_function.eval_clm_apply BoundedContinuousFunction.evalCLM_apply
 
 variable (α β)
 

--- a/Mathlib/Topology/ContinuousFunction/Compact.lean
+++ b/Mathlib/Topology/ContinuousFunction/Compact.lean
@@ -282,12 +282,12 @@ def linearIsometryBoundedOfCompact : C(α, E) ≃ₗᵢ[𝕜] α →ᵇ E :=
 
 variable {α E}
 
--- to match `BoundedContinuousFunction.evalClm`
+-- to match `BoundedContinuousFunction.evalCLM`
 /-- The evaluation at a point, as a continuous linear map from `C(α, 𝕜)` to `𝕜`. -/
-def evalClm (x : α) : C(α, E) →L[𝕜] E :=
-  (BoundedContinuousFunction.evalClm 𝕜 x).comp
+def evalCLM (x : α) : C(α, E) →L[𝕜] E :=
+  (BoundedContinuousFunction.evalCLM 𝕜 x).comp
     (linearIsometryBoundedOfCompact α E 𝕜).toLinearIsometry.toContinuousLinearMap
-#align continuous_map.eval_clm ContinuousMap.evalClm
+#align continuous_map.eval_clm ContinuousMap.evalCLM
 
 end
 

--- a/Mathlib/Topology/ContinuousFunction/Ideals.lean
+++ b/Mathlib/Topology/ContinuousFunction/Ideals.lean
@@ -221,31 +221,31 @@ theorem idealOfSet_ofIdeal_eq_closure (I : Ideal C(X, 𝕜)) :
     Indeed, then `‖f - f * ↑g‖ ≤ ‖f * (1 - ↑g)‖ ≤ ⨆ ‖f * (1 - ↑g) x‖`. When `x ∉ t`, `‖f x‖ < ε / 2`
     and `‖(1 - ↑g) x‖ ≤ 1`, and when `x ∈ t`, `(1 - ↑g) x = 0`, and clearly `f * ↑g ∈ I`. -/
   suffices
-    ∃ g : C(X, ℝ≥0), (algebraMapClm ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g ∈ I ∧ (∀ x, g x ≤ 1) ∧ t.EqOn g 1 by
+    ∃ g : C(X, ℝ≥0), (algebraMapCLM ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g ∈ I ∧ (∀ x, g x ≤ 1) ∧ t.EqOn g 1 by
     obtain ⟨g, hgI, hg, hgt⟩ := this
-    refine' ⟨f * (algebraMapClm ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g, I.mul_mem_left f hgI, _⟩
+    refine' ⟨f * (algebraMapCLM ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g, I.mul_mem_left f hgI, _⟩
     rw [nndist_eq_nnnorm]
     refine' (nnnorm_lt_iff _ hε).2 fun x => _
     simp only [coe_sub, coe_mul, Pi.sub_apply, Pi.mul_apply]
     by_cases hx : x ∈ t
-    · simpa only [hgt hx, comp_apply, Pi.one_apply, ContinuousMap.coe_coe, algebraMapClm_apply,
+    · simpa only [hgt hx, comp_apply, Pi.one_apply, ContinuousMap.coe_coe, algebraMapCLM_apply,
         map_one, mul_one, sub_self, nnnorm_zero] using hε
     · refine' lt_of_le_of_lt _ (half_lt_self hε)
       have :=
         calc
-          ‖((1 - (algebraMapClm ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g) x : 𝕜)‖₊ =
+          ‖((1 - (algebraMapCLM ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g) x : 𝕜)‖₊ =
               ‖1 - algebraMap ℝ≥0 𝕜 (g x)‖₊ := by
             simp only [coe_sub, coe_one, coe_comp, ContinuousMap.coe_coe, Pi.sub_apply,
-              Pi.one_apply, Function.comp_apply, algebraMapClm_apply]
+              Pi.one_apply, Function.comp_apply, algebraMapCLM_apply]
           _ = ‖algebraMap ℝ≥0 𝕜 (1 - g x)‖₊ := by
             simp only [Algebra.algebraMap_eq_smul_one, NNReal.smul_def, ge_iff_le,
               NNReal.coe_sub (hg x), NNReal.coe_one, sub_smul, one_smul]
           _ ≤ 1 := (nnnorm_algebraMap_nNReal 𝕜 (1 - g x)).trans_le tsub_le_self
       calc
-        ‖f x - f x * (algebraMapClm ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g x‖₊ =
-            ‖f x * (1 - (algebraMapClm ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g) x‖₊ := by
+        ‖f x - f x * (algebraMapCLM ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g x‖₊ =
+            ‖f x * (1 - (algebraMapCLM ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g) x‖₊ := by
           simp only [mul_sub, coe_sub, coe_one, Pi.sub_apply, Pi.one_apply, mul_one]
-        _ ≤ ε / 2 * ‖(1 - (algebraMapClm ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g) x‖₊ :=
+        _ ≤ ε / 2 * ‖(1 - (algebraMapCLM ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g) x‖₊ :=
           ((nnnorm_mul_le _ _).trans
             (mul_le_mul_right' (not_le.mp <| show ¬ε / 2 ≤ ‖f x‖₊ from hx).le _))
         _ ≤ ε / 2 := by simpa only [mul_one] using mul_le_mul_left' this _
@@ -255,7 +255,7 @@ theorem idealOfSet_ofIdeal_eq_closure (I : Ideal C(X, 𝕜)) :
     `fₓ x ≠ 0` for some `fₓ ∈ I` and so `fun y ↦ ‖(star fₓ * fₓ) y‖₊` is strictly posiive in a
     neighborhood of `y`. Moreover, `(‖(star fₓ * fₓ) y‖₊ : 𝕜) = (star fₓ * fₓ) y`, so composition of
     this map with the natural embedding is just `star fₓ * fₓ ∈ I`. -/
-  have : ∃ g' : C(X, ℝ≥0), (algebraMapClm ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g' ∈ I ∧ ∀ x ∈ t, 0 < g' x := by
+  have : ∃ g' : C(X, ℝ≥0), (algebraMapCLM ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g' ∈ I ∧ ∀ x ∈ t, 0 < g' x := by
     refine' ht.isCompact.induction_on _ _ _ _
     · refine' ⟨0, _, fun x hx => False.elim hx⟩
       convert I.zero_mem
@@ -283,7 +283,7 @@ theorem idealOfSet_ofIdeal_eq_closure (I : Ideal C(X, 𝕜)) :
             pow_pos (norm_pos_iff.mpr hx.1) 2⟩⟩
       convert I.mul_mem_left (star g) hI
       ext
-      simp only [comp_apply, ContinuousMap.coe_coe, coe_mk, algebraMapClm_toFun, map_pow,
+      simp only [comp_apply, ContinuousMap.coe_coe, coe_mk, algebraMapCLM_toFun, map_pow,
         mul_apply, star_apply, star_def]
       simp only [normSq_eq_def', IsROrC.conj_mul, ofReal_pow]
       rfl
@@ -298,9 +298,9 @@ theorem idealOfSet_ofIdeal_eq_closure (I : Ideal C(X, 𝕜)) :
       ⟨g' x, hgt' x hx, hx'⟩
   obtain ⟨g, hg, hgc⟩ := exists_mul_le_one_eqOn_ge g' hc
   refine' ⟨g * g', _, hg, hgc.mono hgc'⟩
-  convert I.mul_mem_left ((algebraMapClm ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g) hI'
+  convert I.mul_mem_left ((algebraMapCLM ℝ≥0 𝕜 : C(ℝ≥0, 𝕜)).comp g) hI'
   ext
-  simp only [algebraMapClm_coe, comp_apply, mul_apply, ContinuousMap.coe_coe, map_mul]
+  simp only [algebraMapCLM_coe, comp_apply, mul_apply, ContinuousMap.coe_coe, map_mul]
 #align continuous_map.ideal_of_set_of_ideal_eq_closure ContinuousMap.idealOfSet_ofIdeal_eq_closure
 
 theorem idealOfSet_ofIdeal_isClosed {I : Ideal C(X, 𝕜)} (hI : IsClosed (I : Set C(X, 𝕜))) :

--- a/Mathlib/Topology/ContinuousFunction/StoneWeierstrass.lean
+++ b/Mathlib/Topology/ContinuousFunction/StoneWeierstrass.lean
@@ -385,7 +385,7 @@ theorem ContinuousMap.starSubalgebra_topologicalClosure_eq_top_of_separatesPoint
     (A : StarSubalgebra 𝕜 C(X, 𝕜)) (hA : A.SeparatesPoints) : A.topologicalClosure = ⊤ := by
   rw [StarSubalgebra.eq_top_iff]
   -- Let `I` be the natural inclusion of `C(X, ℝ)` into `C(X, 𝕜)`
-  let I : C(X, ℝ) →ₗ[ℝ] C(X, 𝕜) := ofRealClm.compLeftContinuous ℝ X
+  let I : C(X, ℝ) →ₗ[ℝ] C(X, 𝕜) := ofRealCLM.compLeftContinuous ℝ X
   -- The main point of the proof is that its range (i.e., every real-valued function) is contained
   -- in the closure of `A`
   have key : LinearMap.range I ≤ (A.toSubmodule.restrictScalars ℝ).topologicalClosure := by
@@ -400,14 +400,14 @@ theorem ContinuousMap.starSubalgebra_topologicalClosure_eq_top_of_separatesPoint
     rw [← Submodule.map_top, ← SW]
     -- So it suffices to prove that the image under `I` of the closure of `A₀` is contained in the
     -- closure of `A`, which follows by abstract nonsense
-    have h₁ := A₀.topologicalClosure_map ((@ofRealClm 𝕜 _).compLeftContinuousCompact X)
+    have h₁ := A₀.topologicalClosure_map ((@ofRealCLM 𝕜 _).compLeftContinuousCompact X)
     have h₂ := (A.toSubmodule.restrictScalars ℝ).map_comap_le I
     exact h₁.trans (Submodule.topologicalClosure_mono h₂)
   -- In particular, for a function `f` in `C(X, 𝕜)`, the real and imaginary parts of `f` are in the
   -- closure of `A`
   intro f
-  let f_re : C(X, ℝ) := (⟨IsROrC.re, IsROrC.reClm.continuous⟩ : C(𝕜, ℝ)).comp f
-  let f_im : C(X, ℝ) := (⟨IsROrC.im, IsROrC.imClm.continuous⟩ : C(𝕜, ℝ)).comp f
+  let f_re : C(X, ℝ) := (⟨IsROrC.re, IsROrC.reCLM.continuous⟩ : C(𝕜, ℝ)).comp f
+  let f_im : C(X, ℝ) := (⟨IsROrC.im, IsROrC.imCLM.continuous⟩ : C(𝕜, ℝ)).comp f
   have h_f_re : I f_re ∈ A.topologicalClosure := key ⟨f_re, rfl⟩
   have h_f_im : I f_im ∈ A.topologicalClosure := key ⟨f_im, rfl⟩
   -- So `f_re + I • f_im` is in the closure of `A`

--- a/Mathlib/Topology/Instances/TrivSqZeroExt.lean
+++ b/Mathlib/Topology/Instances/TrivSqZeroExt.lean
@@ -85,29 +85,29 @@ variable (R M)
 
 /-- `TrivSqZeroExt.fst` as a continuous linear map. -/
 @[simps]
-def fstClm [CommSemiring R] [AddCommMonoid M] [Module R M] : tsze R M →L[R] R :=
+def fstCLM [CommSemiring R] [AddCommMonoid M] [Module R M] : tsze R M →L[R] R :=
   { ContinuousLinearMap.fst R R M with toFun := fst }
-#align triv_sq_zero_ext.fst_clm TrivSqZeroExt.fstClm
+#align triv_sq_zero_ext.fst_clm TrivSqZeroExt.fstCLM
 
 /-- `TrivSqZeroExt.snd` as a continuous linear map. -/
 @[simps]
-def sndClm [CommSemiring R] [AddCommMonoid M] [Module R M] : tsze R M →L[R] M :=
+def sndCLM [CommSemiring R] [AddCommMonoid M] [Module R M] : tsze R M →L[R] M :=
   { ContinuousLinearMap.snd R R M with
     toFun := snd
     cont := continuous_snd }
-#align triv_sq_zero_ext.snd_clm TrivSqZeroExt.sndClm
+#align triv_sq_zero_ext.snd_clm TrivSqZeroExt.sndCLM
 
 /-- `TrivSqZeroExt.inl` as a continuous linear map. -/
 @[simps]
-def inlClm [CommSemiring R] [AddCommMonoid M] [Module R M] : R →L[R] tsze R M :=
+def inlCLM [CommSemiring R] [AddCommMonoid M] [Module R M] : R →L[R] tsze R M :=
   { ContinuousLinearMap.inl R R M with toFun := inl }
-#align triv_sq_zero_ext.inl_clm TrivSqZeroExt.inlClm
+#align triv_sq_zero_ext.inl_clm TrivSqZeroExt.inlCLM
 
 /-- `TrivSqZeroExt.inr` as a continuous linear map. -/
 @[simps]
-def inrClm [CommSemiring R] [AddCommMonoid M] [Module R M] : M →L[R] tsze R M :=
+def inrCLM [CommSemiring R] [AddCommMonoid M] [Module R M] : M →L[R] tsze R M :=
   { ContinuousLinearMap.inr R R M with toFun := inr }
-#align triv_sq_zero_ext.inr_clm TrivSqZeroExt.inrClm
+#align triv_sq_zero_ext.inr_clm TrivSqZeroExt.inrCLM
 
 variable {R M}
 


### PR DESCRIPTION
Rename

- `Complex.equivRealProdClm` → `Complex.equivRealProdCLM`;
  - [ ] TODO: should this one use `CLE`?
- `Complex.reClm` → `Complex.reCLM`;
- `Complex.imClm` → `Complex.imCLM`;
- `Complex.conjLie` → `Complex.conjLIE`;
- `Complex.conjCle` → `Complex.conjCLE`;
- `Complex.ofRealLi` → `Complex.ofRealLI`;
- `Complex.ofRealClm` → `Complex.ofRealCLM`;
- `fderivInnerClm` → `fderivInnerCLM`;
- `LinearPMap.adjointDomainMkClm` → `LinearPMap.adjointDomainMkCLM`;
- `LinearPMap.adjointDomainMkClmExtend` → `LinearPMap.adjointDomainMkCLMExtend`;
- `IsROrC.reClm` → `IsROrC.reCLM`;
- `IsROrC.imClm` → `IsROrC.imCLM`;
- `IsROrC.conjLie` → `IsROrC.conjLIE`;
- `IsROrC.conjCle` → `IsROrC.conjCLE`;
- `IsROrC.ofRealLi` → `IsROrC.ofRealLI`;
- `IsROrC.ofRealClm` → `IsROrC.ofRealCLM`;
- `MeasureTheory.condexpL1Clm` → `MeasureTheory.condexpL1CLM`;
- `algebraMapClm` → `algebraMapCLM`;
- `WeakDual.CharacterSpace.toClm` → `WeakDual.CharacterSpace.toCLM`;
- `BoundedContinuousFunction.evalClm` → `BoundedContinuousFunction.evalCLM`;
- `ContinuousMap.evalClm` → `ContinuousMap.evalCLM`;
- `TrivSqZeroExt.fstClm` → `TrivSqZeroExt.fstClm`;
- `TrivSqZeroExt.sndClm` → `TrivSqZeroExt.sndCLM`;
- `TrivSqZeroExt.inlClm` → `TrivSqZeroExt.inlCLM`;
- `TrivSqZeroExt.inrClm` → `TrivSqZeroExt.inrCLM`

and related theorems.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)