### PR TITLE
[Merged by Bors] - feat: Add norm_iteratedFDeriv_prod_le using Sym

### DIFF
--- a/Mathlib/Algebra/BigOperators/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Basic.lean
@@ -2322,14 +2322,20 @@ theorem prod_subtype_mul_prod_subtype {α β : Type*} [Fintype α] [CommMonoid �
 end Fintype
 
 namespace Finset
-variable [Fintype ι] [CommMonoid α]
+variable [CommMonoid α]
 
 @[to_additive (attr := simp)]
-lemma prod_attach_univ (f : {i // i ∈ @univ ι _} → α) :
+lemma prod_attach_univ [Fintype ι] (f : {i // i ∈ @univ ι _} → α) :
     ∏ i in univ.attach, f i = ∏ i, f ⟨i, mem_univ _⟩ :=
   Fintype.prod_equiv (Equiv.subtypeUnivEquiv mem_univ) _ _ $ by simp
 #align finset.prod_attach_univ Finset.prod_attach_univ
 #align finset.sum_attach_univ Finset.sum_attach_univ
+
+@[to_additive]
+theorem prod_erase_attach [DecidableEq ι] {s : Finset ι} (f : ι → α) (i : ↑s) :
+    ∏ j in s.attach.erase i, f ↑j = ∏ j in s.erase ↑i, f j := by
+  rw [← Function.Embedding.coe_subtype, ← prod_map]
+  simp [attach_map_val]
 
 end Finset
 

--- a/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Floris van Doorn
 -/
 import Mathlib.Analysis.Calculus.ContDiff.Basic
+import Mathlib.Data.Finset.Sym
 import Mathlib.Data.Nat.Choose.Cast
+import Mathlib.Data.Nat.Choose.Multinomial
 
 #align_import analysis.calculus.cont_diff from "leanprover-community/mathlib"@"3bce8d800a6f2b8f63fe1e588fd76a9ff4adcebe"
 
@@ -290,7 +292,8 @@ end
 
 section
 
-variable {A : Type*} [NormedRing A] [NormedAlgebra 𝕜 A]
+variable {ι : Type*} {A : Type*} [NormedRing A] [NormedAlgebra 𝕜 A] {A' : Type*} [NormedCommRing A']
+  [NormedAlgebra 𝕜 A']
 
 theorem norm_iteratedFDerivWithin_mul_le {f : E → A} {g : E → A} {N : ℕ∞} (hf : ContDiffOn 𝕜 N f s)
     (hg : ContDiffOn 𝕜 N g s) (hs : UniqueDiffOn 𝕜 s) {x : E} (hx : x ∈ s) {n : ℕ}
@@ -310,6 +313,62 @@ theorem norm_iteratedFDeriv_mul_le {f : E → A} {g : E → A} {N : ℕ∞} (hf 
   exact norm_iteratedFDerivWithin_mul_le
     hf.contDiffOn hg.contDiffOn uniqueDiffOn_univ (mem_univ x) hn
 #align norm_iterated_fderiv_mul_le norm_iteratedFDeriv_mul_le
+
+-- TODO: Add `norm_iteratedFDeriv[Within]_list_prod_le` for non-commutative `NormedRing A`.
+
+theorem norm_iteratedFDerivWithin_prod_le [DecidableEq ι] [NormOneClass A'] {u : Finset ι}
+    {f : ι → E → A'} {N : ℕ∞} (hf : ∀ i ∈ u, ContDiffOn 𝕜 N (f i) s) (hs : UniqueDiffOn 𝕜 s) {x : E}
+    (hx : x ∈ s) {n : ℕ} (hn : (n : ℕ∞) ≤ N) :
+    ‖iteratedFDerivWithin 𝕜 n (∏ j in u, f j ·) s x‖ ≤
+      ∑ p in u.sym n, (p : Multiset ι).multinomial *
+        ∏ j in u, ‖iteratedFDerivWithin 𝕜 (Multiset.count j p) (f j) s x‖ := by
+  induction u using Finset.induction generalizing n with
+  | empty =>
+    cases n with
+    | zero => simp [Sym.eq_nil_of_card_zero]
+    | succ n => simp [iteratedFDerivWithin_succ_const _ _ hs hx]
+  | @insert i u hi IH =>
+    conv => lhs; simp only [Finset.prod_insert hi]
+    simp only [Finset.mem_insert, forall_eq_or_imp] at hf
+    refine le_trans (norm_iteratedFDerivWithin_mul_le hf.1 (contDiffOn_prod hf.2) hs hx hn) ?_
+    rw [← Finset.sum_coe_sort (Finset.sym _ _)]
+    rw [Finset.sum_equiv (Finset.symInsertEquiv hi) (t := Finset.univ)
+      (g := (fun v ↦ v.multinomial *
+          ∏ j in insert i u, ‖iteratedFDerivWithin 𝕜 (v.count j) (f j) s x‖) ∘
+        Sym.toMultiset ∘ Subtype.val ∘ (Finset.symInsertEquiv hi).symm)
+      (by simp) (by simp only [← comp_apply (g := Finset.symInsertEquiv hi), comp.assoc]; simp)]
+    rw [← Finset.univ_sigma_univ, Finset.sum_sigma, Finset.sum_range]
+    simp only [comp_apply, Finset.symInsertEquiv_symm_apply_coe]
+    refine Finset.sum_le_sum ?_
+    intro m _
+    specialize IH hf.2 (n := n - m) (le_trans (WithTop.coe_le_coe.mpr (n.sub_le m)) hn)
+    refine le_trans (mul_le_mul_of_nonneg_left IH (by simp [mul_nonneg])) ?_
+    rw [Finset.mul_sum, ← Finset.sum_coe_sort]
+    refine Finset.sum_le_sum ?_
+    simp only [Finset.mem_univ, forall_true_left, Subtype.forall, Finset.mem_sym_iff]
+    intro p hp
+    refine le_of_eq ?_
+    rw [Finset.prod_insert hi]
+    have hip : i ∉ p := mt (hp i) hi
+    rw [Sym.count_coe_fill_self_of_not_mem hip, Sym.multinomial_coe_fill_of_not_mem hip]
+    suffices ∏ j in u, ‖iteratedFDerivWithin 𝕜 (Multiset.count j p) (f j) s x‖ =
+        ∏ j in u, ‖iteratedFDerivWithin 𝕜 (Multiset.count j (Sym.fill i m p)) (f j) s x‖ by
+      rw [this, Nat.cast_mul]
+      ring
+    refine Finset.prod_congr rfl ?_
+    intro j hj
+    have hji : j ≠ i := fun h ↦ hi <| by simpa [h] using hj
+    rw [Sym.count_coe_fill_of_ne hji]
+
+theorem norm_iteratedFDeriv_prod_le [DecidableEq ι] [NormOneClass A'] {u : Finset ι}
+    {f : ι → E → A'} {N : ℕ∞} (hf : ∀ i ∈ u, ContDiff 𝕜 N (f i)) {x : E} {n : ℕ}
+    (hn : (n : ℕ∞) ≤ N) :
+    ‖iteratedFDeriv 𝕜 n (∏ j in u, f j ·) x‖ ≤
+      ∑ p in u.sym n, (p : Multiset ι).multinomial *
+        ∏ j in u, ‖iteratedFDeriv 𝕜 ((p : Multiset ι).count j) (f j) x‖ := by
+  simpa [iteratedFDerivWithin_univ] using
+    norm_iteratedFDerivWithin_prod_le (fun i hi ↦ (hf i hi).contDiffOn) uniqueDiffOn_univ
+      (mem_univ x) hn
 
 end
 

--- a/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
@@ -357,7 +357,7 @@ theorem norm_iteratedFDerivWithin_prod_le [DecidableEq ι] [NormOneClass A'] {u 
       ring
     refine Finset.prod_congr rfl ?_
     intro j hj
-    have hji : j ≠ i := fun h ↦ hi <| by simpa [h] using hj
+    have hji : j ≠ i := mt (· ▸ hj) hi
     rw [Sym.count_coe_fill_of_ne hji]
 
 theorem norm_iteratedFDeriv_prod_le [DecidableEq ι] [NormOneClass A'] {u : Finset ι}

--- a/Mathlib/Analysis/Calculus/Deriv/Mul.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Mul.lean
@@ -283,6 +283,38 @@ theorem deriv_const_mul_field' (u : 𝕜') : (deriv fun x => u * v x) = fun x =>
 
 end Mul
 
+section Prod
+
+variable {ι : Type*} [DecidableEq ι] {𝔸' : Type*} [NormedCommRing 𝔸'] [NormedAlgebra 𝕜 𝔸']
+  {u : Finset ι} {f : ι → 𝕜 → 𝔸'} {f' : ι → 𝔸'}
+
+theorem HasDerivAt.finset_prod (hf : ∀ i ∈ u, HasDerivAt (f i) (f' i) x) :
+    HasDerivAt (∏ i in u, f i ·) (∑ i in u, (∏ j in u.erase i, f j x) • f' i) x := by
+  simpa [ContinuousLinearMap.sum_apply, ContinuousLinearMap.smul_apply] using
+    (HasFDerivAt.finset_prod (fun i hi ↦ (hf i hi).hasFDerivAt)).hasDerivAt
+
+theorem HasDerivWithinAt.finset_prod (hf : ∀ i ∈ u, HasDerivWithinAt (f i) (f' i) s x) :
+    HasDerivWithinAt (∏ i in u, f i ·) (∑ i in u, (∏ j in u.erase i, f j x) • f' i) s x := by
+  simpa [ContinuousLinearMap.sum_apply, ContinuousLinearMap.smul_apply] using
+    (HasFDerivWithinAt.finset_prod (fun i hi ↦ (hf i hi).hasFDerivWithinAt)).hasDerivWithinAt
+
+theorem HasStrictDerivAt.finset_prod (hf : ∀ i ∈ u, HasStrictDerivAt (f i) (f' i) x) :
+    HasStrictDerivAt (∏ i in u, f i ·) (∑ i in u, (∏ j in u.erase i, f j x) • f' i) x := by
+  simpa [ContinuousLinearMap.sum_apply, ContinuousLinearMap.smul_apply] using
+    (HasStrictFDerivAt.finset_prod (fun i hi ↦ (hf i hi).hasStrictFDerivAt)).hasStrictDerivAt
+
+theorem deriv_finset_prod (hf : ∀ i ∈ u, DifferentiableAt 𝕜 (f i) x) :
+    deriv (∏ i in u, f i ·) x = ∑ i in u, (∏ j in u.erase i, f j x) • deriv (f i) x :=
+  (HasDerivAt.finset_prod fun i hi ↦ (hf i hi).hasDerivAt).deriv
+
+theorem derivWithin_finset_prod (hxs : UniqueDiffWithinAt 𝕜 s x)
+    (hf : ∀ i ∈ u, DifferentiableWithinAt 𝕜 (f i) s x) :
+    derivWithin (∏ i in u, f i ·) s x =
+      ∑ i in u, (∏ j in u.erase i, f j x) • derivWithin (f i) s x :=
+  (HasDerivWithinAt.finset_prod fun i hi ↦ (hf i hi).hasDerivWithinAt).derivWithin hxs
+
+end Prod
+
 section Div
 
 variable {𝕜' : Type*} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] {c d : 𝕜 → 𝕜'} {c' d' : 𝕜'}

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -3672,6 +3672,27 @@ theorem map_foldl_erase [DecidableEq β] {f : α → β} (finj : Injective f) {l
   induction l₂ generalizing l₁ <;> [rfl; simp only [foldl_cons, map_erase finj, *]]
 #align list.map_foldl_erase List.map_foldl_erase
 
+theorem erase_get [DecidableEq ι] {l : List ι} (i : Fin l.length) :
+    Perm (l.erase (l.get i)) (l.eraseIdx ↑i) := by
+  induction l with
+  | nil => simp
+  | cons a l IH =>
+    cases i using Fin.cases with
+    | zero => simp
+    | succ i =>
+      by_cases ha : a = l.get i
+      · simpa [ha] using .trans (perm_cons_erase (l.get_mem i i.isLt)) (.cons _ (IH i))
+      · simpa [ha] using IH i
+
+theorem eraseIdx_eq_take_drop_succ {l : List ι} {i : ℕ} :
+    l.eraseIdx i = l.take i ++ l.drop i.succ := by
+  induction l generalizing i with
+  | nil => simp
+  | cons a l IH =>
+    cases i with
+    | zero => simp
+    | succ i => simp [IH]
+
 end Erase
 
 /-! ### diff -/

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -318,6 +318,20 @@ theorem Nodup.erase [DecidableEq α] (a : α) : Nodup l → Nodup (l.erase a) :=
   Nodup.sublist <| erase_sublist _ _
 #align list.nodup.erase List.Nodup.erase
 
+theorem Nodup.erase_get [DecidableEq α] {l : List α} (hl : l.Nodup) :
+    ∀ i : Fin l.length, l.erase (l.get i) = l.eraseIdx ↑i := by
+  induction l with
+  | nil => simp
+  | cons a l IH =>
+    intro i
+    cases i using Fin.cases with
+    | zero => simp
+    | succ i =>
+      rw [nodup_cons] at hl
+      rw [erase_cons_tail]
+      · simp [IH hl.2]
+      · exact fun h ↦ hl.1 <| by simpa [h] using l.get_mem i i.isLt
+
 theorem Nodup.diff [DecidableEq α] : l₁.Nodup → (l₁.diff l₂).Nodup :=
   Nodup.sublist <| diff_sublist _ _
 #align list.nodup.diff List.Nodup.diff

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -330,7 +330,8 @@ theorem Nodup.erase_get [DecidableEq α] {l : List α} (hl : l.Nodup) :
       rw [nodup_cons] at hl
       rw [erase_cons_tail]
       · simp [IH hl.2]
-      · exact fun h ↦ hl.1 <| by simpa [h] using l.get_mem i i.isLt
+      · rw [beq_iff_eq, get_cons_succ']
+        exact mt (· ▸ l.get_mem i i.isLt) hl.1
 
 theorem Nodup.diff [DecidableEq α] : l₁.Nodup → (l₁.diff l₂).Nodup :=
   Nodup.sublist <| diff_sublist _ _

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -2686,6 +2686,15 @@ theorem inter_replicate (s : Multiset α) (n : ℕ) (x : α) :
   rw [inter_comm, replicate_inter, min_comm]
 #align multiset.inter_replicate Multiset.inter_replicate
 
+theorem erase_attach_map_val [DecidableEq α] (s : Multiset α) (x : {x // x ∈ s}) :
+    (s.attach.erase x).map (↑) = s.erase x := by
+  rw [Multiset.map_erase _ val_injective, attach_map_val]
+
+theorem erase_attach_map [DecidableEq α] (s : Multiset α) (f : α → β) (x : {x // x ∈ s}) :
+    (s.attach.erase x).map (fun j : {x // x ∈ s} ↦ f j) = (s.erase x).map f := by
+  simp only [← Function.comp_apply (f := f)]
+  rw [← map_map, erase_attach_map_val]
+
 end
 
 @[ext]

--- a/Mathlib/Data/Nat/Choose/Multinomial.lean
+++ b/Mathlib/Data/Nat/Choose/Multinomial.lean
@@ -214,6 +214,9 @@ theorem multinomial_filter_ne [DecidableEq α] (a : α) (m : Multiset α) :
     · rw [not_ne_iff.1 h, Function.update_same]
 #align multiset.multinomial_filter_ne Multiset.multinomial_filter_ne
 
+@[simp]
+theorem multinomial_zero [DecidableEq α] : multinomial (0 : Multiset α) = 1 := rfl
+
 end Multiset
 
 namespace Finset
@@ -274,3 +277,23 @@ theorem sum_pow [CommSemiring R] (x : α → R) (n : ℕ) :
 #align finset.sum_pow Finset.sum_pow
 
 end Finset
+
+namespace Sym
+
+variable {n : ℕ} {α : Type*} [DecidableEq α]
+
+theorem multinomial_coe_fill_of_not_mem {m : Fin (n + 1)} {s : Sym α (n - m)} {x : α} (hx : x ∉ s) :
+    (fill x m s : Multiset α).multinomial = n.choose m * (s : Multiset α).multinomial := by
+  rw [Multiset.multinomial_filter_ne x]
+  rw [← mem_coe] at hx
+  refine congrArg₂ _ ?_ ?_
+  · rw [card_coe, count_coe_fill_self_of_not_mem hx]
+  · refine congrArg _ ?_
+    rw [coe_fill, coe_replicate, Multiset.filter_add]
+    rw [Multiset.filter_eq_self.mpr]
+    · rw [add_right_eq_self]
+      rw [Multiset.filter_eq_nil]
+      exact fun j hj ↦ by simp [Multiset.mem_replicate.mp hj]
+    · exact fun j hj h ↦ hx <| by simpa [h] using hj
+
+end Sym

--- a/Mathlib/Data/Sym/Basic.lean
+++ b/Mathlib/Data/Sym/Basic.lean
@@ -156,6 +156,9 @@ theorem ofVector_cons (a : α) (v : Vector α n) : ↑(Vector.cons a v) = a ::�
   rfl
 #align sym.of_vector_cons Sym.ofVector_cons
 
+@[simp]
+theorem card_coe : Multiset.card (s : Multiset α) = n := s.prop
+
 /-- `α ∈ s` means that `a` appears as one of the factors in `s`.
 -/
 instance : Membership α (Sym α n) :=
@@ -365,7 +368,7 @@ instance (n : ℕ) [Nontrivial α] : Nontrivial (Sym α (n + 1)) :=
 /-- A function `α → β` induces a function `Sym α n → Sym β n` by applying it to every element of
 the underlying `n`-tuple. -/
 def map {n : ℕ} (f : α → β) (x : Sym α n) : Sym β n :=
-  ⟨x.val.map f, by simpa [Multiset.card_map] using x.property⟩
+  ⟨x.val.map f, by simp⟩
 #align sym.map Sym.map
 
 @[simp]
@@ -597,6 +600,17 @@ theorem filter_ne_fill [DecidableEq α] (a : α) (m : Σi : Fin (n + 1), Sym α 
         exact hb.2 hb.1.2.symm
       · exact fun a ha ha' => h <| ha'.symm ▸ ha)
 #align sym.filter_ne_fill Sym.filter_ne_fill
+
+theorem count_coe_fill_self_of_not_mem [DecidableEq α] {a : α} {i : Fin (n + 1)} {s : Sym α (n - i)}
+    (hx : a ∉ s) :
+    count a (fill a i s : Multiset α) = i := by
+  simp [coe_fill, coe_replicate, hx]
+
+theorem count_coe_fill_of_ne [DecidableEq α] {a x : α} {i : Fin (n + 1)} {s : Sym α (n - i)}
+    (hx : x ≠ a) :
+    count x (fill a i s : Multiset α) = count x s := by
+  suffices x ∉ Multiset.replicate i a by simp [coe_fill, coe_replicate, this]
+  simp [Multiset.mem_replicate, hx]
 
 end Sym
 


### PR DESCRIPTION
add (iterated) deriv for prod

* Add `HasFDerivAt` + variants for `Finset.prod` (and `ContinuousMultilinearMap.mkPiAlgebra`)
* Add missing `iteratedFDerivWithin` equivalents for zero, const (resolves a todo in `Analysis.Calculus.ContDiff.Basic`)
* Add `iteratedFDeriv[Within]_sum` for symmetry
* Add a couple of convenience lemmas for `Sym` and `Finset.{prod,sum}`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)