### PR TITLE
[Merged by Bors] - feat: the Fourier transform is self-adjoint

### DIFF
--- a/Mathlib/Analysis/Fourier/FourierTransform.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransform.lean
@@ -333,13 +333,13 @@ open scoped RealInnerProductSpace
 /-- The Fourier transform of a function on an inner product space, with respect to the standard
 additive character `ω ↦ exp (2 i π ω)`. -/
 def fourierIntegral (f : V → E) (w : V) : E :=
-  VectorFourier.fourierIntegral Real.fourierChar volume (innerₗ V) f w
+  VectorFourier.fourierIntegral 𝐞 volume (innerₗ V) f w
 #align real.fourier_integral Real.fourierIntegral
 
 /-- The inverse Fourier transform of a function on an inner product space, defined as the Fourier
 transform but with opposite sign in the exponential. -/
 def fourierIntegralInv (f : V → E) (w : V) : E :=
-  VectorFourier.fourierIntegral Real.fourierChar volume (-innerₗ V) f w
+  VectorFourier.fourierIntegral 𝐞 volume (-innerₗ V) f w
 
 @[inherit_doc] scoped[FourierTransform] notation "𝓕" => Real.fourierIntegral
 @[inherit_doc] scoped[FourierTransform] notation "𝓕⁻" => Real.fourierIntegralInv
