### PR TITLE
chore: cleanup @[eqns]

### DIFF
--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -1251,7 +1251,6 @@ theorem K'.elim_aux (a b c d) : K'.elim a b c d K'.aux = c := rfl
 
 theorem K'.elim_stack (a b c d) : K'.elim a b c d K'.stack = d := rfl
 
-attribute [eqns K'.elim_main K'.elim_rev K'.elim_aux K'.elim_stack] K'.elim
 attribute [simp] K'.elim
 
 @[simp]

--- a/Mathlib/Data/Ordmap/Ordset.lean
+++ b/Mathlib/Data/Ordmap/Ordset.lean
@@ -280,7 +280,7 @@ theorem rotateR_node (sz : ℕ) (l : Ordnode α) (x : α) (m : Ordnode α) (y : 
 theorem rotateR_nil (y : α) (r : Ordnode α) : rotateR nil y r = node' nil y r :=
   rfl
 
-  attribute [eqns rotateR_node rotateR_nil] rotateR
+attribute [eqns rotateR_node rotateR_nil] rotateR
 
 -- should not happen
 /-- A left balance operation. This will rebalance a concatenation, assuming the original nodes are

--- a/test/eqns.lean
+++ b/test/eqns.lean
@@ -1,20 +1,6 @@
 import Mathlib.Tactic.Eqns
 import Std.Tactic.GuardMsgs
 
-def transpose {m n} (A : m → n → Nat) : n → m → Nat
-  | i, j => A j i
-
-theorem transpose_apply {m n} (A : m → n → Nat) (i j) : transpose A i j = A j i := rfl
-
-attribute [eqns transpose_apply] transpose
-
-theorem transpose_const {m n} (c : Nat) :
-    transpose (fun (_i : m) (_j : n) => c) = fun _j _i => c := by
-  fail_if_success {rw [transpose]}
-  fail_if_success {simp [transpose]}
-  funext i j -- the rw below does not work without this line
-  rw [transpose]
-
 def t : Nat := 0 + 1
 
 theorem t_def : t = 1 := rfl


### PR DESCRIPTION
The main example in the doc-string and `test/eqns.lean` doesn't seem to be a great example: we have the same behaviour with or without the `eqns` attribute!

@eric-wieser, I'm hoping you might be open to rewriting the doc-string to show a better example?

I also removed some `[eqns]` attributes in Mathlib/Computability/TMToPartrec.lean that aren't needed; no objection to reverting this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
