### PR TITLE
[Merged by Bors] - fix(Cache): do not read lake-manifest.json at import-time

### DIFF
--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -73,7 +73,7 @@ def getRootHash : CacheM UInt64 := do
     if isMathlibRoot then
       pure id
     else
-      pure ((← read).mathlibDepPath / ·)
+      pure ((← mathlibDepPath) / ·)
   let hashs ← rootFiles.mapM fun path =>
     hashFileContents <$> IO.FS.readFile (qualifyPath path)
   return hash (hash Lean.githash :: hashs)
@@ -95,7 +95,7 @@ partial def getFileHash (filePath : FilePath) : HashM <| Option UInt64 := do
       modify fun stt => { stt with cache := stt.cache.insert filePath none }
       return none
     let content ← IO.FS.readFile fixedPath
-    let fileImports := getFileImports content (← read).packageDirs
+    let fileImports := getFileImports content (← getPackageDirs)
     let mut importHashes := #[]
     for importHash? in ← fileImports.mapM getFileHash do
       match importHash? with

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -39,7 +39,7 @@ def HashMemo.filterByFilePaths (hashMemo : HashMemo) (filePaths : List FilePath)
   return hashMap
 
 /-- We cache the hash of each file and their dependencies for later lookup -/
-abbrev HashM := StateT HashMemo IO
+abbrev HashM := StateT HashMemo CacheM
 
 /-- Gets the file paths to Mathlib files imported on a Lean source -/
 def getFileImports (source : String) (pkgDirs : PackageDirs) : Array FilePath :=
@@ -66,14 +66,14 @@ and the hash of `Lean.versionString`.
 (We hash `Lean.versionString` in case the toolchain changes even though `lean-toolchain` hasn't.
 This happens with the `lean-pr-testing-NNNN` toolchains when Lean 4 PRs are updated.)
 -/
-def getRootHash : IO UInt64 := do
+def getRootHash : CacheM UInt64 := do
   let rootFiles : List FilePath := ["lakefile.lean", "lean-toolchain", "lake-manifest.json"]
   let isMathlibRoot ← isMathlibRoot
   let qualifyPath ←
     if isMathlibRoot then
       pure id
     else
-      pure ((← mathlibDepPath) / ·)
+      pure ((← read).mathlibDepPath / ·)
   let hashs ← rootFiles.mapM fun path =>
     hashFileContents <$> IO.FS.readFile (qualifyPath path)
   return hash (hash Lean.githash :: hashs)
@@ -95,7 +95,7 @@ partial def getFileHash (filePath : FilePath) : HashM <| Option UInt64 := do
       modify fun stt => { stt with cache := stt.cache.insert filePath none }
       return none
     let content ← IO.FS.readFile fixedPath
-    let fileImports := getFileImports content pkgDirs
+    let fileImports := getFileImports content (← read).packageDirs
     let mut importHashes := #[]
     for importHash? in ← fileImports.mapM getFileHash do
       match importHash? with
@@ -117,7 +117,7 @@ def roots : Array FilePath :=
   #["Mathlib.lean", "MathlibExtras.lean"]
 
 /-- Main API to retrieve the hashes of the Lean files -/
-def getHashMemo (extraRoots : Array FilePath) : IO HashMemo :=
+def getHashMemo (extraRoots : Array FilePath) : CacheM HashMemo :=
   return (← StateT.run ((roots ++ extraRoots).mapM getFileHash) { rootHash := ← getRootHash }).2
 
 end Cache.Hashing

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -73,6 +73,7 @@ def main (args : List String) : IO Unit := do
   if args.isEmpty then
     println help
     Process.exit 0
+  CacheM.run do
   let hashMemo ← getHashMemo extraRoots
   let hashMap := hashMemo.hashMap
   let goodCurl ← pure !curlArgs.contains (args.headD "") <||> validateCurl

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -141,7 +141,7 @@ def downloadFiles (hashMap : IO.HashMap) (forceDownload : Bool) (parallel : Bool
       IO.Process.exit 1
   else IO.println "No files to download"
 
-def checkForToolchainMismatch : IO Unit := do
+def checkForToolchainMismatch : IO.CacheM Unit := do
   let mathlibToolchainFile := (← IO.mathlibDepPath) / "lean-toolchain"
   let downstreamToolchain ← IO.FS.readFile "lean-toolchain"
   let mathlibToolchain ← IO.FS.readFile mathlibToolchainFile
@@ -162,7 +162,7 @@ into the `lean-toolchain` file at the root directory of your project"
 
 /-- Downloads missing files, and unpacks files. -/
 def getFiles (hashMap : IO.HashMap) (forceDownload forceUnpack parallel decompress : Bool) :
-    IO Unit := do
+    IO.CacheM Unit := do
   let isMathlibRoot ← IO.isMathlibRoot
   if !isMathlibRoot then checkForToolchainMismatch
   downloadFiles hashMap forceDownload parallel


### PR DESCRIPTION
Previously this file was read four times at runtime, and once for each file at compile time. Now it is read only once, when `lake exe cache` is run.

`initialize` is not a substitute for correctly passing global state through a program; my impression is that it is intended for *language-* rather than program-level initialization.

The performance impact is negligible, but the new code is more predictable.

Tested on mathlib, and on a package created using `lake new foo math`, pointed at this mathlib branch. `lake exe cache get` works correctly (leaves `lake build` with nothing to do) in both cases.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
