### PR TITLE
feat(CategoryTheory/WithTerminal): Add equivalence of categories.

### DIFF
--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -19,7 +19,7 @@ The terminal resp. initial object is `WithTerminal.star` resp. `WithInitial.star
 the proofs that these are terminal resp. initial are in `WithTerminal.star_terminal`
 and `WithInitial.star_initial`.
 
-The inclusion from `C` intro `WithTerminal C` resp. `WithInitial C` is denoted
+The inclusion from `C` into `WithTerminal C` resp. `WithInitial C` is denoted
 `WithTerminal.incl` resp. `WithInitial.incl`.
 
 The relevant constructions needed for the universal properties of these constructions are:
@@ -31,6 +31,22 @@ The relevant constructions needed for the universal properties of these construc
 
 In addition to this, we provide `WithTerminal.map` and `WithInitial.map` providing the
 functoriality of these constructions with respect to functors on the base categories.
+We define `WithTerminal.mapNatTrans` and `WithInitial.mapNatTrans` which map natural transformations
+with respect to theses constructions.
+
+The maps `WithTerminal.map` and `WithTerminal.mapNatTrans` are combined into a functor
+`WithTerminal.mapFunc` and `WithInitial.map` and `WithInitial.mapNatTrans` are combined into the
+functor `WitInitial.mapFunc`.
+
+Given an equivalence `C≌D` we provide an equivalance  `WithTerminal C ≌ WithTerminal D` and
+`WithInitial C ≌ WithInitial D`.
+
+We provide an equivalence between:
+- `WithTerminal C⥤ D` and the comma category `Comma (𝟭 (C ⥤ D)) (Functor.const C)`
+- `WithInitial C⥤ D` and the comma category `Comma (Functor.const C) (𝟭 (C ⥤ D))`
+- `WithTerminal Cᵒᵖ` and `(WithInitial C)ᵒᵖ`
+- `WithInitial Cᵒᵖ` and `(WithTerminal C)ᵒᵖ`
+
 
 -/
 
@@ -137,7 +153,37 @@ def map {D : Type*} [Category D] (F : C ⥤ D) : WithTerminal C ⥤ WithTerminal
     | of _, star, _ => PUnit.unit
     | star, star, _ => PUnit.unit
 #align category_theory.with_terminal.map CategoryTheory.WithTerminal.map
-
+/-- `map` preserves identities.-/
+theorem map_id (D : Type*) [Category D]  : map (𝟭  D) = 𝟭 (WithTerminal D) := by
+  unfold map
+  apply Functor.ext
+  intro X Y f
+  match X, Y, f with
+  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
+    Category.id_comp]
+                     rfl
+  | of x, star, _ => rfl
+  | star, star, _ => rfl
+  intro X
+  match X with
+  | of x => rfl
+  | star => rfl
+/-- `map` preserves compositions.-/
+theorem map_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
+    map (F⋙G) = (map F )⋙ (map G) := by
+  unfold map
+  apply Functor.ext
+  intro X Y f
+  match X, Y, f with
+  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
+    Category.id_comp]
+                     rfl
+  | of x, star, _ => rfl
+  | star, star, _ => rfl
+  intro X
+  match X with
+  | of x => rfl
+  | star => rfl
 instance {X : WithTerminal C} : Unique (X ⟶ star) where
   default :=
     match X with
@@ -339,54 +385,11 @@ def equivToComma  {D : Type*} [Category D] :
     ({ hom := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G)}
        inv := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G).symm }})
 
-/--From a functor `C⥤D`, the induced `WithTerminal C⥤ WithTerminal D`.-/
-def extendFunctor {D : Type*} [Category D]  (F: C ⥤ D) : WithTerminal C ⥤  WithTerminal D where
-  obj  := fun X =>
-        match X with
-        | of x => of (F.obj x)
-        | star => star
-  map := fun {X Y} f =>
-        match X, Y, f with
-        | of x, of y, f => F.map (down f)
-        | of x, star, _ => starTerminal.from (of (F.obj x))
-        | star, star, _ => 𝟙 _
-
-/--The map  `extendFunctor` preserves identities.-/
-theorem extendFunctor_id (D : Type*) [Category D]  : extendFunctor (𝟭  D) = 𝟭 (WithTerminal D) := by
-  unfold extendFunctor
-  apply Functor.ext
-  intro X Y f
-  match X, Y, f with
-  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
-    Category.id_comp]
-                     rfl
-  | of x, star, _ => rfl
-  | star, star, _ => rfl
-  intro X
-  match X with
-  | of x => rfl
-  | star => rfl
-
-theorem extendFunctor_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
-    extendFunctor (F⋙G) = (extendFunctor F )⋙ (extendFunctor G) := by
-  unfold extendFunctor
-  apply Functor.ext
-  intro X Y f
-  match X, Y, f with
-  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
-    Category.id_comp]
-                     rfl
-  | of x, star, _ => rfl
-  | star, star, _ => rfl
-  intro X
-  match X with
-  | of x => rfl
-  | star => rfl
 
 /--From a natrual transformation of functors `C⥤D`, the induced natural transformation
 of functors `WithTerminal C⥤ WithTerminal D` -/
-def extendNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
-    extendFunctor F ⟶ extendFunctor G where
+def mapNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
+    map F ⟶ map G where
   app := fun X =>
         match X with
         | of x => η.app x
@@ -399,18 +402,18 @@ def extendNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
           | star, star, _ => rfl
 
 /--The functor taking `C⥤D` to `WithTerminal C ⥤ WithTerminal D`.-/
-def extendFuncCat  {D : Type*} [Category D]  : (C⥤D)⥤ (WithTerminal C ⥤ WithTerminal D) where
-  obj:= extendFunctor
-  map:= extendNatTrans
+def mapFunc  {D : Type*} [Category D]  : (C⥤D)⥤ (WithTerminal C ⥤ WithTerminal D) where
+  obj:= map
+  map:= mapNatTrans
 
 /--The extension of an equivalance `C ≌ D` to an equivalance `WithTerminal C ≌ WithTerminal D `.-/
-def extendEquiv {D : Type*} [Category D]  (e: C ≌ D) : WithTerminal C ≌ WithTerminal D :=
-  Equivalence.mk (extendFunctor e.functor) (extendFunctor e.inverse)
-   ((eqToIso (extendFunctor_id C).symm).trans
- ((Functor.mapIso extendFuncCat e.unitIso).trans
-  (eqToIso (extendFunctor_comp e.functor e.inverse))))
-    ( (eqToIso (extendFunctor_comp e.inverse e.functor).symm).trans
-          ((Functor.mapIso extendFuncCat e.counitIso).trans (eqToIso (extendFunctor_id D))))
+def mapEquiv {D : Type*} [Category D]  (e: C ≌ D) : WithTerminal C ≌ WithTerminal D :=
+  Equivalence.mk (map e.functor) (map e.inverse)
+   ((eqToIso (map_id C).symm).trans
+ ((Functor.mapIso mapFunc e.unitIso).trans
+  (eqToIso (map_comp e.functor e.inverse))))
+    ( (eqToIso (map_comp e.inverse e.functor).symm).trans
+          ((Functor.mapIso mapFunc e.counitIso).trans (eqToIso (map_id D))))
 
 
 
@@ -495,6 +498,37 @@ def map {D : Type*} [Category D] (F : C ⥤ D) : WithInitial C ⥤ WithInitial D
     | star, star, _ => PUnit.unit
 
 #align category_theory.with_initial.map CategoryTheory.WithInitial.map
+/--`map` preserves identities.-/
+theorem map_id (D : Type*) [Category D]  : map (𝟭  D) = 𝟭 (WithInitial D) := by
+  unfold map
+  apply Functor.ext
+  intro X Y f
+  match X, Y, f with
+  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
+    Category.id_comp]
+                     rfl
+  | star, of x, _ => rfl
+  | star, star, _ => rfl
+  intro X
+  match X with
+  | of x => rfl
+  | star => rfl
+/--`map` preserves compositions.-/
+theorem map_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
+    map (F⋙G) = (map F )⋙ (map G) := by
+  unfold map
+  apply Functor.ext
+  intro X Y f
+  match X, Y, f with
+  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
+    Category.id_comp]
+                     rfl
+  | star, of x,  _ => rfl
+  | star, star, _ => rfl
+  intro X
+  match X with
+  | of x => rfl
+  | star => rfl
 
 instance {X : WithInitial C} : Unique (star ⟶ X) where
   default :=
@@ -701,55 +735,13 @@ def equivToComma  {D : Type*} [Category D] :
     ({ hom := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G)}
        inv := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G).symm }})
 
-/--From a functor `C⥤D`, the induced `WithInitial C⥤ WithInitial D`.-/
-def extendFunctor {D : Type*} [Category D]  (F: C ⥤ D) : WithInitial C ⥤  WithInitial D where
-  obj  := fun X =>
-        match X with
-        | of x => of (F.obj x)
-        | star => star
-  map := fun {X Y} f =>
-        match X, Y, f with
-        | of x, of y, f => F.map (down f)
-        | star, of x, _ => starInitial.to (of (F.obj x))
-        | star, star, _ => 𝟙 _
 
-/--The map `extendFunctor` preserves identities.-/
-theorem extendFunctor_id (D : Type*) [Category D]  : extendFunctor (𝟭  D) = 𝟭 (WithInitial D) := by
-  unfold extendFunctor
-  apply Functor.ext
-  intro X Y f
-  match X, Y, f with
-  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
-    Category.id_comp]
-                     rfl
-  | star, of x, _ => rfl
-  | star, star, _ => rfl
-  intro X
-  match X with
-  | of x => rfl
-  | star => rfl
 
-/--The map `extendFunctor` preserves compositions.-/
-theorem extendFunctor_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
-    extendFunctor (F⋙G) = (extendFunctor F )⋙ (extendFunctor G) := by
-  unfold extendFunctor
-  apply Functor.ext
-  intro X Y f
-  match X, Y, f with
-  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
-    Category.id_comp]
-                     rfl
-  | star, of x,  _ => rfl
-  | star, star, _ => rfl
-  intro X
-  match X with
-  | of x => rfl
-  | star => rfl
 
 /--From a natrual transformation of functors `C⥤D`, the induced natural transformation
 of functors `WithInitial C⥤ WithInitial D` -/
-def extendNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
-    extendFunctor F ⟶ extendFunctor G where
+def mapNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
+    map F ⟶ map G where
   app := fun X =>
         match X with
         | of x => η.app x
@@ -762,19 +754,19 @@ def extendNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
           | star, star, _ => rfl
 
 /--The functor taking `C⥤D` to `WithInitial C ⥤ WithInitial D`.-/
-def extendFuncCat  {D : Type*} [Category D]  : (C⥤D)⥤ (WithInitial C ⥤ WithInitial D) where
-  obj:= extendFunctor
-  map:= extendNatTrans
+def mapFunc  {D : Type*} [Category D]  : (C⥤D)⥤ (WithInitial C ⥤ WithInitial D) where
+  obj:= map
+  map:= mapNatTrans
 
 /--Given an equivalence between two categories `C` and `D` we get an equivalance between the
 categories  `WithInitial C` and  `WithInitial D  `.-/
-def extendEquiv {D : Type*} [Category D]  (e: C ≌ D) : WithInitial C ≌ WithInitial D :=
-  Equivalence.mk (extendFunctor e.functor) (extendFunctor e.inverse)
-   ((eqToIso (extendFunctor_id C).symm).trans
- ((Functor.mapIso extendFuncCat  e.unitIso).trans
-   (eqToIso (extendFunctor_comp e.functor e.inverse))))
-    ( (eqToIso (extendFunctor_comp e.inverse e.functor).symm).trans
-          ((Functor.mapIso extendFuncCat e.counitIso).trans (eqToIso (extendFunctor_id D))))
+def mapEquiv {D : Type*} [Category D]  (e: C ≌ D) : WithInitial C ≌ WithInitial D :=
+  Equivalence.mk (map e.functor) (map e.inverse)
+   ((eqToIso (map_id C).symm).trans
+ ((Functor.mapIso mapFunc  e.unitIso).trans
+   (eqToIso (map_comp e.functor e.inverse))))
+    ( (eqToIso (map_comp e.inverse e.functor).symm).trans
+          ((Functor.mapIso mapFunc e.counitIso).trans (eqToIso (map_id D))))
 
 
 
@@ -825,7 +817,6 @@ def WithTerminal.op_to_op' : (WithTerminal C)ᵒᵖ ⥤ (WithInitial Cᵒᵖ) wh
      cases X; cases Y; cases Z; cases f; cases g;
      rename_i Xp Yp Zp fp gp
      rw [unop_op,unop_op] at fp gp
-     simp only [unop_op, unop_comp]
      aesop_cat
 
 /--A functor from `(WithInitial C)ᵒᵖ ` to `WithTerminal Cᵒᵖ`.-/
@@ -841,7 +832,6 @@ def WithInitial.op_to_op' : (WithInitial C)ᵒᵖ ⥤ (WithTerminal Cᵒᵖ) whe
      cases X; cases Y; cases Z; cases f; cases g;
      rename_i Xp Yp Zp fp gp
      rw [unop_op,unop_op] at fp gp
-     simp only [unop_op, unop_comp]
      aesop_cat
 
 /--A functor from `WithInitial Cᵒᵖ` to  `(WithTerminal C)ᵒᵖ `.-/
@@ -906,7 +896,7 @@ def equivWithInitialOfOpWithTerminalOp (C : Type*) [Category C]:
     }
   }
 
-/--An equivalance between the categories `WithInitial Cᵒᵖ` and  `(WithTerminal C)ᵒᵖ`.-/
+/--An equivalance between the categories `WithTerminal Cᵒᵖ` and  `(WithInitial C)ᵒᵖ`.-/
 def equivWithTerminalOfOpWithInitialOp (C : Type*) [Category C]:
     WithTerminal Cᵒᵖ  ≌ (WithInitial C)ᵒᵖ  where
   functor := WithInitial.op'_to_op

--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -340,7 +340,7 @@ def equivToComma  {D : Type*} [Category D] :
        inv := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G).symm }})
 
 /--From a functor `C⥤D`, the induced `WithTerminal C⥤ WithTerminal D`.-/
-def liftFunctor {D : Type*} [Category D]  (F: C ⥤ D) : WithTerminal C ⥤  WithTerminal D where
+def extendFunctor {D : Type*} [Category D]  (F: C ⥤ D) : WithTerminal C ⥤  WithTerminal D where
   obj  := fun X =>
         match X with
         | of x => of (F.obj x)
@@ -352,8 +352,8 @@ def liftFunctor {D : Type*} [Category D]  (F: C ⥤ D) : WithTerminal C ⥤  Wit
         | star, star, _ => 𝟙 _
 
 /--The map  `extendFunctor` preserves identities.-/
-theorem liftFunctor_id (D : Type*) [Category D]  : liftFunctor (𝟭  D) = 𝟭 (WithTerminal D) := by
-  unfold liftFunctor
+theorem extendFunctor_id (D : Type*) [Category D]  : extendFunctor (𝟭  D) = 𝟭 (WithTerminal D) := by
+  unfold extendFunctor
   apply Functor.ext
   intro X Y f
   match X, Y, f with
@@ -367,9 +367,9 @@ theorem liftFunctor_id (D : Type*) [Category D]  : liftFunctor (𝟭  D) = 𝟭 
   | of x => rfl
   | star => rfl
 
-theorem liftFunctor_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
-    liftFunctor (F⋙G) = (liftFunctor F )⋙ (liftFunctor G) := by
-  unfold liftFunctor
+theorem extendFunctor_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
+    extendFunctor (F⋙G) = (extendFunctor F )⋙ (extendFunctor G) := by
+  unfold extendFunctor
   apply Functor.ext
   intro X Y f
   match X, Y, f with
@@ -385,8 +385,8 @@ theorem liftFunctor_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : 
 
 /--From a natrual transformation of functors `C⥤D`, the induced natural transformation
 of functors `WithTerminal C⥤ WithTerminal D` -/
-def liftNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
-    liftFunctor F ⟶ liftFunctor G where
+def extendNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
+    extendFunctor F ⟶ extendFunctor G where
   app := fun X =>
         match X with
         | of x => η.app x
@@ -397,28 +397,30 @@ def liftNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
           | of x, of y, f => exact η.naturality f
           | of x, star, _ => rfl
           | star, star, _ => rfl
-
-theorem  liftNatTrans_id  {D : Type*} [Category D]  {F : C ⥤ D}  :
-    liftNatTrans (𝟙 (F)) = 𝟙 (liftFunctor F):= by
+/--The map `extendNatTrans` preserves identities between fuctors.-/
+theorem  extendNatTrans_id  {D : Type*} [Category D]  {F : C ⥤ D}  :
+    extendNatTrans (𝟙 (F)) = 𝟙 (extendFunctor F):= by
   aesop_cat
-theorem  liftNatTrans_comp   {D : Type*} [Category D]  {F G H : C ⥤ D} (η : F⟶ G) (μ : G⟶ H) :
-    liftNatTrans (η ≫ μ ) = liftNatTrans η≫ liftNatTrans μ  := by
+/--The map `extendNatTrans` preserves horizontal compositions of natural transformations.-/
+theorem  extendNatTrans_comp   {D : Type*} [Category D]  {F G H : C ⥤ D} (η : F⟶ G) (μ : G⟶ H) :
+    extendNatTrans (η ≫ μ ) = extendNatTrans η≫ extendNatTrans μ  := by
   aesop_cat
 
-def liftFuncIso {D : Type*} [Category D] {F G: C⥤ D} (η : F ≅ G) :
-    liftFunctor F ≅ liftFunctor G where
-  hom := liftNatTrans η.hom
-  inv := liftNatTrans η.inv
-  hom_inv_id := by rw [← liftNatTrans_comp,η.hom_inv_id,liftNatTrans_id]
-  inv_hom_id := by rw [← liftNatTrans_comp,η.inv_hom_id,liftNatTrans_id]
+/--The extension of a natural isomorphism between functors.-/
+def extendFuncIso {D : Type*} [Category D] {F G: C⥤ D} (η : F ≅ G) :
+    extendFunctor F ≅ extendFunctor G where
+  hom := extendNatTrans η.hom
+  inv := extendNatTrans η.inv
+  hom_inv_id := by rw [← extendNatTrans_comp,η.hom_inv_id,extendNatTrans_id]
+  inv_hom_id := by rw [← extendNatTrans_comp,η.inv_hom_id,extendNatTrans_id]
 
-
-def liftEquiv {D : Type*} [Category D]  (e: C ≌ D) : WithTerminal C ≌ WithTerminal D :=
-  Equivalence.mk (liftFunctor e.functor) (liftFunctor e.inverse)
-   ((eqToIso (liftFunctor_id C).symm).trans
- ((liftFuncIso e.unitIso).trans (eqToIso (liftFunctor_comp e.functor e.inverse))))
-    ( (eqToIso (liftFunctor_comp e.inverse e.functor).symm).trans
-          ((liftFuncIso e.counitIso).trans (eqToIso (liftFunctor_id D))))
+/--The extension of an equivalance `C ≌ D` to an equivalance `WithTerminal C ≌ WithTerminal D `.-/
+def extendEquiv {D : Type*} [Category D]  (e: C ≌ D) : WithTerminal C ≌ WithTerminal D :=
+  Equivalence.mk (extendFunctor e.functor) (extendFunctor e.inverse)
+   ((eqToIso (extendFunctor_id C).symm).trans
+ ((extendFuncIso e.unitIso).trans (eqToIso (extendFunctor_comp e.functor e.inverse))))
+    ( (eqToIso (extendFunctor_comp e.inverse e.functor).symm).trans
+          ((extendFuncIso e.counitIso).trans (eqToIso (extendFunctor_id D))))
 
 
 
@@ -700,7 +702,7 @@ def natTransFromCommaHom {D : Type*} [Category D]  {c1 c2: Comma (Functor.const 
 /--An equivalence of categoryes between the catgory of functors `(WithInitial C ⥤ D)` and
 the comma category `Comma (Functor.const C) (𝟭 (C ⥤ D))`.-/
 def equivToComma  {D : Type*} [Category D] :
-     (WithInitial C ⥤ D) ≌  Comma (Functor.const C) (𝟭 (C ⥤ D)) :=
+    (WithInitial C ⥤ D) ≌  Comma (Functor.const C) (𝟭 (C ⥤ D)) :=
   Equivalence.mk
     ({ obj := commaFromFunc, map := commHomFromNatTrans})
     ({ obj := funcFromComma, map := natTransFromCommaHom})
@@ -803,13 +805,14 @@ def extendEquiv {D : Type*} [Category D]  (e: C ≌ D) : WithInitial C ≌ WithI
 end WithInitial
 variable {C}
 open Opposite
-
-private def withTerminalOpToWithInitialOfOpObj  {D : Type*} [Category D] (X: WithTerminal D):
-    WithInitial Dᵒᵖ :=
+/--From an object in `WithTerminal C`, the corresponding object in `WithInitial Cᵒᵖ`-/
+private def withTerminalOpToWithInitialOfOpObj (X: WithTerminal C):
+    WithInitial Cᵒᵖ :=
   match   X  with
   |  WithTerminal.of x =>  (WithInitial.of (Opposite.op x))
   |  WithTerminal.star =>  WithInitial.star
 
+/--From a morphism in `WithTerminal C`, the corresponding morphism in `WithInitial Cᵒᵖ`-/
 private def withTerminalOpToWithInitialOfOpHom   {X Y: WithTerminal C} (f : X ⟶ Y):
     withTerminalOpToWithInitialOfOpObj Y ⟶ withTerminalOpToWithInitialOfOpObj  X :=
   match X, Y, f  with
@@ -817,7 +820,7 @@ private def withTerminalOpToWithInitialOfOpHom   {X Y: WithTerminal C} (f : X �
   | WithTerminal.of x,WithTerminal.star, _ =>
      (WithInitial.starInitial.to (WithInitial.of (Opposite.op x)))
   | WithTerminal.star, WithTerminal.star, _ => 𝟙 _
-
+/--A functor from `(WithTerminal C)ᵒᵖ ` to `WithInitial Cᵒᵖ`.-/
 def withTerminalOpToWithInitialOfOp : (WithTerminal C)ᵒᵖ ⥤ (WithInitial Cᵒᵖ) where
   obj X :=  withTerminalOpToWithInitialOfOpObj (unop X)
   map {X Y} f := withTerminalOpToWithInitialOfOpHom f.unop
@@ -832,7 +835,7 @@ def withTerminalOpToWithInitialOfOp : (WithTerminal C)ᵒᵖ ⥤ (WithInitial C�
      rw [unop_op,unop_op] at fp gp
      simp only [unop_op, unop_comp]
      aesop_cat
-
+/--A functor from `WithInitial Cᵒᵖ` to  `(WithTerminal C)ᵒᵖ `.-/
 def withInitialOfOpToWithTerminal : (WithInitial Cᵒᵖ) ⥤ (WithTerminal C)ᵒᵖ   where
   obj X :=
     match  X  with
@@ -861,7 +864,7 @@ lemma withTerminalOpToWithInitialOfOp_comp_withInitialOfOpToWithTerminal (X : (W
   aesop_cat
 
 
-
+/--An equivalance between the categories `WithInitial Cᵒᵖ` and  `(WithTerminal C)ᵒᵖ`.-/
 def equivWithInitialOfOpWithTerminalOp (C : Type*) [Category C]:
     WithInitial Cᵒᵖ  ≌ (WithTerminal C)ᵒᵖ  where
   functor := withInitialOfOpToWithTerminal
@@ -902,8 +905,8 @@ def equivWithInitialOfOpWithTerminalOp (C : Type*) [Category C]:
           exact (WithTerminal.false_of_from_star fp).elim
     }
   }
-
-def equivWithTerminalOfOpWithInitialOp :WithTerminal Cᵒᵖ  ≌ (WithInitial C)ᵒᵖ :=
+/--An equivalance between the categories ` WithTerminal Cᵒᵖ ` and  `(WithInitial C)ᵒᵖ`.-/
+def equivWithTerminalOfOpWithInitialOp : WithTerminal Cᵒᵖ  ≌ (WithInitial C)ᵒᵖ :=
   ((Equivalence.op (WithInitial.extendEquiv (opOpEquivalence C)).symm).trans
     ((Equivalence.op (equivWithInitialOfOpWithTerminalOp Cᵒᵖ)).trans
       (opOpEquivalence (WithTerminal Cᵒᵖ)))).symm

--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -153,37 +153,115 @@ def map {D : Type*} [Category D] (F : C ⥤ D) : WithTerminal C ⥤ WithTerminal
     | of _, star, _ => PUnit.unit
     | star, star, _ => PUnit.unit
 #align category_theory.with_terminal.map CategoryTheory.WithTerminal.map
-/-- `map` preserves identities.-/
-theorem map_id (D : Type*) [Category D]  : map (𝟭  D) = 𝟭 (WithTerminal D) := by
-  unfold map
-  apply Functor.ext
-  intro X Y f
-  match X, Y, f with
-  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
-    Category.id_comp]
-                     rfl
-  | of x, star, _ => rfl
-  | star, star, _ => rfl
-  intro X
-  match X with
-  | of x => rfl
-  | star => rfl
-/-- `map` preserves compositions.-/
-theorem map_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
-    map (F⋙G) = (map F )⋙ (map G) := by
-  unfold map
-  apply Functor.ext
-  intro X Y f
-  match X, Y, f with
-  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
-    Category.id_comp]
-                     rfl
-  | of x, star, _ => rfl
-  | star, star, _ => rfl
-  intro X
-  match X with
-  | of x => rfl
-  | star => rfl
+
+/--A natural isomorphism between the functor `map (𝟭 C)` and `𝟭 (WithTerminal C)`.-/
+def mapId  (C : Type*) [Category C] : map (𝟭 C) ≅ 𝟭 (WithTerminal C) where
+  hom := {app  := fun X =>  eqToHom (by cases X <;> rfl)}
+  inv := {app  := fun X =>  eqToHom (by cases X <;> rfl)}
+
+/--A natural isomorphism between the functor `map (F⋙G) ` and `map F ⋙ map G `.-/
+def mapComp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
+    map (F⋙G) ≅ map F ⋙ map G where
+  hom := {app := fun X =>  eqToHom (by cases X <;> rfl)}
+  inv := {app  := fun X =>  eqToHom (by cases X <;> rfl)}
+
+/--From a natrual transformation of functors `C⥤D`, the induced natural transformation
+of functors `WithTerminal C ⥤ WithTerminal D`. -/
+def map₂  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
+    map F ⟶ map G where
+  app := fun X =>
+        match X with
+        | of x => η.app x
+        | star => 𝟙 (star)
+  naturality := by
+          intro X Y f
+          match X, Y, f with
+          | of x, of y, f => exact η.naturality f
+          | of x, star, _ => rfl
+          | star, star, _ => rfl
+
+/-- The pseudofunctor from `Cat` to `Cat` defined with `WithTerminal`.-/
+def pseudofunctor: Pseudofunctor Cat Cat where
+  obj C :=Cat.of (WithTerminal C)
+  map {C D} F := map F
+  map₂ := map₂
+  mapId C := mapId C
+  mapComp {C D E} F G  := mapComp F G
+  map₂_id := by
+        intros
+        apply NatTrans.ext
+        funext X
+        cases X <;> rfl
+  map₂_comp := by
+        intros
+        apply NatTrans.ext
+        funext X
+        cases X <;> rfl
+  map₂_whisker_left := by
+    intros
+    apply NatTrans.ext
+    funext X
+    cases X
+    · rw [NatTrans.comp_app,NatTrans.comp_app]
+      unfold mapComp map  map₂
+      simp only [Cat.comp_obj, Cat.comp_map, Functor.comp_obj, Functor.comp_map, eqToHom_refl,
+        Category.comp_id, Category.id_comp]
+      rfl
+    · rfl
+  map₂_whisker_right := by
+    intros
+    apply NatTrans.ext
+    funext X
+    cases X
+    · rw [NatTrans.comp_app,NatTrans.comp_app]
+      unfold mapComp map  map₂
+      simp only [Cat.comp_obj, Cat.comp_map, Functor.comp_obj, Functor.comp_map, eqToHom_refl,
+        Category.comp_id, Category.id_comp]
+      rfl
+    · rfl
+  map₂_associator := by
+    intros
+    apply NatTrans.ext
+    funext X
+    cases X
+    · rw [NatTrans.comp_app,NatTrans.comp_app,NatTrans.comp_app,NatTrans.comp_app]
+      simp only [Bicategory.Strict.associator_eqToIso, eqToIso_refl, Iso.refl_hom, Cat.comp_obj]
+      unfold map₂ mapComp map
+      rw [NatTrans.id_app,NatTrans.id_app]
+      simp only [Cat.comp_obj, Cat.comp_map, Functor.comp_obj, Functor.comp_map, eqToHom_refl,
+        Bicategory.whiskerRight, whiskerRight_app, down_id, Functor.map_id, Bicategory.whiskerLeft,
+        whiskerLeft_app, Category.comp_id, Category.id_comp]
+    · rfl
+  map₂_left_unitor := by
+    intros
+    apply NatTrans.ext
+    funext X
+    cases X
+    · rw [NatTrans.comp_app,NatTrans.comp_app]
+      unfold map₂ mapComp mapId map
+      simp only [Cat.comp_obj, Cat.comp_map, Cat.id_map, Bicategory.Strict.leftUnitor_eqToIso,
+        eqToIso_refl, Iso.refl_hom, Functor.comp_obj, Functor.comp_map, eqToHom_refl,
+        Bicategory.whiskerRight, Functor.id_obj, Functor.id_map, whiskerRight_app, Category.id_comp]
+      rw [NatTrans.id_app,NatTrans.id_app]
+      simp only [Cat.comp_obj, Category.comp_id]
+      rw [← Functor.map_id]
+      rfl
+    · rfl
+  map₂_right_unitor := by
+    intros
+    apply NatTrans.ext
+    funext X
+    cases X
+    · rw [NatTrans.comp_app,NatTrans.comp_app]
+      unfold map₂ mapComp mapId map
+      simp [Bicategory.whiskerLeft]
+      rw [NatTrans.id_app,NatTrans.id_app]
+      simp only [Cat.comp_obj, Category.comp_id]
+      rw [← Functor.map_id]
+      rfl
+    · rfl
+
+
 instance {X : WithTerminal C} : Unique (X ⟶ star) where
   default :=
     match X with
@@ -498,33 +576,20 @@ def map {D : Type*} [Category D] (F : C ⥤ D) : WithInitial C ⥤ WithInitial D
     | star, star, _ => PUnit.unit
 
 #align category_theory.with_initial.map CategoryTheory.WithInitial.map
-/--`map` preserves identities.-/
-theorem map_id (D : Type*) [Category D]  : map (𝟭  D) = 𝟭 (WithInitial D) := by
-  unfold map
-  apply Functor.ext
-  intro X Y f
-  match X, Y, f with
-  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
-    Category.id_comp]
-                     rfl
-  | star, of x, _ => rfl
-  | star, star, _ => rfl
-  intro X
-  match X with
-  | of x => rfl
-  | star => rfl
 
+/--A natural isomorphism between the functor `map (𝟭 C)` and `𝟭 (WithInitial C)`.-/
 def mapId  (C : Type*) [Category C] : map (𝟭 C) ≅ 𝟭 (WithInitial C) where
   hom := {app  := fun X =>  eqToHom (by cases X <;> rfl)}
   inv := {app  := fun X =>  eqToHom (by cases X <;> rfl)}
 
+/--A natural isomorphism between the functor `map (F⋙G) ` and `map F ⋙ map G `.-/
 def mapComp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
-    map (F⋙G) ≅ (map F) ⋙ (map G) where
+    map (F⋙G) ≅ map F ⋙ map G where
   hom := {app := fun X =>  eqToHom (by cases X <;> rfl)}
   inv := {app  := fun X =>  eqToHom (by cases X <;> rfl)}
 
 /--From a natrual transformation of functors `C⥤D`, the induced natural transformation
-of functors `WithInitial C⥤ WithInitial D` -/
+of functors `WithInitial C ⥤ WithInitial D`. -/
 def map₂  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
     map F ⟶ map G where
   app := fun X =>
@@ -538,7 +603,8 @@ def map₂  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
           | star, of x, _ => rfl
           | star, star, _ => rfl
 
-def psedofunctor: Pseudofunctor Cat Cat where
+/-- The pseudofunctor from `Cat` to `Cat` defined with `WithInitial`.-/
+def pseudofunctor: Pseudofunctor Cat Cat where
   obj C :=Cat.of (WithInitial C)
   map {C D} F := map F
   map₂ := map₂
@@ -618,26 +684,6 @@ def psedofunctor: Pseudofunctor Cat Cat where
       rfl
     · rfl
 
-
-
-
-
-/--`map` preserves compositions.-/
-theorem map_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
-    map (F⋙G) = (map F )⋙ (map G) := by
-  unfold map
-  apply Functor.ext
-  intro X Y f
-  match X, Y, f with
-  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
-    Category.id_comp]
-                     rfl
-  | star, of x,  _ => rfl
-  | star, star, _ => rfl
-  intro X
-  match X with
-  | of x => rfl
-  | star => rfl
 
 
 instance {X : WithInitial C} : Unique (star ⟶ X) where
@@ -844,40 +890,6 @@ def equivToComma  {D : Type*} [Category D] :
        inv := {app := fun G =>  eqToHom (commFromFunc_comp_funcFromComma G) } })
     ({ hom := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G)}
        inv := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G).symm }})
-
-
-
-
-/--From a natrual transformation of functors `C⥤D`, the induced natural transformation
-of functors `WithInitial C⥤ WithInitial D` -/
-def mapNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
-    map F ⟶ map G where
-  app := fun X =>
-        match X with
-        | of x => η.app x
-        | star => 𝟙 (star)
-  naturality := by
-          intro X Y f
-          match X, Y, f with
-          | of x, of y, f => exact η.naturality f
-          | star, of x, _ => rfl
-          | star, star, _ => rfl
-
-/--The functor taking `C⥤D` to `WithInitial C ⥤ WithInitial D`.-/
-def mapFunc  {D : Type*} [Category D]  : (C⥤D)⥤ (WithInitial C ⥤ WithInitial D) where
-  obj:= map
-  map:= mapNatTrans
-
-/--Given an equivalence between two categories `C` and `D` we get an equivalance between the
-categories  `WithInitial C` and  `WithInitial D  `.-/
-def mapEquiv {D : Type*} [Category D]  (e: C ≌ D) : WithInitial C ≌ WithInitial D :=
-  Equivalence.mk (map e.functor) (map e.inverse)
-   ((eqToIso (map_id C).symm).trans
- ((Functor.mapIso mapFunc  e.unitIso).trans
-   (eqToIso (map_comp e.functor e.inverse))))
-    ( (eqToIso (map_comp e.inverse e.functor).symm).trans
-          ((Functor.mapIso mapFunc e.counitIso).trans (eqToIso (map_id D))))
-
 
 
 end WithInitial

--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Tooby-Smith, Adam Topaz
 -/
 import Mathlib.CategoryTheory.Limits.Shapes.Terminal
-
+import Mathlib.CategoryTheory.Bicategory.Functor
 #align_import category_theory.with_terminal from "leanprover-community/mathlib"@"14b69e9f3c16630440a2cbd46f1ddad0d561dee7"
 
 /-!
@@ -513,6 +513,115 @@ theorem map_id (D : Type*) [Category D]  : map (𝟭  D) = 𝟭 (WithInitial D) 
   match X with
   | of x => rfl
   | star => rfl
+
+def mapId  (C : Type*) [Category C] : map (𝟭 C) ≅ 𝟭 (WithInitial C) where
+  hom := {app  := fun X =>  eqToHom (by cases X <;> rfl)}
+  inv := {app  := fun X =>  eqToHom (by cases X <;> rfl)}
+
+def mapComp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
+    map (F⋙G) ≅ (map F) ⋙ (map G) where
+  hom := {app := fun X =>  eqToHom (by cases X <;> rfl)}
+  inv := {app  := fun X =>  eqToHom (by cases X <;> rfl)}
+
+/--From a natrual transformation of functors `C⥤D`, the induced natural transformation
+of functors `WithInitial C⥤ WithInitial D` -/
+def map₂  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
+    map F ⟶ map G where
+  app := fun X =>
+        match X with
+        | of x => η.app x
+        | star => 𝟙 (star)
+  naturality := by
+          intro X Y f
+          match X, Y, f with
+          | of x, of y, f => exact η.naturality f
+          | star, of x, _ => rfl
+          | star, star, _ => rfl
+
+def psedofunctor: Pseudofunctor Cat Cat where
+  obj C :=Cat.of (WithInitial C)
+  map {C D} F := map F
+  map₂ := map₂
+  mapId C := mapId C
+  mapComp {C D E} F G  := mapComp F G
+  map₂_id := by
+        intros
+        apply NatTrans.ext
+        funext X
+        cases X <;> rfl
+  map₂_comp := by
+        intros
+        apply NatTrans.ext
+        funext X
+        cases X <;> rfl
+  map₂_whisker_left := by
+    intros
+    apply NatTrans.ext
+    funext X
+    cases X
+    · rw [NatTrans.comp_app,NatTrans.comp_app]
+      unfold mapComp map  map₂
+      simp only [Cat.comp_obj, Cat.comp_map, Functor.comp_obj, Functor.comp_map, eqToHom_refl,
+        Category.comp_id, Category.id_comp]
+      rfl
+    · rfl
+  map₂_whisker_right := by
+    intros
+    apply NatTrans.ext
+    funext X
+    cases X
+    · rw [NatTrans.comp_app,NatTrans.comp_app]
+      unfold mapComp map  map₂
+      simp only [Cat.comp_obj, Cat.comp_map, Functor.comp_obj, Functor.comp_map, eqToHom_refl,
+        Category.comp_id, Category.id_comp]
+      rfl
+    · rfl
+  map₂_associator := by
+    intros
+    apply NatTrans.ext
+    funext X
+    cases X
+    · rw [NatTrans.comp_app,NatTrans.comp_app,NatTrans.comp_app,NatTrans.comp_app]
+      simp only [Bicategory.Strict.associator_eqToIso, eqToIso_refl, Iso.refl_hom, Cat.comp_obj]
+      unfold map₂ mapComp map
+      rw [NatTrans.id_app,NatTrans.id_app]
+      simp only [Cat.comp_obj, Cat.comp_map, Functor.comp_obj, Functor.comp_map, eqToHom_refl,
+        Bicategory.whiskerRight, whiskerRight_app, down_id, Functor.map_id, Bicategory.whiskerLeft,
+        whiskerLeft_app, Category.comp_id, Category.id_comp]
+    · rfl
+  map₂_left_unitor := by
+    intros
+    apply NatTrans.ext
+    funext X
+    cases X
+    · rw [NatTrans.comp_app,NatTrans.comp_app]
+      unfold map₂ mapComp mapId map
+      simp only [Cat.comp_obj, Cat.comp_map, Cat.id_map, Bicategory.Strict.leftUnitor_eqToIso,
+        eqToIso_refl, Iso.refl_hom, Functor.comp_obj, Functor.comp_map, eqToHom_refl,
+        Bicategory.whiskerRight, Functor.id_obj, Functor.id_map, whiskerRight_app, Category.id_comp]
+      rw [NatTrans.id_app,NatTrans.id_app]
+      simp only [Cat.comp_obj, Category.comp_id]
+      rw [← Functor.map_id]
+      rfl
+    · rfl
+  map₂_right_unitor := by
+    intros
+    apply NatTrans.ext
+    funext X
+    cases X
+    · rw [NatTrans.comp_app,NatTrans.comp_app]
+      unfold map₂ mapComp mapId map
+      simp [Bicategory.whiskerLeft]
+      rw [NatTrans.id_app,NatTrans.id_app]
+      simp only [Cat.comp_obj, Category.comp_id]
+      rw [← Functor.map_id]
+      rfl
+    · rfl
+
+
+
+
+
 /--`map` preserves compositions.-/
 theorem map_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
     map (F⋙G) = (map F )⋙ (map G) := by
@@ -529,6 +638,7 @@ theorem map_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) 
   match X with
   | of x => rfl
   | star => rfl
+
 
 instance {X : WithInitial C} : Unique (star ⟶ X) where
   default :=

--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Adam Topaz
+Authors: Joseph Tooby-Smith, Adam Topaz
 -/
 import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 
@@ -246,7 +246,185 @@ instance isIso_of_from_star {X : WithTerminal C} (f : star ⟶ X) : IsIso f :=
   | star => ⟨f, rfl, rfl⟩
 #align category_theory.with_terminal.is_iso_of_from_star CategoryTheory.WithTerminal.isIso_of_from_star
 
+
+/--From `WithTerminal C ⥤ D`, an object in the comma category defined by the functors `𝟭 (C ⥤ D)`
+and `(Functor.const C)`. -/
+def commaFromFunc {D : Type*} [Category D]  (G : WithTerminal C ⥤ D) :
+    Comma (𝟭 (C ⥤ D)) (Functor.const C) where
+  left  := incl ⋙ G
+  right :=G.obj star
+  hom := {
+    app :=  fun x => G.map (starTerminal.from (incl.obj x))
+    naturality := by
+     simp_all only [Functor.id_obj, Functor.comp_obj, Functor.const_obj_obj, Functor.comp_map, ←
+       G.map_comp, Limits.IsTerminal.comp_from, Functor.const_obj_map, Category.comp_id,
+       implies_true]
+     }
+
+/--Form an object in the comma category defined by the functors `𝟭 (C ⥤ D)`
+and `(Functor.const C)`, a functor `WithTerminal C ⥤ D`. -/
+def funcFromComma {D : Type*} [Category D]
+    (η : Comma (𝟭 (C ⥤ D)) (Functor.const C) )  : WithTerminal C ⥤ D :=by
+  refine lift η.left (fun x => η.hom.app x) ?_
+  simp only [NatTrans.naturality, Functor.const_obj_obj, Functor.const_obj_map, Category.comp_id,
+    implies_true]
+
+/--The function `commaFromFunc` is left-inverse to `commaFromFunc` -/
+theorem funcFromComma_comp_commaFromFunc {D : Type*} [Category D]
+    (η : Comma (𝟭 (C ⥤ D)) (Functor.const C) ):
+    commaFromFunc (funcFromComma η) = η := by
+  constructor
+
+/--The function `commaFromFunc` is right-inverse to `commaFromFunc` -/
+theorem commFromFunc_comp_funcFromComma {D : Type*} [Category D]
+    (G : WithTerminal C ⥤ D):
+    funcFromComma (commaFromFunc G) = G := by
+  apply Functor.ext
+  · intro X Y f
+    match X, Y, f with
+    | of x, of y, f => simp only [Functor.id_obj, eqToHom_refl, Category.comp_id, Category.id_comp]
+                       rfl
+    | of x, star, x_1 => simp only [Functor.id_obj, eqToHom_refl, Category.comp_id,
+                               Category.id_comp]
+                         rfl
+    | star, star, x => simp only [Functor.id_obj, eqToHom_refl, Category.comp_id, Category.id_comp]
+                       exact (G.map_id star).symm
+  · intro X
+    match X with
+    | of x => rfl
+    | star => rfl
+
+/--From a natural transformation of functors `WithTerminal C ⥤ D`, a morphism in the comma category
+ defined by the functors `𝟭 (C ⥤ D)` and `(Functor.const C)`-/
+def commHomFromNatTrans {D : Type*} [Category D]  {G1 G2 : WithTerminal C ⥤ D} (η: G1 ⟶ G2) :
+    commaFromFunc G1 ⟶ commaFromFunc G2 where
+  left := whiskerLeft incl η
+  right := η.app star
+  w := by
+     apply NatTrans.ext
+     funext
+     simp only [commaFromFunc, Functor.id_obj, Functor.comp_obj, Functor.const_obj_obj,
+       Functor.id_map, NatTrans.comp_app, whiskerLeft_app, Functor.const_map_app,
+       NatTrans.naturality]
+
+/--From a morphism in the comma category defined by the functors `𝟭 (C ⥤ D)` and
+`(Functor.const C)`, a natural transformation of functors `WithTerminal C ⥤ D`,-/
+def natTransFromCommaHom {D : Type*} [Category D]  {c1 c2: Comma (𝟭 (C ⥤ D)) (Functor.const C)}
+    (η :c1⟶c2) :   funcFromComma c1 ⟶ funcFromComma c2 where
+  app X :=  match X with
+            | of x => η.left.app x
+            | star => η.right
+  naturality := by
+      intro X Y f
+      let h:= η.w
+      match X, Y, f with
+      | of x, of y, f => simp only [funcFromComma, Functor.id_obj, lift_obj, lift_map,
+                           NatTrans.naturality]
+      | of x, star, x_1 => simp only [Functor.id_obj, Functor.id_map] at h
+                           change _=(η.left ≫ c2.hom).app x
+                           rw [h]
+                           rfl
+      | star, star, _ => simp only [funcFromComma, Functor.id_obj, lift_obj, lift_map,
+        Category.id_comp, Category.comp_id]
+
+/--An equivalence of categoryes between the catgory of functors `(WithTerminal C ⥤ D)` and
+the comma category `Comma (𝟭 (C ⥤ D)) (Functor.const C)`.-/
+def equivToComma  {D : Type*} [Category D] :
+    (WithTerminal C ⥤ D) ≌  Comma (𝟭 (C ⥤ D)) (Functor.const C) :=
+  Equivalence.mk
+    ({ obj := commaFromFunc, map := commHomFromNatTrans})
+    ({ obj := funcFromComma, map := natTransFromCommaHom})
+    ({ hom := {app := fun G =>  eqToHom (commFromFunc_comp_funcFromComma G).symm}
+       inv := {app := fun G =>  eqToHom (commFromFunc_comp_funcFromComma G) } })
+    ({ hom := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G)}
+       inv := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G).symm }})
+
+/--From a functor `C⥤D`, the induced `WithTerminal C⥤ WithTerminal D`.-/
+def liftFunctor {D : Type*} [Category D]  (F: C ⥤ D) : WithTerminal C ⥤  WithTerminal D where
+  obj  := fun X =>
+        match X with
+        | of x => of (F.obj x)
+        | star => star
+  map := fun {X Y} f =>
+        match X, Y, f with
+        | of x, of y, f => F.map (down f)
+        | of x, star, _ => starTerminal.from (of (F.obj x))
+        | star, star, _ => 𝟙 _
+
+/--The map  `extendFunctor` preserves identities.-/
+theorem liftFunctor_id (D : Type*) [Category D]  : liftFunctor (𝟭  D) = 𝟭 (WithTerminal D) := by
+  unfold liftFunctor
+  apply Functor.ext
+  intro X Y f
+  match X, Y, f with
+  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
+    Category.id_comp]
+                     rfl
+  | of x, star, _ => rfl
+  | star, star, _ => rfl
+  intro X
+  match X with
+  | of x => rfl
+  | star => rfl
+
+theorem liftFunctor_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
+    liftFunctor (F⋙G) = (liftFunctor F )⋙ (liftFunctor G) := by
+  unfold liftFunctor
+  apply Functor.ext
+  intro X Y f
+  match X, Y, f with
+  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
+    Category.id_comp]
+                     rfl
+  | of x, star, _ => rfl
+  | star, star, _ => rfl
+  intro X
+  match X with
+  | of x => rfl
+  | star => rfl
+
+/--From a natrual transformation of functors `C⥤D`, the induced natural transformation
+of functors `WithTerminal C⥤ WithTerminal D` -/
+def liftNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
+    liftFunctor F ⟶ liftFunctor G where
+  app := fun X =>
+        match X with
+        | of x => η.app x
+        | star => 𝟙 (star)
+  naturality := by
+          intro X Y f
+          match X, Y, f with
+          | of x, of y, f => exact η.naturality f
+          | of x, star, _ => rfl
+          | star, star, _ => rfl
+
+theorem  liftNatTrans_id  {D : Type*} [Category D]  {F : C ⥤ D}  :
+    liftNatTrans (𝟙 (F)) = 𝟙 (liftFunctor F):= by
+  aesop_cat
+theorem  liftNatTrans_comp   {D : Type*} [Category D]  {F G H : C ⥤ D} (η : F⟶ G) (μ : G⟶ H) :
+    liftNatTrans (η ≫ μ ) = liftNatTrans η≫ liftNatTrans μ  := by
+  aesop_cat
+
+def liftFuncIso {D : Type*} [Category D] {F G: C⥤ D} (η : F ≅ G) :
+    liftFunctor F ≅ liftFunctor G where
+  hom := liftNatTrans η.hom
+  inv := liftNatTrans η.inv
+  hom_inv_id := by rw [← liftNatTrans_comp,η.hom_inv_id,liftNatTrans_id]
+  inv_hom_id := by rw [← liftNatTrans_comp,η.inv_hom_id,liftNatTrans_id]
+
+
+def liftEquiv {D : Type*} [Category D]  (e: C ≌ D) : WithTerminal C ≌ WithTerminal D :=
+  Equivalence.mk (liftFunctor e.functor) (liftFunctor e.inverse)
+   ((eqToIso (liftFunctor_id C).symm).trans
+ ((liftFuncIso e.unitIso).trans (eqToIso (liftFunctor_comp e.functor e.inverse))))
+    ( (eqToIso (liftFunctor_comp e.inverse e.functor).symm).trans
+          ((liftFuncIso e.counitIso).trans (eqToIso (liftFunctor_id D))))
+
+
+
 end WithTerminal
+
+
 
 namespace WithInitial
 
@@ -437,6 +615,297 @@ instance isIso_of_to_star {X : WithInitial C} (f : X ⟶ star) : IsIso f :=
   | star => ⟨f, rfl, rfl⟩
 #align category_theory.with_initial.is_iso_of_to_star CategoryTheory.WithInitial.isIso_of_to_star
 
+/--From `WithInitial C ⥤ D`, an object in the comma category defined by the functors
+ `(Functor.const C)` and `𝟭 (C ⥤ D)`. -/
+def commaFromFunc {D : Type*} [Category D]  (G : WithInitial C ⥤ D) :
+    Comma (Functor.const C) (𝟭 (C ⥤ D))  where
+  left  := G.obj star
+  right :=incl ⋙ G
+  hom := {
+    app :=  fun x => G.map (starInitial.to (incl.obj x))
+    naturality := by
+     simp only [Functor.const_obj_obj, Functor.id_obj, Functor.comp_obj, Functor.const_obj_map,
+       Category.id_comp, Functor.comp_map, ← G.map_comp, Limits.IsInitial.to_comp, implies_true]
+     }
+
+/--Form an object in the comma category defined by the functors
+ `(Functor.const C)` and `𝟭 (C ⥤ D)`, a functor `WithInitial C ⥤ D`. -/
+def funcFromComma {D : Type*} [Category D]
+    (η : Comma (Functor.const C)  (𝟭 (C ⥤ D)) )  : WithInitial C ⥤ D :=by
+  refine lift η.right (fun x => η.hom.app x) ?_
+  intro x y f
+  have h:=η.hom.naturality f
+  simp only [Functor.const_obj_obj, Functor.id_obj, Functor.const_obj_map, Category.id_comp] at h
+  exact h.symm
+
+
+/--The function `commaFromFunc` is left-inverse to `commaFromFunc` -/
+theorem funcFromComma_comp_commaFromFunc {D : Type*} [Category D]
+    (η : Comma  (Functor.const C) (𝟭 (C ⥤ D)) ):
+    commaFromFunc (funcFromComma η) = η := by
+  constructor
+
+/--The function `commaFromFunc` is right-inverse to `commaFromFunc` -/
+theorem commFromFunc_comp_funcFromComma {D : Type*} [Category D]
+    (G : WithInitial C ⥤ D):
+    funcFromComma (commaFromFunc G) = G := by
+  apply Functor.ext
+  · intro X Y f
+    match X, Y, f with
+    | of x, of y, f => simp only [Functor.id_obj, eqToHom_refl, Category.comp_id, Category.id_comp]
+                       rfl
+    | star, of y, x_1 => simp only [Functor.id_obj, eqToHom_refl, Category.comp_id,
+                               Category.id_comp]
+                         rfl
+    | star, star, x => simp only [Functor.id_obj, eqToHom_refl, Category.comp_id, Category.id_comp]
+                       exact (G.map_id star).symm
+  · intro X
+    match X with
+    | of x => rfl
+    | star => rfl
+
+/--From a natural transformation of functors `WithInitial C ⥤ D`, a morphism in the comma category
+ defined by the functors `(Functor.const C)` and `𝟭 (C ⥤ D)`-/
+def commHomFromNatTrans {D : Type*} [Category D]  {G1 G2 : WithInitial C ⥤ D} (η: G1 ⟶ G2) :
+    commaFromFunc G1 ⟶ commaFromFunc G2 where
+  left := η.app star
+  right := whiskerLeft incl η
+  w := by
+     apply NatTrans.ext
+     funext
+     simp only [commaFromFunc, Functor.id_obj, Functor.comp_obj, Functor.const_obj_obj,
+       Functor.id_map, NatTrans.comp_app, whiskerLeft_app, Functor.const_map_app,
+       NatTrans.naturality]
+
+/--From a morphism in the comma category defined by the functors
+`(Functor.const C)` and `𝟭 (C ⥤ D)`, a natural transformation of functors `WithInitial C ⥤ D`.-/
+def natTransFromCommaHom {D : Type*} [Category D]  {c1 c2: Comma (Functor.const C) (𝟭 (C ⥤ D)) }
+    (η :c1⟶c2) :   funcFromComma c1 ⟶ funcFromComma c2 where
+  app X :=  match X with
+            | of x => η.right.app x
+            | star => η.left
+  naturality := by
+      intro X Y f
+      let h:= η.w
+      match X, Y, f with
+      | of x, of y, f => simp only [funcFromComma, Functor.id_obj, lift_obj, lift_map,
+                           NatTrans.naturality]
+      | star , of y, x_1 => simp only [Functor.id_obj, Functor.id_map] at h
+                            change (c1.hom ≫ η.right ).app y=_
+                            rw [← h]
+                            rfl
+      | star, star, _ => simp only [funcFromComma, Functor.id_obj, lift_obj, lift_map,
+        Category.id_comp, Category.comp_id]
+
+/--An equivalence of categoryes between the catgory of functors `(WithInitial C ⥤ D)` and
+the comma category `Comma (Functor.const C) (𝟭 (C ⥤ D))`.-/
+def equivToComma  {D : Type*} [Category D] :
+     (WithInitial C ⥤ D) ≌  Comma (Functor.const C) (𝟭 (C ⥤ D)) :=
+  Equivalence.mk
+    ({ obj := commaFromFunc, map := commHomFromNatTrans})
+    ({ obj := funcFromComma, map := natTransFromCommaHom})
+    ({ hom := {app := fun G =>  eqToHom (commFromFunc_comp_funcFromComma G).symm}
+       inv := {app := fun G =>  eqToHom (commFromFunc_comp_funcFromComma G) } })
+    ({ hom := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G)}
+       inv := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G).symm }})
+
+/--From a functor `C⥤D`, the induced `WithInitial C⥤ WithInitial D`.-/
+def extendFunctor {D : Type*} [Category D]  (F: C ⥤ D) : WithInitial C ⥤  WithInitial D where
+  obj  := fun X =>
+        match X with
+        | of x => of (F.obj x)
+        | star => star
+  map := fun {X Y} f =>
+        match X, Y, f with
+        | of x, of y, f => F.map (down f)
+        | star, of x, _ => starInitial.to (of (F.obj x))
+        | star, star, _ => 𝟙 _
+
+/--The map `extendFunctor` preserves identities.-/
+theorem extendFunctor_id (D : Type*) [Category D]  : extendFunctor (𝟭  D) = 𝟭 (WithInitial D) := by
+  unfold extendFunctor
+  apply Functor.ext
+  intro X Y f
+  match X, Y, f with
+  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
+    Category.id_comp]
+                     rfl
+  | star, of x, _ => rfl
+  | star, star, _ => rfl
+  intro X
+  match X with
+  | of x => rfl
+  | star => rfl
+
+/--The map `extendFunctor` preserves compositions.-/
+theorem extendFunctor_comp {D : Type*} [Category D] {E : Type*} [Category E] (F : C⥤ D) (G:D⥤ E) :
+    extendFunctor (F⋙G) = (extendFunctor F )⋙ (extendFunctor G) := by
+  unfold extendFunctor
+  apply Functor.ext
+  intro X Y f
+  match X, Y, f with
+  | of x, of y, f => simp only [Functor.id_obj, Functor.id_map, eqToHom_refl, Category.comp_id,
+    Category.id_comp]
+                     rfl
+  | star, of x,  _ => rfl
+  | star, star, _ => rfl
+  intro X
+  match X with
+  | of x => rfl
+  | star => rfl
+
+/--From a natrual transformation of functors `C⥤D`, the induced natural transformation
+of functors `WithInitial C⥤ WithInitial D` -/
+def extendNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
+    extendFunctor F ⟶ extendFunctor G where
+  app := fun X =>
+        match X with
+        | of x => η.app x
+        | star => 𝟙 (star)
+  naturality := by
+          intro X Y f
+          match X, Y, f with
+          | of x, of y, f => exact η.naturality f
+          | star, of x, _ => rfl
+          | star, star, _ => rfl
+
+/--The map `extendNatTrans` preserves identities.-/
+theorem  extendNatTrans_id  {D : Type*} [Category D]  {F : C ⥤ D}  :
+    extendNatTrans (𝟙 (F)) = 𝟙 (extendFunctor F):= by
+  aesop_cat
+
+/--The map `extendNatTrans` preserves compositions.-/
+theorem  extendNatTrans_comp   {D : Type*} [Category D]  {F G H : C ⥤ D} (η : F⟶ G) (μ : G⟶ H) :
+    extendNatTrans (η ≫ μ ) = extendNatTrans η≫ extendNatTrans μ  := by
+  aesop_cat
+
+/--Given an natural isomorphism between functors `C⥤D` we get a natural isomorphism between
+the functors `liftFunctor F ≅ liftFunctor G `.-/
+def extendFuncIso {D : Type*} [Category D] {F G: C⥤ D} (η : F ≅ G) :
+    extendFunctor F ≅ extendFunctor G where
+  hom := extendNatTrans η.hom
+  inv := extendNatTrans η.inv
+  hom_inv_id := by rw [← extendNatTrans_comp,η.hom_inv_id,extendNatTrans_id]
+  inv_hom_id := by rw [← extendNatTrans_comp,η.inv_hom_id,extendNatTrans_id]
+
+/--Given an equivalence between two categories `C` and `D` we get an equivalance between the
+categories  `WithInitial C` and  `WithInitial D  `.-/
+def extendEquiv {D : Type*} [Category D]  (e: C ≌ D) : WithInitial C ≌ WithInitial D :=
+  Equivalence.mk (extendFunctor e.functor) (extendFunctor e.inverse)
+   ((eqToIso (extendFunctor_id C).symm).trans
+ ((extendFuncIso e.unitIso).trans (eqToIso (extendFunctor_comp e.functor e.inverse))))
+    ( (eqToIso (extendFunctor_comp e.inverse e.functor).symm).trans
+          ((extendFuncIso e.counitIso).trans (eqToIso (extendFunctor_id D))))
+
+
+
+
 end WithInitial
+variable {C}
+open Opposite
+
+private def withTerminalOpToWithInitialOfOpObj  {D : Type*} [Category D] (X: WithTerminal D):
+    WithInitial Dᵒᵖ :=
+  match   X  with
+  |  WithTerminal.of x =>  (WithInitial.of (Opposite.op x))
+  |  WithTerminal.star =>  WithInitial.star
+
+private def withTerminalOpToWithInitialOfOpHom   {X Y: WithTerminal C} (f : X ⟶ Y):
+    withTerminalOpToWithInitialOfOpObj Y ⟶ withTerminalOpToWithInitialOfOpObj  X :=
+  match X, Y, f  with
+  | WithTerminal.of _, WithTerminal.of _, f' => (WithTerminal.down f').op
+  | WithTerminal.of x,WithTerminal.star, _ =>
+     (WithInitial.starInitial.to (WithInitial.of (Opposite.op x)))
+  | WithTerminal.star, WithTerminal.star, _ => 𝟙 _
+
+def withTerminalOpToWithInitialOfOp : (WithTerminal C)ᵒᵖ ⥤ (WithInitial Cᵒᵖ) where
+  obj X :=  withTerminalOpToWithInitialOfOpObj (unop X)
+  map {X Y} f := withTerminalOpToWithInitialOfOpHom f.unop
+  map_id :=by
+     intro X
+     cases X
+     aesop_cat
+  map_comp :=by
+     intro X Y Z f g
+     cases X; cases Y; cases Z; cases f; cases g;
+     rename_i Xp Yp Zp fp gp
+     rw [unop_op,unop_op] at fp gp
+     simp only [unop_op, unop_comp]
+     aesop_cat
+
+def withInitialOfOpToWithTerminal : (WithInitial Cᵒᵖ) ⥤ (WithTerminal C)ᵒᵖ   where
+  obj X :=
+    match  X  with
+    |  WithInitial.of x =>  op (WithTerminal.of (unop x))
+    |  WithInitial.star =>  op WithTerminal.star
+  map {X Y} f :=
+    match X, Y, f with
+    | WithInitial.of _, WithInitial.of _, f' => f'
+    | WithInitial.star, WithInitial.of x, _ =>
+        (WithTerminal.starTerminal.from ((WithTerminal.of (unop x)))).op
+    | WithInitial.star, WithInitial.star, _ => 𝟙 _
+
+
+
+lemma withInitialOfOpToWithTerminal_comp_withTerminalOpToWithInitialOfOp (X : (WithInitial Cᵒᵖ)) :
+    (withTerminalOpToWithInitialOfOp).obj ((withInitialOfOpToWithTerminal).obj X) = X := by
+  cases X <;> rfl
+
+lemma withTerminalOpToWithInitialOfOp_comp_withInitialOfOpToWithTerminal (X : (WithTerminal C)ᵒᵖ) :
+    (withInitialOfOpToWithTerminal ).obj ((withTerminalOpToWithInitialOfOp).obj X) = X := by
+  unfold withTerminalOpToWithInitialOfOp
+  simp
+  cases X
+  rename_i Y
+  simp only [unop_op]
+  aesop_cat
+
+
+
+def equivWithInitialOfOpWithTerminalOp (C : Type*) [Category C]:
+    WithInitial Cᵒᵖ  ≌ (WithTerminal C)ᵒᵖ  where
+  functor := withInitialOfOpToWithTerminal
+  inverse := withTerminalOpToWithInitialOfOp
+  unitIso := {
+    hom := {app := fun G =>
+     eqToHom (withInitialOfOpToWithTerminal_comp_withTerminalOpToWithInitialOfOp G).symm}
+    inv := {app := fun G =>
+     eqToHom (withInitialOfOpToWithTerminal_comp_withTerminalOpToWithInitialOfOp G) }
+  }
+  counitIso := {
+    hom := {
+      app := fun G =>
+        eqToHom (withTerminalOpToWithInitialOfOp_comp_withInitialOfOpToWithTerminal  G)
+      naturality := by
+          intro X Y f
+          cases X; cases Y; cases f;
+          rename_i Xp Yp fp
+          cases Xp <;> cases Yp <;>
+          simp only [Functor.id_obj, Functor.comp_obj, unop_op, Functor.id_map,
+            eqToHom_refl, Category.comp_id, Functor.comp_map, Category.id_comp]
+          any_goals rfl
+          simp only [unop_op] at fp
+          exact (WithTerminal.false_of_from_star fp).elim
+    }
+    inv := {
+      app := fun G =>
+         eqToHom (withTerminalOpToWithInitialOfOp_comp_withInitialOfOpToWithTerminal G).symm
+      naturality := by
+          intro X Y f
+          cases X; cases Y; cases f;
+          rename_i Xp Yp fp
+          cases Xp <;> cases Yp <;>
+          simp only [Functor.id_obj, Functor.comp_obj, unop_op, Functor.id_map,
+            eqToHom_refl, Category.comp_id, Functor.comp_map, Category.id_comp]
+          any_goals rfl
+          simp only [unop_op] at fp
+          exact (WithTerminal.false_of_from_star fp).elim
+    }
+  }
+
+def equivWithTerminalOfOpWithInitialOp :WithTerminal Cᵒᵖ  ≌ (WithInitial C)ᵒᵖ :=
+  ((Equivalence.op (WithInitial.extendEquiv (opOpEquivalence C)).symm).trans
+    ((Equivalence.op (equivWithInitialOfOpWithTerminalOp Cᵒᵖ)).trans
+      (opOpEquivalence (WithTerminal Cᵒᵖ)))).symm
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -797,167 +797,168 @@ instance isIso_of_to_star {X : WithInitial C} (f : X ⟶ star) : IsIso f :=
   | star => ⟨f, rfl, rfl⟩
 #align category_theory.with_initial.is_iso_of_to_star CategoryTheory.WithInitial.isIso_of_to_star
 
-/--From `WithInitial C ⥤ D`, an object in the comma category defined by the functors
- `(Functor.const C)` and `𝟭 (C ⥤ D)`. -/
-def commaFromFunc {D : Type*} [Category D]  (G : WithInitial C ⥤ D) :
-    Comma (Functor.const C) (𝟭 (C ⥤ D))  where
-  left  := G.obj star
-  right :=incl ⋙ G
-  hom := {
-    app :=  fun x => G.map (starInitial.to (incl.obj x))
+/-- A functor from `(WithInitial C ⥤ D)` to `Comma (Functor.const C)  (𝟭 (C ⥤ D))`.  -/
+def funcToComma {D : Type*} [Category D] :
+    (WithInitial C ⥤ D) ⥤ Comma (Functor.const C) (𝟭 (C ⥤ D))  where
+  obj G := {
+    left  := G.obj star
+    right := incl ⋙ G
+    hom := {
+      app := fun x => G.map (starInitial.to (incl.obj x))
+      naturality := by
+       simp only [Functor.const_obj_obj, Functor.id_obj, Functor.comp_obj, Functor.const_obj_map,
+        Category.id_comp, Functor.comp_map, ← G.map_comp, Limits.IsInitial.to_comp, implies_true]
+    }
+  }
+  map η := {
+    left := η.app star
+    right := whiskerLeft incl η
+    w := by
+      apply NatTrans.ext
+      funext
+      simp only [Functor.id_obj, Functor.comp_obj, Functor.const_obj_obj,
+        Functor.id_map, NatTrans.comp_app, whiskerLeft_app, Functor.const_map_app,
+        NatTrans.naturality]
+  }
+
+/-- A functor from `Comma (Functor.const C)  (𝟭 (C ⥤ D))` to `(WithInitial C ⥤ D)`.  -/
+def commaToFunc {D : Type*} [Category D] :
+    Comma (Functor.const C)  (𝟭 (C ⥤ D)) ⥤ (WithInitial C ⥤ D) where
+  obj c :=  lift c.right (fun x => c.hom.app x)
+    (by
+      intros
+      simpa using (c.hom.naturality _).symm)
+  map {c1 c2} η := {
+    app := fun X => match X with
+      | of x => η.right.app x
+      | star => η.left
     naturality := by
-     simp only [Functor.const_obj_obj, Functor.id_obj, Functor.comp_obj, Functor.const_obj_map,
-       Category.id_comp, Functor.comp_map, ← G.map_comp, Limits.IsInitial.to_comp, implies_true]
-     }
-
-/--Form an object in the comma category defined by the functors
- `(Functor.const C)` and `𝟭 (C ⥤ D)`, a functor `WithInitial C ⥤ D`. -/
-def funcFromComma {D : Type*} [Category D]
-    (η : Comma (Functor.const C)  (𝟭 (C ⥤ D)) )  : WithInitial C ⥤ D :=by
-  refine lift η.right (fun x => η.hom.app x) ?_
-  intro x y f
-  have h:=η.hom.naturality f
-  simp only [Functor.const_obj_obj, Functor.id_obj, Functor.const_obj_map, Category.id_comp] at h
-  exact h.symm
-
-
-/--The function `commaFromFunc` is left-inverse to `commaFromFunc` -/
-theorem funcFromComma_comp_commaFromFunc {D : Type*} [Category D]
-    (η : Comma  (Functor.const C) (𝟭 (C ⥤ D)) ):
-    commaFromFunc (funcFromComma η) = η := by
-  constructor
-
-/--The function `commaFromFunc` is right-inverse to `commaFromFunc` -/
-theorem commFromFunc_comp_funcFromComma {D : Type*} [Category D]
-    (G : WithInitial C ⥤ D):
-    funcFromComma (commaFromFunc G) = G := by
-  apply Functor.ext
-  · intro X Y f
-    match X, Y, f with
-    | of x, of y, f => simp only [Functor.id_obj, eqToHom_refl, Category.comp_id, Category.id_comp]
-                       rfl
-    | star, of y, x_1 => simp only [Functor.id_obj, eqToHom_refl, Category.comp_id,
-                               Category.id_comp]
-                         rfl
-    | star, star, x => simp only [Functor.id_obj, eqToHom_refl, Category.comp_id, Category.id_comp]
-                       exact (G.map_id star).symm
-  · intro X
-    match X with
-    | of x => rfl
-    | star => rfl
-
-/--From a natural transformation of functors `WithInitial C ⥤ D`, a morphism in the comma category
- defined by the functors `(Functor.const C)` and `𝟭 (C ⥤ D)`-/
-def commHomFromNatTrans {D : Type*} [Category D]  {G1 G2 : WithInitial C ⥤ D} (η: G1 ⟶ G2) :
-    commaFromFunc G1 ⟶ commaFromFunc G2 where
-  left := η.app star
-  right := whiskerLeft incl η
-  w := by
-     apply NatTrans.ext
-     funext
-     simp only [commaFromFunc, Functor.id_obj, Functor.comp_obj, Functor.const_obj_obj,
-       Functor.id_map, NatTrans.comp_app, whiskerLeft_app, Functor.const_map_app,
-       NatTrans.naturality]
-
-/--From a morphism in the comma category defined by the functors
-`(Functor.const C)` and `𝟭 (C ⥤ D)`, a natural transformation of functors `WithInitial C ⥤ D`.-/
-def natTransFromCommaHom {D : Type*} [Category D]  {c1 c2: Comma (Functor.const C) (𝟭 (C ⥤ D)) }
-    (η :c1⟶c2) :   funcFromComma c1 ⟶ funcFromComma c2 where
-  app X :=  match X with
-            | of x => η.right.app x
-            | star => η.left
-  naturality := by
       intro X Y f
-      let h:= η.w
       match X, Y, f with
-      | of x, of y, f => simp only [funcFromComma, Functor.id_obj, lift_obj, lift_map,
-                           NatTrans.naturality]
-      | star , of y, x_1 => simp only [Functor.id_obj, Functor.id_map] at h
-                            change (c1.hom ≫ η.right ).app y=_
-                            rw [← h]
-                            rfl
-      | star, star, _ => simp only [funcFromComma, Functor.id_obj, lift_obj, lift_map,
-        Category.id_comp, Category.comp_id]
+      | of x, of y, f =>
+        simp only [Functor.id_obj, Functor.const_obj_obj, Functor.const_obj_map, eq_mp_eq_cast,
+          id_eq, lift_obj, lift_map, NatTrans.naturality]
+      | star , of y, x_1 =>
+        simp only [Functor.id_obj, Functor.const_obj_obj, Functor.const_obj_map, eq_mp_eq_cast,
+          id_eq, lift_obj, lift_map, ← NatTrans.comp_app]
+        erw [← η.w]
+        rfl
+      | star, star, _ =>
+        simp only [Functor.id_obj, Functor.const_obj_obj, Functor.const_obj_map, eq_mp_eq_cast,
+          id_eq, lift_obj, lift_map, Category.id_comp, Category.comp_id]
+  }
 
-/--An equivalence of categoryes between the catgory of functors `(WithInitial C ⥤ D)` and
-the comma category `Comma (Functor.const C) (𝟭 (C ⥤ D))`.-/
-def equivToComma  {D : Type*} [Category D] :
-    (WithInitial C ⥤ D) ≌  Comma (Functor.const C) (𝟭 (C ⥤ D)) :=
-  Equivalence.mk
-    ({ obj := commaFromFunc, map := commHomFromNatTrans})
-    ({ obj := funcFromComma, map := natTransFromCommaHom})
-    ({ hom := {app := fun G =>  eqToHom (commFromFunc_comp_funcFromComma G).symm}
-       inv := {app := fun G =>  eqToHom (commFromFunc_comp_funcFromComma G) } })
-    ({ hom := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G)}
-       inv := {app := fun G =>  eqToHom (funcFromComma_comp_commaFromFunc G).symm }})
+/-- A natural isomorphism from `𝟭 (WithInitial C ⥤ D)` to `funcToComma ⋙ commaToFunc `. -/
+def toCommaToFunc {D : Type*} [Category D] :
+    𝟭 (WithInitial C ⥤ D) ≅ funcToComma ⋙ commaToFunc where
+  hom := {
+    app := fun G =>
+      {
+        app := fun X => match X with
+          | of x => 𝟙 _
+          | star => 𝟙 _
+        naturality := by
+          intro X Y f
+          match X, Y, f with
+          | of x, of y, f =>
+            simp only [Functor.comp_obj, Functor.id_obj, Category.comp_id, Category.id_comp]
+            rfl
+          | star, of y, x_1 =>
+            simp only [Functor.comp_obj, Functor.id_obj, Category.comp_id, Category.id_comp]
+            rfl
+          | star, star, x =>
+            rw [show x = 𝟙 star from rfl]
+            simp only [Functor.id_obj, Functor.comp_obj, Functor.map_id, Category.comp_id]
+      }
+    }
+  inv := {
+    app := fun G =>
+      {
+        app := fun X => match X with
+          | of x => 𝟙 _
+          | star => 𝟙 _
+        naturality := by
+          intro X Y f
+          match X, Y, f with
+          | of x, of y, f =>
+            simp only [Functor.comp_obj, Functor.id_obj, Category.comp_id, Category.id_comp]
+            rfl
+          | star, of y, x_1 =>
+            simp only [Functor.comp_obj, Functor.id_obj, Category.comp_id, Category.id_comp]
+            rfl
+          | star, star, x =>
+            rw [show x = 𝟙 star from rfl]
+            simp only [Functor.comp_obj, Functor.id_obj, Functor.map_id, Category.comp_id]
+      }
+    }
 
+/-- A natural isomorphism from `commaToFunc ⋙ funcToComma` to
+`𝟭 (Comma (Functor.const C) (𝟭 (C ⥤ D)))`. -/
+def toFuncToComma {D : Type*} [Category D] :
+    commaToFunc ⋙ funcToComma ≅ 𝟭 (Comma (Functor.const C) (𝟭 (C ⥤ D))) where
+  hom := { app := fun G => 𝟙 _ }
+  inv := { app := fun G => 𝟙 _ }
+
+/-- An equivalence of categories between the catgory of functors `WithInitial C ⥤ D` and
+the comma category `Comma (Functor.const C) (𝟭 (C ⥤ D))`. -/
+def funcCommaEquiv  {D : Type*} [Category D] :
+    WithInitial C ⥤ D ≌ Comma (Functor.const C) (𝟭 (C ⥤ D)) :=
+  Equivalence.mk funcToComma commaToFunc toCommaToFunc toFuncToComma
 
 end WithInitial
 variable {C}
 open Opposite
 
-/--From an object in `WithTerminal C`, the corresponding object in `WithInitial Cᵒᵖ`-/
-def WithTerminal.op' (X: WithTerminal C): WithInitial Cᵒᵖ :=
-  match   X  with
-  |  WithTerminal.of x =>  (WithInitial.of (Opposite.op x))
-  |  WithTerminal.star =>  WithInitial.star
-
-/--From an object in `WithInitial C`, the corresponding object in `WithTerminal Cᵒᵖ`-/
-def WithInitial.op' (X: WithInitial C): WithTerminal Cᵒᵖ :=
-  match   X  with
-  |  WithInitial.of x =>  (WithTerminal.of (Opposite.op x))
-  |  WithInitial.star =>  WithTerminal.star
-
-/--From a morphism in `WithTerminal C`, the corresponding morphism in `WithInitial Cᵒᵖ`-/
-def WithTerminal.homOp'   {X Y: WithTerminal C} (f : X ⟶ Y):
-    WithTerminal.op' Y ⟶ WithTerminal.op'  X :=
-  match X, Y, f  with
-  | WithTerminal.of _, WithTerminal.of _, f' => (WithTerminal.down f').op
-  | WithTerminal.of x,WithTerminal.star, _ =>
-     (WithInitial.starInitial.to (WithInitial.of (Opposite.op x)))
-  | WithTerminal.star, WithTerminal.star, _ => 𝟙 _
-
-/--From a morphism in `WithInitial C`, the corresponding morphism in `WithTerminial Cᵒᵖ`-/
-def WithInitial.homOp'   {X Y: WithInitial C} (f : X ⟶ Y):
-    WithInitial.op' Y ⟶ WithInitial.op'  X :=
-  match X, Y, f  with
-  | WithInitial.of _, WithInitial.of _, f' => (WithTerminal.down f').op
-  | WithInitial.star,WithInitial.of x, _ =>
-     (WithTerminal.starTerminal.from (WithTerminal.of (Opposite.op x)))
-  | WithInitial.star, WithInitial.star, _ => 𝟙 _
+/--A functor from `WithTerminal C` to  `(WithInitial Cᵒᵖ)ᵒᵖ`.-/
+def withTerminalToOpWithInitialOp : (WithTerminal C) ⥤ (WithInitial Cᵒᵖ)ᵒᵖ where
+  obj X :=
+    match  X  with
+    | WithTerminal.of x => op (WithInitial.of (op x))
+    | WithTerminal.star => op WithInitial.star
+  map {X Y} f :=
+      match X, Y, f with
+    | WithTerminal.of _, WithTerminal.of _, f' =>
+      (WithInitial.incl.map (WithTerminal.down f').op).op
+    | WithTerminal.of x,WithTerminal.star, _ =>
+      (WithInitial.starInitial.to ((WithInitial.of (op x)))).op
+    | WithTerminal.star, WithTerminal.star, _ => 𝟙 _
 
 /--A functor from `(WithTerminal C)ᵒᵖ ` to `WithInitial Cᵒᵖ`.-/
-def WithTerminal.op_to_op' : (WithTerminal C)ᵒᵖ ⥤ (WithInitial Cᵒᵖ) where
-  obj X :=  WithTerminal.op' (unop X)
-  map {X Y} f := WithTerminal.homOp' f.unop
-  map_id :=by
-     intro X
-     cases X
-     aesop_cat
-  map_comp :=by
-     intro X Y Z f g
-     cases X; cases Y; cases Z; cases f; cases g;
-     rename_i Xp Yp Zp fp gp
-     rw [unop_op,unop_op] at fp gp
-     aesop_cat
+def withTerminalOpToOpWithInitial : (WithTerminal C)ᵒᵖ ⥤ (WithInitial Cᵒᵖ) :=
+  withTerminalToOpWithInitialOp.leftOp
+
+/--A functor from `WithTerminal Cᵒᵖ` to `(WithInitial C)ᵒᵖ `.-/
+def opWithTerminalToWithInitialOp : (WithTerminal Cᵒᵖ) ⥤ (WithInitial C)ᵒᵖ where
+  obj X :=
+    match  X  with
+    | WithTerminal.of x => op (WithInitial.of (unop x))
+    | WithTerminal.star => op WithInitial.star
+  map {X Y} f :=
+    match X, Y, f with
+    | WithTerminal.of _, WithTerminal.of _, f' => f'
+    | WithTerminal.of x,WithTerminal.star, _ =>
+        (WithInitial.starInitial.to ((WithInitial.of (unop x)))).op
+    | WithTerminal.star, WithTerminal.star, _ => 𝟙 _
+
+/-- A functor from `WithInitial C` to  `(WithTerminal Cᵒᵖ)ᵒᵖ`. -/
+def withInitialToOpWithTerminalOp : (WithInitial C) ⥤ (WithTerminal Cᵒᵖ)ᵒᵖ where
+  obj X :=
+    match  X  with
+    |  WithInitial.of x =>  op (WithTerminal.of (op x))
+    |  WithInitial.star =>  op WithTerminal.star
+  map {X Y} f :=
+      match X, Y, f with
+    | WithInitial.of _, WithInitial.of _, f' => (WithInitial.incl.map (WithTerminal.down f').op).op
+    | WithInitial.star, WithInitial.of x, _ =>
+        (WithTerminal.starTerminal.from ((WithTerminal.of (op x)))).op
+    | WithInitial.star, WithInitial.star, _ => 𝟙 _
 
 /--A functor from `(WithInitial C)ᵒᵖ ` to `WithTerminal Cᵒᵖ`.-/
-def WithInitial.op_to_op' : (WithInitial C)ᵒᵖ ⥤ (WithTerminal Cᵒᵖ) where
-  obj X :=  WithInitial.op' (unop X)
-  map {X Y} f := WithInitial.homOp' f.unop
-  map_id :=by
-     intro X
-     cases X
-     aesop_cat
-  map_comp :=by
-     intro X Y Z f g
-     cases X; cases Y; cases Z; cases f; cases g;
-     rename_i Xp Yp Zp fp gp
-     rw [unop_op,unop_op] at fp gp
-     aesop_cat
+def withInitialOpToOpWithTerminal : (WithInitial C)ᵒᵖ ⥤ (WithTerminal Cᵒᵖ) :=
+  withInitialToOpWithTerminalOp.leftOp
 
 /--A functor from `WithInitial Cᵒᵖ` to  `(WithTerminal C)ᵒᵖ `.-/
-def WithTerminal.op'_to_op : (WithInitial Cᵒᵖ) ⥤ (WithTerminal C)ᵒᵖ   where
+def opWithInitialToWithTerminalOp : (WithInitial Cᵒᵖ) ⥤ (WithTerminal C)ᵒᵖ where
   obj X :=
     match  X  with
     |  WithInitial.of x =>  op (WithTerminal.of (unop x))
@@ -969,90 +970,82 @@ def WithTerminal.op'_to_op : (WithInitial Cᵒᵖ) ⥤ (WithTerminal C)ᵒᵖ   
         (WithTerminal.starTerminal.from ((WithTerminal.of (unop x)))).op
     | WithInitial.star, WithInitial.star, _ => 𝟙 _
 
-/--A functor from `WithTerminal Cᵒᵖ` to  `(WithInitial C)ᵒᵖ `.-/
-def WithInitial.op'_to_op : (WithTerminal Cᵒᵖ) ⥤ (WithInitial C)ᵒᵖ   where
-  obj X :=
-    match  X  with
-    |  WithTerminal.of x =>  op (WithInitial.of (unop x))
-    |  WithTerminal.star =>  op WithInitial.star
-  map {X Y} f :=
-    match X, Y, f with
-    | WithTerminal.of _, WithTerminal.of _, f' => f'
-    | WithTerminal.of x,WithTerminal.star, _ =>
-        (WithInitial.starInitial.to ((WithInitial.of (unop x)))).op
-    | WithTerminal.star, WithTerminal.star, _ => 𝟙 _
+ /-- A natural isomorphism between `𝟭 (WithInitial Cᵒᵖ)` and
+`opWithInitialToWithTerminalOp ⋙ withTerminalOpToOpWithInitial`. -/
+def opWithInitialWithTerminalOp : 𝟭 (WithInitial Cᵒᵖ) ≅
+    opWithInitialToWithTerminalOp ⋙ withTerminalOpToOpWithInitial where
+  hom :=  {
+    app := fun X => match X with
+      | WithInitial.of x => 𝟙 _
+      | WithInitial.star => 𝟙 _
+  }
+  inv := {
+    app := fun X => match X with
+      | WithInitial.of x => 𝟙 _
+      | WithInitial.star => 𝟙 _
+  }
+
+ /-- A natural isomorphism between `𝟭 (WithTerminal C)` and
+`(withTerminalOpToOpWithInitial ⋙ opWithInitialToWithTerminalOp).unop`. -/
+def withTerminalOpOpWithInitial : 𝟭 (WithTerminal C) ≅
+     (withTerminalOpToOpWithInitial ⋙ opWithInitialToWithTerminalOp).unop where
+  hom := {
+    app := fun X => match X with
+      | WithTerminal.of x => 𝟙 _
+      | WithTerminal.star => 𝟙 _
+  }
+  inv := {
+    app := fun X => match X with
+      | WithTerminal.of x => 𝟙 _
+      | WithTerminal.star => 𝟙 _
+  }
+
+/-- A natural isomorphism between `𝟭 (WithTerminal Cᵒᵖ)` and
+`opWithTerminalToWithInitialOp ⋙ withInitialOpToOpWithTerminal`. -/
+def opWithTerminalWithInitialOp : 𝟭 (WithTerminal Cᵒᵖ) ≅
+    opWithTerminalToWithInitialOp ⋙ withInitialOpToOpWithTerminal where
+  hom :=  {
+    app := fun X => match X with
+      | WithTerminal.of x => 𝟙 _
+      | WithTerminal.star => 𝟙 _
+  }
+  inv := {
+    app := fun X => match X with
+      | WithTerminal.of x => 𝟙 _
+      | WithTerminal.star => 𝟙 _
+  }
+
+/-- A natural isomorphism between `𝟭 (WithInitial C)` and
+`(withInitialOpToOpWithTerminal ⋙ opWithTerminalToWithInitialOp).unop `. -/
+def withInitialOpOpWithTerminal : 𝟭 (WithInitial C) ≅
+    (withInitialOpToOpWithTerminal ⋙ opWithTerminalToWithInitialOp).unop where
+  hom := {
+    app := fun X => match X with
+      | WithInitial.of x => 𝟙 _
+      | WithInitial.star => 𝟙 _
+  }
+  inv := {
+    app := fun X => match X with
+      | WithInitial.of x => 𝟙 _
+      | WithInitial.star => 𝟙 _
+  }
 
 /--An equivalance between the categories `WithInitial Cᵒᵖ` and  `(WithTerminal C)ᵒᵖ`.-/
-def equivWithInitialOfOpWithTerminalOp (C : Type*) [Category C]:
-    WithInitial Cᵒᵖ  ≌ (WithTerminal C)ᵒᵖ  where
-  functor := WithTerminal.op'_to_op
-  inverse := WithTerminal.op_to_op'
-  unitIso := {
-    hom := {app := fun X => eqToHom (by cases X <;> rfl)}
-    inv := {app := fun X => eqToHom (by cases X <;> rfl) }
-  }
-  counitIso := {
-    hom := {
-      app := fun X => eqToHom (by cases X; rename_i X;  cases X  <;> rfl)
-      naturality := by
-          intro X Y f
-          cases X; cases Y; cases f;
-          rename_i Xp Yp fp
-          cases Xp <;> cases Yp <;>
-          simp only [Functor.id_obj, Functor.comp_obj, unop_op, Functor.id_map,
-            eqToHom_refl, Category.comp_id, Functor.comp_map, Category.id_comp]
-          any_goals rfl
-          exact (WithTerminal.false_of_from_star fp).elim
-    }
-    inv := {
-      app := fun X => eqToHom (by cases X; rename_i X;  cases X  <;> rfl)
-      naturality := by
-          intro X Y f
-          cases X; cases Y; cases f;
-          rename_i Xp Yp fp
-          cases Xp <;> cases Yp <;>
-          simp only [Functor.id_obj, Functor.comp_obj, unop_op, Functor.id_map,
-            eqToHom_refl, Category.comp_id, Functor.comp_map, Category.id_comp]
-          any_goals rfl
-          exact (WithTerminal.false_of_from_star fp).elim
-    }
-  }
+def opWithInitialEquivWithTerminalOp (C : Type*) [Category C] :
+    WithInitial Cᵒᵖ ≌ (WithTerminal C)ᵒᵖ :=
+  Equivalence.mk
+    opWithInitialToWithTerminalOp
+    withTerminalOpToOpWithInitial
+    opWithInitialWithTerminalOp
+    (NatIso.op withTerminalOpOpWithInitial)
 
-/--An equivalance between the categories `WithTerminal Cᵒᵖ` and  `(WithInitial C)ᵒᵖ`.-/
-def equivWithTerminalOfOpWithInitialOp (C : Type*) [Category C]:
-    WithTerminal Cᵒᵖ  ≌ (WithInitial C)ᵒᵖ  where
-  functor := WithInitial.op'_to_op
-  inverse := WithInitial.op_to_op'
-  unitIso := {
-    hom := {app := fun X => eqToHom (by cases X <;> rfl)}
-    inv := {app := fun X => eqToHom (by cases X <;> rfl) }
-  }
-  counitIso := {
-    hom := {
-      app := fun X => eqToHom (by cases X; rename_i X;  cases X  <;> rfl)
-      naturality := by
-          intro X Y f
-          cases X; cases Y; cases f;
-          rename_i Xp Yp fp
-          cases Xp <;> cases Yp <;>
-          simp only [Functor.id_obj, Functor.comp_obj, unop_op, Functor.id_map,
-            eqToHom_refl, Category.comp_id, Functor.comp_map, Category.id_comp]
-          any_goals rfl
-          exact (WithInitial.false_of_to_star fp).elim
-    }
-    inv := {
-      app := fun X => eqToHom (by cases X; rename_i X;  cases X  <;> rfl)
-      naturality := by
-          intro X Y f
-          cases X; cases Y; cases f;
-          rename_i Xp Yp fp
-          cases Xp <;> cases Yp <;>
-          simp only [Functor.id_obj, Functor.comp_obj, unop_op, Functor.id_map,
-            eqToHom_refl, Category.comp_id, Functor.comp_map, Category.id_comp]
-          any_goals rfl
-          exact (WithInitial.false_of_to_star fp).elim
-    }
-  }
-
+/-- An equivalance between the categories `WithTerminal Cᵒᵖ` and  `(WithInitial C)ᵒᵖ`. -/
+def opWithTerminalEquivWithInitialOp (C : Type*) [Category C] :
+    WithTerminal Cᵒᵖ ≌ (WithInitial C)ᵒᵖ :=
+  Equivalence.mk
+    opWithTerminalToWithInitialOp
+    withInitialOpToOpWithTerminal
+    opWithTerminalWithInitialOp
+    (NatIso.op withInitialOpOpWithTerminal)
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -397,30 +397,20 @@ def extendNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
           | of x, of y, f => exact η.naturality f
           | of x, star, _ => rfl
           | star, star, _ => rfl
-/--The map `extendNatTrans` preserves identities between fuctors.-/
-theorem  extendNatTrans_id  {D : Type*} [Category D]  {F : C ⥤ D}  :
-    extendNatTrans (𝟙 (F)) = 𝟙 (extendFunctor F):= by
-  aesop_cat
-/--The map `extendNatTrans` preserves horizontal compositions of natural transformations.-/
-theorem  extendNatTrans_comp   {D : Type*} [Category D]  {F G H : C ⥤ D} (η : F⟶ G) (μ : G⟶ H) :
-    extendNatTrans (η ≫ μ ) = extendNatTrans η≫ extendNatTrans μ  := by
-  aesop_cat
 
-/--The extension of a natural isomorphism between functors.-/
-def extendFuncIso {D : Type*} [Category D] {F G: C⥤ D} (η : F ≅ G) :
-    extendFunctor F ≅ extendFunctor G where
-  hom := extendNatTrans η.hom
-  inv := extendNatTrans η.inv
-  hom_inv_id := by rw [← extendNatTrans_comp,η.hom_inv_id,extendNatTrans_id]
-  inv_hom_id := by rw [← extendNatTrans_comp,η.inv_hom_id,extendNatTrans_id]
+/--The functor taking `C⥤D` to `WithTerminal C ⥤ WithTerminal D`.-/
+def extendFuncCat  {D : Type*} [Category D]  : (C⥤D)⥤ (WithTerminal C ⥤ WithTerminal D) where
+  obj:= extendFunctor
+  map:= extendNatTrans
 
 /--The extension of an equivalance `C ≌ D` to an equivalance `WithTerminal C ≌ WithTerminal D `.-/
 def extendEquiv {D : Type*} [Category D]  (e: C ≌ D) : WithTerminal C ≌ WithTerminal D :=
   Equivalence.mk (extendFunctor e.functor) (extendFunctor e.inverse)
    ((eqToIso (extendFunctor_id C).symm).trans
- ((extendFuncIso e.unitIso).trans (eqToIso (extendFunctor_comp e.functor e.inverse))))
+ ((Functor.mapIso extendFuncCat e.unitIso).trans
+  (eqToIso (extendFunctor_comp e.functor e.inverse))))
     ( (eqToIso (extendFunctor_comp e.inverse e.functor).symm).trans
-          ((extendFuncIso e.counitIso).trans (eqToIso (extendFunctor_id D))))
+          ((Functor.mapIso extendFuncCat e.counitIso).trans (eqToIso (extendFunctor_id D))))
 
 
 
@@ -771,59 +761,61 @@ def extendNatTrans  {D : Type*} [Category D]  {F G: C ⥤ D} (η : F ⟶ G) :
           | star, of x, _ => rfl
           | star, star, _ => rfl
 
-/--The map `extendNatTrans` preserves identities.-/
-theorem  extendNatTrans_id  {D : Type*} [Category D]  {F : C ⥤ D}  :
-    extendNatTrans (𝟙 (F)) = 𝟙 (extendFunctor F):= by
-  aesop_cat
-
-/--The map `extendNatTrans` preserves compositions.-/
-theorem  extendNatTrans_comp   {D : Type*} [Category D]  {F G H : C ⥤ D} (η : F⟶ G) (μ : G⟶ H) :
-    extendNatTrans (η ≫ μ ) = extendNatTrans η≫ extendNatTrans μ  := by
-  aesop_cat
-
-/--Given an natural isomorphism between functors `C⥤D` we get a natural isomorphism between
-the functors `liftFunctor F ≅ liftFunctor G `.-/
-def extendFuncIso {D : Type*} [Category D] {F G: C⥤ D} (η : F ≅ G) :
-    extendFunctor F ≅ extendFunctor G where
-  hom := extendNatTrans η.hom
-  inv := extendNatTrans η.inv
-  hom_inv_id := by rw [← extendNatTrans_comp,η.hom_inv_id,extendNatTrans_id]
-  inv_hom_id := by rw [← extendNatTrans_comp,η.inv_hom_id,extendNatTrans_id]
+/--The functor taking `C⥤D` to `WithInitial C ⥤ WithInitial D`.-/
+def extendFuncCat  {D : Type*} [Category D]  : (C⥤D)⥤ (WithInitial C ⥤ WithInitial D) where
+  obj:= extendFunctor
+  map:= extendNatTrans
 
 /--Given an equivalence between two categories `C` and `D` we get an equivalance between the
 categories  `WithInitial C` and  `WithInitial D  `.-/
 def extendEquiv {D : Type*} [Category D]  (e: C ≌ D) : WithInitial C ≌ WithInitial D :=
   Equivalence.mk (extendFunctor e.functor) (extendFunctor e.inverse)
    ((eqToIso (extendFunctor_id C).symm).trans
- ((extendFuncIso e.unitIso).trans (eqToIso (extendFunctor_comp e.functor e.inverse))))
+ ((Functor.mapIso extendFuncCat  e.unitIso).trans
+   (eqToIso (extendFunctor_comp e.functor e.inverse))))
     ( (eqToIso (extendFunctor_comp e.inverse e.functor).symm).trans
-          ((extendFuncIso e.counitIso).trans (eqToIso (extendFunctor_id D))))
-
+          ((Functor.mapIso extendFuncCat e.counitIso).trans (eqToIso (extendFunctor_id D))))
 
 
 
 end WithInitial
 variable {C}
 open Opposite
+
 /--From an object in `WithTerminal C`, the corresponding object in `WithInitial Cᵒᵖ`-/
-private def withTerminalOpToWithInitialOfOpObj (X: WithTerminal C):
-    WithInitial Cᵒᵖ :=
+def WithTerminal.op' (X: WithTerminal C): WithInitial Cᵒᵖ :=
   match   X  with
   |  WithTerminal.of x =>  (WithInitial.of (Opposite.op x))
   |  WithTerminal.star =>  WithInitial.star
 
+/--From an object in `WithInitial C`, the corresponding object in `WithTerminal Cᵒᵖ`-/
+def WithInitial.op' (X: WithInitial C): WithTerminal Cᵒᵖ :=
+  match   X  with
+  |  WithInitial.of x =>  (WithTerminal.of (Opposite.op x))
+  |  WithInitial.star =>  WithTerminal.star
+
 /--From a morphism in `WithTerminal C`, the corresponding morphism in `WithInitial Cᵒᵖ`-/
-private def withTerminalOpToWithInitialOfOpHom   {X Y: WithTerminal C} (f : X ⟶ Y):
-    withTerminalOpToWithInitialOfOpObj Y ⟶ withTerminalOpToWithInitialOfOpObj  X :=
+def WithTerminal.homOp'   {X Y: WithTerminal C} (f : X ⟶ Y):
+    WithTerminal.op' Y ⟶ WithTerminal.op'  X :=
   match X, Y, f  with
   | WithTerminal.of _, WithTerminal.of _, f' => (WithTerminal.down f').op
   | WithTerminal.of x,WithTerminal.star, _ =>
      (WithInitial.starInitial.to (WithInitial.of (Opposite.op x)))
   | WithTerminal.star, WithTerminal.star, _ => 𝟙 _
+
+/--From a morphism in `WithInitial C`, the corresponding morphism in `WithTerminial Cᵒᵖ`-/
+def WithInitial.homOp'   {X Y: WithInitial C} (f : X ⟶ Y):
+    WithInitial.op' Y ⟶ WithInitial.op'  X :=
+  match X, Y, f  with
+  | WithInitial.of _, WithInitial.of _, f' => (WithTerminal.down f').op
+  | WithInitial.star,WithInitial.of x, _ =>
+     (WithTerminal.starTerminal.from (WithTerminal.of (Opposite.op x)))
+  | WithInitial.star, WithInitial.star, _ => 𝟙 _
+
 /--A functor from `(WithTerminal C)ᵒᵖ ` to `WithInitial Cᵒᵖ`.-/
-def withTerminalOpToWithInitialOfOp : (WithTerminal C)ᵒᵖ ⥤ (WithInitial Cᵒᵖ) where
-  obj X :=  withTerminalOpToWithInitialOfOpObj (unop X)
-  map {X Y} f := withTerminalOpToWithInitialOfOpHom f.unop
+def WithTerminal.op_to_op' : (WithTerminal C)ᵒᵖ ⥤ (WithInitial Cᵒᵖ) where
+  obj X :=  WithTerminal.op' (unop X)
+  map {X Y} f := WithTerminal.homOp' f.unop
   map_id :=by
      intro X
      cases X
@@ -835,8 +827,25 @@ def withTerminalOpToWithInitialOfOp : (WithTerminal C)ᵒᵖ ⥤ (WithInitial C�
      rw [unop_op,unop_op] at fp gp
      simp only [unop_op, unop_comp]
      aesop_cat
+
+/--A functor from `(WithInitial C)ᵒᵖ ` to `WithTerminal Cᵒᵖ`.-/
+def WithInitial.op_to_op' : (WithInitial C)ᵒᵖ ⥤ (WithTerminal Cᵒᵖ) where
+  obj X :=  WithInitial.op' (unop X)
+  map {X Y} f := WithInitial.homOp' f.unop
+  map_id :=by
+     intro X
+     cases X
+     aesop_cat
+  map_comp :=by
+     intro X Y Z f g
+     cases X; cases Y; cases Z; cases f; cases g;
+     rename_i Xp Yp Zp fp gp
+     rw [unop_op,unop_op] at fp gp
+     simp only [unop_op, unop_comp]
+     aesop_cat
+
 /--A functor from `WithInitial Cᵒᵖ` to  `(WithTerminal C)ᵒᵖ `.-/
-def withInitialOfOpToWithTerminal : (WithInitial Cᵒᵖ) ⥤ (WithTerminal C)ᵒᵖ   where
+def WithTerminal.op'_to_op : (WithInitial Cᵒᵖ) ⥤ (WithTerminal C)ᵒᵖ   where
   obj X :=
     match  X  with
     |  WithInitial.of x =>  op (WithTerminal.of (unop x))
@@ -848,37 +857,31 @@ def withInitialOfOpToWithTerminal : (WithInitial Cᵒᵖ) ⥤ (WithTerminal C)�
         (WithTerminal.starTerminal.from ((WithTerminal.of (unop x)))).op
     | WithInitial.star, WithInitial.star, _ => 𝟙 _
 
-
-
-lemma withInitialOfOpToWithTerminal_comp_withTerminalOpToWithInitialOfOp (X : (WithInitial Cᵒᵖ)) :
-    (withTerminalOpToWithInitialOfOp).obj ((withInitialOfOpToWithTerminal).obj X) = X := by
-  cases X <;> rfl
-
-lemma withTerminalOpToWithInitialOfOp_comp_withInitialOfOpToWithTerminal (X : (WithTerminal C)ᵒᵖ) :
-    (withInitialOfOpToWithTerminal ).obj ((withTerminalOpToWithInitialOfOp).obj X) = X := by
-  unfold withTerminalOpToWithInitialOfOp
-  simp
-  cases X
-  rename_i Y
-  simp only [unop_op]
-  aesop_cat
-
+/--A functor from `WithTerminal Cᵒᵖ` to  `(WithInitial C)ᵒᵖ `.-/
+def WithInitial.op'_to_op : (WithTerminal Cᵒᵖ) ⥤ (WithInitial C)ᵒᵖ   where
+  obj X :=
+    match  X  with
+    |  WithTerminal.of x =>  op (WithInitial.of (unop x))
+    |  WithTerminal.star =>  op WithInitial.star
+  map {X Y} f :=
+    match X, Y, f with
+    | WithTerminal.of _, WithTerminal.of _, f' => f'
+    | WithTerminal.of x,WithTerminal.star, _ =>
+        (WithInitial.starInitial.to ((WithInitial.of (unop x)))).op
+    | WithTerminal.star, WithTerminal.star, _ => 𝟙 _
 
 /--An equivalance between the categories `WithInitial Cᵒᵖ` and  `(WithTerminal C)ᵒᵖ`.-/
 def equivWithInitialOfOpWithTerminalOp (C : Type*) [Category C]:
     WithInitial Cᵒᵖ  ≌ (WithTerminal C)ᵒᵖ  where
-  functor := withInitialOfOpToWithTerminal
-  inverse := withTerminalOpToWithInitialOfOp
+  functor := WithTerminal.op'_to_op
+  inverse := WithTerminal.op_to_op'
   unitIso := {
-    hom := {app := fun G =>
-     eqToHom (withInitialOfOpToWithTerminal_comp_withTerminalOpToWithInitialOfOp G).symm}
-    inv := {app := fun G =>
-     eqToHom (withInitialOfOpToWithTerminal_comp_withTerminalOpToWithInitialOfOp G) }
+    hom := {app := fun X => eqToHom (by cases X <;> rfl)}
+    inv := {app := fun X => eqToHom (by cases X <;> rfl) }
   }
   counitIso := {
     hom := {
-      app := fun G =>
-        eqToHom (withTerminalOpToWithInitialOfOp_comp_withInitialOfOpToWithTerminal  G)
+      app := fun X => eqToHom (by cases X; rename_i X;  cases X  <;> rfl)
       naturality := by
           intro X Y f
           cases X; cases Y; cases f;
@@ -887,12 +890,10 @@ def equivWithInitialOfOpWithTerminalOp (C : Type*) [Category C]:
           simp only [Functor.id_obj, Functor.comp_obj, unop_op, Functor.id_map,
             eqToHom_refl, Category.comp_id, Functor.comp_map, Category.id_comp]
           any_goals rfl
-          simp only [unop_op] at fp
           exact (WithTerminal.false_of_from_star fp).elim
     }
     inv := {
-      app := fun G =>
-         eqToHom (withTerminalOpToWithInitialOfOp_comp_withInitialOfOpToWithTerminal G).symm
+      app := fun X => eqToHom (by cases X; rename_i X;  cases X  <;> rfl)
       naturality := by
           intro X Y f
           cases X; cases Y; cases f;
@@ -901,14 +902,45 @@ def equivWithInitialOfOpWithTerminalOp (C : Type*) [Category C]:
           simp only [Functor.id_obj, Functor.comp_obj, unop_op, Functor.id_map,
             eqToHom_refl, Category.comp_id, Functor.comp_map, Category.id_comp]
           any_goals rfl
-          simp only [unop_op] at fp
           exact (WithTerminal.false_of_from_star fp).elim
     }
   }
-/--An equivalance between the categories ` WithTerminal Cᵒᵖ ` and  `(WithInitial C)ᵒᵖ`.-/
-def equivWithTerminalOfOpWithInitialOp : WithTerminal Cᵒᵖ  ≌ (WithInitial C)ᵒᵖ :=
-  ((Equivalence.op (WithInitial.extendEquiv (opOpEquivalence C)).symm).trans
-    ((Equivalence.op (equivWithInitialOfOpWithTerminalOp Cᵒᵖ)).trans
-      (opOpEquivalence (WithTerminal Cᵒᵖ)))).symm
+
+/--An equivalance between the categories `WithInitial Cᵒᵖ` and  `(WithTerminal C)ᵒᵖ`.-/
+def equivWithTerminalOfOpWithInitialOp (C : Type*) [Category C]:
+    WithTerminal Cᵒᵖ  ≌ (WithInitial C)ᵒᵖ  where
+  functor := WithInitial.op'_to_op
+  inverse := WithInitial.op_to_op'
+  unitIso := {
+    hom := {app := fun X => eqToHom (by cases X <;> rfl)}
+    inv := {app := fun X => eqToHom (by cases X <;> rfl) }
+  }
+  counitIso := {
+    hom := {
+      app := fun X => eqToHom (by cases X; rename_i X;  cases X  <;> rfl)
+      naturality := by
+          intro X Y f
+          cases X; cases Y; cases f;
+          rename_i Xp Yp fp
+          cases Xp <;> cases Yp <;>
+          simp only [Functor.id_obj, Functor.comp_obj, unop_op, Functor.id_map,
+            eqToHom_refl, Category.comp_id, Functor.comp_map, Category.id_comp]
+          any_goals rfl
+          exact (WithInitial.false_of_to_star fp).elim
+    }
+    inv := {
+      app := fun X => eqToHom (by cases X; rename_i X;  cases X  <;> rfl)
+      naturality := by
+          intro X Y f
+          cases X; cases Y; cases f;
+          rename_i Xp Yp fp
+          cases Xp <;> cases Yp <;>
+          simp only [Functor.id_obj, Functor.comp_obj, unop_op, Functor.id_map,
+            eqToHom_refl, Category.comp_id, Functor.comp_map, Category.id_comp]
+          any_goals rfl
+          exact (WithInitial.false_of_to_star fp).elim
+    }
+  }
+
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -988,7 +988,7 @@ def opWithInitialWithTerminalOp : 𝟭 (WithInitial Cᵒᵖ) ≅
  /-- A natural isomorphism between `𝟭 (WithTerminal C)` and
 `(withTerminalOpToOpWithInitial ⋙ opWithInitialToWithTerminalOp).unop`. -/
 def withTerminalOpOpWithInitial : 𝟭 (WithTerminal C) ≅
-     (withTerminalOpToOpWithInitial ⋙ opWithInitialToWithTerminalOp).unop where
+    (withTerminalOpToOpWithInitial ⋙ opWithInitialToWithTerminalOp).unop where
   hom := {
     app := fun X => match X with
       | WithTerminal.of x => 𝟙 _


### PR DESCRIPTION
Added the following

- An equivalence between `WithTerminal C` and `WithTerminal D`, and between  `WithInitial C` and `WithInitial D`, from an equivalence between `C` and `D`.
-  An equivalence `(WithTerminal C)⥤ D` and the comma category `Comma (𝟭 (C ⥤ D)) (Functor.const C)`
-  An equivalence `(WithInitial C)⥤ D` and the comma category `Comma (Functor.const C) (𝟭 (C ⥤ D))`
-  An equivalence  `WithTerminal Cᵒᵖ` and `(WithInitial C)ᵒᵖ`
-  An equivalence `WithInitial Cᵒᵖ` and `(WithTerminal C)ᵒᵖ`

and related definitions and lemmas.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
