### PR TITLE
[Merged by Bors] - feat: `Subsingleton.pairwise`

### DIFF
--- a/Mathlib/Logic/Pairwise.lean
+++ b/Mathlib/Logic/Pairwise.lean
@@ -42,6 +42,9 @@ protected theorem Pairwise.eq (h : Pairwise r) : ¬r a b → a = b :=
   not_imp_comm.1 <| @h _ _
 #align pairwise.eq Pairwise.eq
 
+protected lemma Subsingleton.pairwise [Subsingleton α] : Pairwise r :=
+  fun _ _ h ↦ False.elim <| h.elim <| Subsingleton.elim _ _
+
 theorem Function.injective_iff_pairwise_ne : Injective f ↔ Pairwise ((· ≠ ·) on f) :=
   forall₂_congr fun _i _j => not_imp_not.symm
 #align function.injective_iff_pairwise_ne Function.injective_iff_pairwise_ne


### PR DESCRIPTION
We have `Set.Subsingleton.pairwise`, but not, it seems, the corresponding lemma for `Pairwise` as applied to a relation on a subsingleton type rather than a subsingleton set.

From AperiodicMonotilesLean.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
