### PR TITLE
[Merged by Bors] - chore(Order): add missing `inst` prefix to instance names

### DIFF
--- a/Mathlib/Algebra/Order/Kleene.lean
+++ b/Mathlib/Algebra/Order/Kleene.lean
@@ -288,7 +288,7 @@ end KleeneAlgebra
 namespace Prod
 
 instance instIdemSemiring [IdemSemiring α] [IdemSemiring β] : IdemSemiring (α × β) :=
-  { Prod.instSemiring, Prod.semilatticeSup _ _, Prod.orderBot _ _ with
+  { Prod.instSemiring, Prod.instSemilatticeSup _ _, Prod.instOrderBot _ _ with
     add_eq_sup := fun _ _ ↦ ext (add_eq_sup _ _) (add_eq_sup _ _) }
 
 instance [IdemCommSemiring α] [IdemCommSemiring β] : IdemCommSemiring (α × β) :=
@@ -324,7 +324,7 @@ end Prod
 namespace Pi
 
 instance instIdemSemiring [∀ i, IdemSemiring (π i)] : IdemSemiring (∀ i, π i) :=
-  { Pi.semiring, Pi.semilatticeSup, Pi.orderBot with
+  { Pi.semiring, Pi.instSemilatticeSup, Pi.instOrderBot with
     add_eq_sup := fun _ _ ↦ funext fun _ ↦ add_eq_sup _ _ }
 
 instance [∀ i, IdemCommSemiring (π i)] : IdemCommSemiring (∀ i, π i) :=

--- a/Mathlib/Algebra/Order/Nonneg/Ring.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Ring.lean
@@ -336,7 +336,7 @@ instance canonicallyOrderedCommSemiring [OrderedCommRing α] [NoZeroDivisors α]
 
 instance canonicallyLinearOrderedAddCommMonoid [LinearOrderedRing α] :
     CanonicallyLinearOrderedAddCommMonoid { x : α // 0 ≤ x } :=
-  { Subtype.linearOrder _, Nonneg.canonicallyOrderedAddCommMonoid with }
+  { Subtype.instLinearOrder _, Nonneg.canonicallyOrderedAddCommMonoid with }
 #align nonneg.canonically_linear_ordered_add_monoid Nonneg.canonicallyLinearOrderedAddCommMonoid
 
 section LinearOrder

--- a/Mathlib/Algebra/Order/Pi.lean
+++ b/Mathlib/Algebra/Order/Pi.lean
@@ -51,7 +51,7 @@ instance existsMulOfLe {ι : Type*} {α : ι → Type*} [∀ i, LE (α i)] [∀ 
 a canonically ordered additive monoid."]
 instance {ι : Type*} {Z : ι → Type*} [∀ i, CanonicallyOrderedCommMonoid (Z i)] :
     CanonicallyOrderedCommMonoid (∀ i, Z i) where
-  __ := Pi.orderBot
+  __ := Pi.instOrderBot
   __ := Pi.orderedCommMonoid
   __ := Pi.existsMulOfLe
   le_self_mul _ _ := fun _ => le_self_mul

--- a/Mathlib/Algebra/Order/Positive/Ring.lean
+++ b/Mathlib/Algebra/Order/Positive/Ring.lean
@@ -146,7 +146,7 @@ instance orderedCommMonoid [StrictOrderedCommSemiring R] [Nontrivial R] :
 ordered cancellative commutative monoid. -/
 instance linearOrderedCancelCommMonoid [LinearOrderedCommSemiring R] :
     LinearOrderedCancelCommMonoid { x : R // 0 < x } :=
-  { Subtype.linearOrder _, Positive.orderedCommMonoid with
+  { Subtype.instLinearOrder _, Positive.orderedCommMonoid with
     le_of_mul_le_mul_left := fun a _ _ h => Subtype.coe_le_coe.1 <| (mul_le_mul_left a.2).1 h }
 #align positive.subtype.linear_ordered_cancel_comm_monoid Positive.linearOrderedCancelCommMonoid
 

--- a/Mathlib/Algebra/PUnitInstances.lean
+++ b/Mathlib/Algebra/PUnitInstances.lean
@@ -114,19 +114,19 @@ theorem norm_unit_eq {x : PUnit} : normUnit x = 1 :=
 
 instance canonicallyOrderedAddCommMonoid : CanonicallyOrderedAddCommMonoid PUnit := by
   refine'
-    { PUnit.commRing, PUnit.completeBooleanAlgebra with
+    { PUnit.commRing, PUnit.instCompleteBooleanAlgebra with
       exists_add_of_le := fun {_ _} _ => ⟨unit, Subsingleton.elim _ _⟩.. } <;>
     intros <;>
     trivial
 
 instance linearOrderedCancelAddCommMonoid : LinearOrderedCancelAddCommMonoid PUnit where
   __ := PUnit.canonicallyOrderedAddCommMonoid
-  __ := PUnit.linearOrder
+  __ := PUnit.instLinearOrder
   le_of_add_le_add_left _ _ _ _ := trivial
   add_le_add_left := by intros; rfl
 
 instance : LinearOrderedAddCommMonoidWithTop PUnit :=
-  { PUnit.completeBooleanAlgebra, PUnit.linearOrderedCancelAddCommMonoid with
+  { PUnit.instCompleteBooleanAlgebra, PUnit.linearOrderedCancelAddCommMonoid with
     top_add' := fun _ => rfl }
 
 @[to_additive]

--- a/Mathlib/Analysis/Normed/Order/Lattice.lean
+++ b/Mathlib/Analysis/Normed/Order/Lattice.lean
@@ -107,8 +107,9 @@ theorem dual_solid (a b : α) (h : b ⊓ -b ≤ a ⊓ -a) : ‖a‖ ≤ ‖b‖ 
 /-- Let `α` be a normed lattice ordered group, then the order dual is also a
 normed lattice ordered group.
 -/
-instance (priority := 100) OrderDual.normedLatticeAddCommGroup : NormedLatticeAddCommGroup αᵒᵈ :=
-  { OrderDual.orderedAddCommGroup, OrderDual.normedAddCommGroup, OrderDual.lattice α with
+instance (priority := 100) OrderDual.instNormedLatticeAddCommGroup :
+    NormedLatticeAddCommGroup αᵒᵈ :=
+  { OrderDual.orderedAddCommGroup, OrderDual.normedAddCommGroup, OrderDual.instLattice α with
     solid := dual_solid (α := α) }
 
 theorem norm_abs_eq_norm (a : α) : ‖|a|‖ = ‖a‖ :=

--- a/Mathlib/Data/Nat/Order/Lemmas.lean
+++ b/Mathlib/Data/Nat/Order/Lemmas.lean
@@ -36,7 +36,7 @@ instance Subtype.orderBot (s : Set ℕ) [DecidablePred (· ∈ s)] [h : Nonempty
 #align nat.subtype.order_bot Nat.Subtype.orderBot
 
 instance Subtype.semilatticeSup (s : Set ℕ) : SemilatticeSup s :=
-  { Subtype.linearOrder s, LinearOrder.toLattice with }
+  { Subtype.instLinearOrder s, LinearOrder.toLattice with }
 #align nat.subtype.semilattice_sup Nat.Subtype.semilatticeSup
 
 theorem Subtype.coe_bot {s : Set ℕ} [DecidablePred (· ∈ s)] [h : Nonempty s] :

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -460,6 +460,5 @@ theorem Quot.subsingleton_iff (r : α → α → Prop) : Subsingleton (Quot r) �
   refine' (surjective_quot_mk _).forall.trans (forall_congr' fun a => _)
   refine' (surjective_quot_mk _).forall.trans (forall_congr' fun b => _)
   rw [Quot.eq]
-  simp only [forall_const, le_Prop_eq, OrderTop.toTop, Pi.orderTop, Pi.top_apply,
-             Prop.top_eq_true, true_implies]
+  simp only [forall_const, le_Prop_eq, Pi.top_apply, Prop.top_eq_true, true_implies]
 #align quot.subsingleton_iff Quot.subsingleton_iff

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -1247,7 +1247,7 @@ instance decidableLT [Preorder α] [h : @DecidableRel α (· < ·)] {p : α → 
 /-- A subtype of a linear order is a linear order. We explicitly give the proofs of decidable
 equality and decidable order in order to ensure the decidability instances are all definitionally
 equal. -/
-instance linearOrder [LinearOrder α] (p : α → Prop) : LinearOrder (Subtype p) :=
+instance instLinearOrder [LinearOrder α] (p : α → Prop) : LinearOrder (Subtype p) :=
   @LinearOrder.lift (Subtype p) _ _ ⟨fun x y ↦ ⟨max x y, max_rec' _ x.2 y.2⟩⟩
     ⟨fun x y ↦ ⟨min x y, min_rec' _ x.2 y.2⟩⟩ (fun (a : Subtype p) ↦ (a : α))
     Subtype.coe_injective (fun _ _ ↦ rfl) fun _ _ ↦
@@ -1432,7 +1432,7 @@ namespace PUnit
 
 variable (a b : PUnit.{u + 1})
 
-instance linearOrder : LinearOrder PUnit where
+instance instLinearOrder : LinearOrder PUnit where
   le  := fun _ _ ↦ True
   lt  := fun _ _ ↦ False
   max := fun _ _ ↦ unit

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -727,9 +727,9 @@ theorem compl_le_iff_compl_le : xᶜ ≤ y ↔ yᶜ ≤ x :=
 theorem sdiff_compl : x \ yᶜ = x ⊓ y := by rw [sdiff_eq, compl_compl]
 #align sdiff_compl sdiff_compl
 
-instance OrderDual.booleanAlgebra (α) [BooleanAlgebra α] : BooleanAlgebra αᵒᵈ where
-  __ := OrderDual.distribLattice α
-  __ := OrderDual.boundedOrder α
+instance OrderDual.instBooleanAlgebra (α) [BooleanAlgebra α] : BooleanAlgebra αᵒᵈ where
+  __ := OrderDual.instDistribLattice α
+  __ := OrderDual.instBoundedOrder α
   compl a := toDual (ofDual aᶜ)
   sdiff a b := toDual (ofDual b ⇨ ofDual a); himp := fun a b => toDual (ofDual b \ ofDual a)
   inf_compl_le_bot a := (@codisjoint_hnot_right _ _ (ofDual a)).top_le
@@ -789,38 +789,38 @@ lemma himp_ne_right : x ⇨ y ≠ x ↔ x ≠ ⊤ ∨ y ≠ ⊤ := himp_eq_left.
 
 end BooleanAlgebra
 
-instance Prop.booleanAlgebra : BooleanAlgebra Prop where
-  __ := Prop.heytingAlgebra
+instance Prop.instBooleanAlgebra : BooleanAlgebra Prop where
+  __ := Prop.instHeytingAlgebra
   __ := GeneralizedHeytingAlgebra.toDistribLattice
   compl := Not
   himp_eq p q := propext imp_iff_or_not
   inf_compl_le_bot p H := H.2 H.1
   top_le_sup_compl p _ := Classical.em p
-#align Prop.boolean_algebra Prop.booleanAlgebra
+#align Prop.boolean_algebra Prop.instBooleanAlgebra
 
-instance Prod.booleanAlgebra (α β) [BooleanAlgebra α] [BooleanAlgebra β] :
+instance Prod.instBooleanAlgebra (α β) [BooleanAlgebra α] [BooleanAlgebra β] :
     BooleanAlgebra (α × β) where
-  __ := Prod.heytingAlgebra
-  __ := Prod.distribLattice α β
+  __ := Prod.instHeytingAlgebra
+  __ := Prod.instDistribLattice α β
   himp_eq x y := by ext <;> simp [himp_eq]
   sdiff_eq x y := by ext <;> simp [sdiff_eq]
   inf_compl_le_bot x := by constructor <;> simp
   top_le_sup_compl x := by constructor <;> simp
 
-instance Pi.booleanAlgebra {ι : Type u} {α : ι → Type v} [∀ i, BooleanAlgebra (α i)] :
+instance Pi.instBooleanAlgebra {ι : Type u} {α : ι → Type v} [∀ i, BooleanAlgebra (α i)] :
     BooleanAlgebra (∀ i, α i) where
   __ := Pi.sdiff
-  __ := Pi.heytingAlgebra
-  __ := @Pi.distribLattice ι α _
+  __ := Pi.instHeytingAlgebra
+  __ := @Pi.instDistribLattice ι α _
   sdiff_eq _ _ := funext fun _ => sdiff_eq
   himp_eq _ _ := funext fun _ => himp_eq
   inf_compl_le_bot _ _ := BooleanAlgebra.inf_compl_le_bot _
   top_le_sup_compl _ _ := BooleanAlgebra.top_le_sup_compl _
-#align pi.boolean_algebra Pi.booleanAlgebra
+#align pi.boolean_algebra Pi.instBooleanAlgebra
 
 instance Bool.instBooleanAlgebra : BooleanAlgebra Bool where
   __ := Bool.linearOrder
-  __ := Bool.boundedOrder
+  __ := Bool.instBoundedOrder
   __ := Bool.instDistribLattice
   compl := not
   inf_compl_le_bot a := a.and_not_self.le
@@ -879,7 +879,7 @@ protected def Function.Injective.booleanAlgebra [Sup α] [Inf α] [Top α] [Bot 
 
 end lift
 
-instance PUnit.booleanAlgebra : BooleanAlgebra PUnit := by
+instance PUnit.instBooleanAlgebra : BooleanAlgebra PUnit := by
   refine'
-  { PUnit.biheytingAlgebra with
+  { PUnit.instBiheytingAlgebra with
     .. } <;> (intros; trivial)

--- a/Mathlib/Order/BoundedOrder.lean
+++ b/Mathlib/Order/BoundedOrder.lean
@@ -235,17 +235,17 @@ namespace OrderDual
 
 variable (α)
 
-instance top [Bot α] : Top αᵒᵈ :=
+instance instTop [Bot α] : Top αᵒᵈ :=
   ⟨(⊥ : α)⟩
 
-instance bot [Top α] : Bot αᵒᵈ :=
+instance instBot [Top α] : Bot αᵒᵈ :=
   ⟨(⊤ : α)⟩
 
-instance orderTop [LE α] [OrderBot α] : OrderTop αᵒᵈ where
+instance instOrderTop [LE α] [OrderBot α] : OrderTop αᵒᵈ where
   __ := inferInstanceAs (Top αᵒᵈ)
   le_top := @bot_le α _ _
 
-instance orderBot [LE α] [OrderTop α] : OrderBot αᵒᵈ where
+instance instOrderBot [LE α] [OrderTop α] : OrderBot αᵒᵈ where
   __ := inferInstanceAs (Bot αᵒᵈ)
   bot_le := @le_top α _ _
 
@@ -475,7 +475,7 @@ end SemilatticeInfBot
 class BoundedOrder (α : Type u) [LE α] extends OrderTop α, OrderBot α
 #align bounded_order BoundedOrder
 
-instance OrderDual.boundedOrder (α : Type u) [LE α] [BoundedOrder α] : BoundedOrder αᵒᵈ where
+instance OrderDual.instBoundedOrder (α : Type u) [LE α] [BoundedOrder α] : BoundedOrder αᵒᵈ where
   __ := inferInstanceAs (OrderTop αᵒᵈ)
   __ := inferInstanceAs (OrderBot αᵒᵈ)
 
@@ -618,13 +618,14 @@ theorem top_def [∀ i, Top (α' i)] : (⊤ : ∀ i, α' i) = fun _ => ⊤ :=
   rfl
 #align pi.top_def Pi.top_def
 
-instance orderTop [∀ i, LE (α' i)] [∀ i, OrderTop (α' i)] : OrderTop (∀ i, α' i) where
+instance instOrderTop [∀ i, LE (α' i)] [∀ i, OrderTop (α' i)] : OrderTop (∀ i, α' i) where
   le_top _ := fun _ => le_top
 
-instance orderBot [∀ i, LE (α' i)] [∀ i, OrderBot (α' i)] : OrderBot (∀ i, α' i) where
+instance instOrderBot [∀ i, LE (α' i)] [∀ i, OrderBot (α' i)] : OrderBot (∀ i, α' i) where
   bot_le _ := fun _ => bot_le
 
-instance boundedOrder [∀ i, LE (α' i)] [∀ i, BoundedOrder (α' i)] : BoundedOrder (∀ i, α' i) where
+instance instBoundedOrder [∀ i, LE (α' i)] [∀ i, BoundedOrder (α' i)] :
+    BoundedOrder (∀ i, α' i) where
   __ := inferInstanceAs (OrderTop (∀ i, α' i))
   __ := inferInstanceAs (OrderBot (∀ i, α' i))
 
@@ -777,10 +778,10 @@ namespace Prod
 
 variable (α β)
 
-instance top [Top α] [Top β] : Top (α × β) :=
+instance instTop [Top α] [Top β] : Top (α × β) :=
   ⟨⟨⊤, ⊤⟩⟩
 
-instance bot [Bot α] [Bot β] : Bot (α × β) :=
+instance instBot [Bot α] [Bot β] : Bot (α × β) :=
   ⟨⟨⊥, ⊥⟩⟩
 
 theorem fst_top [Top α] [Top β] : (⊤ : α × β).fst = ⊤ := rfl
@@ -788,15 +789,16 @@ theorem snd_top [Top α] [Top β] : (⊤ : α × β).snd = ⊤ := rfl
 theorem fst_bot [Bot α] [Bot β] : (⊥ : α × β).fst = ⊥ := rfl
 theorem snd_bot [Bot α] [Bot β] : (⊥ : α × β).snd = ⊥ := rfl
 
-instance orderTop [LE α] [LE β] [OrderTop α] [OrderTop β] : OrderTop (α × β) where
+instance instOrderTop [LE α] [LE β] [OrderTop α] [OrderTop β] : OrderTop (α × β) where
   __ := inferInstanceAs (Top (α × β))
   le_top _ := ⟨le_top, le_top⟩
 
-instance orderBot [LE α] [LE β] [OrderBot α] [OrderBot β] : OrderBot (α × β) where
+instance instOrderBot [LE α] [LE β] [OrderBot α] [OrderBot β] : OrderBot (α × β) where
   __ := inferInstanceAs (Bot (α × β))
   bot_le _ := ⟨bot_le, bot_le⟩
 
-instance boundedOrder [LE α] [LE β] [BoundedOrder α] [BoundedOrder β] : BoundedOrder (α × β) where
+instance instBoundedOrder [LE α] [LE β] [BoundedOrder α] [BoundedOrder β] :
+    BoundedOrder (α × β) where
   __ := inferInstanceAs (OrderTop (α × β))
   __ := inferInstanceAs (OrderBot (α × β))
 
@@ -899,7 +901,7 @@ section Bool
 
 open Bool
 
-instance Bool.boundedOrder : BoundedOrder Bool where
+instance Bool.instBoundedOrder : BoundedOrder Bool where
   top := true
   le_top := Bool.le_true
   bot := false

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -187,10 +187,10 @@ section Frame
 
 variable [Frame α] {s t : Set α} {a b : α}
 
-instance OrderDual.coframe : Coframe αᵒᵈ where
-  __ := OrderDual.completeLattice α
+instance OrderDual.instCoframe : Coframe αᵒᵈ where
+  __ := OrderDual.instCompleteLattice α
   iInf_sup_le_sup_sInf := @Frame.inf_sSup_le_iSup_inf α _
-#align order_dual.coframe OrderDual.coframe
+#align order_dual.coframe OrderDual.instCoframe
 
 theorem inf_sSup_eq : a ⊓ sSup s = ⨆ b ∈ s, a ⊓ b :=
   (Frame.inf_sSup_le_iSup_inf _ _).antisymm iSup_inf_le_inf_sSup
@@ -208,8 +208,8 @@ theorem inf_iSup_eq (a : α) (f : ι → α) : (a ⊓ ⨆ i, f i) = ⨆ i, a ⊓
   simpa only [inf_comm] using iSup_inf_eq f a
 #align inf_supr_eq inf_iSup_eq
 
-instance Prod.frame (α β) [Frame α] [Frame β] : Frame (α × β) where
-  __ := Prod.completeLattice α β
+instance Prod.instFrame (α β) [Frame α] [Frame β] : Frame (α × β) where
+  __ := Prod.instCompleteLattice α β
   inf_sSup_le_iSup_inf a s := by
     simp [Prod.le_def, sSup_eq_iSup, fst_iSup, snd_iSup, fst_iInf, snd_iInf, inf_iSup_eq]
 
@@ -278,11 +278,11 @@ theorem iSup_inf_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (swap (·
   @iSup_inf_of_monotone α _ ιᵒᵈ _ _ f g hf.dual_left hg.dual_left
 #align supr_inf_of_antitone iSup_inf_of_antitone
 
-instance Pi.frame {ι : Type*} {π : ι → Type*} [∀ i, Frame (π i)] : Frame (∀ i, π i) where
-  __ := Pi.completeLattice
+instance Pi.instFrame {ι : Type*} {π : ι → Type*} [∀ i, Frame (π i)] : Frame (∀ i, π i) where
+  __ := Pi.instCompleteLattice
   inf_sSup_le_iSup_inf a s := fun i => by
     simp only [sSup_apply, iSup_apply, inf_apply, inf_iSup_eq, ← iSup_subtype'']; rfl
-#align pi.frame Pi.frame
+#align pi.frame Pi.instFrame
 
 -- see Note [lower instance priority]
 instance (priority := 100) Frame.toDistribLattice : DistribLattice α :=
@@ -296,10 +296,10 @@ section Coframe
 
 variable [Coframe α] {s t : Set α} {a b : α}
 
-instance OrderDual.frame : Frame αᵒᵈ where
-  __ := OrderDual.completeLattice α
+instance OrderDual.instFrame : Frame αᵒᵈ where
+  __ := OrderDual.instCompleteLattice α
   inf_sSup_le_iSup_inf := @Coframe.iInf_sup_le_sup_sInf α _
-#align order_dual.frame OrderDual.frame
+#align order_dual.frame OrderDual.instFrame
 
 theorem sup_sInf_eq : a ⊔ sInf s = ⨅ b ∈ s, a ⊔ b :=
   @inf_sSup_eq αᵒᵈ _ _ _
@@ -317,8 +317,8 @@ theorem sup_iInf_eq (a : α) (f : ι → α) : (a ⊔ ⨅ i, f i) = ⨅ i, a ⊔
   @inf_iSup_eq αᵒᵈ _ _ _ _
 #align sup_infi_eq sup_iInf_eq
 
-instance Prod.coframe (α β) [Coframe α] [Coframe β] : Coframe (α × β) where
-  __ := Prod.completeLattice α β
+instance Prod.instCoframe (α β) [Coframe α] [Coframe β] : Coframe (α × β) where
+  __ := Prod.instCompleteLattice α β
   iInf_sup_le_sup_sInf a s := by
     simp [Prod.le_def, sInf_eq_iInf, fst_iSup, snd_iSup, fst_iInf, snd_iInf, sup_iInf_eq]
 
@@ -354,11 +354,11 @@ theorem iInf_sup_of_antitone {ι : Type*} [Preorder ι] [IsDirected ι (· ≤ �
   @iSup_inf_of_monotone αᵒᵈ _ _ _ _ _ _ hf.dual_right hg.dual_right
 #align infi_sup_of_antitone iInf_sup_of_antitone
 
-instance Pi.coframe {ι : Type*} {π : ι → Type*} [∀ i, Coframe (π i)] : Coframe (∀ i, π i) where
-  __ := Pi.completeLattice
+instance Pi.instCoframe {ι : Type*} {π : ι → Type*} [∀ i, Coframe (π i)] : Coframe (∀ i, π i) where
+  __ := Pi.instCompleteLattice
   iInf_sup_le_sup_sInf a s := fun i => by
     simp only [sInf_apply, iInf_apply, sup_apply, sup_iInf_eq, ← iInf_subtype'']; rfl
-#align pi.coframe Pi.coframe
+#align pi.coframe Pi.instCoframe
 
 -- see Note [lower instance priority]
 instance (priority := 100) Coframe.toDistribLattice : DistribLattice α where
@@ -376,42 +376,42 @@ variable [CompleteDistribLattice α] {a b : α} {s t : Set α}
 -- Porting note (#11083): this is mysteriously slow. Minimised in
 -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Performance.20issue.20with.20.60CompleteBooleanAlgebra.60
 -- but not yet resolved.
-instance OrderDual.completeDistribLattice (α) [CompleteDistribLattice α] :
+instance OrderDual.instCompleteDistribLattice (α) [CompleteDistribLattice α] :
     CompleteDistribLattice αᵒᵈ where
-  __ := OrderDual.frame
-  __ := OrderDual.coframe
+  __ := OrderDual.instFrame
+  __ := OrderDual.instCoframe
 
-instance Prod.completeDistribLattice (α β)
+instance Prod.instCompleteDistribLattice (α β)
     [CompleteDistribLattice α] [CompleteDistribLattice β] :
     CompleteDistribLattice (α × β) where
-  __ := Prod.completeLattice α β
-  __ := Prod.frame α β
-  __ := Prod.coframe α β
+  __ := Prod.instCompleteLattice α β
+  __ := Prod.instFrame α β
+  __ := Prod.instCoframe α β
 
-instance Pi.completeDistribLattice {ι : Type*} {π : ι → Type*}
+instance Pi.instCompleteDistribLattice {ι : Type*} {π : ι → Type*}
     [∀ i, CompleteDistribLattice (π i)] : CompleteDistribLattice (∀ i, π i) where
-  __ := Pi.frame
-  __ := Pi.coframe
-#align pi.complete_distrib_lattice Pi.completeDistribLattice
+  __ := Pi.instFrame
+  __ := Pi.instCoframe
+#align pi.complete_distrib_lattice Pi.instCompleteDistribLattice
 
 end CompleteDistribLattice
 
 section CompletelyDistribLattice
 
-instance OrderDual.completelyDistribLattice (α) [CompletelyDistribLattice α] :
+instance OrderDual.instCompletelyDistribLattice (α) [CompletelyDistribLattice α] :
     CompletelyDistribLattice αᵒᵈ where
-  __ := OrderDual.completeLattice α
+  __ := OrderDual.instCompleteLattice α
   iInf_iSup_eq _ := iSup_iInf_eq (α := α)
 
-instance Prod.completelyDistribLattice (α β)
+instance Prod.instCompletelyDistribLattice (α β)
     [CompletelyDistribLattice α] [CompletelyDistribLattice β] :
     CompletelyDistribLattice (α × β) where
-  __ := Prod.completeLattice α β
+  __ := Prod.instCompleteLattice α β
   iInf_iSup_eq f := by ext <;> simp [fst_iSup, fst_iInf, snd_iSup, snd_iInf, iInf_iSup_eq]
 
-instance Pi.completelyDistribLattice {ι : Type*} {π : ι → Type*}
+instance Pi.instCompletelyDistribLattice {ι : Type*} {π : ι → Type*}
     [∀ i, CompletelyDistribLattice (π i)] : CompletelyDistribLattice (∀ i, π i) where
-  __ := Pi.completeLattice
+  __ := Pi.instCompleteLattice
   iInf_iSup_eq f := by ext i; simp only [iInf_apply, iSup_apply, iInf_iSup_eq]
 
 end CompletelyDistribLattice
@@ -424,22 +424,22 @@ It is only completely distributive if it is also atomic.
 class CompleteBooleanAlgebra (α) extends BooleanAlgebra α, CompleteDistribLattice α
 #align complete_boolean_algebra CompleteBooleanAlgebra
 
-instance Prod.completeBooleanAlgebra (α β)
+instance Prod.instCompleteBooleanAlgebra (α β)
     [CompleteBooleanAlgebra α] [CompleteBooleanAlgebra β] :
     CompleteBooleanAlgebra (α × β) where
-  __ := Prod.booleanAlgebra α β
-  __ := Prod.completeDistribLattice α β
+  __ := Prod.instBooleanAlgebra α β
+  __ := Prod.instCompleteDistribLattice α β
 
-instance Pi.completeBooleanAlgebra {ι : Type*} {π : ι → Type*}
+instance Pi.instCompleteBooleanAlgebra {ι : Type*} {π : ι → Type*}
     [∀ i, CompleteBooleanAlgebra (π i)] : CompleteBooleanAlgebra (∀ i, π i) where
-  __ := Pi.booleanAlgebra
-  __ := Pi.completeDistribLattice
-#align pi.complete_boolean_algebra Pi.completeBooleanAlgebra
+  __ := Pi.instBooleanAlgebra
+  __ := Pi.instCompleteDistribLattice
+#align pi.complete_boolean_algebra Pi.instCompleteBooleanAlgebra
 
-instance OrderDual.completeBooleanAlgebra (α) [CompleteBooleanAlgebra α] :
+instance OrderDual.instCompleteBooleanAlgebra (α) [CompleteBooleanAlgebra α] :
     CompleteBooleanAlgebra αᵒᵈ where
-  __ := OrderDual.booleanAlgebra α
-  __ := OrderDual.completeDistribLattice α
+  __ := OrderDual.instBooleanAlgebra α
+  __ := OrderDual.instCompleteDistribLattice α
 
 section CompleteBooleanAlgebra
 
@@ -484,29 +484,29 @@ class CompleteAtomicBooleanAlgebra (α : Type u) extends
   iInf_sup_le_sup_sInf := CompletelyDistribLattice.toCompleteDistribLattice.iInf_sup_le_sup_sInf
   inf_sSup_le_iSup_inf := CompletelyDistribLattice.toCompleteDistribLattice.inf_sSup_le_iSup_inf
 
-instance Prod.completeAtomicBooleanAlgebra (α β)
+instance Prod.instCompleteAtomicBooleanAlgebra (α β)
     [CompleteAtomicBooleanAlgebra α] [CompleteAtomicBooleanAlgebra β] :
     CompleteAtomicBooleanAlgebra (α × β) where
-  __ := Prod.booleanAlgebra α β
-  __ := Prod.completelyDistribLattice α β
+  __ := Prod.instBooleanAlgebra α β
+  __ := Prod.instCompletelyDistribLattice α β
 
-instance Pi.completeAtomicBooleanAlgebra {ι : Type*} {π : ι → Type*}
+instance Pi.instCompleteAtomicBooleanAlgebra {ι : Type*} {π : ι → Type*}
     [∀ i, CompleteAtomicBooleanAlgebra (π i)] : CompleteAtomicBooleanAlgebra (∀ i, π i) where
-  __ := Pi.completeBooleanAlgebra
+  __ := Pi.instCompleteBooleanAlgebra
   iInf_iSup_eq f := by ext; rw [iInf_iSup_eq]
 
-instance OrderDual.completeAtomicBooleanAlgebra (α) [CompleteAtomicBooleanAlgebra α] :
+instance OrderDual.instCompleteAtomicBooleanAlgebra (α) [CompleteAtomicBooleanAlgebra α] :
     CompleteAtomicBooleanAlgebra αᵒᵈ where
-  __ := OrderDual.completeBooleanAlgebra α
-  __ := OrderDual.completelyDistribLattice α
+  __ := OrderDual.instCompleteBooleanAlgebra α
+  __ := OrderDual.instCompletelyDistribLattice α
 
-instance Prop.completeAtomicBooleanAlgebra : CompleteAtomicBooleanAlgebra Prop where
-  __ := Prop.completeLattice
-  __ := Prop.booleanAlgebra
+instance Prop.instCompleteAtomicBooleanAlgebra : CompleteAtomicBooleanAlgebra Prop where
+  __ := Prop.instCompleteLattice
+  __ := Prop.instBooleanAlgebra
   iInf_iSup_eq f := by simp [Classical.skolem]
 
-instance Prop.completeBooleanAlgebra : CompleteBooleanAlgebra Prop := inferInstance
-#align Prop.complete_boolean_algebra Prop.completeBooleanAlgebra
+instance Prop.instCompleteBooleanAlgebra : CompleteBooleanAlgebra Prop := inferInstance
+#align Prop.complete_boolean_algebra Prop.instCompleteBooleanAlgebra
 
 section lift
 
@@ -600,7 +600,7 @@ namespace PUnit
 
 variable (s : Set PUnit.{u + 1}) (x y : PUnit.{u + 1})
 
-instance completeAtomicBooleanAlgebra : CompleteAtomicBooleanAlgebra PUnit := by
+instance instCompleteAtomicBooleanAlgebra : CompleteAtomicBooleanAlgebra PUnit := by
   refine'
     { PUnit.booleanAlgebra with
       sSup := fun _ => unit
@@ -608,10 +608,10 @@ instance completeAtomicBooleanAlgebra : CompleteAtomicBooleanAlgebra PUnit := by
       .. } <;>
   (intros; trivial)
 
-instance completeBooleanAlgebra : CompleteBooleanAlgebra PUnit := inferInstance
+instance instCompleteBooleanAlgebra : CompleteBooleanAlgebra PUnit := inferInstance
 
-instance completeLinearOrder : CompleteLinearOrder PUnit :=
-  { PUnit.completeBooleanAlgebra, PUnit.linearOrder with }
+instance instCompleteLinearOrder : CompleteLinearOrder PUnit :=
+  { PUnit.instCompleteBooleanAlgebra, PUnit.linearOrder with }
 
 @[simp]
 theorem sSup_eq : sSup s = unit :=

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -602,7 +602,7 @@ variable (s : Set PUnit.{u + 1}) (x y : PUnit.{u + 1})
 
 instance instCompleteAtomicBooleanAlgebra : CompleteAtomicBooleanAlgebra PUnit := by
   refine'
-    { PUnit.booleanAlgebra with
+    { PUnit.instBooleanAlgebra with
       sSup := fun _ => unit
       sInf := fun _ => unit
       .. } <;>
@@ -611,7 +611,7 @@ instance instCompleteAtomicBooleanAlgebra : CompleteAtomicBooleanAlgebra PUnit :
 instance instCompleteBooleanAlgebra : CompleteBooleanAlgebra PUnit := inferInstance
 
 instance instCompleteLinearOrder : CompleteLinearOrder PUnit :=
-  { PUnit.instCompleteBooleanAlgebra, PUnit.linearOrder with }
+  { PUnit.instCompleteBooleanAlgebra, PUnit.instLinearOrder with }
 
 @[simp]
 theorem sSup_eq : sSup s = unit :=

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -339,18 +339,18 @@ namespace OrderDual
 
 variable (α)
 
-instance completeLattice [CompleteLattice α] : CompleteLattice αᵒᵈ where
-  __ := OrderDual.lattice α
+instance instCompleteLattice [CompleteLattice α] : CompleteLattice αᵒᵈ where
+  __ := OrderDual.instLattice α
   __ := OrderDual.supSet α
   __ := OrderDual.infSet α
-  __ := OrderDual.boundedOrder α
+  __ := OrderDual.instBoundedOrder α
   le_sSup := @CompleteLattice.sInf_le α _
   sSup_le := @CompleteLattice.le_sInf α _
   sInf_le := @CompleteLattice.le_sSup α _
   le_sInf := @CompleteLattice.sSup_le α _
 
 instance [CompleteLinearOrder α] : CompleteLinearOrder αᵒᵈ where
-  __ := OrderDual.completeLattice α
+  __ := OrderDual.instCompleteLattice α
   __ := OrderDual.instLinearOrder α
 
 end OrderDual
@@ -1691,21 +1691,21 @@ end CompleteLinearOrder
 -/
 
 
-instance Prop.completeLattice : CompleteLattice Prop where
-  __ := Prop.boundedOrder
-  __ := Prop.distribLattice
+instance Prop.instCompleteLattice : CompleteLattice Prop where
+  __ := Prop.instBoundedOrder
+  __ := Prop.instDistribLattice
   sSup s := ∃ a ∈ s, a
   le_sSup _ a h p := ⟨a, h, p⟩
   sSup_le _ _ h := fun ⟨b, h', p⟩ => h b h' p
   sInf s := ∀ a, a ∈ s → a
   sInf_le _ a h p := p a h
   le_sInf _ _ h p b hb := h b hb p
-#align Prop.complete_lattice Prop.completeLattice
+#align Prop.complete_lattice Prop.instCompleteLattice
 
-noncomputable instance Prop.completeLinearOrder : CompleteLinearOrder Prop where
-  __ := Prop.completeLattice
+noncomputable instance Prop.instCompleteLinearOrder : CompleteLinearOrder Prop where
+  __ := Prop.instCompleteLattice
   __ := Prop.linearOrder
-#align Prop.complete_linear_order Prop.completeLinearOrder
+#align Prop.complete_linear_order Prop.instCompleteLinearOrder
 
 @[simp]
 theorem sSup_Prop_eq {s : Set Prop} : sSup s = ∃ p ∈ s, p :=
@@ -1736,14 +1736,14 @@ instance Pi.infSet {α : Type*} {β : α → Type*} [∀ i, InfSet (β i)] : Inf
   ⟨fun s i => ⨅ f : s, (f : ∀ i, β i) i⟩
 #align pi.has_Inf Pi.infSet
 
-instance Pi.completeLattice {α : Type*} {β : α → Type*} [∀ i, CompleteLattice (β i)] :
+instance Pi.instCompleteLattice {α : Type*} {β : α → Type*} [∀ i, CompleteLattice (β i)] :
     CompleteLattice (∀ i, β i) where
-  __ := Pi.boundedOrder; __ := Pi.lattice
+  __ := Pi.instBoundedOrder; __ := Pi.instLattice
   le_sSup s f hf := fun i => le_iSup (fun f : s => (f : ∀ i, β i) i) ⟨f, hf⟩
   sInf_le s f hf := fun i => iInf_le (fun f : s => (f : ∀ i, β i) i) ⟨f, hf⟩
   sSup_le _ _ hf := fun i => iSup_le fun g => hf g g.2 i
   le_sInf _ _ hf := fun i => le_iInf fun g => hf g g.2 i
-#align pi.complete_lattice Pi.completeLattice
+#align pi.complete_lattice Pi.instCompleteLattice
 
 theorem sSup_apply {α : Type*} {β : α → Type*} [∀ i, SupSet (β i)] {s : Set (∀ a, β a)} {a : α} :
     (sSup s) a = ⨆ f : s, (f : ∀ a, β a) a :=
@@ -1880,9 +1880,9 @@ theorem iSup_mk [SupSet α] [SupSet β] (f : ι → α) (g : ι → β) :
 
 variable (α β)
 
-instance completeLattice [CompleteLattice α] [CompleteLattice β] : CompleteLattice (α × β) where
-  __ := Prod.lattice α β
-  __ := Prod.boundedOrder α β
+instance instCompleteLattice [CompleteLattice α] [CompleteLattice β] : CompleteLattice (α × β) where
+  __ := Prod.instLattice α β
+  __ := Prod.instBoundedOrder α β
   __ := Prod.supSet α β
   __ := Prod.infSet α β
   le_sSup _ _ hab := ⟨le_sSup <| mem_image_of_mem _ hab, le_sSup <| mem_image_of_mem _ hab⟩
@@ -1994,7 +1994,7 @@ theorem down_iInf [InfSet α] (f : ι → ULift.{v} α) : (⨅ i, f i).down = �
 theorem up_iInf [InfSet α] (f : ι → α) : up (⨅ i, f i) = ⨅ i, up (f i) :=
   congr_arg ULift.up <| (down_iInf _).symm
 
-instance completeLattice [CompleteLattice α] : CompleteLattice (ULift.{v} α) :=
+instance instCompleteLattice [CompleteLattice α] : CompleteLattice (ULift.{v} α) :=
   ULift.down_injective.completeLattice _ down_sup down_inf
     (fun s => by rw [sSup_eq_iSup', down_iSup, iSup_subtype''])
     (fun s => by rw [sInf_eq_iInf', down_iInf, iInf_subtype'']) down_top down_bot

--- a/Mathlib/Order/CompleteLatticeIntervals.lean
+++ b/Mathlib/Order/CompleteLatticeIntervals.lean
@@ -218,7 +218,7 @@ noncomputable def Set.Icc.completeLattice [ConditionallyCompleteLattice α]
 /-- Complete linear order structure on `Set.Icc` -/
 noncomputable def Set.Icc.completeLinearOrder [ConditionallyCompleteLinearOrder α]
     {a b : α} (h : a ≤ b) : CompleteLinearOrder (Set.Icc a b) :=
-  { Set.Icc.completeLattice h, Subtype.linearOrder _ with }
+  { Set.Icc.completeLattice h, Subtype.instLinearOrder _ with }
 
 lemma Set.Icc.coe_sSup [ConditionallyCompleteLattice α] {a b : α} (h : a ≤ b)
     {S : Set (Set.Icc a b)} (hS : S.Nonempty) : letI := Set.Icc.completeLattice h

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -978,7 +978,7 @@ end ConditionallyCompleteLattice
 
 instance Pi.conditionallyCompleteLattice {ι : Type*} {α : ι → Type*}
     [∀ i, ConditionallyCompleteLattice (α i)] : ConditionallyCompleteLattice (∀ i, α i) :=
-  { Pi.lattice, Pi.supSet, Pi.infSet with
+  { Pi.instLattice, Pi.supSet, Pi.infSet with
     le_csSup := fun s f ⟨g, hg⟩ hf i =>
       le_csSup ⟨g i, Set.forall_mem_range.2 fun ⟨f', hf'⟩ => hg hf' i⟩ ⟨⟨f, hf⟩, rfl⟩
     csSup_le := fun s f hs hf i =>

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -304,22 +304,22 @@ noncomputable def IsWellOrder.conditionallyCompleteLinearOrderBot (α : Type*)
 
 end
 
-section OrderDual
+namespace OrderDual
 
-instance instConditionallyCompleteLatticeOrderDual (α : Type*) [ConditionallyCompleteLattice α] :
+instance instConditionallyCompleteLattice (α : Type*) [ConditionallyCompleteLattice α] :
     ConditionallyCompleteLattice αᵒᵈ :=
-  { instInfOrderDual α, instSupOrderDual α, OrderDual.lattice α with
+  { OrderDual.instInf α, OrderDual.instSup α, OrderDual.instLattice α with
     le_csSup := ConditionallyCompleteLattice.csInf_le (α := α)
     csSup_le := ConditionallyCompleteLattice.le_csInf (α := α)
     le_csInf := ConditionallyCompleteLattice.csSup_le (α := α)
     csInf_le := ConditionallyCompleteLattice.le_csSup (α := α) }
 
 instance (α : Type*) [ConditionallyCompleteLinearOrder α] : ConditionallyCompleteLinearOrder αᵒᵈ :=
-  { instConditionallyCompleteLatticeOrderDual α, OrderDual.instLinearOrder α with
+  { OrderDual.instConditionallyCompleteLattice α, OrderDual.instLinearOrder α with
     csSup_of_not_bddAbove := ConditionallyCompleteLinearOrder.csInf_of_not_bddBelow (α := α)
     csInf_of_not_bddBelow := ConditionallyCompleteLinearOrder.csSup_of_not_bddAbove (α := α) }
 
-end OrderDual
+namespace OrderDual
 
 /-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sup` function
 that returns the least upper bound of a nonempty set which is bounded above. Usually this

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -319,7 +319,7 @@ instance (α : Type*) [ConditionallyCompleteLinearOrder α] : ConditionallyCompl
     csSup_of_not_bddAbove := ConditionallyCompleteLinearOrder.csInf_of_not_bddBelow (α := α)
     csInf_of_not_bddBelow := ConditionallyCompleteLinearOrder.csSup_of_not_bddAbove (α := α) }
 
-namespace OrderDual
+end OrderDual
 
 /-- Create a `ConditionallyCompleteLattice` from a `PartialOrder` and `sup` function
 that returns the least upper bound of a nonempty set which is bounded above. Usually this

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -487,7 +487,7 @@ section CompleteLattice
   we want to have different definitional equalities for some lattice operations. So we define them
   upfront and change the lattice operations for the complete lattice instance. -/
 instance instCompleteLatticeFilter : CompleteLattice (Filter α) :=
-  { @OrderDual.completeLattice _ (giGenerate α).liftCompleteLattice with
+  { @OrderDual.instCompleteLattice _ (giGenerate α).liftCompleteLattice with
     le := (· ≤ ·)
     top := ⊤
     le_top := fun _ _s hs => (mem_top.1 hs).symm ▸ univ_mem

--- a/Mathlib/Order/FixedPoints.lean
+++ b/Mathlib/Order/FixedPoints.lean
@@ -279,7 +279,7 @@ instance : SemilatticeSup (fixedPoints f) :=
 /- porting note: removed `Subtype.partialOrder _` from mathlib3port version,
   threw `typeclass instance` error and was seemingly unnecessary?-/
 instance : SemilatticeInf (fixedPoints f) :=
-  { OrderDual.semilatticeInf (fixedPoints (OrderHom.dual f)) with
+  { OrderDual.instSemilatticeInf (fixedPoints (OrderHom.dual f)) with
     inf := fun x y => f.prevFixed (x ⊓ y) (f.map_inf_fixedPoints_le x y) }
 
 -- Porting note: `coe` replaced with `Subtype.val`

--- a/Mathlib/Order/GaloisConnection.lean
+++ b/Mathlib/Order/GaloisConnection.lean
@@ -878,11 +878,11 @@ variable [PartialOrder α]
 def liftSemilatticeInf [SemilatticeInf β] (gi : GaloisCoinsertion l u) : SemilatticeInf α :=
   { ‹PartialOrder α› with
     inf_le_left := fun a b => by
-      exact (@OrderDual.semilatticeInf αᵒᵈ gi.dual.liftSemilatticeSup).inf_le_left a b
+      exact (@OrderDual.instSemilatticeInf αᵒᵈ gi.dual.liftSemilatticeSup).inf_le_left a b
     inf_le_right := fun a b => by
-      exact (@OrderDual.semilatticeInf αᵒᵈ gi.dual.liftSemilatticeSup).inf_le_right a b
+      exact (@OrderDual.instSemilatticeInf αᵒᵈ gi.dual.liftSemilatticeSup).inf_le_right a b
     le_inf := fun a b c => by
-      exact (@OrderDual.semilatticeInf αᵒᵈ gi.dual.liftSemilatticeSup).le_inf a b c
+      exact (@OrderDual.instSemilatticeInf αᵒᵈ gi.dual.liftSemilatticeSup).le_inf a b c
     inf := fun a b => u (l a ⊓ l b) }
 #align galois_coinsertion.lift_semilattice_inf GaloisCoinsertion.liftSemilatticeInf
 
@@ -896,11 +896,11 @@ def liftSemilatticeSup [SemilatticeSup β] (gi : GaloisCoinsertion l u) : Semila
         sup_le (gi.gc.monotone_l <| gi.gc.le_u <| le_sup_left)
           (gi.gc.monotone_l <| gi.gc.le_u <| le_sup_right)
     le_sup_left := fun a b => by
-      exact (@OrderDual.semilatticeSup αᵒᵈ gi.dual.liftSemilatticeInf).le_sup_left a b
+      exact (@OrderDual.instSemilatticeSup αᵒᵈ gi.dual.liftSemilatticeInf).le_sup_left a b
     le_sup_right := fun a b => by
-      exact (@OrderDual.semilatticeSup αᵒᵈ gi.dual.liftSemilatticeInf).le_sup_right a b
+      exact (@OrderDual.instSemilatticeSup αᵒᵈ gi.dual.liftSemilatticeInf).le_sup_right a b
     sup_le := fun a b c => by
-      exact (@OrderDual.semilatticeSup αᵒᵈ gi.dual.liftSemilatticeInf).sup_le a b c }
+      exact (@OrderDual.instSemilatticeSup αᵒᵈ gi.dual.liftSemilatticeInf).sup_le a b c }
 #align galois_coinsertion.lift_semilattice_sup GaloisCoinsertion.liftSemilatticeSup
 
 -- See note [reducible non instances]
@@ -914,7 +914,7 @@ def liftLattice [Lattice β] (gi : GaloisCoinsertion l u) : Lattice α :=
 /-- Lift the bot along a Galois coinsertion -/
 @[reducible]
 def liftOrderBot [Preorder β] [OrderBot β] (gi : GaloisCoinsertion l u) : OrderBot α :=
-  { @OrderDual.orderBot _ _ gi.dual.liftOrderTop with bot := gi.choice ⊥ <| bot_le }
+  { @OrderDual.instOrderBot _ _ gi.dual.liftOrderTop with bot := gi.choice ⊥ <| bot_le }
 #align galois_coinsertion.lift_order_bot GaloisCoinsertion.liftOrderBot
 
 -- See note [reducible non instances]
@@ -928,7 +928,7 @@ def liftBoundedOrder [Preorder β] [BoundedOrder β] (gi : GaloisCoinsertion l u
 /-- Lift all suprema and infima along a Galois coinsertion -/
 @[reducible]
 def liftCompleteLattice [CompleteLattice β] (gi : GaloisCoinsertion l u) : CompleteLattice α :=
-  { @OrderDual.completeLattice αᵒᵈ gi.dual.liftCompleteLattice with
+  { @OrderDual.instCompleteLattice αᵒᵈ gi.dual.liftCompleteLattice with
     sInf := fun s => u (sInf (l '' s))
     sSup := fun s => gi.choice (sSup (l '' s)) _ }
 #align galois_coinsertion.lift_complete_lattice GaloisCoinsertion.liftCompleteLattice

--- a/Mathlib/Order/Heyting/Basic.lean
+++ b/Mathlib/Order/Heyting/Basic.lean
@@ -53,16 +53,16 @@ variable {ι α β : Type*}
 section
 variable (α β)
 
-instance Prod.himp [HImp α] [HImp β] : HImp (α × β) :=
+instance Prod.instHImp [HImp α] [HImp β] : HImp (α × β) :=
   ⟨fun a b => (a.1 ⇨ b.1, a.2 ⇨ b.2)⟩
 
-instance Prod.hnot [HNot α] [HNot β] : HNot (α × β) :=
+instance Prod.instHNot [HNot α] [HNot β] : HNot (α × β) :=
   ⟨fun a => (￢a.1, ￢a.2)⟩
 
-instance Prod.sdiff [SDiff α] [SDiff β] : SDiff (α × β) :=
+instance Prod.instSDiff [SDiff α] [SDiff β] : SDiff (α × β) :=
   ⟨fun a b => (a.1 \ b.1, a.2 \ b.2)⟩
 
-instance Prod.hasCompl [HasCompl α] [HasCompl β] : HasCompl (α × β) :=
+instance Prod.instHasCompl [HasCompl α] [HasCompl β] : HasCompl (α × β) :=
   ⟨fun a => (a.1ᶜ, a.2ᶜ)⟩
 
 end
@@ -421,23 +421,23 @@ instance (priority := 100) GeneralizedHeytingAlgebra.toDistribLattice : DistribL
 #align generalized_heyting_algebra.to_distrib_lattice GeneralizedHeytingAlgebra.toDistribLattice
 
 instance : GeneralizedCoheytingAlgebra αᵒᵈ :=
-  { OrderDual.lattice α, OrderDual.orderBot α with
+  { OrderDual.instLattice α, OrderDual.instOrderBot α with
     sdiff := fun a b => toDual (ofDual b ⇨ ofDual a),
     sdiff_le_iff := fun a b c => by
       rw [sup_comm]
       exact le_himp_iff }
 
-instance Prod.generalizedHeytingAlgebra [GeneralizedHeytingAlgebra β] :
+instance Prod.instGeneralizedHeytingAlgebra [GeneralizedHeytingAlgebra β] :
     GeneralizedHeytingAlgebra (α × β) :=
-  { Prod.lattice α β, Prod.orderTop α β, Prod.himp α β with
+  { Prod.instLattice α β, Prod.instOrderTop α β, Prod.instHImp α β with
     le_himp_iff := fun _ _ _ => and_congr le_himp_iff le_himp_iff }
-#align prod.generalized_heyting_algebra Prod.generalizedHeytingAlgebra
+#align prod.generalized_heyting_algebra Prod.instGeneralizedHeytingAlgebra
 
-instance Pi.generalizedHeytingAlgebra {α : ι → Type*} [∀ i, GeneralizedHeytingAlgebra (α i)] :
+instance Pi.instGeneralizedHeytingAlgebra {α : ι → Type*} [∀ i, GeneralizedHeytingAlgebra (α i)] :
     GeneralizedHeytingAlgebra (∀ i, α i) :=
-  { Pi.lattice, Pi.orderTop with
+  { Pi.instLattice, Pi.instOrderTop with
     le_himp_iff := fun i => by simp [le_def] }
-#align pi.generalized_heyting_algebra Pi.generalizedHeytingAlgebra
+#align pi.generalized_heyting_algebra Pi.instGeneralizedHeytingAlgebra
 
 end GeneralizedHeytingAlgebra
 
@@ -704,23 +704,24 @@ instance (priority := 100) GeneralizedCoheytingAlgebra.toDistribLattice : Distri
 #align generalized_coheyting_algebra.to_distrib_lattice GeneralizedCoheytingAlgebra.toDistribLattice
 
 instance : GeneralizedHeytingAlgebra αᵒᵈ :=
-  { OrderDual.lattice α, OrderDual.orderTop α with
+  { OrderDual.instLattice α, OrderDual.instOrderTop α with
     himp := fun a b => toDual (ofDual b \ ofDual a),
     le_himp_iff := fun a b c => by
       rw [inf_comm]
       exact sdiff_le_iff }
 
-instance Prod.generalizedCoheytingAlgebra [GeneralizedCoheytingAlgebra β] :
+instance Prod.instGeneralizedCoheytingAlgebra [GeneralizedCoheytingAlgebra β] :
     GeneralizedCoheytingAlgebra (α × β) :=
-  { Prod.lattice α β, Prod.orderBot α β, Prod.sdiff α β with
+  { Prod.instLattice α β, Prod.instOrderBot α β, Prod.instSDiff α β with
     sdiff_le_iff := fun _ _ _ => and_congr sdiff_le_iff sdiff_le_iff }
-#align prod.generalized_coheyting_algebra Prod.generalizedCoheytingAlgebra
+#align prod.generalized_coheyting_algebra Prod.instGeneralizedCoheytingAlgebra
 
-instance Pi.generalizedCoheytingAlgebra {α : ι → Type*} [∀ i, GeneralizedCoheytingAlgebra (α i)] :
+instance Pi.instGeneralizedCoheytingAlgebra {α : ι → Type*}
+    [∀ i, GeneralizedCoheytingAlgebra (α i)] :
     GeneralizedCoheytingAlgebra (∀ i, α i) :=
-  { Pi.lattice, Pi.orderBot with
+  { Pi.instLattice, Pi.instOrderBot with
     sdiff_le_iff := fun i => by simp [le_def] }
-#align pi.generalized_coheyting_algebra Pi.generalizedCoheytingAlgebra
+#align pi.generalized_coheyting_algebra Pi.instGeneralizedCoheytingAlgebra
 
 end GeneralizedCoheytingAlgebra
 
@@ -911,7 +912,7 @@ theorem compl_compl_himp_distrib (a b : α) : (a ⇨ b)ᶜᶜ = aᶜᶜ ⇨ bᶜ
 #align compl_compl_himp_distrib compl_compl_himp_distrib
 
 instance : CoheytingAlgebra αᵒᵈ :=
-  { OrderDual.lattice α, OrderDual.boundedOrder α with
+  { OrderDual.instLattice α, OrderDual.instBoundedOrder α with
     hnot := toDual ∘ compl ∘ ofDual,
     sdiff := fun a b => toDual (ofDual b ⇨ ofDual a),
     sdiff_le_iff := fun a b c => by
@@ -929,16 +930,16 @@ theorem toDual_compl (a : α) : toDual aᶜ = ￢toDual a :=
   rfl
 #align to_dual_compl toDual_compl
 
-instance Prod.heytingAlgebra [HeytingAlgebra β] : HeytingAlgebra (α × β) :=
-  { Prod.generalizedHeytingAlgebra, Prod.boundedOrder α β, Prod.hasCompl α β with
+instance Prod.instHeytingAlgebra [HeytingAlgebra β] : HeytingAlgebra (α × β) :=
+  { Prod.instGeneralizedHeytingAlgebra, Prod.instBoundedOrder α β, Prod.instHasCompl α β with
      himp_bot := fun a => Prod.ext_iff.2 ⟨himp_bot a.1, himp_bot a.2⟩ }
-#align prod.heyting_algebra Prod.heytingAlgebra
+#align prod.heyting_algebra Prod.instHeytingAlgebra
 
-instance Pi.heytingAlgebra {α : ι → Type*} [∀ i, HeytingAlgebra (α i)] :
+instance Pi.instHeytingAlgebra {α : ι → Type*} [∀ i, HeytingAlgebra (α i)] :
     HeytingAlgebra (∀ i, α i) :=
-  { Pi.orderBot, Pi.generalizedHeytingAlgebra with
+  { Pi.instOrderBot, Pi.instGeneralizedHeytingAlgebra with
     himp_bot := fun f => funext fun i => himp_bot (f i) }
-#align pi.heyting_algebra Pi.heytingAlgebra
+#align pi.heyting_algebra Pi.instHeytingAlgebra
 
 end HeytingAlgebra
 
@@ -1091,7 +1092,7 @@ theorem hnot_hnot_sdiff_distrib (a b : α) : ￢￢(a \ b) = ￢￢a \ ￢￢b :
 #align hnot_hnot_sdiff_distrib hnot_hnot_sdiff_distrib
 
 instance : HeytingAlgebra αᵒᵈ :=
-  { OrderDual.lattice α, OrderDual.boundedOrder α with
+  { OrderDual.instLattice α, OrderDual.instBoundedOrder α with
     compl := toDual ∘ hnot ∘ ofDual,
     himp := fun a b => toDual (ofDual b \ ofDual a),
     le_himp_iff := fun a b c => by
@@ -1119,17 +1120,17 @@ theorem toDual_sdiff (a b : α) : toDual (a \ b) = toDual b ⇨ toDual a :=
   rfl
 #align to_dual_sdiff toDual_sdiff
 
-instance Prod.coheytingAlgebra [CoheytingAlgebra β] : CoheytingAlgebra (α × β) :=
-  { Prod.lattice α β, Prod.boundedOrder α β, Prod.sdiff α β, Prod.hnot α β with
+instance Prod.instCoheytingAlgebra [CoheytingAlgebra β] : CoheytingAlgebra (α × β) :=
+  { Prod.instLattice α β, Prod.instBoundedOrder α β, Prod.instSDiff α β, Prod.instHNot α β with
     sdiff_le_iff := fun _ _ _ => and_congr sdiff_le_iff sdiff_le_iff,
     top_sdiff := fun a => Prod.ext_iff.2 ⟨top_sdiff' a.1, top_sdiff' a.2⟩ }
-#align prod.coheyting_algebra Prod.coheytingAlgebra
+#align prod.coheyting_algebra Prod.instCoheytingAlgebra
 
-instance Pi.coheytingAlgebra {α : ι → Type*} [∀ i, CoheytingAlgebra (α i)] :
+instance Pi.instCoheytingAlgebra {α : ι → Type*} [∀ i, CoheytingAlgebra (α i)] :
     CoheytingAlgebra (∀ i, α i) :=
-  { Pi.orderTop, Pi.generalizedCoheytingAlgebra with
+  { Pi.instOrderTop, Pi.instGeneralizedCoheytingAlgebra with
     top_sdiff := fun f => funext fun i => top_sdiff' (f i) }
-#align pi.coheyting_algebra Pi.coheytingAlgebra
+#align pi.coheyting_algebra Pi.instCoheytingAlgebra
 
 end CoheytingAlgebra
 
@@ -1145,11 +1146,11 @@ end BiheytingAlgebra
 
 /-- Propositions form a Heyting algebra with implication as Heyting implication and negation as
 complement. -/
-instance Prop.heytingAlgebra : HeytingAlgebra Prop :=
-  { Prop.distribLattice, Prop.boundedOrder with
+instance Prop.instHeytingAlgebra : HeytingAlgebra Prop :=
+  { Prop.instDistribLattice, Prop.instBoundedOrder with
     himp := (· → ·),
     le_himp_iff := fun _ _ _ => and_imp.symm, himp_bot := fun _ => rfl }
-#align Prop.heyting_algebra Prop.heytingAlgebra
+#align Prop.heyting_algebra Prop.instHeytingAlgebra
 
 @[simp]
 theorem himp_iff_imp (p q : Prop) : p ⇨ q ↔ p → q :=
@@ -1282,8 +1283,8 @@ namespace PUnit
 
 variable (a b : PUnit.{u + 1})
 
-instance biheytingAlgebra : BiheytingAlgebra PUnit.{u+1} :=
-  { PUnit.linearOrder.{u} with
+instance instBiheytingAlgebra : BiheytingAlgebra PUnit.{u+1} :=
+  { PUnit.instLinearOrder.{u} with
     top := unit,
     bot := unit,
     sup := fun _ _ => unit,

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -98,10 +98,10 @@ def SemilatticeSup.mk' {α : Type*} [Sup α] (sup_comm : ∀ a b : α, a ⊔ b =
   sup_le a b c hac hbc := by dsimp; rwa [sup_assoc, hbc]
 #align semilattice_sup.mk' SemilatticeSup.mk'
 
-instance instSupOrderDual (α : Type*) [Inf α] : Sup αᵒᵈ :=
+instance OrderDual.instSup (α : Type*) [Inf α] : Sup αᵒᵈ :=
   ⟨((· ⊓ ·) : α → α → α)⟩
 
-instance instInfOrderDual (α : Type*) [Sup α] : Inf αᵒᵈ :=
+instance OrderDual.instInf (α : Type*) [Sup α] : Inf αᵒᵈ :=
   ⟨((· ⊔ ·) : α → α → α)⟩
 
 section SemilatticeSup
@@ -333,14 +333,14 @@ class SemilatticeInf (α : Type u) extends Inf α, PartialOrder α where
   protected le_inf : ∀ a b c : α, a ≤ b → a ≤ c → a ≤ b ⊓ c
 #align semilattice_inf SemilatticeInf
 
-instance OrderDual.semilatticeSup (α) [SemilatticeInf α] : SemilatticeSup αᵒᵈ where
+instance OrderDual.instSemilatticeSup (α) [SemilatticeInf α] : SemilatticeSup αᵒᵈ where
   __ := inferInstanceAs (PartialOrder αᵒᵈ)
   __ := inferInstanceAs (Sup αᵒᵈ)
   le_sup_left := @SemilatticeInf.inf_le_left α _
   le_sup_right := @SemilatticeInf.inf_le_right α _
   sup_le := fun _ _ _ hca hcb => @SemilatticeInf.le_inf α _ _ _ _ hca hcb
 
-instance OrderDual.semilatticeInf (α) [SemilatticeSup α] : SemilatticeInf αᵒᵈ where
+instance OrderDual.instSemilatticeInf (α) [SemilatticeSup α] : SemilatticeInf αᵒᵈ where
   __ := inferInstanceAs (PartialOrder αᵒᵈ)
   __ := inferInstanceAs (Inf αᵒᵈ)
   inf_le_left := @le_sup_left α _
@@ -348,7 +348,7 @@ instance OrderDual.semilatticeInf (α) [SemilatticeSup α] : SemilatticeInf α�
   le_inf := fun _ _ _ hca hcb => @sup_le α _ _ _ _ hca hcb
 
 theorem SemilatticeSup.dual_dual (α : Type*) [H : SemilatticeSup α] :
-    OrderDual.semilatticeSup αᵒᵈ = H :=
+    OrderDual.instSemilatticeSup αᵒᵈ = H :=
   SemilatticeSup.ext fun _ _ => Iff.rfl
 #align semilattice_sup.dual_dual SemilatticeSup.dual_dual
 
@@ -540,7 +540,7 @@ theorem SemilatticeInf.ext {α} {A B : SemilatticeInf α}
 #align semilattice_inf.ext SemilatticeInf.ext
 
 theorem SemilatticeInf.dual_dual (α : Type*) [H : SemilatticeInf α] :
-    OrderDual.semilatticeInf αᵒᵈ = H :=
+    OrderDual.instSemilatticeInf αᵒᵈ = H :=
   SemilatticeInf.ext fun _ _ => Iff.rfl
 #align semilattice_inf.dual_dual SemilatticeInf.dual_dual
 
@@ -560,7 +560,7 @@ def SemilatticeInf.mk' {α : Type*} [Inf α] (inf_comm : ∀ a b : α, a ⊓ b =
     (inf_assoc : ∀ a b c : α, a ⊓ b ⊓ c = a ⊓ (b ⊓ c)) (inf_idem : ∀ a : α, a ⊓ a = a) :
     SemilatticeInf α := by
   haveI : SemilatticeSup αᵒᵈ := SemilatticeSup.mk' inf_comm inf_assoc inf_idem
-  haveI i := OrderDual.semilatticeInf αᵒᵈ
+  haveI i := OrderDual.instSemilatticeInf αᵒᵈ
   exact i
 #align semilattice_inf.mk' SemilatticeInf.mk'
 
@@ -573,9 +573,9 @@ def SemilatticeInf.mk' {α : Type*} [Inf α] (inf_comm : ∀ a b : α, a ⊓ b =
 class Lattice (α : Type u) extends SemilatticeSup α, SemilatticeInf α
 #align lattice Lattice
 
-instance OrderDual.lattice (α) [Lattice α] : Lattice αᵒᵈ where
-  __ := OrderDual.semilatticeSup α
-  __ := OrderDual.semilatticeInf α
+instance OrderDual.instLattice (α) [Lattice α] : Lattice αᵒᵈ where
+  __ := OrderDual.instSemilatticeSup α
+  __ := OrderDual.instSemilatticeInf α
 
 /-- The partial orders from `SemilatticeSup_mk'` and `SemilatticeInf_mk'` agree
 if `sup` and `inf` satisfy the lattice absorption laws `sup_inf_self` (`a ⊔ a ⊓ b = a`)
@@ -736,7 +736,7 @@ theorem inf_sup_left (a b c : α) : a ⊓ (b ⊔ c) = a ⊓ b ⊔ a ⊓ c :=
     _ = a ⊓ b ⊔ a ⊓ c := by rw [sup_inf_left]
 #align inf_sup_left inf_sup_left
 
-instance OrderDual.distribLattice (α : Type*) [DistribLattice α] : DistribLattice αᵒᵈ where
+instance OrderDual.instDistribLattice (α : Type*) [DistribLattice α] : DistribLattice αᵒᵈ where
   __ := inferInstanceAs (Lattice αᵒᵈ)
   le_sup_inf _ _ _ := (inf_sup_left _ _ _).le
 
@@ -766,7 +766,7 @@ end DistribLattice
 @[reducible]
 def DistribLattice.ofInfSupLe [Lattice α] (inf_sup_le : ∀ a b c : α, a ⊓ (b ⊔ c) ≤ a ⊓ b ⊔ a ⊓ c) :
     DistribLattice α where
-  le_sup_inf := (@OrderDual.distribLattice αᵒᵈ {inferInstanceAs (Lattice αᵒᵈ) with
+  le_sup_inf := (@OrderDual.instDistribLattice αᵒᵈ {inferInstanceAs (Lattice αᵒᵈ) with
       le_sup_inf := inf_sup_le}).le_sup_inf
 #align distrib_lattice.of_inf_sup_le DistribLattice.ofInfSupLe
 
@@ -984,21 +984,21 @@ theorem inf_def [∀ i, Inf (α' i)] (f g : ∀ i, α' i) : f ⊓ g = fun i => f
   rfl
 #align pi.inf_def Pi.inf_def
 
-instance semilatticeSup [∀ i, SemilatticeSup (α' i)] : SemilatticeSup (∀ i, α' i) where
+instance instSemilatticeSup [∀ i, SemilatticeSup (α' i)] : SemilatticeSup (∀ i, α' i) where
   le_sup_left _ _ _ := le_sup_left
   le_sup_right _ _ _ := le_sup_right
   sup_le _ _ _ ac bc i := sup_le (ac i) (bc i)
 
-instance semilatticeInf [∀ i, SemilatticeInf (α' i)] : SemilatticeInf (∀ i, α' i) where
+instance instSemilatticeInf [∀ i, SemilatticeInf (α' i)] : SemilatticeInf (∀ i, α' i) where
   inf_le_left _ _ _ := inf_le_left
   inf_le_right _ _ _ := inf_le_right
   le_inf _ _ _ ac bc i := le_inf (ac i) (bc i)
 
-instance lattice [∀ i, Lattice (α' i)] : Lattice (∀ i, α' i) where
+instance instLattice [∀ i, Lattice (α' i)] : Lattice (∀ i, α' i) where
   __ := inferInstanceAs (SemilatticeSup (∀ i, α' i))
   __ := inferInstanceAs (SemilatticeInf (∀ i, α' i))
 
-instance distribLattice [∀ i, DistribLattice (α' i)] : DistribLattice (∀ i, α' i) where
+instance instDistribLattice [∀ i, DistribLattice (α' i)] : DistribLattice (∀ i, α' i) where
   le_sup_inf _ _ _ _ := le_sup_inf
 
 end Pi
@@ -1313,25 +1313,25 @@ theorem inf_def [Inf α] [Inf β] (p q : α × β) : p ⊓ q = (p.fst ⊓ q.fst,
   rfl
 #align prod.inf_def Prod.inf_def
 
-instance semilatticeSup [SemilatticeSup α] [SemilatticeSup β] : SemilatticeSup (α × β) where
+instance instSemilatticeSup [SemilatticeSup α] [SemilatticeSup β] : SemilatticeSup (α × β) where
   __ := inferInstanceAs (PartialOrder (α × β))
   __ := inferInstanceAs (Sup (α × β))
   sup_le _ _ _ h₁ h₂ := ⟨sup_le h₁.1 h₂.1, sup_le h₁.2 h₂.2⟩
   le_sup_left _ _ := ⟨le_sup_left, le_sup_left⟩
   le_sup_right _ _ := ⟨le_sup_right, le_sup_right⟩
 
-instance semilatticeInf [SemilatticeInf α] [SemilatticeInf β] : SemilatticeInf (α × β) where
+instance instSemilatticeInf [SemilatticeInf α] [SemilatticeInf β] : SemilatticeInf (α × β) where
   __ := inferInstanceAs (PartialOrder (α × β))
   __ := inferInstanceAs (Inf (α × β))
   le_inf _ _ _ h₁ h₂ := ⟨le_inf h₁.1 h₂.1, le_inf h₁.2 h₂.2⟩
   inf_le_left _ _ := ⟨inf_le_left, inf_le_left⟩
   inf_le_right _ _ := ⟨inf_le_right, inf_le_right⟩
 
-instance lattice [Lattice α] [Lattice β] : Lattice (α × β) where
+instance instLattice [Lattice α] [Lattice β] : Lattice (α × β) where
   __ := inferInstanceAs (SemilatticeSup (α × β))
   __ := inferInstanceAs (SemilatticeInf (α × β))
 
-instance distribLattice [DistribLattice α] [DistribLattice β] : DistribLattice (α × β) where
+instance instDistribLattice [DistribLattice α] [DistribLattice β] : DistribLattice (α × β) where
   __ := inferInstanceAs (Lattice (α × β))
   le_sup_inf _ _ _ := ⟨le_sup_inf, le_sup_inf⟩
 

--- a/Mathlib/Order/PropInstances.lean
+++ b/Mathlib/Order/PropInstances.lean
@@ -19,7 +19,7 @@ set_option autoImplicit true
 
 
 /-- Propositions form a distributive lattice. -/
-instance Prop.distribLattice : DistribLattice Prop where
+instance Prop.instDistribLattice : DistribLattice Prop where
   sup := Or
   le_sup_left := @Or.inl
   le_sup_right := @Or.inr
@@ -29,15 +29,15 @@ instance Prop.distribLattice : DistribLattice Prop where
   inf_le_right := @And.right
   le_inf := fun _ _ _ Hab Hac Ha => And.intro (Hab Ha) (Hac Ha)
   le_sup_inf := fun _ _ _ => or_and_left.2
-#align Prop.distrib_lattice Prop.distribLattice
+#align Prop.distrib_lattice Prop.instDistribLattice
 
 /-- Propositions form a bounded order. -/
-instance Prop.boundedOrder : BoundedOrder Prop where
+instance Prop.instBoundedOrder : BoundedOrder Prop where
   top := True
   le_top _ _ := True.intro
   bot := False
   bot_le := @False.elim
-#align Prop.bounded_order Prop.boundedOrder
+#align Prop.bounded_order Prop.instBoundedOrder
 
 theorem Prop.bot_eq_false : (⊥ : Prop) = False :=
   rfl


### PR DESCRIPTION
This is not exhaustive; it largely does not rename instances that relate to algebra, and only focuses on the "core" order files.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
