### PR TITLE
[Merged by Bors] - chore: scope `open Classical`

### DIFF
--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -346,7 +346,7 @@ end
 
 section DecidableEq
 
-open Classical
+open scoped Classical
 
 theorem mem_span_mul_finite_of_mem_span_mul {R A} [Semiring R] [AddCommMonoid A] [Mul A]
     [Module R A] {S : Set A} {S' : Set A} {x : A} (hx : x ∈ span R (S * S')) :

--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -89,7 +89,7 @@ section
 
 /- Note: we use classical logic only for these definitions, to ensure that we do not write lemmas
 with `Classical.dec` in their statement. -/
-open Classical
+open scoped Classical
 
 /-- Sum of `f x` as `x` ranges over the elements of the support of `f`, if it's finite. Zero
 otherwise. -/

--- a/Mathlib/Algebra/BigOperators/Finsupp.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp.lean
@@ -688,7 +688,7 @@ theorem Finsupp.sum_apply' : g.sum k x = g.sum fun i b => k i b x :=
 
 section
 
-open Classical
+open scoped Classical
 
 theorem Finsupp.sum_sum_index' : (∑ x in s, f x).sum t = ∑ x in s, (f x).sum t :=
   Finset.induction_on s rfl fun a s has ih => by

--- a/Mathlib/Algebra/Category/GroupCat/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/GroupCat/FilteredColimits.lean
@@ -29,7 +29,7 @@ universe v u
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 open CategoryTheory
 

--- a/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Adjunctions.lean
@@ -27,7 +27,7 @@ namespace ModuleCat
 
 universe u
 
-open Classical
+open scoped Classical
 
 variable (R : Type u)
 

--- a/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
@@ -29,7 +29,7 @@ universe v u
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 open CategoryTheory
 

--- a/Mathlib/Algebra/Category/Ring/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/Ring/Adjunctions.lean
@@ -25,7 +25,7 @@ open CategoryTheory
 namespace CommRingCat
 set_option linter.uppercaseLean3 false -- `CommRing`
 
-open Classical
+open scoped Classical
 
 /-- The free functor `Type u ⥤ CommRingCat` sending a type `X` to the multivariable (commutative)
 polynomials with variables `x : X`.

--- a/Mathlib/Algebra/Category/Ring/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/Ring/FilteredColimits.lean
@@ -27,7 +27,7 @@ universe v u
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 open CategoryTheory
 

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -264,7 +264,7 @@ end functorial
 
 section Totalize
 
-open Classical
+open scoped Classical
 
 variable (G f)
 
@@ -289,7 +289,7 @@ end Totalize
 
 variable [DirectedSystem G fun i j h => f i j h]
 
-open Classical
+open scoped Classical
 
 theorem toModule_totalize_of_le {x : DirectSum ι G} {i j : ι} (hij : i ≤ j)
     (hx : ∀ k ∈ x.support, k ≤ i) :
