### PR TITLE
chore(ModelTheory): rename `BoundedFormula` to `Semiformula`

### DIFF
--- a/Mathlib/ModelTheory/Algebra/Field/Basic.lean
+++ b/Mathlib/ModelTheory/Algebra/Field/Basic.lean
@@ -31,7 +31,7 @@ namespace FirstOrder
 
 namespace Field
 
-open Language Ring Structure BoundedFormula
+open Language Ring Structure Semiformula
 
 /-- An indexing type to name each of the field axioms. The theory
 of fields is defined as the range of a function `FieldAxiom ->

--- a/Mathlib/ModelTheory/Definability.lean
+++ b/Mathlib/ModelTheory/Definability.lean
@@ -59,12 +59,12 @@ theorem Definable.map_expansion {L' : FirstOrder.Language} [L'.Structure M] (h :
 
 theorem definable_iff_exists_formula_sum :
     A.Definable L s ↔ ∃ φ : L.Formula (A ⊕ α), s = {v | φ.Realize (Sum.elim (↑) v)} := by
-  rw [Definable, Equiv.exists_congr_left (BoundedFormula.constantsVarsEquiv)]
+  rw [Definable, Equiv.exists_congr_left (Semiformula.constantsVarsEquiv)]
   refine exists_congr (fun φ => iff_iff_eq.2 (congr_arg (s = .) ?_))
   ext
-  simp only [Formula.Realize, BoundedFormula.constantsVarsEquiv, constantsOn, mk₂_Relations,
-    BoundedFormula.mapTermRelEquiv_symm_apply, mem_setOf_eq]
-  refine BoundedFormula.realize_mapTermRel_id ?_ (fun _ _ _ => rfl)
+  simp only [Formula.Realize, Semiformula.constantsVarsEquiv, constantsOn, mk₂_Relations,
+    Semiformula.mapTermRelEquiv_symm_apply, mem_setOf_eq]
+  refine Semiformula.realize_mapTermRel_id ?_ (fun _ _ _ => rfl)
   intros
   simp only [Term.constantsVarsEquivLeft_symm_apply, Term.realize_varsToConstants,
     coe_con, Term.realize_relabel]
@@ -201,10 +201,10 @@ theorem definable_iff_finitely_definable :
       · exact Sum.inl (Sum.inl ⟨a, by simpa [A0] using ha⟩)
       · exact Sum.inl (Sum.inr a)
     · ext v
-      simp only [Formula.Realize, BoundedFormula.realize_relabel,
+      simp only [Formula.Realize, Semiformula.realize_relabel,
         Set.mem_setOf_eq]
       apply Iff.symm
-      convert BoundedFormula.realize_restrictFreeVar _
+      convert Semiformula.realize_restrictFreeVar _
       · ext a
         rcases a with ⟨_ | _, _⟩ <;> simp
   · rintro ⟨A0, hA0, hd⟩
@@ -214,10 +214,10 @@ theorem definable_iff_finitely_definable :
 theorem Definable.image_comp_sum_inl_fin (m : ℕ) {s : Set (Sum α (Fin m) → M)}
     (h : A.Definable L s) : A.Definable L ((fun g : Sum α (Fin m) → M => g ∘ Sum.inl) '' s) := by
   obtain ⟨φ, rfl⟩ := h
-  refine' ⟨(BoundedFormula.relabel id φ).exs, _⟩
+  refine' ⟨(Semiformula.relabel id φ).exs, _⟩
   ext x
-  simp only [Set.mem_image, mem_setOf_eq, BoundedFormula.realize_exs,
-    BoundedFormula.realize_relabel, Function.comp_id, Fin.castAdd_zero, Fin.cast_refl]
+  simp only [Set.mem_image, mem_setOf_eq, Semiformula.realize_exs,
+    Semiformula.realize_relabel, Function.comp_id, Fin.castAdd_zero, Fin.cast_refl]
   constructor
   · rintro ⟨y, hy, rfl⟩
     exact

--- a/Mathlib/ModelTheory/ElementaryMaps.lean
+++ b/Mathlib/ModelTheory/ElementaryMaps.lean
@@ -77,14 +77,14 @@ instance : CoeFun (M ↪ₑ[L] N) fun _ => M → N :=
   DFunLike.hasCoeToFun
 
 @[simp]
-theorem map_boundedFormula (f : M ↪ₑ[L] N) {α : Type*} {n : ℕ} (φ : L.BoundedFormula α n)
+theorem map_semiformula (f : M ↪ₑ[L] N) {α : Type*} {n : ℕ} (φ : L.Semiformula α n)
     (v : α → M) (xs : Fin n → M) : φ.Realize (f ∘ v) (f ∘ xs) ↔ φ.Realize v xs := by
   classical
-    rw [← BoundedFormula.realize_restrictFreeVar Set.Subset.rfl, Set.inclusion_eq_id, iff_eq_eq]
+    rw [← Semiformula.realize_restrictFreeVar Set.Subset.rfl, Set.inclusion_eq_id, iff_eq_eq]
     have h :=
       f.map_formula' ((φ.restrictFreeVar id).toFormula.relabel (Fintype.equivFin _))
         (Sum.elim (v ∘ (↑)) xs ∘ (Fintype.equivFin _).symm)
-    simp only [Formula.realize_relabel, BoundedFormula.realize_toFormula, iff_eq_eq] at h
+    simp only [Formula.realize_relabel, Semiformula.realize_toFormula, iff_eq_eq] at h
     rw [← Function.comp.assoc _ _ (Fintype.equivFin _).symm,
       Function.comp.assoc _ (Fintype.equivFin _).symm (Fintype.equivFin _),
       _root_.Equiv.symm_comp_self, Function.comp_id, Function.comp.assoc, Sum.elim_comp_inl,
@@ -92,14 +92,14 @@ theorem map_boundedFormula (f : M ↪ₑ[L] N) {α : Type*} {n : ℕ} (φ : L.Bo
     refine' h.trans _
     erw [Function.comp.assoc _ _ (Fintype.equivFin _), _root_.Equiv.symm_comp_self,
       Function.comp_id, Sum.elim_comp_inl, Sum.elim_comp_inr (v ∘ Subtype.val) xs,
-      ← Set.inclusion_eq_id (s := (BoundedFormula.freeVarFinset φ : Set α)) Set.Subset.rfl,
-      BoundedFormula.realize_restrictFreeVar Set.Subset.rfl]
-#align first_order.language.elementary_embedding.map_bounded_formula FirstOrder.Language.ElementaryEmbedding.map_boundedFormula
+      ← Set.inclusion_eq_id (s := (Semiformula.freeVarFinset φ : Set α)) Set.Subset.rfl,
+      Semiformula.realize_restrictFreeVar Set.Subset.rfl]
+#align first_order.language.elementary_embedding.map_bounded_formula FirstOrder.Language.ElementaryEmbedding.map_semiformula
 
 @[simp]
 theorem map_formula (f : M ↪ₑ[L] N) {α : Type*} (φ : L.Formula α) (x : α → M) :
     φ.Realize (f ∘ x) ↔ φ.Realize x := by
-  rw [Formula.Realize, Formula.Realize, ← f.map_boundedFormula, Unique.eq_default (f ∘ default)]
+  rw [Formula.Realize, Formula.Realize, ← f.map_semiformula, Unique.eq_default (f ∘ default)]
 #align first_order.language.elementary_embedding.map_formula FirstOrder.Language.ElementaryEmbedding.map_formula
 
 theorem map_sentence (f : M ↪ₑ[L] N) (φ : L.Sentence) : M ⊨ φ ↔ N ⊨ φ := by
@@ -255,14 +255,14 @@ def ElementaryEmbedding.ofModelsElementaryDiagram (N : Type*) [L.Structure N] [L
     refine'
       _root_.trans _
         ((realize_iff_of_model_completeTheory M N
-              (((L.lhomWithConstants M).onBoundedFormula φ).subst
+              (((L.lhomWithConstants M).onSemiformula φ).subst
                   (Constants.term ∘ Sum.inr ∘ x)).alls).trans
           _)
-    · simp_rw [Sentence.Realize, BoundedFormula.realize_alls, BoundedFormula.realize_subst,
-        LHom.realize_onBoundedFormula, Formula.Realize, Unique.forall_iff, Function.comp,
+    · simp_rw [Sentence.Realize, Semiformula.realize_alls, Semiformula.realize_subst,
+        LHom.realize_onSemiformula, Formula.Realize, Unique.forall_iff, Function.comp,
         Term.realize_constants]
-    · simp_rw [Sentence.Realize, BoundedFormula.realize_alls, BoundedFormula.realize_subst,
-        LHom.realize_onBoundedFormula, Formula.Realize, Unique.forall_iff]
+    · simp_rw [Sentence.Realize, Semiformula.realize_alls, Semiformula.realize_subst,
+        LHom.realize_onSemiformula, Formula.Realize, Unique.forall_iff]
       rfl⟩
 #align first_order.language.elementary_embedding.of_models_elementary_diagram FirstOrder.Language.ElementaryEmbedding.ofModelsElementaryDiagram
 
@@ -273,32 +273,32 @@ namespace Embedding
 /-- The **Tarski-Vaught test** for elementarity of an embedding. -/
 theorem isElementary_of_exists (f : M ↪[L] N)
     (htv :
-      ∀ (n : ℕ) (φ : L.BoundedFormula Empty (n + 1)) (x : Fin n → M) (a : N),
+      ∀ (n : ℕ) (φ : L.Semiformula Empty (n + 1)) (x : Fin n → M) (a : N),
         φ.Realize default (Fin.snoc (f ∘ x) a : _ → N) →
           ∃ b : M, φ.Realize default (Fin.snoc (f ∘ x) (f b) : _ → N)) :
     ∀ {n} (φ : L.Formula (Fin n)) (x : Fin n → M), φ.Realize (f ∘ x) ↔ φ.Realize x := by
-  suffices h : ∀ (n : ℕ) (φ : L.BoundedFormula Empty n) (xs : Fin n → M),
+  suffices h : ∀ (n : ℕ) (φ : L.Semiformula Empty n) (xs : Fin n → M),
       φ.Realize (f ∘ default) (f ∘ xs) ↔ φ.Realize default xs by
     intro n φ x
     exact φ.realize_relabel_sum_inr.symm.trans (_root_.trans (h n _ _) φ.realize_relabel_sum_inr)
   refine' fun n φ => φ.recOn _ _ _ _ _
   · exact fun {_} _ => Iff.rfl
   · intros
-    simp [BoundedFormula.Realize, ← Sum.comp_elim, Embedding.realize_term]
+    simp [Semiformula.Realize, ← Sum.comp_elim, Embedding.realize_term]
   · intros
-    simp only [BoundedFormula.Realize, ← Sum.comp_elim, realize_term]
+    simp only [Semiformula.Realize, ← Sum.comp_elim, realize_term]
     erw [map_rel f]
   · intro _ _ _ ih1 ih2 _
     simp [ih1, ih2]
   · intro n φ ih xs
-    simp only [BoundedFormula.realize_all]
+    simp only [Semiformula.realize_all]
     refine' ⟨fun h a => _, _⟩
     · rw [← ih, Fin.comp_snoc]
       exact h (f a)
     · contrapose!
       rintro ⟨a, ha⟩
       obtain ⟨b, hb⟩ := htv n φ.not xs a (by
-          rw [BoundedFormula.realize_not, ← Unique.eq_default (f ∘ default)]
+          rw [Semiformula.realize_not, ← Unique.eq_default (f ∘ default)]
           exact ha)
       · refine' ⟨b, fun h => hb (Eq.mp _ ((ih _).2 h))⟩
         rw [Unique.eq_default (f ∘ default), Fin.comp_snoc]
@@ -308,7 +308,7 @@ theorem isElementary_of_exists (f : M ↪[L] N)
 @[simps]
 def toElementaryEmbedding (f : M ↪[L] N)
     (htv :
-      ∀ (n : ℕ) (φ : L.BoundedFormula Empty (n + 1)) (x : Fin n → M) (a : N),
+      ∀ (n : ℕ) (φ : L.Semiformula Empty (n + 1)) (x : Fin n → M) (a : N),
         φ.Realize default (Fin.snoc (f ∘ x) a : _ → N) →
           ∃ b : M, φ.Realize default (Fin.snoc (f ∘ x) (f b) : _ → N)) :
     M ↪ₑ[L] N :=

--- a/Mathlib/ModelTheory/ElementarySubstructures.lean
+++ b/Mathlib/ModelTheory/ElementarySubstructures.lean
@@ -134,7 +134,7 @@ namespace Substructure
 /-- The Tarski-Vaught test for elementarity of a substructure. -/
 theorem isElementary_of_exists (S : L.Substructure M)
     (htv :
-      ∀ (n : ℕ) (φ : L.BoundedFormula Empty (n + 1)) (x : Fin n → S) (a : M),
+      ∀ (n : ℕ) (φ : L.Semiformula Empty (n + 1)) (x : Fin n → S) (a : M),
         φ.Realize default (Fin.snoc ((↑) ∘ x) a : _ → M) →
           ∃ b : S, φ.Realize default (Fin.snoc ((↑) ∘ x) b : _ → M)) :
     S.IsElementary := fun _ => S.subtype.isElementary_of_exists htv
@@ -144,7 +144,7 @@ theorem isElementary_of_exists (S : L.Substructure M)
 @[simps]
 def toElementarySubstructure (S : L.Substructure M)
     (htv :
-      ∀ (n : ℕ) (φ : L.BoundedFormula Empty (n + 1)) (x : Fin n → S) (a : M),
+      ∀ (n : ℕ) (φ : L.Semiformula Empty (n + 1)) (x : Fin n → S) (a : M),
         φ.Realize default (Fin.snoc ((↑) ∘ x) a : _ → M) →
           ∃ b : S, φ.Realize default (Fin.snoc ((↑) ∘ x) b : _ → M)) :
     L.ElementarySubstructure M :=

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -75,12 +75,12 @@ section IsOrdered
 variable [IsOrdered L]
 
 /-- Joins two terms `t₁, t₂` in a formula representing `t₁ ≤ t₂`. -/
-def Term.le (t₁ t₂ : L.Term (Sum α (Fin n))) : L.BoundedFormula α n :=
-  leSymb.boundedFormula₂ t₁ t₂
+def Term.le (t₁ t₂ : L.Term (Sum α (Fin n))) : L.Semiformula α n :=
+  leSymb.semiformula₂ t₁ t₂
 #align first_order.language.term.le FirstOrder.Language.Term.le
 
 /-- Joins two terms `t₁, t₂` in a formula representing `t₁ < t₂`. -/
-def Term.lt (t₁ t₂ : L.Term (Sum α (Fin n))) : L.BoundedFormula α n :=
+def Term.lt (t₁ t₂ : L.Term (Sum α (Fin n))) : L.Semiformula α n :=
   t₁.le t₂ ⊓ ∼(t₂.le t₁)
 #align first_order.language.term.lt FirstOrder.Language.Term.lt
 
@@ -229,8 +229,8 @@ section LE
 variable [LE M]
 
 theorem realize_noTopOrder_iff : M ⊨ Language.order.noTopOrderSentence ↔ NoTopOrder M := by
-  simp only [noTopOrderSentence, Sentence.Realize, Formula.Realize, BoundedFormula.realize_all,
-    BoundedFormula.realize_ex, BoundedFormula.realize_not, Term.realize, Term.realize_le,
+  simp only [noTopOrderSentence, Sentence.Realize, Formula.Realize, Semiformula.realize_all,
+    Semiformula.realize_ex, Semiformula.realize_not, Term.realize, Term.realize_le,
     Sum.elim_inr]
   refine' ⟨fun h => ⟨fun a => h a⟩, _⟩
   intro h a
@@ -243,8 +243,8 @@ theorem realize_noTopOrder [h : NoTopOrder M] : M ⊨ Language.order.noTopOrderS
 #align first_order.language.realize_no_top_order FirstOrder.Language.realize_noTopOrder
 
 theorem realize_noBotOrder_iff : M ⊨ Language.order.noBotOrderSentence ↔ NoBotOrder M := by
-  simp only [noBotOrderSentence, Sentence.Realize, Formula.Realize, BoundedFormula.realize_all,
-    BoundedFormula.realize_ex, BoundedFormula.realize_not, Term.realize, Term.realize_le,
+  simp only [noBotOrderSentence, Sentence.Realize, Formula.Realize, Semiformula.realize_all,
+    Semiformula.realize_ex, Semiformula.realize_not, Term.realize, Term.realize_le,
     Sum.elim_inr]
   refine' ⟨fun h => ⟨fun a => h a⟩, _⟩
   intro h a
@@ -261,8 +261,8 @@ end LE
 theorem realize_denselyOrdered_iff [Preorder M] :
     M ⊨ Language.order.denselyOrderedSentence ↔ DenselyOrdered M := by
   simp only [denselyOrderedSentence, Sentence.Realize, Formula.Realize,
-    BoundedFormula.realize_imp, BoundedFormula.realize_all, Term.realize, Term.realize_lt,
-    Sum.elim_inr, BoundedFormula.realize_ex, BoundedFormula.realize_inf]
+    Semiformula.realize_imp, Semiformula.realize_all, Term.realize, Term.realize_lt,
+    Sum.elim_inr, Semiformula.realize_ex, Semiformula.realize_inf]
   refine' ⟨fun h => ⟨fun a b ab => h a b ab⟩, _⟩
   intro h a b ab
   exact exists_between ab

--- a/Mathlib/ModelTheory/Satisfiability.lean
+++ b/Mathlib/ModelTheory/Satisfiability.lean
@@ -299,14 +299,14 @@ variable (T)
 
 /-- A theory models a (bounded) formula when any of its nonempty models realizes that formula on all
   inputs.-/
-def ModelsBoundedFormula (φ : L.BoundedFormula α n) : Prop :=
+def ModelsSemiformula (φ : L.Semiformula α n) : Prop :=
   ∀ (M : ModelType.{u, v, max u v} T) (v : α → M) (xs : Fin n → M), φ.Realize v xs
-#align first_order.language.Theory.models_bounded_formula FirstOrder.Language.Theory.ModelsBoundedFormula
+#align first_order.language.Theory.models_bounded_formula FirstOrder.Language.Theory.ModelsSemiformula
 
 -- Porting note: In Lean3 it was `⊨` but ambiguous.
 -- mathport name: models_bounded_formula
-@[inherit_doc FirstOrder.Language.Theory.ModelsBoundedFormula]
-infixl:51 " ⊨ᵇ " => ModelsBoundedFormula -- input using \|= or \vDash, but not using \models
+@[inherit_doc FirstOrder.Language.Theory.ModelsSemiformula]
+infixl:51 " ⊨ᵇ " => ModelsSemiformula -- input using \|= or \vDash, but not using \models
 
 variable {T}
 
@@ -341,7 +341,7 @@ theorem models_iff_not_satisfiable (φ : L.Sentence) : T ⊨ᵇ φ ↔ ¬IsSatis
   exact h
 #align first_order.language.Theory.models_iff_not_satisfiable FirstOrder.Language.Theory.models_iff_not_satisfiable
 
-theorem ModelsBoundedFormula.realize_sentence {φ : L.Sentence} (h : T ⊨ᵇ φ) (M : Type*)
+theorem ModelsSemiformula.realize_sentence {φ : L.Sentence} (h : T ⊨ᵇ φ) (M : Type*)
     [L.Structure M] [M ⊨ T] [Nonempty M] : M ⊨ φ := by
   rw [models_iff_not_satisfiable] at h
   contrapose! h
@@ -351,7 +351,7 @@ theorem ModelsBoundedFormula.realize_sentence {φ : L.Sentence} (h : T ⊨ᵇ φ
     rw [← model_iff]
     exact ⟨h, inferInstance⟩
   exact Model.isSatisfiable M
-#align first_order.language.Theory.models_bounded_formula.realize_sentence FirstOrder.Language.Theory.ModelsBoundedFormula.realize_sentence
+#align first_order.language.Theory.models_bounded_formula.realize_sentence FirstOrder.Language.Theory.ModelsSemiformula.realize_sentence
 
 theorem models_of_models_theory {T' : L.Theory}
     (h : ∀ φ : L.Sentence, φ ∈ T' → T ⊨ᵇ φ)
@@ -438,39 +438,39 @@ theorem IsMaximal.mem_iff_models (h : T.IsMaximal) (φ : L.Sentence) : φ ∈ T 
 /-- Two (bounded) formulas are semantically equivalent over a theory `T` when they have the same
 interpretation in every model of `T`. (This is also known as logical equivalence, which also has a
 proof-theoretic definition.) -/
-def SemanticallyEquivalent (T : L.Theory) (φ ψ : L.BoundedFormula α n) : Prop :=
+def SemanticallyEquivalent (T : L.Theory) (φ ψ : L.Semiformula α n) : Prop :=
   T ⊨ᵇ φ.iff ψ
 #align first_order.language.Theory.semantically_equivalent FirstOrder.Language.Theory.SemanticallyEquivalent
 
 @[refl]
-theorem SemanticallyEquivalent.refl (φ : L.BoundedFormula α n) : T.SemanticallyEquivalent φ φ :=
-  fun M v xs => by rw [BoundedFormula.realize_iff]
+theorem SemanticallyEquivalent.refl (φ : L.Semiformula α n) : T.SemanticallyEquivalent φ φ :=
+  fun M v xs => by rw [Semiformula.realize_iff]
 #align first_order.language.Theory.semantically_equivalent.refl FirstOrder.Language.Theory.SemanticallyEquivalent.refl
 
-instance : IsRefl (L.BoundedFormula α n) T.SemanticallyEquivalent :=
+instance : IsRefl (L.Semiformula α n) T.SemanticallyEquivalent :=
   ⟨SemanticallyEquivalent.refl⟩
 
 @[symm]
-theorem SemanticallyEquivalent.symm {φ ψ : L.BoundedFormula α n}
+theorem SemanticallyEquivalent.symm {φ ψ : L.Semiformula α n}
     (h : T.SemanticallyEquivalent φ ψ) : T.SemanticallyEquivalent ψ φ := fun M v xs => by
-  rw [BoundedFormula.realize_iff, Iff.comm, ← BoundedFormula.realize_iff]
+  rw [Semiformula.realize_iff, Iff.comm, ← Semiformula.realize_iff]
   exact h M v xs
 #align first_order.language.Theory.semantically_equivalent.symm FirstOrder.Language.Theory.SemanticallyEquivalent.symm
 
 @[trans]
-theorem SemanticallyEquivalent.trans {φ ψ θ : L.BoundedFormula α n}
+theorem SemanticallyEquivalent.trans {φ ψ θ : L.Semiformula α n}
     (h1 : T.SemanticallyEquivalent φ ψ) (h2 : T.SemanticallyEquivalent ψ θ) :
     T.SemanticallyEquivalent φ θ := fun M v xs => by
   have h1' := h1 M v xs
   have h2' := h2 M v xs
-  rw [BoundedFormula.realize_iff] at *
+  rw [Semiformula.realize_iff] at *
   exact ⟨h2'.1 ∘ h1'.1, h1'.2 ∘ h2'.2⟩
 #align first_order.language.Theory.semantically_equivalent.trans FirstOrder.Language.Theory.SemanticallyEquivalent.trans
 
-theorem SemanticallyEquivalent.realize_bd_iff {φ ψ : L.BoundedFormula α n} {M : Type max u v}
+theorem SemanticallyEquivalent.realize_bd_iff {φ ψ : L.Semiformula α n} {M : Type max u v}
     [Nonempty M] [L.Structure M] [T.Model M] (h : T.SemanticallyEquivalent φ ψ)
     {v : α → M} {xs : Fin n → M} : φ.Realize v xs ↔ ψ.Realize v xs :=
-  BoundedFormula.realize_iff.1 (h (ModelType.of T M) v xs)
+  Semiformula.realize_iff.1 (h (ModelType.of T M) v xs)
 #align first_order.language.Theory.semantically_equivalent.realize_bd_iff FirstOrder.Language.Theory.SemanticallyEquivalent.realize_bd_iff
 
 theorem SemanticallyEquivalent.realize_iff {φ ψ : L.Formula α} {M : Type max u v} [Nonempty M]
@@ -480,37 +480,37 @@ theorem SemanticallyEquivalent.realize_iff {φ ψ : L.Formula α} {M : Type max 
 #align first_order.language.Theory.semantically_equivalent.realize_iff FirstOrder.Language.Theory.SemanticallyEquivalent.realize_iff
 
 /-- Semantic equivalence forms an equivalence relation on formulas. -/
-def semanticallyEquivalentSetoid (T : L.Theory) : Setoid (L.BoundedFormula α n) where
+def semanticallyEquivalentSetoid (T : L.Theory) : Setoid (L.Semiformula α n) where
   r := SemanticallyEquivalent T
   iseqv := ⟨fun _ => refl _, fun {_ _} h => h.symm, fun {_ _ _} h1 h2 => h1.trans h2⟩
 #align first_order.language.Theory.semantically_equivalent_setoid FirstOrder.Language.Theory.semanticallyEquivalentSetoid
 
-protected theorem SemanticallyEquivalent.all {φ ψ : L.BoundedFormula α (n + 1)}
+protected theorem SemanticallyEquivalent.all {φ ψ : L.Semiformula α (n + 1)}
     (h : T.SemanticallyEquivalent φ ψ) : T.SemanticallyEquivalent φ.all ψ.all := by
-  simp_rw [SemanticallyEquivalent, ModelsBoundedFormula, BoundedFormula.realize_iff,
-    BoundedFormula.realize_all]
+  simp_rw [SemanticallyEquivalent, ModelsSemiformula, Semiformula.realize_iff,
+    Semiformula.realize_all]
   exact fun M v xs => forall_congr' fun a => h.realize_bd_iff
 #align first_order.language.Theory.semantically_equivalent.all FirstOrder.Language.Theory.SemanticallyEquivalent.all
 
-protected theorem SemanticallyEquivalent.ex {φ ψ : L.BoundedFormula α (n + 1)}
+protected theorem SemanticallyEquivalent.ex {φ ψ : L.Semiformula α (n + 1)}
     (h : T.SemanticallyEquivalent φ ψ) : T.SemanticallyEquivalent φ.ex ψ.ex := by
-  simp_rw [SemanticallyEquivalent, ModelsBoundedFormula, BoundedFormula.realize_iff,
-    BoundedFormula.realize_ex]
+  simp_rw [SemanticallyEquivalent, ModelsSemiformula, Semiformula.realize_iff,
+    Semiformula.realize_ex]
   exact fun M v xs => exists_congr fun a => h.realize_bd_iff
 #align first_order.language.Theory.semantically_equivalent.ex FirstOrder.Language.Theory.SemanticallyEquivalent.ex
 
-protected theorem SemanticallyEquivalent.not {φ ψ : L.BoundedFormula α n}
+protected theorem SemanticallyEquivalent.not {φ ψ : L.Semiformula α n}
     (h : T.SemanticallyEquivalent φ ψ) : T.SemanticallyEquivalent φ.not ψ.not := by
-  simp_rw [SemanticallyEquivalent, ModelsBoundedFormula, BoundedFormula.realize_iff,
-    BoundedFormula.realize_not]
+  simp_rw [SemanticallyEquivalent, ModelsSemiformula, Semiformula.realize_iff,
+    Semiformula.realize_not]
   exact fun M v xs => not_congr h.realize_bd_iff
 #align first_order.language.Theory.semantically_equivalent.not FirstOrder.Language.Theory.SemanticallyEquivalent.not
 
-protected theorem SemanticallyEquivalent.imp {φ ψ φ' ψ' : L.BoundedFormula α n}
+protected theorem SemanticallyEquivalent.imp {φ ψ φ' ψ' : L.Semiformula α n}
     (h : T.SemanticallyEquivalent φ ψ) (h' : T.SemanticallyEquivalent φ' ψ') :
     T.SemanticallyEquivalent (φ.imp φ') (ψ.imp ψ') := by
-  simp_rw [SemanticallyEquivalent, ModelsBoundedFormula, BoundedFormula.realize_iff,
-    BoundedFormula.realize_imp]
+  simp_rw [SemanticallyEquivalent, ModelsSemiformula, Semiformula.realize_iff,
+    Semiformula.realize_imp]
   exact fun M v xs => imp_congr h.realize_bd_iff h'.realize_bd_iff
 #align first_order.language.Theory.semantically_equivalent.imp FirstOrder.Language.Theory.SemanticallyEquivalent.imp
 
@@ -539,127 +539,127 @@ theorem isComplete [Nonempty M] : (L.completeTheory M).IsComplete :=
 
 end completeTheory
 
-namespace BoundedFormula
+namespace Semiformula
 
-variable (φ ψ : L.BoundedFormula α n)
+variable (φ ψ : L.Semiformula α n)
 
 theorem semanticallyEquivalent_not_not : T.SemanticallyEquivalent φ φ.not.not := fun M v xs => by
   simp
-#align first_order.language.bounded_formula.semantically_equivalent_not_not FirstOrder.Language.BoundedFormula.semanticallyEquivalent_not_not
+#align first_order.language.bounded_formula.semantically_equivalent_not_not FirstOrder.Language.Semiformula.semanticallyEquivalent_not_not
 
 theorem imp_semanticallyEquivalent_not_sup : T.SemanticallyEquivalent (φ.imp ψ) (φ.not ⊔ ψ) :=
   fun M v xs => by simp [imp_iff_not_or]
-#align first_order.language.bounded_formula.imp_semantically_equivalent_not_sup FirstOrder.Language.BoundedFormula.imp_semanticallyEquivalent_not_sup
+#align first_order.language.bounded_formula.imp_semantically_equivalent_not_sup FirstOrder.Language.Semiformula.imp_semanticallyEquivalent_not_sup
 
 theorem sup_semanticallyEquivalent_not_inf_not :
     T.SemanticallyEquivalent (φ ⊔ ψ) (φ.not ⊓ ψ.not).not := fun M v xs => by simp [imp_iff_not_or]
-#align first_order.language.bounded_formula.sup_semantically_equivalent_not_inf_not FirstOrder.Language.BoundedFormula.sup_semanticallyEquivalent_not_inf_not
+#align first_order.language.bounded_formula.sup_semantically_equivalent_not_inf_not FirstOrder.Language.Semiformula.sup_semanticallyEquivalent_not_inf_not
 
 theorem inf_semanticallyEquivalent_not_sup_not :
     T.SemanticallyEquivalent (φ ⊓ ψ) (φ.not ⊔ ψ.not).not := fun M v xs => by
   simp [and_iff_not_or_not]
-#align first_order.language.bounded_formula.inf_semantically_equivalent_not_sup_not FirstOrder.Language.BoundedFormula.inf_semanticallyEquivalent_not_sup_not
+#align first_order.language.bounded_formula.inf_semantically_equivalent_not_sup_not FirstOrder.Language.Semiformula.inf_semanticallyEquivalent_not_sup_not
 
-theorem all_semanticallyEquivalent_not_ex_not (φ : L.BoundedFormula α (n + 1)) :
+theorem all_semanticallyEquivalent_not_ex_not (φ : L.Semiformula α (n + 1)) :
     T.SemanticallyEquivalent φ.all φ.not.ex.not := fun M v xs => by simp
-#align first_order.language.bounded_formula.all_semantically_equivalent_not_ex_not FirstOrder.Language.BoundedFormula.all_semanticallyEquivalent_not_ex_not
+#align first_order.language.bounded_formula.all_semantically_equivalent_not_ex_not FirstOrder.Language.Semiformula.all_semanticallyEquivalent_not_ex_not
 
-theorem ex_semanticallyEquivalent_not_all_not (φ : L.BoundedFormula α (n + 1)) :
+theorem ex_semanticallyEquivalent_not_all_not (φ : L.Semiformula α (n + 1)) :
     T.SemanticallyEquivalent φ.ex φ.not.all.not := fun M v xs => by simp
-#align first_order.language.bounded_formula.ex_semantically_equivalent_not_all_not FirstOrder.Language.BoundedFormula.ex_semanticallyEquivalent_not_all_not
+#align first_order.language.bounded_formula.ex_semantically_equivalent_not_all_not FirstOrder.Language.Semiformula.ex_semanticallyEquivalent_not_all_not
 
 theorem semanticallyEquivalent_all_liftAt : T.SemanticallyEquivalent φ (φ.liftAt 1 n).all :=
   fun M v xs => by
   skip
   rw [realize_iff, realize_all_liftAt_one_self]
-#align first_order.language.bounded_formula.semantically_equivalent_all_lift_at FirstOrder.Language.BoundedFormula.semanticallyEquivalent_all_liftAt
+#align first_order.language.bounded_formula.semantically_equivalent_all_lift_at FirstOrder.Language.Semiformula.semanticallyEquivalent_all_liftAt
 
-end BoundedFormula
+end Semiformula
 
 namespace Formula
 
 variable (φ ψ : L.Formula α)
 
 theorem semanticallyEquivalent_not_not : T.SemanticallyEquivalent φ φ.not.not :=
-  BoundedFormula.semanticallyEquivalent_not_not φ
+  Semiformula.semanticallyEquivalent_not_not φ
 #align first_order.language.formula.semantically_equivalent_not_not FirstOrder.Language.Formula.semanticallyEquivalent_not_not
 
 theorem imp_semanticallyEquivalent_not_sup : T.SemanticallyEquivalent (φ.imp ψ) (φ.not ⊔ ψ) :=
-  BoundedFormula.imp_semanticallyEquivalent_not_sup φ ψ
+  Semiformula.imp_semanticallyEquivalent_not_sup φ ψ
 #align first_order.language.formula.imp_semantically_equivalent_not_sup FirstOrder.Language.Formula.imp_semanticallyEquivalent_not_sup
 
 theorem sup_semanticallyEquivalent_not_inf_not :
     T.SemanticallyEquivalent (φ ⊔ ψ) (φ.not ⊓ ψ.not).not :=
-  BoundedFormula.sup_semanticallyEquivalent_not_inf_not φ ψ
+  Semiformula.sup_semanticallyEquivalent_not_inf_not φ ψ
 #align first_order.language.formula.sup_semantically_equivalent_not_inf_not FirstOrder.Language.Formula.sup_semanticallyEquivalent_not_inf_not
 
 theorem inf_semanticallyEquivalent_not_sup_not :
     T.SemanticallyEquivalent (φ ⊓ ψ) (φ.not ⊔ ψ.not).not :=
-  BoundedFormula.inf_semanticallyEquivalent_not_sup_not φ ψ
+  Semiformula.inf_semanticallyEquivalent_not_sup_not φ ψ
 #align first_order.language.formula.inf_semantically_equivalent_not_sup_not FirstOrder.Language.Formula.inf_semanticallyEquivalent_not_sup_not
 
 end Formula
 
-namespace BoundedFormula
+namespace Semiformula
 
-theorem IsQF.induction_on_sup_not {P : L.BoundedFormula α n → Prop} {φ : L.BoundedFormula α n}
-    (h : IsQF φ) (hf : P (⊥ : L.BoundedFormula α n))
-    (ha : ∀ ψ : L.BoundedFormula α n, IsAtomic ψ → P ψ)
+theorem IsQF.induction_on_sup_not {P : L.Semiformula α n → Prop} {φ : L.Semiformula α n}
+    (h : IsQF φ) (hf : P (⊥ : L.Semiformula α n))
+    (ha : ∀ ψ : L.Semiformula α n, IsAtomic ψ → P ψ)
     (hsup : ∀ {φ₁ φ₂}, P φ₁ → P φ₂ → P (φ₁ ⊔ φ₂)) (hnot : ∀ {φ}, P φ → P φ.not)
     (hse :
-      ∀ {φ₁ φ₂ : L.BoundedFormula α n}, Theory.SemanticallyEquivalent ∅ φ₁ φ₂ → (P φ₁ ↔ P φ₂)) :
+      ∀ {φ₁ φ₂ : L.Semiformula α n}, Theory.SemanticallyEquivalent ∅ φ₁ φ₂ → (P φ₁ ↔ P φ₂)) :
     P φ :=
   IsQF.recOn h hf @(ha) fun {φ₁ φ₂} _ _ h1 h2 =>
     (hse (φ₁.imp_semanticallyEquivalent_not_sup φ₂)).2 (hsup (hnot h1) h2)
-#align first_order.language.bounded_formula.is_qf.induction_on_sup_not FirstOrder.Language.BoundedFormula.IsQF.induction_on_sup_not
+#align first_order.language.bounded_formula.is_qf.induction_on_sup_not FirstOrder.Language.Semiformula.IsQF.induction_on_sup_not
 
-theorem IsQF.induction_on_inf_not {P : L.BoundedFormula α n → Prop} {φ : L.BoundedFormula α n}
-    (h : IsQF φ) (hf : P (⊥ : L.BoundedFormula α n))
-    (ha : ∀ ψ : L.BoundedFormula α n, IsAtomic ψ → P ψ)
+theorem IsQF.induction_on_inf_not {P : L.Semiformula α n → Prop} {φ : L.Semiformula α n}
+    (h : IsQF φ) (hf : P (⊥ : L.Semiformula α n))
+    (ha : ∀ ψ : L.Semiformula α n, IsAtomic ψ → P ψ)
     (hinf : ∀ {φ₁ φ₂}, P φ₁ → P φ₂ → P (φ₁ ⊓ φ₂)) (hnot : ∀ {φ}, P φ → P φ.not)
     (hse :
-      ∀ {φ₁ φ₂ : L.BoundedFormula α n}, Theory.SemanticallyEquivalent ∅ φ₁ φ₂ → (P φ₁ ↔ P φ₂)) :
+      ∀ {φ₁ φ₂ : L.Semiformula α n}, Theory.SemanticallyEquivalent ∅ φ₁ φ₂ → (P φ₁ ↔ P φ₂)) :
     P φ :=
   h.induction_on_sup_not hf ha
     (fun {φ₁ φ₂} h1 h2 =>
       (hse (φ₁.sup_semanticallyEquivalent_not_inf_not φ₂)).2 (hnot (hinf (hnot h1) (hnot h2))))
     (fun {_} => hnot) fun {_ _} => hse
-#align first_order.language.bounded_formula.is_qf.induction_on_inf_not FirstOrder.Language.BoundedFormula.IsQF.induction_on_inf_not
+#align first_order.language.bounded_formula.is_qf.induction_on_inf_not FirstOrder.Language.Semiformula.IsQF.induction_on_inf_not
 
-theorem semanticallyEquivalent_toPrenex (φ : L.BoundedFormula α n) :
+theorem semanticallyEquivalent_toPrenex (φ : L.Semiformula α n) :
     (∅ : L.Theory).SemanticallyEquivalent φ φ.toPrenex := fun M v xs => by
   rw [realize_iff, realize_toPrenex]
-#align first_order.language.bounded_formula.semantically_equivalent_to_prenex FirstOrder.Language.BoundedFormula.semanticallyEquivalent_toPrenex
+#align first_order.language.bounded_formula.semantically_equivalent_to_prenex FirstOrder.Language.Semiformula.semanticallyEquivalent_toPrenex
 
-theorem induction_on_all_ex {P : ∀ {m}, L.BoundedFormula α m → Prop} (φ : L.BoundedFormula α n)
-    (hqf : ∀ {m} {ψ : L.BoundedFormula α m}, IsQF ψ → P ψ)
-    (hall : ∀ {m} {ψ : L.BoundedFormula α (m + 1)}, P ψ → P ψ.all)
-    (hex : ∀ {m} {φ : L.BoundedFormula α (m + 1)}, P φ → P φ.ex)
-    (hse : ∀ {m} {φ₁ φ₂ : L.BoundedFormula α m},
+theorem induction_on_all_ex {P : ∀ {m}, L.Semiformula α m → Prop} (φ : L.Semiformula α n)
+    (hqf : ∀ {m} {ψ : L.Semiformula α m}, IsQF ψ → P ψ)
+    (hall : ∀ {m} {ψ : L.Semiformula α (m + 1)}, P ψ → P ψ.all)
+    (hex : ∀ {m} {φ : L.Semiformula α (m + 1)}, P φ → P φ.ex)
+    (hse : ∀ {m} {φ₁ φ₂ : L.Semiformula α m},
       Theory.SemanticallyEquivalent ∅ φ₁ φ₂ → (P φ₁ ↔ P φ₂)) :
     P φ := by
-  suffices h' : ∀ {m} {φ : L.BoundedFormula α m}, φ.IsPrenex → P φ from
+  suffices h' : ∀ {m} {φ : L.Semiformula α m}, φ.IsPrenex → P φ from
     (hse φ.semanticallyEquivalent_toPrenex).2 (h' φ.toPrenex_isPrenex)
   intro m φ hφ
   induction' hφ with _ _ hφ _ _ _ hφ _ _ _ hφ
   · exact hqf hφ
   · exact hall hφ
   · exact hex hφ
-#align first_order.language.bounded_formula.induction_on_all_ex FirstOrder.Language.BoundedFormula.induction_on_all_ex
+#align first_order.language.bounded_formula.induction_on_all_ex FirstOrder.Language.Semiformula.induction_on_all_ex
 
-theorem induction_on_exists_not {P : ∀ {m}, L.BoundedFormula α m → Prop} (φ : L.BoundedFormula α n)
-    (hqf : ∀ {m} {ψ : L.BoundedFormula α m}, IsQF ψ → P ψ)
-    (hnot : ∀ {m} {φ : L.BoundedFormula α m}, P φ → P φ.not)
-    (hex : ∀ {m} {φ : L.BoundedFormula α (m + 1)}, P φ → P φ.ex)
-    (hse : ∀ {m} {φ₁ φ₂ : L.BoundedFormula α m},
+theorem induction_on_exists_not {P : ∀ {m}, L.Semiformula α m → Prop} (φ : L.Semiformula α n)
+    (hqf : ∀ {m} {ψ : L.Semiformula α m}, IsQF ψ → P ψ)
+    (hnot : ∀ {m} {φ : L.Semiformula α m}, P φ → P φ.not)
+    (hex : ∀ {m} {φ : L.Semiformula α (m + 1)}, P φ → P φ.ex)
+    (hse : ∀ {m} {φ₁ φ₂ : L.Semiformula α m},
       Theory.SemanticallyEquivalent ∅ φ₁ φ₂ → (P φ₁ ↔ P φ₂)) :
     P φ :=
   φ.induction_on_all_ex (fun {_ _} => hqf)
     (fun {_ φ} hφ => (hse φ.all_semanticallyEquivalent_not_ex_not).2 (hnot (hex (hnot hφ))))
     (fun {_ _} => hex) fun {_ _ _} => hse
-#align first_order.language.bounded_formula.induction_on_exists_not FirstOrder.Language.BoundedFormula.induction_on_exists_not
+#align first_order.language.bounded_formula.induction_on_exists_not FirstOrder.Language.Semiformula.induction_on_exists_not
 
-end BoundedFormula
+end Semiformula
 
 end Language
 

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -17,7 +17,7 @@ in a style inspired by the [Flypitch project](https://flypitch.github.io/).
 ## Main Definitions
 * `FirstOrder.Language.Term.realize` is defined so that `t.realize v` is the term `t` evaluated at
 variables `v`.
-* `FirstOrder.Language.BoundedFormula.Realize` is defined so that `φ.Realize v xs` is the bounded
+* `FirstOrder.Language.Semiformula.Realize` is defined so that `φ.Realize v xs` is the bounded
 formula `φ` evaluated at tuples of variables `v` and `xs`.
 * `FirstOrder.Language.Formula.Realize` is defined so that `φ.Realize v` is the formula `φ`
 evaluated at variables `v`.
@@ -27,17 +27,17 @@ evaluated in the structure `M`. Also denoted `M ⊨ φ`.
 sentence of `T` is realized in `M`. Also denoted `T ⊨ φ`.
 
 ## Main Results
-* `FirstOrder.Language.BoundedFormula.realize_toPrenex` shows that the prenex normal form of a
+* `FirstOrder.Language.Semiformula.realize_toPrenex` shows that the prenex normal form of a
 formula has the same realization as the original formula.
 * Several results in this file show that syntactic constructions such as `relabel`, `castLE`,
 `liftAt`, `subst`, and the actions of language maps commute with realization of terms, formulas,
 sentences, and theories.
 
 ## Implementation Notes
-* Formulas use a modified version of de Bruijn variables. Specifically, a `L.BoundedFormula α n`
+* Formulas use a modified version of de Bruijn variables. Specifically, a `L.Semiformula α n`
 is a formula with some variables indexed by a type `α`, which cannot be quantified over, and some
-indexed by `Fin n`, which can. For any `φ : L.BoundedFormula α (n + 1)`, we define the formula
-`∀' φ : L.BoundedFormula α n` by universally quantifying over the variable indexed by
+indexed by `Fin n`, which can. For any `φ : L.Semiformula α (n + 1)`, we define the formula
+`∀' φ : L.Semiformula α n` by universally quantifying over the variable indexed by
 `n : Fin (n + 1)`.
 
 ## References
