### PR TITLE
[Merged by Bors] - refactor: Split off the Pontryagin dual into separate file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3657,6 +3657,7 @@ import Mathlib.Topology.Algebra.Order.Rolle
 import Mathlib.Topology.Algebra.Order.T5
 import Mathlib.Topology.Algebra.Order.UpperLower
 import Mathlib.Topology.Algebra.Polynomial
+import Mathlib.Topology.Algebra.PontryaginDual
 import Mathlib.Topology.Algebra.ProperConstSMul
 import Mathlib.Topology.Algebra.Ring.Basic
 import Mathlib.Topology.Algebra.Ring.Ideal

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
-import Mathlib.Analysis.Complex.Circle
 import Mathlib.Topology.ContinuousFunction.Algebra
 
 #align_import topology.algebra.continuous_monoid_hom from "leanprover-community/mathlib"@"6ca1a09bc9aa75824bf97388c9e3b441fc4ccf3f"
@@ -380,84 +379,3 @@ def compRight {B : Type*} [CommGroup B] [TopologicalSpace B] [TopologicalGroup B
 #align continuous_add_monoid_hom.comp_right ContinuousAddMonoidHom.compRight
 
 end ContinuousMonoidHom
-
-
-
-/-- The Pontryagin dual of `A` is the group of continuous homomorphism `A → circle`. -/
-def PontryaginDual :=
-  ContinuousMonoidHom A circle
-#align pontryagin_dual PontryaginDual
-
--- porting note: `deriving` doesn't derive these instances
-instance : TopologicalSpace (PontryaginDual A) :=
-  (inferInstance : TopologicalSpace (ContinuousMonoidHom A circle))
-
-instance : T2Space (PontryaginDual A) :=
-  (inferInstance : T2Space (ContinuousMonoidHom A circle))
-
--- porting note: instance is now noncomputable
-noncomputable instance : CommGroup (PontryaginDual A) :=
-  (inferInstance : CommGroup (ContinuousMonoidHom A circle))
-
-instance : TopologicalGroup (PontryaginDual A) :=
-  (inferInstance : TopologicalGroup (ContinuousMonoidHom A circle))
-
--- porting note: instance is now noncomputable
-noncomputable instance : Inhabited (PontryaginDual A) :=
-  (inferInstance : Inhabited (ContinuousMonoidHom A circle))
-
-
-variable {A B C D E}
-
-namespace PontryaginDual
-
-open ContinuousMonoidHom
-
-instance : FunLike (PontryaginDual A) A circle :=
-  ContinuousMonoidHom.funLike
-
-noncomputable instance : ContinuousMonoidHomClass (PontryaginDual A) A circle :=
-  ContinuousMonoidHom.ContinuousMonoidHomClass
-
-/-- `PontryaginDual` is a functor. -/
-noncomputable def map (f : ContinuousMonoidHom A B) :
-    ContinuousMonoidHom (PontryaginDual B) (PontryaginDual A) :=
-  f.compLeft circle
-#align pontryagin_dual.map PontryaginDual.map
-
-@[simp]
-theorem map_apply (f : ContinuousMonoidHom A B) (x : PontryaginDual B) (y : A) :
-    map f x y = x (f y) :=
-  rfl
-#align pontryagin_dual.map_apply PontryaginDual.map_apply
-
-@[simp]
-theorem map_one : map (one A B) = one (PontryaginDual B) (PontryaginDual A) :=
-  ext fun x => ext (fun _y => OneHomClass.map_one x)
-#align pontryagin_dual.map_one PontryaginDual.map_one
-
-@[simp]
-theorem map_comp (g : ContinuousMonoidHom B C) (f : ContinuousMonoidHom A B) :
-    map (comp g f) = ContinuousMonoidHom.comp (map f) (map g) :=
-  ext fun _x => ext fun _y => rfl
-#align pontryagin_dual.map_comp PontryaginDual.map_comp
-
-
-@[simp]
-nonrec theorem map_mul (f g : ContinuousMonoidHom A E) : map (f * g) = map f * map g :=
-  ext fun x => ext fun y => map_mul x (f y) (g y)
-#align pontryagin_dual.map_mul PontryaginDual.map_mul
-
-variable (A B C D E)
-
-/-- `ContinuousMonoidHom.dual` as a `ContinuousMonoidHom`. -/
-noncomputable def mapHom [LocallyCompactSpace E] :
-    ContinuousMonoidHom (ContinuousMonoidHom A E)
-      (ContinuousMonoidHom (PontryaginDual E) (PontryaginDual A)) where
-  toFun := map
-  map_one' := map_one
-  map_mul' := map_mul
-  continuous_toFun := continuous_of_continuous_uncurry _ continuous_comp
-#align pontryagin_dual.map_hom PontryaginDual.mapHom
-
-end PontryaginDual

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -12,11 +12,11 @@ import Mathlib.Topology.Algebra.ContinuousMonoidHom
 
 # Continuous Monoid Homs
 
-This file defines the space of continuous homomorphisms between two topological groups.
+This file defines the Pontryagin dual of a topological group.
 
 ## Main definitions
 
-* `PontryaginDual A`: The continuous homomorphisms `A →* circle`.
+* `PontryaginDual A`: The group of continuous homomorphisms `A →* circle`.
 -/
 
 open Pointwise Function

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -11,7 +11,11 @@ import Mathlib.Topology.Algebra.ContinuousMonoidHom
 /-!
 # Pontryagin dual
 
-This file defines the Pontryagin dual of a topological group.
+This file defines the Pontryagin dual of a topological group. The Pontryagin dual of a topological
+group `A` is the topological group of continuous homomorphisms `A →* circle` with the compact-open
+topology. For example, `ℤ` and `circle` are Pontryagin duals of each other. This is an example of
+Pontryagin duality, which states that a locally compact abelian topological group is canonically
+isomorphic to its double dual.
 
 ## Main definitions
 
@@ -59,7 +63,7 @@ instance : FunLike (PontryaginDual A) A circle :=
 noncomputable instance : ContinuousMonoidHomClass (PontryaginDual A) A circle :=
   ContinuousMonoidHom.ContinuousMonoidHomClass
 
-/-- `PontryaginDual` is a functor. -/
+/-- `PontryaginDual` is a contravariant functor. -/
 noncomputable def map (f : ContinuousMonoidHom A B) :
     ContinuousMonoidHom (PontryaginDual B) (PontryaginDual A) :=
   f.compLeft circle

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2024 Thomas Browning. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Browning
+-/
+import Mathlib.Analysis.Complex.Circle
+import Mathlib.Topology.Algebra.ContinuousMonoidHom
+
+#align_import topology.algebra.continuous_monoid_hom from "leanprover-community/mathlib"@"6ca1a09bc9aa75824bf97388c9e3b441fc4ccf3f"
+
+/-!
+
+# Continuous Monoid Homs
+
+This file defines the space of continuous homomorphisms between two topological groups.
+
+## Main definitions
+
+* `PontryaginDual A`: The continuous homomorphisms `A →* circle`.
+-/
+
+open Pointwise Function
+
+variable (A B C D E : Type*) [Monoid A] [Monoid B] [Monoid C] [Monoid D] [CommGroup E]
+  [TopologicalSpace A] [TopologicalSpace B] [TopologicalSpace C] [TopologicalSpace D]
+  [TopologicalSpace E] [TopologicalGroup E]
+
+/-- The Pontryagin dual of `A` is the group of continuous homomorphism `A → circle`. -/
+def PontryaginDual :=
+  ContinuousMonoidHom A circle
+#align pontryagin_dual PontryaginDual
+
+-- porting note: `deriving` doesn't derive these instances
+instance : TopologicalSpace (PontryaginDual A) :=
+  (inferInstance : TopologicalSpace (ContinuousMonoidHom A circle))
+
+instance : T2Space (PontryaginDual A) :=
+  (inferInstance : T2Space (ContinuousMonoidHom A circle))
+
+-- porting note: instance is now noncomputable
+noncomputable instance : CommGroup (PontryaginDual A) :=
+  (inferInstance : CommGroup (ContinuousMonoidHom A circle))
+
+instance : TopologicalGroup (PontryaginDual A) :=
+  (inferInstance : TopologicalGroup (ContinuousMonoidHom A circle))
+
+-- porting note: instance is now noncomputable
+noncomputable instance : Inhabited (PontryaginDual A) :=
+  (inferInstance : Inhabited (ContinuousMonoidHom A circle))
+
+variable {A B C D E}
+
+namespace PontryaginDual
+
+open ContinuousMonoidHom
+
+instance : FunLike (PontryaginDual A) A circle :=
+  ContinuousMonoidHom.funLike
+
+noncomputable instance : ContinuousMonoidHomClass (PontryaginDual A) A circle :=
+  ContinuousMonoidHom.ContinuousMonoidHomClass
+
+/-- `PontryaginDual` is a functor. -/
+noncomputable def map (f : ContinuousMonoidHom A B) :
+    ContinuousMonoidHom (PontryaginDual B) (PontryaginDual A) :=
+  f.compLeft circle
+#align pontryagin_dual.map PontryaginDual.map
+
+@[simp]
+theorem map_apply (f : ContinuousMonoidHom A B) (x : PontryaginDual B) (y : A) :
+    map f x y = x (f y) :=
+  rfl
+#align pontryagin_dual.map_apply PontryaginDual.map_apply
+
+@[simp]
+theorem map_one : map (one A B) = one (PontryaginDual B) (PontryaginDual A) :=
+  ext fun x => ext (fun _y => OneHomClass.map_one x)
+#align pontryagin_dual.map_one PontryaginDual.map_one
+
+@[simp]
+theorem map_comp (g : ContinuousMonoidHom B C) (f : ContinuousMonoidHom A B) :
+    map (comp g f) = ContinuousMonoidHom.comp (map f) (map g) :=
+  ext fun _x => ext fun _y => rfl
+#align pontryagin_dual.map_comp PontryaginDual.map_comp
+
+@[simp]
+nonrec theorem map_mul (f g : ContinuousMonoidHom A E) : map (f * g) = map f * map g :=
+  ext fun x => ext fun y => map_mul x (f y) (g y)
+#align pontryagin_dual.map_mul PontryaginDual.map_mul
+
+variable (A B C D E)
+
+/-- `ContinuousMonoidHom.dual` as a `ContinuousMonoidHom`. -/
+noncomputable def mapHom [LocallyCompactSpace E] :
+    ContinuousMonoidHom (ContinuousMonoidHom A E)
+      (ContinuousMonoidHom (PontryaginDual E) (PontryaginDual A)) where
+  toFun := map
+  map_one' := map_one
+  map_mul' := map_mul
+  continuous_toFun := continuous_of_continuous_uncurry _ continuous_comp
+#align pontryagin_dual.map_hom PontryaginDual.mapHom
+
+end PontryaginDual

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Thomas Browning. All rights reserved.
+Copyright (c) 2022 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -9,8 +9,7 @@ import Mathlib.Topology.Algebra.ContinuousMonoidHom
 #align_import topology.algebra.continuous_monoid_hom from "leanprover-community/mathlib"@"6ca1a09bc9aa75824bf97388c9e3b441fc4ccf3f"
 
 /-!
-
-# Continuous Monoid Homs
+# Pontryagin dual
 
 This file defines the Pontryagin dual of a topological group.
 


### PR DESCRIPTION
This PR splits off the Pontryagin dual to a separate file to avoid unnecessary imports in `ContinuousMonoidHom.lean`. For instance, local compactness of the Pontryagin dual will require some heavy imports such as Arzela-Ascoli and the fact that the exponential map is a covering map.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
