### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/Module/WeakDual): prove basic relations between the weak topology and the original topology

### DIFF
--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -350,68 +350,15 @@ theorem coe_map (f : E →L[𝕜] F) : (WeakSpace.map f : E → F) = f :=
   rfl
 #align weak_space.coe_map WeakSpace.coe_map
 
-/-- The canonical preimage in `E` of an open set in `WeakSpace 𝕜 E` is open in `E`. -/
-theorem isOpen_of_isOpen_WeakSpace (U : Set (WeakSpace 𝕜 E))
-    (hU : IsOpen[(WeakSpace.instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E))] U) :
-    IsOpen ((continuousLinearMapToWeakSpace 𝕜 E) ⁻¹' U) := by
-  exact ((continuousLinearMapToWeakSpace 𝕜 E).cont).isOpen_preimage U hU
-
 /-- The canonical map from `WeakSpace 𝕜 E` to `E` is an open map. -/
 theorem isOpenMap_inv_toWeakSpace : IsOpenMap (toWeakSpace 𝕜 E).symm :=
   IsOpenMap.of_inverse (continuousLinearMapToWeakSpace 𝕜 E).cont
     (toWeakSpace 𝕜 E).left_inv (toWeakSpace 𝕜 E).right_inv
 
 /-- A set in `E` which is open in the weak topology is open. -/
-theorem isOpen_of_isOpen_WeakSpace' (V : Set E)
-    (hV : IsOpen[(WeakSpace.instTopologicalSpace)]
-    ((continuousLinearMapToWeakSpace 𝕜 E) '' V : Set (WeakSpace 𝕜 E))) : IsOpen V := by
-  have : (continuousLinearMapToWeakSpace 𝕜 E) ⁻¹' ((continuousLinearMapToWeakSpace 𝕜 E) '' V)
-  = V := by
-   ext x
-   constructor
-   · intro hx
-     obtain ⟨y, hy⟩ := hx
-     rw [continuousLinearMapToWeakSpace_eq_toWeakSpace,
-       continuousLinearMapToWeakSpace_eq_toWeakSpace] at hy
-     have : y = x := LinearEquiv.injective (toWeakSpace 𝕜 E) hy.2
-     rw [this] at hy
-     exact hy.1
-   · intro hx
-     simp only [Set.mem_preimage, Set.mem_image]
-     use x
-  rw [← this]
-  exact isOpen_of_isOpen_WeakSpace ((continuousLinearMapToWeakSpace 𝕜 E) '' V) hV
-
-/-- If `f : α → E` is convergent in the original topology,
-then it is convergent in the weak topology. -/
-theorem tendsto_WeakSpace_of_tendsto
-    {α : Type*} {l : Filter α} {f : α → E} {p : E} (hf : Tendsto f l (nhds p)) :
-    Tendsto (fun x ↦ (continuousLinearMapToWeakSpace 𝕜 E) (f x))
-    l (nhds ((continuousLinearMapToWeakSpace 𝕜 E) p)) := by
-  refine tendsto_nhds.mpr ?_
-  intro U hpU hU
-  rw [tendsto_nhds] at hf
-  have : (fun x ↦ (continuousLinearMapToWeakSpace 𝕜 E) (f x))
-    = (fun x ↦ ((continuousLinearMapToWeakSpace 𝕜 E) ∘ f) x) := by
-    rfl
-  rw [this, Set.preimage_comp]
-  apply hf ((continuousLinearMapToWeakSpace 𝕜 E) ⁻¹' U)
-    ((continuousLinearMapToWeakSpace 𝕜 E).cont.isOpen_preimage U hpU)
-  exact hU
-
-/-- If `f : α → E` is convergent in the original topology,
-then `y ∘ f` is convergent for any `y : E →L[𝕜] 𝕜`. -/
-theorem eval_tendsto_of_tendsto
-    {α : Type*} {l : Filter α} {f : α → E} {p : E} (hf : Tendsto f l (nhds p)) (y : E →L[𝕜] 𝕜) :
-    Tendsto (fun x => y (f x)) l (nhds (y p)) := by
-  exact ((y.continuous).tendsto p).comp hf
-
-/-- If `f : E → α` is continuous from `E` in the weak topology,
-then it is continuous in the original topology. -/
-theorem continuous_of_continuous_WeakSpace
-    {α : Type*} [TopologicalSpace α] {f : (WeakSpace 𝕜 E) → α} (hf : Continuous f) :
-    Continuous (f ∘ (continuousLinearMapToWeakSpace 𝕜 E)) := by
-  exact Continuous.comp hf (continuousLinearMapToWeakSpace 𝕜 E).cont
+theorem isOpen_of_isOpen_WeakSpace (V : Set E)
+    (hV : IsOpen ((continuousLinearMapToWeakSpace 𝕜 E) '' V : Set (WeakSpace 𝕜 E))) : IsOpen V := by
+  simpa [Set.image_image] using isOpenMap_inv_toWeakSpace _ hV
 
 end WeakSpace
 

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -360,14 +360,9 @@ theorem isOpen_of_isOpen_WeakSpace (U : Set (WeakSpace 𝕜 E))
   exact ((continuousLinearMapToWeakSpace 𝕜 E).cont).isOpen_preimage U hU
 
 /-- The canonical map from `WeakSpace 𝕜 E` to `E` is an open map. -/
-theorem isOpenMap_inv_toWeakSpace : IsOpenMap (toWeakSpace 𝕜 E).symm := by
-  apply IsOpenMap.of_inverse (continuousLinearMapToWeakSpace 𝕜 E).cont _ _
-  intro x
-  simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, ContinuousLinearMap.coe_coe,
-    continuousLinearMapToWeakSpace_eq_toWeakSpace, LinearEquiv.symm_apply_apply]
-  intro x
-  simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, ContinuousLinearMap.coe_coe,
-    continuousLinearMapToWeakSpace_eq_toWeakSpace, LinearEquiv.apply_symm_apply]
+theorem isOpenMap_inv_toWeakSpace : IsOpenMap (toWeakSpace 𝕜 E).symm :=
+  IsOpenMap.of_inverse (continuousLinearMapToWeakSpace 𝕜 E).cont
+    (toWeakSpace 𝕜 E).left_inv (toWeakSpace 𝕜 E).right_inv
 
 /-- A set in `E` which is open in the weak topology is open. -/
 theorem isOpen_of_isOpen_WeakSpace' (V : Set E)

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -327,12 +327,9 @@ variable (𝕜 E) in
 theorem continuousLinearMapToWeakSpace_eq_toWeakSpace (x : E) :
     continuousLinearMapToWeakSpace 𝕜 E x = toWeakSpace 𝕜 E x := by rfl
 
