### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Monoidal): add whiskerings to free monoidal categories

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
@@ -35,6 +35,81 @@ variable {C : Type u}
 
 section
 
+/-
+
+/-- Auxiliary structure to carry only the data fields of (and provide notation for)
+`MonoidalCategory`. -/
+class MonoidalCategoryStruct (C : Type u) [𝒞 : Category.{v} C] where
+  /-- curried tensor product of objects -/
+  tensorObj : C → C → C
+  /-- left whiskering for morphisms -/
+  whiskerLeft (X : C) {Y₁ Y₂ : C} (f : Y₁ ⟶ Y₂) : tensorObj X Y₁ ⟶ tensorObj X Y₂
+  /-- right whiskering for morphisms -/
+  whiskerRight {X₁ X₂ : C} (f : X₁ ⟶ X₂) (Y : C) : tensorObj X₁ Y ⟶ tensorObj X₂ Y
+  /-- Tensor product of identity maps is the identity: `(𝟙 X₁ ⊗ 𝟙 X₂) = 𝟙 (X₁ ⊗ X₂)` -/
+  -- By default, it is defined in terms of whiskerings.
+  tensorHom {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ⟶ Y₁) (g: X₂ ⟶ Y₂) : (tensorObj X₁ X₂ ⟶ tensorObj Y₁ Y₂) :=
+    whiskerRight f X₂ ≫ whiskerLeft Y₁ g
+  /-- The tensor unity in the monoidal structure `𝟙_ C` -/
+  tensorUnit : C
+  /-- The associator isomorphism `(X ⊗ Y) ⊗ Z ≃ X ⊗ (Y ⊗ Z)` -/
+  associator : ∀ X Y Z : C, tensorObj (tensorObj X Y) Z ≅ tensorObj X (tensorObj Y Z)
+  /-- The left unitor: `𝟙_ C ⊗ X ≃ X` -/
+  leftUnitor : ∀ X : C, tensorObj tensorUnit X ≅ X
+  /-- The right unitor: `X ⊗ 𝟙_ C ≃ X` -/
+  rightUnitor : ∀ X : C, tensorObj X tensorUnit ≅ X
+
+class MonoidalCategory (C : Type u) [𝒞 : Category.{v} C] extends MonoidalCategoryStruct C where
+  tensorHom_def {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ⟶ Y₁) (g: X₂ ⟶ Y₂) :
+    f ⊗ g = (f ▷ X₂) ≫ (Y₁ ◁ g) := by
+      aesop_cat
+  /-- Tensor product of identity maps is the identity: `(𝟙 X₁ ⊗ 𝟙 X₂) = 𝟙 (X₁ ⊗ X₂)` -/
+  tensor_id : ∀ X₁ X₂ : C, 𝟙 X₁ ⊗ 𝟙 X₂ = 𝟙 (X₁ ⊗ X₂) := by aesop_cat
+  /--
+  Composition of tensor products is tensor product of compositions:
+  `(f₁ ⊗ g₁) ∘ (f₂ ⊗ g₂) = (f₁ ∘ f₂) ⊗ (g₁ ⊗ g₂)`
+  -/
+  tensor_comp :
+    ∀ {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : C} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : Y₁ ⟶ Z₁) (g₂ : Y₂ ⟶ Z₂),
+      (f₁ ≫ g₁) ⊗ (f₂ ≫ g₂) = (f₁ ⊗ f₂) ≫ (g₁ ⊗ g₂) := by
+    aesop_cat
+  whiskerLeft_id : ∀ (X Y : C), X ◁ 𝟙 Y = 𝟙 (X ⊗ Y) := by
+    aesop_cat
+  id_whiskerRight : ∀ (X Y : C), 𝟙 X ▷ Y = 𝟙 (X ⊗ Y) := by
+    aesop_cat
+  /-- Naturality of the associator isomorphism: `(f₁ ⊗ f₂) ⊗ f₃ ≃ f₁ ⊗ (f₂ ⊗ f₃)` -/
+  associator_naturality :
+    ∀ {X₁ X₂ X₃ Y₁ Y₂ Y₃ : C} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃),
+      ((f₁ ⊗ f₂) ⊗ f₃) ≫ (α_ Y₁ Y₂ Y₃).hom = (α_ X₁ X₂ X₃).hom ≫ (f₁ ⊗ (f₂ ⊗ f₃)) := by
+    aesop_cat
+  /--
+  Naturality of the left unitor, commutativity of `𝟙_ C ⊗ X ⟶ 𝟙_ C ⊗ Y ⟶ Y` and `𝟙_ C ⊗ X ⟶ X ⟶ Y`
+  -/
+  leftUnitor_naturality :
+    ∀ {X Y : C} (f : X ⟶ Y), 𝟙_ _ ◁ f ≫ (λ_ Y).hom = (λ_ X).hom ≫ f := by
+    aesop_cat
+  /--
+  Naturality of the right unitor: commutativity of `X ⊗ 𝟙_ C ⟶ Y ⊗ 𝟙_ C ⟶ Y` and `X ⊗ 𝟙_ C ⟶ X ⟶ Y`
+  -/
+  rightUnitor_naturality :
+    ∀ {X Y : C} (f : X ⟶ Y), f ▷ 𝟙_ _ ≫ (ρ_ Y).hom = (ρ_ X).hom ≫ f := by
+    aesop_cat
+  /--
+  The pentagon identity relating the isomorphism between `X ⊗ (Y ⊗ (Z ⊗ W))` and `((X ⊗ Y) ⊗ Z) ⊗ W`
+  -/
+  pentagon :
+    ∀ W X Y Z : C,
+      (α_ W X Y).hom ▷ Z ≫ (α_ W (X ⊗ Y) Z).hom ≫ W ◁ (α_ X Y Z).hom =
+        (α_ (W ⊗ X) Y Z).hom ≫ (α_ W X (Y ⊗ Z)).hom := by
+    aesop_cat
+  /--
+  The identity relating the isomorphisms between `X ⊗ (𝟙_ C ⊗ Y)`, `(X ⊗ 𝟙_ C) ⊗ Y` and `X ⊗ Y`
+  -/
+  triangle :
+    ∀ X Y : C, (α_ X (𝟙_ _) Y).hom ≫ X ◁ (λ_ Y).hom = (ρ_ X).hom ▷ Y := by
+    aesop_cat
+-/
+
 variable (C)
 
 /--
@@ -71,6 +146,8 @@ inductive Hom : F C → F C → Type u
   | ρ_hom (X : F C) : Hom (X.tensor unit) X
   | ρ_inv (X : F C) : Hom X (X.tensor unit)
   | comp {X Y Z} (f : Hom X Y) (g : Hom Y Z) : Hom X Z
+  | whiskerLeft (X : F C) {Y₁ Y₂} (f : Hom Y₁ Y₂) : Hom (X.tensor Y₁) (X.tensor Y₂)
+  | whiskerRight {X₁ X₂} (f : Hom X₁ X₂) (Y : F C) : Hom (X₁.tensor Y) (X₂.tensor Y)
   | tensor {W X Y Z} (f : Hom W Y) (g : Hom X Z) : Hom (W.tensor X) (Y.tensor Z)
 #align category_theory.free_monoidal_category.hom CategoryTheory.FreeMonoidalCategory.Hom
 
@@ -84,8 +161,21 @@ inductive HomEquiv : ∀ {X Y : F C}, (X ⟶ᵐ Y) → (X ⟶ᵐ Y) → Prop
   | trans {X Y} {f g h : X ⟶ᵐ Y} : HomEquiv f g → HomEquiv g h → HomEquiv f h
   | comp {X Y Z} {f f' : X ⟶ᵐ Y} {g g' : Y ⟶ᵐ Z} :
       HomEquiv f f' → HomEquiv g g' → HomEquiv (f.comp g) (f'.comp g')
