### PR TITLE
Feat: Heterogeneous functions + ternary currying for functors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2595,6 +2595,7 @@ import Mathlib.Logic.Function.Basic
 import Mathlib.Logic.Function.Conjugate
 import Mathlib.Logic.Function.Iterate
 import Mathlib.Logic.Function.OfArity
+import Mathlib.Logic.Function.OfHArity
 import Mathlib.Logic.Hydra
 import Mathlib.Logic.IsEmpty
 import Mathlib.Logic.Lemmas

--- a/Mathlib/CategoryTheory/Functor/Currying.lean
+++ b/Mathlib/CategoryTheory/Functor/Currying.lean
@@ -25,22 +25,28 @@ universe v₁ v₂ v₃ v₄ v₅ u₁ u₂ u₃ u₄ u₅
 variable {B : Type u₁} [Category.{v₁} B] {C : Type u₂} [Category.{v₂} C] {D : Type u₃}
   [Category.{v₃} D] {E : Type u₄} [Category.{v₄} E] {H : Type u₅} [Category.{v₅} H]
 
+/-- The action on objects of a bifunctor. -/
 def Functor.obj₂ (F : B ⥤ C ⥤ D) (X : B) (Y : C) : D :=
   (F.obj X).obj Y
 
+/-- The action on objects of a trifunctor. -/
 def Functor.obj₃ (F : B ⥤ C ⥤ D ⥤ E) (X : B) (Y : C) (Z : D) : E :=
   ((F.obj X).obj Y).obj Z
 
+/-- The component of a morphism of bifunctors at two objects. -/
 def NatTrans.app₂ {F G : B ⥤ C ⥤ D} (α : NatTrans F G) (X : B) (Y : C) :
     F.obj₂ X Y ⟶ G.obj₂ X Y := (α.app X).app Y
 
+/-- The component of a morphism of trifunctors at three objects. -/
 def NatTrans.app₃ {F G : B ⥤ C ⥤ D ⥤ E} (α : NatTrans F G) (X : B) (Y : C) (Z : D) :
     F.obj₃ X Y Z ⟶ G.obj₃ X Y Z := ((α.app X).app Y).app Z
 
