### PR TITLE
[Merged by Bors] - refactor(LinearAlgebra/ExteriorAlgebra/{Basic,Grading}): add a definition and notation for the exterior powers of a module

### DIFF
--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
@@ -295,7 +295,7 @@ variable (R)
 
 This is a special case of `MultilinearMap.mkPiAlgebraFin`, and the exterior algebra version of
 `TensorAlgebra.tprod`. -/
-def ιMulti (n : ℕ) : M [Λ^Fin n]→ₗ[R] ExteriorAlgebra R M :=
+def ιMulti (n : ℕ) : M [⋀^Fin n]→ₗ[R] ExteriorAlgebra R M :=
   let F := (MultilinearMap.mkPiAlgebraFin R n (ExteriorAlgebra R M)).compLinearMap fun _ => ι R
   { F with
     map_eq_zero_of_eq' := fun f x y hfxy hxy => by

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
@@ -365,8 +365,8 @@ lemma ιMulti_range (n : ℕ) :
 of the exterior algebra. -/
 lemma ιMulti_span_fixedDegree (n : ℕ) :
     Submodule.span R (Set.range (ιMulti R n)) = Λ[R]^n M := by
-  refine le_antisymm (b := (LinearMap.range (ι R)) ^ n) (Submodule.span_le.2 (ιMulti_range R n)) ?_
-  rw [Submodule.pow_eq_span_pow_set, Submodule.span_le]
+  refine le_antisymm (Submodule.span_le.2 (ιMulti_range R n)) ?_
+  rw [exteriorPower, Submodule.pow_eq_span_pow_set, Submodule.span_le]
   refine fun u hu ↦ Submodule.subset_span ?_
   obtain ⟨f, rfl⟩ := Set.mem_pow.mp hu
   refine ⟨fun i => ιInv (f i).1, ?_⟩

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
@@ -21,7 +21,7 @@ It is endowed with the structure of an `R`-algebra.
 The `n`th exterior power of the `R`-module `M` is denoted by `exteriorPower R n M`;
 it is of type `Submodule R (ExteriorAlgebra R M)` and defined as
 `LinearMap.range (ExteriorAlgebra.ι R : M →ₗ[R] ExteriorAlgebra R M) ^ n`.
-We also introduce the notation `Λ[R]^n M` for `exteriorPower R n M`.
+We also introduce the notation `⋀[R]^n M` for `exteriorPower R n M`.
 
 Given a linear morphism `f : M → A` from a module `M` to another `R`-algebra `A`, such that
 `cond : ∀ m : M, f m * f m = 0`, there is a (unique) lift of `f` to an `R`-algebra morphism,
@@ -77,12 +77,12 @@ section exteriorPower
 variable (n : ℕ) (M : Type u2) [AddCommGroup M] [Module R M]
 
 /-- Definition of the `n`th exterior power of a `R`-module `N`. We introduce the notation
-`Λ[R]^n M` for `exteriorPower R n M`. -/
+`⋀[R]^n M` for `exteriorPower R n M`. -/
 abbrev exteriorPower : Submodule R (ExteriorAlgebra R M) :=
   LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M) ^ n
 
 @[inherit_doc exteriorPower]
-notation:max "Λ[" R "]^" n:arg => exteriorPower R n
+notation:max "⋀[" R "]^" n:arg => exteriorPower R n
 
 end exteriorPower
 
@@ -353,7 +353,7 @@ variable (R)
 
 /-- The image of `ExteriorAlgebra.ιMulti R n` is contained in the `n`th exterior power. -/
 lemma ιMulti_range (n : ℕ) :
-    Set.range (ιMulti R n (M := M)) ⊆ ↑(Λ[R]^n M) := by
+    Set.range (ιMulti R n (M := M)) ⊆ ↑(⋀[R]^n M) := by
   rw [Set.range_subset_iff]
   intro v
   rw [ιMulti_apply]
@@ -364,7 +364,7 @@ lemma ιMulti_range (n : ℕ) :
 /-- The image of `ExteriorAlgebra.ιMulti R n` spans the `n`th exterior power, as a submodule
 of the exterior algebra. -/
 lemma ιMulti_span_fixedDegree (n : ℕ) :
