### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Galois): fix spelling and rename connected objects

### DIFF
--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -15,14 +15,14 @@ import Mathlib.CategoryTheory.SingleObj
 /-!
 # Definition and basic properties of Galois categories
 
-We define the notion of a Galois category and a fibre functor as in SGA1, following
+We define the notion of a Galois category and a fiber functor as in SGA1, following
 the definitions in Lenstras notes (see below for a reference).
 
 ## Main definitions
 
-* `PreGaloisCategory` : defining properties of Galois categories not involving a fibre functor
-* `FibreFunctor`      : a fibre functor from a PreGaloisCategory to `FintypeCat`
-* `GaloisCategory`    : a `PreGaloisCategory` that admits a `FibreFunctor`
+* `PreGaloisCategory` : defining properties of Galois categories not involving a fiber functor
+* `FiberFunctor`      : a fiber functor from a PreGaloisCategory to `FintypeCat`
+* `GaloisCategory`    : a `PreGaloisCategory` that admits a `FiberFunctor`
 * `ConnectedObject`   : an object of a category that is not initial and has no non-trivial
                         subobjects
 
@@ -48,11 +48,11 @@ open Limits Functor
 
 /-!
 A category `C` is a PreGalois category if it satisfies all properties
-of a Galois category in the sense of SGA1 that do not involve a fibre functor.
-A Galois category should furthermore admit a fibre functor.
+of a Galois category in the sense of SGA1 that do not involve a fiber functor.
+A Galois category should furthermore admit a fiber functor.
 
-The only difference between `[PreGaloisCategory C] (F : C ⥤ FintypeCat) [FibreFunctor F]` and
-`[GaloisCategory C]` is that the former fixes one fibre functor `F`.
+The only difference between `[PreGaloisCategory C] (F : C ⥤ FintypeCat) [FiberFunctor F]` and
+`[GaloisCategory C]` is that the former fixes one fiber functor `F`.
 -/
 
 /-- Definition of a (Pre)Galois category. Lenstra, Def 3.1, (G1)-(G3) -/
@@ -72,8 +72,8 @@ class PreGaloisCategory (C : Type u₁) [Category.{u₂, u₁} C] : Prop where
 
 namespace PreGaloisCategory
 
-/-- Definition of a fibre functor from a Galois category. Lenstra, Def 3.1, (G4)-(G6) -/
-class FibreFunctor {C : Type u₁} [Category.{u₂, u₁} C] [PreGaloisCategory C]
+/-- Definition of a fiber functor from a Galois category. Lenstra, Def 3.1, (G4)-(G6) -/
+class FiberFunctor {C : Type u₁} [Category.{u₂, u₁} C] [PreGaloisCategory C]
     (F : C ⥤ FintypeCat.{w}) where
   /-- `F` preserves terminal objects (G4). -/
   preservesTerminalObjects : PreservesLimitsOfShape (CategoryTheory.Discrete PEmpty.{1}) F :=
@@ -115,10 +115,10 @@ instance : HasBinaryProducts C := hasBinaryProducts_of_hasTerminal_and_pullbacks
 
 instance : HasEqualizers C := hasEqualizers_of_hasPullbacks_and_binary_products
 
-namespace FibreFunctor
+namespace FiberFunctor
 
 variable {C : Type u₁} [Category.{u₂, u₁} C] {F : C ⥤ FintypeCat.{w}} [PreGaloisCategory C]
-  [FibreFunctor F]
+  [FiberFunctor F]
 
 attribute [instance] preservesTerminalObjects preservesPullbacks preservesEpis
   preservesFiniteCoproducts reflectsIsos preservesQuotientsByFiniteGroups
@@ -132,7 +132,7 @@ noncomputable instance : ReflectsColimitsOfShape (Discrete PEmpty.{1}) F :=
 noncomputable instance : PreservesFiniteLimits F :=
   preservesFiniteLimitsOfPreservesTerminalAndPullbacks F
 
