### PR TITLE
[Merged by Bors] - feat: lower priority in Init/Order/Defs

### DIFF
--- a/Mathlib/Init/Order/Defs.lean
+++ b/Mathlib/Init/Order/Defs.lean
@@ -18,13 +18,6 @@ Defines classes for preorders, partial orders, and linear orders
 and proves some basic lemmas about them.
 -/
 
-/-
-TODO: Does Lean4 have an equivalent for this:
-  Make sure instances defined in this file have lower priority than the ones
-  defined for concrete structures
-set_option default_priority 100
--/
-
 universe u
 variable {α : Type u}
 
@@ -137,14 +130,14 @@ theorem gt_of_ge_of_gt {a b c : α} (h₁ : a ≥ b) (h₂ : b > c) : a > c :=
 #align gt_of_ge_of_gt gt_of_ge_of_gt
 
 -- porting note: new
-instance : @Trans α α α LE.le LE.le LE.le := ⟨le_trans⟩
-instance : @Trans α α α LT.lt LT.lt LT.lt := ⟨lt_trans⟩
-instance : @Trans α α α LT.lt LE.le LT.lt := ⟨lt_of_lt_of_le⟩
-instance : @Trans α α α LE.le LT.lt LT.lt := ⟨lt_of_le_of_lt⟩
-instance : @Trans α α α GE.ge GE.ge GE.ge := ⟨ge_trans⟩
-instance : @Trans α α α GT.gt GT.gt GT.gt := ⟨gt_trans⟩
-instance : @Trans α α α GT.gt GE.ge GT.gt := ⟨gt_of_gt_of_ge⟩
-instance : @Trans α α α GE.ge GT.gt GT.gt := ⟨gt_of_ge_of_gt⟩
+instance (priority := 900) : @Trans α α α LE.le LE.le LE.le := ⟨le_trans⟩
+instance (priority := 900) : @Trans α α α LT.lt LT.lt LT.lt := ⟨lt_trans⟩
+instance (priority := 900) : @Trans α α α LT.lt LE.le LT.lt := ⟨lt_of_lt_of_le⟩
+instance (priority := 900) : @Trans α α α LE.le LT.lt LT.lt := ⟨lt_of_le_of_lt⟩
+instance (priority := 900) : @Trans α α α GE.ge GE.ge GE.ge := ⟨ge_trans⟩
+instance (priority := 900) : @Trans α α α GT.gt GT.gt GT.gt := ⟨gt_trans⟩
+instance (priority := 900) : @Trans α α α GT.gt GE.ge GT.gt := ⟨gt_of_gt_of_ge⟩
+instance (priority := 900) : @Trans α α α GE.ge GT.gt GT.gt := ⟨gt_of_ge_of_gt⟩
 
 theorem not_le_of_gt {a b : α} (h : a > b) : ¬a ≤ b :=
   (le_not_le_of_lt h).right
@@ -375,13 +368,13 @@ theorem not_le {a b : α} : ¬a ≤ b ↔ b < a :=
   (lt_iff_not_ge _ _).symm
 #align not_le not_le
 
-instance (a b : α) : Decidable (a < b) :=
+instance (priority := 900) (a b : α) : Decidable (a < b) :=
   LinearOrder.decidableLT a b
 
-instance (a b : α) : Decidable (a ≤ b) :=
+instance (priority := 900) (a b : α) : Decidable (a ≤ b) :=
   LinearOrder.decidableLE a b
 
-instance (a b : α) : Decidable (a = b) :=
+instance (priority := 900) (a b : α) : Decidable (a = b) :=
   LinearOrder.decidableEq a b
 
 theorem eq_or_lt_of_not_lt {a b : α} (h : ¬a < b) : a = b ∨ b < a :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

These changes were needed to fix the build in the (unsatisfactory) experiment https://github.com/leanprover-community/mathlib4/pull/10335. They seem useful to have in any case, as independent refactors could stumble on the same issues.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
