### PR TITLE
[Merged by Bors] - chore: Make sure `WithOne` doesn't import rings

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -478,6 +478,7 @@ import Mathlib.Algebra.Ring.Regular
 import Mathlib.Algebra.Ring.Semiconj
 import Mathlib.Algebra.Ring.ULift
 import Mathlib.Algebra.Ring.Units
+import Mathlib.Algebra.Ring.WithZero
 import Mathlib.Algebra.RingQuot
 import Mathlib.Algebra.SMulWithZero
 import Mathlib.Algebra.Squarefree.Basic

--- a/Mathlib/Algebra/Group/WithOne/Basic.lean
+++ b/Mathlib/Algebra/Group/WithOne/Basic.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Johan Commelin
 -/
 import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Group.WithOne.Defs
+import Mathlib.Data.Option.Basic
 
 #align_import algebra.group.with_one.basic from "leanprover-community/mathlib"@"4dc134b97a3de65ef2ed881f3513d56260971562"
 

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -3,8 +3,12 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johan Commelin
 -/
-import Mathlib.Algebra.Ring.Defs
-import Mathlib.Order.WithBot
+import Mathlib.Algebra.GroupWithZero.Defs
+import Mathlib.Data.Nat.Cast.Defs
+import Mathlib.Data.Option.Defs
+import Mathlib.Data.Option.NAry
+import Mathlib.Logic.Nontrivial.Basic
+import Mathlib.Tactic.Common
 
 #align_import algebra.group.with_one.defs from "leanprover-community/mathlib"@"995b47e555f1b6297c7cf16855f1023e355219fb"
 
@@ -119,8 +123,7 @@ attribute [elab_as_elim] WithZero.recZeroCoe
 /-- Deconstruct an `x : WithOne α` to the underlying value in `α`, given a proof that `x ≠ 1`. -/
 @[to_additive unzero
       "Deconstruct an `x : WithZero α` to the underlying value in `α`, given a proof that `x ≠ 0`."]
-def unone {x : WithOne α} (hx : x ≠ 1) : α :=
-  WithBot.unbot x hx
+def unone : ∀ {x : WithOne α}, x ≠ 1 → α | (x : α), _ => x
 #align with_one.unone WithOne.unone
 #align with_zero.unzero WithZero.unzero
 
@@ -131,8 +134,7 @@ theorem unone_coe {x : α} (hx : (x : WithOne α) ≠ 1) : unone hx = x :=
 #align with_zero.unzero_coe WithZero.unzero_coe
 
 @[to_additive (attr := simp) coe_unzero]
-theorem coe_unone {x : WithOne α} (hx : x ≠ 1) : ↑(unone hx) = x :=
-  WithBot.coe_unbot x hx
+theorem coe_unone : ∀ {x : WithOne α} (hx : x ≠ 1), unone hx = x | (x : α), _ => rfl
 #align with_one.coe_unone WithOne.coe_unone
 #align with_zero.coe_unzero WithZero.coe_unzero
 
@@ -375,30 +377,6 @@ instance addMonoidWithOne [AddMonoidWithOne α] : AddMonoidWithOne (WithZero α)
           rw [Nat.cast_succ, coe_add, coe_one]
       }
 
-instance instLeftDistribClass [Mul α] [Add α] [LeftDistribClass α] :
-    LeftDistribClass (WithZero α) where
-  left_distrib a b c := by
-    cases' a with a; · rfl
-    cases' b with b <;> cases' c with c <;> try rfl
-    exact congr_arg some (left_distrib _ _ _)
-
-instance instRightDistribClass [Mul α] [Add α] [RightDistribClass α] :
-    RightDistribClass (WithZero α) where
-  right_distrib a b c := by
-    cases' c with c
-    · change (a + b) * 0 = a * 0 + b * 0
-      simp
-    cases' a with a <;> cases' b with b <;> try rfl
-    exact congr_arg some (right_distrib _ _ _)
-
-instance instDistrib [Distrib α] : Distrib (WithZero α) where
-  left_distrib := left_distrib
-  right_distrib := right_distrib
-
-instance semiring [Semiring α] : Semiring (WithZero α) :=
-  { WithZero.addMonoidWithOne, WithZero.addCommMonoid, WithZero.mulZeroClass,
-    WithZero.monoidWithZero, WithZero.instDistrib with }
-
 end WithZero
 
 -- Check that we haven't needed to import all the basic lemmas about groups,
