### PR TITLE
[Merged by Bors] - feat: sums over residue classes

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -978,6 +978,7 @@ import Mathlib.Analysis.SpecificLimits.IsROrC
 import Mathlib.Analysis.SpecificLimits.Normed
 import Mathlib.Analysis.Subadditive
 import Mathlib.Analysis.SumIntegralComparisons
+import Mathlib.Analysis.SumOverResidueClass
 import Mathlib.Analysis.VonNeumannAlgebra.Basic
 import Mathlib.CategoryTheory.Abelian.Basic
 import Mathlib.CategoryTheory.Abelian.DiagramLemmas.Four

--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury G. Kudryashov
 -/
 import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
+import Mathlib.Analysis.SumOverResidueClass
 
 #align_import analysis.p_series from "leanprover-community/mathlib"@"0b9eaaa7686280fad8cce467f5c3c57ee6ce77f8"
 
@@ -27,10 +28,6 @@ test once we need it.
 p-series, Cauchy condensation test
 -/
 
-open Filter
-
-open BigOperators ENNReal NNReal Topology
-
 /-!
 ### Cauchy condensation test
 
@@ -42,6 +39,8 @@ terms of the partial sums of the other series.
 
 
 namespace Finset
+
+open BigOperators
 
 variable {M : Type*} [OrderedAddCommMonoid M] {f : ℕ → M}
 
@@ -94,6 +93,8 @@ end Finset
 
 namespace ENNReal
 
+open Filter BigOperators
+
 variable {f : ℕ → ℝ≥0∞}
 
 theorem le_tsum_condensed (hf : ∀ ⦃m n⦄, 0 < m → m ≤ n → f n ≤ f m) :
@@ -119,6 +120,7 @@ end ENNReal
 
 namespace NNReal
 
+open ENNReal in
 /-- Cauchy condensation test for a series of `NNReal` version. -/
 theorem summable_condensed_iff {f : ℕ → ℝ≥0} (hf : ∀ ⦃m n⦄, 0 < m → m ≤ n → f n ≤ f m) :
     (Summable fun k : ℕ => (2 : ℝ≥0) ^ k * f (2 ^ k)) ↔ Summable f := by
