### PR TITLE
[Merged by Bors] - feat(Analysis.Calculus.FDeriv.Analytic + Analysis.Complex.TaylorSeries): Taylor series of holomorphic functions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -688,6 +688,7 @@ import Mathlib.Analysis.Complex.ReImTopology
 import Mathlib.Analysis.Complex.RealDeriv
 import Mathlib.Analysis.Complex.RemovableSingularity
 import Mathlib.Analysis.Complex.Schwarz
+import Mathlib.Analysis.Complex.TaylorSeries
 import Mathlib.Analysis.Complex.UnitDisc.Basic
 import Mathlib.Analysis.Complex.UpperHalfPlane.Basic
 import Mathlib.Analysis.Complex.UpperHalfPlane.FunctionsBoundedAtInfty

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -1295,6 +1295,13 @@ theorem changeOrigin_radius : p.radius - ‖x‖₊ ≤ (p.changeOrigin x).radiu
     (NNReal.summable_sigma.1 (p.changeOriginSeries_summable_aux₁ hr)).2
 #align formal_multilinear_series.change_origin_radius FormalMultilinearSeries.changeOrigin_radius
 
+/-- `derivSeries p` is a power series for `fderiv 𝕜 f` if `p` is a power series for `f`,
+see `HasFPowerSeriesOnBall.fderiv`. -/
+noncomputable
+def derivSeries : FormalMultilinearSeries 𝕜 E (E →L[𝕜] F) :=
+  (continuousMultilinearCurryFin1 𝕜 E F : (E[×1]→L[𝕜] F) →L[𝕜] E →L[𝕜] F)
+    |>.compFormalMultilinearSeries (p.changeOriginSeries 1)
+
 end
 
 -- From this point on, assume that the space is complete, to make sure that series that converge

