### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/RootSystem/Defs): Properties of pairs of roots

### DIFF
--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -130,7 +130,7 @@ lemma reflection_dualMap_eq_coreflection :
   simp [coreflection_apply, reflection_apply, mul_comm (P.toLin m (P.coroot i))]
 
 lemma isCrystallographic_iff :
-    P.IsCrystallographic ↔ ∀ i j, ∃ (z : ℤ), z = P.pairing i j := by
+    P.IsCrystallographic ↔ ∀ i j, ∃ z : ℤ, z = P.pairing i j := by
   rw [IsCrystallographic]
   refine ⟨fun h i j ↦ ?_, fun h i _ ⟨j, hj⟩ ↦ ?_⟩
   · simpa [AddSubgroup.mem_zmultiples_iff] using h i (mem_range_self j)

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -129,6 +129,13 @@ lemma reflection_dualMap_eq_coreflection :
   ext n m
   simp [coreflection_apply, reflection_apply, mul_comm (P.toLin m (P.coroot i))]
 
+lemma isCrystallographic_iff :
+    P.IsCrystallographic ↔ ∀ i j, ∃ (z : ℤ), z = P.pairing i j := by
+  rw [IsCrystallographic]
+  refine ⟨fun h i j ↦ ?_, fun h i _ ⟨j, hj⟩ ↦ ?_⟩
+  · simpa [AddSubgroup.mem_zmultiples_iff] using h i (mem_range_self j)
+  · simpa [← hj, AddSubgroup.mem_zmultiples_iff] using h i j
+
 variable [Finite ι]
 
 lemma eq_of_pairing_pairing_eq_two [NoZeroSMulDivisors ℤ M] (i j : ι)

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -131,21 +131,16 @@ lemma reflection_dualMap_eq_coreflection :
 
 variable [Finite ι]
 
-/-- Even though the roots may not span, coroots are distinguished by their pairing with the
-roots. The proof depends crucially on the fact that there are finitely-many roots.
-
-Modulo trivial generalisations, this statement is exactly Lemma 1.1.4 on page 87 of SGA 3 XXI.
-See also `RootPairing.injOn_dualMap_subtype_span_root_coroot` for a more useful restatement. -/
-lemma eq_of_forall_coroot_root_eq [NoZeroSMulDivisors ℤ M] (i j : ι)
-    (h : ∀ k, P.pairing k i = P.pairing k j) :
+lemma eq_of_pairing_pairing_eq_two [NoZeroSMulDivisors ℤ M] (i j : ι)
+    (hij : P.pairing i j = 2) (hji : P.pairing j i = 2) :
     i = j := by
   set α := P.root i
   set β := P.root j
   set sα : M ≃ₗ[R] M := P.reflection i
   set sβ : M ≃ₗ[R] M := P.reflection j
   set sαβ : M ≃ₗ[R] M := sβ.trans sα
-  have hα : sα β = β - (2 : R) • α := by rw [P.reflection_apply_root, h j, P.pairing_same j]
-  have hβ : sβ α = α - (2 : R) • β := by rw [P.reflection_apply_root, ← h i, P.pairing_same i]
+  have hα : sα β = β - (2 : R) • α := by rw [P.reflection_apply_root, hji]
+  have hβ : sβ α = α - (2 : R) • β := by rw [P.reflection_apply_root, hij]
   have hb : BijOn sαβ (range P.root) (range P.root) :=
     (P.bijOn_reflection_root i).comp (P.bijOn_reflection_root j)
   set f : ℕ → M := fun n ↦ β + (2 * n : ℤ) • (α - β)
@@ -165,11 +160,17 @@ lemma eq_of_forall_coroot_root_eq [NoZeroSMulDivisors ℤ M] (i j : ι)
     sub_eq_zero] at hnm
   linarith [hnm.resolve_right (P.root.injective.ne this)]
 
+/-- Even though the roots may not span, coroots are distinguished by their pairing with the
+roots. The proof depends crucially on the fact that there are finitely-many roots.
+
+Modulo trivial generalisations, this statement is exactly Lemma 1.1.4 on page 87 of SGA 3 XXI. -/
 lemma injOn_dualMap_subtype_span_root_coroot [NoZeroSMulDivisors ℤ M] :
     InjOn ((span R (range P.root)).subtype.dualMap ∘ₗ P.toLin.flip) (range P.coroot) := by
   rintro - ⟨i, rfl⟩ - ⟨j, rfl⟩ hij
   congr
