### PR TITLE
[Merged by Bors] - feat: add Basis.flag_le_ker_dual

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1082,8 +1082,8 @@ theorem coe_eq_castSucc {a : Fin n} : (a : Fin (n + 1)) = castSucc a := by
   exact val_cast_of_lt (Nat.lt.step a.is_lt)
 #align fin.coe_eq_cast_succ Fin.coe_eq_castSucc
 
-theorem Fin.coe_succ_lt_iff_lt {n : ℕ} {j k : Fin n} : (j : Fin <| n + 1) < k ↔ j < k := by
-  simp only [Fin.coe_eq_castSucc]; rfl
+theorem coe_succ_lt_iff_lt {n : ℕ} {j k : Fin n} : (j : Fin <| n + 1) < k ↔ j < k := by
+  simp only [coe_eq_castSucc]; rfl
 
 #align fin.coe_succ_eq_succ Fin.coeSucc_eq_succ
 

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1082,6 +1082,9 @@ theorem coe_eq_castSucc {a : Fin n} : (a : Fin (n + 1)) = castSucc a := by
   exact val_cast_of_lt (Nat.lt.step a.is_lt)
 #align fin.coe_eq_cast_succ Fin.coe_eq_castSucc
 
+theorem Fin.coe_succ_lt_iff_lt {n : ℕ} {j k : Fin n} : (j : Fin <| n + 1) < k ↔ j < k := by
+  simp only [Fin.coe_eq_castSucc]; rfl
+
 #align fin.coe_succ_eq_succ Fin.coeSucc_eq_succ
 
 #align fin.lt_succ Fin.lt_succ

--- a/Mathlib/LinearAlgebra/Basis/Flag.lean
+++ b/Mathlib/LinearAlgebra/Basis/Flag.lean
@@ -80,6 +80,15 @@ theorem flag_le_ker_coord (b : Basis (Fin n) R M) {k : Fin (n + 1)} {l : Fin n}
   nontriviality R
   exact b.flag_le_ker_coord_iff.2 h
 
+theorem Basis.flag_le_ker_dual (b : Basis (Fin n) R M) (k : Fin n) :
+    b.flag k ≤ LinearMap.ker (b.dualBasis k) := by
+  erw [span_le]
+  rintro _ ⟨j, hj : j.castSucc < k, rfl⟩
+  have : j < k := by rw [← Fin.coe_eq_castSucc, Fin.coe_succ_lt_iff_lt] at hj; exact hj
+  simp only [coe_dualBasis, SetLike.mem_coe, LinearMap.mem_ker, coord_apply, repr_self]
+  rw [Finsupp.single_apply_eq_zero]
+  exact fun h ↦ False.elim (by omega)
+
 end CommRing
 
 section DivisionRing
