### PR TITLE
Replace instances of `∀ x, NeBot (𝓝[≠] x)` with instances of `PerfectSpace α`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3747,6 +3747,7 @@ import Mathlib.Topology.MetricSpace.Kuratowski
 import Mathlib.Topology.MetricSpace.Lipschitz
 import Mathlib.Topology.MetricSpace.MetricSeparated
 import Mathlib.Topology.MetricSpace.PartitionOfUnity
+import Mathlib.Topology.MetricSpace.Perfect
 import Mathlib.Topology.MetricSpace.PiNat
 import Mathlib.Topology.MetricSpace.Polish
 import Mathlib.Topology.MetricSpace.ProperSpace

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -698,7 +698,7 @@ theorem fderivWithin_univ : fderivWithin 𝕜 f univ = fderiv 𝕜 f := by
   nontriviality E
   have H : 𝓝[univ \ {x}] x ≠ ⊥
   · rw [← compl_eq_univ_diff, ← neBot_iff]
-    exact Module.punctured_nhds_neBot 𝕜 E x
+    exact (Module.perfectSpace 𝕜 E).not_isolated x
   simp [fderivWithin, fderiv, H]
 #align fderiv_within_univ fderivWithin_univ
 

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -9,6 +9,7 @@ import Mathlib.Analysis.Normed.Group.Basic
 import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.Topology.Instances.NNReal
 import Mathlib.Topology.MetricSpace.DilationEquiv
+import Mathlib.Topology.Perfect
 
 #align_import analysis.normed.field.basic from "leanprover-community/mathlib"@"f06058e64b7e8397234455038f3f8aec83aaba5a"
 
@@ -969,18 +970,20 @@ theorem exists_norm_lt_one : ∃ x : α, 0 < ‖x‖ ∧ ‖x‖ < 1 :=
 
 variable {α}
 
-@[instance]
-theorem punctured_nhds_neBot (x : α) : NeBot (𝓝[≠] x) := by
+instance perfectSpace : PerfectSpace α := perfectSpace_iff_forall_not_isolated.mpr fun x => by
   rw [← mem_closure_iff_nhdsWithin_neBot, Metric.mem_closure_iff]
