### PR TITLE
[Merged by Bors] - fix: rename `LocallyFiniteOrderTop.ofIic` to `LocallyFiniteOrderBot`

### DIFF
--- a/Mathlib/Data/Pi/Interval.lean
+++ b/Mathlib/Data/Pi/Interval.lean
@@ -61,7 +61,7 @@ section LocallyFiniteOrderBot
 variable [∀ i, LocallyFiniteOrderBot (α i)] (b : ∀ i, α i)
 
 instance instLocallyFiniteOrderBot : LocallyFiniteOrderBot (∀ i, α i) :=
-  LocallyFiniteOrderTop.ofIic _ (fun b => piFinset fun i => Iic (b i)) fun b x => by
+  LocallyFiniteOrderBot.ofIic _ (fun b => piFinset fun i => Iic (b i)) fun b x => by
     simp_rw [mem_piFinset, mem_Iic, le_def]
 
 theorem card_Iic : (Iic b).card = ∏ i, (Iic (b i)).card :=

--- a/Mathlib/Data/Pi/Interval.lean
+++ b/Mathlib/Data/Pi/Interval.lean
@@ -61,7 +61,7 @@ section LocallyFiniteOrderBot
 variable [∀ i, LocallyFiniteOrderBot (α i)] (b : ∀ i, α i)
 
 instance instLocallyFiniteOrderBot : LocallyFiniteOrderBot (∀ i, α i) :=
-  LocallyFiniteOrderBot.ofIic _ (fun b => piFinset fun i => Iic (b i)) fun b x => by
+  .ofIic _ (fun b => piFinset fun i => Iic (b i)) fun b x => by
     simp_rw [mem_piFinset, mem_Iic, le_def]
 
 theorem card_Iic : (Iic b).card = ∏ i, (Iic (b i)).card :=

--- a/Mathlib/Order/LocallyFinite.lean
+++ b/Mathlib/Order/LocallyFinite.lean
@@ -239,7 +239,7 @@ def LocallyFiniteOrderBot.ofIic (α : Type*) [PartialOrder α] [DecidableEq α]
     finsetIio := fun a => (finsetIic a).filter fun x => x ≠ a
     finset_mem_Iic := mem_Iic
     finset_mem_Iio := fun a x => by rw [mem_filter, mem_Iic, lt_iff_le_and_ne] }
--- Note: this is in the wrong namespace in Mathlib 3.
+-- Note: this was in the wrong namespace in Mathlib 3.
 #align locally_finite_order_top.of_Iic LocallyFiniteOrderBot.ofIic
 
 variable {α β : Type*}

--- a/Mathlib/Order/LocallyFinite.lean
+++ b/Mathlib/Order/LocallyFinite.lean
@@ -193,7 +193,7 @@ def LocallyFiniteOrder.ofIcc (α : Type*) [PartialOrder α] [DecidableEq α]
       rw [Finset.mem_filter, mem_Icc, and_and_and_comm, lt_iff_le_and_ne, lt_iff_le_and_ne] }
 #align locally_finite_order.of_Icc LocallyFiniteOrder.ofIcc
 
-/-- A constructor from a definition of `Finset.Iic` alone, the other ones being derived by removing
+/-- A constructor from a definition of `Finset.Ici` alone, the other ones being derived by removing
 the ends. As opposed to `LocallyFiniteOrderTop.ofIci`, this one requires `DecidableRel (· ≤ ·)` but
 only `Preorder`. -/
 def LocallyFiniteOrderTop.ofIci' (α : Type*) [Preorder α] [DecidableRel ((· ≤ ·) : α → α → Prop)]
@@ -205,7 +205,7 @@ def LocallyFiniteOrderTop.ofIci' (α : Type*) [Preorder α] [DecidableRel ((· �
     finset_mem_Ioi := fun a x => by rw [mem_filter, mem_Ici, lt_iff_le_not_le] }
 #align locally_finite_order_top.of_Ici' LocallyFiniteOrderTop.ofIci'
 
-/-- A constructor from a definition of `Finset.Iic` alone, the other ones being derived by removing
+/-- A constructor from a definition of `Finset.Ici` alone, the other ones being derived by removing
 the ends. As opposed to `LocallyFiniteOrderTop.ofIci'`, this one requires `PartialOrder` but
 only `DecidableEq`. -/
 def LocallyFiniteOrderTop.ofIci (α : Type*) [PartialOrder α] [DecidableEq α]
@@ -218,7 +218,7 @@ def LocallyFiniteOrderTop.ofIci (α : Type*) [PartialOrder α] [DecidableEq α]
 #align locally_finite_order_top.of_Ici LocallyFiniteOrderTop.ofIci
 
 /-- A constructor from a definition of `Finset.Iic` alone, the other ones being derived by removing
-the ends. As opposed to `LocallyFiniteOrder.ofIcc`, this one requires `DecidableRel (· ≤ ·)` but
+the ends. As opposed to `LocallyFiniteOrderBot.ofIic`, this one requires `DecidableRel (· ≤ ·)` but
 only `Preorder`. -/
 def LocallyFiniteOrderBot.ofIic' (α : Type*) [Preorder α] [DecidableRel ((· ≤ ·) : α → α → Prop)]
     (finsetIic : α → Finset α) (mem_Iic : ∀ a x, x ∈ finsetIic a ↔ x ≤ a) :
@@ -230,16 +230,17 @@ def LocallyFiniteOrderBot.ofIic' (α : Type*) [Preorder α] [DecidableRel ((· �
 #align locally_finite_order_bot.of_Iic' LocallyFiniteOrderBot.ofIic'
 
 /-- A constructor from a definition of `Finset.Iic` alone, the other ones being derived by removing
-the ends. As opposed to `LocallyFiniteOrderTop.ofIci'`, this one requires `PartialOrder` but
+the ends. As opposed to `LocallyFiniteOrderBot.ofIic'`, this one requires `PartialOrder` but
 only `DecidableEq`. -/
-def LocallyFiniteOrderTop.ofIic (α : Type*) [PartialOrder α] [DecidableEq α]
+def LocallyFiniteOrderBot.ofIic (α : Type*) [PartialOrder α] [DecidableEq α]
     (finsetIic : α → Finset α) (mem_Iic : ∀ a x, x ∈ finsetIic a ↔ x ≤ a) :
     LocallyFiniteOrderBot α :=
   { finsetIic
     finsetIio := fun a => (finsetIic a).filter fun x => x ≠ a
     finset_mem_Iic := mem_Iic
     finset_mem_Iio := fun a x => by rw [mem_filter, mem_Iic, lt_iff_le_and_ne] }
-#align locally_finite_order_top.of_Iic LocallyFiniteOrderTop.ofIic
+-- Note: this is in the wrong namespace in Mathlib 3.
+#align locally_finite_order_top.of_Iic LocallyFiniteOrderBot.ofIic
 
 variable {α β : Type*}
 


### PR DESCRIPTION
It's about `LocallyFiniteOrderBot`, so the current name is simply wrong.

Also fix documentation mistakes. These errors were already present in Mathlib 3, before the port.

---

It appears that these are simply minor slips that were not noticed during review.
* Introduced in [mathlib3#14430](https://github.com/leanprover-community/mathlib/pull/14430)
* Ported in #1754

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
