### PR TITLE
feat(Topology/Algebra/Module/WeakDual): prove basic relations between the weak topology and the original topology

### DIFF
--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -314,6 +314,45 @@ instance instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E) :=
 instance instContinuousAdd : ContinuousAdd (WeakSpace 𝕜 E) :=
   WeakBilin.instContinuousAdd (topDualPairing 𝕜 E).flip
 
+
+/-- There is a canonical map `E → WeakSpace 𝕜 E` (the "identity"
+mapping). It is a linear equivalence. -/
+def toWeakSpace : E ≃ₗ[𝕜] WeakSpace 𝕜 E := LinearEquiv.refl 𝕜 E
+-- align?
+
+@[simp]
+-- theorem coe_toWeakSpace (x : E) : (toWeakSpace x : WeakSpace 𝕜 E) = x :=
+theorem coe_toWeakSpace (x : E) : toWeakSpace x = x :=
+  rfl
+-- #align ?
+
+@[simp]
+theorem toWeakSpace_eq_iff (x y : E) : (toWeakSpace x : WeakSpace 𝕜 E) = toWeakSpace y ↔ x = y :=
+  Function.Injective.eq_iff <| LinearEquiv.injective toWeakSpace
+-- #align ?
+
+-- theorem toWeakSpace_continuous : Continuous fun x : E => (toWeakSpace x : WeakSpace 𝕜 E) := by
+theorem toWeakSpace_continuous : Continuous fun x : E => toWeakSpace x := by
+  refine { isOpen_preimage := ?isOpen_preimage }
+  intro U hU
+  apply Continuous.le_induced _ U hU
+  apply continuous_pi_iff.mpr
+  intro y
+  exact ContinuousLinearMap.continuous y
+
+
+/-- For a topological vector space `E`, according to `toWeakSpace_continuous` the "identity mapping"
+`E → WeakSpace 𝕜 E` is continuous. This definition implements it as a continuous linear map. -/
+def continuousLinearMapToWeakSpace : E →L[𝕜] WeakDual 𝕜 E :=
+  { toWeakSpace with cont := toWeakSpace_continuous }
+-- #align ?
+
+/-- There is a canonical map `E → WeakSpace 𝕜 E` (the "identity"
+mapping). It is a linear equivalence. -/
+def toOriginalSpace : WeakSpace 𝕜 E ≃ₗ[𝕜] E := LinearEquiv.refl 𝕜 E
+-- align?
+
+
 variable [AddCommMonoid F] [Module 𝕜 F] [TopologicalSpace F]
 
 /-- A continuous linear map from `E` to `F` is still continuous when `E` and `F` are equipped with
@@ -336,7 +375,7 @@ theorem coe_map (f : E →L[𝕜] F) : (WeakSpace.map f : E → F) = f :=
 /-- A weakly open set is open in the original topology. -/
 theorem isOpen_of_isOpen_WeakSpace (U : Set E)
     (hU : IsOpen[(WeakSpace.instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E))]
-    (id U : Set (WeakSpace 𝕜 E))) : IsOpen U := by
+    (U : Set (WeakSpace 𝕜 E))) : IsOpen U := by
   apply Continuous.le_induced _ U hU
   refine continuous_pi ?h.h
   intro y

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -326,9 +326,7 @@ theorem toWeakSpace_eq_iff (x y : E) : (toWeakSpace x : WeakSpace 𝕜 E) = toWe
 /-- For a topological vector space `E`, "identity mapping" `E → WeakSpace 𝕜 E` is continuous.
 This definition implements it as a continuous linear map. -/
 def continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E where
-  toFun := toWeakSpace
-  map_add' := toWeakSpace.map_add'
-  map_smul' := toWeakSpace.map_smul'
+  __ := toWeakSpace
   cont := by
     apply WeakBilin.continuous_of_continuous_eval
     exact ContinuousLinearMap.continuous

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -352,8 +352,8 @@ theorem tendsto_WeakSpace_of_tendsto
   rw [tendsto_nhds] at hf
   exact hf (id U : Set E) (isOpen_of_isOpen_WeakSpace (id U : Set E) hpU) hU
 
-/-- If `f : E → α` is continuous in the weak topology,
-then it is convergent in the original topology. -/
+/-- If `f : E → α` is continuous from `E` in the weak topology,
+then it is continuous in the original topology. -/
 theorem continuous_of_continuous_WeakSpace
     {α : Type*} [TopologicalSpace α] {f : E → α} (hf : Continuous (f ∘ (id : (WeakSpace 𝕜 E) → E)))
     : Continuous f := by

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -337,13 +337,14 @@ def continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E where
 --       exact ContinuousLinearMap.continuous }
 
 @[simp]
