### PR TITLE
[Merged by Bors] - refactor: remove simp attribute from yonedaEquiv_apply

### DIFF
--- a/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
+++ b/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
@@ -488,7 +488,7 @@ theorem extension_iff_amalgamation {P : Cᵒᵖ ⥤ Type v₁} (x : S.functor �
   · rintro rfl Y f hf
     rw [yonedaEquiv_naturality]
     dsimp
-    simp
+    simp [yonedaEquiv_apply]
   -- See note [dsimp, simp].
   · intro h
     ext Y ⟨f, hf⟩

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -400,7 +400,6 @@ def yonedaEquiv {X : C} {F : Cᵒᵖ ⥤ Type v₁} : (yoneda.obj X ⟶ F) ≃ F
   (yonedaSections X F).toEquiv.trans Equiv.ulift
 #align category_theory.yoneda_equiv CategoryTheory.yonedaEquiv
 
-@[simp]
 theorem yonedaEquiv_apply {X : C} {F : Cᵒᵖ ⥤ Type v₁} (f : yoneda.obj X ⟶ F) :
     yonedaEquiv f = f.app (op X) (𝟙 X) :=
   rfl


### PR DESCRIPTION
---

I'm currently working on a proof where `yonedaEquiv_apply` as a simp lemma does much more harm than good, so given that there is only one proof currently in mathlib which used this as a `simp` lemma I suggest removing the `simp` attribute.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
