### PR TITLE
[Merged by Bors] - move: Algebraic pi instances

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -192,7 +192,8 @@ import Mathlib.Algebra.Group.NatPowAssoc
 import Mathlib.Algebra.Group.Opposite
 import Mathlib.Algebra.Group.OrderSynonym
 import Mathlib.Algebra.Group.PNatPowAssoc
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Basic
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Group.Semiconj.Basic
 import Mathlib.Algebra.Group.Semiconj.Defs
@@ -1912,7 +1913,6 @@ import Mathlib.Data.PNat.Prime
 import Mathlib.Data.PNat.Xgcd
 import Mathlib.Data.PSigma.Order
 import Mathlib.Data.Part
-import Mathlib.Data.Pi.Algebra
 import Mathlib.Data.Pi.Interval
 import Mathlib.Data.Pi.Lex
 import Mathlib.Data.Polynomial.AlgebraMap

--- a/Mathlib/Algebra/Category/GroupCat/Biproducts.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Biproducts.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Category.GroupCat.Preadditive
 import Mathlib.CategoryTheory.Preadditive.Biproducts
 import Mathlib.Algebra.Category.GroupCat.Limits

--- a/Mathlib/Algebra/Category/ModuleCat/Biproducts.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Biproducts.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.CategoryTheory.Limits.Shapes.Biproducts
 import Mathlib.Algebra.Category.ModuleCat.Abelian
 import Mathlib.Algebra.Homology.ShortComplex.ModuleCat

--- a/Mathlib/Algebra/Category/MonCat/Limits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Limits.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import Mathlib.Algebra.Category.MonCat.Basic
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.CategoryTheory.Limits.Creates
 import Mathlib.CategoryTheory.Limits.Types
 import Mathlib.GroupTheory.Submonoid.Operations

--- a/Mathlib/Algebra/Divisibility/Prod.lean
+++ b/Mathlib/Algebra/Divisibility/Prod.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 import Mathlib.Algebra.Divisibility.Basic
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.Prod
 
 /-!

--- a/Mathlib/Algebra/Divisibility/Prod.lean
+++ b/Mathlib/Algebra/Divisibility/Prod.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 import Mathlib.Algebra.Divisibility.Basic
-import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.Prod
 
 /-!

--- a/Mathlib/Algebra/Function/Indicator.lean
+++ b/Mathlib/Algebra/Function/Indicator.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou
 -/
 import Mathlib.Algebra.Function.Support
+import Mathlib.Algebra.Group.Pi.Lemmas
 
 #align_import algebra.indicator_function from "leanprover-community/mathlib"@"2445c98ae4b87eabebdde552593519b9b6dc350c"
 

--- a/Mathlib/Algebra/Function/Support.lean
+++ b/Mathlib/Algebra/Function/Support.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Order.Cover
 

--- a/Mathlib/Algebra/Function/Support.lean
+++ b/Mathlib/Algebra/Function/Support.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Order.Cover
 

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Kevin Buzzard, Scott Morrison, Johan Commelin, Chris Hughes,
   Johannes Hölzl, Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Data.FunLike.Basic
-import Mathlib.Data.Pi.Algebra
 
 #align_import algebra.hom.group from "leanprover-community/mathlib"@"a148d797a1094ab554ad4183a4ad6f130358ef64"
 

--- a/Mathlib/Algebra/Group/NatPowAssoc.lean
+++ b/Mathlib/Algebra/Group/NatPowAssoc.lean
@@ -3,11 +3,7 @@ Copyright (c) 2023 Scott Carnahan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Carnahan
 -/
-
-import Mathlib.Algebra.Group.Defs
 import Mathlib.Algebra.GroupPower.Basic
-import Mathlib.Algebra.Group.Prod
-import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.GroupTheory.GroupAction.Prod
 import Mathlib.Data.Int.Basic
 import Mathlib.Data.Nat.Cast.Basic

