### PR TITLE
[Merged by Bors] - chore: add setting to prevent accidental editing of dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,9 @@
   "githubPullRequests.ignoredPullRequestBranches": [
     "master"
   ],
-  "git.ignoreLimitWarning": true
+  "git.ignoreLimitWarning": true,
+  "files.readonlyInclude": {
+    "**/.elan/**": true,
+    "**/.lake/**": true
+  }
 }


### PR DESCRIPTION
Adds `**/.lake/**` and `**/.elan/**` to a readonly include list in the VSCode workspace settings. This should prevent users from accidentally editing files in dependencies they might navigate to in VSCode.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
