### PR TITLE
[Merged by Bors] - chore(MeasureTheory.Decomposition.Lebesgue): cleaning and a few new basic lemmas

### DIFF
--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -82,15 +82,9 @@ irreducible_def rnDeriv (μ ν : Measure α) : α → ℝ≥0∞ :=
   if h : HaveLebesgueDecomposition μ ν then (Classical.choose h.lebesgue_decomposition).2 else 0
 #align measure_theory.measure.rn_deriv MeasureTheory.Measure.rnDeriv
 
-lemma singularPart_of_not_haveLebesgueDecomposition {μ ν : Measure α}
-    (h : ¬ HaveLebesgueDecomposition μ ν) :
-    μ.singularPart ν = 0 := by
-  rw [singularPart]; exact dif_neg h
+section ByDefinition
 
-lemma rnDeriv_of_not_haveLebesgueDecomposition {μ ν : Measure α}
-    (h : ¬ HaveLebesgueDecomposition μ ν) :
-    μ.rnDeriv ν = 0 := by
-  rw [rnDeriv]; exact dif_neg h
+variable {μ ν : Measure α}
 
 theorem haveLebesgueDecomposition_spec (μ ν : Measure α) [h : HaveLebesgueDecomposition μ ν] :
     Measurable (μ.rnDeriv ν) ∧