-theorem injective_continuousLinearMapToWeakSpace :
-    Function.Injective (continuousLinearMapToWeakSpace 𝕜 E) := by
-  intro x y hxy
-  rw [continuousLinearMapToWeakSpace_eq_toWeakSpace,
-    continuousLinearMapToWeakSpace_eq_toWeakSpace] at hxy
-  exact LinearEquiv.injective (toWeakSpace 𝕜 E) hxy
+theorem continuousLinearMapToWeakSpace_bijective :
+    Function.Bijective (continuousLinearMapToWeakSpace 𝕜 E) :=
+  (toWeakSpace 𝕜 E).bijective
 
 variable [AddCommMonoid F] [Module 𝕜 F] [TopologicalSpace F]
 

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -307,6 +307,39 @@ instance instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E) :=
 instance instContinuousAdd : ContinuousAdd (WeakSpace 𝕜 E) :=
   WeakBilin.instContinuousAdd (topDualPairing 𝕜 E).flip
 
+
+/-- There is a canonical map `E → WeakSpace 𝕜 E` (the "identity"
+mapping). It is a linear equivalence. -/
+def toWeakSpace : E ≃ₗ[𝕜] WeakSpace 𝕜 E := LinearEquiv.refl 𝕜 E
+
+@[simp]
+theorem toWeakSpace_eq_iff (x y : E) : (toWeakSpace x : WeakSpace 𝕜 E) = toWeakSpace y ↔ x = y :=
+  Function.Injective.eq_iff <| LinearEquiv.injective toWeakSpace
+
+/-- For a topological vector space `E`, "identity mapping" `E → WeakSpace 𝕜 E` is continuous.
+This definition implements it as a continuous linear map. -/
+def continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E where
+  __ := toWeakSpace
+  cont := by
+    apply WeakBilin.continuous_of_continuous_eval
+    exact ContinuousLinearMap.continuous
+-- def continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E :=
+--   { (toWeakSpace : E ≃ₗ[𝕜] WeakSpace 𝕜 E) with
+--     cont := by
+--       apply WeakBilin.continuous_of_continuous_eval
+--       exact ContinuousLinearMap.continuous }
+
+@[simp]
+theorem toWeakSpace_eq_continuousLinearMapToWeakSpace (x : E) :
+    (toWeakSpace x : WeakSpace 𝕜 E) = continuousLinearMapToWeakSpace x := by rfl
+
+theorem injective_continuousLinearMapToWeakSpace :
+    Function.Injective (continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E ) := by
+  intro x y hxy
+  rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace,
+    ← toWeakSpace_eq_continuousLinearMapToWeakSpace] at hxy
+  exact LinearEquiv.injective toWeakSpace hxy
+
 variable [AddCommMonoid F] [Module 𝕜 F] [TopologicalSpace F]
 
 /-- A continuous linear map from `E` to `F` is still continuous when `E` and `F` are equipped with
