### PR TITLE
[Merged by Bors] - feat: DFA.acceptsFrom, DFA.map, DFA.equiv

### DIFF
--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -56,8 +56,8 @@ instance [Inhabited σ] : Inhabited (DFA α σ) :=
   ⟨DFA.mk (fun _ _ => default) default ∅⟩
 
 /-- `M.evalFrom s x` evaluates `M` with input `x` starting from the state `s`. -/
-def evalFrom (start : σ) : List α → σ :=
-  List.foldl M.step start
+def evalFrom (s : σ) : List α → σ :=
+  List.foldl M.step s
 #align DFA.eval_from DFA.evalFrom
 
 @[simp]
@@ -102,12 +102,12 @@ theorem evalFrom_of_append (start : σ) (x y : List α) :
 #align DFA.eval_from_of_append DFA.evalFrom_of_append
 
 /--
-`M.acceptsFrom start` is the language of `x` such that `M.evalFrom start x` is an accept state.
+`M.acceptsFrom s` is the language of `x` such that `M.evalFrom s x` is an accept state.
 -/
-def acceptsFrom (start : σ) : Language α := {x | M.evalFrom start x ∈ M.accept}
+def acceptsFrom (s : σ) : Language α := {x | M.evalFrom start x ∈ M.accept}
 
-theorem mem_acceptsFrom {start : σ} {x : List α} :
-    x ∈ M.acceptsFrom start ↔ M.evalFrom start x ∈ M.accept := by rfl
+theorem mem_acceptsFrom {s : σ} {x : List α} :
+    x ∈ M.acceptsFrom s ↔ M.evalFrom s x ∈ M.accept := by rfl
 
 /-- `M.accepts` is the language of `x` such that `M.eval x` is an accept state. -/
 def accepts : Language α := M.acceptsFrom M.start

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -215,7 +215,6 @@ section Reindex
 variable {σ' : Type*} (g : σ ≃ σ')
 
 /-- Lifts an equivalence on states to an equivalence on DFAs. -/