@@ -406,3 +384,5 @@ end WithZero
 assert_not_exists inv_involutive
 assert_not_exists div_right_inj
 assert_not_exists pow_ite
+
+assert_not_exists Ring

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -134,7 +134,8 @@ theorem unone_coe {x : α} (hx : (x : WithOne α) ≠ 1) : unone hx = x :=
 #align with_zero.unzero_coe WithZero.unzero_coe
 
 @[to_additive (attr := simp) coe_unzero]
-theorem coe_unone : ∀ {x : WithOne α} (hx : x ≠ 1), unone hx = x | (x : α), _ => rfl
+lemma coe_unone : ∀ {x : WithOne α} (hx : x ≠ 1), unone hx = x
+  | (x : α), _ => rfl
 #align with_one.coe_unone WithOne.coe_unone
 #align with_zero.coe_unzero WithZero.coe_unzero
 

--- a/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithZero/Defs.lean
@@ -6,6 +6,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 import Mathlib.Algebra.Order.ZeroLEOne
+import Mathlib.Order.WithBot
 
 #align_import algebra.order.monoid.with_zero.defs from "leanprover-community/mathlib"@"4dc134b97a3de65ef2ed881f3513d56260971562"
 

--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -12,9 +12,8 @@ import Mathlib.Algebra.Order.Monoid.MinMax
 import Mathlib.Algebra.Order.Monoid.NatCast
 import Mathlib.Algebra.Order.Monoid.WithZero.Defs
 import Mathlib.Algebra.Order.Ring.Lemmas
+import Mathlib.Algebra.Ring.Defs
 import Mathlib.Data.Pi.Algebra
-import Mathlib.Tactic.ByContra
-import Mathlib.Tactic.Nontriviality
 import Mathlib.Tactic.Tauto
 
 #align_import algebra.order.ring.defs from "leanprover-community/mathlib"@"44e29dbcff83ba7114a464d592b8c3743987c1e5"

--- a/Mathlib/Algebra/Ring/WithZero.lean
+++ b/Mathlib/Algebra/Ring/WithZero.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2020 Mario Carneiro, Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Johan Commelin
+-/
+import Mathlib.Algebra.Group.WithOne.Defs
+import Mathlib.Algebra.Ring.Defs
+
+/-!
+# Adjoining a zero to a semiring
+-/
+
+namespace WithZero
+variable {α : Type*}
+
+instance instLeftDistribClass [Mul α] [Add α] [LeftDistribClass α] :
+    LeftDistribClass (WithZero α) where
+  left_distrib a b c := by
+    cases' a with a; · rfl
+    cases' b with b <;> cases' c with c <;> try rfl
+    exact congr_arg some (left_distrib _ _ _)
+
+instance instRightDistribClass [Mul α] [Add α] [RightDistribClass α] :
+    RightDistribClass (WithZero α) where
+  right_distrib a b c := by
+    cases' c with c
+    · change (a + b) * 0 = a * 0 + b * 0
+      simp
+    cases' a with a <;> cases' b with b <;> try rfl
+    exact congr_arg some (right_distrib _ _ _)
+
+instance instDistrib [Distrib α] : Distrib (WithZero α) where
+  left_distrib := left_distrib
+  right_distrib := right_distrib
+
+instance instSemiring [Semiring α] : Semiring (WithZero α) :=
+  { addMonoidWithOne, addCommMonoid, mulZeroClass, monoidWithZero, instDistrib with }
+
+end WithZero


### PR DESCRIPTION
Reorder the `WithOne` material.
* `Algebra.Group.WithOne.Defs` was hiding a `Ring` import! I credit Johan and Mario for https://github.com/leanprover-community/mathlib/pull/2707.
* `WithBot` is not needed to define `WithOne.unone`. It's simpler to redefine it by hand. In the future, we might want to have an `Option` version (but not sure how much that's worth, since it would basically be `Option.get` again).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
