### PR TITLE
[Merged by Bors] - doc(FieldTheory/Finiteness): fix docstring

### DIFF
--- a/Mathlib/FieldTheory/Finiteness.lean
+++ b/Mathlib/FieldTheory/Finiteness.lean
@@ -87,7 +87,7 @@ theorem coeSort_finsetBasisIndex [IsNoetherian K V] :
 #align is_noetherian.coe_sort_finset_basis_index IsNoetherian.coeSort_finsetBasisIndex
 
 /-- In a noetherian module over a division ring, there exists a finite basis.
-This is indexed by the `Finset` `FiniteDimensional.finsetBasisIndex`.
+This is indexed by the `Finset` `IsNoetherian.finsetBasisIndex`.
 This is in contrast to the result `finite_basis_index (Basis.ofVectorSpace K V)`,
 which provides a set and a `Set.finite`.
 -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The namespace of `finsetBasisIndex` was changed three years ago in mathlib3 https://github.com/leanprover-community/mathlib/pull/7644 from (mathlib3 names) `finite_dimensional` to `is_noetherian`, but this docstring was not updated.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