--- a/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
@@ -1520,7 +1520,7 @@ noncomputable def iteratedFDeriv (n : ℕ) (f : E → F) : E → E[×n]→L[𝕜
     ContinuousLinearMap.uncurryLeft (fderiv 𝕜 rec x)
 #align iterated_fderiv iteratedFDeriv
 
-/-- Formal Taylor series associated to a function within a set. -/
+/-- Formal Taylor series associated to a function. -/
 def ftaylorSeries (f : E → F) (x : E) : FormalMultilinearSeries 𝕜 E F := fun n =>
   iteratedFDeriv 𝕜 n f x
 #align ftaylor_series ftaylorSeries

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -358,9 +358,9 @@ theorem factorial_smul (n : ℕ) :
     rfl
 
 theorem hasSum_iteratedFDeriv [CharZero 𝕜] {y : E} (hy : y ∈ EMetric.ball 0 r) :
-    HasSum (fun n ↦ (1 / n ! : 𝕜) • iteratedFDeriv 𝕜 n f x fun _ ↦ y) (f (x + y)) := by
+    HasSum (fun n ↦ (n ! : 𝕜)⁻¹ • iteratedFDeriv 𝕜 n f x fun _ ↦ y) (f (x + y)) := by
   convert h.hasSum hy with n
   rw [← h.factorial_smul y n, smul_comm, ← smul_assoc, nsmul_eq_mul,
-    mul_one_div_cancel <| cast_ne_zero.mpr n.factorial_ne_zero, one_smul]
+    mul_inv_cancel <| cast_ne_zero.mpr n.factorial_ne_zero, one_smul]
 
 end HasFPowerSeriesOnBall

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -89,9 +89,7 @@ theorem HasFPowerSeriesOnBall.fderiv_eq [CompleteSpace F] (h : HasFPowerSeriesOn
 
 /-- If a function has a power series on a ball, then so does its derivative. -/
 theorem HasFPowerSeriesOnBall.fderiv [CompleteSpace F] (h : HasFPowerSeriesOnBall f p x r) :
-    HasFPowerSeriesOnBall (fderiv 𝕜 f)
-      ((continuousMultilinearCurryFin1 𝕜 E F : (E[×1]→L[𝕜] F) →L[𝕜] E →L[𝕜] F)
-        |>.compFormalMultilinearSeries (p.changeOriginSeries 1)) x r := by
+    HasFPowerSeriesOnBall (fderiv 𝕜 f) p.derivSeries x r := by
   refine .congr (f := fun z ↦ continuousMultilinearCurryFin1 𝕜 E F (p.changeOrigin (z - x) 1)) ?_
     fun z hz ↦ ?_
   · refine continuousMultilinearCurryFin1 𝕜 E F
@@ -206,9 +204,7 @@ theorem HasFiniteFPowerSeriesOnBall.fderiv_eq (h : HasFiniteFPowerSeriesOnBall f
 /-- If a function has a finite power series on a ball, then so does its derivative. -/
 protected theorem HasFiniteFPowerSeriesOnBall.fderiv
     (h : HasFiniteFPowerSeriesOnBall f p x (n + 1) r) :
-    HasFiniteFPowerSeriesOnBall (fderiv 𝕜 f)
-      ((continuousMultilinearCurryFin1 𝕜 E F : (E[×1]→L[𝕜] F) →L[𝕜] E →L[𝕜] F)
-        |>.compFormalMultilinearSeries (p.changeOriginSeries 1)) x n r := by
+    HasFiniteFPowerSeriesOnBall (fderiv 𝕜 f) p.derivSeries x n r := by
   refine .congr (f := fun z ↦ continuousMultilinearCurryFin1 𝕜 E F (p.changeOrigin (z - x) 1)) ?_
     fun z hz ↦ ?_
   · refine continuousMultilinearCurryFin1 𝕜 E F
@@ -223,9 +219,7 @@ protected theorem HasFiniteFPowerSeriesOnBall.fderiv
 This is a variant of `HasFiniteFPowerSeriesOnBall.fderiv` where the degree of `f` is `< n`
 and not `< n + 1`. -/
 theorem HasFiniteFPowerSeriesOnBall.fderiv' (h : HasFiniteFPowerSeriesOnBall f p x n r) :
-    HasFiniteFPowerSeriesOnBall (fderiv 𝕜 f)
-      ((continuousMultilinearCurryFin1 𝕜 E F : (E[×1]→L[𝕜] F) →L[𝕜] E →L[𝕜] F)
-        |>.compFormalMultilinearSeries (p.changeOriginSeries 1)) x (n - 1) r := by
+    HasFiniteFPowerSeriesOnBall (fderiv 𝕜 f) p.derivSeries x (n - 1) r := by
   obtain rfl | hn := eq_or_ne n 0
   · rw [zero_tsub]
     refine HasFiniteFPowerSeriesOnBall.bound_zero_of_eq_zero (fun y hy ↦ ?_) h.r_pos fun n ↦ ?_
@@ -301,12 +295,6 @@ namespace FormalMultilinearSeries
 
 variable (p : FormalMultilinearSeries 𝕜 E F)
 
-/-- This series appears in `HasFPowerSeriesOnBall.fderiv` -/
-noncomputable
-def derivSeries : FormalMultilinearSeries 𝕜 E (E →L[𝕜] F) :=
-  (continuousMultilinearCurryFin1 𝕜 E F : (E[×1]→L[𝕜] F) →L[𝕜] E →L[𝕜] F)
-    |>.compFormalMultilinearSeries (p.changeOriginSeries 1)
-
 open Fintype ContinuousLinearMap in
 theorem derivSeries_apply_diag (n : ℕ) (x : E) :
     derivSeries p n (fun _ ↦ x) x = (n + 1) • p (n + 1) fun _ ↦ x := by
@@ -328,8 +316,8 @@ open FormalMultilinearSeries ENNReal Nat
 variable {p : FormalMultilinearSeries 𝕜 E F} {f : E → F} {x : E} {r : ℝ≥0∞}
   (h : HasFPowerSeriesOnBall f p x r) (y : E)
 
-theorem iteratedFDeriv_zero_apply_diag :
-    iteratedFDeriv 𝕜 0 f x (fun _ ↦ y) = p 0 (fun _ ↦ y) := by
+theorem iteratedFDeriv_zero_apply_diag : iteratedFDeriv 𝕜 0 f x = p 0 := by
+  ext
   convert (h.hasSum <| EMetric.mem_ball_self h.r_pos).tsum_eq.symm
   · rw [iteratedFDeriv_zero_apply, add_zero]
   · rw [tsum_eq_single 0 <| fun n hn ↦ by haveI := NeZero.mk hn; exact (p n).map_zero]
@@ -343,7 +331,7 @@ private theorem factorial_smul' {n : ℕ} : ∀ {F : Type max u v} [NormedAddCom
     n ! • p n (fun _ ↦ y) = iteratedFDeriv 𝕜 n f x (fun _ ↦ y) := by
   induction' n with n ih <;> intro F _ _ _ p f h
   · rw [factorial_zero, one_smul, h.iteratedFDeriv_zero_apply_diag]
-  · rw [factorial_succ, mul_comm, mul_smul, ← derivSeries_apply_diag, ← smul_apply, derivSeries,
+  · rw [factorial_succ, mul_comm, mul_smul, ← derivSeries_apply_diag, ← smul_apply,
       ih h.fderiv, iteratedFDeriv_succ_apply_right]
     rfl
 

--- a/Mathlib/Analysis/Complex/TaylorSeries.lean
+++ b/Mathlib/Analysis/Complex/TaylorSeries.lean
@@ -34,7 +34,7 @@ variable ⦃z : ℂ⦄ (hz : z ∈ Metric.ball c r)
 /-- A function that is complex differentiable on the open ball of radius `r` around `c`
 is given by evaluating its Taylor series at `c` on this open ball. -/
 lemma hasSum_taylorSeries_on_ball :
-    HasSum (fun n : ℕ ↦ (1 / n ! : ℂ) • (z - c) ^ n • iteratedDeriv n f c) (f z) := by
+    HasSum (fun n : ℕ ↦ (n ! : ℂ)⁻¹ • (z - c) ^ n • iteratedDeriv n f c) (f z) := by
   obtain ⟨r', hr', hr'₀, hzr'⟩ : ∃ r' < r, 0 < r' ∧ z ∈ Metric.ball c r'
   · obtain ⟨r', h₁, h₂⟩ := exists_between (Metric.mem_ball'.mp hz)
     lift r' to NNReal using dist_nonneg.trans h₁.le
@@ -53,13 +53,13 @@ lemma hasSum_taylorSeries_on_ball :
 /-- A function that is complex differentiable on the open ball of radius `r` around `c`
 is given by evaluating its Taylor series at `c` on theis open ball. -/
 lemma taylorSeries_eq_on_ball :
-    ∑' n : ℕ, (1 / n ! : ℂ) • (z - c) ^ n • iteratedDeriv n f c = f z :=
+    ∑' n : ℕ, (n ! : ℂ)⁻¹ • (z - c) ^ n • iteratedDeriv n f c = f z :=
   (hasSum_taylorSeries_on_ball hf hz).tsum_eq
 
 /-- A function that is complex differentiable on the open ball of radius `r` around `c`
 is given by evaluating its Taylor series at `c` on this open ball. -/
 lemma taylorSeries_eq_on_ball' {f : ℂ → ℂ} (hf : DifferentiableOn ℂ f (Metric.ball c r)) :
-    ∑' n : ℕ, (1 / n ! : ℂ) * iteratedDeriv n f c * (z - c) ^ n = f z := by
+    ∑' n : ℕ, (n ! : ℂ)⁻¹ * iteratedDeriv n f c * (z - c) ^ n = f z := by
   convert taylorSeries_eq_on_ball hf hz using 3 with n
   rw [mul_right_comm, smul_eq_mul, smul_eq_mul, mul_assoc]
 
@@ -72,7 +72,7 @@ variable ⦃f : ℂ → E⦄ (hf : Differentiable ℂ f) (c z : ℂ)
 /-- A function that is complex differentiable on the complex plane is given by evaluating
 its Taylor series at any point `c`. -/
 lemma hasSum_taylorSeries_of_entire :
-    HasSum (fun n : ℕ ↦ (1 / n ! : ℂ) • (z - c) ^ n • iteratedDeriv n f c) (f z) := by
+    HasSum (fun n : ℕ ↦ (n ! : ℂ)⁻¹ • (z - c) ^ n • iteratedDeriv n f c) (f z) := by
   have hf' : DifferentiableOn ℂ f
       (Metric.ball c (⟨1 + ‖z - c‖, add_nonneg zero_le_one <| norm_nonneg _⟩ : NNReal)) :=
     hf.differentiableOn
@@ -83,13 +83,13 @@ lemma hasSum_taylorSeries_of_entire :
 /-- A function that is complex differentiable on the complex plane is given by evaluating
 its Taylor series at any point `c`. -/
 lemma taylorSeries_eq_of_entire :
-    ∑' n : ℕ, (1 / n ! : ℂ) • (z - c) ^ n • iteratedDeriv n f c = f z :=
+    ∑' n : ℕ, (n ! : ℂ)⁻¹ • (z - c) ^ n • iteratedDeriv n f c = f z :=
   (hasSum_taylorSeries_of_entire hf c z).tsum_eq
 
 /-- A function that is complex differentiable on the complex plane is given by evaluating
 its Taylor series at any point `c`. -/
 lemma taylorSeries_eq_of_entire' {f : ℂ → ℂ} (hf : Differentiable ℂ f) :
-    ∑' n : ℕ, (1 / n ! : ℂ) * iteratedDeriv n f c * (z - c) ^ n = f z := by
+    ∑' n : ℕ, (n ! : ℂ)⁻¹ * iteratedDeriv n f c * (z - c) ^ n = f z := by
   convert taylorSeries_eq_of_entire hf c z using 3 with n
   rw [mul_right_comm, smul_eq_mul, smul_eq_mul, mul_assoc]
 

--- a/Mathlib/Analysis/Complex/TaylorSeries.lean
+++ b/Mathlib/Analysis/Complex/TaylorSeries.lean
@@ -55,7 +55,7 @@ lemma hasSum_taylorSeries_on_ball :
     using ((iteratedFDeriv ℂ n f c).map_smul_univ (fun _ ↦ z - c) (fun _ ↦ 1)).symm
 
 /-- A function that is complex differentiable on the open ball of radius `r` around `c`
-is given by evaluating its Taylor series at `c` on theis open ball. -/
+is given by evaluating its Taylor series at `c` on this open ball. -/
 lemma taylorSeries_eq_on_ball :
     ∑' n : ℕ, (n ! : ℂ)⁻¹ • (z - c) ^ n • iteratedDeriv n f c = f z :=
   (hasSum_taylorSeries_on_ball hf hz).tsum_eq

--- a/Mathlib/Analysis/Complex/TaylorSeries.lean
+++ b/Mathlib/Analysis/Complex/TaylorSeries.lean
@@ -14,21 +14,26 @@ see `Complex.hasSum_taylorSeries_on_ball` and `Complex.taylorSeries_eq_on_ball` 
 (in terms of `HasSum` and `tsum`, repsectively) for functions to a complete normed
 space over `ℂ`, and `Complex.taylorSeries_eq_on_ball'` for a variant when `f : ℂ → ℂ`.
 
-We also show that the Taylor series of a function `f` that is complex differentiable on
-all of `ℂ` converges to  `f` on `ℂ`; see `Complex.hasSum_taylorSeries_of_entire`,
-`Complex.taylorSeries_eq_of_entire` and `Complex.taylorSeries_eq_of_entire'`.
+We also show that the Taylor series around some point `c : ℂ` of a function `f` that is complex
+differentiable on all of `ℂ` converges to  `f` on `ℂ`;
+see `Complex.hasSum_taylorSeries_of_entire`, `Complex.taylorSeries_eq_of_entire` and
+`Complex.taylorSeries_eq_of_entire'`.
 -/
 
 namespace Complex
 
 open BigOperators Nat
 
-variable {E : Type u} [NormedAddCommGroup E] [NormedSpace ℂ E] [CompleteSpace E]
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] [CompleteSpace E] ⦃f : ℂ → E⦄
+
+section ball
+
+variable ⦃c : ℂ⦄ ⦃r : NNReal⦄ (hf : DifferentiableOn ℂ f (Metric.ball c r))
+variable ⦃z : ℂ⦄ (hz : z ∈ Metric.ball c r)
 
 /-- A function that is complex differentiable on the open ball of radius `r` around `c`
 is given by evaluating its Taylor series at `c` on this open ball. -/
-lemma hasSum_taylorSeries_on_ball {f : ℂ → E} ⦃r : NNReal⦄ (hr : 0 < r)
-    (hf : DifferentiableOn ℂ f (Metric.ball c r)) ⦃z : ℂ⦄ (hz : z ∈ Metric.ball c r) :
+lemma hasSum_taylorSeries_on_ball :
     HasSum (fun n : ℕ ↦ (1 / n ! : ℂ) • (z - c) ^ n • iteratedDeriv n f c) (f z) := by
   obtain ⟨r', hr', hr'₀, hzr'⟩ : ∃ r' < r, 0 < r' ∧ z ∈ Metric.ball c r'
   · obtain ⟨r', h₁, h₂⟩ := exists_between (Metric.mem_ball'.mp hz)
