### PR TITLE
[Merged by Bors] - chore: classify `cannot automatically derive` porting notes

### DIFF
--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -106,13 +106,13 @@ def Spec : CommRingCatᵒᵖ ⥤ AffineScheme :=
   Scheme.Spec.toEssImage
 #align algebraic_geometry.AffineScheme.Spec AlgebraicGeometry.AffineScheme.Spec
 
--- Porting note: cannot automatically derive
+-- Porting note (#11081): cannot automatically derive
 instance Spec_full : Full Spec := Full.toEssImage _
 
--- Porting note: cannot automatically derive
+-- Porting note (#11081): cannot automatically derive
 instance Spec_faithful : Faithful Spec := Faithful.toEssImage _
 
--- Porting note: cannot automatically derive
+-- Porting note (#11081): cannot automatically derive
 instance Spec_essSurj : EssSurj Spec := EssSurj.toEssImage (F := _)
 
 /-- The forgetful functor `AffineScheme ⥤ Scheme`. -/
@@ -121,11 +121,11 @@ def forgetToScheme : AffineScheme ⥤ Scheme :=
   Scheme.Spec.essImageInclusion
 #align algebraic_geometry.AffineScheme.forget_to_Scheme AlgebraicGeometry.AffineScheme.forgetToScheme
 
--- Porting note: cannot automatically derive
+-- Porting note (#11081): cannot automatically derive
 instance forgetToScheme_full : Full forgetToScheme :=
 show Full (Scheme.Spec.essImageInclusion) from inferInstance
 
--- Porting note: cannot automatically derive
+-- Porting note (#11081): cannot automatically derive
 instance forgetToScheme_faithful : Faithful forgetToScheme :=
 show Faithful (Scheme.Spec.essImageInclusion) from inferInstance
 

--- a/Mathlib/Data/Sign.lean
+++ b/Mathlib/Data/Sign.lean
@@ -14,7 +14,7 @@ This file defines the sign function for types with zero and a decidable less-tha
 proves some basic theorems about it.
 -/
 
--- Porting note: Cannot automatically derive Fintype, added manually
+-- Porting note (#11081): cannot automatically derive Fintype, added manually
 /-- The type of signs. -/
 inductive SignType
   | zero


### PR DESCRIPTION
Classifies by adding issue number #11081 to porting notes claiming: 

> cannot automatically derive