-@[simps]
 def reindex : DFA α σ ≃ DFA α σ' where
   toFun M := {
     step := fun s a => g (M.step (g.symm s) a)
@@ -235,6 +234,15 @@ theorem reindex_refl : reindex (Equiv.refl σ) M = M := rfl
 
 @[simp]
 theorem reindex_symm : (reindex (α := α) g).symm = reindex g.symm := rfl
+
+@[simp]
+theorem reindex_step (s : σ') (a : α) : (reindex g M).step s a = g (M.step (g.symm s) a) := rfl
+
+@[simp]
+theorem reindex_start : (reindex g M).start = g M.start := rfl
+
+@[simp]
+theorem reindex_accept : (reindex g M).accept = g.symm ⁻¹' M.accept := rfl
 
 @[simp]
 theorem reindex_evalFrom (s : σ') (x : List α) :

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -96,14 +96,14 @@ theorem evalFrom_of_append (start : σ) (x y : List α) :
 -/
 def acceptsFrom (start : σ) : Language α := {x | M.evalFrom start x ∈ M.accept}
 
-theorem mem_acceptsFrom (start : σ) (x : List α) :
+theorem mem_acceptsFrom {start : σ} {x : List α} :
     x ∈ M.acceptsFrom start ↔ M.evalFrom start x ∈ M.accept := by rfl
 
 /-- `M.accepts` is the language of `x` such that `M.eval x` is an accept state. -/
 def accepts : Language α := M.acceptsFrom M.start
 #align DFA.accepts DFA.accepts
 
-theorem mem_accepts (x : List α) : x ∈ M.accepts ↔ M.eval x ∈ M.accept := by rfl
+theorem mem_accepts {x : List α} : x ∈ M.accepts ↔ M.eval x ∈ M.accept := by rfl
 #align DFA.mem_accepts DFA.mem_accepts
 
 theorem evalFrom_split [Fintype σ] {x : List α} {s t : σ} (hlen : Fintype.card σ ≤ x.length)

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -178,7 +178,10 @@ section Maps
 
 variable {α' σ' : Type*} (f : α' → α) (g : σ ≃ σ')
 
-/-- Transforms the alphabet of a DFA. -/
+/--
+`M.comap f` pulls back the alphabet of `M` along `f`. In other words, it applies `f` to the input
+before passing it to `M`.
+-/
 @[simps]
 def comap : DFA α' σ where
   step s a := M.step s (f a)

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -18,6 +18,16 @@ determines whether a string (implemented as a list over an arbitrary alphabet) i
 in linear time.
 Note that this definition allows for Automaton with infinite states, a `Fintype` instance must be
 supplied for true DFA's.
+
+## Implementation notes
+
+Currently, there are two disjoint sets of simp lemmas: one for `DFA.eval`, and another for
+`DFA.evalFrom`. You can switch from the former to the latter using `simp [eval]`.
+
+TODO:
+- Should we unify these simp sets, such that `eval` is rewritten to `evalFrom` automatically?
+- Should `mem_accepts` and `mem_acceptsFrom` be marked `@[simp]`? This depends on the question
+  above, as they map to `eval` and `evalFrom` respectively.
 -/
 
 

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -174,9 +174,9 @@ theorem pumping_lemma [Fintype σ] {x : List α} (hx : x ∈ M.accepts)
   rwa [mem_accepts, eval, evalFrom_of_append, evalFrom_of_append, h, hc]
 #align DFA.pumping_lemma DFA.pumping_lemma
 
-section Comap
+section Maps
 
-variable {α' : Type*} (f : α' → α)
+variable {α' σ' : Type*} (f : α' → α) (g : σ ≃ σ')
 
 /-- Transforms the alphabet of a DFA. -/
 @[simps]
@@ -205,12 +205,6 @@ theorem comap_accepts : (M.comap f).accepts = List.map f ⁻¹' M.accepts := by
     rhs
     rw [Set.mem_preimage, mem_accepts]
   simp [mem_accepts]
-
-end Comap
-
-section Reindex
-
-variable {σ' : Type*} (g : σ ≃ σ')
 
 /-- Lifts an equivalence on states to an equivalence on DFAs. -/
 @[simps apply_step apply_start apply_accept]
@@ -249,6 +243,8 @@ theorem reindex_accepts : (reindex g M).accepts = M.accepts := by
   ext x
   simp [mem_accepts]
 
-end Reindex
+theorem reindex_comap : (reindex g M).comap f = reindex g (M.comap f) := by simp [comap, reindex]
+
+end Maps
 
 end DFA

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -24,10 +24,10 @@ supplied for true DFA's.
 Currently, there are two disjoint sets of simp lemmas: one for `DFA.eval`, and another for
 `DFA.evalFrom`. You can switch from the former to the latter using `simp [eval]`.
 
-TODO:
+## TODO
+
 - Should we unify these simp sets, such that `eval` is rewritten to `evalFrom` automatically?
-- Should `mem_accepts` and `mem_acceptsFrom` be marked `@[simp]`? This depends on the question
-  above, as they map to `eval` and `evalFrom` respectively.
+- Should `mem_accepts` and `mem_acceptsFrom` be marked `@[simp]`?
 -/
 
 

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -186,14 +186,14 @@ theorem pumping_lemma [Fintype σ] {x : List α} (hx : x ∈ M.accepts)
 
 section Maps
 
-variable {α' σ' : Type*} (f : α' → α) (g : σ ≃ σ')
+variable {α' σ' : Type*}
 
 /--
 `M.comap f` pulls back the alphabet of `M` along `f`. In other words, it applies `f` to the input
 before passing it to `M`.
 -/
 @[simps]
-def comap : DFA α' σ where
+def comap (f : α' → α) : DFA α' σ where
   step s a := M.step s (f a)
   start := M.start
   accept := M.accept
@@ -202,17 +202,18 @@ def comap : DFA α' σ where
 theorem comap_id : M.comap id = M := rfl
 
 @[simp]
-theorem evalFrom_comap (s : σ) (x : List α') :
+theorem evalFrom_comap (f : α' → α) (s : σ) (x : List α') :
     (M.comap f).evalFrom s x = M.evalFrom s (x.map f) := by
   induction x using List.list_reverse_induction with
   | base => simp
   | ind x a ih => simp [ih]
 
 @[simp]
-theorem eval_comap (x : List α') : (M.comap f).eval x = M.eval (x.map f) := by simp [eval]
+theorem eval_comap (f : α' → α) (x : List α') : (M.comap f).eval x = M.eval (x.map f) := by
+  simp [eval]
 
 @[simp]
-theorem accepts_comap : (M.comap f).accepts = List.map f ⁻¹' M.accepts := by
+theorem accepts_comap (f : α' → α) : (M.comap f).accepts = List.map f ⁻¹' M.accepts := by
   ext x
   conv =>
     rhs
@@ -221,7 +222,7 @@ theorem accepts_comap : (M.comap f).accepts = List.map f ⁻¹' M.accepts := by
 
 /-- Lifts an equivalence on states to an equivalence on DFAs. -/
 @[simps apply_step apply_start apply_accept]
-def reindex : DFA α σ ≃ DFA α σ' where
+def reindex (g : σ ≃ σ') : DFA α σ ≃ DFA α σ' where
   toFun M := {
     step := fun s a => g (M.step (g.symm s) a)
     start := g M.start
@@ -239,24 +240,27 @@ def reindex : DFA α σ ≃ DFA α σ' where
 theorem reindex_refl : reindex (Equiv.refl σ) M = M := rfl
 
 @[simp]
-theorem symm_reindex : (reindex (α := α) g).symm = reindex g.symm := rfl
+theorem symm_reindex (g : σ ≃ σ') : (reindex (α := α) g).symm = reindex g.symm := rfl
 
 @[simp]
-theorem evalFrom_reindex (s : σ') (x : List α) :
+theorem evalFrom_reindex (g : σ ≃ σ') (s : σ') (x : List α) :
     (reindex g M).evalFrom s x = g (M.evalFrom (g.symm s) x) := by
   induction x using List.list_reverse_induction with
   | base => simp
   | ind x a ih => simp [ih]
 
 @[simp]
-theorem eval_reindex (x : List α) : (reindex g M).eval x = g (M.eval x) := by simp [eval]
+theorem eval_reindex (g : σ ≃ σ') (x : List α) : (reindex g M).eval x = g (M.eval x) := by
+  simp [eval]
 
 @[simp]
-theorem accepts_reindex : (reindex g M).accepts = M.accepts := by
+theorem accepts_reindex (g : σ ≃ σ') : (reindex g M).accepts = M.accepts := by
   ext x
   simp [mem_accepts]
 
-theorem comap_reindex : (reindex g M).comap f = reindex g (M.comap f) := by simp [comap, reindex]
+theorem comap_reindex (f : α' → α) (g : σ ≃ σ') :
+    (reindex g M).comap f = reindex g (M.comap f) := by
+  simp [comap, reindex]
 
 end Maps
 

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -215,6 +215,7 @@ section Reindex
 variable {σ' : Type*} (g : σ ≃ σ')
 
 /-- Lifts an equivalence on states to an equivalence on DFAs. -/
+@[simps]
 def reindex : DFA α σ ≃ DFA α σ' where
   toFun M := {
     step := fun s a => g (M.step (g.symm s) a)
@@ -234,15 +235,6 @@ theorem reindex_refl : reindex (Equiv.refl σ) M = M := rfl
 
 @[simp]
 theorem reindex_symm : (reindex (α := α) g).symm = reindex g.symm := rfl
-
-@[simp]
-theorem reindex_step (s : σ') (a : α) : (reindex g M).step s a = g (M.step (g.symm s) a) := rfl
-
-@[simp]
-theorem reindex_start : (reindex g M).start = g M.start := rfl
-
-@[simp]
-theorem reindex_accept : (reindex g M).accept = g.symm ⁻¹' M.accept := rfl
 
 @[simp]
 theorem reindex_evalFrom (s : σ') (x : List α) :

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -104,9 +104,7 @@ def accepts : Language α := M.acceptsFrom M.start
 #align DFA.accepts DFA.accepts
 
 theorem mem_accepts (x : List α) : x ∈ M.accepts ↔ M.eval x ∈ M.accept := by rfl
-
-theorem mem_accepts' (x : List α) : x ∈ M.accepts ↔ M.evalFrom M.start x ∈ M.accept := by rfl
-#align DFA.mem_accepts DFA.mem_accepts'
+#align DFA.mem_accepts DFA.mem_accepts
 
 theorem evalFrom_split [Fintype σ] {x : List α} {s t : σ} (hlen : Fintype.card σ ≤ x.length)
     (hx : M.evalFrom s x = t) :
@@ -173,7 +171,7 @@ theorem pumping_lemma [Fintype σ] {x : List α} (hx : x ∈ M.accepts)
   rw [Set.mem_singleton_iff] at ha' hc'
   substs ha' hc'
   have h := M.evalFrom_of_pow hb hb'
-  rwa [mem_accepts', evalFrom_of_append, evalFrom_of_append, h, hc]
+  rwa [mem_accepts, eval, evalFrom_of_append, evalFrom_of_append, h, hc]
 #align DFA.pumping_lemma DFA.pumping_lemma
 
 section Comap

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -193,7 +193,7 @@ variable {α' σ' : Type*}
 before passing it to `M`.
 -/
 @[simps]
-def comap (f : α' → α) : DFA α' σ where
+def comap (f : α' → α) (M : DFA α σ) : DFA α' σ where
   step s a := M.step s (f a)
   start := M.start
   accept := M.accept

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -189,17 +189,17 @@ def comap : DFA α' σ where
 theorem comap_id : M.comap id = M := rfl
 
 @[simp]
-theorem comap_evalFrom (s : σ) (x : List α') :
+theorem evalFrom_comap (s : σ) (x : List α') :
     (M.comap f).evalFrom s x = M.evalFrom s (x.map f) := by
   induction x using List.list_reverse_induction with
   | base => simp
   | ind x a ih => simp [ih]
 
 @[simp]
-theorem comap_eval (x : List α') : (M.comap f).eval x = M.eval (x.map f) := by simp [eval]
+theorem eval_comap (x : List α') : (M.comap f).eval x = M.eval (x.map f) := by simp [eval]
 
 @[simp]
-theorem comap_accepts : (M.comap f).accepts = List.map f ⁻¹' M.accepts := by
+theorem accepts_comap : (M.comap f).accepts = List.map f ⁻¹' M.accepts := by
   ext x
   conv =>
     rhs
@@ -226,24 +226,24 @@ def reindex : DFA α σ ≃ DFA α σ' where
 theorem reindex_refl : reindex (Equiv.refl σ) M = M := rfl
 
 @[simp]
-theorem reindex_symm : (reindex (α := α) g).symm = reindex g.symm := rfl
+theorem symm_reindex : (reindex (α := α) g).symm = reindex g.symm := rfl
 
 @[simp]
-theorem reindex_evalFrom (s : σ') (x : List α) :
+theorem evalFrom_reindex (s : σ') (x : List α) :
     (reindex g M).evalFrom s x = g (M.evalFrom (g.symm s) x) := by
   induction x using List.list_reverse_induction with
   | base => simp
   | ind x a ih => simp [ih]
 
 @[simp]
-theorem reindex_eval (x : List α) : (reindex g M).eval x = g (M.eval x) := by simp [eval]
+theorem eval_reindex (x : List α) : (reindex g M).eval x = g (M.eval x) := by simp [eval]
 
 @[simp]
-theorem reindex_accepts : (reindex g M).accepts = M.accepts := by
+theorem accepts_reindex : (reindex g M).accepts = M.accepts := by
   ext x
   simp [mem_accepts]
 
-theorem reindex_comap : (reindex g M).comap f = reindex g (M.comap f) := by simp [comap, reindex]
+theorem comap_reindex : (reindex g M).comap f = reindex g (M.comap f) := by simp [comap, reindex]
 
 end Maps
 

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -215,6 +215,7 @@ section Reindex
 variable {σ' : Type*} (g : σ ≃ σ')
 
 /-- Lifts an equivalence on states to an equivalence on DFAs. -/
+@[simps apply_step apply_start apply_accept]
 def reindex : DFA α σ ≃ DFA α σ' where
   toFun M := {
     step := fun s a => g (M.step (g.symm s) a)
@@ -234,15 +235,6 @@ theorem reindex_refl : reindex (Equiv.refl σ) M = M := rfl
 
 @[simp]
 theorem reindex_symm : (reindex (α := α) g).symm = reindex g.symm := rfl
-
-@[simp]
-theorem reindex_step (s : σ') (a : α) : (reindex g M).step s a = g (M.step (g.symm s) a) := rfl
-
-@[simp]
-theorem reindex_start : (reindex g M).start = g M.start := rfl
-
-@[simp]
-theorem reindex_accept : (reindex g M).accept = g.symm ⁻¹' M.accept := rfl
 
 @[simp]
 theorem reindex_evalFrom (s : σ') (x : List α) :

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -104,7 +104,7 @@ theorem evalFrom_of_append (start : σ) (x y : List α) :
 /--
 `M.acceptsFrom s` is the language of `x` such that `M.evalFrom s x` is an accept state.
 -/
-def acceptsFrom (s : σ) : Language α := {x | M.evalFrom start x ∈ M.accept}
+def acceptsFrom (s : σ) : Language α := {x | M.evalFrom s x ∈ M.accept}
 
 theorem mem_acceptsFrom {s : σ} {x : List α} :
     x ∈ M.acceptsFrom s ↔ M.evalFrom s x ∈ M.accept := by rfl


### PR DESCRIPTION
`acceptsFrom` is used in #11311 to define left quotients.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
