### PR TITLE
[Merged by Bors] - chore: simplify `birthday` proof; avoiding max recursion depth is easier now

### DIFF
--- a/Archive/Wiedijk100Theorems/BirthdayProblem.lean
+++ b/Archive/Wiedijk100Theorems/BirthdayProblem.lean
@@ -29,12 +29,7 @@ local notation "‖" x "‖" => Fintype.card x
 /-- **Birthday Problem**: set cardinality interpretation. -/
 theorem birthday :
     2 * ‖Fin 23 ↪ Fin 365‖ < ‖Fin 23 → Fin 365‖ ∧ 2 * ‖Fin 22 ↪ Fin 365‖ > ‖Fin 22 → Fin 365‖ := by
-  -- This used to be
-  -- `simp only [Nat.descFactorial, Fintype.card_fin, Fintype.card_embedding_eq, Fintype.card_fun]`
-  -- but after leanprover/lean4#2790 that triggers a max recursion depth exception.
-  -- As a workaround, we make some of the reduction steps more explicit.
-  rw [Fintype.card_embedding_eq, Fintype.card_fun, Fintype.card_fin, Fintype.card_fin]
-  rw [Fintype.card_embedding_eq, Fintype.card_fun, Fintype.card_fin, Fintype.card_fin]
+  simp only [Nat.descFactorial, Fintype.card_fin, Fintype.card_embedding_eq, Fintype.card_fun]
   decide
 #align theorems_100.birthday Theorems100.birthday
 

--- a/Archive/Wiedijk100Theorems/BirthdayProblem.lean
+++ b/Archive/Wiedijk100Theorems/BirthdayProblem.lean
@@ -29,7 +29,7 @@ local notation "‖" x "‖" => Fintype.card x
 /-- **Birthday Problem**: set cardinality interpretation. -/
 theorem birthday :
     2 * ‖Fin 23 ↪ Fin 365‖ < ‖Fin 23 → Fin 365‖ ∧ 2 * ‖Fin 22 ↪ Fin 365‖ > ‖Fin 22 → Fin 365‖ := by
-  simp only [Nat.descFactorial, Fintype.card_fin, Fintype.card_embedding_eq, Fintype.card_fun]
+  simp only [Fintype.card_fin, Fintype.card_embedding_eq, Fintype.card_fun]
   decide
 #align theorems_100.birthday Theorems100.birthday
 


### PR DESCRIPTION
Now that `decide := false` is the default for simp, we can use a plain `simp only` instead of two `rw` steps.
I observe (via `set_option trace.profiler true`) the new proof to take about 0.03 seconds whereas the current one
takes about 0.05 seconds.
If I add in `Nat.descFactorial` to the simp lemmas (as it used to be, according to the comment), the proof slows down
to about 0.10 seconds.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