@@ -99,24 +93,64 @@ theorem haveLebesgueDecomposition_spec (μ ν : Measure α) [h : HaveLebesgueDec
   exact Classical.choose_spec h.lebesgue_decomposition
 #align measure_theory.measure.have_lebesgue_decomposition_spec MeasureTheory.Measure.haveLebesgueDecomposition_spec
 
-instance instHaveLebesgueDecomposition_zero_left : HaveLebesgueDecomposition 0 ν where
-  lebesgue_decomposition := ⟨⟨0, 0⟩, measurable_zero, MutuallySingular.zero_left, by simp⟩
+lemma rnDeriv_of_not_haveLebesgueDecomposition (h : ¬ HaveLebesgueDecomposition μ ν) :
+    μ.rnDeriv ν = 0 := by
+  rw [rnDeriv, dif_neg h]
 
-instance instHaveLebesgueDecomposition_zero_right : HaveLebesgueDecomposition μ 0 where
-  lebesgue_decomposition := ⟨⟨μ, 0⟩, measurable_zero, MutuallySingular.zero_right, by simp⟩
+lemma singularPart_of_not_haveLebesgueDecomposition (h : ¬ HaveLebesgueDecomposition μ ν) :
+    μ.singularPart ν = 0 := by
+  rw [singularPart, dif_neg h]
+
+@[measurability]
+theorem measurable_rnDeriv (μ ν : Measure α) : Measurable <| μ.rnDeriv ν := by
+  by_cases h : HaveLebesgueDecomposition μ ν
+  · exact (haveLebesgueDecomposition_spec μ ν).1
+  · rw [rnDeriv_of_not_haveLebesgueDecomposition h]
+    exact measurable_zero
+#align measure_theory.measure.measurable_rn_deriv MeasureTheory.Measure.measurable_rnDeriv
+
+theorem mutuallySingular_singularPart (μ ν : Measure α) : μ.singularPart ν ⟂ₘ ν := by
+  by_cases h : HaveLebesgueDecomposition μ ν
+  · exact (haveLebesgueDecomposition_spec μ ν).2.1
+  · rw [singularPart_of_not_haveLebesgueDecomposition h]
+    exact MutuallySingular.zero_left
+#align measure_theory.measure.mutually_singular_singular_part MeasureTheory.Measure.mutuallySingular_singularPart
 
 theorem haveLebesgueDecomposition_add (μ ν : Measure α) [HaveLebesgueDecomposition μ ν] :
     μ = μ.singularPart ν + ν.withDensity (μ.rnDeriv ν) :=
   (haveLebesgueDecomposition_spec μ ν).2.2
 #align measure_theory.measure.have_lebesgue_decomposition_add MeasureTheory.Measure.haveLebesgueDecomposition_add
 
-instance haveLebesgueDecomposition_smul (μ ν : Measure α) [HaveLebesgueDecomposition μ ν]
-    (r : ℝ≥0) : (r • μ).HaveLebesgueDecomposition ν where
+lemma singularPart_add_rnDeriv (μ ν : Measure α) [HaveLebesgueDecomposition μ ν] :
+    μ.singularPart ν + ν.withDensity (μ.rnDeriv ν) = μ := (haveLebesgueDecomposition_add μ ν).symm
+
+lemma rnDeriv_add_singularPart (μ ν : Measure α) [HaveLebesgueDecomposition μ ν] :
+    ν.withDensity (μ.rnDeriv ν) + μ.singularPart ν = μ := by rw [add_comm, singularPart_add_rnDeriv]
+
+end ByDefinition
+
+section HaveLebesgueDecomposition
+
+instance instHaveLebesgueDecomposition_zero_left : HaveLebesgueDecomposition 0 ν where
+  lebesgue_decomposition := ⟨⟨0, 0⟩, measurable_zero, MutuallySingular.zero_left, by simp⟩
+
+instance instHaveLebesgueDecomposition_zero_right : HaveLebesgueDecomposition μ 0 where
+  lebesgue_decomposition := ⟨⟨μ, 0⟩, measurable_zero, MutuallySingular.zero_right, by simp⟩
+
+instance instHaveLebesgueDecomposition_self : HaveLebesgueDecomposition μ μ where
+  lebesgue_decomposition := ⟨⟨0, 1⟩, measurable_const, MutuallySingular.zero_left, by simp⟩
+
+instance haveLebesgueDecomposition_smul' (μ ν : Measure α) [HaveLebesgueDecomposition μ ν]
+    (r : ℝ≥0∞) : (r • μ).HaveLebesgueDecomposition ν where
   lebesgue_decomposition := by
     obtain ⟨hmeas, hsing, hadd⟩ := haveLebesgueDecomposition_spec μ ν
-    refine' ⟨⟨r • μ.singularPart ν, r • μ.rnDeriv ν⟩, hmeas.const_smul _, hsing.smul _, _⟩
+    refine ⟨⟨r • μ.singularPart ν, r • μ.rnDeriv ν⟩, hmeas.const_smul _, hsing.smul _, ?_⟩
     simp only [ENNReal.smul_def]
     rw [withDensity_smul _ hmeas, ← smul_add, ← hadd]
+
+instance haveLebesgueDecomposition_smul (μ ν : Measure α) [HaveLebesgueDecomposition μ ν]
+    (r : ℝ≥0) : (r • μ).HaveLebesgueDecomposition ν := by
+  rw [ENNReal.smul_def]; infer_instance
 #align measure_theory.measure.have_lebesgue_decomposition_smul MeasureTheory.Measure.haveLebesgueDecomposition_smul
 
 instance haveLebesgueDecomposition_smul_right (μ ν : Measure α) [HaveLebesgueDecomposition μ ν]
@@ -138,29 +172,19 @@ instance haveLebesgueDecomposition_smul_right (μ ν : Measure α) [HaveLebesgue
 theorem haveLebesgueDecomposition_withDensity (μ : Measure α) {f : α → ℝ≥0∞} (hf : Measurable f) :
     (μ.withDensity f).HaveLebesgueDecomposition μ := ⟨⟨⟨0, f⟩, hf, .zero_left, (zero_add _).symm⟩⟩
 
-@[measurability]
-theorem measurable_rnDeriv (μ ν : Measure α) : Measurable <| μ.rnDeriv ν := by
-  by_cases h : HaveLebesgueDecomposition μ ν
-  · exact (haveLebesgueDecomposition_spec μ ν).1
-  · rw [rnDeriv, dif_neg h]
-    exact measurable_zero
-#align measure_theory.measure.measurable_rn_deriv MeasureTheory.Measure.measurable_rnDeriv
-
-theorem mutuallySingular_singularPart (μ ν : Measure α) : μ.singularPart ν ⟂ₘ ν := by
-  by_cases h : HaveLebesgueDecomposition μ ν
-  · exact (haveLebesgueDecomposition_spec μ ν).2.1
-  · rw [singularPart, dif_neg h]
-    exact MutuallySingular.zero_left
-#align measure_theory.measure.mutually_singular_singular_part MeasureTheory.Measure.mutuallySingular_singularPart
+instance haveLebesgueDecomposition_rnDeriv (μ ν : Measure α) :
+    HaveLebesgueDecomposition (ν.withDensity (μ.rnDeriv ν)) ν :=
+  haveLebesgueDecomposition_withDensity ν (measurable_rnDeriv _ _)
 
 instance instHaveLebesgueDecomposition_singularPart :
     HaveLebesgueDecomposition (μ.singularPart ν) ν :=
   ⟨⟨μ.singularPart ν, 0⟩, measurable_zero, mutuallySingular_singularPart μ ν, by simp⟩
 
+end HaveLebesgueDecomposition
+
 theorem singularPart_le (μ ν : Measure α) : μ.singularPart ν ≤ μ := by
   by_cases hl : HaveLebesgueDecomposition μ ν
-  · cases' (haveLebesgueDecomposition_spec μ ν).2 with _ h
-    conv_rhs => rw [h]
+  · conv_rhs => rw [haveLebesgueDecomposition_add μ ν]
     exact Measure.le_add_right le_rfl
   · rw [singularPart, dif_neg hl]
     exact Measure.zero_le μ
@@ -168,8 +192,7 @@ theorem singularPart_le (μ ν : Measure α) : μ.singularPart ν ≤ μ := by
 
 theorem withDensity_rnDeriv_le (μ ν : Measure α) : ν.withDensity (μ.rnDeriv ν) ≤ μ := by
   by_cases hl : HaveLebesgueDecomposition μ ν
-  · cases' (haveLebesgueDecomposition_spec μ ν).2 with _ h
-    conv_rhs => rw [h]
+  · conv_rhs => rw [haveLebesgueDecomposition_add μ ν]
     exact Measure.le_add_left le_rfl
   · rw [rnDeriv, dif_neg hl, withDensity_zero]
     exact Measure.zero_le μ
@@ -189,8 +212,7 @@ lemma MutuallySingular.singularPart (h : μ ⟂ₘ ν) (ν' : Measure α) :
     μ.singularPart ν' ⟂ₘ ν :=
   h.mono (singularPart_le μ ν') le_rfl
 
-lemma absolutelyContinuous_withDensity_rnDeriv {μ ν : Measure α} [HaveLebesgueDecomposition ν μ]
-    (hμν : μ ≪ ν) :
+lemma absolutelyContinuous_withDensity_rnDeriv [HaveLebesgueDecomposition ν μ] (hμν : μ ≪ ν) :
     μ ≪ μ.withDensity (ν.rnDeriv μ) := by
   rw [haveLebesgueDecomposition_add ν μ] at hμν
   refine AbsolutelyContinuous.mk (fun s _ hνs ↦ ?_)
@@ -205,6 +227,24 @@ lemma absolutelyContinuous_withDensity_rnDeriv {μ ν : Measure α} [HaveLebesgu
     · exact measure_mono_null (Set.inter_subset_right _ _) ht1
     · exact measure_mono_null (Set.inter_subset_left _ _) hνs
   · exact measure_mono_null (Set.inter_subset_right _ _) ht2
+
+lemma singularPart_eq_zero_of_ac (h : μ ≪ ν) : μ.singularPart ν = 0 := by
+  rw [← MutuallySingular.self_iff]
+  exact MutuallySingular.mono_ac (mutuallySingular_singularPart _ _)
+    AbsolutelyContinuous.rfl ((absolutelyContinuous_of_le (singularPart_le _ _)).trans h)
+
+@[simp]
+theorem singularPart_zero (ν : Measure α) : (0 : Measure α).singularPart ν = 0 :=
+  singularPart_eq_zero_of_ac (AbsolutelyContinuous.zero _)
+#align measure_theory.measure.singular_part_zero MeasureTheory.Measure.singularPart_zero
+
+lemma singularPart_eq_zero (μ ν : Measure α) [μ.HaveLebesgueDecomposition ν] :
+    μ.singularPart ν = 0 ↔ μ ≪ ν := by
+  have h_dec := haveLebesgueDecomposition_add μ ν
+  refine ⟨fun h ↦ ?_, singularPart_eq_zero_of_ac⟩
+  rw [h, zero_add] at h_dec
+  rw [h_dec]
+  exact withDensity_absolutelyContinuous ν _
 
 @[simp]
 lemma withDensity_rnDeriv_eq_zero (μ ν : Measure α) [μ.HaveLebesgueDecomposition ν] :
@@ -228,17 +268,33 @@ lemma rnDeriv_zero (ν : Measure α) : (0 : Measure α).rnDeriv ν =ᵐ[ν] 0 :=
   rw [rnDeriv_eq_zero]
   exact MutuallySingular.zero_left
 
-lemma MutuallySingular.rnDeriv_ae_eq_zero {μ ν : Measure α} (hμν : μ ⟂ₘ ν) :
+lemma MutuallySingular.rnDeriv_ae_eq_zero (hμν : μ ⟂ₘ ν) :
     μ.rnDeriv ν =ᵐ[ν] 0 := by
   by_cases h : μ.HaveLebesgueDecomposition ν
   · rw [rnDeriv_eq_zero]
     exact hμν
   · rw [rnDeriv_of_not_haveLebesgueDecomposition h]
 
+theorem singularPart_withDensity (ν : Measure α) (f : α → ℝ≥0∞) :
+    (ν.withDensity f).singularPart ν = 0 :=
+  singularPart_eq_zero_of_ac (withDensity_absolutelyContinuous _ _)
+#align measure_theory.measure.singular_part_with_density MeasureTheory.Measure.singularPart_withDensity
+
 lemma rnDeriv_singularPart (μ ν : Measure α) :
     (μ.singularPart ν).rnDeriv ν =ᵐ[ν] 0 := by
   rw [rnDeriv_eq_zero]
   exact mutuallySingular_singularPart μ ν
+
+lemma singularPart_self (μ : Measure α) : μ.singularPart μ = 0 :=
+  singularPart_eq_zero_of_ac Measure.AbsolutelyContinuous.rfl
+
+lemma rnDeriv_self (μ : Measure α) [SigmaFinite μ] : μ.rnDeriv μ =ᵐ[μ] fun _ ↦ 1 := by
+  have h := rnDeriv_add_singularPart μ μ
+  rw [singularPart_self, add_zero] at h
+  have h_one : μ = μ.withDensity 1 := by simp
+  conv_rhs at h => rw [h_one]
+  rwa [withDensity_eq_iff_of_sigmaFinite (measurable_rnDeriv _ _).aemeasurable] at h
+  exact aemeasurable_const
 
 instance singularPart.instIsFiniteMeasure [IsFiniteMeasure μ] :
     IsFiniteMeasure (μ.singularPart ν) :=
@@ -269,16 +325,17 @@ instance withDensity.instIsLocallyFiniteMeasure [TopologicalSpace α] [IsLocally
   isLocallyFiniteMeasure_of_le <| withDensity_rnDeriv_le μ ν
 #align measure_theory.measure.with_density.measure_theory.is_locally_finite_measure MeasureTheory.Measure.withDensity.instIsLocallyFiniteMeasure
 
-theorem lintegral_rnDeriv_lt_top_of_measure_ne_top {μ : Measure α} (ν : Measure α) {s : Set α}
-    (hs : μ s ≠ ∞) : ∫⁻ x in s, μ.rnDeriv ν x ∂ν < ∞ := by
+section RNDerivFinite
+
+theorem lintegral_rnDeriv_lt_top_of_measure_ne_top (ν : Measure α) {s : Set α} (hs : μ s ≠ ∞) :
+    ∫⁻ x in s, μ.rnDeriv ν x ∂ν < ∞ := by
   by_cases hl : HaveLebesgueDecomposition μ ν
-  · obtain ⟨-, -, hadd⟩ := haveLebesgueDecomposition_spec μ ν
-    suffices (∫⁻ x in toMeasurable μ s, μ.rnDeriv ν x ∂ν) < ∞ from
+  · suffices (∫⁻ x in toMeasurable μ s, μ.rnDeriv ν x ∂ν) < ∞ from
       lt_of_le_of_lt (lintegral_mono_set (subset_toMeasurable _ _)) this
     rw [← withDensity_apply _ (measurableSet_toMeasurable _ _)]
     calc
       _ ≤ (singularPart μ ν) (toMeasurable μ s) + _ := le_add_self
-      _ = μ s := by rw [← Measure.add_apply, ← hadd, measure_toMeasurable]
+      _ = μ s := by rw [← Measure.add_apply, ← haveLebesgueDecomposition_add, measure_toMeasurable]
       _ < ⊤ := hs.lt_top
   · simp only [Measure.rnDeriv, dif_neg hl, Pi.zero_apply, lintegral_zero, ENNReal.zero_lt_top]
 #align measure_theory.measure.lintegral_rn_deriv_lt_top_of_measure_ne_top MeasureTheory.Measure.lintegral_rnDeriv_lt_top_of_measure_ne_top
@@ -289,7 +346,7 @@ theorem lintegral_rnDeriv_lt_top (μ ν : Measure α) [IsFiniteMeasure μ] :
   exact lintegral_rnDeriv_lt_top_of_measure_ne_top _ (measure_lt_top _ _).ne
 #align measure_theory.measure.lintegral_rn_deriv_lt_top MeasureTheory.Measure.lintegral_rnDeriv_lt_top
 
-lemma integrable_toReal_rnDeriv {μ ν : Measure α} [IsFiniteMeasure μ] :
+lemma integrable_toReal_rnDeriv [IsFiniteMeasure μ] :
     Integrable (fun x ↦ (μ.rnDeriv ν x).toReal) ν :=
   integrable_toReal_of_lintegral_ne_top (Measure.measurable_rnDeriv _ _).aemeasurable
     (Measure.lintegral_rnDeriv_lt_top _ _).ne
@@ -302,12 +359,14 @@ theorem rnDeriv_lt_top (μ ν : Measure α) [SigmaFinite μ] : ∀ᵐ x ∂ν, �
   intro n
   rw [← ae_restrict_iff' (measurable_spanningSets _ _)]
   apply ae_lt_top (measurable_rnDeriv _ _)
-  refine' (lintegral_rnDeriv_lt_top_of_measure_ne_top _ _).ne
+  refine (lintegral_rnDeriv_lt_top_of_measure_ne_top _ ?_).ne
   exact (measure_spanningSets_lt_top _ _).ne
 #align measure_theory.measure.rn_deriv_lt_top MeasureTheory.Measure.rnDeriv_lt_top
 
 lemma rnDeriv_ne_top (μ ν : Measure α) [SigmaFinite μ] : ∀ᵐ x ∂ν, μ.rnDeriv ν x ≠ ∞ := by
   filter_upwards [Measure.rnDeriv_lt_top μ ν] with x hx using hx.ne
+
+end RNDerivFinite
 
 /-- Given measures `μ` and `ν`, if `s` is a measure mutually singular to `ν` and `f` is a
 measurable function such that `μ = s + fν`, then `s = μ.singularPart μ`.
@@ -323,16 +382,16 @@ theorem eq_singularPart {s : Measure α} {f : α → ℝ≥0∞} (hf : Measurabl
   rw [hadd'] at hadd
   have hνinter : ν (S ∩ T)ᶜ = 0 := by
     rw [compl_inter]
-    refine' nonpos_iff_eq_zero.1 (le_trans (measure_union_le _ _) _)
+    refine nonpos_iff_eq_zero.1 (le_trans (measure_union_le _ _) ?_)
     rw [hT₃, hS₃, add_zero]
   have heq : s.restrict (S ∩ T)ᶜ = (μ.singularPart ν).restrict (S ∩ T)ᶜ := by
     ext1 A hA
     have hf : ν.withDensity f (A ∩ (S ∩ T)ᶜ) = 0 := by
-      refine' withDensity_absolutelyContinuous ν _ _
+      refine withDensity_absolutelyContinuous ν _ ?_
       rw [← nonpos_iff_eq_zero]
       exact hνinter ▸ measure_mono (inter_subset_right _ _)
     have hrn : ν.withDensity (μ.rnDeriv ν) (A ∩ (S ∩ T)ᶜ) = 0 := by
-      refine' withDensity_absolutelyContinuous ν _ _
+      refine withDensity_absolutelyContinuous ν _ ?_
       rw [← nonpos_iff_eq_zero]
       exact hνinter ▸ measure_mono (inter_subset_right _ _)
     rw [restrict_apply hA, restrict_apply hA, ← add_zero (s (A ∩ (S ∩ T)ᶜ)), ← hf, ← add_apply, ←
@@ -350,23 +409,17 @@ theorem eq_singularPart {s : Measure α} {f : α → ℝ≥0∞} (hf : Measurabl
   rw [heq' A hA, heq, restrict_apply hA, ← diff_eq, AEDisjoint.measure_diff_left hμinter]
 #align measure_theory.measure.eq_singular_part MeasureTheory.Measure.eq_singularPart
 
-theorem singularPart_zero (ν : Measure α) : (0 : Measure α).singularPart ν = 0 := by
-  refine' (eq_singularPart measurable_zero MutuallySingular.zero_left _).symm
-  rw [zero_add, withDensity_zero]
-#align measure_theory.measure.singular_part_zero MeasureTheory.Measure.singularPart_zero
-
 theorem singularPart_smul (μ ν : Measure α) (r : ℝ≥0) :
     (r • μ).singularPart ν = r • μ.singularPart ν := by
   by_cases hr : r = 0
   · rw [hr, zero_smul, zero_smul, singularPart_zero]
   by_cases hl : HaveLebesgueDecomposition μ ν
-  · refine'
-      (eq_singularPart ((measurable_rnDeriv μ ν).const_smul (r : ℝ≥0∞))
-          (MutuallySingular.smul r (haveLebesgueDecomposition_spec _ _).2.1) _).symm
+  · refine (eq_singularPart ((measurable_rnDeriv μ ν).const_smul (r : ℝ≥0∞))
+          (MutuallySingular.smul r (mutuallySingular_singularPart _ _)) ?_).symm
     rw [withDensity_smul _ (measurable_rnDeriv _ _), ← smul_add,
       ← haveLebesgueDecomposition_add μ ν, ENNReal.smul_def]
   · rw [singularPart, singularPart, dif_neg hl, dif_neg, smul_zero]
-    refine' fun hl' => hl _
+    refine fun hl' ↦ hl ?_
     rw [← inv_smul_smul₀ hr μ]
     exact Measure.haveLebesgueDecomposition_smul _ _ _
 #align measure_theory.measure.singular_part_smul MeasureTheory.Measure.singularPart_smul
@@ -384,29 +437,20 @@ theorem singularPart_smul_right (μ ν : Measure α) (r : ℝ≥0) (hr : r ≠ 0
       simp only [Pi.smul_apply]
       rw [← ENNReal.smul_def, smul_inv_smul₀ hr]
   · rw [singularPart, singularPart, dif_neg hl, dif_neg]
-    refine fun hl' => hl ?_
+    refine fun hl' ↦ hl ?_
     rw [← inv_smul_smul₀ hr ν]
     infer_instance
 
 theorem singularPart_add (μ₁ μ₂ ν : Measure α) [HaveLebesgueDecomposition μ₁ ν]
     [HaveLebesgueDecomposition μ₂ ν] :
     (μ₁ + μ₂).singularPart ν = μ₁.singularPart ν + μ₂.singularPart ν := by
-  refine'
-    (eq_singularPart ((measurable_rnDeriv μ₁ ν).add (measurable_rnDeriv μ₂ ν))
-        ((haveLebesgueDecomposition_spec _ _).2.1.add_left
-          (haveLebesgueDecomposition_spec _ _).2.1)
-        _).symm
+  refine (eq_singularPart ((measurable_rnDeriv μ₁ ν).add (measurable_rnDeriv μ₂ ν))
+    ((mutuallySingular_singularPart _ _).add_left (mutuallySingular_singularPart _ _)) ?_).symm
   erw [withDensity_add_left (measurable_rnDeriv μ₁ ν)]
   conv_rhs => rw [add_assoc, add_comm (μ₂.singularPart ν), ← add_assoc, ← add_assoc]
   rw [← haveLebesgueDecomposition_add μ₁ ν, add_assoc, add_comm (ν.withDensity (μ₂.rnDeriv ν)),
     ← haveLebesgueDecomposition_add μ₂ ν]
 #align measure_theory.measure.singular_part_add MeasureTheory.Measure.singularPart_add
-
-theorem singularPart_withDensity (ν : Measure α) {f : α → ℝ≥0∞} (hf : Measurable f) :
-    (ν.withDensity f).singularPart ν = 0 :=
-  have : ν.withDensity f = 0 + ν.withDensity f := by rw [zero_add]
-  (eq_singularPart hf MutuallySingular.zero_left this).symm
-#align measure_theory.measure.singular_part_with_density MeasureTheory.Measure.singularPart_withDensity
 
 /-- Given measures `μ` and `ν`, if `s` is a measure mutually singular to `ν` and `f` is a
 measurable function such that `μ = s + fν`, then `f = μ.rnDeriv ν`.
@@ -423,7 +467,7 @@ theorem eq_withDensity_rnDeriv {s : Measure α} {f : α → ℝ≥0∞} (hf : Me
   rw [hadd'] at hadd
   have hνinter : ν (S ∩ T)ᶜ = 0 := by
     rw [compl_inter]
-    refine' nonpos_iff_eq_zero.1 (le_trans (measure_union_le _ _) _)
+    refine nonpos_iff_eq_zero.1 (le_trans (measure_union_le _ _) ?_)
     rw [hT₃, hS₃, add_zero]
   have heq :
     (ν.withDensity f).restrict (S ∩ T) = (ν.withDensity (μ.rnDeriv ν)).restrict (S ∩ T) := by
@@ -454,13 +498,13 @@ theorem eq_withDensity_rnDeriv {s : Measure α} {f : α → ℝ≥0∞} (hf : Me
     restrict_apply hA, ← diff_eq, measure_inter_add_diff _ (hS₁.inter hT₁)]
 #align measure_theory.measure.eq_with_density_rn_deriv MeasureTheory.Measure.eq_withDensity_rnDeriv
 
-theorem eq_withDensity_rnDeriv₀ {μ ν : Measure α} {s : Measure α} {f : α → ℝ≥0∞}
+theorem eq_withDensity_rnDeriv₀ {s : Measure α} {f : α → ℝ≥0∞}
     (hf : AEMeasurable f ν) (hs : s ⟂ₘ ν) (hadd : μ = s + ν.withDensity f) :
     ν.withDensity f = ν.withDensity (μ.rnDeriv ν) := by
   rw [withDensity_congr_ae hf.ae_eq_mk] at hadd ⊢
   exact eq_withDensity_rnDeriv hf.measurable_mk hs hadd
 
-theorem eq_rnDeriv₀ {μ ν : Measure α} [SigmaFinite ν] {s : Measure α} {f : α → ℝ≥0∞}
+theorem eq_rnDeriv₀ [SigmaFinite ν] {s : Measure α} {f : α → ℝ≥0∞}
     (hf : AEMeasurable f ν) (hs : s ⟂ₘ ν) (hadd : μ = s + ν.withDensity f) :
     f =ᵐ[ν] μ.rnDeriv ν :=
   (withDensity_eq_iff_of_sigmaFinite hf (measurable_rnDeriv _ _).aemeasurable).mp
@@ -477,9 +521,6 @@ theorem eq_rnDeriv [SigmaFinite ν] {s : Measure α} {f : α → ℝ≥0∞} (hf
     (hadd : μ = s + ν.withDensity f) : f =ᵐ[ν] μ.rnDeriv ν :=
   eq_rnDeriv₀ hf.aemeasurable hs hadd
 #align measure_theory.measure.eq_rn_deriv MeasureTheory.Measure.eq_rnDeriv
-
-lemma rnDeriv_self (μ : Measure α) [SigmaFinite μ] : μ.rnDeriv μ =ᵐ[μ] fun _ ↦ 1 :=
-  (eq_rnDeriv (measurable_const) MutuallySingular.zero_left (by simp)).symm
 
 /-- The Radon-Nikodym derivative of `f ν` with respect to `ν` is `f`. -/
 theorem rnDeriv_withDensity₀ (ν : Measure α) [SigmaFinite ν] {f : α → ℝ≥0∞}
@@ -608,7 +649,7 @@ theorem exists_positive_of_not_mutuallySingular (μ ν : Measure α) [IsFiniteMe
   -- set `A` to be the intersection of all the negative parts of obtained Hahn decompositions
   -- and we show that `μ A = 0`
   set A := ⋂ n, (f n)ᶜ with hA₁
-  have hAmeas : MeasurableSet A := MeasurableSet.iInter fun n => (hf₁ n).compl
+  have hAmeas : MeasurableSet A := MeasurableSet.iInter fun n ↦ (hf₁ n).compl
   have hA₂ : ∀ n : ℕ, μ.toSignedMeasure - ((1 / (n + 1) : ℝ≥0) • ν).toSignedMeasure ≤[A] 0 := by
     intro n; exact restrict_le_restrict_subset _ _ (hf₁ n).compl (hf₃ n) (iInter_subset _ _)
   have hA₃ : ∀ n : ℕ, μ A ≤ (1 / (n + 1) : ℝ≥0) * ν A := by
@@ -628,10 +669,8 @@ theorem exists_positive_of_not_mutuallySingular (μ ν : Measure α) [IsFiniteMe
         exact h' (not_le.2 (NNReal.half_lt_self h))
       intro c hc
       have : ∃ n : ℕ, 1 / (n + 1 : ℝ) < c * (νA : ℝ)⁻¹ := by
-        refine' exists_nat_one_div_lt _
-        refine' mul_pos hc _
-        rw [_root_.inv_pos]
-        exact hb
+        refine exists_nat_one_div_lt ?_
+        positivity
       rcases this with ⟨n, hn⟩
       have hb₁ : (0 : ℝ) < (νA : ℝ)⁻¹ := by rw [_root_.inv_pos]; exact hb
       have h' : 1 / (↑n + 1) * νA < c := by
@@ -640,7 +679,7 @@ theorem exists_positive_of_not_mutuallySingular (μ ν : Measure α) [IsFiniteMe
           NNReal.coe_inv]
         · exact hn
         · exact hb.ne'
-      refine' le_trans _ (le_of_lt h')
+      refine le_trans ?_ h'.le
       rw [← ENNReal.coe_le_coe, ENNReal.coe_mul]
       exact hA₃ n
     · rw [not_lt, le_zero_iff] at hb
@@ -671,17 +710,17 @@ def measurableLE (μ ν : Measure α) : Set (α → ℝ≥0∞) :=
 #align measure_theory.measure.lebesgue_decomposition.measurable_le MeasureTheory.Measure.LebesgueDecomposition.measurableLE
 
 theorem zero_mem_measurableLE : (0 : α → ℝ≥0∞) ∈ measurableLE μ ν :=
-  ⟨measurable_zero, fun A _ => by simp⟩
+  ⟨measurable_zero, fun A _ ↦ by simp⟩
 #align measure_theory.measure.lebesgue_decomposition.zero_mem_measurable_le MeasureTheory.Measure.LebesgueDecomposition.zero_mem_measurableLE
 
 theorem sup_mem_measurableLE {f g : α → ℝ≥0∞} (hf : f ∈ measurableLE μ ν)
-    (hg : g ∈ measurableLE μ ν) : (fun a => f a ⊔ g a) ∈ measurableLE μ ν := by
+    (hg : g ∈ measurableLE μ ν) : (fun a ↦ f a ⊔ g a) ∈ measurableLE μ ν := by
   simp_rw [ENNReal.sup_eq_max]
-  refine' ⟨Measurable.max hf.1 hg.1, fun A hA => _⟩
+  refine ⟨Measurable.max hf.1 hg.1, fun A hA ↦ ?_⟩
   have h₁ := hA.inter (measurableSet_le hf.1 hg.1)
   have h₂ := hA.inter (measurableSet_lt hg.1 hf.1)
   rw [set_lintegral_max hf.1 hg.1]
-  refine' (add_le_add (hg.2 _ h₁) (hf.2 _ h₂)).trans_eq _
+  refine (add_le_add (hg.2 _ h₁) (hf.2 _ h₂)).trans_eq ?_
   · simp only [← not_le, ← compl_setOf, ← diff_eq]
     exact measure_inter_add_diff _ (measurableSet_le hf.1 hg.1)
 #align measure_theory.measure.lebesgue_decomposition.sup_mem_measurable_le MeasureTheory.Measure.LebesgueDecomposition.sup_mem_measurableLE
@@ -691,26 +730,26 @@ theorem iSup_succ_eq_sup {α} (f : ℕ → α → ℝ≥0∞) (m : ℕ) (a : α)
   set c := ⨆ (k : ℕ) (_ : k ≤ m + 1), f k a with hc
   set d := f m.succ a ⊔ ⨆ (k : ℕ) (_ : k ≤ m), f k a with hd
   rw [le_antisymm_iff, hc, hd]
-  refine' ⟨_, _⟩
-  · refine' iSup₂_le fun n hn => _
+  constructor
+  · refine iSup₂_le fun n hn ↦ ?_
     rcases Nat.of_le_succ hn with (h | h)
-    · exact le_sup_of_le_right (le_iSup₂ (f := fun k (_ : k ≤ m) => f k a) n h)
+    · exact le_sup_of_le_right (le_iSup₂ (f := fun k (_ : k ≤ m) ↦ f k a) n h)
     · exact h ▸ le_sup_left
-  · refine' sup_le _ (biSup_mono fun n hn => hn.trans m.le_succ)
-    exact @le_iSup₂ ℝ≥0∞ ℕ (fun i => i ≤ m + 1) _ _ (m + 1) le_rfl
+  · refine sup_le ?_ (biSup_mono fun n hn ↦ hn.trans m.le_succ)
+    exact @le_iSup₂ ℝ≥0∞ ℕ (fun i ↦ i ≤ m + 1) _ _ (m + 1) le_rfl
 #align measure_theory.measure.lebesgue_decomposition.supr_succ_eq_sup MeasureTheory.Measure.LebesgueDecomposition.iSup_succ_eq_sup
 
 theorem iSup_mem_measurableLE (f : ℕ → α → ℝ≥0∞) (hf : ∀ n, f n ∈ measurableLE μ ν) (n : ℕ) :
-    (fun x => ⨆ (k) (_ : k ≤ n), f k x) ∈ measurableLE μ ν := by
+    (fun x ↦ ⨆ (k) (_ : k ≤ n), f k x) ∈ measurableLE μ ν := by
   induction' n with m hm
-  · refine' ⟨_, _⟩
+  · constructor
     · simp [(hf 0).1]
     · intro A hA; simp [(hf 0).2 A hA]
   · have :
-      (fun a : α => ⨆ (k : ℕ) (_ : k ≤ m + 1), f k a) = fun a =>
+      (fun a : α ↦ ⨆ (k : ℕ) (_ : k ≤ m + 1), f k a) = fun a ↦
         f m.succ a ⊔ ⨆ (k : ℕ) (_ : k ≤ m), f k a :=
-      funext fun _ => iSup_succ_eq_sup _ _ _
-    refine' ⟨measurable_iSup fun n => Measurable.iSup_Prop _ (hf n).1, fun A hA => _⟩
+      funext fun _ ↦ iSup_succ_eq_sup _ _ _
+    refine ⟨measurable_iSup fun n ↦ Measurable.iSup_Prop _ (hf n).1, fun A hA ↦ ?_⟩
     rw [this]; exact (sup_mem_measurableLE (hf m.succ) hm).2 A hA
 #align measure_theory.measure.lebesgue_decomposition.supr_mem_measurable_le MeasureTheory.Measure.LebesgueDecomposition.iSup_mem_measurableLE
 
@@ -725,24 +764,24 @@ section SuprLemmas
 --TODO: these statements should be moved elsewhere
 
 theorem iSup_monotone {α : Type*} (f : ℕ → α → ℝ≥0∞) :
-    Monotone fun n x => ⨆ (k) (_ : k ≤ n), f k x := fun _ _ hnm _ =>
-  biSup_mono fun _ => ge_trans hnm
+    Monotone fun n x ↦ ⨆ (k) (_ : k ≤ n), f k x :=
+  fun _ _ hnm _ ↦ biSup_mono fun _ ↦ ge_trans hnm
 #align measure_theory.measure.lebesgue_decomposition.supr_monotone MeasureTheory.Measure.LebesgueDecomposition.iSup_monotone
 
 theorem iSup_monotone' {α : Type*} (f : ℕ → α → ℝ≥0∞) (x : α) :
-    Monotone fun n => ⨆ (k) (_ : k ≤ n), f k x := fun _ _ hnm => iSup_monotone f hnm x
+    Monotone fun n ↦ ⨆ (k) (_ : k ≤ n), f k x := fun _ _ hnm ↦ iSup_monotone f hnm x
 #align measure_theory.measure.lebesgue_decomposition.supr_monotone' MeasureTheory.Measure.LebesgueDecomposition.iSup_monotone'
 
 theorem iSup_le_le {α : Type*} (f : ℕ → α → ℝ≥0∞) (n k : ℕ) (hk : k ≤ n) :
-    f k ≤ fun x => ⨆ (k) (_ : k ≤ n), f k x :=
-  fun x => le_iSup₂ (f := fun k (_ : k ≤ n) => f k x) k hk
+    f k ≤ fun x ↦ ⨆ (k) (_ : k ≤ n), f k x :=
+  fun x ↦ le_iSup₂ (f := fun k (_ : k ≤ n) ↦ f k x) k hk
 #align measure_theory.measure.lebesgue_decomposition.supr_le_le MeasureTheory.Measure.LebesgueDecomposition.iSup_le_le
 
 end SuprLemmas
 
 /-- `measurableLEEval μ ν` is the set of `∫⁻ x, f x ∂μ` for all `f ∈ measurableLE μ ν`. -/
 def measurableLEEval (μ ν : Measure α) : Set ℝ≥0∞ :=
-  (fun f : α → ℝ≥0∞ => ∫⁻ x, f x ∂μ) '' measurableLE μ ν
+  (fun f : α → ℝ≥0∞ ↦ ∫⁻ x, f x ∂μ) '' measurableLE μ ν
 #align measure_theory.measure.lebesgue_decomposition.measurable_le_eval MeasureTheory.Measure.LebesgueDecomposition.measurableLEEval
 
 end LebesgueDecomposition
@@ -758,34 +797,33 @@ This is not an instance since this is also shown for the more general σ-finite 
 theorem haveLebesgueDecomposition_of_finiteMeasure [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
     HaveLebesgueDecomposition μ ν :=
   ⟨by
-    have h :=
-      @exists_seq_tendsto_sSup _ _ _ _ _ (measurableLEEval ν μ)
-        ⟨0, 0, zero_mem_measurableLE, by simp⟩ (OrderTop.bddAbove _)
+    have h := @exists_seq_tendsto_sSup _ _ _ _ _ (measurableLEEval ν μ)
+      ⟨0, 0, zero_mem_measurableLE, by simp⟩ (OrderTop.bddAbove _)
     choose g _ hg₂ f hf₁ hf₂ using h
     -- we set `ξ` to be the supremum of an increasing sequence of functions obtained from above
     set ξ := ⨆ (n) (k) (_ : k ≤ n), f k with hξ
     -- we see that `ξ` has the largest integral among all functions in `measurableLE`
     have hξ₁ : sSup (measurableLEEval ν μ) = ∫⁻ a, ξ a ∂ν := by
       have :=
-        @lintegral_tendsto_of_tendsto_of_monotone _ _ ν (fun n => ⨆ (k) (_ : k ≤ n), f k)
+        @lintegral_tendsto_of_tendsto_of_monotone _ _ ν (fun n ↦ ⨆ (k) (_ : k ≤ n), f k)
           (⨆ (n) (k) (_ : k ≤ n), f k) ?_ ?_ ?_
-      · refine' tendsto_nhds_unique _ this
-        refine' tendsto_of_tendsto_of_tendsto_of_le_of_le hg₂ tendsto_const_nhds _ _
+      · refine tendsto_nhds_unique ?_ this
+        refine tendsto_of_tendsto_of_tendsto_of_le_of_le hg₂ tendsto_const_nhds ?_ ?_
         · intro n; rw [← hf₂ n]
           apply lintegral_mono
           simp only [iSup_apply, iSup_le_le f n n le_rfl]
         · intro n
           exact le_sSup ⟨⨆ (k : ℕ) (_ : k ≤ n), f k, iSup_mem_measurableLE' _ hf₁ _, rfl⟩
       · intro n
-        refine' Measurable.aemeasurable _
+        refine Measurable.aemeasurable ?_
         convert (iSup_mem_measurableLE _ hf₁ n).1
         simp
-      · refine' Filter.eventually_of_forall fun a => _
+      · refine Filter.eventually_of_forall fun a ↦ ?_
         simp [iSup_monotone' f _]
-      · refine' Filter.eventually_of_forall fun a => _
+      · refine Filter.eventually_of_forall fun a ↦ ?_
         simp [tendsto_atTop_iSup (iSup_monotone' f a)]
     have hξm : Measurable ξ := by
-      convert measurable_iSup fun n => (iSup_mem_measurableLE _ hf₁ n).1
+      convert measurable_iSup fun n ↦ (iSup_mem_measurableLE _ hf₁ n).1
       simp [hξ]
     -- `ξ` is the `f` in the theorem statement and we set `μ₁` to be `μ - ν.withDensity ξ`
     -- since we need `μ₁ + ν.withDensity ξ = μ`
@@ -794,14 +832,14 @@ theorem haveLebesgueDecomposition_of_finiteMeasure [IsFiniteMeasure μ] [IsFinit
       refine le_iff.2 fun B hB ↦ ?_
       rw [hξ, withDensity_apply _ hB]
       simp_rw [iSup_apply]
-      rw [lintegral_iSup (fun i => (iSup_mem_measurableLE _ hf₁ i).1) (iSup_monotone _)]
-      exact iSup_le fun i => (iSup_mem_measurableLE _ hf₁ i).2 B hB
+      rw [lintegral_iSup (fun i ↦ (iSup_mem_measurableLE _ hf₁ i).1) (iSup_monotone _)]
+      exact iSup_le fun i ↦ (iSup_mem_measurableLE _ hf₁ i).2 B hB
     have : IsFiniteMeasure (ν.withDensity ξ) := by
-      refine' isFiniteMeasure_withDensity _
+      refine isFiniteMeasure_withDensity ?_
       have hle' := hle univ
       rw [withDensity_apply _ MeasurableSet.univ, Measure.restrict_univ] at hle'
       exact ne_top_of_le_ne_top (measure_ne_top _ _) hle'
-    refine' ⟨⟨μ₁, ξ⟩, hξm, _, _⟩
+    refine ⟨⟨μ₁, ξ⟩, hξm, ?_, ?_⟩
     · by_contra h
       -- if they are not mutually singular, then from `exists_positive_of_not_mutuallySingular`,
       -- there exists some `ε > 0` and a measurable set `E`, such that `μ(E) > 0` and `E` is
@@ -811,8 +849,8 @@ theorem haveLebesgueDecomposition_of_finiteMeasure [IsFiniteMeasure μ] [IsFinit
       have hξle : ∀ A, MeasurableSet A → (∫⁻ a in A, ξ a ∂ν) ≤ μ A := by
         intro A hA; rw [hξ]
         simp_rw [iSup_apply]
-        rw [lintegral_iSup (fun n => (iSup_mem_measurableLE _ hf₁ n).1) (iSup_monotone _)]
-        exact iSup_le fun n => (iSup_mem_measurableLE _ hf₁ n).2 A hA
+        rw [lintegral_iSup (fun n ↦ (iSup_mem_measurableLE _ hf₁ n).1) (iSup_monotone _)]
+        exact iSup_le fun n ↦ (iSup_mem_measurableLE _ hf₁ n).2 A hA
       -- since `E` is positive, we have `∫⁻ a in A ∩ E, ε + ξ a ∂ν ≤ μ (A ∩ E)` for all `A`
       have hε₂ : ∀ A : Set α, MeasurableSet A → (∫⁻ a in A ∩ E, ε + ξ a ∂ν) ≤ μ (A ∩ E) := by
         intro A hA
@@ -832,10 +870,10 @@ theorem haveLebesgueDecomposition_of_finiteMeasure [IsFiniteMeasure μ] [IsFinit
           exact hξle (A ∩ E) (hA.inter hE₁)
       -- from this, we can show `ξ + ε * E.indicator` is a function in `measurableLE` with
       -- integral greater than `ξ`
-      have hξε : (ξ + E.indicator fun _ => (ε : ℝ≥0∞)) ∈ measurableLE ν μ := by
-        refine' ⟨Measurable.add hξm (Measurable.indicator measurable_const hE₁), fun A hA => _⟩
+      have hξε : (ξ + E.indicator fun _ ↦ (ε : ℝ≥0∞)) ∈ measurableLE ν μ := by
+        refine ⟨Measurable.add hξm (Measurable.indicator measurable_const hE₁), fun A hA ↦ ?_⟩
         have :
-          (∫⁻ a in A, (ξ + E.indicator fun _ => (ε : ℝ≥0∞)) a ∂ν) =
+          (∫⁻ a in A, (ξ + E.indicator fun _ ↦ (ε : ℝ≥0∞)) a ∂ν) =
             (∫⁻ a in A ∩ E, ε + ξ a ∂ν) + ∫⁻ a in A \ E, ξ a ∂ν := by
           simp only [lintegral_add_left measurable_const, lintegral_add_left hξm,
             set_lintegral_const, add_assoc, lintegral_inter_add_diff _ _ hE₁, Pi.add_apply,
@@ -843,12 +881,12 @@ theorem haveLebesgueDecomposition_of_finiteMeasure [IsFiniteMeasure μ] [IsFinit
           rw [inter_comm, add_comm]
         rw [this, ← measure_inter_add_diff A hE₁]
         exact add_le_add (hε₂ A hA) (hξle (A \ E) (hA.diff hE₁))
-      have : (∫⁻ a, ξ a + E.indicator (fun _ => (ε : ℝ≥0∞)) a ∂ν) ≤ sSup (measurableLEEval ν μ) :=
-        le_sSup ⟨ξ + E.indicator fun _ => (ε : ℝ≥0∞), hξε, rfl⟩
+      have : (∫⁻ a, ξ a + E.indicator (fun _ ↦ (ε : ℝ≥0∞)) a ∂ν) ≤ sSup (measurableLEEval ν μ) :=
+        le_sSup ⟨ξ + E.indicator fun _ ↦ (ε : ℝ≥0∞), hξε, rfl⟩
       -- but this contradicts the maximality of `∫⁻ x, ξ x ∂ν`
-      refine' not_lt.2 this _
+      refine not_lt.2 this ?_
       rw [hξ₁, lintegral_add_left hξm, lintegral_indicator _ hE₁, set_lintegral_const]
-      refine' ENNReal.lt_add_right _ (ENNReal.mul_pos_iff.2 ⟨ENNReal.coe_pos.2 hε₁, hE₂⟩).ne'
+      refine ENNReal.lt_add_right ?_ (ENNReal.mul_pos_iff.2 ⟨ENNReal.coe_pos.2 hε₁, hE₂⟩).ne'
       have := measure_ne_top (ν.withDensity ξ) univ
       rwa [withDensity_apply _ MeasurableSet.univ, Measure.restrict_univ] at this
     -- since `ν.withDensity ξ ≤ μ`, it is clear that `μ = μ₁ + ν.withDensity ξ`
@@ -878,38 +916,35 @@ instance (priority := 100) haveLebesgueDecomposition_of_sigmaFinite (μ ν : Mea
     -- We define `μn` and `νn` as sequences of measures such that `μn n = μ ∩ S n` and
     -- `νn n = ν ∩ S n` where `S` is the aforementioned finite spanning set sequence.
     -- Since `S` is spanning, it is clear that `sum μn = μ` and `sum νn = ν`
-    set μn : ℕ → Measure α := fun n => μ.restrict (S.set n) with hμn
+    set μn : ℕ → Measure α := fun n ↦ μ.restrict (S.set n) with hμn
     have hμ : μ = sum μn := by rw [hμn, ← restrict_iUnion h₂ S.set_mem, S.spanning, restrict_univ]
-    set νn : ℕ → Measure α := fun n => ν.restrict (T.set n) with hνn
+    set νn : ℕ → Measure α := fun n ↦ ν.restrict (T.set n) with hνn
     have hν : ν = sum νn := by rw [hνn, ← restrict_iUnion h₃ T.set_mem, T.spanning, restrict_univ]
     -- As `S` is finite with respect to both `μ` and `ν`, it is clear that `μn n` and `νn n` are
     -- finite measures for all `n : ℕ`. Thus, we may apply the finite Lebesgue decomposition theorem
     -- to `μn n` and `νn n`. We define `ξ` as the sum of the singular part of the Lebesgue
     -- decompositions of `μn n` and `νn n`, and `f` as the sum of the Radon-Nikodym derivatives of
     -- `μn n` and `νn n` restricted on `S n`
-    set ξ := sum fun n => singularPart (μn n) (νn n) with hξ
+    set ξ := sum fun n ↦ singularPart (μn n) (νn n) with hξ
     set f := ∑' n, (S.set n).indicator (rnDeriv (μn n) (νn n))
     -- I claim `ξ` and `f` form a Lebesgue decomposition of `μ` and `ν`
-    refine' ⟨⟨ξ, f⟩, _, _, _⟩
-    · exact
-        Measurable.ennreal_tsum' fun n =>
-          Measurable.indicator (measurable_rnDeriv (μn n) (νn n)) (S.set_mem n)
+    refine ⟨⟨ξ, f⟩, ?_, ?_, ?_⟩
+    · exact Measurable.ennreal_tsum'
+        fun n ↦ Measurable.indicator (measurable_rnDeriv (μn n) (νn n)) (S.set_mem n)
     -- We show that `ξ` is mutually singular with respect to `ν`
-    · choose A hA₁ hA₂ hA₃ using fun n => mutuallySingular_singularPart (μn n) (νn n)
+    · choose A hA₁ hA₂ hA₃ using fun n ↦ mutuallySingular_singularPart (μn n) (νn n)
       simp only [hξ]
       -- We use the set `B := ⋃ j, (S.set j) ∩ A j` where `A n` is the set provided as
       -- `singularPart (μn n) (νn n) ⟂ₘ νn n`
-      refine' ⟨⋃ j, S.set j ∩ A j, MeasurableSet.iUnion fun n => (S.set_mem n).inter (hA₁ n), _, _⟩
+      refine ⟨⋃ j, S.set j ∩ A j, MeasurableSet.iUnion fun n ↦ (S.set_mem n).inter (hA₁ n), ?_, ?_⟩
       -- `ξ B = 0` since `ξ B = ∑ i j, singularPart (μn j) (νn j) (S.set i ∩ A i)`
       --                     `= ∑ i, singularPart (μn i) (νn i) (S.set i ∩ A i)`
       --                     `≤ ∑ i, singularPart (μn i) (νn i) (A i) = 0`
       -- where the second equality follows as `singularPart (μn j) (νn j) (S.set i ∩ A i)` vanishes
       -- for all `i ≠ j`
       · rw [measure_iUnion]
-        · have :
-            ∀ i,
-              (sum fun n => (μn n).singularPart (νn n)) (S.set i ∩ A i) =
-                (μn i).singularPart (νn i) (S.set i ∩ A i) := by
+        · have : ∀ i, (sum fun n ↦ (μn n).singularPart (νn n)) (S.set i ∩ A i)
+              = (μn i).singularPart (νn i) (S.set i ∩ A i) := by
             intro i; rw [sum_apply _ ((S.set_mem i).inter (hA₁ i)), tsum_eq_single i]
             · intro j hij
               rw [hμn, ← nonpos_iff_eq_zero]
@@ -920,8 +955,8 @@ instance (priority := 100) haveLebesgueDecomposition_of_sigmaFinite (μ ν : Mea
               rw [this, empty_inter, measure_empty]
           simp_rw [this, tsum_eq_zero_iff ENNReal.summable]
           intro n; exact measure_mono_null (inter_subset_right _ _) (hA₂ n)
-        · exact h₂.mono fun i j => Disjoint.mono inf_le_left inf_le_left
-        · exact fun n => (S.set_mem n).inter (hA₁ n)
+        · exact h₂.mono fun i j ↦ Disjoint.mono inf_le_left inf_le_left
+        · exact fun n ↦ (S.set_mem n).inter (hA₁ n)
       -- We will now show `ν Bᶜ = 0`. This follows since `Bᶜ = ⋃ n, S.set n ∩ (A n)ᶜ` and thus,
       -- `ν Bᶜ = ∑ i, ν (S.set i ∩ (A i)ᶜ) = ∑ i, (νn i) (A i)ᶜ = 0`
       · have hcompl : IsCompl (⋃ n, S.set n ∩ A n) (⋃ n, S.set n ∩ (A n)ᶜ) := by
@@ -941,8 +976,8 @@ instance (priority := 100) haveLebesgueDecomposition_of_sigmaFinite (μ ν : Mea
             exact ⟨i, hi, h i hi⟩
         rw [hcompl.compl_eq, measure_iUnion, tsum_eq_zero_iff ENNReal.summable]
         · intro n; rw [inter_comm, ← restrict_apply (hA₁ n).compl, ← hA₃ n, hνn, h₁]
-        · exact h₂.mono fun i j => Disjoint.mono inf_le_left inf_le_left
-        · exact fun n => (S.set_mem n).inter (hA₁ n).compl
+        · exact h₂.mono fun i j ↦ Disjoint.mono inf_le_left inf_le_left
+        · exact fun n ↦ (S.set_mem n).inter (hA₁ n).compl
     -- Finally, it remains to show `μ = ξ + ν.withDensity f`. Since `μ = sum μn`, and
     -- `ξ + ν.withDensity f = ∑ n, singularPart (μn n) (νn n)`
     --                        `+ ν.withDensity (rnDeriv (μn n) (νn n)) ∩ (S.set n)`,
@@ -951,19 +986,19 @@ instance (priority := 100) haveLebesgueDecomposition_of_sigmaFinite (μ ν : Mea
     · simp only
       nth_rw 1 [hμ]
       rw [withDensity_tsum _, sum_add_sum]
-      · refine' sum_congr fun n => _
+      · refine sum_congr fun n ↦ ?_
         nth_rw 1 [haveLebesgueDecomposition_add (μn n) (νn n)]
         suffices heq :
           (νn n).withDensity ((μn n).rnDeriv (νn n)) =
             ν.withDensity ((S.set n).indicator ((μn n).rnDeriv (νn n))) by rw [heq]
         rw [hν, withDensity_indicator (S.set_mem n), restrict_sum _ (S.set_mem n)]
-        suffices hsumeq : (sum fun i : ℕ => (νn i).restrict (S.set n)) = νn n by rw [hsumeq]
+        suffices hsumeq : (sum fun i : ℕ ↦ (νn i).restrict (S.set n)) = νn n by rw [hsumeq]
         ext1 s hs
         rw [sum_apply _ hs, tsum_eq_single n, hνn, h₁, restrict_restrict (T.set_mem n), inter_self]
         · intro m hm
           rw [hνn, h₁, restrict_restrict (T.set_mem n), (h₃ hm.symm).inter_eq, restrict_empty,
             coe_zero, Pi.zero_apply]
-      · exact fun n => Measurable.indicator (measurable_rnDeriv _ _) (S.set_mem n)⟩
+      · exact fun n ↦ Measurable.indicator (measurable_rnDeriv _ _) (S.set_mem n)⟩
 #align measure_theory.measure.have_lebesgue_decomposition_of_sigma_finite MeasureTheory.Measure.haveLebesgueDecomposition_of_sigmaFinite
 
 section rnDeriv

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -129,16 +129,16 @@ end ByDefinition
 
 section HaveLebesgueDecomposition
 
-instance instHaveLebesgueDecomposition_zero_left : HaveLebesgueDecomposition 0 ν where
+instance instHaveLebesgueDecompositionZeroLeft : HaveLebesgueDecomposition 0 ν where
   lebesgue_decomposition := ⟨⟨0, 0⟩, measurable_zero, MutuallySingular.zero_left, by simp⟩
 
-instance instHaveLebesgueDecomposition_zero_right : HaveLebesgueDecomposition μ 0 where
+instance instHaveLebesgueDecompositionZeroRight : HaveLebesgueDecomposition μ 0 where
   lebesgue_decomposition := ⟨⟨μ, 0⟩, measurable_zero, MutuallySingular.zero_right, by simp⟩
 
-instance instHaveLebesgueDecomposition_self : HaveLebesgueDecomposition μ μ where
+instance instHaveLebesgueDecompositionSelf : HaveLebesgueDecomposition μ μ where
   lebesgue_decomposition := ⟨⟨0, 1⟩, measurable_const, MutuallySingular.zero_left, by simp⟩
 
-instance haveLebesgueDecomposition_smul' (μ ν : Measure α) [HaveLebesgueDecomposition μ ν]
+instance haveLebesgueDecompositionSmul' (μ ν : Measure α) [HaveLebesgueDecomposition μ ν]
     (r : ℝ≥0∞) : (r • μ).HaveLebesgueDecomposition ν where
   lebesgue_decomposition := by
     obtain ⟨hmeas, hsing, hadd⟩ := haveLebesgueDecomposition_spec μ ν
@@ -146,12 +146,12 @@ instance haveLebesgueDecomposition_smul' (μ ν : Measure α) [HaveLebesgueDecom
     simp only [ENNReal.smul_def]
     rw [withDensity_smul _ hmeas, ← smul_add, ← hadd]
 
-instance haveLebesgueDecomposition_smul (μ ν : Measure α) [HaveLebesgueDecomposition μ ν]
+instance haveLebesgueDecompositionSmul (μ ν : Measure α) [HaveLebesgueDecomposition μ ν]
     (r : ℝ≥0) : (r • μ).HaveLebesgueDecomposition ν := by
   rw [ENNReal.smul_def]; infer_instance
-#align measure_theory.measure.have_lebesgue_decomposition_smul MeasureTheory.Measure.haveLebesgueDecomposition_smul
+#align measure_theory.measure.have_lebesgue_decomposition_smul MeasureTheory.Measure.haveLebesgueDecompositionSmul
 
-instance haveLebesgueDecomposition_smul_right (μ ν : Measure α) [HaveLebesgueDecomposition μ ν]
+instance haveLebesgueDecompositionSmulRight (μ ν : Measure α) [HaveLebesgueDecomposition μ ν]
     (r : ℝ≥0) :
     μ.HaveLebesgueDecomposition (r • ν) where
   lebesgue_decomposition := by
@@ -170,11 +170,11 @@ instance haveLebesgueDecomposition_smul_right (μ ν : Measure α) [HaveLebesgue
 theorem haveLebesgueDecomposition_withDensity (μ : Measure α) {f : α → ℝ≥0∞} (hf : Measurable f) :
     (μ.withDensity f).HaveLebesgueDecomposition μ := ⟨⟨⟨0, f⟩, hf, .zero_left, (zero_add _).symm⟩⟩
 
-instance haveLebesgueDecomposition_rnDeriv (μ ν : Measure α) :
+instance haveLebesgueDecompositionRnDeriv (μ ν : Measure α) :
     HaveLebesgueDecomposition (ν.withDensity (μ.rnDeriv ν)) ν :=
   haveLebesgueDecomposition_withDensity ν (measurable_rnDeriv _ _)
 
-instance instHaveLebesgueDecomposition_singularPart :
+instance instHaveLebesgueDecompositionSingularPart :
     HaveLebesgueDecomposition (μ.singularPart ν) ν :=
   ⟨⟨μ.singularPart ν, 0⟩, measurable_zero, mutuallySingular_singularPart μ ν, by simp⟩
 
@@ -427,7 +427,7 @@ theorem singularPart_smul (μ ν : Measure α) (r : ℝ≥0) :
   · rw [singularPart, singularPart, dif_neg hl, dif_neg, smul_zero]
     refine fun hl' ↦ hl ?_
     rw [← inv_smul_smul₀ hr μ]
-    exact Measure.haveLebesgueDecomposition_smul _ _ _
+    infer_instance
 #align measure_theory.measure.singular_part_smul MeasureTheory.Measure.singularPart_smul
 
 theorem singularPart_smul_right (μ ν : Measure α) (r : ℝ≥0) (hr : r ≠ 0) :

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -273,6 +273,7 @@ lemma MutuallySingular.rnDeriv_ae_eq_zero (hμν : μ ⟂ₘ ν) :
     exact hμν
   · rw [rnDeriv_of_not_haveLebesgueDecomposition h]
 
+@[simp]
 theorem singularPart_withDensity (ν : Measure α) (f : α → ℝ≥0∞) :
     (ν.withDensity f).singularPart ν = 0 :=
   singularPart_eq_zero_of_ac (withDensity_absolutelyContinuous _ _)
@@ -283,6 +284,7 @@ lemma rnDeriv_singularPart (μ ν : Measure α) :
   rw [rnDeriv_eq_zero]
   exact mutuallySingular_singularPart μ ν
 
+@[simp]
 lemma singularPart_self (μ : Measure α) : μ.singularPart μ = 0 :=
   singularPart_eq_zero_of_ac Measure.AbsolutelyContinuous.rfl
 

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -84,8 +84,6 @@ irreducible_def rnDeriv (μ ν : Measure α) : α → ℝ≥0∞ :=
 
 section ByDefinition
 
-variable {μ ν : Measure α}
-
 theorem haveLebesgueDecomposition_spec (μ ν : Measure α) [h : HaveLebesgueDecomposition μ ν] :
     Measurable (μ.rnDeriv ν) ∧
       μ.singularPart ν ⟂ₘ ν ∧ μ = μ.singularPart ν + ν.withDensity (μ.rnDeriv ν) := by

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -294,6 +294,14 @@ lemma rnDeriv_self (μ : Measure α) [SigmaFinite μ] : μ.rnDeriv μ =ᵐ[μ] f
   rwa [withDensity_eq_iff_of_sigmaFinite (measurable_rnDeriv _ _).aemeasurable] at h
   exact aemeasurable_const
 
+lemma singularPart_eq_self [μ.HaveLebesgueDecomposition ν] : μ.singularPart ν = μ ↔ μ ⟂ₘ ν := by
+  have h_dec := haveLebesgueDecomposition_add μ ν
+  refine ⟨fun h ↦ ?_, fun  h ↦ ?_⟩
+  · rw [← h]
+    exact mutuallySingular_singularPart _ _
+  · conv_rhs => rw [h_dec]
+    rw [(withDensity_rnDeriv_eq_zero _ _).mpr h, add_zero]
+
 instance singularPart.instIsFiniteMeasure [IsFiniteMeasure μ] :
     IsFiniteMeasure (μ.singularPart ν) :=
   isFiniteMeasure_of_le μ <| singularPart_le μ ν


### PR DESCRIPTION
Move lemmas to put similar ones together, replace `refine'` by `refine` and `=>` by `↦`.
Lemmas added:
* `singularPart_add_rnDeriv` and `rnDeriv_add_singularPart`: almost aliases of `haveLebesgueDecomposition_add`
* `haveLebesgueDecomposition_smul'`, `haveLebesgueDecomposition_rnDeriv`
* `singularPart_eq_zero_of_ac`, `singularPart_eq_zero`, `singularPart_self`, `singularPart_eq_self`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
