### PR TITLE
fix: CI fail on archive and counterexamples

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -239,7 +239,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive -KCI | tee stdout.log"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive -KCI | tee --append stdout.log"
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -249,7 +249,7 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples -KCI | tee stdout.log"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples -KCI | tee --append stdout.log"
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -239,7 +239,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          lake build Archive | tee --append stdout.log
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive -KCI | tee stdout.log"
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -249,7 +249,7 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          lake build Counterexamples | tee --append stdout.log
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples -KCI | tee stdout.log"
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive -KCI | tee stdout.log"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive -KCI | tee --append stdout.log"
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -256,7 +256,7 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples -KCI | tee stdout.log"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples -KCI | tee --append stdout.log"
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          lake build Archive | tee --append stdout.log
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive -KCI | tee stdout.log"
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -256,7 +256,7 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          lake build Counterexamples | tee --append stdout.log
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples -KCI | tee stdout.log"
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -225,7 +225,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive -KCI | tee stdout.log"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive -KCI | tee --append stdout.log"
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -235,7 +235,7 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples -KCI | tee stdout.log"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples -KCI | tee --append stdout.log"
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -225,7 +225,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          lake build Archive | tee --append stdout.log
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive -KCI | tee stdout.log"
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -235,7 +235,7 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          lake build Counterexamples | tee --append stdout.log
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples -KCI | tee stdout.log"
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -243,7 +243,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive -KCI | tee stdout.log"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive -KCI | tee --append stdout.log"
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -253,7 +253,7 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples -KCI | tee stdout.log"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples -KCI | tee --append stdout.log"
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -243,7 +243,7 @@ jobs:
           # storing and transferring oleans over the network.
           # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
           lake exe cache get Archive.lean
-          lake build Archive | tee --append stdout.log
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive -KCI | tee stdout.log"
           lake exe cache put Archive.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
@@ -253,7 +253,7 @@ jobs:
         id: counterexamples
         run: |
           lake exe cache get Counterexamples.lean
-          lake build Counterexamples | tee --append stdout.log
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples -KCI | tee stdout.log"
           lake exe cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}


### PR DESCRIPTION
Ensure that unsuccessful build of Archive and Counterexamples makes CI also fail.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/CI.20on.20Archive.2F)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
