### PR TITLE
[Merged by Bors] - chore(MeasureTheory): `Fintype` -> `Finite`

### DIFF
--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -183,14 +183,13 @@ theorem hasFiniteIntegral_of_bounded [IsFiniteMeasure μ] {f : α → β} {C : �
   (hasFiniteIntegral_const C).mono' hC
 #align measure_theory.has_finite_integral_of_bounded MeasureTheory.hasFiniteIntegral_of_bounded
 
-theorem hasFiniteIntegral_of_fintype [Fintype α] [IsFiniteMeasure μ] {f : α → β} :
+theorem HasFiniteIntegral.of_finite [Finite α] [IsFiniteMeasure μ] {f : α → β} :
     HasFiniteIntegral f μ :=
-  hasFiniteIntegral_of_bounded (C := (Finset.sup .univ (fun a => ‖f a‖₊) : NNReal)) <| by
-    apply ae_of_all μ
-    intro x
-    rw [← coe_nnnorm (f x)]
-    apply NNReal.toReal_le_toReal
-    apply Finset.le_sup (Finset.mem_univ x)
+  let ⟨_⟩ := nonempty_fintype α
+  hasFiniteIntegral_of_bounded <| ae_of_all μ <| norm_le_pi_norm f
+
+@[deprecated] -- Since 2024/02/05
+alias hasFiniteIntegral_of_fintype := HasFiniteIntegral.of_finite
 
 theorem HasFiniteIntegral.mono_measure {f : α → β} (h : HasFiniteIntegral f ν) (hμ : μ ≤ ν) :
     HasFiniteIntegral f μ :=
@@ -506,10 +505,12 @@ theorem integrable_const [IsFiniteMeasure μ] (c : β) : Integrable (fun _ : α 
 #align measure_theory.integrable_const MeasureTheory.integrable_const
 
 @[simp]
-theorem integrable_of_fintype [Fintype α] [MeasurableSpace α] [MeasurableSingletonClass α]
+theorem Integrable.of_finite [Finite α] [MeasurableSpace α] [MeasurableSingletonClass α]
     (μ : Measure α) [IsFiniteMeasure μ] (f : α → β) : Integrable (fun a ↦ f a) μ :=
-  ⟨ StronglyMeasurable.aestronglyMeasurable (stronglyMeasurable_of_fintype f),
-    hasFiniteIntegral_of_fintype ⟩
+  ⟨(StronglyMeasurable.of_finite f).aestronglyMeasurable, .of_finite⟩
+
+@[deprecated] -- Since 2024/02/05
+alias integrable_of_fintype := Integrable.of_finite
 
 theorem Memℒp.integrable_norm_rpow {f : α → β} {p : ℝ≥0∞} (hf : Memℒp f p μ) (hp_ne_zero : p ≠ 0)
     (hp_ne_top : p ≠ ∞) : Integrable (fun x : α => ‖f x‖ ^ p.toReal) μ := by

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -84,18 +84,18 @@ theorem apply_mk (f : α → β) (h h') (x : α) : SimpleFunc.mk f h h' x = f x 
   rfl
 #align measure_theory.simple_func.apply_mk MeasureTheory.SimpleFunc.apply_mk
 
-/-- Simple function defined on the empty type. -/
-def ofIsEmpty [IsEmpty α] : α →ₛ β where
-  toFun := isEmptyElim
-  measurableSet_fiber' x := Subsingleton.measurableSet
-  finite_range' := by simp [range_eq_empty]
-#align measure_theory.simple_func.of_is_empty MeasureTheory.SimpleFunc.ofIsEmpty
-
 /-- Simple function defined on a finite type. -/
-def ofFintype [Fintype α] [MeasurableSingletonClass α] (f : α → β) : α →ₛ β where
+def ofFinite [Finite α] [MeasurableSingletonClass α] (f : α → β) : α →ₛ β where
   toFun := f
-  measurableSet_fiber' x := Finite.measurableSet (toFinite (f ⁻¹' {x}))
+  measurableSet_fiber' x := (toFinite (f ⁻¹' {x})).measurableSet
   finite_range' := Set.finite_range f