@@ -109,18 +118,3 @@ theorem isMaxChain_range_flag (b : Basis (Fin n) K V) : IsMaxChain (· ≤ ·) (
   b.toFlag.maxChain
 
 end DivisionRing
-
--- move to Data.ZMod.Defs
-theorem Fin.coe_succ_lt_iff_lt {n : ℕ} {j k : Fin n} : (j : Fin <| n + 1) < k ↔ j < k := by
-  simp only [Fin.coe_eq_castSucc]; rfl
-
-variable {R : Type*} [CommRing R] {M : Type*} [AddCommGroup M] [Module R M]
-
-variable {n : ℕ} (b : Basis (Fin n) R M)
-theorem Basis.flag_le_ker_dual (k : Fin n) : b.flag k ≤ LinearMap.ker (b.dualBasis k) := by
-  erw [span_le]
-  rintro _ ⟨j, hj : j.castSucc < k, rfl⟩
-  have : j < k := by rw [← Fin.coe_eq_castSucc, Fin.coe_succ_lt_iff_lt] at hj; exact hj
-  simp only [coe_dualBasis, SetLike.mem_coe, LinearMap.mem_ker, coord_apply, repr_self]
-  rw [Finsupp.single_apply_eq_zero]
-  exact fun h ↦ False.elim (by omega)

--- a/Mathlib/LinearAlgebra/Basis/Flag.lean
+++ b/Mathlib/LinearAlgebra/Basis/Flag.lean
@@ -82,11 +82,8 @@ theorem flag_le_ker_coord (b : Basis (Fin n) R M) {k : Fin (n + 1)} {l : Fin n}
 
 theorem flag_le_ker_dual (b : Basis (Fin n) R M) (k : Fin n) :
     b.flag k.castSucc ≤ LinearMap.ker (b.dualBasis k) := by
-  erw [span_le]
-  rintro _ ⟨j, hj : j < k, rfl⟩
-  simp only [coe_dualBasis, SetLike.mem_coe, LinearMap.mem_ker, coord_apply, repr_self]
-  rw [Finsupp.single_apply_eq_zero]
-  exact fun h ↦ False.elim (by omega)
+  nontriviality R
+  rw [coe_dualBasis, b.flag_le_ker_coord_iff]
 
 end CommRing
 

--- a/Mathlib/LinearAlgebra/Basis/Flag.lean
+++ b/Mathlib/LinearAlgebra/Basis/Flag.lean
@@ -80,7 +80,7 @@ theorem flag_le_ker_coord (b : Basis (Fin n) R M) {k : Fin (n + 1)} {l : Fin n}
   nontriviality R
   exact b.flag_le_ker_coord_iff.2 h
 
-theorem Basis.flag_le_ker_dual (b : Basis (Fin n) R M) (k : Fin n) :
+theorem flag_le_ker_dual (b : Basis (Fin n) R M) (k : Fin n) :
     b.flag k ≤ LinearMap.ker (b.dualBasis k) := by
   erw [span_le]
   rintro _ ⟨j, hj : j.castSucc < k, rfl⟩

--- a/Mathlib/LinearAlgebra/Basis/Flag.lean
+++ b/Mathlib/LinearAlgebra/Basis/Flag.lean
@@ -81,7 +81,7 @@ theorem flag_le_ker_coord (b : Basis (Fin n) R M) {k : Fin (n + 1)} {l : Fin n}
   exact b.flag_le_ker_coord_iff.2 h
 
 theorem flag_le_ker_dual (b : Basis (Fin n) R M) (k : Fin n) :
-    b.flag k ≤ LinearMap.ker (b.dualBasis k) := by
+    b.flag k.castSucc ≤ LinearMap.ker (b.dualBasis k) := by
   erw [span_le]
   rintro _ ⟨j, hj : j.castSucc < k, rfl⟩
   have : j < k := by rw [← Fin.coe_eq_castSucc, Fin.coe_succ_lt_iff_lt] at hj; exact hj

--- a/Mathlib/LinearAlgebra/Basis/Flag.lean
+++ b/Mathlib/LinearAlgebra/Basis/Flag.lean
@@ -83,8 +83,7 @@ theorem flag_le_ker_coord (b : Basis (Fin n) R M) {k : Fin (n + 1)} {l : Fin n}
 theorem flag_le_ker_dual (b : Basis (Fin n) R M) (k : Fin n) :
     b.flag k.castSucc ≤ LinearMap.ker (b.dualBasis k) := by
   erw [span_le]
-  rintro _ ⟨j, hj : j.castSucc < k, rfl⟩
-  have : j < k := by rw [← Fin.coe_eq_castSucc, Fin.coe_succ_lt_iff_lt] at hj; exact hj
+  rintro _ ⟨j, hj : j < k, rfl⟩
   simp only [coe_dualBasis, SetLike.mem_coe, LinearMap.mem_ker, coord_apply, repr_self]
   rw [Finsupp.single_apply_eq_zero]
   exact fun h ↦ False.elim (by omega)

--- a/Mathlib/LinearAlgebra/Basis/Flag.lean
+++ b/Mathlib/LinearAlgebra/Basis/Flag.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Patrick Massot
 -/
 import Mathlib.LinearAlgebra.Basis
+import Mathlib.LinearAlgebra.Dual
 import Mathlib.Data.Fin.FlagRange
 
 /-!
@@ -108,3 +109,18 @@ theorem isMaxChain_range_flag (b : Basis (Fin n) K V) : IsMaxChain (· ≤ ·) (
   b.toFlag.maxChain
 
 end DivisionRing
+
+-- move to Data.ZMod.Defs
+theorem Fin.coe_succ_lt_iff_lt {n : ℕ} {j k : Fin n} : (j : Fin <| n + 1) < k ↔ j < k := by
+  simp only [Fin.coe_eq_castSucc]; rfl
+
+variable {R : Type*} [CommRing R] {M : Type*} [AddCommGroup M] [Module R M]
+
+variable {n : ℕ} (b : Basis (Fin n) R M)
+theorem Basis.flag_le_ker_dual (k : Fin n) : b.flag k ≤ LinearMap.ker (b.dualBasis k) := by
+  erw [span_le]
+  rintro _ ⟨j, hj : j.castSucc < k, rfl⟩
+  have : j < k := by rw [← Fin.coe_eq_castSucc, Fin.coe_succ_lt_iff_lt] at hj; exact hj
+  simp only [coe_dualBasis, SetLike.mem_coe, LinearMap.mem_ker, coord_apply, repr_self]
+  rw [Finsupp.single_apply_eq_zero]
+  exact fun h ↦ False.elim (by omega)


### PR DESCRIPTION
From sphere-eversion; I adapted the proof to mathlib's definition and golfed it a bit.
This adds a new import; as this file is not imported anywhere, this seems fine.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
