### PR TITLE
[Merged by Bors] - chore(NumberTheory/ArithmeticFunction): remove `Nat.` part  from `ArithmeticFunction` namespace

### DIFF
--- a/Archive/Wiedijk100Theorems/PerfectNumbers.lean
+++ b/Archive/Wiedijk100Theorems/PerfectNumbers.lean
@@ -37,7 +37,7 @@ theorem odd_mersenne_succ (k : ℕ) : ¬2 ∣ mersenne (k + 1) := by
 
 namespace Nat
 
-open Nat.ArithmeticFunction Finset
+open ArithmeticFunction Finset
 
 theorem sigma_two_pow_eq_mersenne_succ (k : ℕ) : σ 1 (2 ^ k) = mersenne (k + 1) := by
   simp_rw [sigma_one_apply, mersenne, show 2 = 1 + 1 from rfl, ← geom_sum_mul_add 1 (k + 1)]

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -63,7 +63,7 @@ open Finset
 
 open BigOperators
 
-namespace Nat
+open Nat
 
 variable (R : Type*)
 
@@ -72,7 +72,7 @@ variable (R : Type*)
   Dirichlet convolution. -/
 def ArithmeticFunction [Zero R] :=
   ZeroHom ℕ R
-#align nat.arithmetic_function Nat.ArithmeticFunction
+#align nat.arithmetic_function ArithmeticFunction
 
 instance ArithmeticFunction.zero [Zero R] : Zero (ArithmeticFunction R) :=
   inferInstanceAs (Zero (ZeroHom ℕ R))
@@ -93,7 +93,7 @@ instance : FunLike (ArithmeticFunction R) ℕ R :=
 
 @[simp]
 theorem toFun_eq (f : ArithmeticFunction R) : f.toFun = f := rfl
-#align nat.arithmetic_function.to_fun_eq Nat.ArithmeticFunction.toFun_eq
+#align nat.arithmetic_function.to_fun_eq ArithmeticFunction.toFun_eq
 
 @[simp]
 theorem coe_mk (f : ℕ → R) (hf) : @DFunLike.coe (ArithmeticFunction R) _ _ _
@@ -102,25 +102,25 @@ theorem coe_mk (f : ℕ → R) (hf) : @DFunLike.coe (ArithmeticFunction R) _ _ _
 @[simp]
 theorem map_zero {f : ArithmeticFunction R} : f 0 = 0 :=
   ZeroHom.map_zero' f
-#align nat.arithmetic_function.map_zero Nat.ArithmeticFunction.map_zero
+#align nat.arithmetic_function.map_zero ArithmeticFunction.map_zero
 
 theorem coe_inj {f g : ArithmeticFunction R} : (f : ℕ → R) = g ↔ f = g :=
   DFunLike.coe_fn_eq
-#align nat.arithmetic_function.coe_inj Nat.ArithmeticFunction.coe_inj
+#align nat.arithmetic_function.coe_inj ArithmeticFunction.coe_inj
 
 @[simp]
 theorem zero_apply {x : ℕ} : (0 : ArithmeticFunction R) x = 0 :=
   ZeroHom.zero_apply x
-#align nat.arithmetic_function.zero_apply Nat.ArithmeticFunction.zero_apply
+#align nat.arithmetic_function.zero_apply ArithmeticFunction.zero_apply
 
 @[ext]
 theorem ext ⦃f g : ArithmeticFunction R⦄ (h : ∀ x, f x = g x) : f = g :=
   ZeroHom.ext h
-#align nat.arithmetic_function.ext Nat.ArithmeticFunction.ext
+#align nat.arithmetic_function.ext ArithmeticFunction.ext
 
 theorem ext_iff {f g : ArithmeticFunction R} : f = g ↔ ∀ x, f x = g x :=
   DFunLike.ext_iff
-#align nat.arithmetic_function.ext_iff Nat.ArithmeticFunction.ext_iff
+#align nat.arithmetic_function.ext_iff ArithmeticFunction.ext_iff
 
 section One
 
@@ -131,17 +131,17 @@ instance one : One (ArithmeticFunction R) :=
 
 theorem one_apply {x : ℕ} : (1 : ArithmeticFunction R) x = ite (x = 1) 1 0 :=
   rfl
-#align nat.arithmetic_function.one_apply Nat.ArithmeticFunction.one_apply
+#align nat.arithmetic_function.one_apply ArithmeticFunction.one_apply
 
 @[simp]
 theorem one_one : (1 : ArithmeticFunction R) 1 = 1 :=
   rfl
-#align nat.arithmetic_function.one_one Nat.ArithmeticFunction.one_one
+#align nat.arithmetic_function.one_one ArithmeticFunction.one_one
 
 @[simp]
 theorem one_apply_ne {x : ℕ} (h : x ≠ 1) : (1 : ArithmeticFunction R) x = 0 :=
   if_neg h
-#align nat.arithmetic_function.one_apply_ne Nat.ArithmeticFunction.one_apply_ne
+#align nat.arithmetic_function.one_apply_ne ArithmeticFunction.one_apply_ne
 
 end One
 
@@ -156,18 +156,18 @@ def natToArithmeticFunction [AddMonoidWithOne R] :
 
 instance natCoe [AddMonoidWithOne R] : Coe (ArithmeticFunction ℕ) (ArithmeticFunction R) :=
   ⟨natToArithmeticFunction⟩
-#align nat.arithmetic_function.nat_coe Nat.ArithmeticFunction.natCoe
+#align nat.arithmetic_function.nat_coe ArithmeticFunction.natCoe
 
 @[simp]
 theorem natCoe_nat (f : ArithmeticFunction ℕ) : natToArithmeticFunction f = f :=
   ext fun _ => cast_id _
-#align nat.arithmetic_function.nat_coe_nat Nat.ArithmeticFunction.natCoe_nat
+#align nat.arithmetic_function.nat_coe_nat ArithmeticFunction.natCoe_nat
 
 @[simp]
 theorem natCoe_apply [AddMonoidWithOne R] {f : ArithmeticFunction ℕ} {x : ℕ} :
     (f : ArithmeticFunction R) x = f x :=
   rfl
-#align nat.arithmetic_function.nat_coe_apply Nat.ArithmeticFunction.natCoe_apply
+#align nat.arithmetic_function.nat_coe_apply ArithmeticFunction.natCoe_apply
 
 /-- Coerce an arithmetic function with values in `ℤ` to one with values in `R`. We cannot inline
 this in `intCoe` because it gets unfolded too much. -/
@@ -178,38 +178,38 @@ def ofInt [AddGroupWithOne R] :
 
 instance intCoe [AddGroupWithOne R] : Coe (ArithmeticFunction ℤ) (ArithmeticFunction R) :=
   ⟨ofInt⟩
-#align nat.arithmetic_function.int_coe Nat.ArithmeticFunction.intCoe
+#align nat.arithmetic_function.int_coe ArithmeticFunction.intCoe
 
 @[simp]
 theorem intCoe_int (f : ArithmeticFunction ℤ) : ofInt f = f :=
   ext fun _ => Int.cast_id
-#align nat.arithmetic_function.int_coe_int Nat.ArithmeticFunction.intCoe_int
+#align nat.arithmetic_function.int_coe_int ArithmeticFunction.intCoe_int
 
 @[simp]
 theorem intCoe_apply [AddGroupWithOne R] {f : ArithmeticFunction ℤ} {x : ℕ} :
     (f : ArithmeticFunction R) x = f x := rfl
-#align nat.arithmetic_function.int_coe_apply Nat.ArithmeticFunction.intCoe_apply
+#align nat.arithmetic_function.int_coe_apply ArithmeticFunction.intCoe_apply
 
 @[simp]
 theorem coe_coe [AddGroupWithOne R] {f : ArithmeticFunction ℕ} :
     ((f : ArithmeticFunction ℤ) : ArithmeticFunction R) = (f : ArithmeticFunction R) := by
   ext
   simp
-#align nat.arithmetic_function.coe_coe Nat.ArithmeticFunction.coe_coe
+#align nat.arithmetic_function.coe_coe ArithmeticFunction.coe_coe
 
 @[simp]
 theorem natCoe_one [AddMonoidWithOne R] :
     ((1 : ArithmeticFunction ℕ) : ArithmeticFunction R) = 1 := by
   ext n
   simp [one_apply]
-#align nat.arithmetic_function.nat_coe_one Nat.ArithmeticFunction.natCoe_one
+#align nat.arithmetic_function.nat_coe_one ArithmeticFunction.natCoe_one
 
 @[simp]
 theorem intCoe_one [AddGroupWithOne R] : ((1 : ArithmeticFunction ℤ) :
     ArithmeticFunction R) = 1 := by
   ext n
   simp [one_apply]
-#align nat.arithmetic_function.int_coe_one Nat.ArithmeticFunction.intCoe_one
+#align nat.arithmetic_function.int_coe_one ArithmeticFunction.intCoe_one
 
 section AddMonoid
 
@@ -221,7 +221,7 @@ instance add : Add (ArithmeticFunction R) :=
 @[simp]
 theorem add_apply {f g : ArithmeticFunction R} {n : ℕ} : (f + g) n = f n + g n :=
   rfl
-#align nat.arithmetic_function.add_apply Nat.ArithmeticFunction.add_apply
+#align nat.arithmetic_function.add_apply ArithmeticFunction.add_apply
 
 instance instAddMonoid : AddMonoid (ArithmeticFunction R) :=
   { ArithmeticFunction.zero R,
@@ -229,7 +229,7 @@ instance instAddMonoid : AddMonoid (ArithmeticFunction R) :=
     add_assoc := fun _ _ _ => ext fun _ => add_assoc _ _ _
     zero_add := fun _ => ext fun _ => zero_add _
     add_zero := fun _ => ext fun _ => add_zero _ }
-#align nat.arithmetic_function.add_monoid Nat.ArithmeticFunction.instAddMonoid
+#align nat.arithmetic_function.add_monoid ArithmeticFunction.instAddMonoid
 
 end AddMonoid
 
@@ -239,7 +239,7 @@ instance instAddMonoidWithOne [AddMonoidWithOne R] : AddMonoidWithOne (Arithmeti
     natCast := fun n => ⟨fun x => if x = 1 then (n : R) else 0, by simp⟩
     natCast_zero := by ext; simp
     natCast_succ := fun n => by ext x; by_cases h : x = 1 <;> simp [h] }
-#align nat.arithmetic_function.add_monoid_with_one Nat.ArithmeticFunction.instAddMonoidWithOne
+#align nat.arithmetic_function.add_monoid_with_one ArithmeticFunction.instAddMonoidWithOne
 
 instance instAddCommMonoid [AddCommMonoid R] : AddCommMonoid (ArithmeticFunction R) :=
   { ArithmeticFunction.instAddMonoid with add_comm := fun _ _ => ext fun _ => add_comm _ _ }
@@ -266,7 +266,7 @@ instance : SMul (ArithmeticFunction R) (ArithmeticFunction M) :=
 theorem smul_apply {f : ArithmeticFunction R} {g : ArithmeticFunction M} {n : ℕ} :
     (f • g) n = ∑ x in divisorsAntidiagonal n, f x.fst • g x.snd :=
   rfl