@@ -135,6 +137,7 @@ theorem summable_condensed_iff {f : ℕ → ℝ≥0} (hf : ∀ ⦃m n⦄, 0 < m 
 
 end NNReal
 
+open NNReal in
 /-- Cauchy condensation test for series of nonnegative real numbers. -/
 theorem summable_condensed_iff_of_nonneg {f : ℕ → ℝ} (h_nonneg : ∀ n, 0 ≤ f n)
     (h_mono : ∀ ⦃m n⦄, 0 < m → m ≤ n → f n ≤ f m) :
@@ -144,7 +147,7 @@ theorem summable_condensed_iff_of_nonneg {f : ℕ → ℝ} (h_nonneg : ∀ n, 0 
   exact_mod_cast NNReal.summable_condensed_iff h_mono
 #align summable_condensed_iff_of_nonneg summable_condensed_iff_of_nonneg
 
-open Real
+section p_series
 
 /-!
 ### Convergence of the `p`-series
@@ -155,11 +158,14 @@ Cauchy condensation test we formalized above. This test implies that `∑ n, 1 /
 and only if `∑ n, 2 ^ n / ((2 ^ n) ^ p)` converges, and the latter series is a geometric series with
 common ratio `2 ^ {1 - p}`. -/
 
+namespace Real
+
+open Filter BigOperators
 
 /-- Test for convergence of the `p`-series: the real-valued series `∑' n : ℕ, (n ^ p)⁻¹` converges
 if and only if `1 < p`. -/
 @[simp]
-theorem Real.summable_nat_rpow_inv {p : ℝ} :
+theorem summable_nat_rpow_inv {p : ℝ} :
     Summable (fun n => ((n : ℝ) ^ p)⁻¹ : ℕ → ℝ) ↔ 1 < p := by
   rcases le_or_lt 0 p with hp | hp
   /- Cauchy condensation test applies only to antitone sequences, so we consider the
@@ -191,14 +197,14 @@ theorem Real.summable_nat_rpow_inv {p : ℝ} :
 #align real.summable_nat_rpow_inv Real.summable_nat_rpow_inv
 
 @[simp]
-theorem Real.summable_nat_rpow {p : ℝ} : Summable (fun n => (n : ℝ) ^ p : ℕ → ℝ) ↔ p < -1 := by
+theorem summable_nat_rpow {p : ℝ} : Summable (fun n => (n : ℝ) ^ p : ℕ → ℝ) ↔ p < -1 := by
   rcases neg_surjective p with ⟨p, rfl⟩
   simp [rpow_neg]
 #align real.summable_nat_rpow Real.summable_nat_rpow
 
 /-- Test for convergence of the `p`-series: the real-valued series `∑' n : ℕ, 1 / n ^ p` converges
 if and only if `1 < p`. -/
-theorem Real.summable_one_div_nat_rpow {p : ℝ} :
+theorem summable_one_div_nat_rpow {p : ℝ} :
     Summable (fun n => 1 / (n : ℝ) ^ p : ℕ → ℝ) ↔ 1 < p := by
   simp
 #align real.summable_one_div_nat_rpow Real.summable_one_div_nat_rpow
@@ -207,32 +213,32 @@ theorem Real.summable_one_div_nat_rpow {p : ℝ} :
 if and only if `1 < p`. -/
 -- Porting note: temporarily remove `@[simp]` because of a problem with `simp`
 -- see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/looping.20in.20.60simp.60.20set/near/361134234
-theorem Real.summable_nat_pow_inv {p : ℕ} :
+theorem summable_nat_pow_inv {p : ℕ} :
     Summable (fun n => ((n : ℝ) ^ p)⁻¹ : ℕ → ℝ) ↔ 1 < p := by
-  simp only [← rpow_nat_cast, Real.summable_nat_rpow_inv, Nat.one_lt_cast]
+  simp only [← rpow_nat_cast, summable_nat_rpow_inv, Nat.one_lt_cast]
 #align real.summable_nat_pow_inv Real.summable_nat_pow_inv
 
 /-- Test for convergence of the `p`-series: the real-valued series `∑' n : ℕ, 1 / n ^ p` converges
 if and only if `1 < p`. -/
-theorem Real.summable_one_div_nat_pow {p : ℕ} :
+theorem summable_one_div_nat_pow {p : ℕ} :
     Summable (fun n => 1 / (n : ℝ) ^ p : ℕ → ℝ) ↔ 1 < p := by
   -- porting note (#10745): was `simp`
   simp only [one_div, Real.summable_nat_pow_inv]
 #align real.summable_one_div_nat_pow Real.summable_one_div_nat_pow
 
 /-- Summability of the `p`-series over `ℤ`. -/
-theorem Real.summable_one_div_int_pow {p : ℕ} :
+theorem summable_one_div_int_pow {p : ℕ} :
     (Summable fun n : ℤ => 1 / (n : ℝ) ^ p) ↔ 1 < p := by
   refine'
-    ⟨fun h => Real.summable_one_div_nat_pow.mp (h.comp_injective Nat.cast_injective), fun h =>
-      summable_int_of_summable_nat (Real.summable_one_div_nat_pow.mpr h)
-        (((Real.summable_one_div_nat_pow.mpr h).mul_left <| 1 / (-1 : ℝ) ^ p).congr fun n => _)⟩
+    ⟨fun h => summable_one_div_nat_pow.mp (h.comp_injective Nat.cast_injective), fun h =>
+      summable_int_of_summable_nat (summable_one_div_nat_pow.mpr h)
+        (((summable_one_div_nat_pow.mpr h).mul_left <| 1 / (-1 : ℝ) ^ p).congr fun n => _)⟩
   conv_rhs =>
     rw [Int.cast_neg, neg_eq_neg_one_mul, mul_pow, ← div_div]
   conv_lhs => rw [mul_div, mul_one]
 #align real.summable_one_div_int_pow Real.summable_one_div_int_pow
 
-theorem Real.summable_abs_int_rpow {b : ℝ} (hb : 1 < b) :
+theorem summable_abs_int_rpow {b : ℝ} (hb : 1 < b) :
     Summable fun n : ℤ => |(n : ℝ)| ^ (-b) := by
   -- Porting note: was
   -- refine'
@@ -246,48 +252,56 @@ theorem Real.summable_abs_int_rpow {b : ℝ} (hb : 1 < b) :
   on_goal 2 => simp_rw [Int.cast_neg, abs_neg]
   all_goals
     simp_rw [Int.cast_ofNat, fun n : ℕ => abs_of_nonneg (n.cast_nonneg : 0 ≤ (n : ℝ))]
-    rwa [Real.summable_nat_rpow, neg_lt_neg_iff]
+    rwa [summable_nat_rpow, neg_lt_neg_iff]
 #align real.summable_abs_int_rpow Real.summable_abs_int_rpow
 
 /-- Harmonic series is not unconditionally summable. -/
-theorem Real.not_summable_nat_cast_inv : ¬Summable (fun n => n⁻¹ : ℕ → ℝ) := by
+theorem not_summable_nat_cast_inv : ¬Summable (fun n => n⁻¹ : ℕ → ℝ) := by
   have : ¬Summable (fun n => ((n : ℝ) ^ 1)⁻¹ : ℕ → ℝ) :=
-    mt (Real.summable_nat_pow_inv (p := 1)).1 (lt_irrefl 1)
+    mt (summable_nat_pow_inv (p := 1)).1 (lt_irrefl 1)
   simpa
 #align real.not_summable_nat_cast_inv Real.not_summable_nat_cast_inv
 
 /-- Harmonic series is not unconditionally summable. -/
-theorem Real.not_summable_one_div_nat_cast : ¬Summable (fun n => 1 / n : ℕ → ℝ) := by
-  simpa only [inv_eq_one_div] using Real.not_summable_nat_cast_inv
+theorem not_summable_one_div_nat_cast : ¬Summable (fun n => 1 / n : ℕ → ℝ) := by
+  simpa only [inv_eq_one_div] using not_summable_nat_cast_inv
 #align real.not_summable_one_div_nat_cast Real.not_summable_one_div_nat_cast
 
 /-- **Divergence of the Harmonic Series** -/
-theorem Real.tendsto_sum_range_one_div_nat_succ_atTop :
+theorem tendsto_sum_range_one_div_nat_succ_atTop :
     Tendsto (fun n => ∑ i in Finset.range n, (1 / (i + 1) : ℝ)) atTop atTop := by
   rw [← not_summable_iff_tendsto_nat_atTop_of_nonneg]
-  · exact_mod_cast mt (_root_.summable_nat_add_iff 1).1 Real.not_summable_one_div_nat_cast
+  · exact_mod_cast mt (_root_.summable_nat_add_iff 1).1 not_summable_one_div_nat_cast
   · exact fun i => by positivity
 #align real.tendsto_sum_range_one_div_nat_succ_at_top Real.tendsto_sum_range_one_div_nat_succ_atTop
 
+end Real
+
+namespace NNReal
+
 @[simp]
-theorem NNReal.summable_rpow_inv {p : ℝ} :
+theorem summable_rpow_inv {p : ℝ} :
     Summable (fun n => ((n : ℝ≥0) ^ p)⁻¹ : ℕ → ℝ≥0) ↔ 1 < p := by
   simp [← NNReal.summable_coe]
 #align nnreal.summable_rpow_inv NNReal.summable_rpow_inv
 
 @[simp]
-theorem NNReal.summable_rpow {p : ℝ} : Summable (fun n => (n : ℝ≥0) ^ p : ℕ → ℝ≥0) ↔ p < -1 := by
+theorem summable_rpow {p : ℝ} : Summable (fun n => (n : ℝ≥0) ^ p : ℕ → ℝ≥0) ↔ p < -1 := by
   simp [← NNReal.summable_coe]
 #align nnreal.summable_rpow NNReal.summable_rpow
 
-theorem NNReal.summable_one_div_rpow {p : ℝ} :
+theorem summable_one_div_rpow {p : ℝ} :
     Summable (fun n => 1 / (n : ℝ≥0) ^ p : ℕ → ℝ≥0) ↔ 1 < p := by
   simp
 #align nnreal.summable_one_div_rpow NNReal.summable_one_div_rpow
 
+end NNReal
+
+end p_series
+
 section
 
-open Finset
+open Finset BigOperators
 
 variable {α : Type*} [LinearOrderedField α]
 
@@ -335,7 +349,19 @@ theorem sum_Ioo_inv_sq_le (k n : ℕ) : (∑ i in Ioo k n, (i ^ 2 : α)⁻¹) �
       gcongr
       simpa using pow_le_pow_right A one_le_two
     _ = 2 / (k + 1) := by ring
-
 #align sum_Ioo_inv_sq_le sum_Ioo_inv_sq_le
 
 end
+
+open Set Nat in
+/-- The harmonic series restricted to a residue class is not summable. -/
+lemma Real.not_summable_indicator_one_div_natCast {m : ℕ} (hm : m ≠ 0) (k : ZMod m) :
+    ¬ Summable ({n : ℕ | (n : ZMod m) = k}.indicator fun n : ℕ ↦ (1 / n : ℝ)) := by
+  have : NeZero m := ⟨hm⟩ -- instance is needed below
+  rw [← summable_nat_add_iff 1] -- shift by one to avoid non-monotonicity at zero
+  have h (n : ℕ) : {n : ℕ | (n : ZMod m) = k - 1}.indicator (fun n : ℕ ↦ (1 / (n + 1 :) : ℝ)) n =
+      if (n : ZMod m) = k - 1 then (1 / (n + 1) : ℝ) else (0 : ℝ) := by
+    simp only [indicator_apply, mem_setOf_eq, cast_add, cast_one]
+  simp_rw [indicator_apply, mem_setOf, cast_add, cast_one, ← eq_sub_iff_add_eq, ← h]
+  rw [summable_indicator_mod_iff m (fun n₁ n₂ h ↦ by gcongr) (fun n ↦ by positivity) (k - 1)]
+  exact mt (summable_nat_add_iff (f := fun n : ℕ ↦ 1 / (n : ℝ)) 1).mp not_summable_one_div_nat_cast

--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -363,5 +363,5 @@ lemma Real.not_summable_indicator_one_div_natCast {m : ℕ} (hm : m ≠ 0) (k : 
       if (n : ZMod m) = k - 1 then (1 / (n + 1) : ℝ) else (0 : ℝ) := by
     simp only [indicator_apply, mem_setOf_eq, cast_add, cast_one]
   simp_rw [indicator_apply, mem_setOf, cast_add, cast_one, ← eq_sub_iff_add_eq, ← h]
-  rw [summable_indicator_mod_iff m (fun n₁ n₂ h ↦ by gcongr) (fun n ↦ by positivity) (k - 1)]
+  rw [summable_indicator_mod_iff (fun n₁ n₂ h ↦ by gcongr) (k - 1)]
   exact mt (summable_nat_add_iff (f := fun n : ℕ ↦ 1 / (n : ℝ)) 1).mp not_summable_one_div_nat_cast

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -5,6 +5,8 @@ Authors: Michael Stoll
 -/
 import Mathlib.Data.ZMod.Basic
 import Mathlib.Topology.Instances.ENNReal
+import Mathlib.Topology.Instances.NNReal
+import Mathlib.Analysis.NormedSpace.FiniteDimension
 
 /-!
 # Sums over residue classes
@@ -26,13 +28,11 @@ lemma Finset.sum_indicator_mod {R : Type*} [AddCommMonoid R] (m : ℕ) [NeZero m
   simp only [Finset.sum_apply, Set.indicator_apply, Set.mem_setOf_eq, Finset.sum_ite_eq,
     Finset.mem_univ, ↓reduceIte]
 
-variable (m : ℕ) [hm : NeZero m]
-
 open Set in
 /-- A sequence `f` with values in an additive topological group `R` is summable on the
 residue class of `k` mod `m` if and only if `f (m*n + k)` is summable. -/
 lemma summable_indicator_mod_iff_summable {R : Type*} [AddCommGroup R] [TopologicalSpace R]
-    [TopologicalAddGroup R] (k : ℕ) (f : ℕ → R) :
+    [TopologicalAddGroup R] (m : ℕ) [hm : NeZero m] (k : ℕ) (f : ℕ → R) :
     Summable ({n : ℕ | (n : ZMod m) = k}.indicator f) ↔ Summable fun n ↦ f (m * n + k) := by
   trans Summable ({n : ℕ | (n : ZMod m) = k ∧ k ≤ n}.indicator f)
   · rw [← (finite_lt_nat k).summable_compl_iff (f := {n : ℕ | (n : ZMod m) = k}.indicator f)]
@@ -48,27 +48,50 @@ lemma summable_indicator_mod_iff_summable {R : Type*} [AddCommGroup R] [Topologi
     simp only [Function.comp_apply, mem_setOf_eq, Nat.cast_add, Nat.cast_mul, CharP.cast_eq_zero,
       zero_mul, zero_add, le_add_iff_nonneg_left, zero_le, and_self, indicator_of_mem, g]
 
-variable {f : ℕ → ℝ}
+/-- If `f : ℕ → ℝ` is decreasing and has a negative term, then `f` restricted to a residue
+class is not summable.-/
+lemma not_summable_of_antitone_of_neg {m : ℕ} [hm : NeZero m] {f : ℕ → ℝ} (hf : Antitone f)
+    {n : ℕ} (hn : f n < 0) (k : ZMod m) :
+    ¬ Summable ({n : ℕ | (n : ZMod m) = k}.indicator f) := by
+  rw [← ZMod.nat_cast_zmod_val k, summable_indicator_mod_iff_summable, ← summable_norm_iff]
+  intro hs
+  have := hs.tendsto_atTop_zero
+  simp only [Real.norm_eq_abs, Metric.tendsto_atTop, dist_zero_right, abs_abs] at this
+  obtain ⟨N, hN⟩ := this (|f n|) (abs_pos_of_neg hn)
+  specialize hN (max n N) (Nat.le_max_right n N)
+  contrapose! hN; clear hN
+  have H : f (m * max n N + k.val) ≤ f n :=
+    hf <|
+    calc
+      n ≤ m * n + k.val := (Nat.le_mul_of_pos_left n Fin.size_pos').trans <| Nat.le_add_right ..
+      _ ≤ m * max n N + k.val := by gcongr; exact Nat.le_max_left n N
+  rwa [abs_of_neg hn, abs_of_neg (lt_of_le_of_lt H hn), neg_le_neg_iff]
 
-/-- If a decreasing nonngeative sequence of real numbers is summable on one residue class
+/-- If a decreasing sequence of real numbers is summable on one residue class
 modulo `m`, then it is also summable on every other residue class mod `m`. -/
-lemma summable_indicator_mod_iff_summable_indicator_mod (hf : Antitone f) (hf₀ : ∀ n, 0 ≤ f n)
+lemma summable_indicator_mod_iff_summable_indicator_mod {m : ℕ} [NeZero m] {f : ℕ → ℝ}
+    (hf : Antitone f) --(hf₀ : ∀ n, 0 ≤ f n)
     {k : ZMod m} (l : ZMod m) (hs : Summable ({n : ℕ | (n : ZMod m) = k}.indicator f)) :
     Summable ({n : ℕ | (n : ZMod m) = l}.indicator f) := by
-  rw [← ZMod.nat_cast_zmod_val k, summable_indicator_mod_iff_summable] at hs
-  have hl : (l.val + m : ZMod m) = l := by
-    simp only [ZMod.nat_cast_val, ZMod.cast_id', id_eq, CharP.cast_eq_zero, add_zero]
-  rw [← hl, ← Nat.cast_add, summable_indicator_mod_iff_summable]
-  refine Summable.of_nonneg_of_le (fun n ↦ hf₀ _) (fun n ↦ hf <| Nat.add_le_add Nat.le.refl ?_) hs
-  exact ((ZMod.val_lt k).trans_le <| m.le_add_left (ZMod.val l)).le
+  by_cases hf₀ : ∀ n, 0 ≤ f n
+  · rw [← ZMod.nat_cast_zmod_val k, summable_indicator_mod_iff_summable] at hs
+    have hl : (l.val + m : ZMod m) = l := by
+      simp only [ZMod.nat_cast_val, ZMod.cast_id', id_eq, CharP.cast_eq_zero, add_zero]
+    rw [← hl, ← Nat.cast_add, summable_indicator_mod_iff_summable]
+    refine Summable.of_nonneg_of_le (fun n ↦ hf₀ _) (fun n ↦ hf <| Nat.add_le_add Nat.le.refl ?_) hs
+    exact ((ZMod.val_lt k).trans_le <| m.le_add_left (ZMod.val l)).le
+  · push_neg at hf₀
+    obtain ⟨n, hn⟩ := hf₀
+    exact (not_summable_of_antitone_of_neg hf hn k hs).elim
 
-/-- A decreasing nonnegative sequence of real numbers is summable on a residue class
+/-- A decreasing sequence of real numbers is summable on a residue class
 if and only if it is summable. -/
-lemma summable_indicator_mod_iff (hf : Antitone f) (hf₀ : ∀ n, 0 ≤ f n) (k : ZMod m) :
+lemma summable_indicator_mod_iff {m : ℕ} [NeZero m] {f : ℕ → ℝ} (hf : Antitone f)
+    (k : ZMod m) :
     Summable ({n : ℕ | (n : ZMod m) = k}.indicator f) ↔ Summable f := by
   refine ⟨fun H ↦ ?_, fun H ↦ Summable.indicator H _⟩
   have key (a : ZMod m) : Summable ({n : ℕ | (n :ZMod m) = a}.indicator f) :=
-    summable_indicator_mod_iff_summable_indicator_mod m hf hf₀ a H
+    summable_indicator_mod_iff_summable_indicator_mod hf a H
   rw [Finset.sum_indicator_mod m f]
   convert summable_sum (s := Finset.univ) fun a _ ↦ key a
   simp only [Finset.sum_apply]

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -3,7 +3,11 @@ Copyright (c) 2024 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
-import Mathlib.Analysis.NormedSpace.FiniteDimension
+import Mathlib.Algebra.Star.Order
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Topology.Instances.ENNReal
+import Mathlib.Analysis.Normed.Field.Basic
+
 
 /-!
 # Sums over residue classes

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -11,7 +11,7 @@ import Mathlib.Analysis.NormedSpace.FiniteDimension
 We consider infinite sums over functions `f` on `ℕ`, restricted to a residue class mod `m`.
 
 The main result is `summable_indicator_mod_iff`, which states that when `f : ℕ → ℝ` is
-decreasing and takes nonnegative values, then the sum over `f` restricted to any residue class
+decreasing, then the sum over `f` restricted to any residue class
 mod `m ≠ 0` converges if and only if the sum over all of `ℕ` converges.
 -/
 

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -46,9 +46,9 @@ lemma summable_indicator_mod_iff_summable {R : Type*} [AddCommGroup R] [Topologi
       zero_mul, zero_add, le_add_iff_nonneg_left, zero_le, and_self, indicator_of_mem, g]
 
 /-- If `f : ℕ → ℝ` is decreasing and has a negative term, then `f` restricted to a residue
-class is not summable.-/
-lemma not_summable_of_antitone_of_neg {m : ℕ} [hm : NeZero m] {f : ℕ → ℝ} (hf : Antitone f)
-    {n : ℕ} (hn : f n < 0) (k : ZMod m) :
+class is not summable. -/
+lemma not_summable_indicator_mod_of_antitone_of_neg {m : ℕ} [hm : NeZero m] {f : ℕ → ℝ}
+    (hf : Antitone f) {n : ℕ} (hn : f n < 0) (k : ZMod m) :
     ¬ Summable ({n : ℕ | (n : ZMod m) = k}.indicator f) := by
   rw [← ZMod.nat_cast_zmod_val k, summable_indicator_mod_iff_summable, ← summable_norm_iff]
   intro hs
@@ -79,7 +79,7 @@ lemma summable_indicator_mod_iff_summable_indicator_mod {m : ℕ} [NeZero m] {f 
     exact ((ZMod.val_lt k).trans_le <| m.le_add_left (ZMod.val l)).le
   · push_neg at hf₀
     obtain ⟨n, hn⟩ := hf₀
-    exact (not_summable_of_antitone_of_neg hf hn k hs).elim
+    exact (not_summable_indicator_mod_of_antitone_of_neg hf hn k hs).elim
 
 /-- A decreasing sequence of real numbers is summable on a residue class
 if and only if it is summable. -/

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -26,7 +26,7 @@ lemma Finset.sum_indicator_mod {R : Type*} [AddCommMonoid R] (m : ℕ) [NeZero m
   simp only [Finset.sum_apply, Set.indicator_apply, Set.mem_setOf_eq, Finset.sum_ite_eq,
     Finset.mem_univ, ↓reduceIte]
 
-variable (m : ℕ) [hm: NeZero m]
+variable (m : ℕ) [hm : NeZero m]
 
 open Set in
 /-- A sequence `f` with values in an additive topological group `R` is summable on the
@@ -48,12 +48,12 @@ lemma summable_indicator_mod_iff_summable {R : Type*} [AddCommGroup R] [Topologi
     simp only [Function.comp_apply, mem_setOf_eq, Nat.cast_add, Nat.cast_mul, CharP.cast_eq_zero,
       zero_mul, zero_add, le_add_iff_nonneg_left, zero_le, and_self, indicator_of_mem, g]
 
-variable {f : ℕ → ℝ} (hf : Antitone f) (hf₀ : ∀ n, 0 ≤ f n)
+variable {f : ℕ → ℝ}
 
 /-- If a decreasing nonngeative sequence of real numbers is summable on one residue class
 modulo `m`, then it is also summable on every other residue class mod `m`. -/
-lemma summable_indicator_mod_iff_summable_indicator_mod {k : ZMod m} (l : ZMod m)
-    (hs : Summable ({n : ℕ | (n : ZMod m) = k}.indicator f)) :
+lemma summable_indicator_mod_iff_summable_indicator_mod (hf : Antitone f) (hf₀ : ∀ n, 0 ≤ f n)
+    {k : ZMod m} (l : ZMod m) (hs : Summable ({n : ℕ | (n : ZMod m) = k}.indicator f)) :
     Summable ({n : ℕ | (n : ZMod m) = l}.indicator f) := by
   rw [← ZMod.nat_cast_zmod_val k, summable_indicator_mod_iff_summable] at hs
   have hl : (l.val + m : ZMod m) = l := by
@@ -64,7 +64,7 @@ lemma summable_indicator_mod_iff_summable_indicator_mod {k : ZMod m} (l : ZMod m
 
 /-- A decreasing nonnegative sequence of real numbers is summable on a residue class
 if and only if it is summable. -/
-lemma summable_indicator_mod_iff (k : ZMod m) :
+lemma summable_indicator_mod_iff (hf : Antitone f) (hf₀ : ∀ n, 0 ≤ f n) (k : ZMod m) :
     Summable ({n : ℕ | (n : ZMod m) = k}.indicator f) ↔ Summable f := by
   refine ⟨fun H ↦ ?_, fun H ↦ Summable.indicator H _⟩
   have key (a : ZMod m) : Summable ({n : ℕ | (n :ZMod m) = a}.indicator f) :=

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -83,8 +83,7 @@ lemma summable_indicator_mod_iff_summable_indicator_mod {m : ℕ} [NeZero m] {f 
 
 /-- A decreasing sequence of real numbers is summable on a residue class
 if and only if it is summable. -/
-lemma summable_indicator_mod_iff {m : ℕ} [NeZero m] {f : ℕ → ℝ} (hf : Antitone f)
-    (k : ZMod m) :
+lemma summable_indicator_mod_iff {m : ℕ} [NeZero m] {f : ℕ → ℝ} (hf : Antitone f) (k : ZMod m) :
     Summable ({n : ℕ | (n : ZMod m) = k}.indicator f) ↔ Summable f := by
   refine ⟨fun H ↦ ?_, fun H ↦ Summable.indicator H _⟩
   have key (a : ZMod m) : Summable ({n : ℕ | (n :ZMod m) = a}.indicator f) :=

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2024 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Stoll
+-/
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Topology.Instances.ENNReal
+
+/-!
+# Sums over residue classes
+
+We consider infinite sums over functions `f` on `ℕ`, restricted to a residue class mod `m`.
+
+The main result is `summable_indicator_mod_iff`, which states that when `f : ℕ → ℝ` is
+decreasing and takes nonnegative values, then the sum over `f` restricted to any residue class
+mod `m ≠ 0` converges if and only if the sum over all of `ℕ` converges.
+
+(Note that we want to use `Summable.of_nonneg_of_le`, which insists on `ℝ` as the target.)
+-/
+
+
+open BigOperators in
+lemma Finset.sum_indicator_mod {R : Type*} [AddCommMonoid R] (m : ℕ) [NeZero m] (f : ℕ → R) :
+    f = ∑ a : ZMod m, {n : ℕ | (n : ZMod m) = a}.indicator f := by
+  ext n
+  simp only [Finset.sum_apply, Set.indicator_apply, Set.mem_setOf_eq, Finset.sum_ite_eq,
+    Finset.mem_univ, ↓reduceIte]
+
+variable (m : ℕ) [hm: NeZero m]
+
+open Set in
+/-- A sequence `f` with values in an additive topological group `R` is summable on the
+residue class of `k` mod `m` if and only if `f (m*n + k)` is summable. -/
+lemma summable_indicator_mod_iff_summable {R : Type*} [AddCommGroup R] [TopologicalSpace R]
+    [TopologicalAddGroup R] (k : ℕ) (f : ℕ → R) :
+    Summable ({n : ℕ | (n : ZMod m) = k}.indicator f) ↔ Summable fun n ↦ f (m * n + k) := by
+  trans Summable ({n : ℕ | (n : ZMod m) = k ∧ k ≤ n}.indicator f)
+  · rw [← (finite_lt_nat k).summable_compl_iff (f := {n : ℕ | (n : ZMod m) = k}.indicator f)]
+    simp only [summable_subtype_iff_indicator, indicator_indicator, inter_comm, setOf_and,
+      compl_setOf, not_lt]
+  · let g : ℕ → ℕ := fun n ↦ m * n + k
+    have hg : Function.Injective g := fun m n hmn ↦ by simpa [g, hm.ne] using hmn
+    have hg' : ∀ n ∉ range g, {n : ℕ | (n : ZMod m) = k ∧ k ≤ n}.indicator f n = 0 := by
+      intro n hn
+      contrapose! hn
+      exact (Nat.range_mul_add m k).symm ▸ mem_of_indicator_ne_zero hn
+    convert (Function.Injective.summable_iff hg hg').symm using 3
+    simp only [Function.comp_apply, mem_setOf_eq, Nat.cast_add, Nat.cast_mul, CharP.cast_eq_zero,
+      zero_mul, zero_add, le_add_iff_nonneg_left, zero_le, and_self, indicator_of_mem, g]
+
+variable {f : ℕ → ℝ} (hf : Antitone f) (hf₀ : ∀ n, 0 ≤ f n)
+
+/-- If a decreasing nonngeative sequence of real numbers is summable on one residue class
+modulo `m`, then it is also summable on every other residue class mod `m`. -/
+lemma summable_indicator_mod_iff_summable_indicator_mod {k : ZMod m} (l : ZMod m)
+    (hs : Summable ({n : ℕ | (n : ZMod m) = k}.indicator f)) :
+    Summable ({n : ℕ | (n : ZMod m) = l}.indicator f) := by
+  rw [← ZMod.nat_cast_zmod_val k, summable_indicator_mod_iff_summable] at hs
+  have hl : (l.val + m : ZMod m) = l := by
+    simp only [ZMod.nat_cast_val, ZMod.cast_id', id_eq, CharP.cast_eq_zero, add_zero]
+  rw [← hl, ← Nat.cast_add, summable_indicator_mod_iff_summable]
+  refine Summable.of_nonneg_of_le (fun n ↦ hf₀ _) (fun n ↦ hf <| Nat.add_le_add Nat.le.refl ?_) hs
+  exact ((ZMod.val_lt k).trans_le <| m.le_add_left (ZMod.val l)).le
+
+/-- A decreasing nonnegative sequence of real numbers is summable on a residue class
+if and only if it is summable. -/
+lemma summable_indicator_mod_iff (k : ZMod m) :
+    Summable ({n : ℕ | (n : ZMod m) = k}.indicator f) ↔ Summable f := by
+  refine ⟨fun H ↦ ?_, fun H ↦ Summable.indicator H _⟩
+  have key (a : ZMod m) : Summable ({n : ℕ | (n :ZMod m) = a}.indicator f) :=
+    summable_indicator_mod_iff_summable_indicator_mod m hf hf₀ a H
+  rw [Finset.sum_indicator_mod m f]
+  convert summable_sum (s := Finset.univ) fun a _ ↦ key a
+  simp only [Finset.sum_apply]

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -13,8 +13,6 @@ We consider infinite sums over functions `f` on `ℕ`, restricted to a residue c
 The main result is `summable_indicator_mod_iff`, which states that when `f : ℕ → ℝ` is
 decreasing and takes nonnegative values, then the sum over `f` restricted to any residue class
 mod `m ≠ 0` converges if and only if the sum over all of `ℕ` converges.
-
-(Note that we want to use `Summable.of_nonneg_of_le`, which insists on `ℝ` as the target.)
 -/
 
 

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -67,8 +67,8 @@ lemma not_summable_of_antitone_of_neg {m : ℕ} [hm : NeZero m] {f : ℕ → ℝ
 /-- If a decreasing sequence of real numbers is summable on one residue class
 modulo `m`, then it is also summable on every other residue class mod `m`. -/
 lemma summable_indicator_mod_iff_summable_indicator_mod {m : ℕ} [NeZero m] {f : ℕ → ℝ}
-    (hf : Antitone f) --(hf₀ : ∀ n, 0 ≤ f n)
-    {k : ZMod m} (l : ZMod m) (hs : Summable ({n : ℕ | (n : ZMod m) = k}.indicator f)) :
+    (hf : Antitone f) {k : ZMod m} (l : ZMod m)
+    (hs : Summable ({n : ℕ | (n : ZMod m) = k}.indicator f)) :
     Summable ({n : ℕ | (n : ZMod m) = l}.indicator f) := by
   by_cases hf₀ : ∀ n, 0 ≤ f n
   · rw [← ZMod.nat_cast_zmod_val k, summable_indicator_mod_iff_summable] at hs

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -3,9 +3,6 @@ Copyright (c) 2024 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
-import Mathlib.Data.ZMod.Basic
-import Mathlib.Topology.Instances.ENNReal
-import Mathlib.Topology.Instances.NNReal
 import Mathlib.Analysis.NormedSpace.FiniteDimension
 
 /-!

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -1357,3 +1357,17 @@ theorem lift_comp_castAddHom : (ZMod.lift n f).comp (Int.castAddHom (ZMod n)) = 
 end lift
 
 end ZMod
+
+/-- The range of `(m * · + k)` on natural numbers is the set of elements `≥ k` in the
+residue class of `k` mod `m`. -/
+lemma Nat.range_mul_add (m k : ℕ) :
+    Set.range (fun n : ℕ ↦ m * n + k) = {n : ℕ | (n : ZMod m) = k ∧ k ≤ n} := by
+  ext n
+  simp only [Set.mem_range, Set.mem_setOf_eq]
+  conv => enter [1, 1, y]; rw [add_comm, eq_comm]
+  refine ⟨fun ⟨a, ha⟩ ↦ ⟨?_, le_iff_exists_add.mpr ⟨_, ha⟩⟩, fun ⟨H₁, H₂⟩ ↦ ?_⟩
+  · simpa using congr_arg ((↑) : ℕ → ZMod m) ha
+  · obtain ⟨a, ha⟩ := le_iff_exists_add.mp H₂
+    simp only [ha, Nat.cast_add, add_right_eq_self, ZMod.nat_cast_zmod_eq_zero_iff_dvd] at H₁
+    obtain ⟨b, rfl⟩ := H₁
+    exact ⟨b, ha⟩


### PR DESCRIPTION
This adds a file `Analysis.SumOverResidueClass`, whose main result is
```lean
/-- A decreasing sequence of real numbers is summable on a residue class
if and only if it is summable. -/
lemma summable_indicator_mod_iff {m : ℕ} [NeZero m] {f : ℕ → ℝ} (hf : Antitone f) (k : ZMod m) :
    Summable ({n : ℕ | (n : ZMod m) = k}.indicator f) ↔ Summable f
```
We then use this to show that the harmonic series still diverges when restricted to a residue class.

This is needed for the proof that the abscissa of absolute convergence of a Dirichlet L-series is 1.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