-  refine P.eq_of_forall_coroot_root_eq i j fun k ↦ ?_
+  suffices ∀ k, P.pairing k i = P.pairing k j from
+    P.eq_of_pairing_pairing_eq_two i j (by simp [← this i]) (by simp [this j])
+  intro k
   simpa using LinearMap.congr_fun hij ⟨P.root k, Submodule.subset_span (mem_range_self k)⟩
 
 /-- In characteristic zero if there is no torsion, the correspondence between roots and coroots is

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -49,14 +49,30 @@ lemma ne_zero [CharZero R] : (P.root i : M) ≠ 0 :=
 lemma ne_zero' [CharZero R] : (P.coroot i : N) ≠ 0 :=
   fun h ↦ by simpa [h] using P.root_coroot_two i
 
+@[simp]
+lemma root_coroot_eq_pairing (j : ι) :
+    P.toLin (P.root i) (P.coroot j) = P.pairing i j :=
+  rfl
+
+lemma coroot_root_eq_pairing (j : ι) :
+    P.toLin.flip (P.coroot i) (P.root j) = P.pairing j i := by
+  simp
+
+@[simp]
+lemma pairing_same : P.pairing i i = 2 := P.root_coroot_two i
+
 lemma coroot_root_two :
-    (P.toLin.flip (P.coroot i)) (P.root i) = 2 := by
-  rw [LinearMap.flip_apply, P.root_coroot_two i]
+    P.toLin.flip (P.coroot i) (P.root i) = 2 := by
+  simp
 
 @[simp] lemma flip_flip : P.flip.flip = P := rfl
 
 lemma reflection_apply (x : M) :
     P.reflection i x = x - (P.toLin x (P.coroot i)) • P.root i :=
+  rfl
+
+lemma reflection_apply_root (j : ι) :
+    P.reflection i (P.root j) = P.root j - (P.pairing j i) • P.root i :=
   rfl
 
 @[simp]
@@ -121,15 +137,15 @@ roots. The proof depends crucially on the fact that there are finitely-many root
 Modulo trivial generalisations, this statement is exactly Lemma 1.1.4 on page 87 of SGA 3 XXI.
 See also `RootPairing.injOn_dualMap_subtype_span_root_coroot` for a more useful restatement. -/
 lemma eq_of_forall_coroot_root_eq [NoZeroSMulDivisors ℤ M] (i j : ι)
-    (h : ∀ k, P.toLin (P.root k) (P.coroot i) = P.toLin (P.root k) (P.coroot j)) :
+    (h : ∀ k, P.pairing k i = P.pairing k j) :
     i = j := by
   set α := P.root i
   set β := P.root j
   set sα : M ≃ₗ[R] M := P.reflection i
   set sβ : M ≃ₗ[R] M := P.reflection j
   set sαβ : M ≃ₗ[R] M := sβ.trans sα
-  have hα : sα β = β - (2 : R) • α := by rw [P.reflection_apply, h j, P.root_coroot_two j]
-  have hβ : sβ α = α - (2 : R) • β := by rw [P.reflection_apply, ← h i, P.root_coroot_two i]
+  have hα : sα β = β - (2 : R) • α := by rw [P.reflection_apply_root, h j, P.pairing_same j]
+  have hβ : sβ α = α - (2 : R) • β := by rw [P.reflection_apply_root, ← h i, P.pairing_same i]
   have hb : BijOn sαβ (range P.root) (range P.root) :=
     (P.bijOn_reflection_root i).comp (P.bijOn_reflection_root j)
   set f : ℕ → M := fun n ↦ β + (2 * n : ℤ) • (α - β)

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -110,9 +110,10 @@ always an integer.-/
 def IsCrystallographic : Prop :=
   ∀ i, MapsTo (P.toLin (P.root i)) (range P.coroot) (zmultiples (1 : R))
 
-/-- A root pairing is said to be reduced if it never contains the double of a root.-/
+/-- A root pairing is said to be reduced if any linearly dependent pair of roots is related by a
+sign. -/
 def IsReduced : Prop :=
-  ∀ i, 2 • P.root i ∉ range P.root
+  ∀ i j, ¬ LinearIndependent R ![P.root i, P.root j] → (P.root i = P.root j ∨ P.root i = - P.root j)
 
 /-- If we interchange the roles of `M` and `N`, we still have a root pairing. -/
 protected def flip : RootPairing ι R N M :=
