### PR TITLE
[Merged by Bors] - Composing non_zero function with injective fun is non_zero

### DIFF
--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -548,8 +548,8 @@ theorem bijective_pi_map {F : ∀ i, f i → g i} (hF : ∀ i, Bijective (F i)) 
   ⟨injective_pi_map fun i => (hF i).injective, surjective_pi_map fun i => (hF i).surjective⟩
 #align function.bijective_pi_map Function.bijective_pi_map
 
-lemma comp_eq_const_iff (b : β) (f : α → β) {g : β → γ}
-    (hg : Injective g) : g ∘ f = Function.const _ (g b) ↔ f = Function.const _ b :=
+lemma comp_eq_const_iff (b : β) (f : α → β) {g : β → γ} (hg : Injective g) :
+    g ∘ f = Function.const _ (g b) ↔ f = Function.const _ b :=
   hg.comp_left.eq_iff' rfl
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -556,7 +556,7 @@ lemma comp_eq_zero_iff {α β γ : Type*} [OfNat β 0] [OfNat γ 0] (f : α → 
     (hg : Injective g) (hg0 : g 0 = 0) : g ∘ f = 0 ↔ f = 0 := by
   simpa [hg0, const_zero] using comp_eq_const_iff 0 f hg
 
-lemma comp_inj_ne_zero {α β γ : Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) {g : β → γ}
+lemma comp_inj_ne_zero {α β γ : Type*} [OfNat β 0] [OfNat γ 0] (f : α → β) {g : β → γ}
     (hg : Injective g) (hg0 : g 0 = 0) : (g ∘ f) ≠ 0 ↔ f ≠ 0 :=
   (comp_eq_zero_iff f hg hg0).ne
 

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -554,10 +554,7 @@ lemma comp_eq_const_iff {α β γ: Type*} (b : β) (f : α → β) (g : β → �
 
 lemma comp_eq_zero_iff {α β γ: Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) (g : β → γ)
     (hg : Injective g) (hg0 : g 0 = 0) : g ∘ f = 0 ↔ f = 0 := by
-  have := (comp_eq_const_iff 0 f g hg)
-  rw [hg0] at this
-  simp only [const_zero] at this
-  exact this
+  simpa [hg0, const_zero] using comp_eq_const_iff 0 f g hg
 
 lemma comp_inj_ne_zero {α β γ: Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) (g : β → γ)
     (hg : Injective g) (hg0 : g 0 = 0) : (g ∘ f) ≠ 0 ↔ f ≠ 0 :=

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -548,17 +548,19 @@ theorem bijective_pi_map {F : ∀ i, f i → g i} (hF : ∀ i, Bijective (F i)) 
   ⟨injective_pi_map fun i => (hF i).injective, surjective_pi_map fun i => (hF i).surjective⟩
 #align function.bijective_pi_map Function.bijective_pi_map
 
-lemma comp_eq_const_iff {α β γ : Type*} (b : β) (f : α → β) {g : β → γ}
+lemma comp_eq_const_iff (b : β) (f : α → β) {g : β → γ}
     (hg : Injective g) : g ∘ f = Function.const _ (g b) ↔ f = Function.const _ b :=
   hg.comp_left.eq_iff' rfl
 
-lemma comp_eq_zero_iff {α β γ : Type*} [OfNat β 0] [OfNat γ 0] (f : α → β) {g : β → γ}
-    (hg : Injective g) (hg0 : g 0 = 0) : g ∘ f = 0 ↔ f = 0 := by
-  simpa [hg0, const_zero] using comp_eq_const_iff 0 f hg
+@[to_additive]
+lemma comp_eq_one_iff [One β] [One γ] (f : α → β) {g : β → γ} (hg : Injective g) (hg0 : g 1 = 1) :
+    g ∘ f = 1 ↔ f = 1 := by
+  simpa [hg0, const_one] using comp_eq_const_iff 1 f hg
 
-lemma comp_inj_ne_zero {α β γ : Type*} [OfNat β 0] [OfNat γ 0] (f : α → β) {g : β → γ}
-    (hg : Injective g) (hg0 : g 0 = 0) : (g ∘ f) ≠ 0 ↔ f ≠ 0 :=
-  (comp_eq_zero_iff f hg hg0).ne
+@[to_additive]
+lemma comp_ne_one_iff [One β] [One γ] (f : α → β) {g : β → γ} (hg : Injective g) (hg0 : g 1 = 1) :
+    g ∘ f ≠ 1 ↔ f ≠ 1 :=
+  (comp_eq_one_iff f hg hg0).ne
 
 end Function
 

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -548,7 +548,7 @@ theorem bijective_pi_map {F : ∀ i, f i → g i} (hF : ∀ i, Bijective (F i)) 
   ⟨injective_pi_map fun i => (hF i).injective, surjective_pi_map fun i => (hF i).surjective⟩
 #align function.bijective_pi_map Function.bijective_pi_map
 
-lemma comp_eq_const_iff {α β γ: Type*} (b : β) (f : α → β) (g : β → γ)
+lemma comp_eq_const_iff {α β γ : Type*} (b : β) (f : α → β) (g : β → γ)
     (hg : Injective g) : g ∘ f = Function.const _ (g b) ↔ f = Function.const _ b :=
   hg.comp_left.eq_iff' rfl
 

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -554,7 +554,7 @@ lemma comp_eq_const_iff {α β γ : Type*} (b : β) (f : α → β) (g : β → 
 
 lemma comp_eq_zero_iff {α β γ: Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) (g : β → γ)
     (hg : Injective g) (hg0 : g 0 = 0) : g ∘ f = 0 ↔ f = 0 := by
-  simpa [hg0, const_zero] using comp_eq_const_iff 0 f g hg
+  simpa [hg0, const_zero] using comp_eq_const_iff 0 f hg
 
 lemma comp_inj_ne_zero {α β γ: Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) (g : β → γ)
     (hg : Injective g) (hg0 : g 0 = 0) : (g ∘ f) ≠ 0 ↔ f ≠ 0 :=

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -556,7 +556,7 @@ lemma comp_eq_zero_iff {α β γ : Type*} [OfNat β 0] [ OfNat γ 0] (f : α →
     (hg : Injective g) (hg0 : g 0 = 0) : g ∘ f = 0 ↔ f = 0 := by
   simpa [hg0, const_zero] using comp_eq_const_iff 0 f hg
 
-lemma comp_inj_ne_zero {α β γ: Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) (g : β → γ)
+lemma comp_inj_ne_zero {α β γ : Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) {g : β → γ}
     (hg : Injective g) (hg0 : g 0 = 0) : (g ∘ f) ≠ 0 ↔ f ≠ 0 :=
   (comp_eq_zero_iff f g hg hg0).ne
 

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -548,7 +548,7 @@ theorem bijective_pi_map {F : ∀ i, f i → g i} (hF : ∀ i, Bijective (F i)) 
   ⟨injective_pi_map fun i => (hF i).injective, surjective_pi_map fun i => (hF i).surjective⟩
 #align function.bijective_pi_map Function.bijective_pi_map
 
-lemma comp_eq_const_iff {α β γ : Type*} (b : β) (f : α → β) (g : β → γ)
+lemma comp_eq_const_iff {α β γ : Type*} (b : β) (f : α → β) {g : β → γ}
     (hg : Injective g) : g ∘ f = Function.const _ (g b) ↔ f = Function.const _ b :=
   hg.comp_left.eq_iff' rfl
 

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -548,6 +548,21 @@ theorem bijective_pi_map {F : ∀ i, f i → g i} (hF : ∀ i, Bijective (F i)) 
   ⟨injective_pi_map fun i => (hF i).injective, surjective_pi_map fun i => (hF i).surjective⟩
 #align function.bijective_pi_map Function.bijective_pi_map
 
+lemma comp_eq_const_iff {α β γ: Type*} (b : β) (f : α → β) (g : β → γ)
+    (hg : Injective g) : g ∘ f = Function.const _ (g b) ↔ f = Function.const _ b :=
+  hg.comp_left.eq_iff' rfl
+
+lemma comp_eq_zero_iff {α β γ: Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) (g : β → γ)
+    (hg : Injective g) (hg0 : g 0 = 0) : g ∘ f = 0 ↔ f = 0 := by
+  have := (comp_eq_const_iff 0 f g hg)
+  rw [hg0] at this
+  simp only [const_zero] at this
+  exact this
+
+lemma comp_inj_ne_zero {α β γ: Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) (g : β → γ)
+    (hg : Injective g) (hg0 : g 0 = 0) : (g ∘ f) ≠ 0 ↔ f ≠ 0 :=
+  (Iff.ne (comp_eq_zero_iff f g hg hg0))
+
 end Function
 
 /-- If the one function is surjective, the codomain is trivial. -/

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -558,7 +558,7 @@ lemma comp_eq_zero_iff {α β γ : Type*} [OfNat β 0] [ OfNat γ 0] (f : α →
 
 lemma comp_inj_ne_zero {α β γ : Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) {g : β → γ}
     (hg : Injective g) (hg0 : g 0 = 0) : (g ∘ f) ≠ 0 ↔ f ≠ 0 :=
-  (comp_eq_zero_iff f g hg hg0).ne
+  (comp_eq_zero_iff f hg hg0).ne
 
 end Function
 

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -552,7 +552,7 @@ lemma comp_eq_const_iff {α β γ : Type*} (b : β) (f : α → β) {g : β → 
     (hg : Injective g) : g ∘ f = Function.const _ (g b) ↔ f = Function.const _ b :=
   hg.comp_left.eq_iff' rfl
 
-lemma comp_eq_zero_iff {α β γ : Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) {g : β → γ}
+lemma comp_eq_zero_iff {α β γ : Type*} [OfNat β 0] [OfNat γ 0] (f : α → β) {g : β → γ}
     (hg : Injective g) (hg0 : g 0 = 0) : g ∘ f = 0 ↔ f = 0 := by
   simpa [hg0, const_zero] using comp_eq_const_iff 0 f hg
 

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -558,7 +558,7 @@ lemma comp_eq_zero_iff {α β γ: Type*} [OfNat β 0] [ OfNat γ 0] (f : α → 
 
 lemma comp_inj_ne_zero {α β γ: Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) (g : β → γ)
     (hg : Injective g) (hg0 : g 0 = 0) : (g ∘ f) ≠ 0 ↔ f ≠ 0 :=
-  (Iff.ne (comp_eq_zero_iff f g hg hg0))
+  (comp_eq_zero_iff f g hg hg0).ne
 
 end Function
 

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -552,7 +552,7 @@ lemma comp_eq_const_iff {α β γ : Type*} (b : β) (f : α → β) (g : β → 
     (hg : Injective g) : g ∘ f = Function.const _ (g b) ↔ f = Function.const _ b :=
   hg.comp_left.eq_iff' rfl
 
-lemma comp_eq_zero_iff {α β γ: Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) (g : β → γ)
+lemma comp_eq_zero_iff {α β γ : Type*} [OfNat β 0] [ OfNat γ 0] (f : α → β) {g : β → γ}
     (hg : Injective g) (hg0 : g 0 = 0) : g ∘ f = 0 ↔ f = 0 := by
   simpa [hg0, const_zero] using comp_eq_const_iff 0 f hg
 


### PR DESCRIPTION
Some basic missing lemmas about injective function composition.  See this Zulip [thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/injective.20function.20composed.20with.20non.20zero.20function.20ne.20zero) 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
