### PR TITLE
[Merged by Bors] - refactor: Names the function of Equiv.piFinSuccAbove

### DIFF
--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -968,6 +968,17 @@ theorem preimage_insertNth_Icc_of_not_mem {i : Fin (n + 1)} {x : α i} {q₁ q�
     simp only [mem_preimage, insertNth_mem_Icc, hx, false_and_iff, mem_empty_iff_false]
 #align fin.preimage_insert_nth_Icc_of_not_mem Fin.preimage_insertNth_Icc_of_not_mem
 
+/-- Separates a tuple, returning a selected index and then the rest of the tuple.
+Functional form of `Equiv.piFinSuccAbove`. -/
+def extractNth (i : Fin (n + 1)) (f : (∀ j, α j)) :
+    α i × ∀ j, α (i.succAbove j) :=
+  (f i, fun j => f (i.succAbove j))
+
+@[simp]
+theorem extractNth_insertNth (i : Fin (n + 1)) (x : α i) (p : ∀ j : Fin n, α (i.succAbove j)) :
+    extractNth i (i.insertNth x p) = (x, p) := by
+  simp [extractNth]
+
 end InsertNth
 
 section Find

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -968,7 +968,7 @@ theorem preimage_insertNth_Icc_of_not_mem {i : Fin (n + 1)} {x : α i} {q₁ q�
     simp only [mem_preimage, insertNth_mem_Icc, hx, false_and_iff, mem_empty_iff_false]
 #align fin.preimage_insert_nth_Icc_of_not_mem Fin.preimage_insertNth_Icc_of_not_mem
 
-/-- Separates a Fin-indexed tuple, returning a selected index and then the rest of the tuple.
+/-- Separates an `n+1`-tuple, returning a selected index and then the rest of the tuple.
 Functional form of `Equiv.piFinSuccAbove`. -/
 def extractNth (i : Fin (n + 1)) (f : (∀ j, α j)) :
     α i × ∀ j, α (i.succAbove j) :=

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -979,6 +979,11 @@ theorem extractNth_insertNth (i : Fin (n + 1)) (x : α i) (p : ∀ j : Fin n, α
     extractNth i (i.insertNth x p) = (x, p) := by
   simp [extractNth]
 
+@[simp]
+theorem insertNth_extractNth (i : Fin (n + 1)) (f : ∀ j, α j) :
+    i.insertNth (extractNth i f).1 (extractNth i f).2 = f := by
+  simp [Fin.extractNth, Fin.insertNth_eq_iff]
+
 end InsertNth
 
 section Find

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -968,7 +968,7 @@ theorem preimage_insertNth_Icc_of_not_mem {i : Fin (n + 1)} {x : α i} {q₁ q�
     simp only [mem_preimage, insertNth_mem_Icc, hx, false_and_iff, mem_empty_iff_false]
 #align fin.preimage_insert_nth_Icc_of_not_mem Fin.preimage_insertNth_Icc_of_not_mem
 
-/-- Separates a tuple, returning a selected index and then the rest of the tuple.
+/-- Separates a Fin-indexed tuple, returning a selected index and then the rest of the tuple.
 Functional form of `Equiv.piFinSuccAbove`. -/
 def extractNth (i : Fin (n + 1)) (f : (∀ j, α j)) :
     α i × ∀ j, α (i.succAbove j) :=

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -976,12 +976,12 @@ def extractNth (i : Fin (n + 1)) (f : (∀ j, α j)) :
 
 @[simp]
 theorem extractNth_insertNth (i : Fin (n + 1)) (x : α i) (p : ∀ j : Fin n, α (i.succAbove j)) :
-    extractNth i (i.insertNth x p) = (x, p) := by
+    i.extractNth (i.insertNth x p) = (x, p) := by
   simp [extractNth]
 
 @[simp]
 theorem insertNth_extractNth (i : Fin (n + 1)) (f : ∀ j, α j) :
-    i.insertNth (extractNth i f).1 (extractNth i f).2 = f := by
+    i.insertNth (i.extractNth f).1 (i.extractNth f).2 = f := by
   simp [Fin.extractNth, Fin.insertNth_eq_iff]
 
 end InsertNth

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -975,12 +975,12 @@ def extractNth (i : Fin (n + 1)) (f : (∀ j, α j)) :
   (f i, fun j => f (i.succAbove j))
 
 @[simp]
-theorem extractNth_insertNth (i : Fin (n + 1)) (x : α i) (p : ∀ j : Fin n, α (i.succAbove j)) :
+theorem extractNth_insertNth {i : Fin (n + 1)} (x : α i) (p : ∀ j : Fin n, α (i.succAbove j)) :
     i.extractNth (i.insertNth x p) = (x, p) := by
   simp [extractNth]
 
 @[simp]
-theorem insertNth_extractNth (i : Fin (n + 1)) (f : ∀ j, α j) :
+theorem insertNth_extractNth {i : Fin (n + 1)} (f : ∀ j, α j) :
     i.insertNth (i.extractNth f).1 (i.extractNth f).2 = f := by
   simp [Fin.extractNth, Fin.insertNth_eq_iff]
 

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -292,7 +292,7 @@ def Equiv.piFinSuccAbove (α : Fin (n + 1) → Type u) (i : Fin (n + 1)) :
     (∀ j, α j) ≃ α i × ∀ j, α (i.succAbove j) where
   toFun f := i.extractNth f
   invFun f := i.insertNth f.1 f.2
-  left_inv g := by simp
+  left_inv f := by simp
   right_inv f := by simp
 #align equiv.pi_fin_succ_above_equiv Equiv.piFinSuccAbove
 #align equiv.pi_fin_succ_above_equiv_apply Equiv.piFinSuccAbove_apply

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -292,8 +292,8 @@ def Equiv.piFinSuccAbove (α : Fin (n + 1) → Type u) (i : Fin (n + 1)) :
     (∀ j, α j) ≃ α i × ∀ j, α (i.succAbove j) where
   toFun f := i.extractNth f
   invFun f := i.insertNth f.1 f.2
-  left_inv f := by simp [Fin.extractNth, Fin.insertNth_eq_iff]
-  right_inv f := by simp only [Fin.extractNth_insertNth]
+  left_inv g := by simp
+  right_inv f := by simp
 #align equiv.pi_fin_succ_above_equiv Equiv.piFinSuccAbove
 #align equiv.pi_fin_succ_above_equiv_apply Equiv.piFinSuccAbove_apply
 #align equiv.pi_fin_succ_above_equiv_symm_apply Equiv.piFinSuccAbove_symm_apply

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
 import Mathlib.Data.Fin.VecNotation
+import Mathlib.Data.Fin.Tuple.Basic
 import Mathlib.Data.Int.Order.Basic
 import Mathlib.Logic.Equiv.Defs
 
@@ -286,20 +287,14 @@ theorem finSuccEquivLast_symm_some (i : Fin n) :
   finSuccEquiv'_symm_none _
 #align fin_succ_equiv_last_symm_none finSuccEquivLast_symm_none
 
-/-- Separates a tuple, returning a selected index and then the rest of the tuple.
-Functional form of `Equiv.piFinSuccAbove`. -/
-def extractNth (α : Fin (n + 1) → Type u) (i : Fin (n + 1)) (f : (∀ j, α j)) :
-    α i × ∀ j, α (i.succAbove j) :=
-  (f i, fun j => f (i.succAbove j))
-
 /-- Equivalence between `Π j : Fin (n + 1), α j` and `α i × Π j : Fin n, α (Fin.succAbove i j)`. -/
 @[simps (config := .asFn)]
 def Equiv.piFinSuccAbove (α : Fin (n + 1) → Type u) (i : Fin (n + 1)) :
     (∀ j, α j) ≃ α i × ∀ j, α (i.succAbove j) where
-  toFun f := extractNth α i f
+  toFun f := i.extractNth f
   invFun f := i.insertNth f.1 f.2
-  left_inv f := by simp [extractNth, Fin.insertNth_eq_iff]
-  right_inv f := by simp [extractNth]
+  left_inv f := by simp [Fin.extractNth, Fin.insertNth_eq_iff]
+  right_inv f := by simp only [Fin.extractNth_insertNth]
 #align equiv.pi_fin_succ_above_equiv Equiv.piFinSuccAbove
 #align equiv.pi_fin_succ_above_equiv_apply Equiv.piFinSuccAbove_apply
 #align equiv.pi_fin_succ_above_equiv_symm_apply Equiv.piFinSuccAbove_symm_apply

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -286,14 +286,20 @@ theorem finSuccEquivLast_symm_some (i : Fin n) :
   finSuccEquiv'_symm_none _
 #align fin_succ_equiv_last_symm_none finSuccEquivLast_symm_none
 
+/-- Separates a tuple, returning a selected index and then the rest of the tuple.
+Functional form of `Equiv.piFinSuccAbove`. -/
+def extractNth (α : Fin (n + 1) → Type u) (i : Fin (n + 1)) (f : (∀ j, α j)) :
+    α i × ∀ j, α (i.succAbove j) :=
+  (f i, fun j => f (i.succAbove j))
+
 /-- Equivalence between `Π j : Fin (n + 1), α j` and `α i × Π j : Fin n, α (Fin.succAbove i j)`. -/
 @[simps (config := .asFn)]
 def Equiv.piFinSuccAbove (α : Fin (n + 1) → Type u) (i : Fin (n + 1)) :
     (∀ j, α j) ≃ α i × ∀ j, α (i.succAbove j) where
-  toFun f := (f i, fun j => f (i.succAbove j))
+  toFun f := extractNth α i f
   invFun f := i.insertNth f.1 f.2
-  left_inv f := by simp [Fin.insertNth_eq_iff]
-  right_inv f := by simp
+  left_inv f := by simp [extractNth, Fin.insertNth_eq_iff]
+  right_inv f := by simp [extractNth]
 #align equiv.pi_fin_succ_above_equiv Equiv.piFinSuccAbove
 #align equiv.pi_fin_succ_above_equiv_apply Equiv.piFinSuccAbove_apply
 #align equiv.pi_fin_succ_above_equiv_symm_apply Equiv.piFinSuccAbove_symm_apply

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
 import Mathlib.Data.Fin.VecNotation
-import Mathlib.Data.Fin.Tuple.Basic
 import Mathlib.Data.Int.Order.Basic
 import Mathlib.Logic.Equiv.Defs
 


### PR DESCRIPTION
Creates `extractNth` to do the opposite of `insertNth` for tuples. Rewrites the `Equiv` definition.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
