### PR TITLE
[Merged by Bors] - chore(Data/Matrix): add explicit `of` typecasts

### DIFF
--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -146,9 +146,7 @@ theorem head_val' (B : Fin m.succ → n' → α) (j : n') : (vecHead fun i => B 
 
 @[simp, nolint simpNF] -- Porting note: LHS does not simplify.
 theorem tail_val' (B : Fin m.succ → n' → α) (j : n') :
-    (vecTail fun i => B i j) = fun i => vecTail B i j := by
-  ext
-  simp [vecTail]
+    (vecTail fun i => B i j) = fun i => vecTail B i j := rfl
 #align matrix.tail_val' Matrix.tail_val'
 
 section DotProduct
@@ -187,21 +185,18 @@ theorem col_empty (v : Fin 0 → α) : col v = vecEmpty :=
 #align matrix.col_empty Matrix.col_empty
 
 @[simp]
-theorem col_cons (x : α) (u : Fin m → α) : col (vecCons x u) = vecCons (fun _ => x) (col u) := by
+theorem col_cons (x : α) (u : Fin m → α) :
+    col (vecCons x u) = of (vecCons (fun _ => x) (col u)) := by
   ext i j
   refine' Fin.cases _ _ i <;> simp [vecHead, vecTail]
 #align matrix.col_cons Matrix.col_cons
 
 @[simp]
-theorem row_empty : row (vecEmpty : Fin 0 → α) = fun _ => vecEmpty := by
-  ext
-  rfl
+theorem row_empty : row (vecEmpty : Fin 0 → α) = of fun _ => vecEmpty := rfl
 #align matrix.row_empty Matrix.row_empty
 
 @[simp]
-theorem row_cons (x : α) (u : Fin m → α) : row (vecCons x u) = fun _ => vecCons x u := by
-  ext
-  rfl
+theorem row_cons (x : α) (u : Fin m → α) : row (vecCons x u) = of fun _ => vecCons x u := rfl
 #align matrix.row_cons Matrix.row_cons
 
 end ColRow
@@ -350,7 +345,7 @@ theorem empty_vecMulVec (v : Fin 0 → α) (w : n' → α) : vecMulVec v w = ![]
 #align matrix.empty_vec_mul_vec Matrix.empty_vecMulVec
 
 @[simp]
-theorem vecMulVec_empty (v : m' → α) (w : Fin 0 → α) : vecMulVec v w = fun _ => ![] :=
+theorem vecMulVec_empty (v : m' → α) (w : Fin 0 → α) : vecMulVec v w = of fun _ => ![] :=
   funext fun _ => empty_eq _
 #align matrix.vec_mul_vec_empty Matrix.vecMulVec_empty
 
@@ -363,9 +358,7 @@ theorem cons_vecMulVec (x : α) (v : Fin m → α) (w : n' → α) :
 
 @[simp]
 theorem vecMulVec_cons (v : m' → α) (x : α) (w : Fin n → α) :
-    vecMulVec v (vecCons x w) = fun i => v i • vecCons x w := by
-  ext i j
-  rw [vecMulVec_apply, Pi.smul_apply, smul_eq_mul]
+    vecMulVec v (vecCons x w) = of fun i => v i • vecCons x w := rfl
 #align matrix.vec_mul_vec_cons Matrix.vecMulVec_cons
 
 end VecMulVec

--- a/Mathlib/Data/Matrix/PEquiv.lean
+++ b/Mathlib/Data/Matrix/PEquiv.lean
@@ -94,9 +94,9 @@ theorem matrix_mul_apply [Fintype m] [Semiring α] [DecidableEq n] (M : Matrix l
 #align pequiv.matrix_mul_apply PEquiv.matrix_mul_apply
 
 theorem toPEquiv_mul_matrix [Fintype m] [DecidableEq m] [Semiring α] (f : m ≃ m)
-    (M : Matrix m n α) : f.toPEquiv.toMatrix * M = fun i => M (f i) := by
+    (M : Matrix m n α) : f.toPEquiv.toMatrix * M = M.submatrix f id := by
   ext i j
-  rw [mul_matrix_apply, Equiv.toPEquiv_apply]
+  rw [mul_matrix_apply, Equiv.toPEquiv_apply, submatrix_apply, id.def]
 #align pequiv.to_pequiv_mul_matrix PEquiv.toPEquiv_mul_matrix
 
 theorem mul_toPEquiv_toMatrix {m n α : Type*} [Fintype n] [DecidableEq n] [Semiring α] (f : n ≃ n)

--- a/Mathlib/LinearAlgebra/Matrix/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant.lean
@@ -238,9 +238,14 @@ theorem det_transpose (M : Matrix n n R) : Mᵀ.det = M.det := by
 
 /-- Permuting the columns changes the sign of the determinant. -/
 theorem det_permute (σ : Perm n) (M : Matrix n n R) :
-    (Matrix.det fun i => M (σ i)) = Perm.sign σ * M.det :=
+    (M.submatrix σ id).det = Perm.sign σ * M.det :=
   ((detRowAlternating : (n → R) [⋀^n]→ₗ[R] R).map_perm M σ).trans (by simp [Units.smul_def])
 #align matrix.det_permute Matrix.det_permute
+
+/-- Permuting the rows changes the sign of the determinant. -/
+theorem det_permute' (σ : Perm n) (M : Matrix n n R) :
+    (M.submatrix id σ).det = Perm.sign σ * M.det := by
+  rw [← det_transpose, transpose_submatrix, det_permute, det_transpose]
 
 /-- Permuting rows and columns with the same equivalence has no effect. -/
 @[simp]
@@ -756,11 +761,12 @@ theorem det_succ_row {n : ℕ} (A : Matrix (Fin n.succ) (Fin n.succ) R) (i : Fin
   congr
   rw [← det_permute, det_succ_row_zero]
   refine' Finset.sum_congr rfl fun j _ => _
-  rw [mul_assoc, Matrix.submatrix, Matrix.submatrix]
+  rw [mul_assoc, Matrix.submatrix_apply, submatrix_submatrix, id_comp, Function.comp_def, id.def]
   congr
   · rw [Equiv.Perm.inv_def, Fin.cycleRange_symm_zero]
   · ext i' j'
-    rw [Equiv.Perm.inv_def, Fin.cycleRange_symm_succ]
+    rw [Equiv.Perm.inv_def, Matrix.submatrix_apply, Matrix.submatrix_apply,
+      Fin.cycleRange_symm_succ]
 #align matrix.det_succ_row Matrix.det_succ_row
 
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along column `j`. -/


### PR DESCRIPTION
This adds some missing `Matrix.of` typecasts, and uses `Matrix.submatrix` in places where this is more reasonable than adding `of`.

`Matrix.det_permute'` is a new lemma that fills the obvious gap that these `submatrix` restatements emphasize.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
