### PR TITLE
feat(fun_prop): support for `HasDeriv` and alike

### DIFF
--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -75,6 +75,7 @@ nonrec theorem HasFDerivWithinAt.const_smul (h : HasFDerivWithinAt f f' s x) (c 
   h.const_smul c
 #align has_fderiv_within_at.const_smul HasFDerivWithinAt.const_smul
 
+@[fun_prop]
 nonrec theorem HasFDerivAt.const_smul (h : HasFDerivAt f f' x) (c : R) :
     HasFDerivAt (fun x => c • f x) (c • f') x :=
   h.const_smul c
@@ -135,6 +136,7 @@ nonrec theorem HasFDerivWithinAt.add (hf : HasFDerivWithinAt f f' s x)
   hf.add hg
 #align has_fderiv_within_at.add HasFDerivWithinAt.add
 
+@[fun_prop]
 nonrec theorem HasFDerivAt.add (hf : HasFDerivAt f f' x) (hg : HasFDerivAt g g' x) :
     HasFDerivAt (fun x => f x + g x) (f' + g') x :=
   hf.add hg
@@ -186,6 +188,7 @@ nonrec theorem HasFDerivWithinAt.add_const (hf : HasFDerivWithinAt f f' s x) (c 
   hf.add_const c
 #align has_fderiv_within_at.add_const HasFDerivWithinAt.add_const
 
+@[fun_prop]
 nonrec theorem HasFDerivAt.add_const (hf : HasFDerivAt f f' x) (c : F) :
     HasFDerivAt (fun x => f x + c) f' x :=
   hf.add_const c
@@ -261,6 +264,7 @@ nonrec theorem HasFDerivWithinAt.const_add (hf : HasFDerivWithinAt f f' s x) (c 
   hf.const_add c
 #align has_fderiv_within_at.const_add HasFDerivWithinAt.const_add
 
+@[fun_prop]
 nonrec theorem HasFDerivAt.const_add (hf : HasFDerivAt f f' x) (c : F) :
     HasFDerivAt (fun x => c + f x) f' x :=
   hf.const_add c
@@ -347,6 +351,7 @@ theorem HasFDerivWithinAt.sum (h : ∀ i ∈ u, HasFDerivWithinAt (A i) (A' i) s
   HasFDerivAtFilter.sum h
 #align has_fderiv_within_at.sum HasFDerivWithinAt.sum
 
+@[fun_prop]
 theorem HasFDerivAt.sum (h : ∀ i ∈ u, HasFDerivAt (A i) (A' i) x) :
     HasFDerivAt (fun y => ∑ i in u, A i y) (∑ i in u, A' i) x :=
   HasFDerivAtFilter.sum h
@@ -407,6 +412,7 @@ nonrec theorem HasFDerivWithinAt.neg (h : HasFDerivWithinAt f f' s x) :
   h.neg
 #align has_fderiv_within_at.neg HasFDerivWithinAt.neg
 
+@[fun_prop]
 nonrec theorem HasFDerivAt.neg (h : HasFDerivAt f f' x) : HasFDerivAt (fun x => -f x) (-f') x :=
   h.neg
 #align has_fderiv_at.neg HasFDerivAt.neg
@@ -485,6 +491,7 @@ nonrec theorem HasFDerivWithinAt.sub (hf : HasFDerivWithinAt f f' s x)
   hf.sub hg
 #align has_fderiv_within_at.sub HasFDerivWithinAt.sub
 
+@[fun_prop]
 nonrec theorem HasFDerivAt.sub (hf : HasFDerivAt f f' x) (hg : HasFDerivAt g g' x) :
     HasFDerivAt (fun x => f x - g x) (f' - g') x :=
   hf.sub hg
@@ -536,6 +543,7 @@ nonrec theorem HasFDerivWithinAt.sub_const (hf : HasFDerivWithinAt f f' s x) (c 
   hf.sub_const c
 #align has_fderiv_within_at.sub_const HasFDerivWithinAt.sub_const
 
+@[fun_prop]
 nonrec theorem HasFDerivAt.sub_const (hf : HasFDerivAt f f' x) (c : F) :
     HasFDerivAt (fun x => f x - c) f' x :=
   hf.sub_const c
@@ -544,6 +552,7 @@ nonrec theorem HasFDerivAt.sub_const (hf : HasFDerivAt f f' x) (c : F) :
 theorem hasStrictFDerivAt_sub_const {x : F} (c : F) : HasStrictFDerivAt (· - c) (id 𝕜 F) x :=
   (hasStrictFDerivAt_id x).sub_const c
 
+@[fun_prop]
 theorem hasFDerivAt_sub_const {x : F} (c : F) : HasFDerivAt (· - c) (id 𝕜 F) x :=
   (hasFDerivAt_id x).sub_const c
 
@@ -613,6 +622,7 @@ nonrec theorem HasFDerivWithinAt.const_sub (hf : HasFDerivWithinAt f f' s x) (c 
   hf.const_sub c
 #align has_fderiv_within_at.const_sub HasFDerivWithinAt.const_sub
 
+@[fun_prop]
 nonrec theorem HasFDerivAt.const_sub (hf : HasFDerivAt f f' x) (c : F) :
     HasFDerivAt (fun x => c - f x) (-f') x :=
   hf.const_sub c

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -151,6 +151,7 @@ def HasFDerivWithinAt (f : E → F) (f' : E →L[𝕜] F) (s : Set E) (x : E) :=
 
 /-- A function `f` has the continuous linear map `f'` as derivative at `x` if
 `f x' = f x + f' (x' - x) + o (x' - x)` when `x'` tends to `x`. -/
+@[fun_prop]
 def HasFDerivAt (f : E → F) (f' : E →L[𝕜] F) (x : E) :=
   HasFDerivAtFilter f f' x (𝓝 x)
 #align has_fderiv_at HasFDerivAt
@@ -1078,9 +1079,14 @@ theorem hasFDerivWithinAt_id (x : E) (s : Set E) : HasFDerivWithinAt id (id 𝕜
   hasFDerivAtFilter_id _ _
 #align has_fderiv_within_at_id hasFDerivWithinAt_id
 
+@[fun_prop]
 theorem hasFDerivAt_id (x : E) : HasFDerivAt id (id 𝕜 E) x :=
   hasFDerivAtFilter_id _ _
 #align has_fderiv_at_id hasFDerivAt_id
+
+@[fun_prop]
+theorem hasFDerivAt_id' (x : E) : HasFDerivAt (fun x => x)  (id 𝕜 E) x :=
+  hasFDerivAt_id x
 
 @[simp]
 theorem differentiableAt_id : DifferentiableAt 𝕜 id x :=
@@ -1149,6 +1155,7 @@ theorem hasFDerivWithinAt_const (c : F) (x : E) (s : Set E) :
   hasFDerivAtFilter_const _ _ _
 #align has_fderiv_within_at_const hasFDerivWithinAt_const
 
+@[fun_prop]
 theorem hasFDerivAt_const (c : F) (x : E) : HasFDerivAt (fun _ => c) (0 : E →L[𝕜] F) x :=
   hasFDerivAtFilter_const _ _ _
 #align has_fderiv_at_const hasFDerivAt_const

--- a/Mathlib/Analysis/Calculus/FDeriv/Comp.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Comp.lean
@@ -102,10 +102,16 @@ theorem HasFDerivWithinAt.comp_of_mem {g : F → G} {g' : F →L[𝕜] G} {t : S
 #align has_fderiv_within_at.comp_of_mem HasFDerivWithinAt.comp_of_mem
 
 /-- The chain rule. -/
+@[fun_prop]
 theorem HasFDerivAt.comp {g : F → G} {g' : F →L[𝕜] G} (hg : HasFDerivAt g g' (f x))
     (hf : HasFDerivAt f f' x) : HasFDerivAt (g ∘ f) (g'.comp f') x :=
   HasFDerivAtFilter.comp x hg hf hf.continuousAt
 #align has_fderiv_at.comp HasFDerivAt.comp
+
+@[fun_prop]
+theorem HasFDerivAt.comp' {g : F → G} {g' : F →L[𝕜] G} (hg : HasFDerivAt g g' (f x))
+    (hf : HasFDerivAt f f' x) : HasFDerivAt (fun x => g (f x)) (g'.comp f') x :=
+  HasFDerivAtFilter.comp x hg hf hf.continuousAt
 
 theorem DifferentiableWithinAt.comp {g : F → G} {t : Set F}
     (hg : DifferentiableWithinAt 𝕜 g t (f x)) (hf : DifferentiableWithinAt 𝕜 f s x)
@@ -215,6 +221,7 @@ protected theorem HasFDerivAtFilter.iterate {f : E → E} {f' : E →L[𝕜] E}
     exact ihn.comp x hf hL
 #align has_fderiv_at_filter.iterate HasFDerivAtFilter.iterate
 
+@[fun_prop]
 protected theorem HasFDerivAt.iterate {f : E → E} {f' : E →L[𝕜] E} (hf : HasFDerivAt f f' x)
     (hx : f x = x) (n : ℕ) : HasFDerivAt f^[n] (f' ^ n) x := by
   refine' HasFDerivAtFilter.iterate hf _ hx n

--- a/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
@@ -70,6 +70,7 @@ theorem HasFDerivWithinAt.clm_comp (hc : HasFDerivWithinAt c c' s x)
   (isBoundedBilinearMap_comp.hasFDerivAt (c x, d x)).comp_hasFDerivWithinAt x <| hc.prod hd
 #align has_fderiv_within_at.clm_comp HasFDerivWithinAt.clm_comp
 
+@[fun_prop]
 theorem HasFDerivAt.clm_comp (hc : HasFDerivAt c c' x) (hd : HasFDerivAt d d' x) :
     HasFDerivAt (fun y => (c y).comp (d y))
       ((compL 𝕜 F G H (c x)).comp d' + ((compL 𝕜 F G H).flip (d x)).comp c') x :=
@@ -122,6 +123,7 @@ theorem HasFDerivWithinAt.clm_apply (hc : HasFDerivWithinAt c c' s x)
   (isBoundedBilinearMap_apply.hasFDerivAt (c x, u x)).comp_hasFDerivWithinAt x (hc.prod hu)
 #align has_fderiv_within_at.clm_apply HasFDerivWithinAt.clm_apply
 
+@[fun_prop]
 theorem HasFDerivAt.clm_apply (hc : HasFDerivAt c c' x) (hu : HasFDerivAt u u' x) :
     HasFDerivAt (fun y => (c y) (u y)) ((c x).comp u' + c'.flip (u x)) x :=
   (isBoundedBilinearMap_apply.hasFDerivAt (c x, u x)).comp x (hc.prod hu)
@@ -178,6 +180,7 @@ theorem HasFDerivWithinAt.continuousMultilinear_apply_const (hc : HasFDerivWithi
     HasFDerivWithinAt (fun y ↦ (c y) u) (c'.flipMultilinear u) s x :=
   (ContinuousMultilinearMap.apply 𝕜 M H u).hasFDerivAt.comp_hasFDerivWithinAt x hc
 
+@[fun_prop]
 theorem HasFDerivAt.continuousMultilinear_apply_const (hc : HasFDerivAt c c' x) (u : ∀ i, M i) :
     HasFDerivAt (fun y ↦ (c y) u) (c'.flipMultilinear u) x :=
   (ContinuousMultilinearMap.apply 𝕜 M H u).hasFDerivAt.comp x hc
@@ -249,6 +252,7 @@ theorem HasFDerivWithinAt.smul (hc : HasFDerivWithinAt c c' s x) (hf : HasFDeriv
   (isBoundedBilinearMap_smul.hasFDerivAt (c x, f x)).comp_hasFDerivWithinAt x <| hc.prod hf
 #align has_fderiv_within_at.smul HasFDerivWithinAt.smul
 
+@[fun_prop]
 theorem HasFDerivAt.smul (hc : HasFDerivAt c c' x) (hf : HasFDerivAt f f' x) :
     HasFDerivAt (fun y => c y • f y) (c x • f' + c'.smulRight (f x)) x :=
   (isBoundedBilinearMap_smul.hasFDerivAt (c x, f x)).comp x <| hc.prod hf
@@ -367,11 +371,13 @@ theorem HasFDerivWithinAt.mul (hc : HasFDerivWithinAt c c' s x) (hd : HasFDerivW
   apply mul_comm
 #align has_fderiv_within_at.mul HasFDerivWithinAt.mul
 
+@[fun_prop]
 theorem HasFDerivAt.mul' (ha : HasFDerivAt a a' x) (hb : HasFDerivAt b b' x) :
     HasFDerivAt (fun y => a y * b y) (a x • b' + a'.smulRight (b x)) x :=
   ((ContinuousLinearMap.mul 𝕜 𝔸).isBoundedBilinearMap.hasFDerivAt (a x, b x)).comp x (ha.prod hb)
 #align has_fderiv_at.mul' HasFDerivAt.mul'
 
+@[fun_prop]
 theorem HasFDerivAt.mul (hc : HasFDerivAt c c' x) (hd : HasFDerivAt d d' x) :
     HasFDerivAt (fun y => c y * d y) (c x • d' + d x • c') x := by
   convert hc.mul' hd
@@ -578,6 +584,7 @@ operation is the linear map `fun t ↦ - x⁻¹ * t * x⁻¹`.
 TODO: prove that `Ring.inverse` is analytic and use it to prove a `HasStrictFDerivAt` lemma.
 TODO (low prio): prove a version without assumption `[CompleteSpace R]` but within the set of
 units. -/
+@[fun_prop]
 theorem hasFDerivAt_ring_inverse (x : Rˣ) :
     HasFDerivAt Ring.inverse (-mulLeftRight 𝕜 R ↑x⁻¹ ↑x⁻¹) x :=
   have : (fun t : R => Ring.inverse (↑x + t) - ↑x⁻¹ + ↑x⁻¹ * t * ↑x⁻¹) =o[𝓝 0] id :=
@@ -640,6 +647,7 @@ open NormedRing ContinuousLinearMap Ring
 
 /-- At an invertible element `x` of a normed division algebra `R`, the Fréchet derivative of the
 inversion operation is the linear map `λ t, - x⁻¹ * t * x⁻¹`. -/
+@[fun_prop]
 theorem hasFDerivAt_inv' {x : R} (hx : x ≠ 0) : HasFDerivAt Inv.inv (-mulLeftRight 𝕜 R x⁻¹ x⁻¹) x :=
   by simpa using hasFDerivAt_ring_inverse (Units.mk0 _ hx)
 #align has_fderiv_at_inv' hasFDerivAt_inv'

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -76,6 +76,7 @@ nonrec theorem HasFDerivWithinAt.prod (hf₁ : HasFDerivWithinAt f₁ f₁' s x)
   hf₁.prod hf₂
 #align has_fderiv_within_at.prod HasFDerivWithinAt.prod
 
+@[fun_prop]
 nonrec theorem HasFDerivAt.prod (hf₁ : HasFDerivAt f₁ f₁' x) (hf₂ : HasFDerivAt f₂ f₂' x) :
     HasFDerivAt (fun x => (f₁ x, f₂ x)) (f₁'.prod f₂') x :=
   hf₁.prod hf₂
@@ -151,10 +152,12 @@ protected theorem HasFDerivAtFilter.fst (h : HasFDerivAtFilter f₂ f₂' x L) :
   hasFDerivAtFilter_fst.comp x h tendsto_map
 #align has_fderiv_at_filter.fst HasFDerivAtFilter.fst
 
+@[fun_prop]
 theorem hasFDerivAt_fst : HasFDerivAt (@Prod.fst E F) (fst 𝕜 E F) p :=
   hasFDerivAtFilter_fst
 #align has_fderiv_at_fst hasFDerivAt_fst
 
+@[fun_prop]
 protected nonrec theorem HasFDerivAt.fst (h : HasFDerivAt f₂ f₂' x) :
     HasFDerivAt (fun x => (f₂ x).1) ((fst 𝕜 F G).comp f₂') x :=
   h.fst
@@ -252,10 +255,12 @@ protected theorem HasFDerivAtFilter.snd (h : HasFDerivAtFilter f₂ f₂' x L) :
   hasFDerivAtFilter_snd.comp x h tendsto_map
 #align has_fderiv_at_filter.snd HasFDerivAtFilter.snd
 
+@[fun_prop]
 theorem hasFDerivAt_snd : HasFDerivAt (@Prod.snd E F) (snd 𝕜 E F) p :=
   hasFDerivAtFilter_snd
 #align has_fderiv_at_snd hasFDerivAt_snd
 
+@[fun_prop]
 protected nonrec theorem HasFDerivAt.snd (h : HasFDerivAt f₂ f₂' x) :
     HasFDerivAt (fun x => (f₂ x).2) ((snd 𝕜 F G).comp f₂') x :=
   h.snd
@@ -339,6 +344,7 @@ protected theorem HasStrictFDerivAt.prodMap (hf : HasStrictFDerivAt f f' p.1)
   (hf.comp p hasStrictFDerivAt_fst).prod (hf₂.comp p hasStrictFDerivAt_snd)
 #align has_strict_fderiv_at.prod_map HasStrictFDerivAt.prodMap
 
+@[fun_prop]
 protected theorem HasFDerivAt.prodMap (hf : HasFDerivAt f f' p.1) (hf₂ : HasFDerivAt f₂ f₂' p.2) :
     HasFDerivAt (Prod.map f f₂) (f'.prodMap f₂') p :=
   (hf.comp p hasFDerivAt_fst).prod (hf₂.comp p hasFDerivAt_snd)
@@ -412,6 +418,11 @@ theorem hasFDerivAt_pi :
       ∀ i, HasFDerivAt (φ i) (φ' i) x :=
   hasFDerivAtFilter_pi
 #align has_fderiv_at_pi hasFDerivAt_pi
+
+@[fun_prop]
+theorem hasFDerivAt_pi'' (hφ : ∀ i, HasFDerivAt (φ i) (φ' i) x) :
+    HasFDerivAt (fun x i => φ i x) (ContinuousLinearMap.pi φ') x :=
+  hasFDerivAt_pi.2 hφ
 
 @[simp]
 theorem hasFDerivWithinAt_pi' :

--- a/Mathlib/Tactic/FunProp/Decl.lean
+++ b/Mathlib/Tactic/FunProp/Decl.lean
@@ -55,7 +55,7 @@ def addFunPropDecl (declName : Name) (dischargeStx? : Option (TSyntax `tactic)) 
 
   let info ← getConstInfo declName
 
-  let (xs,_,b) ← forallMetaTelescope info.type
+  let (xs,bi,b) ← forallMetaTelescope info.type
 
   if ¬b.isProp then
     throwError "invalid fun_prop declaration, has to be `Prop` valued function"
@@ -64,14 +64,14 @@ def addFunPropDecl (declName : Name) (dischargeStx? : Option (TSyntax `tactic)) 
   let e := mkAppN (.const declName lvls) xs
   let path ← DiscrTree.mkPath e {}
 
-  -- find the argument position of the function `f` in `P f`
-  let mut .some funArgId ← xs.reverse.findIdxM? fun x => do
-    if (← inferType x).isForall then
+  -- Find the argument position of the function `f` in `P f`
+  -- It is the first explicit argument with function type
+  let mut .some funArgId ← (xs.zip bi).findIdxM? fun (x,bi) => do
+    if (← inferType x).isForall && bi.isExplicit then
       return true
     else
       return false
     | throwError "invalid fun_prop declaration, can't find argument of type `α → β`"
-  funArgId := xs.size - funArgId - 1
 
   let decl : FunPropDecl := {
     funPropName := declName

--- a/test/fun_prop_dev.lean
+++ b/test/fun_prop_dev.lean
@@ -272,3 +272,64 @@ example (f : α → β -o γ) (hf : Lin (fun (x,y) => f x y)) (g : α → β) (h
 
 -- is working up to here
 
+----------------------------------------------------------------------------------------------------
+
+
+@[fun_prop]
+opaque HasDeriv (f : α → β) (f' : α → α → β) : Prop
+
+
+@[fun_prop]
+theorem hasDeriv_id : HasDeriv (fun x : α => x) (fun x dx => dx) := silentSorry
+
+@[fun_prop]
+theorem hasDeriv_const [Zero β]  (y:β): HasDeriv (fun x : α => y) (fun x dx => 0) := silentSorry
+
+@[fun_prop]
+theorem hasDeriv_comp
+    (f : β → γ) (f' : β → β → γ) (hf : HasDeriv f f')
+    (g : α → β) (g' : α → α → β) (hg : HasDeriv g g') :
+    HasDeriv (fun x => (f (g x))) (fun x dx => f' (g x) (g' x dx)) := silentSorry
+
+
+
+@[fun_prop]
+theorem hasDeriv_prod_mk'
+    (f : α → β) (f' : α → α → β) (hf : HasDeriv f f')
+    (g : α → γ) (g' : α → α → γ) (hg : HasDeriv g g') :
+    HasDeriv (fun x => (f x, g x)) (fun x dx => (f' x dx, g' x dx)) := silentSorry
+
+
+@[fun_prop]
+theorem hasDeriv_prod_fst
+    (f : α → β×γ) (f' : α → α → β×γ) (hf : HasDeriv f f') :
+    HasDeriv (fun x => (f x).1) (fun x dx => (f' x dx).1) := silentSorry
+
+@[fun_prop]
+theorem hasDeriv_prod_snd
+    (f : α → β×γ) (f' : α → α → β×γ) (hf : HasDeriv f f') :
+    HasDeriv (fun x => (f x).2) (fun x dx => (f' x dx).2) := silentSorry
+
+
+@[fun_prop]
+theorem hasDeriv_add
+    (f : α → β) (f' : α → α → β) (hf : HasDeriv f f')
+    (g : α → β) (g' : α → α → β) (hg : HasDeriv g g') :
+    HasDeriv (fun x => f x + g x) (fun x dx => f' x dx + g' x dx) := silentSorry
+
+@[fun_prop]
+theorem hasDeriv_mul [Mul β] [Add β]
+    (f : α → β) (f' : α → α → β) (hf : HasDeriv f f')
+    (g : α → β) (g' : α → α → β) (hg : HasDeriv g g') :
+    HasDeriv (fun x => f x * g x) (fun x dx => f' x dx * g x + g' x dx * f x) := silentSorry
+
+
+variable [Mul α]
+
+/--
+info: hasDeriv_mul (fun x => x * x) (fun x dx => dx * x + dx * x)
+  (hasDeriv_mul (fun x => x) (fun x dx => dx) hasDeriv_id (fun x => x) (fun x dx => dx) hasDeriv_id) (fun x => x)
+  (fun x dx => dx) hasDeriv_id : HasDeriv (fun x => x * x * x) fun x dx => (dx * x + dx * x) * x + dx * (x * x)
+-/
+#guard_msgs in
+#check ((by fun_prop) : HasDeriv (fun x : α => x * x * x) _)

--- a/test/fun_prop_has_deriv.lean
+++ b/test/fun_prop_has_deriv.lean
@@ -1,0 +1,41 @@
+import Mathlib.Analysis.Calculus.FDeriv.Basic
+import Mathlib.Analysis.Calculus.FDeriv.Comp
+import Mathlib.Analysis.Calculus.FDeriv.Prod
+import Mathlib.Analysis.Calculus.FDeriv.Add
+import Mathlib.Analysis.Calculus.FDeriv.Mul
+
+
+variable (a b c : ℝ) (ha : a ≠ 0)
+
+
+/--
+info: HasFDerivAt.mul (hasFDerivAt_id' a)
+  (hasFDerivAt_id' a) : HasFDerivAt (fun y => y * y) (a • ContinuousLinearMap.id ℝ ℝ + a • ContinuousLinearMap.id ℝ ℝ) a
+-/
+#guard_msgs in
+#check (((by fun_prop) : @HasFDerivAt ℝ _ _ _ _ _ _ _ (fun x : ℝ => x * x) _ a))
+
+/--
+info: hasFDerivAt_inv' ha : HasFDerivAt Inv.inv (-((ContinuousLinearMap.mulLeftRight ℝ ℝ) a⁻¹) a⁻¹) a
+-/
+#guard_msgs in
+#check ((by fun_prop (disch:=assumption)) : (@HasFDerivAt ℝ _ _ _ _ _ _ _ (fun x : ℝ => x⁻¹) _ a))
+
+
+variable (ha' : a*a + 1 ≠ 0)
+
+/--
+info: HasFDerivAt.mul (HasFDerivAt.add_const (hasFDerivAt_id' a) 3)
+  (HasFDerivAt.comp' a (hasFDerivAt_inv' ha')
+    (HasFDerivAt.add_const (HasFDerivAt.mul (hasFDerivAt_id' a) (hasFDerivAt_id' a))
+      1)) : HasFDerivAt (fun y => (y + 3) * (y * y + 1)⁻¹)
+  ((a + 3) •
+      ContinuousLinearMap.comp (-((ContinuousLinearMap.mulLeftRight ℝ ℝ) (a * a + 1)⁻¹) (a * a + 1)⁻¹)
+        (a • ContinuousLinearMap.id ℝ ℝ + a • ContinuousLinearMap.id ℝ ℝ) +
+    (a * a + 1)⁻¹ • ContinuousLinearMap.id ℝ ℝ)
+  a
+-/
+#guard_msgs in
+#check ((by fun_prop (disch:=assumption)) : (@HasFDerivAt ℝ _ _ _ _ _ _ _ (fun x : ℝ => (x+3)*(x*x + 1)⁻¹) _ a))
+
+  --


### PR DESCRIPTION
feat(fun_prop): support for `HasDeriv` and alike

A small tweak to `fun_prop`. Previously `fun_prop` thought that `HasDeriv ℝ f f'` was stating a function property about `f'`.

In general, if you mark new function property with `fun_prop`. It will look for the first explicit argument that is a function. It is then assumed that the function property is talking about that argument. 

This PR is mainly a fix to `fun_prop`. Extensive tagging of  `HasFDerivAt`  theorems will come in a future PR. I just did the minimal setup to demonstrate that it works.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