-/-- Fibre functors reflect monomorphisms. -/
+/-- Fiber functors reflect monomorphisms. -/
 instance : ReflectsMonomorphisms F := ReflectsMonomorphisms.mk <| by
   intro X Y f _
   haveI : IsIso (pullback.fst : pullback (F.map f) (F.map f) ⟶ F.obj X) :=
@@ -143,7 +143,7 @@ instance : ReflectsMonomorphisms F := ReflectsMonomorphisms.mk <| by
   haveI : IsIso (pullback.fst : pullback f f ⟶ X) := isIso_of_reflects_iso pullback.fst F
   exact (pullback.diagonal_isKernelPair f).mono_of_isIso_fst
 
-/-- Fibre functors are faithful. -/
+/-- Fiber functors are faithful. -/
 instance : Faithful F where
   map_injective {X Y} f g h := by
     haveI : IsIso (equalizer.ι (F.map f) (F.map g)) := equalizer.ι_of_eq h
@@ -153,12 +153,12 @@ instance : Faithful F where
     haveI : IsIso (equalizer.ι f g) := isIso_of_reflects_iso _ F
     exact eq_of_epi_equalizer
 
-end FibreFunctor
+end FiberFunctor
 
-variable (F : C ⥤ FintypeCat.{w}) [FibreFunctor F]
+variable (F : C ⥤ FintypeCat.{w}) [FiberFunctor F]
 
 /-- An object is initial if and only if its fiber is empty. -/
-lemma initial_iff_fibre_empty (X : C) : Nonempty (IsInitial X) ↔ IsEmpty (F.obj X) := by
+lemma initial_iff_fiber_empty (X : C) : Nonempty (IsInitial X) ↔ IsEmpty (F.obj X) := by
   rw [(IsInitial.isInitialIffObj F X).nonempty_congr]
   haveI : PreservesFiniteColimits (forget FintypeCat) := by
     show PreservesFiniteColimits FintypeCat.incl
