### PR TITLE
[Merged by Bors] - fix: typo

### DIFF
--- a/Mathlib/RingTheory/Subring/Units.lean
+++ b/Mathlib/RingTheory/Subring/Units.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2021 Chris Birbeck. All rights reserved.
+Copyright (c) 2021 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Chris Birbeck
+Authors: Chris Birkbeck
 -/
 
 import Mathlib.GroupTheory.Submonoid.Order


### PR DESCRIPTION

This was accidentally mangled in #10900.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