@@ -47,39 +52,47 @@ lemma hasSum_taylorSeries_on_ball {f : ℂ → E} ⦃r : NNReal⦄ (hr : 0 < r)
 
 /-- A function that is complex differentiable on the open ball of radius `r` around `c`
 is given by evaluating its Taylor series at `c` on theis open ball. -/
-lemma taylorSeries_eq_on_ball {f : ℂ → E} ⦃r : NNReal⦄ (hr : 0 < r)
-    (hf : DifferentiableOn ℂ f (Metric.ball c r)) ⦃z : ℂ⦄ (hz : z ∈ Metric.ball c r) :
+lemma taylorSeries_eq_on_ball :
     ∑' n : ℕ, (1 / n ! : ℂ) • (z - c) ^ n • iteratedDeriv n f c = f z :=
-  (hasSum_taylorSeries_on_ball hr hf hz).tsum_eq
+  (hasSum_taylorSeries_on_ball hf hz).tsum_eq
 
 /-- A function that is complex differentiable on the open ball of radius `r` around `c`
 is given by evaluating its Taylor series at `c` on this open ball. -/
-lemma taylorSeries_eq_on_ball' {f : ℂ → ℂ} ⦃r : NNReal⦄ (hr : 0 < r)
-    (hf : DifferentiableOn ℂ f (Metric.ball c r)) ⦃z : ℂ⦄ (hz : z ∈ Metric.ball c r) :
+lemma taylorSeries_eq_on_ball' {f : ℂ → ℂ} (hf : DifferentiableOn ℂ f (Metric.ball c r)) :
     ∑' n : ℕ, (1 / n ! : ℂ) * iteratedDeriv n f c * (z - c) ^ n = f z := by
