### PR TITLE
fix(fun_prop): bug fix - use Mor.headBeta insted of Expr.headBeta

### DIFF
--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -21,9 +21,12 @@ open Lean Meta Qq
 namespace Meta.FunProp
 
 
-/-- Puts function `f` into expected form
+/--
+Puts function `f` into expected form, that means
   1. has at least one lambda binder
-  2. body of the lambda is (morphism)beta reduced -/
+  2. body of the lambda is (morphism)beta reduced
+
+Does nothing if `f` is not a function. -/
 def fpropNormalForm (f : Expr) : FunPropM Expr := do
   -- make sure `f` is lambda with at least one bound variable
   let .lam xName xType xBody xBi ← etaExpand1 f | return f

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -21,6 +21,9 @@ open Lean Meta Qq
 namespace Meta.FunProp
 
 
+/-- Puts function `f` into expected form
+  1. has at least one lambda binder
+  2. body of the lambda is (morphism)beta reduced -/
 def fpropNormalForm (f : Expr) : FunPropM Expr := do
   -- make sure `f` is lambda with at least one bound variable
   let .lam xName xType xBody xBi ← etaExpand1 f | return f

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -755,6 +755,8 @@ mutual
   /-- Main `funProp` function. Returns proof of `e`. -/
   private partial def main (e : Expr) : FunPropM (Option Result) := do
 
+    let e ← instantiateMVars e
+
     let .some (funPropDecl, f) ← getFunProp? e
       | return none
 

--- a/test/fun_prop_dev.lean
+++ b/test/fun_prop_dev.lean
@@ -270,5 +270,9 @@ example (f : α → α → α) (hf : Con (fun (x,y) => f x y)) : Con (fun x : α
 example (f : α → β -o γ) (hf : Lin (fun (x,y) => f x y)) (g : α → β) (hg : Lin g)  : Lin (fun x => f x (g x)) := by fun_prop
 
 
--- is working up to here
+example (f : α → β ->> γ) (hf : Con (fun (x,y) => f x y)) (g : α → α) (hg : Con g) : Con (fun (x, y) => f (g x) y) := by fun_prop
+-- stess test of unfolding HasUncurry.uncurry
+example (f : α → β ->> γ) (hf : Con ↿f) (g : α → α) (hg : Con g) : Con (↿fun x => f (g x)) := by fun_prop
+example (f : α → β ->> γ ->> γ ->> γ) (hf : Con ↿f) (g : α → α) (hg : Con g) : Con (↿fun x => f (g x)) := by fun_prop
 
+-- is working up to here


### PR DESCRIPTION
fix(fun_prop): bug fix - use Mor.headBeta insted of Expr.headBeta

This comes up when using HasUncurry.uncurry with bundled morphisms


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
