### PR TITLE
[Merged by Bors] - feat: Lemmas about `(extChartAt I x).target` being open if we're boundaryless

### DIFF
--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -1393,7 +1393,7 @@ theorem isOpen_extChartAt_target [I.Boundaryless] (x : M) : IsOpen (extChartAt I
   simp_rw [extChartAt_target, I.range_eq_univ, inter_univ]
   exact (PartialHomeomorph.open_target _).preimage I.continuous_symm
 
--- If we're boundaryless, `(extChartAt I x).target` is a neighborhood of the key point -/
+/-- If we're boundaryless, `(extChartAt I x).target` is a neighborhood of the key point -/
 theorem extChartAt_target_mem_nhds [I.Boundaryless] (x : M) :
     (extChartAt I x).target ∈ 𝓝 (extChartAt I x x) := by
   convert extChartAt_target_mem_nhdsWithin I x

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -1388,6 +1388,23 @@ theorem extChartAt_target_mem_nhdsWithin (x : M) :
   extChartAt_target_mem_nhdsWithin' I (mem_extChartAt_source I x)
 #align ext_chart_at_target_mem_nhds_within extChartAt_target_mem_nhdsWithin
 
+/-- If we're boundaryless, `extChartAt` has open target -/
+theorem isOpen_extChartAt_target [I.Boundaryless] (x : M) : IsOpen (extChartAt I x).target := by
+  simp only [extChartAt, PartialHomeomorph.extend, I.range_eq_univ, PartialEquiv.trans_target,
+    I.target_eq, I.toPartialEquiv_coe_symm, univ_inter]
+  exact (PartialHomeomorph.open_target _).preimage I.continuous_symm
+
+-- If we're boundaryless, `(extChartAt I x).target` is a neighborhood of the key point -/
+theorem extChartAt_target_mem_nhds [I.Boundaryless] (x : M) :
+    (extChartAt I x).target ∈ 𝓝 (extChartAt I x x) := by
+  convert extChartAt_target_mem_nhdsWithin I x
+  simp only [I.range_eq_univ, nhdsWithin_univ]
+
+-- If we're boundaryless, `(extChartAt I x).target` is a neighborhood of any of its points -/
+theorem extChartAt_target_mem_nhds' [I.Boundaryless] {x : M} {y : E}
+    (m : y ∈ (extChartAt I x).target) : (extChartAt I x).target ∈ 𝓝 y :=
+  (isOpen_extChartAt_target I x).mem_nhds m
+
 theorem extChartAt_target_subset_range (x : M) : (extChartAt I x).target ⊆ range I := by
   simp only [mfld_simps]
 #align ext_chart_at_target_subset_range extChartAt_target_subset_range

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -1390,8 +1390,7 @@ theorem extChartAt_target_mem_nhdsWithin (x : M) :
 
 /-- If we're boundaryless, `extChartAt` has open target -/
 theorem isOpen_extChartAt_target [I.Boundaryless] (x : M) : IsOpen (extChartAt I x).target := by
-  simp only [extChartAt, PartialHomeomorph.extend, I.range_eq_univ, PartialEquiv.trans_target,
-    I.target_eq, I.toPartialEquiv_coe_symm, univ_inter]
+  simp_rw [extChartAt_target, I.range_eq_univ, inter_univ]
   exact (PartialHomeomorph.open_target _).preimage I.continuous_symm
 
 -- If we're boundaryless, `(extChartAt I x).target` is a neighborhood of the key point -/

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -1399,7 +1399,7 @@ theorem extChartAt_target_mem_nhds [I.Boundaryless] (x : M) :
   convert extChartAt_target_mem_nhdsWithin I x
   simp only [I.range_eq_univ, nhdsWithin_univ]
 
--- If we're boundaryless, `(extChartAt I x).target` is a neighborhood of any of its points -/
+/-- If we're boundaryless, `(extChartAt I x).target` is a neighborhood of any of its points -/
 theorem extChartAt_target_mem_nhds' [I.Boundaryless] {x : M} {y : E}
     (m : y ∈ (extChartAt I x).target) : (extChartAt I x).target ∈ 𝓝 y :=
   (isOpen_extChartAt_target I x).mem_nhds m


### PR DESCRIPTION
`(extChartAt I x).source` is always open, so there are nice lemmas like

1. `isOpen_extChartAt_source`
2. `extChartAt_source_mem_nhds`
3. `extChartAt_source_mem_nhds'`

`(extChartAt I x).target` fails to be open near manifold boundary points, but we recover the nice lemmas when `I.Boundaryless`.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
