### PR TITLE
feat: delete `open scoped Classical` in `finsuppTensorFinsupp`

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/Constructions.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Constructions.lean
@@ -355,8 +355,10 @@ open Module.Free
 theorem rank_tensorProduct :
     Module.rank S (M ⊗[S] M') =
       Cardinal.lift.{v'} (Module.rank S M) * Cardinal.lift.{v} (Module.rank S M') := by
-  obtain ⟨⟨_, bM⟩⟩ := Module.Free.exists_basis (R := S) (M := M)
-  obtain ⟨⟨_, bN⟩⟩ := Module.Free.exists_basis (R := S) (M := M')
+  obtain ⟨⟨ι, bM⟩⟩ := Module.Free.exists_basis (R := S) (M := M)
+  obtain ⟨⟨κ, bN⟩⟩ := Module.Free.exists_basis (R := S) (M := M')
+  haveI := Classical.decEq ι
+  haveI := Classical.decEq κ
   rw [← bM.mk_eq_rank'', ← bN.mk_eq_rank'', ← (bM.tensorProduct bN).mk_eq_rank'', Cardinal.mk_prod]
 #align rank_tensor_product rank_tensorProduct
 

--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -30,29 +30,26 @@ open TensorProduct
 
 open TensorProduct
 
-open scoped Classical in
+variable (R M N ι κ : Type*) [CommSemiring R] [AddCommMonoid M] [Module R M]
+  [AddCommMonoid N] [Module R N] [DecidableEq ι] [DecidableEq κ]
+
 -- `noncomputable` is a performance workaround for mathlib4#7103
 /-- The tensor product of `ι →₀ M` and `κ →₀ N` is linearly equivalent to `(ι × κ) →₀ (M ⊗ N)`. -/
-noncomputable def finsuppTensorFinsupp (R M N ι κ : Sort _) [CommSemiring R] [AddCommMonoid M]
-    [Module R M] [AddCommMonoid N] [Module R N] : (ι →₀ M) ⊗[R] (κ →₀ N) ≃ₗ[R] ι × κ →₀ M ⊗[R] N :=
+noncomputable def finsuppTensorFinsupp : (ι →₀ M) ⊗[R] (κ →₀ N) ≃ₗ[R] ι × κ →₀ M ⊗[R] N :=
   TensorProduct.congr (finsuppLEquivDirectSum R M ι) (finsuppLEquivDirectSum R N κ) ≪≫ₗ
     ((TensorProduct.directSum R (fun _ : ι => M) fun _ : κ => N) ≪≫ₗ
       (finsuppLEquivDirectSum R (M ⊗[R] N) (ι × κ)).symm)
 #align finsupp_tensor_finsupp finsuppTensorFinsupp
 
 @[simp]
-theorem finsuppTensorFinsupp_single (R M N ι κ : Sort _)
-    [CommSemiring R] [AddCommMonoid M] [Module R M]
-    [AddCommMonoid N] [Module R N] (i : ι) (m : M) (k : κ) (n : N) :
+theorem finsuppTensorFinsupp_single (i : ι) (m : M) (k : κ) (n : N) :
     finsuppTensorFinsupp R M N ι κ (Finsupp.single i m ⊗ₜ Finsupp.single k n) =
-      Finsupp.single (i, k) (m ⊗ₜ n) :=
-  by classical simp [finsuppTensorFinsupp]
+      Finsupp.single (i, k) (m ⊗ₜ n) := by
+  simp [finsuppTensorFinsupp]
 #align finsupp_tensor_finsupp_single finsuppTensorFinsupp_single
 
 @[simp]
-theorem finsuppTensorFinsupp_apply (R M N ι κ : Sort _)
-    [CommSemiring R] [AddCommMonoid M] [Module R M]
-    [AddCommMonoid N] [Module R N] (f : ι →₀ M) (g : κ →₀ N) (i : ι) (k : κ) :
+theorem finsuppTensorFinsupp_apply (f : ι →₀ M) (g : κ →₀ N) (i : ι) (k : κ) :
     finsuppTensorFinsupp R M N ι κ (f ⊗ₜ g) (i, k) = f i ⊗ₜ g k := by
   apply Finsupp.induction_linear f
   · simp
@@ -74,32 +71,28 @@ theorem finsuppTensorFinsupp_apply (R M N ι κ : Sort _)
 #align finsupp_tensor_finsupp_apply finsuppTensorFinsupp_apply
 
 @[simp]
-theorem finsuppTensorFinsupp_symm_single (R M N ι κ : Sort _) [CommSemiring R] [AddCommMonoid M]
-    [Module R M] [AddCommMonoid N] [Module R N] (i : ι × κ) (m : M) (n : N) :
+theorem finsuppTensorFinsupp_symm_single (i : ι × κ) (m : M) (n : N) :
     (finsuppTensorFinsupp R M N ι κ).symm (Finsupp.single i (m ⊗ₜ n)) =
       Finsupp.single i.1 m ⊗ₜ Finsupp.single i.2 n :=
   Prod.casesOn i fun _ _ =>
     (LinearEquiv.symm_apply_eq _).2 (finsuppTensorFinsupp_single _ _ _ _ _ _ _ _ _).symm
 #align finsupp_tensor_finsupp_symm_single finsuppTensorFinsupp_symm_single
 
-variable (S : Type*) [CommSemiring S] (α β : Type*)
-
 /-- A variant of `finsuppTensorFinsupp` where both modules are the ground ring. -/
-def finsuppTensorFinsupp' : (α →₀ S) ⊗[S] (β →₀ S) ≃ₗ[S] α × β →₀ S :=
-  (finsuppTensorFinsupp S S S α β).trans (Finsupp.lcongr (Equiv.refl _) (TensorProduct.lid S S))
+def finsuppTensorFinsupp' : (ι →₀ R) ⊗[R] (κ →₀ R) ≃ₗ[R] ι × κ →₀ R :=
+  (finsuppTensorFinsupp R R R ι κ).trans (Finsupp.lcongr (Equiv.refl _) (TensorProduct.lid R R))
 #align finsupp_tensor_finsupp' finsuppTensorFinsupp'
 
 @[simp]
-theorem finsuppTensorFinsupp'_apply_apply (f : α →₀ S) (g : β →₀ S) (a : α) (b : β) :
-    finsuppTensorFinsupp' S α β (f ⊗ₜ[S] g) (a, b) = f a * g b := by simp [finsuppTensorFinsupp']
+theorem finsuppTensorFinsupp'_apply_apply (f : ι →₀ R) (g : κ →₀ R) (a : ι) (b : κ) :
+    finsuppTensorFinsupp' R ι κ (f ⊗ₜ[R] g) (a, b) = f a * g b := by simp [finsuppTensorFinsupp']
 #align finsupp_tensor_finsupp'_apply_apply finsuppTensorFinsupp'_apply_apply
 
 @[simp]
-theorem finsuppTensorFinsupp'_single_tmul_single (a : α) (b : β) (r₁ r₂ : S) :
-    finsuppTensorFinsupp' S α β (Finsupp.single a r₁ ⊗ₜ[S] Finsupp.single b r₂) =
+theorem finsuppTensorFinsupp'_single_tmul_single (a : ι) (b : κ) (r₁ r₂ : R) :
+    finsuppTensorFinsupp' R ι κ (Finsupp.single a r₁ ⊗ₜ[R] Finsupp.single b r₂) =
       Finsupp.single (a, b) (r₁ * r₂) := by
   ext ⟨a', b'⟩
-  classical
   aesop (add norm [Finsupp.single_apply])
 #align finsupp_tensor_finsupp'_single_tmul_single finsuppTensorFinsupp'_single_tmul_single
 

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -200,6 +200,8 @@ variable [AddCommGroup N] [Module R N] [Module.Free R N]
 instance tensor : Module.Free R (M ⊗[R] N) :=
   let ⟨bM⟩ := exists_basis (R := R) (M := M)
   let ⟨bN⟩ := exists_basis (R := R) (M := N)
+  haveI := Classical.decEq bM.1
+  haveI := Classical.decEq bN.1
   of_basis (bM.2.tensorProduct bN.2)
 #align module.free.tensor Module.Free.tensor
 

--- a/Mathlib/LinearAlgebra/TensorProductBasis.lean
+++ b/Mathlib/LinearAlgebra/TensorProductBasis.lean
@@ -23,9 +23,8 @@ open Set LinearMap Submodule
 
 section CommRing
 
-variable {R : Type*} {M : Type*} {N : Type*} {ι : Type*} {κ : Type*}
-
-variable [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+variable {R M N ι κ : Type*} [CommRing R] [AddCommGroup M] [Module R M]
+  [AddCommGroup N] [Module R N] [DecidableEq ι] [DecidableEq κ]
 
 /-- If `b : ι → M` and `c : κ → N` are bases then so is `fun i ↦ b i.1 ⊗ₜ c i.2 : ι × κ → M ⊗ N`. -/
 def Basis.tensorProduct (b : Basis ι R M) (c : Basis κ R N) :

--- a/Mathlib/LinearAlgebra/Trace.lean
+++ b/Mathlib/LinearAlgebra/Trace.lean
@@ -137,7 +137,7 @@ variable {R : Type*} [CommRing R] {M : Type*} [AddCommGroup M] [Module R M]
 
 variable (N P : Type*) [AddCommGroup N] [Module R N] [AddCommGroup P] [Module R P]
 
-variable {ι : Type*}
+variable {ι : Type*} [DecidableEq ι]
 
 /-- The trace of a linear map correspond to the contraction pairing under the isomorphism
  `End(M) ≃ M* ⊗ M`-/

--- a/Mathlib/RingTheory/TensorProduct.lean
+++ b/Mathlib/RingTheory/TensorProduct.lean
@@ -1083,7 +1083,7 @@ end
 section Basis
 
 universe uM uι
-variable {M : Type uM} {ι : Type uι}
+variable {M : Type uM} {ι : Type uι} [DecidableEq ι]
 variable [CommRing R] [Ring A] [Algebra R A] [AddCommMonoid M] [Module R M] (b : Basis ι R M)
 
 variable (A)


### PR DESCRIPTION
Replace `open scoped Classical` with `DecidableEq` type class implicit arguments
in `finsuppTensorFinsupp`, and add DecidableEq elsewhere when needed as a result.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
