### PR TITLE
[Merged by Bors] - refactor(Data.Finset.Card): termination_by change

### DIFF
--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -145,7 +145,7 @@ theorem ack_strictMono_right : ∀ m, StrictMono (ack m)
     rw [ack_succ_succ, ack_succ_succ]
     apply ack_strictMono_right _ (ack_strictMono_right _ _)
     rwa [add_lt_add_iff_right] at h
-  termination_by m x y h => (m, x)
+  termination_by m x => (m, x)
 #align ack_strict_mono_right ack_strictMono_right
 
 theorem ack_mono_right (m : ℕ) : Monotone (ack m) :=

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -799,7 +799,7 @@ protected lemma Nonempty.strong_induction {p : ∀ s, s.Nonempty → Prop}
     · refine h₁ hs fun t ht hts ↦ ?_
       have := card_lt_card hts
       exact ht.strong_induction h₀ h₁
-termination_by Finset.card ‹_›
+termination_by s => Finset.card s
 
 /-- Suppose that, given that `p t` can be defined on all supersets of `s` of cardinality less than
 `n`, one knows how to define `p s`. Then one can inductively define `p s` for all finsets `s` of

--- a/Mathlib/Data/Polynomial/Div.lean
+++ b/Mathlib/Data/Polynomial/Div.lean
@@ -256,7 +256,7 @@ theorem modByMonic_eq_sub_mul_div :
       unfold modByMonic divByMonic divModByMonicAux
       dsimp
       rw [dif_pos hq, if_neg h, dif_pos hq, if_neg h, mul_zero, sub_zero]
-  termination_by p q hq => p
+  termination_by p => p
 #align polynomial.mod_by_monic_eq_sub_mul_div Polynomial.modByMonic_eq_sub_mul_div
 
 theorem modByMonic_add_div (p : R[X]) {q : R[X]} (hq : Monic q) : p %ₘ q + q * (p /ₘ q) = p :=

--- a/Mathlib/Data/Polynomial/Div.lean
+++ b/Mathlib/Data/Polynomial/Div.lean
@@ -112,7 +112,7 @@ noncomputable def divModByMonicAux : ∀ (_p : R[X]) {q : R[X]}, Monic q → R[X
       let dm := divModByMonicAux (p - q * z) hq
       ⟨z + dm.1, dm.2⟩
     else ⟨0, p⟩
-  termination_by p q hq => p
+  termination_by p => p
 #align polynomial.div_mod_by_monic_aux Polynomial.divModByMonicAux
 
 /-- `divByMonic` gives the quotient of `p` by a monic polynomial `q`. -/

--- a/Mathlib/Data/Polynomial/Div.lean
+++ b/Mathlib/Data/Polynomial/Div.lean
@@ -160,7 +160,7 @@ theorem degree_modByMonic_lt [Nontrivial R] :
           dsimp
           rw [dif_pos hq, if_neg h, Classical.not_not.1 hp]
           exact lt_of_le_of_ne bot_le (Ne.symm (mt degree_eq_bot.1 hq.ne_zero)))
-  termination_by p q hq => p
+  termination_by p => p
 #align polynomial.degree_mod_by_monic_lt Polynomial.degree_modByMonic_lt
 
 theorem natDegree_modByMonic_lt (p : R[X]) {q : R[X]} (hmq : Monic q) (hq : q ≠ 1) :

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1664,7 +1664,7 @@ def Relabelling.addCongr : ∀ {w x y z : PGame.{u}}, w ≡r x → y ≡r z → 
     · exact Hwx.addCongr (hL₂ j)
     · exact (hR₁ i).addCongr Hyz
     · exact Hwx.addCongr (hR₂ j)
-termination_by w x y z => (x, z)
+termination_by _ x _ z => (x, z)
 #align pgame.relabelling.add_congr SetTheory.PGame.Relabelling.addCongr
 
 instance : Sub PGame :=


### PR DESCRIPTION
this will break once https://github.com/leanprover/lean4/pull/3658
lands, so let's fix this now.

Also avoids binding unused variables in `termination_by`.