### PR TITLE
[Merged by Bors] - chore(Set/Finset): standardize names of distributivity laws

### DIFF
--- a/Archive/Imo/Imo2021Q1.lean
+++ b/Archive/Imo/Imo2021Q1.lean
@@ -124,7 +124,7 @@ theorem imo2021_q1 :
   have hBsub : B ⊆ Finset.Icc n (2 * n) := by
     intro c hcB; simpa only [Finset.mem_Icc] using h₂ c hcB
   have hB' : 2 * 1 < (B ∩ (Finset.Icc n (2 * n) \ A) ∪ B ∩ A).card := by
-    rw [← inter_distrib_left, sdiff_union_self_eq_union, union_eq_left.2 hA,
+    rw [← inter_union_distrib_left, sdiff_union_self_eq_union, union_eq_left.2 hA,
       inter_eq_left.2 hBsub]
     exact Nat.succ_le_iff.mp hB
   -- Since B has cardinality greater or equal to 3, there must exist a subset C ⊆ B such that

--- a/Counterexamples/Phillips.lean
+++ b/Counterexamples/Phillips.lean
@@ -374,7 +374,7 @@ def continuousPart (f : BoundedAdditiveMeasure α) : BoundedAdditiveMeasure α :
 theorem eq_add_parts (f : BoundedAdditiveMeasure α) (s : Set α) :
     f s = f.discretePart s + f.continuousPart s := by
   simp only [discretePart, continuousPart, restrict_apply]
-  rw [← f.additive, ← inter_distrib_right]
+  rw [← f.additive, ← union_inter_distrib_right]
   · simp only [union_univ, union_diff_self, univ_inter]
   · have : Disjoint f.discreteSupport (univ \ f.discreteSupport) := disjoint_sdiff_self_right
     exact this.mono (inter_subset_left _ _) (inter_subset_left _ _)

--- a/Mathlib/Combinatorics/Additive/SalemSpencer.lean
+++ b/Mathlib/Combinatorics/Additive/SalemSpencer.lean
@@ -380,7 +380,7 @@ theorem mulRothNumber_union_le (s t : Finset α) :
   let ⟨u, hus, hcard, hu⟩ := mulRothNumber_spec (s ∪ t)
   calc
     mulRothNumber (s ∪ t) = u.card := hcard.symm
-    _ = (u ∩ s ∪ u ∩ t).card := by rw [← inter_distrib_left, inter_eq_left.2 hus]
+    _ = (u ∩ s ∪ u ∩ t).card := by rw [← inter_union_distrib_left, inter_eq_left.2 hus]
     _ ≤ (u ∩ s).card + (u ∩ t).card := (card_union_le _ _)
     _ ≤ mulRothNumber s + mulRothNumber t := _root_.add_le_add
       ((hu.mono <| inter_subset_left _ _).le_mulRothNumber <| inter_subset_right _ _)

--- a/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
+++ b/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
@@ -229,8 +229,9 @@ lemma sum_collapse (h𝒜 : 𝒜 ⊆ (insert a u).powerset) (hu : a ∉ u) :
     · rw [insert_erase (erase_ne_self.1 fun hs ↦ ?_)]
       rw [hs] at h
       exact h.2 h.1
-  · rw [← sum_union (disjoint_sdiff_self_right.mono inf_le_left inf_le_left), ← inter_distrib_right,
-      union_sdiff_of_subset (powerset_mono.2 <| subset_insert _ _), inter_eq_right.2 h𝒜]
+  · rw [← sum_union (disjoint_sdiff_self_right.mono inf_le_left inf_le_left),
+      ← union_inter_distrib_right, union_sdiff_of_subset (powerset_mono.2 <| subset_insert _ _),
+      inter_eq_right.2 h𝒜]
 
 /-- The **Four Functions Theorem** on a powerset algebra. See `four_functions_theorem` for the
 finite distributive lattice generalisation. -/

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -1807,24 +1807,28 @@ theorem inter_union_distrib_left (s t u : Finset α) : s ∩ (t ∪ u) = s ∩ t
   inf_sup_left _ _ _
 #align finset.inter_distrib_left Finset.inter_union_distrib_left
 
+-- 2024-03-22
 @[deprecated] alias inter_distrib_left := inter_union_distrib_left
 
 theorem inter_union_distrib_right (s t u : Finset α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
   sup_inf_right _ _ _
 #align finset.union_distrib_right Finset.inter_union_distrib_right
 
+-- 2024-03-22
 @[deprecated] alias union_distrib_right := inter_union_distrib_right
 
 theorem union_inter_distrib_left (s t u : Finset α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
   sup_inf_left _ _ _
 #align finset.union_distrib_left Finset.union_inter_distrib_left
 
+-- 2024-03-22
 @[deprecated] alias union_distrib_left := union_inter_distrib_left
 
 theorem union_inter_distrib_right (s t u : Finset α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
   inf_sup_right _ _ _
 #align finset.inter_distrib_right Finset.union_inter_distrib_right
 
+-- 2024-03-22
 @[deprecated] alias inter_distrib_right := union_inter_distrib_right
 
 theorem union_union_distrib_left (s t u : Finset α) : s ∪ (t ∪ u) = s ∪ t ∪ (s ∪ u) :=

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -1803,45 +1803,45 @@ theorem inter_left_idem (s t : Finset α) : s ∩ (s ∩ t) = s ∩ t := inf_lef
 theorem inter_right_idem (s t : Finset α) : s ∩ t ∩ t = s ∩ t := inf_right_idem _ _
 #align finset.inter_right_idem Finset.inter_right_idem
 
-/-- Deprecated, use `Finset.inter_union_distrib_left` instead. -/
-@[deprecated inter_distrib_left]
-theorem inter_distrib_left (s t u : Finset α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
-  inf_sup_left _ _ _
-#align finset.inter_distrib_left Finset.inter_distrib_left
-
 theorem inter_union_distrib_left (s t u : Finset α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
   inf_sup_left _ _ _
 #align finset.inter_union_distrib_left Finset.inter_union_distrib_left
 
-/-- Deprecated, use `Finset.inter_union_distrib_right` instead. -/
-@[deprecated union_distrib_right]
-theorem union_distrib_right (s t u : Finset α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
-  sup_inf_right _ _ _
-#align finset.union_distrib_right Finset.union_distrib_right
+/-- Deprecated, use `Finset.inter_union_distrib_left` instead. -/
+@[deprecated inter_union_distrib_left]
+theorem inter_distrib_left (s t u : Finset α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
+  inf_sup_left _ _ _
+#align finset.inter_distrib_left Finset.inter_distrib_left
 
 theorem inter_union_distrib_right (s t u : Finset α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
   sup_inf_right _ _ _
 #align finset.inter_union_distrib_right Finset.inter_union_distrib_right
 
-/-- Deprecated, use `Finset.union_inter_distrib_left` instead. -/
-@[deprecated union_distrib_left]
-theorem union_distrib_left (s t u : Finset α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
-  sup_inf_left _ _ _
-#align finset.union_distrib_left Finset.union_distrib_left
+/-- Deprecated, use `Finset.inter_union_distrib_right` instead. -/
+@[deprecated inter_union_distrib_right]
+theorem union_distrib_right (s t u : Finset α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
+  sup_inf_right _ _ _
+#align finset.union_distrib_right Finset.union_distrib_right
 
 theorem union_inter_distrib_left (s t u : Finset α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
   sup_inf_left _ _ _
 #align finset.union_inter_distrib_left Finset.union_inter_distrib_left
 
-/-- Deprecated, use `Finset.union_inter_distrib_right` instead. -/
-@[deprecated inter_distrib_right]
-theorem inter_distrib_right (s t u : Finset α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
-  inf_sup_right _ _ _
-#align finset.inter_distrib_right Finset.inter_distrib_right
+/-- Deprecated, use `Finset.union_inter_distrib_left` instead. -/
+@[deprecated union_inter_distrib_left]
+theorem union_distrib_left (s t u : Finset α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
+  sup_inf_left _ _ _
+#align finset.union_distrib_left Finset.union_distrib_left
 
 theorem union_inter_distrib_right (s t u : Finset α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
   inf_sup_right _ _ _
 #align finset.union_inter_distrib_right Finset.union_inter_distrib_right
+
+/-- Deprecated, use `Finset.union_inter_distrib_right` instead. -/
+@[deprecated union_inter_distrib_right]
+theorem inter_distrib_right (s t u : Finset α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
+  inf_sup_right _ _ _
+#align finset.inter_distrib_right Finset.inter_distrib_right
 
 theorem union_union_distrib_left (s t u : Finset α) : s ∪ (t ∪ u) = s ∪ t ∪ (s ∪ u) :=
   sup_sup_distrib_left _ _ _
@@ -2396,7 +2396,7 @@ theorem erase_union_distrib (s t : Finset α) (a : α) : (s ∪ t).erase a = s.e
 #align finset.erase_union_distrib Finset.erase_union_distrib
 
 theorem insert_inter_distrib (s t : Finset α) (a : α) :
-    insert a (s ∩ t) = insert a s ∩ insert a t := by simp_rw [insert_eq, union_distrib_left]
+    insert a (s ∩ t) = insert a s ∩ insert a t := by simp_rw [insert_eq, union_inter_distrib_left]
 #align finset.insert_inter_distrib Finset.insert_inter_distrib
 
 theorem erase_sdiff_distrib (s t : Finset α) (a : α) : (s \ t).erase a = s.erase a \ t.erase a :=

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -1805,43 +1805,27 @@ theorem inter_right_idem (s t : Finset α) : s ∩ t ∩ t = s ∩ t := inf_righ
 
 theorem inter_union_distrib_left (s t u : Finset α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
   inf_sup_left _ _ _
-#align finset.inter_union_distrib_left Finset.inter_union_distrib_left
+#align finset.inter_distrib_left Finset.inter_union_distrib_left
 
-/-- Deprecated, use `Finset.inter_union_distrib_left` instead. -/
-@[deprecated inter_union_distrib_left]
-theorem inter_distrib_left (s t u : Finset α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
-  inf_sup_left _ _ _
-#align finset.inter_distrib_left Finset.inter_distrib_left
+@[deprecated] alias inter_distrib_left := inter_union_distrib_left
 
 theorem inter_union_distrib_right (s t u : Finset α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
   sup_inf_right _ _ _
-#align finset.inter_union_distrib_right Finset.inter_union_distrib_right
+#align finset.union_distrib_right Finset.inter_union_distrib_right
 
-/-- Deprecated, use `Finset.inter_union_distrib_right` instead. -/
-@[deprecated inter_union_distrib_right]
-theorem union_distrib_right (s t u : Finset α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
-  sup_inf_right _ _ _
-#align finset.union_distrib_right Finset.union_distrib_right
+@[deprecated] alias union_distrib_right := inter_union_distrib_right
 
 theorem union_inter_distrib_left (s t u : Finset α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
   sup_inf_left _ _ _
-#align finset.union_inter_distrib_left Finset.union_inter_distrib_left
+#align finset.union_distrib_left Finset.union_inter_distrib_left
 
-/-- Deprecated, use `Finset.union_inter_distrib_left` instead. -/
-@[deprecated union_inter_distrib_left]
-theorem union_distrib_left (s t u : Finset α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
-  sup_inf_left _ _ _
-#align finset.union_distrib_left Finset.union_distrib_left
+@[deprecated] alias union_distrib_left := union_inter_distrib_left
 
 theorem union_inter_distrib_right (s t u : Finset α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
   inf_sup_right _ _ _
-#align finset.union_inter_distrib_right Finset.union_inter_distrib_right
+#align finset.inter_distrib_right Finset.union_inter_distrib_right
 
-/-- Deprecated, use `Finset.union_inter_distrib_right` instead. -/
-@[deprecated union_inter_distrib_right]
-theorem inter_distrib_right (s t u : Finset α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
-  inf_sup_right _ _ _
-#align finset.inter_distrib_right Finset.inter_distrib_right
+@[deprecated] alias inter_distrib_right := union_inter_distrib_right
 
 theorem union_union_distrib_left (s t u : Finset α) : s ∪ (t ∪ u) = s ∪ t ∪ (s ∪ u) :=
   sup_sup_distrib_left _ _ _

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -1803,21 +1803,45 @@ theorem inter_left_idem (s t : Finset α) : s ∩ (s ∩ t) = s ∩ t := inf_lef
 theorem inter_right_idem (s t : Finset α) : s ∩ t ∩ t = s ∩ t := inf_right_idem _ _
 #align finset.inter_right_idem Finset.inter_right_idem
 
+/-- Deprecated, use `Finset.inter_union_distrib_left` instead. -/
+@[deprecated inter_distrib_left]
 theorem inter_distrib_left (s t u : Finset α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
   inf_sup_left _ _ _
 #align finset.inter_distrib_left Finset.inter_distrib_left
 
-theorem inter_distrib_right (s t u : Finset α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
-  inf_sup_right _ _ _
-#align finset.inter_distrib_right Finset.inter_distrib_right
+theorem inter_union_distrib_left (s t u : Finset α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
+  inf_sup_left _ _ _
+#align finset.inter_union_distrib_left Finset.inter_union_distrib_left
 
+/-- Deprecated, use `Finset.inter_union_distrib_right` instead. -/
+@[deprecated union_distrib_right]
+theorem union_distrib_right (s t u : Finset α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
+  sup_inf_right _ _ _
+#align finset.union_distrib_right Finset.union_distrib_right
+
+theorem inter_union_distrib_right (s t u : Finset α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
+  sup_inf_right _ _ _
+#align finset.inter_union_distrib_right Finset.inter_union_distrib_right
+
+/-- Deprecated, use `Finset.union_inter_distrib_left` instead. -/
+@[deprecated union_distrib_left]
 theorem union_distrib_left (s t u : Finset α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
   sup_inf_left _ _ _
 #align finset.union_distrib_left Finset.union_distrib_left
 
-theorem union_distrib_right (s t u : Finset α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
-  sup_inf_right _ _ _
-#align finset.union_distrib_right Finset.union_distrib_right
+theorem union_inter_distrib_left (s t u : Finset α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
+  sup_inf_left _ _ _
+#align finset.union_inter_distrib_left Finset.union_inter_distrib_left
+
+/-- Deprecated, use `Finset.union_inter_distrib_right` instead. -/
+@[deprecated inter_distrib_right]
+theorem inter_distrib_right (s t u : Finset α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
+  inf_sup_right _ _ _
+#align finset.inter_distrib_right Finset.inter_distrib_right
+
+theorem union_inter_distrib_right (s t u : Finset α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
+  inf_sup_right _ _ _
+#align finset.union_inter_distrib_right Finset.union_inter_distrib_right
 
 theorem union_union_distrib_left (s t u : Finset α) : s ∪ (t ∪ u) = s ∪ t ∪ (s ∪ u) :=
   sup_sup_distrib_left _ _ _

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -1807,28 +1807,22 @@ theorem inter_union_distrib_left (s t u : Finset α) : s ∩ (t ∪ u) = s ∩ t
   inf_sup_left _ _ _
 #align finset.inter_distrib_left Finset.inter_union_distrib_left
 
--- 2024-03-22
-@[deprecated] alias inter_distrib_left := inter_union_distrib_left
-
 theorem inter_union_distrib_right (s t u : Finset α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
   sup_inf_right _ _ _
 #align finset.union_distrib_right Finset.inter_union_distrib_right
 
--- 2024-03-22
-@[deprecated] alias union_distrib_right := inter_union_distrib_right
-
 theorem union_inter_distrib_left (s t u : Finset α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
   sup_inf_left _ _ _
 #align finset.union_distrib_left Finset.union_inter_distrib_left
-
--- 2024-03-22
-@[deprecated] alias union_distrib_left := union_inter_distrib_left
 
 theorem union_inter_distrib_right (s t u : Finset α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
   inf_sup_right _ _ _
 #align finset.inter_distrib_right Finset.union_inter_distrib_right
 
 -- 2024-03-22
+@[deprecated] alias inter_distrib_left := inter_union_distrib_left
+@[deprecated] alias union_distrib_right := inter_union_distrib_right
+@[deprecated] alias union_distrib_left := union_inter_distrib_left
 @[deprecated] alias inter_distrib_right := union_inter_distrib_right
 
 theorem union_union_distrib_left (s t u : Finset α) : s ∪ (t ∪ u) = s ∪ t ∪ (s ∪ u) :=

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -1807,23 +1807,23 @@ theorem inter_union_distrib_left (s t u : Finset α) : s ∩ (t ∪ u) = s ∩ t
   inf_sup_left _ _ _
 #align finset.inter_distrib_left Finset.inter_union_distrib_left
 
-theorem inter_union_distrib_right (s t u : Finset α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
-  sup_inf_right _ _ _
-#align finset.union_distrib_right Finset.inter_union_distrib_right
+theorem union_inter_distrib_right (s t u : Finset α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
+  inf_sup_right _ _ _
+#align finset.inter_distrib_right Finset.union_inter_distrib_right
 
 theorem union_inter_distrib_left (s t u : Finset α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
   sup_inf_left _ _ _
 #align finset.union_distrib_left Finset.union_inter_distrib_left
 
-theorem union_inter_distrib_right (s t u : Finset α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
-  inf_sup_right _ _ _
-#align finset.inter_distrib_right Finset.union_inter_distrib_right
+theorem inter_union_distrib_right (s t u : Finset α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
+  sup_inf_right _ _ _
+#align finset.union_distrib_right Finset.inter_union_distrib_right
 
 -- 2024-03-22
 @[deprecated] alias inter_distrib_left := inter_union_distrib_left
-@[deprecated] alias union_distrib_right := inter_union_distrib_right
-@[deprecated] alias union_distrib_left := union_inter_distrib_left
 @[deprecated] alias inter_distrib_right := union_inter_distrib_right
+@[deprecated] alias union_distrib_left := union_inter_distrib_left
+@[deprecated] alias union_distrib_right := inter_union_distrib_right
 
 theorem union_union_distrib_left (s t u : Finset α) : s ∪ (t ∪ u) = s ∪ t ∪ (s ∪ u) :=
   sup_sup_distrib_left _ _ _

--- a/Mathlib/Data/Finset/Sups.lean
+++ b/Mathlib/Data/Finset/Sups.lean
@@ -445,7 +445,7 @@ variable {𝒜 ℬ : Finset (Finset α)} {s t : Finset α} {a : α}
   ext u
   simp only [mem_sups, mem_powerset, le_eq_subset, sup_eq_union]
   refine ⟨fun h ↦ ⟨_, inter_subset_left _ u, _, inter_subset_left _ u, ?_⟩, ?_⟩
-  · rwa [← inter_distrib_right, inter_eq_right]
+  · rwa [← union_inter_distrib_right, inter_eq_right]
   · rintro ⟨v, hv, w, hw, rfl⟩
     exact union_subset_union hv hw
 

--- a/Mathlib/Data/Matroid/Dual.lean
+++ b/Mathlib/Data/Matroid/Dual.lean
@@ -88,7 +88,7 @@ section dual
         ← inter_eq_self_of_subset_left hB''.subset_ground, inter_right_comm, inter_assoc]
 
       calc _ ⊆ _ := inter_subset_inter_right _ hssJ
-           _ ⊆ _ := by rw [inter_distrib_left, hdj.symm.inter_eq, union_empty]
+           _ ⊆ _ := by rw [inter_union_distrib_left, hdj.symm.inter_eq, union_empty]
            _ ⊆ _ := inter_subset_right _ _
 
     obtain ⟨B₁,hB₁,hI'B₁,hB₁I⟩ := (hB'.indep.subset hI').exists_base_subset_union_base hB''
@@ -188,7 +188,7 @@ theorem Base.compl_inter_basis_of_inter_basis (hB : M.Base B) (hBX : M.Basis (B 
     and_iff_left ((inter_subset_left _ _).trans (diff_subset _ _))]
   refine' fun B' hB' ↦ by_contra (fun hem ↦ _)
   rw [nonempty_iff_ne_empty, not_ne_iff, ← union_singleton, diff_inter_diff,
-   inter_distrib_right, union_empty_iff, singleton_inter_eq_empty, diff_eq,
+   union_inter_distrib_right, union_empty_iff, singleton_inter_eq_empty, diff_eq,
    inter_right_comm, inter_eq_self_of_subset_right hB'.subset_ground, ← diff_eq,
    diff_eq_empty] at hem
   obtain ⟨f, hfb, hBf⟩ := hB.exchange hB' ⟨he.2, hem.2⟩

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -516,7 +516,7 @@ theorem preimage_eq (f : α →. β) (s : Set β) : f.preimage s = f.core s ∩ 
 #align pfun.preimage_eq PFun.preimage_eq
 
 theorem core_eq (f : α →. β) (s : Set β) : f.core s = f.preimage s ∪ f.Domᶜ := by
-  rw [preimage_eq, Set.union_distrib_right, Set.union_comm (Dom f), Set.compl_union_self,
+  rw [preimage_eq, Set.inter_union_distrib_right, Set.union_comm (Dom f), Set.compl_union_self,
     Set.inter_univ, Set.union_eq_self_of_subset_right (f.compl_dom_subset_core s)]
 #align pfun.core_eq PFun.core_eq
 

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1021,38 +1021,45 @@ theorem setOf_inter_eq_sep (p : α → Prop) (s : Set α) : {a | p a} ∩ s = {a
 
 /-! ### Distributivity laws -/
 
-
+/-- Deprecated, use `Set.inter_union_distrib_left` instead. -/
+@[deprecated inter_distrib_left]
 theorem inter_distrib_left (s t u : Set α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
   inf_sup_left _ _ _
 #align set.inter_distrib_left Set.inter_distrib_left
 
-theorem inter_union_distrib_left {s t u : Set α} : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
+theorem inter_union_distrib_left (s t u : Set α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
   inf_sup_left _ _ _
 #align set.inter_union_distrib_left Set.inter_union_distrib_left
 
-theorem inter_distrib_right (s t u : Set α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
-  inf_sup_right _ _ _
-#align set.inter_distrib_right Set.inter_distrib_right
-
-theorem union_inter_distrib_right {s t u : Set α} : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
-  inf_sup_right _ _ _
-#align set.union_inter_distrib_right Set.union_inter_distrib_right
-
-theorem union_distrib_left (s t u : Set α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
-  sup_inf_left _ _ _
-#align set.union_distrib_left Set.union_distrib_left
-
-theorem union_inter_distrib_left {s t u : Set α} : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
-  sup_inf_left _ _ _
-#align set.union_inter_distrib_left Set.union_inter_distrib_left
-
+/-- Deprecated, use `Set.inter_union_distrib_right` instead. -/
+@[deprecated union_distrib_right]
 theorem union_distrib_right (s t u : Set α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
   sup_inf_right _ _ _
 #align set.union_distrib_right Set.union_distrib_right
 
-theorem inter_union_distrib_right {s t u : Set α} : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
+theorem inter_union_distrib_right (s t u : Set α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
   sup_inf_right _ _ _
 #align set.inter_union_distrib_right Set.inter_union_distrib_right
+
+/-- Deprecated, use `Set.union_inter_distrib_left` instead. -/
+@[deprecated union_distrib_left]
+theorem union_distrib_left (s t u : Set α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
+  sup_inf_left _ _ _
+#align set.union_distrib_left Set.union_distrib_left
+
+theorem union_inter_distrib_left (s t u : Set α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
+  sup_inf_left _ _ _
+#align set.union_inter_distrib_left Set.union_inter_distrib_left
+
+/-- Deprecated, use `Set.union_inter_distrib_right` instead. -/
+@[deprecated inter_distrib_right]
+theorem inter_distrib_right (s t u : Set α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
+  inf_sup_right _ _ _
+#align set.inter_distrib_right Set.inter_distrib_right
+
+theorem union_inter_distrib_right (s t u : Set α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
+  inf_sup_right _ _ _
+#align set.union_inter_distrib_right Set.union_inter_distrib_right
 
 theorem union_union_distrib_left (s t u : Set α) : s ∪ (t ∪ u) = s ∪ t ∪ (s ∪ u) :=
   sup_sup_distrib_left _ _ _
@@ -1448,7 +1455,7 @@ theorem sep_univ : { x ∈ (univ : Set α) | p x } = { x | p x } :=
 
 @[simp]
 theorem sep_union : { x | (x ∈ s ∨ x ∈ t) ∧ p x } = { x ∈ s | p x } ∪ { x ∈ t | p x } :=
-  union_inter_distrib_right
+  union_inter_distrib_right { x | x ∈ s } { x | x ∈ t } p
 #align set.sep_union Set.sep_union
 
 @[simp]
@@ -1463,7 +1470,7 @@ theorem sep_and : { x ∈ s | p x ∧ q x } = { x ∈ s | p x } ∩ { x ∈ s | 
 
 @[simp]
 theorem sep_or : { x ∈ s | p x ∨ q x } = { x ∈ s | p x } ∪ { x ∈ s | q x } :=
-  inter_union_distrib_left
+  inter_union_distrib_left s p q
 #align set.sep_or Set.sep_or
 
 @[simp]

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1025,24 +1025,28 @@ theorem inter_union_distrib_left (s t u : Set α) : s ∩ (t ∪ u) = s ∩ t �
   inf_sup_left _ _ _
 #align set.inter_distrib_left Set.inter_union_distrib_left
 
+-- 2024-03-22
 @[deprecated] alias inter_distrib_left := inter_union_distrib_left
 
 theorem inter_union_distrib_right (s t u : Set α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
   sup_inf_right _ _ _
 #align set.union_distrib_right Set.inter_union_distrib_right
 
+-- 2024-03-22
 @[deprecated] alias union_distrib_right := inter_union_distrib_right
 
 theorem union_inter_distrib_left (s t u : Set α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
   sup_inf_left _ _ _
 #align set.union_distrib_left Set.union_inter_distrib_left
 
+-- 2024-03-22
 @[deprecated] alias union_distrib_left := union_inter_distrib_left
 
 theorem union_inter_distrib_right (s t u : Set α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
   inf_sup_right _ _ _
 #align set.inter_distrib_right Set.union_inter_distrib_right
 
+-- 2024-03-22
 @[deprecated] alias inter_distrib_right := union_inter_distrib_right
 
 theorem union_union_distrib_left (s t u : Set α) : s ∪ (t ∪ u) = s ∪ t ∪ (s ∪ u) :=

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1021,45 +1021,45 @@ theorem setOf_inter_eq_sep (p : α → Prop) (s : Set α) : {a | p a} ∩ s = {a
 
 /-! ### Distributivity laws -/
 
-/-- Deprecated, use `Set.inter_union_distrib_left` instead. -/
-@[deprecated inter_distrib_left]
-theorem inter_distrib_left (s t u : Set α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
-  inf_sup_left _ _ _
-#align set.inter_distrib_left Set.inter_distrib_left
-
 theorem inter_union_distrib_left (s t u : Set α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
   inf_sup_left _ _ _
 #align set.inter_union_distrib_left Set.inter_union_distrib_left
 
-/-- Deprecated, use `Set.inter_union_distrib_right` instead. -/
-@[deprecated union_distrib_right]
-theorem union_distrib_right (s t u : Set α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
-  sup_inf_right _ _ _
-#align set.union_distrib_right Set.union_distrib_right
+/-- Deprecated, use `Set.inter_union_distrib_left` instead. -/
+@[deprecated inter_union_distrib_left]
+theorem inter_distrib_left (s t u : Set α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
+  inf_sup_left _ _ _
+#align set.inter_distrib_left Set.inter_distrib_left
 
 theorem inter_union_distrib_right (s t u : Set α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
   sup_inf_right _ _ _
 #align set.inter_union_distrib_right Set.inter_union_distrib_right
 
-/-- Deprecated, use `Set.union_inter_distrib_left` instead. -/
-@[deprecated union_distrib_left]
-theorem union_distrib_left (s t u : Set α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
-  sup_inf_left _ _ _
-#align set.union_distrib_left Set.union_distrib_left
+/-- Deprecated, use `Set.inter_union_distrib_right` instead. -/
+@[deprecated inter_union_distrib_right]
+theorem union_distrib_right (s t u : Set α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
+  sup_inf_right _ _ _
+#align set.union_distrib_right Set.union_distrib_right
 
 theorem union_inter_distrib_left (s t u : Set α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
   sup_inf_left _ _ _
 #align set.union_inter_distrib_left Set.union_inter_distrib_left
 
-/-- Deprecated, use `Set.union_inter_distrib_right` instead. -/
-@[deprecated inter_distrib_right]
-theorem inter_distrib_right (s t u : Set α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
-  inf_sup_right _ _ _
-#align set.inter_distrib_right Set.inter_distrib_right
+/-- Deprecated, use `Set.union_inter_distrib_left` instead. -/
+@[deprecated union_inter_distrib_left]
+theorem union_distrib_left (s t u : Set α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
+  sup_inf_left _ _ _
+#align set.union_distrib_left Set.union_distrib_left
 
 theorem union_inter_distrib_right (s t u : Set α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
   inf_sup_right _ _ _
 #align set.union_inter_distrib_right Set.union_inter_distrib_right
+
+/-- Deprecated, use `Set.union_inter_distrib_right` instead. -/
+@[deprecated union_inter_distrib_right]
+theorem inter_distrib_right (s t u : Set α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
+  inf_sup_right _ _ _
+#align set.inter_distrib_right Set.inter_distrib_right
 
 theorem union_union_distrib_left (s t u : Set α) : s ∪ (t ∪ u) = s ∪ t ∪ (s ∪ u) :=
   sup_sup_distrib_left _ _ _

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1025,23 +1025,23 @@ theorem inter_union_distrib_left (s t u : Set α) : s ∩ (t ∪ u) = s ∩ t �
   inf_sup_left _ _ _
 #align set.inter_distrib_left Set.inter_union_distrib_left
 
-theorem inter_union_distrib_right (s t u : Set α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
-  sup_inf_right _ _ _
-#align set.union_distrib_right Set.inter_union_distrib_right
+theorem union_inter_distrib_right (s t u : Set α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
+  inf_sup_right _ _ _
+#align set.inter_distrib_right Set.union_inter_distrib_right
 
 theorem union_inter_distrib_left (s t u : Set α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
   sup_inf_left _ _ _
 #align set.union_distrib_left Set.union_inter_distrib_left
 
-theorem union_inter_distrib_right (s t u : Set α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
-  inf_sup_right _ _ _
-#align set.inter_distrib_right Set.union_inter_distrib_right
+theorem inter_union_distrib_right (s t u : Set α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
+  sup_inf_right _ _ _
+#align set.union_distrib_right Set.inter_union_distrib_right
 
 -- 2024-03-22
 @[deprecated] alias inter_distrib_left := inter_union_distrib_left
-@[deprecated] alias union_distrib_right := inter_union_distrib_right
-@[deprecated] alias union_distrib_left := union_inter_distrib_left
 @[deprecated] alias inter_distrib_right := union_inter_distrib_right
+@[deprecated] alias union_distrib_left := union_inter_distrib_left
+@[deprecated] alias union_distrib_right := inter_union_distrib_right
 
 theorem union_union_distrib_left (s t u : Set α) : s ∪ (t ∪ u) = s ∪ t ∪ (s ∪ u) :=
   sup_sup_distrib_left _ _ _

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1023,43 +1023,27 @@ theorem setOf_inter_eq_sep (p : α → Prop) (s : Set α) : {a | p a} ∩ s = {a
 
 theorem inter_union_distrib_left (s t u : Set α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
   inf_sup_left _ _ _
-#align set.inter_union_distrib_left Set.inter_union_distrib_left
+#align set.inter_distrib_left Set.inter_union_distrib_left
 
-/-- Deprecated, use `Set.inter_union_distrib_left` instead. -/
-@[deprecated inter_union_distrib_left]
-theorem inter_distrib_left (s t u : Set α) : s ∩ (t ∪ u) = s ∩ t ∪ s ∩ u :=
-  inf_sup_left _ _ _
-#align set.inter_distrib_left Set.inter_distrib_left
+@[deprecated] alias inter_distrib_left := inter_union_distrib_left
 
 theorem inter_union_distrib_right (s t u : Set α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
   sup_inf_right _ _ _
-#align set.inter_union_distrib_right Set.inter_union_distrib_right
+#align set.union_distrib_right Set.inter_union_distrib_right
 
-/-- Deprecated, use `Set.inter_union_distrib_right` instead. -/
-@[deprecated inter_union_distrib_right]
-theorem union_distrib_right (s t u : Set α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
-  sup_inf_right _ _ _
-#align set.union_distrib_right Set.union_distrib_right
+@[deprecated] alias union_distrib_right := inter_union_distrib_right
 
 theorem union_inter_distrib_left (s t u : Set α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
   sup_inf_left _ _ _
-#align set.union_inter_distrib_left Set.union_inter_distrib_left
+#align set.union_distrib_left Set.union_inter_distrib_left
 
-/-- Deprecated, use `Set.union_inter_distrib_left` instead. -/
-@[deprecated union_inter_distrib_left]
-theorem union_distrib_left (s t u : Set α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
-  sup_inf_left _ _ _
-#align set.union_distrib_left Set.union_distrib_left
+@[deprecated] alias union_distrib_left := union_inter_distrib_left
 
 theorem union_inter_distrib_right (s t u : Set α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
   inf_sup_right _ _ _
-#align set.union_inter_distrib_right Set.union_inter_distrib_right
+#align set.inter_distrib_right Set.union_inter_distrib_right
 
-/-- Deprecated, use `Set.union_inter_distrib_right` instead. -/
-@[deprecated union_inter_distrib_right]
-theorem inter_distrib_right (s t u : Set α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
-  inf_sup_right _ _ _
-#align set.inter_distrib_right Set.inter_distrib_right
+@[deprecated] alias inter_distrib_right := union_inter_distrib_right
 
 theorem union_union_distrib_left (s t u : Set α) : s ∪ (t ∪ u) = s ∪ t ∪ (s ∪ u) :=
   sup_sup_distrib_left _ _ _

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1025,28 +1025,22 @@ theorem inter_union_distrib_left (s t u : Set α) : s ∩ (t ∪ u) = s ∩ t �
   inf_sup_left _ _ _
 #align set.inter_distrib_left Set.inter_union_distrib_left
 
--- 2024-03-22
-@[deprecated] alias inter_distrib_left := inter_union_distrib_left
-
 theorem inter_union_distrib_right (s t u : Set α) : s ∩ t ∪ u = (s ∪ u) ∩ (t ∪ u) :=
   sup_inf_right _ _ _
 #align set.union_distrib_right Set.inter_union_distrib_right
 
--- 2024-03-22
-@[deprecated] alias union_distrib_right := inter_union_distrib_right
-
 theorem union_inter_distrib_left (s t u : Set α) : s ∪ t ∩ u = (s ∪ t) ∩ (s ∪ u) :=
   sup_inf_left _ _ _
 #align set.union_distrib_left Set.union_inter_distrib_left
-
--- 2024-03-22
-@[deprecated] alias union_distrib_left := union_inter_distrib_left
 
 theorem union_inter_distrib_right (s t u : Set α) : (s ∪ t) ∩ u = s ∩ u ∪ t ∩ u :=
   inf_sup_right _ _ _
 #align set.inter_distrib_right Set.union_inter_distrib_right
 
 -- 2024-03-22
+@[deprecated] alias inter_distrib_left := inter_union_distrib_left
+@[deprecated] alias union_distrib_right := inter_union_distrib_right
+@[deprecated] alias union_distrib_left := union_inter_distrib_left
 @[deprecated] alias inter_distrib_right := union_inter_distrib_right
 
 theorem union_union_distrib_left (s t u : Set α) : s ∪ (t ∪ u) = s ∪ t ∪ (s ∪ u) :=

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -941,7 +941,7 @@ theorem compl_range_inr : (range (Sum.inr : β → Sum α β))ᶜ = range (Sum.i
 
 theorem image_preimage_inl_union_image_preimage_inr (s : Set (Sum α β)) :
     Sum.inl '' (Sum.inl ⁻¹' s) ∪ Sum.inr '' (Sum.inr ⁻¹' s) = s := by
-  rw [image_preimage_eq_inter_range, image_preimage_eq_inter_range, ← inter_distrib_left,
+  rw [image_preimage_eq_inter_range, image_preimage_eq_inter_range, ← inter_union_distrib_left,
     range_inl_union_range_inr, inter_univ]
 #align set.image_preimage_inl_union_image_preimage_inr Set.image_preimage_inl_union_image_preimage_inr
 

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -1680,8 +1680,8 @@ theorem measure_eq_measure_preimage_add_measure_tsum_Ico_zpow [MeasurableSpace �
       ∑' n : ℤ, μ (s ∩ f ⁻¹' Ico ((t : ℝ≥0∞) ^ n) ((t : ℝ≥0∞) ^ (n + 1))) := by
   have A : μ s = μ (s ∩ f ⁻¹' {0}) + μ (s ∩ f ⁻¹' Ioi 0) := by
     rw [← measure_union]
-    · rw [← inter_distrib_left, ← preimage_union, singleton_union, Ioi_insert, ← _root_.bot_eq_zero,
-        Ici_bot, preimage_univ, inter_univ]
+    · rw [← inter_union_distrib_left, ← preimage_union, singleton_union, Ioi_insert,
+        ← _root_.bot_eq_zero, Ici_bot, preimage_univ, inter_univ]
     · exact disjoint_singleton_left.mpr not_mem_Ioi_self
         |>.preimage f |>.inter_right' s |>.inter_left' s
     · exact hs.inter (hf measurableSet_Ioi)

--- a/Mathlib/MeasureTheory/Covering/Differentiation.lean
+++ b/Mathlib/MeasureTheory/Covering/Differentiation.lean
@@ -326,8 +326,8 @@ theorem exists_measurable_supersets_limRatio {p q : ℝ≥0} (hpq : p < q) :
           (toMeasurable μ sᶜ ∪ ⋃ n, toMeasurable (ρ + μ) (w n)) ⊆
         toMeasurable μ sᶜ ∪
           ⋃ (m) (n), toMeasurable (ρ + μ) (u m) ∩ toMeasurable (ρ + μ) (w n) := by
-      simp only [inter_distrib_left, inter_distrib_right, true_and_iff, subset_union_left,
-        union_subset_iff, inter_self]
+      simp only [inter_union_distrib_left, union_inter_distrib_righ, true_and_iff,
+        subset_union_left, union_subset_iff, inter_self]
       refine' ⟨_, _, _⟩
       · exact (inter_subset_right _ _).trans (subset_union_left _ _)
       · exact (inter_subset_left _ _).trans (subset_union_left _ _)

--- a/Mathlib/MeasureTheory/Covering/Differentiation.lean
+++ b/Mathlib/MeasureTheory/Covering/Differentiation.lean
@@ -326,7 +326,7 @@ theorem exists_measurable_supersets_limRatio {p q : ℝ≥0} (hpq : p < q) :
           (toMeasurable μ sᶜ ∪ ⋃ n, toMeasurable (ρ + μ) (w n)) ⊆
         toMeasurable μ sᶜ ∪
           ⋃ (m) (n), toMeasurable (ρ + μ) (u m) ∩ toMeasurable (ρ + μ) (w n) := by
-      simp only [inter_union_distrib_left, union_inter_distrib_righ, true_and_iff,
+      simp only [inter_union_distrib_left, union_inter_distrib_right, true_and_iff,
         subset_union_left, union_subset_iff, inter_self]
       refine' ⟨_, _, _⟩
       · exact (inter_subset_right _ _).trans (subset_union_left _ _)

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -659,7 +659,7 @@ theorem MeasurableSet.of_union_cover {s t u : Set α} (hs : MeasurableSet s) (ht
     (h : univ ⊆ s ∪ t) (hsu : MeasurableSet (((↑) : s → α) ⁻¹' u))
     (htu : MeasurableSet (((↑) : t → α) ⁻¹' u)) : MeasurableSet u := by
   convert (hs.subtype_image hsu).union (ht.subtype_image htu)
-  simp [image_preimage_eq_inter_range, ← inter_distrib_left, univ_subset_iff.1 h]
+  simp [image_preimage_eq_inter_range, ← inter_union_distrib_left, univ_subset_iff.1 h]
 
 theorem measurable_of_measurable_union_cover {f : α → β} (s t : Set α) (hs : MeasurableSet s)
     (ht : MeasurableSet t) (h : univ ⊆ s ∪ t) (hc : Measurable fun a : s => f a)

--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -715,7 +715,7 @@ theorem frontier_inter_subset (s t : Set X) :
     frontier (s ∩ t) ⊆ frontier s ∩ closure t ∪ closure s ∩ frontier t := by
   simp only [frontier_eq_closure_inter_closure, compl_inter, closure_union]
   refine' (inter_subset_inter_left _ (closure_inter_subset_inter_closure s t)).trans_eq _
-  simp only [inter_distrib_left, inter_distrib_right, inter_assoc, inter_comm (closure t)]
+  simp only [inter_union_distrib_left, union_inter_distrib_right, inter_assoc, inter_comm (closure t)]
 #align frontier_inter_subset frontier_inter_subset
 
 theorem frontier_union_subset (s t : Set X) :

--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -715,7 +715,8 @@ theorem frontier_inter_subset (s t : Set X) :
     frontier (s ∩ t) ⊆ frontier s ∩ closure t ∪ closure s ∩ frontier t := by
   simp only [frontier_eq_closure_inter_closure, compl_inter, closure_union]
   refine' (inter_subset_inter_left _ (closure_inter_subset_inter_closure s t)).trans_eq _
-  simp only [inter_union_distrib_left, union_inter_distrib_right, inter_assoc, inter_comm (closure t)]
+  simp only [inter_union_distrib_left, union_inter_distrib_right, inter_assoc,
+    inter_comm (closure t)]
 #align frontier_inter_subset frontier_inter_subset
 
 theorem frontier_union_subset (s t : Set X) :

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -318,7 +318,7 @@ protected theorem IsPreconnected.image [TopologicalSpace β] {s : Set α} (H : I
   replace huv : s ⊆ u' ∪ v' := by
     rw [image_subset_iff, preimage_union] at huv
     replace huv := subset_inter huv Subset.rfl
-    rw [inter_distrib_right, u'_eq, v'_eq, ← inter_distrib_right] at huv
+    rw [union_inter_distrib_right, u'_eq, v'_eq, ← union_inter_distrib_right] at huv
     exact (subset_inter_iff.1 huv).1
   -- Now `s ⊆ u' ∪ v'`, so we can apply `‹IsPreconnected s›`
   obtain ⟨z, hz⟩ : (s ∩ (u' ∩ v')).Nonempty := by
@@ -1121,7 +1121,7 @@ theorem isPreconnected_iff_subset_of_fully_disjoint_closed {s : Set α} (hs : Is
   rw [subset_inter_iff, subset_inter_iff] at H1
   simp only [Subset.refl, and_true] at H1
   apply H1 (hu.inter hs) (hv.inter hs)
-  · rw [← inter_distrib_right]
+  · rw [← union_inter_distrib_right]
     exact subset_inter hss Subset.rfl
   · rwa [disjoint_iff_inter_eq_empty, ← inter_inter_distrib_right, inter_comm]
 #align is_preconnected_iff_subset_of_fully_disjoint_closed isPreconnected_iff_subset_of_fully_disjoint_closed


### PR DESCRIPTION
Standardizes the following names for distributivity laws across `Finset` and `Set`:

- `inter_union_distrib_left`
- `inter_union_distrib_right`
- `union_inter_distrib_left`
- `union_inter_distrib_right`

Makes arguments explicit in:

- `Set.union_inter_distrib_right`
- `Set.union_inter_distrib_left`
- `Set.inter_union_distrib_right`

Deprecates these theorem names:

- `Finset.inter_distrib_left`
- `Finset.inter_distrib_right`
- `Finset.union_distrib_right`
- `Finset.union_distrib_left`
- `Set.inter_distrib_left`
- `Set.inter_distrib_right`
- `Set.union_distrib_right`
- `Set.union_distrib_left`

Fixes use of deprecated names and implicit arguments in these files:

- Topology/Basic
- Topology/Connected/Basic
- MeasureTheory/MeasurableSpace/Basic
- MeasureTheory/Covering/Differentiation
- MeasureTheory/Constructions/BorelSpace/Basic
- Data/Set/Image
- Data/Set/Basic
- Data/PFun
- Data/Matroid/Dual
- Data/Finset/Sups
- Data/Finset/Basic
- Combinatorics/SetFamily/FourFunctions
- Combinatorics/Additive/SalemSpencer
- Counterexamples/Phillips.lean
- Archive/Imo/Imo2021Q1.lean