### PR TITLE
[Merged by Bors] - refactor: Make `Frame` extend `HeytingAlgebra`

### DIFF
--- a/Archive/Imo/Imo1998Q2.lean
+++ b/Archive/Imo/Imo1998Q2.lean
@@ -116,7 +116,7 @@ theorem A_fibre_over_contestant_card (c : C) :
   apply Finset.card_image_of_injOn
   unfold Set.InjOn
   rintro ⟨a, p⟩ h ⟨a', p'⟩ h' rfl
-  aesop
+  aesop (add simp AgreedTriple.contestant)
 
 theorem A_fibre_over_judgePair {p : JudgePair J} (h : p.Distinct) :
     agreedContestants r p = ((A r).filter fun a : AgreedTriple C J => a.judgePair = p).image

--- a/Mathlib/Combinatorics/SimpleGraph/Finsubgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finsubgraph.lean
@@ -61,6 +61,9 @@ instance : Sup G.Finsubgraph :=
 instance : Inf G.Finsubgraph :=
   ⟨fun G₁ G₂ => ⟨G₁ ⊓ G₂, G₁.2.subset inter_subset_left⟩⟩
 
+instance instSDiff : SDiff G.Finsubgraph where
+  sdiff G₁ G₂ := ⟨G₁ \ G₂, G₁.2.subset (Subgraph.verts_mono sdiff_le)⟩
+
 @[simp, norm_cast] lemma coe_bot : (⊥ : G.Finsubgraph) = (⊥ : G.Subgraph) := rfl
 
 @[simp, norm_cast]
