### PR TITLE
[Merged by Bors] - chore: cleanup proof of `Nat.Partrec.Code.rec_prim`

### DIFF
--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -542,6 +542,8 @@ variable {α : Type*} {β : Type*} {γ : Type*} {δ : Type*} {σ : Type*}
 
 variable [Primcodable α] [Primcodable β] [Primcodable γ] [Primcodable δ] [Primcodable σ]
 
+theorem mk {f : α → β → σ} (hf : Computable fun p : α × β => f p.1 p.2) : Computable₂ f := hf
+
 nonrec theorem comp {f : β → γ → σ} {g : α → β} {h : α → γ} (hf : Computable₂ f)
     (hg : Computable g) (hh : Computable h) : Computable fun a => f (g a) (h a) :=
   hf.comp (hg.pair hh)

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -42,7 +42,7 @@ of some code.
 -/
 
 
-open Encodable Denumerable Primrec
+open Encodable Denumerable
 
 namespace Nat.Partrec
 
@@ -230,7 +230,13 @@ theorem encode_lt_rfind' (cf) : encode cf < encode (rfind' cf) := by
     Nat.lt_succ_of_le <| Nat.mul_le_mul_left _ <| le_rfl)
 #align nat.partrec.code.encode_lt_rfind' Nat.Partrec.Code.encode_lt_rfind'
 
+end Nat.Partrec.Code
+
+-- Porting note: Opening `Primrec` inside `namespace Nat.Partrec.Code` causes it to resolve
+-- to `Nat.Partrec`. Needs `open _root_.Partrec` support
 section
+open Primrec
+namespace Nat.Partrec.Code
 
 theorem pair_prim : Primrec₂ pair :=
   Primrec₂.ofNat_iff.2 <|
@@ -288,96 +294,70 @@ theorem rec_prim' {α σ} [Primcodable α] [Primcodable σ] {c : α → Code} (h
     Primrec (fun a => F a (c a) : α → σ) := by
   intros _ _ _ _ F
   let G₁ : (α × List σ) × ℕ × ℕ → Option σ := fun p =>
-    let a := p.1.1
-    let IH := p.1.2
-    let n := p.2.1
-    let m := p.2.2
+    letI a := p.1.1; letI IH := p.1.2; letI n := p.2.1; letI m := p.2.2
     (IH.get? m).bind fun s =>
-      (IH.get? m.unpair.1).bind fun s₁ =>
-        (IH.get? m.unpair.2).map fun s₂ =>
-          cond n.bodd
-            (cond n.div2.bodd (rf a (ofNat Code m, s))
-              (pc a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂)))
-            (cond n.div2.bodd (co a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂))
-              (pr a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂)))
-  have : Primrec G₁ := by
-    refine' option_bind (list_get?.comp (snd.comp fst) (snd.comp snd)) _
-    unfold Primrec₂
-    refine'
-      option_bind
-        ((list_get?.comp (snd.comp fst)
-          (fst.comp <| Primrec.unpair.comp (snd.comp snd))).comp fst) _
-    unfold Primrec₂
-    refine'
-      option_map
-        ((list_get?.comp (snd.comp fst)
-          (snd.comp <| Primrec.unpair.comp (snd.comp snd))).comp <| fst.comp fst) _
-    have a : Primrec (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.1.1.1.1) :=
-      fst.comp (fst.comp <| fst.comp <| fst.comp fst)
-    have n : Primrec (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.1.1.2.1) :=
-      fst.comp (snd.comp <| fst.comp <| fst.comp fst)
-    have m : Primrec (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.1.1.2.2) :=
-      snd.comp (snd.comp <| fst.comp <| fst.comp fst)
+    (IH.get? m.unpair.1).bind fun s₁ =>
+    (IH.get? m.unpair.2).map fun s₂ =>
+    cond n.bodd
+      (cond n.div2.bodd (rf a (ofNat Code m, s))
+        (pc a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂)))
+      (cond n.div2.bodd (co a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂))
+        (pr a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂)))
+  have : Primrec G₁ :=
+    option_bind (list_get?.comp (snd.comp fst) (snd.comp snd)) <| .mk <|
+    option_bind ((list_get?.comp (snd.comp fst)
+      (fst.comp <| Primrec.unpair.comp (snd.comp snd))).comp fst) <| .mk <|
+    option_map ((list_get?.comp (snd.comp fst)
+      (snd.comp <| Primrec.unpair.comp (snd.comp snd))).comp <| fst.comp fst) <| .mk <|
+    have a := fst.comp (fst.comp <| fst.comp <| fst.comp fst)
+    have n := fst.comp (snd.comp <| fst.comp <| fst.comp fst)
+    have m := snd.comp (snd.comp <| fst.comp <| fst.comp fst)
     have m₁ := fst.comp (Primrec.unpair.comp m)
     have m₂ := snd.comp (Primrec.unpair.comp m)
