### PR TITLE
[Merged by Bors] - Deprecate allowing auto-replacement

### DIFF
--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -272,7 +272,7 @@ theorem linfty_opNorm_def (A : Matrix m n α) :
   simp [Pi.norm_def, PiLp.nnnorm_eq_sum ENNReal.one_ne_top]
 #align matrix.linfty_op_norm_def Matrix.linfty_opNorm_def
 
-@[deprecated linfty_opNorm_def]
+@[deprecated]
 alias linfty_op_norm_def :=
   linfty_opNorm_def -- deprecated on 2024-02-02
 
@@ -281,7 +281,7 @@ theorem linfty_opNNNorm_def (A : Matrix m n α) :
   Subtype.ext <| linfty_opNorm_def A
 #align matrix.linfty_op_nnnorm_def Matrix.linfty_opNNNorm_def
 
-@[deprecated linfty_opNNNorm_def]
+@[deprecated]
 alias linfty_op_nnnorm_def :=
   linfty_opNNNorm_def -- deprecated on 2024-02-02
 
@@ -291,7 +291,7 @@ theorem linfty_opNNNorm_col (v : m → α) : ‖col v‖₊ = ‖v‖₊ := by
   simp
 #align matrix.linfty_op_nnnorm_col Matrix.linfty_opNNNorm_col
 
-@[deprecated linfty_opNNNorm_col]
+@[deprecated]
 alias linfty_op_nnnorm_col :=
   linfty_opNNNorm_col -- deprecated on 2024-02-02
 
@@ -300,7 +300,7 @@ theorem linfty_opNorm_col (v : m → α) : ‖col v‖ = ‖v‖ :=
   congr_arg ((↑) : ℝ≥0 → ℝ) <| linfty_opNNNorm_col v
 #align matrix.linfty_op_norm_col Matrix.linfty_opNorm_col
 
-@[deprecated linfty_opNorm_col]
+@[deprecated]
 alias linfty_op_norm_col :=
   linfty_opNorm_col -- deprecated on 2024-02-02
 
@@ -308,7 +308,7 @@ alias linfty_op_norm_col :=
 theorem linfty_opNNNorm_row (v : n → α) : ‖row v‖₊ = ∑ i, ‖v i‖₊ := by simp [linfty_opNNNorm_def]
 #align matrix.linfty_op_nnnorm_row Matrix.linfty_opNNNorm_row
 
-@[deprecated linfty_opNNNorm_row]
+@[deprecated]
 alias linfty_op_nnnorm_row :=
   linfty_opNNNorm_row -- deprecated on 2024-02-02
 
@@ -317,7 +317,7 @@ theorem linfty_opNorm_row (v : n → α) : ‖row v‖ = ∑ i, ‖v i‖ :=
   (congr_arg ((↑) : ℝ≥0 → ℝ) <| linfty_opNNNorm_row v).trans <| by simp [NNReal.coe_sum]
 #align matrix.linfty_op_norm_row Matrix.linfty_opNorm_row
 
-@[deprecated linfty_opNorm_row]
+@[deprecated]
 alias linfty_op_norm_row :=
   linfty_opNorm_row -- deprecated on 2024-02-02
 
@@ -330,7 +330,7 @@ theorem linfty_opNNNorm_diagonal [DecidableEq m] (v : m → α) : ‖diagonal v�
   · rw [diagonal_apply_eq]
 #align matrix.linfty_op_nnnorm_diagonal Matrix.linfty_opNNNorm_diagonal
 
-@[deprecated linfty_opNNNorm_diagonal]
+@[deprecated]
 alias linfty_op_nnnorm_diagonal :=
   linfty_opNNNorm_diagonal -- deprecated on 2024-02-02
 
@@ -339,7 +339,7 @@ theorem linfty_opNorm_diagonal [DecidableEq m] (v : m → α) : ‖diagonal v‖
   congr_arg ((↑) : ℝ≥0 → ℝ) <| linfty_opNNNorm_diagonal v
 #align matrix.linfty_op_norm_diagonal Matrix.linfty_opNorm_diagonal
 
-@[deprecated linfty_opNorm_diagonal]
+@[deprecated]
 alias linfty_op_norm_diagonal :=
   linfty_opNorm_diagonal -- deprecated on 2024-02-02
 
@@ -368,7 +368,7 @@ theorem linfty_opNNNorm_mul (A : Matrix l m α) (B : Matrix m n α) : ‖A * B�
       rfl
 #align matrix.linfty_op_nnnorm_mul Matrix.linfty_opNNNorm_mul
 
-@[deprecated linfty_opNNNorm_mul]
+@[deprecated]
 alias linfty_op_nnnorm_mul :=
   linfty_opNNNorm_mul -- deprecated on 2024-02-02
 
@@ -376,7 +376,7 @@ theorem linfty_opNorm_mul (A : Matrix l m α) (B : Matrix m n α) : ‖A * B‖ 
   linfty_opNNNorm_mul _ _
 #align matrix.linfty_op_norm_mul Matrix.linfty_opNorm_mul
 
-@[deprecated linfty_opNorm_mul]
+@[deprecated]
 alias linfty_op_norm_mul :=
   linfty_opNorm_mul -- deprecated on 2024-02-02
 
@@ -385,7 +385,7 @@ theorem linfty_opNNNorm_mulVec (A : Matrix l m α) (v : m → α) : ‖A.mulVec 
   exact linfty_opNNNorm_mul A (col v)
 #align matrix.linfty_op_nnnorm_mul_vec Matrix.linfty_opNNNorm_mulVec
 
-@[deprecated linfty_opNNNorm_mulVec]
+@[deprecated]
 alias linfty_op_nnnorm_mulVec :=
   linfty_opNNNorm_mulVec -- deprecated on 2024-02-02
 
@@ -393,7 +393,7 @@ theorem linfty_opNorm_mulVec (A : Matrix l m α) (v : m → α) : ‖Matrix.mulV
   linfty_opNNNorm_mulVec _ _
 #align matrix.linfty_op_norm_mul_vec Matrix.linfty_opNorm_mulVec
 
-@[deprecated linfty_opNorm_mulVec]
+@[deprecated]
 alias linfty_op_norm_mulVec :=
   linfty_opNorm_mulVec -- deprecated on 2024-02-02
 
@@ -500,7 +500,7 @@ lemma linfty_opNNNorm_eq_opNNNorm (A : Matrix m n α) :
     mul_one] at hN
   exact hN
 
-@[deprecated linfty_opNNNorm_eq_opNNNorm]
+@[deprecated]
 alias linfty_op_nnnorm_eq_op_nnnorm :=
   linfty_opNNNorm_eq_opNNNorm -- deprecated on 2024-02-02
 
@@ -508,7 +508,7 @@ lemma linfty_opNorm_eq_opNorm (A : Matrix m n α) :
     ‖A‖ = ‖ContinuousLinearMap.mk (Matrix.mulVecLin A)‖ :=
   congr_arg NNReal.toReal (linfty_opNNNorm_eq_opNNNorm A)
 
-@[deprecated linfty_opNorm_eq_opNorm]
+@[deprecated]
 alias linfty_op_norm_eq_op_norm :=
   linfty_opNorm_eq_opNorm -- deprecated on 2024-02-02
 
@@ -519,7 +519,7 @@ variable [DecidableEq n]
   rw [linfty_opNNNorm_eq_opNNNorm]
   simp only [← toLin'_apply', toLin'_toMatrix']
 
-@[deprecated linfty_opNNNorm_toMatrix]
+@[deprecated]
 alias linfty_op_nnnorm_toMatrix :=
   linfty_opNNNorm_toMatrix -- deprecated on 2024-02-02
 
@@ -527,7 +527,7 @@ alias linfty_op_nnnorm_toMatrix :=
     ‖LinearMap.toMatrix' (↑f : (n → α) →ₗ[α] (m → α))‖ = ‖f‖ :=
   congr_arg NNReal.toReal (linfty_opNNNorm_toMatrix f)
 
-@[deprecated linfty_opNorm_toMatrix]
+@[deprecated]
 alias linfty_op_norm_toMatrix :=
   linfty_opNorm_toMatrix -- deprecated on 2024-02-02
 

