### PR TITLE
[Merged by Bors] - refactor(Topology/Order) : Fix inconsistencies between Lower/Upper and Scott topologies

### DIFF
--- a/Mathlib/Topology/Order/LowerUpperTopology.lean
+++ b/Mathlib/Topology/Order/LowerUpperTopology.lean
@@ -209,12 +209,6 @@ lemma topology_eq : ‹_› = lower α := topology_eq_lowerTopology
 
 variable {α}
 
-/-- If `α` is equipped with the lower topology, then it is homeomorphic to `WithLower α`.
--/
-def WithLowerHomeomorph : WithLower α ≃ₜ α :=
-  WithLower.ofLower.toHomeomorphOfInducing ⟨by erw [topology_eq α, induced_id]; rfl⟩
-#align lower_topology.with_lower_topology_homeomorph Topology.IsLower.WithLowerHomeomorph
-
 theorem isOpen_iff_generate_Ici_compl : IsOpen s ↔ GenerateOpen { t | ∃ a, (Ici a)ᶜ = t } s := by
   rw [topology_eq α]; rfl
 #align lower_topology.is_open_iff_generate_Ici_compl Topology.IsLower.isOpen_iff_generate_Ici_compl
@@ -305,6 +299,12 @@ end PartialOrder
 
 end IsLower
 
+/-- If `α` is equipped with the lower topology, then it is homeomorphic to `WithLower α`.
+-/
+def WithLower.WithLowerHomeomorph [Preorder α] [TopologicalSpace α] [IsLower α] :
+    WithLower α ≃ₜ α :=
+  WithLower.ofLower.toHomeomorphOfInducing ⟨by erw [IsLower.topology_eq α, induced_id]; rfl⟩
+#align lower_topology.with_lower_topology_homeomorph Topology.WithLower.WithLowerHomeomorph
 
 namespace IsUpper
 
@@ -321,11 +321,6 @@ variable [Preorder α] [TopologicalSpace α] [IsUpper α] {s : Set α}
 lemma topology_eq : ‹_› = upper α := topology_eq_upperTopology
 
 variable {α}
-
-/-- If `α` is equipped with the upper topology, then it is homeomorphic to `WithUpper α`.
--/
-def WithUpperHomeomorph : WithUpper α ≃ₜ α :=
-  WithUpper.ofUpper.toHomeomorphOfInducing ⟨by erw [topology_eq α, induced_id]; rfl⟩
 
 theorem isOpen_iff_generate_Iic_compl : IsOpen s ↔ GenerateOpen { t | ∃ a, (Iic a)ᶜ = t } s := by
   rw [topology_eq α]; rfl
@@ -388,6 +383,12 @@ instance (priority := 90) t0Space : T0Space α :=
 end PartialOrder
 
 end IsUpper
+
+/-- If `α` is equipped with the upper topology, then it is homeomorphic to `WithUpper α`.
+-/
+def WithUpper.WithUpperHomeomorph [Preorder α] [TopologicalSpace α] [IsUpper α] :
+    WithUpper α ≃ₜ α :=
+  WithUpper.ofUpper.toHomeomorphOfInducing ⟨by erw [IsUpper.topology_eq α, induced_id]; rfl⟩
 
 instance instIsLowerProd [Preorder α] [TopologicalSpace α] [IsLower α]
     [OrderBot α] [Preorder β] [TopologicalSpace β] [IsLower β] [OrderBot β] :

--- a/Mathlib/Topology/Order/LowerUpperTopology.lean
+++ b/Mathlib/Topology/Order/LowerUpperTopology.lean
@@ -213,7 +213,7 @@ variable {α}
 -/
 def withLowerHomeomorph : WithLower α ≃ₜ α :=
   WithLower.ofLower.toHomeomorphOfInducing ⟨by erw [topology_eq α, induced_id]; rfl⟩
-#align lower_topology.with_lower_topology_homeomorph Topology.IsLower.WithLowerHomeomorph
+#align lower_topology.with_lower_topology_homeomorph Topology.IsLower.withLowerHomeomorph
 
 theorem isOpen_iff_generate_Ici_compl : IsOpen s ↔ GenerateOpen { t | ∃ a, (Ici a)ᶜ = t } s := by
   rw [topology_eq α]; rfl