-theorem toWeakSpace_eq_continuousLinearMapToWeakSpace (x : E)
-    : (toWeakSpace x : WeakSpace 𝕜 E) = continuousLinearMapToWeakSpace x := by rfl
+theorem toWeakSpace_eq_continuousLinearMapToWeakSpace (x : E) :
+    (toWeakSpace x : WeakSpace 𝕜 E) = continuousLinearMapToWeakSpace x := by rfl
 
-theorem injective_continuousLinearMapToWeakSpace
-    : Function.Injective (continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E ) := by
+theorem injective_continuousLinearMapToWeakSpace :
+    Function.Injective (continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E ) := by
   intro x y hxy
-  rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace, ← toWeakSpace_eq_continuousLinearMapToWeakSpace] at hxy
+  rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace,
+    ← toWeakSpace_eq_continuousLinearMapToWeakSpace] at hxy
   exact LinearEquiv.injective toWeakSpace hxy
 
 variable [AddCommMonoid F] [Module 𝕜 F] [TopologicalSpace F]
@@ -367,8 +368,8 @@ theorem coe_map (f : E →L[𝕜] F) : (WeakSpace.map f : E → F) = f :=
 
 /-- The canonical preimage in `E` of an open set in `WeakSpace 𝕜 E` is open in `E`. -/
 theorem isOpen_of_isOpen_WeakSpace (U : Set (WeakSpace 𝕜 E))
-    (hU : IsOpen[(WeakSpace.instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E))] U)
-    : IsOpen (continuousLinearMapToWeakSpace ⁻¹' U) := by
+    (hU : IsOpen[(WeakSpace.instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E))] U) :
+    IsOpen (continuousLinearMapToWeakSpace ⁻¹' U) := by
   exact ((continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E).cont).isOpen_preimage U hU
 
 /-- A set in `E` which is open in the weak topology is open. -/
@@ -384,12 +385,13 @@ theorem isOpen_of_isOpen_WeakSpace' (V : Set E)
        exact hx
      obtain ⟨y, hy⟩ := hx
      rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace] at this
-     rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace, ← toWeakSpace_eq_continuousLinearMapToWeakSpace] at hy
+     rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace,
+       ← toWeakSpace_eq_continuousLinearMapToWeakSpace] at hy
      have : y = x := LinearEquiv.injective toWeakSpace hy.2
      rw [this] at hy
      exact hy.1
    · intro hx
-     simp
+     simp only [Set.mem_preimage, Set.mem_image]
      use x
   rw [← this]
   exact isOpen_of_isOpen_WeakSpace (continuousLinearMapToWeakSpace '' V) hV
@@ -406,7 +408,8 @@ theorem tendsto_WeakSpace_of_tendsto
     = (fun x ↦ ((continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E) ∘ f) x) := by
     rfl
   rw [this, Set.preimage_comp]
