### PR TITLE
[Merged by Bors] - chore: classify `broken dot notation` porting notes

### DIFF
--- a/Mathlib/Data/Set/Semiring.lean
+++ b/Mathlib/Data/Set/Semiring.lean
@@ -55,36 +55,36 @@ protected def down : SetSemiring α ≃ Set α :=
 open SetSemiring (down)
 open Set (up)
 
--- Porting note: dot notation no longer works
+-- Porting note (#11036): dot notation no longer works
 @[simp]
 protected theorem down_up (s : Set α) : SetSemiring.down (Set.up s) = s :=
   rfl
 #align set_semiring.down_up SetSemiring.down_up
 
--- Porting note: dot notation no longer works
+-- Porting note (#11036): dot notation no longer works
 @[simp]
 protected theorem up_down (s : SetSemiring α) : Set.up (SetSemiring.down s) = s :=
   rfl
 #align set_semiring.up_down SetSemiring.up_down
 
 -- TODO: These lemmas are not tagged `simp` because `Set.le_eq_subset` simplifies the LHS
--- Porting note: dot notation no longer works
+-- Porting note (#11036): dot notation no longer works
 theorem up_le_up {s t : Set α} : Set.up s ≤ Set.up t ↔ s ⊆ t :=
   Iff.rfl
 #align set_semiring.up_le_up SetSemiring.up_le_up
 
--- Porting note: dot notation no longer works
+-- Porting note (#11036): dot notation no longer works
 theorem up_lt_up {s t : Set α} : Set.up s < Set.up t ↔ s ⊂ t :=
   Iff.rfl
 #align set_semiring.up_lt_up SetSemiring.up_lt_up
 
--- Porting note: dot notation no longer works
+-- Porting note (#11036): dot notation no longer works
 @[simp]
 theorem down_subset_down {s t : SetSemiring α} : SetSemiring.down s ⊆ SetSemiring.down t ↔ s ≤ t :=
   Iff.rfl
 #align set_semiring.down_subset_down SetSemiring.down_subset_down
 
--- Porting note: dot notation no longer works
+-- Porting note (#11036): dot notation no longer works
 @[simp]
 theorem down_ssubset_down {s t : SetSemiring α} : SetSemiring.down s ⊂ SetSemiring.down t ↔ s < t :=
   Iff.rfl
@@ -94,7 +94,7 @@ instance : Zero (SetSemiring α) where zero := Set.up (∅ : Set α)
 
 instance : Add (SetSemiring α) where add s t := Set.up (SetSemiring.down s ∪ SetSemiring.down t)
 
--- Porting note: dot notation no longer works
+-- Porting note (#11036): dot notation no longer works
 instance : AddCommMonoid (SetSemiring α) where
   add_assoc := union_assoc
   zero_add := empty_union
@@ -140,7 +140,7 @@ section Mul
 
 variable [Mul α]
 
--- Porting note: dot notation no longer works
+-- Porting note (#11036): dot notation no longer works
 instance : NonUnitalNonAssocSemiring (SetSemiring α) :=
   { (inferInstance : AddCommMonoid (SetSemiring α)) with
     mul := fun s t => Set.up (image2 (· * ·) (SetSemiring.down s) (SetSemiring.down t))


### PR DESCRIPTION
Classifies by adding issue number #11036 to porting notes claiming: 

> dot notation no longer works