### PR TITLE
[Merged by Bors] - doc: replace `variables`, `universes`' syntax in doc comments

### DIFF
--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -43,12 +43,12 @@ Typically any concrete example will either be a `SmallCategory`, where `v = u`,
 which can be introduced as
 ```
 universes u
-variables {C : Type u} [SmallCategory C]
+variable {C : Type u} [SmallCategory C]
 ```
 or a `LargeCategory`, where `u = v+1`, which can be introduced as
 ```
 universes u
-variables {C : Type (u+1)} [LargeCategory C]
+variable {C : Type (u+1)} [LargeCategory C]
 ```
 
 In order for the library to handle these cases uniformly,

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -42,12 +42,12 @@ specified explicitly, as `Category.{v} C`.
 Typically any concrete example will either be a `SmallCategory`, where `v = u`,
 which can be introduced as
 ```
-universes u
+universe u
 variable {C : Type u} [SmallCategory C]
 ```
 or a `LargeCategory`, where `u = v+1`, which can be introduced as
 ```
-universes u
+universe u
 variable {C : Type (u+1)} [LargeCategory C]
 ```
 
@@ -61,11 +61,11 @@ can not be automatically inferred, through the category theory library
 we introduce universe parameters with morphism levels listed first,
 as in
 ```
-universes v u
+universe v u
 ```
 or
 ```
-universes v₁ v₂ u₁ u₂
+universe v₁ v₂ u₁ u₂
 ```
 when multiple independent universes are needed.
 

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -25,7 +25,7 @@ structure MyHom (A B : Type*) [MyClass A] [MyClass B] :=
 
 namespace MyHom
 
-variables (A B : Type*) [MyClass A] [MyClass B]
+variable (A B : Type*) [MyClass A] [MyClass B]
 
 -- This instance is optional if you follow the "morphism class" design below:
 instance : FunLike (MyHom A B) A B :=

--- a/Mathlib/Data/FunLike/Embedding.lean
+++ b/Mathlib/Data/FunLike/Embedding.lean
@@ -23,7 +23,7 @@ structure MyEmbedding (A B : Type*) [MyClass A] [MyClass B] :=
 
 namespace MyEmbedding
 
-variables (A B : Type*) [MyClass A] [MyClass B]
+variable (A B : Type*) [MyClass A] [MyClass B]
 
 -- This instance is optional if you follow the "Embedding class" design below:
 instance : EmbeddingLike (MyEmbedding A B) A B :=

--- a/Mathlib/Data/FunLike/Equiv.lean
+++ b/Mathlib/Data/FunLike/Equiv.lean
@@ -22,7 +22,7 @@ structure MyIso (A B : Type*) [MyClass A] [MyClass B]
 
 namespace MyIso
 
-variables (A B : Type*) [MyClass A] [MyClass B]
+variable (A B : Type*) [MyClass A] [MyClass B]
 
 -- This instance is optional if you follow the "Isomorphism class" design below:
 instance : EquivLike (MyIso A B) A (λ _, B) :=

--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -36,7 +36,7 @@ structure MySubobject (X : Type*) [ObjectTypeclass X] :=
 
 namespace MySubobject
 
-variables {X : Type*} [ObjectTypeclass X] {x : X}
+variable {X : Type*} [ObjectTypeclass X] {x : X}
 
 instance : SetLike (MySubobject X) X :=
   ⟨MySubobject.carrier, fun p q h => by cases p; cases q; congr!⟩


### PR DESCRIPTION
It's deprecated in favour of `variable`; likely a leftover from the port.
Also replace `universes`, which is invalid now.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
