### PR TITLE
[Merged by Bors] - feat(CategoryTheory/GradedObject): the single functor

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1088,6 +1088,7 @@ import Mathlib.CategoryTheory.Generator
 import Mathlib.CategoryTheory.GlueData
 import Mathlib.CategoryTheory.GradedObject
 import Mathlib.CategoryTheory.GradedObject.Bifunctor
+import Mathlib.CategoryTheory.GradedObject.Single
 import Mathlib.CategoryTheory.GradedObject.Trifunctor
 import Mathlib.CategoryTheory.Grothendieck
 import Mathlib.CategoryTheory.Groupoid

--- a/Mathlib/CategoryTheory/GradedObject/Single.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Single.lean
@@ -72,6 +72,11 @@ lemma single_map_singleObjApplyIso_hom (j : J) {X Y : C} (f : X ⟶ Y) :
     (single j).map f j ≫ (singleObjApplyIso j Y).hom = (singleObjApplyIso j X).hom ≫ f := by
   apply single_map_singleObjApplyIsoOfEq_hom
 
+variable (C) in
+@[simps!]
+noncomputable def singleCompEval (j : J) : single j ⋙ eval j ≅ 𝟭 C :=
+  NatIso.ofComponents (singleObjApplyIso j) (by aesop_cat)
+
 end GradedObject
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/GradedObject/Single.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Single.lean
@@ -73,6 +73,8 @@ lemma single_map_singleObjApplyIso_hom (j : J) {X Y : C} (f : X ⟶ Y) :
   apply single_map_singleObjApplyIsoOfEq_hom
 
 variable (C) in
+/-- The composition of the single functor `single j : C ⥤ GradedObject J C` and the
+evaluation functor `eval j` identifies to the identity functor. -/
 @[simps!]
 noncomputable def singleCompEval (j : J) : single j ⋙ eval j ≅ 𝟭 C :=
   NatIso.ofComponents (singleObjApplyIso j) (by aesop_cat)

--- a/Mathlib/CategoryTheory/GradedObject/Single.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Single.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 import Mathlib.CategoryTheory.GradedObject
+
 /-!
 # The graded object in a single degree
 

--- a/Mathlib/CategoryTheory/GradedObject/Single.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Single.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.GradedObject
+/-!
+# The graded object in a single degree
+
+In this file, we define the functor `GradedObject.single j : C ⥤ GradedObject J C`
+which sends an object `X : C` to the graded object which is `X` in degree `j` and
+the initial object of `C` in other degrees.
+
+-/
+
+namespace CategoryTheory
+
+open Limits
+
+namespace GradedObject
+
+variable {J : Type*} {C : Type*} [Category C] [HasInitial C] [DecidableEq J]
+
+/-- The functor which sends `X : C` to the graded object which is `X` in degree `j`
+and the initial object in other degrees. -/
+noncomputable def single (j : J) : C ⥤ GradedObject J C where
+  obj X i := if i = j then X else ⊥_ C
+  map {X₁ X₂} f i :=
+    if h : i = j then eqToHom (if_pos h) ≫ f ≫ eqToHom (if_pos h).symm
+    else eqToHom (by dsimp; rw [if_neg h, if_neg h])
+
+variable (J) in
+/-- The functor which sends `X : C` to the graded object which is `X` in degree `0`
+and the initial object in nonzero degrees. -/
+noncomputable abbrev single₀ [Zero J] : C ⥤ GradedObject J C := single 0
+
+/-- The canonical isomorphism `(single j).obj X i ≅ X` when `i = j`. -/
+noncomputable def singleObjApplyIsoOfEq (j : J) (X : C) (i : J) (h : i = j) :
+    (single j).obj X i ≅ X := eqToIso (if_pos h)
+
+/-- The canonical isomorphism `(single j).obj X j ≅ X`. -/
+noncomputable abbrev singleObjApplyIso (j : J) (X : C) :
+    (single j).obj X j ≅ X := singleObjApplyIsoOfEq j X j rfl
+
+/-- The object `(single j).obj X i` is initial when `i ≠ j`. -/
+noncomputable def isInitialSingleObjApply (j : J) (X : C) (i : J) (h : i ≠ j) :
+    IsInitial ((single j).obj X i) := by
+  dsimp [single]
+  rw [if_neg h]
+  exact initialIsInitial
+
+lemma singleObjApplyIsoOfEq_inv_single_map (j : J) {X Y : C} (f : X ⟶ Y) (i : J) (h : i = j) :
+    (singleObjApplyIsoOfEq j X i h).inv ≫ (single j).map f i =
+      f ≫ (singleObjApplyIsoOfEq j Y i h).inv := by
+  subst h
+  simp [singleObjApplyIsoOfEq, single]
+
+lemma single_map_singleObjApplyIsoOfEq_hom (j : J) {X Y : C} (f : X ⟶ Y) (i : J) (h : i = j) :
+    (single j).map f i ≫ (singleObjApplyIsoOfEq j Y i h).hom =
+      (singleObjApplyIsoOfEq j X i h).hom ≫ f := by
+  subst h
+  simp [singleObjApplyIsoOfEq, single]
+
+@[reassoc (attr := simp)]
+lemma singleObjApplyIso_inv_single_map (j : J) {X Y : C} (f : X ⟶ Y) :
+    (singleObjApplyIso j X).inv ≫ (single j).map f j = f ≫ (singleObjApplyIso j Y).inv := by
+  apply singleObjApplyIsoOfEq_inv_single_map
+
+@[reassoc (attr := simp)]
+lemma single_map_singleObjApplyIso_hom (j : J) {X Y : C} (f : X ⟶ Y) :
+    (single j).map f j ≫ (singleObjApplyIso j Y).hom = (singleObjApplyIso j X).hom ≫ f := by
+  apply single_map_singleObjApplyIsoOfEq_hom
+
+end GradedObject
+
+end CategoryTheory


### PR DESCRIPTION
This PR defines the functor `GradedObject.single : C ⥤ GradedObject J C` which sends an object `X : C` to the graded object which is `X` in degree `j` and the initial object of `C` in other degrees.

This shall be used in the construction of the unit of the tensor product on `I`-graded objects (when `I` is an additive monoid).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
