### PR TITLE
[Merged by Bors] - feat(Mathlib/RingTheory/Ideal/QuotientOperations): First Isomorphism Theorem for algebras

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -567,7 +567,6 @@ variable [Semiring A] [Algebra R A] [Semiring B] [Algebra R B] [Semiring C] [Alg
 
 variable (φ : A →ₐ[R] B)
 
-#check RingHom.range
 /-- Range of an `AlgHom` as a subalgebra. -/
 protected def range (φ : A →ₐ[R] B) : Subalgebra R B :=
   { φ.toRingHom.rangeS with algebraMap_mem' := fun r => ⟨algebraMap R A r, φ.commutes r⟩ }

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -567,6 +567,7 @@ variable [Semiring A] [Algebra R A] [Semiring B] [Algebra R B] [Semiring C] [Alg
 
 variable (φ : A →ₐ[R] B)
 
+#check RingHom.range
 /-- Range of an `AlgHom` as a subalgebra. -/
 protected def range (φ : A →ₐ[R] B) : Subalgebra R B :=
   { φ.toRingHom.rangeS with algebraMap_mem' := fun r => ⟨algebraMap R A r, φ.commutes r⟩ }
@@ -625,6 +626,12 @@ This is the bundled version of `Set.rangeFactorization`. -/
 def rangeRestrict (f : A →ₐ[R] B) : A →ₐ[R] f.range :=
   f.codRestrict f.range f.mem_range_self
 #align alg_hom.range_restrict AlgHom.rangeRestrict
+
+theorem rangeRestrict_surjective (f : A →ₐ[R] B):
+    Function.Surjective (f.rangeRestrict) :=
+  fun ⟨_y, hy⟩ =>
+  let ⟨x, hx⟩ := hy
+  ⟨x, SetCoe.ext hx⟩
 
 /-- The equalizer of two R-algebra homomorphisms -/
 def equalizer (ϕ ψ : A →ₐ[R] B) : Subalgebra R A where

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -633,6 +633,10 @@ theorem rangeRestrict_surjective (f : A →ₐ[R] B):
   let ⟨x, hx⟩ := hy
   ⟨x, SetCoe.ext hx⟩
 
+theorem ker_rangeRestrict (f : A →ₐ[R] B) :
+    RingHom.ker f.rangeRestrict = RingHom.ker f :=
+  Ideal.ext fun _ ↦ Subtype.ext_iff
+
 /-- The equalizer of two R-algebra homomorphisms -/
 def equalizer (ϕ ψ : A →ₐ[R] B) : Subalgebra R A where
   carrier := { a | ϕ a = ψ a }

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau, Patrick Massot
 import Mathlib.RingTheory.Ideal.Operations
 import Mathlib.RingTheory.Ideal.Quotient
 import Mathlib.Algebra.Ring.Fin
+import Mathlib.Algebra.Algebra.Subalgebra.Basic
 
 #align_import ring_theory.ideal.quotient_operations from "leanprover-community/mathlib"@"b88d81c84530450a8989e918608e5960f015e6c8"
 
@@ -14,8 +15,12 @@ import Mathlib.Algebra.Ring.Fin
 
 ## Main results:
 
- - `quotientKerEquivRange` : the **first isomorphism theorem** for commutative rings.
- - `quotientKerEquivRangeS` : the **first isomorphism theorem**
+ - `RingHom.quotientKerEquivRange` : the **first isomorphism theorem** for commutative rings.
+ - `RingHom.quotientKerEquivRangeS` : the **first isomorphism theorem**
+  for a morphism from a commutative ring to a semiring.
+ - `AlgHom.quotientKerEquivRange` : the **first isomorphism theorem**
+  for a morphism of algebras (over a commutative semiring)
+ - `RingHom.quotientKerEquivRangeS` : the **first isomorphism theorem**
   for a morphism from a commutative ring to a semiring.
  - `Ideal.quotientInfRingEquivPiQuotient`: the **Chinese Remainder Theorem**, version for coprime
    ideals (see also `ZMod.prodEquivPi` in `Data.ZMod.Quotient` for elementary versions about
@@ -643,6 +648,16 @@ theorem quotientEquivAlgOfEq_symm {I J : Ideal A} (h : I = J) :
 lemma comap_map_mk {I J : Ideal R} (h : I ≤ J) :
     Ideal.comap (Ideal.Quotient.mk I) (Ideal.map (Ideal.Quotient.mk I) J) = J :=
   by ext; rw [← Ideal.mem_quotient_iff_mem h, Ideal.mem_comap]
+
+/-- The **first isomorphism theorem** for commutative algebras (`AlgHom.range` version). -/
+noncomputable def quotientKerEquivRange
+  {A B : Type*} [Semiring A] [Algebra R₁ A] [Semiring B] [Algebra R₁ B]
+  (f : A →ₐ[R₁] B) :
+  (A ⧸ RingHom.ker f) ≃ₐ[R₁] f.range :=
+  (Ideal.quotientEquivAlgOfEq R f.ker_rangeRestrict.symm).trans <|
+-- it necessary to add `(f := …)` here, otherwise Lean times out…
+    Ideal.quotientKerAlgEquivOfSurjective (f := f.rangeRestrict)
+      f.rangeRestrict_surjective
 
 end QuotientAlgebra
 

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -651,13 +651,11 @@ lemma comap_map_mk {I J : Ideal R} (h : I ≤ J) :
 
 /-- The **first isomorphism theorem** for commutative algebras (`AlgHom.range` version). -/
 noncomputable def quotientKerEquivRange
-  {A B : Type*} [Semiring A] [Algebra R₁ A] [Semiring B] [Algebra R₁ B]
-  (f : A →ₐ[R₁] B) :
-  (A ⧸ RingHom.ker f) ≃ₐ[R₁] f.range :=
-  (Ideal.quotientEquivAlgOfEq R f.ker_rangeRestrict.symm).trans <|
--- it necessary to add `(f := …)` here, otherwise Lean times out…
-    Ideal.quotientKerAlgEquivOfSurjective (f := f.rangeRestrict)
-      f.rangeRestrict_surjective
+  {A B : Type*} [CommRing A] [Algebra R A] [Semiring B] [Algebra R B]
+  (f : A →ₐ[R] B) :
+  (A ⧸ RingHom.ker f) ≃ₐ[R] f.range :=
+  (Ideal.quotientEquivAlgOfEq R (AlgHom.ker_rangeRestrict f).symm).trans <|
+    Ideal.quotientKerAlgEquivOfSurjective f.rangeRestrict_surjective
 
 end QuotientAlgebra
 


### PR DESCRIPTION
We add the First Isomorphism Theorem for algebras.
(only the surjective version was present in mathlib).
We also adjust the docstring on top of the file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