@@ -133,7 +134,7 @@ def coreflection : N ≃ₗ[R] N :=
 
 section pairs
 
-variable (i j : ι)
+variable (j : ι)
 
 /-- This is the pairing between roots and coroots. -/
 def pairing : R := P.toLin (P.root i) (P.coroot j)
@@ -144,33 +145,3 @@ def coxeterWeight : R := pairing P i j * pairing P j i
 
 /-- Two roots are orthogonal when they are fixed by each others' reflections. -/
 def IsOrthogonal : Prop := pairing P i j = 0 ∧ pairing P j i = 0
-
-/-- A pair of roots is nonsymmetrizable if the existence of a Weyl-invariant form on their span is
-obstructed.  When `R` has no zero divisors, this happens when exactly one root is fixed by the
-other's reflection. -/
-def IsNonSymmetrizable : Prop := coxeterWeight P i j = 0 ∧ ¬ IsOrthogonal P i j
-
-/-- Two roots are parallel if their Coxeter weight is exactly 4.  A linearly independent pair of
-parallel roots generates an infinite dihedral group of reflections on their span, and their span
-has an invariant singular line. -/
-def IsParallel : Prop := coxeterWeight P i j = 4
-
-variable [LinearOrderedCommRing R]
-
-/-- An imaginary pair is one whose Coxeter weight is negative.  Any symmetrization yields an
-invariant form where one of the roots has negative norm and the other has positive norm. Root
-systems with imaginary pairs are not often considered, since the geometry of reflection is
-cumbersome. -/
-def IsImaginary : Prop := coxeterWeight P i j < 0
-
-/-- A pair of roots is definite if there is a unique (up to scalars) definite reflection-invariant
-form on their span. This happens precisely when the Coxeter weight is strictly between `0` and `4`.
--/
-def IsDefinite : Prop := 0 < coxeterWeight P i j ∧ coxeterWeight P i j < 4
-
-/-- A pair of roots is ultraparallel if its Coxeter weight is strictly greater than 4.
-Symmetrization induces a nondegenerate indefinite form on the span, and reflections generate an
-infinite dihedral group. -/
-def IsUltraParallel : Prop := 4 < coxeterWeight P i j
-
-end pairs

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -28,9 +28,9 @@ This file contains basic definitions for root systems and root data.
 ## Todo
 
 * Introduce the Weyl Group
-* Coxeter weights of pairs
-* Properties of pairs of roots, e.g., parallel, ultraparallel, definite, orthogonal, imaginary,
-non-symmetrizable
+* Base change of root pairings.
+* Isomorphism of root pairings.
+* Crystallographic root systems are isomorphic to base changes of root systems over ℤ?
 
 ## Implementation details
 
@@ -130,3 +130,47 @@ def reflection : M ≃ₗ[R] M :=
 /-- The reflection associated to a coroot. -/
 def coreflection : N ≃ₗ[R] N :=
   Module.reflection (P.root_coroot_two i)
+
+section pairs
+
+variable (i j : ι)
+
+/-- This is the pairing between roots and coroots. (Is this a bad name? It seems to be standard.) -/
+def n : R := P.toLin (P.root i) (P.coroot j)
+
+/-- The Coxeter Weight of a pair gives the weight of an edge in a Coxeter diagram, when it is
+finite.  It is `4 cos² θ`, where `θ` describes the dihedral angle between hyperplanes. -/
+def CoxeterWeight : R := n P i j * n P j i
+
+/-- Two roots are orthogonal when they are fixed by each others' reflections. -/
+def isOrthogonal : Prop := n P i j = 0 ∧ n P j i = 0
+
+/-- A pair of roots is nonsymmetrizable if exactly one is fixed by the other's reflection.  This is
+an obstruction to the existence of a Weyl-invariant form. We have written this in a way that assumes
+`R` has no zero divisors, so perhaps this docstring needs to be revised. -/
+def isNonSymmetrizable : Prop := CoxeterWeight P i j = 0 ∧ ¬ isOrthogonal P i j
+
+/-- Two roots are parallel if their Coxeter weight is exactly 4.  A linearly independent pair of
+parallel roots generates an infinite dihedral group of reflections on their span, and their span
+has an invariant singular line. -/
+def isParallel : Prop := CoxeterWeight P i j = 4
+
+variable [LinearOrderedCommRing R]
+
+/-- An imaginary pair is one whose Coxeter weight is negative.  Any symmetrization yields an
+invariant form where one of the roots has negative norm and the other has positive norm. Root
+systems with imaginary pairs are not often considered, since the geometry of reflection is
+cumbersome. -/
+def isImaginary : Prop := CoxeterWeight P i j < 0
+
+/-- A pair of roots is definite if there is a unique (up to scalars) definite reflection-invariant
+form on their span. This happens precisely when the Coxeter weight is strictly between `0` and `4`.
+-/
+def isDefinite : Prop := 0 < CoxeterWeight P i j ∧ CoxeterWeight P i j < 4
+
+/-- A pair of roots is ultraparallel if its Coxeter weight is strictly greater than 4.
+Symmetrization induces a nondegenerate indefinite form on the span, and reflections generate an
+infinite dihedral group. -/
+def isUltraParallel : Prop := 4 < CoxeterWeight P i j
+
+end pairs

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -135,25 +135,25 @@ section pairs
 
 variable (i j : ι)
 
