### PR TITLE
[Merged by Bors] - chore: split `Order`ed instances for subobjects into separate files 

### DIFF
--- a/Counterexamples/CanonicallyOrderedCommSemiringTwoMul.lean
+++ b/Counterexamples/CanonicallyOrderedCommSemiringTwoMul.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 import Mathlib.Data.ZMod.Basic
-import Mathlib.RingTheory.Subsemiring.Basic
+import Mathlib.RingTheory.Subsemiring.Order
 import Mathlib.Algebra.Order.Monoid.Basic
 
 #align_import canonically_ordered_comm_semiring_two_mul from "leanprover-community/mathlib"@"328375597f2c0dd00522d9c2e5a33b6a6128feeb"

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2186,6 +2186,7 @@ import Mathlib.FieldTheory.SeparableDegree
 import Mathlib.FieldTheory.SplittingField.Construction
 import Mathlib.FieldTheory.SplittingField.IsSplittingField
 import Mathlib.FieldTheory.Subfield
+import Mathlib.FieldTheory.Subfield.Order
 import Mathlib.FieldTheory.Tower
 import Mathlib.Geometry.Euclidean.Angle.Oriented.Affine
 import Mathlib.Geometry.Euclidean.Angle.Oriented.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -351,6 +351,7 @@ import Mathlib.Algebra.Module.Submodule.Lattice
 import Mathlib.Algebra.Module.Submodule.LinearMap
 import Mathlib.Algebra.Module.Submodule.Localization
 import Mathlib.Algebra.Module.Submodule.Map
+import Mathlib.Algebra.Module.Submodule.Order
 import Mathlib.Algebra.Module.Submodule.Pointwise
 import Mathlib.Algebra.Module.Submodule.RestrictScalars
 import Mathlib.Algebra.Module.Torsion

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -13,6 +13,7 @@ import Mathlib.Algebra.Algebra.Prod
 import Mathlib.Algebra.Algebra.RestrictScalars
 import Mathlib.Algebra.Algebra.Spectrum
 import Mathlib.Algebra.Algebra.Subalgebra.Basic
+import Mathlib.Algebra.Algebra.Subalgebra.Order
 import Mathlib.Algebra.Algebra.Subalgebra.Pointwise
 import Mathlib.Algebra.Algebra.Subalgebra.Tower
 import Mathlib.Algebra.Algebra.Subalgebra.Unitization
@@ -3333,8 +3334,10 @@ import Mathlib.RingTheory.RootsOfUnity.Complex
 import Mathlib.RingTheory.RootsOfUnity.Minpoly
 import Mathlib.RingTheory.SimpleModule
 import Mathlib.RingTheory.Subring.Basic
+import Mathlib.RingTheory.Subring.Order
 import Mathlib.RingTheory.Subring.Pointwise
 import Mathlib.RingTheory.Subsemiring.Basic
+import Mathlib.RingTheory.Subsemiring.Order
 import Mathlib.RingTheory.Subsemiring.Pointwise
 import Mathlib.RingTheory.TensorProduct
 import Mathlib.RingTheory.Trace

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2345,6 +2345,7 @@ import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.GroupTheory.Subgroup.Basic
 import Mathlib.GroupTheory.Subgroup.Finite
 import Mathlib.GroupTheory.Subgroup.MulOpposite
+import Mathlib.GroupTheory.Subgroup.Order
 import Mathlib.GroupTheory.Subgroup.Pointwise
 import Mathlib.GroupTheory.Subgroup.Saturated
 import Mathlib.GroupTheory.Subgroup.Simple

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3339,8 +3339,8 @@ import Mathlib.RingTheory.RootsOfUnity.Minpoly
 import Mathlib.RingTheory.SimpleModule
 import Mathlib.RingTheory.Subring.Basic
 import Mathlib.RingTheory.Subring.Order
-import Mathlib.RingTheory.Subring.Units
 import Mathlib.RingTheory.Subring.Pointwise
+import Mathlib.RingTheory.Subring.Units
 import Mathlib.RingTheory.Subsemiring.Basic
 import Mathlib.RingTheory.Subsemiring.Order
 import Mathlib.RingTheory.Subsemiring.Pointwise

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3339,6 +3339,7 @@ import Mathlib.RingTheory.RootsOfUnity.Minpoly
 import Mathlib.RingTheory.SimpleModule
 import Mathlib.RingTheory.Subring.Basic
 import Mathlib.RingTheory.Subring.Order
+import Mathlib.RingTheory.Subring.Units
 import Mathlib.RingTheory.Subring.Pointwise
 import Mathlib.RingTheory.Subsemiring.Basic
 import Mathlib.RingTheory.Subsemiring.Order

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2356,6 +2356,7 @@ import Mathlib.GroupTheory.Submonoid.Inverses
 import Mathlib.GroupTheory.Submonoid.Membership
 import Mathlib.GroupTheory.Submonoid.MulOpposite
 import Mathlib.GroupTheory.Submonoid.Operations
