### PR TITLE
[Merged by Bors] - Refactor(Mathlib/CategoryTheory/Monoidal/Opposite): Make MonoidalOpposite a structure

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Opposite.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Opposite.lean
@@ -23,59 +23,47 @@ namespace CategoryTheory
 
 open CategoryTheory.MonoidalCategory
 
-/-- A type synonym for the monoidal opposite. Use the notation `Cᴹᵒᵖ`. -/
+/-- The type of objects of the opposite (or "reverse") monoidal category.
+Use the notation `Cᴹᵒᵖ`. -/
 -- @[nolint has_nonempty_instance] -- Porting note: This linter does not exist yet.
-def MonoidalOpposite (C : Type u₁) :=
-  C
+structure MonoidalOpposite (C : Type u₁) where
+  /-- The object of `MonoidalOpposite C` that represents `x : C`. -/ mop ::
+  /-- The object of `C` represented by `x : MonoidalOpposite C`. -/ unmop : C
 #align category_theory.monoidal_opposite CategoryTheory.MonoidalOpposite
+#align category_theory.monoidal_opposite.mop CategoryTheory.MonoidalOpposite.mop
+#align category_theory.monoidal_opposite.unmop CategoryTheory.MonoidalOpposite.unmop
 
 namespace MonoidalOpposite
 
 @[inherit_doc]
 notation:max C "ᴹᵒᵖ" => MonoidalOpposite C
 
-/-- Think of an object of `C` as an object of `Cᴹᵒᵖ`. -/
--- @[pp_nodot] -- Porting note: removed
-def mop (X : C) : Cᴹᵒᵖ :=
-  X
-#align category_theory.monoidal_opposite.mop CategoryTheory.MonoidalOpposite.mop
-
-/-- Think of an object of `Cᴹᵒᵖ` as an object of `C`. -/
--- @[pp_nodot] -- Porting note: removed
-def unmop (X : Cᴹᵒᵖ) : C :=
-  X
-#align category_theory.monoidal_opposite.unmop CategoryTheory.MonoidalOpposite.unmop
-
-theorem mop_injective : Function.Injective (mop : C → Cᴹᵒᵖ) :=
-  fun _ _ => id
+theorem mop_injective : Function.Injective (mop : C → Cᴹᵒᵖ) := @mop.inj C
 #align category_theory.monoidal_opposite.op_injective CategoryTheory.MonoidalOpposite.mop_injective
 
 theorem unmop_injective : Function.Injective (unmop : Cᴹᵒᵖ → C) :=
-  fun _ _ => id
+  fun _ _ h => congrArg mop h
 #align category_theory.monoidal_opposite.unop_injective CategoryTheory.MonoidalOpposite.unmop_injective
 
-@[simp]
-theorem mop_inj_iff (x y : C) : mop x = mop y ↔ x = y :=
-  Iff.rfl
+theorem mop_inj_iff (x y : C) : mop x = mop y ↔ x = y := mop_injective.eq_iff
 #align category_theory.monoidal_opposite.op_inj_iff CategoryTheory.MonoidalOpposite.mop_inj_iff
 
 @[simp]
-theorem unmop_inj_iff (x y : Cᴹᵒᵖ) : unmop x = unmop y ↔ x = y :=
-  Iff.rfl
+theorem unmop_inj_iff (x y : Cᴹᵒᵖ) : unmop x = unmop y ↔ x = y := unmop_injective.eq_iff
 #align category_theory.monoidal_opposite.unop_inj_iff CategoryTheory.MonoidalOpposite.unmop_inj_iff
 
 @[simp]
-theorem mop_unmop (X : Cᴹᵒᵖ) : mop (unmop X) = X :=
-  rfl
+theorem mop_unmop (X : Cᴹᵒᵖ) : mop (unmop X) = X := rfl
 #align category_theory.monoidal_opposite.mop_unmop CategoryTheory.MonoidalOpposite.mop_unmop
 
 @[simp]
-theorem unmop_mop (X : C) : unmop (mop X) = X :=
-  rfl
+theorem unmop_mop (X : C) : unmop (mop X) = X := rfl
 #align category_theory.monoidal_opposite.unmop_mop CategoryTheory.MonoidalOpposite.unmop_mop
 
-instance monoidalOppositeCategory [Category.{v₁} C] : Category Cᴹᵒᵖ :=
-  InducedCategory.category unmop
+instance monoidalOppositeCategory [Category.{v₁} C] : Category Cᴹᵒᵖ where
+  Hom X Y := (unmop X ⟶ unmop Y)ᴹᵒᵖ
+  id X := mop (𝟙 (unmop X))
+  comp f g := mop (unmop f ≫ unmop g)
 #align category_theory.monoidal_opposite.monoidal_opposite_category CategoryTheory.MonoidalOpposite.monoidalOppositeCategory
 
 end MonoidalOpposite
