### PR TITLE
[Merged by Bors] - feat(Algebra/GroupPower/Basic): add zpow_eq_zpow_zmod

### DIFF
--- a/Mathlib/Algebra/GroupPower/Basic.lean
+++ b/Mathlib/Algebra/GroupPower/Basic.lean
@@ -162,9 +162,9 @@ theorem pow_sub_mul_pow (a : M) {m n : ℕ} (h : m ≤ n) : a ^ (n - m) * a ^ m 
 @[to_additive nsmul_eq_mod_nsmul "If `n • x = 0`, then `m • x` is the same as `(m % n) • x`"]
 theorem pow_eq_pow_mod {M : Type*} [Monoid M] {x : M} (m : ℕ) {n : ℕ} (h : x ^ n = 1) :
     x ^ m = x ^ (m % n) := by
-  have t : x ^ m = x ^ (n * (m / n) + m % n) :=
-    congr_arg (fun a => x ^ a) ((Nat.add_comm _ _).trans (Nat.mod_add_div _ _)).symm
-  rw [t, pow_add, pow_mul, h, one_pow, one_mul]
+  calc
+    x ^ m = x ^ (m % n + n * (m / n)) := by rw [Nat.mod_add_div]
+    _ = x ^ (m % n) := by simp [pow_add, pow_mul, h]
 #align pow_eq_pow_mod pow_eq_pow_mod
 #align nsmul_eq_mod_nsmul nsmul_eq_mod_nsmul
 
