### PR TITLE
[Merged by Bors] - perf(CategoryTheory.Subterminal): avoid autoParams 

### DIFF
--- a/Mathlib/CategoryTheory/Subterminal.lean
+++ b/Mathlib/CategoryTheory/Subterminal.lean
@@ -9,7 +9,6 @@ import Mathlib.CategoryTheory.Subobject.MonoOver
 
 #align_import category_theory.subterminal from "leanprover-community/mathlib"@"bb103f356534a9a7d3596a672097e375290a4c3a"
 
-set_option profiler true
 
 /-!
 # Subterminal objects

--- a/Mathlib/CategoryTheory/Subterminal.lean
+++ b/Mathlib/CategoryTheory/Subterminal.lean
@@ -9,6 +9,8 @@ import Mathlib.CategoryTheory.Subobject.MonoOver
 
 #align_import category_theory.subterminal from "leanprover-community/mathlib"@"bb103f356534a9a7d3596a672097e375290a4c3a"
 
+set_option profiler true
+
 /-!
 # Subterminal objects
 
@@ -157,17 +159,24 @@ object (which is in turn equivalent to the subobjects of the terminal object).
 def subterminalsEquivMonoOverTerminal [HasTerminal C] : Subterminals C ≌ MonoOver (⊤_ C) where
   functor :=
     { obj := fun X => ⟨Over.mk (terminal.from X.1), X.2.mono_terminal_from⟩
-      map := fun f => MonoOver.homMk f (by ext1 ⟨⟨⟩⟩) }
+      map := fun f => MonoOver.homMk f (by ext1 ⟨⟨⟩⟩)
+      map_id := fun X => rfl
+      map_comp := fun f g => rfl }
   inverse :=
     { obj := fun X =>
         ⟨X.obj.left, fun Z f g => by
           rw [← cancel_mono X.arrow]
           apply Subsingleton.elim⟩
-      map := fun f => f.1 }
+      map := fun f => f.1
+      map_id := fun X => rfl
+      map_comp := fun f g => rfl }
   -- Porting note: the original definition was triggering a timeout, using `NatIso.ofComponents`
   -- in the definition of the natural isomorphisms makes the situation slightly better
-  unitIso := NatIso.ofComponents fun X => Iso.refl _
-  counitIso := NatIso.ofComponents fun X => MonoOver.isoMk (Iso.refl _)
+  unitIso := NatIso.ofComponents (fun X => Iso.refl X) (fun _ => by apply Subsingleton.elim)
+  counitIso := NatIso.ofComponents (fun X => MonoOver.isoMk (Iso.refl _))
+    (fun _ => by apply Subsingleton.elim)
+  functor_unitIso_comp := fun _ => by apply Subsingleton.elim
+  -- With `aesop` filling the auto-params this was taking 20s or so
 #align category_theory.subterminals_equiv_mono_over_terminal CategoryTheory.subterminalsEquivMonoOverTerminal
 
 @[simp]


### PR DESCRIPTION
With `aesop_cat` as `autoParam` this was taking 20-25s to build one declaration. This explicitly provides fills the argument and significantly speeds up the build. A comment is left about the issue.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
