### PR TITLE
[Merged by Bors] - chore: Split LinearAlgebra/RootSystem/Basic into two files.

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2573,6 +2573,7 @@ import Mathlib.LinearAlgebra.QuotientPi
 import Mathlib.LinearAlgebra.Ray
 import Mathlib.LinearAlgebra.Reflection
 import Mathlib.LinearAlgebra.RootSystem.Basic
+import Mathlib.LinearAlgebra.RootSystem.Defs
 import Mathlib.LinearAlgebra.SModEq
 import Mathlib.LinearAlgebra.Semisimple
 import Mathlib.LinearAlgebra.SesquilinearForm

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -1,29 +1,17 @@
 /-
 Copyright (c) 2023 Oliver Nash. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Oliver Nash, Deepro Choudhury
+Authors: Oliver Nash, Deepro Choudhury, Scott Carnahan
 -/
-import Mathlib.LinearAlgebra.PerfectPairing
-import Mathlib.LinearAlgebra.Reflection
+import Mathlib.LinearAlgebra.RootSystem.Defs
 
 /-!
 # Root data and root systems
 
-This file contains basic definitions for root systems and root data.
+This file contains basic results for root systems and root data.
 
 ## Main definitions / results:
 
- * `RootPairing`: Given two perfectly-paired `R`-modules `M` and `N` (over some commutative ring
-   `R`) a root pairing with indexing set `ι` is the data of an `ι`-indexed subset of `M`
-   ("the roots") and an `ι`-indexed subset of `N` ("the coroots") satisfying the axioms familiar
-   from the traditional theory of root systems / data.
- * `RootDatum`: A root datum is a root pairing for which the roots and coroots take values in
-   finitely-generated free Abelian groups.
- * `RootSystem`: A root system is a root pairing for which the roots span their ambient module.
- * `RootPairing.IsCrystallographic`: A root pairing is said to be crystallographic if the pairing
-   between a root and coroot is always an integer.
- * `RootPairing.IsReduced`: A root pairing is said to be reduced if it never contains the double of
-   a root.
  * `RootPairing.ext`: In characteristic zero if there is no torsion, the correspondence between
    roots and coroots is unique.
  * `RootSystem.ext`: In characteristic zero if there is no torsion, a root system is determined
@@ -32,30 +20,12 @@ This file contains basic definitions for root systems and root data.
    roots form a root system, we do not need to check that the coroots are stable under reflections
    since this follows from the corresponding property for the roots.
 
-## Implementation details
+## Todo
 
-A root datum is sometimes defined as two subsets: roots and coroots, together with a bijection
-between them, subject to hypotheses. However the hypotheses ensure that the bijection is unique and
-so the question arises of whether this bijection should be part of the data of a root datum or
-whether one should merely assert its existence. For root systems, things are even more extreme: the
-coroots are uniquely determined by the roots. Furthermore a root system induces a canonical
-non-degenerate bilinear form on the ambient space and many informal accounts even include this form
-as part of the data.
-
-We have opted for a design in which some of the uniquely-determined data is included: the bijection
-between roots and coroots is (implicitly) included and the coroots are included for root systems.
-Empirically this seems to be by far the most convenient design and by providing extensionality
-lemmas expressing the uniqueness we expect to get the best of both worlds.
-
-A final point is that we require roots and coroots to be injections from a base indexing type `ι`
-rather than subsets of their codomains. This design was chosen to avoid the bijection between roots
-and coroots being a dependently-typed object. A third option would be to have the roots and coroots
-be subsets but to avoid having a dependently-typed bijection by defining it globally with junk value
-`0` outside of the roots and coroots. This would work but lacks the convenient symmetry that the
-chosen design enjoys: by introducing the indexing type `ι`, one does not have to pick a direction
-(`roots → coroots` or `coroots → roots`) for the forward direction of the bijection. Besides,
-providing the user with the additional definitional power to specify an indexing type `ι` is a
-benefit and the junk-value pattern is a cost.
+* Derived properties of pairs, e.g., (ultra)parallel linearly independent pairs generate infinite
+   dihedral groups.
+* Properties of Weyl group (faithful action on roots, finiteness for finite `ι`)
+* Conditions for existence of Weyl-invariant form (e.g., finiteness).
 
 -/
 
@@ -66,53 +36,12 @@ open AddSubgroup (zmultiples)
 
 noncomputable section
 
