### PR TITLE
[Merged by Bors] - feat: between star ordered rings, star-preserving ring homomorphisms preserve order

### DIFF
--- a/Mathlib/Algebra/Star/Order.lean
+++ b/Mathlib/Algebra/Star/Order.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import Mathlib.Algebra.Star.SelfAdjoint
-import Mathlib.Algebra.Star.StarAlgHom
 import Mathlib.GroupTheory.Submonoid.Basic
 
 #align_import algebra.star.order from "leanprover-community/mathlib"@"31c24aa72e7b3e5ed97a8412470e904f82b81004"

--- a/Mathlib/Algebra/Star/Order.lean
+++ b/Mathlib/Algebra/Star/Order.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import Mathlib.Algebra.Star.SelfAdjoint
+import Mathlib.Algebra.Star.StarAlgHom
 import Mathlib.GroupTheory.Submonoid.Basic
 
 #align_import algebra.star.order from "leanprover-community/mathlib"@"31c24aa72e7b3e5ed97a8412470e904f82b81004"
@@ -257,3 +258,40 @@ lemma star_lt_one_iff {x : R} : star x < 1 ↔ x < 1 := by
   simpa using star_lt_star_iff (x := x) (y := 1)
 
 end Semiring
+
+section OrderClass
+
+variable {F R S : Type*} [NonUnitalSemiring R] [PartialOrder R] [StarOrderedRing R]
+variable [NonUnitalSemiring S] [PartialOrder S] [StarOrderedRing S]
+
+-- we prove this auxiliary lemma in order to avoid duplicating the proof twice below.
+lemma NonUnitalRingHom.map_le_map_of_map_star (f : R →ₙ+* S) (hf : ∀ r, f (star r) = star (f r))
+    {x y : R} (hxy : x ≤ y) : f x ≤ f y := by
+  rw [StarOrderedRing.le_iff] at hxy ⊢
+  obtain ⟨p, hp, rfl⟩ := hxy
+  refine ⟨f p, ?_, map_add f _ _⟩
+  induction hp using AddSubmonoid.closure_induction'
+  all_goals aesop
+
+instance (priority := 100) StarRingHomClass.instOrderHomClass [FunLike F R S] [StarHomClass F R S]
+    [NonUnitalRingHomClass F R S] : OrderHomClass F R S where
+  map_rel f := (f : R →ₙ+* S).map_le_map_of_map_star (map_star f)
+
+-- This doesn't require any module structure, but the only morphism we currently have bundling
+-- `star` is `starAlgHom`. So we have to build the inverse morphism by hand.
+instance (priority := 100) StarRingHomClass.instOrderIsoClass [EquivLike F R S] [StarHomClass F R S]
+    [RingEquivClass F R S] : OrderIsoClass F R S where
+  map_le_map_iff f x y := by
+    refine ⟨fun h ↦ ?_, map_rel f⟩
+    let f_inv : S →ₙ+* R :=
+      { toFun := EquivLike.inv f
+        map_mul' := fun _ _ ↦ EmbeddingLike.injective f <| by simp
+        map_add' := fun _ _ ↦ EmbeddingLike.injective f <| by simp
+        map_zero' := EmbeddingLike.injective f <| by simp }
+    have f_inv_star (s : S) : f_inv (star s) = star (f_inv s) := EmbeddingLike.injective f <| by
+      simp only [map_star f, show ∀ s, f (f_inv s) = s from EquivLike.apply_inv_apply f]
+    have f_inv_f (r : R) : f_inv (f r) = r := EquivLike.inv_apply_apply f r
+    rw [← f_inv_f x, ← f_inv_f y]
+    exact f_inv.map_le_map_of_map_star f_inv_star h
+
+end OrderClass


### PR DESCRIPTION

---

It's a bit awkward because the only morphisms we have which bundle the `star` operation are `StarAlgHom` and `StarAlgEquiv`, but the results here don't need to reference the module structure at all.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