-    Submodule.span R (Set.range (ιMulti R n)) = Λ[R]^n M := by
+    Submodule.span R (Set.range (ιMulti R n)) = ⋀[R]^n M := by
   refine le_antisymm (Submodule.span_le.2 (ιMulti_range R n)) ?_
   rw [exteriorPower, Submodule.pow_eq_span_pow_set, Submodule.span_le]
   refine fun u hu ↦ Submodule.subset_span ?_

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
@@ -73,13 +73,13 @@ def ι : M →ₗ[R] ExteriorAlgebra R M :=
 
 section exteriorPower
 
-variable (n : ℕ) (N : Type u2) [AddCommGroup N] [Module R N]
--- New variables `n` and `N`, to get the correct order of variables in the notation.
+-- New variables `n` and `M`, to get the correct order of variables in the notation.
+variable (n : ℕ) (M : Type u2) [AddCommGroup M] [Module R M]
 
 /-- Definition of the `n`th exterior power of a `R`-module `N`. We introduce the notation
-`Λ[R]^n N` for `exteriorPower R n N`. -/
-abbrev exteriorPower : Submodule R (ExteriorAlgebra R N) :=
-  LinearMap.range (ι R : N →ₗ[R] ExteriorAlgebra R N) ^ n
+`Λ[R]^n M` for `exteriorPower R n M`. -/
+abbrev exteriorPower : Submodule R (ExteriorAlgebra R M) :=
+  LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M) ^ n
 
 @[inherit_doc exteriorPower]
 notation:max "Λ[" R "]^" n:arg => exteriorPower R n

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
@@ -18,10 +18,10 @@ We construct the exterior algebra of a module `M` over a commutative semiring `R
 The exterior algebra of the `R`-module `M` is denoted as `ExteriorAlgebra R M`.
 It is endowed with the structure of an `R`-algebra.
 
-The `n`th exterior power of the `R`-module `M` is denoted by `exteriorPower R n M`; it is of
-type `Submodule R (ExteriorAlgebra R M)` and defined as `LinearMap.range (ExteriorAlgebra.ι R :
-M →ₗ[R] ExteriorAlgebra R M) ^ n`. We also introduce the notation `Λ[R]^n M` for
-`exteriorPower R n M`.
+The `n`th exterior power of the `R`-module `M` is denoted by `exteriorPower R n M`;
+it is of type `Submodule R (ExteriorAlgebra R M)` and defined as
+`LinearMap.range (ExteriorAlgebra.ι R : M →ₗ[R] ExteriorAlgebra R M) ^ n`.
+We also introduce the notation `Λ[R]^n M` for `exteriorPower R n M`.
 
 Given a linear morphism `f : M → A` from a module `M` to another `R`-algebra `A`, such that
 `cond : ∀ m : M, f m * f m = 0`, there is a (unique) lift of `f` to an `R`-algebra morphism,
@@ -78,11 +78,11 @@ variable (n : ℕ) (N : Type u2) [AddCommGroup N] [Module R N]
 
 /-- Definition of the `n`th exterior power of a `R`-module `N`. We introduce the notation
 `Λ[R]^n N` for `exteriorPower R n N`. -/
-@[reducible]
-def exteriorPower := LinearMap.range (ι R : N →ₗ[R] ExteriorAlgebra R N) ^ n
+abbrev exteriorPower : Submodule R (ExteriorAlgebra R N) :=
+  LinearMap.range (ι R : N →ₗ[R] ExteriorAlgebra R N) ^ n
 
-@[inherit_doc]
-notation:100 "Λ[" R "]^" n:arg => exteriorPower R n
+@[inherit_doc exteriorPower]
+notation:max "Λ[" R "]^" n:arg => exteriorPower R n
 
 end exteriorPower
 
@@ -353,7 +353,7 @@ variable (R)
 
 /-- The image of `ExteriorAlgebra.ιMulti R n` is contained in the `n`th exterior power. -/
 lemma ιMulti_range (n : ℕ) :
-    Set.range (ιMulti R n (M := M)) ⊆ ↑((Λ[R]^n) M) := by
+    Set.range (ιMulti R n (M := M)) ⊆ ↑(Λ[R]^n M) := by
   rw [Set.range_subset_iff]
   intro v
   rw [ιMulti_apply]
@@ -364,7 +364,7 @@ lemma ιMulti_range (n : ℕ) :
 /-- The image of `ExteriorAlgebra.ιMulti R n` spans the `n`th exterior power, as a submodule
 of the exterior algebra. -/
 lemma ιMulti_span_fixedDegree (n : ℕ) :
-    Submodule.span R (Set.range (ιMulti R n)) = (Λ[R]^n) M := by
+    Submodule.span R (Set.range (ιMulti R n)) = Λ[R]^n M := by
   refine le_antisymm (b := (LinearMap.range (ι R)) ^ n) (Submodule.span_le.2 (ιMulti_range R n)) ?_
   rw [Submodule.pow_eq_span_pow_set, Submodule.span_le]
   refine fun u hu ↦ Submodule.subset_span ?_

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
@@ -295,7 +295,7 @@ variable (R)
 
 This is a special case of `MultilinearMap.mkPiAlgebraFin`, and the exterior algebra version of
 `TensorAlgebra.tprod`. -/
-def ιMulti (n : ℕ) : M [⋀^Fin n]→ₗ[R] ExteriorAlgebra R M :=
+def ιMulti (n : ℕ) : M [Λ^Fin n]→ₗ[R] ExteriorAlgebra R M :=
   let F := (MultilinearMap.mkPiAlgebraFin R n (ExteriorAlgebra R M)).compLinearMap fun _ => ι R
   { F with
     map_eq_zero_of_eq' := fun f x y hfxy hxy => by

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
@@ -66,6 +66,21 @@ def ι : M →ₗ[R] ExteriorAlgebra R M :=
   CliffordAlgebra.ι _
 #align exterior_algebra.ι ExteriorAlgebra.ι
 
+section ExteriorPower
+
+variable (n : ℕ) (N : Type u2) [AddCommGroup N] [Module R N]
+-- New variables `n` and `N`, to get the correct order of variables in the notation.
+
+/-- Definition of the `n`th exterior power of a `R`-module `N`. We introduce the notation
+`Λ[R]^n N` for `ExteriorPower R n N`. -/
+@[reducible]
+def ExteriorPower := (LinearMap.range (ι R : N →ₗ[R] ExteriorAlgebra R N) ^ n)
+
+@[inherit_doc]
+notation:100 "Λ[" R "]^" n:arg => ExteriorPower R n
+
+end ExteriorPower
+
 variable {R}
 
 /-- As well as being linear, `ι m` squares to zero. -/
@@ -333,7 +348,7 @@ variable (R)
 
 /-- The image of `ExteriorAlgebra.ιMulti R n` is contained in the `n`th exterior power. -/
 lemma ιMulti_range (n : ℕ) :
-    Set.range (ιMulti R n (M := M)) ⊆ ↑(LinearMap.range (ι R (M := M)) ^ n) := by
+    Set.range (ιMulti R n (M := M)) ⊆ ↑((Λ[R]^n) M) := by
   rw [Set.range_subset_iff]
   intro v
   rw [ιMulti_apply]
@@ -344,9 +359,8 @@ lemma ιMulti_range (n : ℕ) :
 /-- The image of `ExteriorAlgebra.ιMulti R n` spans the `n`th exterior power, as a submodule
 of the exterior algebra. -/
 lemma ιMulti_span_fixedDegree (n : ℕ) :
-    Submodule.span R (Set.range (ιMulti R n)) =
-    LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M) ^ n := by
-  refine le_antisymm (Submodule.span_le.2 (ιMulti_range R n)) ?_
+    Submodule.span R (Set.range (ιMulti R n)) = (Λ[R]^n) M := by
+  refine le_antisymm (b := (LinearMap.range (ι R)) ^ n) (Submodule.span_le.2 (ιMulti_range R n)) ?_
   rw [Submodule.pow_eq_span_pow_set, Submodule.span_le]
   refine fun u hu ↦ Submodule.subset_span ?_
   obtain ⟨f, rfl⟩ := Set.mem_pow.mp hu

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
@@ -21,7 +21,7 @@ It is endowed with the structure of an `R`-algebra.
 The `n`th exterior power of the `R`-module `M` is denoted by `exteriorPower R n M`; it is of
 type `Submodule R (ExteriorAlgebra R M)` and defined as `LinearMap.range (ExteriorAlgebra.ι R :
 M →ₗ[R] ExteriorAlgebra R M) ^ n`. We also introduce the notation `Λ[R]^n M` for
-`ExteriorPower R n M`.
+`exteriorPower R n M`.
 
 Given a linear morphism `f : M → A` from a module `M` to another `R`-algebra `A`, such that
 `cond : ∀ m : M, f m * f m = 0`, there is a (unique) lift of `f` to an `R`-algebra morphism,
@@ -77,7 +77,7 @@ variable (n : ℕ) (N : Type u2) [AddCommGroup N] [Module R N]
 -- New variables `n` and `N`, to get the correct order of variables in the notation.
 
 /-- Definition of the `n`th exterior power of a `R`-module `N`. We introduce the notation
-`Λ[R]^n N` for `ExteriorPower R n N`. -/
+`Λ[R]^n N` for `exteriorPower R n N`. -/
 @[reducible]
 def exteriorPower := LinearMap.range (ι R : N →ₗ[R] ExteriorAlgebra R N) ^ n
 

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
@@ -18,6 +18,11 @@ We construct the exterior algebra of a module `M` over a commutative semiring `R
 The exterior algebra of the `R`-module `M` is denoted as `ExteriorAlgebra R M`.
 It is endowed with the structure of an `R`-algebra.
 