@@ -325,6 +358,66 @@ theorem map_apply (f : E →L[𝕜] F) (x : E) : WeakSpace.map f x = f x :=
 theorem coe_map (f : E →L[𝕜] F) : (WeakSpace.map f : E → F) = f :=
   rfl
 #align weak_space.coe_map WeakSpace.coe_map
+
+/-- The canonical preimage in `E` of an open set in `WeakSpace 𝕜 E` is open in `E`. -/
+theorem isOpen_of_isOpen_WeakSpace (U : Set (WeakSpace 𝕜 E))
+    (hU : IsOpen[(WeakSpace.instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E))] U) :
+    IsOpen (continuousLinearMapToWeakSpace ⁻¹' U) := by
+  exact ((continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E).cont).isOpen_preimage U hU
+
+/-- A set in `E` which is open in the weak topology is open. -/
+theorem isOpen_of_isOpen_WeakSpace' (V : Set E)
+    (hV : IsOpen[(WeakSpace.instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E))]
+    (continuousLinearMapToWeakSpace '' V : Set (WeakSpace 𝕜 E))) : IsOpen V := by
+  have : (continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E) ⁻¹' ((continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E) '' V)
+  = V := by
+   ext x
+   constructor
+   · intro hx
+     have : continuousLinearMapToWeakSpace x ∈ continuousLinearMapToWeakSpace '' V := by
+       exact hx
+     obtain ⟨y, hy⟩ := hx
+     rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace] at this
+     rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace,
+       ← toWeakSpace_eq_continuousLinearMapToWeakSpace] at hy
+     have : y = x := LinearEquiv.injective toWeakSpace hy.2
+     rw [this] at hy
+     exact hy.1
+   · intro hx
+     simp only [Set.mem_preimage, Set.mem_image]
+     use x
+  rw [← this]
+  exact isOpen_of_isOpen_WeakSpace (continuousLinearMapToWeakSpace '' V) hV
+
+/-- If `f : α → E` is convergent in the original topology,
+then it is convergent in the weak topology. -/
+theorem tendsto_WeakSpace_of_tendsto
+    {α : Type*} {l : Filter α} {f : α → E} {p : E} (hf : Tendsto f l (nhds p)) :
+    Tendsto (fun x ↦ (continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E) (f x)) l (nhds (continuousLinearMapToWeakSpace p)) := by
+  refine tendsto_nhds.mpr ?_
+  intro U hpU hU
+  rw [tendsto_nhds] at hf
+  have : (fun x ↦ (continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E) (f x))
+    = (fun x ↦ ((continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E) ∘ f) x) := by
+    rfl
+  rw [this, Set.preimage_comp]
+  apply hf (continuousLinearMapToWeakSpace ⁻¹' U)
+    (continuousLinearMapToWeakSpace.cont.isOpen_preimage U hpU)
+  exact hU
+
+/-- If `f : α → E` is convergent in the original topology,
+then `y ∘ f` is convergent for any `y : E →L[𝕜] 𝕜`. -/
+theorem eval_tendsto_of_tendsto
+    {α : Type*} {l : Filter α} {f : α → E} {p : E}
+    (hf : Tendsto f l (nhds p)) (y : E →L[𝕜] 𝕜) : Tendsto (fun x => y (f x)) l (nhds (y p)) := by
+  exact Tendsto.comp (Continuous.tendsto (ContinuousLinearMap.continuous y) p) hf
+
+/-- If `f : E → α` is continuous from `E` in the weak topology,
+then it is continuous in the original topology. -/
+theorem continuous_of_continuous_WeakSpace
+    {α : Type*} [TopologicalSpace α] {f : (WeakSpace 𝕜 E) → α} (hf : Continuous f) :
+    Continuous (f ∘ continuousLinearMapToWeakSpace) := by
+  exact Continuous.comp hf continuousLinearMapToWeakSpace.cont
 
 end WeakSpace
 

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -329,13 +329,13 @@ def continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E where
 variable (𝕜 E) in
 @[simp]
 theorem toWeakSpace_eq_continuousLinearMapToWeakSpace (x : E) :
-    toWeakSpace 𝕜 E x = (continuousLinearMapToWeakSpace 𝕜 E) x := by rfl
+    continuousLinearMapToWeakSpace 𝕜 E x= toWeakSpace 𝕜 E x := by rfl
 
 theorem injective_continuousLinearMapToWeakSpace :
     Function.Injective (continuousLinearMapToWeakSpace 𝕜 E) := by
   intro x y hxy
-  rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace,
-    ← toWeakSpace_eq_continuousLinearMapToWeakSpace] at hxy
+  rw [toWeakSpace_eq_continuousLinearMapToWeakSpace,
+    toWeakSpace_eq_continuousLinearMapToWeakSpace] at hxy
   exact LinearEquiv.injective (toWeakSpace 𝕜 E) hxy
 
 variable [AddCommMonoid F] [Module 𝕜 F] [TopologicalSpace F]
