### PR TITLE
feat(CategoryTheory/Limits): add `Functor.mapBinaryBiconeInv`

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -640,6 +640,16 @@ def adjunction (E : C ⥤ D) [IsEquivalence E] : E ⊣ E.inv :=
   E.asEquivalence.toAdjunction
 #align category_theory.functor.adjunction CategoryTheory.Functor.adjunction
 
+@[simp]
+theorem adjunction_unit (E : C ⥤ D) [IsEquivalence E] :
+    E.adjunction.unit = E.asEquivalence.unit :=
+  rfl
+
+@[simp]
+theorem adjunction_counit (E : C ⥤ D) [IsEquivalence E] :
+    E.adjunction.counit = E.asEquivalence.counit :=
+  rfl
+
 /-- If `F` is an equivalence, it's a left adjoint. -/
 instance (priority := 10) leftAdjointOfEquivalence {F : C ⥤ D} [IsEquivalence F] : IsLeftAdjoint F
     where

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -545,6 +545,10 @@ theorem asEquivalence_inverse (F : C ⥤ D) [IsEquivalence F] : F.asEquivalence.
 #align category_theory.functor.as_equivalence_inverse CategoryTheory.Functor.asEquivalence_inverse
 
 @[simp]
+theorem inv_asEquivalence (F : C ⥤ D) [IsEquivalence F] :
+    F.inv.asEquivalence = F.asEquivalence.symm := rfl
+
+@[simp]
 theorem asEquivalence_unit {F : C ⥤ D} [IsEquivalence F] :
     F.asEquivalence.unitIso = IsEquivalence.unitIso :=
   rfl

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Biproducts.lean
@@ -76,6 +76,44 @@ def mapBinaryBicone {X Y : C} (b : BinaryBicone X Y) : BinaryBicone (F.obj X) (F
   (BinaryBicones.functoriality _ _ F).obj b
 #align category_theory.functor.map_binary_bicone CategoryTheory.Functor.mapBinaryBicone
 
+/-- An inverse to `CategoryTheory.Functor.mapBinaryBicone` -/
+@[simps]
+def mapBinaryBiconeInv [IsEquivalence F] {X Y : C} (b : BinaryBicone (F.obj X) (F.obj Y)) :
+    BinaryBicone X Y where
+  pt := F.inv.obj b.pt
+  fst := (F.inv.adjunction.homEquiv _ _).symm b.fst
+  snd := (F.inv.adjunction.homEquiv _ _).symm b.snd
+  inl := (F.adjunction.homEquiv _ _) b.inl
+  inr := (F.adjunction.homEquiv _ _) b.inr
+  inl_fst := by
+    simp only [Equivalence.symm_functor, Equivalence.symm_inverse, Adjunction.homEquiv_unit,
+      Functor.id_obj, Functor.comp_obj, Adjunction.homEquiv_counit, Category.assoc]
+    slice_lhs 2 3 => rw [← Functor.map_comp, b.inl_fst, Functor.map_id]
+    simp only [adjunction_unit, adjunction_counit, inv_asEquivalence, Category.id_comp]
+    rw [Equivalence.counit, Equivalence.unit, Equivalence.symm_counitIso]
+    simp
+  inl_snd := by
+    simp only [Equivalence.symm_functor, Equivalence.symm_inverse, Adjunction.homEquiv_unit,
+      Functor.id_obj, Functor.comp_obj, Adjunction.homEquiv_counit, Category.assoc]
+    slice_lhs 2 3 => rw [← Functor.map_comp, b.inl_snd, Functor.map_zero]
+    simp only [adjunction_unit, adjunction_counit, inv_asEquivalence, Category.id_comp]
+    rw [Equivalence.counit, Equivalence.unit, Equivalence.symm_counitIso]
+    simp
+  inr_fst := by
+    simp only [Equivalence.symm_functor, Equivalence.symm_inverse, Adjunction.homEquiv_unit,
+      Functor.id_obj, Functor.comp_obj, Adjunction.homEquiv_counit, Category.assoc]
+    slice_lhs 2 3 => rw [← Functor.map_comp, b.inr_fst, Functor.map_zero]
+    simp only [adjunction_unit, adjunction_counit, inv_asEquivalence, Category.id_comp]
+    rw [Equivalence.counit, Equivalence.unit, Equivalence.symm_counitIso]
+    simp
+  inr_snd := by
+    simp only [Equivalence.symm_functor, Equivalence.symm_inverse, Adjunction.homEquiv_unit,
+      Functor.id_obj, Functor.comp_obj, Adjunction.homEquiv_counit, Category.assoc]
+    slice_lhs 2 3 => rw [← Functor.map_comp, b.inr_snd, Functor.map_id]
+    simp only [adjunction_unit, adjunction_counit, inv_asEquivalence, Category.id_comp]
+    rw [Equivalence.counit, Equivalence.unit, Equivalence.symm_counitIso]
+    simp
+
 end Map
 
 end Functor


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->

- [ ] depends on: #11130

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

It's tempting to try to prove something like
```lean
theorem Functor.mapBinaryBiconeInv_toCone [Limits.HasZeroMorphisms C]
    [Limits.HasZeroMorphisms D]
    (e : D ⥤ C) [IsEquivalence e] {X Y : D} (b : BinaryBicone (e.obj X) (e.obj Y)) :
    (e.mapBinaryBiconeInv b).toCone =
      (e.mapConeInv <| (Cones.postcompose (pairComp X Y e).symm.hom).obj b.toCone) := by
  simp
  sorry

theorem Functor.mapBinaryBiconeInv_toCocone [Limits.HasZeroMorphisms C]
    [Limits.HasZeroMorphisms D]
    (e : D ⥤ C) [IsEquivalence e] {X Y : D} (b : BinaryBicone (e.obj X) (e.obj Y)) :
    (e.mapBinaryBiconeInv b).toCocone =
      (e.mapCoconeInv <| (Cocones.precompose (pairComp X Y e).hom).obj b.toCocone) := by
  sorry
```
but maybe equality is evil here