+
+  -- | comp_left {X Y Z} (f f' : X ⟶ᵐ Y) (g : Y ⟶ᵐ Z) : HomEquiv f f' → HomEquiv (f.comp g) (f'.comp g)
+  -- | comp_right {X Y Z} (f : X ⟶ᵐ Y) (g g' : Y ⟶ᵐ Z) : HomEquiv g g' → HomEquiv (f.comp g) (f.comp g')
+  | whiskerLeft (X) {Y Z} (f f' : Y ⟶ᵐ Z) :
+      HomEquiv f f' → HomEquiv (f.whiskerLeft X) (f'.whiskerLeft X)
+  | whiskerRight {Y Z} (f f' : Y ⟶ᵐ Z) (X) :
+      HomEquiv f f' → HomEquiv (f.whiskerRight X) (f'.whiskerRight X)
   | tensor {W X Y Z} {f f' : W ⟶ᵐ X} {g g' : Y ⟶ᵐ Z} :
       HomEquiv f f' → HomEquiv g g' → HomEquiv (f.tensor g) (f'.tensor g')
+  -- | tensor_left {X₁ Y₁ X₂ Y₂} (f f' : X₁ ⟶ᵐ Y₁) (g : X₂ ⟶ᵐ Y₂) :
+  --     HomEquiv f f' → HomEquiv (f.tensor g) (f'.tensor g)
+  -- | tensor_right {X₁ Y₁ X₂ Y₂} (f : X₁ ⟶ᵐ Y₁) (g g' : X₂ ⟶ᵐ Y₂) :
+  --     HomEquiv g g' → HomEquiv (f.tensor g) (f.tensor g')
+  | tensorHom_def {X₁ Y₁ X₂ Y₂} (f : X₁ ⟶ᵐ Y₁) (g : X₂ ⟶ᵐ Y₂) :
+      HomEquiv (f.tensor g) ((f.whiskerRight X₂).comp (g.whiskerLeft Y₁))
   | comp_id {X Y} (f : X ⟶ᵐ Y) : HomEquiv (f.comp (Hom.id _)) f
   | id_comp {X Y} (f : X ⟶ᵐ Y) : HomEquiv ((Hom.id _).comp f) f
   | assoc {X Y U V : F C} (f : X ⟶ᵐ U) (g : U ⟶ᵐ V) (h : V ⟶ᵐ Y) :
@@ -94,6 +184,8 @@ inductive HomEquiv : ∀ {X Y : F C}, (X ⟶ᵐ Y) → (X ⟶ᵐ Y) → Prop
   | tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : F C} (f₁ : X₁ ⟶ᵐ Y₁) (f₂ : X₂ ⟶ᵐ Y₂) (g₁ : Y₁ ⟶ᵐ Z₁)
       (g₂ : Y₂ ⟶ᵐ Z₂) :
     HomEquiv ((f₁.comp g₁).tensor (f₂.comp g₂)) ((f₁.tensor f₂).comp (g₁.tensor g₂))
+  | whiskerLeft_id (X Y) : HomEquiv ((Hom.id Y).whiskerLeft X) (Hom.id (X.tensor Y))
+  | id_whiskerRight (X Y) : HomEquiv ((Hom.id X).whiskerRight Y) (Hom.id (X.tensor Y))
   | α_hom_inv {X Y Z} : HomEquiv ((Hom.α_hom X Y Z).comp (Hom.α_inv X Y Z)) (Hom.id _)
   | α_inv_hom {X Y Z} : HomEquiv ((Hom.α_inv X Y Z).comp (Hom.α_hom X Y Z)) (Hom.id _)
   | associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃} (f₁ : X₁ ⟶ᵐ Y₁) (f₂ : X₂ ⟶ᵐ Y₂) (f₃ : X₃ ⟶ᵐ Y₃) :
@@ -102,19 +194,19 @@ inductive HomEquiv : ∀ {X Y : F C}, (X ⟶ᵐ Y) → (X ⟶ᵐ Y) → Prop
   | ρ_hom_inv {X} : HomEquiv ((Hom.ρ_hom X).comp (Hom.ρ_inv X)) (Hom.id _)
   | ρ_inv_hom {X} : HomEquiv ((Hom.ρ_inv X).comp (Hom.ρ_hom X)) (Hom.id _)
   | ρ_naturality {X Y} (f : X ⟶ᵐ Y) :
-      HomEquiv ((f.tensor (Hom.id unit)).comp (Hom.ρ_hom Y)) ((Hom.ρ_hom X).comp f)
+      HomEquiv ((f.whiskerRight unit).comp (Hom.ρ_hom Y)) ((Hom.ρ_hom X).comp f)
   | l_hom_inv {X} : HomEquiv ((Hom.l_hom X).comp (Hom.l_inv X)) (Hom.id _)
   | l_inv_hom {X} : HomEquiv ((Hom.l_inv X).comp (Hom.l_hom X)) (Hom.id _)
   | l_naturality {X Y} (f : X ⟶ᵐ Y) :
-      HomEquiv (((Hom.id unit).tensor f).comp (Hom.l_hom Y)) ((Hom.l_hom X).comp f)
+      HomEquiv ((f.whiskerLeft unit).comp (Hom.l_hom Y)) ((Hom.l_hom X).comp f)
   | pentagon {W X Y Z} :
       HomEquiv
-        (((Hom.α_hom W X Y).tensor (Hom.id Z)).comp
-          ((Hom.α_hom W (X.tensor Y) Z).comp ((Hom.id W).tensor (Hom.α_hom X Y Z))))
+        (((Hom.α_hom W X Y).whiskerRight Z).comp
+          ((Hom.α_hom W (X.tensor Y) Z).comp ((Hom.α_hom X Y Z).whiskerLeft W)))
         ((Hom.α_hom (W.tensor X) Y Z).comp (Hom.α_hom W X (Y.tensor Z)))
   | triangle {X Y} :
-      HomEquiv ((Hom.α_hom X unit Y).comp ((Hom.id X).tensor (Hom.l_hom Y)))
-        ((Hom.ρ_hom X).tensor (Hom.id Y))
+      HomEquiv ((Hom.α_hom X unit Y).comp ((Hom.l_hom Y).whiskerLeft X))
+        ((Hom.ρ_hom X).whiskerRight Y)
 set_option linter.uppercaseLean3 false
 #align category_theory.free_monoidal_category.HomEquiv CategoryTheory.FreeMonoidalCategory.HomEquiv
 
@@ -135,13 +227,9 @@ open FreeMonoidalCategory.HomEquiv
 
 instance categoryFreeMonoidalCategory : Category.{u} (F C) where
   Hom X Y := Quotient (FreeMonoidalCategory.setoidHom X Y)
-  id X := ⟦FreeMonoidalCategory.Hom.id _⟧
-  comp := @fun X Y Z f g =>
-    Quotient.map₂ Hom.comp
-      (by
-        intro f f' hf g g' hg
-        exact comp hf hg)
-      f g
+  -- (HomEquiv : (X ⟶ᵐ Y) → (X ⟶ᵐ Y) → Prop)
+  id X := ⟦Hom.id X⟧
+  comp := Quotient.map₂ Hom.comp (fun _ _ hf _ _ hg ↦ HomEquiv.comp hf hg)
   id_comp := by
     rintro X Y ⟨f⟩
     exact Quotient.sound (id_comp f)
@@ -155,36 +243,18 @@ instance categoryFreeMonoidalCategory : Category.{u} (F C) where
 
 instance : MonoidalCategory (F C) where
   tensorObj X Y := FreeMonoidalCategory.tensor X Y
-  tensorHom := @fun X₁ Y₁ X₂ Y₂ =>
-    Quotient.map₂ Hom.tensor <| by
-      intro _ _ h _ _ h'
-      exact HomEquiv.tensor h h'
-  whiskerLeft := fun X _ _ f =>
-    Quotient.map (fun f' => Hom.tensor (Hom.id X) f')
-      (fun _ _ h => HomEquiv.tensor (HomEquiv.refl (Hom.id X)) h) f
-  whiskerRight := fun f Y =>
-    Quotient.map (fun f' => Hom.tensor f' (Hom.id Y))
-      (fun _ _ h => HomEquiv.tensor h (HomEquiv.refl (Hom.id Y))) f
+  tensorHom := Quotient.map₂ Hom.tensor (fun _ _ hf _ _ hg ↦ HomEquiv.tensor hf hg)
+  whiskerLeft X _ _ f := Quot.map (fun f ↦ Hom.whiskerLeft X f) (fun f f' ↦ .whiskerLeft X f f') f
+  whiskerRight f Y := Quot.map (fun f ↦ Hom.whiskerRight f Y) (fun f f' ↦ .whiskerRight f f' Y) f
   tensorHom_def := by
     rintro W X Y Z ⟨f⟩ ⟨g⟩
-    apply Quotient.sound
-    calc Hom.tensor f g
-      _ ≈ Hom.tensor (Hom.comp f (Hom.id X)) (Hom.comp (Hom.id Y) g) := by
-        apply HomEquiv.tensor (HomEquiv.comp_id f).symm (HomEquiv.id_comp g).symm
-      _ ≈ Hom.comp (Hom.tensor f (Hom.id Y)) (Hom.tensor (Hom.id X) g) := by
-        apply HomEquiv.tensor_comp
-  whiskerLeft_id := by
-    rintro X Y
-    apply Quotient.sound
-    apply HomEquiv.tensor_id
-  id_whiskerRight := by
-    intro X Y
-    apply Quotient.sound
-    apply HomEquiv.tensor_id
-  tensor_id X Y := Quotient.sound tensor_id
+    exact Quotient.sound (tensorHom_def _ _)
+  tensor_id X Y := Quot.sound tensor_id
   tensor_comp := @fun X₁ Y₁ Z₁ X₂ Y₂ Z₂ => by
     rintro ⟨f₁⟩ ⟨f₂⟩ ⟨g₁⟩ ⟨g₂⟩
     exact Quotient.sound (tensor_comp _ _ _ _)
+  whiskerLeft_id X Y := Quot.sound (HomEquiv.whiskerLeft_id X Y)
+  id_whiskerRight X Y := Quot.sound (HomEquiv.id_whiskerRight X Y)
   tensorUnit := FreeMonoidalCategory.unit
   associator X Y Z :=
     ⟨⟦Hom.α_hom X Y Z⟧, ⟦Hom.α_inv X Y Z⟧, Quotient.sound α_hom_inv, Quotient.sound α_inv_hom⟩
@@ -214,6 +284,16 @@ theorem mk_tensor {X₁ Y₁ X₂ Y₂ : F C} (f : X₁ ⟶ᵐ Y₁) (g : X₂ �
     ⟦f.tensor g⟧ = @MonoidalCategory.tensorHom (F C) _ _ _ _ _ _ ⟦f⟧ ⟦g⟧ :=
   rfl
 #align category_theory.free_monoidal_category.mk_tensor CategoryTheory.FreeMonoidalCategory.mk_tensor
+
+@[simp]
+theorem mk_whiskerLeft (X : F C) {Y₁ Y₂ : F C} (f : Y₁ ⟶ᵐ Y₂) :
+    ⟦f.whiskerLeft X⟧ = MonoidalCategory.whiskerLeft (C := F C) (X := X) (f := ⟦f⟧) :=
+  rfl
+
+@[simp]
+theorem mk_whiskerRight {X₁ X₂ : F C} (f : X₁ ⟶ᵐ X₂) (Y : F C) :
+    ⟦f.whiskerRight Y⟧ = MonoidalCategory.whiskerRight (C := F C) (f := ⟦f⟧) (Y := Y) :=
+  rfl
 
 @[simp]
 theorem mk_id {X : F C} : ⟦Hom.id X⟧ = 𝟙 X :=
@@ -260,6 +340,40 @@ theorem unit_eq_unit : FreeMonoidalCategory.unit = 𝟙_ (F C) :=
   rfl
 #align category_theory.free_monoidal_category.unit_eq_unit CategoryTheory.FreeMonoidalCategory.unit_eq_unit
 
+abbrev homMk {X Y : F C} (f : X ⟶ᵐ Y) : X ⟶ Y := ⟦f⟧
+
+theorem Hom.inductionOn {motive : {X Y : F C} → (X ⟶ Y) → Prop} {X Y : F C} (t : X ⟶ Y)
+    (id : (X : F C) → motive (𝟙 X))
+    (α_hom : (X Y Z : F C) → motive (α_ X Y Z).hom)
+    (α_inv : (X Y Z : F C) → motive (α_ X Y Z).inv)
+    (l_hom : (X : F C) → motive (λ_ X).hom)
+    (l_inv : (X : F C) → motive (λ_ X).inv)
+    (ρ_hom : (X : F C) → motive (ρ_ X).hom)
+    (ρ_inv : (X : F C) → motive (ρ_ X).inv)
+    (comp : {X Y Z : F C} → (f : X ⟶ Y) → (g : Y ⟶ Z) → motive f → motive g → motive (f ≫ g))
+    (whiskerLeft : (X : F C) → {Y Z : F C} → (f : Y ⟶ Z) → motive f → motive (X ◁ f))
+    (whiskerRight : {X Y : F C} → (f : X ⟶ Y) → (Z : F C) → motive f → motive (f ▷ Z)) :
+    motive t := by
+  apply Quotient.inductionOn
+  intro f
+  induction f with
+  | id X => exact id X
+  | α_hom X Y Z => exact α_hom X Y Z
+  | α_inv X Y Z => exact α_inv X Y Z
+  | l_hom X => exact l_hom X
+  | l_inv X => exact l_inv X
+  | ρ_hom X => exact ρ_hom X
+  | ρ_inv X => exact ρ_inv X
+  | comp f g hf hg => exact comp _ _ (hf ⟦f⟧) (hg ⟦g⟧)
+  | whiskerLeft X f hf => exact whiskerLeft X _ (hf ⟦f⟧)
+  | whiskerRight f X hf => exact whiskerRight _ X (hf ⟦f⟧)
+  | @tensor W X Y Z f g hf hg =>
+      have : homMk f ⊗ homMk g = homMk f ▷ X ≫ Y ◁ homMk g :=
+        Quotient.sound (HomEquiv.tensorHom_def f g)
+      change motive (homMk f ⊗ homMk g)
+      rw [this]
+      exact comp _ _ (whiskerRight _ _ (hf ⟦f⟧)) (whiskerLeft _ _ (hg ⟦g⟧))
+
 section Functor
 
 variable {D : Type u'} [Category.{v'} D] [MonoidalCategory D] (f : C → D)
@@ -288,6 +402,8 @@ def projectMapAux : ∀ {X Y : F C}, (X ⟶ᵐ Y) → (projectObj f X ⟶ projec
   | _, _, ρ_hom _ => (ρ_ _).hom
   | _, _, ρ_inv _ => (ρ_ _).inv
   | _, _, Hom.comp f g => projectMapAux f ≫ projectMapAux g
+  | _, _, Hom.whiskerLeft X p => projectObj f X ◁ projectMapAux p
+  | _, _, Hom.whiskerRight p X => projectMapAux p ▷ projectObj f X
   | _, _, Hom.tensor f g => projectMapAux f ⊗ projectMapAux g
 #align category_theory.free_monoidal_category.project_map_aux CategoryTheory.FreeMonoidalCategory.projectMapAux
 
@@ -301,12 +417,22 @@ def projectMap (X Y : F C) : (X ⟶ Y) → (projectObj f X ⟶ projectObj f Y) :
     | symm _ _ _ hfg' => exact hfg'.symm
     | trans _ _ hfg hgh => exact hfg.trans hgh
     | comp _ _ hf hg => dsimp only [projectMapAux]; rw [hf, hg]
+    | whiskerLeft _ _ _ _ hf => dsimp only [projectMapAux, projectObj]; rw [hf]
+    | whiskerRight _ _ _ _ hf => dsimp only [projectMapAux, projectObj]; rw [hf]
     | tensor _ _ hfg hfg' => dsimp only [projectMapAux]; rw [hfg, hfg']
+    | tensorHom_def _ _ =>
+        dsimp only [projectMapAux, projectObj]; rw [MonoidalCategory.tensorHom_def]
     | comp_id => dsimp only [projectMapAux]; rw [Category.comp_id]
     | id_comp => dsimp only [projectMapAux]; rw [Category.id_comp]
     | assoc => dsimp only [projectMapAux]; rw [Category.assoc]
     | tensor_id => dsimp only [projectMapAux]; rw [MonoidalCategory.tensor_id]; rfl
     | tensor_comp => dsimp only [projectMapAux]; rw [MonoidalCategory.tensor_comp]
+    | whiskerLeft_id =>
+        dsimp only [projectMapAux, projectObj]
+        rw [MonoidalCategory.whiskerLeft_id]
+    | id_whiskerRight =>
+        dsimp only [projectMapAux, projectObj]
+        rw [MonoidalCategory.id_whiskerRight]
     | α_hom_inv => dsimp only [projectMapAux]; rw [Iso.hom_inv_id]
     | α_inv_hom => dsimp only [projectMapAux]; rw [Iso.inv_hom_id]
     | associator_naturality =>
@@ -315,21 +441,18 @@ def projectMap (X Y : F C) : (X ⟶ Y) → (projectObj f X ⟶ projectObj f Y) :
     | ρ_inv_hom => dsimp only [projectMapAux]; rw [Iso.inv_hom_id]
     | ρ_naturality =>
         dsimp only [projectMapAux, projectObj]
-        rw [tensorHom_id, MonoidalCategory.rightUnitor_naturality]
+        rw [MonoidalCategory.rightUnitor_naturality]
     | l_hom_inv => dsimp only [projectMapAux]; rw [Iso.hom_inv_id]
     | l_inv_hom => dsimp only [projectMapAux]; rw [Iso.inv_hom_id]
     | l_naturality =>
         dsimp only [projectMapAux, projectObj]
-        rw [id_tensorHom]
-        exact MonoidalCategory.leftUnitor_naturality _
+        rw [MonoidalCategory.leftUnitor_naturality]
     | pentagon =>
-        dsimp only [projectMapAux]
-        simp only [tensorHom_id, id_tensorHom]
-        exact MonoidalCategory.pentagon _ _ _ _
+        dsimp only [projectMapAux, projectObj]
+        rw [MonoidalCategory.pentagon]
     | triangle =>
-        dsimp only [projectMapAux]
-        simp only [tensorHom_id, id_tensorHom]
-        exact MonoidalCategory.triangle _ _
+        dsimp only [projectMapAux, projectObj]
+        rw [MonoidalCategory.triangle]
 #align category_theory.free_monoidal_category.project_map CategoryTheory.FreeMonoidalCategory.projectMap
 
 end

--- a/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
@@ -257,6 +257,10 @@ theorem unit_eq_unit : FreeMonoidalCategory.unit = 𝟙_ (F C) :=
   rfl
 #align category_theory.free_monoidal_category.unit_eq_unit CategoryTheory.FreeMonoidalCategory.unit_eq_unit
 
+/-- The abbreviation for `⟦f⟧`. -/
+/- This is useful since the notation `⟦f⟧` often behaves like an element of the quotient set,
+but not like a morphism. This is why we need weird `@CategoryStruct.comp (F C) ...` in the
+statement in `mk_comp` above. -/
 abbrev homMk {X Y : F C} (f : X ⟶ᵐ Y) : X ⟶ Y := ⟦f⟧
 
 theorem Hom.inductionOn {motive : {X Y : F C} → (X ⟶ Y) → Prop} {X Y : F C} (t : X ⟶ Y)

--- a/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
@@ -145,13 +145,8 @@ open FreeMonoidalCategory.HomEquiv
 
 instance categoryFreeMonoidalCategory : Category.{u} (F C) where
   Hom X Y := Quotient (FreeMonoidalCategory.setoidHom X Y)
-  id X := ⟦FreeMonoidalCategory.Hom.id _⟧
-  comp := @fun X Y Z f g =>
-    Quotient.map₂ Hom.comp
-      (by
-        intro f f' hf g g' hg
-        exact comp hf hg)
-      f g
+  id X := ⟦Hom.id X⟧
+  comp := Quotient.map₂ Hom.comp (fun _ _ hf _ _ hg ↦ HomEquiv.comp hf hg)
   id_comp := by
     rintro X Y ⟨f⟩
     exact Quotient.sound (id_comp f)

--- a/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
@@ -35,81 +35,6 @@ variable {C : Type u}
 
 section
 
-/-
-
-/-- Auxiliary structure to carry only the data fields of (and provide notation for)
-`MonoidalCategory`. -/
-class MonoidalCategoryStruct (C : Type u) [𝒞 : Category.{v} C] where
-  /-- curried tensor product of objects -/
-  tensorObj : C → C → C
-  /-- left whiskering for morphisms -/
-  whiskerLeft (X : C) {Y₁ Y₂ : C} (f : Y₁ ⟶ Y₂) : tensorObj X Y₁ ⟶ tensorObj X Y₂
-  /-- right whiskering for morphisms -/
-  whiskerRight {X₁ X₂ : C} (f : X₁ ⟶ X₂) (Y : C) : tensorObj X₁ Y ⟶ tensorObj X₂ Y
-  /-- Tensor product of identity maps is the identity: `(𝟙 X₁ ⊗ 𝟙 X₂) = 𝟙 (X₁ ⊗ X₂)` -/
-  -- By default, it is defined in terms of whiskerings.
-  tensorHom {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ⟶ Y₁) (g: X₂ ⟶ Y₂) : (tensorObj X₁ X₂ ⟶ tensorObj Y₁ Y₂) :=
-    whiskerRight f X₂ ≫ whiskerLeft Y₁ g
-  /-- The tensor unity in the monoidal structure `𝟙_ C` -/
-  tensorUnit : C
-  /-- The associator isomorphism `(X ⊗ Y) ⊗ Z ≃ X ⊗ (Y ⊗ Z)` -/
-  associator : ∀ X Y Z : C, tensorObj (tensorObj X Y) Z ≅ tensorObj X (tensorObj Y Z)
-  /-- The left unitor: `𝟙_ C ⊗ X ≃ X` -/
-  leftUnitor : ∀ X : C, tensorObj tensorUnit X ≅ X
-  /-- The right unitor: `X ⊗ 𝟙_ C ≃ X` -/
-  rightUnitor : ∀ X : C, tensorObj X tensorUnit ≅ X
-
-class MonoidalCategory (C : Type u) [𝒞 : Category.{v} C] extends MonoidalCategoryStruct C where
-  tensorHom_def {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ⟶ Y₁) (g: X₂ ⟶ Y₂) :
-    f ⊗ g = (f ▷ X₂) ≫ (Y₁ ◁ g) := by
-      aesop_cat
-  /-- Tensor product of identity maps is the identity: `(𝟙 X₁ ⊗ 𝟙 X₂) = 𝟙 (X₁ ⊗ X₂)` -/
-  tensor_id : ∀ X₁ X₂ : C, 𝟙 X₁ ⊗ 𝟙 X₂ = 𝟙 (X₁ ⊗ X₂) := by aesop_cat
-  /--
-  Composition of tensor products is tensor product of compositions:
-  `(f₁ ⊗ g₁) ∘ (f₂ ⊗ g₂) = (f₁ ∘ f₂) ⊗ (g₁ ⊗ g₂)`
-  -/
-  tensor_comp :
-    ∀ {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : C} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : Y₁ ⟶ Z₁) (g₂ : Y₂ ⟶ Z₂),
-      (f₁ ≫ g₁) ⊗ (f₂ ≫ g₂) = (f₁ ⊗ f₂) ≫ (g₁ ⊗ g₂) := by
-    aesop_cat
-  whiskerLeft_id : ∀ (X Y : C), X ◁ 𝟙 Y = 𝟙 (X ⊗ Y) := by
-    aesop_cat
-  id_whiskerRight : ∀ (X Y : C), 𝟙 X ▷ Y = 𝟙 (X ⊗ Y) := by
-    aesop_cat
-  /-- Naturality of the associator isomorphism: `(f₁ ⊗ f₂) ⊗ f₃ ≃ f₁ ⊗ (f₂ ⊗ f₃)` -/
-  associator_naturality :
-    ∀ {X₁ X₂ X₃ Y₁ Y₂ Y₃ : C} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃),
-      ((f₁ ⊗ f₂) ⊗ f₃) ≫ (α_ Y₁ Y₂ Y₃).hom = (α_ X₁ X₂ X₃).hom ≫ (f₁ ⊗ (f₂ ⊗ f₃)) := by
-    aesop_cat
-  /--
-  Naturality of the left unitor, commutativity of `𝟙_ C ⊗ X ⟶ 𝟙_ C ⊗ Y ⟶ Y` and `𝟙_ C ⊗ X ⟶ X ⟶ Y`
-  -/
-  leftUnitor_naturality :
-    ∀ {X Y : C} (f : X ⟶ Y), 𝟙_ _ ◁ f ≫ (λ_ Y).hom = (λ_ X).hom ≫ f := by
-    aesop_cat
-  /--
-  Naturality of the right unitor: commutativity of `X ⊗ 𝟙_ C ⟶ Y ⊗ 𝟙_ C ⟶ Y` and `X ⊗ 𝟙_ C ⟶ X ⟶ Y`
-  -/
-  rightUnitor_naturality :
-    ∀ {X Y : C} (f : X ⟶ Y), f ▷ 𝟙_ _ ≫ (ρ_ Y).hom = (ρ_ X).hom ≫ f := by
-    aesop_cat
-  /--
-  The pentagon identity relating the isomorphism between `X ⊗ (Y ⊗ (Z ⊗ W))` and `((X ⊗ Y) ⊗ Z) ⊗ W`
-  -/
-  pentagon :
-    ∀ W X Y Z : C,
-      (α_ W X Y).hom ▷ Z ≫ (α_ W (X ⊗ Y) Z).hom ≫ W ◁ (α_ X Y Z).hom =
-        (α_ (W ⊗ X) Y Z).hom ≫ (α_ W X (Y ⊗ Z)).hom := by
-    aesop_cat
-  /--
-  The identity relating the isomorphisms between `X ⊗ (𝟙_ C ⊗ Y)`, `(X ⊗ 𝟙_ C) ⊗ Y` and `X ⊗ Y`
-  -/
-  triangle :
-    ∀ X Y : C, (α_ X (𝟙_ _) Y).hom ≫ X ◁ (λ_ Y).hom = (ρ_ X).hom ▷ Y := by
-    aesop_cat
--/
-
 variable (C)
 
 /--
