### PR TITLE
[Merged by Bors] - doc(Mathlib/CategoryTheory): fix typo

### DIFF
--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -31,7 +31,7 @@ like `mk₁ f`, `mk₂ f g`, `mk₃ f g h` for `ComposableArrows C n` for small 
 TODO (@joelriou):
 * redefine `Arrow C` as `ComposableArrow C 1`?
 * construct some elements in `ComposableArrows m (Fin (n + 1))` for small `n`
-the precomposition with which shall induce funtors
+the precomposition with which shall induce functors
 `ComposableArrows C n ⥤ ComposableArrows C m` which correspond to simplicial operations
 (specifically faces) with good definitional properties (this might be necessary for
 up to `n = 7` in order to formalize spectral sequences following Verdier)


### PR DESCRIPTION
Fix minor typo in `Mathlib/CategoryTheory/ComposableArrows.lean`.