### PR TITLE
[Merged by Bors] - feat: show that every polynomial functor is a (trivial) QPF

### DIFF
--- a/Mathlib/Data/QPF/Multivariate/Basic.lean
+++ b/Mathlib/Data/QPF/Multivariate/Basic.lean
@@ -284,3 +284,11 @@ theorem liftpPreservation_iff_uniform : q.LiftPPreservation ↔ q.IsUniform := b
 #align mvqpf.liftp_preservation_iff_uniform MvQPF.liftpPreservation_iff_uniform
 
 end MvQPF
+
+/-- Every polynomial functor is a (trivial) QPF -/
+instance MvPFunctor.instMvQPFObj {n} (P : MvPFunctor n) : MvQPF P where
+  P := P
+  abs := id
+  repr := id
+  abs_repr := by intros; rfl
+  abs_map := by intros; rfl


### PR DESCRIPTION
Every polynomial functor `P` is trivially also a quotient of a polynomial functor, namely, it's a quotient of itself through equality. That is, `abs` and `repr` are just the identity.

---

Similar to #10806, this is used when showing that existing type functions which are equivalent to polynomial functors but not defined as such (e.g., Sum, Prod, etc.) are QPFs.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
