### PR TITLE
[Merged by Bors] - feat: add `fermatLastTheoremWith_of_fermatLastTheoremWith_coprime`

### DIFF
--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -125,7 +125,7 @@ open Finset in
 that the `gcd` of `{a, b, c}` is a unit. -/
 lemma fermatLastTheoremWith_of_FermatLastTheoremWith_coprime {n : ℕ} {R : Type*} [CommSemiring R]
     [IsDomain R] [DecidableEq R] [NormalizedGCDMonoid R]
-    (hn : ∀ a b c : R, a ≠ 0 → b ≠ 0 → c ≠ 0 → IsUnit (({a, b, c} : Finset R).gcd id) →
+    (hn : ∀ a b c : R, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset R).gcd id = 1 →
       a ^ n + b ^ n ≠ c ^ n) :
     FermatLastTheoremWith R n := by
   intro a b c ha hb hc habc

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -133,29 +133,14 @@ lemma fermatLastTheoremWith_of_FermatLastTheoremWith_coprime {n : ℕ} {R : Type
   obtain ⟨A, hA⟩ : d ∣ a := gcd_dvd (by simp [s])
   obtain ⟨B, hB⟩ : d ∣ b := gcd_dvd (by simp [s])
   obtain ⟨C, hC⟩ : d ∣ c := gcd_dvd (by simp [s])
-  have hdzero : d ≠ 0 := fun hdzero => by
-      simpa [ha] using Finset.gcd_eq_zero_iff.1 hdzero a (by simp [s])
-  have hdn : d ^ n ≠ 0 := fun hdn => hdzero (pow_eq_zero hdn)
-  refine hn A B C (fun h ↦ ha <| by simpa [h] using hA) (fun h ↦ hb <| by simpa [h] using hB)
-    (fun h ↦ hc <| by simpa [h] using hC) ?_ ?_
-  · have : d = (GCDMonoid.gcd a (GCDMonoid.gcd b (c * ↑(normUnit c)))) := by
-      simp only [d]
-      rw [gcd_insert, id_eq]
-      simp only [gcd_insert, id_eq, gcd_singleton, normalize_apply]
-    simp only [gcd_insert, id_eq, gcd_singleton, normalize_apply]
-    apply isUnit_gcd_of_eq_mul_gcd (x := a) (y := GCDMonoid.gcd b (c * (normUnit c)))
-    · rw [← this, hA]
-    · have H := Finset.normalize_gcd (s := s) (f := id)
-      rw [← this, hB, hC, mul_assoc, _root_.gcd_mul_left, H,
-        normUnit_mul hdzero fun h ↦ hc <| by simp [h, hC]]
-      congr 3
-      simp only [Units.val_mul, ne_eq, Units.ne_zero, not_false_eq_true, mul_eq_right₀,
-        Units.val_eq_one]
-      nth_rewrite 2 [← mul_one (s.gcd id)] at H
-      exact Units.ext <| by simpa using mul_left_cancel₀ hdzero H
-    · simp [hc]
-  · rw [hA, hB, hC, mul_pow, mul_pow, mul_pow, ← mul_add] at habc
-    simpa [hdn] using habc
+  simp only [hA, hB, hC, mul_ne_zero_iff, mul_pow] at ha hb hc habc
+  rw [← mul_add, mul_right_inj' (pow_ne_zero n ha.1)] at habc
+  refine hn A B C ha.2 hb.2 hc.2 ?_ habc
+  rw [← Finset.normalize_gcd, normalize_eq_one]
+  obtain ⟨u, hu⟩ := normalize_associated d
+  refine ⟨u, mul_left_cancel₀ (mt normalize_eq_zero.mp ha.1) (hu.symm ▸ ?_)⟩
+  rw [← Finset.gcd_mul_left, gcd_eq_gcd_image, image_insert, image_insert, image_singleton,
+      id_eq, id_eq, id_eq, ← hA, ← hB, ← hC]
 
 /-- To prove Fermat Last Theorem for `ℤ` one can assume that `a`, `b` and `c` are coprime, in the
 sense that the gcd of `{a, b, c}` is `1`. -/

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -122,7 +122,7 @@ lemma fermatLastTheoremFor_iff_rat {n : ℕ} : FermatLastTheoremFor n ↔ Fermat
 
 open Finset in
 /-- To prove Fermat Last Theorem in any semiring that is a `NormalizedGCDMonoid` one can assume
-that the `gcd` of `{a, b, c}` is a unit. -/
+that the `gcd` of `{a, b, c}` is `1`. -/
 lemma fermatLastTheoremWith_of_FermatLastTheoremWith_coprime {n : ℕ} {R : Type*} [CommSemiring R]
     [IsDomain R] [DecidableEq R] [NormalizedGCDMonoid R]
     (hn : ∀ a b c : R, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset R).gcd id = 1 →

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -123,7 +123,7 @@ lemma fermatLastTheoremFor_iff_rat {n : ℕ} : FermatLastTheoremFor n ↔ Fermat
 open Finset in
 /-- To prove Fermat Last Theorem in any semiring that is a `NormalizedGCDMonoid` one can assume
 that the `gcd` of `{a, b, c}` is a unit. -/
-lemma FermatLastTheoremWith_of_FermatLastTheoremWith_coprime {n : ℕ} {R : Type*} [CommSemiring R]
+lemma fermatLastTheoremWith_of_FermatLastTheoremWith_coprime {n : ℕ} {R : Type*} [CommSemiring R]
     [IsDomain R] [DecidableEq R] [NormalizedGCDMonoid R]
     (hn : ∀ a b c : R, a ≠ 0 → b ≠ 0 → c ≠ 0 → IsUnit (({a, b, c} : Finset R).gcd id) →
       a ^ n + b ^ n ≠ c ^ n) :
@@ -163,7 +163,7 @@ lemma FermatLastTheoremWith_int_of_FermatLastTheoremWith_int_coprime {n : ℕ}
     (hn : ∀ a b c : ℤ, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset ℤ).gcd id = 1 →
       a ^ n + b ^ n ≠ c ^ n) :
     FermatLastTheoremWith ℤ n := by
-  refine FermatLastTheoremWith_of_FermatLastTheoremWith_coprime (R := ℤ)
+  refine fermatLastTheoremWith_of_FermatLastTheoremWith_coprime (R := ℤ)
     (fun a b c ha hb hc H h ↦ hn a b c ha hb hc ?_ h)
   rcases Int.isUnit_iff.1 H with (H | H)
   · exact H
@@ -175,5 +175,5 @@ lemma FermatLastTheoremFor_of_FermatLastTheoremFor_coprime {n : ℕ}
     (hn : ∀ a b c, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset ℕ).gcd id = 1 →
       a ^ n + b ^ n ≠ c ^ n) :
     FermatLastTheoremFor n :=