+The `n`th exterior power of the `R`-module `M` is denoted by `exteriorPower R n M`; it is of
+type `Submodule R (ExteriorAlgebra R M)` and defined as `LinearMap.range (ExteriorAlgebra.ι R :
+M →ₗ[R] ExteriorAlgebra R M) ^ n`. We also introduce the notation `Λ[R]^n M` for
+`ExteriorPower R n M`.
+
 Given a linear morphism `f : M → A` from a module `M` to another `R`-algebra `A`, such that
 `cond : ∀ m : M, f m * f m = 0`, there is a (unique) lift of `f` to an `R`-algebra morphism,
 which is denoted `ExteriorAlgebra.lift R f cond`.
@@ -66,7 +71,7 @@ def ι : M →ₗ[R] ExteriorAlgebra R M :=
   CliffordAlgebra.ι _
 #align exterior_algebra.ι ExteriorAlgebra.ι
 
-section ExteriorPower
+section exteriorPower
 
 variable (n : ℕ) (N : Type u2) [AddCommGroup N] [Module R N]
 -- New variables `n` and `N`, to get the correct order of variables in the notation.
@@ -74,12 +79,12 @@ variable (n : ℕ) (N : Type u2) [AddCommGroup N] [Module R N]
 /-- Definition of the `n`th exterior power of a `R`-module `N`. We introduce the notation
 `Λ[R]^n N` for `ExteriorPower R n N`. -/
 @[reducible]
