### PR TITLE
[Merged by Bors] - feat(Data/ZMod/Basic): more ringEquivCongr API

### DIFF
--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -474,7 +474,7 @@ lemma ringEquivCongr_trans {a b c : ℕ} (hab : a = b) (hbc : b = c) :
   cases a <;> rfl
 
 lemma ringEquivCongr_trans_apply {a b c : ℕ} (hab : a = b) (hbc : b = c) (x : ZMod a) :
-    (ringEquivCongr hbc) ((ringEquivCongr hab) x) = (ringEquivCongr (hab ▸ hbc)) x := by
+    (ringEquivCongr hbc) (ringEquivCongr hab x) = ringEquivCongr (hab ▸ hbc) x := by
   rw [← ringEquivCongr_trans hab hbc]
   rfl
 

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -468,10 +468,6 @@ lemma ringEquivCongr_symm {a b : ℕ} (hab : a = b) :
   subst hab
   cases a <;> rfl
 
-lemma ringEquivCongr_symm_apply {a b : ℕ} (hab : a = b) (y : ZMod b) :
-    (ringEquivCongr hab).symm y = ringEquivCongr hab.symm y := by
-  rw [ringEquivCongr_symm]
-
 lemma ringEquivCongr_trans {a b c : ℕ} (hab : a = b) (hbc : b = c) :
     (ringEquivCongr hab).trans (ringEquivCongr hbc) = ringEquivCongr (hab ▸ hbc) := by
   subst hab hbc

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -456,20 +456,31 @@ def ringEquivCongr {m n : ℕ} (h : m = n) : ZMod m ≃+* ZMod n := by
           rw [Fin.coe_cast, Fin.val_add, Fin.val_add, Fin.coe_cast, Fin.coe_cast, ← h] }
 #align zmod.ring_equiv_congr ZMod.ringEquivCongr
 
-lemma ringEquivCongr_rfl {a : ℕ} (x : ZMod a) : ZMod.ringEquivCongr rfl x = x := by
+@[simp] lemma ringEquivCongr_refl (a : ℕ) : ringEquivCongr (rfl : a = a) = .refl _ := by
   cases a <;> rfl
 
-lemma ringEquivCongr_symm {a b : ℕ} (hab : a = b) (x : ZMod a) (y : ZMod b)
-    (hyz : y = ZMod.ringEquivCongr hab x) : x = ZMod.ringEquivCongr hab.symm y := by
-  subst hab hyz
+lemma ringEquivCongr_refl_apply {a : ℕ} (x : ZMod a) : ringEquivCongr rfl x = x := by
+  rw [ringEquivCongr_refl]
+  rfl
+
+lemma ringEquivCongr_symm {a b : ℕ} (hab : a = b) :
+    (ringEquivCongr hab).symm = ringEquivCongr hab.symm := by
+  subst hab
   cases a <;> rfl
 
-lemma ringEquivCongr_trans {a b c : ℕ} (hab : a = b) (hbc : b = c)
-    (x : ZMod a) (y : ZMod b) (z : ZMod c)
-    (hyx : y = ZMod.ringEquivCongr hab x) (hzy : z = ZMod.ringEquivCongr hbc y) :
-    z = ZMod.ringEquivCongr (hbc ▸ hab) x := by
-  subst hyx hzy hab hbc
+lemma ringEquivCongr_symm_apply {a b : ℕ} (hab : a = b) (y : ZMod b) :
+    (ringEquivCongr hab).symm y = ringEquivCongr hab.symm y := by
+  rw [ringEquivCongr_symm]
+
+lemma ringEquivCongr_trans {a b c : ℕ} (hab : a = b) (hbc : b = c) :
+     (ringEquivCongr hab).trans (ringEquivCongr hbc) = (ringEquivCongr (hab ▸ hbc)) := by
+  subst hab hbc
   cases a <;> rfl
+
+lemma ringEquivCongr_trans_apply {a b c : ℕ} (hab : a = b) (hbc : b = c) (x : ZMod a) :
+     (ringEquivCongr hbc) ((ringEquivCongr hab) x) = (ringEquivCongr (hab ▸ hbc)) x := by
+  rw [← ringEquivCongr_trans hab hbc]
+  rfl
 
 lemma ringEquivCongr_val {a b : ℕ} (h : a = b) (x : ZMod a) :
     ZMod.val ((ZMod.ringEquivCongr h) x) = ZMod.val x := by

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -456,6 +456,21 @@ def ringEquivCongr {m n : ℕ} (h : m = n) : ZMod m ≃+* ZMod n := by
           rw [Fin.coe_cast, Fin.val_add, Fin.val_add, Fin.coe_cast, Fin.coe_cast, ← h] }
 #align zmod.ring_equiv_congr ZMod.ringEquivCongr
 
