### PR TITLE
[Merged by Bors] - refactor: Make `Nat.floorRoot` computable

### DIFF
--- a/Mathlib/Algebra/Order/Floor/Div.lean
+++ b/Mathlib/Algebra/Order/Floor/Div.lean
@@ -238,7 +238,8 @@ noncomputable instance instFloorDiv : FloorDiv α (ι →₀ β) where
   floorDiv_nonpos a ha f := by ext i; exact floorDiv_of_nonpos ha _
   zero_floorDiv a := by ext; exact zero_floorDiv _
 
-lemma floorDiv_def (f : ι →₀ β) (a : α) : f ⌊/⌋ a = fun i ↦ f i ⌊/⌋ a := rfl
+lemma floorDiv_def (f : ι →₀ β) (a : α) : f ⌊/⌋ a = f.mapRange (· ⌊/⌋ a) (zero_floorDiv _) := rfl
+@[norm_cast] lemma coe_floorDiv (f : ι →₀ β) (a : α) : f ⌊/⌋ a = fun i ↦ f i ⌊/⌋ a := rfl
 @[simp] lemma floorDiv_apply (f : ι →₀ β) (a : α) (i : ι) : (f ⌊/⌋ a) i = f i ⌊/⌋ a := rfl
 
 lemma support_floorDiv_subset : (f ⌊/⌋ a).support ⊆ f.support := by
@@ -250,13 +251,14 @@ section CeilDiv
 variable [CeilDiv α β] {f : ι →₀ β} {a : α}
 
 noncomputable instance instCeilDiv : CeilDiv α (ι →₀ β) where
-  ceilDiv f a := f.mapRange (· ⌈/⌉ a) <| by simp
+  ceilDiv f a := f.mapRange (· ⌈/⌉ a) <| zero_ceilDiv _
   ceilDiv_gc _a ha f _g := forall_congr' fun i ↦ by
     simpa only [coe_smul, Pi.smul_apply, mapRange_apply] using gc_smul_ceilDiv ha (f i) _
   ceilDiv_nonpos a ha f := by ext i; exact ceilDiv_of_nonpos ha _
   zero_ceilDiv a := by ext; exact zero_ceilDiv _
 
-lemma ceilDiv_def (f : ι →₀ β) (a : α) : f ⌈/⌉ a = fun i ↦ f i ⌈/⌉ a := rfl
+lemma ceilDiv_def (f : ι →₀ β) (a : α) : f ⌈/⌉ a = f.mapRange (· ⌈/⌉ a) (zero_ceilDiv _) := rfl
+@[norm_cast] lemma coe_ceilDiv_def (f : ι →₀ β) (a : α) : f ⌈/⌉ a = fun i ↦ f i ⌈/⌉ a := rfl
 @[simp] lemma ceilDiv_apply (f : ι →₀ β) (a : α) (i : ι) : (f ⌈/⌉ a) i = f i ⌈/⌉ a := rfl
 
 lemma support_ceilDiv_subset : (f ⌈/⌉ a).support ⊆ f.support := by

--- a/Mathlib/Data/Nat/Factorization/Root.lean
+++ b/Mathlib/Data/Nat/Factorization/Root.lean
@@ -26,7 +26,6 @@ multiple of `a` as the multiples of some fixed number (aka `ceilRoot n a`). See
 ## TODO
 
 * `norm_num` extension
-* Computable `csimp` version
 -/
 
 open Finsupp
@@ -47,8 +46,14 @@ we special-case the following values:
 * `floorRoot 0 a = 0`
 * `floorRoot n 0 = 0`
 -/
-noncomputable def floorRoot (n a : ℕ) : ℕ :=
-  if n = 0 ∨ a = 0 then 0 else (a.factorization ⌊/⌋ n).prod (· ^ ·)
+def floorRoot (n a : ℕ) : ℕ :=
+  if n = 0 ∨ a = 0 then 0 else a.factorization.prod fun p k ↦ p ^ (k / n)
+
+/-- The RHS is a noncomputable version of `Nat.floorRoot` with better order theoretical
+properties. -/
+lemma floorRoot_def :
+    floorRoot n a = if n = 0 ∨ a = 0 then 0 else (a.factorization ⌊/⌋ n).prod (· ^ ·) := by
+  unfold floorRoot; split_ifs with h <;> simp [Finsupp.floorDiv_def, prod_mapRange_index pow_zero]
 
 @[simp] lemma floorRoot_zero_left (a : ℕ) : floorRoot 0 a = 0 := by simp [floorRoot]
 @[simp] lemma floorRoot_zero_right (n : ℕ) : floorRoot n 0 = 0 := by simp [floorRoot]
