### PR TITLE
[Merged by Bors] - feat: `@[simp]` `Icc a b ∈ 𝓝 x`

### DIFF
--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -1544,8 +1544,8 @@ theorem interior_Icc [NoMinOrder α] [NoMaxOrder α] {a b : α} : interior (Icc 
 
 @[simp]
 theorem Icc_mem_nhds_iff [NoMinOrder α] [NoMaxOrder α] {a b x : α} :
-    Icc a b ∈ 𝓝 x ↔ Ioo a b ∈ 𝓝 x := by
-  rw [← interior_Icc, interior_mem_nhds]
+    Icc a b ∈ 𝓝 x ↔ x ∈ Ioo a b := by
+  rw [← interior_Icc, mem_interior_iff_mem_nhds]
 
 @[simp]
 theorem interior_Ico [NoMinOrder α] {a b : α} : interior (Ico a b) = Ioo a b := by
@@ -1553,8 +1553,8 @@ theorem interior_Ico [NoMinOrder α] {a b : α} : interior (Ico a b) = Ioo a b :
 #align interior_Ico interior_Ico
 
 @[simp]
-theorem Ico_mem_nhds_iff [NoMinOrder α] {a b x : α} : Ico a b ∈ 𝓝 x ↔ Ioo a b ∈ 𝓝 x := by
-  rw [← interior_Ico, interior_mem_nhds]
+theorem Ico_mem_nhds_iff [NoMinOrder α] {a b x : α} : Ico a b ∈ 𝓝 x ↔ x ∈ Ioo a b := by
+  rw [← interior_Ico, mem_interior_iff_mem_nhds]
 
 @[simp]
 theorem interior_Ioc [NoMaxOrder α] {a b : α} : interior (Ioc a b) = Ioo a b := by
@@ -1562,8 +1562,8 @@ theorem interior_Ioc [NoMaxOrder α] {a b : α} : interior (Ioc a b) = Ioo a b :
 #align interior_Ioc interior_Ioc
 
 @[simp]
-theorem Ioc_mem_nhds_iff [NoMaxOrder α] {a b x : α} : Ioc a b ∈ 𝓝 x ↔ Ioo a b ∈ 𝓝 x := by
-  rw [← interior_Ioc, interior_mem_nhds]
+theorem Ioc_mem_nhds_iff [NoMaxOrder α] {a b x : α} : Ioc a b ∈ 𝓝 x ↔ x ∈ Ioo a b := by
+  rw [← interior_Ioc, mem_interior_iff_mem_nhds]
 
 theorem closure_interior_Icc {a b : α} (h : a ≠ b) : closure (interior (Icc a b)) = Icc a b :=
   (closure_minimal interior_subset isClosed_Icc).antisymm <|

--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -1543,14 +1543,27 @@ theorem interior_Icc [NoMinOrder α] [NoMaxOrder α] {a b : α} : interior (Icc 
 #align interior_Icc interior_Icc
 
 @[simp]
+theorem Icc_mem_nhds_iff [NoMinOrder α] [NoMaxOrder α] {a b x : α} :
+    Icc a b ∈ 𝓝 x ↔ Ioo a b ∈ 𝓝 x := by
+  rw [← interior_Icc, interior_mem_nhds]
+
+@[simp]
 theorem interior_Ico [NoMinOrder α] {a b : α} : interior (Ico a b) = Ioo a b := by
   rw [← Ici_inter_Iio, interior_inter, interior_Ici, interior_Iio, Ioi_inter_Iio]
 #align interior_Ico interior_Ico
 
 @[simp]
+theorem Ico_mem_nhds_iff [NoMinOrder α] {a b x : α} : Ico a b ∈ 𝓝 x ↔ Ioo a b ∈ 𝓝 x := by
+  rw [← interior_Ico, interior_mem_nhds]
+
+@[simp]
 theorem interior_Ioc [NoMaxOrder α] {a b : α} : interior (Ioc a b) = Ioo a b := by
   rw [← Ioi_inter_Iic, interior_inter, interior_Ioi, interior_Iic, Ioi_inter_Iio]
 #align interior_Ioc interior_Ioc
+
+@[simp]
+theorem Ioc_mem_nhds_iff [NoMaxOrder α] {a b x : α} : Ioc a b ∈ 𝓝 x ↔ Ioo a b ∈ 𝓝 x := by
+  rw [← interior_Ioc, interior_mem_nhds]
 
 theorem closure_interior_Icc {a b : α} (h : a ≠ b) : closure (interior (Icc a b)) = Icc a b :=
   (closure_minimal interior_subset isClosed_Icc).antisymm <|


### PR DESCRIPTION
Currently doesn't simplify since `interior_Icc` goes the other way.

We were using it in PrimeNumberTheoremAnd for things like "point does not lie on boundary of rectangle".


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