-  convert taylorSeries_eq_on_ball hr hf hz using 3 with n
+  convert taylorSeries_eq_on_ball hf hz using 3 with n
   rw [mul_right_comm, smul_eq_mul, smul_eq_mul, mul_assoc]
+
+end ball
+
+section entire
+
+variable ⦃f : ℂ → E⦄ (hf : Differentiable ℂ f) (c z : ℂ)
 
 /-- A function that is complex differentiable on the complex plane is given by evaluating
 its Taylor series at any point `c`. -/
-lemma hasSum_taylorSeries_of_entire {f : ℂ → E} (hf : Differentiable ℂ f) (c z : ℂ) :
+lemma hasSum_taylorSeries_of_entire :
     HasSum (fun n : ℕ ↦ (1 / n ! : ℂ) • (z - c) ^ n • iteratedDeriv n f c) (f z) := by
-  have hR := lt_add_of_pos_of_le zero_lt_one <| zero_le (⟨‖z - c‖, norm_nonneg _⟩ : NNReal)
-  refine hasSum_taylorSeries_on_ball hR hf.differentiableOn ?_
-  rw [mem_ball_iff_norm, NNReal.coe_add, NNReal.coe_one, NNReal.coe_mk, lt_add_iff_pos_left]
+  have hf' : DifferentiableOn ℂ f
+      (Metric.ball c (⟨1 + ‖z - c‖, add_nonneg zero_le_one <| norm_nonneg _⟩ : NNReal)) :=
+    hf.differentiableOn
+  refine hasSum_taylorSeries_on_ball hf' ?_
+  rw [mem_ball_iff_norm, NNReal.coe_mk, lt_add_iff_pos_left]
   exact zero_lt_one
 
 /-- A function that is complex differentiable on the complex plane is given by evaluating
 its Taylor series at any point `c`. -/