@@ -633,7 +633,7 @@ theorem exists_of [Nonempty ι] [IsDirected ι (· ≤ ·)] (z : DirectLimit G f
 
 section
 
-open Classical
+open scoped Classical
 
 open Polynomial
 
@@ -667,7 +667,7 @@ theorem induction_on [Nonempty ι] [IsDirected ι (· ≤ ·)] {C : DirectLimit 
 
 section OfZeroExact
 
-open Classical
+open scoped Classical
 
 variable (f' : ∀ i j, i ≤ j → G i →+* G j)
 
@@ -1003,7 +1003,7 @@ theorem exists_inv {p : Ring.DirectLimit G f} : p ≠ 0 → ∃ y, p * y = 1 :=
 
 section
 
-open Classical
+open scoped Classical
 
 /-- Noncomputable multiplicative inverse in a direct limit of fields. -/
 noncomputable def inv (p : Ring.DirectLimit G f) : Ring.DirectLimit G f :=

--- a/Mathlib/Algebra/EuclideanDomain/Defs.lean
+++ b/Mathlib/Algebra/EuclideanDomain/Defs.lean
@@ -173,7 +173,7 @@ theorem div_zero (a : R) : a / 0 = 0 :=
 
 section
 
-open Classical
+open scoped Classical
 
 @[elab_as_elim]
 theorem GCD.induction {P : R → R → Prop} (a b : R) (H0 : ∀ x, P 0 x)

--- a/Mathlib/Algebra/Field/IsField.lean
+++ b/Mathlib/Algebra/Field/IsField.lean
@@ -60,7 +60,7 @@ theorem not_isField_of_subsingleton (R : Type u) [Semiring R] [Subsingleton R] :
   h (Subsingleton.elim _ _)
 #align not_is_field_of_subsingleton not_isField_of_subsingleton
 
-open Classical
+open scoped Classical
 
 /-- Transferring from `IsField` to `Semifield`. -/
 noncomputable def IsField.toSemifield {R : Type u} [Semiring R] (h : IsField R) : Semifield R :=

--- a/Mathlib/Algebra/GCDMonoid/Div.lean
+++ b/Mathlib/Algebra/GCDMonoid/Div.lean
@@ -70,7 +70,8 @@ end Int
 
 namespace Polynomial
 
-open Polynomial Classical
+open scoped Classical
+open Polynomial
 
 noncomputable section
 

--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -36,7 +36,7 @@ and require `0⁻¹ = 0`.
 -/
 
 
-open Classical
+open scoped Classical
 
 open Function
 

--- a/Mathlib/Algebra/GroupWithZero/Commute.lean
+++ b/Mathlib/Algebra/GroupWithZero/Commute.lean
@@ -21,7 +21,7 @@ variable [MonoidWithZero M₀]
 
 namespace Ring
 
-open Classical
+open scoped Classical
 
 theorem mul_inverse_rev' {a b : M₀} (h : Commute a b) :
     inverse (a * b) = inverse b * inverse a := by

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -78,7 +78,7 @@ theorem not_isUnit_zero [Nontrivial M₀] : ¬IsUnit (0 : M₀) :=
 
 namespace Ring
 
-open Classical
+open scoped Classical
 
 /-- Introduce a function `inverse` on a monoid with zero `M₀`, which sends `x` to `x⁻¹` if `x` is
 invertible and to `0` otherwise.  This definition is somewhat ad hoc, but one needs a fully (rather
@@ -328,7 +328,7 @@ end CommGroupWithZero
 
 section NoncomputableDefs
 
-open Classical
+open scoped Classical
 
 variable {M : Type*} [Nontrivial M]
 

--- a/Mathlib/Algebra/Homology/ComplexShape.lean
+++ b/Mathlib/Algebra/Homology/ComplexShape.lean
@@ -43,7 +43,7 @@ so `d : X i ⟶ X j` is nonzero only when `i = j + 1`.
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 /-- A `c : ComplexShape ι` describes the shape of a chain complex,
 with chain groups indexed by `ι`.

--- a/Mathlib/Algebra/Homology/Homology.lean
+++ b/Mathlib/Algebra/Homology/Homology.lean
@@ -40,7 +40,8 @@ variable {V : Type u} [Category.{v} V] [HasZeroMorphisms V]
 
 variable {c : ComplexShape ι} (C : HomologicalComplex V c)
 
-open Classical ZeroObject
+open scoped Classical
+open ZeroObject
 
 noncomputable section
 

--- a/Mathlib/Algebra/Homology/Homotopy.lean
+++ b/Mathlib/Algebra/Homology/Homotopy.lean
@@ -18,7 +18,7 @@ We define chain homotopies, and prove that homotopic chain maps induce the same 
 
 universe v u
 
-open Classical
+open scoped Classical
 
 noncomputable section
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory.lean
@@ -22,7 +22,7 @@ set_option autoImplicit true
 
 universe v u
 
-open Classical
+open scoped Classical
 
 noncomputable section
 

--- a/Mathlib/Algebra/Homology/ImageToKernel.lean
+++ b/Mathlib/Algebra/Homology/ImageToKernel.lean
@@ -35,7 +35,7 @@ variable {ι : Type*}
 
 variable {V : Type u} [Category.{v} V] [HasZeroMorphisms V]
 
-open Classical
+open scoped Classical
 
 noncomputable section
 

--- a/Mathlib/Algebra/MonoidAlgebra/Degree.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Degree.lean
@@ -22,7 +22,8 @@ variable {R R' A T B ι : Type*}
 
 namespace AddMonoidAlgebra
 
-open Classical BigOperators
+open scoped Classical
+open BigOperators
 
 /-!
 

--- a/Mathlib/Algebra/Order/CauSeq/Completion.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Completion.lean
@@ -198,7 +198,7 @@ instance Cauchy.commRing : CommRing (Cauchy abv) :=
 
 end
 
-open Classical
+open scoped Classical
 
 section
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine.lean
@@ -480,7 +480,7 @@ section Field
 
 /-! ### Group operation polynomials over a field -/
 
-open Classical
+open scoped Classical
 
 /-- The slope of the line through two affine points $(x_1, y_1)$ and $(x_2, y_2)$ in `W`.
 If $x_1 \ne x_2$, then this line is the secant of `W` through $(x_1, y_1)$ and $(x_2, y_2)$,
@@ -691,7 +691,7 @@ lemma neg_some {x y : R} (h : W.nonsingular x y) : -some h = some (nonsingular_n
 instance : InvolutiveNeg W.Point :=
   ⟨by rintro (_ | _) <;> simp [zero_def]; ring1⟩
 
-open Classical
+open scoped Classical
 
 variable {F : Type u} [Field F] {W : Affine F}
 

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -47,7 +47,7 @@ and Chris Hughes (on an earlier repository).
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 universe u v
 

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Maximal.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Maximal.lean
@@ -28,7 +28,7 @@ natural inclusion into the prime spectrum to avoid API duplication for zero loci
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 universe u v
 

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -74,7 +74,8 @@ noncomputable section
 
 variable {𝕜 E F G : Type*}
 
-open Topology Classical BigOperators NNReal Filter ENNReal
+open scoped Classical
+open Topology BigOperators NNReal Filter ENNReal
 
 open Set Filter Asymptotics
 

--- a/Mathlib/Analysis/Analytic/CPolynomial.lean
+++ b/Mathlib/Analysis/Analytic/CPolynomial.lean
@@ -42,7 +42,8 @@ We develop the basic properties of these notions, notably:
 variable {𝕜 E F G : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   [NormedAddCommGroup F] [NormedSpace 𝕜 F] [NormedAddCommGroup G] [NormedSpace 𝕜 G]
 
-open Topology Classical BigOperators NNReal Filter ENNReal
+open scoped Classical
+open Topology BigOperators NNReal Filter ENNReal
 
 open Set Filter Asymptotics
 

--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -19,7 +19,8 @@ We show that the following are analytic:
 
 noncomputable section
 
-open Topology Classical BigOperators NNReal Filter ENNReal
+open scoped Classical
+open Topology BigOperators NNReal Filter ENNReal
 
 open Set Filter Asymptotics
 

--- a/Mathlib/Analysis/Asymptotics/Asymptotics.lean
+++ b/Mathlib/Analysis/Asymptotics/Asymptotics.lean
@@ -49,7 +49,8 @@ the Fréchet derivative.)
 
 open Filter Set
 
-open Topology BigOperators Classical Filter NNReal
+open scoped Classical
+open Topology BigOperators Filter NNReal
 
 namespace Asymptotics
 

--- a/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
@@ -56,7 +56,8 @@ open Set Function Metric Filter
 
 noncomputable section
 
-open NNReal Classical Topology
+open scoped Classical
+open NNReal Topology
 
 namespace BoxIntegral
 

--- a/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
@@ -31,7 +31,8 @@ rectangular box, additive function
 
 noncomputable section
 
-open Classical BigOperators Function Set
+open scoped Classical
+open BigOperators Function Set
 
 namespace BoxIntegral
 

--- a/Mathlib/Analysis/BoxIntegral/Partition/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Basic.lean
@@ -41,7 +41,8 @@ rectangular box, partition
 
 open Set Finset Function
 
-open Classical NNReal BigOperators
+open scoped Classical
+open NNReal BigOperators
 
 noncomputable section
 

--- a/Mathlib/Analysis/BoxIntegral/Partition/Filter.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Filter.lean
@@ -168,7 +168,8 @@ integral, rectangular box, partition, filter
 
 open Set Function Filter Metric Finset Bool
 
-open Classical Topology Filter NNReal
+open scoped Classical
+open Topology Filter NNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/BoxIntegral/Partition/Split.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Split.lean
@@ -40,7 +40,8 @@ rectangular box, partition, hyperplane
 
 noncomputable section
 
-open Classical BigOperators Filter
+open scoped Classical
+open BigOperators Filter
 
 open Function Set Filter
 

--- a/Mathlib/Analysis/BoxIntegral/Partition/SubboxInduction.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/SubboxInduction.lean
@@ -33,7 +33,8 @@ namespace BoxIntegral
 
 open Set Metric
 
-open Classical Topology
+open scoped Classical
+open Topology
 
 noncomputable section
 

--- a/Mathlib/Analysis/BoxIntegral/Partition/Tagged.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Tagged.lean
@@ -27,7 +27,8 @@ rectangular box, box partition
 
 noncomputable section
 
-open Classical ENNReal NNReal
+open scoped Classical
+open ENNReal NNReal
 
 open Set Function
 

--- a/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
@@ -156,7 +156,8 @@ derivative, differentiability, higher derivative, `C^n`, multilinear, Taylor ser
 
 noncomputable section
 
-open Classical BigOperators NNReal Topology Filter
+open scoped Classical
+open BigOperators NNReal Topology Filter
 
 local notation "∞" => (⊤ : ℕ∞)
 

--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -24,7 +24,8 @@ derivative
 
 universe u v w
 
-open Classical Topology BigOperators Filter ENNReal
+open scoped Classical
+open Topology BigOperators Filter ENNReal
 
 open Filter Asymptotics Set
 

--- a/Mathlib/Analysis/Calculus/Deriv/Comp.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Comp.lean
@@ -32,7 +32,8 @@ derivative, chain rule
 
 universe u v w
 
-open Classical Topology BigOperators Filter ENNReal
+open scoped Classical
+open Topology BigOperators Filter ENNReal
 
 open Filter Asymptotics Set
 

--- a/Mathlib/Analysis/Calculus/Deriv/Inv.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inv.lean
@@ -25,7 +25,8 @@ derivative
 
 universe u v w
 
-open Classical Topology BigOperators Filter ENNReal
+open scoped Classical
+open Topology BigOperators Filter ENNReal
 
 open Filter Asymptotics Set
 

--- a/Mathlib/Analysis/Calculus/Deriv/Inverse.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inverse.lean
@@ -26,7 +26,8 @@ derivative, inverse function
 
 universe u v w
 
-open Classical Topology BigOperators Filter ENNReal
+open scoped Classical
+open Topology BigOperators Filter ENNReal
 
 open Filter Asymptotics Set
 

--- a/Mathlib/Analysis/Calculus/Deriv/Pow.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Pow.lean
@@ -23,7 +23,8 @@ derivative, power
 
 universe u v w
 
-open Classical Topology BigOperators Filter ENNReal
+open scoped Classical
+open Topology BigOperators Filter ENNReal
 
 open Filter Asymptotics Set
 
@@ -119,4 +120,3 @@ theorem deriv_pow'' (hc : DifferentiableAt 𝕜 c x) :
     deriv (fun x => c x ^ n) x = (n : 𝕜) * c x ^ (n - 1) * deriv c x :=
   (hc.hasDerivAt.pow n).deriv
 #align deriv_pow'' deriv_pow''
-

--- a/Mathlib/Analysis/Calculus/Deriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Prod.lean
@@ -24,7 +24,8 @@ derivative
 
 universe u v w
 
-open Classical Topology BigOperators Filter
+open scoped Classical
+open Topology BigOperators Filter
 
 open Filter Asymptotics Set
 
@@ -115,4 +116,3 @@ theorem deriv_pi (h : ∀ i, DifferentiableAt 𝕜 (fun x => φ x i) x) :
 #align deriv_pi deriv_pi
 
 end Pi
-

--- a/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
@@ -23,7 +23,8 @@ derivative, power
 
 universe u v w
 
-open Classical Topology BigOperators Filter
+open scoped Classical
+open Topology BigOperators Filter
 
 open Filter Asymptotics Set
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -25,7 +25,8 @@ This file contains the usual formulas (and existence assertions) for the derivat
 
 open Filter Asymptotics ContinuousLinearMap Set Metric
 
-open Topology Classical NNReal Filter Asymptotics ENNReal
+open scoped Classical
+open Topology NNReal Filter Asymptotics ENNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -117,7 +117,8 @@ derivative, differentiable, Fréchet, calculus
 
 open Filter Asymptotics ContinuousLinearMap Set Metric
 
-open Topology Classical NNReal Filter Asymptotics ENNReal
+open scoped Classical
+open Topology NNReal Filter Asymptotics ENNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Bilinear.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Bilinear.lean
@@ -19,7 +19,8 @@ bounded bilinear maps.
 
 
 open Filter Asymptotics ContinuousLinearMap Set Metric
-open Topology Classical NNReal Asymptotics ENNReal
+open scoped Classical
+open Topology NNReal Asymptotics ENNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Comp.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Comp.lean
@@ -20,7 +20,8 @@ composition of functions (the chain rule).
 
 open Filter Asymptotics ContinuousLinearMap Set Metric
 
-open Topology Classical NNReal Filter Asymptotics ENNReal
+open scoped Classical
+open Topology NNReal Filter Asymptotics ENNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Equiv.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Equiv.lean
@@ -24,7 +24,8 @@ The inverse function theorem is in `Mathlib/Analysis/Calculus/InverseFunctionThe
 
 open Filter Asymptotics ContinuousLinearMap Set Metric
 
-open Topology Classical NNReal Filter Asymptotics ENNReal
+open scoped Classical
+open Topology NNReal Filter Asymptotics ENNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Linear.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Linear.lean
@@ -21,7 +21,8 @@ bounded linear maps.
 
 open Filter Asymptotics ContinuousLinearMap Set Metric
 
-open Topology Classical NNReal Filter Asymptotics ENNReal
+open scoped Classical
+open Topology NNReal Filter Asymptotics ENNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
@@ -21,7 +21,8 @@ This file contains the usual formulas (and existence assertions) for the derivat
 -/
 
 
-open Filter Asymptotics ContinuousLinearMap Set Metric Topology Classical NNReal ENNReal
+open scoped Classical
+open Filter Asymptotics ContinuousLinearMap Set Metric Topology NNReal ENNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -21,7 +21,8 @@ cartesian products of functions, and functions into Pi-types.
 
 open Filter Asymptotics ContinuousLinearMap Set Metric
 
-open Topology Classical NNReal Filter Asymptotics ENNReal
+open scoped Classical
+open Topology NNReal Filter Asymptotics ENNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/Calculus/FDeriv/RestrictScalars.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/RestrictScalars.lean
@@ -20,7 +20,8 @@ the scalar restriction of a linear map.
 
 open Filter Asymptotics ContinuousLinearMap Set Metric
 
-open Topology Classical NNReal Filter Asymptotics ENNReal
+open scoped Classical
+open Topology NNReal Filter Asymptotics ENNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Star.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Star.lean
@@ -22,7 +22,7 @@ star operation; which as should be expected rules out `𝕜 = ℂ`.
 -/
 
 
-open Classical
+open scoped Classical
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [StarRing 𝕜] [TrivialStar 𝕜]
 

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -28,7 +28,8 @@ lemmas unconditional on the sum of the weights being `1`.
 
 open Set Function
 
-open BigOperators Classical Pointwise
+open scoped Classical
+open BigOperators Pointwise
 
 universe u u'
 

--- a/Mathlib/Analysis/Convex/Cone/Basic.lean
+++ b/Mathlib/Analysis/Convex/Cone/Basic.lean
@@ -44,7 +44,8 @@ assert_not_exists Real
 
 open Set LinearMap
 
-open Classical Pointwise
+open scoped Classical
+open Pointwise
 
 variable {𝕜 E F G : Type*}
 

--- a/Mathlib/Analysis/Convex/Cone/InnerDual.lean
+++ b/Mathlib/Analysis/Convex/Cone/InnerDual.lean
@@ -31,7 +31,8 @@ We prove the following theorems:
 
 open Set LinearMap
 
-open Classical Pointwise
+open scoped Classical
+open Pointwise
 
 variable {𝕜 E F G : Type*}
 

--- a/Mathlib/Analysis/Convex/Exposed.lean
+++ b/Mathlib/Analysis/Convex/Exposed.lean
@@ -46,7 +46,8 @@ More not-yet-PRed stuff is available on the branch `sperner_again`.
 -/
 
 
-open Classical Affine BigOperators
+open scoped Classical
+open Affine BigOperators
 
 open Set
 

--- a/Mathlib/Analysis/Convex/Extrema.lean
+++ b/Mathlib/Analysis/Convex/Extrema.lean
@@ -22,7 +22,8 @@ variable {E β : Type*} [AddCommGroup E] [TopologicalSpace E] [Module ℝ E] [To
 
 open Set Filter Function
 
-open Classical Topology
+open scoped Classical
+open Topology
 
 /-- Helper lemma for the more general case: `IsMinOn.of_isLocalMinOn_of_convexOn`.
 -/

--- a/Mathlib/Analysis/Convex/Extreme.lean
+++ b/Mathlib/Analysis/Convex/Extreme.lean
@@ -45,7 +45,8 @@ More not-yet-PRed stuff is available on the mathlib3 branch `sperner_again`.
 
 open Function Set
 
-open Affine Classical
+open scoped Classical
+open Affine
 
 variable {𝕜 E F ι : Type*} {π : ι → Type*}
 

--- a/Mathlib/Analysis/Convex/Function.lean
+++ b/Mathlib/Analysis/Convex/Function.lean
@@ -29,7 +29,8 @@ a convex set.
 -/
 
 
-open LinearMap Set BigOperators Classical Convex Pointwise
+open scoped Classical
+open LinearMap Set BigOperators Convex Pointwise
 
 variable {𝕜 E F α β ι : Type*}
 

--- a/Mathlib/Analysis/Convex/Independent.lean
+++ b/Mathlib/Analysis/Convex/Independent.lean
@@ -42,7 +42,8 @@ independence, convex position
 -/
 
 
-open Affine BigOperators Classical
+open scoped Classical
+open Affine BigOperators
 
 open Finset Function
 

--- a/Mathlib/Analysis/Convex/Jensen.lean
+++ b/Mathlib/Analysis/Convex/Jensen.lean
@@ -35,7 +35,8 @@ As corollaries, we get:
 
 open Finset LinearMap Set
 
-open BigOperators Classical Convex Pointwise
+open scoped Classical
+open BigOperators Convex Pointwise
 
 variable {𝕜 E F β ι : Type*}
 

--- a/Mathlib/Analysis/Hofer.lean
+++ b/Mathlib/Analysis/Hofer.lean
@@ -21,7 +21,8 @@ example of a proof needing to construct a sequence by induction in the middle of
 -/
 
 
-open Classical Topology BigOperators
+open scoped Classical
+open Topology BigOperators
 
 open Filter Finset
 

--- a/Mathlib/Analysis/InnerProductSpace/Dual.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Dual.lean
@@ -39,7 +39,8 @@ dual, Fréchet-Riesz
 
 noncomputable section
 
-open Classical ComplexConjugate
+open scoped Classical
+open ComplexConjugate
 
 universe u v
 

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -92,7 +92,8 @@ less than or equal to the sum of the maximum values of the summands.
 
 universe u v
 
-open Finset Classical BigOperators NNReal ENNReal
+open scoped Classical
+open Finset BigOperators NNReal ENNReal
 
 set_option linter.uppercaseLean3 false
 

--- a/Mathlib/Analysis/MeanInequalitiesPow.lean
+++ b/Mathlib/Analysis/MeanInequalitiesPow.lean
@@ -47,7 +47,8 @@ universe u v
 
 open Finset
 
-open Classical BigOperators NNReal ENNReal
+open scoped Classical
+open BigOperators NNReal ENNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/Normed/Field/InfiniteSum.lean
+++ b/Mathlib/Analysis/Normed/Field/InfiniteSum.lean
@@ -23,7 +23,8 @@ We first establish results about arbitrary index types, `ι` and `ι'`, and then
 
 variable {R : Type*} {ι : Type*} {ι' : Type*} [NormedRing R]
 
-open BigOperators Classical
+open scoped Classical
+open BigOperators
 
 open Finset
 

--- a/Mathlib/Analysis/NormedSpace/Banach.lean
+++ b/Mathlib/Analysis/NormedSpace/Banach.lean
@@ -18,7 +18,8 @@ This file contains the Banach open mapping theorem, i.e., the fact that a biject
 bounded linear map between Banach spaces has a bounded inverse.
 -/
 
-open Function Metric Set Filter Finset Classical Topology BigOperators NNReal
+open scoped Classical
+open Function Metric Set Filter Finset Topology BigOperators NNReal
 
 open LinearMap (range ker)
 

--- a/Mathlib/Analysis/NormedSpace/Dual.lean
+++ b/Mathlib/Analysis/NormedSpace/Dual.lean
@@ -38,7 +38,8 @@ dual
 
 noncomputable section
 
-open Classical Topology Bornology
+open scoped Classical
+open Topology Bornology
 
 universe u v
 

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
@@ -146,7 +146,7 @@ variable {E : Type u} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 
 open ContinuousLinearEquiv Submodule
 
-open Classical
+open scoped Classical
 
 theorem coord_norm' {x : E} (h : x ≠ 0) : ‖(‖x‖ : 𝕜) • coord 𝕜 x h‖ = 1 := by
   rw [norm_smul (x := coord 𝕜 x h), IsROrC.norm_coe_norm, coord_norm,

--- a/Mathlib/Analysis/NormedSpace/ProdLp.lean
+++ b/Mathlib/Analysis/NormedSpace/ProdLp.lean
@@ -138,7 +138,7 @@ section EDist
 
 variable [EDist α] [EDist β]
 
-open Classical in
+open scoped Classical in
 /-- Endowing the space `WithLp p (α × β)` with the `L^p` edistance. We register this instance
 separate from `WithLp.instProdPseudoEMetric` since the latter requires the type class hypothesis
 `[Fact (1 ≤ p)]` in order to prove the triangle inequality.
@@ -210,7 +210,7 @@ section Dist
 
 variable [Dist α] [Dist β]
 
-open Classical in
+open scoped Classical in
 /-- Endowing the space `WithLp p (α × β)` with the `L^p` distance. We register this instance
 separate from `WithLp.instProdPseudoMetricSpace` since the latter requires the type class hypothesis
 `[Fact (1 ≤ p)]` in order to prove the triangle inequality.
@@ -249,7 +249,7 @@ section Norm
 
 variable [Norm α] [Norm β]
 
-open Classical in
+open scoped Classical in
 /-- Endowing the space `WithLp p (α × β)` with the `L^p` norm. We register this instance
 separate from `WithLp.instProdSeminormedAddCommGroup` since the latter requires the type class
 hypothesis `[Fact (1 ≤ p)]` in order to prove the triangle inequality.

--- a/Mathlib/Analysis/NormedSpace/Units.lean
+++ b/Mathlib/Analysis/NormedSpace/Units.lean
@@ -106,7 +106,8 @@ end nonunits
 
 namespace NormedRing
 
-open Classical BigOperators
+open scoped Classical
+open BigOperators
 
 open Asymptotics Filter Metric Finset Ring
 

--- a/Mathlib/Analysis/Seminorm.lean
+++ b/Mathlib/Analysis/Seminorm.lean
@@ -528,7 +528,7 @@ theorem smul_inf [SMul R ℝ] [SMul R ℝ≥0] [IsScalarTower R ℝ≥0 ℝ] (r 
 
 section Classical
 
-open Classical
+open scoped Classical
 
 /-- We define the supremum of an arbitrary subset of `Seminorm 𝕜 E` as follows:
 * if `s` is `BddAbove` *as a set of functions `E → ℝ`* (that is, if `s` is pointwise bounded

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -20,7 +20,8 @@ set_option linter.uppercaseLean3 false
 
 noncomputable section
 
-open Classical Real Topology NNReal ENNReal Filter BigOperators ComplexConjugate Finset Set
+open scoped Classical
+open Real Topology NNReal ENNReal Filter BigOperators ComplexConjugate Finset Set
 
 /-!
 ## Limits at `+∞`

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Complex.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Complex.lean
@@ -13,7 +13,8 @@ import Mathlib.Analysis.SpecialFunctions.Complex.Log
 We construct the power functions `x ^ y`, where `x` and `y` are complex numbers.
 -/
 
-open Classical Real Topology Filter ComplexConjugate Finset Set
+open scoped Classical
+open Real Topology Filter ComplexConjugate Finset Set
 
 namespace Complex
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
@@ -17,7 +17,8 @@ This file contains lemmas about continuity of the power functions on `ℂ`, `ℝ
 
 noncomputable section
 
-open Classical Real Topology NNReal ENNReal Filter BigOperators ComplexConjugate
+open scoped Classical
+open Real Topology NNReal ENNReal Filter BigOperators ComplexConjugate
 
 open Filter Finset Set
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -20,7 +20,8 @@ We also prove basic properties of these functions.
 
 noncomputable section
 
-open Classical Real NNReal ENNReal BigOperators ComplexConjugate
+open scoped Classical
+open Real NNReal ENNReal BigOperators ComplexConjugate
 
 open Finset Function Set
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -18,7 +18,8 @@ We construct the power functions `x ^ y`, where `x` and `y` are real numbers.
 
 noncomputable section
 
-open Classical Real BigOperators ComplexConjugate
+open scoped Classical
+open Real BigOperators ComplexConjugate
 
 open Finset Set
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -44,7 +44,8 @@ sin, cos, tan, angle
 
 noncomputable section
 
-open Classical Topology Filter Set
+open scoped Classical
+open Topology Filter Set
 
 namespace Complex
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean
@@ -20,7 +20,8 @@ Basic inequalities on trigonometric functions.
 
 noncomputable section
 
-open Classical Topology Filter
+open scoped Classical
+open Topology Filter
 
 open Set Filter
 

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -22,9 +22,11 @@ instances of these such as `ℝ`, `ℝ≥0` and `ℝ≥0∞`.
 
 noncomputable section
 
-open Classical Set Function Filter Finset Metric
+open scoped Classical
+open Set Function Filter Finset Metric
 
-open Classical Topology Nat BigOperators uniformity NNReal ENNReal
+open scoped Classical
+open Topology Nat BigOperators uniformity NNReal ENNReal
 
 variable {α : Type*} {β : Type*} {ι : Type*}
 

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -23,9 +23,11 @@ well as such computations in `ℝ` when the natural proof passes through a fact 
 
 noncomputable section
 
-open Classical Set Function Filter Finset Metric Asymptotics
+open scoped Classical
+open Set Function Filter Finset Metric Asymptotics
 
-open Classical Topology Nat BigOperators uniformity NNReal ENNReal
+open scoped Classical
+open Topology Nat BigOperators uniformity NNReal ENNReal
 
 variable {α : Type*} {β : Type*} {ι : Type*}
 

--- a/Mathlib/CategoryTheory/Countable.lean
+++ b/Mathlib/CategoryTheory/Countable.lean
@@ -16,7 +16,7 @@ A category is countable in this sense if it has countably many objects and count
 
 universe w v u
 
-open Classical
+open scoped Classical
 
 noncomputable section
 

--- a/Mathlib/CategoryTheory/FinCategory/AsType.lean
+++ b/Mathlib/CategoryTheory/FinCategory/AsType.lean
@@ -15,7 +15,7 @@ import Mathlib.CategoryTheory.FinCategory.Basic
 
 universe w v u
 
-open Classical
+open scoped Classical
 
 noncomputable section
 

--- a/Mathlib/CategoryTheory/FinCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/FinCategory/Basic.lean
@@ -25,7 +25,7 @@ having to supply instances or delay with non-defeq conflicts between instances.
 
 universe w v u
 
-open Classical
+open scoped Classical
 
 noncomputable section
 

--- a/Mathlib/CategoryTheory/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/FintypeCat.lean
@@ -24,7 +24,7 @@ We prove that `FintypeCat.Skeleton` is a skeleton of `FintypeCat` in `FintypeCat
 -/
 
 
-open Classical
+open scoped Classical
 
 open CategoryTheory
 

--- a/Mathlib/CategoryTheory/Limits/Bicones.lean
+++ b/Mathlib/CategoryTheory/Limits/Bicones.lean
@@ -29,7 +29,7 @@ noncomputable section
 
 open CategoryTheory.Limits
 
-open Classical
+open scoped Classical
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -498,7 +498,7 @@ theorem biproduct.bicone_ι (f : J → C) [HasBiproduct f] (b : J) :
 #align category_theory.limits.biproduct.bicone_ι CategoryTheory.Limits.biproduct.bicone_ι
 
 /-- Note that as this lemma has an `if` in the statement, we include a `DecidableEq` argument.
-This means you may not be able to `simp` using this lemma unless you `open Classical`. -/
+This means you may not be able to `simp` using this lemma unless you `open scoped Classical`. -/
 @[reassoc]
 theorem biproduct.ι_π [DecidableEq J] (f : J → C) [HasBiproduct f] (j j' : J) :
     biproduct.ι f j ≫ biproduct.π f j' = if h : j = j' then eqToHom (congr_arg f h) else 0 := by

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -54,7 +54,7 @@ open CategoryTheory
 
 open CategoryTheory.Functor
 
-open Classical
+open scoped Classical
 
 namespace CategoryTheory
 
@@ -916,7 +916,7 @@ end
 
 section
 
-open Classical
+open scoped Classical
 
 -- Per leanprover-community/mathlib#15067, we only allow indexing in `Type 0` here.
 variable {K : Type} [Finite K] [HasFiniteBiproducts C] (f : K → C)

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
@@ -19,7 +19,7 @@ universe w v u
 
 open CategoryTheory
 
-open Classical
+open scoped Classical
 
 namespace CategoryTheory.Limits
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
@@ -38,7 +38,7 @@ open CategoryTheory
 
 open CategoryTheory.Category
 
-open Classical
+open scoped Classical
 
 namespace CategoryTheory.Limits
 

--- a/Mathlib/CategoryTheory/Monoidal/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Preadditive.lean
@@ -17,7 +17,7 @@ is linear in both factors.
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
@@ -65,7 +65,7 @@ open CategoryTheory.Functor
 
 open CategoryTheory.Preadditive
 
-open Classical
+open scoped Classical
 
 open BigOperators
 

--- a/Mathlib/CategoryTheory/Preadditive/HomOrthogonal.lean
+++ b/Mathlib/CategoryTheory/Preadditive/HomOrthogonal.lean
@@ -38,7 +38,8 @@ This is preliminary to defining semisimple categories.
 -/
 
 
-open Classical Matrix CategoryTheory.Limits
+open scoped Classical
+open Matrix CategoryTheory.Limits
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Sites/Canonical.lean
+++ b/Mathlib/CategoryTheory/Sites/Canonical.lean
@@ -38,7 +38,8 @@ universe v u
 
 namespace CategoryTheory
 
-open CategoryTheory Category Limits Sieve Classical
+open scoped Classical
+open CategoryTheory Category Limits Sieve
 
 variable {C : Type u} [Category.{v} C]
 

--- a/Mathlib/Combinatorics/HalesJewett.lean
+++ b/Mathlib/Combinatorics/HalesJewett.lean
@@ -60,7 +60,7 @@ combinatorial line, Ramsey theory, arithmetic progression
 -/
 
 
-open Classical
+open scoped Classical
 
 open BigOperators
 

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
@@ -109,7 +109,7 @@ theorem not_isUniform_iff :
   simp only [not_forall, not_lt, exists_prop, exists_and_left, Rat.cast_abs, Rat.cast_sub]
 #align simple_graph.not_is_uniform_iff SimpleGraph.not_isUniform_iff
 
-open Classical
+open scoped Classical
 
 variable (G)
 
@@ -197,7 +197,7 @@ variable [DecidableEq α] {A : Finset α} (P : Finpartition A) (G : SimpleGraph 
 
 namespace Finpartition
 
-open Classical
+open scoped Classical
 
 /-- The pairs of parts of a partition `P` which are not `ε`-uniform in a graph `G`. Note that we
 dismiss the diagonal. We do not care whether `s` is `ε`-uniform with itself. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
@@ -32,7 +32,7 @@ This module defines and proves properties about triangles in simple graphs.
 
 open Finset Fintype Nat
 
-open Classical
+open scoped Classical
 
 namespace SimpleGraph
 

--- a/Mathlib/Computability/TuringMachine.lean
+++ b/Mathlib/Computability/TuringMachine.lean
@@ -1304,7 +1304,7 @@ def SupportsStmt (S : Finset Λ) : Stmt₁ → Prop
   | halt => True
 #align turing.TM1.supports_stmt Turing.TM1.SupportsStmt
 
-open Classical
+open scoped Classical
 
 /-- The subterm closure of a statement. -/
 noncomputable def stmts₁ : Stmt₁ → Finset Stmt₁
@@ -1528,7 +1528,7 @@ noncomputable def trStmts (S : Finset Λ) : Finset Λ'₁₀ :=
   (TM1.stmts M S) ×ˢ Finset.univ
 #align turing.TM1to0.tr_stmts Turing.TM1to0.trStmts
 
-open Classical
+open scoped Classical
 
 attribute [local simp] TM1.stmts₁_self
 
@@ -1888,7 +1888,7 @@ theorem tr_respects {enc₀} :
       apply ReflTransGen.refl
 #align turing.TM1to1.tr_respects Turing.TM1to1.tr_respects
 
-open Classical
+open scoped Classical
 
 variable [Fintype Γ]
 
@@ -2172,7 +2172,7 @@ def SupportsStmt (S : Finset Λ) : Stmt₂ → Prop
   | halt => True
 #align turing.TM2.supports_stmt Turing.TM2.SupportsStmt
 
-open Classical
+open scoped Classical
 
 /-- The set of subtree statements in a statement. -/
 noncomputable def stmts₁ : Stmt₂ → Finset Stmt₂
@@ -2529,7 +2529,7 @@ theorem trNormal_run {k : K} (s : StAct₂ k) (q : Stmt₂) :
   cases s <;> rfl
 #align turing.TM2to1.tr_normal_run Turing.TM2to1.trNormal_run
 
-open Classical
+open scoped Classical
 
 /-- The set of machine states accessible from an initial TM2 statement. -/
 noncomputable def trStmts₁ : Stmt₂ → Finset Λ'₂₁

--- a/Mathlib/Control/Fix.lean
+++ b/Mathlib/Control/Fix.lean
@@ -26,7 +26,7 @@ An instance is defined for `Part`.
 
 universe u v
 
-open Classical
+open scoped Classical
 
 variable {α : Type*} {β : α → Type*}
 

--- a/Mathlib/Control/LawfulFix.lean
+++ b/Mathlib/Control/LawfulFix.lean
@@ -24,7 +24,7 @@ omega complete partial orders (ωCPO). Proofs of the lawfulness of all `Fix` ins
 
 universe u v
 
-open Classical
+open scoped Classical
 
 variable {α : Type*} {β : α → Type*}
 

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -566,7 +566,7 @@ theorem cons_eq_zero_iff {v : Fin n → α} {x : α} : vecCons x v = 0 ↔ x = 0
     fun ⟨hx, hv⟩ => by simp [hx, hv]⟩
 #align matrix.cons_eq_zero_iff Matrix.cons_eq_zero_iff
 
-open Classical
+open scoped Classical
 
 theorem cons_nonzero_iff {v : Fin n → α} {x : α} : vecCons x v ≠ 0 ↔ x ≠ 0 ∨ v ≠ 0 :=
   ⟨fun h => not_and_or.mp (h ∘ cons_eq_zero_iff.mpr), fun h =>

--- a/Mathlib/Data/Finite/Basic.lean
+++ b/Mathlib/Data/Finite/Basic.lean
@@ -45,7 +45,7 @@ finiteness, finite types
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 variable {α β γ : Type*}
 

--- a/Mathlib/Data/Finite/Basic.lean
+++ b/Mathlib/Data/Finite/Basic.lean
@@ -33,7 +33,7 @@ instances or other `Fintype` instances, then we need to "lower" the instance
 to be a `Finite` instance by removing the `Decidable` instances and switching
 the `Fintype` instances to `Finite` instances. These are precisely the ones
 that cannot be inferred using `Finite.of_fintype`. (However, when using
-`open Classical` or the `classical` tactic the instances relying only
+`open scoped Classical` or the `classical` tactic the instances relying only
 on `Decidable` instances will give `Finite` instances.) In the future we might
 consider writing automation to create these "lowered" instances.
 

--- a/Mathlib/Data/Finite/Card.lean
+++ b/Mathlib/Data/Finite/Card.lean
@@ -30,7 +30,7 @@ it. We generally put such theorems into the `SetTheory.Cardinal.Finite` module.
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 variable {α β γ : Type*}
 

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -3034,7 +3034,7 @@ theorem subset_union_elim {s : Finset α} {t₁ t₂ : Set α} (h : ↑s ⊆ t�
 
 section Classical
 
-open Classical
+open scoped Classical
 
 -- Porting note: The notation `{ x ∈ s | p x }` in Lean 4 is hardcoded to be about `Set`.
 -- So at the moment the whole `Sep`-class is useless, as it doesn't have notation.

--- a/Mathlib/Data/Finset/Finsupp.lean
+++ b/Mathlib/Data/Finset/Finsupp.lean
@@ -33,7 +33,8 @@ noncomputable section
 
 open Finsupp
 
-open BigOperators Classical Pointwise
+open scoped Classical
+open BigOperators Pointwise
 
 variable {ι α : Type*} [Zero α] {s : Finset ι} {f : ι →₀ α}
 

--- a/Mathlib/Data/Finset/Functor.lean
+++ b/Mathlib/Data/Finset/Functor.lean
@@ -202,7 +202,7 @@ theorem id_traverse [DecidableEq α] (s : Finset α) : traverse (pure : α → I
   exact s.val_toFinset
 #align finset.id_traverse Finset.id_traverse
 
-open Classical
+open scoped Classical
 
 @[simp]
 theorem map_comp_coe (h : α → β) :

--- a/Mathlib/Data/Finsupp/Interval.lean
+++ b/Mathlib/Data/Finsupp/Interval.lean
@@ -64,7 +64,7 @@ variable [Zero α] [PartialOrder α] [LocallyFiniteOrder α] {f g : ι →₀ α
 def rangeIcc (f g : ι →₀ α) : ι →₀ Finset α where
   toFun i := Icc (f i) (g i)
   support :=
-    -- Porting note: Not needed (due to open Classical), in mathlib3 too
+    -- Porting note: Not needed (due to open scoped Classical), in mathlib3 too
     -- haveI := Classical.decEq ι
     f.support ∪ g.support
   mem_support_toFun i := by
@@ -90,7 +90,7 @@ section PartialOrder
 variable [PartialOrder α] [Zero α] [LocallyFiniteOrder α] (f g : ι →₀ α)
 
 instance instLocallyFiniteOrder : LocallyFiniteOrder (ι →₀ α) :=
-  -- Porting note: Not needed (due to open Classical), in mathlib3 too
+  -- Porting note: Not needed (due to open scoped Classical), in mathlib3 too
   -- haveI := Classical.decEq ι
   -- haveI := Classical.decEq α
   LocallyFiniteOrder.ofIcc (ι →₀ α) (fun f g => (f.support ∪ g.support).finsupp <| f.rangeIcc g)

--- a/Mathlib/Data/Finsupp/Interval.lean
+++ b/Mathlib/Data/Finsupp/Interval.lean
@@ -29,7 +29,8 @@ noncomputable section
 
 open Finset Finsupp Function
 
-open BigOperators Classical Pointwise
+open scoped Classical
+open BigOperators Pointwise
 
 variable {ι α : Type*}
 

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -980,7 +980,7 @@ noncomputable def fintypeOfNotInfinite {α : Type*} (h : ¬Infinite α) : Fintyp
 
 section
 
-open Classical
+open scoped Classical
 
 /-- Any type is (classically) either a `Fintype`, or `Infinite`.
 

--- a/Mathlib/Data/Fintype/Order.lean
+++ b/Mathlib/Data/Fintype/Order.lean
@@ -84,7 +84,7 @@ section BoundedOrder
 
 variable (α)
 
-open Classical
+open scoped Classical
 
 -- See note [reducible non-instances]
 /-- A finite bounded lattice is complete. -/

--- a/Mathlib/Data/Fintype/Prod.lean
+++ b/Mathlib/Data/Fintype/Prod.lean
@@ -63,7 +63,7 @@ theorem Fintype.card_prod (α β : Type*) [Fintype α] [Fintype β] :
 
 section
 
-open Classical
+open scoped Classical
 
 @[simp]
 theorem infinite_prod : Infinite (α × β) ↔ Infinite α ∧ Nonempty β ∨ Nonempty α ∧ Infinite β := by

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -133,7 +133,7 @@ theorem Fintype.card_subtype_or_disjoint (p q : α → Prop) (h : Disjoint p q) 
 
 section
 
-open Classical
+open scoped Classical
 
 @[simp]
 theorem infinite_sum : Infinite (Sum α β) ↔ Infinite α ∨ Infinite β := by

--- a/Mathlib/Data/Int/ConditionallyCompleteOrder.lean
+++ b/Mathlib/Data/Int/ConditionallyCompleteOrder.lean
@@ -19,7 +19,7 @@ open Int
 
 
 noncomputable section
-open Classical
+open scoped Classical
 
 instance : ConditionallyCompleteLinearOrder ℤ :=
   { Int.linearOrderedCommRing,

--- a/Mathlib/Data/IsROrC/Lemmas.lean
+++ b/Mathlib/Data/IsROrC/Lemmas.lean
@@ -26,7 +26,7 @@ end Polynomial
 
 namespace FiniteDimensional
 
-open Classical
+open scoped Classical
 
 open IsROrC
 

--- a/Mathlib/Data/MvPolynomial/Rename.lean
+++ b/Mathlib/Data/MvPolynomial/Rename.lean
@@ -124,7 +124,7 @@ section
 
 variable {f : σ → τ} (hf : Function.Injective f)
 
-open Classical
+open scoped Classical
 
 /-- Given a function between sets of variables `f : σ → τ` that is injective with proof `hf`,
   `MvPolynomial.killCompl hf` is the `AlgHom` from `R[τ]` to `R[σ]` that is left inverse to

--- a/Mathlib/Data/Nat/Lattice.lean
+++ b/Mathlib/Data/Nat/Lattice.lean
@@ -22,7 +22,7 @@ open Set
 
 namespace Nat
 
-open Classical
+open scoped Classical
 
 noncomputable instance : InfSet ℕ :=
   ⟨fun s ↦ if h : ∃ n, n ∈ s then @Nat.find (fun n ↦ n ∈ s) _ h else 0⟩

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -704,7 +704,7 @@ theorem toWithTop_ofENat (n : ℕ∞) {_ : Decidable (n : PartENat).Dom} : toWit
 
 section WithTopEquiv
 
-open Classical
+open scoped Classical
 
 @[simp]
 theorem toWithTop_add {x y : PartENat} : toWithTop (x + y) = toWithTop x + toWithTop y := by

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -41,7 +41,7 @@ with `+` and `≤`.
 clear what `0 * ⊤` should be. `mul` is hence left undefined. Similarly `⊤ - ⊤` is ambiguous
 so there is no `-` defined on `PartENat`.
 
-Before the `open Classical` line, various proofs are made with decidability assumptions.
+Before the `open scoped Classical` line, various proofs are made with decidability assumptions.
 This can cause issues -- see for example the non-simp lemma `toWithTopZero` proved by `rfl`,
 followed by `@[simp] lemma toWithTopZero'` whose proof uses `convert`.
 

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -403,7 +403,7 @@ theorem orElse_eq_none' (o o' : Option α) : o.orElse (fun _ ↦ o') = none ↔ 
 
 section
 
-open Classical
+open scoped Classical
 
 theorem choice_eq_none (α : Type*) [IsEmpty α] : choice α = none :=
   dif_neg (not_nonempty_iff_imp_false.mpr isEmptyElim)

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -487,7 +487,7 @@ theorem mem_core_res (f : α → β) (s : Set α) (t : Set β) (x : α) :
 
 section
 
-open Classical
+open scoped Classical
 
 theorem core_res (f : α → β) (s : Set α) (t : Set β) : (res f s).core t = sᶜ ∪ f ⁻¹' t := by
   ext x

--- a/Mathlib/Data/Real/Archimedean.lean
+++ b/Mathlib/Data/Real/Archimedean.lean
@@ -15,7 +15,8 @@ import Mathlib.Algebra.Bounds
 
 -/
 
-open Pointwise CauSeq Classical
+open scoped Classical
+open Pointwise CauSeq
 
 namespace Real
 

--- a/Mathlib/Data/Real/Basic.lean
+++ b/Mathlib/Data/Real/Basic.lean
@@ -549,7 +549,7 @@ instance : SemilatticeInf ℝ :=
 instance : SemilatticeSup ℝ :=
   inferInstance
 
-open Classical
+open scoped Classical
 
 instance : IsTotal ℝ (· ≤ ·) :=
   ⟨by

--- a/Mathlib/Data/Real/ENatENNReal.lean
+++ b/Mathlib/Data/Real/ENatENNReal.lean
@@ -15,7 +15,8 @@ In this file we define a coercion from `ℕ∞` to `ℝ≥0∞` and prove some b
 -/
 
 
-open Classical NNReal ENNReal
+open scoped Classical
+open NNReal ENNReal
 
 noncomputable section
 

--- a/Mathlib/Data/Real/Hyperreal.lean
+++ b/Mathlib/Data/Real/Hyperreal.lean
@@ -13,7 +13,8 @@ import Mathlib.Analysis.SpecificLimits.Basic
 -/
 
 
-open Filter Germ Topology Classical
+open scoped Classical
+open Filter Germ Topology
 
 /-- Hyperreal numbers on the ultrafilter extending the cofinite filter -/
 def Hyperreal : Type :=

--- a/Mathlib/Data/Set/BoolIndicator.lean
+++ b/Mathlib/Data/Set/BoolIndicator.lean
@@ -42,7 +42,7 @@ theorem preimage_boolIndicator_false : s.boolIndicator ⁻¹' {false} = sᶜ :=
   ext fun x ↦ (s.not_mem_iff_boolIndicator x).symm
 #align set.preimage_bool_indicator_false Set.preimage_boolIndicator_false
 
-open Classical
+open scoped Classical
 
 theorem preimage_boolIndicator_eq_union (t : Set Bool) :
     s.boolIndicator ⁻¹' t = (if true ∈ t then s else ∅) ∪ if false ∈ t then sᶜ else ∅ := by

--- a/Mathlib/Data/Set/Countable.lean
+++ b/Mathlib/Data/Set/Countable.lean
@@ -26,7 +26,8 @@ sets, countable set
 
 noncomputable section
 
-open Function Set Encodable Classical
+open scoped Classical
+open Function Set Encodable
 
 universe u v w x
 

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -589,7 +589,7 @@ Some set instances do not appear here since they are consequences of others, for
 
 namespace Finite.Set
 
-open Classical
+open scoped Classical
 
 example {s : Set α} [Finite α] : Finite s :=
   inferInstance

--- a/Mathlib/Data/Set/Intervals/Basic.lean
+++ b/Mathlib/Data/Set/Intervals/Basic.lean
@@ -1189,7 +1189,7 @@ lemma Ici_eq_singleton_iff_isTop {x : α} : (Ici x = {x}) ↔ IsTop x := by
   rw [h, mem_singleton_iff] at this
   exact lt_irrefl y (this.le.trans_lt H)
 
-open Classical
+open scoped Classical
 
 @[simp]
 theorem Ioi_subset_Ioi_iff : Ioi b ⊆ Ioi a ↔ a ≤ b := by

--- a/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
+++ b/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
@@ -119,7 +119,8 @@ circle homeomorphism, rotation number
 -/
 
 
-open Filter Set Int Topology Classical
+open scoped Classical
+open Filter Set Int Topology
 open Function hiding Commute
 
 /-!

--- a/Mathlib/Dynamics/Ergodic/Conservative.lean
+++ b/Mathlib/Dynamics/Ergodic/Conservative.lean
@@ -40,9 +40,11 @@ conservative dynamical system, Poincare recurrence theorem
 
 noncomputable section
 
-open Classical Set Filter MeasureTheory Finset Function TopologicalSpace
+open scoped Classical
+open Set Filter MeasureTheory Finset Function TopologicalSpace
 
-open Classical Topology
+open scoped Classical
+open Topology
 
 variable {ι : Type*} {α : Type*} [MeasurableSpace α] {f : α → α} {s : Set α} {μ : Measure α}
 

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -265,7 +265,7 @@ theorem Semiconj.mapsTo_periodicPts {g : α → β} (h : Semiconj g fa fb) :
     MapsTo g (periodicPts fa) (periodicPts fb) := fun _ ⟨n, hn, hx⟩ => ⟨n, hn, hx.map h⟩
 #align function.semiconj.maps_to_periodic_pts Function.Semiconj.mapsTo_periodicPts
 
-open Classical
+open scoped Classical
 
 noncomputable section
 

--- a/Mathlib/FieldTheory/Finiteness.lean
+++ b/Mathlib/FieldTheory/Finiteness.lean
@@ -17,7 +17,8 @@ import Mathlib.LinearAlgebra.Dimension.Finite
 
 universe u v
 
-open Classical Cardinal
+open scoped Classical
+open Cardinal
 
 open Cardinal Submodule Module Function
 

--- a/Mathlib/FieldTheory/Minpoly/Basic.lean
+++ b/Mathlib/FieldTheory/Minpoly/Basic.lean
@@ -17,7 +17,8 @@ such as irreducibility under the assumption `B` is a domain.
 -/
 
 
-open Classical Polynomial Set Function
+open scoped Classical
+open Polynomial Set Function
 
 variable {A B B' : Type*}
 

--- a/Mathlib/FieldTheory/Minpoly/Field.lean
+++ b/Mathlib/FieldTheory/Minpoly/Field.lean
@@ -19,7 +19,8 @@ are irreducible, and uniquely determined by their defining property.
 -/
 
 
-open Classical Polynomial Set Function minpoly
+open scoped Classical
+open Polynomial Set Function minpoly
 
 namespace minpoly
 

--- a/Mathlib/FieldTheory/MvPolynomial.lean
+++ b/Mathlib/FieldTheory/MvPolynomial.lean
@@ -20,7 +20,7 @@ finitely supported functions from the indexing set to `ℕ`.
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 open Set LinearMap Submodule
 
@@ -52,7 +52,7 @@ universe u
 
 variable {σ : Type u} {K : Type u} [Field K]
 
-open Classical
+open scoped Classical
 
 theorem rank_mvPolynomial : Module.rank K (MvPolynomial σ K) = Cardinal.mk (σ →₀ ℕ) := by
   rw [← Cardinal.lift_inj, ← (basisMonomials σ K).mk_eq_rank]

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -27,7 +27,8 @@ properties about separable polynomials here.
 
 universe u v w
 
-open Classical BigOperators Polynomial Finset
+open scoped Classical
+open BigOperators Polynomial Finset
 
 namespace Polynomial
 

--- a/Mathlib/Geometry/Euclidean/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Basic.lean
@@ -51,7 +51,7 @@ noncomputable section
 
 open BigOperators
 
-open Classical
+open scoped Classical
 
 open RealInnerProductSpace
 

--- a/Mathlib/Geometry/Euclidean/Circumcenter.lean
+++ b/Mathlib/Geometry/Euclidean/Circumcenter.lean
@@ -34,7 +34,7 @@ noncomputable section
 
 open BigOperators
 
-open Classical
+open scoped Classical
 
 open RealInnerProductSpace
 

--- a/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
+++ b/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
@@ -47,7 +47,8 @@ in the one for `LiftPropWithinAt`.
 
 noncomputable section
 
-open Classical Manifold Topology
+open scoped Classical
+open Manifold Topology
 
 open Set Filter TopologicalSpace
 

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -30,7 +30,7 @@ set_option autoImplicit true
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 open BigOperators
 

--- a/Mathlib/GroupTheory/Exponent.lean
+++ b/Mathlib/GroupTheory/Exponent.lean
@@ -50,7 +50,7 @@ universe u
 
 variable {G : Type u}
 
-open Classical
+open scoped Classical
 
 namespace Monoid
 

--- a/Mathlib/GroupTheory/FreeAbelianGroup.lean
+++ b/Mathlib/GroupTheory/FreeAbelianGroup.lean
@@ -139,7 +139,7 @@ end lift
 
 section
 
-open Classical
+open scoped Classical
 
 theorem of_injective : Function.Injective (of : α → FreeAbelianGroup α) :=
   fun x y hoxy ↦ Classical.by_contradiction fun hxy : x ≠ y ↦

--- a/Mathlib/GroupTheory/FreeAbelianGroupFinsupp.lean
+++ b/Mathlib/GroupTheory/FreeAbelianGroupFinsupp.lean
@@ -188,7 +188,7 @@ theorem support_nsmul (k : ℕ) (h : k ≠ 0) (a : FreeAbelianGroup X) :
   exact mod_cast h
 #align free_abelian_group.support_nsmul FreeAbelianGroup.support_nsmul
 
-open Classical
+open scoped Classical
 
 theorem support_add (a b : FreeAbelianGroup X) : support (a + b) ⊆ a.support ∪ b.support := by
   simp only [support, AddMonoidHom.map_add]

--- a/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
+++ b/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
@@ -52,7 +52,7 @@ free group, free groupoid, Nielsen-Schreier
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 universe v u
 

--- a/Mathlib/GroupTheory/Perm/ViaEmbedding.lean
+++ b/Mathlib/GroupTheory/Perm/ViaEmbedding.lean
@@ -21,7 +21,7 @@ namespace Perm
 
 variable (e : Perm α) (ι : α ↪ β)
 
-open Classical
+open scoped Classical
 
 /-- Noncomputable version of `Equiv.Perm.viaFintypeEmbedding` that does not assume `Fintype` -/
 noncomputable def viaEmbedding : Perm β :=

--- a/Mathlib/GroupTheory/QuotientGroup.lean
+++ b/Mathlib/GroupTheory/QuotientGroup.lean
@@ -726,7 +726,7 @@ end QuotientGroup
 
 namespace Group
 
-open Classical
+open scoped Classical
 
 open QuotientGroup Subgroup
 

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -282,7 +282,7 @@ open Finset Nat
 
 section Classical
 
-open Classical
+open scoped Classical
 
 @[to_additive IsAddCyclic.card_nsmul_eq_zero_le]
 theorem IsCyclic.card_pow_eq_one_le [DecidableEq α] [Fintype α] [IsCyclic α] {n : ℕ} (hn0 : 0 < n) :

--- a/Mathlib/GroupTheory/Subgroup/Basic.lean
+++ b/Mathlib/GroupTheory/Subgroup/Basic.lean
@@ -2225,7 +2225,7 @@ theorem center_le_normalizer : center G ≤ H.normalizer := fun x hx y => by
 #align subgroup.center_le_normalizer Subgroup.center_le_normalizer
 #align add_subgroup.center_le_normalizer AddSubgroup.center_le_normalizer
 
-open Classical
+open scoped Classical
 
 @[to_additive]
 theorem le_normalizer_of_normal [hK : (H.subgroupOf K).Normal] (HK : H ≤ K) : K ≤ H.normalizer :=

--- a/Mathlib/LinearAlgebra/LinearPMap.lean
+++ b/Mathlib/LinearAlgebra/LinearPMap.lean
@@ -1010,7 +1010,7 @@ noncomputable def toLinearPMapAux (g : Submodule R (E × F))
     rw [Prod.smul_mk] at hav'
     exact (existsUnique_from_graph @hg hsmul).unique hav hav'
 
-open Classical in
+open scoped Classical in
 /-- Define a `LinearPMap` from its graph.
 
 In the case that the submodule is not a graph of a `LinearPMap` then the underlying linear map

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -317,7 +317,7 @@ def center_equiv_rootsOfUnity' (i : n) :
     rw [← scalar_eq_coe_self_center A i, ← scalar_eq_coe_self_center B i]
     simp
 
-open Classical in
+open scoped Classical in
 /-- An equivalence of groups, from the center of the special linear group to the roots of unity.
 
 See also `center_equiv_rootsOfUnity'`. -/

--- a/Mathlib/LinearAlgebra/Trace.lean
+++ b/Mathlib/LinearAlgebra/Trace.lean
@@ -73,7 +73,7 @@ theorem traceAux_eq : traceAux R b = traceAux R c :=
       _ = Matrix.trace (LinearMap.toMatrix c c f) := by rw [LinearMap.comp_id, LinearMap.comp_id]
 #align linear_map.trace_aux_eq LinearMap.traceAux_eq
 
-open Classical
+open scoped Classical
 
 variable (M)
 

--- a/Mathlib/Logic/Denumerable.lean
+++ b/Mathlib/Logic/Denumerable.lean
@@ -216,7 +216,7 @@ variable {s : Set ℕ} [Infinite s]
 
 section Classical
 
-open Classical
+open scoped Classical
 
 theorem exists_succ (x : s) : ∃ n, (x : ℕ) + n + 1 ∈ s :=
   _root_.by_contradiction fun h =>

--- a/Mathlib/Logic/Nontrivial/Basic.lean
+++ b/Mathlib/Logic/Nontrivial/Basic.lean
@@ -22,7 +22,7 @@ Results about `Nontrivial`.
 
 variable {α : Type*} {β : Type*}
 
-open Classical
+open scoped Classical
 
 -- `x` and `y` are explicit here, as they are often needed to guide typechecking of `h`.
 theorem nontrivial_of_lt [Preorder α] (x y : α) (h : x < y) : Nontrivial α :=

--- a/Mathlib/Logic/Nontrivial/Defs.lean
+++ b/Mathlib/Logic/Nontrivial/Defs.lean
@@ -81,7 +81,7 @@ theorem subsingleton_iff : Subsingleton α ↔ ∀ x y : α, x = y :=
 #align subsingleton_iff subsingleton_iff
 
 theorem not_nontrivial_iff_subsingleton : ¬Nontrivial α ↔ Subsingleton α := by
-  simp only [nontrivial_iff, subsingleton_iff, not_exists, Ne.def, not_not]
+  simp only [nontrivial_iff, subsingleton_iff, not_exists, Ne.def, Classical.not_not]
 #align not_nontrivial_iff_subsingleton not_nontrivial_iff_subsingleton
 
 theorem not_nontrivial (α) [Subsingleton α] : ¬Nontrivial α :=
@@ -93,7 +93,7 @@ theorem not_subsingleton (α) [Nontrivial α] : ¬Subsingleton α :=
 #align not_subsingleton not_subsingleton
 
 lemma not_subsingleton_iff_nontrivial : ¬ Subsingleton α ↔ Nontrivial α := by
-  rw [← not_nontrivial_iff_subsingleton, not_not]
+  rw [← not_nontrivial_iff_subsingleton, Classical.not_not]
 
 /-- A type is either a subsingleton or nontrivial. -/
 theorem subsingleton_or_nontrivial (α : Type*) : Subsingleton α ∨ Nontrivial α := by

--- a/Mathlib/Logic/Nontrivial/Defs.lean
+++ b/Mathlib/Logic/Nontrivial/Defs.lean
@@ -24,7 +24,7 @@ Basic results about nontrivial types are in `Mathlib.Logic.Nontrivial.Basic`.
 
 variable {α : Type*} {β : Type*}
 
-open Classical
+open scoped Classical
 
 /-- Predicate typeclass for expressing that a type is not reduced to a single element. In rings,
 this is equivalent to `0 ≠ 1`. In vector spaces, this is equivalent to positive dimension. -/

--- a/Mathlib/Logic/Small/Basic.lean
+++ b/Mathlib/Logic/Small/Basic.lean
@@ -21,7 +21,7 @@ universe u w v v'
 
 section
 
-open Classical
+open scoped Classical
 
 instance small_subtype (α : Type v) [Small.{w} α] (P : α → Prop) : Small.{w} { x // P x } :=
   small_map (equivShrink α).subtypeEquivOfSubtype'

--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -103,7 +103,7 @@ theorem small_type : Small.{max (u + 1) v} (Type u) :=
 
 section
 
-open Classical
+open scoped Classical
 
 theorem small_congr {α : Type*} {β : Type*} (e : α ≃ β) : Small.{w} α ↔ Small.{w} β :=
   ⟨fun h => @small_map _ _ h e.symm, fun h => @small_map _ _ h e⟩

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Metrizable.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Metrizable.lean
@@ -15,7 +15,8 @@ import Mathlib.Topology.IndicatorConstPointwise
 
 open Filter MeasureTheory TopologicalSpace
 
-open Classical Topology NNReal ENNReal MeasureTheory
+open scoped Classical
+open Topology NNReal ENNReal MeasureTheory
 
 variable {α β : Type*} [MeasurableSpace α]
 

--- a/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
@@ -56,7 +56,8 @@ product measure, Tonelli's theorem, Fubini-Tonelli theorem
 
 noncomputable section
 
-open Classical Topology ENNReal MeasureTheory
+open scoped Classical
+open Topology ENNReal MeasureTheory
 
 open Set Function Real ENNReal
 

--- a/Mathlib/MeasureTheory/Covering/Vitali.lean
+++ b/Mathlib/MeasureTheory/Covering/Vitali.lean
@@ -40,7 +40,8 @@ variable {α ι : Type*}
 
 open Set Metric MeasureTheory TopologicalSpace Filter
 
-open NNReal Classical ENNReal Topology
+open scoped Classical
+open NNReal ENNReal Topology
 
 namespace Vitali
 

--- a/Mathlib/MeasureTheory/Decomposition/Jordan.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Jordan.lean
@@ -217,7 +217,8 @@ end JordanDecomposition
 
 namespace SignedMeasure
 
-open Classical JordanDecomposition Measure Set VectorMeasure
+open scoped Classical
+open JordanDecomposition Measure Set VectorMeasure
 
 variable {s : SignedMeasure α} {μ ν : Measure α} [IsFiniteMeasure μ] [IsFiniteMeasure ν]
 

--- a/Mathlib/MeasureTheory/Decomposition/Jordan.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Jordan.lean
@@ -227,8 +227,8 @@ such that `s = j.toSignedMeasure`. This property is known as the Jordan decompos
 theorem, and is shown by
 `MeasureTheory.SignedMeasure.toSignedMeasure_toJordanDecomposition`. -/
 def toJordanDecomposition (s : SignedMeasure α) : JordanDecomposition α :=
-  let i := choose s.exists_compl_positive_negative
-  let hi := choose_spec s.exists_compl_positive_negative
+  let i := s.exists_compl_positive_negative.choose
+  let hi := s.exists_compl_positive_negative.choose_spec
   { posPart := s.toMeasureOfZeroLE i hi.1 hi.2.1
     negPart := s.toMeasureOfLEZero iᶜ hi.1.compl hi.2.2
     posPart_finite := inferInstance
@@ -244,8 +244,8 @@ theorem toJordanDecomposition_spec (s : SignedMeasure α) :
     ∃ (i : Set α) (hi₁ : MeasurableSet i) (hi₂ : 0 ≤[i] s) (hi₃ : s ≤[iᶜ] 0),
       s.toJordanDecomposition.posPart = s.toMeasureOfZeroLE i hi₁ hi₂ ∧
         s.toJordanDecomposition.negPart = s.toMeasureOfLEZero iᶜ hi₁.compl hi₃ := by
-  set i := choose s.exists_compl_positive_negative
-  obtain ⟨hi₁, hi₂, hi₃⟩ := choose_spec s.exists_compl_positive_negative
+  set i := s.exists_compl_positive_negative.choose
+  obtain ⟨hi₁, hi₂, hi₃⟩ := s.exists_compl_positive_negative.choose_spec
   exact ⟨i, hi₁, hi₂, hi₃, rfl, rfl⟩
 #align measure_theory.signed_measure.to_jordan_decomposition_spec MeasureTheory.SignedMeasure.toJordanDecomposition_spec
 

--- a/Mathlib/MeasureTheory/Decomposition/UnsignedHahn.lean
+++ b/Mathlib/MeasureTheory/Decomposition/UnsignedHahn.lean
@@ -26,7 +26,8 @@ Hahn decomposition
 
 open Set Filter
 
-open Classical Topology ENNReal
+open scoped Classical
+open Topology ENNReal
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Function/AEEqFun.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqFun.lean
@@ -74,7 +74,8 @@ set_option autoImplicit true
 
 noncomputable section
 
-open Classical ENNReal Topology
+open scoped Classical
+open ENNReal Topology
 
 open Set Filter TopologicalSpace ENNReal EMetric MeasureTheory Function
 

--- a/Mathlib/MeasureTheory/Function/AEMeasurableOrder.lean
+++ b/Mathlib/MeasureTheory/Function/AEMeasurableOrder.lean
@@ -25,7 +25,8 @@ as possible.
 
 open MeasureTheory Set TopologicalSpace
 
-open Classical ENNReal NNReal
+open scoped Classical
+open ENNReal NNReal
 
 /-- If a function `f : α → β` is such that the level sets `{f < p}` and `{q < f}` have measurable
 supersets which are disjoint up to measure zero when `p < q`, then `f` is almost-everywhere

--- a/Mathlib/MeasureTheory/Function/AEMeasurableSequence.lean
+++ b/Mathlib/MeasureTheory/Function/AEMeasurableSequence.lean
@@ -25,7 +25,7 @@ and a measurable set `aeSeqSet hf p`, such that
 
 open MeasureTheory
 
-open Classical
+open scoped Classical
 
 variable {ι : Sort*} {α β γ : Type*} [MeasurableSpace α] [MeasurableSpace β] {f : ι → α → β}
   {μ : Measure α} {p : α → (ι → β) → Prop}

--- a/Mathlib/MeasureTheory/Function/Egorov.lean
+++ b/Mathlib/MeasureTheory/Function/Egorov.lean
@@ -25,7 +25,8 @@ convergence in measure.
 
 noncomputable section
 
-open Classical MeasureTheory NNReal ENNReal Topology
+open scoped Classical
+open MeasureTheory NNReal ENNReal Topology
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -49,7 +49,8 @@ integrable, function space, l1
 
 noncomputable section
 
-open Classical Topology BigOperators ENNReal MeasureTheory NNReal
+open scoped Classical
+open Topology BigOperators ENNReal MeasureTheory NNReal
 
 open Set Filter TopologicalSpace ENNReal EMetric MeasureTheory
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -30,7 +30,8 @@ open Filter ENNReal
 
 open Function (support)
 
-open Classical Topology BigOperators NNReal ENNReal MeasureTheory
+open scoped Classical
+open Topology BigOperators NNReal ENNReal MeasureTheory
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDense.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDense.lean
@@ -36,7 +36,8 @@ by a sequence of simple functions.
 
 open Set Function Filter TopologicalSpace ENNReal EMetric Finset
 
-open Classical Topology ENNReal MeasureTheory BigOperators
+open scoped Classical
+open Topology ENNReal MeasureTheory BigOperators
 
 variable {α β ι E F 𝕜 : Type*}
 

--- a/Mathlib/MeasureTheory/Integral/FundThmCalculus.lean
+++ b/Mathlib/MeasureTheory/Integral/FundThmCalculus.lean
@@ -145,7 +145,8 @@ set_option autoImplicit true
 
 noncomputable section
 
-open MeasureTheory Set Classical Filter Function
+open scoped Classical
+open MeasureTheory Set Filter Function
 
 open scoped Classical Topology Filter ENNReal BigOperators Interval NNReal
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -50,7 +50,8 @@ integral
 
 noncomputable section
 
-open MeasureTheory Set Classical Filter Function
+open scoped Classical
+open MeasureTheory Set Filter Function
 
 open scoped Classical Topology Filter ENNReal BigOperators Interval NNReal
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -42,7 +42,8 @@ open Filter ENNReal
 
 open Function (support)
 
-open Classical Topology BigOperators NNReal ENNReal MeasureTheory
+open scoped Classical
+open Topology BigOperators NNReal ENNReal MeasureTheory
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -54,7 +54,8 @@ only to prove the more general results:
 
 noncomputable section
 
-open Classical BigOperators NNReal ENNReal MeasureTheory Finset
+open scoped Classical
+open BigOperators NNReal ENNReal MeasureTheory Finset
 
 set_option linter.uppercaseLean3 false
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -1878,7 +1878,7 @@ theorem of_measurable_inverse (hf₁ : Measurable f) (hf₂ : MeasurableSet (ran
   of_measurable_inverse_on_range hf₁ hf₂ (hg.comp measurable_subtype_coe) H
 #align measurable_embedding.of_measurable_inverse MeasurableEmbedding.of_measurable_inverse
 
-open Classical
+open scoped Classical
 
 /-- The **measurable Schröder-Bernstein Theorem**: given measurable embeddings
 `α → β` and `β → α`, we can find a measurable equivalence `α ≃ᵐ β`.-/
@@ -1997,7 +1997,7 @@ instance [MeasurableSpace α] {s : Set α} [h : CountablyGenerated s] [Measurabl
 
 variable (α)
 
-open Classical
+open scoped Classical
 
 /-- If a measurable space is countably generated and separates points, it admits a measurable
 injection into the Cantor space `ℕ → Bool` (equipped with the product sigma algebra). -/

--- a/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
@@ -39,7 +39,7 @@ measurable space, σ-algebra, measurable function
 
 open Set Encodable Function Equiv
 
-open Classical
+open scoped Classical
 
 variable {α β γ δ δ' : Type*} {ι : Sort*} {s t u : Set α}
 

--- a/Mathlib/MeasureTheory/Measure/AEMeasurable.lean
+++ b/Mathlib/MeasureTheory/Measure/AEMeasurable.lean
@@ -15,7 +15,8 @@ function. This property, called `AEMeasurable f μ`, is defined in the file `Mea
 We discuss several of its properties that are analogous to properties of measurable functions.
 -/
 
-open MeasureTheory MeasureTheory.Measure Filter Set Function Classical ENNReal
+open scoped Classical
+open MeasureTheory MeasureTheory.Measure Filter Set Function ENNReal
 
 variable {ι α β γ δ R : Type*} {m0 : MeasurableSpace α} [MeasurableSpace β] [MeasurableSpace γ]
   [MeasurableSpace δ] {f g : α → β} {μ ν : Measure α}

--- a/Mathlib/MeasureTheory/Measure/GiryMonad.lean
+++ b/Mathlib/MeasureTheory/Measure/GiryMonad.lean
@@ -32,9 +32,11 @@ giry monad
 
 noncomputable section
 
-open Classical BigOperators ENNReal
+open scoped Classical
+open BigOperators ENNReal
 
-open Classical Set Filter
+open scoped Classical
+open Set Filter
 
 variable {α β : Type*}
 

--- a/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
@@ -274,7 +274,7 @@ lemma exists_integral_isMulLeftInvariant_eq_smul_of_hasCompactSupport (μ' μ : 
   simp only [B, integral_smul_nnreal_measure]
   rfl
 
-open Classical in
+open scoped Classical in
 /-- Given two left-invariant measures which are finite on compacts, `haarScalarFactor μ' μ` is a
 scalar such that `∫ f dμ' = (haarScalarFactor μ' μ) ∫ f dμ` for any compactly supported continuous
 function `f`.

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Basic.lean
@@ -34,7 +34,8 @@ assert_not_exists MeasureTheory.integral
 
 noncomputable section
 
-open Classical Set Filter MeasureTheory MeasureTheory.Measure TopologicalSpace
+open scoped Classical
+open Set Filter MeasureTheory MeasureTheory.Measure TopologicalSpace
 
 open ENNReal (ofReal)
 

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -86,7 +86,8 @@ open Set
 open Filter hiding map
 
 open Function MeasurableSpace
-open Classical Topology BigOperators Filter ENNReal NNReal Interval MeasureTheory
+open scoped Classical
+open Topology BigOperators Filter ENNReal NNReal Interval MeasureTheory
 
 variable {α β γ δ ι R R' : Type*}
 

--- a/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
@@ -56,13 +56,15 @@ measure, almost everywhere, measure space
 
 noncomputable section
 
-open Classical Set
+open scoped Classical
+open Set
 
 open Filter hiding map
 
 open Function MeasurableSpace
 
-open Classical Topology BigOperators Filter ENNReal NNReal
+open scoped Classical
+open Topology BigOperators Filter ENNReal NNReal
 
 variable {α β γ δ : Type*} {ι : Sort*}
 

--- a/Mathlib/MeasureTheory/Measure/Stieltjes.lean
+++ b/Mathlib/MeasureTheory/Measure/Stieltjes.lean
@@ -26,7 +26,8 @@ a Borel measure `f.measure`.
 
 noncomputable section
 
-open Classical Set Filter Function BigOperators ENNReal NNReal Topology MeasureTheory
+open scoped Classical
+open Set Filter Function BigOperators ENNReal NNReal Topology MeasureTheory
 
 open ENNReal (ofReal)
 

--- a/Mathlib/MeasureTheory/Measure/Typeclasses.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses.lean
@@ -616,19 +616,19 @@ theorem isCountablySpanning_spanningSets (μ : Measure α) [SigmaFinite μ] :
   ⟨spanningSets μ, mem_range_self, iUnion_spanningSets μ⟩
 #align measure_theory.is_countably_spanning_spanning_sets MeasureTheory.isCountablySpanning_spanningSets
 
-open Classical in
+open scoped Classical in
 /-- `spanningSetsIndex μ x` is the least `n : ℕ` such that `x ∈ spanningSets μ n`. -/
 noncomputable def spanningSetsIndex (μ : Measure α) [SigmaFinite μ] (x : α) : ℕ :=
   Nat.find <| iUnion_eq_univ_iff.1 (iUnion_spanningSets μ) x
 #align measure_theory.spanning_sets_index MeasureTheory.spanningSetsIndex
 
-open Classical in
+open scoped Classical in
 theorem measurable_spanningSetsIndex (μ : Measure α) [SigmaFinite μ] :
     Measurable (spanningSetsIndex μ) :=
   measurable_find _ <| measurable_spanningSets μ
 #align measure_theory.measurable_spanning_sets_index MeasureTheory.measurable_spanningSetsIndex
 
-open Classical in
+open scoped Classical in
 theorem preimage_spanningSetsIndex_singleton (μ : Measure α) [SigmaFinite μ] (n : ℕ) :
     spanningSetsIndex μ ⁻¹' {n} = disjointed (spanningSets μ) n :=
   preimage_find_eq_disjointed _ _ _

--- a/Mathlib/MeasureTheory/Measure/VectorMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/VectorMeasure.lean
@@ -45,7 +45,8 @@ vector measure, signed measure, complex measure
 
 noncomputable section
 
-open Classical BigOperators NNReal ENNReal MeasureTheory
+open scoped Classical
+open BigOperators NNReal ENNReal MeasureTheory
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
@@ -56,7 +56,8 @@ outer measure, Carathéodory-measurable, Carathéodory's criterion
 noncomputable section
 
 open Set Function Filter
-open Classical BigOperators NNReal Topology ENNReal MeasureTheory
+open scoped Classical
+open BigOperators NNReal Topology ENNReal MeasureTheory
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -58,7 +58,8 @@ import Mathlib.MeasureTheory.MeasurableSpace.Defs
 
 open MeasurableSpace Set
 
-open Classical MeasureTheory
+open scoped Classical
+open MeasureTheory
 
 /-- A π-system is a collection of subsets of `α` that is closed under binary intersection of
   non-disjoint sets. Usually it is also required that the collection is nonempty, but we don't do

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -58,7 +58,7 @@ lemma isPiSystem (hC : IsSetSemiring C) : IsPiSystem C := fun s hs t ht _ ↦ hC
 
 section diffFinset
 
-open Classical in
+open scoped Classical in
 /-- In a semi-ring of sets `C`, for all sets `s, t ∈ C`, `s \ t` is equal to a disjoint union of
 finitely many sets in `C`. The finite set of sets in the union is not unique, but this definition
 gives an arbitrary `Finset (Set α)` that satisfies the equality.
@@ -198,7 +198,7 @@ lemma exists_disjoint_finset_diff_eq (hC : IsSetSemiring C) (hs : s ∈ C) (hI :
       simp only [mem_coe]
     · simp only [hi, iUnion_of_empty, iUnion_empty]
 
-open Classical in
+open scoped Classical in
 /-- In a semiring of sets `C`, for all set `s ∈ C` and finite set of sets `I ⊆ C`,
 `diffFinset₀` is a finite set of sets in `C` such that `s \ ⋃₀ I = ⋃₀ (hC.diffFinset₀ hs I hI)`.
 `diffFinset` is a special case of `diffFinset₀` where `I` is a singleton. -/

--- a/Mathlib/ModelTheory/Types.lean
+++ b/Mathlib/ModelTheory/Types.lean
@@ -41,7 +41,8 @@ universe u v w w'
 
 open Cardinal Set
 
-open Cardinal FirstOrder Classical
+open scoped Classical
+open Cardinal FirstOrder
 
 namespace FirstOrder
 

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -32,7 +32,8 @@ divisors, perfect numbers
 -/
 
 
-open BigOperators Classical Finset
+open scoped Classical
+open BigOperators Finset
 
 namespace Nat
 

--- a/Mathlib/NumberTheory/FLT/Four.lean
+++ b/Mathlib/NumberTheory/FLT/Four.lean
@@ -18,7 +18,7 @@ There are no non-zero integers `a`, `b` and `c` such that `a ^ 4 + b ^ 4 = c ^ 4
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 /-- Shorthand for three non-zero integers `a`, `b`, and `c` satisfying `a ^ 4 + b ^ 4 = c ^ 2`.
 We will show that no integers satisfy this equation. Clearly Fermat's Last theorem for n = 4

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding.lean
@@ -249,7 +249,8 @@ end commMap
 
 noncomputable section stdBasis
 
-open Classical Complex MeasureTheory MeasureTheory.Measure Zspan Matrix BigOperators
+open scoped Classical
+open Complex MeasureTheory MeasureTheory.Measure Zspan Matrix BigOperators
   ComplexConjugate
 
 variable [NumberField K]

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding.lean
@@ -618,7 +618,7 @@ section convexBodyLT'
 
 open  Metric ENNReal NNReal
 
-open Classical
+open scoped Classical
 
 variable (f : InfinitePlace K → ℝ≥0) (w₀ : {w : InfinitePlace K // IsComplex w})
 

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding.lean
@@ -929,7 +929,8 @@ end convexBodySum
 
 section minkowski
 
-open MeasureTheory MeasureTheory.Measure Classical FiniteDimensional Zspan Real Submodule
+open scoped Classical
+open MeasureTheory MeasureTheory.Measure FiniteDimensional Zspan Real Submodule
 
 open scoped ENNReal NNReal nonZeroDivisors IntermediateField
 

--- a/Mathlib/NumberTheory/NumberField/Units.lean
+++ b/Mathlib/NumberTheory/NumberField/Units.lean
@@ -461,7 +461,8 @@ section statements
 
 variable [NumberField K]
 
-open dirichletUnitTheorem FiniteDimensional Classical
+open scoped Classical
+open dirichletUnitTheorem FiniteDimensional
 
 /-- The unit rank of the number field `K`, it is equal to `card (InfinitePlace K) - 1`. -/
 def rank : ℕ := Fintype.card (InfinitePlace K) - 1

--- a/Mathlib/NumberTheory/NumberField/Units.lean
+++ b/Mathlib/NumberTheory/NumberField/Units.lean
@@ -178,7 +178,8 @@ spans the full space over `ℝ` (see `unitLattice_span_eq_top`); this is the mai
 see the section `span_top` below for more details.
 -/
 
-open Classical Finset
+open scoped Classical
+open Finset
 
 variable [NumberField K]
 

--- a/Mathlib/NumberTheory/Padics/Hensel.lean
+++ b/Mathlib/NumberTheory/Padics/Hensel.lean
@@ -36,7 +36,8 @@ p-adic, p adic, padic, p-adic integer
 
 noncomputable section
 
-open Classical Topology
+open scoped Classical
+open Topology
 
 -- We begin with some general lemmas that are used below in the computation.
 theorem padic_polynomial_dist {p : ℕ} [Fact p.Prime] (F : Polynomial ℤ_[p]) (x y : ℤ_[p]) :

--- a/Mathlib/NumberTheory/Padics/PadicIntegers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicIntegers.lean
@@ -52,7 +52,7 @@ open Padic Metric LocalRing
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 /-- The `p`-adic integers `ℤ_[p]` are the `p`-adic numbers with norm `≤ 1`. -/
 def PadicInt (p : ℕ) [Fact p.Prime] :=

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -64,7 +64,7 @@ p-adic, p adic, padic, norm, valuation, cauchy, completion, p-adic completion
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 open Nat multiplicity padicNorm CauSeq CauSeq.Completion Metric
 
@@ -675,7 +675,7 @@ theorem rat_dense' (q : ℚ_[p]) {ε : ℚ} (hε : 0 < ε) : ∃ r : ℚ, padicN
         · exact hN _ (lt_of_not_ge hle).le _ le_rfl⟩
 #align padic.rat_dense' Padic.rat_dense'
 
-open Classical
+open scoped Classical
 
 private theorem div_nat_pos (n : ℕ) : 0 < 1 / (n + 1 : ℚ) :=
   div_pos zero_lt_one (mod_cast succ_pos _)

--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -41,7 +41,8 @@ which removes some boilerplate code.
 
 noncomputable section
 
-open Classical Nat LocalRing Padic
+open scoped Classical
+open Nat LocalRing Padic
 
 namespace PadicInt
 

--- a/Mathlib/NumberTheory/PythagoreanTriples.lean
+++ b/Mathlib/NumberTheory/PythagoreanTriples.lean
@@ -41,7 +41,7 @@ theorem Int.sq_ne_two_mod_four (z : ℤ) : z * z % 4 ≠ 2 := by
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 /-- Three integers `x`, `y`, and `z` form a Pythagorean triple if `x * x + y * y = z * z`. -/
 def PythagoreanTriple (x y z : ℤ) : Prop :=

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -685,7 +685,7 @@ end DecidableEq
 
 variable [Lattice α] [BoundedOrder α] [IsSimpleOrder α]
 
-open Classical
+open scoped Classical
 
 /-- A simple `BoundedOrder` is also complete. -/
 protected noncomputable def completeLattice : CompleteLattice α :=

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -1048,7 +1048,7 @@ instance isAtomic [∀ i, PartialOrder (π i)] [∀ i, OrderBot (π i)] [∀ i, 
   eq_bot_or_exists_atom_le b := or_iff_not_imp_left.2 fun h =>
     have ⟨i, hi⟩ : ∃ i, b i ≠ ⊥ := not_forall.1 (h.imp Pi.eq_bot_iff.2)
     have ⟨a, ha, hab⟩ := (eq_bot_or_exists_atom_le (b i)).resolve_left hi
-    have : DecidableEq ι := open Classical in inferInstance
+    have : DecidableEq ι := open scoped Classical in inferInstance
     ⟨Function.update ⊥ i a, isAtom_single ha, update_le_iff.2 ⟨hab, by simp⟩⟩
 
 instance isCoatomic [∀ i, PartialOrder (π i)] [∀ i, OrderTop (π i)] [∀ i, IsCoatomic (π i)] :

--- a/Mathlib/Order/Chain.lean
+++ b/Mathlib/Order/Chain.lean
@@ -29,7 +29,8 @@ Fleuriot, Tobias Nipkow, Christian Sternagel.
 -/
 
 
-open Classical Set
+open scoped Classical
+open Set
 
 variable {α β : Type*}
 

--- a/Mathlib/Order/Chain.lean
+++ b/Mathlib/Order/Chain.lean
@@ -159,7 +159,7 @@ theorem IsMaxChain.top_mem [LE α] [OrderTop α] (h : IsMaxChain (· ≤ ·) s) 
   (h.2 (h.1.insert fun _ _ _ => Or.inr le_top) <| subset_insert _ _).symm ▸ mem_insert _ _
 #align is_max_chain.top_mem IsMaxChain.top_mem
 
-open Classical
+open scoped Classical
 
 /-- Given a set `s`, if there exists a chain `t` strictly including `s`, then `SuccChain s`
 is one of these chains. Otherwise it is `s`. -/

--- a/Mathlib/Order/Chain.lean
+++ b/Mathlib/Order/Chain.lean
@@ -165,13 +165,12 @@ open scoped Classical
 /-- Given a set `s`, if there exists a chain `t` strictly including `s`, then `SuccChain s`
 is one of these chains. Otherwise it is `s`. -/
 def SuccChain (r : α → α → Prop) (s : Set α) : Set α :=
-  if h : ∃ t, IsChain r s ∧ SuperChain r s t then choose h else s
+  if h : ∃ t, IsChain r s ∧ SuperChain r s t then h.choose else s
 #align succ_chain SuccChain
 
 theorem succChain_spec (h : ∃ t, IsChain r s ∧ SuperChain r s t) :
     SuperChain r s (SuccChain r s) := by
-  have : IsChain r s ∧ SuperChain r s (choose h) :=
-    @choose_spec _ (fun t => IsChain r s ∧ SuperChain r s t) _
+  have : IsChain r s ∧ SuperChain r s h.choose := h.choose_spec
   simpa [SuccChain, dif_pos, exists_and_left.mp h] using this.2
 #align succ_chain_spec succChain_spec
 

--- a/Mathlib/Order/CompleteLatticeIntervals.lean
+++ b/Mathlib/Order/CompleteLatticeIntervals.lean
@@ -23,7 +23,7 @@ default values for `sSup` and `sInf`.
 -/
 
 
-open Classical
+open scoped Classical
 
 open Set
 

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -43,7 +43,7 @@ Extension of `sSup` and `sInf` from a preorder `α` to `WithTop α` and `WithBot
 -/
 
 
-open Classical
+open scoped Classical
 
 noncomputable instance WithTop.instSupSet {α : Type*} [Preorder α] [SupSet α] :
     SupSet (WithTop α) :=
@@ -269,7 +269,7 @@ instance (priority := 100) CompleteLinearOrder.toConditionallyCompleteLinearOrde
 
 section
 
-open Classical
+open scoped Classical
 
 /-- A well founded linear order is conditionally complete, with a bottom element. -/
 @[reducible]
@@ -1271,7 +1271,7 @@ end ConditionallyCompleteLinearOrderBot
 
 namespace WithTop
 
-open Classical
+open scoped Classical
 
 variable [ConditionallyCompleteLinearOrderBot α]
 
@@ -1619,7 +1619,7 @@ This result can be used to show that the extended reals `[-∞, ∞]` are a comp
 -/
 
 
-open Classical
+open scoped Classical
 
 /-- Adding a top element to a conditionally complete lattice
 gives a conditionally complete lattice -/

--- a/Mathlib/Order/CountableDenseLinearOrder.lean
+++ b/Mathlib/Order/CountableDenseLinearOrder.lean
@@ -33,7 +33,7 @@ back and forth, dense, countable, order
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 namespace Order
 

--- a/Mathlib/Order/Extension/Linear.lean
+++ b/Mathlib/Order/Extension/Linear.lean
@@ -19,7 +19,7 @@ universe u
 
 open Set Classical
 
-open Classical
+open scoped Classical
 
 /-- Any partial order can be extended to a linear order.
 -/

--- a/Mathlib/Order/Filter/Bases.lean
+++ b/Mathlib/Order/Filter/Bases.lean
@@ -83,7 +83,8 @@ set_option autoImplicit true
 
 open Set Filter
 
-open Filter Classical
+open scoped Classical
+open Filter
 
 section sort
 

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -82,7 +82,6 @@ set_option autoImplicit true
 
 open Function Set Order
 open scoped Classical
-open hiding by_cases not_not
 
 universe u v w x y
 

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -81,7 +81,8 @@ set_option autoImplicit true
 
 
 open Function Set Order
-open Classical hiding by_cases not_not
+open scoped Classical
+open hiding by_cases not_not
 
 universe u v w x y
 

--- a/Mathlib/Order/Filter/FilterProduct.lean
+++ b/Mathlib/Order/Filter/FilterProduct.lean
@@ -25,7 +25,7 @@ universe u v
 
 variable {α : Type u} {β : Type v} {φ : Ultrafilter α}
 
-open Classical
+open scoped Classical
 
 namespace Filter
 

--- a/Mathlib/Order/Filter/Pi.lean
+++ b/Mathlib/Order/Filter/Pi.lean
@@ -24,7 +24,8 @@ In this file we define two filters on `Π i, α i` and prove some basic properti
 
 open Set Function
 
-open Classical Filter
+open scoped Classical
+open Filter
 
 namespace Filter
 

--- a/Mathlib/Order/Filter/Ultrafilter.lean
+++ b/Mathlib/Order/Filter/Ultrafilter.lean
@@ -28,7 +28,8 @@ variable {α : Type u} {β : Type v} {γ : Type*}
 
 open Set Filter Function
 
-open Classical Filter
+open scoped Classical
+open Filter
 
 /-- `Filter α` is an atomic type: for every filter there exists an ultrafilter that is less than or
 equal to this filter. -/

--- a/Mathlib/Order/LiminfLimsup.lean
+++ b/Mathlib/Order/LiminfLimsup.lean
@@ -1344,11 +1344,11 @@ noncomputable def liminf_reparam
     (f : ι → α) (s : ι' → Set ι) (p : ι' → Prop) [Countable (Subtype p)] [Nonempty (Subtype p)]
     (j : Subtype p) : Subtype p :=
   let m : Set (Subtype p) := {j | BddBelow (range (fun (i : s j) ↦ f i))}
-  let g : ℕ → Subtype p := choose (exists_surjective_nat _)
+  let g : ℕ → Subtype p := (exists_surjective_nat _).choose
   have Z : ∃ n, g n ∈ m ∨ ∀ j, j ∉ m := by
     by_cases H : ∃ j, j ∈ m
     · rcases H with ⟨j, hj⟩
-      rcases choose_spec (exists_surjective_nat (Subtype p)) j with ⟨n, rfl⟩
+      rcases (exists_surjective_nat (Subtype p)).choose_spec j with ⟨n, rfl⟩
       exact ⟨n, Or.inl hj⟩
     · push_neg at H
       exact ⟨0, Or.inr H⟩
@@ -1385,8 +1385,8 @@ theorem HasBasis.liminf_eq_ciSup_ciInf {v : Filter ι}
     by_cases Hj : j ∈ m
     · simpa only [liminf_reparam, if_pos Hj] using Hj
     · simp only [liminf_reparam, if_neg Hj]
-      have Z : ∃ n, choose (exists_surjective_nat (Subtype p)) n ∈ m ∨ ∀ j, j ∉ m := by
-        rcases choose_spec (exists_surjective_nat (Subtype p)) j0 with ⟨n, rfl⟩
+      have Z : ∃ n, (exists_surjective_nat (Subtype p)).choose n ∈ m ∨ ∀ j, j ∉ m := by
+        rcases (exists_surjective_nat (Subtype p)).choose_spec j0 with ⟨n, rfl⟩
         exact ⟨n, Or.inl hj0⟩
       rcases Nat.find_spec Z with hZ|hZ
       · exact hZ

--- a/Mathlib/Order/LiminfLimsup.lean
+++ b/Mathlib/Order/LiminfLimsup.lean
@@ -1332,7 +1332,7 @@ set_option linter.uppercaseLean3 false in
 
 section Classical
 
-open Classical
+open scoped Classical
 
 /-- Given an indexed family of sets `s j` over `j : Subtype p` and a function `f`, then
 `liminf_reparam j` is equal to `j` if `f` is bounded below on `s j`, and otherwise to some

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -60,7 +60,7 @@ universe u v
 -- Porting note: can this really be a good idea?
 attribute [-simp] Part.bind_eq_bind Part.map_eq_map
 
-open Classical
+open scoped Classical
 
 namespace OrderHom
 

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -104,7 +104,7 @@ protected theorem lt_sup {r : α → α → Prop} (wf : WellFounded r) {s : Set 
 
 section
 
-open Classical
+open scoped Classical
 
 /-- A successor of an element `x` in a well-founded order is a minimal element `y` such that
 `x < y` if one exists. Otherwise it is `x` itself. -/

--- a/Mathlib/Order/Zorn.lean
+++ b/Mathlib/Order/Zorn.lean
@@ -63,7 +63,8 @@ Fleuriot, Tobias Nipkow, Christian Sternagel.
 -/
 
 
-open Classical Set
+open scoped Classical
+open Set
 
 variable {α β : Type*} {r : α → α → Prop} {c : Set α}
 

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -185,7 +185,7 @@ theorem measurable_compProdFun (κ : kernel α β) [IsSFiniteKernel κ] (η : ke
   exact h_meas.lintegral_kernel_prod_right
 #align probability_theory.kernel.measurable_comp_prod_fun ProbabilityTheory.kernel.measurable_compProdFun
 
-open Classical
+open scoped Classical
 
 /-- Composition-Product of kernels. For s-finite kernels, it satisfies
 `∫⁻ bc, f bc ∂(compProd κ η a) = ∫⁻ b, ∫⁻ c, f (b, c) ∂(η (a, b)) ∂(κ a)`

--- a/Mathlib/Probability/Kernel/Disintegration/MeasurableStieltjes.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/MeasurableStieltjes.lean
@@ -219,7 +219,7 @@ section ToRatCDF
 
 variable {f : α → ℚ → ℝ}
 
-open Classical in
+open scoped Classical in
 /-- Turn a function `f : α → ℚ → ℝ` into another with the property `IsRatStieltjesPoint f a`
 everywhere. At `a` that does not satisfy that property, `f a` is replaced by an arbitrary suitable
 function.

--- a/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
@@ -36,7 +36,8 @@ noncomputable section
 
 variable {α β γ : Type*}
 
-open Classical BigOperators NNReal ENNReal MeasureTheory
+open scoped Classical
+open BigOperators NNReal ENNReal MeasureTheory
 
 /-- A probability mass function, or discrete probability measures is a function `α → ℝ≥0∞` such
   that the values have (infinite) sum `1`. -/

--- a/Mathlib/Probability/ProbabilityMassFunction/Constructions.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Constructions.lean
@@ -33,7 +33,8 @@ noncomputable section
 
 variable {α β γ : Type*}
 
-open Classical BigOperators NNReal ENNReal
+open scoped Classical
+open BigOperators NNReal ENNReal
 
 section Map
 

--- a/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
@@ -25,7 +25,8 @@ noncomputable section
 
 variable {α β γ : Type*}
 
-open Classical BigOperators NNReal ENNReal
+open scoped Classical
+open BigOperators NNReal ENNReal
 
 open MeasureTheory
 

--- a/Mathlib/RingTheory/Adjoin/FG.lean
+++ b/Mathlib/RingTheory/Adjoin/FG.lean
@@ -140,7 +140,7 @@ theorem FG.prod {S : Subalgebra R A} {T : Subalgebra R B} (hS : S.FG) (hT : T.FG
 
 section
 
-open Classical
+open scoped Classical
 
 theorem FG.map {S : Subalgebra R A} (f : A →ₐ[R] B) (hs : S.FG) : (S.map f).FG :=
   let ⟨s, hs⟩ := hs

--- a/Mathlib/RingTheory/Adjoin/Tower.lean
+++ b/Mathlib/RingTheory/Adjoin/Tower.lean
@@ -62,7 +62,7 @@ end Algebra
 
 section
 
-open Classical
+open scoped Classical
 
 theorem Algebra.fg_trans' {R S A : Type*} [CommSemiring R] [CommSemiring S] [Semiring A]
     [Algebra R S] [Algebra S A] [Algebra R A] [IsScalarTower R S A] (hRS : (⊤ : Subalgebra R S).FG)
@@ -88,7 +88,7 @@ variable [Algebra A B] [Algebra B C] [Algebra A C] [IsScalarTower A B C]
 
 open Finset Submodule
 
-open Classical
+open scoped Classical
 
 theorem exists_subalgebra_of_fg (hAC : (⊤ : Subalgebra A C).FG) (hBC : (⊤ : Submodule B C).FG) :
     ∃ B₀ : Subalgebra A B, B₀.FG ∧ (⊤ : Submodule B₀ C).FG := by

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -49,7 +49,7 @@ The main definitions are in the `AdjoinRoot` namespace.
 
 noncomputable section
 
-open Classical
+open scoped Classical
 
 open BigOperators Polynomial
 

--- a/Mathlib/RingTheory/AlgebraTower.lean
+++ b/Mathlib/RingTheory/AlgebraTower.lean
@@ -102,7 +102,8 @@ section Semiring
 
 open Finsupp
 
-open BigOperators Classical
+open scoped Classical
+open BigOperators
 
 universe v₁ w₁
 

--- a/Mathlib/RingTheory/Algebraic.lean
+++ b/Mathlib/RingTheory/Algebraic.lean
@@ -21,7 +21,8 @@ a tower of algebraic field extensions is algebraic.
 
 universe u v w
 
-open Classical Polynomial
+open scoped Classical
+open Polynomial
 
 section
 

--- a/Mathlib/RingTheory/AlgebraicIndependent.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent.lean
@@ -44,7 +44,8 @@ noncomputable section
 
 open Function Set Subalgebra MvPolynomial Algebra
 
-open Classical BigOperators
+open scoped Classical
+open BigOperators
 
 universe x u v w
 

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -42,7 +42,7 @@ discrete valuation ring
 -/
 
 
-open Classical
+open scoped Classical
 
 universe u
 

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -85,7 +85,7 @@ protected theorem polynomial : FiniteType R R[X] :=
       exact Polynomial.adjoin_X⟩⟩
 #align algebra.finite_type.polynomial Algebra.FiniteType.polynomial
 
-open Classical
+open scoped Classical
 
 protected theorem freeAlgebra (ι : Type*) [Finite ι] : FiniteType R (FreeAlgebra R ι) := by
   cases nonempty_fintype ι

--- a/Mathlib/RingTheory/Fintype.lean
+++ b/Mathlib/RingTheory/Fintype.lean
@@ -12,7 +12,7 @@ import Mathlib.Data.Fintype.Units
 -/
 
 
-open Classical
+open scoped Classical
 
 theorem card_units_lt (M₀ : Type*) [MonoidWithZero M₀] [Nontrivial M₀] [Fintype M₀] :
     Fintype.card M₀ˣ < Fintype.card M₀ :=

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -194,7 +194,7 @@ instance directSum (ι : Type v) (M : ι → Type w) [(i : ι) → AddCommGroup 
     h₃, LinearMap.map_eq_zero_iff] at f
   simp [f]
 
-open Classical in
+open scoped Classical in
 /-- Free `R`-modules over discrete types are flat. -/
 instance finsupp (ι : Type v) : Flat R (ι →₀ R) :=
   of_linearEquiv R _ _ (finsuppLEquivDirectSum R R ι)

--- a/Mathlib/RingTheory/FractionalIdeal/Operations.lean
+++ b/Mathlib/RingTheory/FractionalIdeal/Operations.lean
@@ -379,7 +379,7 @@ is a field because `R` is a domain.
 -/
 
 
-open Classical
+open scoped Classical
 
 variable {R₁ : Type*} [CommRing R₁] {K : Type*} [Field K]
 
@@ -577,7 +577,7 @@ variable {R₁ : Type*} [CommRing R₁] {K : Type*} [Field K]
 
 variable [Algebra R₁ K] [IsFractionRing R₁ K]
 
-open Classical
+open scoped Classical
 
 variable (R₁)
 

--- a/Mathlib/RingTheory/FreeCommRing.lean
+++ b/Mathlib/RingTheory/FreeCommRing.lean
@@ -52,7 +52,8 @@ free commutative ring, free ring
 
 noncomputable section
 
-open Classical Polynomial
+open scoped Classical
+open Polynomial
 
 universe u v
 

--- a/Mathlib/RingTheory/HahnSeries/Addition.lean
+++ b/Mathlib/RingTheory/HahnSeries/Addition.lean
@@ -26,7 +26,8 @@ set_option linter.uppercaseLean3 false
 
 open Finset Function
 
-open BigOperators Classical
+open scoped Classical
+open BigOperators
 
 noncomputable section
 

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -31,7 +31,8 @@ set_option linter.uppercaseLean3 false
 
 open Finset Function
 
-open BigOperators Classical
+open scoped Classical
+open BigOperators
 
 noncomputable section
 

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -30,7 +30,8 @@ set_option linter.uppercaseLean3 false
 
 open Finset Function
 
-open BigOperators Classical Pointwise
+open scoped Classical
+open BigOperators Pointwise
 
 noncomputable section
 

--- a/Mathlib/RingTheory/HahnSeries/PowerSeries.lean
+++ b/Mathlib/RingTheory/HahnSeries/PowerSeries.lean
@@ -32,7 +32,8 @@ set_option linter.uppercaseLean3 false
 
 open Finset Function
 
-open BigOperators Classical Pointwise Polynomial
+open scoped Classical
+open BigOperators Pointwise Polynomial
 
 noncomputable section
 

--- a/Mathlib/RingTheory/HahnSeries/Summable.lean
+++ b/Mathlib/RingTheory/HahnSeries/Summable.lean
@@ -36,7 +36,8 @@ set_option linter.uppercaseLean3 false
 
 open Finset Function
 
-open BigOperators Classical Pointwise
+open scoped Classical
+open BigOperators Pointwise
 
 noncomputable section
 

--- a/Mathlib/RingTheory/Ideal/LocalRing.lean
+++ b/Mathlib/RingTheory/Ideal/LocalRing.lean
@@ -517,7 +517,7 @@ namespace Field
 
 variable (K) [Field K]
 
-open Classical
+open scoped Classical
 
 -- see Note [lower instance priority]
 instance (priority := 100) : LocalRing K :=

--- a/Mathlib/RingTheory/Ideal/Quotient.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient.lean
@@ -204,7 +204,7 @@ theorem exists_inv {I : Ideal R} [hI : I.IsMaximal] :
   rwa [abc, ← neg_mem_iff (G := R) (H := I), neg_sub] at hc
 #align ideal.quotient.exists_inv Ideal.Quotient.exists_inv
 
-open Classical
+open scoped Classical
 
 /-- The quotient by a maximal ideal is a group with zero. This is a `def` rather than `instance`,
 since users will have computable inverses in some applications.

--- a/Mathlib/RingTheory/IntegralClosure.lean
+++ b/Mathlib/RingTheory/IntegralClosure.lean
@@ -33,7 +33,8 @@ Let `R` be a `CommRing` and let `A` be an R-algebra.
 -/
 
 
-open Classical BigOperators Polynomial Submodule
+open scoped Classical
+open BigOperators Polynomial Submodule
 
 section Ring
 

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -23,7 +23,8 @@ import Mathlib.RingTheory.Localization.FractionRing
 -/
 
 
-open HahnSeries BigOperators Classical Polynomial
+open scoped Classical
+open HahnSeries BigOperators Polynomial
 
 noncomputable section
 

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -109,7 +109,7 @@ protected theorem isDomain : IsDomain K :=
 #align is_fraction_ring.is_domain IsFractionRing.isDomain
 
 /-- The inverse of an element in the field of fractions of an integral domain. -/
-protected noncomputable irreducible_def inv (z : K) : K := open Classical in
+protected noncomputable irreducible_def inv (z : K) : K := open scoped Classical in
   if h : z = 0 then 0
   else
     mk' K ↑(sec (nonZeroDivisors A) z).2

--- a/Mathlib/RingTheory/Localization/Integral.lean
+++ b/Mathlib/RingTheory/Localization/Integral.lean
@@ -41,7 +41,7 @@ open Polynomial
 
 variable [IsLocalization M S]
 
-open Classical
+open scoped Classical
 
 /-- `coeffIntegerNormalization p` gives the coefficients of the polynomial
 `integerNormalization p` -/

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -333,7 +333,7 @@ theorem unit_right {a : α} (ha : ¬IsUnit a) (u : αˣ) : multiplicity a u = 0 
   isUnit_right ha u.isUnit
 #align multiplicity.unit_right multiplicity.unit_right
 
-open Classical
+open scoped Classical
 
 theorem multiplicity_le_multiplicity_of_dvd_left {a b c : α} (hdvd : a ∣ b) :
     multiplicity b c ≤ multiplicity a c :=
@@ -577,7 +577,7 @@ protected theorem mul' {p a b : α} (hp : Prime p) (h : (multiplicity p (a * b))
   rw [← PartENat.natCast_inj, PartENat.natCast_get, eq_coe_iff]; exact ⟨hdiv, hsucc⟩
 #align multiplicity.mul' multiplicity.mul'
 
-open Classical
+open scoped Classical
 
 protected theorem mul {p a b : α} (hp : Prime p) :
     multiplicity p (a * b) = multiplicity p a + multiplicity p b :=

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -871,7 +871,7 @@ noncomputable section DivisionRing
 
 open nonZeroDivisors
 
-open Classical
+open scoped Classical
 
 variable {R : Type*} [Ring R] [Nontrivial R] [OreSet R⁰]
 

--- a/Mathlib/RingTheory/Polynomial/SeparableDegree.lean
+++ b/Mathlib/RingTheory/Polynomial/SeparableDegree.lean
@@ -40,7 +40,8 @@ noncomputable section
 
 namespace Polynomial
 
-open Classical Polynomial
+open scoped Classical
+open Polynomial
 
 section CommSemiring
 

--- a/Mathlib/RingTheory/PrincipalIdealDomain.lean
+++ b/Mathlib/RingTheory/PrincipalIdealDomain.lean
@@ -330,7 +330,7 @@ variable [CommRing R] [IsDomain R] [IsPrincipalIdealRing R]
 
 section
 
-open Classical
+open scoped Classical
 
 /-- `factors a` is a multiset of irreducible elements whose product is `a`, up to units -/
 noncomputable def factors (a : R) : Multiset R :=

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -867,7 +867,7 @@ end UniqueFactorizationMonoid
 
 namespace UniqueFactorizationMonoid
 
-open Classical
+open scoped Classical
 
 open Multiset Associates
 

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -61,7 +61,8 @@ boilerplate lemmas to `ValuationClass`.
 -/
 
 
-open Classical BigOperators Function Ideal
+open scoped Classical
+open BigOperators Function Ideal
 
 noncomputable section
 

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -767,13 +767,13 @@ end OrderProperties
 
 protected theorem lt_wf : @WellFounded Cardinal.{u} (· < ·) :=
   ⟨fun a =>
-    byContradiction fun h => by
+    by_contradiction fun h => by
       let ι := { c : Cardinal // ¬Acc (· < ·) c }
       let f : ι → Cardinal := Subtype.val
       haveI hι : Nonempty ι := ⟨⟨_, h⟩⟩
       obtain ⟨⟨c : Cardinal, hc : ¬Acc (· < ·) c⟩, ⟨h_1 : ∀ j, (f ⟨c, hc⟩).out ↪ (f j).out⟩⟩ :=
         Embedding.min_injective fun i => (f i).out
-      refine hc (Acc.intro _ fun j h' => byContradiction fun hj => h'.2 ?_)
+      refine hc (Acc.intro _ fun j h' => by_contradiction fun hj => h'.2 ?_)
       have : #_ ≤ #_ := ⟨h_1 ⟨j, hj⟩⟩
       simpa only [mk_out] using this⟩
 #align cardinal.lt_wf Cardinal.lt_wf

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -81,7 +81,8 @@ Cantor's theorem, König's theorem, Konig's theorem
 -/
 
 
-open Function Set Order BigOperators Classical
+open scoped Classical
+open Function Set Order BigOperators
 
 noncomputable section
 

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -49,7 +49,8 @@ noncomputable section
 
 open Function Cardinal Set Order
 
-open Classical Cardinal Ordinal
+open scoped Classical
+open Cardinal Ordinal
 
 universe u v w
 

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -50,7 +50,8 @@ noncomputable section
 
 open Function Cardinal Set Equiv Order
 
-open Classical Cardinal Ordinal
+open scoped Classical
+open Cardinal Ordinal
 
 universe u v w
 

--- a/Mathlib/SetTheory/Cardinal/SchroederBernstein.lean
+++ b/Mathlib/SetTheory/Cardinal/SchroederBernstein.lean
@@ -30,7 +30,7 @@ Cardinals are defined and further developed in the folder `SetTheory.Cardinal`.
 
 open Set Function
 
-open Classical
+open scoped Classical
 
 universe u v
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -55,7 +55,8 @@ noncomputable section
 
 open Function Cardinal Set Equiv Order
 
-open Classical Cardinal Ordinal
+open scoped Classical
+open Cardinal Ordinal
 
 universe u v w
 

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -59,7 +59,8 @@ noncomputable section
 
 open Function Cardinal Set Equiv Order
 
-open Classical Cardinal InitialSeg
+open scoped Classical
+open Cardinal InitialSeg
 
 universe u v w
 

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -19,7 +19,8 @@ noncomputable section
 
 open Function Cardinal Set Equiv Order
 
-open Classical Cardinal Ordinal
+open scoped Classical
+open Cardinal Ordinal
 
 universe u v w
 

--- a/Mathlib/Topology/Algebra/Algebra.lean
+++ b/Mathlib/Topology/Algebra/Algebra.lean
@@ -27,7 +27,7 @@ which as an algebra is a topological algebra.
 
 open Classical Set TopologicalSpace Algebra
 
-open Classical
+open scoped Classical
 
 universe u v w
 

--- a/Mathlib/Topology/Algebra/Algebra.lean
+++ b/Mathlib/Topology/Algebra/Algebra.lean
@@ -25,7 +25,8 @@ which as an algebra is a topological algebra.
 -/
 
 
-open Classical Set TopologicalSpace Algebra
+open scoped Classical
+open Set TopologicalSpace Algebra
 
 open scoped Classical
 

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -34,7 +34,8 @@ topological space, group, topological group
 -/
 
 
-open Classical Set Filter TopologicalSpace Function Topology Pointwise MulOpposite
+open scoped Classical
+open Set Filter TopologicalSpace Function Topology Pointwise MulOpposite
 
 universe u v w x
 

--- a/Mathlib/Topology/Algebra/Group/Compact.lean
+++ b/Mathlib/Topology/Algebra/Group/Compact.lean
@@ -18,9 +18,11 @@ imports developing either positive compacts or the compact open topology.
 -/
 
 
-open Classical Set Filter TopologicalSpace Function
+open scoped Classical
+open Set Filter TopologicalSpace Function
 
-open Classical Topology Filter Pointwise
+open scoped Classical
+open Topology Filter Pointwise
 
 universe u v w x
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -390,7 +390,7 @@ theorem tsum_singleton (b : β) (f : β → α) : ∑' x : ({b} : Set β), f x =
   rw [← coe_singleton, Finset.tsum_subtype', sum_singleton]
 #align tsum_singleton tsum_singleton
 
-open Classical in
+open scoped Classical in
 theorem Function.Injective.tsum_eq {g : γ → β} (hg : Injective g) {f : β → α}
     (hf : support f ⊆ Set.range g) : ∑' c, f (g c) = ∑' b, f b := by
   have : support f = g '' support (f ∘ g) := by

--- a/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
@@ -73,7 +73,7 @@ irreducible_def tsum {β} (f : β → α) :=
   When the support of `f` is finite, we make the most reasonable choice to use the finite sum over
   the support. Otherwise, we choose arbitrarily an `a` satisfying `HasSum f a`. -/
     if (support f).Finite then finsum f
-    else choose h
+    else h.choose
   else 0
 #align tsum tsum
 
@@ -123,7 +123,7 @@ theorem Summable.hasSum (ha : Summable f) : HasSum f (∑' b, f b) := by
   simp only [tsum_def, ha, dite_true]
   by_cases H : (support f).Finite
   · simp [H, hasSum_sum_of_ne_finset_zero, finsum_eq_sum]
-  · simpa [H] using Classical.choose_spec ha
+  · simpa [H] using ha.choose_spec
 #align summable.has_sum Summable.hasSum
 
 theorem HasSum.unique {a₁ a₂ : α} [T2Space α] : HasSum f a₁ → HasSum f a₂ → a₁ = a₂ := by

--- a/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
@@ -65,7 +65,7 @@ def Summable (f : β → α) : Prop :=
   ∃ a, HasSum f a
 #align summable Summable
 
-open Classical in
+open scoped Classical in
 /-- `∑' i, f i` is the sum of `f` it exists, or 0 otherwise. -/
 irreducible_def tsum {β} (f : β → α) :=
   if h : Summable f then

--- a/Mathlib/Topology/Algebra/InfiniteSum/Ring.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Ring.lean
@@ -22,7 +22,8 @@ This file provides lemmas about the interaction between infinite sums and multip
 
 open Filter Finset Function
 
-open BigOperators Classical
+open scoped Classical
+open BigOperators
 
 variable {ι κ R α : Type*}
 

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -2592,7 +2592,7 @@ end ContinuousLinearEquiv
 
 namespace ContinuousLinearMap
 
-open Classical
+open scoped Classical
 
 variable {R : Type*} {M : Type*} {M₂ : Type*} [TopologicalSpace M] [TopologicalSpace M₂]
 

--- a/Mathlib/Topology/Algebra/Module/LinearPMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearPMap.lean
@@ -96,7 +96,7 @@ theorem IsClosable.existsUnique {f : E →ₗ.[R] F} (hf : f.IsClosable) :
   rw [← hy₁, ← hy₂]
 #align linear_pmap.is_closable.exists_unique LinearPMap.IsClosable.existsUnique
 
-open Classical
+open scoped Classical
 
 /-- If `f` is closable, then `f.closure` is the closure. Otherwise it is defined
 as `f.closure = f`. -/

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -22,9 +22,11 @@ the definitions.
 
 universe u v
 
-open Classical Set Filter TopologicalSpace
+open scoped Classical
+open Set Filter TopologicalSpace
 
-open Classical Topology BigOperators Pointwise
+open scoped Classical
+open Topology BigOperators Pointwise
 
 variable {ι α M N X : Type*} [TopologicalSpace X]
 

--- a/Mathlib/Topology/Algebra/Order/ExtendFrom.lean
+++ b/Mathlib/Topology/Algebra/Order/ExtendFrom.lean
@@ -17,7 +17,8 @@ set_option autoImplicit true
 
 open Filter Set TopologicalSpace
 
-open Topology Classical
+open scoped Classical
+open Topology
 
 theorem continuousOn_Icc_extendFrom_Ioo [TopologicalSpace α] [LinearOrder α] [DenselyOrdered α]
     [OrderTopology α] [TopologicalSpace β] [RegularSpace β] {f : α → β} {a b : α} {la lb : β}

--- a/Mathlib/Topology/Algebra/Order/MonotoneConvergence.lean
+++ b/Mathlib/Topology/Algebra/Order/MonotoneConvergence.lean
@@ -30,7 +30,8 @@ monotone convergence
 
 open Filter Set Function
 
-open Filter Topology Classical
+open scoped Classical
+open Filter Topology
 
 variable {α β : Type*}
 

--- a/Mathlib/Topology/Algebra/StarSubalgebra.lean
+++ b/Mathlib/Topology/Algebra/StarSubalgebra.lean
@@ -27,7 +27,7 @@ which as a star algebra is a topological star algebra.
 
 open Classical Set TopologicalSpace
 
-open Classical
+open scoped Classical
 
 namespace StarSubalgebra
 

--- a/Mathlib/Topology/Algebra/StarSubalgebra.lean
+++ b/Mathlib/Topology/Algebra/StarSubalgebra.lean
@@ -25,7 +25,8 @@ which as a star algebra is a topological star algebra.
 -/
 
 
-open Classical Set TopologicalSpace
+open scoped Classical
+open Set TopologicalSpace
 
 open scoped Classical
 

--- a/Mathlib/Topology/Algebra/UniformField.lean
+++ b/Mathlib/Topology/Algebra/UniformField.lean
@@ -36,7 +36,8 @@ type class and the main results are the instances `UniformSpace.Completion.Field
 
 noncomputable section
 
-open Classical uniformity Topology
+open scoped Classical
+open uniformity Topology
 
 open Set UniformSpace UniformSpace.Completion Filter
 

--- a/Mathlib/Topology/Algebra/UniformGroup.lean
+++ b/Mathlib/Topology/Algebra/UniformGroup.lean
@@ -892,9 +892,9 @@ section CompleteQuotient
 
 universe u
 
-open scoped Classical
 open TopologicalSpace
 
+open Classical in
 /-- The quotient `G ⧸ N` of a complete first countable topological group `G` by a normal subgroup
 is itself complete. [N. Bourbaki, *General Topology*, IX.3.1 Proposition 4][bourbaki1966b]
 

--- a/Mathlib/Topology/Algebra/UniformGroup.lean
+++ b/Mathlib/Topology/Algebra/UniformGroup.lean
@@ -892,7 +892,8 @@ section CompleteQuotient
 
 universe u
 
-open TopologicalSpace Classical
+open scoped Classical
+open TopologicalSpace
 
 /-- The quotient `G ⧸ N` of a complete first countable topological group `G` by a normal subgroup
 is itself complete. [N. Bourbaki, *General Topology*, IX.3.1 Proposition 4][bourbaki1966b]

--- a/Mathlib/Topology/Algebra/UniformGroup.lean
+++ b/Mathlib/Topology/Algebra/UniformGroup.lean
@@ -39,7 +39,8 @@ group naturally induces a uniform structure.
 
 noncomputable section
 
-open Classical Uniformity Topology Filter Pointwise
+open scoped Classical
+open Uniformity Topology Filter Pointwise
 
 section UniformGroup
 

--- a/Mathlib/Topology/Algebra/UniformRing.lean
+++ b/Mathlib/Topology/Algebra/UniformRing.lean
@@ -35,7 +35,8 @@ TODO: Generalise the results here from the concrete `Completion` to any `Abstrac
 -/
 
 
-open Classical Set Filter TopologicalSpace AddCommGroup
+open scoped Classical
+open Set Filter TopologicalSpace AddCommGroup
 
 open scoped Classical
 

--- a/Mathlib/Topology/Algebra/UniformRing.lean
+++ b/Mathlib/Topology/Algebra/UniformRing.lean
@@ -37,7 +37,7 @@ TODO: Generalise the results here from the concrete `Completion` to any `Abstrac
 
 open Classical Set Filter TopologicalSpace AddCommGroup
 
-open Classical
+open scoped Classical
 
 noncomputable section
 

--- a/Mathlib/Topology/Algebra/Valuation.lean
+++ b/Mathlib/Topology/Algebra/Valuation.lean
@@ -18,7 +18,8 @@ values in a group with zero. Other instances are then deduced from this.
 -/
 
 
-open Classical Topology uniformity
+open scoped Classical
+open Topology uniformity
 
 open Set Valuation
 

--- a/Mathlib/Topology/Category/Compactum.lean
+++ b/Mathlib/Topology/Category/Compactum.lean
@@ -77,7 +77,8 @@ universe u
 
 open CategoryTheory Filter Ultrafilter TopologicalSpace CategoryTheory.Limits FiniteInter
 
-open Classical Topology
+open scoped Classical
+open Topology
 
 local notation "β" => ofTypeMonad Ultrafilter
 

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -491,7 +491,7 @@ instance : Fintype (π C (· ∈ s)) := by
   · simp only [Proj, if_neg hi]
 
 
-open Classical in
+open scoped Classical in
 /-- The Kronecker delta as a locally constant map from `π C (· ∈ s)` to `ℤ`. -/
 noncomputable
 def spanFinBasis (x : π C (· ∈ s)) : LocallyConstant (π C (· ∈ s)) ℤ where
@@ -500,7 +500,7 @@ def spanFinBasis (x : π C (· ∈ s)) : LocallyConstant (π C (· ∈ s)) ℤ w
     haveI : DiscreteTopology (π C (· ∈ s)) := discrete_of_t1_of_finite
     IsLocallyConstant.of_discrete _
 
-open Classical in
+open scoped Classical in
 theorem spanFinBasis.span : ⊤ ≤ Submodule.span ℤ (Set.range (spanFinBasis C s)) := by
   intro f _
   rw [Finsupp.mem_span_range_iff_exists_finsupp]
@@ -1300,7 +1300,7 @@ theorem C1_projOrd {x : I → Bool} (hx : x ∈ C1 C ho) : SwapTrue o (Proj (ord
     simp only [not_lt, Bool.not_eq_true, Order.succ_le_iff] at hsC
     exact (hsC h').symm
 
-open Classical in
+open scoped Classical in
 theorem CC_exact {f : LocallyConstant C ℤ} (hf : Linear_CC' C hsC ho f = 0) :
     ∃ y, πs C o y = f := by
   dsimp [Linear_CC', Linear_CC'₀, Linear_CC'₁] at hf
@@ -1760,12 +1760,12 @@ end NobelingProof
 
 variable (S : Profinite.{u})
 
-open Classical in
+open scoped Classical in
 /-- The embedding `S → (I → Bool)` where `I` is the set of clopens of `S`. -/
 noncomputable
 def Nobeling.ι : S → ({C : Set S // IsClopen C} → Bool) := fun s C => decide (s ∈ C.1)
 
-open Classical in
+open scoped Classical in
 /-- The map `Nobeling.ι` is a closed embedding. -/
 theorem Nobeling.embedding : ClosedEmbedding (Nobeling.ι S) := by
   apply Continuous.closedEmbedding

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -63,7 +63,8 @@ on `(-∞, 0]` and to `y` on `[1, +∞)`.
 
 noncomputable section
 
-open Classical Topology Filter unitInterval Set Function
+open scoped Classical
+open Topology Filter unitInterval Set Function
 
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {x y z : X} {ι : Type*}
 

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -36,7 +36,8 @@ product, sum, disjoint union, subspace, quotient space
 
 noncomputable section
 
-open Topology TopologicalSpace Set Filter Function Classical
+open scoped Classical
+open Topology TopologicalSpace Set Filter Function
 
 universe u v
 

--- a/Mathlib/Topology/ContinuousFunction/Bounded.lean
+++ b/Mathlib/Topology/ContinuousFunction/Bounded.lean
@@ -23,7 +23,8 @@ the uniform distance.
 
 noncomputable section
 
-open Topology Bornology Classical NNReal uniformity UniformConvergence
+open scoped Classical
+open Topology Bornology NNReal uniformity UniformConvergence
 
 open Set Filter Metric Function
 

--- a/Mathlib/Topology/ContinuousFunction/Compact.lean
+++ b/Mathlib/Topology/ContinuousFunction/Compact.lean
@@ -29,7 +29,8 @@ you should restate it here. You can also use
 
 noncomputable section
 
-open Topology Classical NNReal BoundedContinuousFunction BigOperators
+open scoped Classical
+open Topology NNReal BoundedContinuousFunction BigOperators
 
 open Set Filter Metric
 

--- a/Mathlib/Topology/ContinuousFunction/FunctionalCalculus.lean
+++ b/Mathlib/Topology/ContinuousFunction/FunctionalCalculus.lean
@@ -270,7 +270,7 @@ syntax (name := cfcContTac) "cfc_cont_tac" : tactic
 macro_rules
   | `(tactic| cfc_cont_tac) => `(tactic| try (first | fun_prop (disch := aesop) | assumption))
 
-open Classical in
+open scoped Classical in
 /-- This is the *continuous functional calculus* of an element `a : A` applied to bare functions.
 When either `a` does not satisfy the predicate `p` (i.e., `a` is not `IsStarNormal`,
 `IsSelfAdjoint`, or `0 ≤ a` when `R` is `ℂ`, `ℝ`, or `ℝ≥0`, respectively), or when `f : R → R` is

--- a/Mathlib/Topology/ExtremallyDisconnected.lean
+++ b/Mathlib/Topology/ExtremallyDisconnected.lean
@@ -32,7 +32,8 @@ compact Hausdorff spaces.
 
 noncomputable section
 
-open Classical Function Set
+open scoped Classical
+open Function Set
 
 universe u
 

--- a/Mathlib/Topology/FiberBundle/Constructions.lean
+++ b/Mathlib/Topology/FiberBundle/Constructions.lean
@@ -30,7 +30,8 @@ fiber bundle, fibre bundle, fiberwise product, pullback
 
 open TopologicalSpace Filter Set Bundle
 
-open Topology Classical Bundle
+open scoped Classical
+open Topology Bundle
 
 /-! ### The trivial bundle -/
 

--- a/Mathlib/Topology/Instances/EReal.lean
+++ b/Mathlib/Topology/Instances/EReal.lean
@@ -30,7 +30,8 @@ Most proofs are adapted from the corresponding proofs on `ℝ≥0∞`.
 
 noncomputable section
 
-open Classical Set Filter Metric TopologicalSpace Topology
+open scoped Classical
+open Set Filter Metric TopologicalSpace Topology
 open scoped ENNReal NNReal BigOperators Filter
 
 variable {α : Type*} [TopologicalSpace α]

--- a/Mathlib/Topology/Instances/NNReal.lean
+++ b/Mathlib/Topology/Instances/NNReal.lean
@@ -185,7 +185,7 @@ theorem summable_mk {f : α → ℝ} (hf : ∀ n, 0 ≤ f n) :
   Iff.symm <| summable_coe (f := fun x => ⟨f x, hf x⟩)
 #align nnreal.summable_coe_of_nonneg NNReal.summable_mk
 
-open Classical
+open scoped Classical
 
 @[norm_cast]
 theorem coe_tsum {f : α → ℝ≥0} : ↑(∑' a, f a) = ∑' a, (f a : ℝ) :=

--- a/Mathlib/Topology/Instances/Real.lean
+++ b/Mathlib/Topology/Instances/Real.lean
@@ -18,7 +18,8 @@ import Mathlib.Topology.Instances.Int
 
 noncomputable section
 
-open Classical Filter Int Metric Set TopologicalSpace Bornology
+open scoped Classical
+open Filter Int Metric Set TopologicalSpace Bornology
 open scoped Topology Uniformity Interval
 
 universe u v w

--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -449,7 +449,7 @@ theorem flip_unflip {X α β : Type*} [Finite α] [TopologicalSpace X]
 
 section Comap
 
-open Classical
+open scoped Classical
 
 variable [TopologicalSpace Y]
 
@@ -543,7 +543,7 @@ section Indicator
 
 variable {R : Type*} [One R] {U : Set X} (f : LocallyConstant X R)
 
-open Classical
+open scoped Classical
 
 /-- Given a clopen set `U` and a locally constant function `f`, `LocallyConstant.mulIndicator`
   returns the locally constant function that is `f` on `U` and `1` otherwise. -/

--- a/Mathlib/Topology/MetricSpace/CantorScheme.lean
+++ b/Mathlib/Topology/MetricSpace/CantorScheme.lean
@@ -45,7 +45,8 @@ namespace CantorScheme
 
 open List Function Filter Set PiNat
 
-open Classical Topology
+open scoped Classical
+open Topology
 
 variable {β α : Type*} (A : List β → Set α)
 

--- a/Mathlib/Topology/MetricSpace/CauSeqFilter.lean
+++ b/Mathlib/Topology/MetricSpace/CauSeqFilter.lean
@@ -20,7 +20,8 @@ universe u v
 
 open Set Filter
 
-open Topology Classical
+open scoped Classical
+open Topology
 
 variable {β : Type v}
 

--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -133,9 +133,9 @@ instance Closeds.completeSpace [CompleteSpace α] : CompleteSpace (Closeds α) :
           rw [← pow_add]
           apply hs <;> simp
         exact ⟨⟨z', z'_mem⟩, le_of_lt hz'⟩
-      use fun k => Nat.recOn k ⟨x, hx⟩ fun l z => choose (this l z)
+      use fun k => Nat.recOn k ⟨x, hx⟩ fun l z => (this l z).choose
       simp only [Nat.add_zero, Nat.zero_eq, Nat.rec_zero, Nat.rec_add_one, true_and]
-      exact fun k => choose_spec (this k _)
+      exact fun k => (this k _).choose_spec
     -- it follows from the previous bound that `z` is a Cauchy sequence
     have : CauchySeq fun k => (z k : α) := cauchySeq_of_edist_le_geometric_two (B n) (B_ne_top n) hz
     -- therefore, it converges
@@ -341,8 +341,8 @@ instance NonemptyCompacts.secondCountableTopology [SecondCountableTopology α] :
         intro x
         rcases mem_closure_iff.1 (s_dense x) (δ / 2) δpos' with ⟨y, ys, hy⟩
         exact ⟨y, ⟨ys, hy⟩⟩
-      let F x := choose (Exy x)
-      have Fspec : ∀ x, F x ∈ s ∧ edist x (F x) < δ / 2 := fun x => choose_spec (Exy x)
+      let F x := (Exy x).choose
+      have Fspec : ∀ x, F x ∈ s ∧ edist x (F x) < δ / 2 := fun x => (Exy x).choose_spec
       -- cover `t` with finitely many balls. Their centers form a set `a`
       have : TotallyBounded (t : Set α) := t.isCompact.totallyBounded
       rcases totallyBounded_iff.1 this (δ / 2) δpos' with ⟨a, af, ta⟩

--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -27,11 +27,13 @@ always finite in this context.
 
 noncomputable section
 
-open Classical Topology ENNReal
+open scoped Classical
+open Topology ENNReal
 
 universe u
 
-open Classical Set Function TopologicalSpace Filter
+open scoped Classical
+open Set Function TopologicalSpace Filter
 
 namespace EMetric
 

--- a/Mathlib/Topology/MetricSpace/Contracting.lean
+++ b/Mathlib/Topology/MetricSpace/Contracting.lean
@@ -31,7 +31,8 @@ contracting map, fixed point, Banach fixed point theorem
 -/
 
 
-open NNReal Topology Classical ENNReal Filter Function
+open scoped Classical
+open NNReal Topology ENNReal Filter Function
 
 variable {α : Type*}
 

--- a/Mathlib/Topology/MetricSpace/Gluing.lean
+++ b/Mathlib/Topology/MetricSpace/Gluing.lean
@@ -311,7 +311,7 @@ namespace Sigma
 of two spaces. I.e., work with sigma types instead of sum types. -/
 variable {ι : Type*} {E : ι → Type*} [∀ i, MetricSpace (E i)]
 
-open Classical
+open scoped Classical
 
 /-- Distance on a disjoint union. There are many (noncanonical) ways to put a distance compatible
 with each factor.

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -52,7 +52,8 @@ local notation "ℓ_infty_ℝ" => lp (fun n : ℕ => ℝ) ∞
 
 universe u v w
 
-open Classical Set Function TopologicalSpace Filter Metric Quotient Bornology
+open scoped Classical
+open Set Function TopologicalSpace Filter Metric Quotient Bornology
 
 open BoundedContinuousFunction Nat Int kuratowskiEmbedding
 

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -817,7 +817,7 @@ theorem totallyBounded {t : Set GHSpace} {C : ℝ} {u : ℕ → ℝ} {K : ℕ �
     · have : Nonempty (Equiv (∅ : Set p.Rep) (Fin 0)) := by
         rw [← Fintype.card_eq];
         simp only [empty_card', Fintype.card_fin]
-      use ∅, 0, bot_le, choice this
+      use ∅, 0, bot_le, this.some
       -- Porting note: unclear why this next line wasn't needed in Lean 3
       exact fun hp' => (hp hp').elim
     · rcases hcov _ (Set.not_not_mem.1 hp) n with ⟨s, ⟨scard, scover⟩⟩

--- a/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
@@ -34,11 +34,13 @@ space structure on `X ⊕ Y`. The corresponding metric quotient is `OptimalGHCou
 
 noncomputable section
 
-open Classical Topology NNReal
+open scoped Classical
+open Topology NNReal
 
 universe u v w
 
-open Classical Set Function TopologicalSpace Filter Metric Quotient
+open scoped Classical
+open Set Function TopologicalSpace Filter Metric Quotient
 
 open BoundedContinuousFunction
 

--- a/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
@@ -102,7 +102,7 @@ section Constructions
 variable {X : Type u} {Y : Type v} [MetricSpace X] [CompactSpace X] [Nonempty X] [MetricSpace Y]
   [CompactSpace Y] [Nonempty Y] {f : ProdSpaceFun X Y} {x y z t : X ⊕ Y}
 
-attribute [local instance 10] inhabited_of_nonempty'
+attribute [local instance 10] Classical.inhabited_of_nonempty'
 
 private theorem maxVar_bound : dist x y ≤ maxVar X Y :=
   calc

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -52,7 +52,8 @@ in general), and `ι` is countable.
 
 noncomputable section
 
-open Classical Topology Filter
+open scoped Classical
+open Topology Filter
 
 open TopologicalSpace Set Metric Filter Function
 

--- a/Mathlib/Topology/MetricSpace/Polish.lean
+++ b/Mathlib/Topology/MetricSpace/Polish.lean
@@ -48,7 +48,8 @@ with additional properties:
 
 noncomputable section
 
-open Classical Topology Filter TopologicalSpace Set Metric Function
+open scoped Classical
+open Topology Filter TopologicalSpace Set Metric Function
 
 variable {α : Type*} {β : Type*}
 

--- a/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
+++ b/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
@@ -36,7 +36,8 @@ members of the approximating sequence are nonnegative bounded continuous functio
 -/
 
 
-open Classical NNReal ENNReal Topology BoundedContinuousFunction
+open scoped Classical
+open NNReal ENNReal Topology BoundedContinuousFunction
 
 open NNReal ENNReal Set Metric EMetric Filter
 

--- a/Mathlib/Topology/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Topology/OmegaCompletePartialOrder.lean
@@ -24,7 +24,7 @@ of continuity is equivalent to continuity in ωCPOs.
 
 open Set OmegaCompletePartialOrder
 
-open Classical
+open scoped Classical
 
 universe u
 

--- a/Mathlib/Topology/PartitionOfUnity.lean
+++ b/Mathlib/Topology/PartitionOfUnity.lean
@@ -80,7 +80,8 @@ universe u v
 
 open Function Set Filter
 
-open BigOperators Topology Classical
+open scoped Classical
+open BigOperators Topology
 
 noncomputable section
 

--- a/Mathlib/Topology/UniformSpace/Cauchy.lean
+++ b/Mathlib/Topology/UniformSpace/Cauchy.lean
@@ -698,7 +698,7 @@ noncomputable section
 /-- An auxiliary sequence of sets approximating a Cauchy filter. -/
 def setSeqAux (n : ℕ) : { s : Set α // s ∈ f ∧ s ×ˢ s ⊆ U n } :=
   -- Porting note: changed `∃ _ : s ∈ f, ..` to `s ∈ f ∧ ..`
-  indefiniteDescription _ <| (cauchy_iff.1 hf).2 (U n) (U_mem n)
+  Classical.indefiniteDescription _ <| (cauchy_iff.1 hf).2 (U n) (U_mem n)
 #align sequentially_complete.set_seq_aux SequentiallyComplete.setSeqAux
 
 /-- Given a Cauchy filter `f` and a sequence `U` of entourages, `set_seq` provides
@@ -730,11 +730,11 @@ theorem setSeq_prod_subset {N m n} (hm : N ≤ m) (hn : N ≤ n) :
 sequence of sets `setSeq n ∈ f` with diameters controlled by a given sequence
 of entourages. -/
 def seq (n : ℕ) : α :=
-  choose <| hf.1.nonempty_of_mem (setSeq_mem hf U_mem n)
+  (hf.1.nonempty_of_mem (setSeq_mem hf U_mem n)).choose
 #align sequentially_complete.seq SequentiallyComplete.seq
 
 theorem seq_mem (n : ℕ) : seq hf U_mem n ∈ setSeq hf U_mem n :=
-  choose_spec <| hf.1.nonempty_of_mem (setSeq_mem hf U_mem n)
+  (hf.1.nonempty_of_mem (setSeq_mem hf U_mem n)).choose_spec
 #align sequentially_complete.seq_mem SequentiallyComplete.seq_mem
 
 theorem seq_pair_mem ⦃N m n : ℕ⦄ (hm : N ≤ m) (hn : N ≤ n) :

--- a/Mathlib/Topology/UniformSpace/Cauchy.lean
+++ b/Mathlib/Topology/UniformSpace/Cauchy.lean
@@ -16,7 +16,8 @@ import Mathlib.Topology.UniformSpace.Basic
 
 universe u v
 
-open Filter TopologicalSpace Set Classical UniformSpace Function
+open scoped Classical
+open Filter TopologicalSpace Set UniformSpace Function
 
 open scoped Classical
 open Uniformity Topology Filter

--- a/Mathlib/Topology/UniformSpace/Cauchy.lean
+++ b/Mathlib/Topology/UniformSpace/Cauchy.lean
@@ -18,7 +18,8 @@ universe u v
 
 open Filter TopologicalSpace Set Classical UniformSpace Function
 
-open Classical Uniformity Topology Filter
+open scoped Classical
+open Uniformity Topology Filter
 
 variable {α : Type u} {β : Type v} [uniformSpace : UniformSpace α]
 

--- a/Mathlib/Topology/UniformSpace/Compact.lean
+++ b/Mathlib/Topology/UniformSpace/Compact.lean
@@ -36,7 +36,8 @@ uniform space, uniform continuity, compact space
 -/
 
 
-open Classical Uniformity Topology Filter UniformSpace Set
+open scoped Classical
+open Uniformity Topology Filter UniformSpace Set
 
 variable {α β γ : Type*} [UniformSpace α] [UniformSpace β]
 

--- a/Mathlib/Topology/UniformSpace/Completion.lean
+++ b/Mathlib/Topology/UniformSpace/Completion.lean
@@ -49,7 +49,8 @@ open Filter Set
 
 universe u v w x
 
-open Uniformity Classical Topology Filter
+open scoped Classical
+open Uniformity Topology Filter
 
 /-- Space of Cauchy filters
 

--- a/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
@@ -135,7 +135,8 @@ uniform convergence
 
 noncomputable section
 
-open Topology Classical Uniformity Filter
+open scoped Classical
+open Topology Uniformity Filter
 
 open Set Filter
 

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -22,7 +22,8 @@ We provide basic instances, as well as a custom tactic for discharging
 
 noncomputable section
 
-open Classical Topology Filter
+open scoped Classical
+open Topology Filter
 
 open Set Int Set.Icc
 

--- a/Mathlib/Topology/VectorBundle/Basic.lean
+++ b/Mathlib/Topology/VectorBundle/Basic.lean
@@ -56,7 +56,8 @@ Vector bundle
 
 noncomputable section
 
-open Bundle Set Classical
+open scoped Classical
+open Bundle Set
 open scoped Topology
 
 variable (R : Type*) {B : Type*} (F : Type*) (E : B → Type*)

--- a/Mathlib/Topology/VectorBundle/Constructions.lean
+++ b/Mathlib/Topology/VectorBundle/Constructions.lean
@@ -31,7 +31,8 @@ Vector bundle, direct sum, pullback
 
 noncomputable section
 
-open Bundle Set FiberBundle Classical
+open scoped Classical
+open Bundle Set FiberBundle
 
 /-! ### The trivial vector bundle -/
 

--- a/test/SplitIfs.lean
+++ b/test/SplitIfs.lean
@@ -65,7 +65,7 @@ example : True := by
   fail_if_success { split_ifs }
   trivial
 
-open Classical in
+open scoped Classical in
 example (P Q : Prop) (w : if P then (if Q then true else true) else true = true) : true := by
   split_ifs at w
   -- check that we've fully split w into three subgoals

--- a/test/Tauto.lean
+++ b/test/Tauto.lean
@@ -72,7 +72,7 @@ example (p : Prop) : p → ¬ (p → ¬ p) := by tauto
 example (p : Prop) (em : p ∨ ¬ p) : ¬ (p ↔ ¬ p) := by tauto
 
 -- reported at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/weird.20tactic.20bug/near/370505747
-open Classical in
+open scoped Classical in
 example (hp : p) (hq : q) : (if p ∧ q then 1 else 0) = 1 := by
   -- split_ifs creates a hypothesis with a type that's a metavariable
   split_ifs


### PR DESCRIPTION
We remove all but one `open Classical`s, instead preferring to use `open scoped Classical`. The only real side-effect this led to is moving a couple declarations to use `Exists.choose` instead of `Classical.choose`.

The first few commits are explicitly labelled regex replaces for ease of review.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
