### PR TITLE
refactor(Finset): redefine Finset.diag, review API

### DIFF
--- a/Archive/Imo/Imo1998Q2.lean
+++ b/Archive/Imo/Imo1998Q2.lean
@@ -160,7 +160,7 @@ theorem A_card_upper_bound {k : ℕ}
     (hk : ∀ p : JudgePair J, p.Distinct → (agreedContestants r p).card ≤ k) :
     (A r).card ≤ k * (Fintype.card J * Fintype.card J - Fintype.card J) := by
   change _ ≤ k * (Finset.card _ * Finset.card _ - Finset.card _)
-  rw [← Finset.offDiag_card]
+  rw [← Finset.card_offDiag]
   apply Finset.card_le_mul_card_image_of_maps_to (A_maps_to_offDiag_judgePair r)
   intro p hp
   have hp' : p.Distinct := by simp [Finset.mem_offDiag] at hp; exact hp
@@ -211,7 +211,7 @@ theorem distinct_judge_pairs_card_lower_bound {z : ℕ} (hJ : Fintype.card J = 2
     · unfold_let s t
       suffices p.judge₁ = p.judge₂ by simp [this]
       aesop
-  have hst' : (s \ t).card = 2 * z + 1 := by rw [hst, Finset.diag_card, ← hJ]; rfl
+  have hst' : (s \ t).card = 2 * z + 1 := by rw [hst, Finset.card_diag, ← hJ]; rfl
   rw [Finset.filter_and, ← Finset.sdiff_sdiff_self_left s t, Finset.card_sdiff]
   · rw [hst']; rw [add_assoc] at hs; apply le_tsub_of_add_le_right hs
   · apply Finset.sdiff_subset

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1645,6 +1645,7 @@ import Mathlib.Data.Finset.Antidiagonal
 import Mathlib.Data.Finset.Attr
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Diag
 import Mathlib.Data.Finset.Fin
 import Mathlib.Data.Finset.Finsupp
 import Mathlib.Data.Finset.Fold

--- a/Mathlib/Algebra/BigOperators/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Basic.lean
@@ -770,9 +770,9 @@ lemma prod_univ_pi [DecidableEq ι] [Fintype ι] {κ : ι → Type*} (t : ∀ i,
 #align finset.sum_univ_pi Finset.sum_univ_pi
 
 @[to_additive (attr := simp)]
-lemma prod_diag [DecidableEq α] (s : Finset α) (f : α × α → β) :
-    ∏ i in s.diag, f i = ∏ i in s, f (i, i) := by
-  apply prod_nbij' Prod.fst (fun i ↦ (i, i)) <;> simp
+lemma prod_diag (s : Finset α) (f : α × α → β) :
+    ∏ i in s.diag, f i = ∏ i in s, f (i, i) :=
+  prod_map ..
 
 @[to_additive]
 theorem prod_finset_product (r : Finset (γ × α)) (s : Finset γ) (t : γ → Finset α)

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
@@ -53,7 +53,7 @@ theorem energy_le_one : P.energy G ≤ 1 :=
           (sq_le_one_iff <| G.edgeDensity_nonneg _ _).2 <| G.edgeDensity_le_one _ _
       _ = P.parts.offDiag.card := (Nat.smul_one_eq_coe _)
       _ ≤ _ := by
-        rw [offDiag_card, one_mul]
+        rw [card_offDiag, one_mul]
         norm_cast
         rw [sq]
         exact tsub_le_self

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
@@ -156,7 +156,7 @@ theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ P.parts.card)
         rw [← sum_biUnion pairwiseDisjoint_distinctPairs]
         exact sum_le_sum_of_subset_of_nonneg distinctPairs_increment fun i _ _ ↦ sq_nonneg _
   gcongr
-  rw [Finpartition.IsUniform, not_le, mul_tsub, mul_one, ← offDiag_card] at hPG
+  rw [Finpartition.IsUniform, not_le, mul_tsub, mul_one, ← card_offDiag] at hPG
   calc
     _ ≤ ∑ x in P.parts.offDiag, (edgeDensity G x.1 x.2 : ℝ) ^ 2 +
         ((nonUniforms P G ε).card * (ε ^ 4 / 3) - P.parts.offDiag.card * (ε ^ 5 / 25)) :=
@@ -172,7 +172,7 @@ theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ P.parts.card)
     _ = (6/7 * P.parts.card ^ 2) * ε ^ 5 * (7 / 24) := by ring
     _ ≤ P.parts.offDiag.card * ε ^ 5 * (22 / 75) := by
         gcongr ?_ * _ * ?_
-        · rw [← mul_div_right_comm, div_le_iff (by norm_num), offDiag_card]
+        · rw [← mul_div_right_comm, div_le_iff (by norm_num), card_offDiag]
           norm_cast
           rw [tsub_mul]
           refine le_tsub_of_add_le_left ?_

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
@@ -240,7 +240,7 @@ theorem isUniformOne : P.IsUniform G (1 : 𝕜) := by
   rw [IsUniform, mul_one, Nat.cast_le]
   refine' (card_filter_le _
     (fun uv => ¬SimpleGraph.IsUniform G 1 (Prod.fst uv) (Prod.snd uv))).trans _
