### PR TITLE
[Merged by Bors] - feat: Complex `exp`, `log`, and `cpow` are analytic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -905,6 +905,7 @@ import Mathlib.Analysis.Seminorm
 import Mathlib.Analysis.SpecialFunctions.Arsinh
 import Mathlib.Analysis.SpecialFunctions.Bernstein
 import Mathlib.Analysis.SpecialFunctions.CompareExp
+import Mathlib.Analysis.SpecialFunctions.Complex.Analytic
 import Mathlib.Analysis.SpecialFunctions.Complex.Arctan
 import Mathlib.Analysis.SpecialFunctions.Complex.Arg
 import Mathlib.Analysis.SpecialFunctions.Complex.Circle

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -626,4 +626,30 @@ protected theorem _root_.Differentiable.hasFPowerSeriesOnBall {f : ℂ → E} (h
     ⟨_, h.differentiableOn.hasFPowerSeriesOnBall hr⟩
 #align differentiable.has_fpower_series_on_ball Differentiable.hasFPowerSeriesOnBall
 
+/-- On an open set, `f : ℂ → E` is analytic iff it is differentiable -/
+theorem analyticOn_iff_differentiableOn {f : ℂ → E} {s : Set ℂ} (o : IsOpen s) :
+    AnalyticOn ℂ f s ↔ DifferentiableOn ℂ f s :=
+  ⟨AnalyticOn.differentiableOn, fun d _ zs ↦ d.analyticAt (o.mem_nhds zs)⟩
+
+/-- `f : ℂ → E` is entire iff it's differentiable -/
+theorem analyticOn_univ_iff_differentiable {f : ℂ → E} :
+    AnalyticOn ℂ f univ ↔ Differentiable ℂ f := by
+  simp only [← differentiableOn_univ]
+  exact analyticOn_iff_differentiableOn isOpen_univ
+
+/-- `f : ℂ → E` is analytic at `z` iff it's differentiable near `z` -/
+theorem analyticAt_iff_eventually_differentiableAt {f : ℂ → E} {c : ℂ} :
+    AnalyticAt ℂ f c ↔ ∀ᶠ z in 𝓝 c, DifferentiableAt ℂ f z := by
+  constructor
+  · intro fa
+    filter_upwards [fa.eventually_analyticAt]
+    apply AnalyticAt.differentiableAt
+  · intro d
+    rcases _root_.eventually_nhds_iff.mp d with ⟨s, d, o, m⟩
+    have h : AnalyticOn ℂ f s := by
+      refine DifferentiableOn.analyticOn ?_ o
+      intro z m
+      exact (d z m).differentiableWithinAt
+    exact h _ m
+
 end Complex

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Analytic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Analytic.lean
@@ -21,12 +21,20 @@ variable {E : Type} [NormedAddCommGroup E] [NormedSpace ℂ E]
 variable {f g : E → ℂ} {z : ℂ} {x : E} {s : Set E}
 
 /-- `exp` is entire -/
-theorem AnalyticOn.cexp : AnalyticOn ℂ exp univ := by
+theorem analyticOn_cexp : AnalyticOn ℂ exp univ := by
   rw [analyticOn_univ_iff_differentiable]; exact differentiable_exp
 
 /-- `exp` is analytic at any point -/
-theorem AnalyticAt.cexp : AnalyticAt ℂ exp z :=
-  AnalyticOn.cexp z (Set.mem_univ _)
+theorem analyticAt_cexp : AnalyticAt ℂ exp z :=
+  analyticOn_cexp z (mem_univ _)
+
+/-- `exp ∘ f` is analytic -/
+theorem AnalyticAt.cexp (fa : AnalyticAt ℂ f x) : AnalyticAt ℂ (fun z ↦ exp (f z)) x :=
+  analyticAt_cexp.comp fa
+
+/-- `exp ∘ f` is analytic -/
+theorem AnalyticOn.cexp (fs : AnalyticOn ℂ f s) : AnalyticOn ℂ (fun z ↦ exp (f z)) s :=
+  fun z n ↦ analyticAt_cexp.comp (fs z n)
 
 /-- `log` is analytic away from nonpositive reals -/
 theorem analyticAt_clog (m : z ∈ slitPlane) : AnalyticAt ℂ log z := by
@@ -53,4 +61,9 @@ theorem AnalyticAt.cpow (fa : AnalyticAt ℂ f x) (ga : AnalyticAt ℂ g x)
     intro z fz
     simp only [fz, cpow_def, if_false]
   rw [analyticAt_congr e]
-  exact AnalyticAt.cexp.comp ((fa.clog m).mul ga)
+  exact ((fa.clog m).mul ga).cexp
+
+/-- `f z ^ g z` is analytic if `f z` avoids nonpositive reals -/
+theorem AnalyticOn.cpow (fs : AnalyticOn ℂ f s) (gs : AnalyticOn ℂ g s)
+    (m : ∀ z ∈ s, f z ∈ slitPlane) : AnalyticOn ℂ (fun z ↦ f z ^ g z) s :=
+  fun z n ↦ (fs z n).cpow (gs z n) (m z n)

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Analytic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Analytic.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2024 Geoffrey Irving. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Geoffrey Irving
+-/
+import Mathlib.Analysis.Analytic.Composition
+import Mathlib.Analysis.Analytic.Constructions
+import Mathlib.Analysis.Complex.CauchyIntegral
+import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
+
+/-!
+# Various complex special functions are analytic
+
+`exp`, `log`, and `cpow` are analytic, since they are differentiable.
+-/
+
+open Complex Set
+open scoped Topology
+
+variable {E : Type} [NormedAddCommGroup E] [NormedSpace ℂ E]
+variable {f g : E → ℂ} {z : ℂ} {x : E} {s : Set E}
+
+/-- `exp` is entire -/
+theorem AnalyticOn.cexp : AnalyticOn ℂ exp univ := by
+  rw [analyticOn_univ_iff_differentiable]; exact differentiable_exp
+
+/-- `exp` is analytic at any point -/
+theorem AnalyticAt.cexp : AnalyticAt ℂ exp z :=
+  AnalyticOn.cexp z (Set.mem_univ _)
+
+/-- `log` is analytic away from nonpositive reals -/
+theorem analyticAt_clog (m : z ∈ slitPlane) : AnalyticAt ℂ log z := by
+  rw [analyticAt_iff_eventually_differentiableAt]
+  filter_upwards [isOpen_slitPlane.eventually_mem m]
+  intro z m
+  exact differentiableAt_id.clog m
+
+/-- `log` is analytic away from nonpositive reals -/
+theorem AnalyticAt.clog (fa : AnalyticAt ℂ f x) (m : f x ∈ slitPlane) :
+    AnalyticAt ℂ (fun z ↦ log (f z)) x :=
+  (analyticAt_clog m).comp fa
+
+/-- `log` is analytic away from nonpositive reals -/
+theorem AnalyticOn.clog (fs : AnalyticOn ℂ f s) (m : ∀ z ∈ s, f z ∈ slitPlane) :
+    AnalyticOn ℂ (fun z ↦ log (f z)) s :=
+  fun z n ↦ (analyticAt_clog (m z n)).comp (fs z n)
+
+/-- `f z ^ g z` is analytic if `f z` is not a nonpositive real -/
+theorem AnalyticAt.cpow (fa : AnalyticAt ℂ f x) (ga : AnalyticAt ℂ g x)
+    (m : f x ∈ slitPlane) : AnalyticAt ℂ (fun z ↦ f z ^ g z) x := by
+  have e : (fun z ↦ f z ^ g z) =ᶠ[𝓝 x] fun z ↦ exp (log (f z) * g z) := by
+    filter_upwards [(fa.continuousAt.eventually_ne (slitPlane_ne_zero m))]
+    intro z fz
+    simp only [fz, cpow_def, if_false]
+  rw [analyticAt_congr e]
+  exact AnalyticAt.cexp.comp ((fa.clog m).mul ga)


### PR DESCRIPTION
These are all immediate from differentiability.

We also record several rewrite lemmas for switching between analyticity and differentiability.  These are immediate from existing theorems, but as far as I can tell don't yet exist as iffs.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
