### PR TITLE
[Merged by Bors] - perf(LinearAlgebra.TensorProduct.Basic): add `TensorProduct.addMonoid`

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -333,15 +333,18 @@ protected theorem add_smul (r s : R'') (x : M ⊗[R] N) : (r + s) • x = r • 
     rw [ihx, ihy, add_add_add_comm]
 #align tensor_product.add_smul TensorProduct.add_smul
 
+instance addMonoid : AddMonoid (M ⊗[R] N) :=
+{ TensorProduct.addZeroClass _ _ with
+  toAddSemigroup := TensorProduct.addSemigroup _ _
+  toZero := (TensorProduct.addZeroClass _ _).toZero
+  nsmul := fun n v => n • v
+  nsmul_zero := by simp [TensorProduct.zero_smul]
+  nsmul_succ := by simp only [TensorProduct.one_smul, TensorProduct.add_smul, add_comm,
+    forall_const] }
+
 instance addCommMonoid : AddCommMonoid (M ⊗[R] N) :=
-  { TensorProduct.addCommSemigroup _ _,
-    TensorProduct.addZeroClass _ _ with
-    toAddSemigroup := TensorProduct.addSemigroup _ _
-    toZero := (TensorProduct.addZeroClass _ _).toZero
-    nsmul := fun n v => n • v
-    nsmul_zero := by simp [TensorProduct.zero_smul]
-    nsmul_succ := by simp only [TensorProduct.one_smul, TensorProduct.add_smul, add_comm,
-      forall_const] }
+  { TensorProduct.addCommSemigroup _ _ with
+    toAddMonoid := TensorProduct.addMonoid }
 
 instance leftDistribMulAction : DistribMulAction R' (M ⊗[R] N) :=
   have : ∀ (r : R') (m : M) (n : N), r • m ⊗ₜ[R] n = (r • m) ⊗ₜ n := fun _ _ _ => rfl


### PR DESCRIPTION
We define `TensorProduct.addCommMonoid` in terms of `TensorProduct.addMonoid` to reduce unfolding.

---

Relevant discussion [here](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/checking.20for.20reducible.20rfl/near/427747486)
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