-  rintro ε ε0
-  rcases exists_norm_lt α ε0 with ⟨b, hb0, hbε⟩
-  refine' ⟨x + b, mt (Set.mem_singleton_iff.trans add_right_eq_self).1 <| norm_pos_iff.1 hb0, _⟩
+  intro ε ε0
+  have ⟨b, hb0, hbε⟩ := exists_norm_lt α ε0
+  refine ⟨x + b, mt (Set.mem_singleton_iff.trans add_right_eq_self).1 <| norm_pos_iff.1 hb0, ?lt⟩
   rwa [dist_comm, dist_eq_norm, add_sub_cancel']
+
+@[deprecated NormedField.perfectSpace]
+theorem punctured_nhds_neBot (x : α) : NeBot (𝓝[≠] x) := inferInstance
 #align normed_field.punctured_nhds_ne_bot NormedField.punctured_nhds_neBot
 
 @[instance]
 theorem nhdsWithin_isUnit_neBot : NeBot (𝓝[{ x : α | IsUnit x }] 0) := by
-  simpa only [isUnit_iff_ne_zero] using punctured_nhds_neBot (0 : α)
+  simpa only [isUnit_iff_ne_zero] using (PerfectSpace.not_isolated (0 : α))
 #align normed_field.nhds_within_is_unit_ne_bot NormedField.nhdsWithin_isUnit_neBot
 
 end Nontrivially

--- a/Mathlib/Analysis/NormedSpace/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Basic.lean
@@ -299,12 +299,20 @@ theorem range_nnnorm : range (nnnorm : E → ℝ≥0) = univ :=
 
 end Surj
 
+section PerfectSpace
+
+variable (E : Type*) [AddCommGroup E] [TopologicalSpace E] [ContinuousAdd E] [Nontrivial E]
+  [Module ℝ E] [ContinuousSMul ℝ E]
+
 /-- If `E` is a nontrivial topological module over `ℝ`, then `E` has no isolated points.
 This is a particular case of `Module.punctured_nhds_neBot`. -/
-instance Real.punctured_nhds_module_neBot {E : Type*} [AddCommGroup E] [TopologicalSpace E]
-    [ContinuousAdd E] [Nontrivial E] [Module ℝ E] [ContinuousSMul ℝ E] (x : E) : NeBot (𝓝[≠] x) :=
-  Module.punctured_nhds_neBot ℝ E x
+instance Real.module_perfectSpace : PerfectSpace E := Module.perfectSpace ℝ E
+
+@[deprecated Real.module_perfectSpace]
+theorem Real.punctured_nhds_module_neBot (x : E) : NeBot (𝓝[≠] x) := inferInstance
 #align real.punctured_nhds_module_ne_bot Real.punctured_nhds_module_neBot
+
+end PerfectSpace
 
 theorem interior_closedBall' [NormedSpace ℝ E] [Nontrivial E] (x : E) (r : ℝ) :
     interior (closedBall x r) = ball x r := by

--- a/Mathlib/MeasureTheory/Constructions/Polish.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Felix Weilacher
 -/
 import Mathlib.Data.Real.Cardinality
-import Mathlib.Topology.Perfect
+import Mathlib.Topology.MetricSpace.Perfect
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 
 #align_import measure_theory.constructions.polish from "leanprover-community/mathlib"@"9f55d0d4363ae59948c33864cbc52e0b12e0e8ce"

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -9,6 +9,7 @@ import Mathlib.Topology.Algebra.MulAction
 import Mathlib.Topology.Algebra.UniformGroup
 import Mathlib.Topology.ContinuousFunction.Basic
 import Mathlib.Topology.UniformSpace.UniformEmbedding
+import Mathlib.Topology.Perfect
 import Mathlib.Algebra.Algebra.Basic
 import Mathlib.LinearAlgebra.Projection
 import Mathlib.LinearAlgebra.Pi
@@ -77,14 +78,14 @@ variable (R M)
 /-- Let `R` be a topological ring such that zero is not an isolated point (e.g., a nontrivially
 normed field, see `NormedField.punctured_nhds_neBot`). Let `M` be a nontrivial module over `R`
 such that `c • x = 0` implies `c = 0 ∨ x = 0`. Then `M` has no isolated points. We formulate this
-using `NeBot (𝓝[≠] x)`.
+using `PerfectSpace M`.
 
 This lemma is not an instance because Lean would need to find `[ContinuousSMul ?m_1 M]` with
 unknown `?m_1`. We register this as an instance for `R = ℝ` in `Real.punctured_nhds_module_neBot`.
-One can also use `haveI := Module.punctured_nhds_neBot R M` in a proof.
+One can also use `haveI := Module.perfectSpace R M` in a proof.
 -/
-theorem Module.punctured_nhds_neBot [Nontrivial M] [NeBot (𝓝[≠] (0 : R))] [NoZeroSMulDivisors R M]
-    (x : M) : NeBot (𝓝[≠] x) := by
+theorem Module.perfectSpace [Nontrivial M] [NeBot (𝓝[≠] (0 : R))] [NoZeroSMulDivisors R M] :
+    PerfectSpace M := perfectSpace_iff_forall_not_isolated.mpr fun x => by
   rcases exists_ne (0 : M) with ⟨y, hy⟩
   suffices : Tendsto (fun c : R => x + c • y) (𝓝[≠] 0) (𝓝[≠] x); exact this.neBot
   refine' Tendsto.inf _ (tendsto_principal_principal.2 <| _)
@@ -92,6 +93,17 @@ theorem Module.punctured_nhds_neBot [Nontrivial M] [NeBot (𝓝[≠] (0 : R))] [
     rw [zero_smul, add_zero]
   · intro c hc
     simpa [hy] using hc
+
+/--
+This theorem is deprecated in favor of `Module.perfectSpace`; any
+`haveI := Module.punctured_nhds_neBot R M` can safely be replaced with
+`haveI := Module.perfectSpace R M`, as the latter provides this theorem as an instance.
+-/
+@[deprecated Module.perfectSpace]
+theorem Module.punctured_nhds_neBot [Nontrivial M] [NeBot (𝓝[≠] (0 : R))] [NoZeroSMulDivisors R M]
+    (x : M) : NeBot (𝓝[≠] x) :=
+  haveI := Module.perfectSpace R M
+  PerfectSpace.not_isolated x
 #align module.punctured_nhds_ne_bot Module.punctured_nhds_neBot
 
 end

--- a/Mathlib/Topology/Algebra/Module/Cardinality.lean
+++ b/Mathlib/Topology/Algebra/Module/Cardinality.lean
@@ -6,7 +6,7 @@ Authors: Sébastien Gouëzel
 import Mathlib.SetTheory.Cardinal.CountableCover
 import Mathlib.SetTheory.Cardinal.Continuum
 import Mathlib.Analysis.SpecificLimits.Normed
-import Mathlib.Topology.Perfect
+import Mathlib.Topology.MetricSpace.Perfect
 
 /-!
 # Cardinality of open subsets of vector spaces

--- a/Mathlib/Topology/Compactification/OnePoint.lean
+++ b/Mathlib/Topology/Compactification/OnePoint.lean
@@ -6,6 +6,7 @@ Authors: Yourong Zang, Yury Kudryashov
 import Mathlib.Data.Fintype.Option
 import Mathlib.Topology.Separation
 import Mathlib.Topology.Sets.Opens
+import Mathlib.Topology.Perfect
 
 #align_import topology.alexandroff from "leanprover-community/mathlib"@"dc6c365e751e34d100e80fe6e314c3c3e0fd2988"
 
@@ -321,11 +322,11 @@ instance nhdsWithin_compl_infty_neBot [NoncompactSpace X] : NeBot (𝓝[≠] (�
   infer_instance
 #align alexandroff.nhds_within_compl_infty_ne_bot OnePoint.nhdsWithin_compl_infty_neBot
 
-instance (priority := 900) nhdsWithin_compl_neBot [∀ x : X, NeBot (𝓝[≠] x)] [NoncompactSpace X]
-    (x : OnePoint X) : NeBot (𝓝[≠] x) :=
+instance (priority := 900) perfectSpace [PerfectSpace X] [NoncompactSpace X] :
+    PerfectSpace (OnePoint X) := perfectSpace_iff_forall_not_isolated.mpr fun x =>
   OnePoint.rec OnePoint.nhdsWithin_compl_infty_neBot
     (fun y => OnePoint.nhdsWithin_compl_coe_neBot y) x
-#align alexandroff.nhds_within_compl_ne_bot OnePoint.nhdsWithin_compl_neBot
+#align alexandroff.nhds_within_compl_ne_bot OnePoint.perfectSpace
 
 theorem nhds_infty_eq : 𝓝 (∞ : OnePoint X) = map (↑) (coclosedCompact X) ⊔ pure ∞ := by
   rw [← nhdsWithin_compl_infty_eq, nhdsWithin_compl_singleton_sup_pure]

--- a/Mathlib/Topology/MetricSpace/Perfect.lean
+++ b/Mathlib/Topology/MetricSpace/Perfect.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2022 Felix Weilacher. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Felix Weilacher
+-/
+
+import Mathlib.Topology.Perfect
+import Mathlib.Topology.MetricSpace.Polish
+import Mathlib.Topology.MetricSpace.CantorScheme
+
+/-!
+# Perfect Sets
+
+In this file we define properties of `Perfect` subsets of a metric space,
+including a version of the Cantor-Bendixson Theorem.
+
+## Main Statements
+
+* `Perfect.exists_nat_bool_injection`: A perfect nonempty set in a complete metric space
+  admits an embedding from the Cantor space.
+
+## References
+
+* [kechris1995] (Chapters 6-7)
+
+## Tags
+
+accumulation point, perfect set, cantor-bendixson.
+
+--/
+
+section CantorInjMetric
+
+open Function ENNReal Set Filter
+
+variable {α : Type*} [MetricSpace α] {C : Set α} (hC : Perfect C) {ε : ℝ≥0∞}
+
+private theorem Perfect.small_diam_aux (ε_pos : 0 < ε) {x : α} (xC : x ∈ C) :
+    let D := closure (EMetric.ball x (ε / 2) ∩ C)
+    Perfect D ∧ D.Nonempty ∧ D ⊆ C ∧ EMetric.diam D ≤ ε := by
+  have : x ∈ EMetric.ball x (ε / 2) := by
+    apply EMetric.mem_ball_self
+    rw [ENNReal.div_pos_iff]
+    exact ⟨ne_of_gt ε_pos, by norm_num⟩
+  have := hC.closure_nhds_inter x xC this EMetric.isOpen_ball
+  refine' ⟨this.1, this.2, _, _⟩
+  · rw [IsClosed.closure_subset_iff hC.closed]
+    apply inter_subset_right
+  rw [EMetric.diam_closure]
+  apply le_trans (EMetric.diam_mono (inter_subset_left _ _))
+  convert EMetric.diam_ball (x := x)
+  rw [mul_comm, ENNReal.div_mul_cancel] <;> norm_num
+
+variable (hnonempty : C.Nonempty)
+
+/-- A refinement of `Perfect.splitting` for metric spaces, where we also control
+the diameter of the new perfect sets. -/
+theorem Perfect.small_diam_splitting (ε_pos : 0 < ε) :
+    ∃ C₀ C₁ : Set α, (Perfect C₀ ∧ C₀.Nonempty ∧ C₀ ⊆ C ∧ EMetric.diam C₀ ≤ ε) ∧
+    (Perfect C₁ ∧ C₁.Nonempty ∧ C₁ ⊆ C ∧ EMetric.diam C₁ ≤ ε) ∧ Disjoint C₀ C₁ := by
+  rcases hC.splitting hnonempty with ⟨D₀, D₁, ⟨perf0, non0, sub0⟩, ⟨perf1, non1, sub1⟩, hdisj⟩
+  cases' non0 with x₀ hx₀
+  cases' non1 with x₁ hx₁
+  rcases perf0.small_diam_aux ε_pos hx₀ with ⟨perf0', non0', sub0', diam0⟩
+  rcases perf1.small_diam_aux ε_pos hx₁ with ⟨perf1', non1', sub1', diam1⟩
+  refine'
+    ⟨closure (EMetric.ball x₀ (ε / 2) ∩ D₀), closure (EMetric.ball x₁ (ε / 2) ∩ D₁),
+      ⟨perf0', non0', sub0'.trans sub0, diam0⟩, ⟨perf1', non1', sub1'.trans sub1, diam1⟩, _⟩
+  apply Disjoint.mono _ _ hdisj <;> assumption
+#align perfect.small_diam_splitting Perfect.small_diam_splitting
+
+open CantorScheme
+
+/-- Any nonempty perfect set in a complete metric space admits a continuous injection
+from the Cantor space, `ℕ → Bool`. -/
+theorem Perfect.exists_nat_bool_injection [CompleteSpace α] :
+    ∃ f : (ℕ → Bool) → α, range f ⊆ C ∧ Continuous f ∧ Injective f := by
+  obtain ⟨u, -, upos', hu⟩ := exists_seq_strictAnti_tendsto' (zero_lt_one' ℝ≥0∞)
+  have upos := fun n => (upos' n).1
+  let P := Subtype fun E : Set α => Perfect E ∧ E.Nonempty
+  choose C0 C1 h0 h1 hdisj using
+    fun {C : Set α} (hC : Perfect C) (hnonempty : C.Nonempty) {ε : ℝ≥0∞} (hε : 0 < ε) =>
+    hC.small_diam_splitting hnonempty hε
+  let DP : List Bool → P := fun l => by
+    induction' l with a l ih; · exact ⟨C, ⟨hC, hnonempty⟩⟩
+    cases a
+    · use C0 ih.property.1 ih.property.2 (upos l.length.succ)
+      exact ⟨(h0 _ _ _).1, (h0 _ _ _).2.1⟩
+    use C1 ih.property.1 ih.property.2 (upos l.length.succ)
+    exact ⟨(h1 _ _ _).1, (h1 _ _ _).2.1⟩
+  let D : List Bool → Set α := fun l => (DP l).val
+  have hanti : ClosureAntitone D := by
+    refine Antitone.closureAntitone ?canto_antitone fun l => (DP l).property.1.closed
+    intro l a
+    cases a
+    · exact (h0 _ _ _).2.2.1
+    exact (h1 _ _ _).2.2.1
+  have hdiam : VanishingDiam D := by
+    intro x
+    apply tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds hu
+    · simp only [zero_le, eventually_atTop, ge_iff_le, implies_true, forall_const, exists_const]
+    rw [eventually_atTop]
+    refine ⟨1, fun m (hm : 1 ≤ m) => ?diam_le⟩
+    rw [Nat.one_le_iff_ne_zero] at hm
+    rcases Nat.exists_eq_succ_of_ne_zero hm with ⟨n, rfl⟩
+    dsimp only [PiNat.res_succ]
+
+    cases x n <;> rw [PiNat.res_length]
+    · exact (h0 _ _ _).2.2.2
+    · exact (h1 _ _ _).2.2.2
+  have hdisj' : CantorScheme.Disjoint D := by
+    rintro l (a | a) (b | b) hab <;> try contradiction
+    · exact hdisj _ _ _
+    exact (hdisj _ _ _).symm
+  have hdom : ∀ {x : ℕ → Bool}, x ∈ (inducedMap D).1 := fun {x} => by
+    rw [hanti.map_of_vanishingDiam hdiam fun l => (DP l).property.2]
+    apply mem_univ
+  refine ⟨fun x => (inducedMap D).2 ⟨x, hdom⟩, ?range_subset, ?continuous, ?injective⟩
+  · rintro y ⟨x, rfl⟩
+    exact map_mem ⟨_, hdom⟩ 0
+  · apply hdiam.map_continuous.comp
+    apply Continuous.subtype_mk
+    exact continuous_id'
+  intro x y hxy
+  simpa only [← Subtype.val_inj] using hdisj'.map_injective hxy
+#align perfect.exists_nat_bool_injection Perfect.exists_nat_bool_injection
+
+end CantorInjMetric
+
+/-- Any closed uncountable subset of a Polish space admits a continuous injection
+from the Cantor space `ℕ → Bool`.-/
+theorem IsClosed.exists_nat_bool_injection_of_not_countable {α : Type*} [TopologicalSpace α]
+    [PolishSpace α] {C : Set α} (hC : IsClosed C) (hunc : ¬C.Countable) :
+    ∃ f : (ℕ → Bool) → α, Set.range f ⊆ C ∧ Continuous f ∧ Function.Injective f := by
+  letI := upgradePolishSpace α
+  obtain ⟨D, hD, Dnonempty, hDC⟩ := exists_perfect_nonempty_of_isClosed_of_not_countable hC hunc
+  obtain ⟨f, hfD, hf⟩ := hD.exists_nat_bool_injection Dnonempty
+  exact ⟨f, hfD.trans hDC, hf⟩
+#align is_closed.exists_nat_bool_injection_of_not_countable IsClosed.exists_nat_bool_injection_of_not_countable

--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -2645,6 +2645,7 @@ theorem tendsto_Iio_atTop {f : β → Iio a} :
   rw [← comap_coe_Iio_nhdsWithin_Iio, tendsto_comap_iff]; rfl
 #align tendsto_Iio_at_top tendsto_Iio_atTop
 
+-- TODO: upon splitting this module, prove `PerfectSpace α` here instead
 instance (x : α) [Nontrivial α] : NeBot (𝓝[≠] x) := by
   refine forall_mem_nonempty_iff_neBot.1 fun s hs => ?_
   obtain ⟨u, u_open, xu, us⟩ : ∃ u : Set α, IsOpen u ∧ x ∈ u ∧ u ∩ {x}ᶜ ⊆ s := mem_nhdsWithin.1 hs

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -18,6 +18,7 @@ including a version of the Cantor-Bendixson Theorem.
 
 * `Perfect C`: A set `C` is perfect, meaning it is closed and every point of it
   is an accumulation point of itself.
+* `PerfectSpace X`: A topological space `X` is perfect if its universe is a perfect set.
 
 ## Main Statements
 
@@ -54,25 +55,9 @@ accumulation point, perfect set, cantor-bendixson.
 
 open Topology Filter Set
 open TopologicalSpace (IsTopologicalBasis)
-
-section Basic
-
 variable {α : Type*} [TopologicalSpace α] {s t : Set α}
 
-/-- If `x` is an accumulation point of a set `C` and `U` is a neighborhood of `x`,
-then `x` is an accumulation point of `U ∩ C`. -/
-theorem accPt_principal_iff_inter_of_mem_nhds {x : α} (t_nhds : t ∈ 𝓝 x) :
-    AccPt x (𝓟 s) ↔ AccPt x (𝓟 (s ∩ t)) := by
-  refine ⟨fun h_acc => ?acc_inter,
-    fun h_acc => AccPt.mono h_acc <| Filter.principal_mono.mpr <| Set.inter_subset_left _ _⟩
-  have : 𝓝[≠] x ≤ 𝓟 t := le_principal_iff.mpr <| mem_nhdsWithin_of_mem_nhds t_nhds
-  rw [AccPt, ← inf_principal, inf_comm (a := 𝓟 s), ← inf_assoc, inf_of_le_left this]
-  exact h_acc
-
-theorem AccPt.nhds_inter {x : α} (h_acc : AccPt x (𝓟 s)) (t_nhds : t ∈ 𝓝 x) :
-    AccPt x (𝓟 (t ∩ s)) :=
-  Set.inter_comm _ _ ▸ (accPt_principal_iff_inter_of_mem_nhds t_nhds).mp h_acc
-#align acc_pt.nhds_inter AccPt.nhds_inter
+section Defs
 
 /-- A set `C` is preperfect if all of its points are accumulation points of itself.
 If `C` is nonempty and `α` is a T1 space, this is equivalent to the closure of `C` being perfect.
@@ -92,6 +77,31 @@ structure Perfect (C : Set α) : Prop where
 theorem preperfect_iff_nhds : Preperfect s ↔ ∀ x ∈ s, ∀ U ∈ 𝓝 x, ∃ y ∈ U ∩ s, y ≠ x := by
   simp only [Preperfect, accPt_iff_nhds]
 #align preperfect_iff_nhds preperfect_iff_nhds
+
+/--
+A topological space `X` is said to be perfect if its universe is a perfect set.
+Equivalently, this means that `𝓝[≠] x ≠ ⊥` for every point `x : X`.
+-/
+class PerfectSpace (X : Type*) [TopologicalSpace X]: Prop :=
+  univ_perfect' : Perfect (Set.univ : Set X)
+
+variable [PerfectSpace α] in
+variable (α) in
+theorem PerfectSpace.univ_perfect : Perfect (Set.univ : Set α) := PerfectSpace.univ_perfect'
+
+end Defs
+
+section Preperfect
+
+/-- If `x` is an accumulation point of a set `C` and `U` is a neighborhood of `x`,
+then `x` is an accumulation point of `U ∩ C`. -/
+theorem accPt_principal_iff_inter_of_mem_nhds {x : α} (t_nhds : t ∈ 𝓝 x) :
+    AccPt x (𝓟 s) ↔ AccPt x (𝓟 (s ∩ t)) := by
+  refine ⟨fun h_acc => ?acc_inter,
+    fun h_acc => AccPt.mono h_acc <| Filter.principal_mono.mpr <| Set.inter_subset_left _ _⟩
+  have : 𝓝[≠] x ≤ 𝓟 t := le_principal_iff.mpr <| mem_nhdsWithin_of_mem_nhds t_nhds
+  rw [AccPt, ← inf_principal, inf_comm (a := 𝓟 s), ← inf_assoc, inf_of_le_left this]
+  exact h_acc
 
 /-- The intersection of a preperfect set and an open set is preperfect. -/
 theorem Preperfect.open_inter (s_prePerfect : Preperfect s) (t_open : IsOpen t) :
@@ -129,6 +139,10 @@ theorem preperfect_iff_perfect_closure [T1Space α] : Preperfect s ↔ Perfect (
   exact H.mono this
 #align preperfect_iff_perfect_closure preperfect_iff_perfect_closure
 
+end Preperfect
+
+section Splitting
+
 theorem Perfect.closure_nhds_inter (s_perfect : Perfect s) (x : α) (x_in_s : x ∈ s) (x_in_t : x ∈ t)
     (t_open : IsOpen t) : Perfect (closure (t ∩ s)) ∧ (closure (t ∩ s)).Nonempty := ⟨
   Preperfect.perfect_closure <| Set.inter_comm _ _ ▸ s_perfect.acc.open_inter t_open,
@@ -158,6 +172,8 @@ theorem Perfect.splitting [T25Space α] (hC : Perfect s) (hnonempty : s.Nonempty
     exact inter_subset_right _ _
   apply Disjoint.mono _ _ hUV <;> apply closure_mono <;> exact inter_subset_left _ _
 #align perfect.splitting Perfect.splitting
+
+end Splitting
 
 section Kernel
 
@@ -215,4 +231,49 @@ theorem exists_perfect_nonempty_of_isClosed_of_not_countable [SecondCountableTop
 
 end Kernel
 
-end Basic
+section PerfectSpace
+
+theorem perfectSpace_of_forall_not_isolated (h_forall : ∀ x : α, Filter.NeBot (𝓝[≠] x)) :
+    PerfectSpace α := ⟨⟨isClosed_univ, fun x _ => by
+  rw [AccPt, Filter.principal_univ, inf_top_eq]
+  exact h_forall x⟩⟩
+
+variable [PerfectSpace α]
+
+instance PerfectSpace.not_isolated (x : α): Filter.NeBot (𝓝[≠] x) := by
+  have := (PerfectSpace.univ_perfect α).acc (Set.mem_univ x)
+  rwa [AccPt, Filter.principal_univ, inf_top_eq] at this
+
+end PerfectSpace
+
+section PerfectSpace.Prod
+
+variable {β : Type*} [TopologicalSpace β]
+
+theorem nhdsWithin_punctured_prod_neBot_iff' {p : α} {q : β} : Filter.NeBot (𝓝[≠] (p, q)) ↔
+    Filter.NeBot (𝓝[≠] p) ∨ Filter.NeBot (𝓝[≠] q) := by
+  simp_rw [← Set.singleton_prod_singleton, Set.compl_prod_eq_union, nhdsWithin_union,
+    nhdsWithin_prod_eq, nhdsWithin_univ, Filter.neBot_iff, ne_eq, sup_eq_bot_iff,
+    Filter.prod_eq_bot, Filter.NeBot.ne <| nhds_neBot, or_false, false_or, not_and_or]
+
+variable (α β) in
+instance PerfectSpace.prod_left [PerfectSpace α] : PerfectSpace (α × β) :=
+  perfectSpace_of_forall_not_isolated fun ⟨p, q⟩ => by
+    rw [nhdsWithin_punctured_prod_neBot_iff]
+    left
+    exact PerfectSpace.not_isolated p
+
+variable (α β) in
+instance PerfectSpace.prod_right [PerfectSpace β] : PerfectSpace (α × β) :=
+  perfectSpace_of_forall_not_isolated fun ⟨p, q⟩ => by
+    rw [nhdsWithin_punctured_prod_neBot_iff]
+    right
+    exact PerfectSpace.not_isolated q
+
+end PerfectSpace.Prod
+
+@[deprecated accPt_principal_iff_inter_of_mem_nhds]
+theorem AccPt.nhds_inter {x : α} (h_acc : AccPt x (𝓟 s)) (t_nhds : t ∈ 𝓝 x) :
+    AccPt x (𝓟 (t ∩ s)) :=
+  Set.inter_comm _ _ ▸ (accPt_principal_iff_inter_of_mem_nhds t_nhds).mp h_acc
+#align acc_pt.nhds_inter AccPt.nhds_inter

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -241,16 +241,17 @@ end Kernel
 
 section PerfectSpace
 
-theorem perfectSpace_of_forall_not_isolated (h_forall : ∀ x : X, Filter.NeBot (𝓝[≠] x)) :
-    PerfectSpace X := ⟨⟨isClosed_univ, fun x _ => by
-  rw [AccPt, Filter.principal_univ, inf_top_eq]
-  exact h_forall x⟩⟩
-
-variable [PerfectSpace X]
-
+variable [PerfectSpace X] in
 instance PerfectSpace.not_isolated (x : X): Filter.NeBot (𝓝[≠] x) := by
   have := (PerfectSpace.univ_perfect X).acc (Set.mem_univ x)
   rwa [AccPt, Filter.principal_univ, inf_top_eq] at this
+
+theorem perfectSpace_iff_forall_not_isolated : PerfectSpace X ↔ ∀ x : X, Filter.NeBot (𝓝[≠] x) :=
+  ⟨fun perfect x => perfect.not_isolated x, fun h_forall => ⟨⟨isClosed_univ, fun x _ => by
+    rw [AccPt, Filter.principal_univ, inf_top_eq]
+    exact h_forall x⟩⟩⟩
+
+variable [PerfectSpace X]
 
 theorem PerfectSpace.preperfect_of_isOpen {s : Set X} (s_open : IsOpen s) : Preperfect s :=
   Set.univ_inter s ▸ (PerfectSpace.univ_perfect X).acc.open_inter s_open
@@ -275,14 +276,14 @@ theorem nhdsWithin_punctured_prod_neBot_iff {p : X} {q : β} : Filter.NeBot (�
 
 variable (α β) in
 instance PerfectSpace.prod_left [PerfectSpace X] : PerfectSpace (X × β) :=
-  perfectSpace_of_forall_not_isolated fun ⟨p, q⟩ => by
+  perfectSpace_iff_forall_not_isolated.mpr fun ⟨p, q⟩ => by
     rw [nhdsWithin_punctured_prod_neBot_iff]
     left
     exact PerfectSpace.not_isolated p
 
 variable (α β) in
 instance PerfectSpace.prod_right [PerfectSpace β] : PerfectSpace (X × β) :=
-  perfectSpace_of_forall_not_isolated fun ⟨p, q⟩ => by
+  perfectSpace_iff_forall_not_isolated.mpr fun ⟨p, q⟩ => by
     rw [nhdsWithin_punctured_prod_neBot_iff]
     right
     exact PerfectSpace.not_isolated q
@@ -290,7 +291,7 @@ instance PerfectSpace.prod_right [PerfectSpace β] : PerfectSpace (X × β) :=
 /-- A non-trivial connected T1 space has no isolated points. -/
 instance (priority := 100) ConnectedSpace.perfectSpace_of_nontrivial_of_t1space
     [PreconnectedSpace X] [Nontrivial X] [T1Space X] : PerfectSpace X := by
-  apply perfectSpace_of_forall_not_isolated
+  rw [perfectSpace_iff_forall_not_isolated]
   intro x
   by_contra contra
   rw [not_neBot, ← isOpen_singleton_iff_punctured_nhds] at contra

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -331,7 +331,7 @@ variable (α) in
 /--
 If a topological space is perfect, T1 and nonempty, then it is infinite.
 -/
-theorem infinite_of_perfectSpace [T1Space X] [PerfectSpace X] [Nonempty X] : Infinite X :=
+theorem PerfectSpace.infinite [T1Space X] [PerfectSpace X] [Nonempty X] : Infinite X :=
   Set.infinite_univ_iff.mp (set_infinite_of_perfectSpace isOpen_univ univ_nonempty)
 
 end PerfectSpace.Infinite

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -58,35 +58,36 @@ accumulation point, perfect set, cantor-bendixson.
 
 open Topology Filter Set
 open TopologicalSpace (IsTopologicalBasis)
-variable {α : Type*} [TopologicalSpace α] {s t : Set α}
+variable {X : Type*} [TopologicalSpace X] {s t : Set X}
 
 section Defs
 
-/-- A set `C` is preperfect if all of its points are accumulation points of itself.
-If `C` is nonempty and `α` is a T1 space, this is equivalent to the closure of `C` being perfect.
+/-- A set `s` is preperfect if all of its points are accumulation points of itself.
+If `s` is nonempty and `X` is a T1 space, this is equivalent to the closure of `s` being perfect.
 See `preperfect_iff_perfect_closure`.-/
-def Preperfect (C : Set α) : Prop :=
-  ∀ ⦃x⦄, x ∈ C → AccPt x (𝓟 C)
+def Preperfect (s : Set X) : Prop :=
+  ∀ ⦃x⦄, x ∈ s → AccPt x (𝓟 s)
 #align preperfect Preperfect
 
-/-- A set `C` is called perfect if it is closed and all of its
+/-- A set `s` is called perfect if it is closed and all of its
 points are accumulation points of itself.
-Note that we do not require `C` to be nonempty.-/
-structure Perfect (C : Set α) : Prop where
-  closed : IsClosed C
-  acc : Preperfect C
+Note that we do not require `s` to be nonempty.-/
+structure Perfect (s : Set X) : Prop where
+  closed : IsClosed s
+  acc : Preperfect s
 #align perfect Perfect
 
+variable (X) in
 /--
 A topological space `X` is said to be perfect if its universe is a perfect set.
 Equivalently, this means that `𝓝[≠] x ≠ ⊥` for every point `x : X`.
 -/
-class PerfectSpace (X : Type*) [TopologicalSpace X]: Prop :=
+class PerfectSpace : Prop :=
   univ_perfect' : Perfect (Set.univ : Set X)
 
-variable [PerfectSpace α] in
-variable (α) in
-theorem PerfectSpace.univ_perfect : Perfect (Set.univ : Set α) := PerfectSpace.univ_perfect'
+variable (X) in
+variable [PerfectSpace X] in
+theorem PerfectSpace.univ_perfect : Perfect (Set.univ : Set X) := PerfectSpace.univ_perfect'
 
 end Defs
 
@@ -96,13 +97,13 @@ theorem preperfect_iff_nhds : Preperfect s ↔ ∀ x ∈ s, ∀ U ∈ 𝓝 x, �
   simp only [Preperfect, accPt_iff_nhds]
 #align preperfect_iff_nhds preperfect_iff_nhds
 
-theorem Preperfect.nhdsWithin_neBot (s_prePerfect : Preperfect s) {x : α} (x_in_s : x ∈ s) :
+theorem Preperfect.nhdsWithin_neBot (s_preperfect : Preperfect s) {x : X} (x_in_s : x ∈ s) :
     Filter.NeBot (𝓝[≠] x) := ⟨fun eq_bot => by
-  simpa [AccPt, Filter.neBot_iff, eq_bot, bot_inf_eq] using s_prePerfect x_in_s⟩
+  simpa [AccPt, Filter.neBot_iff, eq_bot, bot_inf_eq] using s_preperfect x_in_s⟩
 
 /-- If `x` is an accumulation point of a set `C` and `U` is a neighborhood of `x`,
 then `x` is an accumulation point of `U ∩ C`. -/
-theorem accPt_principal_iff_inter_of_mem_nhds {x : α} (t_nhds : t ∈ 𝓝 x) :
+theorem accPt_principal_iff_inter_of_mem_nhds {x : X} (t_nhds : t ∈ 𝓝 x) :
     AccPt x (𝓟 s) ↔ AccPt x (𝓟 (s ∩ t)) := by
   refine ⟨fun h_acc => ?acc_inter,
     fun h_acc => AccPt.mono h_acc <| Filter.principal_mono.mpr <| Set.inter_subset_left _ _⟩
@@ -111,19 +112,19 @@ theorem accPt_principal_iff_inter_of_mem_nhds {x : α} (t_nhds : t ∈ 𝓝 x) :
   exact h_acc
 
 /-- The intersection of a preperfect set and an open set is preperfect. -/
-theorem Preperfect.open_inter (s_prePerfect : Preperfect s) (t_open : IsOpen t) :
+theorem Preperfect.open_inter (s_preperfect : Preperfect s) (t_open : IsOpen t) :
     Preperfect (s ∩ t) := fun _ ⟨x_in_s, x_in_t⟩ =>
-  (accPt_principal_iff_inter_of_mem_nhds <| t_open.mem_nhds x_in_t).mp (s_prePerfect x_in_s)
+  (accPt_principal_iff_inter_of_mem_nhds <| t_open.mem_nhds x_in_t).mp (s_preperfect x_in_s)
 
 #align preperfect.open_inter Preperfect.open_inter
 
 /-- The closure of a preperfect set is perfect.
 For a converse, see `preperfect_iff_perfect_closure`. -/
-theorem Preperfect.perfect_closure (s_prePerfect : Preperfect s) : Perfect (closure s) := by
+theorem Preperfect.perfect_closure (s_preperfect : Preperfect s) : Perfect (closure s) := by
   constructor; · exact isClosed_closure
   intro x hx
   by_cases h : x ∈ s <;> apply AccPt.mono _ (principal_mono.mpr subset_closure)
-  · exact s_prePerfect h
+  · exact s_preperfect h
   have : {x}ᶜ ∩ s = s := by simp [h]
   rw [AccPt, nhdsWithin, inf_assoc, inf_principal, this]
   rw [closure_eq_cluster_pts] at hx
@@ -131,7 +132,7 @@ theorem Preperfect.perfect_closure (s_prePerfect : Preperfect s) : Perfect (clos
 #align preperfect.perfect_closure Preperfect.perfect_closure
 
 /-- In a T1 space, being preperfect is equivalent to having perfect closure.-/
-theorem preperfect_iff_perfect_closure [T1Space α] : Preperfect s ↔ Perfect (closure s) := by
+theorem preperfect_iff_perfect_closure [T1Space X] : Preperfect s ↔ Perfect (closure s) := by
   constructor <;> intro h
   · exact h.perfect_closure
   intro x xC
@@ -150,7 +151,7 @@ end Preperfect
 
 section Splitting
 
-theorem Perfect.closure_nhds_inter (s_perfect : Perfect s) (x : α) (x_in_s : x ∈ s) (x_in_t : x ∈ t)
+theorem Perfect.closure_nhds_inter (s_perfect : Perfect s) (x : X) (x_in_s : x ∈ s) (x_in_t : x ∈ t)
     (t_open : IsOpen t) : Perfect (closure (t ∩ s)) ∧ (closure (t ∩ s)).Nonempty := ⟨
   Preperfect.perfect_closure <| Set.inter_comm _ _ ▸ s_perfect.acc.open_inter t_open,
   ⟨x, subset_closure ⟨x_in_t, x_in_s⟩⟩⟩
@@ -158,24 +159,24 @@ theorem Perfect.closure_nhds_inter (s_perfect : Perfect s) (x : α) (x_in_s : x 
 
 /-- Given a perfect nonempty set in a T2.5 space, we can find two disjoint perfect subsets.
 This is the main inductive step in the proof of the Cantor-Bendixson Theorem. -/
-theorem Perfect.splitting [T25Space α] (hC : Perfect s) (hnonempty : s.Nonempty) :
-    ∃ C₀ C₁ : Set α,
+theorem Perfect.splitting [T25Space X] (s_perfect : Perfect s) (hnonempty : s.Nonempty) :
+    ∃ C₀ C₁ : Set X,
     (Perfect C₀ ∧ C₀.Nonempty ∧ C₀ ⊆ s) ∧ (Perfect C₁ ∧ C₁.Nonempty ∧ C₁ ⊆ s) ∧ Disjoint C₀ C₁ := by
   cases' hnonempty with y yC
   obtain ⟨x, xC, hxy⟩ : ∃ x ∈ s, x ≠ y := by
-    have := hC.acc yC
+    have := s_perfect.acc yC
     rw [accPt_iff_nhds] at this
     rcases this univ univ_mem with ⟨x, xC, hxy⟩
     exact ⟨x, xC.2, hxy⟩
   obtain ⟨U, xU, Uop, V, yV, Vop, hUV⟩ := exists_open_nhds_disjoint_closure hxy
   use closure (U ∩ s), closure (V ∩ s)
   constructor <;> rw [← and_assoc]
-  · refine' ⟨hC.closure_nhds_inter x xC xU Uop, _⟩
-    rw [hC.closed.closure_subset_iff]
+  · refine' ⟨s_perfect.closure_nhds_inter x xC xU Uop, _⟩
+    rw [s_perfect.closed.closure_subset_iff]
     exact inter_subset_right _ _
   constructor
-  · refine' ⟨hC.closure_nhds_inter y yC yV Vop, _⟩
-    rw [hC.closed.closure_subset_iff]
+  · refine' ⟨s_perfect.closure_nhds_inter y yC yV Vop, _⟩
+    rw [s_perfect.closed.closure_subset_iff]
     exact inter_subset_right _ _
   apply Disjoint.mono _ _ hUV <;> apply closure_mono <;> exact inter_subset_left _ _
 #align perfect.splitting Perfect.splitting
@@ -186,9 +187,9 @@ section Kernel
 
 /-- The **Cantor-Bendixson Theorem**: Any closed subset of a second countable space
 can be written as the union of a countable set and a perfect set.-/
-theorem exists_countable_union_perfect_of_isClosed [SecondCountableTopology α]
-    (hclosed : IsClosed s) : ∃ V D : Set α, V.Countable ∧ Perfect D ∧ s = V ∪ D := by
-  obtain ⟨b, bct, _, bbasis⟩ := TopologicalSpace.exists_countable_basis α
+theorem exists_countable_union_perfect_of_isClosed [SecondCountableTopology X]
+    (hclosed : IsClosed s) : ∃ V D : Set X, V.Countable ∧ Perfect D ∧ s = V ∪ D := by
+  obtain ⟨b, bct, _, bbasis⟩ := TopologicalSpace.exists_countable_basis X
   let v := { U ∈ b | (U ∩ s).Countable }
   let V := ⋃ U ∈ v, U
   let D := s \ V
@@ -222,8 +223,8 @@ theorem exists_countable_union_perfect_of_isClosed [SecondCountableTopology α]
 #align exists_countable_union_perfect_of_is_closed exists_countable_union_perfect_of_isClosed
 
 /-- Any uncountable closed set in a second countable space contains a nonempty perfect subset.-/
-theorem exists_perfect_nonempty_of_isClosed_of_not_countable [SecondCountableTopology α]
-    (hclosed : IsClosed s) (hunc : ¬s.Countable) : ∃ D : Set α, Perfect D ∧ D.Nonempty ∧ D ⊆ s := by
+theorem exists_perfect_nonempty_of_isClosed_of_not_countable [SecondCountableTopology X]
+    (hclosed : IsClosed s) (hunc : ¬s.Countable) : ∃ D : Set X, Perfect D ∧ D.Nonempty ∧ D ⊆ s := by
   rcases exists_countable_union_perfect_of_isClosed hclosed with ⟨V, D, Vct, Dperf, VD⟩
   refine' ⟨D, ⟨Dperf, _⟩⟩
   constructor
@@ -240,19 +241,19 @@ end Kernel
 
 section PerfectSpace
 
-theorem perfectSpace_of_forall_not_isolated (h_forall : ∀ x : α, Filter.NeBot (𝓝[≠] x)) :
-    PerfectSpace α := ⟨⟨isClosed_univ, fun x _ => by
+theorem perfectSpace_of_forall_not_isolated (h_forall : ∀ x : X, Filter.NeBot (𝓝[≠] x)) :
+    PerfectSpace X := ⟨⟨isClosed_univ, fun x _ => by
   rw [AccPt, Filter.principal_univ, inf_top_eq]
   exact h_forall x⟩⟩
 
-variable [PerfectSpace α]
+variable [PerfectSpace X]
 
-instance PerfectSpace.not_isolated (x : α): Filter.NeBot (𝓝[≠] x) := by
-  have := (PerfectSpace.univ_perfect α).acc (Set.mem_univ x)
+instance PerfectSpace.not_isolated (x : X): Filter.NeBot (𝓝[≠] x) := by
+  have := (PerfectSpace.univ_perfect X).acc (Set.mem_univ x)
   rwa [AccPt, Filter.principal_univ, inf_top_eq] at this
 
-theorem PerfectSpace.prePerfect_of_isOpen {s : Set α} (s_open : IsOpen s) : Preperfect s :=
-  Set.univ_inter s ▸ (PerfectSpace.univ_perfect α).acc.open_inter s_open
+theorem PerfectSpace.preperfect_of_isOpen {s : Set X} (s_open : IsOpen s) : Preperfect s :=
+  Set.univ_inter s ▸ (PerfectSpace.univ_perfect X).acc.open_inter s_open
 
 end PerfectSpace
 
@@ -266,21 +267,21 @@ The product topological space `α × β` is perfect if `α` or `β` is perfect.
 
 variable {β : Type*} [TopologicalSpace β]
 
-theorem nhdsWithin_punctured_prod_neBot_iff {p : α} {q : β} : Filter.NeBot (𝓝[≠] (p, q)) ↔
+theorem nhdsWithin_punctured_prod_neBot_iff {p : X} {q : β} : Filter.NeBot (𝓝[≠] (p, q)) ↔
     Filter.NeBot (𝓝[≠] p) ∨ Filter.NeBot (𝓝[≠] q) := by
   simp_rw [← Set.singleton_prod_singleton, Set.compl_prod_eq_union, nhdsWithin_union,
     nhdsWithin_prod_eq, nhdsWithin_univ, Filter.neBot_iff, ne_eq, sup_eq_bot_iff,
     Filter.prod_eq_bot, Filter.NeBot.ne <| nhds_neBot, or_false, false_or, not_and_or]
 
 variable (α β) in
-instance PerfectSpace.prod_left [PerfectSpace α] : PerfectSpace (α × β) :=
+instance PerfectSpace.prod_left [PerfectSpace X] : PerfectSpace (X × β) :=
   perfectSpace_of_forall_not_isolated fun ⟨p, q⟩ => by
     rw [nhdsWithin_punctured_prod_neBot_iff]
     left
     exact PerfectSpace.not_isolated p
 
 variable (α β) in
-instance PerfectSpace.prod_right [PerfectSpace β] : PerfectSpace (α × β) :=
+instance PerfectSpace.prod_right [PerfectSpace β] : PerfectSpace (X × β) :=
   perfectSpace_of_forall_not_isolated fun ⟨p, q⟩ => by
     rw [nhdsWithin_punctured_prod_neBot_iff]
     right
@@ -288,7 +289,7 @@ instance PerfectSpace.prod_right [PerfectSpace β] : PerfectSpace (α × β) :=
 
 /-- A non-trivial connected T1 space has no isolated points. -/
 instance (priority := 100) ConnectedSpace.perfectSpace_of_nontrivial_of_t1space
-    [PreconnectedSpace α] [Nontrivial α] [T1Space α] : PerfectSpace α := by
+    [PreconnectedSpace X] [Nontrivial X] [T1Space X] : PerfectSpace X := by
   apply perfectSpace_of_forall_not_isolated
   intro x
   by_contra contra
@@ -311,31 +312,31 @@ open set must be infinite (`set_infinite_of_perfectSpace`).
 /--
 In a T1 space, nonempty open pre-perfect sets are infinite.
 -/
-theorem set_infinite_of_prePerfect [T1Space α] {s : Set α} (s_prePerfect : Preperfect s)
+theorem set_infinite_of_preperfect [T1Space X] {s : Set X} (s_preperfect : Preperfect s)
     (s_open : IsOpen s) (s_nonempty : s.Nonempty) : s.Infinite := by
   let ⟨p, p_in_s⟩ := s_nonempty
-  have := s_prePerfect.nhdsWithin_neBot p_in_s
+  have := s_preperfect.nhdsWithin_neBot p_in_s
   apply infinite_of_mem_nhds p
   exact IsOpen.mem_nhds s_open p_in_s
 
 /--
 In a T1, perfect space, nonempty open sets are infinite.
 -/
-theorem set_infinite_of_perfectSpace [T1Space α] [PerfectSpace α] {s : Set α} (s_open : IsOpen s)
+theorem set_infinite_of_perfectSpace [T1Space X] [PerfectSpace X] {s : Set X} (s_open : IsOpen s)
     (s_nonempty : s.Nonempty) : s.Infinite :=
-  set_infinite_of_prePerfect (PerfectSpace.prePerfect_of_isOpen s_open) s_open s_nonempty
+  set_infinite_of_preperfect (PerfectSpace.preperfect_of_isOpen s_open) s_open s_nonempty
 
 variable (α) in
 /--
 If a topological space is perfect, T1 and nonempty, then it is infinite.
 -/
-theorem infinite_of_perfectSpace [T1Space α] [PerfectSpace α] [Nonempty α] : Infinite α :=
+theorem infinite_of_perfectSpace [T1Space X] [PerfectSpace X] [Nonempty X] : Infinite X :=
   Set.infinite_univ_iff.mp (set_infinite_of_perfectSpace isOpen_univ univ_nonempty)
 
 end PerfectSpace.Infinite
 
 @[deprecated accPt_principal_iff_inter_of_mem_nhds]
-theorem AccPt.nhds_inter {x : α} (h_acc : AccPt x (𝓟 s)) (t_nhds : t ∈ 𝓝 x) :
+theorem AccPt.nhds_inter {x : X} (h_acc : AccPt x (𝓟 s)) (t_nhds : t ∈ 𝓝 x) :
     AccPt x (𝓟 (t ∩ s)) :=
   Set.inter_comm _ _ ▸ (accPt_principal_iff_inter_of_mem_nhds t_nhds).mp h_acc
 #align acc_pt.nhds_inter AccPt.nhds_inter

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -1,10 +1,10 @@
 /-
 Copyright (c) 2022 Felix Weilacher. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Felix Weilacher
+Authors: Felix Weilacher, Emilie Burgun
 -/
-import Mathlib.Topology.MetricSpace.Polish
-import Mathlib.Topology.MetricSpace.CantorScheme
+
+import Mathlib.Topology.Separation
 
 #align_import topology.perfect from "leanprover-community/mathlib"@"3905fa80e62c0898131285baab35559fbc4e5cda"
 
@@ -27,8 +27,6 @@ including a version of the Cantor-Bendixson Theorem.
 * `exists_countable_union_perfect_of_isClosed`: One version of the **Cantor-Bendixson Theorem**:
   A closed set in a second countable space can be written as the union of a countable set and a
   perfect set.
-* `Perfect.exists_nat_bool_injection`: A perfect nonempty set in a complete metric space
-  admits an embedding from the Cantor space.
 
 ## Implementation Notes
 
@@ -37,6 +35,11 @@ We do not require perfect sets to be nonempty.
 We define a nonstandard predicate, `Preperfect`, which drops the closed-ness requirement
 from the definition of perfect. In T1 spaces, this is equivalent to having a perfect closure,
 see `preperfect_iff_perfect_closure`.
+
+## See also
+
+`Mathlib.Topology.MetricSpace.Perfect`, for properties of perfect sets in metric spaces,
+namely Polish spaces.
 
 ## References
 
@@ -49,30 +52,33 @@ accumulation point, perfect set, cantor-bendixson.
 -/
 
 
-open Topology Filter
-
-open TopologicalSpace Filter Set
+open Topology Filter Set
+open TopologicalSpace (IsTopologicalBasis)
 
 section Basic
 
-variable {α : Type*} [TopologicalSpace α] {C : Set α}
+variable {α : Type*} [TopologicalSpace α] {s t : Set α}
 
 /-- If `x` is an accumulation point of a set `C` and `U` is a neighborhood of `x`,
 then `x` is an accumulation point of `U ∩ C`. -/
-theorem AccPt.nhds_inter {x : α} {U : Set α} (h_acc : AccPt x (𝓟 C)) (hU : U ∈ 𝓝 x) :
-    AccPt x (𝓟 (U ∩ C)) := by
-  have : 𝓝[≠] x ≤ 𝓟 U := by
-    rw [le_principal_iff]
-    exact mem_nhdsWithin_of_mem_nhds hU
-  rw [AccPt, ← inf_principal, ← inf_assoc, inf_of_le_left this]
+theorem accPt_principal_iff_inter_of_mem_nhds {x : α} (t_nhds : t ∈ 𝓝 x) :
+    AccPt x (𝓟 s) ↔ AccPt x (𝓟 (s ∩ t)) := by
+  refine ⟨fun h_acc => ?acc_inter,
+    fun h_acc => AccPt.mono h_acc <| Filter.principal_mono.mpr <| Set.inter_subset_left _ _⟩
+  have : 𝓝[≠] x ≤ 𝓟 t := le_principal_iff.mpr <| mem_nhdsWithin_of_mem_nhds t_nhds
+  rw [AccPt, ← inf_principal, inf_comm (a := 𝓟 s), ← inf_assoc, inf_of_le_left this]
   exact h_acc
+
+theorem AccPt.nhds_inter {x : α} (h_acc : AccPt x (𝓟 s)) (t_nhds : t ∈ 𝓝 x) :
+    AccPt x (𝓟 (t ∩ s)) :=
+  Set.inter_comm _ _ ▸ (accPt_principal_iff_inter_of_mem_nhds t_nhds).mp h_acc
 #align acc_pt.nhds_inter AccPt.nhds_inter
 
 /-- A set `C` is preperfect if all of its points are accumulation points of itself.
 If `C` is nonempty and `α` is a T1 space, this is equivalent to the closure of `C` being perfect.
 See `preperfect_iff_perfect_closure`.-/
 def Preperfect (C : Set α) : Prop :=
-  ∀ x ∈ C, AccPt x (𝓟 C)
+  ∀ ⦃x⦄, x ∈ C → AccPt x (𝓟 C)
 #align preperfect Preperfect
 
 /-- A set `C` is called perfect if it is closed and all of its
@@ -83,39 +89,38 @@ structure Perfect (C : Set α) : Prop where
   acc : Preperfect C
 #align perfect Perfect
 
-theorem preperfect_iff_nhds : Preperfect C ↔ ∀ x ∈ C, ∀ U ∈ 𝓝 x, ∃ y ∈ U ∩ C, y ≠ x := by
+theorem preperfect_iff_nhds : Preperfect s ↔ ∀ x ∈ s, ∀ U ∈ 𝓝 x, ∃ y ∈ U ∩ s, y ≠ x := by
   simp only [Preperfect, accPt_iff_nhds]
 #align preperfect_iff_nhds preperfect_iff_nhds
 
 /-- The intersection of a preperfect set and an open set is preperfect. -/
-theorem Preperfect.open_inter {U : Set α} (hC : Preperfect C) (hU : IsOpen U) :
-    Preperfect (U ∩ C) := by
-  rintro x ⟨xU, xC⟩
-  apply (hC _ xC).nhds_inter
-  exact hU.mem_nhds xU
+theorem Preperfect.open_inter (s_prePerfect : Preperfect s) (t_open : IsOpen t) :
+    Preperfect (s ∩ t) := fun _ ⟨x_in_s, x_in_t⟩ =>
+  (accPt_principal_iff_inter_of_mem_nhds <| t_open.mem_nhds x_in_t).mp (s_prePerfect x_in_s)
+
 #align preperfect.open_inter Preperfect.open_inter
 
 /-- The closure of a preperfect set is perfect.
 For a converse, see `preperfect_iff_perfect_closure`. -/
-theorem Preperfect.perfect_closure (hC : Preperfect C) : Perfect (closure C) := by
+theorem Preperfect.perfect_closure (s_prePerfect : Preperfect s) : Perfect (closure s) := by
   constructor; · exact isClosed_closure
   intro x hx
-  by_cases h : x ∈ C <;> apply AccPt.mono _ (principal_mono.mpr subset_closure)
-  · exact hC _ h
-  have : {x}ᶜ ∩ C = C := by simp [h]
+  by_cases h : x ∈ s <;> apply AccPt.mono _ (principal_mono.mpr subset_closure)
+  · exact s_prePerfect h
+  have : {x}ᶜ ∩ s = s := by simp [h]
   rw [AccPt, nhdsWithin, inf_assoc, inf_principal, this]
   rw [closure_eq_cluster_pts] at hx
   exact hx
 #align preperfect.perfect_closure Preperfect.perfect_closure
 
 /-- In a T1 space, being preperfect is equivalent to having perfect closure.-/
-theorem preperfect_iff_perfect_closure [T1Space α] : Preperfect C ↔ Perfect (closure C) := by
+theorem preperfect_iff_perfect_closure [T1Space α] : Preperfect s ↔ Perfect (closure s) := by
   constructor <;> intro h
   · exact h.perfect_closure
   intro x xC
-  have H : AccPt x (𝓟 (closure C)) := h.acc _ (subset_closure xC)
+  have H : AccPt x (𝓟 (closure s)) := h.acc (subset_closure xC)
   rw [accPt_iff_frequently] at *
-  have : ∀ y, y ≠ x ∧ y ∈ closure C → ∃ᶠ z in 𝓝 y, z ≠ x ∧ z ∈ C := by
+  have : ∀ y, y ≠ x ∧ y ∈ closure s → ∃ᶠ z in 𝓝 y, z ≠ x ∧ z ∈ s := by
     rintro y ⟨hyx, yC⟩
     simp only [← mem_compl_singleton_iff, and_comm, ← frequently_nhdsWithin_iff,
       hyx.nhdsWithin_compl_singleton, ← mem_closure_iff_frequently]
@@ -124,28 +129,25 @@ theorem preperfect_iff_perfect_closure [T1Space α] : Preperfect C ↔ Perfect (
   exact H.mono this
 #align preperfect_iff_perfect_closure preperfect_iff_perfect_closure
 
-theorem Perfect.closure_nhds_inter {U : Set α} (hC : Perfect C) (x : α) (xC : x ∈ C) (xU : x ∈ U)
-    (Uop : IsOpen U) : Perfect (closure (U ∩ C)) ∧ (closure (U ∩ C)).Nonempty := by
-  constructor
-  · apply Preperfect.perfect_closure
-    exact hC.acc.open_inter Uop
-  apply Nonempty.closure
-  exact ⟨x, ⟨xU, xC⟩⟩
+theorem Perfect.closure_nhds_inter (s_perfect : Perfect s) (x : α) (x_in_s : x ∈ s) (x_in_t : x ∈ t)
+    (t_open : IsOpen t) : Perfect (closure (t ∩ s)) ∧ (closure (t ∩ s)).Nonempty := ⟨
+  Preperfect.perfect_closure <| Set.inter_comm _ _ ▸ s_perfect.acc.open_inter t_open,
+  ⟨x, subset_closure ⟨x_in_t, x_in_s⟩⟩⟩
 #align perfect.closure_nhds_inter Perfect.closure_nhds_inter
 
 /-- Given a perfect nonempty set in a T2.5 space, we can find two disjoint perfect subsets.
 This is the main inductive step in the proof of the Cantor-Bendixson Theorem. -/
-theorem Perfect.splitting [T25Space α] (hC : Perfect C) (hnonempty : C.Nonempty) :
+theorem Perfect.splitting [T25Space α] (hC : Perfect s) (hnonempty : s.Nonempty) :
     ∃ C₀ C₁ : Set α,
-    (Perfect C₀ ∧ C₀.Nonempty ∧ C₀ ⊆ C) ∧ (Perfect C₁ ∧ C₁.Nonempty ∧ C₁ ⊆ C) ∧ Disjoint C₀ C₁ := by
+    (Perfect C₀ ∧ C₀.Nonempty ∧ C₀ ⊆ s) ∧ (Perfect C₁ ∧ C₁.Nonempty ∧ C₁ ⊆ s) ∧ Disjoint C₀ C₁ := by
   cases' hnonempty with y yC
-  obtain ⟨x, xC, hxy⟩ : ∃ x ∈ C, x ≠ y := by
-    have := hC.acc _ yC
+  obtain ⟨x, xC, hxy⟩ : ∃ x ∈ s, x ≠ y := by
+    have := hC.acc yC
     rw [accPt_iff_nhds] at this
     rcases this univ univ_mem with ⟨x, xC, hxy⟩
     exact ⟨x, xC.2, hxy⟩
   obtain ⟨U, xU, Uop, V, yV, Vop, hUV⟩ := exists_open_nhds_disjoint_closure hxy
-  use closure (U ∩ C), closure (V ∩ C)
+  use closure (U ∩ s), closure (V ∩ s)
   constructor <;> rw [← and_assoc]
   · refine' ⟨hC.closure_nhds_inter x xC xU Uop, _⟩
     rw [hC.closed.closure_subset_iff]
@@ -162,17 +164,17 @@ section Kernel
 /-- The **Cantor-Bendixson Theorem**: Any closed subset of a second countable space
 can be written as the union of a countable set and a perfect set.-/
 theorem exists_countable_union_perfect_of_isClosed [SecondCountableTopology α]
-    (hclosed : IsClosed C) : ∃ V D : Set α, V.Countable ∧ Perfect D ∧ C = V ∪ D := by
+    (hclosed : IsClosed s) : ∃ V D : Set α, V.Countable ∧ Perfect D ∧ s = V ∪ D := by
   obtain ⟨b, bct, _, bbasis⟩ := TopologicalSpace.exists_countable_basis α
-  let v := { U ∈ b | (U ∩ C).Countable }
+  let v := { U ∈ b | (U ∩ s).Countable }
   let V := ⋃ U ∈ v, U
-  let D := C \ V
-  have Vct : (V ∩ C).Countable := by
+  let D := s \ V
+  have Vct : (V ∩ s).Countable := by
     simp only [iUnion_inter, mem_sep_iff]
     apply Countable.biUnion
     · exact Countable.mono (inter_subset_left _ _) bct
     · exact inter_subset_right _ _
-  refine' ⟨V ∩ C, D, Vct, ⟨_, _⟩, _⟩
+  refine' ⟨V ∩ s, D, Vct, ⟨_, _⟩, _⟩
   · refine' hclosed.sdiff (isOpen_biUnion fun _ ↦ _)
     exact fun ⟨Ub, _⟩ ↦ IsTopologicalBasis.isOpen bbasis Ub
   · rw [preperfect_iff_nhds]
@@ -181,8 +183,8 @@ theorem exists_countable_union_perfect_of_isClosed [SecondCountableTopology α]
       intro h
       obtain ⟨U, hUb, xU, hU⟩ : ∃ U ∈ b, x ∈ U ∧ U ⊆ E :=
         (IsTopologicalBasis.mem_nhds_iff bbasis).mp xE
-      have hU_cnt : (U ∩ C).Countable := by
-        apply @Countable.mono _ _ (E ∩ D ∪ V ∩ C)
+      have hU_cnt : (U ∩ s).Countable := by
+        apply @Countable.mono _ _ (E ∩ D ∪ V ∩ s)
         · rintro y ⟨yU, yC⟩
           by_cases h : y ∈ V
           · exact mem_union_right _ (mem_inter h yC)
@@ -198,7 +200,7 @@ theorem exists_countable_union_perfect_of_isClosed [SecondCountableTopology α]
 
 /-- Any uncountable closed set in a second countable space contains a nonempty perfect subset.-/
 theorem exists_perfect_nonempty_of_isClosed_of_not_countable [SecondCountableTopology α]
-    (hclosed : IsClosed C) (hunc : ¬C.Countable) : ∃ D : Set α, Perfect D ∧ D.Nonempty ∧ D ⊆ C := by
+    (hclosed : IsClosed s) (hunc : ¬s.Countable) : ∃ D : Set α, Perfect D ∧ D.Nonempty ∧ D ⊆ s := by
   rcases exists_countable_union_perfect_of_isClosed hclosed with ⟨V, D, Vct, Dperf, VD⟩
   refine' ⟨D, ⟨Dperf, _⟩⟩
   constructor
@@ -214,112 +216,3 @@ theorem exists_perfect_nonempty_of_isClosed_of_not_countable [SecondCountableTop
 end Kernel
 
 end Basic
-
-section CantorInjMetric
-
-open Function ENNReal
-
-variable {α : Type*} [MetricSpace α] {C : Set α} (hC : Perfect C) {ε : ℝ≥0∞}
-
-private theorem Perfect.small_diam_aux (ε_pos : 0 < ε) {x : α} (xC : x ∈ C) :
-    let D := closure (EMetric.ball x (ε / 2) ∩ C)
-    Perfect D ∧ D.Nonempty ∧ D ⊆ C ∧ EMetric.diam D ≤ ε := by
-  have : x ∈ EMetric.ball x (ε / 2) := by
-    apply EMetric.mem_ball_self
-    rw [ENNReal.div_pos_iff]
-    exact ⟨ne_of_gt ε_pos, by norm_num⟩
-  have := hC.closure_nhds_inter x xC this EMetric.isOpen_ball
-  refine' ⟨this.1, this.2, _, _⟩
-  · rw [IsClosed.closure_subset_iff hC.closed]
-    apply inter_subset_right
-  rw [EMetric.diam_closure]
-  apply le_trans (EMetric.diam_mono (inter_subset_left _ _))
-  convert EMetric.diam_ball (x := x)
-  rw [mul_comm, ENNReal.div_mul_cancel] <;> norm_num
-
-variable (hnonempty : C.Nonempty)
-
-/-- A refinement of `Perfect.splitting` for metric spaces, where we also control
-the diameter of the new perfect sets. -/
-theorem Perfect.small_diam_splitting (ε_pos : 0 < ε) :
-    ∃ C₀ C₁ : Set α, (Perfect C₀ ∧ C₀.Nonempty ∧ C₀ ⊆ C ∧ EMetric.diam C₀ ≤ ε) ∧
-    (Perfect C₁ ∧ C₁.Nonempty ∧ C₁ ⊆ C ∧ EMetric.diam C₁ ≤ ε) ∧ Disjoint C₀ C₁ := by
-  rcases hC.splitting hnonempty with ⟨D₀, D₁, ⟨perf0, non0, sub0⟩, ⟨perf1, non1, sub1⟩, hdisj⟩
-  cases' non0 with x₀ hx₀
-  cases' non1 with x₁ hx₁
-  rcases perf0.small_diam_aux ε_pos hx₀ with ⟨perf0', non0', sub0', diam0⟩
-  rcases perf1.small_diam_aux ε_pos hx₁ with ⟨perf1', non1', sub1', diam1⟩
-  refine'
-    ⟨closure (EMetric.ball x₀ (ε / 2) ∩ D₀), closure (EMetric.ball x₁ (ε / 2) ∩ D₁),
-      ⟨perf0', non0', sub0'.trans sub0, diam0⟩, ⟨perf1', non1', sub1'.trans sub1, diam1⟩, _⟩
-  apply Disjoint.mono _ _ hdisj <;> assumption
-#align perfect.small_diam_splitting Perfect.small_diam_splitting
-
-open CantorScheme
-
-/-- Any nonempty perfect set in a complete metric space admits a continuous injection
-from the Cantor space, `ℕ → Bool`. -/
-theorem Perfect.exists_nat_bool_injection [CompleteSpace α] :
-    ∃ f : (ℕ → Bool) → α, range f ⊆ C ∧ Continuous f ∧ Injective f := by
-  obtain ⟨u, -, upos', hu⟩ := exists_seq_strictAnti_tendsto' (zero_lt_one' ℝ≥0∞)
-  have upos := fun n => (upos' n).1
-  let P := Subtype fun E : Set α => Perfect E ∧ E.Nonempty
-  choose C0 C1 h0 h1 hdisj using
-    fun {C : Set α} (hC : Perfect C) (hnonempty : C.Nonempty) {ε : ℝ≥0∞} (hε : 0 < ε) =>
-    hC.small_diam_splitting hnonempty hε
-  let DP : List Bool → P := fun l => by
-    induction' l with a l ih; · exact ⟨C, ⟨hC, hnonempty⟩⟩
-    cases a
-    · use C0 ih.property.1 ih.property.2 (upos l.length.succ)
-      exact ⟨(h0 _ _ _).1, (h0 _ _ _).2.1⟩
-    use C1 ih.property.1 ih.property.2 (upos l.length.succ)
-    exact ⟨(h1 _ _ _).1, (h1 _ _ _).2.1⟩
-  let D : List Bool → Set α := fun l => (DP l).val
-  have hanti : ClosureAntitone D := by
-    refine' Antitone.closureAntitone _ fun l => (DP l).property.1.closed
-    intro l a
-    cases a
-    · exact (h0 _ _ _).2.2.1
-    exact (h1 _ _ _).2.2.1
-  have hdiam : VanishingDiam D := by
-    intro x
-    apply tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds hu
-    · simp
-    rw [eventually_atTop]
-    refine' ⟨1, fun m (hm : 1 ≤ m) => _⟩
-    rw [Nat.one_le_iff_ne_zero] at hm
-    rcases Nat.exists_eq_succ_of_ne_zero hm with ⟨n, rfl⟩
-    dsimp
-    cases x n
-    · convert (h0 _ _ _).2.2.2
-      rw [PiNat.res_length]
-    convert (h1 _ _ _).2.2.2
-    rw [PiNat.res_length]
-  have hdisj' : CantorScheme.Disjoint D := by
-    rintro l (a | a) (b | b) hab <;> try contradiction
-    · exact hdisj _ _ _
-    exact (hdisj _ _ _).symm
-  have hdom : ∀ {x : ℕ → Bool}, x ∈ (inducedMap D).1 := fun {x} => by
-    rw [hanti.map_of_vanishingDiam hdiam fun l => (DP l).property.2]
-    apply mem_univ
-  refine' ⟨fun x => (inducedMap D).2 ⟨x, hdom⟩, _, _, _⟩
-  · rintro y ⟨x, rfl⟩
-    exact map_mem ⟨_, hdom⟩ 0
-  · apply hdiam.map_continuous.comp
-    continuity
-  intro x y hxy
-  simpa only [← Subtype.val_inj] using hdisj'.map_injective hxy
-#align perfect.exists_nat_bool_injection Perfect.exists_nat_bool_injection
-
-end CantorInjMetric
-
-/-- Any closed uncountable subset of a Polish space admits a continuous injection
-from the Cantor space `ℕ → Bool`.-/
-theorem IsClosed.exists_nat_bool_injection_of_not_countable {α : Type*} [TopologicalSpace α]
-    [PolishSpace α] {C : Set α} (hC : IsClosed C) (hunc : ¬C.Countable) :
-    ∃ f : (ℕ → Bool) → α, range f ⊆ C ∧ Continuous f ∧ Function.Injective f := by
-  letI := upgradePolishSpace α
-  obtain ⟨D, hD, Dnonempty, hDC⟩ := exists_perfect_nonempty_of_isClosed_of_not_countable hC hunc
-  obtain ⟨f, hfD, hf⟩ := hD.exists_nat_bool_injection Dnonempty
-  exact ⟨f, hfD.trans hDC, hf⟩
-#align is_closed.exists_nat_bool_injection_of_not_countable IsClosed.exists_nat_bool_injection_of_not_countable

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -838,7 +838,10 @@ theorem IsPreconnected.infinite_of_nontrivial [T1Space X] {s : Set X} (h : IsPre
   exact @PreconnectedSpace.trivial_of_discrete _ _ (Subtype.preconnectedSpace h) _
 #align is_preconnected.infinite_of_nontrivial IsPreconnected.infinite_of_nontrivial
 
-@[deprecated PerfectSpace.infinite]
+/--
+Prefer `PerfectSpace.infinite`, which is a strictly broader theorem.
+-/
+@[deprecated]
 theorem ConnectedSpace.infinite [ConnectedSpace X] [Nontrivial X] [T1Space X] : Infinite X :=
   infinite_univ_iff.mp <| isPreconnected_univ.infinite_of_nontrivial nontrivial_univ
 #align connected_space.infinite ConnectedSpace.infinite

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -842,16 +842,6 @@ theorem ConnectedSpace.infinite [ConnectedSpace X] [Nontrivial X] [T1Space X] : 
   infinite_univ_iff.mp <| isPreconnected_univ.infinite_of_nontrivial nontrivial_univ
 #align connected_space.infinite ConnectedSpace.infinite
 
-/-- A non-trivial connected T1 space has no isolated points. -/
-instance (priority := 100) ConnectedSpace.neBot_nhdsWithin_compl_of_nontrivial_of_t1space
-    [ConnectedSpace X] [Nontrivial X] [T1Space X] (x : X) :
-    NeBot (𝓝[≠] x) := by
-  by_contra contra
-  rw [not_neBot, ← isOpen_singleton_iff_punctured_nhds] at contra
-  replace contra := nonempty_inter isOpen_compl_singleton
-    contra (compl_union_self _) (Set.nonempty_compl_of_nontrivial _) (singleton_nonempty _)
-  simp [compl_inter_self {x}] at contra
-
 theorem singleton_mem_nhdsWithin_of_mem_discrete {s : Set X} [DiscreteTopology s] {x : X}
     (hx : x ∈ s) : {x} ∈ 𝓝[s] x := by
   have : ({⟨x, hx⟩} : Set s) ∈ 𝓝 (⟨x, hx⟩ : s) := by simp [nhds_discrete]

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -838,6 +838,7 @@ theorem IsPreconnected.infinite_of_nontrivial [T1Space X] {s : Set X} (h : IsPre
   exact @PreconnectedSpace.trivial_of_discrete _ _ (Subtype.preconnectedSpace h) _
 #align is_preconnected.infinite_of_nontrivial IsPreconnected.infinite_of_nontrivial
 
+@[deprecated PerfectSpace.infinite]
 theorem ConnectedSpace.infinite [ConnectedSpace X] [Nontrivial X] [T1Space X] : Infinite X :=
   infinite_univ_iff.mp <| isPreconnected_univ.infinite_of_nontrivial nontrivial_univ
 #align connected_space.infinite ConnectedSpace.infinite


### PR DESCRIPTION
This follows the addition of `PerfectSpace` in #10246, and replaces proofs of `NeBot (𝓝[≠] x)` with proofs of `PerfectSpace α`,
enabling easier generalization of theorems.

---
- [ ] depends on: #10272 (split `Topology.Perfect` into two modules, moving it higher in the import tree)
- [ ] depends on: #10246 (define `PerfectSpace`)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
