### PR TITLE
[Merged by Bors] - feat(NumberTheory/LSeries): abstract functional equations

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2924,6 +2924,7 @@ import Mathlib.NumberTheory.Harmonic.Bounds
 import Mathlib.NumberTheory.Harmonic.Defs
 import Mathlib.NumberTheory.Harmonic.Int
 import Mathlib.NumberTheory.KummerDedekind
+import Mathlib.NumberTheory.LSeries.AbstractFuncEq
 import Mathlib.NumberTheory.LSeries.Basic
 import Mathlib.NumberTheory.LSeries.Convergence
 import Mathlib.NumberTheory.LegendreSymbol.AddCharacter

--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -192,7 +192,7 @@ lemma hf_zero' (r : ℝ) : P.f =O[𝓝[>] 0] (· ^ r) := by
 def Λ : ℂ → E := mellin P.f
 
 /-- The Mellin transform of `f` is well-defined and equal to `P.Λ s`, for all `s`. -/
-lemma hasMellin (s : ℂ) : HasMellin P.f s (P.Λ s) :=
+theorem hasMellin (s : ℂ) : HasMellin P.f s (P.Λ s) :=
   let ⟨_, ht⟩ := exists_gt s.re
   let ⟨_, hu⟩ := exists_lt s.re
   ⟨mellinConvergent_of_isBigO_rpow P.hf_int (P.hf_top' _) ht (P.hf_zero' _) hu, rfl⟩
@@ -202,7 +202,7 @@ lemma Λ_eq : P.Λ = mellin P.f := rfl
 lemma symm_Λ_eq : P.symm.Λ = mellin P.g := rfl
 
 /-- If `(f, g)` are a strong FE pair, then the Mellin transform of `f` is entire. -/
-lemma differentiable_Λ : Differentiable ℂ P.Λ := fun s ↦
+theorem differentiable_Λ : Differentiable ℂ P.Λ := fun s ↦
   let ⟨_, ht⟩ := exists_gt s.re
   let ⟨_, hu⟩ := exists_lt s.re
   mellin_differentiableAt_of_isBigO_rpow P.hf_int (P.hf_top' _) ht (P.hf_zero' _) hu
@@ -211,7 +211,7 @@ lemma differentiable_Λ : Differentiable ℂ P.Λ := fun s ↦
 transforms of `f` and `g` are related by `s ↦ k - s`.
 
 This is proved by making a substitution `t ↦ t⁻¹` in the Mellin transform integral. -/
-lemma functional_equation (s : ℂ) :
+theorem functional_equation (s : ℂ) :
     P.Λ (P.k - s) = P.ε • P.symm.Λ s := by
   -- unfold definition:
   rw [P.Λ_eq, P.symm_Λ_eq]
@@ -296,7 +296,7 @@ lemma hf_modif_FE (x : ℝ) (hx : 0 < x) :
 
 /-- Given a weak FE-pair `(f, g)`, modify it into a strong FE-pair by subtracting suitable
 correction terms from `f` and `g`. -/
-def modifStrongFEPair : StrongFEPair E where
+def toStrongFEPair : StrongFEPair E where
   hf_int   := P.hf_modif_int
   hg_int   := P.symm.hf_modif_int
   h_feq    := P.hf_modif_FE
@@ -391,9 +391,9 @@ lemma symm_Λ₀_eq (s : ℂ) :
   rw [P.symm.Λ₀_eq]
   rfl
 
-lemma differentiable_Λ₀ : Differentiable ℂ P.Λ₀ := P.modifStrongFEPair.differentiable_Λ
+theorem differentiable_Λ₀ : Differentiable ℂ P.Λ₀ := P.toStrongFEPair.differentiable_Λ
 
