### PR TITLE
[Merged by Bors] - fix(LinearAlgebra/TensorPower): correct notation precedence

### DIFF
--- a/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
@@ -24,7 +24,7 @@ variable {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
 namespace TensorPower
 
 /-- The canonical embedding from a tensor power to the tensor algebra -/
-def toTensorAlgebra {n} : (⨂[R]^n) M →ₗ[R] TensorAlgebra R M :=
+def toTensorAlgebra {n} : ⨂[R]^n M →ₗ[R] TensorAlgebra R M :=
   PiTensorProduct.lift (TensorAlgebra.tprod R M n)
 #align tensor_power.to_tensor_algebra TensorPower.toTensorAlgebra
 
@@ -36,13 +36,13 @@ theorem toTensorAlgebra_tprod {n} (x : Fin n → M) :
 
 @[simp]
 theorem toTensorAlgebra_gOne :
-    TensorPower.toTensorAlgebra (@GradedMonoid.GOne.one _ (fun n => (⨂[R]^n) M) _ _) = 1 :=
+    TensorPower.toTensorAlgebra (@GradedMonoid.GOne.one _ (fun n => ⨂[R]^n M) _ _) = 1 :=
   TensorPower.toTensorAlgebra_tprod _
 #align tensor_power.to_tensor_algebra_ghas_one TensorPower.toTensorAlgebra_gOne
 
 @[simp]
 theorem toTensorAlgebra_gMul {i j} (a : (⨂[R]^i) M) (b : (⨂[R]^j) M) :
-    TensorPower.toTensorAlgebra (@GradedMonoid.GMul.mul _ (fun n => (⨂[R]^n) M) _ _ _ _ a b) =
+    TensorPower.toTensorAlgebra (@GradedMonoid.GMul.mul _ (fun n => ⨂[R]^n M) _ _ _ _ a b) =
       TensorPower.toTensorAlgebra a * TensorPower.toTensorAlgebra b := by
   -- change `a` and `b` to `tprod R a` and `tprod R b`
   rw [TensorPower.gMul_eq_coe_linearMap, ← LinearMap.compr₂_apply, ← @LinearMap.mul_apply' R, ←
@@ -67,7 +67,7 @@ theorem toTensorAlgebra_gMul {i j} (a : (⨂[R]^i) M) (b : (⨂[R]^j) M) :
 
 @[simp]
 theorem toTensorAlgebra_galgebra_toFun (r : R) :
-    TensorPower.toTensorAlgebra (DirectSum.GAlgebra.toFun (R := R) (A := fun n => (⨂[R]^n) M) r) =
+    TensorPower.toTensorAlgebra (DirectSum.GAlgebra.toFun (R := R) (A := fun n => ⨂[R]^n M) r) =
       algebraMap _ _ r := by
   rw [TensorPower.galgebra_toFun_def, TensorPower.algebraMap₀_eq_smul_one, LinearMap.map_smul,
     TensorPower.toTensorAlgebra_gOne, Algebra.algebraMap_eq_smul_one]
@@ -78,7 +78,7 @@ end TensorPower
 namespace TensorAlgebra
 
 /-- The canonical map from a direct sum of tensor powers to the tensor algebra. -/
-def ofDirectSum : (⨁ n, (⨂[R]^n) M) →ₐ[R] TensorAlgebra R M :=
+def ofDirectSum : (⨁ n, ⨂[R]^n M) →ₐ[R] TensorAlgebra R M :=
   DirectSum.toAlgebra _ _ (fun _ => TensorPower.toTensorAlgebra) TensorPower.toTensorAlgebra_gOne
     (fun {_ _} => TensorPower.toTensorAlgebra_gMul)
 #align tensor_algebra.of_direct_sum TensorAlgebra.ofDirectSum
@@ -92,16 +92,16 @@ theorem ofDirectSum_of_tprod {n} (x : Fin n → M) :
 #align tensor_algebra.of_direct_sum_of_tprod TensorAlgebra.ofDirectSum_of_tprod
 
 /-- The canonical map from the tensor algebra to a direct sum of tensor powers. -/
-def toDirectSum : TensorAlgebra R M →ₐ[R] ⨁ n, (⨂[R]^n) M :=
+def toDirectSum : TensorAlgebra R M →ₐ[R] ⨁ n, ⨂[R]^n M :=
   TensorAlgebra.lift R <|
-    DirectSum.lof R ℕ (fun n => (⨂[R]^n) M) _ ∘ₗ
+    DirectSum.lof R ℕ (fun n => ⨂[R]^n M) _ ∘ₗ
       (LinearEquiv.symm <| PiTensorProduct.subsingletonEquiv (0 : Fin 1) : M ≃ₗ[R] _).toLinearMap
 #align tensor_algebra.to_direct_sum TensorAlgebra.toDirectSum
 
 @[simp]
 theorem toDirectSum_ι (x : M) :
     toDirectSum (ι R x) =
-      DirectSum.of (fun n => (⨂[R]^n) M) _ (PiTensorProduct.tprod R fun _ : Fin 1 => x) :=
+      DirectSum.of (fun n => ⨂[R]^n M) _ (PiTensorProduct.tprod R fun _ : Fin 1 => x) :=
   TensorAlgebra.lift_ι_apply _ _
 #align tensor_algebra.to_direct_sum_ι TensorAlgebra.toDirectSum_ι
 
@@ -118,7 +118,7 @@ theorem ofDirectSum_toDirectSum (x : TensorAlgebra R M) :
 #align tensor_algebra.of_direct_sum_to_direct_sum TensorAlgebra.ofDirectSum_toDirectSum
 
 @[simp, nolint simpNF] -- see std4#365 for the simpNF issue
-theorem mk_reindex_cast {n m : ℕ} (h : n = m) (x : (⨂[R]^n) M) :
+theorem mk_reindex_cast {n m : ℕ} (h : n = m) (x : ⨂[R]^n M) :
     GradedMonoid.mk (A := fun i => (⨂[R]^i) M) m
     (PiTensorProduct.reindex R (fun _ ↦ M) (Equiv.cast <| congr_arg Fin h) x) =
     GradedMonoid.mk n x :=
@@ -126,7 +126,7 @@ theorem mk_reindex_cast {n m : ℕ} (h : n = m) (x : (⨂[R]^n) M) :
 #align tensor_algebra.mk_reindex_cast TensorAlgebra.mk_reindex_cast
 
 @[simp]
-theorem mk_reindex_fin_cast {n m : ℕ} (h : n = m) (x : (⨂[R]^n) M) :
+theorem mk_reindex_fin_cast {n m : ℕ} (h : n = m) (x : ⨂[R]^n M) :
     GradedMonoid.mk (A := fun i => (⨂[R]^i) M) m
     (PiTensorProduct.reindex R (fun _ ↦ M) (Fin.castIso h).toEquiv x) = GradedMonoid.mk n x := by
   rw [Fin.castIso_to_equiv, mk_reindex_cast h]
@@ -137,7 +137,7 @@ all the vectors. -/
 theorem _root_.TensorPower.list_prod_gradedMonoid_mk_single (n : ℕ) (x : Fin n → M) :
     ((List.finRange n).map fun a =>
           (GradedMonoid.mk _ (PiTensorProduct.tprod R fun _ : Fin 1 => x a) :
-            GradedMonoid fun n => (⨂[R]^n) M)).prod =
+            GradedMonoid fun n => ⨂[R]^n M)).prod =
       GradedMonoid.mk n (PiTensorProduct.tprod R x) := by
   refine' Fin.consInduction _ _ x <;> clear x
   · rw [List.finRange_zero, List.map_nil, List.prod_nil]
