### PR TITLE
[Merged by Bors] - fix: add `&` in front of `before, after`

### DIFF
--- a/Mathlib/Tactic/ExtendDoc.lean
+++ b/Mathlib/Tactic/ExtendDoc.lean
@@ -26,7 +26,7 @@ namespace Mathlib.Tactic.ExtendDocs
 
 /-- `extend_docs <declName> before <prefix_string> after <suffix_string>` extends the
 docs of `<declName>` by adding `<prefix_string>` before and `<suffix_string>` after. -/
-syntax "extend_docs" ident (colGt "before" str)? (colGt "after" str)? : command
+syntax "extend_docs" ident (colGt &"before" str)? (colGt &"after" str)? : command
 
 open Lean in
 elab_rules : command


### PR DESCRIPTION
Use `&"before"` and `&"after"` in `ExtendDocs`.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.60after.60.20is.20a.20reserved.20token)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
