### PR TITLE
[Merged by Bors] - chore: solve `not necessary anymore` porting notes

### DIFF
--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -186,6 +186,9 @@ theorem coe_eq_coe {x y : p} : (x : B) = y ↔ x = y :=
   Subtype.ext_iff_val.symm
 #align set_like.coe_eq_coe SetLike.coe_eq_coe
 
+-- porting note: this is not necessary anymore due to the way coercions work
+ #noalign set_like.coe_mk
+
 @[simp]
 theorem coe_mem (x : p) : (x : B) ∈ p :=
   x.2

--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -186,9 +186,6 @@ theorem coe_eq_coe {x y : p} : (x : B) = y ↔ x = y :=
   Subtype.ext_iff_val.symm
 #align set_like.coe_eq_coe SetLike.coe_eq_coe
 
--- porting note: this is not necessary anymore due to the way coercions work
-#noalign set_like.coe_mk
-
 @[simp]
 theorem coe_mem (x : p) : (x : B) ∈ p :=
   x.2

--- a/Mathlib/LinearAlgebra/GeneralLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/GeneralLinearGroup.lean
@@ -37,9 +37,6 @@ namespace GeneralLinearGroup
 
 variable {R M}
 
--- Porting note: This is not necessary anymore
--- instance : CoeFun (GeneralLinearGroup R M) fun _ ↦ M → M := by infer_instance
-
 /-- An invertible linear map `f` determines an equivalence from `M` to itself. -/
 def toLinearEquiv (f : GeneralLinearGroup R M) : M ≃ₗ[R] M :=
   { f.val with

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -102,11 +102,6 @@ instance instFunLike : FunLike (Poly α) (α → ℕ) ℤ :=
   ⟨Subtype.val, Subtype.val_injective⟩
 #align poly.fun_like Poly.instFunLike
 
--- Porting note: This instance is not necessary anymore
--- /-- Helper instance for when there are too many metavariables to apply `DFunLike.hasCoeToFun`
--- directly. -/
--- instance : CoeFun (Poly α) fun _ => (α → ℕ) → ℤ := DFunLike.hasCoeToFun
-
 /-- The underlying function of a `Poly` is a polynomial -/
 protected theorem isPoly (f : Poly α) : IsPoly f := f.2
 #align poly.is_poly Poly.isPoly

--- a/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
@@ -158,11 +158,6 @@ def UniformOnFun (α β : Type*) (_ : Set (Set α)) :=
 
 @[inherit_doc] scoped[UniformConvergence] notation:25 α " →ᵤ[" 𝔖 "] " β:0 => UniformOnFun α β 𝔖
 
--- Porting note: these are not used anymore
--- scoped[UniformConvergence] notation3 "λᵘ "(...)", "r:(scoped p => UniformFun.ofFun p) => r
-
--- scoped[UniformConvergence] notation3 "λᵘ["𝔖"] "(...)", "r:(scoped p => UniformFun.ofFun p) => r
-
 open UniformConvergence
 
 variable {α β : Type*} {𝔖 : Set (Set α)}


### PR DESCRIPTION
Solves porting notes claiming
- "not necessary anymore" 
- "not used anymore"

by simply deleting them.