### PR TITLE
[Merged by Bors] - refactor(Order): rename cInf -> csInf and cSup -> csSup

### DIFF
--- a/Mathlib/Data/Nat/Lattice.lean
+++ b/Mathlib/Data/Nat/Lattice.lean
@@ -149,7 +149,7 @@ noncomputable instance : ConditionallyCompleteLinearOrderBot ℕ :=
 
 theorem sSup_mem {s : Set ℕ} (h₁ : s.Nonempty) (h₂ : BddAbove s) : sSup s ∈ s :=
   let ⟨k, hk⟩ := h₂
-  h₁.cSup_mem ((finite_le_nat k).subset hk)
+  h₁.csSup_mem ((finite_le_nat k).subset hk)
 #align nat.Sup_mem Nat.sSup_mem
 
 theorem sInf_add {n : ℕ} {p : ℕ → Prop} (hn : n ≤ sInf { m | p m }) :

--- a/Mathlib/GroupTheory/Exponent.lean
+++ b/Mathlib/GroupTheory/Exponent.lean
@@ -429,7 +429,7 @@ theorem exists_orderOf_eq_exponent (hG : ExponentExists G) : ∃ g : G, orderOf 
   have hne : (Set.range (orderOf : G → ℕ)).Nonempty := ⟨1, 1, orderOf_one⟩
   have hfin : (Set.range (orderOf : G → ℕ)).Finite := by
     rwa [← exponent_ne_zero_iff_range_orderOf_finite hG.orderOf_pos]
-  obtain ⟨t, ht⟩ := hne.cSup_mem hfin
+  obtain ⟨t, ht⟩ := hne.csSup_mem hfin
   use t
   apply Nat.dvd_antisymm (order_dvd_exponent _)
   refine' Nat.dvd_of_factors_subperm he _
@@ -503,7 +503,7 @@ variable [CancelCommMonoid G]
 @[to_additive]
 theorem exponent_eq_max'_orderOf [Fintype G] :
     exponent G = ((@Finset.univ G _).image orderOf).max' ⟨1, by simp⟩ := by
