### PR TITLE
[Merged by Bors] - chore: replace `λ` by `fun`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Order.lean
+++ b/Mathlib/Algebra/BigOperators/Order.lean
@@ -754,9 +754,9 @@ theorem prod_mono' : Monotone fun f : ι → M ↦ ∏ i, f i := fun _ _ hfg ↦
 #align fintype.sum_mono Fintype.sum_mono
 
 @[to_additive sum_nonneg]
-lemma one_le_prod (hf : 1 ≤ f) : 1 ≤ ∏ i, f i := Finset.one_le_prod' λ _ _ ↦ hf _
+lemma one_le_prod (hf : 1 ≤ f) : 1 ≤ ∏ i, f i := Finset.one_le_prod' fun _ _ ↦ hf _
 
-@[to_additive] lemma prod_le_one (hf : f ≤ 1) : ∏ i, f i ≤ 1 := Finset.prod_le_one' λ _ _ ↦ hf _
+@[to_additive] lemma prod_le_one (hf : f ≤ 1) : ∏ i, f i ≤ 1 := Finset.prod_le_one' fun _ _ ↦ hf _
 
 @[to_additive]
 lemma prod_eq_one_iff_of_one_le (hf : 1 ≤ f) : ∏ i, f i = 1 ↔ f = 1 :=
@@ -781,11 +781,11 @@ theorem prod_strictMono' : StrictMono fun f : ι → M ↦ ∏ x, f x :=
 
 @[to_additive sum_pos]
 lemma one_lt_prod (hf : 1 < f) : 1 < ∏ i, f i :=
-  Finset.one_lt_prod' (λ _ _ ↦ hf.le _) <| by simpa using (Pi.lt_def.1 hf).2
+  Finset.one_lt_prod' (fun _ _ ↦ hf.le _) <| by simpa using (Pi.lt_def.1 hf).2
 
 @[to_additive]
 lemma prod_lt_one (hf : f < 1) : ∏ i, f i < 1 :=
-  Finset.prod_lt_one' (λ _ _ ↦ hf.le _) <| by simpa using (Pi.lt_def.1 hf).2
+  Finset.prod_lt_one' (fun _ _ ↦ hf.le _) <| by simpa using (Pi.lt_def.1 hf).2
 
 @[to_additive sum_pos_iff_of_nonneg]
 lemma one_lt_prod_iff_of_one_le (hf : 1 ≤ f) : 1 < ∏ i, f i ↔ 1 < f := by

--- a/Mathlib/Algebra/Field/ULift.lean
+++ b/Mathlib/Algebra/Field/ULift.lean
@@ -21,7 +21,7 @@ variable {α : Type u} {x y : ULift.{v} α}
 
 namespace ULift
 
-instance [RatCast α] : RatCast (ULift α) := ⟨λ a ↦ up a⟩
+instance [RatCast α] : RatCast (ULift α) := ⟨fun a ↦ up a⟩
 
 @[simp, norm_cast]
 theorem up_ratCast [RatCast α] (q : ℚ) : up (q : α) = q :=

--- a/Mathlib/Algebra/Field/ULift.lean
+++ b/Mathlib/Algebra/Field/ULift.lean
@@ -21,7 +21,7 @@ variable {α : Type u} {x y : ULift.{v} α}
 
 namespace ULift
 
-instance [RatCast α] : RatCast (ULift α) := ⟨fun a ↦ up a⟩
+instance [RatCast α] : RatCast (ULift α) := ⟨(up ·)⟩
 
 @[simp, norm_cast]
 theorem up_ratCast [RatCast α] (q : ℚ) : up (q : α) = q :=

--- a/Mathlib/Algebra/GCDMonoid/Multiset.lean
+++ b/Mathlib/Algebra/GCDMonoid/Multiset.lean
@@ -235,7 +235,7 @@ theorem extract_gcd' (s t : Multiset α) (hs : ∃ x, x ∈ s ∧ x ≠ (0 : α)
 converted to `Multiset.replicate` format yet, so I made some ad hoc ones in `Data.Multiset.Basic`
 using the originals. -/
 /- Porting note: The old proof used a strange form
-`have := _, refine ⟨s.pmap @f (λ _, id), this, extract_gcd' s _ h this⟩,`
+`have := _, refine ⟨s.pmap @f (fun _ ↦ id), this, extract_gcd' s _ h this⟩,`
 so I rearranged the proof slightly. -/
 theorem extract_gcd (s : Multiset α) (hs : s ≠ 0) :
     ∃ t : Multiset α, s = t.map (s.gcd * ·) ∧ t.gcd = 1 := by

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -381,8 +381,8 @@ instance addCommMonoidWithOne [AddCommMonoidWithOne α] : AddCommMonoidWithOne �
 
 instance addCommGroupWithOne [AddCommGroupWithOne α] : AddCommGroupWithOne αᵃᵒᵖ :=
   { AddOpposite.addCommMonoidWithOne α, AddOpposite.addCommGroup α, AddOpposite.intCast α with
-    intCast_ofNat := λ _ ↦ congr_arg op <| Int.cast_ofNat _
-    intCast_negSucc := λ _ ↦ congr_arg op <| Int.cast_negSucc _ }
+    intCast_ofNat := fun _ ↦ congr_arg op <| Int.cast_ofNat _
+    intCast_negSucc := fun _ ↦ congr_arg op <| Int.cast_negSucc _ }
 
 variable {α}
 

--- a/Mathlib/Algebra/Group/ULift.lean
+++ b/Mathlib/Algebra/Group/ULift.lean
@@ -182,7 +182,7 @@ theorem down_intCast [IntCast α] (n : ℤ) : down (n : ULift α) = n :=
 
 instance addMonoidWithOne [AddMonoidWithOne α] : AddMonoidWithOne (ULift α) :=
   { ULift.one, ULift.addMonoid with
-      natCast := fun n => ⟨n⟩
+      natCast := (⟨·⟩)
       natCast_zero := congr_arg ULift.up Nat.cast_zero,
       natCast_succ := fun _ => congr_arg ULift.up (Nat.cast_succ _) }
 #align ulift.add_monoid_with_one ULift.addMonoidWithOne
@@ -222,7 +222,7 @@ instance commGroup [CommGroup α] : CommGroup (ULift α) :=
 
 instance addGroupWithOne [AddGroupWithOne α] : AddGroupWithOne (ULift α) :=
   { ULift.addMonoidWithOne, ULift.addGroup with
-      intCast := fun n => ⟨n⟩,
+      intCast := (⟨·⟩),
       intCast_ofNat := fun _ => congr_arg ULift.up (Int.cast_ofNat _),
       intCast_negSucc := fun _ => congr_arg ULift.up (Int.cast_negSucc _) }
 #align ulift.add_group_with_one ULift.addGroupWithOne

--- a/Mathlib/Algebra/Group/ULift.lean
+++ b/Mathlib/Algebra/Group/ULift.lean
@@ -143,9 +143,9 @@ instance commMonoid [CommMonoid α] : CommMonoid (ULift α) :=
 #align ulift.comm_monoid ULift.commMonoid
 #align ulift.add_comm_monoid ULift.addCommMonoid
 
-instance natCast [NatCast α] : NatCast (ULift α) := ⟨fun a ↦ up a⟩
+instance natCast [NatCast α] : NatCast (ULift α) := ⟨(up ·)⟩
 #align ulift.has_nat_cast ULift.natCast
-instance intCast [IntCast α] : IntCast (ULift α) := ⟨fun a ↦ up a⟩
+instance intCast [IntCast α] : IntCast (ULift α) := ⟨(up ·)⟩
 #align ulift.has_int_cast ULift.intCast
 
 @[simp, norm_cast]

--- a/Mathlib/Algebra/Group/ULift.lean
+++ b/Mathlib/Algebra/Group/ULift.lean
@@ -143,9 +143,9 @@ instance commMonoid [CommMonoid α] : CommMonoid (ULift α) :=
 #align ulift.comm_monoid ULift.commMonoid
 #align ulift.add_comm_monoid ULift.addCommMonoid
 
-instance natCast [NatCast α] : NatCast (ULift α) := ⟨λ a ↦ up a⟩
+instance natCast [NatCast α] : NatCast (ULift α) := ⟨fun a ↦ up a⟩
 #align ulift.has_nat_cast ULift.natCast
-instance intCast [IntCast α] : IntCast (ULift α) := ⟨λ a ↦ up a⟩
+instance intCast [IntCast α] : IntCast (ULift α) := ⟨fun a ↦ up a⟩
 #align ulift.has_int_cast ULift.intCast
 
 @[simp, norm_cast]

--- a/Mathlib/Algebra/Homology/HomologicalComplexLimits.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplexLimits.lean
@@ -181,7 +181,7 @@ def preservesLimitsOfShapeOfEval {D : Type*} [Category D]
     (G : D ⥤ HomologicalComplex C c)
     (_ : ∀ (i : ι), PreservesLimitsOfShape J (G ⋙ eval C c i)) :
     PreservesLimitsOfShape J G :=
-  ⟨fun {_} => ⟨fun hs =>  isLimitOfEval _ _
+  ⟨fun {_} => ⟨fun hs ↦ isLimitOfEval _ _
     (fun i => isLimitOfPreserves (G ⋙ eval C c i) hs)⟩⟩
 
 /-- A functor `D ⥤ HomologicalComplex C c` preserves colimits of shape `J`
@@ -190,7 +190,7 @@ def preservesColimitsOfShapeOfEval {D : Type*} [Category D]
     (G : D ⥤ HomologicalComplex C c)
     (_ : ∀ (i : ι), PreservesColimitsOfShape J (G ⋙ eval C c i)) :
     PreservesColimitsOfShape J G :=
-  ⟨fun {_} => ⟨fun hs =>  isColimitOfEval _ _
+  ⟨fun {_} => ⟨fun hs ↦ isColimitOfEval _ _
     (fun i => isColimitOfPreserves (G ⋙ eval C c i) hs)⟩⟩
 
 end HomologicalComplex

