### PR TITLE
[Merged by Bors] - feat(Positivity): Strictness extractors

### DIFF
--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -49,6 +49,20 @@ def Strictness.toString : Strictness zα pα e → String
   | nonzero _ => "nonzero"
   | none => "none"
 
+/-- Combinator to turn a `Strictness` information about `e` into a proof that `e` is nonnegative, if
+possible. -/
+def Strictness.toNonneg {e} : Strictness zα pα e → Option Q(0 ≤ $e)
+  | .positive pf => some q(le_of_lt $pf)
+  | .nonnegative pf => some pf
+  | _ => .none
+
+/-- Combinator to turn a `Strictness` information about `e` into a proof that `e` is nonzero, if
+possible. -/
+def Strictness.toNonzero {e} : Strictness zα pα e → Option Q($e ≠ 0)
+  | .positive pf => some q(ne_of_gt $pf)
+  | .nonzero pf => some pf
+  | _ => .none
+
 /-- An extension for `positivity`. -/
 structure PositivityExt where
   /-- Attempts to prove an expression `e : α` is `>0`, `≥0`, or `≠0`. -/

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -49,15 +49,13 @@ def Strictness.toString : Strictness zα pα e → String
   | nonzero _ => "nonzero"
   | none => "none"
 
-/-- Combinator to turn a `Strictness` information about `e` into a proof that `e` is nonnegative, if
-possible. -/
+/-- Extract a proof that `e` is nonnegative, if possible, from `Strictness` information about `e`. -/
 def Strictness.toNonneg {e} : Strictness zα pα e → Option Q(0 ≤ $e)
   | .positive pf => some q(le_of_lt $pf)
   | .nonnegative pf => some pf
   | _ => .none
 
-/-- Combinator to turn a `Strictness` information about `e` into a proof that `e` is nonzero, if
-possible. -/
+/-- Extract a proof that `e` is nonzero, if possible, from `Strictness` information about `e`. -/
 def Strictness.toNonzero {e} : Strictness zα pα e → Option Q($e ≠ 0)
   | .positive pf => some q(ne_of_gt $pf)
   | .nonzero pf => some pf

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -49,7 +49,8 @@ def Strictness.toString : Strictness zα pα e → String
   | nonzero _ => "nonzero"
   | none => "none"
 
-/-- Extract a proof that `e` is nonnegative, if possible, from `Strictness` information about `e`. -/
+/-- Extract a proof that `e` is nonnegative, if possible, from `Strictness` information about `e`.
+-/
 def Strictness.toNonneg {e} : Strictness zα pα e → Option Q(0 ≤ $e)
   | .positive pf => some q(le_of_lt $pf)
   | .nonnegative pf => some pf


### PR DESCRIPTION
Define combinators to turn strictness assumptions into proofs of nonnegativity or nonzeroness.

These are useful to write `positivity` extensions where having `0 < a` doesn't help.

We might want binary combinators in the future. Eg the pattern "Binary function `foo` is positive/nonnegative/nonzero if its inputs are" is very common.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
