### PR TITLE
[Merged by Bors] - Feat: Add Yang-Baxter equation and the opposite braided monoidal category 

### DIFF
--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -71,6 +71,10 @@ theorem unop {W X Y Z : Cᵒᵖ} {f : W ⟶ X} {g : W ⟶ Y} {h : X ⟶ Z} {i : 
   ⟨by simp only [← unop_comp, p.w]⟩
 #align category_theory.comm_sq.unop CategoryTheory.CommSq.unop
 
+theorem vert_inv {g : W ≅ Y} {h : X ≅ Z} (p : CommSq f g.hom h.hom i) :
+    CommSq i g.inv h.inv f :=
+  ⟨by rw [Iso.comp_inv_eq, Category.assoc, Iso.eq_inv_comp, p.w]⟩
+
 end CommSq
 
 namespace Functor

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -130,7 +130,7 @@ theorem braiding_naturality {X X' Y Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
   simp_rw [Category.assoc, braiding_naturality_left, braiding_naturality_right_assoc]
 
 theorem yang_baxter (X Y Z : C) :
-    (α_ X Y Z).inv ≫ ((β_ X Y).hom ▷ Z) ≫ (α_ Y X Z).hom ≫ 
+    (α_ X Y Z).inv ≫ ((β_ X Y).hom ▷ Z) ≫ (α_ Y X Z).hom ≫
     (Y ◁ (β_ X Z).hom) ≫ (α_ Y Z X).inv ≫
     ((β_ Y Z).hom ▷ X) ≫ (α_ Z Y X).hom
     = (X ◁ (β_ Y Z).hom) ≫ (α_ X Z Y).inv ≫
@@ -154,7 +154,7 @@ theorem yang_baxter' (X Y Z : C) :
              comp_id, assoc, tensor_id, id_comp, yang_baxter]
 
 theorem yang_baxter_iso (X Y Z : C) :
-    (α_ X Y Z).symm ≪≫ whiskerRightIso (β_ X Y) Z ≪≫ α_ Y X Z ≪≫ 
+    (α_ X Y Z).symm ≪≫ whiskerRightIso (β_ X Y) Z ≪≫ α_ Y X Z ≪≫
     whiskerLeftIso Y (β_ X Z) ≪≫ (α_ Y Z X).symm ≪≫
     whiskerRightIso (β_ Y Z) X ≪≫ (α_ Z Y X)
     = whiskerLeftIso X (β_ Y Z) ≪≫ (α_ X Z Y).symm ≪≫

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -28,6 +28,10 @@ The rationale is that we are not carrying any additional data, just requiring a 
 * Construct the Drinfeld center of a monoidal category as a braided monoidal category.
 * Say something about pseudo-natural transformations.
 
+## References
+
+* [Pavel Etingof, Shlomo Gelaki, Dmitri Nikshych, Victor Ostrik, *Tensor categories*][egno15]
+
 -/
 
 
@@ -678,22 +682,15 @@ end Tensor
 namespace MonoidalOpposite
 
 instance instBraiding : BraidedCategory Cᴹᵒᵖ where
-  braiding X Y := ((reverseBraiding C).braiding (unmop Y) (unmop X)).mop
-  braiding_naturality_right X {_ _} f :=
-    (reverseBraiding C).braiding_naturality_left f.unmop (unmop X)
-  braiding_naturality_left {_ _} f Z :=
-    (reverseBraiding C).braiding_naturality_right (unmop Z) f.unmop
-  hexagon_forward X Y Z :=
-    (reverseBraiding C).hexagon_reverse (unmop Z) (unmop Y) (unmop X)
-  hexagon_reverse X Y Z :=
-    (reverseBraiding C).hexagon_forward (unmop Z) (unmop Y) (unmop X)
+  braiding X Y := (β_ (unmop Y) (unmop X)).mop
+  braiding_naturality_right X {_ _} f := braiding_naturality_left f.unmop (unmop X)
+  braiding_naturality_left {_ _} f Z := braiding_naturality_right (unmop Z) f.unmop
+  hexagon_forward X Y Z := hexagon_reverse (unmop Z) (unmop Y) (unmop X)
+  hexagon_reverse X Y Z := hexagon_forward (unmop Z) (unmop Y) (unmop X)
 
-@[simps!] def mopMonoidalFunctor : MonoidalFunctor C Cᴹᵒᵖ where
+@[simps!] def mopBraidedFunctor : BraidedFunctor C Cᴹᵒᵖ where
   μ X Y := (β_ (mop X) (mop Y)).hom
   ε := 𝟙 (𝟙_ Cᴹᵒᵖ)
-  μ_isIso X Y := inferInstanceAs (IsIso (β_ X Y).inv)
-  μ_natural_left f X' := braiding_naturality f.mop (𝟙 (mop X'))
-  μ_natural_right {X Y} X' f := braiding_naturality (𝟙 (mop X')) f.mop
   associativity X Y Z := by
     simp only [tensorHom_id, id_tensorHom]
     change (β_ (mop X) (mop Y)).hom ▷ (mop Z) ≫ (β_ (mop Y ⊗ mop X) (mop Z)).hom
@@ -714,12 +711,9 @@ instance instBraiding : BraidedCategory Cᴹᵒᵖ where
     $ Eq.trans (id_comp _) (braiding_leftUnitor Cᴹᵒᵖ (mop X))
   __ := mopFunctor C
 
-@[simps!] def unmopMonoidalFunctor : MonoidalFunctor Cᴹᵒᵖ C where
+@[simps!] def unmopBraidedFunctor : BraidedFunctor Cᴹᵒᵖ C where
   μ X Y := (β_ (unmop X) (unmop Y)).hom
   ε := 𝟙 (𝟙_ C)
