### PR TITLE
[Merged by Bors] - chore: move #guard_msgs in PosDef to test file

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -150,13 +150,6 @@ def delabSqrt : Delab :=
       return (← read).optionsPerPos.setBool (← getPos) `pp.proofs.withType true
     withTheReader Context ({· with optionsPerPos}) delab
 
--- test for custom elaborator
-/--
-info: (_ : PosSemidef A).sqrt : Matrix n n 𝕜
--/
-#guard_msgs in
-#check (id hA).sqrt
-
 lemma posSemidef_sqrt : PosSemidef hA.sqrt := by
   apply PosSemidef.mul_mul_conjTranspose_same
   refine posSemidef_diagonal_iff.mpr fun i ↦ ?_

--- a/test/PosDef.lean
+++ b/test/PosDef.lean
@@ -1,0 +1,14 @@
+import Mathlib.LinearAlgebra.Matrix.PosDef
+
+open Matrix
+open scoped ComplexOrder
+
+variable {n 𝕜 : Type*} [Fintype n] [IsROrC 𝕜] [DecidableEq n]
+  {A : Matrix n n 𝕜} (hA : PosSemidef A)
+
+-- test for custom elaborator
+/--
+info: (_ : PosSemidef A).sqrt : Matrix n n 𝕜
+-/
+#guard_msgs in
+#check (id hA).sqrt


### PR DESCRIPTION
This PR moves a `#guard_msgs` command from `LinearAlgebra/Matrix/PosDef` to a test file: it is a preparation for #10809. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
