### PR TITLE
[Merged by Bors] - feat(NumberTheory/ArithmeticFunction): Basic lemmas about `μ^2`

### DIFF
--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -1073,16 +1073,15 @@ theorem abs_moebius_eq_one_of_squarefree {l : ℕ} (hl : Squarefree l) : |μ l| 
 theorem moebius_sq {n : ℕ} :
     μ n ^ 2 = if Squarefree n then 1 else 0 := by
   split_ifs with h
-  · exact moebius_sq_of_squarefree h
-  · simp only [Nat.isUnit_iff, zero_lt_two, pow_eq_zero_iff, moebius_eq_zero_of_not_squarefree h,
-      zero_pow (show 2 ≠ 0 by norm_num)]
+  · exact moebius_sq_eq_one_of_squarefree h
+  · simp only [pow_eq_zero_iff, moebius_eq_zero_of_not_squarefree h,
+    zero_pow (show 2 ≠ 0 by norm_num)]
 
 theorem abs_moebius {n : ℕ} :
     |μ n| = if Squarefree n then 1 else 0 := by
   split_ifs with h
-  · exact abs_moebius_of_squarefree h
-  · simp only [Nat.isUnit_iff, zero_lt_two, pow_eq_zero_iff, moebius_eq_zero_of_not_squarefree h,
-      abs_zero]
+  · exact abs_moebius_eq_one_of_squarefree h
+  · simp only [moebius_eq_zero_of_not_squarefree h, abs_zero]
 
 theorem moebius_apply_prime {p : ℕ} (hp : p.Prime) : μ p = -1 := by
   rw [moebius_apply_of_squarefree hp.squarefree, cardFactors_apply_prime hp, pow_one]

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -1064,10 +1064,10 @@ theorem moebius_ne_zero_iff_eq_or {n : ℕ} : μ n ≠ 0 ↔ μ n = 1 ∨ μ n =
   · rcases h with (h | h) <;> simp [h]
 #align nat.arithmetic_function.moebius_ne_zero_iff_eq_or ArithmeticFunction.moebius_ne_zero_iff_eq_or
 
-theorem moebius_sq_of_squarefree {l : ℕ} (hl : Squarefree l) : μ l ^ 2 = 1 := by
+theorem moebius_sq_eq_one_of_squarefree {l : ℕ} (hl : Squarefree l) : μ l ^ 2 = 1 := by
   rw [moebius_apply_of_squarefree hl, ← pow_mul, mul_comm, pow_mul, neg_one_sq, one_pow]
 
-theorem abs_moebius_of_squarefree {l : ℕ} (hl : Squarefree l) : |μ l| = 1 := by
+theorem abs_moebius_eq_one_of_squarefree {l : ℕ} (hl : Squarefree l) : |μ l| = 1 := by
   simp only [moebius_apply_of_squarefree hl, abs_pow, abs_neg, abs_one, one_pow]
 
 theorem moebius_sq {n : ℕ} :

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -1065,7 +1065,7 @@ theorem moebius_ne_zero_iff_eq_or {n : ℕ} : μ n ≠ 0 ↔ μ n = 1 ∨ μ n =
 #align nat.arithmetic_function.moebius_ne_zero_iff_eq_or ArithmeticFunction.moebius_ne_zero_iff_eq_or
 
 theorem moebius_sq_of_squarefree {l : ℕ} (hl : Squarefree l) : μ l ^ 2 = 1 := by
-  rw [moebius_apply_of_squarefree hl, ←pow_mul, mul_comm, pow_mul, neg_one_sq, one_pow]
+  rw [moebius_apply_of_squarefree hl, ← pow_mul, mul_comm, pow_mul, neg_one_sq, one_pow]
 
 theorem abs_moebius_of_squarefree {l : ℕ} (hl : Squarefree l) : |μ l| = 1 := by
   simp only [moebius_apply_of_squarefree hl, abs_pow, abs_neg, abs_one, one_pow]

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -1064,6 +1064,26 @@ theorem moebius_ne_zero_iff_eq_or {n : ℕ} : μ n ≠ 0 ↔ μ n = 1 ∨ μ n =
   · rcases h with (h | h) <;> simp [h]
 #align nat.arithmetic_function.moebius_ne_zero_iff_eq_or ArithmeticFunction.moebius_ne_zero_iff_eq_or
 
+theorem moebius_sq_of_squarefree {l : ℕ} (hl : Squarefree l) : μ l ^ 2 = 1 := by
+  rw [moebius_apply_of_squarefree hl, ←pow_mul, mul_comm, pow_mul, neg_one_sq, one_pow]
+
+theorem abs_moebius_of_squarefree {l : ℕ} (hl : Squarefree l) : |μ l| = 1 := by
+  simp only [moebius_apply_of_squarefree hl, abs_pow, abs_neg, abs_one, one_pow]
+
+theorem moebius_sq {n : ℕ} :
+    μ n ^ 2 = if Squarefree n then 1 else 0 := by
+  split_ifs with h
+  · exact moebius_sq_of_squarefree h
+  · simp only [Nat.isUnit_iff, zero_lt_two, pow_eq_zero_iff, moebius_eq_zero_of_not_squarefree h,
+      zero_pow (show 2 ≠ 0 by norm_num)]
+
+theorem abs_moebius {n : ℕ} :
+    |μ n| = if Squarefree n then 1 else 0 := by
+  split_ifs with h
+  · exact abs_moebius_of_squarefree h
+  · simp only [Nat.isUnit_iff, zero_lt_two, pow_eq_zero_iff, moebius_eq_zero_of_not_squarefree h,
+      abs_zero]
+
 theorem moebius_apply_prime {p : ℕ} (hp : p.Prime) : μ p = -1 := by
   rw [moebius_apply_of_squarefree hp.squarefree, cardFactors_apply_prime hp, pow_one]
 #align nat.arithmetic_function.moebius_apply_prime ArithmeticFunction.moebius_apply_prime


### PR DESCRIPTION
Basic results stating `μ^2` is the indicator function for squarefree natural numbers. This came up during my Selberg sieve project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
