### PR TITLE
[Merged by Bors] - doc(Algebra/Module/LinearMap/End, LinearAlgebra/Dual): fix typos in docstrings

### DIFF
--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -343,7 +343,7 @@ section SMulRight
 variable [Semiring R] [Semiring R₂] [AddCommMonoid M] [AddCommMonoid M₁] [Module R M] [Module R M₁]
 variable [Semiring S] [Module R S] [Module S M] [IsScalarTower R S M]
 
-/-- When `f` is an `R`-linear map taking values in `S`, then `fun ↦ b, f b • x` is an `R`-linear
+/-- When `f` is an `R`-linear map taking values in `S`, then `fun b ↦ f b • x` is an `R`-linear
 map. -/
 def smulRight (f : M₁ →ₗ[R] S) (x : M) : M₁ →ₗ[R] M where
   toFun b := f b • x

--- a/Mathlib/LinearAlgebra/Dual.lean
+++ b/Mathlib/LinearAlgebra/Dual.lean
@@ -1793,7 +1793,7 @@ variable [CommRing R] [AddCommGroup M] [AddCommGroup N]
 
 variable [Module R M] [Module R N]
 
-/-- An inverse to `dual_tensor_dual_map` given bases.
+/-- An inverse to `TensorProduct.dualDistrib` given bases.
 -/
 noncomputable def dualDistribInvOfBasis (b : Basis ι R M) (c : Basis κ R N) :
     Dual R (M ⊗[R] N) →ₗ[R] Dual R M ⊗[R] Dual R N :=


### PR DESCRIPTION
Fix two typos:
* In `LinearAlgebra/Dual`, the doctring of `TensorProduct.dualDistribInvOfBasis` says "An inverse to `dual_tensor_dual_map` given bases.", but `dual_tensor_dual_map` is now called `TensorProduct.dualDistrib`.
* In `Algebra/Module/LinearMap/End`, the doctstring of `LinearMap.smulRight` says "When `f` is an `R`-linear map taking values in `S`, then `fun ↦ b, f b • x` is an `R`-linear map.". The map should be `fun b ↦ f b • x`.





---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
