### PR TITLE
[Merged by Bors] - feat(Algebra/UniformConvergence): drop unneeded assumptions

### DIFF
--- a/Mathlib/Analysis/LocallyConvex/Basic.lean
+++ b/Mathlib/Analysis/LocallyConvex/Basic.lean
@@ -164,6 +164,19 @@ section NormedField
 variable [NormedField 𝕜] [NormedRing 𝕝] [NormedSpace 𝕜 𝕝] [AddCommGroup E] [Module 𝕜 E]
   [SMulWithZero 𝕝 E] [IsScalarTower 𝕜 𝕝 E] {s t u v A B : Set E} {x : E} {a b : 𝕜}
 
+theorem absorbs_iff_eventually_nhdsWithin_zero :
+    Absorbs 𝕜 s t ↔ ∀ᶠ c : 𝕜 in 𝓝[≠] 0, MapsTo (c • ·) t s := by
+  rw [absorbs_iff_eventually_cobounded_mapsTo, ← Filter.inv_cobounded₀]; rfl
+
+alias ⟨Absorbs.eventually_nhdsWithin_zero, _⟩ := absorbs_iff_eventually_nhdsWithin_zero
+
+theorem Absorbs.eventually_nhds_zero (h : Absorbs 𝕜 s t) (h₀ : 0 ∈ s) :
+    ∀ᶠ c : 𝕜 in 𝓝 0, MapsTo (c • ·) t s := by
+  rw [← nhdsWithin_compl_singleton_sup_pure, Filter.eventually_sup, Filter.eventually_pure,
+    ← absorbs_iff_eventually_nhdsWithin_zero]
+  refine ⟨h, fun x _ ↦ ?_⟩
+  simpa only [zero_smul]
+
 /-- Scalar multiplication (by possibly different types) of a balanced set is monotone. -/
 theorem Balanced.smul_mono (hs : Balanced 𝕝 s) {a : 𝕝} {b : 𝕜} (h : ‖a‖ ≤ ‖b‖) : a • s ⊆ b • s := by
   obtain rfl | hb := eq_or_ne b 0