@@ -164,20 +164,20 @@ theorem toDirectSum_tensorPower_tprod {n} (x : Fin n → M) :
 #align tensor_algebra.to_direct_sum_tensor_power_tprod TensorAlgebra.toDirectSum_tensorPower_tprod
 
 theorem toDirectSum_comp_ofDirectSum :
-    toDirectSum.comp ofDirectSum = AlgHom.id R (⨁ n, (⨂[R]^n) M) := by
+    toDirectSum.comp ofDirectSum = AlgHom.id R (⨁ n, ⨂[R]^n M) := by
   ext
   simp [DirectSum.lof_eq_of, -tprod_apply, toDirectSum_tensorPower_tprod]
 #align tensor_algebra.to_direct_sum_comp_of_direct_sum TensorAlgebra.toDirectSum_comp_ofDirectSum
 
 @[simp]
-theorem toDirectSum_ofDirectSum (x : ⨁ n, (⨂[R]^n) M) :
+theorem toDirectSum_ofDirectSum (x : ⨁ n, ⨂[R]^n M) :
     TensorAlgebra.toDirectSum (ofDirectSum x) = x :=
   AlgHom.congr_fun toDirectSum_comp_ofDirectSum x
 #align tensor_algebra.to_direct_sum_of_direct_sum TensorAlgebra.toDirectSum_ofDirectSum
 
 /-- The tensor algebra is isomorphic to a direct sum of tensor powers. -/
 @[simps!]