@@ -374,7 +374,7 @@ lemma fourierIntegralInv_comp_linearIsometry (A : W ≃ₗᵢ[ℝ] V) (f : V →
   simp [fourierIntegralInv_eq_fourierIntegral_neg, fourierIntegral_comp_linearIsometry]
 
 theorem fourierIntegral_real_eq (f : ℝ → E) (w : ℝ) :
-    fourierIntegral f w = ∫ v : ℝ, fourierChar[-(v * w)] • f v :=
+    fourierIntegral f w = ∫ v : ℝ, 𝐞[-(v * w)] • f v :=
   rfl
 #align real.fourier_integral_def Real.fourierIntegral_real_eq
 

--- a/Mathlib/Analysis/Fourier/FourierTransform.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransform.lean
@@ -5,7 +5,10 @@ Authors: David Loeffler
 -/
 import Mathlib.Analysis.Complex.Circle
 import Mathlib.MeasureTheory.Group.Integral
+import Mathlib.MeasureTheory.Integral.SetIntegral
 import Mathlib.MeasureTheory.Measure.Haar.OfBasis
+import Mathlib.MeasureTheory.Constructions.Prod.Integral
+import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 
 #align_import analysis.fourier.fourier_transform from "leanprover-community/mathlib"@"fd5edc43dc4f10b85abfe544b88f82cf13c5f844"
 
@@ -33,12 +36,17 @@ where `e [x]` is notational sugar for `(e (Multiplicative.ofAdd x) : ℂ)` (avai
 `fourier_transform`). This includes the cases `W` is the dual of `V` and `L` is the canonical
 pairing, or `W = V` and `L` is a bilinear form (e.g. an inner product).
 
-In namespace `fourier`, we consider the more familiar special case when `V = W = 𝕜` and `L` is the
+In namespace `Fourier`, we consider the more familiar special case when `V = W = 𝕜` and `L` is the
 multiplication map (but still allowing `𝕜` to be an arbitrary ring equipped with a measure).
 
 The most familiar case of all is when `V = W = 𝕜 = ℝ`, `L` is multiplication, `μ` is volume, and
-`e` is `Real.fourierChar`, i.e. the character `fun x ↦ exp ((2 * π * x) * I)`. The Fourier integral
-in this case is defined as `Real.fourierIntegral`.
+`e` is `Real.fourierChar`, i.e. the character `fun x ↦ exp ((2 * π * x) * I)` (for which we
+introduce the notation `𝐞` in the locale `FourierTransform`).
+
+Another familiar case (which generalizes the previous one) is when `V = W` is an inner product space
+over `ℝ` and `L` is the scalar product. We introduce two notations `𝓕` for the Fourier transform in
+this case and `𝓕⁻ f (v) = 𝓕 f (-v)` for the inverse Fourier transform. These notations make
+in particular sense for `V = W = ℝ`.
 
 ## Main results
 
@@ -56,6 +64,7 @@ open MeasureTheory Filter
 open scoped Topology
 
 -- To avoid messing around with multiplicative vs. additive characters, we make a notation.
+/-- Notation for multiplicative character applied in an additive setting. -/
 scoped[FourierTransform] notation e "[" x "]" => (e (Multiplicative.ofAdd x) : ℂ)
 
 open FourierTransform
@@ -66,7 +75,9 @@ open FourierTransform
 namespace VectorFourier
 
 variable {𝕜 : Type*} [CommRing 𝕜] {V : Type*} [AddCommGroup V] [Module 𝕜 V] [MeasurableSpace V]
-  {W : Type*} [AddCommGroup W] [Module 𝕜 W] {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+  {W : Type*} [AddCommGroup W] [Module 𝕜 W]
+  {E F G : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] [NormedAddCommGroup F] [NormedSpace ℂ F]
+  [NormedAddCommGroup G] [NormedSpace ℂ G]
 
 section Defs
 
@@ -174,6 +185,63 @@ theorem fourierIntegral_continuous [FirstCountableTopology W] (he : Continuous e
 
 end Continuous
 
+section Fubini
+
+variable [TopologicalSpace 𝕜] [TopologicalRing 𝕜] [TopologicalSpace V] [BorelSpace V]
+  [TopologicalSpace W] [MeasurableSpace W] [BorelSpace W]
+  {e : Multiplicative 𝕜 →* 𝕊} {μ : Measure V} {L : V →ₗ[𝕜] W →ₗ[𝕜] 𝕜}
+  {ν : Measure W} [SigmaFinite μ] [SigmaFinite ν] [SecondCountableTopology V]
+
+variable [CompleteSpace E] [CompleteSpace F]
+
+/-- The Fourier transform satisfies `∫ 𝓕 f * g = ∫ f * 𝓕 g`, i.e., it is self-adjoint.
+Version where the multiplication is replaced by a general bilinear form `M`. -/
+theorem integral_bilin_fourierIntegral_eq_flip
+    {f : V → E} {g : W → F} (M : E →L[ℂ] F →L[ℂ] G) (he : Continuous e)
+    (hL : Continuous fun p : V × W => L p.1 p.2) (hf : Integrable f μ) (hg : Integrable g ν) :
+    ∫ ξ, M (fourierIntegral e μ L f ξ) (g ξ) ∂ν =
+      ∫ x, M (f x) (fourierIntegral e ν L.flip g x) ∂μ := by
+  by_cases hG : CompleteSpace G; swap; · simp [integral, hG]
+  calc
+  ∫ ξ, M (fourierIntegral e μ L f ξ) (g ξ) ∂ν
+    = ∫ ξ, M.flip (g ξ) (∫ x, e[-L x ξ] • f x ∂μ) ∂ν := rfl
+  _ = ∫ ξ, (∫ x, M.flip (g ξ) (e[-L x ξ] • f x) ∂μ) ∂ν := by
+    congr with ξ
+    apply (ContinuousLinearMap.integral_comp_comm _ _).symm
+    exact (fourier_integral_convergent_iff he hL _).1 hf
+  _ = ∫ x, (∫ ξ, M.flip (g ξ) (e[-L x ξ] • f x) ∂ν) ∂μ := by
+    rw [integral_integral_swap]
+    have : Integrable (fun (p : W × V) ↦ ‖M‖ * (‖g p.1‖ * ‖f p.2‖)) (ν.prod μ) :=
+      (hg.norm.prod_mul hf.norm).const_mul _
+    apply this.mono
+    · have A : AEStronglyMeasurable (fun (p : W × V) ↦ e[-L p.2 p.1] • f p.2) (ν.prod μ) := by
+        apply (Continuous.aestronglyMeasurable ?_).smul hf.1.snd
+        refine (continuous_induced_rng.mp he).comp (continuous_ofAdd.comp ?_)
+        exact (hL.comp continuous_swap).neg
+      exact M.flip.continuous₂.comp_aestronglyMeasurable (hg.1.fst.prod_mk A)
+    · apply eventually_of_forall
+      rintro ⟨ξ, x⟩
+      simp only [ofAdd_neg, map_inv, coe_inv_unitSphere, SMulHomClass.map_smul,
+        ContinuousLinearMap.flip_apply, Function.uncurry_apply_pair, norm_smul, norm_inv,
+        norm_eq_of_mem_sphere, inv_one, one_mul, norm_mul, norm_norm]
+      exact (M.le_opNorm₂ (f x) (g ξ)).trans (le_of_eq (by ring))
+  _ = ∫ x, (∫ ξ, M (f x) (e[-L.flip ξ x] • g ξ) ∂ν) ∂μ := by simp
+  _ = ∫ x, M (f x) (∫ ξ, e[-L.flip ξ x] • g ξ ∂ν) ∂μ := by
+    congr with x
+    apply ContinuousLinearMap.integral_comp_comm
+    apply (fourier_integral_convergent_iff he _ _).1 hg
+    exact hL.comp continuous_swap
+
+/-- The Fourier transform satisfies `∫ 𝓕 f * g = ∫ f * 𝓕 g`, i.e., it is self-adjoint. -/
+theorem integral_fourierIntegral_smul_eq_flip
+    {f : V → ℂ} {g : W → F} (he : Continuous e)
+    (hL : Continuous fun p : V × W => L p.1 p.2) (hf : Integrable f μ) (hg : Integrable g ν) :
+    ∫ ξ, (fourierIntegral e μ L f ξ) • (g ξ) ∂ν =
+      ∫ x, (f x) • (fourierIntegral e ν L.flip g x) ∂μ :=
+  integral_bilin_fourierIntegral_eq_flip (ContinuousLinearMap.lsmul ℂ ℂ) he hL hf hg
+
+end Fubini
+
 end VectorFourier
 
 /-! ## Fourier theory for functions on `𝕜` -/
@@ -232,12 +300,14 @@ def fourierChar : Multiplicative ℝ →* 𝕊 where
   map_mul' x y := by simp only; rw [toAdd_mul, mul_add, expMapCircle_add]
 #align real.fourier_char Real.fourierChar
 
-theorem fourierChar_apply (x : ℝ) : Real.fourierChar[x] = Complex.exp (↑(2 * π * x) * Complex.I) :=
+@[inherit_doc] scoped[FourierTransform] notation "𝐞" => Real.fourierChar
+
+theorem fourierChar_apply (x : ℝ) : 𝐞[x] = Complex.exp (↑(2 * π * x) * Complex.I) :=
   by rfl
 #align real.fourier_char_apply Real.fourierChar_apply
 
 @[continuity]
-theorem continuous_fourierChar : Continuous Real.fourierChar :=
+theorem continuous_fourierChar : Continuous 𝐞 :=
   (map_continuous expMapCircle).comp (continuous_const.mul continuous_toAdd)
 #align real.continuous_fourier_char Real.continuous_fourierChar
 
@@ -251,23 +321,71 @@ theorem vector_fourierIntegral_eq_integral_exp_smul {V : Type*} [AddCommGroup V]
   by simp_rw [VectorFourier.fourierIntegral, Real.fourierChar_apply, mul_neg, neg_mul]
 #align real.vector_fourier_integral_eq_integral_exp_smul Real.vector_fourierIntegral_eq_integral_exp_smul
 
-/-- The Fourier integral for `f : ℝ → E`, with respect to the standard additive character and
-measure on `ℝ`. -/
-def fourierIntegral (f : ℝ → E) (w : ℝ) :=
-  Fourier.fourierIntegral fourierChar volume f w
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+  {V : Type*} [NormedAddCommGroup V]
+  [InnerProductSpace ℝ V] [MeasurableSpace V] [BorelSpace V] [FiniteDimensional ℝ V]
+  {W : Type*} [NormedAddCommGroup W]
+  [InnerProductSpace ℝ W] [MeasurableSpace W] [BorelSpace W] [FiniteDimensional ℝ W]
+
+open scoped RealInnerProductSpace
+
+/-- The Fourier transform of a function on an inner product space, with respect to the standard
+additive character `ω ↦ exp (2 i π ω)`. -/
+def fourierIntegral (f : V → E) (w : V) : E :=
+  VectorFourier.fourierIntegral Real.fourierChar volume (innerₗ V) f w
 #align real.fourier_integral Real.fourierIntegral
 
-theorem fourierIntegral_def (f : ℝ → E) (w : ℝ) :
-    fourierIntegral f w = ∫ v : ℝ, fourierChar[-(v * w)] • f v :=
-  rfl
-#align real.fourier_integral_def Real.fourierIntegral_def
+/-- The inverse Fourier transform of a function on an inner product space, defined as the Fourier
+transform but with opposite sign in the exponential. -/
+def fourierIntegralInv (f : V → E) (w : V) : E :=
+  VectorFourier.fourierIntegral Real.fourierChar volume (-innerₗ V) f w
 
 @[inherit_doc] scoped[FourierTransform] notation "𝓕" => Real.fourierIntegral
+@[inherit_doc] scoped[FourierTransform] notation "𝓕⁻" => Real.fourierIntegralInv
 
-theorem fourierIntegral_eq_integral_exp_smul {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
-    (f : ℝ → E) (w : ℝ) :
+lemma fourierIntegral_eq (f : V → E) (w : V) :
+    𝓕 f w = ∫ v, 𝐞[-⟪v, w⟫] • f v := rfl
+
+lemma fourierIntegral_eq' (f : V → E) (w : V) :
+    𝓕 f w = ∫ v, Complex.exp ((↑(-2 * π * ⟪v, w⟫) * Complex.I)) • f v := by
+  simp_rw [fourierIntegral_eq, Real.fourierChar_apply, mul_neg, neg_mul]
+
+lemma fourierIntegralInv_eq (f : V → E) (w : V) :
+    𝓕⁻ f w = ∫ v, 𝐞[⟪v, w⟫] • f v := by
+  simp [fourierIntegralInv, VectorFourier.fourierIntegral]
+
+lemma fourierIntegralInv_eq' (f : V → E) (w : V) :
+    𝓕⁻ f w = ∫ v, Complex.exp ((↑(2 * π * ⟪v, w⟫) * Complex.I)) • f v := by
+  simp_rw [fourierIntegralInv_eq, Real.fourierChar_apply]
+
+lemma fourierIntegralInv_eq_fourierIntegral_neg (f : V → E) (w : V) :
+    𝓕⁻ f w = 𝓕 f (-w) := by
+  simp [fourierIntegral_eq, fourierIntegralInv_eq]
+
+lemma fourierIntegral_comp_linearIsometry (A : W ≃ₗᵢ[ℝ] V) (f : V → E) (w : W) :
+    𝓕 (f ∘ A) w = (𝓕 f) (A w) := by
+  simp only [fourierIntegral_eq, ofAdd_neg, map_inv, coe_inv_unitSphere, Function.comp_apply,
+    ← MeasurePreserving.integral_comp A.measurePreserving A.toHomeomorph.measurableEmbedding,
+    ← A.inner_map_map]
+
+lemma fourierIntegralInv_comp_linearIsometry (A : W ≃ₗᵢ[ℝ] V) (f : V → E) (w : W) :
+    𝓕⁻ (f ∘ A) w = (𝓕⁻ f) (A w) := by
+  simp [fourierIntegralInv_eq_fourierIntegral_neg, fourierIntegral_comp_linearIsometry]
+
+theorem fourierIntegral_real_eq (f : ℝ → E) (w : ℝ) :
+    fourierIntegral f w = ∫ v : ℝ, fourierChar[-(v * w)] • f v :=
+  rfl
+#align real.fourier_integral_def Real.fourierIntegral_real_eq
+
+@[deprecated] alias fourierIntegral_def := fourierIntegral_real_eq -- deprecated on 2024-02-21
+
+theorem fourierIntegral_real_eq_integral_exp_smul (f : ℝ → E) (w : ℝ) :
     𝓕 f w = ∫ v : ℝ, Complex.exp (↑(-2 * π * v * w) * Complex.I) • f v := by
-  simp_rw [fourierIntegral_def, Real.fourierChar_apply, mul_neg, neg_mul, mul_assoc]
-#align real.fourier_integral_eq_integral_exp_smul Real.fourierIntegral_eq_integral_exp_smul
+  simp_rw [fourierIntegral_real_eq, Real.fourierChar_apply, mul_neg, neg_mul, mul_assoc]
+#align real.fourier_integral_eq_integral_exp_smul Real.fourierIntegral_real_eq_integral_exp_smul
+
+@[deprecated] alias fourierIntegral_eq_integral_exp_smul :=
+  fourierIntegral_real_eq_integral_exp_smul -- deprecated on 2024-02-21
 
 end Real

--- a/Mathlib/Analysis/Fourier/PoissonSummation.lean
+++ b/Mathlib/Analysis/Fourier/PoissonSummation.lean
@@ -97,7 +97,7 @@ theorem Real.fourierCoeff_tsum_comp_add {f : C(ℝ, ℂ)}
       exact funext fun n => neK ⟨Icc 0 1, isCompact_Icc⟩ _
     -- Minor tidying to finish
     _ = 𝓕 f m := by
-      rw [fourierIntegral_eq_integral_exp_smul]
+      rw [fourierIntegral_real_eq_integral_exp_smul]
       congr 1 with x : 1
       rw [smul_eq_mul, comp_apply, coe_mk, coe_mk, ContinuousMap.toFun_eq_coe, fourier_coe_apply]
       congr 2

--- a/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
+++ b/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
@@ -23,7 +23,7 @@ spaces `V`: if `f` is a function on `V` (valued in a complete normed space `E`),
 Fourier transform of `f`, viewed as a function on the dual space of `V`, tends to 0 along the
 cocompact filter. Here the Fourier transform is defined by
 
-`fun w : V →L[ℝ] ℝ ↦ ∫ (v : V), exp (↑(2 * π * w v) * I) • f x`.
+`fun w : V →L[ℝ] ℝ ↦ ∫ (v : V), exp (↑(2 * π * w v) * I) • f v`.
 
 This is true for arbitrary functions, but is only interesting for `L¹` functions (if `f` is not
 integrable then the integral is zero for all `w`). This is proved first for continuous
@@ -53,8 +53,6 @@ open scoped Filter Topology Real ENNReal FourierTransform RealInnerProductSpace 
 
 variable {E V : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] {f : V → E}
 
-local notation "e" => Real.fourierChar
-
 section InnerProductSpace
 
 variable [NormedAddCommGroup V] [MeasurableSpace V] [BorelSpace V] [InnerProductSpace ℝ V]
@@ -62,7 +60,7 @@ variable [NormedAddCommGroup V] [MeasurableSpace V] [BorelSpace V] [InnerProduct
 
 /-- The integrand in the Riemann-Lebesgue lemma for `f` is integrable iff `f` is. -/
 theorem fourier_integrand_integrable (w : V) :
-    Integrable f ↔ Integrable fun v : V => e[-⟪v, w⟫] • f v := by
+    Integrable f ↔ Integrable fun v : V => 𝐞[-⟪v, w⟫] • f v := by
   have hL : Continuous fun p : V × V => BilinForm.toLin bilinFormOfRealInner p.1 p.2 :=
     continuous_inner
   rw [VectorFourier.fourier_integral_convergent_iff Real.continuous_fourierChar hL w]
@@ -75,14 +73,14 @@ local notation3 "i" => fun (w : V) => (1 / (2 * ‖w‖ ^ 2) : ℝ) • w
 
 /-- Shifting `f` by `(1 / (2 * ‖w‖ ^ 2)) • w` negates the integral in the Riemann-Lebesgue lemma. -/
 theorem fourier_integral_half_period_translate {w : V} (hw : w ≠ 0) :
-    (∫ v : V, e[-⟪v, w⟫] • f (v + i w)) = -∫ v : V, e[-⟪v, w⟫] • f v := by
+    (∫ v : V, 𝐞[-⟪v, w⟫] • f (v + i w)) = -∫ v : V, 𝐞[-⟪v, w⟫] • f v := by
   have hiw : ⟪i w, w⟫ = 1 / 2 := by
     rw [inner_smul_left, inner_self_eq_norm_sq_to_K, IsROrC.ofReal_real_eq_id, id.def,
       IsROrC.conj_to_real, ← div_div, div_mul_cancel]
     rwa [Ne.def, sq_eq_zero_iff, norm_eq_zero]
   have :
-    (fun v : V => e[-⟪v, w⟫] • f (v + i w)) =
-      fun v : V => (fun x : V => -e[-⟪x, w⟫] • f x) (v + i w) := by
+    (fun v : V => 𝐞[-⟪v, w⟫] • f (v + i w)) =
+      fun v : V => (fun x : V => -𝐞[-⟪x, w⟫] • f x) (v + i w) := by
     ext1 v
     simp_rw [inner_add_left, hiw, Real.fourierChar_apply, neg_add, mul_add, ofReal_add, add_mul,
       exp_add]
@@ -91,10 +89,10 @@ theorem fourier_integral_half_period_translate {w : V} (hw : w ≠ 0) :
   rw [this]
   -- Porting note:
   -- The next three lines had just been
-  -- rw [integral_add_right_eq_self (fun (x : V) ↦ -(e[-⟪x, w⟫]) • f x)
+  -- rw [integral_add_right_eq_self (fun (x : V) ↦ -(𝐞[-⟪x, w⟫]) • f x)
   --       ((fun w ↦ (1 / (2 * ‖w‖ ^ (2 : ℕ))) • w) w)]
   -- Unfortunately now we need to specify `volume`, and call `dsimp`.
-  have := @integral_add_right_eq_self _ _ _ _ _ volume _ _ _ (fun (x : V) ↦ -(e[-⟪x, w⟫]) • f x)
+  have := @integral_add_right_eq_self _ _ _ _ _ volume _ _ _ (fun (x : V) ↦ -(𝐞[-⟪x, w⟫]) • f x)
     ((fun w ↦ (1 / (2 * ‖w‖ ^ (2 : ℕ))) • w) w)
   erw [this] -- Porting note, we can avoid `erw` by first calling `dsimp at this ⊢`.
   simp only [neg_smul, integral_neg]
@@ -103,7 +101,7 @@ theorem fourier_integral_half_period_translate {w : V} (hw : w ≠ 0) :
 /-- Rewrite the Fourier integral in a form that allows us to use uniform continuity. -/
 theorem fourier_integral_eq_half_sub_half_period_translate {w : V} (hw : w ≠ 0)
     (hf : Integrable f) :
-    ∫ v : V, e[-⟪v, w⟫] • f v = (1 / (2 : ℂ)) • ∫ v : V, e[-⟪v, w⟫] • (f v - f (v + i w)) := by
+    ∫ v : V, 𝐞[-⟪v, w⟫] • f v = (1 / (2 : ℂ)) • ∫ v : V, 𝐞[-⟪v, w⟫] • (f v - f (v + i w)) := by
   simp_rw [smul_sub]
   rw [integral_sub, fourier_integral_half_period_translate hw, sub_eq_add_neg, neg_neg, ←
     two_smul ℂ _, ← @smul_assoc _ _ _ _ _ _ (IsScalarTower.left ℂ), smul_eq_mul]
@@ -118,9 +116,9 @@ of interest as a preparatory step for the more general result
 `tendsto_integral_exp_inner_smul_cocompact` in which `f` can be arbitrary. -/
 theorem tendsto_integral_exp_inner_smul_cocompact_of_continuous_compact_support (hf1 : Continuous f)
     (hf2 : HasCompactSupport f) :
-    Tendsto (fun w : V => ∫ v : V, e[-⟪v, w⟫] • f v) (cocompact V) (𝓝 0) := by
+    Tendsto (fun w : V => ∫ v : V, 𝐞[-⟪v, w⟫] • f v) (cocompact V) (𝓝 0) := by
   refine' NormedAddCommGroup.tendsto_nhds_zero.mpr fun ε hε => _
-  suffices ∃ T : ℝ, ∀ w : V, T ≤ ‖w‖ → ‖∫ v : V, e[-⟪v, w⟫] • f v‖ < ε by
+  suffices ∃ T : ℝ, ∀ w : V, T ≤ ‖w‖ → ‖∫ v : V, 𝐞[-⟪v, w⟫] • f v‖ < ε by
     simp_rw [← comap_dist_left_atTop_eq_cocompact (0 : V), eventually_comap, eventually_atTop,
       dist_eq_norm', sub_zero]
     exact
@@ -214,7 +212,7 @@ variable (f)
 /-- Riemann-Lebesgue lemma for functions on a real inner-product space: the integral
 `∫ v, exp (-2 * π * ⟪w, v⟫ * I) • f v` tends to 0 as `w → ∞`. -/
 theorem tendsto_integral_exp_inner_smul_cocompact :
-    Tendsto (fun w : V => ∫ v, e[-⟪v, w⟫] • f v) (cocompact V) (𝓝 0) := by
+    Tendsto (fun w : V => ∫ v, 𝐞[-⟪v, w⟫] • f v) (cocompact V) (𝓝 0) := by
   by_cases hfi : Integrable f; swap
   · convert tendsto_const_nhds (x := (0 : E)) with w
     apply integral_undef
@@ -229,14 +227,14 @@ theorem tendsto_integral_exp_inner_smul_cocompact :
           _ (div_pos hε two_pos)).mp
       (eventually_of_forall fun w hI => _)
   rw [dist_eq_norm] at hI ⊢
-  have : ‖(∫ v, e[-⟪v, w⟫] • f v) - ∫ v, e[-⟪v, w⟫] • g v‖ ≤ ε / 2 := by
+  have : ‖(∫ v, 𝐞[-⟪v, w⟫] • f v) - ∫ v, 𝐞[-⟪v, w⟫] • g v‖ ≤ ε / 2 := by
     refine' le_trans _ hfg
     simp_rw [←
       integral_sub ((fourier_integrand_integrable w).mp hfi)
         ((fourier_integrand_integrable w).mp (hg_cont.integrable_of_hasCompactSupport hg_supp)),
       ← smul_sub, ← Pi.sub_apply]
     exact
-      VectorFourier.norm_fourierIntegral_le_integral_norm e volume
+      VectorFourier.norm_fourierIntegral_le_integral_norm 𝐞 volume
         (BilinForm.toLin bilinFormOfRealInner) (f - g) w
   replace := add_lt_add_of_le_of_lt this hI
   rw [add_halves] at this
@@ -246,7 +244,7 @@ theorem tendsto_integral_exp_inner_smul_cocompact :
 
 /-- The Riemann-Lebesgue lemma for functions on `ℝ`. -/
 theorem Real.tendsto_integral_exp_smul_cocompact (f : ℝ → E) :
-    Tendsto (fun w : ℝ => ∫ v : ℝ, e[-(v * w)] • f v) (cocompact ℝ) (𝓝 0) :=
+    Tendsto (fun w : ℝ => ∫ v : ℝ, 𝐞[-(v * w)] • f v) (cocompact ℝ) (𝓝 0) :=
   tendsto_integral_exp_inner_smul_cocompact f
 #align real.tendsto_integral_exp_smul_cocompact Real.tendsto_integral_exp_smul_cocompact
 
@@ -259,13 +257,13 @@ theorem Real.zero_at_infty_fourierIntegral (f : ℝ → E) : Tendsto (𝓕 f) (c
 via dual space. **Do not use** -- it is only a stepping stone to
 `tendsto_integral_exp_smul_cocompact` where the inner-product-space structure isn't required. -/
 theorem tendsto_integral_exp_smul_cocompact_of_inner_product (μ : Measure V) [μ.IsAddHaarMeasure] :
-    Tendsto (fun w : V →L[ℝ] ℝ => ∫ v, e[-w v] • f v ∂μ) (cocompact (V →L[ℝ] ℝ)) (𝓝 0) := by
+    Tendsto (fun w : V →L[ℝ] ℝ => ∫ v, 𝐞[-w v] • f v ∂μ) (cocompact (V →L[ℝ] ℝ)) (𝓝 0) := by
   rw [μ.isAddLeftInvariant_eq_smul volume]
   simp_rw [integral_smul_nnreal_measure]
   rw [← (smul_zero _ : Measure.addHaarScalarFactor μ volume • (0 : E) = 0)]
   apply Tendsto.const_smul
   let A := (InnerProductSpace.toDual ℝ V).symm
-  have : (fun w : V →L[ℝ] ℝ => ∫ v, e[-w v] • f v) = (fun w : V => ∫ v, e[-⟪v, w⟫] • f v) ∘ A := by
+  have : (fun w : V →L[ℝ] ℝ => ∫ v, 𝐞[-w v] • f v) = (fun w : V => ∫ v, 𝐞[-⟪v, w⟫] • f v) ∘ A := by
     ext1 w
     congr 1 with v : 1
     rw [← inner_conj_symm, IsROrC.conj_to_real, InnerProductSpace.toDual_symm_apply]
@@ -286,7 +284,7 @@ variable (f) [AddCommGroup V] [TopologicalSpace V] [TopologicalAddGroup V] [T2Sp
 /-- Riemann-Lebesgue lemma for functions on a finite-dimensional real vector space, formulated via
 dual space. -/
 theorem tendsto_integral_exp_smul_cocompact (μ : Measure V) [μ.IsAddHaarMeasure] :
-    Tendsto (fun w : V →L[ℝ] ℝ => ∫ v, e[-w v] • f v ∂μ) (cocompact (V →L[ℝ] ℝ)) (𝓝 0) := by
+    Tendsto (fun w : V →L[ℝ] ℝ => ∫ v, 𝐞[-w v] • f v ∂μ) (cocompact (V →L[ℝ] ℝ)) (𝓝 0) := by
   -- We have already proved the result for inner-product spaces, formulated in a way which doesn't
   -- refer to the inner product. So we choose an arbitrary inner-product space isomorphic to V
   -- and port the result over from there.
@@ -343,7 +341,7 @@ theorem tendsto_integral_exp_smul_cocompact (μ : Measure V) [μ.IsAddHaarMeasur
 pairing in the definition of `fourier_integral` taken to be the canonical pairing between `V` and
 its dual space). -/
 theorem Real.zero_at_infty_vector_fourierIntegral (μ : Measure V) [μ.IsAddHaarMeasure] :
-    Tendsto (VectorFourier.fourierIntegral e μ (topDualPairing ℝ V).flip f) (cocompact (V →L[ℝ] ℝ))
+    Tendsto (VectorFourier.fourierIntegral 𝐞 μ (topDualPairing ℝ V).flip f) (cocompact (V →L[ℝ] ℝ))
       (𝓝 0) :=
   _root_.tendsto_integral_exp_smul_cocompact f μ
 #align real.zero_at_infty_vector_fourier_integral Real.zero_at_infty_vector_fourierIntegral

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -1270,6 +1270,11 @@ theorem LinearIsometryEquiv.inner_map_map (f : E ≃ₗᵢ[𝕜] E') (x y : E) :
   f.toLinearIsometry.inner_map_map x y
 #align linear_isometry_equiv.inner_map_map LinearIsometryEquiv.inner_map_map
 
+/-- The adjoint of a linear isometric equivalence is its inverse. -/
+theorem LinearIsometryEquiv.inner_map_eq_flip (f : E ≃ₗᵢ[𝕜] E') (x : E) (y : E') :
+    ⟪f x, y⟫_𝕜 = ⟪x, f.symm y⟫_𝕜 := by
+  conv_lhs => rw [← f.apply_symm_apply y, f.inner_map_map]
+
 /-- A linear map that preserves the inner product is a linear isometry. -/
 def LinearMap.isometryOfInner (f : E →ₗ[𝕜] E') (h : ∀ x y, ⟪f x, f y⟫ = ⟪x, y⟫) : E →ₗᵢ[𝕜] E' :=
   ⟨f, fun x => by simp only [@norm_eq_sqrt_inner 𝕜, h]⟩
@@ -1752,6 +1757,18 @@ theorem innerₛₗ_apply_coe (v : E) : ⇑(innerₛₗ 𝕜 v) = fun w => ⟪v,
 theorem innerₛₗ_apply (v w : E) : innerₛₗ 𝕜 v w = ⟪v, w⟫ :=
   rfl
 #align innerₛₗ_apply innerₛₗ_apply
+
+variable (F)
+/-- The inner product as a bilinear map in the real case. -/
+def innerₗ : F →ₗ[ℝ] F →ₗ[ℝ] ℝ := innerₛₗ ℝ
+
+@[simp] lemma flip_innerₗ : (innerₗ F).flip = innerₗ F := by
+  ext v w
+  exact real_inner_comm v w
+
+variable {F}
+
+@[simp] lemma innerₗ_apply (v w : F) : innerₗ F v w = ⟪v, w⟫_ℝ := rfl
 
 /-- The inner product as a continuous sesquilinear map. Note that `toDualMap` (resp. `toDual`)
 in `InnerProductSpace.Dual` is a version of this given as a linear isometry (resp. linear

--- a/Mathlib/Analysis/SpecialFunctions/Gaussian.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian.lean
@@ -582,7 +582,7 @@ theorem _root_.fourier_transform_gaussian_pi' (hb : 0 < b.re) (c : ℂ) :
   have h : (-↑π * b).re < 0 := by
     simpa only [neg_mul, neg_re, re_ofReal_mul, neg_lt_zero] using mul_pos pi_pos hb
   ext1 t
-  simp_rw [fourierIntegral_eq_integral_exp_smul, smul_eq_mul, ← Complex.exp_add, ← add_assoc]
+  simp_rw [fourierIntegral_real_eq_integral_exp_smul, smul_eq_mul, ← Complex.exp_add, ← add_assoc]
   have (x : ℝ) : ↑(-2 * π * x * t) * I + -π * b * x ^ 2 + 2 * π * c * x =
     -π * b * x ^ 2 + (-2 * π * I * t + 2 * π * c) * x + 0 := by push_cast; ring
   simp_rw [this, integral_cexp_quadratic h, neg_mul, neg_neg]
@@ -596,7 +596,7 @@ theorem _root_.fourier_transform_gaussian_pi' (hb : 0 < b.re) (c : ℂ) :
     ring
 
 theorem _root_.fourier_transform_gaussian_pi (hb : 0 < b.re) :
-    (𝓕 fun x ↦ cexp (-π * b * x ^ 2)) =
+    (𝓕 fun (x : ℝ) ↦ cexp (-π * b * x ^ 2)) =
     fun t : ℝ ↦ 1 / b ^ (1 / 2 : ℂ) * cexp (-π / b * t ^ 2) := by
   simpa only [mul_zero, zero_mul, add_zero] using fourier_transform_gaussian_pi' hb 0
 #align fourier_transform_gaussian_pi fourier_transform_gaussian_pi


### PR DESCRIPTION
Also extend the notation `𝓕` for the Fourier transform to inner product spaces, introduce a notation `𝓕⁻` for the inverse Fourier transform, and generalize a few results from the real line to inner product spaces.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