-  FermatLastTheoremWith_of_FermatLastTheoremWith_coprime (R := ℕ)
+  fermatLastTheoremWith_of_FermatLastTheoremWith_coprime (R := ℕ)
     (fun a b c ha hb hc H h ↦ hn a b c ha hb hc (by simpa using H) h)

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -122,7 +122,7 @@ lemma fermatLastTheoremFor_iff_rat {n : ℕ} : FermatLastTheoremFor n ↔ Fermat
 open Finset in
 /-- To prove Fermat Last Theorem in any semiring that is a `NormalizedGCDMonoid` one can assume
 that the `gcd` of `{a, b, c}` is `1`. -/
-lemma fermatLastTheoremWith_of_FermatLastTheoremWith_coprime {n : ℕ} {R : Type*} [CommSemiring R]
+lemma fermatLastTheoremWith_of_fermatLastTheoremWith_coprime {n : ℕ} {R : Type*} [CommSemiring R]
     [IsDomain R] [DecidableEq R] [NormalizedGCDMonoid R]
     (hn : ∀ a b c : R, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset R).gcd id = 1 →
       a ^ n + b ^ n ≠ c ^ n) :

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -148,8 +148,7 @@ lemma FermatLastTheoremWith_int_of_FermatLastTheoremWith_int_coprime {n : ℕ}
     (hn : ∀ a b c : ℤ, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset ℤ).gcd id = 1 →
       a ^ n + b ^ n ≠ c ^ n) :
     FermatLastTheoremWith ℤ n :=
