### PR TITLE
[Merged by Bors] - feat(NumberTheory/LegendreSymbol/MulCharacter): weaken assumptions

### DIFF
--- a/Mathlib/NumberTheory/LegendreSymbol/MulCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/MulCharacter.lean
@@ -419,7 +419,7 @@ end DefinitionAndGroup
 We introduce the properties of being nontrivial or quadratic and prove
 some basic facts about them.
 
-We now assume that domain and target are commutative rings.
+We now (mostly) assume that the target is a commutativ ring.
 -/
 
 
@@ -429,7 +429,9 @@ namespace MulChar
 
 universe u v w
 
-variable {R : Type u} [CommRing R] {R' : Type v} [CommRing R'] {R'' : Type w} [CommRing R'']
+section nontrivial
+
+variable {R : Type u} [CommMonoid R] {R' : Type v} [CommMonoidWithZero R']
 
 /-- A multiplicative character is *nontrivial* if it takes a value `≠ 1` on a unit. -/
 def IsNontrivial (χ : MulChar R R') : Prop :=
@@ -441,8 +443,14 @@ theorem isNontrivial_iff (χ : MulChar R R') : χ.IsNontrivial ↔ χ ≠ 1 := b
   simp only [IsNontrivial, Ne.def, ext_iff, not_forall, one_apply_coe]
 #align mul_char.is_nontrivial_iff MulChar.isNontrivial_iff
 
+end nontrivial
+
+section quadratic_and_comp
+
+variable {R : Type u} [CommMonoid R] {R' : Type v} [CommRing R'] {R'' : Type w} [CommRing R'']
+
 /-- A multiplicative character is *quadratic* if it takes only the values `0`, `1`, `-1`. -/
-def IsQuadratic (χ : MulChar R R') : Prop :=
+def IsQuadratic {R' : Type v} [CommRing R'] (χ : MulChar R R') : Prop :=
   ∀ a, χ a = 0 ∨ χ a = 1 ∨ χ a = -1
 #align mul_char.is_quadratic MulChar.IsQuadratic
 
@@ -522,11 +530,17 @@ theorem IsQuadratic.pow_odd {χ : MulChar R R'} (hχ : χ.IsQuadratic) {n : ℕ}
   rw [pow_add, pow_one, hχ.pow_even (even_two_mul _), one_mul]
 #align mul_char.is_quadratic.pow_odd MulChar.IsQuadratic.pow_odd
 
+end quadratic_and_comp
+
 open BigOperators
+
+section sum
+
+variable {R : Type u} [CommMonoid R] [Fintype R] {R' : Type v} [CommRing R']
 
 /-- The sum over all values of a nontrivial multiplicative character on a finite ring is zero
 (when the target is a domain). -/
-theorem IsNontrivial.sum_eq_zero [Fintype R] [IsDomain R'] {χ : MulChar R R'}
+theorem IsNontrivial.sum_eq_zero [IsDomain R'] {χ : MulChar R R'}
     (hχ : χ.IsNontrivial) : ∑ a, χ a = 0 := by
   rcases hχ with ⟨b, hb⟩
   refine' eq_zero_of_mul_eq_self_left hb _
@@ -553,6 +567,8 @@ theorem sum_one_eq_card_units [Fintype R] [DecidableEq R] :
     simp only [Finset.mem_filter, Finset.mem_univ, true_and_iff, Finset.mem_map,
       Function.Embedding.coeFn_mk, exists_true_left, IsUnit]
 #align mul_char.sum_one_eq_card_units MulChar.sum_one_eq_card_units
+
+end sum
 
 end MulChar
 

--- a/Mathlib/NumberTheory/LegendreSymbol/MulCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/MulCharacter.lean
@@ -450,7 +450,7 @@ section quadratic_and_comp
 variable {R : Type u} [CommMonoid R] {R' : Type v} [CommRing R'] {R'' : Type w} [CommRing R'']
 
 /-- A multiplicative character is *quadratic* if it takes only the values `0`, `1`, `-1`. -/
-def IsQuadratic {R' : Type v} [CommRing R'] (χ : MulChar R R') : Prop :=
+def IsQuadratic (χ : MulChar R R') : Prop :=
   ∀ a, χ a = 0 ∨ χ a = 1 ∨ χ a = -1
 #align mul_char.is_quadratic MulChar.IsQuadratic
 

--- a/Mathlib/NumberTheory/LegendreSymbol/MulCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/MulCharacter.lean
@@ -419,7 +419,7 @@ end DefinitionAndGroup
 We introduce the properties of being nontrivial or quadratic and prove
 some basic facts about them.
 
-We now (mostly) assume that the target is a commutativ ring.
+We now (mostly) assume that the target is a commutative ring.
 -/
 
 


### PR DESCRIPTION
This PR weakens the type class assumptions on some results about multiplicative characters  (from assuming the domain is a commutative ring to only requiring it is a commutative monoid).

See [here](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Multiplicative.20characters.20of.20finite.20groups/near/423605701) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
