### PR TITLE
[Merged by Bors] - feat: leantar: remove corrupted files instead of failing

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -70,7 +70,7 @@ def CURLBIN :=
 
 /-- leantar version at https://github.com/digama0/leangz -/
 def LEANTARVERSION :=
-  "0.1.10"
+  "0.1.11"
 
 def EXE := if System.Platform.isWindows then ".exe" else ""
 
@@ -339,7 +339,7 @@ def unpackCache (hashMap : HashMap) (force : Bool) : IO Unit := do
     let now ← IO.monoMsNow
     IO.println s!"Decompressing {size} file(s)"
     let isMathlibRoot ← isMathlibRoot
-    let args := (if force then #["-f"] else #[]) ++ #["-x", "-j", "-"]
+    let args := (if force then #["-f"] else #[]) ++ #["-x", "--delete-corrupted", "-j", "-"]
     let child ← IO.Process.spawn { cmd := ← getLeanTar, args, stdin := .piped }
     let (stdin, child) ← child.takeStdin
     let mathlibDepPath := (← mathlibDepPath).toString


### PR DESCRIPTION
The [latest leantar bump](https://github.com/digama0/leangz/compare/v0.1.10...v0.1.11) resolves an issue [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/build.20failing/near/418290193), in which corrupted ltar files would result in an error message and failing error code (although it still unpacks everything else). Now, when you pass the `--delete-corrupted` flag to `leantar` (enabled by default in `lake exe cache get`), it will instead delete any input files that failed to parse, meaning that `lake build` can be used to reconstruct the file, and a second invocation of `lake exe cache get` will try again to download the file.

The new leantar version also makes sure to remove any partially written files for a given archive in the event of an IO or parse error during unpacking.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