--- a/Mathlib/Topology/Order/LowerUpperTopology.lean
+++ b/Mathlib/Topology/Order/LowerUpperTopology.lean
@@ -211,7 +211,7 @@ variable {α}
 
 /-- If `α` is equipped with the lower topology, then it is homeomorphic to `WithLower α`.
 -/
-def WithLowerHomeomorph : WithLower α ≃ₜ α :=
+def withLowerHomeomorph : WithLower α ≃ₜ α :=
   WithLower.ofLower.toHomeomorphOfInducing ⟨by erw [topology_eq α, induced_id]; rfl⟩
 #align lower_topology.with_lower_topology_homeomorph Topology.IsLower.WithLowerHomeomorph
 
@@ -324,7 +324,7 @@ variable {α}
 
 /-- If `α` is equipped with the upper topology, then it is homeomorphic to `WithUpper α`.
 -/
-def WithUpperHomeomorph : WithUpper α ≃ₜ α :=
+def withUpperHomeomorph : WithUpper α ≃ₜ α :=
   WithUpper.ofUpper.toHomeomorphOfInducing ⟨by erw [topology_eq α, induced_id]; rfl⟩
 
 theorem isOpen_iff_generate_Iic_compl : IsOpen s ↔ GenerateOpen { t | ∃ a, (Iic a)ᶜ = t } s := by

--- a/Mathlib/Topology/Order/LowerUpperTopology.lean
+++ b/Mathlib/Topology/Order/LowerUpperTopology.lean
@@ -209,6 +209,12 @@ lemma topology_eq : ‹_› = lower α := topology_eq_lowerTopology
 
 variable {α}
 
+/-- If `α` is equipped with the lower topology, then it is homeomorphic to `WithLower α`.
+-/
+def WithLowerHomeomorph : WithLower α ≃ₜ α :=
+  WithLower.ofLower.toHomeomorphOfInducing ⟨by erw [topology_eq α, induced_id]; rfl⟩
+#align lower_topology.with_lower_topology_homeomorph Topology.IsLower.WithLowerHomeomorph
+
 theorem isOpen_iff_generate_Ici_compl : IsOpen s ↔ GenerateOpen { t | ∃ a, (Ici a)ᶜ = t } s := by
   rw [topology_eq α]; rfl
 #align lower_topology.is_open_iff_generate_Ici_compl Topology.IsLower.isOpen_iff_generate_Ici_compl
@@ -299,12 +305,6 @@ end PartialOrder
 
 end IsLower
 
-/-- If `α` is equipped with the lower topology, then it is homeomorphic to `WithLower α`.
--/
-def WithLower.WithLowerHomeomorph [Preorder α] [TopologicalSpace α] [IsLower α] :
-    WithLower α ≃ₜ α :=
-  WithLower.ofLower.toHomeomorphOfInducing ⟨by erw [IsLower.topology_eq α, induced_id]; rfl⟩
-#align lower_topology.with_lower_topology_homeomorph Topology.WithLower.WithLowerHomeomorph
 
 namespace IsUpper
 
@@ -321,6 +321,11 @@ variable [Preorder α] [TopologicalSpace α] [IsUpper α] {s : Set α}
 lemma topology_eq : ‹_› = upper α := topology_eq_upperTopology
 
 variable {α}
+
+/-- If `α` is equipped with the upper topology, then it is homeomorphic to `WithUpper α`.
+-/
+def WithUpperHomeomorph : WithUpper α ≃ₜ α :=
+  WithUpper.ofUpper.toHomeomorphOfInducing ⟨by erw [topology_eq α, induced_id]; rfl⟩
 
 theorem isOpen_iff_generate_Iic_compl : IsOpen s ↔ GenerateOpen { t | ∃ a, (Iic a)ᶜ = t } s := by
   rw [topology_eq α]; rfl
@@ -383,12 +388,6 @@ instance (priority := 90) t0Space : T0Space α :=
 end PartialOrder
 
 end IsUpper
-
-/-- If `α` is equipped with the upper topology, then it is homeomorphic to `WithUpper α`.
--/
-def WithUpper.WithUpperHomeomorph [Preorder α] [TopologicalSpace α] [IsUpper α] :
-    WithUpper α ≃ₜ α :=
-  WithUpper.ofUpper.toHomeomorphOfInducing ⟨by erw [IsUpper.topology_eq α, induced_id]; rfl⟩
 
 instance instIsLowerProd [Preorder α] [TopologicalSpace α] [IsLower α]
     [OrderBot α] [Preorder β] [TopologicalSpace β] [IsLower β] [OrderBot β] :