-  rw [offDiag_card, Nat.mul_sub_left_distrib, mul_one]
+  rw [card_offDiag, Nat.mul_sub_left_distrib, mul_one]
 #align finpartition.is_uniform_one Finpartition.isUniformOne
 
 variable {P G}

--- a/Mathlib/Data/Finset/Diag.lean
+++ b/Mathlib/Data/Finset/Diag.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2020 Oliver Nash. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oliver Nash, Yury Kudryashov
+-/
+import Mathlib.Data.Finset.Image
+import Mathlib.Data.Finset.Card
+
+#align_import data.finset.prod from "leanprover-community/mathlib"@"9003f28797c0664a49e4179487267c494477d853"
+
+/-!
+# Diagonal finset
+
+In this file we define `Finset.diag s`
+to be the `Finset (α × α)` of pairs `(a, a)` with `a ∈ s`.
+-/
+
+namespace Finset
+
+section
+
+variable {α : Type*} {s t : Finset α}
+
+/-- Given a finite set `s`, the diagonal,
+`Finset.diag s` is the set of pairs of the form `(a, a)` for `a ∈ s`. -/
+def diag (s : Finset α) : Finset (α × α) :=
+  s.map ⟨fun x ↦ (x, x), fun _ _ h ↦ congr_arg Prod.fst h⟩
+#align finset.diag Finset.diag
+
+theorem diag_eq_map (s : Finset α) :
+    diag s = map ⟨fun x ↦ (x, x), fun _ _ h ↦ congr_arg Prod.fst h⟩ s :=
+  rfl
+
+theorem coe_diag (s : Finset α) : ↑(diag s) = Set.diagonal α ∩ (↑s ×ˢ ↑s) := by
+  simp_rw [diag_eq_map, coe_map, Function.Embedding.coeFn_mk, Set.diag_image]
+
+@[simp]
+theorem mem_diag {x : α × α} : x ∈ diag s ↔ x.1 ∈ s ∧ x.1 = x.2 := by
+  cases x; simp (config := {contextual := true}) [diag_eq_map, eq_comm]
+#align finset.mem_diag Finset.mem_diag
+
+@[simp]
+theorem card_diag : (diag s).card = s.card := by simp [diag_eq_map]
+#align finset.diag_card Finset.card_diag
+
+@[deprecated] alias diag_card := card_diag -- 2024-03-23
+
+@[simp] theorem diag_subset_diag : diag s ⊆ diag t ↔ s ⊆ t := map_subset_map
+@[simp] theorem diag_ssubset_diag : diag s ⊂ diag t ↔ s ⊂ t := map_ssubset_map
+
+theorem diag_mono : Monotone (diag : Finset α → Finset (α × α)) := fun _ _ ↦ diag_subset_diag.2
+#align finset.diag_mono Finset.diag_mono
+
+theorem diag_strictMono : StrictMono (diag : Finset α → Finset (α × α)) := fun _ _ ↦
+  diag_ssubset_diag.2
+
+@[simp] theorem diag_eq_empty : diag s = ∅ ↔ s = ∅ := map_eq_empty
+@[simp] theorem diag_nonempty : (diag s).Nonempty ↔ s.Nonempty := map_nonempty
+@[simp] theorem diag_nontrivial : (diag s).Nontrivial ↔ s.Nontrivial := map_nontrivial
+@[simp] theorem disjoint_diag_diag : Disjoint (diag s) (diag t) ↔ Disjoint s t := disjoint_map _
+
+@[simp] theorem diag_empty : diag (∅ : Finset α) = ∅ := map_empty _
+#align finset.diag_empty Finset.diag_empty
+
+@[simp] theorem diag_singleton (a : α) : diag {a} = {(a, a)} := map_singleton _ _
+#align finset.diag_singleton Finset.diag_singleton
+
+@[simp]
+theorem diag_cons {a : α} (h : a ∉ s) : diag (cons a s h) = cons (a, a) (diag s) (by simpa) :=
+  map_cons ..
+
+@[simp]
+theorem diag_disjUnion (h : Disjoint s t) :
+    diag (disjUnion s t h) = disjUnion (diag s) (diag t) (disjoint_diag_diag.2 h) :=
+  map_disjUnion ..
+
+end
+
+variable {α : Type*} [DecidableEq α] {s t : Finset α}
+
+@[simp] theorem diag_union (s t : Finset α) : diag (s ∪ t) = diag s ∪ diag t := map_union ..
+#align finset.diag_union Finset.diag_union
+
+@[simp] theorem diag_inter (s t : Finset α) : diag (s ∩ t) = diag s ∩ diag t := map_inter ..
+#align finset.diag_inter Finset.diag_inter
+
+@[simp]
+theorem diag_insert (a : α) (s : Finset α) : diag (insert a s) = insert (a, a) (diag s) :=
+  map_insert ..
+#align finset.diag_insert Finset.diag_insert
+
+end Finset

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -162,6 +162,8 @@ theorem map_subset_map {s₁ s₂ : Finset α} : s₁.map f ⊆ s₂.map f ↔ s
    fun h => by simp [subset_def, Multiset.map_subset_map h]⟩
 #align finset.map_subset_map Finset.map_subset_map
 
