### PR TITLE
[Merged by Bors] - fix: `shake --downstream` bug

### DIFF
--- a/Shake/Main.lean
+++ b/Shake/Main.lean
@@ -87,7 +87,7 @@ structure State where
   /-- Maps a module index to the module data. -/
   mods : Array ModuleData := #[]
   /-- `j ∈ deps[i]` if module `j` is a direct dependency of module `i` -/
-  deps : Array Bitset := #[]
+  deps : Array (Array USize) := #[]
   /-- `j ∈ transDeps[i]` is the reflexive transitive closure of `deps` -/
   transDeps : Array Bitset := #[]
   /-- `j ∈ needs[i]` if module `i` uses a constant declared in module `j`.
@@ -117,13 +117,13 @@ Returns a pair `(imps, transImps)` where:
 * `j ∈ imps` if `j` is one of the module indexes in `imports`
 * `j ∈ transImps` if module `j` is transitively reachable from `imports`
  -/
-partial def loadModules (imports : Array Import) : StateT State IO (Bitset × Bitset) := do
-  let mut imps := 0
+partial def loadModules (imports : Array Import) : StateT State IO (Array USize × Bitset) := do
+  let mut imps := #[]
   let mut transImps := 0
   for imp in imports do
     let s ← get
     if let some i := s.toIdx.find? imp.module then
-      imps := imps ||| (1 <<< i.toNat)
+      imps := imps.push i
       transImps := transImps ||| s.transDeps[i]!
     else
       let mFile ← findOLean imp.module
