### PR TITLE
[Merged by Bors] - chore(Topology/Sequences): split file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3767,6 +3767,7 @@ import Mathlib.Topology.Covering
 import Mathlib.Topology.Defs.Basic
 import Mathlib.Topology.Defs.Filter
 import Mathlib.Topology.Defs.Induced
+import Mathlib.Topology.Defs.Sequences
 import Mathlib.Topology.DenseEmbedding
 import Mathlib.Topology.DiscreteQuotient
 import Mathlib.Topology.DiscreteSubset
@@ -3850,6 +3851,7 @@ import Mathlib.Topology.MetricSpace.PiNat
 import Mathlib.Topology.MetricSpace.Polish
 import Mathlib.Topology.MetricSpace.ProperSpace
 import Mathlib.Topology.MetricSpace.PseudoMetric
+import Mathlib.Topology.MetricSpace.Sequences
 import Mathlib.Topology.MetricSpace.ShrinkingLemma
 import Mathlib.Topology.MetricSpace.ThickenedIndicator
 import Mathlib.Topology.MetricSpace.Thickening

--- a/Mathlib/Topology/Defs/Sequences.lean
+++ b/Mathlib/Topology/Defs/Sequences.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2018 Jan-David Salchow. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jan-David Salchow, Patrick Massot, Yury Kudryashov
+-/
+import Mathlib.Topology.Defs.Filter
+
+/-!
+# Sequences in topological spaces
+
+In this file we define sequential closure, continuity, compactness etc.
+
+## Main definitions
+
+### Set operation
+* `seqClosure s`: sequential closure of a set, the set of limits of sequences of points of `s`;
+
+### Predicates
+
+* `IsSeqClosed s`: predicate saying that a set is sequentially closed, i.e., `seqClosure s ⊆ s`;
+* `SeqContinuous f`: predicate saying that a function is sequentially continuous, i.e.,
+  for any sequence `u : ℕ → X` that converges to a point `x`, the sequence `f ∘ u` converges to
+  `f x`;
+* `IsSeqCompact s`: predicate saying that a set is sequentially compact, i.e., every sequence
+  taking values in `s` has a converging subsequence.
+
+### Type classes
+
+* `FrechetUrysohnSpace X`: a typeclass saying that a topological space is a *Fréchet-Urysohn
+  space*, i.e., the sequential closure of any set is equal to its closure.
+* `SequentialSpace X`: a typeclass saying that a topological space is a *sequential space*, i.e.,
+  any sequentially closed set in this space is closed. This condition is weaker than being a
+  Fréchet-Urysohn space.
+* `SeqCompactSpace X`: a typeclass saying that a topological space is sequentially compact, i.e.,
+  every sequence in `X` has a converging subsequence.
+
+## Tags
+
+sequentially closed, sequentially compact, sequential space
+-/
+
+open Set Filter
+open scoped Topology
+
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+
+/-- The sequential closure of a set `s : Set X` in a topological space `X` is the set of all `a : X`
+which arise as limit of sequences in `s`. Note that the sequential closure of a set is not
+guaranteed to be sequentially closed. -/
+def seqClosure (s : Set X) : Set X :=
+  { a | ∃ x : ℕ → X, (∀ n : ℕ, x n ∈ s) ∧ Tendsto x atTop (𝓝 a) }
+#align seq_closure seqClosure
+
+/-- A set `s` is sequentially closed if for any converging sequence `x n` of elements of `s`, the
+limit belongs to `s` as well. Note that the sequential closure of a set is not guaranteed to be
+sequentially closed. -/
+def IsSeqClosed (s : Set X) : Prop :=
+  ∀ ⦃x : ℕ → X⦄ ⦃p : X⦄, (∀ n, x n ∈ s) → Tendsto x atTop (𝓝 p) → p ∈ s
+#align is_seq_closed IsSeqClosed
+
+/-- A function between topological spaces is sequentially continuous if it commutes with limit of
+ convergent sequences. -/
+def SeqContinuous (f : X → Y) : Prop :=
+  ∀ ⦃x : ℕ → X⦄ ⦃p : X⦄, Tendsto x atTop (𝓝 p) → Tendsto (f ∘ x) atTop (𝓝 (f p))
+#align seq_continuous SeqContinuous
+
+/-- A set `s` is sequentially compact if every sequence taking values in `s` has a
+converging subsequence. -/
+def IsSeqCompact (s : Set X) :=
+  ∀ ⦃x : ℕ → X⦄, (∀ n, x n ∈ s) → ∃ a ∈ s, ∃ φ : ℕ → ℕ, StrictMono φ ∧ Tendsto (x ∘ φ) atTop (𝓝 a)
+#align is_seq_compact IsSeqCompact
+
+variable (X)
+
+/-- A space `X` is sequentially compact if every sequence in `X` has a
+converging subsequence. -/
+@[mk_iff]
+class SeqCompactSpace : Prop where
+  seq_compact_univ : IsSeqCompact (univ : Set X)
+#align seq_compact_space SeqCompactSpace
+#align seq_compact_space_iff seqCompactSpace_iff
+
+export SeqCompactSpace (seq_compact_univ)
+
+/-- A topological space is called a *Fréchet-Urysohn space*, if the sequential closure of any set
+is equal to its closure. Since one of the inclusions is trivial, we require only the non-trivial one
+in the definition. -/
+class FrechetUrysohnSpace : Prop where
+  closure_subset_seqClosure : ∀ s : Set X, closure s ⊆ seqClosure s
+#align frechet_urysohn_space FrechetUrysohnSpace
+
+/-- A topological space is said to be a *sequential space* if any sequentially closed set in this
+space is closed. This condition is weaker than being a Fréchet-Urysohn space. -/
+class SequentialSpace : Prop where
+  isClosed_of_seq : ∀ s : Set X, IsSeqClosed s → IsClosed s
+#align sequential_space SequentialSpace
+
+variable {X}
+
+/-- In a sequential space, a sequentially closed set is closed. -/
+protected theorem IsSeqClosed.isClosed [SequentialSpace X] {s : Set X} (hs : IsSeqClosed s) :
+    IsClosed s :=
+  SequentialSpace.isClosed_of_seq s hs
+#align is_seq_closed.is_closed IsSeqClosed.isClosed

