### PR TITLE
[Merged by Bors] - feat: Add `Real.pi_nonneg = Real.pi_pos.le`

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -168,7 +168,7 @@ theorem pi_nonneg : 0 ≤ π :=
   pi_pos.le
 
 theorem pi_ne_zero : π ≠ 0 :=
-  ne_of_gt pi_pos
+  pi_pos.ne'
 #align real.pi_ne_zero Real.pi_ne_zero
 
 theorem pi_div_two_pos : 0 < π / 2 :=

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -164,6 +164,9 @@ theorem pi_pos : 0 < π :=
   lt_of_lt_of_le (by norm_num) two_le_pi
 #align real.pi_pos Real.pi_pos
 
+theorem pi_nonneg : 0 ≤ π :=
+  pi_pos.le
+
 theorem pi_ne_zero : π ≠ 0 :=
   ne_of_gt pi_pos
 #align real.pi_ne_zero Real.pi_ne_zero


### PR DESCRIPTION
I think if `Real.exp_nonneg` exists as a separate lemma, `Real.pi_nonneg` is reasonable.  And it's useful as a separate lemma for Aesop purposes too.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
