### PR TITLE
[Merged by Bors] - feat: generalize `DirectSum` results to avoid negation

### DIFF
--- a/Mathlib/Algebra/DirectSum/Finsupp.lean
+++ b/Mathlib/Algebra/DirectSum/Finsupp.lean
@@ -24,7 +24,7 @@ open DirectSum
 
 open LinearMap Submodule
 
-variable {R : Type u} {M : Type v} [Ring R] [AddCommGroup M] [Module R M]
+variable {R : Type u} {M : Type v} [Semiring R] [AddCommMonoid M] [Module R M]
 
 section finsuppLequivDirectSum
 

--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -24,9 +24,6 @@ open DirectSum
 
 open Set LinearMap Submodule
 
-variable {R : Type u} {M : Type v} {N : Type w} [CommSemiring R] [AddCommMonoid M] [Module R M]
-  [AddCommMonoid N] [Module R N]
-
 section TensorProduct
 
 open TensorProduct

--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -24,8 +24,8 @@ open DirectSum
 
 open Set LinearMap Submodule
 
-variable {R : Type u} {M : Type v} {N : Type w} [Ring R] [AddCommGroup M] [Module R M]
-  [AddCommGroup N] [Module R N]
+variable {R : Type u} {M : Type v} {N : Type w} [CommSemiring R] [AddCommMonoid M] [Module R M]
+  [AddCommMonoid N] [Module R N]
 
 section TensorProduct
 
@@ -36,24 +36,24 @@ open TensorProduct
 open scoped Classical in
 -- `noncomputable` is a performance workaround for mathlib4#7103
 /-- The tensor product of `ι →₀ M` and `κ →₀ N` is linearly equivalent to `(ι × κ) →₀ (M ⊗ N)`. -/
-noncomputable def finsuppTensorFinsupp (R M N ι κ : Sort _) [CommRing R] [AddCommGroup M]
-    [Module R M] [AddCommGroup N] [Module R N] : (ι →₀ M) ⊗[R] (κ →₀ N) ≃ₗ[R] ι × κ →₀ M ⊗[R] N :=
+noncomputable def finsuppTensorFinsupp (R M N ι κ : Sort _) [CommSemiring R] [AddCommMonoid M]
+    [Module R M] [AddCommMonoid N] [Module R N] : (ι →₀ M) ⊗[R] (κ →₀ N) ≃ₗ[R] ι × κ →₀ M ⊗[R] N :=
   TensorProduct.congr (finsuppLEquivDirectSum R M ι) (finsuppLEquivDirectSum R N κ) ≪≫ₗ
     ((TensorProduct.directSum R (fun _ : ι => M) fun _ : κ => N) ≪≫ₗ
       (finsuppLEquivDirectSum R (M ⊗[R] N) (ι × κ)).symm)
 #align finsupp_tensor_finsupp finsuppTensorFinsupp
 
 @[simp]
-theorem finsuppTensorFinsupp_single (R M N ι κ : Sort _) [CommRing R] [AddCommGroup M] [Module R M]
-    [AddCommGroup N] [Module R N] (i : ι) (m : M) (k : κ) (n : N) :
+theorem finsuppTensorFinsupp_single (R M N ι κ : Sort _) [CommSemiring R] [AddCommMonoid M] [Module R M]
+    [AddCommMonoid N] [Module R N] (i : ι) (m : M) (k : κ) (n : N) :
     finsuppTensorFinsupp R M N ι κ (Finsupp.single i m ⊗ₜ Finsupp.single k n) =
       Finsupp.single (i, k) (m ⊗ₜ n) :=
   by classical simp [finsuppTensorFinsupp]
 #align finsupp_tensor_finsupp_single finsuppTensorFinsupp_single
 
 @[simp]
-theorem finsuppTensorFinsupp_apply (R M N ι κ : Sort _) [CommRing R] [AddCommGroup M] [Module R M]
-    [AddCommGroup N] [Module R N] (f : ι →₀ M) (g : κ →₀ N) (i : ι) (k : κ) :
+theorem finsuppTensorFinsupp_apply (R M N ι κ : Sort _) [CommSemiring R] [AddCommMonoid M] [Module R M]
+    [AddCommMonoid N] [Module R N] (f : ι →₀ M) (g : κ →₀ N) (i : ι) (k : κ) :
     finsuppTensorFinsupp R M N ι κ (f ⊗ₜ g) (i, k) = f i ⊗ₜ g k := by
   apply Finsupp.induction_linear f
   · simp
