### PR TITLE
[Merged by Bors] - fix(LinearAlgebra/Projectivization/Independence): use DivisionRing instead of Field

### DIFF
--- a/Mathlib/LinearAlgebra/Projectivization/Independence.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Independence.lean
@@ -32,7 +32,7 @@ ambient vector space. Similarly for the definition of dependence.
 
 open scoped LinearAlgebra.Projectivization
 
-variable {ι K V : Type*} [Field K] [AddCommGroup V] [Module K V] {f : ι → ℙ K V}
+variable {ι K V : Type*} [DivisionRing K] [AddCommGroup V] [Module K V] {f : ι → ℙ K V}
 
 namespace Projectivization
 


### PR DESCRIPTION
I need $K$ to be a skew field instead of a field to prove that projectivization of a vector space is a projective geometry stated in proposition 2.1.6 in the book "Modern Projective Geometry" by Claude-Alain Faure and Alfred Frölicher, see p. 27-28. In p.27, just before the proposition, it is noted that "... $K$ is allowed to be a skew field (often called *division ring*)."

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
