### PR TITLE
fix: actually remove `set_option`s from `compute_degree`s

### DIFF
--- a/Mathlib/Analysis/Complex/Polynomial.lean
+++ b/Mathlib/Analysis/Complex/Polynomial.lean
@@ -209,7 +209,6 @@ lemma Irreducible.degree_le_two {p : ℝ[X]} (hp : Irreducible p) : degree p ≤
     exact (degree_eq_one_of_irreducible_of_root hp hz).trans_le one_le_two
   | inr hz0 =>
     obtain ⟨q, rfl⟩ := p.quadratic_dvd_of_aeval_eq_zero_im_ne_zero hz hz0
-    set_option tactic.skipAssignedInstances false in
     have hd : degree (X ^ 2 - C (2 * z.re) * X + C (‖z‖ ^ 2)) = 2 := by
       compute_degree!
     have hq : IsUnit q := by

--- a/Mathlib/Data/Polynomial/CancelLeads.lean
+++ b/Mathlib/Data/Polynomial/CancelLeads.lean
@@ -49,7 +49,6 @@ theorem neg_cancelLeads : -p.cancelLeads q = q.cancelLeads p :=
   neg_sub _ _
 #align polynomial.neg_cancel_leads Polynomial.neg_cancelLeads
 
-set_option tactic.skipAssignedInstances false in
 theorem natDegree_cancelLeads_lt_of_natDegree_le_natDegree_of_comm
     (comm : p.leadingCoeff * q.leadingCoeff = q.leadingCoeff * p.leadingCoeff)
     (h : p.natDegree ≤ q.natDegree) (hq : 0 < q.natDegree) :


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
