### PR TITLE
[Merged by Bors] - Refactor(Analysis): from BilinForm to LinearMap.BilinForm

### DIFF
--- a/Archive/Hairer.lean
+++ b/Archive/Hairer.lean
@@ -8,6 +8,7 @@ import Mathlib.Analysis.Analytic.Polynomial
 import Mathlib.Analysis.Analytic.Uniqueness
 import Mathlib.Analysis.Distribution.AEEqOfIntegralContDiff
 import Mathlib.Data.MvPolynomial.Funext
+import Mathlib.LinearAlgebra.Dual
 import Mathlib.RingTheory.MvPolynomial.Basic
 import Mathlib.Topology.Algebra.MvPolynomial
 

--- a/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
+++ b/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
@@ -61,10 +61,10 @@ variable [NormedAddCommGroup V] [MeasurableSpace V] [BorelSpace V] [InnerProduct
 /-- The integrand in the Riemann-Lebesgue lemma for `f` is integrable iff `f` is. -/
 theorem fourier_integrand_integrable (w : V) :
     Integrable f ↔ Integrable fun v : V => 𝐞[-⟪v, w⟫] • f v := by
-  have hL : Continuous fun p : V × V => BilinForm.toLin bilinFormOfRealInner p.1 p.2 :=
+  have hL : Continuous fun p : V × V => bilinFormOfRealInner p.1 p.2 :=
     continuous_inner
   rw [VectorFourier.fourier_integral_convergent_iff Real.continuous_fourierChar hL w]
-  simp only [BilinForm.toLin_apply, bilinFormOfRealInner_apply]
+  simp only [bilinFormOfRealInner_apply_apply, ofAdd_neg, map_inv, coe_inv_unitSphere]
 #align fourier_integrand_integrable fourier_integrand_integrable
 
 variable [CompleteSpace E]
@@ -234,7 +234,7 @@ theorem tendsto_integral_exp_inner_smul_cocompact :
       ← smul_sub, ← Pi.sub_apply]
     exact
       VectorFourier.norm_fourierIntegral_le_integral_norm 𝐞 volume
-        (BilinForm.toLin bilinFormOfRealInner) (f - g) w
+        (bilinFormOfRealInner) (f - g) w
   replace := add_lt_add_of_le_of_lt this hI
   rw [add_halves] at this
   refine' ((le_of_eq _).trans (norm_add_le _ _)).trans_lt this

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -499,7 +499,9 @@ def sesqFormOfInner : E →ₗ[𝕜] E →ₗ⋆[𝕜] 𝕜 :=
     (fun _x _y _z => inner_add_left _ _ _) fun _r _x _y => inner_smul_left _ _ _
 #align sesq_form_of_inner sesqFormOfInner
 
-/-- The real inner product as a bilinear form. -/
+/-- The real inner product as a bilinear form.
+
+ Note that unlike `sesqFormOfInner`, this does not reverse the order of the arguments. -/
 @[simps!]
 def bilinFormOfRealInner : BilinForm ℝ F := sesqFormOfInner.flip
 #align bilin_form_of_real_inner bilinFormOfRealInner

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -501,7 +501,7 @@ def sesqFormOfInner : E →ₗ[𝕜] E →ₗ⋆[𝕜] 𝕜 :=
 
 /-- The real inner product as a bilinear form.
 
- Note that unlike `sesqFormOfInner`, this does not reverse the order of the arguments. -/
+Note that unlike `sesqFormOfInner`, this does not reverse the order of the arguments. -/
 @[simps!]
 def bilinFormOfRealInner : BilinForm ℝ F := sesqFormOfInner.flip
 #align bilin_form_of_real_inner bilinFormOfRealInner

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -500,21 +500,8 @@ def sesqFormOfInner : E →ₗ[𝕜] E →ₗ⋆[𝕜] 𝕜 :=
 #align sesq_form_of_inner sesqFormOfInner
 
 /-- The real inner product as a bilinear form. -/
