### PR TITLE
[Merged by Bors] - chore: classify `deprecated` porting notes

### DIFF
--- a/Mathlib/Data/PNat/Basic.lean
+++ b/Mathlib/Data/PNat/Basic.lean
@@ -181,7 +181,7 @@ theorem bot_eq_one : (⊥ : ℕ+) = 1 :=
   rfl
 #align pnat.bot_eq_one PNat.bot_eq_one
 
--- Porting note: deprecated
+-- Porting note (#11229): deprecated
 section deprecated
 
 set_option linter.deprecated false
@@ -256,7 +256,7 @@ theorem lt_add_right (n m : ℕ+) : n < n + m :=
   (lt_add_left n m).trans_eq (add_comm _ _)
 #align pnat.lt_add_right PNat.lt_add_right
 
--- Porting note: deprecated
+-- Porting note (#11229): deprecated
 section deprecated
 
 set_option linter.deprecated false

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -538,7 +538,7 @@ instance commSemiring : CommSemiring Cardinal.{u} where
   natCast_zero := rfl
   natCast_succ := Cardinal.cast_succ
 
-/-! Porting note: Deprecated section. Remove. -/
+/-! Porting note (#11229): Deprecated section. Remove. -/
 section deprecated
 set_option linter.deprecated false
 
@@ -618,7 +618,7 @@ theorem lift_mul (a b : Cardinal.{u}) : lift.{v} (a * b) = lift.{v} a * lift.{v}
     mk_congr <| Equiv.ulift.trans (Equiv.prodCongr Equiv.ulift Equiv.ulift).symm
 #align cardinal.lift_mul Cardinal.lift_mul
 
-/-! Porting note: Deprecated section. Remove. -/
+/-! Porting note (#11229): Deprecated section. Remove. -/
 section deprecated
 set_option linter.deprecated false
 


### PR DESCRIPTION
Classifies by adding issue number #11229 to porting notes claiming: 

> deprecated