### PR TITLE
refactor(GroupTheory/Submonoid/Operations): Use `SubmonoidClass` and delete redundant instances

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -1216,64 +1216,14 @@ section Actions
 
 variable {α β : Type*}
 
-/-- The action by a subalgebra is the action by the underlying algebra. -/
-instance [SMul A α] (S : Subalgebra R A) : SMul S α :=
-  inferInstanceAs (SMul S.toSubsemiring α)
-
 theorem smul_def [SMul A α] {S : Subalgebra R A} (g : S) (m : α) : g • m = (g : A) • m := rfl
 #align subalgebra.smul_def Subalgebra.smul_def
-
-instance smulCommClass_left [SMul A β] [SMul α β] [SMulCommClass A α β] (S : Subalgebra R A) :
-    SMulCommClass S α β :=
-  S.toSubsemiring.smulCommClass_left
-#align subalgebra.smul_comm_class_left Subalgebra.smulCommClass_left
-
-instance smulCommClass_right [SMul α β] [SMul A β] [SMulCommClass α A β] (S : Subalgebra R A) :
-    SMulCommClass α S β :=
-  S.toSubsemiring.smulCommClass_right
-#align subalgebra.smul_comm_class_right Subalgebra.smulCommClass_right
-
-/-- Note that this provides `IsScalarTower S R R` which is needed by `smul_mul_assoc`. -/
-instance isScalarTower_left [SMul α β] [SMul A α] [SMul A β] [IsScalarTower A α β]
-    (S : Subalgebra R A) : IsScalarTower S α β :=
-  inferInstanceAs (IsScalarTower S.toSubsemiring α β)
-#align subalgebra.is_scalar_tower_left Subalgebra.isScalarTower_left
 
 instance isScalarTower_mid {R S T : Type*} [CommSemiring R] [Semiring S] [AddCommMonoid T]
     [Algebra R S] [Module R T] [Module S T] [IsScalarTower R S T] (S' : Subalgebra R S) :
     IsScalarTower R S' T :=
   ⟨fun _x y _z => (smul_assoc _ (y : S) _ : _)⟩
 #align subalgebra.is_scalar_tower_mid Subalgebra.isScalarTower_mid
-
-instance [SMul A α] [FaithfulSMul A α] (S : Subalgebra R A) : FaithfulSMul S α :=
-  inferInstanceAs (FaithfulSMul S.toSubsemiring α)
-
-/-- The action by a subalgebra is the action by the underlying algebra. -/
-instance [MulAction A α] (S : Subalgebra R A) : MulAction S α :=
-  inferInstanceAs (MulAction S.toSubsemiring α)
-
-/-- The action by a subalgebra is the action by the underlying algebra. -/
-instance [AddMonoid α] [DistribMulAction A α] (S : Subalgebra R A) : DistribMulAction S α :=
-  inferInstanceAs (DistribMulAction S.toSubsemiring α)
-
-/-- The action by a subalgebra is the action by the underlying algebra. -/
-instance [Zero α] [SMulWithZero A α] (S : Subalgebra R A) : SMulWithZero S α :=
-  inferInstanceAs (SMulWithZero S.toSubsemiring α)
-
-/-- The action by a subalgebra is the action by the underlying algebra. -/
-instance [Zero α] [MulActionWithZero A α] (S : Subalgebra R A) : MulActionWithZero S α :=
-  inferInstanceAs (MulActionWithZero S.toSubsemiring α)
-
-/-- The action by a subalgebra is the action by the underlying algebra. -/
-instance moduleLeft [AddCommMonoid α] [Module A α] (S : Subalgebra R A) : Module S α :=
-  inferInstanceAs (Module S.toSubsemiring α)
-#align subalgebra.module_left Subalgebra.moduleLeft
-
-/-- The action by a subalgebra is the action by the underlying algebra. -/
-instance toAlgebra {R A : Type*} [CommSemiring R] [CommSemiring A] [Semiring α] [Algebra R A]
-    [Algebra A α] (S : Subalgebra R A) : Algebra S α :=
-  Algebra.ofSubsemiring S.toSubsemiring
-#align subalgebra.to_algebra Subalgebra.toAlgebra
 
 theorem algebraMap_eq {R A : Type*} [CommSemiring R] [CommSemiring A] [Semiring α] [Algebra R A]
     [Algebra A α] (S : Subalgebra R A) : algebraMap S α = (algebraMap A α).comp S.val :=

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -1225,6 +1225,12 @@ instance isScalarTower_mid {R S T : Type*} [CommSemiring R] [Semiring S] [AddCom
   ⟨fun _x y _z => (smul_assoc _ (y : S) _ : _)⟩
 #align subalgebra.is_scalar_tower_mid Subalgebra.isScalarTower_mid
 
+/-- The action by a subalgebra is the action by the underlying algebra. -/
+instance toAlgebra {R A : Type*} [CommSemiring R] [CommSemiring A] [Semiring α] [Algebra R A]
+    [Algebra A α] (S : Subalgebra R A) : Algebra S α :=
+  Algebra.ofSubsemiring S.toSubsemiring
+#align subalgebra.to_algebra Subalgebra.toAlgebra
+
 theorem algebraMap_eq {R A : Type*} [CommSemiring R] [CommSemiring A] [Semiring α] [Algebra R A]
     [Algebra A α] (S : Subalgebra R A) : algebraMap S α = (algebraMap A α).comp S.val :=
   rfl

--- a/Mathlib/Algebra/Module/Submodule/Basic.lean
+++ b/Mathlib/Algebra/Module/Submodule/Basic.lean
@@ -363,13 +363,6 @@ These instances work particularly well in conjunction with `AddGroup.toAddAction
 
 variable {α β : Type*}
 
-instance [VAdd M α] : VAdd p α :=
-  p.toAddSubmonoid.vadd
-
-instance vaddCommClass [VAdd M β] [VAdd α β] [VAddCommClass M α β] : VAddCommClass p α β :=
-  ⟨fun a => (vadd_comm (a : M) : _)⟩
-#align submodule.vadd_comm_class Submodule.vaddCommClass
-
 instance [VAdd M α] [FaithfulVAdd M α] : FaithfulVAdd p α :=
   ⟨fun h => Subtype.ext <| eq_of_vadd_eq_vadd h⟩
 

--- a/Mathlib/Algebra/Periodic.lean
+++ b/Mathlib/Algebra/Periodic.lean
@@ -6,6 +6,7 @@ Authors: Benjamin Davidson
 import Mathlib.Algebra.Field.Opposite
 import Mathlib.Algebra.Order.Archimedean
 import Mathlib.GroupTheory.Coset
+import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.GroupTheory.Subgroup.ZPowers
 import Mathlib.GroupTheory.Submonoid.Membership
 

--- a/Mathlib/GroupTheory/Coset.lean
+++ b/Mathlib/GroupTheory/Coset.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Quotient
 import Mathlib.Data.Fintype.Prod
 import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.GroupTheory.Subgroup.MulOpposite
-import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.Data.Set.Basic
 
 #align_import group_theory.coset from "leanprover-community/mathlib"@"f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c"

--- a/Mathlib/GroupTheory/Coset.lean
+++ b/Mathlib/GroupTheory/Coset.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Quotient
 import Mathlib.Data.Fintype.Prod
 import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.GroupTheory.Subgroup.MulOpposite
+import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.Data.Set.Basic
 
 #align_import group_theory.coset from "leanprover-community/mathlib"@"f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c"

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Antoine Chambert-Loir. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir
 -/
-import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.GroupTheory.GroupAction.FixedPoints
 

--- a/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/FixingSubgroup.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Antoine Chambert-Loir. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir
 -/
+import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.GroupTheory.GroupAction.Basic
 import Mathlib.GroupTheory.GroupAction.FixedPoints
 

--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -10,6 +10,7 @@ import Mathlib.GroupTheory.Commutator
 import Mathlib.GroupTheory.Coset
 import Mathlib.GroupTheory.GroupAction.ConjAct
 import Mathlib.GroupTheory.GroupAction.Hom
+import Mathlib.GroupTheory.Subgroup.Actions
 
 #align_import group_theory.group_action.quotient from "leanprover-community/mathlib"@"4be589053caf347b899a494da75410deb55fb3ef"
 

--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -10,7 +10,6 @@ import Mathlib.GroupTheory.Commutator
 import Mathlib.GroupTheory.Coset
 import Mathlib.GroupTheory.GroupAction.ConjAct
 import Mathlib.GroupTheory.GroupAction.Hom
-import Mathlib.GroupTheory.Subgroup.Actions
 
 #align_import group_theory.group_action.quotient from "leanprover-community/mathlib"@"4be589053caf347b899a494da75410deb55fb3ef"
 

--- a/Mathlib/GroupTheory/QuotientGroup.lean
+++ b/Mathlib/GroupTheory/QuotientGroup.lean
@@ -7,6 +7,7 @@ This file is to a certain extent based on `quotient_module.lean` by Johannes Hö
 -/
 import Mathlib.GroupTheory.Congruence
 import Mathlib.GroupTheory.Coset
+import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.GroupTheory.Subgroup.Finite
 import Mathlib.GroupTheory.Subgroup.Pointwise
 

--- a/Mathlib/GroupTheory/QuotientGroup.lean
+++ b/Mathlib/GroupTheory/QuotientGroup.lean
@@ -7,7 +7,6 @@ This file is to a certain extent based on `quotient_module.lean` by Johannes Hö
 -/
 import Mathlib.GroupTheory.Congruence
 import Mathlib.GroupTheory.Coset
-import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.GroupTheory.Subgroup.Finite
 import Mathlib.GroupTheory.Subgroup.Pointwise
 

--- a/Mathlib/GroupTheory/Subgroup/Actions.lean
+++ b/Mathlib/GroupTheory/Subgroup/Actions.lean
@@ -24,10 +24,6 @@ variable {G α β : Type*} [Group G]
 section MulAction
 variable [MulAction G α] {S : Subgroup G}
 
-/-- The action by a subgroup is the action by the underlying group. -/
-@[to_additive "The additive action by an add_subgroup is the action by the underlying `AddGroup`. "]
-instance instMulAction : MulAction S α := inferInstanceAs (MulAction S.toSubmonoid α)
-
 @[to_additive] lemma smul_def (g : S) (m : α) : g • m = (g : G) • m := rfl
 #align subgroup.smul_def Subgroup.smul_def
 #align add_subgroup.vadd_def AddSubgroup.vadd_def
@@ -36,36 +32,6 @@ instance instMulAction : MulAction S α := inferInstanceAs (MulAction S.toSubmon
 lemma mk_smul (g : G) (hg : g ∈ S) (a : α) : (⟨g, hg⟩ : S) • a = g • a := rfl
 
 end MulAction
-
-@[to_additive]
-instance smulCommClass_left [MulAction G β] [SMul α β] [SMulCommClass G α β] (S : Subgroup G) :
-    SMulCommClass S α β :=
-  S.toSubmonoid.smulCommClass_left
-#align subgroup.smul_comm_class_left Subgroup.smulCommClass_left
-#align add_subgroup.vadd_comm_class_left AddSubgroup.vaddCommClass_left
-
-@[to_additive]
-instance smulCommClass_right [SMul α β] [MulAction G β] [SMulCommClass α G β] (S : Subgroup G) :
-    SMulCommClass α S β :=
-  S.toSubmonoid.smulCommClass_right
-#align subgroup.smul_comm_class_right Subgroup.smulCommClass_right
-#align add_subgroup.vadd_comm_class_right AddSubgroup.vaddCommClass_right
-
-/-- Note that this provides `IsScalarTower S G G` which is needed by `smul_mul_assoc`. -/
-instance [SMul α β] [MulAction G α] [MulAction G β] [IsScalarTower G α β] (S : Subgroup G) :
-    IsScalarTower S α β :=
-  inferInstanceAs (IsScalarTower S.toSubmonoid α β)
-
-instance [MulAction G α] [FaithfulSMul G α] (S : Subgroup G) : FaithfulSMul S α :=
-  inferInstanceAs (FaithfulSMul S.toSubmonoid α)
-
-/-- The action by a subgroup is the action by the underlying group. -/
-instance [AddMonoid α] [DistribMulAction G α] (S : Subgroup G) : DistribMulAction S α :=
-  inferInstanceAs (DistribMulAction S.toSubmonoid α)
-
-/-- The action by a subgroup is the action by the underlying group. -/
-instance [Monoid α] [MulDistribMulAction G α] (S : Subgroup G) : MulDistribMulAction S α :=
-  inferInstanceAs (MulDistribMulAction S.toSubmonoid α)
 
 /-- The center of a group acts commutatively on that group. -/
 instance center.smulCommClass_left : SMulCommClass (center G) G G :=

--- a/Mathlib/GroupTheory/Submonoid/Operations.lean
+++ b/Mathlib/GroupTheory/Submonoid/Operations.lean
@@ -1444,7 +1444,7 @@ instance isScalarTower [SMul α β] [SMul M' α] [SMul M' β] [IsScalarTower M' 
   ⟨fun a => (smul_assoc (a : M') : _)⟩
 
 section SMul
-variable [SMul M' α] {S}
+variable [SMul M' α] {S : F}
 
 @[to_additive] lemma smul_def (g : S) (a : α) : g • a = (g : M') • a := rfl
 #align submonoid.smul_def Submonoid.smul_def

--- a/Mathlib/GroupTheory/Submonoid/Operations.lean
+++ b/Mathlib/GroupTheory/Submonoid/Operations.lean
@@ -1420,34 +1420,31 @@ variable {M' : Type*} {α β : Type*}
 
 section MulOneClass
 
-variable [MulOneClass M']
+variable [MulOneClass M'] {F : Type*} [SetLike F M'] [SubmonoidClass F M'] (S : F)
 
 @[to_additive]
-instance smul [SMul M' α] (S : Submonoid M') : SMul S α :=
-  SMul.comp _ S.subtype
+instance smul [SMul M' α] : SMul S α :=
+  SMul.comp _ (SubmonoidClass.subtype S)
 
 @[to_additive]
-instance smulCommClass_left [SMul M' β] [SMul α β] [SMulCommClass M' α β]
-    (S : Submonoid M') : SMulCommClass S α β :=
+instance smulCommClass_left [SMul M' β] [SMul α β] [SMulCommClass M' α β] : SMulCommClass S α β :=
   ⟨fun a _ _ => (smul_comm (a : M') _ _ : _)⟩
 #align submonoid.smul_comm_class_left Submonoid.smulCommClass_left
 #align add_submonoid.vadd_comm_class_left AddSubmonoid.vaddCommClass_left
 
 @[to_additive]
-instance smulCommClass_right [SMul α β] [SMul M' β] [SMulCommClass α M' β]
-    (S : Submonoid M') : SMulCommClass α S β :=
+instance smulCommClass_right [SMul α β] [SMul M' β] [SMulCommClass α M' β] : SMulCommClass α S β :=
   ⟨fun a s => (smul_comm a (s : M') : _)⟩
 #align submonoid.smul_comm_class_right Submonoid.smulCommClass_right
 #align add_submonoid.vadd_comm_class_right AddSubmonoid.vaddCommClass_right
 
 /-- Note that this provides `IsScalarTower S M' M'` which is needed by `SMulMulAssoc`. -/
-instance isScalarTower [SMul α β] [SMul M' α] [SMul M' β] [IsScalarTower M' α β]
-      (S : Submonoid M') :
+instance isScalarTower [SMul α β] [SMul M' α] [SMul M' β] [IsScalarTower M' α β] :
     IsScalarTower S α β :=
   ⟨fun a => (smul_assoc (a : M') : _)⟩
 
 section SMul
-variable [SMul M' α] {S : Submonoid M'}
+variable [SMul M' α] {S}
 
 @[to_additive] lemma smul_def (g : S) (a : α) : g • a = (g : M') • a := rfl
 #align submonoid.smul_def Submonoid.smul_def
@@ -1462,25 +1459,23 @@ instance faithfulSMul [FaithfulSMul M' α] : FaithfulSMul S α :=
 end SMul
 end MulOneClass
 
-variable [Monoid M']
+variable [Monoid M'] {F : Type*} [SetLike F M'] [SubmonoidClass F M'] (S : F)
 
 /-- The action by a submonoid is the action by the underlying monoid. -/
 @[to_additive
       "The additive action by an `AddSubmonoid` is the action by the underlying `AddMonoid`. "]
-instance mulAction [MulAction M' α] (S : Submonoid M') : MulAction S α :=
-  MulAction.compHom _ S.subtype
+instance mulAction [MulAction M' α] : MulAction S α :=
+  MulAction.compHom _ (SubmonoidClass.subtype S)
 
 /-- The action by a submonoid is the action by the underlying monoid. -/
-instance distribMulAction [AddMonoid α] [DistribMulAction M' α] (S : Submonoid M') :
-    DistribMulAction S α :=
-  DistribMulAction.compHom _ S.subtype
+instance distribMulAction [AddMonoid α] [DistribMulAction M' α] : DistribMulAction S α :=
+  DistribMulAction.compHom _ (SubmonoidClass.subtype S)
 
 /-- The action by a submonoid is the action by the underlying monoid. -/
-instance mulDistribMulAction [Monoid α] [MulDistribMulAction M' α] (S : Submonoid M') :
-    MulDistribMulAction S α :=
-  MulDistribMulAction.compHom _ S.subtype
+instance mulDistribMulAction [Monoid α] [MulDistribMulAction M' α] : MulDistribMulAction S α :=
+  MulDistribMulAction.compHom _ (SubmonoidClass.subtype S)
 
-example {S : Submonoid M'} : IsScalarTower S M' M' := by infer_instance
+example : IsScalarTower S M' M' := by infer_instance
 
 
 end Submonoid

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 -/
 import Mathlib.Algebra.Order.Module.Algebra
+import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.LinearAlgebra.LinearIndependent
 import Mathlib.RingTheory.Subring.Units
 

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 -/
 import Mathlib.Algebra.Order.Module.Algebra
-import Mathlib.GroupTheory.Subgroup.Actions
 import Mathlib.LinearAlgebra.LinearIndependent
 import Mathlib.RingTheory.Subring.Units
 

--- a/Mathlib/RingTheory/Subring/Basic.lean
+++ b/Mathlib/RingTheory/Subring/Basic.lean
@@ -5,6 +5,7 @@ Authors: Ashvni Narayanan
 -/
 import Mathlib.GroupTheory.Subgroup.Basic
 import Mathlib.RingTheory.Subsemiring.Basic
+import Mathlib.Algebra.GroupRingAction.Subobjects
 
 #align_import ring_theory.subring.basic from "leanprover-community/mathlib"@"b915e9392ecb2a861e1e766f0e1df6ac481188ca"
 

--- a/Mathlib/RingTheory/Subring/Basic.lean
+++ b/Mathlib/RingTheory/Subring/Basic.lean
@@ -5,7 +5,6 @@ Authors: Ashvni Narayanan
 -/
 import Mathlib.GroupTheory.Subgroup.Basic
 import Mathlib.RingTheory.Subsemiring.Basic
-import Mathlib.Algebra.GroupRingAction.Subobjects
 
 #align_import ring_theory.subring.basic from "leanprover-community/mathlib"@"b915e9392ecb2a861e1e766f0e1df6ac481188ca"
 

--- a/Mathlib/RingTheory/Subring/Basic.lean
+++ b/Mathlib/RingTheory/Subring/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Ashvni Narayanan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ashvni Narayanan
 -/
+import Mathlib.Algebra.GroupRingAction.Subobjects
 import Mathlib.GroupTheory.Subgroup.Basic
 import Mathlib.RingTheory.Subsemiring.Basic
 

--- a/Mathlib/RingTheory/Subsemiring/Basic.lean
+++ b/Mathlib/RingTheory/Subsemiring/Basic.lean
@@ -1287,32 +1287,9 @@ section NonAssocSemiring
 
 variable [NonAssocSemiring R']
 
-/-- The action by a subsemiring is the action by the underlying semiring. -/
-instance smul [SMul R' α] (S : Subsemiring R') : SMul S α :=
-  S.toSubmonoid.smul
-
 theorem smul_def [SMul R' α] {S : Subsemiring R'} (g : S) (m : α) : g • m = (g : R') • m :=
   rfl
 #align subsemiring.smul_def Subsemiring.smul_def
-
-instance smulCommClass_left [SMul R' β] [SMul α β] [SMulCommClass R' α β] (S : Subsemiring R') :
-    SMulCommClass S α β :=
-  S.toSubmonoid.smulCommClass_left
-#align subsemiring.smul_comm_class_left Subsemiring.smulCommClass_left
-
-instance smulCommClass_right [SMul α β] [SMul R' β] [SMulCommClass α R' β] (S : Subsemiring R') :
-    SMulCommClass α S β :=
-  S.toSubmonoid.smulCommClass_right
-#align subsemiring.smul_comm_class_right Subsemiring.smulCommClass_right
-
-/-- Note that this provides `IsScalarTower S R R` which is needed by `smul_mul_assoc`. -/
-instance isScalarTower [SMul α β] [SMul R' α] [SMul R' β] [IsScalarTower R' α β]
-    (S : Subsemiring R') :
-    IsScalarTower S α β :=
-  S.toSubmonoid.isScalarTower
-
-instance faithfulSMul [SMul R' α] [FaithfulSMul R' α] (S : Subsemiring R') : FaithfulSMul S α :=
-  S.toSubmonoid.faithfulSMul
 
 /-- The action by a subsemiring is the action by the underlying semiring. -/
 instance [Zero α] [SMulWithZero R' α] (S : Subsemiring R') : SMulWithZero S α :=
@@ -1321,20 +1298,6 @@ instance [Zero α] [SMulWithZero R' α] (S : Subsemiring R') : SMulWithZero S α
 end NonAssocSemiring
 
 variable [Semiring R']
-
-/-- The action by a subsemiring is the action by the underlying semiring. -/
-instance mulAction [MulAction R' α] (S : Subsemiring R') : MulAction S α :=
-  S.toSubmonoid.mulAction
-
-/-- The action by a subsemiring is the action by the underlying semiring. -/
-instance distribMulAction [AddMonoid α] [DistribMulAction R' α] (S : Subsemiring R') :
-    DistribMulAction S α :=
-  S.toSubmonoid.distribMulAction
-
-/-- The action by a subsemiring is the action by the underlying semiring. -/
-instance mulDistribMulAction [Monoid α] [MulDistribMulAction R' α] (S : Subsemiring R') :
-    MulDistribMulAction S α :=
-  S.toSubmonoid.mulDistribMulAction
 
 /-- The action by a subsemiring is the action by the underlying semiring. -/
 instance mulActionWithZero [Zero α] [MulActionWithZero R' α] (S : Subsemiring R') :
@@ -1347,10 +1310,6 @@ instance module [AddCommMonoid α] [Module R' α] (S : Subsemiring R') : Module 
   -- Porting note: copying over the `smul` field causes a timeout
   -- { Module.compHom _ S.subtype with smul := (· • ·) }
   Module.compHom _ S.subtype
-
-/-- The action by a subsemiring is the action by the underlying semiring. -/
-instance [Semiring α] [MulSemiringAction R' α] (S : Subsemiring R') : MulSemiringAction S α :=
-  S.toSubmonoid.mulSemiringAction
 
 /-- The center of a semiring acts commutatively on that semiring. -/
 instance center.smulCommClass_left : SMulCommClass (center R') R' R' :=

--- a/Mathlib/RingTheory/Subsemiring/Basic.lean
+++ b/Mathlib/RingTheory/Subsemiring/Basic.lean
@@ -6,7 +6,6 @@ Authors: Yury Kudryashov
 import Mathlib.Algebra.Module.Basic
 import Mathlib.Algebra.Ring.Equiv
 import Mathlib.Algebra.Ring.Prod
-import Mathlib.Algebra.GroupRingAction.Subobjects
 import Mathlib.Data.Set.Finite
 import Mathlib.GroupTheory.Submonoid.Centralizer
 import Mathlib.GroupTheory.Submonoid.Membership

--- a/Mathlib/RingTheory/Subsemiring/Basic.lean
+++ b/Mathlib/RingTheory/Subsemiring/Basic.lean
@@ -6,6 +6,7 @@ Authors: Yury Kudryashov
 import Mathlib.Algebra.Module.Basic
 import Mathlib.Algebra.Ring.Equiv
 import Mathlib.Algebra.Ring.Prod
+import Mathlib.Algebra.GroupRingAction.Subobjects
 import Mathlib.Data.Set.Finite
 import Mathlib.GroupTheory.Submonoid.Centralizer
 import Mathlib.GroupTheory.Submonoid.Membership

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -299,9 +299,9 @@
   "Mathlib.Logic.Equiv.Defs": ["Mathlib.Init.Data.Bool.Lemmas"],
   "Mathlib.LinearAlgebra.Matrix.Transvection": ["Mathlib.Data.Matrix.DMatrix"],
   "Mathlib.LinearAlgebra.AffineSpace.Basic": ["Mathlib.Algebra.AddTorsor"],
-  "Mathlib.Lean.Expr.Basic": ["Std.Logic"],
-  "Mathlib.Lean.Expr.ExtraRecognizers": ["Mathlib.Data.Set.Defs"],
   "Mathlib.Lean.Meta": ["Std.Logic"],
+  "Mathlib.Lean.Expr.ExtraRecognizers": ["Mathlib.Data.Set.Defs"],
+  "Mathlib.Lean.Expr.Basic": ["Std.Logic"],
   "Mathlib.Init.Data.Nat.GCD": ["Std.Data.Nat.Gcd"],
   "Mathlib.Init.Data.Int.Basic": ["Std.Data.Int.Order"],
   "Mathlib.Init.Core": ["Std.Classes.Dvd"],
@@ -322,6 +322,7 @@
   "Mathlib.AlgebraicTopology.DoldKan.Notations":
   ["Mathlib.AlgebraicTopology.AlternatingFaceMapComplex"],
   "Mathlib.Algebra.Ring.CentroidHom": ["Mathlib.Algebra.Algebra.Basic"],
+  "Mathlib.Algebra.Periodic": ["Mathlib.GroupTheory.Subgroup.Actions"],
   "Mathlib.Algebra.Order.Ring.Defs":
   ["Mathlib.Algebra.Order.Monoid.WithZero.Defs"],
   "Mathlib.Algebra.Module.Submodule.Order":


### PR DESCRIPTION
This PR refactors some `SMul` instances in `GroupTheory/Submonoid/Operations.lean` to use `SubmonoidClass`. This makes many other similar instances redundant.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
