### PR TITLE
[Merged by Bors] - chore(MetricSpace.Gluing): address porting note

### DIFF
--- a/Mathlib/Topology/MetricSpace/Gluing.lean
+++ b/Mathlib/Topology/MetricSpace/Gluing.lean
@@ -493,7 +493,7 @@ def GlueSpace (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : Type _ :=
   @UniformSpace.SeparationQuotient _ (gluePremetric hΦ hΨ).toUniformSpace
 #align metric.glue_space Metric.GlueSpace
 
-instance  (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : MetricSpace (GlueSpace hΦ hΨ) :=
+instance (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : MetricSpace (GlueSpace hΦ hΨ) :=
   inferInstanceAs <| MetricSpace <|
     @UniformSpace.SeparationQuotient _ (gluePremetric hΦ hΨ).toUniformSpace
 

--- a/Mathlib/Topology/MetricSpace/Gluing.lean
+++ b/Mathlib/Topology/MetricSpace/Gluing.lean
@@ -493,8 +493,7 @@ def GlueSpace (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : Type _ :=
   @UniformSpace.SeparationQuotient _ (gluePremetric hΦ hΨ).toUniformSpace
 #align metric.glue_space Metric.GlueSpace
 
--- porting note: TODO: w/o `@`, tries to generate some `[MetricSpace _]` before finding `X` `Y`
-instance (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : MetricSpace (@GlueSpace X Y Z _ _ _ _ _ _ hΦ hΨ) :=
+instance  (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : MetricSpace (GlueSpace hΦ hΨ) :=
   inferInstanceAs <| MetricSpace <|
     @UniformSpace.SeparationQuotient _ (gluePremetric hΦ hΨ).toUniformSpace
 


### PR DESCRIPTION
The current porting note says ``TODO: w/o `@`, tries to generate some `[MetricSpace _]` before finding `X` `Y` `` but removing the `@` seems to generate identical terms with `pp.all true`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Here is code to check yourself.

```lean
-- porting note: TODO: w/o `@`, tries to generate some `[MetricSpace _]` before finding `X` `Y`
instance foo (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : MetricSpace (GlueSpace hΦ hΨ) :=
  inferInstanceAs <| MetricSpace <|
    @UniformSpace.SeparationQuotient _ (gluePremetric hΦ hΨ).toUniformSpace
set_option pp.all true in
#print foo
/-
def Metric.foo.{u, v, w} : {X : Type u} →
  {Y : Type v} →
    {Z : Type w} →
      [inst : Nonempty.{w + 1} Z] →
        [inst_1 : MetricSpace.{w} Z] →
          [inst_2 : MetricSpace.{u} X] →
            [inst_3 : MetricSpace.{v} Y] →
              {Φ : Z → X} →
                {Ψ : Z → Y} →
                  (hΦ :
                      @Isometry.{w, u} Z X
                        (@EMetricSpace.toPseudoEMetricSpace.{w} Z (@MetricSpace.toEMetricSpace.{w} Z inst_1))
                        (@EMetricSpace.toPseudoEMetricSpace.{u} X (@MetricSpace.toEMetricSpace.{u} X inst_2)) Φ) →
                    (hΨ :
                        @Isometry.{w, v} Z Y
                          (@EMetricSpace.toPseudoEMetricSpace.{w} Z (@MetricSpace.toEMetricSpace.{w} Z inst_1))
                          (@EMetricSpace.toPseudoEMetricSpace.{v} Y (@MetricSpace.toEMetricSpace.{v} Y inst_3)) Ψ) →
                      MetricSpace.{max v u} (@Metric.GlueSpace.{u, v, w} X Y Z inst inst_1 inst_2 inst_3 Φ Ψ hΦ hΨ) :=
-/

instance foo' (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : MetricSpace (@GlueSpace X Y Z _ _ _ _ _ _ hΦ hΨ) :=
  inferInstanceAs <| MetricSpace <|
    @UniformSpace.SeparationQuotient _ (gluePremetric hΦ hΨ).toUniformSpace
set_option pp.all true in
#print foo'
/-
def Metric.foo.{u, v, w} : {X : Type u} →
  {Y : Type v} →
    {Z : Type w} →
      [inst : Nonempty.{w + 1} Z] →
        [inst_1 : MetricSpace.{w} Z] →
          [inst_2 : MetricSpace.{u} X] →
            [inst_3 : MetricSpace.{v} Y] →
              {Φ : Z → X} →
                {Ψ : Z → Y} →
                  (hΦ :
                      @Isometry.{w, u} Z X
                        (@EMetricSpace.toPseudoEMetricSpace.{w} Z (@MetricSpace.toEMetricSpace.{w} Z inst_1))
                        (@EMetricSpace.toPseudoEMetricSpace.{u} X (@MetricSpace.toEMetricSpace.{u} X inst_2)) Φ) →
                    (hΨ :
                        @Isometry.{w, v} Z Y
                          (@EMetricSpace.toPseudoEMetricSpace.{w} Z (@MetricSpace.toEMetricSpace.{w} Z inst_1))
                          (@EMetricSpace.toPseudoEMetricSpace.{v} Y (@MetricSpace.toEMetricSpace.{v} Y inst_3)) Ψ) →
                      MetricSpace.{max v u} (@Metric.GlueSpace.{u, v, w} X Y Z inst inst_1 inst_2 inst_3 Φ Ψ hΦ hΨ) :=
-/
```

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
