### PR TITLE
feat: allow preorders in Disjoint

### DIFF
--- a/Mathlib/Order/Disjoint.lean
+++ b/Mathlib/Order/Disjoint.lean
@@ -29,9 +29,9 @@ variable {α : Type*}
 
 section Disjoint
 
-section PartialOrderBot
+section PreOrderBot
 
-variable [PartialOrder α] [OrderBot α] {a b c d : α}
+variable [Preorder α] [OrderBot α] {a b c d : α}
 
 /-- Two elements of a lattice are disjoint if their inf is the bottom element.
   (This generalizes disjoint sets, viewed as members of the subset lattice.)
@@ -80,11 +80,16 @@ theorem Disjoint.mono_right : b ≤ c → Disjoint a c → Disjoint a b :=
   Disjoint.mono le_rfl
 #align disjoint.mono_right Disjoint.mono_right
 
+end PreOrderBot
+
+section PartialOrderBot
+
+variable [PartialOrder α] [OrderBot α] {a b c d : α}
+
 @[simp]
 theorem disjoint_self : Disjoint a a ↔ a = ⊥ :=
   ⟨fun hd ↦ bot_unique <| hd le_rfl le_rfl, fun h _ ha _ ↦ ha.trans_eq h⟩
 #align disjoint_self disjoint_self
-
 /- TODO: Rename `Disjoint.eq_bot` to `Disjoint.inf_eq` and `Disjoint.eq_bot_of_self` to
 `Disjoint.eq_bot` -/
 alias ⟨Disjoint.eq_bot_of_self, _⟩ := disjoint_self

--- a/Mathlib/Order/Disjoint.lean
+++ b/Mathlib/Order/Disjoint.lean
@@ -29,7 +29,7 @@ variable {α : Type*}
 
 section Disjoint
 
-section PreOrderBot
+section PreorderBot
 
 variable [Preorder α] [OrderBot α] {a b c d : α}
 
@@ -80,7 +80,7 @@ theorem Disjoint.mono_right : b ≤ c → Disjoint a c → Disjoint a b :=
   Disjoint.mono le_rfl
 #align disjoint.mono_right Disjoint.mono_right
 
-end PreOrderBot
+end PreorderBot
 
 section PartialOrderBot
 

--- a/Mathlib/Order/Disjoint.lean
+++ b/Mathlib/Order/Disjoint.lean
@@ -90,6 +90,7 @@ variable [PartialOrder α] [OrderBot α] {a b c d : α}
 theorem disjoint_self : Disjoint a a ↔ a = ⊥ :=
   ⟨fun hd ↦ bot_unique <| hd le_rfl le_rfl, fun h _ ha _ ↦ ha.trans_eq h⟩
 #align disjoint_self disjoint_self
+
 /- TODO: Rename `Disjoint.eq_bot` to `Disjoint.inf_eq` and `Disjoint.eq_bot_of_self` to
 `Disjoint.eq_bot` -/
 alias ⟨Disjoint.eq_bot_of_self, _⟩ := disjoint_self


### PR DESCRIPTION
It's convenient to have a way of saying "coprime" in a unique factorization monoid; we can't currently use Disjoint because the divisibility preorder on a UFM isn't in general a partial order. 

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Coprime.20if.20product.20is.20squarefree/near/419341762)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
