### PR TITLE
[Merged by Bors] - chore: update style exceptions

### DIFF
--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -32,7 +32,6 @@ Mathlib/Data/ByteArray.lean : line 5 : ERR_COP : Malformed or missing copyright 
 Mathlib/Data/ByteArray.lean : line 5 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Data/Complex/Exponential.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2046 lines, try to split it up
 Mathlib/Data/DFinsupp/Basic.lean : line 1 : ERR_NUM_LIN : 2500 file contains 2395 lines, try to split it up
-Mathlib/Data/ENNReal/Basic.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2716 lines, try to split it up
 Mathlib/Data/Fin/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2010 lines, try to split it up
 Mathlib/Data/Finset/Basic.lean : line 1 : ERR_NUM_LIN : 4100 file contains 3992 lines, try to split it up
 Mathlib/Data/Finset/Lattice.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2240 lines, try to split it up
@@ -117,7 +116,7 @@ Mathlib/Order/LiminfLimsup.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1504
 Mathlib/Order/LocallyFinite.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1534 lines, try to split it up
 Mathlib/Order/SuccPred/Basic.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1560 lines, try to split it up
 Mathlib/Order/UpperLower/Basic.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2019 lines, try to split it up
-Mathlib/RingTheory/FractionalIdeal/Basic.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1691 lines, try to split it up
+Mathlib/RingTheory/DedekindDomain/Ideal.lean : line 1 : ERR_NUM_LIN: 1700 file contains 1542 lines, try to split it up
 Mathlib/RingTheory/HahnSeries.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1835 lines, try to split it up
 Mathlib/RingTheory/Ideal/Operations.lean : line 1 : ERR_NUM_LIN : 2600 file contains 2414 lines, try to split it up
 Mathlib/RingTheory/PowerSeries/Basic.lean : line 1 : ERR_NUM_LIN : 3000 file contains 2865 lines, try to split it up


### PR DESCRIPTION
- two long files have been split now (remove their entries)
- add an exception for `DedekindDomain/Ideal.lean`, which #9727 pushed over the limit

-----------

I'm not entirely sure why #9727 merged cleanly: part of the reason might be that it was created before the large file linter landed...

@RubenVandeVelde Do you happen to have a spare moment to split some material off `Ideal.lean`? (I'm not expert on that part of the library.) No obligations at all --- but *if* you do have time for the split, now could be a great moment to do so.