### PR TITLE
[Merged by Bors] - feat (Topology/EMetricSpace): ext lemmas for Extended metric classes

### DIFF
--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -1027,8 +1027,8 @@ class EMetricSpace (α : Type u) extends PseudoEMetricSpace α : Type u where
 #align emetric_space EMetricSpace
 
 @[ext]
-protected theorem EMetricSpace.ext {α : Type*} {m m' : EMetricSpace α} (h : m.toEDist = m'.toEDist) :
-    m = m' := by
+protected theorem EMetricSpace.ext
+    {α : Type*} {m m' : EMetricSpace α} (h : m.toEDist = m'.toEDist) : m = m' := by
   cases m
   cases m'
   congr

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -93,13 +93,12 @@ namespace, while notions associated to metric spaces are mostly in the root name
 
 /-- Two pseudo emetric space structures with the same edistance function coincide. -/
 @[ext]
-theorem PseudoEMetricSpace.ext {α : Type*} {m m' : PseudoEMetricSpace α}
+protected theorem PseudoEMetricSpace.ext {α : Type*} {m m' : PseudoEMetricSpace α}
     (h : m.toEDist = m'.toEDist) : m = m' := by
   cases' m with ed  _ _ _ U hU
   cases' m' with ed' _ _ _ U' hU'
-  obtain rfl : ed = ed' := h
-  congr
-  · exact UniformSpace.ext (hU.trans hU'.symm)
+  congr 1
+  exact UniformSpace.ext (((show ed = ed' from h) ▸ hU).trans hU'.symm)
 
 variable [PseudoEMetricSpace α]
 
@@ -1028,9 +1027,13 @@ class EMetricSpace (α : Type u) extends PseudoEMetricSpace α : Type u where
 #align emetric_space EMetricSpace
 
 @[ext]
-theorem EMetricSpace.ext {α : Type*} {m m' : EMetricSpace α} (h : m.toEDist = m'.toEDist) :
+protected theorem EMetricSpace.ext {α : Type*} {m m' : EMetricSpace α} (h : m.toEDist = m'.toEDist) :
     m = m' := by
-  cases m; cases m'; congr; ext1; assumption
+  cases m
+  cases m'
+  congr
+  ext1
+  assumption
 
 variable {γ : Type w} [EMetricSpace γ]
 

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -47,6 +47,7 @@ theorem uniformity_dist_of_mem_uniformity [LinearOrder β] {U : Filter (α × α
 #align uniformity_dist_of_mem_uniformity uniformity_dist_of_mem_uniformity
 
 /-- `EDist α` means that `α` is equipped with an extended distance. -/
+@[ext]
 class EDist (α : Type*) where
   edist : α → α → ℝ≥0∞
 #align has_edist EDist
@@ -89,6 +90,17 @@ attribute [instance] PseudoEMetricSpace.toUniformSpace
 
 /- Pseudoemetric spaces are less common than metric spaces. Therefore, we work in a dedicated
 namespace, while notions associated to metric spaces are mostly in the root namespace. -/
+
+/-- Two pseudo emetric space structures with the same edistance function coincide. -/
+@[ext]
+theorem PseudoEMetricSpace.ext {α : Type*} {m m' : PseudoEMetricSpace α}
+    (h : m.toEDist = m'.toEDist) : m = m' := by
+  cases' m with ed  _ _ _ U hU
+  cases' m' with ed' _ _ _ U' hU'
+  obtain rfl : ed = ed' := h
+  congr
+  · exact UniformSpace.ext (hU.trans hU'.symm)
+
 variable [PseudoEMetricSpace α]
 
 export PseudoEMetricSpace (edist_self edist_comm edist_triangle)
@@ -1014,6 +1026,11 @@ end EMetric
 class EMetricSpace (α : Type u) extends PseudoEMetricSpace α : Type u where
   eq_of_edist_eq_zero : ∀ {x y : α}, edist x y = 0 → x = y
 #align emetric_space EMetricSpace
+
+@[ext]
+theorem EMetricSpace.ext {α : Type*} {m m' : EMetricSpace α} (h : m.toEDist = m'.toEDist) :
+    m = m' := by
+  cases m; cases m'; congr; ext1; assumption
 
 variable {γ : Type w} [EMetricSpace γ]
 


### PR DESCRIPTION

previously the `ext` tactic would fail for these classes. now it won't.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
these lemmas are basically copied over from their non-extended equivalents.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
