### PR TITLE
[Merged by Bors] - docs(FunLike/Fintype): fix typo in doc comments

### DIFF
--- a/Mathlib/Data/FunLike/Fintype.lean
+++ b/Mathlib/Data/FunLike/Fintype.lean
@@ -19,8 +19,8 @@ This corresponds to the following two pairs of declarations:
    codomain are.
  * `DFunLike.finite` is a lemma stating all `DFunLike`s are finite if their domain and
    codomain are.
- * `DFunLike.fintype'` is a non-dependent version of `DFunLike.fintype` and
- * `DFunLike.finite` is a non-dependent version of `DFunLike.finite`, because dependent instances
+ * `FunLike.fintype` is a non-dependent version of `DFunLike.fintype` and
+ * `FunLike.finite` is a non-dependent version of `DFunLike.finite`, because dependent instances
    are harder to infer.
 
 You can use these to produce instances for specific `DFunLike` types.


### PR DESCRIPTION
The non-dependent version of `DFunLike.{fintype,finite}` is called `FunLike.{fintype,finite}`; the names in the docstring do not exist.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
