### PR TITLE
Adaption PR for Std4#535

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -621,6 +621,20 @@ class Monoid (M : Type u) extends Semigroup M, MulOneClass M where
 #align monoid.npow_zero' Monoid.npow_zero
 #align monoid.npow_succ' Monoid.npow_succ
 
+instance {M} [Monoid M] : Std.Associative (α := M) (op := (· * ·)) where
+  assoc := mul_assoc
+
+instance {M} [Monoid M] : Std.LawfulIdentity (α := M) (op := (· * ·)) (o := 1) where
+  left_id := one_mul
+  right_id := mul_one
+
+instance {M} [AddMonoid M] : Std.Associative (α := M) (op := (· + ·)) where
+  assoc := add_assoc
+
+instance {M} [AddMonoid M] : Std.LawfulIdentity (α := M) (op := (· + ·)) (o := 0) where
+  left_id := zero_add
+  right_id := add_zero
+
 -- Bug #660
 attribute [to_additive existing] Monoid.toMulOneClass
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -1734,11 +1734,6 @@ theorem bind_congr {l : List α} {f g : α → List β} (h : ∀ x ∈ l, f x = 
 #align list.bind_congr List.bind_congr
 
 @[simp]
-theorem map_eq_map {α β} (f : α → β) (l : List α) : f <$> l = map f l :=
-  rfl
-#align list.map_eq_map List.map_eq_map
-
-@[simp]
 theorem map_tail (f : α → β) (l) : map f (tail l) = tail (map f l) := by cases l <;> rfl
 #align list.map_tail List.map_tail
 
@@ -2671,6 +2666,7 @@ local notation a " ⋆ " b => op a b
 /-- Notation for `foldl op a l`. -/
 local notation l " <*> " a => foldl op a l
 
+/-
 theorem foldl_assoc : ∀ {l : List α} {a₁ a₂}, (l <*> a₁ ⋆ a₂) = a₁ ⋆ l <*> a₂
   | [], a₁, a₂ => rfl
   | a :: l, a₁, a₂ =>
@@ -2678,6 +2674,7 @@ theorem foldl_assoc : ∀ {l : List α} {a₁ a₂}, (l <*> a₁ ⋆ a₂) = a�
       ((a :: l) <*> a₁ ⋆ a₂) = l <*> a₁ ⋆ a₂ ⋆ a := by simp only [foldl_cons, ha.assoc]
       _ = a₁ ⋆ (a :: l) <*> a₂ := by rw [foldl_assoc, foldl_cons]
 #align list.foldl_assoc List.foldl_assoc
+-/
 
 theorem foldl_op_eq_op_foldr_assoc :
     ∀ {l : List α} {a₁ a₂}, ((l <*> a₁) ⋆ a₂) = a₁ ⋆ l.foldr (· ⋆ ·) a₂

--- a/Mathlib/Data/List/BigOperators/Basic.lean
+++ b/Mathlib/Data/List/BigOperators/Basic.lean
@@ -26,26 +26,15 @@ section Monoid
 
 variable [Monoid M] [Monoid N] [Monoid P] {l l₁ l₂ : List M} {a : M}
 
-@[to_additive (attr := simp)]
-theorem prod_nil : ([] : List M).prod = 1 :=
-  rfl
-#align list.prod_nil List.prod_nil
-#align list.sum_nil List.sum_nil
+attribute [to_additive existing] prod_nil
+attribute [to_additive existing] prod_cons
+attribute [to_additive existing] prod_append
 
 @[to_additive]
 theorem prod_singleton : [a].prod = a :=
   one_mul a
 #align list.prod_singleton List.prod_singleton
 #align list.sum_singleton List.sum_singleton
-
-@[to_additive (attr := simp)]
-theorem prod_cons : (a :: l).prod = a * l.prod :=
-  calc
-    (a :: l).prod = foldl (· * ·) (a * 1) l :=
-      by simp only [List.prod, foldl_cons, one_mul, mul_one]
-    _ = _ := foldl_assoc
-#align list.prod_cons List.prod_cons
-#align list.sum_cons List.sum_cons
 
 @[to_additive]
 lemma prod_induction
@@ -55,14 +44,6 @@ lemma prod_induction
   rw [List.prod_cons]
   simp only [Bool.not_eq_true, List.mem_cons, forall_eq_or_imp] at base
   exact hom _ _ (base.1) (ih base.2)
-
-@[to_additive (attr := simp)]
-theorem prod_append : (l₁ ++ l₂).prod = l₁.prod * l₂.prod :=
-  calc
-    (l₁ ++ l₂).prod = foldl (· * ·) (foldl (· * ·) 1 l₁ * 1) l₂ := by simp [List.prod]
-    _ = l₁.prod * l₂.prod := foldl_assoc
-#align list.prod_append List.prod_append
-#align list.sum_append List.sum_append
 
 @[to_additive]
 theorem prod_concat : (l.concat a).prod = l.prod * a := by

--- a/Mathlib/Data/List/BigOperators/Defs.lean
+++ b/Mathlib/Data/List/BigOperators/Defs.lean
@@ -14,12 +14,7 @@ import Mathlib.Algebra.Group.Defs
 
 namespace List
 
-/-- Product of a list.
-
-`List.prod [a, b, c] = ((1 * a) * b) * c` -/
-@[to_additive "Sum of a list.\n\n`List.sum [a, b, c] = ((0 + a) + b) + c`"]
-def prod {α} [Mul α] [One α] : List α → α :=
-  foldl (· * ·) 1
+attribute [to_additive existing] List.prod
 #align list.prod List.prod
 #align list.sum List.sum
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -26,7 +26,7 @@ package mathlib where
 meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
-require std from git "https://github.com/leanprover/std4" @ "main"
+require std from git "https://github.com/leanprover/std4" @ "jhx/algebra"
 require Qq from git "https://github.com/leanprover-community/quote4" @ "master"
 require aesop from git "https://github.com/leanprover-community/aesop" @ "master"
 require proofwidgets from git "https://github.com/leanprover-community/ProofWidgets4" @ "v0.0.27"


### PR DESCRIPTION

This adapts Mathlib to migrating a `List.prod` and `List.sum` (and a map lemma that seems helpful) from Mathlib to Std4 in leanprover/std4#535.

The main change is they no longer depend on Mathlib specific classes, but depend on Core classes are over the binary operator rather than type.

---

I could use help on fixing the breakage in the use of `to_additive` tactics.

 
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
