### PR TITLE
[Merged by Bors] - feat: `MeasureSpace` instance on `unitInterval`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2643,6 +2643,7 @@ import Mathlib.MeasureTheory.Constructions.Polish
 import Mathlib.MeasureTheory.Constructions.Prod.Basic
 import Mathlib.MeasureTheory.Constructions.Prod.Integral
 import Mathlib.MeasureTheory.Constructions.Projective
+import Mathlib.MeasureTheory.Constructions.UnitInterval
 import Mathlib.MeasureTheory.Covering.Besicovitch
 import Mathlib.MeasureTheory.Covering.BesicovitchVectorSpace
 import Mathlib.MeasureTheory.Covering.DensityTheorem

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2024 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.Topology.UnitInterval
+import Mathlib.MeasureTheory.Measure.Haar.OfBasis
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+
+/-!
+# The canonical measure on the unit interval
+
+This file provides a `MeasureTheory.MeasureSpace` instance on `unitInterval`,
+and shows it is a probability measure.
+-/
+open scoped unitInterval
+open MeasureTheory
+
+namespace unitInterval
+
+noncomputable instance : MeasureSpace I := Measure.Subtype.measureSpace
+
+theorem volume_def : (volume : Measure I) = volume.comap Subtype.val := rfl
+
+instance : IsProbabilityMeasure (volume : Measure I) where
+  measure_univ := by
+    rw [Measure.Subtype.volume_univ measurableSet_Icc.nullMeasurableSet, Real.volume_Icc, sub_zero,
+      ENNReal.ofReal_one]
+
+theorem measurable_symm : Measurable symm := (measurable_subtype_coe.const_sub _).subtype_mk
+
+/-- `unitInterval.symm` as a `MeasurableEquiv`. -/
+@[simps]
+def symm_measurableEquiv : I ≃ᵐ I where
+  toFun := σ
+  invFun := σ
+  left_inv := symm_symm
+  right_inv := symm_symm
+  measurable_toFun := measurable_symm
+  measurable_invFun := measurable_symm
+
+end unitInterval

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -32,7 +32,7 @@ instance : IsProbabilityMeasure (volume : Measure I) where
 theorem measurable_symm : Measurable symm := continuous_symm.measurable
 
 /-- `unitInterval.symm` as a `MeasurableEquiv`. -/
-@[simps]
+@[simps!]
 def symmMeasurableEquiv : I ≃ᵐ I := symmHomeomorph.toMeasurableEquiv
 
 end unitInterval

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -33,6 +33,6 @@ theorem measurable_symm : Measurable symm := continuous_symm.measurable
 
 /-- `unitInterval.symm` as a `MeasurableEquiv`. -/
 @[simps]
-def symm_measurableEquiv : I ≃ᵐ I := symmHomeomorph.toMeasurableEquiv
+def symmMeasurableEquiv : I ≃ᵐ I := symmHomeomorph.toMeasurableEquiv
 
 end unitInterval

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -31,8 +31,4 @@ instance : IsProbabilityMeasure (volume : Measure I) where
 @[measurability]
 theorem measurable_symm : Measurable symm := continuous_symm.measurable
 
-/-- `unitInterval.symm` as a `MeasurableEquiv`. -/
-@[simps!]
-def symmMeasurableEquiv : I ≃ᵐ I := symmHomeomorph.toMeasurableEquiv
-
 end unitInterval

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Topology.UnitInterval
+import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 import Mathlib.MeasureTheory.Measure.Haar.OfBasis
 import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
 
@@ -27,16 +28,11 @@ instance : IsProbabilityMeasure (volume : Measure I) where
     rw [Measure.Subtype.volume_univ measurableSet_Icc.nullMeasurableSet, Real.volume_Icc, sub_zero,
       ENNReal.ofReal_one]
 
-theorem measurable_symm : Measurable symm := (measurable_subtype_coe.const_sub _).subtype_mk
+@[measurability]
+theorem measurable_symm : Measurable symm := continuous_symm.measurable
 
 /-- `unitInterval.symm` as a `MeasurableEquiv`. -/
 @[simps]
-def symm_measurableEquiv : I ≃ᵐ I where
-  toFun := σ
-  invFun := σ
-  left_inv := symm_symm
-  right_inv := symm_symm
-  measurable_toFun := measurable_symm
-  measurable_invFun := measurable_symm
+def symm_measurableEquiv : I ≃ᵐ I := symmHomeomorph.toMeasurableEquiv
 
 end unitInterval

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -148,6 +148,12 @@ def symmHomeomorph : I ≃ₜ I where
 
 theorem strictAnti_symm : StrictAnti σ := fun _ _ h ↦ sub_lt_sub_left (α := ℝ) h _
 
+-- 2024-02-27
+@[deprecated] alias involutive_symm := symm_involutive
+
+-- 2024-02-27
+@[deprecated] alias bijective_symm := symm_bijective
+
 theorem half_le_symm_iff (t : I) : 1 / 2 ≤ (σ t : ℝ) ↔ (t : ℝ) ≤ 1 / 2 := by
   rw [coe_symm_eq, le_sub_iff_add_le, add_comm, ← le_sub_iff_add_le, sub_half]
 

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -123,8 +123,9 @@ theorem symm_symm (x : I) : σ (σ x) = x :=
   Subtype.ext <| by simp [symm]
 #align unit_interval.symm_symm unitInterval.symm_symm
 
-theorem symm_bijective : Function.Bijective (symm : I → I) :=
-  Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
+theorem symm_involutive : Function.Involutive (symm : I → I) := symm_symm
+
+theorem symm_bijective : Function.Bijective (symm : I → I) := symm_involutive.bijective
 
 @[simp]
 theorem coe_symm_eq (x : I) : (σ x : ℝ) = 1 - x :=
@@ -137,11 +138,15 @@ theorem continuous_symm : Continuous σ :=
   (continuous_const.add continuous_induced_dom.neg).subtype_mk _
 #align unit_interval.continuous_symm unitInterval.continuous_symm
 
+/-- `unitInterval.symm` as a `Homeomorph`. -/
+@[simps]
+def symmHomeomorph : I ≃ₜ I where
+  toFun := symm
+  invFun := symm
+  left_inv := symm_symm
+  right_inv := symm_symm
+
 theorem strictAnti_symm : StrictAnti σ := fun _ _ h ↦ sub_lt_sub_left (α := ℝ) h _
-
-theorem involutive_symm : Function.Involutive σ := symm_symm
-
-theorem bijective_symm : Function.Bijective σ := involutive_symm.bijective
 
 theorem half_le_symm_iff (t : I) : 1 / 2 ≤ (σ t : ℝ) ↔ (t : ℝ) ≤ 1 / 2 := by
   rw [coe_symm_eq, le_sub_iff_add_le, add_comm, ← le_sub_iff_add_le, sub_half]


### PR DESCRIPTION
Also shows that it is a probability measure, and that `symm` is measurable.

This deprecates two duplicate theorems.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/MeasureSpace.20instance.20on.20unitInterval/near/420921313)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
