### PR TITLE
[Merged by Bors] - feat: let `congr!` discharge equalities of `BEq` instances

### DIFF
--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -1292,3 +1292,20 @@ theorem not_beq_of_ne [BEq α] [LawfulBEq α] {a b : α} (ne : a ≠ b) : ¬(a =
 theorem beq_eq_decide [BEq α] [LawfulBEq α] {a b : α} : (a == b) = decide (a = b) := by
   rw [← beq_iff_eq a b]
   cases a == b <;> simp
+
+@[ext]
+theorem beq_ext (inst1 : BEq α) (inst2 : BEq α)
+    (h : ∀ x y, @BEq.beq _ inst1 x y = @BEq.beq _ inst2 x y) :
+    inst1 = inst2 := by
+  have ⟨beq1⟩ := inst1
+  have ⟨beq2⟩ := inst2
+  congr
+  funext x y
+  exact h x y
+
+theorem lawful_beq_subsingleton (inst1 : BEq α) (inst2 : BEq α)
+    [@LawfulBEq α inst1] [@LawfulBEq α inst2] :
+    inst1 = inst2 := by
+  apply beq_ext
+  intro x y
+  simp only [beq_eq_decide]

--- a/Mathlib/Tactic/Congr!.lean
+++ b/Mathlib/Tactic/Congr!.lean
@@ -6,6 +6,7 @@ Authors: Kyle Miller
 import Lean.Elab.Tactic.Config
 import Lean.Elab.Tactic.RCases
 import Mathlib.Lean.Meta.CongrTheorems
+import Mathlib.Logic.Basic
 import Mathlib.Tactic.Relation.Rfl
 import Std.Logic
 
@@ -107,6 +108,9 @@ structure Congr!.Config where
   `preferLHS`, `partialApp` and `maxArgs` and transparency settings. It acts as if `sameFun := true`
   and it ignores `typeEqs`. -/
   useCongrSimp : Bool := false
+  /-- Whether to use a special congruence lemma for `BEq` instances.
+  This synthesizes `LawfulBEq` instances to discharge equalities of `BEq` instances. -/
+  beqEq : Bool := true
 
 /-- A configuration option that makes `congr!` do the sorts of aggressive unfoldings that `congr`
 does while also similarly preventing `congr!` from considering partial applications or congruences
@@ -333,7 +337,7 @@ where
       observing? <| applyCongrThm? config mvarId congrThm.type congrThm.proof
   /-- Like `mkCongrSimp?` but takes in a specific arity. -/
   mkCongrSimpNArgs (f : Expr) (nArgs : Nat) : MetaM (Option CongrTheorem) := do
-    let f := (← instantiateMVars f).cleanupAnnotations
+    let f := (← Lean.instantiateMVars f).cleanupAnnotations
     let info ← getFunInfoNArgs f nArgs
     mkCongrSimpCore? f info
       (← getCongrSimpKinds f info) (subsingletonInstImplicitRhs := false)
@@ -445,6 +449,13 @@ def Lean.MVarId.subsingletonHelim? (mvarId : MVarId) : MetaM (Option (List MVarI
     failure
 
 /--
+Tries to apply `lawful_beq_subsingleton` to prove that two `BEq` instances are equal
+by synthesizing `LawfulBEq` instances for both.
+-/
+def Lean.MVarId.beqInst? (mvarId : MVarId) : MetaM (Option (List MVarId)) :=
+  observing? do withReducible <| mvarId.applyConst ``lawful_beq_subsingleton
+
+/--
 A list of all the congruence strategies used by `Lean.MVarId.congrCore!`.
 -/
 def Lean.MVarId.congrPasses! :
@@ -453,10 +464,17 @@ def Lean.MVarId.congrPasses! :
    ("hcongr lemma", smartHCongr?),
    ("congr simp lemma", congrSimp?),
    ("Subsingleton.helim", fun _ => subsingletonHelim?),
+   ("BEq instances", fun config => when config (·.beqEq) beqInst?),
    ("obvious funext", fun _ => obviousFunext?),
    ("obvious hfunext", fun _ => obviousHfunext?),
    ("congr_implies", fun _ => congrImplies?'),
    ("congr_pi", fun _ => congrPi?)]
+where
+  when (config : Congr!.Config) (b : Congr!.Config → Bool)
+      (f : MVarId → MetaM (Option (List MVarId))) :
+      MVarId → MetaM (Option (List MVarId)) := fun mvar => do
+    unless b config do return none
+    f mvar
 
 structure CongrState where
   /-- Accumulated goals that `congr!` could not handle. -/
@@ -517,7 +535,7 @@ where
         if ty.isArrow then
           if ← (isTrivialType ty.bindingDomain!
                 <||> (← getLCtx).anyM (fun decl => do
-                        return (← instantiateMVars decl.type) == ty.bindingDomain!)) then
+                        return (← Lean.instantiateMVars decl.type) == ty.bindingDomain!)) then
             -- Don't intro, clear it
             let mvar ← mkFreshExprSyntheticOpaqueMVar ty.bindingBody! (← mvarId.getTag)
             mvarId.assign <| .lam .anonymous ty.bindingDomain! mvar .default
@@ -533,7 +551,7 @@ where
   isTrivialType (ty : Expr) : MetaM Bool := do
     unless ← Meta.isProp ty do
       return false
-    let ty ← instantiateMVars ty
+    let ty ← Lean.instantiateMVars ty
     if let some (lhs, rhs) := ty.eqOrIff? then
       if lhs.cleanupAnnotations == rhs.cleanupAnnotations then
         return true

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -273,6 +273,7 @@
    "Mathlib.Data.Fintype.Sigma",
    "Mathlib.Data.Fintype.Sum"],
   "Mathlib.Tactic.Continuity": ["Mathlib.Tactic.Continuity.Init"],
