### PR TITLE
[Merged by Bors] - chore: update unexpanders

### DIFF
--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -404,32 +404,21 @@ theorem map_involutive [Nonempty α] [Nonempty β] {f : α → α} {g : β → �
   map_leftInverse
 #align prod.map_involutive Prod.map_involutive
 
-end Prod
-
 section delaborators
 open Lean PrettyPrinter Delaborator
 
-/-- Delaborator for simple product projections. -/
-@[delab app.Prod.fst, delab app.Prod.snd]
-def delabProdProjs : Delab := do
-  let #[_, _, _] := (← SubExpr.getExpr).getAppArgs | failure
-  let stx ← delabProjectionApp
-  match stx with
-  | `($(x).fst) => `($(x).1)
-  | `($(x).snd) => `($(x).2)
-  | _ => failure
+/-- Delaborator for `Prod.fst x` as `x.1`. -/
+@[delab app.Prod.fst]
+def delabProdFst : Delab := withOverApp 3 do
+  let x ← SubExpr.withAppArg delab
+  `($(x).1)
 
-/-- Delaborator for product first projection when the projection is a function
-that is then applied. -/
-@[app_unexpander Prod.fst]
-def unexpandProdFst : Lean.PrettyPrinter.Unexpander
-  | `($(_) $p $xs*) => `($p.1 $xs*)
-  | _ => throw ()
+/-- Delaborator for `Prod.snd x` as `x.2`. -/
+@[delab app.Prod.snd]
+def delabProdSnd : Delab := withOverApp 3 do
+  let x ← SubExpr.withAppArg delab
+  `($(x).2)
 
-/-- Delaborator for product second projection when the projection is a function
-that is then applied. -/
-@[app_unexpander Prod.snd]
-def unexpandProdSnd : Lean.PrettyPrinter.Unexpander
-  | `($(_) $p $xs*) => `($p.2 $xs*)
-  | _ => throw ()
 end delaborators
+
+end Prod

--- a/Mathlib/Tactic/ProjectionNotation.lean
+++ b/Mathlib/Tactic/ProjectionNotation.lean
@@ -40,8 +40,6 @@ def mkExtendedFieldNotationUnexpander (f : Name) : CommandElabM Unit := do
         -- Having a zero-argument pattern prevents unnecessary parenthesization in output
         | `($$_ $$(x).$(mkIdent toA))
         | `($$_ $$x) => set_option hygiene false in `($$(x).$(mkIdent projName))
-        | `($$_ $$(x).$(mkIdent toA) $$args*)
-        | `($$_ $$x $$args*) => set_option hygiene false in `($$(x).$(mkIdent projName) $$args*)
         | _ => throw ())
   else
     elabCommand <| ← `(command|
@@ -49,7 +47,6 @@ def mkExtendedFieldNotationUnexpander (f : Name) : CommandElabM Unit := do
       aux_def $(mkIdent <| Name.str f "unexpander") : Lean.PrettyPrinter.Unexpander := fun
         -- Having this zero-argument pattern prevents unnecessary parenthesization in output
         | `($$_ $$x) => set_option hygiene false in `($$(x).$(mkIdent projName))
-        | `($$_ $$x $$args*) => set_option hygiene false in `($$(x).$(mkIdent projName) $$args*)
         | _ => throw ())
 
 /--

--- a/test/delaborators.lean
+++ b/test/delaborators.lean
@@ -228,7 +228,7 @@ variable (x : ℕ × ℕ)
 
 variable (p : (ℕ → ℕ) × (ℕ → ℕ))
 
-/-- info: p.fst 22 : ℕ -/
+/-- info: p.1 22 : ℕ -/
 #guard_msgs in
 #check p.1 22
 


### PR DESCRIPTION
lean4#3375 makes it so that unexpanders do not need to handle overapplication.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