-lemma taylorSeries_eq_of_entire {f : ℂ → E} (hf : Differentiable ℂ f) (c z : ℂ) :
+lemma taylorSeries_eq_of_entire :
     ∑' n : ℕ, (1 / n ! : ℂ) • (z - c) ^ n • iteratedDeriv n f c = f z :=
   (hasSum_taylorSeries_of_entire hf c z).tsum_eq
 
 /-- A function that is complex differentiable on the complex plane is given by evaluating
 its Taylor series at any point `c`. -/
-lemma taylorSeries_eq_of_entire' {f : ℂ → ℂ} (hf : Differentiable ℂ f) (c z : ℂ) :
+lemma taylorSeries_eq_of_entire' {f : ℂ → ℂ} (hf : Differentiable ℂ f) :
     ∑' n : ℕ, (1 / n ! : ℂ) * iteratedDeriv n f c * (z - c) ^ n = f z := by
   convert taylorSeries_eq_of_entire hf c z using 3 with n
   rw [mul_right_comm, smul_eq_mul, smul_eq_mul, mul_assoc]
+
+end entire
 
 end Complex

--- a/Mathlib/Analysis/Complex/TaylorSeries.lean
+++ b/Mathlib/Analysis/Complex/TaylorSeries.lean
@@ -14,6 +14,10 @@ see `Complex.hasSum_taylorSeries_on_ball` and `Complex.taylorSeries_eq_on_ball` 
 (in terms of `HasSum` and `tsum`, repsectively) for functions to a complete normed
 space over `ℂ`, and `Complex.taylorSeries_eq_on_ball'` for a variant when `f : ℂ → ℂ`.
 
+There are corresponding statements for `EMEtric.ball`s; see
+`Complex.hasSum_taylorSeries_on_emetric_ball`, `Complex.taylorSeries_eq_on_emetric_ball`
+and `Complex.taylorSeries_eq_on_ball'`.
+
 We also show that the Taylor series around some point `c : ℂ` of a function `f` that is complex
 differentiable on all of `ℂ` converges to `f` on `ℂ`;
 see `Complex.hasSum_taylorSeries_of_entire`, `Complex.taylorSeries_eq_of_entire` and
@@ -70,7 +74,7 @@ section emetric
 variable ⦃c : ℂ⦄ ⦃r : ENNReal⦄ (hf : DifferentiableOn ℂ f (EMetric.ball c r))
 variable ⦃z : ℂ⦄ (hz : z ∈ EMetric.ball c r)
 