+@[gcongr] alias ⟨_, _root_.GCongr.finsetMap_subset⟩ := map_subset_map
+
 /-- The `Finset` version of `Equiv.subset_symm_image`. -/
 theorem subset_map_symm {t : Finset β} {f : α ≃ β} : s ⊆ t.map f.symm ↔ s.map f ⊆ t := by
   constructor <;> intro h x hx
@@ -188,6 +190,11 @@ theorem map_inj {s₁ s₂ : Finset α} : s₁.map f = s₂.map f ↔ s₁ = s�
 theorem map_injective (f : α ↪ β) : Injective (map f) :=
   (mapEmbedding f).injective
 #align finset.map_injective Finset.map_injective
+
+@[simp]
+theorem map_ssubset_map {s t : Finset α} : s.map f ⊂ t.map f ↔ s ⊂ t := (mapEmbedding f).lt_iff_lt
+
+@[gcongr] alias ⟨_, _root_.GCongr.finsetMap_ssubset⟩ := map_ssubset_map
 
 @[simp]
 theorem mapEmbedding_apply : mapEmbedding f s = map f s :=
@@ -225,11 +232,8 @@ theorem map_filter {f : α ≃ β} {p : α → Prop} [DecidablePred p] :
 
 @[simp]
 theorem disjoint_map {s t : Finset α} (f : α ↪ β) :
