### PR TITLE
[Merged by Bors] - feat: Myhill–Nerode theorem

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2369,6 +2369,7 @@ import Mathlib.Computability.Encoding
 import Mathlib.Computability.EpsilonNFA
 import Mathlib.Computability.Halting
 import Mathlib.Computability.Language
+import Mathlib.Computability.MyhillNerode
 import Mathlib.Computability.NFA
 import Mathlib.Computability.Partrec
 import Mathlib.Computability.PartrecCode

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Fox Thomson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Fox Thomson, Chris Wong
+Authors: Fox Thomson, Chris Wong, Chris Wong
 -/
 import Mathlib.Computability.Language
 import Mathlib.Data.Countable.Small
@@ -244,6 +244,41 @@ theorem comap_reindex (f : α' → α) (g : σ ≃ σ') :
   simp [comap, reindex]
 
 end Maps
+
+section equivOfStates
+
+variable {σ' : Type*} (f : σ ≃ σ') (M : DFA α σ)
+
+/-- Lift an equivalence on states to an equivalence on DFAs. -/
+def equivOfStates : DFA α σ ≃ DFA α σ' where
+  toFun M := ⟨fun s a => f (M.step (f.symm s) a), f M.start, f '' M.accept⟩
+  invFun M := ⟨fun s a => f.symm (M.step (f s) a), f.symm M.start, f.symm '' M.accept⟩
+  left_inv M := by simp
+  right_inv M := by simp
+
+@[simp]
+theorem equivOfStates_step (s : σ') (a : α) :
+    (equivOfStates f M).step s a = f (M.step (f.symm s) a) := rfl
+
+@[simp]
+theorem equivOfStates_start : (equivOfStates f M).start = f M.start := rfl
+
+@[simp]
+theorem equivOfStates_accept : (equivOfStates f M).accept = f '' M.accept := rfl
+
+@[simp]
+theorem equivOfStates_evalFrom (s : σ) (x : List α) :
+    (equivOfStates f M).evalFrom (f s) x = f (M.evalFrom s x) := by
+  induction x using List.list_reverse_induction with
+  | base => simp
+  | ind x a ih => simp [ih]
+
+@[simp]
+theorem equivOfStates_accepts : (equivOfStates f M).accepts = M.accepts := by
+  ext x
+  simp [eval, mem_accepts]
+
+end equivOfStates
 
 end DFA
 

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -245,41 +245,6 @@ theorem comap_reindex (f : α' → α) (g : σ ≃ σ') :
 
 end Maps
 
-section equivOfStates
-
-variable {σ' : Type*} (f : σ ≃ σ') (M : DFA α σ)
-
-/-- Lift an equivalence on states to an equivalence on DFAs. -/
-def equivOfStates : DFA α σ ≃ DFA α σ' where
-  toFun M := ⟨fun s a => f (M.step (f.symm s) a), f M.start, f '' M.accept⟩
-  invFun M := ⟨fun s a => f.symm (M.step (f s) a), f.symm M.start, f.symm '' M.accept⟩
-  left_inv M := by simp
-  right_inv M := by simp
-
-@[simp]
-theorem equivOfStates_step (s : σ') (a : α) :
-    (equivOfStates f M).step s a = f (M.step (f.symm s) a) := rfl
-
-@[simp]
-theorem equivOfStates_start : (equivOfStates f M).start = f M.start := rfl
-
-@[simp]
-theorem equivOfStates_accept : (equivOfStates f M).accept = f '' M.accept := rfl
-
-@[simp]
-theorem equivOfStates_evalFrom (s : σ) (x : List α) :
-    (equivOfStates f M).evalFrom (f s) x = f (M.evalFrom s x) := by
-  induction x using List.list_reverse_induction with
-  | base => simp
-  | ind x a ih => simp [ih]
-
-@[simp]
-theorem equivOfStates_accepts : (equivOfStates f M).accepts = M.accepts := by
-  ext x
-  simp [eval, mem_accepts]
-
-end equivOfStates
-
 end DFA
 
 /-- A regular language is a language that is defined by a DFA with finite states. -/

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Fox Thomson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Fox Thomson, Chris Wong, Chris Wong
+Authors: Fox Thomson, Chris Wong
 -/
 import Mathlib.Computability.Language
 import Mathlib.Data.Countable.Small

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -52,6 +52,7 @@ theorem leftQuotient_accepts (M : DFA α σ) (x : List α) :
   rw [DFA.mem_acceptsFrom, DFA.eval, ← DFA.evalFrom_of_append, leftQuotient_mem, DFA.mem_accepts,
     DFA.eval]
 
+/-- Like `leftQuotient_accepts`, but as an equality on functions. -/
 theorem leftQuotient_accepts' (M : DFA α σ) : leftQuotient M.accepts = M.acceptsFrom ∘ M.eval :=
   funext <| leftQuotient_accepts M
 

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -94,7 +94,7 @@ theorem toDFA_accepts : L.toDFA.accepts = L := by
 theorem exists_dfa_of_finite_leftQuotient (h : Set.Finite (Set.range L.leftQuotient)) :
     ∃ n, ∃ M : DFA α (Fin n), M.accepts = L :=
   have ⟨n, ⟨f⟩⟩ := h.exists_equiv_fin
-  ⟨n, DFA.equivOfStates f L.toDFA, by simp⟩
+  ⟨n, DFA.reindex f L.toDFA, by simp⟩
 
 /--
 **Myhill–Nerode theorem**. There exists a DFA for a language if and only if the set of left

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2024 Google. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Wong
+-/
+import Mathlib.Computability.DFA
+import Mathlib.Data.Set.Finite
+
+/-!
+# Myhill–Nerode theorem
+
+This file proves the Myhill–Nerode theorem via left quotients.
+
+Given a language `L` and a word `x`, the *left quotient* is the set of suffixes `y` such that
+`x ++ y` is in `L`. The *Myhill–Nerode theorem* shows that each left quotient, in fact, corresponds
+to the state of an automaton that matches `L`, and that `L` is regular if and only if there are
+finitely many such states.
+
+## Implementation notes
+
+Since mathlib doesn't have an `IsRegular` definition yet, we define regularity directly as the
+existence of a DFA.
+
+## References
+
+* <https://en.wikipedia.org/wiki/Syntactic_monoid#Myhill%E2%80%93Nerode_theorem>
+-/
+
+universe u v
+variable {α : Type u} {σ : Type v} (L : Language α)
+
+namespace Language
+
+/-- The *left quotient* of `x` is the set of suffixes `y` such that `x ++ y` is in `L`. -/
+def leftQuotient (x : List α) : Language α := { y | x ++ y ∈ L }
+
+@[simp]
+theorem leftQuotient_nil : L.leftQuotient [] = L := rfl
+
+@[simp]
+theorem leftQuotient_append (x y : List α) :
+    L.leftQuotient (x ++ y) = (L.leftQuotient x).leftQuotient y := by
+  dsimp [leftQuotient, Language]
+  simp_rw [List.append_assoc]
+
+@[simp]
+theorem leftQuotient_mem (x y : List α) : y ∈ L.leftQuotient x ↔ x ++ y ∈ L := Iff.rfl
+
+theorem leftQuotient_accepts (M : DFA α σ) (x : List α) :
+    leftQuotient M.accepts x = M.acceptsFrom (M.eval x) := by
+  ext y
+  rw [DFA.mem_acceptsFrom, DFA.eval, ← DFA.evalFrom_of_append, ← DFA.mem_accepts, leftQuotient_mem]
+
+theorem leftQuotient_accepts' (M : DFA α σ) : leftQuotient M.accepts = M.acceptsFrom ∘ M.eval :=
+  funext <| leftQuotient_accepts M
+
+theorem finite_leftQuotient_of_dfa [Finite σ] (M : DFA α σ) :
+    Set.Finite (Set.range M.accepts.leftQuotient) :=
+  leftQuotient_accepts' M ▸
+    Set.Finite.of_surjOn
+      M.acceptsFrom
+      (fun _ ⟨y, hy⟩ => ⟨M.eval y, Set.mem_univ _, hy⟩)
+      Set.finite_univ
+
+/-- The left quotients of a language are the states of an automaton that accepts the language. -/
+def toDFA : DFA α (Set.range L.leftQuotient) where
+  step s a := by
+    refine ⟨s.val.leftQuotient [a], ?_⟩
+    obtain ⟨y, hy⟩ := s.prop
+    exists y ++ [a]
+    rw [← hy, leftQuotient_append]
+  start := ⟨L, by exists []⟩
+  accept := { s | [] ∈ s.val }
+
+@[simp]
+theorem mem_toDFA_accept (s : Set.range L.leftQuotient) : s ∈ L.toDFA.accept ↔ [] ∈ s.val := Iff.rfl
+
+@[simp]
+theorem toDFA_step (s : Set.range L.leftQuotient) (a : α) :
+    (L.toDFA.step s a).val = s.val.leftQuotient [a] := rfl
+
+@[simp]
+theorem toDFA_start : L.toDFA.start.val = L := rfl
+
+@[simp]
+theorem toDFA_accepts : L.toDFA.accepts = L := by
+  ext x
+  rw [DFA.mem_accepts, ← DFA.eval]
+  suffices L.toDFA.eval x = L.leftQuotient x by simp [this]
+  induction x using List.list_reverse_induction with
+  | base => simp
+  | ind x a ih => simp [ih]
+
+theorem exists_dfa_of_finite_leftQuotient (h : Set.Finite (Set.range L.leftQuotient)) :
+    ∃ n, ∃ M : DFA α (Fin n), M.accepts = L :=
+  have ⟨n, ⟨f⟩⟩ := h.exists_equiv_fin
+  ⟨n, DFA.equivOfStates f (toDFA L), by simp⟩
+
+/--
+**Myhill–Nerode theorem**. There exists a DFA for a language if and only if the set of left
+quotients is finite.
+-/
+theorem exists_dfa_iff_finite_leftQuotient :
+    (∃ n, ∃ M : DFA α (Fin n), M.accepts = L) ↔ Set.Finite (Set.range L.leftQuotient) :=
+  ⟨fun ⟨_, M, hM⟩ => hM ▸ finite_leftQuotient_of_dfa M, exists_dfa_of_finite_leftQuotient L⟩
+
+end Language

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -38,7 +38,7 @@ theorem leftQuotient_append (x y : List α) :
   simp_rw [List.append_assoc]
 
 @[simp]
-theorem leftQuotient_mem (x y : List α) : y ∈ L.leftQuotient x ↔ x ++ y ∈ L := Iff.rfl
+theorem mem_leftQuotient (x y : List α) : y ∈ L.leftQuotient x ↔ x ++ y ∈ L := Iff.rfl
 
 theorem leftQuotient_accepts (M : DFA α σ) (x : List α) :
     leftQuotient M.accepts x = M.acceptsFrom (M.eval x) := by

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -57,8 +57,8 @@ theorem leftQuotient_accepts' (M : DFA α σ) : leftQuotient M.accepts = M.accep
 theorem finite_leftQuotient_of_dfa [Finite σ] (M : DFA α σ) :
     Set.Finite (Set.range M.accepts.leftQuotient) :=
   leftQuotient_accepts' M ▸
-    Set.finite_of_finite_preimage (f := M.acceptsFrom) (Set.toFinite _)
-      fun _ ⟨y, hy⟩ => ⟨DFA.eval M y, hy⟩
+    Set.finite_of_finite_preimage (Set.toFinite _)
+      (Set.range_comp_subset_range M.eval M.acceptsFrom)
 
 /-- The left quotients of a language are the states of an automaton that accepts the language. -/
 def toDFA : DFA α (Set.range L.leftQuotient) where

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -32,7 +32,6 @@ def leftQuotient (x : List α) : Language α := { y | x ++ y ∈ L }
 @[simp]
 theorem leftQuotient_nil : L.leftQuotient [] = L := rfl
 
-@[simp]
 theorem leftQuotient_append (x y : List α) :
     L.leftQuotient (x ++ y) = (L.leftQuotient x).leftQuotient y := by
   dsimp [leftQuotient, Language]
@@ -85,7 +84,7 @@ theorem toDFA_accepts : L.toDFA.accepts = L := by
   suffices L.toDFA.eval x = L.leftQuotient x by simp [this]
   induction x using List.list_reverse_induction with
   | base => simp
-  | ind x a ih => simp [ih]
+  | ind x a ih => simp [ih, leftQuotient_append]
 
 theorem isRegular_of_finite_leftQuotient (h : Set.Finite (Set.range L.leftQuotient))
     : L.IsRegular :=

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -94,7 +94,7 @@ theorem IsRegular.of_finite_range_leftQuotient (h : Set.Finite (Set.range L.left
 **Myhill–Nerode theorem**. A language is regular if and only if the set of left quotients is finite.
 -/
 theorem isRegular_iff_finite_range_leftQuotient :
-    L.IsRegular ↔ Set.Finite (Set.range L.leftQuotient) :=
+    L.IsRegular ↔ (Set.range L.leftQuotient).Finite :=
   ⟨IsRegular.finite_range_leftQuotient, .of_finite_range_leftQuotient⟩
 
 end Language

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -57,10 +57,8 @@ theorem leftQuotient_accepts' (M : DFA α σ) : leftQuotient M.accepts = M.accep
 theorem finite_leftQuotient_of_dfa [Finite σ] (M : DFA α σ) :
     Set.Finite (Set.range M.accepts.leftQuotient) :=
   leftQuotient_accepts' M ▸
-    Set.Finite.of_surjOn
-      M.acceptsFrom
-      (fun _ ⟨y, hy⟩ => ⟨M.eval y, Set.mem_univ _, hy⟩)
-      Set.finite_univ
+    Set.finite_of_finite_preimage (f := M.acceptsFrom) (Set.toFinite _)
+      fun _ ⟨y, hy⟩ => ⟨DFA.eval M y, hy⟩
 
 /-- The left quotients of a language are the states of an automaton that accepts the language. -/
 def toDFA : DFA α (Set.range L.leftQuotient) where

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -9,12 +9,12 @@ import Mathlib.Data.Set.Finite.Basic
 /-!
 # Myhill–Nerode theorem
 
-This file proves the Myhill–Nerode theorem via left quotients.
+This file proves the Myhill–Nerode theorem using left quotients.
 
-Given a language `L` and a word `x`, the *left quotient* is the set of suffixes `y` such that
-`x ++ y` is in `L`. The *Myhill–Nerode theorem* shows that each left quotient, in fact, corresponds
-to the state of an automaton that matches `L`, and that `L` is regular if and only if there are
-finitely many such states.
+Given a language `L` and a word `x`, the *left quotient* of `L` by `x` is the set of suffixes `y`
+such that `x ++ y` is in `L`. The *Myhill–Nerode theorem* shows that each left quotient, in fact,
+corresponds to the state of an automaton that matches `L`, and that `L` is regular if and only if
+there are finitely many such states.
 
 ## References
 

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -26,6 +26,7 @@ variable {α : Type u} {σ : Type v} {L : Language α}
 
 namespace Language
 
+variable (L) in
 /-- The *left quotient* of `x` is the set of suffixes `y` such that `x ++ y` is in `L`. -/
 def leftQuotient (x : List α) : Language α := { y | x ++ y ∈ L }
 
@@ -45,15 +46,16 @@ theorem leftQuotient_accepts_apply (M : DFA α σ) (x : List α) :
   simp [DFA.mem_accepts, DFA.mem_acceptsFrom, DFA.eval, DFA.evalFrom_of_append]
 
 theorem leftQuotient_accepts (M : DFA α σ) : leftQuotient M.accepts = M.acceptsFrom ∘ M.eval :=
-  funext <| leftQuotient_accepts M
+  funext <| leftQuotient_accepts_apply M
 
 theorem IsRegular.finite_range_leftQuotient (h : L.IsRegular) :
     (Set.range L.leftQuotient).Finite := by
   have ⟨σ, x, M, hM⟩ := h
-  rw [← hM, leftQuotient_accepts']
+  rw [← hM, leftQuotient_accepts]
   exact Set.finite_of_finite_preimage (Set.toFinite _)
     (Set.range_comp_subset_range M.eval M.acceptsFrom)
 
+variable (L) in
 /-- The left quotients of a language are the states of an automaton that accepts the language. -/
 def toDFA : DFA α (Set.range L.leftQuotient) where
   step s a := by
@@ -93,6 +95,6 @@ theorem IsRegular.of_finite_range_leftQuotient (h : Set.Finite (Set.range L.left
 -/
 theorem isRegular_iff_finite_range_leftQuotient :
     L.IsRegular ↔ Set.Finite (Set.range L.leftQuotient) :=
-  ⟨IsRegular.finite_range_leftQuotient, .of_finite_leftQuotient⟩
+  ⟨IsRegular.finite_range_leftQuotient, .of_finite_range_leftQuotient⟩
 
 end Language

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Wong
 -/
 import Mathlib.Computability.DFA
-import Mathlib.Data.Set.Finite
+import Mathlib.Data.Set.Finite.Basic
 
 /-!
 # Myhill–Nerode theorem
@@ -49,7 +49,8 @@ theorem leftQuotient_mem (x y : List α) : y ∈ L.leftQuotient x ↔ x ++ y ∈
 theorem leftQuotient_accepts (M : DFA α σ) (x : List α) :
     leftQuotient M.accepts x = M.acceptsFrom (M.eval x) := by
   ext y
-  rw [DFA.mem_acceptsFrom, DFA.eval, ← DFA.evalFrom_of_append, ← DFA.mem_accepts, leftQuotient_mem]
+  rw [DFA.mem_acceptsFrom, DFA.eval, ← DFA.evalFrom_of_append, leftQuotient_mem, DFA.mem_accepts,
+    DFA.eval]
 
 theorem leftQuotient_accepts' (M : DFA α σ) : leftQuotient M.accepts = M.acceptsFrom ∘ M.eval :=
   funext <| leftQuotient_accepts M
@@ -83,7 +84,7 @@ theorem toDFA_start : L.toDFA.start.val = L := rfl
 @[simp]
 theorem toDFA_accepts : L.toDFA.accepts = L := by
   ext x
-  rw [DFA.mem_accepts, ← DFA.eval]
+  rw [DFA.mem_accepts]
   suffices L.toDFA.eval x = L.leftQuotient x by simp [this]
   induction x using List.list_reverse_induction with
   | base => simp

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -43,8 +43,7 @@ theorem leftQuotient_mem (x y : List α) : y ∈ L.leftQuotient x ↔ x ++ y ∈
 theorem leftQuotient_accepts (M : DFA α σ) (x : List α) :
     leftQuotient M.accepts x = M.acceptsFrom (M.eval x) := by
   ext y
-  rw [DFA.mem_acceptsFrom, DFA.eval, ← DFA.evalFrom_of_append, leftQuotient_mem, DFA.mem_accepts,
-    DFA.eval]
+  simp [DFA.mem_accepts, DFA.mem_acceptsFrom, DFA.eval, DFA.evalFrom_of_append]
 
 /-- Like `leftQuotient_accepts`, but as an equality on functions. -/
 theorem leftQuotient_accepts' (M : DFA α σ) : leftQuotient M.accepts = M.acceptsFrom ∘ M.eval :=

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -22,7 +22,7 @@ there are finitely many such states.
 -/
 
 universe u v
-variable {α : Type u} {σ : Type v} (L : Language α)
+variable {α : Type u} {σ : Type v} {L : Language α}
 
 namespace Language
 
@@ -39,17 +39,16 @@ theorem leftQuotient_append (x y : List α) :
 @[simp]
 theorem mem_leftQuotient (x y : List α) : y ∈ L.leftQuotient x ↔ x ++ y ∈ L := Iff.rfl
 
-theorem leftQuotient_accepts (M : DFA α σ) (x : List α) :
+theorem leftQuotient_accepts_apply (M : DFA α σ) (x : List α) :
     leftQuotient M.accepts x = M.acceptsFrom (M.eval x) := by
   ext y
   simp [DFA.mem_accepts, DFA.mem_acceptsFrom, DFA.eval, DFA.evalFrom_of_append]
 
-/-- Like `leftQuotient_accepts`, but as an equality on functions. -/
-theorem leftQuotient_accepts' (M : DFA α σ) : leftQuotient M.accepts = M.acceptsFrom ∘ M.eval :=
+theorem leftQuotient_accepts (M : DFA α σ) : leftQuotient M.accepts = M.acceptsFrom ∘ M.eval :=
   funext <| leftQuotient_accepts M
 
-theorem finite_leftQuotient_of_isRegular (h : L.IsRegular) :
-    Set.Finite (Set.range L.leftQuotient) := by
+theorem IsRegular.finite_range_leftQuotient (h : L.IsRegular) :
+    (Set.range L.leftQuotient).Finite := by
   have ⟨σ, x, M, hM⟩ := h
   rw [← hM, leftQuotient_accepts']
   exact Set.finite_of_finite_preimage (Set.toFinite _)
@@ -66,17 +65,17 @@ def toDFA : DFA α (Set.range L.leftQuotient) where
   accept := { s | [] ∈ s.val }
 
 @[simp]
-theorem mem_toDFA_accept (s : Set.range L.leftQuotient) : s ∈ L.toDFA.accept ↔ [] ∈ s.val := Iff.rfl
+theorem mem_accept_toDFA (s : Set.range L.leftQuotient) : s ∈ L.toDFA.accept ↔ [] ∈ s.val := Iff.rfl
 
 @[simp]
-theorem toDFA_step (s : Set.range L.leftQuotient) (a : α) :
+theorem step_toDFA (s : Set.range L.leftQuotient) (a : α) :
     (L.toDFA.step s a).val = s.val.leftQuotient [a] := rfl
 
 @[simp]
-theorem toDFA_start : L.toDFA.start.val = L := rfl
+theorem start_toDFA : L.toDFA.start.val = L := rfl
 
 @[simp]
-theorem toDFA_accepts : L.toDFA.accepts = L := by
+theorem accepts_toDFA : L.toDFA.accepts = L := by
   ext x
   rw [DFA.mem_accepts]
   suffices L.toDFA.eval x = L.leftQuotient x by simp [this]
@@ -84,7 +83,7 @@ theorem toDFA_accepts : L.toDFA.accepts = L := by
   | base => simp
   | ind x a ih => simp [ih, leftQuotient_append]
 
-theorem isRegular_of_finite_leftQuotient (h : Set.Finite (Set.range L.leftQuotient)) :
+theorem IsRegular.of_finite_range_leftQuotient (h : Set.Finite (Set.range L.leftQuotient)) :
     L.IsRegular :=
   have ⟨n, ⟨f⟩⟩ := h.exists_equiv_fin
   ⟨Fin n, Fin.fintype n, DFA.reindex f L.toDFA, by simp⟩
@@ -92,7 +91,8 @@ theorem isRegular_of_finite_leftQuotient (h : Set.Finite (Set.range L.leftQuotie
 /--
 **Myhill–Nerode theorem**. A language is regular if and only if the set of left quotients is finite.
 -/
-theorem isRegular_iff_finite_leftQuotient : L.IsRegular ↔ Set.Finite (Set.range L.leftQuotient) :=
-  ⟨finite_leftQuotient_of_isRegular L, isRegular_of_finite_leftQuotient L⟩
+theorem isRegular_iff_finite_range_leftQuotient :
+    L.IsRegular ↔ Set.Finite (Set.range L.leftQuotient) :=
+  ⟨IsRegular.finite_range_leftQuotient, .of_finite_leftQuotient⟩
 
 end Language

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -34,8 +34,7 @@ theorem leftQuotient_nil : L.leftQuotient [] = L := rfl
 
 theorem leftQuotient_append (x y : List α) :
     L.leftQuotient (x ++ y) = (L.leftQuotient x).leftQuotient y := by
-  dsimp [leftQuotient, Language]
-  simp_rw [List.append_assoc]
+  simp [leftQuotient, Language]
 
 @[simp]
 theorem mem_leftQuotient (x y : List α) : y ∈ L.leftQuotient x ↔ x ++ y ∈ L := Iff.rfl

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -92,7 +92,7 @@ theorem toDFA_accepts : L.toDFA.accepts = L := by
 theorem exists_dfa_of_finite_leftQuotient (h : Set.Finite (Set.range L.leftQuotient)) :
     ∃ n, ∃ M : DFA α (Fin n), M.accepts = L :=
   have ⟨n, ⟨f⟩⟩ := h.exists_equiv_fin
-  ⟨n, DFA.equivOfStates f (toDFA L), by simp⟩
+  ⟨n, DFA.equivOfStates f L.toDFA, by simp⟩
 
 /--
 **Myhill–Nerode theorem**. There exists a DFA for a language if and only if the set of left

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -84,8 +84,8 @@ theorem toDFA_accepts : L.toDFA.accepts = L := by
   | base => simp
   | ind x a ih => simp [ih, leftQuotient_append]
 
-theorem isRegular_of_finite_leftQuotient (h : Set.Finite (Set.range L.leftQuotient))
-    : L.IsRegular :=
+theorem isRegular_of_finite_leftQuotient (h : Set.Finite (Set.range L.leftQuotient)) :
+    L.IsRegular :=
   have ⟨n, ⟨f⟩⟩ := h.exists_equiv_fin
   ⟨Fin n, Fin.fintype n, DFA.reindex f L.toDFA, by simp⟩
 

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -87,8 +87,7 @@ theorem accepts_toDFA : L.toDFA.accepts = L := by
 
 theorem IsRegular.of_finite_range_leftQuotient (h : Set.Finite (Set.range L.leftQuotient)) :
     L.IsRegular :=
-  have ⟨n, ⟨f⟩⟩ := h.exists_equiv_fin
-  ⟨Fin n, Fin.fintype n, DFA.reindex f L.toDFA, by simp⟩
+  Language.isRegular_iff.mpr ⟨_, h.fintype, L.toDFA, by simp⟩
 
 /--
 **Myhill–Nerode theorem**. A language is regular if and only if the set of left quotients is finite.

--- a/Mathlib/Computability/MyhillNerode.lean
+++ b/Mathlib/Computability/MyhillNerode.lean
@@ -30,9 +30,11 @@ variable (L) in
 /-- The *left quotient* of `x` is the set of suffixes `y` such that `x ++ y` is in `L`. -/
 def leftQuotient (x : List α) : Language α := { y | x ++ y ∈ L }
 
+variable (L) in
 @[simp]
 theorem leftQuotient_nil : L.leftQuotient [] = L := rfl
 
+variable (L) in
 theorem leftQuotient_append (x y : List α) :
     L.leftQuotient (x ++ y) = (L.leftQuotient x).leftQuotient y := by
   simp [leftQuotient, Language]
@@ -73,9 +75,11 @@ theorem mem_accept_toDFA (s : Set.range L.leftQuotient) : s ∈ L.toDFA.accept �
 theorem step_toDFA (s : Set.range L.leftQuotient) (a : α) :
     (L.toDFA.step s a).val = s.val.leftQuotient [a] := rfl
 
+variable (L) in
 @[simp]
 theorem start_toDFA : L.toDFA.start.val = L := rfl
 
+variable (L) in
 @[simp]
 theorem accepts_toDFA : L.toDFA.accepts = L := by
   ext x

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -391,6 +391,7 @@ Q422187:
   title: Myhill–Nerode theorem
   decl: Language.isRegular_iff_finite_range_leftQuotient
   author: Chris Wong
+  date: 2024-03-24
 
 Q425432:
   title: Laurent expansion theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -389,9 +389,8 @@ Q420714:
 
 Q422187:
   title: Myhill–Nerode theorem
-  # two in-progress formalisations, none merged as of end of 2024
-  # https://github.com/atarnoam/lean-automata/blob/main/src/regular_languages.lean
-  # https://github.com/leanprover-community/mathlib4/pull/11311
+  decl: Language.isRegular_iff_finite_range_leftQuotient
+  author: Chris Wong
 
 Q425432:
   title: Laurent expansion theorem


### PR DESCRIPTION
I take a different approach to the [`lean-automata` version](https://github.com/atarnoam/lean-automata/blob/main/src/regular_languages.lean) by @atarnoam. Rather than taking a `Quotient` by the Nerode relation, I instead talk about the the function `leftQuotient := fun x => { y | x ++ y ∈ L }`. This is more direct as it avoids going through the `Quotient` API. The Nerode relation can be defined later (not in this PR) as the [kernel](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Setoid/Basic.html#Setoid.ker) of this function.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #11372

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