@@ -372,12 +372,9 @@ theorem isOpen_of_isOpen_WeakSpace' (V : Set E)
    ext x
    constructor
    · intro hx
-     have : (continuousLinearMapToWeakSpace 𝕜 E) x ∈ (continuousLinearMapToWeakSpace 𝕜 E) '' V := by
-       exact hx
      obtain ⟨y, hy⟩ := hx
-     rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace] at this
-     rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace,
-       ← toWeakSpace_eq_continuousLinearMapToWeakSpace] at hy
+     rw [toWeakSpace_eq_continuousLinearMapToWeakSpace,
+       toWeakSpace_eq_continuousLinearMapToWeakSpace] at hy
      have : y = x := LinearEquiv.injective (toWeakSpace 𝕜 E) hy.2
      rw [this] at hy
      exact hy.1

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -313,10 +313,6 @@ variable (𝕜 E) in
 mapping). It is a linear equivalence. -/
 def toWeakSpace : E ≃ₗ[𝕜] WeakSpace 𝕜 E := LinearEquiv.refl 𝕜 E
 
-@[simp]
-theorem toWeakSpace_eq_iff (x y : E) : toWeakSpace 𝕜 E x = toWeakSpace 𝕜 E y ↔ x = y :=
-  Function.Injective.eq_iff <| LinearEquiv.injective (toWeakSpace 𝕜 E)
-
 variable (𝕜 E) in
 /-- For a topological vector space `E`, "identity mapping" `E → WeakSpace 𝕜 E` is continuous.
 This definition implements it as a continuous linear map. -/
@@ -329,7 +325,7 @@ def continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E where
 variable (𝕜 E) in
 @[simp]
 theorem toWeakSpace_eq_continuousLinearMapToWeakSpace (x : E) :
-    continuousLinearMapToWeakSpace 𝕜 E x= toWeakSpace 𝕜 E x := by rfl
+    continuousLinearMapToWeakSpace 𝕜 E x = toWeakSpace 𝕜 E x := by rfl
 
 theorem injective_continuousLinearMapToWeakSpace :
     Function.Injective (continuousLinearMapToWeakSpace 𝕜 E) := by

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -324,14 +324,14 @@ def continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E where
 
 variable (𝕜 E) in
 @[simp]
-theorem toWeakSpace_eq_continuousLinearMapToWeakSpace (x : E) :
+theorem continuousLinearMapToWeakSpace_eq_toWeakSpace (x : E) :
     continuousLinearMapToWeakSpace 𝕜 E x = toWeakSpace 𝕜 E x := by rfl
 
 theorem injective_continuousLinearMapToWeakSpace :
     Function.Injective (continuousLinearMapToWeakSpace 𝕜 E) := by
   intro x y hxy
-  rw [toWeakSpace_eq_continuousLinearMapToWeakSpace,
-    toWeakSpace_eq_continuousLinearMapToWeakSpace] at hxy
+  rw [continuousLinearMapToWeakSpace_eq_toWeakSpace,
+    continuousLinearMapToWeakSpace_eq_toWeakSpace] at hxy
   exact LinearEquiv.injective (toWeakSpace 𝕜 E) hxy
 
 variable [AddCommMonoid F] [Module 𝕜 F] [TopologicalSpace F]