@@ -89,13 +77,11 @@ open CategoryTheory.MonoidalOpposite
 variable [Category.{v₁} C]
 
 /-- The monoidal opposite of a morphism `f : X ⟶ Y` is just `f`, thought of as `mop X ⟶ mop Y`. -/
-def Quiver.Hom.mop {X Y : C} (f : X ⟶ Y) : @Quiver.Hom Cᴹᵒᵖ _ (mop X) (mop Y) :=
-  f
+def Quiver.Hom.mop {X Y : C} (f : X ⟶ Y) : mop X ⟶ mop Y := MonoidalOpposite.mop f
 #align quiver.hom.mop Quiver.Hom.mop
 
 /-- We can think of a morphism `f : mop X ⟶ mop Y` as a morphism `X ⟶ Y`. -/
-def Quiver.Hom.unmop {X Y : Cᴹᵒᵖ} (f : X ⟶ Y) : unmop X ⟶ unmop Y :=
-  f
+def Quiver.Hom.unmop {X Y : Cᴹᵒᵖ} (f : X ⟶ Y) : unmop X ⟶ unmop Y := MonoidalOpposite.unmop f
 #align quiver.hom.unmop Quiver.Hom.unmop
 
 namespace Quiver.Hom
@@ -127,62 +113,63 @@ end Quiver.Hom
 namespace CategoryTheory
 
 @[simp]
-theorem mop_comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g).mop = f.mop ≫ g.mop :=
-  rfl
+theorem mop_comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} :
+    (f ≫ g).mop = f.mop ≫ g.mop := rfl
 #align category_theory.mop_comp CategoryTheory.mop_comp
 
 @[simp]
-theorem mop_id {X : C} : (𝟙 X).mop = 𝟙 (mop X) :=
-  rfl
+theorem mop_id {X : C} : (𝟙 X).mop = 𝟙 (mop X) := rfl
 #align category_theory.mop_id CategoryTheory.mop_id
 
 @[simp]
-theorem unmop_comp {X Y Z : Cᴹᵒᵖ} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g).unmop = f.unmop ≫ g.unmop :=
-  rfl
+theorem unmop_comp {X Y Z : Cᴹᵒᵖ} {f : X ⟶ Y} {g : Y ⟶ Z} :
+    (f ≫ g).unmop = f.unmop ≫ g.unmop := rfl
 #align category_theory.unmop_comp CategoryTheory.unmop_comp
 
 @[simp]
-theorem unmop_id {X : Cᴹᵒᵖ} : (𝟙 X).unmop = 𝟙 (unmop X) :=
-  rfl
+theorem unmop_id {X : Cᴹᵒᵖ} : (𝟙 X).unmop = 𝟙 (unmop X) := rfl
 #align category_theory.unmop_id CategoryTheory.unmop_id
 
 @[simp]
-theorem unmop_id_mop {X : C} : (𝟙 (mop X)).unmop = 𝟙 X :=
-  rfl
+theorem unmop_id_mop {X : C} : (𝟙 (mop X)).unmop = 𝟙 X := rfl
 #align category_theory.unmop_id_mop CategoryTheory.unmop_id_mop
 
 @[simp]
-theorem mop_id_unmop {X : Cᴹᵒᵖ} : (𝟙 (unmop X)).mop = 𝟙 X :=
-  rfl
+theorem mop_id_unmop {X : Cᴹᵒᵖ} : (𝟙 (unmop X)).mop = 𝟙 X := rfl
 #align category_theory.mop_id_unmop CategoryTheory.mop_id_unmop
+
+variable (C)
+
+def mopFunctor : C ⥤ Cᴹᵒᵖ := Functor.mk ⟨mop, .mop⟩
+def unmopFunctor : Cᴹᵒᵖ ⥤ C := Functor.mk ⟨unmop, .unmop⟩
+
+variable {C}
+
+@[simp] lemma mopFunctor_obj (X : C) : (mopFunctor C).obj X = mop X := rfl
+@[simp] lemma mopFunctor_map {X Y : C} (f : X ⟶ Y) : (mopFunctor C).map f = f.mop := rfl
+
+@[simp] lemma unmopFunctor_obj (X : Cᴹᵒᵖ) : (unmopFunctor C).obj X = unmop X := rfl
+@[simp] lemma unmopFunctor_map {X Y : Cᴹᵒᵖ} (f : X ⟶ Y) : (unmopFunctor C).map f = f.unmop := rfl
 
 namespace Iso
 
 /-- An isomorphism in `C` gives an isomorphism in `Cᴹᵒᵖ`. -/
