### PR TITLE
[Merged by Bors] - feat: chosen finite products in a category

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1051,6 +1051,7 @@ import Mathlib.CategoryTheory.Category.Quiv
 import Mathlib.CategoryTheory.Category.RelCat
 import Mathlib.CategoryTheory.Category.TwoP
 import Mathlib.CategoryTheory.Category.ULift
+import Mathlib.CategoryTheory.ChosenFiniteProducts
 import Mathlib.CategoryTheory.Closed.Cartesian
 import Mathlib.CategoryTheory.Closed.Functor
 import Mathlib.CategoryTheory.Closed.FunctorCategory

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -1,15 +1,12 @@
 /-
-Copyright (c) 2024 Adam Topaz All rights reserved.
+Copyright (c) 2024 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
-
 import Mathlib.CategoryTheory.Monoidal.OfChosenFiniteProducts.Symmetric
 import Mathlib.CategoryTheory.Limits.Constructions.FiniteProductsOfBinaryProducts
 
 /-!
-
-# Categories with chosen finite products
 
 We introduce a class, `ChosenFiniteProducts`, which bundles explicit choices
 for a terminal object and binary products in a category `C`.

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -1,9 +1,8 @@
 /-
-Copyright (c) 2024 Adam Topaz All rights reserved.
+Copyright (c) 2024 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
-
 import Mathlib.CategoryTheory.Monoidal.OfChosenFiniteProducts.Symmetric
 import Mathlib.CategoryTheory.Limits.Constructions.FiniteProductsOfBinaryProducts
 

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -5,6 +5,7 @@ Authors: Adam Topaz
 -/
 
 import Mathlib.CategoryTheory.Monoidal.OfChosenFiniteProducts.Symmetric
+import Mathlib.CategoryTheory.Limits.Constructions.FiniteProductsOfBinaryProducts
 
 /-!
 
@@ -102,6 +103,23 @@ lemma lift_unique {T X Y : C} (f g : T ⟶ X ⊗ Y)
     (h_snd : f ≫ snd _ _ = g ≫ snd _ _) :
     f = g :=
   (product X Y).isLimit.hom_ext fun ⟨j⟩ => j.recOn h_fst h_snd
