### PR TITLE
[Merged by Bors] - feat(Algebra/Order/AbsoluteValue): Add AbsoluteValue.{le_add,sub_le_add}

### DIFF
--- a/Mathlib/Algebra/Order/AbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue.lean
@@ -245,7 +245,7 @@ protected theorem le_add (a b : R) : abv a - abv b ≤ abv (a + b) := by
   simpa only [tsub_le_iff_right, add_neg_cancel_right, abv.map_neg] using abv.add_le (a + b) (-b)
 
 /-- Bound `abv (a - b)` from above -/
-lemma sub_le' (a b : R) : abv (a - b) ≤ abv a + abv b := by
+lemma sub_le_add (a b : R) : abv (a - b) ≤ abv a + abv b := by
   simpa only [← sub_eq_add_neg, AbsoluteValue.map_neg] using abv.add_le a (-b)
 
 end OrderedCommRing

--- a/Mathlib/Algebra/Order/AbsoluteValue.lean
+++ b/Mathlib/Algebra/Order/AbsoluteValue.lean
@@ -240,6 +240,14 @@ protected theorem map_neg (a : R) : abv (-a) = abv a := by
 protected theorem map_sub (a b : R) : abv (a - b) = abv (b - a) := by rw [← neg_sub, abv.map_neg]
 #align absolute_value.map_sub AbsoluteValue.map_sub
 
+/-- Bound `abv (a + b)` from below -/
+protected theorem le_add (a b : R) : abv a - abv b ≤ abv (a + b) := by
+  simpa only [tsub_le_iff_right, add_neg_cancel_right, abv.map_neg] using abv.add_le (a + b) (-b)
+
+/-- Bound `abv (a - b)` from above -/
+lemma sub_le' (a b : R) : abv (a - b) ≤ abv a + abv b := by
+  simpa only [← sub_eq_add_neg, AbsoluteValue.map_neg] using abv.add_le a (-b)
+
 end OrderedCommRing
 
 instance {R S : Type*} [Ring R] [OrderedCommRing S] [Nontrivial R] [IsDomain S] :


### PR DESCRIPTION
These triangle inequalities bound `abv (a + b)` from below and `abv (a - b)` from above, and are essentially `AbsoluteValue.le_sub` and `.add_le` with signs flipped, respectively.

---

I use these inequalities for the `bound` tactic ([Zulip](https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tactics/topic/.60bound.60.20mixes.20.60gcongr.60.20and.20.60positivity.60/near/412120380), and they seem appropriate to add as core `AbsoluteValue` lemmas.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)