-lemma differentiableAt_Λ {s : ℂ} (hs : s ≠ 0 ∨ P.f₀ = 0) (hs' : s ≠ P.k ∨ P.g₀ = 0) :
+theorem differentiableAt_Λ {s : ℂ} (hs : s ≠ 0 ∨ P.f₀ = 0) (hs' : s ≠ P.k ∨ P.g₀ = 0) :
     DifferentiableAt ℂ P.Λ s := by
   refine ((P.differentiable_Λ₀ s).sub ?_).sub ?_
   · rcases hs with hs | hs
@@ -406,13 +406,13 @@ lemma differentiableAt_Λ {s : ℂ} (hs : s ≠ 0 ∨ P.f₀ = 0) (hs' : s ≠ P
     · simpa only [hs', smul_zero] using differentiableAt_const (0 : E)
 
 /-- Relation between `Λ s` and the Mellin transform of `f - f₀`, where the latter is defined. -/
-lemma hasMellin {s : ℂ} (hs : P.k < s.re) : HasMellin (P.f · - P.f₀) s (P.Λ s) := by
+theorem hasMellin {s : ℂ} (hs : P.k < s.re) : HasMellin (P.f · - P.f₀) s (P.Λ s) := by
   have hc1 : MellinConvergent (P.f · - P.f₀) s :=
     let ⟨_, ht⟩ := exists_gt s.re
     mellinConvergent_of_isBigO_rpow (P.hf_int.sub (locallyIntegrableOn_const _)) (P.hf_top _) ht
       P.hf_zero' hs
   refine ⟨hc1, ?_⟩
-  have hc2 : HasMellin P.f_modif s (P.Λ₀ s) := P.modifStrongFEPair.hasMellin s
+  have hc2 : HasMellin P.f_modif s (P.Λ₀ s) := P.toStrongFEPair.hasMellin s
   have hc3 : mellin (fun x ↦ f_modif P x - f P x + P.f₀) s =
     (1 / s) • P.f₀ + (P.ε / (↑P.k - s)) • P.g₀ := P.f_modif_aux2 hs
   have := (hasMellin_sub hc2.1 hc1).2
@@ -420,11 +420,11 @@ lemma hasMellin {s : ℂ} (hs : P.k < s.re) : HasMellin (P.f · - P.f₀) s (P.�
   exact this
 
 /-- Functional equation formulated for `Λ₀`. -/
-lemma functional_equation₀ (s : ℂ) : P.Λ₀ (P.k - s) = P.ε • P.symm.Λ₀ s :=
-  P.modifStrongFEPair.functional_equation s
+theorem functional_equation₀ (s : ℂ) : P.Λ₀ (P.k - s) = P.ε • P.symm.Λ₀ s :=
+  P.toStrongFEPair.functional_equation s
 
 /-- Functional equation formulated for `Λ`. -/
-lemma functional_equation (s : ℂ) :
+theorem functional_equation (s : ℂ) :
     P.Λ (P.k - s) = P.ε • P.symm.Λ s := by
   have := P.functional_equation₀ s
   rw [P.Λ₀_eq, P.symm_Λ₀_eq, sub_sub_cancel] at this
@@ -432,7 +432,7 @@ lemma functional_equation (s : ℂ) :
     mul_inv_cancel P.hε, add_assoc, add_comm (_ • _), add_assoc, add_left_inj] at this
 
 /-- The residue of `Λ` at `s = k` is equal to `ε • g₀`. -/
-lemma Λ_residue_k :
+theorem Λ_residue_k :
     Tendsto (fun s : ℂ ↦ (s - P.k) • P.Λ s) (𝓝[≠] P.k) (𝓝 (P.ε • P.g₀)) := by
   simp_rw [Λ, smul_sub, (by simp : 𝓝 (P.ε • P.g₀) = 𝓝 (0 - 0 - -P.ε • P.g₀))]
   refine ((Tendsto.sub ?_ ?_).mono_left nhdsWithin_le_nhds).sub ?_
@@ -449,7 +449,7 @@ lemma Λ_residue_k :
     ring
 
 /-- The residue of `Λ` at `s = 0` is equal to `-f₀`. -/
-lemma Λ_residue_zero :
+theorem Λ_residue_zero :
     Tendsto (fun s : ℂ ↦ s • P.Λ s) (𝓝[≠] 0) (𝓝 (-P.f₀)) := by
   simp_rw [Λ, smul_sub, (by simp : 𝓝 (-P.f₀) = 𝓝 (((0 : ℂ) • P.Λ₀ 0) - P.f₀ - 0))]
   refine ((Tendsto.mono_left ?_ nhdsWithin_le_nhds).sub ?_).sub ?_

--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -134,8 +134,8 @@ namespace WeakFEPair
 
 /-- As `x → 0`, we have `F x = x ^ (-P.k) • constant` up to a rapidly decaying error. -/
 lemma hf_zero (P : WeakFEPair E) (r : ℝ) :
-    (fun x ↦ P.f x - (P.ε * ↑(x ^ (-P.k))) • P.g₀) =O[𝓝[>] 0] (· ^ (-r)) := by
-  have := (P.hg_top (-(r - P.k))).comp_tendsto tendsto_inv_zero_atTop
+    (fun x ↦ P.f x - (P.ε * ↑(x ^ (-P.k))) • P.g₀) =O[𝓝[>] 0] (· ^ r) := by
+  have := (P.hg_top (-(r + P.k))).comp_tendsto tendsto_inv_zero_atTop
   simp_rw [IsBigO, IsBigOWith, eventually_nhdsWithin_iff] at this ⊢
   obtain ⟨C, hC⟩ := this
   use ‖P.ε‖ * C
@@ -143,15 +143,15 @@ lemma hf_zero (P : WeakFEPair E) (r : ℝ) :
   have h_nv2 : ↑(x ^ P.k) ≠ (0 : ℂ) := ofReal_ne_zero.mpr (rpow_pos_of_pos hx _).ne'
   have h_nv : P.ε⁻¹ * ↑(x ^ P.k) ≠ 0 := mul_ne_zero P.symm.hε h_nv2
   specialize hC' hx
-  simp_rw [Function.comp_apply, ← one_div, neg_neg, P.h_feq' _ hx] at hC'
+  simp_rw [Function.comp_apply, ← one_div, P.h_feq' _ hx] at hC'
   rw [← ((mul_inv_cancel h_nv).symm ▸ one_smul ℂ P.g₀ :), mul_smul _ _ P.g₀, ← smul_sub, norm_smul,
     ← le_div_iff' (lt_of_le_of_ne (norm_nonneg _) (norm_ne_zero_iff.mpr h_nv).symm)] at hC'
   convert hC' using 1
   · congr 3
     rw [rpow_neg hx.le]
     field_simp
-  · simp_rw [norm_mul, norm_real, rpow_neg hx.le, one_div, inv_rpow hx.le, norm_inv,
-      norm_of_nonneg (rpow_pos_of_pos hx _).le, rpow_sub hx]
+  · simp_rw [norm_mul, norm_real, one_div, inv_rpow hx.le, rpow_neg hx.le, inv_inv, norm_inv,
+      norm_of_nonneg (rpow_pos_of_pos hx _).le, rpow_add hx]
     field_simp
     ring
 
@@ -176,11 +176,11 @@ namespace StrongFEPair
 variable (P : StrongFEPair E)
 
 /-- As `x → ∞`, `f x` decays faster than any power of `x`. -/
-lemma hf_top' (r : ℝ) : P.f =O[atTop] (· ^ (-r)) := by
+lemma hf_top' (r : ℝ) : P.f =O[atTop] (· ^ r) := by
   simpa only [P.hf₀, sub_zero] using P.hf_top r
 
 /-- As `x → 0`, `f x` decays faster than any power of `x`. -/
-lemma hf_zero' (r : ℝ) : P.f =O[𝓝[>] 0] (· ^ (-r)) := by
+lemma hf_zero' (r : ℝ) : P.f =O[𝓝[>] 0] (· ^ r) := by
   have := P.hg₀ ▸ P.hf_zero r
   simpa only [smul_zero, sub_zero]
 
@@ -193,9 +193,9 @@ def Λ : ℂ → E := mellin P.f
 
 /-- The Mellin transform of `f` is well-defined and equal to `P.Λ s`, for all `s`. -/
 lemma hasMellin (s : ℂ) : HasMellin P.f s (P.Λ s) :=
-  let ⟨t, ht⟩ := exists_gt s.re
-  let ⟨u, hu⟩ := exists_lt s.re
-  ⟨mellinConvergent_of_isBigO_rpow P.hf_int (P.hf_top' t) ht (P.hf_zero' u) hu, rfl⟩
+  let ⟨_, ht⟩ := exists_gt s.re
+  let ⟨_, hu⟩ := exists_lt s.re
+  ⟨mellinConvergent_of_isBigO_rpow P.hf_int (P.hf_top' _) ht (P.hf_zero' _) hu, rfl⟩
 
 lemma Λ_eq : P.Λ = mellin P.f := rfl
 
@@ -323,12 +323,11 @@ lemma f_modif_aux1 : EqOn (fun x ↦ P.f_modif x - P.f x + P.f₀)
   intro x (hx : 0 < x)
   simp_rw [f_modif, Pi.add_apply]
   rcases lt_trichotomy x 1 with hx' | rfl | hx'
-  · simp_rw [indicator_of_not_mem (not_mem_Ioi.mpr hx'.le), zero_add,
-      indicator_of_mem (mem_Ioo.mpr ⟨hx, hx'⟩)]
-    rw [indicator_of_not_mem (mem_singleton_iff.not.mpr hx'.ne), add_zero]
+  · simp_rw [indicator_of_not_mem (not_mem_Ioi.mpr hx'.le),
+      indicator_of_mem (mem_Ioo.mpr ⟨hx, hx'⟩),
+      indicator_of_not_mem (mem_singleton_iff.not.mpr hx'.ne)]
     abel
   · simp [add_comm, sub_eq_add_neg]
-    abel
   · simp_rw [indicator_of_mem (mem_Ioi.mpr hx'),
       indicator_of_not_mem (not_mem_Ioo_of_ge hx'.le),
       indicator_of_not_mem (mem_singleton_iff.not.mpr hx'.ne')]

--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -56,6 +56,13 @@ See the sections *Main theorems on weak FE-pairs* and
   - `WeakFEPair.Λ_residue_zero`: computation of the residue at `0`.
 -/
 
+
+/- TODO : Consider extending the results to allow functional equations of the form
+`f (N / x) = (const) • x ^ k • g x` for a real parameter `0 < N`. This could be done either by
+generalising the existing proofs in situ, or by a separate wrapper `FEPairWithLevel` which just
+applies a scaling factor to `f` and `g` to reduce to the `N = 1` case.
+ -/
+
 noncomputable section
 
 open Real Complex Filter Topology Asymptotics Set MeasureTheory

--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -1,0 +1,450 @@
+/-
+Copyright (c) 2024 David Loeffler. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David Loeffler
+-/
+
+import Mathlib.Analysis.MellinTransform
+
+/-!
+# Abstract functional equations for Mellin transforms
+
+This file formalises a general version of an argument used to prove functional equations for
+zeta and L functions.
+
+### FE-pairs
+
+We define a *weak FE-pair* to be a pair of functions `f, g` on the positive reals which are
+locally integrable, have the form "constant" + "rapidly decaying term" at `∞`, and satisfy a
+functional equation of the form
+
+`f (1 / x) = ε * x ^ k * g x`
+
+for some constants `k ∈ ℝ` and `ε ∈ ℂ`. (Modular forms give rise to natural examples
+with `k` being the weight and `ε` the global root number; hence the notation.) We could arrange
+`ε = 1` by scaling `g`; but this is inconvenient in applications so we set things up more generally.
+
+A *strong FE-pair* is a weak FE-pair where the constant terms of `f` and `g` at `∞` are both 0.
+
+The main property of these pairs is the following: if `f`, `g` are a weak FE-pair, then the Mellin
+transforms `Λ` and `Λ'` of `f - f₀` and `g - g₀` respectively both have meromorphic continuation
+and satisfy a functional equation of the form
+
+`Λ (k - s) = ε * Λ' s`.
+
+The poles (and their residues) are explicitly given in terms of `f₀` and `g₀`; in particular, if
+`(f, g)` are a strong FE-pair, then the Mellin transforms of `f` and `g` are entire functions.
+
+### Main results
+
+See the sections *Main theorems on weak FE-pairs* and
+*Main theorems on strong FE-pairs* below.
+
+* Strong FE pairs:
+  - `StrongFEPair.Λ` : function of `s : ℂ`
+  - `StrongFEPair.differentiable_Λ`: `Λ` is entire
+  - `StrongFEPair.hasMellin`: `Λ` is everywhere equal to the Mellin transform of `f`
+  - `StrongFEPair.functional_equation`: the functional equation for `Λ`
+* Weak FE pairs:
+  - `WeakFEPair.Λ₀`: and `WeakFEPair.Λ`: functions of `s : ℂ`
+  - `WeakFEPair.differentiable_Λ₀`: `Λ₀` is entire
+  - `WeakFEPair.differentiableAt_Λ`: `Λ` is differentiable away from `s = 0` and `s = k`
+  - `WeakFEPair.hasMellin`: for `k < re s`, `Λ s` equals the Mellin transform of `f - f₀`
+  - `WeakFEPair.functional_equation₀`: the functional equation for `Λ₀`
+  - `WeakFEPair.functional_equation`: the functional equation for `Λ`
+  - `WeakFEPair.Λ_residue_k`: computation of the residue at `k`
+  - `WeakFEPair.Λ_residue_zero`: computation of the residue at `0`.
+-/
+
+noncomputable section
+
+open Real Complex Filter Topology Asymptotics Set MeasureTheory
+
+variable (E : Type*) [NormedAddCommGroup E] [NormedSpace ℂ E] [CompleteSpace E]
+
+/-!
+## Definitions and symmetry
+-/
+
+/-- A structure designed to hold the hypotheses for the Mellin-functional-equation argument
+(most general version: rapid decay at `∞` up to constant terms) -/
+structure WeakFEPair where
+  /-- The functions whose Mellin transform we study -/
+  (f g : ℝ → E)
+  /-- Weight (exponent in the functional equation) -/
+  (k : ℝ)
+  /-- Root number -/
+  (ε : ℂ)
+  /-- Constant terms at `∞` -/
+  (f₀ g₀ : E)
+  (hf_int : LocallyIntegrableOn f (Ioi 0))
+  (hg_int : LocallyIntegrableOn g (Ioi 0))
+  (hk : 0 < k)
+  (hε : ε ≠ 0)
+  (h_feq : ∀ x ∈ Ioi 0, f (1 / x) = (ε * ↑(x ^ k)) • g x)
+  (hf_top (r : ℝ) : (f · - f₀) =O[atTop] (· ^ (-r)))
+  (hg_top (r : ℝ) : (g · - g₀) =O[atTop] (· ^ (-r)))
+
+/-- A structure designed to hold the hypotheses for the Mellin-functional-equation argument
+(version without constant terms) -/
+structure StrongFEPair extends WeakFEPair E where (hf₀ : f₀ = 0) (hg₀ : g₀ = 0)
+
+variable {E}
+
+section symmetry
+
+/-- Reformulated functional equation with `f` and `g` interchanged. -/
+lemma WeakFEPair.h_feq' (P : WeakFEPair E) (x : ℝ) (hx : 0 < x) :
+    P.g (1 / x) = (P.ε⁻¹ * ↑(x ^ P.k)) • P.f x := by
+  rw [(div_div_cancel' (one_ne_zero' ℝ) ▸ P.h_feq (1 / x) (one_div_pos.mpr hx) :), ← mul_smul]
+  convert (one_smul ℂ (P.g (1 / x))).symm using 2
+  have h1 : (↑(x ^ P.k : ℝ) : ℂ) ≠ 0 := ofReal_ne_zero.mpr (rpow_pos_of_pos hx _).ne'
+  rw [one_div, inv_rpow hx.le, ofReal_inv]
+  field_simp [P.hε]
+
+/-- The hypotheses are symmetric in `f` and `g`, with the constant `ε` replaced by `ε⁻¹`. -/
+def WeakFEPair.symm (P : WeakFEPair E) : WeakFEPair E where
+  hf_int := P.hg_int
+  hg_int := P.hf_int
+  hf_top := P.hg_top
+  hg_top := P.hf_top
+  hε     := inv_ne_zero P.hε
+  hk     := P.hk
+  h_feq  := P.h_feq'
+
+/-- The hypotheses are symmetric in `f` and `g`, with the constant `ε` replaced by `ε⁻¹`. -/
+def StrongFEPair.symm (P : StrongFEPair E) : StrongFEPair E where
+  toWeakFEPair := P.toWeakFEPair.symm
+  hf₀ := P.hg₀
+  hg₀ := P.hf₀
+
+end symmetry
+
+namespace WeakFEPair
+
+/-!
+## Auxiliary results I: lemmas on asymptotics
+-/
+
+/-- As `x → 0`, we have `F x = x ^ (-P.k) • constant` up to a rapidly decaying error. -/
+lemma hf_zero (P : WeakFEPair E) (r : ℝ) :
+    (fun x ↦ P.f x - (P.ε * ↑(x ^ (-P.k))) • P.g₀) =O[𝓝[>] 0] (· ^ (-r)) := by
+  have := (P.hg_top (-(r - P.k))).comp_tendsto tendsto_inv_zero_atTop
+  simp_rw [IsBigO, IsBigOWith, eventually_nhdsWithin_iff] at this ⊢
+  obtain ⟨C, hC⟩ := this
+  use ‖P.ε‖ * C
+  filter_upwards [hC] with x hC' (hx : 0 < x)
+  have h_nv2 : ↑(x ^ P.k) ≠ (0 : ℂ) := ofReal_ne_zero.mpr (rpow_pos_of_pos hx _).ne'
+  have h_nv : P.ε⁻¹ * ↑(x ^ P.k) ≠ 0 := mul_ne_zero P.symm.hε h_nv2
+  specialize hC' hx
+  simp_rw [Function.comp_apply, ← one_div, neg_neg, P.h_feq' _ hx] at hC'
+  rw [← ((mul_inv_cancel h_nv).symm ▸ one_smul ℂ P.g₀ :), mul_smul _ _ P.g₀, ← smul_sub, norm_smul,
+    ← le_div_iff' (lt_of_le_of_ne (norm_nonneg _) (norm_ne_zero_iff.mpr h_nv).symm)] at hC'
+  convert hC' using 1
+  · congr 3
+    rw [rpow_neg hx.le]
+    field_simp
+  · simp_rw [norm_mul, norm_real, rpow_neg hx.le, one_div, inv_rpow hx.le, norm_inv,
+      norm_of_nonneg (rpow_pos_of_pos hx _).le, rpow_sub hx]
+    field_simp
+    ring
+
+/-- Power asymptotic for `f - f₀` as `x → 0`. -/
+lemma hf_zero' (P : WeakFEPair E) :
+    (fun x : ℝ ↦ P.f x - P.f₀) =O[𝓝[>] 0] (· ^ (-P.k)) := by
+  simp_rw [← fun x ↦ sub_add_sub_cancel (P.f x) ((P.ε * ↑(x ^ (-P.k))) • P.g₀) P.f₀]
+  refine (P.hf_zero _).add (IsBigO.sub ?_ ?_)
+  · rw [← isBigO_norm_norm]
+    simp_rw [mul_smul, norm_smul, mul_comm _ ‖P.g₀‖, ← mul_assoc, norm_real]
+    apply (isBigO_refl _ _).const_mul_left
+  · refine IsBigO.of_bound ‖P.f₀‖ (eventually_nhdsWithin_iff.mpr ?_)
+    filter_upwards [eventually_le_nhds zero_lt_one] with x hx' (hx : 0 < x)
+    apply le_mul_of_one_le_right (norm_nonneg _)
+    rw [norm_of_nonneg (rpow_pos_of_pos hx _).le, rpow_neg hx.le]
+    exact one_le_inv (rpow_pos_of_pos hx _) (rpow_le_one hx.le hx' P.hk.le)
+
+end WeakFEPair
+
+namespace StrongFEPair
+
+variable (P : StrongFEPair E)
+
+/-- As `x → 0`, `F x` decays faster than any power of `x`. -/
+lemma hf_top' (r : ℝ) :
+    P.f =O[atTop] (· ^ (-r)) := by
+  simpa only [P.hf₀, sub_zero] using P.hf_top r
+
+/-- As `x → 0`, `F x` decays faster than any power of `x`. -/
+lemma hf_zero' (r : ℝ) :
+    P.f =O[𝓝[>] 0] (· ^ (-r)) := by
+  have := P.hg₀ ▸ P.hf_zero r
+  simpa only [smul_zero, sub_zero]
+
+/-!
+## Main theorems on strong FE-pairs
+-/
+
+/-- The completed L-function. -/
+def Λ : ℂ → E := mellin P.f
+
+/-- The Mellin transform of `f` is well-defined and equal to `P.Λ s`, for all `s`. -/
+lemma hasMellin (s : ℂ) :
+    HasMellin P.f s (P.Λ s):=
+  let ⟨t, ht⟩ := exists_gt s.re
+  let ⟨u, hu⟩ := exists_lt s.re
+  ⟨mellinConvergent_of_isBigO_rpow P.hf_int (P.hf_top' t) ht (P.hf_zero' u) hu, rfl⟩
+
+/-- If `(f, g)` are a strong FE pair, then the Mellin transform of `f` is entire. -/
+lemma differentiable_Λ : Differentiable ℂ P.Λ := fun s ↦
+  let ⟨_, ht⟩ := exists_gt s.re
+  let ⟨_, hu⟩ := exists_lt s.re
+  mellin_differentiableAt_of_isBigO_rpow P.hf_int (P.hf_top' _) ht (P.hf_zero' _) hu
+
+/-- Main theorem about strong FE pairs: if `(f, g)` are a strong FE pair, then the Mellin
+transforms of `f` and `g` are related by `s ↦ k - s`. -/
+lemma functional_equation (s : ℂ) :
+    P.Λ (P.k - s) = P.ε • P.symm.Λ s := by
+  change mellin P.f (P.k - s) = P.ε • mellin P.g s
+  have step1 := mellin_comp_rpow P.g (-s) (-1)
+  simp_rw [abs_neg, abs_one, inv_one, one_smul, ofReal_neg, ofReal_one, div_neg, div_one, neg_neg,
+    rpow_neg_one, ← one_div] at step1
+  have step2 := mellin_cpow_smul (fun t ↦ P.g (1 / t)) (P.k - s) (-P.k)
+  rw [← sub_eq_add_neg, sub_right_comm, sub_self, zero_sub] at step2
+  simp_rw [step1] at step2
+  have step3 := mellin_const_smul (fun t ↦ (t : ℂ) ^ (-P.k : ℂ) • P.g (1 / t)) (P.k - s) P.ε
+  rw [step2] at step3
+  rw [← step3]
+  refine set_integral_congr measurableSet_Ioi (fun t ht ↦ ?_)
+  simp_rw [P.h_feq' t ht, ← mul_smul]
+  rw [cpow_neg, ofReal_cpow (le_of_lt ht)]
+  have : (t : ℂ) ^ (P.k : ℂ) ≠ 0 := by
+    simpa only [← ofReal_cpow (le_of_lt ht), ofReal_ne_zero] using (rpow_pos_of_pos ht _).ne'
+  field_simp [P.hε]
+
+end StrongFEPair
+
+namespace WeakFEPair
+
+variable (P : WeakFEPair E)
+
+/-!
+## Auxiliary results II: building a strong FE-pair from a weak FE-pair
+-/
+
+/-- Piecewise modified version of `f` with optimal asymptotics. We deliberately choose intervals
+which don't quite join up, so the function is `0` at `x = 1`, in order to maintain symmetry;
+there is no `good` choice of value at `1`. -/
+def f_mod : ℝ → E :=
+  (Ioi 1).indicator (fun x ↦ P.f x - P.f₀) +
+  (Ioo 0 1).indicator (fun x ↦ P.f x - (P.ε * ↑(x ^ (-P.k))) • P.g₀)
+
+/-- Piecewise modified version of `g` with optimal asymptotics. -/
+def g_mod : ℝ → E :=
+  (Ioi 1).indicator (fun x ↦ P.g x - P.g₀) +
+  (Ioo 0 1).indicator (fun x ↦ P.g x - (P.ε⁻¹ * ↑(x ^ (-P.k))) • P.f₀)
+
+lemma hf_mod_int :
+    LocallyIntegrableOn P.f_mod (Ioi 0) := by
+  have : LocallyIntegrableOn (fun x : ℝ ↦ (P.ε * ↑(x ^ (-P.k))) • P.g₀) (Ioi 0) := by
+    refine ContinuousOn.locallyIntegrableOn ?_ measurableSet_Ioi
+    refine ContinuousAt.continuousOn (fun x (hx : 0 < x) ↦ ?_)
+    refine (continuousAt_const.mul ?_).smul continuousAt_const
+    exact continuous_ofReal.continuousAt.comp (continuousAt_rpow_const _ _ (Or.inl hx.ne'))
+  refine LocallyIntegrableOn.add (fun x hx ↦ ?_) (fun x hx ↦ ?_)
+  · obtain ⟨s, hs, hs'⟩ := P.hf_int.sub (locallyIntegrableOn_const _) x hx
+    refine ⟨s, hs, ?_⟩
+    rw [IntegrableOn, integrable_indicator_iff measurableSet_Ioi, IntegrableOn,
+      Measure.restrict_restrict measurableSet_Ioi, ← IntegrableOn]
+    exact hs'.mono_set (Set.inter_subset_right _ _)
+  · obtain ⟨s, hs, hs'⟩ := P.hf_int.sub this x hx
+    refine ⟨s, hs, ?_⟩
+    rw [IntegrableOn, integrable_indicator_iff measurableSet_Ioo, IntegrableOn,
+      Measure.restrict_restrict measurableSet_Ioo, ← IntegrableOn]
+    exact hs'.mono_set (Set.inter_subset_right _ _)
+
+lemma hf_mod_FE (x : ℝ) (hx : 0 < x) :
+    P.f_mod (1 / x) = (P.ε * ↑(x ^ P.k)) • P.g_mod x := by
+  rcases lt_trichotomy 1 x with hx' | rfl | hx'
+  · have : 1 / x < 1 := by rwa [one_div_lt hx one_pos, div_one]
+    rw [f_mod, Pi.add_apply, indicator_of_not_mem (not_mem_Ioi.mpr this.le),
+      zero_add, indicator_of_mem (mem_Ioo.mpr ⟨div_pos one_pos hx, this⟩), g_mod, Pi.add_apply,
+      indicator_of_mem (mem_Ioi.mpr hx'), indicator_of_not_mem
+      (not_mem_Ioo_of_ge hx'.le), add_zero, P.h_feq _ hx, smul_sub]
+    simp_rw [rpow_neg (one_div_pos.mpr hx).le, one_div, inv_rpow hx.le, inv_inv]
+  · rw [div_one, f_mod, Pi.add_apply, indicator_of_not_mem, indicator_of_not_mem,
+      g_mod, Pi.add_apply, indicator_of_not_mem, indicator_of_not_mem]
+    simp only [add_zero, smul_zero]
+    all_goals { simp }
+  · have : 1 < 1 / x := by rwa [lt_one_div one_pos hx, div_one]
+    rw [f_mod, Pi.add_apply, indicator_of_mem (mem_Ioi.mpr this),
+      indicator_of_not_mem (not_mem_Ioo_of_ge this.le), add_zero, g_mod, Pi.add_apply,
+      indicator_of_not_mem (not_mem_Ioi.mpr hx'.le),
+      indicator_of_mem (mem_Ioo.mpr ⟨hx, hx'⟩), zero_add, P.h_feq _ hx, smul_sub]
+    simp_rw [rpow_neg hx.le, ← mul_smul]
+    field_simp [(rpow_pos_of_pos hx P.k).ne', P.hε]
+
+/-- A strong FE-pair derived from `(f, g)` by subtracting a suitable correction term. -/
+def modStrongFEPair : StrongFEPair E where
+  hf_int   := P.hf_mod_int
+  hg_int   := P.symm.hf_mod_int
+  h_feq    := P.hf_mod_FE
+  hε       := P.hε
+  hk       := P.hk
+  hf₀      := rfl
+  hg₀      := rfl
+  hf_top r := by
+    refine (P.hf_top r).congr' ?_ (by rfl)
+    filter_upwards [eventually_gt_atTop 1] with x hx
+    rw [f_mod, Pi.add_apply, indicator_of_mem (mem_Ioi.mpr hx),
+      indicator_of_not_mem (not_mem_Ioo_of_ge hx.le), add_zero, sub_zero]
+  hg_top r := by
+    refine (P.hg_top r).congr' ?_ (by rfl)
+    filter_upwards [eventually_gt_atTop 1] with x hx
+    rw [f_mod, Pi.add_apply, indicator_of_mem (mem_Ioi.mpr hx),
+      indicator_of_not_mem (not_mem_Ioo_of_ge hx.le), add_zero, sub_zero]
+    rfl
+
+/- Alternative form for the difference between `f - f₀` and its modified term. -/
+lemma f_mod_aux1 : EqOn (fun x ↦ P.f_mod x - P.f x + P.f₀)
+    ((Ioo 0 1).indicator (fun x : ℝ ↦ P.f₀ - (P.ε * ↑(x ^ (-P.k))) • P.g₀)
+    + ({1} : Set ℝ).indicator (fun _ ↦ P.f₀ - P.f 1)) (Ioi 0) := by
+  intro x (hx : 0 < x)
+  simp_rw [f_mod, Pi.add_apply]
+  rcases lt_trichotomy x 1 with hx' | rfl | hx'
+  · simp_rw [indicator_of_not_mem (not_mem_Ioi.mpr hx'.le), zero_add,
+      indicator_of_mem (mem_Ioo.mpr ⟨hx, hx'⟩)]
+    rw [indicator_of_not_mem (mem_singleton_iff.not.mpr hx'.ne), add_zero]
+    abel
+  · simp_rw [indicator_of_not_mem (not_mem_Ioi.mpr le_rfl), zero_add,
+      indicator_of_not_mem (not_mem_Ioo_of_ge le_rfl), zero_sub, zero_add]
+    rw [indicator_of_mem (mem_singleton _)]
+    abel
+  · simp_rw [indicator_of_mem (mem_Ioi.mpr hx'),
+      indicator_of_not_mem (not_mem_Ioo_of_ge hx'.le),
+      indicator_of_not_mem (mem_singleton_iff.not.mpr hx'.ne')]
+    abel
+
+/-- Compute the Mellin transform of the modifying term used to kill off the constants at
+`0` and `∞`. -/
+lemma f_mod_aux2 {s : ℂ} (hs : P.k < re s) :
+    mellin (fun x ↦ P.f_mod x - P.f x + P.f₀) s = (1 / s) • P.f₀ + (P.ε  / (P.k - s)) • P.g₀ := by
+  have h_re1 : -1 < re (s - 1) := by simpa using P.hk.trans hs
+  have h_re2 : -1 < re (s - P.k - 1) := by simpa using hs
+  calc
+  _ = ∫ (x : ℝ) in Ioi 0, (x : ℂ) ^ (s - 1) •
+      ((Ioo 0 1).indicator (fun t : ℝ ↦ P.f₀ - (P.ε * ↑(t ^ (-P.k))) • P.g₀) x
+      + ({1} : Set ℝ).indicator (fun _ ↦ P.f₀ - P.f 1) x) :=
+    set_integral_congr measurableSet_Ioi (fun x hx ↦ by simp [f_mod_aux1 P hx])
+  _ = ∫ (x : ℝ) in Ioi 0, (x : ℂ) ^ (s - 1) • ((Ioo 0 1).indicator
+      (fun t : ℝ ↦ P.f₀ - (P.ε * ↑(t ^ (-P.k))) • P.g₀) x) := by
+    refine set_integral_congr_ae measurableSet_Ioi (eventually_of_mem (U := {1}ᶜ)
+        (compl_mem_ae_iff.mpr (subsingleton_singleton.measure_zero _)) (fun x hx _ ↦ ?_))
+    rw [indicator_of_not_mem hx, add_zero]
+  _ = ∫ (x : ℝ) in Ioc 0 1, (x : ℂ) ^ (s - 1) • (P.f₀ - (P.ε * ↑(x ^ (-P.k))) • P.g₀) := by
+    simp_rw [← indicator_smul, set_integral_indicator measurableSet_Ioo,
+      inter_eq_right.mpr Ioo_subset_Ioi_self, integral_Ioc_eq_integral_Ioo]
+  _ = ∫ x : ℝ in Ioc 0 1, ((x : ℂ) ^ (s - 1) • P.f₀ - P.ε • (x : ℂ) ^ (s - P.k - 1) • P.g₀) := by
+    refine set_integral_congr measurableSet_Ioc (fun x ⟨hx, _⟩ ↦ ?_)
+    rw [ofReal_cpow hx.le, ofReal_neg, smul_sub, ← mul_smul, mul_comm, mul_assoc, mul_smul,
+      mul_comm, ← cpow_add _ _ (ofReal_ne_zero.mpr hx.ne'), ← sub_eq_add_neg, sub_right_comm]
+  _ = (∫ (x : ℝ) in Ioc 0 1, (x : ℂ) ^ (s - 1)) • P.f₀
+        - P.ε • (∫ (x : ℝ) in Ioc 0 1, (x : ℂ) ^ (s - P.k - 1)) • P.g₀ := by
+    rw [integral_sub, integral_smul, integral_smul_const, integral_smul_const]
+    · apply Integrable.smul_const
+      rw [← integrableOn_def, ← intervalIntegrable_iff_integrableOn_Ioc_of_le zero_le_one]
+      exact intervalIntegral.intervalIntegrable_cpow' h_re1
+    · refine (Integrable.smul_const ?_ _).smul _
+      rw [← integrableOn_def, ← intervalIntegrable_iff_integrableOn_Ioc_of_le zero_le_one]
+      exact intervalIntegral.intervalIntegrable_cpow' h_re2
+  _ = _ := by simp_rw [← intervalIntegral.integral_of_le zero_le_one,
+      integral_cpow (Or.inl h_re1), integral_cpow (Or.inl h_re2), ofReal_zero, ofReal_one,
+      one_cpow, sub_add_cancel, zero_cpow fun h ↦ lt_irrefl _ (P.hk.le.trans_lt (zero_re ▸ h ▸ hs)),
+      zero_cpow (sub_ne_zero.mpr (fun h ↦ lt_irrefl _ ((ofReal_re _) ▸ h ▸ hs)) : s - P.k ≠ 0),
+      sub_zero, sub_eq_add_neg (_ •  _), ← mul_smul, ← neg_smul, mul_one_div, ← div_neg, neg_sub]
+
+/-!
+## Main theorems on weak FE-pairs
+-/
+
+/-- An entire function which differs from the Mellin transform of `f - f₀`, where defined, by a
+correction term of the form `A / s + B / (k - s)`. -/
+def Λ₀ : ℂ → E := mellin P.f_mod
+
+/-- A meromorphic function which agrees with the Mellin transform of `f - f₀` where defined -/
+def Λ (s : ℂ) : E := P.Λ₀ s - (1 / s) • P.f₀ - (P.ε / (P.k - s)) • P.g₀
+
+lemma Λ₀_eq (s : ℂ) : P.Λ₀ s = P.Λ s + (1 / s) • P.f₀ + (P.ε / (P.k - s)) • P.g₀ := by
+  unfold Λ Λ₀
+  abel
+
+lemma differentiable_Λ₀ : Differentiable ℂ P.Λ₀ := P.modStrongFEPair.differentiable_Λ
+
+lemma differentiableAt_Λ {s : ℂ} (hs : s ≠ 0 ∨ P.f₀ = 0) (hs' : s ≠ P.k ∨ P.g₀ = 0) :
+    DifferentiableAt ℂ P.Λ s := by
+  refine ((P.differentiable_Λ₀ s).sub  ?_).sub ?_
+  · rcases hs with hs | hs
+    · simpa only [one_div] using (differentiableAt_inv' hs).smul_const P.f₀
+    · simpa only [hs, smul_zero] using differentiableAt_const (0 : E)
+  · rcases hs' with hs' | hs'
+    · apply DifferentiableAt.smul_const
+      apply (differentiableAt_const _).div ((differentiableAt_const _).sub (differentiable_id _))
+      rwa [sub_ne_zero, ne_comm]
+    · simpa only [hs', smul_zero] using differentiableAt_const (0 : E)
+
+/-- Relation between `Λ s` and the Mellin transform of `f - f₀`, where the latter is defined. -/
+lemma hasMellin {s : ℂ} (hs : P.k < s.re) : HasMellin (P.f · - P.f₀) s (P.Λ s) := by
+  have hc1 : MellinConvergent (P.f · - P.f₀) s :=
+    let ⟨_, ht⟩ := exists_gt s.re
+    mellinConvergent_of_isBigO_rpow (P.hf_int.sub (locallyIntegrableOn_const _)) (P.hf_top _) ht
+      P.hf_zero' hs
+  refine ⟨hc1, ?_⟩
+  have hc2 : HasMellin P.f_mod s (P.Λ₀ s) := P.modStrongFEPair.hasMellin s
+  have hc3 : mellin (fun x ↦ f_mod P x - f P x + P.f₀) s =
+    (1 / s) • P.f₀ + (P.ε / (↑P.k - s)) • P.g₀ := P.f_mod_aux2 hs
+  have := (hasMellin_sub hc2.1 hc1).2
+  simp_rw [← sub_add, hc3, eq_sub_iff_add_eq, ← eq_sub_iff_add_eq', ← sub_sub] at this
+  exact this
+
+/-- Functional equation formulated for `Λ₀`. -/
+lemma functional_equation₀ (s : ℂ) : P.Λ₀ (P.k - s) = P.ε • P.symm.Λ₀ s :=
+  P.modStrongFEPair.functional_equation s
+
+/-- Functional equation formulated for `Λ`. -/
+lemma functional_equation (s : ℂ) :
+    P.Λ (P.k - s) = P.ε • P.symm.Λ s := by
+  have := P.functional_equation₀ s
+  rw [P.Λ₀_eq, P.symm.Λ₀_eq, sub_sub_cancel] at this
+  change _ = P.ε • (_ + _ • P.g₀ + (P.ε⁻¹ / (P.k - s)) • P.f₀) at this
+  rwa [smul_add, smul_add, ← mul_smul, mul_one_div, ← mul_smul, ← mul_div_assoc,
+    mul_inv_cancel P.hε, add_assoc, add_comm (_ • _), add_assoc, add_left_inj] at this
+
+/-- The residue of `Λ` at `s = k` is equal to `ε • g₀`. -/
+lemma Λ_residue_k :
+    Tendsto (fun s : ℂ ↦ (s - P.k) • P.Λ s) (𝓝[≠] P.k) (𝓝 (P.ε • P.g₀)) := by
+  simp_rw [Λ, smul_sub, (by simp : 𝓝 (P.ε • P.g₀) = 𝓝 (0 - 0 - -P.ε • P.g₀))]
+  refine ((Tendsto.sub ?_ ?_).mono_left nhdsWithin_le_nhds).sub ?_
+  · rw [(by rw [sub_self, zero_smul] : 𝓝 0 = 𝓝 ((P.k - P.k : ℂ) • P.Λ₀ P.k))]
+    apply ((continuous_sub_right _).smul P.differentiable_Λ₀.continuous).tendsto
+  · rw [(by rw [sub_self, zero_smul] : 𝓝 0 = 𝓝 ((P.k - P.k : ℂ) • (1 / P.k : ℂ) • P.f₀))]
+    refine (continuous_sub_right _).continuousAt.smul (ContinuousAt.smul ?_ continuousAt_const)
+    exact continuousAt_const.div continuousAt_id (ofReal_ne_zero.mpr P.hk.ne')
+  · refine (tendsto_const_nhds.mono_left nhdsWithin_le_nhds).congr' ?_
+    refine eventually_nhdsWithin_of_forall (fun s (hs : s ≠ P.k) ↦ ?_)
+    simp_rw [← mul_smul]
+    congr 1
+    field_simp [sub_ne_zero.mpr hs.symm]
+    ring
+
+/-- The residue of `Λ` at `s = 0` is equal to `-f₀`. -/
+lemma Λ_residue_zero :
+    Tendsto (fun s : ℂ ↦ s • P.Λ s) (𝓝[≠] 0) (𝓝 (-P.f₀)) := by
+  simp_rw [Λ, smul_sub, (by simp : 𝓝 (-P.f₀) = 𝓝 (((0 : ℂ) • P.Λ₀ 0) - P.f₀ - 0))]
+  refine ((Tendsto.mono_left ?_ nhdsWithin_le_nhds).sub ?_).sub ?_
+  · exact (continuous_id.smul P.differentiable_Λ₀.continuous).tendsto _
+  · refine (tendsto_const_nhds.mono_left nhdsWithin_le_nhds).congr' ?_
+    refine eventually_nhdsWithin_of_forall (fun s (hs : s ≠ 0) ↦ ?_)
+    simp_rw [← mul_smul]
+    field_simp [sub_ne_zero.mpr hs.symm]
+  · rw [show 𝓝 0 = 𝓝 ((0 : ℂ) • (P.ε / (P.k - 0 : ℂ)) • P.g₀) by rw [zero_smul]]
+    exact (continuousAt_id.smul ((continuousAt_const.div ((continuous_sub_left _).continuousAt)
+      (by simpa using P.hk.ne')).smul continuousAt_const)).mono_left nhdsWithin_le_nhds

--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -132,7 +132,7 @@ namespace WeakFEPair
 ## Auxiliary results I: lemmas on asymptotics
 -/
 
-/-- As `x → 0`, we have `F x = x ^ (-P.k) • constant` up to a rapidly decaying error. -/
+/-- As `x → 0`, we have `f x = x ^ (-P.k) • constant` up to a rapidly decaying error. -/
 lemma hf_zero (P : WeakFEPair E) (r : ℝ) :
     (fun x ↦ P.f x - (P.ε * ↑(x ^ (-P.k))) • P.g₀) =O[𝓝[>] 0] (· ^ r) := by
   have := (P.hg_top (-(r + P.k))).comp_tendsto tendsto_inv_zero_atTop

--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -394,6 +394,11 @@ lemma Λ₀_eq (s : ℂ) : P.Λ₀ s = P.Λ s + (1 / s) • P.f₀ + (P.ε / (P.
   unfold Λ Λ₀
   abel
 
+lemma symm_Λ₀_eq (s : ℂ) :
+  P.symm.Λ₀ s = P.symm.Λ s + (1 / s) • P.g₀ + (P.ε⁻¹ / (P.k - s)) • P.f₀ := by
+    rw [P.symm.Λ₀_eq]
+    rfl
+
 lemma differentiable_Λ₀ : Differentiable ℂ P.Λ₀ := P.modifStrongFEPair.differentiable_Λ
 
 lemma differentiableAt_Λ {s : ℂ} (hs : s ≠ 0 ∨ P.f₀ = 0) (hs' : s ≠ P.k ∨ P.g₀ = 0) :
@@ -430,8 +435,7 @@ lemma functional_equation₀ (s : ℂ) : P.Λ₀ (P.k - s) = P.ε • P.symm.Λ�
 lemma functional_equation (s : ℂ) :
     P.Λ (P.k - s) = P.ε • P.symm.Λ s := by
   have := P.functional_equation₀ s
-  rw [P.Λ₀_eq, P.symm.Λ₀_eq, sub_sub_cancel] at this
-  change _ = P.ε • (_ + _ • P.g₀ + (P.ε⁻¹ / (P.k - s)) • P.f₀) at this
+  rw [P.Λ₀_eq, P.symm_Λ₀_eq, sub_sub_cancel] at this
   rwa [smul_add, smul_add, ← mul_smul, mul_one_div, ← mul_smul, ← mul_div_assoc,
     mul_inv_cancel P.hε, add_assoc, add_comm (_ • _), add_assoc, add_left_inj] at this
 

--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -89,8 +89,8 @@ structure WeakFEPair where
   (hk : 0 < k)
   (hε : ε ≠ 0)
   (h_feq : ∀ x ∈ Ioi 0, f (1 / x) = (ε * ↑(x ^ k)) • g x)
-  (hf_top (r : ℝ) : (f · - f₀) =O[atTop] (· ^ (-r)))
-  (hg_top (r : ℝ) : (g · - g₀) =O[atTop] (· ^ (-r)))
+  (hf_top (r : ℝ) : (f · - f₀) =O[atTop] (· ^ r))
+  (hg_top (r : ℝ) : (g · - g₀) =O[atTop] (· ^ r))
 
 /-- A structure designed to hold the hypotheses for the Mellin-functional-equation argument
 (version without constant terms) -/

--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -14,8 +14,8 @@ zeta and L functions.
 
 ### FE-pairs
 
-We define a *weak FE-pair* to be a pair of functions `f, g` on the positive reals which are
-locally integrable, have the form "constant" + "rapidly decaying term" at `∞`, and satisfy a
+We define a *weak FE-pair* to be a pair of functions `f, g` on the reals which are locally
+integrable on `(0, ∞)`, have the form "constant" + "rapidly decaying term" at `∞`, and satisfy a
 functional equation of the form
 
 `f (1 / x) = ε * x ^ k * g x`
@@ -105,9 +105,8 @@ lemma WeakFEPair.h_feq' (P : WeakFEPair E) (x : ℝ) (hx : 0 < x) :
     P.g (1 / x) = (P.ε⁻¹ * ↑(x ^ P.k)) • P.f x := by
   rw [(div_div_cancel' (one_ne_zero' ℝ) ▸ P.h_feq (1 / x) (one_div_pos.mpr hx) :), ← mul_smul]
   convert (one_smul ℂ (P.g (1 / x))).symm using 2
-  have h1 : (↑(x ^ P.k : ℝ) : ℂ) ≠ 0 := ofReal_ne_zero.mpr (rpow_pos_of_pos hx _).ne'
   rw [one_div, inv_rpow hx.le, ofReal_inv]
-  field_simp [P.hε]
+  field_simp [P.hε, (rpow_pos_of_pos hx _).ne']
 
 /-- The hypotheses are symmetric in `f` and `g`, with the constant `ε` replaced by `ε⁻¹`. -/
 def WeakFEPair.symm (P : WeakFEPair E) : WeakFEPair E where
@@ -199,6 +198,10 @@ lemma hasMellin (s : ℂ) :
   let ⟨u, hu⟩ := exists_lt s.re
   ⟨mellinConvergent_of_isBigO_rpow P.hf_int (P.hf_top' t) ht (P.hf_zero' u) hu, rfl⟩
 
+lemma Λ_eq : P.Λ = mellin P.f := by rfl
+
+lemma symm_Λ_eq : P.symm.Λ = mellin P.g := by rfl
+
 /-- If `(f, g)` are a strong FE pair, then the Mellin transform of `f` is entire. -/
 lemma differentiable_Λ : Differentiable ℂ P.Λ := fun s ↦
   let ⟨_, ht⟩ := exists_gt s.re
@@ -212,7 +215,7 @@ This is proved by making a substitution `t ↦ t⁻¹` in the Mellin transform i
 lemma functional_equation (s : ℂ) :
     P.Λ (P.k - s) = P.ε • P.symm.Λ s := by
   -- unfold definition:
-  change mellin P.f (P.k - s) = P.ε • mellin P.g s
+  rw [P.Λ_eq, P.symm_Λ_eq]
   -- substitute `t ↦ t⁻¹` in `mellin P.g s`
   have step1 := mellin_comp_rpow P.g (-s) (-1)
   simp_rw [abs_neg, abs_one, inv_one, one_smul, ofReal_neg, ofReal_one, div_neg, div_one, neg_neg,

--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -35,7 +35,7 @@ respectively both have meromorphic continuation and satisfy a functional equatio
 The poles (and their residues) are explicitly given in terms of `f₀` and `g₀`; in particular, if
 `(f, g)` are a strong FE-pair, then the Mellin transforms of `f` and `g` are entire functions.
 
-### Main results
+### Main definitions and results
 
 See the sections *Main theorems on weak FE-pairs* and
 *Main theorems on strong FE-pairs* below.
@@ -175,11 +175,11 @@ namespace StrongFEPair
 
 variable (P : StrongFEPair E)
 
-/-- As `x → ∞`, `F x` decays faster than any power of `x`. -/
+/-- As `x → ∞`, `f x` decays faster than any power of `x`. -/
 lemma hf_top' (r : ℝ) : P.f =O[atTop] (· ^ (-r)) := by
   simpa only [P.hf₀, sub_zero] using P.hf_top r
 
-/-- As `x → 0`, `F x` decays faster than any power of `x`. -/
+/-- As `x → 0`, `f x` decays faster than any power of `x`. -/
 lemma hf_zero' (r : ℝ) : P.f =O[𝓝[>] 0] (· ^ (-r)) := by
   have := P.hg₀ ▸ P.hf_zero r
   simpa only [smul_zero, sub_zero]
@@ -192,15 +192,14 @@ lemma hf_zero' (r : ℝ) : P.f =O[𝓝[>] 0] (· ^ (-r)) := by
 def Λ : ℂ → E := mellin P.f
 
 /-- The Mellin transform of `f` is well-defined and equal to `P.Λ s`, for all `s`. -/
-lemma hasMellin (s : ℂ) :
-    HasMellin P.f s (P.Λ s):=
+lemma hasMellin (s : ℂ) : HasMellin P.f s (P.Λ s) :=
   let ⟨t, ht⟩ := exists_gt s.re
   let ⟨u, hu⟩ := exists_lt s.re
   ⟨mellinConvergent_of_isBigO_rpow P.hf_int (P.hf_top' t) ht (P.hf_zero' u) hu, rfl⟩
 
-lemma Λ_eq : P.Λ = mellin P.f := by rfl
+lemma Λ_eq : P.Λ = mellin P.f := rfl
 
-lemma symm_Λ_eq : P.symm.Λ = mellin P.g := by rfl
+lemma symm_Λ_eq : P.symm.Λ = mellin P.g := rfl
 
 /-- If `(f, g)` are a strong FE pair, then the Mellin transform of `f` is entire. -/
 lemma differentiable_Λ : Differentiable ℂ P.Λ := fun s ↦
@@ -222,8 +221,7 @@ lemma functional_equation (s : ℂ) :
     rpow_neg_one, ← one_div] at step1
   -- introduce a power of `t` to match the hypothesis `P.h_feq`
   have step2 := mellin_cpow_smul (fun t ↦ P.g (1 / t)) (P.k - s) (-P.k)
-  rw [← sub_eq_add_neg, sub_right_comm, sub_self, zero_sub] at step2
-  simp_rw [step1] at step2
+  rw [← sub_eq_add_neg, sub_right_comm, sub_self, zero_sub, step1] at step2
   -- put in the constant `P.ε`
   have step3 := mellin_const_smul (fun t ↦ (t : ℂ) ^ (-P.k : ℂ) • P.g (1 / t)) (P.k - s) P.ε
   rw [step2] at step3
@@ -249,7 +247,7 @@ variable (P : WeakFEPair E)
 
 /-- Piecewise modified version of `f` with optimal asymptotics. We deliberately choose intervals
 which don't quite join up, so the function is `0` at `x = 1`, in order to maintain symmetry;
-there is no `good` choice of value at `1`. -/
+there is no "good" choice of value at `1`. -/
 def f_modif : ℝ → E :=
   (Ioi 1).indicator (fun x ↦ P.f x - P.f₀) +
   (Ioo 0 1).indicator (fun x ↦ P.f x - (P.ε * ↑(x ^ (-P.k))) • P.g₀)
@@ -287,10 +285,7 @@ lemma hf_modif_FE (x : ℝ) (hx : 0 < x) :
       indicator_of_mem (mem_Ioi.mpr hx'), indicator_of_not_mem
       (not_mem_Ioo_of_ge hx'.le), add_zero, P.h_feq _ hx, smul_sub]
     simp_rw [rpow_neg (one_div_pos.mpr hx).le, one_div, inv_rpow hx.le, inv_inv]
-  · rw [div_one, f_modif, Pi.add_apply, indicator_of_not_mem, indicator_of_not_mem,
-      g_modif, Pi.add_apply, indicator_of_not_mem, indicator_of_not_mem]
-    simp only [add_zero, smul_zero]
-    all_goals { simp }
+  · simp [f_modif, g_modif]
   · have : 1 < 1 / x := by rwa [lt_one_div one_pos hx, div_one]
     rw [f_modif, Pi.add_apply, indicator_of_mem (mem_Ioi.mpr this),
       indicator_of_not_mem (not_mem_Ioo_of_ge this.le), add_zero, g_modif, Pi.add_apply,
@@ -332,9 +327,7 @@ lemma f_modif_aux1 : EqOn (fun x ↦ P.f_modif x - P.f x + P.f₀)
       indicator_of_mem (mem_Ioo.mpr ⟨hx, hx'⟩)]
     rw [indicator_of_not_mem (mem_singleton_iff.not.mpr hx'.ne), add_zero]
     abel
-  · simp_rw [indicator_of_not_mem (not_mem_Ioi.mpr le_rfl), zero_add,
-      indicator_of_not_mem (not_mem_Ioo_of_ge le_rfl), zero_sub, zero_add]
-    rw [indicator_of_mem (mem_singleton _)]
+  · simp [add_comm, sub_eq_add_neg]
     abel
   · simp_rw [indicator_of_mem (mem_Ioi.mpr hx'),
       indicator_of_not_mem (not_mem_Ioo_of_ge hx'.le),
@@ -403,7 +396,7 @@ lemma differentiable_Λ₀ : Differentiable ℂ P.Λ₀ := P.modifStrongFEPair.d
 
 lemma differentiableAt_Λ {s : ℂ} (hs : s ≠ 0 ∨ P.f₀ = 0) (hs' : s ≠ P.k ∨ P.g₀ = 0) :
     DifferentiableAt ℂ P.Λ s := by
-  refine ((P.differentiable_Λ₀ s).sub  ?_).sub ?_
+  refine ((P.differentiable_Λ₀ s).sub ?_).sub ?_
   · rcases hs with hs | hs
     · simpa only [one_div] using (differentiableAt_inv' hs).smul_const P.f₀
     · simpa only [hs, smul_zero] using differentiableAt_const (0 : E)

--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -395,9 +395,9 @@ lemma Λ₀_eq (s : ℂ) : P.Λ₀ s = P.Λ s + (1 / s) • P.f₀ + (P.ε / (P.
   abel
 
 lemma symm_Λ₀_eq (s : ℂ) :
-  P.symm.Λ₀ s = P.symm.Λ s + (1 / s) • P.g₀ + (P.ε⁻¹ / (P.k - s)) • P.f₀ := by
-    rw [P.symm.Λ₀_eq]
-    rfl
+    P.symm.Λ₀ s = P.symm.Λ s + (1 / s) • P.g₀ + (P.ε⁻¹ / (P.k - s)) • P.f₀ := by
+  rw [P.symm.Λ₀_eq]
+  rfl
 
 lemma differentiable_Λ₀ : Differentiable ℂ P.Λ₀ := P.modifStrongFEPair.differentiable_Λ
 


### PR DESCRIPTION
A general framework for proving analytic continuation & functional equations via Mellin transforms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

(Note to reviewers: this is a generalisation of the existing argument used in the Riemann zeta function code; but I have not refactored the existing code using this just yet, since I will shortly be PR'ing more general results for Hurwitz and Dirichlet L-series, and Riemann zeta will eventually just be a special case of these.)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