+
+/--
+Construct an instance of `ChosenFiniteProducts C` given an instance of `HasFiniteProducts C`.
+-/
+noncomputable
+def ofFiniteProducts
+    (C : Type u) [Category.{v} C] [Limits.HasFiniteProducts C] :
+    ChosenFiniteProducts C where
+  product X Y := Limits.getLimitCone (Limits.pair X Y)
+  terminal := Limits.getLimitCone (Functor.empty C)
+
+instance : Limits.HasFiniteProducts C :=
+  letI : ∀ (X Y : C), Limits.HasLimit (Limits.pair X Y) := fun _ _ =>
+    .mk <| ChosenFiniteProducts.product _ _
+  letI : Limits.HasBinaryProducts C := Limits.hasBinaryProducts_of_hasLimit_pair _
+  letI : Limits.HasTerminal C := Limits.hasTerminal_of_unique (𝟙_ _)
+  hasFiniteProducts_of_has_binary_and_terminal
 
 end ChosenFiniteProducts
 

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2024 Adam Topaz All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Topaz
+-/
+
+import Mathlib.CategoryTheory.Monoidal.OfChosenFiniteProducts.Symmetric
+
+/-!
+
+# Categories with chosen finite products
+
+We introduce a class, `ChosenFiniteProducts`, which bundles explicit choices
+for a terminal object and binary products in a category `C`.
+This is primarily useful for categories which have finite products with good
+definitional properties, such as the category of types.
+
+Given a category with such an instance, we also provide the associated
+symmetric monoidal structure so that one can write `X ⊗ Y` for the explicit
+binary product and `𝟙_ C` for the explicit terminal object.
+
+-/
+
+namespace CategoryTheory
+
+universe v u
+
+/--
+An instance of `ChosenFiniteProducts C` bundles an explicit choice of a binary
+product of two objects of `C`, and a terminal object in `C`.
+
+Users should use the monoidal notation: `X ⊗ Y` for the product and `𝟙_ C` for
+the terminal object.
+-/
+class ChosenFiniteProducts (C : Type u) [Category.{v} C] where
+  /-- A choice of a limit binary fan for any two objects of the category.-/
+  product : (X Y : C) → Limits.LimitCone (Limits.pair X Y)
+  /-- A choice of a terminal object. -/
+  terminal : Limits.LimitCone (Functor.empty.{v} C)
+
+namespace ChosenFiniteProducts
+
+instance (C : Type u) [Category.{v} C] [ChosenFiniteProducts C] : MonoidalCategory C :=
+  monoidalOfChosenFiniteProducts ChosenFiniteProducts.terminal ChosenFiniteProducts.product
+
+instance (C : Type u) [Category.{v} C] [ChosenFiniteProducts C] : SymmetricCategory C :=
+  symmetricOfChosenFiniteProducts _ _
+
+variable {C : Type u} [Category.{v} C] [ChosenFiniteProducts C]
+
+open MonoidalCategory
+
+/--
+The unique map to the terminal object.
+-/
+def toUnit (X : C) : X ⟶ 𝟙_ C :=
+  terminal.isLimit.lift <| .mk _ <| .mk (fun x => x.as.elim) fun x => x.as.elim
+
+instance (X : C) : Unique (X ⟶ 𝟙_ C) where
+  default := toUnit _
+  uniq _ := terminal.isLimit.hom_ext fun ⟨j⟩ => j.elim
+
+/--
+This lemma follows from the preexisting `Unique` instance, but
+it is often convenient to use it directly as `apply toUnit_unique` forcing
+lean to do the necessary elaboration.
+-/
+lemma toUnit_unique {X : C} (f g : X ⟶ 𝟙_ _) : f = g :=
+  Subsingleton.elim _ _
+
+/--
+Construct a morphism to the product given its two components.
+-/
+def lift {T X Y : C} (f : T ⟶ X) (g : T ⟶ Y) : T ⟶ X ⊗ Y :=
+  (product X Y).isLimit.lift <| Limits.BinaryFan.mk f g
+
+/--
+The first projection from the product.
+-/
+def fst (X Y : C) : X ⊗ Y ⟶ X :=
+  letI F : Limits.BinaryFan X Y := (product X Y).cone
+  F.fst
+
+/--
+The second projection from the product.
+-/
+def snd (X Y : C) : X ⊗ Y ⟶ Y :=
+  letI F : Limits.BinaryFan X Y := (product X Y).cone
+  F.snd
+
+@[reassoc (attr := simp)]
+lemma lift_fst {T X Y : C} (f : T ⟶ X) (g : T ⟶ Y) : lift f g ≫ fst _ _ = f := by
+  simp [lift, fst]
+
+@[reassoc (attr := simp)]
+lemma lift_snd {T X Y : C} (f : T ⟶ X) (g : T ⟶ Y) : lift f g ≫ snd _ _ = g := by
+  simp [lift, snd]
+
+@[ext 1050]
+lemma lift_unique {T X Y : C} (f g : T ⟶ X ⊗ Y)
+    (h_fst : f ≫ fst _ _ = g ≫ fst _ _)
+    (h_snd : f ≫ snd _ _ = g ≫ snd _ _) :
+    f = g :=
+  (product X Y).isLimit.hom_ext fun ⟨j⟩ => j.recOn h_fst h_snd
+
+end ChosenFiniteProducts
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -1,12 +1,14 @@
 /-
-Copyright (c) 2024 Adam Topaz. All rights reserved.
+Copyright (c) 2024 Adam Topaz All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
+
 import Mathlib.CategoryTheory.Monoidal.OfChosenFiniteProducts.Symmetric
 import Mathlib.CategoryTheory.Limits.Constructions.FiniteProductsOfBinaryProducts
 
 /-!
+# Categories with chosen finite products
 
 We introduce a class, `ChosenFiniteProducts`, which bundles explicit choices
 for a terminal object and binary products in a category `C`.

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -45,10 +45,12 @@ class ChosenFiniteProducts (C : Type u) [Category.{v} C] where
 
 namespace ChosenFiniteProducts
 
-instance (C : Type u) [Category.{v} C] [ChosenFiniteProducts C] : MonoidalCategory C :=
+instance (priority := 100) (C : Type u) [Category.{v} C] [ChosenFiniteProducts C] :
+    MonoidalCategory C :=
   monoidalOfChosenFiniteProducts terminal product
 
-instance (C : Type u) [Category.{v} C] [ChosenFiniteProducts C] : SymmetricCategory C :=
+instance (priority := 100) (C : Type u) [Category.{v} C] [ChosenFiniteProducts C] :
+    SymmetricCategory C :=
   symmetricOfChosenFiniteProducts _ _
 
 variable {C : Type u} [Category.{v} C] [ChosenFiniteProducts C]