+import Mathlib.GroupTheory.Submonoid.Order
 import Mathlib.GroupTheory.Submonoid.Pointwise
 import Mathlib.GroupTheory.Submonoid.Units
 import Mathlib.GroupTheory.Subsemigroup.Basic

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -278,56 +278,6 @@ instance toCommRing {R A} [CommRing R] [CommRing A] [Algebra R A] (S : Subalgebr
   S.toSubring.toCommRing
 #align subalgebra.to_comm_ring Subalgebra.toCommRing
 
-instance toOrderedSemiring {R A} [CommSemiring R] [OrderedSemiring A] [Algebra R A]
-    (S : Subalgebra R A) : OrderedSemiring S :=
-  S.toSubsemiring.toOrderedSemiring
-#align subalgebra.to_ordered_semiring Subalgebra.toOrderedSemiring
-
-instance toStrictOrderedSemiring {R A} [CommSemiring R] [StrictOrderedSemiring A] [Algebra R A]
-    (S : Subalgebra R A) : StrictOrderedSemiring S :=
-  S.toSubsemiring.toStrictOrderedSemiring
-#align subalgebra.to_strict_ordered_semiring Subalgebra.toStrictOrderedSemiring
-
-instance toOrderedCommSemiring {R A} [CommSemiring R] [OrderedCommSemiring A] [Algebra R A]
-    (S : Subalgebra R A) : OrderedCommSemiring S :=
-  S.toSubsemiring.toOrderedCommSemiring
-#align subalgebra.to_ordered_comm_semiring Subalgebra.toOrderedCommSemiring
-
-instance toStrictOrderedCommSemiring {R A} [CommSemiring R] [StrictOrderedCommSemiring A]
-    [Algebra R A] (S : Subalgebra R A) : StrictOrderedCommSemiring S :=
-  S.toSubsemiring.toStrictOrderedCommSemiring
-#align subalgebra.to_strict_ordered_comm_semiring Subalgebra.toStrictOrderedCommSemiring
-
-instance toOrderedRing {R A} [CommRing R] [OrderedRing A] [Algebra R A] (S : Subalgebra R A) :
-    OrderedRing S :=
-  S.toSubring.toOrderedRing
-#align subalgebra.to_ordered_ring Subalgebra.toOrderedRing
-
-instance toOrderedCommRing {R A} [CommRing R] [OrderedCommRing A] [Algebra R A]
-    (S : Subalgebra R A) : OrderedCommRing S :=
-  S.toSubring.toOrderedCommRing
-#align subalgebra.to_ordered_comm_ring Subalgebra.toOrderedCommRing
-
-instance toLinearOrderedSemiring {R A} [CommSemiring R] [LinearOrderedSemiring A] [Algebra R A]
-    (S : Subalgebra R A) : LinearOrderedSemiring S :=
-  S.toSubsemiring.toLinearOrderedSemiring
-#align subalgebra.to_linear_ordered_semiring Subalgebra.toLinearOrderedSemiring
-
-instance toLinearOrderedCommSemiring {R A} [CommSemiring R] [LinearOrderedCommSemiring A]
-    [Algebra R A] (S : Subalgebra R A) : LinearOrderedCommSemiring S :=
-  S.toSubsemiring.toLinearOrderedCommSemiring
-#align subalgebra.to_linear_ordered_comm_semiring Subalgebra.toLinearOrderedCommSemiring
-
-instance toLinearOrderedRing {R A} [CommRing R] [LinearOrderedRing A] [Algebra R A]
-    (S : Subalgebra R A) : LinearOrderedRing S :=
-  S.toSubring.toLinearOrderedRing
-#align subalgebra.to_linear_ordered_ring Subalgebra.toLinearOrderedRing
-
-instance toLinearOrderedCommRing {R A} [CommRing R] [LinearOrderedCommRing A] [Algebra R A]
-    (S : Subalgebra R A) : LinearOrderedCommRing S :=
-  S.toSubring.toLinearOrderedCommRing
-#align subalgebra.to_linear_ordered_comm_ring Subalgebra.toLinearOrderedCommRing
-
 end
 
 /-- The forgetful map from `Subalgebra` to `Submodule` as an `OrderEmbedding` -/

--- a/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
@@ -9,9 +9,7 @@ import Mathlib.RingTheory.Subsemiring.Order
 import Mathlib.RingTheory.Subring.Order
 
 /-!
-
 # Order instances on subalgebras
-
 -/
 
 namespace Subalgebra

--- a/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
@@ -15,7 +15,7 @@ import Mathlib.RingTheory.Subring.Order
 
 namespace Subalgebra
 
-variables {R A : Type*}
+variable {R A : Type*}
 
 instance toOrderedSemiring [CommSemiring R] [OrderedSemiring A] [Algebra R A]
     (S : Subalgebra R A) : OrderedSemiring S :=

--- a/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2018 Kenny Lau. All rights reserved.
+Copyright (c) 2021 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kenny Lau, Yury Kudryashov
+Authors: Damiano Testa
 -/
 
 import Mathlib.Algebra.Algebra.Subalgebra.Basic

--- a/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
@@ -14,52 +14,54 @@ import Mathlib.RingTheory.Subring.Order
 
 namespace Subalgebra
 
-instance toOrderedSemiring {R A} [CommSemiring R] [OrderedSemiring A] [Algebra R A]
+variables {R A : Type*}
+
+instance toOrderedSemiring [CommSemiring R] [OrderedSemiring A] [Algebra R A]
     (S : Subalgebra R A) : OrderedSemiring S :=
   S.toSubsemiring.toOrderedSemiring
 #align subalgebra.to_ordered_semiring Subalgebra.toOrderedSemiring
 
-instance toStrictOrderedSemiring {R A} [CommSemiring R] [StrictOrderedSemiring A] [Algebra R A]
+instance toStrictOrderedSemiring [CommSemiring R] [StrictOrderedSemiring A] [Algebra R A]
     (S : Subalgebra R A) : StrictOrderedSemiring S :=
   S.toSubsemiring.toStrictOrderedSemiring
 #align subalgebra.to_strict_ordered_semiring Subalgebra.toStrictOrderedSemiring
 
-instance toOrderedCommSemiring {R A} [CommSemiring R] [OrderedCommSemiring A] [Algebra R A]
+instance toOrderedCommSemiring [CommSemiring R] [OrderedCommSemiring A] [Algebra R A]
     (S : Subalgebra R A) : OrderedCommSemiring S :=
   S.toSubsemiring.toOrderedCommSemiring
 #align subalgebra.to_ordered_comm_semiring Subalgebra.toOrderedCommSemiring
 
-instance toStrictOrderedCommSemiring {R A} [CommSemiring R] [StrictOrderedCommSemiring A]
+instance toStrictOrderedCommSemiring [CommSemiring R] [StrictOrderedCommSemiring A]
     [Algebra R A] (S : Subalgebra R A) : StrictOrderedCommSemiring S :=
   S.toSubsemiring.toStrictOrderedCommSemiring
 #align subalgebra.to_strict_ordered_comm_semiring Subalgebra.toStrictOrderedCommSemiring
 
-instance toOrderedRing {R A} [CommRing R] [OrderedRing A] [Algebra R A] (S : Subalgebra R A) :
+instance toOrderedRing [CommRing R] [OrderedRing A] [Algebra R A] (S : Subalgebra R A) :
     OrderedRing S :=
   S.toSubring.toOrderedRing
 #align subalgebra.to_ordered_ring Subalgebra.toOrderedRing
 
-instance toOrderedCommRing {R A} [CommRing R] [OrderedCommRing A] [Algebra R A]
+instance toOrderedCommRing [CommRing R] [OrderedCommRing A] [Algebra R A]
     (S : Subalgebra R A) : OrderedCommRing S :=
   S.toSubring.toOrderedCommRing
 #align subalgebra.to_ordered_comm_ring Subalgebra.toOrderedCommRing
 
-instance toLinearOrderedSemiring {R A} [CommSemiring R] [LinearOrderedSemiring A] [Algebra R A]
+instance toLinearOrderedSemiring [CommSemiring R] [LinearOrderedSemiring A] [Algebra R A]
     (S : Subalgebra R A) : LinearOrderedSemiring S :=
   S.toSubsemiring.toLinearOrderedSemiring
 #align subalgebra.to_linear_ordered_semiring Subalgebra.toLinearOrderedSemiring
 
-instance toLinearOrderedCommSemiring {R A} [CommSemiring R] [LinearOrderedCommSemiring A]
+instance toLinearOrderedCommSemiring [CommSemiring R] [LinearOrderedCommSemiring A]
     [Algebra R A] (S : Subalgebra R A) : LinearOrderedCommSemiring S :=
   S.toSubsemiring.toLinearOrderedCommSemiring
 #align subalgebra.to_linear_ordered_comm_semiring Subalgebra.toLinearOrderedCommSemiring
 
-instance toLinearOrderedRing {R A} [CommRing R] [LinearOrderedRing A] [Algebra R A]
+instance toLinearOrderedRing [CommRing R] [LinearOrderedRing A] [Algebra R A]
     (S : Subalgebra R A) : LinearOrderedRing S :=
   S.toSubring.toLinearOrderedRing
 #align subalgebra.to_linear_ordered_ring Subalgebra.toLinearOrderedRing
 
-instance toLinearOrderedCommRing {R A} [CommRing R] [LinearOrderedCommRing A] [Algebra R A]
+instance toLinearOrderedCommRing [CommRing R] [LinearOrderedCommRing A] [Algebra R A]
     (S : Subalgebra R A) : LinearOrderedCommRing S :=
   S.toSubring.toLinearOrderedCommRing
 #align subalgebra.to_linear_ordered_comm_ring Subalgebra.toLinearOrderedCommRing

--- a/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
@@ -5,7 +5,7 @@ Authors: Damiano Testa
 -/
 
 import Mathlib.Algebra.Algebra.Subalgebra.Basic
-import Mathlib.Algebra.Module.Order
+import Mathlib.Algebra.Module.Submodule.Order
 import Mathlib.RingTheory.Subsemiring.Order
 import Mathlib.RingTheory.Subring.Order
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2018 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau, Yury Kudryashov
+-/
+
+import Mathlib.Algebra.Algebra.Subalgebra.Basic
+import Mathlib.RingTheory.Subsemiring.Order
+import Mathlib.RingTheory.Subring.Order
+
+/-!
+
+# Order instances on subalgebras
+
+-/
+
+namespace Subalgebra
+
+instance toOrderedSemiring {R A} [CommSemiring R] [OrderedSemiring A] [Algebra R A]
+    (S : Subalgebra R A) : OrderedSemiring S :=
+  S.toSubsemiring.toOrderedSemiring
+#align subalgebra.to_ordered_semiring Subalgebra.toOrderedSemiring
+
+instance toStrictOrderedSemiring {R A} [CommSemiring R] [StrictOrderedSemiring A] [Algebra R A]
+    (S : Subalgebra R A) : StrictOrderedSemiring S :=
+  S.toSubsemiring.toStrictOrderedSemiring
+#align subalgebra.to_strict_ordered_semiring Subalgebra.toStrictOrderedSemiring
+
+instance toOrderedCommSemiring {R A} [CommSemiring R] [OrderedCommSemiring A] [Algebra R A]
+    (S : Subalgebra R A) : OrderedCommSemiring S :=
+  S.toSubsemiring.toOrderedCommSemiring
+#align subalgebra.to_ordered_comm_semiring Subalgebra.toOrderedCommSemiring
+
+instance toStrictOrderedCommSemiring {R A} [CommSemiring R] [StrictOrderedCommSemiring A]
+    [Algebra R A] (S : Subalgebra R A) : StrictOrderedCommSemiring S :=
+  S.toSubsemiring.toStrictOrderedCommSemiring
+#align subalgebra.to_strict_ordered_comm_semiring Subalgebra.toStrictOrderedCommSemiring
+
+instance toOrderedRing {R A} [CommRing R] [OrderedRing A] [Algebra R A] (S : Subalgebra R A) :
+    OrderedRing S :=
+  S.toSubring.toOrderedRing
+#align subalgebra.to_ordered_ring Subalgebra.toOrderedRing
+
+instance toOrderedCommRing {R A} [CommRing R] [OrderedCommRing A] [Algebra R A]
+    (S : Subalgebra R A) : OrderedCommRing S :=
+  S.toSubring.toOrderedCommRing
+#align subalgebra.to_ordered_comm_ring Subalgebra.toOrderedCommRing
+
+instance toLinearOrderedSemiring {R A} [CommSemiring R] [LinearOrderedSemiring A] [Algebra R A]
+    (S : Subalgebra R A) : LinearOrderedSemiring S :=
+  S.toSubsemiring.toLinearOrderedSemiring
+#align subalgebra.to_linear_ordered_semiring Subalgebra.toLinearOrderedSemiring
+
+instance toLinearOrderedCommSemiring {R A} [CommSemiring R] [LinearOrderedCommSemiring A]
+    [Algebra R A] (S : Subalgebra R A) : LinearOrderedCommSemiring S :=
+  S.toSubsemiring.toLinearOrderedCommSemiring
+#align subalgebra.to_linear_ordered_comm_semiring Subalgebra.toLinearOrderedCommSemiring
+
+instance toLinearOrderedRing {R A} [CommRing R] [LinearOrderedRing A] [Algebra R A]
+    (S : Subalgebra R A) : LinearOrderedRing S :=
+  S.toSubring.toLinearOrderedRing
+#align subalgebra.to_linear_ordered_ring Subalgebra.toLinearOrderedRing
+
+instance toLinearOrderedCommRing {R A} [CommRing R] [LinearOrderedCommRing A] [Algebra R A]
+    (S : Subalgebra R A) : LinearOrderedCommRing S :=
+  S.toSubring.toLinearOrderedCommRing
+#align subalgebra.to_linear_ordered_comm_ring Subalgebra.toLinearOrderedCommRing
+
+end Subalgebra

--- a/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Order.lean
@@ -5,6 +5,7 @@ Authors: Damiano Testa
 -/
 
 import Mathlib.Algebra.Algebra.Subalgebra.Basic
+import Mathlib.Algebra.Module.Order
 import Mathlib.RingTheory.Subsemiring.Order
 import Mathlib.RingTheory.Subring.Order
 

--- a/Mathlib/Algebra/Module/Submodule/Basic.lean
+++ b/Mathlib/Algebra/Module/Submodule/Basic.lean
@@ -502,60 +502,6 @@ theorem ne_zero_of_ortho {x : M} {N : Submodule R M}
 
 end IsDomain
 
-section OrderedMonoid
-
-variable [Semiring R]
-
-/-- A submodule of an `OrderedAddCommMonoid` is an `OrderedAddCommMonoid`. -/
-instance toOrderedAddCommMonoid {M} [OrderedAddCommMonoid M] [Module R M] (S : Submodule R M) :
-    OrderedAddCommMonoid S :=
-  Subtype.coe_injective.orderedAddCommMonoid Subtype.val rfl (fun _ _ => rfl) fun _ _ => rfl
-#align submodule.to_ordered_add_comm_monoid Submodule.toOrderedAddCommMonoid
-
-/-- A submodule of a `LinearOrderedAddCommMonoid` is a `LinearOrderedAddCommMonoid`. -/
-instance toLinearOrderedAddCommMonoid {M} [LinearOrderedAddCommMonoid M] [Module R M]
-    (S : Submodule R M) : LinearOrderedAddCommMonoid S :=
-  Subtype.coe_injective.linearOrderedAddCommMonoid Subtype.val rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) fun _ _ => rfl
-#align submodule.to_linear_ordered_add_comm_monoid Submodule.toLinearOrderedAddCommMonoid
-
-/-- A submodule of an `OrderedCancelAddCommMonoid` is an `OrderedCancelAddCommMonoid`. -/
-instance toOrderedCancelAddCommMonoid {M} [OrderedCancelAddCommMonoid M] [Module R M]
-    (S : Submodule R M) : OrderedCancelAddCommMonoid S :=
-  Subtype.coe_injective.orderedCancelAddCommMonoid Subtype.val rfl (fun _ _ => rfl) fun _ _ => rfl
-#align submodule.to_ordered_cancel_add_comm_monoid Submodule.toOrderedCancelAddCommMonoid
-
-/-- A submodule of a `LinearOrderedCancelAddCommMonoid` is a
-`LinearOrderedCancelAddCommMonoid`. -/
-instance toLinearOrderedCancelAddCommMonoid {M} [LinearOrderedCancelAddCommMonoid M] [Module R M]
-    (S : Submodule R M) : LinearOrderedCancelAddCommMonoid S :=
-  Subtype.coe_injective.linearOrderedCancelAddCommMonoid Subtype.val rfl (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align submodule.to_linear_ordered_cancel_add_comm_monoid Submodule.toLinearOrderedCancelAddCommMonoid
-
-end OrderedMonoid
-
-section OrderedGroup
-
-variable [Ring R]
-
-/-- A submodule of an `OrderedAddCommGroup` is an `OrderedAddCommGroup`. -/
-instance toOrderedAddCommGroup {M} [OrderedAddCommGroup M] [Module R M] (S : Submodule R M) :
-    OrderedAddCommGroup S :=
-  Subtype.coe_injective.orderedAddCommGroup Subtype.val rfl (fun _ _ => rfl) (fun _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align submodule.to_ordered_add_comm_group Submodule.toOrderedAddCommGroup
-
-/-- A submodule of a `LinearOrderedAddCommGroup` is a
-`LinearOrderedAddCommGroup`. -/
-instance toLinearOrderedAddCommGroup {M} [LinearOrderedAddCommGroup M] [Module R M]
-    (S : Submodule R M) : LinearOrderedAddCommGroup S :=
-  Subtype.coe_injective.linearOrderedAddCommGroup Subtype.val rfl (fun _ _ => rfl) (fun _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align submodule.to_linear_ordered_add_comm_group Submodule.toLinearOrderedAddCommGroup
-
-end OrderedGroup
-
 end Submodule
 
 namespace Submodule

--- a/Mathlib/Algebra/Module/Submodule/Order.lean
+++ b/Mathlib/Algebra/Module/Submodule/Order.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2021 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import Mathlib.GroupTheory.Subgroup.Order
+import Mathlib.GroupTheory.Submonoid.Order
+import Mathlib.Algebra.Module.Submodule.Basic
+
+/-!
+# Ordered instances on submodules
+-/
+
+namespace Submodule
+variable {R M : Type*}
+
+section OrderedMonoid
+variable [Semiring R]
+
+/-- A submodule of an `OrderedAddCommMonoid` is an `OrderedAddCommMonoid`. -/
+instance toOrderedAddCommMonoid [OrderedAddCommMonoid M] [Module R M] (S : Submodule R M) :
+    OrderedAddCommMonoid S :=
+  Subtype.coe_injective.orderedAddCommMonoid Subtype.val rfl (fun _ _ => rfl) fun _ _ => rfl
+#align submodule.to_ordered_add_comm_monoid Submodule.toOrderedAddCommMonoid
+
+/-- A submodule of a `LinearOrderedAddCommMonoid` is a `LinearOrderedAddCommMonoid`. -/
+instance toLinearOrderedAddCommMonoid [LinearOrderedAddCommMonoid M] [Module R M]
+    (S : Submodule R M) : LinearOrderedAddCommMonoid S :=
+  Subtype.coe_injective.linearOrderedAddCommMonoid Subtype.val rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) fun _ _ => rfl
+#align submodule.to_linear_ordered_add_comm_monoid Submodule.toLinearOrderedAddCommMonoid
+
+/-- A submodule of an `OrderedCancelAddCommMonoid` is an `OrderedCancelAddCommMonoid`. -/
+instance toOrderedCancelAddCommMonoid [OrderedCancelAddCommMonoid M] [Module R M]
+    (S : Submodule R M) : OrderedCancelAddCommMonoid S :=
+  Subtype.coe_injective.orderedCancelAddCommMonoid Subtype.val rfl (fun _ _ => rfl) fun _ _ => rfl
+#align submodule.to_ordered_cancel_add_comm_monoid Submodule.toOrderedCancelAddCommMonoid
+
+/-- A submodule of a `LinearOrderedCancelAddCommMonoid` is a
+`LinearOrderedCancelAddCommMonoid`. -/
+instance toLinearOrderedCancelAddCommMonoid [LinearOrderedCancelAddCommMonoid M] [Module R M]
+    (S : Submodule R M) : LinearOrderedCancelAddCommMonoid S :=
+  Subtype.coe_injective.linearOrderedCancelAddCommMonoid Subtype.val rfl (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align submodule.to_linear_ordered_cancel_add_comm_monoid Submodule.toLinearOrderedCancelAddCommMonoid
+
+end OrderedMonoid
+
+section OrderedGroup
+variable [Ring R]
+
+/-- A submodule of an `OrderedAddCommGroup` is an `OrderedAddCommGroup`. -/
+instance toOrderedAddCommGroup [OrderedAddCommGroup M] [Module R M] (S : Submodule R M) :
+    OrderedAddCommGroup S :=
+  Subtype.coe_injective.orderedAddCommGroup Subtype.val rfl (fun _ _ => rfl) (fun _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align submodule.to_ordered_add_comm_group Submodule.toOrderedAddCommGroup
+
+/-- A submodule of a `LinearOrderedAddCommGroup` is a
+`LinearOrderedAddCommGroup`. -/
+instance toLinearOrderedAddCommGroup [LinearOrderedAddCommGroup M] [Module R M]
+    (S : Submodule R M) : LinearOrderedAddCommGroup S :=
+  Subtype.coe_injective.linearOrderedAddCommGroup Subtype.val rfl (fun _ _ => rfl) (fun _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align submodule.to_linear_ordered_add_comm_group Submodule.toLinearOrderedAddCommGroup
+
+end OrderedGroup

--- a/Mathlib/FieldTheory/Subfield.lean
+++ b/Mathlib/FieldTheory/Subfield.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 import Mathlib.Algebra.Algebra.Basic
-import Mathlib.Algebra.Order.Field.InjSurj
 
 #align_import field_theory.subfield from "leanprover-community/mathlib"@"28aa996fc6fb4317f0083c4e6daf79878d81be33"
 
@@ -141,17 +140,6 @@ instance (priority := 75) toField {K} [Field K] [SetLike S K] [SubfieldClass S K
     (by intros _ _; rfl) (by intros _ _; rfl) (by intros _ _; rfl) (by intros _ _; rfl)
     (by intros _; rfl) (by intros _; rfl) (by intros _; rfl)
 #align subfield_class.to_field SubfieldClass.toField
-
--- Prefer subclasses of `Field` over subclasses of `SubfieldClass`.
-/-- A subfield of a `LinearOrderedField` is a `LinearOrderedField`. -/
-instance (priority := 75) toLinearOrderedField {K} [LinearOrderedField K] [SetLike S K]
-    [SubfieldClass S K] (s : S) : LinearOrderedField s :=
-  Subtype.coe_injective.linearOrderedField (↑) rfl rfl (fun _ _ => rfl)
-    (fun _ _ => rfl)
-    (fun _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
-    (fun _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align subfield_class.to_linear_ordered_field SubfieldClass.toLinearOrderedField
 
 end SubfieldClass
 
@@ -361,14 +349,6 @@ instance toField {K} [Field K] (s : Subfield K) : Field s :=
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ => rfl) fun _ => rfl
 #align subfield.to_field Subfield.toField
-
-/-- A subfield of a `LinearOrderedField` is a `LinearOrderedField`. -/
-instance toLinearOrderedField {K} [LinearOrderedField K] (s : Subfield K) : LinearOrderedField s :=
-  Subtype.coe_injective.linearOrderedField (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
-    (fun _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align subfield.to_linear_ordered_field Subfield.toLinearOrderedField
 
 @[simp, norm_cast]
 theorem coe_add (x y : s) : (↑(x + y) : K) = ↑x + ↑y :=

--- a/Mathlib/FieldTheory/Subfield/Order.lean
+++ b/Mathlib/FieldTheory/Subfield/Order.lean
@@ -13,10 +13,11 @@ import Mathlib.RingTheory.Subring.Order
 -/
 
 namespace SubfieldClass
+variable {K S : Type*} [SetLike S K]
 
 -- Prefer subclasses of `Field` over subclasses of `SubfieldClass`.
 /-- A subfield of a `LinearOrderedField` is a `LinearOrderedField`. -/
-instance (priority := 75) toLinearOrderedField {K} [LinearOrderedField K] [SetLike S K]
+instance (priority := 75) toLinearOrderedField [LinearOrderedField K]
     [SubfieldClass S K] (s : S) : LinearOrderedField s :=
   Subtype.coe_injective.linearOrderedField (↑) rfl rfl (fun _ _ => rfl)
     (fun _ _ => rfl)
@@ -28,9 +29,10 @@ instance (priority := 75) toLinearOrderedField {K} [LinearOrderedField K] [SetLi
 end SubfieldClass
 
 namespace Subfield
+variable {K : Type*}
 
 /-- A subfield of a `LinearOrderedField` is a `LinearOrderedField`. -/
-instance toLinearOrderedField {K} [LinearOrderedField K] (s : Subfield K) : LinearOrderedField s :=
+instance toLinearOrderedField [LinearOrderedField K] (s : Subfield K) : LinearOrderedField s :=
   Subtype.coe_injective.linearOrderedField (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)

--- a/Mathlib/FieldTheory/Subfield/Order.lean
+++ b/Mathlib/FieldTheory/Subfield/Order.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2021 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import Mathlib.Algebra.Order.Field.InjSurj
+import Mathlib.FieldTheory.Subfield
+import Mathlib.RingTheory.Subring.Order
+
+/-!
+# Ordered instances on subfields
+-/
+
+namespace SubfieldClass
+
+-- Prefer subclasses of `Field` over subclasses of `SubfieldClass`.
+/-- A subfield of a `LinearOrderedField` is a `LinearOrderedField`. -/
+instance (priority := 75) toLinearOrderedField {K} [LinearOrderedField K] [SetLike S K]
+    [SubfieldClass S K] (s : S) : LinearOrderedField s :=
+  Subtype.coe_injective.linearOrderedField (↑) rfl rfl (fun _ _ => rfl)
+    (fun _ _ => rfl)
+    (fun _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
+    (fun _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align subfield_class.to_linear_ordered_field SubfieldClass.toLinearOrderedField
+
+end SubfieldClass
+
+namespace Subfield
+
+/-- A subfield of a `LinearOrderedField` is a `LinearOrderedField`. -/
+instance toLinearOrderedField {K} [LinearOrderedField K] (s : Subfield K) : LinearOrderedField s :=
+  Subtype.coe_injective.linearOrderedField (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
+    (fun _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align subfield.to_linear_ordered_field Subfield.toLinearOrderedField
+
+end Subfield

--- a/Mathlib/GroupTheory/Subgroup/Basic.lean
+++ b/Mathlib/GroupTheory/Subgroup/Basic.lean
@@ -5,7 +5,6 @@ Authors: Kexing Ying
 -/
 import Mathlib.Algebra.Group.Conj
 import Mathlib.Algebra.Group.Pi.Lemmas
-import Mathlib.Algebra.Order.Group.InjSurj
 import Mathlib.Data.Set.Image
 import Mathlib.GroupTheory.Submonoid.Centralizer
 import Mathlib.Order.Atoms
@@ -268,28 +267,6 @@ instance (priority := 75) toCommGroup {G : Type*} [CommGroup G] [SetLike S G] [S
     (fun _ _ => rfl) fun _ _ => rfl
 #align subgroup_class.to_comm_group SubgroupClass.toCommGroup
 #align add_subgroup_class.to_add_comm_group AddSubgroupClass.toAddCommGroup
-
--- Prefer subclasses of `Group` over subclasses of `SubgroupClass`.
-/-- A subgroup of an `OrderedCommGroup` is an `OrderedCommGroup`. -/
-@[to_additive "An additive subgroup of an `AddOrderedCommGroup` is an `AddOrderedCommGroup`."]
-instance (priority := 75) toOrderedCommGroup {G : Type*} [OrderedCommGroup G] [SetLike S G]
-    [SubgroupClass S G] : OrderedCommGroup H :=
-  Subtype.coe_injective.orderedCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) fun _ _ => rfl
-#align subgroup_class.to_ordered_comm_group SubgroupClass.toOrderedCommGroup
-#align add_subgroup_class.to_ordered_add_comm_group AddSubgroupClass.toOrderedAddCommGroup
-
--- Prefer subclasses of `Group` over subclasses of `SubgroupClass`.
-/-- A subgroup of a `LinearOrderedCommGroup` is a `LinearOrderedCommGroup`. -/
-@[to_additive
-      "An additive subgroup of a `LinearOrderedAddCommGroup` is a
-        `LinearOrderedAddCommGroup`."]
-instance (priority := 75) toLinearOrderedCommGroup {G : Type*} [LinearOrderedCommGroup G]
-    [SetLike S G] [SubgroupClass S G] : LinearOrderedCommGroup H :=
-  Subtype.coe_injective.linearOrderedCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align subgroup_class.to_linear_ordered_comm_group SubgroupClass.toLinearOrderedCommGroup
-#align add_subgroup_class.to_linear_ordered_add_comm_group AddSubgroupClass.toLinearOrderedAddCommGroup
 
 /-- The natural group hom from a subgroup of group `G` to `G`. -/
 @[to_additive (attr := coe)
@@ -778,26 +755,6 @@ instance toCommGroup {G : Type*} [CommGroup G] (H : Subgroup G) : CommGroup H :=
     (fun _ _ => rfl) fun _ _ => rfl
 #align subgroup.to_comm_group Subgroup.toCommGroup
 #align add_subgroup.to_add_comm_group AddSubgroup.toAddCommGroup
-
-/-- A subgroup of an `OrderedCommGroup` is an `OrderedCommGroup`. -/
-@[to_additive "An `AddSubgroup` of an `AddOrderedCommGroup` is an `AddOrderedCommGroup`."]
-instance toOrderedCommGroup {G : Type*} [OrderedCommGroup G] (H : Subgroup G) :
-    OrderedCommGroup H :=
-  Subtype.coe_injective.orderedCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) fun _ _ => rfl
-#align subgroup.to_ordered_comm_group Subgroup.toOrderedCommGroup
-#align add_subgroup.to_ordered_add_comm_group AddSubgroup.toOrderedAddCommGroup
-
-/-- A subgroup of a `LinearOrderedCommGroup` is a `LinearOrderedCommGroup`. -/
-@[to_additive
-      "An `AddSubgroup` of a `LinearOrderedAddCommGroup` is a
-        `LinearOrderedAddCommGroup`."]
-instance toLinearOrderedCommGroup {G : Type*} [LinearOrderedCommGroup G] (H : Subgroup G) :
-    LinearOrderedCommGroup H :=
-  Subtype.coe_injective.linearOrderedCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align subgroup.to_linear_ordered_comm_group Subgroup.toLinearOrderedCommGroup
-#align add_subgroup.to_linear_ordered_add_comm_group AddSubgroup.toLinearOrderedAddCommGroup
 
 /-- The natural group hom from a subgroup of group `G` to `G`. -/
 @[to_additive "The natural group hom from an `AddSubgroup` of `AddGroup` `G` to `G`."]

--- a/Mathlib/GroupTheory/Subgroup/Order.lean
+++ b/Mathlib/GroupTheory/Subgroup/Order.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2021 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import Mathlib.GroupTheory.Subgroup.Basic
+import Mathlib.GroupTheory.Submonoid.Order
+import Mathlib.Algebra.Order.Group.InjSurj
+
+/-!
+# Ordered instances on subgroups
+-/
+
+namespace SubgroupClass
+variable {G S : Type*} [SetLike S G]
+
+-- Prefer subclasses of `Group` over subclasses of `SubgroupClass`.
+/-- A subgroup of an `OrderedCommGroup` is an `OrderedCommGroup`. -/
+@[to_additive "An additive subgroup of an `AddOrderedCommGroup` is an `AddOrderedCommGroup`."]
+instance (priority := 75) toOrderedCommGroup [OrderedCommGroup G]
+    [SubgroupClass S G] (H : S) : OrderedCommGroup H :=
+  Subtype.coe_injective.orderedCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) fun _ _ => rfl
+#align subgroup_class.to_ordered_comm_group SubgroupClass.toOrderedCommGroup
+#align add_subgroup_class.to_ordered_add_comm_group AddSubgroupClass.toOrderedAddCommGroup
+
+-- Prefer subclasses of `Group` over subclasses of `SubgroupClass`.
+/-- A subgroup of a `LinearOrderedCommGroup` is a `LinearOrderedCommGroup`. -/
+@[to_additive
+      "An additive subgroup of a `LinearOrderedAddCommGroup` is a
+        `LinearOrderedAddCommGroup`."]
+instance (priority := 75) toLinearOrderedCommGroup [LinearOrderedCommGroup G]
+    [SubgroupClass S G] (H : S) : LinearOrderedCommGroup H :=
+  Subtype.coe_injective.linearOrderedCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align subgroup_class.to_linear_ordered_comm_group SubgroupClass.toLinearOrderedCommGroup
+#align add_subgroup_class.to_linear_ordered_add_comm_group AddSubgroupClass.toLinearOrderedAddCommGroup
+
+end SubgroupClass
+
+namespace Subgroup
+
+variable {G : Type*}
+
+/-- A subgroup of an `OrderedCommGroup` is an `OrderedCommGroup`. -/
+@[to_additive "An `AddSubgroup` of an `AddOrderedCommGroup` is an `AddOrderedCommGroup`."]
+instance toOrderedCommGroup [OrderedCommGroup G] (H : Subgroup G) :
+    OrderedCommGroup H :=
+  Subtype.coe_injective.orderedCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) fun _ _ => rfl
+#align subgroup.to_ordered_comm_group Subgroup.toOrderedCommGroup
+#align add_subgroup.to_ordered_add_comm_group AddSubgroup.toOrderedAddCommGroup
+
+/-- A subgroup of a `LinearOrderedCommGroup` is a `LinearOrderedCommGroup`. -/
+@[to_additive
+      "An `AddSubgroup` of a `LinearOrderedAddCommGroup` is a
+        `LinearOrderedAddCommGroup`."]
+instance toLinearOrderedCommGroup [LinearOrderedCommGroup G] (H : Subgroup G) :
+    LinearOrderedCommGroup H :=
+  Subtype.coe_injective.linearOrderedCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align subgroup.to_linear_ordered_comm_group Subgroup.toLinearOrderedCommGroup
+#align add_subgroup.to_linear_ordered_add_comm_group AddSubgroup.toLinearOrderedAddCommGroup
+
+end Subgroup

--- a/Mathlib/GroupTheory/Submonoid/Operations.lean
+++ b/Mathlib/GroupTheory/Submonoid/Operations.lean
@@ -4,9 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau, Johan Commelin, Mario Carneiro, Kevin Buzzard,
 Amelia Livingston, Yury Kudryashov
 -/
-import Mathlib.Algebra.Order.Monoid.Basic
-import Mathlib.Algebra.Order.Ring.Lemmas
-import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.GroupTheory.GroupAction.Defs
 import Mathlib.GroupTheory.Submonoid.Basic
 import Mathlib.GroupTheory.Subsemigroup.Operations
@@ -602,49 +599,6 @@ instance (priority := 75) toCommMonoid {M} [CommMonoid M] {A : Type*} [SetLike A
 #align submonoid_class.to_comm_monoid SubmonoidClass.toCommMonoid
 #align add_submonoid_class.to_add_comm_monoid AddSubmonoidClass.toAddCommMonoid
 
--- Prefer subclasses of `Monoid` over subclasses of `SubmonoidClass`.
-/-- A submonoid of an `OrderedCommMonoid` is an `OrderedCommMonoid`. -/
-@[to_additive "An `AddSubmonoid` of an `OrderedAddCommMonoid` is an `OrderedAddCommMonoid`."]
-instance (priority := 75) toOrderedCommMonoid {M} [OrderedCommMonoid M] {A : Type*} [SetLike A M]
-    [SubmonoidClass A M] (S : A) : OrderedCommMonoid S :=
-  Subtype.coe_injective.orderedCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
-#align submonoid_class.to_ordered_comm_monoid SubmonoidClass.toOrderedCommMonoid
-#align add_submonoid_class.to_ordered_add_comm_monoid AddSubmonoidClass.toOrderedAddCommMonoid
-
--- Prefer subclasses of `Monoid` over subclasses of `SubmonoidClass`.
-/-- A submonoid of a `LinearOrderedCommMonoid` is a `LinearOrderedCommMonoid`. -/
-@[to_additive
-      "An `AddSubmonoid` of a `LinearOrderedAddCommMonoid` is a `LinearOrderedAddCommMonoid`."]
-instance (priority := 75) toLinearOrderedCommMonoid {M} [LinearOrderedCommMonoid M] {A : Type*}
-    [SetLike A M] [SubmonoidClass A M] (S : A) : LinearOrderedCommMonoid S :=
-  Subtype.coe_injective.linearOrderedCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) fun _ _ => rfl
-#align submonoid_class.to_linear_ordered_comm_monoid SubmonoidClass.toLinearOrderedCommMonoid
-#align add_submonoid_class.to_linear_ordered_add_comm_monoid AddSubmonoidClass.toLinearOrderedAddCommMonoid
-
--- Prefer subclasses of `Monoid` over subclasses of `SubmonoidClass`.
-/-- A submonoid of an `OrderedCancelCommMonoid` is an `OrderedCancelCommMonoid`. -/
-@[to_additive AddSubmonoidClass.toOrderedCancelAddCommMonoid
-      "An `AddSubmonoid` of an `OrderedCancelAddCommMonoid` is an `OrderedCancelAddCommMonoid`."]
-instance (priority := 75) toOrderedCancelCommMonoid {M} [OrderedCancelCommMonoid M] {A : Type*}
-    [SetLike A M] [SubmonoidClass A M] (S : A) : OrderedCancelCommMonoid S :=
-  Subtype.coe_injective.orderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
-#align submonoid_class.to_ordered_cancel_comm_monoid SubmonoidClass.toOrderedCancelCommMonoid
-#align add_submonoid_class.to_ordered_cancel_add_comm_monoid AddSubmonoidClass.toOrderedCancelAddCommMonoid
-
--- Prefer subclasses of `Monoid` over subclasses of `SubmonoidClass`.
-/-- A submonoid of a `LinearOrderedCancelCommMonoid` is a `LinearOrderedCancelCommMonoid`.
--/
-@[to_additive AddSubmonoidClass.toLinearOrderedCancelAddCommMonoid
-      "An `AddSubmonoid` of a `LinearOrderedCancelAddCommMonoid` is
-      a `LinearOrderedCancelAddCommMonoid`."]
-instance (priority := 75) toLinearOrderedCancelCommMonoid {M} [LinearOrderedCancelCommMonoid M]
-    {A : Type*} [SetLike A M] [SubmonoidClass A M] (S : A) : LinearOrderedCancelCommMonoid S :=
-  Subtype.coe_injective.linearOrderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) fun _ _ => rfl
-#align submonoid_class.to_linear_ordered_cancel_comm_monoid SubmonoidClass.toLinearOrderedCancelCommMonoid
-#align add_submonoid_class.to_linear_ordered_cancel_add_comm_monoid AddSubmonoidClass.toLinearOrderedCancelAddCommMonoid
-
 /-- The natural monoid hom from a submonoid of monoid `M` to `M`. -/
 @[to_additive "The natural monoid hom from an `AddSubmonoid` of `AddMonoid` `M` to `M`."]
 def subtype : S' →* M where
@@ -739,44 +693,6 @@ instance toCommMonoid {M} [CommMonoid M] (S : Submonoid M) : CommMonoid S :=
   Subtype.coe_injective.commMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid.to_comm_monoid Submonoid.toCommMonoid
 #align add_submonoid.to_add_comm_monoid AddSubmonoid.toAddCommMonoid
-
-/-- A submonoid of an `OrderedCommMonoid` is an `OrderedCommMonoid`. -/
-@[to_additive "An `AddSubmonoid` of an `OrderedAddCommMonoid` is an `OrderedAddCommMonoid`."]
-instance toOrderedCommMonoid {M} [OrderedCommMonoid M] (S : Submonoid M) : OrderedCommMonoid S :=
-  Subtype.coe_injective.orderedCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
-#align submonoid.to_ordered_comm_monoid Submonoid.toOrderedCommMonoid
-#align add_submonoid.to_ordered_add_comm_monoid AddSubmonoid.toOrderedAddCommMonoid
-
-/-- A submonoid of a `LinearOrderedCommMonoid` is a `LinearOrderedCommMonoid`. -/
-@[to_additive
-      "An `AddSubmonoid` of a `LinearOrderedAddCommMonoid` is a `LinearOrderedAddCommMonoid`."]
-instance toLinearOrderedCommMonoid {M} [LinearOrderedCommMonoid M] (S : Submonoid M) :
-    LinearOrderedCommMonoid S :=
-  Subtype.coe_injective.linearOrderedCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) fun _ _ => rfl
-#align submonoid.to_linear_ordered_comm_monoid Submonoid.toLinearOrderedCommMonoid
-#align add_submonoid.to_linear_ordered_add_comm_monoid AddSubmonoid.toLinearOrderedAddCommMonoid
-
-/-- A submonoid of an `OrderedCancelCommMonoid` is an `OrderedCancelCommMonoid`. -/
-@[to_additive AddSubmonoid.toOrderedCancelAddCommMonoid
-      "An `AddSubmonoid` of an `OrderedCancelAddCommMonoid` is an `OrderedCancelAddCommMonoid`."]
-instance toOrderedCancelCommMonoid {M} [OrderedCancelCommMonoid M] (S : Submonoid M) :
-    OrderedCancelCommMonoid S :=
-  Subtype.coe_injective.orderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
-#align submonoid.to_ordered_cancel_comm_monoid Submonoid.toOrderedCancelCommMonoid
-#align add_submonoid.to_ordered_cancel_add_comm_monoid AddSubmonoid.toOrderedCancelAddCommMonoid
-
-/-- A submonoid of a `LinearOrderedCancelCommMonoid` is a `LinearOrderedCancelCommMonoid`.
--/
-@[to_additive AddSubmonoid.toLinearOrderedCancelAddCommMonoid
-      "An `AddSubmonoid` of a `LinearOrderedCancelAddCommMonoid` is
-      a `LinearOrderedCancelAddCommMonoid`."]
-instance toLinearOrderedCancelCommMonoid {M} [LinearOrderedCancelCommMonoid M] (S : Submonoid M) :
-    LinearOrderedCancelCommMonoid S :=
-  Subtype.coe_injective.linearOrderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) fun _ _ => rfl
-#align submonoid.to_linear_ordered_cancel_comm_monoid Submonoid.toLinearOrderedCancelCommMonoid
-#align add_submonoid.to_linear_ordered_cancel_add_comm_monoid AddSubmonoid.toLinearOrderedCancelAddCommMonoid
 
 /-- The natural monoid hom from a submonoid of monoid `M` to `M`. -/
 @[to_additive "The natural monoid hom from an `AddSubmonoid` of `AddMonoid` `M` to `M`."]
@@ -1562,40 +1478,7 @@ instance mulDistribMulAction [Monoid α] [MulDistribMulAction M' α] (S : Submon
 
 example {S : Submonoid M'} : IsScalarTower S M' M' := by infer_instance
 
-section Preorder
-variable (M)
-variable [Preorder M] [CovariantClass M M (· * ·) (· ≤ ·)] {a : M}
 
-/-- The submonoid of elements greater than `1`. -/
-@[to_additive (attr := simps) nonneg "The submonoid of nonnegative elements."]
-def oneLE : Submonoid M where
-  carrier := Set.Ici 1
-  mul_mem' := one_le_mul
-  one_mem' := le_rfl
-
-variable {M}
-
-@[to_additive (attr := simp) mem_nonneg] lemma mem_oneLE : a ∈ oneLE M ↔ 1 ≤ a := Iff.rfl
-
-end Preorder
-
-section MulZeroClass
-variable (α) [MulZeroOneClass α] [PartialOrder α] [PosMulStrictMono α] [ZeroLEOneClass α]
-  [NeZero (1 : α)] {a : α}
-
-/-- The submonoid of positive elements. -/
-@[simps] def pos : Submonoid α where
-  carrier := Set.Ioi 0
-  one_mem' := zero_lt_one
-  mul_mem' := mul_pos
-#align pos_submonoid Submonoid.pos
-
-variable {α}
-
-@[simp] lemma mem_pos : a ∈ pos α ↔ 0 < a := Iff.rfl
-#align mem_pos_monoid Submonoid.mem_pos
-
-end MulZeroClass
 end Submonoid
 
 end Actions

--- a/Mathlib/GroupTheory/Submonoid/Order.lean
+++ b/Mathlib/GroupTheory/Submonoid/Order.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2021 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import Mathlib.Algebra.Order.Monoid.Basic
+import Mathlib.Algebra.Order.Ring.Lemmas
+import Mathlib.Algebra.Order.ZeroLEOne
+import Mathlib.GroupTheory.Submonoid.Operations
+
+/-!
+# Ordered instances on submonoids
+-/
+
+namespace SubmonoidClass
+variable {M S : Type*} [SetLike S M]
+
+-- Prefer subclasses of `Monoid` over subclasses of `SubmonoidClass`.
+/-- A submonoid of an `OrderedCommMonoid` is an `OrderedCommMonoid`. -/
+@[to_additive "An `AddSubmonoid` of an `OrderedAddCommMonoid` is an `OrderedAddCommMonoid`."]
+instance (priority := 75) toOrderedCommMonoid [OrderedCommMonoid M]
+    [SubmonoidClass S M] (s : S) : OrderedCommMonoid s :=
+  Subtype.coe_injective.orderedCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
+#align submonoid_class.to_ordered_comm_monoid SubmonoidClass.toOrderedCommMonoid
+#align add_submonoid_class.to_ordered_add_comm_monoid AddSubmonoidClass.toOrderedAddCommMonoid
+
+-- Prefer subclasses of `Monoid` over subclasses of `SubmonoidClass`.
+/-- A submonoid of a `LinearOrderedCommMonoid` is a `LinearOrderedCommMonoid`. -/
+@[to_additive
+      "An `AddSubmonoid` of a `LinearOrderedAddCommMonoid` is a `LinearOrderedAddCommMonoid`."]
+instance (priority := 75) toLinearOrderedCommMonoid [LinearOrderedCommMonoid M]
+    [SubmonoidClass S M] (s : S) : LinearOrderedCommMonoid s :=
+  Subtype.coe_injective.linearOrderedCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) fun _ _ => rfl
+#align submonoid_class.to_linear_ordered_comm_monoid SubmonoidClass.toLinearOrderedCommMonoid
+#align add_submonoid_class.to_linear_ordered_add_comm_monoid AddSubmonoidClass.toLinearOrderedAddCommMonoid
+
+-- Prefer subclasses of `Monoid` over subclasses of `SubmonoidClass`.
+/-- A submonoid of an `OrderedCancelCommMonoid` is an `OrderedCancelCommMonoid`. -/
+@[to_additive AddSubmonoidClass.toOrderedCancelAddCommMonoid
+      "An `AddSubmonoid` of an `OrderedCancelAddCommMonoid` is an `OrderedCancelAddCommMonoid`."]
+instance (priority := 75) toOrderedCancelCommMonoid [OrderedCancelCommMonoid M]
+    [SubmonoidClass S M] (s : S) : OrderedCancelCommMonoid s :=
+  Subtype.coe_injective.orderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
+#align submonoid_class.to_ordered_cancel_comm_monoid SubmonoidClass.toOrderedCancelCommMonoid
+#align add_submonoid_class.to_ordered_cancel_add_comm_monoid AddSubmonoidClass.toOrderedCancelAddCommMonoid
+
+-- Prefer subclasses of `Monoid` over subclasses of `SubmonoidClass`.
+/-- A submonoid of a `LinearOrderedCancelCommMonoid` is a `LinearOrderedCancelCommMonoid`.
+-/
+@[to_additive AddSubmonoidClass.toLinearOrderedCancelAddCommMonoid
+      "An `AddSubmonoid` of a `LinearOrderedCancelAddCommMonoid` is
+      a `LinearOrderedCancelAddCommMonoid`."]
+instance (priority := 75) toLinearOrderedCancelCommMonoid [LinearOrderedCancelCommMonoid M]
+    [SubmonoidClass S M] (s : S) : LinearOrderedCancelCommMonoid s :=
+  Subtype.coe_injective.linearOrderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) fun _ _ => rfl
+#align submonoid_class.to_linear_ordered_cancel_comm_monoid SubmonoidClass.toLinearOrderedCancelCommMonoid
+#align add_submonoid_class.to_linear_ordered_cancel_add_comm_monoid AddSubmonoidClass.toLinearOrderedCancelAddCommMonoid
+
+
+end SubmonoidClass
+
+namespace Submonoid
+variable {M : Type*}
+
+/-- A submonoid of an `OrderedCommMonoid` is an `OrderedCommMonoid`. -/
+@[to_additive "An `AddSubmonoid` of an `OrderedAddCommMonoid` is an `OrderedAddCommMonoid`."]
+instance toOrderedCommMonoid [OrderedCommMonoid M] (S : Submonoid M) : OrderedCommMonoid S :=
+  Subtype.coe_injective.orderedCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
+#align submonoid.to_ordered_comm_monoid Submonoid.toOrderedCommMonoid
+#align add_submonoid.to_ordered_add_comm_monoid AddSubmonoid.toOrderedAddCommMonoid
+
+/-- A submonoid of a `LinearOrderedCommMonoid` is a `LinearOrderedCommMonoid`. -/
+@[to_additive
+      "An `AddSubmonoid` of a `LinearOrderedAddCommMonoid` is a `LinearOrderedAddCommMonoid`."]
+instance toLinearOrderedCommMonoid [LinearOrderedCommMonoid M] (S : Submonoid M) :
+    LinearOrderedCommMonoid S :=
+  Subtype.coe_injective.linearOrderedCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) fun _ _ => rfl
+#align submonoid.to_linear_ordered_comm_monoid Submonoid.toLinearOrderedCommMonoid
+#align add_submonoid.to_linear_ordered_add_comm_monoid AddSubmonoid.toLinearOrderedAddCommMonoid
+
+/-- A submonoid of an `OrderedCancelCommMonoid` is an `OrderedCancelCommMonoid`. -/
+@[to_additive AddSubmonoid.toOrderedCancelAddCommMonoid
+      "An `AddSubmonoid` of an `OrderedCancelAddCommMonoid` is an `OrderedCancelAddCommMonoid`."]
+instance toOrderedCancelCommMonoid [OrderedCancelCommMonoid M] (S : Submonoid M) :
+    OrderedCancelCommMonoid S :=
+  Subtype.coe_injective.orderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
+#align submonoid.to_ordered_cancel_comm_monoid Submonoid.toOrderedCancelCommMonoid
+#align add_submonoid.to_ordered_cancel_add_comm_monoid AddSubmonoid.toOrderedCancelAddCommMonoid
+
+/-- A submonoid of a `LinearOrderedCancelCommMonoid` is a `LinearOrderedCancelCommMonoid`.
+-/
+@[to_additive AddSubmonoid.toLinearOrderedCancelAddCommMonoid
+      "An `AddSubmonoid` of a `LinearOrderedCancelAddCommMonoid` is
+      a `LinearOrderedCancelAddCommMonoid`."]
+instance toLinearOrderedCancelCommMonoid [LinearOrderedCancelCommMonoid M] (S : Submonoid M) :
+    LinearOrderedCancelCommMonoid S :=
+  Subtype.coe_injective.linearOrderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) fun _ _ => rfl
+#align submonoid.to_linear_ordered_cancel_comm_monoid Submonoid.toLinearOrderedCancelCommMonoid
+#align add_submonoid.to_linear_ordered_cancel_add_comm_monoid AddSubmonoid.toLinearOrderedCancelAddCommMonoid
+
+section Preorder
+variable (M)
+variable [Monoid M] [Preorder M] [CovariantClass M M (· * ·) (· ≤ ·)] {a : M}
+
+/-- The submonoid of elements greater than `1`. -/
+@[to_additive (attr := simps) nonneg "The submonoid of nonnegative elements."]
+def oneLE : Submonoid M where
+  carrier := Set.Ici 1
+  mul_mem' := one_le_mul
+  one_mem' := le_rfl
+
+variable {M}
+
+@[to_additive (attr := simp) mem_nonneg] lemma mem_oneLE : a ∈ oneLE M ↔ 1 ≤ a := Iff.rfl
+
+end Preorder
+
+section MulZeroClass
+variable (α) [MulZeroOneClass α] [PartialOrder α] [PosMulStrictMono α] [ZeroLEOneClass α]
+  [NeZero (1 : α)] {a : α}
+
+/-- The submonoid of positive elements. -/
+@[simps] def pos : Submonoid α where
+  carrier := Set.Ioi 0
+  one_mem' := zero_lt_one
+  mul_mem' := mul_pos
+#align pos_submonoid Submonoid.pos
+
+variable {α}
+
+@[simp] lemma mem_pos : a ∈ pos α ↔ 0 < a := Iff.rfl
+#align mem_pos_monoid Submonoid.mem_pos
+
+end MulZeroClass
+
+end Submonoid

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup.lean
@@ -6,7 +6,7 @@ Authors: Chris Birkbeck
 import Mathlib.LinearAlgebra.GeneralLinearGroup
 import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
-import Mathlib.RingTheory.Subring.Order
+import Mathlib.RingTheory.Subring.Units
 
 #align_import linear_algebra.matrix.general_linear_group from "leanprover-community/mathlib"@"2705404e701abc6b3127da906f40bae062a169c9"
 

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 import Mathlib.LinearAlgebra.GeneralLinearGroup
 import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+import Mathlib.RingTheory.Subring.Order
 
 #align_import linear_algebra.matrix.general_linear_group from "leanprover-community/mathlib"@"2705404e701abc6b3127da906f40bae062a169c9"
 

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -6,7 +6,7 @@ Authors: Joseph Myers
 import Mathlib.Algebra.Order.Module.Algebra
 import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.LinearAlgebra.LinearIndependent
-import Mathlib.RingTheory.Subring.Order
+import Mathlib.RingTheory.Subring.Units
 
 #align_import linear_algebra.ray from "leanprover-community/mathlib"@"0f6670b8af2dff699de1c0b4b49039b31bc13c46"
 

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -6,6 +6,7 @@ Authors: Joseph Myers
 import Mathlib.Algebra.Order.Module.Algebra
 import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.LinearAlgebra.LinearIndependent
+import Mathlib.RingTheory.Subring.Order
 
 #align_import linear_algebra.ray from "leanprover-community/mathlib"@"0f6670b8af2dff699de1c0b4b49039b31bc13c46"
 

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
@@ -8,6 +8,8 @@ import Mathlib.Data.ZMod.Algebra
 
 #align_import ring_theory.polynomial.cyclotomic.expand from "leanprover-community/mathlib"@"0723536a0522d24fc2f159a096fb3304bef77472"
 
+set_option profiler true
+
 /-!
 # Cyclotomic polynomials and `expand`.
 
@@ -42,7 +44,7 @@ theorem cyclotomic_expand_eq_cyclotomic_mul {p n : ℕ} (hp : Nat.Prime p) (hdiv
   suffices expand ℤ p (cyclotomic n ℤ) = cyclotomic (n * p) ℤ * cyclotomic n ℤ by
     rw [← map_cyclotomic_int, ← map_expand, this, Polynomial.map_mul, map_cyclotomic_int,
       map_cyclotomic]
-  refine' eq_of_monic_of_dvd_of_natDegree_le ((cyclotomic.monic _ ℤ).mul (cyclotomic.monic _ _))
+  refine' eq_of_monic_of_dvd_of_natDegree_le ((cyclotomic.monic _ ℤ).mul (cyclotomic.monic _ ℤ))
     ((cyclotomic.monic n ℤ).expand hp.pos) _ _
   · refine' (IsPrimitive.Int.dvd_iff_map_cast_dvd_map_cast _ _
       (IsPrimitive.mul (cyclotomic.isPrimitive (n * p) ℤ) (cyclotomic.isPrimitive n ℤ))
@@ -54,14 +56,14 @@ theorem cyclotomic_expand_eq_cyclotomic_mul {p n : ℕ} (hp : Nat.Prime p) (hdiv
     · have hpos : 0 < n * p := mul_pos hnpos hp.pos
       have hprim := Complex.isPrimitiveRoot_exp _ hpos.ne'
       rw [cyclotomic_eq_minpoly_rat hprim hpos]
-      refine' @minpoly.dvd ℚ ℂ _ _ algebraRat _ _ _
+      refine' minpoly.dvd ℚ _ _
       rw [aeval_def, ← eval_map, map_expand, map_cyclotomic, expand_eval, ← IsRoot.def,
         @isRoot_cyclotomic_iff]
       convert IsPrimitiveRoot.pow_of_dvd hprim hp.ne_zero (dvd_mul_left p n)
       rw [Nat.mul_div_cancel _ (Nat.Prime.pos hp)]
     · have hprim := Complex.isPrimitiveRoot_exp _ hnpos.ne.symm
       rw [cyclotomic_eq_minpoly_rat hprim hnpos]
-      refine' @minpoly.dvd ℚ ℂ _ _ algebraRat _ _ _
+      refine' minpoly.dvd ℚ _ _
       rw [aeval_def, ← eval_map, map_expand, expand_eval, ← IsRoot.def, ←
         cyclotomic_eq_minpoly_rat hprim hnpos, map_cyclotomic, @isRoot_cyclotomic_iff]
       exact IsPrimitiveRoot.pow_of_prime hprim hp hdiv
@@ -82,7 +84,7 @@ theorem cyclotomic_expand_eq_cyclotomic {p n : ℕ} (hp : Nat.Prime p) (hdiv : p
   haveI := NeZero.of_pos hzero
   suffices expand ℤ p (cyclotomic n ℤ) = cyclotomic (n * p) ℤ by
     rw [← map_cyclotomic_int, ← map_expand, this, map_cyclotomic_int]
-  refine' eq_of_monic_of_dvd_of_natDegree_le (cyclotomic.monic _ _)
+  refine' eq_of_monic_of_dvd_of_natDegree_le (cyclotomic.monic _ ℤ)
     ((cyclotomic.monic n ℤ).expand hp.pos) _ _
   · have hpos := Nat.mul_pos hzero hp.pos
     have hprim := Complex.isPrimitiveRoot_exp _ hpos.ne.symm

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
@@ -8,7 +8,6 @@ import Mathlib.Data.ZMod.Algebra
 
 #align_import ring_theory.polynomial.cyclotomic.expand from "leanprover-community/mathlib"@"0723536a0522d24fc2f159a096fb3304bef77472"
 
-set_option profiler true
 
 /-!
 # Cyclotomic polynomials and `expand`.

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
@@ -8,7 +8,6 @@ import Mathlib.Data.ZMod.Algebra
 
 #align_import ring_theory.polynomial.cyclotomic.expand from "leanprover-community/mathlib"@"0723536a0522d24fc2f159a096fb3304bef77472"
 
-
 /-!
 # Cyclotomic polynomials and `expand`.
 

--- a/Mathlib/RingTheory/Subring/Basic.lean
+++ b/Mathlib/RingTheory/Subring/Basic.lean
@@ -1474,18 +1474,3 @@ instance center.smulCommClass_right : SMulCommClass R (center R) R :=
 end Subring
 
 end Actions
-
--- while this definition is not about subrings, this is the earliest we have
--- both ordered ring structures and submonoids available
-/-- The subgroup of positive units of a linear ordered semiring. -/
-def Units.posSubgroup (R : Type*) [LinearOrderedSemiring R] : Subgroup Rˣ :=
-  { (Submonoid.pos R).comap (Units.coeHom R) with
-    carrier := { x | (0 : R) < x }
-    inv_mem' := Units.inv_pos.mpr }
-#align units.pos_subgroup Units.posSubgroup
-
-@[simp]
-theorem Units.mem_posSubgroup {R : Type*} [LinearOrderedSemiring R] (u : Rˣ) :
-    u ∈ Units.posSubgroup R ↔ (0 : R) < u :=
-  Iff.rfl
-#align units.mem_pos_subgroup Units.mem_posSubgroup

--- a/Mathlib/RingTheory/Subring/Basic.lean
+++ b/Mathlib/RingTheory/Subring/Basic.lean
@@ -116,40 +116,6 @@ instance (priority := 75) toCommRing {R} [CommRing R] [SetLike S R] [SubringClas
 instance (priority := 75) {R} [Ring R] [IsDomain R] [SetLike S R] [SubringClass S R] : IsDomain s :=
   NoZeroDivisors.to_isDomain _
 
--- Prefer subclasses of `Ring` over subclasses of `SubringClass`.
-/-- A subring of an `OrderedRing` is an `OrderedRing`. -/
-instance (priority := 75) toOrderedRing {R} [OrderedRing R] [SetLike S R] [SubringClass S R] :
-    OrderedRing s :=
-  Subtype.coe_injective.orderedRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) fun _ => rfl
-#align subring_class.to_ordered_ring SubringClass.toOrderedRing
-
--- Prefer subclasses of `Ring` over subclasses of `SubringClass`.
-/-- A subring of an `OrderedCommRing` is an `OrderedCommRing`. -/
-instance (priority := 75) toOrderedCommRing {R} [OrderedCommRing R] [SetLike S R]
-    [SubringClass S R] : OrderedCommRing s :=
-  Subtype.coe_injective.orderedCommRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) fun _ => rfl
-#align subring_class.to_ordered_comm_ring SubringClass.toOrderedCommRing
-
--- Prefer subclasses of `Ring` over subclasses of `SubringClass`.
-/-- A subring of a `LinearOrderedRing` is a `LinearOrderedRing`. -/
-instance (priority := 75) toLinearOrderedRing {R} [LinearOrderedRing R] [SetLike S R]
-    [SubringClass S R] : LinearOrderedRing s :=
-  Subtype.coe_injective.linearOrderedRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align subring_class.to_linear_ordered_ring SubringClass.toLinearOrderedRing
-
--- Prefer subclasses of `Ring` over subclasses of `SubringClass`.
-/-- A subring of a `LinearOrderedCommRing` is a `LinearOrderedCommRing`. -/
-instance (priority := 75) toLinearOrderedCommRing {R} [LinearOrderedCommRing R] [SetLike S R]
-    [SubringClass S R] : LinearOrderedCommRing s :=
-  Subtype.coe_injective.linearOrderedCommRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align subring_class.to_linear_ordered_comm_ring SubringClass.toLinearOrderedCommRing
-
 /-- The natural ring hom from a subring of ring `R` to `R`. -/
 def subtype (s : S) : s →+* R :=
   { SubmonoidClass.subtype s, AddSubgroupClass.subtype s with
@@ -466,27 +432,6 @@ instance {R} [Ring R] [NoZeroDivisors R] (s : Subring R) : NoZeroDivisors s :=
 /-- A subring of a domain is a domain. -/
 instance {R} [Ring R] [IsDomain R] (s : Subring R) : IsDomain s :=
   NoZeroDivisors.to_isDomain _
-
-/-- A subring of an `OrderedRing` is an `OrderedRing`. -/
-instance toOrderedRing {R} [OrderedRing R] (s : Subring R) : OrderedRing s :=
-  SubringClass.toOrderedRing s
-#align subring.to_ordered_ring Subring.toOrderedRing
-
-/-- A subring of an `OrderedCommRing` is an `OrderedCommRing`. -/
-instance toOrderedCommRing {R} [OrderedCommRing R] (s : Subring R) : OrderedCommRing s :=
-  SubringClass.toOrderedCommRing s
-#align subring.to_ordered_comm_ring Subring.toOrderedCommRing
-
-/-- A subring of a `LinearOrderedRing` is a `LinearOrderedRing`. -/
-instance toLinearOrderedRing {R} [LinearOrderedRing R] (s : Subring R) : LinearOrderedRing s :=
-  SubringClass.toLinearOrderedRing s
-#align subring.to_linear_ordered_ring Subring.toLinearOrderedRing
-
-/-- A subring of a `LinearOrderedCommRing` is a `LinearOrderedCommRing`. -/
-instance toLinearOrderedCommRing {R} [LinearOrderedCommRing R] (s : Subring R) :
-    LinearOrderedCommRing s :=
-  SubringClass.toLinearOrderedCommRing s
-#align subring.to_linear_ordered_comm_ring Subring.toLinearOrderedCommRing
 
 /-- The natural ring hom from a subring of ring `R` to `R`. -/
 def subtype (s : Subring R) : s →+* R :=

--- a/Mathlib/RingTheory/Subring/Order.lean
+++ b/Mathlib/RingTheory/Subring/Order.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2020 Ashvni Narayanan. All rights reserved.
+Copyright (c) 2021 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Ashvni Narayanan
+Authors: Damiano Testa
 -/
 
 import Mathlib.RingTheory.Subring.Basic

--- a/Mathlib/RingTheory/Subring/Order.lean
+++ b/Mathlib/RingTheory/Subring/Order.lean
@@ -55,22 +55,22 @@ namespace Subring
 variable {R : Type*}
 
 /-- A subring of an `OrderedRing` is an `OrderedRing`. -/
-instance toOrderedRing  [OrderedRing R] (s : Subring R) : OrderedRing s :=
+instance toOrderedRing [OrderedRing R] (s : Subring R) : OrderedRing s :=
   SubringClass.toOrderedRing s
 #align subring.to_ordered_ring Subring.toOrderedRing
 
 /-- A subring of an `OrderedCommRing` is an `OrderedCommRing`. -/
-instance toOrderedCommRing  [OrderedCommRing R] (s : Subring R) : OrderedCommRing s :=
+instance toOrderedCommRing [OrderedCommRing R] (s : Subring R) : OrderedCommRing s :=
   SubringClass.toOrderedCommRing s
 #align subring.to_ordered_comm_ring Subring.toOrderedCommRing
 
 /-- A subring of a `LinearOrderedRing` is a `LinearOrderedRing`. -/
-instance toLinearOrderedRing  [LinearOrderedRing R] (s : Subring R) : LinearOrderedRing s :=
+instance toLinearOrderedRing [LinearOrderedRing R] (s : Subring R) : LinearOrderedRing s :=
   SubringClass.toLinearOrderedRing s
 #align subring.to_linear_ordered_ring Subring.toLinearOrderedRing
 
 /-- A subring of a `LinearOrderedCommRing` is a `LinearOrderedCommRing`. -/
-instance toLinearOrderedCommRing  [LinearOrderedCommRing R] (s : Subring R) :
+instance toLinearOrderedCommRing [LinearOrderedCommRing R] (s : Subring R) :
     LinearOrderedCommRing s :=
   SubringClass.toLinearOrderedCommRing s
 #align subring.to_linear_ordered_comm_ring Subring.toLinearOrderedCommRing

--- a/Mathlib/RingTheory/Subring/Order.lean
+++ b/Mathlib/RingTheory/Subring/Order.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2020 Ashvni Narayanan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Ashvni Narayanan
+-/
+
+import Mathlib.RingTheory.Subring.Basic
+
+/-!
+
+# Ordered instances on subrings
+
+-/
+
+namespace SubringClass
+
+variable {R S : Type*} [SetLike S R] (s : S)
+
+-- Prefer subclasses of `Ring` over subclasses of `SubringClass`.
+/-- A subring of an `OrderedRing` is an `OrderedRing`. -/
+instance (priority := 75) toOrderedRing [OrderedRing R] [SubringClass S R] :
+    OrderedRing s :=
+  Subtype.coe_injective.orderedRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) fun _ => rfl
+#align subring_class.to_ordered_ring SubringClass.toOrderedRing
+
+-- Prefer subclasses of `Ring` over subclasses of `SubringClass`.
+/-- A subring of an `OrderedCommRing` is an `OrderedCommRing`. -/
+instance (priority := 75) toOrderedCommRing [OrderedCommRing R] [SubringClass S R] :
+    OrderedCommRing s :=
+  Subtype.coe_injective.orderedCommRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) fun _ => rfl
+#align subring_class.to_ordered_comm_ring SubringClass.toOrderedCommRing
+
+-- Prefer subclasses of `Ring` over subclasses of `SubringClass`.
+/-- A subring of a `LinearOrderedRing` is a `LinearOrderedRing`. -/
+instance (priority := 75) toLinearOrderedRing [LinearOrderedRing R] [SubringClass S R] :
+    LinearOrderedRing s :=
+  Subtype.coe_injective.linearOrderedRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align subring_class.to_linear_ordered_ring SubringClass.toLinearOrderedRing
+
+-- Prefer subclasses of `Ring` over subclasses of `SubringClass`.
+/-- A subring of a `LinearOrderedCommRing` is a `LinearOrderedCommRing`. -/
+instance (priority := 75) toLinearOrderedCommRing [LinearOrderedCommRing R] [SubringClass S R] :
+    LinearOrderedCommRing s :=
+  Subtype.coe_injective.linearOrderedCommRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align subring_class.to_linear_ordered_comm_ring SubringClass.toLinearOrderedCommRing
+
+end SubringClass
+
+namespace Subring
+
+variable {R : Type*}
+
+/-- A subring of an `OrderedRing` is an `OrderedRing`. -/
+instance toOrderedRing  [OrderedRing R] (s : Subring R) : OrderedRing s :=
+  SubringClass.toOrderedRing s
+#align subring.to_ordered_ring Subring.toOrderedRing
+
+/-- A subring of an `OrderedCommRing` is an `OrderedCommRing`. -/
+instance toOrderedCommRing  [OrderedCommRing R] (s : Subring R) : OrderedCommRing s :=
+  SubringClass.toOrderedCommRing s
+#align subring.to_ordered_comm_ring Subring.toOrderedCommRing
+
+/-- A subring of a `LinearOrderedRing` is a `LinearOrderedRing`. -/
+instance toLinearOrderedRing  [LinearOrderedRing R] (s : Subring R) : LinearOrderedRing s :=
+  SubringClass.toLinearOrderedRing s
+#align subring.to_linear_ordered_ring Subring.toLinearOrderedRing
+
+/-- A subring of a `LinearOrderedCommRing` is a `LinearOrderedCommRing`. -/
+instance toLinearOrderedCommRing  [LinearOrderedCommRing R] (s : Subring R) :
+    LinearOrderedCommRing s :=
+  SubringClass.toLinearOrderedCommRing s
+#align subring.to_linear_ordered_comm_ring Subring.toLinearOrderedCommRing
+
+end Subring

--- a/Mathlib/RingTheory/Subring/Order.lean
+++ b/Mathlib/RingTheory/Subring/Order.lean
@@ -6,6 +6,7 @@ Authors: Damiano Testa
 
 import Mathlib.GroupTheory.Subgroup.Order
 import Mathlib.RingTheory.Subsemiring.Order
+import Mathlib.RingTheory.Subring.Basic
 
 /-!
 # Ordered instances on subrings

--- a/Mathlib/RingTheory/Subring/Order.lean
+++ b/Mathlib/RingTheory/Subring/Order.lean
@@ -7,9 +7,7 @@ Authors: Ashvni Narayanan
 import Mathlib.RingTheory.Subring.Basic
 
 /-!
-
 # Ordered instances on subrings
-
 -/
 
 namespace SubringClass

--- a/Mathlib/RingTheory/Subring/Order.lean
+++ b/Mathlib/RingTheory/Subring/Order.lean
@@ -5,7 +5,7 @@ Authors: Damiano Testa
 -/
 
 import Mathlib.GroupTheory.Subgroup.Order
-import Mathlib.RingTheory.Subring.Order
+import Mathlib.RingTheory.Subsemiring.Order
 
 /-!
 # Ordered instances on subrings

--- a/Mathlib/RingTheory/Subring/Order.lean
+++ b/Mathlib/RingTheory/Subring/Order.lean
@@ -77,18 +77,3 @@ instance toLinearOrderedCommRing [LinearOrderedCommRing R] (s : Subring R) :
 #align subring.to_linear_ordered_comm_ring Subring.toLinearOrderedCommRing
 
 end Subring
-
--- while this definition is not about subrings, this is the earliest we have
--- both ordered ring structures and submonoids available
-/-- The subgroup of positive units of a linear ordered semiring. -/
-def Units.posSubgroup (R : Type*) [LinearOrderedSemiring R] : Subgroup Rˣ :=
-  { (Submonoid.pos R).comap (Units.coeHom R) with
-    carrier := { x | (0 : R) < x }
-    inv_mem' := Units.inv_pos.mpr }
-#align units.pos_subgroup Units.posSubgroup
-
-@[simp]
-theorem Units.mem_posSubgroup {R : Type*} [LinearOrderedSemiring R] (u : Rˣ) :
-    u ∈ Units.posSubgroup R ↔ (0 : R) < u :=
-  Iff.rfl
-#align units.mem_pos_subgroup Units.mem_posSubgroup

--- a/Mathlib/RingTheory/Subring/Order.lean
+++ b/Mathlib/RingTheory/Subring/Order.lean
@@ -4,14 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 
-import Mathlib.RingTheory.Subring.Basic
+import Mathlib.GroupTheory.Subgroup.Order
+import Mathlib.RingTheory.Subring.Order
 
 /-!
 # Ordered instances on subrings
 -/
 
 namespace SubringClass
-
 variable {R S : Type*} [SetLike S R] (s : S)
 
 -- Prefer subclasses of `Ring` over subclasses of `SubringClass`.

--- a/Mathlib/RingTheory/Subring/Order.lean
+++ b/Mathlib/RingTheory/Subring/Order.lean
@@ -5,8 +5,8 @@ Authors: Damiano Testa
 -/
 
 import Mathlib.GroupTheory.Subgroup.Order
-import Mathlib.RingTheory.Subsemiring.Order
 import Mathlib.RingTheory.Subring.Basic
+import Mathlib.RingTheory.Subsemiring.Order
 
 /-!
 # Ordered instances on subrings
@@ -77,3 +77,18 @@ instance toLinearOrderedCommRing [LinearOrderedCommRing R] (s : Subring R) :
 #align subring.to_linear_ordered_comm_ring Subring.toLinearOrderedCommRing
 
 end Subring
+
+-- while this definition is not about subrings, this is the earliest we have
+-- both ordered ring structures and submonoids available
+/-- The subgroup of positive units of a linear ordered semiring. -/
+def Units.posSubgroup (R : Type*) [LinearOrderedSemiring R] : Subgroup Rˣ :=
+  { (Submonoid.pos R).comap (Units.coeHom R) with
+    carrier := { x | (0 : R) < x }
+    inv_mem' := Units.inv_pos.mpr }
+#align units.pos_subgroup Units.posSubgroup
+
+@[simp]
+theorem Units.mem_posSubgroup {R : Type*} [LinearOrderedSemiring R] (u : Rˣ) :
+    u ∈ Units.posSubgroup R ↔ (0 : R) < u :=
+  Iff.rfl
+#align units.mem_pos_subgroup Units.mem_posSubgroup

--- a/Mathlib/RingTheory/Subring/Units.lean
+++ b/Mathlib/RingTheory/Subring/Units.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Chris Birbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Damiano Testa
+Authors: Chris Birbeck
 -/
 
 import Mathlib.GroupTheory.Submonoid.Order

--- a/Mathlib/RingTheory/Subring/Units.lean
+++ b/Mathlib/RingTheory/Subring/Units.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2021 Chris Birbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import Mathlib.GroupTheory.Submonoid.Order
+import Mathlib.RingTheory.Subring.Basic
+
+/-!
+
+# Unit subgroups of a ring
+
+-/
+
+def Units.posSubgroup (R : Type*) [LinearOrderedSemiring R] : Subgroup Rˣ :=
+  { (Submonoid.pos R).comap (Units.coeHom R) with
+    carrier := { x | (0 : R) < x }
+    inv_mem' := Units.inv_pos.mpr }
+#align units.pos_subgroup Units.posSubgroup
+
+@[simp]
+theorem Units.mem_posSubgroup {R : Type*} [LinearOrderedSemiring R] (u : Rˣ) :
+    u ∈ Units.posSubgroup R ↔ (0 : R) < u :=
+  Iff.rfl
+#align units.mem_pos_subgroup Units.mem_posSubgroup

--- a/Mathlib/RingTheory/Subring/Units.lean
+++ b/Mathlib/RingTheory/Subring/Units.lean
@@ -5,7 +5,7 @@ Authors: Damiano Testa
 -/
 
 import Mathlib.GroupTheory.Submonoid.Order
-import Mathlib.RingTheory.Subring.Basic
+import Mathlib.GroupTheory.Subgroup.Basic
 
 /-!
 
@@ -13,6 +13,7 @@ import Mathlib.RingTheory.Subring.Basic
 
 -/
 
+/-- The subgroup of positive units of a linear ordered semiring. -/
 def Units.posSubgroup (R : Type*) [LinearOrderedSemiring R] : Subgroup Rˣ :=
   { (Submonoid.pos R).comap (Units.coeHom R) with
     carrier := { x | (0 : R) < x }

--- a/Mathlib/RingTheory/Subsemiring/Basic.lean
+++ b/Mathlib/RingTheory/Subsemiring/Basic.lean
@@ -6,7 +6,6 @@ Authors: Yury Kudryashov
 import Mathlib.Algebra.Module.Basic
 import Mathlib.Algebra.Ring.Equiv
 import Mathlib.Algebra.Ring.Prod
-import Mathlib.Algebra.Order.Ring.InjSurj
 import Mathlib.Algebra.GroupRingAction.Subobjects
 import Mathlib.Data.Set.Finite
 import Mathlib.GroupTheory.Submonoid.Centralizer
@@ -132,48 +131,6 @@ instance toCommSemiring {R} [CommSemiring R] [SetLike S R] [SubsemiringClass S R
   Subtype.coe_injective.commSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ => rfl
 #align subsemiring_class.to_comm_semiring SubsemiringClass.toCommSemiring
-
-/-- A subsemiring of an `OrderedSemiring` is an `OrderedSemiring`. -/
-instance toOrderedSemiring {R} [OrderedSemiring R] [SetLike S R] [SubsemiringClass S R] :
-    OrderedSemiring s :=
-  Subtype.coe_injective.orderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
-#align subsemiring_class.to_ordered_semiring SubsemiringClass.toOrderedSemiring
-
-/-- A subsemiring of a `StrictOrderedSemiring` is a `StrictOrderedSemiring`. -/
-instance toStrictOrderedSemiring {R} [StrictOrderedSemiring R] [SetLike S R]
-    [SubsemiringClass S R] : StrictOrderedSemiring s :=
-  Subtype.coe_injective.strictOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
-#align subsemiring_class.to_strict_ordered_semiring SubsemiringClass.toStrictOrderedSemiring
-
-/-- A subsemiring of an `OrderedCommSemiring` is an `OrderedCommSemiring`. -/
-instance toOrderedCommSemiring {R} [OrderedCommSemiring R] [SetLike S R] [SubsemiringClass S R] :
-    OrderedCommSemiring s :=
-  Subtype.coe_injective.orderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
-#align subsemiring_class.to_ordered_comm_semiring SubsemiringClass.toOrderedCommSemiring
-
-/-- A subsemiring of a `StrictOrderedCommSemiring` is a `StrictOrderedCommSemiring`. -/
-instance toStrictOrderedCommSemiring {R} [StrictOrderedCommSemiring R] [SetLike S R]
-    [SubsemiringClass S R] : StrictOrderedCommSemiring s :=
-  Subtype.coe_injective.strictOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
-#align subsemiring_class.to_strict_ordered_comm_semiring SubsemiringClass.toStrictOrderedCommSemiring
-
-/-- A subsemiring of a `LinearOrderedSemiring` is a `LinearOrderedSemiring`. -/
-instance toLinearOrderedSemiring {R} [LinearOrderedSemiring R] [SetLike S R]
-    [SubsemiringClass S R] : LinearOrderedSemiring s :=
-  Subtype.coe_injective.linearOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align subsemiring_class.to_linear_ordered_semiring SubsemiringClass.toLinearOrderedSemiring
-
-/-- A subsemiring of a `LinearOrderedCommSemiring` is a `LinearOrderedCommSemiring`. -/
-instance toLinearOrderedCommSemiring {R} [LinearOrderedCommSemiring R] [SetLike S R]
-    [SubsemiringClass S R] : LinearOrderedCommSemiring s :=
-  Subtype.coe_injective.linearOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align subsemiring_class.to_linear_ordered_comm_semiring SubsemiringClass.toLinearOrderedCommSemiring
 
 instance instCharZero [CharZero R] : CharZero s :=
   ⟨Function.Injective.of_comp (f := Subtype.val) (g := Nat.cast (R := s)) Nat.cast_injective⟩
@@ -435,47 +392,6 @@ def subtype : s →+* R :=
 theorem coe_subtype : ⇑s.subtype = ((↑) : s → R) :=
   rfl
 #align subsemiring.coe_subtype Subsemiring.coe_subtype
-
-/-- A subsemiring of an `OrderedSemiring` is an `OrderedSemiring`. -/
-instance toOrderedSemiring {R} [OrderedSemiring R] (s : Subsemiring R) : OrderedSemiring s :=
-  Subtype.coe_injective.orderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
-#align subsemiring.to_ordered_semiring Subsemiring.toOrderedSemiring
-
-/-- A subsemiring of a `StrictOrderedSemiring` is a `StrictOrderedSemiring`. -/
-instance toStrictOrderedSemiring {R} [StrictOrderedSemiring R] (s : Subsemiring R) :
-    StrictOrderedSemiring s :=
-  Subtype.coe_injective.strictOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
-#align subsemiring.to_strict_ordered_semiring Subsemiring.toStrictOrderedSemiring
-
-/-- A subsemiring of an `OrderedCommSemiring` is an `OrderedCommSemiring`. -/
-instance toOrderedCommSemiring {R} [OrderedCommSemiring R] (s : Subsemiring R) :
-    OrderedCommSemiring s :=
-  Subtype.coe_injective.orderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
-#align subsemiring.to_ordered_comm_semiring Subsemiring.toOrderedCommSemiring
-
-/-- A subsemiring of a `StrictOrderedCommSemiring` is a `StrictOrderedCommSemiring`. -/
-instance toStrictOrderedCommSemiring {R} [StrictOrderedCommSemiring R] (s : Subsemiring R) :
-    StrictOrderedCommSemiring s :=
-  Subtype.coe_injective.strictOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
-#align subsemiring.to_strict_ordered_comm_semiring Subsemiring.toStrictOrderedCommSemiring
-
-/-- A subsemiring of a `LinearOrderedSemiring` is a `LinearOrderedSemiring`. -/
-instance toLinearOrderedSemiring {R} [LinearOrderedSemiring R] (s : Subsemiring R) :
-    LinearOrderedSemiring s :=
-  Subtype.coe_injective.linearOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align subsemiring.to_linear_ordered_semiring Subsemiring.toLinearOrderedSemiring
-
-/-- A subsemiring of a `LinearOrderedCommSemiring` is a `LinearOrderedCommSemiring`. -/
-instance toLinearOrderedCommSemiring {R} [LinearOrderedCommSemiring R] (s : Subsemiring R) :
-    LinearOrderedCommSemiring s :=
-  Subtype.coe_injective.linearOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
-#align subsemiring.to_linear_ordered_comm_semiring Subsemiring.toLinearOrderedCommSemiring
 
 protected theorem nsmul_mem {x : R} (hx : x ∈ s) (n : ℕ) : n • x ∈ s :=
   nsmul_mem hx n
@@ -1469,12 +1385,3 @@ def closureCommSemiringOfComm {s : Set R'} (hcomm : ∀ a ∈ s, ∀ b ∈ s, a 
 end Subsemiring
 
 end Actions
-
-/-- The set of nonnegative elements in an ordered semiring, as a subsemiring. -/
-@[simps]
-def Subsemiring.nonneg (R : Type*) [OrderedSemiring R] : Subsemiring R where
-  carrier := Set.Ici 0
-  mul_mem' := mul_nonneg
-  one_mem' := zero_le_one
-  add_mem' := add_nonneg
-  zero_mem' := le_rfl

--- a/Mathlib/RingTheory/Subsemiring/Order.lean
+++ b/Mathlib/RingTheory/Subsemiring/Order.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2020 Yury Kudryashov All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+
+import Mathlib.RingTheory.Subsemiring.Basic
+import Mathlib.Algebra.Order.Ring.InjSurj
+
+/-!
+
+`Order`ed instances for `SubsemiringClass` and `Subsemiring`.
+
+-/
+
+namespace SubsemiringClass
+
+-- variable {R : Type u} {S : Type v} {T : Type w} [NonAssocSemiring R] (M : Submonoid R)
+-- variable [SetLike S R] [hSR : SubsemiringClass S R] (s : S)
+
+variable {R S : Type*} [SetLike S R] (s : S)
+
+/-- A subsemiring of an `OrderedSemiring` is an `OrderedSemiring`. -/
+instance toOrderedSemiring [OrderedSemiring R] [SubsemiringClass S R] :
+    OrderedSemiring s :=
+  Subtype.coe_injective.orderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+#align subsemiring_class.to_ordered_semiring SubsemiringClass.toOrderedSemiring
+
+/-- A subsemiring of a `StrictOrderedSemiring` is a `StrictOrderedSemiring`. -/
+instance toStrictOrderedSemiring {R} [StrictOrderedSemiring R] [SetLike S R]
+    [SubsemiringClass S R] : StrictOrderedSemiring s :=
+  Subtype.coe_injective.strictOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+#align subsemiring_class.to_strict_ordered_semiring SubsemiringClass.toStrictOrderedSemiring
+
+/-- A subsemiring of an `OrderedCommSemiring` is an `OrderedCommSemiring`. -/
+instance toOrderedCommSemiring {R} [OrderedCommSemiring R] [SetLike S R] [SubsemiringClass S R] :
+    OrderedCommSemiring s :=
+  Subtype.coe_injective.orderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+#align subsemiring_class.to_ordered_comm_semiring SubsemiringClass.toOrderedCommSemiring
+
+/-- A subsemiring of a `StrictOrderedCommSemiring` is a `StrictOrderedCommSemiring`. -/
+instance toStrictOrderedCommSemiring {R} [StrictOrderedCommSemiring R] [SetLike S R]
+    [SubsemiringClass S R] : StrictOrderedCommSemiring s :=
+  Subtype.coe_injective.strictOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+#align subsemiring_class.to_strict_ordered_comm_semiring SubsemiringClass.toStrictOrderedCommSemiring
+
+/-- A subsemiring of a `LinearOrderedSemiring` is a `LinearOrderedSemiring`. -/
+instance toLinearOrderedSemiring {R} [LinearOrderedSemiring R] [SetLike S R]
+    [SubsemiringClass S R] : LinearOrderedSemiring s :=
+  Subtype.coe_injective.linearOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align subsemiring_class.to_linear_ordered_semiring SubsemiringClass.toLinearOrderedSemiring
+
+/-- A subsemiring of a `LinearOrderedCommSemiring` is a `LinearOrderedCommSemiring`. -/
+instance toLinearOrderedCommSemiring {R} [LinearOrderedCommSemiring R] [SetLike S R]
+    [SubsemiringClass S R] : LinearOrderedCommSemiring s :=
+  Subtype.coe_injective.linearOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align subsemiring_class.to_linear_ordered_comm_semiring SubsemiringClass.toLinearOrderedCommSemiring
+
+end SubsemiringClass
+
+namespace Subsemiring
+
+variable {R : Type*}
+
+/-- A subsemiring of an `OrderedSemiring` is an `OrderedSemiring`. -/
+instance toOrderedSemiring [OrderedSemiring R] (s : Subsemiring R) : OrderedSemiring s :=
+  Subtype.coe_injective.orderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+#align subsemiring.to_ordered_semiring Subsemiring.toOrderedSemiring
+
+/-- A subsemiring of a `StrictOrderedSemiring` is a `StrictOrderedSemiring`. -/
+instance toStrictOrderedSemiring [StrictOrderedSemiring R] (s : Subsemiring R) :
+    StrictOrderedSemiring s :=
+  Subtype.coe_injective.strictOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+#align subsemiring.to_strict_ordered_semiring Subsemiring.toStrictOrderedSemiring
+
+/-- A subsemiring of an `OrderedCommSemiring` is an `OrderedCommSemiring`. -/
+instance toOrderedCommSemiring [OrderedCommSemiring R] (s : Subsemiring R) :
+    OrderedCommSemiring s :=
+  Subtype.coe_injective.orderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+#align subsemiring.to_ordered_comm_semiring Subsemiring.toOrderedCommSemiring
+
+/-- A subsemiring of a `StrictOrderedCommSemiring` is a `StrictOrderedCommSemiring`. -/
+instance toStrictOrderedCommSemiring [StrictOrderedCommSemiring R] (s : Subsemiring R) :
+    StrictOrderedCommSemiring s :=
+  Subtype.coe_injective.strictOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+#align subsemiring.to_strict_ordered_comm_semiring Subsemiring.toStrictOrderedCommSemiring
+
+/-- A subsemiring of a `LinearOrderedSemiring` is a `LinearOrderedSemiring`. -/
+instance toLinearOrderedSemiring [LinearOrderedSemiring R] (s : Subsemiring R) :
+    LinearOrderedSemiring s :=
+  Subtype.coe_injective.linearOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align subsemiring.to_linear_ordered_semiring Subsemiring.toLinearOrderedSemiring
+
+/-- A subsemiring of a `LinearOrderedCommSemiring` is a `LinearOrderedCommSemiring`. -/
+instance toLinearOrderedCommSemiring [LinearOrderedCommSemiring R] (s : Subsemiring R) :
+    LinearOrderedCommSemiring s :=
+  Subtype.coe_injective.linearOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
+    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
+#align subsemiring.to_linear_ordered_comm_semiring Subsemiring.toLinearOrderedCommSemiring
+
+/-- The set of nonnegative elements in an ordered semiring, as a subsemiring. -/
+@[simps]
+def nonneg (R : Type*) [OrderedSemiring R] : Subsemiring R where
+  carrier := Set.Ici 0
+  mul_mem' := mul_nonneg
+  one_mem' := zero_le_one
+  add_mem' := add_nonneg
+  zero_mem' := le_rfl
+
+end Subsemiring

--- a/Mathlib/RingTheory/Subsemiring/Order.lean
+++ b/Mathlib/RingTheory/Subsemiring/Order.lean
@@ -8,9 +8,7 @@ import Mathlib.RingTheory.Subsemiring.Basic
 import Mathlib.Algebra.Order.Ring.InjSurj
 
 /-!
-
-`Order`ed instances for `SubsemiringClass` and `Subsemiring`.
-
+# `Order`ed instances for `SubsemiringClass` and `Subsemiring`.
 -/
 
 namespace SubsemiringClass

--- a/Mathlib/RingTheory/Subsemiring/Order.lean
+++ b/Mathlib/RingTheory/Subsemiring/Order.lean
@@ -4,18 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 
-import Mathlib.RingTheory.Subsemiring.Basic
 import Mathlib.Algebra.Order.Ring.InjSurj
+import Mathlib.GroupTheory.Submonoid.Order
+import Mathlib.RingTheory.Subsemiring.Basic
 
 /-!
 # `Order`ed instances for `SubsemiringClass` and `Subsemiring`.
 -/
 
 namespace SubsemiringClass
-
--- variable {R : Type u} {S : Type v} {T : Type w} [NonAssocSemiring R] (M : Submonoid R)
--- variable [SetLike S R] [hSR : SubsemiringClass S R] (s : S)
-
 variable {R S : Type*} [SetLike S R] (s : S)
 
 /-- A subsemiring of an `OrderedSemiring` is an `OrderedSemiring`. -/
@@ -26,35 +23,35 @@ instance toOrderedSemiring [OrderedSemiring R] [SubsemiringClass S R] :
 #align subsemiring_class.to_ordered_semiring SubsemiringClass.toOrderedSemiring
 
 /-- A subsemiring of a `StrictOrderedSemiring` is a `StrictOrderedSemiring`. -/
-instance toStrictOrderedSemiring {R} [StrictOrderedSemiring R] [SetLike S R]
+instance toStrictOrderedSemiring [StrictOrderedSemiring R] [SetLike S R]
     [SubsemiringClass S R] : StrictOrderedSemiring s :=
   Subtype.coe_injective.strictOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 #align subsemiring_class.to_strict_ordered_semiring SubsemiringClass.toStrictOrderedSemiring
 
 /-- A subsemiring of an `OrderedCommSemiring` is an `OrderedCommSemiring`. -/
-instance toOrderedCommSemiring {R} [OrderedCommSemiring R] [SetLike S R] [SubsemiringClass S R] :
+instance toOrderedCommSemiring [OrderedCommSemiring R] [SetLike S R] [SubsemiringClass S R] :
     OrderedCommSemiring s :=
   Subtype.coe_injective.orderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 #align subsemiring_class.to_ordered_comm_semiring SubsemiringClass.toOrderedCommSemiring
 
 /-- A subsemiring of a `StrictOrderedCommSemiring` is a `StrictOrderedCommSemiring`. -/
-instance toStrictOrderedCommSemiring {R} [StrictOrderedCommSemiring R] [SetLike S R]
+instance toStrictOrderedCommSemiring [StrictOrderedCommSemiring R] [SetLike S R]
     [SubsemiringClass S R] : StrictOrderedCommSemiring s :=
   Subtype.coe_injective.strictOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 #align subsemiring_class.to_strict_ordered_comm_semiring SubsemiringClass.toStrictOrderedCommSemiring
 
 /-- A subsemiring of a `LinearOrderedSemiring` is a `LinearOrderedSemiring`. -/
-instance toLinearOrderedSemiring {R} [LinearOrderedSemiring R] [SetLike S R]
+instance toLinearOrderedSemiring [LinearOrderedSemiring R] [SetLike S R]
     [SubsemiringClass S R] : LinearOrderedSemiring s :=
   Subtype.coe_injective.linearOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 #align subsemiring_class.to_linear_ordered_semiring SubsemiringClass.toLinearOrderedSemiring
 
 /-- A subsemiring of a `LinearOrderedCommSemiring` is a `LinearOrderedCommSemiring`. -/
-instance toLinearOrderedCommSemiring {R} [LinearOrderedCommSemiring R] [SetLike S R]
+instance toLinearOrderedCommSemiring [LinearOrderedCommSemiring R] [SetLike S R]
     [SubsemiringClass S R] : LinearOrderedCommSemiring s :=
   Subtype.coe_injective.linearOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl

--- a/Mathlib/RingTheory/Subsemiring/Order.lean
+++ b/Mathlib/RingTheory/Subsemiring/Order.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2020 Yury Kudryashov All rights reserved.
+Copyright (c) 2021 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yury Kudryashov
+Authors: Damiano Testa
 -/
 
 import Mathlib.RingTheory.Subsemiring.Basic

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -278,6 +278,9 @@
   "Mathlib.Tactic.Basic": ["Std"],
   "Mathlib.Tactic.Attr.Register": ["Lean.Meta.Tactic.Simp.SimpTheorems"],
   "Mathlib.Tactic.ArithMult": ["Mathlib.Tactic.ArithMult.Init"],
+  "Mathlib.RingTheory.Subsemiring.Order":
+  ["Mathlib.GroupTheory.Submonoid.Order"],
+  "Mathlib.RingTheory.Subring.Order": ["Mathlib.GroupTheory.Subgroup.Order"],
   "Mathlib.RingTheory.PolynomialAlgebra": ["Mathlib.Data.Matrix.DMatrix"],
   "Mathlib.RingTheory.MvPolynomial.Homogeneous":
   ["Mathlib.Algebra.DirectSum.Internal"],
@@ -295,6 +298,7 @@
   "Mathlib.Init.Data.Nat.GCD": ["Std.Data.Nat.Gcd"],
   "Mathlib.Init.Data.Int.Basic": ["Std.Data.Int.Order"],
   "Mathlib.Init.Core": ["Std.Classes.Dvd"],
+  "Mathlib.GroupTheory.Subgroup.Order": ["Mathlib.GroupTheory.Submonoid.Order"],
   "Mathlib.Geometry.Manifold.Sheaf.Smooth":
   ["Mathlib.CategoryTheory.Sites.Whiskering"],
   "Mathlib.Data.Vector.Basic": ["Mathlib.Control.Applicative"],
@@ -315,8 +319,12 @@
   "Mathlib.Algebra.Ring.CentroidHom": ["Mathlib.Algebra.Algebra.Basic"],
   "Mathlib.Algebra.Order.Ring.Defs":
   ["Mathlib.Algebra.Order.Monoid.WithZero.Defs"],
+  "Mathlib.Algebra.Module.Submodule.Order":
+  ["Mathlib.GroupTheory.Subgroup.Order", "Mathlib.GroupTheory.Submonoid.Order"],
   "Mathlib.Algebra.Module.LinearMap.Basic": ["Mathlib.Algebra.Star.Basic"],
   "Mathlib.Algebra.Module.LinearMap": ["Mathlib.Algebra.Star.Basic"],
   "Mathlib.Algebra.Homology.ModuleCat": ["Mathlib.Algebra.Homology.Homotopy"],
   "Mathlib.Algebra.Category.Ring.Basic":
-  ["Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso"]}}
+  ["Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso"],
+  "Mathlib.Algebra.Algebra.Subalgebra.Order":
+  ["Mathlib.Algebra.Module.Submodule.Order"]}}


### PR DESCRIPTION
Moving these to separate files should make typeclass synthesis less expensive. Additionally two of them are quite long and this shrinks them slightly.

This handles:
* `Submonoid`
* `Subgroup`
* `Subsemiring`
* `Subring`
* `Subfield`
* `Submodule`
* `Subalgebra`

This also moves `Units.posSubgroup` into its own file.

The copyright headers are from:
* https://github.com/leanprover-community/mathlib/pull/6489
* https://github.com/leanprover-community/mathlib/pull/8466

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
