### PR TITLE
[Merged by Bors] - chore: a non-lean linter for #-commands

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -192,6 +192,12 @@ jobs:
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
 
+      - name: find `#`-commands
+        id: hash_commands
+        run: |
+          chmod u+x scripts/lint_hash_commands.sh
+          ./scripts/lint_hash_commands.sh
+
       - name: build library_search cache
         run: lake build -KCI MathlibExtras
 

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -192,12 +192,6 @@ jobs:
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
 
-      - name: find `#`-commands
-        id: hash_commands
-        run: |
-          chmod u+x scripts/lint_hash_commands.sh
-          ./scripts/lint_hash_commands.sh
-
       - name: build library_search cache
         run: lake build -KCI MathlibExtras
 
@@ -228,6 +222,12 @@ jobs:
             # and if we find " Building Mathlib" in that file we kill `lake build`, and error.
             lake build > tmp & tail --pid=$! -n +1 -F tmp | (! (grep -m 1 " Building Mathlib" && kill $! ))
           fi
+
+      - name: find `#`-commands
+        id: hash_commands
+        run: |
+          chmod u+x scripts/lint_hash_commands.sh
+          ./scripts/lint_hash_commands.sh
 
       - name: build archive
         id: archive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,12 +199,6 @@ jobs:
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
 
-      - name: find `#`-commands
-        id: hash_commands
-        run: |
-          chmod u+x scripts/lint_hash_commands.sh
-          ./scripts/lint_hash_commands.sh
-
       - name: build library_search cache
         run: lake build -KCI MathlibExtras
 
@@ -235,6 +229,12 @@ jobs:
             # and if we find " Building Mathlib" in that file we kill `lake build`, and error.
             lake build > tmp & tail --pid=$! -n +1 -F tmp | (! (grep -m 1 " Building Mathlib" && kill $! ))
           fi
+
+      - name: find `#`-commands
+        id: hash_commands
+        run: |
+          chmod u+x scripts/lint_hash_commands.sh
+          ./scripts/lint_hash_commands.sh
 
       - name: build archive
         id: archive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,6 +199,12 @@ jobs:
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
 
+      - name: find `#`-commands
+        id: hash_commands
+        run: |
+          chmod u+x scripts/lint_hash_commands.sh
+          ./scripts/lint_hash_commands.sh
+
       - name: build library_search cache
         run: lake build -KCI MathlibExtras
 

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -178,12 +178,6 @@ jobs:
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
 
-      - name: find `#`-commands
-        id: hash_commands
-        run: |
-          chmod u+x scripts/lint_hash_commands.sh
-          ./scripts/lint_hash_commands.sh
-
       - name: build library_search cache
         run: lake build -KCI MathlibExtras
 
@@ -214,6 +208,12 @@ jobs:
             # and if we find " Building Mathlib" in that file we kill `lake build`, and error.
             lake build > tmp & tail --pid=$! -n +1 -F tmp | (! (grep -m 1 " Building Mathlib" && kill $! ))
           fi
+
+      - name: find `#`-commands
+        id: hash_commands
+        run: |
+          chmod u+x scripts/lint_hash_commands.sh
+          ./scripts/lint_hash_commands.sh
 
       - name: build archive
         id: archive

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -178,6 +178,12 @@ jobs:
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
 
+      - name: find `#`-commands
+        id: hash_commands
+        run: |
+          chmod u+x scripts/lint_hash_commands.sh
+          ./scripts/lint_hash_commands.sh
+
       - name: build library_search cache
         run: lake build -KCI MathlibExtras
 

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -196,12 +196,6 @@ jobs:
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
 
-      - name: find `#`-commands
-        id: hash_commands
-        run: |
-          chmod u+x scripts/lint_hash_commands.sh
-          ./scripts/lint_hash_commands.sh
-
       - name: build library_search cache
         run: lake build -KCI MathlibExtras
 
