### PR TITLE
[Merged by Bors] - chore(NumberTheory/Bertrand): inconsistent names of assumptions n_large

### DIFF
--- a/Mathlib/NumberTheory/Bertrand.lean
+++ b/Mathlib/NumberTheory/Bertrand.lean
@@ -51,7 +51,7 @@ namespace Bertrand
 /-- A reified version of the `Bertrand.main_inequality` below.
 This is not best possible: it actually holds for 464 ≤ x.
 -/
-theorem real_main_inequality {x : ℝ} (n_large : (512 : ℝ) ≤ x) :
+theorem real_main_inequality {x : ℝ} (x_large : (512 : ℝ) ≤ x) :
     x * (2 * x) ^ sqrt (2 * x) * 4 ^ (2 * x / 3) ≤ 4 ^ x := by
   let f : ℝ → ℝ := fun x => log x + sqrt (2 * x) * log (2 * x) - log 4 / 3 * x
   have hf' : ∀ x, 0 < x → 0 < x * (2 * x) ^ sqrt (2 * x) / 4 ^ (x / 3) := fun x h =>
@@ -62,7 +62,7 @@ theorem real_main_inequality {x : ℝ} (n_large : (512 : ℝ) ≤ x) :
     have h7 := rpow_pos_of_pos h6 (sqrt (2 * x))
     rw [log_div (mul_pos h5 h7).ne' (rpow_pos_of_pos four_pos _).ne', log_mul h5.ne' h7.ne',
       log_rpow h6, log_rpow zero_lt_four, ← mul_div_right_comm, ← mul_div, mul_comm x]
-  have h5 : 0 < x := lt_of_lt_of_le (by norm_num1) n_large
+  have h5 : 0 < x := lt_of_lt_of_le (by norm_num1) x_large
   rw [← div_le_one (rpow_pos_of_pos four_pos x), ← div_div_eq_mul_div, ← rpow_sub four_pos, ←
     mul_div 2 x, mul_div_left_comm, ← mul_one_sub, (by norm_num1 : (1 : ℝ) - 2 / 3 = 1 / 3),
     mul_one_div, ← log_nonpos_iff (hf' x h5), ← hf x h5]
@@ -86,7 +86,7 @@ theorem real_main_inequality {x : ℝ} (n_large : (512 : ℝ) ≤ x) :
   suffices ∃ x1 x2, 0.5 < x1 ∧ x1 < x2 ∧ x2 ≤ x ∧ 0 ≤ f x1 ∧ f x2 ≤ 0 by
     obtain ⟨x1, x2, h1, h2, h0, h3, h4⟩ := this
     exact (h.right_le_of_le_left'' h1 ((h1.trans h2).trans_le h0) h2 h0 (h4.trans h3)).trans h4
-  refine' ⟨18, 512, by norm_num1, by norm_num1, n_large, _, _⟩
+  refine' ⟨18, 512, by norm_num1, by norm_num1, x_large, _, _⟩
   · have : sqrt (2 * 18) = 6 := (sqrt_eq_iff_mul_self_eq_of_pos (by norm_num1)).mpr (by norm_num1)
     rw [hf _ (by norm_num1), log_nonneg_iff (by positivity), this, one_le_div (by norm_num1)]
     norm_num1
@@ -154,10 +154,10 @@ The bound splits the prime factors of `centralBinom n` into those
 4. Between `n` and `2 * n`, which would not exist in the case where Bertrand's postulate is false.
 5. Above `2 * n`, which do not exist.
 -/
-theorem centralBinom_le_of_no_bertrand_prime (n : ℕ) (n_big : 2 < n)
+theorem centralBinom_le_of_no_bertrand_prime (n : ℕ) (n_large : 2 < n)
     (no_prime : ¬∃ p : ℕ, Nat.Prime p ∧ n < p ∧ p ≤ 2 * n) :
     centralBinom n ≤ (2 * n) ^ sqrt (2 * n) * 4 ^ (2 * n / 3) := by
-  have n_pos : 0 < n := (Nat.zero_le _).trans_lt n_big
+  have n_pos : 0 < n := (Nat.zero_le _).trans_lt n_large
   have n2_pos : 1 ≤ 2 * n := mul_pos (zero_lt_two' ℕ) n_pos
   let S := (Finset.range (2 * n / 3 + 1)).filter Nat.Prime
   let f x := x ^ n.centralBinom.factorization x
@@ -165,7 +165,7 @@ theorem centralBinom_le_of_no_bertrand_prime (n : ℕ) (n_big : 2 < n)
     refine' Finset.prod_filter_of_ne fun p _ h => _
     contrapose! h; dsimp only
     rw [factorization_eq_zero_of_non_prime n.centralBinom h, _root_.pow_zero]
-  rw [centralBinom_factorization_small n n_big no_prime, ← this, ←
+  rw [centralBinom_factorization_small n n_large no_prime, ← this, ←
     Finset.prod_filter_mul_prod_filter_not S (· ≤ sqrt (2 * n))]
   apply mul_le_mul'
   · refine' (Finset.prod_le_prod' fun p _ => (_ : f p ≤ 2 * n)).trans _
@@ -188,18 +188,18 @@ namespace Nat
 
 /-- Proves that **Bertrand's postulate** holds for all sufficiently large `n`.
 -/
-theorem exists_prime_lt_and_le_two_mul_eventually (n : ℕ) (n_big : 512 ≤ n) :
+theorem exists_prime_lt_and_le_two_mul_eventually (n : ℕ) (n_large : 512 ≤ n) :
     ∃ p : ℕ, p.Prime ∧ n < p ∧ p ≤ 2 * n := by
   -- Assume there is no prime in the range.
   by_contra no_prime
   -- Then we have the above sub-exponential bound on the size of this central binomial coefficient.
   -- We now couple this bound with an exponential lower bound on the central binomial coefficient,
   -- yielding an inequality which we have seen is false for large enough n.
-  have H1 : n * (2 * n) ^ sqrt (2 * n) * 4 ^ (2 * n / 3) ≤ 4 ^ n := bertrand_main_inequality n_big
+  have H1 : n * (2 * n) ^ sqrt (2 * n) * 4 ^ (2 * n / 3) ≤ 4 ^ n := bertrand_main_inequality n_large
   have H2 : 4 ^ n < n * n.centralBinom :=
-    Nat.four_pow_lt_mul_centralBinom n (le_trans (by norm_num1) n_big)
+    Nat.four_pow_lt_mul_centralBinom n (le_trans (by norm_num1) n_large)
   have H3 : n.centralBinom ≤ (2 * n) ^ sqrt (2 * n) * 4 ^ (2 * n / 3) :=
-    centralBinom_le_of_no_bertrand_prime n (lt_of_lt_of_le (by norm_num1) n_big) no_prime
+    centralBinom_le_of_no_bertrand_prime n (lt_of_lt_of_le (by norm_num1) n_large) no_prime
   rw [mul_assoc] at H1; exact not_le.2 H2 ((mul_le_mul_left' H3 n).trans H1)
 #align nat.exists_prime_lt_and_le_two_mul_eventually Nat.exists_prime_lt_and_le_two_mul_eventually
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