-def ExteriorPower := (LinearMap.range (ι R : N →ₗ[R] ExteriorAlgebra R N) ^ n)
+def exteriorPower := LinearMap.range (ι R : N →ₗ[R] ExteriorAlgebra R N) ^ n
 
 @[inherit_doc]
-notation:100 "Λ[" R "]^" n:arg => ExteriorPower R n
+notation:100 "Λ[" R "]^" n:arg => exteriorPower R n
 
-end ExteriorPower
+end exteriorPower
 
 variable {R}
 

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
@@ -44,7 +44,7 @@ theorem GradedAlgebra.ι_apply (m : M) :
 -- Defining this instance manually, because Lean doesn't seem to be able to synthesize it.
 -- Strangely, this problem only appears when we use the abbreviation or notation for the
 -- exterior powers.
-instance : SetLike.GradedMonoid fun (i : ℕ) ↦ Λ[R]^i M :=
+instance : SetLike.GradedMonoid fun i : ℕ ↦ Λ[R]^i M :=
   Submodule.nat_power_gradedMonoid (LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M))
 
 -- Porting note: Lean needs to be reminded of this instance otherwise it cannot
@@ -82,8 +82,7 @@ theorem GradedAlgebra.liftι_eq (i : ℕ) (x : Λ[R]^i M) :
 #align exterior_algebra.graded_algebra.lift_ι_eq ExteriorAlgebra.GradedAlgebra.liftι_eq
 
 /-- The exterior algebra is graded by the powers of the submodule `(ExteriorAlgebra.ι R).range`. -/
-instance gradedAlgebra :
-    GradedAlgebra (fun (i : ℕ) ↦ Λ[R]^i M) :=
+instance gradedAlgebra : GradedAlgebra (fun i : ℕ ↦ Λ[R]^i M) :=
   GradedAlgebra.ofAlgHom _
     (-- while not necessary, the `by apply` makes this elaborate faster
     by apply GradedAlgebra.liftι R M)

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
@@ -42,7 +42,9 @@ theorem GradedAlgebra.ι_apply (m : M) :
 #align exterior_algebra.graded_algebra.ι_apply ExteriorAlgebra.GradedAlgebra.ι_apply
 
 -- Defining this instance manually, because Lean doesn't seem to be able to synthesize it.