--- a/Mathlib/Algebra/Module/Injective.lean
+++ b/Mathlib/Algebra/Module/Injective.lean
@@ -445,7 +445,7 @@ protected theorem extension_property (h : Module.Baer R Q)
     { toFun := ((extensionOfMax f g).toLinearPMap
         ⟨·, (extensionOfMax_to_submodule_eq_top f g h).symm ▸ ⟨⟩⟩)
       map_add' := fun x y ↦ by rw [← LinearPMap.map_add]; congr
-      map_smul' := fun r x ↦  by rw [← LinearPMap.map_smul]; dsimp } <|
+      map_smul' := fun r x ↦ by rw [← LinearPMap.map_smul]; dsimp } <|
     LinearMap.ext fun x ↦ ((extensionOfMax f g).is_extension x).symm
 
 theorem extension_property_addMonoidHom (h : Module.Baer ℤ Q)

--- a/Mathlib/Algebra/Module/Zlattice.lean
+++ b/Mathlib/Algebra/Module/Zlattice.lean
@@ -481,7 +481,7 @@ theorem Zlattice.rank : finrank ℤ L = finrank K E := by
     have h_mapsto : Set.MapsTo (fun n : ℤ => Zspan.fract e (n • v)) Set.univ
         (Metric.closedBall 0 (∑ i, ‖e i‖) ∩ (L : Set E)) := by
       rw [Set.mapsTo_inter, Set.mapsTo_univ_iff, Set.mapsTo_univ_iff]
-      refine ⟨fun _ =>  mem_closedBall_zero_iff.mpr (Zspan.norm_fract_le e _), fun _ => ?_⟩
+      refine ⟨fun _ ↦ mem_closedBall_zero_iff.mpr (Zspan.norm_fract_le e _), fun _ => ?_⟩
       · change _ ∈ AddSubgroup.toIntSubmodule L
         rw [← h_spanL]
         refine sub_mem ?_ ?_

--- a/Mathlib/Algebra/Order/UpperLower.lean
+++ b/Mathlib/Algebra/Order/UpperLower.lean
@@ -161,7 +161,7 @@ theorem Ici_one : Ici (1 : α) = 1 :=
 
 @[to_additive]
 instance : MulAction α (UpperSet α) :=
-  SetLike.coe_injective.mulAction _ (λ _ _ => rfl)
+  SetLike.coe_injective.mulAction _ (fun _ _ => rfl)
 
 @[to_additive]
 instance commSemigroup : CommSemigroup (UpperSet α) :=
@@ -223,7 +223,7 @@ theorem Iic_one : Iic (1 : α) = 1 :=
 
 @[to_additive]
 instance : MulAction α (LowerSet α) :=
-  SetLike.coe_injective.mulAction _ (λ _ _ => rfl)
+  SetLike.coe_injective.mulAction _ (fun _ _ => rfl)
 
 @[to_additive]
 instance commSemigroup : CommSemigroup (LowerSet α) :=

--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -393,7 +393,7 @@ theorem coe_smul [SMulZeroClass S R] (s : S) (r : R) :
 
 instance : AddCommGroup ℍ[R,c₁,c₂] :=
   (equivProd c₁ c₂).injective.addCommGroup _ rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
-    (λ _ _ ↦ rfl) (λ _ _ ↦ rfl)
+    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 instance : AddCommGroupWithOne ℍ[R,c₁,c₂] where
   natCast n := ((n : R) : ℍ[R,c₁,c₂])

--- a/Mathlib/Algebra/SMulWithZero.lean
+++ b/Mathlib/Algebra/SMulWithZero.lean
@@ -161,7 +161,7 @@ instance MonoidWithZero.toOppositeMulActionWithZero : MulActionWithZero Rᵐᵒ�
 
 protected lemma MulActionWithZero.subsingleton
     [MulActionWithZero R M] [Subsingleton R] : Subsingleton M :=
-  ⟨λ x y => by
+  ⟨fun x y => by
     rw [← one_smul R x, ← one_smul R y, Subsingleton.elim (1 : R) 0, zero_smul, zero_smul]⟩
 #align mul_action_with_zero.subsingleton MulActionWithZero.subsingleton
 

--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -61,7 +61,7 @@ lemma FormalMultilinearSeries.radius_prod_eq_min
     rw [lt_min_iff] at hr
     have := ((p.isLittleO_one_of_lt_radius hr.1).add
       (q.isLittleO_one_of_lt_radius hr.2)).isBigO
-    refine (p.prod q).le_radius_of_isBigO ((isBigO_of_le _ λ n ↦ ?_).trans this)
+    refine (p.prod q).le_radius_of_isBigO ((isBigO_of_le _ fun n ↦ ?_).trans this)
     rw [norm_mul, norm_norm, ← add_mul, norm_mul]
     refine mul_le_mul_of_nonneg_right ?_ (norm_nonneg _)
     rw [FormalMultilinearSeries.prod, ContinuousMultilinearMap.opNorm_prod]

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -242,7 +242,7 @@ theorem Finset.centerMass_mem_convexHull (t : Finset ι) {w : ι → R} (hw₀ :
 lemma Finset.centerMass_mem_convexHull_of_nonpos (t : Finset ι) (hw₀ : ∀ i ∈ t, w i ≤ 0)
     (hws : ∑ i in t, w i < 0) (hz : ∀ i ∈ t, z i ∈ s) : t.centerMass w z ∈ convexHull R s := by
   rw [← centerMass_neg_left]
-  exact Finset.centerMass_mem_convexHull _ (λ _i hi ↦ neg_nonneg.2 <| hw₀ _ hi) (by simpa) hz
+  exact Finset.centerMass_mem_convexHull _ (fun _i hi ↦ neg_nonneg.2 <| hw₀ _ hi) (by simpa) hz
 
 /-- A refinement of `Finset.centerMass_mem_convexHull` when the indexed family is a `Finset` of
 the space. -/

--- a/Mathlib/Analysis/Convex/Radon.lean
+++ b/Mathlib/Analysis/Convex/Radon.lean
@@ -37,7 +37,7 @@ theorem radon_partition (h : ¬ AffineIndependent 𝕜 f) :
   have hI : 0 < ∑ i in I, w i := by
     rcases exists_pos_of_sum_zero_of_exists_nonzero _ h_wsum ⟨nonzero_w_index, h1, h2⟩
       with ⟨pos_w_index, h1', h2'⟩
-    exact sum_pos' (λ _i hi ↦ (mem_filter.1 hi).2)
+    exact sum_pos' (fun _i hi ↦ (mem_filter.1 hi).2)
       ⟨pos_w_index, by simp only [I, mem_filter, h1', h2'.le, and_self, h2']⟩
   have hp : centerMass J w f = p := Finset.centerMass_of_sum_add_sum_eq_zero hJI <| by
     simpa only [← h_vsum, not_lt] using sum_filter_add_sum_filter_not s (fun i ↦ w i < 0) _

--- a/Mathlib/Analysis/NormedSpace/BoundedLinearMaps.lean
+++ b/Mathlib/Analysis/NormedSpace/BoundedLinearMaps.lean
@@ -400,7 +400,7 @@ open Asymptotics in
 /-- Useful to use together with `Continuous.comp₂`. -/
 theorem IsBoundedBilinearMap.continuous (h : IsBoundedBilinearMap 𝕜 f) : Continuous f := by
   refine continuous_iff_continuousAt.2 fun x ↦ tendsto_sub_nhds_zero_iff.1 ?_
-  suffices Tendsto (λ y : E × F ↦ f (y.1 - x.1, y.2) + f (x.1, y.2 - x.2)) (𝓝 x) (𝓝 (0 + 0)) by
+  suffices Tendsto (fun y : E × F ↦ f (y.1 - x.1, y.2) + f (x.1, y.2 - x.2)) (𝓝 x) (𝓝 (0 + 0)) by
     simpa only [h.map_sub_left, h.map_sub_right, sub_add_sub_cancel, zero_add] using this
   apply Tendsto.add
   · rw [← isLittleO_one_iff ℝ, ← one_mul 1]

--- a/Mathlib/Analysis/NormedSpace/LpEquiv.lean
+++ b/Mathlib/Analysis/NormedSpace/LpEquiv.lean
@@ -15,9 +15,9 @@ import Mathlib.Topology.ContinuousFunction.Bounded
 In this file we collect a variety of equivalences among various $L^p$ spaces.  In particular,
 when `α` is a `Fintype`, given `E : α → Type u` and `p : ℝ≥0∞`, there is a natural linear isometric
 equivalence `lpPiLpₗᵢₓ : lp E p ≃ₗᵢ PiLp p E`. In addition, when `α` is a discrete topological
-space, the bounded continuous functions `α →ᵇ β` correspond exactly to `lp (λ _, β) ∞`. Here there
-can be more structure, including ring and algebra structures, and we implement these equivalences
-accordingly as well.
+space, the bounded continuous functions `α →ᵇ β` correspond exactly to `lp (fun _ ↦ β) ∞`.
+Here there can be more structure, including ring and algebra structures,
+and we implement these equivalences accordingly as well.
 
 We keep this as a separate file so that the various $L^p$ space files don't import the others.
 

--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -68,7 +68,7 @@ theorem locally_lipschitz_exp {r : ℝ} (hr_nonneg : 0 ≤ r) (hr_le : r ≤ 1) 
 theorem continuous_exp : Continuous exp :=
   continuous_iff_continuousAt.mpr fun x =>
     continuousAt_of_locally_lipschitz zero_lt_one (2 * ‖exp x‖)
-      (λ y => by
+      (fun y ↦ by
         convert locally_lipschitz_exp zero_le_one le_rfl x y using 2
         congr
         ring)

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -57,7 +57,7 @@ lemma tendsto_rpow_atTop_of_base_lt_one (b : ℝ) (hb₀ : -1 < b) (hb₁ : b < 
     Tendsto (rpow b) atTop (𝓝 (0:ℝ)) := by
   show Tendsto (fun z => b^z) atTop (𝓝 0)
   rcases lt_trichotomy b 0 with hb|rfl|hb
-  case inl =>   -- b < 0
+  case inl => -- b < 0
     simp_rw [Real.rpow_def_of_nonpos hb.le, hb.ne, ite_false]
     rw [← isLittleO_const_iff (c := (1:ℝ)) one_ne_zero, (one_mul (1 : ℝ)).symm]
     refine IsLittleO.mul_isBigO ?exp ?cos
@@ -69,12 +69,12 @@ lemma tendsto_rpow_atTop_of_base_lt_one (b : ℝ) (hb₀ : -1 < b) (hb₁ : b < 
     case cos =>
       rw [isBigO_iff]
       exact ⟨1, eventually_of_forall fun x => by simp [Real.abs_cos_le_one]⟩
-  case inr.inl =>  -- b = 0
+  case inr.inl => -- b = 0
     refine Tendsto.mono_right ?_ (Iff.mpr pure_le_nhds_iff rfl)
     rw [tendsto_pure]
     filter_upwards [eventually_ne_atTop 0] with _ hx
     simp [hx]
-  case inr.inr =>   -- b > 0
+  case inr.inr => -- b > 0
     simp_rw [Real.rpow_def_of_pos hb]
     refine tendsto_exp_atBot.comp <| (tendsto_const_mul_atBot_of_neg ?_).mpr tendsto_id
     exact (log_neg_iff hb).mpr hb₁

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -693,7 +693,7 @@ theorem tendsto_nat_ceil_div_atTop : Tendsto (fun x ↦ (⌈x⌉₊ : R) / x) at
   simpa using tendsto_nat_ceil_mul_div_atTop (zero_le_one' R)
 #align tendsto_nat_ceil_div_at_top tendsto_nat_ceil_div_atTop
 
-lemma Nat.tendsto_div_const_atTop {n : ℕ} (hn : n ≠ 0) : Tendsto (fun x ↦ x / n) atTop atTop := by
+lemma Nat.tendsto_div_const_atTop {n : ℕ} (hn : n ≠ 0) : Tendsto (· / n) atTop atTop := by
   rw [Tendsto, map_div_atTop_eq_nat n hn.bot_lt]
 
 end

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -693,7 +693,7 @@ theorem tendsto_nat_ceil_div_atTop : Tendsto (fun x ↦ (⌈x⌉₊ : R) / x) at
   simpa using tendsto_nat_ceil_mul_div_atTop (zero_le_one' R)
 #align tendsto_nat_ceil_div_at_top tendsto_nat_ceil_div_atTop
 
-lemma Nat.tendsto_div_const_atTop {n : ℕ} (hn : n ≠ 0) : Tendsto (λ x ↦ x / n) atTop atTop := by
+lemma Nat.tendsto_div_const_atTop {n : ℕ} (hn : n ≠ 0) : Tendsto (fun x ↦ x / n) atTop atTop := by
   rw [Tendsto, map_div_atTop_eq_nat n hn.bot_lt]
 
 end

--- a/Mathlib/Combinatorics/Additive/Energy.lean
+++ b/Mathlib/Combinatorics/Additive/Energy.lean
@@ -17,8 +17,8 @@ additive combinatorics.
 ## TODO
 
 It's possibly interesting to have
-`(s ×ˢ s) ×ˢ t ×ˢ t).filter (λ x : (α × α) × α × α, x.1.1 * x.2.1 = x.1.2 * x.2.2)` (whose `card`
-is `multiplicativeEnergy s t`) as a standalone definition.
+`(s ×ˢ s) ×ˢ t ×ˢ t).filter (fun x : (α × α) × α × α ↦ x.1.1 * x.2.1 = x.1.2 * x.2.2)`
+(whose `card` is `multiplicativeEnergy s t`) as a standalone definition.
 -/
 
 

--- a/Mathlib/Combinatorics/Quiver/Cast.lean
+++ b/Mathlib/Combinatorics/Quiver/Cast.lean
@@ -32,7 +32,7 @@ namespace Quiver
 
 /-- Change the endpoints of an arrow using equalities. -/
 def Hom.cast {u v u' v' : U} (hu : u = u') (hv : v = v') (e : u ⟶ v) : u' ⟶ v' :=
-  Eq.ndrec (motive := λ x => x ⟶ v') (Eq.ndrec e hv) hu
+  Eq.ndrec (motive := fun x ↦ x ⟶ v') (Eq.ndrec e hv) hu
 #align quiver.hom.cast Quiver.Hom.cast
 
 theorem Hom.cast_eq_cast {u v u' v' : U} (hu : u = u') (hv : v = v') (e : u ⟶ v) :
@@ -81,7 +81,7 @@ open Path
 
 /-- Change the endpoints of a path using equalities. -/
 def Path.cast {u v u' v' : U} (hu : u = u') (hv : v = v') (p : Path u v) : Path u' v' :=
-  Eq.ndrec (motive := λ x => Path x v') (Eq.ndrec p hv) hu
+  Eq.ndrec (motive := fun x ↦ Path x v') (Eq.ndrec p hv) hu
 #align quiver.path.cast Quiver.Path.cast
 
 theorem Path.cast_eq_cast {u v u' v' : U} (hu : u = u') (hv : v = v') (p : Path u v) :

--- a/Mathlib/Combinatorics/Quiver/Cast.lean
+++ b/Mathlib/Combinatorics/Quiver/Cast.lean
@@ -32,7 +32,7 @@ namespace Quiver
 
 /-- Change the endpoints of an arrow using equalities. -/
 def Hom.cast {u v u' v' : U} (hu : u = u') (hv : v = v') (e : u ⟶ v) : u' ⟶ v' :=
-  Eq.ndrec (motive := fun x ↦ x ⟶ v') (Eq.ndrec e hv) hu
+  Eq.ndrec (motive := (· ⟶ v')) (Eq.ndrec e hv) hu
 #align quiver.hom.cast Quiver.Hom.cast
 
 theorem Hom.cast_eq_cast {u v u' v' : U} (hu : u = u') (hv : v = v') (e : u ⟶ v) :
@@ -81,7 +81,7 @@ open Path
 
 /-- Change the endpoints of a path using equalities. -/
 def Path.cast {u v u' v' : U} (hu : u = u') (hv : v = v') (p : Path u v) : Path u' v' :=
-  Eq.ndrec (motive := fun x ↦ Path x v') (Eq.ndrec p hv) hu
+  Eq.ndrec (motive := (Path · v')) (Eq.ndrec p hv) hu
 #align quiver.path.cast Quiver.Path.cast
 
 theorem Path.cast_eq_cast {u v u' v' : U} (hu : u = u') (hv : v = v') (p : Path u v) :

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -63,7 +63,7 @@ structure IsTree : Prop where
 
 variable {G}
 
-@[simp] lemma isAcyclic_bot : IsAcyclic (⊥ : SimpleGraph V) := λ _a _w hw ↦ hw.ne_bot rfl
+@[simp] lemma isAcyclic_bot : IsAcyclic (⊥ : SimpleGraph V) := fun _a _w hw ↦ hw.ne_bot rfl
 
 theorem isAcyclic_iff_forall_adj_isBridge :
     G.IsAcyclic ↔ ∀ ⦃v w : V⦄, G.Adj v w → G.IsBridge s(v, w) := by

--- a/Mathlib/Combinatorics/SimpleGraph/Girth.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Girth.lean
@@ -29,11 +29,11 @@ noncomputable def girth (G : SimpleGraph α) : ℕ∞ :=
 protected alias ⟨_, IsAcyclic.girth_eq_top⟩ := girth_eq_top
 
 lemma girth_anti : Antitone (girth : SimpleGraph α → ℕ∞) :=
-λ G H h ↦ iInf_mono λ a ↦ iInf₂_mono' λ w hw ↦ ⟨w.mapLe h, hw.mapLe _, by simp⟩
+fun G H h ↦ iInf_mono fun a ↦ iInf₂_mono' fun w hw ↦ ⟨w.mapLe h, hw.mapLe _, by simp⟩
 
 lemma exists_girth_eq_length :
     (∃ (a : α) (w : G.Walk a a), w.IsCycle ∧ G.girth = w.length) ↔ ¬ G.IsAcyclic := by
-  refine' ⟨_, λ h ↦ _⟩
+  refine' ⟨_, fun h ↦ _⟩
   · rintro ⟨a, w, hw, _⟩ hG
     exact hG _ hw
   · simp_rw [← girth_eq_top, ← Ne.def, girth, iInf_subtype', iInf_sigma', ENat.iInf_coe_ne_top,

--- a/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
+++ b/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
@@ -263,8 +263,8 @@ lemma eventually_log_b_mul_pos : ∀ᶠ (n:ℕ) in atTop, ∀ i, 0 < log (b i * 
   induction n using Nat.strongInductionOn with
   | ind n h_ind =>
     cases lt_or_le n R.n₀ with
-    | inl hn => exact R.T_gt_zero' n hn   -- n < R.n₀
-    | inr hn =>   -- R.n₀ ≤ n
+    | inl hn => exact R.T_gt_zero' n hn -- n < R.n₀
+    | inr hn => -- R.n₀ ≤ n
       rw [R.h_rec n hn]
       have := R.g_nonneg
       refine add_pos_of_pos_of_nonneg (Finset.sum_pos ?sum_elems univ_nonempty) (by aesop)
@@ -609,7 +609,7 @@ lemma eventually_atTop_sumTransform_le :
   have hrpos_i := hrpos i
   have g_nonneg : 0 ≤ g n := R.g_nonneg n (by positivity)
   cases le_or_lt 0 (p a b + 1) with
-  | inl hp =>   -- 0 ≤ p a b + 1
+  | inl hp => -- 0 ≤ p a b + 1
     calc sumTransform (p a b) g (r i n) n
            = n ^ (p a b) * (∑ u in Finset.Ico (r i n) n, g u / u ^ ((p a b) + 1)) := by rfl
          _ ≤ n ^ (p a b) * (∑ u in Finset.Ico (r i n) n, c₂ * g n / u ^ ((p a b) + 1)) := by
@@ -641,7 +641,7 @@ lemma eventually_atTop_sumTransform_le :
          _ = c₂ * g n / c₁ ^ ((p a b) + 1) := by rw [div_self (by positivity), mul_one]
          _ = (c₂ / c₁ ^ ((p a b) + 1)) * g n := by ring
          _ ≤ max c₂ (c₂ / c₁ ^ ((p a b) + 1)) * g n := by gcongr; exact le_max_right _ _
-  | inr hp =>   -- p a b + 1 < 0
+  | inr hp => -- p a b + 1 < 0
     calc sumTransform (p a b) g (r i n) n
            = n ^ (p a b) * (∑ u in Finset.Ico (r i n) n, g u / u ^ ((p a b) + 1)) := by rfl
          _ ≤ n ^ (p a b) * (∑ u in Finset.Ico (r i n) n, c₂ * g n / u ^ ((p a b) + 1)) := by
@@ -688,7 +688,7 @@ lemma eventually_atTop_sumTransform_ge :
   have hrpos_i := hrpos i
   have g_nonneg : 0 ≤ g n := R.g_nonneg n (by positivity)
   cases le_or_gt 0 (p a b + 1) with
-  | inl hp =>   -- 0 ≤ (p a b) + 1
+  | inl hp => -- 0 ≤ (p a b) + 1
     calc sumTransform (p a b) g (r i n) n
            = n ^ (p a b) * (∑ u in Finset.Ico (r i n) n, g u / u ^ ((p a b) + 1))     := by rfl
          _ ≥ n ^ (p a b) * (∑ u in Finset.Ico (r i n) n, c₂ * g n / u^((p a b) + 1)) := by
@@ -722,7 +722,7 @@ lemma eventually_atTop_sumTransform_ge :
          _ = c₂ * (1 - c₃) * g n := by rw [div_self (by positivity), mul_one]
          _ ≥ min (c₂ * (1 - c₃)) ((1 - c₃) * c₂ / c₁ ^ ((p a b) + 1)) * g n := by
                 gcongr; exact min_le_left _ _
-  | inr hp =>  -- (p a b) + 1 < 0
+  | inr hp => -- (p a b) + 1 < 0
     calc sumTransform (p a b) g (r i n) n
         = n ^ (p a b) * (∑ u in Finset.Ico (r i n) n, g u / u^((p a b) + 1))     := by rfl
       _ ≥ n ^ (p a b) * (∑ u in Finset.Ico (r i n) n, c₂ * g n / u ^ ((p a b) + 1)) := by
@@ -918,7 +918,7 @@ lemma growsPolynomially_deriv_rpow_p_mul_one_sub_smoothingFn (p : ℝ) :
       (GrowsPolynomially.pow 2 growsPolynomially_log ?_)
     filter_upwards [eventually_ge_atTop 1] with _ hx
     exact log_nonneg hx
-  | inr hp =>  -- p ≠ 0
+  | inr hp => -- p ≠ 0
     refine GrowsPolynomially.of_isTheta (growsPolynomially_rpow (p-1))
       (isTheta_deriv_rpow_p_mul_one_sub_smoothingFn hp) ?_
     filter_upwards [eventually_gt_atTop 0] with _ _
@@ -927,7 +927,7 @@ lemma growsPolynomially_deriv_rpow_p_mul_one_sub_smoothingFn (p : ℝ) :
 lemma growsPolynomially_deriv_rpow_p_mul_one_add_smoothingFn (p : ℝ) :
     GrowsPolynomially fun x => ‖deriv (fun z => z ^ p * (1 + ε z)) x‖ := by
   cases eq_or_ne p 0 with
-  | inl hp =>   -- p = 0
+  | inl hp => -- p = 0
     have h₁ : (fun x => ‖deriv (fun z => z ^ p * (1 + ε z)) x‖)
         =ᶠ[atTop] fun z => z⁻¹ / (log z ^ 2) := by
       filter_upwards [eventually_deriv_one_add_smoothingFn, eventually_gt_atTop 1] with x hx hx_pos
@@ -941,7 +941,7 @@ lemma growsPolynomially_deriv_rpow_p_mul_one_add_smoothingFn (p : ℝ) :
       (GrowsPolynomially.pow 2 growsPolynomially_log ?_)
     filter_upwards [eventually_ge_atTop 1] with x hx
     exact log_nonneg hx
-  | inr hp =>    -- p ≠ 0
+  | inr hp => -- p ≠ 0
     refine GrowsPolynomially.of_isTheta (growsPolynomially_rpow (p-1))
       (isTheta_deriv_rpow_p_mul_one_add_smoothingFn hp) ?_
     filter_upwards [eventually_gt_atTop 0] with _ _

--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -155,7 +155,7 @@ lemma eventually_atTop_nonneg_or_nonpos (hf : GrowsPolynomially f) :
     (∀ᶠ x in atTop, 0 ≤ f x) ∨ (∀ᶠ x in atTop, f x ≤ 0) := by
   obtain ⟨c₁, _, c₂, _, h⟩ := hf (1/2) (by norm_num)
   match lt_trichotomy c₁ c₂ with
-  | .inl hlt =>  -- c₁ < c₂
+  | .inl hlt => -- c₁ < c₂
     left
     filter_upwards [h, eventually_ge_atTop 0] with x hx hx_nonneg
     have h' : 3 / 4 * x ∈ Set.Icc (1 / 2 * x) x := by
@@ -166,7 +166,7 @@ lemma eventually_atTop_nonneg_or_nonpos (hf : GrowsPolynomially f) :
     rw [Set.nonempty_Icc] at hu
     have hu' : 0 ≤ (c₂ - c₁) * f x := by linarith
     exact nonneg_of_mul_nonneg_right hu' (by linarith)
-  | .inr (.inr hgt) =>   -- c₂ < c₁
+  | .inr (.inr hgt) => -- c₂ < c₁
     right
     filter_upwards [h, eventually_ge_atTop 0] with x hx hx_nonneg
     have h' : 3 / 4 * x ∈ Set.Icc (1 / 2 * x) x := by
@@ -177,7 +177,7 @@ lemma eventually_atTop_nonneg_or_nonpos (hf : GrowsPolynomially f) :
     rw [Set.nonempty_Icc] at hu
     have hu' : (c₁ - c₂) * f x ≤ 0 := by linarith
     exact nonpos_of_mul_nonpos_right hu' (by linarith)
-  | .inr (.inl heq) =>   -- c₁ = c₂
+  | .inr (.inl heq) => -- c₁ = c₂
     have hmain : ∃ c, ∀ᶠ x in atTop, f x = c := by
       simp only [heq, Set.Icc_self, Set.mem_singleton_iff, one_mul] at h
       rw [eventually_atTop] at h
@@ -406,7 +406,7 @@ lemma GrowsPolynomially.add_isLittleO {f g : ℝ → ℝ} (hf : GrowsPolynomiall
   have hb_ub := hb.2
   rw [isLittleO_iff] at hfg
   cases hf.eventually_atTop_nonneg_or_nonpos with
-  | inl hf' =>  -- f is eventually nonneg
+  | inl hf' => -- f is eventually non-negative
     have hf := hf b hb
     obtain ⟨c₁, hc₁_mem : 0 < c₁, c₂, hc₂_mem : 0 < c₂, hf⟩ := hf
     specialize hfg (c := 1/2) (by norm_num)
@@ -568,7 +568,7 @@ protected lemma GrowsPolynomially.rpow (p : ℝ) (hf : GrowsPolynomially f)
   have hc₁p : 0 < c₁ ^ p := Real.rpow_pos_of_pos hc₁_mem _
   have hc₂p : 0 < c₂ ^ p := Real.rpow_pos_of_pos hc₂_mem _
   cases le_or_lt 0 p with
-  | inl =>    -- 0 ≤ p
+  | inl => -- 0 ≤ p
     refine ⟨c₁^p, hc₁p, ?_⟩
     refine ⟨c₂^p, hc₂p, ?_⟩
     filter_upwards [eventually_gt_atTop 0, hfnew, hf_nonneg,
@@ -583,7 +583,7 @@ protected lemma GrowsPolynomially.rpow (p : ℝ) (hf : GrowsPolynomially f)
     case ub => calc
       (f u)^p ≤ (c₂ * f x)^p := by gcongr; exact (hf₁ u hu).2
         _ = _ := by rw [← mul_rpow (le_of_lt hc₂_mem) hf_nonneg]
-  | inr hp =>   -- p < 0
+  | inr hp => -- p < 0
     match hf.eventually_atTop_zero_or_pos_or_neg with
     | .inl hzero => -- eventually zero
       refine ⟨1, by norm_num, 1, by norm_num, ?_⟩

--- a/Mathlib/Control/Random.lean
+++ b/Mathlib/Control/Random.lean
@@ -95,7 +95,7 @@ def randBound (α : Type u)
   (BoundedRandom.randomR lo hi h : RandGT g _ _)
 
 def randFin {n : Nat} [RandomGen g] : RandGT g m (Fin n.succ) :=
-  λ ⟨g⟩ => pure <| randNat g 0 n.succ |>.map Fin.ofNat ULift.up
+  fun ⟨g⟩ ↦ pure <| randNat g 0 n.succ |>.map Fin.ofNat ULift.up
 
 instance {n : Nat} : Random m (Fin n.succ) where
   random := randFin

--- a/Mathlib/Control/Traversable/Basic.lean
+++ b/Mathlib/Control/Traversable/Basic.lean
@@ -87,7 +87,7 @@ variable (F : Type u → Type v) [Applicative F] [LawfulApplicative F]
 variable (G : Type u → Type w) [Applicative G] [LawfulApplicative G]
 
 instance : CoeFun (ApplicativeTransformation F G) fun _ => ∀ {α}, F α → G α :=
-  ⟨λ η => η.app _⟩
+  ⟨fun η ↦ η.app _⟩
 
 variable {F G}
 

--- a/Mathlib/Data/Analysis/Topology.lean
+++ b/Mathlib/Data/Analysis/Topology.lean
@@ -280,4 +280,4 @@ instance [TopologicalSpace α] : Inhabited (Compact.Realizer (∅ : Set α)) :=
   ⟨fun {f} F x h hF ↦ by
     suffices f = ⊥ from absurd this h
     rw [← F.eq, eq_bot_iff]
-    exact λ s _ ↦ ⟨x, hF.trans s.empty_subset⟩⟩
+    exact fun s _ ↦ ⟨x, hF.trans s.empty_subset⟩⟩

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -32,14 +32,14 @@ theorem decide_False {h} : @decide False h = false :=
 @[simp]
 theorem decide_coe (b : Bool) {h} : @decide b h = b := by
   cases b
-  · exact _root_.decide_eq_false <| λ j => by cases j
+  · exact _root_.decide_eq_false <| fun j ↦ by cases j
   · exact _root_.decide_eq_true <| rfl
 #align bool.to_bool_coe Bool.decide_coe
 
 theorem coe_decide (p : Prop) [d : Decidable p] : decide p ↔ p :=
   match d with
-  | isTrue hp => ⟨λ _ => hp, λ _ => rfl⟩
-  | isFalse hnp => ⟨λ h => Bool.noConfusion h, λ hp => (hnp hp).elim⟩
+  | isTrue hp => ⟨fun _ ↦ hp, fun _ ↦ rfl⟩
+  | isFalse hnp => ⟨fun h ↦ Bool.noConfusion h, fun hp ↦ (hnp hp).elim⟩
 #align bool.coe_to_bool Bool.coe_decide
 
 theorem of_decide_iff {p : Prop} [Decidable p] : decide p ↔ p :=

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -2007,8 +2007,8 @@ lemma erase_eq_iff_eq_insert (hs : a ∈ s) (ht : a ∉ t) : erase s a = t ↔ s
   aesop
 
 lemma insert_erase_invOn :
-    Set.InvOn (insert a) (λ s ↦ erase s a) {s : Finset α | a ∈ s} {s : Finset α | a ∉ s} :=
-  ⟨λ _s ↦ insert_erase, λ _s ↦ erase_insert⟩
+    Set.InvOn (insert a) (fun s ↦ erase s a) {s : Finset α | a ∈ s} {s : Finset α | a ∉ s} :=
+  ⟨fun _s ↦ insert_erase, fun _s ↦ erase_insert⟩
 
 theorem erase_subset_erase (a : α) {s t : Finset α} (h : s ⊆ t) : erase s a ⊆ erase t a :=
   val_le_iff.1 <| erase_le_erase _ <| val_le_iff.2 h
@@ -2724,10 +2724,10 @@ instance decidableDforallFinset {p : ∀ a ∈ s, Prop} [_hp : ∀ (a) (h : a �
 -- Porting note: In lean3, `decidableDforallFinset` was picked up when decidability of `s ⊆ t` was
 -- needed. In lean4 it seems this is not the case.
 instance instDecidableRelSubset [DecidableEq α] : @DecidableRel (Finset α) (· ⊆ ·) :=
-  λ _ _ ↦ decidableDforallFinset
+  fun _ _ ↦ decidableDforallFinset
 
 instance instDecidableRelSSubset [DecidableEq α] : @DecidableRel (Finset α) (· ⊂ ·) :=
-  λ _ _ ↦ instDecidableAnd
+  fun _ _ ↦ instDecidableAnd
 
 instance instDecidableLE [DecidableEq α] : @DecidableRel (Finset α) (· ≤ ·) :=
   instDecidableRelSubset

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -514,7 +514,7 @@ theorem coe_image_subset_range : ↑(s.image f) ⊆ Set.range f :=
 #align finset.coe_image_subset_range Finset.coe_image_subset_range
 
 theorem filter_image {p : β → Prop} [DecidablePred p] :
-    (s.image f).filter p = (s.filter λ a ↦ p (f a)).image f :=
+    (s.image f).filter p = (s.filter fun a ↦ p (f a)).image f :=
   ext fun b => by
     simp only [mem_filter, mem_image, exists_prop]
     exact

--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -1240,8 +1240,9 @@ section DistribLattice
 variable [DistribLattice α] {s : Finset ι} {t : Finset κ} (hs : s.Nonempty) (ht : t.Nonempty)
   {f : ι → α} {g : κ → α} {a : α}
 
-theorem sup'_inf_distrib_left (f : ι → α) (a : α) : a ⊓ s.sup' hs f = s.sup' hs λ i => a ⊓ f i := by
-  refine' hs.cons_induction (fun i => _) fun i s hi hs ih => _
+theorem sup'_inf_distrib_left (f : ι → α) (a : α) :
+    a ⊓ s.sup' hs f = s.sup' hs fun i ↦ a ⊓ f i := by
+  refine' hs.cons_induction (fun i ↦ ?_) fun i s hi hs ih ↦ ?_
   · simp
   · simp_rw [sup'_cons hs, inf_sup_left]
     rw [ih]

--- a/Mathlib/Data/Finset/Sups.lean
+++ b/Mathlib/Data/Finset/Sups.lean
@@ -739,10 +739,10 @@ protected alias ⟨Nonempty.of_compls, Nonempty.compls⟩ := compls_nonempty
 @[simp] lemma compls_inter (s t : Finset α) : (s ∩ t)ᶜˢ = sᶜˢ ∩ tᶜˢ := map_inter _ _
 
 @[simp] lemma compls_infs (s t : Finset α) : (s ⊼ t)ᶜˢ = sᶜˢ ⊻ tᶜˢ := by
-  simp_rw [← image_compl]; exact image_image₂_distrib λ _ _ ↦ compl_inf
+  simp_rw [← image_compl]; exact image_image₂_distrib fun _ _ ↦ compl_inf
 
 @[simp] lemma compls_sups (s t : Finset α) : (s ⊻ t)ᶜˢ = sᶜˢ ⊼ tᶜˢ := by
-  simp_rw [← image_compl]; exact image_image₂_distrib λ _ _ ↦ compl_sup
+  simp_rw [← image_compl]; exact image_image₂_distrib fun _ _ ↦ compl_sup
 
 @[simp] lemma infs_compls_eq_diffs (s t : Finset α) : s ⊼ tᶜˢ = s \\ t := by
   ext; simp [sdiff_eq]; aesop
@@ -757,7 +757,7 @@ variable [Fintype α] {𝒜 : Finset (Finset α)} {n : ℕ}
 
 protected lemma _root_.Set.Sized.compls (h𝒜 : (𝒜 : Set (Finset α)).Sized n) :
     (𝒜ᶜˢ : Set (Finset α)).Sized (Fintype.card α - n) :=
-  Finset.forall_mem_compls.2 <| λ s hs ↦ by rw [Finset.card_compl, h𝒜 hs]
+  Finset.forall_mem_compls.2 <| fun s hs ↦ by rw [Finset.card_compl, h𝒜 hs]
 
 lemma sized_compls (hn : n ≤ Fintype.card α) :
     (𝒜ᶜˢ : Set (Finset α)).Sized n ↔ (𝒜 : Set (Finset α)).Sized (Fintype.card α - n) where

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -319,7 +319,7 @@ theorem single_eq_set_indicator : ⇑(single a b) = Set.indicator {a} fun _ => b
 
 @[simp]
 theorem single_eq_same : (single a b : α →₀ M) a = b := by
-  classical exact Pi.single_eq_same (f := λ _ => M) a b
+  classical exact Pi.single_eq_same (f := fun _ ↦ M) a b
 #align finsupp.single_eq_same Finsupp.single_eq_same
 
 @[simp]

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -1123,8 +1123,8 @@ private theorem natEmbeddingAux_injective (α : Type*) [Infinite α] :
   by_contra hmn
   have hmn : m < n := lt_of_le_of_ne hmlen hmn
   refine (Classical.choose_spec (exists_not_mem_finset
-    ((Multiset.range n).pmap (λ m (_ : m < n) => natEmbeddingAux α m)
-      (fun _ => Multiset.mem_range.1)).toFinset)) ?_
+    ((Multiset.range n).pmap (fun m (_ : m < n) ↦ natEmbeddingAux α m)
+      (fun _ ↦ Multiset.mem_range.1)).toFinset)) ?_
   refine Multiset.mem_toFinset.2 (Multiset.mem_pmap.2 ⟨m, Multiset.mem_range.2 hmn, ?_⟩)
   rw [h, natEmbeddingAux]
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -515,7 +515,7 @@ These can also be written in terms of `List.zip` or `List.zipWith`.
 For example, `zipWith3 f xs ys zs` could also be written as
 `zipWith id (zipWith f xs ys) zs`
 or as
-`(zip xs <| zip ys zs).map <| λ ⟨x, y, z⟩, f x y z`.
+`(zip xs <| zip ys zs).map <| fun ⟨x, y, z⟩ ↦ f x y z`.
 -/
 
 /-- Ternary version of `List.zipWith`. -/

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -553,7 +553,7 @@ theorem Indep.base_of_maximal (hI : M.Indep I) (h : ∀ J, M.Indep J → I ⊆ J
   base_iff_maximal_indep.mpr ⟨hI,h⟩
 
 theorem Base.dep_of_ssubset (hB : M.Base B) (h : B ⊂ X) (hX : X ⊆ M.E := by aesop_mat) : M.Dep X :=
-  ⟨λ hX ↦ h.ne (hB.eq_of_subset_indep hX h.subset), hX⟩
+  ⟨fun hX ↦ h.ne (hB.eq_of_subset_indep hX h.subset), hX⟩
 
 theorem Base.dep_of_insert (hB : M.Base B) (heB : e ∉ B) (he : e ∈ M.E := by aesop_mat) :
     M.Dep (insert e B) := hB.dep_of_ssubset (ssubset_insert heB) (insert_subset he hB.subset_ground)

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -442,7 +442,7 @@ theorem base_compl_iff_mem_maximals_disjoint_base (hB : B ⊆ M.E := by aesop_ma
     fun I hI B' ⟨hB', hIB'⟩ hBI ↦ hBI.antisymm _⟩, fun ⟨⟨B', hB', hBB'⟩,h⟩ ↦ _⟩
   · rw [hB'.eq_of_subset_base h, ← subset_compl_iff_disjoint_right, diff_eq, compl_inter,
       compl_compl] at hIB'
-    · exact fun e he ↦  (hIB' he).elim (fun h' ↦ (h' (hI he)).elim) id
+    · exact fun e he ↦ (hIB' he).elim (fun h' ↦ (h' (hI he)).elim) id
     rw [subset_diff, and_iff_right hB'.subset_ground, disjoint_comm]
     exact disjoint_of_subset_left hBI hIB'
   rw [h (diff_subset M.E B') B' ⟨hB', disjoint_sdiff_left⟩]

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -235,7 +235,7 @@ theorem pbind_eq_some {f : ∀ a : α, a ∈ x → Option β} {y : β} :
     intro z h
     simp at h
   · simp only [pbind]
-    refine ⟨λ h => ⟨x, rfl, h⟩, ?_⟩
+    refine ⟨fun h ↦ ⟨x, rfl, h⟩, ?_⟩
     rintro ⟨z, H, hz⟩
     simp only [mem_def, Option.some_inj] at H
     simpa [H] using hz

--- a/Mathlib/Data/Ordmap/Ordnode.lean
+++ b/Mathlib/Data/Ordmap/Ordnode.lean
@@ -1349,7 +1349,7 @@ def ofList' : List α → Ordnode α
 Equivalent elements are selected with a preference for smaller source elements.
 
     image (fun x ↦ x + 2) {1, 2, 4} = {3, 4, 6}
-    image (λ x : ℕ, x - 2) {1, 2, 4} = {0, 2} -/
+    image (fun x : ℕ ↦ x - 2) {1, 2, 4} = {0, 2} -/
 def image {α β} [LE β] [@DecidableRel β (· ≤ ·)] (f : α → β) (t : Ordnode α) : Ordnode β :=
   ofList (t.toList.map f)
 #align ordnode.image Ordnode.image

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -695,16 +695,16 @@ theorem prodLift_fst_comp_snd_comp (f : α →. γ) (g : β →. δ) :
 
 @[simp]
 theorem prodMap_id_id : (PFun.id α).prodMap (PFun.id β) = PFun.id _ :=
-  ext fun _ _ => by simp [eq_comm]
+  ext fun _ _ ↦ by simp [eq_comm]
 #align pfun.prod_map_id_id PFun.prodMap_id_id
 
 @[simp]
 theorem prodMap_comp_comp (f₁ : α →. β) (f₂ : β →. γ) (g₁ : δ →. ε) (g₂ : ε →. ι) :
     (f₂.comp f₁).prodMap (g₂.comp g₁) = (f₂.prodMap g₂).comp (f₁.prodMap g₁) := -- by
-  -- Porting note: was `by tidy`, below is a golf'd version of the `tidy?` proof
-  ext <| λ ⟨_, _⟩ ⟨_, _⟩ =>
-  ⟨λ ⟨⟨⟨h1l1, h1l2⟩, ⟨h1r1, h1r2⟩⟩, h2⟩ => ⟨⟨⟨h1l1, h1r1⟩, ⟨h1l2, h1r2⟩⟩, h2⟩,
-   λ ⟨⟨⟨h1l1, h1r1⟩, ⟨h1l2, h1r2⟩⟩, h2⟩ => ⟨⟨⟨h1l1, h1l2⟩, ⟨h1r1, h1r2⟩⟩, h2⟩⟩
+  -- Porting note: was `by tidy`, below is a golfed version of the `tidy?` proof
+  ext <| fun ⟨_, _⟩ ⟨_, _⟩ ↦
+  ⟨fun ⟨⟨⟨h1l1, h1l2⟩, ⟨h1r1, h1r2⟩⟩, h2⟩ ↦ ⟨⟨⟨h1l1, h1r1⟩, ⟨h1l2, h1r2⟩⟩, h2⟩,
+   fun ⟨⟨⟨h1l1, h1r1⟩, ⟨h1l2, h1r2⟩⟩, h2⟩ ↦ ⟨⟨⟨h1l1, h1l2⟩, ⟨h1r1, h1r2⟩⟩, h2⟩⟩
 #align pfun.prod_map_comp_comp PFun.prodMap_comp_comp
 
 end PFun

--- a/Mathlib/Data/Prod/TProd.lean
+++ b/Mathlib/Data/Prod/TProd.lean
@@ -10,7 +10,7 @@ import Mathlib.Data.List.Nodup
 # Finite products of types
 
 This file defines the product of types over a list. For `l : List ι` and `α : ι → Type v` we define
-`List.TProd α l = l.foldr (λ i β, α i × β) PUnit`.
+`List.TProd α l = l.foldr (fun i β ↦ α i × β) PUnit`.
 This type should not be used if `∀ i, α i` or `∀ i ∈ l, α i` can be used instead
 (in the last expression, we could also replace the list `l` by a set or a finset).
 This type is used as an intermediary between binary products and finitary products.

--- a/Mathlib/Data/QPF/Multivariate/Constructions/Fix.lean
+++ b/Mathlib/Data/QPF/Multivariate/Constructions/Fix.lean
@@ -97,7 +97,7 @@ theorem recF_eq_of_wEquiv (α : TypeVec n) {β : Type u} (u : F (α.append1 β) 
   intro a₁ f'₁ f₁
   intro h
   -- Porting note: induction on h doesn't work.
-  refine' @WEquiv.recOn _ _ _ _ _ (λ a a' _ => recF u a = recF u a') _ _ h _ _ _
+  refine' @WEquiv.recOn _ _ _ _ _ (fun a a' _ ↦ recF u a = recF u a') _ _ h _ _ _
   · intros a f' f₀ f₁ _h ih; simp only [recF_eq, Function.comp]
     congr; funext; congr; funext; apply ih
   · intros a₀ f'₀ f₀ a₁ f'₁ f₁ h; simp only [recF_eq', abs_map, MvPFunctor.wDest'_wMk, h]

--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -170,28 +170,28 @@ protected def recOnSubsingleton₂ {φ : Quot r → Quot s → Sort*}
     [h : ∀ a b, Subsingleton (φ ⟦a⟧ ⟦b⟧)] (q₁ : Quot r)
     (q₂ : Quot s) (f : ∀ a b, φ ⟦a⟧ ⟦b⟧) : φ q₁ q₂ :=
   @Quot.recOnSubsingleton _ r (fun q ↦ φ q q₂)
-    (fun a ↦ Quot.ind (β := λ b => Subsingleton (φ (mk r a) b)) (h a) q₂) q₁
+    (fun a ↦ Quot.ind (β := fun b ↦ Subsingleton (φ (mk r a) b)) (h a) q₂) q₁
     fun a ↦ Quot.recOnSubsingleton q₂ fun b ↦ f a b
 #align quot.rec_on_subsingleton₂ Quot.recOnSubsingleton₂
 
 @[elab_as_elim]
 protected theorem induction_on₂ {δ : Quot r → Quot s → Prop} (q₁ : Quot r) (q₂ : Quot s)
     (h : ∀ a b, δ (Quot.mk r a) (Quot.mk s b)) : δ q₁ q₂ :=
-  Quot.ind (β := λ a => δ a q₂) (fun a₁ ↦ Quot.ind (fun a₂ ↦ h a₁ a₂) q₂) q₁
+  Quot.ind (β := fun a ↦ δ a q₂) (fun a₁ ↦ Quot.ind (fun a₂ ↦ h a₁ a₂) q₂) q₁
 #align quot.induction_on₂ Quot.induction_on₂
 
 @[elab_as_elim]
 protected theorem induction_on₃ {δ : Quot r → Quot s → Quot t → Prop} (q₁ : Quot r)
     (q₂ : Quot s) (q₃ : Quot t) (h : ∀ a b c, δ (Quot.mk r a) (Quot.mk s b) (Quot.mk t c)) :
     δ q₁ q₂ q₃ :=
-  Quot.ind (β := λ a => δ a q₂ q₃) (fun a₁ ↦ Quot.ind (β := λ b => δ _ b q₃)
+  Quot.ind (β := fun a ↦ δ a q₂ q₃) (fun a₁ ↦ Quot.ind (β := fun b ↦ δ _ b q₃)
     (fun a₂ ↦ Quot.ind (fun a₃ ↦ h a₁ a₂ a₃) q₃) q₂) q₁
 #align quot.induction_on₃ Quot.induction_on₃
 
 instance lift.decidablePred (r : α → α → Prop) (f : α → Prop) (h : ∀ a b, r a b → f a = f b)
     [hf : DecidablePred f] :
     DecidablePred (Quot.lift f h) :=
-  fun q ↦ Quot.recOnSubsingleton (motive := λ _ => Decidable _) q hf
+  fun q ↦ Quot.recOnSubsingleton (motive := fun _ ↦ Decidable _) q hf
 
 /-- Note that this provides `DecidableRel (Quot.Lift₂ f ha hb)` when `α = β`. -/
 instance lift₂.decidablePred (r : α → α → Prop) (s : β → β → Prop) (f : α → β → Prop)
@@ -636,7 +636,7 @@ protected theorem liftOn'_mk'' (f : α → φ) (h) (x : α) :
   rfl
 
 @[simp] lemma surjective_liftOn' {f : α → φ} (h) :
-    Function.Surjective (λ x : Quotient s₁ => x.liftOn' f h) ↔ Function.Surjective f :=
+    Function.Surjective (fun x : Quotient s₁ ↦ x.liftOn' f h) ↔ Function.Surjective f :=
   Quot.surjective_lift _
 #align quotient.surjective_lift_on' Quotient.surjective_liftOn'
 

--- a/Mathlib/Data/Rel.lean
+++ b/Mathlib/Data/Rel.lean
@@ -128,12 +128,12 @@ theorem comp_left_bot (r : Rel α β) : (⊥ : Rel γ α) • r = ⊥ := by
   simp [comp, Bot.bot]
 
 @[simp]
-theorem comp_right_top (r : Rel α β) : r • (⊤ : Rel β γ) = λ x _ ↦ x ∈ r.dom := by
+theorem comp_right_top (r : Rel α β) : r • (⊤ : Rel β γ) = fun x _ ↦ x ∈ r.dom := by
   ext x z
   simp [comp, Top.top, dom]
 
 @[simp]
-theorem comp_left_top (r : Rel α β) : (⊤ : Rel γ α) • r = λ _ y ↦ y ∈ r.codom := by
+theorem comp_left_top (r : Rel α β) : (⊤ : Rel γ α) • r = fun _ y ↦ y ∈ r.codom := by
   ext x z
   simp [comp, Top.top, codom]
 
@@ -213,7 +213,7 @@ theorem image_bot (s : Set α) : (⊥ : Rel α β).image s = ∅ := by
 @[simp]
 theorem image_top {s : Set α} (h : Set.Nonempty s) :
     (⊤ : Rel α β).image s = Set.univ :=
-  Set.eq_univ_of_forall λ x ↦ ⟨h.some, by simp [h.some_mem, Top.top]⟩
+  Set.eq_univ_of_forall fun x ↦ ⟨h.some, by simp [h.some_mem, Top.top]⟩
 
 /-- Preimage of a set under a relation `r`. Same as the image of `s` under `r.inv` -/
 def preimage (s : Set β) : Set α :=

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -253,7 +253,7 @@ attribute [simp] lmap rmap
 theorem corec_eq (f : β → Sum α β) (b : β) : destruct (corec f b) = rmap (corec f) (f b) := by
   dsimp [corec, destruct]
   rw [show Stream'.corec' (Corec.f f) (Sum.inr b) 0 =
-    Sum.rec Option.some (λ _ => none) (f b) by
+    Sum.rec Option.some (fun _ ↦ none) (f b) by
     dsimp [Corec.f, Stream'.corec', Stream'.corec, Stream'.map, Stream'.get, Stream'.iterate]
     match (f b) with
     | Sum.inl x => rfl
@@ -1278,8 +1278,8 @@ theorem LiftRelRec.lem {R : α → β → Prop} (C : Computation α → Computat
     (H : ∀ {ca cb}, C ca cb → LiftRelAux R C (destruct ca) (destruct cb)) (ca cb) (Hc : C ca cb) (a)
     (ha : a ∈ ca) : LiftRel R ca cb := by
   revert cb
-  refine' memRecOn (C := (λ ca => ∀ (cb : Computation β), C ca cb → LiftRel R ca cb))
-    ha _ (fun ca' IH => _) <;> intro cb Hc <;> have h := H Hc
+  refine memRecOn (C := (fun ca ↦ ∀ (cb : Computation β), C ca cb → LiftRel R ca cb))
+    ha ?_ (fun ca' IH => ?_) <;> intro cb Hc <;> have h := H Hc
   · simp only [destruct_pure, LiftRelAux.ret_left] at h
     simp [h]
   · simp only [liftRel_think_left]

--- a/Mathlib/Data/Set/Pointwise/Basic.lean
+++ b/Mathlib/Data/Set/Pointwise/Basic.lean
@@ -39,8 +39,8 @@ Appropriate definitions and results are also transported to the additive theory 
 ## Implementation notes
 
 * The following expressions are considered in simp-normal form in a group:
-  `(λ h, h * g) ⁻¹' s`, `(λ h, g * h) ⁻¹' s`, `(λ h, h * g⁻¹) ⁻¹' s`, `(λ h, g⁻¹ * h) ⁻¹' s`,
-  `s * t`, `s⁻¹`, `(1 : Set _)` (and similarly for additive variants).
+  `(fun h ↦ h * g) ⁻¹' s`, `(fun h ↦ g * h) ⁻¹' s`, `(fun h ↦ h * g⁻¹) ⁻¹' s`,
+  `(fun h ↦ g⁻¹ * h) ⁻¹' s`, `s * t`, `s⁻¹`, `(1 : Set _)` (and similarly for additive variants).
   Expressions equal to one of these will be simplified.
 * We put all instances in the locale `Pointwise`, so that these instances are not available by
   default. Note that we do not mark them as reducible (as argued by note [reducible non-instances])

--- a/Mathlib/Data/Set/Sups.lean
+++ b/Mathlib/Data/Set/Sups.lean
@@ -173,7 +173,7 @@ theorem sups_inter_subset_right : s ⊻ (t₁ ∩ t₂) ⊆ s ⊻ t₁ ∩ s ⊻
 lemma image_sups (f : F) (s t : Set α) : f '' (s ⊻ t) = f '' s ⊻ f '' t :=
   image_image2_distrib <| map_sup f
 
-lemma subset_sups_self : s ⊆ s ⊻ s := λ _a ha ↦ mem_sups.2 ⟨_, ha, _, ha, sup_idem _⟩
+lemma subset_sups_self : s ⊆ s ⊻ s := fun _a ha ↦ mem_sups.2 ⟨_, ha, _, ha, sup_idem _⟩
 lemma sups_subset_self : s ⊻ s ⊆ s ↔ SupClosed s := sups_subset_iff
 
 @[simp] lemma sups_eq_self : s ⊻ s = s ↔ SupClosed s :=
@@ -335,7 +335,7 @@ theorem infs_inter_subset_right : s ⊼ (t₁ ∩ t₂) ⊆ s ⊼ t₁ ∩ s ⊼
 lemma image_infs (f : F) (s t : Set α) : f '' (s ⊼ t) = f '' s ⊼ f '' t :=
   image_image2_distrib <| map_inf f
 
-lemma subset_infs_self : s ⊆ s ⊼ s := λ _a ha ↦ mem_infs.2 ⟨_, ha, _, ha, inf_idem _⟩
+lemma subset_infs_self : s ⊆ s ⊼ s := fun _a ha ↦ mem_infs.2 ⟨_, ha, _, ha, inf_idem _⟩
 lemma infs_self_subset : s ⊼ s ⊆ s ↔ InfClosed s := infs_subset_iff
 
 @[simp] lemma infs_self : s ⊼ s = s ↔ InfClosed s :=

--- a/Mathlib/Data/Sigma/Basic.lean
+++ b/Mathlib/Data/Sigma/Basic.lean
@@ -56,8 +56,8 @@ instance instDecidableEqSigma [h₁ : DecidableEq α] [h₂ : ∀ a, DecidableEq
 @[simp] -- @[nolint simpNF]
 theorem mk.inj_iff {a₁ a₂ : α} {b₁ : β a₁} {b₂ : β a₂} :
     Sigma.mk a₁ b₁ = ⟨a₂, b₂⟩ ↔ a₁ = a₂ ∧ HEq b₁ b₂ :=
-  ⟨λ h => by cases h; exact ⟨rfl, heq_of_eq rfl⟩, -- in Lean 3 `simp` solved this
-   λ ⟨h₁, h₂⟩ => by subst h₁; rw [eq_of_heq h₂]⟩
+  ⟨fun h ↦ by cases h; exact ⟨rfl, heq_of_eq rfl⟩, -- in Lean 3 `simp` solved this
+   fun ⟨h₁, h₂⟩ ↦ by subst h₁; rw [eq_of_heq h₂]⟩
 #align sigma.mk.inj_iff Sigma.mk.inj_iff
 
 @[simp]
@@ -102,10 +102,10 @@ theorem «exists» {p : (Σa, β a) → Prop} : (∃ x, p x) ↔ ∃ a b, p ⟨a
 #align sigma.exists Sigma.exists
 
 lemma exists' {p : ∀ a, β a → Prop} : (∃ a b, p a b) ↔ ∃ x : Σ a, β a, p x.1 x.2 :=
-  (Sigma.exists (p := λ x ↦ p x.1 x.2)).symm
+  (Sigma.exists (p := fun x ↦ p x.1 x.2)).symm
 
 lemma forall' {p : ∀ a, β a → Prop} : (∀ a b, p a b) ↔ ∀ x : Σ a, β a, p x.1 x.2 :=
-  (Sigma.forall (p := λ x ↦ p x.1 x.2)).symm
+  (Sigma.forall (p := fun x ↦ p x.1 x.2)).symm
 
 theorem _root_.sigma_mk_injective {i : α} : Injective (@Sigma.mk α β i)
   | _, _, rfl => rfl

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -72,8 +72,8 @@ theorem ext_iff {a1 a2 : { x // p x }} : a1 = a2 ↔ (a1 : α) = (a2 : α) :=
 
 theorem heq_iff_coe_eq (h : ∀ x, p x ↔ q x) {a1 : { x // p x }} {a2 : { x // q x }} :
     HEq a1 a2 ↔ (a1 : α) = (a2 : α) :=
-  Eq.rec (motive := λ (pp: (α → Prop)) _ => ∀ a2' : {x // pp x}, HEq a1 a2' ↔ (a1 : α) = (a2' : α))
-         (λ _ => heq_iff_eq.trans ext_iff) (funext <| λ x => propext (h x)) a2
+  Eq.rec (motive := fun (pp: (α → Prop)) _ ↦ ∀ a2' : {x // pp x}, HEq a1 a2' ↔ (a1 : α) = (a2' : α))
+         (fun _ ↦ heq_iff_eq.trans ext_iff) (funext <| fun x ↦ propext (h x)) a2
 #align subtype.heq_iff_coe_eq Subtype.heq_iff_coe_eq
 
 lemma heq_iff_coe_heq {α β : Sort _} {p : α → Prop} {q : β → Prop} {a : {x // p x}}

--- a/Mathlib/Data/W/Cardinal.lean
+++ b/Mathlib/Data/W/Cardinal.lean
@@ -42,7 +42,7 @@ theorem cardinal_mk_eq_sum' : #(WType β) = sum (fun a : α => #(WType β) ^ lif
   (mk_congr <| equivSigma β).trans <| by
     simp_rw [mk_sigma, mk_arrow]; rw [lift_id'.{v, u}, lift_umax.{v, u}]
 
-/-- `#(WType β)` is the least cardinal `κ` such that `sum (λ a : α, κ ^ #(β a)) ≤ κ` -/
+/-- `#(WType β)` is the least cardinal `κ` such that `sum (fun a : α ↦ κ ^ #(β a)) ≤ κ` -/
 theorem cardinal_mk_le_of_le' {κ : Cardinal.{max u v}}
     (hκ : (sum fun a : α => κ ^ lift.{u} #(β a)) ≤ κ) :
     #(WType β) ≤ κ := by
@@ -89,7 +89,7 @@ theorem cardinal_mk_eq_sum : #(WType β) = sum (fun a : α => #(WType β) ^ #(β
   cardinal_mk_eq_sum'.trans <| by simp_rw [lift_id]
 #align W_type.cardinal_mk_eq_sum WType.cardinal_mk_eq_sum
 
-/-- `#(WType β)` is the least cardinal `κ` such that `sum (λ a : α, κ ^ #(β a)) ≤ κ` -/
+/-- `#(WType β)` is the least cardinal `κ` such that `sum (fun a : α ↦ κ ^ #(β a)) ≤ κ` -/
 theorem cardinal_mk_le_of_le {κ : Cardinal.{u}} (hκ : (sum fun a : α => κ ^ #(β a)) ≤ κ) :
     #(WType β) ≤ κ := cardinal_mk_le_of_le' <| by simp_rw [lift_id]; exact hκ
 #align W_type.cardinal_mk_le_of_le WType.cardinal_mk_le_of_le

--- a/Mathlib/FieldTheory/IsAlgClosed/Spectrum.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Spectrum.lean
@@ -14,9 +14,9 @@ import Mathlib.FieldTheory.IsAlgClosed.Basic
 This file develops proves the spectral mapping theorem for polynomials over algebraically closed
 fields. In particular, if `a` is an element of a `𝕜`-algebra `A` where `𝕜` is a field, and
 `p : 𝕜[X]` is a polynomial, then the spectrum of `Polynomial.aeval a p` contains the image of the
-spectrum of `a` under `(λ k, Polynomial.eval k p)`. When `𝕜` is algebraically closed, these are in
-fact equal (assuming either that the spectrum of `a` is nonempty or the polynomial has positive
-degree), which is the **spectral mapping theorem**.
+spectrum of `a` under `(fun k ↦ Polynomial.eval k p)`. When `𝕜` is algebraically closed,
+these are in fact equal (assuming either that the spectrum of `a` is nonempty or the polynomial
+has positive degree), which is the **spectral mapping theorem**.
 
 In addition, this file contains the fact that every element of a finite dimensional nontrivial
 algebra over an algebraically closed field has nonempty spectrum. In particular, this is used in

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -82,8 +82,8 @@ Here, `I.Boundaryless` is a typeclass property ensuring that there is no boundar
 instance the case for `modelWithCornersSelf`, or products of these). Note that one could consider
 as a natural assumption to only use the trivial model with corners `modelWithCornersSelf ℝ E`,
 but again in product manifolds the natural model with corners will not be this one but the product
-one (and they are not defeq as `(λp : E × F, (p.1, p.2))` is not defeq to the identity). So, it is
-important to use the above incantation to maximize the applicability of theorems.
+one (and they are not defeq as `(fun p : E × F ↦ (p.1, p.2))` is not defeq to the identity).
+So, it is important to use the above incantation to maximize the applicability of theorems.
 
 ## Implementation notes
 

--- a/Mathlib/Init/Data/Quot.lean
+++ b/Mathlib/Init/Data/Quot.lean
@@ -46,7 +46,7 @@ theorem Quot.EqvGen_sound {r : α → α → Prop} {a b : α} (H : EqvGen r a b)
     Quot.mk r a = Quot.mk r b :=
   EqvGen.rec
     (fun _ _ h ↦ Quot.sound h)
-    (fun _ ↦  rfl)
+    (fun _ ↦ rfl)
     (fun _ _ _ IH ↦ Eq.symm IH)
     (fun _ _ _ _ _ IH₁ IH₂ ↦ Eq.trans IH₁ IH₂)
     H

--- a/Mathlib/Init/Data/Quot.lean
+++ b/Mathlib/Init/Data/Quot.lean
@@ -39,16 +39,16 @@ def EqvGen.Setoid : Setoid α :=
 
 theorem Quot.exact {a b : α} (H : Quot.mk r a = Quot.mk r b) : EqvGen r a b :=
   @Quotient.exact _ (EqvGen.Setoid r) a b (congr_arg
-    (Quot.lift (Quotient.mk (EqvGen.Setoid r)) (λx y h => Quot.sound (EqvGen.rel x y h))) H)
+    (Quot.lift (Quotient.mk (EqvGen.Setoid r)) (fun x y h ↦ Quot.sound (EqvGen.rel x y h))) H)
 #align quot.exact Quot.exact
 
 theorem Quot.EqvGen_sound {r : α → α → Prop} {a b : α} (H : EqvGen r a b) :
     Quot.mk r a = Quot.mk r b :=
   EqvGen.rec
-    (λ _ _ h => Quot.sound h)
-    (λ _ => rfl)
-    (λ _ _ _ IH => Eq.symm IH)
-    (λ _ _ _ _ _ IH₁ IH₂ => Eq.trans IH₁ IH₂)
+    (fun _ _ h ↦ Quot.sound h)
+    (fun _ ↦  rfl)
+    (fun _ _ _ IH ↦ Eq.symm IH)
+    (fun _ _ _ _ _ IH₁ IH₂ ↦ Eq.trans IH₁ IH₂)
     H
 #align quot.eqv_gen_sound Quot.EqvGen_sound
 
@@ -57,9 +57,9 @@ end
 open Decidable
 instance Quotient.decidableEq {α : Sort u} {s : Setoid α} [d : ∀ a b : α, Decidable (a ≈ b)] :
     DecidableEq (Quotient s) :=
-  λ q₁ q₂ : Quotient s =>
+  fun q₁ q₂ : Quotient s ↦
     Quotient.recOnSubsingleton₂ q₁ q₂
-      (λ a₁ a₂ =>
+      (fun a₁ a₂ ↦
         match (d a₁ a₂) with
         | (isTrue h₁)  => isTrue (Quotient.sound h₁)
-        | (isFalse h₂) => isFalse (λ h => absurd (Quotient.exact h) h₂))
+        | (isFalse h₂) => isFalse (fun h ↦ absurd (Quotient.exact h) h₂))

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -230,11 +230,11 @@ theorem ExistsUnique.intro {p : α → Prop} (w : α)
 
 theorem ExistsUnique.elim {α : Sort u} {p : α → Prop} {b : Prop}
     (h₂ : ∃! x, p x) (h₁ : ∀ x, p x → (∀ y, p y → y = x) → b) : b :=
-  Exists.elim h₂ (λ w hw => h₁ w (And.left hw) (And.right hw))
+  Exists.elim h₂ (fun w hw ↦ h₁ w (And.left hw) (And.right hw))
 
 theorem exists_unique_of_exists_of_unique {α : Sort u} {p : α → Prop}
     (hex : ∃ x, p x) (hunique : ∀ y₁ y₂, p y₁ → p y₂ → y₁ = y₂) : ∃! x, p x :=
-  Exists.elim hex (λ x px => ExistsUnique.intro x px (λ y (h : p y) => hunique y x h px))
+  Exists.elim hex (fun x px ↦ ExistsUnique.intro x px (fun y (h : p y) ↦ hunique y x h px))
 
 theorem ExistsUnique.exists {p : α → Prop} : (∃! x, p x) → ∃ x, p x | ⟨x, h, _⟩ => ⟨x, h⟩
 #align exists_of_exists_unique ExistsUnique.exists
@@ -318,7 +318,7 @@ def decidableEq_of_bool_pred {α : Sort u} {p : α → α → Bool} (h₁ : IsDe
     (h₂ : IsDecRefl p) : DecidableEq α
   | x, y =>
     if hp : p x y = true then isTrue (h₁ hp)
-    else isFalse (λ hxy : x = y => absurd (h₂ y) (by rwa [hxy] at hp))
+    else isFalse (fun hxy : x = y ↦ absurd (h₂ y) (by rwa [hxy] at hp))
 #align decidable_eq_of_bool_pred decidableEq_of_bool_pred
 
 theorem decidableEq_inl_refl {α : Sort u} [h : DecidableEq α] (a : α) :
@@ -365,7 +365,7 @@ theorem if_ctx_congr {α : Sort u} {b c : Prop} [dec_b : Decidable b] [dec_c : D
 
 theorem if_congr {α : Sort u} {b c : Prop} [Decidable b] [Decidable c]
     {x y u v : α} (h_c : b ↔ c) (h_t : x = u) (h_e : y = v) : ite b x y = ite c u v :=
-  if_ctx_congr h_c (λ _ => h_t) (λ _ => h_e)
+  if_ctx_congr h_c (fun _ ↦ h_t) (fun _ ↦ h_e)
 
 theorem if_ctx_congr_prop {b c x y u v : Prop} [dec_b : Decidable b] [dec_c : Decidable c]
     (h_c : b ↔ c) (h_t : c → (x ↔ u)) (h_e : ¬c → (y ↔ v)) : ite b x y ↔ ite c u v :=
@@ -378,7 +378,7 @@ theorem if_ctx_congr_prop {b c x y u v : Prop} [dec_b : Decidable b] [dec_c : De
 -- @[congr]
 theorem if_congr_prop {b c x y u v : Prop} [Decidable b] [Decidable c] (h_c : b ↔ c) (h_t : x ↔ u)
     (h_e : y ↔ v) : ite b x y ↔ ite c u v :=
-  if_ctx_congr_prop h_c (λ _ => h_t) (λ _ => h_e)
+  if_ctx_congr_prop h_c (fun _ ↦ h_t) (fun _ ↦ h_e)
 
 theorem if_ctx_simp_congr_prop {b c x y u v : Prop} [Decidable b] (h_c : b ↔ c) (h_t : c → (x ↔ u))
     -- FIXME: after https://github.com/leanprover/lean4/issues/1867 is fixed,
@@ -392,7 +392,7 @@ theorem if_simp_congr_prop {b c x y u v : Prop} [Decidable b] (h_c : b ↔ c) (h
     -- this should be changed back to:
     -- (h_e : y ↔ v) : ite b x y ↔ (ite c (h := decidable_of_decidable_of_iff h_c) u v) :=
     (h_e : y ↔ v) : ite b x y ↔ (@ite _ c (decidable_of_decidable_of_iff h_c) u v) :=
-  if_ctx_simp_congr_prop h_c (λ _ => h_t) (λ _ => h_e)
+  if_ctx_simp_congr_prop h_c (fun _ ↦ h_t) (fun _ ↦ h_e)
 
 -- @[congr]
 theorem dif_ctx_congr {α : Sort u} {b c : Prop} [dec_b : Decidable b] [dec_c : Decidable c]
@@ -467,10 +467,10 @@ def Transitive := ∀ ⦃x y z⦄, x ≺ y → y ≺ z → x ≺ z
 
 lemma Equivalence.reflexive {r : β → β → Prop} (h : Equivalence r) : Reflexive r := h.refl
 
-lemma Equivalence.symmetric {r : β → β → Prop} (h : Equivalence r) : Symmetric r := λ _ _ => h.symm
+lemma Equivalence.symmetric {r : β → β → Prop} (h : Equivalence r) : Symmetric r := fun _ _ ↦ h.symm
 
 lemma Equivalence.transitive {r : β → β → Prop}(h : Equivalence r) : Transitive r :=
-  λ _ _ _ => h.trans
+  fun _ _ _ ↦ h.trans
 
 /-- A relation is total if for all `x` and `y`, either `x ≺ y` or `y ≺ x`. -/
 def Total := ∀ x y, x ≺ y ∨ y ≺ x
@@ -485,7 +485,7 @@ def AntiSymmetric := ∀ ⦃x y⦄, x ≺ y → y ≺ x → x = y
 
 /-- An empty relation does not relate any elements. -/
 @[nolint unusedArguments]
-def EmptyRelation := λ _ _ : α => False
+def EmptyRelation := fun _ _ : α ↦ False
 
 theorem InvImage.trans (f : α → β) (h : Transitive r) : Transitive (InvImage r f) :=
   fun (a₁ a₂ a₃ : α) (h₁ : InvImage r f a₁ a₂) (h₂ : InvImage r f a₂ a₃) ↦ h h₁ h₂

--- a/Mathlib/Init/Order/LinearOrder.lean
+++ b/Mathlib/Init/Order/LinearOrder.lean
@@ -159,15 +159,15 @@ theorem max_eq_right_of_lt {a b : α} (h : a < b) : max a b = b :=
 theorem lt_min {a b c : α} (h₁ : a < b) (h₂ : a < c) : a < min b c :=
   -- Porting note: no `min_tac` tactic
   Or.elim (le_or_gt b c)
-    (λ h : b ≤ c => by rwa [min_eq_left h])
-    (λ h : b > c => by rwa [min_eq_right_of_lt h])
+    (fun h : b ≤ c ↦ by rwa [min_eq_left h])
+    (fun h : b > c ↦ by rwa [min_eq_right_of_lt h])
 #align lt_min lt_min
 
 theorem max_lt {a b c : α} (h₁ : a < c) (h₂ : b < c) : max a b < c :=
   -- Porting note: no `min_tac` tactic
   Or.elim (le_or_gt a b)
-    (λ h : a ≤ b => by rwa [max_eq_right h])
-    (λ h : a > b => by rwa [max_eq_left_of_lt h])
+    (fun h : a ≤ b ↦ by rwa [max_eq_right h])
+    (fun h : a > b ↦ by rwa [max_eq_left_of_lt h])
 #align max_lt max_lt
 
 end

--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -80,7 +80,7 @@ instance : HasSubset (Set α) :=
   ⟨(· ≤ ·)⟩
 
 instance : EmptyCollection (Set α) :=
-  ⟨λ _ => False⟩
+  ⟨fun _ ↦  False⟩
 
 syntax "{" extBinder " | " term "}" : term
 
@@ -206,10 +206,10 @@ def image (f : α → β) (s : Set α) : Set β := {f a | a ∈ s}
 instance : Functor Set where map := @Set.image
 
 instance : LawfulFunctor Set where
-  id_map _ := funext fun _ ↦ propext ⟨λ ⟨_, sb, rfl⟩ => sb, λ sb => ⟨_, sb, rfl⟩⟩
-  comp_map g h _ := funext <| λ c => propext
-    ⟨λ ⟨a, ⟨h₁, h₂⟩⟩ => ⟨g a, ⟨⟨a, ⟨h₁, rfl⟩⟩, h₂⟩⟩,
-     λ ⟨_, ⟨⟨a, ⟨h₁, h₂⟩⟩, h₃⟩⟩ => ⟨a, ⟨h₁, show h (g a) = c from h₂ ▸ h₃⟩⟩⟩
+  id_map _ := funext fun _ ↦ propext ⟨fun ⟨_, sb, rfl⟩ ↦ sb, fun sb ↦ ⟨_, sb, rfl⟩⟩
+  comp_map g h _ := funext <| fun c ↦ propext
+    ⟨fun ⟨a, ⟨h₁, h₂⟩⟩ ↦ ⟨g a, ⟨⟨a, ⟨h₁, rfl⟩⟩, h₂⟩⟩,
+     fun ⟨_, ⟨⟨a, ⟨h₁, h₂⟩⟩, h₃⟩⟩ ↦ ⟨a, ⟨h₁, show h (g a) = c from h₂ ▸ h₃⟩⟩⟩
   map_const := rfl
 
 /-- The property `s.Nonempty` expresses the fact that the set `s` is not empty. It should be used

--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -80,7 +80,7 @@ instance : HasSubset (Set α) :=
   ⟨(· ≤ ·)⟩
 
 instance : EmptyCollection (Set α) :=
-  ⟨fun _ ↦  False⟩
+  ⟨fun _ ↦ False⟩
 
 syntax "{" extBinder " | " term "}" : term
 

--- a/Mathlib/Lean/Meta.lean
+++ b/Mathlib/Lean/Meta.lean
@@ -27,7 +27,7 @@ def «let» (g : MVarId) (h : Name) (v : Expr) (t : Option Expr := .none) :
 /-- Has the effect of `refine ⟨e₁,e₂,⋯, ?_⟩`.
 -/
 def existsi (mvar : MVarId) (es : List Expr) : MetaM MVarId := do
-  es.foldlM (λ mv e => do
+  es.foldlM (fun mv e ↦ do
       let (subgoals,_) ← Elab.Term.TermElabM.run <| Elab.Tactic.run mv do
         Elab.Tactic.evalTactic (← `(tactic| refine ⟨?_,?_⟩))
       let [sg1, sg2] := subgoals | throwError "expected two subgoals"

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -965,7 +965,7 @@ theorem centroid_eq_iff [CharZero k] {n : ℕ} (s : Simplex k P n) {fs₁ fs₂ 
   specialize ha i
   have key : ∀ n : ℕ, (n : k) + 1 ≠ 0 := fun n h => by norm_cast at h
   -- we should be able to golf this to
-  -- `refine ⟨fun hi => decidable.by_contradiction (λ hni, _), ...⟩`,
+  -- `refine ⟨fun hi ↦ decidable.by_contradiction (fun hni ↦ ?_), ...⟩`,
   -- but for some unknown reason it doesn't work.
   constructor <;> intro hi <;> by_contra hni
   · simp [hni, hi, key] at ha

--- a/Mathlib/LinearAlgebra/FinsuppVectorSpace.lean
+++ b/Mathlib/LinearAlgebra/FinsuppVectorSpace.lean
@@ -63,7 +63,7 @@ variable [Semiring R] [AddCommMonoid M] [Module R M]
 open LinearMap Submodule
 
 open scoped Classical in
-/-- The basis on `ι →₀ M` with basis vectors `λ ⟨i, x⟩, single i (b i x)`. -/
+/-- The basis on `ι →₀ M` with basis vectors `fun ⟨i, x⟩ ↦ single i (b i x)`. -/
 protected def basis {φ : ι → Type*} (b : ∀ i, Basis (φ i) R M) : Basis (Σi, φ i) R (ι →₀ M) :=
   Basis.ofRepr
     { toFun := fun g =>

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -285,7 +285,7 @@ the scalars are the `n`-th roots of unity.-/
 theorem mem_center_iff {A : SpecialLinearGroup n R} :
     A ∈ center (SpecialLinearGroup n R) ↔ ∃ (r : R), r ^ (Fintype.card n) = 1 ∧ scalar n r = A := by
   rcases isEmpty_or_nonempty n with hn | ⟨⟨i⟩⟩; · exact ⟨by aesop, by simp [Subsingleton.elim A 1]⟩
-  refine ⟨fun h ↦  ⟨A i i, ?_, ?_⟩, fun ⟨r, _, hr⟩ ↦ mem_center_iff.mpr fun B ↦ ?_⟩
+  refine ⟨fun h ↦ ⟨A i i, ?_, ?_⟩, fun ⟨r, _, hr⟩ ↦ mem_center_iff.mpr fun B ↦ ?_⟩
   · have : det ((scalar n) (A i i)) = 1 := (scalar_eq_self_of_mem_center h i).symm ▸ A.property
     simpa using this
   · exact scalar_eq_self_of_mem_center h i

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -1018,16 +1018,17 @@ sending a multilinear map `g` to `g (f₁ ⬝ , ..., fₙ ⬝ )` is linear in `g
 sending a multilinear map `g` to `g (f₁ ⬝ , ..., fₙ ⬝ )` is linear in `g` and multilinear in
 `f₁, ..., fₙ`. -/
 @[simps] def compLinearMapMultilinear :
-  @MultilinearMap R ι (λ i ↦ M₁ i →ₗ[R] M₁' i)
-    ((MultilinearMap R M₁' M₂) →ₗ[R] MultilinearMap R M₁ M₂) _ _ _ (λ i ↦ LinearMap.module) _ where
+  @MultilinearMap R ι (fun i ↦ M₁ i →ₗ[R] M₁' i)
+    ((MultilinearMap R M₁' M₂) →ₗ[R] MultilinearMap R M₁ M₂) _ _ _
+      (fun i ↦ LinearMap.module) _ where
   toFun := MultilinearMap.compLinearMapₗ
   map_add' := by
     intro _ f i f₁ f₂
     ext g x
     change (g fun j ↦ update f i (f₁ + f₂) j <| x j) =
         (g fun j ↦ update f i f₁ j <|x j) + g fun j ↦ update f i f₂ j (x j)
-    let c : Π (i : ι), (M₁ i →ₗ[R] M₁' i) → M₁' i := λ i f ↦ f (x i)
-    convert g.map_add (λ j ↦ f j (x j)) i (f₁ (x i)) (f₂ (x i)) with j j j
+    let c : Π (i : ι), (M₁ i →ₗ[R] M₁' i) → M₁' i := fun i f ↦ f (x i)
+    convert g.map_add (fun j ↦ f j (x j)) i (f₁ (x i)) (f₂ (x i)) with j j j
     · exact Function.apply_update c f i (f₁ + f₂) j
     · exact Function.apply_update c f i f₁ j
     · exact Function.apply_update c f i f₂ j
@@ -1035,8 +1036,8 @@ sending a multilinear map `g` to `g (f₁ ⬝ , ..., fₙ ⬝ )` is linear in `g
     intro _ f i a f₀
     ext g x
     change (g fun j ↦ update f i (a • f₀) j <| x j) = a • g fun j ↦ update f i f₀ j (x j)
-    let c : Π (i : ι), (M₁ i →ₗ[R] M₁' i) → M₁' i := λ i f ↦ f (x i)
-    convert g.map_smul (λ j ↦ f j (x j)) i a (f₀ (x i)) with j j j
+    let c : Π (i : ι), (M₁ i →ₗ[R] M₁' i) → M₁' i := fun i f ↦ f (x i)
+    convert g.map_smul (fun j ↦ f j (x j)) i a (f₀ (x i)) with j j j
     · exact Function.apply_update c f i (a • f₀) j
     · exact Function.apply_update c f i f₀ j
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -352,9 +352,9 @@ def ofPolar (toFun : M → R) (toFun_smul : ∀ (a : R) (x : M), toFun (a • x)
   { toFun
     toFun_smul
     exists_companion' := ⟨LinearMap.mk₂ R (polar toFun) (polar_add_left) (polar_smul_left)
-      (fun x _ _ => by simp_rw [polar_comm _ x, polar_add_left])
-      (fun _ _ _ => by rw [polar_comm, polar_smul_left, polar_comm]),
-      fun _ _ =>  by
+      (fun x _ _ ↦ by simp_rw [polar_comm _ x, polar_add_left])
+      (fun _ _ _ ↦ by rw [polar_comm, polar_smul_left, polar_comm]),
+      fun _ _ ↦ by
         simp only [LinearMap.mk₂_apply]
         rw [polar, sub_sub, add_sub_cancel'_right]⟩ }
 #align quadratic_form.of_polar QuadraticForm.ofPolar

--- a/Mathlib/LinearAlgebra/StdBasis.lean
+++ b/Mathlib/LinearAlgebra/StdBasis.lean
@@ -18,7 +18,7 @@ which is the `Σ j, ι j`-indexed basis of `Π j, M j`. The basis vectors are gi
 
 The standard basis on `R^η`, i.e. `η → R` is called `Pi.basisFun`.
 
-To give a concrete example, `LinearMap.stdBasis R (λ (i : Fin 3), R) i 1`
+To give a concrete example, `LinearMap.stdBasis R (fun (i : Fin 3) ↦ R) i 1`
 gives the `i`th unit basis vector in `R³`, and `Pi.basisFun R (Fin 3)` proves
 this is a basis over `Fin 3 → R`.
 

--- a/Mathlib/Logic/Embedding/Basic.lean
+++ b/Mathlib/Logic/Embedding/Basic.lean
@@ -105,7 +105,7 @@ namespace Function
 
 namespace Embedding
 
-theorem coe_injective {α β} : @Injective (α ↪ β) (α → β) (λ f => ↑f) :=
+theorem coe_injective {α β} : @Injective (α ↪ β) (α → β) (fun f ↦ ↑f) :=
   DFunLike.coe_injective
 #align function.embedding.coe_injective Function.Embedding.coe_injective
 

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -61,9 +61,8 @@ theorem onFun_apply (f : β → β → γ) (g : α → β) (a b : α) : onFun f 
 lemma hfunext {α α' : Sort u} {β : α → Sort v} {β' : α' → Sort v} {f : ∀a, β a} {f' : ∀a, β' a}
     (hα : α = α') (h : ∀a a', HEq a a' → HEq (f a) (f' a')) : HEq f f' := by
   subst hα
-  have : ∀a, HEq (f a) (f' a) := λ a => h a a (HEq.refl a)
-  have : β = β' := by funext a
-                      exact type_eq_of_heq (this a)
+  have : ∀a, HEq (f a) (f' a) := fun a ↦ h a a (HEq.refl a)
+  have : β = β' := by funext a; exact type_eq_of_heq (this a)
   subst this
   apply heq_of_eq
   funext a
@@ -159,7 +158,7 @@ lemma Injective.dite (p : α → Prop) [DecidablePred p]
     {f : {a : α // p a} → β} {f' : {a : α // ¬ p a} → β}
     (hf : Injective f) (hf' : Injective f')
     (im_disj : ∀ {x x' : α} {hx : p x} {hx' : ¬ p x'}, f ⟨x, hx⟩ ≠ f' ⟨x', hx'⟩) :
-    Function.Injective (λ x => if h : p x then f ⟨x, h⟩ else f' ⟨x, h⟩) := fun x₁ x₂ h => by
+    Function.Injective (fun x ↦ if h : p x then f ⟨x, h⟩ else f' ⟨x, h⟩) := fun x₁ x₂ h => by
  dsimp only at h
  by_cases h₁ : p x₁ <;> by_cases h₂ : p x₂
  · rw [dif_pos h₁, dif_pos h₂] at h; injection (hf h)
@@ -291,7 +290,7 @@ theorem cantor_surjective {α} (f : α → Set α) : ¬Surjective f
 to `α`. -/
 theorem cantor_injective {α : Type*} (f : Set α → α) : ¬Injective f
   | i => cantor_surjective (fun a ↦ {b | ∀ U, a = f U → U b}) <|
-         RightInverse.surjective (λ U => Set.ext fun _ ↦ ⟨fun h ↦ h U rfl, fun h _ e ↦ i e ▸ h⟩)
+         RightInverse.surjective (fun U ↦ Set.ext fun _ ↦ ⟨fun h ↦ h U rfl, fun h _ e ↦ i e ▸ h⟩)
 #align function.cantor_injective Function.cantor_injective
 
 /-- There is no surjection from `α : Type u` into `Type (max u v)`. This theorem

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -202,7 +202,7 @@ theorem _root_.Acc.of_downward_closed (dc : ∀ {a b}, rβ b (f a) → ∃ c, f 
   ha.of_fibration f fun a _ h ↦
     let ⟨a', he⟩ := dc h
     -- Porting note: Lean 3 did not need the motive
-    ⟨a', he.substr (p := λ x => rβ x (f a)) h, he⟩
+    ⟨a', he.substr (p := fun x ↦ rβ x (f a)) h, he⟩
 #align acc.of_downward_closed Acc.of_downward_closed
 
 end Fibration
@@ -329,7 +329,7 @@ theorem head_induction_on {P : ∀ a : α, ReflTransGen r a b → Prop} {a : α}
   | refl => exact refl
   | @tail b c _ hbc ih =>
   -- Porting note: Lean 3 figured out the motive and `apply ih` worked
-  refine @ih (λ {a : α} (hab : ReflTransGen r a b) => P a (ReflTransGen.tail hab hbc)) ?_ ?_
+  refine @ih (fun {a : α} (hab : ReflTransGen r a b) ↦ P a (ReflTransGen.tail hab hbc)) ?_ ?_
   · exact head hbc _ refl
   · exact fun h1 h2 ↦ head h1 (h2.tail hbc)
 #align relation.refl_trans_gen.head_induction_on Relation.ReflTransGen.head_induction_on
@@ -421,7 +421,7 @@ theorem head_induction_on {P : ∀ a : α, TransGen r a b → Prop} {a : α} (h 
   | single h => exact base h
   | @tail b c _ hbc h_ih =>
   -- Lean 3 could figure out the motive and `apply h_ih` worked
-  refine @h_ih (λ {a : α} (hab : @TransGen α r a b) => P a (TransGen.tail hab hbc)) ?_ ?_;
+  refine @h_ih (fun {a : α} (hab : @TransGen α r a b) ↦ P a (TransGen.tail hab hbc)) ?_ ?_;
   exact fun h ↦ ih h (single hbc) (base hbc)
   exact fun hab hbc ↦ ih hab _
 #align relation.trans_gen.head_induction_on Relation.TransGen.head_induction_on

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -39,7 +39,7 @@ in φ i, f x ∂μ` as `i` tends to `l`.
 When using this definition with a measure restricted to a set `s`, which happens fairly often, one
 should not try too hard to use a `MeasureTheory.AECover` of subsets of `s`, as it often makes proofs
 more complicated than necessary. See for example the proof of
-`MeasureTheory.integrableOn_Iic_of_intervalIntegral_norm_tendsto` where we use `(λ x, Ioi x)` as a
+`MeasureTheory.integrableOn_Iic_of_intervalIntegral_norm_tendsto` where we use `(fun x ↦ oi x)` as a
 `MeasureTheory.AECover` w.r.t. `μ.restrict (Iic b)`, instead of using `(fun x ↦ Ioc x b)`.
 
 ## Main statements

--- a/Mathlib/MeasureTheory/Integral/Marginal.lean
+++ b/Mathlib/MeasureTheory/Integral/Marginal.lean
@@ -202,7 +202,7 @@ theorem lmarginal_image [DecidableEq δ'] {e : δ' → δ} (he : Injective e) (s
     {f : (∀ i, π (e i)) → ℝ≥0∞} (hf : Measurable f) (x : ∀ i, π i) :
       (∫⋯∫⁻_s.image e, f ∘ (· ∘' e) ∂μ) x = (∫⋯∫⁻_s, f ∂μ ∘' e) (x ∘' e) := by
   have h : Measurable ((· ∘' e) : (∀ i, π i) → _) :=
-    measurable_pi_iff.mpr <| λ i ↦ measurable_pi_apply (e i)
+    measurable_pi_iff.mpr <| fun i ↦ measurable_pi_apply (e i)
   induction s using Finset.induction generalizing x with
   | empty => simp
   | insert hi ih =>

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -186,8 +186,9 @@ theorem le_map_comap : m ≤ (m.comap g).map g :=
 
 end Functors
 
-@[simp] theorem map_const {m} (b : β) : MeasurableSpace.map (fun _a : α ↦ b) m = ⊤ :=
-  eq_top_iff.2 <| λ s _ ↦ by by_cases b ∈ s <;> simp [*, map_def] <;> rw [Set.preimage_id'] <;> simp
+@[simp] theorem map_const {m} (b : β) : MeasurableSpace.map (fun _a : α ↦ b) m = ⊤ := by
+  refine eq_top_iff.2 <| fun s ?_
+  by_cases b ∈ s <;> simp [*, map_def] <;> rw [Set.preimage_id'] <;> simp
 #align measurable_space.map_const MeasurableSpace.map_const
 
 set_option tactic.skipAssignedInstances false in

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -186,9 +186,9 @@ theorem le_map_comap : m ≤ (m.comap g).map g :=
 
 end Functors
 
-@[simp] theorem map_const {m} (b : β) : MeasurableSpace.map (fun _a : α ↦ b) m = ⊤ := by
-  refine eq_top_iff.2 <| fun s ?_
-  by_cases b ∈ s <;> simp [*, map_def] <;> rw [Set.preimage_id'] <;> simp
+@[simp] theorem map_const {m} (b : β) : MeasurableSpace.map (fun _a : α ↦ b) m = ⊤ :=
+  eq_top_iff.2 <| fun s _ ↦ by
+    by_cases b ∈ s <;> simp [*, map_def] <;> rw [Set.preimage_id'] <;> simp
 #align measurable_space.map_const MeasurableSpace.map_const
 
 set_option tactic.skipAssignedInstances false in

--- a/Mathlib/MeasureTheory/Measure/AEDisjoint.lean
+++ b/Mathlib/MeasureTheory/Measure/AEDisjoint.lean
@@ -40,7 +40,7 @@ theorem exists_null_pairwise_disjoint_diff [Countable ι] {s : ι → Set α}
     exact (measure_biUnion_null_iff <| to_countable _).2 fun j hj => hd (Ne.symm hj)
   · simp only [Pairwise, disjoint_left, onFun, mem_diff, not_and, and_imp, Classical.not_not]
     intro i j hne x hi hU hj
-    replace hU : x ∉ s i ∩ iUnion fun j ↦ iUnion fun _ ↦  s j :=
+    replace hU : x ∉ s i ∩ iUnion fun j ↦ iUnion fun _ ↦ s j :=
       fun h ↦ hU (subset_toMeasurable _ _ h)
     simp only [mem_inter_iff, mem_iUnion, not_and, not_exists] at hU
     exact (hU hi j hne.symm hj).elim

--- a/Mathlib/MeasureTheory/Measure/AEDisjoint.lean
+++ b/Mathlib/MeasureTheory/Measure/AEDisjoint.lean
@@ -40,7 +40,8 @@ theorem exists_null_pairwise_disjoint_diff [Countable ι] {s : ι → Set α}
     exact (measure_biUnion_null_iff <| to_countable _).2 fun j hj => hd (Ne.symm hj)
   · simp only [Pairwise, disjoint_left, onFun, mem_diff, not_and, and_imp, Classical.not_not]
     intro i j hne x hi hU hj
-    replace hU : x ∉ s i ∩ iUnion λ j => iUnion λ _ => s j := λ h => hU (subset_toMeasurable _ _ h)
+    replace hU : x ∉ s i ∩ iUnion fun j ↦ iUnion fun _ ↦  s j :=
+      fun h ↦ hU (subset_toMeasurable _ _ h)
     simp only [mem_inter_iff, mem_iUnion, not_and, not_exists] at hU
     exact (hU hi j hne.symm hj).elim
 #align measure_theory.exists_null_pairwise_disjoint_diff MeasureTheory.exists_null_pairwise_disjoint_diff

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -85,7 +85,7 @@ theorem MeasureTheory.measure_lt_one_eq_integral_div_gamma {p : ℝ} (hp : 0 < p
     edist_dist := fun _ _ => rfl
     eq_of_dist_eq_zero := by convert fun _ _ h => eq_of_sub_eq_zero (h4 h) }
   letI : NormedSpace ℝ F :=
-  { norm_smul_le := fun _ _ =>  h5 _ _ }
+  { norm_smul_le := fun _ _ ↦ h5 _ _ }
   -- We put the new topology on F
   letI : TopologicalSpace F := UniformSpace.toTopologicalSpace
   letI : MeasurableSpace F := borel F
@@ -128,7 +128,7 @@ theorem MeasureTheory.measure_le_eq_lt [Nontrivial E] (r : ℝ) :
     edist_dist := fun _ _ => rfl
     eq_of_dist_eq_zero := by convert fun _ _ h => eq_of_sub_eq_zero (h4 h) }
   letI : NormedSpace ℝ F :=
-  { norm_smul_le := fun _ _ =>  h5 _ _ }
+  { norm_smul_le := fun _ _ ↦ h5 _ _ }
   -- We put the new topology on F
   letI : TopologicalSpace F := UniformSpace.toTopologicalSpace
   letI : MeasurableSpace F := borel F

--- a/Mathlib/NumberTheory/ZetaValues.lean
+++ b/Mathlib/NumberTheory/ZetaValues.lean
@@ -201,7 +201,7 @@ theorem hasSum_one_div_pow_mul_fourier_mul_bernoulliFun {k : ℕ} (hk : 2 ≤ k)
       (-(2 * π * I) ^ k / k ! * bernoulliFun k x) := by
   -- first show it suffices to prove result for `Ico 0 1`
   suffices ∀ {y : ℝ}, y ∈ Ico (0 : ℝ) 1 →
-      HasSum (λ (n : ℤ) => 1 / (n : ℂ) ^ k * fourier n y)
+      HasSum (fun (n : ℤ) ↦ 1 / (n : ℂ) ^ k * fourier n y)
         (-(2 * (π : ℂ) * I) ^ k / k ! * bernoulliFun k y) by
     rw [← Ico_insert_right (zero_le_one' ℝ), mem_insert_iff, or_comm] at hx
     rcases hx with (hx | rfl)

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -832,13 +832,13 @@ instance instPartialOrder (α : Type*) [PartialOrder α] : PartialOrder αᵒᵈ
 
 instance instLinearOrder (α : Type*) [LinearOrder α] : LinearOrder αᵒᵈ where
   __ := inferInstanceAs (PartialOrder αᵒᵈ)
-  le_total := λ a b : α => le_total b a
+  le_total := fun a b : α ↦ le_total b a
   max := fun a b ↦ (min a b : α)
   min := fun a b ↦ (max a b : α)
   min_def := fun a b ↦ show (max .. : α) = _ by rw [max_comm, max_def]; rfl
   max_def := fun a b ↦ show (min .. : α) = _ by rw [min_comm, min_def]; rfl
-  decidableLE := (inferInstance : DecidableRel (λ a b : α => b ≤ a))
-  decidableLT := (inferInstance : DecidableRel (λ a b : α => b < a))
+  decidableLE := (inferInstance : DecidableRel (fun a b : α ↦ b ≤ a))
+  decidableLT := (inferInstance : DecidableRel (fun a b : α ↦ b < a))
 #align order_dual.linear_order OrderDual.instLinearOrder
 
 instance : ∀ [Inhabited α], Inhabited αᵒᵈ := fun [x : Inhabited α] => x

--- a/Mathlib/Order/Booleanisation.lean
+++ b/Mathlib/Order/Booleanisation.lean
@@ -131,12 +131,12 @@ instance instSDiff : SDiff (Booleanisation α) where
 @[simp] lemma lift_le_lift : lift a ≤ lift b ↔ a ≤ b := ⟨by rintro ⟨_⟩; assumption, LE.lift⟩
 @[simp] lemma comp_le_comp : comp a ≤ comp b ↔ b ≤ a := ⟨by rintro ⟨_⟩; assumption, LE.comp⟩
 @[simp] lemma lift_le_comp : lift a ≤ comp b ↔ Disjoint a b := ⟨by rintro ⟨_⟩; assumption, LE.sep⟩
-@[simp] lemma not_comp_le_lift : ¬ comp a ≤ lift b := λ h ↦ nomatch h
+@[simp] lemma not_comp_le_lift : ¬ comp a ≤ lift b := fun h ↦ nomatch h
 
 @[simp] lemma lift_lt_lift : lift a < lift b ↔ a < b := ⟨by rintro ⟨_⟩; assumption, LT.lift⟩
 @[simp] lemma comp_lt_comp : comp a < comp b ↔ b < a := ⟨by rintro ⟨_⟩; assumption, LT.comp⟩
 @[simp] lemma lift_lt_comp : lift a < comp b ↔ Disjoint a b := ⟨by rintro ⟨_⟩; assumption, LT.sep⟩
-@[simp] lemma not_comp_lt_lift : ¬ comp a < lift b := λ h ↦ nomatch h
+@[simp] lemma not_comp_lt_lift : ¬ comp a < lift b := fun h ↦ nomatch h
 
 @[simp] lemma lift_sup_lift (a b : α) : lift a ⊔ lift b = lift (a ⊔ b) := rfl
 @[simp] lemma lift_sup_comp (a b : α) : lift a ⊔ comp b = comp (b \ a) := rfl

--- a/Mathlib/Order/Closure.lean
+++ b/Mathlib/Order/Closure.lean
@@ -136,7 +136,7 @@ def ofPred (f : α → α) (p : α → Prop) (hf : ∀ x, x ≤ f x) (hfp : ∀ 
     (hmin : ∀ ⦃x y⦄, x ≤ y → p y → f x ≤ y) : ClosureOperator α where
   __ := mk₂ f hf fun _ y hxy => hmin hxy (hfp y)
   IsClosed := p
-  isClosed_iff := ⟨λ hx ↦ (hmin le_rfl hx).antisymm <| hf _, λ hx ↦ hx ▸ hfp _⟩
+  isClosed_iff := ⟨fun hx ↦ (hmin le_rfl hx).antisymm <| hf _, fun hx ↦ hx ▸ hfp _⟩
 #align closure_operator.mk₃ ClosureOperator.ofPred
 #align closure_operator.mk₃_apply ClosureOperator.ofPred_apply
 #align closure_operator.mem_mk₃_closed ClosureOperator.ofPred_isClosed

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -1520,11 +1520,11 @@ theorem iInf_sigma {p : β → Type*} {f : Sigma p → α} : ⨅ x, f x = ⨅ (i
 
 lemma iSup_sigma' {κ : β → Type*} (f : ∀ i, κ i → α) :
     (⨆ i, ⨆ j, f i j) = ⨆ x : Σ i, κ i, f x.1 x.2 :=
-(iSup_sigma (f := λ x ↦ f x.1 x.2)).symm
+(iSup_sigma (f := fun x ↦ f x.1 x.2)).symm
 
 lemma iInf_sigma' {κ : β → Type*} (f : ∀ i, κ i → α) :
     (⨅ i, ⨅ j, f i j) = ⨅ x : Σ i, κ i, f x.1 x.2 :=
-(iInf_sigma (f := λ x ↦ f x.1 x.2)).symm
+(iInf_sigma (f := fun x ↦ f x.1 x.2)).symm
 
 theorem iSup_prod {f : β × γ → α} : ⨆ x, f x = ⨆ (i) (j), f (i, j) :=
   eq_of_forall_ge_iff fun c => by simp only [iSup_le_iff, Prod.forall]
@@ -1535,10 +1535,10 @@ theorem iInf_prod {f : β × γ → α} : ⨅ x, f x = ⨅ (i) (j), f (i, j) :=
 #align infi_prod iInf_prod
 
 lemma iSup_prod' (f : β → γ → α) : (⨆ i, ⨆ j, f i j) = ⨆ x : β × γ, f x.1 x.2 :=
-(iSup_prod (f := λ x ↦ f x.1 x.2)).symm
+(iSup_prod (f := fun x ↦ f x.1 x.2)).symm
 
 lemma iInf_prod' (f : β → γ → α) : (⨅ i, ⨅ j, f i j) = ⨅ x : β × γ, f x.1 x.2 :=
-(iInf_prod (f := λ x ↦ f x.1 x.2)).symm
+(iInf_prod (f := fun x ↦ f x.1 x.2)).symm
 
 theorem biSup_prod {f : β × γ → α} {s : Set β} {t : Set γ} :
     ⨆ x ∈ s ×ˢ t, f x = ⨆ (a ∈ s) (b ∈ t), f (a, b) := by

--- a/Mathlib/Order/CompletePartialOrder.lean
+++ b/Mathlib/Order/CompletePartialOrder.lean
@@ -64,7 +64,7 @@ hf.directedOn_range.sSup_le <| Set.forall_mem_range.2 ha
 lemma CompletePartialOrder.scottContinuous {f : α → β} :
     ScottContinuous f ↔
     ∀ ⦃d : Set α⦄, d.Nonempty → DirectedOn (. ≤ .) d → IsLUB (f '' d) (f (sSup d)) := by
-  refine' ⟨λ h d hd₁ hd₂ ↦ h hd₁ hd₂ hd₂.isLUB_sSup, λ h d hne hd a hda ↦ _⟩
+  refine' ⟨fun h d hd₁ hd₂ ↦ h hd₁ hd₂ hd₂.isLUB_sSup, fun h d hne hd a hda ↦ ?_⟩
   rw [hda.unique hd.isLUB_sSup]
   exact h hne hd
 

--- a/Mathlib/Order/Filter/AtTopBot.lean
+++ b/Mathlib/Order/Filter/AtTopBot.lean
@@ -1077,7 +1077,7 @@ theorem tendsto_mul_const_atTop_of_pos (hr : 0 < r) :
 /-- If `r` is a positive constant, `x ↦ f x / r` tends to infinity along a filter
 if and only if `f` tends to infinity along the same filter. -/
 lemma tendsto_div_const_atTop_of_pos (hr : 0 < r) :
-    Tendsto (λ x ↦ f x / r) l atTop ↔ Tendsto f l atTop := by
+    Tendsto (fun x ↦ f x / r) l atTop ↔ Tendsto f l atTop := by
   simpa only [div_eq_mul_inv] using tendsto_mul_const_atTop_of_pos (inv_pos.2 hr)
 
 /-- If `f` tends to infinity along a nontrivial filter `l`, then
@@ -1099,7 +1099,7 @@ theorem tendsto_mul_const_atTop_iff_pos [NeBot l] (h : Tendsto f l atTop) :
 /-- If `f` tends to infinity along a nontrivial filter `l`, then
 `x ↦ f x * r` tends to infinity if and only if `0 < r. `-/
 lemma tendsto_div_const_atTop_iff_pos [NeBot l] (h : Tendsto f l atTop) :
-    Tendsto (λ x ↦ f x / r) l atTop ↔ 0 < r := by
+    Tendsto (fun x ↦ f x / r) l atTop ↔ 0 < r := by
   simp only [div_eq_mul_inv, tendsto_mul_const_atTop_iff_pos h, inv_pos]
 
 /-- If `f` tends to infinity along a filter, then `f` multiplied by a positive

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -394,7 +394,7 @@ theorem mem_generate_iff {s : Set <| Set α} {U : Set α} :
 #align filter.mem_generate_iff Filter.mem_generate_iff
 
 @[simp] lemma generate_singleton (s : Set α) : generate {s} = 𝓟 s :=
-  le_antisymm (λ _t ht ↦ mem_of_superset (mem_generate_of_mem <| mem_singleton _) ht) <|
+  le_antisymm (fun _t ht ↦ mem_of_superset (mem_generate_of_mem <| mem_singleton _) ht) <|
     le_generate_iff.2 <| singleton_subset_iff.2 Subset.rfl
 
 /-- `mk_of_closure s hs` constructs a filter on `α` whose elements set is exactly

--- a/Mathlib/Order/Filter/Lift.lean
+++ b/Mathlib/Order/Filter/Lift.lean
@@ -35,8 +35,9 @@ theorem lift_top (g : Set α → Filter β) : (⊤ : Filter α).lift g = g univ 
 -- Porting note: use `∃ i, p i ∧ _` instead of `∃ i (hi : p i), _`
 /-- If `(p : ι → Prop, s : ι → Set α)` is a basis of a filter `f`, `g` is a monotone function
 `Set α → Filter γ`, and for each `i`, `(pg : β i → Prop, sg : β i → Set α)` is a basis
-of the filter `g (s i)`, then `(λ (i : ι) (x : β i), p i ∧ pg i x, λ (i : ι) (x : β i), sg i x)`
-is a basis of the filter `f.lift g`.
+of the filter `g (s i)`, then
+`(fun (i : ι) (x : β i) ↦ p i ∧ pg i x, fun (i : ι) (x : β i) ↦ sg i x)` is a basis
+of the filter `f.lift g`.
 
 This basis is parametrized by `i : ι` and `x : β i`, so in order to formulate this fact using
 `Filter.HasBasis` one has to use `Σ i, β i` as the index type, see `Filter.HasBasis.lift`.
@@ -54,7 +55,8 @@ theorem HasBasis.mem_lift_iff {ι} {p : ι → Prop} {s : ι → Set α} {f : Fi
 
 /-- If `(p : ι → Prop, s : ι → Set α)` is a basis of a filter `f`, `g` is a monotone function
 `Set α → Filter γ`, and for each `i`, `(pg : β i → Prop, sg : β i → Set α)` is a basis
-of the filter `g (s i)`, then `(λ (i : ι) (x : β i), p i ∧ pg i x, λ (i : ι) (x : β i), sg i x)`
+of the filter `g (s i)`, then
+`(fun (i : ι) (x : β i) ↦ p i ∧ pg i x, fun (i : ι) (x : β i) ↦ sg i x)`
 is a basis of the filter `f.lift g`.
 
 This basis is parametrized by `i : ι` and `x : β i`, so in order to formulate this fact using

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -258,8 +258,8 @@ theorem isStrictWeakOrder_of_isOrderConnected [IsAsymm α r] [IsOrderConnected �
 -- see Note [lower instance priority]
 instance (priority := 100) isStrictOrderConnected_of_isStrictTotalOrder [IsStrictTotalOrder α r] :
     IsOrderConnected α r :=
-  ⟨λ _ _ _ h => (trichotomous _ _).imp_right
-    fun o => o.elim (fun e => e ▸ h) fun h' => _root_.trans h' h⟩
+  ⟨fun _ _ _ h ↦ (trichotomous _ _).imp_right
+    fun o ↦ o.elim (fun e ↦ e ▸ h) fun h' ↦ _root_.trans h' h⟩
 #align is_order_connected_of_is_strict_total_order isStrictOrderConnected_of_isStrictTotalOrder
 
 -- see Note [lower instance priority]

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -685,7 +685,7 @@ theorem coe_fn_toEquiv (f : r ≃r s) : (f.toEquiv : α → β) = f :=
 #align rel_iso.coe_fn_to_equiv RelIso.coe_fn_toEquiv
 
 /-- The map `coe_fn : (r ≃r s) → (α → β)` is injective. Lean fails to parse
-`function.injective (λ e : r ≃r s, (e : α → β))`, so we use a trick to say the same. -/
+`function.injective (fun e : r ≃r s ↦ (e : α → β))`, so we use a trick to say the same. -/
 theorem coe_fn_injective : Injective fun f : r ≃r s => (f : α → β) :=
   DFunLike.coe_injective
 #align rel_iso.coe_fn_injective RelIso.coe_fn_injective

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -1485,16 +1485,16 @@ variable [Preorder α] [Nonempty α] [Preorder β] {f : α → β}
 lemma StrictMono.not_bddAbove_range [NoMaxOrder α] [SuccOrder β] [IsSuccArchimedean β]
     (hf : StrictMono f) : ¬ BddAbove (Set.range f) := by
   rintro ⟨m, hm⟩
-  have hm' : ∀ a, f a ≤ m := λ a ↦ hm <| Set.mem_range_self _
+  have hm' : ∀ a, f a ≤ m := fun a ↦ hm <| Set.mem_range_self _
   obtain ⟨a₀⟩ := ‹Nonempty α›
   suffices ∀ b, f a₀ ≤ b → ∃ a, b < f a by
     obtain ⟨a, ha⟩ : ∃ a, m < f a := this m (hm' a₀)
     exact ha.not_le (hm' a)
-  have h : ∀ a, ∃ a', f a < f a' := λ a ↦ (exists_gt a).imp (λ a' h ↦ hf h)
+  have h : ∀ a, ∃ a', f a < f a' := fun a ↦ (exists_gt a).imp (fun a' h ↦ hf h)
   apply Succ.rec
   · exact h a₀
   rintro b _ ⟨a, hba⟩
-  exact (h a).imp (λ a' ↦ (succ_le_of_lt hba).trans_lt)
+  exact (h a).imp (fun a' ↦ (succ_le_of_lt hba).trans_lt)
 
 lemma StrictMono.not_bddBelow_range [NoMinOrder α] [PredOrder β] [IsPredArchimedean β]
     (hf : StrictMono f) : ¬ BddBelow (Set.range f) := hf.dual.not_bddAbove_range

--- a/Mathlib/Order/SupClosed.lean
+++ b/Mathlib/Order/SupClosed.lean
@@ -46,16 +46,16 @@ def SupClosed (s : Set α) : Prop := ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈
 
 @[simp] lemma supClosed_univ : SupClosed (univ : Set α) := by simp [SupClosed]
 lemma SupClosed.inter (hs : SupClosed s) (ht : SupClosed t) : SupClosed (s ∩ t) :=
-λ _a ha _b hb ↦ ⟨hs ha.1 hb.1, ht ha.2 hb.2⟩
+  fun _a ha _b hb ↦ ⟨hs ha.1 hb.1, ht ha.2 hb.2⟩
 
 lemma supClosed_sInter (hS : ∀ s ∈ S, SupClosed s) : SupClosed (⋂₀ S) :=
-λ _a ha _b hb _s hs ↦ hS _ hs (ha _ hs) (hb _ hs)
+  fun _a ha _b hb _s hs ↦ hS _ hs (ha _ hs) (hb _ hs)
 
 lemma supClosed_iInter (hf : ∀ i, SupClosed (f i)) : SupClosed (⋂ i, f i) :=
-supClosed_sInter <| forall_mem_range.2 hf
+  supClosed_sInter <| forall_mem_range.2 hf
 
 lemma SupClosed.directedOn (hs : SupClosed s) : DirectedOn (· ≤ ·) s :=
-λ _a ha _b hb ↦ ⟨_, hs ha hb, le_sup_left, le_sup_right⟩
+  fun _a ha _b hb ↦ ⟨_, hs ha hb, le_sup_left, le_sup_right⟩
 
 lemma IsUpperSet.supClosed (hs : IsUpperSet s) : SupClosed s := fun _a _ _b ↦ hs le_sup_right
 
@@ -112,18 +112,18 @@ def InfClosed (s : Set α) : Prop := ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈
 
 @[simp] lemma infClosed_univ : InfClosed (univ : Set α) := by simp [InfClosed]
 lemma InfClosed.inter (hs : InfClosed s) (ht : InfClosed t) : InfClosed (s ∩ t) :=
-λ _a ha _b hb ↦ ⟨hs ha.1 hb.1, ht ha.2 hb.2⟩
+  fun _a ha _b hb ↦ ⟨hs ha.1 hb.1, ht ha.2 hb.2⟩
 
 lemma infClosed_sInter (hS : ∀ s ∈ S, InfClosed s) : InfClosed (⋂₀ S) :=
-λ _a ha _b hb _s hs ↦ hS _ hs (ha _ hs) (hb _ hs)
+  fun _a ha _b hb _s hs ↦ hS _ hs (ha _ hs) (hb _ hs)
 
 lemma infClosed_iInter (hf : ∀ i, InfClosed (f i)) : InfClosed (⋂ i, f i) :=
-infClosed_sInter <| forall_mem_range.2 hf
+  infClosed_sInter <| forall_mem_range.2 hf
 
 lemma InfClosed.codirectedOn (hs : InfClosed s) : DirectedOn (· ≥ ·) s :=
-λ _a ha _b hb ↦ ⟨_, hs ha hb, inf_le_left, inf_le_right⟩
+  fun _a ha _b hb ↦ ⟨_, hs ha hb, inf_le_left, inf_le_right⟩
 
-lemma IsLowerSet.infClosed (hs : IsLowerSet s) :  InfClosed s := λ _a _ _b ↦ hs inf_le_right
+lemma IsLowerSet.infClosed (hs : IsLowerSet s) :  InfClosed s := fun _a _ _b ↦ hs inf_le_right
 
 lemma InfClosed.preimage [FunLike F β α] [InfHomClass F β α] (hs : InfClosed s) (f : F) :
     InfClosed (f ⁻¹' s) :=
@@ -209,7 +209,7 @@ lemma IsSublattice.prod {t : Set β} (hs : IsSublattice s) (ht : IsSublattice t)
 
 lemma isSublattice_pi {ι : Type*} {α : ι → Type*} [∀ i, Lattice (α i)] {s : Set ι}
     {t : ∀ i, Set (α i)} (ht : ∀ i ∈ s, IsSublattice (t i)) : IsSublattice (s.pi t) :=
-  ⟨supClosed_pi λ _i hi ↦ (ht _ hi).1, infClosed_pi λ _i hi ↦ (ht _ hi).2⟩
+  ⟨supClosed_pi fun _i hi ↦ (ht _ hi).1, infClosed_pi fun _i hi ↦ (ht _ hi).2⟩
 
 @[simp] lemma supClosed_preimage_toDual {s : Set αᵒᵈ} :
     SupClosed (toDual ⁻¹' s) ↔ InfClosed s := Iff.rfl
@@ -240,10 +240,10 @@ section LinearOrder
 variable [LinearOrder α]
 
 @[simp] protected lemma LinearOrder.supClosed (s : Set α) : SupClosed s :=
-λ a ha b hb ↦ by cases le_total a b <;> simp [*]
+  fun a ha b hb ↦ by cases le_total a b <;> simp [*]
 
 @[simp] protected lemma LinearOrder.infClosed (s : Set α) : InfClosed s :=
-λ a ha b hb ↦ by cases le_total a b <;> simp [*]
+  fun a ha b hb ↦ by cases le_total a b <;> simp [*]
 
 @[simp] protected lemma LinearOrder.isSublattice (s : Set α) : IsSublattice s :=
   ⟨LinearOrder.supClosed _, LinearOrder.infClosed _⟩
@@ -260,16 +260,16 @@ variable [SemilatticeSup α] [SemilatticeSup β] {s t : Set α} {a b : α}
 /-- Every set in a join-semilattice generates a set closed under join. -/
 @[simps! isClosed]
 def supClosure : ClosureOperator (Set α) := .ofPred
-  (λ s ↦ {a | ∃ (t : Finset α) (ht : t.Nonempty), ↑t ⊆ s ∧ t.sup' ht id = a})
+  (fun s ↦ {a | ∃ (t : Finset α) (ht : t.Nonempty), ↑t ⊆ s ∧ t.sup' ht id = a})
   SupClosed
-  (λ s a ha ↦ ⟨{a}, singleton_nonempty _, by simpa⟩)
+  (fun s a ha ↦ ⟨{a}, singleton_nonempty _, by simpa⟩)
   (by
     classical
     rintro s _ ⟨t, ht, hts, rfl⟩ _ ⟨u, hu, hus, rfl⟩
     refine' ⟨_, ht.mono <| subset_union_left _ _, _, sup'_union ht hu _⟩
     rw [coe_union]
     exact Set.union_subset hts hus)
-  (by rintro s₁ s₂ hs h₂ _ ⟨t, ht, hts, rfl⟩; exact h₂.finsetSup'_mem ht λ i hi ↦ hs <| hts hi)
+  (by rintro s₁ s₂ hs h₂ _ ⟨t, ht, hts, rfl⟩; exact h₂.finsetSup'_mem ht fun i hi ↦ hs <| hts hi)
 
 @[simp] lemma subset_supClosure {s : Set α} : s ⊆ supClosure s := supClosure.le_closure _
 
@@ -291,7 +291,7 @@ supClosure.idempotent _
 @[simp] lemma upperBounds_supClosure (s : Set α) : upperBounds (supClosure s) = upperBounds s :=
 (upperBounds_mono_set subset_supClosure).antisymm <| by
   rintro a ha _ ⟨t, ht, hts, rfl⟩
-  exact sup'_le _ _ λ b hb ↦ ha <| hts hb
+  exact sup'_le _ _ fun b hb ↦ ha <| hts hb
 
 @[simp] lemma isLUB_supClosure : IsLUB (supClosure s) a ↔ IsLUB s a := by simp [IsLUB]
 
@@ -323,16 +323,16 @@ variable [SemilatticeInf α] [SemilatticeInf β] {s t : Set α} {a b : α}
 /-- Every set in a join-semilattice generates a set closed under join. -/
 @[simps! isClosed]
 def infClosure : ClosureOperator (Set α) := ClosureOperator.ofPred
-  (λ s ↦ {a | ∃ (t : Finset α) (ht : t.Nonempty), ↑t ⊆ s ∧ t.inf' ht id = a})
+  (fun s ↦ {a | ∃ (t : Finset α) (ht : t.Nonempty), ↑t ⊆ s ∧ t.inf' ht id = a})
   InfClosed
-  (λ s a ha ↦ ⟨{a}, singleton_nonempty _, by simpa⟩)
+  (fun s a ha ↦ ⟨{a}, singleton_nonempty _, by simpa⟩)
   (by
     classical
     rintro s _ ⟨t, ht, hts, rfl⟩ _ ⟨u, hu, hus, rfl⟩
     refine' ⟨_, ht.mono <| subset_union_left _ _, _, inf'_union ht hu _⟩
     rw [coe_union]
     exact Set.union_subset hts hus)
-  (by rintro s₁ s₂ hs h₂ _ ⟨t, ht, hts, rfl⟩; exact h₂.finsetInf'_mem ht λ i hi ↦ hs <| hts hi)
+  (by rintro s₁ s₂ hs h₂ _ ⟨t, ht, hts, rfl⟩; exact h₂.finsetInf'_mem ht fun i hi ↦ hs <| hts hi)
 
 @[simp] lemma subset_infClosure {s : Set α} : s ⊆ infClosure s := infClosure.le_closure _
 
@@ -354,7 +354,7 @@ infClosure.idempotent _
 @[simp] lemma lowerBounds_infClosure (s : Set α) : lowerBounds (infClosure s) = lowerBounds s :=
 (lowerBounds_mono_set subset_infClosure).antisymm <| by
   rintro a ha _ ⟨t, ht, hts, rfl⟩
-  exact le_inf' _ _ λ b hb ↦ ha <| hts hb
+  exact le_inf' _ _ fun b hb ↦ ha <| hts hb
 
 @[simp] lemma isGLB_infClosure : IsGLB (infClosure s) a ↔ IsGLB s a := by simp [IsGLB]
 open Finset

--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -1615,12 +1615,14 @@ theorem ordConnected_iff_upperClosure_inter_lowerClosure :
 
 @[simp]
 theorem upperBounds_lowerClosure : upperBounds (lowerClosure s : Set α) = upperBounds s :=
-  (upperBounds_mono_set subset_lowerClosure).antisymm λ _a ha _b ⟨_c, hc, hcb⟩ => hcb.trans <| ha hc
+  (upperBounds_mono_set subset_lowerClosure).antisymm
+    fun _a ha _b ⟨_c, hc, hcb⟩ ↦ hcb.trans <| ha hc
 #align upper_bounds_lower_closure upperBounds_lowerClosure
 
 @[simp]
 theorem lowerBounds_upperClosure : lowerBounds (upperClosure s : Set α) = lowerBounds s :=
-  (lowerBounds_mono_set subset_upperClosure).antisymm λ _a ha _b ⟨_c, hc, hcb⟩ => (ha hc).trans hcb
+  (lowerBounds_mono_set subset_upperClosure).antisymm
+    fun _a ha _b ⟨_c, hc, hcb⟩ ↦ (ha hc).trans hcb
 #align lower_bounds_upper_closure lowerBounds_upperClosure
 
 @[simp]

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -376,8 +376,8 @@ theorem coe_mono : Monotone (fun (a : α) => (a : WithBot α)) := fun _ _ => coe
 #align with_bot.coe_mono WithBot.coe_mono
 
 theorem monotone_iff {f : WithBot α → β} :
-    Monotone f ↔ Monotone (λ a => f a : α → β) ∧ ∀ x : α, f ⊥ ≤ f x :=
-  ⟨fun h => ⟨h.comp WithBot.coe_mono, fun _ => h bot_le⟩, fun h =>
+    Monotone f ↔ Monotone (fun a ↦ f a : α → β) ∧ ∀ x : α, f ⊥ ≤ f x :=
+  ⟨fun h ↦ ⟨h.comp WithBot.coe_mono, fun _ ↦ h bot_le⟩, fun h ↦
     WithBot.forall.2
       ⟨WithBot.forall.2 ⟨fun _ => le_rfl, fun x _ => h.2 x⟩, fun _ =>
         WithBot.forall.2 ⟨fun h => (not_coe_le_bot _ h).elim,
@@ -401,7 +401,7 @@ theorem strictMono_iff {f : WithBot α → β} :
 #align with_bot.strict_mono_iff WithBot.strictMono_iff
 
 theorem strictAnti_iff {f : WithBot α → β} :
-    StrictAnti f ↔ StrictAnti (λ a => f a : α → β) ∧ ∀ x : α, f x < f ⊥ :=
+    StrictAnti f ↔ StrictAnti (fun a ↦ f a : α → β) ∧ ∀ x : α, f x < f ⊥ :=
   strictMono_iff (β := βᵒᵈ)
 
 @[simp]
@@ -1223,7 +1223,7 @@ theorem strictMono_iff {f : WithTop α → β} :
 #align with_top.strict_mono_iff WithTop.strictMono_iff
 
 theorem strictAnti_iff {f : WithTop α → β} :
-    StrictAnti f ↔ StrictAnti (λ a => f a : α → β) ∧ ∀ x : α, f ⊤ < f x :=
+    StrictAnti f ↔ StrictAnti (fun a ↦ f a : α → β) ∧ ∀ x : α, f ⊤ < f x :=
   strictMono_iff (β := βᵒᵈ)
 
 @[simp]

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -193,7 +193,7 @@ open scoped Classical
 If either of the kernels is not s-finite, `compProd` is given the junk value 0. -/
 noncomputable def compProd (κ : kernel α β) (η : kernel (α × β) γ) : kernel α (β × γ) :=
 if h : IsSFiniteKernel κ ∧ IsSFiniteKernel η then
-{ val := λ a ↦
+{ val := fun a ↦
     Measure.ofMeasurable (fun s _ => compProdFun κ η a s) (compProdFun_empty κ η a)
       (@compProdFun_iUnion _ _ _ _ _ _ κ η h.2 a)
   property := by

--- a/Mathlib/RingTheory/PowerSeries/Derivative.lean
+++ b/Mathlib/RingTheory/PowerSeries/Derivative.lean
@@ -36,7 +36,7 @@ The formal derivative of a power series in one variable.
 This is defined here as a function, but will be packaged as a
 derivation `derivative` on `R⟦X⟧`.
 -/
-noncomputable def derivativeFun (f : R⟦X⟧) : R⟦X⟧ := mk λ n ↦ coeff R (n + 1) f * (n + 1)
+noncomputable def derivativeFun (f : R⟦X⟧) : R⟦X⟧ := mk fun n ↦ coeff R (n + 1) f * (n + 1)
 
 theorem coeff_derivativeFun (f : R⟦X⟧) (n : ℕ) :
     coeff R n f.derivativeFun = coeff R (n + 1) f * (n + 1) := by

--- a/Mathlib/RingTheory/WittVector/Verschiebung.lean
+++ b/Mathlib/RingTheory/WittVector/Verschiebung.lean
@@ -106,7 +106,7 @@ instance verschiebungFun_isPoly : IsPoly p fun R _Rcr => @verschiebungFun p R _R
 -- Porting note: we add this example as a verification that Lean 4's instance resolution
 -- can handle what in Lean 3 we needed the `@[is_poly]` attribute to help with.
 example (p : ℕ) (f : ⦃R : Type _⦄ → [CommRing R] → WittVector p R → WittVector p R) [IsPoly p f] :
-    IsPoly p (λ (R : Type*) (I : CommRing R) => verschiebungFun ∘ (@f R I)) :=
+    IsPoly p (fun (R : Type*) (I : CommRing R) ↦ verschiebungFun ∘ (@f R I)) :=
   inferInstance
 
 variable {p}

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -1787,7 +1787,7 @@ private lemma toSet_equiv_aux {s : Set ZFSet.{u}} (hs : Small.{u} s) :
   (mk <| PSet.mk (Shrink s) fun x ↦ ((equivShrink s).symm x).1.out).toSet = s := by
     ext x
     rw [mem_toSet, ← mk_out x, mk_mem_iff, mk_out]
-    refine' ⟨_, λ xs ↦ ⟨equivShrink s (Subtype.mk x xs), _⟩⟩
+    refine' ⟨_, fun xs ↦ ⟨equivShrink s (Subtype.mk x xs), _⟩⟩
     · rintro ⟨b, h2⟩
       rw [← ZFSet.eq, ZFSet.mk_out] at h2
       simp [h2]
@@ -1797,9 +1797,9 @@ private lemma toSet_equiv_aux {s : Set ZFSet.{u}} (hs : Small.{u} s) :
 @[simps apply_coe]
 noncomputable def toSet_equiv : ZFSet.{u} ≃ {s : Set ZFSet.{u} // Small.{u, u+1} s} where
   toFun x := ⟨x.toSet, x.small_toSet⟩
-  invFun := λ ⟨s, h⟩ ↦ mk <| PSet.mk (Shrink s) fun x ↦ ((equivShrink.{u, u+1} s).symm x).1.out
+  invFun := fun ⟨s, h⟩ ↦ mk <| PSet.mk (Shrink s) fun x ↦ ((equivShrink.{u, u+1} s).symm x).1.out
   left_inv := Function.rightInverse_of_injective_of_leftInverse (by intros x y; simp)
-    λ s ↦ Subtype.coe_injective <| toSet_equiv_aux s.2
+    fun s ↦ Subtype.coe_injective <| toSet_equiv_aux s.2
   right_inv s := Subtype.coe_injective <| toSet_equiv_aux s.2
 
 end ZFSet

--- a/Mathlib/Tactic/CancelDenoms/Core.lean
+++ b/Mathlib/Tactic/CancelDenoms/Core.lean
@@ -338,7 +338,7 @@ def cancelDenominatorsTarget : TacticM Unit := do
 
 def cancelDenominators (loc : Location) : TacticM Unit := do
   withLocation loc cancelDenominatorsAt cancelDenominatorsTarget
-    (fun _ ↦  throwError "Failed to cancel any denominators")
+    (fun _ ↦ throwError "Failed to cancel any denominators")
 
 elab "cancel_denoms" loc?:(location)? : tactic => do
   cancelDenominators (expandOptLocation (Lean.mkOptionalNode loc?))

--- a/Mathlib/Tactic/CancelDenoms/Core.lean
+++ b/Mathlib/Tactic/CancelDenoms/Core.lean
@@ -338,7 +338,7 @@ def cancelDenominatorsTarget : TacticM Unit := do
 
 def cancelDenominators (loc : Location) : TacticM Unit := do
   withLocation loc cancelDenominatorsAt cancelDenominatorsTarget
-    (λ _ => throwError "Failed to cancel any denominators")
+    (fun _ ↦  throwError "Failed to cancel any denominators")
 
 elab "cancel_denoms" loc?:(location)? : tactic => do
   cancelDenominators (expandOptLocation (Lean.mkOptionalNode loc?))

--- a/Mathlib/Tactic/FunProp/ToStd.lean
+++ b/Mathlib/Tactic/FunProp/ToStd.lean
@@ -36,7 +36,7 @@ def isOrderedSubsetOf {α} [Inhabited α] [DecidableEq α] (a b : Array α) : Bo
 private def letTelescopeImpl {α} (e : Expr) (k : Array Expr → Expr → MetaM α) :
     MetaM α :=
   lambdaLetTelescope e λ xs b => do
-    if let .some i ← xs.findIdxM? (λ x => do pure ¬(← x.fvarId!.isLetVar)) then
+    if let .some i ← xs.findIdxM? (fun x ↦ do pure ¬(← x.fvarId!.isLetVar)) then
       k xs[0:i] (← mkLambdaFVars xs[i:] b)
     else
       k xs b

--- a/Mathlib/Tactic/Linarith/Datatypes.lean
+++ b/Mathlib/Tactic/Linarith/Datatypes.lean
@@ -164,7 +164,7 @@ end Ineq
 The main datatype for FM elimination.
 Variables are represented by natural numbers, each of which has an integer coefficient.
 Index 0 is reserved for constants, i.e. `coeffs.find 0` is the coefficient of 1.
-The represented term is `coeffs.sum (λ ⟨k, v⟩, v * Var[k])`.
+The represented term is `coeffs.sum (fun ⟨k, v⟩ ↦ v * Var[k])`.
 str determines the strength of the comparison -- is it < 0, ≤ 0, or = 0?
 -/
 structure Comp : Type where

--- a/Mathlib/Tactic/Linarith/Parsing.lean
+++ b/Mathlib/Tactic/Linarith/Parsing.lean
@@ -189,7 +189,7 @@ but each monomial key is replaced with its index according to `map`.
 If any new monomials are encountered, they are assigned variable numbers and `map` is updated.
  -/
 def elimMonom (s : Sum) (m : Map Monom ℕ) : Map Monom ℕ × Map ℕ ℤ :=
-  s.foldr (λ mn coeff ⟨map, out⟩ =>
+  s.foldr (fun mn coeff ⟨map, out⟩ ↦
     match map.find? mn with
     | some n => ⟨map, out.insert n coeff⟩
     | none =>

--- a/Mathlib/Tactic/Widget/SelectPanelUtils.lean
+++ b/Mathlib/Tactic/Widget/SelectPanelUtils.lean
@@ -30,7 +30,7 @@ def getGoalLocations (locations : Array GoalsLocation) : Array SubExpr.Pos := Id
 
 /-- Replace the sub-expression at the given position by a fresh meta-variable. -/
 def insertMetaVar (e : Expr) (pos : SubExpr.Pos) : MetaM Expr :=
-replaceSubexpr (fun _ ↦  do mkFreshExprMVar none .synthetic) pos e
+replaceSubexpr (fun _ ↦ do mkFreshExprMVar none .synthetic) pos e
 
 /-- Replace all meta-variable names by "?_". -/
 def String.renameMetaVar (s : String) : String :=

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -42,12 +42,12 @@ namespace Gen
 
 /-- Lift `Random.random` to the `Gen` monad. -/
 def chooseAny (α : Type u) [Random Id α] : Gen α :=
-  λ _ => rand α
+  fun _ ↦  rand α
 
 /-- Lift `BoundedRandom.randomR` to the `Gen` monad. -/
 def choose (α : Type u) [Preorder α] [BoundedRandom Id α] (lo hi : α) (h : lo ≤ hi) :
     Gen {a // lo ≤ a ∧ a ≤ hi} :=
-  λ _ => randBound α lo hi h
+  fun _ ↦  randBound α lo hi h
 
 lemma chooseNatLt_aux {lo hi : Nat} (a : Nat) (h : Nat.succ lo ≤ a ∧ a ≤ hi) :
     lo ≤ Nat.pred a ∧ Nat.pred a < hi :=

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -42,12 +42,12 @@ namespace Gen
 
 /-- Lift `Random.random` to the `Gen` monad. -/
 def chooseAny (α : Type u) [Random Id α] : Gen α :=
-  fun _ ↦  rand α
+  fun _ ↦ rand α
 
 /-- Lift `BoundedRandom.randomR` to the `Gen` monad. -/
 def choose (α : Type u) [Preorder α] [BoundedRandom Id α] (lo hi : α) (h : lo ≤ hi) :
     Gen {a // lo ≤ a ∧ a ≤ hi} :=
-  fun _ ↦  randBound α lo hi h
+  fun _ ↦ randBound α lo hi h
 
 lemma chooseNatLt_aux {lo hi : Nat} (a : Nat) (h : Nat.succ lo ≤ a ∧ a ≤ hi) :
     lo ≤ Nat.pred a ∧ Nat.pred a < hi :=

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -95,7 +95,7 @@ open Random Gen
 /-- Given an example `x : α`, `Shrinkable α` gives us a way to shrink it
 and suggest simpler examples. -/
 class Shrinkable (α : Type u) where
-  shrink : (x : α) → List α := fun _ ↦  []
+  shrink : (x : α) → List α := fun _ ↦ []
 
 /-- `SampleableExt` can be used in two ways. The first (and most common)
 is to simply generate values of a type directly using the `Gen` monad,
@@ -269,7 +269,7 @@ instance inhabited [inst : Inhabited α] : Inhabited (NoShrink α) := inst
 instance repr [inst : Repr α] : Repr (NoShrink α) := inst
 
 instance shrinkable : Shrinkable (NoShrink α) where
-  shrink := fun _ ↦  []
+  shrink := fun _ ↦ []
 
 instance sampleableExt [SampleableExt α] [Repr α] : SampleableExt (NoShrink α) :=
   SampleableExt.mkSelfContained <| (NoShrink.mk ∘ SampleableExt.interp) <$> SampleableExt.sample

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -95,7 +95,7 @@ open Random Gen
 /-- Given an example `x : α`, `Shrinkable α` gives us a way to shrink it
 and suggest simpler examples. -/
 class Shrinkable (α : Type u) where
-  shrink : (x : α) → List α := λ _ => []
+  shrink : (x : α) → List α := fun _ ↦  []
 
 /-- `SampleableExt` can be used in two ways. The first (and most common)
 is to simply generate values of a type directly using the `Gen` monad,
@@ -159,7 +159,7 @@ instance Fin.shrinkable {n : Nat} : Shrinkable (Fin n.succ) where
 
 /-- `Int.shrinkable` operates like `Nat.shrinkable` but also includes the negative variants. -/
 instance Int.shrinkable : Shrinkable Int where
-  shrink n := Nat.shrink n.natAbs |>.map (λ x => ([x, -x] : List ℤ)) |>.join
+  shrink n := Nat.shrink n.natAbs |>.map (fun x ↦ ([x, -x] : List ℤ)) |>.join
 
 instance Rat.shrinkable : Shrinkable Rat where
   shrink r :=
@@ -170,14 +170,14 @@ instance Char.shrinkable : Shrinkable Char := {}
 
 instance Prod.shrinkable [shrA : Shrinkable α] [shrB : Shrinkable β] :
     Shrinkable (Prod α β) where
-  shrink := λ (fst,snd) =>
+  shrink := fun (fst,snd) ↦
     let shrink1 := shrA.shrink fst |>.map fun x ↦ (x, snd)
     let shrink2 := shrB.shrink snd |>.map fun x ↦ (fst, x)
     shrink1 ++ shrink2
 
 instance Sigma.shrinkable [shrA : Shrinkable α] [shrB : Shrinkable β] :
     Shrinkable ((_ : α) × β) where
-  shrink := λ ⟨fst,snd⟩ =>
+  shrink := fun ⟨fst,snd⟩ ↦
     let shrink1 := shrA.shrink fst |>.map fun x ↦ ⟨x, snd⟩
     let shrink2 := shrB.shrink snd |>.map fun x ↦ ⟨fst, x⟩
     shrink1 ++ shrink2
@@ -269,7 +269,7 @@ instance inhabited [inst : Inhabited α] : Inhabited (NoShrink α) := inst
 instance repr [inst : Repr α] : Repr (NoShrink α) := inst
 
 instance shrinkable : Shrinkable (NoShrink α) where
-  shrink := λ _ => []
+  shrink := fun _ ↦  []
 
 instance sampleableExt [SampleableExt α] [Repr α] : SampleableExt (NoShrink α) :=
   SampleableExt.mkSelfContained <| (NoShrink.mk ∘ SampleableExt.interp) <$> SampleableExt.sample

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -171,8 +171,8 @@ def combine {p q : Prop} : PSum Unit (p → q) → PSum Unit p → PSum Unit q
 
 /-- Combine the test result for properties `p` and `q` to create a test for their conjunction. -/
 def and : TestResult p → TestResult q → TestResult (p ∧ q)
-  | failure h xs n, _ => failure (λ h2 => h h2.left) xs n
-  | _, failure h xs n => failure (λ h2 => h h2.right) xs n
+  | failure h xs n, _ => failure (fun h2 ↦ h h2.left) xs n
+  | _, failure h xs n => failure (fun h2 ↦ h h2.right) xs n
   | success h1, success h2 => success <| combine (combine (PSum.inr And.intro) h1) h2
   | gaveUp n, gaveUp m => gaveUp <| n + m
   | gaveUp n, _ => gaveUp n
@@ -181,7 +181,7 @@ def and : TestResult p → TestResult q → TestResult (p ∧ q)
 /-- Combine the test result for properties `p` and `q` to create a test for their disjunction. -/
 def or : TestResult p → TestResult q → TestResult (p ∨ q)
   | failure h1 xs n, failure h2 ys m =>
-    let h3 := λ h =>
+    let h3 := fun h ↦
       match h with
       | Or.inl h3 => h1 h3
       | Or.inr h3 => h2 h3
@@ -244,16 +244,16 @@ open TestResult
 def runProp (p : Prop) [Testable p] : Configuration → Bool → Gen (TestResult p) := Testable.run
 
 /-- A `dbgTrace` with special formatting -/
-def slimTrace [Pure m] (s : String) : m PUnit := dbgTrace s!"[SlimCheck: {s}]" (λ _ => pure ())
+def slimTrace [Pure m] (s : String) : m PUnit := dbgTrace s!"[SlimCheck: {s}]" (fun _ ↦  pure ())
 
 instance andTestable [Testable p] [Testable q] : Testable (p ∧ q) where
-  run := λ cfg min => do
+  run := fun cfg min ↦ do
     let xp ← runProp p cfg min
     let xq ← runProp q cfg min
     pure <| and xp xq
 
 instance orTestable [Testable p] [Testable q] : Testable (p ∨ q) where
-  run := λ cfg min => do
+  run := fun cfg min ↦ do
     let xp ← runProp p cfg min
     -- As a little performance optimization we can just not run the second
     -- test if the first succeeds
@@ -265,7 +265,7 @@ instance orTestable [Testable p] [Testable q] : Testable (p ∨ q) where
       pure <| or xp xq
 
 instance iffTestable [Testable ((p ∧ q) ∨ (¬ p ∧ ¬ q))] : Testable (p ↔ q) where
-  run := λ cfg min => do
+  run := fun cfg min ↦ do
     let h ← runProp ((p ∧ q) ∨ (¬ p ∧ ¬ q)) cfg min
     pure <| iff iff_iff_and_or_not_and_not h
 
@@ -273,13 +273,13 @@ variable {var : String}
 
 instance decGuardTestable [PrintableProp p] [Decidable p] {β : p → Prop} [∀ h, Testable (β h)] :
     Testable (NamedBinder var <| ∀ h, β h) where
-  run := λ cfg min => do
+  run := fun cfg min ↦ do
     if h : p then
       let res := (runProp (β h) cfg min)
       let s := printProp p
-      (λ r => addInfo s!"guard: {s}" (· <| h) r (PSum.inr <| λ q _ => q)) <$> res
+      (fun r ↦ addInfo s!"guard: {s}" (· <| h) r (PSum.inr <| fun q _ ↦ q)) <$> res
     else if cfg.traceDiscarded || cfg.traceSuccesses then
-      let res := (λ _ => pure <| gaveUp 1)
+      let res := (fun _ ↦  pure <| gaveUp 1)
       let s := printProp p
       slimTrace s!"discard: Guard {s} does not hold"; res
     else
@@ -287,7 +287,7 @@ instance decGuardTestable [PrintableProp p] [Decidable p] {β : p → Prop} [∀
 
 instance forallTypesTestable {f : Type → Prop} [Testable (f Int)] :
     Testable (NamedBinder var <| ∀ x, f x) where
-  run := λ cfg min => do
+  run := fun cfg min ↦ do
     let r ← runProp (f Int) cfg min
     pure <| addVarInfo var "ℤ" (· <| Int) r
 
@@ -354,7 +354,7 @@ def minimize [SampleableExt α] {β : α → Prop} [∀ x, Testable (β x)] (cfg
 bound variable with it. -/
 instance varTestable [SampleableExt α] {β : α → Prop} [∀ x, Testable (β x)] :
     Testable (NamedBinder var <| ∀ x : α, β x) where
-  run := λ cfg min => do
+  run := fun cfg min ↦ do
     let x ← SampleableExt.sample
     if cfg.traceSuccesses || cfg.traceDiscarded then
       slimTrace s!"{var} := {repr x}"
@@ -375,18 +375,18 @@ instance varTestable [SampleableExt α] {β : α → Prop} [∀ x, Testable (β 
 instance propVarTestable {β : Prop → Prop} [∀ b : Bool, Testable (β b)] :
   Testable (NamedBinder var <| ∀ p : Prop, β p)
 where
-  run := λ cfg min =>
-    imp (λ h (b : Bool) => h b) <$> Testable.runProp (NamedBinder var <| ∀ b : Bool, β b) cfg min
+  run := fun cfg min ↦
+    imp (fun h (b : Bool) ↦ h b) <$> Testable.runProp (NamedBinder var <| ∀ b : Bool, β b) cfg min
 
 instance (priority := high) unusedVarTestable [Nonempty α] [Testable β] :
   Testable (NamedBinder var (α → β))
 where
-  run := λ cfg min => do
+  run := fun cfg min ↦ do
     if cfg.traceDiscarded || cfg.traceSuccesses then
       slimTrace s!"{var} is unused"
     let r ← Testable.runProp β cfg min
     let finalR := addInfo s!"{var} is irrelevant (unused)" id r
-    pure <| imp (· <| Classical.ofNonempty) finalR (PSum.inr <| λ x _ => x)
+    pure <| imp (· <| Classical.ofNonempty) finalR (PSum.inr <| fun x _ ↦ x)
 
 instance (priority := 2000) subtypeVarTestable {p : α → Prop} {β : α → Prop}
     [∀ x, PrintableProp (p x)]
@@ -395,7 +395,7 @@ instance (priority := 2000) subtypeVarTestable {p : α → Prop} {β : α → Pr
     Testable (NamedBinder var <| Π x : α, NamedBinder var' <| p x → β x) where
   run cfg min :=
     letI (x : Subtype p) : Testable (β x) :=
-      { run := fun cfg min => do
+      { run := fun cfg min ↦ do
           let r ← Testable.runProp (β x.val) cfg min
           pure <| addInfo s!"guard: {printProp (p x)} (by construction)" id r (PSum.inr id) }
     do
@@ -404,7 +404,7 @@ instance (priority := 2000) subtypeVarTestable {p : α → Prop} {β : α → Pr
 
 instance (priority := low) decidableTestable {p : Prop} [PrintableProp p] [Decidable p] :
     Testable p where
-  run := λ _ _ =>
+  run := fun _ _ ↦
     if h : p then
       pure <| success (PSum.inr h)
     else

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -244,7 +244,7 @@ open TestResult
 def runProp (p : Prop) [Testable p] : Configuration → Bool → Gen (TestResult p) := Testable.run
 
 /-- A `dbgTrace` with special formatting -/
-def slimTrace [Pure m] (s : String) : m PUnit := dbgTrace s!"[SlimCheck: {s}]" (fun _ ↦  pure ())
+def slimTrace [Pure m] (s : String) : m PUnit := dbgTrace s!"[SlimCheck: {s}]" (fun _ ↦ pure ())
 
 instance andTestable [Testable p] [Testable q] : Testable (p ∧ q) where
   run := fun cfg min ↦ do
@@ -279,7 +279,7 @@ instance decGuardTestable [PrintableProp p] [Decidable p] {β : p → Prop} [∀
       let s := printProp p
       (fun r ↦ addInfo s!"guard: {s}" (· <| h) r (PSum.inr <| fun q _ ↦ q)) <$> res
     else if cfg.traceDiscarded || cfg.traceSuccesses then
-      let res := (fun _ ↦  pure <| gaveUp 1)
+      let res := (fun _ ↦ pure <| gaveUp 1)
       let s := printProp p
       slimTrace s!"discard: Guard {s} does not hold"; res
     else

--- a/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
@@ -504,7 +504,7 @@ theorem map_piecewise_smul [DecidableEq ι] (c : ι → R) (m : ι → M) (s : F
   f.toMultilinearMap.map_piecewise_smul _ _ _
 
 /-- Multiplicativity of a continuous alternating map along all coordinates at the same time,
-writing `f (λ i, c i • m i)` as `(∏ i, c i) • f m`. -/
+writing `f (fun i ↦ c i • m i)` as `(∏ i, c i) • f m`. -/
 theorem map_smul_univ [Fintype ι] (c : ι → R) (m : ι → M) :
     (f fun i => c i • m i) = (∏ i, c i) • f m :=
   f.toMultilinearMap.map_smul_univ _ _

--- a/Mathlib/Topology/Algebra/Module/StrongTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/StrongTopology.lean
@@ -266,7 +266,7 @@ def precomp [TopologicalAddGroup G] [ContinuousConstSMul 𝕜₃ G] [RingHomSurj
     haveI : UniformAddGroup G := comm_topologicalAddGroup_is_uniform
     rw [(strongTopology.embedding_coeFn _ _ _).continuous_iff]
     -- Porting note: without this, the following doesn't work
-    change Continuous ((λ f ↦ UniformOnFun.ofFun _ (f ∘ L)) ∘ DFunLike.coe)
+    change Continuous ((fun f ↦ UniformOnFun.ofFun _ (f ∘ L)) ∘ DFunLike.coe)
     exact (UniformOnFun.precomp_uniformContinuous fun S hS => hS.image L).continuous.comp
         (strongTopology.embedding_coeFn _ _ _).continuous
 #align continuous_linear_map.precomp ContinuousLinearMap.precomp

--- a/Mathlib/Topology/Bases.lean
+++ b/Mathlib/Topology/Bases.lean
@@ -212,7 +212,7 @@ lemma IsTopologicalBasis.subset_of_forall_subset {t : Set α} (hB : IsTopologica
 lemma IsTopologicalBasis.eq_of_forall_subset_iff {t : Set α} (hB : IsTopologicalBasis B)
     (hs : IsOpen s) (ht : IsOpen t) (h : ∀ U ∈ B, U ⊆ s ↔ U ⊆ t) : s = t := by
   rw [hB.open_eq_sUnion' hs, hB.open_eq_sUnion' ht]
-  exact congr_arg _ (Set.ext λ U ↦ and_congr_right <| h _)
+  exact congr_arg _ (Set.ext fun U ↦ and_congr_right <| h _)
 
 /-- A point `a` is in the closure of `s` iff all basis sets containing `a` intersect `s`. -/
 theorem IsTopologicalBasis.mem_closure_iff {b : Set (Set α)} (hb : IsTopologicalBasis b) {s : Set α}

--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -1857,11 +1857,11 @@ However, lemmas with this conclusion are not nice to use in practice because
   elaboration process.
   ```
   variable {M : Type*} [Add M] [TopologicalSpace M] [ContinuousAdd M]
-  example : Continuous (λ x : M, x + x) :=
-  continuous_add.comp _
+  example : Continuous (fun x : M ↦ x + x) :=
+    continuous_add.comp _
 
-  example : Continuous (λ x : M, x + x) :=
-  continuous_add.comp (continuous_id.prod_mk continuous_id)
+  example : Continuous (fun x : M ↦ x + x) :=
+    continuous_add.comp (continuous_id.prod_mk continuous_id)
   ```
   The second is a valid proof, which is accepted if you write it as
   `continuous_add.comp (continuous_id.prod_mk continuous_id : _)`
@@ -1873,7 +1873,8 @@ However, lemmas with this conclusion are not nice to use in practice because
 
 A much more convenient way to write continuity lemmas is like `Continuous.add`:
 ```
-Continuous.add {f g : X → M} (hf : Continuous f) (hg : Continuous g) : Continuous (λ x, f x + g x)
+Continuous.add {f g : X → M} (hf : Continuous f) (hg : Continuous g) :
+  Continuous (fun x ↦ f x + g x)
 ```
 The conclusion can be `Continuous (f + g)`, which is definitionally equal.
 This has the following advantages

--- a/Mathlib/Topology/Category/LightProfinite/Basic.lean
+++ b/Mathlib/Topology/Category/LightProfinite/Basic.lean
@@ -44,7 +44,7 @@ def FintypeCat.toLightProfinite (X : FintypeCat) : LightProfinite where
   isLimit := {
     lift := fun s ↦ s.π.app ⟨0⟩
     fac := fun s j ↦ (s.π.naturality (homOfLE (zero_le (unop j))).op)
-    uniq := fun _ _ h ↦  h ⟨0⟩ }
+    uniq := fun _ _ h ↦ h ⟨0⟩ }
 
 namespace LightProfinite
 

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -810,20 +810,20 @@ variable {Z : Type*} [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace
 @[simps toEquiv]
 def toHomeomorph (e : X ≃ Y) (he : ∀ s, IsOpen (e ⁻¹' s) ↔ IsOpen s) : X ≃ₜ Y where
   toEquiv := e
-  continuous_toFun := continuous_def.2 λ s ↦ (he _).2
-  continuous_invFun := continuous_def.2 λ s ↦ by convert (he _).1; simp
+  continuous_toFun := continuous_def.2 fun s ↦ (he _).2
+  continuous_invFun := continuous_def.2 fun s ↦ by convert (he _).1; simp
 
 @[simp] lemma coe_toHomeomorph (e : X ≃ Y) (he) : ⇑(e.toHomeomorph he) = e := rfl
 lemma toHomeomorph_apply (e : X ≃ Y) (he) (x : X) : e.toHomeomorph he x = e x := rfl
 
 @[simp] lemma toHomeomorph_refl :
-  (Equiv.refl X).toHomeomorph (λ _s ↦ Iff.rfl) = Homeomorph.refl _ := rfl
+  (Equiv.refl X).toHomeomorph (fun _s ↦ Iff.rfl) = Homeomorph.refl _ := rfl
 
 @[simp] lemma toHomeomorph_symm (e : X ≃ Y) (he) :
-  (e.toHomeomorph he).symm = e.symm.toHomeomorph λ s ↦ by convert (he _).symm; simp := rfl
+  (e.toHomeomorph he).symm = e.symm.toHomeomorph fun s ↦ by convert (he _).symm; simp := rfl
 
 lemma toHomeomorph_trans (e : X ≃ Y) (f : Y ≃ Z) (he hf) :
-    (e.trans f).toHomeomorph (λ _s ↦ (he _).trans (hf _)) =
+    (e.trans f).toHomeomorph (fun _s ↦ (he _).trans (hf _)) =
     (e.toHomeomorph he).trans (f.toHomeomorph hf) := rfl
 
 /-- An inducing equiv between topological spaces is a homeomorphism. -/

--- a/Mathlib/Topology/NoetherianSpace.lean
+++ b/Mathlib/Topology/NoetherianSpace.lean
@@ -231,9 +231,9 @@ theorem NoetherianSpace.exists_open_ne_empty_le_irreducibleComponent [Noetherian
   have hι' : Finite ι := by rwa [Set.finite_coe_iff]
 
   let U := Z \ ⋃ (x : ι), x
-  have hU0 : U ≠ ∅ := λ r ↦ by
+  have hU0 : U ≠ ∅ := fun r ↦ by
     obtain ⟨Z', hZ'⟩ := isIrreducible_iff_sUnion_closed.mp H.1 hι.toFinset
-      (λ z hz ↦ by
+      (fun z hz ↦ by
         simp only [Set.Finite.mem_toFinset, Set.mem_diff, Set.mem_singleton_iff] at hz
         exact isClosed_of_mem_irreducibleComponents _ hz.1)
       (by
@@ -262,6 +262,6 @@ theorem NoetherianSpace.exists_open_ne_empty_le_irreducibleComponent [Noetherian
       · exact ⟨i, Or.inr i.2, hi⟩
 
   refine ⟨U, hU1 ▸ isOpen_compl_iff.mpr ?_, hU0, sdiff_le⟩
-  exact isClosed_iUnion_of_finite λ i ↦ isClosed_of_mem_irreducibleComponents i.1 i.2.1
+  exact isClosed_iUnion_of_finite fun i ↦ isClosed_of_mem_irreducibleComponents i.1 i.2.1
 
 end TopologicalSpace

--- a/Mathlib/Topology/Order/Category/AlexDisc.lean
+++ b/Mathlib/Topology/Order/Category/AlexDisc.lean
@@ -59,8 +59,8 @@ end AlexDisc
 @[simps]
 def alexDiscEquivPreord : AlexDisc ≌ Preord where
   functor := forget₂ _ _ ⋙ topToPreord
-  inverse := { obj := λ X ↦ AlexDisc.of (WithUpperSet X), map := WithUpperSet.map }
-  unitIso := NatIso.ofComponents λ X ↦ AlexDisc.Iso.mk <| by
+  inverse := { obj := fun X ↦ AlexDisc.of (WithUpperSet X), map := WithUpperSet.map }
+  unitIso := NatIso.ofComponents fun X ↦ AlexDisc.Iso.mk <| by
     dsimp; exact homeoWithUpperSetTopologyorderIso X
-  counitIso := NatIso.ofComponents λ X ↦ Preord.Iso.mk <| by
+  counitIso := NatIso.ofComponents fun X ↦ Preord.Iso.mk <| by
     dsimp; exact (orderIsoSpecializationWithUpperSetTopology X).symm

--- a/Mathlib/Topology/Order/UpperLowerSetTopology.lean
+++ b/Mathlib/Topology/Order/UpperLowerSetTopology.lean
@@ -364,7 +364,7 @@ variable [Preorder α] [Preorder β] [Preorder γ]
 with the upper set topology. -/
 def map (f : α →o β) : C(WithUpperSet α, WithUpperSet β) where
   toFun := toUpperSet ∘ f ∘ ofUpperSet
-  continuous_toFun := continuous_def.2 λ _s hs ↦ IsUpperSet.preimage hs f.monotone
+  continuous_toFun := continuous_def.2 fun _s hs ↦ IsUpperSet.preimage hs f.monotone
 
 @[simp] lemma map_id : map (OrderHom.id : α →o α) = ContinuousMap.id _ := rfl
 @[simp] lemma map_comp (g : β →o γ) (f : α →o β): map (g.comp f) = (map g).comp (map f) := rfl
@@ -392,7 +392,7 @@ variable [Preorder α] [Preorder β] [Preorder γ]
 with the lower set topology. -/
 def map (f : α →o β) : C(WithLowerSet α, WithLowerSet β) where
   toFun := toLowerSet ∘ f ∘ ofLowerSet
-  continuous_toFun := continuous_def.2 λ _s hs ↦ IsLowerSet.preimage hs f.monotone
+  continuous_toFun := continuous_def.2 fun _s hs ↦ IsLowerSet.preimage hs f.monotone
 
 @[simp] lemma map_id : map (OrderHom.id : α →o α) = ContinuousMap.id _ := rfl
 @[simp] lemma map_comp (g : β →o γ) (f : α →o β): map (g.comp f) = (map g).comp (map f) := rfl

--- a/Mathlib/Topology/Semicontinuous.lean
+++ b/Mathlib/Topology/Semicontinuous.lean
@@ -31,8 +31,8 @@ We introduce 4 definitions related to lower semicontinuity:
 
 We build a basic API using dot notation around these notions, and we prove that
 * constant functions are lower semicontinuous;
-* `indicator s (λ _, y)` is lower semicontinuous when `s` is open and `0 ≤ y`, or when `s` is closed
-  and `y ≤ 0`;
+* `indicator s (fun _ ↦ y)` is lower semicontinuous when `s` is open and `0 ≤ y`,
+  or when `s` is closed and `y ≤ 0`;
 * continuous functions are lower semicontinuous;
 * composition with a continuous monotone functions maps lower semicontinuous functions to lower
   semicontinuous functions. If the function is anti-monotone, it instead maps lower semicontinuous

--- a/Mathlib/Topology/Specialization.lean
+++ b/Mathlib/Topology/Specialization.lean
@@ -80,7 +80,7 @@ def orderIsoSpecializationWithUpperSetTopology (α : Type*) [Preorder α] :
 order. -/
 def homeoWithUpperSetTopologyorderIso (α : Type*) [TopologicalSpace α] [AlexandrovDiscrete α] :
     α ≃ₜ WithUpperSet (Specialization α) :=
-(toEquiv.trans toUpperSet).toHomeomorph λ s ↦ by simp [Set.preimage_comp]
+(toEquiv.trans toUpperSet).toHomeomorph fun s ↦ by simp [Set.preimage_comp]
 
 /-- Sends a topological space to its specialisation order. -/
 @[simps]

--- a/test/Continuity.lean
+++ b/test/Continuity.lean
@@ -78,6 +78,6 @@ end basic
 
 example {α β : Type _} [TopologicalSpace α] [TopologicalSpace β] {x₀ : α} (f : α → α → β)
   (hf : ContinuousAt (Function.uncurry f) (x₀, x₀)) :
-  ContinuousAt (λ x ↦ f x x) x₀ := by
+  ContinuousAt (fun x ↦ f x x) x₀ := by
   fail_if_success { exact hf.comp (continuousAt_id.prod continuousAt_id) }
   exact hf.comp_of_eq (continuousAt_id.prod continuousAt_id) rfl

--- a/test/Explode.lean
+++ b/test/Explode.lean
@@ -28,7 +28,7 @@ info: true_iff : ∀ (p : Prop), (True ↔ p) = p
 set_option pp.unicode.fun true
 
 theorem lambda : True → True :=
-  λ a => a
+  fun a ↦ a
 
 /--
 info: lambda : True → True
@@ -50,7 +50,7 @@ info: application : True ∧ True
 #guard_msgs in #explode application
 
 theorem theorem_1 : ∀ (p : Prop), p → p :=
-  λ (p : Prop) => (λ hP : p => hP)
+  fun (p : Prop) ↦ (fun hP : p ↦ hP)
 /--
 info: theorem_1 : ∀ (p : Prop), p → p
 
@@ -61,7 +61,7 @@ info: theorem_1 : ∀ (p : Prop), p → p
 #guard_msgs in #explode theorem_1
 
 theorem theorem_2 : ∀ (p : Prop) (q : Prop), p → q → p ∧ q :=
-  λ p => λ q => λ hP => λ hQ => And.intro hP hQ
+  fun p ↦ fun q ↦ fun hP ↦ fun hQ ↦ And.intro hP hQ
 
 /--
 info: theorem_2 : ∀ (p q : Prop), p → q → p ∧ q
@@ -77,8 +77,8 @@ info: theorem_2 : ∀ (p q : Prop), p → q → p ∧ q
 
 theorem theorem_3 (a : Prop) (h : a) : a ↔ True :=
   Iff.intro
-    (λ hl => trivial)
-    (λ hr => h)
+    (fun hl ↦ trivial)
+    (fun hr ↦ h)
 
 /--
 info: theorem_3 : ∀ (a : Prop), a → (a ↔ True)
@@ -97,7 +97,7 @@ info: theorem_3 : ∀ (a : Prop), a → (a ↔ True)
 
 
 theorem theorem_4 : ∀ p q : Prop, (p → q) → (¬q → ¬p) :=
-  λ U => λ W => λ hPQ => λ hNQ => λ hP => False.elim (hNQ (hPQ hP))
+  fun U ↦ fun W ↦ fun hPQ ↦ fun hNQ ↦ fun hP ↦ False.elim (hNQ (hPQ hP))
 
 /--
 info: theorem_4 : ∀ (p q : Prop), (p → q) → ¬q → ¬p
@@ -115,12 +115,12 @@ info: theorem_4 : ∀ (p q : Prop), (p → q) → ¬q → ¬p
 #guard_msgs in #explode theorem_4
 
 lemma lemma_5 : ∀ p q : Prop, (¬q → ¬p) → (p → q) :=
-  λ p => λ q =>
-  λ hNQNP =>
-  λ hP =>
+  fun p ↦ fun q ↦
+  fun hNQNP ↦
+  fun hP ↦
     Or.elim (Classical.em q)
-    (λ hQ => hQ)
-    (λ hNQ =>
+    (fun hQ ↦ hQ)
+    (fun hNQ ↦
       let hNP := hNQNP hNQ
       False.elim (hNP hP))
 
@@ -146,7 +146,7 @@ info: lemma_5 : ∀ (p q : Prop), (¬q → ¬p) → p → q
 
 
 lemma lemma_6 : ∀ p q : Prop, (p → q) → p → q :=
-  λ p h hpq hp => hpq hp
+  fun p h hpq hp ↦ hpq hp
 
 /--
 info: lemma_6 : ∀ (p q : Prop), (p → q) → p → q
@@ -161,7 +161,7 @@ info: lemma_6 : ∀ (p q : Prop), (p → q) → p → q
 #guard_msgs in #explode lemma_6
 
 lemma lemma_7 : ∀ p q r : Prop, (p → q) → (p → q → r) → (p → r) :=
-  λ p q r hq hqr hp =>
+  fun p q r hq hqr hp ↦
     let hq' := hq hp
     let hqr' := hqr hp
     hqr' hq'
@@ -183,11 +183,11 @@ info: lemma_7 : ∀ (p q r : Prop), (p → q) → (p → q → r) → p → r
 #guard_msgs in #explode lemma_7
 
 lemma lemma_5' : ∀ p q : Prop, (¬q → ¬p) → (p → q) :=
-  λ p => λ q =>
-  λ hNQNP =>
+  fun p ↦ fun q ↦
+  fun hNQNP ↦
     Or.elim (Classical.em q)
-    (λ hQ hP => hQ)
-    (λ hNQ hP =>
+    (fun hQ hP ↦ hQ)
+    (fun hNQ hP ↦
       let hNP := hNQNP hNQ
       False.elim (hNP hP))
 
@@ -223,7 +223,7 @@ info: fun hp hnp ↦ hnp hp : p → (p → q) → q
 2│1,0  │ ∀E  │ q
 3│0,1,2│ ∀I  │ p → (p → q) → q
 -/
-#guard_msgs in #explode fun (hp : p) (hnp : p → q) => hnp hp
+#guard_msgs in #explode fun (hp : p) (hnp : p → q) ↦ hnp hp
 
 /--
 info: fun hNQNP ↦
@@ -245,10 +245,10 @@ info: fun hNQNP ↦
 12│1,4,11│ Or.elim      │ p → q
 13│0,12  │ ∀I           │ (¬q → ¬p) → p → q
 -/
-#guard_msgs in #explode fun (hNQNP : ¬q → ¬p) =>
+#guard_msgs in #explode fun (hNQNP : ¬q → ¬p) ↦
   Or.elim (Classical.em q)
-    (λ hQ hP => hQ)
-    (λ hNQ hP =>
+    (fun hQ hP ↦ hQ)
+    (fun hNQ hP ↦
       let hNP := hNQNP hNQ
       False.elim (hNP hP))
 

--- a/test/Expr.lean
+++ b/test/Expr.lean
@@ -10,7 +10,7 @@ section replaceRec
 /-- Reorder the last two arguments of every function in the expression.
   (The resulting term will generally not be a type-correct) -/
 def reorderLastArguments : Expr → Expr :=
-  Expr.replaceRec λ r e =>
+  Expr.replaceRec fun r e ↦
     let n := e.getAppNumArgs
     if n ≥ 2 then
       mkAppN e.getAppFn <| e.getAppArgs.map r |>.swap! (n - 1) (n - 2)

--- a/test/MfldSetTac.lean
+++ b/test/MfldSetTac.lean
@@ -24,7 +24,7 @@ section stub_lemmas
 structure PartialHomeomorph (α : Type u) (β : Type u) extends PartialEquiv α β
 
 noncomputable
-instance PartialHomeomorph.has_coe_to_fun : CoeFun (PartialHomeomorph α β) (fun _ ↦  α → β) := test_sorry
+instance PartialHomeomorph.has_coe_to_fun : CoeFun (PartialHomeomorph α β) (fun _ ↦ α → β) := test_sorry
 
 noncomputable
 def PartialHomeomorph.symm (_e : PartialHomeomorph α β) : PartialHomeomorph β α := test_sorry
@@ -55,7 +55,7 @@ noncomputable
 def ModelWithCorners.symm (_I : ModelWithCorners 𝕜 E H) : PartialEquiv E H := test_sorry
 
 noncomputable
-instance ModelWithCorners.has_coe_to_fun : CoeFun (ModelWithCorners 𝕜 E H) (fun _ ↦  H → E) := test_sorry
+instance ModelWithCorners.has_coe_to_fun : CoeFun (ModelWithCorners 𝕜 E H) (fun _ ↦ H → E) := test_sorry
 
 @[mfld_simps] lemma ModelWithCorners.left_inv (I : ModelWithCorners 𝕜 E H) (x : H) :
   I.symm (I x) = x :=

--- a/test/MfldSetTac.lean
+++ b/test/MfldSetTac.lean
@@ -24,7 +24,7 @@ section stub_lemmas
 structure PartialHomeomorph (α : Type u) (β : Type u) extends PartialEquiv α β
 
 noncomputable
-instance PartialHomeomorph.has_coe_to_fun : CoeFun (PartialHomeomorph α β) (λ _ => α → β) := test_sorry
+instance PartialHomeomorph.has_coe_to_fun : CoeFun (PartialHomeomorph α β) (fun _ ↦  α → β) := test_sorry
 
 noncomputable
 def PartialHomeomorph.symm (_e : PartialHomeomorph α β) : PartialHomeomorph β α := test_sorry
@@ -55,7 +55,7 @@ noncomputable
 def ModelWithCorners.symm (_I : ModelWithCorners 𝕜 E H) : PartialEquiv E H := test_sorry
 
 noncomputable
-instance ModelWithCorners.has_coe_to_fun : CoeFun (ModelWithCorners 𝕜 E H) (λ _ => H → E) := test_sorry
+instance ModelWithCorners.has_coe_to_fun : CoeFun (ModelWithCorners 𝕜 E H) (fun _ ↦  H → E) := test_sorry
 
 @[mfld_simps] lemma ModelWithCorners.left_inv (I : ModelWithCorners 𝕜 E H) (x : H) :
   I.symm (I x) = x :=

--- a/test/SimpRw.lean
+++ b/test/SimpRw.lean
@@ -9,7 +9,7 @@ import Mathlib.Tactic.SimpRw
 private axiom test_sorry : ∀ {α}, α
 
 -- `simp_rw` can perform rewrites under binders:
-example : (λ (x y : Nat) => x + y) = (λ x y => y + x) := by simp_rw [Nat.add_comm]
+example : (fun (x y : Nat) ↦ x + y) = (fun x y ↦ y + x) := by simp_rw [Nat.add_comm]
 
 -- `simp_rw` can apply reverse rules:
 example (f : Nat → Nat) {a b c : Nat} (ha : f b = a) (hc : f b = c) : a = c := by simp_rw [← ha, hc]

--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -108,7 +108,7 @@ def MyProd.map {α α' β β'} (f : α → α') (g : β → β') (x : MyProd α 
 
 namespace foo
 @[simps] protected def rfl {α} : α ≃ α :=
-  ⟨id, fun x ↦ x, fun _ ↦  rfl, fun _ ↦  rfl⟩
+  ⟨id, fun x ↦ x, fun _ ↦ rfl, fun _ ↦ rfl⟩
 
 /- simps adds declarations -/
 run_cmd liftTermElabM <| do
@@ -166,13 +166,13 @@ example {α} (x : α) : rfl2.toFun x = x ∧ rfl2.invFun x = x := by
 /- test `fullyApplied` option -/
 
 @[simps (config := .asFn)]
-def rfl3 {α} : α ≃ α := ⟨id, fun x ↦ x, fun _ ↦  rfl, fun _ ↦  rfl⟩
+def rfl3 {α} : α ≃ α := ⟨id, fun x ↦ x, fun _ ↦ rfl, fun _ ↦ rfl⟩
 
 end foo
 
 /- we reduce the type when applying [simps] -/
 def my_equiv := Equiv'
-@[simps] def baz : my_equiv ℕ ℕ := ⟨id, fun x ↦ x, fun _ ↦  rfl, fun _ ↦  rfl⟩
+@[simps] def baz : my_equiv ℕ ℕ := ⟨id, fun x ↦ x, fun _ ↦ rfl, fun _ ↦ rfl⟩
 
 /- todo: test that name clashes gives an error -/
 
@@ -239,7 +239,7 @@ def test {α} : ComplicatedEquivPlusData α :=
   { foo.rfl with
     P := fun f ↦ f = id
     data := rfl
-    extra := fun _ ↦  ⟨(⟨3, 5⟩ : MyProd _ _).1, (⟨3, 5⟩ : MyProd _ _).2⟩ }
+    extra := fun _ ↦ ⟨(⟨3, 5⟩ : MyProd _ _).1, (⟨3, 5⟩ : MyProd _ _).2⟩ }
 
 /- test whether this is indeed rejected as a valid eta expansion -/
 @[simps!]
@@ -247,7 +247,7 @@ def test_sneaky {α} : ComplicatedEquivPlusData α :=
   { foo.rfl with
     P := fun f ↦ f = id
     data := rfl
-    extra := fun _ ↦  ⟨(3,5).1,(3,5).2⟩ }
+    extra := fun _ ↦ ⟨(3,5).1,(3,5).2⟩ }
 
 run_cmd liftTermElabM <| do
   let env ← getEnv
@@ -437,7 +437,7 @@ infixr:80 " ≫ " => CategoryStruct.comp -- type as \gg
 
 @[simps] instance types : CategoryStruct (Type u) :=
   { hom  := fun a b ↦ (a → b)
-    id   := fun _ ↦  id
+    id   := fun _ ↦ id
     comp := fun f g ↦ g ∘ f }
 
 @[ext] theorem types.ext {X Y : Type u} {f g : X ⟶ Y} : (∀ x, f x = g x) → f = g := funext
@@ -479,10 +479,10 @@ structure Equiv2 (α : Sort _) (β : Sort _) :=
   (left_inv  : invFun.LeftInverse toFun)
   (right_inv : invFun.RightInverse toFun)
 
-instance {α β} : CoeFun (Equiv2 α β) (fun _ ↦  α → β) := ⟨Equiv2.toFun⟩
+instance {α β} : CoeFun (Equiv2 α β) (fun _ ↦ α → β) := ⟨Equiv2.toFun⟩
 
 @[simps] protected def rfl2 {α} : Equiv2 α α :=
-  ⟨fun x ↦ x, fun x ↦ x, fun _ ↦  rfl, fun _ ↦  rfl⟩
+  ⟨fun x ↦ x, fun x ↦ x, fun _ ↦ rfl, fun _ ↦ rfl⟩
 
 example {α} (x x' : α) (h : x = x') : coercing.rfl2 x = x' := by rw [coercing.rfl2_toFun, h]
 example {α} (x x' : α) (h : x = x') : coercing.rfl2 x = x' := by simp; rw [h]
@@ -542,7 +542,7 @@ class ExtendingStuff (G : Type u) extends Mul G, Zero G, Neg G, HasSubset G :=
     zero := 0
     neg := Nat.succ
     Subset := fun _ _ ↦ True
-    new_axiom := fun _ ↦  trivial }
+    new_axiom := fun _ ↦ trivial }
 
 section
 attribute [local instance] bar
@@ -557,7 +557,7 @@ class new_ExtendingStuff (G : Type u) extends Mul G, Zero G, Neg G, HasSubset G 
     zero := 0
     neg := Nat.succ
     Subset := fun _ _ ↦ True
-    new_axiom := fun _ ↦  trivial }
+    new_axiom := fun _ ↦ trivial }
 
 section
 attribute [local instance] new_bar
@@ -577,7 +577,7 @@ local infix:25 (priority := high) " ≃ " => ManualCoercion.Equiv
 
 variable {α β γ : Sort _}
 
-instance : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv.toFun⟩
+instance : CoeFun (α ≃ β) (fun _ ↦ α → β) := ⟨Equiv.toFun⟩
 
 def Equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.invFun, e.toFun⟩
 
@@ -627,7 +627,7 @@ structure Equiv (α : Sort _) (β : Sort _) :=
 
 local infix:25 (priority := high) " ≃ " => ManualInitialize.Equiv
 
-instance : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv.toFun⟩
+instance : CoeFun (α ≃ β) (fun _ ↦ α → β) := ⟨Equiv.toFun⟩
 
 def Equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.invFun, e.toFun⟩
 
@@ -659,7 +659,7 @@ structure Equiv (α : Sort u) (β : Sort v) :=
 
 local infix:25 (priority := high) " ≃ " => FaultyUniverses.Equiv
 
-instance : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv.toFun⟩
+instance : CoeFun (α ≃ β) (fun _ ↦ α → β) := ⟨Equiv.toFun⟩
 
 def Equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.invFun, e.toFun⟩
 
@@ -688,7 +688,7 @@ structure Equiv (α : Sort u) (β : Sort v) :=
 
 local infix:25 (priority := high) " ≃ " => ManualUniverses.Equiv
 
-instance : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv.toFun⟩
+instance : CoeFun (α ≃ β) (fun _ ↦ α → β) := ⟨Equiv.toFun⟩
 
 def Equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.invFun, e.toFun⟩
 
@@ -711,7 +711,7 @@ local infix:25 (priority := high) " ≃ " => ManualProjectionNames.Equiv
 
 variable {α β γ : Sort _}
 
-instance : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv.toFun⟩
+instance : CoeFun (α ≃ β) (fun _ ↦ α → β) := ⟨Equiv.toFun⟩
 
 def Equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.invFun, e.toFun⟩
 
@@ -751,7 +751,7 @@ local infix:25 (priority := high) " ≃ " => PrefixProjectionNames.Equiv
 
 variable {α β γ : Sort _}
 
-instance : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv.toFun⟩
+instance : CoeFun (α ≃ β) (fun _ ↦ α → β) := ⟨Equiv.toFun⟩
 
 def Equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.invFun, e.toFun⟩
 
@@ -867,7 +867,7 @@ structure NeedsPropClass (n : ℕ) [PropClass n] :=
 structure AlgHom (R A B : Type _) :=
   (toFun : A → B)
 
-instance (R A B : Type _) : CoeFun (AlgHom R A B) (fun _ ↦  A → B) := ⟨fun f ↦ f.toFun⟩
+instance (R A B : Type _) : CoeFun (AlgHom R A B) (fun _ ↦ A → B) := ⟨fun f ↦ f.toFun⟩
 
 @[simps] def myAlgHom : AlgHom Unit Bool Bool :=
   { toFun := id }
@@ -879,7 +879,7 @@ example (x : Bool) {z} (h : id x = z) : myAlgHom x = z := by
 structure RingHom (A B : Type _) where
   toFun : A → B
 
-instance (A B : Type _) : CoeFun (RingHom A B) (fun _ ↦  A → B) := ⟨fun f ↦ f.toFun⟩
+instance (A B : Type _) : CoeFun (RingHom A B) (fun _ ↦ A → B) := ⟨fun f ↦ f.toFun⟩
 
 @[simps] def myRingHom : RingHom Bool Bool :=
 { toFun := id }
@@ -965,7 +965,7 @@ end
 
 section comp_projs
 
-instance {α β} : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv'.toFun⟩
+instance {α β} : CoeFun (α ≃ β) (fun _ ↦ α → β) := ⟨Equiv'.toFun⟩
 
 @[simps] protected def Equiv'.symm {α β} (f : α ≃ β) : β ≃ α :=
   ⟨f.invFun, f, f.right_inv, f.left_inv⟩
@@ -974,7 +974,7 @@ structure DecoratedEquiv (α : Sort _) (β : Sort _) extends Equiv' α β :=
   (P_toFun  : Function.Injective toFun )
   (P_invFun : Function.Injective invFun)
 
-instance {α β} : CoeFun (DecoratedEquiv α β) (fun _ ↦  α → β) := ⟨fun f ↦ f.toEquiv'⟩
+instance {α β} : CoeFun (DecoratedEquiv α β) (fun _ ↦ α → β) := ⟨fun f ↦ f.toEquiv'⟩
 
 def DecoratedEquiv.symm {α β : Sort _} (e : DecoratedEquiv α β) : DecoratedEquiv β α :=
   { toEquiv' := e.toEquiv'.symm
@@ -989,8 +989,8 @@ initialize_simps_projections DecoratedEquiv (toFun → apply, invFun → symm_ap
 @[simps] def foo (α : Type) : DecoratedEquiv α α :=
   { toFun     := fun x ↦ x
     invFun    := fun x ↦ x
-    left_inv  := fun _ ↦  rfl
-    right_inv := fun _ ↦  rfl
+    left_inv  := fun _ ↦ rfl
+    right_inv := fun _ ↦ rfl
     P_toFun   := fun _ _ h ↦ h
     P_invFun  := fun _ _ h ↦ h }
 
@@ -1024,7 +1024,7 @@ structure FurtherDecoratedEquiv (α : Sort _) (β : Sort _) extends DecoratedEqu
   (Q_toFun  : Function.Surjective toFun )
   (Q_invFun : Function.Surjective invFun )
 
-instance {α β} : CoeFun (FurtherDecoratedEquiv α β) (fun _ ↦  α → β) :=
+instance {α β} : CoeFun (FurtherDecoratedEquiv α β) (fun _ ↦ α → β) :=
   ⟨fun f ↦ f.toDecoratedEquiv⟩
 
 def FurtherDecoratedEquiv.symm {α β : Sort _} (e : FurtherDecoratedEquiv α β) :
@@ -1043,8 +1043,8 @@ initialize_simps_projections FurtherDecoratedEquiv
 @[simps] def ffoo (α : Type) : FurtherDecoratedEquiv α α :=
   { toFun     := fun x ↦ x
     invFun    := fun x ↦ x
-    left_inv  := fun _ ↦  rfl
-    right_inv := fun _ ↦  rfl
+    left_inv  := fun _ ↦ rfl
+    right_inv := fun _ ↦ rfl
     P_toFun   := fun _ _ h ↦ h
     P_invFun  := fun _ _ h ↦ h
     Q_toFun   := fun y ↦ ⟨y, rfl⟩
@@ -1064,7 +1064,7 @@ def ffoo4 (α : Type) : FurtherDecoratedEquiv α α :=
 
 structure OneMore (α : Sort _) (β : Sort _) extends FurtherDecoratedEquiv α β
 
-instance {α β} : CoeFun (OneMore α β) (fun _ ↦  α → β) :=
+instance {α β} : CoeFun (OneMore α β) (fun _ ↦ α → β) :=
   ⟨fun f ↦ f.toFurtherDecoratedEquiv⟩
 
 def OneMore.symm {α β : Sort _} (e : OneMore α β) :
@@ -1080,8 +1080,8 @@ initialize_simps_projections OneMore (toFun → apply, invFun → symm_apply,
 @[simps] def fffoo (α : Type) : OneMore α α :=
   { toFun     := fun x ↦ x
     invFun    := fun x ↦ x
-    left_inv  := fun _ ↦  rfl
-    right_inv := fun _ ↦  rfl
+    left_inv  := fun _ ↦ rfl
+    right_inv := fun _ ↦ rfl
     P_toFun   := fun _ _ h ↦ h
     P_invFun  := fun _ _ h ↦ h
     Q_toFun   := fun y ↦ ⟨y, rfl⟩
@@ -1108,7 +1108,7 @@ structure AddMonoidHom (M N : Type _) [AddMonoid M] [AddMonoid N]
 
 infixr:25 " →+ " => AddMonoidHom
 
-instance (M N : Type _) [AddMonoid M] [AddMonoid N] : CoeFun (M →+ N) (fun _ ↦  M → N) := ⟨(·.toFun)⟩
+instance (M N : Type _) [AddMonoid M] [AddMonoid N] : CoeFun (M →+ N) (fun _ ↦ M → N) := ⟨(·.toFun)⟩
 
 class AddHomPlus [Add ι] [∀ i, AddCommMonoid (A i)] :=
   (myMul {i} : A i →+ A i)

--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -108,7 +108,7 @@ def MyProd.map {α α' β β'} (f : α → α') (g : β → β') (x : MyProd α 
 
 namespace foo
 @[simps] protected def rfl {α} : α ≃ α :=
-  ⟨id, λ x => x, λ _ => rfl, λ _ => rfl⟩
+  ⟨id, fun x ↦ x, fun _ ↦  rfl, fun _ ↦  rfl⟩
 
 /- simps adds declarations -/
 run_cmd liftTermElabM <| do
@@ -166,13 +166,13 @@ example {α} (x : α) : rfl2.toFun x = x ∧ rfl2.invFun x = x := by
 /- test `fullyApplied` option -/
 
 @[simps (config := .asFn)]
-def rfl3 {α} : α ≃ α := ⟨id, λ x => x, λ _ => rfl, λ _ => rfl⟩
+def rfl3 {α} : α ≃ α := ⟨id, fun x ↦ x, fun _ ↦  rfl, fun _ ↦  rfl⟩
 
 end foo
 
 /- we reduce the type when applying [simps] -/
 def my_equiv := Equiv'
-@[simps] def baz : my_equiv ℕ ℕ := ⟨id, λ x => x, λ _ => rfl, λ _ => rfl⟩
+@[simps] def baz : my_equiv ℕ ℕ := ⟨id, fun x ↦ x, fun _ ↦  rfl, fun _ ↦  rfl⟩
 
 /- todo: test that name clashes gives an error -/
 
@@ -239,7 +239,7 @@ def test {α} : ComplicatedEquivPlusData α :=
   { foo.rfl with
     P := λ f => f = id
     data := rfl
-    extra := λ _ => ⟨(⟨3, 5⟩ : MyProd _ _).1, (⟨3, 5⟩ : MyProd _ _).2⟩ }
+    extra := fun _ ↦  ⟨(⟨3, 5⟩ : MyProd _ _).1, (⟨3, 5⟩ : MyProd _ _).2⟩ }
 
 /- test whether this is indeed rejected as a valid eta expansion -/
 @[simps!]
@@ -247,7 +247,7 @@ def test_sneaky {α} : ComplicatedEquivPlusData α :=
   { foo.rfl with
     P := λ f => f = id
     data := rfl
-    extra := λ _ => ⟨(3,5).1,(3,5).2⟩ }
+    extra := fun _ ↦  ⟨(3,5).1,(3,5).2⟩ }
 
 run_cmd liftTermElabM <| do
   let env ← getEnv
@@ -394,8 +394,8 @@ example (n : ℕ) : myNatEquiv.toFun (myNatEquiv.toFun <| myNatEquiv.invFun n) =
 
 /- test that we don't recursively take projections of `prod` and `PProd` -/
 @[simps] def pprodEquivProd2 : PProd ℕ ℕ ≃ ℕ × ℕ :=
-  { toFun := λ x => ⟨x.1, x.2⟩
-    invFun := λ x => ⟨x.1, x.2⟩
+  { toFun := fun x ↦ ⟨x.1, x.2⟩
+    invFun := fun x ↦ ⟨x.1, x.2⟩
     left_inv := λ ⟨_, _⟩ => rfl
     right_inv := λ ⟨_, _⟩ => rfl }
 
@@ -437,7 +437,7 @@ infixr:80 " ≫ " => CategoryStruct.comp -- type as \gg
 
 @[simps] instance types : CategoryStruct (Type u) :=
   { hom  := λ a b => (a → b)
-    id   := λ _ => id
+    id   := fun _ ↦  id
     comp := λ f g => g ∘ f }
 
 @[ext] theorem types.ext {X Y : Type u} {f g : X ⟶ Y} : (∀ x, f x = g x) → f = g := funext
@@ -479,10 +479,10 @@ structure Equiv2 (α : Sort _) (β : Sort _) :=
   (left_inv  : invFun.LeftInverse toFun)
   (right_inv : invFun.RightInverse toFun)
 
-instance {α β} : CoeFun (Equiv2 α β) (λ _ => α → β) := ⟨Equiv2.toFun⟩
+instance {α β} : CoeFun (Equiv2 α β) (fun _ ↦  α → β) := ⟨Equiv2.toFun⟩
 
 @[simps] protected def rfl2 {α} : Equiv2 α α :=
-  ⟨λ x => x, λ x => x, λ _ => rfl, λ _ => rfl⟩
+  ⟨fun x ↦ x, fun x ↦ x, fun _ ↦  rfl, fun _ ↦  rfl⟩
 
 example {α} (x x' : α) (h : x = x') : coercing.rfl2 x = x' := by rw [coercing.rfl2_toFun, h]
 example {α} (x x' : α) (h : x = x') : coercing.rfl2 x = x' := by simp; rw [h]
@@ -542,7 +542,7 @@ class ExtendingStuff (G : Type u) extends Mul G, Zero G, Neg G, HasSubset G :=
     zero := 0
     neg := Nat.succ
     Subset := λ _ _ => True
-    new_axiom := λ _ => trivial }
+    new_axiom := fun _ ↦  trivial }
 
 section
 attribute [local instance] bar
@@ -557,7 +557,7 @@ class new_ExtendingStuff (G : Type u) extends Mul G, Zero G, Neg G, HasSubset G 
     zero := 0
     neg := Nat.succ
     Subset := λ _ _ => True
-    new_axiom := λ _ => trivial }
+    new_axiom := fun _ ↦  trivial }
 
 section
 attribute [local instance] new_bar
@@ -577,7 +577,7 @@ local infix:25 (priority := high) " ≃ " => ManualCoercion.Equiv
 
 variable {α β γ : Sort _}
 
-instance : CoeFun (α ≃ β) (λ _ => α → β) := ⟨Equiv.toFun⟩
+instance : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv.toFun⟩
 
 def Equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.invFun, e.toFun⟩
 
@@ -627,7 +627,7 @@ structure Equiv (α : Sort _) (β : Sort _) :=
 
 local infix:25 (priority := high) " ≃ " => ManualInitialize.Equiv
 
-instance : CoeFun (α ≃ β) (λ _ => α → β) := ⟨Equiv.toFun⟩
+instance : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv.toFun⟩
 
 def Equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.invFun, e.toFun⟩
 
@@ -659,7 +659,7 @@ structure Equiv (α : Sort u) (β : Sort v) :=
 
 local infix:25 (priority := high) " ≃ " => FaultyUniverses.Equiv
 
-instance : CoeFun (α ≃ β) (λ _ => α → β) := ⟨Equiv.toFun⟩
+instance : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv.toFun⟩
 
 def Equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.invFun, e.toFun⟩
 
@@ -688,7 +688,7 @@ structure Equiv (α : Sort u) (β : Sort v) :=
 
 local infix:25 (priority := high) " ≃ " => ManualUniverses.Equiv
 
-instance : CoeFun (α ≃ β) (λ _ => α → β) := ⟨Equiv.toFun⟩
+instance : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv.toFun⟩
 
 def Equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.invFun, e.toFun⟩
 
@@ -711,7 +711,7 @@ local infix:25 (priority := high) " ≃ " => ManualProjectionNames.Equiv
 
 variable {α β γ : Sort _}
 
-instance : CoeFun (α ≃ β) (λ _ => α → β) := ⟨Equiv.toFun⟩
+instance : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv.toFun⟩
 
 def Equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.invFun, e.toFun⟩
 
@@ -751,7 +751,7 @@ local infix:25 (priority := high) " ≃ " => PrefixProjectionNames.Equiv
 
 variable {α β γ : Sort _}
 
-instance : CoeFun (α ≃ β) (λ _ => α → β) := ⟨Equiv.toFun⟩
+instance : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv.toFun⟩
 
 def Equiv.symm (e : α ≃ β) : β ≃ α := ⟨e.invFun, e.toFun⟩
 
@@ -867,7 +867,7 @@ structure NeedsPropClass (n : ℕ) [PropClass n] :=
 structure AlgHom (R A B : Type _) :=
   (toFun : A → B)
 
-instance (R A B : Type _) : CoeFun (AlgHom R A B) (λ _ => A → B) := ⟨λ f => f.toFun⟩
+instance (R A B : Type _) : CoeFun (AlgHom R A B) (fun _ ↦  A → B) := ⟨λ f => f.toFun⟩
 
 @[simps] def myAlgHom : AlgHom Unit Bool Bool :=
   { toFun := id }
@@ -879,7 +879,7 @@ example (x : Bool) {z} (h : id x = z) : myAlgHom x = z := by
 structure RingHom (A B : Type _) where
   toFun : A → B
 
-instance (A B : Type _) : CoeFun (RingHom A B) (λ _ => A → B) := ⟨λ f => f.toFun⟩
+instance (A B : Type _) : CoeFun (RingHom A B) (fun _ ↦  A → B) := ⟨λ f => f.toFun⟩
 
 @[simps] def myRingHom : RingHom Bool Bool :=
 { toFun := id }
@@ -965,7 +965,7 @@ end
 
 section comp_projs
 
-instance {α β} : CoeFun (α ≃ β) (λ _ => α → β) := ⟨Equiv'.toFun⟩
+instance {α β} : CoeFun (α ≃ β) (fun _ ↦  α → β) := ⟨Equiv'.toFun⟩
 
 @[simps] protected def Equiv'.symm {α β} (f : α ≃ β) : β ≃ α :=
   ⟨f.invFun, f, f.right_inv, f.left_inv⟩
@@ -974,7 +974,7 @@ structure DecoratedEquiv (α : Sort _) (β : Sort _) extends Equiv' α β :=
   (P_toFun  : Function.Injective toFun )
   (P_invFun : Function.Injective invFun)
 
-instance {α β} : CoeFun (DecoratedEquiv α β) (λ _ => α → β) := ⟨λ f => f.toEquiv'⟩
+instance {α β} : CoeFun (DecoratedEquiv α β) (fun _ ↦  α → β) := ⟨λ f => f.toEquiv'⟩
 
 def DecoratedEquiv.symm {α β : Sort _} (e : DecoratedEquiv α β) : DecoratedEquiv β α :=
   { toEquiv' := e.toEquiv'.symm
@@ -987,10 +987,10 @@ def DecoratedEquiv.Simps.symm_apply {α β : Sort _} (e : DecoratedEquiv α β) 
 initialize_simps_projections DecoratedEquiv (toFun → apply, invFun → symm_apply, -toEquiv')
 
 @[simps] def foo (α : Type) : DecoratedEquiv α α :=
-  { toFun     := λ x => x
-    invFun    := λ x => x
-    left_inv  := λ _ => rfl
-    right_inv := λ _ => rfl
+  { toFun     := fun x ↦ x
+    invFun    := fun x ↦ x
+    left_inv  := fun _ ↦  rfl
+    right_inv := fun _ ↦  rfl
     P_toFun   := λ _ _ h => h
     P_invFun  := λ _ _ h => h }
 
@@ -1024,7 +1024,7 @@ structure FurtherDecoratedEquiv (α : Sort _) (β : Sort _) extends DecoratedEqu
   (Q_toFun  : Function.Surjective toFun )
   (Q_invFun : Function.Surjective invFun )
 
-instance {α β} : CoeFun (FurtherDecoratedEquiv α β) (λ _ => α → β) :=
+instance {α β} : CoeFun (FurtherDecoratedEquiv α β) (fun _ ↦  α → β) :=
   ⟨λ f => f.toDecoratedEquiv⟩
 
 def FurtherDecoratedEquiv.symm {α β : Sort _} (e : FurtherDecoratedEquiv α β) :
@@ -1041,10 +1041,10 @@ initialize_simps_projections FurtherDecoratedEquiv
   (toFun → apply, invFun → symm_apply, -toDecoratedEquiv, toEquiv' → toEquiv', -toEquiv')
 
 @[simps] def ffoo (α : Type) : FurtherDecoratedEquiv α α :=
-  { toFun     := λ x => x
-    invFun    := λ x => x
-    left_inv  := λ _ => rfl
-    right_inv := λ _ => rfl
+  { toFun     := fun x ↦ x
+    invFun    := fun x ↦ x
+    left_inv  := fun _ ↦  rfl
+    right_inv := fun _ ↦  rfl
     P_toFun   := λ _ _ h => h
     P_invFun  := λ _ _ h => h
     Q_toFun   := λ y => ⟨y, rfl⟩
@@ -1064,7 +1064,7 @@ def ffoo4 (α : Type) : FurtherDecoratedEquiv α α :=
 
 structure OneMore (α : Sort _) (β : Sort _) extends FurtherDecoratedEquiv α β
 
-instance {α β} : CoeFun (OneMore α β) (λ _ => α → β) :=
+instance {α β} : CoeFun (OneMore α β) (fun _ ↦  α → β) :=
   ⟨λ f => f.toFurtherDecoratedEquiv⟩
 
 def OneMore.symm {α β : Sort _} (e : OneMore α β) :
@@ -1078,10 +1078,10 @@ initialize_simps_projections OneMore (toFun → apply, invFun → symm_apply,
   -toFurtherDecoratedEquiv, toDecoratedEquiv → to_dequiv, -to_dequiv)
 
 @[simps] def fffoo (α : Type) : OneMore α α :=
-  { toFun     := λ x => x
-    invFun    := λ x => x
-    left_inv  := λ _ => rfl
-    right_inv := λ _ => rfl
+  { toFun     := fun x ↦ x
+    invFun    := fun x ↦ x
+    left_inv  := fun _ ↦  rfl
+    right_inv := fun _ ↦  rfl
     P_toFun   := λ _ _ h => h
     P_invFun  := λ _ _ h => h
     Q_toFun   := λ y => ⟨y, rfl⟩
@@ -1108,7 +1108,7 @@ structure AddMonoidHom (M N : Type _) [AddMonoid M] [AddMonoid N]
 
 infixr:25 " →+ " => AddMonoidHom
 
-instance (M N : Type _) [AddMonoid M] [AddMonoid N] : CoeFun (M →+ N) (λ _ => M → N) := ⟨(·.toFun)⟩
+instance (M N : Type _) [AddMonoid M] [AddMonoid N] : CoeFun (M →+ N) (fun _ ↦  M → N) := ⟨(·.toFun)⟩
 
 class AddHomPlus [Add ι] [∀ i, AddCommMonoid (A i)] :=
   (myMul {i} : A i →+ A i)

--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -37,7 +37,7 @@ run_cmd liftTermElabM <| do
 structure Foo2 (α : Type _) : Type _ where
   elim : α × α
 
-def Foo2.Simps.elim (α : Type _) : Foo2 α → α × α := fun x => (x.elim.1, x.elim.2)
+def Foo2.Simps.elim (α : Type _) : Foo2 α → α × α := fun x ↦ (x.elim.1, x.elim.2)
 
 initialize_simps_projections Foo2
 
@@ -84,7 +84,7 @@ class Something (α : Type _) where
   op : α → α → α → α
 
 instance {α : Type _} [Something α] : Add α :=
-  ⟨λ x y => Something.op x y y⟩
+  ⟨fun x y ↦ Something.op x y y⟩
 
 
 initialize_simps_projections Something
@@ -205,7 +205,7 @@ run_cmd liftTermElabM <| do
   guard <| not <| hasSimpAttribute env `CountNested.nested2_fst -- lemmas_only doesn't add simp lemma
   -- todo: maybe test that there are no other lemmas generated
   -- guard <| 7 = env.fold 0
-  --   (λ d n => n + if d.to_name.components.init.ilast = `CountNested then 1 else 0)
+  --   (fun d n ↦ n + if d.to_name.components.init.ilast = `CountNested then 1 else 0)
 
 -- testing with arguments
 @[simps] def bar {_ : Type _} (n m : ℕ) : ℕ × ℤ :=
@@ -224,12 +224,12 @@ structure ComplicatedEquivPlusData (α) extends α ⊕ α ≃ α ⊕ α where
 @[simps!]
 def rflWithData {α} : EquivPlusData α α :=
   { foo.rfl with
-    P := λ f => f = id
+    P := fun f ↦ f = id
     data := rfl }
 
 @[simps!]
 def rflWithData' {α} : EquivPlusData α α :=
-  { P := λ f => f = id
+  { P := fun f ↦ f = id
     data := rfl
     toEquiv' := foo.rfl }
 
@@ -237,7 +237,7 @@ def rflWithData' {α} : EquivPlusData α α :=
 @[simps!]
 def test {α} : ComplicatedEquivPlusData α :=
   { foo.rfl with
-    P := λ f => f = id
+    P := fun f ↦ f = id
     data := rfl
     extra := fun _ ↦  ⟨(⟨3, 5⟩ : MyProd _ _).1, (⟨3, 5⟩ : MyProd _ _).2⟩ }
 
@@ -245,7 +245,7 @@ def test {α} : ComplicatedEquivPlusData α :=
 @[simps!]
 def test_sneaky {α} : ComplicatedEquivPlusData α :=
   { foo.rfl with
-    P := λ f => f = id
+    P := fun f ↦ f = id
     data := rfl
     extra := fun _ ↦  ⟨(3,5).1,(3,5).2⟩ }
 
@@ -269,7 +269,7 @@ structure PartiallyAppliedStr :=
 def partially_applied_term : PartiallyAppliedStr := ⟨MyProd.mk 3⟩
 
 @[simps]
-def another_term : PartiallyAppliedStr := ⟨λ n => ⟨n + 1, n + 2⟩⟩
+def another_term : PartiallyAppliedStr := ⟨fun n ↦ ⟨n + 1, n + 2⟩⟩
 
 run_cmd liftTermElabM <| do
   let env ← getEnv
@@ -292,16 +292,16 @@ run_cmd liftTermElabM <| do
   guard <| env.find? `very_partially_applied_term_data_snd |>.isSome
 
 @[simps] def let1 : ℕ × ℤ :=
-let n := 3; ⟨n + 4, 5⟩
+  let n := 3; ⟨n + 4, 5⟩
 
 @[simps] def let2 : ℕ × ℤ :=
-let n := 3; let m := 4; let k := 5; ⟨n + m, k⟩
+  let n := 3; let m := 4; let k := 5; ⟨n + m, k⟩
 
 @[simps] def let3 : ℕ → ℕ × ℤ :=
-λ n => let m := 4; let k := 5; ⟨n + m, k⟩
+  fun n ↦ let m := 4; let k := 5; ⟨n + m, k⟩
 
 @[simps] def let4 : ℕ → ℕ × ℤ :=
-let m := 4; let k := 5; λ n => ⟨n + m, k⟩
+  let m := 4; let k := 5; fun n ↦ ⟨n + m, k⟩
 
 run_cmd liftTermElabM <| do
   let env ← getEnv
@@ -383,21 +383,21 @@ example {α β γ : Type} (f : α ≃ β) (g : β ≃ γ) (x : α) {z : γ} (h :
 
 attribute [local simp] Nat.zero_add Nat.one_mul Nat.mul_one
 @[simps (config := {simpRhs := true})] def myNatEquiv : ℕ ≃ ℕ :=
-  ⟨λ n => 0 + n, λ n => 1 * n * 1, by intro n; simp, by intro n; simp⟩
+  ⟨fun n ↦ 0 + n, fun n ↦ 1 * n * 1, by intro n; simp, by intro n; simp⟩
 
 example (n : ℕ) : myNatEquiv.toFun (myNatEquiv.toFun <| myNatEquiv.invFun n) = n := by
   { /-successIfFail { rfl },-/ simp only [myNatEquiv_toFun, myNatEquiv_invFun] }
 
 @[simps (config := {simpRhs := true})] def succeed_without_simplification_possible : ℕ ≃ ℕ :=
-  ⟨λ n => n, λ n => n, by intro n; rfl, by intro n; rfl⟩
+  ⟨fun n ↦ n, fun n ↦ n, by intro n; rfl, by intro n; rfl⟩
 
 
 /- test that we don't recursively take projections of `prod` and `PProd` -/
 @[simps] def pprodEquivProd2 : PProd ℕ ℕ ≃ ℕ × ℕ :=
   { toFun := fun x ↦ ⟨x.1, x.2⟩
     invFun := fun x ↦ ⟨x.1, x.2⟩
-    left_inv := λ ⟨_, _⟩ => rfl
-    right_inv := λ ⟨_, _⟩ => rfl }
+    left_inv := fun ⟨_, _⟩ ↦ rfl
+    right_inv := fun ⟨_, _⟩ ↦ rfl }
 
 run_cmd liftTermElabM <| do
   let env ← getEnv
@@ -436,9 +436,9 @@ notation "𝟙" => CategoryStruct.id -- type as \b1
 infixr:80 " ≫ " => CategoryStruct.comp -- type as \gg
 
 @[simps] instance types : CategoryStruct (Type u) :=
-  { hom  := λ a b => (a → b)
+  { hom  := fun a b ↦ (a → b)
     id   := fun _ ↦  id
-    comp := λ f g => g ∘ f }
+    comp := fun f g ↦ g ∘ f }
 
 @[ext] theorem types.ext {X Y : Type u} {f g : X ⟶ Y} : (∀ x, f x = g x) → f = g := funext
 
@@ -508,8 +508,8 @@ class Semigroup (G : Type u) extends Mul G where
   mul_assoc : ∀ a b c : G, a * b * c = a * (b * c)
 
 @[simps] instance {α β} [Semigroup α] [Semigroup β] : Semigroup (α × β) :=
-  { mul := λ x y => (x.1 * y.1, x.2 * y.2)
-    mul_assoc := λ _ _ _ => Prod.ext (Semigroup.mul_assoc ..) (Semigroup.mul_assoc ..) }
+  { mul := fun x y ↦ (x.1 * y.1, x.2 * y.2)
+    mul_assoc := fun _ _ _ ↦ Prod.ext (Semigroup.mul_assoc ..) (Semigroup.mul_assoc ..) }
 
 example {α β} [Semigroup α] [Semigroup β] (x y : α × β) : x * y = (x.1 * y.1, x.2 * y.2) := by simp
 example {α β} [Semigroup α] [Semigroup β] (x y : α × β) : (x * y).1 = x.1 * y.1 := by simp
@@ -529,8 +529,8 @@ instance (G : BSemigroup) : Mul G := ⟨G.op⟩
 
 protected def prod (G H : BSemigroup) : BSemigroup :=
   { G := G × H
-    op := λ x y => (x.1 * y.1, x.2 * y.2)
-    op_assoc := λ _ _ _ => Prod.ext (BSemigroup.op_assoc ..) (BSemigroup.op_assoc ..) }
+    op := fun x y ↦ (x.1 * y.1, x.2 * y.2)
+    op_assoc := fun _ _ _ ↦ Prod.ext (BSemigroup.op_assoc ..) (BSemigroup.op_assoc ..) }
 
 end BSemigroup
 
@@ -541,7 +541,7 @@ class ExtendingStuff (G : Type u) extends Mul G, Zero G, Neg G, HasSubset G :=
   { mul := (·*·)
     zero := 0
     neg := Nat.succ
-    Subset := λ _ _ => True
+    Subset := fun _ _ ↦ True
     new_axiom := fun _ ↦  trivial }
 
 section
@@ -556,7 +556,7 @@ class new_ExtendingStuff (G : Type u) extends Mul G, Zero G, Neg G, HasSubset G 
   { mul := (·*·)
     zero := 0
     neg := Nat.succ
-    Subset := λ _ _ => True
+    Subset := fun _ _ ↦ True
     new_axiom := fun _ ↦  trivial }
 
 section
@@ -867,7 +867,7 @@ structure NeedsPropClass (n : ℕ) [PropClass n] :=
 structure AlgHom (R A B : Type _) :=
   (toFun : A → B)
 
-instance (R A B : Type _) : CoeFun (AlgHom R A B) (fun _ ↦  A → B) := ⟨λ f => f.toFun⟩
+instance (R A B : Type _) : CoeFun (AlgHom R A B) (fun _ ↦  A → B) := ⟨fun f ↦ f.toFun⟩
 
 @[simps] def myAlgHom : AlgHom Unit Bool Bool :=
   { toFun := id }
@@ -879,7 +879,7 @@ example (x : Bool) {z} (h : id x = z) : myAlgHom x = z := by
 structure RingHom (A B : Type _) where
   toFun : A → B
 
-instance (A B : Type _) : CoeFun (RingHom A B) (fun _ ↦  A → B) := ⟨λ f => f.toFun⟩
+instance (A B : Type _) : CoeFun (RingHom A B) (fun _ ↦  A → B) := ⟨fun f ↦ f.toFun⟩
 
 @[simps] def myRingHom : RingHom Bool Bool :=
 { toFun := id }
@@ -893,7 +893,7 @@ example (x : Bool) {z} (h : id x = z) : myRingHom x = z := by
 -- set_option trace.simps.debug true
 
 @[to_additive (attr := simps) instAddProd]
-instance {M N} [Mul M] [Mul N] : Mul (M × N) := ⟨λ p q => ⟨p.1 * q.1, p.2 * q.2⟩⟩
+instance {M N} [Mul M] [Mul N] : Mul (M × N) := ⟨fun p q ↦ ⟨p.1 * q.1, p.2 * q.2⟩⟩
 
 run_cmd liftTermElabM <| do
   let env ← getEnv
@@ -953,7 +953,7 @@ example (h : false) (x y : { x : Fin (Nat.add 3 0) // 1 + 1 = 2 }) : myTypeDef.A
 
 -- test that `to_additive` works with a custom name
 @[to_additive (attr := simps) some_test2]
-def some_test1 (M : Type _) [CommMonoid M] : Subtype (λ _ : M => True) := ⟨1, trivial⟩
+def some_test1 (M : Type _) [CommMonoid M] : Subtype (fun _ : M ↦ True) := ⟨1, trivial⟩
 
 run_cmd liftTermElabM <| do
   let env ← getEnv
@@ -974,7 +974,7 @@ structure DecoratedEquiv (α : Sort _) (β : Sort _) extends Equiv' α β :=
   (P_toFun  : Function.Injective toFun )
   (P_invFun : Function.Injective invFun)
 
-instance {α β} : CoeFun (DecoratedEquiv α β) (fun _ ↦  α → β) := ⟨λ f => f.toEquiv'⟩
+instance {α β} : CoeFun (DecoratedEquiv α β) (fun _ ↦  α → β) := ⟨fun f ↦ f.toEquiv'⟩
 
 def DecoratedEquiv.symm {α β : Sort _} (e : DecoratedEquiv α β) : DecoratedEquiv β α :=
   { toEquiv' := e.toEquiv'.symm
@@ -991,8 +991,8 @@ initialize_simps_projections DecoratedEquiv (toFun → apply, invFun → symm_ap
     invFun    := fun x ↦ x
     left_inv  := fun _ ↦  rfl
     right_inv := fun _ ↦  rfl
-    P_toFun   := λ _ _ h => h
-    P_invFun  := λ _ _ h => h }
+    P_toFun   := fun _ _ h ↦ h
+    P_invFun  := fun _ _ h ↦ h }
 
 example {α : Type} (x z : α) (h : x = z) : (foo α).symm x = z := by
   dsimp
@@ -1001,8 +1001,8 @@ example {α : Type} (x z : α) (h : x = z) : (foo α).symm x = z := by
 
 @[simps! toEquiv' apply symm_apply] def foo2 (α : Type) : DecoratedEquiv α α :=
   { foo.rfl with
-    P_toFun  := λ _ _ h => h
-    P_invFun := λ _ _ h => h }
+    P_toFun  := fun _ _ h ↦ h
+    P_invFun := fun _ _ h ↦ h }
 
 
 example {α : Type} (x z : α) (h : foo.rfl x = z) : (foo2 α).toEquiv' x = z := by
@@ -1025,7 +1025,7 @@ structure FurtherDecoratedEquiv (α : Sort _) (β : Sort _) extends DecoratedEqu
   (Q_invFun : Function.Surjective invFun )
 
 instance {α β} : CoeFun (FurtherDecoratedEquiv α β) (fun _ ↦  α → β) :=
-  ⟨λ f => f.toDecoratedEquiv⟩
+  ⟨fun f ↦ f.toDecoratedEquiv⟩
 
 def FurtherDecoratedEquiv.symm {α β : Sort _} (e : FurtherDecoratedEquiv α β) :
     FurtherDecoratedEquiv β α :=
@@ -1045,10 +1045,10 @@ initialize_simps_projections FurtherDecoratedEquiv
     invFun    := fun x ↦ x
     left_inv  := fun _ ↦  rfl
     right_inv := fun _ ↦  rfl
-    P_toFun   := λ _ _ h => h
-    P_invFun  := λ _ _ h => h
-    Q_toFun   := λ y => ⟨y, rfl⟩
-    Q_invFun  := λ y => ⟨y, rfl⟩ }
+    P_toFun   := fun _ _ h ↦ h
+    P_invFun  := fun _ _ h ↦ h
+    Q_toFun   := fun y ↦ ⟨y, rfl⟩
+    Q_invFun  := fun y ↦ ⟨y, rfl⟩ }
 
 example {α : Type} (x z : α) (h : x = z) : (ffoo α).symm x = z := by
   dsimp
@@ -1056,16 +1056,16 @@ example {α : Type} (x z : α) (h : x = z) : (ffoo α).symm x = z := by
   rw [h]
 
 @[simps!] def ffoo3 (α : Type) : FurtherDecoratedEquiv α α :=
-  { foo α with Q_toFun := λ y => ⟨y, rfl⟩, Q_invFun := λ y => ⟨y, rfl⟩ }
+  { foo α with Q_toFun := fun y ↦ ⟨y, rfl⟩, Q_invFun := fun y ↦ ⟨y, rfl⟩ }
 
 @[simps! apply toEquiv' toEquiv'_toFun toDecoratedEquiv_apply]
 def ffoo4 (α : Type) : FurtherDecoratedEquiv α α :=
-  { Q_toFun := λ y => ⟨y, rfl⟩, Q_invFun := λ y => ⟨y, rfl⟩, toDecoratedEquiv := foo α }
+  { Q_toFun := fun y ↦ ⟨y, rfl⟩, Q_invFun := fun y ↦ ⟨y, rfl⟩, toDecoratedEquiv := foo α }
 
 structure OneMore (α : Sort _) (β : Sort _) extends FurtherDecoratedEquiv α β
 
 instance {α β} : CoeFun (OneMore α β) (fun _ ↦  α → β) :=
-  ⟨λ f => f.toFurtherDecoratedEquiv⟩
+  ⟨fun f ↦ f.toFurtherDecoratedEquiv⟩
 
 def OneMore.symm {α β : Sort _} (e : OneMore α β) :
     OneMore β α :=
@@ -1082,10 +1082,10 @@ initialize_simps_projections OneMore (toFun → apply, invFun → symm_apply,
     invFun    := fun x ↦ x
     left_inv  := fun _ ↦  rfl
     right_inv := fun _ ↦  rfl
-    P_toFun   := λ _ _ h => h
-    P_invFun  := λ _ _ h => h
-    Q_toFun   := λ y => ⟨y, rfl⟩
-    Q_invFun  := λ y => ⟨y, rfl⟩ }
+    P_toFun   := fun _ _ h ↦ h
+    P_invFun  := fun _ _ h ↦ h
+    Q_toFun   := fun y ↦ ⟨y, rfl⟩
+    Q_invFun  := fun y ↦ ⟨y, rfl⟩ }
 
 example {α : Type} (x : α) : (fffoo α).symm x = x := by dsimp
 
@@ -1130,9 +1130,9 @@ initialize_simps_projections AddHomPlus2 (-myMul, myMul_toFun_toFun → mul)
 attribute [ext] Equiv'
 
 @[simps]
-def thing (h : Bool ≃ (Bool ≃ Bool)) : AddHomPlus2 (λ _ : ℕ => Bool) :=
+def thing (h : Bool ≃ (Bool ≃ Bool)) : AddHomPlus2 (fun _ : ℕ ↦ Bool) :=
   { myMul :=
-    { toFun := λ b =>
+    { toFun := fun b ↦
       { toFun := h b
         invFun := (h b).symm
         left_inv := (h b).left_inv
@@ -1158,7 +1158,7 @@ local infixr:26 " ⥤ " => MyFunctor
 @[simps]
 noncomputable def fooSum {I J : Type _} (C : I → Type _) {D : J → Type _} :
     (∀ i, C i) ⥤ (∀ j, D j) ⥤ (∀ s : I ⊕ J, Sum.rec C D s) :=
-  { obj := λ f => { obj := λ g s => Sum.rec f g s }}
+  { obj := fun f ↦ { obj := fun g s ↦ Sum.rec f g s }}
 
 end
 

--- a/test/norm_num_ext.lean
+++ b/test/norm_num_ext.lean
@@ -348,10 +348,10 @@ example : (({1, 2, 1, 3} : Multiset ℚ).map (fun i => i^2)).sum = 15 := by
   norm_num
 
 -- Finsets:
-example : Finset.prod (Finset.cons 2 ∅ (Finset.not_mem_empty _)) (λ x => x) = 2 := by norm_num1
+example : Finset.prod (Finset.cons 2 ∅ (Finset.not_mem_empty _)) (fun x ↦ x) = 2 := by norm_num1
 example : Finset.prod
     (Finset.cons 6 (Finset.cons 2 ∅ (Finset.not_mem_empty _)) (by norm_num))
-    (λ x => x) =
+    (fun x ↦ x) =
   12 := by norm_num1
 
 example (f : ℕ → α) : ∏ i in Finset.range 0, f i = 1 := by norm_num1

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -269,7 +269,7 @@ class FooClass (α) : Prop where
   refle : ∀ a : α, a = a
 
 @[to_additive]
-instance FooClass_one [One α] : FooClass α := ⟨fun _ ↦  rfl⟩
+instance FooClass_one [One α] : FooClass α := ⟨fun _ ↦ rfl⟩
 
 lemma one_fooClass [One α] : FooClass α := by infer_instance
 

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -269,7 +269,7 @@ class FooClass (α) : Prop where
   refle : ∀ a : α, a = a
 
 @[to_additive]
-instance FooClass_one [One α] : FooClass α := ⟨λ _ => rfl⟩
+instance FooClass_one [One α] : FooClass α := ⟨fun _ ↦  rfl⟩
 
 lemma one_fooClass [One α] : FooClass α := by infer_instance
 


### PR DESCRIPTION
Per the style guidelines, `λ` is disallowed in mathlib.
This is close to exhaustive; I left some tactic code alone when it seemed to me that tactic could be upstreamed soon.

Notes
- In lines I was modifying anyway, I also converted `=>` to `↦`.
- Also contains some mild in-passing indentation fixes in `Mathlib/Order/SupClosed`.
- Some doc comments still contained Lean 3 syntax `λ x, `, which I also replaced.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
