### PR TITLE
chore: rename List.merge

### DIFF
--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -420,7 +420,7 @@ def merge' : List α → List α → List α
   | l, [] => l
   | a :: l, b :: l' => if a ≼ b then a :: merge' l (b :: l') else b :: merge' (a :: l) l'
   termination_by l₁ l₂ => length l₁ + length l₂
-#align list.merge List.merge
+#align list.merge List.merge'
 
 /-- Implementation of a merge sort algorithm to sort a list. -/
 def mergeSort : List α → List α
@@ -455,7 +455,7 @@ theorem perm_merge' : ∀ l l' : List α, merge' r l l' ~ l ++ l'
     · suffices b :: merge' r (a :: l) l' ~ a :: (l ++ b :: l') by simpa [merge', h]
       exact ((perm_merge' _ _).cons _).trans ((swap _ _ _).trans (perm_middle.symm.cons _))
   termination_by l₁ l₂ => length l₁ + length l₂
-#align list.perm_merge List.perm_merge
+#align list.perm_merge List.perm_merge'
 
 theorem perm_mergeSort : ∀ l : List α, mergeSort r l ~ l
   | [] => by simp [mergeSort]
@@ -486,7 +486,7 @@ theorem Sorted.merge' : ∀ {l l' : List α}, Sorted r l → Sorted r l' → Sor
   | a :: l, b :: l', h₁, h₂ => by
     by_cases h : a ≼ b
     · suffices ∀ b' ∈ List.merge' r l (b :: l'), r a b' by
-        simpa [List.merge', h, h₁.of_cons.merge h₂]
+        simpa [List.merge', h, h₁.of_cons.merge' h₂]
       intro b' bm
       rcases show b' = b ∨ b' ∈ l ∨ b' ∈ l' by
           simpa [or_left_comm] using (perm_merge' _ _ _).subset bm with
@@ -496,7 +496,7 @@ theorem Sorted.merge' : ∀ {l l' : List α}, Sorted r l → Sorted r l' → Sor
       · exact rel_of_sorted_cons h₁ _ bl
       · exact _root_.trans h (rel_of_sorted_cons h₂ _ bl')
     · suffices ∀ b' ∈ List.merge' r (a :: l) l', r b b' by
-        simpa [List.merge', h, h₁.merge h₂.of_cons]
+        simpa [List.merge', h, h₁.merge' h₂.of_cons]
       intro b' bm
       have ba : b ≼ a := (total_of r _ _).resolve_left h
       have : b' = a ∨ b' ∈ l ∨ b' ∈ l' := by simpa using (perm_merge' _ _ _).subset bm

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -415,10 +415,10 @@ theorem perm_split : ∀ {l l₁ l₂ : List α}, split l = (l₁, l₂) → l ~
 /-- Merge two sorted lists into one in linear time.
 
      merge [1, 2, 4, 5] [0, 1, 3, 4] = [0, 1, 1, 2, 3, 4, 4, 5] -/
-def merge : List α → List α → List α
+def merge' : List α → List α → List α
   | [], l' => l'
   | l, [] => l
-  | a :: l, b :: l' => if a ≼ b then a :: merge l (b :: l') else b :: merge (a :: l) l'
+  | a :: l, b :: l' => if a ≼ b then a :: merge' l (b :: l') else b :: merge' (a :: l) l'
   termination_by l₁ l₂ => length l₁ + length l₂
 #align list.merge List.merge
 
@@ -433,27 +433,27 @@ def mergeSort : List α → List α
     have h := length_split_lt e
     have := h.1
     have := h.2
-    exact merge r (mergeSort ls.1) (mergeSort ls.2)
+    exact merge' r (mergeSort ls.1) (mergeSort ls.2)
   termination_by l => length l
 #align list.merge_sort List.mergeSort
 
 @[nolint unusedHavesSuffices] -- Porting note: false positive
 theorem mergeSort_cons_cons {a b} {l l₁ l₂ : List α} (h : split (a :: b :: l) = (l₁, l₂)) :
-    mergeSort r (a :: b :: l) = merge r (mergeSort r l₁) (mergeSort r l₂) := by
+    mergeSort r (a :: b :: l) = merge' r (mergeSort r l₁) (mergeSort r l₂) := by
   simp only [mergeSort, h]
 #align list.merge_sort_cons_cons List.mergeSort_cons_cons
 
 section Correctness
 
-theorem perm_merge : ∀ l l' : List α, merge r l l' ~ l ++ l'
-  | [], [] => by simp [merge]
-  | [], b :: l' => by simp [merge]
-  | a :: l, [] => by simp [merge]
+theorem perm_merge' : ∀ l l' : List α, merge' r l l' ~ l ++ l'
+  | [], [] => by simp [merge']
+  | [], b :: l' => by simp [merge']
+  | a :: l, [] => by simp [merge']
   | a :: l, b :: l' => by
     by_cases h : a ≼ b
-    · simpa [merge, h] using perm_merge _ _
-    · suffices b :: merge r (a :: l) l' ~ a :: (l ++ b :: l') by simpa [merge, h]
-      exact ((perm_merge _ _).cons _).trans ((swap _ _ _).trans (perm_middle.symm.cons _))
+    · simpa [merge', h] using perm_merge' _ _
+    · suffices b :: merge' r (a :: l) l' ~ a :: (l ++ b :: l') by simpa [merge', h]
+      exact ((perm_merge' _ _).cons _).trans ((swap _ _ _).trans (perm_middle.symm.cons _))
   termination_by l₁ l₂ => length l₁ + length l₂
 #align list.perm_merge List.perm_merge
 
@@ -464,7 +464,7 @@ theorem perm_mergeSort : ∀ l : List α, mergeSort r l ~ l
     cases' e : split (a :: b :: l) with l₁ l₂
     cases' length_split_lt e with h₁ h₂
     rw [mergeSort_cons_cons r e]
-    apply (perm_merge r _ _).trans
+    apply (perm_merge' r _ _).trans
     exact
       ((perm_mergeSort l₁).append (perm_mergeSort l₂)).trans (perm_split e).symm
   termination_by l => length l
@@ -479,34 +479,34 @@ section TotalAndTransitive
 
 variable {r} [IsTotal α r] [IsTrans α r]
 
-theorem Sorted.merge : ∀ {l l' : List α}, Sorted r l → Sorted r l' → Sorted r (merge r l l')
-  | [], [], _, _ => by simp [List.merge]
-  | [], b :: l', _, h₂ => by simpa [List.merge] using h₂
-  | a :: l, [], h₁, _ => by simpa [List.merge] using h₁
+theorem Sorted.merge' : ∀ {l l' : List α}, Sorted r l → Sorted r l' → Sorted r (merge' r l l')
+  | [], [], _, _ => by simp [List.merge']
+  | [], b :: l', _, h₂ => by simpa [List.merge'] using h₂
+  | a :: l, [], h₁, _ => by simpa [List.merge'] using h₁
   | a :: l, b :: l', h₁, h₂ => by
     by_cases h : a ≼ b
-    · suffices ∀ b' ∈ List.merge r l (b :: l'), r a b' by
-        simpa [List.merge, h, h₁.of_cons.merge h₂]
+    · suffices ∀ b' ∈ List.merge' r l (b :: l'), r a b' by
+        simpa [List.merge', h, h₁.of_cons.merge h₂]
       intro b' bm
       rcases show b' = b ∨ b' ∈ l ∨ b' ∈ l' by
-          simpa [or_left_comm] using (perm_merge _ _ _).subset bm with
+          simpa [or_left_comm] using (perm_merge' _ _ _).subset bm with
         (be | bl | bl')
       · subst b'
         assumption
       · exact rel_of_sorted_cons h₁ _ bl
       · exact _root_.trans h (rel_of_sorted_cons h₂ _ bl')
-    · suffices ∀ b' ∈ List.merge r (a :: l) l', r b b' by
-        simpa [List.merge, h, h₁.merge h₂.of_cons]
+    · suffices ∀ b' ∈ List.merge' r (a :: l) l', r b b' by
+        simpa [List.merge', h, h₁.merge h₂.of_cons]
       intro b' bm
       have ba : b ≼ a := (total_of r _ _).resolve_left h
-      have : b' = a ∨ b' ∈ l ∨ b' ∈ l' := by simpa using (perm_merge _ _ _).subset bm
+      have : b' = a ∨ b' ∈ l ∨ b' ∈ l' := by simpa using (perm_merge' _ _ _).subset bm
       rcases this with (be | bl | bl')
       · subst b'
         assumption
       · exact _root_.trans ba (rel_of_sorted_cons h₁ _ bl)
       · exact rel_of_sorted_cons h₂ _ bl'
   termination_by l₁ l₂ => length l₁ + length l₂
-#align list.sorted.merge List.Sorted.merge
+#align list.sorted.merge List.Sorted.merge'
 
 variable (r)
 
@@ -517,7 +517,7 @@ theorem sorted_mergeSort : ∀ l : List α, Sorted r (mergeSort r l)
     cases' e : split (a :: b :: l) with l₁ l₂
     cases' length_split_lt e with h₁ h₂
     rw [mergeSort_cons_cons r e]
-    exact (sorted_mergeSort l₁).merge (sorted_mergeSort l₂)
+    exact (sorted_mergeSort l₁).merge' (sorted_mergeSort l₂)
   termination_by l => length l
 #align list.sorted_merge_sort List.sorted_mergeSort
 


### PR DESCRIPTION
Std has added a different definition with the same name in https://github.com/leanprover/std4/pull/579. It is easier to preemptively rename the version in mathlib.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
