### PR TITLE
[Merged by Bors] - feat: cyclic group lemmas

### DIFF
--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -639,6 +639,12 @@ def IsUnit [Monoid M] (a : M) : Prop :=
 #align is_unit IsUnit
 #align is_add_unit IsAddUnit
 
+@[to_additive]
+lemma isUnit_iff [Monoid M] {x : M} : IsUnit x ↔ ∃ b, x * b = 1 ∧ b * x = 1 := by
+  refine ⟨fun ⟨u, hu⟩ => ?_, fun ⟨b, h1b, h2b⟩ => ⟨⟨x, b, h1b, h2b⟩, rfl⟩⟩
+  subst x
+  exact ⟨u.inv, u.val_inv, u.inv_val⟩
+
 @[to_additive (attr := nontriviality)]
 theorem isUnit_of_subsingleton [Monoid M] [Subsingleton M] (a : M) : IsUnit a :=
   ⟨⟨a, a, Subsingleton.elim _ _, Subsingleton.elim _ _⟩, rfl⟩

--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -640,7 +640,7 @@ def IsUnit [Monoid M] (a : M) : Prop :=
 #align is_add_unit IsAddUnit
 
 @[to_additive]
-lemma isUnit_iff [Monoid M] {x : M} : IsUnit x ↔ ∃ b, x * b = 1 ∧ b * x = 1 := by
+lemma isUnit_iff_exists [Monoid M] {x : M} : IsUnit x ↔ ∃ b, x * b = 1 ∧ b * x = 1 := by
   refine ⟨fun ⟨u, hu⟩ => ?_, fun ⟨b, h1b, h2b⟩ => ⟨⟨x, b, h1b, h2b⟩, rfl⟩⟩
   subst x
   exact ⟨u.inv, u.val_inv, u.inv_val⟩

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -146,7 +146,7 @@ theorem mem_zpowers_of_prime_card {G : Type*} [Group G] {_ : Fintype G} {p : ℕ
   simp_rw [zpowers_eq_top_of_prime_card h hg, Subgroup.mem_top]
 
 @[to_additive mem_multiples_of_prime_card]
-theorem mem_powers_of_prime_card {G : Type u} [Group G] {_ : Fintype G} {p : ℕ} [hp : Fact p.Prime]
+theorem mem_powers_of_prime_card {G : Type*} [Group G] {_ : Fintype G} {p : ℕ} [hp : Fact p.Prime]
     (h : Fintype.card G = p) {g g' : G} (hg : g ≠ 1) : g' ∈ Submonoid.powers g := by
   rw [mem_powers_iff_mem_zpowers]
   exact mem_zpowers_of_prime_card h hg

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -130,35 +130,39 @@ theorem isCyclic_of_orderOf_eq_card [Fintype α] (x : α) (hx : orderOf x = Fint
 #align is_cyclic_of_order_of_eq_card isCyclic_of_orderOf_eq_card
 #align is_add_cyclic_of_order_of_eq_card isAddCyclic_of_orderOf_eq_card
 
+/-- Any non-identity element of a finite group of prime order generates the group. -/
+@[to_additive zmultiples_eq_top_of_prime_card "Any non-identity element of a finite group of prime
+  order generates the group."]
+theorem zpowers_eq_top_of_prime_card {G : Type*} [Group G] {_ : Fintype G} {p : ℕ}
+    [hp : Fact p.Prime] (h : Fintype.card G = p) {g : G} (hg : g ≠ 1) : zpowers g = ⊤ := by
+  have := card_subgroup_dvd_card (zpowers g)
+  simp_rw [h, Nat.dvd_prime hp.1, ← eq_bot_iff_card, zpowers_eq_bot, hg, false_or, ← h,
+    card_eq_iff_eq_top] at this
+  exact this
+
+@[to_additive mem_zmultiples_of_prime_card]
+theorem mem_zpowers_of_prime_card {G : Type*} [Group G] {_ : Fintype G} {p : ℕ} [hp : Fact p.Prime]
+    (h : Fintype.card G = p) {g g' : G} (hg : g ≠ 1) : g' ∈ zpowers g := by
+  simp_rw [zpowers_eq_top_of_prime_card h hg, Subgroup.mem_top]
+
+@[to_additive mem_multiples_of_prime_card]
+theorem mem_powers_of_prime_card {G : Type u} [Group G] {_ : Fintype G} {p : ℕ} [hp : Fact p.Prime]
+    (h : Fintype.card G = p) {g g' : G} (hg : g ≠ 1) : g' ∈ Submonoid.powers g := by
+  rw [mem_powers_iff_mem_zpowers]
+  exact mem_zpowers_of_prime_card h hg
+
+@[to_additive multiples_eq_top_of_prime_card]
+theorem powers_eq_top_of_prime_card {G : Type*} [Group G] {_ : Fintype G} {p : ℕ}
+    [hp : Fact p.Prime] (h : Fintype.card G = p) {g : G} (hg : g ≠ 1) : Submonoid.powers g = ⊤ := by
+  ext x
+  simp [mem_powers_of_prime_card h hg]
+
 /-- A finite group of prime order is cyclic. -/
 @[to_additive "A finite group of prime order is cyclic."]
 theorem isCyclic_of_prime_card {α : Type u} [Group α] [Fintype α] {p : ℕ} [hp : Fact p.Prime]
-    (h : Fintype.card α = p) : IsCyclic α :=
-  ⟨by
-    obtain ⟨g, hg⟩ : ∃ g : α, g ≠ 1 := Fintype.exists_ne_of_one_lt_card (h.symm ▸ hp.1.one_lt) 1
-    classical
-      -- for Fintype (Subgroup.zpowers g)
-      have : Fintype.card (Subgroup.zpowers g) ∣ p := by
-        rw [← h]
-        apply card_subgroup_dvd_card
-      rw [Nat.dvd_prime hp.1] at this
-      cases' this with that that
-      · rw [Fintype.card_eq_one_iff] at that
-        cases' that with t ht
-        suffices g = 1 by contradiction
-        have hgt :=
-          ht
-            ⟨g, by
-              change g ∈ Subgroup.zpowers g
-              exact Subgroup.mem_zpowers g⟩
-        rw [← ht 1] at hgt
-        change (⟨_, _⟩ : Subgroup.zpowers g) = ⟨_, _⟩ at hgt
-        simpa using hgt
-      · use g
-        intro x
-        rw [← h] at that
-        rw [Subgroup.eq_top_of_card_eq _ that]
-        exact Subgroup.mem_top _⟩
+    (h : Fintype.card α = p) : IsCyclic α := by
+  obtain ⟨g, hg⟩ : ∃ g, g ≠ 1 := Fintype.exists_ne_of_one_lt_card (h.symm ▸ hp.1.one_lt) 1
+  exact ⟨g, fun g' ↦ mem_zpowers_of_prime_card h hg⟩
 #align is_cyclic_of_prime_card isCyclic_of_prime_card
 #align is_add_cyclic_of_prime_card isAddCyclic_of_prime_card
 


### PR DESCRIPTION
* Add a lemma stating that non-identity element of a finite group of prime order generates the group (stated in 4 ways)
* Use this to golf `isCyclic_of_prime_card`
* Add a version of `isUnit_iff_exists_inv` for non-commutative monoids.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
