### PR TITLE
feat: allow anyone to add basic labels, via comments

### DIFF
--- a/.github/workflows/add_label_from_comment.yml
+++ b/.github/workflows/add_label_from_comment.yml
@@ -141,3 +141,36 @@ jobs:
           curl --request DELETE \
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-review \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+
+  update-label:
+    if: github.event.issue.pull_request != null && (github.event.comment.body == 'awaiting-review' || github.event.comment.body == 'awaiting-author' || github.event.comment.body == 'WIP')
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Remove all relevant labels
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { owner, repo, number: issue_number } = context.issue;
+
+          // Remove the labels if they exist
+          await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'awaiting-review' }).catch(() => {});
+          await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'awaiting-author' }).catch(() => {});
+          await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'WIP' }).catch(() => {});
+
+    - name: Add label based on comment
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { owner, repo, number: issue_number  } = context.issue;
+          const commentBody = context.payload.comment.body;
+
+          if (commentBody == 'awaiting-review') {
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['awaiting-review'] });
+          } else if (commentBody == 'awaiting-author') {
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['awaiting-author'] });
+          } else if (commentBody == 'WIP') {
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['WIP'] });
+          }


### PR DESCRIPTION
Not everyone contributes to Mathlib by first asking for write permission: see #7339 for an example.

For those users, it's nice if it is at least possible to change `awaiting-review` and `awaiting-author` labels.

This PR copies across the existing functionality for this from Std.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
