### PR TITLE
feat(Tactic/Positivity): non-negativity of functions

### DIFF
--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -292,6 +292,23 @@ def compareHyp (e : Q($α)) (ldecl : LocalDecl) : MetaM (Strictness zα pα e) :
     | _, _ => pure .none
   | _ => pure .none
 
+/-- A variation on `assumption` which checks if the hypothesis `ldecl` is `a ≤ f`
+where `a` is a numeral and `e = f x` for some `x`. -/
+def compareHypFun (e : Q($α)) (ldecl : LocalDecl) : MetaM (Strictness zα pα e) := do
+  have e' : Q(Prop) := ldecl.type
+  let p : Q($e') := .fvar ldecl.fvarId
+  match e' with
+  | ~q(@LE.le.{u} ($β → $β) $_le $lo $hi) =>
+    let .defEq (_ : $α =Q $β) ← isDefEqQ α β | return .none
+    let a ← mkFreshExprMVarQ q($α)
+    let .defEq _h ← isDefEqQ q($e) q($hi $a) | return .none
+    match lo with
+    | ~q(0) =>
+      assertInstancesCommute
+      return .nonnegative q(Pi.le_def.mp $p $a)
+    | _ => pure .none
+  | _ => pure .none
+
 variable {zα pα} in
 /-- The main combinator which combines multiple `positivity` results.
 It assumes `t₁` has already been run for a result, and runs `t₂` and takes the best result.
@@ -330,6 +347,7 @@ def core (e : Q($α)) : MetaM (Strictness zα pα e) := do
   for ldecl in ← getLCtx do
     if !ldecl.isImplementationDetail then
       result ← orElse result <| compareHyp zα pα e ldecl
+      result ← orElse result <| compareHypFun zα pα e ldecl
   trace[Tactic.positivity] "{e} => {result.toString}"
   throwNone (pure result)
 

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -307,6 +307,15 @@ def compareHypFun (e : Q($α)) (ldecl : LocalDecl) : MetaM (Strictness zα pα e
       assertInstancesCommute
       return .nonnegative q(Pi.le_def.mp $p $a)
     | _ => pure .none
+  | ~q(@LT.lt.{u} ($β → $β) $_le $lo $hi) =>
+    let .defEq (_ : $α =Q $β) ← isDefEqQ α β | return .none
+    let a ← mkFreshExprMVarQ q($α)
+    let .defEq _h ← isDefEqQ q($e) q($hi $a) | return .none
+    match lo with
+    | ~q(0) =>
+      assertInstancesCommute
+      return .nonnegative q((Pi.lt_def.mp $p).1 $a)
+    | _ => pure .none
   | _ => pure .none
 
 variable {zα pα} in


### PR DESCRIPTION
---

This makes the `Finset.sum` and `integral_nonneg` extensions even more useful.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