@@ -69,17 +72,28 @@ lemma coe_sup (G₁ G₂ : G.Finsubgraph) : ↑(G₁ ⊔ G₂) = (G₁ ⊔ G₂ 
 @[simp, norm_cast]
 lemma coe_inf (G₁ G₂ : G.Finsubgraph) : ↑(G₁ ⊓ G₂) = (G₁ ⊓ G₂ : G.Subgraph) := rfl
 
-instance : DistribLattice G.Finsubgraph :=
-  Subtype.coe_injective.distribLattice _ (fun _ _ => rfl) fun _ _ => rfl
+@[simp, norm_cast]
+lemma coe_sdiff (G₁ G₂ : G.Finsubgraph) : ↑(G₁ \ G₂) = (G₁ \ G₂ : G.Subgraph) := rfl
+
+instance instGeneralizedCoheytingAlgebra : GeneralizedCoheytingAlgebra G.Finsubgraph :=
+  Subtype.coe_injective.generalizedCoheytingAlgebra _ coe_sup coe_inf coe_bot coe_sdiff
 
 section Finite
 variable [Finite V]
 
 instance instTop : Top G.Finsubgraph where top := ⟨⊤, finite_univ⟩
+instance instHasCompl : HasCompl G.Finsubgraph where compl G' := ⟨G'ᶜ, Set.toFinite _⟩
+instance instHNot : HNot G.Finsubgraph where hnot G' := ⟨￢G', Set.toFinite _⟩
+instance instHImp : HImp G.Finsubgraph where himp G₁ G₂ := ⟨G₁ ⇨ G₂, Set.toFinite _⟩
 instance instSupSet : SupSet G.Finsubgraph where sSup s := ⟨⨆ G ∈ s, ↑G, Set.toFinite _⟩
 instance instInfSet : InfSet G.Finsubgraph where sInf s := ⟨⨅ G ∈ s, ↑G, Set.toFinite _⟩
 
-@[simp, norm_cast] lemma coe_top : ↑(⊤ : G.Finsubgraph) = (⊤ : G.Subgraph) := rfl
+@[simp, norm_cast] lemma coe_top : (⊤ : G.Finsubgraph) = (⊤ : G.Subgraph) := rfl
+@[simp, norm_cast] lemma coe_compl (G' : G.Finsubgraph) : ↑(G'ᶜ) = (G'ᶜ : G.Subgraph) := rfl
+@[simp, norm_cast] lemma coe_hnot (G' : G.Finsubgraph) : ↑(￢G') = (￢G' : G.Subgraph) := rfl
+
+@[simp, norm_cast]
+lemma coe_himp (G₁ G₂ : G.Finsubgraph) : ↑(G₁ ⇨ G₂) = (G₁ ⇨ G₂ : G.Subgraph) := rfl
 
 @[simp, norm_cast]
 lemma coe_sSup (s : Set G.Finsubgraph) : sSup s = (⨆ G ∈ s, G : G.Subgraph) := rfl
@@ -97,6 +111,7 @@ lemma coe_iInf {ι : Sort*} (f : ι → G.Finsubgraph) : ⨅ i, f i = (⨅ i, f 
 
 instance instCompletelyDistribLattice : CompletelyDistribLattice G.Finsubgraph :=
   Subtype.coe_injective.completelyDistribLattice _ coe_sup coe_inf coe_sSup coe_sInf coe_top coe_bot
+    coe_compl coe_himp coe_hnot coe_sdiff
 
 end Finite
 end Finsubgraph

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -397,8 +397,8 @@ instance : BoundedOrder (Subgraph G) where
   le_top x := ⟨Set.subset_univ _, fun _ _ => x.adj_sub⟩
   bot_le _ := ⟨Set.empty_subset _, fun _ _ => False.elim⟩
 
--- Note that subgraphs do not form a Boolean algebra, because of `verts`.
-instance : CompletelyDistribLattice G.Subgraph :=
+/-- Note that subgraphs do not form a Boolean algebra, because of `verts`. -/
+def completelyDistribLatticeMinimalAxioms : CompletelyDistribLattice.MinimalAxioms G.Subgraph :=
   { Subgraph.distribLattice with
     le := (· ≤ ·)
     sup := (· ⊔ ·)
@@ -421,6 +421,9 @@ instance : CompletelyDistribLattice G.Subgraph :=
         ⟨fun H hH => (hG' _ hH).2 hab, G'.adj_sub hab⟩⟩
     iInf_iSup_eq := fun f => Subgraph.ext _ _ (by simpa using iInf_iSup_eq)
       (by ext; simp [Classical.skolem]) }
+
+instance : CompletelyDistribLattice G.Subgraph :=
+  .ofMinimalAxioms completelyDistribLatticeMinimalAxioms
 
 @[gcongr] lemma verts_mono {H H' : G.Subgraph} (h : H ≤ H') : H.verts ⊆ H'.verts := h.1
 lemma verts_monotone : Monotone (verts : G.Subgraph → Set V) := fun _ _ h ↦ h.1

--- a/Mathlib/Data/Fintype/Order.lean
+++ b/Mathlib/Data/Fintype/Order.lean
@@ -91,11 +91,10 @@ noncomputable abbrev toCompleteLattice [Lattice α] [BoundedOrder α] : Complete
   sInf_le := fun _ _ ha => Finset.inf_le (Set.mem_toFinset.mpr ha)
   le_sInf := fun s _ ha => Finset.le_inf fun b hb => ha _ <| Set.mem_toFinset.mp hb
 
--- Porting note: `convert` doesn't work as well as it used to.
 -- See note [reducible non-instances]
 /-- A finite bounded distributive lattice is completely distributive. -/
-noncomputable abbrev toCompleteDistribLattice [DistribLattice α] [BoundedOrder α] :
-    CompleteDistribLattice α where
+noncomputable abbrev toCompleteDistribLatticeMinimalAxioms [DistribLattice α] [BoundedOrder α] :
+    CompleteDistribLattice.MinimalAxioms α where
   __ := toCompleteLattice α
   iInf_sup_le_sup_sInf := fun a s => by
     convert (Finset.inf_sup_distrib_left s.toFinset id a).ge using 1
@@ -107,6 +106,11 @@ noncomputable abbrev toCompleteDistribLattice [DistribLattice α] [BoundedOrder 
     rw [Finset.sup_eq_iSup]
     simp_rw [Set.mem_toFinset]
     rfl
+
+-- See note [reducible non-instances]
+/-- A finite bounded distributive lattice is completely distributive. -/
+noncomputable abbrev toCompleteDistribLattice [DistribLattice α] [BoundedOrder α] :
+    CompleteDistribLattice α := .ofMinimalAxioms (toCompleteDistribLatticeMinimalAxioms _)
 
 -- See note [reducible non-instances]
 /-- A finite bounded linear order is complete. -/

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -1287,6 +1287,7 @@ theorem coe_top : ↑(⊤ : Subtype (MeasurableSet : Set α → Prop)) = (⊤ : 
 noncomputable instance Subtype.instBooleanAlgebra :
     BooleanAlgebra (Subtype (MeasurableSet : Set α → Prop)) :=
   Subtype.coe_injective.booleanAlgebra _ coe_union coe_inter coe_top coe_bot coe_compl coe_sdiff
+    coe_himp
 
 @[measurability]
 theorem measurableSet_blimsup {s : ℕ → Set α} {p : ℕ → Prop} (h : ∀ n, p n → MeasurableSet (s n)) :

--- a/Mathlib/ModelTheory/Definability.lean
+++ b/Mathlib/ModelTheory/Definability.lean
@@ -377,9 +377,9 @@ theorem coe_sdiff (s t : L.DefinableSet A α) :
 @[simp, norm_cast]
 lemma coe_himp (s t : L.DefinableSet A α) : ↑(s ⇨ t) = (s ⇨ t : Set (α → M)) := rfl
 
-instance instBooleanAlgebra : BooleanAlgebra (L.DefinableSet A α) :=
+noncomputable instance instBooleanAlgebra : BooleanAlgebra (L.DefinableSet A α) :=
   Function.Injective.booleanAlgebra (α := L.DefinableSet A α) _ Subtype.coe_injective
-    coe_sup coe_inf coe_top coe_bot coe_compl coe_sdiff
+    coe_sup coe_inf coe_top coe_bot coe_compl coe_sdiff coe_himp
 
 end DefinableSet
 

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -751,12 +751,14 @@ protected abbrev Function.Injective.generalizedBooleanAlgebra [Sup α] [Inf α] 
 -- See note [reducible non-instances]
 /-- Pullback a `BooleanAlgebra` along an injection. -/
 protected abbrev Function.Injective.booleanAlgebra [Sup α] [Inf α] [Top α] [Bot α] [HasCompl α]
-    [SDiff α] [BooleanAlgebra β] (f : α → β) (hf : Injective f)
+    [SDiff α] [HImp α] [BooleanAlgebra β] (f : α → β) (hf : Injective f)
     (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
     (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) (map_compl : ∀ a, f aᶜ = (f a)ᶜ)
-    (map_sdiff : ∀ a b, f (a \ b) = f a \ f b) : BooleanAlgebra α where
+    (map_sdiff : ∀ a b, f (a \ b) = f a \ f b) (map_himp : ∀ a b, f (a ⇨ b) = f a ⇨ f b) :
+    BooleanAlgebra α where
   __ := hf.generalizedBooleanAlgebra f map_sup map_inf map_bot map_sdiff
   compl := compl
+  himp := himp
   top := ⊤
   le_top a := (@le_top β _ _ _).trans map_top.ge
   bot_le a := map_bot.le.trans bot_le
@@ -765,6 +767,8 @@ protected abbrev Function.Injective.booleanAlgebra [Sup α] [Inf α] [Top α] [B
   sdiff_eq a b := by
     refine hf ((map_sdiff _ _).trans (sdiff_eq.trans ?_))
     rw [map_inf, map_compl]
+  himp_eq a b := hf $ (map_himp _ _).trans $ himp_eq.trans $ by rw [map_sup, map_compl]
+
 
 end lift
 

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -769,7 +769,6 @@ protected abbrev Function.Injective.booleanAlgebra [Sup α] [Inf α] [Top α] [B
     rw [map_inf, map_compl]
   himp_eq a b := hf $ (map_himp _ _).trans $ himp_eq.trans $ by rw [map_sup, map_compl]
 
-
 end lift
 
 instance PUnit.instBooleanAlgebra : BooleanAlgebra PUnit where

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -54,6 +54,22 @@ universe u v w w'
 
 variable {α : Type u} {β : Type v} {ι : Sort w} {κ : ι → Sort w'}
 
+/-- Structure containing the minimal axioms required to check that an order is a frame. Do NOT use,
+except for implementing `Order.Frame` via `Order.Frame.ofMinimalAxioms`.
+
+This structure omits the `himp`, `compl` fields, which can be recovered using
+`Order.Frame.ofMinimalAxioms`. -/
+class Order.Frame.MinimalAxioms (α : Type u) extends CompleteLattice α where
+  inf_sSup_le_iSup_inf (a : α) (s : Set α) : a ⊓ sSup s ≤ ⨆ b ∈ s, a ⊓ b
+
+/-- Structure containing the minimal axioms required to check that an order is a coframe. Do NOT
+use, except for implementing `Order.Coframe` via `Order.Coframe.ofMinimalAxioms`.
+
+This structure omits the `sdiff`, `hnot` fields, which can be recovered using
+`Order.Coframe.ofMinimalAxioms`. -/
+class Order.Coframe.MinimalAxioms (α : Type u) extends CompleteLattice α where
+  iInf_sup_le_sup_sInf (a : α) (s : Set α) : ⨅ b ∈ s, a ⊔ b ≤ a ⊔ sInf s
+
 /-- A frame, aka complete Heyting algebra, is a complete lattice whose `⊓` distributes over `⨆`. -/
 class Order.Frame (α : Type*) extends CompleteLattice α, HeytingAlgebra α where
   /-- `⊓` distributes over `⨆`. -/
@@ -67,12 +83,35 @@ class Order.Coframe (α : Type*) extends CompleteLattice α, CoheytingAlgebra α
 
 open Order
 
+/-- Structure containing the minimal axioms required to check that an order is a complete
+distributive lattice. Do NOT use, except for implementing `CompleteDistribLattice` via
+`CompleteDistribLattice.ofMinimalAxioms`.
+
+This structure omits the `himp`, `compl`, `sdiff`, `hnot` fields, which can be recovered using
+`CompleteDistribLattice.ofMinimalAxioms`. -/
+structure CompleteDistribLattice.MinimalAxioms (α : Type u)
+    extends CompleteLattice α, Frame.MinimalAxioms α, Coframe.MinimalAxioms α where
+
+-- We give those projections better name further down
+attribute [nolint docBlame] CompleteDistribLattice.MinimalAxioms.toMinimalAxioms
+  CompleteDistribLattice.MinimalAxioms.toMinimalAxioms_1
+
 /-- A complete distributive lattice is a complete lattice whose `⊔` and `⊓` respectively
 distribute over `⨅` and `⨆`. -/
-class CompleteDistribLattice (α : Type*) extends Frame α, Coframe α
+class CompleteDistribLattice (α : Type*) extends Frame α, Coframe α, BiheytingAlgebra α
 
 /-- In a complete distributive lattice, `⊔` distributes over `⨅`. -/
 add_decl_doc CompleteDistribLattice.iInf_sup_le_sup_sInf
+
+/-- Structure containing the minimal axioms required to check that an order is a completely
+distributive. Do NOT use, except for implementing `CompletelyDistribLattice` via
+`CompletelyDistribLattice.ofMinimalAxioms`.
+
+This structure omits the `himp`, `compl`, `sdiff`, `hnot` fields, which can be recovered using
+`CompletelyDistribLattice.ofMinimalAxioms`. -/
+structure CompletelyDistribLattice.MinimalAxioms (α : Type u) extends CompleteLattice α where
+  protected iInf_iSup_eq {ι : Type u} {κ : ι → Type u} (f : ∀ a, κ a → α) :
+    (⨅ a, ⨆ b, f a b) = ⨆ g : ∀ a, κ a, ⨅ a, f a (g a)
 
 /-- A completely distributive lattice is a complete lattice whose `⨅` and `⨆`
 distribute over each other. -/
@@ -84,25 +123,131 @@ theorem le_iInf_iSup [CompleteLattice α] {f : ∀ a, κ a → α} :
     (⨆ g : ∀ a, κ a, ⨅ a, f a (g a)) ≤ ⨅ a, ⨆ b, f a b :=
   iSup_le fun _ => le_iInf fun a => le_trans (iInf_le _ a) (le_iSup _ _)
 
-theorem iInf_iSup_eq [CompletelyDistribLattice α] {f : ∀ a, κ a → α} :
-    (⨅ a, ⨆ b, f a b) = ⨆ g : ∀ a, κ a, ⨅ a, f a (g a) :=
-  (le_antisymm · le_iInf_iSup) <| calc
+lemma iSup_iInf_le [CompleteLattice α] {f : ∀ a, κ a → α} :
+    ⨆ a, ⨅ b, f a b ≤ ⨅ g : ∀ a, κ a, ⨆ a, f a (g a) :=
+  le_iInf_iSup (α := αᵒᵈ)
+
+namespace Order.Frame.MinimalAxioms
+variable (minAx : MinimalAxioms α) {s : Set α} {a b : α}
+
+lemma inf_sSup_eq : a ⊓ sSup s = ⨆ b ∈ s, a ⊓ b :=
+  (minAx.inf_sSup_le_iSup_inf _ _).antisymm iSup_inf_le_inf_sSup
+
+lemma sSup_inf_eq : sSup s ⊓ b = ⨆ a ∈ s, a ⊓ b := by
+  simpa only [inf_comm] using @inf_sSup_eq α _ s b
+
+lemma iSup_inf_eq (f : ι → α) (a : α) : (⨆ i, f i) ⊓ a = ⨆ i, f i ⊓ a := by
+  rw [iSup, sSup_inf_eq, iSup_range]
+
+lemma inf_iSup_eq (a : α) (f : ι → α) : (a ⊓ ⨆ i, f i) = ⨆ i, a ⊓ f i := by
+  simpa only [inf_comm] using minAx.iSup_inf_eq f a
+
+lemma inf_iSup₂_eq {f : ∀ i, κ i → α} (a : α) : (a ⊓ ⨆ i, ⨆ j, f i j) = ⨆ i, ⨆ j, a ⊓ f i j := by
+  simp only [inf_iSup_eq]
+
+/-- The `Order.Frame.MinimalAxioms` element corresponding to a frame. -/
+def of [Frame α] : MinimalAxioms α := { ‹Frame α› with }
+
+end MinimalAxioms
+
+/-- Construct a frame instance using the minimal amount of work needed.
+
+This sets `a ⇨ b := sSup {c | c ⊓ a ≤ b}` and `aᶜ := a ⇨ ⊥`. -/
+-- See note [reducible non instances]
+abbrev ofMinimalAxioms (minAx : MinimalAxioms α) : Frame α where
+  __ := minAx
+  himp a b := sSup {c | c ⊓ a ≤ b}
+  le_himp_iff a b c :=
+    ⟨fun h ↦ (inf_le_inf_right _ h).trans (by simp [minAx.sSup_inf_eq]), fun h ↦ le_sSup h⟩
+  himp_bot _ := rfl
+
+end Order.Frame
+
+namespace Order.Coframe.MinimalAxioms
+variable (minAx : MinimalAxioms α) {s : Set α} {a b : α}
+
+lemma sup_sInf_eq : a ⊔ sInf s = ⨅ b ∈ s, a ⊔ b :=
+  sup_sInf_le_iInf_sup.antisymm (minAx.iInf_sup_le_sup_sInf _ _)
+
+lemma sInf_sup_eq : sInf s ⊔ b = ⨅ a ∈ s, a ⊔ b := by
+  simpa only [sup_comm] using @sup_sInf_eq α _ s b
+
+lemma iInf_sup_eq (f : ι → α) (a : α) : (⨅ i, f i) ⊔ a = ⨅ i, f i ⊔ a := by
+  rw [iInf, sInf_sup_eq, iInf_range]
+
+lemma sup_iInf_eq (a : α) (f : ι → α) : (a ⊔ ⨅ i, f i) = ⨅ i, a ⊔ f i := by
+  simpa only [sup_comm] using minAx.iInf_sup_eq f a
+
+lemma sup_iInf₂_eq {f : ∀ i, κ i → α} (a : α) : (a ⊔ ⨅ i, ⨅ j, f i j) = ⨅ i, ⨅ j, a ⊔ f i j := by
+  simp only [sup_iInf_eq]
+
+/-- The `Order.Coframe.MinimalAxioms` element corresponding to a frame. -/
+def of [Coframe α] : MinimalAxioms α := { ‹Coframe α› with }
+
+end MinimalAxioms
+
+/-- Construct a coframe instance using the minimal amount of work needed.
+
+This sets `a \ b := sInf {c | a ≤ b ⊔ c}` and `￢a := ⊤ \ a`. -/
+-- See note [reducible non instances]
+abbrev ofMinimalAxioms (minAx : MinimalAxioms α) : Coframe α where
+  __ := minAx
+  sdiff a b := sInf {c | a ≤ b ⊔ c}
+  sdiff_le_iff a b c :=
+    ⟨fun h ↦ (sup_le_sup_left h _).trans' (by simp [minAx.sup_sInf_eq]), fun h ↦ sInf_le h⟩
+  top_sdiff _ := rfl
+
+end Order.Coframe
+
+namespace CompleteDistribLattice.MinimalAxioms
+variable (minAx : MinimalAxioms α) {s : Set α} {a b : α}
+
+/-- The `CompleteDistribLattice.MinimalAxioms` element corresponding to a complete distrib lattice.
+-/
+def of [CompleteDistribLattice α] : MinimalAxioms α := { ‹CompleteDistribLattice α› with }
+
+/-- Turn minimal axioms for `CompleteDistribLattice` into minimal axioms for `Order.Frame`. -/
+abbrev toFrame : Frame.MinimalAxioms α := minAx.toMinimalAxioms
+
+/-- Turn minimal axioms for `CompleteDistribLattice` into minimal axioms for `Order.Coframe`. -/
+abbrev toCoframe : Coframe.MinimalAxioms α where __ := minAx
+
+end MinimalAxioms
+
+/-- Construct a complete distrib lattice instance using the minimal amount of work needed.
+
+This sets `a ⇨ b := sSup {c | c ⊓ a ≤ b}`, `aᶜ := a ⇨ ⊥`, `a \ b := sInf {c | a ≤ b ⊔ c}` and
+`￢a := ⊤ \ a`. -/
+-- See note [reducible non instances]
+abbrev ofMinimalAxioms (minAx : MinimalAxioms α) : CompleteDistribLattice α where
+  __ := Frame.ofMinimalAxioms minAx.toFrame
+  __ := Coframe.ofMinimalAxioms minAx.toCoframe
+
+end CompleteDistribLattice
+
+namespace CompletelyDistribLattice.MinimalAxioms
+variable (minAx : MinimalAxioms α)
+
+lemma iInf_iSup_eq' (f : ∀ a, κ a → α) :
+    let _ := minAx.toCompleteLattice
+    ⨅ i, ⨆ j, f i j = ⨆ g : ∀ i, κ i, ⨅ i, f i (g i) := by
+  let _ := minAx.toCompleteLattice
+  refine le_antisymm ?_ le_iInf_iSup
+  calc
     _ = ⨅ a : range (range <| f ·), ⨆ b : a.1, b.1 := by
       simp_rw [iInf_subtype, iInf_range, iSup_subtype, iSup_range]
-    _ = _ := CompletelyDistribLattice.iInf_iSup_eq _
+    _ = _ := minAx.iInf_iSup_eq _
     _ ≤ _ := iSup_le fun g => by
       refine le_trans ?_ <| le_iSup _ fun a => Classical.choose (g ⟨_, a, rfl⟩).2
       refine le_iInf fun a => le_trans (iInf_le _ ⟨range (f a), a, rfl⟩) ?_
       rw [← Classical.choose_spec (g ⟨_, a, rfl⟩).2]
 
-theorem iSup_iInf_le [CompleteLattice α] {f : ∀ a, κ a → α} :
-    (⨆ a, ⨅ b, f a b) ≤ ⨅ g : ∀ a, κ a, ⨆ a, f a (g a) :=
-  le_iInf_iSup (α := αᵒᵈ)
-
-theorem iSup_iInf_eq [CompletelyDistribLattice α] {f : ∀ a, κ a → α} :
-    (⨆ a, ⨅ b, f a b) = ⨅ g : ∀ a, κ a, ⨆ a, f a (g a) := by
+lemma iSup_iInf_eq (f : ∀ i, κ i → α) :
+    let _ := minAx.toCompleteLattice
+    ⨆ i, ⨅ j, f i j = ⨅ g : ∀ i, κ i, ⨆ i, f i (g i) := by
+  let _ := minAx.toCompleteLattice
   refine le_antisymm iSup_iInf_le ?_
-  rw [iInf_iSup_eq]
+  rw [minAx.iInf_iSup_eq']
   refine iSup_le fun g => ?_
   have ⟨a, ha⟩ : ∃ a, ∀ b, ∃ f, ∃ h : a = g f, h ▸ b = f (g f) := of_not_not fun h => by
     push_neg at h
@@ -114,28 +259,59 @@ theorem iSup_iInf_eq [CompletelyDistribLattice α] {f : ∀ a, κ a → α} :
   obtain ⟨h, rfl, rfl⟩ := ha b
   exact iInf_le _ _
 
+/-- Turn minimal axioms for `CompletelyDistribLattice` into minimal axioms for
+`CompleteDistribLattice`. -/
+abbrev toCompleteDistribLattice : CompleteDistribLattice.MinimalAxioms α where
+  __ := minAx
+  inf_sSup_le_iSup_inf a s := by
+    let _ := minAx.toCompleteLattice
+    calc
+      _ = ⨅ i : ULift.{u} Bool, ⨆ j : match i with | .up true => PUnit.{u + 1} | .up false => s,
+          match i with
+          | .up true => a
+          | .up false => j := by simp [le_antisymm_iff, sSup_eq_iSup', iSup_unique, iInf_bool_eq]
+      _ ≤ _ := by
+        simp only [minAx.iInf_iSup_eq, iInf_ulift, iInf_bool_eq, iSup_le_iff]
+        exact fun x ↦ le_biSup _ (x (.up false)).2
+  iInf_sup_le_sup_sInf a s := by
+    let _ := minAx.toCompleteLattice
+    calc
+      _ ≤ ⨆ i : ULift.{u} Bool, ⨅ j : match i with | .up true => PUnit.{u + 1} | .up false => s,
+          match i with
+          | .up true => a
+          | .up false => j := by
+        simp only [minAx.iSup_iInf_eq, iSup_ulift, iSup_bool_eq, le_iInf_iff]
+        exact fun x ↦ biInf_le _ (x (.up false)).2
+      _ = _ := by simp [le_antisymm_iff, sInf_eq_iInf', iInf_unique, iSup_bool_eq]
+
+/-- The `CompletelyDistribLattice.MinimalAxioms` element corresponding to a frame. -/
+def of [CompletelyDistribLattice α] : MinimalAxioms α := { ‹CompletelyDistribLattice α› with }
+
+end MinimalAxioms
+
+/-- Construct a completely distributive lattice instance using the minimal amount of work needed.
+
+This sets `a ⇨ b := sSup {c | c ⊓ a ≤ b}`, `aᶜ := a ⇨ ⊥`, `a \ b := sInf {c | a ≤ b ⊔ c}` and
+`￢a := ⊤ \ a`. -/
+-- See note [reducible non instances]
+abbrev ofMinimalAxioms (minAx : MinimalAxioms α) : CompletelyDistribLattice α where
+  __ := minAx
+  __ := CompleteDistribLattice.ofMinimalAxioms minAx.toCompleteDistribLattice
+
+end CompletelyDistribLattice
+
+theorem iInf_iSup_eq [CompletelyDistribLattice α] {f : ∀ a, κ a → α} :
+    (⨅ a, ⨆ b, f a b) = ⨆ g : ∀ a, κ a, ⨅ a, f a (g a) :=
+  CompletelyDistribLattice.MinimalAxioms.of.iInf_iSup_eq' _
+
+theorem iSup_iInf_eq [CompletelyDistribLattice α] {f : ∀ a, κ a → α} :
+    (⨆ a, ⨅ b, f a b) = ⨅ g : ∀ a, κ a, ⨆ a, f a (g a) :=
+  CompletelyDistribLattice.MinimalAxioms.of.iSup_iInf_eq _
+
 instance (priority := 100) CompletelyDistribLattice.toCompleteDistribLattice
     [CompletelyDistribLattice α] : CompleteDistribLattice α where
   __ := ‹CompletelyDistribLattice α›
-  iInf_sup_le_sup_sInf a s := calc
-    _ = ⨅ b : s, ⨆ x : Bool, cond x a b := by simp_rw [iInf_subtype, iSup_bool_eq, cond]
-    _ = _ := iInf_iSup_eq
-    _ ≤ _ := iSup_le fun f => by
-      if h : ∀ i, f i = false then
-        simp [h, iInf_subtype, ← sInf_eq_iInf]
-      else
-        have ⟨i, h⟩ : ∃ i, f i = true := by simpa using h
-        refine le_trans (iInf_le _ i) ?_
-        simp [h]
-  inf_sSup_le_iSup_inf a s := calc
-    _ = ⨅ x : Bool, ⨆ y : cond x PUnit s, match x with | true => a | false => y.1 := by
-      simp_rw [iInf_bool_eq, cond, iSup_const, iSup_subtype, sSup_eq_iSup]
-    _ = _ := by exact iInf_iSup_eq
-    _ ≤ _ := by
-      simp_rw [iInf_bool_eq]
-      refine iSup_le fun g => le_trans ?_ (le_iSup _ (g false).1)
-      refine le_trans ?_ (le_iSup _ (g false).2)
-      rfl
+  __ := CompleteDistribLattice.ofMinimalAxioms MinimalAxioms.of.toCompleteDistribLattice
 
 -- See note [lower instance priority]
 instance (priority := 100) CompleteLinearOrder.toCompletelyDistribLattice [CompleteLinearOrder α] :
@@ -490,6 +666,34 @@ instance Prop.instCompleteBooleanAlgebra : CompleteBooleanAlgebra Prop := inferI
 section lift
 
 -- See note [reducible non-instances]
+/-- Pullback an `Order.Frame.MinimalAxioms` along an injection. -/
+protected abbrev Function.Injective.frameMinimalAxioms [Sup α] [Inf α] [SupSet α] [InfSet α] [Top α]
+    [Bot α] (minAx : Frame.MinimalAxioms β) (f : α → β) (hf : Injective f)
+    (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
+    (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a)
+    (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) : Frame.MinimalAxioms α where
+  __ := hf.completeLattice f map_sup map_inf map_sSup map_sInf map_top map_bot
+  inf_sSup_le_iSup_inf a s := by
+    change f (a ⊓ sSup s) ≤ f _
+    rw [← sSup_image, map_inf, map_sSup s, minAx.inf_iSup₂_eq]
+    simp_rw [← map_inf]
+    exact ((map_sSup _).trans iSup_image).ge
+
+-- See note [reducible non-instances]
+/-- Pullback an `Order.Coframe.MinimalAxioms` along an injection. -/
+protected abbrev Function.Injective.coframeMinimalAxioms [Sup α] [Inf α] [SupSet α] [InfSet α]
+    [Top α] [Bot α] (minAx : Coframe.MinimalAxioms β) (f : α → β) (hf : Injective f)
+    (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
+    (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a)
+    (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) : Coframe.MinimalAxioms α where
+  __ := hf.completeLattice f map_sup map_inf map_sSup map_sInf map_top map_bot
+  iInf_sup_le_sup_sInf a s := by
+    change f _ ≤ f (a ⊔ sInf s)
+    rw [← sInf_image, map_sup, map_sInf s, minAx.sup_iInf₂_eq]
+    simp_rw [← map_sup]
+    exact ((map_sInf _).trans iInf_image).le
+
+-- See note [reducible non-instances]
 /-- Pullback an `Order.Frame` along an injection. -/
 protected abbrev Function.Injective.frame [Sup α] [Inf α] [SupSet α] [InfSet α] [Top α] [Bot α]
     [HasCompl α] [HImp α] [Frame β] (f : α → β) (hf : Injective f)
@@ -497,13 +701,8 @@ protected abbrev Function.Injective.frame [Sup α] [Inf α] [SupSet α] [InfSet 
     (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a)
     (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) (map_compl : ∀ a, f aᶜ = (f a)ᶜ)
     (map_himp : ∀ a b, f (a ⇨ b) = f a ⇨ f b) : Frame α where
-  __ := hf.completeLattice f map_sup map_inf map_sSup map_sInf map_top map_bot
+  __ := hf.frameMinimalAxioms .of f map_sup map_inf map_sSup map_sInf map_top map_bot
   __ := hf.heytingAlgebra f map_sup map_inf map_top map_bot map_compl map_himp
-  inf_sSup_le_iSup_inf a s := by
-    change f (a ⊓ sSup s) ≤ f _
-    rw [← sSup_image, map_inf, map_sSup s, inf_iSup₂_eq]
-    simp_rw [← map_inf]
-    exact ((map_sSup _).trans iSup_image).ge
 
 -- See note [reducible non-instances]
 /-- Pullback an `Order.Coframe` along an injection. -/
@@ -513,13 +712,23 @@ protected abbrev Function.Injective.coframe [Sup α] [Inf α] [SupSet α] [InfSe
     (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a)
     (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) (map_hnot : ∀ a, f (￢a) = ￢f a)
     (map_sdiff : ∀ a b, f (a \ b) = f a \ f b) : Coframe α where
-  __ := hf.completeLattice f map_sup map_inf map_sSup map_sInf map_top map_bot
+  __ := hf.coframeMinimalAxioms .of f map_sup map_inf map_sSup map_sInf map_top map_bot
   __ := hf.coheytingAlgebra f map_sup map_inf map_top map_bot map_hnot map_sdiff
-  iInf_sup_le_sup_sInf a s := by
-    change f _ ≤ f (a ⊔ sInf s)
-    rw [← sInf_image, map_sup, map_sInf s, sup_iInf₂_eq]
-    simp_rw [← map_sup]
-    exact ((map_sInf _).trans iInf_image).le
+
+-- See note [reducible non-instances]
+/-- Pullback a `CompleteDistribLattice.MinimalAxioms` along an injection. -/
+protected abbrev Function.Injective.completeDistribLatticeMinimalAxioms [Sup α] [Inf α] [SupSet α]
+    [InfSet α] [Top α] [Bot α] (minAx : CompleteDistribLattice.MinimalAxioms β) (f : α → β)
+    (hf : Injective f) (map_sup : let _ := minAx.toCompleteLattice
+      ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : let _ := minAx.toCompleteLattice
+      ∀ a b, f (a ⊓ b) = f a ⊓ f b) (map_sSup : let _ := minAx.toCompleteLattice
+      ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : let _ := minAx.toCompleteLattice
+      ∀ s, f (sInf s) = ⨅ a ∈ s, f a) (map_top : let _ := minAx.toCompleteLattice
+      f ⊤ = ⊤) (map_bot : let _ := minAx.toCompleteLattice
+      f ⊥ = ⊥) :
+    CompleteDistribLattice.MinimalAxioms α where
+  __ := hf.frameMinimalAxioms minAx.toFrame f map_sup map_inf map_sSup map_sInf map_top map_bot
+  __ := hf.coframeMinimalAxioms minAx.toCoframe f map_sup map_inf map_sSup map_sInf map_top map_bot
 
 -- See note [reducible non-instances]
 /-- Pullback a `CompleteDistribLattice` along an injection. -/
@@ -534,6 +743,24 @@ protected abbrev Function.Injective.completeDistribLattice [Sup α] [Inf α] [Su
     CompleteDistribLattice α where
   __ := hf.frame f map_sup map_inf map_sSup map_sInf map_top map_bot map_compl map_himp
   __ := hf.coframe f map_sup map_inf map_sSup map_sInf map_top map_bot map_hnot map_sdiff
+
+-- See note [reducible non-instances]
+/-- Pullback a `CompletelyDistribLattice.MinimalAxioms` along an injection. -/
+protected abbrev Function.Injective.completelyDistribLatticeMinimalAxioms [Sup α] [Inf α] [SupSet α]
+    [InfSet α] [Top α] [Bot α] (minAx : CompletelyDistribLattice.MinimalAxioms β) (f : α → β)
+    (hf : Injective f) (map_sup : let _ := minAx.toCompleteLattice
+      ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : let _ := minAx.toCompleteLattice
+      ∀ a b, f (a ⊓ b) = f a ⊓ f b) (map_sSup : let _ := minAx.toCompleteLattice
+      ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : let _ := minAx.toCompleteLattice
+      ∀ s, f (sInf s) = ⨅ a ∈ s, f a) (map_top : let _ := minAx.toCompleteLattice
+      f ⊤ = ⊤) (map_bot : let _ := minAx.toCompleteLattice
+      f ⊥ = ⊥) :
+    CompletelyDistribLattice.MinimalAxioms α where
+  __ := hf.completeDistribLatticeMinimalAxioms minAx.toCompleteDistribLattice f map_sup map_inf
+    map_sSup map_sInf map_top map_bot
+  iInf_iSup_eq g := hf <| by
+    simp_rw [iInf, map_sInf, iInf_range, iSup, map_sSup, iSup_range, map_sInf, iInf_range,
+      minAx.iInf_iSup_eq']
 
 -- See note [reducible non-instances]
 /-- Pullback a `CompletelyDistribLattice` along an injection. -/

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -372,10 +372,18 @@ A complete Boolean algebra is a Boolean algebra that is also a complete distribu
 
 It is only completely distributive if it is also atomic.
 -/
-class CompleteBooleanAlgebra (α) extends BooleanAlgebra α, CompleteDistribLattice α
+-- We do not directly extend `CompleteDistribLattice` to avoid having the `hnot` field
+class CompleteBooleanAlgebra (α) extends CompleteLattice α, BooleanAlgebra α where
+  /-- `⊓` distributes over `⨆`. -/
+  inf_sSup_le_iSup_inf (a : α) (s : Set α) : a ⊓ sSup s ≤ ⨆ b ∈ s, a ⊓ b
+  /-- `⊔` distributes over `⨅`. -/
+  iInf_sup_le_sup_sInf (a : α) (s : Set α) : ⨅ b ∈ s, a ⊔ b ≤ a ⊔ sInf s
 
--- TODO: this breaks things
-example {α} [CompleteBooleanAlgebra α] {a : α} : ￢a = aᶜ := rfl
+-- See note [lower instance priority]
+instance (priority := 100) CompleteBooleanAlgebra.toCompleteDistribLattice
+    [CompleteBooleanAlgebra α] : CompleteDistribLattice α where
+  __ := ‹CompleteBooleanAlgebra α›
+  __ := BooleanAlgebra.toBiheytingAlgebra
 
 instance Prod.instCompleteBooleanAlgebra [CompleteBooleanAlgebra α] [CompleteBooleanAlgebra β] :
     CompleteBooleanAlgebra (α × β) where
@@ -438,10 +446,24 @@ that is also completely distributive.
 We take iSup_iInf_eq as the definition here,
 and prove later on that this implies atomicity.
 -/
-class CompleteAtomicBooleanAlgebra (α : Type u) extends
-    CompletelyDistribLattice α, CompleteBooleanAlgebra α where
-  iInf_sup_le_sup_sInf := CompletelyDistribLattice.toCompleteDistribLattice.iInf_sup_le_sup_sInf
-  inf_sSup_le_iSup_inf := CompletelyDistribLattice.toCompleteDistribLattice.inf_sSup_le_iSup_inf
+-- We do not directly extend `CompletelyDistribLattice` to avoid having the `hnot` field
+-- We do not directly extend `CompleteBooleanAlgebra` to avoid having the `inf_sSup_le_iSup_inf` and
+-- `iInf_sup_le_sup_sInf` fields
+class CompleteAtomicBooleanAlgebra (α : Type u) extends CompleteLattice α, BooleanAlgebra α where
+  protected iInf_iSup_eq {ι : Type u} {κ : ι → Type u} (f : ∀ a, κ a → α) :
+    (⨅ a, ⨆ b, f a b) = ⨆ g : ∀ a, κ a, ⨅ a, f a (g a)
+
+-- See note [lower instance priority]
+instance (priority := 100) CompleteAtomicBooleanAlgebra.toCompletelyDistribLattice
+    [CompleteAtomicBooleanAlgebra α] : CompletelyDistribLattice α where
+  __ := ‹CompleteAtomicBooleanAlgebra α›
+  __ := BooleanAlgebra.toBiheytingAlgebra
+
+-- See note [lower instance priority]
+instance (priority := 100) CompleteAtomicBooleanAlgebra.toCompleteBooleanAlgebra
+    [CompleteAtomicBooleanAlgebra α] : CompleteBooleanAlgebra α where
+  __ := ‹CompleteAtomicBooleanAlgebra α›
+  __ := CompletelyDistribLattice.toCompleteDistribLattice
 
 instance Prod.instCompleteAtomicBooleanAlgebra [CompleteAtomicBooleanAlgebra α]
     [CompleteAtomicBooleanAlgebra β] : CompleteAtomicBooleanAlgebra (α × β) where
@@ -461,7 +483,6 @@ instance OrderDual.instCompleteAtomicBooleanAlgebra [CompleteAtomicBooleanAlgebr
 instance Prop.instCompleteAtomicBooleanAlgebra : CompleteAtomicBooleanAlgebra Prop where
   __ := Prop.instCompleteLattice
   __ := Prop.instBooleanAlgebra
-  __ := BooleanAlgebra.toBiheytingAlgebra
   iInf_iSup_eq f := by simp [Classical.skolem]
 
 instance Prop.instCompleteBooleanAlgebra : CompleteBooleanAlgebra Prop := inferInstance
@@ -534,16 +555,25 @@ protected abbrev Function.Injective.completelyDistribLattice [Sup α] [Inf α] [
 -- See note [reducible non-instances]
 /-- Pullback a `CompleteBooleanAlgebra` along an injection. -/
 protected abbrev Function.Injective.completeBooleanAlgebra [Sup α] [Inf α] [SupSet α] [InfSet α]
-    [Top α] [Bot α] [HasCompl α] [HImp α] [HNot α] [SDiff α] [CompleteBooleanAlgebra β] (f : α → β)
+    [Top α] [Bot α] [HasCompl α] [HImp α] [SDiff α] [CompleteBooleanAlgebra β] (f : α → β)
     (hf : Injective f) (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b)
     (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b) (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a)
     (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a) (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥)
     (map_compl : ∀ a, f aᶜ = (f a)ᶜ) (map_himp : ∀ a b, f (a ⇨ b) = f a ⇨ f b)
-    (map_hnot : ∀ a, f (￢a) = ￢f a) (map_sdiff : ∀ a b, f (a \ b) = f a \ f b) :
+    (map_sdiff : ∀ a b, f (a \ b) = f a \ f b) :
     CompleteBooleanAlgebra α where
-  __ := hf.completeDistribLattice f map_sup map_inf map_sSup map_sInf map_top map_bot map_compl
-    map_himp map_hnot map_sdiff
-  __ := hf.booleanAlgebra f map_sup map_inf map_top map_bot map_compl map_sdiff
+  __ := hf.completeLattice f map_sup map_inf map_sSup map_sInf map_top map_bot
+  __ := hf.booleanAlgebra f map_sup map_inf map_top map_bot map_compl map_sdiff map_himp
+  inf_sSup_le_iSup_inf a s := by
+    change f (a ⊓ sSup s) ≤ f _
+    rw [← sSup_image, map_inf, map_sSup s, inf_iSup₂_eq]
+    simp_rw [← map_inf]
+    exact ((map_sSup _).trans iSup_image).ge
+  iInf_sup_le_sup_sInf a s := by
+    change f _ ≤ f (a ⊔ sInf s)
+    rw [← sInf_image, map_sup, map_sInf s, sup_iInf₂_eq]
+    simp_rw [← map_sup]
+    exact ((map_sInf _).trans iInf_image).le
 
 -- See note [reducible non-instances]
 /-- Pullback a `CompleteAtomicBooleanAlgebra` along an injection. -/
@@ -558,7 +588,7 @@ protected abbrev Function.Injective.completeAtomicBooleanAlgebra [Sup α] [Inf �
     CompleteAtomicBooleanAlgebra α where
   __ := hf.completelyDistribLattice f map_sup map_inf map_sSup map_sInf map_top map_bot map_compl
     map_himp map_hnot map_sdiff
-  __ := hf.booleanAlgebra f map_sup map_inf map_top map_bot map_compl map_sdiff
+  __ := hf.booleanAlgebra f map_sup map_inf map_top map_bot map_compl map_sdiff map_himp
 
 end lift
 

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -374,6 +374,9 @@ It is only completely distributive if it is also atomic.
 -/
 class CompleteBooleanAlgebra (α) extends BooleanAlgebra α, CompleteDistribLattice α
 
+-- TODO: this breaks things
+example {α} [CompleteBooleanAlgebra α] {a : α} : ￢a = aᶜ := rfl
+
 instance Prod.instCompleteBooleanAlgebra [CompleteBooleanAlgebra α] [CompleteBooleanAlgebra β] :
     CompleteBooleanAlgebra (α × β) where
   __ := instBooleanAlgebra

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -47,6 +47,12 @@ open Function OrderDual Set
 
 variable {α β β₂ γ : Type*} {ι ι' : Sort*} {κ : ι → Sort*} {κ' : ι' → Sort*}
 
+@[simp] lemma iSup_ulift {ι : Type*} [SupSet α] (f : ULift ι → α) :
+    ⨆ i : ULift ι, f i = ⨆ i, f (.up i) := by simp [iSup]; congr with x; simp
+
+@[simp] lemma iInf_ulift {ι : Type*} [InfSet α] (f : ULift ι → α) :
+    ⨅ i : ULift ι, f i = ⨅ i, f (.up i) := by simp [iInf]; congr with x; simp
+
 instance OrderDual.supSet (α) [InfSet α] : SupSet αᵒᵈ :=
   ⟨(sInf : Set α → α)⟩
 
@@ -837,6 +843,12 @@ theorem iSup_const [Nonempty ι] : ⨆ _ : ι, a = a := by rw [iSup, range_const
 
 theorem iInf_const [Nonempty ι] : ⨅ _ : ι, a = a :=
   @iSup_const αᵒᵈ _ _ a _
+
+lemma iSup_unique [Unique ι] (f : ι → α) : ⨆ i, f i = f default := by
+  simp only [congr_arg f (Unique.eq_default _), iSup_const]
+
+lemma iInf_unique [Unique ι] (f : ι → α) : ⨅ i, f i = f default := by
+  simp only [congr_arg f (Unique.eq_default _), iInf_const]
 
 @[simp]
 theorem iSup_bot : (⨆ _ : ι, ⊥ : α) = ⊥ :=

--- a/Mathlib/Order/Copy.lean
+++ b/Mathlib/Order/Copy.lean
@@ -188,12 +188,16 @@ def Frame.copy (c : Frame α) (le : α → α → Prop) (eq_le : le = (by infer_
     (bot : α) (eq_bot : bot = (by infer_instance : Bot α).bot)
     (sup : α → α → α) (eq_sup : sup = (by infer_instance : Sup α).sup)
     (inf : α → α → α) (eq_inf : inf = (by infer_instance : Inf α).inf)
+    (himp : α → α → α) (eq_himp : himp = (by infer_instance : HImp α).himp)
+    (compl : α → α) (eq_compl : compl = (by infer_instance : HasCompl α).compl)
     (sSup : Set α → α) (eq_sSup : sSup = (by infer_instance : SupSet α).sSup)
     (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) : Frame α where
   toCompleteLattice := CompleteLattice.copy (@Frame.toCompleteLattice α c)
     le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf sSup eq_sSup sInf eq_sInf
   inf_sSup_le_iSup_inf := fun a s => by
     simp [eq_le, eq_sup, eq_inf, eq_sSup, @Order.Frame.inf_sSup_le_iSup_inf α _ a s]
+  __ := HeytingAlgebra.copy (@Frame.toHeytingAlgebra α c)
+    le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf himp eq_himp compl eq_compl
 
 /-- A function to create a provable equal copy of a coframe with possibly different definitional
 equalities. -/
@@ -202,12 +206,16 @@ def Coframe.copy (c : Coframe α) (le : α → α → Prop) (eq_le : le = (by in
     (bot : α) (eq_bot : bot = (by infer_instance : Bot α).bot)
     (sup : α → α → α) (eq_sup : sup = (by infer_instance : Sup α).sup)
     (inf : α → α → α) (eq_inf : inf = (by infer_instance : Inf α).inf)
+    (sdiff : α → α → α) (eq_sdiff : sdiff = (by infer_instance : SDiff α).sdiff)
+    (hnot : α → α) (eq_hnot : hnot = (by infer_instance : HNot α).hnot)
     (sSup : Set α → α) (eq_sSup : sSup = (by infer_instance : SupSet α).sSup)
     (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) : Coframe α where
   toCompleteLattice := CompleteLattice.copy (@Coframe.toCompleteLattice α c)
     le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf sSup eq_sSup sInf eq_sInf
   iInf_sup_le_sup_sInf := fun a s => by
     simp [eq_le, eq_sup, eq_inf, eq_sInf, @Order.Coframe.iInf_sup_le_sup_sInf α _ a s]
+  __ := CoheytingAlgebra.copy (@Coframe.toCoheytingAlgebra α c)
+    le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf sdiff eq_sdiff hnot eq_hnot
 
 /-- A function to create a provable equal copy of a complete distributive lattice
 with possibly different definitional equalities. -/
@@ -217,13 +225,17 @@ def CompleteDistribLattice.copy (c : CompleteDistribLattice α)
     (bot : α) (eq_bot : bot = (by infer_instance : Bot α).bot)
     (sup : α → α → α) (eq_sup : sup = (by infer_instance : Sup α).sup)
     (inf : α → α → α) (eq_inf : inf = (by infer_instance : Inf α).inf)
+    (sdiff : α → α → α) (eq_sdiff : sdiff = (by infer_instance : SDiff α).sdiff)
+    (hnot : α → α) (eq_hnot : hnot = (by infer_instance : HNot α).hnot)
+    (himp : α → α → α) (eq_himp : himp = (by infer_instance : HImp α).himp)
+    (compl : α → α) (eq_compl : compl = (by infer_instance : HasCompl α).compl)
     (sSup : Set α → α) (eq_sSup : sSup = (by infer_instance : SupSet α).sSup)
     (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) :
     CompleteDistribLattice α where
-  toFrame := Frame.copy (@CompleteDistribLattice.toFrame α c)
-    le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf sSup eq_sSup sInf eq_sInf
-  __ := Coframe.copy (@CompleteDistribLattice.toCoframe α c)
-    le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf sSup eq_sSup sInf eq_sInf
+  toFrame := Frame.copy (@CompleteDistribLattice.toFrame α c) le eq_le top eq_top bot eq_bot sup
+    eq_sup inf eq_inf himp eq_himp compl eq_compl sSup eq_sSup sInf eq_sInf
+  __ := Coframe.copy (@CompleteDistribLattice.toCoframe α c) le eq_le top eq_top bot eq_bot sup
+    eq_sup inf eq_inf sdiff eq_sdiff hnot eq_hnot sSup eq_sSup sInf eq_sInf
 
 /-- A function to create a provable equal copy of a conditionally complete lattice
 with possibly different definitional equalities. -/

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -782,8 +782,8 @@ instance : DistribLattice (Filter α) :=
         ⟨t₁, x.sets_of_superset hs inter_subset_left, ht₁, t₂,
           x.sets_of_superset hs inter_subset_right, ht₂, rfl⟩ }
 
--- The dual version does not hold! `Filter α` is not a `CompleteDistribLattice`. -/
-instance : Coframe (Filter α) :=
+/-- The dual version does not hold! `Filter α` is not a `CompleteDistribLattice`. -/
+def coframeMinimalAxioms : Coframe.MinimalAxioms (Filter α) :=
   { Filter.instCompleteLatticeFilter with
     iInf_sup_le_sup_sInf := fun f s t ⟨h₁, h₂⟩ => by
       rw [iInf_subtype']
@@ -795,6 +795,8 @@ instance : Coframe (Filter α) :=
       rintro ⟨i⟩ u _ ih
       rw [Finset.inf_insert, sup_inf_left]
       exact le_inf (iInf_le _ _) ih }
+
+instance instCoframe : Coframe (Filter α) := .ofMinimalAxioms coframeMinimalAxioms
 
 theorem mem_iInf_finset {s : Finset α} {f : α → Filter β} {t : Set β} :
     (t ∈ ⨅ a ∈ s, f a) ↔ ∃ p : α → Set β, (∀ a ∈ s, p a ∈ f a) ∧ t = ⋂ a ∈ s, p a := by

--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -531,9 +531,14 @@ instance : SupSet (UpperSet α) :=
 instance : InfSet (UpperSet α) :=
   ⟨fun S => ⟨⋃ s ∈ S, ↑s, isUpperSet_iUnion₂ fun s _ => s.upper⟩⟩
 
-instance completelyDistribLattice : CompletelyDistribLattice (UpperSet α) :=
-  (toDual.injective.comp SetLike.coe_injective).completelyDistribLattice _ (fun _ _ => rfl)
+instance completeLattice : CompleteLattice (UpperSet α) :=
+  (toDual.injective.comp SetLike.coe_injective).completeLattice _ (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ => rfl) rfl rfl
+
+instance completelyDistribLattice : CompletelyDistribLattice (UpperSet α) :=
+  .ofMinimalAxioms $
+    (toDual.injective.comp SetLike.coe_injective).completelyDistribLatticeMinimalAxioms .of _
+      (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ => rfl) rfl rfl
 
 instance : Inhabited (UpperSet α) :=
   ⟨⊥⟩
@@ -661,9 +666,13 @@ instance : SupSet (LowerSet α) :=
 instance : InfSet (LowerSet α) :=
   ⟨fun S => ⟨⋂ s ∈ S, ↑s, isLowerSet_iInter₂ fun s _ => s.lower⟩⟩
 
-instance completelyDistribLattice : CompletelyDistribLattice (LowerSet α) :=
-  SetLike.coe_injective.completelyDistribLattice _ (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
+instance completeLattice : CompleteLattice (LowerSet α) :=
+  SetLike.coe_injective.completeLattice _ (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
     (fun _ => rfl) rfl rfl
+
+instance completelyDistribLattice : CompletelyDistribLattice (LowerSet α) :=
+  .ofMinimalAxioms $ SetLike.coe_injective.completelyDistribLatticeMinimalAxioms .of _
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ => rfl) rfl rfl
 
 instance : Inhabited (LowerSet α) :=
   ⟨⊥⟩
@@ -920,10 +929,10 @@ noncomputable instance LowerSet.instLinearOrder : LinearOrder (LowerSet α) := b
   classical exact Lattice.toLinearOrder _
 
 noncomputable instance UpperSet.instCompleteLinearOrder : CompleteLinearOrder (UpperSet α) :=
-  { completelyDistribLattice, instLinearOrder, LinearOrder.toBiheytingAlgebra with }
+  { completelyDistribLattice, instLinearOrder with }
 
 noncomputable instance LowerSet.instCompleteLinearOrder : CompleteLinearOrder (LowerSet α) :=
-  { completelyDistribLattice, instLinearOrder, LinearOrder.toBiheytingAlgebra with }
+  { completelyDistribLattice, instLinearOrder with }
 
 end LinearOrder
 

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -162,11 +162,12 @@ theorem iInf_mk {ι} (s : ι → Set α) (h : ∀ i, IsClosed (s i)) :
     (⨅ i, ⟨s i, h i⟩ : Closeds α) = ⟨⋂ i, s i, isClosed_iInter h⟩ :=
   iInf_def _
 
-instance : Coframe (Closeds α) :=
-  { inferInstanceAs (CompleteLattice (Closeds α)) with
-    sInf := sInf
-    iInf_sup_le_sup_sInf := fun a s =>
-      (SetLike.coe_injective <| by simp only [coe_sup, coe_iInf, coe_sInf, Set.union_iInter₂]).le }
+/-- Closed sets in a topological space form a coframe. -/
+def coframeMinimalAxioms : Coframe.MinimalAxioms (Closeds α) where
+  iInf_sup_le_sup_sInf a s :=
+    (SetLike.coe_injective <| by simp only [coe_sup, coe_iInf, coe_sInf, Set.union_iInter₂]).le
+
+instance instCoframe : Coframe (Closeds α) := .ofMinimalAxioms coframeMinimalAxioms
 
 /-- The term of `TopologicalSpace.Closeds α` corresponding to a singleton. -/
 @[simps]
@@ -305,6 +306,7 @@ instance : HasCompl (Clopens α) := ⟨fun s => ⟨sᶜ, s.isClopen.compl⟩⟩
 
 instance : BooleanAlgebra (Clopens α) :=
   SetLike.coe_injective.booleanAlgebra _ coe_sup coe_inf coe_top coe_bot coe_compl coe_sdiff
+    coe_himp
 
 instance : Inhabited (Clopens α) := ⟨⊥⟩
 

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -509,6 +509,7 @@ instance instHImp : HImp (CompactOpens α) where
 
 instance instBooleanAlgebra : BooleanAlgebra (CompactOpens α) :=
   SetLike.coe_injective.booleanAlgebra _ coe_sup coe_inf coe_top coe_bot coe_compl coe_sdiff
+    coe_himp
 
 end Top.Compl
 

--- a/Mathlib/Topology/Sets/Opens.lean
+++ b/Mathlib/Topology/Sets/Opens.lean
@@ -226,11 +226,12 @@ theorem mem_iSup {ι} {x : α} {s : ι → Opens α} : x ∈ iSup s ↔ ∃ i, x
 theorem mem_sSup {Us : Set (Opens α)} {x : α} : x ∈ sSup Us ↔ ∃ u ∈ Us, x ∈ u := by
   simp_rw [sSup_eq_iSup, mem_iSup, exists_prop]
 
-instance : Frame (Opens α) :=
-  { inferInstanceAs (CompleteLattice (Opens α)) with
-    sSup := sSup
-    inf_sSup_le_iSup_inf := fun a s =>
-      (ext <| by simp only [coe_inf, coe_iSup, coe_sSup, Set.inter_iUnion₂]).le }
+/-- Open sets in a topological space form a frame. -/
+def frameMinimalAxioms : Frame.MinimalAxioms (Opens α) where
+  inf_sSup_le_iSup_inf a s :=
+    (ext <| by simp only [coe_inf, coe_iSup, coe_sSup, Set.inter_iUnion₂]).le
+
+instance instFrame : Frame (Opens α) := .ofMinimalAxioms frameMinimalAxioms
 
 theorem openEmbedding' (U : Opens α) : OpenEmbedding (Subtype.val : U → α) :=
   U.isOpen.openEmbedding_subtype_val


### PR DESCRIPTION
It is mathematically true that a frame is a Heyting algebra. However we want nice defeqs, so we can't just provide an instance defining `himp` as some supremum. Instead, we need `Frame` to directly extend `HeytingAlgebra`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #12730
- [x] depends on: #12731
- [x] depends on: #15005
- [x] depends on: #15006

I'm not exactly sure why there's a non-defeq diamond showing up in the `OrderDual` instances but not in the `Prod` ones.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