--- a/Mathlib/Topology/Order/LowerUpperTopology.lean
+++ b/Mathlib/Topology/Order/LowerUpperTopology.lean
@@ -301,10 +301,10 @@ end IsLower
 
 /-- If `α` is equipped with the lower topology, then it is homeomorphic to `WithLower α`.
 -/
-def WithLower.withLowerHomeomorph [Preorder α] [TopologicalSpace α] [IsLower α] :
+def WithLower.WithLowerHomeomorph [Preorder α] [TopologicalSpace α] [IsLower α] :
     WithLower α ≃ₜ α :=
   WithLower.ofLower.toHomeomorphOfInducing ⟨by erw [IsLower.topology_eq α, induced_id]; rfl⟩
-#align lower_topology.with_lower_topology_homeomorph Topology.WithLower.withLowerHomeomorph
+#align lower_topology.with_lower_topology_homeomorph Topology.WithLower.WithLowerHomeomorph
 
 namespace IsUpper
 
@@ -386,7 +386,7 @@ end IsUpper
 
 /-- If `α` is equipped with the upper topology, then it is homeomorphic to `WithUpper α`.
 -/
-def WithUpper.withUpperHomeomorph [Preorder α] [TopologicalSpace α] [IsUpper α] :
+def WithUpper.WithUpperHomeomorph [Preorder α] [TopologicalSpace α] [IsUpper α] :
     WithUpper α ≃ₜ α :=
   WithUpper.ofUpper.toHomeomorphOfInducing ⟨by erw [IsUpper.topology_eq α, induced_id]; rfl⟩
 

--- a/Mathlib/Topology/Order/LowerUpperTopology.lean
+++ b/Mathlib/Topology/Order/LowerUpperTopology.lean
@@ -301,10 +301,10 @@ end IsLower
 
 /-- If `α` is equipped with the lower topology, then it is homeomorphic to `WithLower α`.
 -/
-def WithLower.WithLowerHomeomorph [Preorder α] [TopologicalSpace α] [IsLower α] :
+def WithLower.withLowerHomeomorph [Preorder α] [TopologicalSpace α] [IsLower α] :
     WithLower α ≃ₜ α :=
   WithLower.ofLower.toHomeomorphOfInducing ⟨by erw [IsLower.topology_eq α, induced_id]; rfl⟩
-#align lower_topology.with_lower_topology_homeomorph Topology.WithLower.WithLowerHomeomorph
+#align lower_topology.with_lower_topology_homeomorph Topology.WithLower.withLowerHomeomorph
 
 namespace IsUpper
 
@@ -386,7 +386,7 @@ end IsUpper
 
 /-- If `α` is equipped with the upper topology, then it is homeomorphic to `WithUpper α`.
 -/
-def WithUpper.WithUpperHomeomorph [Preorder α] [TopologicalSpace α] [IsUpper α] :
+def WithUpper.withUpperHomeomorph [Preorder α] [TopologicalSpace α] [IsUpper α] :
     WithUpper α ≃ₜ α :=
   WithUpper.ofUpper.toHomeomorphOfInducing ⟨by erw [IsUpper.topology_eq α, induced_id]; rfl⟩
 

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -129,7 +129,7 @@ variable [Preorder α] {s : Set α}
 
 A set `u` is open in the Scott-Hausdorff topology iff when the least upper bound of a directed set
 `d` lies in `u` then there is a tail of `d` which is a subset of `u`. -/
-def scottHausdorff : TopologicalSpace α where
+def scottHausdorff (α : Type*) [Preorder α] : TopologicalSpace α where
   IsOpen u := ∀ ⦃d : Set α⦄, d.Nonempty → DirectedOn (· ≤ ·) d → ∀ ⦃a : α⦄, IsLUB d a →
     a ∈ u → ∃ b ∈ d, Ici b ∩ d ⊆ u
   isOpen_univ := fun d ⟨b, hb⟩ _ _ _ _ ↦ ⟨b, hb, (Ici b ∩ d).subset_univ⟩
@@ -149,14 +149,15 @@ variable (α) [TopologicalSpace α]
 A set `u` is open in the Scott-Hausdorff topology iff when the least upper bound of a directed set
 `d` lies in `u` then there is a tail of `d` which is a subset of `u`. -/
 class IsScottHausdorff : Prop where
