### PR TITLE
[Merged by Bors] - chore: Remove `PosPart` notation class

### DIFF
--- a/Mathlib/Algebra/Order/Group/PosPart.lean
+++ b/Mathlib/Algebra/Order/Group/PosPart.lean
@@ -56,7 +56,7 @@ variable [Lattice α]
 section Group
 variable [Group α] [CovariantClass α α (· * ·) (· ≤ ·)]
   [CovariantClass α α (swap (· * ·)) (· ≤ ·)] {a : α}
-  
+
 #noalign has_pos_part
 #noalign has_neg_part
 #noalign lattice_ordered_comm_group.has_one_lattice_has_pos_part

--- a/Mathlib/Algebra/Order/Group/PosPart.lean
+++ b/Mathlib/Algebra/Order/Group/PosPart.lean
@@ -56,7 +56,9 @@ variable [Lattice α]
 section Group
 variable [Group α] [CovariantClass α α (· * ·) (· ≤ ·)]
   [CovariantClass α α (swap (· * ·)) (· ≤ ·)] {a : α}
-
+  
+#noalign has_pos_part
+#noalign has_neg_part
 #noalign lattice_ordered_comm_group.has_one_lattice_has_pos_part
 #noalign lattice_ordered_comm_group.has_zero_lattice_has_pos_part
 #noalign lattice_ordered_comm_group.has_one_lattice_has_neg_part

--- a/Mathlib/Algebra/Order/Group/PosPart.lean
+++ b/Mathlib/Algebra/Order/Group/PosPart.lean
@@ -44,28 +44,6 @@ lattice ordered group.
 positive part, negative part
 -/
 
-/-- The positive part of an element admitting a decomposition into positive and negative parts.
--/
-class PosPart (α : Type*) where
-  /-- The positive part function. -/
-  pos : α → α
-
-#align has_pos_part PosPart
-
-/-- The negative part of an element admitting a decomposition into positive and negative parts.
--/
-class NegPart (α : Type*) where
-  /-- The negative part function. -/
-  neg : α → α
-
-#align has_neg_part NegPart
-
-@[inherit_doc]
-postfix:max "⁺" => PosPart.pos
-
-@[inherit_doc]
-postfix:max "⁻" => NegPart.neg
-
 open Function
 
 universe u v


### PR DESCRIPTION
These two notation classes should have been removed in #9740


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
