### PR TITLE
[Merged by Bors] - feat: add a `SpectrumRestricts` structure

### DIFF
--- a/Mathlib/Algebra/Algebra/Spectrum.lean
+++ b/Mathlib/Algebra/Algebra/Spectrum.lean
@@ -498,4 +498,22 @@ theorem apply_mem {s : S} (hs : s ∈ spectrum S a) : f s ∈ spectrum R a :=
 theorem subset_preimage : spectrum S a ⊆ f ⁻¹' spectrum R a :=
   h.image ▸ (spectrum S a).subset_preimage_image f
 
+lemma of_spectrum_eq {a b : A} {f : S → R} (ha : SpectrumRestricts a f)
+    (h : spectrum S a = spectrum S b) : SpectrumRestricts b f where
+  rightInvOn := h ▸ ha.rightInvOn
+  left_inv := ha.left_inv
+
+protected lemma comp {R₁ R₂ R₃ A : Type*} [CommSemiring R₁] [CommSemiring R₂] [CommSemiring R₃]
+    [Ring A] [Algebra R₁ A] [Algebra R₂ A] [Algebra R₃ A] [Algebra R₁ R₂] [Algebra R₂ R₃]
+    [Algebra R₁ R₃] [IsScalarTower R₁ R₂ R₃] [IsScalarTower R₂ R₃ A]
+    {a : A} {f : R₃ → R₂} {g : R₂ → R₁} {e : R₃ → R₁} (hfge : g ∘ f = e)
+    (hf : SpectrumRestricts a f) (hg : SpectrumRestricts a g) :
+    SpectrumRestricts a e where
+  left_inv := by
+    convert hfge ▸ hf.left_inv.comp hg.left_inv
+    congrm(⇑$(IsScalarTower.algebraMap_eq R₁ R₂ R₃))
+  rightInvOn := by
+    convert hfge ▸ hg.rightInvOn.comp hf.rightInvOn fun _ ↦ hf.apply_mem
+    congrm(⇑$(IsScalarTower.algebraMap_eq R₁ R₂ R₃))
+
 end SpectrumRestricts

--- a/Mathlib/Algebra/Algebra/Spectrum.lean
+++ b/Mathlib/Algebra/Algebra/Spectrum.lean
@@ -494,3 +494,8 @@ theorem image : f '' spectrum S a = spectrum R a := by
 
 theorem apply_mem {s : S} (hs : s ∈ spectrum S a) : f s ∈ spectrum R a :=
   h.image ▸ ⟨s, hs, rfl⟩
+
+theorem subset_preimage : spectrum S a ⊆ f ⁻¹' spectrum R a :=
+  h.image ▸ (spectrum S a).subset_preimage_image f
+
+end SpectrumRestricts

--- a/Mathlib/Algebra/Algebra/Spectrum.lean
+++ b/Mathlib/Algebra/Algebra/Spectrum.lean
@@ -462,6 +462,10 @@ theorem AlgEquiv.spectrum_eq {F R A B : Type*} [CommSemiring R] [Ring A] [Ring B
 the spectrum of `a` restricts via a function `f : S → R` if `f` is a left inverse of
 `algebraMap R S`, and `f` is a right inverse of `algebraMap R S` on `spectrum S a`.
 
+For example, when `f = Complex.re` (so `S := ℂ` and `R := ℝ`), `SpectrumRestricts a f` means that
+the `ℂ`-spectrum of `a` is contained within `ℝ`. This arises naturally when `a` is selfadjoint
+and `A` is a C⋆-algebra.
+
 This is the property allows us to restrict a continuous functional calculus over `S` to a
 continuous functional calculus over `R`. -/
 structure SpectrumRestricts {R S A : Type*} [CommSemiring R] [CommSemiring S] [Ring A]


### PR DESCRIPTION
when `A` is and `S`-algebra and `R` is a subring of `S`, `SpectrumRestricts (a : A) (f : S → R)` means that the `S`-spectrum of `a` is entirely contained within the image of the `R`-spectrum of `a` under `algebraMap R S`. We include `f` because we want to explicitly specify the function that takes us back into `R` from `S`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