-  topology_eq_scottHausdorff : ‹TopologicalSpace α› = scottHausdorff
+  topology_eq_scottHausdorff : ‹TopologicalSpace α› = scottHausdorff α
 
-instance : @IsScottHausdorff α _ scottHausdorff := @IsScottHausdorff.mk _ _ scottHausdorff rfl
+instance : @IsScottHausdorff α _ (scottHausdorff α) :=
+  @IsScottHausdorff.mk _ _ (scottHausdorff α) rfl
 
 namespace IsScottHausdorff
 variable [IsScottHausdorff α] {s : Set α}
 
-lemma topology_eq : ‹_› = scottHausdorff := topology_eq_scottHausdorff
+lemma topology_eq : ‹_› = scottHausdorff α := topology_eq_scottHausdorff
 
 variable {α}
 
@@ -189,7 +190,7 @@ variable [Preorder α]
 /-- The Scott topology.
 
 It is defined as the join of the topology of upper sets and the Scott-Hausdorff topology. -/
-def scott : TopologicalSpace α := upperSet α ⊔ scottHausdorff
+def scott : TopologicalSpace α := upperSet α ⊔ scottHausdorff α
 
 lemma upperSet_le_scott : upperSet α ≤ scott := le_sup_left
 
@@ -215,12 +216,13 @@ lemma topology_eq : ‹_› = scott := topology_eq_scott
 variable {α} {s : Set α} {a : α}
 
 lemma isOpen_iff_isUpperSet_and_scottHausdorff_open :
-    IsOpen s ↔ IsUpperSet s ∧ IsOpen[scottHausdorff] s := by erw [topology_eq α]; rfl
+    IsOpen s ↔ IsUpperSet s ∧ IsOpen[scottHausdorff α] s := by erw [topology_eq α]; rfl
 
 lemma isOpen_iff_isUpperSet_and_dirSupInacc : IsOpen s ↔ IsUpperSet s ∧ DirSupInacc s := by
   rw [isOpen_iff_isUpperSet_and_scottHausdorff_open]
   refine and_congr_right fun h ↦
-    ⟨@IsScottHausdorff.dirSupInacc_of_isOpen _ _ scottHausdorff _ _, fun h' d d₁ d₂ _ d₃ ha ↦ ?_⟩
+    ⟨@IsScottHausdorff.dirSupInacc_of_isOpen _ _ (scottHausdorff α) _ _,
+      fun h' d d₁ d₂ _ d₃ ha ↦ ?_⟩
   obtain ⟨b, hbd, hbu⟩ := h' d₁ d₂ d₃ ha
   exact ⟨b, hbd, Subset.trans (inter_subset_left (Ici b) d) (h.Ici_subset hbu)⟩
 
@@ -329,7 +331,7 @@ instance : TopologicalSpace (WithScott α) := scott
 instance : IsScott (WithScott α) := ⟨rfl⟩
 
 lemma isOpen_iff_isUpperSet_and_scottHausdorff_open' {u : Set α} :