-  rw [← Finset.Nonempty.cSup_eq_max', Finset.coe_image, Finset.coe_univ, Set.image_univ, ← iSup]
+  rw [← Finset.Nonempty.csSup_eq_max', Finset.coe_image, Finset.coe_univ, Set.image_univ, ← iSup]
   exact exponent_eq_iSup_orderOf orderOf_pos
 #align monoid.exponent_eq_max'_order_of Monoid.exponent_eq_max'_orderOf
 #align add_monoid.exponent_eq_max'_order_of AddMonoid.exponent_eq_max'_addOrderOf

--- a/Mathlib/Order/ConditionallyCompleteLattice/Finset.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Finset.lean
@@ -22,39 +22,39 @@ section ConditionallyCompleteLinearOrder
 
 variable [ConditionallyCompleteLinearOrder α] {s t : Set α} {a b : α}
 
-theorem Finset.Nonempty.cSup_eq_max' {s : Finset α} (h : s.Nonempty) : sSup ↑s = s.max' h :=
+theorem Finset.Nonempty.csSup_eq_max' {s : Finset α} (h : s.Nonempty) : sSup ↑s = s.max' h :=
   eq_of_forall_ge_iff fun _ => (csSup_le_iff s.bddAbove h.to_set).trans (s.max'_le_iff h).symm
-#align finset.nonempty.cSup_eq_max' Finset.Nonempty.cSup_eq_max'
+#align finset.nonempty.cSup_eq_max' Finset.Nonempty.csSup_eq_max'
 
-theorem Finset.Nonempty.cInf_eq_min' {s : Finset α} (h : s.Nonempty) : sInf ↑s = s.min' h :=
-  @Finset.Nonempty.cSup_eq_max' αᵒᵈ _ s h
-#align finset.nonempty.cInf_eq_min' Finset.Nonempty.cInf_eq_min'
+theorem Finset.Nonempty.csInf_eq_min' {s : Finset α} (h : s.Nonempty) : sInf ↑s = s.min' h :=
+  @Finset.Nonempty.csSup_eq_max' αᵒᵈ _ s h
+#align finset.nonempty.cInf_eq_min' Finset.Nonempty.csInf_eq_min'
 
-theorem Finset.Nonempty.cSup_mem {s : Finset α} (h : s.Nonempty) : sSup (s : Set α) ∈ s := by
-  rw [h.cSup_eq_max']
+theorem Finset.Nonempty.csSup_mem {s : Finset α} (h : s.Nonempty) : sSup (s : Set α) ∈ s := by
+  rw [h.csSup_eq_max']
   exact s.max'_mem _
-#align finset.nonempty.cSup_mem Finset.Nonempty.cSup_mem
+#align finset.nonempty.cSup_mem Finset.Nonempty.csSup_mem
 
-theorem Finset.Nonempty.cInf_mem {s : Finset α} (h : s.Nonempty) : sInf (s : Set α) ∈ s :=
-  @Finset.Nonempty.cSup_mem αᵒᵈ _ _ h
-#align finset.nonempty.cInf_mem Finset.Nonempty.cInf_mem
+theorem Finset.Nonempty.csInf_mem {s : Finset α} (h : s.Nonempty) : sInf (s : Set α) ∈ s :=
+  @Finset.Nonempty.csSup_mem αᵒᵈ _ _ h
+#align finset.nonempty.cInf_mem Finset.Nonempty.csInf_mem
 
-theorem Set.Nonempty.cSup_mem (h : s.Nonempty) (hs : s.Finite) : sSup s ∈ s := by
+theorem Set.Nonempty.csSup_mem (h : s.Nonempty) (hs : s.Finite) : sSup s ∈ s := by
   lift s to Finset α using hs
-  exact Finset.Nonempty.cSup_mem h
-#align set.nonempty.cSup_mem Set.Nonempty.cSup_mem
+  exact Finset.Nonempty.csSup_mem h
+#align set.nonempty.cSup_mem Set.Nonempty.csSup_mem
 
-theorem Set.Nonempty.cInf_mem (h : s.Nonempty) (hs : s.Finite) : sInf s ∈ s :=
-  @Set.Nonempty.cSup_mem αᵒᵈ _ _ h hs
-#align set.nonempty.cInf_mem Set.Nonempty.cInf_mem
+theorem Set.Nonempty.csInf_mem (h : s.Nonempty) (hs : s.Finite) : sInf s ∈ s :=
+  @Set.Nonempty.csSup_mem αᵒᵈ _ _ h hs
+#align set.nonempty.cInf_mem Set.Nonempty.csInf_mem
 
-theorem Set.Finite.cSup_lt_iff (hs : s.Finite) (h : s.Nonempty) : sSup s < a ↔ ∀ x ∈ s, x < a :=
-  ⟨fun h _ hx => (le_csSup hs.bddAbove hx).trans_lt h, fun H => H _ <| h.cSup_mem hs⟩
-#align set.finite.cSup_lt_iff Set.Finite.cSup_lt_iff
+theorem Set.Finite.csSup_lt_iff (hs : s.Finite) (h : s.Nonempty) : sSup s < a ↔ ∀ x ∈ s, x < a :=
+  ⟨fun h _ hx => (le_csSup hs.bddAbove hx).trans_lt h, fun H => H _ <| h.csSup_mem hs⟩
+#align set.finite.cSup_lt_iff Set.Finite.csSup_lt_iff
 
-theorem Set.Finite.lt_cInf_iff (hs : s.Finite) (h : s.Nonempty) : a < sInf s ↔ ∀ x ∈ s, a < x :=
-  @Set.Finite.cSup_lt_iff αᵒᵈ _ _ _ hs h
-#align set.finite.lt_cInf_iff Set.Finite.lt_cInf_iff
+theorem Set.Finite.lt_csInf_iff (hs : s.Finite) (h : s.Nonempty) : a < sInf s ↔ ∀ x ∈ s, a < x :=
+  @Set.Finite.csSup_lt_iff αᵒᵈ _ _ _ hs h
+#align set.finite.lt_cInf_iff Set.Finite.lt_csInf_iff
 
 end ConditionallyCompleteLinearOrder
 

--- a/Mathlib/Probability/Martingale/Upcrossing.lean
+++ b/Mathlib/Probability/Martingale/Upcrossing.lean
@@ -468,7 +468,7 @@ theorem upcrossingsBefore_zero' : upcrossingsBefore a b f 0 = 0 := by
 theorem upperCrossingTime_lt_of_le_upcrossingsBefore (hN : 0 < N) (hab : a < b)
     (hn : n ≤ upcrossingsBefore a b f N ω) : upperCrossingTime a b f N n ω < N :=
   haveI : upperCrossingTime a b f N (upcrossingsBefore a b f N ω) ω < N :=
-    (upperCrossingTime_lt_nonempty hN).cSup_mem
+    (upperCrossingTime_lt_nonempty hN).csSup_mem
       ((OrderBot.bddBelow _).finite_of_bddAbove (upperCrossingTime_lt_bddAbove hab))
   lt_of_le_of_lt (upperCrossingTime_mono hn) this
 #align measure_theory.upper_crossing_time_lt_of_le_upcrossings_before MeasureTheory.upperCrossingTime_lt_of_le_upcrossingsBefore


### PR DESCRIPTION
Does the following renames:
- `cSup_eq_max'` -> `csSup_eq_max'`
- `cInf_eq_min'` -> `csInf_eq_min'`
- `cSup_mem` -> `csSup_mem`
- `cInf_mem` -> `csInf_mem`
- `cSup_lt_iff` -> `csSup_lt_iff`
- `lt_cInf_iff` -> `lt_csInf_iff`

---

Some theorem names in `Mathlib/Order/CompleteLattice/Finset.lean` had been left out of the rename of `cinf` to `csInf`/`ciInf` during the port to lean 4. This caused them to be very hard to discover when searching for terms like `csInf` or `ciInf`.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