+lemma ringEquivCongr_rfl {a : ℕ} (x : ZMod a) : ZMod.ringEquivCongr rfl x = x := by
+  cases a <;> rfl
+
+lemma ringEquivCongr_symm {a b : ℕ} (hab : a = b) (x : ZMod a) (y : ZMod b)
+    (hyz : y = ZMod.ringEquivCongr hab x) : x = ZMod.ringEquivCongr hab.symm y := by
+  subst hab hyz
+  cases a <;> rfl
+
+lemma ringEquivCongr_trans {a b c : ℕ} (hab : a = b) (hbc : b = c)
+    (x : ZMod a) (y : ZMod b) (z : ZMod c)
+    (hyx : y = ZMod.ringEquivCongr hab x) (hzy : z = ZMod.ringEquivCongr hbc y) :
+    z = ZMod.ringEquivCongr (hbc ▸ hab) x := by
+  subst hyx hzy hab hbc
+  cases a <;> rfl
+
 lemma ringEquivCongr_val {a b : ℕ} (h : a = b) (x : ZMod a) :
     ZMod.val ((ZMod.ringEquivCongr h) x) = ZMod.val x := by
   subst h

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -473,7 +473,7 @@ lemma ringEquivCongr_symm_apply {a b : ℕ} (hab : a = b) (y : ZMod b) :
   rw [ringEquivCongr_symm]
 
 lemma ringEquivCongr_trans {a b c : ℕ} (hab : a = b) (hbc : b = c) :
-    (ringEquivCongr hab).trans (ringEquivCongr hbc) = (ringEquivCongr (hab ▸ hbc)) := by
+    (ringEquivCongr hab).trans (ringEquivCongr hbc) = ringEquivCongr (hab ▸ hbc) := by
   subst hab hbc
   cases a <;> rfl
 

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -473,8 +473,8 @@ lemma ringEquivCongr_trans {a b c : ℕ} (hab : a = b) (hbc : b = c) :
   subst hab hbc
   cases a <;> rfl
 
-lemma ringEquivCongr_trans_apply {a b c : ℕ} (hab : a = b) (hbc : b = c) (x : ZMod a) :
-    (ringEquivCongr hbc) (ringEquivCongr hab x) = ringEquivCongr (hab ▸ hbc) x := by
+lemma ringEquivCongr_ringEquivCongr_apply {a b c : ℕ} (hab : a = b) (hbc : b = c) (x : ZMod a) :
+    ringEquivCongr hbc (ringEquivCongr hab x) = ringEquivCongr (hab.trans hbc) x := by
   rw [← ringEquivCongr_trans hab hbc]
   rfl
 

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -473,12 +473,12 @@ lemma ringEquivCongr_symm_apply {a b : ℕ} (hab : a = b) (y : ZMod b) :
   rw [ringEquivCongr_symm]
 
 lemma ringEquivCongr_trans {a b c : ℕ} (hab : a = b) (hbc : b = c) :
-     (ringEquivCongr hab).trans (ringEquivCongr hbc) = (ringEquivCongr (hab ▸ hbc)) := by
+    (ringEquivCongr hab).trans (ringEquivCongr hbc) = (ringEquivCongr (hab ▸ hbc)) := by
   subst hab hbc
   cases a <;> rfl
 
 lemma ringEquivCongr_trans_apply {a b c : ℕ} (hab : a = b) (hbc : b = c) (x : ZMod a) :
-     (ringEquivCongr hbc) ((ringEquivCongr hab) x) = (ringEquivCongr (hab ▸ hbc)) x := by
+    (ringEquivCongr hbc) ((ringEquivCongr hab) x) = (ringEquivCongr (hab ▸ hbc)) x := by
   rw [← ringEquivCongr_trans hab hbc]
   rfl
 

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -469,7 +469,7 @@ lemma ringEquivCongr_symm {a b : ℕ} (hab : a = b) :
   cases a <;> rfl
 
 lemma ringEquivCongr_trans {a b c : ℕ} (hab : a = b) (hbc : b = c) :
-    (ringEquivCongr hab).trans (ringEquivCongr hbc) = ringEquivCongr (hab ▸ hbc) := by
+    (ringEquivCongr hab).trans (ringEquivCongr hbc) = ringEquivCongr (hab.trans hbc) := by
   subst hab hbc
   cases a <;> rfl
 


### PR DESCRIPTION
Add rfl, symm and trans lemmas for ringEquivCongr.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
