### PR TITLE
feat: CompTypeclasses 

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -190,6 +190,7 @@ import Mathlib.Algebra.Group.Equiv.TypeTags
 import Mathlib.Algebra.Group.Ext
 import Mathlib.Algebra.Group.Freiman
 import Mathlib.Algebra.Group.Hom.Basic
+import Mathlib.Algebra.Group.Hom.CompTypeclasses
 import Mathlib.Algebra.Group.Hom.Defs
 import Mathlib.Algebra.Group.Hom.Instances
 import Mathlib.Algebra.Group.InjSurj
@@ -2704,6 +2705,7 @@ import Mathlib.Logic.Equiv.PartialEquiv
 import Mathlib.Logic.Equiv.Set
 import Mathlib.Logic.Equiv.TransferInstance
 import Mathlib.Logic.Function.Basic
+import Mathlib.Logic.Function.CompTypeclasses
 import Mathlib.Logic.Function.Conjugate
 import Mathlib.Logic.Function.FromTypes
 import Mathlib.Logic.Function.Iterate

--- a/Mathlib/Algebra/Group/Hom/CompTypeclasses.lean
+++ b/Mathlib/Algebra/Group/Hom/CompTypeclasses.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2024 Antoine Chambert-Loir. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir
+-/
+
+
+import Mathlib.Logic.Function.CompTypeclasses
+import Mathlib.Algebra.Group.Hom.Defs
+
+/-!
+# Propositional typeclasses on several monoid homs
+
+This file contains typeclasses used in the definition of equivariant maps,
+in the spirit what was initially developed by Frédéric Dupuis and Heather Macbeth for linear maps.
+However, we do not expect that all maps should be guessed automatically,
+as it happens for linear maps.
+
+If `φ`, `ψ`… are monoid homs and `M`, `N`… are monoids, we add two instances:
+* `MonoidHom.CompTriple φ ψ χ`, which expresses that `ψ.comp φ = χ`
+* `MonoidHom.IsId φ`, which expresses that `φ = id`
+
+Some basic lemmas are proved:
+* `MonoidHom.CompTriple.comp` asserts `MonoidHom.CompTriple φ ψ (ψ.comp φ)`
+* `MonoidHom.CompTriple.id_comp` asserts `MonoidHom.CompTriple φ ψ ψ`
+  in the presence of `MonoidHom.IsId φ`
+* its variant `MonoidHom.CompTriple.comp_id`
+
+TODO :
+* align with RingHomCompTriple
+* probably rename MonoidHom.CompTriple as MonoidHomCompTriple
+(or, on the opposite, rename RingHomCompTriple as RingHom.CompTriple)
+* does one need AddHom.CompTriple ?
+
+-/
+
+section MonoidHomCompTriple
+
+namespace MonoidHom
+
+/-- Class of composing triples -/
+class CompTriple  {M N P : Type*} [Monoid M] [Monoid N] [Monoid P]
+  (φ : M →* N) (ψ : N →* P) (χ : outParam (M →* P)) : Prop where
+  /-- The maps form a commuting triangle -/
+  comp_eq : ψ.comp φ = χ
+
+attribute [simp] CompTriple.comp_eq
+
+namespace CompTriple
+
+variable {M' : Type*} [Monoid M']
+variable {M N P : Type*} [Monoid M] [Monoid N] [Monoid P]
+
+/-- Class of Id maps -/
+class IsId (σ : M →* M) : Prop where
+  eq_id : σ = MonoidHom.id M
+
+instance instIsId {M : Type*} [Monoid M] : IsId (MonoidHom.id M) where
+  eq_id := rfl
+
+instance {σ : M →* M} [h : _root_.CompTriple.IsId σ] : IsId σ  where
+  eq_id := by ext; exact _root_.congr_fun h.eq_id _
+
+instance instComp_id {N P : Type*} [Monoid N] [Monoid P]
+    {φ : N →* N} [IsId φ] {ψ : N →* P} :
+    CompTriple φ ψ ψ where
+  comp_eq := by simp only [IsId.eq_id, MonoidHom.comp_id]
+
+instance instId_comp {M N : Type*} [Monoid M] [Monoid N]
+    {φ : M →* N} {ψ : N →* N} [IsId ψ] :
+    CompTriple φ ψ φ where
+  comp_eq := by simp only [IsId.eq_id, MonoidHom.id_comp]
+
+lemma comp_inv {φ : M →* N} {ψ : N →* M} (h : Function.RightInverse φ ψ)
+    {χ : M →* M} [IsId χ] :
+    CompTriple φ ψ χ where
+  comp_eq := by
+    simp only [IsId.eq_id, ← DFunLike.coe_fn_eq, coe_comp, h.id]
+    rfl
+
+instance instRootCompTriple {φ : M →* N} {ψ : N  →* P} {χ : M →* P} [κ : CompTriple φ ψ χ] :
+    _root_.CompTriple φ ψ χ where
+  comp_eq := by rw [← MonoidHom.coe_comp, κ.comp_eq]
+
+instance (priority := 10) instComp {φ : M →* N} {ψ : N →* P} :
+    CompTriple φ ψ (ψ.comp φ) where
+  comp_eq := rfl
+
+lemma comp_apply
+    {φ : M →* N} {ψ : N →* P} {χ : M →* P} (h : CompTriple φ ψ χ) (x : M) :
+    ψ (φ x) = χ x := by
+  rw [← h.comp_eq, MonoidHom.comp_apply]
+
+@[simp]
+theorem comp_assoc {Q : Type*} [Monoid Q]
+    {φ₁ : M →* N} {φ₂ : N →* P} {φ₁₂ : M →* P}
+    (κ : CompTriple φ₁ φ₂ φ₁₂)
+    {φ₃ : P →* Q} {φ₂₃ : N →* Q} (κ' : CompTriple φ₂ φ₃ φ₂₃)
+    {φ₁₂₃ : M →* Q} :
+    CompTriple φ₁ φ₂₃ φ₁₂₃ ↔ CompTriple φ₁₂ φ₃ φ₁₂₃ := by
+  constructor <;>
+  · rintro ⟨h⟩
+    exact ⟨by simp only [← κ.comp_eq, ← h, ← κ'.comp_eq, MonoidHom.comp_assoc]⟩
+
+end MonoidHom.CompTriple

--- a/Mathlib/Algebra/Group/Hom/CompTypeclasses.lean
+++ b/Mathlib/Algebra/Group/Hom/CompTypeclasses.lean
@@ -61,11 +61,13 @@ instance instIsId {M : Type*} [Monoid M] : IsId (MonoidHom.id M) where
 instance {σ : M →* M} [h : _root_.CompTriple.IsId σ] : IsId σ  where
   eq_id := by ext; exact _root_.congr_fun h.eq_id _
 
+/-- Trivial CompTriple when the first map is id -/
 instance instComp_id {N P : Type*} [Monoid N] [Monoid P]
     {φ : N →* N} [IsId φ] {ψ : N →* P} :
     CompTriple φ ψ ψ where
   comp_eq := by simp only [IsId.eq_id, MonoidHom.comp_id]
 
+/-- Trivial CompTriple when the second map is id -/
 instance instId_comp {M N : Type*} [Monoid M] [Monoid N]
     {φ : M →* N} {ψ : N →* N} [IsId ψ] :
     CompTriple φ ψ φ where
@@ -82,12 +84,14 @@ instance instRootCompTriple {φ : M →* N} {ψ : N  →* P} {χ : M →* P} [κ
     _root_.CompTriple φ ψ χ where
   comp_eq := by rw [← MonoidHom.coe_comp, κ.comp_eq]
 
+/-- This instance has a low priority because it misses any possible simplification. -/
 instance (priority := 10) instComp {φ : M →* N} {ψ : N →* P} :
     CompTriple φ ψ (ψ.comp φ) where
   comp_eq := rfl
 
+@[simp]
 lemma comp_apply
-    {φ : M →* N} {ψ : N →* P} {χ : M →* P} (h : CompTriple φ ψ χ) (x : M) :
+    {φ : M →* N} {ψ : N →* P} {χ : M →* P} [h : CompTriple φ ψ χ] (x : M) :
     ψ (φ x) = χ x := by
   rw [← h.comp_eq, MonoidHom.comp_apply]
 
@@ -95,7 +99,7 @@ lemma comp_apply
 theorem comp_assoc {Q : Type*} [Monoid Q]
     {φ₁ : M →* N} {φ₂ : N →* P} {φ₁₂ : M →* P}
     (κ : CompTriple φ₁ φ₂ φ₁₂)
-    {φ₃ : P →* Q} {φ₂₃ : N →* Q} (κ' : CompTriple φ₂ φ₃ φ₂₃)
+    {φ₃ : P →* Q} {φ₂₃ : N →* Q} [κ' : CompTriple φ₂ φ₃ φ₂₃]
     {φ₁₂₃ : M →* Q} :
     CompTriple φ₁ φ₂₃ φ₁₂₃ ↔ CompTriple φ₁₂ φ₃ φ₁₂₃ := by
   constructor <;>

--- a/Mathlib/Logic/Function/CompTypeclasses.lean
+++ b/Mathlib/Logic/Function/CompTypeclasses.lean
@@ -39,14 +39,17 @@ class IsId {M : Type*} (σ : M → M) : Prop where
 instance {M : Type*} : IsId (@id M) where
   eq_id := rfl
 
+/-- Trivial CompTriple when the first map is id -/
 instance instComp_id {N P : Type*} {φ : N → N} [IsId φ] {ψ : N → P} :
     CompTriple φ ψ ψ where
   comp_eq := by simp only [IsId.eq_id, Function.comp_id]
 
+/-- Trivial CompTriple when the second map is id -/
 instance instId_comp {M N : Type*} {φ : M → N} {ψ : N → N} [IsId ψ] :
     CompTriple φ ψ φ where
   comp_eq := by simp only [IsId.eq_id, Function.id_comp]
 
+/-- This instance has a very low priority because it misses any possible simplification. -/
 instance (priority := 10) instComp {M N P : Type*}
     {φ : M → N} {ψ : N → P} :
     CompTriple φ ψ (ψ.comp φ) where
@@ -57,8 +60,9 @@ lemma comp_inv {M N : Type*} {φ : M → N} {ψ : N → M}
     CompTriple φ ψ χ where
   comp_eq := by simp only [IsId.eq_id, h.id]
 
+@[simp]
 lemma comp_apply {M N P : Type*}
-    {φ : M → N} {ψ : N → P} {χ : M → P} (h : CompTriple φ ψ χ) (x : M) :
+    {φ : M → N} {ψ : N → P} {χ : M → P} [h : CompTriple φ ψ χ] (x : M) :
     ψ (φ x) = χ x := by
   rw [← h.comp_eq, Function.comp_apply]
 

--- a/Mathlib/Logic/Function/CompTypeclasses.lean
+++ b/Mathlib/Logic/Function/CompTypeclasses.lean
@@ -49,7 +49,7 @@ instance instId_comp {M N : Type*} {φ : M → N} {ψ : N → N} [IsId ψ] :
 
 instance (priority := 10) instComp {M N P : Type*}
     {φ : M → N} {ψ : N → P} :
-    CompTriple φ ψ  (ψ.comp φ) where
+    CompTriple φ ψ (ψ.comp φ) where
   comp_eq := rfl
 
 lemma comp_inv {M N : Type*} {φ : M → N} {ψ : N → M}

--- a/Mathlib/Logic/Function/CompTypeclasses.lean
+++ b/Mathlib/Logic/Function/CompTypeclasses.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2024 Antoine Chambert-Loir. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir
+-/
+
+import Mathlib.Init.Function
+
+/-!
+# Propositional typeclasses on several maps
+
+This file contains typeclasses that are used in the definition of
+equivariant maps in the spirit what was initially developed
+by Frédéric Dupuis and Heather Macbeth for linear maps.
+
+* `CompTriple φ ψ χ`, which expresses that `ψ.comp φ = χ`
+* `CompTriple.IsId φ`, which expresses that `φ = id`
+
+TODO :
+* align with RingHomCompTriple
+
+-/
+
+section CompTriple
+
+/-- Class of composing triples -/
+class CompTriple  {M N P : Type*} (φ : M → N) (ψ : N → P) (χ : outParam (M → P)) : Prop where
+  /-- The maps form a commuting triangle -/
+  comp_eq : ψ.comp φ = χ
+
+attribute [simp] CompTriple.comp_eq
+
+namespace CompTriple
+
+/-- Class of Id maps -/
+class IsId {M : Type*} (σ : M → M) : Prop where
+  eq_id : σ = id
+
+instance {M : Type*} : IsId (@id M) where
+  eq_id := rfl
+
+instance instComp_id {N P : Type*} {φ : N → N} [IsId φ] {ψ : N → P} :
+    CompTriple φ ψ ψ where
+  comp_eq := by simp only [IsId.eq_id, Function.comp_id]
+
+instance instId_comp {M N : Type*} {φ : M → N} {ψ : N → N} [IsId ψ] :
+    CompTriple φ ψ φ where
+  comp_eq := by simp only [IsId.eq_id, Function.id_comp]
+
+instance (priority := 10) instComp {M N P : Type*}
+    {φ : M → N} {ψ : N → P} :
+    CompTriple φ ψ  (ψ.comp φ) where
+  comp_eq := rfl
+
+lemma comp_inv {M N : Type*} {φ : M → N} {ψ : N → M}
+    (h : Function.RightInverse φ ψ) {χ : M → M} [IsId χ] :
+    CompTriple φ ψ χ where
+  comp_eq := by simp only [IsId.eq_id, h.id]
+
+lemma comp_apply {M N P : Type*}
+    {φ : M → N} {ψ : N → P} {χ : M → P} (h : CompTriple φ ψ χ) (x : M) :
+    ψ (φ x) = χ x := by
+  rw [← h.comp_eq, Function.comp_apply]
+
+end CompTriple


### PR DESCRIPTION
This PR provides type classes that tell that triples of maps compose.
They are inspired from the file RingHomComptypeclasses that is used for semilinear maps,
and will be used in #6057  to provide equivariant maps for mul actions, distrib mul actions, and refactor semilinear maps.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
