### PR TITLE
[Merged by Bors] - refactor: flip `LinearMap.convexHull_image` and rename to `LinearMap.image_convexHull`

### DIFF
--- a/Mathlib/Analysis/Complex/Convex.lean
+++ b/Mathlib/Analysis/Complex/Convex.lean
@@ -21,7 +21,7 @@ lemma convexHull_reProdIm (s t : Set ℝ) :
   calc
     convexHull ℝ (equivRealProdLm ⁻¹' (s ×ˢ t)) = equivRealProdLm ⁻¹' (convexHull ℝ (s ×ˢ t)) := by
       simpa only [← LinearEquiv.image_symm_eq_preimage]
-        using equivRealProdLm.symm.toLinearMap.image_convexHull (s ×ˢ t)
+        using ((equivRealProdLm.symm.toLinearMap).image_convexHull (s ×ˢ t)).symm
     _ = convexHull ℝ s ×ℂ convexHull ℝ t := by rw [convexHull_prod]; rfl
 
 /-- The slit plane is star-convex at a positive number. -/

--- a/Mathlib/Analysis/Complex/Convex.lean
+++ b/Mathlib/Analysis/Complex/Convex.lean
@@ -19,7 +19,7 @@ namespace Complex
 lemma convexHull_reProdIm (s t : Set ℝ) :
     convexHull ℝ (s ×ℂ t) = convexHull ℝ s ×ℂ convexHull ℝ t :=
   calc
-    convexHull ℝ (equivRealProdLm ⁻¹' (s ×ˢ t)) = equivRealProdLm ⁻¹' (convexHull ℝ (s ×ˢ t)) := by
+    convexHull ℝ (equivRealProdLm ⁻¹' (s ×ˢ t)) = equivRealProdLm ⁻¹' convexHull ℝ (s ×ˢ t) := by
       simpa only [← LinearEquiv.image_symm_eq_preimage]
         using ((equivRealProdLm.symm.toLinearMap).image_convexHull (s ×ˢ t)).symm
     _ = convexHull ℝ s ×ℂ convexHull ℝ t := by rw [convexHull_prod]; rfl

--- a/Mathlib/Analysis/Complex/Convex.lean
+++ b/Mathlib/Analysis/Complex/Convex.lean
@@ -21,7 +21,7 @@ lemma convexHull_reProdIm (s t : Set ℝ) :
   calc
     convexHull ℝ (equivRealProdLm ⁻¹' (s ×ˢ t)) = equivRealProdLm ⁻¹' (convexHull ℝ (s ×ˢ t)) := by
       simpa only [← LinearEquiv.image_symm_eq_preimage]
-        using equivRealProdLm.symm.toLinearMap.convexHull_image (s ×ˢ t)
+        using equivRealProdLm.symm.toLinearMap.image_convexHull (s ×ˢ t)
     _ = convexHull ℝ s ×ℂ convexHull ℝ t := by rw [convexHull_prod]; rfl
 
 /-- The slit plane is star-convex at a positive number. -/

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -459,7 +459,7 @@ theorem convexHull_prod (s : Set E) (t : Set F) :
 #align convex_hull_prod convexHull_prod
 
 theorem convexHull_add (s t : Set E) : convexHull R (s + t) = convexHull R s + convexHull R t := by
-  simp_rw [← image2_add, ← image_prod, IsLinearMap.isLinearMap_add.image_convexHull,
+  simp_rw [← image2_add, ← image_prod, ← IsLinearMap.isLinearMap_add.image_convexHull,
     convexHull_prod]
 #align convex_hull_add convexHull_add
 
@@ -523,7 +523,7 @@ theorem Set.Finite.convexHull_eq_image {s : Set E} (hs : s.Finite) : convexHull 
     haveI := hs.fintype
     (⇑(∑ x : s, (@LinearMap.proj R s _ (fun _ => R) _ _ x).smulRight x.1)) '' stdSimplex R s := by
   letI := hs.fintype
-  rw [← convexHull_basis_eq_stdSimplex, ← LinearMap.image_convexHull, ← Set.range_comp]
+  rw [← convexHull_basis_eq_stdSimplex, LinearMap.image_convexHull, ← Set.range_comp]
   apply congr_arg
   simp_rw [Function.comp]
   convert Subtype.range_coe.symm

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -459,7 +459,7 @@ theorem convexHull_prod (s : Set E) (t : Set F) :
 #align convex_hull_prod convexHull_prod
 
 theorem convexHull_add (s t : Set E) : convexHull R (s + t) = convexHull R s + convexHull R t := by
-  simp_rw [← image2_add, ← image_prod, IsLinearMap.isLinearMap_add.convexHull_image,
+  simp_rw [← image2_add, ← image_prod, IsLinearMap.isLinearMap_add.image_convexHull,
     convexHull_prod]
 #align convex_hull_add convexHull_add
 
@@ -523,7 +523,7 @@ theorem Set.Finite.convexHull_eq_image {s : Set E} (hs : s.Finite) : convexHull 
     haveI := hs.fintype
     (⇑(∑ x : s, (@LinearMap.proj R s _ (fun _ => R) _ _ x).smulRight x.1)) '' stdSimplex R s := by
   letI := hs.fintype
-  rw [← convexHull_basis_eq_stdSimplex, ← LinearMap.convexHull_image, ← Set.range_comp]
+  rw [← convexHull_basis_eq_stdSimplex, ← LinearMap.image_convexHull, ← Set.range_comp]
   apply congr_arg
   simp_rw [Function.comp]
   convert Subtype.range_coe.symm

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -477,7 +477,7 @@ noncomputable def convexHullAddMonoidHom : Set E →+ Set E where
 variable {R E}
 
 theorem convexHull_sub (s t : Set E) : convexHull R (s - t) = convexHull R s - convexHull R t := by
-  simp_rw [sub_eq_add_neg, convexHull_add, convexHull_neg]
+  simp_rw [sub_eq_add_neg, convexHull_add, ← convexHull_neg]
 #align convex_hull_sub convexHull_sub
 
 theorem convexHull_list_sum (l : List (Set E)) : convexHull R l.sum = (l.map <| convexHull R).sum :=

--- a/Mathlib/Analysis/Convex/Hull.lean
+++ b/Mathlib/Analysis/Convex/Hull.lean
@@ -158,20 +158,20 @@ theorem Convex.convex_remove_iff_not_mem_convexHull_remove {s : Set E} (hs : Con
         exact hx hy⟩
 #align convex.convex_remove_iff_not_mem_convex_hull_remove Convex.convex_remove_iff_not_mem_convexHull_remove
 
-theorem IsLinearMap.convexHull_image {f : E → F} (hf : IsLinearMap 𝕜 f) (s : Set E) :
-    convexHull 𝕜 (f '' s) = f '' convexHull 𝕜 s :=
+theorem IsLinearMap.image_convexHull {f : E → F} (hf : IsLinearMap 𝕜 f) (s : Set E) :
+    f '' convexHull 𝕜 s = convexHull 𝕜 (f '' s) :=
   Set.Subset.antisymm
-    (convexHull_min (image_subset _ (subset_convexHull 𝕜 s)) <|
-      (convex_convexHull 𝕜 s).is_linear_image hf)
     (image_subset_iff.2 <|
       convexHull_min (image_subset_iff.1 <| subset_convexHull 𝕜 _)
         ((convex_convexHull 𝕜 _).is_linear_preimage hf))
-#align is_linear_map.convex_hull_image IsLinearMap.convexHull_image
+    (convexHull_min (image_subset _ (subset_convexHull 𝕜 s)) <|
+      (convex_convexHull 𝕜 s).is_linear_image hf)
+#align is_linear_map.convex_hull_image IsLinearMap.image_convexHull
 
-theorem LinearMap.convexHull_image (f : E →ₗ[𝕜] F) (s : Set E) :
-    convexHull 𝕜 (f '' s) = f '' convexHull 𝕜 s :=
-  f.isLinear.convexHull_image s
-#align linear_map.convex_hull_image LinearMap.convexHull_image
+theorem LinearMap.image_convexHull (f : E →ₗ[𝕜] F) (s : Set E) :
+    f '' convexHull 𝕜 s = convexHull 𝕜 (f '' s) :=
+  f.isLinear.image_convexHull s
+#align linear_map.convex_hull_image LinearMap.image_convexHull
 
 end AddCommMonoid
 
@@ -182,7 +182,7 @@ section OrderedCommSemiring
 variable [OrderedCommSemiring 𝕜] [AddCommMonoid E] [Module 𝕜 E]
 
 theorem convexHull_smul (a : 𝕜) (s : Set E) : convexHull 𝕜 (a • s) = a • convexHull 𝕜 s :=
-  (LinearMap.lsmul _ _ a).convexHull_image _
+  ((LinearMap.lsmul _ _ a).image_convexHull _).symm
 #align convex_hull_smul convexHull_smul
 
 end OrderedCommSemiring

--- a/Mathlib/Analysis/Convex/Hull.lean
+++ b/Mathlib/Analysis/Convex/Hull.lean
@@ -195,7 +195,7 @@ section AddCommGroup
 
 variable [AddCommGroup E] [AddCommGroup F] [Module 𝕜 E] [Module 𝕜 F]
 
-theorem AffineMap.image_convexHull (f : E →ᵃ[𝕜] F) (s : Set E) :
+theorem AffineMap.convexHull_image (f : E →ᵃ[𝕜] F) (s : Set E) :
     convexHull 𝕜 (f '' s) = f '' convexHull 𝕜 s := by
   apply Set.Subset.antisymm
   · exact convexHull_min (Set.image_subset _ (subset_convexHull 𝕜 s))
@@ -204,7 +204,7 @@ theorem AffineMap.image_convexHull (f : E →ᵃ[𝕜] F) (s : Set E) :
     refine' convexHull_min _ ((convex_convexHull 𝕜 (f '' s)).affine_preimage f)
     rw [← Set.image_subset_iff]
     exact subset_convexHull 𝕜 (f '' s)
-#align affine_map.image_convex_hull AffineMap.image_convexHull
+#align affine_map.image_convex_hull AffineMap.convexHull_image
 
 theorem convexHull_subset_affineSpan (s : Set E) : convexHull 𝕜 s ⊆ (affineSpan 𝕜 s : Set E) :=
   convexHull_min (subset_affineSpan 𝕜 s) (affineSpan 𝕜 s).convex
@@ -219,7 +219,7 @@ theorem affineSpan_convexHull (s : Set E) : affineSpan 𝕜 (convexHull 𝕜 s) 
 
 theorem convexHull_neg (s : Set E) : convexHull 𝕜 (-s) = -convexHull 𝕜 s := by
   simp_rw [← image_neg]
-  exact AffineMap.image_convexHull (-1) _
+  exact AffineMap.convexHull_image (-1) _
 #align convex_hull_neg convexHull_neg
 
 end AddCommGroup

--- a/Mathlib/Analysis/Convex/Hull.lean
+++ b/Mathlib/Analysis/Convex/Hull.lean
@@ -181,8 +181,8 @@ section OrderedCommSemiring
 
 variable [OrderedCommSemiring 𝕜] [AddCommMonoid E] [Module 𝕜 E]
 
-theorem convexHull_smul (a : 𝕜) (s : Set E) : convexHull 𝕜 (a • s) = a • convexHull 𝕜 s :=
-  ((LinearMap.lsmul _ _ a).image_convexHull _).symm
+theorem convexHull_smul (a : 𝕜) (s : Set E) : a • convexHull 𝕜 s = convexHull 𝕜 (a • s) :=
+  (LinearMap.lsmul _ _ a).image_convexHull _
 #align convex_hull_smul convexHull_smul
 
 end OrderedCommSemiring
@@ -217,9 +217,9 @@ theorem affineSpan_convexHull (s : Set E) : affineSpan 𝕜 (convexHull 𝕜 s) 
   exact convexHull_subset_affineSpan s
 #align affine_span_convex_hull affineSpan_convexHull
 
-theorem convexHull_neg (s : Set E) : convexHull 𝕜 (-s) = -convexHull 𝕜 s := by
+theorem convexHull_neg (s : Set E) : -convexHull 𝕜 s = convexHull 𝕜 (-s) := by
   simp_rw [← image_neg]
-  exact (AffineMap.image_convexHull (-1) _).symm
+  exact AffineMap.image_convexHull (-1) _
 #align convex_hull_neg convexHull_neg
 
 end AddCommGroup

--- a/Mathlib/Analysis/Convex/Hull.lean
+++ b/Mathlib/Analysis/Convex/Hull.lean
@@ -196,14 +196,14 @@ section AddCommGroup
 variable [AddCommGroup E] [AddCommGroup F] [Module 𝕜 E] [Module 𝕜 F]
 
 theorem AffineMap.image_convexHull (f : E →ᵃ[𝕜] F) (s : Set E) :
-    f '' convexHull 𝕜 s = convexHull 𝕜 (f '' s) := by
+    convexHull 𝕜 (f '' s) = f '' convexHull 𝕜 s := by
   apply Set.Subset.antisymm
+  · exact convexHull_min (Set.image_subset _ (subset_convexHull 𝕜 s))
+      ((convex_convexHull 𝕜 s).affine_image f)
   · rw [Set.image_subset_iff]
     refine' convexHull_min _ ((convex_convexHull 𝕜 (f '' s)).affine_preimage f)
     rw [← Set.image_subset_iff]
     exact subset_convexHull 𝕜 (f '' s)
-  · exact convexHull_min (Set.image_subset _ (subset_convexHull 𝕜 s))
-      ((convex_convexHull 𝕜 s).affine_image f)
 #align affine_map.image_convex_hull AffineMap.image_convexHull
 
 theorem convexHull_subset_affineSpan (s : Set E) : convexHull 𝕜 s ⊆ (affineSpan 𝕜 s : Set E) :=
@@ -219,7 +219,7 @@ theorem affineSpan_convexHull (s : Set E) : affineSpan 𝕜 (convexHull 𝕜 s) 
 
 theorem convexHull_neg (s : Set E) : convexHull 𝕜 (-s) = -convexHull 𝕜 s := by
   simp_rw [← image_neg]
-  exact (AffineMap.image_convexHull (-1) _).symm
+  exact AffineMap.image_convexHull (-1) _
 #align convex_hull_neg convexHull_neg
 
 end AddCommGroup

--- a/Mathlib/Analysis/Convex/Hull.lean
+++ b/Mathlib/Analysis/Convex/Hull.lean
@@ -193,9 +193,9 @@ variable [OrderedRing 𝕜]
 
 section AddCommGroup
 
-variable [AddCommGroup E] [AddCommGroup F] [Module 𝕜 E] [Module 𝕜 F] (s : Set E)
+variable [AddCommGroup E] [AddCommGroup F] [Module 𝕜 E] [Module 𝕜 F]
 
-theorem AffineMap.image_convexHull (f : E →ᵃ[𝕜] F) :
+theorem AffineMap.image_convexHull (f : E →ᵃ[𝕜] F) (s : Set E) :
     f '' convexHull 𝕜 s = convexHull 𝕜 (f '' s) := by
   apply Set.Subset.antisymm
   · rw [Set.image_subset_iff]
@@ -206,12 +206,12 @@ theorem AffineMap.image_convexHull (f : E →ᵃ[𝕜] F) :
       ((convex_convexHull 𝕜 s).affine_image f)
 #align affine_map.image_convex_hull AffineMap.image_convexHull
 
-theorem convexHull_subset_affineSpan : convexHull 𝕜 s ⊆ (affineSpan 𝕜 s : Set E) :=
+theorem convexHull_subset_affineSpan (s : Set E) : convexHull 𝕜 s ⊆ (affineSpan 𝕜 s : Set E) :=
   convexHull_min (subset_affineSpan 𝕜 s) (affineSpan 𝕜 s).convex
 #align convex_hull_subset_affine_span convexHull_subset_affineSpan
 
 @[simp]
-theorem affineSpan_convexHull : affineSpan 𝕜 (convexHull 𝕜 s) = affineSpan 𝕜 s := by
+theorem affineSpan_convexHull (s : Set E) : affineSpan 𝕜 (convexHull 𝕜 s) = affineSpan 𝕜 s := by
   refine' le_antisymm _ (affineSpan_mono 𝕜 (subset_convexHull 𝕜 s))
   rw [affineSpan_le]
   exact convexHull_subset_affineSpan s
@@ -219,7 +219,7 @@ theorem affineSpan_convexHull : affineSpan 𝕜 (convexHull 𝕜 s) = affineSpan
 
 theorem convexHull_neg (s : Set E) : convexHull 𝕜 (-s) = -convexHull 𝕜 s := by
   simp_rw [← image_neg]
-  exact (AffineMap.image_convexHull _ <| -1).symm
+  exact (AffineMap.image_convexHull (-1) _).symm
 #align convex_hull_neg convexHull_neg
 
 end AddCommGroup

--- a/Mathlib/Analysis/Convex/Hull.lean
+++ b/Mathlib/Analysis/Convex/Hull.lean
@@ -195,16 +195,16 @@ section AddCommGroup
 
 variable [AddCommGroup E] [AddCommGroup F] [Module 𝕜 E] [Module 𝕜 F]
 
-theorem AffineMap.convexHull_image (f : E →ᵃ[𝕜] F) (s : Set E) :
-    convexHull 𝕜 (f '' s) = f '' convexHull 𝕜 s := by
+theorem AffineMap.image_convexHull (f : E →ᵃ[𝕜] F) (s : Set E) :
+    f '' convexHull 𝕜 s = convexHull 𝕜 (f '' s) := by
   apply Set.Subset.antisymm
-  · exact convexHull_min (Set.image_subset _ (subset_convexHull 𝕜 s))
-      ((convex_convexHull 𝕜 s).affine_image f)
   · rw [Set.image_subset_iff]
-    refine' convexHull_min _ ((convex_convexHull 𝕜 (f '' s)).affine_preimage f)
+    refine convexHull_min ?_ ((convex_convexHull 𝕜 (f '' s)).affine_preimage f)
     rw [← Set.image_subset_iff]
     exact subset_convexHull 𝕜 (f '' s)
-#align affine_map.image_convex_hull AffineMap.convexHull_image
+  · exact convexHull_min (Set.image_subset _ (subset_convexHull 𝕜 s))
+      ((convex_convexHull 𝕜 s).affine_image f)
+#align affine_map.image_convex_hull AffineMap.image_convexHull
 
 theorem convexHull_subset_affineSpan (s : Set E) : convexHull 𝕜 s ⊆ (affineSpan 𝕜 s : Set E) :=
   convexHull_min (subset_affineSpan 𝕜 s) (affineSpan 𝕜 s).convex
@@ -219,7 +219,7 @@ theorem affineSpan_convexHull (s : Set E) : affineSpan 𝕜 (convexHull 𝕜 s) 
 
 theorem convexHull_neg (s : Set E) : convexHull 𝕜 (-s) = -convexHull 𝕜 s := by
   simp_rw [← image_neg]
-  exact AffineMap.convexHull_image (-1) _
+  exact (AffineMap.image_convexHull (-1) _).symm
 #align convex_hull_neg convexHull_neg
 
 end AddCommGroup


### PR DESCRIPTION
- flip `LinearMap.convexHull_image` and rename to `image_convexHull`
- while at it, also flip the direction of `convexHull_smul` and `convexHull_neg` to match this

- fix argument order of `AffineMap.convexHull_image`: have the `AffineMap` argument come first; there's no good reason not to and this enables dot notation
- inline variable `(s : Set E)` to achieve this; this is slightly clearer anyway

[zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/image_convexHull.20vs.20convexHull_image)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
