### PR TITLE
[Merged by Bors] - Feat(Logic/Nonempty): Add a non-dependent version of `Nonempty.forall` for better unification

### DIFF
--- a/Mathlib/Logic/Nonempty.lean
+++ b/Mathlib/Logic/Nonempty.lean
@@ -31,6 +31,16 @@ instance (priority := 20) Zero.instNonempty [Zero α] : Nonempty α :=
 instance (priority := 20) One.instNonempty [One α] : Nonempty α :=
   ⟨1⟩
 
+@[simp]
+theorem Nonempty.forall {α} {p : Nonempty α → Prop} : (∀ h : Nonempty α, p h) ↔ ∀ a, p ⟨a⟩ :=
+  Iff.intro (fun h _ ↦ h _) fun h ⟨a⟩ ↦ h a
+#align nonempty.forall Nonempty.forall
+
+@[simp]
+theorem Nonempty.exists {α} {p : Nonempty α → Prop} : (∃ h : Nonempty α, p h) ↔ ∃ a, p ⟨a⟩ :=
+  Iff.intro (fun ⟨⟨a⟩, h⟩ ↦ ⟨a, h⟩) fun ⟨a, h⟩ ↦ ⟨⟨a⟩, h⟩
+#align nonempty.exists Nonempty.exists
+
 theorem exists_true_iff_nonempty {α : Sort*} : (∃ _ : α, True) ↔ Nonempty α :=
   Iff.intro (fun ⟨a, _⟩ ↦ ⟨a⟩) fun ⟨a⟩ ↦ ⟨a, trivial⟩
 #align exists_true_iff_nonempty exists_true_iff_nonempty
@@ -40,8 +50,11 @@ theorem nonempty_Prop {p : Prop} : Nonempty p ↔ p :=
   Iff.intro (fun ⟨h⟩ ↦ h) fun h ↦ ⟨h⟩
 #align nonempty_Prop nonempty_Prop
 
+theorem Nonempty.imp {α} {p : Prop} : (Nonempty α → p) ↔ (α → p) :=
+  Nonempty.forall
+
 theorem not_nonempty_iff_imp_false {α : Sort*} : ¬Nonempty α ↔ α → False :=
-  ⟨fun h a ↦ h ⟨a⟩, fun h ⟨a⟩ ↦ h a⟩
+  Nonempty.imp
 #align not_nonempty_iff_imp_false not_nonempty_iff_imp_false
 
 @[simp]
@@ -104,16 +117,6 @@ theorem nonempty_ulift : Nonempty (ULift α) ↔ Nonempty α :=
 theorem nonempty_plift {α} : Nonempty (PLift α) ↔ Nonempty α :=
   Iff.intro (fun ⟨⟨a⟩⟩ ↦ ⟨a⟩) fun ⟨a⟩ ↦ ⟨⟨a⟩⟩
 #align nonempty_plift nonempty_plift
-
-@[simp]
-theorem Nonempty.forall {α} {p : Nonempty α → Prop} : (∀ h : Nonempty α, p h) ↔ ∀ a, p ⟨a⟩ :=
-  Iff.intro (fun h _ ↦ h _) fun h ⟨a⟩ ↦ h a
-#align nonempty.forall Nonempty.forall
-
-@[simp]
-theorem Nonempty.exists {α} {p : Nonempty α → Prop} : (∃ h : Nonempty α, p h) ↔ ∃ a, p ⟨a⟩ :=
-  Iff.intro (fun ⟨⟨a⟩, h⟩ ↦ ⟨a, h⟩) fun ⟨a, h⟩ ↦ ⟨⟨a⟩, h⟩
-#align nonempty.exists Nonempty.exists
 
 /-- Using `Classical.choice`, lifts a (`Prop`-valued) `Nonempty` instance to a (`Type`-valued)
   `Inhabited` instance. `Classical.inhabited_of_nonempty` already exists, in


### PR DESCRIPTION
Add a non-dependent version of `Nonempty.forall` for better unification

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