-#align nat.arithmetic_function.smul_apply Nat.ArithmeticFunction.smul_apply
+#align nat.arithmetic_function.smul_apply ArithmeticFunction.smul_apply
 
 end SMul
 
@@ -279,24 +279,24 @@ instance [Semiring R] : Mul (ArithmeticFunction R) :=
 theorem mul_apply [Semiring R] {f g : ArithmeticFunction R} {n : ℕ} :
     (f * g) n = ∑ x in divisorsAntidiagonal n, f x.fst * g x.snd :=
   rfl
-#align nat.arithmetic_function.mul_apply Nat.ArithmeticFunction.mul_apply
+#align nat.arithmetic_function.mul_apply ArithmeticFunction.mul_apply
 
 theorem mul_apply_one [Semiring R] {f g : ArithmeticFunction R} : (f * g) 1 = f 1 * g 1 := by simp
-#align nat.arithmetic_function.mul_apply_one Nat.ArithmeticFunction.mul_apply_one
+#align nat.arithmetic_function.mul_apply_one ArithmeticFunction.mul_apply_one
 
 @[simp, norm_cast]
 theorem natCoe_mul [Semiring R] {f g : ArithmeticFunction ℕ} :
     (↑(f * g) : ArithmeticFunction R) = f * g := by
   ext n
   simp
-#align nat.arithmetic_function.nat_coe_mul Nat.ArithmeticFunction.natCoe_mul
+#align nat.arithmetic_function.nat_coe_mul ArithmeticFunction.natCoe_mul
 
 @[simp, norm_cast]
 theorem intCoe_mul [Ring R] {f g : ArithmeticFunction ℤ} :
     (↑(f * g) : ArithmeticFunction R) = ↑f * g := by
   ext n
   simp
-#align nat.arithmetic_function.int_coe_mul Nat.ArithmeticFunction.intCoe_mul
+#align nat.arithmetic_function.int_coe_mul ArithmeticFunction.intCoe_mul
 
 section Module
 
@@ -308,7 +308,7 @@ theorem mul_smul' (f g : ArithmeticFunction R) (h : ArithmeticFunction M) :
   simp only [mul_apply, smul_apply, sum_smul, mul_smul, smul_sum, Finset.sum_sigma']
   apply Finset.sum_nbij' (fun ⟨⟨_i, j⟩, ⟨k, l⟩⟩ ↦ ⟨(k, l * j), (l, j)⟩)
     (fun ⟨⟨i, _j⟩, ⟨k, l⟩⟩ ↦ ⟨(i * k, l), (i, k)⟩) <;> aesop (add simp mul_assoc)
-#align nat.arithmetic_function.mul_smul' Nat.ArithmeticFunction.mul_smul'
+#align nat.arithmetic_function.mul_smul' ArithmeticFunction.mul_smul'
 
 theorem one_smul' (b : ArithmeticFunction M) : (1 : ArithmeticFunction R) • b = b := by
   ext x
@@ -330,7 +330,7 @@ theorem one_smul' (b : ArithmeticFunction M) : (1 : ArithmeticFunction R) • b 
     tauto
 
   simp [y1ne]
-#align nat.arithmetic_function.one_smul' Nat.ArithmeticFunction.one_smul'
+#align nat.arithmetic_function.one_smul' ArithmeticFunction.one_smul'
 
 end Module
 
@@ -359,7 +359,7 @@ instance instMonoid : Monoid (ArithmeticFunction R) :=
         tauto
       simp [y2ne]
     mul_assoc := mul_smul' }
-#align nat.arithmetic_function.monoid Nat.ArithmeticFunction.instMonoid
+#align nat.arithmetic_function.monoid ArithmeticFunction.instMonoid
 
 instance instSemiring : Semiring (ArithmeticFunction R) :=
   -- porting note: I reorganized this instance
@@ -378,7 +378,7 @@ instance instSemiring : Semiring (ArithmeticFunction R) :=
     right_distrib := fun a b c => by
       ext
       simp only [← sum_add_distrib, add_mul, mul_apply, add_apply] }
-#align nat.arithmetic_function.semiring Nat.ArithmeticFunction.instSemiring
+#align nat.arithmetic_function.semiring ArithmeticFunction.instSemiring
 
 end Semiring
 
@@ -416,20 +416,20 @@ section Zeta
 /-- `ζ 0 = 0`, otherwise `ζ x = 1`. The Dirichlet Series is the Riemann `ζ`.  -/
 def zeta : ArithmeticFunction ℕ :=
   ⟨fun x => ite (x = 0) 0 1, rfl⟩
-#align nat.arithmetic_function.zeta Nat.ArithmeticFunction.zeta
+#align nat.arithmetic_function.zeta ArithmeticFunction.zeta
 
 -- porting note: added `Nat.` to the scoped namespace
 @[inherit_doc]
-scoped[Nat.ArithmeticFunction] notation "ζ" => Nat.ArithmeticFunction.zeta
+scoped[ArithmeticFunction] notation "ζ" => ArithmeticFunction.zeta
 
 @[simp]
 theorem zeta_apply {x : ℕ} : ζ x = if x = 0 then 0 else 1 :=
   rfl
-#align nat.arithmetic_function.zeta_apply Nat.ArithmeticFunction.zeta_apply
+#align nat.arithmetic_function.zeta_apply ArithmeticFunction.zeta_apply
 
 theorem zeta_apply_ne {x : ℕ} (h : x ≠ 0) : ζ x = 1 :=
   if_neg h
-#align nat.arithmetic_function.zeta_apply_ne Nat.ArithmeticFunction.zeta_apply_ne
+#align nat.arithmetic_function.zeta_apply_ne ArithmeticFunction.zeta_apply_ne
 
 -- Porting note: removed `@[simp]`, LHS not in normal form
 theorem coe_zeta_smul_apply {M} [Semiring R] [AddCommMonoid M] [Module R M]
@@ -441,13 +441,13 @@ theorem coe_zeta_smul_apply {M} [Semiring R] [AddCommMonoid M] [Module R M]
     rcases mem_divisorsAntidiagonal.1 hi with ⟨rfl, h⟩
     rw [natCoe_apply, zeta_apply_ne (left_ne_zero_of_mul h), cast_one, one_smul]
   · rw [← map_div_left_divisors, sum_map, Function.Embedding.coeFn_mk]
-#align nat.arithmetic_function.coe_zeta_smul_apply Nat.ArithmeticFunction.coe_zeta_smul_apply
+#align nat.arithmetic_function.coe_zeta_smul_apply ArithmeticFunction.coe_zeta_smul_apply
 
 -- Porting note: removed `@[simp]` to make the linter happy.
 theorem coe_zeta_mul_apply [Semiring R] {f : ArithmeticFunction R} {x : ℕ} :
     (↑ζ * f) x = ∑ i in divisors x, f i :=
   coe_zeta_smul_apply
-#align nat.arithmetic_function.coe_zeta_mul_apply Nat.ArithmeticFunction.coe_zeta_mul_apply
+#align nat.arithmetic_function.coe_zeta_mul_apply ArithmeticFunction.coe_zeta_mul_apply
 
 -- Porting note: removed `@[simp]` to make the linter happy.
 theorem coe_mul_zeta_apply [Semiring R] {f : ArithmeticFunction R} {x : ℕ} :
@@ -458,17 +458,17 @@ theorem coe_mul_zeta_apply [Semiring R] {f : ArithmeticFunction R} {x : ℕ} :
     rcases mem_divisorsAntidiagonal.1 hi with ⟨rfl, h⟩
     rw [natCoe_apply, zeta_apply_ne (right_ne_zero_of_mul h), cast_one, mul_one]
   · rw [← map_div_right_divisors, sum_map, Function.Embedding.coeFn_mk]
-#align nat.arithmetic_function.coe_mul_zeta_apply Nat.ArithmeticFunction.coe_mul_zeta_apply
+#align nat.arithmetic_function.coe_mul_zeta_apply ArithmeticFunction.coe_mul_zeta_apply
 
 theorem zeta_mul_apply {f : ArithmeticFunction ℕ} {x : ℕ} : (ζ * f) x = ∑ i in divisors x, f i :=
   coe_zeta_mul_apply
   --porting note: was `by rw [← nat_coe_nat ζ, coe_zeta_mul_apply]`.  Is this `theorem` obsolete?
-#align nat.arithmetic_function.zeta_mul_apply Nat.ArithmeticFunction.zeta_mul_apply
+#align nat.arithmetic_function.zeta_mul_apply ArithmeticFunction.zeta_mul_apply
 
 theorem mul_zeta_apply {f : ArithmeticFunction ℕ} {x : ℕ} : (f * ζ) x = ∑ i in divisors x, f i :=
   coe_mul_zeta_apply
   --porting note: was `by rw [← natCoe_nat ζ, coe_mul_zeta_apply]`.  Is this `theorem` obsolete=
-#align nat.arithmetic_function.mul_zeta_apply Nat.ArithmeticFunction.mul_zeta_apply
+#align nat.arithmetic_function.mul_zeta_apply ArithmeticFunction.mul_zeta_apply
 
 end Zeta
 
@@ -479,17 +479,17 @@ section Pmul
 /-- This is the pointwise product of `ArithmeticFunction`s. -/
 def pmul [MulZeroClass R] (f g : ArithmeticFunction R) : ArithmeticFunction R :=
   ⟨fun x => f x * g x, by simp⟩
-#align nat.arithmetic_function.pmul Nat.ArithmeticFunction.pmul
+#align nat.arithmetic_function.pmul ArithmeticFunction.pmul
 
 @[simp]
 theorem pmul_apply [MulZeroClass R] {f g : ArithmeticFunction R} {x : ℕ} : f.pmul g x = f x * g x :=
   rfl
-#align nat.arithmetic_function.pmul_apply Nat.ArithmeticFunction.pmul_apply
+#align nat.arithmetic_function.pmul_apply ArithmeticFunction.pmul_apply
 
 theorem pmul_comm [CommMonoidWithZero R] (f g : ArithmeticFunction R) : f.pmul g = g.pmul f := by
   ext
   simp [mul_comm]
-#align nat.arithmetic_function.pmul_comm Nat.ArithmeticFunction.pmul_comm
+#align nat.arithmetic_function.pmul_comm ArithmeticFunction.pmul_comm
 
 section NonAssocSemiring
 
@@ -499,13 +499,13 @@ variable [NonAssocSemiring R]
 theorem pmul_zeta (f : ArithmeticFunction R) : f.pmul ↑ζ = f := by
   ext x
   cases x <;> simp [Nat.succ_ne_zero]
-#align nat.arithmetic_function.pmul_zeta Nat.ArithmeticFunction.pmul_zeta
+#align nat.arithmetic_function.pmul_zeta ArithmeticFunction.pmul_zeta
 
 @[simp]
 theorem zeta_pmul (f : ArithmeticFunction R) : (ζ : ArithmeticFunction R).pmul f = f := by
   ext x
   cases x <;> simp [Nat.succ_ne_zero]
-#align nat.arithmetic_function.zeta_pmul Nat.ArithmeticFunction.zeta_pmul
+#align nat.arithmetic_function.zeta_pmul ArithmeticFunction.zeta_pmul
 
 end NonAssocSemiring
 
