### PR TITLE
[Merged by Bors] - feat: shake: error if not built

### DIFF
--- a/Shake/Main.lean
+++ b/Shake/Main.lean
@@ -377,6 +377,10 @@ def main (args : List String) : IO UInt32 := do
     IO.println help
     IO.Process.exit 0
 
+  if (← IO.Process.output { cmd := "lake", args := #["build", "--no-build"] }).exitCode != 0 then
+    IO.println "There are out of date oleans. Run `lake build` or `lake exe cache get` first"
+    IO.Process.exit 1
+
   -- Parse the `--cfg` argument
   let srcSearchPath ← initSrcSearchPath
   let cfgFile ← if let some cfg := args.cfg then


### PR DESCRIPTION
As [suggested on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Tree.20shaking/near/421206132), we can detect if there are unbuilt oleans and error out rather than giving incorrect output.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