-  fermatLastTheoremWith_of_FermatLastTheoremWith_coprime
-    (fun a b c ha hb hc H h ↦ hn a b c ha hb hc H h)
+  fermatLastTheoremWith_of_FermatLastTheoremWith_coprime hn
 
 /-- To prove Fermat Last Theorem one can assume that `a`, `b` and `c` are coprime, in the sense
 that the gcd of `{a, b, c}` is `1`. -/
@@ -157,5 +156,4 @@ lemma FermatLastTheoremFor_of_FermatLastTheoremFor_coprime {n : ℕ}
     (hn : ∀ a b c, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset ℕ).gcd id = 1 →
       a ^ n + b ^ n ≠ c ^ n) :
     FermatLastTheoremFor n :=
-  fermatLastTheoremWith_of_FermatLastTheoremWith_coprime (R := ℕ)
-    (fun a b c ha hb hc H h ↦ hn a b c ha hb hc (by simpa using H) h)
+  fermatLastTheoremWith_of_FermatLastTheoremWith_coprime hn

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -141,19 +141,3 @@ lemma fermatLastTheoremWith_of_FermatLastTheoremWith_coprime {n : ℕ} {R : Type
   refine ⟨u, mul_left_cancel₀ (mt normalize_eq_zero.mp ha.1) (hu.symm ▸ ?_)⟩
   rw [← Finset.gcd_mul_left, gcd_eq_gcd_image, image_insert, image_insert, image_singleton,
       id_eq, id_eq, id_eq, ← hA, ← hB, ← hC]
-
-/-- To prove Fermat Last Theorem for `ℤ` one can assume that `a`, `b` and `c` are coprime, in the
-sense that the gcd of `{a, b, c}` is `1`. -/
-lemma FermatLastTheoremWith_int_of_FermatLastTheoremWith_int_coprime {n : ℕ}
-    (hn : ∀ a b c : ℤ, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset ℤ).gcd id = 1 →
-      a ^ n + b ^ n ≠ c ^ n) :
-    FermatLastTheoremWith ℤ n :=
-  fermatLastTheoremWith_of_FermatLastTheoremWith_coprime hn
-
-/-- To prove Fermat Last Theorem one can assume that `a`, `b` and `c` are coprime, in the sense
-that the gcd of `{a, b, c}` is `1`. -/
-lemma FermatLastTheoremFor_of_FermatLastTheoremFor_coprime {n : ℕ}
-    (hn : ∀ a b c, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset ℕ).gcd id = 1 →
-      a ^ n + b ^ n ≠ c ^ n) :
-    FermatLastTheoremFor n :=
-  fermatLastTheoremWith_of_FermatLastTheoremWith_coprime hn

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -147,12 +147,9 @@ sense that the gcd of `{a, b, c}` is `1`. -/
 lemma FermatLastTheoremWith_int_of_FermatLastTheoremWith_int_coprime {n : ℕ}
     (hn : ∀ a b c : ℤ, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset ℤ).gcd id = 1 →
       a ^ n + b ^ n ≠ c ^ n) :
-    FermatLastTheoremWith ℤ n := by
-  refine fermatLastTheoremWith_of_FermatLastTheoremWith_coprime (R := ℤ)
-    (fun a b c ha hb hc H h ↦ hn a b c ha hb hc ?_ h)
-  rcases Int.isUnit_iff.1 H with (H | H)
-  · exact H
-  · simp at H
+    FermatLastTheoremWith ℤ n :=
+  fermatLastTheoremWith_of_FermatLastTheoremWith_coprime
+    (fun a b c ha hb hc H h ↦ hn a b c ha hb hc H h)
 
 /-- To prove Fermat Last Theorem one can assume that `a`, `b` and `c` are coprime, in the sense
 that the gcd of `{a, b, c}` is `1`. -/

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.GCDMonoid.Finset
 import Mathlib.Algebra.GroupPower.Ring
 import Mathlib.Data.Nat.Parity
 import Mathlib.Data.Rat.Defs
