### PR TITLE
[Merged by Bors] - feat(Topology): Define `PerfectSpace`

### DIFF
--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -98,10 +98,10 @@ Equivalently, this means that `𝓝[≠] x ≠ ⊥` for every point `x : X`.
 -/
 @[mk_iff perfectSpace_def]
 class PerfectSpace: Prop :=
-  univ_perfect' : Perfect (Set.univ : Set α)
+  univ_preperfect : Preperfect (Set.univ : Set α)
 
 theorem PerfectSpace.univ_perfect [PerfectSpace α] : Perfect (Set.univ : Set α) :=
-  PerfectSpace.univ_perfect'
+  ⟨isClosed_univ, PerfectSpace.univ_preperfect⟩
 
 end PerfectSpace
 
@@ -242,7 +242,7 @@ section PerfectSpace
 variable {X : Type*} [TopologicalSpace X]
 
 theorem perfectSpace_iff_forall_not_isolated : PerfectSpace X ↔ ∀ x : X, Filter.NeBot (𝓝[≠] x) := by
-  simp [perfectSpace_def, perfect_def, Preperfect, AccPt]
+  simp [perfectSpace_def, Preperfect, AccPt]
 
 instance PerfectSpace.not_isolated [PerfectSpace X] (x : X) : Filter.NeBot (𝓝[≠] x) :=
   perfectSpace_iff_forall_not_isolated.mp ‹_› x

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -51,10 +51,7 @@ accumulation point, perfect set, cantor-bendixson.
 -/
 
 
-open Topology Filter
-
-open Filter Set
-open TopologicalSpace (IsTopologicalBasis)
+open Topology Filter Set TopologicalSpace
 
 section Basic
 
@@ -90,16 +87,21 @@ theorem preperfect_iff_nhds : Preperfect C ↔ ∀ x ∈ C, ∀ U ∈ 𝓝 x, �
   simp only [Preperfect, accPt_iff_nhds]
 #align preperfect_iff_nhds preperfect_iff_nhds
 
+section PerfectSpace
+
+variable (α)
+
 /--
 A topological space `X` is said to be perfect if its universe is a perfect set.
 Equivalently, this means that `𝓝[≠] x ≠ ⊥` for every point `x : X`.
 -/
-class PerfectSpace (X : Type*) [TopologicalSpace X]: Prop :=
-  univ_perfect' : Perfect (Set.univ : Set X)
+class PerfectSpace: Prop :=
+  univ_perfect' : Perfect (Set.univ : Set α)
 
-variable [PerfectSpace α] in
-variable (α) in
-theorem PerfectSpace.univ_perfect : Perfect (Set.univ : Set α) := PerfectSpace.univ_perfect'
+theorem PerfectSpace.univ_perfect [PerfectSpace α] : Perfect (Set.univ : Set α) :=
+    PerfectSpace.univ_perfect'
+
+end PerfectSpace
 
 section Preperfect
 
@@ -237,8 +239,7 @@ section PerfectSpace
 
 variable {X : Type*} [TopologicalSpace X]
 
-variable [PerfectSpace X] in
-instance PerfectSpace.not_isolated (x : X): Filter.NeBot (𝓝[≠] x) := by
+instance PerfectSpace.not_isolated [PerfectSpace X] (x : X) : Filter.NeBot (𝓝[≠] x) := by
   have := (PerfectSpace.univ_perfect X).acc _ (Set.mem_univ x)
   rwa [AccPt, Filter.principal_univ, inf_top_eq] at this
 

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -78,6 +78,7 @@ def Preperfect (C : Set α) : Prop :=
 /-- A set `C` is called perfect if it is closed and all of its
 points are accumulation points of itself.
 Note that we do not require `C` to be nonempty.-/
+@[mk_iff perfect_def]
 structure Perfect (C : Set α) : Prop where
   closed : IsClosed C
   acc : Preperfect C
@@ -95,11 +96,12 @@ variable (α)
 A topological space `X` is said to be perfect if its universe is a perfect set.
 Equivalently, this means that `𝓝[≠] x ≠ ⊥` for every point `x : X`.
 -/
+@[mk_iff perfectSpace_def]
 class PerfectSpace: Prop :=
   univ_perfect' : Perfect (Set.univ : Set α)
 
 theorem PerfectSpace.univ_perfect [PerfectSpace α] : Perfect (Set.univ : Set α) :=
-    PerfectSpace.univ_perfect'
+  PerfectSpace.univ_perfect'
 
 end PerfectSpace
 
@@ -239,13 +241,10 @@ section PerfectSpace
 
 variable {X : Type*} [TopologicalSpace X]
 
-instance PerfectSpace.not_isolated [PerfectSpace X] (x : X) : Filter.NeBot (𝓝[≠] x) := by
-  have := (PerfectSpace.univ_perfect X).acc _ (Set.mem_univ x)
-  rwa [AccPt, Filter.principal_univ, inf_top_eq] at this
+theorem perfectSpace_iff_forall_not_isolated : PerfectSpace X ↔ ∀ x : X, Filter.NeBot (𝓝[≠] x) := by
+  simp [perfectSpace_def, perfect_def, Preperfect, AccPt]
 
