### PR TITLE
[Merged by Bors] - feat(Gauge): add `comap_gauge_nhds_zero` etc

### DIFF
--- a/Mathlib/Analysis/Convex/Gauge.lean
+++ b/Mathlib/Analysis/Convex/Gauge.lean
@@ -338,7 +338,38 @@ theorem gauge_smul (hs : Balanced 𝕜 s) (r : 𝕜) (x : E) : gauge s (r • x)
 
 end IsROrC
 
+open Filter
+
 section TopologicalSpace
+
+variable [TopologicalSpace E]
+
+theorem comap_gauge_nhds_zero_le (ha : Absorbent ℝ s) (hb : Bornology.IsVonNBounded ℝ s) :
+    comap (gauge s) (𝓝 0) ≤ 𝓝 0 := fun u hu ↦ by
+  rcases (hb hu).exists_pos with ⟨r, hr₀, hr⟩
+  filter_upwards [preimage_mem_comap (gt_mem_nhds (inv_pos.2 hr₀))] with x (hx : gauge s x < r⁻¹)
+  rcases exists_lt_of_gauge_lt ha hx with ⟨c, hc₀, hcr, y, hy, rfl⟩
+  have hrc := (lt_inv hr₀ hc₀).2 hcr
+  rcases hr c⁻¹ (hrc.le.trans (le_abs_self _)) hy with ⟨z, hz, rfl⟩
+  simpa only [smul_inv_smul₀ hc₀.ne']
+
+variable [T1Space E]
+
+theorem gauge_eq_zero (hs : Absorbent ℝ s) (hb : Bornology.IsVonNBounded ℝ s) :
+    gauge s x = 0 ↔ x = 0 := by
+  refine ⟨fun h₀ ↦ by_contra fun (hne : x ≠ 0) ↦ ?_, fun h ↦ h.symm ▸ gauge_zero⟩
+  have : {x}ᶜ ∈ comap (gauge s) (𝓝 0) :=
+    comap_gauge_nhds_zero_le hs hb (isOpen_compl_singleton.mem_nhds hne.symm)
+  rcases ((nhds_basis_zero_abs_sub_lt _).comap _).mem_iff.1 this with ⟨r, hr₀, hr⟩
+  exact hr (by simpa [h₀]) rfl
+
+theorem gauge_pos (hs : Absorbent ℝ s) (hb : Bornology.IsVonNBounded ℝ s) :
+    0 < gauge s x ↔ x ≠ 0 := by
+  simp only [(gauge_nonneg _).gt_iff_ne, Ne.def, gauge_eq_zero hs hb]
+
+end TopologicalSpace
+
+section ContinuousSMul
 
 variable [TopologicalSpace E] [ContinuousSMul ℝ E]
 
@@ -394,9 +425,29 @@ theorem mem_frontier_of_gauge_eq_one (hc : Convex ℝ s) (hs₀ : 0 ∈ s) (ha :
   ⟨mem_closure_of_gauge_le_one hc hs₀ ha h.le, fun h' ↦
     (interior_subset_gauge_lt_one s h').out.ne h⟩
 
-end TopologicalSpace
+theorem tendsto_gauge_nhds_zero' (hs : s ∈ 𝓝 0) : Tendsto (gauge s) (𝓝 0) (𝓝[≥] 0) := by
+  refine nhdsWithin_Ici_basis_Icc.tendsto_right_iff.2 fun ε hε ↦ ?_
+  rw [← set_smul_mem_nhds_zero_iff hε.ne'] at hs
+  filter_upwards [hs] with x hx
+  exact ⟨gauge_nonneg _, gauge_le_of_mem hε.le hx⟩
 
-section TopologicalAddGroup
+theorem tendsto_gauge_nhds_zero (hs : s ∈ 𝓝 0) : Tendsto (gauge s) (𝓝 0) (𝓝 0) :=
+  (tendsto_gauge_nhds_zero' hs).mono_right inf_le_left
+
+/-- If `s` is a neighborhood of the origin, then `gauge s` is continuous at the origin.
+See also `continuousAt_gauge`. -/
+theorem continuousAt_gauge_zero (hs : s ∈ 𝓝 0) : ContinuousAt (gauge s) 0 := by
+  rw [ContinuousAt, gauge_zero]
+  exact tendsto_gauge_nhds_zero hs
+
+theorem comap_gauge_nhds_zero (hb : Bornology.IsVonNBounded ℝ s) (h₀ : s ∈ 𝓝 0) :
+    comap (gauge s) (𝓝 0) = 𝓝 0 :=
+  (comap_gauge_nhds_zero_le (absorbent_nhds_zero h₀) hb).antisymm
+    (tendsto_gauge_nhds_zero h₀).le_comap
+
+end ContinuousSMul
+
+section TopologicalVectorSpace
 
 open Filter
 
@@ -451,24 +502,7 @@ theorem gauge_eq_one_iff_mem_frontier (hc : Convex ℝ s) (hs₀ : s ∈ 𝓝 0)
   rw [eq_iff_le_not_lt, gauge_le_one_iff_mem_closure hc hs₀, gauge_lt_one_iff_mem_interior hc hs₀]
   rfl
 
-theorem gauge_eq_zero [T1Space E] (hs : Absorbent ℝ s) (hb : Bornology.IsVonNBounded ℝ s) :
-    gauge s x = 0 ↔ x = 0 := by
-  refine ⟨not_imp_not.1 fun (h : x ≠ 0) ↦ ne_of_gt ?_, fun h ↦ h.symm ▸ gauge_zero⟩
-  rcases (hb (isOpen_compl_singleton.mem_nhds h.symm)).exists_pos with ⟨c, hc₀, hc⟩
-  refine (inv_pos.2 hc₀).trans_le <| le_csInf hs.gauge_set_nonempty ?_
-  rintro r ⟨hr₀, x, hx, rfl⟩
-  contrapose! hc
-  refine ⟨r⁻¹, ?_, fun h ↦ ?_⟩
-  · rw [norm_inv, Real.norm_of_nonneg hr₀.le, le_inv hc₀ hr₀]
-    exact hc.le
-  · rcases h hx with ⟨y, hy, rfl⟩
-    simp [hr₀.ne'] at hy
-
-theorem gauge_pos [T1Space E] (hs : Absorbent ℝ s) (hb : Bornology.IsVonNBounded ℝ s) :
-    0 < gauge s x ↔ x ≠ 0 := by
-  simp only [(gauge_nonneg _).gt_iff_ne, Ne.def, gauge_eq_zero hs hb]
-
-end TopologicalAddGroup
+end TopologicalVectorSpace
 
 section IsROrC
 


### PR DESCRIPTION
Add `comap_gauge_nhds_zero`, `comap_gauge_nhds_zero_le`,
`tendsto_gauge_nhds_zero`, `tendsto_gauge_nhds_zero'`,
and `continuousAt_gauge_zero`.


---

Cleaning up old branches.

Changes according to `leaff`:

```
+ added tendsto_gauge_nhds_zero'.{u_2}
+ added comap_gauge_nhds_zero.{u_2}
+ added comap_gauge_nhds_zero_le.{u_2}
+ added tendsto_gauge_nhds_zero.{u_2}
+ added continuousAt_gauge_zero.{u_2}
+ doc added to continuousAt_gauge_zero
! proof changed for gauge_eq_zero
```

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)