### PR TITLE
[Merged by Bors] - chore: generalize typeclasses for `exp` on `DualNumber`

### DIFF
--- a/Mathlib/Analysis/NormedSpace/DualNumber.lean
+++ b/Mathlib/Analysis/NormedSpace/DualNumber.lean
@@ -27,9 +27,9 @@ open TrivSqZeroExt
 
 variable (𝕜 : Type*) {R : Type*}
 
-variable [IsROrC 𝕜] [NormedCommRing R] [NormedAlgebra 𝕜 R]
+variable [Field 𝕜] [CharZero 𝕜] [CommRing R] [Algebra 𝕜 R]
 
-variable [TopologicalRing R] [CompleteSpace R] [T2Space R]
+variable [UniformSpace R] [TopologicalRing R] [CompleteSpace R] [T2Space R]
 
 @[simp]
 theorem exp_eps : exp 𝕜 (eps : DualNumber R) = 1 + eps :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
