### PR TITLE
feat(Tactic/ComputeDegree): add `polynomial` tactic

### DIFF
--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -132,6 +132,13 @@ theorem degree_smul_le_of_le {n : ℕ} {a : R} {f : R[X]} (hf : degree f ≤ n) 
 
 theorem coeff_smul {n : ℕ} {a : R} {f : R[X]} : (a • f).coeff n = a * f.coeff n := rfl
 
+lemma _root_.Polynomial.leadingCoeff_eq_of_natDegree_le_of_coeff_eq {R} [Semiring R]
+    {n : Nat} {r : R} {f : R[X]} (dn : f.natDegree ≤ n) (cn : f.coeff n = r) (r0 : r ≠ 0) :
+    f.leadingCoeff = r := by
+  subst cn
+  unfold leadingCoeff
+  rw [natDegree_eq_of_le_of_coeff_ne_zero dn r0]
+
 section congr_lemmas
 
 /--  The following two lemmas should be viewed as a hand-made "congr"-lemmas.
@@ -495,6 +502,18 @@ macro (name := monicityMacro) "monicity" : tactic =>
 @[inherit_doc monicityMacro]
 macro "monicity!" : tactic =>
   `(tactic| (apply monic_of_natDegree_le_of_coeff_eq_one <;> compute_degree!))
+
+elab "polynomial" : tactic => do
+  match (← getMainTarget).getAppFnArgs with
+  | (``Eq, #[_, lhs, _rhs]) =>
+    match lhs.getAppFn.constName with
+    | ``leadingCoeff => evalTactic (← `(tactic|
+      (apply leadingCoeff_eq_of_natDegree_le_of_coeff_eq <;> try compute_degree)))
+    | _ => evalTactic (← `(tactic| compute_degree))
+  | (``Monic, _) => evalTactic (← `(tactic| monicity))
+  | _ => evalTactic (← `(tactic| compute_degree))
+
+elab "polynomial!" : tactic => do evalTactic (← `(tactic| polynomial <;> norm_num))
 
 end Tactic
 

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -503,7 +503,11 @@ macro (name := monicityMacro) "monicity" : tactic =>
 macro "monicity!" : tactic =>
   `(tactic| (apply monic_of_natDegree_le_of_coeff_eq_one <;> compute_degree!))
 
-elab "polynomial" : tactic => do
+/-- The `polynomial` tactic (and its more aggressive version `polynomial!`) tries to solve goals of
+the form `natDegree f = d`, `natDegree f ≤ d`, `degree f = d`, `degree f ≤ d`,
+`leadingCoeff f = r`, `Monic f`
+in the case where `f` is an *explicit* polynomial. -/
+elab (name := polynomialTac) "polynomial" : tactic => do
   match (← getMainTarget).getAppFnArgs with
   | (``Eq, #[_, lhs, _rhs]) =>
     match lhs.getAppFn.constName with
@@ -513,6 +517,7 @@ elab "polynomial" : tactic => do
   | (``Monic, _) => evalTactic (← `(tactic| monicity))
   | _ => evalTactic (← `(tactic| compute_degree))
 
+@[inherit_doc polynomialTac]
 elab "polynomial!" : tactic => do evalTactic (← `(tactic| polynomial <;> norm_num))
 
 end Tactic


### PR DESCRIPTION
Introducing the `polynomial` tactic, summing up `compute_degree, monicity` and adding support for `leadingCoeff`.

This is more of a proof of concept: if there is interest in this tactic, I can polish it up.

See [this Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Compute.20roots.20of.20polynomials/near/420713624).

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
