### PR TITLE
[Merged by Bors] - feat(Logic/Equiv/Defs): composing an `EquivLike` with its `symm`

### DIFF
--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -293,6 +293,22 @@ theorem Perm.coe_subsingleton {α : Type*} [Subsingleton α] (e : Perm α) : (e 
 @[simp] theorem self_comp_symm (e : α ≃ β) : e ∘ e.symm = id := funext e.apply_symm_apply
 #align equiv.self_comp_symm Equiv.self_comp_symm
 
+@[simp] lemma _root_.EquivLike.apply_coe_symm_apply {F} [EquivLike F α β] (e : F) (x : β) :
+    e ((e : α ≃ β).symm x) = x :=
+  (e : α ≃ β).apply_symm_apply x
+
+@[simp] lemma _root_.EquivLike.coe_symm_apply_apply {F} [EquivLike F α β] (e : F) (x : α) :
+    (e : α ≃ β).symm (e x) = x :=
+  (e : α ≃ β).symm_apply_apply x
+
+@[simp] lemma _root_.EquivLike.coe_symm_comp_self {F} [EquivLike F α β] (e : F) :
+    (e : α ≃ β).symm ∘ e = id :=
+  (e : α ≃ β).symm_comp_self
+
+@[simp] lemma _root_.EquivLike.self_comp_coe_symm {F} [EquivLike F α β] (e : F) :
+    e ∘ (e : α ≃ β).symm = id :=
+  (e : α ≃ β).self_comp_symm
+
 @[simp] theorem symm_trans_apply (f : α ≃ β) (g : β ≃ γ) (a : γ) :
     (f.trans g).symm a = f.symm (g.symm a) := rfl
 #align equiv.symm_trans_apply Equiv.symm_trans_apply


### PR DESCRIPTION
If you convert an `EquivLike` to an `Equiv` in order to use `symm`, you can get combinations of the coercion of that `EquivLike` direct to a function, and the coercion of that `symm` to a function, which should simplify but `simp` fails to do anything with.  Add four `simp` lemmas to enable `simp` to act on such combinations.

From AperiodicMonotilesLean.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