@@ -118,7 +120,7 @@ def ofFiniteProducts
   product X Y := Limits.getLimitCone (Limits.pair X Y)
   terminal := Limits.getLimitCone (Functor.empty C)
 
-instance : Limits.HasFiniteProducts C :=
+instance (priority := 100) : Limits.HasFiniteProducts C :=
   letI : ∀ (X Y : C), Limits.HasLimit (Limits.pair X Y) := fun _ _ =>
     .mk <| ChosenFiniteProducts.product _ _
   letI : Limits.HasBinaryProducts C := Limits.hasBinaryProducts_of_hasLimit_pair _

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -20,6 +20,12 @@ Given a category with such an instance, we also provide the associated
 symmetric monoidal structure so that one can write `X ⊗ Y` for the explicit
 binary product and `𝟙_ C` for the explicit terminal object.
 
+# Projects
+
+- Construct an instance of chosen finite products in the category of affine scheme, using
+  the tensor product.
+- Construct chosen finite products in other categories appearing "in nature".
+
 -/
 
 namespace CategoryTheory
@@ -42,7 +48,7 @@ class ChosenFiniteProducts (C : Type u) [Category.{v} C] where
 namespace ChosenFiniteProducts
 
 instance (C : Type u) [Category.{v} C] [ChosenFiniteProducts C] : MonoidalCategory C :=
-  monoidalOfChosenFiniteProducts ChosenFiniteProducts.terminal ChosenFiniteProducts.product
+  monoidalOfChosenFiniteProducts terminal product
 
 instance (C : Type u) [Category.{v} C] [ChosenFiniteProducts C] : SymmetricCategory C :=
   symmetricOfChosenFiniteProducts _ _
@@ -98,7 +104,7 @@ lemma lift_snd {T X Y : C} (f : T ⟶ X) (g : T ⟶ Y) : lift f g ≫ snd _ _ = 
   simp [lift, snd]
 
 @[ext 1050]
-lemma lift_unique {T X Y : C} (f g : T ⟶ X ⊗ Y)
+lemma hom_ext {T X Y : C} (f g : T ⟶ X ⊗ Y)
     (h_fst : f ≫ fst _ _ = g ≫ fst _ _)
     (h_snd : f ≫ snd _ _ = g ≫ snd _ _) :
     f = g :=

--- a/Mathlib/CategoryTheory/Monoidal/Types/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Types/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Jendrusch, Scott Morrison
 -/
 import Mathlib.CategoryTheory.Monoidal.Functor
-import Mathlib.CategoryTheory.Monoidal.OfChosenFiniteProducts.Basic
+import Mathlib.CategoryTheory.ChosenFiniteProducts
 import Mathlib.CategoryTheory.Limits.Shapes.Types
 import Mathlib.Logic.Equiv.Fin
 
@@ -23,9 +23,9 @@ universe v u
 
 namespace CategoryTheory
 
-noncomputable instance typesMonoidal : MonoidalCategory.{u} (Type u) :=
-  monoidalOfChosenFiniteProducts Types.terminalLimitCone Types.binaryProductLimitCone
-#align category_theory.types_monoidal CategoryTheory.typesMonoidal
+instance typesChosenFiniteProducts : ChosenFiniteProducts (Type u) where
+  product := Types.binaryProductLimitCone
+  terminal := Types.terminalLimitCone
 
 @[simp]
 theorem tensor_apply {W X Y Z : Type u} (f : W ⟶ X) (g : Y ⟶ Z) (p : W ⊗ Y) :


### PR DESCRIPTION
This PR introduces a class for categories with explicit choices of binary products and terminal objects, and introduces the associated (Cartesian) symmetric monoidal instance. The primary use of this class is to be able to define internal algebraic objects in categories with chosen finite products, while retaining good definitional properties of the products in question, primarily as a convenience.

We introduce an instance of this new class for the category of types where the binary product is the usual type-theoretic product and the terminal object is `PUnit`. Future work will introduce an instance for other categories, especially the category of affine schemes which should make objects like group schemes more convenient.

NOTE: In some sense this reverses the refactor done in https://github.com/leanprover-community/mathlib/pull/3995 but only in the particular case of binary products and terminal objects. Working with (nonexplicit) (co)limits is still the preferred way to work with (co)limits in abstract categories, and instances of `ChosenFiniteProducts` (and other similar classes which may be introduced in the future) should be carefully considered before they are introduced.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
