### PR TITLE
feat: add "stars and bars" lemma `Nat.card_sum_eq_choose`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -368,7 +368,7 @@ theorem exists_minimal_degree_vertex [DecidableRel G.Adj] [Nonempty V] :
     ∃ v, G.minDegree = G.degree v := by
   obtain ⟨t, ht : _ = _⟩ := min_of_nonempty (univ_nonempty.image fun v => G.degree v)
   obtain ⟨v, _, rfl⟩ := mem_image.mp (mem_of_min ht)
-  exact ⟨v, by simp [minDegree, ht]⟩
+  exact ⟨v, by simp only [minDegree, ht, WithTop.untop'_coe]⟩
 #align simple_graph.exists_minimal_degree_vertex SimpleGraph.exists_minimal_degree_vertex
 
 /-- The minimum degree in the graph is at most the degree of any particular vertex. -/

--- a/Mathlib/Data/Sym/Card.lean
+++ b/Mathlib/Data/Sym/Card.lean
@@ -5,8 +5,10 @@ Authors: Yaël Dillies, Bhavik Mehta, Huỳnh Trần Khanh, Stuart Presnell
 -/
 import Mathlib.Algebra.BigOperators.Basic
 import Mathlib.Data.Finset.Sym
+import Mathlib.Data.Finsupp.Multiset
 import Mathlib.Data.Fintype.Sum
 import Mathlib.Data.Fintype.Prod
+import Mathlib.SetTheory.Cardinal.Finite
 
 #align_import data.sym.card from "leanprover-community/mathlib"@"0bd2ea37bcba5769e14866170f251c9bc64e35d7"
 
@@ -54,7 +56,7 @@ stars and bars, multichoose
 -/
 
 
-open Finset Fintype Function Sum Nat
+open BigOperators Finset Fintype Function Sum Nat
 
 variable {α β : Type*}
 
@@ -100,7 +102,7 @@ theorem card_sym_fin_eq_multichoose : ∀ n k : ℕ, card (Sym (Fin n) k) = mult
   | 1, k + 1 => by simp
   | n + 2, k + 1 => by
     rw [multichoose_succ_succ, ← card_sym_fin_eq_multichoose (n + 1) (k + 1),
-      ← card_sym_fin_eq_multichoose (n + 2) k, add_comm (Fintype.card _), ← card_sum]
+      ← card_sym_fin_eq_multichoose (n + 2) k, add_comm (Fintype.card _), ← Fintype.card_sum]
     refine Fintype.card_congr (Equiv.symm ?_)
     apply (Sym.e1.symm.sumCongr Sym.e2.symm).trans
     apply Equiv.sumCompl
@@ -125,13 +127,20 @@ end Sym
 
 end Sym
 
+@[simp]
+lemma Nat.card_sum_eq_choose (ι : Type*) [Fintype ι] (k : ℕ) :
+    Nat.card {P : ι → ℕ // ∑ i, P i = k} = Nat.choose (Fintype.card ι + k - 1) k := by
+  classical
+  rw [Nat.card_congr (Sym.equivNatSumOfFintype ι k).symm, card_eq_fintype_card,
+    Sym.card_sym_eq_choose]
+
 namespace Sym2
 
 variable [DecidableEq α]
 
 /-- The `diag` of `s : Finset α` is sent on a finset of `Sym2 α` of card `s.card`. -/
 theorem card_image_diag (s : Finset α) : (s.diag.image Sym2.mk).card = s.card := by
-  rw [card_image_of_injOn, diag_card]
+  rw [Finset.card_image_of_injOn, diag_card]
   rintro ⟨x₀, x₁⟩ hx _ _ h
   cases Sym2.eq.1 h
   · rfl


### PR DESCRIPTION
According to `#find_home`, the only places for this lemma are some graph theory files (which are obviously not appropriate) so we either have to tinker with imports or create a new file just for this result.

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
