### PR TITLE
[Merged by Bors] - feat(GroupTheory/GroupAction/SubMulAction): two more orbit lemmas

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
@@ -336,7 +336,7 @@ theorem val_preimage_orbit {p : SubMulAction R M} (m : p) :
 
 lemma mem_orbit_subMul_iff {p : SubMulAction R M} {x m : p} :
     x ∈ MulAction.orbit R m ↔ (x : M) ∈ MulAction.orbit R (m : M) := by
-  rw [←val_preimage_orbit, Set.mem_preimage]
+  rw [← val_preimage_orbit, Set.mem_preimage]
 
 /-- Stabilizers in monoid SubMulAction coincide with stabilizers in the ambient space -/
 theorem stabilizer_of_subMul.submonoid {p : SubMulAction R M} (m : p) :

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
@@ -330,9 +330,13 @@ lemma orbit_of_sub_mul {p : SubMulAction R M} (m : p) :
     (mul_action.orbit R m : set M) = MulAction.orbit R (m : M) := rfl
 -/
 
+theorem val_preimage_orbit {p : SubMulAction R M} (m : p) :
+    Subtype.val ⁻¹' MulAction.orbit R (m : M) = MulAction.orbit R m := by
+  rw [← val_image_orbit, Subtype.val_injective.preimage_image]
+
 lemma mem_orbit_subMul_iff {p : SubMulAction R M} {x m : p} :
     x ∈ MulAction.orbit R m ↔ (x : M) ∈ MulAction.orbit R (m : M) := by
-  erw [← val_image_orbit, Subtype.val_injective.mem_set_image]
+  rw [←val_preimage_orbit, Set.mem_preimage]
 
 /-- Stabilizers in monoid SubMulAction coincide with stabilizers in the ambient space -/
 theorem stabilizer_of_subMul.submonoid {p : SubMulAction R M} (m : p) :

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
@@ -329,6 +329,11 @@ theorem val_image_orbit {p : SubMulAction R M} (m : p) :
 lemma orbit_of_sub_mul {p : SubMulAction R M} (m : p) :
     (mul_action.orbit R m : set M) = MulAction.orbit R (m : M) := rfl
 -/
+
+lemma mem_orbit_subMul_iff {p : SubMulAction R M} {x m : p} :
+    x ∈ MulAction.orbit R m ↔ (x : M) ∈ MulAction.orbit R (m : M) := by
+  erw [← val_image_orbit, Subtype.val_injective.mem_set_image]
+
 /-- Stabilizers in monoid SubMulAction coincide with stabilizers in the ambient space -/
 theorem stabilizer_of_subMul.submonoid {p : SubMulAction R M} (m : p) :
     MulAction.stabilizerSubmonoid R m = MulAction.stabilizerSubmonoid R (m : M) := by
@@ -341,6 +346,12 @@ end MulActionMonoid
 section MulActionGroup
 
 variable [Group R] [MulAction R M]
+
+lemma orbitRel_of_subMul (p : SubMulAction R M) :
+    MulAction.orbitRel R p = (MulAction.orbitRel R M).comap Subtype.val := by
+  refine Setoid.ext_iff.2 (fun x y ↦ ?_)
+  rw [Setoid.comap_rel]
+  exact mem_orbit_subMul_iff
 
 /-- Stabilizers in group SubMulAction coincide with stabilizers in the ambient space -/
 theorem stabilizer_of_subMul {p : SubMulAction R M} (m : p) :


### PR DESCRIPTION
Add two more lemmas about orbits in a `SubMulAction`, both closely related to the existing `val_image_orbit`.

From AperiodicMonotilesLean.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
