### PR TITLE
[Merged by Bors] - chore: remove unused tactics in Archive and Counterexamples

### DIFF
--- a/Archive/Imo/Imo1960Q1.lean
+++ b/Archive/Imo/Imo1960Q1.lean
@@ -94,7 +94,7 @@ theorem right_direction {n : ℕ} : ProblemPredicate n → SolutionPredicate n :
   have := searchUpTo_start
   iterate 82
     replace :=
-      searchUpTo_step this (by norm_num1; rfl) (by norm_num1; rfl) (by norm_num1; rfl)
+      searchUpTo_step this (by norm_num1; rfl) (by norm_num1; rfl) rfl
         (by norm_num <;> decide)
   exact searchUpTo_end this
 #align imo1960_q1.right_direction Imo1960Q1.right_direction

--- a/Archive/Sensitivity.lean
+++ b/Archive/Sensitivity.lean
@@ -183,11 +183,11 @@ variable (n : ℕ)
 /-! `V n` is a real vector space whose equality relation is computable. -/
 
 
-instance : DecidableEq (V n) := by induction n <;> · dsimp only [V]; skip; infer_instance
+instance : DecidableEq (V n) := by induction n <;> · dsimp only [V]; infer_instance
 
-instance : AddCommGroup (V n) := by induction n <;> · dsimp only [V]; skip; infer_instance
+instance : AddCommGroup (V n) := by induction n <;> · dsimp only [V]; infer_instance
 
-instance : Module ℝ (V n) := by induction n <;> · dsimp only [V]; skip; infer_instance
+instance : Module ℝ (V n) := by induction n <;> · dsimp only [V]; infer_instance
 
 end V
 

--- a/Counterexamples/Phillips.lean
+++ b/Counterexamples/Phillips.lean
@@ -498,7 +498,6 @@ We need the continuum hypothesis to construct it.
 theorem sierpinski_pathological_family (Hcont : #ℝ = aleph 1) :
     ∃ f : ℝ → Set ℝ, (∀ x, (univ \ f x).Countable) ∧ ∀ y, {x : ℝ | y ∈ f x}.Countable := by
   rcases Cardinal.ord_eq ℝ with ⟨r, hr, H⟩
-  skip
   refine' ⟨fun x => {y | r x y}, fun x => _, fun y => _⟩
   · have : univ \ {y | r x y} = {y | r y x} ∪ {x} := by
       ext y


### PR DESCRIPTION
More unused tactics flagged by the linter (#11308): these are all the changes in `Archive/Counterexamples` that the linter found.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
