### PR TITLE
feat(Algebra.Module.Zlattice): Add Voronoi Domain

### DIFF
--- a/Mathlib/Algebra/Module/Zlattice.lean
+++ b/Mathlib/Algebra/Module/Zlattice.lean
@@ -85,6 +85,23 @@ lemma fundamentalDomain_pi_basisFun [Fintype ι] :
     fundamentalDomain (Pi.basisFun ℝ ι) = Set.pi Set.univ fun _ : ι ↦ Set.Ico (0 : ℝ) 1 := by
   ext; simp
 
+  /-- The Voronoi domain of the ℤ-lattice spanned by `b`. -/
+def VoronoiDomain : Set E := {m | ∀ v ∈ span ℤ (Set.range b), ‖m‖ ≤ ‖m - v‖}
+
+@[simp]
+theorem mem_VoronoiDomain {m : E} :
+    m ∈ VoronoiDomain b ↔ ∀ v ∈ span ℤ (Set.range b), ‖m‖ ≤ ‖m - v‖ := Iff.rfl
+
+theorem map_VoronoiDomain {F : Type*} [NormedAddCommGroup F] [NormedSpace K F] (f : E ≃ₗ[K] F) :
+    f '' (VoronoiDomain b) = VoronoiDomain (b.map f) := by
+  ext x
+  sorry -- this seems like it should be true but need to find a proof
+
+@[simp]
+theorem VoronoiDomain_reindex {ι' : Type*} (e : ι ≃ ι') :
+    VoronoiDomain (b.reindex e) = VoronoiDomain b := by
+  ext; simp
+
 variable [FloorRing K]
 
 section Fintype


### PR DESCRIPTION
Adds the definition for a Voronoi Domain in regards to the $\mathbb{Z}$-lattice:

$$C := \lbrace\mathbf{w} \in \mathbb{V}^n\ :\ |\mathbf{w}| \leq |\mathbf{w} - \mathbf{v}|\ \text{for all}\ \mathbf{v} \in \mathbf{L} \rbrace$$

where $\mathbf{L}\$ is the $\mathbb{Z}$-lattice.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