-instance thisshouldnotbenecessary : SetLike.GradedMonoid fun (i : ℕ) ↦ (Λ[R]^i) M :=
+-- Strangely, this problem only appears when we use the abbreviation or notation for the
+-- exterior powers.
+instance : SetLike.GradedMonoid fun (i : ℕ) ↦ (Λ[R]^i) M :=
   Submodule.nat_power_gradedMonoid (LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M))
 
 -- Porting note: Lean needs to be reminded of this instance otherwise it cannot

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
@@ -29,14 +29,14 @@ open scoped DirectSum
 primarily an auxiliary construction used to provide `ExteriorAlgebra.gradedAlgebra`. -/
 -- porting note: protected
 protected def GradedAlgebra.ι :
-    M →ₗ[R] ⨁ i : ℕ, Λ[R]^i M :=
-  DirectSum.lof R ℕ (fun i => Λ[R]^i M) 1 ∘ₗ
+    M →ₗ[R] ⨁ i : ℕ, ⋀[R]^i M :=
+  DirectSum.lof R ℕ (fun i => ⋀[R]^i M) 1 ∘ₗ
     (ι R).codRestrict _ fun m => by simpa only [pow_one] using LinearMap.mem_range_self _ m
 #align exterior_algebra.graded_algebra.ι ExteriorAlgebra.GradedAlgebra.ι
 
 theorem GradedAlgebra.ι_apply (m : M) :
     GradedAlgebra.ι R M m =
-      DirectSum.of (fun i : ℕ => Λ[R]^i M) 1
+      DirectSum.of (fun i : ℕ => ⋀[R]^i M) 1
         ⟨ι R m, by simpa only [pow_one] using LinearMap.mem_range_self _ m⟩ :=
   rfl
 #align exterior_algebra.graded_algebra.ι_apply ExteriorAlgebra.GradedAlgebra.ι_apply
@@ -44,7 +44,7 @@ theorem GradedAlgebra.ι_apply (m : M) :
 -- Defining this instance manually, because Lean doesn't seem to be able to synthesize it.
 -- Strangely, this problem only appears when we use the abbreviation or notation for the
 -- exterior powers.
-instance : SetLike.GradedMonoid fun i : ℕ ↦ Λ[R]^i M :=
+instance : SetLike.GradedMonoid fun i : ℕ ↦ ⋀[R]^i M :=
   Submodule.nat_power_gradedMonoid (LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M))
 
 -- Porting note: Lean needs to be reminded of this instance otherwise it cannot
@@ -58,12 +58,12 @@ theorem GradedAlgebra.ι_sq_zero (m : M) : GradedAlgebra.ι R M m * GradedAlgebr
 /-- `ExteriorAlgebra.GradedAlgebra.ι` lifted to exterior algebra. This is
 primarily an auxiliary construction used to provide `ExteriorAlgebra.gradedAlgebra`. -/
 def GradedAlgebra.liftι :
-    ExteriorAlgebra R M →ₐ[R] ⨁ i : ℕ, Λ[R]^i M :=
+    ExteriorAlgebra R M →ₐ[R] ⨁ i : ℕ, ⋀[R]^i M :=
   lift R ⟨by apply GradedAlgebra.ι R M, GradedAlgebra.ι_sq_zero R M⟩
 #align exterior_algebra.graded_algebra.lift_ι ExteriorAlgebra.GradedAlgebra.liftι
 
-theorem GradedAlgebra.liftι_eq (i : ℕ) (x : Λ[R]^i M) :
-    GradedAlgebra.liftι R M x = DirectSum.of (fun i => Λ[R]^i M) i x := by
+theorem GradedAlgebra.liftι_eq (i : ℕ) (x : ⋀[R]^i M) :
+    GradedAlgebra.liftι R M x = DirectSum.of (fun i => ⋀[R]^i M) i x := by
   cases' x with x hx
   dsimp only [Subtype.coe_mk, DirectSum.lof_eq_of]
   -- Porting note: original statement was
@@ -82,7 +82,7 @@ theorem GradedAlgebra.liftι_eq (i : ℕ) (x : Λ[R]^i M) :
 #align exterior_algebra.graded_algebra.lift_ι_eq ExteriorAlgebra.GradedAlgebra.liftι_eq
 
 /-- The exterior algebra is graded by the powers of the submodule `(ExteriorAlgebra.ι R).range`. -/
-instance gradedAlgebra : GradedAlgebra (fun i : ℕ ↦ Λ[R]^i M) :=
+instance gradedAlgebra : GradedAlgebra (fun i : ℕ ↦ ⋀[R]^i M) :=
   GradedAlgebra.ofAlgHom _
     (-- while not necessary, the `by apply` makes this elaborate faster
     by apply GradedAlgebra.liftι R M)
