### PR TITLE
refactor: swap `bernoulli` and `bernoulli'`

### DIFF
--- a/Mathlib/NumberTheory/Bernoulli.lean
+++ b/Mathlib/NumberTheory/Bernoulli.lean
@@ -202,11 +202,11 @@ theorem bernoulli_eq_bernoulli' (n : ℕ) : bernoulli n = (-1) ^ n * bernoulli' 
 
 @[simp]
 theorem bernoulli'_zero : bernoulli' 0 = 1 := by simp [bernoulli']
-#align bernoulli_zero bernoulli_zero
+#align bernoulli_zero bernoulli'_zero
 
 @[simp]
 theorem bernoulli'_one : bernoulli' 1 = -1 / 2 := by norm_num [bernoulli']
-#align bernoulli_one bernoulli_one
+#align bernoulli_one bernoulli'_one
 
 theorem bernoulli'_eq_bernoulli_of_ne_one {n : ℕ} (hn : n ≠ 1) : bernoulli' n = bernoulli n := by
   by_cases h0 : n = 0; · simp [h0]

--- a/Mathlib/NumberTheory/Bernoulli.lean
+++ b/Mathlib/NumberTheory/Bernoulli.lean
@@ -14,43 +14,40 @@ import Mathlib.Tactic.FieldSimp
 /-!
 # Bernoulli numbers
 
-The Bernoulli numbers are a sequence of rational numbers that frequently show up in
-number theory.
+The Bernoulli numbers are a sequence of rational numbers that frequently show up in number theory.
 
 ## Mathematical overview
 
-The Bernoulli numbers $(B_0, B_1, B_2, \ldots)=(1, -1/2, 1/6, 0, -1/30, \ldots)$ are
-a sequence of rational numbers. They show up in the formula for the sums of $k$th
-powers. They are related to the Taylor series expansions of $x/\tan(x)$ and
-of $\coth(x)$, and also show up in the values that the Riemann Zeta function
-takes both at both negative and positive integers (and hence in the
-theory of modular forms). For example, if $1 \leq n$ is even then
+The Bernoulli numbers $(B_0, B_1, B_2, \ldots)=(1, 1/2, 1/6, 0, -1/30, \ldots)$ are a sequence of
+rational numbers. They show up in the formula for the sums of $k$th powers.
+They are related to the Taylor series expansions of $x/\tan(x)$ and $\coth(x)$ and also show up in
+the values that the Riemann zeta function takes both at both negative and positive integers
+(and hence in the theory of modular forms). For example, if $1\le n$ is even then
 
-$$\zeta(2n)=\sum_{t\geq1}t^{-2n}=(-1)^{n+1}\frac{(2\pi)^{2n}B_{2n}}{2(2n)!}.$$
+$$\zeta(2n)=\sum_{t\ge1}t^{-2n}=(-1)^{n+1}\frac{(2\pi)^{2n}B_{2n}}{2(2n)!}.$$
 
-Note however that this result is not yet formalised in Lean.
+This result is `riemannZeta_two_mul_nat` in `Mathlib.NumberTheory.ZetaFunction`.
 
 The Bernoulli numbers can be formally defined using the power series
 
 $$\sum B_n\frac{t^n}{n!}=\frac{t}{1-e^{-t}}$$
 
-although that happens to not be the definition in mathlib (this is an *implementation
-detail* and need not concern the mathematician).
+although that happens to not be the definition in mathlib (this is an *implementation detail*
+and need not concern the mathematician).
 
-Note that $B_1=-1/2$, meaning that we are using the $B_n^-$ of
-[from Wikipedia](https://en.wikipedia.org/wiki/Bernoulli_number).
+Note that $B_1=1/2$, meaning that we are using the $B_n^+$ of
+[Wikipedia](https://en.wikipedia.org/wiki/Bernoulli_number).
 
 ## Implementation detail
 
 The Bernoulli numbers are defined using well-founded induction, by the formula
 $$B_n=1-\sum_{k\lt n}\frac{\binom{n}{k}}{n-k+1}B_k.$$
-This formula is true for all $n$ and in particular $B_0=1$. Note that this is the definition
-for positive Bernoulli numbers, which we call `bernoulli'`. The negative Bernoulli numbers are
-then defined as `bernoulli := (-1)^n * bernoulli'`.
+This formula is true for all $n$ and in particular $B_0=1$. The negative Bernoulli numbers
+(as used by Abramowitz & Stegun) are then defined as `bernoulli' := (-1)^n * bernoulli`.
 
 ## Main theorems
 
-`sum_bernoulli : ∑ k in Finset.range n, (n.choose k : ℚ) * bernoulli k = if n = 1 then 1 else 0`
+`sum_bernoulli : ∑ k in Finset.range n, (n.choose k : ℚ) * bernoulli k = n`
 -/
 
 
@@ -61,38 +58,37 @@ variable (A : Type*) [CommRing A] [Algebra ℚ A]
 /-! ### Definitions -/
 
 
-/-- The Bernoulli numbers:
-the $n$-th Bernoulli number $B_n$ is defined recursively via
+/-- The Bernoulli numbers: the $n$-th Bernoulli number $B_n$ is defined recursively via
 $$B_n = 1 - \sum_{k < n} \binom{n}{k}\frac{B_k}{n+1-k}$$ -/
-def bernoulli' : ℕ → ℚ :=
-  WellFounded.fix Nat.lt_wfRel.wf fun n bernoulli' =>
-    1 - ∑ k : Fin n, n.choose k / (n - k + 1) * bernoulli' k k.2
-#align bernoulli' bernoulli'
+def bernoulli : ℕ → ℚ :=
+  WellFounded.fix Nat.lt_wfRel.wf fun n bernoulli =>
+    1 - ∑ k : Fin n, n.choose k / (n - k + 1) * bernoulli k k.2
+#align bernoulli' bernoulli
 
-theorem bernoulli'_def' (n : ℕ) :
-    bernoulli' n = 1 - ∑ k : Fin n, n.choose k / (n - k + 1) * bernoulli' k :=
+theorem bernoulli_def' (n : ℕ) :
+    bernoulli n = 1 - ∑ k : Fin n, n.choose k / (n - k + 1) * bernoulli k :=
   WellFounded.fix_eq _ _ _
-#align bernoulli'_def' bernoulli'_def'
+#align bernoulli'_def' bernoulli_def'
 
-theorem bernoulli'_def (n : ℕ) :
-    bernoulli' n = 1 - ∑ k in range n, n.choose k / (n - k + 1) * bernoulli' k := by
-  rw [bernoulli'_def', ← Fin.sum_univ_eq_sum_range]
-#align bernoulli'_def bernoulli'_def
+theorem bernoulli_def (n : ℕ) :
+    bernoulli n = 1 - ∑ k in range n, n.choose k / (n - k + 1) * bernoulli k := by
+  rw [bernoulli_def', ← Fin.sum_univ_eq_sum_range]
+#align bernoulli'_def bernoulli_def
 
-theorem bernoulli'_spec (n : ℕ) :
-    (∑ k in range n.succ, (n.choose (n - k) : ℚ) / (n - k + 1) * bernoulli' k) = 1 := by
-  rw [sum_range_succ_comm, bernoulli'_def n, tsub_self, choose_zero_right, sub_self, zero_add,
+theorem bernoulli_spec (n : ℕ) :
+    (∑ k in range n.succ, (n.choose (n - k) : ℚ) / (n - k + 1) * bernoulli k) = 1 := by
+  rw [sum_range_succ_comm, bernoulli_def n, tsub_self, choose_zero_right, sub_self, zero_add,
     div_one, cast_one, one_mul, sub_add, ← sum_sub_distrib, ← sub_eq_zero, sub_sub_cancel_left,
     neg_eq_zero]
   exact Finset.sum_eq_zero (fun x hx => by rw [choose_symm (le_of_lt (mem_range.1 hx)), sub_self])
-#align bernoulli'_spec bernoulli'_spec
+#align bernoulli'_spec bernoulli_spec
 
-theorem bernoulli'_spec' (n : ℕ) :
-    (∑ k in antidiagonal n, ((k.1 + k.2).choose k.2 : ℚ) / (k.2 + 1) * bernoulli' k.1) = 1 := by
-  refine' ((sum_antidiagonal_eq_sum_range_succ_mk _ n).trans _).trans (bernoulli'_spec n)
+theorem bernoulli_spec' (n : ℕ) :
+    (∑ k in antidiagonal n, ((k.1 + k.2).choose k.2 : ℚ) / (k.2 + 1) * bernoulli k.1) = 1 := by
+  refine' ((sum_antidiagonal_eq_sum_range_succ_mk _ n).trans _).trans (bernoulli_spec n)
   refine' sum_congr rfl fun x hx => _
   simp only [add_tsub_cancel_of_le, mem_range_succ_iff.mp hx, cast_sub]
-#align bernoulli'_spec' bernoulli'_spec'
+#align bernoulli'_spec' bernoulli_spec'
 
 /-! ### Examples -/
 
@@ -100,46 +96,46 @@ theorem bernoulli'_spec' (n : ℕ) :
 section Examples
 
 @[simp]
-theorem bernoulli'_zero : bernoulli' 0 = 1 := by
-  rw [bernoulli'_def]
+theorem bernoulli_zero : bernoulli 0 = 1 := by
+  rw [bernoulli_def]
   norm_num
-#align bernoulli'_zero bernoulli'_zero
+#align bernoulli'_zero bernoulli_zero
 
 @[simp]
-theorem bernoulli'_one : bernoulli' 1 = 1 / 2 := by
-  rw [bernoulli'_def]
+theorem bernoulli_one : bernoulli 1 = 1 / 2 := by
+  rw [bernoulli_def]
   norm_num
-#align bernoulli'_one bernoulli'_one
+#align bernoulli'_one bernoulli_one
 
 @[simp]
-theorem bernoulli'_two : bernoulli' 2 = 1 / 6 := by
-  rw [bernoulli'_def]
+theorem bernoulli_two : bernoulli 2 = 1 / 6 := by
+  rw [bernoulli_def]
   norm_num [sum_range_succ, sum_range_succ, sum_range_zero]
-#align bernoulli'_two bernoulli'_two
+#align bernoulli'_two bernoulli_two
 
 @[simp]
-theorem bernoulli'_three : bernoulli' 3 = 0 := by
-  rw [bernoulli'_def]
+theorem bernoulli_three : bernoulli 3 = 0 := by
+  rw [bernoulli_def]
   norm_num [sum_range_succ, sum_range_succ, sum_range_zero]
-#align bernoulli'_three bernoulli'_three
+#align bernoulli'_three bernoulli_three
 
 @[simp]
-theorem bernoulli'_four : bernoulli' 4 = -1 / 30 := by
+theorem bernoulli_four : bernoulli 4 = -1 / 30 := by
   have : Nat.choose 4 2 = 6 := by decide -- shrug
-  rw [bernoulli'_def]
+  rw [bernoulli_def]
   norm_num [sum_range_succ, sum_range_succ, sum_range_zero, this]
-#align bernoulli'_four bernoulli'_four
+#align bernoulli'_four bernoulli_four
 
 end Examples
 
 @[simp]
-theorem sum_bernoulli' (n : ℕ) : (∑ k in range n, (n.choose k : ℚ) * bernoulli' k) = n := by
+theorem sum_bernoulli (n : ℕ) : (∑ k in range n, (n.choose k : ℚ) * bernoulli k) = n := by
   cases' n with n
   · simp
   suffices
-    ((n + 1 : ℚ) * ∑ k in range n, ↑(n.choose k) / (n - k + 1) * bernoulli' k) =
-      ∑ x in range n, ↑(n.succ.choose x) * bernoulli' x by
-    rw_mod_cast [sum_range_succ, bernoulli'_def, ← this, choose_succ_self_right]
+    ((n + 1 : ℚ) * ∑ k in range n, ↑(n.choose k) / (n - k + 1) * bernoulli k) =
+      ∑ x in range n, ↑(n.succ.choose x) * bernoulli x by
+    rw_mod_cast [sum_range_succ, bernoulli_def, ← this, choose_succ_self_right]
     ring
   simp_rw [mul_sum, ← mul_assoc]
   refine' sum_congr rfl fun k hk => _
@@ -147,38 +143,38 @@ theorem sum_bernoulli' (n : ℕ) : (∑ k in range n, (n.choose k : ℚ) * berno
   have : ((n - k : ℕ) : ℚ) + 1 ≠ 0 := by norm_cast; exact succ_ne_zero _
   field_simp [← cast_sub (mem_range.1 hk).le, mul_comm]
   rw_mod_cast [tsub_add_eq_add_tsub (mem_range.1 hk).le, choose_mul_succ_eq]
-#align sum_bernoulli' sum_bernoulli'
+#align sum_bernoulli' sum_bernoulli
 
-/-- The exponential generating function for the Bernoulli numbers `bernoulli' n`. -/
-def bernoulli'PowerSeries :=
-  mk fun n => algebraMap ℚ A (bernoulli' n / n !)
-#align bernoulli'_power_series bernoulli'PowerSeries
+/-- The exponential generating function for the Bernoulli numbers. -/
+def bernoulliPowerSeries :=
+  mk fun n => algebraMap ℚ A (bernoulli n / n !)
+#align bernoulli'_power_series bernoulliPowerSeries
 
-theorem bernoulli'PowerSeries_mul_exp_sub_one :
-    bernoulli'PowerSeries A * (exp A - 1) = X * exp A := by
+theorem bernoulliPowerSeries_mul_exp_sub_one :
+    bernoulliPowerSeries A * (exp A - 1) = X * exp A := by
   ext n
   -- constant coefficient is a special case
   cases' n with n
   · simp
-  rw [bernoulli'PowerSeries, coeff_mul, mul_comm X, sum_antidiagonal_succ']
+  rw [bernoulliPowerSeries, coeff_mul, mul_comm X, sum_antidiagonal_succ']
   suffices (∑ p in antidiagonal n,
-      bernoulli' p.1 / p.1! * ((p.2 + 1) * p.2! : ℚ)⁻¹) = (n ! : ℚ)⁻¹ by
+      bernoulli p.1 / p.1! * ((p.2 + 1) * p.2! : ℚ)⁻¹) = (n ! : ℚ)⁻¹ by
     simpa [map_sum, Nat.factorial] using congr_arg (algebraMap ℚ A) this
   apply eq_inv_of_mul_eq_one_left
   rw [sum_mul]
-  convert bernoulli'_spec' n using 1
+  convert bernoulli_spec' n using 1
   apply sum_congr rfl
   simp_rw [mem_antidiagonal]
   rintro ⟨i, j⟩ rfl
   have := factorial_mul_factorial_dvd_factorial_add i j
-  field_simp [mul_comm _ (bernoulli' i), mul_assoc, add_choose]
+  field_simp [mul_comm _ (bernoulli i), mul_assoc, add_choose]
   norm_cast
   simp [mul_comm (j + 1)]
-#align bernoulli'_power_series_mul_exp_sub_one bernoulli'PowerSeries_mul_exp_sub_one
+#align bernoulli'_power_series_mul_exp_sub_one bernoulliPowerSeries_mul_exp_sub_one
 
 /-- Odd Bernoulli numbers (greater than 1) are zero. -/
-theorem bernoulli'_odd_eq_zero {n : ℕ} (h_odd : Odd n) (hlt : 1 < n) : bernoulli' n = 0 := by
-  let B := mk fun n => bernoulli' n / (n ! : ℚ)
+theorem bernoulli_odd_eq_zero {n : ℕ} (h_odd : Odd n) (hlt : 1 < n) : bernoulli n = 0 := by
+  let B := mk fun n => bernoulli n / (n ! : ℚ)
   suffices (B - evalNegHom B) * (exp ℚ - 1) = X * (exp ℚ - 1) by
     cases' mul_eq_mul_right_iff.mp this with h h <;>
       simp only [PowerSeries.ext_iff, evalNegHom, coeff_X] at h
@@ -187,97 +183,96 @@ theorem bernoulli'_odd_eq_zero {n : ℕ} (h_odd : Odd n) (hlt : 1 < n) : bernoul
       split_ifs at h <;> simp_all [h_odd.neg_one_pow, factorial_ne_zero]
     · simpa (config := {decide := true}) [Nat.factorial] using h 1
   have h : B * (exp ℚ - 1) = X * exp ℚ := by
-    simpa [bernoulli'PowerSeries] using bernoulli'PowerSeries_mul_exp_sub_one ℚ
+    simpa [bernoulliPowerSeries] using bernoulliPowerSeries_mul_exp_sub_one ℚ
   rw [sub_mul, h, mul_sub X, sub_right_inj, ← neg_sub, mul_neg, neg_eq_iff_eq_neg]
   suffices evalNegHom (B * (exp ℚ - 1)) * exp ℚ = evalNegHom (X * exp ℚ) * exp ℚ by
     rw [map_mul, map_mul] at this --Porting note: Why doesn't simp do this?
     simpa [mul_assoc, sub_mul, mul_comm (evalNegHom (exp ℚ)), exp_mul_exp_neg_eq_one]
   congr
-#align bernoulli'_odd_eq_zero bernoulli'_odd_eq_zero
+#align bernoulli'_odd_eq_zero bernoulli_odd_eq_zero
 
-/-- The Bernoulli numbers are defined to be `bernoulli'` with a parity sign. -/
-def bernoulli (n : ℕ) : ℚ :=
-  (-1) ^ n * bernoulli' n
-#align bernoulli bernoulli
+/-- The negative Bernoulli numbers are defined to be `bernoulli` with a parity sign. -/
+def bernoulli' (n : ℕ) : ℚ :=
+  (-1) ^ n * bernoulli n
+#align bernoulli bernoulli'
 
-theorem bernoulli'_eq_bernoulli (n : ℕ) : bernoulli' n = (-1) ^ n * bernoulli n := by
-  simp [bernoulli, ← mul_assoc, ← sq, ← pow_mul, mul_comm n 2, pow_mul]
-#align bernoulli'_eq_bernoulli bernoulli'_eq_bernoulli
+theorem bernoulli_eq_bernoulli' (n : ℕ) : bernoulli n = (-1) ^ n * bernoulli' n := by
+  simp [bernoulli', ← mul_assoc, ← sq, ← pow_mul, mul_comm n 2, pow_mul]
+#align bernoulli'_eq_bernoulli bernoulli_eq_bernoulli'
 
 @[simp]
-theorem bernoulli_zero : bernoulli 0 = 1 := by simp [bernoulli]
+theorem bernoulli'_zero : bernoulli' 0 = 1 := by simp [bernoulli']
 #align bernoulli_zero bernoulli_zero
 
 @[simp]
-theorem bernoulli_one : bernoulli 1 = -1 / 2 := by norm_num [bernoulli]
+theorem bernoulli'_one : bernoulli' 1 = -1 / 2 := by norm_num [bernoulli']
 #align bernoulli_one bernoulli_one
 
-theorem bernoulli_eq_bernoulli'_of_ne_one {n : ℕ} (hn : n ≠ 1) : bernoulli n = bernoulli' n := by
+theorem bernoulli'_eq_bernoulli_of_ne_one {n : ℕ} (hn : n ≠ 1) : bernoulli' n = bernoulli n := by
   by_cases h0 : n = 0; · simp [h0]
-  rw [bernoulli, neg_one_pow_eq_pow_mod_two]
+  rw [bernoulli', neg_one_pow_eq_pow_mod_two]
   cases' mod_two_eq_zero_or_one n with h h
   · simp [h]
-  · simp [bernoulli'_odd_eq_zero (odd_iff.mpr h) (one_lt_iff_ne_zero_and_ne_one.mpr ⟨h0, hn⟩)]
-#align bernoulli_eq_bernoulli'_of_ne_one bernoulli_eq_bernoulli'_of_ne_one
+  · simp [bernoulli_odd_eq_zero (odd_iff.mpr h) (one_lt_iff_ne_zero_and_ne_one.mpr ⟨h0, hn⟩)]
+#align bernoulli_eq_bernoulli'_of_ne_one bernoulli'_eq_bernoulli_of_ne_one
 
 @[simp]
-theorem sum_bernoulli (n : ℕ) :
-    (∑ k in range n, (n.choose k : ℚ) * bernoulli k) = if n = 1 then 1 else 0 := by
+theorem sum_bernoulli' (n : ℕ) :
+    (∑ k in range n, (n.choose k : ℚ) * bernoulli' k) = if n = 1 then 1 else 0 := by
   cases' n with n n
   · simp
   cases' n with n n
   · rw [sum_range_one]
     simp
-  suffices (∑ i in range n, ↑((n + 2).choose (i + 2)) * bernoulli (i + 2)) = n / 2 by
-    simp only [this, sum_range_succ', cast_succ, bernoulli_one, bernoulli_zero, choose_one_right,
+  suffices (∑ i in range n, ↑((n + 2).choose (i + 2)) * bernoulli' (i + 2)) = n / 2 by
+    simp only [this, sum_range_succ', cast_succ, bernoulli'_one, bernoulli'_zero, choose_one_right,
       mul_one, choose_zero_right, cast_zero, if_false, zero_add, succ_succ_ne_one]
     ring
-  have f := sum_bernoulli' n.succ.succ
+  have f := sum_bernoulli n.succ.succ
   simp_rw [sum_range_succ', cast_succ, ← eq_sub_iff_add_eq] at f
-  -- porting note: was `convert f`
-  refine' Eq.trans _ (Eq.trans f _)
+  convert f using 1
   · congr
     funext x
-    rw [bernoulli_eq_bernoulli'_of_ne_one (succ_ne_zero x ∘ succ.inj)]
-  · simp only [one_div, mul_one, bernoulli'_zero, cast_one, choose_zero_right, add_sub_cancel,
-      zero_add, choose_one_right, cast_succ, cast_add, cast_one, bernoulli'_one, one_div]
+    rw [bernoulli'_eq_bernoulli_of_ne_one (succ_ne_zero x ∘ succ.inj)]
+  · simp only [one_div, mul_one, bernoulli_zero, cast_one, choose_zero_right, add_sub_cancel,
+      zero_add, choose_one_right, cast_succ, cast_add, cast_one, bernoulli_one, one_div]
     ring
-#align sum_bernoulli sum_bernoulli
+#align sum_bernoulli sum_bernoulli'
 
-theorem bernoulli_spec' (n : ℕ) :
-    (∑ k in antidiagonal n, ((k.1 + k.2).choose k.2 : ℚ) / (k.2 + 1) * bernoulli k.1) =
+theorem bernoulli'_spec' (n : ℕ) :
+    (∑ k in antidiagonal n, ((k.1 + k.2).choose k.2 : ℚ) / (k.2 + 1) * bernoulli' k.1) =
       if n = 0 then 1 else 0 := by
-  cases' n with n n;
+  cases' n with n n
   · simp
   rw [if_neg (succ_ne_zero _)]
   -- algebra facts
   have h₁ : (1, n) ∈ antidiagonal n.succ := by simp [mem_antidiagonal, add_comm]
   have h₂ : (n : ℚ) + 1 ≠ 0 := by norm_cast; exact succ_ne_zero _
   have h₃ : (1 + n).choose n = n + 1 := by simp [add_comm]
-  -- key equation: the corresponding fact for `bernoulli'`
-  have H := bernoulli'_spec' n.succ
+  -- key equation: the corresponding fact for `bernoulli`
+  have H := bernoulli_spec' n.succ
   -- massage it to match the structure of the goal, then convert piece by piece
   rw [sum_eq_add_sum_diff_singleton h₁] at H ⊢
   apply add_eq_of_eq_sub'
   convert eq_sub_of_add_eq' H using 1
   · refine' sum_congr rfl fun p h => _
     obtain ⟨h', h''⟩ : p ∈ _ ∧ p ≠ _ := by rwa [mem_sdiff, mem_singleton] at h
-    simp [bernoulli_eq_bernoulli'_of_ne_one ((not_congr (antidiagonal_congr h' h₁)).mp h'')]
+    simp [bernoulli'_eq_bernoulli_of_ne_one ((not_congr (antidiagonal_congr h' h₁)).mp h'')]
   · field_simp [h₃]
     norm_num
-#align bernoulli_spec' bernoulli_spec'
+#align bernoulli_spec' bernoulli'_spec'
 
-/-- The exponential generating function for the Bernoulli numbers `bernoulli n`. -/
-def bernoulliPowerSeries :=
-  mk fun n => algebraMap ℚ A (bernoulli n / n !)
-#align bernoulli_power_series bernoulliPowerSeries
+/-- The exponential generating function for the negative Bernoulli numbers. -/
+def bernoulli'PowerSeries :=
+  mk fun n => algebraMap ℚ A (bernoulli' n / n !)
+#align bernoulli_power_series bernoulli'PowerSeries
 
-theorem bernoulliPowerSeries_mul_exp_sub_one : bernoulliPowerSeries A * (exp A - 1) = X := by
+theorem bernoulli'PowerSeries_mul_exp_sub_one : bernoulli'PowerSeries A * (exp A - 1) = X := by
   ext n
   -- constant coefficient is a special case
-  cases' n with n n;
+  cases' n with n n
   · simp
-  simp only [bernoulliPowerSeries, coeff_mul, coeff_X, sum_antidiagonal_succ', one_div, coeff_mk,
+  simp only [bernoulli'PowerSeries, coeff_mul, coeff_X, sum_antidiagonal_succ', one_div, coeff_mk,
     coeff_one, coeff_exp, LinearMap.map_sub, factorial, if_pos, cast_succ, cast_one, cast_mul,
     sub_zero, RingHom.map_one, add_eq_zero_iff, if_false, _root_.inv_one, zero_add, one_ne_zero,
     mul_zero, and_false_iff, sub_self, ← RingHom.map_mul, ← map_sum]
@@ -287,34 +282,33 @@ theorem bernoulliPowerSeries_mul_exp_sub_one : bernoulliPowerSeries A * (exp A -
   have hfact : ∀ m, (m ! : ℚ) ≠ 0 := fun m => mod_cast factorial_ne_zero m
   have hite2 : ite (n.succ = 0) 1 0 = (0 : ℚ) := if_neg n.succ_ne_zero
   simp only [CharP.cast_eq_zero, zero_add, inv_one, map_one, sub_self, mul_zero, add_eq]
-  rw [← map_zero (algebraMap ℚ A), ← zero_div (n.succ ! : ℚ), ← hite2, ← bernoulli_spec', sum_div]
+  rw [← map_zero (algebraMap ℚ A), ← zero_div (n.succ ! : ℚ), ← hite2, ← bernoulli'_spec', sum_div]
   refine' congr_arg (algebraMap ℚ A) (sum_congr rfl fun x h => eq_div_of_mul_eq (hfact n.succ) _)
   rw [mem_antidiagonal] at h
   rw [← h, add_choose, cast_div_charZero (factorial_mul_factorial_dvd_factorial_add _ _)]
-  field_simp [hfact x.1, mul_comm _ (bernoulli x.1), mul_assoc]
+  field_simp [hfact x.1, mul_comm _ (bernoulli' x.1), mul_assoc]
   -- porting note: was `cc`, which was not yet ported
   left
   left
   ring
-#align bernoulli_power_series_mul_exp_sub_one bernoulliPowerSeries_mul_exp_sub_one
+#align bernoulli_power_series_mul_exp_sub_one bernoulli'PowerSeries_mul_exp_sub_one
 
 section Faulhaber
 
-/-- **Faulhaber's theorem** relating the **sum of p-th powers** to the Bernoulli numbers:
-$$\sum_{k=0}^{n-1} k^p = \sum_{i=0}^p B_i\binom{p+1}{i}\frac{n^{p+1-i}}{p+1}.$$
+/-- **Faulhaber's theorem** relating the **sum of p-th powers** to the negative Bernoulli numbers:
+$$\sum_{k=0}^{n-1} k^p = \sum_{i=0}^p B_i^-\binom{p+1}{i}\frac{n^{p+1-i}}{p+1}.$$
 See https://proofwiki.org/wiki/Faulhaber%27s_Formula and [orosi2018faulhaber] for
 the proof provided here. -/
-theorem sum_range_pow (n p : ℕ) :
-    (∑ k in range n, (k : ℚ) ^ p) =
-      ∑ i in range (p + 1), bernoulli i * ((p + 1).choose i) * (n : ℚ) ^ (p + 1 - i) / (p + 1) := by
+theorem sum_range_pow (n p : ℕ) : (∑ k in range n, (k : ℚ) ^ p) =
+    ∑ i in range (p + 1), bernoulli' i * ((p + 1).choose i) * (n : ℚ) ^ (p + 1 - i) / (p + 1) := by
   have hne : ∀ m : ℕ, (m ! : ℚ) ≠ 0 := fun m => mod_cast factorial_ne_zero m
   -- compute the Cauchy product of two power series
   have h_cauchy :
-    ((mk fun p => bernoulli p / p !) * mk fun q => coeff ℚ (q + 1) (exp ℚ ^ n)) =
+    ((mk fun p => bernoulli' p / p !) * mk fun q => coeff ℚ (q + 1) (exp ℚ ^ n)) =
       mk fun p => ∑ i in range (p + 1),
-          bernoulli i * (p + 1).choose i * (n : ℚ) ^ (p + 1 - i) / (p + 1)! := by
+          bernoulli' i * (p + 1).choose i * (n : ℚ) ^ (p + 1 - i) / (p + 1)! := by
     ext q : 1
-    let f a b := bernoulli a / a ! * coeff ℚ (b + 1) (exp ℚ ^ n)
+    let f a b := bernoulli' a / a ! * coeff ℚ (b + 1) (exp ℚ ^ n)
     -- key step: use `PowerSeries.coeff_mul` and then rewrite sums
     simp only [coeff_mul, coeff_mk, cast_mul, sum_antidiagonal_eq_sum_range_succ f]
     apply sum_congr rfl
@@ -337,11 +331,10 @@ theorem sum_range_pow (n p : ℕ) :
   have hps :
     (∑ k in range n, (k : ℚ) ^ p) =
       (∑ i in range (p + 1),
-          bernoulli i * (p + 1).choose i * (n : ℚ) ^ (p + 1 - i) / (p + 1)!) * p ! := by
-    suffices
-      (mk fun p => ∑ k in range n, (k : ℚ) ^ p * algebraMap ℚ ℚ p !⁻¹) =
-        mk fun p =>
-          ∑ i in range (p + 1), bernoulli i * (p + 1).choose i * (n : ℚ) ^ (p + 1 - i) / (p + 1)! by
+          bernoulli' i * (p + 1).choose i * (n : ℚ) ^ (p + 1 - i) / (p + 1)!) * p ! := by
+    suffices (mk fun p => ∑ k in range n, (k : ℚ) ^ p * algebraMap ℚ ℚ p !⁻¹) =
+        mk fun p => ∑ i in range (p + 1),
+          bernoulli' i * (p + 1).choose i * (n : ℚ) ^ (p + 1 - i) / (p + 1)! by
       rw [← div_eq_iff (hne p), div_eq_mul_inv, sum_mul]
       rw [PowerSeries.ext_iff] at this
       simpa using this p
@@ -356,14 +349,13 @@ theorem sum_range_pow (n p : ℕ) :
     -- key step: a chain of equalities of power series
     -- porting note: altered proof slightly
     rw [← mul_right_inj' hexp, mul_comm]
-    rw [← exp_pow_sum, geom_sum_mul, h_r, ← bernoulliPowerSeries_mul_exp_sub_one,
-      bernoulliPowerSeries, mul_right_comm]
+    rw [← exp_pow_sum, geom_sum_mul, h_r, ← bernoulli'PowerSeries_mul_exp_sub_one,
+      bernoulli'PowerSeries, mul_right_comm]
     simp only [mul_comm, mul_eq_mul_left_iff, hexp, or_false]
     refine' Eq.trans (mul_eq_mul_right_iff.mpr _) (Eq.trans h_cauchy _)
     · left
       congr
     · simp only [mul_comm, factorial, cast_succ, cast_pow]
-
   -- massage `hps` into our goal
   rw [hps, sum_mul]
   refine' sum_congr rfl fun x _ => _
@@ -371,18 +363,17 @@ theorem sum_range_pow (n p : ℕ) :
   ring
 #align sum_range_pow sum_range_pow
 
-/-- Alternate form of **Faulhaber's theorem**, relating the sum of p-th powers to the Bernoulli
-numbers: $$\sum_{k=1}^{n} k^p = \sum_{i=0}^p (-1)^iB_i\binom{p+1}{i}\frac{n^{p+1-i}}{p+1}.$$
+/-- **Faulhaber's theorem** relating the sum of p-th powers to the Bernoulli numbers:
+$$\sum_{k=1}^{n} k^p = \sum_{i=0}^p (-1)^iB_i\binom{p+1}{i}\frac{n^{p+1-i}}{p+1}.$$
 Deduced from `sum_range_pow`. -/
-theorem sum_Ico_pow (n p : ℕ) :
-    (∑ k in Ico 1 (n + 1), (k : ℚ) ^ p) =
-      ∑ i in range (p + 1), bernoulli' i * (p + 1).choose i * (n : ℚ) ^ (p + 1 - i) / (p + 1) := by
+theorem sum_Ico_pow (n p : ℕ) : (∑ k in Ico 1 (n + 1), (k : ℚ) ^ p) =
+    ∑ i in range (p + 1), bernoulli i * (p + 1).choose i * (n : ℚ) ^ (p + 1 - i) / (p + 1) := by
   rw [← Nat.cast_succ]
   -- dispose of the trivial case
   cases' p with p p
   · simp
-  let f i := bernoulli i * p.succ.succ.choose i * (n : ℚ) ^ (p.succ.succ - i) / p.succ.succ
-  let f' i := bernoulli' i * p.succ.succ.choose i * (n : ℚ) ^ (p.succ.succ - i) / p.succ.succ
+  let f i := bernoulli' i * p.succ.succ.choose i * (n : ℚ) ^ (p.succ.succ - i) / p.succ.succ
+  let f' i := bernoulli i * p.succ.succ.choose i * (n : ℚ) ^ (p.succ.succ - i) / p.succ.succ
   suffices (∑ k in Ico 1 n.succ, (k : ℚ) ^ p.succ) = ∑ i in range p.succ.succ, f' i by convert this
   -- prove some algebraic facts that will make things easier for us later on
   have hle := Nat.le_add_left 1 n
@@ -390,12 +381,12 @@ theorem sum_Ico_pow (n p : ℕ) :
   have h1 : ∀ r : ℚ, r * (p + 1 + 1) * (n : ℚ) ^ p.succ / (p + 1 + 1 : ℚ) = r * (n : ℚ) ^ p.succ :=
       fun r => by rw [mul_div_right_comm, mul_div_cancel _ hne]
   have h2 : f 1 + (n : ℚ) ^ p.succ = 1 / 2 * (n : ℚ) ^ p.succ := by
-    simp_rw [bernoulli_one, choose_one_right, succ_sub_succ_eq_sub, cast_succ, tsub_zero, h1]
+    simp_rw [bernoulli'_one, choose_one_right, succ_sub_succ_eq_sub, cast_succ, tsub_zero, h1]
     ring
   have :
-    (∑ i in range p, bernoulli (i + 2) * (p + 2).choose (i + 2) * (n : ℚ) ^ (p - i) / ↑(p + 2)) =
-      ∑ i in range p, bernoulli' (i + 2) * (p + 2).choose (i + 2) * (n : ℚ) ^ (p - i) / ↑(p + 2) :=
-    sum_congr rfl fun i _ => by rw [bernoulli_eq_bernoulli'_of_ne_one (succ_succ_ne_one i)]
+    (∑ i in range p, bernoulli' (i + 2) * (p + 2).choose (i + 2) * (n : ℚ) ^ (p - i) / ↑(p + 2)) =
+      ∑ i in range p, bernoulli (i + 2) * (p + 2).choose (i + 2) * (n : ℚ) ^ (p - i) / ↑(p + 2) :=
+    sum_congr rfl fun i _ => by rw [bernoulli'_eq_bernoulli_of_ne_one (succ_succ_ne_one i)]
   calc
     (-- replace sum over `Ico` with sum over `range` and simplify
         ∑ k in Ico 1 n.succ, (k : ℚ) ^ p.succ) = ∑ k in range n.succ, (k : ℚ) ^ p.succ :=
@@ -411,7 +402,7 @@ theorem sum_Ico_pow (n p : ℕ) :
       by simp_rw [sum_range_succ']
         _ = (∑ i in range p, f i.succ.succ) + (f 1 + (n : ℚ) ^ p.succ) + f 0 := by ring
         _ = (∑ i in range p, f i.succ.succ) + 1 / 2 * (n : ℚ) ^ p.succ + f 0 := by rw [h2]
-    -- convert from `bernoulli` to `bernoulli'`
+    -- convert from `bernoulli'` to `bernoulli`
         _ = (∑ i in range p, f' i.succ.succ) + f' 1 + f' 0 :=
       by simpa [h1, fun i => show i + 2 = i + 1 + 1 from rfl]
     -- rejoin the first two terms of the sum

--- a/Mathlib/NumberTheory/BernoulliPolynomials.lean
+++ b/Mathlib/NumberTheory/BernoulliPolynomials.lean
@@ -25,7 +25,7 @@ $$ \frac{t e^{tX} }{ e^t - 1} = ∑_{n = 0}^{\infty} B_n(X) \frac{t^n}{n!} $$
 
 ## Implementation detail
 
-Bernoulli polynomials are defined using `bernoulli`, the Bernoulli numbers.
+Bernoulli polynomials are defined using `bernoulli'`, the negative Bernoulli numbers.
 
 ## Main theorems
 
@@ -53,11 +53,11 @@ namespace Polynomial
 
 /-- The Bernoulli polynomials are defined in terms of the negative Bernoulli numbers. -/
 def bernoulli (n : ℕ) : ℚ[X] :=
-  ∑ i in range (n + 1), Polynomial.monomial (n - i) (_root_.bernoulli i * choose n i)
+  ∑ i in range (n + 1), Polynomial.monomial (n - i) (bernoulli' i * choose n i)
 #align polynomial.bernoulli Polynomial.bernoulli
 
 theorem bernoulli_def (n : ℕ) : bernoulli n =
-    ∑ i in range (n + 1), Polynomial.monomial i (_root_.bernoulli (n - i) * choose n i) := by
+    ∑ i in range (n + 1), Polynomial.monomial i (bernoulli' (n - i) * choose n i) := by
   rw [← sum_range_reflect, add_succ_sub_one, add_zero, bernoulli]
   apply sum_congr rfl
   rintro x hx
@@ -74,9 +74,9 @@ theorem bernoulli_zero : bernoulli 0 = 1 := by simp [bernoulli]
 #align polynomial.bernoulli_zero Polynomial.bernoulli_zero
 
 @[simp]
-theorem bernoulli_eval_zero (n : ℕ) : (bernoulli n).eval 0 = _root_.bernoulli n := by
+theorem bernoulli_eval_zero (n : ℕ) : (bernoulli n).eval 0 = bernoulli' n := by
   rw [bernoulli, eval_finset_sum, sum_range_succ]
-  have : (∑ x : ℕ in range n, _root_.bernoulli x * n.choose x * 0 ^ (n - x)) = 0 := by
+  have : (∑ x : ℕ in range n, bernoulli' x * n.choose x * 0 ^ (n - x)) = 0 := by
     apply sum_eq_zero fun x hx => _
     intros x hx
     have h : x < n := (mem_range.1 hx)
@@ -85,14 +85,14 @@ theorem bernoulli_eval_zero (n : ℕ) : (bernoulli n).eval 0 = _root_.bernoulli 
 #align polynomial.bernoulli_eval_zero Polynomial.bernoulli_eval_zero
 
 @[simp]
-theorem bernoulli_eval_one (n : ℕ) : (bernoulli n).eval 1 = bernoulli' n := by
+theorem bernoulli_eval_one (n : ℕ) : (bernoulli n).eval 1 = _root_.bernoulli n := by
   simp only [bernoulli, eval_finset_sum]
   simp only [← succ_eq_add_one, sum_range_succ, mul_one, cast_one, choose_self,
-    (_root_.bernoulli _).mul_comm, sum_bernoulli, one_pow, mul_one, eval_C, eval_monomial, one_mul]
+    (bernoulli' _).mul_comm, sum_bernoulli, one_pow, mul_one, eval_C, eval_monomial, one_mul]
   by_cases h : n = 1
   · norm_num [h]
   · simp [h]
-    exact bernoulli_eq_bernoulli'_of_ne_one h
+    exact bernoulli'_eq_bernoulli_of_ne_one h
 #align polynomial.bernoulli_eval_one Polynomial.bernoulli_eval_one
 
 end Examples
@@ -124,7 +124,7 @@ nonrec theorem sum_bernoulli (n : ℕ) :
   simp_rw [bernoulli_def, Finset.smul_sum, Finset.range_eq_Ico, ← Finset.sum_Ico_Ico_comm,
     Finset.sum_Ico_eq_sum_range]
   simp only [add_tsub_cancel_left, tsub_zero, zero_add, map_add]
-  simp_rw [smul_monomial, mul_comm (_root_.bernoulli _) _, smul_eq_mul, ← mul_assoc]
+  simp_rw [smul_monomial, mul_comm (bernoulli' _) _, smul_eq_mul, ← mul_assoc]
   conv_lhs =>
     apply_congr
     · skip
@@ -138,8 +138,8 @@ nonrec theorem sum_bernoulli (n : ℕ) :
   simp_rw [← sum_smul]
   rw [sum_range_succ_comm]
   simp only [add_right_eq_self, mul_one, cast_one, cast_add, add_tsub_cancel_left,
-    choose_succ_self_right, one_smul, _root_.bernoulli_zero, sum_singleton, zero_add,
-    map_add, range_one, bernoulli_zero, mul_one, one_mul, add_zero, choose_self]
+    choose_succ_self_right, one_smul, bernoulli'_zero, sum_singleton, zero_add,
+    map_add, range_one, bernoulli'_zero, mul_one, one_mul, add_zero, choose_self]
   apply sum_eq_zero fun x hx => _
   have f : ∀ x ∈ range n, ¬n + 1 - x = 1 := by
     rintro x H
@@ -147,7 +147,7 @@ nonrec theorem sum_bernoulli (n : ℕ) :
     rw [eq_comm]
     exact _root_.ne_of_lt (Nat.lt_of_lt_of_le one_lt_two (le_tsub_of_add_le_left (succ_le_succ H)))
   intro x hx
-  rw [sum_bernoulli]
+  rw [sum_bernoulli']
   have g : ite (n + 1 - x = 1) (1 : ℚ) 0 = 0 := by
     simp only [ite_eq_right_iff, one_ne_zero]
     intro h₁
@@ -166,7 +166,7 @@ theorem bernoulli_eq_sub_sum (n : ℕ) :
 /-- Another version of `sum_range_pow`. -/
 theorem sum_range_pow_eq_bernoulli_sub (n p : ℕ) :
     ((p + 1 : ℚ) * ∑ k in range n, (k : ℚ) ^ p) = (bernoulli p.succ).eval (n : ℚ) -
-    _root_.bernoulli p.succ := by
+    bernoulli' p.succ := by
   rw [sum_range_pow, bernoulli_def, eval_finset_sum, ← sum_div, mul_div_cancel' _ _]
   · simp_rw [eval_monomial]
     symm
@@ -184,7 +184,7 @@ theorem sum_range_pow_eq_bernoulli_sub (n p : ℕ) :
 
 /-- Rearrangement of `Polynomial.sum_range_pow_eq_bernoulli_sub`. -/
 theorem bernoulli_succ_eval (n p : ℕ) : (bernoulli p.succ).eval (n : ℚ) =
-    _root_.bernoulli p.succ + (p + 1 : ℚ) * ∑ k in range n, (k : ℚ) ^ p := by
+    bernoulli' p.succ + (p + 1 : ℚ) * ∑ k in range n, (k : ℚ) ^ p := by
   apply eq_add_of_sub_eq'
   rw [sum_range_pow_eq_bernoulli_sub]
 #align polynomial.bernoulli_succ_eval Polynomial.bernoulli_succ_eval
@@ -205,7 +205,7 @@ theorem bernoulli_eval_one_add (n : ℕ) (x : ℚ) :
       · rw [eval_smul, hd _ (mem_range.1 (by assumption))]
   rw [eval_sub, eval_finset_sum]
   simp_rw [eval_smul, smul_add]
-  rw [sum_add_distrib, sub_add, sub_eq_sub_iff_sub_eq_sub, _root_.add_sub_sub_cancel]
+  rw [sum_add_distrib, sub_add, sub_eq_sub_iff_sub_eq_sub, add_sub_sub_cancel]
   conv_rhs =>
     congr
     · skip

--- a/Mathlib/NumberTheory/ZetaFunction.lean
+++ b/Mathlib/NumberTheory/ZetaFunction.lean
@@ -35,7 +35,7 @@ I haven't checked exactly what they are).
 * `riemannCompletedZeta₀_one_sub`, `riemannCompletedZeta_one_sub`, and `riemannZeta_one_sub` :
   functional equation relating values at `s` and `1 - s`
 * `riemannZeta_neg_nat_eq_bernoulli` : for any `k ∈ ℕ` we have the formula
-  `riemannZeta (-k) = (-1) ^ k * bernoulli (k + 1) / (k + 1)`
+  `riemannZeta (-k) = -bernoulli (k + 1) / (k + 1)`
 * `riemannZeta_two_mul_nat`: formula for `ζ(2 * k)` for `k ∈ ℕ, k ≠ 0` in terms of Bernoulli
   numbers
 
@@ -727,23 +727,19 @@ theorem riemannZeta_one_sub {s : ℂ} (hs : ∀ n : ℕ, s ≠ -n) (hs' : s ≠ 
 #align riemann_zeta_one_sub riemannZeta_one_sub
 
 theorem riemannZeta_neg_nat_eq_bernoulli (k : ℕ) :
-    riemannZeta (-k) = (-1 : ℂ) ^ k * bernoulli (k + 1) / (k + 1) := by
+    riemannZeta (-k) = -bernoulli (k + 1) / (k + 1) := by
   rcases Nat.even_or_odd' k with ⟨m, rfl | rfl⟩
   · cases' m with m m
-    ·-- k = 0 : evaluate explicitly
-      rw [Nat.zero_eq, mul_zero, Nat.cast_zero, pow_zero, one_mul, zero_add, neg_zero, zero_add,
+    · -- k = 0 : evaluate explicitly
+      rw [Nat.zero_eq, mul_zero, Nat.cast_zero, zero_add, neg_zero, zero_add,
         div_one, bernoulli_one, riemannZeta_zero]
       norm_num
     · -- k = 2 * (m + 1) : both sides "trivially" zero
       rw [Nat.cast_mul, ← neg_mul, Nat.cast_two, Nat.cast_succ, riemannZeta_neg_two_mul_nat_add_one,
-        bernoulli_eq_bernoulli'_of_ne_one]
-      swap; · apply ne_of_gt; norm_num
-      rw [bernoulli'_odd_eq_zero ⟨m + 1, rfl⟩ (by norm_num), Rat.cast_zero, mul_zero,
-        zero_div]
+        bernoulli_odd_eq_zero ⟨m + 1, rfl⟩ (by norm_num)]
+      norm_num
   · -- k = 2 * m + 1 : the interesting case
-    rw [Odd.neg_one_pow ⟨m, rfl⟩]
-    rw [show -(↑(2 * m + 1) : ℂ) = 1 - (2 * m + 2) by push_cast; ring]
-    rw [riemannZeta_one_sub]
+    rw [show -(↑(2 * m + 1) : ℂ) = 1 - (2 * m + 2) by push_cast; ring, riemannZeta_one_sub]
     rotate_left
     · intro n
       rw [(by norm_cast : 2 * (m : ℂ) + 2 = ↑(2 * m + 2)), ← Int.cast_neg_natCast, ← Int.cast_ofNat,
@@ -774,7 +770,7 @@ theorem riemannZeta_neg_nat_eq_bernoulli (k : ℕ) :
           Complex.Gamma_nat_eq_factorial, (by ring : 2 * (m + 1) = 2 * m + 1 + 1),
           Nat.factorial_succ, Nat.cast_mul, mul_comm]
         norm_num]
-    rw [← div_div, neg_one_mul]
+    rw [← div_div]
     congr 1
     rw [div_eq_iff (Gamma_ne_zero_of_re_pos _)]
     swap; · rw [(by norm_num : 2 * (m : ℂ) + 2 = ↑(2 * (m : ℝ) + 2)), ofReal_re]; positivity

--- a/Mathlib/NumberTheory/ZetaValues.lean
+++ b/Mathlib/NumberTheory/ZetaValues.lean
@@ -48,14 +48,14 @@ def bernoulliFun (k : ℕ) (x : ℝ) : ℝ :=
   (Polynomial.map (algebraMap ℚ ℝ) (Polynomial.bernoulli k)).eval x
 #align bernoulli_fun bernoulliFun
 
-theorem bernoulliFun_eval_zero (k : ℕ) : bernoulliFun k 0 = bernoulli k := by
+theorem bernoulliFun_eval_zero (k : ℕ) : bernoulliFun k 0 = bernoulli' k := by
   rw [bernoulliFun, Polynomial.eval_zero_map, Polynomial.bernoulli_eval_zero, eq_ratCast]
 #align bernoulli_fun_eval_zero bernoulliFun_eval_zero
 
 theorem bernoulliFun_endpoints_eq_of_ne_one {k : ℕ} (hk : k ≠ 1) :
     bernoulliFun k 1 = bernoulliFun k 0 := by
   rw [bernoulliFun_eval_zero, bernoulliFun, Polynomial.eval_one_map, Polynomial.bernoulli_eval_one,
-    bernoulli_eq_bernoulli'_of_ne_one hk, eq_ratCast]
+    bernoulli'_eq_bernoulli_of_ne_one hk, eq_ratCast]
 #align bernoulli_fun_endpoints_eq_of_ne_one bernoulliFun_endpoints_eq_of_ne_one
 
 theorem bernoulliFun_eval_one (k : ℕ) : bernoulliFun k 1 = bernoulliFun k 0 + ite (k = 1) 1 0 := by
@@ -63,7 +63,7 @@ theorem bernoulliFun_eval_one (k : ℕ) : bernoulliFun k 1 = bernoulliFun k 0 + 
   split_ifs with h
   · rw [h, bernoulli_one, bernoulli'_one, eq_ratCast]
     push_cast; ring
-  · rw [bernoulli_eq_bernoulli'_of_ne_one h, add_zero, eq_ratCast]
+  · rw [bernoulli'_eq_bernoulli_of_ne_one h, add_zero, eq_ratCast]
 #align bernoulli_fun_eval_one bernoulliFun_eval_one
 
 theorem hasDerivAt_bernoulliFun (k : ℕ) (x : ℝ) :
@@ -336,6 +336,7 @@ theorem hasSum_zeta_nat {k : ℕ} (hk : k ≠ 0) :
     HasSum (fun n : ℕ => 1 / (n : ℝ) ^ (2 * k))
       ((-1 : ℝ) ^ (k + 1) * (2 : ℝ) ^ (2 * k - 1) * π ^ (2 * k) *
         bernoulli (2 * k) / (2 * k)!) := by
+  rw [← bernoulli'_eq_bernoulli_of_ne_one (by simp)]
   convert hasSum_one_div_nat_pow_mul_cos hk (left_mem_Icc.mpr zero_le_one) using 1
   · ext1 n; rw [mul_zero, Real.cos_zero, mul_one]
   rw [Polynomial.eval_zero_map, Polynomial.bernoulli_eval_zero, eq_ratCast]
@@ -356,25 +357,23 @@ end Cleanup
 section Examples
 
 theorem hasSum_zeta_two : HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 2) (π ^ 2 / 6) := by
-  convert hasSum_zeta_nat one_ne_zero using 1; rw [mul_one]
-  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide : 2 ≠ 1), bernoulli'_two]
+  convert hasSum_zeta_nat one_ne_zero using 1
+  rw [mul_one, bernoulli_two]
   norm_num [Nat.factorial]; field_simp; ring
 #align has_sum_zeta_two hasSum_zeta_two
 
 theorem hasSum_zeta_four : HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 4) (π ^ 4 / 90) := by
-  convert hasSum_zeta_nat two_ne_zero using 1; norm_num
-  rw [bernoulli_eq_bernoulli'_of_ne_one, bernoulli'_four]
-  norm_num [Nat.factorial]; field_simp; ring; decide
+  convert hasSum_zeta_nat two_ne_zero using 1
+  norm_num [Nat.factorial]; field_simp; ring
 #align has_sum_zeta_four hasSum_zeta_four
 
 theorem Polynomial.bernoulli_three_eval_one_quarter :
     (Polynomial.bernoulli 3).eval (1 / 4) = 3 / 64 := by
   simp_rw [Polynomial.bernoulli, Finset.sum_range_succ, Polynomial.eval_add,
     Polynomial.eval_monomial]
-  rw [Finset.sum_range_zero, Polynomial.eval_zero, zero_add, bernoulli_one]
-  rw [bernoulli_eq_bernoulli'_of_ne_one zero_ne_one, bernoulli'_zero,
-    bernoulli_eq_bernoulli'_of_ne_one (by decide : 2 ≠ 1), bernoulli'_two,
-    bernoulli_eq_bernoulli'_of_ne_one (by decide : 3 ≠ 1), bernoulli'_three]
+  rw [Finset.sum_range_zero, Polynomial.eval_zero, zero_add, bernoulli'_zero, bernoulli'_one,
+    bernoulli'_eq_bernoulli_of_ne_one (by decide : 2 ≠ 1), bernoulli_two,
+    bernoulli'_eq_bernoulli_of_ne_one (by decide : 3 ≠ 1), bernoulli_three]
   norm_num
 #align polynomial.bernoulli_three_eval_one_quarter Polynomial.bernoulli_three_eval_one_quarter
 


### PR DESCRIPTION
i.e. `bernoulli 1 = +1 / 2` and `bernoulli' 1 = -1 / 2`. Defining `bernoulli 1 = +1 / 2` makes more formulas involving Bernoulli numbers simpler; see `riemannZeta_neg_nat_eq_bernoulli` for an example and
* https://github.com/sympy/sympy/issues/23866
* https://github.com/sympy/sympy/pull/23984

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