@@ -242,126 +242,126 @@ theorem Equiv.realize_term {v : α → M} (t : L.Term α) (g : M ≃[L] N) :
 
 variable {n : ℕ}
 
-namespace BoundedFormula
+namespace Semiformula
 
 open Term
 
 -- Porting note: universes in different order
 /-- A bounded formula can be evaluated as true or false by giving values to each free variable. -/
-def Realize : ∀ {l} (_f : L.BoundedFormula α l) (_v : α → M) (_xs : Fin l → M), Prop
+def Realize : ∀ {l} (_f : L.Semiformula α l) (_v : α → M) (_xs : Fin l → M), Prop
   | _, falsum, _v, _xs => False
   | _, equal t₁ t₂, v, xs => t₁.realize (Sum.elim v xs) = t₂.realize (Sum.elim v xs)
   | _, rel R ts, v, xs => RelMap R fun i => (ts i).realize (Sum.elim v xs)
   | _, imp f₁ f₂, v, xs => Realize f₁ v xs → Realize f₂ v xs
   | _, all f, v, xs => ∀ x : M, Realize f v (snoc xs x)
-#align first_order.language.bounded_formula.realize FirstOrder.Language.BoundedFormula.Realize
+#align first_order.language.bounded_formula.realize FirstOrder.Language.Semiformula.Realize
 
