### PR TITLE
[Merged by Bors] - feat: lemmas about `kernel.withDensity`

### DIFF
--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -73,7 +73,7 @@ protected theorem withDensity_apply' (κ : kernel α β) [IsSFiniteKernel κ]
 #align probability_theory.kernel.with_density_apply' ProbabilityTheory.kernel.withDensity_apply'
 
 nonrec lemma withDensity_congr_ae (κ : kernel α β) [IsSFiniteKernel κ] {f g : α → β → ℝ≥0∞}
-  (hf : Measurable (Function.uncurry f)) (hg : Measurable (Function.uncurry g))
+    (hf : Measurable (Function.uncurry f)) (hg : Measurable (Function.uncurry g))
     (hfg : ∀ a, f a =ᵐ[κ a] g a) :
     withDensity κ f = withDensity κ g := by
   ext a

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -72,7 +72,7 @@ protected theorem withDensity_apply' (κ : kernel α β) [IsSFiniteKernel κ]
   rw [kernel.withDensity_apply κ hf, withDensity_apply' _ s]
 #align probability_theory.kernel.with_density_apply' ProbabilityTheory.kernel.withDensity_apply'
 
-nonrec lemma kernel.withDensity_absolutelyContinuous [IsSFiniteKernel κ]
+nonrec lemma withDensity_absolutelyContinuous [IsSFiniteKernel κ]
     (f : α → β → ℝ≥0∞) (a : α) :
     kernel.withDensity κ f a ≪ κ a := by
   by_cases hf : Measurable (Function.uncurry f)

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -72,6 +72,33 @@ protected theorem withDensity_apply' (κ : kernel α β) [IsSFiniteKernel κ]
   rw [kernel.withDensity_apply κ hf, withDensity_apply' _ s]
 #align probability_theory.kernel.with_density_apply' ProbabilityTheory.kernel.withDensity_apply'
 
+nonrec lemma kernel.withDensity_absolutelyContinuous [IsSFiniteKernel κ]
+    (f : α → β → ℝ≥0∞) (a : α) :
+    kernel.withDensity κ f a ≪ κ a := by
+  by_cases hf : Measurable (Function.uncurry f)
+  · rw [kernel.withDensity_apply _ hf]
+    exact withDensity_absolutelyContinuous _ _
+  · rw [withDensity_of_not_measurable _ hf]
+    simp [Measure.AbsolutelyContinuous.zero]
+
+@[simp]
+lemma withDensity_one (κ : kernel α β) [IsSFiniteKernel κ] :
+    kernel.withDensity κ 1 = κ := by
+  ext; rw [kernel.withDensity_apply _ measurable_const]; simp
+
+@[simp]
+lemma withDensity_one' (κ : kernel α β) [IsSFiniteKernel κ] :
+    kernel.withDensity κ (fun _ _ ↦ 1) = κ := kernel.withDensity_one _
+
+@[simp]
+lemma withDensity_zero (κ : kernel α β) [IsSFiniteKernel κ] :
+    kernel.withDensity κ 0 = 0 := by
+  ext; rw [kernel.withDensity_apply _ measurable_const]; simp
+
+@[simp]
+lemma withDensity_zero' (κ : kernel α β) [IsSFiniteKernel κ] :
+    kernel.withDensity κ (fun _ _ ↦ 0) = 0 := kernel.withDensity_zero _
+
 theorem lintegral_withDensity (κ : kernel α β) [IsSFiniteKernel κ]
     (hf : Measurable (Function.uncurry f)) (a : α) {g : β → ℝ≥0∞} (hg : Measurable g) :
     ∫⁻ b, g b ∂withDensity κ f a = ∫⁻ b, f a b * g b ∂κ a := by
@@ -133,6 +160,21 @@ theorem withDensity_tsum [Countable ι] (κ : kernel α β) [IsSFiniteKernel κ]
   congr with n
   rw [kernel.withDensity_apply' _ (hf n) a s]
 #align probability_theory.kernel.with_density_tsum ProbabilityTheory.kernel.withDensity_tsum
+
+lemma withDensity_sub_add [IsSFiniteKernel κ] {f g : α → β → ℝ≥0∞}
+    (hf : Measurable (Function.uncurry f)) (hg : Measurable (Function.uncurry g))
+    (hg_int : ∀ a, ∫⁻ x, g a x ∂(κ a) ≠ ∞) (hfg : ∀ a, g a ≤ᵐ[κ a] f a) :
+    withDensity κ (fun a x ↦ f a x - g a x) + withDensity κ g = withDensity κ f := by
+  ext a s
+  simp only [coeFn_add, Pi.add_apply, Measure.add_toOuterMeasure, OuterMeasure.coe_add]
+  rw [kernel.withDensity_apply' _ hf, kernel.withDensity_apply' _ hg, kernel.withDensity_apply']
+  swap; · exact hf.sub hg
+  rw [lintegral_sub]
+  · rw [tsub_add_cancel_iff_le]
+    exact lintegral_mono_ae (ae_restrict_of_ae (hfg a))
+  · exact hg.comp measurable_prod_mk_left
+  · exact ((set_lintegral_le_lintegral _ _).trans_lt (hg_int a).lt_top).ne
+  · exact ae_restrict_of_ae (hfg a)
 
 /-- If a kernel `κ` is finite and a function `f : α → β → ℝ≥0∞` is bounded, then `withDensity κ f`
 is finite. -/
@@ -229,5 +271,21 @@ nonrec theorem IsSFiniteKernel.withDensity (κ : kernel α β) [IsSFiniteKernel 
 instance (κ : kernel α β) [IsSFiniteKernel κ] (f : α → β → ℝ≥0) :
     IsSFiniteKernel (withDensity κ fun a b => f a b) :=
   IsSFiniteKernel.withDensity κ fun _ _ => ENNReal.coe_ne_top
+
+nonrec lemma withDensity_mul [IsSFiniteKernel κ] {f : α → β → ℝ≥0} {g : α → β → ℝ≥0∞}
+    (hf : Measurable (Function.uncurry f)) (hg : Measurable (Function.uncurry g)) :
+    withDensity κ (fun a x ↦ f a x * g a x)
+      = withDensity (withDensity κ fun a x ↦ f a x) g := by
+  ext a : 1
+  rw [kernel.withDensity_apply]
+  swap; · exact (measurable_coe_nnreal_ennreal.comp hf).mul hg
+  change (Measure.withDensity (κ a) ((fun x ↦ (f a x : ℝ≥0∞)) * (fun x ↦ (g a x : ℝ≥0∞)))) =
+      (withDensity (withDensity κ fun a x ↦ f a x) g) a
+  rw [withDensity_mul]
+  · rw [kernel.withDensity_apply _ hg, kernel.withDensity_apply]
+    exact measurable_coe_nnreal_ennreal.comp hf
+  · rw [measurable_coe_nnreal_ennreal_iff]
+    exact hf.comp measurable_prod_mk_left
+  · exact hg.comp measurable_prod_mk_left
 
 end ProbabilityTheory.kernel


### PR DESCRIPTION
Add a few simp lemmas about withDensity of constant functions 1 and 0, and the 3 more interesting lemmas
- `withDensity_add_right`: `withDensity κ (f + g) = withDensity κ f + withDensity κ g`
- `withDensity_sub_add_cancel`: `withDensity κ (fun a x ↦ f a x - g a x) + withDensity κ g = withDensity κ f`
- `withDensity_mul`: `withDensity κ (fun a x ↦ f a x * g a x) = withDensity (withDensity κ fun a x ↦ f a x) g`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