-import Mathlib.RingTheory.Int.Basic
 import Mathlib.Tactic.Positivity.Basic
 import Mathlib.Tactic.TFAE
 

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -123,20 +123,23 @@ lemma fermatLastTheoremFor_iff_rat {n : ℕ} : FermatLastTheoremFor n ↔ Fermat
 open Finset in
 /-- To prove Fermat Last Theorem one can assume that `a`, `b` and `c` are coprime. -/
 lemma FermatLastTheoremFor_of_FermatLastTheoremFor_coprime {n : ℕ}
-    (hn : ∀ a b c, ({a, b, c} : Finset ℕ).gcd id = 1 → a ^ n + b ^ n ≠ c ^ n) :
+    (hn : ∀ a b c, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset ℕ).gcd id = 1 →
+      a ^ n + b ^ n ≠ c ^ n) :
     FermatLastTheoremFor n := by
-  intro a b c ha _ _ habc
+  intro a b c ha hb hc habc
   let s : Finset ℕ := {a, b, c}; let d := s.gcd id
   have hadiv : d ∣ a := gcd_dvd (by simp [s])
   have hbdiv : d ∣ b := gcd_dvd (by simp [s])
   have hcdiv : d ∣ c := gcd_dvd (by simp [s])
-  refine hn (a / d) (b / d) (c / d) ?_ ?_
+  have hdzero : 0 < d := Nat.pos_of_ne_zero <| fun hdzero => by
+      simpa [ha] using Finset.gcd_eq_zero_iff.1 hdzero a (by simp [s])
+  have hdp : d ^ n ≠ 0 := fun hdn => hdzero.ne' (pow_eq_zero hdn)
+  refine hn (a / d) (b / d) (c / d) (fun h ↦ ha <| Nat.eq_zero_of_dvd_of_div_eq_zero hadiv h)
+    (fun h ↦ hb <| Nat.eq_zero_of_dvd_of_div_eq_zero hbdiv h)
+    (fun h ↦ hc <| Nat.eq_zero_of_dvd_of_div_eq_zero hcdiv h) ?_ ?_
   · simpa [gcd_eq_gcd_image, d] using
       Nat.gcd_div_id_eq_one (show a ∈ ({a, b, c} : Finset ℕ) by simp) ha
-  · have hdzero : 0 < d := Nat.pos_of_ne_zero <| fun hdzero => by
-      simpa [ha] using Finset.gcd_eq_zero_iff.1 hdzero a (by simp [s])
-    have hdp : d ^ n ≠ 0 := fun hdn => hdzero.ne' (pow_eq_zero hdn)
-    obtain ⟨na, hna⟩ := hadiv; obtain ⟨nb, hnb⟩ := hbdiv; obtain ⟨nc, hnc⟩ := hcdiv
+  · obtain ⟨na, hna⟩ := hadiv; obtain ⟨nb, hnb⟩ := hbdiv; obtain ⟨nc, hnc⟩ := hcdiv
     rwa [← mul_left_inj' hdp, add_mul, ← mul_pow, ← mul_pow, ← mul_pow, hna, hnb, hnc,
       Nat.mul_div_cancel_left _ hdzero, Nat.mul_div_cancel_left _ hdzero,
       Nat.mul_div_cancel_left _ hdzero, mul_comm, ← hna, mul_comm, ← hnb, mul_comm, ← hnc]

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -121,25 +121,60 @@ lemma fermatLastTheoremFor_iff_rat {n : ℕ} : FermatLastTheoremFor n ↔ Fermat
   (fermatLastTheoremWith_nat_int_rat_tfae n).out 0 2
 
 open Finset in