-variable {l : ℕ} {φ ψ : L.BoundedFormula α l} {θ : L.BoundedFormula α l.succ}
+variable {l : ℕ} {φ ψ : L.Semiformula α l} {θ : L.Semiformula α l.succ}
 
 variable {v : α → M} {xs : Fin l → M}
 
 @[simp]
-theorem realize_bot : (⊥ : L.BoundedFormula α l).Realize v xs ↔ False :=
+theorem realize_bot : (⊥ : L.Semiformula α l).Realize v xs ↔ False :=
   Iff.rfl
-#align first_order.language.bounded_formula.realize_bot FirstOrder.Language.BoundedFormula.realize_bot
+#align first_order.language.bounded_formula.realize_bot FirstOrder.Language.Semiformula.realize_bot
 
 @[simp]
 theorem realize_not : φ.not.Realize v xs ↔ ¬φ.Realize v xs :=
   Iff.rfl
-#align first_order.language.bounded_formula.realize_not FirstOrder.Language.BoundedFormula.realize_not
+#align first_order.language.bounded_formula.realize_not FirstOrder.Language.Semiformula.realize_not
 
 @[simp]
 theorem realize_bdEqual (t₁ t₂ : L.Term (Sum α (Fin l))) :
     (t₁.bdEqual t₂).Realize v xs ↔ t₁.realize (Sum.elim v xs) = t₂.realize (Sum.elim v xs) :=
   Iff.rfl
-#align first_order.language.bounded_formula.realize_bd_equal FirstOrder.Language.BoundedFormula.realize_bdEqual
+#align first_order.language.bounded_formula.realize_bd_equal FirstOrder.Language.Semiformula.realize_bdEqual
 
 @[simp]
-theorem realize_top : (⊤ : L.BoundedFormula α l).Realize v xs ↔ True := by simp [Top.top]
-#align first_order.language.bounded_formula.realize_top FirstOrder.Language.BoundedFormula.realize_top
+theorem realize_top : (⊤ : L.Semiformula α l).Realize v xs ↔ True := by simp [Top.top]
+#align first_order.language.bounded_formula.realize_top FirstOrder.Language.Semiformula.realize_top
 
 @[simp]
 theorem realize_inf : (φ ⊓ ψ).Realize v xs ↔ φ.Realize v xs ∧ ψ.Realize v xs := by
   simp [Inf.inf, Realize]
-#align first_order.language.bounded_formula.realize_inf FirstOrder.Language.BoundedFormula.realize_inf
+#align first_order.language.bounded_formula.realize_inf FirstOrder.Language.Semiformula.realize_inf
 
 @[simp]
-theorem realize_foldr_inf (l : List (L.BoundedFormula α n)) (v : α → M) (xs : Fin n → M) :
-    (l.foldr (· ⊓ ·) ⊤).Realize v xs ↔ ∀ φ ∈ l, BoundedFormula.Realize φ v xs := by
+theorem realize_foldr_inf (l : List (L.Semiformula α n)) (v : α → M) (xs : Fin n → M) :
+    (l.foldr (· ⊓ ·) ⊤).Realize v xs ↔ ∀ φ ∈ l, Semiformula.Realize φ v xs := by
   induction' l with φ l ih
   · simp
   · simp [ih]
-#align first_order.language.bounded_formula.realize_foldr_inf FirstOrder.Language.BoundedFormula.realize_foldr_inf
+#align first_order.language.bounded_formula.realize_foldr_inf FirstOrder.Language.Semiformula.realize_foldr_inf
 
 @[simp]
 theorem realize_imp : (φ.imp ψ).Realize v xs ↔ φ.Realize v xs → ψ.Realize v xs := by
   simp only [Realize]
-#align first_order.language.bounded_formula.realize_imp FirstOrder.Language.BoundedFormula.realize_imp
+#align first_order.language.bounded_formula.realize_imp FirstOrder.Language.Semiformula.realize_imp
 
 @[simp]
 theorem realize_rel {k : ℕ} {R : L.Relations k} {ts : Fin k → L.Term _} :
-    (R.boundedFormula ts).Realize v xs ↔ RelMap R fun i => (ts i).realize (Sum.elim v xs) :=
+    (R.semiformula ts).Realize v xs ↔ RelMap R fun i => (ts i).realize (Sum.elim v xs) :=
   Iff.rfl
-#align first_order.language.bounded_formula.realize_rel FirstOrder.Language.BoundedFormula.realize_rel
+#align first_order.language.bounded_formula.realize_rel FirstOrder.Language.Semiformula.realize_rel
 
 @[simp]
 theorem realize_rel₁ {R : L.Relations 1} {t : L.Term _} :
-    (R.boundedFormula₁ t).Realize v xs ↔ RelMap R ![t.realize (Sum.elim v xs)] := by
-  rw [Relations.boundedFormula₁, realize_rel, iff_eq_eq]
+    (R.semiformula₁ t).Realize v xs ↔ RelMap R ![t.realize (Sum.elim v xs)] := by
+  rw [Relations.semiformula₁, realize_rel, iff_eq_eq]
   refine' congr rfl (funext fun _ => _)
   simp only [Matrix.cons_val_fin_one]
-#align first_order.language.bounded_formula.realize_rel₁ FirstOrder.Language.BoundedFormula.realize_rel₁
+#align first_order.language.bounded_formula.realize_rel₁ FirstOrder.Language.Semiformula.realize_rel₁
 
 @[simp]
 theorem realize_rel₂ {R : L.Relations 2} {t₁ t₂ : L.Term _} :
-    (R.boundedFormula₂ t₁ t₂).Realize v xs ↔
+    (R.semiformula₂ t₁ t₂).Realize v xs ↔
       RelMap R ![t₁.realize (Sum.elim v xs), t₂.realize (Sum.elim v xs)] := by
-  rw [Relations.boundedFormula₂, realize_rel, iff_eq_eq]
+  rw [Relations.semiformula₂, realize_rel, iff_eq_eq]
   refine' congr rfl (funext (Fin.cases _ _))
   · simp only [Matrix.cons_val_zero]
   · simp only [Matrix.cons_val_succ, Matrix.cons_val_fin_one, forall_const]
-#align first_order.language.bounded_formula.realize_rel₂ FirstOrder.Language.BoundedFormula.realize_rel₂
+#align first_order.language.bounded_formula.realize_rel₂ FirstOrder.Language.Semiformula.realize_rel₂
 
 @[simp]
 theorem realize_sup : (φ ⊔ ψ).Realize v xs ↔ φ.Realize v xs ∨ ψ.Realize v xs := by
   simp only [realize, Sup.sup, realize_not, eq_iff_iff]
   tauto
-#align first_order.language.bounded_formula.realize_sup FirstOrder.Language.BoundedFormula.realize_sup
+#align first_order.language.bounded_formula.realize_sup FirstOrder.Language.Semiformula.realize_sup
 
 @[simp]
-theorem realize_foldr_sup (l : List (L.BoundedFormula α n)) (v : α → M) (xs : Fin n → M) :
-    (l.foldr (· ⊔ ·) ⊥).Realize v xs ↔ ∃ φ ∈ l, BoundedFormula.Realize φ v xs := by
+theorem realize_foldr_sup (l : List (L.Semiformula α n)) (v : α → M) (xs : Fin n → M) :
+    (l.foldr (· ⊔ ·) ⊥).Realize v xs ↔ ∃ φ ∈ l, Semiformula.Realize φ v xs := by
   induction' l with φ l ih
   · simp
   · simp_rw [List.foldr_cons, realize_sup, ih, List.mem_cons, or_and_right, exists_or,
       exists_eq_left]
-#align first_order.language.bounded_formula.realize_foldr_sup FirstOrder.Language.BoundedFormula.realize_foldr_sup
+#align first_order.language.bounded_formula.realize_foldr_sup FirstOrder.Language.Semiformula.realize_foldr_sup
 
 @[simp]
 theorem realize_all : (all θ).Realize v xs ↔ ∀ a : M, θ.Realize v (Fin.snoc xs a) :=
   Iff.rfl
-#align first_order.language.bounded_formula.realize_all FirstOrder.Language.BoundedFormula.realize_all
+#align first_order.language.bounded_formula.realize_all FirstOrder.Language.Semiformula.realize_all
 
 @[simp]
 theorem realize_ex : θ.ex.Realize v xs ↔ ∃ a : M, θ.Realize v (Fin.snoc xs a) := by
-  rw [BoundedFormula.ex, realize_not, realize_all, not_forall]
+  rw [Semiformula.ex, realize_not, realize_all, not_forall]
   simp_rw [realize_not, Classical.not_not]
-#align first_order.language.bounded_formula.realize_ex FirstOrder.Language.BoundedFormula.realize_ex
+#align first_order.language.bounded_formula.realize_ex FirstOrder.Language.Semiformula.realize_ex
 
 @[simp]
 theorem realize_iff : (φ.iff ψ).Realize v xs ↔ (φ.Realize v xs ↔ ψ.Realize v xs) := by
-  simp only [BoundedFormula.iff, realize_inf, realize_imp, and_imp, ← iff_def]
-#align first_order.language.bounded_formula.realize_iff FirstOrder.Language.BoundedFormula.realize_iff
+  simp only [Semiformula.iff, realize_inf, realize_imp, and_imp, ← iff_def]
+#align first_order.language.bounded_formula.realize_iff FirstOrder.Language.Semiformula.realize_iff
 
