### PR TITLE
perf: small speedup

### DIFF
--- a/Mathlib/Algebra/Group/InjSurj.lean
+++ b/Mathlib/Algebra/Group/InjSurj.lean
@@ -183,7 +183,10 @@ admits an injective map that preserves `0` and `+` to an additive commutative mo
 protected def commMonoid [CommMonoid M₂] (f : M₁ → M₂) (hf : Injective f) (one : f 1 = 1)
     (mul : ∀ x y, f (x * y) = f x * f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n) :
     CommMonoid M₁ :=
-  { hf.commSemigroup f mul, hf.monoid f one mul npow with }
+  { toMonoid := hf.monoid f one mul npow
+    mul_comm := (hf.commSemigroup f mul).mul_comm
+  }
+--  { hf.commSemigroup f mul, hf.monoid f one mul npow with }
 #align function.injective.comm_monoid Function.Injective.commMonoid
 #align function.injective.add_comm_monoid Function.Injective.addCommMonoid
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is the same content as #6530, which I apparently messed up by doing the Wrong Kind Of Merge. Removing a "with" gave [this](https://github.com/leanprover-community/mathlib4/pull/6530#issuecomment-1962422265) as a speedup, but Johan suggested waiting for the next Lean release to see if it still had any effect. That release came, I messed up with the merge, so I've opened a new PR rather than rewriting history.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