@@ -514,30 +514,30 @@ variable [Semiring R]
 /-- This is the pointwise power of `ArithmeticFunction`s. -/
 def ppow (f : ArithmeticFunction R) (k : ℕ) : ArithmeticFunction R :=
   if h0 : k = 0 then ζ else ⟨fun x ↦ f x ^ k, by simp_rw [map_zero, zero_pow h0]⟩
-#align nat.arithmetic_function.ppow Nat.ArithmeticFunction.ppow
+#align nat.arithmetic_function.ppow ArithmeticFunction.ppow
 
 @[simp]
 theorem ppow_zero {f : ArithmeticFunction R} : f.ppow 0 = ζ := by rw [ppow, dif_pos rfl]
-#align nat.arithmetic_function.ppow_zero Nat.ArithmeticFunction.ppow_zero
+#align nat.arithmetic_function.ppow_zero ArithmeticFunction.ppow_zero
 
 @[simp]
 theorem ppow_apply {f : ArithmeticFunction R} {k x : ℕ} (kpos : 0 < k) : f.ppow k x = f x ^ k := by
-  rw [ppow, dif_neg (ne_of_gt kpos)]
+  rw [ppow, dif_neg (Nat.ne_of_gt kpos)]
   rfl
-#align nat.arithmetic_function.ppow_apply Nat.ArithmeticFunction.ppow_apply
+#align nat.arithmetic_function.ppow_apply ArithmeticFunction.ppow_apply
 
 theorem ppow_succ {f : ArithmeticFunction R} {k : ℕ} : f.ppow (k + 1) = f.pmul (f.ppow k) := by
   ext x
   rw [ppow_apply (Nat.succ_pos k), _root_.pow_succ]
   induction k <;> simp