@@ -171,22 +171,22 @@ lemma initial_iff_fibre_empty (X : C) : Nonempty (IsInitial X) ↔ IsEmpty (F.ob
 /-- An object is not initial if and only if its fiber is nonempty. -/
 lemma not_initial_iff_fiber_nonempty (X : C) : (IsInitial X → False) ↔ Nonempty (F.obj X) := by
   rw [← not_isEmpty_iff]
-  refine ⟨fun h he ↦ ?_, fun h hin ↦ h <| (initial_iff_fibre_empty F X).mp ⟨hin⟩⟩
-  exact Nonempty.elim ((initial_iff_fibre_empty F X).mpr he) h
+  refine ⟨fun h he ↦ ?_, fun h hin ↦ h <| (initial_iff_fiber_empty F X).mp ⟨hin⟩⟩
+  exact Nonempty.elim ((initial_iff_fiber_empty F X).mpr he) h
 
-/-- An object whose fibre is inhabited is not initial. -/
+/-- An object whose fiber is inhabited is not initial. -/
 lemma not_initial_of_inhabited {X : C} (x : F.obj X) (h : IsInitial X) : False :=
-  ((initial_iff_fibre_empty F X).mp ⟨h⟩).false x
+  ((initial_iff_fiber_empty F X).mp ⟨h⟩).false x
 
-/-- The fibre of a connected object is nonempty. -/
-instance nonempty_fibre_of_connected (X : C) [ConnectedObject X] : Nonempty (F.obj X) := by
+/-- The fiber of a connected object is nonempty. -/
+instance nonempty_fiber_of_connected (X : C) [ConnectedObject X] : Nonempty (F.obj X) := by
   by_contra h
-  have ⟨hin⟩ : Nonempty (IsInitial X) := (initial_iff_fibre_empty F X).mpr (not_nonempty_iff.mp h)
+  have ⟨hin⟩ : Nonempty (IsInitial X) := (initial_iff_fiber_empty F X).mpr (not_nonempty_iff.mp h)
   exact ConnectedObject.notInitial hin
 
-/-- The fibre of the equalizer of `f g : X ⟶ Y` is equivalent to the set of agreement of `f`
+/-- The fiber of the equalizer of `f g : X ⟶ Y` is equivalent to the set of agreement of `f`
 and `g`. -/
-private noncomputable def fibreEqualizerEquiv {X Y : C} (f g : X ⟶ Y) :
+private noncomputable def fiberEqualizerEquiv {X Y : C} (f g : X ⟶ Y) :
     F.obj (equalizer f g) ≃ { x : F.obj X // F.map f x = F.map g x } := by
   apply Iso.toEquiv
   trans
@@ -199,7 +199,7 @@ lemma evaluationInjective_of_connected (A X : C) [ConnectedObject A] (a : F.obj 
   intro f g (h : F.map f a = F.map g a)
   haveI : IsIso (equalizer.ι f g) := by
     apply ConnectedObject.noTrivialComponent _ (equalizer.ι f g)
-    exact not_initial_of_inhabited F ((fibreEqualizerEquiv F f g).symm ⟨a, h⟩)
+    exact not_initial_of_inhabited F ((fiberEqualizerEquiv F f g).symm ⟨a, h⟩)
   exact eq_of_epi_equalizer
 
 /-- The evaluation map on automorphisms is injective for connected objects. -/
@@ -212,10 +212,10 @@ lemma evaluation_aut_injective_of_connected (A : C) [ConnectedObject A] (a : F.o
 
 end PreGaloisCategory
 
-/-- A `PreGaloisCategory` is a `GaloisCategory` if it admits a fibre functor. -/
+/-- A `PreGaloisCategory` is a `GaloisCategory` if it admits a fiber functor. -/
 class GaloisCategory (C : Type u₁) [Category.{u₂, u₁} C]
     extends PreGaloisCategory C : Prop where
-  hasFibreFunctor : ∃ F : C ⥤ FintypeCat.{u₂}, Nonempty (PreGaloisCategory.FibreFunctor F)
+  hasFiberFunctor : ∃ F : C ⥤ FintypeCat.{u₂}, Nonempty (PreGaloisCategory.FiberFunctor F)
 
 namespace PreGaloisCategory
 
@@ -223,15 +223,15 @@ variable {C : Type u₁} [Category.{u₂, u₁} C] [GaloisCategory C]
 
 /-- In a `GaloisCategory` the set of morphisms out of a connected object is finite. -/
 instance (A X : C) [ConnectedObject A] : Finite (A ⟶ X) := by
-  obtain ⟨F, ⟨hF⟩⟩ := @GaloisCategory.hasFibreFunctor C _ _
-  obtain ⟨a⟩ := nonempty_fibre_of_connected F A
+  obtain ⟨F, ⟨hF⟩⟩ := @GaloisCategory.hasFiberFunctor C _ _
+  obtain ⟨a⟩ := nonempty_fiber_of_connected F A
   apply Finite.of_injective (fun f ↦ F.map f a)
   exact evaluationInjective_of_connected F A X a
 
 /-- In a `GaloisCategory` the set of automorphism of a connected object is finite. -/
 instance (A : C) [ConnectedObject A] : Finite (Aut A) := by
-  obtain ⟨F, ⟨hF⟩⟩ := @GaloisCategory.hasFibreFunctor C _ _
-  obtain ⟨a⟩ := nonempty_fibre_of_connected F A
+  obtain ⟨F, ⟨hF⟩⟩ := @GaloisCategory.hasFiberFunctor C _ _
+  obtain ⟨a⟩ := nonempty_fiber_of_connected F A
   apply Finite.of_injective (fun f ↦ F.map f.hom a)
   exact evaluation_aut_injective_of_connected F A a
 

--- a/Mathlib/CategoryTheory/Galois/Examples.lean
+++ b/Mathlib/CategoryTheory/Galois/Examples.lean
@@ -12,10 +12,10 @@ import Mathlib.CategoryTheory.Limits.Shapes.Types
 import Mathlib.Logic.Equiv.TransferInstance
 
 /-!
-# Examples of Galois categories and fibre functors
+# Examples of Galois categories and fiber functors
 
 We show that for a group `G` the category of finite `G`-sets is a `PreGaloisCategory` and that the
-forgetful functor to `FintypeCat` is a `FibreFunctor`.
+forgetful functor to `FintypeCat` is a `FiberFunctor`.
 
 The connected finite `G`-sets are precisely the ones with transitive `G`-action.
 
@@ -90,15 +90,15 @@ instance : PreGaloisCategory (Action FintypeCat (MonCat.of G)) where
       (isColimitMapCoconeBinaryCofanEquiv (forget _) i _).symm
       (Types.isCoprodOfMono ((forget _).map i))⟩⟩
 
-/-- The forgetful functor from finite `G`-sets to sets is a `FibreFunctor`. -/
-noncomputable instance : FibreFunctor (Action.forget FintypeCat (MonCat.of G)) where
+/-- The forgetful functor from finite `G`-sets to sets is a `FiberFunctor`. -/
+noncomputable instance : FiberFunctor (Action.forget FintypeCat (MonCat.of G)) where
   preservesFiniteCoproducts := ⟨fun _ _ ↦ inferInstance⟩
   preservesQuotientsByFiniteGroups _ _ _ := inferInstance
   reflectsIsos := ⟨fun f (h : IsIso f.hom) => inferInstance⟩
 
 /-- The category of finite `G`-sets is a `GaloisCategory`. -/
 instance : GaloisCategory (Action FintypeCat (MonCat.of G)) where
-  hasFibreFunctor := ⟨Action.forget FintypeCat (MonCat.of G), ⟨inferInstance⟩⟩
+  hasFiberFunctor := ⟨Action.forget FintypeCat (MonCat.of G), ⟨inferInstance⟩⟩
 
 /-- The `G`-action on a connected finite `G`-set is transitive. -/
 theorem Action.pretransitive_of_connected (X : Action FintypeCat (MonCat.of G))

--- a/Mathlib/CategoryTheory/Galois/Examples.lean
+++ b/Mathlib/CategoryTheory/Galois/Examples.lean
@@ -101,8 +101,8 @@ instance : GaloisCategory (Action FintypeCat (MonCat.of G)) where
   hasFiberFunctor := ⟨Action.forget FintypeCat (MonCat.of G), ⟨inferInstance⟩⟩
 
 /-- The `G`-action on a connected finite `G`-set is transitive. -/
-theorem Action.pretransitive_of_connected (X : Action FintypeCat (MonCat.of G))
-    [ConnectedObject X] : MulAction.IsPretransitive G X.V where
+theorem Action.pretransitive_of_isConnected (X : Action FintypeCat (MonCat.of G))
+    [IsConnected X] : MulAction.IsPretransitive G X.V where
   exists_smul_eq x y := by
     /- We show that the `G`-orbit of `x` is a non-initial subobject of `X` and hence by
     connectedness, the orbit equals `X.V`. -/
@@ -113,7 +113,7 @@ theorem Action.pretransitive_of_connected (X : Action FintypeCat (MonCat.of G))
     let i : T' ⟶ X := ⟨Subtype.val, fun _ ↦ rfl⟩
     have : Mono i := ConcreteCategory.mono_of_injective _ (Subtype.val_injective)
     have : IsIso i := by
-      apply ConnectedObject.noTrivialComponent T' i
+      apply IsConnected.noTrivialComponent T' i
       apply (not_initial_iff_fiber_nonempty (Action.forget _ _) T').mpr
       exact Set.Nonempty.coe_sort (MulAction.orbit_nonempty x)
     have hb : Function.Bijective i.hom := by
@@ -124,9 +124,9 @@ theorem Action.pretransitive_of_connected (X : Action FintypeCat (MonCat.of G))
     exact hg.trans hy'
 
 /-- A nonempty `G`-set with transitive `G`-action is connected. -/
-theorem Action.connected_of_transitive (X : FintypeCat) [MulAction G X]
+theorem Action.isConnected_of_transitive (X : FintypeCat) [MulAction G X]
     [MulAction.IsPretransitive G X] [h : Nonempty X] :
-    ConnectedObject (Action.FintypeCat.ofMulAction G X) where
+    IsConnected (Action.FintypeCat.ofMulAction G X) where
   notInitial := not_initial_of_inhabited (Action.forget _ _) h.some
   noTrivialComponent Y i hm hni := by
     /- We show that the induced inclusion `i.hom` of finite sets is surjective, using the
@@ -145,9 +145,9 @@ theorem Action.connected_of_transitive (X : FintypeCat) [MulAction G X]
     apply isIso_of_reflects_iso i (Action.forget _ _)
 
 /-- A nonempty finite `G`-set is connected if and only if the `G`-action is transitive. -/
-theorem Action.connected_iff_transitive (X : Action FintypeCat (MonCat.of G)) [Nonempty X.V] :
-    ConnectedObject X ↔ MulAction.IsPretransitive G X.V :=
-  ⟨fun _ ↦ pretransitive_of_connected G X, fun _ ↦ connected_of_transitive G X.V⟩
+theorem Action.isConnected_iff_transitive (X : Action FintypeCat (MonCat.of G)) [Nonempty X.V] :
+    IsConnected X ↔ MulAction.IsPretransitive G X.V :=
+  ⟨fun _ ↦ pretransitive_of_isConnected G X, fun _ ↦ isConnected_of_transitive G X.V⟩
 
 end FintypeCat
 

--- a/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
+++ b/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
@@ -12,7 +12,7 @@ import Mathlib.Logic.Equiv.TransferInstance
 /-!
 # Galois objects in Galois categories
 
-We define when a connected object of a Galois category `C` is Galois in a fibre functor independent
+We define when a connected object of a Galois category `C` is Galois in a fiber functor independent
 way and show equivalent characterisations.
 
 ## Main definitions
@@ -22,7 +22,7 @@ way and show equivalent characterisations.
 ## Main results
 
 * `galois_iff_pretransitive` : A connected object `X` is Galois if and only if `Aut X`
-                               acts transitively on `F.obj X` for a fibre functor `F`.
+                               acts transitively on `F.obj X` for a fiber functor `F`.
 
 -/
 universe u₁ u₂ v₁ v₂ v w
@@ -46,7 +46,7 @@ class IsGalois {C : Type u₁} [Category.{u₂, u₁} C] [GaloisCategory C] (X :
 variable {C : Type u₁} [Category.{u₂, u₁} C]
 
 /-- The natural action of `Aut X` on `F.obj X`. -/
-instance autMulFibre (F : C ⥤ FintypeCat.{w}) (X : C) : MulAction (Aut X) (F.obj X) where
+instance autMulFiber (F : C ⥤ FintypeCat.{w}) (X : C) : MulAction (Aut X) (F.obj X) where
   smul σ a := F.map σ.hom a
   one_smul a := by
     show F.map (𝟙 X) a = a
@@ -55,7 +55,7 @@ instance autMulFibre (F : C ⥤ FintypeCat.{w}) (X : C) : MulAction (Aut X) (F.o
     show F.map (h.hom ≫ g.hom) a = (F.map h.hom ≫ F.map g.hom) a
     simp only [map_comp, FintypeCat.comp_apply]
 
-variable [GaloisCategory C] (F : C ⥤ FintypeCat.{w}) [FibreFunctor F]
+variable [GaloisCategory C] (F : C ⥤ FintypeCat.{w}) [FiberFunctor F]
 
 /-- For a connected object `X` of `C`, the quotient `X / Aut X` is terminal if and only if
 the quotient `F.obj X / Aut X` has exactly one element. -/
@@ -76,7 +76,7 @@ lemma isGalois_iff_aux (X : C) [ConnectedObject X] :
     IsGalois X ↔ Nonempty (IsTerminal <| colimit <| SingleObj.functor <| Aut.toEnd X) :=
   ⟨fun h ↦ h.quotientByAutTerminal, fun h ↦ ⟨h⟩⟩
 
-/-- Given a fibre functor `F` and a connected object `X` of `C`. Then `X` is Galois if and only if
+/-- Given a fiber functor `F` and a connected object `X` of `C`. Then `X` is Galois if and only if
 the natural action of `Aut X` on `F.obj X` is transitive. -/
 theorem isGalois_iff_pretransitive (X : C) [ConnectedObject X] :
     IsGalois X ↔ MulAction.IsPretransitive (Aut X) (F.obj X) := by
@@ -89,7 +89,7 @@ noncomputable def isTerminalQuotientOfIsGalois (X : C) [IsGalois X] :
   Nonempty.some IsGalois.quotientByAutTerminal
 
 /-- If `X` is Galois, then the action of `Aut X` on `F.obj X` is
-transitive for every fibre functor `F`. -/
+transitive for every fiber functor `F`. -/
 instance isPretransitive_of_isGalois (X : C) [IsGalois X] :
     MulAction.IsPretransitive (Aut X) (F.obj X) := by
   rw [← isGalois_iff_pretransitive]

--- a/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
+++ b/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
@@ -40,7 +40,7 @@ noncomputable instance {G : Type v} [Group G] [Finite G] :
 
 /-- A connected object `X` of `C` is Galois if the quotient `X / Aut X` is terminal. -/
 class IsGalois {C : Type u₁} [Category.{u₂, u₁} C] [GaloisCategory C] (X : C)
-    extends ConnectedObject X : Prop where
+    extends IsConnected X : Prop where
   quotientByAutTerminal : Nonempty (IsTerminal <| colimit <| SingleObj.functor <| Aut.toEnd X)
 
 variable {C : Type u₁} [Category.{u₂, u₁} C]
@@ -60,7 +60,7 @@ variable [GaloisCategory C] (F : C ⥤ FintypeCat.{w}) [FiberFunctor F]
 /-- For a connected object `X` of `C`, the quotient `X / Aut X` is terminal if and only if
 the quotient `F.obj X / Aut X` has exactly one element. -/
 noncomputable def quotientByAutTerminalEquivUniqueQuotient
-    (X : C) [ConnectedObject X] :
+    (X : C) [IsConnected X] :
     IsTerminal (colimit <| SingleObj.functor <| Aut.toEnd X) ≃
     Unique (MulAction.orbitRel.Quotient (Aut X) (F.obj X)) := by
   let J : SingleObj (Aut X) ⥤ C := SingleObj.functor (Aut.toEnd X)
@@ -72,13 +72,13 @@ noncomputable def quotientByAutTerminalEquivUniqueQuotient
     (isLimitEmptyConeEquiv _ (asEmptyCone _) (asEmptyCone _) e)
   exact Types.isTerminalEquivUnique _
 
-lemma isGalois_iff_aux (X : C) [ConnectedObject X] :
+lemma isGalois_iff_aux (X : C) [IsConnected X] :
     IsGalois X ↔ Nonempty (IsTerminal <| colimit <| SingleObj.functor <| Aut.toEnd X) :=
   ⟨fun h ↦ h.quotientByAutTerminal, fun h ↦ ⟨h⟩⟩
 
 /-- Given a fiber functor `F` and a connected object `X` of `C`. Then `X` is Galois if and only if
 the natural action of `Aut X` on `F.obj X` is transitive. -/
-theorem isGalois_iff_pretransitive (X : C) [ConnectedObject X] :
+theorem isGalois_iff_pretransitive (X : C) [IsConnected X] :
     IsGalois X ↔ MulAction.IsPretransitive (Aut X) (F.obj X) := by
   rw [isGalois_iff_aux, Equiv.nonempty_congr <| quotientByAutTerminalEquivUniqueQuotient F X]
   exact (MulAction.pretransitive_iff_unique_quotient_of_nonempty (Aut X) (F.obj X)).symm


### PR DESCRIPTION
Changes the spelling of `FibreFunctor` to `FiberFunctor` to match the US spelling and adapts other names accordingly. Renames `ConnectedObject` to `IsConnected` to match `IsGalois`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