@@ -475,6 +475,15 @@ lemma mul_zpow_self (a : G) (n : ℤ) : a ^ n * a = a ^ (n + 1) := (zpow_add_one
   rw [← zpow_add, Int.add_comm, zpow_add]
 #align zpow_mul_comm zpow_mul_comm
 #align zsmul_add_comm zsmul_add_comm
+
+theorem zpow_eq_zpow_zmod {x : G} (m : ℤ) {n : ℤ} (h : x ^ n = 1) :
+  x ^ m = x ^ (m % n) := by
+calc
+    x ^ m = x ^ (m % n + n * (m / n)) := by rw [Int.emod_add_ediv]
+    _ = x ^ (m % (n : ℤ)) := by simp [zpow_add, zpow_mul, h]
+
+theorem zpow_eq_zpow_mod {x : G} (m : ℤ) {n : ℕ} (h : x ^ n = 1) :
+  x ^ m = x ^ (m % (n : ℤ)) := zpow_eq_zpow_zmod m (by simpa)
 
 section bit1
 

--- a/Mathlib/Algebra/GroupPower/Basic.lean
+++ b/Mathlib/Algebra/GroupPower/Basic.lean
@@ -480,7 +480,7 @@ theorem zpow_eq_zpow_zmod {x : G} (m : ℤ) {n : ℤ} (h : x ^ n = 1) :
     x ^ m = x ^ (m % n) := by
 calc
     x ^ m = x ^ (m % n + n * (m / n)) := by rw [Int.emod_add_ediv]
-    _ = x ^ (m % (n : ℤ)) := by simp [zpow_add, zpow_mul, h]
+    _ = x ^ (m % n) := by simp [zpow_add, zpow_mul, h]
 
 theorem zpow_eq_zpow_mod {x : G} (m : ℤ) {n : ℕ} (h : x ^ n = 1) :
     x ^ m = x ^ (m % (n : ℤ)) := zpow_eq_zpow_zmod m (by simpa)

--- a/Mathlib/Algebra/GroupPower/Basic.lean
+++ b/Mathlib/Algebra/GroupPower/Basic.lean
@@ -476,14 +476,14 @@ lemma mul_zpow_self (a : G) (n : ℤ) : a ^ n * a = a ^ (n + 1) := (zpow_add_one
 #align zpow_mul_comm zpow_mul_comm
 #align zsmul_add_comm zsmul_add_comm
 
-theorem zpow_eq_zpow_mod {x : G} (m : ℤ) {n : ℤ} (h : x ^ n = 1) :
-    x ^ m = x ^ (m % n) := by
-calc
+theorem zpow_eq_zpow_emod {x : G} (m : ℤ) {n : ℤ} (h : x ^ n = 1) :
+    x ^ m = x ^ (m % n) :=
+  calc
     x ^ m = x ^ (m % n + n * (m / n)) := by rw [Int.emod_add_ediv]
     _ = x ^ (m % n) := by simp [zpow_add, zpow_mul, h]
 
-theorem zpow_eq_zpow_mod' {x : G} (m : ℤ) {n : ℕ} (h : x ^ n = 1) :
-    x ^ m = x ^ (m % (n : ℤ)) := zpow_eq_zpow_mod m (by simpa)
+theorem zpow_eq_zpow_emod' {x : G} (m : ℤ) {n : ℕ} (h : x ^ n = 1) :
+    x ^ m = x ^ (m % (n : ℤ)) := zpow_eq_zpow_emod m (by simpa)
 
 section bit1
 

--- a/Mathlib/Algebra/GroupPower/Basic.lean
+++ b/Mathlib/Algebra/GroupPower/Basic.lean
@@ -477,13 +477,13 @@ lemma mul_zpow_self (a : G) (n : ℤ) : a ^ n * a = a ^ (n + 1) := (zpow_add_one
 #align zsmul_add_comm zsmul_add_comm
 
 theorem zpow_eq_zpow_zmod {x : G} (m : ℤ) {n : ℤ} (h : x ^ n = 1) :
-  x ^ m = x ^ (m % n) := by
+    x ^ m = x ^ (m % n) := by
 calc
     x ^ m = x ^ (m % n + n * (m / n)) := by rw [Int.emod_add_ediv]
     _ = x ^ (m % (n : ℤ)) := by simp [zpow_add, zpow_mul, h]
 
 theorem zpow_eq_zpow_mod {x : G} (m : ℤ) {n : ℕ} (h : x ^ n = 1) :
-  x ^ m = x ^ (m % (n : ℤ)) := zpow_eq_zpow_zmod m (by simpa)
+    x ^ m = x ^ (m % (n : ℤ)) := zpow_eq_zpow_zmod m (by simpa)
 
 section bit1
 

--- a/Mathlib/Algebra/GroupPower/Basic.lean
+++ b/Mathlib/Algebra/GroupPower/Basic.lean
@@ -476,14 +476,14 @@ lemma mul_zpow_self (a : G) (n : ℤ) : a ^ n * a = a ^ (n + 1) := (zpow_add_one
 #align zpow_mul_comm zpow_mul_comm
 #align zsmul_add_comm zsmul_add_comm
 
-theorem zpow_eq_zpow_zmod {x : G} (m : ℤ) {n : ℤ} (h : x ^ n = 1) :
+theorem zpow_eq_zpow_mod {x : G} (m : ℤ) {n : ℤ} (h : x ^ n = 1) :
     x ^ m = x ^ (m % n) := by
 calc
     x ^ m = x ^ (m % n + n * (m / n)) := by rw [Int.emod_add_ediv]
     _ = x ^ (m % n) := by simp [zpow_add, zpow_mul, h]
 
-theorem zpow_eq_zpow_mod {x : G} (m : ℤ) {n : ℕ} (h : x ^ n = 1) :
-    x ^ m = x ^ (m % (n : ℤ)) := zpow_eq_zpow_zmod m (by simpa)
+theorem zpow_eq_zpow_mod' {x : G} (m : ℤ) {n : ℕ} (h : x ^ n = 1) :
+    x ^ m = x ^ (m % (n : ℤ)) := zpow_eq_zpow_mod m (by simpa)
 
 section bit1
 


### PR DESCRIPTION
To match `pow_eq_pow_mod` for monoids.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Also beautify the proof of `pow_eq_pow_mod` (thanks Riccardo!) and add a hybrid `zpow_eq_zpow_mod`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

