### PR TITLE
[Merged by Bors] - feat: `Pairwise` and composition with an equiv

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2629,6 +2629,7 @@ import Mathlib.Logic.Equiv.Functor
 import Mathlib.Logic.Equiv.List
 import Mathlib.Logic.Equiv.Nat
 import Mathlib.Logic.Equiv.Option
+import Mathlib.Logic.Equiv.Pairwise
 import Mathlib.Logic.Equiv.PartialEquiv
 import Mathlib.Logic.Equiv.Set
 import Mathlib.Logic.Equiv.TransferInstance

--- a/Mathlib/Logic/Equiv/Pairwise.lean
+++ b/Mathlib/Logic/Equiv/Pairwise.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2024 Joseph Myers. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Myers
+-/
+import Mathlib.Data.FunLike.Equiv
+import Mathlib.Logic.Pairwise
+
+/-!
+# Interaction of equivalences with `Pairwise`
+-/
+
+lemma EquivLike.pairwise_comp_iff {X : Type*} {Y : Type*} {F} [EquivLike F Y X]
+    (f : F) (p : X → X → Prop) : Pairwise (fun y z ↦ p (f y) (f z)) ↔ Pairwise p := by
+  refine ⟨fun h ↦ fun i j hij ↦ ?_,
+          fun h ↦ fun i j hij ↦ h <| (EquivLike.injective f).ne hij⟩
+  convert h (?_ : EquivLike.inv f i ≠ EquivLike.inv f j)
+  · simp
+  · simp
+  · refine Function.Injective.ne ((EquivLike.injective_comp f _).1 (fun x y hxy ↦ ?_)) hij
+    simpa using hxy

--- a/Mathlib/Logic/Equiv/Pairwise.lean
+++ b/Mathlib/Logic/Equiv/Pairwise.lean
@@ -11,7 +11,7 @@ import Mathlib.Logic.Pairwise
 -/
 
 lemma EquivLike.pairwise_comp_iff {X : Type*} {Y : Type*} {F} [EquivLike F Y X]
-    (f : F) (p : X → X → Prop) : Pairwise (fun y z ↦ p (f y) (f z)) ↔ Pairwise p := by
+    (f : F) (p : X → X → Prop) : Pairwise (p on f) ↔ Pairwise p := by
   refine ⟨fun h ↦ fun i j hij ↦ ?_,
           fun h ↦ fun i j hij ↦ h <| (EquivLike.injective f).ne hij⟩
   convert h (?_ : EquivLike.inv f i ≠ EquivLike.inv f j)

--- a/Mathlib/Logic/Equiv/Pairwise.lean
+++ b/Mathlib/Logic/Equiv/Pairwise.lean
@@ -10,12 +10,10 @@ import Mathlib.Logic.Pairwise
 # Interaction of equivalences with `Pairwise`
 -/
 
+lemma EmbeddingLike.pairwise_comp {X : Type*} {Y : Type*} {F} [FunLike F Y X] [EmbeddingLike F Y X]
+    (f : F) {p : X → X → Prop} (h : Pairwise p) : Pairwise (p on f) :=
+  h.comp_of_injective <| EmbeddingLike.injective f
+
 lemma EquivLike.pairwise_comp_iff {X : Type*} {Y : Type*} {F} [EquivLike F Y X]
-    (f : F) (p : X → X → Prop) : Pairwise (p on f) ↔ Pairwise p := by
-  refine ⟨fun h ↦ fun i j hij ↦ ?_,
-          fun h ↦ fun i j hij ↦ h <| (EquivLike.injective f).ne hij⟩
-  convert h (?_ : EquivLike.inv f i ≠ EquivLike.inv f j)
-  · simp
-  · simp
-  · refine Function.Injective.ne ((EquivLike.injective_comp f _).1 (fun x y hxy ↦ ?_)) hij
-    simpa using hxy
+    (f : F) (p : X → X → Prop) : Pairwise (p on f) ↔ Pairwise p :=
+  (EquivLike.bijective f).pairwise_comp_iff

--- a/Mathlib/Logic/Pairwise.lean
+++ b/Mathlib/Logic/Pairwise.lean
@@ -49,6 +49,17 @@ theorem Function.injective_iff_pairwise_ne : Injective f ↔ Pairwise ((· ≠ �
 alias ⟨Function.Injective.pairwise_ne, _⟩ := Function.injective_iff_pairwise_ne
 #align function.injective.pairwise_ne Function.Injective.pairwise_ne
 
+lemma Pairwise.comp_of_injective (hr : Pairwise r) {f : β → α} (hf : Injective f) :
+    Pairwise (r on f) :=
+  fun _ _ h ↦ hr <| hf.ne h
+
+lemma Pairwise.of_comp_of_surjective {f : β → α} (hr : Pairwise (r on f)) (hf : Surjective f) :
+    Pairwise r := hf.forall₂.2 fun _ _ h ↦ hr <| ne_of_apply_ne f h
+
+lemma Function.Bijective.pairwise_comp_iff {f : β → α} (hf : Bijective f) :
+    Pairwise (r on f) ↔ Pairwise r :=
+  ⟨fun hr ↦ hr.of_comp_of_surjective hf.surjective, fun hr ↦ hr.comp_of_injective hf.injective⟩
+
 namespace Set
 
 /-- The relation `r` holds pairwise on the set `s` if `r x y` for all *distinct* `x y ∈ s`. -/


### PR DESCRIPTION
Add a lemma about `Pairwise` being preserved by composing the arguments of the pairwise relation with an equiv.

```lean
lemma EquivLike.pairwise_comp_iff {X : Type*} {Y : Type*} {F} [EquivLike F Y X]
    (f : F) (p : X → X → Prop) : Pairwise (fun y z ↦ p (f y) (f z)) ↔ Pairwise p := by
```

This depends on `Mathlib.Data.FunLike.Equiv` and
`Mathlib.Logic.Pairwise`, neither of which imports the other, so to avoid increasing the imports of very basic files I put it in its own new file, but feel free to suggest a better location of this lemma (and to golf the proof).

From AperiodicMonotilesLean.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