+  "Mathlib.Tactic.Congr!": ["Mathlib.Logic.Basic"],
   "Mathlib.Tactic.Choose": ["Mathlib.Logic.Function.Basic"],
   "Mathlib.Tactic.CategoryTheory.Slice":
   ["Mathlib.CategoryTheory.Category.Basic"],

--- a/test/congr.lean
+++ b/test/congr.lean
@@ -309,3 +309,28 @@ example {α} [AddCommMonoid α] [PartialOrder α] {a b c d e f g : α} :
     (a + b) + (c + d) + (e + f) + g ≤ a + d + e + f + c + b + g := by
   ac_change a + d + e + f + c + g + b ≤ a + d + e + f + c + g + b
   rfl
+
+/-!
+Lawful BEq instances are "subsingletons".
+-/
+
+example (inst1 : BEq α) [LawfulBEq α] (inst2 : BEq α) [LawfulBEq α] (xs : List α) (x : α) :
+    @List.erase _ inst1 xs x = @List.erase _ inst2 xs x := by
+  congr!
+
+/--
+error: unsolved goals
+case h.e'_2
+α : Type ?u.83134
+inst1 : BEq α
+inst✝¹ : LawfulBEq α
+inst2 : BEq α
+inst✝ : LawfulBEq α
+xs : List α
+x : α
+⊢ inst1 = inst2
+-/
+#guard_msgs in
+example (inst1 : BEq α) [LawfulBEq α] (inst2 : BEq α) [LawfulBEq α] (xs : List α) (x : α) :
+    @List.erase _ inst1 xs x = @List.erase _ inst2 xs x := by
+  congr! (config := { beqEq := false })


### PR DESCRIPTION
Adds a congruence lemma for `BEq` instances that makes use of `LawfulBEq` instances, and gives `congr!` the ability to use this congruence lemma. This is meant to help with diamonds that arise from interactions between Decidable and BEq instances.

This feature can be turned off using the `beqEq` configuration setting, like `congr! (config := { beqEq := false })`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