+
+@[deprecated] -- Since 2024/02/05
+alias ofFintype := ofFinite
+
+/-- Simple function defined on the empty type. -/
+def ofIsEmpty [IsEmpty α] : α →ₛ β := ofFinite isEmptyElim
+#align measure_theory.simple_func.of_is_empty MeasureTheory.SimpleFunc.ofIsEmpty
 
 /-- Range of a simple function `α →ₛ β` as a `Finset β`. -/
 protected def range (f : α →ₛ β) : Finset β :=

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -129,15 +129,20 @@ theorem SimpleFunc.stronglyMeasurable {α β} {_ : MeasurableSpace α} [Topologi
   ⟨fun _ => f, fun _ => tendsto_const_nhds⟩
 #align measure_theory.simple_func.strongly_measurable MeasureTheory.SimpleFunc.stronglyMeasurable
 
-theorem stronglyMeasurable_of_isEmpty [IsEmpty α] {_ : MeasurableSpace α} [TopologicalSpace β]
-    (f : α → β) : StronglyMeasurable f :=
-  ⟨fun _ => SimpleFunc.ofIsEmpty, isEmptyElim⟩
-#align measure_theory.strongly_measurable_of_is_empty MeasureTheory.stronglyMeasurable_of_isEmpty
-
-theorem stronglyMeasurable_of_fintype [Fintype α] {_ : MeasurableSpace α}
+@[nontriviality]
+theorem StronglyMeasurable.of_finite [Finite α] {_ : MeasurableSpace α}
     [MeasurableSingletonClass α] [TopologicalSpace β]
     (f : α → β) : StronglyMeasurable f :=
-  ⟨fun _ => SimpleFunc.ofFintype f, fun _ => tendsto_const_nhds⟩
+  ⟨fun _ => SimpleFunc.ofFinite f, fun _ => tendsto_const_nhds⟩
+
+@[deprecated] -- Since 2024/02/05
+alias stronglyMeasurable_of_fintype := StronglyMeasurable.of_finite
+
+@[deprecated StronglyMeasurable.of_finite]
+theorem stronglyMeasurable_of_isEmpty [IsEmpty α] {_ : MeasurableSpace α} [TopologicalSpace β]
+    (f : α → β) : StronglyMeasurable f :=
+  .of_finite f
+#align measure_theory.strongly_measurable_of_is_empty MeasureTheory.StronglyMeasurable.of_finite
 
 theorem stronglyMeasurable_const {α β} {_ : MeasurableSpace α} [TopologicalSpace β] {b : β} :
     StronglyMeasurable fun _ : α => b :=
@@ -147,7 +152,7 @@ theorem stronglyMeasurable_const {α β} {_ : MeasurableSpace α} [TopologicalSp
 @[to_additive]
 theorem stronglyMeasurable_one {α β} {_ : MeasurableSpace α} [TopologicalSpace β] [One β] :
     StronglyMeasurable (1 : α → β) :=
-  @stronglyMeasurable_const _ _ _ _ 1
+  stronglyMeasurable_const
 #align measure_theory.strongly_measurable_one MeasureTheory.stronglyMeasurable_one
 #align measure_theory.strongly_measurable_zero MeasureTheory.stronglyMeasurable_zero
 
@@ -155,10 +160,10 @@ theorem stronglyMeasurable_one {α β} {_ : MeasurableSpace α} [TopologicalSpac
 This version works for functions between empty types. -/
 theorem stronglyMeasurable_const' {α β} {m : MeasurableSpace α} [TopologicalSpace β] {f : α → β}
     (hf : ∀ x y, f x = f y) : StronglyMeasurable f := by
-  cases' isEmpty_or_nonempty α with _ h
-  · exact stronglyMeasurable_of_isEmpty f
-  · convert stronglyMeasurable_const (β := β) using 1
-    exact funext fun x => hf x h.some
+  nontriviality α
+  inhabit α
+  convert stronglyMeasurable_const (β := β) using 1
+  exact funext fun x => hf x default
 #align measure_theory.strongly_measurable_const' MeasureTheory.stronglyMeasurable_const'
 
 -- porting note: changed binding type of `MeasurableSpace α`.

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -1825,7 +1825,7 @@ theorem integral_fintype [MeasurableSingletonClass α] [Fintype α] (f : α → 
     (hf : Integrable f μ) :
     ∫ x, f x ∂μ = ∑ x, (μ {x}).toReal • f x := by
   -- NB: Integrable f does not follow from Fintype, because the measure itself could be non-finite
-  rw [← integral_finset .univ , Finset.coe_univ, Measure.restrict_univ]
+  rw [← integral_finset .univ, Finset.coe_univ, Measure.restrict_univ]
   simp only [Finset.coe_univ, Measure.restrict_univ, hf]
 
 theorem integral_unique [Unique α] (f : α → E) : ∫ x, f x ∂μ = (μ univ).toReal • f default :=

--- a/Mathlib/Probability/ProbabilityMassFunction/Integrals.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Integrals.lean
@@ -42,7 +42,7 @@ theorem integral_eq_tsum (p : PMF α) (f : α → E) (hf : Integrable f p.toMeas
 
 theorem integral_eq_sum [Fintype α] (p : PMF α) (f : α → E) :
     ∫ a, f a ∂(p.toMeasure) = ∑ a, (p a).toReal • f a := by
-  rw [integral_fintype _ (integrable_of_fintype _ f)]
+  rw [integral_fintype _ (.of_finite _ f)]
   congr with x; congr
   exact PMF.toMeasure_apply_singleton p x (MeasurableSet.singleton _)
 


### PR DESCRIPTION
* Rename `hasFiniteIntegral_of_fintype` to `HasFiniteIntegral.of_finite`, generalize to `[Finite α]`, golf.
* Rename `integrable_of_fintype` to `Integrable.of_finite`, generalize to `[Finite α]`.
* Rename `SimpleFunc.ofFintype` to `SimpleFunc.ofFinite`, generalize to `[Finite α]`, use it to golf `SimpleFunc.ofIsEmpty`.
* Rename `stronglyMeasurable_of_fintype` to `StronglyMeasurable.of_finite`, deprecate `stronglyMeasurable_of_isEmpty`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
