### PR TITLE
[Merged by Bors] - perf(Algebra.Homology.Bifunctor): minor rearrangement to proofs

### DIFF
--- a/Mathlib/Algebra/Homology/Bifunctor.lean
+++ b/Mathlib/Algebra/Homology/Bifunctor.lean
@@ -21,6 +21,8 @@ bicomplex `(((F.mapBifunctorHomologicalComplex c₁ c₂).obj K₁).obj K₂)`.
 
 -/
 
+set_option profiler true
+
 open CategoryTheory Limits
 
 variable {C₁ C₂ D : Type*} [Category C₁] [Category C₂] [Category D]
@@ -59,12 +61,13 @@ def mapBifunctorHomologicalComplexObj (K₁ : HomologicalComplex C₁ c₁) :
         dsimp
         rw [NatTrans.naturality])
   map {K₂ K₂' φ} := HomologicalComplex₂.homMk
-      (((GradedObject.mapBifunctor F I₁ I₂).obj K₁.X).map φ.f) (by simp) (by
-        intros
-        dsimp
-        simp only [← Functor.map_comp, φ.comm])
-  map_id K₂ := by ext; dsimp; rw [Functor.map_id]
-  map_comp f g := by ext; dsimp; rw [Functor.map_comp]
+      (((GradedObject.mapBifunctor F I₁ I₂).obj K₁.X).map φ.f)
+        (by dsimp; intros; rw [NatTrans.naturality]) (by
+          dsimp
+          intros
+          simp only [← Functor.map_comp, φ.comm])
+  map_id K₂ := by dsimp; ext; dsimp; rw [Functor.map_id]
+  map_comp f g := by dsimp; ext; dsimp; rw [Functor.map_comp]
 
 /-- Given a functor `F : C₁ ⥤ C₂ ⥤ D`, this is the bifunctor which sends
 `K₁ : HomologicalComplex C₁ c₁` and `K₂ : HomologicalComplex C₂ c₂` to the bicomplex

--- a/Mathlib/Algebra/Homology/Bifunctor.lean
+++ b/Mathlib/Algebra/Homology/Bifunctor.lean
@@ -21,7 +21,6 @@ bicomplex `(((F.mapBifunctorHomologicalComplex c₁ c₂).obj K₁).obj K₂)`.
 
 -/
 
-set_option profiler true
 
 open CategoryTheory Limits
 


### PR DESCRIPTION
Often cleaning up with `dsimp` before using other tactics can speed up unification checks in a proof. This is one such example speeding up this file by 30% on my machine.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