-theorem perfectSpace_iff_forall_not_isolated : PerfectSpace X ↔ ∀ x : X, Filter.NeBot (𝓝[≠] x) :=
-  ⟨fun perfect x => perfect.not_isolated x, fun h_forall => ⟨⟨isClosed_univ, fun x _ => by
-    rw [AccPt, Filter.principal_univ, inf_top_eq]
-    exact h_forall x⟩⟩⟩
+instance PerfectSpace.not_isolated [PerfectSpace X] (x : X) : Filter.NeBot (𝓝[≠] x) :=
+  perfectSpace_iff_forall_not_isolated.mp ‹_› x
 
 end PerfectSpace

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -237,16 +237,19 @@ section PerfectSpace
 
 variable {X : Type*} [TopologicalSpace X]
 
-theorem perfectSpace_of_forall_not_isolated (h_forall : ∀ x : X, Filter.NeBot (𝓝[≠] x)) :
-    PerfectSpace X := ⟨⟨isClosed_univ, fun x _ => by
-  rw [AccPt, Filter.principal_univ, inf_top_eq]
-  exact h_forall x⟩⟩
-
-variable [PerfectSpace X]
-
+variable [PerfectSpace X] in
 instance PerfectSpace.not_isolated (x : X): Filter.NeBot (𝓝[≠] x) := by
   have := (PerfectSpace.univ_perfect X).acc _ (Set.mem_univ x)
   rwa [AccPt, Filter.principal_univ, inf_top_eq] at this
+
+theorem perfectSpace_iff_forall_not_isolated : PerfectSpace X ↔ ∀ x : X, Filter.NeBot (𝓝[≠] x) :=
+  ⟨fun perfect x => perfect.not_isolated x, fun h_forall => ⟨⟨isClosed_univ, fun x _ => by
+    rw [AccPt, Filter.principal_univ, inf_top_eq]
+    exact h_forall x⟩⟩⟩
+
+variable [PerfectSpace X] in
+theorem PerfectSpace.preperfect_of_isOpen {s : Set X} (s_open : IsOpen s) : Preperfect s :=
+  Set.inter_univ s ▸ (PerfectSpace.univ_perfect X).acc.open_inter s_open
 
 section Prod
 
@@ -260,14 +263,14 @@ theorem nhdsWithin_punctured_prod_neBot_iff {p : X} {q : Y} : Filter.NeBot (𝓝
 
 variable (X Y) in
 instance PerfectSpace.prod_left [PerfectSpace X] : PerfectSpace (X × Y) :=
-  perfectSpace_of_forall_not_isolated fun ⟨p, q⟩ => by
+  perfectSpace_iff_forall_not_isolated.mpr fun ⟨p, q⟩ => by
     rw [nhdsWithin_punctured_prod_neBot_iff]
     left
     exact PerfectSpace.not_isolated p
 
 variable (X Y) in
 instance PerfectSpace.prod_right [PerfectSpace Y] : PerfectSpace (X × Y) :=
-  perfectSpace_of_forall_not_isolated fun ⟨p, q⟩ => by
+  perfectSpace_iff_forall_not_isolated.mpr fun ⟨p, q⟩ => by
     rw [nhdsWithin_punctured_prod_neBot_iff]
     right
     exact PerfectSpace.not_isolated q

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -247,32 +247,4 @@ theorem perfectSpace_iff_forall_not_isolated : PerfectSpace X ↔ ∀ x : X, Fil
     rw [AccPt, Filter.principal_univ, inf_top_eq]
     exact h_forall x⟩⟩⟩
 
-variable [PerfectSpace X] in
-theorem PerfectSpace.preperfect_of_isOpen {s : Set X} (s_open : IsOpen s) : Preperfect s :=
-  Set.inter_univ s ▸ (PerfectSpace.univ_perfect X).acc.open_inter s_open
-
-section Prod
-
-variable {Y : Type*} [TopologicalSpace Y]
-
-theorem nhdsWithin_punctured_prod_neBot_iff {p : X} {q : Y} : Filter.NeBot (𝓝[≠] (p, q)) ↔
-    Filter.NeBot (𝓝[≠] p) ∨ Filter.NeBot (𝓝[≠] q) := by
-  simp_rw [← Set.singleton_prod_singleton, Set.compl_prod_eq_union, nhdsWithin_union,
-    nhdsWithin_prod_eq, nhdsWithin_univ, Filter.neBot_iff, ne_eq, sup_eq_bot_iff,
-    Filter.prod_eq_bot, Filter.NeBot.ne <| nhds_neBot, or_false, false_or, not_and_or]
-
-variable (X Y) in
-instance PerfectSpace.prod_left [PerfectSpace X] : PerfectSpace (X × Y) :=
-  perfectSpace_iff_forall_not_isolated.mpr fun ⟨p, q⟩ => by
-    rw [nhdsWithin_punctured_prod_neBot_iff]
-    left
-    exact PerfectSpace.not_isolated p
-
-variable (X Y) in
-instance PerfectSpace.prod_right [PerfectSpace Y] : PerfectSpace (X × Y) :=
-  perfectSpace_iff_forall_not_isolated.mpr fun ⟨p, q⟩ => by
-    rw [nhdsWithin_punctured_prod_neBot_iff]
-    right
-    exact PerfectSpace.not_isolated q
-
-end Prod
+end PerfectSpace


### PR DESCRIPTION
Introduces a new class, `PerfectSpace`, which requires that `Set.univ` is a perfect set. This is equivalent to say that no points are isolated (`perfectSpace_iff_forall_not_isolated`).

---

This PR is part of my effort to formalize Rubin's theorem into Mathlib.
See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Defining.20perfect.20spaces for the zulip discussion on this subject.

- [ ] depends on: #10272

This PR has been stripped down to only the changes that I critically need to progress in my formalization of Rubin's theorem, since I want to keep the PR chain for it as small as possible.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