--- a/Mathlib/Topology/MetricSpace/Sequences.lean
+++ b/Mathlib/Topology/MetricSpace/Sequences.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2018 Jan-David Salchow. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jan-David Salchow, Patrick Massot, Yury Kudryashov
+-/
+import Mathlib.Topology.Sequences
+
+/-!
+# Sequencial compacts in metric spaces
+
+In this file we prove 2 versions of Bolzano-Weistrass theorem for proper metric spaces.
+-/
+
+open Filter Bornology Metric
+open scoped Topology
+
+variable {X : Type*} [PseudoMetricSpace X]
+
+@[deprecated lebesgue_number_lemma_of_metric] -- 2024-02-24
+nonrec theorem SeqCompact.lebesgue_number_lemma_of_metric {ι : Sort*} {c : ι → Set X} {s : Set X}
+    (hs : IsSeqCompact s) (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : s ⊆ ⋃ i, c i) :
+    ∃ δ > 0, ∀ a ∈ s, ∃ i, ball a δ ⊆ c i :=
+  lebesgue_number_lemma_of_metric hs.isCompact hc₁ hc₂
+#align seq_compact.lebesgue_number_lemma_of_metric SeqCompact.lebesgue_number_lemma_of_metric
+
+variable [ProperSpace X] {s : Set X}
+
+/-- A version of **Bolzano-Weistrass**: in a proper metric space (eg. $ℝ^n$),
+every bounded sequence has a converging subsequence. This version assumes only
+that the sequence is frequently in some bounded set. -/
+theorem tendsto_subseq_of_frequently_bounded (hs : IsBounded s) {x : ℕ → X}
+    (hx : ∃ᶠ n in atTop, x n ∈ s) :
+    ∃ a ∈ closure s, ∃ φ : ℕ → ℕ, StrictMono φ ∧ Tendsto (x ∘ φ) atTop (𝓝 a) :=
+  have hcs : IsSeqCompact (closure s) := hs.isCompact_closure.isSeqCompact
+  have hu' : ∃ᶠ n in atTop, x n ∈ closure s := hx.mono fun _n hn => subset_closure hn
+  hcs.subseq_of_frequently_in hu'
+#align tendsto_subseq_of_frequently_bounded tendsto_subseq_of_frequently_bounded
+
+/-- A version of **Bolzano-Weistrass**: in a proper metric space (eg. $ℝ^n$),
+every bounded sequence has a converging subsequence. -/
+theorem tendsto_subseq_of_bounded (hs : IsBounded s) {x : ℕ → X} (hx : ∀ n, x n ∈ s) :
+    ∃ a ∈ closure s, ∃ φ : ℕ → ℕ, StrictMono φ ∧ Tendsto (x ∘ φ) atTop (𝓝 a) :=
+  tendsto_subseq_of_frequently_bounded hs <| frequently_of_forall hx
+#align tendsto_subseq_of_bounded tendsto_subseq_of_bounded
+

