### PR TITLE
[Merged by Bors] - feat: define the coroots of a semisimple Lie algebra

### DIFF
--- a/Mathlib/Algebra/Lie/Killing.lean
+++ b/Mathlib/Algebra/Lie/Killing.lean
@@ -692,7 +692,7 @@ lemma root_apply_coroot {α : Weight K H L} (hα : α.IsNonZero) :
 lemma coe_corootSpace_eq_span_singleton (α : Weight K H L) :
     LieSubmodule.toSubmodule (corootSpace α) = K ∙ coroot α := by
   if hα : α.IsZero then
-    simp [α.coe_eq_zero_iff.mpr hα, coroot_eq_zero_iff.mpr hα]
+    simp [hα.eq, coroot_eq_zero_iff.mpr hα]
   else
     set α' := (cartanEquivDual H).symm α
     have hα' : (cartanEquivDual H).symm α ≠ 0 := by simpa using hα

--- a/Mathlib/Algebra/Lie/Killing.lean
+++ b/Mathlib/Algebra/Lie/Killing.lean
@@ -46,6 +46,10 @@ We define the trace / Killing form in this file and prove some basic properties.
  * `LieAlgebra.IsKilling.span_weight_eq_top`: given a splitting Cartan subalgebra `H` of a
    finite-dimensional Lie algebra with non-singular Killing form, the corresponding roots span the
    dual space of `H`.
+ * `LieAlgebra.IsKilling.coroot`: the coroot corresponding to a root.
+ * `LieAlgebra.IsKilling.isCompl_ker_weight_span_coroot`: given a root `α` with respect to a Cartan
+   subalgebra `H`, we have a natural decomposition of `H` as the kernel of `α` and the span of the
+   coroot corresponding to `α`.
 
 ## TODO
 
@@ -210,6 +214,16 @@ lemma trace_toEndomorphism_eq_zero_of_mem_lcs
   · simp
   · simp [hu, hv]
   · simp [hu]