@@ -359,6 +359,16 @@ theorem isOpen_of_isOpen_WeakSpace (U : Set (WeakSpace 𝕜 E))
     IsOpen ((continuousLinearMapToWeakSpace 𝕜 E) ⁻¹' U) := by
   exact ((continuousLinearMapToWeakSpace 𝕜 E).cont).isOpen_preimage U hU
 
+/-- The canonical map from `WeakSpace 𝕜 E` to `E` is an open map. -/
+theorem isOpenMap_inv_toWeakSpace : IsOpenMap (toWeakSpace 𝕜 E).symm := by
+  apply IsOpenMap.of_inverse (continuousLinearMapToWeakSpace 𝕜 E).cont _ _
+  intro x
+  simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, ContinuousLinearMap.coe_coe,
+    continuousLinearMapToWeakSpace_eq_toWeakSpace, LinearEquiv.symm_apply_apply]
+  intro x
+  simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, ContinuousLinearMap.coe_coe,
+    continuousLinearMapToWeakSpace_eq_toWeakSpace, LinearEquiv.apply_symm_apply]
+
 /-- A set in `E` which is open in the weak topology is open. -/
 theorem isOpen_of_isOpen_WeakSpace' (V : Set E)
     (hV : IsOpen[(WeakSpace.instTopologicalSpace)]
@@ -369,8 +379,8 @@ theorem isOpen_of_isOpen_WeakSpace' (V : Set E)
    constructor
    · intro hx
      obtain ⟨y, hy⟩ := hx
-     rw [toWeakSpace_eq_continuousLinearMapToWeakSpace,
-       toWeakSpace_eq_continuousLinearMapToWeakSpace] at hy
+     rw [continuousLinearMapToWeakSpace_eq_toWeakSpace,
+       continuousLinearMapToWeakSpace_eq_toWeakSpace] at hy
      have : y = x := LinearEquiv.injective (toWeakSpace 𝕜 E) hy.2
      rw [this] at hy
      exact hy.1
@@ -402,7 +412,7 @@ then `y ∘ f` is convergent for any `y : E →L[𝕜] 𝕜`. -/
 theorem eval_tendsto_of_tendsto
     {α : Type*} {l : Filter α} {f : α → E} {p : E} (hf : Tendsto f l (nhds p)) (y : E →L[𝕜] 𝕜) :
     Tendsto (fun x => y (f x)) l (nhds (y p)) := by
-  exact Tendsto.comp (Continuous.tendsto (ContinuousLinearMap.continuous y) p) hf
+  exact ((y.continuous).tendsto p).comp hf
 
 /-- If `f : E → α` is continuous from `E` in the weak topology,
 then it is continuous in the original topology. -/

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -308,37 +308,35 @@ instance instContinuousAdd : ContinuousAdd (WeakSpace 𝕜 E) :=
   WeakBilin.instContinuousAdd (topDualPairing 𝕜 E).flip
 
 
+variable (𝕜 E) in
 /-- There is a canonical map `E → WeakSpace 𝕜 E` (the "identity"
 mapping). It is a linear equivalence. -/
 def toWeakSpace : E ≃ₗ[𝕜] WeakSpace 𝕜 E := LinearEquiv.refl 𝕜 E
 
 @[simp]
-theorem toWeakSpace_eq_iff (x y : E) : (toWeakSpace x : WeakSpace 𝕜 E) = toWeakSpace y ↔ x = y :=
-  Function.Injective.eq_iff <| LinearEquiv.injective toWeakSpace
+theorem toWeakSpace_eq_iff (x y : E) : toWeakSpace 𝕜 E x = toWeakSpace 𝕜 E y ↔ x = y :=
+  Function.Injective.eq_iff <| LinearEquiv.injective (toWeakSpace 𝕜 E)
 
+variable (𝕜 E) in
 /-- For a topological vector space `E`, "identity mapping" `E → WeakSpace 𝕜 E` is continuous.
 This definition implements it as a continuous linear map. -/
 def continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E where
-  __ := toWeakSpace
+  __ := toWeakSpace 𝕜 E
   cont := by
     apply WeakBilin.continuous_of_continuous_eval
     exact ContinuousLinearMap.continuous
--- def continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E :=
---   { (toWeakSpace : E ≃ₗ[𝕜] WeakSpace 𝕜 E) with
---     cont := by
---       apply WeakBilin.continuous_of_continuous_eval
---       exact ContinuousLinearMap.continuous }
 
+variable (𝕜 E) in
 @[simp]
 theorem toWeakSpace_eq_continuousLinearMapToWeakSpace (x : E) :
-    (toWeakSpace x : WeakSpace 𝕜 E) = continuousLinearMapToWeakSpace x := by rfl
+    toWeakSpace 𝕜 E x = (continuousLinearMapToWeakSpace 𝕜 E) x := by rfl
 
 theorem injective_continuousLinearMapToWeakSpace :
-    Function.Injective (continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E ) := by
+    Function.Injective (continuousLinearMapToWeakSpace 𝕜 E) := by
   intro x y hxy
   rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace,
     ← toWeakSpace_eq_continuousLinearMapToWeakSpace] at hxy
