### PR TITLE
[Merged by Bors] - docs: add `monicity` to the module docs

### DIFF
--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -8,9 +8,9 @@ import Mathlib.Data.Polynomial.Degree.Lemmas
 
 /-!
 
-# `compute_degree` a tactic for computing degrees of polynomials
+# `compute_degree` and `monicity`: tactics for explicit polynomials
 
-This file defines the tactic `compute_degree`.
+This file defines two related tactics: `compute_degree` and `monicity`.
 
 Using `compute_degree` when the goal is of one of the five forms
 *  `natDegree f ≤ d`,
@@ -21,11 +21,17 @@ Using `compute_degree` when the goal is of one of the five forms
 tries to solve the goal.
 It may leave side-goals, in case it is not entirely successful.
 
-See the doc-string for more details.
+Using `monicity` when the goal is of the form `Monic f` tries to solve the goal.
+It may leave side-goals, in case it is not entirely successful.
+
+Both tactics admit a `!` modifier (`compute_degree!` and `monicity!`) instructing
+Lean to try harder to close the goal.
+
+See the doc-strings for more details.
 
 ##  Future work
 
-* Currently, the tactic does not deal correctly with some edge cases.  For instance,
+* Currently, `compute_degree` does not deal correctly with some edge cases.  For instance,
   ```lean
   example [Semiring R] : natDegree (C 0 : R[X]) = 0 := by
     compute_degree


### PR DESCRIPTION
Adding docs is (almost) always good!  In this case, it was prompted by [this Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.22Missing.20Tactics.22.20list/near/420442132).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
