### PR TITLE
[Merged by Bors] - chore: make natDegree_sub_C rw_search test more robust

### DIFF
--- a/test/RewriteSearch/Polynomial.lean
+++ b/test/RewriteSearch/Polynomial.lean
@@ -11,7 +11,7 @@ open Polynomial
 #guard_msgs in
 example {R : Type*} [Ring R] {p : Polynomial R} {a : R} :
     natDegree (p - C a) = natDegree p := by
-  rw_search [-Polynomial.natDegree_sub_C]
+  rw_search [-Polynomial.natDegree_sub_C, -sub_eq_neg_add]
 
 
 -- This one works, but is very slow:


### PR DESCRIPTION
Sometimes it comes up with rw [@natDegree_sub, @sub_eq_neg_add, @natDegree_add_C, @natDegree_neg] instead.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
