### PR TITLE
[Merged by Bors] - feat: generalize `algHom_C`, add `killCompl_C`

### DIFF
--- a/Mathlib/Data/MvPolynomial/Basic.lean
+++ b/Mathlib/Data/MvPolynomial/Basic.lean
@@ -505,7 +505,7 @@ theorem algHom_ext {A : Type*} [Semiring A] [Algebra R A] {f g : MvPolynomial σ
 #align mv_polynomial.alg_hom_ext MvPolynomial.algHom_ext
 
 @[simp]
-theorem algHom_C (f : MvPolynomial σ R →ₐ[R] MvPolynomial σ R) (r : R) : f (C r) = C r :=
+theorem algHom_C (f : MvPolynomial σ R →ₐ[R] MvPolynomial τ R) (r : R) : f (C r) = C r :=
   f.commutes r
 #align mv_polynomial.alg_hom_C MvPolynomial.algHom_C
 

--- a/Mathlib/Data/MvPolynomial/Monad.lean
+++ b/Mathlib/Data/MvPolynomial/Monad.lean
@@ -168,9 +168,7 @@ set_option linter.uppercaseLean3 false in
 
 variable (f : σ → MvPolynomial τ R)
 
-@[simp]
-theorem bind₁_C_right (f : σ → MvPolynomial τ R) (x) : bind₁ f (C x) = C x := by
-  simp [bind₁, algebraMap_eq]
+theorem bind₁_C_right (f : σ → MvPolynomial τ R) (x) : bind₁ f (C x) = C x := algHom_C _ _
 set_option linter.uppercaseLean3 false in
 #align mv_polynomial.bind₁_C_right MvPolynomial.bind₁_C_right
 

--- a/Mathlib/Data/MvPolynomial/Rename.lean
+++ b/Mathlib/Data/MvPolynomial/Rename.lean
@@ -133,6 +133,11 @@ def killCompl : MvPolynomial τ R →ₐ[R] MvPolynomial σ R :=
   aeval fun i => if h : i ∈ Set.range f then X <| (Equiv.ofInjective f hf).symm ⟨i, h⟩ else 0
 #align mv_polynomial.kill_compl MvPolynomial.killCompl
 
+@[simp]
+theorem killCompl_C (r : R) : killCompl hf (C r) = C r := by
+  -- rw [algHom_C (killCompl _) r] -- Why doesn't this work?
+  simp only [killCompl, aeval_C, algebraMap_eq]
+
 theorem killCompl_comp_rename : (killCompl hf).comp (rename f) = AlgHom.id R _ :=
   algHom_ext fun i => by
     dsimp

--- a/Mathlib/Data/MvPolynomial/Rename.lean
+++ b/Mathlib/Data/MvPolynomial/Rename.lean
@@ -132,8 +132,7 @@ def killCompl : MvPolynomial τ R →ₐ[R] MvPolynomial σ R :=
   aeval fun i => if h : i ∈ Set.range f then X <| (Equiv.ofInjective f hf).symm ⟨i, h⟩ else 0
 #align mv_polynomial.kill_compl MvPolynomial.killCompl
 
-theorem killCompl_C (r : R) : killCompl hf (C r) = C r := by
-  simp [algHom_C]
+theorem killCompl_C (r : R) : killCompl hf (C r) = C r := algHom_C _ _
 
 theorem killCompl_comp_rename : (killCompl hf).comp (rename f) = AlgHom.id R _ :=
   algHom_ext fun i => by

--- a/Mathlib/Data/MvPolynomial/Rename.lean
+++ b/Mathlib/Data/MvPolynomial/Rename.lean
@@ -135,7 +135,6 @@ def killCompl : MvPolynomial τ R →ₐ[R] MvPolynomial σ R :=
 
 @[simp]
 theorem killCompl_C (r : R) : killCompl hf (C r) = C r := by
-  -- rw [algHom_C (killCompl _) r] -- Why doesn't this work?
   simp only [killCompl, aeval_C, algebraMap_eq]
 
 theorem killCompl_comp_rename : (killCompl hf).comp (rename f) = AlgHom.id R _ :=

--- a/Mathlib/Data/MvPolynomial/Rename.lean
+++ b/Mathlib/Data/MvPolynomial/Rename.lean
@@ -57,7 +57,6 @@ def rename (f : σ → τ) : MvPolynomial σ R →ₐ[R] MvPolynomial τ R :=
   aeval (X ∘ f)
 #align mv_polynomial.rename MvPolynomial.rename
 
-@[simp]
 theorem rename_C (f : σ → τ) (r : R) : rename f (C r) = C r :=
   eval₂_C _ _ _
 set_option linter.uppercaseLean3 false in
@@ -133,7 +132,6 @@ def killCompl : MvPolynomial τ R →ₐ[R] MvPolynomial σ R :=
   aeval fun i => if h : i ∈ Set.range f then X <| (Equiv.ofInjective f hf).symm ⟨i, h⟩ else 0
 #align mv_polynomial.kill_compl MvPolynomial.killCompl
 
-@[simp]
 theorem killCompl_C (r : R) : killCompl hf (C r) = C r := by
   simp [algHom_C]
 

--- a/Mathlib/Data/MvPolynomial/Rename.lean
+++ b/Mathlib/Data/MvPolynomial/Rename.lean
@@ -135,7 +135,7 @@ def killCompl : MvPolynomial τ R →ₐ[R] MvPolynomial σ R :=
 
 @[simp]
 theorem killCompl_C (r : R) : killCompl hf (C r) = C r := by
-  simp only [killCompl, aeval_C, algebraMap_eq]
+  simp [algHom_C]
 
 theorem killCompl_comp_rename : (killCompl hf).comp (rename f) = AlgHom.id R _ :=
   algHom_ext fun i => by


### PR DESCRIPTION
Generalizes `algHom_C` to work over polynomials of different variable types. Adds related lemma `killCompl_C` using this. Also removes simp tags from a few lemmas that are made redundant by this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