-#align nat.arithmetic_function.ppow_succ Nat.ArithmeticFunction.ppow_succ
+#align nat.arithmetic_function.ppow_succ ArithmeticFunction.ppow_succ
 
 theorem ppow_succ' {f : ArithmeticFunction R} {k : ℕ} {kpos : 0 < k} :
     f.ppow (k + 1) = (f.ppow k).pmul f := by
   ext x
   rw [ppow_apply (Nat.succ_pos k), _root_.pow_succ']
   induction k <;> simp
-#align nat.arithmetic_function.ppow_succ' Nat.ArithmeticFunction.ppow_succ'
+#align nat.arithmetic_function.ppow_succ' ArithmeticFunction.ppow_succ'
 
 end Pmul
 
@@ -585,7 +585,7 @@ end ProdPrimeFactors
 /-- Multiplicative functions -/
 def IsMultiplicative [MonoidWithZero R] (f : ArithmeticFunction R) : Prop :=
   f 1 = 1 ∧ ∀ {m n : ℕ}, m.Coprime n → f (m * n) = f m * f n
-#align nat.arithmetic_function.is_multiplicative Nat.ArithmeticFunction.IsMultiplicative
+#align nat.arithmetic_function.is_multiplicative ArithmeticFunction.IsMultiplicative
 
 namespace IsMultiplicative
 
@@ -596,17 +596,17 @@ variable [MonoidWithZero R]
 @[simp]
 theorem map_one {f : ArithmeticFunction R} (h : f.IsMultiplicative) : f 1 = 1 :=
   h.1
-#align nat.arithmetic_function.is_multiplicative.map_one Nat.ArithmeticFunction.IsMultiplicative.map_one
+#align nat.arithmetic_function.is_multiplicative.map_one ArithmeticFunction.IsMultiplicative.map_one
 
 @[simp]
 theorem map_mul_of_coprime {f : ArithmeticFunction R} (hf : f.IsMultiplicative) {m n : ℕ}
     (h : m.Coprime n) : f (m * n) = f m * f n :=
   hf.2 h
-#align nat.arithmetic_function.is_multiplicative.map_mul_of_coprime Nat.ArithmeticFunction.IsMultiplicative.map_mul_of_coprime
+#align nat.arithmetic_function.is_multiplicative.map_mul_of_coprime ArithmeticFunction.IsMultiplicative.map_mul_of_coprime
 
 end MonoidWithZero
 
-theorem map_prod {ι : Type*} [CommMonoidWithZero R] (g : ι → ℕ) {f : Nat.ArithmeticFunction R}
+theorem map_prod {ι : Type*} [CommMonoidWithZero R] (g : ι → ℕ) {f : ArithmeticFunction R}
     (hf : f.IsMultiplicative) (s : Finset ι) (hs : (s : Set ι).Pairwise (Coprime on g)) :
     f (∏ i in s, g i) = ∏ i in s, f (g i) := by
   classical
@@ -615,7 +615,7 @@ theorem map_prod {ι : Type*} [CommMonoidWithZero R] (g : ι → ℕ) {f : Nat.A
     rw [coe_insert, Set.pairwise_insert_of_symmetric (Coprime.symmetric.comap g)] at hs
     rw [prod_insert has, prod_insert has, hf.map_mul_of_coprime, ih hs.1]
     exact .prod_right fun i hi => hs.2 _ hi (hi.ne_of_not_mem has).symm
-#align nat.arithmetic_function.is_multiplicative.map_prod Nat.ArithmeticFunction.IsMultiplicative.map_prod
+#align nat.arithmetic_function.is_multiplicative.map_prod ArithmeticFunction.IsMultiplicative.map_prod
 
 theorem map_prod_of_prime [CommSemiring R] {f : ArithmeticFunction R}
     (h_mult : ArithmeticFunction.IsMultiplicative f)
@@ -633,13 +633,13 @@ theorem nat_cast {f : ArithmeticFunction ℕ} [Semiring R] (h : f.IsMultiplicati
     IsMultiplicative (f : ArithmeticFunction R) :=
                                  -- porting note: was `by simp [cop, h]`
   ⟨by simp [h], fun {m n} cop => by simp [h.2 cop]⟩
-#align nat.arithmetic_function.is_multiplicative.nat_cast Nat.ArithmeticFunction.IsMultiplicative.nat_cast
+#align nat.arithmetic_function.is_multiplicative.nat_cast ArithmeticFunction.IsMultiplicative.nat_cast
 
 theorem int_cast {f : ArithmeticFunction ℤ} [Ring R] (h : f.IsMultiplicative) :
     IsMultiplicative (f : ArithmeticFunction R) :=
                                  -- porting note: was `by simp [cop, h]`
   ⟨by simp [h], fun {m n} cop => by simp [h.2 cop]⟩
-#align nat.arithmetic_function.is_multiplicative.int_cast Nat.ArithmeticFunction.IsMultiplicative.int_cast
+#align nat.arithmetic_function.is_multiplicative.int_cast ArithmeticFunction.IsMultiplicative.int_cast
 
 theorem mul [CommSemiring R] {f g : ArithmeticFunction R} (hf : f.IsMultiplicative)
     (hg : g.IsMultiplicative) : IsMultiplicative (f * g) := by
@@ -700,14 +700,14 @@ theorem mul [CommSemiring R] {f g : ArithmeticFunction R} (hf : f.IsMultiplicati
     rw [hf.map_mul_of_coprime cop.coprime_mul_right.coprime_mul_right_right,
       hg.map_mul_of_coprime cop.coprime_mul_left.coprime_mul_left_right]
     ring
-#align nat.arithmetic_function.is_multiplicative.mul Nat.ArithmeticFunction.IsMultiplicative.mul
+#align nat.arithmetic_function.is_multiplicative.mul ArithmeticFunction.IsMultiplicative.mul
 
 theorem pmul [CommSemiring R] {f g : ArithmeticFunction R} (hf : f.IsMultiplicative)
     (hg : g.IsMultiplicative) : IsMultiplicative (f.pmul g) :=
   ⟨by simp [hf, hg], fun {m n} cop => by
     simp only [pmul_apply, hf.map_mul_of_coprime cop, hg.map_mul_of_coprime cop]
     ring⟩
-#align nat.arithmetic_function.is_multiplicative.pmul Nat.ArithmeticFunction.IsMultiplicative.pmul
+#align nat.arithmetic_function.is_multiplicative.pmul ArithmeticFunction.IsMultiplicative.pmul
 
 theorem pdiv [CommGroupWithZero R] {f g : ArithmeticFunction R} (hf : IsMultiplicative f)
     (hg : IsMultiplicative g) : IsMultiplicative (pdiv f g) :=
@@ -723,7 +723,7 @@ theorem multiplicative_factorization [CommMonoidWithZero R] (f : ArithmeticFunct
     (hf : f.IsMultiplicative) {n : ℕ} (hn : n ≠ 0) :
     f n = n.factorization.prod fun p k => f (p ^ k) :=
   multiplicative_factorization f (fun _ _ => hf.2) hf.1 hn
-#align nat.arithmetic_function.is_multiplicative.multiplicative_factorization Nat.ArithmeticFunction.IsMultiplicative.multiplicative_factorization
+#align nat.arithmetic_function.is_multiplicative.multiplicative_factorization ArithmeticFunction.IsMultiplicative.multiplicative_factorization
 
 /-- A recapitulation of the definition of multiplicative that is simpler for proofs -/
 theorem iff_ne_zero [MonoidWithZero R] {f : ArithmeticFunction R} :
@@ -735,7 +735,7 @@ theorem iff_ne_zero [MonoidWithZero R] {f : ArithmeticFunction R} :
   rcases eq_or_ne n 0 with (rfl | hn)
   · simp
   exact h hm hn hmn
-#align nat.arithmetic_function.is_multiplicative.iff_ne_zero Nat.ArithmeticFunction.IsMultiplicative.iff_ne_zero
+#align nat.arithmetic_function.is_multiplicative.iff_ne_zero ArithmeticFunction.IsMultiplicative.iff_ne_zero
 
 /-- Two multiplicative functions `f` and `g` are equal if and only if
 they agree on prime powers -/
@@ -751,7 +751,7 @@ theorem eq_iff_eq_on_prime_powers [CommMonoidWithZero R] (f : ArithmeticFunction
   · rw [hn, ArithmeticFunction.map_zero, ArithmeticFunction.map_zero]
   rw [multiplicative_factorization f hf hn, multiplicative_factorization g hg hn]
   exact Finset.prod_congr rfl fun p hp ↦ h p _ (Nat.prime_of_mem_primeFactors hp)
-#align nat.arithmetic_function.is_multiplicative.eq_iff_eq_on_prime_powers Nat.ArithmeticFunction.IsMultiplicative.eq_iff_eq_on_prime_powers
+#align nat.arithmetic_function.is_multiplicative.eq_iff_eq_on_prime_powers ArithmeticFunction.IsMultiplicative.eq_iff_eq_on_prime_powers
 
 theorem prodPrimeFactors [CommMonoidWithZero R] (f : ℕ → R) :
     IsMultiplicative (prodPrimeFactors f) := by
@@ -781,13 +781,13 @@ theorem lcm_apply_mul_gcd_apply [CommMonoidWithZero R] {f : ArithmeticFunction R
     (hf : f.IsMultiplicative) {x y : ℕ} :
     f (x.lcm y) * f (x.gcd y) = f x * f y := by
   by_cases hx : x = 0
-  · simp only [hx, f.map_zero, zero_mul, lcm_zero_left, gcd_zero_left]
+  · simp only [hx, f.map_zero, zero_mul, Nat.lcm_zero_left, Nat.gcd_zero_left]
   by_cases hy : y = 0
-  · simp only [hy, f.map_zero, mul_zero, lcm_zero_right, gcd_zero_right, zero_mul]
+  · simp only [hy, f.map_zero, mul_zero, Nat.lcm_zero_right, Nat.gcd_zero_right, zero_mul]
   have hgcd_ne_zero : x.gcd y ≠ 0 := gcd_ne_zero_left hx
   have hlcm_ne_zero : x.lcm y ≠ 0 := lcm_ne_zero hx hy
   have hfi_zero : ∀ {i}, f (i ^ 0) = 1
-  · intro i; rw [pow_zero, hf.1]
+  · intro i; rw [Nat.pow_zero, hf.1]
   iterate 4 rw [hf.multiplicative_factorization f (by assumption),
     Finsupp.prod_of_support_subset _ _ _ (fun _ _ => hfi_zero)
       (s := (x.primeFactors ⊔ y.primeFactors))]
@@ -812,53 +812,53 @@ section SpecialFunctions
 nonrec  -- porting note: added
 def id : ArithmeticFunction ℕ :=
   ⟨id, rfl⟩
-#align nat.arithmetic_function.id Nat.ArithmeticFunction.id
+#align nat.arithmetic_function.id ArithmeticFunction.id
 
 @[simp]
 theorem id_apply {x : ℕ} : id x = x :=
   rfl
-#align nat.arithmetic_function.id_apply Nat.ArithmeticFunction.id_apply
+#align nat.arithmetic_function.id_apply ArithmeticFunction.id_apply
 
 /-- `pow k n = n ^ k`, except `pow 0 0 = 0`. -/
 def pow (k : ℕ) : ArithmeticFunction ℕ :=
   id.ppow k
-#align nat.arithmetic_function.pow Nat.ArithmeticFunction.pow
+#align nat.arithmetic_function.pow ArithmeticFunction.pow
 
 @[simp]
 theorem pow_apply {k n : ℕ} : pow k n = if k = 0 ∧ n = 0 then 0 else n ^ k := by
   cases k
   · simp [pow]
   rename_i k  -- porting note: added
-  simp [pow, (ne_of_lt (Nat.succ_pos k)).symm]
-#align nat.arithmetic_function.pow_apply Nat.ArithmeticFunction.pow_apply
+  simp [pow, k.succ_pos.ne']
+#align nat.arithmetic_function.pow_apply ArithmeticFunction.pow_apply
 
 theorem pow_zero_eq_zeta : pow 0 = ζ := by
   ext n
   simp
-#align nat.arithmetic_function.pow_zero_eq_zeta Nat.ArithmeticFunction.pow_zero_eq_zeta
+#align nat.arithmetic_function.pow_zero_eq_zeta ArithmeticFunction.pow_zero_eq_zeta
 
 /-- `σ k n` is the sum of the `k`th powers of the divisors of `n` -/
 def sigma (k : ℕ) : ArithmeticFunction ℕ :=
   ⟨fun n => ∑ d in divisors n, d ^ k, by simp⟩
-#align nat.arithmetic_function.sigma Nat.ArithmeticFunction.sigma
+#align nat.arithmetic_function.sigma ArithmeticFunction.sigma
 
 -- porting note: added `Nat.` to the scoped namespace
 @[inherit_doc]
-scoped[Nat.ArithmeticFunction] notation "σ" => Nat.ArithmeticFunction.sigma
+scoped[ArithmeticFunction] notation "σ" => ArithmeticFunction.sigma
 
 theorem sigma_apply {k n : ℕ} : σ k n = ∑ d in divisors n, d ^ k :=
   rfl
-#align nat.arithmetic_function.sigma_apply Nat.ArithmeticFunction.sigma_apply
+#align nat.arithmetic_function.sigma_apply ArithmeticFunction.sigma_apply
 
 theorem sigma_one_apply (n : ℕ) : σ 1 n = ∑ d in divisors n, d := by simp [sigma_apply]
-#align nat.arithmetic_function.sigma_one_apply Nat.ArithmeticFunction.sigma_one_apply
+#align nat.arithmetic_function.sigma_one_apply ArithmeticFunction.sigma_one_apply
 
 theorem sigma_zero_apply (n : ℕ) : σ 0 n = (divisors n).card := by simp [sigma_apply]
-#align nat.arithmetic_function.sigma_zero_apply Nat.ArithmeticFunction.sigma_zero_apply
+#align nat.arithmetic_function.sigma_zero_apply ArithmeticFunction.sigma_zero_apply
 
 theorem sigma_zero_apply_prime_pow {p i : ℕ} (hp : p.Prime) : σ 0 (p ^ i) = i + 1 := by
   rw [sigma_zero_apply, divisors_prime_pow hp, card_map, card_range]
-#align nat.arithmetic_function.sigma_zero_apply_prime_pow Nat.ArithmeticFunction.sigma_zero_apply_prime_pow
+#align nat.arithmetic_function.sigma_zero_apply_prime_pow ArithmeticFunction.sigma_zero_apply_prime_pow
 
 theorem zeta_mul_pow_eq_sigma {k : ℕ} : ζ * pow k = σ k := by
   ext
@@ -868,7 +868,7 @@ theorem zeta_mul_pow_eq_sigma {k : ℕ} : ζ * pow k = σ k := by
   rw [pow_apply, if_neg (not_and_of_not_right _ _)]
   contrapose! hx
   simp [hx]
-#align nat.arithmetic_function.zeta_mul_pow_eq_sigma Nat.ArithmeticFunction.zeta_mul_pow_eq_sigma
+#align nat.arithmetic_function.zeta_mul_pow_eq_sigma ArithmeticFunction.zeta_mul_pow_eq_sigma
 
 theorem isMultiplicative_one [MonoidWithZero R] : IsMultiplicative (1 : ArithmeticFunction R) :=
   IsMultiplicative.iff_ne_zero.2
@@ -879,15 +879,15 @@ theorem isMultiplicative_one [MonoidWithZero R] : IsMultiplicative (1 : Arithmet
       rw [one_apply_ne, one_apply_ne hm', zero_mul]
       rw [Ne.def, mul_eq_one, not_and_or]
       exact Or.inl hm'⟩
-#align nat.arithmetic_function.is_multiplicative_one Nat.ArithmeticFunction.isMultiplicative_one
+#align nat.arithmetic_function.is_multiplicative_one ArithmeticFunction.isMultiplicative_one
 
 theorem isMultiplicative_zeta : IsMultiplicative ζ :=
   IsMultiplicative.iff_ne_zero.2 ⟨by simp, by simp (config := { contextual := true })⟩
-#align nat.arithmetic_function.is_multiplicative_zeta Nat.ArithmeticFunction.isMultiplicative_zeta
+#align nat.arithmetic_function.is_multiplicative_zeta ArithmeticFunction.isMultiplicative_zeta
 
 theorem isMultiplicative_id : IsMultiplicative ArithmeticFunction.id :=
   ⟨rfl, fun {_ _} _ => rfl⟩
-#align nat.arithmetic_function.is_multiplicative_id Nat.ArithmeticFunction.isMultiplicative_id
+#align nat.arithmetic_function.is_multiplicative_id ArithmeticFunction.isMultiplicative_id
 
 theorem IsMultiplicative.ppow [CommSemiring R] {f : ArithmeticFunction R} (hf : f.IsMultiplicative)
     {k : ℕ} : IsMultiplicative (f.ppow k) := by
@@ -895,35 +895,35 @@ theorem IsMultiplicative.ppow [CommSemiring R] {f : ArithmeticFunction R} (hf : 
   · exact isMultiplicative_zeta.nat_cast
   · rw [ppow_succ]
     apply hf.pmul hi
-#align nat.arithmetic_function.is_multiplicative.ppow Nat.ArithmeticFunction.IsMultiplicative.ppow
+#align nat.arithmetic_function.is_multiplicative.ppow ArithmeticFunction.IsMultiplicative.ppow
 
 theorem isMultiplicative_pow {k : ℕ} : IsMultiplicative (pow k) :=
   isMultiplicative_id.ppow
-#align nat.arithmetic_function.is_multiplicative_pow Nat.ArithmeticFunction.isMultiplicative_pow
+#align nat.arithmetic_function.is_multiplicative_pow ArithmeticFunction.isMultiplicative_pow
 
 theorem isMultiplicative_sigma {k : ℕ} : IsMultiplicative (σ k) := by
   rw [← zeta_mul_pow_eq_sigma]
   apply isMultiplicative_zeta.mul isMultiplicative_pow
-#align nat.arithmetic_function.is_multiplicative_sigma Nat.ArithmeticFunction.isMultiplicative_sigma
+#align nat.arithmetic_function.is_multiplicative_sigma ArithmeticFunction.isMultiplicative_sigma
 
 /-- `Ω n` is the number of prime factors of `n`. -/
 def cardFactors : ArithmeticFunction ℕ :=
   ⟨fun n => n.factors.length, by simp⟩
-#align nat.arithmetic_function.card_factors Nat.ArithmeticFunction.cardFactors
+#align nat.arithmetic_function.card_factors ArithmeticFunction.cardFactors
 
 -- porting note: added `Nat.` to the scoped namespace
 @[inherit_doc]
-scoped[Nat.ArithmeticFunction] notation "Ω" => Nat.ArithmeticFunction.cardFactors
+scoped[ArithmeticFunction] notation "Ω" => ArithmeticFunction.cardFactors
 
 theorem cardFactors_apply {n : ℕ} : Ω n = n.factors.length :=
   rfl
-#align nat.arithmetic_function.card_factors_apply Nat.ArithmeticFunction.cardFactors_apply
+#align nat.arithmetic_function.card_factors_apply ArithmeticFunction.cardFactors_apply
 
 @[simp, nolint simpNF] -- this is a `dsimp` lemma
 lemma cardFactors_zero : Ω 0 = 0 := rfl
 
 @[simp] theorem cardFactors_one : Ω 1 = 0 := rfl
-#align nat.arithmetic_function.card_factors_one Nat.ArithmeticFunction.cardFactors_one
+#align nat.arithmetic_function.card_factors_one ArithmeticFunction.cardFactors_one
 
 @[simp]
 theorem cardFactors_eq_one_iff_prime {n : ℕ} : Ω n = 1 ↔ n.Prime := by
@@ -935,50 +935,50 @@ theorem cardFactors_eq_one_iff_prime {n : ℕ} : Ω n = 1 ↔ n.Prime := by
   rw [← prod_factors n.succ_ne_zero, hx, List.prod_singleton]
   apply prime_of_mem_factors
   rw [hx, List.mem_singleton]
-#align nat.arithmetic_function.card_factors_eq_one_iff_prime Nat.ArithmeticFunction.cardFactors_eq_one_iff_prime
+#align nat.arithmetic_function.card_factors_eq_one_iff_prime ArithmeticFunction.cardFactors_eq_one_iff_prime
 
 theorem cardFactors_mul {m n : ℕ} (m0 : m ≠ 0) (n0 : n ≠ 0) : Ω (m * n) = Ω m + Ω n := by
   rw [cardFactors_apply, cardFactors_apply, cardFactors_apply, ← Multiset.coe_card, ← factors_eq,
     UniqueFactorizationMonoid.normalizedFactors_mul m0 n0, factors_eq, factors_eq,
     Multiset.card_add, Multiset.coe_card, Multiset.coe_card]
-#align nat.arithmetic_function.card_factors_mul Nat.ArithmeticFunction.cardFactors_mul
+#align nat.arithmetic_function.card_factors_mul ArithmeticFunction.cardFactors_mul
 
 theorem cardFactors_multiset_prod {s : Multiset ℕ} (h0 : s.prod ≠ 0) :
     Ω s.prod = (Multiset.map Ω s).sum := by
   induction s using Multiset.induction_on with
   | empty => simp
   | cons ih => simp_all [cardFactors_mul, not_or]
-#align nat.arithmetic_function.card_factors_multiset_prod Nat.ArithmeticFunction.cardFactors_multiset_prod
+#align nat.arithmetic_function.card_factors_multiset_prod ArithmeticFunction.cardFactors_multiset_prod
 
 @[simp]
 theorem cardFactors_apply_prime {p : ℕ} (hp : p.Prime) : Ω p = 1 :=
   cardFactors_eq_one_iff_prime.2 hp
-#align nat.arithmetic_function.card_factors_apply_prime Nat.ArithmeticFunction.cardFactors_apply_prime
+#align nat.arithmetic_function.card_factors_apply_prime ArithmeticFunction.cardFactors_apply_prime
 
 @[simp]
 theorem cardFactors_apply_prime_pow {p k : ℕ} (hp : p.Prime) : Ω (p ^ k) = k := by
   rw [cardFactors_apply, hp.factors_pow, List.length_replicate]
-#align nat.arithmetic_function.card_factors_apply_prime_pow Nat.ArithmeticFunction.cardFactors_apply_prime_pow
+#align nat.arithmetic_function.card_factors_apply_prime_pow ArithmeticFunction.cardFactors_apply_prime_pow
 
 /-- `ω n` is the number of distinct prime factors of `n`. -/
 def cardDistinctFactors : ArithmeticFunction ℕ :=
   ⟨fun n => n.factors.dedup.length, by simp⟩
-#align nat.arithmetic_function.card_distinct_factors Nat.ArithmeticFunction.cardDistinctFactors
+#align nat.arithmetic_function.card_distinct_factors ArithmeticFunction.cardDistinctFactors
 
 -- porting note: added `Nat.` to the scoped namespace
 @[inherit_doc]
-scoped[Nat.ArithmeticFunction] notation "ω" => Nat.ArithmeticFunction.cardDistinctFactors
+scoped[ArithmeticFunction] notation "ω" => ArithmeticFunction.cardDistinctFactors
 
 theorem cardDistinctFactors_zero : ω 0 = 0 := by simp
-#align nat.arithmetic_function.card_distinct_factors_zero Nat.ArithmeticFunction.cardDistinctFactors_zero
+#align nat.arithmetic_function.card_distinct_factors_zero ArithmeticFunction.cardDistinctFactors_zero
 
 @[simp]
 theorem cardDistinctFactors_one : ω 1 = 0 := by simp [cardDistinctFactors]
-#align nat.arithmetic_function.card_distinct_factors_one Nat.ArithmeticFunction.cardDistinctFactors_one
+#align nat.arithmetic_function.card_distinct_factors_one ArithmeticFunction.cardDistinctFactors_one
 
 theorem cardDistinctFactors_apply {n : ℕ} : ω n = n.factors.dedup.length :=
   rfl
-#align nat.arithmetic_function.card_distinct_factors_apply Nat.ArithmeticFunction.cardDistinctFactors_apply
+#align nat.arithmetic_function.card_distinct_factors_apply ArithmeticFunction.cardDistinctFactors_apply
 
 theorem cardDistinctFactors_eq_cardFactors_iff_squarefree {n : ℕ} (h0 : n ≠ 0) :
     ω n = Ω n ↔ Squarefree n := by
@@ -988,49 +988,49 @@ theorem cardDistinctFactors_eq_cardFactors_iff_squarefree {n : ℕ} (h0 : n ≠ 
     apply List.nodup_dedup
   · rw [h.dedup]
     rfl
-#align nat.arithmetic_function.card_distinct_factors_eq_card_factors_iff_squarefree Nat.ArithmeticFunction.cardDistinctFactors_eq_cardFactors_iff_squarefree
+#align nat.arithmetic_function.card_distinct_factors_eq_card_factors_iff_squarefree ArithmeticFunction.cardDistinctFactors_eq_cardFactors_iff_squarefree
 
 @[simp]
 theorem cardDistinctFactors_apply_prime_pow {p k : ℕ} (hp : p.Prime) (hk : k ≠ 0) :
     ω (p ^ k) = 1 := by
   rw [cardDistinctFactors_apply, hp.factors_pow, List.replicate_dedup hk, List.length_singleton]
-#align nat.arithmetic_function.card_distinct_factors_apply_prime_pow Nat.ArithmeticFunction.cardDistinctFactors_apply_prime_pow
+#align nat.arithmetic_function.card_distinct_factors_apply_prime_pow ArithmeticFunction.cardDistinctFactors_apply_prime_pow
 
 @[simp]
 theorem cardDistinctFactors_apply_prime {p : ℕ} (hp : p.Prime) : ω p = 1 := by
   rw [← pow_one p, cardDistinctFactors_apply_prime_pow hp one_ne_zero]
-#align nat.arithmetic_function.card_distinct_factors_apply_prime Nat.ArithmeticFunction.cardDistinctFactors_apply_prime
+#align nat.arithmetic_function.card_distinct_factors_apply_prime ArithmeticFunction.cardDistinctFactors_apply_prime
 
 /-- `μ` is the Möbius function. If `n` is squarefree with an even number of distinct prime factors,
   `μ n = 1`. If `n` is squarefree with an odd number of distinct prime factors, `μ n = -1`.
   If `n` is not squarefree, `μ n = 0`. -/
 def moebius : ArithmeticFunction ℤ :=
   ⟨fun n => if Squarefree n then (-1) ^ cardFactors n else 0, by simp⟩
-#align nat.arithmetic_function.moebius Nat.ArithmeticFunction.moebius
+#align nat.arithmetic_function.moebius ArithmeticFunction.moebius
 
 -- porting note: added `Nat.` to the scoped namespace
 @[inherit_doc]
-scoped[Nat.ArithmeticFunction] notation "μ" => Nat.ArithmeticFunction.moebius
+scoped[ArithmeticFunction] notation "μ" => ArithmeticFunction.moebius
 
 @[simp]
 theorem moebius_apply_of_squarefree {n : ℕ} (h : Squarefree n) : μ n = (-1) ^ cardFactors n :=
   if_pos h
-#align nat.arithmetic_function.moebius_apply_of_squarefree Nat.ArithmeticFunction.moebius_apply_of_squarefree
+#align nat.arithmetic_function.moebius_apply_of_squarefree ArithmeticFunction.moebius_apply_of_squarefree
 
 @[simp]
 theorem moebius_eq_zero_of_not_squarefree {n : ℕ} (h : ¬Squarefree n) : μ n = 0 :=
   if_neg h
-#align nat.arithmetic_function.moebius_eq_zero_of_not_squarefree Nat.ArithmeticFunction.moebius_eq_zero_of_not_squarefree
+#align nat.arithmetic_function.moebius_eq_zero_of_not_squarefree ArithmeticFunction.moebius_eq_zero_of_not_squarefree
 
 theorem moebius_apply_one : μ 1 = 1 := by simp
-#align nat.arithmetic_function.moebius_apply_one Nat.ArithmeticFunction.moebius_apply_one
+#align nat.arithmetic_function.moebius_apply_one ArithmeticFunction.moebius_apply_one
 
 theorem moebius_ne_zero_iff_squarefree {n : ℕ} : μ n ≠ 0 ↔ Squarefree n := by
   constructor <;> intro h
   · contrapose! h
     simp [h]
   · simp [h, pow_ne_zero]
-#align nat.arithmetic_function.moebius_ne_zero_iff_squarefree Nat.ArithmeticFunction.moebius_ne_zero_iff_squarefree
+#align nat.arithmetic_function.moebius_ne_zero_iff_squarefree ArithmeticFunction.moebius_ne_zero_iff_squarefree
 
 theorem moebius_ne_zero_iff_eq_or {n : ℕ} : μ n ≠ 0 ↔ μ n = 1 ∨ μ n = -1 := by
   constructor <;> intro h
@@ -1038,11 +1038,11 @@ theorem moebius_ne_zero_iff_eq_or {n : ℕ} : μ n ≠ 0 ↔ μ n = 1 ∨ μ n =
     rw [moebius_apply_of_squarefree h]
     apply neg_one_pow_eq_or
   · rcases h with (h | h) <;> simp [h]
-#align nat.arithmetic_function.moebius_ne_zero_iff_eq_or Nat.ArithmeticFunction.moebius_ne_zero_iff_eq_or
+#align nat.arithmetic_function.moebius_ne_zero_iff_eq_or ArithmeticFunction.moebius_ne_zero_iff_eq_or
 
 theorem moebius_apply_prime {p : ℕ} (hp : p.Prime) : μ p = -1 := by
   rw [moebius_apply_of_squarefree hp.squarefree, cardFactors_apply_prime hp, pow_one]
-#align nat.arithmetic_function.moebius_apply_prime Nat.ArithmeticFunction.moebius_apply_prime
+#align nat.arithmetic_function.moebius_apply_prime ArithmeticFunction.moebius_apply_prime
 
 theorem moebius_apply_prime_pow {p k : ℕ} (hp : p.Prime) (hk : k ≠ 0) :
     μ (p ^ k) = if k = 1 then -1 else 0 := by
@@ -1051,7 +1051,7 @@ theorem moebius_apply_prime_pow {p k : ℕ} (hp : p.Prime) (hk : k ≠ 0) :
   rw [moebius_eq_zero_of_not_squarefree]
   rw [squarefree_pow_iff hp.ne_one hk, not_and_or]
   exact Or.inr h
-#align nat.arithmetic_function.moebius_apply_prime_pow Nat.ArithmeticFunction.moebius_apply_prime_pow
+#align nat.arithmetic_function.moebius_apply_prime_pow ArithmeticFunction.moebius_apply_prime_pow
 
 theorem moebius_apply_isPrimePow_not_prime {n : ℕ} (hn : IsPrimePow n) (hn' : ¬n.Prime) :
     μ n = 0 := by
@@ -1059,7 +1059,7 @@ theorem moebius_apply_isPrimePow_not_prime {n : ℕ} (hn : IsPrimePow n) (hn' : 
   rw [moebius_apply_prime_pow hp hk.ne', if_neg]
   rintro rfl
   exact hn' (by simpa)
-#align nat.arithmetic_function.moebius_apply_is_prime_pow_not_prime Nat.ArithmeticFunction.moebius_apply_isPrimePow_not_prime
+#align nat.arithmetic_function.moebius_apply_is_prime_pow_not_prime ArithmeticFunction.moebius_apply_isPrimePow_not_prime
 
 theorem isMultiplicative_moebius : IsMultiplicative μ := by
   rw [IsMultiplicative.iff_ne_zero]
@@ -1067,7 +1067,7 @@ theorem isMultiplicative_moebius : IsMultiplicative μ := by
   simp only [moebius, ZeroHom.coe_mk, coe_mk, ZeroHom.toFun_eq_coe, Eq.ndrec, ZeroHom.coe_mk,
     IsUnit.mul_iff, Nat.isUnit_iff, squarefree_mul hnm, ite_zero_mul_ite_zero,
     cardFactors_mul hn hm, pow_add]
-#align nat.arithmetic_function.is_multiplicative_moebius Nat.ArithmeticFunction.isMultiplicative_moebius
+#align nat.arithmetic_function.is_multiplicative_moebius ArithmeticFunction.isMultiplicative_moebius
 
 theorem IsMultiplicative.prodPrimeFactors_one_add_of_squarefree [CommSemiring R]
     {f : ArithmeticFunction R} (h_mult : f.IsMultiplicative) {n : ℕ} (hn : Squarefree n) :
@@ -1098,7 +1098,7 @@ theorem moebius_mul_coe_zeta : (μ * ζ : ArithmeticFunction ℤ) = 1 := by
   refine' recOnPosPrimePosCoprime _ _ _ _ n
   · intro p n hp hn
     rw [coe_mul_zeta_apply, sum_divisors_prime_pow hp, sum_range_succ']
-    simp_rw [pow_zero, moebius_apply_one,
+    simp_rw [Nat.pow_zero, moebius_apply_one,
       moebius_apply_prime_pow hp (Nat.succ_ne_zero _), Nat.succ_inj', sum_ite_eq', mem_range,
       if_pos hn, add_left_neg]
     rw [one_apply_ne]
@@ -1111,22 +1111,22 @@ theorem moebius_mul_coe_zeta : (μ * ζ : ArithmeticFunction ℤ) = 1 := by
     rw [IsMultiplicative.map_mul_of_coprime _ hab, ha', hb',
       IsMultiplicative.map_mul_of_coprime isMultiplicative_one hab]
     exact isMultiplicative_moebius.mul isMultiplicative_zeta.nat_cast
-#align nat.arithmetic_function.moebius_mul_coe_zeta Nat.ArithmeticFunction.moebius_mul_coe_zeta
+#align nat.arithmetic_function.moebius_mul_coe_zeta ArithmeticFunction.moebius_mul_coe_zeta
 
 @[simp]
 theorem coe_zeta_mul_moebius : (ζ * μ : ArithmeticFunction ℤ) = 1 := by
   rw [mul_comm, moebius_mul_coe_zeta]
-#align nat.arithmetic_function.coe_zeta_mul_moebius Nat.ArithmeticFunction.coe_zeta_mul_moebius
+#align nat.arithmetic_function.coe_zeta_mul_moebius ArithmeticFunction.coe_zeta_mul_moebius
 
 @[simp]
 theorem coe_moebius_mul_coe_zeta [Ring R] : (μ * ζ : ArithmeticFunction R) = 1 := by
   rw [← coe_coe, ← intCoe_mul, moebius_mul_coe_zeta, intCoe_one]
-#align nat.arithmetic_function.coe_moebius_mul_coe_zeta Nat.ArithmeticFunction.coe_moebius_mul_coe_zeta
+#align nat.arithmetic_function.coe_moebius_mul_coe_zeta ArithmeticFunction.coe_moebius_mul_coe_zeta
 
 @[simp]
 theorem coe_zeta_mul_coe_moebius [Ring R] : (ζ * μ : ArithmeticFunction R) = 1 := by
   rw [← coe_coe, ← intCoe_mul, coe_zeta_mul_moebius, intCoe_one]
-#align nat.arithmetic_function.coe_zeta_mul_coe_moebius Nat.ArithmeticFunction.coe_zeta_mul_coe_moebius
+#align nat.arithmetic_function.coe_zeta_mul_coe_moebius ArithmeticFunction.coe_zeta_mul_coe_moebius
 
 section CommRing
 
@@ -1140,17 +1140,17 @@ instance : Invertible (ζ : ArithmeticFunction R) where
 /-- A unit in `ArithmeticFunction R` that evaluates to `ζ`, with inverse `μ`. -/
 def zetaUnit : (ArithmeticFunction R)ˣ :=
   ⟨ζ, μ, coe_zeta_mul_coe_moebius, coe_moebius_mul_coe_zeta⟩
-#align nat.arithmetic_function.zeta_unit Nat.ArithmeticFunction.zetaUnit
+#align nat.arithmetic_function.zeta_unit ArithmeticFunction.zetaUnit
 
 @[simp]
 theorem coe_zetaUnit : ((zetaUnit : (ArithmeticFunction R)ˣ) : ArithmeticFunction R) = ζ :=
   rfl
-#align nat.arithmetic_function.coe_zeta_unit Nat.ArithmeticFunction.coe_zetaUnit
+#align nat.arithmetic_function.coe_zeta_unit ArithmeticFunction.coe_zetaUnit
 
 @[simp]
 theorem inv_zetaUnit : ((zetaUnit⁻¹ : (ArithmeticFunction R)ˣ) : ArithmeticFunction R) = μ :=
   rfl
-#align nat.arithmetic_function.inv_zeta_unit Nat.ArithmeticFunction.inv_zetaUnit
+#align nat.arithmetic_function.inv_zeta_unit ArithmeticFunction.inv_zetaUnit
 
 end CommRing
 
@@ -1171,7 +1171,7 @@ theorem sum_eq_iff_sum_smul_moebius_eq [AddCommGroup R] {f g : ℕ → R} :
       simp only [n.succ_ne_zero, forall_prop_of_true, succ_pos', if_false, ZeroHom.coe_mk]
       simp only [coe_mk, succ_ne_zero, ite_false]
       rw [sum_congr rfl fun x hx => ?_]
-      rw [if_neg (ne_of_gt (Nat.pos_of_mem_divisors hx))]
+      rw [if_neg (Nat.pos_of_mem_divisors hx).ne']
   trans μ • g' = f'
   · constructor <;> intro h
     · rw [← h, ← mul_smul, moebius_mul_coe_zeta, one_smul]
@@ -1187,8 +1187,8 @@ theorem sum_eq_iff_sum_smul_moebius_eq [AddCommGroup R] {f g : ℕ → R} :
       -- porting note: added following `simp only`
       simp only [Nat.isUnit_iff, coe_mk, ZeroHom.toFun_eq_coe, succ_ne_zero, ite_false]
       rw [sum_congr rfl fun x hx => ?_]
-      rw [if_neg (ne_of_gt (Nat.pos_of_mem_divisors (snd_mem_divisors_of_mem_antidiagonal hx)))]
-#align nat.arithmetic_function.sum_eq_iff_sum_smul_moebius_eq Nat.ArithmeticFunction.sum_eq_iff_sum_smul_moebius_eq
+      rw [if_neg (Nat.pos_of_mem_divisors (snd_mem_divisors_of_mem_antidiagonal hx)).ne']
+#align nat.arithmetic_function.sum_eq_iff_sum_smul_moebius_eq ArithmeticFunction.sum_eq_iff_sum_smul_moebius_eq
 
 /-- Möbius inversion for functions to a `Ring`. -/
 theorem sum_eq_iff_sum_mul_moebius_eq [Ring R] {f g : ℕ → R} :
@@ -1198,14 +1198,14 @@ theorem sum_eq_iff_sum_mul_moebius_eq [Ring R] {f g : ℕ → R} :
   apply forall_congr'
   refine' fun a => imp_congr_right fun _ => (sum_congr rfl fun x _hx => _).congr_left
   rw [zsmul_eq_mul]
-#align nat.arithmetic_function.sum_eq_iff_sum_mul_moebius_eq Nat.ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq
+#align nat.arithmetic_function.sum_eq_iff_sum_mul_moebius_eq ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq
 
 /-- Möbius inversion for functions to a `CommGroup`. -/
 theorem prod_eq_iff_prod_pow_moebius_eq [CommGroup R] {f g : ℕ → R} :
     (∀ n > 0, ∏ i in n.divisors, f i = g n) ↔
       ∀ n > 0, ∏ x : ℕ × ℕ in n.divisorsAntidiagonal, g x.snd ^ μ x.fst = f n :=
   @sum_eq_iff_sum_smul_moebius_eq (Additive R) _ _ _
-#align nat.arithmetic_function.prod_eq_iff_prod_pow_moebius_eq Nat.ArithmeticFunction.prod_eq_iff_prod_pow_moebius_eq
+#align nat.arithmetic_function.prod_eq_iff_prod_pow_moebius_eq ArithmeticFunction.prod_eq_iff_prod_pow_moebius_eq
 
 /-- Möbius inversion for functions to a `CommGroupWithZero`. -/
 theorem prod_eq_iff_prod_pow_moebius_eq_of_nonzero [CommGroupWithZero R] {f g : ℕ → R}
@@ -1231,7 +1231,7 @@ theorem prod_eq_iff_prod_pow_moebius_eq_of_nonzero [CommGroupWithZero R] {f g : 
     intro x hx
     rw [dif_pos (Nat.pos_of_mem_divisors (Nat.snd_mem_divisors_of_mem_antidiagonal hx)),
       Units.coeHom_apply, Units.val_zpow_eq_zpow_val, Units.val_mk0]
-#align nat.arithmetic_function.prod_eq_iff_prod_pow_moebius_eq_of_nonzero Nat.ArithmeticFunction.prod_eq_iff_prod_pow_moebius_eq_of_nonzero
+#align nat.arithmetic_function.prod_eq_iff_prod_pow_moebius_eq_of_nonzero ArithmeticFunction.prod_eq_iff_prod_pow_moebius_eq_of_nonzero
 
 /-- Möbius inversion for functions to an `AddCommGroup`, where the equalities only hold on a
 well-behaved set. -/
@@ -1322,5 +1322,3 @@ theorem prod_eq_iff_prod_pow_moebius_eq_on_of_nonzero [CommGroupWithZero R]
 end SpecialFunctions
 
 end ArithmeticFunction
-
-end Nat

--- a/Mathlib/NumberTheory/EulerProduct/Basic.lean
+++ b/Mathlib/NumberTheory/EulerProduct/Basic.lean
@@ -15,9 +15,9 @@ The main result in this file is `EulerProduct.eulerProduct`, which says that
 if `f : ℕ → R` is norm-summable, where `R` is a complete normed commutative ring and `f` is
 multiplicative on coprime arguments with `f 0 = 0`, then
 `∏ p in primesBelow N, ∑' e : ℕ, f (p^e)` tends to `∑' n, f n` as `N` tends to infinity.
-`Nat.ArithmeticFunction.IsMultiplicative.eulerProduct` is a version of
+`ArithmeticFunction.IsMultiplicative.eulerProduct` is a version of
 `EulerProduct.eulerProduct` for multiplicative arithmetic functions in the sense of
-`Nat.ArithmeticFunction.IsMultiplicative`.
+`ArithmeticFunction.IsMultiplicative`.
 
 There is also a version `EulerProduct.eulerProduct_completely_multiplicative`, which states that
 `∏ p in primesBelow N, (1 - f p)⁻¹` tends to `∑' n, f n` as `N` tends to infinity,
@@ -132,7 +132,7 @@ complete normed commutative ring `R`: if `‖f ·‖` is summable, then
 Since there are no infinite products yet in Mathlib, we state it in the form of
 convergence of finite partial products. -/
 -- TODO: Change to use `∏'` once infinite products are in Mathlib
-nonrec theorem _root_.Nat.ArithmeticFunction.IsMultiplicative.eulerProduct
+nonrec theorem _root_.ArithmeticFunction.IsMultiplicative.eulerProduct
     {f : ArithmeticFunction R} (hf : f.IsMultiplicative) (hsum : Summable (‖f ·‖)) :
     Tendsto (fun n : ℕ ↦ ∏ p in primesBelow n, ∑' e, f (p ^ e)) atTop (𝓝 (∑' n, f n)) :=
   eulerProduct hf.1 hf.2 hsum f.map_zero

--- a/Mathlib/NumberTheory/LSeries/Basic.lean
+++ b/Mathlib/NumberTheory/LSeries/Basic.lean
@@ -16,15 +16,15 @@ import Mathlib.Topology.Algebra.InfiniteSum.Basic
 Given an arithmetic function, we define the corresponding L-series.
 
 ## Main Definitions
- * `Nat.ArithmeticFunction.LSeries` is the `LSeries` with a given arithmetic function as its
+ * `ArithmeticFunction.LSeries` is the `LSeries` with a given arithmetic function as its
   coefficients. This is not the analytic continuation, just the infinite series.
- * `Nat.ArithmeticFunction.LSeriesSummable` indicates that the `LSeries`
+ * `ArithmeticFunction.LSeriesSummable` indicates that the `LSeries`
   converges at a given point.
 
 ## Main Results
- * `Nat.ArithmeticFunction.LSeriesSummable_of_bounded_of_one_lt_real`: the `LSeries` of a bounded
+ * `ArithmeticFunction.LSeriesSummable_of_bounded_of_one_lt_real`: the `LSeries` of a bounded
   arithmetic function converges when `1 < z.re`.
- * `Nat.ArithmeticFunction.zeta_LSeriesSummable_iff_one_lt_re`: the `LSeries` of `ζ`
+ * `ArithmeticFunction.zeta_LSeriesSummable_iff_one_lt_re`: the `LSeries` of `ζ`
   (whose analytic continuation is the Riemann ζ) converges iff `1 < z.re`.
 
 -/
@@ -34,29 +34,29 @@ noncomputable section
 
 open scoped BigOperators
 
-namespace Nat
-
 namespace ArithmeticFunction
+
+open Nat
 
 /-- The L-series of an `ArithmeticFunction`. -/
 def LSeries (f : ArithmeticFunction ℂ) (z : ℂ) : ℂ :=
   ∑' n, f n / n ^ z
-#align nat.arithmetic_function.l_series Nat.ArithmeticFunction.LSeries
+#align nat.arithmetic_function.l_series ArithmeticFunction.LSeries
 
 /-- `f.LSeriesSummable z` indicates that the L-series of `f` converges at `z`. -/
 def LSeriesSummable (f : ArithmeticFunction ℂ) (z : ℂ) : Prop :=
   Summable fun n => f n / n ^ z
-#align nat.arithmetic_function.l_series_summable Nat.ArithmeticFunction.LSeriesSummable
+#align nat.arithmetic_function.l_series_summable ArithmeticFunction.LSeriesSummable
 
 theorem LSeries_eq_zero_of_not_LSeriesSummable (f : ArithmeticFunction ℂ) (z : ℂ) :
     ¬f.LSeriesSummable z → f.LSeries z = 0 :=
   tsum_eq_zero_of_not_summable
-#align nat.arithmetic_function.l_series_eq_zero_of_not_l_series_summable Nat.ArithmeticFunction.LSeries_eq_zero_of_not_LSeriesSummable
+#align nat.arithmetic_function.l_series_eq_zero_of_not_l_series_summable ArithmeticFunction.LSeries_eq_zero_of_not_LSeriesSummable
 
 @[simp]
 theorem LSeriesSummable_zero {z : ℂ} : LSeriesSummable 0 z := by
   simp [LSeriesSummable, summable_zero]
-#align nat.arithmetic_function.l_series_summable_zero Nat.ArithmeticFunction.LSeriesSummable_zero
+#align nat.arithmetic_function.l_series_summable_zero ArithmeticFunction.LSeriesSummable_zero
 
 theorem LSeriesSummable_of_bounded_of_one_lt_real {f : ArithmeticFunction ℂ} {m : ℝ}
     (h : ∀ n : ℕ, Complex.abs (f n) ≤ m) {z : ℝ} (hz : 1 < z) : f.LSeriesSummable z := by
@@ -75,7 +75,7 @@ theorem LSeriesSummable_of_bounded_of_one_lt_real {f : ArithmeticFunction ℂ} {
     simp only [map_div₀, Complex.norm_eq_abs]
     apply div_le_div hm (h _) (Real.rpow_pos_of_pos (Nat.cast_pos.2 n.succ_pos) _) (le_of_eq _)
     rw [Complex.abs_cpow_real, Complex.abs_natCast]
-#align nat.arithmetic_function.l_series_summable_of_bounded_of_one_lt_real Nat.ArithmeticFunction.LSeriesSummable_of_bounded_of_one_lt_real
+#align nat.arithmetic_function.l_series_summable_of_bounded_of_one_lt_real ArithmeticFunction.LSeriesSummable_of_bounded_of_one_lt_real
 
 theorem LSeriesSummable_iff_of_re_eq_re {f : ArithmeticFunction ℂ} {w z : ℂ} (h : w.re = z.re) :
     f.LSeriesSummable w ↔ f.LSeriesSummable z := by
@@ -93,14 +93,14 @@ theorem LSeriesSummable_iff_of_re_eq_re {f : ArithmeticFunction ℂ} {w z : ℂ}
   right
   rw [Complex.log_im, ← Complex.ofReal_nat_cast]
   exact Complex.arg_ofReal_of_nonneg (le_of_lt (cast_pos.2 n.succ_pos))
-#align nat.arithmetic_function.l_series_summable_iff_of_re_eq_re Nat.ArithmeticFunction.LSeriesSummable_iff_of_re_eq_re
+#align nat.arithmetic_function.l_series_summable_iff_of_re_eq_re ArithmeticFunction.LSeriesSummable_iff_of_re_eq_re
 
 theorem LSeriesSummable_of_bounded_of_one_lt_re {f : ArithmeticFunction ℂ} {m : ℝ}
     (h : ∀ n : ℕ, Complex.abs (f n) ≤ m) {z : ℂ} (hz : 1 < z.re) : f.LSeriesSummable z := by
   rw [← LSeriesSummable_iff_of_re_eq_re (Complex.ofReal_re z.re)]
   apply LSeriesSummable_of_bounded_of_one_lt_real h
   exact hz
-#align nat.arithmetic_function.l_series_summable_of_bounded_of_one_lt_re Nat.ArithmeticFunction.LSeriesSummable_of_bounded_of_one_lt_re
+#align nat.arithmetic_function.l_series_summable_of_bounded_of_one_lt_re ArithmeticFunction.LSeriesSummable_of_bounded_of_one_lt_re
 
 open scoped ArithmeticFunction
 
@@ -118,7 +118,7 @@ theorem zeta_LSeriesSummable_iff_one_lt_re {z : ℂ} : LSeriesSummable ζ z ↔ 
     simp only [cast_zero, natCoe_apply, zeta_apply, succ_ne_zero, if_false, cast_succ, one_div,
       Complex.norm_eq_abs, map_inv₀, Complex.abs_cpow_real, inv_inj, zero_add]
     rw [← cast_one, ← cast_add, Complex.abs_natCast, cast_add, cast_one]
-#align nat.arithmetic_function.zeta_l_series_summable_iff_one_lt_re Nat.ArithmeticFunction.zeta_LSeriesSummable_iff_one_lt_re
+#align nat.arithmetic_function.zeta_l_series_summable_iff_one_lt_re ArithmeticFunction.zeta_LSeriesSummable_iff_one_lt_re
 
 @[simp]
 theorem LSeries_add {f g : ArithmeticFunction ℂ} {z : ℂ} (hf : f.LSeriesSummable z)
@@ -127,8 +127,6 @@ theorem LSeries_add {f g : ArithmeticFunction ℂ} {z : ℂ} (hf : f.LSeriesSumm
   rw [← tsum_add hf hg]
   apply congr rfl (funext fun n => _)
   simp [_root_.add_div]
-#align nat.arithmetic_function.l_series_add Nat.ArithmeticFunction.LSeries_add
+#align nat.arithmetic_function.l_series_add ArithmeticFunction.LSeries_add
 
 end ArithmeticFunction
-
-end Nat

--- a/Mathlib/NumberTheory/VonMangoldt.lean
+++ b/Mathlib/NumberTheory/VonMangoldt.lean
@@ -19,12 +19,12 @@ In this file we define the von Mangoldt function: the function on natural number
 
 The main definition for this file is
 
-- `Nat.ArithmeticFunction.vonMangoldt`: The von Mangoldt function `Λ`.
+- `ArithmeticFunction.vonMangoldt`: The von Mangoldt function `Λ`.
 
 We then prove the classical summation property of the von Mangoldt function in
-`Nat.ArithmeticFunction.vonMangoldt_sum`, that `∑ i in n.divisors, Λ i = Real.log n`, and use this
+`ArithmeticFunction.vonMangoldt_sum`, that `∑ i in n.divisors, Λ i = Real.log n`, and use this
 to deduce alternative expressions for the von Mangoldt function via Möbius inversion, see
-`Nat.ArithmeticFunction.sum_moebius_mul_log_eq`.
+`ArithmeticFunction.sum_moebius_mul_log_eq`.
 
 ## Notation
 
@@ -32,26 +32,23 @@ We use the standard notation `Λ` to represent the von Mangoldt function.
 
 -/
 
-
-namespace Nat
-
 namespace ArithmeticFunction
 
-open Finset
+open Finset Nat
 
 open scoped ArithmeticFunction
 
-/-- `log` as an arithmetic function `ℕ → ℝ`. Note this is in the `Nat.ArithmeticFunction`
+/-- `log` as an arithmetic function `ℕ → ℝ`. Note this is in the `ArithmeticFunction`
 namespace to indicate that it is bundled as an `ArithmeticFunction` rather than being the usual
 real logarithm. -/
 noncomputable def log : ArithmeticFunction ℝ :=
   ⟨fun n => Real.log n, by simp⟩
-#align nat.arithmetic_function.log Nat.ArithmeticFunction.log
+#align nat.arithmetic_function.log ArithmeticFunction.log
 
 @[simp]
 theorem log_apply {n : ℕ} : log n = Real.log n :=
   rfl
-#align nat.arithmetic_function.log_apply Nat.ArithmeticFunction.log_apply
+#align nat.arithmetic_function.log_apply ArithmeticFunction.log_apply
 
 /--
 The `vonMangoldt` function is the function on natural numbers that returns `log p` if the input can
@@ -63,17 +60,17 @@ In the `ArithmeticFunction` locale, we have the notation `Λ` for this function.
 -/
 noncomputable def vonMangoldt : ArithmeticFunction ℝ :=
   ⟨fun n => if IsPrimePow n then Real.log (minFac n) else 0, if_neg not_isPrimePow_zero⟩
-#align nat.arithmetic_function.von_mangoldt Nat.ArithmeticFunction.vonMangoldt
+#align nat.arithmetic_function.von_mangoldt ArithmeticFunction.vonMangoldt
 
-@[inherit_doc] scoped[Nat.ArithmeticFunction] notation "Λ" => Nat.ArithmeticFunction.vonMangoldt
+@[inherit_doc] scoped[ArithmeticFunction] notation "Λ" => ArithmeticFunction.vonMangoldt
 
 theorem vonMangoldt_apply {n : ℕ} : Λ n = if IsPrimePow n then Real.log (minFac n) else 0 :=
   rfl
-#align nat.arithmetic_function.von_mangoldt_apply Nat.ArithmeticFunction.vonMangoldt_apply
+#align nat.arithmetic_function.von_mangoldt_apply ArithmeticFunction.vonMangoldt_apply
 
 @[simp]
 theorem vonMangoldt_apply_one : Λ 1 = 0 := by simp [vonMangoldt_apply]
-#align nat.arithmetic_function.von_mangoldt_apply_one Nat.ArithmeticFunction.vonMangoldt_apply_one
+#align nat.arithmetic_function.von_mangoldt_apply_one ArithmeticFunction.vonMangoldt_apply_one
 
 @[simp]
 theorem vonMangoldt_nonneg {n : ℕ} : 0 ≤ Λ n := by
@@ -81,28 +78,28 @@ theorem vonMangoldt_nonneg {n : ℕ} : 0 ≤ Λ n := by
   split_ifs
   · exact Real.log_nonneg (one_le_cast.2 (Nat.minFac_pos n))
   rfl
-#align nat.arithmetic_function.von_mangoldt_nonneg Nat.ArithmeticFunction.vonMangoldt_nonneg
+#align nat.arithmetic_function.von_mangoldt_nonneg ArithmeticFunction.vonMangoldt_nonneg
 
 theorem vonMangoldt_apply_pow {n k : ℕ} (hk : k ≠ 0) : Λ (n ^ k) = Λ n := by
   simp only [vonMangoldt_apply, isPrimePow_pow_iff hk, pow_minFac hk]
-#align nat.arithmetic_function.von_mangoldt_apply_pow Nat.ArithmeticFunction.vonMangoldt_apply_pow
+#align nat.arithmetic_function.von_mangoldt_apply_pow ArithmeticFunction.vonMangoldt_apply_pow
 
 theorem vonMangoldt_apply_prime {p : ℕ} (hp : p.Prime) : Λ p = Real.log p := by
   rw [vonMangoldt_apply, Prime.minFac_eq hp, if_pos hp.prime.isPrimePow]
-#align nat.arithmetic_function.von_mangoldt_apply_prime Nat.ArithmeticFunction.vonMangoldt_apply_prime
+#align nat.arithmetic_function.von_mangoldt_apply_prime ArithmeticFunction.vonMangoldt_apply_prime
 
 theorem vonMangoldt_ne_zero_iff {n : ℕ} : Λ n ≠ 0 ↔ IsPrimePow n := by
   rcases eq_or_ne n 1 with (rfl | hn); · simp [not_isPrimePow_one]
   exact (Real.log_pos (one_lt_cast.2 (minFac_prime hn).one_lt)).ne'.ite_ne_right_iff
-#align nat.arithmetic_function.von_mangoldt_ne_zero_iff Nat.ArithmeticFunction.vonMangoldt_ne_zero_iff
+#align nat.arithmetic_function.von_mangoldt_ne_zero_iff ArithmeticFunction.vonMangoldt_ne_zero_iff
 
 theorem vonMangoldt_pos_iff {n : ℕ} : 0 < Λ n ↔ IsPrimePow n :=
   vonMangoldt_nonneg.lt_iff_ne.trans (ne_comm.trans vonMangoldt_ne_zero_iff)
-#align nat.arithmetic_function.von_mangoldt_pos_iff Nat.ArithmeticFunction.vonMangoldt_pos_iff
+#align nat.arithmetic_function.von_mangoldt_pos_iff ArithmeticFunction.vonMangoldt_pos_iff
 
 theorem vonMangoldt_eq_zero_iff {n : ℕ} : Λ n = 0 ↔ ¬IsPrimePow n :=
   vonMangoldt_ne_zero_iff.not_right
-#align nat.arithmetic_function.von_mangoldt_eq_zero_iff Nat.ArithmeticFunction.vonMangoldt_eq_zero_iff
+#align nat.arithmetic_function.von_mangoldt_eq_zero_iff ArithmeticFunction.vonMangoldt_eq_zero_iff
 
 open scoped BigOperators
 
@@ -110,7 +107,7 @@ theorem vonMangoldt_sum {n : ℕ} : ∑ i in n.divisors, Λ i = Real.log n := by
   refine' recOnPrimeCoprime _ _ _ n
   · simp
   · intro p k hp
-    rw [sum_divisors_prime_pow hp, cast_pow, Real.log_pow, Finset.sum_range_succ', pow_zero,
+    rw [sum_divisors_prime_pow hp, cast_pow, Real.log_pow, Finset.sum_range_succ', Nat.pow_zero,
       vonMangoldt_apply_one]
     simp [vonMangoldt_apply_pow (Nat.succ_ne_zero _), vonMangoldt_apply_prime hp]
   intro a b ha' hb' hab ha hb
@@ -118,26 +115,26 @@ theorem vonMangoldt_sum {n : ℕ} : ∑ i in n.divisors, Λ i = Real.log n := by
   rw [mul_divisors_filter_prime_pow hab, filter_union,
     sum_union (disjoint_divisors_filter_isPrimePow hab), ha, hb, Nat.cast_mul,
     Real.log_mul (cast_ne_zero.2 (pos_of_gt ha').ne') (cast_ne_zero.2 (pos_of_gt hb').ne')]
-#align nat.arithmetic_function.von_mangoldt_sum Nat.ArithmeticFunction.vonMangoldt_sum
+#align nat.arithmetic_function.von_mangoldt_sum ArithmeticFunction.vonMangoldt_sum
 
 @[simp]
 theorem vonMangoldt_mul_zeta : Λ * ζ = log := by
   ext n; rw [coe_mul_zeta_apply, vonMangoldt_sum]; rfl
-#align nat.arithmetic_function.von_mangoldt_mul_zeta Nat.ArithmeticFunction.vonMangoldt_mul_zeta
+#align nat.arithmetic_function.von_mangoldt_mul_zeta ArithmeticFunction.vonMangoldt_mul_zeta
 
 @[simp]
 theorem zeta_mul_vonMangoldt : (ζ : ArithmeticFunction ℝ) * Λ = log := by rw [mul_comm]; simp
-#align nat.arithmetic_function.zeta_mul_von_mangoldt Nat.ArithmeticFunction.zeta_mul_vonMangoldt
+#align nat.arithmetic_function.zeta_mul_von_mangoldt ArithmeticFunction.zeta_mul_vonMangoldt
 
 @[simp]
 theorem log_mul_moebius_eq_vonMangoldt : log * μ = Λ := by
   rw [← vonMangoldt_mul_zeta, mul_assoc, coe_zeta_mul_coe_moebius, mul_one]
-#align nat.arithmetic_function.log_mul_moebius_eq_von_mangoldt Nat.ArithmeticFunction.log_mul_moebius_eq_vonMangoldt
+#align nat.arithmetic_function.log_mul_moebius_eq_von_mangoldt ArithmeticFunction.log_mul_moebius_eq_vonMangoldt
 
 @[simp]
 theorem moebius_mul_log_eq_vonMangoldt : (μ : ArithmeticFunction ℝ) * log = Λ := by
   rw [mul_comm]; simp
-#align nat.arithmetic_function.moebius_mul_log_eq_von_mangoldt Nat.ArithmeticFunction.moebius_mul_log_eq_vonMangoldt
+#align nat.arithmetic_function.moebius_mul_log_eq_von_mangoldt ArithmeticFunction.moebius_mul_log_eq_vonMangoldt
 
 theorem sum_moebius_mul_log_eq {n : ℕ} : (∑ d in n.divisors, (μ d : ℝ) * log d) = -Λ n := by
   simp only [← log_mul_moebius_eq_vonMangoldt, mul_comm log, mul_apply, log_apply, intCoe_apply, ←
@@ -156,7 +153,7 @@ theorem sum_moebius_mul_log_eq {n : ℕ} : (∑ d in n.divisors, (μ d : ℝ) * 
   rw [this, sum_sub_distrib, ← sum_mul, ← Int.cast_sum, ← coe_mul_zeta_apply, eq_comm, sub_eq_self,
     moebius_mul_coe_zeta]
   rcases eq_or_ne n 1 with (hn | hn) <;> simp [hn]
-#align nat.arithmetic_function.sum_moebius_mul_log_eq Nat.ArithmeticFunction.sum_moebius_mul_log_eq
+#align nat.arithmetic_function.sum_moebius_mul_log_eq ArithmeticFunction.sum_moebius_mul_log_eq
 
 theorem vonMangoldt_le_log : ∀ {n : ℕ}, Λ n ≤ Real.log (n : ℝ)
   | 0 => by simp
@@ -164,8 +161,6 @@ theorem vonMangoldt_le_log : ∀ {n : ℕ}, Λ n ≤ Real.log (n : ℝ)
     rw [← vonMangoldt_sum]
     exact single_le_sum (by exact fun _ _ => vonMangoldt_nonneg)
       (mem_divisors_self _ n.succ_ne_zero)
-#align nat.arithmetic_function.von_mangoldt_le_log Nat.ArithmeticFunction.vonMangoldt_le_log
+#align nat.arithmetic_function.von_mangoldt_le_log ArithmeticFunction.vonMangoldt_le_log
 
 end ArithmeticFunction
-
-end Nat

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Basic.lean
@@ -455,9 +455,9 @@ set_option linter.uppercaseLean3 false in
 
 section ArithmeticFunction
 
-open Nat.ArithmeticFunction
+open ArithmeticFunction
 
-open scoped Nat.ArithmeticFunction
+open scoped ArithmeticFunction
 
 /-- `cyclotomic n R` can be expressed as a product in a fraction field of `R[X]`
   using Möbius inversion. -/

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -130,7 +130,7 @@ General algebra:
     quadratic reciprocity: 'legendreSym.quadratic_reciprocity'
     "solutions to Pell's equation": 'Pell.pell'
     "Matiyasevič's theorem": 'Pell.matiyasevic'
-    arithmetic functions: 'Nat.ArithmeticFunction'
+    arithmetic functions: 'ArithmeticFunction'
     Bernoulli numbers: 'bernoulli'
     Chevalley-Warning theorem: 'char_dvd_card_solutions'
     "Hensel's lemma (for $\\mathbb{Z}_p$)": 'hensels_lemma'


### PR DESCRIPTION
This changes `Nat.ArithmeticFunction` to `ArithmeticFunction` since the `Nat` part seems redundant.

See [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Nat.2EArithmeticFunction.20--.3E.20ArithmeticFunction/near/420713063) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