--- a/Mathlib/Topology/MetricSpace/Sequences.lean
+++ b/Mathlib/Topology/MetricSpace/Sequences.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jan-David Salchow, Patrick Massot, Yury Kudryashov
 -/
 import Mathlib.Topology.Sequences
+import Mathlib.Topology.MetricSpace.Bounded
 
 /-!
 # Sequencial compacts in metric spaces

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Jan-David Salchow. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jan-David Salchow, Patrick Massot, Yury Kudryashov
 -/
+import Mathlib.Topology.Defs.Sequences
 import Mathlib.Topology.MetricSpace.Bounded
 
 #align_import topology.sequences from "leanprover-community/mathlib"@"f2ce6086713c78a7f880485f7917ea547a215982"
@@ -10,10 +11,13 @@ import Mathlib.Topology.MetricSpace.Bounded
 /-!
 # Sequences in topological spaces
 
-In this file we define sequences in topological spaces and show how they are related to
-filters and the topology.
+In this file we prove theorems about relations
+between closure/compactness/continuity etc and their sequential counterparts.
 
 ## Main definitions
+
+The following notions are defined in `Topology/Defs/Sequences`.
+We build theory about these definitions here, so we remind the definitions.
 
 ### Set operation
 * `seqClosure s`: sequential closure of a set, the set of limits of sequences of points of `s`;
@@ -66,17 +70,9 @@ variable {X Y : Type*}
 
 /-! ### Sequential closures, sequential continuity, and sequential spaces. -/
 
-
 section TopologicalSpace
 
 variable [TopologicalSpace X] [TopologicalSpace Y]
-
-/-- The sequential closure of a set `s : Set X` in a topological space `X` is the set of all `a : X`
-which arise as limit of sequences in `s`. Note that the sequential closure of a set is not
-guaranteed to be sequentially closed. -/
-def seqClosure (s : Set X) : Set X :=
-  { a | ∃ x : ℕ → X, (∀ n : ℕ, x n ∈ s) ∧ Tendsto x atTop (𝓝 a) }
-#align seq_closure seqClosure
 
 theorem subset_seqClosure {s : Set X} : s ⊆ seqClosure s := fun p hp =>
   ⟨const ℕ p, fun _ => hp, tendsto_const_nhds⟩
