### PR TITLE
[Merged by Bors] - doc(LinearAlgebra/PiTensorProduct): improve docstring for tprod notation

### DIFF
--- a/Mathlib/LinearAlgebra/PiTensorProduct.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct.lean
@@ -35,7 +35,7 @@ binary tensor product in `LinearAlgebra/TensorProduct.lean`.
 ## Notations
 
 * `⨂[R] i, s i` is defined as localized notation in locale `TensorProduct`.
-* `⨂ₜ[R] i, f i` with `f : ∀ i, f i` is defined globally as the tensor product of all the `f i`'s.
+* `⨂ₜ[R] i, f i` with `f : ∀ i, s i` is defined globally as the tensor product of all the `f i`'s.
 
 ## Implementation notes
 
@@ -301,7 +301,9 @@ instance : IsScalarTower R R (⨂[R] i, s i) :=
 
 variable (R)
 
-/-- The canonical `MultilinearMap R s (⨂[R] i, s i)`. -/
+/-- The canonical `MultilinearMap R s (⨂[R] i, s i)`.
+
+`tprod R fun i => f i` has notation `⨂ₜ[R] i, f i`. -/
 def tprod : MultilinearMap R s (⨂[R] i, s i) where
   toFun := tprodCoeff R 1
   map_add' {_ f} i x y := (add_tprodCoeff (1 : R) f i x y).symm
@@ -312,8 +314,7 @@ def tprod : MultilinearMap R s (⨂[R] i, s i) where
 variable {R}
 
 unsuppress_compilation in
-/-- pure tensor in tensor product over some index type -/
--- TODO(kmill) The generated delaborator never applies; figure out why this doesn't pretty print.
+@[inherit_doc tprod]
 notation3:100 "⨂ₜ["R"] "(...)", "r:(scoped f => tprod R f) => r
 
 --Porting note: new theorem


### PR DESCRIPTION
Also remove a TODO by @kmill; `tprod r fun i => f i` delaborates correctly now. `tprod R f` does not use notation, but this is no different to the behavior of `Finset.sum s f`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
