### PR TITLE
[Merged by Bors] - chore: handle comment nesting in `lint-style.py`

### DIFF
--- a/Mathlib/GroupTheory/Subgroup/Basic.lean
+++ b/Mathlib/GroupTheory/Subgroup/Basic.lean
@@ -1805,9 +1805,9 @@ variable {η : Type*} {f : η → Type*}
 /-- A version of `Set.pi` for submonoids. Given an index set `I` and a family of submodules
 `s : Π i, Submonoid f i`, `pi I s` is the submonoid of dependent functions `f : Π i, f i` such that
 `f i` belongs to `Pi I s` whenever `i ∈ I`. -/
-@[to_additive " A version of `Set.pi` for `AddSubmonoid`s. Given an index set `I` and a family
+@[to_additive "A version of `Set.pi` for `AddSubmonoid`s. Given an index set `I` and a family
   of submodules `s : Π i, AddSubmonoid f i`, `pi I s` is the `AddSubmonoid` of dependent functions
-  `f : Π i, f i` such that `f i` belongs to `pi I s` whenever `i ∈ I`. -/ "]
+  `f : Π i, f i` such that `f i` belongs to `pi I s` whenever `i ∈ I`."]
 def _root_.Submonoid.pi [∀ i, MulOneClass (f i)] (I : Set η) (s : ∀ i, Submonoid (f i)) :
     Submonoid (∀ i, f i) where
   carrier := I.pi fun i => (s i).carrier
@@ -1822,9 +1822,9 @@ variable [∀ i, Group (f i)]
 `s : Π i, Subgroup f i`, `pi I s` is the subgroup of dependent functions `f : Π i, f i` such that
 `f i` belongs to `pi I s` whenever `i ∈ I`. -/
 @[to_additive
-      " A version of `Set.pi` for `AddSubgroup`s. Given an index set `I` and a family
+      "A version of `Set.pi` for `AddSubgroup`s. Given an index set `I` and a family
       of submodules `s : Π i, AddSubgroup f i`, `pi I s` is the `AddSubgroup` of dependent functions
-      `f : Π i, f i` such that `f i` belongs to `pi I s` whenever `i ∈ I`. -/ "]
+      `f : Π i, f i` such that `f i` belongs to `pi I s` whenever `i ∈ I`."]
 def pi (I : Set η) (H : ∀ i, Subgroup (f i)) : Subgroup (∀ i, f i) :=
   { Submonoid.pi I fun i => (H i).toSubmonoid with
     inv_mem' := fun hp i hI => (H i).inv_mem (hp i hI) }

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -91,21 +91,21 @@ def annotate_comments(enumerate_lines):
     (line_number, line, ..., True/False)
     where lines have True attached when they are in comments.
     """
-    in_comment = False
+    nesting_depth = 0 # We're in a comment when `nesting_depth > 0`.
+    starts_in_comment = False # Whether we're in a comment when starting the line.
     for line_nr, line, *rem in enumerate_lines:
-        if line.lstrip().startswith("--"):
+        # We assume multiline comments do not begin or end within single-line comments.
+        if line == "\n" or line.lstrip().startswith("--"):
             yield line_nr, line, *rem, True
             continue
-        if "/-" in line:
-            in_comment = True
-        if "-/" in line:
-            in_comment = False
-            yield line_nr, line, *rem, True
-            continue
-        if line == "\n" or in_comment:
-            yield line_nr, line, *rem, True
-            continue
-        yield line_nr, line, *rem, False
+        # We assume that "/-/" and "-/-" never occur outside of "--" comments.
+        # We assume that we do not encounter "... -/ <term> /- ...".
+        # We also don't account for "/-" and "-/" appearing in strings.
+        starts_in_comment = (nesting_depth > 0)
+        nesting_depth = nesting_depth + line.count("/-") - line.count("-/")
+        in_comment = (starts_in_comment or line.lstrip().startswith("/-")) and \
+            (nesting_depth > 0 or line.rstrip().endswith("-/"))
+        yield line_nr, line, *rem, in_comment
 
 def annotate_strings(enumerate_lines):
     """
@@ -311,7 +311,9 @@ def left_arrow_check(lines, path):
         if is_comment or in_string:
             newlines.append((line_nr, line))
             continue
-        new_line = re.sub(r'←(?!%)(\S)', r'← \1', line)
+        # Allow "←" to be followed by "%" or "`", but not by "`(" or "``(" (since "`()" and "``()"
+        # are used for syntax quotations). Otherwise, insert a space after "←".
+        new_line = re.sub(r'←(?:(?=``?\()|(?![%`]))(\S)', r'← \1', line)
         if new_line != line:
             errors += [(ERR_ARR, line_nr, path)]
         newlines.append((line_nr, new_line))


### PR DESCRIPTION
This PR adjusts `annotate_comments` to respect comment nesting while linting.

Note that `annotate_strings` does not necessarily respect comment nesting, so this is an improvement, not a full fix. (Likewise, `annotate_comments` (still) doesn't ignore comment markers in strings.)

See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/False.20positive.20on.20.60.E2.86.90.60.20style.20linter).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This issue appeared when the "space after "←"" linter was activated within a docstring (hence the branch name); see #10991. The latter half had been considered "not in a comment" too early due to the presence of `-/` in a code block earlier in that docstring (which set `in_comment` to `False`).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
