### PR TITLE
[Merged by Bors] - feat(RingTheory/UniqueFactorizationDomain): add lemma UniqueFactorizationMonoid.IsPrime.exists_mem_Prime_of_neq_bot

### DIFF
--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -1183,6 +1183,11 @@ theorem IsPrime.prod_le {s : Finset ι} {f : ι → Ideal R} {P : Ideal R} (hp :
   hp.multiset_prod_map_le f
 #align ideal.is_prime.prod_le Ideal.IsPrime.prod_le
 
+theorem IsPrime.prod_mem_iff_exists_mem {I : Ideal R} (hI : I.IsPrime) (s : Finset R) :
+    s.prod (fun x ↦ x) ∈ I ↔ ∃ p ∈ s, p ∈ I := by
+  rw [Finset.prod_eq_multiset_prod, Multiset.map_id']
+  exact hI.multiset_prod_mem_iff_exists_mem s.val
+
 theorem IsPrime.inf_le' {s : Finset ι} {f : ι → Ideal R} {P : Ideal R} (hp : IsPrime P) :
     s.inf f ≤ P ↔ ∃ i ∈ s, f i ≤ P :=
   ⟨fun h ↦ hp.prod_le.1 <| prod_le_inf.trans h, fun ⟨_, his, hip⟩ ↦ (Finset.inf_le his).trans hip⟩

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -1174,6 +1174,10 @@ theorem IsPrime.multiset_prod_map_le {s : Multiset ι} (f : ι → Ideal R) {P :
   simp_rw [hp.multiset_prod_le, Multiset.mem_map, exists_exists_and_eq_and]
 #align ideal.is_prime.multiset_prod_map_le Ideal.IsPrime.multiset_prod_map_le
 
+theorem IsPrime.multiset_prod_mem_iff {I : Ideal R} (hI : I.IsPrime) (s : Multiset R) :
+    s.prod ∈ I ↔ ∃ p ∈ s, p ∈ I := by
+  simpa [← span_singleton_le_iff_mem] using (hI.multiset_prod_map_le (fun r ↦ span {r}))
+
 theorem IsPrime.prod_le {s : Finset ι} {f : ι → Ideal R} {P : Ideal R} (hp : IsPrime P) :
     s.prod f ≤ P ↔ ∃ i ∈ s, f i ≤ P :=
   hp.multiset_prod_map_le f

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -1176,7 +1176,7 @@ theorem IsPrime.multiset_prod_map_le {s : Multiset ι} (f : ι → Ideal R) {P :
 
 theorem IsPrime.multiset_prod_mem_iff {I : Ideal R} (hI : I.IsPrime) (s : Multiset R) :
     s.prod ∈ I ↔ ∃ p ∈ s, p ∈ I := by
-  simpa [← span_singleton_le_iff_mem] using (hI.multiset_prod_map_le (fun r ↦ span {r}))
+  simpa [span_singleton_le_iff_mem] using (hI.multiset_prod_map_le (span {·}))
 
 theorem IsPrime.prod_le {s : Finset ι} {f : ι → Ideal R} {P : Ideal R} (hp : IsPrime P) :
     s.prod f ≤ P ↔ ∃ i ∈ s, f i ≤ P :=

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -1174,7 +1174,7 @@ theorem IsPrime.multiset_prod_map_le {s : Multiset ι} (f : ι → Ideal R) {P :
   simp_rw [hp.multiset_prod_le, Multiset.mem_map, exists_exists_and_eq_and]
 #align ideal.is_prime.multiset_prod_map_le Ideal.IsPrime.multiset_prod_map_le
 
-theorem IsPrime.multiset_prod_mem_iff {I : Ideal R} (hI : I.IsPrime) (s : Multiset R) :
+theorem IsPrime.multiset_prod_mem_iff_exists_mem {I : Ideal R} (hI : I.IsPrime) (s : Multiset R) :
     s.prod ∈ I ↔ ∃ p ∈ s, p ∈ I := by
   simpa [span_singleton_le_iff_mem] using (hI.multiset_prod_map_le (span {·}))
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -588,7 +588,7 @@ theorem IsPrime.exists_mem_Prime_of_neq_bot {R : Type*} [CommSemiring R] [IsDoma
   obtain ⟨u, ha₃⟩ := factors_prod ha₂
   rw [← ha₃] at ha₁
   rcases (IsPrime.mem_or_mem hI₂) ha₁ with (ha₄ | ha₅)
-  · obtain ⟨p, ha₅, ha₆⟩ := (hI₂.multiset_prod_mem_iff (factors a)).1 ha₄  
+  · obtain ⟨p, ha₅, ha₆⟩ := (hI₂.multiset_prod_mem_iff (factors a)).1 ha₄
     exact ⟨p, ha₆, prime_of_factor p ha₅⟩
   · exfalso
     exact (isPrime_iff.1 hI₂).1 (eq_top_of_isUnit_mem _ ha₅ u.isUnit)

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -588,7 +588,7 @@ theorem IsPrime.exists_mem_Prime_of_neq_bot {R : Type*} [CommSemiring R] [IsDoma
   obtain ⟨u, ha₃⟩ := factors_prod ha₂
   rw [← ha₃] at ha₁
   rcases (IsPrime.mem_or_mem hI₂) ha₁ with (ha₄ | ha₅)
-  · rcases (hI₂.multiset_prod_mem_iff (factors a)).1 ha₄ with ⟨p, ha₅, ha₆⟩
+  · obtain ⟨p, ha₅, ha₆⟩ := (hI₂.multiset_prod_mem_iff (factors a)).1 ha₄  
     exact ⟨p, ha₆, prime_of_factor p ha₅⟩
   · exfalso
     exact (isPrime_iff.1 hI₂).1 (eq_top_of_isUnit_mem _ ha₅ u.isUnit)

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -588,7 +588,7 @@ theorem IsPrime.exists_mem_Prime_of_neq_bot {R : Type*} [CommSemiring R] [IsDoma
   obtain ⟨u, ha₃⟩ := factors_prod ha₂
   rw [← ha₃] at ha₁
   rcases (IsPrime.mem_or_mem hI₂) ha₁ with (ha₄ | ha₅)
-  · obtain ⟨p, ha₅, ha₆⟩ := (hI₂.multiset_prod_mem_iff (factors a)).1 ha₄
+  · obtain ⟨p, ha₅, ha₆⟩ := (hI₂.multiset_prod_mem_iff_exists_mem (factors a)).1 ha₄
     exact ⟨p, ha₆, prime_of_factor p ha₅⟩
   · exfalso
     exact (isPrime_iff.1 hI₂).1 (eq_top_of_isUnit_mem _ ha₅ u.isUnit)

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -581,7 +581,7 @@ open Ideal in
   /-- If an integral domain is a `UniqueFactorizationMonoid`, then every nonzero prime ideal
   contains a prime element. -/
 theorem IsPrime.exists_mem_Prime_of_neq_bot {R : Type*} [CommSemiring R] [IsDomain R]
-    [DecidableEq R] [UniqueFactorizationMonoid R] {I : Ideal R} (hI₂ : I.IsPrime) (hI : I ≠ ⊥) :
+    [UniqueFactorizationMonoid R] {I : Ideal R} (hI₂ : I.IsPrime) (hI : I ≠ ⊥) :
     ∃ x ∈ I, Prime x := by
   rcases Submodule.exists_mem_ne_zero_of_ne_bot hI with ⟨a, ha₁, ha₂⟩
   rcases factors_prod ha₂ with ⟨u, ha₃⟩

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -585,7 +585,7 @@ theorem IsPrime.exists_mem_Prime_of_neq_bot {R : Type*} [CommSemiring R] [IsDoma
     ∃ x ∈ I, Prime x := by
   classical
   obtain ⟨a, ha₁, ha₂⟩ := Submodule.exists_mem_ne_zero_of_ne_bot hI
-  rcases factors_prod ha₂ with ⟨u, ha₃⟩
+  obtain ⟨u, ha₃⟩ := factors_prod ha₂
   rw [← ha₃] at ha₁
   rcases (IsPrime.mem_or_mem hI₂) ha₁ with (ha₄ | ha₅)
   · rcases (hI₂.multiset_prod_mem_iff (factors a)).1 ha₄ with ⟨p, ha₅, ha₆⟩

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -578,7 +578,8 @@ theorem factors_pow_count_prod {x : α} (hx : x ≠ 0) :
   _ ~ᵤ x := factors_prod hx
 
 open Ideal in
-  /-- If an integral domain R is a UFD, then every nonzero prime ideal contains a prime element. -/
+  /-- If an integral domain is a `UniqueFactorizationMonoid`, then every nonzero prime ideal
+  contains a prime element. -/
 theorem IsPrime.exists_mem_Prime_of_neq_bot {R : Type*} [CommSemiring R] [IsDomain R]
     [DecidableEq R] [UniqueFactorizationMonoid R] {I : Ideal R} (hI₂ : I.IsPrime) (hI : I ≠ ⊥) :
     ∃ x ∈ I, Prime x := by

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -583,7 +583,8 @@ open Ideal in
 theorem IsPrime.exists_mem_Prime_of_neq_bot {R : Type*} [CommSemiring R] [IsDomain R]
     [UniqueFactorizationMonoid R] {I : Ideal R} (hI₂ : I.IsPrime) (hI : I ≠ ⊥) :
     ∃ x ∈ I, Prime x := by
-  rcases Submodule.exists_mem_ne_zero_of_ne_bot hI with ⟨a, ha₁, ha₂⟩
+  classical
+  obtain ⟨a, ha₁, ha₂⟩ := Submodule.exists_mem_ne_zero_of_ne_bot hI
   rcases factors_prod ha₂ with ⟨u, ha₃⟩
   rw [← ha₃] at ha₁
   rcases (IsPrime.mem_or_mem hI₂) ha₁ with (ha₄ | ha₅)

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -577,6 +577,20 @@ theorem factors_pow_count_prod {x : α} (hx : x ≠ 0) :
   _ = prod (factors x) := by rw [toFinset_sum_count_nsmul_eq (factors x)]
   _ ~ᵤ x := factors_prod hx
 
+open Ideal in
+  /-- If an integral domain R is a UFD, then every nonzero prime ideal contains a prime element. -/
+theorem exists_prime_of_uniqueFactorizationMonoid {R : Type*} [CommSemiring R] [IsDomain R]
+    [DecidableEq R] [UniqueFactorizationMonoid R] {I : Ideal R}
+    (hI : I ≠ ⊥) (hI₂ : I.IsPrime) : ∃ x ∈ I, Prime x := by
+  rcases Submodule.exists_mem_ne_zero_of_ne_bot hI with ⟨a, ha₁, ha₂⟩
+  rcases factors_prod ha₂ with ⟨u, ha₃⟩
+  rw [← ha₃] at ha₁
+  rcases (IsPrime.mem_or_mem hI₂) ha₁ with (ha₄ | ha₅)
+  · rcases (hI₂.multiset_prod_mem_iff (factors a)).1 ha₄ with ⟨p, ha₅, ha₆⟩
+    exact ⟨p, ha₆, prime_of_factor p ha₅⟩
+  · exfalso
+    exact (isPrime_iff.1 hI₂).1 (eq_top_of_isUnit_mem _ ha₅ u.isUnit)
+
 end UniqueFactorizationMonoid
 
 namespace UniqueFactorizationMonoid

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -579,9 +579,9 @@ theorem factors_pow_count_prod {x : α} (hx : x ≠ 0) :
 
 open Ideal in
   /-- If an integral domain R is a UFD, then every nonzero prime ideal contains a prime element. -/
-theorem exists_prime_of_uniqueFactorizationMonoid {R : Type*} [CommSemiring R] [IsDomain R]
-    [DecidableEq R] [UniqueFactorizationMonoid R] {I : Ideal R}
-    (hI : I ≠ ⊥) (hI₂ : I.IsPrime) : ∃ x ∈ I, Prime x := by
+theorem IsPrime.exists_mem_Prime_of_neq_bot {R : Type*} [CommSemiring R] [IsDomain R]
+    [DecidableEq R] [UniqueFactorizationMonoid R] {I : Ideal R} (hI₂ : I.IsPrime) (hI : I ≠ ⊥) :
+    ∃ x ∈ I, Prime x := by
   rcases Submodule.exists_mem_ne_zero_of_ne_bot hI with ⟨a, ha₁, ha₂⟩
   rcases factors_prod ha₂ with ⟨u, ha₃⟩
   rw [← ha₃] at ha₁

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -577,22 +577,6 @@ theorem factors_pow_count_prod {x : α} (hx : x ≠ 0) :
   _ = prod (factors x) := by rw [toFinset_sum_count_nsmul_eq (factors x)]
   _ ~ᵤ x := factors_prod hx
 
-open Ideal in
-  /-- If an integral domain is a `UniqueFactorizationMonoid`, then every nonzero prime ideal
-  contains a prime element. -/
-theorem IsPrime.exists_mem_Prime_of_neq_bot {R : Type*} [CommSemiring R] [IsDomain R]
-    [UniqueFactorizationMonoid R] {I : Ideal R} (hI₂ : I.IsPrime) (hI : I ≠ ⊥) :
-    ∃ x ∈ I, Prime x := by
-  classical
-  obtain ⟨a, ha₁, ha₂⟩ := Submodule.exists_mem_ne_zero_of_ne_bot hI
-  obtain ⟨u, ha₃⟩ := factors_prod ha₂
-  rw [← ha₃] at ha₁
-  rcases (IsPrime.mem_or_mem hI₂) ha₁ with (ha₄ | ha₅)
-  · obtain ⟨p, ha₅, ha₆⟩ := (hI₂.multiset_prod_mem_iff_exists_mem (factors a)).1 ha₄
-    exact ⟨p, ha₆, prime_of_factor p ha₅⟩
-  · exfalso
-    exact (isPrime_iff.1 hI₂).1 (eq_top_of_isUnit_mem _ ha₅ u.isUnit)
-
 end UniqueFactorizationMonoid
 
 namespace UniqueFactorizationMonoid
@@ -2090,3 +2074,17 @@ theorem associated_of_factorization_eq (a b : α) (ha : a ≠ 0) (hb : b ≠ 0)
 #align associated_of_factorization_eq associated_of_factorization_eq
 
 end Finsupp
+
+open UniqueFactorizationMonoid in
+/-- Every non-zero prime ideal in a unique factorization domain contains a prime element. -/
+theorem Ideal.IsPrime.exists_mem_prime_of_ne_bot {R : Type*} [CommSemiring R] [IsDomain R]
+    [UniqueFactorizationMonoid R] {I : Ideal R} (hI₂ : I.IsPrime) (hI : I ≠ ⊥) :
+    ∃ x ∈ I, Prime x := by
+  classical
+  obtain ⟨a : R, ha₁ : a ∈ I, ha₂ : a ≠ 0⟩ := Submodule.exists_mem_ne_zero_of_ne_bot hI
+  replace ha₁ : (factors a).prod ∈ I := by
+    obtain ⟨u : Rˣ, hu : (factors a).prod * u = a⟩ := factors_prod ha₂
+    rwa [← hu, mul_unit_mem_iff_mem _ u.isUnit] at ha₁
+  obtain ⟨p : R, hp₁ : p ∈ factors a, hp₂ : p ∈ I⟩ :=
+    (hI₂.multiset_prod_mem_iff_exists_mem <| factors a).1 ha₁
+  exact ⟨p, hp₂, prime_of_factor p hp₁⟩


### PR DESCRIPTION
We add `UniqueFactorizationMonoid.IsPrime.exists_mem_Prime_of_neq_bot`: if an integral domain is a `UniqueFactorizationMonoid`, then every nonzero prime ideal contains a prime element.

We plan to add the other implication (known as Kaplansky's criterion) in a future PR. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
