### PR TITLE
[Merged by Bors] - fix: restore `ext1?`/`ext?` (deleted upstream) as syntax stubs

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -163,6 +163,11 @@ open Lean Parser.Tactic
 /- S -/ syntax (name := elide) "elide " num (location)? : tactic
 /- S -/ syntax (name := unelide) "unelide" (location)? : tactic
 
+/-- `ext1? pat*` is like `ext1 pat*` but gives a suggestion on what pattern to use -/
+/- M -/ syntax (name := ext1?) "ext1?" (colGt ppSpace rintroPat)* : tactic
+/-- `ext? pat*` is like `ext pat*` but gives a suggestion on what pattern to use -/
+/- M -/ syntax (name := ext?) "ext?" (colGt ppSpace rintroPat)* (" : " num)? : tactic
+
 /- S -/ syntax (name := clarify) "clarify" (config)?
   (Parser.Tactic.simpArgs)? (" using " term,+)? : tactic
 /- S -/ syntax (name := safe) "safe" (config)?


### PR DESCRIPTION
Fixing mathport breakage.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