-def equivDirectSum : TensorAlgebra R M ≃ₐ[R] ⨁ n, (⨂[R]^n) M :=
+def equivDirectSum : TensorAlgebra R M ≃ₐ[R] ⨁ n, ⨂[R]^n M :=
   AlgEquiv.ofAlgHom toDirectSum ofDirectSum toDirectSum_comp_ofDirectSum
     ofDirectSum_comp_toDirectSum
 #align tensor_algebra.equiv_direct_sum TensorAlgebra.equivDirectSum

--- a/Mathlib/LinearAlgebra/TensorPower.lean
+++ b/Mathlib/LinearAlgebra/TensorPower.lean
@@ -43,7 +43,7 @@ def TensorPower (R : Type*) (n : ℕ) (M : Type*) [CommSemiring R] [AddCommMonoi
 
 variable {R : Type*} {M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
 
-@[inherit_doc] scoped[TensorProduct] notation:100 "⨂[" R "]^" n:arg => TensorPower R n
+@[inherit_doc] scoped[TensorProduct] notation:max "⨂[" R "]^" n:arg => TensorPower R n
 
 namespace PiTensorProduct
 
@@ -67,43 +67,43 @@ open scoped TensorProduct DirectSum
 open PiTensorProduct
 
 /-- As a graded monoid, `⨂[R]^i M` has a `1 : ⨂[R]^0 M`. -/
-instance gOne : GradedMonoid.GOne fun i => (⨂[R]^i) M where one := tprod R <| @Fin.elim0 M
+instance gOne : GradedMonoid.GOne fun i => ⨂[R]^i M where one := tprod R <| @Fin.elim0 M
 #align tensor_power.ghas_one TensorPower.gOne
 
-local notation "ₜ1" => @GradedMonoid.GOne.one ℕ (fun i => (⨂[R]^i) M) _ _
+local notation "ₜ1" => @GradedMonoid.GOne.one ℕ (fun i => ⨂[R]^i M) _ _
 
 theorem gOne_def : ₜ1 = tprod R (@Fin.elim0 M) :=
   rfl
 #align tensor_power.ghas_one_def TensorPower.gOne_def
 
 /-- A variant of `PiTensorProduct.tmulEquiv` with the result indexed by `Fin (n + m)`. -/
-def mulEquiv {n m : ℕ} : (⨂[R]^n) M ⊗[R] (⨂[R]^m) M ≃ₗ[R] (⨂[R]^(n + m)) M :=
+def mulEquiv {n m : ℕ} : ⨂[R]^n M ⊗[R] (⨂[R]^m) M ≃ₗ[R] (⨂[R]^(n + m)) M :=
   (tmulEquiv R M).trans (reindex R (fun _ ↦ M) finSumFinEquiv)
 #align tensor_power.mul_equiv TensorPower.mulEquiv
 
 /-- As a graded monoid, `⨂[R]^i M` has a `(*) : ⨂[R]^i M → ⨂[R]^j M → ⨂[R]^(i + j) M`. -/
-instance gMul : GradedMonoid.GMul fun i => (⨂[R]^i) M where
+instance gMul : GradedMonoid.GMul fun i => ⨂[R]^i M where
   mul {i j} a b :=
     (TensorProduct.mk R _ _).compr₂ (↑(mulEquiv : _ ≃ₗ[R] (⨂[R]^(i + j)) M)) a b
 #align tensor_power.ghas_mul TensorPower.gMul
 
-local infixl:70 " ₜ* " => @GradedMonoid.GMul.mul ℕ (fun i => (⨂[R]^i) M) _ _ _ _
+local infixl:70 " ₜ* " => @GradedMonoid.GMul.mul ℕ (fun i => ⨂[R]^i M) _ _ _ _
 
-theorem gMul_def {i j} (a : (⨂[R]^i) M) (b : (⨂[R]^j) M) :
+theorem gMul_def {i j} (a : ⨂[R]^i M) (b : (⨂[R]^j) M) :
     a ₜ* b = @mulEquiv R M _ _ _ i j (a ⊗ₜ b) :=
   rfl
 #align tensor_power.ghas_mul_def TensorPower.gMul_def
 
-theorem gMul_eq_coe_linearMap {i j} (a : (⨂[R]^i) M) (b : (⨂[R]^j) M) :
+theorem gMul_eq_coe_linearMap {i j} (a : ⨂[R]^i M) (b : (⨂[R]^j) M) :
     a ₜ* b = ((TensorProduct.mk R _ _).compr₂ ↑(mulEquiv : _ ≃ₗ[R] (⨂[R]^(i + j)) M) :
-      (⨂[R]^i) M →ₗ[R] (⨂[R]^j) M →ₗ[R] (⨂[R]^(i + j)) M) a b :=
+      ⨂[R]^i M →ₗ[R] (⨂[R]^j) M →ₗ[R] (⨂[R]^(i + j)) M) a b :=
   rfl
 #align tensor_power.ghas_mul_eq_coe_linear_map TensorPower.gMul_eq_coe_linearMap
 
 variable (R M)
 
 /-- Cast between "equal" tensor powers. -/
-def cast {i j} (h : i = j) : (⨂[R]^i) M ≃ₗ[R] (⨂[R]^j) M :=
+def cast {i j} (h : i = j) : ⨂[R]^i M ≃ₗ[R] (⨂[R]^j) M :=
   reindex R (fun _ ↦ M) (Fin.castIso h).toEquiv
 #align tensor_power.cast TensorPower.cast
 
@@ -132,7 +132,7 @@ theorem cast_trans {i j k} (h : i = j) (h' : j = k) :
 variable {R M}
 
 @[simp]
-theorem cast_cast {i j k} (h : i = j) (h' : j = k) (a : (⨂[R]^i) M) :
+theorem cast_cast {i j k} (h : i = j) (h' : j = k) (a : ⨂[R]^i M) :
     cast R M h' (cast R M h a) = cast R M (h.trans h') a :=
   reindex_reindex _ _ _
 #align tensor_power.cast_cast TensorPower.cast_cast
@@ -146,7 +146,7 @@ theorem gradedMonoid_eq_of_cast {a b : GradedMonoid fun n => ⨂[R] _ : Fin n, M
 #align tensor_power.graded_monoid_eq_of_cast TensorPower.gradedMonoid_eq_of_cast
 
 theorem cast_eq_cast {i j} (h : i = j) :
-    ⇑(cast R M h) = _root_.cast (congrArg (fun i => (⨂[R]^i) M) h) := by
+    ⇑(cast R M h) = _root_.cast (congrArg (fun i => ⨂[R]^i M) h) := by
   subst h
   rw [cast_refl]
   rfl
@@ -167,7 +167,7 @@ theorem tprod_mul_tprod {na nb} (a : Fin na → M) (b : Fin nb → M) :
 
 variable {R}
 
-theorem one_mul {n} (a : (⨂[R]^n) M) : cast R M (zero_add n) (ₜ1 ₜ* a) = a := by
+theorem one_mul {n} (a : ⨂[R]^n M) : cast R M (zero_add n) (ₜ1 ₜ* a) = a := by
   rw [gMul_def, gOne_def]
   induction a using PiTensorProduct.induction_on with
   | smul_tprod r a =>
@@ -181,7 +181,7 @@ theorem one_mul {n} (a : (⨂[R]^n) M) : cast R M (zero_add n) (ₜ1 ₜ* a) = a
     rw [TensorProduct.tmul_add, map_add, map_add, hx, hy]
 #align tensor_power.one_mul TensorPower.one_mul
 
-theorem mul_one {n} (a : (⨂[R]^n) M) : cast R M (add_zero _) (a ₜ* ₜ1) = a := by
+theorem mul_one {n} (a : ⨂[R]^n M) : cast R M (add_zero _) (a ₜ* ₜ1) = a := by
   rw [gMul_def, gOne_def]
   induction a using PiTensorProduct.induction_on with
   | smul_tprod r a =>
@@ -197,7 +197,7 @@ theorem mul_one {n} (a : (⨂[R]^n) M) : cast R M (add_zero _) (a ₜ* ₜ1) = a
 
 theorem mul_assoc {na nb nc} (a : (⨂[R]^na) M) (b : (⨂[R]^nb) M) (c : (⨂[R]^nc) M) :
     cast R M (add_assoc _ _ _) (a ₜ* b ₜ* c) = a ₜ* (b ₜ* c) := by
-  let mul : ∀ n m : ℕ, (⨂[R]^n) M →ₗ[R] (⨂[R]^m) M →ₗ[R] (⨂[R]^(n + m)) M := fun n m =>
+  let mul : ∀ n m : ℕ, ⨂[R]^n M →ₗ[R] (⨂[R]^m) M →ₗ[R] (⨂[R]^(n + m)) M := fun n m =>
     (TensorProduct.mk R _ _).compr₂ ↑(mulEquiv : _ ≃ₗ[R] (⨂[R]^(n + m)) M)
   -- replace `a`, `b`, `c` with `tprod R a`, `tprod R b`, `tprod R c`
   let e : (⨂[R]^(na + nb + nc)) M ≃ₗ[R] (⨂[R]^(na + (nb + nc))) M := cast R M (add_assoc _ _ _)
@@ -220,7 +220,7 @@ theorem mul_assoc {na nb nc} (a : (⨂[R]^na) M) (b : (⨂[R]^nb) M) (c : (⨂[R
 #align tensor_power.mul_assoc TensorPower.mul_assoc
 
 -- for now we just use the default for the `gnpow` field as it's easier.
-instance gmonoid : GradedMonoid.GMonoid fun i => (⨂[R]^i) M :=
+instance gmonoid : GradedMonoid.GMonoid fun i => ⨂[R]^i M :=
   { TensorPower.gMul, TensorPower.gOne with
     one_mul := fun a => gradedMonoid_eq_of_cast (zero_add _) (one_mul _)
     mul_one := fun a => gradedMonoid_eq_of_cast (add_zero _) (mul_one _)
@@ -241,13 +241,13 @@ theorem algebraMap₀_one : (algebraMap₀ 1 : (⨂[R]^0) M) = ₜ1 :=
   (algebraMap₀_eq_smul_one 1).trans (one_smul _ _)
 #align tensor_power.algebra_map₀_one TensorPower.algebraMap₀_one
 
-theorem algebraMap₀_mul {n} (r : R) (a : (⨂[R]^n) M) :
+theorem algebraMap₀_mul {n} (r : R) (a : ⨂[R]^n M) :
     cast R M (zero_add _) (algebraMap₀ r ₜ* a) = r • a := by
   rw [gMul_eq_coe_linearMap, algebraMap₀_eq_smul_one, LinearMap.map_smul₂,
     LinearEquiv.map_smul, ← gMul_eq_coe_linearMap, one_mul]
 #align tensor_power.algebra_map₀_mul TensorPower.algebraMap₀_mul
 
-theorem mul_algebraMap₀ {n} (r : R) (a : (⨂[R]^n) M) :
+theorem mul_algebraMap₀ {n} (r : R) (a : ⨂[R]^n M) :
     cast R M (add_zero _) (a ₜ* algebraMap₀ r) = r • a := by
   rw [gMul_eq_coe_linearMap, algebraMap₀_eq_smul_one, LinearMap.map_smul,
     LinearEquiv.map_smul, ← gMul_eq_coe_linearMap, mul_one]
@@ -259,7 +259,7 @@ theorem algebraMap₀_mul_algebraMap₀ (r s : R) :
   exact algebraMap₀_mul r (@algebraMap₀ R M _ _ _ s)
 #align tensor_power.algebra_map₀_mul_algebra_map₀ TensorPower.algebraMap₀_mul_algebraMap₀
 
-instance gsemiring : DirectSum.GSemiring fun i => (⨂[R]^i) M :=
+instance gsemiring : DirectSum.GSemiring fun i => ⨂[R]^i M :=
   { TensorPower.gmonoid with
     mul_zero := fun a => LinearMap.map_zero _
     zero_mul := fun b => LinearMap.map_zero₂ _ _
@@ -270,12 +270,12 @@ instance gsemiring : DirectSum.GSemiring fun i => (⨂[R]^i) M :=
     natCast_succ := fun n => by simp only [Nat.cast_succ, map_add, algebraMap₀_one] }
 #align tensor_power.gsemiring TensorPower.gsemiring
 
-example : Semiring (⨁ n : ℕ, (⨂[R]^n) M) := by infer_instance
+example : Semiring (⨁ n : ℕ, ⨂[R]^n M) := by infer_instance
 
 /-- The tensor powers form a graded algebra.
 
 Note that this instance implies `Algebra R (⨁ n : ℕ, ⨂[R]^n M)` via `DirectSum.Algebra`. -/
-instance galgebra : DirectSum.GAlgebra R fun i => (⨂[R]^i) M where
+instance galgebra : DirectSum.GAlgebra R fun i => ⨂[R]^i M where
   toFun := (algebraMap₀ : R ≃ₗ[R] (⨂[R]^0) M).toLinearMap.toAddMonoidHom
   map_one := algebraMap₀_one
   map_mul r s := gradedMonoid_eq_of_cast rfl (by
@@ -293,10 +293,10 @@ instance galgebra : DirectSum.GAlgebra R fun i => (⨂[R]^i) M where
 #align tensor_power.galgebra TensorPower.galgebra
 
 theorem galgebra_toFun_def (r : R) :
-    @DirectSum.GAlgebra.toFun ℕ R (fun i => (⨂[R]^i) M) _ _ _ _ _ _ _ r = algebraMap₀ r :=
+    @DirectSum.GAlgebra.toFun ℕ R (fun i => ⨂[R]^i M) _ _ _ _ _ _ _ r = algebraMap₀ r :=
   rfl
 #align tensor_power.galgebra_to_fun_def TensorPower.galgebra_toFun_def
 
-example : Algebra R (⨁ n : ℕ, (⨂[R]^n) M) := by infer_instance
+example : Algebra R (⨁ n : ℕ, ⨂[R]^n M) := by infer_instance
 
 end TensorPower


### PR DESCRIPTION
This removes some ugly parens that were introduced during porting


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