+/-- The action on morphisms of a bifunctor. -/
 def Functor.map₂ (F : B ⥤ C ⥤ D) {X X' : B} {Y Y' : C} (f : X ⟶ X') (g : Y ⟶ Y') :
     F.obj₂ X Y ⟶ F.obj₂ X' Y' :=
   (F.map f).app Y ≫ (F.obj X').map g
 
+/-- The action on morphisms of a trifunctor. -/
 def Functor.map₃ (F : B ⥤ C ⥤ D ⥤ E) {X X' : B} {Y Y' : C} {Z Z' : D}
     (f : X ⟶ X') (g : Y ⟶ Y') (h : Z ⟶ Z') :
     F.obj₃ X Y Z ⟶ F.obj₃ X' Y' Z' :=

--- a/Mathlib/CategoryTheory/Functor/Currying.lean
+++ b/Mathlib/CategoryTheory/Functor/Currying.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import Mathlib.CategoryTheory.Products.Associator
-import Mathlib.Data.Fin.Tuple.Curry
 
 #align_import category_theory.functor.currying from "leanprover-community/mathlib"@"369525b73f229ccd76a6ec0e0e0bf2be57599768"
 
@@ -29,28 +28,14 @@ variable {B : Type u₁} [Category.{v₁} B] {C : Type u₂} [Category.{v₂} C]
 def Functor.obj₂ (F : B ⥤ C ⥤ D) (X : B) (Y : C) : D :=
   (F.obj X).obj Y
 
-/-- The action on objects of a trifunctor. -/
-def Functor.obj₃ (F : B ⥤ C ⥤ D ⥤ E) (X : B) (Y : C) (Z : D) : E :=
-  ((F.obj X).obj Y).obj Z
-
 /-- The component of a morphism of bifunctors at two objects. -/
 def NatTrans.app₂ {F G : B ⥤ C ⥤ D} (α : NatTrans F G) (X : B) (Y : C) :
     F.obj₂ X Y ⟶ G.obj₂ X Y := (α.app X).app Y
-
-/-- The component of a morphism of trifunctors at three objects. -/
-def NatTrans.app₃ {F G : B ⥤ C ⥤ D ⥤ E} (α : NatTrans F G) (X : B) (Y : C) (Z : D) :
-    F.obj₃ X Y Z ⟶ G.obj₃ X Y Z := ((α.app X).app Y).app Z
 
 /-- The action on morphisms of a bifunctor. -/
 def Functor.map₂ (F : B ⥤ C ⥤ D) {X X' : B} {Y Y' : C} (f : X ⟶ X') (g : Y ⟶ Y') :
     F.obj₂ X Y ⟶ F.obj₂ X' Y' :=
   (F.map f).app Y ≫ (F.obj X').map g
-
-/-- The action on morphisms of a trifunctor. -/
-def Functor.map₃ (F : B ⥤ C ⥤ D ⥤ E) {X X' : B} {Y Y' : C} {Z Z' : D}
-    (f : X ⟶ X') (g : Y ⟶ Y') (h : Z ⟶ Z') :
-    F.obj₃ X Y Z ⟶ F.obj₃ X' Y' Z' :=
-  (F.map f).app₂ Y Z ≫ (F.obj X').map₂ g h
 
 /-- The uncurrying functor, taking a functor `C ⥤ (D ⥤ E)` and producing a functor `(C × D) ⥤ E`.
 -/
@@ -149,44 +134,6 @@ swapping the factors followed by the uncurrying of `F`. -/
 def uncurryObjFlip (F : C ⥤ D ⥤ E) : uncurry.obj F.flip ≅ Prod.swap _ _ ⋙ uncurry.obj F :=
   NatIso.ofComponents fun p => Iso.refl _
 #align category_theory.uncurry_obj_flip CategoryTheory.uncurryObjFlip
-
--- create projection simp lemmas even though this isn't a `{ .. }`.
-/-- The equivalence of trifunctor categories given by currying/uncurrying. -/
-@[simps!]
-def currying₃ : B ⥤ C ⥤ D ⥤ E ≌ B × C × D ⥤ E :=
-  .trans (@currying B _ C _ (D ⥤ E) _)
-  $ .trans (@currying (B × C) _ D _ E _)
-  $ (prod.associativity B C D).congrLeft (E := E)
--- why is this so slow???
-
-/-- The ternary uncurrying functor, taking a functor `B ⥤ (C ⥤ (D ⥤ E))` and
-producing a functor `(B × C × D) ⥤ E`.-/
-@[simps!] def uncurry₃ : (B ⥤ C ⥤ D ⥤ E) ⥤ B × C × D ⥤ E := currying₃.functor
-
-/-- The ternary currying functor, taking a functor `(B × C × D) ⥤ E` and
-producing a functor `B ⥤ (C ⥤ (D ⥤ E))`.
--/
-@[simps!] def curry₃ : (B × C × D ⥤ E) ⥤ B ⥤ C ⥤ D ⥤ E := currying₃.inverse
-
-lemma uncurry₃_obj_obj_eq_uncurry₃_obj₃ (F : B ⥤ C ⥤ D ⥤ E) :
-    (uncurry₃.obj F).obj = F.obj₃.uncurry₃ := rfl
-
-lemma uncurry₃_obj_map_eq_uncurry₃_map₃ (F : B ⥤ C ⥤ D ⥤ E) {X Y : B × C × D} :
-    ((uncurry₃.obj F).map : (X ⟶ Y) → _) = F.map₃.uncurry₃ :=
-  funext $ fun _ => Category.assoc _ _ _
-
-lemma curry₃_obj_obj₃_eq_curry₃_obj (F : B × C × D ⥤ E) :
-    (curry₃.obj F).obj₃ = F.obj.curry₃ := rfl
-
-lemma curry₃_obj_map₃_eq_curry₃_map (F : B × C × D ⥤ E) {X X' Y Y' Z Z'} :
-    (curry₃.obj F).map₃
-    = (F.map (X := (X, Y, Z)) (Y := (X', Y', Z'))).curry₃ :=
-  funext₃ $ fun _ _ _ =>
-    Eq.trans (congrArg (_ ≫ .) (F.map_comp _ _).symm)
-    $ Eq.trans (F.map_comp _ _).symm $ congrArg _
-    $ congrArg₂ _ (Eq.trans (congrArg _ (Category.comp_id _)) (Category.comp_id _))
-    $ congrArg₂ _ (Eq.trans (Category.id_comp _) (Category.comp_id _))
-                  (Eq.trans (Category.id_comp _) (Category.id_comp _))
 
 variable (B C D E)
 

--- a/Mathlib/CategoryTheory/Functor/Currying.lean
+++ b/Mathlib/CategoryTheory/Functor/Currying.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.CategoryTheory.Products.Associator
+import Mathlib.CategoryTheory.Products.Basic
 
 #align_import category_theory.functor.currying from "leanprover-community/mathlib"@"369525b73f229ccd76a6ec0e0e0bf2be57599768"
 

--- a/Mathlib/CategoryTheory/Functor/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Trifunctor.lean
@@ -146,7 +146,6 @@ lemma curry₃_obj_map₃_apply_eq_curry₃_map_apply (F : C₁ × C₂ × C₃ 
     = (F.map (X := (X, Y, Z)) (Y := (X', Y', Z'))).curry₃ f g h :=
   congrFun₃ (curry₃_obj_map₃_eq_curry₃_map F X X' Y Y' Z Z') f g h
 
-@[simp]
 lemma Functor.map₃_id₂_id₃ (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄) {X X'} (f : X ⟶ X') (Y : C₂)
     (Z : C₃) : F.map₃ f (𝟙 Y) (𝟙 Z) = (F.map f).app₂ Y Z := by
   simp only [map₃, map₂, NatTrans.app₂, map_id, NatTrans.id_app]

--- a/Mathlib/CategoryTheory/Functor/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Trifunctor.lean
@@ -5,6 +5,7 @@ Authors: Joël Riou, Brendan Murphy
 -/
 import Mathlib.CategoryTheory.Functor.Currying
 import Mathlib.Data.Fin.Tuple.Curry
+import Mathlib.CategoryTheory.Products.Associator
 
 /-!
 # Trifunctors obtained by composition of bifunctors and currying

--- a/Mathlib/CategoryTheory/Functor/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Trifunctor.lean
@@ -1,11 +1,13 @@
 /-
 Copyright (c) 2023 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Joël Riou
+Authors: Joël Riou, Brendan Murphy
 -/
-import Mathlib.CategoryTheory.Functor.Category
+import Mathlib.CategoryTheory.Functor.Currying
+import Mathlib.Data.Fin.Tuple.Curry
+
 /-!
-# Trifunctors obtained by composition of bifunctors
+# Trifunctors obtained by composition of bifunctors and currying
 
 Given two bifunctors `F₁₂ : C₁ ⥤ C₂ ⥤ C₁₂` and `G : C₁₂ ⥤ C₃ ⥤ C₄`, we define
 the trifunctor `bifunctorComp₁₂ F₁₂ G : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄` which sends three
@@ -15,6 +17,7 @@ Similarly, given two bifunctors `F : C₁ ⥤ C₂₃ ⥤ C₄` and `G₂₃ : C
 the trifunctor `bifunctorComp₂₃ F G₂₃ : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄` which sends three
 objects `X₁ : C₁`, `X₂ : C₂` and `X₃ : C₃` to `(F.obj X₁).obj ((G₂₃.obj X₂).obj X₃)`.
 
+Finally we establish the ternary version of currying functors.
 -/
 
 namespace CategoryTheory
@@ -76,5 +79,59 @@ def bifunctorComp₂₃ : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ where
         { app := fun X₃ => (F.map φ).app ((G₂₃.obj X₂).obj X₃) } }
 
 end
+
+
+/-- The action on objects of a trifunctor. -/
+def Functor.obj₃ (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄) (X : C₁) (Y : C₂) (Z : C₃) : C₄ :=
+  ((F.obj X).obj Y).obj Z
+
+/-- The component of a morphism of trifunctors at three objects. -/
+def NatTrans.app₃ {F G : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄} (α : NatTrans F G)
+    (X : C₁) (Y : C₂) (Z : C₃) : F.obj₃ X Y Z ⟶ G.obj₃ X Y Z :=
+  ((α.app X).app Y).app Z
+
+/-- The action on morphisms of a trifunctor. -/
+def Functor.map₃ (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄) {X X' : C₁} {Y Y' : C₂} {Z Z' : C₃}
+    (f : X ⟶ X') (g : Y ⟶ Y') (h : Z ⟶ Z') :
+    F.obj₃ X Y Z ⟶ F.obj₃ X' Y' Z' :=
+  (F.map f).app₂ Y Z ≫ (F.obj X').map₂ g h
+
+-- create projection simp lemmas even though this isn't a `{ .. }`.
+/-- The equivalence of trifunctor categories given by currying/uncurrying. -/
+@[simps!]
+def currying₃ : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ ≌ C₁ × C₂ × C₃ ⥤ C₄ :=
+  .trans (@currying C₁ _ C₂ _ (C₃ ⥤ C₄) _)
+  $ .trans (@currying (C₁ × C₂) _ C₃ _ C₄ _)
+  $ (prod.associativity C₁ C₂ C₃).congrLeft (E := C₄)
+-- why is this so slow???
+
+/-- The ternary uncurrying functor, taking a functor `C₁ ⥤ (C₂ ⥤ (C₃ ⥤ C₄))` and
+producing a functor `(C₁ × C₂ × C₃) ⥤ C₄`.-/
+@[simps!] def uncurry₃ : (C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄) ⥤ C₁ × C₂ × C₃ ⥤ C₄ := currying₃.functor
+
+/-- The ternary currying functor, taking a functor `(C₁ × C₂ × C₃) ⥤ C₄` and
+producing a functor `C₁ ⥤ (C₂ ⥤ (C₃ ⥤ C₄))`.
+-/
+@[simps!] def curry₃ : (C₁ × C₂ × C₃ ⥤ C₄) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄ := currying₃.inverse
+
+lemma uncurry₃_obj_obj_eq_uncurry₃_obj₃ (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄) :
+    (uncurry₃.obj F).obj = F.obj₃.uncurry₃ := rfl
+
+lemma uncurry₃_obj_map_eq_uncurry₃_map₃ (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄) {X Y : C₁ × C₂ × C₃} :
+    ((uncurry₃.obj F).map : (X ⟶ Y) → _) = F.map₃.uncurry₃ :=
+  funext $ fun _ => Category.assoc _ _ _
+
+lemma curry₃_obj_obj₃_eq_curry₃_obj (F : C₁ × C₂ × C₃ ⥤ C₄) :
+    (curry₃.obj F).obj₃ = F.obj.curry₃ := rfl
+
+lemma curry₃_obj_map₃_eq_curry₃_map (F : C₁ × C₂ × C₃ ⥤ C₄) {X X' Y Y' Z Z'} :
+    (curry₃.obj F).map₃
+    = (F.map (X := (X, Y, Z)) (Y := (X', Y', Z'))).curry₃ :=
+  funext₃ $ fun _ _ _ =>
+    Eq.trans (congrArg (_ ≫ .) (F.map_comp _ _).symm)
+    $ Eq.trans (F.map_comp _ _).symm $ congrArg _
+    $ congrArg₂ _ (Eq.trans (congrArg _ (Category.comp_id _)) (Category.comp_id _))
+    $ congrArg₂ _ (Eq.trans (Category.id_comp _) (Category.comp_id _))
+                  (Eq.trans (Category.id_comp _) (Category.id_comp _))
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Functor/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Trifunctor.lean
@@ -117,14 +117,19 @@ producing a functor `C₁ ⥤ (C₂ ⥤ (C₃ ⥤ C₄))`.
 lemma uncurry₃_obj_obj_eq_uncurry₃_obj₃ (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄) :
     (uncurry₃.obj F).obj = F.obj₃.uncurry₃ := rfl
 
-lemma uncurry₃_obj_map_eq_uncurry₃_map₃ (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄) {X Y : C₁ × C₂ × C₃} :
+lemma uncurry₃_obj_map_eq_uncurry₃_map₃ (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄) (X Y : C₁ × C₂ × C₃) :
     ((uncurry₃.obj F).map : (X ⟶ Y) → _) = F.map₃.uncurry₃ :=
   funext $ fun _ => Category.assoc _ _ _
+
+lemma uncurry₃_obj_map_apply_eq_uncurry₃_map₃_apply (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄)
+    {X Y} (f : X ⟶ Y) :
+    (uncurry₃.obj F).map f = F.map₃.uncurry₃ f :=
+  congrFun (uncurry₃_obj_map_eq_uncurry₃_map₃ F X Y) f
 
 lemma curry₃_obj_obj₃_eq_curry₃_obj (F : C₁ × C₂ × C₃ ⥤ C₄) :
     (curry₃.obj F).obj₃ = F.obj.curry₃ := rfl
 
-lemma curry₃_obj_map₃_eq_curry₃_map (F : C₁ × C₂ × C₃ ⥤ C₄) {X X' Y Y' Z Z'} :
+lemma curry₃_obj_map₃_eq_curry₃_map (F : C₁ × C₂ × C₃ ⥤ C₄) (X X' Y Y' Z Z') :
     (curry₃.obj F).map₃
     = (F.map (X := (X, Y, Z)) (Y := (X', Y', Z'))).curry₃ :=
   funext₃ $ fun _ _ _ =>
@@ -133,5 +138,38 @@ lemma curry₃_obj_map₃_eq_curry₃_map (F : C₁ × C₂ × C₃ ⥤ C₄) {X
     $ congrArg₂ _ (Eq.trans (congrArg _ (Category.comp_id _)) (Category.comp_id _))
     $ congrArg₂ _ (Eq.trans (Category.id_comp _) (Category.comp_id _))
                   (Eq.trans (Category.id_comp _) (Category.id_comp _))
+
+lemma curry₃_obj_map₃_apply_eq_curry₃_map_apply (F : C₁ × C₂ × C₃ ⥤ C₄)
+    {X X' Y Y' Z Z'} (f : X ⟶ X') (g : Y ⟶ Y') (h : Z ⟶ Z') :
+    (curry₃.obj F).map₃ f g h
+    = (F.map (X := (X, Y, Z)) (Y := (X', Y', Z'))).curry₃ f g h :=
+  congrFun₃ (curry₃_obj_map₃_eq_curry₃_map F X X' Y Y' Z Z') f g h
+
+@[simp]
+lemma Functor.map₃_id₂_id₃ (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄) {X X'} (f : X ⟶ X') (Y : C₂)
+    (Z : C₃) : F.map₃ f (𝟙 Y) (𝟙 Z) = (F.map f).app₂ Y Z := by
+  simp only [map₃, map₂, NatTrans.app₂, map_id, NatTrans.id_app]
+  exact Eq.trans (congrArg _ (Category.comp_id _)) (Category.comp_id _)
+
+@[simp]
+lemma Functor.map₃_id₃ (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄) (X : C₁) (Y : C₂) (Z : C₃) :
+    F.map₃ (𝟙 X) (𝟙 Y) (𝟙 Z) = 𝟙 (F.obj₃ X Y Z) :=
+  Eq.trans (map₃_id₂_id₃ F _ Y Z) (congrArg (NatTrans.app₂ . Y Z) (F.map_id _))
+
+@[simp]
+lemma Functor.map₃_comp₃ (F : C₁ ⥤ C₂ ⥤ C₃ ⥤ C₄) {X X' X'' Y Y' Y'' Z Z' Z''}
+    (f : X ⟶ X')    (g : Y ⟶ Y')    (h : Z ⟶ Z')
+    (f' : X' ⟶ X'') (g' : Y' ⟶ Y'') (h' : Z' ⟶ Z'') :
+    F.map₃ (f ≫ f') (g ≫ g') (h ≫ h') =
+    F.map₃ f g h ≫ F.map₃ f' g' h' :=
+  let p  : (X,  Y,  Z)  ⟶ (X',  Y',  Z')  := (f,  g,  h)
+  let p' : (X', Y', Z') ⟶ (X'', Y'', Z'') := (f', g', h')
+  Eq.trans (uncurry₃_obj_map_apply_eq_uncurry₃_map₃_apply F (p ≫ p')).symm
+  $ Eq.trans (Functor.map_comp _ p p')
+  $ congrArg₂ _ (uncurry₃_obj_map_apply_eq_uncurry₃_map₃_apply F p)
+                (uncurry₃_obj_map_apply_eq_uncurry₃_map₃_apply F p')
+
+--TODO: Postcomposition, precomposition with ₁, ₂, ₃, and 1+2 = 3 or 2+1 = 3
+-- operadic composition
 
 end CategoryTheory

--- a/Mathlib/Data/Fin/Tuple/Curry.lean
+++ b/Mathlib/Data/Fin/Tuple/Curry.lean
@@ -29,10 +29,10 @@ universe u v w w'
 
 namespace Function
 
-@[inline] abbrev curry₂   := @Function.curry.{u, v, w}
-@[inline] abbrev uncurry₂ := @Function.uncurry.{u, v, w}
+/-- Currying for 3-ary functions. -/
 @[inline] def curry₃ {α : Type u} {β : Type v} {γ : Type w} {δ : Type w'} :
     (α × β × γ → δ) → α → β → γ → δ := fun f a b c => f (a, b, c)
+/-- Uncurrying for 3-ary functions. -/
 @[inline] def uncurry₃ {α : Type u} {β : Type v} {γ : Type w} {δ : Type w'} :
     (α → β → γ → δ) → (α × β × γ) → δ := fun f x => f x.1 x.2.1 x.2.2
 
@@ -84,11 +84,11 @@ def curryEquiv (n : ℕ) : ((Fin n → α) → β) ≃ OfArity α β n where
   left_inv := uncurry_curry
   right_inv := curry_uncurry
 
-lemma curry_2_eq_curry₂ {α β : Type u} (f : ((i : Fin 2) → α) → β) :
-    curry f = curry₂ (f ∘ (finTwoArrowEquiv α).symm) := rfl
+lemma curry_2_eq_curry {α β : Type u} (f : ((i : Fin 2) → α) → β) :
+    curry f = Function.curry (f ∘ (finTwoArrowEquiv α).symm) := rfl
 
 lemma uncurry_2_eq_uncurry₂ {α β : Type u} (f : OfArity α β 2) :
-    uncurry f = uncurry₂ f ∘ (finTwoArrowEquiv α) := rfl
+    uncurry f = Function.uncurry f ∘ (finTwoArrowEquiv α) := rfl
 
 lemma curry_3_eq_curry₃ {α β : Type u} (f : ((i : Fin 3) → α) → β) :
     curry f = curry₃ (f ∘ (finThreeArrowEquiv α).symm) := rfl
@@ -164,11 +164,11 @@ def curryEquiv (p : Fin n → Type u) : (((i : Fin n) → p i) → τ) ≃ OfHAr
 
 lemma curry_2_eq_curry₂ {p : Fin 2 → Type u} {τ : Type u}
     (f : ((i : Fin 2) → p i) → τ) :
-    curry f = curry₂ (f ∘ (piFinTwoEquiv p).symm) := rfl
+    curry f = Function.curry (f ∘ (piFinTwoEquiv p).symm) := rfl
 
 lemma uncurry_2_eq_uncurry₂ (p : Fin 2 → Type u) (τ : Type u)
     (f : Function.OfHArity p τ) :
-    uncurry f = uncurry₂ f ∘ piFinTwoEquiv p := rfl
+    uncurry f = Function.uncurry f ∘ piFinTwoEquiv p := rfl
 
 lemma curry_3_eq_curry₃ {p : Fin 3 → Type u} {τ : Type u}
     (f : ((i : Fin 3) → p i) → τ) :

--- a/Mathlib/Data/Fin/Tuple/Curry.lean
+++ b/Mathlib/Data/Fin/Tuple/Curry.lean
@@ -1,10 +1,11 @@
 /-
 Copyright (c) 2023 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Eric Wieser
+Authors: Eric Wieser, Brendan Murphy
 -/
 import Mathlib.Data.Fin.Tuple.Basic
-import Mathlib.Logic.Function.OfArity
+import Mathlib.Logic.Equiv.Fin
+import Mathlib.Logic.Function.OfHArity
 
 /-!
 # Currying and uncurrying of n-ary functions
@@ -17,24 +18,39 @@ n-ary generalizations of the binary `curry` and `uncurry`.
 
 * `Function.OfArity.uncurry`: convert an `n`-ary function to a function from `Fin n → α`.
 * `Function.OfArity.curry`: convert a function from `Fin n → α` to an `n`-ary function.
+* `Function.OfHArity.uncurry`: convert an `p`-ary heterogeneous function to a
+  function from `(i : Fin n) → p i`.
+* `Function.OfHArity.curry`: convert a function from `(i : Fin n) → p i` to a
+  `p`-ary heterogeneous function.
 
 -/
 
-universe u
+universe u v w w'
 
-variable {α β : Type u}
+namespace Function
+
+@[inline] abbrev curry₂   := @Function.curry.{u, v, w}
+@[inline] abbrev uncurry₂ := @Function.uncurry.{u, v, w}
+@[inline] def curry₃ {α : Type u} {β : Type v} {γ : Type w} {δ : Type w'} :
+    (α × β × γ → δ) → α → β → γ → δ := fun f a b c => f (a, b, c)
+@[inline] def uncurry₃ {α : Type u} {β : Type v} {γ : Type w} {δ : Type w'} :
+    (α → β → γ → δ) → (α × β × γ) → δ := fun f x => f x.1 x.2.1 x.2.2
+
+end Function
 
 namespace Function.OfArity
 
+variable {α β : Type u}
+
 /-- Uncurry all the arguments of `Function.OfArity α n` to get a function from a tuple.
 
-Note this can be used on raw functions if used-/
+Note this can be used on raw functions if used. -/
 def uncurry {n} (f : Function.OfArity α β n) : (Fin n → α) → β :=
   match n with
   | 0 => fun _ => f
   | _ + 1 => fun args => (f (args 0)).uncurry (args ∘ Fin.succ)
 
-/-- Uncurry all the arguments of `Function.OfArity α β n` to get a function from a tuple. -/
+/-- Curry all the arguments of `Function.OfArity α β n` to get a function from a tuple. -/
 def curry {n} (f : (Fin n → α) → β) : Function.OfArity α β n :=
   match n with
   | 0 => f Fin.elim0
@@ -68,4 +84,98 @@ def curryEquiv (n : ℕ) : ((Fin n → α) → β) ≃ OfArity α β n where
   left_inv := uncurry_curry
   right_inv := curry_uncurry
 
+lemma curry_2_eq_curry₂ {α β : Type u} (f : ((i : Fin 2) → α) → β) :
+    curry f = curry₂ (f ∘ (finTwoArrowEquiv α).symm) := rfl
+
+lemma uncurry_2_eq_uncurry₂ {α β : Type u} (f : OfArity α β 2) :
+    uncurry f = uncurry₂ f ∘ (finTwoArrowEquiv α) := rfl
+
+lemma curry_3_eq_curry₃ {α β : Type u} (f : ((i : Fin 3) → α) → β) :
+    curry f = curry₃ (f ∘ (finThreeArrowEquiv α).symm) := rfl
+
+lemma uncurry_3_eq_uncurry₃ {α β : Type u} (f : OfArity α β 3) :
+    uncurry f = uncurry₃ f ∘ (finThreeArrowEquiv α) := rfl
+
 end Function.OfArity
+
+namespace Function.OfHArity
+
+open Matrix (vecCons vecHead vecTail vecEmpty)
+
+/-- Uncurry all the arguments of `Function.OfHArity p τ` to get
+a function from a tuple.
+
+Note this can be used on raw functions if used. -/
+def uncurry : {n : ℕ} → {p : Fin n → Type u} → {τ : Type u} →
+    (f : Function.OfHArity p τ) → ((i : Fin n) → p i) → τ
+  | 0    , _, _, f => fun _    => f
+  | _ + 1, _, _, f => fun args => (f (args 0)).uncurry (args ∘' Fin.succ)
+
+/-- Curry all the arguments of `Function.OfHArity p τ` to get a function from a tuple. -/
+def curry : {n : ℕ} → {p : Fin n → Type u} → {τ : Type u} →
+    (((i : Fin n) → p i) → τ) → Function.OfHArity p τ
+  | 0    , _, _, f => f isEmptyElim
+  | _ + 1, _, _, f => fun a => curry (fun args => f (Fin.cons a args))
+
+@[simp]
+theorem uncurry_apply_cons {n : ℕ} {α} {p : Fin n → Type u} {τ : Type u}
+    (f : Function.OfHArity (vecCons α p) τ) (a : α) (args : (i : Fin n) → p i) :
+    uncurry f (Fin.cons a args) = @uncurry _ p _ (f a) args := rfl
+
+@[simp low]
+theorem uncurry_apply_succ {n : ℕ} {p : Fin (n + 1) → Type u} {τ : Type u}
+    (f : Function.OfHArity p τ) (args : (i : Fin (n + 1)) → p i) :
+    uncurry f args = uncurry (f (args 0)) (Fin.tail args) :=
+  @uncurry_apply_cons n (p 0) (vecTail p) τ f (args 0) (Fin.tail args)
+
+@[simp]
+theorem curry_apply_cons {n : ℕ} {α} {p : Fin n → Type u} {τ : Type u}
+    (f : ((i : Fin (n + 1)) → (vecCons α p) i) → τ) (a : α) :
+    curry f a = @curry _ p _ (f ∘' Fin.cons a) := rfl
+
+@[simp low]
+theorem curry_apply_succ {n : ℕ} {p : Fin (n + 1) → Type u} {τ : Type u}
+    (f : ((i : Fin (n + 1)) → p i) → τ) (a : p 0) :
+    curry f a = curry (f ∘ Fin.cons a) := rfl
+
+variable {n : ℕ} {p : Fin n → Type u} {τ : Type u}
+
+@[simp]
+theorem curry_uncurry (f : Function.OfHArity p τ) : curry (uncurry f) = f := by
+  induction n with
+  | zero => rfl
+  | succ n ih => exact funext (ih $ f .)
+
+@[simp]
+theorem uncurry_curry (f : ((i : Fin n) → p i) → τ) :
+    uncurry (curry f) = f := by
+  ext args
+  induction n with
+  | zero => exact congrArg f (Subsingleton.allEq _ _)
+  | succ n ih => exact Eq.trans (ih _ _) (congrArg f (Fin.cons_self_tail args))
+
+/-- `Equiv.curry` for `p`-ary heterogeneous functions. -/
+@[simps]
+def curryEquiv (p : Fin n → Type u) : (((i : Fin n) → p i) → τ) ≃ OfHArity p τ where
+  toFun := curry
+  invFun := uncurry
+  left_inv := uncurry_curry
+  right_inv := curry_uncurry
+
+lemma curry_2_eq_curry₂ {p : Fin 2 → Type u} {τ : Type u}
+    (f : ((i : Fin 2) → p i) → τ) :
+    curry f = curry₂ (f ∘ (piFinTwoEquiv p).symm) := rfl
+
+lemma uncurry_2_eq_uncurry₂ (p : Fin 2 → Type u) (τ : Type u)
+    (f : Function.OfHArity p τ) :
+    uncurry f = uncurry₂ f ∘ piFinTwoEquiv p := rfl
+
+lemma curry_3_eq_curry₃ {p : Fin 3 → Type u} {τ : Type u}
+    (f : ((i : Fin 3) → p i) → τ) :
+    curry f = curry₃ (f ∘ (piFinThreeEquiv p).symm) := rfl
+
+lemma uncurry_3_eq_uncurry₃ (p : Fin 3 → Type u) (τ : Type u)
+    (f : Function.OfHArity p τ) :
+    uncurry f = uncurry₃ f ∘ piFinThreeEquiv p := rfl
+
+end Function.OfHArity

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.Int.Order.Basic
 import Mathlib.Logic.Equiv.Defs
+import Mathlib.Tactic.FinCases
 
 #align_import logic.equiv.fin from "leanprover-community/mathlib"@"bd835ef554f37ef9b804f0903089211f89cb370b"
 
@@ -40,10 +41,10 @@ def finTwoEquiv : Fin 2 ≃ Bool where
   right_inv := Bool.forall_bool.2 <| by simp
 #align fin_two_equiv finTwoEquiv
 
-/-- `Π i : Fin 2, α i` is equivalent to `α 0 × α 1`. See also `finTwoArrowEquiv` for a
+/-- `(i : Fin 2) → α i` is equivalent to `α 0 × α 1`. See also `finTwoArrowEquiv` for a
 non-dependent version and `prodEquivPiFinTwo` for a version with inputs `α β : Type u`. -/
 @[simps (config := .asFn)]
-def piFinTwoEquiv (α : Fin 2 → Type u) : (∀ i, α i) ≃ α 0 × α 1
+def piFinTwoEquiv (α : Fin 2 → Type u) : ((i : Fin 2) → α i) ≃ α 0 × α 1
     where
   toFun f := (f 0, f 1)
   invFun p := Fin.cons p.1 <| Fin.cons p.2 finZeroElim
@@ -67,11 +68,11 @@ theorem Fin.preimage_apply_01_prod' {α : Type u} (s t : Set α) :
   @Fin.preimage_apply_01_prod (fun _ => α) s t
 #align fin.preimage_apply_01_prod' Fin.preimage_apply_01_prod'
 
-/-- A product space `α × β` is equivalent to the space `Π i : Fin 2, γ i`, where
+/-- A product space `α × β` is equivalent to the space `(i : Fin 2) → γ i`, where
 `γ = Fin.cons α (Fin.cons β finZeroElim)`. See also `piFinTwoEquiv` and
 `finTwoArrowEquiv`. -/
 @[simps! (config := .asFn)]
-def prodEquivPiFinTwo (α β : Type u) : α × β ≃ ∀ i : Fin 2, ![α, β] i :=
+def prodEquivPiFinTwo (α β : Type u) : α × β ≃ ((i : Fin 2) → ![α, β] i) :=
   (piFinTwoEquiv (Fin.cons α (Fin.cons β finZeroElim))).symm
 #align prod_equiv_pi_fin_two prodEquivPiFinTwo
 #align prod_equiv_pi_fin_two_apply prodEquivPiFinTwo_apply
@@ -86,10 +87,10 @@ def finTwoArrowEquiv (α : Type*) : (Fin 2 → α) ≃ α × α :=
 #align fin_two_arrow_equiv_symm_apply finTwoArrowEquiv_symm_apply
 #align fin_two_arrow_equiv_apply finTwoArrowEquiv_apply
 
-/-- `Π i : Fin 2, α i` is order equivalent to `α 0 × α 1`. See also `OrderIso.finTwoArrowEquiv`
+/-- `(i : Fin 2) → α i` is order equivalent to `α 0 × α 1`. See also `OrderIso.finTwoArrowEquiv`
 for a non-dependent version. -/
-def OrderIso.piFinTwoIso (α : Fin 2 → Type u) [∀ i, Preorder (α i)] : (∀ i, α i) ≃o α 0 × α 1
-    where
+def OrderIso.piFinTwoIso (α : Fin 2 → Type u) [∀ i, Preorder (α i)] :
+    ((i : Fin 2) → α i) ≃o α 0 × α 1 where
   toEquiv := piFinTwoEquiv α
   map_rel_iff' := Iff.symm Fin.forall_fin_two
 #align order_iso.pi_fin_two_iso OrderIso.piFinTwoIso
@@ -286,10 +287,11 @@ theorem finSuccEquivLast_symm_some (i : Fin n) :
   finSuccEquiv'_symm_none _
 #align fin_succ_equiv_last_symm_none finSuccEquivLast_symm_none
 
-/-- Equivalence between `Π j : Fin (n + 1), α j` and `α i × Π j : Fin n, α (Fin.succAbove i j)`. -/
+/-- Equivalence between `(j : Fin (n + 1)) → α j` and
+`α i × ((j : Fin n) → α (Fin.succAbove i j))`. -/
 @[simps (config := .asFn)]
 def Equiv.piFinSuccAbove (α : Fin (n + 1) → Type u) (i : Fin (n + 1)) :
-    (∀ j, α j) ≃ α i × ∀ j, α (i.succAbove j) where
+    ((j : Fin (n + 1)) → α j) ≃ α i × ((j : Fin n) → α (i.succAbove j)) where
   toFun f := (f i, fun j => f (i.succAbove j))
   invFun f := i.insertNth f.1 f.2
   left_inv f := by simp [Fin.insertNth_eq_iff]
@@ -298,14 +300,16 @@ def Equiv.piFinSuccAbove (α : Fin (n + 1) → Type u) (i : Fin (n + 1)) :
 #align equiv.pi_fin_succ_above_equiv_apply Equiv.piFinSuccAbove_apply
 #align equiv.pi_fin_succ_above_equiv_symm_apply Equiv.piFinSuccAbove_symm_apply
 
-/-- Order isomorphism between `Π j : Fin (n + 1), α j` and
-`α i × Π j : Fin n, α (Fin.succAbove i j)`. -/
+/-- Order isomorphism between `(j : Fin (n + 1)) → α j` and
+`α i × ((j : Fin n) → α (Fin.succAbove i j))`. -/
 def OrderIso.piFinSuccAboveIso (α : Fin (n + 1) → Type u) [∀ i, LE (α i)]
-    (i : Fin (n + 1)) : (∀ j, α j) ≃o α i × ∀ j, α (i.succAbove j) where
+    (i : Fin (n + 1)) : ((j : Fin (n + 1)) → α j) ≃o α i × ((j : Fin n) → α (i.succAbove j)) where
   toEquiv := Equiv.piFinSuccAbove α i
   map_rel_iff' := Iff.symm i.forall_iff_succAbove
 #align order_iso.pi_fin_succ_above_iso OrderIso.piFinSuccAboveIso
 
+-- it seems bad that this is inconsistent with the
+-- pi/arrow naming convention used by piFinTwo
 /-- Equivalence between `Fin (n + 1) → β` and `β × (Fin n → β)`. -/
 @[simps! (config := .asFn)]
 def Equiv.piFinSucc (n : ℕ) (β : Type u) : (Fin (n + 1) → β) ≃ β × (Fin n → β) :=
@@ -313,6 +317,35 @@ def Equiv.piFinSucc (n : ℕ) (β : Type u) : (Fin (n + 1) → β) ≃ β × (Fi
 #align equiv.pi_fin_succ Equiv.piFinSucc
 #align equiv.pi_fin_succ_apply Equiv.piFinSucc_apply
 #align equiv.pi_fin_succ_symm_apply Equiv.piFinSucc_symm_apply
+
+/-- `(i : Fin 3) → α i` is equivalent to `α 0 × α 1 × α 2`. See also `finThreeArrowEquiv` for a
+non-dependent version and `prodEquivPiFinThree` for a version with inputs `α β γ : Type u`. -/
+@[simps (config := .asFn)]
+def piFinThreeEquiv (α : Fin 3 → Type u) : ((i : Fin 3) → α i) ≃ α 0 × α 1 × α 2 where
+  toFun f := (f 0, f 1, f 2)
+  invFun p := Fin.cons p.1 <| Fin.cons p.2.1 <| Fin.cons p.2.2 finZeroElim
+  left_inv _ := by funext i; fin_cases i <;> rfl
+  right_inv := fun _ => rfl
+
+lemma piFinThreeEquiv_eq_piFinSuccAbove_trans_piFinTwoEquiv (α : Fin 3 → Type u) :
+    piFinThreeEquiv α
+    = .trans (.piFinSuccAbove α 0)
+             (.prodCongr (.refl (α 0)) (piFinTwoEquiv (Fin.tail α))) := by
+  ext <;> rfl
+
+/-- A product space `α × β × γ` is equivalent to the space `(i : Fin 3) → μ i`, where
+`μ = Fin.cons α (Fin.cons β (Fin.cons γ finZeroElim))`. See also `piFinThreeEquiv` and
+`finThreeArrowEquiv`. -/
+@[simps! (config := .asFn)]
+def prodEquivPiFinThree (α β γ : Type u) :
+    α × β × γ ≃ ((i : Fin 3) → ![α, β, γ] i) :=
+  (piFinThreeEquiv (Fin.cons α (Fin.cons β (Fin.cons γ finZeroElim)))).symm
+
+/-- The space of functions `Fin 3 → α` is equivalent to `α × α × α`.
+See also `piFinThreeEquiv` and `prodEquivPiFinThree`. -/
+@[simps (config := .asFn)]
+def finThreeArrowEquiv (α : Type*) : (Fin 3 → α) ≃ α × α × α :=
+  { piFinThreeEquiv fun _ => α with invFun := fun x => ![x.1, x.2.1, x.2.2] }
 
 /-- Equivalence between `Fin m ⊕ Fin n` and `Fin (m + n)` -/
 def finSumFinEquiv : Sum (Fin m) (Fin n) ≃ Fin (m + n)

--- a/Mathlib/Logic/Function/OfArity.lean
+++ b/Mathlib/Logic/Function/OfArity.lean
@@ -43,7 +43,7 @@ theorem ofArity_succ (α β : Type u) (n : ℕ) : OfArity α β n.succ = (α →
 
 namespace OfArity
 
-/-- Constant `n`-ary function with value `a`. -/
+/-- Constant `n`-ary function with value `b`. -/
 def const (α : Type u) {β : Type u} (b : β) : ∀ n, OfArity α β n
   | 0 => b
   | n + 1 => fun _ => const _ b n

--- a/Mathlib/Logic/Function/OfHArity.lean
+++ b/Mathlib/Logic/Function/OfHArity.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2024 Brendan Murphy. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Brendan Murphy
+-/
+
+import Mathlib.Logic.Function.OfArity
+import Mathlib.Data.Fin.VecNotation
+
+/-! # Function types of a given heterogeneous arity
+
+This provides `FunctionOfHArity`, such that `OfHArity ![α, β] τ = α → β → τ`.
+Note that it is often preferable to use `((i : Fin n) → p i) → τ` in place of `OfArity p τ`.
+
+## Main definitions
+
+* `Function.OfHArity p τ`: `n`-ary function `p 0 → p 1 → ... → p (n - 1) → β`.
+-/
+
+universe u
+
+namespace Function
+
+open Matrix (vecCons vecHead vecTail vecEmpty)
+
+/-- The type of `n`-ary functions `p 0 → p 1 → ... → p (n - 1) → τ`. -/
+def OfHArity : {n : ℕ} → (Fin n → Type u) → Type u → Type u
+  | 0    , _, τ => τ
+  | n + 1, p, τ => vecHead p → @OfHArity n (vecTail p) τ
+
+@[simp]
+theorem ofHArity_zero (p : Fin 0 → Type u) (τ : Type u) : OfHArity p τ = τ := rfl
+
+theorem ofHArity_nil (τ : Type u) : OfHArity ![] τ = τ := ofHArity_zero ![] τ
+
+@[simp low] -- prefer `ofHArity_cons` when it (syntactically) applies
+theorem ofHArity_succ {n} (p : Fin (n + 1) → Type u) (τ : Type u) :
+    OfHArity p τ = (vecHead p → OfHArity (vecTail p) τ) := rfl
+
+@[simp]
+theorem ofHArity_cons {n} (α : Type u) (p : Fin n → Type u) (τ : Type u) :
+    OfHArity (vecCons α p) τ = (α → OfHArity p τ) := ofHArity_succ _ τ
+
+@[simps!]
+def ofHArity_zero_equiv (p : Fin 0 → Type u) (τ : Type u) :
+    OfHArity p τ ≃ τ := Equiv.refl _
+
+@[simps!]
+def ofHArity_nil_equiv (τ : Type u) : OfHArity ![] τ ≃ τ :=
+  ofHArity_zero_equiv ![] τ
+
+@[simps!]
+def ofHArity_succ_equiv {n} (p : Fin (n + 1) → Type u) (τ : Type u) :
+    OfHArity p τ ≃ (vecHead p → OfHArity (vecTail p) τ) := Equiv.refl _
+
+@[simps!]
+def ofHArity_cons_equiv {n} (α : Type u) (p : Fin n → Type u) (τ : Type u) :
+    OfHArity (vecCons α p) τ ≃ (α → OfHArity p τ) := ofHArity_succ_equiv _ _
+
+-- not a definitional equality, generally prefer `ofHArity_fin_const_equiv`
+lemma ofHArity_fin_const {n} (α β : Type u) :
+    OfHArity (fun (_ : Fin n) => α) β = OfArity α β n :=
+  match n with
+  | 0   => Eq.refl β
+  | n+1 => congrArg (α → .) (@ofHArity_fin_const n α β)
+
+def ofHArity_fin_const_equiv : {n : ℕ} → (α β : Type u) →
+    OfHArity (fun (_ : Fin n) => α) β ≃ OfArity α β n
+  | 0,   _, β => .refl β
+  | n+1, α, β => .arrowCongr (.refl α) (@ofHArity_fin_const_equiv n α β)
+
+namespace OfHArity
+
+/-- Constant `n`-ary function with value `t`. -/
+def const : {n : ℕ} → (p : Fin n → Type u) → {τ : Type u} → (t : τ) → OfHArity p τ
+  | 0,     _, _, t => t
+  | n + 1, p, τ, t => fun _ => @const n (vecTail p) τ t
+
+@[simp]
+theorem const_zero (p : Fin 0 → Type u) {τ : Type u} (t : τ) : const p t = t :=
+  rfl
+
+@[simp]
+theorem const_succ {n} (p : Fin (n + 1) → Type u) {τ : Type u} (t : τ) :
+    const p t = fun _ => const (vecTail p) t := rfl
+
+theorem const_succ_apply {n} (p : Fin (n + 1) → Type u) {τ : Type u} (t : τ)
+    (x : p 0) : const p t x = const (vecTail p) t := rfl
+
+instance OfHArity.inhabited {n} {p : Fin n → Type u} {τ} [Inhabited τ] :
+    Inhabited (OfHArity p τ) := ⟨const p default⟩
+
+end OfHArity
+
+end Function

--- a/Mathlib/Logic/Function/OfHArity.lean
+++ b/Mathlib/Logic/Function/OfHArity.lean
@@ -41,19 +41,23 @@ theorem ofHArity_succ {n} (p : Fin (n + 1) → Type u) (τ : Type u) :
 theorem ofHArity_cons {n} (α : Type u) (p : Fin n → Type u) (τ : Type u) :
     OfHArity (vecCons α p) τ = (α → OfHArity p τ) := ofHArity_succ _ τ
 
-@[simps!]
+/-- The (identity) equivalence between 0-ary heterogeneous functions and
+the terminal codomain type. -/
 def ofHArity_zero_equiv (p : Fin 0 → Type u) (τ : Type u) :
     OfHArity p τ ≃ τ := Equiv.refl _
 
-@[simps!]
+/-- The (identity) equivalence between `![]`-ary heterogeneous functions and
+the terminal codomain type. -/
 def ofHArity_nil_equiv (τ : Type u) : OfHArity ![] τ ≃ τ :=
   ofHArity_zero_equiv ![] τ
 
-@[simps!]
+/-- The (identity) equivalence between `p`-ary heterogeneous functions and
+unary functions from the head of `p` to `vecTail p`-ary heterogeneous functions. -/
 def ofHArity_succ_equiv {n} (p : Fin (n + 1) → Type u) (τ : Type u) :
     OfHArity p τ ≃ (vecHead p → OfHArity (vecTail p) τ) := Equiv.refl _
 
-@[simps!]
+/-- The (identity) equivalence between `(vecCons α p)`-ary heterogeneous functions and
+unary functions from `α` to `p`-ary heterogeneous functions. -/
 def ofHArity_cons_equiv {n} (α : Type u) (p : Fin n → Type u) (τ : Type u) :
     OfHArity (vecCons α p) τ ≃ (α → OfHArity p τ) := ofHArity_succ_equiv _ _
 
@@ -64,6 +68,8 @@ lemma ofHArity_fin_const {n} (α β : Type u) :
   | 0   => Eq.refl β
   | n+1 => congrArg (α → .) (@ofHArity_fin_const n α β)
 
+/-- The equivalence (not a definitional equality!) between `n`-ary heterogeneous
+functions that aren't actually heterogeneous and `n`-ary functions. -/
 def ofHArity_fin_const_equiv : {n : ℕ} → (α β : Type u) →
     OfHArity (fun (_ : Fin n) => α) β ≃ OfArity α β n
   | 0,   _, β => .refl β


### PR DESCRIPTION
I'm currently working on proving the self enrichment of a closed monoidal category. Closed categories have several extranatural transformations that pop out of their structure, and it would be nice to verify that extranatural structure (and necessary if we wish to axiomatize closed categories that are not assumed to be monoidal). Extranatural transformations go between ternary functors, and it's awkward to talk about them without some theory of currying and 3-ary obj/map projections. In the future it would be nice to define multicategories and do this stuff in all arities at once, but I think before that we need heterogeneous functions in Type. So this PR is setting the basic foundations for multicategories, extranatural transformations, profunctors, and all a grab bag of 2-category/enriched category stuff.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
