### PR TITLE
[Merged by Bors] - chore: add shortcut `T2Space ℂ` instance

### DIFF
--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -238,6 +238,8 @@ theorem uniformEmbedding_equivRealProd : UniformEmbedding equivRealProd :=
 instance : CompleteSpace ℂ :=
   (completeSpace_congr uniformEmbedding_equivRealProd).mpr inferInstance
 
+instance instT2Space : T2Space ℂ := TopologicalSpace.t2Space_of_metrizableSpace
+
 /-- The natural `ContinuousLinearEquiv` from `ℂ` to `ℝ × ℝ`. -/
 @[simps! (config := { simpRhs := true }) apply symm_apply_re symm_apply_im]
 def equivRealProdCLM : ℂ ≃L[ℝ] ℝ × ℝ :=


### PR DESCRIPTION
This adds a shortcut instance for `T2Space ℂ` in `Analysis.Complex.Basic`.

See [this thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.22.23synth.20T2Space.20.E2.84.82.22.20fails/near/425351881) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
