### PR TITLE
[Merged by Bors] - Refactor(Mathlib/CategoryTheory/Core): Make functorToCore compute

### DIFF
--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -77,9 +77,9 @@ variable {C} {G : Type u₂} [Groupoid.{v₂} G]
 -- Note that this function is not functorial
 -- (consider the two functors from [0] to [1], and the natural transformation between them).
 /-- A functor from a groupoid to a category C factors through the core of C. -/
-noncomputable def functorToCore (F : G ⥤ C) : G ⥤ Core C where
+def functorToCore (F : G ⥤ C) : G ⥤ Core C where
   obj X := F.obj X
-  map f := ⟨F.map f, F.map (inv f), _, _⟩
+  map f := ⟨F.map f, F.map (Groupoid.inv f), _, _⟩
 #align category_theory.core.functor_to_core CategoryTheory.Core.functorToCore
 
 /-- We can functorially associate to any functor from a groupoid to the core of a category `C`,


### PR DESCRIPTION
Change `functorToCore` to use `Groupoid.inv` instead of `IsIso.inv` and as a consequence make it's computable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is the 2nd time I've seen a noncomputable marker on a declaration because `inv` unqualified means `IsIso.inv` and not `Groupoid.inv`. I don't know what could be changed to mitigate this, but it seems like an ongoing problem

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