-/-- To prove Fermat Last Theorem one can assume that `a`, `b` and `c` are coprime. -/
+/-- To prove Fermat Last Theorem in any semiring that is a `NormalizedGCDMonoid` one can assume
+that the `gcd` of `{a, b, c}` is a unit. -/
+lemma FermatLastTheoremWith_of_FermatLastTheoremWith_coprime {n : ℕ} {R : Type*} [CommSemiring R]
+    [IsDomain R] [DecidableEq R] [NormalizedGCDMonoid R]
+    (hn : ∀ a b c : R, a ≠ 0 → b ≠ 0 → c ≠ 0 → IsUnit (({a, b, c} : Finset R).gcd id) →
+      a ^ n + b ^ n ≠ c ^ n) :
+    FermatLastTheoremWith R n := by
+  intro a b c ha hb hc habc
+  let s : Finset R := {a, b, c}; let d := s.gcd id
+  obtain ⟨A, hA⟩ : d ∣ a := gcd_dvd (by simp [s])
+  obtain ⟨B, hB⟩ : d ∣ b := gcd_dvd (by simp [s])
+  obtain ⟨C, hC⟩ : d ∣ c := gcd_dvd (by simp [s])
+  have hdzero : d ≠ 0 := fun hdzero => by
+      simpa [ha] using Finset.gcd_eq_zero_iff.1 hdzero a (by simp [s])
+  have hdn : d ^ n ≠ 0 := fun hdn => hdzero (pow_eq_zero hdn)
+  refine hn A B C (fun h ↦ ha <| by simpa [h] using hA) (fun h ↦ hb <| by simpa [h] using hB)
+    (fun h ↦ hc <| by simpa [h] using hC) ?_ ?_
+  · have : d = (GCDMonoid.gcd a (GCDMonoid.gcd b (c * ↑(normUnit c)))) := by
+      simp [d]
+      rw [gcd_insert, id_eq]
+      simp only [gcd_insert, id_eq, gcd_singleton, normalize_apply]
+    simp only [gcd_insert, id_eq, gcd_singleton, normalize_apply]
+    apply isUnit_gcd_of_eq_mul_gcd (x := a) (y := GCDMonoid.gcd b (c * ↑(normUnit c)))
+    · rw [← this, hA]
+    · have H := Finset.normalize_gcd (s := s) (f := id)
+      rw [← this, hB, hC, mul_assoc, _root_.gcd_mul_left, H,
+        normUnit_mul hdzero fun h ↦ hc <| by simp [h, hC]]
+      congr 3
+      simp only [Units.val_mul, ne_eq, Units.ne_zero, not_false_eq_true, mul_eq_right₀,
+        Units.val_eq_one]
+      nth_rewrite 2 [← mul_one (s.gcd id)] at H
+      rw [normalize_apply] at H
+      exact Units.ext <| by simpa using mul_left_cancel₀ hdzero H
+    · simp [hc]
+  · rw [hA, hB, hC, mul_pow, mul_pow, mul_pow, ← mul_add] at habc
+    simpa [hdn] using habc
+
+/-- To prove Fermat Last Theorem for `ℤ` one can assume that `a`, `b` and `c` are coprime, in the
+sense that the gcd of `{a, b, c}` is `1`. -/
+lemma FermatLastTheoremWith_int_of_FermatLastTheoremWith_int_coprime {n : ℕ}
+    (hn : ∀ a b c : ℤ, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset ℤ).gcd id = 1 →
+      a ^ n + b ^ n ≠ c ^ n) :
+    FermatLastTheoremWith ℤ n := by
+  refine FermatLastTheoremWith_of_FermatLastTheoremWith_coprime (R := ℤ)
+    (fun a b c ha hb hc H h ↦ hn a b c ha hb hc ?_ h)
+  rcases Int.isUnit_iff.1 H with (H | H)
+  · exact H
+  · simp at H
+
+/-- To prove Fermat Last Theorem one can assume that `a`, `b` and `c` are coprime, in the sense
+that the gcd of `{a, b, c}` is `1`. -/
 lemma FermatLastTheoremFor_of_FermatLastTheoremFor_coprime {n : ℕ}
     (hn : ∀ a b c, a ≠ 0 → b ≠ 0 → c ≠ 0 → ({a, b, c} : Finset ℕ).gcd id = 1 →
       a ^ n + b ^ n ≠ c ^ n) :
