### PR TITLE
[Merged by Bors] - feat: Bergelson's Intersectivity Lemma

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3032,6 +3032,7 @@ import Mathlib.MeasureTheory.Function.ConvergenceInMeasure
 import Mathlib.MeasureTheory.Function.Egorov
 import Mathlib.MeasureTheory.Function.EssSup
 import Mathlib.MeasureTheory.Function.Floor
+import Mathlib.MeasureTheory.Function.Intersectivity
 import Mathlib.MeasureTheory.Function.Jacobian
 import Mathlib.MeasureTheory.Function.L1Space
 import Mathlib.MeasureTheory.Function.L2Space

--- a/Mathlib/MeasureTheory/Function/Intersectivity.lean
+++ b/Mathlib/MeasureTheory/Function/Intersectivity.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2023 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.MeasureTheory.Integral.Average
+
+/-!
+# Bergelson's intersectivity lemma
+
+This file proves the Bergelson intersectivity lemma: In a finite measure space, a sequence of events
+that have measure at least `r` has an infinite subset whose finite intersections all have positive
+volume.
+
+This is in some sense a finitary version of the second Borel-Cantelli lemma.
+
+## References
+
+[Bergelson, *Sets of recurrence of `ℤᵐ`-actions and properties of sets of differences in
+`ℤᵐ`][bergelson1985]
+
+## TODO
+
+Restate the theorem using the upper density of a set of naturals, once we have it. This will make
+`strong_bergelson` be actually strong.
+
+Use the ergodic theorem to deduce the refinement of the Poincaré recurrence theorem proved by
+Bergelson.
+-/
+
+open Filter Function MeasureTheory Set
+open scoped BigOperators ENNReal NNReal
+
+variable {ι α : Type*} [MeasurableSpace α] {μ : Measure α} [IsFiniteMeasure μ] {r : ℝ≥0∞}
+
+/-- **Bergelson Intersectivity Lemma**: In a finite measure space, a sequence of events that have
+measure at least `r` has an infinite subset whose finite intersections all have positive volume.
+
+TODO: The infinity of `t` should be strengthened to `t` having positive natural density. -/
+lemma strong_bergelson {s : ℕ → Set α} (hs : ∀ n, MeasurableSet (s n)) (hr₀ : r ≠ 0)
+    (hr : ∀ n, r ≤ μ (s n)) :
+  ∃ t : Set ℕ, t.Infinite ∧ ∀ ⦃u⦄, u ⊆ t → u.Finite → 0 < μ (⋂ n ∈ u, s n) := by
+  -- We let `M f` be the set on which the norm of `f` exceeds its essential supremum, and `N` be the
+  -- union of `M` of the finite products of the indicators of the `s n`.
+  let M (f : α → ℝ) : Set α := {x | snormEssSup f μ < ‖f x‖₊}
+  let N : Set α := ⋃ u : Finset ℕ, M (Set.indicator (⋂ n ∈ u, s n) 1)
+  -- `N` is a null set since `M f` is a null set for each `f`.
+  have hN₀ : μ N = 0 := measure_iUnion_null fun u ↦ meas_snormEssSup_lt
+  -- The important thing about `N` is that if we remove `N` from our space, then finite unions of
+  -- the `s n` are null iff they are empty.
+  have hN₁ (u : Finset ℕ) : ((⋂ n ∈ u, s n) \ N).Nonempty → 0 < μ (⋂ n ∈ u, s n) := by
+    simp_rw [pos_iff_ne_zero]
+    rintro ⟨x, hx⟩ hu
+    refine hx.2 (mem_iUnion.2 ⟨u, ?_⟩)
+    rw [mem_setOf, indicator_of_mem hx.1, snormEssSup_eq_zero_iff.2]
+    · simp
+    · rwa [indicator_ae_eq_zero, Function.support_one, inter_univ]
+  -- Define `f n` to be the average of the first `n + 1` indicators of the `s k`.
+  let f (n : ℕ) : α → ℝ≥0∞ := (↑(n + 1) : ℝ≥0∞)⁻¹ • ∑ k in Finset.range (n + 1), (s k).indicator 1
+  -- We gather a few simple properties of `f`.
+  have hfapp : ∀ n a, f n a = (↑(n + 1))⁻¹ * ∑ k in Finset.range (n + 1), (s k).indicator 1 a := by
+    simp only [f, Pi.natCast_def, Pi.smul_apply, Pi.inv_apply, Finset.sum_apply, eq_self_iff_true,
+    forall_const, imp_true_iff, smul_eq_mul]
+  have hf n : Measurable (f n) := Measurable.mul' (@measurable_const ℝ≥0∞ _ _ _ (↑(n + 1))⁻¹)
+      (Finset.measurable_sum' _ fun i _ ↦ measurable_one.indicator $ hs i)
+  have hf₁ n : f n ≤ 1 := by
+    rintro a
+    rw [hfapp, ← ENNReal.div_eq_inv_mul]
+    refine (ENNReal.div_le_iff_le_mul (Or.inl $ Nat.cast_ne_zero.2 n.succ_ne_zero) $
+      Or.inr one_ne_zero).2 ?_
+    rw [mul_comm, ← nsmul_eq_mul, ← Finset.card_range n.succ]
+    exact Finset.sum_le_card_nsmul _ _ _ fun _ _ ↦ indicator_le (fun _ _ ↦ le_rfl) _
+  -- By assumption, `f n` has integral at least `r`.
+  have hrf n : r ≤ ∫⁻ a, f n a ∂μ := by
+    simp_rw [hfapp]
+    rw [lintegral_const_mul _ (Finset.measurable_sum _ fun _ _ ↦ measurable_one.indicator $ hs _),
+      lintegral_finset_sum _ fun _ _ ↦ measurable_one.indicator (hs _)]
+    simp only [lintegral_indicator_one (hs _)]
+    rw [← ENNReal.div_eq_inv_mul, ENNReal.le_div_iff_mul_le (by simp) (by simp), ← nsmul_eq_mul']
+    simpa using Finset.card_nsmul_le_sum (Finset.range (n + 1)) _ _ fun _ _ ↦ hr _
+  -- Collect some basic fact
+  have hμ : μ ≠ 0 := by rintro rfl; exact hr₀ $ le_bot_iff.1 $ hr 0
+  have : ∫⁻ x, limsup (f · x) atTop ∂μ ≤ μ univ := by
+    rw [← lintegral_one]
+    exact lintegral_mono fun a ↦ limsup_le_of_le ⟨0, fun R _ ↦ bot_le⟩ $
+      eventually_of_forall fun n ↦ hf₁ _ _
+  -- By the first moment method, there exists some `x ∉ N` such that `limsup f n x` is at least `r`.
+  obtain ⟨x, hxN, hx⟩ := exists_not_mem_null_laverage_le hμ
+    (ne_top_of_le_ne_top (measure_ne_top μ univ) this) hN₀
+  replace hx : r / μ univ ≤ limsup (f · x) atTop :=
+    calc
+      _ ≤ limsup (⨍⁻ x, f · x ∂μ) atTop := le_limsup_of_le ⟨1, eventually_map.2 ?_⟩ fun b hb ↦ ?_
+      _ ≤ ⨍⁻ x, limsup (f · x) atTop ∂μ := limsup_lintegral_le 1 hf (ae_of_all _ $ hf₁ ·) (by simp)
+      _ ≤ limsup (f · x) atTop := hx
+  -- This exactly means that the `s n` containing `x` have all their finite intersection non-null.
+  refine ⟨{n | x ∈ s n}, fun hxs ↦ ?_, fun u hux hu ↦ ?_⟩
+  -- This next block proves that a set of strictly positive natural density is infinite, mixed with
+  -- the fact that `{n | x ∈ s n}` has strictly positive natural density.
+  -- TODO: Separate it out to a lemma once we have a natural density API.
+  · refine ENNReal.div_ne_zero.2 ⟨hr₀, measure_ne_top _ _⟩ $ eq_bot_mono hx $ Tendsto.limsup_eq $
+      tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds
+      (h := fun n ↦ (n.succ : ℝ≥0∞)⁻¹ * hxs.toFinset.card) ?_ bot_le fun n ↦ mul_le_mul_left' ?_ _
+    · simpa using ENNReal.Tendsto.mul_const (ENNReal.tendsto_inv_nat_nhds_zero.comp $
+        tendsto_add_atTop_nat 1) (.inr $ ENNReal.natCast_ne_top _)
+    · classical
+      simpa only [Finset.sum_apply, indicator_apply, Pi.one_apply, Finset.sum_boole, Nat.cast_le]
+        using Finset.card_le_card fun m hm ↦ hxs.mem_toFinset.2 (Finset.mem_filter.1 hm).2
+  · simp_rw [← hu.mem_toFinset]
+    exact hN₁ _ ⟨x, mem_iInter₂.2 fun n hn ↦ hux $ hu.mem_toFinset.1 hn, hxN⟩
+  · refine eventually_of_forall fun n ↦ ?_
+    obtain rfl | _ := eq_zero_or_neZero μ
+    · simp
+    · rw [← laverage_const μ 1]
+      exact lintegral_mono (hf₁ _)
+  · obtain ⟨n, hn⟩ := hb.exists
+    rw [laverage_eq] at hn
+    exact (ENNReal.div_le_div_right (hrf _) _).trans hn
+
+/-- **Bergelson Intersectivity Lemma**: In a finite measure space, a sequence of events that have
+measure at least `r` has an infinite subset whose finite intersections all have positive volume. -/
+lemma weak_bergelson [Infinite ι] {s : ι → Set α} (hs : ∀ i, MeasurableSet (s i)) (hr₀ : r ≠ 0)
+    (hr : ∀ i, r ≤ μ (s i)) :
+  ∃ t : Set ι, t.Infinite ∧ ∀ ⦃u⦄, u ⊆ t → u.Finite → 0 < μ (⋂ i ∈ u, s i) := by
+  obtain ⟨t, ht, h⟩ := bergelson' (fun n ↦ hs $ Infinite.natEmbedding _ n) hr₀ (fun n ↦ hr _)
+  refine ⟨_, ht.image (Infinite.natEmbedding _).injective.injOn, fun u hut hu ↦
+    (h (preimage_subset_of_surjOn (Infinite.natEmbedding _).injective hut) $ hu.preimage
+    (Embedding.injective _).injOn).trans_le $ measure_mono $ subset_iInter₂ fun i hi ↦ ?_⟩
+  obtain ⟨n, -, rfl⟩ := hut hi
+  exact iInter₂_subset n hi

--- a/Mathlib/MeasureTheory/Function/Intersectivity.lean
+++ b/Mathlib/MeasureTheory/Function/Intersectivity.lean
@@ -22,7 +22,7 @@ This is in some sense a finitary version of the second Borel-Cantelli lemma.
 ## TODO
 
 Restate the theorem using the upper density of a set of naturals, once we have it. This will make
-`strong_bergelson` be actually strong.
+`bergelson'` be actually strong (and please then rename it to `strong_bergelson`).
 
 Use the ergodic theorem to deduce the refinement of the Poincaré recurrence theorem proved by
 Bergelson.
@@ -37,7 +37,7 @@ variable {ι α : Type*} [MeasurableSpace α] {μ : Measure α} [IsFiniteMeasure
 measure at least `r` has an infinite subset whose finite intersections all have positive volume.
 
 TODO: The infinity of `t` should be strengthened to `t` having positive natural density. -/
-lemma strong_bergelson {s : ℕ → Set α} (hs : ∀ n, MeasurableSet (s n)) (hr₀ : r ≠ 0)
+lemma bergelson' {s : ℕ → Set α} (hs : ∀ n, MeasurableSet (s n)) (hr₀ : r ≠ 0)
     (hr : ∀ n, r ≤ μ (s n)) :
   ∃ t : Set ℕ, t.Infinite ∧ ∀ ⦃u⦄, u ⊆ t → u.Finite → 0 < μ (⋂ n ∈ u, s n) := by
   -- We let `M f` be the set on which the norm of `f` exceeds its essential supremum, and `N` be the
@@ -118,11 +118,11 @@ lemma strong_bergelson {s : ℕ → Set α} (hs : ∀ n, MeasurableSet (s n)) (h
 
 /-- **Bergelson Intersectivity Lemma**: In a finite measure space, a sequence of events that have
 measure at least `r` has an infinite subset whose finite intersections all have positive volume. -/
-lemma weak_bergelson [Infinite ι] {s : ι → Set α} (hs : ∀ i, MeasurableSet (s i)) (hr₀ : r ≠ 0)
+lemma bergelson [Infinite ι] {s : ι → Set α} (hs : ∀ i, MeasurableSet (s i)) (hr₀ : r ≠ 0)
     (hr : ∀ i, r ≤ μ (s i)) :
   ∃ t : Set ι, t.Infinite ∧ ∀ ⦃u⦄, u ⊆ t → u.Finite → 0 < μ (⋂ i ∈ u, s i) := by
   obtain ⟨t, ht, h⟩ := bergelson' (fun n ↦ hs $ Infinite.natEmbedding _ n) hr₀ (fun n ↦ hr _)
-  refine ⟨_, ht.image (Infinite.natEmbedding _).injective.injOn, fun u hut hu ↦
+  refine ⟨_, ht.image $ (Infinite.natEmbedding _).injective.injOn, fun u hut hu ↦
     (h (preimage_subset_of_surjOn (Infinite.natEmbedding _).injective hut) $ hu.preimage
     (Embedding.injective _).injOn).trans_le $ measure_mono $ subset_iInter₂ fun i hi ↦ ?_⟩
   obtain ⟨n, -, rfl⟩ := hut hi

--- a/Mathlib/MeasureTheory/Integral/Average.lean
+++ b/Mathlib/MeasureTheory/Integral/Average.lean
@@ -29,11 +29,6 @@ The average is defined as an integral over `(μ univ)⁻¹ • μ` so that all t
 integrals work for the average without modifications. For theorems that require integrability of a
 function, we provide a convenience lemma `MeasureTheory.Integrable.to_average`.
 
-## TODO
-
-Provide the first moment method for the Lebesgue integral as well. A draft is available on branch
-`first_moment_lintegral` in mathlib3 repository.
-
 ## Tags
 
 integral, center mass, average value

--- a/Mathlib/MeasureTheory/Integral/Average.lean
+++ b/Mathlib/MeasureTheory/Integral/Average.lean
@@ -21,7 +21,9 @@ average w.r.t. the volume, one can omit `∂volume`.
 Both have a version for the Lebesgue integral rather than Bochner.
 
 We prove several version of the first moment method: An integrable function is below/above its
-average on a set of positive measure.
+average on a set of positive measure:
+* `measure_le_setLaverage_pos` for the Lebesgue integral
+* `measure_le_setAverage_pos` for the Bochner integral
 
 ## Implementation notes
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -1192,7 +1192,7 @@ theorem lintegral_liminf_le {f : ℕ → α → ℝ≥0∞} (h_meas : ∀ n, Mea
   lintegral_liminf_le' fun n => (h_meas n).aemeasurable
 #align measure_theory.lintegral_liminf_le MeasureTheory.lintegral_liminf_le
 
-theorem limsup_lintegral_le {f : ℕ → α → ℝ≥0∞} {g : α → ℝ≥0∞} (hf_meas : ∀ n, Measurable (f n))
+theorem limsup_lintegral_le {f : ℕ → α → ℝ≥0∞} (g : α → ℝ≥0∞) (hf_meas : ∀ n, Measurable (f n))
     (h_bound : ∀ n, f n ≤ᵐ[μ] g) (h_fin : ∫⁻ a, g a ∂μ ≠ ∞) :
     limsup (fun n => ∫⁻ a, f n a ∂μ) atTop ≤ ∫⁻ a, limsup (fun n => f n a) atTop ∂μ :=
   calc
@@ -1224,7 +1224,7 @@ theorem tendsto_lintegral_of_dominated_convergence {F : ℕ → α → ℝ≥0�
       )
     (calc
       limsup (fun n : ℕ => ∫⁻ a, F n a ∂μ) atTop ≤ ∫⁻ a, limsup (fun n => F n a) atTop ∂μ :=
-        limsup_lintegral_le hF_meas h_bound h_fin
+        limsup_lintegral_le _ hF_meas h_bound h_fin
       _ = ∫⁻ a, f a ∂μ := lintegral_congr_ae <| h_lim.mono fun a h => h.limsup_eq
       )
 #align measure_theory.tendsto_lintegral_of_dominated_convergence MeasureTheory.tendsto_lintegral_of_dominated_convergence

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -230,6 +230,20 @@
   zbl           = {0436.46013}
 }
 
+@Article{         bergelson1985,
+  author        = {Bergelson, Vitaly},
+  title         = {Sets of Recurrence of Zm-Actions and Properties of Sets of
+                  Differences in Zm},
+  journal       = {Journal of the London Mathematical Society},
+  volume        = {s2-31},
+  number        = {2},
+  pages         = {295-304},
+  doi           = {https://doi.org/10.1112/jlms/s2-31.2.295},
+  url           = {https://londmathsoc.onlinelibrary.wiley.com/doi/abs/10.1112/jlms/s2-31.2.295},
+  eprint        = {https://londmathsoc.onlinelibrary.wiley.com/doi/pdf/10.1112/jlms/s2-31.2.295},
+  year          = {1985}
+}
+
 @Book{            berger1987,
   author        = {Marcel Berger},
   title         = {Geometry I},


### PR DESCRIPTION
Prove a weak version of the Bergelson intersectivity lemma. The proof gives the strong version, but we need natural density to state it. This is a prerequisite to Tao and Ziegler's recent paper [Infinite partial sumsets in the primes](https://arxiv.org/abs/2301.10303).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #14421
- [x] depends on: #14423 

See https://github.com/leanprover-community/mathlib/pull/18732

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