-@[simps]
-def bilinFormOfRealInner : BilinForm ℝ F where
-  toFun := fun x => {
-    toFun := fun y => inner x y
-    map_add' := by
-      simp only [inner_add_right, forall_const]
-    map_smul' := fun r z => by
-      simp only [inner_smul_right, RingHom.id_apply, smul_eq_mul]
-  }
-  map_add' := fun w z => by
-    simp only [inner_add_left]
-    rfl
-  map_smul' := fun r z => by
-    simp only [inner_smul_left, conj_trivial, RingHom.id_apply]
-    rfl
+@[simps!]
+def bilinFormOfRealInner : BilinForm ℝ F := sesqFormOfInner.flip
 #align bilin_form_of_real_inner bilinFormOfRealInner
 
 /-- An inner product with a sum on the left. -/

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -8,7 +8,6 @@ import Mathlib.Analysis.Complex.Basic
 import Mathlib.Analysis.Convex.Uniform
 import Mathlib.Analysis.NormedSpace.Completion
 import Mathlib.Analysis.NormedSpace.BoundedLinearMaps
-import Mathlib.LinearAlgebra.BilinearForm.Basic
 
 #align_import analysis.inner_product_space.basic from "leanprover-community/mathlib"@"3f655f5297b030a87d641ad4e825af8d9679eb0b"
 
@@ -70,6 +69,8 @@ noncomputable section
 open IsROrC Real Filter
 
 open BigOperators Topology ComplexConjugate
+
+open LinearMap (BilinForm)
 
 variable {𝕜 E F : Type*} [IsROrC 𝕜]
 
@@ -501,11 +502,19 @@ def sesqFormOfInner : E →ₗ[𝕜] E →ₗ⋆[𝕜] 𝕜 :=
 /-- The real inner product as a bilinear form. -/
 @[simps]
 def bilinFormOfRealInner : BilinForm ℝ F where
-  bilin := inner
-  bilin_add_left := inner_add_left
-  bilin_smul_left _a _x _y := inner_smul_left _ _ _
-  bilin_add_right := inner_add_right
-  bilin_smul_right _a _x _y := inner_smul_right _ _ _
+  toFun := fun x => {
+    toFun := fun y => inner x y
+    map_add' := by
+      simp only [inner_add_right, forall_const]
+    map_smul' := fun r z => by
+      simp only [inner_smul_right, RingHom.id_apply, smul_eq_mul]
+  }
+  map_add' := fun w z => by
+    simp only [inner_add_left]
+    rfl
+  map_smul' := fun r z => by
+    simp only [inner_smul_left, conj_trivial, RingHom.id_apply]
+    rfl
 #align bilin_form_of_real_inner bilinFormOfRealInner
 
 /-- An inner product with a sum on the left. -/

--- a/Mathlib/Analysis/InnerProductSpace/Orthogonal.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Orthogonal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zhouhang Zhou, Sébastien Gouëzel, Frédéric Dupuis
 -/
 import Mathlib.Analysis.InnerProductSpace.Basic
-import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
+import Mathlib.LinearAlgebra.SesquilinearForm
 
 #align_import analysis.inner_product_space.orthogonal from "leanprover-community/mathlib"@"f0c8bf9245297a541f468be517f1bde6195105e9"
 
@@ -223,7 +223,7 @@ end Submodule
 
 @[simp]
 theorem bilinFormOfRealInner_orthogonal {E} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
-    (K : Submodule ℝ E) : bilinFormOfRealInner.orthogonal K = Kᗮ :=
+    (K : Submodule ℝ E) : K.orthogonalBilin bilinFormOfRealInner = Kᗮ :=
   rfl
 #align bilin_form_of_real_inner_orthogonal bilinFormOfRealInner_orthogonal
 


### PR DESCRIPTION
Replaces `BilinForm` with `LinearMap.BilinForm` in support of #10553

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