--- a/Mathlib/Algebra/Group/NatPowAssoc.lean
+++ b/Mathlib/Algebra/Group/NatPowAssoc.lean
@@ -7,7 +7,7 @@ Authors: Scott Carnahan
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.Group.Prod
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.GroupTheory.GroupAction.Prod
 import Mathlib.Data.Int.Basic
 import Mathlib.Data.Nat.Cast.Basic

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -5,18 +5,29 @@ Authors: Simon Hudon, Patrick Massot, Eric Wieser
 -/
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Data.Prod.Basic
-import Mathlib.Logic.Unique
 import Mathlib.Data.Sum.Basic
+import Mathlib.Logic.Unique
+import Mathlib.Tactic.Spread
 
 #align_import data.pi.algebra from "leanprover-community/mathlib"@"70d50ecfd4900dd6d328da39ab7ebd516abe4025"
 
 /-!
 # Instances and theorems on pi types
 
-This file provides basic definitions and notation instances for Pi types.
+This file provides instances for the typeclass defined in `Algebra.Group.Defs`. More sophisticated
+instances are defined in `Algebra.Group.Pi.Lemmas` files elsewhere.
 
-Instances of more sophisticated classes are defined in `Pi.lean` files elsewhere.
+## Porting note
+
+This file relied on the `pi_instance` tactic, which was not available at the time of porting. The
+comment `--pi_instance` is inserted before all fields which were previously derived by
+`pi_instance`. See this Zulip discussion:
+[https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/not.20porting.20pi_instance]
 -/
+
+-- We enforce to only import `Algebra.Group.Defs` and basic logic
+assert_not_exists Set.range
+assert_not_exists MonoidHom
 
 open Function
 
@@ -213,6 +224,130 @@ theorem div_comp [Div γ] (x y : β → γ) (z : α → β) : (x / y) ∘ z = x 
 lemma _root_.Function.const_div [Div β] (a b : β) : const α a / const α b = const α (a / b) := rfl
 #align pi.const_div Function.const_div
 #align pi.const_sub Function.const_sub
