### PR TITLE
[Merged by Bors] - chore: `mathlib3` to `mathlib`

### DIFF
--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -995,7 +995,7 @@ def fixAbbreviation : List String → List String
   | "add" :: "_" :: "indicator" :: s  => "indicator" :: fixAbbreviation s
   | "is" :: "Square" :: s             => "even" :: fixAbbreviation s
   | "Is" :: "Square" :: s             => "Even" :: fixAbbreviation s
-  -- "Regular" is well-used in mathlib3 with various meanings (e.g. in
+  -- "Regular" is well-used in mathlib with various meanings (e.g. in
   -- measure theory) and a direct translation
   -- "regular" --> ["add", "Regular"] in `nameDict` above seems error-prone.
   | "is" :: "Regular" :: s            => "isAddRegular" :: fixAbbreviation s


### PR DESCRIPTION
I just noticed this reference to `mathlib3` and updated it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