-variable (ι R M N : Type*)
+variable {ι R M N : Type*}
   [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
-
-/-- Given two perfectly-paired `R`-modules `M` and `N`, a root pairing with indexing set `ι`
-is the data of an `ι`-indexed subset of `M` ("the roots") and an `ι`-indexed subset of `N`
-("the coroots") satisfying the axioms familiar from the traditional theory of root systems / data.
-
-It exists to allow for a convenient unification of the theories of root systems and root data. -/
-structure RootPairing extends PerfectPairing R M N :=
-  root : ι ↪ M
-  coroot : ι ↪ N
-  root_coroot_two : ∀ i, toLin (root i) (coroot i) = 2
-  mapsTo_preReflection_root :
-    ∀ i, MapsTo (preReflection (root i) (toLin.flip (coroot i))) (range root) (range root)
-  mapsTo_preReflection_coroot :
-    ∀ i, MapsTo (preReflection (coroot i) (toLin (root i))) (range coroot) (range coroot)
-
-attribute [nolint docBlame] RootPairing.root
-attribute [nolint docBlame] RootPairing.coroot
-
-/-- A root datum is a root pairing with coefficients in the integers and for which the root and
-coroot spaces are finitely-generated free Abelian groups.
-
-Note that the latter assumptions `[Free ℤ X₁] [Finite ℤ X₁] [Free ℤ X₂] [Finite ℤ X₂]` should be
-supplied as mixins. -/
-abbrev RootDatum (X₁ X₂ : Type*) [AddCommGroup X₁] [AddCommGroup X₂] := RootPairing ι ℤ X₁ X₂
-
-/-- A root system is a root pairing for which the roots span their ambient module.
-
-Note that this is slightly more general than the usual definition in the sense that `N` is not
-required to be the dual of `M`. -/
-structure RootSystem extends RootPairing ι R M N :=
-  span_eq_top : span R (range root) = ⊤
 
 namespace RootPairing
 
-variable {ι R M N}
 variable (P : RootPairing ι R M N) (i : ι)
-
-/-- A root pairing is said to be crystallographic if the pairing between a root and coroot is
-always an integer.-/
-def IsCrystallographic : Prop :=
-  ∀ i, MapsTo (P.toLin (P.root i)) (range P.coroot) (zmultiples (1 : R))
-
-/-- A root pairing is said to be reduced if it never contains the double of a root.-/
-def IsReduced : Prop :=
-  ∀ i, 2 • P.root i ∉ range P.root
 
 lemma ne_zero [CharZero R] : (P.root i : M) ≠ 0 :=
   fun h ↦ by simpa [h] using P.root_coroot_two i
@@ -124,20 +53,7 @@ lemma coroot_root_two :
     (P.toLin.flip (P.coroot i)) (P.root i) = 2 := by
   rw [LinearMap.flip_apply, P.root_coroot_two i]
 
-/-- If we interchange the roles of `M` and `N`, we still have a root pairing. -/
-protected def flip : RootPairing ι R N M :=
-  { P.toPerfectPairing.flip with
-    root := P.coroot
-    coroot := P.root
-    root_coroot_two := P.root_coroot_two
-    mapsTo_preReflection_root := P.mapsTo_preReflection_coroot
-    mapsTo_preReflection_coroot := P.mapsTo_preReflection_root }
-
 @[simp] lemma flip_flip : P.flip.flip = P := rfl
-
-/-- The reflection associated to a root. -/
-def reflection : M ≃ₗ[R] M :=
-  Module.reflection (P.coroot_root_two i)
 
 lemma reflection_apply (x : M) :
     P.reflection i x = x - (P.toLin x (P.coroot i)) • P.root i :=
@@ -159,10 +75,6 @@ lemma reflection_invOn_self : InvOn (P.reflection i) (P.reflection i) (range P.r
 
 lemma bijOn_reflection_root : BijOn (P.reflection i) (range P.root) (range P.root) := InvOn.bijOn
   (reflection_invOn_self P i) (mapsTo_preReflection_root P i) (mapsTo_preReflection_root P i)
-
-/-- The reflection associated to a coroot. -/
-def coreflection : N ≃ₗ[R] N :=
-  Module.reflection (P.root_coroot_two i)
 
 lemma coreflection_apply (f : N) :
     P.coreflection i f = f - (P.toLin (P.root i) f) • P.coroot i :=
@@ -313,7 +225,7 @@ namespace RootSystem
 
 open RootPairing
 
-variable {ι} [Finite ι]
+variable [Finite ι]
 variable (P : RootSystem ι R M N)
 
 /-- In characteristic zero if there is no torsion, a finite root system is determined entirely by

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2023 Oliver Nash. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oliver Nash, Deepro Choudhury, Scott Carnahan
+-/
+import Mathlib.LinearAlgebra.PerfectPairing
+import Mathlib.LinearAlgebra.Reflection
+
+/-!
+# Root data and root systems
+
+This file contains basic definitions for root systems and root data.
+
+## Main definitions:
+
+ * `RootPairing`: Given two perfectly-paired `R`-modules `M` and `N` (over some commutative ring
+   `R`) a root pairing with indexing set `ι` is the data of an `ι`-indexed subset of `M`
+   ("the roots") and an `ι`-indexed subset of `N` ("the coroots") satisfying the axioms familiar
+   from the traditional theory of root systems / data.
+ * `RootDatum`: A root datum is a root pairing for which the roots and coroots take values in
+   finitely-generated free Abelian groups.
+ * `RootSystem`: A root system is a root pairing for which the roots span their ambient module.
+ * `RootPairing.IsCrystallographic`: A root pairing is said to be crystallographic if the pairing
+   between a root and coroot is always an integer.
+ * `RootPairing.IsReduced`: A root pairing is said to be reduced if it never contains the double of
+   a root.
+
+## Todo
+
+* Introduce the Weyl Group
+* Coxeter weights of pairs
+* Properties of pairs of roots, e.g., parallel, ultraparallel, definite, orthogonal, imaginary,
+non-symmetrizable
+
+## Implementation details
+
+A root datum is sometimes defined as two subsets: roots and coroots, together with a bijection
+between them, subject to hypotheses. However the hypotheses ensure that the bijection is unique and
+so the question arises of whether this bijection should be part of the data of a root datum or
+whether one should merely assert its existence. For root systems, things are even more extreme: the
+coroots are uniquely determined by the roots. Furthermore a root system induces a canonical
+non-degenerate bilinear form on the ambient space and many informal accounts even include this form
+as part of the data.
+
+We have opted for a design in which some of the uniquely-determined data is included: the bijection
+between roots and coroots is (implicitly) included and the coroots are included for root systems.
+Empirically this seems to be by far the most convenient design and by providing extensionality
+lemmas expressing the uniqueness we expect to get the best of both worlds.
+
+A final point is that we require roots and coroots to be injections from a base indexing type `ι`
+rather than subsets of their codomains. This design was chosen to avoid the bijection between roots
+and coroots being a dependently-typed object. A third option would be to have the roots and coroots
+be subsets but to avoid having a dependently-typed bijection by defining it globally with junk value
+`0` outside of the roots and coroots. This would work but lacks the convenient symmetry that the
+chosen design enjoys: by introducing the indexing type `ι`, one does not have to pick a direction
+(`roots → coroots` or `coroots → roots`) for the forward direction of the bijection. Besides,
+providing the user with the additional definitional power to specify an indexing type `ι` is a
+benefit and the junk-value pattern is a cost.
+
+-/
+
+open Set Function
+open Module hiding reflection
+open Submodule (span)
+open AddSubgroup (zmultiples)
+
+noncomputable section
+
+variable (ι R M N : Type*)
+  [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+
+/-- Given two perfectly-paired `R`-modules `M` and `N`, a root pairing with indexing set `ι`
+is the data of an `ι`-indexed subset of `M` ("the roots") and an `ι`-indexed subset of `N`
+("the coroots") satisfying the axioms familiar from the traditional theory of root systems / data.
+
+It exists to allow for a convenient unification of the theories of root systems and root data. -/
+structure RootPairing extends PerfectPairing R M N :=
+  root : ι ↪ M
+  coroot : ι ↪ N
+  root_coroot_two : ∀ i, toLin (root i) (coroot i) = 2
+  mapsTo_preReflection_root :
+    ∀ i, MapsTo (preReflection (root i) (toLin.flip (coroot i))) (range root) (range root)
+  mapsTo_preReflection_coroot :
+    ∀ i, MapsTo (preReflection (coroot i) (toLin (root i))) (range coroot) (range coroot)
+
+attribute [nolint docBlame] RootPairing.root
+attribute [nolint docBlame] RootPairing.coroot
+
+/-- A root datum is a root pairing with coefficients in the integers and for which the root and
+coroot spaces are finitely-generated free Abelian groups.
+
+Note that the latter assumptions `[Free ℤ X₁] [Finite ℤ X₁] [Free ℤ X₂] [Finite ℤ X₂]` should be
+supplied as mixins. -/
+abbrev RootDatum (X₁ X₂ : Type*) [AddCommGroup X₁] [AddCommGroup X₂] := RootPairing ι ℤ X₁ X₂
+
+/-- A root system is a root pairing for which the roots span their ambient module.
+
+Note that this is slightly more general than the usual definition in the sense that `N` is not
+required to be the dual of `M`. -/
+structure RootSystem extends RootPairing ι R M N :=
+  span_eq_top : span R (range root) = ⊤
+
+namespace RootPairing
+
+variable {ι R M N}
+variable (P : RootPairing ι R M N) (i : ι)
+
+/-- A root pairing is said to be crystallographic if the pairing between a root and coroot is
+always an integer.-/
+def IsCrystallographic : Prop :=
+  ∀ i, MapsTo (P.toLin (P.root i)) (range P.coroot) (zmultiples (1 : R))
+
+/-- A root pairing is said to be reduced if it never contains the double of a root.-/
+def IsReduced : Prop :=
+  ∀ i, 2 • P.root i ∉ range P.root
+
+/-- If we interchange the roles of `M` and `N`, we still have a root pairing. -/
+protected def flip : RootPairing ι R N M :=
+  { P.toPerfectPairing.flip with
+    root := P.coroot
+    coroot := P.root
+    root_coroot_two := P.root_coroot_two
+    mapsTo_preReflection_root := P.mapsTo_preReflection_coroot
+    mapsTo_preReflection_coroot := P.mapsTo_preReflection_root }
+
+/-- The reflection associated to a root. -/
+def reflection : M ≃ₗ[R] M :=
+  Module.reflection (P.flip.root_coroot_two i)
+
+/-- The reflection associated to a coroot. -/
+def coreflection : N ≃ₗ[R] N :=
+  Module.reflection (P.root_coroot_two i)


### PR DESCRIPTION
I put the definitions into the new file `Defs` and left the results in `Basic`.  Also, I added some todos.

I welcome any suggestions for improved splitting schemes.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