-    have s : Primrec (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.1.2) :=
-      snd.comp (fst.comp fst)
-    have s₁ : Primrec (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.2) :=
-      snd.comp fst
-    have s₂ : Primrec (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.2) :=
-      snd
-    unfold Primrec₂
-    exact
-      (nat_bodd.comp n).cond
-        ((nat_bodd.comp <| nat_div2.comp n).cond (hrf.comp a (((Primrec.ofNat Code).comp m).pair s))
-          (hpc.comp a
-            (((Primrec.ofNat Code).comp m₁).pair <|
-              ((Primrec.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
-        (Primrec.cond (nat_bodd.comp <| nat_div2.comp n)
-          (hco.comp a
-            (((Primrec.ofNat Code).comp m₁).pair <|
-              ((Primrec.ofNat Code).comp m₂).pair <| s₁.pair s₂))
-          (hpr.comp a
-            (((Primrec.ofNat Code).comp m₁).pair <|
-              ((Primrec.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
+    have s := snd.comp (fst.comp fst)
+    have s₁ := snd.comp fst
+    have s₂ := snd
+    (nat_bodd.comp n).cond
+      ((nat_bodd.comp <| nat_div2.comp n).cond
+        (hrf.comp a (((Primrec.ofNat Code).comp m).pair s))
+        (hpc.comp a (((Primrec.ofNat Code).comp m₁).pair <|
+          ((Primrec.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
+      (Primrec.cond (nat_bodd.comp <| nat_div2.comp n)
+        (hco.comp a (((Primrec.ofNat Code).comp m₁).pair <|
+          ((Primrec.ofNat Code).comp m₂).pair <| s₁.pair s₂))
+        (hpr.comp a (((Primrec.ofNat Code).comp m₁).pair <|
+          ((Primrec.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
   let G : α → List σ → Option σ := fun a IH =>
     IH.length.casesOn (some (z a)) fun n =>
-      n.casesOn (some (s a)) fun n =>
-        n.casesOn (some (l a)) fun n =>
-          n.casesOn (some (r a)) fun n => G₁ ((a, IH), n, n.div2.div2)
-  have : Primrec₂ G := by
-    unfold Primrec₂
-    refine nat_casesOn
-      (list_length.comp snd) (option_some_iff.2 (hz.comp fst)) ?_
-    unfold Primrec₂
-    refine nat_casesOn snd (option_some_iff.2 (hs.comp (fst.comp fst))) ?_
-    unfold Primrec₂
-    refine nat_casesOn snd (option_some_iff.2 (hl.comp (fst.comp <| fst.comp fst))) ?_
-    unfold Primrec₂
-    refine nat_casesOn snd (option_some_iff.2 (hr.comp (fst.comp <| fst.comp <| fst.comp fst))) ?_
-    unfold Primrec₂
-    exact this.comp <|
+    n.casesOn (some (s a)) fun n =>
+    n.casesOn (some (l a)) fun n =>
+    n.casesOn (some (r a)) fun n =>
+    G₁ ((a, IH), n, n.div2.div2)
+  have : Primrec₂ G := .mk <|
+    nat_casesOn (list_length.comp snd) (option_some_iff.2 (hz.comp fst)) <| .mk <|
+    nat_casesOn snd (option_some_iff.2 (hs.comp (fst.comp fst))) <| .mk <|
+    nat_casesOn snd (option_some_iff.2 (hl.comp (fst.comp <| fst.comp fst))) <| .mk <|
+    nat_casesOn snd (option_some_iff.2 (hr.comp (fst.comp <| fst.comp <| fst.comp fst))) <| .mk <|
+    this.comp <|
       ((fst.pair snd).comp <| fst.comp <| fst.comp <| fst.comp <| fst).pair <|
-        snd.pair <| nat_div2.comp <| nat_div2.comp snd
-  refine'
-    ((nat_strong_rec (fun a n => F a (ofNat Code n)) this.to₂ fun a n => _).comp
-      _root_.Primrec.id <| encode_iff.2 hc).of_eq fun a => by simp
+      snd.pair <| nat_div2.comp <| nat_div2.comp snd
+  refine (nat_strong_rec (fun a n => F a (ofNat Code n)) this.to₂ fun a n => ?_)
+    |>.comp .id (encode_iff.2 hc) |>.of_eq fun a => by simp
   simp (config := { zeta := false })
   iterate 4 cases' n with n; · simp (config := { zeta := false }) [ofNatCode_eq, ofNatCode]; rfl
-  simp only []
-  rw [List.length_map, List.length_range]
+  simp only [G]; rw [List.length_map, List.length_range]
   let m := n.div2.div2
-  show
-    G₁ ((a, (List.range (n + 4)).map fun n => F a (ofNat Code n)), n, m) =
-      some (F a (ofNat Code (n + 4)))
+  show G₁ ((a, (List.range (n + 4)).map fun n => F a (ofNat Code n)), n, m)
+    = some (F a (ofNat Code (n + 4)))
   have hm : m < n + 4 := by
-    simp only [div2_val]
-    exact
-      lt_of_le_of_lt (le_trans (Nat.div_le_self _ _) (Nat.div_le_self _ _))
-        (Nat.succ_le_succ (Nat.le_add_right _ _))
+    simp only [m, div2_val]
+    exact lt_of_le_of_lt
+      (le_trans (Nat.div_le_self ..) (Nat.div_le_self ..))
+      (Nat.succ_le_succ (Nat.le_add_right ..))
   have m1 : m.unpair.1 < n + 4 := lt_of_le_of_lt m.unpair_left_le hm
   have m2 : m.unpair.2 < n + 4 := lt_of_le_of_lt m.unpair_right_le hm
-  simp [List.get?_map, List.get?_range, hm, m1, m2]
+  simp (config := { zeta := false }) [G₁]
+  simp (config := { zeta := false }) [m, List.get?_map, List.get?_range, hm, m1, m2]
   rw [show ofNat Code (n + 4) = ofNatCode (n + 4) from rfl]
   simp [ofNatCode]
   cases n.bodd <;> cases n.div2.bodd <;> rfl
@@ -395,103 +375,18 @@ theorem rec_prim {α σ} [Primcodable α] [Primcodable σ] {c : α → Code} (hc
     {rf : α → Code → σ → σ} (hrf : Primrec fun a : α × Code × σ => rf a.1 a.2.1 a.2.2) :
     let F (a : α) (c : Code) : σ :=
       Nat.Partrec.Code.recOn c (z a) (s a) (l a) (r a) (pr a) (co a) (pc a) (rf a)
-    Primrec fun a => F a (c a) := by
-  intros F
-  let G₁ : (α × List σ) × ℕ × ℕ → Option σ := fun p =>
-    let a := p.1.1
-    let IH := p.1.2
-    let n := p.2.1
-    let m := p.2.2
-    (IH.get? m).bind fun s =>
-      (IH.get? m.unpair.1).bind fun s₁ =>
-        (IH.get? m.unpair.2).map fun s₂ =>
-          cond n.bodd
-            (cond n.div2.bodd (rf a (ofNat Code m) s)
-              (pc a (ofNat Code m.unpair.1) (ofNat Code m.unpair.2) s₁ s₂))
-            (cond n.div2.bodd (co a (ofNat Code m.unpair.1) (ofNat Code m.unpair.2) s₁ s₂)
-              (pr a (ofNat Code m.unpair.1) (ofNat Code m.unpair.2) s₁ s₂))
-  have : Primrec G₁ := by
-    refine' option_bind (list_get?.comp (snd.comp fst) (snd.comp snd)) _
-    unfold Primrec₂
-    refine' option_bind ((list_get?.comp (snd.comp fst) (fst.comp <| Primrec.unpair.comp
-            (snd.comp snd))).comp fst) _
-    unfold Primrec₂
-    refine'
-      option_map
-        ((list_get?.comp (snd.comp fst) (snd.comp <| Primrec.unpair.comp (snd.comp snd))).comp <|
-          fst.comp fst)
-        _
-    have a : Primrec (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.1.1.1.1) :=
-      fst.comp (fst.comp <| fst.comp <| fst.comp fst)
-    have n : Primrec (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.1.1.2.1) :=
-      fst.comp (snd.comp <| fst.comp <| fst.comp fst)
-    have m : Primrec (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.1.1.2.2) :=
-      snd.comp (snd.comp <| fst.comp <| fst.comp fst)
-    have m₁ := fst.comp (Primrec.unpair.comp m)
-    have m₂ := snd.comp (Primrec.unpair.comp m)
-    have s : Primrec (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.1.2) :=
-      snd.comp (fst.comp fst)
-    have s₁ : Primrec (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.2) :=
-      snd.comp fst
-    have s₂ : Primrec (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.2) :=
-      snd
-    have h₁ := hrf.comp <| a.pair (((Primrec.ofNat Code).comp m).pair s)
-    have h₂ := hpc.comp <| a.pair (((Primrec.ofNat Code).comp m₁).pair <|
-      ((Primrec.ofNat Code).comp m₂).pair <| s₁.pair s₂)
-    have h₃ := hco.comp <| a.pair
-      (((Primrec.ofNat Code).comp m₁).pair <| ((Primrec.ofNat Code).comp m₂).pair <| s₁.pair s₂)
-    have h₄ := hpr.comp <| a.pair
-      (((Primrec.ofNat Code).comp m₁).pair <| ((Primrec.ofNat Code).comp m₂).pair <| s₁.pair s₂)
-    unfold Primrec₂
-    exact
-      (nat_bodd.comp n).cond
-        ((nat_bodd.comp <| nat_div2.comp n).cond h₁ h₂)
-        (cond (nat_bodd.comp <| nat_div2.comp n) h₃ h₄)
-  let G : α → List σ → Option σ := fun a IH =>
-    IH.length.casesOn (some (z a)) fun n =>
-      n.casesOn (some (s a)) fun n =>
-        n.casesOn (some (l a)) fun n =>
-          n.casesOn (some (r a)) fun n => G₁ ((a, IH), n, n.div2.div2)
-  have : Primrec₂ G := by
-    unfold Primrec₂
-    refine nat_casesOn (list_length.comp snd) (option_some_iff.2 (hz.comp fst)) ?_
-    unfold Primrec₂
-    refine nat_casesOn snd (option_some_iff.2 (hs.comp (fst.comp fst))) ?_
-    unfold Primrec₂
-    refine nat_casesOn snd (option_some_iff.2 (hl.comp (fst.comp <| fst.comp fst))) ?_
-    unfold Primrec₂
-    refine nat_casesOn snd (option_some_iff.2 (hr.comp (fst.comp <| fst.comp <| fst.comp fst))) ?_
-    unfold Primrec₂
-    exact this.comp <|
-      ((fst.pair snd).comp <| fst.comp <| fst.comp <| fst.comp <| fst).pair <|
-          snd.pair <| nat_div2.comp <| nat_div2.comp snd
-  refine'
-    ((nat_strong_rec (fun a n => F a (ofNat Code n)) this.to₂ fun a n => _).comp
-      _root_.Primrec.id <| encode_iff.2 hc).of_eq
-      fun a => by simp
-  simp (config := { zeta := false })
-  iterate 4 cases' n with n; · simp (config := { zeta := false }) [ofNatCode_eq, ofNatCode]; rfl
-  simp only []
-  rw [List.length_map, List.length_range]
-  let m := n.div2.div2
-  show
-    G₁ ((a, (List.range (n + 4)).map fun n => F a (ofNat Code n)), n, m) =
-      some (F a (ofNat Code (n + 4)))
-  have hm : m < n + 4 := by
-    simp only [div2_val]
-    exact
-      lt_of_le_of_lt (le_trans (Nat.div_le_self _ _) (Nat.div_le_self _ _))
-        (Nat.succ_le_succ (Nat.le_add_right _ _))
-  have m1 : m.unpair.1 < n + 4 := lt_of_le_of_lt m.unpair_left_le hm
-  have m2 : m.unpair.2 < n + 4 := lt_of_le_of_lt m.unpair_right_le hm
-  simp [List.get?_map, List.get?_range, hm, m1, m2]
-  rw [show ofNat Code (n + 4) = ofNatCode (n + 4) from rfl]
-  simp [ofNatCode]
-  cases n.bodd <;> cases n.div2.bodd <;> rfl
+    Primrec fun a => F a (c a) :=
+  rec_prim' hc hz hs hl hr
+    (pr := fun a b => pr a b.1 b.2.1 b.2.2.1 b.2.2.2) (.mk hpr)
+    (co := fun a b => co a b.1 b.2.1 b.2.2.1 b.2.2.2) (.mk hco)
+    (pc := fun a b => pc a b.1 b.2.1 b.2.2.1 b.2.2.2) (.mk hpc)
+    (rf := fun a b => rf a b.1 b.2) (.mk hrf)
 #align nat.partrec.code.rec_prim Nat.Partrec.Code.rec_prim
 
+end Nat.Partrec.Code
 end
 
+namespace Nat.Partrec.Code
 section
 
 open Computable
@@ -512,91 +407,71 @@ theorem rec_computable {α σ} [Primcodable α] [Primcodable σ] {c : α → Cod
   -- TODO(Mario): less copy-paste from previous proof
   intros _ _ _ _ F
   let G₁ : (α × List σ) × ℕ × ℕ → Option σ := fun p =>
-    let a := p.1.1
-    let IH := p.1.2
-    let n := p.2.1
-    let m := p.2.2
+    letI a := p.1.1; letI IH := p.1.2; letI n := p.2.1; letI m := p.2.2
     (IH.get? m).bind fun s =>
-      (IH.get? m.unpair.1).bind fun s₁ =>
-        (IH.get? m.unpair.2).map fun s₂ =>
-          cond n.bodd
-            (cond n.div2.bodd (rf a (ofNat Code m, s))
-              (pc a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂)))
-            (cond n.div2.bodd (co a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂))
-              (pr a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂)))
+    (IH.get? m.unpair.1).bind fun s₁ =>
+    (IH.get? m.unpair.2).map fun s₂ =>
+    cond n.bodd
+      (cond n.div2.bodd (rf a (ofNat Code m, s))
+        (pc a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂)))
+      (cond n.div2.bodd (co a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂))
+        (pr a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂)))
   have : Computable G₁ := by
-    refine' option_bind (list_get?.comp (snd.comp fst) (snd.comp snd)) _
-    unfold Computable₂
-    refine'
-      option_bind
-        ((list_get?.comp (snd.comp fst)
-          (fst.comp <| Computable.unpair.comp (snd.comp snd))).comp fst) _
-    unfold Computable₂
-    refine'
-      option_map
-        ((list_get?.comp (snd.comp fst)
-          (snd.comp <| Computable.unpair.comp (snd.comp snd))).comp <| fst.comp fst) _
-    have a : Computable (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.1.1.1.1) :=
-      fst.comp (fst.comp <| fst.comp <| fst.comp fst)
-    have n : Computable (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.1.1.2.1) :=
-      fst.comp (snd.comp <| fst.comp <| fst.comp fst)
-    have m : Computable (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.1.1.2.2) :=
-      snd.comp (snd.comp <| fst.comp <| fst.comp fst)
-    have m₁ := fst.comp (Computable.unpair.comp m)
-    have m₂ := snd.comp (Computable.unpair.comp m)
-    have s : Computable (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.1.2) :=
-      snd.comp (fst.comp fst)
-    have s₁ : Computable (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.1.2) :=
-      snd.comp fst
-    have s₂ : Computable (fun p : ((((α × List σ) × ℕ × ℕ) × σ) × σ) × σ => p.2) :=
-      snd
+    refine option_bind (list_get?.comp (snd.comp fst) (snd.comp snd)) <| .mk ?_
+    refine option_bind ((list_get?.comp (snd.comp fst)
+      (fst.comp <| Computable.unpair.comp (snd.comp snd))).comp fst) <| .mk ?_
+    refine option_map ((list_get?.comp (snd.comp fst)
+      (snd.comp <| Computable.unpair.comp (snd.comp snd))).comp <| fst.comp fst) <| .mk ?_
     exact
+      have a := fst.comp (fst.comp <| fst.comp <| fst.comp fst)
+      have n := fst.comp (snd.comp <| fst.comp <| fst.comp fst)
+      have m := snd.comp (snd.comp <| fst.comp <| fst.comp fst)
+      have m₁ := fst.comp (Computable.unpair.comp m)
+      have m₂ := snd.comp (Computable.unpair.comp m)
+      have s := snd.comp (fst.comp fst)
+      have s₁ := snd.comp fst
+      have s₂ := snd
       (nat_bodd.comp n).cond
         ((nat_bodd.comp <| nat_div2.comp n).cond
           (hrf.comp a (((Computable.ofNat Code).comp m).pair s))
-          (hpc.comp a
-            (((Computable.ofNat Code).comp m₁).pair <|
-              ((Computable.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
+          (hpc.comp a (((Computable.ofNat Code).comp m₁).pair <|
+            ((Computable.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
         (Computable.cond (nat_bodd.comp <| nat_div2.comp n)
-          (hco.comp a
-            (((Computable.ofNat Code).comp m₁).pair <|
-              ((Computable.ofNat Code).comp m₂).pair <| s₁.pair s₂))
-          (hpr.comp a
-            (((Computable.ofNat Code).comp m₁).pair <|
-              ((Computable.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
+          (hco.comp a (((Computable.ofNat Code).comp m₁).pair <|
+            ((Computable.ofNat Code).comp m₂).pair <| s₁.pair s₂))
+          (hpr.comp a (((Computable.ofNat Code).comp m₁).pair <|
+            ((Computable.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
   let G : α → List σ → Option σ := fun a IH =>
     IH.length.casesOn (some (z a)) fun n =>
-      n.casesOn (some (s a)) fun n =>
-        n.casesOn (some (l a)) fun n =>
-          n.casesOn (some (r a)) fun n => G₁ ((a, IH), n, n.div2.div2)
-  have : Computable₂ G :=
-    Computable.nat_casesOn (list_length.comp snd) (option_some_iff.2 (hz.comp fst)) <|
-      Computable.nat_casesOn snd (option_some_iff.2 (hs.comp (fst.comp fst))) <|
-        Computable.nat_casesOn snd (option_some_iff.2 (hl.comp (fst.comp <| fst.comp fst))) <|
-          Computable.nat_casesOn snd
-            (option_some_iff.2 (hr.comp (fst.comp <| fst.comp <| fst.comp fst)))
-            (this.comp <|
-              ((Computable.fst.pair snd).comp <| fst.comp <| fst.comp <| fst.comp <| fst).pair <|
-                snd.pair <| nat_div2.comp <| nat_div2.comp snd)
-  refine'
-    ((nat_strong_rec (fun a n => F a (ofNat Code n)) this.to₂ fun a n => _).comp Computable.id <|
-      encode_iff.2 hc).of_eq fun a => by simp
+    n.casesOn (some (s a)) fun n =>
+    n.casesOn (some (l a)) fun n =>
+    n.casesOn (some (r a)) fun n =>
+    G₁ ((a, IH), n, n.div2.div2)
+  have : Computable₂ G := .mk <|
+    nat_casesOn (list_length.comp snd) (option_some_iff.2 (hz.comp fst)) <| .mk <|
+    nat_casesOn snd (option_some_iff.2 (hs.comp (fst.comp fst))) <| .mk <|
+    nat_casesOn snd (option_some_iff.2 (hl.comp (fst.comp <| fst.comp fst))) <| .mk <|
+    nat_casesOn snd (option_some_iff.2 (hr.comp (fst.comp <| fst.comp <| fst.comp fst))) <| .mk <|
+    this.comp <|
+      ((fst.pair snd).comp <| fst.comp <| fst.comp <| fst.comp <| fst).pair <|
+      snd.pair <| nat_div2.comp <| nat_div2.comp snd
+  refine (nat_strong_rec (fun a n => F a (ofNat Code n)) this.to₂ fun a n => ?_)
+    |>.comp .id (encode_iff.2 hc) |>.of_eq fun a => by simp
   simp (config := { zeta := false })
   iterate 4 cases' n with n; · simp (config := { zeta := false }) [ofNatCode_eq, ofNatCode]; rfl
-  simp only []
-  rw [List.length_map, List.length_range]
+  simp only [G]; rw [List.length_map, List.length_range]
   let m := n.div2.div2
-  show
-    G₁ ((a, (List.range (n + 4)).map fun n => F a (ofNat Code n)), n, m) =
-      some (F a (ofNat Code (n + 4)))
+  show G₁ ((a, (List.range (n + 4)).map fun n => F a (ofNat Code n)), n, m)
+    = some (F a (ofNat Code (n + 4)))
   have hm : m < n + 4 := by
-    simp only [div2_val]
-    exact
-      lt_of_le_of_lt (le_trans (Nat.div_le_self _ _) (Nat.div_le_self _ _))
-        (Nat.succ_le_succ (Nat.le_add_right _ _))
+    simp only [m, div2_val]
+    exact lt_of_le_of_lt
+      (le_trans (Nat.div_le_self ..) (Nat.div_le_self ..))
+      (Nat.succ_le_succ (Nat.le_add_right ..))
   have m1 : m.unpair.1 < n + 4 := lt_of_le_of_lt m.unpair_left_le hm
   have m2 : m.unpair.2 < n + 4 := lt_of_le_of_lt m.unpair_right_le hm
-  simp [List.get?_map, List.get?_range, hm, m1, m2]
+  simp (config := { zeta := false }) [G₁]
+  simp (config := { zeta := false }) [m, List.get?_map, List.get?_range, hm, m1, m2]
   rw [show ofNat Code (n + 4) = ofNatCode (n + 4) from rfl]
   simp [ofNatCode]
   cases n.bodd <;> cases n.div2.bodd <;> rfl

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -411,6 +411,8 @@ variable {α : Type*} {β : Type*} {σ : Type*}
 
 variable [Primcodable α] [Primcodable β] [Primcodable σ]
 
+theorem mk {f : α → β → σ} (hf : Primrec fun p : α × β => f p.1 p.2) : Primrec₂ f := hf
+
 theorem of_eq {f g : α → β → σ} (hg : Primrec₂ f) (H : ∀ a b, f a b = g a b) : Primrec₂ g :=
   (by funext a b; apply H : f = g) ▸ hg
 #align primrec₂.of_eq Primrec₂.of_eq


### PR DESCRIPTION
This is in preparation for a fix to be performed on `nightly-testing`. It restores the proof structure to something more similar to the original lean 3 proof.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
