### PR TITLE
[Merged by Bors] - chore(Topology.GDelta): remove porting note

### DIFF
--- a/Mathlib/Topology/GDelta.lean
+++ b/Mathlib/Topology/GDelta.lean
@@ -133,7 +133,7 @@ theorem IsGδ.union {s t : Set X} (hs : IsGδ s) (ht : IsGδ t) : IsGδ (s ∪ t
   exact (Sopen a ha).union (Topen b hb)
 #align is_Gδ.union IsGδ.union
 
--- porting note: TODO: add `iUnion` and `sUnion` versions
+-- TODO: add `iUnion` and `sUnion` versions
 /-- The union of finitely many Gδ sets is a Gδ set. -/
 theorem isGδ_biUnion {s : Set ι} (hs : s.Finite) {f : ι → Set X} (h : ∀ i ∈ s, IsGδ (f i)) :
     IsGδ (⋃ i ∈ s, f i) := by


### PR DESCRIPTION
A `TODO` was added inside a porting note. We change it to a `TODO`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
