### PR TITLE
[Merged by Bors] - chore: remove useless `include` porting note

### DIFF
--- a/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
@@ -36,9 +36,6 @@ universe u v
 
 variable {J : Type v} [SmallCategory J] [IsCofiltered J] {F : J ⥤ ProfiniteMax.{u, v}} (C : Cone F)
 
--- include hC
--- Porting note: I just add `(hC : IsLimit C)` explicitly as a hypothesis to all the theorems
-
 /-- If `X` is a cofiltered limit of profinite sets, then any clopen subset of `X` arises from
 a clopen set in one of the terms in the limit.
 -/


### PR DESCRIPTION
This one was added by myself and not removed in #10503.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
