### PR TITLE
[Merged by Bors] - doc(docs/100.yaml): add Mathlib ref for sum over 1/p

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -335,7 +335,8 @@
   title  : Divergence of the Prime Reciprocal Series
   links  :
     mathlib archive : https://github.com/leanprover-community/mathlib4/blob/master/Archive/Wiedijk100Theorems/SumOfPrimeReciprocalsDiverges.lean
-  author : Manuel Candales
+  decl   : not_summable_one_div_on_primes
+  author : Manuel Candales (archive), Michael Stoll (Mathlib)
 82:
   title  : Dissection of Cubes (J.E. Littlewood’s ‘elegant’ proof)
   links :


### PR DESCRIPTION
I noticed that the statement that the sum over primes of `1/p` diverges is one of Wiedijk's "100 Theorems". There is a version in the `Archive/` folder, but it was also recently added to Mathlib. This PR attempts to update the `100.yaml` file accordingly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