-  exact LinearEquiv.injective toWeakSpace hxy
+  exact LinearEquiv.injective (toWeakSpace 𝕜 E) hxy
 
 variable [AddCommMonoid F] [Module 𝕜 F] [TopologicalSpace F]
 
@@ -362,62 +360,63 @@ theorem coe_map (f : E →L[𝕜] F) : (WeakSpace.map f : E → F) = f :=
 /-- The canonical preimage in `E` of an open set in `WeakSpace 𝕜 E` is open in `E`. -/
 theorem isOpen_of_isOpen_WeakSpace (U : Set (WeakSpace 𝕜 E))
     (hU : IsOpen[(WeakSpace.instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E))] U) :
-    IsOpen (continuousLinearMapToWeakSpace ⁻¹' U) := by
-  exact ((continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E).cont).isOpen_preimage U hU
+    IsOpen ((continuousLinearMapToWeakSpace 𝕜 E) ⁻¹' U) := by
+  exact ((continuousLinearMapToWeakSpace 𝕜 E).cont).isOpen_preimage U hU
 
 /-- A set in `E` which is open in the weak topology is open. -/
 theorem isOpen_of_isOpen_WeakSpace' (V : Set E)
-    (hV : IsOpen[(WeakSpace.instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E))]
-    (continuousLinearMapToWeakSpace '' V : Set (WeakSpace 𝕜 E))) : IsOpen V := by
-  have : (continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E) ⁻¹' ((continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E) '' V)
+    (hV : IsOpen[(WeakSpace.instTopologicalSpace)]
+    ((continuousLinearMapToWeakSpace 𝕜 E) '' V : Set (WeakSpace 𝕜 E))) : IsOpen V := by
+  have : (continuousLinearMapToWeakSpace 𝕜 E) ⁻¹' ((continuousLinearMapToWeakSpace 𝕜 E) '' V)
   = V := by
    ext x
    constructor
    · intro hx
-     have : continuousLinearMapToWeakSpace x ∈ continuousLinearMapToWeakSpace '' V := by
+     have : (continuousLinearMapToWeakSpace 𝕜 E) x ∈ (continuousLinearMapToWeakSpace 𝕜 E) '' V := by
        exact hx
      obtain ⟨y, hy⟩ := hx
      rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace] at this
      rw [← toWeakSpace_eq_continuousLinearMapToWeakSpace,
        ← toWeakSpace_eq_continuousLinearMapToWeakSpace] at hy
-     have : y = x := LinearEquiv.injective toWeakSpace hy.2
+     have : y = x := LinearEquiv.injective (toWeakSpace 𝕜 E) hy.2
      rw [this] at hy
      exact hy.1
    · intro hx
      simp only [Set.mem_preimage, Set.mem_image]
      use x
   rw [← this]
-  exact isOpen_of_isOpen_WeakSpace (continuousLinearMapToWeakSpace '' V) hV
+  exact isOpen_of_isOpen_WeakSpace ((continuousLinearMapToWeakSpace 𝕜 E) '' V) hV
 
 /-- If `f : α → E` is convergent in the original topology,
 then it is convergent in the weak topology. -/
 theorem tendsto_WeakSpace_of_tendsto
     {α : Type*} {l : Filter α} {f : α → E} {p : E} (hf : Tendsto f l (nhds p)) :
-    Tendsto (fun x ↦ (continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E) (f x)) l (nhds (continuousLinearMapToWeakSpace p)) := by
+    Tendsto (fun x ↦ (continuousLinearMapToWeakSpace 𝕜 E) (f x))
+    l (nhds ((continuousLinearMapToWeakSpace 𝕜 E) p)) := by
   refine tendsto_nhds.mpr ?_
   intro U hpU hU
   rw [tendsto_nhds] at hf
-  have : (fun x ↦ (continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E) (f x))
-    = (fun x ↦ ((continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E) ∘ f) x) := by
+  have : (fun x ↦ (continuousLinearMapToWeakSpace 𝕜 E) (f x))
+    = (fun x ↦ ((continuousLinearMapToWeakSpace 𝕜 E) ∘ f) x) := by
     rfl
   rw [this, Set.preimage_comp]