@@ -57,7 +62,7 @@ noncomputable def floorRoot (n a : ℕ) : ℕ :=
 @[simp] lemma floorRoot_one_right (hn : n ≠ 0) : floorRoot n 1 = 1 := by simp [floorRoot, hn]
 
 @[simp] lemma floorRoot_pow_self (hn : n ≠ 0) (a : ℕ) : floorRoot n (a ^ n) = a := by
-  simp [floorRoot, pos_iff_ne_zero.2, hn]; split_ifs <;> simp [*]
+  simp [floorRoot_def, pos_iff_ne_zero.2, hn]; split_ifs <;> simp [*]
 
 lemma floorRoot_ne_zero : floorRoot n a ≠ 0 ↔ n ≠ 0 ∧ a ≠ 0 := by
   simp (config := { contextual := true }) [floorRoot, not_imp_not, not_or]
@@ -67,7 +72,7 @@ lemma floorRoot_ne_zero : floorRoot n a ≠ 0 ↔ n ≠ 0 ∧ a ≠ 0 := by
 
 @[simp] lemma factorization_floorRoot (n a : ℕ) :
     (floorRoot n a).factorization = a.factorization ⌊/⌋ n := by
-  unfold floorRoot
+  rw [floorRoot_def]
   split_ifs with h
   · obtain rfl | rfl := h <;> simp
   refine prod_pow_factorization_eq_self fun p hp ↦ ?_
@@ -101,8 +106,16 @@ we special-case the following values:
 * `ceilRoot 0 a = 0` (this one is not strictly necessary)
 * `ceilRoot n 0 = 0`
 -/
-noncomputable def ceilRoot (n a : ℕ) : ℕ :=
-  if n = 0 ∨ a = 0 then 0 else (a.factorization ⌈/⌉ n).prod (· ^ ·)
+def ceilRoot (n a : ℕ) : ℕ :=
+  if n = 0 ∨ a = 0 then 0 else a.factorization.prod fun p k ↦ p ^ ((k + n - 1) / n)
+
+/-- The RHS is a noncomputable version of `Nat.ceilRoot` with better order theoretical
+properties. -/
+lemma ceilRoot_def :
+    ceilRoot n a = if n = 0 ∨ a = 0 then 0 else (a.factorization ⌈/⌉ n).prod (· ^ ·) := by
+  unfold ceilRoot
+  split_ifs with h <;>
+    simp [Finsupp.ceilDiv_def, prod_mapRange_index pow_zero, Nat.ceilDiv_eq_add_pred_div]
 
 @[simp] lemma ceilRoot_zero_left (a : ℕ) : ceilRoot 0 a = 0 := by simp [ceilRoot]
 @[simp] lemma ceilRoot_zero_right (n : ℕ) : ceilRoot n 0 = 0 := by simp [ceilRoot]
@@ -111,17 +124,17 @@ noncomputable def ceilRoot (n a : ℕ) : ℕ :=
 @[simp] lemma ceilRoot_one_right (hn : n ≠ 0) : ceilRoot n 1 = 1 := by simp [ceilRoot, hn]
 
 @[simp] lemma ceilRoot_pow_self (hn : n ≠ 0) (a : ℕ) : ceilRoot n (a ^ n) = a := by
-  simp [ceilRoot, pos_iff_ne_zero.2, hn]; split_ifs <;> simp [*]
+  simp [ceilRoot_def, pos_iff_ne_zero.2, hn]; split_ifs <;> simp [*]
 
 lemma ceilRoot_ne_zero : ceilRoot n a ≠ 0 ↔ n ≠ 0 ∧ a ≠ 0 := by
-  simp (config := { contextual := true }) [ceilRoot, not_imp_not, not_or]
+  simp (config := { contextual := true }) [ceilRoot_def, not_imp_not, not_or]
 
 @[simp] lemma ceilRoot_eq_zero : ceilRoot n a = 0 ↔ n = 0 ∨ a = 0 :=
   ceilRoot_ne_zero.not_right.trans $ by simp only [not_and_or, ne_eq, not_not]
 
 @[simp] lemma factorization_ceilRoot (n a : ℕ) :
     (ceilRoot n a).factorization = a.factorization ⌈/⌉ n := by
-  unfold ceilRoot
+  rw [ceilRoot_def]
   split_ifs with h
   · obtain rfl | rfl := h <;> simp
   refine prod_pow_factorization_eq_self fun p hp ↦ ?_


### PR DESCRIPTION
Avoiding `Finsupp.mapRange` means that we can actually compute the function.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