-/-- A function that is complex differentiable on the open ball of radius `r` around `c`
+/-- A function that is complex differentiable on the open ball of radius `r ≤ ∞` around `c`
 is given by evaluating its Taylor series at `c` on this open ball. -/
 lemma hasSum_taylorSeries_on_emetric_ball :
     HasSum (fun n : ℕ ↦ (n ! : ℂ)⁻¹ • (z - c) ^ n • iteratedDeriv n f c) (f z) := by
@@ -78,19 +82,18 @@ lemma hasSum_taylorSeries_on_emetric_ball :
   · obtain ⟨r', h₁, h₂⟩ := exists_between (EMetric.mem_ball'.mp hz)
     exact ⟨r', h₂, EMetric.mem_ball'.mpr h₁⟩
   lift r' to NNReal using ne_top_of_lt hr'
-  have hf' : DifferentiableOn ℂ f (Metric.ball c r')
-  · rw [← Metric.emetric_ball_nnreal]
-    exact hf.mono <| EMetric.ball_subset_ball hr'.le
   rw [Metric.emetric_ball_nnreal] at hzr'
-  exact hasSum_taylorSeries_on_ball hf' hzr'
+  refine hasSum_taylorSeries_on_ball ?_ hzr'
+  rw [← Metric.emetric_ball_nnreal]
+  exact hf.mono <| EMetric.ball_subset_ball hr'.le
 
-/-- A function that is complex differentiable on the open ball of radius `r` around `c`
+/-- A function that is complex differentiable on the open ball of radius `r ≤ ∞` around `c`
 is given by evaluating its Taylor series at `c` on theis open ball. -/
 lemma taylorSeries_eq_on_emetric_ball :
     ∑' n : ℕ, (n ! : ℂ)⁻¹ • (z - c) ^ n • iteratedDeriv n f c = f z :=
   (hasSum_taylorSeries_on_emetric_ball hf hz).tsum_eq
 
-/-- A function that is complex differentiable on the open ball of radius `r` around `c`
+/-- A function that is complex differentiable on the open ball of radius `r ≤ ∞` around `c`
 is given by evaluating its Taylor series at `c` on this open ball. -/
 lemma taylorSeries_eq_on_emetric_ball' {f : ℂ → ℂ} (hf : DifferentiableOn ℂ f (EMetric.ball c r)) :
     ∑' n : ℕ, (n ! : ℂ)⁻¹ * iteratedDeriv n f c * (z - c) ^ n = f z := by

