### PR TITLE
[Merged by Bors] - feat(Data/ZMod/{Basic|Units}): some lemmas on units in ZMod

### DIFF
--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -36,8 +36,7 @@ open Function
 
 namespace ZMod
 
-instance charZero : CharZero (ZMod 0) :=
-  (by infer_instance : CharZero ℤ)
+instance charZero : CharZero (ZMod 0) := inferInstanceAs (CharZero ℤ)
 
 /-- `val a` is a natural number defined as:
   - for `a : ZMod 0` it is the absolute value of `a`
@@ -80,6 +79,11 @@ theorem val_neg' {n : ZMod 0} : (-n).val = n.val :=
 theorem val_mul' {m n : ZMod 0} : (m * n).val = m.val * n.val :=
   Int.natAbs_mul m n
 #align zmod.val_mul' ZMod.val_mul'
+
+lemma eq_one_of_isUnit_natCast {n : ℕ} (h : IsUnit (n : ZMod 0)) : n = 1 := by
+  have := Int.isUnit_iff.mp h
+  norm_cast at this
+  exact this.resolve_right not_false
 
 @[simp]
 theorem val_nat_cast {n : ℕ} (a : ℕ) : (a : ZMod n).val = a % n := by
@@ -747,6 +751,17 @@ theorem val_coe_unit_coprime {n : ℕ} (u : (ZMod n)ˣ) : Nat.Coprime (u : ZMod 
   rw [← nat_cast_zmod_val ((u * u⁻¹ : Units (ZMod (n + 1))) : ZMod (n + 1))]
   rw [Units.val_mul, val_mul, nat_cast_mod]
 #align zmod.val_coe_unit_coprime ZMod.val_coe_unit_coprime
+
+lemma isUnit_iff_coprime (m n : ℕ) : IsUnit (m : ZMod n) ↔ m.Coprime n := by
+  refine ⟨fun H ↦ ?_, fun H ↦ (unitOfCoprime m H).isUnit⟩
+  have H' := val_coe_unit_coprime H.unit
+  rw [IsUnit.unit_spec, val_nat_cast m, Nat.coprime_iff_gcd_eq_one] at H'
+  rw [Nat.coprime_iff_gcd_eq_one, Nat.gcd_comm, ← H']
+  exact Nat.gcd_rec n m
+
+lemma isUnit_prime_of_not_dvd {n p : ℕ} (hp : p.Prime) (h : ¬ p ∣ n) : IsUnit (p : ZMod n) := by
+  rw [isUnit_iff_coprime]
+  exact (Nat.Prime.coprime_iff_not_dvd hp).mpr h
 
 @[simp]
 theorem inv_coe_unit {n : ℕ} (u : (ZMod n)ˣ) : (u : ZMod n)⁻¹ = (u⁻¹ : (ZMod n)ˣ) := by

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -80,11 +80,6 @@ theorem val_mul' {m n : ZMod 0} : (m * n).val = m.val * n.val :=
   Int.natAbs_mul m n
 #align zmod.val_mul' ZMod.val_mul'
 
-lemma eq_one_of_isUnit_natCast {n : ℕ} (h : IsUnit (n : ZMod 0)) : n = 1 := by
-  have := Int.isUnit_iff.mp h
-  norm_cast at this
-  exact this.resolve_right not_false
-
 @[simp]
 theorem val_nat_cast {n : ℕ} (a : ℕ) : (a : ZMod n).val = a % n := by
   cases n
@@ -92,6 +87,13 @@ theorem val_nat_cast {n : ℕ} (a : ℕ) : (a : ZMod n).val = a % n := by
     exact Int.natAbs_ofNat a
   · apply Fin.val_nat_cast
 #align zmod.val_nat_cast ZMod.val_nat_cast
+
+theorem val_unit' {n : ZMod 0} : IsUnit n ↔ n.val = 1 := by
+  simp only [val]
+  rw [Int.isUnit_iff, Int.natAbs_eq_iff, Nat.cast_one]
+
+lemma eq_one_of_isUnit_natCast {n : ℕ} (h : IsUnit (n : ZMod 0)) : n = 1 := by
+  rw [← Nat.mod_zero n, ← val_nat_cast, val_unit'.mp h]
 
 theorem val_nat_cast_of_lt {n a : ℕ} (h : a < n) : (a : ZMod n).val = a := by
   rwa [val_nat_cast, Nat.mod_eq_of_lt]
@@ -759,9 +761,11 @@ lemma isUnit_iff_coprime (m n : ℕ) : IsUnit (m : ZMod n) ↔ m.Coprime n := by
   rw [Nat.coprime_iff_gcd_eq_one, Nat.gcd_comm, ← H']
   exact Nat.gcd_rec n m
 
-lemma isUnit_prime_of_not_dvd {n p : ℕ} (hp : p.Prime) (h : ¬ p ∣ n) : IsUnit (p : ZMod n) := by
-  rw [isUnit_iff_coprime]
-  exact (Nat.Prime.coprime_iff_not_dvd hp).mpr h
+lemma isUnit_prime_iff_not_dvd {n p : ℕ} (hp : p.Prime) : IsUnit (p : ZMod n) ↔ ¬p ∣ n := by
+  rw [isUnit_iff_coprime, Nat.Prime.coprime_iff_not_dvd hp]
+
+lemma isUnit_prime_of_not_dvd {n p : ℕ} (hp : p.Prime) (h : ¬ p ∣ n) : IsUnit (p : ZMod n) :=
+  (isUnit_prime_iff_not_dvd hp).mpr h
 
 @[simp]
 theorem inv_coe_unit {n : ℕ} (u : (ZMod n)ˣ) : (u : ZMod n)⁻¹ = (u⁻¹ : (ZMod n)ˣ) := by

--- a/Mathlib/Data/ZMod/Units.lean
+++ b/Mathlib/Data/ZMod/Units.lean
@@ -62,4 +62,11 @@ theorem unitsMap_surjective [hm : NeZero m] (h : n ∣ m) :
     rw [Nat.add_sub_cancel] at h
     contradiction
 
+-- This needs `Nat.primeFactors`, so cannot go into `Mathlib.Data.ZMod.Basic`.
+open Nat in
+lemma not_isUnit_of_mem_primeFactors {n p : ℕ} (h : p ∈ n.primeFactors) :
+    ¬ IsUnit (p : ZMod n) := by
+  rw [isUnit_iff_coprime]
+  exact (Prime.dvd_iff_not_coprime <| prime_of_mem_primeFactors h).mp <| dvd_of_mem_primeFactors h
+
 end ZMod


### PR DESCRIPTION
This is the second PR in a sequence that adds auxiliary lemmas from the [EulerProducts](https://github.com/MichaelStollBayreuth/EulerProducts) project to Mathlib.

It adds four lemmas on units in `ZMod n`:
```lean
lemma ZMod.eq_one_of_isUnit_natCast {n : ℕ} (h : IsUnit (n : ZMod 0)) : n = 1

lemma ZMod.isUnit_iff_coprime (m n : ℕ) : IsUnit (m : ZMod n) ↔ m.Coprime n

lemma ZMod.isUnit_prime_of_not_dvd {n p : ℕ} (hp : p.Prime) (h : ¬ p ∣ n) : IsUnit (p : ZMod n)

lemma ZMod.not_isUnit_of_mem_primeFactors {n p : ℕ} (h : p ∈ n.primeFactors) : ¬ IsUnit (p : ZMod n)
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
