### PR TITLE
[Merged by Bors] - feat: Add `Set.subset_setOf` and `Set.setOf_subset` lemmas

### DIFF
--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -267,6 +267,12 @@ theorem setOf_bijective : Bijective (setOf : (α → Prop) → Set α) :=
   bijective_id
 #align set.set_of_bijective Set.setOf_bijective
 
+theorem subset_setOf {p : α → Prop} {s : Set α} : s ⊆ setOf p ↔ ∀ x, x ∈ s → p x :=
+  Iff.rfl
+
+theorem setOf_subset {p : α → Prop} {s : Set α} : setOf p ⊆ s ↔ ∀ x, p x → x ∈ s :=
+  Iff.rfl
+
 @[simp]
 theorem setOf_subset_setOf {p q : α → Prop} : { a | p a } ⊆ { a | q a } ↔ ∀ a, p a → q a :=
   Iff.rfl


### PR DESCRIPTION
Expressions like `s ⊆ setOf p` often appear unintentionally; these replace them with clean `∀` statements.

These aren't registered as `@[simp]`, not least because doing so breaks a few things in mathlib, and it's not clear one always wants to do these.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
