### PR TITLE
[Merged by Bors] - chore: classify `need dsimp only` porting notes

### DIFF
--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -1048,14 +1048,14 @@ noncomputable def gcdMonoidOfGCD [DecidableEq α] (gcd : α → α → α)
     lcm := fun a b =>
       if a = 0 then 0 else Classical.choose ((gcd_dvd_left a b).trans (Dvd.intro b rfl))
     gcd_mul_lcm := fun a b => by
-      -- Porting note: need `dsimp only` before `split_ifs`
+      -- Porting note (#10971): need `dsimp only` before `split_ifs`
       dsimp only
       split_ifs with a0
       · rw [mul_zero, a0, zero_mul]
       · rw [← Classical.choose_spec ((gcd_dvd_left a b).trans (Dvd.intro b rfl))]
     lcm_zero_left := fun a => if_pos rfl
     lcm_zero_right := fun a => by
-      -- Porting note: need `dsimp only` before `split_ifs`
+      -- Porting note (#10971): need `dsimp only` before `split_ifs`
       dsimp only
       split_ifs with a0
       · rfl
@@ -1108,7 +1108,7 @@ noncomputable def normalizedGCDMonoidOfGCD [NormalizationMonoid α] [DecidableEq
         rw [← normalize_gcd] at this
         rwa [normalize.map_mul, normalize_gcd, mul_right_inj' h1] at h2
     gcd_mul_lcm := fun a b => by
-      -- Porting note: need `dsimp only`
+      -- Porting note (#10971): need `dsimp only`
       dsimp only
       split_ifs with a0
       · rw [mul_zero, a0, zero_mul]
@@ -1117,7 +1117,7 @@ noncomputable def normalizedGCDMonoidOfGCD [NormalizationMonoid α] [DecidableEq
         exact normalize_associated (a * b)
     lcm_zero_left := fun a => if_pos rfl
     lcm_zero_right := fun a => by
-      -- Porting note: need `dsimp only`
+      -- Porting note (#10971): need `dsimp only`
       dsimp only
       split_ifs with a0
       · rfl
@@ -1141,7 +1141,7 @@ noncomputable def gcdMonoidOfLCM [DecidableEq α] (lcm : α → α → α)
   { lcm
     gcd := fun a b => if a = 0 then b else if b = 0 then a else Classical.choose (exists_gcd a b)
     gcd_mul_lcm := fun a b => by
-      -- Porting note: need `dsimp only`
+      -- Porting note (#10971): need `dsimp only`
       dsimp only
       split_ifs with h h_1
       · rw [h, eq_zero_of_zero_dvd (dvd_lcm_left _ _), mul_zero, zero_mul]
@@ -1150,7 +1150,7 @@ noncomputable def gcdMonoidOfLCM [DecidableEq α] (lcm : α → α → α)
     lcm_zero_left := fun a => eq_zero_of_zero_dvd (dvd_lcm_left _ _)
     lcm_zero_right := fun a => eq_zero_of_zero_dvd (dvd_lcm_right _ _)
     gcd_dvd_left := fun a b => by
-      -- Porting note: need `dsimp only`
+      -- Porting note (#10971): need `dsimp only`
       dsimp only
       split_ifs with h h_1
       · rw [h]
@@ -1167,7 +1167,7 @@ noncomputable def gcdMonoidOfLCM [DecidableEq α] (lcm : α → α → α)
         mul_dvd_mul_iff_right h]
       apply dvd_lcm_right
     gcd_dvd_right := fun a b => by
-      -- Porting note: need `dsimp only`
+      -- Porting note (#10971): need `dsimp only`
       dsimp only
       split_ifs with h h_1
       · exact dvd_rfl
@@ -1184,7 +1184,7 @@ noncomputable def gcdMonoidOfLCM [DecidableEq α] (lcm : α → α → α)
         mul_dvd_mul_iff_right h_1]
       apply dvd_lcm_left
     dvd_gcd := fun {a b c} ac ab => by
-      -- Porting note: need `dsimp only`
+      -- Porting note (#10971): need `dsimp only`
       dsimp only
       split_ifs with h h_1
       · exact ab
@@ -1357,7 +1357,7 @@ instance (priority := 100) : NormalizedGCDMonoid G₀ where
   normUnit x := if h : x = 0 then 1 else (Units.mk0 x h)⁻¹
   normUnit_zero := dif_pos rfl
   normUnit_mul := fun {x y} x0 y0 => Units.eq_iff.1 (by
-    -- Porting note: need `dsimp only`, also `simp` reaches maximum heartbeat
+    -- Porting note (#10971): need `dsimp only`, also `simp` reaches maximum heartbeat
     -- by Units.eq_iff.mp (by simp only [x0, y0, mul_comm])
     dsimp only
     split_ifs with h
@@ -1367,25 +1367,25 @@ instance (priority := 100) : NormalizedGCDMonoid G₀ where
       · exact absurd ‹y = 0› y0
     · rw [Units.mk0_mul, mul_inv_rev, mul_comm] )
   normUnit_coe_units u := by
-    -- Porting note: need `dsimp only`
+    -- Porting note (#10971): need `dsimp only`
     dsimp only
     rw [dif_neg (Units.ne_zero _), Units.mk0_val]
   gcd a b := if a = 0 ∧ b = 0 then 0 else 1
   lcm a b := if a = 0 ∨ b = 0 then 0 else 1
   gcd_dvd_left a b := by
-    -- Porting note: need `dsimp only`
+    -- Porting note (#10971): need `dsimp only`
     dsimp only
     split_ifs with h
     · rw [h.1]
     · exact one_dvd _
   gcd_dvd_right a b := by
-    -- Porting note: need `dsimp only`
+    -- Porting note (#10971): need `dsimp only`
     dsimp only
     split_ifs with h
     · rw [h.2]
     · exact one_dvd _
   dvd_gcd := fun {a b c} hac hab => by
-    -- Porting note: need `dsimp only`
+    -- Porting note (#10971): need `dsimp only`
     dsimp only
     split_ifs with h
     · apply dvd_zero
@@ -1402,7 +1402,7 @@ instance (priority := 100) : NormalizedGCDMonoid G₀ where
     · by_cases hb : b = 0
       · simp only [hb, and_true, or_true, ite_true, mul_zero]
         exact Associated.refl _
-      -- Porting note: need `dsimp only`
+      -- Porting note (#10971): need `dsimp only`
       · dsimp only
         rw [if_neg (not_and_of_not_left _ ha), one_mul, if_neg (not_or_of_not ha hb)]
         exact (associated_one_iff_isUnit.mpr ((IsUnit.mk0 _ ha).mul (IsUnit.mk0 _ hb))).symm

--- a/Mathlib/Algebra/GroupPower/IterateHom.lean
+++ b/Mathlib/Algebra/GroupPower/IterateHom.lean
@@ -227,7 +227,7 @@ section Semigroup
 
 variable [Semigroup G] {a b c : G}
 
--- Porting note: need `dsimp only`, see https://leanprover.zulipchat.com/#narrow/stream/
+-- Porting note (#10971): need `dsimp only`, see https://leanprover.zulipchat.com/#narrow/stream/
 -- 287929-mathlib4/topic/dsimp.20before.20rw/near/317063489
 @[to_additive]
 theorem SemiconjBy.function_semiconj_mul_left (h : SemiconjBy a b c) :


### PR DESCRIPTION
Classifies by adding issue number #10971 to porting notes claiming: 

> need `dsimp only`. 