-@[simps]
-def mop {X Y : C} (f : X ≅ Y) : mop X ≅ mop Y where
-  hom := f.hom.mop
-  inv := f.inv.mop
-  -- Porting note: it's a pity `attribute [aesop safe apply (rule_sets [CategoryTheory])] unmop_inj`
-  -- doesn't automate these proofs.
-  hom_inv_id := Quiver.Hom.unmop_inj (hom_inv_id f)
-  inv_hom_id := Quiver.Hom.unmop_inj (inv_hom_id f)
+@[reducible]
+def mop {X Y : C} (f : X ≅ Y) : mop X ≅ mop Y := (mopFunctor C).mapIso f
 #align category_theory.iso.mop CategoryTheory.Iso.mop
 
 /-- An isomorphism in `Cᴹᵒᵖ` gives an isomorphism in `C`. -/
-@[simps]
-def unmop {X Y : Cᴹᵒᵖ} (f : X ≅ Y) : unmop X ≅ unmop Y where
-  hom := f.hom.unmop
-  inv := f.inv.unmop
-  hom_inv_id := Quiver.Hom.mop_inj (hom_inv_id f)
-  inv_hom_id := Quiver.Hom.mop_inj (inv_hom_id f)
+@[reducible]
+def unmop {X Y : Cᴹᵒᵖ} (f : X ≅ Y) : unmop X ≅ unmop Y := (unmopFunctor C).mapIso f
 
 end Iso
 
 namespace IsIso
 
-instance {X Y : C}    (f : X ⟶ Y) [i : IsIso f] : IsIso f.mop := i
-instance {X Y : Cᴹᵒᵖ} (f : X ⟶ Y) [i : IsIso f] : IsIso f.unmop := i
+instance {X Y : C} (f : X ⟶ Y) [IsIso f] : IsIso f.mop :=
+  (mopFunctor C).map_isIso f
+instance {X Y : Cᴹᵒᵖ} (f : X ⟶ Y) [IsIso f] : IsIso f.unmop :=
+  (unmopFunctor C).map_isIso f
 
 end IsIso
 
@@ -202,11 +189,11 @@ instance monoidalCategoryOp : MonoidalCategory Cᵒᵖ where
   associator X Y Z := (α_ (unop X) (unop Y) (unop Z)).symm.op
   leftUnitor X := (λ_ (unop X)).symm.op
   rightUnitor X := (ρ_ (unop X)).symm.op
-  associator_naturality f g h := Quiver.Hom.unop_inj (by simp)
-  leftUnitor_naturality f := Quiver.Hom.unop_inj (by simp)
-  rightUnitor_naturality f := Quiver.Hom.unop_inj (by simp)
-  triangle X Y := Quiver.Hom.unop_inj (by dsimp; coherence)
-  pentagon W X Y Z := Quiver.Hom.unop_inj (by dsimp; coherence)
+  associator_naturality f g h := Quiver.Hom.unop_inj <| by simp
+  leftUnitor_naturality f := Quiver.Hom.unop_inj <| by simp
+  rightUnitor_naturality f := Quiver.Hom.unop_inj <| by simp
+  triangle X Y := Quiver.Hom.unop_inj <| by dsimp; coherence
+  pentagon W X Y Z := Quiver.Hom.unop_inj <| by dsimp; coherence
 #align category_theory.monoidal_category_op CategoryTheory.monoidalCategoryOp
 
 section OppositeLemmas
@@ -277,12 +264,12 @@ instance monoidalCategoryMop : MonoidalCategory Cᴹᵒᵖ where
   associator X Y Z := (α_ (unmop Z) (unmop Y) (unmop X)).symm.mop
   leftUnitor X := (ρ_ (unmop X)).mop
   rightUnitor X := (λ_ (unmop X)).mop
-  associator_naturality f g h := Quiver.Hom.unmop_inj (by simp)
-  leftUnitor_naturality f := Quiver.Hom.unmop_inj (by simp)
-  rightUnitor_naturality f := Quiver.Hom.unmop_inj (by simp)
+  associator_naturality f g h := Quiver.Hom.unmop_inj <| by simp
+  leftUnitor_naturality f := Quiver.Hom.unmop_inj <| by simp
+  rightUnitor_naturality f := Quiver.Hom.unmop_inj <| by simp
   -- Porting note: Changed `by coherence` to `by simp` below
