### PR TITLE
[Merged by Bors] - fix: correctly elaborate Simp.Config in field_simp

### DIFF
--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -151,7 +151,7 @@ syntax (name := fieldSimp) "field_simp" (config)? (discharger)? (&" only")?
 elab_rules : tactic
 | `(tactic| field_simp $[$cfg:config]? $[(discharger := $dis)]? $[only%$only?]?
     $[$sa:simpArgs]? $[$loc:location]?) => withMainContext do
-  let cfg ← elabSimpConfig (cfg.getD ⟨.missing⟩) .simp
+  let cfg ← elabSimpConfig (mkOptionalNode cfg) .simp
   let loc := expandOptLocation (mkOptionalNode loc)
 
   let dis ← match dis with

--- a/test/FieldSimp.lean
+++ b/test/FieldSimp.lean
@@ -60,6 +60,13 @@ example (x : ℚ) (h₀ : x ≠ 0) :
   field_simp (discharger := simp; assumption)
   ring
 
+/-- Specify a simp config. -/
+example (x : ℚ) (h₀ : x ≠ 0) :
+    (4 / x)⁻¹ * ((3 * x^3) / x)^2 * ((1 / (2 * x))⁻¹)^3 = 18 * x^8 := by
+  fail_if_success field_simp (config := {maxSteps := 0})
+  field_simp (config := {})
+  ring
+
 example {x y z w : ℚ} (h : x / y = z / w) (hy : y ≠ 0) (hw : w ≠ 0) : x * w = z * y := by
   field_simp at h
   assumption


### PR DESCRIPTION
`elabSimpConfig` expects the `cfg` syntax to be wrapped in an "optional node".

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
