### PR TITLE
[Merged by Bors] - style(Order): use `where __ := x` instead of `:= { x with }`

### DIFF
--- a/Mathlib/Algebra/Order/Pi.lean
+++ b/Mathlib/Algebra/Order/Pi.lean
@@ -29,9 +29,10 @@ namespace Pi
       "The product of a family of ordered additive commutative monoids is
 an ordered additive commutative monoid."]
 instance orderedCommMonoid {ι : Type*} {Z : ι → Type*} [∀ i, OrderedCommMonoid (Z i)] :
-    OrderedCommMonoid (∀ i, Z i) :=
-  { Pi.partialOrder, Pi.commMonoid with
-    mul_le_mul_left := fun _ _ w _ i => mul_le_mul_left' (w i) _ }
+    OrderedCommMonoid (∀ i, Z i) where
+  __ := Pi.partialOrder
+  __ := Pi.commMonoid
+  mul_le_mul_left _ _ w _ := fun i => mul_le_mul_left' (w i) _
 #align pi.ordered_comm_monoid Pi.orderedCommMonoid
 #align pi.ordered_add_comm_monoid Pi.orderedAddCommMonoid
 
@@ -49,9 +50,11 @@ instance existsMulOfLe {ι : Type*} {α : ι → Type*} [∀ i, LE (α i)] [∀ 
       "The product of a family of canonically ordered additive monoids is
 a canonically ordered additive monoid."]
 instance {ι : Type*} {Z : ι → Type*} [∀ i, CanonicallyOrderedCommMonoid (Z i)] :
-    CanonicallyOrderedCommMonoid (∀ i, Z i) :=
-  { Pi.orderBot, Pi.orderedCommMonoid, Pi.existsMulOfLe with
-    le_self_mul := fun _ _ _ => le_self_mul }
+    CanonicallyOrderedCommMonoid (∀ i, Z i) where
+  __ := Pi.orderBot
+  __ := Pi.orderedCommMonoid
+  __ := Pi.existsMulOfLe
+  le_self_mul _ _ := fun _ => le_self_mul
 
 @[to_additive]
 instance orderedCancelCommMonoid [∀ i, OrderedCancelCommMonoid <| f i] :
@@ -72,31 +75,36 @@ instance orderedCancelCommMonoid [∀ i, OrderedCancelCommMonoid <| f i] :
 #align pi.ordered_cancel_add_comm_monoid Pi.orderedAddCancelCommMonoid
 
 @[to_additive]
-instance orderedCommGroup [∀ i, OrderedCommGroup <| f i] : OrderedCommGroup (∀ i : I, f i) :=
-  { Pi.commGroup, Pi.orderedCommMonoid with
-    npow := Monoid.npow }
+instance orderedCommGroup [∀ i, OrderedCommGroup <| f i] : OrderedCommGroup (∀ i : I, f i) where
+  __ := Pi.commGroup
+  __ := Pi.orderedCommMonoid
+  npow := Monoid.npow
 #align pi.ordered_comm_group Pi.orderedCommGroup
 #align pi.ordered_add_comm_group Pi.orderedAddCommGroup
 
-instance orderedSemiring [∀ i, OrderedSemiring (f i)] : OrderedSemiring (∀ i, f i) :=
-  { Pi.semiring,
-    Pi.partialOrder with
-    add_le_add_left := fun _ _ hab _ _ => add_le_add_left (hab _) _
-    zero_le_one := fun i => zero_le_one (α := f i)
-    mul_le_mul_of_nonneg_left := fun _ _ _ hab hc _ => mul_le_mul_of_nonneg_left (hab _) <| hc _
-    mul_le_mul_of_nonneg_right := fun _ _ _ hab hc _ => mul_le_mul_of_nonneg_right (hab _) <| hc _ }
+instance orderedSemiring [∀ i, OrderedSemiring (f i)] : OrderedSemiring (∀ i, f i) where
+  __ := Pi.semiring
+  __ := Pi.partialOrder
+  add_le_add_left _ _ hab _ := fun _ => add_le_add_left (hab _) _
+  zero_le_one := fun i => zero_le_one (α := f i)
+  mul_le_mul_of_nonneg_left _ _ _ hab hc := fun _ => mul_le_mul_of_nonneg_left (hab _) <| hc _
+  mul_le_mul_of_nonneg_right _ _ _ hab hc := fun _ => mul_le_mul_of_nonneg_right (hab _) <| hc _
 #align pi.ordered_semiring Pi.orderedSemiring
 
-instance orderedCommSemiring [∀ i, OrderedCommSemiring (f i)] : OrderedCommSemiring (∀ i, f i) :=
-  { Pi.commSemiring, Pi.orderedSemiring with }
+instance orderedCommSemiring [∀ i, OrderedCommSemiring (f i)] : OrderedCommSemiring (∀ i, f i) where
+  __ := Pi.commSemiring
+  __ := Pi.orderedSemiring
 #align pi.ordered_comm_semiring Pi.orderedCommSemiring
 
-instance orderedRing [∀ i, OrderedRing (f i)] : OrderedRing (∀ i, f i) :=
-  { Pi.ring, Pi.orderedSemiring with mul_nonneg := fun _ _ ha hb _ => mul_nonneg (ha _) (hb _) }
+instance orderedRing [∀ i, OrderedRing (f i)] : OrderedRing (∀ i, f i) where
+  __ := Pi.ring
+  __ := Pi.orderedSemiring
+  mul_nonneg _ _ ha hb := fun _ => mul_nonneg (ha _) (hb _)
 #align pi.ordered_ring Pi.orderedRing
 
-instance orderedCommRing [∀ i, OrderedCommRing (f i)] : OrderedCommRing (∀ i, f i) :=
-  { Pi.commRing, Pi.orderedRing with }
+instance orderedCommRing [∀ i, OrderedCommRing (f i)] : OrderedCommRing (∀ i, f i) where
+  __ := Pi.commRing
+  __ := Pi.orderedRing
 #align pi.ordered_comm_ring Pi.orderedCommRing
 
 end Pi

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -112,11 +112,11 @@ theorem inf_sdiff_inf (x y : α) : x \ y ⊓ (x ⊓ y) = ⊥ := by rw [inf_comm,
 #align inf_sdiff_inf inf_sdiff_inf
 
 -- see Note [lower instance priority]
-instance (priority := 100) GeneralizedBooleanAlgebra.toOrderBot : OrderBot α :=
-  { GeneralizedBooleanAlgebra.toBot with
-    bot_le := fun a => by
-      rw [← inf_inf_sdiff a a, inf_assoc]
-      exact inf_le_left }
+instance (priority := 100) GeneralizedBooleanAlgebra.toOrderBot : OrderBot α where
+  __ := GeneralizedBooleanAlgebra.toBot
+  bot_le a := by
+    rw [← inf_inf_sdiff a a, inf_assoc]
+    exact inf_le_left
 #align generalized_boolean_algebra.to_order_bot GeneralizedBooleanAlgebra.toOrderBot
 
 theorem disjoint_inf_sdiff : Disjoint (x ⊓ y) (x \ y) :=
@@ -178,32 +178,33 @@ theorem inf_sdiff_self_left : y \ x ⊓ x = ⊥ := by rw [inf_comm, inf_sdiff_se
 
 -- see Note [lower instance priority]
 instance (priority := 100) GeneralizedBooleanAlgebra.toGeneralizedCoheytingAlgebra :
-    GeneralizedCoheytingAlgebra α :=
-  { ‹GeneralizedBooleanAlgebra α›, GeneralizedBooleanAlgebra.toOrderBot with
-    sdiff := (· \ ·),
-    sdiff_le_iff := fun y x z =>
-      ⟨fun h =>
-        le_of_inf_le_sup_le
-          (le_of_eq
-            (calc
-              y ⊓ y \ x = y \ x := inf_of_le_right sdiff_le'
-              _ = x ⊓ y \ x ⊔ z ⊓ y \ x :=
-                by rw [inf_eq_right.2 h, inf_sdiff_self_right, bot_sup_eq]
-              _ = (x ⊔ z) ⊓ y \ x := inf_sup_right.symm))
+    GeneralizedCoheytingAlgebra α where
+  __ := ‹GeneralizedBooleanAlgebra α›
+  __ := GeneralizedBooleanAlgebra.toOrderBot
+  sdiff := (· \ ·)
+  sdiff_le_iff y x z :=
+    ⟨fun h =>
+      le_of_inf_le_sup_le
+        (le_of_eq
           (calc
-            y ⊔ y \ x = y := sup_of_le_left sdiff_le'
-            _ ≤ y ⊔ (x ⊔ z) := le_sup_left
-            _ = y \ x ⊔ x ⊔ z := by rw [← sup_assoc, ← @sdiff_sup_self' _ x y]
-            _ = x ⊔ z ⊔ y \ x := by ac_rfl),
-        fun h =>
-        le_of_inf_le_sup_le
-          (calc
-            y \ x ⊓ x = ⊥ := inf_sdiff_self_left
-            _ ≤ z ⊓ x := bot_le)
-          (calc
-            y \ x ⊔ x = y ⊔ x := sdiff_sup_self'
-            _ ≤ x ⊔ z ⊔ x := sup_le_sup_right h x
-            _ ≤ z ⊔ x := by rw [sup_assoc, sup_comm, sup_assoc, sup_idem])⟩ }
+            y ⊓ y \ x = y \ x := inf_of_le_right sdiff_le'
+            _ = x ⊓ y \ x ⊔ z ⊓ y \ x :=
+              by rw [inf_eq_right.2 h, inf_sdiff_self_right, bot_sup_eq]
+            _ = (x ⊔ z) ⊓ y \ x := inf_sup_right.symm))
+        (calc
+          y ⊔ y \ x = y := sup_of_le_left sdiff_le'
+          _ ≤ y ⊔ (x ⊔ z) := le_sup_left
+          _ = y \ x ⊔ x ⊔ z := by rw [← sup_assoc, ← @sdiff_sup_self' _ x y]
+          _ = x ⊔ z ⊔ y \ x := by ac_rfl),
+      fun h =>
+      le_of_inf_le_sup_le
+        (calc
+          y \ x ⊓ x = ⊥ := inf_sdiff_self_left
+          _ ≤ z ⊓ x := bot_le)
+        (calc
+          y \ x ⊔ x = y ⊔ x := sdiff_sup_self'
+          _ ≤ x ⊔ z ⊔ x := sup_le_sup_right h x
+          _ ≤ z ⊔ x := by rw [sup_assoc, sup_comm, sup_assoc, sup_idem])⟩
 #align generalized_boolean_algebra.to_generalized_coheyting_algebra GeneralizedBooleanAlgebra.toGeneralizedCoheytingAlgebra
 
 theorem disjoint_sdiff_self_left : Disjoint (y \ x) x :=
@@ -556,15 +557,17 @@ instance (priority := 100) BooleanAlgebra.toBoundedOrder [h : BooleanAlgebra α]
 /-- A bounded generalized boolean algebra is a boolean algebra. -/
 @[reducible]
 def GeneralizedBooleanAlgebra.toBooleanAlgebra [GeneralizedBooleanAlgebra α] [OrderTop α] :
-    BooleanAlgebra α :=
-  { ‹GeneralizedBooleanAlgebra α›, GeneralizedBooleanAlgebra.toOrderBot, ‹OrderTop α› with
-    compl := fun a => ⊤ \ a,
-    inf_compl_le_bot := fun _ => disjoint_sdiff_self_right.le_bot,
-    top_le_sup_compl := fun _ => le_sup_sdiff,
-    sdiff_eq := fun _ _ => by
+    BooleanAlgebra α where
+  __ := ‹GeneralizedBooleanAlgebra α›
+  __ := GeneralizedBooleanAlgebra.toOrderBot
+  __ := ‹OrderTop α›
+  compl a := ⊤ \ a
+  inf_compl_le_bot _ := disjoint_sdiff_self_right.le_bot
+  top_le_sup_compl _ := le_sup_sdiff
+  sdiff_eq _ _ := by
       -- Porting note: changed `rw` to `erw` here.
       -- https://github.com/leanprover-community/mathlib4/issues/5164
-      erw [← inf_sdiff_assoc, inf_top_eq] }
+      erw [← inf_sdiff_assoc, inf_top_eq]
 #align generalized_boolean_algebra.to_boolean_algebra GeneralizedBooleanAlgebra.toBooleanAlgebra
 
 section BooleanAlgebra
@@ -603,20 +606,21 @@ instance (priority := 100) BooleanAlgebra.toComplementedLattice : ComplementedLa
 
 -- see Note [lower instance priority]
 instance (priority := 100) BooleanAlgebra.toGeneralizedBooleanAlgebra :
-    GeneralizedBooleanAlgebra α :=
-  { ‹BooleanAlgebra α› with
-    sup_inf_sdiff := fun a b => by rw [sdiff_eq, ← inf_sup_left, sup_compl_eq_top, inf_top_eq],
-    inf_inf_sdiff := fun a b => by
-      rw [sdiff_eq, ← inf_inf_distrib_left, inf_compl_eq_bot', inf_bot_eq] }
+    GeneralizedBooleanAlgebra α where
+  __ := ‹BooleanAlgebra α›
+  sup_inf_sdiff a b := by rw [sdiff_eq, ← inf_sup_left, sup_compl_eq_top, inf_top_eq]
+  inf_inf_sdiff a b := by
+    rw [sdiff_eq, ← inf_inf_distrib_left, inf_compl_eq_bot', inf_bot_eq]
 #align boolean_algebra.to_generalized_boolean_algebra BooleanAlgebra.toGeneralizedBooleanAlgebra
 
 -- See note [lower instance priority]
-instance (priority := 100) BooleanAlgebra.toBiheytingAlgebra : BiheytingAlgebra α :=
-  { ‹BooleanAlgebra α›, GeneralizedBooleanAlgebra.toGeneralizedCoheytingAlgebra with
-    hnot := compl,
-    le_himp_iff := fun a b c => by rw [himp_eq, isCompl_compl.le_sup_right_iff_inf_left_le],
-    himp_bot := fun _ => _root_.himp_eq.trans bot_sup_eq,
-    top_sdiff := fun a => by rw [sdiff_eq, top_inf_eq]; rfl }
+instance (priority := 100) BooleanAlgebra.toBiheytingAlgebra : BiheytingAlgebra α where
+  __ := ‹BooleanAlgebra α›
+  __ := GeneralizedBooleanAlgebra.toGeneralizedCoheytingAlgebra
+  hnot := compl
+  le_himp_iff a b c := by rw [himp_eq, isCompl_compl.le_sup_right_iff_inf_left_le]
+  himp_bot _ := _root_.himp_eq.trans bot_sup_eq
+  top_sdiff a := by rw [sdiff_eq, top_inf_eq]; rfl
 #align boolean_algebra.to_biheyting_algebra BooleanAlgebra.toBiheytingAlgebra
 
 @[simp]
@@ -724,15 +728,15 @@ theorem compl_le_iff_compl_le : xᶜ ≤ y ↔ yᶜ ≤ x :=
 theorem sdiff_compl : x \ yᶜ = x ⊓ y := by rw [sdiff_eq, compl_compl]
 #align sdiff_compl sdiff_compl
 
-instance OrderDual.booleanAlgebra (α) [BooleanAlgebra α] : BooleanAlgebra αᵒᵈ :=
-  { OrderDual.distribLattice α, OrderDual.boundedOrder α with
-    compl := fun a => toDual (ofDual aᶜ),
-    sdiff :=
-      fun a b => toDual (ofDual b ⇨ ofDual a), himp := fun a b => toDual (ofDual b \ ofDual a),
-    inf_compl_le_bot := fun a => (@codisjoint_hnot_right _ _ (ofDual a)).top_le,
-    top_le_sup_compl := fun a => (@disjoint_compl_right _ _ (ofDual a)).le_bot,
-    sdiff_eq := fun _ _ => @himp_eq α _ _ _,
-    himp_eq := fun _ _ => @sdiff_eq α _ _ _, }
+instance OrderDual.booleanAlgebra (α) [BooleanAlgebra α] : BooleanAlgebra αᵒᵈ where
+  __ := OrderDual.distribLattice α
+  __ := OrderDual.boundedOrder α
+  compl a := toDual (ofDual aᶜ)
+  sdiff a b := toDual (ofDual b ⇨ ofDual a); himp := fun a b => toDual (ofDual b \ ofDual a)
+  inf_compl_le_bot a := (@codisjoint_hnot_right _ _ (ofDual a)).top_le
+  top_le_sup_compl a := (@disjoint_compl_right _ _ (ofDual a)).le_bot
+  sdiff_eq _ _ := @himp_eq α _ _ _
+  himp_eq _ _ := @sdiff_eq α _ _ _
 
 @[simp]
 theorem sup_inf_inf_compl : x ⊓ y ⊔ x ⊓ yᶜ = x := by rw [← sdiff_eq, sup_inf_sdiff _ _]
@@ -786,12 +790,13 @@ lemma himp_ne_right : x ⇨ y ≠ x ↔ x ≠ ⊤ ∨ y ≠ ⊤ := himp_eq_left.
 
 end BooleanAlgebra
 
-instance Prop.booleanAlgebra : BooleanAlgebra Prop :=
-  { Prop.heytingAlgebra, GeneralizedHeytingAlgebra.toDistribLattice with
-    compl := Not,
-    himp_eq := fun p q => propext imp_iff_or_not,
-    inf_compl_le_bot := fun p ⟨Hp, Hpc⟩ => Hpc Hp,
-    top_le_sup_compl := fun p _ => Classical.em p }
+instance Prop.booleanAlgebra : BooleanAlgebra Prop where
+  __ := Prop.heytingAlgebra
+  __ := GeneralizedHeytingAlgebra.toDistribLattice
+  compl := Not
+  himp_eq p q := propext imp_iff_or_not
+  inf_compl_le_bot p H := H.2 H.1
+  top_le_sup_compl p _ := Classical.em p
 #align Prop.boolean_algebra Prop.booleanAlgebra
 
 instance Prod.booleanAlgebra (α β) [BooleanAlgebra α] [BooleanAlgebra β] :
@@ -804,12 +809,14 @@ instance Prod.booleanAlgebra (α β) [BooleanAlgebra α] [BooleanAlgebra β] :
   top_le_sup_compl x := by constructor <;> simp
 
 instance Pi.booleanAlgebra {ι : Type u} {α : ι → Type v} [∀ i, BooleanAlgebra (α i)] :
-    BooleanAlgebra (∀ i, α i) :=
-  { Pi.sdiff, Pi.heytingAlgebra, @Pi.distribLattice ι α _ with
-    sdiff_eq := fun _ _ => funext fun _ => sdiff_eq,
-    himp_eq := fun _ _ => funext fun _ => himp_eq,
-    inf_compl_le_bot := fun _ _ => BooleanAlgebra.inf_compl_le_bot _,
-    top_le_sup_compl := fun _ _ => BooleanAlgebra.top_le_sup_compl _ }
+    BooleanAlgebra (∀ i, α i) where
+  __ := Pi.sdiff
+  __ := Pi.heytingAlgebra
+  __ := @Pi.distribLattice ι α _
+  sdiff_eq _ _ := funext fun _ => sdiff_eq
+  himp_eq _ _ := funext fun _ => himp_eq
+  inf_compl_le_bot _ _ := BooleanAlgebra.inf_compl_le_bot _
+  top_le_sup_compl _ _ := BooleanAlgebra.top_le_sup_compl _
 #align pi.boolean_algebra Pi.booleanAlgebra
 
 instance Bool.instBooleanAlgebra : BooleanAlgebra Bool where
@@ -844,11 +851,11 @@ protected def Function.Injective.generalizedBooleanAlgebra [Sup α] [Inf α] [Bo
     [GeneralizedBooleanAlgebra β] (f : α → β) (hf : Injective f)
     (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
     (map_bot : f ⊥ = ⊥) (map_sdiff : ∀ a b, f (a \ b) = f a \ f b) :
-    GeneralizedBooleanAlgebra α :=
-  { hf.generalizedCoheytingAlgebra f map_sup map_inf map_bot map_sdiff,
-    hf.distribLattice f map_sup map_inf with
-    sup_inf_sdiff := fun a b => hf <| by erw [map_sup, map_sdiff, map_inf, sup_inf_sdiff],
-    inf_inf_sdiff := fun a b => hf <| by erw [map_inf, map_sdiff, map_inf, inf_inf_sdiff, map_bot] }
+    GeneralizedBooleanAlgebra α where
+  __ := hf.generalizedCoheytingAlgebra f map_sup map_inf map_bot map_sdiff
+  __ := hf.distribLattice f map_sup map_inf
+  sup_inf_sdiff a b := hf <| by erw [map_sup, map_sdiff, map_inf, sup_inf_sdiff]
+  inf_inf_sdiff a b := hf <| by erw [map_inf, map_sdiff, map_inf, inf_inf_sdiff, map_bot]
 #align function.injective.generalized_boolean_algebra Function.Injective.generalizedBooleanAlgebra
 
 -- See note [reducible non-instances]
@@ -858,19 +865,17 @@ protected def Function.Injective.booleanAlgebra [Sup α] [Inf α] [Top α] [Bot 
     [SDiff α] [BooleanAlgebra β] (f : α → β) (hf : Injective f)
     (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
     (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) (map_compl : ∀ a, f aᶜ = (f a)ᶜ)
-    (map_sdiff : ∀ a b, f (a \ b) = f a \ f b) : BooleanAlgebra α :=
-  { hf.generalizedBooleanAlgebra f map_sup map_inf map_bot map_sdiff with
-    compl := compl,
-    top := ⊤,
-    le_top := fun a => (@le_top β _ _ _).trans map_top.ge,
-    bot_le := fun a => map_bot.le.trans bot_le,
-    inf_compl_le_bot :=
-      fun a => ((map_inf _ _).trans <| by rw [map_compl, inf_compl_eq_bot, map_bot]).le,
-    top_le_sup_compl :=
-      fun a => ((map_sup _ _).trans <| by rw [map_compl, sup_compl_eq_top, map_top]).ge,
-    sdiff_eq := fun a b => by
-      refine hf ((map_sdiff _ _).trans (sdiff_eq.trans ?_))
-      rw [map_inf, map_compl] }
+    (map_sdiff : ∀ a b, f (a \ b) = f a \ f b) : BooleanAlgebra α where
+  __ := hf.generalizedBooleanAlgebra f map_sup map_inf map_bot map_sdiff
+  compl := compl
+  top := ⊤
+  le_top a := (@le_top β _ _ _).trans map_top.ge
+  bot_le a := map_bot.le.trans bot_le
+  inf_compl_le_bot a := ((map_inf _ _).trans <| by rw [map_compl, inf_compl_eq_bot, map_bot]).le
+  top_le_sup_compl a := ((map_sup _ _).trans <| by rw [map_compl, sup_compl_eq_top, map_top]).ge
+  sdiff_eq a b := by
+    refine hf ((map_sdiff _ _).trans (sdiff_eq.trans ?_))
+    rw [map_inf, map_compl]
 #align function.injective.boolean_algebra Function.Injective.booleanAlgebra
 
 end lift

--- a/Mathlib/Order/BoundedOrder.lean
+++ b/Mathlib/Order/BoundedOrder.lean
@@ -622,11 +622,11 @@ theorem top_def [∀ i, Top (α' i)] : (⊤ : ∀ i, α' i) = fun _ => ⊤ :=
   rfl
 #align pi.top_def Pi.top_def
 
-instance orderTop [∀ i, LE (α' i)] [∀ i, OrderTop (α' i)] : OrderTop (∀ i, α' i) :=
-  { inferInstanceAs (Top (∀ i, α' i)) with le_top := fun _ _ => le_top }
+instance orderTop [∀ i, LE (α' i)] [∀ i, OrderTop (α' i)] : OrderTop (∀ i, α' i) where
+  le_top _ := fun _ => le_top
 
-instance orderBot [∀ i, LE (α' i)] [∀ i, OrderBot (α' i)] : OrderBot (∀ i, α' i) :=
-  { inferInstanceAs (Bot (∀ i, α' i)) with bot_le := fun _ _ => bot_le }
+instance orderBot [∀ i, LE (α' i)] [∀ i, OrderBot (α' i)] : OrderBot (∀ i, α' i) where
+  bot_le _ := fun _ => bot_le
 
 instance boundedOrder [∀ i, LE (α' i)] [∀ i, BoundedOrder (α' i)] : BoundedOrder (∀ i, α' i) where
   __ := inferInstanceAs (OrderTop (∀ i, α' i))
@@ -691,8 +691,10 @@ def OrderBot.lift [LE α] [Bot α] [LE β] [OrderBot β] (f : α → β)
 /-- Pullback a `BoundedOrder`. -/
 @[reducible]
 def BoundedOrder.lift [LE α] [Top α] [Bot α] [LE β] [BoundedOrder β] (f : α → β)
-    (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) : BoundedOrder α :=
-  { OrderTop.lift f map_le map_top, OrderBot.lift f map_le map_bot with }
+    (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) :
+    BoundedOrder α where
+  __ := OrderTop.lift f map_le map_top
+  __ := OrderBot.lift f map_le map_bot
 #align bounded_order.lift BoundedOrder.lift
 
 end lift
@@ -724,8 +726,9 @@ protected def orderTop [LE α] [OrderTop α] (htop : p ⊤) : OrderTop { x : α 
 /-- A subtype remains a bounded order if the property holds at `⊥` and `⊤`. -/
 @[reducible]
 protected def boundedOrder [LE α] [BoundedOrder α] (hbot : p ⊥) (htop : p ⊤) :
-    BoundedOrder (Subtype p) :=
-  { Subtype.orderTop htop, Subtype.orderBot hbot with }
+    BoundedOrder (Subtype p) where
+  __ := Subtype.orderTop htop
+  __ := Subtype.orderBot hbot
 #align subtype.bounded_order Subtype.boundedOrder
 
 variable [PartialOrder α]

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -187,8 +187,9 @@ section Frame
 
 variable [Frame α] {s t : Set α} {a b : α}
 
-instance OrderDual.coframe : Coframe αᵒᵈ :=
-  { OrderDual.completeLattice α with iInf_sup_le_sup_sInf := @Frame.inf_sSup_le_iSup_inf α _ }
+instance OrderDual.coframe : Coframe αᵒᵈ where
+  __ := OrderDual.completeLattice α
+  iInf_sup_le_sup_sInf := @Frame.inf_sSup_le_iSup_inf α _
 #align order_dual.coframe OrderDual.coframe
 
 theorem inf_sSup_eq : a ⊓ sSup s = ⨆ b ∈ s, a ⊓ b :=
@@ -277,10 +278,10 @@ theorem iSup_inf_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (swap (·
   @iSup_inf_of_monotone α _ ιᵒᵈ _ _ f g hf.dual_left hg.dual_left
 #align supr_inf_of_antitone iSup_inf_of_antitone
 
-instance Pi.frame {ι : Type*} {π : ι → Type*} [∀ i, Frame (π i)] : Frame (∀ i, π i) :=
-  { Pi.completeLattice with
-    inf_sSup_le_iSup_inf := fun a s i => by
-      simp only [sSup_apply, iSup_apply, inf_apply, inf_iSup_eq, ← iSup_subtype'']; rfl }
+instance Pi.frame {ι : Type*} {π : ι → Type*} [∀ i, Frame (π i)] : Frame (∀ i, π i) where
+  __ := Pi.completeLattice
+  inf_sSup_le_iSup_inf a s := fun i => by
+    simp only [sSup_apply, iSup_apply, inf_apply, inf_iSup_eq, ← iSup_subtype'']; rfl
 #align pi.frame Pi.frame
 
 -- see Note [lower instance priority]
@@ -295,8 +296,9 @@ section Coframe
 
 variable [Coframe α] {s t : Set α} {a b : α}
 
-instance OrderDual.frame : Frame αᵒᵈ :=
-  { OrderDual.completeLattice α with inf_sSup_le_iSup_inf := @Coframe.iInf_sup_le_sup_sInf α _ }
+instance OrderDual.frame : Frame αᵒᵈ where
+  __ := OrderDual.completeLattice α
+  inf_sSup_le_iSup_inf := @Coframe.iInf_sup_le_sup_sInf α _
 #align order_dual.frame OrderDual.frame
 
 theorem sup_sInf_eq : a ⊔ sInf s = ⨅ b ∈ s, a ⊔ b :=
@@ -352,17 +354,17 @@ theorem iInf_sup_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (· ≤ �
   @iSup_inf_of_monotone αᵒᵈ _ _ _ _ _ _ hf.dual_right hg.dual_right
 #align infi_sup_of_antitone iInf_sup_of_antitone
 
-instance Pi.coframe {ι : Type*} {π : ι → Type*} [∀ i, Coframe (π i)] : Coframe (∀ i, π i) :=
-  { Pi.completeLattice with
-    iInf_sup_le_sup_sInf := fun a s i => by
-      simp only [sInf_apply, iInf_apply, sup_apply, sup_iInf_eq, ← iInf_subtype'']; rfl }
+instance Pi.coframe {ι : Type*} {π : ι → Type*} [∀ i, Coframe (π i)] : Coframe (∀ i, π i) where
+  __ := Pi.completeLattice
+  iInf_sup_le_sup_sInf a s := fun i => by
+    simp only [sInf_apply, iInf_apply, sup_apply, sup_iInf_eq, ← iInf_subtype'']; rfl
 #align pi.coframe Pi.coframe
 
 -- see Note [lower instance priority]
-instance (priority := 100) Coframe.toDistribLattice : DistribLattice α :=
-  { ‹Coframe α› with
-    le_sup_inf := fun a b c => by
-      rw [← sInf_pair, ← sInf_pair, sup_sInf_eq, ← sInf_image, image_pair] }
+instance (priority := 100) Coframe.toDistribLattice : DistribLattice α where
+  __ := ‹Coframe α›
+  le_sup_inf a b c := by
+    rw [← sInf_pair, ← sInf_pair, sup_sInf_eq, ← sInf_image, image_pair]
 #align coframe.to_distrib_lattice Coframe.toDistribLattice
 
 end Coframe
@@ -375,8 +377,9 @@ variable [CompleteDistribLattice α] {a b : α} {s t : Set α}
 -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Performance.20issue.20with.20.60CompleteBooleanAlgebra.60
 -- but not yet resolved.
 instance OrderDual.completeDistribLattice (α) [CompleteDistribLattice α] :
-    CompleteDistribLattice αᵒᵈ :=
-  { OrderDual.frame, OrderDual.coframe with }
+    CompleteDistribLattice αᵒᵈ where
+  __ := OrderDual.frame
+  __ := OrderDual.coframe
 
 instance Prod.completeDistribLattice (α β)
     [CompleteDistribLattice α] [CompleteDistribLattice β] :
@@ -386,8 +389,9 @@ instance Prod.completeDistribLattice (α β)
   __ := Prod.coframe α β
 
 instance Pi.completeDistribLattice {ι : Type*} {π : ι → Type*}
-    [∀ i, CompleteDistribLattice (π i)] : CompleteDistribLattice (∀ i, π i) :=
-  { Pi.frame, Pi.coframe with }
+    [∀ i, CompleteDistribLattice (π i)] : CompleteDistribLattice (∀ i, π i) where
+  __ := Pi.frame
+  __ := Pi.coframe
 #align pi.complete_distrib_lattice Pi.completeDistribLattice
 
 end CompleteDistribLattice
@@ -427,8 +431,9 @@ instance Prod.completeBooleanAlgebra (α β)
   __ := Prod.completeDistribLattice α β
 
 instance Pi.completeBooleanAlgebra {ι : Type*} {π : ι → Type*}
-    [∀ i, CompleteBooleanAlgebra (π i)] : CompleteBooleanAlgebra (∀ i, π i) :=
-  { Pi.booleanAlgebra, Pi.completeDistribLattice with }
+    [∀ i, CompleteBooleanAlgebra (π i)] : CompleteBooleanAlgebra (∀ i, π i) where
+  __ := Pi.booleanAlgebra
+  __ := Pi.completeDistribLattice
 #align pi.complete_boolean_algebra Pi.completeBooleanAlgebra
 
 instance OrderDual.completeBooleanAlgebra (α) [CompleteBooleanAlgebra α] :
@@ -512,13 +517,13 @@ protected def Function.Injective.frame [Sup α] [Inf α] [SupSet α] [InfSet α]
     [Frame β] (f : α → β) (hf : Injective f) (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b)
     (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b) (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a)
     (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a) (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) :
-    Frame α :=
-  { hf.completeLattice f map_sup map_inf map_sSup map_sInf map_top map_bot with
-    inf_sSup_le_iSup_inf := fun a s => by
+    Frame α where
+  __ := hf.completeLattice f map_sup map_inf map_sSup map_sInf map_top map_bot
+  inf_sSup_le_iSup_inf a s := by
       change f (a ⊓ sSup s) ≤ f _
       rw [← sSup_image, map_inf, map_sSup s, inf_iSup₂_eq]
       simp_rw [← map_inf]
-      exact ((map_sSup _).trans iSup_image).ge }
+      exact ((map_sSup _).trans iSup_image).ge
 #align function.injective.frame Function.Injective.frame
 
 -- See note [reducible non-instances]
@@ -528,13 +533,13 @@ protected def Function.Injective.coframe [Sup α] [Inf α] [SupSet α] [InfSet �
     [Coframe β] (f : α → β) (hf : Injective f) (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b)
     (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b) (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a)
     (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a) (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) :
-    Coframe α :=
-  { hf.completeLattice f map_sup map_inf map_sSup map_sInf map_top map_bot with
-    iInf_sup_le_sup_sInf := fun a s => by
+    Coframe α where
+  __ := hf.completeLattice f map_sup map_inf map_sSup map_sInf map_top map_bot
+  iInf_sup_le_sup_sInf a s := by
       change f _ ≤ f (a ⊔ sInf s)
       rw [← sInf_image, map_sup, map_sInf s, sup_iInf₂_eq]
       simp_rw [← map_sup]
-      exact ((map_sInf _).trans iInf_image).le }
+      exact ((map_sInf _).trans iInf_image).le
 #align function.injective.coframe Function.Injective.coframe
 
 -- See note [reducible non-instances]
@@ -544,9 +549,9 @@ protected def Function.Injective.completeDistribLattice [Sup α] [Inf α] [SupSe
     [Top α] [Bot α] [CompleteDistribLattice β] (f : α → β) (hf : Function.Injective f)
     (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
     (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a)
-    (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) : CompleteDistribLattice α :=
-  { hf.frame f map_sup map_inf map_sSup map_sInf map_top map_bot,
-    hf.coframe f map_sup map_inf map_sSup map_sInf map_top map_bot with }
+    (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) : CompleteDistribLattice α where
+  __ := hf.frame f map_sup map_inf map_sSup map_sInf map_top map_bot
+  __ := hf.coframe f map_sup map_inf map_sSup map_sInf map_top map_bot
 #align function.injective.complete_distrib_lattice Function.Injective.completeDistribLattice
 
 -- See note [reducible non-instances]
@@ -571,9 +576,9 @@ protected def Function.Injective.completeBooleanAlgebra [Sup α] [Inf α] [SupSe
     (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b) (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a)
     (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a) (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥)
     (map_compl : ∀ a, f aᶜ = (f a)ᶜ) (map_sdiff : ∀ a b, f (a \ b) = f a \ f b) :
-    CompleteBooleanAlgebra α :=
-  { hf.completeDistribLattice f map_sup map_inf map_sSup map_sInf map_top map_bot,
-    hf.booleanAlgebra f map_sup map_inf map_top map_bot map_compl map_sdiff with }
+    CompleteBooleanAlgebra α where
+  __ := hf.completeDistribLattice f map_sup map_inf map_sSup map_sInf map_top map_bot
+  __ := hf.booleanAlgebra f map_sup map_inf map_top map_bot map_compl map_sdiff
 #align function.injective.complete_boolean_algebra Function.Injective.completeBooleanAlgebra
 
 -- See note [reducible non-instances]

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -217,37 +217,37 @@ poor definitional equalities.  If other fields are known explicitly, they should
 provided; for example, if `inf` is known explicitly, construct the `CompleteLattice`
 instance as
 ```
-instance : CompleteLattice my_T :=
-  { inf := better_inf,
-    le_inf := ...,
-    inf_le_right := ...,
-    inf_le_left := ...
-    -- don't care to fix sup, sSup, bot, top
-    ..completeLatticeOfInf my_T _ }
+instance : CompleteLattice my_T where
+  inf := better_inf
+  le_inf := ...
+  inf_le_right := ...
+  inf_le_left := ...
+  -- don't care to fix sup, sSup, bot, top
+  __ := completeLatticeOfInf my_T _
 ```
 -/
 def completeLatticeOfInf (α : Type*) [H1 : PartialOrder α] [H2 : InfSet α]
-    (isGLB_sInf : ∀ s : Set α, IsGLB s (sInf s)) : CompleteLattice α :=
-  { H1, H2 with
-    bot := sInf univ
-    bot_le := fun x => (isGLB_sInf univ).1 trivial
-    top := sInf ∅
-    le_top := fun a => (isGLB_sInf ∅).2 <| by simp
-    sup := fun a b => sInf { x : α | a ≤ x ∧ b ≤ x }
-    inf := fun a b => sInf {a, b}
-    le_inf := fun a b c hab hac => by
-      apply (isGLB_sInf _).2
-      simp [*]
-    inf_le_right := fun a b => (isGLB_sInf _).1 <| mem_insert_of_mem _ <| mem_singleton _
-    inf_le_left := fun a b => (isGLB_sInf _).1 <| mem_insert _ _
-    sup_le := fun a b c hac hbc => (isGLB_sInf _).1 <| by simp [*]
-    le_sup_left := fun a b => (isGLB_sInf _).2 fun x => And.left
-    le_sup_right := fun a b => (isGLB_sInf _).2 fun x => And.right
-    le_sInf := fun s a ha => (isGLB_sInf s).2 ha
-    sInf_le := fun s a ha => (isGLB_sInf s).1 ha
-    sSup := fun s => sInf (upperBounds s)
-    le_sSup := fun s a ha => (isGLB_sInf (upperBounds s)).2 fun b hb => hb ha
-    sSup_le := fun s a ha => (isGLB_sInf (upperBounds s)).1 ha }
+    (isGLB_sInf : ∀ s : Set α, IsGLB s (sInf s)) : CompleteLattice α where
+  __ := H1; __ := H2
+  bot := sInf univ
+  bot_le x := (isGLB_sInf univ).1 trivial
+  top := sInf ∅
+  le_top a := (isGLB_sInf ∅).2 <| by simp
+  sup a b := sInf { x : α | a ≤ x ∧ b ≤ x }
+  inf a b := sInf {a, b}
+  le_inf a b c hab hac := by
+    apply (isGLB_sInf _).2
+    simp [*]
+  inf_le_right a b := (isGLB_sInf _).1 <| mem_insert_of_mem _ <| mem_singleton _
+  inf_le_left a b := (isGLB_sInf _).1 <| mem_insert _ _
+  sup_le a b c hac hbc := (isGLB_sInf _).1 <| by simp [*]
+  le_sup_left a b := (isGLB_sInf _).2 fun x => And.left
+  le_sup_right a b := (isGLB_sInf _).2 fun x => And.right
+  le_sInf s a ha := (isGLB_sInf s).2 ha
+  sInf_le s a ha := (isGLB_sInf s).1 ha
+  sSup s := sInf (upperBounds s)
+  le_sSup s a ha := (isGLB_sInf (upperBounds s)).2 fun b hb => hb ha
+  sSup_le s a ha := (isGLB_sInf (upperBounds s)).1 ha
 #align complete_lattice_of_Inf completeLatticeOfInf
 
 /-- Any `CompleteSemilatticeInf` is in fact a `CompleteLattice`.
@@ -266,35 +266,35 @@ poor definitional equalities.  If other fields are known explicitly, they should
 provided; for example, if `inf` is known explicitly, construct the `CompleteLattice`
 instance as
 ```
-instance : CompleteLattice my_T :=
-  { inf := better_inf,
-    le_inf := ...,
-    inf_le_right := ...,
-    inf_le_left := ...
-    -- don't care to fix sup, sInf, bot, top
-    ..completeLatticeOfSup my_T _ }
+instance : CompleteLattice my_T where
+  inf := better_inf
+  le_inf := ...
+  inf_le_right := ...
+  inf_le_left := ...
+  -- don't care to fix sup, sInf, bot, top
+  __ := completeLatticeOfSup my_T _
 ```
 -/
 def completeLatticeOfSup (α : Type*) [H1 : PartialOrder α] [H2 : SupSet α]
-    (isLUB_sSup : ∀ s : Set α, IsLUB s (sSup s)) : CompleteLattice α :=
-  { H1, H2 with
-    top := sSup univ
-    le_top := fun x => (isLUB_sSup univ).1 trivial
-    bot := sSup ∅
-    bot_le := fun x => (isLUB_sSup ∅).2 <| by simp
-    sup := fun a b => sSup {a, b}
-    sup_le := fun a b c hac hbc => (isLUB_sSup _).2 (by simp [*])
-    le_sup_left := fun a b => (isLUB_sSup _).1 <| mem_insert _ _
-    le_sup_right := fun a b => (isLUB_sSup _).1 <| mem_insert_of_mem _ <| mem_singleton _
-    inf := fun a b => sSup { x | x ≤ a ∧ x ≤ b }
-    le_inf := fun a b c hab hac => (isLUB_sSup _).1 <| by simp [*]
-    inf_le_left := fun a b => (isLUB_sSup _).2 fun x => And.left
-    inf_le_right := fun a b => (isLUB_sSup _).2 fun x => And.right
-    sInf := fun s => sSup (lowerBounds s)
-    sSup_le := fun s a ha => (isLUB_sSup s).2 ha
-    le_sSup := fun s a ha => (isLUB_sSup s).1 ha
-    sInf_le := fun s a ha => (isLUB_sSup (lowerBounds s)).2 fun b hb => hb ha
-    le_sInf := fun s a ha => (isLUB_sSup (lowerBounds s)).1 ha }
+    (isLUB_sSup : ∀ s : Set α, IsLUB s (sSup s)) : CompleteLattice α where
+  __ := H1; __ := H2
+  top := sSup univ
+  le_top x := (isLUB_sSup univ).1 trivial
+  bot := sSup ∅
+  bot_le x := (isLUB_sSup ∅).2 <| by simp
+  sup a b := sSup {a, b}
+  sup_le a b c hac hbc := (isLUB_sSup _).2 (by simp [*])
+  le_sup_left a b := (isLUB_sSup _).1 <| mem_insert _ _
+  le_sup_right a b := (isLUB_sSup _).1 <| mem_insert_of_mem _ <| mem_singleton _
+  inf a b := sSup { x | x ≤ a ∧ x ≤ b }
+  le_inf a b c hab hac := (isLUB_sSup _).1 <| by simp [*]
+  inf_le_left a b := (isLUB_sSup _).2 fun x => And.left
+  inf_le_right a b := (isLUB_sSup _).2 fun x => And.right
+  sInf s := sSup (lowerBounds s)
+  sSup_le s a ha := (isLUB_sSup s).2 ha
+  le_sSup s a ha := (isLUB_sSup s).1 ha
+  sInf_le s a ha := (isLUB_sSup (lowerBounds s)).2 fun b hb => hb ha
+  le_sInf s a ha := (isLUB_sSup (lowerBounds s)).1 ha
 #align complete_lattice_of_Sup completeLatticeOfSup
 
 /-- Any `CompleteSemilatticeSup` is in fact a `CompleteLattice`.
@@ -324,32 +324,36 @@ class CompleteLinearOrder (α : Type*) extends CompleteLattice α where
     @decidableLTOfDecidableLE _ _ decidableLE
 #align complete_linear_order CompleteLinearOrder
 
-instance CompleteLinearOrder.toLinearOrder [i : CompleteLinearOrder α] : LinearOrder α :=
-  { i with
-    min := Inf.inf
-    max := Sup.sup
-    min_def := fun a b => by
-      split_ifs with h
-      · simp [h]
-      · simp [(CompleteLinearOrder.le_total a b).resolve_left h]
-    max_def := fun a b => by
-      split_ifs with h
-      · simp [h]
-      · simp [(CompleteLinearOrder.le_total a b).resolve_left h] }
+instance CompleteLinearOrder.toLinearOrder [i : CompleteLinearOrder α] : LinearOrder α where
+  __ := i
+  min := Inf.inf
+  max := Sup.sup
+  min_def a b := by
+    split_ifs with h
+    · simp [h]
+    · simp [(CompleteLinearOrder.le_total a b).resolve_left h]
+  max_def a b := by
+    split_ifs with h
+    · simp [h]
+    · simp [(CompleteLinearOrder.le_total a b).resolve_left h]
 
 namespace OrderDual
 
 variable (α)
 
-instance completeLattice [CompleteLattice α] : CompleteLattice αᵒᵈ :=
-  { OrderDual.lattice α, OrderDual.supSet α, OrderDual.infSet α, OrderDual.boundedOrder α with
-    le_sSup := @CompleteLattice.sInf_le α _
-    sSup_le := @CompleteLattice.le_sInf α _
-    sInf_le := @CompleteLattice.le_sSup α _
-    le_sInf := @CompleteLattice.sSup_le α _ }
+instance completeLattice [CompleteLattice α] : CompleteLattice αᵒᵈ where
+  __ := OrderDual.lattice α
+  __ := OrderDual.supSet α
+  __ := OrderDual.infSet α
+  __ := OrderDual.boundedOrder α
+  le_sSup := @CompleteLattice.sInf_le α _
+  sSup_le := @CompleteLattice.le_sInf α _
+  sInf_le := @CompleteLattice.le_sSup α _
+  le_sInf := @CompleteLattice.sSup_le α _
 
-instance [CompleteLinearOrder α] : CompleteLinearOrder αᵒᵈ :=
-  { OrderDual.completeLattice α, OrderDual.instLinearOrder α with }
+instance [CompleteLinearOrder α] : CompleteLinearOrder αᵒᵈ where
+  __ := OrderDual.completeLattice α
+  __ := OrderDual.instLinearOrder α
 
 end OrderDual
 
@@ -1692,18 +1696,20 @@ end CompleteLinearOrder
 -/
 
 
-instance Prop.completeLattice : CompleteLattice Prop :=
-  { Prop.boundedOrder, Prop.distribLattice with
-    sSup := fun s => ∃ a ∈ s, a
-    le_sSup := fun _ a h p => ⟨a, h, p⟩
-    sSup_le := fun _ _ h ⟨b, h', p⟩ => h b h' p
-    sInf := fun s => ∀ a, a ∈ s → a
-    sInf_le := fun _ a h p => p a h
-    le_sInf := fun _ _ h p b hb => h b hb p }
+instance Prop.completeLattice : CompleteLattice Prop where
+  __ := Prop.boundedOrder
+  __ := Prop.distribLattice
+  sSup s := ∃ a ∈ s, a
+  le_sSup _ a h p := ⟨a, h, p⟩
+  sSup_le _ _ h := fun ⟨b, h', p⟩ => h b h' p
+  sInf s := ∀ a, a ∈ s → a
+  sInf_le _ a h p := p a h
+  le_sInf _ _ h p b hb := h b hb p
 #align Prop.complete_lattice Prop.completeLattice
 
-noncomputable instance Prop.completeLinearOrder : CompleteLinearOrder Prop :=
-  { Prop.completeLattice, Prop.linearOrder with }
+noncomputable instance Prop.completeLinearOrder : CompleteLinearOrder Prop where
+  __ := Prop.completeLattice
+  __ := Prop.linearOrder
 #align Prop.complete_linear_order Prop.completeLinearOrder
 
 @[simp]
@@ -1736,12 +1742,12 @@ instance Pi.infSet {α : Type*} {β : α → Type*} [∀ i, InfSet (β i)] : Inf
 #align pi.has_Inf Pi.infSet
 
 instance Pi.completeLattice {α : Type*} {β : α → Type*} [∀ i, CompleteLattice (β i)] :
-    CompleteLattice (∀ i, β i) :=
-  { Pi.boundedOrder, Pi.lattice with
-    le_sSup := fun s f hf i => le_iSup (fun f : s => (f : ∀ i, β i) i) ⟨f, hf⟩
-    sInf_le := fun s f hf i => iInf_le (fun f : s => (f : ∀ i, β i) i) ⟨f, hf⟩
-    sSup_le := fun _ _ hf i => iSup_le fun g => hf g g.2 i
-    le_sInf := fun _ _ hf i => le_iInf fun g => hf g g.2 i }
+    CompleteLattice (∀ i, β i) where
+  __ := Pi.boundedOrder; __ := Pi.lattice
+  le_sSup s f hf := fun i => le_iSup (fun f : s => (f : ∀ i, β i) i) ⟨f, hf⟩
+  sInf_le s f hf := fun i => iInf_le (fun f : s => (f : ∀ i, β i) i) ⟨f, hf⟩
+  sSup_le _ _ hf := fun i => iSup_le fun g => hf g g.2 i
+  le_sInf _ _ hf := fun i => le_iInf fun g => hf g g.2 i
 #align pi.complete_lattice Pi.completeLattice
 
 theorem sSup_apply {α : Type*} {β : α → Type*} [∀ i, SupSet (β i)] {s : Set (∀ a, β a)} {a : α} :
@@ -1879,16 +1885,19 @@ theorem iSup_mk [SupSet α] [SupSet β] (f : ι → α) (g : ι → β) :
 
 variable (α β)
 
-instance completeLattice [CompleteLattice α] [CompleteLattice β] : CompleteLattice (α × β) :=
-  { Prod.lattice α β, Prod.boundedOrder α β, Prod.supSet α β, Prod.infSet α β with
-    le_sSup := fun _ _ hab => ⟨le_sSup <| mem_image_of_mem _ hab, le_sSup <| mem_image_of_mem _ hab⟩
-    sSup_le := fun _ _ h =>
-      ⟨sSup_le <| ball_image_of_ball fun p hp => (h p hp).1,
-        sSup_le <| ball_image_of_ball fun p hp => (h p hp).2⟩
-    sInf_le := fun _ _ hab => ⟨sInf_le <| mem_image_of_mem _ hab, sInf_le <| mem_image_of_mem _ hab⟩
-    le_sInf := fun _ _ h =>
-      ⟨le_sInf <| ball_image_of_ball fun p hp => (h p hp).1,
-        le_sInf <| ball_image_of_ball fun p hp => (h p hp).2⟩ }
+instance completeLattice [CompleteLattice α] [CompleteLattice β] : CompleteLattice (α × β) where
+  __ := Prod.lattice α β
+  __ := Prod.boundedOrder α β
+  __ := Prod.supSet α β
+  __ := Prod.infSet α β
+  le_sSup _ _ hab := ⟨le_sSup <| mem_image_of_mem _ hab, le_sSup <| mem_image_of_mem _ hab⟩
+  sSup_le _ _ h :=
+    ⟨sSup_le <| ball_image_of_ball fun p hp => (h p hp).1,
+      sSup_le <| ball_image_of_ball fun p hp => (h p hp).2⟩
+  sInf_le _ _ hab := ⟨sInf_le <| mem_image_of_mem _ hab, sInf_le <| mem_image_of_mem _ hab⟩
+  le_sInf _ _ h :=
+    ⟨le_sInf <| ball_image_of_ball fun p hp => (h p hp).1,
+      le_sInf <| ball_image_of_ball fun p hp => (h p hp).2⟩
 
 end Prod
 
@@ -1953,17 +1962,17 @@ protected def Function.Injective.completeLattice [Sup α] [Inf α] [SupSet α] [
     [Bot α] [CompleteLattice β] (f : α → β) (hf : Function.Injective f)
     (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
     (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a)
-    (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) : CompleteLattice α :=
-  { -- we cannot use BoundedOrder.lift here as the `LE` instance doesn't exist yet
-    hf.lattice f map_sup map_inf with
-    le_sSup := fun _ a h => (le_iSup₂ a h).trans (map_sSup _).ge
-    sSup_le := fun _ _ h => (map_sSup _).trans_le <| iSup₂_le h
-    sInf_le := fun _ a h => (map_sInf _).trans_le <| iInf₂_le a h
-    le_sInf := fun _ _ h => (le_iInf₂ h).trans (map_sInf _).ge
-    top := ⊤
-    le_top := fun _ => (@le_top β _ _ _).trans map_top.ge
-    bot := ⊥
-    bot_le := fun _ => map_bot.le.trans bot_le }
+    (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) : CompleteLattice α where
+  -- we cannot use BoundedOrder.lift here as the `LE` instance doesn't exist yet
+  __ := hf.lattice f map_sup map_inf
+  le_sSup _ a h := (le_iSup₂ a h).trans (map_sSup _).ge
+  sSup_le _ _ h := (map_sSup _).trans_le <| iSup₂_le h
+  sInf_le _ a h := (map_sInf _).trans_le <| iInf₂_le a h
+  le_sInf _ _ h := (le_iInf₂ h).trans (map_sInf _).ge
+  top := ⊤
+  le_top _ := (@le_top β _ _ _).trans map_top.ge
+  bot := ⊥
+  bot_le _ := map_bot.le.trans bot_le
 #align function.injective.complete_lattice Function.Injective.completeLattice
 
 namespace ULift

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -602,8 +602,9 @@ def SemilatticeInf.mk' {α : Type*} [Inf α] (inf_comm : ∀ a b : α, a ⊓ b =
 class Lattice (α : Type u) extends SemilatticeSup α, SemilatticeInf α
 #align lattice Lattice
 
-instance OrderDual.lattice (α) [Lattice α] : Lattice αᵒᵈ :=
-  { OrderDual.semilatticeSup α, OrderDual.semilatticeInf α with }
+instance OrderDual.lattice (α) [Lattice α] : Lattice αᵒᵈ where
+  __ := OrderDual.semilatticeSup α
+  __ := OrderDual.semilatticeInf α
 
 /-- The partial orders from `SemilatticeSup_mk'` and `SemilatticeInf_mk'` agree
 if `sup` and `inf` satisfy the lattice absorption laws `sup_inf_self` (`a ⊔ a ⊓ b = a`)
@@ -796,9 +797,9 @@ end DistribLattice
 /-- Prove distributivity of an existing lattice from the dual distributive law. -/
 @[reducible]
 def DistribLattice.ofInfSupLe [Lattice α] (inf_sup_le : ∀ a b c : α, a ⊓ (b ⊔ c) ≤ a ⊓ b ⊔ a ⊓ c) :
-    DistribLattice α :=
-  { le_sup_inf := (@OrderDual.distribLattice αᵒᵈ {inferInstanceAs (Lattice αᵒᵈ) with
-      le_sup_inf := inf_sup_le}).le_sup_inf, }
+    DistribLattice α where
+  le_sup_inf := (@OrderDual.distribLattice αᵒᵈ {inferInstanceAs (Lattice αᵒᵈ) with
+      le_sup_inf := inf_sup_le}).le_sup_inf
 #align distrib_lattice.of_inf_sup_le DistribLattice.ofInfSupLe
 
 /-!
@@ -807,12 +808,12 @@ def DistribLattice.ofInfSupLe [Lattice α] (inf_sup_le : ∀ a b c : α, a ⊓ (
 
 
 -- see Note [lower instance priority]
-instance (priority := 100) LinearOrder.toLattice {α : Type u} [o : LinearOrder α] : Lattice α :=
-  { o with
-    sup := max,
-    le_sup_left := le_max_left, le_sup_right := le_max_right, sup_le := fun _ _ _ => max_le,
-    inf := min,
-    inf_le_left := min_le_left, inf_le_right := min_le_right, le_inf := fun _ _ _ => le_min }
+instance (priority := 100) LinearOrder.toLattice {α : Type u} [o : LinearOrder α] : Lattice α where
+  __ := o
+  sup := max
+  le_sup_left := le_max_left; le_sup_right := le_max_right; sup_le _ _ _ := max_le
+  inf := min
+  inf_le_left := min_le_left; inf_le_right := min_le_right; le_inf _ _ _ := le_min
 
 section LinearOrder
 
@@ -911,21 +912,20 @@ See note [reducible non-instances]. -/
 @[reducible]
 def Lattice.toLinearOrder (α : Type u) [Lattice α] [DecidableEq α]
     [DecidableRel ((· ≤ ·) : α → α → Prop)]
-    [DecidableRel ((· < ·) : α → α → Prop)] [IsTotal α (· ≤ ·)] : LinearOrder α :=
-  { ‹Lattice α› with
-    decidableLE := ‹_›,
-    decidableEq := ‹_›,
-    decidableLT := ‹_›,
-    le_total := total_of (· ≤ ·),
-    max := (· ⊔ ·),
-    max_def := by exact congr_fun₂ sup_eq_maxDefault,
-    min := (· ⊓ ·),
-    min_def := by exact congr_fun₂ inf_eq_minDefault }
+    [DecidableRel ((· < ·) : α → α → Prop)] [IsTotal α (· ≤ ·)] : LinearOrder α where
+  __ := ‹Lattice α›
+  decidableLE := ‹_›
+  decidableEq := ‹_›
+  decidableLT := ‹_›
+  le_total := total_of (· ≤ ·)
+  max := (· ⊔ ·)
+  max_def := by exact congr_fun₂ sup_eq_maxDefault
+  min := (· ⊓ ·)
+  min_def := by exact congr_fun₂ inf_eq_minDefault
 #align lattice.to_linear_order Lattice.toLinearOrder
 
 -- see Note [lower instance priority]
-instance (priority := 100) {α : Type u} [LinearOrder α] :
-  DistribLattice α where
+instance (priority := 100) {α : Type u} [LinearOrder α] : DistribLattice α where
   __ := inferInstanceAs (Lattice α)
   le_sup_inf _ b c :=
     match le_total b c with
@@ -1382,12 +1382,11 @@ See note [reducible non-instances]. -/
 @[reducible]
 protected def semilatticeSup [SemilatticeSup α] {P : α → Prop}
     (Psup : ∀ ⦃x y⦄, P x → P y → P (x ⊔ y)) :
-    SemilatticeSup { x : α // P x } :=
-  { inferInstanceAs (PartialOrder (Subtype P)) with
-    sup := fun x y => ⟨x.1 ⊔ y.1, Psup x.2 y.2⟩,
-    le_sup_left := fun _ _ => le_sup_left,
-    le_sup_right := fun _ _ => le_sup_right,
-    sup_le := fun _ _ _ h1 h2 => sup_le h1 h2 }
+    SemilatticeSup { x : α // P x } where
+  sup x y := ⟨x.1 ⊔ y.1, Psup x.2 y.2⟩
+  le_sup_left _ _ := le_sup_left
+  le_sup_right _ _ := le_sup_right
+  sup_le _ _ _ h1 h2 := sup_le h1 h2
 #align subtype.semilattice_sup Subtype.semilatticeSup
 
 /-- A subtype forms a `⊓`-semilattice if `⊓` preserves the property.
@@ -1395,20 +1394,20 @@ See note [reducible non-instances]. -/
 @[reducible]
 protected def semilatticeInf [SemilatticeInf α] {P : α → Prop}
     (Pinf : ∀ ⦃x y⦄, P x → P y → P (x ⊓ y)) :
-    SemilatticeInf { x : α // P x } :=
-  { inferInstanceAs (PartialOrder (Subtype P)) with
-    inf := fun x y => ⟨x.1 ⊓ y.1, Pinf x.2 y.2⟩,
-    inf_le_left := fun _ _ => inf_le_left,
-    inf_le_right := fun _ _ => inf_le_right,
-    le_inf := fun _ _ _ h1 h2 => le_inf h1 h2 }
+    SemilatticeInf { x : α // P x } where
+  inf x y := ⟨x.1 ⊓ y.1, Pinf x.2 y.2⟩
+  inf_le_left _ _ := inf_le_left
+  inf_le_right _ _ := inf_le_right
+  le_inf _ _ _ h1 h2 := le_inf h1 h2
 #align subtype.semilattice_inf Subtype.semilatticeInf
 
 /-- A subtype forms a lattice if `⊔` and `⊓` preserve the property.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def lattice [Lattice α] {P : α → Prop} (Psup : ∀ ⦃x y⦄, P x → P y → P (x ⊔ y))
-    (Pinf : ∀ ⦃x y⦄, P x → P y → P (x ⊓ y)) : Lattice { x : α // P x } :=
-  { Subtype.semilatticeInf Pinf, Subtype.semilatticeSup Psup with }
+    (Pinf : ∀ ⦃x y⦄, P x → P y → P (x ⊓ y)) : Lattice { x : α // P x } where
+  __ := Subtype.semilatticeInf Pinf
+  __ := Subtype.semilatticeSup Psup
 #align subtype.lattice Subtype.lattice
 
 @[simp, norm_cast]
@@ -1450,21 +1449,22 @@ preserves `⊔` to a `SemilatticeSup`.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Injective.semilatticeSup [Sup α] [SemilatticeSup β] (f : α → β)
-    (hf_inj : Function.Injective f) (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) : SemilatticeSup α :=
-  { PartialOrder.lift f hf_inj with
-    sup := Sup.sup,
-    le_sup_left := fun a b => by
-      change f a ≤ f (a ⊔ b)
-      rw [map_sup]
-      exact le_sup_left,
-    le_sup_right := fun a b => by
-      change f b ≤ f (a ⊔ b)
-      rw [map_sup]
-      exact le_sup_right,
-    sup_le := fun a b c ha hb => by
-      change f (a ⊔ b) ≤ f c
-      rw [map_sup]
-      exact sup_le ha hb }
+    (hf_inj : Function.Injective f) (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) :
+    SemilatticeSup α where
+  __ := PartialOrder.lift f hf_inj
+  sup := Sup.sup
+  le_sup_left a b := by
+    change f a ≤ f (a ⊔ b)
+    rw [map_sup]
+    exact le_sup_left
+  le_sup_right a b := by
+    change f b ≤ f (a ⊔ b)
+    rw [map_sup]
+    exact le_sup_right
+  sup_le a b c ha hb := by
+    change f (a ⊔ b) ≤ f c
+    rw [map_sup]
+    exact sup_le ha hb
 #align function.injective.semilattice_sup Function.Injective.semilatticeSup
 
 /-- A type endowed with `⊓` is a `SemilatticeInf`, if it admits an injective map that
@@ -1472,21 +1472,22 @@ preserves `⊓` to a `SemilatticeInf`.
 See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Injective.semilatticeInf [Inf α] [SemilatticeInf β] (f : α → β)
-    (hf_inj : Function.Injective f) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b) : SemilatticeInf α :=
-  { PartialOrder.lift f hf_inj with
-    inf := Inf.inf,
-    inf_le_left := fun a b => by
-      change f (a ⊓ b) ≤ f a
-      rw [map_inf]
-      exact inf_le_left,
-    inf_le_right := fun a b => by
-      change f (a ⊓ b) ≤ f b
-      rw [map_inf]
-      exact inf_le_right,
-    le_inf := fun a b c ha hb => by
-      change f a ≤ f (b ⊓ c)
-      rw [map_inf]
-      exact le_inf ha hb }
+    (hf_inj : Function.Injective f) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b) :
+    SemilatticeInf α where
+  __ := PartialOrder.lift f hf_inj
+  inf := Inf.inf
+  inf_le_left a b := by
+    change f (a ⊓ b) ≤ f a
+    rw [map_inf]
+    exact inf_le_left
+  inf_le_right a b := by
+    change f (a ⊓ b) ≤ f b
+    rw [map_inf]
+    exact inf_le_right
+  le_inf a b c ha hb := by
+    change f a ≤ f (b ⊓ c)
+    rw [map_inf]
+    exact le_inf ha hb
 #align function.injective.semilattice_inf Function.Injective.semilatticeInf
 
 /-- A type endowed with `⊔` and `⊓` is a `Lattice`, if it admits an injective map that
@@ -1495,8 +1496,10 @@ See note [reducible non-instances]. -/
 @[reducible]
 protected def Function.Injective.lattice [Sup α] [Inf α] [Lattice β] (f : α → β)
     (hf_inj : Function.Injective f)
-    (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b) : Lattice α :=
-  { hf_inj.semilatticeSup f map_sup, hf_inj.semilatticeInf f map_inf with }
+    (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b) :
+    Lattice α where
+  __ := hf_inj.semilatticeSup f map_sup
+  __ := hf_inj.semilatticeInf f map_inf
 #align function.injective.lattice Function.Injective.lattice
 
 /-- A type endowed with `⊔` and `⊓` is a `DistribLattice`, if it admits an injective map that
@@ -1506,12 +1509,12 @@ See note [reducible non-instances]. -/
 protected def Function.Injective.distribLattice [Sup α] [Inf α] [DistribLattice β] (f : α → β)
     (hf_inj : Function.Injective f) (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b)
     (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b) :
-    DistribLattice α :=
-  { hf_inj.lattice f map_sup map_inf with
-    le_sup_inf := fun a b c => by
-      change f ((a ⊔ b) ⊓ (a ⊔ c)) ≤ f (a ⊔ b ⊓ c)
-      rw [map_inf, map_sup, map_sup, map_sup, map_inf]
-      exact le_sup_inf }
+    DistribLattice α where
+  __ := hf_inj.lattice f map_sup map_inf
+  le_sup_inf a b c := by
+    change f ((a ⊔ b) ⊓ (a ⊔ c)) ≤ f (a ⊔ b ⊓ c)
+    rw [map_inf, map_sup, map_sup, map_sup, map_inf]
+    exact le_sup_inf
 #align function.injective.distrib_lattice Function.Injective.distribLattice
 
 end lift


### PR DESCRIPTION
The former style encourages one parent per line, which is easier to review and see diffs of. It also allows a handful of `:= fun a b =>`s to be replaced with the less noisy `a b :=`.

A small number of `inferInstanceAs _ with`s were removed, as they are automatic in those places anyway.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
