### PR TITLE
[Merged by Bors] - feat: define `Fin2.rev` analogously to `Fin.rev`

### DIFF
--- a/Mathlib/Data/Fin/Fin2.lean
+++ b/Mathlib/Data/Fin/Fin2.lean
@@ -146,7 +146,7 @@ def rev {n : Nat} : Fin2 n → Fin2 n
 @[simp] lemma rev_last {n} : rev (@last n) = fz := by
   induction n <;> simp_all [rev, castSucc, last]
 
-@[simp] lemma inv_castSucc {n} (i : Fin2 n) : rev (castSucc i) = fs (rev i) := by
+@[simp] lemma rev_castSucc {n} (i : Fin2 n) : rev (castSucc i) = fs (rev i) := by
   induction i <;> simp_all [rev, castSucc, last]
 
 @[simp] lemma rev_rev {n} (i : Fin2 n) : i.rev.rev = i := by

--- a/Mathlib/Data/Fin/Fin2.lean
+++ b/Mathlib/Data/Fin/Fin2.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro
 import Std.Tactic.NoMatch
 import Mathlib.Init.Data.Nat.Notation
 import Mathlib.Mathport.Rename
+import Mathlib.Logic.Function.Basic
 
 #align_import data.fin.fin2 from "leanprover-community/mathlib"@"c4658a649d216f57e99621708b09dcb3dcccbd23"
 
@@ -125,6 +126,32 @@ def ofNat' : ∀ {n} (m) [IsLT m n], Fin2 n
   | succ _, 0, _ => fz
   | succ n, succ m, h => fs (@ofNat' n m ⟨lt_of_succ_lt_succ h.h⟩)
 #align fin2.of_nat' Fin2.ofNat'
+
+/-- `castSucc i` embeds `i : Fin2 n` in `Fin2 (n+1)`. -/
+def castSucc {n} : Fin2 n → Fin2 (n + 1)
+  | fz   => fz
+  | fs k => fs <| castSucc k
+
+/-- The greatest value of `Fin2 (n+1)`. -/
+def last : {n : Nat} → Fin2 (n+1)
+  | 0   => fz
+  | n+1 => fs (@last n)
+
+/-- Maps `0` to `n-1`, `1` to `n-2`, ..., `n-1` to `0`. -/
+def rev {n : Nat} : Fin2 n → Fin2 n
+  | .fz   => last
+  | .fs i => i.rev.castSucc
+
+@[simp] lemma rev_last {n} : rev (@last n) = fz := by
+  induction n <;> simp_all [rev, castSucc, last]
+
+@[simp] lemma inv_castSucc {n} (i : Fin2 n) : rev (castSucc i) = fs (rev i) := by
+  induction i <;> simp_all [rev, castSucc, last]
+
+@[simp] lemma rev_rev {n} (i : Fin2 n) : i.rev.rev = i := by
+  induction i <;> simp_all [rev]
+
+theorem rev_involutive {n} : Function.Involutive (@rev n) := rev_rev
 
 @[inherit_doc] local prefix:arg "&" => ofNat'
 


### PR DESCRIPTION
This defines `Fin2.rev`, the mapping from `i : Fin2` to (morally) `last - i`, and proves it's an involution.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is code ported from https://github.com/alexkeizer/QpfTypes, and is used to revert a `TypeVec`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
