### PR TITLE
[Merged by Bors] - chore(Algebra/Category): resolve porting notes `was not necessary in mathlib`

### DIFF
--- a/Mathlib/Algebra/Category/GroupWithZeroCat.lean
+++ b/Mathlib/Algebra/Category/GroupWithZeroCat.lean
@@ -52,7 +52,6 @@ instance : LargeCategory.{u} GroupWithZeroCat where
   comp_id := MonoidWithZeroHom.id_comp
   assoc _ _ _ := MonoidWithZeroHom.comp_assoc _ _ _
 
--- porting note: was not necessary in mathlib
 instance {M N : GroupWithZeroCat} : FunLike (M ⟶ N) M N :=
   ⟨fun f => f.toFun, fun f g h => by
     cases f
@@ -88,10 +87,6 @@ instance hasForgetToMon : HasForget₂ GroupWithZeroCat MonCat where
         map := fun f => f.toMonoidHom }
 set_option linter.uppercaseLean3 false in
 #align GroupWithZero.has_forget_to_Mon GroupWithZeroCat.hasForgetToMon
-
--- porting note: this instance was not necessary in mathlib
-instance {X Y : GroupWithZeroCat} : CoeFun (X ⟶ Y) fun _ => X → Y where
-  coe (f : X →*₀ Y) := f
 
 /-- Constructs an isomorphism of groups with zero from a group isomorphism between them. -/
 @[simps]


### PR DESCRIPTION
In this case https://github.com/leanprover-community/mathlib4/blob/4b36afcf085586739aa4e59d507a7d01d9a2dbbf/Mathlib/Algebra/Category/GroupWithZeroCat.lean#L55-L62 

and this case https://github.com/leanprover-community/mathlib4/blob/4b36afcf085586739aa4e59d507a7d01d9a2dbbf/Mathlib/Algebra/Category/GroupWithZeroCat.lean#L92-L94

`was not necessary in mathlib` seems to mean that Lean 4 does less work to see through definitional equalities when looking for instances.

I've commented the first instance out and it seems to be really needed since it returns errors, while the second one doesn't give any error when commented out.

In this PR I've removed the porting note comment for the first instance and removed the whole second instance.

Here is the associated comment on Zulip: https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Addressing.20porting.20notes.3F/near/421930836.