### PR TITLE
[Merged by Bors] - chore: remove unnecessary `pp_dot`s

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation.lean
@@ -72,8 +72,6 @@ structure OplaxNatTrans (F G : OplaxFunctor B C) where
 #align category_theory.oplax_nat_trans.naturality_comp' CategoryTheory.OplaxNatTrans.naturality_comp
 #align category_theory.oplax_nat_trans.naturality_comp CategoryTheory.OplaxNatTrans.naturality_comp
 
-attribute [pp_dot] OplaxNatTrans.app
-
 attribute [nolint docBlame] CategoryTheory.OplaxNatTrans.app
   CategoryTheory.OplaxNatTrans.naturality
   CategoryTheory.OplaxNatTrans.naturality_naturality

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -101,8 +101,6 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 
 namespace Equivalence
 
-attribute [pp_dot] functor inverse unitIso counitIso
-
 /-- The unit of an equivalence of categories. -/
 @[pp_dot] abbrev unit (e : C ≌ D) : 𝟭 C ⟶ e.functor ⋙ e.inverse :=
   e.unitIso.hom

--- a/Mathlib/CategoryTheory/Iso.lean
+++ b/Mathlib/CategoryTheory/Iso.lean
@@ -68,9 +68,6 @@ attribute [reassoc (attr := simp)] Iso.hom_inv_id Iso.inv_hom_id
 #align category_theory.iso.hom_inv_id_assoc CategoryTheory.Iso.hom_inv_id_assoc
 #align category_theory.iso.inv_hom_id_assoc CategoryTheory.Iso.inv_hom_id_assoc
 
--- Pretty printer support for additional arguments when in a concrete category
-attribute [pp_dot] Iso.hom Iso.inv
-
 /-- Notation for an isomorphism in a category. -/
 infixr:10 " ≅ " => Iso -- type as \cong or \iso
 

--- a/Mathlib/CategoryTheory/NatTrans.lean
+++ b/Mathlib/CategoryTheory/NatTrans.lean
@@ -66,8 +66,6 @@ theorem congr_app {F G : C ⥤ D} {α β : NatTrans F G} (h : α = β) (X : C) :
 
 namespace NatTrans
 
-attribute [pp_dot] NatTrans.app
-
 /-- `NatTrans.id F` is the identity natural transformation on a functor `F`. -/
 protected def id (F : C ⥤ D) : NatTrans F F where app X := 𝟙 (F.obj X)
 #align category_theory.nat_trans.id CategoryTheory.NatTrans.id

--- a/Mathlib/CategoryTheory/Sites/Sieves.lean
+++ b/Mathlib/CategoryTheory/Sites/Sieves.lean
@@ -266,8 +266,6 @@ structure Sieve {C : Type u₁} [Category.{v₁} C] (X : C) where
   downward_closed : ∀ {Y Z f} (_ : arrows f) (g : Z ⟶ Y), arrows (g ≫ f)
 #align category_theory.sieve CategoryTheory.Sieve
 
-attribute [pp_dot] Sieve.arrows
-
 namespace Sieve
 
 instance : CoeFun (Sieve X) fun _ => Presieve X :=

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -64,8 +64,6 @@ structure Prefunctor (V : Type u₁) [Quiver.{v₁} V] (W : Type u₂) [Quiver.{
   map : ∀ {X Y : V}, (X ⟶ Y) → (obj X ⟶ obj Y)
 #align prefunctor Prefunctor
 
-attribute [pp_dot] Prefunctor.obj Prefunctor.map
-
 namespace Prefunctor
 
 -- Porting note: added during port.

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -197,8 +197,6 @@ namespace Matroid
 
 variable {α : Type _} {M : Matroid α}
 
-attribute [pp_dot] Base E
-
 /-- Typeclass for a matroid having finite ground set. Just a wrapper for `M.E.Finite`-/
 protected class Finite (M : Matroid α) : Prop where
   /-- The ground set is finite -/

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -104,8 +104,6 @@ structure IndepMatroid (α : Type*) where
 
 namespace IndepMatroid
 
-attribute [pp_dot] Indep E
-
 /-- An `M : IndepMatroid α` gives a `Matroid α` whose bases are the maximal `M`-independent sets. -/
 @[simps] protected def matroid (M : IndepMatroid α) : Matroid α where
   E := M.E

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -658,4 +658,4 @@ end Binary
 #align false_ne_true false_ne_true
 #align ne_comm ne_comm
 
-attribute [pp_dot] Iff.mp Iff.mpr False.elim Eq.symm Eq.trans
+attribute [pp_dot] False.elim Eq.symm Eq.trans

--- a/Mathlib/MeasureTheory/Measure/Tilted.lean
+++ b/Mathlib/MeasureTheory/Measure/Tilted.lean
@@ -34,11 +34,10 @@ variable {α : Type*} {mα : MeasurableSpace α} {μ : Measure α} {f : α → �
 /-- Exponentially tilted measure. When `x ↦ exp (f x)` is integrable, `μ.tilted f` is the
 probability measure with density with respect to `μ` proportional to `exp (f x)`. Otherwise it is 0.
 -/
+@[pp_dot]
 noncomputable
 def Measure.tilted (μ : Measure α) (f : α → ℝ) : Measure α :=
   μ.withDensity (fun x ↦ ENNReal.ofReal (exp (f x) / ∫ x, exp (f x) ∂μ))
-
-attribute [pp_dot] Measure.tilted
 
 @[simp]
 lemma tilted_of_not_integrable (hf : ¬ Integrable (fun x ↦ exp (f x)) μ) : μ.tilted f = 0 := by


### PR DESCRIPTION
Release 4.7.0-rc1 makes it unnecessary to add `pp_dot` to structure fields. It used to be that function fields wouldn't pretty print using dot notation when the function was applied unless `pp_dot` was added.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