-  apply hf (continuousLinearMapToWeakSpace ⁻¹' U) (continuousLinearMapToWeakSpace.cont.isOpen_preimage U hpU)
+  apply hf (continuousLinearMapToWeakSpace ⁻¹' U)
+    (continuousLinearMapToWeakSpace.cont.isOpen_preimage U hpU)
   exact hU
 
 /-- If `f : α → E` is convergent in the original topology,

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -352,6 +352,13 @@ theorem tendsto_WeakSpace_of_tendsto
   rw [tendsto_nhds] at hf
   exact hf (id U : Set E) (isOpen_of_isOpen_WeakSpace (id U : Set E) hpU) hU
 
+/-- If `f : α → E` is convergent in the original topology,
+then `y ∘ f` is convergent for any `y : E →L[𝕜] 𝕜`. -/
+theorem eval_tendsto_of_tendsto
+    {α : Type*} {l : Filter α} {f : α → E} {p : E}
+    (hf : Tendsto f l (nhds p)) (y : E →L[𝕜] 𝕜) : Tendsto (fun x => y (f x)) l (nhds (y p)) := by
+  exact Tendsto.comp (Continuous.tendsto (ContinuousLinearMap.continuous y) p) hf
+
 /-- If `f : E → α` is continuous from `E` in the weak topology,
 then it is continuous in the original topology. -/
 theorem continuous_of_continuous_WeakSpace
@@ -360,13 +367,6 @@ theorem continuous_of_continuous_WeakSpace
   refine { isOpen_preimage := ?isOpen_preimage }
   intro U hU
   exact (isOpen_of_isOpen_WeakSpace (f⁻¹' U) (hf.isOpen_preimage U hU))
-
-/-- If `f : α → E` is convergent in the original topology,
-then `y ∘ f` is convergent for any `y : E →L[𝕜] 𝕜`. -/
-theorem eval_tendsto_of_tendsto
-    {α : Type*} {l : Filter α} {f : α → E} {p : E}
-    (hf : Tendsto f l (nhds p)) (y : E →L[𝕜] 𝕜) : Tendsto (fun x => y (f x)) l (nhds (y p)) := by
-  exact Tendsto.comp (Continuous.tendsto (ContinuousLinearMap.continuous y) p) hf
 
 end WeakSpace
 

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -352,6 +352,15 @@ theorem tendsto_WeakSpace_of_tendsto
   rw [tendsto_nhds] at hf
   exact hf (id U : Set E) (isOpen_of_isOpen_WeakSpace (id U : Set E) hpU) hU
 
+/-- If `f : E → α` is continuous in the weak topology,
+then it is convergent in the original topology. -/
+theorem continuous_of_continuous_WeakSpace
+    {α : Type*} [TopologicalSpace α] {f : E → α} (hf : Continuous (f ∘ (id : (WeakSpace 𝕜 E) → E)))
+    : Continuous f := by
+  refine { isOpen_preimage := ?isOpen_preimage }
+  intro U hU
+  exact (isOpen_of_isOpen_WeakSpace (f⁻¹' U) (hf.isOpen_preimage U hU))
+
 /-- If `f : α → E` is convergent in the original topology,
 then `y ∘ f` is convergent for any `y : E →L[𝕜] 𝕜`. -/
 theorem eval_tendsto_of_tendsto

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -333,6 +333,32 @@ theorem coe_map (f : E →L[𝕜] F) : (WeakSpace.map f : E → F) = f :=
   rfl
 #align weak_space.coe_map WeakSpace.coe_map
 
+/-- A weakly open set is open in the original topology. -/
+theorem isOpen_of_isOpen_WeakSpace (U : Set E)
+    (hU : IsOpen[(WeakSpace.instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E))]
+    (id U : Set (WeakSpace 𝕜 E))) : IsOpen U := by
+  apply Continuous.le_induced _ U hU
+  refine continuous_pi ?h.h
+  intro y
+  exact ContinuousLinearMap.continuous y
+
+/-- If `f : α → E` is convergent in the original topology,
+then it is convergent in the weak topology. -/
+theorem tendsto_WeakSpace_of_tendsto
+    {α : Type*} {l : Filter α} {f : α → E} {p : E} (hf : Tendsto f l (nhds p)) :
+    Tendsto (fun x ↦ (id (f x) : (WeakSpace 𝕜 E))) l (nhds (p : (WeakSpace 𝕜 E))) := by
+  refine tendsto_nhds.mpr ?_
+  intro U hpU hU
+  rw [tendsto_nhds] at hf
+  exact hf (id U : Set E) (isOpen_of_isOpen_WeakSpace (id U : Set E) hpU) hU
+
+/-- If `f : α → E` is convergent in the original topology,
+then `y ∘ f` is convergent for any `y : E →L[𝕜] 𝕜`. -/
+theorem eval_tendsto_of_tendsto
+    {α : Type*} {l : Filter α} {f : α → E} {p : E}
+    (hf : Tendsto f l (nhds p)) (y : E →L[𝕜] 𝕜) : Tendsto (fun x => y (f x)) l (nhds (y p)) := by
+  exact Tendsto.comp (Continuous.tendsto (ContinuousLinearMap.continuous y) p) hf
+
 end WeakSpace
 
 theorem tendsto_iff_forall_eval_tendsto_topDualPairing {l : Filter α} {f : α → WeakDual 𝕜 E}


### PR DESCRIPTION
prove the following basic facts about the weak topology in a topological vector space (or AddCommMonoid) `E`.
- any set that is open in the weak topology is open in the original topology.
- any function in `E` that converges to a point in the original topology (with respect to some filter) converges also in the weak topology.
- if a function in `E` converges to a point in the original topology, then its composition with a continuous linear functional converges.
- any function from `E` that is continuous in the weak topology is also continuous in the original topology.

Motivation: `WeakSpace` has some basic properties, analogue of which are proved for `WeakDual`.