-  apply hf (continuousLinearMapToWeakSpace ⁻¹' U)
-    (continuousLinearMapToWeakSpace.cont.isOpen_preimage U hpU)
+  apply hf ((continuousLinearMapToWeakSpace 𝕜 E) ⁻¹' U)
+    ((continuousLinearMapToWeakSpace 𝕜 E).cont.isOpen_preimage U hpU)
   exact hU
 
 /-- If `f : α → E` is convergent in the original topology,
 then `y ∘ f` is convergent for any `y : E →L[𝕜] 𝕜`. -/
 theorem eval_tendsto_of_tendsto
-    {α : Type*} {l : Filter α} {f : α → E} {p : E}
-    (hf : Tendsto f l (nhds p)) (y : E →L[𝕜] 𝕜) : Tendsto (fun x => y (f x)) l (nhds (y p)) := by
+    {α : Type*} {l : Filter α} {f : α → E} {p : E} (hf : Tendsto f l (nhds p)) (y : E →L[𝕜] 𝕜) :
+    Tendsto (fun x => y (f x)) l (nhds (y p)) := by
   exact Tendsto.comp (Continuous.tendsto (ContinuousLinearMap.continuous y) p) hf
 
 /-- If `f : E → α` is continuous from `E` in the weak topology,
 then it is continuous in the original topology. -/
 theorem continuous_of_continuous_WeakSpace
     {α : Type*} [TopologicalSpace α] {f : (WeakSpace 𝕜 E) → α} (hf : Continuous f) :
-    Continuous (f ∘ continuousLinearMapToWeakSpace) := by
-  exact Continuous.comp hf continuousLinearMapToWeakSpace.cont
+    Continuous (f ∘ (continuousLinearMapToWeakSpace 𝕜 E)) := by
+  exact Continuous.comp hf (continuousLinearMapToWeakSpace 𝕜 E).cont
 
 end WeakSpace
 

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -308,6 +308,28 @@ instance instContinuousAdd : ContinuousAdd (WeakSpace 𝕜 E) :=
   WeakBilin.instContinuousAdd (topDualPairing 𝕜 E).flip
 
 
+variable [AddCommMonoid F] [Module 𝕜 F] [TopologicalSpace F]
+
+/-- A continuous linear map from `E` to `F` is still continuous when `E` and `F` are equipped with
+their weak topologies. -/
+def map (f : E →L[𝕜] F) : WeakSpace 𝕜 E →L[𝕜] WeakSpace 𝕜 F :=
+  { f with
+    cont :=
+      WeakBilin.continuous_of_continuous_eval _ fun l => WeakBilin.eval_continuous _ (l ∘L f) }
+#align weak_space.map WeakSpace.map
+
+theorem map_apply (f : E →L[𝕜] F) (x : E) : WeakSpace.map f x = f x :=
+  rfl
+#align weak_space.map_apply WeakSpace.map_apply
+
+@[simp]
+theorem coe_map (f : E →L[𝕜] F) : (WeakSpace.map f : E → F) = f :=
+  rfl
+#align weak_space.coe_map WeakSpace.coe_map
+
+
+end WeakSpace
+
 variable (𝕜 E) in
 /-- There is a canonical map `E → WeakSpace 𝕜 E` (the "identity"
 mapping). It is a linear equivalence. -/
@@ -331,25 +353,6 @@ theorem continuousLinearMapToWeakSpace_bijective :
     Function.Bijective (continuousLinearMapToWeakSpace 𝕜 E) :=
   (toWeakSpace 𝕜 E).bijective
 
-variable [AddCommMonoid F] [Module 𝕜 F] [TopologicalSpace F]
-
-/-- A continuous linear map from `E` to `F` is still continuous when `E` and `F` are equipped with
-their weak topologies. -/
-def map (f : E →L[𝕜] F) : WeakSpace 𝕜 E →L[𝕜] WeakSpace 𝕜 F :=
-  { f with
-    cont :=
-      WeakBilin.continuous_of_continuous_eval _ fun l => WeakBilin.eval_continuous _ (l ∘L f) }
-#align weak_space.map WeakSpace.map
-
-theorem map_apply (f : E →L[𝕜] F) (x : E) : WeakSpace.map f x = f x :=
-  rfl
-#align weak_space.map_apply WeakSpace.map_apply
-
-@[simp]
-theorem coe_map (f : E →L[𝕜] F) : (WeakSpace.map f : E → F) = f :=
-  rfl
-#align weak_space.coe_map WeakSpace.coe_map
-
 /-- The canonical map from `WeakSpace 𝕜 E` to `E` is an open map. -/
 theorem isOpenMap_toWeakSpace_symm : IsOpenMap (toWeakSpace 𝕜 E).symm :=
   IsOpenMap.of_inverse (continuousLinearMapToWeakSpace 𝕜 E).cont
@@ -358,9 +361,7 @@ theorem isOpenMap_toWeakSpace_symm : IsOpenMap (toWeakSpace 𝕜 E).symm :=
 /-- A set in `E` which is open in the weak topology is open. -/
 theorem isOpen_of_isOpen (V : Set E)
     (hV : IsOpen ((continuousLinearMapToWeakSpace 𝕜 E) '' V : Set (WeakSpace 𝕜 E))) : IsOpen V := by
-  simpa [Set.image_image] using isOpenMap_inv_toWeakSpace _ hV
-
-end WeakSpace
+  simpa [Set.image_image] using isOpenMap_toWeakSpace_symm _ hV
 
 theorem tendsto_iff_forall_eval_tendsto_topDualPairing {l : Filter α} {f : α → WeakDual 𝕜 E}
     {x : WeakDual 𝕜 E} :

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -326,7 +326,6 @@ theorem coe_map (f : E →L[𝕜] F) : (WeakSpace.map f : E → F) = f :=
   rfl
 #align weak_space.coe_map WeakSpace.coe_map
 
-
 end WeakSpace
 
 variable (𝕜 E) in

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -359,7 +359,7 @@ theorem isOpenMap_toWeakSpace_symm : IsOpenMap (toWeakSpace 𝕜 E).symm :=
     (toWeakSpace 𝕜 E).left_inv (toWeakSpace 𝕜 E).right_inv
 
 /-- A set in `E` which is open in the weak topology is open. -/
-theorem isOpen_of_isOpen (V : Set E)
+theorem WeakSpace.isOpen_of_isOpen (V : Set E)
     (hV : IsOpen ((continuousLinearMapToWeakSpace 𝕜 E) '' V : Set (WeakSpace 𝕜 E))) : IsOpen V := by
   simpa [Set.image_image] using isOpenMap_toWeakSpace_symm _ hV
 

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -351,7 +351,7 @@ theorem coe_map (f : E →L[𝕜] F) : (WeakSpace.map f : E → F) = f :=
 #align weak_space.coe_map WeakSpace.coe_map
 
 /-- The canonical map from `WeakSpace 𝕜 E` to `E` is an open map. -/
-theorem isOpenMap_inv_toWeakSpace : IsOpenMap (toWeakSpace 𝕜 E).symm :=
+theorem isOpenMap_toWeakSpace_symm : IsOpenMap (toWeakSpace 𝕜 E).symm :=
   IsOpenMap.of_inverse (continuousLinearMapToWeakSpace 𝕜 E).cont
     (toWeakSpace 𝕜 E).left_inv (toWeakSpace 𝕜 E).right_inv
 

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -356,7 +356,7 @@ theorem isOpenMap_toWeakSpace_symm : IsOpenMap (toWeakSpace 𝕜 E).symm :=
     (toWeakSpace 𝕜 E).left_inv (toWeakSpace 𝕜 E).right_inv
 
 /-- A set in `E` which is open in the weak topology is open. -/
-theorem isOpen_of_isOpen_WeakSpace (V : Set E)
+theorem isOpen_of_isOpen (V : Set E)
     (hV : IsOpen ((continuousLinearMapToWeakSpace 𝕜 E) '' V : Set (WeakSpace 𝕜 E))) : IsOpen V := by
   simpa [Set.image_image] using isOpenMap_inv_toWeakSpace _ hV
 

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -307,7 +307,6 @@ instance instTopologicalSpace : TopologicalSpace (WeakSpace 𝕜 E) :=
 instance instContinuousAdd : ContinuousAdd (WeakSpace 𝕜 E) :=
   WeakBilin.instContinuousAdd (topDualPairing 𝕜 E).flip
 
-
 variable [AddCommMonoid F] [Module 𝕜 F] [TopologicalSpace F]
 
 /-- A continuous linear map from `E` to `F` is still continuous when `E` and `F` are equipped with


### PR DESCRIPTION
(This PR continues #11472)
Prove the following basic facts about the weak topology in a topological vector space (or AddCommMonoid) `E`.
- any set that is open in the weak topology is open in the original topology.
- any function in `E` that converges to a point in the original topology (with respect to some filter) converges also in the weak topology.
- if a function in `E` converges to a point in the original topology, then its composition with a continuous linear functional converges.
- any function from `E` that is continuous in the weak topology is also continuous in the original topology.

Motivation: WeakSpace has some basic properties, analogue of which are proved for WeakDual.

I have some doubts:
- in order to avoid typeclass instance problem, I had to add a type ascription `continuousLinearMapToWeakSpace : E →L[𝕜] WeakSpace 𝕜 E` when needed. Is this fine or is there a canonical way to avoid it? (I tried to add `variable (𝕜 E) in` before def/thm but it gave type mismatch in many places)
- I made two theorems about IsOpen, but not sure about the naming convention.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