@@ -101,7 +101,7 @@ lemma ιMulti_span :
     Submodule.span R (Set.range fun x : Σ n, (Fin n → M) => ιMulti R x.1 x.2) = ⊤ := by
   rw [Submodule.eq_top_iff']
   intro x
-  induction x using DirectSum.Decomposition.inductionOn fun i => Λ[R]^i M with
+  induction x using DirectSum.Decomposition.inductionOn fun i => ⋀[R]^i M with
   | h_zero => exact Submodule.zero_mem _
   | h_add _ _ hm hm' => exact Submodule.add_mem _ hm hm'
   | h_homogeneous hm =>

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
@@ -29,14 +29,14 @@ open scoped DirectSum
 primarily an auxiliary construction used to provide `ExteriorAlgebra.gradedAlgebra`. -/
 -- porting note: protected
 protected def GradedAlgebra.ι :
-    M →ₗ[R] ⨁ i : ℕ, ↥((Λ[R]^i) M : Submodule R (ExteriorAlgebra R M)) :=
-  DirectSum.lof R ℕ (fun i => ↥((Λ[R]^i) M : Submodule R (ExteriorAlgebra R M))) 1 ∘ₗ
+    M →ₗ[R] ⨁ i : ℕ, Λ[R]^i M :=
+  DirectSum.lof R ℕ (fun i => Λ[R]^i M) 1 ∘ₗ
     (ι R).codRestrict _ fun m => by simpa only [pow_one] using LinearMap.mem_range_self _ m
 #align exterior_algebra.graded_algebra.ι ExteriorAlgebra.GradedAlgebra.ι
 
 theorem GradedAlgebra.ι_apply (m : M) :
     GradedAlgebra.ι R M m =
-      DirectSum.of (fun i : ℕ => ↥((Λ[R]^i) M)) 1
+      DirectSum.of (fun i : ℕ => Λ[R]^i M) 1
         ⟨ι R m, by simpa only [pow_one] using LinearMap.mem_range_self _ m⟩ :=
   rfl
 #align exterior_algebra.graded_algebra.ι_apply ExteriorAlgebra.GradedAlgebra.ι_apply
@@ -44,7 +44,7 @@ theorem GradedAlgebra.ι_apply (m : M) :
 -- Defining this instance manually, because Lean doesn't seem to be able to synthesize it.
 -- Strangely, this problem only appears when we use the abbreviation or notation for the
 -- exterior powers.
-instance : SetLike.GradedMonoid fun (i : ℕ) ↦ (Λ[R]^i) M :=
+instance : SetLike.GradedMonoid fun (i : ℕ) ↦ Λ[R]^i M :=
   Submodule.nat_power_gradedMonoid (LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M))
 
 -- Porting note: Lean needs to be reminded of this instance otherwise it cannot
@@ -58,15 +58,12 @@ theorem GradedAlgebra.ι_sq_zero (m : M) : GradedAlgebra.ι R M m * GradedAlgebr
 /-- `ExteriorAlgebra.GradedAlgebra.ι` lifted to exterior algebra. This is
 primarily an auxiliary construction used to provide `ExteriorAlgebra.gradedAlgebra`. -/
 def GradedAlgebra.liftι :
-    ExteriorAlgebra R M →ₐ[R] ⨁ i : ℕ, ((Λ[R]^i) M : Submodule R (ExteriorAlgebra R M)) :=
+    ExteriorAlgebra R M →ₐ[R] ⨁ i : ℕ, Λ[R]^i M :=
   lift R ⟨by apply GradedAlgebra.ι R M, GradedAlgebra.ι_sq_zero R M⟩
 #align exterior_algebra.graded_algebra.lift_ι ExteriorAlgebra.GradedAlgebra.liftι
 
-theorem GradedAlgebra.liftι_eq (i : ℕ)
-    (x : ((Λ[R]^i) M : Submodule R (ExteriorAlgebra R M))) :
-    GradedAlgebra.liftι R M x =
-    DirectSum.of (fun i =>
-      ↥((Λ[R]^i) M : Submodule R (ExteriorAlgebra R M))) i x := by
+theorem GradedAlgebra.liftι_eq (i : ℕ) (x : Λ[R]^i M) :
+    GradedAlgebra.liftι R M x = DirectSum.of (fun i => Λ[R]^i M) i x := by
   cases' x with x hx
   dsimp only [Subtype.coe_mk, DirectSum.lof_eq_of]
   -- Porting note: original statement was
