### PR TITLE
[Merged by Bors] - feat(NumberTheory/LSeries): introduce notations

### DIFF
--- a/Mathlib/NumberTheory/LSeries/Basic.lean
+++ b/Mathlib/NumberTheory/LSeries/Basic.lean
@@ -36,6 +36,13 @@ Given a sequence `f: ℕ → ℂ`, we define the corresponding L-series.
  * `LSeriesSummable.isBigO_rpow`: if the `LSeries` of `f` is summable at `s`,
     then `f = O(n^(re s))`.
 
+## Notation
+
+We introduce `L` as notation for `LSeries` and `↗f` as notation for `fun n : ℕ ↦ (f n : ℂ)`,
+both scoped to `LSeries.notation`. The latter makes it convenient to use arithmetic functions
+or Dirichlet characters (or anything that coerces to a function `N → R`, where `ℕ` coerces
+to `N` and `R` coerces to `ℂ`) as arguments to `LSeries` etc.
+
 ## Tags
 
 L-series
@@ -47,7 +54,6 @@ L-series
 
 * Move `LSeries_add` and friends to a new file on algebraic operations on L-series
 -/
-
 
 open scoped BigOperators
 
@@ -184,6 +190,21 @@ theorem LSeriesSummable_iff_of_re_eq_re {f : ℕ → ℂ} {s s' : ℂ} (h : s.re
     LSeriesSummable f s ↔ LSeriesSummable f s' :=
   ⟨fun H ↦ H.of_re_le_re h.le, fun H ↦ H.of_re_le_re h.symm.le⟩
 #align nat.arithmetic_function.l_series_summable_iff_of_re_eq_re LSeriesSummable_iff_of_re_eq_re
+
+
+/-!
+### Notation
+-/
+
+@[inherit_doc]
+scoped[LSeries.notation] notation "L" => LSeries
+
+/-- We introduce notation `↗f` for `f` interpreted as a function `ℕ → ℂ`.
+
+Let `R` be a ring with a coercion to `ℂ`. Then we can write `↗χ` when `χ : DirichletCharacter R`
+or `↗f` when `f : ArithmeticFunction R` or simply `f : N → R` with a coercion from `ℕ` to `N`
+as an argument to `LSeries`, `LSeriesHasSum`, `LSeriesSummable` etc. -/
+scoped[LSeries.notation] notation:max "↗" f:max => fun n : ℕ ↦ (f n : ℂ)
 
 
 /-!


### PR DESCRIPTION
This just introduces `L` as a short notation for `LSeries` and `↗f` as notation for `fun n : ℕ ↦ (f n : ℂ)`,
both scoped to `LSeries.notation`. The latter makes it convenient to use arithmetic functions
or Dirichlet characters (or anything that coerces to a function `N → R`, where `ℕ` coerces
to `N` and `R` coerces to `ℂ`) as arguments to `LSeries` etc. The first is for convenience (and agreement with informal math, where we write "L(f, s)"), and the second one considerably simplifies statements involving Dirichlet characters or arithmetic functions like the von Mangoldt function and their L-series.

See [here](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/L-series/near/424858837) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
