### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Functor): pointwise left Kan extensions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1062,6 +1062,7 @@ import Mathlib.CategoryTheory.Functor.FullyFaithful
 import Mathlib.CategoryTheory.Functor.Functorial
 import Mathlib.CategoryTheory.Functor.Hom
 import Mathlib.CategoryTheory.Functor.KanExtension.Basic
+import Mathlib.CategoryTheory.Functor.KanExtension.Pointwise
 import Mathlib.CategoryTheory.Functor.ReflectsIso
 import Mathlib.CategoryTheory.Functor.Trifunctor
 import Mathlib.CategoryTheory.Galois.Basic

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -567,8 +567,7 @@ instance isEquivalenceTrans (F : C ⥤ D) (G : D ⥤ E) [IsEquivalence F] [IsEqu
   IsEquivalence.ofEquivalence (Equivalence.trans (asEquivalence F) (asEquivalence G))
 #align category_theory.functor.is_equivalence_trans CategoryTheory.Functor.isEquivalenceTrans
 
-instance (F : C ⥤ D) [IsEquivalence F] :
-    IsEquivalence ((whiskeringLeft C D E).obj F) :=
+instance (F : C ⥤ D) [IsEquivalence F] : IsEquivalence ((whiskeringLeft C D E).obj F) :=
   (inferInstance : IsEquivalence (Equivalence.congrLeft F.asEquivalence).inverse)
 
 instance (F : C ⥤ D) [IsEquivalence F] :

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -567,6 +567,14 @@ instance isEquivalenceTrans (F : C ⥤ D) (G : D ⥤ E) [IsEquivalence F] [IsEqu
   IsEquivalence.ofEquivalence (Equivalence.trans (asEquivalence F) (asEquivalence G))
 #align category_theory.functor.is_equivalence_trans CategoryTheory.Functor.isEquivalenceTrans
 
+instance (F : C ⥤ D) [IsEquivalence F] :
+    IsEquivalence ((whiskeringLeft C D E).obj F) :=
+  (inferInstance : IsEquivalence (Equivalence.congrLeft F.asEquivalence).inverse)
+
+instance (F : C ⥤ D) [IsEquivalence F] :
+    IsEquivalence ((whiskeringRight E C D).obj F) :=
+  (inferInstance : IsEquivalence (Equivalence.congrRight F.asEquivalence).functor)
+
 end Functor
 
 namespace Equivalence

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -570,8 +570,7 @@ instance isEquivalenceTrans (F : C ⥤ D) (G : D ⥤ E) [IsEquivalence F] [IsEqu
 instance (F : C ⥤ D) [IsEquivalence F] : IsEquivalence ((whiskeringLeft C D E).obj F) :=
   (inferInstance : IsEquivalence (Equivalence.congrLeft F.asEquivalence).inverse)
 
-instance (F : C ⥤ D) [IsEquivalence F] :
-    IsEquivalence ((whiskeringRight E C D).obj F) :=
+instance (F : C ⥤ D) [IsEquivalence F] : IsEquivalence ((whiskeringRight E C D).obj F) :=
   (inferInstance : IsEquivalence (Equivalence.congrRight F.asEquivalence).functor)
 
 end Functor

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -26,12 +26,10 @@ are obtained as `leftKanExtension L F` and `rightKanExtension L F`.
 
 ## TODO (@joelriou)
 
-* define a condition expressing that a functor is a pointwise Kan extension
-* refactor the file `CategoryTheory.Limits.KanExtension` using this new general API
 * define left/right derived functors as particular cases of Kan extensions
 
 ## References
-https://ncatlab.org/nlab/show/Kan+extension
+* https://ncatlab.org/nlab/show/Kan+extension
 
 -/
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -289,8 +289,7 @@ a natural isomorphism `F ≅ F'`. -/
 def rightExtensionEquivalenceOfIso₂ : RightExtension L F ≌ RightExtension L F' :=
   CostructuredArrow.mapIso iso₂
 
-lemma hasRightExtension_iff_of_iso₂ :
-    HasRightKanExtension L F ↔ HasRightKanExtension L F' :=
+lemma hasRightExtension_iff_of_iso₂ : HasRightKanExtension L F ↔ HasRightKanExtension L F' :=
   (rightExtensionEquivalenceOfIso₂ L iso₂).hasTerminal_iff
 
 /-- The equivalence `LeftExtension L F ≌ LeftExtension L F'` induced by

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -276,8 +276,7 @@ lemma hasRightExtension_iff_of_iso₁ : HasRightKanExtension L F ↔ HasRightKan
 
 /-- The equivalence `LeftExtension L F ≌ LeftExtension L' F` induced by
 a natural isomorphism `L ≅ L'`. -/
-def leftExtensionEquivalenceOfIso₁ :
-    LeftExtension L F ≌ LeftExtension L' F :=
+def leftExtensionEquivalenceOfIso₁ : LeftExtension L F ≌ LeftExtension L' F :=
   StructuredArrow.mapNatIso ((whiskeringLeft C H D).mapIso iso₁)
 
 lemma hasLeftExtension_iff_of_iso₁ :

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -286,8 +286,7 @@ variable (L) {F F'}
 
 /-- The equivalence `RightExtension L F ≌ RightExtension L F'` induced by
 a natural isomorphism `F ≅ F'`. -/
-def rightExtensionEquivalenceOfIso₂ :
-    RightExtension L F ≌ RightExtension L F' :=
+def rightExtensionEquivalenceOfIso₂ : RightExtension L F ≌ RightExtension L F' :=
   CostructuredArrow.mapIso iso₂
 
 lemma hasRightExtension_iff_of_iso₂ :

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -297,8 +297,7 @@ a natural isomorphism `F ≅ F'`. -/
 def leftExtensionEquivalenceOfIso₂ : LeftExtension L F ≌ LeftExtension L F' :=
   StructuredArrow.mapIso iso₂
 
-lemma hasLeftExtension_iff_of_iso₂ :
-    HasLeftKanExtension L F ↔ HasLeftKanExtension L F' :=
+lemma hasLeftExtension_iff_of_iso₂ : HasLeftKanExtension L F ↔ HasLeftKanExtension L F' :=
   (leftExtensionEquivalenceOfIso₂ L iso₂).hasInitial_iff
 
 end

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -279,8 +279,7 @@ a natural isomorphism `L ≅ L'`. -/
 def leftExtensionEquivalenceOfIso₁ : LeftExtension L F ≌ LeftExtension L' F :=
   StructuredArrow.mapNatIso ((whiskeringLeft C H D).mapIso iso₁)
 
-lemma hasLeftExtension_iff_of_iso₁ :
-    HasLeftKanExtension L F ↔ HasLeftKanExtension L' F :=
+lemma hasLeftExtension_iff_of_iso₁ : HasLeftKanExtension L F ↔ HasLeftKanExtension L' F :=
   (leftExtensionEquivalenceOfIso₁ iso₁ F).hasInitial_iff
 
 variable (L) {F F'}

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 import Mathlib.CategoryTheory.Comma.StructuredArrow
+import Mathlib.CategoryTheory.Limits.Shapes.Equivalence
 
 /-!
 # Kan extensions
@@ -19,9 +20,12 @@ extension of `F` along `L`, i.e. that it is a terminal object in a
 category `RightExtension L F` of costructured arrows. The condition
 `F'.IsLeftKanExtension α` for `α : F ⟶ L ⋙ F'` is defined similarly.
 
+We also introduce typeclasses `HasRightKanExtension L F` and `HasLeftKanExtension L F`
+which assert the existence of a right or left Kan extension, and chosen Kan extensions
+are obtained as `leftKanExtension L F` and `rightKanExtension L F`.
+
 ## TODO (@joelriou)
 
-* define a property `HasRightKanExtension L F` and related API
 * define a condition expressing that a functor is a pointwise Kan extension
 * refactor the file `CategoryTheory.Limits.KanExtension` using this new general API
 * define left/right derived functors as particular cases of Kan extensions
@@ -37,7 +41,7 @@ open Category Limits
 
 namespace Functor
 
-variable {C D H : Type*} [Category C] [Category D] [Category H]
+variable {C D H H' : Type*} [Category C] [Category D] [Category H] [Category H']
 
 /-- Given two functors `L : C ⥤ H` and `F : C ⥤ D`, this is the category of functors
 `F' : H ⥤ D` equipped with a natural transformation `L ⋙ F' ⟶ F`. -/
@@ -166,6 +170,143 @@ lemma isLeftKanExtension_iff_of_iso {F' : H ⥤ D} {F'' : H ⥤ D} (e : F' ≅ F
   · intro
     refine isLeftKanExtension_of_iso e.symm α' α ?_
     rw [← comm, assoc, ← whiskerLeft_comp, Iso.symm_hom, e.hom_inv_id, whiskerLeft_id', comp_id]
+
+end
+
+/-- This property `HasRightKanExtension L F` holds when the functor `F` has a right
+Kan extension along `L`. -/
+abbrev HasRightKanExtension (L : C ⥤ H) (F : C ⥤ D) := HasTerminal (RightExtension L F)
+
+lemma HasRightKanExtension.mk (F' : H ⥤ D) {L : C ⥤ H} {F : C ⥤ D} (α : L ⋙ F' ⟶ F)
+    [F'.IsRightKanExtension α] : HasRightKanExtension L F :=
+  (F'.isUniversalOfIsRightKanExtension α).hasTerminal
+
+/-- This property `HasLeftKanExtension L F` holds when the functor `F` has a left
+Kan extension along `L`. -/
+abbrev HasLeftKanExtension (L : C ⥤ H) (F : C ⥤ D) := HasInitial (LeftExtension L F)
+
+lemma HasLeftKanExtension.mk (F' : H ⥤ D) {L : C ⥤ H} {F : C ⥤ D} (α : F ⟶ L ⋙ F')
+    [F'.IsLeftKanExtension α] : HasLeftKanExtension L F :=
+  (F'.isUniversalOfIsLeftKanExtension α).hasInitial
+
+section
+
+variable (L : C ⥤ H) (F : C ⥤ D) [HasRightKanExtension L F]
+
+/-- A chosen right Kan extension when `[HasRightKanExtension L F]` holds. -/
+noncomputable def rightKanExtension : H ⥤ D := (⊤_ _ : RightExtension L F).left
+
+/-- The counit of the chosen right Kan extension `rightKanExtension L F`. -/
+noncomputable def rightKanExtensionCounit : L ⋙ rightKanExtension L F ⟶ F :=
+  (⊤_ _ : RightExtension L F).hom
+
+instance : (L.rightKanExtension F).IsRightKanExtension (L.rightKanExtensionCounit F) where
+  nonempty_isUniversal := ⟨terminalIsTerminal⟩
+
+@[ext]
+lemma rightKanExtension_hom_ext {G : H ⥤ D} (γ₁ γ₂ : G ⟶ rightKanExtension L F)
+    (hγ : whiskerLeft L γ₁ ≫ rightKanExtensionCounit L F =
+      whiskerLeft L γ₂ ≫ rightKanExtensionCounit L F) :
+    γ₁ = γ₂ :=
+  hom_ext_of_isRightKanExtension _ _ _ _ hγ
+
+end
+
+section
+
+variable (L : C ⥤ H) (F : C ⥤ D) [HasLeftKanExtension L F]
+
+/-- A chosen left Kan extension when `[HasLeftKanExtension L F]` holds. -/
+noncomputable def leftKanExtension : H ⥤ D := (⊥_ _ : LeftExtension L F).right
+
+/-- The unit of the chosen left Kan extension `leftKanExtension L F`. -/
+noncomputable def leftKanExtensionUnit : F ⟶ L ⋙ leftKanExtension L F :=
+  (⊥_ _ : LeftExtension L F).hom
+
+instance : (L.leftKanExtension F).IsLeftKanExtension (L.leftKanExtensionUnit F) where
+  nonempty_isUniversal := ⟨initialIsInitial⟩
+
+@[ext]
+lemma leftKanExtension_hom_ext {G : H ⥤ D} (γ₁ γ₂ : leftKanExtension L F ⟶ G)
+    (hγ : leftKanExtensionUnit L F ≫ whiskerLeft L γ₁ =
+      leftKanExtensionUnit L F ≫ whiskerLeft L γ₂) : γ₁ = γ₂ :=
+  hom_ext_of_isLeftKanExtension _ _ _ _ hγ
+
+end
+
+section
+
+variable (L L' : C ⥤ H) (iso₁ : L ≅ L') (F F' : C ⥤ D) (e : H ≌ H') (iso₂ : F ≅ F')
+
+/-- The equivalence of categories `RightExtension (L ⋙ e.functor) F ≌ RightExtension L F`
+when `e` is an equivalence. -/
+noncomputable def rightExtensionEquivalenceOfPostcomp₁ :
+    RightExtension (L ⋙ e.functor) F ≌ RightExtension L F := by
+  have := CostructuredArrow.isEquivalencePre ((whiskeringLeft H H' D).obj e.functor)
+    ((whiskeringLeft C H D).obj L) F
+  exact Functor.asEquivalence (CostructuredArrow.pre ((whiskeringLeft H H' D).obj e.functor)
+    ((whiskeringLeft C H D).obj L) F)
+
+lemma hasRightExtension_iff_postcomp₁ :
+    HasRightKanExtension L F ↔ HasRightKanExtension (L ⋙ e.functor) F :=
+  (rightExtensionEquivalenceOfPostcomp₁ L F e).symm.hasTerminal_iff
+
+/-- The equivalence of categories `LeftExtension (L ⋙ e.functor) F ≌ LeftExtension L F`
+when `e` is an equivalence. -/
+noncomputable def leftExtensionEquivalenceOfPostcomp₁ :
+    LeftExtension (L ⋙ e.functor) F ≌ LeftExtension L F := by
+  have := StructuredArrow.isEquivalencePre F ((whiskeringLeft H H' D).obj e.functor)
+    ((whiskeringLeft C H D).obj L)
+  exact Functor.asEquivalence (StructuredArrow.pre F ((whiskeringLeft H H' D).obj e.functor)
+    ((whiskeringLeft C H D).obj L))
+
+lemma hasLeftExtension_iff_postcomp₁ :
+    HasLeftKanExtension L F ↔ HasLeftKanExtension (L ⋙ e.functor) F :=
+  (leftExtensionEquivalenceOfPostcomp₁ L F e).symm.hasInitial_iff
+
+variable {L L'}
+
+/-- The equivalence `RightExtension L F ≌ RightExtension L' F` induced by
+a natural isomorphism `L ≅ L'`. -/
+def rightExtensionEquivalenceOfIso₁ :
+    RightExtension L F ≌ RightExtension L' F :=
+  CostructuredArrow.mapNatIso ((whiskeringLeft C H D).mapIso iso₁)
+
+lemma hasRightExtension_iff_of_iso₁ :
+    HasRightKanExtension L F ↔ HasRightKanExtension L' F :=
+  (rightExtensionEquivalenceOfIso₁ iso₁ F).hasTerminal_iff
+
+/-- The equivalence `LeftExtension L F ≌ LeftExtension L' F` induced by
+a natural isomorphism `L ≅ L'`. -/
+def leftExtensionEquivalenceOfIso₁ :
+    LeftExtension L F ≌ LeftExtension L' F :=
+  StructuredArrow.mapNatIso ((whiskeringLeft C H D).mapIso iso₁)
+
+lemma hasLeftExtension_iff_of_iso₁ :
+    HasLeftKanExtension L F ↔ HasLeftKanExtension L' F :=
+  (leftExtensionEquivalenceOfIso₁ iso₁ F).hasInitial_iff
+
+variable (L) {F F'}
+
+/-- The equivalence `RightExtension L F ≌ RightExtension L F'` induced by
+a natural isomorphism `F ≅ F'`. -/
+def rightExtensionEquivalenceOfIso₂ :
+    RightExtension L F ≌ RightExtension L F' :=
+  CostructuredArrow.mapIso iso₂
+
+lemma hasRightExtension_iff_of_iso₂ :
+    HasRightKanExtension L F ↔ HasRightKanExtension L F' :=
+  (rightExtensionEquivalenceOfIso₂ L iso₂).hasTerminal_iff
+
+/-- The equivalence `LeftExtension L F ≌ LeftExtension L F'` induced by
+a natural isomorphism `F ≅ F'`. -/
+def leftExtensionEquivalenceOfIso₂ :
+    LeftExtension L F ≌ LeftExtension L F' :=
+  StructuredArrow.mapIso iso₂
+
+lemma hasLeftExtension_iff_of_iso₂ :
+    HasLeftKanExtension L F ↔ HasLeftKanExtension L F' :=
+  (leftExtensionEquivalenceOfIso₂ L iso₂).hasInitial_iff
 
 end
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -268,8 +268,7 @@ variable {L L'}
 
 /-- The equivalence `RightExtension L F ≌ RightExtension L' F` induced by
 a natural isomorphism `L ≅ L'`. -/
-def rightExtensionEquivalenceOfIso₁ :
-    RightExtension L F ≌ RightExtension L' F :=
+def rightExtensionEquivalenceOfIso₁ : RightExtension L F ≌ RightExtension L' F :=
   CostructuredArrow.mapNatIso ((whiskeringLeft C H D).mapIso iso₁)
 
 lemma hasRightExtension_iff_of_iso₁ :

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -294,8 +294,7 @@ lemma hasRightExtension_iff_of_iso₂ : HasRightKanExtension L F ↔ HasRightKan
 
 /-- The equivalence `LeftExtension L F ≌ LeftExtension L F'` induced by
 a natural isomorphism `F ≅ F'`. -/
-def leftExtensionEquivalenceOfIso₂ :
-    LeftExtension L F ≌ LeftExtension L F' :=
+def leftExtensionEquivalenceOfIso₂ : LeftExtension L F ≌ LeftExtension L F' :=
   StructuredArrow.mapIso iso₂
 
 lemma hasLeftExtension_iff_of_iso₂ :

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -271,8 +271,7 @@ a natural isomorphism `L ≅ L'`. -/
 def rightExtensionEquivalenceOfIso₁ : RightExtension L F ≌ RightExtension L' F :=
   CostructuredArrow.mapNatIso ((whiskeringLeft C H D).mapIso iso₁)
 
-lemma hasRightExtension_iff_of_iso₁ :
-    HasRightKanExtension L F ↔ HasRightKanExtension L' F :=
+lemma hasRightExtension_iff_of_iso₁ : HasRightKanExtension L F ↔ HasRightKanExtension L' F :=
   (rightExtensionEquivalenceOfIso₁ iso₁ F).hasTerminal_iff
 
 /-- The equivalence `LeftExtension L F ≌ LeftExtension L' F` induced by

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Functor.KanExtension.Basic
+
+/-!
+# Pointwise Kan extensions
+
+In this file, we define the notion of pointwise (left) Kan Extension. Given two functors
+`F : C ⥤ H` and `L : C ⥤ D`, and `E : LeftExtension L F`, we introduce a cocone
+`E.coconeAt Y` for the functor `CostructuredArrow.proj L Y ⋙ F : CostructuredArrow L Y ⥤ H`,
+and the type `E.IsPointwiseLeftKanExtensionAt Y` which expresses that `E.coconeAt Y` is colimit.
+When this holds for all `Y : D`, we may say that `E` is a pointwise left Kan extension
+(`E.IsPointwiseLeftKanExtension`).
+
+Conversely, when `CostructuredArrow.proj L Y ⋙ F` has a colimit, we say that
+`F` has a pointwise left Kan extension at `Y : D` (`HasPointwiseLeftKanExtensionAt L F Y`),
+and if this holds for all `Y : D`, we construct a functor
+`pointwiseLeftKanExtension L F : D ⥤ H` and show
+
+ we say that `F` has a pointwise left Kan Extension at `Y : D`
+(`HasPointwiseLeftKanExtensionAt L F Y`) if the functor
+`CostructuredArrow.proj L Y ⋙ F : CostructuredArrow L Y ⥤ H` has a colimit.
+
+
+
+## TODO
+
+* Dualize the results
+
+-/
+
+namespace CategoryTheory
+
+open Category Limits
+
+namespace Functor
+
+variable {C D H : Type*} [Category C] [Category D] [Category H] (L : C ⥤ D) (F : C ⥤ H)
+
+abbrev HasPointwiseLeftKanExtensionAt (Y : D) :=
+  HasColimit (CostructuredArrow.proj L Y ⋙ F)
+
+abbrev HasPointwiseLeftKanExtension := ∀ (Y : D), HasPointwiseLeftKanExtensionAt L F Y
+
+namespace LeftExtension
+
+variable {F L} (E : LeftExtension L F)
+
+@[simps]
+def coconeAt (Y : D) : Cocone (CostructuredArrow.proj L Y ⋙ F) where
+  pt := E.right.obj Y
+  ι :=
+    { app := fun g => E.hom.app g.left ≫ E.right.map g.hom
+      naturality := fun g₁ g₂ φ => by
+        dsimp
+        rw [← CostructuredArrow.w φ]
+        simp only [assoc, NatTrans.naturality_assoc, Functor.comp_map,
+          Functor.map_comp, comp_id] }
+
+def IsPointwiseLeftKanExtensionAt (Y : D) := IsColimit (E.coconeAt Y)
+
+variable {E}
+
+lemma IsPointwiseLeftKanExtensionAt.hasPointwiseLeftKanExtensionAt
+    {E : LeftExtension L F} {Y : D} (h : E.IsPointwiseLeftKanExtensionAt Y) :
+  HasPointwiseLeftKanExtensionAt L F Y := ⟨_, h⟩
+
+variable (E)
+
+abbrev IsPointwiseLeftKanExtension := ∀ (Y : D), E.IsPointwiseLeftKanExtensionAt Y
+
+variable (h : E.IsPointwiseLeftKanExtension)
+
+lemma IsPointwiseLeftKanExtension.hasPointwiseLeftKanExtension :
+    HasPointwiseLeftKanExtension L F :=
+  fun Y => (h Y).hasPointwiseLeftKanExtensionAt
+
+def isUniversalOfPointwise : E.IsUniversal :=
+  IsInitial.ofUniqueHom (fun G => StructuredArrow.homMk
+        { app := fun Y => (h Y).desc (LeftExtension.coconeAt G Y)
+          naturality := fun Y₁ Y₂ φ => (h Y₁).hom_ext (fun X => by
+            rw [(h Y₁).fac_assoc (coconeAt G Y₁) X]
+            simpa using (h Y₂).fac (coconeAt G Y₂) ((CostructuredArrow.map φ).obj X)) }
+      (by
+        ext X
+        simpa using (h (L.obj X)).fac (LeftExtension.coconeAt G _) (CostructuredArrow.mk (𝟙 _))))
+    (fun G => by
+      suffices ∀ (m₁ m₂ : E ⟶ G), m₁ = m₂ by intros; apply this
+      intro m₁ m₂
+      ext Y
+      apply (h Y).hom_ext
+      intro X
+      have eq₁ := congr_app (StructuredArrow.w m₁) X.left
+      have eq₂ := congr_app (StructuredArrow.w m₂) X.left
+      dsimp at eq₁ eq₂ ⊢
+      simp only [assoc, NatTrans.naturality]
+      rw [reassoc_of% eq₁, reassoc_of% eq₂])
+
+--lemma IsPointwiseLeftKanExtension.hasLeftKanExtension :
+--    HasLeftKanExtension L F where
+
+end LeftExtension
+
+section
+
+variable [HasPointwiseLeftKanExtension L F]
+
+@[simps]
+noncomputable def pointwiseLeftKanExtension : D ⥤ H where
+  obj Y := colimit (CostructuredArrow.proj L Y ⋙ F)
+  map {Y₁ Y₂} f :=
+    colimit.desc (CostructuredArrow.proj L Y₁ ⋙ F)
+      (Cocone.mk (colimit (CostructuredArrow.proj L Y₂ ⋙ F))
+        { app := fun g => colimit.ι (CostructuredArrow.proj L Y₂ ⋙ F)
+            ((CostructuredArrow.map f).obj g)
+          naturality := fun g₁ g₂ φ => by
+            simpa using colimit.w (CostructuredArrow.proj L Y₂ ⋙ F)
+              ((CostructuredArrow.map f).map φ) })
+  map_id Y := colimit.hom_ext (fun j => by
+    dsimp
+    simp only [colimit.ι_desc, comp_id]
+    congr
+    apply CostructuredArrow.map_id)
+  map_comp {Y₁ Y₂ Y₃} f f' := colimit.hom_ext (fun j => by
+    dsimp
+    simp only [colimit.ι_desc, colimit.ι_desc_assoc, comp_obj, CostructuredArrow.proj_obj]
+    congr 1
+    apply CostructuredArrow.map_comp)
+
+@[simps]
+noncomputable def pointwiseLeftKanExtensionUnit : F ⟶ L ⋙ pointwiseLeftKanExtension L F where
+  app X := colimit.ι (CostructuredArrow.proj L (L.obj X) ⋙ F) (CostructuredArrow.mk (𝟙 (L.obj X)))
+  naturality {X₁ X₂} f:= by
+    simp only [comp_obj, pointwiseLeftKanExtension_obj, comp_map,
+      pointwiseLeftKanExtension_map, colimit.ι_desc, CostructuredArrow.map_mk]
+    rw [id_comp]
+    let φ : CostructuredArrow.mk (L.map f) ⟶ CostructuredArrow.mk (𝟙 (L.obj X₂)) :=
+      CostructuredArrow.homMk f
+    exact colimit.w (CostructuredArrow.proj L (L.obj X₂) ⋙ F) φ
+
+noncomputable def pointwiseLeftKanExtensionIsPointwiseLeftKanExtension :
+    (LeftExtension.mk _ (pointwiseLeftKanExtensionUnit L F)).IsPointwiseLeftKanExtension :=
+  fun X => IsColimit.ofIsoColimit (colimit.isColimit _) (Cocones.ext (Iso.refl _) (fun j => by
+    dsimp
+    simp only [comp_id, colimit.ι_desc, CostructuredArrow.map_mk]
+    congr 1
+    rw [id_comp]
+    rfl))
+
+noncomputable def pointwiseLeftKanExtensionIsUniversal :
+    (LeftExtension.mk _ (pointwiseLeftKanExtensionUnit L F)).IsUniversal :=
+  LeftExtension.isUniversalOfPointwise _
+    (pointwiseLeftKanExtensionIsPointwiseLeftKanExtension L F)
+
+instance : (pointwiseLeftKanExtension L F).IsLeftKanExtension
+    (pointwiseLeftKanExtensionUnit L F) where
+  nonempty_isUniversal := ⟨pointwiseLeftKanExtensionIsUniversal L F⟩
+
+--instance : HasLeftKanExtension L F :=
+--  HasLeftKanExtension.mk' _ (F.pointwiseLeftKanExtensionNatTrans L)
+
+end
+
+end Functor
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -153,7 +153,7 @@ noncomputable def pointwiseLeftKanExtension : D ⥤ H where
 noncomputable def pointwiseLeftKanExtensionUnit : F ⟶ L ⋙ pointwiseLeftKanExtension L F where
   app X := colimit.ι (CostructuredArrow.proj L (L.obj X) ⋙ F)
     (CostructuredArrow.mk (𝟙 (L.obj X)))
-  naturality {X₁ X₂} f:= by
+  naturality {X₁ X₂} f := by
     simp only [comp_obj, pointwiseLeftKanExtension_obj, comp_map,
       pointwiseLeftKanExtension_map, colimit.ι_desc, CostructuredArrow.map_mk]
     rw [id_comp]

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -169,8 +169,7 @@ noncomputable def pointwiseLeftKanExtensionIsPointwiseLeftKanExtension :
     dsimp
     simp only [comp_id, colimit.ι_desc, CostructuredArrow.map_mk]
     congr 1
-    rw [id_comp]
-    rfl))
+    rw [id_comp, ← CostructuredArrow.eq_mk]
 
 /-- The functor `pointwiseLeftKanExtension L F` is a left Kan extension of `F` along `L`. -/
 noncomputable def pointwiseLeftKanExtensionIsUniversal :

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -75,8 +75,7 @@ lemma IsPointwiseLeftKanExtensionAt.hasPointwiseLeftKanExtensionAt
     {E : LeftExtension L F} {Y : D} (h : E.IsPointwiseLeftKanExtensionAt Y) :
     HasPointwiseLeftKanExtensionAt L F Y := ⟨_, h⟩
 
-variable (E)
-
+variable (E) in
 /-- A left extension `E : LeftExtension L F` is a pointwise left Kan extension when
 it is a pointwise left Kan extension at any object. -/
 abbrev IsPointwiseLeftKanExtension := ∀ (Y : D), E.IsPointwiseLeftKanExtensionAt Y
@@ -87,27 +86,30 @@ lemma IsPointwiseLeftKanExtension.hasPointwiseLeftKanExtension :
     HasPointwiseLeftKanExtension L F :=
   fun Y => (h Y).hasPointwiseLeftKanExtensionAt
 
+/-- The (unique) morphism from a pointwise left Kan extension. -/
+def IsPointwiseLeftKanExtension.homFrom (G : LeftExtension L F) : E ⟶ G :=
+  StructuredArrow.homMk
+    { app := fun Y => (h Y).desc (LeftExtension.coconeAt G Y)
+      naturality := fun Y₁ Y₂ φ => (h Y₁).hom_ext (fun X => by
+        rw [(h Y₁).fac_assoc (coconeAt G Y₁) X]
+        simpa using (h Y₂).fac (coconeAt G Y₂) ((CostructuredArrow.map φ).obj X)) }
+    (by
+      ext X
+      simpa using (h (L.obj X)).fac (LeftExtension.coconeAt G _) (CostructuredArrow.mk (𝟙 _)))
+
+lemma IsPointwiseLeftKanExtension.hom_ext {G : LeftExtension L F} {f₁ f₂ : E ⟶ G} : f₁ = f₂ := by
+  ext Y
+  apply (h Y).hom_ext
+  intro X
+  have eq₁ := congr_app (StructuredArrow.w f₁) X.left
+  have eq₂ := congr_app (StructuredArrow.w f₂) X.left
+  dsimp at eq₁ eq₂ ⊢
+  simp only [assoc, NatTrans.naturality]
+  rw [reassoc_of% eq₁, reassoc_of% eq₂]
+
 /-- A pointwise left Kan extension is universal, i.e. it is a left Kan extension. -/
 def IsPointwiseLeftKanExtension.isUniversal : E.IsUniversal :=
-  IsInitial.ofUniqueHom (fun G => StructuredArrow.homMk
-        { app := fun Y => (h Y).desc (LeftExtension.coconeAt G Y)
-          naturality := fun Y₁ Y₂ φ => (h Y₁).hom_ext (fun X => by
-            rw [(h Y₁).fac_assoc (coconeAt G Y₁) X]
-            simpa using (h Y₂).fac (coconeAt G Y₂) ((CostructuredArrow.map φ).obj X)) }
-      (by
-        ext X
-        simpa using (h (L.obj X)).fac (LeftExtension.coconeAt G _) (CostructuredArrow.mk (𝟙 _))))
-    (fun G => by
-      suffices ∀ (m₁ m₂ : E ⟶ G), m₁ = m₂ by intros; apply this
-      intro m₁ m₂
-      ext Y
-      apply (h Y).hom_ext
-      intro X
-      have eq₁ := congr_app (StructuredArrow.w m₁) X.left
-      have eq₂ := congr_app (StructuredArrow.w m₂) X.left
-      dsimp at eq₁ eq₂ ⊢
-      simp only [assoc, NatTrans.naturality]
-      rw [reassoc_of% eq₁, reassoc_of% eq₂])
+  IsInitial.ofUniqueHom h.homFrom (fun _ _ => h.hom_ext)
 
 lemma IsPointwiseLeftKanExtension.isLeftKanExtension :
     E.right.IsLeftKanExtension E.hom where
@@ -169,7 +171,7 @@ noncomputable def pointwiseLeftKanExtensionIsPointwiseLeftKanExtension :
     dsimp
     simp only [comp_id, colimit.ι_desc, CostructuredArrow.map_mk]
     congr 1
-    rw [id_comp, ← CostructuredArrow.eq_mk]
+    rw [id_comp, ← CostructuredArrow.eq_mk]))
 
 /-- The functor `pointwiseLeftKanExtension L F` is a left Kan extension of `F` along `L`. -/
 noncomputable def pointwiseLeftKanExtensionIsUniversal :

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -73,7 +73,7 @@ variable {E}
 
 lemma IsPointwiseLeftKanExtensionAt.hasPointwiseLeftKanExtensionAt
     {E : LeftExtension L F} {Y : D} (h : E.IsPointwiseLeftKanExtensionAt Y) :
-  HasPointwiseLeftKanExtensionAt L F Y := ⟨_, h⟩
+    HasPointwiseLeftKanExtensionAt L F Y := ⟨_, h⟩
 
 variable (E)
 


### PR DESCRIPTION
In this PR, we introduce pointwise left Kan extensions: a criteria `IsPointwiseLeftKanExtension`, a typeclass `HasPointwiseLeftKanExtension` (which asserts the existence of certain colimits) and a construction of a pointwise left Kan extension when `HasPointwiseLeftKanExtension` holds. We also show that pointwise left Kan extensions are left Kan extensions.

---
- [x] depends on: #10384

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