@@ -75,15 +75,15 @@ theorem finsuppTensorFinsupp_apply (R M N ι κ : Sort _) [CommRing R] [AddCommG
 #align finsupp_tensor_finsupp_apply finsuppTensorFinsupp_apply
 
 @[simp]
-theorem finsuppTensorFinsupp_symm_single (R M N ι κ : Sort _) [CommRing R] [AddCommGroup M]
-    [Module R M] [AddCommGroup N] [Module R N] (i : ι × κ) (m : M) (n : N) :
+theorem finsuppTensorFinsupp_symm_single (R M N ι κ : Sort _) [CommSemiring R] [AddCommMonoid M]
+    [Module R M] [AddCommMonoid N] [Module R N] (i : ι × κ) (m : M) (n : N) :
     (finsuppTensorFinsupp R M N ι κ).symm (Finsupp.single i (m ⊗ₜ n)) =
       Finsupp.single i.1 m ⊗ₜ Finsupp.single i.2 n :=
   Prod.casesOn i fun _ _ =>
     (LinearEquiv.symm_apply_eq _).2 (finsuppTensorFinsupp_single _ _ _ _ _ _ _ _ _).symm
 #align finsupp_tensor_finsupp_symm_single finsuppTensorFinsupp_symm_single
 
-variable (S : Type*) [CommRing S] (α β : Type*)
+variable (S : Type*) [CommSemiring S] (α β : Type*)
 
 /-- A variant of `finsuppTensorFinsupp` where both modules are the ground ring. -/
 def finsuppTensorFinsupp' : (α →₀ S) ⊗[S] (β →₀ S) ≃ₗ[S] α × β →₀ S :=

--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -44,7 +44,8 @@ noncomputable def finsuppTensorFinsupp (R M N ι κ : Sort _) [CommSemiring R] [
 #align finsupp_tensor_finsupp finsuppTensorFinsupp
 
 @[simp]
-theorem finsuppTensorFinsupp_single (R M N ι κ : Sort _) [CommSemiring R] [AddCommMonoid M] [Module R M]
+theorem finsuppTensorFinsupp_single (R M N ι κ : Sort _)
+    [CommSemiring R] [AddCommMonoid M] [Module R M]
     [AddCommMonoid N] [Module R N] (i : ι) (m : M) (k : κ) (n : N) :
     finsuppTensorFinsupp R M N ι κ (Finsupp.single i m ⊗ₜ Finsupp.single k n) =
       Finsupp.single (i, k) (m ⊗ₜ n) :=
@@ -52,7 +53,8 @@ theorem finsuppTensorFinsupp_single (R M N ι κ : Sort _) [CommSemiring R] [Add
 #align finsupp_tensor_finsupp_single finsuppTensorFinsupp_single
 
 @[simp]
-theorem finsuppTensorFinsupp_apply (R M N ι κ : Sort _) [CommSemiring R] [AddCommMonoid M] [Module R M]
+theorem finsuppTensorFinsupp_apply (R M N ι κ : Sort _)
+    [CommSemiring R] [AddCommMonoid M] [Module R M]
     [AddCommMonoid N] [Module R N] (f : ι →₀ M) (g : κ →₀ N) (i : ι) (k : κ) :
     finsuppTensorFinsupp R M N ι κ (f ⊗ₜ g) (i, k) = f i ⊗ₜ g k := by
   apply Finsupp.induction_linear f

--- a/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
@@ -35,7 +35,7 @@ open LinearMap
 
 attribute [local ext] TensorProduct.ext
 
-variable (R : Type u) [CommRing R]
+variable (R : Type u) [CommSemiring R]
 
 variable {ι₁ : Type v₁} {ι₂ : Type v₂}
 
@@ -43,9 +43,9 @@ variable [DecidableEq ι₁] [DecidableEq ι₂]
 
 variable (M₁ : ι₁ → Type w₁) (M₁' : Type w₁') (M₂ : ι₂ → Type w₂) (M₂' : Type w₂')
 
-variable [∀ i₁, AddCommGroup (M₁ i₁)] [AddCommGroup M₁']
+variable [∀ i₁, AddCommMonoid (M₁ i₁)] [AddCommMonoid M₁']
 
-variable [∀ i₂, AddCommGroup (M₂ i₂)] [AddCommGroup M₂']
+variable [∀ i₂, AddCommMonoid (M₂ i₂)] [AddCommMonoid M₂']
 
 variable [∀ i₁, Module R (M₁ i₁)] [Module R M₁'] [∀ i₂, Module R (M₂ i₂)] [Module R M₂']
 

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -181,6 +181,16 @@ open DirectSum LinearMap Submodule
 
 variable (R : Type u) [CommRing R]
 
+-- ACL
+-- Why is it necessary to add this instance ?
+
+noncomputable local instance (ι : Type v)
+    (M : ι → Type w) [(i : ι) → AddCommGroup (M i)] [(i : ι) → Module R (M i)]
+    (I : Ideal R) :
+    AddCommGroup (⨁ i, ↥I ⊗[R] M i) :=
+  instAddCommGroupDirectSumToAddCommMonoid fun i ↦ ↥I ⊗[R] M i
+
+-- endACL
 /-- A direct sum of flat `R`-modules is flat. -/
 instance directSum (ι : Type v) (M : ι → Type w) [(i : ι) → AddCommGroup (M i)]
     [(i : ι) → Module R (M i)] [F : (i : ι) → (Flat R (M i))] : Flat R (⨁ i, M i) := by
@@ -198,6 +208,7 @@ instance directSum (ι : Type v) (M : ι → Type w) [(i : ι) → AddCommGroup 
   rw [← Equiv.injective_comp (TensorProduct.directSumRight _ _ _).symm.toEquiv]
   rw [LinearEquiv.coe_toEquiv, ← LinearEquiv.coe_coe, ← LinearMap.coe_comp]
   rw [LinearEquiv.coe_toEquiv, ← LinearEquiv.coe_coe, ← LinearMap.coe_comp]
+  --
   rw [← psi_def, injective_iff_map_eq_zero ((η₁.comp ρ).comp ψ)]
   have h₁ : ∀ (i : ι), (π i).comp ((η₁.comp ρ).comp ψ) = (η i).comp ((φ i).comp (τ i)) := by
     intro i
@@ -220,7 +231,11 @@ instance directSum (ι : Type v) (M : ι → Type w) [(i : ι) → AddCommGroup 
   have h₃ := h₂ hI
   simp only [coe_comp, LinearEquiv.coe_coe, Function.comp_apply, AddEquivClass.map_eq_zero_iff,
     h₃, LinearMap.map_eq_zero_iff] at f
+  --
+  rw [_root_.map_zero]
+  --
   simp [f]
+
 
 /-- Free `R`-modules over discrete types are flat. -/
 instance finsupp (ι : Type v) : Flat R (ι →₀ R) :=

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -181,22 +181,13 @@ open DirectSum LinearMap Submodule
 
 variable (R : Type u) [CommRing R]
 
--- ACL
--- Why is it necessary to add this instance ?
-/-- instance that a direct sum of tensor products is an add comm group -/
-noncomputable local instance (ι : Type v)
-    (M : ι → Type w) [(i : ι) → AddCommGroup (M i)] [(i : ι) → Module R (M i)]
-    (I : Ideal R) :
-    AddCommGroup (⨁ i, ↥I ⊗[R] M i) :=
-  instAddCommGroupDirectSumToAddCommMonoid fun i ↦ ↥I ⊗[R] M i
-
--- endACL
 /-- A direct sum of flat `R`-modules is flat. -/
 instance directSum (ι : Type v) (M : ι → Type w) [(i : ι) → AddCommGroup (M i)]
     [(i : ι) → Module R (M i)] [F : (i : ι) → (Flat R (M i))] : Flat R (⨁ i, M i) := by
   classical
   rw [iff_rTensor_injective]
   intro I hI
+  letI : ∀ i, AddCommGroup (↥I ⊗[R] (M i)) := fun i ↦ TensorProduct.addCommGroup
   rw [← Equiv.comp_injective _ (TensorProduct.lid R (⨁ i, M i)).toEquiv]
   set η₁ := TensorProduct.lid R (⨁ i, M i)
   set η := (fun i ↦ TensorProduct.lid R (M i))
@@ -208,7 +199,6 @@ instance directSum (ι : Type v) (M : ι → Type w) [(i : ι) → AddCommGroup 
   rw [← Equiv.injective_comp (TensorProduct.directSumRight _ _ _).symm.toEquiv]
   rw [LinearEquiv.coe_toEquiv, ← LinearEquiv.coe_coe, ← LinearMap.coe_comp]
   rw [LinearEquiv.coe_toEquiv, ← LinearEquiv.coe_coe, ← LinearMap.coe_comp]
-  --
   rw [← psi_def, injective_iff_map_eq_zero ((η₁.comp ρ).comp ψ)]
   have h₁ : ∀ (i : ι), (π i).comp ((η₁.comp ρ).comp ψ) = (η i).comp ((φ i).comp (τ i)) := by
     intro i
@@ -231,9 +221,6 @@ instance directSum (ι : Type v) (M : ι → Type w) [(i : ι) → AddCommGroup 
   have h₃ := h₂ hI
   simp only [coe_comp, LinearEquiv.coe_coe, Function.comp_apply, AddEquivClass.map_eq_zero_iff,
     h₃, LinearMap.map_eq_zero_iff] at f
-  --
-  rw [_root_.map_zero]
-  --
   simp [f]
 
 

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -188,8 +188,8 @@ instance directSum (ι : Type v) (M : ι → Type w) [(i : ι) → AddCommGroup 
   rw [iff_rTensor_injective]
   intro I hI
   -- This instance was added during PR #10828,
-  -- see  https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2310828.20-.20generalizing.20CommRing.20to.20CommSemiring.20etc.2E/near/422684923
-  letI : ∀ i, AddCommGroup (↥I ⊗[R] (M i)) := fun i ↦ TensorProduct.addCommGroup
+  -- see https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2310828.20-.20generalizing.20CommRing.20to.20CommSemiring.20etc.2E/near/422684923
+  letI : ∀ i, AddCommGroup (I ⊗[R] M i) := inferInstance
   rw [← Equiv.comp_injective _ (TensorProduct.lid R (⨁ i, M i)).toEquiv]
   set η₁ := TensorProduct.lid R (⨁ i, M i)
   set η := (fun i ↦ TensorProduct.lid R (M i))

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -225,7 +225,6 @@ instance directSum (ι : Type v) (M : ι → Type w) [(i : ι) → AddCommGroup 
     h₃, LinearMap.map_eq_zero_iff] at f
   simp [f]
 
-
 /-- Free `R`-modules over discrete types are flat. -/
 instance finsupp (ι : Type v) : Flat R (ι →₀ R) :=
   let _ := Classical.decEq ι

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -183,7 +183,7 @@ variable (R : Type u) [CommRing R]
 
 -- ACL
 -- Why is it necessary to add this instance ?
-
+/-- instance that a direct sum of tensor products is an add comm group -/
 noncomputable local instance (ι : Type v)
     (M : ι → Type w) [(i : ι) → AddCommGroup (M i)] [(i : ι) → Module R (M i)]
     (I : Ideal R) :

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -187,6 +187,8 @@ instance directSum (ι : Type v) (M : ι → Type w) [(i : ι) → AddCommGroup 
   classical
   rw [iff_rTensor_injective]
   intro I hI
+  -- This instance was added during PR #10828,
+  -- see  https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2310828.20-.20generalizing.20CommRing.20to.20CommSemiring.20etc.2E/near/422684923
   letI : ∀ i, AddCommGroup (↥I ⊗[R] (M i)) := fun i ↦ TensorProduct.addCommGroup
   rw [← Equiv.comp_injective _ (TensorProduct.lid R (⨁ i, M i)).toEquiv]
   set η₁ := TensorProduct.lid R (⨁ i, M i)


### PR DESCRIPTION
Three files are modified, where the hypotheses are relaxed from `Ring` or `CommRing` to `Semiring` or `CommSemiring`, and `AddCommGroup` to `AddCommMonoid`.
Besides this, no definition is changed, and for one proof in `RingTheory.Flat.Basic`, I needed to add an instance (`letI`…) in the proof.
(Everything pertains to direct sums of modules.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