-  triangle X Y := Quiver.Hom.unmop_inj (by simp)
-  pentagon W X Y Z := Quiver.Hom.unmop_inj (by dsimp; coherence)
+  triangle X Y := Quiver.Hom.unmop_inj <| by simp
+  pentagon W X Y Z := Quiver.Hom.unmop_inj <| by dsimp; coherence
 #align category_theory.monoidal_category_mop CategoryTheory.monoidalCategoryMop
 
 -- it would be nice if we could autogenerate all of these somehow
@@ -346,17 +333,20 @@ end MonoidalOppositeLemmas
 
 variable (C)
 
-/-- The identity functor on `C`, viewed as a functor from `C` to its monoidal opposite. -/
-@[simps!] def mopFunctor : C ⥤ Cᴹᵒᵖ := Functor.mk ⟨mop, .mop⟩
-/-- The identity functor on `C`, viewed as a functor from the monoidal opposite of `C` to `C`. -/
-@[simps!] def unmopFunctor : Cᴹᵒᵖ ⥤ C := Functor.mk ⟨unmop, .unmop⟩
-
 /-- The (identity) equivalence between `C` and its monoidal opposite. -/
-@[simps!] def MonoidalOpposite.underlyingEquiv : C ≌ Cᴹᵒᵖ := Equivalence.refl
+@[simps] def MonoidalOpposite.mopEquiv : C ≌ Cᴹᵒᵖ where
+  functor   := mopFunctor C
+  inverse   := unmopFunctor C
+  unitIso   := Iso.refl _
+  counitIso := Iso.refl _
+
+/-- The (identity) equivalence between `Cᴹᵒᵖ` and `C`. -/
+@[simps!] def MonoidalOpposite.unmopEquiv : Cᴹᵒᵖ ≌ C := (mopEquiv C).symm
 
 -- todo: upgrade to monoidal equivalence
 /-- The equivalence between `C` and its monoidal opposite's monoidal opposite. -/
-@[simps!] def MonoidalOpposite.mopMopEquivalence : Cᴹᵒᵖᴹᵒᵖ ≌ C := Equivalence.refl
+@[simps!] def MonoidalOpposite.mopMopEquivalence : Cᴹᵒᵖᴹᵒᵖ ≌ C :=
+  .trans (MonoidalOpposite.unmopEquiv Cᴹᵒᵖ) (MonoidalOpposite.unmopEquiv C)
 
 /-- The identification `mop X ⊗ mop Y = mop (Y ⊗ X)` as a natural isomorphism. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Monoidal/Opposite.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Opposite.lean
@@ -56,7 +56,7 @@ theorem unmop_inj_iff (x y : Cᴹᵒᵖ) : unmop x = unmop y ↔ x = y := unmop_
 theorem mop_unmop (X : Cᴹᵒᵖ) : mop (unmop X) = X := rfl
 #align category_theory.monoidal_opposite.mop_unmop CategoryTheory.MonoidalOpposite.mop_unmop
 
-@[simp]
+-- can't be simp bc after putting the lhs in whnf it's `X = X`
 theorem unmop_mop (X : C) : unmop (mop X) = X := rfl
 #align category_theory.monoidal_opposite.unmop_mop CategoryTheory.MonoidalOpposite.unmop_mop
 
@@ -140,16 +140,14 @@ theorem mop_id_unmop {X : Cᴹᵒᵖ} : (𝟙 (unmop X)).mop = 𝟙 X := rfl
 
 variable (C)
 
+/-- The identity functor on `C`, viewed as a functor from `C` to its monoidal opposite. -/
+@[simps obj map] -- need to specify `obj, map` or else we generate `mopFunctor_obj_unmop`
 def mopFunctor : C ⥤ Cᴹᵒᵖ := Functor.mk ⟨mop, .mop⟩
+/-- The identity functor on `C`, viewed as a functor from the monoidal opposite of `C` to `C`. -/
+@[simps obj map] -- not necessary but the symmetry with `mopFunctor` looks nicer
 def unmopFunctor : Cᴹᵒᵖ ⥤ C := Functor.mk ⟨unmop, .unmop⟩
 
 variable {C}
-
-@[simp] lemma mopFunctor_obj (X : C) : (mopFunctor C).obj X = mop X := rfl
-@[simp] lemma mopFunctor_map {X Y : C} (f : X ⟶ Y) : (mopFunctor C).map f = f.mop := rfl
-
-@[simp] lemma unmopFunctor_obj (X : Cᴹᵒᵖ) : (unmopFunctor C).obj X = unmop X := rfl
-@[simp] lemma unmopFunctor_map {X Y : Cᴹᵒᵖ} (f : X ⟶ Y) : (unmopFunctor C).map f = f.unmop := rfl
 
 namespace Iso
 


### PR DESCRIPTION
Refactor `MonoidalOpposite` into a structure for consistency with `Opposite`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