-    Disjoint (s.map f) (t.map f) ↔ Disjoint s t := by
-  simp only [disjoint_iff_ne, mem_map, exists_prop, exists_imp, and_imp]
-  refine' ⟨fun h a ha b hb hab => h _ _ ha rfl _ _ hb rfl <| congr_arg _ hab, _⟩
-  rintro h _ a ha rfl _ b hb rfl
-  exact f.injective.ne (h _ ha _ hb)
+    Disjoint (s.map f) (t.map f) ↔ Disjoint s t :=
+  mod_cast Set.disjoint_image_iff f.injective (s := s) (t := t)
 #align finset.disjoint_map Finset.disjoint_map
 
 theorem map_disjUnion {f : α ↪ β} (s₁ s₂ : Finset α) (h) (h' := (disjoint_map _).mpr h) :
@@ -245,12 +249,12 @@ theorem map_disjUnion' {f : α ↪ β} (s₁ s₂ : Finset α) (h') (h := (disjo
 
 theorem map_union [DecidableEq α] [DecidableEq β] {f : α ↪ β} (s₁ s₂ : Finset α) :
     (s₁ ∪ s₂).map f = s₁.map f ∪ s₂.map f :=
-  coe_injective <| by simp only [coe_map, coe_union, Set.image_union]
+  mod_cast Set.image_union f s₁ s₂
 #align finset.map_union Finset.map_union
 
 theorem map_inter [DecidableEq α] [DecidableEq β] {f : α ↪ β} (s₁ s₂ : Finset α) :
     (s₁ ∩ s₂).map f = s₁.map f ∩ s₂.map f :=
-  coe_injective <| by simp only [coe_map, coe_inter, Set.image_inter f.injective]
+  mod_cast Set.image_inter f.injective (s := s₁) (t := s₂)
 #align finset.map_inter Finset.map_inter
 
 @[simp]
@@ -271,41 +275,36 @@ theorem map_cons (f : α ↪ β) (a : α) (s : Finset α) (ha : a ∉ s) :
 #align finset.map_cons Finset.map_cons
 
 @[simp]
-theorem map_eq_empty : s.map f = ∅ ↔ s = ∅ :=
-  ⟨fun h => eq_empty_of_forall_not_mem fun _ m => ne_empty_of_mem (mem_map_of_mem _ m) h, fun e =>
-    e.symm ▸ rfl⟩
+theorem map_eq_empty : s.map f = ∅ ↔ s = ∅ := (map_injective f).eq_iff' (map_empty f)
 #align finset.map_eq_empty Finset.map_eq_empty
 
 @[simp, aesop safe apply (rule_sets := [finsetNonempty])]
-theorem map_nonempty : (s.map f).Nonempty ↔ s.Nonempty := by
-  rw [nonempty_iff_ne_empty, nonempty_iff_ne_empty, Ne.def, map_eq_empty]
+theorem map_nonempty : (s.map f).Nonempty ↔ s.Nonempty :=
+  mod_cast Set.image_nonempty (f := f) (s := s)
 #align finset.map_nonempty Finset.map_nonempty
 
-alias ⟨_, Nonempty.map⟩ := map_nonempty
+protected alias ⟨_, Nonempty.map⟩ := map_nonempty
 #align finset.nonempty.map Finset.Nonempty.map
+
+@[simp]
+theorem map_nontrivial : (s.map f).Nontrivial ↔ s.Nontrivial :=
+  mod_cast Set.nontrivial_image f.injective (s := s)
 
 theorem attach_map_val {s : Finset α} : s.attach.map (Embedding.subtype _) = s :=
   eq_of_veq <| by rw [map_val, attach_val]; exact Multiset.attach_map_val _
 #align finset.attach_map_val Finset.attach_map_val
 
-theorem disjoint_range_addLeftEmbedding (a b : ℕ) :
-    Disjoint (range a) (map (addLeftEmbedding a) (range b)) := by
-  refine' disjoint_iff_inf_le.mpr _
-  intro k hk
-  simp only [exists_prop, mem_range, inf_eq_inter, mem_map, addLeftEmbedding, mem_inter]
-    at hk
-  obtain ⟨a, _, ha⟩ := hk.2
-  simpa [← ha] using hk.1
+theorem disjoint_range_addLeftEmbedding (a : ℕ) (s : Finset ℕ):
+    Disjoint (range a) (map (addLeftEmbedding a) s) := by
+  simp_rw [disjoint_left, mem_map, mem_range]
+  rintro _ h ⟨l, -, rfl⟩
+  simp at h
 #align finset.disjoint_range_add_left_embedding Finset.disjoint_range_addLeftEmbedding
 
-theorem disjoint_range_addRightEmbedding (a b : ℕ) :
-    Disjoint (range a) (map (addRightEmbedding a) (range b)) := by
-  refine' disjoint_iff_inf_le.mpr _
-  intro k hk
-  simp only [exists_prop, mem_range, inf_eq_inter, mem_map, addRightEmbedding, mem_inter]
-    at hk
-  obtain ⟨a, _, ha⟩ := hk.2
-  simpa [← ha] using hk.1
+theorem disjoint_range_addRightEmbedding (a : ℕ) (s : Finset ℕ) :
+    Disjoint (range a) (map (addRightEmbedding a) s) := by
+  rw [← addLeftEmbedding_eq_addRightEmbedding]
+  apply disjoint_range_addLeftEmbedding
 #align finset.disjoint_range_add_right_embedding Finset.disjoint_range_addRightEmbedding
 
 theorem map_disjiUnion {f : α ↪ β} {s : Finset α} {t : β → Finset γ} {h} :
@@ -317,12 +316,7 @@ theorem map_disjiUnion {f : α ↪ β} {s : Finset α} {t : β → Finset γ} {h
 
 theorem disjiUnion_map {s : Finset α} {t : α → Finset β} {f : β ↪ γ} {h} :
     (s.disjiUnion t h).map f =
-      s.disjiUnion (fun a => (t a).map f) fun a ha b hb hab =>
-        disjoint_left.mpr fun x hxa hxb => by
-          obtain ⟨xa, hfa, rfl⟩ := mem_map.mp hxa
-          obtain ⟨xb, hfb, hfab⟩ := mem_map.mp hxb
-          obtain rfl := f.injective hfab
-          exact disjoint_left.mp (h ha hb hab) hfa hfb :=
+      s.disjiUnion (fun a => (t a).map f) (h.mono' fun _ _ ↦ (disjoint_map _).2) :=
   eq_of_veq <| Multiset.map_bind _ _ _
 #align finset.disj_Union_map Finset.disjiUnion_map
 
@@ -425,8 +419,8 @@ theorem coe_image : ↑(s.image f) = f '' ↑s :=
 #align finset.coe_image Finset.coe_image
 
 @[simp, aesop safe apply (rule_sets := [finsetNonempty])]
-lemma image_nonempty : (s.image f).Nonempty ↔ s.Nonempty := by
-  exact_mod_cast Set.image_nonempty (f := f) (s := (s : Set α))
+lemma image_nonempty : (s.image f).Nonempty ↔ s.Nonempty :=
+  mod_cast Set.image_nonempty (f := f) (s := (s : Set α))
 #align finset.nonempty.image_iff Finset.image_nonempty
 
 protected theorem Nonempty.image (h : s.Nonempty) (f : α → β) : (s.image f).Nonempty :=
@@ -497,10 +491,8 @@ lemma image_inj {t : Finset α} (hf : Injective f) : s.image f = t.image f ↔ s
   (image_injective hf).eq_iff
 
 theorem image_subset_image_iff {t : Finset α} (hf : Injective f) :
-    s.image f ⊆ t.image f ↔ s ⊆ t := by
-  simp_rw [← coe_subset]
-  push_cast
-  exact Set.image_subset_image_iff hf
+    s.image f ⊆ t.image f ↔ s ⊆ t :=
+  mod_cast Set.image_subset_image_iff hf (s := s) (t := t)
 #align finset.image_subset_image_iff Finset.image_subset_image_iff
 
 lemma image_ssubset_image {t : Finset α} (hf : Injective f) : s.image f ⊂ t.image f ↔ s ⊂ t := by
@@ -524,13 +516,12 @@ theorem filter_image {p : β → Prop} [DecidablePred p] :
 
 theorem image_union [DecidableEq α] {f : α → β} (s₁ s₂ : Finset α) :
     (s₁ ∪ s₂).image f = s₁.image f ∪ s₂.image f :=
-  ext fun _ => by simp only [mem_image, mem_union, exists_prop, or_and_right, exists_or]
+  mod_cast Set.image_union f s₁ s₂
 #align finset.image_union Finset.image_union
 
 theorem image_inter_subset [DecidableEq α] (f : α → β) (s t : Finset α) :
     (s ∩ t).image f ⊆ s.image f ∩ t.image f :=
-  subset_inter (image_subset_image <| inter_subset_left _ _) <|
-    image_subset_image <| inter_subset_right _ _
+  (image_mono f).map_inf_le s t
 #align finset.image_inter_subset Finset.image_inter_subset
 
 theorem image_inter_of_injOn [DecidableEq α] {f : α → β} (s t : Finset α)
@@ -565,32 +556,23 @@ theorem erase_image_subset_image_erase [DecidableEq α] (f : α → β) (s : Fin
 
 @[simp]
 theorem image_erase [DecidableEq α] {f : α → β} (hf : Injective f) (s : Finset α) (a : α) :
-    (s.erase a).image f = (s.image f).erase (f a) := by
-  refine' (erase_image_subset_image_erase _ _ _).antisymm' fun b => _
-  simp only [mem_image, exists_prop, mem_erase]
-  rintro ⟨a', ⟨haa', ha'⟩, rfl⟩
-  exact ⟨hf.ne haa', a', ha', rfl⟩
+    (s.erase a).image f = (s.image f).erase (f a) :=
+  coe_injective <| by push_cast [Set.image_diff hf, Set.image_singleton]; rfl
 #align finset.image_erase Finset.image_erase
 
 @[simp]
-theorem image_eq_empty : s.image f = ∅ ↔ s = ∅ :=
-  ⟨fun h => eq_empty_of_forall_not_mem fun _ m => ne_empty_of_mem (mem_image_of_mem _ m) h,
-   fun e => e.symm ▸ rfl⟩
+theorem image_eq_empty : s.image f = ∅ ↔ s = ∅ := mod_cast Set.image_eq_empty (f := f) (s := s)
 #align finset.image_eq_empty Finset.image_eq_empty
 
 theorem image_sdiff [DecidableEq α] {f : α → β} (s t : Finset α) (hf : Injective f) :
     (s \ t).image f = s.image f \ t.image f :=
-  coe_injective <| by
-    push_cast
-    exact Set.image_diff hf _ _
+  mod_cast Set.image_diff hf s t
 #align finset.image_sdiff Finset.image_sdiff
 
 open scoped symmDiff in
 theorem image_symmDiff [DecidableEq α] {f : α → β} (s t : Finset α) (hf : Injective f) :
     (s ∆ t).image f = s.image f ∆ t.image f :=
-  coe_injective <| by
-    push_cast
-    exact Set.image_symmDiff hf _ _
+  mod_cast Set.image_symmDiff hf s t
 #align finset.image_symm_diff Finset.image_symmDiff
 
 @[simp]
@@ -652,15 +634,12 @@ theorem attach_insert [DecidableEq α] {a : α} {s : Finset α} :
 
 @[simp]
 theorem disjoint_image {s t : Finset α} {f : α → β} (hf : Injective f) :
-    Disjoint (s.image f) (t.image f) ↔ Disjoint s t := by
-  convert disjoint_map ⟨_, hf⟩ using 1
-  simp [map_eq_image]
+    Disjoint (s.image f) (t.image f) ↔ Disjoint s t :=
+  mod_cast Set.disjoint_image_iff hf (s := s) (t := t)
 #align finset.disjoint_image Finset.disjoint_image
 
 theorem image_const {s : Finset α} (h : s.Nonempty) (b : β) : (s.image fun _ => b) = singleton b :=
-  ext fun b' => by
-    simp only [mem_image, exists_prop, exists_and_right, h.bex, true_and_iff, mem_singleton,
-      eq_comm]
+  mod_cast Set.Nonempty.image_const (coe_nonempty.2 h) b
 #align finset.image_const Finset.image_const
 
 @[simp]

--- a/Mathlib/Data/Finset/Prod.lean
+++ b/Mathlib/Data/Finset/Prod.lean
@@ -312,7 +312,6 @@ theorem coe_offDiag : (s.offDiag : Set (α × α)) = (s : Set α).offDiag :=
 @[simp] theorem disjoint_diag_offDiag : Disjoint s.diag s.offDiag := by simp [disjoint_left]
 #align finset.disjoint_diag_off_diag Finset.disjoint_diag_offDiag
 
-@[simp]
 theorem diag_disjUnion_offDiag : s.diag.disjUnion s.offDiag s.disjoint_diag_offDiag = s ×ˢ s := by
   ext ⟨x, y⟩
   rcases eq_or_ne x y with rfl | hxy <;> simp [*]

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -1237,6 +1237,10 @@ theorem nontrivial_of_image (f : α → β) (s : Set α) (hs : (f '' s).Nontrivi
   ⟨x, hx, y, hy, mt (congr_arg f) hxy⟩
 #align set.nontrivial_of_image Set.nontrivial_of_image
 
+@[simp]
+theorem nontrivial_image {f : α → β} (hf : f.Injective) : (f '' s).Nontrivial ↔ s.Nontrivial :=
+  ⟨nontrivial_of_image f s, fun h ↦ h.image hf⟩
+
 /-- If the preimage of a set under an injective map is nontrivial, the set is nontrivial. -/
 theorem nontrivial_of_preimage {f : α → β} (hf : Function.Injective f) (s : Set β)
     (hs : (f ⁻¹' s).Nontrivial) : s.Nontrivial :=

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -471,10 +471,13 @@ instance decidableMemDiagonal [h : DecidableEq α] (x : α × α) : Decidable (x
   h x.1 x.2
 #align set.decidable_mem_diagonal Set.decidableMemDiagonal
 
+theorem preimage_prodMap_diagonal {β : Type*} {f : α → β} (hf : Injective f) :
+    Prod.map f f ⁻¹' diagonal β = diagonal α := by
+  ext; apply hf.eq_iff
+
 theorem preimage_coe_coe_diagonal (s : Set α) :
-    Prod.map (fun x : s => (x : α)) (fun x : s => (x : α)) ⁻¹' diagonal α = diagonal s := by
-  ext ⟨⟨x, hx⟩, ⟨y, hy⟩⟩
-  simp [Set.diagonal]
+    Prod.map (fun x : s => (x : α)) (fun x : s => (x : α)) ⁻¹' diagonal α = diagonal s :=
+  preimage_prodMap_diagonal Subtype.coe_injective
 #align set.preimage_coe_coe_diagonal Set.preimage_coe_coe_diagonal
 
 @[simp]
@@ -502,13 +505,7 @@ theorem diag_preimage_prod_self (s : Set α) : (fun x => (x, x)) ⁻¹' s ×ˢ s
 #align set.diag_preimage_prod_self Set.diag_preimage_prod_self
 
 theorem diag_image (s : Set α) : (fun x => (x, x)) '' s = diagonal α ∩ s ×ˢ s := by
-  ext x
-  constructor
-  · rintro ⟨x, hx, rfl⟩
-    exact ⟨rfl, hx, hx⟩
-  · obtain ⟨x, y⟩ := x
-    rintro ⟨rfl : x = y, h2x⟩
-    exact mem_image_of_mem _ h2x.1
+  rw [← range_diag, ← image_preimage_eq_range_inter, diag_preimage_prod_self]
 #align set.diag_image Set.diag_image
 
 theorem diagonal_eq_univ_iff : diagonal α = univ ↔ Subsingleton α := by

--- a/Mathlib/Data/Sym/Card.lean
+++ b/Mathlib/Data/Sym/Card.lean
@@ -130,7 +130,7 @@ variable [DecidableEq α]
 
 /-- The `diag` of `s : Finset α` is sent on a finset of `Sym2 α` of card `s.card`. -/
 theorem card_image_diag (s : Finset α) : (s.diag.image Sym2.mk).card = s.card := by
-  rw [card_image_of_injOn, diag_card]
+  rw [card_image_of_injOn, card_diag]
   rintro ⟨x₀, x₁⟩ hx _ _ h
   cases Sym2.eq.1 h
   · rfl
@@ -164,7 +164,7 @@ This is because every element `s(x, y)` of `Sym2 α` not on the diagonal comes f
 pairs: `(x, y)` and `(y, x)`. -/
 theorem card_image_offDiag (s : Finset α) :
     (s.offDiag.image Sym2.mk).card = s.card.choose 2 := by
-  rw [Nat.choose_two_right, mul_tsub, mul_one, ← offDiag_card,
+  rw [Nat.choose_two_right, mul_tsub, mul_one, ← card_offDiag,
     Nat.div_eq_of_eq_mul_right zero_lt_two (two_mul_card_image_offDiag s).symm]
 #align sym2.card_image_off_diag Sym2.card_image_offDiag
 

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -724,31 +724,13 @@ theorem other_invol {a : α} {z : Sym2 α} (ha : a ∈ z) (hb : Mem.other ha ∈
 
 theorem filter_image_mk_isDiag [DecidableEq α] (s : Finset α) :
     ((s ×ˢ s).image Sym2.mk).filter IsDiag = s.diag.image Sym2.mk := by
-  ext z
-  induction' z using Sym2.inductionOn
-  simp only [mem_image, mem_diag, exists_prop, mem_filter, Prod.exists, mem_product]
-  constructor
-  · rintro ⟨⟨a, b, ⟨ha, hb⟩, h⟩, hab⟩
-    rw [← h, Sym2.mk_isDiag_iff] at hab
-    exact ⟨a, b, ⟨ha, hab⟩, h⟩
-  · rintro ⟨a, b, ⟨ha, rfl⟩, h⟩
-    rw [← h]
-    exact ⟨⟨a, a, ⟨ha, ha⟩, rfl⟩, rfl⟩
+  simp_rw [Finset.filter_image, isDiag_iff_proj_eq, Finset.filter_eq_product_eq_diag]
 #align sym2.filter_image_quotient_mk_is_diag Sym2.filter_image_mk_isDiag
 
 theorem filter_image_mk_not_isDiag [DecidableEq α] (s : Finset α) :
     (((s ×ˢ s).image Sym2.mk).filter fun a : Sym2 α => ¬a.IsDiag) =
       s.offDiag.image Sym2.mk := by
-  ext z
-  induction z using Sym2.inductionOn
-  simp only [mem_image, mem_offDiag, mem_filter, Prod.exists, mem_product]
-  constructor
-  · rintro ⟨⟨a, b, ⟨ha, hb⟩, h⟩, hab⟩
-    rw [← h, Sym2.mk_isDiag_iff] at hab
-    exact ⟨a, b, ⟨ha, hb, hab⟩, h⟩
-  · rintro ⟨a, b, ⟨ha, hb, hab⟩, h⟩
-    rw [Ne.def, ← Sym2.mk_isDiag_iff, h] at hab
-    exact ⟨⟨a, b, ⟨ha, hb⟩, h⟩, hab⟩
+  simp_rw [Finset.filter_image, isDiag_iff_proj_eq, Finset.offDiag]
 #align sym2.filter_image_quotient_mk_not_is_diag Sym2.filter_image_mk_not_isDiag
 
 end Decidable


### PR DESCRIPTION
Redefine `Finset.diag` using `Finset.map`.
The new definition doesn't rely on `DecidableEq` and is much more computationally efficient.

Also review API and golf proofs here and there.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
