### PR TITLE
[Merged by Bors] - perf: don't use the whole simp set in `proveFinsetNonempty`

### DIFF
--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -4041,6 +4041,7 @@ def proveFinsetNonempty {u : Level} {α : Q(Type u)} (s : Q(Finset $α)) :
   let options : Aesop.Options' :=
     { terminal := true, -- Fail if the new goal is not closed.
       generateScript := false,
+      useDefaultSimpSet := false, -- Avoiding the whole simp set to speed up the tactic.
       warnOnNonterminal := false } -- Don't show a warning on failure, simply return `none`.
   let rules ← Aesop.mkLocalRuleSet rulesets options
   let (remainingGoals, _) ←


### PR DESCRIPTION
The new `proveFinsetNonempty` prover was timing out all over the place when I tried to bump LeanAPAP. Turns out we had left `aesop` use the whole `simp` set!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
