### PR TITLE
feat: remove Algebra.cast

### DIFF
--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -121,15 +121,13 @@ def algebraMap (R : Type u) (A : Type v) [CommSemiring R] [Semiring A] [Algebra 
   Algebra.toRingHom
 #align algebra_map algebraMap
 
-/-- Coercion from a commutative semiring to an algebra over this semiring. -/
-@[coe] def Algebra.cast {R A : Type*} [CommSemiring R] [Semiring A] [Algebra R A] : R → A :=
-  algebraMap R A
+attribute [coe] algebraMap
 
 namespace algebraMap
 
 scoped instance coeHTCT (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A] :
     CoeHTCT R A :=
-  ⟨Algebra.cast⟩
+  ⟨algebraMap _ _⟩
 #align algebra_map.has_lift_t algebraMap.coeHTCT
 
 section CommSemiringSemiring

--- a/Mathlib/Data/IsROrC/Basic.lean
+++ b/Mathlib/Data/IsROrC/Basic.lean
@@ -90,7 +90,7 @@ namespace IsROrC
 open ComplexConjugate
 
 /-- Coercion from `ℝ` to an `IsROrC` field. -/
-@[coe] abbrev ofReal : ℝ → K := Algebra.cast
+@[coe] abbrev ofReal : ℝ → K := algebraMap ℝ K
 
 /- The priority must be set at 900 to ensure that coercions are tried in the right order.
 See Note [coercion into rings], or `Mathlib/Data/Nat/Cast/Basic.lean` for more details. -/

--- a/Mathlib/Data/Real/NNReal.lean
+++ b/Mathlib/Data/Real/NNReal.lean
@@ -270,6 +270,8 @@ instance {M : Type*} [AddCommMonoid M] [Module ℝ M] : Module ℝ≥0 M :=
   Module.compHom M toRealHom
 
 -- porting note: TODO: after this line, `↑` uses `Algebra.cast` instead of `toReal`
+-- note (kmb) : I don't understand this note: the coercion from where to where?
+-- the coercion from ℝ≥0 to ℝ is still `toReal` after this declaration
 /-- An `Algebra` over `ℝ` restricts to an `Algebra` over `ℝ≥0`. -/
 instance {A : Type*} [Semiring A] [Algebra ℝ A] : Algebra ℝ≥0 A where
   smul := (· • ·)

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -88,7 +88,7 @@ variable {R K}
 
 @[norm_cast, simp]
 -- Porting note: using `↑` didn't work, so I needed to explicitly put in the cast myself
-theorem coe_inj {a b : R} : (Algebra.cast a : K) = Algebra.cast b ↔ a = b :=
+theorem coe_inj {a b : R} : algebraMap R K a = algebraMap R K b ↔ a = b :=
   (IsFractionRing.injective R K).eq_iff
 #align is_fraction_ring.coe_inj IsFractionRing.coe_inj
 


### PR DESCRIPTION
I don't really understand why this declaration exists so I thought I'd remove it to see what happens.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I will be the first to admit that I do not understand the subtleties of coercions at all. What is the reason it's set up as it is?