### PR TITLE
[Merged by Bors] - feat: breadcrumb path for `assert_not_exists`

### DIFF
--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -28,7 +28,7 @@ in the current import scope.
 Be careful to use names (e.g. `Rat`) rather than notations (e.g. `ℚ`).
 -/
 elab "assert_exists " n:ident : command => do
-  -- this throw an error if the user types something ambiguous or doesn't exist, otherwise succeed
+  -- this throws an error if the user types something ambiguous or doesn't exist, otherwise succeeds
   let _ ← resolveGlobalConstNoOverloadWithInfo n
 
 /--
@@ -47,9 +47,21 @@ In this case, you should refactor your work
 (for example by creating new files rather than adding imports to existing files).
 You should *not* delete the `assert_not_exists` statement without careful discussion ahead of time.
 -/
-elab "assert_not_exists " n:ident : command =>
-  do let [] ← try resolveGlobalConstWithInfos n catch _ => return
-      | throw <| .error n m!"Declaration {n} is not allowed to be imported by this file.\n\n\
-          These invariants are maintained by `assert_not_exists` statements, \
-          and exist in order to ensure that \"complicated\" parts of the library \
-          are not accidentally introduced as dependencies of \"simple\" parts of the library."
+elab "assert_not_exists " n:ident : command => do
+  let decl ← try resolveGlobalConstNoOverloadWithInfo n catch _ => return
+  let env ← getEnv
+  let c ← mkConstWithLevelParams decl
+  let msg ← (do
+    let mut some idx := env.getModuleIdxFor? decl
+      | pure m!"Declaration {c} is defined in this file."
+    let mut msg := m!"Declaration {c} is not allowed to be imported by this file.\n\
+      It is defined in {env.header.moduleNames[idx.toNat]!},"
+    for i in [idx.toNat+1:env.header.moduleData.size] do
+      if env.header.moduleData[i]!.imports.any (·.module == env.header.moduleNames[idx.toNat]!) then
+        idx := i
+        msg := msg ++ m!"\n  which is imported by {env.header.moduleNames[i]!},"
+    pure <| msg ++ m!"\n  which is imported by this file.")
+  throw <| .error n m!"{msg}\n\n\
+    These invariants are maintained by `assert_not_exists` statements, \
+    and exist in order to ensure that \"complicated\" parts of the library \
+    are not accidentally introduced as dependencies of \"simple\" parts of the library."

--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -28,7 +28,8 @@ in the current import scope.
 Be careful to use names (e.g. `Rat`) rather than notations (e.g. `ℚ`).
 -/
 elab "assert_exists " n:ident : command => do
-  -- this throws an error if the user types something ambiguous or doesn't exist, otherwise succeeds
+  -- this throws an error if the user types something ambiguous or
+  -- something that doesn't exist, otherwise succeeds
   let _ ← resolveGlobalConstNoOverloadWithInfo n
 
 /--


### PR DESCRIPTION
As [requested on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/assert_not_exists/near/423181469).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