--- a/Mathlib/Analysis/Complex/TaylorSeries.lean
+++ b/Mathlib/Analysis/Complex/TaylorSeries.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2024 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Stoll
+-/
+import Mathlib.Analysis.Complex.CauchyIntegral
+
+/-!
+# Convergence of Taylor series of holomorphic functions
+
+We show that the Taylor series around some point `c : ℂ` of a function `f` that is complex
+differentiable on the open ball of radius `r` around `c` converges to `f` on that open ball;
+see `Complex.hasSum_taylorSeries_on_ball` and `Complex.taylorSeries_eq_on_ball` for versions
+(in terms of `HasSum` and `tsum`, repsectively) for functions to a complete normed
+space over `ℂ`, and `Complex.taylorSeries_eq_on_ball'` for a variant when `f : ℂ → ℂ`.
+
+We also show that the Taylor series of a function `f` that is complex differentiable on
+all of `ℂ` converges to  `f` on `ℂ`; see `Complex.hasSum_taylorSeries_of_entire`,
+`Complex.taylorSeries_eq_of_entire` and `Complex.taylorSeries_eq_of_entire'`.
+-/
+
+namespace Complex
+
+open BigOperators Nat
+
+variable {E : Type u} [NormedAddCommGroup E] [NormedSpace ℂ E] [CompleteSpace E]
+
+/-- A function that is complex differentiable on the open ball of radius `r` around `c`
+is given by evaluating its Taylor series at `c` on this open ball. -/
+lemma hasSum_taylorSeries_on_ball {f : ℂ → E} ⦃r : NNReal⦄ (hr : 0 < r)
+    (hf : DifferentiableOn ℂ f (Metric.ball c r)) ⦃z : ℂ⦄ (hz : z ∈ Metric.ball c r) :
+    HasSum (fun n : ℕ ↦ (1 / n ! : ℂ) • (z - c) ^ n • iteratedDeriv n f c) (f z) := by
+  obtain ⟨r', hr', hr'₀, hzr'⟩ : ∃ r' < r, 0 < r' ∧ z ∈ Metric.ball c r'
+  · obtain ⟨r', h₁, h₂⟩ := exists_between (Metric.mem_ball'.mp hz)
+    lift r' to NNReal using dist_nonneg.trans h₁.le
+    exact ⟨r', h₂, pos_of_gt h₁, Metric.mem_ball'.mpr h₁⟩
+  have hz' : z - c ∈ EMetric.ball 0 r'
+  · rw [Metric.emetric_ball_nnreal]
+    exact mem_ball_zero_iff.mpr hzr'
+  have H := (hf.mono <| Metric.closedBall_subset_ball hr').hasFPowerSeriesOnBall hr'₀
+      |>.hasSum_iteratedFDeriv hz'
+  simp only [add_sub_cancel'_right] at H
+  convert H using 4 with n
+  simpa only [iteratedDeriv_eq_iteratedFDeriv, smul_eq_mul, mul_one, Finset.prod_const,
+    Finset.card_fin]
+    using ((iteratedFDeriv ℂ n f c).map_smul_univ (fun _ ↦ z - c) (fun _ ↦ 1)).symm
+
+/-- A function that is complex differentiable on the open ball of radius `r` around `c`
+is given by evaluating its Taylor series at `c` on theis open ball. -/
+lemma taylorSeries_eq_on_ball {f : ℂ → E} ⦃r : NNReal⦄ (hr : 0 < r)
+    (hf : DifferentiableOn ℂ f (Metric.ball c r)) ⦃z : ℂ⦄ (hz : z ∈ Metric.ball c r) :
+    ∑' n : ℕ, (1 / n ! : ℂ) • (z - c) ^ n • iteratedDeriv n f c = f z :=
+  (hasSum_taylorSeries_on_ball hr hf hz).tsum_eq
+
+/-- A function that is complex differentiable on the open ball of radius `r` around `c`
+is given by evaluating its Taylor series at `c` on this open ball. -/
+lemma taylorSeries_eq_on_ball' {f : ℂ → ℂ} ⦃r : NNReal⦄ (hr : 0 < r)
+    (hf : DifferentiableOn ℂ f (Metric.ball c r)) ⦃z : ℂ⦄ (hz : z ∈ Metric.ball c r) :
+    ∑' n : ℕ, (1 / n ! : ℂ) * iteratedDeriv n f c * (z - c) ^ n = f z := by
+  convert taylorSeries_eq_on_ball hr hf hz using 3 with n
+  rw [mul_right_comm, smul_eq_mul, smul_eq_mul, mul_assoc]
+
+/-- A function that is complex differentiable on the complex plane is given by evaluating
+its Taylor series at any point `c`. -/
+lemma hasSum_taylorSeries_of_entire {f : ℂ → E} (hf : Differentiable ℂ f) (c z : ℂ) :
+    HasSum (fun n : ℕ ↦ (1 / n ! : ℂ) • (z - c) ^ n • iteratedDeriv n f c) (f z) := by
+  have hR := lt_add_of_pos_of_le zero_lt_one <| zero_le (⟨‖z - c‖, norm_nonneg _⟩ : NNReal)
+  refine hasSum_taylorSeries_on_ball hR hf.differentiableOn ?_
+  rw [mem_ball_iff_norm, NNReal.coe_add, NNReal.coe_one, NNReal.coe_mk, lt_add_iff_pos_left]
+  exact zero_lt_one
+
+/-- A function that is complex differentiable on the complex plane is given by evaluating
+its Taylor series at any point `c`. -/
+lemma taylorSeries_eq_of_entire {f : ℂ → E} (hf : Differentiable ℂ f) (c z : ℂ) :
+    ∑' n : ℕ, (1 / n ! : ℂ) • (z - c) ^ n • iteratedDeriv n f c = f z :=
+  (hasSum_taylorSeries_of_entire hf c z).tsum_eq
+
+/-- A function that is complex differentiable on the complex plane is given by evaluating
+its Taylor series at any point `c`. -/
+lemma taylorSeries_eq_of_entire' {f : ℂ → ℂ} (hf : Differentiable ℂ f) (c z : ℂ) :
+    ∑' n : ℕ, (1 / n ! : ℂ) * iteratedDeriv n f c * (z - c) ^ n = f z := by
+  convert taylorSeries_eq_of_entire hf c z using 3 with n
+  rw [mul_right_comm, smul_eq_mul, smul_eq_mul, mul_assoc]
+
+end Complex

--- a/Mathlib/Analysis/Complex/TaylorSeries.lean
+++ b/Mathlib/Analysis/Complex/TaylorSeries.lean
@@ -88,7 +88,7 @@ lemma hasSum_taylorSeries_on_emetric_ball :
   exact hf.mono <| EMetric.ball_subset_ball hr'.le
 
 /-- A function that is complex differentiable on the open ball of radius `r ≤ ∞` around `c`
-is given by evaluating its Taylor series at `c` on theis open ball. -/
+is given by evaluating its Taylor series at `c` on this open ball. -/
 lemma taylorSeries_eq_on_emetric_ball :
     ∑' n : ℕ, (n ! : ℂ)⁻¹ • (z - c) ^ n • iteratedDeriv n f c = f z :=
   (hasSum_taylorSeries_on_emetric_ball hf hz).tsum_eq

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -504,6 +504,12 @@ theorem snoc_comp_castSucc {n : ℕ} {α : Sort _} {a : α} {f : Fin n → α} :
 theorem snoc_last : snoc p x (last n) = x := by simp [snoc]
 #align fin.snoc_last Fin.snoc_last
 
+lemma snoc_zero {α : Type*} (p : Fin 0 → α) (x : α) :
+    Fin.snoc p x = fun _ ↦ x := by
+  ext y
+  have : Subsingleton (Fin (0 + 1)) := Fin.subsingleton_one
+  simp only [Subsingleton.elim y (Fin.last 0), snoc_last]
+
 @[simp]
 theorem snoc_comp_nat_add {n m : ℕ} {α : Sort _} (f : Fin (m + n) → α) (a : α) :
     (snoc f a : Fin _ → α) ∘ (natAdd m : Fin (n + 1) → Fin (m + n + 1)) =

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -2705,6 +2705,10 @@ theorem piecewise_mem_Icc' {δ : α → Type*} [∀ i, Preorder (δ i)] {f g : �
   piecewise_mem_Icc_of_mem_of_mem _ (Set.right_mem_Icc.2 h) (Set.left_mem_Icc.2 h)
 #align finset.piecewise_mem_Icc' Finset.piecewise_mem_Icc'
 
+lemma piecewise_same : s.piecewise f f = f := by
+  ext i
+  by_cases h : i ∈ s <;> simp [h]
+
 end Piecewise
 
 section DecidablePiExists


### PR DESCRIPTION
See [here](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/The.20Taylor.20series.20of.20an.20entire.20function.20converges.20to.20it/near/417334632) on Zulip.

This adds some general lemmas due to Junyan Xu, culminating in
```lean
theorem HasFPowerSeriesOnBall.hasSum_iteratedFDeriv {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*}
    [ NormedAddCommGroup E] [NormedSpace 𝕜 E] {F : Type*} [NormedAddCommGroup F]
    [NormedSpace 𝕜 F] {p : FormalMultilinearSeries 𝕜 E F} {f : E → F} {x : E} {r : ℝ≥0∞}
    (h : HasFPowerSeriesOnBall f p x r) [CompleteSpace F] [CharZero 𝕜] {y : E} (hy : y ∈ EMetric.ball 0 r) :+1:
    HasSum (fun n ↦ (n ! : 𝕜)⁻¹• (iteratedFDeriv 𝕜 n f x) fun x ↦ y) (f (x + y))
```
and uses this to show that the Taylor series of a function that is complex differentiable on an open ball in ℂ converges there to the function; similarly for functions that are holomorphic on all of ℂ:
```lean
lemma Complex.hasSum_taylorSeries_on_ball {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
    [CompleteSpace E] ⦃f : ℂ → E⦄ ⦃c : ℂ⦄ ⦃r : NNReal⦄ (hf : DifferentiableOn ℂ f (Metric.ball c ↑r)) ⦃z : ℂ⦄
    (hz : z ∈ Metric.ball c ↑r) :
    HasSum (fun n ↦ (n ! : ℂ)⁻¹ • (z - c) ^ n • iteratedDeriv n f c) (f z)

lemma Complex.taylorSeries_eq_on_ball {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
    [CompleteSpace E] ⦃f : ℂ → E⦄ ⦃c : ℂ⦄ ⦃r : NNReal⦄ (hf : DifferentiableOn ℂ f (Metric.ball c ↑r)) ⦃z : ℂ⦄
    (hz : z ∈ Metric.ball c ↑r) : 
    ∑' (n : ℕ), (n ! : ℂ)⁻¹ • (z - c) ^ n • iteratedDeriv n f c = f z

lemma Complex.taylorSeries_eq_on_ball' ⦃c : ℂ⦄ ⦃r : NNReal⦄ ⦃z : ℂ⦄ (hz : z ∈ Metric.ball c ↑r) {f : ℂ → ℂ}
    (hf : DifferentiableOn ℂ f (Metric.ball c ↑r)) : 
    ∑' (n : ℕ), (n ! : ℂ)⁻¹ * iteratedDeriv n f c * (z - c) ^ n = f z
```
and similar lemmas for `EMetric.ball`s and entire functions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