--- a/Mathlib/Analysis/NormedSpace/FiniteDimension.lean
+++ b/Mathlib/Analysis/NormedSpace/FiniteDimension.lean
@@ -288,7 +288,7 @@ theorem Basis.opNNNorm_le {ι : Type*} [Fintype ι] (v : Basis ι 𝕜 E) {u : E
       _ = Fintype.card ι • ‖φ‖₊ * M * ‖e‖₊ := by simp only [smul_mul_assoc, mul_right_comm]
 #align basis.op_nnnorm_le Basis.opNNNorm_le
 
-@[deprecated Basis.opNNNorm_le]
+@[deprecated]
 alias Basis.op_nnnorm_le :=
   Basis.opNNNorm_le -- deprecated on 2024-02-02
 
@@ -298,7 +298,7 @@ theorem Basis.opNorm_le {ι : Type*} [Fintype ι] (v : Basis ι 𝕜 E) {u : E �
   simpa using NNReal.coe_le_coe.mpr (v.opNNNorm_le ⟨M, hM⟩ hu)
 #align basis.op_norm_le Basis.opNorm_le
 
-@[deprecated Basis.opNorm_le]
+@[deprecated]
 alias Basis.op_norm_le :=
   Basis.opNorm_le -- deprecated on 2024-02-02
 
@@ -312,7 +312,7 @@ theorem Basis.exists_opNNNorm_le {ι : Type*} [Finite ι] (v : Basis ι 𝕜 E) 
       (v.opNNNorm_le M hu).trans <| mul_le_mul_of_nonneg_right (le_max_left _ _) (zero_le M)⟩
 #align basis.exists_op_nnnorm_le Basis.exists_opNNNorm_le
 
-@[deprecated Basis.exists_opNNNorm_le]
+@[deprecated]
 alias Basis.exists_op_nnnorm_le :=
   Basis.exists_opNNNorm_le -- deprecated on 2024-02-02
 
@@ -326,7 +326,7 @@ theorem Basis.exists_opNorm_le {ι : Type*} [Finite ι] (v : Basis ι 𝕜 E) :
   simpa using h ⟨M, hM⟩ H
 #align basis.exists_op_norm_le Basis.exists_opNorm_le
 
-@[deprecated Basis.exists_opNorm_le]
+@[deprecated]
 alias Basis.exists_op_norm_le :=
   Basis.exists_opNorm_le -- deprecated on 2024-02-02
 

--- a/Mathlib/Analysis/NormedSpace/IsROrC.lean
+++ b/Mathlib/Analysis/NormedSpace/IsROrC.lean
@@ -93,7 +93,7 @@ theorem ContinuousLinearMap.opNorm_bound_of_ball_bound {r : ℝ} (r_pos : 0 < r)
   exact fun z hz => h z hz
 #align continuous_linear_map.op_norm_bound_of_ball_bound ContinuousLinearMap.opNorm_bound_of_ball_bound
 
-@[deprecated ContinuousLinearMap.opNorm_bound_of_ball_bound]
+@[deprecated]
 alias ContinuousLinearMap.op_norm_bound_of_ball_bound :=
   ContinuousLinearMap.opNorm_bound_of_ball_bound -- deprecated on 2024-02-02
 

--- a/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
@@ -357,7 +357,7 @@ theorem isLeast_opNorm : IsLeast {c : ℝ | 0 ≤ c ∧ ∀ m, ‖f m‖ ≤ c *
   exact isClosed_Ici.inter (isClosed_iInter fun m ↦
     isClosed_le continuous_const (continuous_id.mul continuous_const))
 
-@[deprecated isLeast_opNorm]
+@[deprecated]
 alias isLeast_op_norm :=
   isLeast_opNorm -- deprecated on 2024-02-02
 
@@ -365,7 +365,7 @@ theorem opNorm_nonneg : 0 ≤ ‖f‖ :=
   Real.sInf_nonneg _ fun _ ⟨hx, _⟩ => hx
 #align continuous_multilinear_map.op_norm_nonneg ContinuousMultilinearMap.opNorm_nonneg
 
-@[deprecated opNorm_nonneg]
+@[deprecated]
 alias op_norm_nonneg :=
   opNorm_nonneg -- deprecated on 2024-02-02
 
@@ -374,7 +374,7 @@ alias op_norm_nonneg :=
 theorem le_opNorm : ‖f m‖ ≤ ‖f‖ * ∏ i, ‖m i‖ := f.isLeast_opNorm.1.2 m
 #align continuous_multilinear_map.le_op_norm ContinuousMultilinearMap.le_opNorm
 
-@[deprecated le_opNorm]
+@[deprecated]
 alias le_op_norm :=
   le_opNorm -- deprecated on 2024-02-02
 
@@ -385,7 +385,7 @@ theorem le_mul_prod_of_le_opNorm_of_le {C : ℝ} {b : ι → ℝ} (hC : ‖f‖ 
   (f.le_opNorm m).trans <| mul_le_mul hC (prod_le_prod (fun _ _ ↦ norm_nonneg _) fun _ _ ↦ hm _)
     (prod_nonneg fun _ _ ↦ norm_nonneg _) ((opNorm_nonneg _).trans hC)
 
-@[deprecated le_mul_prod_of_le_opNorm_of_le]
+@[deprecated]
 alias le_mul_prod_of_le_op_norm_of_le :=
   le_mul_prod_of_le_opNorm_of_le -- deprecated on 2024-02-02
 
@@ -395,7 +395,7 @@ theorem le_opNorm_mul_prod_of_le {b : ι → ℝ} (hm : ∀ i, ‖m i‖ ≤ b i
   le_mul_prod_of_le_opNorm_of_le le_rfl hm
 #align continuous_multilinear_map.le_op_norm_mul_prod_of_le ContinuousMultilinearMap.le_opNorm_mul_prod_of_le
 
-@[deprecated le_opNorm_mul_prod_of_le]
+@[deprecated]
 alias le_op_norm_mul_prod_of_le :=
   le_opNorm_mul_prod_of_le -- deprecated on 2024-02-02
 
@@ -404,7 +404,7 @@ theorem le_opNorm_mul_pow_card_of_le {b : ℝ} (hm : ‖m‖ ≤ b) :
   simpa only [prod_const] using f.le_opNorm_mul_prod_of_le fun i => (norm_le_pi_norm m i).trans hm
 #align continuous_multilinear_map.le_op_norm_mul_pow_card_of_le ContinuousMultilinearMap.le_opNorm_mul_pow_card_of_le
 
-@[deprecated le_opNorm_mul_pow_card_of_le]
+@[deprecated]
 alias le_op_norm_mul_pow_card_of_le :=
   le_opNorm_mul_pow_card_of_le -- deprecated on 2024-02-02
 
@@ -414,7 +414,7 @@ theorem le_opNorm_mul_pow_of_le {Ei : Fin n → Type*} [∀ i, NormedAddCommGrou
   simpa only [Fintype.card_fin] using f.le_opNorm_mul_pow_card_of_le hm
 #align continuous_multilinear_map.le_op_norm_mul_pow_of_le ContinuousMultilinearMap.le_opNorm_mul_pow_of_le
 
-@[deprecated le_opNorm_mul_pow_of_le]
+@[deprecated]
 alias le_op_norm_mul_pow_of_le :=
   le_opNorm_mul_pow_of_le -- deprecated on 2024-02-02
 
@@ -424,7 +424,7 @@ theorem le_of_opNorm_le {C : ℝ} (h : ‖f‖ ≤ C) : ‖f m‖ ≤ C * ∏ i,
   le_mul_prod_of_le_opNorm_of_le h fun _ ↦ le_rfl
 #align continuous_multilinear_map.le_of_op_norm_le ContinuousMultilinearMap.le_of_opNorm_le
 
-@[deprecated le_of_opNorm_le]
+@[deprecated]
 alias le_of_op_norm_le :=
   le_of_opNorm_le -- deprecated on 2024-02-02
 
@@ -435,7 +435,7 @@ theorem ratio_le_opNorm : (‖f m‖ / ∏ i, ‖m i‖) ≤ ‖f‖ :=
     (f.le_opNorm m)
 #align continuous_multilinear_map.ratio_le_op_norm ContinuousMultilinearMap.ratio_le_opNorm
 
-@[deprecated ratio_le_opNorm]
+@[deprecated]
 alias ratio_le_op_norm :=
   ratio_le_opNorm -- deprecated on 2024-02-02
 
@@ -444,7 +444,7 @@ theorem unit_le_opNorm (h : ‖m‖ ≤ 1) : ‖f m‖ ≤ ‖f‖ :=
   (le_opNorm_mul_pow_card_of_le f h).trans <| by simp
 #align continuous_multilinear_map.unit_le_op_norm ContinuousMultilinearMap.unit_le_opNorm
 
-@[deprecated unit_le_opNorm]
+@[deprecated]
 alias unit_le_op_norm :=
   unit_le_opNorm -- deprecated on 2024-02-02
 
@@ -453,14 +453,14 @@ theorem opNorm_le_bound {M : ℝ} (hMp : 0 ≤ M) (hM : ∀ m, ‖f m‖ ≤ M *
   csInf_le bounds_bddBelow ⟨hMp, hM⟩
 #align continuous_multilinear_map.op_norm_le_bound ContinuousMultilinearMap.opNorm_le_bound
 
-@[deprecated opNorm_le_bound]
+@[deprecated]
 alias op_norm_le_bound :=
   opNorm_le_bound -- deprecated on 2024-02-02
 
 theorem opNorm_le_iff {C : ℝ} (hC : 0 ≤ C) : ‖f‖ ≤ C ↔ ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖ :=
   ⟨fun h _ ↦ le_of_opNorm_le _ h, opNorm_le_bound _ hC⟩
 
-@[deprecated opNorm_le_iff]
+@[deprecated]
 alias op_norm_le_iff :=
   opNorm_le_iff -- deprecated on 2024-02-02
 
@@ -471,7 +471,7 @@ theorem opNorm_add_le : ‖f + g‖ ≤ ‖f‖ + ‖g‖ :=
     exact norm_add_le_of_le (le_opNorm _ _) (le_opNorm _ _)
 #align continuous_multilinear_map.op_norm_add_le ContinuousMultilinearMap.opNorm_add_le
 
-@[deprecated opNorm_add_le]
+@[deprecated]
 alias op_norm_add_le :=
   opNorm_add_le -- deprecated on 2024-02-02
 
@@ -479,7 +479,7 @@ theorem opNorm_zero : ‖(0 : ContinuousMultilinearMap 𝕜 E G)‖ = 0 :=
   (opNorm_nonneg _).antisymm' <| opNorm_le_bound 0 le_rfl fun m => by simp
 #align continuous_multilinear_map.op_norm_zero ContinuousMultilinearMap.opNorm_zero
 
-@[deprecated opNorm_zero]
+@[deprecated]
 alias op_norm_zero :=
   opNorm_zero -- deprecated on 2024-02-02
 
@@ -493,7 +493,7 @@ theorem opNorm_smul_le (c : 𝕜') : ‖c • f‖ ≤ ‖c‖ * ‖f‖ :=
     exact mul_le_mul_of_nonneg_left (le_opNorm _ _) (norm_nonneg _)
 #align continuous_multilinear_map.op_norm_smul_le ContinuousMultilinearMap.opNorm_smul_le
 
-@[deprecated opNorm_smul_le]
+@[deprecated]
 alias op_norm_smul_le :=
   opNorm_smul_le -- deprecated on 2024-02-02
 
@@ -504,7 +504,7 @@ theorem opNorm_neg : ‖-f‖ = ‖f‖ := by
   simp
 #align continuous_multilinear_map.op_norm_neg ContinuousMultilinearMap.opNorm_neg
 
-@[deprecated opNorm_neg]
+@[deprecated]
 alias op_norm_neg :=
   opNorm_neg -- deprecated on 2024-02-02
 
@@ -542,7 +542,7 @@ theorem le_opNNNorm : ‖f m‖₊ ≤ ‖f‖₊ * ∏ i, ‖m i‖₊ :=
     exact f.le_opNorm m
 #align continuous_multilinear_map.le_op_nnnorm ContinuousMultilinearMap.le_opNNNorm
 
-@[deprecated le_opNNNorm]
+@[deprecated]
 alias le_op_nnnorm :=
   le_opNNNorm -- deprecated on 2024-02-02
 
@@ -550,21 +550,21 @@ theorem le_of_opNNNorm_le {C : ℝ≥0} (h : ‖f‖₊ ≤ C) : ‖f m‖₊ �
   (f.le_opNNNorm m).trans <| mul_le_mul' h le_rfl
 #align continuous_multilinear_map.le_of_op_nnnorm_le ContinuousMultilinearMap.le_of_opNNNorm_le
 
-@[deprecated le_of_opNNNorm_le]
+@[deprecated]
 alias le_of_op_nnnorm_le :=
   le_of_opNNNorm_le -- deprecated on 2024-02-02
 
 theorem opNNNorm_le_iff {C : ℝ≥0} : ‖f‖₊ ≤ C ↔ ∀ m, ‖f m‖₊ ≤ C * ∏ i, ‖m i‖₊ := by
   simp only [← NNReal.coe_le_coe]; simp [opNorm_le_iff _ C.coe_nonneg, NNReal.coe_prod]
 
-@[deprecated opNNNorm_le_iff]
+@[deprecated]
 alias op_nnnorm_le_iff :=
   opNNNorm_le_iff -- deprecated on 2024-02-02
 
 theorem isLeast_opNNNorm : IsLeast {C : ℝ≥0 | ∀ m, ‖f m‖₊ ≤ C * ∏ i, ‖m i‖₊} ‖f‖₊ := by
   simpa only [← opNNNorm_le_iff] using isLeast_Ici
 
-@[deprecated isLeast_opNNNorm]
+@[deprecated]
 alias isLeast_op_nnnorm :=
   isLeast_opNNNorm -- deprecated on 2024-02-02
 
@@ -573,7 +573,7 @@ theorem opNNNorm_prod (f : ContinuousMultilinearMap 𝕜 E G) (g : ContinuousMul
   eq_of_forall_ge_iff fun _ ↦ by
     simp only [opNNNorm_le_iff, prod_apply, Prod.nnnorm_def', max_le_iff, forall_and]
 
-@[deprecated opNNNorm_prod]
+@[deprecated]
 alias op_nnnorm_prod :=
   opNNNorm_prod -- deprecated on 2024-02-02
 
@@ -582,7 +582,7 @@ theorem opNorm_prod (f : ContinuousMultilinearMap 𝕜 E G) (g : ContinuousMulti
   congr_arg NNReal.toReal (opNNNorm_prod f g)
 #align continuous_multilinear_map.op_norm_prod ContinuousMultilinearMap.opNorm_prod
 
-@[deprecated opNorm_prod]
+@[deprecated]
 alias op_norm_prod :=
   opNorm_prod -- deprecated on 2024-02-02
 
@@ -598,7 +598,7 @@ theorem opNorm_pi {ι' : Type v'} [Fintype ι'] {E' : ι' → Type wE'}
   congr_arg NNReal.toReal (opNNNorm_pi f)
 #align continuous_multilinear_map.norm_pi ContinuousMultilinearMap.opNorm_pi
 
-@[deprecated opNorm_pi]
+@[deprecated]
 alias op_norm_pi :=
   opNorm_pi -- deprecated on 2024-02-02
 
@@ -1346,7 +1346,7 @@ theorem opNorm_zero_iff : ‖f‖ = 0 ↔ f = 0 := by
   simp [← (opNorm_nonneg f).le_iff_eq, opNorm_le_iff f le_rfl, ext_iff]
 #align continuous_multilinear_map.op_norm_zero_iff ContinuousMultilinearMap.opNorm_zero_iff
 
-@[deprecated opNorm_zero_iff]
+@[deprecated]
 alias op_norm_zero_iff :=
   opNorm_zero_iff -- deprecated on 2024-02-02
 

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm.lean
@@ -150,7 +150,7 @@ theorem isLeast_opNorm [RingHomIsometric σ₁₂] (f : E →SL[σ₁₂] F) :
   simp only [setOf_and, setOf_forall]
   refine isClosed_Ici.inter <| isClosed_iInter fun _ ↦ isClosed_le ?_ ?_ <;> continuity
 
-@[deprecated isLeast_opNorm]
+@[deprecated]
 alias isLeast_op_norm :=
   isLeast_opNorm -- deprecated on 2024-02-02
 
@@ -160,7 +160,7 @@ theorem opNorm_le_bound (f : E →SL[σ₁₂] F) {M : ℝ} (hMp : 0 ≤ M) (hM 
   csInf_le bounds_bddBelow ⟨hMp, hM⟩
 #align continuous_linear_map.op_norm_le_bound ContinuousLinearMap.opNorm_le_bound
 
-@[deprecated opNorm_le_bound]
+@[deprecated]
 alias op_norm_le_bound :=
   opNorm_le_bound -- deprecated on 2024-02-02
 
@@ -172,7 +172,7 @@ theorem opNorm_le_bound' (f : E →SL[σ₁₂] F) {M : ℝ} (hMp : 0 ≤ M)
       simp only [h, mul_zero, norm_image_of_norm_zero f f.2 h, le_refl]
 #align continuous_linear_map.op_norm_le_bound' ContinuousLinearMap.opNorm_le_bound'
 
-@[deprecated opNorm_le_bound']
+@[deprecated]
 alias op_norm_le_bound' :=
   opNorm_le_bound' -- deprecated on 2024-02-02
 
@@ -181,7 +181,7 @@ theorem opNorm_le_of_lipschitz {f : E →SL[σ₁₂] F} {K : ℝ≥0} (hf : Lip
     simpa only [dist_zero_right, f.map_zero] using hf.dist_le_mul x 0
 #align continuous_linear_map.op_norm_le_of_lipschitz ContinuousLinearMap.opNorm_le_of_lipschitz
 
-@[deprecated opNorm_le_of_lipschitz]
+@[deprecated]
 alias op_norm_le_of_lipschitz :=
   opNorm_le_of_lipschitz -- deprecated on 2024-02-02
 
@@ -193,14 +193,14 @@ theorem opNorm_eq_of_bounds {φ : E →SL[σ₁₂] F} {M : ℝ} (M_nonneg : 0 �
       fun N ⟨N_nonneg, hN⟩ => h_below N N_nonneg hN)
 #align continuous_linear_map.op_norm_eq_of_bounds ContinuousLinearMap.opNorm_eq_of_bounds
 
-@[deprecated opNorm_eq_of_bounds]
+@[deprecated]
 alias op_norm_eq_of_bounds :=
   opNorm_eq_of_bounds -- deprecated on 2024-02-02
 
 theorem opNorm_neg (f : E →SL[σ₁₂] F) : ‖-f‖ = ‖f‖ := by simp only [norm_def, neg_apply, norm_neg]
 #align continuous_linear_map.op_norm_neg ContinuousLinearMap.opNorm_neg
 
-@[deprecated opNorm_neg]
+@[deprecated]
 alias op_norm_neg :=
   opNorm_neg -- deprecated on 2024-02-02
 
@@ -208,7 +208,7 @@ theorem opNorm_nonneg (f : E →SL[σ₁₂] F) : 0 ≤ ‖f‖ :=
   Real.sInf_nonneg _ fun _ ↦ And.left
 #align continuous_linear_map.op_norm_nonneg ContinuousLinearMap.opNorm_nonneg
 
-@[deprecated opNorm_nonneg]
+@[deprecated]
 alias op_norm_nonneg :=
   opNorm_nonneg -- deprecated on 2024-02-02
 
@@ -217,7 +217,7 @@ theorem opNorm_zero : ‖(0 : E →SL[σ₁₂] F)‖ = 0 :=
   le_antisymm (opNorm_le_bound _ le_rfl fun _ ↦ by simp) (opNorm_nonneg _)
 #align continuous_linear_map.op_norm_zero ContinuousLinearMap.opNorm_zero
 
-@[deprecated opNorm_zero]
+@[deprecated]
 alias op_norm_zero :=
   opNorm_zero -- deprecated on 2024-02-02
 
@@ -236,7 +236,7 @@ variable [RingHomIsometric σ₁₂] [RingHomIsometric σ₂₃] (f g : E →SL[
 theorem le_opNorm : ‖f x‖ ≤ ‖f‖ * ‖x‖ := (isLeast_opNorm f).1.2 x
 #align continuous_linear_map.le_op_norm ContinuousLinearMap.le_opNorm
 
-@[deprecated le_opNorm]
+@[deprecated]
 alias le_op_norm :=
   le_opNorm -- deprecated on 2024-02-02
 
@@ -244,7 +244,7 @@ theorem dist_le_opNorm (x y : E) : dist (f x) (f y) ≤ ‖f‖ * dist x y := by
   simp_rw [dist_eq_norm, ← map_sub, f.le_opNorm]
 #align continuous_linear_map.dist_le_op_norm ContinuousLinearMap.dist_le_opNorm
 
-@[deprecated dist_le_opNorm]
+@[deprecated]
 alias dist_le_op_norm :=
   dist_le_opNorm -- deprecated on 2024-02-02
 
@@ -252,7 +252,7 @@ theorem le_of_opNorm_le_of_le {x} {a b : ℝ} (hf : ‖f‖ ≤ a) (hx : ‖x‖
     ‖f x‖ ≤ a * b :=
   (f.le_opNorm x).trans <| by gcongr; exact (opNorm_nonneg f).trans hf
 
-@[deprecated le_of_opNorm_le_of_le]
+@[deprecated]
 alias le_of_op_norm_le_of_le :=
   le_of_opNorm_le_of_le -- deprecated on 2024-02-02
 
@@ -260,7 +260,7 @@ theorem le_opNorm_of_le {c : ℝ} {x} (h : ‖x‖ ≤ c) : ‖f x‖ ≤ ‖f�
   f.le_of_opNorm_le_of_le le_rfl h
 #align continuous_linear_map.le_op_norm_of_le ContinuousLinearMap.le_opNorm_of_le
 
-@[deprecated le_opNorm_of_le]
+@[deprecated]
 alias le_op_norm_of_le :=
   le_opNorm_of_le -- deprecated on 2024-02-02
 
@@ -268,7 +268,7 @@ theorem le_of_opNorm_le {c : ℝ} (h : ‖f‖ ≤ c) (x : E) : ‖f x‖ ≤ c 
   f.le_of_opNorm_le_of_le h le_rfl
 #align continuous_linear_map.le_of_op_norm_le ContinuousLinearMap.le_of_opNorm_le
 
-@[deprecated le_of_opNorm_le]
+@[deprecated]
 alias le_of_op_norm_le :=
   le_of_opNorm_le -- deprecated on 2024-02-02
 
@@ -276,7 +276,7 @@ theorem opNorm_le_iff {f : E →SL[σ₁₂] F} {M : ℝ} (hMp : 0 ≤ M) :
     ‖f‖ ≤ M ↔ ∀ x, ‖f x‖ ≤ M * ‖x‖ :=
   ⟨f.le_of_opNorm_le, opNorm_le_bound f hMp⟩
 
-@[deprecated opNorm_le_iff]
+@[deprecated]
 alias op_norm_le_iff :=
   opNorm_le_iff -- deprecated on 2024-02-02
 
@@ -284,7 +284,7 @@ theorem ratio_le_opNorm : ‖f x‖ / ‖x‖ ≤ ‖f‖ :=
   div_le_of_nonneg_of_le_mul (norm_nonneg _) f.opNorm_nonneg (le_opNorm _ _)
 #align continuous_linear_map.ratio_le_op_norm ContinuousLinearMap.ratio_le_opNorm
 
-@[deprecated ratio_le_opNorm]
+@[deprecated]
 alias ratio_le_op_norm :=
   ratio_le_opNorm -- deprecated on 2024-02-02
 
@@ -293,7 +293,7 @@ theorem unit_le_opNorm : ‖x‖ ≤ 1 → ‖f x‖ ≤ ‖f‖ :=
   mul_one ‖f‖ ▸ f.le_opNorm_of_le
 #align continuous_linear_map.unit_le_op_norm ContinuousLinearMap.unit_le_opNorm
 
-@[deprecated unit_le_opNorm]
+@[deprecated]
 alias unit_le_op_norm :=
   unit_le_opNorm -- deprecated on 2024-02-02
 
@@ -302,7 +302,7 @@ theorem opNorm_le_of_shell {f : E →SL[σ₁₂] F} {ε C : ℝ} (ε_pos : 0 < 
   f.opNorm_le_bound' hC fun _ hx => SemilinearMapClass.bound_of_shell_semi_normed f ε_pos hc hf hx
 #align continuous_linear_map.op_norm_le_of_shell ContinuousLinearMap.opNorm_le_of_shell
 
-@[deprecated opNorm_le_of_shell]
+@[deprecated]
 alias op_norm_le_of_shell :=
   opNorm_le_of_shell -- deprecated on 2024-02-02
 
@@ -313,7 +313,7 @@ theorem opNorm_le_of_ball {f : E →SL[σ₁₂] F} {ε : ℝ} {C : ℝ} (ε_pos
   rwa [ball_zero_eq]
 #align continuous_linear_map.op_norm_le_of_ball ContinuousLinearMap.opNorm_le_of_ball
 
-@[deprecated opNorm_le_of_ball]
+@[deprecated]
 alias op_norm_le_of_ball :=
   opNorm_le_of_ball -- deprecated on 2024-02-02
 
@@ -323,7 +323,7 @@ theorem opNorm_le_of_nhds_zero {f : E →SL[σ₁₂] F} {C : ℝ} (hC : 0 ≤ C
   opNorm_le_of_ball ε0 hC hε
 #align continuous_linear_map.op_norm_le_of_nhds_zero ContinuousLinearMap.opNorm_le_of_nhds_zero
 
-@[deprecated opNorm_le_of_nhds_zero]
+@[deprecated]
 alias op_norm_le_of_nhds_zero :=
   opNorm_le_of_nhds_zero -- deprecated on 2024-02-02
 
@@ -338,7 +338,7 @@ theorem opNorm_le_of_shell' {f : E →SL[σ₁₂] F} {ε C : ℝ} (ε_pos : 0 <
     rwa [norm_inv, div_eq_mul_inv, inv_inv]
 #align continuous_linear_map.op_norm_le_of_shell' ContinuousLinearMap.opNorm_le_of_shell'
 
-@[deprecated opNorm_le_of_shell']
+@[deprecated]
 alias op_norm_le_of_shell' :=
   opNorm_le_of_shell' -- deprecated on 2024-02-02
 
@@ -353,7 +353,7 @@ theorem opNorm_le_of_unit_norm [NormedSpace ℝ E] [NormedSpace ℝ F] {f : E �
   exact (norm_nonneg x).lt_of_ne' hx
 #align continuous_linear_map.op_norm_le_of_unit_norm ContinuousLinearMap.opNorm_le_of_unit_norm
 
-@[deprecated opNorm_le_of_unit_norm]
+@[deprecated]
 alias op_norm_le_of_unit_norm :=
   opNorm_le_of_unit_norm -- deprecated on 2024-02-02
 
@@ -363,7 +363,7 @@ theorem opNorm_add_le : ‖f + g‖ ≤ ‖f‖ + ‖g‖ :=
     (norm_add_le_of_le (f.le_opNorm x) (g.le_opNorm x)).trans_eq (add_mul _ _ _).symm
 #align continuous_linear_map.op_norm_add_le ContinuousLinearMap.opNorm_add_le
 
-@[deprecated opNorm_add_le]
+@[deprecated]
 alias op_norm_add_le :=
   opNorm_add_le -- deprecated on 2024-02-02
 
@@ -383,7 +383,7 @@ theorem opNorm_smul_le {𝕜' : Type*} [NormedField 𝕜'] [NormedSpace 𝕜' F]
     exact mul_le_mul_of_nonneg_left (le_opNorm _ _) (norm_nonneg _)
 #align continuous_linear_map.op_norm_smul_le ContinuousLinearMap.opNorm_smul_le
 
-@[deprecated opNorm_smul_le]
+@[deprecated]
 alias op_norm_smul_le :=
   opNorm_smul_le -- deprecated on 2024-02-02
 
@@ -446,7 +446,7 @@ theorem opNNNorm_le_bound (f : E →SL[σ₁₂] F) (M : ℝ≥0) (hM : ∀ x, �
   opNorm_le_bound f (zero_le M) hM
 #align continuous_linear_map.op_nnnorm_le_bound ContinuousLinearMap.opNNNorm_le_bound
 
-@[deprecated opNNNorm_le_bound]
+@[deprecated]
 alias op_nnnorm_le_bound :=
   opNNNorm_le_bound -- deprecated on 2024-02-02
 
@@ -456,7 +456,7 @@ theorem opNNNorm_le_bound' (f : E →SL[σ₁₂] F) (M : ℝ≥0) (hM : ∀ x, 
   opNorm_le_bound' f (zero_le M) fun x hx => hM x <| by rwa [← NNReal.coe_ne_zero]
 #align continuous_linear_map.op_nnnorm_le_bound' ContinuousLinearMap.opNNNorm_le_bound'
 
-@[deprecated opNNNorm_le_bound']
+@[deprecated]
 alias op_nnnorm_le_bound' :=
   opNNNorm_le_bound' -- deprecated on 2024-02-02
 
@@ -467,7 +467,7 @@ theorem opNNNorm_le_of_unit_nnnorm [NormedSpace ℝ E] [NormedSpace ℝ F] {f : 
   opNorm_le_of_unit_norm C.coe_nonneg fun x hx => hf x <| by rwa [← NNReal.coe_eq_one]
 #align continuous_linear_map.op_nnnorm_le_of_unit_nnnorm ContinuousLinearMap.opNNNorm_le_of_unit_nnnorm
 
-@[deprecated opNNNorm_le_of_unit_nnnorm]
+@[deprecated]
 alias op_nnnorm_le_of_unit_nnnorm :=
   opNNNorm_le_of_unit_nnnorm -- deprecated on 2024-02-02
 
@@ -476,7 +476,7 @@ theorem opNNNorm_le_of_lipschitz {f : E →SL[σ₁₂] F} {K : ℝ≥0} (hf : L
   opNorm_le_of_lipschitz hf
 #align continuous_linear_map.op_nnnorm_le_of_lipschitz ContinuousLinearMap.opNNNorm_le_of_lipschitz
 
-@[deprecated opNNNorm_le_of_lipschitz]
+@[deprecated]
 alias op_nnnorm_le_of_lipschitz :=
   opNNNorm_le_of_lipschitz -- deprecated on 2024-02-02
 
@@ -485,21 +485,21 @@ theorem opNNNorm_eq_of_bounds {φ : E →SL[σ₁₂] F} (M : ℝ≥0) (h_above 
   Subtype.ext <| opNorm_eq_of_bounds (zero_le M) h_above <| Subtype.forall'.mpr h_below
 #align continuous_linear_map.op_nnnorm_eq_of_bounds ContinuousLinearMap.opNNNorm_eq_of_bounds
 
-@[deprecated opNNNorm_eq_of_bounds]
+@[deprecated]
 alias op_nnnorm_eq_of_bounds :=
   opNNNorm_eq_of_bounds -- deprecated on 2024-02-02
 
 theorem opNNNorm_le_iff {f : E →SL[σ₁₂] F} {C : ℝ≥0} : ‖f‖₊ ≤ C ↔ ∀ x, ‖f x‖₊ ≤ C * ‖x‖₊ :=
   opNorm_le_iff C.2
 
-@[deprecated opNNNorm_le_iff]
+@[deprecated]
 alias op_nnnorm_le_iff :=
   opNNNorm_le_iff -- deprecated on 2024-02-02
 
 theorem isLeast_opNNNorm : IsLeast {C : ℝ≥0 | ∀ x, ‖f x‖₊ ≤ C * ‖x‖₊} ‖f‖₊ := by
   simpa only [← opNNNorm_le_iff] using isLeast_Ici
 
-@[deprecated isLeast_opNNNorm]
+@[deprecated]
 alias isLeast_op_nnnorm :=
   isLeast_opNNNorm -- deprecated on 2024-02-02
 
@@ -516,7 +516,7 @@ theorem opNorm_comp_le (f : E →SL[σ₁₂] F) : ‖h.comp f‖ ≤ ‖h‖ * 
       exact h.le_opNorm_of_le (f.le_opNorm x)⟩
 #align continuous_linear_map.op_norm_comp_le ContinuousLinearMap.opNorm_comp_le
 
-@[deprecated opNorm_comp_le]
+@[deprecated]
 alias op_norm_comp_le :=
   opNorm_comp_le -- deprecated on 2024-02-02
 
@@ -524,7 +524,7 @@ theorem opNNNorm_comp_le [RingHomIsometric σ₁₃] (f : E →SL[σ₁₂] F) :
   opNorm_comp_le h f
 #align continuous_linear_map.op_nnnorm_comp_le ContinuousLinearMap.opNNNorm_comp_le
 
-@[deprecated opNNNorm_comp_le]
+@[deprecated]
 alias op_nnnorm_comp_le :=
   opNNNorm_comp_le -- deprecated on 2024-02-02
 
@@ -547,7 +547,7 @@ theorem le_opNNNorm : ‖f x‖₊ ≤ ‖f‖₊ * ‖x‖₊ :=
   f.le_opNorm x
 #align continuous_linear_map.le_op_nnnorm ContinuousLinearMap.le_opNNNorm
 
-@[deprecated le_opNNNorm]
+@[deprecated]
 alias le_op_nnnorm :=
   le_opNNNorm -- deprecated on 2024-02-02
 
@@ -555,7 +555,7 @@ theorem nndist_le_opNNNorm (x y : E) : nndist (f x) (f y) ≤ ‖f‖₊ * nndis
   dist_le_opNorm f x y
 #align continuous_linear_map.nndist_le_op_nnnorm ContinuousLinearMap.nndist_le_opNNNorm
 
-@[deprecated nndist_le_opNNNorm]
+@[deprecated]
 alias nndist_le_op_nnnorm :=
   nndist_le_opNNNorm -- deprecated on 2024-02-02
 
@@ -582,7 +582,7 @@ theorem exists_mul_lt_apply_of_lt_opNNNorm (f : E →SL[σ₁₂] F) {r : ℝ≥
       (OrderBot.bddBelow _)
 #align continuous_linear_map.exists_mul_lt_apply_of_lt_op_nnnorm ContinuousLinearMap.exists_mul_lt_apply_of_lt_opNNNorm
 
-@[deprecated exists_mul_lt_apply_of_lt_opNNNorm]
+@[deprecated]
 alias exists_mul_lt_apply_of_lt_op_nnnorm :=
   exists_mul_lt_apply_of_lt_opNNNorm -- deprecated on 2024-02-02
 
@@ -592,7 +592,7 @@ theorem exists_mul_lt_of_lt_opNorm (f : E →SL[σ₁₂] F) {r : ℝ} (hr₀ : 
   exact f.exists_mul_lt_apply_of_lt_opNNNorm hr
 #align continuous_linear_map.exists_mul_lt_of_lt_op_norm ContinuousLinearMap.exists_mul_lt_of_lt_opNorm
 
-@[deprecated exists_mul_lt_of_lt_opNorm]
+@[deprecated]
 alias exists_mul_lt_of_lt_op_norm :=
   exists_mul_lt_of_lt_opNorm -- deprecated on 2024-02-02
 
@@ -613,7 +613,7 @@ theorem exists_lt_apply_of_lt_opNNNorm {𝕜 𝕜₂ E F : Type*} [NormedAddComm
   rwa [map_smulₛₗ f, nnnorm_smul, ← NNReal.div_lt_iff hfy, div_eq_mul_inv, this]
 #align continuous_linear_map.exists_lt_apply_of_lt_op_nnnorm ContinuousLinearMap.exists_lt_apply_of_lt_opNNNorm
 
-@[deprecated exists_lt_apply_of_lt_opNNNorm]
+@[deprecated]
 alias exists_lt_apply_of_lt_op_nnnorm :=
   exists_lt_apply_of_lt_opNNNorm -- deprecated on 2024-02-02
 
@@ -627,7 +627,7 @@ theorem exists_lt_apply_of_lt_opNorm {𝕜 𝕜₂ E F : Type*} [NormedAddCommGr
     exact f.exists_lt_apply_of_lt_opNNNorm hr
 #align continuous_linear_map.exists_lt_apply_of_lt_op_norm ContinuousLinearMap.exists_lt_apply_of_lt_opNorm
 
-@[deprecated exists_lt_apply_of_lt_opNorm]
+@[deprecated]
 alias exists_lt_apply_of_lt_op_norm :=
   exists_lt_apply_of_lt_opNorm -- deprecated on 2024-02-02
 
@@ -687,7 +687,7 @@ theorem opNorm_ext [RingHomIsometric σ₁₃] (f : E →SL[σ₁₂] F) (g : E 
       exact h₂ z
 #align continuous_linear_map.op_norm_ext ContinuousLinearMap.opNorm_ext
 
-@[deprecated opNorm_ext]
+@[deprecated]
 alias op_norm_ext :=
   opNorm_ext -- deprecated on 2024-02-02
 
@@ -698,7 +698,7 @@ theorem opNorm_le_bound₂ (f : E →SL[σ₁₃] F →SL[σ₂₃] G) {C : ℝ}
   f.opNorm_le_bound h0 fun x => (f x).opNorm_le_bound (mul_nonneg h0 (norm_nonneg _)) <| hC x
 #align continuous_linear_map.op_norm_le_bound₂ ContinuousLinearMap.opNorm_le_bound₂
 
-@[deprecated opNorm_le_bound₂]
+@[deprecated]
 alias op_norm_le_bound₂ :=
   opNorm_le_bound₂ -- deprecated on 2024-02-02
 
@@ -707,7 +707,7 @@ theorem le_opNorm₂ [RingHomIsometric σ₁₃] (f : E →SL[σ₁₃] F →SL[
   (f x).le_of_opNorm_le (f.le_opNorm x) y
 #align continuous_linear_map.le_op_norm₂ ContinuousLinearMap.le_opNorm₂
 
-@[deprecated le_opNorm₂]
+@[deprecated]
 alias le_op_norm₂ :=
   le_opNorm₂ -- deprecated on 2024-02-02
 
@@ -717,7 +717,7 @@ theorem le_of_opNorm₂_le_of_le [RingHomIsometric σ₁₃] (f : E →SL[σ₁�
     ‖f x y‖ ≤ a * b * c :=
   (f x).le_of_opNorm_le_of_le (f.le_of_opNorm_le_of_le hf hx) hy
 
-@[deprecated le_of_opNorm₂_le_of_le]
+@[deprecated]
 alias le_of_op_norm₂_le_of_le :=
   le_of_opNorm₂_le_of_le -- deprecated on 2024-02-02
 
@@ -736,7 +736,7 @@ theorem opNorm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.prod 
         (le_max_right _ _).trans ((f.prod g).le_opNorm x))
 #align continuous_linear_map.op_norm_prod ContinuousLinearMap.opNorm_prod
 
-@[deprecated opNorm_prod]
+@[deprecated]
 alias op_norm_prod :=
   opNorm_prod -- deprecated on 2024-02-02
 
@@ -745,7 +745,7 @@ theorem opNNNorm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ‖f.pro
   Subtype.ext <| opNorm_prod f g
 #align continuous_linear_map.op_nnnorm_prod ContinuousLinearMap.opNNNorm_prod
 
-@[deprecated opNNNorm_prod]
+@[deprecated]
 alias op_nnnorm_prod :=
   opNNNorm_prod -- deprecated on 2024-02-02
 
@@ -766,7 +766,7 @@ theorem opNorm_subsingleton [Subsingleton E] : ‖f‖ = 0 := by
   simp [Subsingleton.elim x 0]
 #align continuous_linear_map.op_norm_subsingleton ContinuousLinearMap.opNorm_subsingleton
 
-@[deprecated opNorm_subsingleton]
+@[deprecated]
 alias op_norm_subsingleton :=
   opNorm_subsingleton -- deprecated on 2024-02-02
 
@@ -928,7 +928,7 @@ theorem opNorm_flip (f : E →SL[σ₁₃] F →SL[σ₂₃] G) : ‖f.flip‖ =
   le_antisymm (by simpa only [flip_flip] using le_norm_flip f.flip) (le_norm_flip f)
 #align continuous_linear_map.op_norm_flip ContinuousLinearMap.opNorm_flip
 
-@[deprecated opNorm_flip]
+@[deprecated]
 alias op_norm_flip :=
   opNorm_flip -- deprecated on 2024-02-02
 
@@ -1218,7 +1218,7 @@ theorem opNorm_mul_apply_le (x : 𝕜') : ‖mul 𝕜 𝕜' x‖ ≤ ‖x‖ :=
   opNorm_le_bound _ (norm_nonneg x) (norm_mul_le x)
 #align continuous_linear_map.op_norm_mul_apply_le ContinuousLinearMap.opNorm_mul_apply_le
 
-@[deprecated opNorm_mul_apply_le]
+@[deprecated]
 alias op_norm_mul_apply_le :=
   opNorm_mul_apply_le -- deprecated on 2024-02-02
 
@@ -1226,7 +1226,7 @@ theorem opNorm_mul_le : ‖mul 𝕜 𝕜'‖ ≤ 1 :=
   LinearMap.mkContinuous₂_norm_le _ zero_le_one _
 #align continuous_linear_map.op_norm_mul_le ContinuousLinearMap.opNorm_mul_le
 
-@[deprecated opNorm_mul_le]
+@[deprecated]
 alias op_norm_mul_le :=
   opNorm_mul_le -- deprecated on 2024-02-02
 
@@ -1268,7 +1268,7 @@ theorem opNorm_mulLeftRight_apply_apply_le (x y : 𝕜') : ‖mulLeftRight 𝕜 
         (norm_nonneg _) (norm_nonneg _)
 #align continuous_linear_map.op_norm_mul_left_right_apply_apply_le ContinuousLinearMap.opNorm_mulLeftRight_apply_apply_le
 
-@[deprecated opNorm_mulLeftRight_apply_apply_le]
+@[deprecated]
 alias op_norm_mulLeftRight_apply_apply_le :=
   opNorm_mulLeftRight_apply_apply_le -- deprecated on 2024-02-02
 
@@ -1276,7 +1276,7 @@ theorem opNorm_mulLeftRight_apply_le (x : 𝕜') : ‖mulLeftRight 𝕜 𝕜' x�
   opNorm_le_bound _ (norm_nonneg x) (opNorm_mulLeftRight_apply_apply_le 𝕜 𝕜' x)
 #align continuous_linear_map.op_norm_mul_left_right_apply_le ContinuousLinearMap.opNorm_mulLeftRight_apply_le
 
-@[deprecated opNorm_mulLeftRight_apply_le]
+@[deprecated]
 alias op_norm_mulLeftRight_apply_le :=
   opNorm_mulLeftRight_apply_le -- deprecated on 2024-02-02
 
@@ -1286,7 +1286,7 @@ theorem opNorm_mulLeftRight_le :
   opNorm_le_bound _ zero_le_one fun x => (one_mul ‖x‖).symm ▸ opNorm_mulLeftRight_apply_le 𝕜 𝕜' x
 #align continuous_linear_map.op_norm_mul_left_right_le ContinuousLinearMap.opNorm_mulLeftRight_le
 
-@[deprecated opNorm_mulLeftRight_le]
+@[deprecated]
 alias op_norm_mulLeftRight_le :=
   opNorm_mulLeftRight_le -- deprecated on 2024-02-02
 
@@ -1320,7 +1320,7 @@ lemma opNorm_mul_apply (x : 𝕜') : ‖mul 𝕜 𝕜' x‖ = ‖x‖ :=
   (AddMonoidHomClass.isometry_iff_norm (mul 𝕜 𝕜')).mp (isometry_mul 𝕜 𝕜') x
 #align continuous_linear_map.op_norm_mul_apply ContinuousLinearMap.opNorm_mul_applyₓ
 
-@[deprecated opNorm_mul_apply]
+@[deprecated]
 alias op_norm_mul_apply :=
   opNorm_mul_apply -- deprecated on 2024-02-02
 
@@ -1328,7 +1328,7 @@ alias op_norm_mul_apply :=
 lemma opNNNorm_mul_apply (x : 𝕜') : ‖mul 𝕜 𝕜' x‖₊ = ‖x‖₊ :=
   Subtype.ext <| opNorm_mul_apply 𝕜 𝕜' x
 
-@[deprecated opNNNorm_mul_apply]
+@[deprecated]
 alias op_nnnorm_mul_apply :=
   opNNNorm_mul_apply -- deprecated on 2024-02-02
 
@@ -1408,7 +1408,7 @@ theorem opNorm_lsmul_apply_le (x : 𝕜') : ‖(lsmul 𝕜 𝕜' x : E →L[𝕜
   ContinuousLinearMap.opNorm_le_bound _ (norm_nonneg x) fun y => norm_smul_le x y
 #align continuous_linear_map.op_norm_lsmul_apply_le ContinuousLinearMap.opNorm_lsmul_apply_le
 
-@[deprecated opNorm_lsmul_apply_le]
+@[deprecated]
 alias op_norm_lsmul_apply_le :=
   opNorm_lsmul_apply_le -- deprecated on 2024-02-02
 
@@ -1419,7 +1419,7 @@ theorem opNorm_lsmul_le : ‖(lsmul 𝕜 𝕜' : 𝕜' →L[𝕜] E →L[𝕜] E
   exact opNorm_lsmul_apply_le _
 #align continuous_linear_map.op_norm_lsmul_le ContinuousLinearMap.opNorm_lsmul_le
 
-@[deprecated opNorm_lsmul_le]
+@[deprecated]
 alias op_norm_lsmul_le :=
   opNorm_lsmul_le -- deprecated on 2024-02-02
 
@@ -1667,7 +1667,7 @@ theorem opNorm_zero_iff [RingHomIsometric σ₁₂] : ‖f‖ = 0 ↔ f = 0 :=
       exact opNorm_zero)
 #align continuous_linear_map.op_norm_zero_iff ContinuousLinearMap.opNorm_zero_iff
 
-@[deprecated opNorm_zero_iff]
+@[deprecated]
 alias op_norm_zero_iff :=
   opNorm_zero_iff -- deprecated on 2024-02-02
 
@@ -1954,7 +1954,7 @@ theorem opNorm_extend_le :
       _ ≤ N * ‖f‖ * ‖e x‖ := by rw [mul_comm ↑N ‖f‖, mul_assoc]
 #align continuous_linear_map.op_norm_extend_le ContinuousLinearMap.opNorm_extend_le
 
-@[deprecated opNorm_extend_le]
+@[deprecated]
 alias op_norm_extend_le :=
   opNorm_extend_le -- deprecated on 2024-02-02
 
@@ -2017,7 +2017,7 @@ theorem opNorm_comp_linearIsometryEquiv (f : F →SL[σ₂₃] G) (g : F' ≃ₛ
     simp [g.symm.toLinearIsometry.norm_toContinuousLinearMap]
 #align continuous_linear_map.op_norm_comp_linear_isometry_equiv ContinuousLinearMap.opNorm_comp_linearIsometryEquiv
 
-@[deprecated opNorm_comp_linearIsometryEquiv]
+@[deprecated]
 alias op_norm_comp_linearIsometryEquiv :=
   opNorm_comp_linearIsometryEquiv -- deprecated on 2024-02-02
 
@@ -2095,7 +2095,7 @@ theorem opNorm_mul : ‖mul 𝕜 𝕜'‖ = 1 :=
   (mulₗᵢ 𝕜 𝕜').norm_toContinuousLinearMap
 #align continuous_linear_map.op_norm_mul ContinuousLinearMap.opNorm_mulₓ
 
-@[deprecated opNorm_mul]
+@[deprecated]
 alias op_norm_mul :=
   opNorm_mul -- deprecated on 2024-02-02
 
@@ -2104,7 +2104,7 @@ theorem opNNNorm_mul : ‖mul 𝕜 𝕜'‖₊ = 1 :=
   Subtype.ext <| opNorm_mul 𝕜 𝕜'
 #align continuous_linear_map.op_nnnorm_mul ContinuousLinearMap.opNNNorm_mulₓ
 
-@[deprecated opNNNorm_mul]
+@[deprecated]
 alias op_nnnorm_mul :=
   opNNNorm_mul -- deprecated on 2024-02-02
 
@@ -2126,7 +2126,7 @@ theorem opNorm_lsmul [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormedSpace
   simp_rw [one_mul, this]
 #align continuous_linear_map.op_norm_lsmul ContinuousLinearMap.opNorm_lsmul
 
-@[deprecated opNorm_lsmul]
+@[deprecated]
 alias op_norm_lsmul :=
   opNorm_lsmul -- deprecated on 2024-02-02
 

--- a/Mathlib/Analysis/NormedSpace/Star/Matrix.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Matrix.lean
@@ -175,14 +175,14 @@ scoped[Matrix.L2OpNorm] attribute [instance] Matrix.instL2OpNormedAddCommGroup
 lemma l2_opNorm_def (A : Matrix m n 𝕜) :
     ‖A‖ = ‖(toEuclideanLin (𝕜 := 𝕜) (m := m) (n := n)).trans toContinuousLinearMap A‖ := rfl
 
-@[deprecated l2_opNorm_def]
+@[deprecated]
 alias l2_op_norm_def :=
   l2_opNorm_def -- deprecated on 2024-02-02
 
 lemma l2_opNNNorm_def (A : Matrix m n 𝕜) :
     ‖A‖₊ = ‖(toEuclideanLin (𝕜 := 𝕜) (m := m) (n := n)).trans toContinuousLinearMap A‖₊ := rfl
 
-@[deprecated l2_opNNNorm_def]
+@[deprecated]
 alias l2_op_nnnorm_def :=
   l2_opNNNorm_def -- deprecated on 2024-02-02
 
@@ -191,14 +191,14 @@ lemma l2_opNorm_conjTranspose (A : Matrix m n 𝕜) : ‖Aᴴ‖ = ‖A‖ := by
     toLin_conjTranspose, adjoint_toContinuousLinearMap]
   exact ContinuousLinearMap.adjoint.norm_map _
 
-@[deprecated l2_opNorm_conjTranspose]
+@[deprecated]
 alias l2_op_norm_conjTranspose :=
   l2_opNorm_conjTranspose -- deprecated on 2024-02-02
 
 lemma l2_opNNNorm_conjTranspose (A : Matrix m n 𝕜) : ‖Aᴴ‖₊ = ‖A‖₊ :=
   Subtype.ext <| l2_opNorm_conjTranspose _
 
-@[deprecated l2_opNNNorm_conjTranspose]
+@[deprecated]
 alias l2_op_nnnorm_conjTranspose :=
   l2_opNNNorm_conjTranspose -- deprecated on 2024-02-02
 
@@ -207,14 +207,14 @@ lemma l2_opNorm_conjTranspose_mul_self (A : Matrix m n 𝕜) : ‖Aᴴ * A‖ = 
     Matrix.toLin_mul (v₂ := (EuclideanSpace.basisFun m 𝕜).toBasis), toLin_conjTranspose]
   exact ContinuousLinearMap.norm_adjoint_comp_self _
 
-@[deprecated l2_opNorm_conjTranspose_mul_self]
+@[deprecated]
 alias l2_op_norm_conjTranspose_mul_self :=
   l2_opNorm_conjTranspose_mul_self -- deprecated on 2024-02-02
 
 lemma l2_opNNNorm_conjTranspose_mul_self (A : Matrix m n 𝕜) : ‖Aᴴ * A‖₊ = ‖A‖₊ * ‖A‖₊ :=
   Subtype.ext <| l2_opNorm_conjTranspose_mul_self _
 
-@[deprecated l2_opNNNorm_conjTranspose_mul_self]
+@[deprecated]
 alias l2_op_nnnorm_conjTranspose_mul_self :=
   l2_opNNNorm_conjTranspose_mul_self -- deprecated on 2024-02-02
 
@@ -223,7 +223,7 @@ lemma l2_opNorm_mulVec (A : Matrix m n 𝕜) (x : EuclideanSpace 𝕜 n) :
     ‖(EuclideanSpace.equiv m 𝕜).symm <| A.mulVec x‖ ≤ ‖A‖ * ‖x‖ :=
   toEuclideanLin (n := n) (m := m) (𝕜 := 𝕜) |>.trans toContinuousLinearMap A |>.le_opNorm x
 
-@[deprecated l2_opNorm_mulVec]
+@[deprecated]
 alias l2_op_norm_mulVec :=
   l2_opNorm_mulVec -- deprecated on 2024-02-02
 
@@ -231,7 +231,7 @@ lemma l2_opNNNorm_mulVec (A : Matrix m n 𝕜) (x : EuclideanSpace 𝕜 n) :
     ‖(EuclideanSpace.equiv m 𝕜).symm <| A.mulVec x‖₊ ≤ ‖A‖₊ * ‖x‖₊ :=
   A.l2_opNorm_mulVec x
 
-@[deprecated l2_opNNNorm_mulVec]
+@[deprecated]
 alias l2_op_nnnorm_mulVec :=
   l2_opNNNorm_mulVec -- deprecated on 2024-02-02
 
@@ -244,14 +244,14 @@ lemma l2_opNorm_mul (A : Matrix m n 𝕜) (B : Matrix n l 𝕜) :
   ext1 x
   exact congr($(Matrix.toLin'_mul A B) x)
 
-@[deprecated l2_opNorm_mul]
+@[deprecated]
 alias l2_op_norm_mul :=
   l2_opNorm_mul -- deprecated on 2024-02-02
 
 lemma l2_opNNNorm_mul (A : Matrix m n 𝕜) (B : Matrix n l 𝕜) : ‖A * B‖₊ ≤ ‖A‖₊ * ‖B‖₊ :=
   l2_opNorm_mul A B
 
-@[deprecated l2_opNNNorm_mul]
+@[deprecated]
 alias l2_op_nnnorm_mul :=
   l2_opNNNorm_mul -- deprecated on 2024-02-02
 

--- a/Mathlib/Analysis/NormedSpace/Star/Unitization.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Unitization.lean
@@ -37,14 +37,14 @@ lemma opNorm_mul_flip_apply (a : E) : ‖(mul 𝕜 E).flip a‖ = ‖a‖ := by
   calc ‖mul 𝕜 E (star a) b‖ = ‖(mul 𝕜 E).flip a (star b)‖ := by simpa using norm_star (star b * a)
     _ ≤ ‖(mul 𝕜 E).flip a‖ * ‖b‖ := by simpa using le_opNorm ((mul 𝕜 E).flip a) (star b)
 
-@[deprecated opNorm_mul_flip_apply]
+@[deprecated]
 alias op_norm_mul_flip_apply :=
   opNorm_mul_flip_apply -- deprecated on 2024-02-02
 
 lemma opNNNorm_mul_flip_apply (a : E) : ‖(mul 𝕜 E).flip a‖₊ = ‖a‖₊ :=
   Subtype.ext (opNorm_mul_flip_apply 𝕜 a)
 
-@[deprecated opNNNorm_mul_flip_apply]
+@[deprecated]
 alias op_nnnorm_mul_flip_apply :=
   opNNNorm_mul_flip_apply -- deprecated on 2024-02-02
 

--- a/Mathlib/MeasureTheory/Integral/SetToL1.lean
+++ b/Mathlib/MeasureTheory/Integral/SetToL1.lean
@@ -573,7 +573,7 @@ theorem norm_setToSimpleFunc_le_sum_opNorm {m : MeasurableSpace α} (T : Set α 
       refine' Finset.sum_le_sum fun b _ => _; simp_rw [ContinuousLinearMap.le_opNorm]
 #align measure_theory.simple_func.norm_set_to_simple_func_le_sum_op_norm MeasureTheory.SimpleFunc.norm_setToSimpleFunc_le_sum_opNorm
 
-@[deprecated norm_setToSimpleFunc_le_sum_opNorm]
+@[deprecated]
 alias norm_setToSimpleFunc_le_sum_op_norm :=
   norm_setToSimpleFunc_le_sum_opNorm -- deprecated on 2024-02-02
 


### PR DESCRIPTION
Following [these](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Thank.20you.20for.20the.20deprecation.20warnings!/near/420078161) [Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/machineApplicableDeprecated.20tag.20attribute/near/397630551) discussions, I realised that my deprecation script produced a deprecation syntax that did not allow for auto-replacement in Sébastien's #10185.

This PR fixes the deprecation statements, allowing self-correction: 119 times I replaced

`@[deprecated xxx] --> @[deprecated]`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