-    IsOpen (WithScott.ofScott ⁻¹' u) ↔ IsUpperSet u ∧ scottHausdorff.IsOpen u := Iff.rfl
+    IsOpen (WithScott.ofScott ⁻¹' u) ↔ IsUpperSet u ∧ (scottHausdorff α).IsOpen u := Iff.rfl
 
 /-- If `α` is equipped with the Scott topology, then it is homeomorphic to `WithScott α`.
 -/
@@ -341,11 +343,12 @@ end Scott
 
 variable [Preorder α] [TopologicalSpace α]
 
-lemma IsScott.scottHausdorff_le [IsScott α] : scottHausdorff ≤ ‹TopologicalSpace α› := by
+lemma IsScott.scottHausdorff_le [IsScott α] : scottHausdorff α ≤ ‹TopologicalSpace α› := by
   rw [IsScott.topology_eq α, scott]; exact le_sup_right
 
-lemma IsLower.scottHausdorff_le [IsLower α] : scottHausdorff ≤ ‹TopologicalSpace α› :=
+lemma IsLower.scottHausdorff_le [IsLower α] : scottHausdorff α ≤ ‹TopologicalSpace α› :=
   fun _ h ↦
-    @IsScottHausdorff.isOpen_of_isLowerSet _ _ scottHausdorff _ _ <| IsLower.isLowerSet_of_isOpen h
+    @IsScottHausdorff.isOpen_of_isLowerSet _ _ (scottHausdorff α) _ _
+      <| IsLower.isLowerSet_of_isOpen h
 
 end Topology

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -190,9 +190,9 @@ variable [Preorder α]
 /-- The Scott topology.
 
 It is defined as the join of the topology of upper sets and the Scott-Hausdorff topology. -/
-def scott : TopologicalSpace α := upperSet α ⊔ scottHausdorff α
+def scott (α : Type*) [Preorder α] : TopologicalSpace α := upperSet α ⊔ scottHausdorff α
 
-lemma upperSet_le_scott : upperSet α ≤ scott := le_sup_left
+lemma upperSet_le_scott : upperSet α ≤ scott α := le_sup_left
 
 lemma scottHausdorff_le_scott : @scottHausdorff α ≤ @scott α := le_sup_right
 
@@ -203,7 +203,7 @@ variable (α) [TopologicalSpace α]
 The Scott topology is defined as the join of the topology of upper sets and the Scott Hausdorff
 topology. -/
 class IsScott : Prop where
-  topology_eq_scott : ‹TopologicalSpace α› = scott
+  topology_eq_scott : ‹TopologicalSpace α› = scott α
 
 end Preorder
 
@@ -211,7 +211,7 @@ namespace IsScott
 section Preorder
 variable (α) [Preorder α] [TopologicalSpace α] [IsScott α]
 
-lemma topology_eq : ‹_› = scott := topology_eq_scott
+lemma topology_eq : ‹_› = scott α := topology_eq_scott
 
 variable {α} {s : Set α} {a : α}
 
@@ -327,7 +327,7 @@ instance [Inhabited α] : Inhabited (WithScott α) := ‹Inhabited α›
 variable [Preorder α]
 
 instance : Preorder (WithScott α) := ‹Preorder α›
-instance : TopologicalSpace (WithScott α) := scott
+instance : TopologicalSpace (WithScott α) := scott α
 instance : IsScott (WithScott α) := ⟨rfl⟩
 
 lemma isOpen_iff_isUpperSet_and_scottHausdorff_open' {u : Set α} :

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -333,15 +333,17 @@ instance : IsScott (WithScott α) := ⟨rfl⟩
 lemma isOpen_iff_isUpperSet_and_scottHausdorff_open' {u : Set α} :
     IsOpen (WithScott.ofScott ⁻¹' u) ↔ IsUpperSet u ∧ (scottHausdorff α).IsOpen u := Iff.rfl
 
-/-- If `α` is equipped with the Scott topology, then it is homeomorphic to `WithScott α`.
--/
-def withScottHomeomorph [TopologicalSpace α] [IsScott α] : WithScott α ≃ₜ α :=
-  WithScott.ofScott.toHomeomorphOfInducing ⟨by erw [IsScott.topology_eq α, induced_id]; rfl⟩
+
 
 end WithScott
 end Scott
 
 variable [Preorder α] [TopologicalSpace α]
+
+/-- If `α` is equipped with the Scott topology, then it is homeomorphic to `WithScott α`.
+-/
+def IsScott.withScottHomeomorph [TopologicalSpace α] [IsScott α] : WithScott α ≃ₜ α :=
+  WithScott.ofScott.toHomeomorphOfInducing ⟨by erw [IsScott.topology_eq α, induced_id]; rfl⟩
 
 lemma IsScott.scottHausdorff_le [IsScott α] : scottHausdorff α ≤ ‹TopologicalSpace α› := by
   rw [IsScott.topology_eq α, scott]; exact le_sup_right

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -333,8 +333,6 @@ instance : IsScott (WithScott α) := ⟨rfl⟩
 lemma isOpen_iff_isUpperSet_and_scottHausdorff_open' {u : Set α} :
     IsOpen (WithScott.ofScott ⁻¹' u) ↔ IsUpperSet u ∧ (scottHausdorff α).IsOpen u := Iff.rfl
 
-
-
 end WithScott
 end Scott
 


### PR DESCRIPTION
- Make type explicit in def of Scott-Hausdorff and Scott topologies
- Move `With{Lower|Upper}Homeomorph` into the correct namespace

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