+
+@[simp]
+lemma traceForm_lieSubalgebra_mk_left (L' : LieSubalgebra R L) {x : L} (hx : x ∈ L') (y : L') :
+    traceForm R L' M ⟨x, hx⟩ y = traceForm R L M x y :=
+  rfl
+
+@[simp]
+lemma traceForm_lieSubalgebra_mk_right (L' : LieSubalgebra R L) {x : L'} {y : L} (hy : y ∈ L') :
+    traceForm R L' M x ⟨y, hy⟩ = traceForm R L M x y :=
+  rfl
 
 open TensorProduct
 
@@ -417,6 +431,10 @@ variable [IsKilling R L]
     LinearMap.ker (killingForm R L) = ⊥ := by
   simp [← LieIdeal.coe_killingCompl_top, killingCompl_top_eq_bot]
 
+lemma killingForm_nondegenerate :
+    (killingForm R L).Nondegenerate := by
+  simp [LinearMap.BilinForm.nondegenerate_iff_ker_eq_bot]
+
 /-- If the Killing form of a Lie algebra is non-singular, it remains non-singular when restricted
 to a Cartan subalgebra. -/
 lemma ker_restrict_eq_bot_of_isCartanSubalgebra
@@ -441,6 +459,11 @@ lemma restrict_killingForm (H : LieSubalgebra R L) :
     [IsNoetherian R L] [IsArtinian R L] (H : LieSubalgebra R L) [H.IsCartanSubalgebra] :
     LinearMap.ker (LieModule.traceForm R H L) = ⊥ :=
   ker_restrict_eq_bot_of_isCartanSubalgebra R L H
+
+lemma traceForm_cartan_nondegenerate
+    [IsNoetherian R L] [IsArtinian R L] (H : LieSubalgebra R L) [H.IsCartanSubalgebra] :
+    (LieModule.traceForm R H L).Nondegenerate := by
+  simp [LinearMap.BilinForm.nondegenerate_iff_ker_eq_bot]
 
 /-- The converse of this is true over a field of characteristic zero. There are counterexamples
 over fields with positive characteristic. -/
@@ -474,35 +497,32 @@ namespace LieModule
 variable [LieAlgebra.IsNilpotent K L] [LinearWeights K L M] [IsTriangularizable K L M]
 
 lemma traceForm_eq_sum_finrank_nsmul_mul (x y : L) :
-    traceForm K L M x y = ∑ χ in weight K L M, finrank K (weightSpace M χ) • (χ x * χ y) := by
-  have hxy : ∀ χ : L → K, MapsTo (toEndomorphism K L M x ∘ₗ toEndomorphism K L M y)
+    traceForm K L M x y = ∑ χ : Weight K L M, finrank K (weightSpace M χ) • (χ x * χ y) := by
+  have hxy : ∀ χ : Weight K L M, MapsTo (toEndomorphism K L M x ∘ₗ toEndomorphism K L M y)
       (weightSpace M χ) (weightSpace M χ) :=
     fun χ m hm ↦ LieSubmodule.lie_mem _ <| LieSubmodule.lie_mem _ hm
-  have hfin : {χ : L → K | (weightSpace M χ : Submodule K M) ≠ ⊥}.Finite := by
-    convert finite_weightSpace_ne_bot K L M
-    exact LieSubmodule.coeSubmodule_eq_bot_iff (weightSpace M _)
   classical
   have hds := DirectSum.isInternal_submodule_of_independent_of_iSup_eq_top
-    (LieSubmodule.independent_iff_coe_toSubmodule.mp <| independent_weightSpace K L M)
-    (LieSubmodule.iSup_eq_top_iff_coe_toSubmodule.mp <| iSup_weightSpace_eq_top K L M)
-  simp only [LinearMap.coeFn_sum, Finset.sum_apply, traceForm_apply_apply,
-    LinearMap.trace_eq_sum_trace_restrict' hds hfin hxy]
-  exact Finset.sum_congr (by simp) (fun χ _ ↦ traceForm_weightSpace_eq K L M χ x y)
+    (LieSubmodule.independent_iff_coe_toSubmodule.mp <| independent_weightSpace' K L M)
+    (LieSubmodule.iSup_eq_top_iff_coe_toSubmodule.mp <| iSup_weightSpace_eq_top' K L M)
+  simp_rw [traceForm_apply_apply, LinearMap.trace_eq_sum_trace_restrict hds hxy,
+    ← traceForm_weightSpace_eq K L M _ x y]
+  rfl
 
 lemma traceForm_eq_sum_finrank_nsmul :
-    traceForm K L M = ∑ χ : weight K L M, finrank K (weightSpace M (χ : L → K)) •
-      (weight.toLinear K L M χ).smulRight (weight.toLinear K L M χ) := by
+    traceForm K L M = ∑ χ : Weight K L M, finrank K (weightSpace M χ) •
+      (χ : L →ₗ[K] K).smulRight (χ : L →ₗ[K] K) := by
   ext
   rw [traceForm_eq_sum_finrank_nsmul_mul, ← Finset.sum_attach]
   simp
 
 -- The reverse inclusion should also hold: TODO prove this!
 lemma range_traceForm_le_span_weight :
-    LinearMap.range (traceForm K L M) ≤ span K (range (weight.toLinear K L M)) := by
+    LinearMap.range (traceForm K L M) ≤ span K (range (Weight.toLinear K L M)) := by
   rintro - ⟨x, rfl⟩
   rw [LieModule.traceForm_eq_sum_finrank_nsmul, LinearMap.coeFn_sum, Finset.sum_apply]
   refine Submodule.sum_mem _ fun χ _ ↦ ?_
-  simp_rw [LinearMap.smul_apply, LinearMap.coe_smulRight, weight.toLinear_apply,
+  simp_rw [LinearMap.smul_apply, LinearMap.coe_smulRight, Weight.toLinear_apply,
     nsmul_eq_smul_cast (R := K)]
   exact Submodule.smul_mem _ _ <| Submodule.smul_mem _ _ <| subset_span <| mem_range_self χ
 
@@ -537,63 +557,176 @@ lemma killingForm_apply_eq_zero_of_mem_rootSpace_of_add_ne_zero {α β : H → K
     (LieSubmodule.iSup_eq_top_iff_coe_toSubmodule.mp <| iSup_weightSpace_eq_top K H L)
   exact LinearMap.trace_eq_zero_of_mapsTo_ne hds σ hσ hf
 
+/-- Elements of the `α` root space which are Killing-orthogonal to the `-α` root space are
+Killing-orthogonal to all of `L`. -/
+lemma mem_ker_killingForm_of_mem_rootSpace_of_forall_rootSpace_neg
+    {α : H → K} {x : L} (hx : x ∈ rootSpace H α)
+    (hx' : ∀ y ∈ rootSpace H (-α), killingForm K L x y = 0) :
+    x ∈ LinearMap.ker (killingForm K L) := by
+  rw [LinearMap.mem_ker]
+  ext y
+  have hy : y ∈ ⨆ β, rootSpace H β := by simp [iSup_weightSpace_eq_top K H L]
+  induction hy using LieSubmodule.iSup_induction'
+  · next β y hy =>
+    by_cases hαβ : α + β = 0
+    · exact hx' _ (add_eq_zero_iff_neg_eq.mp hαβ ▸ hy)
+    · exact killingForm_apply_eq_zero_of_mem_rootSpace_of_add_ne_zero K L H hx hy hαβ
+  · simp
+  · simp_all
+
 namespace IsKilling
 
 variable [IsKilling K L]
+
+variable {K L} in
+/-- The restriction of the Killing form to a Cartan subalgebra, as a linear equivalence to the
+dual. -/
+@[simps!]
+noncomputable def cartanEquivDual :
+    H ≃ₗ[K] Module.Dual K H :=
+  (traceForm K H L).toDual <| traceForm_cartan_nondegenerate K L H
+
+/-- This is Proposition 4.18 from [carter2005] except that we use
+`LieModule.exists_forall_lie_eq_smul` instead of Lie's theorem (and so avoid
+assuming `K` has characteristic zero). -/
+lemma cartanEquivDual_symm_apply_mem_corootSpace (α : Weight K H L) :
+    (cartanEquivDual H).symm α ∈ corootSpace α := by
+  obtain ⟨e, he₀, he⟩ := exists_forall_lie_eq_smul K H L α
+  have heα : e ∈ rootSpace H α := (mem_weightSpace L α e).mpr fun x ↦ ⟨1, by simp [← he x]⟩
+  obtain ⟨f, hfα, hf⟩ : ∃ f ∈ rootSpace H (-α), killingForm K L e f ≠ 0 := by
+    contrapose! he₀
+    simpa using mem_ker_killingForm_of_mem_rootSpace_of_forall_rootSpace_neg K L H heα he₀
+  suffices ⁅e, f⁆ = killingForm K L e f • ((cartanEquivDual H).symm α : L) from
+    (mem_corootSpace α).mpr <| Submodule.subset_span ⟨(killingForm K L e f)⁻¹ • e,
+      Submodule.smul_mem _ _ heα, f, hfα, by simpa [inv_smul_eq_iff₀ hf]⟩
+  set α' := (cartanEquivDual H).symm α
+  rw [← sub_eq_zero, ← Submodule.mem_bot (R := K), ← ker_killingForm_eq_bot]
+  apply mem_ker_killingForm_of_mem_rootSpace_of_forall_rootSpace_neg (α := (0 : H → K))
+  · simp only [rootSpace_zero_eq, LieSubalgebra.mem_toLieSubmodule]
+    refine sub_mem ?_ (H.smul_mem _ α'.property)
+    simpa using mapsTo_toEndomorphism_weightSpace_add_of_mem_rootSpace K L H L α (-α) heα hfα
+  · intro z hz
+    replace hz : z ∈ H := by simpa using hz
+    replace he : ⁅z, e⁆ = α ⟨z, hz⟩ • e := by simpa using he ⟨z, hz⟩
+    have hαz : killingForm K L α' (⟨z, hz⟩ : H) = α ⟨z, hz⟩ :=
+      LinearMap.BilinForm.apply_toDual_symm_apply (hB := traceForm_cartan_nondegenerate K L H) _ _
+    simp [traceForm_comm K L L ⁅e, f⁆, ← traceForm_apply_lie_apply, he, mul_comm _ (α ⟨z, hz⟩), hαz]
 
 /-- Given a splitting Cartan subalgebra `H` of a finite-dimensional Lie algebra with non-singular
 Killing form, the corresponding roots span the dual space of `H`. -/
 @[simp]
 lemma span_weight_eq_top :
-    span K (range (weight.toLinear K H L)) = ⊤ := by
+    span K (range (Weight.toLinear K H L)) = ⊤ := by
   refine eq_top_iff.mpr (le_trans ?_ (LieModule.range_traceForm_le_span_weight K H L))
   rw [← traceForm_flip K H L, ← LinearMap.dualAnnihilator_ker_eq_range_flip,
     ker_traceForm_eq_bot_of_isCartanSubalgebra, Submodule.dualAnnihilator_bot]
 
 @[simp]
 lemma iInf_ker_weight_eq_bot :
-    ⨅ α : weight K H L, LinearMap.ker (weight.toLinear K H L α) = ⊥ := by
+    ⨅ α : Weight K H L, α.ker = ⊥ := by
   rw [← Subspace.dualAnnihilator_inj, Subspace.dualAnnihilator_iInf_eq,
     Submodule.dualAnnihilator_bot]
   simp [← LinearMap.range_dualMap_eq_dualAnnihilator_ker, ← Submodule.span_range_eq_iSup]
 
 @[simp]
-lemma rootSpaceProductNegSelf_zero_eq_bot :
-    (rootSpaceProductNegSelf (0 : H → K)).range = ⊥ := by
+lemma corootSpace_zero_eq_bot :
+    corootSpace (0 : H → K) = ⊥ := by
   refine eq_bot_iff.mpr fun x hx ↦ ?_
-  suffices {x | ∃ y ∈ H, ∃ z ∈ H, ⁅y, z⁆ = x} = {0} by
-    rw [LieSubmodule.mem_bot]
-    simpa [-LieModuleHom.mem_range, this, mem_range_rootSpaceProductNegSelf] using hx
+  suffices {x | ∃ y ∈ H, ∃ z ∈ H, ⁅y, z⁆ = x} = {0} by simpa [mem_corootSpace, this] using hx
   refine eq_singleton_iff_unique_mem.mpr ⟨⟨0, H.zero_mem, 0, H.zero_mem, zero_lie 0⟩, ?_⟩
   rintro - ⟨y, hy, z, hz, rfl⟩
   suffices ⁅(⟨y, hy⟩ : H), (⟨z, hz⟩ : H)⁆ = 0 by
     simpa only [Subtype.ext_iff, LieSubalgebra.coe_bracket, ZeroMemClass.coe_zero] using this
   simp
 
+section CharZero
+
 variable {K H L}
+variable [CharZero K]
 
 /-- The contrapositive of this result is very useful, taking `x` to be the element of `H`
 corresponding to a root `α` under the identification between `H` and `H^*` provided by the Killing
 form. -/
-lemma eq_zero_of_apply_eq_zero_of_mem_rootSpaceProductNegSelf [CharZero K]
-    (x : H) (α : H → K) (hαx : α x = 0) (hx : x ∈ (rootSpaceProductNegSelf α).range) :
+lemma eq_zero_of_apply_eq_zero_of_mem_corootSpace
+    (x : H) (α : H → K) (hαx : α x = 0) (hx : x ∈ corootSpace α) :
     x = 0 := by
   rcases eq_or_ne α 0 with rfl | hα; · simpa using hx
-  replace hx : x ∈ ⨅ β : weight K H L, LinearMap.ker (weight.toLinear K H L β) := by
-    simp only [Submodule.mem_iInf, Subtype.forall, Finite.mem_toFinset]
-    intro β hβ
-    obtain ⟨a, b, hb, hab⟩ := exists_forall_mem_rootSpaceProductNegSelf_smul_add_eq_zero L α β hα hβ
+  replace hx : x ∈ ⨅ β : Weight K H L, β.ker := by
+    refine (Submodule.mem_iInf _).mpr fun β ↦ ?_
+    obtain ⟨a, b, hb, hab⟩ :=
+      exists_forall_mem_corootSpace_smul_add_eq_zero L α β hα β.weightSpace_ne_bot
     simpa [hαx, hb.ne'] using hab _ hx
   simpa using hx
 
--- When `α ≠ 0`, this can be upgraded to `IsCompl`; moreover these complements are orthogonal with
--- respect to the Killing form. TODO prove this!
-lemma ker_weight_inf_rootSpaceProductNegSelf_eq_bot [CharZero K] (α : weight K H L) :
-    LinearMap.ker (weight.toLinear K H L α) ⊓ (rootSpaceProductNegSelf (α : H → K)).range = ⊥ := by
-  rw [LieIdeal.coe_to_lieSubalgebra_to_submodule, LieModuleHom.coeSubmodule_range]
+lemma disjoint_ker_weight_corootSpace (α : Weight K H L) :
+    Disjoint α.ker (corootSpace α) := by
+  rw [disjoint_iff]
   refine (Submodule.eq_bot_iff _).mpr fun x ⟨hαx, hx⟩ ↦ ?_
-  replace hαx : (α : H → K) x = 0 := by simpa using hαx
-  exact eq_zero_of_apply_eq_zero_of_mem_rootSpaceProductNegSelf x α hαx hx
+  replace hαx : α x = 0 := by simpa using hαx
+  exact eq_zero_of_apply_eq_zero_of_mem_corootSpace x α hαx hx
+
+/-- The coroot corresponding to a root. -/
+noncomputable def coroot (α : Weight K H L) : H :=
+  2 • (α <| (cartanEquivDual H).symm α)⁻¹ • (cartanEquivDual H).symm α
+
+lemma root_apply_cartanEquivDual_symm_ne_zero {α : Weight K H L} (hα : α.IsNonZero) :
+    α ((cartanEquivDual H).symm α) ≠ 0 := by
+  contrapose! hα
+  suffices (cartanEquivDual H).symm α ∈ α.ker ⊓ corootSpace α by
+    rw [(disjoint_ker_weight_corootSpace α).eq_bot] at this
+    simpa using this
+  exact Submodule.mem_inf.mp ⟨hα, cartanEquivDual_symm_apply_mem_corootSpace K L H α⟩
+
+lemma root_apply_coroot {α : Weight K H L} (hα : α.IsNonZero) :
+    α (coroot α) = 2 := by
+  rw [← Weight.coe_coe]
+  simpa [coroot] using inv_mul_cancel (root_apply_cartanEquivDual_symm_ne_zero hα)
+
+@[simp] lemma coroot_eq_zero_iff {α : Weight K H L} :
+    coroot α = 0 ↔ α.IsZero := by
+  refine ⟨fun hα ↦ ?_, fun hα ↦ ?_⟩
+  · by_contra contra
+    simpa [hα, ← α.coe_coe, map_zero] using root_apply_coroot contra
+  · simp [coroot, Weight.coe_toLinear_eq_zero_iff.mpr hα]
+
+lemma coe_corootSpace_eq_span_singleton (α : Weight K H L) :
+    LieSubmodule.toSubmodule (corootSpace α) = K ∙ coroot α := by
+  if hα : α.IsZero then
+    simp [α.coe_eq_zero_iff.mpr hα, coroot_eq_zero_iff.mpr hα]
+  else
+    set α' := (cartanEquivDual H).symm α
+    have hα' : (cartanEquivDual H).symm α ≠ 0 := by simpa using hα
+    have h₁ : (K ∙ coroot α) = K ∙ α' := by
+      have : IsUnit (2 * (α α')⁻¹) := by simpa using root_apply_cartanEquivDual_symm_ne_zero hα
+      change (K ∙ (2 • (α α')⁻¹ • α')) = _
+      simpa [nsmul_eq_smul_cast (R := K), smul_smul] using Submodule.span_singleton_smul_eq this _
+    have h₂ : (K ∙ (cartanEquivDual H).symm α : Submodule K H) ≤ corootSpace α := by
+      simpa using cartanEquivDual_symm_apply_mem_corootSpace K L H α
+    suffices finrank K (LieSubmodule.toSubmodule (corootSpace α)) ≤ 1 by
+      rw [← finrank_span_singleton (K := K) hα'] at this
+      exact h₁ ▸ (eq_of_le_of_finrank_le h₂ this).symm
+    have h : finrank K H = finrank K α.ker + 1 :=
+      (Module.Dual.finrank_ker_add_one_of_ne_zero <| Weight.coe_toLinear_ne_zero_iff.mpr hα).symm
+    simpa [h] using Submodule.finrank_add_finrank_le_of_disjoint (disjoint_ker_weight_corootSpace α)
+
+@[simp]
+lemma corootSpace_eq_bot_iff {α : Weight K H L} :
+    corootSpace α = ⊥ ↔ α.IsZero := by
+  simp [← LieSubmodule.coeSubmodule_eq_bot_iff, coe_corootSpace_eq_span_singleton α]
+
+lemma isCompl_ker_weight_span_coroot (α : Weight K H L) :
+    IsCompl α.ker (K ∙ coroot α) := by
+  if hα : α.IsZero then
+    simpa [Weight.coe_toLinear_eq_zero_iff.mpr hα, coroot_eq_zero_iff.mpr hα, Weight.ker]
+      using isCompl_top_bot
+  else
+    rw [← coe_corootSpace_eq_span_singleton]
+    apply Module.Dual.isCompl_ker_of_disjoint_of_ne_bot (by aesop)
+      (disjoint_ker_weight_corootSpace α)
+    replace hα : corootSpace α ≠ ⊥ := by simpa using hα
+    rwa [ne_eq, ← LieSubmodule.coe_toSubmodule_eq_iff] at hα
+
+end CharZero
 
 end IsKilling
 
@@ -611,7 +744,7 @@ respective Killing forms of `L` and `L'` satisfy `κ'(e x, e y) = κ(x, y)`. -/
 
 /-- Given a Killing Lie algebra `L`, if `L'` is isomorphic to `L`, then `L'` is Killing too. -/
 lemma isKilling_of_equiv [IsKilling R L] (e : L ≃ₗ⁅R⁆ L') : IsKilling R L' := by
-  constructor;
+  constructor
   ext x'
   rw [LieIdeal.mem_killingCompl]
   refine ⟨fun hx' ↦ ?_, fun hx y _ ↦ hx ▸ LinearMap.map_zero₂ (killingForm R L') y⟩

--- a/Mathlib/Algebra/Lie/Killing.lean
+++ b/Mathlib/Algebra/Lie/Killing.lean
@@ -591,7 +591,7 @@ noncomputable def cartanEquivDual :
 assuming `K` has characteristic zero). -/
 lemma cartanEquivDual_symm_apply_mem_corootSpace (α : Weight K H L) :
     (cartanEquivDual H).symm α ∈ corootSpace α := by
-  obtain ⟨e, he₀, he⟩ := exists_forall_lie_eq_smul K H L α
+  obtain ⟨e : L, he₀ : e ≠ 0, he : ∀ x, ⁅x, e⁆ = α x • e⟩ := exists_forall_lie_eq_smul K H L α
   have heα : e ∈ rootSpace H α := (mem_weightSpace L α e).mpr fun x ↦ ⟨1, by simp [← he x]⟩
   obtain ⟨f, hfα, hf⟩ : ∃ f ∈ rootSpace H (-α), killingForm K L e f ≠ 0 := by
     contrapose! he₀

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -29,6 +29,7 @@ Basic definitions and properties of the above ideas are provided in this file.
 
   * `LieModule.weightSpaceOf`
   * `LieModule.weightSpace`
+  * `LieModule.Weight`
   * `LieModule.posFittingCompOf`
   * `LieModule.posFittingComp`
   * `LieModule.iSup_ucs_eq_weightSpace_zero`
@@ -183,6 +184,48 @@ theorem mem_weightSpace (χ : L → R) (m : M) :
 lemma weightSpace_le_weightSpaceOf (x : L) (χ : L → R) :
     weightSpace M χ ≤ weightSpaceOf M (χ x) x :=
   iInf_le _ x
+
+variable (R L) in
+/-- A weight of a Lie module is a map `L → R` such that the corresponding weight space is is
+non-trivial. -/
+structure Weight where
+  /-- The family of eigenvalues corresponding to a weight. -/
+  toFun : L → R
+  weightSpace_ne_bot : weightSpace M toFun ≠ ⊥
+
+namespace Weight
+
+instance instFunLike :
+    FunLike (Weight R L M) L R where
+  coe χ := χ.1
+  coe_injective' χ₁ χ₂ h := by cases χ₁; cases χ₂; simp_all
+
+@[simp] lemma coe_weight_mk (χ : L → R) (h) :
+    (↑(⟨χ, h⟩ : Weight R L M) : L → R) = χ :=
+  rfl
+
+variable {M}
+
+/-- The proposition that a weight of a Lie module is zero.
+
+We make this definition because we cannot define a `Zero (Weight R L M)` instance since the weight
+space of the zero function can be trivial. -/
+def IsZero (χ : Weight R L M) := (χ : L → R) = 0
+
+@[simp] lemma coe_eq_zero_iff (χ : Weight R L M) : (χ : L → R) = 0 ↔ χ.IsZero := Iff.rfl
+
+/-- The proposition that a weight of a Lie module is non-zero. -/
+abbrev IsNonZero (χ : Weight R L M) := ¬ IsZero (χ : Weight R L M)
+
+variable (R L M) in
+/-- The set of weights is equivalent to a subtype. -/
+def equivSetOf : Weight R L M ≃ {χ : L → R | weightSpace M χ ≠ ⊥} where
+  toFun w := ⟨w.1, w.2⟩
+  invFun w := ⟨w.1, w.2⟩
+  left_inv w := by simp
+  right_inv w := by simp
+
+end Weight
 
 /-- See also the more useful form `LieModule.zero_weightSpace_eq_top_of_nilpotent`. -/
 @[simp]
@@ -547,6 +590,9 @@ lemma injOn_weightSpace [NoZeroSMulDivisors R M] :
   contrapose! hχ₂
   simpa [hχ₁₂] using disjoint_weightSpace R L M hχ₂
 
+/-- Lie module weight spaces are independent.
+
+See also `LieModule.independent_weightSpace'`. -/
 lemma independent_weightSpace [NoZeroSMulDivisors R M] :
     CompleteLattice.Independent fun (χ : L → R) ↦ weightSpace M χ := by
   classical
@@ -588,6 +634,11 @@ lemma independent_weightSpace [NoZeroSMulDivisors R M] :
     rintro - ⟨u, hu, rfl⟩
     exact LieSubmodule.mapsTo_pow_toEndomorphism_sub_algebraMap _ hu
 
+lemma independent_weightSpace' [NoZeroSMulDivisors R M] :
+    CompleteLattice.Independent fun χ : Weight R L M ↦ weightSpace M χ :=
+  (independent_weightSpace R L M).comp <|
+    Subtype.val_injective.comp (Weight.equivSetOf R L M).injective
+
 lemma independent_weightSpaceOf [NoZeroSMulDivisors R M] (x : L) :
     CompleteLattice.Independent fun (χ : R) ↦ weightSpaceOf M χ x := by
   rw [LieSubmodule.independent_iff_coe_toSubmodule]
@@ -603,9 +654,14 @@ lemma finite_weightSpace_ne_bot [NoZeroSMulDivisors R M] [IsNoetherian R M] :
   CompleteLattice.WellFounded.finite_ne_bot_of_independent
     (LieSubmodule.wellFounded_of_noetherian R L M) (independent_weightSpace R L M)
 
-/-- The collection of weights of a Noetherian Lie module, bundled as a `Finset`. -/
-noncomputable abbrev weight [NoZeroSMulDivisors R M] [IsNoetherian R M] :=
-  (finite_weightSpace_ne_bot R L M).toFinset
+instance Weight.instFinite [NoZeroSMulDivisors R M] [IsNoetherian R M] :
+    Finite (Weight R L M) := by
+  have : Finite {χ : L → R | weightSpace M χ ≠ ⊥} := finite_weightSpace_ne_bot R L M
+  exact Finite.of_injective (equivSetOf R L M) (equivSetOf R L M).injective
+
+noncomputable instance Weight.instFintype [NoZeroSMulDivisors R M] [IsNoetherian R M] :
+    Fintype (Weight R L M) :=
+  Fintype.ofFinite _
 
 /-- A Lie module `M` of a Lie algebra `L` is triangularizable if the endomorhpism of `M` defined by
 any `x : L` is triangularizable. -/
@@ -647,6 +703,9 @@ instance (N : LieSubmodule K L M) [IsTriangularizable K L M] : IsTriangularizabl
   rw [← N.toEndomorphism_restrict_eq_toEndomorphism y]
   exact Module.End.iSup_generalizedEigenspace_restrict_eq_top _ (IsTriangularizable.iSup_eq_top y)
 
+/-- For a triangularizable Lie module in finite dimensions, the weight spaces span the entire space.
+
+See also `LieModule.iSup_weightSpace_eq_top'`. -/
 lemma iSup_weightSpace_eq_top [IsTriangularizable K L M] :
     ⨆ χ : L → K, weightSpace M χ = ⊤ := by
   clear! R -- cf https://github.com/leanprover/lean4/issues/2452
@@ -678,6 +737,12 @@ lemma iSup_weightSpace_eq_top [IsTriangularizable K L M] :
         LieSubmodule.range_incl]
     simpa only [← ih, iSup_comm (ι := K), iSup_iSup_eq_right] using
       iSup_weightSpaceOf_eq_top K L M y
+
+lemma iSup_weightSpace_eq_top' [IsTriangularizable K L M] :
+    ⨆ χ : Weight K L M, weightSpace M χ = ⊤ := by
+  have := iSup_weightSpace_eq_top K L M
+  erw [← iSup_ne_bot_subtype, ← (Weight.equivSetOf K L M).iSup_comp] at this
+  exact this
 
 end field
 

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -211,6 +211,8 @@ We make this definition because we cannot define a `Zero (Weight R L M)` instanc
 space of the zero function can be trivial. -/
 def IsZero (χ : Weight R L M) := (χ : L → R) = 0
 
+@[simp] lemma IsZero.eq {χ : Weight R L M} (hχ : χ.IsZero) : (χ : L → R) = 0 := hχ
+
 @[simp] lemma coe_eq_zero_iff (χ : Weight R L M) : (χ : L → R) = 0 ↔ χ.IsZero := Iff.rfl
 
 /-- The proposition that a weight of a Lie module is non-zero. -/

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -186,7 +186,7 @@ lemma weightSpace_le_weightSpaceOf (x : L) (χ : L → R) :
   iInf_le _ x
 
 variable (R L) in
-/-- A weight of a Lie module is a map `L → R` such that the corresponding weight space is is
+/-- A weight of a Lie module is a map `L → R` such that the corresponding weight space is
 non-trivial. -/
 structure Weight where
   /-- The family of eigenvalues corresponding to a weight. -/

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -195,8 +195,7 @@ structure Weight where
 
 namespace Weight
 
-instance instFunLike :
-    FunLike (Weight R L M) L R where
+instance instFunLike : FunLike (Weight R L M) L R where
   coe χ := χ.1
   coe_injective' χ₁ χ₂ h := by cases χ₁; cases χ₂; simp_all
 

--- a/Mathlib/Algebra/Lie/Weights/Cartan.lean
+++ b/Mathlib/Algebra/Lie/Weights/Cartan.lean
@@ -250,7 +250,7 @@ variable [H.IsCartanSubalgebra] [IsNoetherian R L] (α : H → R)
 an element of the `α` root space and an element of the `-α` root space. Informally it is often
 denoted `⁅H(α), H(-α)⁆`.
 
-When `L` is semisimple over a field of characteristic zero, it is spanned by corresponding coroot
+When `L` is semisimple over a field of characteristic zero, it is spanned by the coroot
 corresponding to `α`, see `LieAlgebra.IsKilling.coe_corootSpace_eq_span_singleton`.
 
 Note that the name "coroot space" is not standard as this space does not seem to have a name in the

--- a/Mathlib/Algebra/Lie/Weights/Cartan.lean
+++ b/Mathlib/Algebra/Lie/Weights/Cartan.lean
@@ -277,7 +277,7 @@ lemma mem_corootSpace {x : H} :
 
 lemma mem_corootSpace' {x : H} :
     x ∈ corootSpace α ↔
-    x ∈ Submodule.span R {u : H | ∃ᵉ (y ∈ rootSpace H α) (z ∈ rootSpace H (-α)), ⁅y, z⁆ = u} := by
+    x ∈ Submodule.span R ({⁅y, z⁆ | (y ∈ rootSpace H α) (z ∈ rootSpace H (-α))} : Set H) := by
   set s : Set H := {u : H | ∃ᵉ (y ∈ rootSpace H α) (z ∈ rootSpace H (-α)), ⁅y, z⁆ = u}
   suffices H.subtype '' s = {⁅y, z⁆ | (y ∈ rootSpace H α) (z ∈ rootSpace H (-α))} by
     obtain ⟨x, hx⟩ := x

--- a/Mathlib/Algebra/Lie/Weights/Cartan.lean
+++ b/Mathlib/Algebra/Lie/Weights/Cartan.lean
@@ -278,7 +278,7 @@ lemma mem_corootSpace {x : H} :
 lemma mem_corootSpace' {x : H} :
     x ∈ corootSpace α ↔
     x ∈ Submodule.span R ({⁅y, z⁆ | (y ∈ rootSpace H α) (z ∈ rootSpace H (-α))} : Set H) := by
-  set s : Set H := {u : H | ∃ᵉ (y ∈ rootSpace H α) (z ∈ rootSpace H (-α)), ⁅y, z⁆ = u}
+  set s : Set H := ({⁅y, z⁆ | (y ∈ rootSpace H α) (z ∈ rootSpace H (-α))} : Set H)
   suffices H.subtype '' s = {⁅y, z⁆ | (y ∈ rootSpace H α) (z ∈ rootSpace H (-α))} by
     obtain ⟨x, hx⟩ := x
     erw [← (H : Submodule R L).injective_subtype.mem_set_image (s := Submodule.span R s)]

--- a/Mathlib/Algebra/Lie/Weights/Cartan.lean
+++ b/Mathlib/Algebra/Lie/Weights/Cartan.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
 import Mathlib.Algebra.Lie.CartanSubalgebra
-import Mathlib.Algebra.Lie.Character
 import Mathlib.Algebra.Lie.Weights.Basic
 
 /-!
@@ -19,9 +18,8 @@ Basic definitions and properties of the above ideas are provided in this file.
 
 ## Main definitions
 
-  * `LieModule.IsWeight`
   * `LieAlgebra.rootSpace`
-  * `LieAlgebra.IsRoot`
+  * `LieAlgebra.corootSpace`
   * `LieAlgebra.rootSpaceWeightSpaceProduct`
   * `LieAlgebra.rootSpaceProduct`
   * `LieAlgebra.zeroRootSubalgebra_eq_iff_is_cartan`
@@ -35,28 +33,6 @@ open Set
 variable {R L : Type*} [CommRing R] [LieRing L] [LieAlgebra R L]
   (H : LieSubalgebra R L) [LieAlgebra.IsNilpotent R H]
   {M : Type*} [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
-
-namespace LieModule
-
-open LieAlgebra TensorProduct TensorProduct.LieModule
-open scoped BigOperators TensorProduct
-
-variable (M)
-
-/-- Given a Lie module `M` of a Lie algebra `L`, a weight of `M` with respect to a nilpotent
-subalgebra `H ⊆ L` is a Lie character whose corresponding weight space is non-empty. -/
-def IsWeight (χ : LieCharacter R H) : Prop :=
-  weightSpace M χ ≠ ⊥
-#align lie_module.is_weight LieModule.IsWeight
-
-/-- For a non-trivial nilpotent Lie module over a nilpotent Lie algebra, the zero character is a
-weight with respect to the `⊤` Lie subalgebra. -/
-theorem isWeight_zero_of_nilpotent [Nontrivial M] [LieAlgebra.IsNilpotent R L] [IsNilpotent R L M] :
-    IsWeight (⊤ : LieSubalgebra R L) M 0 := by
-  rw [IsWeight, LieHom.coe_zero, zero_weightSpace_eq_top_of_nilpotent]; exact top_ne_bot
-#align lie_module.is_weight_zero_of_nilpotent LieModule.isWeight_zero_of_nilpotent
-
-end LieModule
 
 namespace LieAlgebra
 
@@ -73,12 +49,6 @@ theorem zero_rootSpace_eq_top_of_nilpotent [IsNilpotent R L] :
     rootSpace (⊤ : LieSubalgebra R L) 0 = ⊤ :=
   zero_weightSpace_eq_top_of_nilpotent L
 #align lie_algebra.zero_root_space_eq_top_of_nilpotent LieAlgebra.zero_rootSpace_eq_top_of_nilpotent
-
-/-- A root of a Lie algebra `L` with respect to a nilpotent subalgebra `H ⊆ L` is a weight of `L`,
-regarded as a module of `H` via the adjoint action. -/
-abbrev IsRoot (χ : LieCharacter R H) :=
-  χ ≠ 0 ∧ IsWeight H L χ
-#align lie_algebra.is_root LieAlgebra.IsRoot
 
 @[simp]
 theorem rootSpace_comap_eq_weightSpace (χ : H → R) :
@@ -276,33 +246,51 @@ theorem rootSpace_zero_eq (H : LieSubalgebra R L) [H.IsCartanSubalgebra] [IsNoet
 variable {R L H}
 variable [H.IsCartanSubalgebra] [IsNoetherian R L] (α : H → R)
 
-/-- Given a root `α`, the Lie bracket restricted to the product of the root space of `α` and `-α`
-takes value in the Cartan subalgebra.
+/-- Given a root `α` relative to a Cartan subalgebra `H`, this is the span of all products of
+an element of the `α` root space and an element of the `-α` root space. Informally it is often
+denoted `⁅H(α), H(-α)⁆`.
 
-When `L` is semisimple, the image of this map is one-dimensional and is spanned by the corresponding
-coroot. -/
-def rootSpaceProductNegSelf : rootSpace H α ⊗[R] rootSpace H (-α) →ₗ⁅R,H⁆ H :=
-  ((rootSpace H 0).incl.comp <| rootSpaceProduct R L H α (-α) 0 (add_neg_self α)).codRestrict
-    H.toLieSubmodule (by
+When `L` is semisimple over a field of characteristic zero, it is spanned by corresponding coroot
+corresponding to `α`, see `LieAlgebra.IsKilling.coe_corootSpace_eq_span_singleton`.
+
+Note that the name "coroot space" is not standard as this space does not seem to have a name in the
+informal literature. -/
+def corootSpace : LieIdeal R H :=
+  LieModuleHom.range <| ((rootSpace H 0).incl.comp <|
+    rootSpaceProduct R L H α (-α) 0 (add_neg_self α)).codRestrict H.toLieSubmodule (by
   rw [← rootSpace_zero_eq]
   exact fun p ↦ (rootSpaceProduct R L H α (-α) 0 (add_neg_self α) p).property)
 
-@[simp]
-lemma coe_rootSpaceProductNegSelf_apply (x : rootSpace H α) (y : rootSpace H (-α)) :
-    (rootSpaceProductNegSelf α (x ⊗ₜ y) : L) = ⁅(x : L), (y : L)⁆ :=
-  rfl
-
-lemma mem_range_rootSpaceProductNegSelf {x : H} :
-    x ∈ (rootSpaceProductNegSelf α).range ↔
+lemma mem_corootSpace {x : H} :
+    x ∈ corootSpace α ↔
     (x : L) ∈ Submodule.span R {⁅y, z⁆ | (y ∈ rootSpace H α) (z ∈ rootSpace H (-α))} := by
-  have : x ∈ (rootSpaceProductNegSelf α).range ↔
-      (x : L) ∈ (rootSpaceProductNegSelf α).range.map H.toLieSubmodule.incl := by
+  have : x ∈ corootSpace α ↔
+      (x : L) ∈ LieSubmodule.map H.toLieSubmodule.incl (corootSpace α) := by
+    rw [corootSpace]
     simpa using exists_congr fun _ ↦ H.toLieSubmodule.injective_incl.eq_iff.symm
-  simp_rw [this, ← LieModuleHom.map_top, ← LieSubmodule.mem_coeSubmodule,
+  simp_rw [this, corootSpace, ← LieModuleHom.map_top, ← LieSubmodule.mem_coeSubmodule,
     LieSubmodule.coeSubmodule_map, LieSubmodule.top_coeSubmodule, ← TensorProduct.span_tmul_eq_top,
     LinearMap.map_span, Set.image, Set.mem_setOf_eq, exists_exists_exists_and_eq]
   change (x : L) ∈ Submodule.span R
     {x | ∃ (a : rootSpace H α) (b : rootSpace H (-α)), ⁅(a : L), (b : L)⁆ = x} ↔ _
   simp
+
+lemma mem_corootSpace' {x : H} :
+    x ∈ corootSpace α ↔
+    x ∈ Submodule.span R {u : H | ∃ᵉ (y ∈ rootSpace H α) (z ∈ rootSpace H (-α)), ⁅y, z⁆ = u} := by
+  set s : Set H := {u : H | ∃ᵉ (y ∈ rootSpace H α) (z ∈ rootSpace H (-α)), ⁅y, z⁆ = u}
+  suffices H.subtype '' s = {⁅y, z⁆ | (y ∈ rootSpace H α) (z ∈ rootSpace H (-α))} by
+    obtain ⟨x, hx⟩ := x
+    erw [← (H : Submodule R L).injective_subtype.mem_set_image (s := Submodule.span R s)]
+    change _ ↔ x ∈ (Submodule.span R s).map H.subtype
+    rw [Submodule.map_span, mem_corootSpace, ← this]
+    rfl
+  ext u
+  simp only [Submodule.coeSubtype, mem_image, Subtype.exists, LieSubalgebra.mem_coe_submodule,
+    exists_and_right, exists_eq_right, mem_setOf_eq, s]
+  refine ⟨fun ⟨_, y, hy, z, hz, hyz⟩ ↦ ⟨y, hy, z, hz, hyz⟩,
+    fun ⟨y, hy, z, hz, hyz⟩ ↦ ⟨?_, y, hy, z, hz, hyz⟩⟩
+  convert (rootSpaceProduct R L H α (-α) 0 (add_neg_self α) (⟨y, hy⟩ ⊗ₜ[R] ⟨z, hz⟩)).property
+  simp [hyz]
 
 end LieAlgebra

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -31,12 +31,12 @@ We provide basic definitions and results to support `α`-chain techniques in thi
  * `LieModule.weightSpaceChain`: given weights `χ₁`, `χ₂` together with integers `p` and `q`, this
    is the sum of the weight spaces `k • χ₁ + χ₂` for `p < k < q`.
  * `LieModule.trace_toEndomorphism_weightSpaceChain_eq_zero`: given a root `α` relative to a Cartan
-   subalgebra `H`, there is a natural ideal `(rootSpaceProductNegSelf α).range` in `H`. This lemma
+   subalgebra `H`, there is a natural ideal `corootSpace α` in `H`. This lemma
    states that this ideal acts by trace-zero endomorphisms on the sum of root spaces of any
    `α`-chain, provided the weight spaces at the endpoints are both trivial.
- * `LieModule.exists_forall_mem_rootSpaceProductNegSelf_smul_add_eq_zero`: given a (potential) root
+ * `LieModule.exists_forall_mem_corootSpace_smul_add_eq_zero`: given a (potential) root
    `α` relative to a Cartan subalgebra `H`, if we restrict to the ideal
-   `(rootSpaceProductNegSelf α).range` of `H`, we may find an integral linear combination between
+   `corootSpace α` of `H`, we may find an integral linear combination between
    `α` and any weight `χ` of a representation.
 
 -/
@@ -156,37 +156,39 @@ variable [H.IsCartanSubalgebra] [IsNoetherian R L]
 lemma trace_toEndomorphism_weightSpaceChain_eq_zero
     (hp : weightSpace M (p • α + χ) = ⊥)
     (hq : weightSpace M (q • α + χ) = ⊥)
-    {x : H} (hx : x ∈ (rootSpaceProductNegSelf α).range) :
+    {x : H} (hx : x ∈ corootSpace α) :
     LinearMap.trace R _ (toEndomorphism R H (weightSpaceChain M α χ p q) x) = 0 := by
-  obtain ⟨t, rfl⟩ := hx
-  induction' t using TensorProduct.induction_on with y z _ _ h₁ h₂
-  · simp
-  · let f : Module.End R (weightSpaceChain M α χ p q) :=
+  rw [LieAlgebra.mem_corootSpace'] at hx
+  induction hx using Submodule.span_induction'
+  · next u hu =>
+    obtain ⟨y, hy, z, hz, hyz⟩ := hu
+    let f : Module.End R (weightSpaceChain M α χ p q) :=
       { toFun := fun ⟨m, hm⟩ ↦ ⟨⁅(y : L), m⁆,
-          lie_mem_weightSpaceChain_of_weightSpace_eq_bot_right M α χ p q hq y.property hm⟩
+          lie_mem_weightSpaceChain_of_weightSpace_eq_bot_right M α χ p q hq hy hm⟩
         map_add' := fun _ _ ↦ by simp
         map_smul' := fun t m ↦ by simp }
     let g : Module.End R (weightSpaceChain M α χ p q) :=
       { toFun := fun ⟨m, hm⟩ ↦ ⟨⁅(z : L), m⁆,
-          lie_mem_weightSpaceChain_of_weightSpace_eq_bot_left M α χ p q hp z.property hm⟩
+          lie_mem_weightSpaceChain_of_weightSpace_eq_bot_left M α χ p q hp hz hm⟩
         map_add' := fun _ _ ↦ by simp
         map_smul' := fun t m ↦ by simp }
-    have hfg : toEndomorphism R H _ (rootSpaceProductNegSelf α (y ⊗ₜ z)) = ⁅f, g⁆ := by
-      ext; simp [f, g]
+    have hfg : toEndomorphism R H _ u = ⁅f, g⁆ := by ext; simp [f, g, ← hyz]
     simp [hfg]
-  · rw [LieModuleHom.map_add, LieHom.map_add, map_add, h₁, h₂, zero_add]
+  · simp
+  · simp_all
+  · simp_all
 
 /-- Given a (potential) root `α` relative to a Cartan subalgebra `H`, if we restrict to the ideal
-`I = (rootSpaceProductNegSelf α).range` of `H` (informally, `I = ⁅H(α), H(-α)⁆`), we may find an
+`I = corootSpace α` of `H` (informally, `I = ⁅H(α), H(-α)⁆`), we may find an
 integral linear combination between `α` and any weight `χ` of a representation.
 
 This is Proposition 4.4 from [carter2005] and is a key step in the proof that the roots of a
 semisimple Lie algebra form a root system. It shows that the restriction of `α` to `I` vanishes iff
 the restriction of every root to `I` vanishes (which cannot happen in a semisimple Lie algebra). -/
-lemma exists_forall_mem_rootSpaceProductNegSelf_smul_add_eq_zero
+lemma exists_forall_mem_corootSpace_smul_add_eq_zero
     [IsDomain R] [IsPrincipalIdealRing R] [CharZero R] [NoZeroSMulDivisors R M] [IsNoetherian R M]
     (hα : α ≠ 0) (hχ : weightSpace M χ ≠ ⊥) :
-    ∃ a b : ℤ, 0 < b ∧ ∀ x ∈ (rootSpaceProductNegSelf α).range, (a • α + b • χ) x = 0 := by
+    ∃ a b : ℤ, 0 < b ∧ ∀ x ∈ corootSpace α, (a • α + b • χ) x = 0 := by
   obtain ⟨p, hp₀, q, hq₀, hp, hq⟩ := exists₂_weightSpace_smul_add_eq_bot M α χ hα
   let a := ∑ i in Finset.Ioo p q, finrank R (weightSpace M (i • α + χ)) • i
   let b := ∑ i in Finset.Ioo p q, finrank R (weightSpace M (i • α + χ))

--- a/Mathlib/Algebra/Lie/Weights/Linear.lean
+++ b/Mathlib/Algebra/Lie/Weights/Linear.lean
@@ -33,7 +33,7 @@ or `R` has characteristic zero.
    Abelian Lie algebra, the weights of any Lie module are linear.
  * `LieModule.instLinearWeightsOfIsLieAbelian`: a typeclass instance encoding the fact that in
    characteristic zero, the weights of any finite-dimensional Lie module are linear.
- * `LieModule.exists_forall_lie_eq_smul_of_weightSpace_ne_bot`: existence of simultaneous
+ * `LieModule.exists_forall_lie_eq_smul`: existence of simultaneous
    eigenvectors from existence of simultaneous generalized eigenvectors for Noetherian Lie modules
    with linear weights.
 
@@ -53,20 +53,39 @@ class LinearWeights [LieAlgebra.IsNilpotent R L] : Prop :=
   map_smul : ∀ χ : L → R, weightSpace M χ ≠ ⊥ → ∀ (t : R) x, χ (t • x) = t • χ x
   map_lie : ∀ χ : L → R, weightSpace M χ ≠ ⊥ → ∀ x y : L, χ ⁅x, y⁆ = 0
 
+namespace Weight
+
+variable [LieAlgebra.IsNilpotent R L] [LinearWeights R L M]
+    [NoZeroSMulDivisors R M] [IsNoetherian R M] (χ : Weight R L M)
+
 /-- A weight of a Lie module, bundled as a linear map. -/
 @[simps]
-def weight.toLinear [LieAlgebra.IsNilpotent R L] [LinearWeights R L M]
-    [NoZeroSMulDivisors R M] [IsNoetherian R M] (χ : weight R L M) :
-    L →ₗ[R] R where
+def toLinear : L →ₗ[R] R where
   toFun := χ
-  map_add' := LinearWeights.map_add (χ : L → R) (M := M) <| (Finite.mem_toFinset _).mp χ.property
-  map_smul' := LinearWeights.map_smul (χ : L → R) (M := M) <| (Finite.mem_toFinset _).mp χ.property
+  map_add' := LinearWeights.map_add χ χ.weightSpace_ne_bot
+  map_smul' := LinearWeights.map_smul χ χ.weightSpace_ne_bot
+
+instance instCoeLinearMap : CoeOut (Weight R L M) (L →ₗ[R] R) where
+  coe := Weight.toLinear R L M
+
+variable {R L M χ}
 
 @[simp]
-lemma weight.toLinear_apply_lie [LieAlgebra.IsNilpotent R L] [LinearWeights R L M]
-    [NoZeroSMulDivisors R M] [IsNoetherian R M] (χ : weight R L M) (x y : L) :
-    (χ : L → R) ⁅x, y⁆ = 0 :=
-  LinearWeights.map_lie (χ : L → R) ((Finite.mem_toFinset _).mp χ.property) x y
+lemma apply_lie (x y : L) :
+    χ ⁅x, y⁆ = 0 :=
+  LinearWeights.map_lie χ χ.weightSpace_ne_bot x y
+
+@[simp] lemma coe_coe : (↑(χ : L →ₗ[R] R) : L → R) = (χ : L → R) := rfl
+
+@[simp] lemma coe_toLinear_eq_zero_iff : (χ : L →ₗ[R] R) = 0 ↔ χ.IsZero :=
+  ⟨fun h ↦ funext fun x ↦ LinearMap.congr_fun h x, fun h ↦ by ext; simp [χ.coe_eq_zero_iff.mpr h]⟩
+
+lemma coe_toLinear_ne_zero_iff : (χ : L →ₗ[R] R) ≠ 0 ↔ χ.IsNonZero := by simp
+
+/-- The kernel of a weight of a Lie module with linear weights. -/
+abbrev ker := LinearMap.ker (χ : L →ₗ[R] R)
+
+end Weight
 
 /-- For an Abelian Lie algebra, the weights of any Lie module are linear. -/
 instance instLinearWeightsOfIsLieAbelian [IsLieAbelian L] [NoZeroSMulDivisors R M] :
@@ -194,11 +213,10 @@ end shiftedWeightSpace
 /-- Given a Lie module `M` of a Lie algebra `L` with coefficients in `R`, if a function `χ : L → R`
 has a simultaneous generalized eigenvector for the action of `L` then it has a simultaneous true
 eigenvector, provided `M` is Noetherian and has linear weights. -/
-lemma exists_forall_lie_eq_smul_of_weightSpace_ne_bot
-    [IsNoetherian R M] (hχ : weightSpace M χ ≠ ⊥) :
+lemma exists_forall_lie_eq_smul [IsNoetherian R M] (χ : Weight R L M) :
     ∃ m : M, m ≠ 0 ∧ ∀ x : L, ⁅x, m⁆ = χ x • m := by
   replace hχ : Nontrivial (shiftedWeightSpace R L M χ) :=
-    (LieSubmodule.nontrivial_iff_ne_bot R L M).mpr hχ
+    (LieSubmodule.nontrivial_iff_ne_bot R L M).mpr χ.weightSpace_ne_bot
   obtain ⟨⟨⟨m, _⟩, hm₁⟩, hm₂⟩ :=
     @exists_ne _ (nontrivial_max_triv_of_isNilpotent R L (shiftedWeightSpace R L M χ)) 0
   simp_rw [LieSubmodule.mem_coeSubmodule, mem_maxTrivSubmodule, Subtype.ext_iff,

--- a/Mathlib/Algebra/Lie/Weights/Linear.lean
+++ b/Mathlib/Algebra/Lie/Weights/Linear.lean
@@ -78,7 +78,7 @@ lemma apply_lie (x y : L) :
 @[simp] lemma coe_coe : (↑(χ : L →ₗ[R] R) : L → R) = (χ : L → R) := rfl
 
 @[simp] lemma coe_toLinear_eq_zero_iff : (χ : L →ₗ[R] R) = 0 ↔ χ.IsZero :=
-  ⟨fun h ↦ funext fun x ↦ LinearMap.congr_fun h x, fun h ↦ by ext; simp [χ.coe_eq_zero_iff.mpr h]⟩
+  ⟨fun h ↦ funext fun x ↦ LinearMap.congr_fun h x, fun h ↦ by ext; simp [h.eq]⟩
 
 lemma coe_toLinear_ne_zero_iff : (χ : L →ₗ[R] R) ≠ 0 ↔ χ.IsNonZero := by simp
 

--- a/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
@@ -451,6 +451,13 @@ theorem toDual_def {B : BilinForm K V} (b : B.SeparatingLeft) {m n : V} : B.toDu
   rfl
 #align bilin_form.to_dual_def LinearMap.BilinForm.toDual_def
 
+@[simp]
+lemma apply_toDual_symm_apply {B : BilinForm K V} {hB : B.Nondegenerate}
+    (f : Module.Dual K V) (v : V) :
+    B ((B.toDual hB).symm f) v = f v := by
+  change B.toDual hB ((B.toDual hB).symm f) v = f v
+  simp only [LinearEquiv.apply_symm_apply]
+
 lemma Nondegenerate.flip {B : BilinForm K V} (hB : B.Nondegenerate) :
     B.flip.Nondegenerate := by
   intro x hx

--- a/Mathlib/LinearAlgebra/Dimension/Finite.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finite.lean
@@ -436,6 +436,12 @@ theorem Submodule.finrank_eq_zero [StrongRankCondition R] [NoZeroSMulDivisors R 
   rw [← Submodule.rank_eq_zero, ← finrank_eq_rank, ← @Nat.cast_zero Cardinal, Cardinal.natCast_inj]
 #align finrank_eq_zero Submodule.finrank_eq_zero
 
+@[simp]
+lemma Submodule.one_le_finrank_iff [StrongRankCondition R] [NoZeroSMulDivisors R M]
+    {S : Submodule R M} [Module.Finite R S] :
+    1 ≤ finrank R S ↔ S ≠ ⊥ := by
+  simp [← not_iff_not]
+
 variable [Module.Free R M]
 
 theorem finrank_eq_zero_of_basis_imp_not_finite

--- a/Mathlib/LinearAlgebra/Dual.lean
+++ b/Mathlib/LinearAlgebra/Dual.lean
@@ -1453,6 +1453,36 @@ universe uK uV₁ uV₂
 variable {K : Type uK} [Field K] {V₁ : Type uV₁} {V₂ : Type uV₂}
 variable [AddCommGroup V₁] [Module K V₁] [AddCommGroup V₂] [Module K V₂]
 
+namespace Module.Dual
+
+variable [FiniteDimensional K V₁] {f : Module.Dual K V₁} (hf : f ≠ 0)
+
+open FiniteDimensional
+
+lemma range_eq_top_of_ne_zero :
+    LinearMap.range f = ⊤ := by
+  obtain ⟨v, hv⟩ : ∃ v, f v ≠ 0 := by contrapose! hf; ext v; simpa using hf v
+  rw [eq_top_iff]
+  exact fun x _ ↦ ⟨x • (f v)⁻¹ • v, by simp [inv_mul_cancel hv]⟩
+
+lemma finrank_ker_add_one_of_ne_zero :
+    finrank K (LinearMap.ker f) + 1 = finrank K V₁ := by
+  suffices finrank K (LinearMap.range f) = 1 by
+    rw [← (LinearMap.ker f).finrank_quotient_add_finrank, add_comm, add_left_inj,
+    f.quotKerEquivRange.finrank_eq, this]
+  rw [range_eq_top_of_ne_zero hf, finrank_top, finrank_self]
+
+lemma isCompl_ker_of_disjoint_of_ne_bot {p : Submodule K V₁}
+    (hpf : Disjoint (LinearMap.ker f) p) (hp : p ≠ ⊥) :
+    IsCompl (LinearMap.ker f) p := by
+  refine ⟨hpf, codisjoint_iff.mpr <| eq_of_le_of_finrank_le le_top ?_⟩
+  have : finrank K ↑(LinearMap.ker f ⊔ p) = finrank K (LinearMap.ker f) + finrank K p := by
+    simp [← Submodule.finrank_sup_add_finrank_inf_eq (LinearMap.ker f) p, hpf.eq_bot]
+  rwa [finrank_top, this, ← finrank_ker_add_one_of_ne_zero hf, add_le_add_iff_left,
+    Submodule.one_le_finrank_iff]
+
+end Module.Dual
+
 namespace LinearMap
 
 theorem dualPairing_nondegenerate : (dualPairing K V₁).Nondegenerate :=

--- a/Mathlib/LinearAlgebra/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional.lean
@@ -498,6 +498,12 @@ theorem eq_top_of_disjoint [FiniteDimensional K V] (s t : Submodule K V)
   rfl
 #align submodule.eq_top_of_disjoint Submodule.eq_top_of_disjoint
 
+theorem finrank_add_finrank_le_of_disjoint [FiniteDimensional K V]
+    {s t : Submodule K V} (hdisjoint : Disjoint s t) :
+    finrank K s + finrank K t ≤ finrank K V := by
+  rw [← Submodule.finrank_sup_add_finrank_inf_eq s t, hdisjoint.eq_bot, finrank_bot, add_zero]
+  exact Submodule.finrank_le _
+
 end DivisionRing
 
 end Submodule


### PR DESCRIPTION
We define the coroots of a finite-dimensional semisimple Lie algebra with coefficients in a field characteristic zero and establish the key property that a coroot is complementary to the kernel of the root.

In addition we carry out some related, light refactoring. The most important points are:

- Promote `LieModule.weight` from a subtype to a structure `LieModule.Weight` + expand its API (we need this expanded API for the headline results).
- Replace the definition `LieAlgebra.rootSpaceProductNegSelf` with its range which we call `LieAlgebra.corootSpace` (in all places where we used this definition, it was the range that we actually used).
- Drop the very old (unused) definitions `LieAlgebra.IsRoot` and `LieModule.IsWeight`.

---

I could split up this PR into two or three pieces and I am happy to do so upon request.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
