### PR TITLE
[Merged by Bors] - fix: improve the logging behavior of `slim_check`

### DIFF
--- a/Mathlib/Tactic/SlimCheck.lean
+++ b/Mathlib/Tactic/SlimCheck.lean
@@ -179,10 +179,10 @@ elab_rules : tactic | `(tactic| slim_check $[$cfg]?) => withMainContext do
   catch _ => throwError "Failed to create a `testable` instance for `{tgt}`.
 What to do:
 1. make sure that the types you are using have `SlimCheck.SampleableExt` instances
-   (you can use `#sample my_type` if you are unsure);
+  (you can use `#sample my_type` if you are unsure);
 2. make sure that the relations and predicates that your proposition use are decidable;
 3. make sure that instances of `SlimCheck.Testable` exist that, when combined,
-   apply to your decorated proposition:
+  apply to your decorated proposition:
 ```
 {tgt'}
 ```
@@ -199,9 +199,9 @@ set_option trace.Meta.synthInstance true
   --   when_tracing `slim_check.instance   <| do
   --   { inst ← summarize_instance inst >>= pp,
   --     trace!"\n[testable instance]{format.indent inst 2}" },
-  let code ← unsafe evalExpr (IO PUnit) q(IO PUnit) e
+  let code ← unsafe evalExpr (CoreM PUnit) q(CoreM PUnit) e
   _ ← code
-  admitGoal (← getMainGoal)
+  admitGoal g
 
 -- Porting note: below is the remaining code from mathlib3 which supports the
 -- `trace.slim_check.instance` trace option, and which has not been ported.

--- a/Mathlib/Tactic/SlimCheck.lean
+++ b/Mathlib/Tactic/SlimCheck.lean
@@ -179,10 +179,10 @@ elab_rules : tactic | `(tactic| slim_check $[$cfg]?) => withMainContext do
   catch _ => throwError "Failed to create a `testable` instance for `{tgt}`.
 What to do:
 1. make sure that the types you are using have `SlimCheck.SampleableExt` instances
-  (you can use `#sample my_type` if you are unsure);
+   (you can use `#sample my_type` if you are unsure);
 2. make sure that the relations and predicates that your proposition use are decidable;
 3. make sure that instances of `SlimCheck.Testable` exist that, when combined,
-  apply to your decorated proposition:
+   apply to your decorated proposition:
 ```
 {tgt'}
 ```

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -550,7 +550,7 @@ end Decorations
 open Decorations in
 /-- Run a test suite for `p` and throw an exception if `p` does not hold. -/
 def Testable.check (p : Prop) (cfg : Configuration := {})
-    (p' : Decorations.DecorationsOf p := by mk_decorations) [Testable p'] : Lean.Core.CoreM PUnit := do
+    (p' : Decorations.DecorationsOf p := by mk_decorations) [Testable p'] : Lean.CoreM PUnit := do
   match ← Testable.checkIO p' cfg with
   | TestResult.success _ => if !cfg.quiet then Lean.logInfo "Success"
   | TestResult.gaveUp n => if !cfg.quiet then Lean.logWarning s!"Gave up {n} times"

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -550,11 +550,11 @@ end Decorations
 open Decorations in
 /-- Run a test suite for `p` and throw an exception if `p` does not hold. -/
 def Testable.check (p : Prop) (cfg : Configuration := {})
-    (p' : Decorations.DecorationsOf p := by mk_decorations) [Testable p'] : IO PUnit := do
+    (p' : Decorations.DecorationsOf p := by mk_decorations) [Testable p'] : Lean.Core.CoreM PUnit := do
   match ← Testable.checkIO p' cfg with
-  | TestResult.success _ => if !cfg.quiet then IO.println "Success"
-  | TestResult.gaveUp n => if !cfg.quiet then IO.println s!"Gave up {n} times"
-  | TestResult.failure _ xs n => throw (IO.userError <| formatFailure "Found problems!" xs n)
+  | TestResult.success _ => if !cfg.quiet then Lean.logInfo "Success"
+  | TestResult.gaveUp n => if !cfg.quiet then Lean.logWarning s!"Gave up {n} times"
+  | TestResult.failure _ xs n => Lean.throwError <| formatFailure "Found problems!" xs n
 
 -- #eval Testable.check (∀ (x y z a : Nat) (h1 : 3 < x) (h2 : 3 < y), x - y = y - x)
 --   Configuration.verbose

--- a/test/slim_check.lean
+++ b/test/slim_check.lean
@@ -3,6 +3,24 @@ import Mathlib.Tactic.SuccessIfFailWithMsg
 import Mathlib.Data.Finsupp.Notation
 import Mathlib.Testing.SlimCheck.Functions
 
+/--
+warning: Gave up 91 times
+---
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example (z : Nat) (h : z = 37) : z ≠ 0 := by
+  slim_check (config := { randomSeed := some 257 })
+
+/--
+info: Success
+---
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example (z : Nat) (h : z ≤ 37) : z ≤ 37 := by
+  slim_check (config := { randomSeed := some 257 })
+
 -- Porting note:
 -- These are the tests from mathlib3, updated to Lean 4 syntax.
 -- Many of these fail, I think because of missing `Testable` instances.


### PR DESCRIPTION
There was a bug in the tactic that meant it would always print "no goals to be solved".

This also promotes the code-generation from `IO` to `CoreM`, so that the output can be sent through the logging infrastructure rather than `IO.println`.
This is important, because tests are not allowed to be noisy, and we have no way to capture `IO` output.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