-  μ_isIso X Y := inferInstanceAs (IsIso (β_ (unmop X) (unmop Y)).hom)
-  μ_natural_left f X' := braiding_naturality f.unmop (𝟙 (unmop X'))
-  μ_natural_right {X Y} X' f := braiding_naturality (𝟙 (unmop X')) f.unmop
   associativity X Y Z := by
     simp only [tensorHom_id, id_tensorHom]
     change (β_ (unmop X) (unmop Y)).hom ▷ (unmop Z) ≫ (β_ (unmop Y ⊗ unmop X) (unmop Z)).hom

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -128,6 +128,7 @@ theorem braiding_naturality {X X' Y Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
   rw [tensorHom_def' f g, tensorHom_def g f]
   simp_rw [Category.assoc, braiding_naturality_left, braiding_naturality_right_assoc]
 
+@[reassoc]
 theorem yang_baxter (X Y Z : C) :
     (α_ X Y Z).inv ≫ ((β_ X Y).hom ▷ Z) ≫ (α_ Y X Z).hom ≫
     (Y ◁ (β_ X Z).hom) ≫ (α_ Y Z X).inv ≫ ((β_ Y Z).hom ▷ X) ≫ (α_ Z Y X).hom =
@@ -651,8 +652,23 @@ attribute [reassoc] associator_monoidal
 
 end Tensor
 
+@[simps]
+instance : BraidedCategory Cᵒᵖ where
+  braiding X Y := Iso.op (β_ Y.unop X.unop)
+  braiding_naturality_right X {_ _} f :=
+    Quiver.Hom.unop_inj <| (braiding_naturality_left f.unop X.unop).symm
+  braiding_naturality_left {_ _} f Z :=
+    Quiver.Hom.unop_inj <| (braiding_naturality_right Z.unop f.unop).symm
+  hexagon_forward X Y Z := Quiver.Hom.unop_inj <| by
+    convert hexagon_reverse Y.unop Z.unop X.unop using 1
+    <;> exact assoc _ _ _
+  hexagon_reverse X Y Z := Quiver.Hom.unop_inj <| by
+    convert hexagon_forward Z.unop X.unop Y.unop using 1
+    <;> exact assoc _ _ _
+
 namespace MonoidalOpposite
 
+@[simps]
 instance instBraiding : BraidedCategory Cᴹᵒᵖ where
   braiding X Y := (β_ (unmop Y) (unmop X)).mop
   braiding_naturality_right X {_ _} f := braiding_naturality_left f.unmop (unmop X)
@@ -665,18 +681,10 @@ monoidal opposite, upgraded to a braided functor. -/
 @[simps!] def mopBraidedFunctor : BraidedFunctor C Cᴹᵒᵖ where
   μ X Y := (β_ (mop X) (mop Y)).hom
   ε := 𝟙 (𝟙_ Cᴹᵒᵖ)
-  associativity X Y Z := by
-    simp only [tensorHom_id, id_tensorHom]
-    change (β_ (mop X) (mop Y)).hom ▷ (mop Z) ≫ (β_ (mop Y ⊗ mop X) (mop Z)).hom ≫
-              (α_ (mop Z) (mop Y) (mop X)).inv
-            = (α_ (mop X) (mop Y) (mop Z)).hom ≫ (mop X) ◁ (β_ (mop Y) (mop Z)).hom ≫
-                (β_ (mop X) (mop Z ⊗ mop Y)).hom
-    refine (α_ (mop X) (mop Y) (mop Z)).inv_comp_eq.mp ?_
-    simp only [← assoc]
-    refine (α_ (mop Z) (mop Y) (mop X)).comp_inv_eq.mpr ?_
-    simp only [braiding_tensor_left, braiding_tensor_right,
-               assoc, Iso.inv_hom_id, comp_id]
-    exact yang_baxter (mop X) (mop Y) (mop Z)
+  μ_natural_left {_ _} f Z := unmop_inj <| by simp
+  μ_natural_right {_ _} Z f := unmop_inj <| by simp
+  associativity X Y Z := unmop_inj <| by
+    simp [id_tensorHom, tensorHom_id, yang_baxter]
   left_unitality := by intro; erw [tensor_id, id_comp, braiding_rightUnitor]
   right_unitality := by intro; erw [tensor_id, id_comp, braiding_leftUnitor]
   __ := mopFunctor C
@@ -686,18 +694,9 @@ monoidal opposite of `C` to `C`, upgraded to a braided functor. -/
 @[simps!] def unmopBraidedFunctor : BraidedFunctor Cᴹᵒᵖ C where
   μ X Y := (β_ (unmop X) (unmop Y)).hom
   ε := 𝟙 (𝟙_ C)
-  associativity X Y Z := by
-    simp only [tensorHom_id, id_tensorHom]
-    change (β_ (unmop X) (unmop Y)).hom ▷ (unmop Z) ≫ (β_ (unmop Y ⊗ unmop X) (unmop Z)).hom
-              ≫ (α_ (unmop Z) (unmop Y) (unmop X)).inv
-            = (α_ (unmop X) (unmop Y) (unmop Z)).hom ≫ (unmop X) ◁ (β_ (unmop Y) (unmop Z)).hom
-              ≫ (β_ (unmop X) (unmop Z ⊗ unmop Y)).hom
-    refine (α_ (unmop X) (unmop Y) (unmop Z)).inv_comp_eq.mp ?_
-    simp only [← assoc]
-    refine (α_ (unmop Z) (unmop Y) (unmop X)).comp_inv_eq.mpr ?_
-    simp only [braiding_tensor_left, braiding_tensor_right,
-               assoc, Iso.inv_hom_id, comp_id]
-    exact yang_baxter (unmop X) (unmop Y) (unmop Z)
+  associativity X Y Z := mop_inj <| by
+    simp [id_tensorHom, tensorHom_id]
+    exact (yang_baxter Z Y X).symm
   left_unitality := by intro; erw [tensor_id, id_comp, braiding_rightUnitor]
   right_unitality := by intro; erw [tensor_id, id_comp, braiding_leftUnitor]
   __ := unmopFunctor C

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -130,12 +130,12 @@ theorem braiding_naturality {X X' Y Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
   simp_rw [Category.assoc, braiding_naturality_left, braiding_naturality_right_assoc]
 
 theorem yang_baxter (X Y Z : C) :
-    (α_ X Y Z).inv ≫ ((β_ X Y).hom ▷ Z) ≫ (α_ Y X Z).hom
-    ≫ (Y ◁ (β_ X Z).hom) ≫ (α_ Y Z X).inv
-    ≫ ((β_ Y Z).hom ▷ X) ≫ (α_ Z Y X).hom
-    = (X ◁ (β_ Y Z).hom) ≫ (α_ X Z Y).inv
-      ≫ ((β_ X Z).hom ▷ Y) ≫ (α_ Z X Y).hom
-      ≫ (Z ◁ (β_ X Y).hom) := by
+    (α_ X Y Z).inv ≫ ((β_ X Y).hom ▷ Z) ≫ (α_ Y X Z).hom ≫ 
+    (Y ◁ (β_ X Z).hom) ≫ (α_ Y Z X).inv ≫
+    ((β_ Y Z).hom ▷ X) ≫ (α_ Z Y X).hom
+    = (X ◁ (β_ Y Z).hom) ≫ (α_ X Z Y).inv ≫
+      ((β_ X Z).hom ▷ Y) ≫ (α_ Z X Y).hom ≫
+      (Z ◁ (β_ X Y).hom) := by
   have := (braiding_naturality_right_assoc X (β_ Y Z).hom (α_ Z Y X).hom).symm
   refine Eq.trans (Eq.symm ?_) (Eq.trans this ?_)
   · refine Eq.trans (congrArg (. ≫ _) (braiding_tensor_right X Y Z)) ?_
@@ -154,12 +154,12 @@ theorem yang_baxter' (X Y Z : C) :
              comp_id, assoc, tensor_id, id_comp, yang_baxter]
 
 theorem yang_baxter_iso (X Y Z : C) :
-    (α_ X Y Z).symm ≪≫ whiskerRightIso (β_ X Y) Z ≪≫ α_ Y X Z
-    ≪≫ whiskerLeftIso Y (β_ X Z) ≪≫ (α_ Y Z X).symm
-    ≪≫ whiskerRightIso (β_ Y Z) X ≪≫ (α_ Z Y X)
-    = whiskerLeftIso X (β_ Y Z) ≪≫ (α_ X Z Y).symm
-      ≪≫ whiskerRightIso (β_ X Z) Y ≪≫ α_ Z X Y
-      ≪≫ whiskerLeftIso Z (β_ X Y) := Iso.ext (yang_baxter X Y Z)
+    (α_ X Y Z).symm ≪≫ whiskerRightIso (β_ X Y) Z ≪≫ α_ Y X Z ≪≫ 
+    whiskerLeftIso Y (β_ X Z) ≪≫ (α_ Y Z X).symm ≪≫
+    whiskerRightIso (β_ Y Z) X ≪≫ (α_ Z Y X)
+    = whiskerLeftIso X (β_ Y Z) ≪≫ (α_ X Z Y).symm ≪≫
+      whiskerRightIso (β_ X Z) Y ≪≫ α_ Z X Y ≪≫
+      whiskerLeftIso Z (β_ X Y) := Iso.ext (yang_baxter X Y Z)
 
 end BraidedCategory
 
@@ -676,10 +676,10 @@ monoidal opposite, upgraded to a braided functor. -/
   ε := 𝟙 (𝟙_ Cᴹᵒᵖ)
   associativity X Y Z := by
     simp only [tensorHom_id, id_tensorHom]
-    change (β_ (mop X) (mop Y)).hom ▷ (mop Z) ≫ (β_ (mop Y ⊗ mop X) (mop Z)).hom
-              ≫ (α_ (mop Z) (mop Y) (mop X)).inv
-            = (α_ (mop X) (mop Y) (mop Z)).hom ≫ (mop X) ◁ (β_ (mop Y) (mop Z)).hom
-              ≫ (β_ (mop X) (mop Z ⊗ mop Y)).hom
+    change (β_ (mop X) (mop Y)).hom ▷ (mop Z) ≫ (β_ (mop Y ⊗ mop X) (mop Z)).hom ≫
+              (α_ (mop Z) (mop Y) (mop X)).inv
+            = (α_ (mop X) (mop Y) (mop Z)).hom ≫ (mop X) ◁ (β_ (mop Y) (mop Z)).hom ≫
+                (β_ (mop X) (mop Z ⊗ mop Y)).hom
     refine (α_ (mop X) (mop Y) (mop Z)).inv_comp_eq.mp ?_
     simp only [← assoc]
     refine (α_ (mop Z) (mop Y) (mop X)).comp_inv_eq.mpr ?_

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -129,6 +129,21 @@ theorem braiding_naturality {X X' Y Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
   rw [tensorHom_def' f g, tensorHom_def g f]
   simp_rw [Category.assoc, braiding_naturality_left, braiding_naturality_right_assoc]
 
+@[reassoc (attr := simp)]
+theorem braiding_inv_naturality_right (X : C) {Y Z : C} (f : Y ⟶ Z) :
+    X ◁ f ≫ (β_ Z X).inv = (β_ Y X).inv ≫ f ▷ X :=
+  CommSq.w <| .vert_inv <| .mk <| braiding_naturality_left f X
+
+@[reassoc (attr := simp)]
+theorem braiding_inv_naturality_left {X Y : C} (f : X ⟶ Y) (Z : C) :
+    f ▷ Z ≫ (β_ Z Y).inv = (β_ Z X).inv ≫ Z ◁ f :=
+  CommSq.w <| .vert_inv <| .mk <| braiding_naturality_right Z f
+
+@[reassoc (attr := simp)]
+theorem braiding_inv_naturality {X X' Y Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
+    (f ⊗ g) ≫ (β_ Y' Y).inv = (β_ X' X).inv ≫ (g ⊗ f) :=
+  CommSq.w <| .vert_inv <| .mk <| braiding_naturality g f
+
 @[reassoc]
 theorem yang_baxter (X Y Z : C) :
     (α_ X Y Z).inv ≫ (β_ X Y).hom ▷ Z ≫ (α_ Y X Z).hom ≫
@@ -168,15 +183,13 @@ theorem hexagon_reverse_iso (X Y Z : C) :
 theorem hexagon_forward_inv (X Y Z : C) :
     (α_ Y Z X).inv ≫ (β_ X (Y ⊗ Z)).inv ≫ (α_ X Y Z).inv =
       Y ◁ (β_ X Z).inv ≫ (α_ Y X Z).inv ≫ (β_ X Y).inv ▷ Z := by
-  convert congrArg Iso.inv (hexagon_forward_iso X Y Z) using 1
-  <;> exact (assoc _ _ _).symm
+  simp
 
 @[reassoc]
 theorem hexagon_reverse_inv (X Y Z : C) :
     (α_ Z X Y).hom ≫ (β_ (X ⊗ Y) Z).inv ≫ (α_ X Y Z).hom =
       (β_ X Z).inv ▷ Y ≫ (α_ X Z Y).hom ≫ X ◁ (β_ Y Z).inv := by
-  convert congrArg Iso.inv (hexagon_reverse_iso X Y Z) using 1
-  <;> exact (assoc _ _ _).symm
+  simp
 
 end BraidedCategory
 
@@ -681,12 +694,6 @@ instance : BraidedCategory Cᵒᵖ where
   braiding X Y := (β_ Y.unop X.unop).op
   braiding_naturality_right X {_ _} f := Quiver.Hom.unop_inj <| by simp
   braiding_naturality_left {_ _} f Z := Quiver.Hom.unop_inj <| by simp
-  hexagon_forward X Y Z := Quiver.Hom.unop_inj <| by
-    convert hexagon_reverse Y.unop Z.unop X.unop using 1
-    <;> exact assoc _ _ _
-  hexagon_reverse X Y Z := Quiver.Hom.unop_inj <| by
-    convert hexagon_forward Z.unop X.unop Y.unop using 1
-    <;> exact assoc _ _ _
 
 section OppositeLemmas
 
@@ -709,8 +716,6 @@ instance instBraiding : BraidedCategory Cᴹᵒᵖ where
   braiding X Y := (β_ Y.unmop X.unmop).mop
   braiding_naturality_right X {_ _} f := Quiver.Hom.unmop_inj <| by simp
   braiding_naturality_left {_ _} f Z := Quiver.Hom.unmop_inj <| by simp
-  hexagon_forward X Y Z := Quiver.Hom.unmop_inj <| by simp
-  hexagon_reverse X Y Z := Quiver.Hom.unmop_inj <| by simp
 
 section MonoidalOppositeLemmas
 
@@ -756,12 +761,8 @@ This corresponds to the automorphism of the braid group swapping
 over-crossings and under-crossings. -/
 @[reducible] def reverseBraiding : BraidedCategory C where
   braiding X Y := (β_ Y X).symm
-  braiding_naturality_right X {_ _} f :=
-    CommSq.w <| .vert_inv <| .mk <| braiding_naturality_left f X
-  braiding_naturality_left {_ _} f Z :=
-    CommSq.w <| .vert_inv <| .mk <| braiding_naturality_right Z f
-  hexagon_forward X Y Z := hexagon_reverse_inv Y Z X
-  hexagon_reverse X Y Z := hexagon_forward_inv Z X Y
+  braiding_naturality_right X {_ _} f := by simp
+  braiding_naturality_left {_ _} f Z := by simp
 
 lemma SymmetricCategory.reverseBraiding_eq (C : Type u₁) [Category.{v₁} C]
     [MonoidalCategory C] [i : SymmetricCategory C] :

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -148,8 +148,8 @@ theorem yang_baxter' (X Y Z : C) :
 theorem yang_baxter_iso (X Y Z : C) :
     (α_ X Y Z).symm ≪≫ whiskerRightIso (β_ X Y) Z ≪≫ α_ Y X Z ≪≫
     whiskerLeftIso Y (β_ X Z) ≪≫ (α_ Y Z X).symm ≪≫
-    whiskerRightIso (β_ Y Z) X ≪≫ (α_ Z Y X)
-    = whiskerLeftIso X (β_ Y Z) ≪≫ (α_ X Z Y).symm ≪≫
+    whiskerRightIso (β_ Y Z) X ≪≫ (α_ Z Y X) =
+      whiskerLeftIso X (β_ Y Z) ≪≫ (α_ X Z Y).symm ≪≫
       whiskerRightIso (β_ X Z) Y ≪≫ α_ Z X Y ≪≫
       whiskerLeftIso Z (β_ X Y) := Iso.ext (yang_baxter X Y Z)
 

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -138,9 +138,9 @@ theorem yang_baxter (X Y Z : C) :
       ≫ (Z ◁ (β_ X Y).hom) := by
   have := (braiding_naturality_right_assoc X (β_ Y Z).hom (α_ Z Y X).hom).symm
   refine Eq.trans (Eq.symm ?_) (Eq.trans this ?_)
-  . refine Eq.trans (congrArg (. ≫ _) (braiding_tensor_right X Y Z)) ?_
+  · refine Eq.trans (congrArg (. ≫ _) (braiding_tensor_right X Y Z)) ?_
     simp only [assoc]
-  . refine congrArg (_ ≫ .) ((Iso.eq_comp_inv _).mp ?_)
+  · refine congrArg (_ ≫ .) ((Iso.eq_comp_inv _).mp ?_)
     refine Eq.trans (braiding_tensor_right X Z Y) ?_
     simp only [assoc]
 

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.CategoryTheory.Conj
 import Mathlib.CategoryTheory.Monoidal.Free.Coherence
 import Mathlib.CategoryTheory.Monoidal.Discrete
 import Mathlib.CategoryTheory.Monoidal.NaturalTransformation
@@ -131,11 +130,9 @@ theorem braiding_naturality {X X' Y Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
 
 theorem yang_baxter (X Y Z : C) :
     (α_ X Y Z).inv ≫ ((β_ X Y).hom ▷ Z) ≫ (α_ Y X Z).hom ≫
-    (Y ◁ (β_ X Z).hom) ≫ (α_ Y Z X).inv ≫
-    ((β_ Y Z).hom ▷ X) ≫ (α_ Z Y X).hom
-    = (X ◁ (β_ Y Z).hom) ≫ (α_ X Z Y).inv ≫
-      ((β_ X Z).hom ▷ Y) ≫ (α_ Z X Y).hom ≫
-      (Z ◁ (β_ X Y).hom) := by
+    (Y ◁ (β_ X Z).hom) ≫ (α_ Y Z X).inv ≫ ((β_ Y Z).hom ▷ X) ≫ (α_ Z Y X).hom =
+      (X ◁ (β_ Y Z).hom) ≫ (α_ X Z Y).inv ≫ ((β_ X Z).hom ▷ Y) ≫
+      (α_ Z X Y).hom ≫ (Z ◁ (β_ X Y).hom) := by
   have := (braiding_naturality_right_assoc X (β_ Y Z).hom (α_ Z Y X).hom).symm
   refine Eq.trans (Eq.symm ?_) (Eq.trans this ?_)
   · refine Eq.trans (congrArg (. ≫ _) (braiding_tensor_right X Y Z)) ?_
@@ -145,13 +142,11 @@ theorem yang_baxter (X Y Z : C) :
     simp only [assoc]
 
 theorem yang_baxter' (X Y Z : C) :
-    Iso.homCongr (α_ X Y Z) (α_ Z Y X)
-      (((β_ X Y).hom ▷ Z) ⊗≫ (Y ◁ (β_ X Z).hom) ⊗≫ ((β_ Y Z).hom ▷ X))
-    = ((X ◁ (β_ Y Z).hom) ⊗≫ ((β_ X Z).hom ▷ Y) ⊗≫ (Z ◁ (β_ X Y).hom)) := by
-  dsimp only [Mathlib.Tactic.Coherence.monoidalComp,
-              Mathlib.Tactic.Coherence.MonoidalCoherence.hom, Iso.homCongr_apply]
-  simp only [whiskerRight_tensor, id_whiskerRight, id_comp, Iso.inv_hom_id,
-             comp_id, assoc, tensor_id, id_comp, yang_baxter]
+    ((β_ X Y).hom ▷ Z) ⊗≫ (Y ◁ (β_ X Z).hom) ⊗≫ ((β_ Y Z).hom ▷ X) =
+      𝟙 _ ⊗≫ ((X ◁ (β_ Y Z).hom) ⊗≫ ((β_ X Z).hom ▷ Y) ⊗≫ (Z ◁ (β_ X Y).hom)) ⊗≫ 𝟙 _ := by
+  rw [← cancel_epi (α_ X Y Z).inv, ← cancel_mono (α_ Z Y X).hom]
+  convert yang_baxter X Y Z using 1
+  all_goals coherence
 
 theorem yang_baxter_iso (X Y Z : C) :
     (α_ X Y Z).symm ≪≫ whiskerRightIso (β_ X Y) Z ≪≫ α_ Y X Z ≪≫
@@ -686,12 +681,8 @@ monoidal opposite, upgraded to a braided functor. -/
     simp only [braiding_tensor_left, braiding_tensor_right,
                assoc, Iso.inv_hom_id, comp_id]
     exact yang_baxter (mop X) (mop Y) (mop Z)
-  left_unitality X :=
-    Eq.symm $ Eq.trans (congrArg (. ≫ _) (tensor_id _ _))
-    $ Eq.trans (id_comp _) (braiding_rightUnitor Cᴹᵒᵖ (mop X))
-  right_unitality X :=
-    Eq.symm $ Eq.trans (congrArg (. ≫ _) (tensor_id _ _))
-    $ Eq.trans (id_comp _) (braiding_leftUnitor Cᴹᵒᵖ (mop X))
+  left_unitality := by intro; erw [tensor_id, id_comp, braiding_rightUnitor]
+  right_unitality := by intro; erw [tensor_id, id_comp, braiding_leftUnitor]
   __ := mopFunctor C
 
 /-- The identity functor on `C`, viewed as a functor from the
@@ -711,12 +702,8 @@ monoidal opposite of `C` to `C`, upgraded to a braided functor. -/
     simp only [braiding_tensor_left, braiding_tensor_right,
                assoc, Iso.inv_hom_id, comp_id]
     exact yang_baxter (unmop X) (unmop Y) (unmop Z)
-  left_unitality X :=
-    Eq.symm $ Eq.trans (congrArg (. ≫ _) (tensor_id _ _))
-    $ Eq.trans (id_comp _) (braiding_rightUnitor C (unmop X))
-  right_unitality X :=
-    Eq.symm $ Eq.trans (congrArg (. ≫ _) (tensor_id _ _))
-    $ Eq.trans (id_comp _) (braiding_leftUnitor C (unmop X))
+  left_unitality := by intro; erw [tensor_id, id_comp, braiding_rightUnitor]
+  right_unitality := by intro; erw [tensor_id, id_comp, braiding_leftUnitor]
   __ := unmopFunctor C
 
 end MonoidalOpposite

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -88,7 +88,7 @@ namespace BraidedCategory
 
 variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [BraidedCategory.{v} C]
 
-@[simp]
+@[simp, reassoc]
 theorem braiding_tensor_left (X Y Z : C) :
     (β_ (X ⊗ Y) Z).hom  =
       (α_ X Y Z).hom ≫ X ◁ (β_ Y Z).hom ≫ (α_ X Z Y).inv ≫
@@ -98,7 +98,7 @@ theorem braiding_tensor_left (X Y Z : C) :
   apply (cancel_mono (α_ Z X Y).inv).1
   simp [hexagon_reverse]
 
-@[simp]
+@[simp, reassoc]
 theorem braiding_tensor_right (X Y Z : C) :
     (β_ X (Y ⊗ Z)).hom  =
       (α_ X Y Z).inv ≫ (β_ X Y).hom ▷ Z ≫ (α_ Y X Z).hom ≫
@@ -108,14 +108,14 @@ theorem braiding_tensor_right (X Y Z : C) :
   apply (cancel_mono (α_ Y Z X).hom).1
   simp [hexagon_forward]
 
-@[simp]
+@[simp, reassoc]
 theorem braiding_inv_tensor_left (X Y Z : C) :
     (β_ (X ⊗ Y) Z).inv  =
       (α_ Z X Y).inv ≫ (β_ X Z).inv ▷ Y ≫ (α_ X Z Y).hom ≫
         X ◁ (β_ Y Z).inv ≫ (α_ X Y Z).inv :=
   eq_of_inv_eq_inv (by simp)
 
-@[simp]
+@[simp, reassoc]
 theorem braiding_inv_tensor_right (X Y Z : C) :
     (β_ X (Y ⊗ Z)).inv  =
       (α_ Y Z X).hom ≫ Y ◁ (β_ X Z).inv ≫ (α_ Y X Z).inv ≫
@@ -133,13 +133,9 @@ theorem yang_baxter (X Y Z : C) :
     (Y ◁ (β_ X Z).hom) ≫ (α_ Y Z X).inv ≫ ((β_ Y Z).hom ▷ X) ≫ (α_ Z Y X).hom =
       (X ◁ (β_ Y Z).hom) ≫ (α_ X Z Y).inv ≫ ((β_ X Z).hom ▷ Y) ≫
       (α_ Z X Y).hom ≫ (Z ◁ (β_ X Y).hom) := by
-  have := (braiding_naturality_right_assoc X (β_ Y Z).hom (α_ Z Y X).hom).symm
-  refine Eq.trans (Eq.symm ?_) (Eq.trans this ?_)
-  · refine Eq.trans (congrArg (. ≫ _) (braiding_tensor_right X Y Z)) ?_
-    simp only [assoc]
-  · refine congrArg (_ ≫ .) ((Iso.eq_comp_inv _).mp ?_)
-    refine Eq.trans (braiding_tensor_right X Z Y) ?_
-    simp only [assoc]
+  rw [← braiding_tensor_right_assoc X Y Z, ← cancel_mono (α_ Z Y X).inv]
+  repeat rw [assoc]
+  rw [Iso.hom_inv_id, comp_id, ← braiding_naturality_right, braiding_tensor_right]
 
 theorem yang_baxter' (X Y Z : C) :
     ((β_ X Y).hom ▷ Z) ⊗≫ (Y ◁ (β_ X Z).hom) ⊗≫ ((β_ Y Z).hom ▷ X) =

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -336,6 +336,10 @@ class SymmetricCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] e
 
 attribute [reassoc (attr := simp)] SymmetricCategory.symmetry
 
+lemma SymmetricCategory.braiding_swap_eq_inv_braiding {C : Type u₁}
+    [Category.{v₁} C] [MonoidalCategory C] [SymmetricCategory C] (X Y : C) :
+    (β_ Y X).hom = (β_ X Y).inv := Iso.inv_ext' (symmetry X Y)
+
 variable (C : Type u₁) [Category.{v₁} C] [MonoidalCategory C] [BraidedCategory C]
 variable (D : Type u₂) [Category.{v₂} D] [MonoidalCategory D] [BraidedCategory D]
 variable (E : Type u₃) [Category.{v₃} E] [MonoidalCategory E] [BraidedCategory E]
@@ -656,29 +660,6 @@ attribute [reassoc] associator_monoidal
 
 end Tensor
 
-@[reducible] def reverseBraiding : BraidedCategory C where
-  braiding X Y := (β_ Y X).symm
-  braiding_naturality_right := by
-    simp_rw [Iso.symm_hom, Iso.comp_inv_eq, assoc, Iso.eq_inv_comp,
-             braiding_naturality_left, implies_true]
-  braiding_naturality_left  := by
-    simp_rw [Iso.symm_hom, Iso.comp_inv_eq, assoc, Iso.eq_inv_comp,
-             braiding_naturality_right, implies_true]
-  hexagon_forward := by
-    intros X Y Z
-    simp only [← Iso.symm_inv, ← Iso.trans_inv,
-               ← whiskerLeftIso_inv, ← whiskerRightIso_inv]
-    refine (Iso.inv_eq_inv _ _).mpr ?_
-    simp only [Iso.trans_hom, Iso.symm_symm_eq, Iso.symm_hom, assoc]
-    exact hexagon_reverse Y Z X
-  hexagon_reverse := by
-    intros X Y Z
-    simp only [← Iso.symm_inv, ← Iso.trans_inv,
-               ← whiskerLeftIso_inv, ← whiskerRightIso_inv]
-    refine (Iso.inv_eq_inv _ _).mpr ?_
-    simp only [Iso.trans_hom, Iso.symm_symm_eq, Iso.symm_hom, assoc]
-    exact hexagon_forward Z X Y
-
 namespace MonoidalOpposite
 
 instance instBraiding : BraidedCategory Cᴹᵒᵖ where
@@ -688,6 +669,8 @@ instance instBraiding : BraidedCategory Cᴹᵒᵖ where
   hexagon_forward X Y Z := hexagon_reverse (unmop Z) (unmop Y) (unmop X)
   hexagon_reverse X Y Z := hexagon_forward (unmop Z) (unmop Y) (unmop X)
 
+/-- The identity functor on `C`, viewed as a functor from `C` to its
+monoidal opposite, upgraded to a braided functor. -/
 @[simps!] def mopBraidedFunctor : BraidedFunctor C Cᴹᵒᵖ where
   μ X Y := (β_ (mop X) (mop Y)).hom
   ε := 𝟙 (𝟙_ Cᴹᵒᵖ)
@@ -711,6 +694,8 @@ instance instBraiding : BraidedCategory Cᴹᵒᵖ where
     $ Eq.trans (id_comp _) (braiding_leftUnitor Cᴹᵒᵖ (mop X))
   __ := mopFunctor C
 
+/-- The identity functor on `C`, viewed as a functor from the
+monoidal opposite of `C` to `C`, upgraded to a braided functor. -/
 @[simps!] def unmopBraidedFunctor : BraidedFunctor Cᴹᵒᵖ C where
   μ X Y := (β_ (unmop X) (unmop Y)).hom
   ε := 𝟙 (𝟙_ C)
@@ -735,5 +720,48 @@ instance instBraiding : BraidedCategory Cᴹᵒᵖ where
   __ := unmopFunctor C
 
 end MonoidalOpposite
+
+/-- The braided monoidal category obtained from `C` by replacing its braiding
+`β_ X Y : X ⊗ Y ≅ Y ⊗ X` with the inverse `(β_ Y X)⁻¹ : X ⊗ Y ≅ Y ⊗ X`.
+This corresponds to the automorphism of the braid group swapping
+over-crossings and under-crossings. -/
+@[reducible] def reverseBraiding : BraidedCategory C where
+  braiding X Y := (β_ Y X).symm
+  braiding_naturality_right := by
+    simp_rw [Iso.symm_hom, Iso.comp_inv_eq, assoc, Iso.eq_inv_comp,
+             braiding_naturality_left, implies_true]
+  braiding_naturality_left  := by
+    simp_rw [Iso.symm_hom, Iso.comp_inv_eq, assoc, Iso.eq_inv_comp,
+             braiding_naturality_right, implies_true]
+  hexagon_forward := by
+    intros X Y Z
+    simp only [← Iso.symm_inv, ← Iso.trans_inv,
+               ← whiskerLeftIso_inv, ← whiskerRightIso_inv]
+    refine (Iso.inv_eq_inv _ _).mpr ?_
+    simp only [Iso.trans_hom, Iso.symm_symm_eq, Iso.symm_hom, assoc]
+    exact hexagon_reverse Y Z X
+  hexagon_reverse := by
+    intros X Y Z
+    simp only [← Iso.symm_inv, ← Iso.trans_inv,
+               ← whiskerLeftIso_inv, ← whiskerRightIso_inv]
+    refine (Iso.inv_eq_inv _ _).mpr ?_
+    simp only [Iso.trans_hom, Iso.symm_symm_eq, Iso.symm_hom, assoc]
+    exact hexagon_forward Z X Y
+
+lemma SymmetricCategory.reverseBraiding_eq (C : Type u₁) [Category.{v₁} C]
+    [MonoidalCategory C] [i : SymmetricCategory C] :
+    reverseBraiding C = i.toBraidedCategory := by
+  dsimp only [reverseBraiding]
+  congr
+  funext X Y
+  exact Iso.ext (braiding_swap_eq_inv_braiding Y X).symm
+
+/-- The identity functor from `C` to `C`, where the codomain is given the
+reversed braiding, upgraded to a braided functor. -/
+def SymmetricCategory.equivReverseBraiding (C : Type u₁) [Category.{v₁} C]
+    [MonoidalCategory C] [SymmetricCategory C] :=
+  @BraidedFunctor.mk C _ _ _ C _ _ (reverseBraiding C) (.id C) $ fun X Y =>
+    (IsIso.eq_inv_comp _).mpr $ Eq.trans (id_comp _)
+    $ Eq.trans (braiding_swap_eq_inv_braiding Y X) (comp_id _).symm
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -776,8 +776,7 @@ lemma SymmetricCategory.reverseBraiding_eq (C : Type u₁) [Category.{v₁} C]
 reversed braiding, upgraded to a braided functor. -/
 def SymmetricCategory.equivReverseBraiding (C : Type u₁) [Category.{v₁} C]
     [MonoidalCategory C] [SymmetricCategory C] :=
-  @BraidedFunctor.mk C _ _ _ C _ _ (reverseBraiding C) (.id C) $ fun X Y =>
-    (IsIso.eq_inv_comp _).mpr $ Eq.trans (id_comp _)
-    $ Eq.trans (braiding_swap_eq_inv_braiding Y X) (comp_id _).symm
+  @BraidedFunctor.mk C _ _ _ C _ _ (reverseBraiding C) (.id C) <| by
+    intros; simp [reverseBraiding, braiding_swap_eq_inv_braiding]
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -652,13 +652,10 @@ attribute [reassoc] associator_monoidal
 
 end Tensor
 
-@[simps]
 instance : BraidedCategory Cᵒᵖ where
-  braiding X Y := Iso.op (β_ Y.unop X.unop)
-  braiding_naturality_right X {_ _} f :=
-    Quiver.Hom.unop_inj <| (braiding_naturality_left f.unop X.unop).symm
-  braiding_naturality_left {_ _} f Z :=
-    Quiver.Hom.unop_inj <| (braiding_naturality_right Z.unop f.unop).symm
+  braiding X Y := (β_ Y.unop X.unop).op
+  braiding_naturality_right X {_ _} f := Quiver.Hom.unop_inj <| by simp
+  braiding_naturality_left {_ _} f Z := Quiver.Hom.unop_inj <| by simp
   hexagon_forward X Y Z := Quiver.Hom.unop_inj <| by
     convert hexagon_reverse Y.unop Z.unop X.unop using 1
     <;> exact assoc _ _ _
@@ -666,27 +663,55 @@ instance : BraidedCategory Cᵒᵖ where
     convert hexagon_forward Z.unop X.unop Y.unop using 1
     <;> exact assoc _ _ _
 
+section OppositeLemmas
+
+open Opposite
+
+@[simp] lemma op_braiding (X Y : C) : (β_ X Y).op = β_ (op Y) (op X) := rfl
+@[simp] lemma unop_braiding (X Y : Cᵒᵖ) : (β_ X Y).unop = β_ (unop Y) (unop X) := rfl
+
+@[simp] lemma op_hom_braiding (X Y : C) : (β_ X Y).hom.op = (β_ (op Y) (op X)).hom := rfl
+@[simp] lemma unop_hom_braiding (X Y : Cᵒᵖ) : (β_ X Y).hom.unop = (β_ (unop Y) (unop X)).hom := rfl
+
+@[simp] lemma op_inv_braiding (X Y : C) : (β_ X Y).inv.op = (β_ (op Y) (op X)).inv := rfl
+@[simp] lemma unop_inv_braiding (X Y : Cᵒᵖ) : (β_ X Y).inv.unop = (β_ (unop Y) (unop X)).inv := rfl
+
+end OppositeLemmas
+
 namespace MonoidalOpposite
 
-@[simps]
 instance instBraiding : BraidedCategory Cᴹᵒᵖ where
-  braiding X Y := (β_ (unmop Y) (unmop X)).mop
-  braiding_naturality_right X {_ _} f := braiding_naturality_left f.unmop (unmop X)
-  braiding_naturality_left {_ _} f Z := braiding_naturality_right (unmop Z) f.unmop
-  hexagon_forward X Y Z := hexagon_reverse (unmop Z) (unmop Y) (unmop X)
-  hexagon_reverse X Y Z := hexagon_forward (unmop Z) (unmop Y) (unmop X)
+  braiding X Y := (β_ Y.unmop X.unmop).mop
+  braiding_naturality_right X {_ _} f := Quiver.Hom.unmop_inj <| by simp
+  braiding_naturality_left {_ _} f Z := Quiver.Hom.unmop_inj <| by simp
+  hexagon_forward X Y Z := Quiver.Hom.unmop_inj <| by simp
+  hexagon_reverse X Y Z := Quiver.Hom.unmop_inj <| by simp
+
+section MonoidalOppositeLemmas
+
+@[simp] lemma mop_braiding (X Y : C) : (β_ X Y).mop = β_ (mop Y) (mop X) := rfl
+@[simp] lemma unmop_braiding (X Y : Cᴹᵒᵖ) : (β_ X Y).unmop = β_ (unmop Y) (unmop X) := rfl
+
+@[simp] lemma mop_hom_braiding (X Y : C) : (β_ X Y).hom.mop = (β_ (mop Y) (mop X)).hom := rfl
+@[simp]
+lemma unmop_hom_braiding (X Y : Cᴹᵒᵖ) : (β_ X Y).hom.unmop = (β_ (unmop Y) (unmop X)).hom := rfl
+
+@[simp] lemma mop_inv_braiding (X Y : C) : (β_ X Y).inv.mop = (β_ (mop Y) (mop X)).inv := rfl
+@[simp]
+lemma unmop_inv_braiding (X Y : Cᴹᵒᵖ) : (β_ X Y).inv.unmop = (β_ (unmop Y) (unmop X)).inv := rfl
+
+end MonoidalOppositeLemmas
 
 /-- The identity functor on `C`, viewed as a functor from `C` to its
 monoidal opposite, upgraded to a braided functor. -/
 @[simps!] def mopBraidedFunctor : BraidedFunctor C Cᴹᵒᵖ where
   μ X Y := (β_ (mop X) (mop Y)).hom
   ε := 𝟙 (𝟙_ Cᴹᵒᵖ)
-  μ_natural_left {_ _} f Z := unmop_inj <| by simp
-  μ_natural_right {_ _} Z f := unmop_inj <| by simp
-  associativity X Y Z := unmop_inj <| by
+  -- `id_tensorHom`, `tensorHom_id` should be simp lemmas when #6307 is merged
+  -- we could then make this fully automated if we mark `yang_baxter` as simp
+  -- should it be marked as such?
+  associativity X Y Z := Quiver.Hom.unmop_inj <| by
     simp [id_tensorHom, tensorHom_id, yang_baxter]
-  left_unitality := by intro; erw [tensor_id, id_comp, braiding_rightUnitor]
-  right_unitality := by intro; erw [tensor_id, id_comp, braiding_leftUnitor]
   __ := mopFunctor C
 
 /-- The identity functor on `C`, viewed as a functor from the
@@ -694,11 +719,8 @@ monoidal opposite of `C` to `C`, upgraded to a braided functor. -/
 @[simps!] def unmopBraidedFunctor : BraidedFunctor Cᴹᵒᵖ C where
   μ X Y := (β_ (unmop X) (unmop Y)).hom
   ε := 𝟙 (𝟙_ C)
-  associativity X Y Z := mop_inj <| by
-    simp [id_tensorHom, tensorHom_id]
-    exact (yang_baxter Z Y X).symm
-  left_unitality := by intro; erw [tensor_id, id_comp, braiding_rightUnitor]
-  right_unitality := by intro; erw [tensor_id, id_comp, braiding_leftUnitor]
+  associativity X Y Z := Quiver.Hom.mop_inj <| by
+    simp [id_tensorHom, tensorHom_id, yang_baxter]
   __ := unmopFunctor C
 
 end MonoidalOpposite
@@ -709,12 +731,14 @@ This corresponds to the automorphism of the braid group swapping
 over-crossings and under-crossings. -/
 @[reducible] def reverseBraiding : BraidedCategory C where
   braiding X Y := (β_ Y X).symm
-  braiding_naturality_right := by
-    simp_rw [Iso.symm_hom, Iso.comp_inv_eq, assoc, Iso.eq_inv_comp,
-             braiding_naturality_left, implies_true]
-  braiding_naturality_left  := by
-    simp_rw [Iso.symm_hom, Iso.comp_inv_eq, assoc, Iso.eq_inv_comp,
-             braiding_naturality_right, implies_true]
+  braiding_naturality_right X {_ _} f := by
+    -- why isn't `aesop_cat` able to solve this?
+    -- There's got to be a better way of automating the line below
+    simp_rw [Iso.symm_hom, Iso.comp_inv_eq, assoc, Iso.eq_inv_comp]
+    exact (braiding_naturality_left f X).symm
+  braiding_naturality_left {_ _} f Z := by
+    simp_rw [Iso.symm_hom, Iso.comp_inv_eq, assoc, Iso.eq_inv_comp]
+    exact (braiding_naturality_right Z f).symm
   hexagon_forward := by
     intros X Y Z
     simp only [← Iso.symm_inv, ← Iso.trans_inv,

--- a/Mathlib/CategoryTheory/Monoidal/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided.lean
@@ -131,17 +131,17 @@ theorem braiding_naturality {X X' Y Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
 
 @[reassoc]
 theorem yang_baxter (X Y Z : C) :
-    (α_ X Y Z).inv ≫ ((β_ X Y).hom ▷ Z) ≫ (α_ Y X Z).hom ≫
-    (Y ◁ (β_ X Z).hom) ≫ (α_ Y Z X).inv ≫ ((β_ Y Z).hom ▷ X) ≫ (α_ Z Y X).hom =
-      (X ◁ (β_ Y Z).hom) ≫ (α_ X Z Y).inv ≫ ((β_ X Z).hom ▷ Y) ≫
-      (α_ Z X Y).hom ≫ (Z ◁ (β_ X Y).hom) := by
+    (α_ X Y Z).inv ≫ (β_ X Y).hom ▷ Z ≫ (α_ Y X Z).hom ≫
+    Y ◁ (β_ X Z).hom ≫ (α_ Y Z X).inv ≫ (β_ Y Z).hom ▷ X ≫ (α_ Z Y X).hom =
+      X ◁ (β_ Y Z).hom ≫ (α_ X Z Y).inv ≫ (β_ X Z).hom ▷ Y ≫
+      (α_ Z X Y).hom ≫ Z ◁ (β_ X Y).hom := by
   rw [← braiding_tensor_right_assoc X Y Z, ← cancel_mono (α_ Z Y X).inv]
   repeat rw [assoc]
   rw [Iso.hom_inv_id, comp_id, ← braiding_naturality_right, braiding_tensor_right]
 
 theorem yang_baxter' (X Y Z : C) :
-    ((β_ X Y).hom ▷ Z) ⊗≫ (Y ◁ (β_ X Z).hom) ⊗≫ ((β_ Y Z).hom ▷ X) =
-      𝟙 _ ⊗≫ ((X ◁ (β_ Y Z).hom) ⊗≫ ((β_ X Z).hom ▷ Y) ⊗≫ (Z ◁ (β_ X Y).hom)) ⊗≫ 𝟙 _ := by
+    (β_ X Y).hom ▷ Z ⊗≫ Y ◁ (β_ X Z).hom ⊗≫ (β_ Y Z).hom ▷ X =
+      𝟙 _ ⊗≫ (X ◁ (β_ Y Z).hom ⊗≫ (β_ X Z).hom ▷ Y ⊗≫ Z ◁ (β_ X Y).hom) ⊗≫ 𝟙 _ := by
   rw [← cancel_epi (α_ X Y Z).inv, ← cancel_mono (α_ Z Y X).hom]
   convert yang_baxter X Y Z using 1
   all_goals coherence

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -348,6 +348,20 @@ theorem inv_whiskerLeft (X : C) {Y Z : C} (f : Y ⟶ Z) [IsIso f] :
     inv (X ◁ f) = X ◁ inv f := by
   aesop_cat
 
+@[simp]
+lemma whiskerLeftIso_refl (W X : C) :
+    whiskerLeftIso W (Iso.refl X) = Iso.refl (W ⊗ X) :=
+  Iso.ext (whiskerLeft_id W X)
+
+@[simp]
+lemma whiskerLeftIso_trans (W : C) {X Y Z : C} (f : X ≅ Y) (g : Y ≅ Z) :
+    whiskerLeftIso W (f ≪≫ g) = whiskerLeftIso W f ≪≫ whiskerLeftIso W g :=
+  Iso.ext (whiskerLeft_comp W f.hom g.hom)
+
+@[simp]
+lemma whiskerLeftIso_symm (W : C) {X Y : C} (f : X ≅ Y) :
+    whiskerLeftIso W f.symm = (whiskerLeftIso W f).symm := rfl
+
 /-- The right whiskering of an isomorphism is an isomorphism. -/
 @[simps!]
 def whiskerRightIso {X Y : C} (f : X ≅ Y) (Z : C) : X ⊗ Z ≅ Y ⊗ Z where
@@ -361,6 +375,20 @@ instance whiskerRight_isIso {X Y : C} (f : X ⟶ Y) (Z : C) [IsIso f] : IsIso (f
 theorem inv_whiskerRight {X Y : C} (f : X ⟶ Y) (Z : C) [IsIso f] :
     inv (f ▷ Z) = inv f ▷ Z := by
   aesop_cat
+
+@[simp]
+lemma whiskerRightIso_refl (X W : C) :
+    whiskerRightIso (Iso.refl X) W = Iso.refl (X ⊗ W) :=
+  Iso.ext (id_whiskerRight X W)
+
+@[simp]
+lemma whiskerRightIso_trans {X Y Z : C} (f : X ≅ Y) (g : Y ≅ Z) (W : C) :
+    whiskerRightIso (f ≪≫ g) W = whiskerRightIso f W ≪≫ whiskerRightIso g W :=
+  Iso.ext (comp_whiskerRight f.hom g.hom W)
+
+@[simp]
+lemma whiskerRightIso_symm {X Y : C} (f : X ≅ Y) (W : C) :
+    whiskerRightIso f.symm W = (whiskerRightIso f W).symm := rfl
 
 end MonoidalCategory
 

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -360,7 +360,7 @@ lemma whiskerLeftIso_trans (W : C) {X Y Z : C} (f : X ≅ Y) (g : Y ≅ Z) :
 
 @[simp]
 lemma whiskerLeftIso_symm (W : C) {X Y : C} (f : X ≅ Y) :
-    whiskerLeftIso W f.symm = (whiskerLeftIso W f).symm := rfl
+    (whiskerLeftIso W f).symm = whiskerLeftIso W f.symm := rfl
 
 /-- The right whiskering of an isomorphism is an isomorphism. -/
 @[simps!]
@@ -388,7 +388,7 @@ lemma whiskerRightIso_trans {X Y Z : C} (f : X ≅ Y) (g : Y ≅ Z) (W : C) :
 
 @[simp]
 lemma whiskerRightIso_symm {X Y : C} (f : X ≅ Y) (W : C) :
-    whiskerRightIso f.symm W = (whiskerRightIso f W).symm := rfl
+    (whiskerRightIso f W).symm = whiskerRightIso f.symm W := rfl
 
 end MonoidalCategory
 

--- a/Mathlib/CategoryTheory/Monoidal/Opposite.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Opposite.lean
@@ -166,6 +166,14 @@ def mop (f : X ≅ Y) : mop X ≅ mop Y where
 
 end Iso
 
+namespace IsIso
+
+variable {X Y : C}
+
+instance (f : X ⟶ Y) [i : IsIso f] : IsIso (mop f) := i
+
+end IsIso
+
 variable [MonoidalCategory.{v₁} C]
 
 open Opposite MonoidalCategory
@@ -221,5 +229,54 @@ theorem mop_tensorObj (X Y : Cᴹᵒᵖ) : X ⊗ Y = mop (unmop Y ⊗ unmop X) :
 theorem mop_tensorUnit : 𝟙_ Cᴹᵒᵖ = mop (𝟙_ C) :=
   rfl
 #align category_theory.mop_tensor_unit CategoryTheory.mop_tensorUnit
+
+variable (C)
+
+@[simps!] def mopFunctor : C ⥤ Cᴹᵒᵖ := Functor.mk ⟨mop, mop⟩
+@[simps!] def unmopFunctor : Cᴹᵒᵖ ⥤ C := Functor.mk ⟨unmop, unmop⟩
+
+@[simps!]
+def MonoidalOpposite.underlyingEquiv : C ≌ Cᴹᵒᵖ := Equivalence.refl
+
+-- todo: upgrade to monoidal equivalence
+@[simps!] def MonoidalOpposite.double_dual_equiv : Cᴹᵒᵖᴹᵒᵖ ≌ C := Equivalence.refl
+
+@[simps!]
+def MonoidalOpposite.tensor_iso :
+    tensor Cᴹᵒᵖ ≅ (unmopFunctor C).prod (unmopFunctor C)
+                  ⋙ Prod.swap C C ⋙ tensor C ⋙ mopFunctor C :=
+  Iso.refl _
+
+variable {C}
+
+@[simps!]
+def MonoidalOpposite.tensorLeft_iso (X : Cᴹᵒᵖ) :
+    tensorLeft X ≅ unmopFunctor C ⋙ tensorRight (unmop X) ⋙ mopFunctor C :=
+  Iso.refl _
+
+@[simps!]
+def MonoidalOpposite.tensorLeft_mop_iso (X : C) :
+    tensorLeft (mop X) ≅ unmopFunctor C ⋙ tensorRight X ⋙ mopFunctor C :=
+  Iso.refl _
+
+@[simps!]
+def MonoidalOpposite.tensorLeft_unmop_iso (X : Cᴹᵒᵖ) :
+    tensorLeft (unmop X) ≅ mopFunctor C ⋙ tensorRight X ⋙ mopFunctor C :=
+  Iso.refl _
+
+@[simps!]
+def MonoidalOpposite.tensorRight_iso (X : Cᴹᵒᵖ) :
+    tensorRight X ≅ unmopFunctor C ⋙ tensorLeft (unmop X) ⋙ mopFunctor C :=
+  Iso.refl _
+
+@[simps!]
+def MonoidalOpposite.tensorRight_mop_iso (X : C) :
+    tensorRight (mop X) ≅ unmopFunctor C ⋙ tensorLeft X ⋙ mopFunctor C :=
+  Iso.refl _
+
+@[simps!]
+def MonoidalOpposite.tensorRight_unmop_iso (X : Cᴹᵒᵖ) :
+    tensorRight (unmop X) ≅ mopFunctor C ⋙ tensorLeft X ⋙ mopFunctor C :=
+  Iso.refl _
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/Opposite.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Opposite.lean
@@ -361,8 +361,8 @@ variable (C)
 /-- The identification `mop X ⊗ mop Y = mop (Y ⊗ X)` as a natural isomorphism. -/
 @[simps!]
 def MonoidalOpposite.tensorIso :
-    tensor Cᴹᵒᵖ ≅ (unmopFunctor C).prod (unmopFunctor C)
-                  ⋙ Prod.swap C C ⋙ tensor C ⋙ mopFunctor C :=
+    tensor Cᴹᵒᵖ ≅ (unmopFunctor C).prod (unmopFunctor C) ⋙
+      Prod.swap C C ⋙ tensor C ⋙ mopFunctor C :=
   Iso.refl _
 
 variable {C}

--- a/Mathlib/CategoryTheory/Monoidal/Opposite.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Opposite.lean
@@ -160,8 +160,8 @@ def mop (f : X ≅ Y) : mop X ≅ mop Y where
   inv := f.inv.mop
   -- Porting note: it's a pity `attribute [aesop safe apply (rule_sets [CategoryTheory])] unmop_inj`
   -- doesn't automate these proofs.
-  hom_inv_id := unmop_inj (by simp)
-  inv_hom_id := unmop_inj (by simp)
+  hom_inv_id := unmop_inj (hom_inv_id f)
+  inv_hom_id := unmop_inj (inv_hom_id f)
 #align category_theory.iso.mop CategoryTheory.Iso.mop
 
 end Iso
@@ -179,6 +179,7 @@ open Opposite MonoidalCategory
 
 attribute [local simp] id_tensorHom tensorHom_id
 
+@[simps]
 instance monoidalCategoryOp : MonoidalCategory Cᵒᵖ where
   tensorObj X Y := op (unop X ⊗ unop Y)
   whiskerLeft X _ _ f := (X.unop ◁ f.unop).op
@@ -204,6 +205,7 @@ theorem op_tensorUnit : 𝟙_ Cᵒᵖ = op (𝟙_ C) :=
   rfl
 #align category_theory.op_tensor_unit CategoryTheory.op_tensorUnit
 
+@[simps]
 instance monoidalCategoryMop : MonoidalCategory Cᴹᵒᵖ where
   tensorObj X Y := mop (unmop Y ⊗ unmop X)
   whiskerLeft X _ _ f := (f.unmop ▷ X.unmop).mop
@@ -232,9 +234,9 @@ theorem mop_tensorUnit : 𝟙_ Cᴹᵒᵖ = mop (𝟙_ C) :=
 variable (C)
 
 /-- The identity functor on `C`, viewed as a functor from `C` to its monoidal opposite. -/
-@[simps!] def mopFunctor : C ⥤ Cᴹᵒᵖ := Functor.mk ⟨mop, mop⟩
+@[simps!] def mopFunctor : C ⥤ Cᴹᵒᵖ := Functor.mk ⟨mop, .mop⟩
 /-- The identity functor on `C`, viewed as a functor from the monoidal opposite of `C` to `C`. -/
-@[simps!] def unmopFunctor : Cᴹᵒᵖ ⥤ C := Functor.mk ⟨unmop, unmop⟩
+@[simps!] def unmopFunctor : Cᴹᵒᵖ ⥤ C := Functor.mk ⟨unmop, .unmop⟩
 
 /-- The (identity) equivalence between `C` and its monoidal opposite. -/
 @[simps!] def MonoidalOpposite.underlyingEquiv : C ≌ Cᴹᵒᵖ := Equivalence.refl

--- a/Mathlib/CategoryTheory/Monoidal/Opposite.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Opposite.lean
@@ -168,9 +168,8 @@ end Iso
 
 namespace IsIso
 
-variable {X Y : C}
-
-instance (f : X ⟶ Y) [i : IsIso f] : IsIso (mop f) := i
+instance {X Y : C}    (f : X ⟶ Y) [i : IsIso f] : IsIso f.mop := i
+instance {X Y : Cᴹᵒᵖ} (f : X ⟶ Y) [i : IsIso f] : IsIso f.unmop := i
 
 end IsIso
 

--- a/Mathlib/CategoryTheory/Monoidal/Opposite.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Opposite.lean
@@ -231,15 +231,19 @@ theorem mop_tensorUnit : 𝟙_ Cᴹᵒᵖ = mop (𝟙_ C) :=
 
 variable (C)
 
+/-- The identity functor on `C`, viewed as a functor from `C` to its monoidal opposite. -/
 @[simps!] def mopFunctor : C ⥤ Cᴹᵒᵖ := Functor.mk ⟨mop, mop⟩
+/-- The identity functor on `C`, viewed as a functor from the monoidal opposite of `C` to `C`. -/
 @[simps!] def unmopFunctor : Cᴹᵒᵖ ⥤ C := Functor.mk ⟨unmop, unmop⟩
 
-@[simps!]
-def MonoidalOpposite.underlyingEquiv : C ≌ Cᴹᵒᵖ := Equivalence.refl
+/-- The (identity) equivalence between `C` and its monoidal opposite. -/
+@[simps!] def MonoidalOpposite.underlyingEquiv : C ≌ Cᴹᵒᵖ := Equivalence.refl
 
 -- todo: upgrade to monoidal equivalence
+/-- The equivalence between `C` and its monoidal opposite's monoidal opposite. -/
 @[simps!] def MonoidalOpposite.double_dual_equiv : Cᴹᵒᵖᴹᵒᵖ ≌ C := Equivalence.refl
 
+/-- The identification `mop X ⊗ mop Y = mop (Y ⊗ X)` as a natural isomorphism. -/
 @[simps!]
 def MonoidalOpposite.tensor_iso :
     tensor Cᴹᵒᵖ ≅ (unmopFunctor C).prod (unmopFunctor C)
@@ -248,34 +252,40 @@ def MonoidalOpposite.tensor_iso :
 
 variable {C}
 
+/-- The identification `X ⊗ - = mop (- ⊗ unmop X)` as a natural isomorphism. -/
 @[simps!]
 def MonoidalOpposite.tensorLeft_iso (X : Cᴹᵒᵖ) :
     tensorLeft X ≅ unmopFunctor C ⋙ tensorRight (unmop X) ⋙ mopFunctor C :=
   Iso.refl _
 
+/-- The identification `mop X ⊗ - = mop (- ⊗ X)` as a natural isomorphism. -/
 @[simps!]
 def MonoidalOpposite.tensorLeft_mop_iso (X : C) :
     tensorLeft (mop X) ≅ unmopFunctor C ⋙ tensorRight X ⋙ mopFunctor C :=
   Iso.refl _
 
+/-- The identification `unmop X ⊗ - = unmop (mop - ⊗ X)` as a natural isomorphism. -/
 @[simps!]
 def MonoidalOpposite.tensorLeft_unmop_iso (X : Cᴹᵒᵖ) :
-    tensorLeft (unmop X) ≅ mopFunctor C ⋙ tensorRight X ⋙ mopFunctor C :=
+    tensorLeft (unmop X) ≅ mopFunctor C ⋙ tensorRight X ⋙ unmopFunctor C :=
   Iso.refl _
 
+/-- The identification `- ⊗ X = mop (unmop X ⊗ -)` as a natural isomorphism. -/
 @[simps!]
 def MonoidalOpposite.tensorRight_iso (X : Cᴹᵒᵖ) :
     tensorRight X ≅ unmopFunctor C ⋙ tensorLeft (unmop X) ⋙ mopFunctor C :=
   Iso.refl _
 
+/-- The identification `- ⊗ mop X = mop (- ⊗ unmop X)` as a natural isomorphism. -/
 @[simps!]
 def MonoidalOpposite.tensorRight_mop_iso (X : C) :
     tensorRight (mop X) ≅ unmopFunctor C ⋙ tensorLeft X ⋙ mopFunctor C :=
   Iso.refl _
 
+/-- The identification `- ⊗ unmop X = unmop (X ⊗ mop -)` as a natural isomorphism. -/
 @[simps!]
 def MonoidalOpposite.tensorRight_unmop_iso (X : Cᴹᵒᵖ) :
-    tensorRight (unmop X) ≅ mopFunctor C ⋙ tensorLeft X ⋙ mopFunctor C :=
+    tensorRight (unmop X) ≅ mopFunctor C ⋙ tensorLeft X ⋙ unmopFunctor C :=
   Iso.refl _
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/Opposite.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Opposite.lean
@@ -46,23 +46,23 @@ def unmop (X : Cᴹᵒᵖ) : C :=
   X
 #align category_theory.monoidal_opposite.unmop CategoryTheory.MonoidalOpposite.unmop
 
-theorem op_injective : Function.Injective (mop : C → Cᴹᵒᵖ) :=
+theorem mop_injective : Function.Injective (mop : C → Cᴹᵒᵖ) :=
   fun _ _ => id
-#align category_theory.monoidal_opposite.op_injective CategoryTheory.MonoidalOpposite.op_injective
+#align category_theory.monoidal_opposite.op_injective CategoryTheory.MonoidalOpposite.mop_injective
 
-theorem unop_injective : Function.Injective (unmop : Cᴹᵒᵖ → C) :=
+theorem unmop_injective : Function.Injective (unmop : Cᴹᵒᵖ → C) :=
   fun _ _ => id
-#align category_theory.monoidal_opposite.unop_injective CategoryTheory.MonoidalOpposite.unop_injective
+#align category_theory.monoidal_opposite.unop_injective CategoryTheory.MonoidalOpposite.unmop_injective
 
 @[simp]
-theorem op_inj_iff (x y : C) : mop x = mop y ↔ x = y :=
+theorem mop_inj_iff (x y : C) : mop x = mop y ↔ x = y :=
   Iff.rfl
-#align category_theory.monoidal_opposite.op_inj_iff CategoryTheory.MonoidalOpposite.op_inj_iff
+#align category_theory.monoidal_opposite.op_inj_iff CategoryTheory.MonoidalOpposite.mop_inj_iff
 
 @[simp]
-theorem unop_inj_iff (x y : Cᴹᵒᵖ) : unmop x = unmop y ↔ x = y :=
+theorem unmop_inj_iff (x y : Cᴹᵒᵖ) : unmop x = unmop y ↔ x = y :=
   Iff.rfl
-#align category_theory.monoidal_opposite.unop_inj_iff CategoryTheory.MonoidalOpposite.unop_inj_iff
+#align category_theory.monoidal_opposite.unop_inj_iff CategoryTheory.MonoidalOpposite.unmop_inj_iff
 
 @[simp]
 theorem mop_unmop (X : Cᴹᵒᵖ) : mop (unmop X) = X :=
@@ -98,26 +98,33 @@ def Quiver.Hom.unmop {X Y : Cᴹᵒᵖ} (f : X ⟶ Y) : unmop X ⟶ unmop Y :=
   f
 #align quiver.hom.unmop Quiver.Hom.unmop
 
-namespace CategoryTheory
+namespace Quiver.Hom
 
-theorem mop_inj {X Y : C} : Function.Injective (Quiver.Hom.mop : (X ⟶ Y) → (mop X ⟶ mop Y)) :=
+open MonoidalOpposite renaming mop → mop', unmop → unmop'
+
+theorem mop_inj {X Y : C} :
+    Function.Injective (Quiver.Hom.mop : (X ⟶ Y) → (mop' X ⟶ mop' Y)) :=
   fun _ _ H => congr_arg Quiver.Hom.unmop H
-#align category_theory.mop_inj CategoryTheory.mop_inj
+#align category_theory.mop_inj Quiver.Hom.mop_inj
 
 theorem unmop_inj {X Y : Cᴹᵒᵖ} :
-    Function.Injective (Quiver.Hom.unmop : (X ⟶ Y) → (unmop X ⟶ unmop Y)) :=
+    Function.Injective (Quiver.Hom.unmop : (X ⟶ Y) → (unmop' X ⟶ unmop' Y)) :=
   fun _ _ H => congr_arg Quiver.Hom.mop H
-#align category_theory.unmop_inj CategoryTheory.unmop_inj
+#align category_theory.unmop_inj Quiver.Hom.unmop_inj
 
 @[simp]
 theorem unmop_mop {X Y : C} {f : X ⟶ Y} : f.mop.unmop = f :=
   rfl
-#align category_theory.unmop_mop CategoryTheory.unmop_mop
+#align category_theory.unmop_mop Quiver.Hom.unmop_mop
 
 @[simp]
 theorem mop_unmop {X Y : Cᴹᵒᵖ} {f : X ⟶ Y} : f.unmop.mop = f :=
   rfl
-#align category_theory.mop_unmop CategoryTheory.mop_unmop
+#align category_theory.mop_unmop Quiver.Hom.mop_unmop
+
+end Quiver.Hom
+
+namespace CategoryTheory
 
 @[simp]
 theorem mop_comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g).mop = f.mop ≫ g.mop :=
@@ -151,18 +158,24 @@ theorem mop_id_unmop {X : Cᴹᵒᵖ} : (𝟙 (unmop X)).mop = 𝟙 X :=
 
 namespace Iso
 
-variable {X Y : C}
-
 /-- An isomorphism in `C` gives an isomorphism in `Cᴹᵒᵖ`. -/
 @[simps]
-def mop (f : X ≅ Y) : mop X ≅ mop Y where
+def mop {X Y : C} (f : X ≅ Y) : mop X ≅ mop Y where
   hom := f.hom.mop
   inv := f.inv.mop
   -- Porting note: it's a pity `attribute [aesop safe apply (rule_sets [CategoryTheory])] unmop_inj`
   -- doesn't automate these proofs.
-  hom_inv_id := unmop_inj (hom_inv_id f)
-  inv_hom_id := unmop_inj (inv_hom_id f)
+  hom_inv_id := Quiver.Hom.unmop_inj (hom_inv_id f)
+  inv_hom_id := Quiver.Hom.unmop_inj (inv_hom_id f)
 #align category_theory.iso.mop CategoryTheory.Iso.mop
+
+/-- An isomorphism in `Cᴹᵒᵖ` gives an isomorphism in `C`. -/
+@[simps]
+def unmop {X Y : Cᴹᵒᵖ} (f : X ≅ Y) : unmop X ≅ unmop Y where
+  hom := f.hom.unmop
+  inv := f.inv.unmop
+  hom_inv_id := Quiver.Hom.mop_inj (hom_inv_id f)
+  inv_hom_id := Quiver.Hom.mop_inj (inv_hom_id f)
 
 end Iso
 
@@ -179,7 +192,6 @@ open Opposite MonoidalCategory
 
 attribute [local simp] id_tensorHom tensorHom_id
 
-@[simps]
 instance monoidalCategoryOp : MonoidalCategory Cᵒᵖ where
   tensorObj X Y := op (unop X ⊗ unop Y)
   whiskerLeft X _ _ f := (X.unop ◁ f.unop).op
@@ -197,39 +209,140 @@ instance monoidalCategoryOp : MonoidalCategory Cᵒᵖ where
   pentagon W X Y Z := Quiver.Hom.unop_inj (by dsimp; coherence)
 #align category_theory.monoidal_category_op CategoryTheory.monoidalCategoryOp
 
-theorem op_tensorObj (X Y : Cᵒᵖ) : X ⊗ Y = op (unop X ⊗ unop Y) :=
-  rfl
-#align category_theory.op_tensor_obj CategoryTheory.op_tensorObj
+section OppositeLemmas
 
-theorem op_tensorUnit : 𝟙_ Cᵒᵖ = op (𝟙_ C) :=
-  rfl
-#align category_theory.op_tensor_unit CategoryTheory.op_tensorUnit
+@[simp] lemma op_tensorObj (X Y : C) : op (X ⊗ Y) = op X ⊗ op Y := rfl
+@[simp] lemma unop_tensorObj (X Y : Cᵒᵖ) : unop (X ⊗ Y) = unop X ⊗ unop Y := rfl
 
-@[simps]
+@[simp] lemma op_tensorUnit : op (𝟙_ C) = 𝟙_ Cᵒᵖ := rfl
+@[simp] lemma unop_tensorUnit : unop (𝟙_ Cᵒᵖ) = 𝟙_ C := rfl
+
+@[simp] lemma op_tensorHom {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
+    (f ⊗ g).op = f.op ⊗ g.op := rfl
+@[simp] lemma unop_tensorHom {X₁ Y₁ X₂ Y₂ : Cᵒᵖ} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
+    (f ⊗ g).unop = f.unop ⊗ g.unop := rfl
+
+@[simp] lemma op_whiskerLeft (X : C) {Y Z : C} (f : Y ⟶ Z) :
+    (X ◁ f).op = op X ◁ f.op := rfl
+@[simp] lemma unop_whiskerLeft (X : Cᵒᵖ) {Y Z : Cᵒᵖ} (f : Y ⟶ Z) :
+    (X ◁ f).unop =  unop X ◁ f.unop := rfl
+
+@[simp] lemma op_whiskerRight {X Y : C} (f : X ⟶ Y) (Z : C) :
+    (f ▷ Z).op = f.op ▷ op Z := rfl
+@[simp] lemma unop_whiskerRight {X Y : Cᵒᵖ} (f : X ⟶ Y) (Z : Cᵒᵖ) :
+    (f ▷ Z).unop = f.unop ▷ unop Z := rfl
+
+@[simp] lemma op_associator (X Y Z : C) :
+    (α_ X Y Z).op = (α_ (op X) (op Y) (op Z)).symm := rfl
+@[simp] lemma unop_associator (X Y Z : Cᵒᵖ) :
+    (α_ X Y Z).unop = (α_ (unop X) (unop Y) (unop Z)).symm := rfl
+
+@[simp] lemma op_hom_associator (X Y Z : C) :
+    (α_ X Y Z).hom.op = (α_ (op X) (op Y) (op Z)).inv := rfl
+@[simp] lemma unop_hom_associator (X Y Z : Cᵒᵖ) :
+    (α_ X Y Z).hom.unop = (α_ (unop X) (unop Y) (unop Z)).inv := rfl
+
+@[simp] lemma op_inv_associator (X Y Z : C) :
+    (α_ X Y Z).inv.op = (α_ (op X) (op Y) (op Z)).hom := rfl
+@[simp] lemma unop_inv_associator (X Y Z : Cᵒᵖ) :
+    (α_ X Y Z).inv.unop = (α_ (unop X) (unop Y) (unop Z)).hom := rfl
+
+@[simp] lemma op_leftUnitor (X : C) : (λ_ X).op = (λ_ (op X)).symm := rfl
+@[simp] lemma unop_leftUnitor (X : Cᵒᵖ) : (λ_ X).unop = (λ_ (unop X)).symm := rfl
+
+@[simp] lemma op_hom_leftUnitor (X : C) : (λ_ X).hom.op = (λ_ (op X)).inv := rfl
+@[simp] lemma unop_hom_leftUnitor (X : Cᵒᵖ) : (λ_ X).hom.unop = (λ_ (unop X)).inv := rfl
+
+@[simp] lemma op_inv_leftUnitor (X : C) : (λ_ X).inv.op = (λ_ (op X)).hom := rfl
+@[simp] lemma unop_inv_leftUnitor (X : Cᵒᵖ) : (λ_ X).inv.unop = (λ_ (unop X)).hom := rfl
+
+@[simp] lemma op_rightUnitor (X : C) : (ρ_ X).op = (ρ_ (op X)).symm := rfl
+@[simp] lemma unop_rightUnitor (X : Cᵒᵖ) : (ρ_ X).unop = (ρ_ (unop X)).symm := rfl
+
+@[simp] lemma op_hom_rightUnitor (X : C) : (ρ_ X).hom.op = (ρ_ (op X)).inv := rfl
+@[simp] lemma unop_hom_rightUnitor (X : Cᵒᵖ) : (ρ_ X).hom.unop = (ρ_ (unop X)).inv := rfl
+
+@[simp] lemma op_inv_rightUnitor (X : C) : (ρ_ X).inv.op = (ρ_ (op X)).hom := rfl
+@[simp] lemma unop_inv_rightUnitor (X : Cᵒᵖ) : (ρ_ X).inv.unop = (ρ_ (unop X)).hom := rfl
+
+end OppositeLemmas
+
 instance monoidalCategoryMop : MonoidalCategory Cᴹᵒᵖ where
   tensorObj X Y := mop (unmop Y ⊗ unmop X)
   whiskerLeft X _ _ f := (f.unmop ▷ X.unmop).mop
   whiskerRight f X := (X.unmop ◁ f.unmop).mop
   tensorHom f g := (g.unmop ⊗ f.unmop).mop
-  tensorHom_def f g := unmop_inj (tensorHom_def' _ _)
+  tensorHom_def f g := Quiver.Hom.unmop_inj (tensorHom_def' _ _)
   tensorUnit := mop (𝟙_ C)
   associator X Y Z := (α_ (unmop Z) (unmop Y) (unmop X)).symm.mop
   leftUnitor X := (ρ_ (unmop X)).mop
   rightUnitor X := (λ_ (unmop X)).mop
-  associator_naturality f g h := unmop_inj (by simp)
-  leftUnitor_naturality f := unmop_inj (by simp)
-  rightUnitor_naturality f := unmop_inj (by simp)
-  triangle X Y := unmop_inj (by simp) -- Porting note: Changed `by coherence` to `by simp`
-  pentagon W X Y Z := unmop_inj (by dsimp; coherence)
+  associator_naturality f g h := Quiver.Hom.unmop_inj (by simp)
+  leftUnitor_naturality f := Quiver.Hom.unmop_inj (by simp)
+  rightUnitor_naturality f := Quiver.Hom.unmop_inj (by simp)
+  -- Porting note: Changed `by coherence` to `by simp` below
+  triangle X Y := Quiver.Hom.unmop_inj (by simp)
+  pentagon W X Y Z := Quiver.Hom.unmop_inj (by dsimp; coherence)
 #align category_theory.monoidal_category_mop CategoryTheory.monoidalCategoryMop
 
-theorem mop_tensorObj (X Y : Cᴹᵒᵖ) : X ⊗ Y = mop (unmop Y ⊗ unmop X) :=
-  rfl
-#align category_theory.mop_tensor_obj CategoryTheory.mop_tensorObj
+-- it would be nice if we could autogenerate all of these somehow
+section MonoidalOppositeLemmas
 
-theorem mop_tensorUnit : 𝟙_ Cᴹᵒᵖ = mop (𝟙_ C) :=
-  rfl
-#align category_theory.mop_tensor_unit CategoryTheory.mop_tensorUnit
+@[simp] lemma mop_tensorObj (X Y : C) : mop (X ⊗ Y) = mop Y ⊗ mop X := rfl
+@[simp] lemma unmop_tensorObj (X Y : Cᴹᵒᵖ) : unmop (X ⊗ Y) = unmop Y ⊗ unmop X := rfl
+
+@[simp] lemma mop_tensorUnit : mop (𝟙_ C) = 𝟙_ Cᴹᵒᵖ := rfl
+@[simp] lemma unmop_tensorUnit : unmop (𝟙_ Cᴹᵒᵖ) = 𝟙_ C := rfl
+
+@[simp] lemma mop_tensorHom {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
+    (f ⊗ g).mop = g.mop ⊗ f.mop := rfl
+@[simp] lemma unmop_tensorHom {X₁ Y₁ X₂ Y₂ : Cᴹᵒᵖ} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
+    (f ⊗ g).unmop = g.unmop ⊗ f.unmop := rfl
+
+@[simp] lemma mop_whiskerLeft (X : C) {Y Z : C} (f : Y ⟶ Z) :
+    (X ◁ f).mop = f.mop ▷ mop X := rfl
+@[simp] lemma unmop_whiskerLeft (X : Cᴹᵒᵖ) {Y Z : Cᴹᵒᵖ} (f : Y ⟶ Z) :
+    (X ◁ f).unmop = f.unmop ▷ unmop X := rfl
+
+@[simp] lemma mop_whiskerRight {X Y : C} (f : X ⟶ Y) (Z : C) :
+    (f ▷ Z).mop = mop Z ◁ f.mop := rfl
+@[simp] lemma unmop_whiskerRight {X Y : Cᴹᵒᵖ} (f : X ⟶ Y) (Z : Cᴹᵒᵖ) :
+    (f ▷ Z).unmop = unmop Z ◁ f.unmop := rfl
+
+@[simp] lemma mop_associator (X Y Z : C) :
+    (α_ X Y Z).mop = (α_ (mop Z) (mop Y) (mop X)).symm := rfl
+@[simp] lemma unmop_associator (X Y Z : Cᴹᵒᵖ) :
+    (α_ X Y Z).unmop = (α_ (unmop Z) (unmop Y) (unmop X)).symm := rfl
+
+@[simp] lemma mop_hom_associator (X Y Z : C) :
+    (α_ X Y Z).hom.mop = (α_ (mop Z) (mop Y) (mop X)).inv := rfl
+@[simp] lemma unmop_hom_associator (X Y Z : Cᴹᵒᵖ) :
+    (α_ X Y Z).hom.unmop = (α_ (unmop Z) (unmop Y) (unmop X)).inv := rfl
+
+@[simp] lemma mop_inv_associator (X Y Z : C) :
+    (α_ X Y Z).inv.mop = (α_ (mop Z) (mop Y) (mop X)).hom := rfl
+@[simp] lemma unmop_inv_associator (X Y Z : Cᴹᵒᵖ) :
+    (α_ X Y Z).inv.unmop = (α_ (unmop Z) (unmop Y) (unmop X)).hom := rfl
+
+@[simp] lemma mop_leftUnitor (X : C) : (λ_ X).mop = (ρ_ (mop X)) := rfl
+@[simp] lemma unmop_leftUnitor (X : Cᴹᵒᵖ) : (λ_ X).unmop = ρ_ (unmop X) := rfl
+
+@[simp] lemma mop_hom_leftUnitor (X : C) : (λ_ X).hom.mop = (ρ_ (mop X)).hom := rfl
+@[simp] lemma unmop_hom_leftUnitor (X : Cᴹᵒᵖ) : (λ_ X).hom.unmop = (ρ_ (unmop X)).hom := rfl
+
+@[simp] lemma mop_inv_leftUnitor (X : C) : (λ_ X).inv.mop = (ρ_ (mop X)).inv := rfl
+@[simp] lemma unmop_inv_leftUnitor (X : Cᴹᵒᵖ) : (λ_ X).inv.unmop = (ρ_ (unmop X)).inv := rfl
+
+@[simp] lemma mop_rightUnitor (X : C) : (ρ_ X).mop = (λ_ (mop X)) := rfl
+@[simp] lemma unmop_rightUnitor (X : Cᴹᵒᵖ) : (ρ_ X).unmop = λ_ (unmop X) := rfl
+
+@[simp] lemma mop_hom_rightUnitor (X : C) : (ρ_ X).hom.mop = (λ_ (mop X)).hom := rfl
+@[simp] lemma unmop_hom_rightUnitor (X : Cᴹᵒᵖ) : (ρ_ X).hom.unmop = (λ_ (unmop X)).hom := rfl
+
+@[simp] lemma mop_inv_rightUnitor (X : C) : (ρ_ X).inv.mop = (λ_ (mop X)).inv := rfl
+@[simp] lemma unmop_inv_rightUnitor (X : Cᴹᵒᵖ) : (ρ_ X).inv.unmop = (λ_ (unmop X)).inv := rfl
+
+end MonoidalOppositeLemmas
 
 variable (C)
 

--- a/Mathlib/CategoryTheory/Monoidal/Opposite.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Opposite.lean
@@ -356,11 +356,11 @@ variable (C)
 
 -- todo: upgrade to monoidal equivalence
 /-- The equivalence between `C` and its monoidal opposite's monoidal opposite. -/
-@[simps!] def MonoidalOpposite.double_dual_equiv : Cᴹᵒᵖᴹᵒᵖ ≌ C := Equivalence.refl
+@[simps!] def MonoidalOpposite.mopMopEquivalence : Cᴹᵒᵖᴹᵒᵖ ≌ C := Equivalence.refl
 
 /-- The identification `mop X ⊗ mop Y = mop (Y ⊗ X)` as a natural isomorphism. -/
 @[simps!]
-def MonoidalOpposite.tensor_iso :
+def MonoidalOpposite.tensorIso :
     tensor Cᴹᵒᵖ ≅ (unmopFunctor C).prod (unmopFunctor C)
                   ⋙ Prod.swap C C ⋙ tensor C ⋙ mopFunctor C :=
   Iso.refl _
@@ -369,37 +369,37 @@ variable {C}
 
 /-- The identification `X ⊗ - = mop (- ⊗ unmop X)` as a natural isomorphism. -/
 @[simps!]
-def MonoidalOpposite.tensorLeft_iso (X : Cᴹᵒᵖ) :
+def MonoidalOpposite.tensorLeftIso (X : Cᴹᵒᵖ) :
     tensorLeft X ≅ unmopFunctor C ⋙ tensorRight (unmop X) ⋙ mopFunctor C :=
   Iso.refl _
 
 /-- The identification `mop X ⊗ - = mop (- ⊗ X)` as a natural isomorphism. -/
 @[simps!]
-def MonoidalOpposite.tensorLeft_mop_iso (X : C) :
+def MonoidalOpposite.tensorLeftMopIso (X : C) :
     tensorLeft (mop X) ≅ unmopFunctor C ⋙ tensorRight X ⋙ mopFunctor C :=
   Iso.refl _
 
 /-- The identification `unmop X ⊗ - = unmop (mop - ⊗ X)` as a natural isomorphism. -/
 @[simps!]
-def MonoidalOpposite.tensorLeft_unmop_iso (X : Cᴹᵒᵖ) :
+def MonoidalOpposite.tensorLeftUnmopIso (X : Cᴹᵒᵖ) :
     tensorLeft (unmop X) ≅ mopFunctor C ⋙ tensorRight X ⋙ unmopFunctor C :=
   Iso.refl _
 
 /-- The identification `- ⊗ X = mop (unmop X ⊗ -)` as a natural isomorphism. -/
 @[simps!]
-def MonoidalOpposite.tensorRight_iso (X : Cᴹᵒᵖ) :
+def MonoidalOpposite.tensorRightIso (X : Cᴹᵒᵖ) :
     tensorRight X ≅ unmopFunctor C ⋙ tensorLeft (unmop X) ⋙ mopFunctor C :=
   Iso.refl _
 
 /-- The identification `- ⊗ mop X = mop (- ⊗ unmop X)` as a natural isomorphism. -/
 @[simps!]
-def MonoidalOpposite.tensorRight_mop_iso (X : C) :
+def MonoidalOpposite.tensorRightMopIso (X : C) :
     tensorRight (mop X) ≅ unmopFunctor C ⋙ tensorLeft X ⋙ mopFunctor C :=
   Iso.refl _
 
 /-- The identification `- ⊗ unmop X = unmop (X ⊗ mop -)` as a natural isomorphism. -/
 @[simps!]
-def MonoidalOpposite.tensorRight_unmop_iso (X : Cᴹᵒᵖ) :
+def MonoidalOpposite.tensorRightUnmopIso (X : Cᴹᵒᵖ) :
     tensorRight (unmop X) ≅ mopFunctor C ⋙ tensorLeft X ⋙ unmopFunctor C :=
   Iso.refl _
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -912,12 +912,13 @@
 }
 
 @Book{            egno15,
-  author        = {Etingof, Pavel and Gelaki, Shlomo and Nikshych, Dmitri and Ostrik, Victor},
+  author        = {Etingof, Pavel and Gelaki, Shlomo and Nikshych, Dmitri and
+                  Ostrik, Victor},
   title         = {Tensor Categories},
   publisher     = {American Mathematical Society (AMS), Providence, RI},
   year          = 2015,
   pages         = {xvi+343},
-  isbn          = {978-1-4704-3441-0},
+  isbn          = {978-1-4704-3441-0}
 }
 
 @Book{            EinsiedlerWard2017,

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -911,6 +911,15 @@
   doi           = {10.2307/2275431}
 }
 
+@Book{            egno15,
+  author        = {Etingof, Pavel and Gelaki, Shlomo and Nikshych, Dmitri and Ostrik, Victor},
+  title         = {Tensor Categories},
+  publisher     = {American Mathematical Society (AMS), Providence, RI},
+  year          = 2015,
+  pages         = {xvi+343},
+  isbn          = {978-1-4704-3441-0},
+}
+
 @Book{            EinsiedlerWard2017,
   author        = {Einsiedler, Manfred and Ward, Thomas},
   title         = {Functional Analysis, Spectral Theory, and Applications},


### PR DESCRIPTION
This PR adds some basics about monoidal opposite categories and their relation to the original category, as well as the Yang-Baxter equation for braided monoidal categories. It should be easy to define an action of the braid group on an object of a braided monoidal category from this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