+
+@[to_additive]
+instance semigroup [∀ i, Semigroup (f i)] : Semigroup (∀ i, f i) where
+  mul_assoc := by intros; ext; exact mul_assoc _ _ _
+#align pi.semigroup Pi.semigroup
+#align pi.add_semigroup Pi.addSemigroup
+
+@[to_additive]
+instance commSemigroup [∀ i, CommSemigroup (f i)] : CommSemigroup (∀ i, f i) where
+  mul_comm := by intros; ext; exact mul_comm _ _
+#align pi.comm_semigroup Pi.commSemigroup
+#align pi.add_comm_semigroup Pi.addCommSemigroup
+
+@[to_additive]
+instance mulOneClass [∀ i, MulOneClass (f i)] : MulOneClass (∀ i, f i) where
+  one_mul := by intros; ext; exact one_mul _
+  mul_one := by intros; ext; exact mul_one _
+#align pi.mul_one_class Pi.mulOneClass
+#align pi.add_zero_class Pi.addZeroClass
+
+@[to_additive]
+instance invOneClass [∀ i, InvOneClass (f i)] : InvOneClass (∀ i, f i) where
+  inv_one := by intros; ext; exact inv_one
+
+@[to_additive]
+instance monoid [∀ i, Monoid (f i)] : Monoid (∀ i, f i) where
+  __ := semigroup
+  __ := mulOneClass
+  npow := fun n x i => x i ^ n
+  npow_zero := by intros; ext; exact Monoid.npow_zero _
+  npow_succ := by intros; ext; exact Monoid.npow_succ _ _
+#align pi.monoid Pi.monoid
+#align pi.add_monoid Pi.addMonoid
+
+@[to_additive]
+instance commMonoid [∀ i, CommMonoid (f i)] : CommMonoid (∀ i, f i) :=
+  { monoid, commSemigroup with }
+#align pi.comm_monoid Pi.commMonoid
+#align pi.add_comm_monoid Pi.addCommMonoid
+
+@[to_additive Pi.subNegMonoid]
+instance divInvMonoid [∀ i, DivInvMonoid (f i)] : DivInvMonoid (∀ i, f i) where
+  zpow := fun z x i => x i ^ z
+  div_eq_mul_inv := by intros; ext; exact div_eq_mul_inv _ _
+  zpow_zero' := by intros; ext; exact DivInvMonoid.zpow_zero' _
+  zpow_succ' := by intros; ext; exact DivInvMonoid.zpow_succ' _ _
+  zpow_neg' := by intros; ext; exact DivInvMonoid.zpow_neg' _ _
+
+@[to_additive Pi.subNegZeroMonoid]
+instance divInvOneMonoid [∀ i, DivInvOneMonoid (f i)] : DivInvOneMonoid (∀ i, f i) where
+  inv_one := by ext; exact inv_one
+
+@[to_additive]
+instance involutiveInv [∀ i, InvolutiveInv (f i)] : InvolutiveInv (∀ i, f i) where
+  inv_inv := by intros; ext; exact inv_inv _
+
+@[to_additive Pi.subtractionMonoid]
+instance divisionMonoid [∀ i, DivisionMonoid (f i)] : DivisionMonoid (∀ i, f i) where
+  __ := divInvMonoid
+  __ := involutiveInv
+  mul_inv_rev := by intros; ext; exact mul_inv_rev _ _
+  inv_eq_of_mul := by intros _ _ h; ext; exact DivisionMonoid.inv_eq_of_mul _ _ (congrFun h _)
+
+@[to_additive instSubtractionCommMonoid]
+instance divisionCommMonoid [∀ i, DivisionCommMonoid (f i)] : DivisionCommMonoid (∀ i, f i) :=
+  { divisionMonoid, commSemigroup with }
+
+@[to_additive]
+instance group [∀ i, Group (f i)] : Group (∀ i, f i) where
+  mul_left_inv := by intros; ext; exact mul_left_inv _
+#align pi.group Pi.group
+#align pi.add_group Pi.addGroup
+
+@[to_additive]
+instance commGroup [∀ i, CommGroup (f i)] : CommGroup (∀ i, f i) := { group, commMonoid with }
+#align pi.comm_group Pi.commGroup
+#align pi.add_comm_group Pi.addCommGroup
+
+@[to_additive] instance instIsLeftCancelMul [∀ i, Mul (f i)] [∀ i, IsLeftCancelMul (f i)] :
+    IsLeftCancelMul (∀ i, f i) where
+  mul_left_cancel  _ _ _ h := funext fun _ ↦ mul_left_cancel (congr_fun h _)
+
+@[to_additive] instance instIsRightCancelMul [∀ i, Mul (f i)] [∀ i, IsRightCancelMul (f i)] :
+    IsRightCancelMul (∀ i, f i) where
+  mul_right_cancel  _ _ _ h := funext fun _ ↦ mul_right_cancel (congr_fun h _)
+
+@[to_additive] instance instIsCancelMul [∀ i, Mul (f i)] [∀ i, IsCancelMul (f i)] :
+    IsCancelMul (∀ i, f i) where
+
+@[to_additive]
+instance leftCancelSemigroup [∀ i, LeftCancelSemigroup (f i)] : LeftCancelSemigroup (∀ i, f i) :=
+  { semigroup with mul_left_cancel := fun _ _ _ => mul_left_cancel }
+#align pi.left_cancel_semigroup Pi.leftCancelSemigroup
+#align pi.add_left_cancel_semigroup Pi.addLeftCancelSemigroup
+
+@[to_additive]
+instance rightCancelSemigroup [∀ i, RightCancelSemigroup (f i)] : RightCancelSemigroup (∀ i, f i) :=
+  { semigroup with mul_right_cancel := fun _ _ _ => mul_right_cancel }
+#align pi.right_cancel_semigroup Pi.rightCancelSemigroup
+#align pi.add_right_cancel_semigroup Pi.addRightCancelSemigroup
+
+@[to_additive]
+instance leftCancelMonoid [∀ i, LeftCancelMonoid (f i)] : LeftCancelMonoid (∀ i, f i) :=
+  { leftCancelSemigroup, monoid with }
+#align pi.left_cancel_monoid Pi.leftCancelMonoid
+#align pi.add_left_cancel_monoid Pi.addLeftCancelMonoid
+
+@[to_additive]
+instance rightCancelMonoid [∀ i, RightCancelMonoid (f i)] : RightCancelMonoid (∀ i, f i) :=
+  { rightCancelSemigroup, monoid with }
+#align pi.right_cancel_monoid Pi.rightCancelMonoid
+#align pi.add_right_cancel_monoid Pi.addRightCancelMonoid
+
+@[to_additive]
+instance cancelMonoid [∀ i, CancelMonoid (f i)] : CancelMonoid (∀ i, f i) :=
+  { leftCancelMonoid, rightCancelMonoid with }
+#align pi.cancel_monoid Pi.cancelMonoid
+#align pi.add_cancel_monoid Pi.addCancelMonoid
+
+@[to_additive]
+instance cancelCommMonoid [∀ i, CancelCommMonoid (f i)] : CancelCommMonoid (∀ i, f i) :=
+  { leftCancelMonoid, commMonoid with }
+#align pi.cancel_comm_monoid Pi.cancelCommMonoid
+#align pi.add_cancel_comm_monoid Pi.addCancelCommMonoid
 
 section
 

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -5,29 +5,16 @@ Authors: Simon Hudon, Patrick Massot
 -/
 import Mathlib.Init.CCLemmas
 import Mathlib.Algebra.Group.Hom.Instances