@@ -232,6 +226,12 @@ jobs:
             # and if we find " Building Mathlib" in that file we kill `lake build`, and error.
             lake build > tmp & tail --pid=$! -n +1 -F tmp | (! (grep -m 1 " Building Mathlib" && kill $! ))
           fi
+
+      - name: find `#`-commands
+        id: hash_commands
+        run: |
+          chmod u+x scripts/lint_hash_commands.sh
+          ./scripts/lint_hash_commands.sh
 
       - name: build archive
         id: archive

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -196,6 +196,12 @@ jobs:
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
 
+      - name: find `#`-commands
+        id: hash_commands
+        run: |
+          chmod u+x scripts/lint_hash_commands.sh
+          ./scripts/lint_hash_commands.sh
+
       - name: build library_search cache
         run: lake build -KCI MathlibExtras
 

--- a/scripts/lint_hash_commands.sh
+++ b/scripts/lint_hash_commands.sh
@@ -29,7 +29,7 @@ getHashCommands () {
 awk -v csvcmds="$( getHashCommands )" \
   -v con=$( git ls-files 'Mathlib/*.lean' | wc -l ) \
   -v verbose="${1}" \
- 'function perr(msg) { print msg | "cat >&2"; close("cat >&2") }
+ 'function perr(errMsg) { print errMsg | "cat >&2"; close("cat >&2") }
   BEGIN{
     incomment=0
     split(csvcmds, cmds, ",")

--- a/scripts/lint_hash_commands.sh
+++ b/scripts/lint_hash_commands.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+## create a list of all the `#`-commands
+getHashCommands () {
+  >&2 printf $'Learning `#`-commands\n'
+  printf $'import Mathlib\n#help command\n' |
+    lake env lean --stdin |
+    sed -n 's=^syntax "\(#[^"]*\)".*=^\1=p' |
+    grep -v "#align$" |
+    grep -v "#align_import$" |
+    grep -v "#noalign$" |
+    sort -u | tr '\n' , |
+    sed 's=,$=='
+}
+
+## scans all the files in `Mathlib/*.lean` looking for lines that
+## * begin with `#cmd`, where `#cmd` is an output of `getHashCommands`;
+## * are not inside a comment block.
+awk -v csvcmds="$( getHashCommands )" \
+  -v con=$( git ls-files 'Mathlib/*.lean' | wc -l ) \
+ 'function perr(msg) { print msg | "cat >&2"; close("cat >&2") }
+  BEGIN{
+    incomment=0
+    split(csvcmds, cmds, ",")
+    msg=""
+    print "Sniffing `#`-commands"
+  }
+  ## lines that begin with `/-` are labeled as `incomment`
+  /^\/-/ { incomment=1 }
+  ## lines that contain `-/` are labeled as not `incomment`
+  /-\// { incomment=0 }
+  ## lines that begin with `#` and are not `incomment` get processed
+  (/^#/ && incomment == "0") {
+    for(cmd in cmds) { if ($0 ~ cmds[cmd]) {
+      msg=msg sprintf("%s:%s:%s\n", FILENAME, FNR, $0) }
+    } }
+  (FNR == 1) {
+    con--
+    if(con % 100 == 0) perr(sprintf("%5s files to go", con))
+  } END{
+    if (msg != "") {
+      printf("\nThe following `#`-command should not be present:\n\n%s", msg)
+      exit 1
+  }
+}' $( git ls-files 'Mathlib/*.lean' )


### PR DESCRIPTION
This PR introduces an `awk`-based linter for checking that `Mathlib/*.lean` files do not contain `#`-commands.

It takes the names of the commands that begin with `#` by running
```lean
import Mathlib
#help command
```
and after that it is all text-based substitutions.

It triggers an error on lines that begin with `#cmd`, omitting (most) lines contained comment blocks.

CI for this PR should fail until #10772 and #10827 have been merged.

---

#10772 has been merged and the error message for the check decreased.

#10827 has been merged and the error message disappeared.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