@@ -161,19 +86,12 @@ inductive HomEquiv : ∀ {X Y : F C}, (X ⟶ᵐ Y) → (X ⟶ᵐ Y) → Prop
   | trans {X Y} {f g h : X ⟶ᵐ Y} : HomEquiv f g → HomEquiv g h → HomEquiv f h
   | comp {X Y Z} {f f' : X ⟶ᵐ Y} {g g' : Y ⟶ᵐ Z} :
       HomEquiv f f' → HomEquiv g g' → HomEquiv (f.comp g) (f'.comp g')
-
-  -- | comp_left {X Y Z} (f f' : X ⟶ᵐ Y) (g : Y ⟶ᵐ Z) : HomEquiv f f' → HomEquiv (f.comp g) (f'.comp g)
-  -- | comp_right {X Y Z} (f : X ⟶ᵐ Y) (g g' : Y ⟶ᵐ Z) : HomEquiv g g' → HomEquiv (f.comp g) (f.comp g')
   | whiskerLeft (X) {Y Z} (f f' : Y ⟶ᵐ Z) :
       HomEquiv f f' → HomEquiv (f.whiskerLeft X) (f'.whiskerLeft X)
   | whiskerRight {Y Z} (f f' : Y ⟶ᵐ Z) (X) :
       HomEquiv f f' → HomEquiv (f.whiskerRight X) (f'.whiskerRight X)
   | tensor {W X Y Z} {f f' : W ⟶ᵐ X} {g g' : Y ⟶ᵐ Z} :
       HomEquiv f f' → HomEquiv g g' → HomEquiv (f.tensor g) (f'.tensor g')
-  -- | tensor_left {X₁ Y₁ X₂ Y₂} (f f' : X₁ ⟶ᵐ Y₁) (g : X₂ ⟶ᵐ Y₂) :
-  --     HomEquiv f f' → HomEquiv (f.tensor g) (f'.tensor g)
-  -- | tensor_right {X₁ Y₁ X₂ Y₂} (f : X₁ ⟶ᵐ Y₁) (g g' : X₂ ⟶ᵐ Y₂) :
-  --     HomEquiv g g' → HomEquiv (f.tensor g) (f.tensor g')
   | tensorHom_def {X₁ Y₁ X₂ Y₂} (f : X₁ ⟶ᵐ Y₁) (g : X₂ ⟶ᵐ Y₂) :
       HomEquiv (f.tensor g) ((f.whiskerRight X₂).comp (g.whiskerLeft Y₁))
   | comp_id {X Y} (f : X ⟶ᵐ Y) : HomEquiv (f.comp (Hom.id _)) f
@@ -227,9 +145,13 @@ open FreeMonoidalCategory.HomEquiv
 
 instance categoryFreeMonoidalCategory : Category.{u} (F C) where
   Hom X Y := Quotient (FreeMonoidalCategory.setoidHom X Y)
-  -- (HomEquiv : (X ⟶ᵐ Y) → (X ⟶ᵐ Y) → Prop)
-  id X := ⟦Hom.id X⟧
-  comp := Quotient.map₂ Hom.comp (fun _ _ hf _ _ hg ↦ HomEquiv.comp hf hg)
+  id X := ⟦FreeMonoidalCategory.Hom.id _⟧
+  comp := @fun X Y Z f g =>
+    Quotient.map₂ Hom.comp
+      (by
+        intro f f' hf g g' hg
+        exact comp hf hg)
+      f g
   id_comp := by
     rintro X Y ⟨f⟩
     exact Quotient.sound (id_comp f)

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -95,7 +95,6 @@ theorem inclusion_map {X Y : N C} (f : X ⟶ Y) :
   apply inclusion.map_id
 
 /-- Auxiliary definition for `normalize`. -/
-@[simp]
 def normalizeObj : F C → NormalMonoidalObject C → NormalMonoidalObject C
   | unit, n => n
   | of X, n => NormalMonoidalObject.tensor n X
@@ -113,6 +112,9 @@ theorem normalizeObj_tensor (X Y : F C) (n : NormalMonoidalObject C) :
   rfl
 #align category_theory.free_monoidal_category.normalize_obj_tensor CategoryTheory.FreeMonoidalCategory.normalizeObj_tensor
 
+/-- Auxiliary definition for `normalize`. -/
+def normalizeObj' (X : F C) : N C ⥤ N C := Discrete.functor fun n ↦ ⟨normalizeObj X n⟩
+
 section
 
 open Hom
@@ -120,10 +122,7 @@ open Hom
 /-- Auxiliary definition for `normalize`. Here we prove that objects that are related by
     associators and unitors map to the same normal form. -/
 @[simp]
-def normalizeMapAux :
-    ∀ {X Y : F C}, (X ⟶ᵐ Y) →
-      ((Discrete.functor (fun n ↦ ⟨normalizeObj X n⟩) : N C ⥤ N C) ⟶
-        Discrete.functor fun n ↦ ⟨normalizeObj Y n⟩)
+def normalizeMapAux : ∀ {X Y : F C}, (X ⟶ᵐ Y) → (normalizeObj' X ⟶ normalizeObj' Y)
   | _, _, Hom.id _ => 𝟙 _
   | _, _, α_hom X Y Z => by dsimp; exact Discrete.natTrans (fun _ => 𝟙 _)
   | _, _, α_inv _ _ _ => by dsimp; exact Discrete.natTrans (fun _ => 𝟙 _)
@@ -133,13 +132,12 @@ def normalizeMapAux :
   | _, _, ρ_inv _ => by dsimp; exact Discrete.natTrans (fun _ => 𝟙 _)
   | _, _, (@comp _ _ _ _ f g) => normalizeMapAux f ≫ normalizeMapAux g
   | _, _, (@Hom.tensor _ T _ _ W f g) =>
-    Discrete.natTrans (fun ⟨X⟩ => (normalizeMapAux g).app ⟨normalizeObj T X⟩ ≫
-      (Discrete.functor fun n ↦ ⟨normalizeObj W n⟩ : N C ⥤ N C).map ((normalizeMapAux f).app ⟨X⟩))
+    Discrete.natTrans <| fun ⟨X⟩ => (normalizeMapAux g).app ⟨normalizeObj T X⟩ ≫
+      (normalizeObj' W).map ((normalizeMapAux f).app ⟨X⟩)
   | _, _, (@Hom.whiskerLeft _ T _ W f) =>
-    Discrete.natTrans (fun ⟨X⟩ => (normalizeMapAux f).app ⟨normalizeObj T X⟩)
+    Discrete.natTrans <| fun ⟨X⟩ => (normalizeMapAux f).app ⟨normalizeObj T X⟩
   | _, _, (@Hom.whiskerRight _ T _ f W) =>
-    Discrete.natTrans <| fun X =>
-      (Discrete.functor fun n ↦ ⟨normalizeObj W n⟩ : N C ⥤ N C).map <| (normalizeMapAux f).app X
+    Discrete.natTrans <| fun X => (normalizeObj' W).map <| (normalizeMapAux f).app X
 #align category_theory.free_monoidal_category.normalize_map_aux CategoryTheory.FreeMonoidalCategory.normalizeMapAux
 
 end
@@ -153,7 +151,7 @@ variable (C)
     `𝟙_ C`. -/
 @[simp]
 def normalize : F C ⥤ N C ⥤ N C where
-  obj X := Discrete.functor (fun n ↦ ⟨normalizeObj X n⟩)
+  obj X := normalizeObj' X
   map {X Y} := Quotient.lift normalizeMapAux (by aesop_cat)
 #align category_theory.free_monoidal_category.normalize CategoryTheory.FreeMonoidalCategory.normalize
 

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -78,27 +78,38 @@ def inclusionObj : NormalMonoidalObject C → F C
 #align category_theory.free_monoidal_category.inclusion_obj CategoryTheory.FreeMonoidalCategory.inclusionObj
 
 /-- The discrete subcategory of objects in normal form includes into the free monoidal category. -/
-@[simp]
 def inclusion : N C ⥤ F C :=
   Discrete.functor inclusionObj
 #align category_theory.free_monoidal_category.inclusion CategoryTheory.FreeMonoidalCategory.inclusion
 
+@[simp]
+theorem inclusion_obj (X : N C) :
+    inclusion.obj X = inclusionObj X.as :=
+  rfl
+
+@[simp]
+theorem inclusion_map {X Y : N C} (f : X ⟶ Y) :
+    inclusion.map f = eqToHom (congr_arg _ (Discrete.ext _ _ (Discrete.eq_of_hom f))) := by
+  rcases f with ⟨⟨⟩⟩
+  cases Discrete.ext _ _ (by assumption)
+  apply inclusion.map_id
+
 /-- Auxiliary definition for `normalize`. -/
 @[simp]
-def normalizeObj : F C → NormalMonoidalObject C → N C
-  | unit, n => ⟨n⟩
-  | of X, n => ⟨NormalMonoidalObject.tensor n X⟩
-  | tensor X Y, n => normalizeObj Y (normalizeObj X n).as
+def normalizeObj : F C → NormalMonoidalObject C → NormalMonoidalObject C
+  | unit, n => n
+  | of X, n => NormalMonoidalObject.tensor n X
+  | tensor X Y, n => normalizeObj Y (normalizeObj X n)
 #align category_theory.free_monoidal_category.normalize_obj CategoryTheory.FreeMonoidalCategory.normalizeObj
 
 @[simp]
-theorem normalizeObj_unitor (n : NormalMonoidalObject C) : normalizeObj (𝟙_ (F C)) n = ⟨n⟩ :=
+theorem normalizeObj_unitor (n : NormalMonoidalObject C) : normalizeObj (𝟙_ (F C)) n = n :=
   rfl
 #align category_theory.free_monoidal_category.normalize_obj_unitor CategoryTheory.FreeMonoidalCategory.normalizeObj_unitor
 
 @[simp]
 theorem normalizeObj_tensor (X Y : F C) (n : NormalMonoidalObject C) :
-    normalizeObj (X ⊗ Y) n = normalizeObj Y (normalizeObj X n).as :=
+    normalizeObj (X ⊗ Y) n = normalizeObj Y (normalizeObj X n) :=
   rfl
 #align category_theory.free_monoidal_category.normalize_obj_tensor CategoryTheory.FreeMonoidalCategory.normalizeObj_tensor
 
@@ -114,7 +125,8 @@ open Hom
 @[simp]
 def normalizeMapAux :
     ∀ {X Y : F C}, (X ⟶ᵐ Y) →
-      ((Discrete.functor (normalizeObj X) : _ ⥤ N C) ⟶ Discrete.functor (normalizeObj Y))
+      ((Discrete.functor (fun n ↦ ⟨normalizeObj X n⟩) : N C ⥤ N C) ⟶
+        Discrete.functor fun n ↦ ⟨normalizeObj Y n⟩)
   | _, _, Hom.id _ => 𝟙 _
   | _, _, α_hom X Y Z => by dsimp; exact Discrete.natTrans (fun _ => 𝟙 _)
   | _, _, α_inv _ _ _ => by dsimp; exact Discrete.natTrans (fun _ => 𝟙 _)
@@ -123,10 +135,14 @@ def normalizeMapAux :
   | _, _, ρ_hom _ => by dsimp; exact Discrete.natTrans (fun _ => 𝟙 _)
   | _, _, ρ_inv _ => by dsimp; exact Discrete.natTrans (fun _ => 𝟙 _)
   | _, _, (@comp _ _ _ _ f g) => normalizeMapAux f ≫ normalizeMapAux g
-  | _, _, (@Hom.tensor _ T _ _ W f g) => by
-    dsimp
-    exact Discrete.natTrans (fun ⟨X⟩ => (normalizeMapAux g).app (normalizeObj T X) ≫
-      (Discrete.functor (normalizeObj W) : _ ⥤ N C).map ((normalizeMapAux f).app ⟨X⟩))
+  | _, _, (@Hom.tensor _ T _ _ W f g) =>
+    Discrete.natTrans (fun ⟨X⟩ => (normalizeMapAux g).app ⟨normalizeObj T X⟩ ≫
+      (Discrete.functor fun n ↦ ⟨normalizeObj W n⟩ : N C ⥤ N C).map ((normalizeMapAux f).app ⟨X⟩))
+  | _, _, (@Hom.whiskerLeft _ T _ W f) =>
+    Discrete.natTrans (fun ⟨X⟩ => (normalizeMapAux f).app ⟨normalizeObj T X⟩)
+  | _, _, (@Hom.whiskerRight _ T _ f W) =>
+    Discrete.natTrans <| fun X =>
+      (Discrete.functor fun n ↦ ⟨normalizeObj W n⟩ : N C ⥤ N C).map <| (normalizeMapAux f).app X
 #align category_theory.free_monoidal_category.normalize_map_aux CategoryTheory.FreeMonoidalCategory.normalizeMapAux
 
 end
@@ -140,7 +156,7 @@ variable (C)
     `𝟙_ C`. -/
 @[simp]
 def normalize : F C ⥤ N C ⥤ N C where
-  obj X := Discrete.functor (normalizeObj X)
+  obj X := Discrete.functor (fun n ↦ ⟨normalizeObj X n⟩)
   map {X Y} := Quotient.lift normalizeMapAux (by aesop_cat)
 #align category_theory.free_monoidal_category.normalize CategoryTheory.FreeMonoidalCategory.normalize
 
@@ -166,7 +182,7 @@ def tensorFunc : F C ⥤ N C ⥤ F C where
   map f := Discrete.natTrans (fun n => _ ◁ f)
 #align category_theory.free_monoidal_category.tensor_func CategoryTheory.FreeMonoidalCategory.tensorFunc
 
-theorem tensorFunc_map_app {X Y : F C} (f : X ⟶ Y) (n) : ((tensorFunc C).map f).app n = 𝟙 _ ⊗ f :=
+theorem tensorFunc_map_app {X Y : F C} (f : X ⟶ Y) (n) : ((tensorFunc C).map f).app n = _ ◁ f :=
   rfl
 #align category_theory.free_monoidal_category.tensor_func_map_app CategoryTheory.FreeMonoidalCategory.tensorFunc_map_app
 
@@ -188,14 +204,34 @@ def normalizeIsoApp :
     ∀ (X : F C) (n : N C), ((tensorFunc C).obj X).obj n ≅ ((normalize' C).obj X).obj n
   | of _, _ => Iso.refl _
   | unit, _ => ρ_ _
-  | tensor X _, n =>
-    (α_ _ _ _).symm ≪≫ tensorIso (normalizeIsoApp X n) (Iso.refl _) ≪≫ normalizeIsoApp _ _
+  | tensor X a, n =>
+    (α_ _ _ _).symm ≪≫ whiskerRightIso (normalizeIsoApp X n) a ≪≫ normalizeIsoApp _ _
 #align category_theory.free_monoidal_category.normalize_iso_app CategoryTheory.FreeMonoidalCategory.normalizeIsoApp
+
+/-- Almost non-definitionally equall to `normalizeIsoApp`, but has a better definitional property
+in the proof of `normalize_naturality`. -/
+@[simp]
+def normalizeIsoApp' :
+    ∀ (X : F C) (n : NormalMonoidalObject C), inclusionObj n ⊗ X ≅ inclusionObj (normalizeObj X n)
+  | of _, _ => Iso.refl _
+  | unit, _ => ρ_ _
+  | tensor X Y, n =>
+    (α_ _ _ _).symm ≪≫ whiskerRightIso (normalizeIsoApp' X n) Y ≪≫ normalizeIsoApp' _ _
+
+theorem normalizeIsoApp_eq :
+    ∀ (X : F C) (n : N C), normalizeIsoApp C X n = normalizeIsoApp' C X n.as
+  | of X, _ => rfl
+  | unit, _ => rfl
+  | tensor X Y, n => by
+      rw [normalizeIsoApp, normalizeIsoApp']
+      rw [normalizeIsoApp_eq X n]
+      rw [normalizeIsoApp_eq Y ⟨normalizeObj X n.as⟩]
+      rfl
 
 @[simp]
 theorem normalizeIsoApp_tensor (X Y : F C) (n : N C) :
     normalizeIsoApp C (X ⊗ Y) n =
-      (α_ _ _ _).symm ≪≫ tensorIso (normalizeIsoApp C X n) (Iso.refl _) ≪≫ normalizeIsoApp _ _ _ :=
+      (α_ _ _ _).symm ≪≫ whiskerRightIso (normalizeIsoApp C X n) Y ≪≫ normalizeIsoApp _ _ _ :=
   rfl
 #align category_theory.free_monoidal_category.normalize_iso_app_tensor CategoryTheory.FreeMonoidalCategory.normalizeIsoApp_tensor
 
@@ -233,84 +269,58 @@ theorem discrete_functor_map_eq_id (g : X ⟶ X) : (Discrete.functor f).map g = 
 
 end
 
+section
+
+variable {C}
+
+theorem normalizeObj_congr (n : NormalMonoidalObject C) {X Y : F C} (f : X ⟶ Y) :
+    normalizeObj X n = normalizeObj Y n := by
+  rcases f with ⟨f'⟩
+  apply @congr_fun _ _ fun n => normalizeObj X n
+  clear n f
+  induction f' with
+  | comp _ _ _ _ => apply Eq.trans <;> assumption
+  | whiskerLeft  _ _ ih => funext; apply congr_fun ih
+  | whiskerRight _ _ ih => funext; apply congr_arg₂ _ rfl (congr_fun ih _)
+  | @tensor W X Y Z _ _ ih₁ ih₂ =>
+      funext n
+      simp [congr_fun ih₁ n, congr_fun ih₂ (normalizeObj Y n)]
+  | _ => funext; rfl
+
+theorem normalize_naturality (n : NormalMonoidalObject C) {X Y : F C} (f : X ⟶ Y) :
+    inclusionObj n ◁ f ≫ (normalizeIsoApp' C Y n).hom =
+      (normalizeIsoApp' C X n).hom ≫
+        inclusion.map (eqToHom (Discrete.ext _ _ (normalizeObj_congr n f))) := by
+  revert n
+  induction f using Hom.inductionOn
+  case comp f g ihf ihg => simp [ihg, reassoc_of% (ihf _)]
+  case whiskerLeft X' X Y f ih =>
+    intro n
+    dsimp only [normalizeObj_tensor, normalizeIsoApp', tensor_eq_tensor, Iso.trans_hom,
+      Iso.symm_hom, whiskerRightIso_hom, Function.comp_apply, inclusion_obj]
+    rw [associator_inv_naturality_right_assoc, whisker_exchange_assoc, ih]
+    simp
+  case whiskerRight X Y h η' ih =>
+    intro n
+    dsimp only [normalizeObj_tensor, normalizeIsoApp', tensor_eq_tensor, Iso.trans_hom,
+      Iso.symm_hom, whiskerRightIso_hom, Function.comp_apply, inclusion_obj]
+    rw [associator_inv_naturality_middle_assoc, ← comp_whiskerRight_assoc, ih]
+    have := dcongr_arg (fun x => (normalizeIsoApp' C η' x).hom) (normalizeObj_congr n h)
+    simp [this]
+  all_goals simp
+
+end
+
 set_option tactic.skipAssignedInstances false in
 /-- The isomorphism between `n ⊗ X` and `normalize X n` is natural (in both `X` and `n`, but
     naturality in `n` is trivial and was "proved" in `normalizeIsoAux`). This is the real heart
     of our proof of the coherence theorem. -/
 def normalizeIso : tensorFunc C ≅ normalize' C :=
-  NatIso.ofComponents (normalizeIsoAux C)
-    (by -- Porting note: the proof has been mostly rewritten
-      rintro X Y f
-      induction' f using Quotient.recOn with f; swap; rfl
-      induction' f with _ X₁ X₂ X₃ _ _ _ _ _ _ _ _ _ _ _ _ h₁ h₂ X₁ X₂ Y₁ Y₂ f g h₁ h₂
-      · simp only [mk_id, Functor.map_id, Category.comp_id, Category.id_comp]
-      · ext n
-        dsimp
-        rw [mk_α_hom, NatTrans.comp_app, NatTrans.comp_app]
-        dsimp [NatIso.ofComponents, normalizeMapAux, whiskeringRight, whiskerRight, Functor.comp]
-        simp only [comp_tensor_id, associator_conjugation, tensor_id,
-          Category.comp_id]
-        simp only [← Category.assoc]
-        congr 4
-        rw [← cancel_epi ((inclusionObj n.as) ◁ (α_ X₁ X₂ X₃).inv)]
-        simp
-      · ext n
-        dsimp
-        rw [mk_α_inv, NatTrans.comp_app, NatTrans.comp_app]
-        dsimp [NatIso.ofComponents, normalizeMapAux, whiskeringRight, whiskerRight, Functor.comp]
-        simp [tensorHom_id, comp_whiskerRight, Category.assoc, pentagon_inv_assoc,
-          whiskerRight_tensor, Category.comp_id, Iso.cancel_iso_inv_left]
-        erw [Iso.hom_inv_id_assoc]
-      · ext n
-        dsimp [Functor.comp]
-        rw [mk_l_hom, NatTrans.comp_app, NatTrans.comp_app]
-        dsimp [NatIso.ofComponents, normalizeMapAux, whiskeringRight, whiskerRight, Functor.comp]
-        simp only [tensorHom_id, triangle_assoc_comp_right_assoc, Category.comp_id]
-        rfl
-      · ext n
-        dsimp [Functor.comp]
-        rw [mk_l_inv, NatTrans.comp_app, NatTrans.comp_app]
-        dsimp [NatIso.ofComponents, normalizeMapAux, whiskeringRight, whiskerRight, Functor.comp]
-        simp only [tensorHom_id, triangle_assoc_comp_right_assoc, whiskerLeft_inv_hom_assoc,
-          Category.comp_id]
-        rfl
-      · ext n
-        dsimp
-        rw [mk_ρ_hom, NatTrans.comp_app, NatTrans.comp_app]
-        dsimp [NatIso.ofComponents, normalizeMapAux, whiskeringRight, whiskerRight, Functor.comp]
-        simp only [whiskerLeft_rightUnitor, Category.assoc, tensorHom_id,
-          MonoidalCategory.whiskerRight_id, Category.comp_id, Iso.cancel_iso_inv_left,
-          Iso.cancel_iso_hom_left]
-        erw [Iso.inv_hom_id, Category.comp_id]
-      · ext n
-        dsimp
-        rw [mk_ρ_inv, NatTrans.comp_app, NatTrans.comp_app]
-        dsimp [NatIso.ofComponents, normalizeMapAux, whiskeringRight, whiskerRight, Functor.comp]
-        simp only [whiskerLeft_rightUnitor_inv, tensorHom_id, MonoidalCategory.whiskerRight_id,
-          Category.assoc, Iso.hom_inv_id_assoc, Iso.inv_hom_id_assoc, Category.comp_id]
-        erw [Iso.inv_hom_id, Category.comp_id]
-      · rw [mk_comp, Functor.map_comp, Functor.map_comp, Category.assoc, h₂, reassoc_of% h₁]
-      · ext ⟨n⟩
-        replace h₁ := NatTrans.congr_app h₁ ⟨n⟩
-        replace h₂ := NatTrans.congr_app h₂ ((Discrete.functor (normalizeObj X₁)).obj ⟨n⟩)
-        have h₃ := (normalizeIsoAux _ Y₂).hom.naturality ((normalizeMapAux f).app ⟨n⟩)
-        have h₄ : ∀ (X₃ Y₃ : N C) (φ : X₃ ⟶ Y₃), (Discrete.functor inclusionObj).map φ ⊗ 𝟙 Y₂ =
-            (Discrete.functor fun n ↦ inclusionObj n ⊗ Y₂).map φ := by
-          rintro ⟨X₃⟩ ⟨Y₃⟩ φ
-          obtain rfl : X₃ = Y₃ := φ.1.1
-          simp only [discrete_functor_map_eq_id, tensor_id]
-          rfl
-        rw [NatTrans.comp_app, NatTrans.comp_app] at h₁ h₂ ⊢
-        dsimp [NatIso.ofComponents, normalizeMapAux, whiskeringRight, whiskerRight,
-          Functor.comp, Discrete.natTrans] at h₁ h₂ h₃ ⊢
-        simp only [← id_tensorHom, ← tensorHom_id] at h₁ ⊢
-        rw [mk_tensor, associator_inv_naturality_assoc, ← tensor_comp_assoc, h₁,
-          Category.assoc, Category.comp_id, ← @Category.id_comp (F C) _ _ _ (@Quotient.mk _ _ g),
-          tensor_comp, Category.assoc, Category.assoc, Functor.map_comp]
-        congr 2
-        erw [← reassoc_of% h₂]
-        rw [← h₃, ← Category.assoc, ← id_tensor_comp_tensor_id, h₄]
-        rfl)
+    NatIso.ofComponents (normalizeIsoAux C) <| by
+    intro X Y f
+    ext ⟨n⟩
+    convert normalize_naturality n f using 1
+    any_goals dsimp [NatIso.ofComponents]; congr; apply normalizeIsoApp_eq
 #align category_theory.free_monoidal_category.normalize_iso CategoryTheory.FreeMonoidalCategory.normalizeIso
 
 /-- The isomorphism between an object and its normal form is natural. -/
@@ -354,6 +364,8 @@ def inverseAux : ∀ {X Y : F C}, (X ⟶ᵐ Y) → (Y ⟶ᵐ X)
   | _, _, l_hom _ => l_inv _
   | _, _, l_inv _ => l_hom _
   | _, _, comp f g => (inverseAux g).comp (inverseAux f)
+  | _, _, Hom.whiskerLeft X f => (inverseAux f).whiskerLeft X
+  | _, _, Hom.whiskerRight f X => (inverseAux f).whiskerRight X
   | _, _, Hom.tensor f g => (inverseAux f).tensor (inverseAux g)
 #align category_theory.free_monoidal_category.inverse_aux CategoryTheory.FreeMonoidalCategory.inverseAux
 

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -117,9 +117,6 @@ section
 
 open Hom
 
--- Porting note: triggers a PANIC "invalid LCNF substitution of free variable
--- with expression CategoryTheory.FreeMonoidalCategory.NormalMonoidalObject.{u}"
--- prevented with an initial call to dsimp...why?
 /-- Auxiliary definition for `normalize`. Here we prove that objects that are related by
     associators and unitors map to the same normal form. -/
 @[simp]

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -311,7 +311,7 @@ set_option tactic.skipAssignedInstances false in
     naturality in `n` is trivial and was "proved" in `normalizeIsoAux`). This is the real heart
     of our proof of the coherence theorem. -/
 def normalizeIso : tensorFunc C ≅ normalize' C :=
-    NatIso.ofComponents (normalizeIsoAux C) <| by
+  NatIso.ofComponents (normalizeIsoAux C) <| by
     intro X Y f
     ext ⟨n⟩
     convert normalize_naturality n f using 1

--- a/Mathlib/Tactic/CategoryTheory/Coherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence.lean
@@ -90,11 +90,11 @@ instance LiftHom_comp {X Y Z : C} [LiftObj X] [LiftObj Y] [LiftObj Z] (f : X ⟶
 
 instance liftHom_WhiskerLeft (X : C) [LiftObj X] {Y Z : C} [LiftObj Y] [LiftObj Z]
     (f : Y ⟶ Z) [LiftHom f] : LiftHom (X ◁ f) where
-  lift := 𝟙 (LiftObj.lift X) ⊗ LiftHom.lift f
+  lift := LiftObj.lift X ◁ LiftHom.lift f
 
 instance liftHom_WhiskerRight {X Y : C} (f : X ⟶ Y) [LiftObj X] [LiftObj Y] [LiftHom f]
     {Z : C} [LiftObj Z] : LiftHom (f ▷ Z) where
-  lift := LiftHom.lift f ⊗ 𝟙 (LiftObj.lift Z)
+  lift := LiftHom.lift f ▷ LiftObj.lift Z
 
 instance LiftHom_tensor {W X Y Z : C} [LiftObj W] [LiftObj X] [LiftObj Y] [LiftObj Z]
     (f : W ⟶ X) (g : Y ⟶ Z) [LiftHom f] [LiftHom g] : LiftHom (f ⊗ g) where
@@ -119,22 +119,22 @@ instance refl (X : C) [LiftObj X] : MonoidalCoherence X X := ⟨𝟙 _⟩
 @[simps]
 instance whiskerLeft (X Y Z : C) [LiftObj X] [LiftObj Y] [LiftObj Z] [MonoidalCoherence Y Z] :
     MonoidalCoherence (X ⊗ Y) (X ⊗ Z) :=
-  ⟨𝟙 X ⊗ MonoidalCoherence.hom⟩
+  ⟨X ◁ MonoidalCoherence.hom⟩
 
 @[simps]
 instance whiskerRight (X Y Z : C) [LiftObj X] [LiftObj Y] [LiftObj Z] [MonoidalCoherence X Y] :
     MonoidalCoherence (X ⊗ Z) (Y ⊗ Z) :=
-  ⟨MonoidalCoherence.hom ⊗ 𝟙 Z⟩
+  ⟨MonoidalCoherence.hom ▷ Z⟩
 
 @[simps]
 instance tensor_right (X Y : C) [LiftObj X] [LiftObj Y] [MonoidalCoherence (𝟙_ C) Y] :
     MonoidalCoherence X (X ⊗ Y) :=
-  ⟨(ρ_ X).inv ≫ (𝟙 X ⊗  MonoidalCoherence.hom)⟩
+  ⟨(ρ_ X).inv ≫ X ◁  MonoidalCoherence.hom⟩
 
 @[simps]
 instance tensor_right' (X Y : C) [LiftObj X] [LiftObj Y] [MonoidalCoherence Y (𝟙_ C)] :
     MonoidalCoherence (X ⊗ Y) X :=
-  ⟨(𝟙 X ⊗ MonoidalCoherence.hom) ≫ (ρ_ X).hom⟩
+  ⟨X ◁ MonoidalCoherence.hom ≫ (ρ_ X).hom⟩
 
 @[simps]
 instance left (X Y : C) [LiftObj X] [LiftObj Y] [MonoidalCoherence X Y] :
@@ -412,9 +412,5 @@ elab_rules : tactic
       Mathlib.Tactic.BicategoryCoherence.BicategoricalCoherence.hom',
       monoidalComp]);
     whisker_simps (config := {failIfUnchanged := false});
-    monoidal_simps (config := {failIfUnchanged := false});
-    -- Workaround until we define the whiskerings as the primitives in free monoidal categories.
-    simp (config := {failIfUnchanged := false}) only
-      [← MonoidalCategory.id_tensorHom, ← MonoidalCategory.tensorHom_id]
-    ))
+    monoidal_simps (config := {failIfUnchanged := false})))
   coherence_loop


### PR DESCRIPTION
Since the coherence tactic assume that a certain defeq property holds for structural morphisms in a monoidal category and their corresponding morphisms in the free monoidal category, we want free monoidal categories to have the whiskering operators as primitives.

This PR also simplified the proof of the coherence theorem, and removed some porting notes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
