### PR TITLE
[Merged by Bors] - chore(Algebra/Group/AddChar): move results

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -172,6 +172,7 @@ import Mathlib.Algebra.GCDMonoid.Multiset
 import Mathlib.Algebra.GeomSum
 import Mathlib.Algebra.GradedMonoid
 import Mathlib.Algebra.GradedMulAction
+import Mathlib.Algebra.Group.AddChar
 import Mathlib.Algebra.Group.Aut
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Commutator

--- a/Mathlib/Algebra/Group/AddChar.lean
+++ b/Mathlib/Algebra/Group/AddChar.lean
@@ -1,0 +1,234 @@
+/-
+Copyright (c) 2022 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Stoll
+-/
+import Mathlib.Algebra.Group.Hom.Instances
+import Mathlib.Data.Nat.Cast.Basic
+
+#align_import number_theory.legendre_symbol.add_character from "leanprover-community/mathlib"@"0723536a0522d24fc2f159a096fb3304bef77472"
+
+/-!
+# Characters from additive to multiplicative monoids
+
+Let `A` be an additive monoid, and `M` a multiplicative one. An *additive character* of `A` with
+values in `M` is simply a map `A → M` which intertwines the addition operation on `A` with the
+multiplicative operation on `M`.
+
+We define these objects, using the namespace `AddChar`, and show that if `A` is a commutative group
+under addition, then the additive characters are also a group (written multiplicatively). Note that
+we do not need `M` to be a group here.
+
+We also include some constructions specific to the case when `A = R` is a ring; then we define
+`mulShift ψ r`, where `ψ : AddChar R M` and `r : R`, to be the character defined by
+`x ↦ ψ (r * x)`.
+
+For more refined results of a number-theoretic nature (primitive characters, Gauss sums, etc)
+see `Mathlib.NumberTheory.LegendreSymbol.AddCharacter`.
+
+## Tags
+
+additive character
+-/
+
+
+universe u v
+
+/-!
+### Definitions related to and results on additive characters
+-/
+
+section AddCharDef
+
+-- The domain of our additive characters
+variable (A : Type u) [AddMonoid A]
+
+-- The target
+variable (M : Type v) [CommMonoid M]
+
+/-- Define `AddChar A M` as `(Multiplicative A) →* M`.
+The definition works for an additive monoid `A` and a monoid `M`,
+but we will restrict to the case that both are commutative rings for most applications.
+The trivial additive character (sending everything to `1`) is `(1 : AddChar A M).` -/
+def AddChar : Type max u v :=
+  Multiplicative A →* M
+#align add_char AddChar
+
+end AddCharDef
+
+namespace AddChar
+
+-- Porting note(https://github.com/leanprover-community/mathlib4/issues/5020): added
+section DerivedInstances
+
+variable (A : Type u) [AddMonoid A] (M : Type v) [CommMonoid M]
+
+instance : CommMonoid (AddChar A M) :=
+  inferInstanceAs (CommMonoid (Multiplicative A →* M))
+
+instance : Inhabited (AddChar A M) :=
+  inferInstanceAs (Inhabited (Multiplicative A →* M))
+
+end DerivedInstances
+
+section CoeToFun
+
+variable {A : Type u} [AddMonoid A] {M : Type v} [CommMonoid M]
+
+/-- Interpret an additive character as a monoid homomorphism. -/
+def toMonoidHom : AddChar A M → Multiplicative A →* M :=
+  id
+#align add_char.to_monoid_hom AddChar.toMonoidHom
+
+open Multiplicative
+
+/-- Define coercion to a function so that it includes the move from `A` to `Multiplicative A`.
+After we have proved the API lemmas below, we don't need to worry about writing `ofAdd a`
+when we want to apply an additive character. -/
+instance instFunLike : FunLike (AddChar A M) A M :=
+  inferInstanceAs (FunLike (Multiplicative A →* M) A M)
+#noalign add_char.has_coe_to_fun
+
+theorem coe_to_fun_apply (ψ : AddChar A M) (a : A) : ψ a = ψ.toMonoidHom (ofAdd a) :=
+  rfl
+#align add_char.coe_to_fun_apply AddChar.coe_to_fun_apply
+
+-- Porting note: added
+theorem mul_apply (ψ φ : AddChar A M) (a : A) : (ψ * φ) a = ψ a * φ a :=
+  rfl
+
+-- Porting note: added
+@[simp]
+theorem one_apply (a : A) : (1 : AddChar A M) a = 1 := rfl
+
+-- this instance was a bad idea and conflicted with `instFunLike` above
+#noalign add_char.monoid_hom_class
+
+-- Porting note(https://github.com/leanprover-community/mathlib4/issues/5229): added.
+@[ext]
+theorem ext (f g : AddChar A M) (h : ∀ x : A, f x = g x) : f = g :=
+  MonoidHom.ext h
+
+/-- An additive character maps `0` to `1`. -/
+@[simp]
+theorem map_zero_one (ψ : AddChar A M) : ψ 0 = 1 := by rw [coe_to_fun_apply, ofAdd_zero, map_one]
+#align add_char.map_zero_one AddChar.map_zero_one
+
+/-- An additive character maps sums to products. -/
+@[simp]
+theorem map_add_mul (ψ : AddChar A M) (x y : A) : ψ (x + y) = ψ x * ψ y := by
+  rw [coe_to_fun_apply, coe_to_fun_apply _ x, coe_to_fun_apply _ y, ofAdd_add, map_mul]
+#align add_char.map_add_mul AddChar.map_add_mul
+
+/-- An additive character maps multiples by natural numbers to powers. -/
+@[simp]
+theorem map_nsmul_pow (ψ : AddChar A M) (n : ℕ) (x : A) : ψ (n • x) = ψ x ^ n := by
+  rw [coe_to_fun_apply, coe_to_fun_apply _ x, ofAdd_nsmul, map_pow]
+#align add_char.map_nsmul_pow AddChar.map_nsmul_pow
+
+end CoeToFun
+
+section GroupStructure
+
+open Multiplicative
+
+variable {A : Type u} [AddCommGroup A] {M : Type v} [CommMonoid M]
+
+/-- An additive character on a commutative additive group has an inverse.
+
+Note that this is a different inverse to the one provided by `MonoidHom.inv`,
+as it acts on the domain instead of the codomain. -/
+instance hasInv : Inv (AddChar A M) :=
+  ⟨fun ψ => ψ.comp invMonoidHom⟩
+#align add_char.has_inv AddChar.hasInv
+
+theorem inv_apply (ψ : AddChar A M) (x : A) : ψ⁻¹ x = ψ (-x) :=
+  rfl
+#align add_char.inv_apply AddChar.inv_apply
+
+/-- An additive character maps multiples by integers to powers. -/
+@[simp]
+theorem map_zsmul_zpow {M : Type v} [CommGroup M] (ψ : AddChar A M) (n : ℤ) (x : A) :
+    ψ (n • x) = ψ x ^ n := by rw [coe_to_fun_apply, coe_to_fun_apply _ x, ofAdd_zsmul, map_zpow]
+#align add_char.map_zsmul_zpow AddChar.map_zsmul_zpow
+
+/-- The additive characters on a commutative additive group form a commutative group. -/
+instance commGroup : CommGroup (AddChar A M) :=
+  { MonoidHom.commMonoid with
+    inv := Inv.inv
+    mul_left_inv := fun ψ => by
+      ext x
+      rw [AddChar.mul_apply, AddChar.one_apply, inv_apply, ← map_add_mul, add_left_neg,
+        map_zero_one] }
+#align add_char.comm_group AddChar.commGroup
+
+end GroupStructure
+
+section nontrivial
+
+variable {A : Type u} [AddMonoid A] {M : Type v} [CommMonoid M]
+
+/-- An additive character is *nontrivial* if it takes a value `≠ 1`. -/
+def IsNontrivial (ψ : AddChar A M) : Prop :=
+  ∃ a : A, ψ a ≠ 1
+#align add_char.is_nontrivial AddChar.IsNontrivial
+
+/-- An additive character is nontrivial iff it is not the trivial character. -/
+theorem isNontrivial_iff_ne_trivial (ψ : AddChar A M) : IsNontrivial ψ ↔ ψ ≠ 1 := by
+  refine' not_forall.symm.trans (Iff.not _)
+  rw [DFunLike.ext_iff]
+  rfl
+#align add_char.is_nontrivial_iff_ne_trivial AddChar.isNontrivial_iff_ne_trivial
+
+end nontrivial
+
+section Ring
+
+-- The domain and target of our additive characters. Now we restrict to a ring in the domain.
+variable {R : Type u} [CommRing R] {M : Type v} [CommMonoid M]
+
+/-- Define the multiplicative shift of an additive character.
+This satisfies `mulShift ψ a x = ψ (a * x)`. -/
+def mulShift (ψ : AddChar R M) (r : R) : AddChar R M :=
+  ψ.comp (AddMonoidHom.toMultiplicative (AddMonoidHom.mulLeft r))
+#align add_char.mul_shift AddChar.mulShift
+
+@[simp]
+theorem mulShift_apply {ψ : AddChar R M} {r : R} {x : R} : mulShift ψ r x = ψ (r * x) :=
+  rfl
+#align add_char.mul_shift_apply AddChar.mulShift_apply
+
+/-- `ψ⁻¹ = mulShift ψ (-1))`. -/
+theorem inv_mulShift (ψ : AddChar R M) : ψ⁻¹ = mulShift ψ (-1) := by
+  ext
+  rw [inv_apply, mulShift_apply, neg_mul, one_mul]
+#align add_char.inv_mul_shift AddChar.inv_mulShift
+
+/-- If `n` is a natural number, then `mulShift ψ n x = (ψ x) ^ n`. -/
+theorem mulShift_spec' (ψ : AddChar R M) (n : ℕ) (x : R) : mulShift ψ n x = ψ x ^ n := by
+  rw [mulShift_apply, ← nsmul_eq_mul, map_nsmul_pow]
+#align add_char.mul_shift_spec' AddChar.mulShift_spec'
+
+/-- If `n` is a natural number, then `ψ ^ n = mulShift ψ n`. -/
+theorem pow_mulShift (ψ : AddChar R M) (n : ℕ) : ψ ^ n = mulShift ψ n := by
+  ext x
+  rw [show (ψ ^ n) x = ψ x ^ n from rfl, ← mulShift_spec']
+#align add_char.pow_mul_shift AddChar.pow_mulShift
+
+/-- The product of `mulShift ψ r` and `mulShift ψ s` is `mulShift ψ (r + s)`. -/
+theorem mulShift_mul (ψ : AddChar R M) (r s : R) :
+    mulShift ψ r * mulShift ψ s = mulShift ψ (r + s) := by
+  ext
+  rw [mulShift_apply, right_distrib, map_add_mul]; norm_cast
+#align add_char.mul_shift_mul AddChar.mulShift_mul
+
+/-- `mulShift ψ 0` is the trivial character. -/
+@[simp]
+theorem mulShift_zero (ψ : AddChar R M) : mulShift ψ 0 = 1 := by
+  ext
+  rw [mulShift_apply, zero_mul, map_zero_one]; norm_cast
+#align add_char.mul_shift_zero AddChar.mulShift_zero
+
+end Ring
+
+end AddChar

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -5,25 +5,20 @@ Authors: Michael Stoll
 -/
 import Mathlib.NumberTheory.Cyclotomic.PrimitiveRoots
 import Mathlib.FieldTheory.Finite.Trace
+import Mathlib.Algebra.Group.AddChar
 
 #align_import number_theory.legendre_symbol.add_character from "leanprover-community/mathlib"@"0723536a0522d24fc2f159a096fb3304bef77472"
 
 /-!
 # Additive characters of finite rings and fields
 
-Let `R` be a finite commutative ring. An *additive character* of `R` with values
-in another commutative ring `R'` is simply a morphism from the additive group
-of `R` into the multiplicative monoid of `R'`.
-
-The additive characters on `R` with values in `R'` form a commutative group.
-
-We use the namespace `AddChar`.
+This file collects some results on additive characters whose domain is (the additive group of)
+a finite ring or field.
 
 ## Main definitions and results
 
-We define `mulShift ψ a`, where `ψ : AddChar R R'` and `a : R`, to be the
-character defined by `x ↦ ψ (a * x)`. An additive character `ψ` is *primitive*
-if `mulShift ψ a` is trivial only when `a = 0`.
+We define an additive character `ψ` to be *primitive* if `mulShift ψ a` is trivial only when
+`a = 0`.
 
 We show that when `ψ` is primitive, then the map `a ↦ mulShift ψ a` is injective
 (`AddChar.to_mulShift_inj_of_isPrimitive`) and that `ψ` is primitive when `R` is a field
@@ -44,203 +39,12 @@ additive character
 
 universe u v
 
-/-!
-### Definitions related to and results on additive characters
--/
-
-
-section AddCharDef
-
--- The domain of our additive characters
-variable (R : Type u) [AddMonoid R]
-
--- The target
-variable (R' : Type v) [CommMonoid R']
-
-/-- Define `AddChar R R'` as `(Multiplicative R) →* R'`.
-The definition works for an additive monoid `R` and a monoid `R'`,
-but we will restrict to the case that both are commutative rings below.
-We assume right away that `R'` is commutative, so that `AddChar R R'` carries
-a structure of commutative monoid.
-The trivial additive character (sending everything to `1`) is `(1 : AddChar R R').` -/
-def AddChar : Type max u v :=
-  Multiplicative R →* R'
-#align add_char AddChar
-
-end AddCharDef
-
 namespace AddChar
-
--- Porting note(https://github.com/leanprover-community/mathlib4/issues/5020): added
-section DerivedInstances
-
-variable (R : Type u) [AddMonoid R] (R' : Type v) [CommMonoid R']
-
-instance : CommMonoid (AddChar R R') :=
-  inferInstanceAs (CommMonoid (Multiplicative R →* R'))
-
-instance : Inhabited (AddChar R R') :=
-  inferInstanceAs (Inhabited (Multiplicative R →* R'))
-
-end DerivedInstances
-
-section CoeToFun
-
-variable {R : Type u} [AddMonoid R] {R' : Type v} [CommMonoid R']
-
-/-- Interpret an additive character as a monoid homomorphism. -/
-def toMonoidHom : AddChar R R' → Multiplicative R →* R' :=
-  id
-#align add_char.to_monoid_hom AddChar.toMonoidHom
-
-open Multiplicative
-
-/-- Define coercion to a function so that it includes the move from `R` to `Multiplicative R`.
-After we have proved the API lemmas below, we don't need to worry about writing `ofAdd a`
-when we want to apply an additive character. -/
-instance instFunLike : FunLike (AddChar R R') R R' :=
-  inferInstanceAs (FunLike (Multiplicative R →* R') R R')
-#noalign add_char.has_coe_to_fun
-
-theorem coe_to_fun_apply (ψ : AddChar R R') (a : R) : ψ a = ψ.toMonoidHom (ofAdd a) :=
-  rfl
-#align add_char.coe_to_fun_apply AddChar.coe_to_fun_apply
-
--- Porting note: added
-theorem mul_apply (ψ φ : AddChar R R') (a : R) : (ψ * φ) a = ψ a * φ a :=
-  rfl
-
--- Porting note: added
-@[simp]
-theorem one_apply (a : R) : (1 : AddChar R R') a = 1 := rfl
-
--- this instance was a bad idea and conflicted with `instFunLike` above
-#noalign add_char.monoid_hom_class
-
--- Porting note(https://github.com/leanprover-community/mathlib4/issues/5229): added.
-@[ext]
-theorem ext (f g : AddChar R R') (h : ∀ x : R, f x = g x) : f = g :=
-  MonoidHom.ext h
-
-/-- An additive character maps `0` to `1`. -/
-@[simp]
-theorem map_zero_one (ψ : AddChar R R') : ψ 0 = 1 := by rw [coe_to_fun_apply, ofAdd_zero, map_one]
-#align add_char.map_zero_one AddChar.map_zero_one
-
-/-- An additive character maps sums to products. -/
-@[simp]
-theorem map_add_mul (ψ : AddChar R R') (x y : R) : ψ (x + y) = ψ x * ψ y := by
-  rw [coe_to_fun_apply, coe_to_fun_apply _ x, coe_to_fun_apply _ y, ofAdd_add, map_mul]
-#align add_char.map_add_mul AddChar.map_add_mul
-
-/-- An additive character maps multiples by natural numbers to powers. -/
-@[simp]
-theorem map_nsmul_pow (ψ : AddChar R R') (n : ℕ) (x : R) : ψ (n • x) = ψ x ^ n := by
-  rw [coe_to_fun_apply, coe_to_fun_apply _ x, ofAdd_nsmul, map_pow]
-#align add_char.map_nsmul_pow AddChar.map_nsmul_pow
-
-end CoeToFun
-
-section GroupStructure
-
-open Multiplicative
-
-variable {R : Type u} [AddCommGroup R] {R' : Type v} [CommMonoid R']
-
-/-- An additive character on a commutative additive group has an inverse.
-
-Note that this is a different inverse to the one provided by `MonoidHom.inv`,
-as it acts on the domain instead of the codomain. -/
-instance hasInv : Inv (AddChar R R') :=
-  ⟨fun ψ => ψ.comp invMonoidHom⟩
-#align add_char.has_inv AddChar.hasInv
-
-theorem inv_apply (ψ : AddChar R R') (x : R) : ψ⁻¹ x = ψ (-x) :=
-  rfl
-#align add_char.inv_apply AddChar.inv_apply
-
-/-- An additive character maps multiples by integers to powers. -/
-@[simp]
-theorem map_zsmul_zpow {R' : Type v} [CommGroup R'] (ψ : AddChar R R') (n : ℤ) (x : R) :
-    ψ (n • x) = ψ x ^ n := by rw [coe_to_fun_apply, coe_to_fun_apply _ x, ofAdd_zsmul, map_zpow]
-#align add_char.map_zsmul_zpow AddChar.map_zsmul_zpow
-
-/-- The additive characters on a commutative additive group form a commutative group. -/
-instance commGroup : CommGroup (AddChar R R') :=
-  { MonoidHom.commMonoid with
-    inv := Inv.inv
-    mul_left_inv := fun ψ => by
-      ext x
-      rw [AddChar.mul_apply, AddChar.one_apply, inv_apply, ← map_add_mul, add_left_neg,
-        map_zero_one] }
-#align add_char.comm_group AddChar.commGroup
-
-end GroupStructure
-
-section nontrivial
-
-variable {R : Type u} [AddMonoid R] {R' : Type v} [CommMonoid R']
-
-/-- An additive character is *nontrivial* if it takes a value `≠ 1`. -/
-def IsNontrivial (ψ : AddChar R R') : Prop :=
-  ∃ a : R, ψ a ≠ 1
-#align add_char.is_nontrivial AddChar.IsNontrivial
-
-/-- An additive character is nontrivial iff it is not the trivial character. -/
-theorem isNontrivial_iff_ne_trivial (ψ : AddChar R R') : IsNontrivial ψ ↔ ψ ≠ 1 := by
-  refine' not_forall.symm.trans (Iff.not _)
-  rw [DFunLike.ext_iff]
-  rfl
-#align add_char.is_nontrivial_iff_ne_trivial AddChar.isNontrivial_iff_ne_trivial
-
-end nontrivial
 
 section Additive
 
 -- The domain and target of our additive characters. Now we restrict to a ring in the domain.
 variable {R : Type u} [CommRing R] {R' : Type v} [CommMonoid R']
-
-/-- Define the multiplicative shift of an additive character.
-This satisfies `mulShift ψ a x = ψ (a * x)`. -/
-def mulShift (ψ : AddChar R R') (a : R) : AddChar R R' :=
-  ψ.comp (AddMonoidHom.toMultiplicative (AddMonoidHom.mulLeft a))
-#align add_char.mul_shift AddChar.mulShift
-
-@[simp]
-theorem mulShift_apply {ψ : AddChar R R'} {a : R} {x : R} : mulShift ψ a x = ψ (a * x) :=
-  rfl
-#align add_char.mul_shift_apply AddChar.mulShift_apply
-
-/-- `ψ⁻¹ = mulShift ψ (-1))`. -/
-theorem inv_mulShift (ψ : AddChar R R') : ψ⁻¹ = mulShift ψ (-1) := by
-  ext
-  rw [inv_apply, mulShift_apply, neg_mul, one_mul]
-#align add_char.inv_mul_shift AddChar.inv_mulShift
-
-/-- If `n` is a natural number, then `mulShift ψ n x = (ψ x) ^ n`. -/
-theorem mulShift_spec' (ψ : AddChar R R') (n : ℕ) (x : R) : mulShift ψ n x = ψ x ^ n := by
-  rw [mulShift_apply, ← nsmul_eq_mul, map_nsmul_pow]
-#align add_char.mul_shift_spec' AddChar.mulShift_spec'
-
-/-- If `n` is a natural number, then `ψ ^ n = mulShift ψ n`. -/
-theorem pow_mulShift (ψ : AddChar R R') (n : ℕ) : ψ ^ n = mulShift ψ n := by
-  ext x
-  rw [show (ψ ^ n) x = ψ x ^ n from rfl, ← mulShift_spec']
-#align add_char.pow_mul_shift AddChar.pow_mulShift
-
-/-- The product of `mulShift ψ a` and `mulShift ψ b` is `mulShift ψ (a + b)`. -/
-theorem mulShift_mul (ψ : AddChar R R') (a b : R) :
-    mulShift ψ a * mulShift ψ b = mulShift ψ (a + b) := by
-  ext
-  rw [mulShift_apply, right_distrib, map_add_mul]; norm_cast
-#align add_char.mul_shift_mul AddChar.mulShift_mul
-
-/-- `mulShift ψ 0` is the trivial character. -/
-@[simp]
-theorem mulShift_zero (ψ : AddChar R R') : mulShift ψ 0 = 1 := by
-  ext
-  rw [mulShift_apply, zero_mul, map_zero_one]; norm_cast
-#align add_char.mul_shift_zero AddChar.mulShift_zero
 
 /-- An additive character is *primitive* iff all its multiplicative shifts by nonzero
 elements are nontrivial. -/


### PR DESCRIPTION
Currently the definition of additive characters (from an additive to a multiplicative monoid) is hidden away in 
`NumberTheory/LegendreSymbol`. These constructions seem to be getting used more widely, e.g. in Yaël's LeanAPAP project; so this PR carves off the parts of `NumberTheory/LegendreSymbol/AddCharacter` which don't depend on cyclotomic field arithmetic and moves them to `Algebra/Group`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
