### PR TITLE
[Merged by Bors] - feat(Data/Setoid/Basic): equivalence for quotients by two setoids

### DIFF
--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -445,7 +445,7 @@ def correspondence (r : Setoid α) : { s // r ≤ s } ≃o Setoid (Quotient r) w
 
 /-- Given two equivalence relations with `r ≤ s`, a bijection between the sum of the quotients by
 `r` on each equivalence class by `s` and the quotient by `r`. -/
-def equivSigmaFibersOfLe {r s : Setoid α} (hle : r ≤ s) :
+def sigmaQuotientEquivOfLe {r s : Setoid α} (hle : r ≤ s) :
     (Σ q : Quotient s, Quotient (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α))) ≃
       Quotient r :=
   .trans (.symm <| .sigmaCongrRight fun _ ↦ .subtypeQuotientEquivQuotientSubtype

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -443,6 +443,15 @@ def correspondence (r : Setoid α) : { s // r ≤ s } ≃o Setoid (Quotient r) w
     ⟨fun h x y hs ↦ @h ⟦x⟧ ⟦y⟧ hs, fun h x y ↦ Quotient.inductionOn₂ x y fun _ _ hs ↦ h hs⟩
 #align setoid.correspondence Setoid.correspondence
 
+/-- Given two equivalence relations with `r ≤ s`, a bijection between the sum of the quotients by
+`r` on each equivalence class by `s` and the quotient by `r`. -/
+def equivSigmaFibersOfLe {r s : Setoid α} (hle : r ≤ s) :
+    (Σ q : Quotient s, Quotient (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α))) ≃
+      Quotient r :=
+  .trans (.symm <| .sigmaCongrRight fun _ ↦ .subtypeQuotientEquivQuotientSubtype
+      (s₁ := r) (s₂ := r.comap Subtype.val) _ (fun _ ↦ Iff.rfl) fun _ _ ↦ Iff.rfl)
+    (.sigmaFiberEquiv fun a ↦ a.lift (Quotient.mk s) fun _ _ h ↦ Quotient.sound <| hle h)
+
 end Setoid
 
 @[simp]

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -330,60 +330,12 @@ def IsPartition.finpartition {c : Finset (Set α)} (hc : Setoid.IsPartition (c :
 
 /-- Given two equivalence relations with `r ≤ s`, a bijection between the sum of the quotients by
 `r` on each equivalence class by `s` and the quotient by `r`. -/
-noncomputable def equivSigmaFibersOfLe {r s : Setoid α} (hle : r ≤ s) :
-    (Σq : Quotient s, Quotient (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α))) ≃
-      Quotient r := by
-  calc
-    (Σq : Quotient s, Quotient (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α))) ≃
-      Σq : Quotient s, (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α)).classes :=
-        Equiv.sigmaCongrRight fun x ↦ Setoid.quotientEquivClasses _
-    _ ≃ Σq : Quotient s, (fun t ↦ (Subtype.val '' t)) ''
-          (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α)).classes :=
-        Equiv.sigmaCongrRight (fun x ↦ Equiv.Set.image _ _
-          (fun y z h ↦ (Set.image_eq_image Subtype.val_injective).1 h))
-    _ ≃ ⋃ q : Quotient s, (fun t ↦ (Subtype.val '' t)) ''
-          (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α)).classes :=
-        (Set.unionEqSigmaOfDisjoint fun i j hij ↦ Set.disjoint_left.2 fun c hc ↦ by
-          rcases hc with ⟨k, hk, rfl⟩
-          simp only [Set.mem_image, not_exists, not_and]
-          intro k' hk' he
-          have hd : Disjoint (Subtype.val '' k) (Subtype.val '' k') := by
-            by_contra hd
-            simp only [Set.not_disjoint_iff, Set.mem_image, Subtype.exists, Set.mem_preimage,
-                       Set.mem_singleton_iff, exists_and_right, exists_eq_right] at hd
-            rcases hd with ⟨x, ⟨rfl, hi⟩, ⟨rfl, hj⟩⟩
-            exact hij rfl
-          simp only [he, disjoint_self, Set.bot_eq_empty, Set.image_eq_empty] at hd
-          exact Set.not_nonempty_iff_eq_empty.2 hd
-            (nonempty_of_mem_partition (isPartition_classes _) hk)).symm
-    _ ≃ r.classes := Equiv.setCongr (by
-          ext x
-          simp only [Set.mem_iUnion, Set.mem_image, Setoid.classes, Subtype.exists,
-                     Set.mem_preimage, Set.mem_singleton_iff, Set.mem_setOf_eq]
-          refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-          · rcases h with ⟨q, x', ⟨x, rfl, rfl⟩, rfl⟩
-            refine ⟨x, ?_⟩
-            ext y
-            simp only [Set.mem_image, Set.mem_setOf_eq, Subtype.exists, Set.mem_preimage,
-                       Set.mem_singleton_iff, exists_and_right, exists_eq_right]
-            simp_rw [← Quotient.mk''_eq_mk, Quotient.eq'']
-            refine ⟨fun h ↦ ?_, fun h ↦ ⟨le_def.1 hle h, h⟩⟩
-            rcases h with ⟨_, h'⟩
-            exact h'
-          · rcases h with ⟨x, rfl⟩
-            refine ⟨Quotient.mk s x,
-                    quotientEquivClasses (r.comap (Subtype.val : Quotient.mk s ⁻¹' {⟦x⟧} → α))
-                      (Quotient.mk _ ⟨x, by simp⟩),
-                    ⟨⟨x, ⟨rfl, by simp⟩⟩, ?_⟩⟩
-            simp only [quotientEquivClasses_mk_eq]
-            ext y
-            simp only [Set.mem_image, Set.mem_setOf_eq, Subtype.exists, Set.mem_preimage,
-                       Set.mem_singleton_iff, exists_and_right, exists_eq_right]
-            simp_rw [← Quotient.mk''_eq_mk, Quotient.eq'']
-            refine ⟨fun h ↦ ?_, fun h ↦ ⟨le_def.1 hle h, h⟩⟩
-            rcases h with ⟨_, h'⟩
-            exact h')
-    _ ≃ Quotient r := r.quotientEquivClasses.symm
+def equivSigmaFibersOfLe {r s : Setoid α} (hle : r ≤ s) :
+    (Σ q : Quotient s, Quotient (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α))) ≃ 
+      Quotient r :=
+  .trans (.symm <| .sigmaCongrRight fun _ ↦ .subtypeQuotientEquivQuotientSubtype
+      (s₁ := r) (s₂ := r.comap Subtype.val) _ (fun _ ↦ Iff.rfl) fun _ _ ↦ Iff.rfl)
+    (.sigmaFiberEquiv fun a ↦ a.lift (Quotient.mk s) fun _ _ h ↦ Quotient.sound <| hle h)
 
 end Setoid
 

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -328,15 +328,6 @@ def IsPartition.finpartition {c : Finset (Set α)} (hc : Setoid.IsPartition (c :
   not_bot_mem := hc.left
 #align setoid.is_partition.finpartition Setoid.IsPartition.finpartition
 
-/-- Given two equivalence relations with `r ≤ s`, a bijection between the sum of the quotients by
-`r` on each equivalence class by `s` and the quotient by `r`. -/
-def equivSigmaFibersOfLe {r s : Setoid α} (hle : r ≤ s) :
-    (Σ q : Quotient s, Quotient (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α))) ≃ 
-      Quotient r :=
-  .trans (.symm <| .sigmaCongrRight fun _ ↦ .subtypeQuotientEquivQuotientSubtype
-      (s₁ := r) (s₂ := r.comap Subtype.val) _ (fun _ ↦ Iff.rfl) fun _ _ ↦ Iff.rfl)
-    (.sigmaFiberEquiv fun a ↦ a.lift (Quotient.mk s) fun _ _ h ↦ Quotient.sound <| hle h)
-
 end Setoid
 
 /-- A finpartition gives rise to a setoid partition -/

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -328,6 +328,63 @@ def IsPartition.finpartition {c : Finset (Set α)} (hc : Setoid.IsPartition (c :
   not_bot_mem := hc.left
 #align setoid.is_partition.finpartition Setoid.IsPartition.finpartition
 
+/-- Given two equivalence relations with `r ≤ s`, a bijection between the sum of the quotients by
+`r` on each equivalence class by `s` and the quotient by `r`. -/
+noncomputable def equivSigmaFibersOfLe {r s : Setoid α} (hle : r ≤ s) :
+    (Σq : Quotient s, Quotient (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α))) ≃
+      Quotient r := by
+  calc
+    (Σq : Quotient s, Quotient (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α))) ≃
+      Σq : Quotient s, (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α)).classes :=
+        Equiv.sigmaCongrRight fun x ↦ Setoid.quotientEquivClasses _
+    _ ≃ Σq : Quotient s, (fun t ↦ (Subtype.val '' t)) ''
+          (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α)).classes :=
+        Equiv.sigmaCongrRight (fun x ↦ Equiv.Set.image _ _
+          (fun y z h ↦ (Set.image_eq_image Subtype.val_injective).1 h))
+    _ ≃ ⋃ q : Quotient s, (fun t ↦ (Subtype.val '' t)) ''
+          (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α)).classes :=
+        (Set.unionEqSigmaOfDisjoint fun i j hij ↦ Set.disjoint_left.2 fun c hc ↦ by
+          rcases hc with ⟨k, hk, rfl⟩
+          simp only [Set.mem_image, not_exists, not_and]
+          intro k' hk' he
+          have hd : Disjoint (Subtype.val '' k) (Subtype.val '' k') := by
+            by_contra hd
+            simp only [Set.not_disjoint_iff, Set.mem_image, Subtype.exists, Set.mem_preimage,
+                       Set.mem_singleton_iff, exists_and_right, exists_eq_right] at hd
+            rcases hd with ⟨x, ⟨rfl, hi⟩, ⟨rfl, hj⟩⟩
+            exact hij rfl
+          simp only [he, disjoint_self, Set.bot_eq_empty, Set.image_eq_empty] at hd
+          exact Set.not_nonempty_iff_eq_empty.2 hd
+            (nonempty_of_mem_partition (isPartition_classes _) hk)).symm
+    _ ≃ r.classes := Equiv.setCongr (by
+          ext x
+          simp only [Set.mem_iUnion, Set.mem_image, Setoid.classes, Subtype.exists,
+                     Set.mem_preimage, Set.mem_singleton_iff, Set.mem_setOf_eq]
+          refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+          · rcases h with ⟨q, x', ⟨x, rfl, rfl⟩, rfl⟩
+            refine ⟨x, ?_⟩
+            ext y
+            simp only [Set.mem_image, Set.mem_setOf_eq, Subtype.exists, Set.mem_preimage,
+                       Set.mem_singleton_iff, exists_and_right, exists_eq_right]
+            simp_rw [← Quotient.mk''_eq_mk, Quotient.eq'']
+            refine ⟨fun h ↦ ?_, fun h ↦ ⟨le_def.1 hle h, h⟩⟩
+            rcases h with ⟨_, h'⟩
+            exact h'
+          · rcases h with ⟨x, rfl⟩
+            refine ⟨Quotient.mk s x,
+                    quotientEquivClasses (r.comap (Subtype.val : Quotient.mk s ⁻¹' {⟦x⟧} → α))
+                      (Quotient.mk _ ⟨x, by simp⟩),
+                    ⟨⟨x, ⟨rfl, by simp⟩⟩, ?_⟩⟩
+            simp only [quotientEquivClasses_mk_eq]
+            ext y
+            simp only [Set.mem_image, Set.mem_setOf_eq, Subtype.exists, Set.mem_preimage,
+                       Set.mem_singleton_iff, exists_and_right, exists_eq_right]
+            simp_rw [← Quotient.mk''_eq_mk, Quotient.eq'']
+            refine ⟨fun h ↦ ?_, fun h ↦ ⟨le_def.1 hle h, h⟩⟩
+            rcases h with ⟨_, h'⟩
+            exact h')
+    _ ≃ Quotient r := r.quotientEquivClasses.symm
+
 end Setoid
 
 /-- A finpartition gives rise to a setoid partition -/


### PR DESCRIPTION
Given two equivalence relations with `r ≤ s`, define an equivalence between a sigma type for the sum of the quotients by `r` on each equivalence class by `s`, and the quotient by `r`.

The motivating example is bijecting between orbits of an action by a subgroup: the orbits considered within each orbit of the action by the full group are equivalent to the orbits when the subgroup acts directly on the whole space.  This is a generic version for an arbitrary pair of setoids with `r ≤ s`, to be used in defining the version for orbits.

Feel free to golf or suggest a better name for the equivalence.

From AperiodicMonotilesLean.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
