### PR TITLE
[Merged by Bors] - feat: extend convergence of integrals against peak functions to noncompact settings

### DIFF
--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -124,6 +124,26 @@ theorem mono {ν : Measure α} {φ : ι → Set α} (hφ : AECover μ l φ) (hle
 
 end AECover
 
+section MetricSpace
+
+variable [PseudoMetricSpace α] [OpensMeasurableSpace α]
+
+theorem aecover_ball {x : α} {r : ι → ℝ} (hr : Tendsto r l atTop) :
+    AECover μ l (fun i ↦ Metric.ball x (r i)) where
+  measurableSet _ := Metric.isOpen_ball.measurableSet
+  ae_eventually_mem := by
+    apply eventually_of_forall (fun y ↦ ?_)
+    filter_upwards [hr (Ioi_mem_atTop (dist x y))] with a ha using by simpa [dist_comm] using ha
+
+theorem aecover_closedBall {x : α} {r : ι → ℝ} (hr : Tendsto r l atTop) :
+    AECover μ l (fun i ↦ Metric.closedBall x (r i)) where
+  measurableSet _ := Metric.isClosed_ball.measurableSet
+  ae_eventually_mem := by
+    apply eventually_of_forall (fun y ↦ ?_)
+    filter_upwards [hr (Ici_mem_atTop (dist x y))] with a ha using by simpa [dist_comm] using ha
+
+end MetricSpace
+
 section Preorderα
 
 variable [Preorder α] [TopologicalSpace α] [OrderClosedTopology α] [OpensMeasurableSpace α]

--- a/Mathlib/MeasureTheory/Integral/PeakFunction.lean
+++ b/Mathlib/MeasureTheory/Integral/PeakFunction.lean
@@ -5,6 +5,10 @@ Authors: Sébastien Gouëzel
 -/
 import Mathlib.MeasureTheory.Integral.SetIntegral
 import Mathlib.MeasureTheory.Function.LocallyIntegrable
+import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
+import Mathlib.MeasureTheory.Integral.IntegralEqImproper
+import Mathlib.MeasureTheory.Group.Integral
+import Mathlib.MeasureTheory.Measure.Haar.Unique
 
 #align_import measure_theory.integral.peak_function from "leanprover-community/mathlib"@"13b0d72fd8533ba459ac66e9a885e35ffabb32b2"
 
@@ -13,11 +17,12 @@ import Mathlib.MeasureTheory.Function.LocallyIntegrable
 
 A sequence of peak functions is a sequence of functions with average one concentrating around
 a point `x₀`. Given such a sequence `φₙ`, then `∫ φₙ g` tends to `g x₀` in many situations, with
-a whole zoo of possible assumptions on `φₙ` and `g`. This file is devoted to such results.
+a whole zoo of possible assumptions on `φₙ` and `g`. This file is devoted to such results. Such
+functions are also called approximations of unity, or approximations of identity.
 
 ## Main results
 
-* `tendsto_set_integral_peak_smul_of_integrableOn_of_continuousWithinAt`: If a sequence of peak
+* `tendsto_set_integral_peak_smul_of_integrableOn_of_tendsto`: If a sequence of peak
   functions `φᵢ` converges uniformly to zero away from a point `x₀`, and
   `g` is integrable and continuous at `x₀`, then `∫ φᵢ • g` converges to `g x₀`.
 * `tendsto_set_integral_pow_smul_of_unique_maximum_of_isCompact_of_continuousOn`:
@@ -25,6 +30,11 @@ a whole zoo of possible assumptions on `φₙ` and `g`. This file is devoted to 
   then the sequence of functions `(c x) ^ n / ∫ (c x) ^ n` is a sequence of peak functions
   concentrating around `x₀`. Therefore, `∫ (c x) ^ n * g / ∫ (c x) ^ n` converges to `g x₀`
   if `g` is continuous on `s`.
+* `tendsto_integral_comp_smul_smul_of_integrable`:
+  If a nonnegative function `φ` has integral one and decays quickly enough at infinity,
+  then its renormalizations `x ↦ c ^ d * φ (c • x)` form a sequence of peak functions as `c → ∞`.
+  Therefore, `∫ (c ^ d * φ (c • x)) • g x` converges to `g 0` as `c → ∞` if `g` is continuous
+  at `0` and integrable.
 
 Note that there are related results about convolution with respect to peak functions in the file
 `Analysis.Convolution`, such as `convolution_tendsto_right` there.
@@ -40,92 +50,122 @@ theorem Set.disjoint_sdiff_inter {α : Type*} (s t : Set α) : Disjoint (s \ t) 
   disjoint_of_subset_right (inter_subset_right _ _) disjoint_sdiff_left
 #align set.disjoint_sdiff_inter Set.disjoint_sdiff_inter
 
+
+/-!
+### General convergent result for integrals against a sequence of peak functions
+-/
+
 open Set
 
 variable {α E ι : Type*} {hm : MeasurableSpace α} {μ : Measure α} [TopologicalSpace α]
   [BorelSpace α] [NormedAddCommGroup E] [NormedSpace ℝ E] {g : α → E} {l : Filter ι} {x₀ : α}
-  {s : Set α} {φ : ι → α → ℝ}
+  {s t : Set α} {φ : ι → α → ℝ} {a : E}
 
 /-- If a sequence of peak functions `φᵢ` converges uniformly to zero away from a point `x₀`, and
-`g` is integrable and continuous at `x₀`, then `φᵢ • g` is eventually integrable. -/
-theorem integrableOn_peak_smul_of_integrableOn_of_continuousWithinAt (hs : MeasurableSet s)
+`g` is integrable and has a limit at `x₀`, then `φᵢ • g` is eventually integrable. -/
+theorem integrableOn_peak_smul_of_integrableOn_of_tendsto
+    (hs : MeasurableSet s) (h'st : t ∈ 𝓝[s] x₀)
     (hlφ : ∀ u : Set α, IsOpen u → x₀ ∈ u → TendstoUniformlyOn φ 0 l (s \ u))
-    (hiφ : ∀ᶠ i in l, ∫ x in s, φ i x ∂μ = 1) (hmg : IntegrableOn g s μ)
-    (hcg : ContinuousWithinAt g s x₀) : ∀ᶠ i in l, IntegrableOn (fun x => φ i x • g x) s μ := by
-  obtain ⟨u, u_open, x₀u, hu⟩ : ∃ u, IsOpen u ∧ x₀ ∈ u ∧ ∀ x ∈ u ∩ s, g x ∈ ball (g x₀) 1
-  exact mem_nhdsWithin.1 (hcg (ball_mem_nhds _ zero_lt_one))
-  filter_upwards [tendstoUniformlyOn_iff.1 (hlφ u u_open x₀u) 1 zero_lt_one, hiφ] with i hi h'i
+    (hiφ : Tendsto (fun i ↦ ∫ x in t, φ i x ∂μ) l (𝓝 1))
+    (h'iφ : ∀ᶠ i in l, AEStronglyMeasurable (φ i) (μ.restrict s))
+    (hmg : IntegrableOn g s μ) (hcg : Tendsto g (𝓝[s] x₀) (𝓝 a)) :
+    ∀ᶠ i in l, IntegrableOn (fun x => φ i x • g x) s μ := by
+  obtain ⟨u, u_open, x₀u, ut, hu⟩ :
+      ∃ u, IsOpen u ∧ x₀ ∈ u ∧ s ∩ u ⊆ t ∧ ∀ x ∈ u ∩ s, g x ∈ ball a 1 := by
+    rcases mem_nhdsWithin.1 (Filter.inter_mem h'st (hcg (ball_mem_nhds _ zero_lt_one)))
+      with ⟨u, u_open, x₀u, hu⟩
+    refine ⟨u, u_open, x₀u, ?_, hu.trans (inter_subset_right _ _)⟩
+    rw [inter_comm]
+    exact hu.trans (inter_subset_left _ _)
+  rw [tendsto_iff_norm_sub_tendsto_zero] at hiφ
+  filter_upwards [tendstoUniformlyOn_iff.1 (hlφ u u_open x₀u) 1 zero_lt_one,
+    (tendsto_order.1 hiφ).2 1 zero_lt_one, h'iφ] with i hi h'i h''i
+  have I : IntegrableOn (φ i) t μ := .of_integral_ne_zero (fun h ↦ by simp [h] at h'i)
   have A : IntegrableOn (fun x => φ i x • g x) (s \ u) μ := by
     refine' Integrable.smul_of_top_right (hmg.mono (diff_subset _ _) le_rfl) _
-    apply
-      memℒp_top_of_bound
-        ((integrable_of_integral_eq_one h'i).aestronglyMeasurable.mono_set (diff_subset _ _)) 1
+    apply memℒp_top_of_bound (h''i.mono_set (diff_subset _ _)) 1
     filter_upwards [self_mem_ae_restrict (hs.diff u_open.measurableSet)] with x hx
     simpa only [Pi.zero_apply, dist_zero_left] using (hi x hx).le
   have B : IntegrableOn (fun x => φ i x • g x) (s ∩ u) μ := by
     apply Integrable.smul_of_top_left
-    · exact IntegrableOn.mono_set (integrable_of_integral_eq_one h'i) (inter_subset_left _ _)
+    · exact IntegrableOn.mono_set I ut
     · apply
-        memℒp_top_of_bound (hmg.mono_set (inter_subset_left _ _)).aestronglyMeasurable (‖g x₀‖ + 1)
+        memℒp_top_of_bound (hmg.mono_set (inter_subset_left _ _)).aestronglyMeasurable (‖a‖ + 1)
       filter_upwards [self_mem_ae_restrict (hs.inter u_open.measurableSet)] with x hx
       rw [inter_comm] at hx
       exact (norm_lt_of_mem_ball (hu x hx)).le
   convert A.union B
   simp only [diff_union_inter]
-#align integrable_on_peak_smul_of_integrable_on_of_continuous_within_at integrableOn_peak_smul_of_integrableOn_of_continuousWithinAt
+#align integrable_on_peak_smul_of_integrable_on_of_continuous_within_at integrableOn_peak_smul_of_integrableOn_of_tendsto
+@[deprecated] alias integrableOn_peak_smul_of_integrableOn_of_continuousWithinAt :=
+  integrableOn_peak_smul_of_integrableOn_of_tendsto -- deprecated on 2024-02-20
 
 variable [CompleteSpace E]
 
-/-- If a sequence of peak functions `φᵢ` converges uniformly to zero away from a point `x₀`, and
-`g` is integrable and continuous at `x₀`, then `∫ φᵢ • g` converges to `x₀`. Auxiliary lemma
-where one assumes additionally `g x₀ = 0`. -/
-theorem tendsto_set_integral_peak_smul_of_integrableOn_of_continuousWithinAt_aux
-    (hs : MeasurableSet s) (hnφ : ∀ᶠ i in l, ∀ x ∈ s, 0 ≤ φ i x)
+/-- If a sequence of peak functions `φᵢ` converges uniformly to zero away from a point `x₀` and its
+integral on some finite-measure neighborhood of `x₀` converges to `1`, and `g` is integrable and
+has a limit `a` at `x₀`, then `∫ φᵢ • g` converges to `a`.
+Auxiliary lemma where one assumes additionally `a = 0`. -/
+theorem tendsto_set_integral_peak_smul_of_integrableOn_of_tendsto_aux
+    (hs : MeasurableSet s) (ht : MeasurableSet t) (hts : t ⊆ s) (h'ts : t ∈ 𝓝[s] x₀)
+    (hnφ : ∀ᶠ i in l, ∀ x ∈ s, 0 ≤ φ i x)
     (hlφ : ∀ u : Set α, IsOpen u → x₀ ∈ u → TendstoUniformlyOn φ 0 l (s \ u))
-    (hiφ : ∀ᶠ i in l, ∫ x in s, φ i x ∂μ = 1) (hmg : IntegrableOn g s μ) (h'g : g x₀ = 0)
-    (hcg : ContinuousWithinAt g s x₀) :
+    (hiφ : Tendsto (fun i ↦ ∫ x in t, φ i x ∂μ) l (𝓝 1))
+    (h'iφ : ∀ᶠ i in l, AEStronglyMeasurable (φ i) (μ.restrict s))
+    (hmg : IntegrableOn g s μ) (hcg : Tendsto g (𝓝[s] x₀) (𝓝 0)) :
     Tendsto (fun i : ι => ∫ x in s, φ i x • g x ∂μ) l (𝓝 0) := by
   refine' Metric.tendsto_nhds.2 fun ε εpos => _
-  obtain ⟨δ, hδ, δpos⟩ : ∃ δ, (δ * ∫ x in s, ‖g x‖ ∂μ) + δ < ε ∧ 0 < δ := by
+  obtain ⟨δ, hδ, δpos, δone⟩ : ∃ δ, (δ * ∫ x in s, ‖g x‖ ∂μ) + 2 * δ < ε ∧ 0 < δ ∧ δ < 1:= by
     have A :
-      Tendsto (fun δ => (δ * ∫ x in s, ‖g x‖ ∂μ) + δ) (𝓝[>] 0)
-        (𝓝 ((0 * ∫ x in s, ‖g x‖ ∂μ) + 0)) := by
+      Tendsto (fun δ => (δ * ∫ x in s, ‖g x‖ ∂μ) + 2 * δ) (𝓝[>] 0)
+        (𝓝 ((0 * ∫ x in s, ‖g x‖ ∂μ) + 2 * 0)) := by
       apply Tendsto.mono_left _ nhdsWithin_le_nhds
-      exact (tendsto_id.mul tendsto_const_nhds).add tendsto_id
-    rw [zero_mul, zero_add] at A
-    exact (((tendsto_order.1 A).2 ε εpos).and self_mem_nhdsWithin).exists
-  suffices ∀ᶠ i in l, ‖∫ x in s, φ i x • g x ∂μ‖ ≤ (δ * ∫ x in s, ‖g x‖ ∂μ) + δ by
+      exact (tendsto_id.mul tendsto_const_nhds).add (tendsto_id.const_mul _)
+    rw [zero_mul, zero_add, mul_zero] at A
+    have : Ioo (0 : ℝ) 1 ∈ 𝓝[>] 0 := Ioo_mem_nhdsWithin_Ioi ⟨le_rfl, zero_lt_one⟩
+    rcases (((tendsto_order.1 A).2 ε εpos).and this).exists with ⟨δ, hδ, h'δ⟩
+    exact ⟨δ, hδ, h'δ.1, h'δ.2⟩
+  suffices ∀ᶠ i in l, ‖∫ x in s, φ i x • g x ∂μ‖ ≤ (δ * ∫ x in s, ‖g x‖ ∂μ) + 2 * δ by
     filter_upwards [this] with i hi
     simp only [dist_zero_right]
     exact hi.trans_lt hδ
-  obtain ⟨u, u_open, x₀u, hu⟩ : ∃ u, IsOpen u ∧ x₀ ∈ u ∧ ∀ x ∈ u ∩ s, g x ∈ ball (g x₀) δ
-  exact mem_nhdsWithin.1 (hcg (ball_mem_nhds _ δpos))
-  filter_upwards [tendstoUniformlyOn_iff.1 (hlφ u u_open x₀u) δ δpos, hiφ, hnφ,
-    integrableOn_peak_smul_of_integrableOn_of_continuousWithinAt hs hlφ hiφ hmg hcg] with i hi h'i
-    hφpos h''i
-  have B : ‖∫ x in s ∩ u, φ i x • g x ∂μ‖ ≤ δ :=
+  obtain ⟨u, u_open, x₀u, ut, hu⟩ :
+      ∃ u, IsOpen u ∧ x₀ ∈ u ∧ s ∩ u ⊆ t ∧ ∀ x ∈ u ∩ s, g x ∈ ball 0 δ := by
+    rcases mem_nhdsWithin.1 (Filter.inter_mem h'ts (hcg (ball_mem_nhds _ δpos)))
+      with ⟨u, u_open, x₀u, hu⟩
+    refine ⟨u, u_open, x₀u, ?_, hu.trans (inter_subset_right _ _)⟩
+    rw [inter_comm]
+    exact hu.trans (inter_subset_left _ _)
+  filter_upwards [tendstoUniformlyOn_iff.1 (hlφ u u_open x₀u) δ δpos,
+    (tendsto_order.1 (tendsto_iff_norm_sub_tendsto_zero.1 hiφ)).2 δ δpos, hnφ,
+    integrableOn_peak_smul_of_integrableOn_of_tendsto hs h'ts hlφ hiφ h'iφ hmg hcg]
+    with i hi h'i hφpos h''i
+  have I : IntegrableOn (φ i) t μ := by
+    apply Integrable.of_integral_ne_zero (fun h ↦ ?_)
+    simp [h] at h'i
+    linarith
+  have B : ‖∫ x in s ∩ u, φ i x • g x ∂μ‖ ≤ 2 * δ :=
     calc
       ‖∫ x in s ∩ u, φ i x • g x ∂μ‖ ≤ ∫ x in s ∩ u, ‖φ i x • g x‖ ∂μ :=
         norm_integral_le_integral_norm _
       _ ≤ ∫ x in s ∩ u, ‖φ i x‖ * δ ∂μ := by
         refine' set_integral_mono_on _ _ (hs.inter u_open.measurableSet) fun x hx => _
         · exact IntegrableOn.mono_set h''i.norm (inter_subset_left _ _)
-        · exact
-            IntegrableOn.mono_set ((integrable_of_integral_eq_one h'i).norm.mul_const _)
-              (inter_subset_left _ _)
+        · exact IntegrableOn.mono_set (I.norm.mul_const _) ut
         rw [norm_smul]
         apply mul_le_mul_of_nonneg_left _ (norm_nonneg _)
-        rw [inter_comm, h'g] at hu
+        rw [inter_comm] at hu
         exact (mem_ball_zero_iff.1 (hu x hx)).le
-      _ ≤ ∫ x in s, ‖φ i x‖ * δ ∂μ := by
+      _ ≤ ∫ x in t, ‖φ i x‖ * δ ∂μ := by
         apply set_integral_mono_set
-        · exact (integrable_of_integral_eq_one h'i).norm.mul_const _
+        · exact I.norm.mul_const _
         · exact eventually_of_forall fun x => mul_nonneg (norm_nonneg _) δpos.le
-        · apply eventually_of_forall; exact inter_subset_left s u
-      _ = ∫ x in s, φ i x * δ ∂μ := by
-        apply set_integral_congr hs fun x hx => ?_
-        rw [Real.norm_of_nonneg (hφpos _ hx)]
-      _ = δ := by rw [integral_mul_right, h'i, one_mul]
+        · apply eventually_of_forall ut
+      _ = ∫ x in t, φ i x * δ ∂μ := by
+        apply set_integral_congr ht fun x hx => ?_
+        rw [Real.norm_of_nonneg (hφpos _ (hts hx))]
+      _ = (∫ x in t, φ i x ∂μ) * δ := by rw [integral_mul_right]
+      _ ≤ 2 * δ := by gcongr; linarith [(le_abs_self _).trans h'i.le]
   have C : ‖∫ x in s \ u, φ i x • g x ∂μ‖ ≤ δ * ∫ x in s, ‖g x‖ ∂μ :=
     calc
       ‖∫ x in s \ u, φ i x • g x ∂μ‖ ≤ ∫ x in s \ u, ‖φ i x • g x‖ ∂μ :=
@@ -149,36 +189,72 @@ theorem tendsto_set_integral_peak_smul_of_integrableOn_of_continuousWithinAt_aux
       rw [integral_union (disjoint_sdiff_inter _ _) (hs.inter u_open.measurableSet)
           (h''i.mono_set (diff_subset _ _)) (h''i.mono_set (inter_subset_left _ _))]
     _ ≤ ‖∫ x in s \ u, φ i x • g x ∂μ‖ + ‖∫ x in s ∩ u, φ i x • g x ∂μ‖ := (norm_add_le _ _)
-    _ ≤ (δ * ∫ x in s, ‖g x‖ ∂μ) + δ := add_le_add C B
-#align tendsto_set_integral_peak_smul_of_integrable_on_of_continuous_within_at_aux tendsto_set_integral_peak_smul_of_integrableOn_of_continuousWithinAt_aux
+    _ ≤ (δ * ∫ x in s, ‖g x‖ ∂μ) + 2 * δ := add_le_add C B
+#align tendsto_set_integral_peak_smul_of_integrable_on_of_continuous_within_at_aux tendsto_set_integral_peak_smul_of_integrableOn_of_tendsto_aux
+@[deprecated] alias tendsto_set_integral_peak_smul_of_integrableOn_of_continuousWithinAt_aux :=
+  tendsto_set_integral_peak_smul_of_integrableOn_of_tendsto_aux -- deprecated on 2024-02-20
 
-/- If a sequence of peak functions `φᵢ` converges uniformly to zero away from a point `x₀`, and
-`g` is integrable and continuous at `x₀`, then `∫ φᵢ • g` converges to `x₀`. -/
-theorem tendsto_set_integral_peak_smul_of_integrableOn_of_continuousWithinAt (hs : MeasurableSet s)
-    (h's : μ s ≠ ∞) (hnφ : ∀ᶠ i in l, ∀ x ∈ s, 0 ≤ φ i x)
+/-- If a sequence of peak functions `φᵢ` converges uniformly to zero away from a point `x₀` and its
+integral on some finite-measure neighborhood of `x₀` converges to `1`, and `g` is integrable and
+has a limit `a` at `x₀`, then `∫ φᵢ • g` converges to `a`. Version localized to a subset. -/
+theorem tendsto_set_integral_peak_smul_of_integrableOn_of_tendsto
+    (hs : MeasurableSet s) {t : Set α} (ht : MeasurableSet t) (hts : t ⊆ s) (h'ts : t ∈ 𝓝[s] x₀)
+    (h't : μ t ≠ ∞) (hnφ : ∀ᶠ i in l, ∀ x ∈ s, 0 ≤ φ i x)
     (hlφ : ∀ u : Set α, IsOpen u → x₀ ∈ u → TendstoUniformlyOn φ 0 l (s \ u))
-    (hiφ : (fun i => ∫ x in s, φ i x ∂μ) =ᶠ[l] 1) (hmg : IntegrableOn g s μ)
-    (hcg : ContinuousWithinAt g s x₀) :
-    Tendsto (fun i : ι => ∫ x in s, φ i x • g x ∂μ) l (𝓝 (g x₀)) := by
-  let h := g - fun _ => g x₀
-  have A :
-    Tendsto (fun i : ι => (∫ x in s, φ i x • h x ∂μ) + (∫ x in s, φ i x ∂μ) • g x₀) l
-      (𝓝 (0 + (1 : ℝ) • g x₀)) := by
-    refine' Tendsto.add _ (Tendsto.smul (tendsto_const_nhds.congr' hiφ.symm) tendsto_const_nhds)
-    apply tendsto_set_integral_peak_smul_of_integrableOn_of_continuousWithinAt_aux hs hnφ hlφ hiφ
-    · apply Integrable.sub hmg
-      apply integrableOn_const.2
-      simp only [h's.lt_top, or_true_iff]
-    · simp only [Pi.sub_apply, sub_self]
-    · exact hcg.sub continuousWithinAt_const
+    (hiφ : Tendsto (fun i ↦ ∫ x in t, φ i x ∂μ) l (𝓝 1))
+    (h'iφ : ∀ᶠ i in l, AEStronglyMeasurable (φ i) (μ.restrict s))
+    (hmg : IntegrableOn g s μ) (hcg : Tendsto g (𝓝[s] x₀) (𝓝 a)) :
+    Tendsto (fun i : ι ↦ ∫ x in s, φ i x • g x ∂μ) l (𝓝 a) := by
+  let h := g - t.indicator (fun _ ↦ a)
+  have A : Tendsto (fun i : ι => (∫ x in s, φ i x • h x ∂μ) + (∫ x in t, φ i x ∂μ) • a) l
+      (𝓝 (0 + (1 : ℝ) • a)) := by
+    refine' Tendsto.add _ (Tendsto.smul hiφ tendsto_const_nhds)
+    apply tendsto_set_integral_peak_smul_of_integrableOn_of_tendsto_aux hs ht hts h'ts
+        hnφ hlφ hiφ h'iφ
+    · apply hmg.sub
+      simp only [integrable_indicator_iff ht, integrableOn_const, ht, Measure.restrict_apply]
+      right
+      exact lt_of_le_of_lt (measure_mono (inter_subset_left _ _)) (h't.lt_top)
+    · rw [← sub_self a]
+      apply Tendsto.sub hcg
+      apply tendsto_const_nhds.congr'
+      filter_upwards [h'ts] with x hx using by simp [hx]
   simp only [one_smul, zero_add] at A
   refine' Tendsto.congr' _ A
-  filter_upwards [integrableOn_peak_smul_of_integrableOn_of_continuousWithinAt hs hlφ hiφ hmg hcg,
-    hiφ] with i hi h'i
-  simp only [Pi.sub_apply, smul_sub]
-  rw [integral_sub hi, integral_smul_const, sub_add_cancel]
-  exact Integrable.smul_const (integrable_of_integral_eq_one h'i) _
-#align tendsto_set_integral_peak_smul_of_integrable_on_of_continuous_within_at tendsto_set_integral_peak_smul_of_integrableOn_of_continuousWithinAt
+  filter_upwards [integrableOn_peak_smul_of_integrableOn_of_tendsto hs h'ts
+    hlφ hiφ h'iφ hmg hcg,
+    (tendsto_order.1 (tendsto_iff_norm_sub_tendsto_zero.1 hiφ)).2 1 zero_lt_one] with i hi h'i
+  simp only [Pi.sub_apply, smul_sub, ← indicator_smul_apply]
+  rw [integral_sub hi, set_integral_indicator ht, inter_eq_right.mpr hts,
+    integral_smul_const, sub_add_cancel]
+  rw [integrable_indicator_iff ht]
+  apply Integrable.smul_const
+  rw [restrict_restrict ht, inter_eq_left.mpr hts]
+  exact .of_integral_ne_zero (fun h ↦ by simp [h] at h'i)
+#align tendsto_set_integral_peak_smul_of_integrable_on_of_continuous_within_at tendsto_set_integral_peak_smul_of_integrableOn_of_tendsto
+@[deprecated] alias tendsto_set_integral_peak_smul_of_integrableOn_of_continuousWithinAt :=
+  tendsto_set_integral_peak_smul_of_integrableOn_of_tendsto -- deprecated on 2024-02-20
+
+/-- If a sequence of peak functions `φᵢ` converges uniformly to zero away from a point `x₀` and its
+integral on some finite-measure neighborhood of `x₀` converges to `1`, and `g` is integrable and
+has a limit `a` at `x₀`, then `∫ φᵢ • g` converges to `a`. -/
+theorem tendsto_integral_peak_smul_of_integrable_of_tendsto
+    {t : Set α} (ht : MeasurableSet t) (h'ts : t ∈ 𝓝 x₀)
+    (h't : μ t ≠ ∞) (hnφ : ∀ᶠ i in l, ∀ x, 0 ≤ φ i x)
+    (hlφ : ∀ u : Set α, IsOpen u → x₀ ∈ u → TendstoUniformlyOn φ 0 l uᶜ)
+    (hiφ : Tendsto (fun i ↦ ∫ x in t, φ i x ∂μ) l (𝓝 1))
+    (h'iφ : ∀ᶠ i in l, AEStronglyMeasurable (φ i) μ)
+    (hmg : Integrable g μ) (hcg : Tendsto g (𝓝 x₀) (𝓝 a)) :
+    Tendsto (fun i : ι ↦ ∫ x, φ i x • g x ∂μ) l (𝓝 a) := by
+  suffices Tendsto (fun i : ι ↦ ∫ x in univ, φ i x • g x ∂μ) l (𝓝 a) by simpa
+  exact tendsto_set_integral_peak_smul_of_integrableOn_of_tendsto MeasurableSet.univ ht (x₀ := x₀)
+    (subset_univ _) (by simpa [nhdsWithin_univ]) h't (by simpa)
+    (by simpa [← compl_eq_univ_diff] using hlφ) hiφ
+    (by simpa) (by simpa) (by simpa [nhdsWithin_univ])
+
+/-!
+### Peak functions of the form `x ↦ (c x) ^ n / ∫ (c y) ^ n`
+-/
 
 /-- If a continuous function `c` realizes its maximum at a unique point `x₀` in a compact set `s`,
 then the sequence of functions `(c x) ^ n / ∫ (c x) ^ n` is a sequence of peak functions
@@ -272,9 +348,14 @@ theorem tendsto_set_integral_pow_smul_of_unique_maximum_of_isCompact_of_measure_
     filter_upwards [(tendsto_order.1 N).2 ε εpos] with n hn x hx
     simp only [Pi.zero_apply, dist_zero_left, Real.norm_of_nonneg (hnφ n x hx.1)]
     exact (M n x hx).trans_lt hn
-  have : Tendsto (fun i : ℕ => ∫ x : α in s, φ i x • g x ∂μ) atTop (𝓝 (g x₀)) :=
-    tendsto_set_integral_peak_smul_of_integrableOn_of_continuousWithinAt hs.measurableSet
-      hs.measure_lt_top.ne (eventually_of_forall hnφ) A (eventually_of_forall hiφ) hmg hcg
+  have : Tendsto (fun i : ℕ => ∫ x : α in s, φ i x • g x ∂μ) atTop (𝓝 (g x₀)) := by
+    have B : Tendsto (fun i ↦ ∫ (x : α) in s, φ i x ∂μ) atTop (𝓝 1) :=
+      tendsto_const_nhds.congr (fun n ↦ (hiφ n).symm)
+    have C : ∀ᶠ (i : ℕ) in atTop, AEStronglyMeasurable (fun x ↦ φ i x) (μ.restrict s) := by
+      apply eventually_of_forall (fun n ↦ ((I n).const_mul _).aestronglyMeasurable)
+    exact tendsto_set_integral_peak_smul_of_integrableOn_of_tendsto hs.measurableSet
+      hs.measurableSet (Subset.rfl) (self_mem_nhdsWithin)
+      hs.measure_lt_top.ne (eventually_of_forall hnφ) A B C hmg hcg
   convert this
   simp_rw [← smul_smul, integral_smul]
 #align tendsto_set_integral_pow_smul_of_unique_maximum_of_is_compact_of_measure_nhds_within_pos tendsto_set_integral_pow_smul_of_unique_maximum_of_isCompact_of_measure_nhdsWithin_pos
@@ -320,3 +401,94 @@ theorem tendsto_set_integral_pow_smul_of_unique_maximum_of_isCompact_of_continuo
   tendsto_set_integral_pow_smul_of_unique_maximum_of_isCompact_of_integrableOn hs hc h'c hnc hnc₀ h₀
     (hmg.integrableOn_compact hs) (hmg x₀ this)
 #align tendsto_set_integral_pow_smul_of_unique_maximum_of_is_compact_of_continuous_on tendsto_set_integral_pow_smul_of_unique_maximum_of_isCompact_of_continuousOn
+
+/-!
+### Peak functions of the form `x ↦ c ^ dim * φ (c x)`
+-/
+
+open FiniteDimensional Bornology
+
+variable {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F] [FiniteDimensional ℝ F]
+  [MeasurableSpace F] [BorelSpace F] {μ : Measure F} [IsAddHaarMeasure μ]
+
+/-- Consider a nonnegative function `φ` with integral one, decaying quickly enough at infinity.
+Then suitable renormalizations of `φ` form a sequence of peak functions around the origin:
+`∫ (c ^ d * φ (c • x)) • g x` converges to `g 0` as `c → ∞` if `g` is continuous at `0`
+and integrable. -/
+theorem tendsto_integral_comp_smul_smul_of_integrable
+    {φ : F → ℝ} (hφ : ∀ x, 0 ≤ φ x) (h'φ : ∫ x, φ x ∂μ = 1)
+    (h : Tendsto (fun x ↦ ‖x‖ ^ finrank ℝ F * φ x) (cobounded F) (𝓝 0))
+    {g : F → E} (hg : Integrable g μ) (h'g : ContinuousAt g 0) :
+    Tendsto (fun (c : ℝ) ↦ ∫ x, (c ^ (finrank ℝ F) * φ (c • x)) • g x ∂μ) atTop (𝓝 (g 0)) := by
+  have I : Integrable φ μ := (integrable_of_integral_eq_one h'φ)
+  apply tendsto_integral_peak_smul_of_integrable_of_tendsto (t := closedBall 0 1) (x₀ := 0)
+  · exact isClosed_ball.measurableSet
+  · exact closedBall_mem_nhds _ zero_lt_one
+  · exact (isCompact_closedBall 0 1).measure_ne_top
+  · filter_upwards [Ici_mem_atTop 0] with c (hc : 0 ≤ c) x using mul_nonneg (by positivity) (hφ _)
+  · intro u u_open hu
+    apply tendstoUniformlyOn_iff.2 (fun ε εpos ↦ ?_)
+    obtain ⟨δ, δpos, h'u⟩ : ∃ δ > 0, ball 0 δ ⊆ u := Metric.isOpen_iff.1 u_open _ hu
+    obtain ⟨M, Mpos, hM⟩ : ∃ M > 0, ∀ ⦃x : F⦄, x ∈ (closedBall 0 M)ᶜ →
+        ‖x‖ ^ finrank ℝ F * φ x < δ ^ finrank ℝ F * ε := by
+      rcases (hasBasis_cobounded_compl_closedBall (0 : F)).eventually_iff.1
+        ((tendsto_order.1 h).2 (δ ^ finrank ℝ F * ε) (by positivity)) with ⟨M, -, hM⟩
+      refine ⟨max M 1, zero_lt_one.trans_le (le_max_right _ _), fun x hx ↦ hM ?_⟩
+      simp only [mem_compl_iff, mem_closedBall, dist_zero_right, le_max_iff, not_or, not_le] at hx
+      simpa using hx.1
+    filter_upwards [Ioi_mem_atTop (M / δ)] with c (hc : M / δ < c) x hx
+    have cpos : 0 < c := lt_trans (by positivity) hc
+    suffices c ^ finrank ℝ F * φ (c • x) < ε by simpa [abs_of_nonneg (hφ _), abs_of_nonneg cpos.le]
+    have hδx : δ ≤ ‖x‖ := by
+      have : x ∈ (ball 0 δ)ᶜ := fun h ↦ hx (h'u h)
+      simpa only [mem_compl_iff, mem_ball, dist_zero_right, not_lt]
+    suffices δ ^ finrank ℝ F * (c ^ finrank ℝ F * φ (c • x)) < δ ^ finrank ℝ F * ε by
+      rwa [mul_lt_mul_iff_of_pos_left (by positivity)] at this
+    calc
+      δ ^ finrank ℝ F * (c ^ finrank ℝ F * φ (c • x))
+      _ ≤ ‖x‖ ^ finrank ℝ F * (c ^ finrank ℝ F * φ (c • x)) := by
+        gcongr; exact mul_nonneg (by positivity) (hφ _)
+      _ = ‖c • x‖ ^ finrank ℝ F * φ (c • x) := by
+        simp [norm_smul, abs_of_pos cpos, mul_pow]; ring
+      _ < δ ^ finrank ℝ F * ε := by
+        apply hM
+        rw [div_lt_iff δpos] at hc
+        simp only [mem_compl_iff, mem_closedBall, dist_zero_right, norm_smul, Real.norm_eq_abs,
+          abs_of_nonneg cpos.le, not_le, gt_iff_lt]
+        exact hc.trans_le (by gcongr)
+  · have : Tendsto (fun c ↦ ∫ (x : F) in closedBall 0 c, φ x ∂μ) atTop (𝓝 1) := by
+      rw [← h'φ]
+      exact (aecover_closedBall tendsto_id).integral_tendsto_of_countably_generated I
+    apply this.congr'
+    filter_upwards [Ioi_mem_atTop 0] with c (hc : 0 < c)
+    rw [integral_mul_left, set_integral_comp_smul_of_pos _ _ _ hc, smul_eq_mul, ← mul_assoc,
+      mul_inv_cancel (by positivity), _root_.smul_closedBall _ _ zero_le_one]
+    simp [abs_of_nonneg hc.le]
+  · filter_upwards [Ioi_mem_atTop 0] with c (hc : 0 < c)
+    exact (I.comp_smul hc.ne').aestronglyMeasurable.const_mul _
+  · exact hg
+  · exact h'g
+
+/-- Consider a nonnegative function `φ` with integral one, decaying quickly enough at infinity.
+Then suitable renormalizations of `φ` form a sequence of peak functions around any point:
+`∫ (c ^ d * φ (c • (x₀ - x)) • g x` converges to `g x₀` as `c → ∞` if `g` is continuous at `x₀`
+and integrable. -/
+theorem tendsto_integral_comp_smul_smul_of_integrable'
+    {φ : F → ℝ} (hφ : ∀ x, 0 ≤ φ x) (h'φ : ∫ x, φ x ∂μ = 1)
+    (h : Tendsto (fun x ↦ ‖x‖ ^ finrank ℝ F * φ x) (cobounded F) (𝓝 0))
+    {g : F → E} {x₀ : F} (hg : Integrable g μ) (h'g : ContinuousAt g x₀) :
+    Tendsto (fun (c : ℝ) ↦ ∫ x, (c ^ (finrank ℝ F) * φ (c • (x₀ - x))) • g x ∂μ)
+      atTop (𝓝 (g x₀)) := by
+  let f := fun x ↦ g (x₀ - x)
+  have If : Integrable f μ := by simpa [sub_eq_add_neg] using (hg.comp_add_left x₀).comp_neg
+  have : Tendsto (fun (c : ℝ) ↦ ∫ x, (c ^ (finrank ℝ F) * φ (c • x)) • f x ∂μ)
+      atTop (𝓝 (f 0)) := by
+    apply tendsto_integral_comp_smul_smul_of_integrable hφ h'φ h If
+    have A : ContinuousAt g (x₀ - 0) := by simpa using h'g
+    have B : ContinuousAt (fun x ↦ x₀ - x) 0 := Continuous.continuousAt (by continuity)
+    exact A.comp B
+  simp only [sub_zero] at this
+  convert this using 2 with c
+  conv_rhs => rw [← integral_add_left_eq_self x₀ (μ := μ)
+    (f := fun x ↦ (c ^ finrank ℝ F * φ (c • x)) • g (x₀ - x)), ← integral_neg_eq_self]
+  simp [smul_sub, sub_eq_add_neg]

--- a/Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/NormedSpace.lean
@@ -5,7 +5,7 @@ Authors: Floris van Doorn, Sébastien Gouëzel
 -/
 import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
-import Mathlib.MeasureTheory.Integral.Bochner
+import Mathlib.MeasureTheory.Integral.SetIntegral
 
 #align_import measure_theory.measure.haar.normed_space from "leanprover-community/mathlib"@"b84aee748341da06a6d78491367e2c0e9f15e8a5"
 
@@ -62,7 +62,7 @@ variable {s : Set E}
 integral of `f`. The formula we give works even when `f` is not integrable or `R = 0`
 thanks to the convention that a non-integrable function has integral zero. -/
 theorem integral_comp_smul (f : E → F) (R : ℝ) :
-    (∫ x, f (R • x) ∂μ) = |(R ^ finrank ℝ E)⁻¹| • ∫ x, f x ∂μ := by
+    ∫ x, f (R • x) ∂μ = |(R ^ finrank ℝ E)⁻¹| • ∫ x, f x ∂μ := by
   by_cases hF : CompleteSpace F; swap
   · simp [integral, hF]
   rcases eq_or_ne R 0 with (rfl | hR)
@@ -87,7 +87,7 @@ theorem integral_comp_smul (f : E → F) (R : ℝ) :
 integral of `f`. The formula we give works even when `f` is not integrable or `R = 0`
 thanks to the convention that a non-integrable function has integral zero. -/
 theorem integral_comp_smul_of_nonneg (f : E → F) (R : ℝ) {hR : 0 ≤ R} :
-    (∫ x, f (R • x) ∂μ) = (R ^ finrank ℝ E)⁻¹ • ∫ x, f x ∂μ := by
+    ∫ x, f (R • x) ∂μ = (R ^ finrank ℝ E)⁻¹ • ∫ x, f x ∂μ := by
   rw [integral_comp_smul μ f R, abs_of_nonneg (inv_nonneg.2 (pow_nonneg hR _))]
 #align measure_theory.measure.integral_comp_smul_of_nonneg MeasureTheory.Measure.integral_comp_smul_of_nonneg
 
@@ -95,7 +95,7 @@ theorem integral_comp_smul_of_nonneg (f : E → F) (R : ℝ) {hR : 0 ≤ R} :
 integral of `f`. The formula we give works even when `f` is not integrable or `R = 0`
 thanks to the convention that a non-integrable function has integral zero. -/
 theorem integral_comp_inv_smul (f : E → F) (R : ℝ) :
-    (∫ x, f (R⁻¹ • x) ∂μ) = |R ^ finrank ℝ E| • ∫ x, f x ∂μ := by
+    ∫ x, f (R⁻¹ • x) ∂μ = |R ^ finrank ℝ E| • ∫ x, f x ∂μ := by
   rw [integral_comp_smul μ f R⁻¹, inv_pow, inv_inv]
 #align measure_theory.measure.integral_comp_inv_smul MeasureTheory.Measure.integral_comp_inv_smul
 
@@ -103,9 +103,28 @@ theorem integral_comp_inv_smul (f : E → F) (R : ℝ) :
 integral of `f`. The formula we give works even when `f` is not integrable or `R = 0`
 thanks to the convention that a non-integrable function has integral zero. -/
 theorem integral_comp_inv_smul_of_nonneg (f : E → F) {R : ℝ} (hR : 0 ≤ R) :
-    (∫ x, f (R⁻¹ • x) ∂μ) = R ^ finrank ℝ E • ∫ x, f x ∂μ := by
+    ∫ x, f (R⁻¹ • x) ∂μ = R ^ finrank ℝ E • ∫ x, f x ∂μ := by
   rw [integral_comp_inv_smul μ f R, abs_of_nonneg (pow_nonneg hR _)]
 #align measure_theory.measure.integral_comp_inv_smul_of_nonneg MeasureTheory.Measure.integral_comp_inv_smul_of_nonneg
+
+theorem set_integral_comp_smul (f : E → F) {R : ℝ} (s : Set E) (hR : R ≠ 0) :
+    ∫ x in s, f (R • x) ∂μ = |(R ^ finrank ℝ E)⁻¹| • ∫ x in R • s, f x ∂μ := by
+  let e : E ≃ᵐ E := (Homeomorph.smul (Units.mk0 R hR)).toMeasurableEquiv
+  calc
+  ∫ x in s, f (R • x) ∂μ
+    = ∫ x in e ⁻¹' (e.symm ⁻¹' s), f (e x) ∂μ := by simp [← preimage_comp]; rfl
+  _ = ∫ y in e.symm ⁻¹' s, f y ∂map (fun x ↦ R • x) μ := (set_integral_map_equiv _ _ _).symm
+  _ = |(R ^ finrank ℝ E)⁻¹| • ∫ y in e.symm ⁻¹' s, f y ∂μ := by
+    simp [map_addHaar_smul μ hR, integral_smul_measure, ENNReal.toReal_ofReal, abs_nonneg]
+  _ = |(R ^ finrank ℝ E)⁻¹| • ∫ x in R • s, f x ∂μ := by
+    congr
+    ext y
+    rw [mem_smul_set_iff_inv_smul_mem₀ hR]
+    rfl
+
+theorem set_integral_comp_smul_of_pos (f : E → F) {R : ℝ} (s : Set E) (hR : 0 < R) :
+    ∫ x in s, f (R • x) ∂μ = (R ^ finrank ℝ E)⁻¹ • ∫ x in R • s, f x ∂μ := by
+  rw [set_integral_comp_smul μ f s hR.ne', abs_of_nonneg (inv_nonneg.2 (pow_nonneg hR.le _))]
 
 theorem integral_comp_mul_left (g : ℝ → F) (a : ℝ) : (∫ x : ℝ, g (a * x)) = |a⁻¹| • ∫ y : ℝ, g y :=
   by simp_rw [← smul_eq_mul, Measure.integral_comp_smul, FiniteDimensional.finrank_self, pow_one]

--- a/Mathlib/MeasureTheory/Measure/Typeclasses.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses.lean
@@ -1177,6 +1177,11 @@ theorem _root_.IsCompact.measure_lt_top [TopologicalSpace α] {μ : Measure α}
   IsFiniteMeasureOnCompacts.lt_top_of_isCompact hK
 #align is_compact.measure_lt_top IsCompact.measure_lt_top
 
+/-- A compact subset has finite measure for a measure which is finite on compacts. -/
+theorem _root_.IsCompact.measure_ne_top [TopologicalSpace α] {μ : Measure α}
+    [IsFiniteMeasureOnCompacts μ] ⦃K : Set α⦄ (hK : IsCompact K) : μ K ≠ ∞ :=
+  hK.measure_lt_top.ne
+
 /-- A bounded subset has finite measure for a measure which is finite on compact sets, in a
 proper space. -/
 theorem _root_.Bornology.IsBounded.measure_lt_top [PseudoMetricSpace α] [ProperSpace α]


### PR DESCRIPTION
This makes it possible to use Gaussians as peak functions in the proof of Fourier inversion.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
