### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits/Shapes/Biproducts): functoriality of bicones is full and faithful

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -439,7 +439,7 @@ instance functorialityFull [Full G] [Faithful G] : Full (functoriality F G) wher
 #align category_theory.limits.cones.functoriality_full CategoryTheory.Limits.Cones.functorialityFull
 
 instance functoriality_faithful [Faithful G] : Faithful (Cones.functoriality F G) where
-  map_injective {c} {c'} f g e :=
+  map_injective {_X} {_Y} f g h :=
     ConeMorphism.ext f g <| G.map_injective <| congr_arg ConeMorphism.hom h
 #align category_theory.limits.cones.functoriality_faithful CategoryTheory.Limits.Cones.functoriality_faithful
 

--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -438,12 +438,10 @@ instance functorialityFull [Full G] [Faithful G] : Full (functoriality F G) wher
       w := fun j => G.map_injective (by simpa using t.w j) }
 #align category_theory.limits.cones.functoriality_full CategoryTheory.Limits.Cones.functorialityFull
 
-instance functorialityFaithful [Faithful G] : Faithful (Cones.functoriality F G) where
-  map_injective {c} {c'} f g e := by
-    apply ConeMorphism.ext f g
-    let f := ConeMorphism.mk.inj e
-    apply G.map_injective f
-#align category_theory.limits.cones.functoriality_faithful CategoryTheory.Limits.Cones.functorialityFaithful
+instance functoriality_faithful [Faithful G] : Faithful (Cones.functoriality F G) where
+  map_injective {c} {c'} f g e :=
+    ConeMorphism.ext f g <| G.map_injective <| congr_arg ConeMorphism.hom h
+#align category_theory.limits.cones.functoriality_faithful CategoryTheory.Limits.Cones.functoriality_faithful
 
 /-- If `e : C ≌ D` is an equivalence of categories, then `functoriality F e.functor` induces an
 equivalence between cones over `F` and cones over `F ⋙ e.functor`.
@@ -635,10 +633,8 @@ instance functorialityFull [Full G] [Faithful G] : Full (functoriality F G) wher
 #align category_theory.limits.cocones.functoriality_full CategoryTheory.Limits.Cocones.functorialityFull
 
 instance functoriality_faithful [Faithful G] : Faithful (functoriality F G) where
-  map_injective {X} {Y} f g e := by
-    apply CoconeMorphism.ext
-    let h := CoconeMorphism.mk.inj e
-    apply G.map_injective h
+  map_injective {_X} {_Y} f g h :=
+    CoconeMorphism.ext f g <| G.map_injective <| congr_arg CoconeMorphism.hom h
 #align category_theory.limits.cocones.functoriality_faithful CategoryTheory.Limits.Cocones.functoriality_faithful
 
 /-- If `e : C ≌ D` is an equivalence of categories, then `functoriality F e.functor` induces an

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -166,12 +166,10 @@ instance functorialityFull [Functor.PreservesZeroMorphisms G] [Full G] [Faithful
       wι := fun j => G.map_injective (by simpa using t.wι j)
       wπ := fun j => G.map_injective (by simpa using t.wπ j) }
 
-instance functorialityFaithful [Functor.PreservesZeroMorphisms G] [Faithful G] :
+instance functoriality_faithful [Functor.PreservesZeroMorphisms G] [Faithful G] :
     Faithful (functoriality F G) where
-  map_injective {c} {c'} f g e := by
-    apply BiconeMorphism.ext f g
-    let f := BiconeMorphism.mk.inj e
-    apply G.map_injective f
+  map_injective {_X} {_Y} f g h :=
+    BiconeMorphism.ext f g <| G.map_injective <| congr_arg BiconeMorphism.hom h
 
 end Bicones
 
@@ -1264,11 +1262,9 @@ instance functorialityFull [Full F] [Faithful F] : Full (functoriality P Q F) wh
       wfst := F.map_injective (by simpa using t.wfst)
       wsnd := F.map_injective (by simpa using t.wsnd) }
 
-instance functorialityFaithful [Faithful F] : Faithful (functoriality P Q F) where
-  map_injective {c} {c'} f g e := by
-    apply BinaryBiconeMorphism.ext f g
-    let f := BinaryBiconeMorphism.mk.inj e
-    apply F.map_injective f
+instance functoriality_faithful [Faithful F] : Faithful (functoriality P Q F) where
+  map_injective {_X} {_Y} f g h :=
+    BiconeMorphism.ext f g <| G.map_injective <| congr_arg BiconeMorphism.hom h
 
 end BinaryBicones
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -1264,7 +1264,7 @@ instance functorialityFull [Full F] [Faithful F] : Full (functoriality P Q F) wh
 
 instance functoriality_faithful [Faithful F] : Faithful (functoriality P Q F) where
   map_injective {_X} {_Y} f g h :=
-    BiconeMorphism.ext f g <| G.map_injective <| congr_arg BiconeMorphism.hom h
+    BinaryBiconeMorphism.ext f g <| F.map_injective <| congr_arg BinaryBiconeMorphism.hom h
 
 end BinaryBicones
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -157,6 +157,22 @@ def functoriality (G : C ⥤ D) [Functor.PreservesZeroMorphisms G] :
       wπ := fun j => by simp [-BiconeMorphism.wπ, ← f.wπ j]
       wι := fun j => by simp [-BiconeMorphism.wι, ← f.wι j] }
 
+variable (G : C ⥤ D)
+
+instance functorialityFull [Functor.PreservesZeroMorphisms G] [Full G] [Faithful G] :
+    Full (functoriality F G) where
+  preimage t :=
+    { hom := G.preimage t.hom
+      wι := fun j => G.map_injective (by simpa using t.wι j)
+      wπ := fun j => G.map_injective (by simpa using t.wπ j) }
+
+instance functorialityFaithful [Functor.PreservesZeroMorphisms G] [Faithful G] :
+    Faithful (functoriality F G) where
+  map_injective {c} {c'} f g e := by
+    apply BiconeMorphism.ext f g
+    let f := BiconeMorphism.mk.inj e
+    apply G.map_injective f
+
 end Bicones
 
 namespace Bicone
@@ -1217,11 +1233,12 @@ def ext {P Q : C} {c c' : BinaryBicone P Q} (φ : c.pt ≅ c'.pt)
       winl := φ.comp_inv_eq.mpr winl.symm
       winr := φ.comp_inv_eq.mpr winr.symm }
 
+variable (P Q : C) (F : C ⥤ D) [Functor.PreservesZeroMorphisms F]
+
 /-- A functor `F : C ⥤ D` sends binary bicones for `P` and `Q`
 to binary bicones for `G.obj P` and `G.obj Q` functorially. -/
 @[simps]
-def functoriality (P Q : C) (F : C ⥤ D) [Functor.PreservesZeroMorphisms F] :
-    BinaryBicone P Q ⥤ BinaryBicone (F.obj P) (F.obj Q) where
+def functoriality : BinaryBicone P Q ⥤ BinaryBicone (F.obj P) (F.obj Q) where
   obj A :=
     { pt := F.obj A.pt
       fst := F.map A.fst
@@ -1238,6 +1255,20 @@ def functoriality (P Q : C) (F : C ⥤ D) [Functor.PreservesZeroMorphisms F] :
       wsnd := by simp [-BinaryBiconeMorphism.wsnd, ← f.wsnd]
       winl := by simp [-BinaryBiconeMorphism.winl, ← f.winl]
       winr := by simp [-BinaryBiconeMorphism.winr, ← f.winr] }
+
+instance functorialityFull [Full F] [Faithful F] : Full (functoriality P Q F) where
+  preimage t :=
+    { hom := F.preimage t.hom
+      winl := F.map_injective (by simpa using t.winl)
+      winr := F.map_injective (by simpa using t.winr)
+      wfst := F.map_injective (by simpa using t.wfst)
+      wsnd := F.map_injective (by simpa using t.wsnd) }
+
+instance functorialityFaithful [Faithful F] : Faithful (functoriality P Q F) where
+  map_injective {c} {c'} f g e := by
+    apply BinaryBiconeMorphism.ext f g
+    let f := BinaryBiconeMorphism.mk.inj e
+    apply F.map_injective f
 
 end BinaryBicones
 


### PR DESCRIPTION
This follows the API pattern set by `Cone` and `Cocone`.

This also renames `CategoryTheory.Limits.Cones.functorialityFaithful` to `CategoryTheory.Limits.Cones.functoriality_faithful` to match the corresponding `Cocone` instance.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
