### PR TITLE
[Merged by Bors] - chore: make sure that Archive and Counterexamples are quiet

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -255,6 +255,7 @@ jobs:
         id: noisy
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
+          ! grep --after-context=1 "stderr:" stdout.log
 
       - name: check declarations in db files
         run: |

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -187,11 +187,6 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build -KCI | tee stdout.log"
 
-      - name: check for noisy stdout lines
-        id: noisy
-        run: |
-          ! grep --after-context=1 "stdout:" stdout.log
-
       - name: build library_search cache
         run: lake build -KCI MathlibExtras
 
@@ -240,7 +235,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          lake build Archive
+          lake build Archive | tee --append stdout.log
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -250,11 +245,16 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          lake build Counterexamples
+          lake build Counterexamples | tee --append stdout.log
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
+
+      - name: check for noisy stdout lines
+        id: noisy
+        run: |
+          ! grep --after-context=1 "stdout:" stdout.log
 
       - name: check declarations in db files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,11 +194,6 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build -KCI | tee stdout.log"
 
-      - name: check for noisy stdout lines
-        id: noisy
-        run: |
-          ! grep --after-context=1 "stdout:" stdout.log
-
       - name: build library_search cache
         run: lake build -KCI MathlibExtras
 
@@ -247,7 +242,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          lake build Archive
+          lake build Archive | tee --append stdout.log
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -257,11 +252,16 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          lake build Counterexamples
+          lake build Counterexamples | tee --append stdout.log
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
+
+      - name: check for noisy stdout lines
+        id: noisy
+        run: |
+          ! grep --after-context=1 "stdout:" stdout.log
 
       - name: check declarations in db files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,6 +262,7 @@ jobs:
         id: noisy
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
+          ! grep --after-context=1 "stderr:" stdout.log
 
       - name: check declarations in db files
         run: |

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -173,11 +173,6 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build -KCI | tee stdout.log"
 
-      - name: check for noisy stdout lines
-        id: noisy
-        run: |
-          ! grep --after-context=1 "stdout:" stdout.log
-
       - name: build library_search cache
         run: lake build -KCI MathlibExtras
 
@@ -226,7 +221,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          lake build Archive
+          lake build Archive | tee --append stdout.log
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -236,11 +231,16 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          lake build Counterexamples
+          lake build Counterexamples | tee --append stdout.log
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
+
+      - name: check for noisy stdout lines
+        id: noisy
+        run: |
+          ! grep --after-context=1 "stdout:" stdout.log
 
       - name: check declarations in db files
         run: |

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -241,6 +241,7 @@ jobs:
         id: noisy
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
+          ! grep --after-context=1 "stderr:" stdout.log
 
       - name: check declarations in db files
         run: |

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -191,11 +191,6 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build -KCI | tee stdout.log"
 
-      - name: check for noisy stdout lines
-        id: noisy
-        run: |
-          ! grep --after-context=1 "stdout:" stdout.log
-
       - name: build library_search cache
         run: lake build -KCI MathlibExtras
 
@@ -244,7 +239,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          lake build Archive
+          lake build Archive | tee --append stdout.log
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -254,11 +249,16 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          lake build Counterexamples
+          lake build Counterexamples | tee --append stdout.log
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
+
+      - name: check for noisy stdout lines
+        id: noisy
+        run: |
+          ! grep --after-context=1 "stdout:" stdout.log
 
       - name: check declarations in db files
         run: |

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -259,6 +259,7 @@ jobs:
         id: noisy
         run: |
           ! grep --after-context=1 "stdout:" stdout.log
+          ! grep --after-context=1 "stderr:" stdout.log
 
       - name: check declarations in db files
         run: |


### PR DESCRIPTION
This PR proposes two changes to CI.

###  Quiet `Archive` and `Counterexamples`

CI checks that building `Mathlib` and `test` produces no messages.  However, `Archive` and `Counterexamples` could be noisy and CI would not detect it.  This PR makes sure that also `Archive and `Counterexamples` are quiet.

I noticed that `Archive` and `Counterexamples` were not required to be quiet, since they contained unused tactics flagged by the linter.

EDIT: this second item is already available -- see Floris' comment below.

###  Upload the cache even when `Mathlib` is noisy

This PR moves the check of quietness of `Mathlib` until after the uploading cache step, so that you can have the cache available to fix the noisiness!

As a check, PR #11378 made `Mathlib` noisy, CI failed, but only after uploading the cache and building `Archive`, `Counterexamples`.  See in particular [this CI run](https://github.com/leanprover-community/mathlib4/actions/runs/8285030855/job/22671860704).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
