### PR TITLE
[Merged by Bors] - chore: nlinarith bug caused by exposing loose bvars

### DIFF
--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -313,7 +313,7 @@ partial def findSquares (s : HashSet (Expr × Bool)) (e : Expr) : MetaM (HashSet
   -- Completely traversing the expression is non-ideal,
   -- as we can descend into expressions that could not possibly be seen by `linarith`.
   -- As a result we visit expressions with bvars, which then cause panics.
-  -- Ideally this preprocessor would be reimplement so it only visits things that could be atoms.
+  -- Ideally this preprocessor would be reimplemented so it only visits things that could be atoms.
   -- In the meantime we just bail out if we ever encounter loose bvars.
   if e.hasLooseBVars then return s else
   match e.getAppFnArgs with

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -310,6 +310,12 @@ and adds them to the set `s`.
 A pair `(a, true)` is added to `s` when `a^2` appears in `e`,
 and `(a, false)` is added to `s` when `a*a` appears in `e`.  -/
 partial def findSquares (s : HashSet (Expr × Bool)) (e : Expr) : MetaM (HashSet (Expr × Bool)) :=
+  -- Completely traversing the expression is non-ideal,
+  -- as we can descend into expressions that could not possibly be seen by `linarith`.
+  -- As a result we visit expressions with bvars, which then cause panics.
+  -- Ideally this preprocessor would be reimplement so it only visits things that could be atoms.
+  -- In the meantime we just bail out if we ever encounter loose bvars.
+  if e.hasLooseBVars then return s else
   match e.getAppFnArgs with
   | (``HPow.hPow, #[_, _, _, _, a, b]) => match b.numeral? with
     | some 2 => do

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -2,6 +2,7 @@ import Mathlib.Tactic.Linarith
 import Mathlib.Data.Rat.Init
 import Mathlib.Data.Rat.Order
 import Mathlib.Data.Int.Order.Basic
+import Mathlib.Data.Nat.Interval
 
 private axiom test_sorry : ∀ {α}, α
 set_option linter.unusedVariables false
@@ -586,3 +587,13 @@ error: Argument passed to nlinarith has metavariables:
 #guard_msgs in
 example (q : Prop) (p : ∀ (x : ℤ), 1 = 2) : 1 = 2 := by
   nlinarith [p ?a]
+
+open BigOperators
+
+example (h : False): True := by
+  have : ∑ k in Finset.empty, k^2 = 0 := by contradiction
+  have : ∀ k : Nat, 0 ≤ k := by
+    intro h
+    -- this should not panic:
+    nlinarith
+  trivial


### PR DESCRIPTION
Certainly better fixes to the panicking problem here are possible, by simply not traversing into places that would have loose bvars. However I'd like to get this patched quickly, so anyone wanting to make such a change can please do it in a follow up PR! :-)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