@@ -86,7 +83,7 @@ theorem GradedAlgebra.liftι_eq (i : ℕ)
 
 /-- The exterior algebra is graded by the powers of the submodule `(ExteriorAlgebra.ι R).range`. -/
 instance gradedAlgebra :
-    GradedAlgebra (fun (i : ℕ) ↦ ((Λ[R]^i) M : Submodule R _)) :=
+    GradedAlgebra (fun (i : ℕ) ↦ Λ[R]^i M) :=
   GradedAlgebra.ofAlgHom _
     (-- while not necessary, the `by apply` makes this elaborate faster
     by apply GradedAlgebra.liftι R M)
@@ -105,8 +102,7 @@ lemma ιMulti_span :
     Submodule.span R (Set.range fun x : Σ n, (Fin n → M) => ιMulti R x.1 x.2) = ⊤ := by
   rw [Submodule.eq_top_iff']
   intro x
-  induction x
-    using DirectSum.Decomposition.inductionOn fun i => (Λ[R]^i) M with
+  induction x using DirectSum.Decomposition.inductionOn fun i => Λ[R]^i M with
   | h_zero => exact Submodule.zero_mem _
   | h_add _ _ hm hm' => exact Submodule.add_mem _ hm hm'
   | h_homogeneous hm =>

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
@@ -17,7 +17,6 @@ The main result is `ExteriorAlgebra.gradedAlgebra`, which says that the exterior
 ℕ-graded algebra.
 -/
 
-
 namespace ExteriorAlgebra
 
 variable {R M : Type*} [CommRing R] [AddCommGroup M] [Module R M]
@@ -30,8 +29,8 @@ open scoped DirectSum
 primarily an auxiliary construction used to provide `ExteriorAlgebra.gradedAlgebra`. -/
 -- porting note: protected
 protected def GradedAlgebra.ι :
-    M →ₗ[R] ⨁ i : ℕ, ↥((Λ[R]^i) M) :=
-  DirectSum.lof R ℕ (fun i => ↥((Λ[R]^i) M)) 1 ∘ₗ
+    M →ₗ[R] ⨁ i : ℕ, ↥((Λ[R]^i) M : Submodule R (ExteriorAlgebra R M)) :=
+  DirectSum.lof R ℕ (fun i => ↥((Λ[R]^i) M : Submodule R (ExteriorAlgebra R M))) 1 ∘ₗ
     (ι R).codRestrict _ fun m => by simpa only [pow_one] using LinearMap.mem_range_self _ m
 #align exterior_algebra.graded_algebra.ι ExteriorAlgebra.GradedAlgebra.ι
 
@@ -41,6 +40,10 @@ theorem GradedAlgebra.ι_apply (m : M) :
         ⟨ι R m, by simpa only [pow_one] using LinearMap.mem_range_self _ m⟩ :=
   rfl
 #align exterior_algebra.graded_algebra.ι_apply ExteriorAlgebra.GradedAlgebra.ι_apply
+
+-- Defining this instance manually, because Lean doesn't seem to be able to synthesize it.
+instance thisshouldnotbenecessary : SetLike.GradedMonoid fun (i : ℕ) ↦ (Λ[R]^i) M :=
+  Submodule.nat_power_gradedMonoid (LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M))
 
 -- Porting note: Lean needs to be reminded of this instance otherwise it cannot
 -- synthesize 0 in the next theorem
@@ -58,12 +61,10 @@ def GradedAlgebra.liftι :
 #align exterior_algebra.graded_algebra.lift_ι ExteriorAlgebra.GradedAlgebra.liftι
 
 theorem GradedAlgebra.liftι_eq (i : ℕ)
-    (x : (LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M) ^ i :
-      Submodule R (ExteriorAlgebra R M))) :
+    (x : ((Λ[R]^i) M : Submodule R (ExteriorAlgebra R M))) :
     GradedAlgebra.liftι R M x =
     DirectSum.of (fun i =>
-      ↥(LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M) ^ i :
-      Submodule R (ExteriorAlgebra R M))) i x := by
+      ↥((Λ[R]^i) M : Submodule R (ExteriorAlgebra R M))) i x := by
   cases' x with x hx
   dsimp only [Subtype.coe_mk, DirectSum.lof_eq_of]
   -- Porting note: original statement was