-    FermatLastTheoremFor n := by
-  intro a b c ha hb hc habc
-  let s : Finset ℕ := {a, b, c}; let d := s.gcd id
-  have hadiv : d ∣ a := gcd_dvd (by simp [s])
-  have hbdiv : d ∣ b := gcd_dvd (by simp [s])
-  have hcdiv : d ∣ c := gcd_dvd (by simp [s])
-  have hdzero : 0 < d := Nat.pos_of_ne_zero <| fun hdzero => by
-      simpa [ha] using Finset.gcd_eq_zero_iff.1 hdzero a (by simp [s])
-  have hdp : d ^ n ≠ 0 := fun hdn => hdzero.ne' (pow_eq_zero hdn)
-  refine hn (a / d) (b / d) (c / d) (fun h ↦ ha <| Nat.eq_zero_of_dvd_of_div_eq_zero hadiv h)
-    (fun h ↦ hb <| Nat.eq_zero_of_dvd_of_div_eq_zero hbdiv h)
-    (fun h ↦ hc <| Nat.eq_zero_of_dvd_of_div_eq_zero hcdiv h) ?_ ?_
-  · simpa [gcd_eq_gcd_image, d] using
-      Nat.gcd_div_id_eq_one (show a ∈ ({a, b, c} : Finset ℕ) by simp) ha
-  · obtain ⟨na, hna⟩ := hadiv; obtain ⟨nb, hnb⟩ := hbdiv; obtain ⟨nc, hnc⟩ := hcdiv
-    rwa [← mul_left_inj' hdp, add_mul, ← mul_pow, ← mul_pow, ← mul_pow, hna, hnb, hnc,
-      Nat.mul_div_cancel_left _ hdzero, Nat.mul_div_cancel_left _ hdzero,
-      Nat.mul_div_cancel_left _ hdzero, mul_comm, ← hna, mul_comm, ← hnb, mul_comm, ← hnc]
+    FermatLastTheoremFor n :=
+  FermatLastTheoremWith_of_FermatLastTheoremWith_coprime (R := ℕ)
+    (fun a b c ha hb hc H h ↦ hn a b c ha hb hc (by simpa using H) h)

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -143,7 +143,7 @@ lemma FermatLastTheoremWith_of_FermatLastTheoremWith_coprime {n : ℕ} {R : Type
       rw [gcd_insert, id_eq]
       simp only [gcd_insert, id_eq, gcd_singleton, normalize_apply]
     simp only [gcd_insert, id_eq, gcd_singleton, normalize_apply]
-    apply isUnit_gcd_of_eq_mul_gcd (x := a) (y := GCDMonoid.gcd b (c * ↑(normUnit c)))
+    apply isUnit_gcd_of_eq_mul_gcd (x := a) (y := GCDMonoid.gcd b (c * (normUnit c)))
     · rw [← this, hA]
     · have H := Finset.normalize_gcd (s := s) (f := id)
       rw [← this, hB, hC, mul_assoc, _root_.gcd_mul_left, H,
@@ -152,7 +152,6 @@ lemma FermatLastTheoremWith_of_FermatLastTheoremWith_coprime {n : ℕ} {R : Type
       simp only [Units.val_mul, ne_eq, Units.ne_zero, not_false_eq_true, mul_eq_right₀,
         Units.val_eq_one]
       nth_rewrite 2 [← mul_one (s.gcd id)] at H
-      rw [normalize_apply] at H
       exact Units.ext <| by simpa using mul_left_cancel₀ hdzero H
     · simp [hc]
   · rw [hA, hB, hC, mul_pow, mul_pow, mul_pow, ← mul_add] at habc

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -139,7 +139,7 @@ lemma FermatLastTheoremWith_of_FermatLastTheoremWith_coprime {n : ℕ} {R : Type
   refine hn A B C (fun h ↦ ha <| by simpa [h] using hA) (fun h ↦ hb <| by simpa [h] using hB)
     (fun h ↦ hc <| by simpa [h] using hC) ?_ ?_
   · have : d = (GCDMonoid.gcd a (GCDMonoid.gcd b (c * ↑(normUnit c)))) := by
-      simp [d]
+      simp only [d]
       rw [gcd_insert, id_eq]
       simp only [gcd_insert, id_eq, gcd_singleton, normalize_apply]
     simp only [gcd_insert, id_eq, gcd_singleton, normalize_apply]

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard, Yaël Dillies
 -/
-import Mathlib.Algebra.GCDMonoid.Div
+import Mathlib.Algebra.GCDMonoid.Finset
 import Mathlib.Algebra.GroupPower.Ring
 import Mathlib.Data.Nat.Parity
 import Mathlib.Data.Rat.Defs


### PR DESCRIPTION
We add `fermatLastTheoremWith_of_fermatLastTheoremWith_coprime`: To prove Fermat Last Theorem one can assume that `a`, `b` and `c` are coprime.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
