### PR TITLE
[Merged by Bors] - fix(slim_check): do not crash when binders contain a function type

### DIFF
--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -510,7 +510,7 @@ quantifiers and add `NamedBinder` annotations next to them. -/
 partial def addDecorations (e : Expr) : MetaM Expr :=
   Meta.transform e fun expr => do
     if not (← Meta.inferType expr).isProp then
-      return .continue
+      return .done expr
     else if let Expr.forallE name type body data := expr then
       let newType ← addDecorations type
       let newBody ← Meta.withLocalDecl name data type fun fvar => do

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -509,7 +509,7 @@ open Lean
 quantifiers and add `NamedBinder` annotations next to them. -/
 partial def addDecorations (e : Expr) : MetaM Expr :=
   Meta.transform e fun expr => do
-    if not (← Meta.inferType e).isProp then
+    if not (← Meta.inferType expr).isProp then
       return .continue
     else if let Expr.forallE name type body data := expr then
       let newType ← addDecorations type

--- a/test/slim_check.lean
+++ b/test/slim_check.lean
@@ -413,6 +413,21 @@ issue: ⋯ does not hold
     exact test_sorry
   trivial
 
+open scoped BigOperators in
+example (n : ℕ) : true := by
+  have : ∑ f : Unit → Fin (n + 1), f () = 0 := by
+    success_if_fail_with_msg "
+===================
+Found problems!
+n := 1
+issue: 1 = 0 does not hold
+(0 shrinks)
+-------------------
+"
+      slim_check (config := { randomSeed := some 257 })
+    exact test_sorry
+  trivial
+
 -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/slim_check.20question/near/412709012
 open scoped BigOperators in
 /--


### PR DESCRIPTION
Previously
```lean
import Mathlib

open scoped BigOperators in
example (n : ℕ) : ∑ f : Unit → Fin (n + 1), f () = 0 := by slim_check
```
failed with
```
application type mismatch
  SlimCheck.NamedBinder "a._@._hyg.23" (Unit → Fin (n + 1))
argument
  Unit → Fin (n + 1)
has type
  Type : Type 1
but is expected to have type
  Prop : Type
```


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
