### PR TITLE
[Merged by Bors] - refactor: use smul_algebraMap to simply proof of FixedPoints.intermediateField.algebraMap_mem'

### DIFF
--- a/Mathlib/FieldTheory/Galois.lean
+++ b/Mathlib/FieldTheory/Galois.lean
@@ -186,7 +186,7 @@ def FixedPoints.intermediateField (M : Type*) [Monoid M] [MulSemiringAction M E]
     [SMulCommClass M F E] : IntermediateField F E :=
   { FixedPoints.subfield M E with
     carrier := MulAction.fixedPoints M E
-    algebraMap_mem' := fun a g => by rw [Algebra.algebraMap_eq_smul_one, smul_comm, smul_one] }
+    algebraMap_mem' := fun a g => smul_algebraMap g a }
 #align fixed_points.intermediate_field FixedPoints.intermediateField
 
 namespace IntermediateField


### PR DESCRIPTION
Uses `smul_algebraMap` to simplify the proof of `FixedPoints.intermediateField.algebraMap_mem'`.

Amusingly, the current tactic-mode proof is very nearly identical to the body of `smul_algebraMap`:
https://github.com/leanprover-community/mathlib4/blob/bb9eaa6b041bc19ca8615a24fa48e463c672c150/Mathlib/Algebra/Algebra/Basic.lean#L403-L405

After making this simplificiation, I observe the time reported by `trace.profiler` to drop from 0.13 to 0.12 seconds.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