-import Mathlib.Data.Pi.Algebra
 import Mathlib.Data.Set.Function
 import Mathlib.Logic.Pairwise
 
 #align_import algebra.group.pi from "leanprover-community/mathlib"@"e4bc74cbaf429d706cb9140902f7ca6c431e75a4"
 
 /-!
-# Pi instances for groups and monoids
+# Extra lemmas about products of monoids and groups
 
-This file defines instances for group, monoid, semigroup and related structures on Pi types.
--/
-
-/-
-  Porting notes:
-
-  See this Zulip discussion: [https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/not.20porting.20pi_instance]
-
-  * This file now includes the pi instances for `AddMonoidWithOne` and `AddGroupWithOne`
-  * This file relied on the `pi_instance` tactic, which was not available at the time of porting.
-    The comment `--pi_instance` is inserted before all fields which were previously derived by
-    `pi_instance`.
-  * This file previously gave data fields explicitly. Now previously-defined instances are sourced
-    via `with` as much as possible.
+This file proves lemmas about the instances defined in `Algebra.Group.Pi.Basic` that require more
+imports.
 -/
 
 universe u v w
@@ -51,51 +38,6 @@ theorem Set.preimage_one {α β : Type*} [One β] (s : Set β) [Decidable ((1 : 
 
 namespace Pi
 
-@[to_additive]
-instance semigroup [∀ i, Semigroup <| f i] : Semigroup (∀ i : I, f i) :=
-  { mul := (· * ·)
-    --pi_instance
-    mul_assoc := by intros; ext; exact mul_assoc _ _ _ }
-#align pi.semigroup Pi.semigroup
-#align pi.add_semigroup Pi.addSemigroup
-
-@[to_additive]
-instance commSemigroup [∀ i, CommSemigroup <| f i] : CommSemigroup (∀ i : I, f i) :=
-  { semigroup with
-    --pi_instance
-    mul_comm := by intros; ext; exact mul_comm _ _
-  }
-#align pi.comm_semigroup Pi.commSemigroup
-#align pi.add_comm_semigroup Pi.addCommSemigroup
-
-@[to_additive]
-instance mulOneClass [∀ i, MulOneClass <| f i] : MulOneClass (∀ i : I, f i) :=
-  { one := (1 : ∀ i, f i)
-    mul := (· * ·)
-    --pi_instance
-    one_mul := by intros; ext; exact one_mul _
-    mul_one := by intros; ext; exact mul_one _
-  }
-#align pi.mul_one_class Pi.mulOneClass
-#align pi.add_zero_class Pi.addZeroClass
-
-@[to_additive]
-instance invOneClass [∀ i, InvOneClass <| f i] : InvOneClass (∀ i : I, f i) :=
-  { one := (1 : ∀ i, f i)
-    inv := (· ⁻¹)
-    inv_one := by intros; ext; exact inv_one }
-
-@[to_additive]
-instance monoid [∀ i, Monoid <| f i] : Monoid (∀ i : I, f i) :=
-  { semigroup, mulOneClass with
-    npow := fun n x i => x i ^ n
-    --pi_instance
-    npow_zero := by intros; ext; exact Monoid.npow_zero _
-    npow_succ := by intros; ext; exact Monoid.npow_succ _ _
-  }
-#align pi.monoid Pi.monoid
-#align pi.add_monoid Pi.addMonoid
-
 instance addMonoidWithOne [∀ i, AddMonoidWithOne <| f i] : AddMonoidWithOne (∀ i : I, f i) :=
   { addMonoid with
     natCast := fun n _ => n
@@ -103,120 +45,12 @@ instance addMonoidWithOne [∀ i, AddMonoidWithOne <| f i] : AddMonoidWithOne (�
     natCast_succ := fun n => funext fun _ => AddMonoidWithOne.natCast_succ n
   }
 
-@[to_additive]
-instance commMonoid [∀ i, CommMonoid <| f i] : CommMonoid (∀ i : I, f i) :=
-  { monoid, commSemigroup with }
-#align pi.comm_monoid Pi.commMonoid
-#align pi.add_comm_monoid Pi.addCommMonoid
-
-@[to_additive Pi.subNegMonoid]
-instance divInvMonoid [∀ i, DivInvMonoid <| f i] : DivInvMonoid (∀ i : I, f i) :=
-  { monoid with
-    inv := Inv.inv
-    div := Div.div
-    zpow := fun z x i => x i ^ z
-    --pi_instance
-    div_eq_mul_inv := by intros; ext; exact div_eq_mul_inv _ _
-    zpow_zero' := by intros; ext; exact DivInvMonoid.zpow_zero' _
-    zpow_succ' := by intros; ext; exact DivInvMonoid.zpow_succ' _ _
-    zpow_neg' := by intros; ext; exact DivInvMonoid.zpow_neg' _ _
-  }
-
-@[to_additive Pi.subNegZeroMonoid]
-instance divInvOneMonoid [∀ i, DivInvOneMonoid <| f i] : DivInvOneMonoid (∀ i : I, f i) :=
-  { divInvMonoid with
-    inv_one := by ext; exact inv_one }
-
-@[to_additive]
-instance involutiveInv [∀ i, InvolutiveInv <| f i] : InvolutiveInv (∀ i, f i) :=
-  { inv := Inv.inv
-    --pi_instance
-    inv_inv := by intros; ext; exact inv_inv _
-  }
-
-@[to_additive Pi.subtractionMonoid]
-instance divisionMonoid [∀ i, DivisionMonoid <| f i] : DivisionMonoid (∀ i, f i) :=
-  { divInvMonoid, involutiveInv with
-    --pi_instance
-    mul_inv_rev := by intros; ext; exact mul_inv_rev _ _
-    inv_eq_of_mul := by
-      intros _ _ h; ext; exact DivisionMonoid.inv_eq_of_mul _ _ (congrFun h _)
-  }
-
-@[to_additive Pi.subtractionCommMonoid]
-instance [∀ i, DivisionCommMonoid <| f i] : DivisionCommMonoid (∀ i, f i) :=
-  { divisionMonoid, commSemigroup with }
-
-@[to_additive]
-instance group [∀ i, Group <| f i] : Group (∀ i : I, f i) :=
-  { divInvMonoid with
-    --pi_instance
-    mul_left_inv := by intros; ext; exact mul_left_inv _
-    }
-#align pi.group Pi.group
-#align pi.add_group Pi.addGroup
-
 instance addGroupWithOne [∀ i, AddGroupWithOne <| f i] : AddGroupWithOne (∀ i : I, f i) :=
   { addGroup, addMonoidWithOne with
     intCast := fun z _ => z
     intCast_ofNat := fun n => funext fun _ => AddGroupWithOne.intCast_ofNat n
     intCast_negSucc := fun n => funext fun _ => AddGroupWithOne.intCast_negSucc n
   }
-
-@[to_additive]
-instance commGroup [∀ i, CommGroup <| f i] : CommGroup (∀ i : I, f i) :=
-  { group, commMonoid with }
-#align pi.comm_group Pi.commGroup
-#align pi.add_comm_group Pi.addCommGroup
-
-@[to_additive]
-instance [∀ i, Mul <| f i] [∀ i, IsLeftCancelMul <| f i] : IsLeftCancelMul (∀ i : I, f i) where
-  mul_left_cancel  _ _ _ h := funext fun _ => mul_left_cancel (congr_fun h _)
-
-@[to_additive]
-instance [∀ i, Mul <| f i] [∀ i, IsRightCancelMul <| f i] : IsRightCancelMul (∀ i : I, f i) where
-  mul_right_cancel  _ _ _ h := funext fun _ => mul_right_cancel (congr_fun h _)
-
-@[to_additive]
-instance [∀ i, Mul <| f i] [∀ i, IsCancelMul <| f i] : IsCancelMul (∀ i : I, f i) where
-
-@[to_additive]
-instance leftCancelSemigroup [∀ i, LeftCancelSemigroup <| f i] :
-    LeftCancelSemigroup (∀ i : I, f i) :=
-  { semigroup with mul_left_cancel := fun _ _ _ => mul_left_cancel }
-#align pi.left_cancel_semigroup Pi.leftCancelSemigroup
-#align pi.add_left_cancel_semigroup Pi.addLeftCancelSemigroup
-
-@[to_additive]
-instance rightCancelSemigroup [∀ i, RightCancelSemigroup <| f i] :
-    RightCancelSemigroup (∀ i : I, f i) :=
-  { semigroup with mul_right_cancel := fun _ _ _ => mul_right_cancel }
-#align pi.right_cancel_semigroup Pi.rightCancelSemigroup
-#align pi.add_right_cancel_semigroup Pi.addRightCancelSemigroup
-
-@[to_additive]
-instance leftCancelMonoid [∀ i, LeftCancelMonoid <| f i] : LeftCancelMonoid (∀ i : I, f i) :=
-  { leftCancelSemigroup, monoid with }
-#align pi.left_cancel_monoid Pi.leftCancelMonoid
-#align pi.add_left_cancel_monoid Pi.addLeftCancelMonoid
-
-@[to_additive]
-instance rightCancelMonoid [∀ i, RightCancelMonoid <| f i] : RightCancelMonoid (∀ i : I, f i) :=
-  { rightCancelSemigroup, monoid with }
-#align pi.right_cancel_monoid Pi.rightCancelMonoid
-#align pi.add_right_cancel_monoid Pi.addRightCancelMonoid
-
-@[to_additive]
-instance cancelMonoid [∀ i, CancelMonoid <| f i] : CancelMonoid (∀ i : I, f i) :=
-  { leftCancelMonoid, rightCancelMonoid with }
-#align pi.cancel_monoid Pi.cancelMonoid
-#align pi.add_cancel_monoid Pi.addCancelMonoid
-
-@[to_additive]
-instance cancelCommMonoid [∀ i, CancelCommMonoid <| f i] : CancelCommMonoid (∀ i : I, f i) :=
-  { leftCancelMonoid, commMonoid with }
-#align pi.cancel_comm_monoid Pi.cancelCommMonoid
-#align pi.add_cancel_comm_monoid Pi.addCancelCommMonoid
 
 instance mulZeroClass [∀ i, MulZeroClass <| f i] : MulZeroClass (∀ i : I, f i) :=
   { zero := (0 : ∀ i, f i)

--- a/Mathlib/Algebra/Order/Hom/Monoid.lean
+++ b/Mathlib/Algebra/Order/Hom/Monoid.lean
@@ -6,7 +6,6 @@ Authors: Yaël Dillies
 import Mathlib.Algebra.Group.Hom.Basic
 import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Algebra.Order.Monoid.WithZero.Defs
-import Mathlib.Data.Pi.Algebra
 import Mathlib.Order.Hom.Basic
 
 #align_import algebra.order.hom.monoid from "leanprover-community/mathlib"@"3342d1b2178381196f818146ff79bc0e7ccd9e2d"

--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Yaël Dillies
 -/
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Group.Units
 import Mathlib.Algebra.GroupPower.Basic
 import Mathlib.Algebra.GroupWithZero.NeZero
@@ -13,7 +14,6 @@ import Mathlib.Algebra.Order.Monoid.NatCast
 import Mathlib.Algebra.Order.Monoid.WithZero.Defs
 import Mathlib.Algebra.Order.Ring.Lemmas
 import Mathlib.Algebra.Ring.Defs
-import Mathlib.Data.Pi.Algebra
 import Mathlib.Tactic.Tauto
 
 #align_import algebra.order.ring.defs from "leanprover-community/mathlib"@"44e29dbcff83ba7114a464d592b8c3743987c1e5"

--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -3,10 +3,10 @@ Copyright (c) 2019 Amelia Livingston. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amelia Livingston, Jireh Loreaux
 -/
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.GroupWithZero.Hom
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Algebra.Ring.Basic
-import Mathlib.Data.Pi.Algebra
 
 #align_import algebra.hom.ring from "leanprover-community/mathlib"@"cf9386b56953fb40904843af98b7a80757bbe7f9"
 

--- a/Mathlib/Algebra/Ring/Pi.lean
+++ b/Mathlib/Algebra/Ring/Pi.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 -/
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Ring.Hom.Defs
 
 #align_import algebra.ring.pi from "leanprover-community/mathlib"@"ba2245edf0c8bb155f1569fd9b9492a9b384cde6"

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Data.Pi.Algebra
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.CategoryTheory.Limits.Shapes.Products
 import Mathlib.CategoryTheory.Limits.Shapes.Images
 import Mathlib.CategoryTheory.IsomorphismClasses

--- a/Mathlib/Data/Matrix/DMatrix.lean
+++ b/Mathlib/Data/Matrix/DMatrix.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Data.Fintype.Basic
 
 #align_import data.matrix.dmatrix from "leanprover-community/mathlib"@"9003f28797c0664a49e4179487267c494477d853"

--- a/Mathlib/Data/Matrix/DMatrix.lean
+++ b/Mathlib/Data/Matrix/DMatrix.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Data.Fintype.Basic
 
 #align_import data.matrix.dmatrix from "leanprover-community/mathlib"@"9003f28797c0664a49e4179487267c494477d853"

--- a/Mathlib/Data/Pi/Lex.lean
+++ b/Mathlib/Data/Pi/Lex.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import Mathlib.Algebra.Group.OrderSynonym
-import Mathlib.Algebra.Group.Pi.Lemmas
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Order.Group.Defs
-import Mathlib.Order.Basic
 import Mathlib.Order.WellFounded
 import Mathlib.Mathport.Notation
 

--- a/Mathlib/Data/Pi/Lex.lean
+++ b/Mathlib/Data/Pi/Lex.lean
@@ -3,11 +3,11 @@ Copyright (c) 2019 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+import Mathlib.Algebra.Group.OrderSynonym
+import Mathlib.Algebra.Group.Pi.Lemmas
+import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Order.Basic
 import Mathlib.Order.WellFounded
-import Mathlib.Algebra.Group.OrderSynonym
-import Mathlib.Algebra.Group.Pi
-import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Mathport.Notation
 
 #align_import data.pi.lex from "leanprover-community/mathlib"@"6623e6af705e97002a9054c1c05a980180276fc1"

--- a/Mathlib/Data/Set/Intervals/Pi.lean
+++ b/Mathlib/Data/Set/Intervals/Pi.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Data.Pi.Algebra
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Data.Set.Intervals.Basic
 import Mathlib.Data.Set.Intervals.UnorderedInterval
 import Mathlib.Data.Set.Lattice

--- a/Mathlib/GroupTheory/Divisible.lean
+++ b/Mathlib/GroupTheory/Divisible.lean
@@ -3,10 +3,10 @@ Copyright (c) 2022 Jujian Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang
 -/
-import Mathlib.GroupTheory.Subgroup.Pointwise
-import Mathlib.GroupTheory.QuotientGroup
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.ULift
+import Mathlib.GroupTheory.QuotientGroup
+import Mathlib.GroupTheory.Subgroup.Pointwise
 
 #align_import group_theory.divisible from "leanprover-community/mathlib"@"0a0ec35061ed9960bf0e7ffb0335f44447b58977"
 

--- a/Mathlib/GroupTheory/FreeAbelianGroup.lean
+++ b/Mathlib/GroupTheory/FreeAbelianGroup.lean
@@ -3,10 +3,10 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import Mathlib.Algebra.Group.Pi
-import Mathlib.GroupTheory.FreeGroup.Basic
-import Mathlib.GroupTheory.Abelianization
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Module.Basic
+import Mathlib.GroupTheory.Abelianization
+import Mathlib.GroupTheory.FreeGroup.Basic
 
 #align_import group_theory.free_abelian_group from "leanprover-community/mathlib"@"dc6c365e751e34d100e80fe6e314c3c3e0fd2988"
 

--- a/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Opposite
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.GroupTheory.GroupAction.Defs
 
 /-!

--- a/Mathlib/GroupTheory/GroupAction/Pi.lean
+++ b/Mathlib/GroupTheory/GroupAction/Pi.lean
@@ -3,7 +3,8 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 -/
-import Mathlib.Algebra.Group.Pi.Lemmas
+import Mathlib.Algebra.GroupWithZero.Defs
+import Mathlib.Data.Set.Function
 import Mathlib.GroupTheory.GroupAction.Defs
 
 #align_import group_theory.group_action.pi from "leanprover-community/mathlib"@"bbeb185db4ccee8ed07dc48449414ebfa39cb821"

--- a/Mathlib/GroupTheory/GroupAction/Pi.lean
+++ b/Mathlib/GroupTheory/GroupAction/Pi.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 -/
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.GroupTheory.GroupAction.Defs
 
 #align_import group_theory.group_action.pi from "leanprover-community/mathlib"@"bbeb185db4ccee8ed07dc48449414ebfa39cb821"

--- a/Mathlib/GroupTheory/Perm/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
-import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Group.Units.Equiv
 import Mathlib.Algebra.GroupPower.IterateHom

--- a/Mathlib/GroupTheory/Perm/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
-import Mathlib.Algebra.Group.Pi
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Group.Units.Equiv
 import Mathlib.Algebra.GroupPower.IterateHom

--- a/Mathlib/GroupTheory/Subgroup/Basic.lean
+++ b/Mathlib/GroupTheory/Subgroup/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kexing Ying
 -/
 import Mathlib.Algebra.Group.Conj
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Order.Group.InjSurj
 import Mathlib.Data.Set.Image
 import Mathlib.GroupTheory.Submonoid.Centralizer

--- a/Mathlib/Topology/Algebra/GroupWithZero.lean
+++ b/Mathlib/Topology/Algebra/GroupWithZero.lean
@@ -3,8 +3,8 @@ Copyright (c) 2020 Yury G. Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury G. Kudryashov
 -/
+import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Topology.Algebra.Monoid
-import Mathlib.Algebra.Group.Pi
 import Mathlib.Topology.Homeomorph
 
 #align_import topology.algebra.group_with_zero from "leanprover-community/mathlib"@"c10e724be91096453ee3db13862b9fb9a992fef2"


### PR DESCRIPTION
Rename
* `Data.Pi.Algebra` to `Algebra.Group.Pi.Basic`
* `Algebra.Group.Pi` to `Algebra.Group.Pi.Lemmas`

Move a few instances from the latter to the former, the goal being that `Algebra.Group.Pi.Basic` is about all the pi instances of the classes defined in `Algebra.Group.Defs`. `Algebra.Group.Pi.Lemmas` will need further rearranging.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