@@ -83,7 +84,7 @@ theorem GradedAlgebra.liftι_eq (i : ℕ)
 
 /-- The exterior algebra is graded by the powers of the submodule `(ExteriorAlgebra.ι R).range`. -/
 instance gradedAlgebra :
-    GradedAlgebra (LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M) ^ · : ℕ → Submodule R _) :=
+    GradedAlgebra (fun (i : ℕ) ↦ ((Λ[R]^i) M : Submodule R _)) :=
   GradedAlgebra.ofAlgHom _
     (-- while not necessary, the `by apply` makes this elaborate faster
     by apply GradedAlgebra.liftι R M)
@@ -103,7 +104,7 @@ lemma ιMulti_span :
   rw [Submodule.eq_top_iff']
   intro x
   induction x
-    using DirectSum.Decomposition.inductionOn fun i => LinearMap.range (ι R (M := M)) ^ i with
+    using DirectSum.Decomposition.inductionOn fun i => (Λ[R]^i) M with
   | h_zero => exact Submodule.zero_mem _
   | h_add _ _ hm hm' => exact Submodule.add_mem _ hm hm'
   | h_homogeneous hm =>

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
@@ -30,14 +30,14 @@ open scoped DirectSum
 primarily an auxiliary construction used to provide `ExteriorAlgebra.gradedAlgebra`. -/
 -- porting note: protected
 protected def GradedAlgebra.ι :
-    M →ₗ[R] ⨁ i : ℕ, ↥(LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M) ^ i) :=
-  DirectSum.lof R ℕ (fun i => ↥(LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M) ^ i)) 1 ∘ₗ
+    M →ₗ[R] ⨁ i : ℕ, ↥((Λ[R]^i) M) :=
+  DirectSum.lof R ℕ (fun i => ↥((Λ[R]^i) M)) 1 ∘ₗ
     (ι R).codRestrict _ fun m => by simpa only [pow_one] using LinearMap.mem_range_self _ m
 #align exterior_algebra.graded_algebra.ι ExteriorAlgebra.GradedAlgebra.ι
 
 theorem GradedAlgebra.ι_apply (m : M) :
     GradedAlgebra.ι R M m =
-      DirectSum.of (fun i : ℕ => ↥(LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M) ^ i)) 1
+      DirectSum.of (fun i : ℕ => ↥((Λ[R]^i) M)) 1
         ⟨ι R m, by simpa only [pow_one] using LinearMap.mem_range_self _ m⟩ :=
   rfl
 #align exterior_algebra.graded_algebra.ι_apply ExteriorAlgebra.GradedAlgebra.ι_apply
@@ -53,8 +53,7 @@ theorem GradedAlgebra.ι_sq_zero (m : M) : GradedAlgebra.ι R M m * GradedAlgebr
 /-- `ExteriorAlgebra.GradedAlgebra.ι` lifted to exterior algebra. This is
 primarily an auxiliary construction used to provide `ExteriorAlgebra.gradedAlgebra`. -/
 def GradedAlgebra.liftι :
-    ExteriorAlgebra R M →ₐ[R] ⨁ i : ℕ,
-    (LinearMap.range (ι R : M →ₗ[R] ExteriorAlgebra R M) ^ i : Submodule R (ExteriorAlgebra R M)) :=
+    ExteriorAlgebra R M →ₐ[R] ⨁ i : ℕ, ((Λ[R]^i) M : Submodule R (ExteriorAlgebra R M)) :=
   lift R ⟨by apply GradedAlgebra.ι R M, GradedAlgebra.ι_sq_zero R M⟩
 #align exterior_algebra.graded_algebra.lift_ι ExteriorAlgebra.GradedAlgebra.liftι
 


### PR DESCRIPTION
This is split off from PR #10654 (that actually proves some properties of the exterior powers). It introduces the reducible definition `exteriorPower R n M` for the `n`th exterior power of the `R`-module `M`; this is of type `Submodule R (ExteriorAlgebra R M)` and defined as `LinearMap.range (ExteriorAlgebra.ι R : M →ₗ[R] ExteriorAlgebra R M) ^ n`. 
It also introduces the notation `Λ[R]^n M` for `exteriorPower R n M`.

Note: for a reason that I don't understand, Lean becomes unable to synthesize the `SetLike.GradedMonoid` instance on `fun (i : ℕ) ↦ (Λ[R]^i) M`, so I added it manually in `ExteriorAlgebra/Graded.lean`. I am far from sure that this is the correct solution.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