@@ -134,7 +134,7 @@ partial def loadModules (imports : Array Import) : StateT State IO (Bitset × Bi
       let s ← get
       let n := s.mods.size.toUSize
       let transDeps := transDeps ||| (1 <<< n.toNat)
-      imps := imps ||| (1 <<< n.toNat)
+      imps := imps.push n
       transImps := transImps ||| transDeps
       set (σ := State) {
         toIdx := s.toIdx.insert imp.module n
@@ -206,10 +206,10 @@ def visitModule (s : State) (srcSearchPath : SearchPath) (ignoreImps : Bitset)
   -- Include the `ignoreImps` in `transDeps`
   let mut deps := needs
   let mut transDeps := needs ||| ignoreImps
-  for i in [0:s.mods.size] do
-    if deps &&& (1 <<< i) != 0 then
-      let deps2 := s.transDeps[i]!
-      deps := deps ^^^ (deps &&& deps2) ^^^ (1 <<< i)
+  for j in [0:s.mods.size] do
+    if deps &&& (1 <<< j) != 0 then
+      let deps2 := s.transDeps[j]!
+      deps := deps ^^^ (deps &&& deps2) ^^^ (1 <<< j)
       transDeps := transDeps ||| deps2
 
   -- Any import which is not in `transDeps` was unused.
@@ -217,11 +217,11 @@ def visitModule (s : State) (srcSearchPath : SearchPath) (ignoreImps : Bitset)
   let mut toRemove := #[]
   let mut newDeps := 0
   for imp in s.mods[i]!.imports do
-    let i := s.toIdx.find! imp.module
-    if transDeps &&& (1 <<< i.toNat) == 0 then
-      toRemove := toRemove.push i
+    let j := s.toIdx.find! imp.module
+    if transDeps &&& (1 <<< j.toNat) == 0 then
+      toRemove := toRemove.push j
     else
-      newDeps := newDeps ||| s.transDeps[i]!
+      newDeps := newDeps ||| s.transDeps[j]!
 
   if toRemove.isEmpty then return edits -- nothing to do
 
@@ -229,10 +229,10 @@ def visitModule (s : State) (srcSearchPath : SearchPath) (ignoreImps : Bitset)
   -- To minimize new imports we pick only new imports which are not transitively implied by
   -- another new import
   let mut toAdd := #[]
-  for i in [0:s.mods.size] do
-    if deps &&& (1 <<< i) != 0 && newDeps &&& (1 <<< i) == 0 then
-      toAdd := toAdd.push i
-      newDeps := newDeps ||| s.transDeps[i]!
+  for j in [0:s.mods.size] do
+    if deps &&& (1 <<< j) != 0 && newDeps &&& (1 <<< j) == 0 then
+      toAdd := toAdd.push j
+      newDeps := newDeps ||| s.transDeps[j]!
 
   -- mark and report the removals
   let mut edits := toRemove.foldl (init := edits) fun edits n =>
@@ -263,28 +263,52 @@ def visitModule (s : State) (srcSearchPath : SearchPath) (ignoreImps : Bitset)
       edits.add s.modNames[i]! n
     println! "  add {toAdd.map (s.modNames[·]!)}"
 
-  if downstream then
+  if downstream && !toRemove.isEmpty then
     -- In `downstream` mode, we should also check all the other modules to find out if
-    -- we have a situation like `A -/> B -> C`, where we are removing the `A -> B` import
-    -- but `C` depends on `A` and only directly imports `B`.
-    -- This situation occurs when `A ∈ needs[C]` and `B ∈ transDeps[C]`.
-    for r in toRemove do
-      let mut toFix := 0
-      for j in [0:s.mods.size] do
-        if j != i && s.needs[j]! &&& (1 <<< r.toNat) != 0 && s.transDeps[j]! &&& (1 <<< i) != 0 then
-          toFix := toFix ||| (1 <<< j)
-      if toFix != 0 then
-        -- `toFix` is the list of all files that need to have the import of `A` added back in,
-        -- but some of them might be importing others, for example if `A -/> B -> C -> D` where
-        -- `A ∈ needs[C]` and `A ∈ needs[D]`, adding the `A` import to `C` fixes the issue with `D`
-        -- for free. So we take only the minimal elements of `toFix` to actually fix.
-        let mut toFixArr := #[]
-        for j in [0:s.mods.size] do
-          if toFix &&& s.transDeps[j]! == 1 <<< j then
-            toFixArr := toFixArr.push j
-        edits := toFixArr.foldl (init := edits) fun edits n =>
-          edits.add s.modNames[n]! r.toNat
-        println! "  instead import {s.modNames[r]!} in: {toFixArr.map (s.modNames[·]!)}"
+    -- we have a situation like `A -> B -/> C -> D`, where we are removing the `B -> C` import
+    -- but `D` depends on `A` and only directly imports `C`.
+    -- This situation occurs when `A ∈ needs[D]`, `C ∈ transDeps[D]`, and `A ∉ newTransDeps[D]`,
+    -- where `newTransDeps` is the result of recalculating `transDeps` after breaking the `B -> C`
+    -- link.
+
+    -- calculate `newTransDeps[C]`, removing all `B -> C` links from `toRemove`
+    let mut newTransDepsI := 1 <<< i
+    for j in s.deps[i]! do
+      if !toRemove.contains j then
+        newTransDepsI := newTransDepsI ||| s.transDeps[j]!
+
+    let mut newTransDeps := s.transDeps.set! i newTransDepsI -- deep copy
+    let mut reAdded := #[]
+    for j in [i+1:s.mods.size] do -- for each module `D`
+      if s.transDeps[j]! &&& (1 <<< i) != 0 then -- which imports `C`
+        -- calculate `newTransDeps[D]` assuming no change to the imports of `D`
+        let mut newTransDepsJ := s.deps[j]!.foldl (init := 1 <<< j) fun d k =>
+          d ||| newTransDeps[k]!
+        let diff := s.transDeps[j]! ^^^ newTransDepsJ
+        if diff != 0 then -- if the dependency closure of `D` changed
+          let mut reAdd := diff &&& s.needs[j]!
+          if reAdd != 0 then -- and there are things from `needs[D]` which were lost:
+            -- Add them back.
+            -- `reAdd` is the set of all files `A` which have to be added back
+            -- to the closure of `D`, but some of them might be importing others,
+            -- so we take the transitive reduction of `reAdd`.
+            let mut reAddArr := []
+            let mut k := j
+            while reAdd != 0 do -- note: this loop terminates because `reAdd ⊆ [0:k]`
+              k := k - 1
+              if reAdd &&& (1 <<< k) != 0 then
+                reAddArr := k :: reAddArr
+                reAdd := reAdd ^^^ (reAdd &&& newTransDeps[k]!)
+                -- add these to `newTransDeps[D]` so that files downstream of `D`
+                -- (later in the `for j` loop) will take this into account
+                newTransDepsJ := newTransDepsJ ||| newTransDeps[k]!
+            edits := reAddArr.foldl (init := edits) (·.add s.modNames[j]! ·)
+            reAdded := reAdded.push (j, reAddArr)
+          newTransDeps := newTransDeps.set! j newTransDepsJ
+    if !reAdded.isEmpty then
+      println! "  instead"
+      for (j, reAddArr) in reAdded do
+        println! "    import {reAddArr.map (s.modNames[·]!)} in {s.modNames[j]!}"
   return edits
 
 /-- Convert a list of module names to a bitset of module indexes -/


### PR DESCRIPTION
The old code was not taking into account a certain import situation, and the fix requires recalculating the whole transitive dependency graph, which is a bit expensive. Furthermore, the output is now more nuanced, because instead of saying "remove A, instead import A in B1, B2", it may need to suggest importing other files like "remove A, instead import C1 in B1 and C2, C3 in B2". It could suggest to import `A` in all affected downstream files, but those files might not be using `A` directly so this would cause shake to complain again after applying the fix.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
