### PR TITLE
[Merged by Bors] - feat: `DistribSMul R R` instance for `NonUnitalNonAssocSemiring R`

### DIFF
--- a/Mathlib/Algebra/SMulWithZero.lean
+++ b/Mathlib/Algebra/SMulWithZero.lean
@@ -233,3 +233,7 @@ def smulMonoidWithZeroHom {α β : Type*} [MonoidWithZero α] [MulZeroOneClass �
   { smulMonoidHom with map_zero' := smul_zero _ }
 #align smul_monoid_with_zero_hom smulMonoidWithZeroHom
 #align smul_monoid_with_zero_hom_apply smulMonoidWithZeroHom_apply
+
+-- This instance seems a bit incongruous in this file, but `#find_home!` told me to put it here.
+instance NonUnitalNonAssocSemiring.DistribSMul [NonUnitalNonAssocSemiring R] : DistribSMul R R where
+  smul_add := mul_add

--- a/Mathlib/Algebra/SMulWithZero.lean
+++ b/Mathlib/Algebra/SMulWithZero.lean
@@ -235,5 +235,6 @@ def smulMonoidWithZeroHom {α β : Type*} [MonoidWithZero α] [MulZeroOneClass �
 #align smul_monoid_with_zero_hom_apply smulMonoidWithZeroHom_apply
 
 -- This instance seems a bit incongruous in this file, but `#find_home!` told me to put it here.
-instance NonUnitalNonAssocSemiring.toDistribSMul [NonUnitalNonAssocSemiring R] : DistribSMul R R where
+instance NonUnitalNonAssocSemiring.toDistribSMul [NonUnitalNonAssocSemiring R] :
+    DistribSMul R R where
   smul_add := mul_add

--- a/Mathlib/Algebra/SMulWithZero.lean
+++ b/Mathlib/Algebra/SMulWithZero.lean
@@ -235,5 +235,5 @@ def smulMonoidWithZeroHom {α β : Type*} [MonoidWithZero α] [MulZeroOneClass �
 #align smul_monoid_with_zero_hom_apply smulMonoidWithZeroHom_apply
 
 -- This instance seems a bit incongruous in this file, but `#find_home!` told me to put it here.
-instance NonUnitalNonAssocSemiring.DistribSMul [NonUnitalNonAssocSemiring R] : DistribSMul R R where
+instance NonUnitalNonAssocSemiring.toDistribSMul [NonUnitalNonAssocSemiring R] : DistribSMul R R where
   smul_add := mul_add


### PR DESCRIPTION
Nonunital Nonassociative semirings act (in some sense) on themselves by multiplication, and this multiplication satisfies the requirements of the `DistribSMul` class.  This is part of a refactor of HahnSeries that includes having `HahnSeries Γ R` act on `HahnSeries Γ V` for `V` an `R`-module.

I'm not sure about the best file for this instance.  `#find_home!` suggested `Mathlib.Algebra.SMulWithZero`, but it looks a bit strange there.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
