### PR TITLE
[Merged by Bors] - perf: speed up galActionHom_bijective_of_prime_degree

### DIFF
--- a/Mathlib/Analysis/Complex/Polynomial.lean
+++ b/Mathlib/Analysis/Complex/Polynomial.lean
@@ -128,8 +128,6 @@ theorem galActionHom_bijective_of_prime_degree {p : ℚ[X]} (p_irr : Irreducible
     rw [Multiset.toFinset_card_of_nodup, ← natDegree_eq_card_roots]
     · exact IsAlgClosed.splits_codomain p
     · exact nodup_roots ((separable_map (algebraMap ℚ ℂ)).mpr p_irr.separable)
-  have h2 : Fintype.card p.Gal = Fintype.card (galActionHom p ℂ).range :=
-    Fintype.card_congr (MonoidHom.ofInjective (galActionHom_injective p ℂ)).toEquiv
   let conj' := restrict p ℂ (Complex.conjAe.restrictScalars ℚ)
   refine'
     ⟨galActionHom_injective p ℂ, fun x =>
@@ -138,8 +136,9 @@ theorem galActionHom_bijective_of_prime_degree {p : ℚ[X]} (p_irr : Irreducible
   apply Equiv.Perm.subgroup_eq_top_of_swap_mem
   · rwa [h1]
   · rw [h1]
-    convert prime_degree_dvd_card p_irr p_deg using 1
-    convert h2.symm
+    simpa only [Fintype.card_eq_nat_card,
+      Nat.card_congr (MonoidHom.ofInjective (galActionHom_injective p ℂ)).toEquiv.symm]
+      using prime_degree_dvd_card p_irr p_deg
   · exact ⟨conj', rfl⟩
   · rw [← Equiv.Perm.card_support_eq_two]
     apply Nat.add_left_cancel

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -42,6 +42,11 @@ theorem card_eq_fintype_card [Fintype α] : Nat.card α = Fintype.card α :=
   mk_toNat_eq_card
 #align nat.card_eq_fintype_card Nat.card_eq_fintype_card
 
+/-- Because this theorem takes `Fintype α` as a non-instance argument, it can be used in particular
+when `Fintype.card` ends up with different instance than the one found by inference  -/
+theorem _root_.Fintype.card_eq_nat_card {_ : Fintype α} : Fintype.card α = Nat.card α :=
+  mk_toNat_eq_card.symm
+
 lemma card_eq_finsetCard (s : Finset α) : Nat.card s = s.card := by
   simp only [Nat.card_eq_fintype_card, Fintype.card_coe]
 


### PR DESCRIPTION
This takes the proof from approximately 3 seconds to half a second on my laptop.

convert spent a fair amount of time dealing with the equality of Fintype.card calls with the same type but different Fintype instances. This sidesteps the issue by translating to Nat.card, which doesn't have the instance argument.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I'm not sure if the documentation ended up readable; suggestions welcome.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