-/-- This is the pairing between roots and coroots. (Is this a bad name? It seems to be standard.) -/
-def n : R := P.toLin (P.root i) (P.coroot j)
+/-- This is the pairing between roots and coroots. -/
+def pairing : R := P.toLin (P.root i) (P.coroot j)
 
 /-- The Coxeter Weight of a pair gives the weight of an edge in a Coxeter diagram, when it is
 finite.  It is `4 cos² θ`, where `θ` describes the dihedral angle between hyperplanes. -/
-def CoxeterWeight : R := n P i j * n P j i
+def coxeterWeight : R := pairing P i j * pairing P j i
 
 /-- Two roots are orthogonal when they are fixed by each others' reflections. -/
-def isOrthogonal : Prop := n P i j = 0 ∧ n P j i = 0
+def IsOrthogonal : Prop := pairing P i j = 0 ∧ pairing P j i = 0
 
-/-- A pair of roots is nonsymmetrizable if exactly one is fixed by the other's reflection.  This is
-an obstruction to the existence of a Weyl-invariant form. We have written this in a way that assumes
-`R` has no zero divisors, so perhaps this docstring needs to be revised. -/
-def isNonSymmetrizable : Prop := CoxeterWeight P i j = 0 ∧ ¬ isOrthogonal P i j
+/-- A pair of roots is nonsymmetrizable if the existence of a Weyl-invariant form on their span is
+obstructed.  When `R` has no zero divisors, this happens when exactly one root is fixed by the
+other's reflection. -/
+def IsNonSymmetrizable : Prop := coxeterWeight P i j = 0 ∧ ¬ IsOrthogonal P i j
 
 /-- Two roots are parallel if their Coxeter weight is exactly 4.  A linearly independent pair of
 parallel roots generates an infinite dihedral group of reflections on their span, and their span
 has an invariant singular line. -/
-def isParallel : Prop := CoxeterWeight P i j = 4
+def IsParallel : Prop := coxeterWeight P i j = 4
 
 variable [LinearOrderedCommRing R]
 
@@ -161,16 +161,16 @@ variable [LinearOrderedCommRing R]
 invariant form where one of the roots has negative norm and the other has positive norm. Root
 systems with imaginary pairs are not often considered, since the geometry of reflection is
 cumbersome. -/
-def isImaginary : Prop := CoxeterWeight P i j < 0
+def IsImaginary : Prop := coxeterWeight P i j < 0
 
 /-- A pair of roots is definite if there is a unique (up to scalars) definite reflection-invariant
 form on their span. This happens precisely when the Coxeter weight is strictly between `0` and `4`.
 -/
-def isDefinite : Prop := 0 < CoxeterWeight P i j ∧ CoxeterWeight P i j < 4
+def IsDefinite : Prop := 0 < coxeterWeight P i j ∧ coxeterWeight P i j < 4
 
 /-- A pair of roots is ultraparallel if its Coxeter weight is strictly greater than 4.
 Symmetrization induces a nondegenerate indefinite form on the span, and reflections generate an
 infinite dihedral group. -/
-def isUltraParallel : Prop := 4 < CoxeterWeight P i j
+def IsUltraParallel : Prop := 4 < coxeterWeight P i j
 
 end pairs


### PR DESCRIPTION
Given a pair of roots, we can describe the "angle" between them using the pairing between root `i` and coroot `j` together with the reverse pairing.  This PR adds language for describing the various cases.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