@@ -87,13 +83,6 @@ The converse is not true. -/
 theorem seqClosure_subset_closure {s : Set X} : seqClosure s ⊆ closure s := fun _p ⟨_x, xM, xp⟩ =>
   mem_closure_of_tendsto xp (univ_mem' xM)
 #align seq_closure_subset_closure seqClosure_subset_closure
-
-/-- A set `s` is sequentially closed if for any converging sequence `x n` of elements of `s`, the
-limit belongs to `s` as well. Note that the sequential closure of a set is not guaranteed to be
-sequentially closed. -/
-def IsSeqClosed (s : Set X) : Prop :=
-  ∀ ⦃x : ℕ → X⦄ ⦃p : X⦄, (∀ n, x n ∈ s) → Tendsto x atTop (𝓝 p) → p ∈ s
-#align is_seq_closed IsSeqClosed
 
 /-- The sequential closure of a sequentially closed set is the set itself. -/
 theorem IsSeqClosed.seqClosure_eq {s : Set X} (hs : IsSeqClosed s) : seqClosure s = s :=
@@ -114,13 +103,6 @@ theorem isSeqClosed_iff {s : Set X} : IsSeqClosed s ↔ seqClosure s = s :=
 protected theorem IsClosed.isSeqClosed {s : Set X} (hc : IsClosed s) : IsSeqClosed s :=
   fun _u _x hu hx => hc.mem_of_tendsto hx (eventually_of_forall hu)
 #align is_closed.is_seq_closed IsClosed.isSeqClosed
-
-/-- A topological space is called a *Fréchet-Urysohn space*, if the sequential closure of any set
-is equal to its closure. Since one of the inclusions is trivial, we require only the non-trivial one
-in the definition. -/
-class FrechetUrysohnSpace (X : Type*) [TopologicalSpace X] : Prop where
-  closure_subset_seqClosure : ∀ s : Set X, closure s ⊆ seqClosure s
-#align frechet_urysohn_space FrechetUrysohnSpace
 
 theorem seqClosure_eq_closure [FrechetUrysohnSpace X] (s : Set X) : seqClosure s = closure s :=
   seqClosure_subset_closure.antisymm <| FrechetUrysohnSpace.closure_subset_seqClosure s
@@ -176,12 +158,6 @@ instance (priority := 100) FirstCountableTopology.frechetUrysohnSpace
   FrechetUrysohnSpace.of_seq_tendsto_imp_tendsto fun _ _ => tendsto_iff_seq_tendsto.2
 #align topological_space.first_countable_topology.frechet_urysohn_space FirstCountableTopology.frechetUrysohnSpace
 
-/-- A topological space is said to be a *sequential space* if any sequentially closed set in this
-space is closed. This condition is weaker than being a Fréchet-Urysohn space. -/
-class SequentialSpace (X : Type*) [TopologicalSpace X] : Prop where
-  isClosed_of_seq : ∀ s : Set X, IsSeqClosed s → IsClosed s
-#align sequential_space SequentialSpace
-
 -- see Note [lower instance priority]
 /-- Every Fréchet-Urysohn space is a sequential space. -/
 instance (priority := 100) FrechetUrysohnSpace.to_sequentialSpace [FrechetUrysohnSpace X] :
@@ -189,22 +165,10 @@ instance (priority := 100) FrechetUrysohnSpace.to_sequentialSpace [FrechetUrysoh
   ⟨fun s hs => by rw [← closure_eq_iff_isClosed, ← seqClosure_eq_closure, hs.seqClosure_eq]⟩
 #align frechet_urysohn_space.to_sequential_space FrechetUrysohnSpace.to_sequentialSpace
 
-/-- In a sequential space, a sequentially closed set is closed. -/
-protected theorem IsSeqClosed.isClosed [SequentialSpace X] {s : Set X} (hs : IsSeqClosed s) :
-    IsClosed s :=
-  SequentialSpace.isClosed_of_seq s hs
-#align is_seq_closed.is_closed IsSeqClosed.isClosed
-
 /-- In a sequential space, a set is closed iff it's sequentially closed. -/
 theorem isSeqClosed_iff_isClosed [SequentialSpace X] {M : Set X} : IsSeqClosed M ↔ IsClosed M :=
   ⟨IsSeqClosed.isClosed, IsClosed.isSeqClosed⟩
 #align is_seq_closed_iff_is_closed isSeqClosed_iff_isClosed
-
-/-- A function between topological spaces is sequentially continuous if it commutes with limit of
- convergent sequences. -/
-def SeqContinuous (f : X → Y) : Prop :=
-  ∀ ⦃x : ℕ → X⦄ ⦃p : X⦄, Tendsto x atTop (𝓝 p) → Tendsto (f ∘ x) atTop (𝓝 (f p))
-#align seq_continuous SeqContinuous
 
 /-- The preimage of a sequentially closed set under a sequentially continuous map is sequentially
 closed. -/
@@ -246,22 +210,6 @@ section SeqCompact
 open TopologicalSpace FirstCountableTopology
 
 variable [TopologicalSpace X]
-
-/-- A set `s` is sequentially compact if every sequence taking values in `s` has a
-converging subsequence. -/
-def IsSeqCompact (s : Set X) :=
-  ∀ ⦃x : ℕ → X⦄, (∀ n, x n ∈ s) → ∃ a ∈ s, ∃ φ : ℕ → ℕ, StrictMono φ ∧ Tendsto (x ∘ φ) atTop (𝓝 a)
-#align is_seq_compact IsSeqCompact
-
-/-- A space `X` is sequentially compact if every sequence in `X` has a
-converging subsequence. -/
-@[mk_iff]
-class SeqCompactSpace (X : Type*) [TopologicalSpace X] : Prop where
-  seq_compact_univ : IsSeqCompact (univ : Set X)
-#align seq_compact_space SeqCompactSpace
-#align seq_compact_space_iff seqCompactSpace_iff
-
-export SeqCompactSpace (seq_compact_univ)
 
 theorem IsSeqCompact.subseq_of_frequently_in {s : Set X} (hs : IsSeqCompact s) {x : ℕ → X}
     (hx : ∃ᶠ n in atTop, x n ∈ s) :
@@ -398,37 +346,3 @@ theorem UniformSpace.compactSpace_iff_seqCompactSpace : CompactSpace X ↔ SeqCo
 #align uniform_space.compact_space_iff_seq_compact_space UniformSpace.compactSpace_iff_seqCompactSpace
 
 end UniformSpaceSeqCompact
-
-section MetricSeqCompact
-
-variable [PseudoMetricSpace X]
-
-open Metric
-
-nonrec theorem SeqCompact.lebesgue_number_lemma_of_metric {ι : Sort*} {c : ι → Set X} {s : Set X}
-    (hs : IsSeqCompact s) (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : s ⊆ ⋃ i, c i) :
-    ∃ δ > 0, ∀ a ∈ s, ∃ i, ball a δ ⊆ c i :=
-  lebesgue_number_lemma_of_metric hs.isCompact hc₁ hc₂
-#align seq_compact.lebesgue_number_lemma_of_metric SeqCompact.lebesgue_number_lemma_of_metric
-
-variable [ProperSpace X] {s : Set X}
-
-/-- A version of **Bolzano-Weistrass**: in a proper metric space (eg. $ℝ^n$),
-every bounded sequence has a converging subsequence. This version assumes only
-that the sequence is frequently in some bounded set. -/
-theorem tendsto_subseq_of_frequently_bounded (hs : IsBounded s) {x : ℕ → X}
-    (hx : ∃ᶠ n in atTop, x n ∈ s) :
-    ∃ a ∈ closure s, ∃ φ : ℕ → ℕ, StrictMono φ ∧ Tendsto (x ∘ φ) atTop (𝓝 a) :=
-  have hcs : IsSeqCompact (closure s) := hs.isCompact_closure.isSeqCompact
-  have hu' : ∃ᶠ n in atTop, x n ∈ closure s := hx.mono fun _n hn => subset_closure hn
-  hcs.subseq_of_frequently_in hu'
-#align tendsto_subseq_of_frequently_bounded tendsto_subseq_of_frequently_bounded
-
-/-- A version of Bolzano-Weistrass: in a proper metric space (eg. $ℝ^n$),
-every bounded sequence has a converging subsequence. -/
-theorem tendsto_subseq_of_bounded (hs : IsBounded s) {x : ℕ → X} (hx : ∀ n, x n ∈ s) :
-    ∃ a ∈ closure s, ∃ φ : ℕ → ℕ, StrictMono φ ∧ Tendsto (x ∘ φ) atTop (𝓝 a) :=
-  tendsto_subseq_of_frequently_bounded hs <| frequently_of_forall hx
-#align tendsto_subseq_of_bounded tendsto_subseq_of_bounded
-
-end MetricSeqCompact

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jan-David Salchow, Patrick Massot, Yury Kudryashov
 -/
 import Mathlib.Topology.Defs.Sequences
-import Mathlib.Topology.MetricSpace.Bounded
+import Mathlib.Topology.UniformSpace.Cauchy
 
 #align_import topology.sequences from "leanprover-community/mathlib"@"f2ce6086713c78a7f880485f7917ea547a215982"
 


### PR DESCRIPTION
I want to have access to the definitions much earlier.
Also, most of the file doesn't need metric spaces at all.

---

The number of lines increased by >60
because I copied a part of the docstring without deleting it.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
