### PR TITLE
[Merged by Bors] - chore: move tests in `MonCat` to a test file

### DIFF
--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -284,28 +284,6 @@ lemma ofHom_apply {X Y : Type u} [CommMonoid X] [CommMonoid Y] (f : X →* Y) (x
 
 end CommMonCat
 
--- We verify that the coercions of morphisms to functions work correctly:
-example {R S : MonCat} (f : R ⟶ S) : ↑R → ↑S := f
-
--- Porting note: it's essential that simp lemmas for `→*` apply to morphisms.
-example {R S : MonCat} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 := by simp [h]
-
-example {R S : CommMonCat} (f : R ⟶ S) : ↑R → ↑S := f
-
-example {R S : CommMonCat} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 := by simp [h]
-
--- We verify that when constructing a morphism in `CommMonCat`,
--- when we construct the `toFun` field, the types are presented as `↑R`.
-example (R : CommMonCat.{u}) : R ⟶ R :=
-  { toFun := fun x => by
-      match_target (R : Type u)
-      guard_hyp x : (R : Type u)
-      exact x * x
-    map_one' := by simp
-    map_mul' := fun x y => by
-      dsimp
-      rw [mul_assoc x y (x * y), ← mul_assoc y x y, mul_comm y x, mul_assoc, mul_assoc] }
-
 variable {X Y : Type u}
 
 section

--- a/test/MonCat.lean
+++ b/test/MonCat.lean
@@ -1,0 +1,23 @@
+import Mathlib.Algebra.Category.MonCat.Basic
+
+-- We verify that the coercions of morphisms to functions work correctly:
+example {R S : MonCat} (f : R ⟶ S) : ↑R → ↑S := f
+
+-- Porting note: it's essential that simp lemmas for `→*` apply to morphisms.
+example {R S : MonCat} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 := by simp [h]
+
+example {R S : CommMonCat} (f : R ⟶ S) : ↑R → ↑S := f
+
+example {R S : CommMonCat} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 := by simp [h]
+
+-- We verify that when constructing a morphism in `CommMonCat`,
+-- when we construct the `toFun` field, the types are presented as `↑R`.
+example (R : CommMonCat.{u}) : R ⟶ R :=
+  { toFun := fun x => by
+      match_target (R : Type u)
+      guard_hyp x : (R : Type u)
+      exact x * x
+    map_one' := by simp
+    map_mul' := fun x y => by
+      dsimp
+      rw [mul_assoc x y (x * y), ← mul_assoc y x y, mul_comm y x, mul_assoc, mul_assoc] }


### PR DESCRIPTION
The unused tactic linter flagged the final example that this PR moves since it contains `match_target` and `guard_hyp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