-theorem realize_castLE_of_eq {m n : ℕ} (h : m = n) {h' : m ≤ n} {φ : L.BoundedFormula α m}
+theorem realize_castLE_of_eq {m n : ℕ} (h : m = n) {h' : m ≤ n} {φ : L.Semiformula α m}
     {v : α → M} {xs : Fin n → M} : (φ.castLE h').Realize v xs ↔ φ.Realize v (xs ∘ cast h) := by
   subst h
   simp only [castLE_rfl, cast_refl, OrderIso.coe_refl, Function.comp_id]
-#align first_order.language.bounded_formula.realize_cast_le_of_eq FirstOrder.Language.BoundedFormula.realize_castLE_of_eq
+#align first_order.language.bounded_formula.realize_cast_le_of_eq FirstOrder.Language.Semiformula.realize_castLE_of_eq
 
 theorem realize_mapTermRel_id [L'.Structure M]
     {ft : ∀ n, L.Term (Sum α (Fin n)) → L'.Term (Sum β (Fin n))}
-    {fr : ∀ n, L.Relations n → L'.Relations n} {n} {φ : L.BoundedFormula α n} {v : α → M}
+    {fr : ∀ n, L.Relations n → L'.Relations n} {n} {φ : L.Semiformula α n} {v : α → M}
     {v' : β → M} {xs : Fin n → M}
     (h1 :
       ∀ (n) (t : L.Term (Sum α (Fin n))) (xs : Fin n → M),
@@ -374,11 +374,11 @@ theorem realize_mapTermRel_id [L'.Structure M]
   · simp [mapTermRel, Realize, h1, h2]
   · simp [mapTermRel, Realize, ih1, ih2]
   · simp only [mapTermRel, Realize, ih, id.def]
-#align first_order.language.bounded_formula.realize_map_term_rel_id FirstOrder.Language.BoundedFormula.realize_mapTermRel_id
+#align first_order.language.bounded_formula.realize_map_term_rel_id FirstOrder.Language.Semiformula.realize_mapTermRel_id
 
 theorem realize_mapTermRel_add_castLe [L'.Structure M] {k : ℕ}
     {ft : ∀ n, L.Term (Sum α (Fin n)) → L'.Term (Sum β (Fin (k + n)))}
-    {fr : ∀ n, L.Relations n → L'.Relations n} {n} {φ : L.BoundedFormula α n}
+    {fr : ∀ n, L.Relations n → L'.Relations n} {n} {φ : L.Semiformula α n}
     (v : ∀ {n}, (Fin (k + n) → M) → α → M) {v' : β → M} (xs : Fin (k + n) → M)
     (h1 :
       ∀ (n) (t : L.Term (Sum α (Fin n))) (xs' : Fin (k + n) → M),
@@ -393,17 +393,17 @@ theorem realize_mapTermRel_add_castLe [L'.Structure M] {k : ℕ}
   · simp [mapTermRel, Realize, h1, h2]
   · simp [mapTermRel, Realize, ih1, ih2]
   · simp [mapTermRel, Realize, ih, hv]
-#align first_order.language.bounded_formula.realize_map_term_rel_add_cast_le FirstOrder.Language.BoundedFormula.realize_mapTermRel_add_castLe
+#align first_order.language.bounded_formula.realize_map_term_rel_add_cast_le FirstOrder.Language.Semiformula.realize_mapTermRel_add_castLe
 
 @[simp]
-theorem realize_relabel {m n : ℕ} {φ : L.BoundedFormula α n} {g : α → Sum β (Fin m)} {v : β → M}
+theorem realize_relabel {m n : ℕ} {φ : L.Semiformula α n} {g : α → Sum β (Fin m)} {v : β → M}
     {xs : Fin (m + n) → M} :
     (φ.relabel g).Realize v xs ↔
       φ.Realize (Sum.elim v (xs ∘ Fin.castAdd n) ∘ g) (xs ∘ Fin.natAdd m) :=
   by rw [relabel, realize_mapTermRel_add_castLe] <;> intros <;> simp
-#align first_order.language.bounded_formula.realize_relabel FirstOrder.Language.BoundedFormula.realize_relabel
+#align first_order.language.bounded_formula.realize_relabel FirstOrder.Language.Semiformula.realize_relabel
 
-theorem realize_liftAt {n n' m : ℕ} {φ : L.BoundedFormula α n} {v : α → M} {xs : Fin (n + n') → M}
+theorem realize_liftAt {n n' m : ℕ} {φ : L.Semiformula α n} {v : α → M} {xs : Fin (n + n') → M}
     (hmn : m + n' ≤ n + 1) :
     (φ.liftAt n' m).Realize v xs ↔
       φ.Realize v (xs ∘ fun i => if ↑i < m then Fin.castAdd n' i else Fin.addNat i n') := by
@@ -431,25 +431,25 @@ theorem realize_liftAt {n n' m : ℕ} {φ : L.BoundedFormula α n} {v : α → M
       refine' (congr rfl (ext _)).trans (snoc_castSucc _ _ _)
       simp only [coe_castSucc, coe_cast]
       split_ifs <;> simp
-#align first_order.language.bounded_formula.realize_lift_at FirstOrder.Language.BoundedFormula.realize_liftAt
+#align first_order.language.bounded_formula.realize_lift_at FirstOrder.Language.Semiformula.realize_liftAt
 
-theorem realize_liftAt_one {n m : ℕ} {φ : L.BoundedFormula α n} {v : α → M} {xs : Fin (n + 1) → M}
+theorem realize_liftAt_one {n m : ℕ} {φ : L.Semiformula α n} {v : α → M} {xs : Fin (n + 1) → M}
     (hmn : m ≤ n) :
     (φ.liftAt 1 m).Realize v xs ↔
       φ.Realize v (xs ∘ fun i => if ↑i < m then castSucc i else i.succ) := by
   simp [realize_liftAt (add_le_add_right hmn 1), castSucc]
-#align first_order.language.bounded_formula.realize_lift_at_one FirstOrder.Language.BoundedFormula.realize_liftAt_one
+#align first_order.language.bounded_formula.realize_lift_at_one FirstOrder.Language.Semiformula.realize_liftAt_one
 
 @[simp]
-theorem realize_liftAt_one_self {n : ℕ} {φ : L.BoundedFormula α n} {v : α → M}
+theorem realize_liftAt_one_self {n : ℕ} {φ : L.Semiformula α n} {v : α → M}
     {xs : Fin (n + 1) → M} : (φ.liftAt 1 n).Realize v xs ↔ φ.Realize v (xs ∘ castSucc) := by
   rw [realize_liftAt_one (refl n), iff_eq_eq]
   refine' congr rfl (congr rfl (funext fun i => _))
   rw [if_pos i.is_lt]
-#align first_order.language.bounded_formula.realize_lift_at_one_self FirstOrder.Language.BoundedFormula.realize_liftAt_one_self
+#align first_order.language.bounded_formula.realize_lift_at_one_self FirstOrder.Language.Semiformula.realize_liftAt_one_self
 
 @[simp]
-theorem realize_subst {φ : L.BoundedFormula α n} {tf : α → L.Term β} {v : β → M} {xs : Fin n → M} :
+theorem realize_subst {φ : L.Semiformula α n} {tf : α → L.Term β} {v : β → M} {xs : Fin n → M} :
     (φ.subst tf).Realize v xs ↔ φ.Realize (fun a => (tf a).realize v) xs :=
   realize_mapTermRel_id
     (fun n t x => by
@@ -459,10 +459,10 @@ theorem realize_subst {φ : L.BoundedFormula α n} {tf : α → L.Term β} {v : 
         · simp only [Sum.elim_inl, Function.comp_apply, Term.realize_relabel, Sum.elim_comp_inl]
         · rfl)
     (by simp)
-#align first_order.language.bounded_formula.realize_subst FirstOrder.Language.BoundedFormula.realize_subst
+#align first_order.language.bounded_formula.realize_subst FirstOrder.Language.Semiformula.realize_subst
 
 @[simp]
-theorem realize_restrictFreeVar [DecidableEq α] {n : ℕ} {φ : L.BoundedFormula α n} {s : Set α}
+theorem realize_restrictFreeVar [DecidableEq α] {n : ℕ} {φ : L.Semiformula α n} {s : Set α}
     (h : ↑φ.freeVarFinset ⊆ s) {v : α → M} {xs : Fin n → M} :
     (φ.restrictFreeVar (Set.inclusion h)).Realize (v ∘ (↑)) xs ↔ φ.Realize v xs := by
   induction' φ with _ _ _ _ _ _ _ _ _ _ _ ih1 ih2 _ _ ih3
@@ -471,10 +471,10 @@ theorem realize_restrictFreeVar [DecidableEq α] {n : ℕ} {φ : L.BoundedFormul
   · simp [restrictFreeVar, Realize]
   · simp [restrictFreeVar, Realize, ih1, ih2]
   · simp [restrictFreeVar, Realize, ih3]
-#align first_order.language.bounded_formula.realize_restrict_free_var FirstOrder.Language.BoundedFormula.realize_restrictFreeVar
+#align first_order.language.bounded_formula.realize_restrict_free_var FirstOrder.Language.Semiformula.realize_restrictFreeVar
 
 theorem realize_constantsVarsEquiv [L[[α]].Structure M] [(lhomWithConstants L α).IsExpansionOn M]
-    {n} {φ : L[[α]].BoundedFormula β n} {v : β → M} {xs : Fin n → M} :
+    {n} {φ : L[[α]].Semiformula β n} {v : β → M} {xs : Fin n → M} :
     (constantsVarsEquiv φ).Realize (Sum.elim (fun a => ↑(L.con a)) v) xs ↔ φ.Realize v xs := by
   refine' realize_mapTermRel_id (fun n t xs => realize_constantsVarsEquivLeft) fun n R xs => _
   -- This used to be `rw`, but we need `erw` after leanprover/lean4#2644
@@ -485,21 +485,21 @@ theorem realize_constantsVarsEquiv [L[[α]].Structure M] [(lhomWithConstants L �
   · -- This used to be `simp` before leanprover/lean4#2644
     simp; erw [Equiv.sumEmpty_apply_inl]
   · exact isEmptyElim R
-#align first_order.language.bounded_formula.realize_constants_vars_equiv FirstOrder.Language.BoundedFormula.realize_constantsVarsEquiv
+#align first_order.language.bounded_formula.realize_constants_vars_equiv FirstOrder.Language.Semiformula.realize_constantsVarsEquiv
 
 @[simp]
-theorem realize_relabelEquiv {g : α ≃ β} {k} {φ : L.BoundedFormula α k} {v : β → M}
+theorem realize_relabelEquiv {g : α ≃ β} {k} {φ : L.Semiformula α k} {v : β → M}
     {xs : Fin k → M} : (relabelEquiv g φ).Realize v xs ↔ φ.Realize (v ∘ g) xs := by
   simp only [relabelEquiv, mapTermRelEquiv_apply, Equiv.coe_refl]
   refine' realize_mapTermRel_id (fun n t xs => _) fun _ _ _ => rfl
   simp only [relabelEquiv_apply, Term.realize_relabel]
   refine' congr (congr rfl _) rfl
   ext (i | i) <;> rfl
-#align first_order.language.bounded_formula.realize_relabel_equiv FirstOrder.Language.BoundedFormula.realize_relabelEquiv
+#align first_order.language.bounded_formula.realize_relabel_equiv FirstOrder.Language.Semiformula.realize_relabelEquiv
 
 variable [Nonempty M]
 
-theorem realize_all_liftAt_one_self {n : ℕ} {φ : L.BoundedFormula α n} {v : α → M}
+theorem realize_all_liftAt_one_self {n : ℕ} {φ : L.Semiformula α n} {v : α → M}
     {xs : Fin n → M} : (φ.liftAt 1 n).all.Realize v xs ↔ φ.Realize v xs := by
   inhabit M
   simp only [realize_all, realize_liftAt_one_self]
@@ -508,9 +508,9 @@ theorem realize_all_liftAt_one_self {n : ℕ} {φ : L.BoundedFormula α n} {v : 
     simp
   · refine' (congr rfl (funext fun i => _)).mp h
     simp
-#align first_order.language.bounded_formula.realize_all_lift_at_one_self FirstOrder.Language.BoundedFormula.realize_all_liftAt_one_self
+#align first_order.language.bounded_formula.realize_all_lift_at_one_self FirstOrder.Language.Semiformula.realize_all_liftAt_one_self
 
-theorem realize_toPrenexImpRight {φ ψ : L.BoundedFormula α n} (hφ : IsQF φ) (hψ : IsPrenex ψ)
+theorem realize_toPrenexImpRight {φ ψ : L.Semiformula α n} (hφ : IsQF φ) (hψ : IsPrenex ψ)
     {v : α → M} {xs : Fin n → M} :
     (φ.toPrenexImpRight ψ).Realize v xs ↔ (φ.imp ψ).Realize v xs := by
   induction' hψ with _ _ hψ _ _ _hψ ih _ _ _hψ ih
@@ -530,9 +530,9 @@ theorem realize_toPrenexImpRight {φ ψ : L.BoundedFormula α n} (hφ : IsQF φ)
         exact ⟨a, fun _ => ha⟩
       · inhabit M
         exact ⟨default, fun h'' => (h h'').elim⟩
-#align first_order.language.bounded_formula.realize_to_prenex_imp_right FirstOrder.Language.BoundedFormula.realize_toPrenexImpRight
+#align first_order.language.bounded_formula.realize_to_prenex_imp_right FirstOrder.Language.Semiformula.realize_toPrenexImpRight
 
-theorem realize_toPrenexImp {φ ψ : L.BoundedFormula α n} (hφ : IsPrenex φ) (hψ : IsPrenex ψ)
+theorem realize_toPrenexImp {φ ψ : L.Semiformula α n} (hφ : IsPrenex φ) (hψ : IsPrenex ψ)
     {v : α → M} {xs : Fin n → M} : (φ.toPrenexImp ψ).Realize v xs ↔ (φ.imp ψ).Realize v xs := by
   revert ψ
   induction' hφ with _ _ hφ _ _ _hφ ih _ _ _hφ ih <;> intro ψ hψ
@@ -552,10 +552,10 @@ theorem realize_toPrenexImp {φ ψ : L.BoundedFormula α n} (hφ : IsPrenex φ) 
         exact ⟨a, fun h => (ha h).elim⟩
   · refine' _root_.trans (forall_congr' fun _ => ih hψ.liftAt) _
     simp
-#align first_order.language.bounded_formula.realize_to_prenex_imp FirstOrder.Language.BoundedFormula.realize_toPrenexImp
+#align first_order.language.bounded_formula.realize_to_prenex_imp FirstOrder.Language.Semiformula.realize_toPrenexImp
 
 @[simp]
-theorem realize_toPrenex (φ : L.BoundedFormula α n) {v : α → M} :
+theorem realize_toPrenex (φ : L.Semiformula α n) {v : α → M} :
     ∀ {xs : Fin n → M}, φ.toPrenex.Realize v xs ↔ φ.Realize v xs := by
   induction' φ with _ _ _ _ _ _ _ _ _ f1 f2 h1 h2 _ _ h
   · exact Iff.rfl
@@ -567,9 +567,9 @@ theorem realize_toPrenex (φ : L.BoundedFormula α n) {v : α → M} :
   · intros
     rw [realize_all, toPrenex, realize_all]
     exact forall_congr' fun a => h
-#align first_order.language.bounded_formula.realize_to_prenex FirstOrder.Language.BoundedFormula.realize_toPrenex
+#align first_order.language.bounded_formula.realize_to_prenex FirstOrder.Language.Semiformula.realize_toPrenex
 
-end BoundedFormula
+end Semiformula
 
 
 -- Porting note: no `protected` attribute in Lean4
@@ -579,23 +579,23 @@ end BoundedFormula
 
 namespace LHom
 
-open BoundedFormula
+open Semiformula
 
 @[simp]
-theorem realize_onBoundedFormula [L'.Structure M] (φ : L →ᴸ L') [φ.IsExpansionOn M] {n : ℕ}
-    (ψ : L.BoundedFormula α n) {v : α → M} {xs : Fin n → M} :
-    (φ.onBoundedFormula ψ).Realize v xs ↔ ψ.Realize v xs := by
+theorem realize_onSemiformula [L'.Structure M] (φ : L →ᴸ L') [φ.IsExpansionOn M] {n : ℕ}
+    (ψ : L.Semiformula α n) {v : α → M} {xs : Fin n → M} :
+    (φ.onSemiformula ψ).Realize v xs ↔ ψ.Realize v xs := by
   induction' ψ with _ _ _ _ _ _ _ _ _ _ _ ih1 ih2 _ _ ih3
   · rfl
-  · simp only [onBoundedFormula, realize_bdEqual, realize_onTerm]
+  · simp only [onSemiformula, realize_bdEqual, realize_onTerm]
     rfl
-  · simp only [onBoundedFormula, realize_rel, LHom.map_onRelation,
+  · simp only [onSemiformula, realize_rel, LHom.map_onRelation,
       Function.comp_apply, realize_onTerm]
     rfl
-  · simp only [onBoundedFormula, ih1, ih2, realize_imp]
-  · simp only [onBoundedFormula, ih3, realize_all]
+  · simp only [onSemiformula, ih1, ih2, realize_imp]
+  · simp only [onSemiformula, ih3, realize_all]
 set_option linter.uppercaseLean3 false in
-#align first_order.language.Lhom.realize_on_bounded_formula FirstOrder.Language.LHom.realize_onBoundedFormula
+#align first_order.language.Lhom.realize_on_bounded_formula FirstOrder.Language.LHom.realize_onSemiformula
 
 end LHom
 
@@ -625,23 +625,23 @@ theorem realize_bot : (⊥ : L.Formula α).Realize v ↔ False :=
 
 @[simp]
 theorem realize_top : (⊤ : L.Formula α).Realize v ↔ True :=
-  BoundedFormula.realize_top
+  Semiformula.realize_top
 #align first_order.language.formula.realize_top FirstOrder.Language.Formula.realize_top
 
 @[simp]
 theorem realize_inf : (φ ⊓ ψ).Realize v ↔ φ.Realize v ∧ ψ.Realize v :=
-  BoundedFormula.realize_inf
+  Semiformula.realize_inf
 #align first_order.language.formula.realize_inf FirstOrder.Language.Formula.realize_inf
 
 @[simp]
 theorem realize_imp : (φ.imp ψ).Realize v ↔ φ.Realize v → ψ.Realize v :=
-  BoundedFormula.realize_imp
+  Semiformula.realize_imp
 #align first_order.language.formula.realize_imp FirstOrder.Language.Formula.realize_imp
 
 @[simp]
 theorem realize_rel {k : ℕ} {R : L.Relations k} {ts : Fin k → L.Term α} :
     (R.formula ts).Realize v ↔ RelMap R fun i => (ts i).realize v :=
-  BoundedFormula.realize_rel.trans (by simp)
+  Semiformula.realize_rel.trans (by simp)
 #align first_order.language.formula.realize_rel FirstOrder.Language.Formula.realize_rel
 
 @[simp]
@@ -663,24 +663,24 @@ theorem realize_rel₂ {R : L.Relations 2} {t₁ t₂ : L.Term _} :
 
 @[simp]
 theorem realize_sup : (φ ⊔ ψ).Realize v ↔ φ.Realize v ∨ ψ.Realize v :=
-  BoundedFormula.realize_sup
+  Semiformula.realize_sup
 #align first_order.language.formula.realize_sup FirstOrder.Language.Formula.realize_sup
 
 @[simp]
 theorem realize_iff : (φ.iff ψ).Realize v ↔ (φ.Realize v ↔ ψ.Realize v) :=
-  BoundedFormula.realize_iff
+  Semiformula.realize_iff
 #align first_order.language.formula.realize_iff FirstOrder.Language.Formula.realize_iff
 
 @[simp]
 theorem realize_relabel {φ : L.Formula α} {g : α → β} {v : β → M} :
     (φ.relabel g).Realize v ↔ φ.Realize (v ∘ g) := by
-  rw [Realize, Realize, relabel, BoundedFormula.realize_relabel, iff_eq_eq, Fin.castAdd_zero]
+  rw [Realize, Realize, relabel, Semiformula.realize_relabel, iff_eq_eq, Fin.castAdd_zero]
   exact congr rfl (funext finZeroElim)
 #align first_order.language.formula.realize_relabel FirstOrder.Language.Formula.realize_relabel
 
 theorem realize_relabel_sum_inr (φ : L.Formula (Fin n)) {v : Empty → M} {x : Fin n → M} :
-    (BoundedFormula.relabel Sum.inr φ).Realize v x ↔ φ.Realize x := by
-  rw [BoundedFormula.realize_relabel, Formula.Realize, Sum.elim_comp_inr, Fin.castAdd_zero,
+    (Semiformula.relabel Sum.inr φ).Realize v x ↔ φ.Realize x := by
+  rw [Semiformula.realize_relabel, Formula.Realize, Sum.elim_comp_inr, Fin.castAdd_zero,
     cast_refl, Function.comp_id,
     Subsingleton.elim (x ∘ (natAdd n : Fin 0 → Fin n)) default]
 #align first_order.language.formula.realize_relabel_sum_inr FirstOrder.Language.Formula.realize_relabel_sum_inr
@@ -702,7 +702,7 @@ end Formula
 @[simp]
 theorem LHom.realize_onFormula [L'.Structure M] (φ : L →ᴸ L') [φ.IsExpansionOn M] (ψ : L.Formula α)
     {v : α → M} : (φ.onFormula ψ).Realize v ↔ ψ.Realize v :=
-  φ.realize_onBoundedFormula ψ
+  φ.realize_onSemiformula ψ
 set_option linter.uppercaseLean3 false in
 #align first_order.language.Lhom.realize_on_formula FirstOrder.Language.LHom.realize_onFormula
 
@@ -737,8 +737,8 @@ theorem realize_equivSentence_symm_con [L[[α]].Structure M]
     [(L.lhomWithConstants α).IsExpansionOn M] (φ : L[[α]].Sentence) :
     ((equivSentence.symm φ).Realize fun a => (L.con a : M)) ↔ φ.Realize M := by
   simp only [equivSentence, _root_.Equiv.symm_symm, Equiv.coe_trans, Realize,
-    BoundedFormula.realize_relabelEquiv, Function.comp]
-  refine' _root_.trans _ BoundedFormula.realize_constantsVarsEquiv
+    Semiformula.realize_relabelEquiv, Function.comp]
+  refine' _root_.trans _ Semiformula.realize_constantsVarsEquiv
   rw [iff_iff_eq]
   congr with (_ | a)
   · simp
@@ -886,30 +886,30 @@ theorem realize_iff_of_model_completeTheory [N ⊨ L.completeTheory M] (φ : L.S
 
 variable {M N}
 
-namespace BoundedFormula
+namespace Semiformula
 
 @[simp]
-theorem realize_alls {φ : L.BoundedFormula α n} {v : α → M} :
+theorem realize_alls {φ : L.Semiformula α n} {v : α → M} :
     φ.alls.Realize v ↔ ∀ xs : Fin n → M, φ.Realize v xs := by
   induction' n with n ih
   · exact Unique.forall_iff.symm
   · simp only [alls, ih, Realize]
     exact ⟨fun h xs => Fin.snoc_init_self xs ▸ h _ _, fun h xs x => h (Fin.snoc xs x)⟩
-#align first_order.language.bounded_formula.realize_alls FirstOrder.Language.BoundedFormula.realize_alls
+#align first_order.language.bounded_formula.realize_alls FirstOrder.Language.Semiformula.realize_alls
 
 @[simp]
-theorem realize_exs {φ : L.BoundedFormula α n} {v : α → M} :
+theorem realize_exs {φ : L.Semiformula α n} {v : α → M} :
     φ.exs.Realize v ↔ ∃ xs : Fin n → M, φ.Realize v xs := by
   induction' n with n ih
   · exact Unique.exists_iff.symm
-  · simp only [BoundedFormula.exs, ih, realize_ex]
+  · simp only [Semiformula.exs, ih, realize_ex]
     constructor
     · rintro ⟨xs, x, h⟩
       exact ⟨_, h⟩
     · rintro ⟨xs, h⟩
       rw [← Fin.snoc_init_self xs] at h
       exact ⟨_, _, h⟩
-#align first_order.language.bounded_formula.realize_exs FirstOrder.Language.BoundedFormula.realize_exs
+#align first_order.language.bounded_formula.realize_exs FirstOrder.Language.Semiformula.realize_exs
 
 @[simp]
 theorem _root_.FirstOrder.Language.Formula.realize_iAlls
@@ -933,7 +933,7 @@ theorem _root_.FirstOrder.Language.Formula.realize_iAlls
 @[simp]
 theorem realize_iAlls [Finite γ] {f : α → β ⊕ γ}
     {φ : L.Formula α} {v : β → M} {v' : Fin 0 → M} :
-    BoundedFormula.Realize (φ.iAlls f) v v' ↔
+    Semiformula.Realize (φ.iAlls f) v v' ↔
       ∀ (i : γ → M), φ.Realize (fun a => Sum.elim v i (f a)) := by
   rw [← Formula.realize_iAlls, iff_iff_eq]; congr; simp [eq_iff_true_of_subsingleton]
 
@@ -960,17 +960,17 @@ theorem _root_.FirstOrder.Language.Formula.realize_iExs
 @[simp]
 theorem realize_iExs [Finite γ] {f : α → β ⊕ γ}
     {φ : L.Formula α} {v : β → M} {v' : Fin 0 → M} :
-    BoundedFormula.Realize (φ.iExs f) v v' ↔
+    Semiformula.Realize (φ.iExs f) v v' ↔
       ∃ (i : γ → M), φ.Realize (fun a => Sum.elim v i (f a)) := by
   rw [← Formula.realize_iExs, iff_iff_eq]; congr; simp [eq_iff_true_of_subsingleton]
 
 @[simp]
-theorem realize_toFormula (φ : L.BoundedFormula α n) (v : Sum α (Fin n) → M) :
+theorem realize_toFormula (φ : L.Semiformula α n) (v : Sum α (Fin n) → M) :
     φ.toFormula.Realize v ↔ φ.Realize (v ∘ Sum.inl) (v ∘ Sum.inr) := by
   induction' φ with _ _ _ _ _ _ _ _ _ _ _ ih1 ih2 _ _ ih3 a8 a9 a0
   · rfl
-  · simp [BoundedFormula.Realize]
-  · simp [BoundedFormula.Realize]
+  · simp [Semiformula.Realize]
+  · simp [Semiformula.Realize]
   · rw [toFormula, Formula.Realize, realize_imp, ← Formula.Realize, ih1, ← Formula.Realize, ih2,
       realize_imp]
   · rw [toFormula, Formula.Realize, realize_all, realize_all]
@@ -991,36 +991,36 @@ theorem realize_toFormula (φ : L.BoundedFormula α n) (v : Sum α (Fin n) → M
           rw [← castSucc]
           simp
     · exact Fin.elim0 x
-#align first_order.language.bounded_formula.realize_to_formula FirstOrder.Language.BoundedFormula.realize_toFormula
+#align first_order.language.bounded_formula.realize_to_formula FirstOrder.Language.Semiformula.realize_toFormula
 
 @[simp]
-theorem realize_iSup (s : Finset β) (f : β → L.BoundedFormula α n)
+theorem realize_iSup (s : Finset β) (f : β → L.Semiformula α n)
     (v : α → M) (v' : Fin n → M) :
     (iSup s f).Realize v v' ↔ ∃ b ∈ s, (f b).Realize v v' := by
   simp only [iSup, realize_foldr_sup, List.mem_map, Finset.mem_toList,
     exists_exists_and_eq_and]
 
 @[simp]
-theorem realize_iInf (s : Finset β) (f : β → L.BoundedFormula α n)
+theorem realize_iInf (s : Finset β) (f : β → L.Semiformula α n)
     (v : α → M) (v' : Fin n → M) :
     (iInf s f).Realize v v' ↔ ∀ b ∈ s, (f b).Realize v v' := by
   simp only [iInf, realize_foldr_inf, List.mem_map, Finset.mem_toList,
     forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
 
-end BoundedFormula
+end Semiformula
 
 namespace Equiv
 
 @[simp]
-theorem realize_boundedFormula (g : M ≃[L] N) (φ : L.BoundedFormula α n) {v : α → M}
+theorem realize_semiformula (g : M ≃[L] N) (φ : L.Semiformula α n) {v : α → M}
     {xs : Fin n → M} : φ.Realize (g ∘ v) (g ∘ xs) ↔ φ.Realize v xs := by
   induction' φ with _ _ _ _ _ _ _ _ _ _ _ ih1 ih2 _ _ ih3
   · rfl
-  · simp only [BoundedFormula.Realize, ← Sum.comp_elim, Equiv.realize_term, g.injective.eq_iff]
-  · simp only [BoundedFormula.Realize, ← Sum.comp_elim, Equiv.realize_term]
+  · simp only [Semiformula.Realize, ← Sum.comp_elim, Equiv.realize_term, g.injective.eq_iff]
+  · simp only [Semiformula.Realize, ← Sum.comp_elim, Equiv.realize_term]
     exact g.map_rel _ _
-  · rw [BoundedFormula.Realize, ih1, ih2, BoundedFormula.Realize]
-  · rw [BoundedFormula.Realize, BoundedFormula.Realize]
+  · rw [Semiformula.Realize, ih1, ih2, Semiformula.Realize]
+  · rw [Semiformula.Realize, Semiformula.Realize]
     constructor
     · intro h a
       have h' := h (g a)
@@ -1030,12 +1030,12 @@ theorem realize_boundedFormula (g : M ≃[L] N) (φ : L.BoundedFormula α n) {v 
       have h' := h (g.symm a)
       rw [← ih3, Fin.comp_snoc, g.apply_symm_apply] at h'
       exact h'
-#align first_order.language.equiv.realize_bounded_formula FirstOrder.Language.Equiv.realize_boundedFormula
+#align first_order.language.equiv.realize_bounded_formula FirstOrder.Language.Equiv.realize_semiformula
 
 @[simp]
 theorem realize_formula (g : M ≃[L] N) (φ : L.Formula α) {v : α → M} :
     φ.Realize (g ∘ v) ↔ φ.Realize v := by
-  rw [Formula.Realize, Formula.Realize, ← g.realize_boundedFormula φ, iff_eq_eq,
+  rw [Formula.Realize, Formula.Realize, ← g.realize_semiformula φ, iff_eq_eq,
     Unique.eq_default (g ∘ default)]
 #align first_order.language.equiv.realize_formula FirstOrder.Language.Equiv.realize_formula
 
@@ -1056,7 +1056,7 @@ end Equiv
 
 namespace Relations
 
-open BoundedFormula
+open Semiformula
 
 variable {r : L.Relations 2}
 
@@ -1103,8 +1103,8 @@ variable (L)
 @[simp]
 theorem Sentence.realize_cardGe (n) : M ⊨ Sentence.cardGe L n ↔ ↑n ≤ #M := by
   rw [← lift_mk_fin, ← lift_le.{0}, lift_lift, lift_mk_le, Sentence.cardGe, Sentence.Realize,
-    BoundedFormula.realize_exs]
-  simp_rw [BoundedFormula.realize_foldr_inf]
+    Semiformula.realize_exs]
+  simp_rw [Semiformula.realize_foldr_inf]
   simp only [Function.comp_apply, List.mem_map, Prod.exists, Ne.def, List.mem_product,
     List.mem_finRange, forall_exists_index, and_imp, List.mem_filter, true_and_iff]
   refine' ⟨_, fun xs => ⟨xs.some, _⟩⟩
@@ -1112,7 +1112,7 @@ theorem Sentence.realize_cardGe (n) : M ⊨ Sentence.cardGe L n ↔ ↑n ≤ #M 
     refine' ⟨⟨xs, fun i j ij => _⟩⟩
     contrapose! ij
     have hij := h _ i j (by simpa using ij) rfl
-    simp only [BoundedFormula.realize_not, Term.realize, BoundedFormula.realize_bdEqual,
+    simp only [Semiformula.realize_not, Term.realize, Semiformula.realize_bdEqual,
       Sum.elim_inr] at hij
     exact hij
   · rintro _ i j ij rfl

--- a/Mathlib/ModelTheory/Skolem.lean
+++ b/Mathlib/ModelTheory/Skolem.lean
@@ -41,14 +41,14 @@ variable (L : Language.{u, v}) {M : Type w} [Nonempty M] [L.Structure M]
 Called `skolem₁` because it is the first step in building a Skolemization of a language. -/
 @[simps]
 def skolem₁ : Language :=
-  ⟨fun n => L.BoundedFormula Empty (n + 1), fun _ => Empty⟩
+  ⟨fun n => L.Semiformula Empty (n + 1), fun _ => Empty⟩
 #align first_order.language.skolem₁ FirstOrder.Language.skolem₁
 #align first_order.language.skolem₁_functions FirstOrder.Language.skolem₁_Functions
 
 variable {L}
 
 theorem card_functions_sum_skolem₁ :
-    #(Σ n, (L.sum L.skolem₁).Functions n) = #(Σ n, L.BoundedFormula Empty (n + 1)) := by
+    #(Σ n, (L.sum L.skolem₁).Functions n) = #(Σ n, L.Semiformula Empty (n + 1)) := by
   simp only [card_functions_sum, skolem₁_Functions, mk_sigma, sum_add_distrib']
   conv_lhs => enter [2, 1, i]; rw [lift_id'.{u, v}]
   rw [add_comm, add_eq_max, max_eq_left]
@@ -64,11 +64,11 @@ theorem card_functions_sum_skolem₁ :
 
 theorem card_functions_sum_skolem₁_le : #(Σ n, (L.sum L.skolem₁).Functions n) ≤ max ℵ₀ L.card := by
   rw [card_functions_sum_skolem₁]
-  trans #(Σ n, L.BoundedFormula Empty n)
+  trans #(Σ n, L.Semiformula Empty n)
   · exact
       ⟨⟨Sigma.map Nat.succ fun _ => id,
           Nat.succ_injective.sigma_map fun _ => Function.injective_id⟩⟩
-  · refine' _root_.trans BoundedFormula.card_le (lift_le.{max u v}.1 _)
+  · refine' _root_.trans Semiformula.card_le (lift_le.{max u v}.1 _)
     simp only [mk_empty, lift_zero, lift_uzero, zero_add]
     rfl
 #align first_order.language.card_functions_sum_skolem₁_le FirstOrder.Language.card_functions_sum_skolem₁_le
@@ -91,7 +91,7 @@ theorem skolem₁_reduct_isElementary (S : (L.sum L.skolem₁).Substructure M) :
   exact
     ⟨⟨funMap φ' ((↑) ∘ x), S.fun_mem (LHom.sumInr.onFunction φ) ((↑) ∘ x) (by
       exact fun i => (x i).2)⟩,
-      by exact Classical.epsilon_spec (p := fun a => BoundedFormula.Realize φ default
+      by exact Classical.epsilon_spec (p := fun a => Semiformula.Realize φ default
           (Fin.snoc (Subtype.val ∘ x) a)) ⟨a, h⟩⟩
 #align first_order.language.substructure.skolem₁_reduct_is_elementary FirstOrder.Language.Substructure.skolem₁_reduct_isElementary
 

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -686,12 +686,12 @@ theorem coe_topEquiv :
 #align first_order.language.substructure.coe_top_equiv FirstOrder.Language.Substructure.coe_topEquiv
 
 @[simp]
-theorem realize_boundedFormula_top {α : Type*} {n : ℕ} {φ : L.BoundedFormula α n}
+theorem realize_semiformula_top {α : Type*} {n : ℕ} {φ : L.Semiformula α n}
     {v : α → (⊤ : L.Substructure M)} {xs : Fin n → (⊤ : L.Substructure M)} :
     φ.Realize v xs ↔ φ.Realize (((↑) : _ → M) ∘ v) ((↑) ∘ xs) := by
-  rw [← Substructure.topEquiv.realize_boundedFormula φ]
+  rw [← Substructure.topEquiv.realize_semiformula φ]
   simp
-#align first_order.language.substructure.realize_bounded_formula_top FirstOrder.Language.Substructure.realize_boundedFormula_top
+#align first_order.language.substructure.realize_bounded_formula_top FirstOrder.Language.Substructure.realize_semiformula_top
 
 @[simp]
 theorem realize_formula_top {α : Type*} {φ : L.Formula α} {v : α → (⊤ : L.Substructure M)} :

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -22,25 +22,25 @@ This file defines first-order terms, formulas, sentences, and theories in a styl
 * A `FirstOrder.Language.Sentence` is a formula with no free variables.
 * A `FirstOrder.Language.Theory` is a set of sentences.
 * The variables of terms and formulas can be relabelled with `FirstOrder.Language.Term.relabel`,
-`FirstOrder.Language.BoundedFormula.relabel`, and `FirstOrder.Language.Formula.relabel`.
+`FirstOrder.Language.Semiformula.relabel`, and `FirstOrder.Language.Formula.relabel`.
 * Given an operation on terms and an operation on relations,
-  `FirstOrder.Language.BoundedFormula.mapTermRel` gives an operation on formulas.
-* `FirstOrder.Language.BoundedFormula.castLE` adds more `Fin`-indexed variables.
-* `FirstOrder.Language.BoundedFormula.liftAt` raises the indexes of the `Fin`-indexed variables
+  `FirstOrder.Language.Semiformula.mapTermRel` gives an operation on formulas.
+* `FirstOrder.Language.Semiformula.castLE` adds more `Fin`-indexed variables.
+* `FirstOrder.Language.Semiformula.liftAt` raises the indexes of the `Fin`-indexed variables
 above a particular index.
-* `FirstOrder.Language.Term.subst` and `FirstOrder.Language.BoundedFormula.subst` substitute
+* `FirstOrder.Language.Term.subst` and `FirstOrder.Language.Semiformula.subst` substitute
 variables with given terms.
 * Language maps can act on syntactic objects with functions such as
 `FirstOrder.Language.LHom.onFormula`.
 * `FirstOrder.Language.Term.constantsVarsEquiv` and
-`FirstOrder.Language.BoundedFormula.constantsVarsEquiv` switch terms and formulas between having
-constants in the language and having extra variables indexed by the same type.
+`FirstOrder.Language.Semiformula.constantsVarsEquiv` switch terms and formulas between having
+constants in the language and having extra variables indexed by the Semiformula type.
 
 ## Implementation Notes
-* Formulas use a modified version of de Bruijn variables. Specifically, a `L.BoundedFormula α n`
+* Formulas use a modified version of de Bruijn variables. Specifically, a `L.Semiformula α n`
 is a formula with some variables indexed by a type `α`, which cannot be quantified over, and some
-indexed by `Fin n`, which can. For any `φ : L.BoundedFormula α (n + 1)`, we define the formula
-`∀' φ : L.BoundedFormula α n` by universally quantifying over the variable indexed by
+indexed by `Fin n`, which can. For any `φ : L.Semiformula α (n + 1)`, we define the formula
+`∀' φ : L.Semiformula α n` by universally quantifying over the variable indexed by
 `n : Fin (n + 1)`.
 
 ## References
@@ -309,20 +309,20 @@ set_option linter.uppercaseLean3 false in
 
 variable (L) (α)
 
-/-- `BoundedFormula α n` is the type of formulas with free variables indexed by `α` and up to `n`
+/-- `Semiformula α n` is the type of formulas with free variables indexed by `α` and up to `n`
   additional free variables. -/
-inductive BoundedFormula : ℕ → Type max u v u'
-  | falsum {n} : BoundedFormula n
-  | equal {n} (t₁ t₂ : L.Term (Sum α (Fin n))) : BoundedFormula n
-  | rel {n l : ℕ} (R : L.Relations l) (ts : Fin l → L.Term (Sum α (Fin n))) : BoundedFormula n
-  | imp {n} (f₁ f₂ : BoundedFormula n) : BoundedFormula n
-  | all {n} (f : BoundedFormula (n + 1)) : BoundedFormula n
-#align first_order.language.bounded_formula FirstOrder.Language.BoundedFormula
+inductive Semiformula : ℕ → Type max u v u'
+  | falsum {n} : Semiformula n
+  | equal {n} (t₁ t₂ : L.Term (Sum α (Fin n))) : Semiformula n
+  | rel {n l : ℕ} (R : L.Relations l) (ts : Fin l → L.Term (Sum α (Fin n))) : Semiformula n
+  | imp {n} (f₁ f₂ : Semiformula n) : Semiformula n
+  | all {n} (f : Semiformula (n + 1)) : Semiformula n
+#align first_order.language.bounded_formula FirstOrder.Language.Semiformula
 
 /-- `Formula α` is the type of formulas with all free variables indexed by `α`. -/
 @[reducible]
 def Formula :=
-  L.BoundedFormula α 0
+  L.Semiformula α 0
 #align first_order.language.formula FirstOrder.Language.Formula
 
 /-- A sentence is a formula with no free variables. -/
@@ -341,31 +341,31 @@ set_option linter.uppercaseLean3 false in
 variable {L} {α} {n : ℕ}
 
 /-- Applies a relation to terms as a bounded formula. -/
-def Relations.boundedFormula {l : ℕ} (R : L.Relations n) (ts : Fin n → L.Term (Sum α (Fin l))) :
-    L.BoundedFormula α l :=
-  BoundedFormula.rel R ts
-#align first_order.language.relations.bounded_formula FirstOrder.Language.Relations.boundedFormula
+def Relations.semiformula {l : ℕ} (R : L.Relations n) (ts : Fin n → L.Term (Sum α (Fin l))) :
+    L.Semiformula α l :=
+  Semiformula.rel R ts
+#align first_order.language.relations.bounded_formula FirstOrder.Language.Relations.semiformula
 
 /-- Applies a unary relation to a term as a bounded formula. -/
-def Relations.boundedFormula₁ (r : L.Relations 1) (t : L.Term (Sum α (Fin n))) :
-    L.BoundedFormula α n :=
-  r.boundedFormula ![t]
-#align first_order.language.relations.bounded_formula₁ FirstOrder.Language.Relations.boundedFormula₁
+def Relations.semiformula₁ (r : L.Relations 1) (t : L.Term (Sum α (Fin n))) :
+    L.Semiformula α n :=
+  r.semiformula ![t]
+#align first_order.language.relations.bounded_formula₁ FirstOrder.Language.Relations.semiformula₁
 
 /-- Applies a binary relation to two terms as a bounded formula. -/
-def Relations.boundedFormula₂ (r : L.Relations 2) (t₁ t₂ : L.Term (Sum α (Fin n))) :
-    L.BoundedFormula α n :=
-  r.boundedFormula ![t₁, t₂]
-#align first_order.language.relations.bounded_formula₂ FirstOrder.Language.Relations.boundedFormula₂
+def Relations.semiformula₂ (r : L.Relations 2) (t₁ t₂ : L.Term (Sum α (Fin n))) :
+    L.Semiformula α n :=
+  r.semiformula ![t₁, t₂]
+#align first_order.language.relations.bounded_formula₂ FirstOrder.Language.Relations.semiformula₂
 
 /-- The equality of two terms as a bounded formula. -/
-def Term.bdEqual (t₁ t₂ : L.Term (Sum α (Fin n))) : L.BoundedFormula α n :=
-  BoundedFormula.equal t₁ t₂
+def Term.bdEqual (t₁ t₂ : L.Term (Sum α (Fin n))) : L.Semiformula α n :=
+  Semiformula.equal t₁ t₂
 #align first_order.language.term.bd_equal FirstOrder.Language.Term.bdEqual
 
 /-- Applies a relation to terms as a bounded formula. -/
 def Relations.formula (R : L.Relations n) (ts : Fin n → L.Term α) : L.Formula α :=
-  R.boundedFormula fun i => (ts i).relabel Sum.inl
+  R.semiformula fun i => (ts i).relabel Sum.inl
 #align first_order.language.relations.formula FirstOrder.Language.Relations.formula
 
 /-- Applies a unary relation to a term as a formula. -/
@@ -383,77 +383,77 @@ def Term.equal (t₁ t₂ : L.Term α) : L.Formula α :=
   (t₁.relabel Sum.inl).bdEqual (t₂.relabel Sum.inl)
 #align first_order.language.term.equal FirstOrder.Language.Term.equal
 
-namespace BoundedFormula
+namespace Semiformula
 
-instance : Inhabited (L.BoundedFormula α n) :=
+instance : Inhabited (L.Semiformula α n) :=
   ⟨falsum⟩
 
-instance : Bot (L.BoundedFormula α n) :=
+instance : Bot (L.Semiformula α n) :=
   ⟨falsum⟩
 
 /-- The negation of a bounded formula is also a bounded formula. -/
 @[match_pattern]
-protected def not (φ : L.BoundedFormula α n) : L.BoundedFormula α n :=
+protected def not (φ : L.Semiformula α n) : L.Semiformula α n :=
   φ.imp ⊥
-#align first_order.language.bounded_formula.not FirstOrder.Language.BoundedFormula.not
+#align first_order.language.bounded_formula.not FirstOrder.Language.Semiformula.not
 
 /-- Puts an `∃` quantifier on a bounded formula. -/
 @[match_pattern]
-protected def ex (φ : L.BoundedFormula α (n + 1)) : L.BoundedFormula α n :=
+protected def ex (φ : L.Semiformula α (n + 1)) : L.Semiformula α n :=
   φ.not.all.not
-#align first_order.language.bounded_formula.ex FirstOrder.Language.BoundedFormula.ex
+#align first_order.language.bounded_formula.ex FirstOrder.Language.Semiformula.ex
 
-instance : Top (L.BoundedFormula α n) :=
-  ⟨BoundedFormula.not ⊥⟩
+instance : Top (L.Semiformula α n) :=
+  ⟨Semiformula.not ⊥⟩
 
-instance : Inf (L.BoundedFormula α n) :=
+instance : Inf (L.Semiformula α n) :=
   ⟨fun f g => (f.imp g.not).not⟩
 
-instance : Sup (L.BoundedFormula α n) :=
+instance : Sup (L.Semiformula α n) :=
   ⟨fun f g => f.not.imp g⟩
 
 /-- The biimplication between two bounded formulas. -/
-protected def iff (φ ψ : L.BoundedFormula α n) :=
+protected def iff (φ ψ : L.Semiformula α n) :=
   φ.imp ψ ⊓ ψ.imp φ
-#align first_order.language.bounded_formula.iff FirstOrder.Language.BoundedFormula.iff
+#align first_order.language.bounded_formula.iff FirstOrder.Language.Semiformula.iff
 
 open Finset
 
 -- Porting note: universes in different order
 /-- The `Finset` of variables used in a given formula. -/
 @[simp]
-def freeVarFinset [DecidableEq α] : ∀ {n}, L.BoundedFormula α n → Finset α
+def freeVarFinset [DecidableEq α] : ∀ {n}, L.Semiformula α n → Finset α
   | _n, falsum => ∅
   | _n, equal t₁ t₂ => t₁.varFinsetLeft ∪ t₂.varFinsetLeft
   | _n, rel _R ts => univ.biUnion fun i => (ts i).varFinsetLeft
   | _n, imp f₁ f₂ => f₁.freeVarFinset ∪ f₂.freeVarFinset
   | _n, all f => f.freeVarFinset
-#align first_order.language.bounded_formula.free_var_finset FirstOrder.Language.BoundedFormula.freeVarFinset
+#align first_order.language.bounded_formula.free_var_finset FirstOrder.Language.Semiformula.freeVarFinset
 
 -- Porting note: universes in different order
-/-- Casts `L.BoundedFormula α m` as `L.BoundedFormula α n`, where `m ≤ n`. -/
+/-- Casts `L.Semiformula α m` as `L.Semiformula α n`, where `m ≤ n`. -/
 @[simp]
-def castLE : ∀ {m n : ℕ} (_h : m ≤ n), L.BoundedFormula α m → L.BoundedFormula α n
+def castLE : ∀ {m n : ℕ} (_h : m ≤ n), L.Semiformula α m → L.Semiformula α n
   | _m, _n, _h, falsum => falsum
   | _m, _n, h, equal t₁ t₂ =>
     equal (t₁.relabel (Sum.map id (Fin.castLE h))) (t₂.relabel (Sum.map id (Fin.castLE h)))
   | _m, _n, h, rel R ts => rel R (Term.relabel (Sum.map id (Fin.castLE h)) ∘ ts)
   | _m, _n, h, imp f₁ f₂ => (f₁.castLE h).imp (f₂.castLE h)
   | _m, _n, h, all f => (f.castLE (add_le_add_right h 1)).all
-#align first_order.language.bounded_formula.cast_le FirstOrder.Language.BoundedFormula.castLE
+#align first_order.language.bounded_formula.cast_le FirstOrder.Language.Semiformula.castLE
 
 @[simp]
-theorem castLE_rfl {n} (h : n ≤ n) (φ : L.BoundedFormula α n) : φ.castLE h = φ := by
+theorem castLE_rfl {n} (h : n ≤ n) (φ : L.Semiformula α n) : φ.castLE h = φ := by
   induction' φ with _ _ _ _ _ _ _ _ _ _ _ ih1 ih2 _ _ ih3
   · rfl
   · simp [Fin.castLE_of_eq]
   · simp [Fin.castLE_of_eq]
   · simp [Fin.castLE_of_eq, ih1, ih2]
   · simp [Fin.castLE_of_eq, ih3]
-#align first_order.language.bounded_formula.cast_le_rfl FirstOrder.Language.BoundedFormula.castLE_rfl
+#align first_order.language.bounded_formula.cast_le_rfl FirstOrder.Language.Semiformula.castLE_rfl
 
 @[simp]
-theorem castLE_castLE {k m n} (km : k ≤ m) (mn : m ≤ n) (φ : L.BoundedFormula α k) :
+theorem castLE_castLE {k m n} (km : k ≤ m) (mn : m ≤ n) (φ : L.Semiformula α k) :
     (φ.castLE km).castLE mn = φ.castLE (km.trans mn) := by
   revert m n
   induction' φ with _ _ _ _ _ _ _ _ _ _ _ ih1 ih2 _ _ ih3 <;> intro m n km mn
@@ -464,20 +464,20 @@ theorem castLE_castLE {k m n} (km : k ≤ m) (mn : m ≤ n) (φ : L.BoundedFormu
     simp
   · simp [ih1, ih2]
   · simp only [castLE, ih3]
-#align first_order.language.bounded_formula.cast_le_cast_le FirstOrder.Language.BoundedFormula.castLE_castLE
+#align first_order.language.bounded_formula.cast_le_cast_le FirstOrder.Language.Semiformula.castLE_castLE
 
 @[simp]
 theorem castLE_comp_castLE {k m n} (km : k ≤ m) (mn : m ≤ n) :
-    (BoundedFormula.castLE mn ∘ BoundedFormula.castLE km :
-        L.BoundedFormula α k → L.BoundedFormula α n) =
-      BoundedFormula.castLE (km.trans mn) :=
+    (Semiformula.castLE mn ∘ Semiformula.castLE km :
+        L.Semiformula α k → L.Semiformula α n) =
+      Semiformula.castLE (km.trans mn) :=
   funext (castLE_castLE km mn)
-#align first_order.language.bounded_formula.cast_le_comp_cast_le FirstOrder.Language.BoundedFormula.castLE_comp_castLE
+#align first_order.language.bounded_formula.cast_le_comp_cast_le FirstOrder.Language.Semiformula.castLE_comp_castLE
 
 -- Porting note: universes in different order
 /-- Restricts a bounded formula to only use a particular set of free variables. -/
 def restrictFreeVar [DecidableEq α] :
-    ∀ {n : ℕ} (φ : L.BoundedFormula α n) (_f : φ.freeVarFinset → β), L.BoundedFormula β n
+    ∀ {n : ℕ} (φ : L.Semiformula α n) (_f : φ.freeVarFinset → β), L.Semiformula β n
   | _n, falsum, _f => falsum
   | _n, equal t₁ t₂, f =>
     equal (t₁.restrictVarLeft (f ∘ Set.inclusion (subset_union_left _ _)))
@@ -489,48 +489,48 @@ def restrictFreeVar [DecidableEq α] :
     (φ₁.restrictFreeVar (f ∘ Set.inclusion (subset_union_left _ _))).imp
       (φ₂.restrictFreeVar (f ∘ Set.inclusion (subset_union_right _ _)))
   | _n, all φ, f => (φ.restrictFreeVar f).all
-#align first_order.language.bounded_formula.restrict_free_var FirstOrder.Language.BoundedFormula.restrictFreeVar
+#align first_order.language.bounded_formula.restrict_free_var FirstOrder.Language.Semiformula.restrictFreeVar
 
 -- Porting note: universes in different order
 /-- Places universal quantifiers on all extra variables of a bounded formula. -/
-def alls : ∀ {n}, L.BoundedFormula α n → L.Formula α
+def alls : ∀ {n}, L.Semiformula α n → L.Formula α
   | 0, φ => φ
   | _n + 1, φ => φ.all.alls
-#align first_order.language.bounded_formula.alls FirstOrder.Language.BoundedFormula.alls
+#align first_order.language.bounded_formula.alls FirstOrder.Language.Semiformula.alls
 
 -- Porting note: universes in different order
 /-- Places existential quantifiers on all extra variables of a bounded formula. -/
-def exs : ∀ {n}, L.BoundedFormula α n → L.Formula α
+def exs : ∀ {n}, L.Semiformula α n → L.Formula α
   | 0, φ => φ
   | _n + 1, φ => φ.ex.exs
-#align first_order.language.bounded_formula.exs FirstOrder.Language.BoundedFormula.exs
+#align first_order.language.bounded_formula.exs FirstOrder.Language.Semiformula.exs
 
 -- Porting note: universes in different order
 /-- Maps bounded formulas along a map of terms and a map of relations. -/
 def mapTermRel {g : ℕ → ℕ} (ft : ∀ n, L.Term (Sum α (Fin n)) → L'.Term (Sum β (Fin (g n))))
     (fr : ∀ n, L.Relations n → L'.Relations n)
-    (h : ∀ n, L'.BoundedFormula β (g (n + 1)) → L'.BoundedFormula β (g n + 1)) :
-    ∀ {n}, L.BoundedFormula α n → L'.BoundedFormula β (g n)
+    (h : ∀ n, L'.Semiformula β (g (n + 1)) → L'.Semiformula β (g n + 1)) :
+    ∀ {n}, L.Semiformula α n → L'.Semiformula β (g n)
   | _n, falsum => falsum
   | _n, equal t₁ t₂ => equal (ft _ t₁) (ft _ t₂)
   | _n, rel R ts => rel (fr _ R) fun i => ft _ (ts i)
   | _n, imp φ₁ φ₂ => (φ₁.mapTermRel ft fr h).imp (φ₂.mapTermRel ft fr h)
   | n, all φ => (h n (φ.mapTermRel ft fr h)).all
-#align first_order.language.bounded_formula.map_term_rel FirstOrder.Language.BoundedFormula.mapTermRel
+#align first_order.language.bounded_formula.map_term_rel FirstOrder.Language.Semiformula.mapTermRel
 
 /-- Raises all of the `Fin`-indexed variables of a formula greater than or equal to `m` by `n'`. -/
-def liftAt : ∀ {n : ℕ} (n' _m : ℕ), L.BoundedFormula α n → L.BoundedFormula α (n + n') :=
+def liftAt : ∀ {n : ℕ} (n' _m : ℕ), L.Semiformula α n → L.Semiformula α (n + n') :=
   fun {n} n' m φ =>
   φ.mapTermRel (fun k t => t.liftAt n' m) (fun _ => id) fun _ =>
     castLE (by rw [add_assoc, add_comm 1, add_assoc])
-#align first_order.language.bounded_formula.lift_at FirstOrder.Language.BoundedFormula.liftAt
+#align first_order.language.bounded_formula.lift_at FirstOrder.Language.Semiformula.liftAt
 
 @[simp]
 theorem mapTermRel_mapTermRel {L'' : Language}
     (ft : ∀ n, L.Term (Sum α (Fin n)) → L'.Term (Sum β (Fin n)))
     (fr : ∀ n, L.Relations n → L'.Relations n)
     (ft' : ∀ n, L'.Term (Sum β (Fin n)) → L''.Term (Sum γ (Fin n)))
-    (fr' : ∀ n, L'.Relations n → L''.Relations n) {n} (φ : L.BoundedFormula α n) :
+    (fr' : ∀ n, L'.Relations n → L''.Relations n) {n} (φ : L.Semiformula α n) :
     ((φ.mapTermRel ft fr fun _ => id).mapTermRel ft' fr' fun _ => id) =
       φ.mapTermRel (fun _ => ft' _ ∘ ft _) (fun _ => fr' _ ∘ fr _) fun _ => id := by
   induction' φ with _ _ _ _ _ _ _ _ _ _ _ ih1 ih2 _ _ ih3
@@ -539,10 +539,10 @@ theorem mapTermRel_mapTermRel {L'' : Language}
   · simp [mapTermRel]
   · simp [mapTermRel, ih1, ih2]
   · simp [mapTermRel, ih3]
-#align first_order.language.bounded_formula.map_term_rel_map_term_rel FirstOrder.Language.BoundedFormula.mapTermRel_mapTermRel
+#align first_order.language.bounded_formula.map_term_rel_map_term_rel FirstOrder.Language.Semiformula.mapTermRel_mapTermRel
 
 @[simp]
-theorem mapTermRel_id_id_id {n} (φ : L.BoundedFormula α n) :
+theorem mapTermRel_id_id_id {n} (φ : L.Semiformula α n) :
     (φ.mapTermRel (fun _ => id) (fun _ => id) fun _ => id) = φ := by
   induction' φ with _ _ _ _ _ _ _ _ _ _ _ ih1 ih2 _ _ ih3
   · rfl
@@ -550,22 +550,22 @@ theorem mapTermRel_id_id_id {n} (φ : L.BoundedFormula α n) :
   · simp [mapTermRel]
   · simp [mapTermRel, ih1, ih2]
   · simp [mapTermRel, ih3]
-#align first_order.language.bounded_formula.map_term_rel_id_id_id FirstOrder.Language.BoundedFormula.mapTermRel_id_id_id
+#align first_order.language.bounded_formula.map_term_rel_id_id_id FirstOrder.Language.Semiformula.mapTermRel_id_id_id
 
 /-- An equivalence of bounded formulas given by an equivalence of terms and an equivalence of
 relations. -/
 @[simps]
 def mapTermRelEquiv (ft : ∀ n, L.Term (Sum α (Fin n)) ≃ L'.Term (Sum β (Fin n)))
-    (fr : ∀ n, L.Relations n ≃ L'.Relations n) {n} : L.BoundedFormula α n ≃ L'.BoundedFormula β n :=
+    (fr : ∀ n, L.Relations n ≃ L'.Relations n) {n} : L.Semiformula α n ≃ L'.Semiformula β n :=
   ⟨mapTermRel (fun n => ft n) (fun n => fr n) fun _ => id,
     mapTermRel (fun n => (ft n).symm) (fun n => (fr n).symm) fun _ => id, fun φ => by simp, fun φ =>
     by simp⟩
-#align first_order.language.bounded_formula.map_term_rel_equiv FirstOrder.Language.BoundedFormula.mapTermRelEquiv
+#align first_order.language.bounded_formula.map_term_rel_equiv FirstOrder.Language.Semiformula.mapTermRelEquiv
 
 /-- A function to help relabel the variables in bounded formulas. -/
 def relabelAux (g : α → Sum β (Fin n)) (k : ℕ) : Sum α (Fin k) → Sum β (Fin (n + k)) :=
   Sum.map id finSumFinEquiv ∘ Equiv.sumAssoc _ _ _ ∘ Sum.map g id
-#align first_order.language.bounded_formula.relabel_aux FirstOrder.Language.BoundedFormula.relabelAux
+#align first_order.language.bounded_formula.relabel_aux FirstOrder.Language.Semiformula.relabelAux
 
 @[simp]
 theorem sum_elim_comp_relabelAux {m : ℕ} {g : α → Sum β (Fin n)} {v : β → M}
@@ -573,67 +573,67 @@ theorem sum_elim_comp_relabelAux {m : ℕ} {g : α → Sum β (Fin n)} {v : β �
     Sum.elim (Sum.elim v (xs ∘ castAdd m) ∘ g) (xs ∘ natAdd n) := by
   ext x
   cases' x with x x
-  · simp only [BoundedFormula.relabelAux, Function.comp_apply, Sum.map_inl, Sum.elim_inl]
+  · simp only [Semiformula.relabelAux, Function.comp_apply, Sum.map_inl, Sum.elim_inl]
     cases' g x with l r <;> simp
-  · simp [BoundedFormula.relabelAux]
-#align first_order.language.bounded_formula.sum_elim_comp_relabel_aux FirstOrder.Language.BoundedFormula.sum_elim_comp_relabelAux
+  · simp [Semiformula.relabelAux]
+#align first_order.language.bounded_formula.sum_elim_comp_relabel_aux FirstOrder.Language.Semiformula.sum_elim_comp_relabelAux
 
 @[simp]
 theorem relabelAux_sum_inl (k : ℕ) :
     relabelAux (Sum.inl : α → Sum α (Fin n)) k = Sum.map id (natAdd n) := by
   ext x
   cases x <;> · simp [relabelAux]
-#align first_order.language.bounded_formula.relabel_aux_sum_inl FirstOrder.Language.BoundedFormula.relabelAux_sum_inl
+#align first_order.language.bounded_formula.relabel_aux_sum_inl FirstOrder.Language.Semiformula.relabelAux_sum_inl
 
 /-- Relabels a bounded formula's variables along a particular function. -/
-def relabel (g : α → Sum β (Fin n)) {k} (φ : L.BoundedFormula α k) : L.BoundedFormula β (n + k) :=
+def relabel (g : α → Sum β (Fin n)) {k} (φ : L.Semiformula α k) : L.Semiformula β (n + k) :=
   φ.mapTermRel (fun _ t => t.relabel (relabelAux g _)) (fun _ => id) fun _ =>
     castLE (ge_of_eq (add_assoc _ _ _))
-#align first_order.language.bounded_formula.relabel FirstOrder.Language.BoundedFormula.relabel
+#align first_order.language.bounded_formula.relabel FirstOrder.Language.Semiformula.relabel
 
 /-- Relabels a bounded formula's free variables along a bijection. -/
-def relabelEquiv (g : α ≃ β) {k} : L.BoundedFormula α k ≃ L.BoundedFormula β k :=
+def relabelEquiv (g : α ≃ β) {k} : L.Semiformula α k ≃ L.Semiformula β k :=
   mapTermRelEquiv (fun _n => Term.relabelEquiv (g.sumCongr (_root_.Equiv.refl _)))
     fun _n => _root_.Equiv.refl _
-#align first_order.language.bounded_formula.relabel_equiv FirstOrder.Language.BoundedFormula.relabelEquiv
+#align first_order.language.bounded_formula.relabel_equiv FirstOrder.Language.Semiformula.relabelEquiv
 
 @[simp]
 theorem relabel_falsum (g : α → Sum β (Fin n)) {k} :
-    (falsum : L.BoundedFormula α k).relabel g = falsum :=
+    (falsum : L.Semiformula α k).relabel g = falsum :=
   rfl
-#align first_order.language.bounded_formula.relabel_falsum FirstOrder.Language.BoundedFormula.relabel_falsum
+#align first_order.language.bounded_formula.relabel_falsum FirstOrder.Language.Semiformula.relabel_falsum
 
 @[simp]
-theorem relabel_bot (g : α → Sum β (Fin n)) {k} : (⊥ : L.BoundedFormula α k).relabel g = ⊥ :=
+theorem relabel_bot (g : α → Sum β (Fin n)) {k} : (⊥ : L.Semiformula α k).relabel g = ⊥ :=
   rfl
-#align first_order.language.bounded_formula.relabel_bot FirstOrder.Language.BoundedFormula.relabel_bot
+#align first_order.language.bounded_formula.relabel_bot FirstOrder.Language.Semiformula.relabel_bot
 
 @[simp]
-theorem relabel_imp (g : α → Sum β (Fin n)) {k} (φ ψ : L.BoundedFormula α k) :
+theorem relabel_imp (g : α → Sum β (Fin n)) {k} (φ ψ : L.Semiformula α k) :
     (φ.imp ψ).relabel g = (φ.relabel g).imp (ψ.relabel g) :=
   rfl
-#align first_order.language.bounded_formula.relabel_imp FirstOrder.Language.BoundedFormula.relabel_imp
+#align first_order.language.bounded_formula.relabel_imp FirstOrder.Language.Semiformula.relabel_imp
 
 @[simp]
-theorem relabel_not (g : α → Sum β (Fin n)) {k} (φ : L.BoundedFormula α k) :
-    φ.not.relabel g = (φ.relabel g).not := by simp [BoundedFormula.not]
-#align first_order.language.bounded_formula.relabel_not FirstOrder.Language.BoundedFormula.relabel_not
+theorem relabel_not (g : α → Sum β (Fin n)) {k} (φ : L.Semiformula α k) :
+    φ.not.relabel g = (φ.relabel g).not := by simp [Semiformula.not]
+#align first_order.language.bounded_formula.relabel_not FirstOrder.Language.Semiformula.relabel_not
 
 @[simp]
-theorem relabel_all (g : α → Sum β (Fin n)) {k} (φ : L.BoundedFormula α (k + 1)) :
+theorem relabel_all (g : α → Sum β (Fin n)) {k} (φ : L.Semiformula α (k + 1)) :
     φ.all.relabel g = (φ.relabel g).all := by
   rw [relabel, mapTermRel, relabel]
   simp
-#align first_order.language.bounded_formula.relabel_all FirstOrder.Language.BoundedFormula.relabel_all
+#align first_order.language.bounded_formula.relabel_all FirstOrder.Language.Semiformula.relabel_all
 
 @[simp]
-theorem relabel_ex (g : α → Sum β (Fin n)) {k} (φ : L.BoundedFormula α (k + 1)) :
-    φ.ex.relabel g = (φ.relabel g).ex := by simp [BoundedFormula.ex]
-#align first_order.language.bounded_formula.relabel_ex FirstOrder.Language.BoundedFormula.relabel_ex
+theorem relabel_ex (g : α → Sum β (Fin n)) {k} (φ : L.Semiformula α (k + 1)) :
+    φ.ex.relabel g = (φ.relabel g).ex := by simp [Semiformula.ex]
+#align first_order.language.bounded_formula.relabel_ex FirstOrder.Language.Semiformula.relabel_ex
 
 @[simp]
-theorem relabel_sum_inl (φ : L.BoundedFormula α n) :
-    (φ.relabel Sum.inl : L.BoundedFormula α (0 + n)) = φ.castLE (ge_of_eq (zero_add n)) := by
+theorem relabel_sum_inl (φ : L.Semiformula α n) :
+    (φ.relabel Sum.inl : L.Semiformula α (0 + n)) = φ.castLE (ge_of_eq (zero_add n)) := by
   simp only [relabel, relabelAux_sum_inl]
   induction' φ with _ _ _ _ _ _ _ _ _ _ _ ih1 ih2 _ _ ih3
   · rfl
@@ -641,23 +641,23 @@ theorem relabel_sum_inl (φ : L.BoundedFormula α n) :
   · simp [Fin.natAdd_zero, castLE_of_eq, mapTermRel]; rfl
   · simp [mapTermRel, ih1, ih2]
   · simp [mapTermRel, ih3, castLE]
-#align first_order.language.bounded_formula.relabel_sum_inl FirstOrder.Language.BoundedFormula.relabel_sum_inl
+#align first_order.language.bounded_formula.relabel_sum_inl FirstOrder.Language.Semiformula.relabel_sum_inl
 
 /-- Substitutes the variables in a given formula with terms. -/
-def subst {n : ℕ} (φ : L.BoundedFormula α n) (f : α → L.Term β) : L.BoundedFormula β n :=
+def subst {n : ℕ} (φ : L.Semiformula α n) (f : α → L.Term β) : L.Semiformula β n :=
   φ.mapTermRel (fun _ t => t.subst (Sum.elim (Term.relabel Sum.inl ∘ f) (var ∘ Sum.inr)))
     (fun _ => id) fun _ => id
-#align first_order.language.bounded_formula.subst FirstOrder.Language.BoundedFormula.subst
+#align first_order.language.bounded_formula.subst FirstOrder.Language.Semiformula.subst
 
 /-- A bijection sending formulas with constants to formulas with extra variables. -/
-def constantsVarsEquiv : L[[γ]].BoundedFormula α n ≃ L.BoundedFormula (Sum γ α) n :=
+def constantsVarsEquiv : L[[γ]].Semiformula α n ≃ L.Semiformula (Sum γ α) n :=
   mapTermRelEquiv (fun _ => Term.constantsVarsEquivLeft) fun _ => Equiv.sumEmpty _ _
-#align first_order.language.bounded_formula.constants_vars_equiv FirstOrder.Language.BoundedFormula.constantsVarsEquiv
+#align first_order.language.bounded_formula.constants_vars_equiv FirstOrder.Language.Semiformula.constantsVarsEquiv
 
 -- Porting note: universes in different order
 /-- Turns the extra variables of a bounded formula into free variables. -/
 @[simp]
-def toFormula : ∀ {n : ℕ}, L.BoundedFormula α n → L.Formula (Sum α (Fin n))
+def toFormula : ∀ {n : ℕ}, L.Semiformula α n → L.Formula (Sum α (Fin n))
   | _n, falsum => falsum
   | _n, equal t₁ t₂ => t₁.equal t₂
   | _n, rel R ts => R.formula ts
@@ -665,147 +665,147 @@ def toFormula : ∀ {n : ℕ}, L.BoundedFormula α n → L.Formula (Sum α (Fin 
   | _n, all φ =>
     (φ.toFormula.relabel
         (Sum.elim (Sum.inl ∘ Sum.inl) (Sum.map Sum.inr id ∘ finSumFinEquiv.symm))).all
-#align first_order.language.bounded_formula.to_formula FirstOrder.Language.BoundedFormula.toFormula
+#align first_order.language.bounded_formula.to_formula FirstOrder.Language.Semiformula.toFormula
 
 /-- take the disjunction of a finite set of formulas -/
-noncomputable def iSup (s : Finset β) (f : β → L.BoundedFormula α n) : L.BoundedFormula α n :=
+noncomputable def iSup (s : Finset β) (f : β → L.Semiformula α n) : L.Semiformula α n :=
   (s.toList.map f).foldr (. ⊔ .) ⊥
 
 /-- take the conjunction of a finite set of formulas -/
-noncomputable def iInf (s : Finset β) (f : β → L.BoundedFormula α n) : L.BoundedFormula α n :=
+noncomputable def iInf (s : Finset β) (f : β → L.Semiformula α n) : L.Semiformula α n :=
   (s.toList.map f).foldr (. ⊓ .) ⊤
 
 
-variable {l : ℕ} {φ ψ : L.BoundedFormula α l} {θ : L.BoundedFormula α l.succ}
+variable {l : ℕ} {φ ψ : L.Semiformula α l} {θ : L.Semiformula α l.succ}
 
 variable {v : α → M} {xs : Fin l → M}
 
 /-- An atomic formula is either equality or a relation symbol applied to terms.
   Note that `⊥` and `⊤` are not considered atomic in this convention. -/
-inductive IsAtomic : L.BoundedFormula α n → Prop
+inductive IsAtomic : L.Semiformula α n → Prop
   | equal (t₁ t₂ : L.Term (Sum α (Fin n))) : IsAtomic (t₁.bdEqual t₂)
   | rel {l : ℕ} (R : L.Relations l) (ts : Fin l → L.Term (Sum α (Fin n))) :
-    IsAtomic (R.boundedFormula ts)
-#align first_order.language.bounded_formula.is_atomic FirstOrder.Language.BoundedFormula.IsAtomic
+    IsAtomic (R.semiformula ts)
+#align first_order.language.bounded_formula.is_atomic FirstOrder.Language.Semiformula.IsAtomic
 
-theorem not_all_isAtomic (φ : L.BoundedFormula α (n + 1)) : ¬φ.all.IsAtomic := fun con => by
+theorem not_all_isAtomic (φ : L.Semiformula α (n + 1)) : ¬φ.all.IsAtomic := fun con => by
   cases con
-#align first_order.language.bounded_formula.not_all_is_atomic FirstOrder.Language.BoundedFormula.not_all_isAtomic
+#align first_order.language.bounded_formula.not_all_is_atomic FirstOrder.Language.Semiformula.not_all_isAtomic
 
-theorem not_ex_isAtomic (φ : L.BoundedFormula α (n + 1)) : ¬φ.ex.IsAtomic := fun con => by cases con
-#align first_order.language.bounded_formula.not_ex_is_atomic FirstOrder.Language.BoundedFormula.not_ex_isAtomic
+theorem not_ex_isAtomic (φ : L.Semiformula α (n + 1)) : ¬φ.ex.IsAtomic := fun con => by cases con
+#align first_order.language.bounded_formula.not_ex_is_atomic FirstOrder.Language.Semiformula.not_ex_isAtomic
 
-theorem IsAtomic.relabel {m : ℕ} {φ : L.BoundedFormula α m} (h : φ.IsAtomic)
+theorem IsAtomic.relabel {m : ℕ} {φ : L.Semiformula α m} (h : φ.IsAtomic)
     (f : α → Sum β (Fin n)) : (φ.relabel f).IsAtomic :=
   IsAtomic.recOn h (fun _ _ => IsAtomic.equal _ _) fun _ _ => IsAtomic.rel _ _
-#align first_order.language.bounded_formula.is_atomic.relabel FirstOrder.Language.BoundedFormula.IsAtomic.relabel
+#align first_order.language.bounded_formula.is_atomic.relabel FirstOrder.Language.Semiformula.IsAtomic.relabel
 
 theorem IsAtomic.liftAt {k m : ℕ} (h : IsAtomic φ) : (φ.liftAt k m).IsAtomic :=
   IsAtomic.recOn h (fun _ _ => IsAtomic.equal _ _) fun _ _ => IsAtomic.rel _ _
-#align first_order.language.bounded_formula.is_atomic.lift_at FirstOrder.Language.BoundedFormula.IsAtomic.liftAt
+#align first_order.language.bounded_formula.is_atomic.lift_at FirstOrder.Language.Semiformula.IsAtomic.liftAt
 
 theorem IsAtomic.castLE {h : l ≤ n} (hφ : IsAtomic φ) : (φ.castLE h).IsAtomic :=
   IsAtomic.recOn hφ (fun _ _ => IsAtomic.equal _ _) fun _ _ => IsAtomic.rel _ _
-#align first_order.language.bounded_formula.is_atomic.cast_le FirstOrder.Language.BoundedFormula.IsAtomic.castLE
+#align first_order.language.bounded_formula.is_atomic.cast_le FirstOrder.Language.Semiformula.IsAtomic.castLE
 
 /-- A quantifier-free formula is a formula defined without quantifiers. These are all equivalent
 to boolean combinations of atomic formulas. -/
-inductive IsQF : L.BoundedFormula α n → Prop
+inductive IsQF : L.Semiformula α n → Prop
   | falsum : IsQF falsum
   | of_isAtomic {φ} (h : IsAtomic φ) : IsQF φ
   | imp {φ₁ φ₂} (h₁ : IsQF φ₁) (h₂ : IsQF φ₂) : IsQF (φ₁.imp φ₂)
-#align first_order.language.bounded_formula.is_qf FirstOrder.Language.BoundedFormula.IsQF
+#align first_order.language.bounded_formula.is_qf FirstOrder.Language.Semiformula.IsQF
 
-theorem IsAtomic.isQF {φ : L.BoundedFormula α n} : IsAtomic φ → IsQF φ :=
+theorem IsAtomic.isQF {φ : L.Semiformula α n} : IsAtomic φ → IsQF φ :=
   IsQF.of_isAtomic
-#align first_order.language.bounded_formula.is_atomic.is_qf FirstOrder.Language.BoundedFormula.IsAtomic.isQF
+#align first_order.language.bounded_formula.is_atomic.is_qf FirstOrder.Language.Semiformula.IsAtomic.isQF
 
-theorem isQF_bot : IsQF (⊥ : L.BoundedFormula α n) :=
+theorem isQF_bot : IsQF (⊥ : L.Semiformula α n) :=
   IsQF.falsum
-#align first_order.language.bounded_formula.is_qf_bot FirstOrder.Language.BoundedFormula.isQF_bot
+#align first_order.language.bounded_formula.is_qf_bot FirstOrder.Language.Semiformula.isQF_bot
 
-theorem IsQF.not {φ : L.BoundedFormula α n} (h : IsQF φ) : IsQF φ.not :=
+theorem IsQF.not {φ : L.Semiformula α n} (h : IsQF φ) : IsQF φ.not :=
   h.imp isQF_bot
-#align first_order.language.bounded_formula.is_qf.not FirstOrder.Language.BoundedFormula.IsQF.not
+#align first_order.language.bounded_formula.is_qf.not FirstOrder.Language.Semiformula.IsQF.not
 
-theorem IsQF.relabel {m : ℕ} {φ : L.BoundedFormula α m} (h : φ.IsQF) (f : α → Sum β (Fin n)) :
+theorem IsQF.relabel {m : ℕ} {φ : L.Semiformula α m} (h : φ.IsQF) (f : α → Sum β (Fin n)) :
     (φ.relabel f).IsQF :=
   IsQF.recOn h isQF_bot (fun h => (h.relabel f).isQF) fun _ _ h1 h2 => h1.imp h2
-#align first_order.language.bounded_formula.is_qf.relabel FirstOrder.Language.BoundedFormula.IsQF.relabel
+#align first_order.language.bounded_formula.is_qf.relabel FirstOrder.Language.Semiformula.IsQF.relabel
 
 theorem IsQF.liftAt {k m : ℕ} (h : IsQF φ) : (φ.liftAt k m).IsQF :=
   IsQF.recOn h isQF_bot (fun ih => ih.liftAt.isQF) fun _ _ ih1 ih2 => ih1.imp ih2
-#align first_order.language.bounded_formula.is_qf.lift_at FirstOrder.Language.BoundedFormula.IsQF.liftAt
+#align first_order.language.bounded_formula.is_qf.lift_at FirstOrder.Language.Semiformula.IsQF.liftAt
 
 theorem IsQF.castLE {h : l ≤ n} (hφ : IsQF φ) : (φ.castLE h).IsQF :=
   IsQF.recOn hφ isQF_bot (fun ih => ih.castLE.isQF) fun _ _ ih1 ih2 => ih1.imp ih2
-#align first_order.language.bounded_formula.is_qf.cast_le FirstOrder.Language.BoundedFormula.IsQF.castLE
+#align first_order.language.bounded_formula.is_qf.cast_le FirstOrder.Language.Semiformula.IsQF.castLE
 
-theorem not_all_isQF (φ : L.BoundedFormula α (n + 1)) : ¬φ.all.IsQF := fun con => by
+theorem not_all_isQF (φ : L.Semiformula α (n + 1)) : ¬φ.all.IsQF := fun con => by
   cases' con with _ con
   exact φ.not_all_isAtomic con
-#align first_order.language.bounded_formula.not_all_is_qf FirstOrder.Language.BoundedFormula.not_all_isQF
+#align first_order.language.bounded_formula.not_all_is_qf FirstOrder.Language.Semiformula.not_all_isQF
 
-theorem not_ex_isQF (φ : L.BoundedFormula α (n + 1)) : ¬φ.ex.IsQF := fun con => by
+theorem not_ex_isQF (φ : L.Semiformula α (n + 1)) : ¬φ.ex.IsQF := fun con => by
   cases' con with _ con _ _ con
   · exact φ.not_ex_isAtomic con
   · exact not_all_isQF _ con
-#align first_order.language.bounded_formula.not_ex_is_qf FirstOrder.Language.BoundedFormula.not_ex_isQF
+#align first_order.language.bounded_formula.not_ex_is_qf FirstOrder.Language.Semiformula.not_ex_isQF
 
 /-- Indicates that a bounded formula is in prenex normal form - that is, it consists of quantifiers
   applied to a quantifier-free formula. -/
-inductive IsPrenex : ∀ {n}, L.BoundedFormula α n → Prop
-  | of_isQF {n} {φ : L.BoundedFormula α n} (h : IsQF φ) : IsPrenex φ
-  | all {n} {φ : L.BoundedFormula α (n + 1)} (h : IsPrenex φ) : IsPrenex φ.all
-  | ex {n} {φ : L.BoundedFormula α (n + 1)} (h : IsPrenex φ) : IsPrenex φ.ex
-#align first_order.language.bounded_formula.is_prenex FirstOrder.Language.BoundedFormula.IsPrenex
+inductive IsPrenex : ∀ {n}, L.Semiformula α n → Prop
+  | of_isQF {n} {φ : L.Semiformula α n} (h : IsQF φ) : IsPrenex φ
+  | all {n} {φ : L.Semiformula α (n + 1)} (h : IsPrenex φ) : IsPrenex φ.all
+  | ex {n} {φ : L.Semiformula α (n + 1)} (h : IsPrenex φ) : IsPrenex φ.ex
+#align first_order.language.bounded_formula.is_prenex FirstOrder.Language.Semiformula.IsPrenex
 
-theorem IsQF.isPrenex {φ : L.BoundedFormula α n} : IsQF φ → IsPrenex φ :=
+theorem IsQF.isPrenex {φ : L.Semiformula α n} : IsQF φ → IsPrenex φ :=
   IsPrenex.of_isQF
-#align first_order.language.bounded_formula.is_qf.is_prenex FirstOrder.Language.BoundedFormula.IsQF.isPrenex
+#align first_order.language.bounded_formula.is_qf.is_prenex FirstOrder.Language.Semiformula.IsQF.isPrenex
 
-theorem IsAtomic.isPrenex {φ : L.BoundedFormula α n} (h : IsAtomic φ) : IsPrenex φ :=
+theorem IsAtomic.isPrenex {φ : L.Semiformula α n} (h : IsAtomic φ) : IsPrenex φ :=
   h.isQF.isPrenex
-#align first_order.language.bounded_formula.is_atomic.is_prenex FirstOrder.Language.BoundedFormula.IsAtomic.isPrenex
+#align first_order.language.bounded_formula.is_atomic.is_prenex FirstOrder.Language.Semiformula.IsAtomic.isPrenex
 
-theorem IsPrenex.induction_on_all_not {P : ∀ {n}, L.BoundedFormula α n → Prop}
-    {φ : L.BoundedFormula α n} (h : IsPrenex φ)
-    (hq : ∀ {m} {ψ : L.BoundedFormula α m}, ψ.IsQF → P ψ)
-    (ha : ∀ {m} {ψ : L.BoundedFormula α (m + 1)}, P ψ → P ψ.all)
-    (hn : ∀ {m} {ψ : L.BoundedFormula α m}, P ψ → P ψ.not) : P φ :=
+theorem IsPrenex.induction_on_all_not {P : ∀ {n}, L.Semiformula α n → Prop}
+    {φ : L.Semiformula α n} (h : IsPrenex φ)
+    (hq : ∀ {m} {ψ : L.Semiformula α m}, ψ.IsQF → P ψ)
+    (ha : ∀ {m} {ψ : L.Semiformula α (m + 1)}, P ψ → P ψ.all)
+    (hn : ∀ {m} {ψ : L.Semiformula α m}, P ψ → P ψ.not) : P φ :=
   IsPrenex.recOn h hq (fun _ => ha) fun _ ih => hn (ha (hn ih))
-#align first_order.language.bounded_formula.is_prenex.induction_on_all_not FirstOrder.Language.BoundedFormula.IsPrenex.induction_on_all_not
+#align first_order.language.bounded_formula.is_prenex.induction_on_all_not FirstOrder.Language.Semiformula.IsPrenex.induction_on_all_not
 
-theorem IsPrenex.relabel {m : ℕ} {φ : L.BoundedFormula α m} (h : φ.IsPrenex)
+theorem IsPrenex.relabel {m : ℕ} {φ : L.Semiformula α m} (h : φ.IsPrenex)
     (f : α → Sum β (Fin n)) : (φ.relabel f).IsPrenex :=
   IsPrenex.recOn h (fun h => (h.relabel f).isPrenex) (fun _ h => by simp [h.all])
     fun _ h => by simp [h.ex]
-#align first_order.language.bounded_formula.is_prenex.relabel FirstOrder.Language.BoundedFormula.IsPrenex.relabel
+#align first_order.language.bounded_formula.is_prenex.relabel FirstOrder.Language.Semiformula.IsPrenex.relabel
 
 theorem IsPrenex.castLE (hφ : IsPrenex φ) : ∀ {n} {h : l ≤ n}, (φ.castLE h).IsPrenex :=
   IsPrenex.recOn (motive := @fun l φ _ => ∀ (n : ℕ) (h : l ≤ n), (φ.castLE h).IsPrenex) hφ
     (@fun _ _ ih _ _ => ih.castLE.isPrenex)
     (@fun _ _ _ ih _ _ => (ih _ _).all)
     (@fun _ _ _ ih _ _ => (ih _ _).ex) _ _
-#align first_order.language.bounded_formula.is_prenex.cast_le FirstOrder.Language.BoundedFormula.IsPrenex.castLE
+#align first_order.language.bounded_formula.is_prenex.cast_le FirstOrder.Language.Semiformula.IsPrenex.castLE
 
 theorem IsPrenex.liftAt {k m : ℕ} (h : IsPrenex φ) : (φ.liftAt k m).IsPrenex :=
   IsPrenex.recOn h (fun ih => ih.liftAt.isPrenex) (fun _ ih => ih.castLE.all)
     fun _ ih => ih.castLE.ex
-#align first_order.language.bounded_formula.is_prenex.lift_at FirstOrder.Language.BoundedFormula.IsPrenex.liftAt
+#align first_order.language.bounded_formula.is_prenex.lift_at FirstOrder.Language.Semiformula.IsPrenex.liftAt
 
 -- Porting note: universes in different order
-/-- An auxiliary operation to `FirstOrder.Language.BoundedFormula.toPrenex`.
+/-- An auxiliary operation to `FirstOrder.Language.Semiformula.toPrenex`.
   If `φ` is quantifier-free and `ψ` is in prenex normal form, then `φ.toPrenexImpRight ψ`
   is a prenex normal form for `φ.imp ψ`. -/
-def toPrenexImpRight : ∀ {n}, L.BoundedFormula α n → L.BoundedFormula α n → L.BoundedFormula α n
-  | n, φ, BoundedFormula.ex ψ => ((φ.liftAt 1 n).toPrenexImpRight ψ).ex
+def toPrenexImpRight : ∀ {n}, L.Semiformula α n → L.Semiformula α n → L.Semiformula α n
+  | n, φ, Semiformula.ex ψ => ((φ.liftAt 1 n).toPrenexImpRight ψ).ex
   | n, φ, all ψ => ((φ.liftAt 1 n).toPrenexImpRight ψ).all
   | _n, φ, ψ => φ.imp ψ
-#align first_order.language.bounded_formula.to_prenex_imp_right FirstOrder.Language.BoundedFormula.toPrenexImpRight
+#align first_order.language.bounded_formula.to_prenex_imp_right FirstOrder.Language.Semiformula.toPrenexImpRight
 
-theorem IsQF.toPrenexImpRight {φ : L.BoundedFormula α n} :
-    ∀ {ψ : L.BoundedFormula α n}, IsQF ψ → φ.toPrenexImpRight ψ = φ.imp ψ
+theorem IsQF.toPrenexImpRight {φ : L.Semiformula α n} :
+    ∀ {ψ : L.Semiformula α n}, IsQF ψ → φ.toPrenexImpRight ψ = φ.imp ψ
   | _, IsQF.falsum => rfl
   | _, IsQF.of_isAtomic (IsAtomic.equal _ _) => rfl
   | _, IsQF.of_isAtomic (IsAtomic.rel _ _) => rfl
@@ -813,29 +813,29 @@ theorem IsQF.toPrenexImpRight {φ : L.BoundedFormula α n} :
   | _, IsQF.imp (IsQF.of_isAtomic (IsAtomic.equal _ _)) _ => rfl
   | _, IsQF.imp (IsQF.of_isAtomic (IsAtomic.rel _ _)) _ => rfl
   | _, IsQF.imp (IsQF.imp _ _) _ => rfl
-#align first_order.language.bounded_formula.is_qf.to_prenex_imp_right FirstOrder.Language.BoundedFormula.IsQF.toPrenexImpRight
+#align first_order.language.bounded_formula.is_qf.to_prenex_imp_right FirstOrder.Language.Semiformula.IsQF.toPrenexImpRight
 
-theorem isPrenex_toPrenexImpRight {φ ψ : L.BoundedFormula α n} (hφ : IsQF φ) (hψ : IsPrenex ψ) :
+theorem isPrenex_toPrenexImpRight {φ ψ : L.Semiformula α n} (hφ : IsQF φ) (hψ : IsPrenex ψ) :
     IsPrenex (φ.toPrenexImpRight ψ) := by
   induction' hψ with _ _ hψ _ _ _ ih1 _ _ _ ih2
   · rw [hψ.toPrenexImpRight]
     exact (hφ.imp hψ).isPrenex
   · exact (ih1 hφ.liftAt).all
   · exact (ih2 hφ.liftAt).ex
-#align first_order.language.bounded_formula.is_prenex_to_prenex_imp_right FirstOrder.Language.BoundedFormula.isPrenex_toPrenexImpRight
+#align first_order.language.bounded_formula.is_prenex_to_prenex_imp_right FirstOrder.Language.Semiformula.isPrenex_toPrenexImpRight
 
 -- Porting note: universes in different order
-/-- An auxiliary operation to `FirstOrder.Language.BoundedFormula.toPrenex`.
+/-- An auxiliary operation to `FirstOrder.Language.Semiformula.toPrenex`.
   If `φ` and `ψ` are in prenex normal form, then `φ.toPrenexImp ψ`
   is a prenex normal form for `φ.imp ψ`. -/
-def toPrenexImp : ∀ {n}, L.BoundedFormula α n → L.BoundedFormula α n → L.BoundedFormula α n
-  | n, BoundedFormula.ex φ, ψ => (φ.toPrenexImp (ψ.liftAt 1 n)).all
+def toPrenexImp : ∀ {n}, L.Semiformula α n → L.Semiformula α n → L.Semiformula α n
+  | n, Semiformula.ex φ, ψ => (φ.toPrenexImp (ψ.liftAt 1 n)).all
   | n, all φ, ψ => (φ.toPrenexImp (ψ.liftAt 1 n)).ex
   | _, φ, ψ => φ.toPrenexImpRight ψ
-#align first_order.language.bounded_formula.to_prenex_imp FirstOrder.Language.BoundedFormula.toPrenexImp
+#align first_order.language.bounded_formula.to_prenex_imp FirstOrder.Language.Semiformula.toPrenexImp
 
 theorem IsQF.toPrenexImp :
-    ∀ {φ ψ : L.BoundedFormula α n}, φ.IsQF → φ.toPrenexImp ψ = φ.toPrenexImpRight ψ
+    ∀ {φ ψ : L.Semiformula α n}, φ.IsQF → φ.toPrenexImp ψ = φ.toPrenexImpRight ψ
   | _, _, IsQF.falsum => rfl
   | _, _, IsQF.of_isAtomic (IsAtomic.equal _ _) => rfl
   | _, _, IsQF.of_isAtomic (IsAtomic.rel _ _) => rfl
@@ -843,84 +843,84 @@ theorem IsQF.toPrenexImp :
   | _, _, IsQF.imp (IsQF.of_isAtomic (IsAtomic.equal _ _)) _ => rfl
   | _, _, IsQF.imp (IsQF.of_isAtomic (IsAtomic.rel _ _)) _ => rfl
   | _, _, IsQF.imp (IsQF.imp _ _) _ => rfl
-#align first_order.language.bounded_formula.is_qf.to_prenex_imp FirstOrder.Language.BoundedFormula.IsQF.toPrenexImp
+#align first_order.language.bounded_formula.is_qf.to_prenex_imp FirstOrder.Language.Semiformula.IsQF.toPrenexImp
 
-theorem isPrenex_toPrenexImp {φ ψ : L.BoundedFormula α n} (hφ : IsPrenex φ) (hψ : IsPrenex ψ) :
+theorem isPrenex_toPrenexImp {φ ψ : L.Semiformula α n} (hφ : IsPrenex φ) (hψ : IsPrenex ψ) :
     IsPrenex (φ.toPrenexImp ψ) := by
   induction' hφ with _ _ hφ _ _ _ ih1 _ _ _ ih2
   · rw [hφ.toPrenexImp]
     exact isPrenex_toPrenexImpRight hφ hψ
   · exact (ih1 hψ.liftAt).ex
   · exact (ih2 hψ.liftAt).all
-#align first_order.language.bounded_formula.is_prenex_to_prenex_imp FirstOrder.Language.BoundedFormula.isPrenex_toPrenexImp
+#align first_order.language.bounded_formula.is_prenex_to_prenex_imp FirstOrder.Language.Semiformula.isPrenex_toPrenexImp
 
 -- Porting note: universes in different order
 /-- For any bounded formula `φ`, `φ.toPrenex` is a semantically-equivalent formula in prenex normal
   form. -/
-def toPrenex : ∀ {n}, L.BoundedFormula α n → L.BoundedFormula α n
+def toPrenex : ∀ {n}, L.Semiformula α n → L.Semiformula α n
   | _, falsum => ⊥
   | _, equal t₁ t₂ => t₁.bdEqual t₂
   | _, rel R ts => rel R ts
   | _, imp f₁ f₂ => f₁.toPrenex.toPrenexImp f₂.toPrenex
   | _, all f => f.toPrenex.all
-#align first_order.language.bounded_formula.to_prenex FirstOrder.Language.BoundedFormula.toPrenex
+#align first_order.language.bounded_formula.to_prenex FirstOrder.Language.Semiformula.toPrenex
 
-theorem toPrenex_isPrenex (φ : L.BoundedFormula α n) : φ.toPrenex.IsPrenex :=
-  BoundedFormula.recOn φ isQF_bot.isPrenex (fun _ _ => (IsAtomic.equal _ _).isPrenex)
+theorem toPrenex_isPrenex (φ : L.Semiformula α n) : φ.toPrenex.IsPrenex :=
+  Semiformula.recOn φ isQF_bot.isPrenex (fun _ _ => (IsAtomic.equal _ _).isPrenex)
     (fun _ _ => (IsAtomic.rel _ _).isPrenex) (fun _ _ h1 h2 => isPrenex_toPrenexImp h1 h2)
     fun _ => IsPrenex.all
-#align first_order.language.bounded_formula.to_prenex_is_prenex FirstOrder.Language.BoundedFormula.toPrenex_isPrenex
+#align first_order.language.bounded_formula.to_prenex_is_prenex FirstOrder.Language.Semiformula.toPrenex_isPrenex
 
-end BoundedFormula
+end Semiformula
 
 namespace LHom
 
-open BoundedFormula
+open Semiformula
 
 -- Porting note: universes in different order
 /-- Maps a bounded formula's symbols along a language map. -/
 @[simp]
-def onBoundedFormula (g : L →ᴸ L') : ∀ {k : ℕ}, L.BoundedFormula α k → L'.BoundedFormula α k
+def onSemiformula (g : L →ᴸ L') : ∀ {k : ℕ}, L.Semiformula α k → L'.Semiformula α k
   | _k, falsum => falsum
   | _k, equal t₁ t₂ => (g.onTerm t₁).bdEqual (g.onTerm t₂)
-  | _k, rel R ts => (g.onRelation R).boundedFormula (g.onTerm ∘ ts)
-  | _k, imp f₁ f₂ => (onBoundedFormula g f₁).imp (onBoundedFormula g f₂)
-  | _k, all f => (onBoundedFormula g f).all
+  | _k, rel R ts => (g.onRelation R).semiformula (g.onTerm ∘ ts)
+  | _k, imp f₁ f₂ => (onSemiformula g f₁).imp (onSemiformula g f₂)
+  | _k, all f => (onSemiformula g f).all
 set_option linter.uppercaseLean3 false in
-#align first_order.language.Lhom.on_bounded_formula FirstOrder.Language.LHom.onBoundedFormula
+#align first_order.language.Lhom.on_bounded_formula FirstOrder.Language.LHom.onSemiformula
 
 @[simp]
-theorem id_onBoundedFormula :
-    ((LHom.id L).onBoundedFormula : L.BoundedFormula α n → L.BoundedFormula α n) = id := by
+theorem id_onSemiformula :
+    ((LHom.id L).onSemiformula : L.Semiformula α n → L.Semiformula α n) = id := by
   ext f
   induction' f with _ _ _ _ _ _ _ _ _ _ _ ih1 ih2 _ _ ih3
   · rfl
-  · rw [onBoundedFormula, LHom.id_onTerm, id.def, id.def, id.def, Term.bdEqual]
-  · rw [onBoundedFormula, LHom.id_onTerm]
+  · rw [onSemiformula, LHom.id_onTerm, id.def, id.def, id.def, Term.bdEqual]
+  · rw [onSemiformula, LHom.id_onTerm]
     rfl
-  · rw [onBoundedFormula, ih1, ih2, id.def, id.def, id.def]
-  · rw [onBoundedFormula, ih3, id.def, id.def]
+  · rw [onSemiformula, ih1, ih2, id.def, id.def, id.def]
+  · rw [onSemiformula, ih3, id.def, id.def]
 set_option linter.uppercaseLean3 false in
-#align first_order.language.Lhom.id_on_bounded_formula FirstOrder.Language.LHom.id_onBoundedFormula
+#align first_order.language.Lhom.id_on_bounded_formula FirstOrder.Language.LHom.id_onSemiformula
 
 @[simp]
-theorem comp_onBoundedFormula {L'' : Language} (φ : L' →ᴸ L'') (ψ : L →ᴸ L') :
-    ((φ.comp ψ).onBoundedFormula : L.BoundedFormula α n → L''.BoundedFormula α n) =
-      φ.onBoundedFormula ∘ ψ.onBoundedFormula := by
+theorem comp_onSemiformula {L'' : Language} (φ : L' →ᴸ L'') (ψ : L →ᴸ L') :
+    ((φ.comp ψ).onSemiformula : L.Semiformula α n → L''.Semiformula α n) =
+      φ.onSemiformula ∘ ψ.onSemiformula := by
   ext f
   induction' f with _ _ _ _ _ _ _ _ _ _ _ ih1 ih2 _ _ ih3
   · rfl
-  · simp only [onBoundedFormula, comp_onTerm, Function.comp_apply]
-  · simp only [onBoundedFormula, comp_onRelation, comp_onTerm, Function.comp_apply]
+  · simp only [onSemiformula, comp_onTerm, Function.comp_apply]
+  · simp only [onSemiformula, comp_onRelation, comp_onTerm, Function.comp_apply]
     rfl
-  · simp only [onBoundedFormula, Function.comp_apply, ih1, ih2, eq_self_iff_true, and_self_iff]
-  · simp only [ih3, onBoundedFormula, Function.comp_apply]
+  · simp only [onSemiformula, Function.comp_apply, ih1, ih2, eq_self_iff_true, and_self_iff]
+  · simp only [ih3, onSemiformula, Function.comp_apply]
 set_option linter.uppercaseLean3 false in
-#align first_order.language.Lhom.comp_on_bounded_formula FirstOrder.Language.LHom.comp_onBoundedFormula
+#align first_order.language.Lhom.comp_on_bounded_formula FirstOrder.Language.LHom.comp_onSemiformula
 
 /-- Maps a formula's symbols along a language map. -/
 def onFormula (g : L →ᴸ L') : L.Formula α → L'.Formula α :=
-  g.onBoundedFormula
+  g.onSemiformula
 set_option linter.uppercaseLean3 false in
 #align first_order.language.Lhom.on_formula FirstOrder.Language.LHom.onFormula
 
@@ -949,28 +949,28 @@ namespace LEquiv
 
 /-- Maps a bounded formula's symbols along a language equivalence. -/
 @[simps]
-def onBoundedFormula (φ : L ≃ᴸ L') : L.BoundedFormula α n ≃ L'.BoundedFormula α n where
-  toFun := φ.toLHom.onBoundedFormula
-  invFun := φ.invLHom.onBoundedFormula
+def onSemiformula (φ : L ≃ᴸ L') : L.Semiformula α n ≃ L'.Semiformula α n where
+  toFun := φ.toLHom.onSemiformula
+  invFun := φ.invLHom.onSemiformula
   left_inv := by
-    rw [Function.leftInverse_iff_comp, ← LHom.comp_onBoundedFormula, φ.left_inv,
-      LHom.id_onBoundedFormula]
+    rw [Function.leftInverse_iff_comp, ← LHom.comp_onSemiformula, φ.left_inv,
+      LHom.id_onSemiformula]
   right_inv := by
-    rw [Function.rightInverse_iff_comp, ← LHom.comp_onBoundedFormula, φ.right_inv,
-      LHom.id_onBoundedFormula]
+    rw [Function.rightInverse_iff_comp, ← LHom.comp_onSemiformula, φ.right_inv,
+      LHom.id_onSemiformula]
 set_option linter.uppercaseLean3 false in
-#align first_order.language.Lequiv.on_bounded_formula FirstOrder.Language.LEquiv.onBoundedFormula
+#align first_order.language.Lequiv.on_bounded_formula FirstOrder.Language.LEquiv.onSemiformula
 
-theorem onBoundedFormula_symm (φ : L ≃ᴸ L') :
-    (φ.onBoundedFormula.symm : L'.BoundedFormula α n ≃ L.BoundedFormula α n) =
-      φ.symm.onBoundedFormula :=
+theorem onSemiformula_symm (φ : L ≃ᴸ L') :
+    (φ.onSemiformula.symm : L'.Semiformula α n ≃ L.Semiformula α n) =
+      φ.symm.onSemiformula :=
   rfl
 set_option linter.uppercaseLean3 false in
-#align first_order.language.Lequiv.on_bounded_formula_symm FirstOrder.Language.LEquiv.onBoundedFormula_symm
+#align first_order.language.Lequiv.on_bounded_formula_symm FirstOrder.Language.LEquiv.onSemiformula_symm
 
 /-- Maps a formula's symbols along a language equivalence. -/
 def onFormula (φ : L ≃ᴸ L') : L.Formula α ≃ L'.Formula α :=
-  φ.onBoundedFormula
+  φ.onSemiformula
 set_option linter.uppercaseLean3 false in
 #align first_order.language.Lequiv.on_formula FirstOrder.Language.LEquiv.onFormula
 
@@ -1000,25 +1000,25 @@ end LEquiv
 scoped[FirstOrder] infixl:88 " =' " => FirstOrder.Language.Term.bdEqual
 -- input \~- or \simeq
 
-scoped[FirstOrder] infixr:62 " ⟹ " => FirstOrder.Language.BoundedFormula.imp
+scoped[FirstOrder] infixr:62 " ⟹ " => FirstOrder.Language.Semiformula.imp
 -- input \==>
 
-scoped[FirstOrder] prefix:110 "∀'" => FirstOrder.Language.BoundedFormula.all
+scoped[FirstOrder] prefix:110 "∀'" => FirstOrder.Language.Semiformula.all
 
-scoped[FirstOrder] prefix:arg "∼" => FirstOrder.Language.BoundedFormula.not
+scoped[FirstOrder] prefix:arg "∼" => FirstOrder.Language.Semiformula.not
 -- input \~, the ASCII character ~ has too low precedence
 
-scoped[FirstOrder] infixl:61 " ⇔ " => FirstOrder.Language.BoundedFormula.iff
+scoped[FirstOrder] infixl:61 " ⇔ " => FirstOrder.Language.Semiformula.iff
 -- input \<=>
 
-scoped[FirstOrder] prefix:110 "∃'" => FirstOrder.Language.BoundedFormula.ex
+scoped[FirstOrder] prefix:110 "∃'" => FirstOrder.Language.Semiformula.ex
 -- input \ex
 
 namespace Formula
 
 /-- Relabels a formula's variables along a particular function. -/
 def relabel (g : α → β) : L.Formula α → L.Formula β :=
-  @BoundedFormula.relabel _ _ _ 0 (Sum.inl ∘ g) 0
+  @Semiformula.relabel _ _ _ 0 (Sum.inl ∘ g) 0
 #align first_order.language.formula.relabel FirstOrder.Language.Formula.relabel
 
 /-- The graph of a function as a first-order formula. -/
@@ -1033,7 +1033,7 @@ protected nonrec abbrev not (φ : L.Formula α) : L.Formula α :=
 
 /-- The implication between formulas, as a formula. -/
 protected abbrev imp : L.Formula α → L.Formula α → L.Formula α :=
-  BoundedFormula.imp
+  Semiformula.imp
 #align first_order.language.formula.imp FirstOrder.Language.Formula.imp
 
 /-- Given a map `f : α → β ⊕ γ`, `iAlls f φ` transforms a `L.Formula α`
@@ -1042,7 +1042,7 @@ quantifying over all variables `Sum.inr _`. -/
 noncomputable def iAlls [Finite γ] (f : α → β ⊕ γ)
     (φ : L.Formula α) : L.Formula β :=
   let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin γ))
-  (BoundedFormula.relabel (fun a => Sum.map id e (f a)) φ).alls
+  (Semiformula.relabel (fun a => Sum.map id e (f a)) φ).alls
 
 /-- Given a map `f : α → β ⊕ γ`, `iExs f φ` transforms a `L.Formula α`
 into a `L.Formula β` by renaming variables with the map `f` and then universally
@@ -1050,7 +1050,7 @@ quantifying over all variables `Sum.inr _`. -/
 noncomputable def iExs [Finite γ] (f : α → β ⊕ γ)
     (φ : L.Formula α) : L.Formula β :=
   let e := Classical.choice (Classical.choose_spec (Finite.exists_equiv_fin γ))
-  (BoundedFormula.relabel (fun a => Sum.map id e (f a)) φ).exs
+  (Semiformula.relabel (fun a => Sum.map id e (f a)) φ).exs
 
 /-- The biimplication between formulas, as a formula. -/
 protected nonrec abbrev iff (φ ψ : L.Formula α) : L.Formula α :=
@@ -1058,12 +1058,12 @@ protected nonrec abbrev iff (φ ψ : L.Formula α) : L.Formula α :=
 #align first_order.language.formula.iff FirstOrder.Language.Formula.iff
 
 theorem isAtomic_graph (f : L.Functions n) : (graph f).IsAtomic :=
-  BoundedFormula.IsAtomic.equal _ _
+  Semiformula.IsAtomic.equal _ _
 #align first_order.language.formula.is_atomic_graph FirstOrder.Language.Formula.isAtomic_graph
 
 /-- A bijection sending formulas to sentences with constants. -/
 def equivSentence : L.Formula α ≃ L[[α]].Sentence :=
-  (BoundedFormula.constantsVarsEquiv.trans (BoundedFormula.relabelEquiv (Equiv.sumEmpty _ _))).symm
+  (Semiformula.constantsVarsEquiv.trans (Semiformula.relabelEquiv (Equiv.sumEmpty _ _))).symm
 #align first_order.language.formula.equiv_sentence FirstOrder.Language.Formula.equivSentence
 
 theorem equivSentence_not (φ : L.Formula α) : equivSentence φ.not = (equivSentence φ).not :=
@@ -1083,32 +1083,32 @@ variable (r : L.Relations 2)
 
 /-- The sentence indicating that a basic relation symbol is reflexive. -/
 protected def reflexive : L.Sentence :=
-  ∀'r.boundedFormula₂ (&0) &0
+  ∀'r.semiformula₂ (&0) &0
 #align first_order.language.relations.reflexive FirstOrder.Language.Relations.reflexive
 
 /-- The sentence indicating that a basic relation symbol is irreflexive. -/
 protected def irreflexive : L.Sentence :=
-  ∀'∼(r.boundedFormula₂ (&0) &0)
+  ∀'∼(r.semiformula₂ (&0) &0)
 #align first_order.language.relations.irreflexive FirstOrder.Language.Relations.irreflexive
 
 /-- The sentence indicating that a basic relation symbol is symmetric. -/
 protected def symmetric : L.Sentence :=
-  ∀'∀'(r.boundedFormula₂ (&0) &1 ⟹ r.boundedFormula₂ (&1) &0)
+  ∀'∀'(r.semiformula₂ (&0) &1 ⟹ r.semiformula₂ (&1) &0)
 #align first_order.language.relations.symmetric FirstOrder.Language.Relations.symmetric
 
 /-- The sentence indicating that a basic relation symbol is antisymmetric. -/
 protected def antisymmetric : L.Sentence :=
-  ∀'∀'(r.boundedFormula₂ (&0) &1 ⟹ r.boundedFormula₂ (&1) &0 ⟹ Term.bdEqual (&0) &1)
+  ∀'∀'(r.semiformula₂ (&0) &1 ⟹ r.semiformula₂ (&1) &0 ⟹ Term.bdEqual (&0) &1)
 #align first_order.language.relations.antisymmetric FirstOrder.Language.Relations.antisymmetric
 
 /-- The sentence indicating that a basic relation symbol is transitive. -/
 protected def transitive : L.Sentence :=
-  ∀'∀'∀'(r.boundedFormula₂ (&0) &1 ⟹ r.boundedFormula₂ (&1) &2 ⟹ r.boundedFormula₂ (&0) &2)
+  ∀'∀'∀'(r.semiformula₂ (&0) &1 ⟹ r.semiformula₂ (&1) &2 ⟹ r.semiformula₂ (&0) &2)
 #align first_order.language.relations.transitive FirstOrder.Language.Relations.transitive
 
 /-- The sentence indicating that a basic relation symbol is total. -/
 protected def total : L.Sentence :=
-  ∀'∀'(r.boundedFormula₂ (&0) &1 ⊔ r.boundedFormula₂ (&1) &0)
+  ∀'∀'(r.semiformula₂ (&0) &1 ⊔ r.semiformula₂ (&1) &0)
 #align first_order.language.relations.total FirstOrder.Language.Relations.total
 
 end Relations

--- a/Mathlib/ModelTheory/Types.lean
+++ b/Mathlib/ModelTheory/Types.lean
@@ -164,7 +164,7 @@ theorem iInter_setOf_subset {ι : Type*} (S : ι → L[[α]].Theory) :
 theorem toList_foldr_inf_mem {p : T.CompleteType α} {t : Finset (L[[α]]).Sentence} :
     t.toList.foldr (· ⊓ ·) ⊤ ∈ p ↔ (t : L[[α]].Theory) ⊆ ↑p := by
   simp_rw [subset_def, ← SetLike.mem_coe, p.isMaximal.mem_iff_models, models_sentence_iff,
-    Sentence.Realize, Formula.Realize, BoundedFormula.realize_foldr_inf, Finset.mem_toList]
+    Sentence.Realize, Formula.Realize, Semiformula.realize_foldr_inf, Finset.mem_toList]
   exact ⟨fun h φ hφ M => h _ _ hφ, fun h M φ hφ => h _ hφ _⟩
 #align first_order.language.Theory.complete_type.to_list_foldr_inf_mem FirstOrder.Language.Theory.CompleteType.toList_foldr_inf_mem
 

--- a/Mathlib/ModelTheory/Ultraproducts.lean
+++ b/Mathlib/ModelTheory/Ultraproducts.lean
@@ -93,29 +93,29 @@ theorem term_realize_cast {β : Type*} (x : β → ∀ a, M a) (t : L.Term β) :
 
 variable [∀ a : α, Nonempty (M a)]
 
-theorem boundedFormula_realize_cast {β : Type*} {n : ℕ} (φ : L.BoundedFormula β n)
+theorem semiformula_realize_cast {β : Type*} {n : ℕ} (φ : L.Semiformula β n)
     (x : β → ∀ a, M a) (v : Fin n → ∀ a, M a) :
     (φ.Realize (fun i : β => (x i : (u : Filter α).Product M))
         (fun i => (v i : (u : Filter α).Product M))) ↔
       ∀ᶠ a : α in u, φ.Realize (fun i : β => x i a) fun i => v i a := by
   letI := (u : Filter α).productSetoid M
   induction' φ with _ _ _ _ _ _ _ _ m _ _ ih ih' k φ ih
-  · simp only [BoundedFormula.Realize, eventually_const]
+  · simp only [Semiformula.Realize, eventually_const]
   · have h2 : ∀ a : α, (Sum.elim (fun i : β => x i a) fun i => v i a) = fun i => Sum.elim x v i a :=
       fun a => funext fun i => Sum.casesOn i (fun i => rfl) fun i => rfl
-    simp only [BoundedFormula.Realize, h2, term_realize_cast]
+    simp only [Semiformula.Realize, h2, term_realize_cast]
     erw [(Sum.comp_elim ((↑) : (∀ a, M a) → (u : Filter α).Product M) x v).symm,
       term_realize_cast, term_realize_cast]
     exact Quotient.eq''
   · have h2 : ∀ a : α, (Sum.elim (fun i : β => x i a) fun i => v i a) = fun i => Sum.elim x v i a :=
       fun a => funext fun i => Sum.casesOn i (fun i => rfl) fun i => rfl
-    simp only [BoundedFormula.Realize, h2]
+    simp only [Semiformula.Realize, h2]
     erw [(Sum.comp_elim ((↑) : (∀ a, M a) → (u : Filter α).Product M) x v).symm]
     conv_lhs => enter [2, i]; erw [term_realize_cast]
     apply relMap_quotient_mk'
-  · simp only [BoundedFormula.Realize, ih v, ih' v]
+  · simp only [Semiformula.Realize, ih v, ih' v]
     rw [Ultrafilter.eventually_imp]
-  · simp only [BoundedFormula.Realize]
+  · simp only [Semiformula.Realize]
     apply Iff.trans (b := ∀ m : ∀ a : α, M a,
       φ.Realize (fun i : β => (x i : (u : Filter α).Product M))
         (Fin.snoc (((↑) : (∀ a, M a) → (u : Filter α).Product M) ∘ v)
@@ -142,12 +142,12 @@ theorem boundedFormula_realize_cast {β : Type*} {n : ℕ} (φ : L.BoundedFormul
       exact Filter.mem_of_superset h fun a ha => Classical.epsilon_spec ha
     · rw [Filter.eventually_iff] at *
       exact Filter.mem_of_superset h fun a ha => ha (m a)
-#align first_order.language.ultraproduct.bounded_formula_realize_cast FirstOrder.Language.Ultraproduct.boundedFormula_realize_cast
+#align first_order.language.ultraproduct.bounded_formula_realize_cast FirstOrder.Language.Ultraproduct.semiformula_realize_cast
 
 theorem realize_formula_cast {β : Type*} (φ : L.Formula β) (x : β → ∀ a, M a) :
     (φ.Realize fun i => (x i : (u : Filter α).Product M)) ↔
       ∀ᶠ a : α in u, φ.Realize fun i => x i a := by
-  simp_rw [Formula.Realize, ← boundedFormula_realize_cast φ x, iff_eq_eq]
+  simp_rw [Formula.Realize, ← semiformula_realize_cast φ x, iff_eq_eq]
   exact congr rfl (Subsingleton.elim _ _)
 #align first_order.language.ultraproduct.realize_formula_cast FirstOrder.Language.Ultraproduct.realize_formula_cast
 


### PR DESCRIPTION
The name `BoundedFormula` is not good because it is confusing with a bounded formula (a formula with all quantifiers are bounded). Semiformula is a term used in proof theory as a formula in which bounded variables appear freely in addition to free variables (e.g. An Introduction to Proof Theory by Samuel R. Buss), and is considered more appropriate.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
