### PR TITLE
chore(Algebra.Ring.InjSurj): remove redundant `mul` and `add` fields 

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3548,6 +3548,7 @@ import Mathlib.Tactic.Explode.Pretty
 import Mathlib.Tactic.ExtendDoc
 import Mathlib.Tactic.ExtractGoal
 import Mathlib.Tactic.ExtractLets
+import Mathlib.Tactic.FastInstance
 import Mathlib.Tactic.FBinop
 import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.FieldSimp

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3548,9 +3548,9 @@ import Mathlib.Tactic.Explode.Pretty
 import Mathlib.Tactic.ExtendDoc
 import Mathlib.Tactic.ExtractGoal
 import Mathlib.Tactic.ExtractLets
-import Mathlib.Tactic.FastInstance
 import Mathlib.Tactic.FBinop
 import Mathlib.Tactic.FailIfNoProgress
+import Mathlib.Tactic.FastInstance
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Find

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Triangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Triangulated.lean
@@ -107,7 +107,7 @@ noncomputable def homotopyInvHomId : Homotopy (inv f g ≫ hom f g) (𝟙 _) :=
           (by linarith) (by linarith)] says
         simp only [mappingConeCompTriangle_obj₁, mappingConeCompTriangle_obj₂,
           mappingConeCompTriangle_mor₁, map, inv, hom, Cochain.ofHom_comp, ofHom_desc, ofHom_lift,
-          descCocycle_coe, AddSubmonoid.coe_zero, Cochain.comp_zero_cochain_v,
+          descCocycle_coe, ZeroMemClass.coe_zero, Cochain.comp_zero_cochain_v,
           inl_v_descCochain_v_assoc, Cochain.zero_cochain_comp_v, assoc, inl_v_snd_v_assoc,
           zero_comp, Cochain.id_comp, Cochain.comp_assoc_of_first_is_zero_cochain,
           Cochain.comp_add, Cochain.comp_neg, Cochain.comp_assoc_of_second_is_zero_cochain,

--- a/Mathlib/Algebra/Module/Submodule/Basic.lean
+++ b/Mathlib/Algebra/Module/Submodule/Basic.lean
@@ -182,6 +182,7 @@ variable [Semiring R] [AddCommMonoid M] [Module R M] {A : Type*} [SetLike A M]
 -- Prefer subclasses of `Module` over `SMulMemClass`.
 /-- A submodule of a `Module` is a `Module`.  -/
 instance (priority := 75) toModule : Module R S' :=
+  fast_instance%
   Subtype.coe_injective.module R (AddSubmonoidClass.subtype S') (SetLike.val_smul S')
 #align submodule_class.to_module SMulMemClass.toModule
 

--- a/Mathlib/Algebra/Module/Submodule/Order.lean
+++ b/Mathlib/Algebra/Module/Submodule/Order.lean
@@ -21,12 +21,14 @@ variable [Semiring R]
 /-- A submodule of an `OrderedAddCommMonoid` is an `OrderedAddCommMonoid`. -/
 instance toOrderedAddCommMonoid [OrderedAddCommMonoid M] [Module R M] (S : Submodule R M) :
     OrderedAddCommMonoid S :=
+  fast_instance%
   Subtype.coe_injective.orderedAddCommMonoid Subtype.val rfl (fun _ _ => rfl) fun _ _ => rfl
 #align submodule.to_ordered_add_comm_monoid Submodule.toOrderedAddCommMonoid
 
 /-- A submodule of a `LinearOrderedAddCommMonoid` is a `LinearOrderedAddCommMonoid`. -/
 instance toLinearOrderedAddCommMonoid [LinearOrderedAddCommMonoid M] [Module R M]
     (S : Submodule R M) : LinearOrderedAddCommMonoid S :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedAddCommMonoid Subtype.val rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 #align submodule.to_linear_ordered_add_comm_monoid Submodule.toLinearOrderedAddCommMonoid
@@ -34,6 +36,7 @@ instance toLinearOrderedAddCommMonoid [LinearOrderedAddCommMonoid M] [Module R M
 /-- A submodule of an `OrderedCancelAddCommMonoid` is an `OrderedCancelAddCommMonoid`. -/
 instance toOrderedCancelAddCommMonoid [OrderedCancelAddCommMonoid M] [Module R M]
     (S : Submodule R M) : OrderedCancelAddCommMonoid S :=
+  fast_instance%
   Subtype.coe_injective.orderedCancelAddCommMonoid Subtype.val rfl (fun _ _ => rfl) fun _ _ => rfl
 #align submodule.to_ordered_cancel_add_comm_monoid Submodule.toOrderedCancelAddCommMonoid
 
@@ -41,6 +44,7 @@ instance toOrderedCancelAddCommMonoid [OrderedCancelAddCommMonoid M] [Module R M
 `LinearOrderedCancelAddCommMonoid`. -/
 instance toLinearOrderedCancelAddCommMonoid [LinearOrderedCancelAddCommMonoid M] [Module R M]
     (S : Submodule R M) : LinearOrderedCancelAddCommMonoid S :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedCancelAddCommMonoid Subtype.val rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 #align submodule.to_linear_ordered_cancel_add_comm_monoid Submodule.toLinearOrderedCancelAddCommMonoid
@@ -53,6 +57,7 @@ variable [Ring R]
 /-- A submodule of an `OrderedAddCommGroup` is an `OrderedAddCommGroup`. -/
 instance toOrderedAddCommGroup [OrderedAddCommGroup M] [Module R M] (S : Submodule R M) :
     OrderedAddCommGroup S :=
+  fast_instance%
   Subtype.coe_injective.orderedAddCommGroup Subtype.val rfl (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 #align submodule.to_ordered_add_comm_group Submodule.toOrderedAddCommGroup
@@ -61,6 +66,7 @@ instance toOrderedAddCommGroup [OrderedAddCommGroup M] [Module R M] (S : Submodu
 `LinearOrderedAddCommGroup`. -/
 instance toLinearOrderedAddCommGroup [LinearOrderedAddCommGroup M] [Module R M]
     (S : Submodule R M) : LinearOrderedAddCommGroup S :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedAddCommGroup Subtype.val rfl (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 #align submodule.to_linear_ordered_add_comm_group Submodule.toLinearOrderedAddCommGroup

--- a/Mathlib/Algebra/Order/CauSeq/Completion.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Completion.lean
@@ -161,6 +161,7 @@ private theorem one_def : 1 = @mk _ _ _ _ abv _ 1 :=
   rfl
 
 instance Cauchy.ring : Ring (Cauchy abv) :=
+  fast_instance%
   Function.Surjective.ring mk (surjective_quotient_mk' _) zero_def.symm one_def.symm
     (fun _ _ => (mk_add _ _).symm) (fun _ _ => (mk_mul _ _).symm) (fun _ => (mk_neg _).symm)
     (fun _ _ => (mk_sub _ _).symm) (fun _ _ => (mk_smul _ _).symm) (fun _ _ => (mk_smul _ _).symm)
@@ -189,6 +190,7 @@ variable {α : Type*} [LinearOrderedField α]
 variable {β : Type*} [CommRing β] {abv : β → α} [IsAbsoluteValue abv]
 
 instance Cauchy.commRing : CommRing (Cauchy abv) :=
+  fast_instance%
   Function.Surjective.commRing mk (surjective_quotient_mk' _) zero_def.symm one_def.symm
     (fun _ _ => (mk_add _ _).symm) (fun _ _ => (mk_mul _ _).symm) (fun _ => (mk_neg _).symm)
     (fun _ _ => (mk_sub _ _).symm) (fun _ _ => (mk_smul _ _).symm) (fun _ _ => (mk_smul _ _).symm)

--- a/Mathlib/Algebra/Order/Nonneg/Field.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Field.lean
@@ -80,6 +80,7 @@ theorem mk_zpow (hx : 0 ≤ x) (n : ℤ) :
 #align nonneg.mk_zpow Nonneg.mk_zpow
 
 instance linearOrderedSemifield : LinearOrderedSemifield { x : α // 0 ≤ x } :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedSemifield _ Nonneg.coe_zero Nonneg.coe_one Nonneg.coe_add
     Nonneg.coe_mul Nonneg.coe_inv Nonneg.coe_div (fun _ _ => rfl) Nonneg.coe_pow Nonneg.coe_zpow
     Nonneg.coe_nat_cast (fun _ _ => rfl) fun _ _ => rfl
@@ -89,12 +90,13 @@ end LinearOrderedSemifield
 
 instance canonicallyLinearOrderedSemifield [LinearOrderedField α] :
     CanonicallyLinearOrderedSemifield { x : α // 0 ≤ x } :=
+  fast_instance%
   { Nonneg.linearOrderedSemifield, Nonneg.canonicallyOrderedCommSemiring with }
 #align nonneg.canonically_linear_ordered_semifield Nonneg.canonicallyLinearOrderedSemifield
 
 instance linearOrderedCommGroupWithZero [LinearOrderedField α] :
     LinearOrderedCommGroupWithZero { x : α // 0 ≤ x } :=
-  inferInstance
+  fast_instance% inferInstance
 #align nonneg.linear_ordered_comm_group_with_zero Nonneg.linearOrderedCommGroupWithZero
 
 end Nonneg

--- a/Mathlib/Algebra/Order/Nonneg/Ring.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Ring.lean
@@ -247,12 +247,15 @@ protected theorem coe_pow [OrderedSemiring α] (a : { x : α // 0 ≤ x }) (n : 
     (↑(a ^ n) : α) = (a : α) ^ n :=
   rfl
 #align nonneg.coe_pow Nonneg.coe_pow
-
 @[simp]
 theorem mk_pow [OrderedSemiring α] {x : α} (hx : 0 ≤ x) (n : ℕ) :
     (⟨x, hx⟩ : { x : α // 0 ≤ x }) ^ n = ⟨x ^ n, pow_nonneg hx n⟩ :=
   rfl
 #align nonneg.mk_pow Nonneg.mk_pow
+
+instance nontrivial [Nontrivial α] [OrderedSemiring α] : Nontrivial { x : α // 0 ≤ x } :=
+  pullback_nonzero Subtype.val rfl rfl
+#align nonneg.nontrivial Nonneg.nontrivial
 
 instance orderedSemiring [OrderedSemiring α] : OrderedSemiring { x : α // 0 ≤ x } :=
   fast_instance%
@@ -263,7 +266,7 @@ instance orderedSemiring [OrderedSemiring α] : OrderedSemiring { x : α // 0 �
 
 instance strictOrderedSemiring [StrictOrderedSemiring α] :
     StrictOrderedSemiring { x : α // 0 ≤ x } :=
-  -- fast_instance% -- TODO: fix
+  fast_instance%
   Subtype.coe_injective.strictOrderedSemiring _ Nonneg.coe_zero Nonneg.coe_one
     (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
@@ -300,10 +303,6 @@ instance semiring [OrderedSemiring α] : Semiring { x : α // 0 ≤ x } :=
 instance commSemiring [OrderedCommSemiring α] : CommSemiring { x : α // 0 ≤ x } :=
   inferInstance
 #align nonneg.comm_semiring Nonneg.commSemiring
-
-instance nontrivial [LinearOrderedSemiring α] : Nontrivial { x : α // 0 ≤ x } :=
-  ⟨⟨0, 1, fun h => zero_ne_one (congr_arg Subtype.val h)⟩⟩
-#align nonneg.nontrivial Nonneg.nontrivial
 
 instance linearOrderedSemiring [LinearOrderedSemiring α] :
     LinearOrderedSemiring { x : α // 0 ≤ x } :=

--- a/Mathlib/Algebra/Order/Nonneg/Ring.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Ring.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Algebra.Order.Ring.InjSurj
 import Mathlib.Order.CompleteLatticeIntervals
 import Mathlib.Order.LatticeIntervals
+import Mathlib.Tactic.FastInstance
 
 #align_import algebra.order.nonneg.ring from "leanprover-community/mathlib"@"422e70f7ce183d2900c586a8cda8381e788a0c62"
 
@@ -150,11 +151,13 @@ protected theorem coe_nsmul [AddMonoid α] [Preorder α] [CovariantClass α α (
 #align nonneg.coe_nsmul Nonneg.coe_nsmul
 
 instance orderedAddCommMonoid [OrderedAddCommMonoid α] : OrderedAddCommMonoid { x : α // 0 ≤ x } :=
+  fast_instance%
   Subtype.coe_injective.orderedAddCommMonoid _ Nonneg.coe_zero (fun _ _ => rfl) fun _ _ => rfl
 #align nonneg.ordered_add_comm_monoid Nonneg.orderedAddCommMonoid
 
 instance linearOrderedAddCommMonoid [LinearOrderedAddCommMonoid α] :
     LinearOrderedAddCommMonoid { x : α // 0 ≤ x } :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedAddCommMonoid _ Nonneg.coe_zero
     (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
@@ -162,11 +165,13 @@ instance linearOrderedAddCommMonoid [LinearOrderedAddCommMonoid α] :
 
 instance orderedCancelAddCommMonoid [OrderedCancelAddCommMonoid α] :
     OrderedCancelAddCommMonoid { x : α // 0 ≤ x } :=
+  fast_instance%
   Subtype.coe_injective.orderedCancelAddCommMonoid _ Nonneg.coe_zero (fun _ _ => rfl) fun _ _ => rfl
 #align nonneg.ordered_cancel_add_comm_monoid Nonneg.orderedCancelAddCommMonoid
 
 instance linearOrderedCancelAddCommMonoid [LinearOrderedCancelAddCommMonoid α] :
     LinearOrderedCancelAddCommMonoid { x : α // 0 ≤ x } :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedCancelAddCommMonoid _ Nonneg.coe_zero
     (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
@@ -250,6 +255,7 @@ theorem mk_pow [OrderedSemiring α] {x : α} (hx : 0 ≤ x) (n : ℕ) :
 #align nonneg.mk_pow Nonneg.mk_pow
 
 instance orderedSemiring [OrderedSemiring α] : OrderedSemiring { x : α // 0 ≤ x } :=
+  fast_instance%
   Subtype.coe_injective.orderedSemiring _ Nonneg.coe_zero Nonneg.coe_one
     (fun _ _ => rfl) (fun _ _=> rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ => rfl
@@ -257,12 +263,14 @@ instance orderedSemiring [OrderedSemiring α] : OrderedSemiring { x : α // 0 �
 
 instance strictOrderedSemiring [StrictOrderedSemiring α] :
     StrictOrderedSemiring { x : α // 0 ≤ x } :=
+  -- fast_instance% -- TODO: fix
   Subtype.coe_injective.strictOrderedSemiring _ Nonneg.coe_zero Nonneg.coe_one
     (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 #align nonneg.strict_ordered_semiring Nonneg.strictOrderedSemiring
 
 instance orderedCommSemiring [OrderedCommSemiring α] : OrderedCommSemiring { x : α // 0 ≤ x } :=
+  fast_instance%
   Subtype.coe_injective.orderedCommSemiring _ Nonneg.coe_zero Nonneg.coe_one
     (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
@@ -270,6 +278,7 @@ instance orderedCommSemiring [OrderedCommSemiring α] : OrderedCommSemiring { x 
 
 instance strictOrderedCommSemiring [StrictOrderedCommSemiring α] :
     StrictOrderedCommSemiring { x : α // 0 ≤ x } :=
+  fast_instance%
   Subtype.coe_injective.strictOrderedCommSemiring _ Nonneg.coe_zero Nonneg.coe_one
     (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
@@ -298,6 +307,7 @@ instance nontrivial [LinearOrderedSemiring α] : Nontrivial { x : α // 0 ≤ x 
 
 instance linearOrderedSemiring [LinearOrderedSemiring α] :
     LinearOrderedSemiring { x : α // 0 ≤ x } :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedSemiring _ Nonneg.coe_zero Nonneg.coe_one
     (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl

--- a/Mathlib/Algebra/Order/Positive/Ring.lean
+++ b/Mathlib/Algebra/Order/Positive/Ring.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Algebra.Ring.InjSurj
+import Mathlib.Tactic.FastInstance
 
 #align_import algebra.order.positive.ring from "leanprover-community/mathlib"@"655994e298904d7e5bbd1e18c95defd7b543eb94"
 
@@ -36,21 +37,25 @@ theorem coe_add (x y : { x : M // 0 < x }) : ↑(x + y) = (x + y : M) :=
 #align positive.coe_add Positive.coe_add
 
 instance addSemigroup : AddSemigroup { x : M // 0 < x } :=
+  fast_instance%
   Subtype.coe_injective.addSemigroup _ coe_add
 #align positive.subtype.add_semigroup Positive.addSemigroup
 
 instance addCommSemigroup {M : Type*} [AddCommMonoid M] [Preorder M]
     [CovariantClass M M (· + ·) (· < ·)] : AddCommSemigroup { x : M // 0 < x } :=
+  fast_instance%
   Subtype.coe_injective.addCommSemigroup _ coe_add
 #align positive.subtype.add_comm_semigroup Positive.addCommSemigroup
 
 instance addLeftCancelSemigroup {M : Type*} [AddLeftCancelMonoid M] [Preorder M]
     [CovariantClass M M (· + ·) (· < ·)] : AddLeftCancelSemigroup { x : M // 0 < x } :=
+  fast_instance%
   Subtype.coe_injective.addLeftCancelSemigroup _ coe_add
 #align positive.subtype.add_left_cancel_semigroup Positive.addLeftCancelSemigroup
 
 instance addRightCancelSemigroup {M : Type*} [AddRightCancelMonoid M] [Preorder M]
     [CovariantClass M M (· + ·) (· < ·)] : AddRightCancelSemigroup { x : M // 0 < x } :=
+  fast_instance%
   Subtype.coe_injective.addRightCancelSemigroup _ coe_add
 #align positive.subtype.add_right_cancel_semigroup Positive.addRightCancelSemigroup
 
@@ -114,9 +119,11 @@ theorem val_pow (x : { x : R // 0 < x }) (n : ℕ) :
 #align positive.coe_pow Positive.val_pow
 
 instance : Semigroup { x : R // 0 < x } :=
+  fast_instance%
   Subtype.coe_injective.semigroup Subtype.val val_mul
 
 instance : Distrib { x : R // 0 < x } :=
+  fast_instance%
   Subtype.coe_injective.distrib _ coe_add val_mul
 
 instance [Nontrivial R] : One { x : R // 0 < x } :=
@@ -128,6 +135,7 @@ theorem val_one [Nontrivial R] : ((1 : { x : R // 0 < x }) : R) = 1 :=
 #align positive.coe_one Positive.val_one
 
 instance [Nontrivial R] : Monoid { x : R // 0 < x } :=
+  fast_instance%
   Subtype.coe_injective.monoid _ val_one val_mul val_pow
 
 end Mul
@@ -136,6 +144,7 @@ section mul_comm
 
 instance orderedCommMonoid [StrictOrderedCommSemiring R] [Nontrivial R] :
     OrderedCommMonoid { x : R // 0 < x } :=
+  fast_instance%
   { Subtype.partialOrder _,
     Subtype.coe_injective.commMonoid (M₂ := R) (Subtype.val) val_one val_mul val_pow with
     mul_le_mul_left := fun _ _ hxy c =>
@@ -146,6 +155,7 @@ instance orderedCommMonoid [StrictOrderedCommSemiring R] [Nontrivial R] :
 ordered cancellative commutative monoid. -/
 instance linearOrderedCancelCommMonoid [LinearOrderedCommSemiring R] :
     LinearOrderedCancelCommMonoid { x : R // 0 < x } :=
+  fast_instance%
   { Subtype.instLinearOrder _, Positive.orderedCommMonoid with
     le_of_mul_le_mul_left := fun a _ _ h => Subtype.coe_le_coe.1 <| (mul_le_mul_left a.2).1 h }
 #align positive.subtype.linear_ordered_cancel_comm_monoid Positive.linearOrderedCancelCommMonoid

--- a/Mathlib/Algebra/Ring/InjSurj.lean
+++ b/Mathlib/Algebra/Ring/InjSurj.lean
@@ -32,8 +32,6 @@ See note [reducible non-instances]. -/
 protected def Function.Injective.distrib {S} [Mul R] [Add R] [Distrib S] (f : R → S)
     (hf : Injective f) (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y) :
     Distrib R where
-  mul := (· * ·)
-  add := (· + ·)
   left_distrib x y z := hf <| by simp only [*, left_distrib]
   right_distrib x y z := hf <| by simp only [*, right_distrib]
 #align function.injective.distrib Function.Injective.distrib
@@ -44,8 +42,6 @@ See note [reducible non-instances]. -/
 protected def Function.Surjective.distrib {S} [Distrib R] [Add S] [Mul S] (f : R → S)
     (hf : Surjective f) (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y) :
     Distrib S where
-  mul := (· * ·)
-  add := (· + ·)
   left_distrib := hf.forall₃.2 fun x y z => by simp only [← add, ← mul, left_distrib]
   right_distrib := hf.forall₃.2 fun x y z => by simp only [← add, ← mul, right_distrib]
 #align function.surjective.distrib Function.Surjective.distrib

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Scott Morrison
 import Mathlib.Algebra.Function.Indicator
 import Mathlib.Data.Set.Finite
 import Mathlib.GroupTheory.Submonoid.Basic
+import Mathlib.Tactic.FastInstance
 
 #align_import data.finsupp.defs from "leanprover-community/mathlib"@"842328d9df7e96fd90fc424e115679c15fb23a71"
 
@@ -1286,9 +1287,8 @@ instance instAddMonoid : AddMonoid (α →₀ M) :=
 end AddMonoid
 
 instance instAddCommMonoid [AddCommMonoid M] : AddCommMonoid (α →₀ M) :=
-  --TODO: add reference to library note in PR #7432
-  { DFunLike.coe_injective.addCommMonoid (↑) coe_zero coe_add (fun _ _ => rfl) with
-    toAddMonoid := Finsupp.instAddMonoid }
+  fast_instance%
+  DFunLike.coe_injective.addCommMonoid (↑) coe_zero coe_add (fun _ _ => rfl)
 #align finsupp.add_comm_monoid Finsupp.instAddCommMonoid
 
 instance instNeg [NegZeroClass G] : Neg (α →₀ G) :=
@@ -1343,17 +1343,15 @@ instance instIntSMul [AddGroup G] : SMul ℤ (α →₀ G) :=
 #align finsupp.has_int_scalar Finsupp.instIntSMul
 
 instance instAddGroup [AddGroup G] : AddGroup (α →₀ G) :=
-  --TODO: add reference to library note in PR #7432
-  { DFunLike.coe_injective.addGroup (↑) coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl)
-      fun _ _ => rfl with
-    toAddMonoid := Finsupp.instAddMonoid }
+  fast_instance%
+  DFunLike.coe_injective.addGroup (↑) coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl)
+      fun _ _ => rfl
 #align finsupp.add_group Finsupp.instAddGroup
 
 instance instAddCommGroup [AddCommGroup G] : AddCommGroup (α →₀ G) :=
-  --TODO: add reference to library note in PR #7432
-  { DFunLike.coe_injective.addCommGroup (↑) coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl)
-      fun _ _ => rfl with
-    toAddGroup := Finsupp.instAddGroup }
+  fast_instance%
+  DFunLike.coe_injective.addCommGroup (↑) coe_zero coe_add coe_neg coe_sub (fun _ _ => rfl)
+      fun _ _ => rfl
 #align finsupp.add_comm_group Finsupp.instAddCommGroup
 
 theorem single_add_single_eq_single_add_single [AddCommMonoid M] {k l m n : α} {u v : M}

--- a/Mathlib/Data/Polynomial/Basic.lean
+++ b/Mathlib/Data/Polynomial/Basic.lean
@@ -305,17 +305,15 @@ instance semiring : Semiring R[X] :=
 #align polynomial.semiring Polynomial.semiring
 
 instance distribSMul {S} [DistribSMul S R] : DistribSMul S R[X] :=
-  --TODO: add reference to library note in PR #7432
-  { Function.Injective.distribSMul ⟨⟨toFinsupp, toFinsupp_zero⟩, toFinsupp_add⟩ toFinsupp_injective
-      toFinsupp_smul with
-    toSMulZeroClass := Polynomial.smulZeroClass }
+  fast_instance%
+  Function.Injective.distribSMul ⟨⟨toFinsupp, toFinsupp_zero⟩, toFinsupp_add⟩ toFinsupp_injective
+      toFinsupp_smul
 #align polynomial.distrib_smul Polynomial.distribSMul
 
 instance distribMulAction {S} [Monoid S] [DistribMulAction S R] : DistribMulAction S R[X] :=
-  --TODO: add reference to library note in PR #7432
-  { Function.Injective.distribMulAction ⟨⟨toFinsupp, toFinsupp_zero (R := R)⟩, toFinsupp_add⟩
-      toFinsupp_injective toFinsupp_smul with
-    toSMul := Polynomial.smulZeroClass.toSMul }
+  fast_instance%
+  Function.Injective.distribMulAction ⟨⟨toFinsupp, toFinsupp_zero (R := R)⟩, toFinsupp_add⟩
+      toFinsupp_injective toFinsupp_smul
 #align polynomial.distrib_mul_action Polynomial.distribMulAction
 
 instance faithfulSMul {S} [SMulZeroClass S R] [FaithfulSMul S R] : FaithfulSMul S R[X] where
@@ -324,10 +322,9 @@ instance faithfulSMul {S} [SMulZeroClass S R] [FaithfulSMul S R] : FaithfulSMul 
 #align polynomial.has_faithful_smul Polynomial.faithfulSMul
 
 instance module {S} [Semiring S] [Module S R] : Module S R[X] :=
-  --TODO: add reference to library note in PR #7432
-  { Function.Injective.module _ ⟨⟨toFinsupp, toFinsupp_zero⟩, toFinsupp_add⟩ toFinsupp_injective
-      toFinsupp_smul with
-    toDistribMulAction := Polynomial.distribMulAction }
+  fast_instance%
+  Function.Injective.module _ ⟨⟨toFinsupp, toFinsupp_zero⟩, toFinsupp_add⟩ toFinsupp_injective
+      toFinsupp_smul
 #align polynomial.module Polynomial.module
 
 instance smulCommClass {S₁ S₂} [SMulZeroClass S₁ R] [SMulZeroClass S₂ R] [SMulCommClass S₁ S₂ R] :

--- a/Mathlib/Data/Set/Intervals/Instances.lean
+++ b/Mathlib/Data/Set/Intervals/Instances.lean
@@ -6,6 +6,7 @@ Authors: Stuart Presnell, Eric Wieser, Yaël Dillies, Patrick Massot, Scott Morr
 import Mathlib.Algebra.GroupPower.Order
 import Mathlib.Algebra.Ring.Regular
 import Mathlib.Data.Set.Intervals.Basic
+import Mathlib.Tactic.FastInstance
 
 #align_import data.set.intervals.instances from "leanprover-community/mathlib"@"d012cd09a9b256d870751284dd6a29882b0be105"
 
@@ -140,11 +141,13 @@ theorem mul_le_right {x y : Icc (0 : α) 1} : x * y ≤ y :=
 #align set.Icc.mul_le_right Set.Icc.mul_le_right
 
 instance monoidWithZero : MonoidWithZero (Icc (0 : α) 1) :=
+  fast_instance%
   Subtype.coe_injective.monoidWithZero _ coe_zero coe_one coe_mul coe_pow
 #align set.Icc.monoid_with_zero Set.Icc.monoidWithZero
 
 instance commMonoidWithZero {α : Type*} [OrderedCommSemiring α] :
     CommMonoidWithZero (Icc (0 : α) 1) :=
+  fast_instance%
   Subtype.coe_injective.commMonoidWithZero _ coe_zero coe_one coe_mul coe_pow
 #align set.Icc.comm_monoid_with_zero Set.Icc.commMonoidWithZero
 
@@ -231,10 +234,12 @@ theorem coe_mul (x y : Ico (0 : α) 1) : ↑(x * y) = (x * y : α) :=
 #align set.Ico.coe_mul Set.Ico.coe_mul
 
 instance semigroup : Semigroup (Ico (0 : α) 1) :=
+  fast_instance%
   Subtype.coe_injective.semigroup _ coe_mul
 #align set.Ico.semigroup Set.Ico.semigroup
 
 instance commSemigroup {α : Type*} [OrderedCommSemiring α] : CommSemigroup (Ico (0 : α) 1) :=
+  fast_instance%
   Subtype.coe_injective.commSemigroup _ coe_mul
 #align set.Ico.comm_semigroup Set.Ico.commSemigroup
 
@@ -304,19 +309,23 @@ theorem coe_pow (x : Ioc (0 : α) 1) (n : ℕ) : ↑(x ^ n) = ((x : α) ^ n) :=
 #align set.Ioc.coe_pow Set.Ioc.coe_pow
 
 instance semigroup : Semigroup (Ioc (0 : α) 1) :=
+  fast_instance%
   Subtype.coe_injective.semigroup _ coe_mul
 #align set.Ioc.semigroup Set.Ioc.semigroup
 
 instance monoid [Nontrivial α] : Monoid (Ioc (0 : α) 1) :=
+  fast_instance%
   Subtype.coe_injective.monoid _ coe_one coe_mul coe_pow
 #align set.Ioc.monoid Set.Ioc.monoid
 
 instance commSemigroup {α : Type*} [StrictOrderedCommSemiring α] : CommSemigroup (Ioc (0 : α) 1) :=
+  fast_instance%
   Subtype.coe_injective.commSemigroup _ coe_mul
 #align set.Ioc.comm_semigroup Set.Ioc.commSemigroup
 
 instance commMonoid {α : Type*} [StrictOrderedCommSemiring α] [Nontrivial α] :
     CommMonoid (Ioc (0 : α) 1) :=
+  fast_instance%
   Subtype.coe_injective.commMonoid _ coe_one coe_mul coe_pow
 #align set.Ioc.comm_monoid Set.Ioc.commMonoid
 
@@ -360,10 +369,12 @@ theorem coe_mul (x y : Ioo (0 : α) 1) : ↑(x * y) = (x * y : α) :=
 #align set.Ioo.coe_mul Set.Ioo.coe_mul
 
 instance semigroup : Semigroup (Ioo (0 : α) 1) :=
+  fast_instance%
   Subtype.coe_injective.semigroup _ coe_mul
 #align set.Ioo.semigroup Set.Ioo.semigroup
 
 instance commSemigroup {α : Type*} [StrictOrderedCommSemiring α] : CommSemigroup (Ioo (0 : α) 1) :=
+  fast_instance%
   Subtype.coe_injective.commSemigroup _ coe_mul
 #align set.Ioo.comm_semigroup Set.Ioo.commSemigroup
 

--- a/Mathlib/FieldTheory/Subfield.lean
+++ b/Mathlib/FieldTheory/Subfield.lean
@@ -124,6 +124,7 @@ variable (S)
 
 /-- A subfield inherits a division ring structure -/
 instance (priority := 75) toDivisionRing (s : S) : DivisionRing s :=
+  fast_instance%
   Subtype.coe_injective.divisionRing ((↑) : s → K)
     (by rfl) (by rfl) (by intros _ _; rfl) (by intros _ _; rfl) (by intros _; rfl)
     (by intros _ _; rfl) (by intros _; rfl) (by intros _ _; rfl) (by intros _ _; rfl)
@@ -134,6 +135,7 @@ instance (priority := 75) toDivisionRing (s : S) : DivisionRing s :=
 /-- A subfield of a field inherits a field structure -/
 instance (priority := 75) toField {K} [Field K] [SetLike S K] [SubfieldClass S K] (s : S) :
     Field s :=
+  fast_instance%
   Subtype.coe_injective.field ((↑) : s → K)
     (by rfl) (by rfl) (by intros _ _; rfl) (by intros _ _; rfl) (by intros _; rfl)
     (by intros _ _; rfl) (by intros _; rfl) (by intros _ _; rfl) (by intros _ _; rfl)
@@ -339,12 +341,14 @@ instance : Pow s ℤ :=
   ⟨fun x z => ⟨x ^ z, s.zpow_mem x.2 z⟩⟩
 
 instance toDivisionRing (s : Subfield K) : DivisionRing s :=
+  fast_instance%
   Subtype.coe_injective.divisionRing ((↑) : s → K) rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
     (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
     (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl) fun _ ↦ rfl
 
 /-- A subfield inherits a field structure -/
 instance toField {K} [Field K] (s : Subfield K) : Field s :=
+  fast_instance%
   Subtype.coe_injective.field ((↑) : s → K) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ => rfl) fun _ => rfl

--- a/Mathlib/FieldTheory/Subfield/Order.lean
+++ b/Mathlib/FieldTheory/Subfield/Order.lean
@@ -19,6 +19,7 @@ variable {K S : Type*} [SetLike S K]
 /-- A subfield of a `LinearOrderedField` is a `LinearOrderedField`. -/
 instance (priority := 75) toLinearOrderedField [LinearOrderedField K]
     [SubfieldClass S K] (s : S) : LinearOrderedField s :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedField (↑) rfl rfl (fun _ _ => rfl)
     (fun _ _ => rfl)
     (fun _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
@@ -33,6 +34,7 @@ variable {K : Type*}
 
 /-- A subfield of a `LinearOrderedField` is a `LinearOrderedField`. -/
 instance toLinearOrderedField [LinearOrderedField K] (s : Subfield K) : LinearOrderedField s :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedField (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)

--- a/Mathlib/GroupTheory/Congruence.lean
+++ b/Mathlib/GroupTheory/Congruence.lean
@@ -1171,12 +1171,8 @@ instance {M : Type*} [Monoid M] (c : Con M) : Pow c.Quotient ℕ where
 @[to_additive "The quotient of an `AddSemigroup` by an additive congruence relation is
 an `AddSemigroup`."]
 instance semigroup {M : Type*} [Semigroup M] (c : Con M) : Semigroup c.Quotient :=
-  { (Function.Surjective.semigroup _ Quotient.surjective_Quotient_mk'' fun _ _ => rfl :
-      Semigroup c.Quotient) with
-    /- The `toMul` field is given explicitly for performance reasons.
-    This avoids any need to unfold `Function.Surjective.semigroup` when the type checker is checking
-    that instance diagrams commute -/
-    toMul := Con.hasMul _ }
+  fast_instance%
+  Function.Surjective.semigroup _ Quotient.surjective_Quotient_mk'' fun _ _ => rfl
 #align con.semigroup Con.semigroup
 #align add_con.add_semigroup AddCon.addSemigroup
 
@@ -1184,12 +1180,8 @@ instance semigroup {M : Type*} [Semigroup M] (c : Con M) : Semigroup c.Quotient 
 @[to_additive "The quotient of an `AddCommSemigroup` by an additive congruence relation is
 an `AddCommSemigroup`."]
 instance commSemigroup {M : Type*} [CommSemigroup M] (c : Con M) : CommSemigroup c.Quotient :=
-  { (Function.Surjective.commSemigroup _ Quotient.surjective_Quotient_mk'' fun _ _ => rfl :
-      CommSemigroup c.Quotient) with
-    /- The `toSemigroup` field is given explicitly for performance reasons.
-    This avoids any need to unfold `Function.Surjective.commSemigroup` when the type checker is
-    checking that instance diagrams commute -/
-    toSemigroup := Con.semigroup _ }
+  fast_instance%
+  Function.Surjective.commSemigroup _ Quotient.surjective_Quotient_mk'' fun _ _ => rfl
 #align con.comm_semigroup Con.commSemigroup
 #align add_con.add_comm_semigroup AddCon.addCommSemigroup
 
@@ -1197,13 +1189,9 @@ instance commSemigroup {M : Type*} [CommSemigroup M] (c : Con M) : CommSemigroup
 @[to_additive "The quotient of an `AddMonoid` by an additive congruence relation is
 an `AddMonoid`."]
 instance monoid {M : Type*} [Monoid M] (c : Con M) : Monoid c.Quotient :=
-  { (Function.Surjective.monoid _ Quotient.surjective_Quotient_mk'' rfl
-      (fun _ _ => rfl) fun _ _ => rfl : Monoid c.Quotient) with
-    /- The `toSemigroup` and `toOne` fields are given explicitly for performance reasons.
-    This avoids any need to unfold `Function.Surjective.monoid` when the type checker is
-    checking that instance diagrams commute -/
-    toSemigroup := Con.semigroup _
-    toOne := Con.one _ }
+  fast_instance%
+  Function.Surjective.monoid
+    _ Quotient.surjective_Quotient_mk'' rfl (fun _ _ => rfl) fun _ _ => rfl
 #align con.monoid Con.monoid
 #align add_con.add_monoid AddCon.addMonoid
 
@@ -1211,12 +1199,10 @@ instance monoid {M : Type*} [Monoid M] (c : Con M) : Monoid c.Quotient :=
 @[to_additive "The quotient of an `AddCommMonoid` by an additive congruence
 relation is an `AddCommMonoid`."]
 instance commMonoid {M : Type*} [CommMonoid M] (c : Con M) : CommMonoid c.Quotient :=
-  { (Function.Surjective.commMonoid _ Quotient.surjective_Quotient_mk'' rfl
-      (fun _ _ => rfl) fun _ _ => rfl : CommMonoid c.Quotient) with
-    /- The `toMonoid` field is given explicitly for performance reasons.
-    This avoids any need to unfold `Function.Surjective.commMonoid` when the type checker is
-    checking that instance diagrams commute -/
-    toMonoid := Con.monoid _ }
+  fast_instance%
+  Function.Surjective.commMonoid
+    _ Quotient.surjective_Quotient_mk'' rfl
+      (fun _ _ => rfl) fun _ _ => rfl
 #align con.comm_monoid Con.commMonoid
 #align add_con.add_comm_monoid AddCon.addCommMonoid
 

--- a/Mathlib/GroupTheory/Subgroup/Basic.lean
+++ b/Mathlib/GroupTheory/Subgroup/Basic.lean
@@ -252,6 +252,7 @@ variable (H)
 /-- A subgroup of a group inherits a group structure. -/
 @[to_additive "An additive subgroup of an `AddGroup` inherits an `AddGroup` structure."]
 instance (priority := 75) toGroup : Group H :=
+  fast_instance%
   Subtype.coe_injective.group _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 #align subgroup_class.to_group SubgroupClass.toGroup
@@ -262,6 +263,7 @@ instance (priority := 75) toGroup : Group H :=
 @[to_additive "An additive subgroup of an `AddCommGroup` is an `AddCommGroup`."]
 instance (priority := 75) toCommGroup {G : Type*} [CommGroup G] [SetLike S G] [SubgroupClass S G] :
     CommGroup H :=
+  fast_instance%
   Subtype.coe_injective.commGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 #align subgroup_class.to_comm_group SubgroupClass.toCommGroup
@@ -741,6 +743,7 @@ theorem mk_eq_one {g : G} {h} : (⟨g, h⟩ : H) = 1 ↔ g = 1 := by simp
 /-- A subgroup of a group inherits a group structure. -/
 @[to_additive "An `AddSubgroup` of an `AddGroup` inherits an `AddGroup` structure."]
 instance toGroup {G : Type*} [Group G] (H : Subgroup G) : Group H :=
+  fast_instance%
   Subtype.coe_injective.group _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 #align subgroup.to_group Subgroup.toGroup
@@ -749,6 +752,7 @@ instance toGroup {G : Type*} [Group G] (H : Subgroup G) : Group H :=
 /-- A subgroup of a `CommGroup` is a `CommGroup`. -/
 @[to_additive "An `AddSubgroup` of an `AddCommGroup` is an `AddCommGroup`."]
 instance toCommGroup {G : Type*} [CommGroup G] (H : Subgroup G) : CommGroup H :=
+  fast_instance%
   Subtype.coe_injective.commGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 #align subgroup.to_comm_group Subgroup.toCommGroup

--- a/Mathlib/GroupTheory/Subgroup/Order.lean
+++ b/Mathlib/GroupTheory/Subgroup/Order.lean
@@ -20,6 +20,7 @@ variable {G S : Type*} [SetLike S G]
 @[to_additive "An additive subgroup of an `AddOrderedCommGroup` is an `AddOrderedCommGroup`."]
 instance (priority := 75) toOrderedCommGroup [OrderedCommGroup G]
     [SubgroupClass S G] (H : S) : OrderedCommGroup H :=
+  fast_instance%
   Subtype.coe_injective.orderedCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 #align subgroup_class.to_ordered_comm_group SubgroupClass.toOrderedCommGroup
@@ -32,6 +33,7 @@ instance (priority := 75) toOrderedCommGroup [OrderedCommGroup G]
         `LinearOrderedAddCommGroup`."]
 instance (priority := 75) toLinearOrderedCommGroup [LinearOrderedCommGroup G]
     [SubgroupClass S G] (H : S) : LinearOrderedCommGroup H :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 #align subgroup_class.to_linear_ordered_comm_group SubgroupClass.toLinearOrderedCommGroup
@@ -47,6 +49,7 @@ variable {G : Type*}
 @[to_additive "An `AddSubgroup` of an `AddOrderedCommGroup` is an `AddOrderedCommGroup`."]
 instance toOrderedCommGroup [OrderedCommGroup G] (H : Subgroup G) :
     OrderedCommGroup H :=
+  fast_instance%
   Subtype.coe_injective.orderedCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 #align subgroup.to_ordered_comm_group Subgroup.toOrderedCommGroup
@@ -58,6 +61,7 @@ instance toOrderedCommGroup [OrderedCommGroup G] (H : Subgroup G) :
         `LinearOrderedAddCommGroup`."]
 instance toLinearOrderedCommGroup [LinearOrderedCommGroup G] (H : Subgroup G) :
     LinearOrderedCommGroup H :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 #align subgroup.to_linear_ordered_comm_group Subgroup.toLinearOrderedCommGroup

--- a/Mathlib/GroupTheory/Submonoid/Operations.lean
+++ b/Mathlib/GroupTheory/Submonoid/Operations.lean
@@ -579,7 +579,7 @@ theorem mk_pow {M} [Monoid M] {A : Type*} [SetLike A M] [SubmonoidClass A M] {S 
 instance (priority := 75) toMulOneClass {M : Type*} [MulOneClass M] {A : Type*} [SetLike A M]
     [SubmonoidClass A M] (S : A) : MulOneClass S :=
   fast_instance%
-    Subtype.coe_injective.mulOneClass (↑) rfl (fun _ _ => rfl)
+  Subtype.coe_injective.mulOneClass (↑) rfl (fun _ _ => rfl)
 #align submonoid_class.to_mul_one_class SubmonoidClass.toMulOneClass
 #align add_submonoid_class.to_add_zero_class AddSubmonoidClass.toAddZeroClass
 
@@ -589,7 +589,7 @@ instance (priority := 75) toMulOneClass {M : Type*} [MulOneClass M] {A : Type*} 
 instance (priority := 75) toMonoid {M : Type*} [Monoid M] {A : Type*} [SetLike A M]
     [SubmonoidClass A M] (S : A) : Monoid S :=
   fast_instance%
-    Subtype.coe_injective.monoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
+  Subtype.coe_injective.monoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
 #align submonoid_class.to_monoid SubmonoidClass.toMonoid
 #align add_submonoid_class.to_add_monoid AddSubmonoidClass.toAddMonoid
 
@@ -672,7 +672,7 @@ theorem one_def : (1 : S) = ⟨1, S.one_mem⟩ :=
       "An `AddSubmonoid` of a unital additive magma inherits a unital additive magma structure."]
 instance toMulOneClass {M : Type*} [MulOneClass M] (S : Submonoid M) : MulOneClass S :=
   fast_instance%
-    Subtype.coe_injective.mulOneClass (↑) rfl fun _ _ => rfl
+  Subtype.coe_injective.mulOneClass (↑) rfl fun _ _ => rfl
 #align submonoid.to_mul_one_class Submonoid.toMulOneClass
 #align add_submonoid.to_add_zero_class AddSubmonoid.toAddZeroClass
 
@@ -691,7 +691,7 @@ protected theorem pow_mem {M : Type*} [Monoid M] (S : Submonoid M) {x : M} (hx :
 @[to_additive "An `AddSubmonoid` of an `AddMonoid` inherits an `AddMonoid` structure."]
 instance toMonoid {M : Type*} [Monoid M] (S : Submonoid M) : Monoid S :=
   fast_instance%
-    Subtype.coe_injective.monoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
+  Subtype.coe_injective.monoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid.to_monoid Submonoid.toMonoid
 #align add_submonoid.to_add_monoid AddSubmonoid.toAddMonoid
 
@@ -699,7 +699,7 @@ instance toMonoid {M : Type*} [Monoid M] (S : Submonoid M) : Monoid S :=
 @[to_additive "An `AddSubmonoid` of an `AddCommMonoid` is an `AddCommMonoid`."]
 instance toCommMonoid {M} [CommMonoid M] (S : Submonoid M) : CommMonoid S :=
   fast_instance%
-    Subtype.coe_injective.commMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
+  Subtype.coe_injective.commMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid.to_comm_monoid Submonoid.toCommMonoid
 #align add_submonoid.to_add_comm_monoid AddSubmonoid.toAddCommMonoid
 

--- a/Mathlib/GroupTheory/Submonoid/Operations.lean
+++ b/Mathlib/GroupTheory/Submonoid/Operations.lean
@@ -578,6 +578,7 @@ theorem mk_pow {M} [Monoid M] {A : Type*} [SetLike A M] [SubmonoidClass A M] {S 
       "An `AddSubmonoid` of a unital additive magma inherits a unital additive magma structure."]
 instance (priority := 75) toMulOneClass {M : Type*} [MulOneClass M] {A : Type*} [SetLike A M]
     [SubmonoidClass A M] (S : A) : MulOneClass S :=
+  fast_instance%
     Subtype.coe_injective.mulOneClass (↑) rfl (fun _ _ => rfl)
 #align submonoid_class.to_mul_one_class SubmonoidClass.toMulOneClass
 #align add_submonoid_class.to_add_zero_class AddSubmonoidClass.toAddZeroClass
@@ -587,7 +588,8 @@ instance (priority := 75) toMulOneClass {M : Type*} [MulOneClass M] {A : Type*} 
 @[to_additive "An `AddSubmonoid` of an `AddMonoid` inherits an `AddMonoid` structure."]
 instance (priority := 75) toMonoid {M : Type*} [Monoid M] {A : Type*} [SetLike A M]
     [SubmonoidClass A M] (S : A) : Monoid S :=
-  Subtype.coe_injective.monoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
+  fast_instance%
+    Subtype.coe_injective.monoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
 #align submonoid_class.to_monoid SubmonoidClass.toMonoid
 #align add_submonoid_class.to_add_monoid AddSubmonoidClass.toAddMonoid
 
@@ -669,7 +671,8 @@ theorem one_def : (1 : S) = ⟨1, S.one_mem⟩ :=
 @[to_additive
       "An `AddSubmonoid` of a unital additive magma inherits a unital additive magma structure."]
 instance toMulOneClass {M : Type*} [MulOneClass M] (S : Submonoid M) : MulOneClass S :=
-  Subtype.coe_injective.mulOneClass (↑) rfl fun _ _ => rfl
+  fast_instance%
+    Subtype.coe_injective.mulOneClass (↑) rfl fun _ _ => rfl
 #align submonoid.to_mul_one_class Submonoid.toMulOneClass
 #align add_submonoid.to_add_zero_class AddSubmonoid.toAddZeroClass
 
@@ -687,14 +690,16 @@ protected theorem pow_mem {M : Type*} [Monoid M] (S : Submonoid M) {x : M} (hx :
 /-- A submonoid of a monoid inherits a monoid structure. -/
 @[to_additive "An `AddSubmonoid` of an `AddMonoid` inherits an `AddMonoid` structure."]
 instance toMonoid {M : Type*} [Monoid M] (S : Submonoid M) : Monoid S :=
-  Subtype.coe_injective.monoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
+  fast_instance%
+    Subtype.coe_injective.monoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid.to_monoid Submonoid.toMonoid
 #align add_submonoid.to_add_monoid AddSubmonoid.toAddMonoid
 
 /-- A submonoid of a `CommMonoid` is a `CommMonoid`. -/
 @[to_additive "An `AddSubmonoid` of an `AddCommMonoid` is an `AddCommMonoid`."]
 instance toCommMonoid {M} [CommMonoid M] (S : Submonoid M) : CommMonoid S :=
-  Subtype.coe_injective.commMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
+  fast_instance%
+    Subtype.coe_injective.commMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid.to_comm_monoid Submonoid.toCommMonoid
 #align add_submonoid.to_add_comm_monoid AddSubmonoid.toAddCommMonoid
 

--- a/Mathlib/GroupTheory/Submonoid/Order.lean
+++ b/Mathlib/GroupTheory/Submonoid/Order.lean
@@ -21,7 +21,8 @@ variable {M S : Type*} [SetLike S M]
 @[to_additive "An `AddSubmonoid` of an `OrderedAddCommMonoid` is an `OrderedAddCommMonoid`."]
 instance (priority := 75) toOrderedCommMonoid [OrderedCommMonoid M]
     [SubmonoidClass S M] (s : S) : OrderedCommMonoid s :=
-  Subtype.coe_injective.orderedCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
+  fast_instance%
+    Subtype.coe_injective.orderedCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid_class.to_ordered_comm_monoid SubmonoidClass.toOrderedCommMonoid
 #align add_submonoid_class.to_ordered_add_comm_monoid AddSubmonoidClass.toOrderedAddCommMonoid
 

--- a/Mathlib/GroupTheory/Submonoid/Order.lean
+++ b/Mathlib/GroupTheory/Submonoid/Order.lean
@@ -22,7 +22,7 @@ variable {M S : Type*} [SetLike S M]
 instance (priority := 75) toOrderedCommMonoid [OrderedCommMonoid M]
     [SubmonoidClass S M] (s : S) : OrderedCommMonoid s :=
   fast_instance%
-    Subtype.coe_injective.orderedCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
+  Subtype.coe_injective.orderedCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid_class.to_ordered_comm_monoid SubmonoidClass.toOrderedCommMonoid
 #align add_submonoid_class.to_ordered_add_comm_monoid AddSubmonoidClass.toOrderedAddCommMonoid
 
@@ -32,6 +32,7 @@ instance (priority := 75) toOrderedCommMonoid [OrderedCommMonoid M]
       "An `AddSubmonoid` of a `LinearOrderedAddCommMonoid` is a `LinearOrderedAddCommMonoid`."]
 instance (priority := 75) toLinearOrderedCommMonoid [LinearOrderedCommMonoid M]
     [SubmonoidClass S M] (s : S) : LinearOrderedCommMonoid s :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid_class.to_linear_ordered_comm_monoid SubmonoidClass.toLinearOrderedCommMonoid
@@ -43,6 +44,7 @@ instance (priority := 75) toLinearOrderedCommMonoid [LinearOrderedCommMonoid M]
       "An `AddSubmonoid` of an `OrderedCancelAddCommMonoid` is an `OrderedCancelAddCommMonoid`."]
 instance (priority := 75) toOrderedCancelCommMonoid [OrderedCancelCommMonoid M]
     [SubmonoidClass S M] (s : S) : OrderedCancelCommMonoid s :=
+  fast_instance%
   Subtype.coe_injective.orderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid_class.to_ordered_cancel_comm_monoid SubmonoidClass.toOrderedCancelCommMonoid
 #align add_submonoid_class.to_ordered_cancel_add_comm_monoid AddSubmonoidClass.toOrderedCancelAddCommMonoid
@@ -55,6 +57,7 @@ instance (priority := 75) toOrderedCancelCommMonoid [OrderedCancelCommMonoid M]
       a `LinearOrderedCancelAddCommMonoid`."]
 instance (priority := 75) toLinearOrderedCancelCommMonoid [LinearOrderedCancelCommMonoid M]
     [SubmonoidClass S M] (s : S) : LinearOrderedCancelCommMonoid s :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid_class.to_linear_ordered_cancel_comm_monoid SubmonoidClass.toLinearOrderedCancelCommMonoid
@@ -69,6 +72,7 @@ variable {M : Type*}
 /-- A submonoid of an `OrderedCommMonoid` is an `OrderedCommMonoid`. -/
 @[to_additive "An `AddSubmonoid` of an `OrderedAddCommMonoid` is an `OrderedAddCommMonoid`."]
 instance toOrderedCommMonoid [OrderedCommMonoid M] (S : Submonoid M) : OrderedCommMonoid S :=
+  fast_instance%
   Subtype.coe_injective.orderedCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid.to_ordered_comm_monoid Submonoid.toOrderedCommMonoid
 #align add_submonoid.to_ordered_add_comm_monoid AddSubmonoid.toOrderedAddCommMonoid
@@ -78,6 +82,7 @@ instance toOrderedCommMonoid [OrderedCommMonoid M] (S : Submonoid M) : OrderedCo
       "An `AddSubmonoid` of a `LinearOrderedAddCommMonoid` is a `LinearOrderedAddCommMonoid`."]
 instance toLinearOrderedCommMonoid [LinearOrderedCommMonoid M] (S : Submonoid M) :
     LinearOrderedCommMonoid S :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid.to_linear_ordered_comm_monoid Submonoid.toLinearOrderedCommMonoid
@@ -88,7 +93,8 @@ instance toLinearOrderedCommMonoid [LinearOrderedCommMonoid M] (S : Submonoid M)
       "An `AddSubmonoid` of an `OrderedCancelAddCommMonoid` is an `OrderedCancelAddCommMonoid`."]
 instance toOrderedCancelCommMonoid [OrderedCancelCommMonoid M] (S : Submonoid M) :
     OrderedCancelCommMonoid S :=
-  Subtype.coe_injective.orderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
+  fast_instance%
+    Subtype.coe_injective.orderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid.to_ordered_cancel_comm_monoid Submonoid.toOrderedCancelCommMonoid
 #align add_submonoid.to_ordered_cancel_add_comm_monoid AddSubmonoid.toOrderedCancelAddCommMonoid
 
@@ -99,8 +105,9 @@ instance toOrderedCancelCommMonoid [OrderedCancelCommMonoid M] (S : Submonoid M)
       a `LinearOrderedCancelAddCommMonoid`."]
 instance toLinearOrderedCancelCommMonoid [LinearOrderedCancelCommMonoid M] (S : Submonoid M) :
     LinearOrderedCancelCommMonoid S :=
-  Subtype.coe_injective.linearOrderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) fun _ _ => rfl
+  fast_instance%
+    Subtype.coe_injective.linearOrderedCancelCommMonoid (↑) rfl (fun _ _ => rfl) (fun _ _ => rfl)
+      (fun _ _ => rfl) fun _ _ => rfl
 #align submonoid.to_linear_ordered_cancel_comm_monoid Submonoid.toLinearOrderedCancelCommMonoid
 #align add_submonoid.to_linear_ordered_cancel_add_comm_monoid AddSubmonoid.toLinearOrderedCancelAddCommMonoid
 

--- a/Mathlib/GroupTheory/Subsemigroup/Operations.lean
+++ b/Mathlib/GroupTheory/Subsemigroup/Operations.lean
@@ -553,7 +553,7 @@ theorem mul_def (x y : S') : x * y = ⟨x * y, mul_mem x.2 y.2⟩ :=
 instance toSemigroup {M : Type*} [Semigroup M] {A : Type*} [SetLike A M] [MulMemClass A M]
     (S : A) : Semigroup S :=
   fast_instance%
-    Subtype.coe_injective.semigroup Subtype.val fun _ _ => rfl
+  Subtype.coe_injective.semigroup Subtype.val fun _ _ => rfl
 #align mul_mem_class.to_semigroup MulMemClass.toSemigroup
 #align add_mem_class.to_add_semigroup AddMemClass.toAddSemigroup
 
@@ -562,7 +562,7 @@ instance toSemigroup {M : Type*} [Semigroup M] {A : Type*} [SetLike A M] [MulMem
 instance toCommSemigroup {M} [CommSemigroup M] {A : Type*} [SetLike A M] [MulMemClass A M]
     (S : A) : CommSemigroup S :=
   fast_instance%
-    Subtype.coe_injective.commSemigroup Subtype.val fun _ _ => rfl
+  Subtype.coe_injective.commSemigroup Subtype.val fun _ _ => rfl
 #align mul_mem_class.to_comm_semigroup MulMemClass.toCommSemigroup
 #align add_mem_class.to_add_comm_semigroup AddMemClass.toAddCommSemigroup
 

--- a/Mathlib/GroupTheory/Subsemigroup/Operations.lean
+++ b/Mathlib/GroupTheory/Subsemigroup/Operations.lean
@@ -7,6 +7,7 @@ Amelia Livingston, Yury Kudryashov, Yakov Pechersky, Jireh Loreaux
 import Mathlib.GroupTheory.Subsemigroup.Basic
 import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Group.TypeTags
+import Mathlib.Tactic.FastInstance
 
 #align_import group_theory.subsemigroup.operations from "leanprover-community/mathlib"@"207cfac9fcd06138865b5d04f7091e46d9320432"
 
@@ -551,7 +552,8 @@ theorem mul_def (x y : S') : x * y = ⟨x * y, mul_mem x.2 y.2⟩ :=
 @[to_additive "An `AddSubsemigroup` of an `AddSemigroup` inherits an `AddSemigroup` structure."]
 instance toSemigroup {M : Type*} [Semigroup M] {A : Type*} [SetLike A M] [MulMemClass A M]
     (S : A) : Semigroup S :=
-  Subtype.coe_injective.semigroup Subtype.val fun _ _ => rfl
+  fast_instance%
+    Subtype.coe_injective.semigroup Subtype.val fun _ _ => rfl
 #align mul_mem_class.to_semigroup MulMemClass.toSemigroup
 #align add_mem_class.to_add_semigroup AddMemClass.toAddSemigroup
 
@@ -559,7 +561,8 @@ instance toSemigroup {M : Type*} [Semigroup M] {A : Type*} [SetLike A M] [MulMem
 @[to_additive "An `AddSubsemigroup` of an `AddCommSemigroup` is an `AddCommSemigroup`."]
 instance toCommSemigroup {M} [CommSemigroup M] {A : Type*} [SetLike A M] [MulMemClass A M]
     (S : A) : CommSemigroup S :=
-  Subtype.coe_injective.commSemigroup Subtype.val fun _ _ => rfl
+  fast_instance%
+    Subtype.coe_injective.commSemigroup Subtype.val fun _ _ => rfl
 #align mul_mem_class.to_comm_semigroup MulMemClass.toCommSemigroup
 #align add_mem_class.to_add_comm_semigroup AddMemClass.toAddCommSemigroup
 

--- a/Mathlib/LinearAlgebra/Quotient.lean
+++ b/Mathlib/LinearAlgebra/Quotient.lean
@@ -161,12 +161,10 @@ section Module
 
 variable {S : Type*}
 
--- Performance of `Function.Surjective.mulAction` is worse since it has to unify data to apply
--- TODO: leanprover-community/mathlib4#7432
 instance mulAction' [Monoid S] [SMul S R] [MulAction S M] [IsScalarTower S R M]
     (P : Submodule R M) : MulAction S (M ⧸ P) :=
-  { Function.Surjective.mulAction mk (surjective_quot_mk _) <| Submodule.Quotient.mk_smul P with
-    toSMul := instSMul' _ }
+  fast_instance%
+  Function.Surjective.mulAction mk (surjective_quot_mk _) <| Submodule.Quotient.mk_smul P
 #align submodule.quotient.mul_action' Submodule.Quotient.mulAction'
 
 -- Porting note: should this be marked as a `@[default_instance]`?
@@ -184,13 +182,11 @@ instance smulZeroClass (P : Submodule R M) : SMulZeroClass R (M ⧸ P) :=
   Quotient.smulZeroClass' P
 #align submodule.quotient.smul_zero_class Submodule.Quotient.smulZeroClass
 
--- Performance of `Function.Surjective.distribSMul` is worse since it has to unify data to apply
--- TODO: leanprover-community/mathlib4#7432
 instance distribSMul' [SMul S R] [DistribSMul S M] [IsScalarTower S R M] (P : Submodule R M) :
     DistribSMul S (M ⧸ P) :=
-  { Function.Surjective.distribSMul {toFun := mk, map_zero' := rfl, map_add' := fun _ _ => rfl}
-    (surjective_quot_mk _) (Submodule.Quotient.mk_smul P) with
-    toSMulZeroClass := smulZeroClass' _ }
+  fast_instance%
+  Function.Surjective.distribSMul {toFun := mk, map_zero' := rfl, map_add' := fun _ _ => rfl}
+    (surjective_quot_mk _) (Submodule.Quotient.mk_smul P)
 #align submodule.quotient.distrib_smul' Submodule.Quotient.distribSMul'
 
 -- Porting note: should this be marked as a `@[default_instance]`?
@@ -198,13 +194,11 @@ instance distribSMul (P : Submodule R M) : DistribSMul R (M ⧸ P) :=
   Quotient.distribSMul' P
 #align submodule.quotient.distrib_smul Submodule.Quotient.distribSMul
 
--- Performance of `Function.Surjective.distribMulAction` is worse since it has to unify data
--- TODO: leanprover-community/mathlib4#7432
 instance distribMulAction' [Monoid S] [SMul S R] [DistribMulAction S M] [IsScalarTower S R M]
     (P : Submodule R M) : DistribMulAction S (M ⧸ P) :=
-  { Function.Surjective.distribMulAction {toFun := mk, map_zero' := rfl, map_add' := fun _ _ => rfl}
-    (surjective_quot_mk _) (Submodule.Quotient.mk_smul P) with
-    toMulAction := mulAction' _ }
+  fast_instance%
+  Function.Surjective.distribMulAction {toFun := mk, map_zero' := rfl, map_add' := fun _ _ => rfl}
+    (surjective_quot_mk _) (Submodule.Quotient.mk_smul P)
 #align submodule.quotient.distrib_mul_action' Submodule.Quotient.distribMulAction'
 
 -- Porting note: should this be marked as a `@[default_instance]`?
@@ -212,13 +206,11 @@ instance distribMulAction (P : Submodule R M) : DistribMulAction R (M ⧸ P) :=
   Quotient.distribMulAction' P
 #align submodule.quotient.distrib_mul_action Submodule.Quotient.distribMulAction
 
--- Performance of `Function.Surjective.module` is worse since it has to unify data to apply
--- TODO: leanprover-community/mathlib4#7432
 instance module' [Semiring S] [SMul S R] [Module S M] [IsScalarTower S R M] (P : Submodule R M) :
     Module S (M ⧸ P) :=
-  { Function.Surjective.module _ {toFun := mk, map_zero' := by rfl, map_add' := fun _ _ => by rfl}
-    (surjective_quot_mk _) (Submodule.Quotient.mk_smul P) with
-    toDistribMulAction := distribMulAction' _ }
+  fast_instance%
+  Function.Surjective.module _ {toFun := mk, map_zero' := by rfl, map_add' := fun _ _ => by rfl}
+    (surjective_quot_mk _) (Submodule.Quotient.mk_smul P)
 #align submodule.quotient.module' Submodule.Quotient.module'
 
 -- Porting note: should this be marked as a `@[default_instance]`?

--- a/Mathlib/RingTheory/Congruence.lean
+++ b/Mathlib/RingTheory/Congruence.lean
@@ -335,44 +335,54 @@ The operations above on the quotient by `c : RingCon R` preserve the algebraic s
 section Algebraic
 
 instance [NonUnitalNonAssocSemiring R] (c : RingCon R) : NonUnitalNonAssocSemiring c.Quotient :=
+  fast_instance%
   Function.Surjective.nonUnitalNonAssocSemiring _ Quotient.surjective_Quotient_mk'' rfl
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 
 instance [NonAssocSemiring R] (c : RingCon R) : NonAssocSemiring c.Quotient :=
+  fast_instance%
   Function.Surjective.nonAssocSemiring _ Quotient.surjective_Quotient_mk'' rfl rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 
 instance [NonUnitalSemiring R] (c : RingCon R) : NonUnitalSemiring c.Quotient :=
+  fast_instance%
   Function.Surjective.nonUnitalSemiring _ Quotient.surjective_Quotient_mk'' rfl (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
 
 instance [Semiring R] (c : RingCon R) : Semiring c.Quotient :=
+  fast_instance%
   Function.Surjective.semiring _ Quotient.surjective_Quotient_mk'' rfl rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 
 instance [CommSemiring R] (c : RingCon R) : CommSemiring c.Quotient :=
+  fast_instance%
   Function.Surjective.commSemiring _ Quotient.surjective_Quotient_mk'' rfl rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 
 instance [NonUnitalNonAssocRing R] (c : RingCon R) : NonUnitalNonAssocRing c.Quotient :=
+  fast_instance%
   Function.Surjective.nonUnitalNonAssocRing _ Quotient.surjective_Quotient_mk'' rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 
 instance [NonAssocRing R] (c : RingCon R) : NonAssocRing c.Quotient :=
+  fast_instance%
   Function.Surjective.nonAssocRing _ Quotient.surjective_Quotient_mk'' rfl rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ => rfl) fun _ => rfl
 
 instance [NonUnitalRing R] (c : RingCon R) : NonUnitalRing c.Quotient :=
+  fast_instance%
   Function.Surjective.nonUnitalRing _ Quotient.surjective_Quotient_mk'' rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 
 instance [Ring R] (c : RingCon R) : Ring c.Quotient :=
+  fast_instance%
   Function.Surjective.ring _ Quotient.surjective_Quotient_mk'' rfl rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) fun _ => rfl
 
 instance [CommRing R] (c : RingCon R) : CommRing c.Quotient :=
+  fast_instance%
   Function.Surjective.commRing _ Quotient.surjective_Quotient_mk'' rfl rfl (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ => rfl) fun _ => rfl

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -94,6 +94,7 @@ namespace NonUnitalSubringClass
 -- Prefer subclasses of `NonUnitalRing` over subclasses of `NonUnitalSubringClass`.
 /-- A non-unital subring of a non-unital ring inherits a non-unital ring structure -/
 instance (priority := 75) toNonUnitalNonAssocRing : NonUnitalNonAssocRing s :=
+  fast_instance%
   Subtype.val_injective.nonUnitalNonAssocRing _ rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 
@@ -101,6 +102,7 @@ instance (priority := 75) toNonUnitalNonAssocRing : NonUnitalNonAssocRing s :=
 /-- A non-unital subring of a non-unital ring inherits a non-unital ring structure -/
 instance (priority := 75) toNonUnitalRing {R : Type*} [NonUnitalRing R] [SetLike S R]
     [NonUnitalSubringClass S R] (s : S) : NonUnitalRing s :=
+  fast_instance%
   Subtype.val_injective.nonUnitalRing _ rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 
@@ -108,6 +110,7 @@ instance (priority := 75) toNonUnitalRing {R : Type*} [NonUnitalRing R] [SetLike
 /-- A non-unital subring of a `NonUnitalCommRing` is a `NonUnitalCommRing`. -/
 instance (priority := 75) toNonUnitalCommRing {R} [NonUnitalCommRing R] [SetLike S R]
     [NonUnitalSubringClass S R] : NonUnitalCommRing s :=
+  fast_instance%
   Subtype.val_injective.nonUnitalCommRing _ rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -303,6 +303,7 @@ protected theorem sum_mem {R : Type*} [NonUnitalNonAssocRing R] (s : NonUnitalSu
 /-- A non-unital subring of a non-unital ring inherits a non-unital ring structure -/
 instance toNonUnitalRing {R : Type*} [NonUnitalRing R] (s : NonUnitalSubring R) :
     NonUnitalRing s :=
+  fast_instance%
   Subtype.coe_injective.nonUnitalRing _ rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 
@@ -331,6 +332,7 @@ theorem coe_eq_zero_iff {x : s} : (x : R) = 0 ↔ x = 0 := by
 /-- A non-unital subring of a `NonUnitalCommRing` is a `NonUnitalCommRing`. -/
 instance toNonUnitalCommRing {R} [NonUnitalCommRing R] (s : NonUnitalSubring R) :
     NonUnitalCommRing s :=
+  fast_instance%
   Subtype.coe_injective.nonUnitalCommRing _ rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
@@ -52,6 +52,7 @@ open AddSubmonoidClass
 /-- A non-unital subsemiring of a `NonUnitalNonAssocSemiring` inherits a
 `NonUnitalNonAssocSemiring` structure -/
 instance (priority := 75) toNonUnitalNonAssocSemiring : NonUnitalNonAssocSemiring s :=
+  fast_instance%
   Subtype.coe_injective.nonUnitalNonAssocSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
 #align non_unital_subsemiring_class.to_non_unital_non_assoc_semiring NonUnitalSubsemiringClass.toNonUnitalNonAssocSemiring
 
@@ -73,12 +74,14 @@ theorem coeSubtype : (subtype s : s → R) = ((↑) : s → R) :=
 /-- A non-unital subsemiring of a `NonUnitalSemiring` is a `NonUnitalSemiring`. -/
 instance toNonUnitalSemiring {R} [NonUnitalSemiring R] [SetLike S R]
     [NonUnitalSubsemiringClass S R] : NonUnitalSemiring s :=
+  fast_instance%
   Subtype.coe_injective.nonUnitalSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
 #align non_unital_subsemiring_class.to_non_unital_semiring NonUnitalSubsemiringClass.toNonUnitalSemiring
 
 /-- A non-unital subsemiring of a `NonUnitalCommSemiring` is a `NonUnitalCommSemiring`. -/
 instance toNonUnitalCommSemiring {R} [NonUnitalCommSemiring R] [SetLike S R]
     [NonUnitalSubsemiringClass S R] : NonUnitalCommSemiring s :=
+  fast_instance%
   Subtype.coe_injective.nonUnitalCommSemiring (↑) rfl (by simp) (fun _ _ => rfl) fun _ _ => rfl
 #align non_unital_subsemiring_class.to_non_unital_comm_semiring NonUnitalSubsemiringClass.toNonUnitalCommSemiring
 

--- a/Mathlib/RingTheory/Subring/Basic.lean
+++ b/Mathlib/RingTheory/Subring/Basic.lean
@@ -99,6 +99,7 @@ instance (priority := 75) toHasIntCast : IntCast s :=
 -- Prefer subclasses of `Ring` over subclasses of `SubringClass`.
 /-- A subring of a ring inherits a ring structure -/
 instance (priority := 75) toRing : Ring s :=
+  fast_instance%
   Subtype.coe_injective.ring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) fun _ => rfl
 #align subring_class.to_ring SubringClass.toRing
@@ -107,6 +108,7 @@ instance (priority := 75) toRing : Ring s :=
 /-- A subring of a `CommRing` is a `CommRing`. -/
 instance (priority := 75) toCommRing {R} [CommRing R] [SetLike S R] [SubringClass S R] :
     CommRing s :=
+  fast_instance%
   Subtype.coe_injective.commRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) fun _ => rfl
 #align subring_class.to_comm_ring SubringClass.toCommRing
@@ -766,6 +768,7 @@ section DivisionRing
 variable {K : Type u} [DivisionRing K]
 
 instance : Field (center K) :=
+  fast_instance%
   { inferInstanceAs (CommRing (center K)) with
     inv := fun a => ⟨a⁻¹, Set.inv_mem_center₀ a.prop⟩
     mul_inv_cancel := fun ⟨a, ha⟩ h => Subtype.ext <| mul_inv_cancel <| Subtype.coe_injective.ne h

--- a/Mathlib/RingTheory/Subring/Order.lean
+++ b/Mathlib/RingTheory/Subring/Order.lean
@@ -27,6 +27,7 @@ variable {R S : Type*} [SetLike S R] (s : S)
 /-- A subring of an `OrderedRing` is an `OrderedRing`. -/
 instance (priority := 75) toOrderedRing [OrderedRing R] [SubringClass S R] :
     OrderedRing s :=
+  fast_instance%
   Subtype.coe_injective.orderedRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) fun _ => rfl
 #align subring_class.to_ordered_ring SubringClass.toOrderedRing
@@ -35,6 +36,7 @@ instance (priority := 75) toOrderedRing [OrderedRing R] [SubringClass S R] :
 /-- A subring of an `OrderedCommRing` is an `OrderedCommRing`. -/
 instance (priority := 75) toOrderedCommRing [OrderedCommRing R] [SubringClass S R] :
     OrderedCommRing s :=
+  fast_instance%
   Subtype.coe_injective.orderedCommRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) fun _ => rfl
 #align subring_class.to_ordered_comm_ring SubringClass.toOrderedCommRing
@@ -43,6 +45,7 @@ instance (priority := 75) toOrderedCommRing [OrderedCommRing R] [SubringClass S 
 /-- A subring of a `LinearOrderedRing` is a `LinearOrderedRing`. -/
 instance (priority := 75) toLinearOrderedRing [LinearOrderedRing R] [SubringClass S R] :
     LinearOrderedRing s :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
@@ -52,6 +55,7 @@ instance (priority := 75) toLinearOrderedRing [LinearOrderedRing R] [SubringClas
 /-- A subring of a `LinearOrderedCommRing` is a `LinearOrderedCommRing`. -/
 instance (priority := 75) toLinearOrderedCommRing [LinearOrderedCommRing R] [SubringClass S R] :
     LinearOrderedCommRing s :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedCommRing (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl

--- a/Mathlib/RingTheory/Subsemiring/Basic.lean
+++ b/Mathlib/RingTheory/Subsemiring/Basic.lean
@@ -87,6 +87,7 @@ namespace SubsemiringClass
 -- Prefer subclasses of `NonAssocSemiring` over subclasses of `SubsemiringClass`.
 /-- A subsemiring of a `NonAssocSemiring` inherits a `NonAssocSemiring` structure -/
 instance (priority := 75) toNonAssocSemiring : NonAssocSemiring s :=
+  fast_instance%
   Subtype.coe_injective.nonAssocSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ => rfl
 #align subsemiring_class.to_non_assoc_semiring SubsemiringClass.toNonAssocSemiring
@@ -113,6 +114,7 @@ theorem coe_subtype : (subtype s : s → R) = ((↑) : s → R) :=
 /-- A subsemiring of a `Semiring` is a `Semiring`. -/
 instance (priority := 75) toSemiring {R} [Semiring R] [SetLike S R] [SubsemiringClass S R] :
     Semiring s :=
+  fast_instance%
   Subtype.coe_injective.semiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ => rfl
 #align subsemiring_class.to_semiring SubsemiringClass.toSemiring
@@ -128,6 +130,7 @@ theorem coe_pow {R} [Semiring R] [SetLike S R] [SubsemiringClass S R] (x : s) (n
 /-- A subsemiring of a `CommSemiring` is a `CommSemiring`. -/
 instance toCommSemiring {R} [CommSemiring R] [SetLike S R] [SubsemiringClass S R] :
     CommSemiring s :=
+  fast_instance%
   Subtype.coe_injective.commSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ => rfl
 #align subsemiring_class.to_comm_semiring SubsemiringClass.toCommSemiring

--- a/Mathlib/RingTheory/Subsemiring/Order.lean
+++ b/Mathlib/RingTheory/Subsemiring/Order.lean
@@ -18,6 +18,7 @@ variable {R S : Type*} [SetLike S R] (s : S)
 /-- A subsemiring of an `OrderedSemiring` is an `OrderedSemiring`. -/
 instance toOrderedSemiring [OrderedSemiring R] [SubsemiringClass S R] :
     OrderedSemiring s :=
+  fast_instance%
   Subtype.coe_injective.orderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 #align subsemiring_class.to_ordered_semiring SubsemiringClass.toOrderedSemiring
@@ -25,6 +26,7 @@ instance toOrderedSemiring [OrderedSemiring R] [SubsemiringClass S R] :
 /-- A subsemiring of a `StrictOrderedSemiring` is a `StrictOrderedSemiring`. -/
 instance toStrictOrderedSemiring [StrictOrderedSemiring R] [SetLike S R]
     [SubsemiringClass S R] : StrictOrderedSemiring s :=
+  fast_instance%
   Subtype.coe_injective.strictOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 #align subsemiring_class.to_strict_ordered_semiring SubsemiringClass.toStrictOrderedSemiring
@@ -32,6 +34,7 @@ instance toStrictOrderedSemiring [StrictOrderedSemiring R] [SetLike S R]
 /-- A subsemiring of an `OrderedCommSemiring` is an `OrderedCommSemiring`. -/
 instance toOrderedCommSemiring [OrderedCommSemiring R] [SetLike S R] [SubsemiringClass S R] :
     OrderedCommSemiring s :=
+  fast_instance%
   Subtype.coe_injective.orderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 #align subsemiring_class.to_ordered_comm_semiring SubsemiringClass.toOrderedCommSemiring
@@ -39,6 +42,7 @@ instance toOrderedCommSemiring [OrderedCommSemiring R] [SetLike S R] [Subsemirin
 /-- A subsemiring of a `StrictOrderedCommSemiring` is a `StrictOrderedCommSemiring`. -/
 instance toStrictOrderedCommSemiring [StrictOrderedCommSemiring R] [SetLike S R]
     [SubsemiringClass S R] : StrictOrderedCommSemiring s :=
+  fast_instance%
   Subtype.coe_injective.strictOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 #align subsemiring_class.to_strict_ordered_comm_semiring SubsemiringClass.toStrictOrderedCommSemiring
@@ -46,6 +50,7 @@ instance toStrictOrderedCommSemiring [StrictOrderedCommSemiring R] [SetLike S R]
 /-- A subsemiring of a `LinearOrderedSemiring` is a `LinearOrderedSemiring`. -/
 instance toLinearOrderedSemiring [LinearOrderedSemiring R] [SetLike S R]
     [SubsemiringClass S R] : LinearOrderedSemiring s :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 #align subsemiring_class.to_linear_ordered_semiring SubsemiringClass.toLinearOrderedSemiring
@@ -53,6 +58,7 @@ instance toLinearOrderedSemiring [LinearOrderedSemiring R] [SetLike S R]
 /-- A subsemiring of a `LinearOrderedCommSemiring` is a `LinearOrderedCommSemiring`. -/
 instance toLinearOrderedCommSemiring [LinearOrderedCommSemiring R] [SetLike S R]
     [SubsemiringClass S R] : LinearOrderedCommSemiring s :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 #align subsemiring_class.to_linear_ordered_comm_semiring SubsemiringClass.toLinearOrderedCommSemiring
@@ -65,6 +71,7 @@ variable {R : Type*}
 
 /-- A subsemiring of an `OrderedSemiring` is an `OrderedSemiring`. -/
 instance toOrderedSemiring [OrderedSemiring R] (s : Subsemiring R) : OrderedSemiring s :=
+  fast_instance%
   Subtype.coe_injective.orderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 #align subsemiring.to_ordered_semiring Subsemiring.toOrderedSemiring
@@ -72,6 +79,7 @@ instance toOrderedSemiring [OrderedSemiring R] (s : Subsemiring R) : OrderedSemi
 /-- A subsemiring of a `StrictOrderedSemiring` is a `StrictOrderedSemiring`. -/
 instance toStrictOrderedSemiring [StrictOrderedSemiring R] (s : Subsemiring R) :
     StrictOrderedSemiring s :=
+  fast_instance%
   Subtype.coe_injective.strictOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 #align subsemiring.to_strict_ordered_semiring Subsemiring.toStrictOrderedSemiring
@@ -79,6 +87,7 @@ instance toStrictOrderedSemiring [StrictOrderedSemiring R] (s : Subsemiring R) :
 /-- A subsemiring of an `OrderedCommSemiring` is an `OrderedCommSemiring`. -/
 instance toOrderedCommSemiring [OrderedCommSemiring R] (s : Subsemiring R) :
     OrderedCommSemiring s :=
+  fast_instance%
   Subtype.coe_injective.orderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 #align subsemiring.to_ordered_comm_semiring Subsemiring.toOrderedCommSemiring
@@ -86,6 +95,7 @@ instance toOrderedCommSemiring [OrderedCommSemiring R] (s : Subsemiring R) :
 /-- A subsemiring of a `StrictOrderedCommSemiring` is a `StrictOrderedCommSemiring`. -/
 instance toStrictOrderedCommSemiring [StrictOrderedCommSemiring R] (s : Subsemiring R) :
     StrictOrderedCommSemiring s :=
+  fast_instance%
   Subtype.coe_injective.strictOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 #align subsemiring.to_strict_ordered_comm_semiring Subsemiring.toStrictOrderedCommSemiring
@@ -93,6 +103,7 @@ instance toStrictOrderedCommSemiring [StrictOrderedCommSemiring R] (s : Subsemir
 /-- A subsemiring of a `LinearOrderedSemiring` is a `LinearOrderedSemiring`. -/
 instance toLinearOrderedSemiring [LinearOrderedSemiring R] (s : Subsemiring R) :
     LinearOrderedSemiring s :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 #align subsemiring.to_linear_ordered_semiring Subsemiring.toLinearOrderedSemiring
@@ -100,6 +111,7 @@ instance toLinearOrderedSemiring [LinearOrderedSemiring R] (s : Subsemiring R) :
 /-- A subsemiring of a `LinearOrderedCommSemiring` is a `LinearOrderedCommSemiring`. -/
 instance toLinearOrderedCommSemiring [LinearOrderedCommSemiring R] (s : Subsemiring R) :
     LinearOrderedCommSemiring s :=
+  fast_instance%
   Subtype.coe_injective.linearOrderedCommSemiring (↑) rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl) fun _ _ => rfl
 #align subsemiring.to_linear_ordered_comm_semiring Subsemiring.toLinearOrderedCommSemiring

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -51,6 +51,7 @@ import Mathlib.Tactic.Explode.Pretty
 import Mathlib.Tactic.ExtendDoc
 import Mathlib.Tactic.ExtractGoal
 import Mathlib.Tactic.ExtractLets
+import Mathlib.Tactic.FastInstance
 import Mathlib.Tactic.FBinop
 import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.FieldSimp

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -51,9 +51,9 @@ import Mathlib.Tactic.Explode.Pretty
 import Mathlib.Tactic.ExtendDoc
 import Mathlib.Tactic.ExtractGoal
 import Mathlib.Tactic.ExtractLets
-import Mathlib.Tactic.FastInstance
 import Mathlib.Tactic.FBinop
 import Mathlib.Tactic.FailIfNoProgress
+import Mathlib.Tactic.FastInstance
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Find

--- a/Mathlib/Tactic/FastInstance.lean
+++ b/Mathlib/Tactic/FastInstance.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieserf
 -/
 
-import Lean.Elab
+import Lean.Elab.ComputedFields
+import Lean.Meta.Tactic.ElimInfo
 
 /-!
 # The `fast_instance%` term elaborator

--- a/Mathlib/Tactic/FastInstance.lean
+++ b/Mathlib/Tactic/FastInstance.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2024 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+
+import Lean.Elab
+
+open Lean Meta
+
+elab "fast_instance%" arg:term : term <= expectedType => do
+  let .some className ← Lean.Meta.isClass? expectedType |
+    throwError "Can only be used for classes"
+  let ctor := Lean.getStructureCtor (← getEnv) className
+  let provided ← Lean.Elab.Term.elabTerm arg (some expectedType)
+  -- create universe variables
+  let levels ← Meta.mkFreshLevelMVarsFor (.ctorInfo ctor)
+  let mut e := Expr.const ctor.name levels
+  -- get argument types
+  let (mvars, binders, _body_) ← forallMetaTelescope (←inferType e)
+  e := mkAppN e mvars
+  guard (← isDefEq (←inferType e) expectedType)
+  e ← instantiateMVars e
+  -- substitute parent classes with direct instances, if possible
+  for arg in mvars.extract ctor.numParams (ctor.numParams + ctor.numFields),
+      bi in binders.extract ctor.numParams (ctor.numParams + ctor.numFields) do
+    if let .instImplicit := bi then
+      if let .some new_arg ← trySynthInstance (←inferType arg) then
+        arg.mvarId!.assign new_arg
+  -- must be defeq to what the user passed
+  if !(← isDefEq provided e) then
+    Lean.logError "Not defeq"
+  pure e

--- a/Mathlib/Tactic/FastInstance.lean
+++ b/Mathlib/Tactic/FastInstance.lean
@@ -57,11 +57,20 @@ private partial def makeFastInstance (provided : Expr) : MetaM Expr := do
     return provided
   pure e
 
+/-- `fast_instance% inst` takes an expression for a typeclass instance `inst`, and unfolds it into
+constructor applications that leverage existing instances.
+
+For instance, when used as
+```lean
+instance instSemiring : Semiring X := sorry
+instance instRing : Ring X := fast_instance% Function.Injective.ring ..
+```
+this will define `instRing` as a nested constructor application that refers to `instSemiring`.
+The advantage is then that `instRing.toSemiring` unifies almost immediately with `instSemiring`,
+rather than having to break it down into smaller pieces. -/
 syntax (name := fastInstance) "fast_instance%" term : term
 
-/-- This elaborator can improve performance when inserted before uses of `Function.Injective.ring`
-etc. -/
-@[term_elab fastInstance]
+@[term_elab fastInstance, inherit_doc fastInstance]
 def elabFastInstance : Elab.Term.TermElab
   | `(term| fast_instance% $arg), expectedType => do
     -- passthrough the term

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -308,6 +308,8 @@
   "Mathlib.Init.Data.Nat.GCD": ["Std.Data.Nat.Gcd"],
   "Mathlib.Init.Data.Int.Basic": ["Std.Data.Int.Order"],
   "Mathlib.Init.Core": ["Std.Classes.Dvd"],
+  "Mathlib.GroupTheory.Subsemigroup.Operations":
+  ["Mathlib.Tactic.FastInstance"],
   "Mathlib.GroupTheory.Subgroup.Order": ["Mathlib.GroupTheory.Submonoid.Order"],
   "Mathlib.Geometry.Manifold.Sheaf.Smooth":
   ["Mathlib.CategoryTheory.Sites.Whiskering"],

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -313,6 +313,7 @@
   "Mathlib.GroupTheory.Subgroup.Order": ["Mathlib.GroupTheory.Submonoid.Order"],
   "Mathlib.Geometry.Manifold.Sheaf.Smooth":
   ["Mathlib.CategoryTheory.Sites.Whiskering"],
+  "Mathlib.FieldTheory.Subfield.Order": ["Mathlib.Algebra.Order.Field.InjSurj"],
   "Mathlib.Data.Vector.Basic": ["Mathlib.Control.Applicative"],
   "Mathlib.Data.Rat.Init": ["Std.Data.Rat.Basic"],
   "Mathlib.Data.Multiset.Bind": ["Mathlib.GroupTheory.GroupAction.Defs"],
@@ -329,6 +330,9 @@
   "Mathlib.Algebra.Ring.CentroidHom": ["Mathlib.Algebra.Algebra.Basic"],
   "Mathlib.Algebra.Order.Ring.Defs":
   ["Mathlib.Algebra.Order.Monoid.WithZero.Defs"],
+  "Mathlib.Algebra.Order.Positive.Ring": ["Mathlib.Tactic.FastInstance"],
+  "Mathlib.Algebra.Order.Nonneg.Ring": ["Mathlib.Tactic.FastInstance"],
+  "Mathlib.Algebra.Order.Nonneg.Field": ["Mathlib.Algebra.Order.Field.InjSurj"],
   "Mathlib.Algebra.Module.Submodule.Order":
   ["Mathlib.GroupTheory.Subgroup.Order", "Mathlib.GroupTheory.Submonoid.Order"],
   "Mathlib.Algebra.Module.LinearMap.Basic": ["Mathlib.Algebra.Star.Basic"],

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -319,6 +319,7 @@
   "Mathlib.Data.Multiset.Bind": ["Mathlib.GroupTheory.GroupAction.Defs"],
   "Mathlib.Data.List.EditDistance.Defs": ["Mathlib.Data.Nat.Basic"],
   "Mathlib.Data.List.Basic": ["Mathlib.Data.Option.Basic", "Mathlib.Init.Core"],
+  "Mathlib.Data.Finsupp.Defs": ["Mathlib.Tactic.FastInstance"],
   "Mathlib.Data.Finset.Basic": ["Mathlib.Data.Finset.Attr"],
   "Mathlib.Control.Traversable.Instances": ["Mathlib.Control.Applicative"],
   "Mathlib.Control.Monad.Basic": ["Mathlib.Init.Control.Lawful"],

--- a/test/fast_instance.lean
+++ b/test/fast_instance.lean
@@ -1,0 +1,36 @@
+import Mathlib.Tactic.FastInstance
+import Mathlib.Algebra.Group.InjSurj
+
+variable (α : Type*)
+
+structure Wrapped where
+  val : α
+
+theorem val_injective : Function.Injective (Wrapped.val (α := α)) :=
+  fun ⟨_⟩ ⟨_⟩ h => congr_arg _ h
+
+instance [Zero α] : Zero (Wrapped α) where zero := ⟨0⟩
+
+instance [Add α] : Add (Wrapped α) where add m n := ⟨m.1 + n.1⟩
+
+instance instAddSemigroup [AddSemigroup α] : AddSemigroup (Wrapped α) :=
+  fast_instance% Function.Injective.addSemigroup _ (val_injective _) (fun _ _ => rfl)
+
+instance instAddCommSemigroup [AddCommSemigroup α] : AddCommSemigroup (Wrapped α) :=
+  fast_instance% Function.Injective.addCommSemigroup _ (val_injective _) (fun _ _ => rfl)
+
+/--
+info: def instAddSemigroup.{u_1} : (α : Type u_1) → [inst : AddSemigroup α] → AddSemigroup (Wrapped α) :=
+fun α [inst : AddSemigroup α] => @AddSemigroup.mk (Wrapped α) (@instAddWrapped α (@AddSemigroup.toAdd α inst)) ⋯
+-/
+#guard_msgs in
+set_option pp.explicit true in
+#print instAddSemigroup
+/--
+info: def instAddCommSemigroup.{u_1} : (α : Type u_1) → [inst : AddCommSemigroup α] → AddCommSemigroup (Wrapped α) :=
+fun α [inst : AddCommSemigroup α] =>
+  @AddCommSemigroup.mk (Wrapped α) (@instAddSemigroup α (@AddCommSemigroup.toAddSemigroup α inst)) ⋯
+-/
+#guard_msgs in
+set_option pp.explicit true in
+#print instAddCommSemigroup


### PR DESCRIPTION
Lean can figure these out and if inferred instance of `Mul` (or `Add`) contains non-reducible terms, it will block unification.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [ ] depends on: #11521

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