--- a/Mathlib/Topology/Algebra/Module/StrongTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/StrongTopology.lean
@@ -135,17 +135,14 @@ theorem strongTopology.t2Space [TopologicalSpace F] [TopologicalAddGroup F] [T2S
 
 theorem strongTopology.continuousSMul [RingHomSurjective σ] [RingHomIsometric σ]
     [TopologicalSpace F] [TopologicalAddGroup F] [ContinuousSMul 𝕜₂ F] (𝔖 : Set (Set E))
-    (h𝔖₁ : 𝔖.Nonempty) (h𝔖₂ : DirectedOn (· ⊆ ·) 𝔖)
     (h𝔖₃ : ∀ S ∈ 𝔖, Bornology.IsVonNBounded 𝕜₁ S) :
     @ContinuousSMul 𝕜₂ (E →SL[σ] F) _ _ (strongTopology σ F 𝔖) := by
   letI : UniformSpace F := TopologicalAddGroup.toUniformSpace F
   haveI : UniformAddGroup F := comm_topologicalAddGroup_is_uniform
   letI : TopologicalSpace (E →SL[σ] F) := strongTopology σ F 𝔖
-  let φ : (E →SL[σ] F) →ₗ[𝕜₂] E →ᵤ[𝔖] F :=
-    ⟨⟨(DFunLike.coe : (E →SL[σ] F) → E → F), fun _ _ => rfl⟩, fun _ _ => rfl⟩
-  exact
-    UniformOnFun.continuousSMul_induced_of_image_bounded 𝕜₂ E F (E →SL[σ] F) h𝔖₁ h𝔖₂ φ ⟨rfl⟩
-      fun u s hs => (h𝔖₃ s hs).image u
+  let φ : (E →SL[σ] F) →ₗ[𝕜₂] E → F := ⟨⟨DFunLike.coe, fun _ _ => rfl⟩, fun _ _ => rfl⟩
+  exact UniformOnFun.continuousSMul_induced_of_image_bounded 𝕜₂ E F (E →SL[σ] F) φ ⟨rfl⟩
+    fun u s hs => (h𝔖₃ s hs).image u
 #align continuous_linear_map.strong_topology.has_continuous_smul ContinuousLinearMap.strongTopology.continuousSMul
 
 theorem strongTopology.hasBasis_nhds_zero_of_basis [TopologicalSpace F] [TopologicalAddGroup F]
@@ -211,9 +208,7 @@ instance topologicalAddGroup [TopologicalSpace F] [TopologicalAddGroup F] :
 
 instance continuousSMul [RingHomSurjective σ] [RingHomIsometric σ] [TopologicalSpace F]
     [TopologicalAddGroup F] [ContinuousSMul 𝕜₂ F] : ContinuousSMul 𝕜₂ (E →SL[σ] F) :=
-  strongTopology.continuousSMul σ F { S | Bornology.IsVonNBounded 𝕜₁ S }
-    ⟨∅, Bornology.isVonNBounded_empty 𝕜₁ E⟩
-    (directedOn_of_sup_mem fun _ _ => Bornology.IsVonNBounded.union) fun _ hs => hs
+  strongTopology.continuousSMul σ F { S | Bornology.IsVonNBounded 𝕜₁ S } fun _ hs => hs
 
 instance uniformSpace [UniformSpace F] [UniformAddGroup F] : UniformSpace (E →SL[σ] F) :=
   strongUniformity σ F { S | Bornology.IsVonNBounded 𝕜₁ S }

--- a/Mathlib/Topology/Algebra/UniformConvergence.lean
+++ b/Mathlib/Topology/Algebra/UniformConvergence.lean
@@ -32,13 +32,6 @@ Like in `Topology/UniformSpace/UniformConvergenceTopology`, we use the type alia
 `UniformFun` (denoted `α →ᵤ β`) and `UniformOnFun` (denoted `α →ᵤ[𝔖] β`) for functions from `α`
 to `β` endowed with the structures of uniform convergence and `𝔖`-convergence.
 
-## TODO
-
-* `UniformOnFun.continuousSMul_induced_of_image_bounded` unnecessarily asks for `𝔖` to be
-  nonempty and directed. This will be easy to solve once we know that replacing `𝔖` by its
-  ***noncovering*** bornology (i.e ***not*** what `Bornology` currently refers to in mathlib)
-  doesn't change the topology.
-
 ## References
 
 * [N. Bourbaki, *General Topology, Chapter X*][bourbaki1966]
@@ -51,7 +44,8 @@ uniform convergence, strong dual
 -/
 
 open Filter
-open scoped Topology Pointwise UniformConvergence
+
+open scoped Topology Pointwise UniformConvergence Uniformity
 
 section AlgebraicInstances
 
@@ -313,7 +307,41 @@ section Module
 variable (𝕜 α E H : Type*) {hom : Type*} [NormedField 𝕜] [AddCommGroup H] [Module 𝕜 H]
   [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace H] [UniformSpace E] [UniformAddGroup E]
   [ContinuousSMul 𝕜 E] {𝔖 : Set <| Set α}
-  [FunLike hom H (α →ᵤ[𝔖] E)] [LinearMapClass hom 𝕜 H (α →ᵤ[𝔖] E)]
+  [FunLike hom H (α → E)] [LinearMapClass hom 𝕜 H (α → E)]
+
+/-- Let `E` be a topological vector space over a normed field `𝕜`, let `α` be any type.
+Let `H` be a submodule of `α →ᵤ E` such that the range of each `f ∈ H` is von Neumann bounded.
+Then `H` is a topological vector space over `𝕜`,
+i.e., the pointwise scalar multiplication is continuous in both variables.
+
+For convenience we require that `H` is a vector space over `𝕜`
+with a topology induced by `UniformFun.ofFun ∘ φ`, where `φ : H →ₗ[𝕜] (α → E)`. -/
+lemma UniformFun.continuousSMul_induced_of_range_bounded (φ : hom)
+    (hφ : Inducing (ofFun ∘ φ)) (h : ∀ u : H, Bornology.IsVonNBounded 𝕜 (Set.range (φ u))) :
+    ContinuousSMul 𝕜 H := by
+  have : TopologicalAddGroup H :=
+    let ofFun' : (α → E) →+ (α →ᵤ E) := AddMonoidHom.id _
+    Inducing.topologicalAddGroup (ofFun'.comp (φ : H →+ (α → E))) hφ
+  have hb : (𝓝 (0 : H)).HasBasis (· ∈ 𝓝 (0 : E)) fun V ↦ {u | ∀ x, φ u x ∈ V} := by
+    simp only [hφ.nhds_eq_comap, Function.comp_apply, map_zero]
+    exact UniformFun.hasBasis_nhds_zero.comap _
+  apply ContinuousSMul.of_basis_zero hb
+  · intro U hU
+    have : Tendsto (fun x : 𝕜 × E ↦ x.1 • x.2) (𝓝 0) (𝓝 0) :=
+      continuous_smul.tendsto' _ _ (zero_smul _ _)
+    rcases ((Filter.basis_sets _).prod_nhds (Filter.basis_sets _)).tendsto_left_iff.1 this U hU
+      with ⟨⟨V, W⟩, ⟨hV, hW⟩, hVW⟩
+    refine ⟨V, hV, W, hW, Set.smul_subset_iff.2 fun a ha u hu x ↦ ?_⟩
+    rw [map_smul]
+    exact hVW (Set.mk_mem_prod ha (hu x))
+  · intro c U hU
+    have : Tendsto (c • · : E → E) (𝓝 0) (𝓝 0) :=
+      (continuous_const_smul c).tendsto' _ _ (smul_zero _)
+    refine ⟨_, this hU, fun u hu x ↦ ?_⟩
+    simpa only [map_smul] using hu x
+  · intro u U hU
+    simp only [Set.mem_setOf_eq, map_smul, Pi.smul_apply]
+    simpa only [Set.mapsTo_range_iff] using (h u hU).eventually_nhds_zero (mem_of_mem_nhds hU)
 
 /-- Let `E` be a TVS, `𝔖 : Set (Set α)` and `H` a submodule of `α →ᵤ[𝔖] E`. If the image of any
 `S ∈ 𝔖` by any `u ∈ H` is bounded (in the sense of `Bornology.IsVonNBounded`), then `H`,
@@ -323,50 +351,20 @@ For convenience, we don't literally ask for `H : Submodule (α →ᵤ[𝔖] E)`.
 result for any vector space `H` equipped with a linear inducing to `α →ᵤ[𝔖] E`, which is often
 easier to use. We also state the `Submodule` version as
 `UniformOnFun.continuousSMul_submodule_of_image_bounded`. -/
-theorem UniformOnFun.continuousSMul_induced_of_image_bounded (h𝔖₁ : 𝔖.Nonempty)
-    (h𝔖₂ : DirectedOn (· ⊆ ·) 𝔖) (φ : hom) (hφ : Inducing φ)
+theorem UniformOnFun.continuousSMul_induced_of_image_bounded (φ : hom) (hφ : Inducing (ofFun 𝔖 ∘ φ))
     (h : ∀ u : H, ∀ s ∈ 𝔖, Bornology.IsVonNBounded 𝕜 ((φ u : α → E) '' s)) :
     ContinuousSMul 𝕜 H := by
-  have : TopologicalAddGroup H := by
-    rw [hφ.induced]
-    exact topologicalAddGroup_induced φ
-  have : (𝓝 0 : Filter H).HasBasis _ _ := by
-    rw [hφ.induced, nhds_induced, map_zero]
-    exact (UniformOnFun.hasBasis_nhds_zero 𝔖 h𝔖₁ h𝔖₂).comap φ
-  refine' ContinuousSMul.of_basis_zero this _ _ _
-  · rintro ⟨S, V⟩ ⟨hS, hV⟩
-    have : Tendsto (fun kx : 𝕜 × E => kx.1 • kx.2) (𝓝 (0, 0)) (𝓝 <| (0 : 𝕜) • (0 : E)) :=
-      continuous_smul.tendsto (0 : 𝕜 × E)
-    rw [zero_smul, nhds_prod_eq] at this
-    have := this hV
-    rw [mem_map, mem_prod_iff] at this
-    rcases this with ⟨U, hU, W, hW, hUW⟩
-    refine' ⟨U, hU, ⟨S, W⟩, ⟨hS, hW⟩, _⟩
-    rw [Set.smul_subset_iff]
-    intro a ha u hu x hx
-    rw [map_smul]
-    exact hUW (⟨ha, hu x hx⟩ : (a, φ u x) ∈ U ×ˢ W)
-  · rintro a ⟨S, V⟩ ⟨hS, hV⟩
-    have : Tendsto (fun x : E => a • x) (𝓝 0) (𝓝 <| a • (0 : E)) := tendsto_id.const_smul a
-    rw [smul_zero] at this
-    refine' ⟨⟨S, (a • ·) ⁻¹' V⟩, ⟨hS, this hV⟩, fun f hf x hx => _⟩
-    rw [map_smul]
-    exact hf x hx
-  · rintro u ⟨S, V⟩ ⟨hS, hV⟩
-    rcases (h u S hS hV).exists_pos with ⟨r, hrpos, hr⟩
-    rw [Metric.eventually_nhds_iff_ball]
-    refine' ⟨r⁻¹, inv_pos.mpr hrpos, fun a ha x hx => _⟩
-    by_cases ha0 : a = 0
-    · rw [ha0]
-      simpa using mem_of_mem_nhds hV
-    · rw [mem_ball_zero_iff] at ha
-      rw [map_smul, Pi.smul_apply]
-      have : φ u x ∈ a⁻¹ • V := by
-        have ha0 : 0 < ‖a‖ := norm_pos_iff.mpr ha0
-        refine' (hr a⁻¹ _) (Set.mem_image_of_mem (φ u) hx)
-        rw [norm_inv, le_inv hrpos ha0]
-        exact ha.le
-      rwa [Set.mem_inv_smul_set_iff₀ ha0] at this
+  obtain rfl := hφ.induced; clear hφ
+  simp only [induced_iInf, UniformOnFun.topologicalSpace_eq, induced_compose]
+  refine continuousSMul_iInf fun s ↦ continuousSMul_iInf fun hs ↦ ?_
+  letI : TopologicalSpace H :=
+    .induced (UniformFun.ofFun ∘ s.restrict ∘ φ) (UniformFun.topologicalSpace s E)
+  set φ' : H →ₗ[𝕜] (s → E) :=
+    { toFun := s.restrict ∘ φ,
+      map_smul' := fun c x ↦ by exact congr_arg s.restrict (map_smul φ c x),
+      map_add' := fun x y ↦ by exact congr_arg s.restrict (map_add φ x y) }
+  refine UniformFun.continuousSMul_induced_of_range_bounded 𝕜 s E H φ' ⟨rfl⟩ fun u ↦ ?_
+  simpa only [Set.image_eq_range] using h u s hs
 #align uniform_on_fun.has_continuous_smul_induced_of_image_bounded UniformOnFun.continuousSMul_induced_of_image_bounded
 
 /-- Let `E` be a TVS, `𝔖 : Set (Set α)` and `H` a submodule of `α →ᵤ[𝔖] E`. If the image of any
@@ -374,13 +372,10 @@ theorem UniformOnFun.continuousSMul_induced_of_image_bounded (h𝔖₁ : 𝔖.No
 equipped with the topology of `𝔖`-convergence, is a TVS.
 
 If you have a hard time using this lemma, try the one above instead. -/
-theorem UniformOnFun.continuousSMul_submodule_of_image_bounded (h𝔖₁ : 𝔖.Nonempty)
-    (h𝔖₂ : DirectedOn (· ⊆ ·) 𝔖) (H : Submodule 𝕜 (α →ᵤ[𝔖] E))
+theorem UniformOnFun.continuousSMul_submodule_of_image_bounded (H : Submodule 𝕜 (α →ᵤ[𝔖] E))
     (h : ∀ u ∈ H, ∀ s ∈ 𝔖, Bornology.IsVonNBounded 𝕜 (u '' s)) :
     @ContinuousSMul 𝕜 H _ _ ((UniformOnFun.topologicalSpace α E 𝔖).induced ((↑) : H → α →ᵤ[𝔖] E)) :=
-  haveI : TopologicalAddGroup H :=
-    topologicalAddGroup_induced (LinearMap.id.domRestrict H : H →ₗ[𝕜] α → E)
-  UniformOnFun.continuousSMul_induced_of_image_bounded 𝕜 α E H h𝔖₁ h𝔖₂
+  UniformOnFun.continuousSMul_induced_of_image_bounded 𝕜 α E H
     (LinearMap.id.domRestrict H : H →ₗ[𝕜] α → E) inducing_subtype_val fun ⟨u, hu⟩ => h u hu
 #align uniform_on_fun.has_continuous_smul_submodule_of_image_bounded UniformOnFun.continuousSMul_submodule_of_image_bounded
 

--- a/Mathlib/Topology/Order.lean
+++ b/Mathlib/Topology/Order.lean
@@ -463,7 +463,7 @@ theorem induced_id [t : TopologicalSpace α] : t.induced id = t :=
     funext fun s => propext <| ⟨fun ⟨_, hs, h⟩ => h ▸ hs, fun hs => ⟨s, hs, rfl⟩⟩
 #align induced_id induced_id
 
-theorem induced_compose [tγ : TopologicalSpace γ] {f : α → β} {g : β → γ} :
+theorem induced_compose {tγ : TopologicalSpace γ} {f : α → β} {g : β → γ} :
     (tγ.induced g).induced f = tγ.induced (g ∘ f) :=
   TopologicalSpace.ext <|
     funext fun _ => propext


### PR DESCRIPTION
- Prove a version
  of `UniformOnFun.continuousSMul_induced_of_image_bounded`
  for `UniformFun`s.
- Deal with `φ : H →ₗ[𝕜] (α → E)` and `ofFun ∘ φ`,
  not `φ : H →ₗ[𝕜] (α →ᵤ[𝔖] E)`.
- Drop unneeded assumptions (nonempty, directed).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)