### PR TITLE
[Merged by Bors] - feat(Mathlib/LinearAlgebra/DirectSum/Finsupp): tensor products of finsupp sums

### DIFF
--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl
+Authors: Johannes Hölzl, Antoine Chambert-Loir
 -/
 import Mathlib.Algebra.DirectSum.Finsupp
 import Mathlib.LinearAlgebra.Finsupp
@@ -12,20 +12,264 @@ import Mathlib.LinearAlgebra.DirectSum.TensorProduct
 /-!
 # Results on finitely supported functions.
 
-The tensor product of `ι →₀ M` and `κ →₀ N` is linearly equivalent to `(ι × κ) →₀ (M ⊗ N)`.
+* `TensorProduct.finsuppLeft`, the tensor product of `ι →₀ M` and `N`
+  is linearly equivalent to `ι →₀ M ⊗[R] N`
+
+* `TensorProduct.finsuppScalarLeft`, the tensor product of `ι →₀ R` and `N`
+  is linearly equivalent to `ι →₀ N`
+
+* `TensorProduct.finsuppRight`, the tensor product of `M` and `ι →₀ N`
+  is linearly equivalent to `ι →₀ M ⊗[R] N`
+
+* `TensorProduct.finsuppScalarRight`, the tensor product of `M` and `ι →₀ R`
+  is linearly equivalent to `ι →₀ N`
+
+
+* `TensorProduct.finsuppLeft'`, if `M` is an `S`-module,
+  then the tensor product of `ι →₀ M` and `N` is `S`-linearly equivalent
+  to `ι →₀ M ⊗[R] N`
+
+* `finsuppTensorFinsupp`, the tensor product of `ι →₀ M` and `κ →₀ N`
+  is linearly equivalent to `(ι × κ) →₀ (M ⊗ N)`.
+
+## Case of MvPolynomial
+
+These functions apply to `MvPolynomial`, one can define
+```
+noncomputable def MvPolynomial.rTensor' :
+    MvPolynomial σ S ⊗[R] N ≃ₗ[S] (σ →₀ ℕ) →₀ (S ⊗[R] N) :=
+  TensorProduct.finsuppLeft'
+
+noncomputable def MvPolynomial.rTensor :
+    MvPolynomial σ R ⊗[R] N ≃ₗ[R] (σ →₀ ℕ) →₀ N :=
+  TensorProduct.finsuppScalarLeft
+ ```
+
+## Case of `Polynomial`
+
+`Polynomial` is a structure containing a `Finsupp`, so these functions
+can't be applied directly to `Polynomial`.
+
+Some linear equivs need to be added to mathlib for that.
+
+## TODO
+
+* generalize to `MonoidAlgebra`, `AlgHom `
+
+* reprove `TensorProduct.finsuppLeft'` using existing heterobasic version of `TensorProduct.congr`
 -/
 
 
 noncomputable section
 
-open DirectSum Set LinearMap Submodule TensorProduct
+open DirectSum TensorProduct
+
+open Set LinearMap Submodule
+
+section TensorProduct
+
+variable {R : Type*} [CommSemiring R]
+  {M : Type*} [AddCommMonoid M] [Module R M]
+  {N : Type*} [AddCommMonoid N] [Module R N]
+
+namespace TensorProduct
+
+variable {ι : Type*} [DecidableEq ι]
+
+/-- The tensor product of `ι →₀ M` and `N` is linearly equivalent to `ι →₀ M ⊗[R] N` -/
+noncomputable def finsuppLeft :
+    (ι →₀ M) ⊗[R] N ≃ₗ[R] ι →₀ (M ⊗[R] N) :=
+  (congr (finsuppLEquivDirectSum R M ι) (LinearEquiv.refl R N)).trans
+    ((directSumLeft R (fun _ : ι => M) N).trans
+      (finsuppLEquivDirectSum R (M ⊗[R] N) ι).symm)
+
+lemma finsuppLeft_apply_tmul (p : ι →₀ M) (n : N) :
+    finsuppLeft (p ⊗ₜ[R] n) = p.sum (fun i m ↦ Finsupp.single i (m ⊗ₜ[R] n)) := by
+  simp only [finsuppLeft, LinearEquiv.trans_apply, congr_tmul, LinearEquiv.refl_apply]
+  conv_lhs => rw [← Finsupp.sum_single p]
+  rw [LinearEquiv.symm_apply_eq]
+  simp only [map_finsupp_sum]
+  simp only [finsuppLEquivDirectSum_single]
+  rw [← LinearEquiv.eq_symm_apply]
+  simp only [map_finsupp_sum]
+  simp only [directSumLeft_symm_lof_tmul]
+  simp only [Finsupp.sum, sum_tmul]
+
+lemma finsuppLeft_apply_tmul_apply (p : ι →₀ M) (n : N) (i : ι) :
+    finsuppLeft (p ⊗ₜ[R] n) i = p i ⊗ₜ[R] n := by
+  rw [finsuppLeft_apply_tmul]
+  simp only [Finsupp.sum_apply]
+  conv_rhs => rw [← Finsupp.single_eq_same (a := i) (b := p i ⊗ₜ[R] n)]
+  apply Finsupp.sum_eq_single i
+  · exact fun _ _ ↦ Finsupp.single_eq_of_ne
+  · intro _
+    simp
+
+theorem finsuppLeft_apply (t : (ι →₀ M) ⊗[R] N) (i : ι) :
+    (finsuppLeft t) i = (rTensor N (Finsupp.lapply i)) t := by
+  induction t using TensorProduct.induction_on with
+  | zero => simp
+  | tmul f n => simp [finsuppLeft_apply_tmul_apply]
+  | add x y hx hy => simp [LinearEquiv.map_add, hx, hy]
+
+lemma finsuppLeft_symm_apply_single (i : ι) (m : M) (n : N) :
+    finsuppLeft.symm (Finsupp.single i (m ⊗ₜ[R] n)) =
+      Finsupp.single i m ⊗ₜ[R] n := by
+  simp [finsuppLeft, Finsupp.lsum]
+
+/-- The tensor product of `M` and `ι →₀ N` is linearly equivalent to `ι →₀ M ⊗[R] N` -/
+noncomputable def finsuppRight :
+    M ⊗[R] (ι →₀ N) ≃ₗ[R] ι →₀ (M ⊗[R] N) :=
+  (congr (LinearEquiv.refl R M) (finsuppLEquivDirectSum R N ι)).trans
+    ((directSumRight R M (fun _ : ι => N)).trans
+      (finsuppLEquivDirectSum R (M ⊗[R] N) ι).symm)
+
+lemma finsuppRight_apply_tmul (m : M) (p : ι →₀ N) :
+    finsuppRight (m ⊗ₜ[R] p) = p.sum (fun i n ↦ Finsupp.single i (m ⊗ₜ[R] n)) := by
+  simp [finsuppRight]
+  conv_lhs => rw [← Finsupp.sum_single p]
+  rw [LinearEquiv.symm_apply_eq]
+  simp only [map_finsupp_sum]
+  simp only [finsuppLEquivDirectSum_single]
+  rw [← LinearEquiv.eq_symm_apply]
+  simp only [map_finsupp_sum]
+  simp only [directSumRight_symm_lof_tmul]
+  simp only [Finsupp.sum, tmul_sum]
+
+lemma finsuppRight_apply_tmul_apply (m : M) (p : ι →₀ N) (i : ι) :
+    finsuppRight (m ⊗ₜ[R] p) i = m ⊗ₜ[R] p i := by
+  rw [finsuppRight_apply_tmul]
+  simp only [Finsupp.sum_apply]
+  conv_rhs => rw [← Finsupp.single_eq_same (a := i) (b := m ⊗ₜ[R] p i)]
+  apply Finsupp.sum_eq_single i
+  · exact fun _ _ ↦ Finsupp.single_eq_of_ne
+  · intro _
+    simp
+
+theorem finsuppRight_apply (t : M ⊗[R] (ι →₀ N)) (i : ι) :
+    (finsuppRight t) i = (lTensor M (Finsupp.lapply i)) t := by
+  induction t using TensorProduct.induction_on with
+  | zero => simp
+  | tmul m f => simp [finsuppRight_apply_tmul_apply]
+  | add x y hx hy => simp [LinearEquiv.map_add, hx, hy]
+
+lemma finsuppRight_symm_apply_single (i : ι) (m : M) (n : N) :
+    finsuppRight.symm (Finsupp.single i (m ⊗ₜ[R] n)) =
+      m ⊗ₜ[R] Finsupp.single i n := by
+  simp [finsuppRight, Finsupp.lsum]
+
+variable {S : Type*} [CommSemiring S] [Algebra R S]
+  [Module S M] [IsScalarTower R S M]
+
+lemma finsuppLeft_smul' (s : S) (t : (ι →₀ M) ⊗[R] N) :
+    finsuppLeft (s • t) = s • finsuppLeft t := by
+  induction t using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy =>
+    simp only [AddHom.toFun_eq_coe, coe_toAddHom, LinearEquiv.coe_coe, RingHom.id_apply] at hx hy ⊢
+    simp only [smul_add, map_add, hx, hy]
+  | tmul p n =>
+    simp only [smul_tmul', finsuppLeft_apply_tmul]
+    rw [Finsupp.smul_sum]
+    simp only [Finsupp.smul_single]
+    apply Finsupp.sum_smul_index'
+    simp
+
+/-- When `M` is also an `S`-module, then `TensorProduct.finsuppLeft R M N``
+  is an `S`-linear equiv -/
+noncomputable def finsuppLeft' :
+    (ι →₀ M) ⊗[R] N ≃ₗ[S] ι →₀ (M ⊗[R] N) := {
+  finsuppLeft with
+  map_smul' := finsuppLeft_smul' }
+
+lemma finsuppLeft'_apply (x : (ι →₀ M) ⊗[R] N) :
+    finsuppLeft' (S := S) x = finsuppLeft x := rfl
+
+/- -- TODO : reprove using the existing heterobasic lemmas
+noncomputable example :
+    (ι →₀ M) ⊗[R] N ≃ₗ[S] ι →₀ (M ⊗[R] N) := by
+  have f : (⨁ (i₁ : ι), M) ⊗[R] N ≃ₗ[S] ⨁ (i : ι), M ⊗[R] N := sorry
+  exact (AlgebraTensorModule.congr
+    (finsuppLEquivDirectSum S M ι) (LinearEquiv.refl R N)).trans
+    (f.trans (finsuppLEquivDirectSum S (M ⊗[R] N) ι).symm) -/
+
+/-- The tensor product of `ι →₀ R` and `N` is linearly equivalent to `ι →₀ N` -/
+noncomputable def finsuppScalarLeft :
+    (ι →₀ R) ⊗[R] N ≃ₗ[R] ι →₀ N :=
+  finsuppLeft.trans (Finsupp.mapRange.linearEquiv (TensorProduct.lid R N))
+
+lemma finsuppScalarLeft_apply_tmul_apply (p : ι →₀ R) (n : N) (i : ι) :
+    finsuppScalarLeft (p ⊗ₜ[R] n) i = (p i) • n := by
+  simp only [finsuppScalarLeft, LinearEquiv.trans_apply, finsuppLeft_apply_tmul,
+    Finsupp.mapRange.linearEquiv_apply, Finsupp.mapRange.linearMap_apply, LinearEquiv.coe_coe,
+    Finsupp.mapRange_apply, Finsupp.sum_apply]
+  apply symm
+  rw [← LinearEquiv.symm_apply_eq, lid_symm_apply]
+  rw [Finsupp.sum_eq_single i (fun _ _ => Finsupp.single_eq_of_ne) (fun _ => by simp)]
+  simp only [Finsupp.single_eq_same]
+  rw [tmul_smul, smul_tmul', smul_eq_mul, mul_one]
+
+lemma finsuppScalarLeft_apply_tmul (p : ι →₀ R) (n : N) :
+    finsuppScalarLeft (p ⊗ₜ[R] n) = p.sum (fun i m ↦ Finsupp.single i (m • n)) := by
+  ext i
+  rw [finsuppScalarLeft_apply_tmul_apply]
+  simp only [Finsupp.sum_apply]
+  rw [Finsupp.sum_eq_single i (fun _ _ => Finsupp.single_eq_of_ne) (fun _ => by simp)]
+  simp only [Finsupp.single_eq_same]
+
+lemma finsuppScalarLeft_apply (pn : (ι →₀ R) ⊗[R] N) (i : ι) :
+    finsuppScalarLeft pn i = TensorProduct.lid R N ((Finsupp.lapply i).rTensor N pn) := by
+  simp [finsuppScalarLeft, finsuppLeft_apply]
+
+lemma finsuppScalarLeft_symm_apply_single (i : ι) (n : N) :
+    finsuppScalarLeft.symm (Finsupp.single i n) =
+      (Finsupp.single i 1) ⊗ₜ[R] n := by
+  simp [finsuppScalarLeft, finsuppLeft_symm_apply_single]
+
+/-- The tensor product of `M` and `ι →₀ R` is linearly equivalent to `ι →₀ N` -/
+noncomputable def finsuppScalarRight :
+    M ⊗[R] (ι →₀ R) ≃ₗ[R] ι →₀ M :=
+  finsuppRight.trans (Finsupp.mapRange.linearEquiv (TensorProduct.rid R M))
+
+lemma finsuppScalarRight_apply_tmul_apply (m : M) (p : ι →₀ R) (i : ι) :
+    finsuppScalarRight (m ⊗ₜ[R] p) i = (p i) • m := by
+  simp only [finsuppScalarRight, LinearEquiv.trans_apply, finsuppRight_apply_tmul,
+    Finsupp.mapRange.linearEquiv_apply, Finsupp.mapRange.linearMap_apply, LinearEquiv.coe_coe,
+    Finsupp.mapRange_apply, Finsupp.sum_apply]
+  apply symm
+  rw [← LinearEquiv.symm_apply_eq, rid_symm_apply]
+  rw [Finsupp.sum_eq_single i (fun _ _ => Finsupp.single_eq_of_ne) (fun _ => by simp)]
+  simp only [Finsupp.single_eq_same]
+  rw [smul_tmul, smul_eq_mul, mul_one]
+
+lemma finsuppScalarRight_apply_tmul (m : M) (p : ι →₀ R) :
+    finsuppScalarRight (m ⊗ₜ[R] p) = p.sum (fun i n ↦ Finsupp.single i (n • m)) := by
+  ext i
+  rw [finsuppScalarRight_apply_tmul_apply]
+  simp only [Finsupp.sum_apply]
+  rw [Finsupp.sum_eq_single i (fun _ _ => Finsupp.single_eq_of_ne) (fun _ => by simp)]
+  simp only [Finsupp.single_eq_same]
+
+lemma finsuppScalarRight_apply (t : M ⊗[R] (ι →₀ R)) (i : ι) :
+    finsuppScalarRight t i = TensorProduct.rid R M ((Finsupp.lapply i).lTensor M t) := by
+  simp [finsuppScalarRight, finsuppRight_apply]
+
+lemma finsuppScalarRight_symm_apply_single (i : ι) (m : M) :
+    finsuppScalarRight.symm (Finsupp.single i m) =
+      m ⊗ₜ[R] (Finsupp.single i 1) := by
+  simp [finsuppScalarRight, finsuppRight_symm_apply_single]
+
+end TensorProduct
+
+end TensorProduct
 
 variable (R M N ι κ : Type*)
   [CommSemiring R] [AddCommMonoid M] [Module R M] [AddCommMonoid N] [Module R N]
 
 open scoped Classical in
 /-- The tensor product of `ι →₀ M` and `κ →₀ N` is linearly equivalent to `(ι × κ) →₀ (M ⊗ N)`. -/
-def finsuppTensorFinsupp : (ι →₀ M) ⊗[R] (κ →₀ N) ≃ₗ[R] ι × κ →₀ M ⊗[R] N :=
+noncomputable def finsuppTensorFinsupp :
+    (ι →₀ M) ⊗[R] (κ →₀ N) ≃ₗ[R] ι × κ →₀ M ⊗[R] N :=
   TensorProduct.congr (finsuppLEquivDirectSum R M ι) (finsuppLEquivDirectSum R N κ) ≪≫ₗ
     ((TensorProduct.directSum R (fun _ : ι => M) fun _ : κ => N) ≪≫ₗ
       (finsuppLEquivDirectSum R (M ⊗[R] N) (ι × κ)).symm)

--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -24,7 +24,6 @@ import Mathlib.LinearAlgebra.DirectSum.TensorProduct
 * `TensorProduct.finsuppScalarRight`, the tensor product of `M` and `ι →₀ R`
   is linearly equivalent to `ι →₀ N`
 
-
 * `TensorProduct.finsuppLeft'`, if `M` is an `S`-module,
   then the tensor product of `ι →₀ M` and `N` is `S`-linearly equivalent
   to `ι →₀ M ⊗[R] N`
@@ -45,12 +44,15 @@ noncomputable def MvPolynomial.rTensor :
   TensorProduct.finsuppScalarLeft
  ```
 
+However, to be actually usable, these definitions need lemmas to be given in companion PR.
+
 ## Case of `Polynomial`
 
 `Polynomial` is a structure containing a `Finsupp`, so these functions
 can't be applied directly to `Polynomial`.
 
 Some linear equivs need to be added to mathlib for that.
+This belongs to a companion PR.
 
 ## TODO
 
@@ -95,6 +97,7 @@ lemma finsuppLeft_apply_tmul (p : ι →₀ M) (n : N) :
   simp only [directSumLeft_symm_lof_tmul]
   simp only [Finsupp.sum, sum_tmul]
 
+@[simp]
 lemma finsuppLeft_apply_tmul_apply (p : ι →₀ M) (n : N) (i : ι) :
     finsuppLeft (p ⊗ₜ[R] n) i = p i ⊗ₜ[R] n := by
   rw [finsuppLeft_apply_tmul]
@@ -109,9 +112,10 @@ theorem finsuppLeft_apply (t : (ι →₀ M) ⊗[R] N) (i : ι) :
     (finsuppLeft t) i = (rTensor N (Finsupp.lapply i)) t := by
   induction t using TensorProduct.induction_on with
   | zero => simp
-  | tmul f n => simp [finsuppLeft_apply_tmul_apply]
+  | tmul f n => simp only [finsuppLeft_apply_tmul_apply, rTensor_tmul, Finsupp.lapply_apply]
   | add x y hx hy => simp [LinearEquiv.map_add, hx, hy]
 
+@[simp]
 lemma finsuppLeft_symm_apply_single (i : ι) (m : M) (n : N) :
     finsuppLeft.symm (Finsupp.single i (m ⊗ₜ[R] n)) =
       Finsupp.single i m ⊗ₜ[R] n := by
@@ -136,6 +140,7 @@ lemma finsuppRight_apply_tmul (m : M) (p : ι →₀ N) :
   simp only [directSumRight_symm_lof_tmul]
   simp only [Finsupp.sum, tmul_sum]
 
+@[simp]
 lemma finsuppRight_apply_tmul_apply (m : M) (p : ι →₀ N) (i : ι) :
     finsuppRight (m ⊗ₜ[R] p) i = m ⊗ₜ[R] p i := by
   rw [finsuppRight_apply_tmul]
@@ -153,6 +158,7 @@ theorem finsuppRight_apply (t : M ⊗[R] (ι →₀ N)) (i : ι) :
   | tmul m f => simp [finsuppRight_apply_tmul_apply]
   | add x y hx hy => simp [LinearEquiv.map_add, hx, hy]
 
+@[simp]
 lemma finsuppRight_symm_apply_single (i : ι) (m : M) (n : N) :
     finsuppRight.symm (Finsupp.single i (m ⊗ₜ[R] n)) =
       m ⊗ₜ[R] Finsupp.single i n := by
@@ -198,6 +204,7 @@ noncomputable def finsuppScalarLeft :
     (ι →₀ R) ⊗[R] N ≃ₗ[R] ι →₀ N :=
   finsuppLeft.trans (Finsupp.mapRange.linearEquiv (TensorProduct.lid R N))
 
+@[simp]
 lemma finsuppScalarLeft_apply_tmul_apply (p : ι →₀ R) (n : N) (i : ι) :
     finsuppScalarLeft (p ⊗ₜ[R] n) i = (p i) • n := by
   simp only [finsuppScalarLeft, LinearEquiv.trans_apply, finsuppLeft_apply_tmul,
@@ -217,10 +224,12 @@ lemma finsuppScalarLeft_apply_tmul (p : ι →₀ R) (n : N) :
   rw [Finsupp.sum_eq_single i (fun _ _ => Finsupp.single_eq_of_ne) (fun _ => by simp)]
   simp only [Finsupp.single_eq_same]
 
+@[simp]
 lemma finsuppScalarLeft_apply (pn : (ι →₀ R) ⊗[R] N) (i : ι) :
     finsuppScalarLeft pn i = TensorProduct.lid R N ((Finsupp.lapply i).rTensor N pn) := by
   simp [finsuppScalarLeft, finsuppLeft_apply]
 
+@[simp]
 lemma finsuppScalarLeft_symm_apply_single (i : ι) (n : N) :
     finsuppScalarLeft.symm (Finsupp.single i n) =
       (Finsupp.single i 1) ⊗ₜ[R] n := by
@@ -231,6 +240,7 @@ noncomputable def finsuppScalarRight :
     M ⊗[R] (ι →₀ R) ≃ₗ[R] ι →₀ M :=
   finsuppRight.trans (Finsupp.mapRange.linearEquiv (TensorProduct.rid R M))
 
+@[simp]
 lemma finsuppScalarRight_apply_tmul_apply (m : M) (p : ι →₀ R) (i : ι) :
     finsuppScalarRight (m ⊗ₜ[R] p) i = (p i) • m := by
   simp only [finsuppScalarRight, LinearEquiv.trans_apply, finsuppRight_apply_tmul,
@@ -250,10 +260,12 @@ lemma finsuppScalarRight_apply_tmul (m : M) (p : ι →₀ R) :
   rw [Finsupp.sum_eq_single i (fun _ _ => Finsupp.single_eq_of_ne) (fun _ => by simp)]
   simp only [Finsupp.single_eq_same]
 
+@[simp]
 lemma finsuppScalarRight_apply (t : M ⊗[R] (ι →₀ R)) (i : ι) :
     finsuppScalarRight t i = TensorProduct.rid R M ((Finsupp.lapply i).lTensor M t) := by
   simp [finsuppScalarRight, finsuppRight_apply]
 
+@[simp]
 lemma finsuppScalarRight_symm_apply_single (i : ι) (m : M) :
     finsuppScalarRight.symm (Finsupp.single i m) =
       m ⊗ₜ[R] (Finsupp.single i 1) := by

--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -80,13 +80,13 @@ variable {ι : Type*} [DecidableEq ι]
 
 /-- The tensor product of `ι →₀ M` and `N` is linearly equivalent to `ι →₀ M ⊗[R] N` -/
 noncomputable def finsuppLeft :
-    (ι →₀ M) ⊗[R] N ≃ₗ[R] ι →₀ (M ⊗[R] N) :=
-  (congr (finsuppLEquivDirectSum R M ι) (LinearEquiv.refl R N)).trans
-    ((directSumLeft R (fun _ : ι => M) N).trans
-      (finsuppLEquivDirectSum R (M ⊗[R] N) ι).symm)
+    (ι →₀ M) ⊗[R] N ≃ₗ[R] ι →₀ M ⊗[R] N :=
+  congr (finsuppLEquivDirectSum R M ι) (LinearEquiv.refl R N) ≪≫ₗ
+    directSumLeft R (fun _ : ι => M) N ≪≫ₗ
+      (finsuppLEquivDirectSum R (M ⊗[R] N) ι).symm
 
 lemma finsuppLeft_apply_tmul (p : ι →₀ M) (n : N) :
-    finsuppLeft (p ⊗ₜ[R] n) = p.sum (fun i m ↦ Finsupp.single i (m ⊗ₜ[R] n)) := by
+    finsuppLeft (p ⊗ₜ[R] n) = p.sum fun i m ↦ Finsupp.single i (m ⊗ₜ[R] n) := by
   simp only [finsuppLeft, LinearEquiv.trans_apply, congr_tmul, LinearEquiv.refl_apply]
   conv_lhs => rw [← Finsupp.sum_single p]
   rw [LinearEquiv.symm_apply_eq]
@@ -109,7 +109,7 @@ lemma finsuppLeft_apply_tmul_apply (p : ι →₀ M) (n : N) (i : ι) :
     simp
 
 theorem finsuppLeft_apply (t : (ι →₀ M) ⊗[R] N) (i : ι) :
-    (finsuppLeft t) i = (rTensor N (Finsupp.lapply i)) t := by
+    finsuppLeft t i = rTensor N (Finsupp.lapply i) t := by
   induction t using TensorProduct.induction_on with
   | zero => simp
   | tmul f n => simp only [finsuppLeft_apply_tmul_apply, rTensor_tmul, Finsupp.lapply_apply]
@@ -123,21 +123,19 @@ lemma finsuppLeft_symm_apply_single (i : ι) (m : M) (n : N) :
 
 /-- The tensor product of `M` and `ι →₀ N` is linearly equivalent to `ι →₀ M ⊗[R] N` -/
 noncomputable def finsuppRight :
-    M ⊗[R] (ι →₀ N) ≃ₗ[R] ι →₀ (M ⊗[R] N) :=
-  (congr (LinearEquiv.refl R M) (finsuppLEquivDirectSum R N ι)).trans
-    ((directSumRight R M (fun _ : ι => N)).trans
-      (finsuppLEquivDirectSum R (M ⊗[R] N) ι).symm)
+    M ⊗[R] (ι →₀ N) ≃ₗ[R] ι →₀ M ⊗[R] N :=
+  congr (LinearEquiv.refl R M) (finsuppLEquivDirectSum R N ι) ≪≫ₗ
+    directSumRight R M (fun _ : ι => N) ≪≫ₗ
+      (finsuppLEquivDirectSum R (M ⊗[R] N) ι).symm
 
 lemma finsuppRight_apply_tmul (m : M) (p : ι →₀ N) :
-    finsuppRight (m ⊗ₜ[R] p) = p.sum (fun i n ↦ Finsupp.single i (m ⊗ₜ[R] n)) := by
+    finsuppRight (m ⊗ₜ[R] p) = p.sum fun i n ↦ Finsupp.single i (m ⊗ₜ[R] n) := by
   simp [finsuppRight]
   conv_lhs => rw [← Finsupp.sum_single p]
   rw [LinearEquiv.symm_apply_eq]
-  simp only [map_finsupp_sum]
-  simp only [finsuppLEquivDirectSum_single]
+  simp only [map_finsupp_sum, finsuppLEquivDirectSum_single]
   rw [← LinearEquiv.eq_symm_apply]
-  simp only [map_finsupp_sum]
-  simp only [directSumRight_symm_lof_tmul]
+  simp only [map_finsupp_sum, directSumRight_symm_lof_tmul]
   simp only [Finsupp.sum, tmul_sum]
 
 @[simp]
@@ -152,7 +150,7 @@ lemma finsuppRight_apply_tmul_apply (m : M) (p : ι →₀ N) (i : ι) :
     simp
 
 theorem finsuppRight_apply (t : M ⊗[R] (ι →₀ N)) (i : ι) :
-    (finsuppRight t) i = (lTensor M (Finsupp.lapply i)) t := by
+    finsuppRight t i = lTensor M (Finsupp.lapply i) t := by
   induction t using TensorProduct.induction_on with
   | zero => simp
   | tmul m f => simp [finsuppRight_apply_tmul_apply]
@@ -184,7 +182,7 @@ lemma finsuppLeft_smul' (s : S) (t : (ι →₀ M) ⊗[R] N) :
 /-- When `M` is also an `S`-module, then `TensorProduct.finsuppLeft R M N``
   is an `S`-linear equiv -/
 noncomputable def finsuppLeft' :
-    (ι →₀ M) ⊗[R] N ≃ₗ[S] ι →₀ (M ⊗[R] N) := {
+    (ι →₀ M) ⊗[R] N ≃ₗ[S] ι →₀ M ⊗[R] N := {
   finsuppLeft with
   map_smul' := finsuppLeft_smul' }
 
@@ -202,7 +200,7 @@ noncomputable example :
 /-- The tensor product of `ι →₀ R` and `N` is linearly equivalent to `ι →₀ N` -/
 noncomputable def finsuppScalarLeft :
     (ι →₀ R) ⊗[R] N ≃ₗ[R] ι →₀ N :=
-  finsuppLeft.trans (Finsupp.mapRange.linearEquiv (TensorProduct.lid R N))
+  finsuppLeft ≪≫ₗ Finsupp.mapRange.linearEquiv (TensorProduct.lid R N)
 
 @[simp]
 lemma finsuppScalarLeft_apply_tmul_apply (p : ι →₀ R) (n : N) (i : ι) :
@@ -217,7 +215,7 @@ lemma finsuppScalarLeft_apply_tmul_apply (p : ι →₀ R) (n : N) (i : ι) :
   rw [tmul_smul, smul_tmul', smul_eq_mul, mul_one]
 
 lemma finsuppScalarLeft_apply_tmul (p : ι →₀ R) (n : N) :
-    finsuppScalarLeft (p ⊗ₜ[R] n) = p.sum (fun i m ↦ Finsupp.single i (m • n)) := by
+    finsuppScalarLeft (p ⊗ₜ[R] n) = p.sum fun i m ↦ Finsupp.single i (m • n) := by
   ext i
   rw [finsuppScalarLeft_apply_tmul_apply]
   simp only [Finsupp.sum_apply]
@@ -237,11 +235,11 @@ lemma finsuppScalarLeft_symm_apply_single (i : ι) (n : N) :
 /-- The tensor product of `M` and `ι →₀ R` is linearly equivalent to `ι →₀ N` -/
 noncomputable def finsuppScalarRight :
     M ⊗[R] (ι →₀ R) ≃ₗ[R] ι →₀ M :=
-  finsuppRight.trans (Finsupp.mapRange.linearEquiv (TensorProduct.rid R M))
+  finsuppRight ≪≫ₗ Finsupp.mapRange.linearEquiv (TensorProduct.rid R M)
 
 @[simp]
 lemma finsuppScalarRight_apply_tmul_apply (m : M) (p : ι →₀ R) (i : ι) :
-    finsuppScalarRight (m ⊗ₜ[R] p) i = (p i) • m := by
+    finsuppScalarRight (m ⊗ₜ[R] p) i = p i • m := by
   simp only [finsuppScalarRight, LinearEquiv.trans_apply, finsuppRight_apply_tmul,
     Finsupp.mapRange.linearEquiv_apply, Finsupp.mapRange.linearMap_apply, LinearEquiv.coe_coe,
     Finsupp.mapRange_apply, Finsupp.sum_apply]
@@ -252,7 +250,7 @@ lemma finsuppScalarRight_apply_tmul_apply (m : M) (p : ι →₀ R) (i : ι) :
   rw [smul_tmul, smul_eq_mul, mul_one]
 
 lemma finsuppScalarRight_apply_tmul (m : M) (p : ι →₀ R) :
-    finsuppScalarRight (m ⊗ₜ[R] p) = p.sum (fun i n ↦ Finsupp.single i (n • m)) := by
+    finsuppScalarRight (m ⊗ₜ[R] p) = p.sum fun i n ↦ Finsupp.single i (n • m) := by
   ext i
   rw [finsuppScalarRight_apply_tmul_apply]
   simp only [Finsupp.sum_apply]

--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -224,7 +224,6 @@ lemma finsuppScalarLeft_apply_tmul (p : ι →₀ R) (n : N) :
   rw [Finsupp.sum_eq_single i (fun _ _ => Finsupp.single_eq_of_ne) (fun _ => by simp)]
   simp only [Finsupp.single_eq_same]
 
-@[simp]
 lemma finsuppScalarLeft_apply (pn : (ι →₀ R) ⊗[R] N) (i : ι) :
     finsuppScalarLeft pn i = TensorProduct.lid R N ((Finsupp.lapply i).rTensor N pn) := by
   simp [finsuppScalarLeft, finsuppLeft_apply]
@@ -260,7 +259,6 @@ lemma finsuppScalarRight_apply_tmul (m : M) (p : ι →₀ R) :
   rw [Finsupp.sum_eq_single i (fun _ _ => Finsupp.single_eq_of_ne) (fun _ => by simp)]
   simp only [Finsupp.single_eq_same]
 
-@[simp]
 lemma finsuppScalarRight_apply (t : M ⊗[R] (ι →₀ R)) (i : ι) :
     finsuppScalarRight t i = TensorProduct.rid R M ((Finsupp.lapply i).lTensor M t) := by
   simp [finsuppScalarRight, finsuppRight_apply]

--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -87,7 +87,7 @@ noncomputable def finsuppLeft :
 variable {R M N ι}
 
 lemma finsuppLeft_apply_tmul (p : ι →₀ M) (n : N) :
-    finsuppLeft (p ⊗ₜ[R] n) = p.sum fun i m ↦ Finsupp.single i (m ⊗ₜ[R] n) := by
+    finsuppLeft R M N ι (p ⊗ₜ[R] n) = p.sum fun i m ↦ Finsupp.single i (m ⊗ₜ[R] n) := by
   apply p.induction_linear
   · simp
   · intros f g hf hg; simp [add_tmul, map_add, hf, hg, Finsupp.sum_add_index]
@@ -95,12 +95,12 @@ lemma finsuppLeft_apply_tmul (p : ι →₀ M) (n : N) :
 
 @[simp]
 lemma finsuppLeft_apply_tmul_apply (p : ι →₀ M) (n : N) (i : ι) :
-    finsuppLeft (p ⊗ₜ[R] n) i = p i ⊗ₜ[R] n := by
+    finsuppLeft R M N ι (p ⊗ₜ[R] n) i = p i ⊗ₜ[R] n := by
   rw [finsuppLeft_apply_tmul, Finsupp.sum_apply,
     Finsupp.sum_eq_single i (fun _ _ ↦ Finsupp.single_eq_of_ne) (by simp), Finsupp.single_eq_same]
 
 theorem finsuppLeft_apply (t : (ι →₀ M) ⊗[R] N) (i : ι) :
-    finsuppLeft t i = rTensor N (Finsupp.lapply i) t := by
+    finsuppLeft R M N ι t i = rTensor N (Finsupp.lapply i) t := by
   induction t using TensorProduct.induction_on with
   | zero => simp
   | tmul f n => simp only [finsuppLeft_apply_tmul_apply, rTensor_tmul, Finsupp.lapply_apply]
@@ -108,7 +108,7 @@ theorem finsuppLeft_apply (t : (ι →₀ M) ⊗[R] N) (i : ι) :
 
 @[simp]
 lemma finsuppLeft_symm_apply_single (i : ι) (m : M) (n : N) :
-    finsuppLeft.symm (Finsupp.single i (m ⊗ₜ[R] n)) =
+    (finsuppLeft R M N ι).symm (Finsupp.single i (m ⊗ₜ[R] n)) =
       Finsupp.single i m ⊗ₜ[R] n := by
   simp [finsuppLeft, Finsupp.lsum]
 
@@ -122,7 +122,7 @@ noncomputable def finsuppRight :
 variable {R M N ι}
 
 lemma finsuppRight_apply_tmul (m : M) (p : ι →₀ N) :
-    finsuppRight (m ⊗ₜ[R] p) = p.sum fun i n ↦ Finsupp.single i (m ⊗ₜ[R] n) := by
+    finsuppRight R M N ι (m ⊗ₜ[R] p) = p.sum fun i n ↦ Finsupp.single i (m ⊗ₜ[R] n) := by
   apply p.induction_linear
   · simp
   · intros f g hf hg; simp [tmul_add, map_add, hf, hg, Finsupp.sum_add_index]
@@ -130,12 +130,12 @@ lemma finsuppRight_apply_tmul (m : M) (p : ι →₀ N) :
 
 @[simp]
 lemma finsuppRight_apply_tmul_apply (m : M) (p : ι →₀ N) (i : ι) :
-    finsuppRight (m ⊗ₜ[R] p) i = m ⊗ₜ[R] p i := by
+    finsuppRight R M N ι (m ⊗ₜ[R] p) i = m ⊗ₜ[R] p i := by
   rw [finsuppRight_apply_tmul, Finsupp.sum_apply,
     Finsupp.sum_eq_single i (fun _ _ ↦ Finsupp.single_eq_of_ne) (by simp), Finsupp.single_eq_same]
 
 theorem finsuppRight_apply (t : M ⊗[R] (ι →₀ N)) (i : ι) :
-    finsuppRight t i = lTensor M (Finsupp.lapply i) t := by
+    finsuppRight R M N ι t i = lTensor M (Finsupp.lapply i) t := by
   induction t using TensorProduct.induction_on with
   | zero => simp
   | tmul m f => simp [finsuppRight_apply_tmul_apply]
@@ -143,7 +143,7 @@ theorem finsuppRight_apply (t : M ⊗[R] (ι →₀ N)) (i : ι) :
 
 @[simp]
 lemma finsuppRight_symm_apply_single (i : ι) (m : M) (n : N) :
-    finsuppRight.symm (Finsupp.single i (m ⊗ₜ[R] n)) =
+    (finsuppRight R M N ι).symm (Finsupp.single i (m ⊗ₜ[R] n)) =
       m ⊗ₜ[R] Finsupp.single i n := by
   simp [finsuppRight, Finsupp.lsum]
 
@@ -151,21 +151,23 @@ variable {S : Type*} [CommSemiring S] [Algebra R S]
   [Module S M] [IsScalarTower R S M]
 
 lemma finsuppLeft_smul' (s : S) (t : (ι →₀ M) ⊗[R] N) :
-    finsuppLeft (s • t) = s • finsuppLeft t := by
+    finsuppLeft R M N ι (s • t) = s • finsuppLeft R M N ι t := by
   induction t using TensorProduct.induction_on with
   | zero => simp
   | add x y hx hy => simp [hx, hy]
   | tmul p n => ext; simp [smul_tmul', finsuppLeft_apply_tmul_apply]
 
+variable (R M N ι S)
 /-- When `M` is also an `S`-module, then `TensorProduct.finsuppLeft R M N``
   is an `S`-linear equiv -/
 noncomputable def finsuppLeft' :
     (ι →₀ M) ⊗[R] N ≃ₗ[S] ι →₀ M ⊗[R] N where
-  __ := finsuppLeft
+  __ := finsuppLeft R M N ι
   map_smul' := finsuppLeft_smul'
 
+variable {R M N ι S}
 lemma finsuppLeft'_apply (x : (ι →₀ M) ⊗[R] N) :
-    finsuppLeft' (S := S) x = finsuppLeft x := rfl
+    finsuppLeft' R M N ι S x = finsuppLeft R M N ι x := rfl
 
 /- -- TODO : reprove using the existing heterobasic lemmas
 noncomputable example :
@@ -175,55 +177,61 @@ noncomputable example :
     (finsuppLEquivDirectSum S M ι) (.refl R N)).trans
     (f.trans (finsuppLEquivDirectSum S (M ⊗[R] N) ι).symm) -/
 
+variable (R M N ι)
 /-- The tensor product of `ι →₀ R` and `N` is linearly equivalent to `ι →₀ N` -/
 noncomputable def finsuppScalarLeft :
     (ι →₀ R) ⊗[R] N ≃ₗ[R] ι →₀ N :=
-  finsuppLeft ≪≫ₗ Finsupp.mapRange.linearEquiv (TensorProduct.lid R N)
+  finsuppLeft R R N ι ≪≫ₗ (Finsupp.mapRange.linearEquiv (TensorProduct.lid R N))
 
+variable {R M N ι}
 @[simp]
 lemma finsuppScalarLeft_apply_tmul_apply (p : ι →₀ R) (n : N) (i : ι) :
-    finsuppScalarLeft (p ⊗ₜ[R] n) i = p i • n := by
+    finsuppScalarLeft R N ι (p ⊗ₜ[R] n) i = p i • n := by
   simp [finsuppScalarLeft]
 
 lemma finsuppScalarLeft_apply_tmul (p : ι →₀ R) (n : N) :
-    finsuppScalarLeft (p ⊗ₜ[R] n) = p.sum fun i m ↦ Finsupp.single i (m • n) := by
+    finsuppScalarLeft R N ι (p ⊗ₜ[R] n) = p.sum fun i m ↦ Finsupp.single i (m • n) := by
   ext i
   rw [finsuppScalarLeft_apply_tmul_apply, Finsupp.sum_apply,
     Finsupp.sum_eq_single i (fun _ _ ↦ Finsupp.single_eq_of_ne) (by simp), Finsupp.single_eq_same]
 
 lemma finsuppScalarLeft_apply (pn : (ι →₀ R) ⊗[R] N) (i : ι) :
-    finsuppScalarLeft pn i = TensorProduct.lid R N ((Finsupp.lapply i).rTensor N pn) := by
+    finsuppScalarLeft R N ι pn i = TensorProduct.lid R N ((Finsupp.lapply i).rTensor N pn) := by
   simp [finsuppScalarLeft, finsuppLeft_apply]
 
 @[simp]
 lemma finsuppScalarLeft_symm_apply_single (i : ι) (n : N) :
-    finsuppScalarLeft.symm (Finsupp.single i n) =
+    (finsuppScalarLeft R N ι).symm (Finsupp.single i n) =
       (Finsupp.single i 1) ⊗ₜ[R] n := by
   simp [finsuppScalarLeft, finsuppLeft_symm_apply_single]
+
+variable (R M N ι)
 
 /-- The tensor product of `M` and `ι →₀ R` is linearly equivalent to `ι →₀ N` -/
 noncomputable def finsuppScalarRight :
     M ⊗[R] (ι →₀ R) ≃ₗ[R] ι →₀ M :=
-  finsuppRight ≪≫ₗ Finsupp.mapRange.linearEquiv (TensorProduct.rid R M)
+  finsuppRight R M R ι ≪≫ₗ Finsupp.mapRange.linearEquiv (TensorProduct.rid R M)
+
+variable {R M N ι}
 
 @[simp]
 lemma finsuppScalarRight_apply_tmul_apply (m : M) (p : ι →₀ R) (i : ι) :
-    finsuppScalarRight (m ⊗ₜ[R] p) i = p i • m := by
+    finsuppScalarRight R M ι (m ⊗ₜ[R] p) i = p i • m := by
   simp [finsuppScalarRight]
 
 lemma finsuppScalarRight_apply_tmul (m : M) (p : ι →₀ R) :
-    finsuppScalarRight (m ⊗ₜ[R] p) = p.sum fun i n ↦ Finsupp.single i (n • m) := by
+    finsuppScalarRight R M ι (m ⊗ₜ[R] p) = p.sum fun i n ↦ Finsupp.single i (n • m) := by
   ext i
   rw [finsuppScalarRight_apply_tmul_apply, Finsupp.sum_apply,
     Finsupp.sum_eq_single i (fun _ _ ↦ Finsupp.single_eq_of_ne) (by simp), Finsupp.single_eq_same]
 
 lemma finsuppScalarRight_apply (t : M ⊗[R] (ι →₀ R)) (i : ι) :
-    finsuppScalarRight t i = TensorProduct.rid R M ((Finsupp.lapply i).lTensor M t) := by
+    finsuppScalarRight R M ι t i = TensorProduct.rid R M ((Finsupp.lapply i).lTensor M t) := by
   simp [finsuppScalarRight, finsuppRight_apply]
 
 @[simp]
 lemma finsuppScalarRight_symm_apply_single (i : ι) (m : M) :
-    finsuppScalarRight.symm (Finsupp.single i m) =
+    (finsuppScalarRight R M ι).symm (Finsupp.single i m) =
       m ⊗ₜ[R] (Finsupp.single i 1) := by
   simp [finsuppScalarRight, finsuppRight_symm_apply_single]
 

--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -76,7 +76,7 @@ variable (R : Type*) [CommSemiring R]
 
 namespace TensorProduct
 
-variable {ι : Type*} [DecidableEq ι]
+variable (ι : Type*) [DecidableEq ι]
 
 /-- The tensor product of `ι →₀ M` and `N` is linearly equivalent to `ι →₀ M ⊗[R] N` -/
 noncomputable def finsuppLeft :
@@ -84,7 +84,7 @@ noncomputable def finsuppLeft :
   congr (finsuppLEquivDirectSum R M ι) (.refl R N) ≪≫ₗ
     directSumLeft R (fun _ ↦ M) N ≪≫ₗ (finsuppLEquivDirectSum R _ ι).symm
 
-variable {R M N}
+variable {R M N ι}
 
 lemma finsuppLeft_apply_tmul (p : ι →₀ M) (n : N) :
     finsuppLeft (p ⊗ₜ[R] n) = p.sum fun i m ↦ Finsupp.single i (m ⊗ₜ[R] n) := by
@@ -112,11 +112,14 @@ lemma finsuppLeft_symm_apply_single (i : ι) (m : M) (n : N) :
       Finsupp.single i m ⊗ₜ[R] n := by
   simp [finsuppLeft, Finsupp.lsum]
 
+variable (R M N ι)
 /-- The tensor product of `M` and `ι →₀ N` is linearly equivalent to `ι →₀ M ⊗[R] N` -/
 noncomputable def finsuppRight :
     M ⊗[R] (ι →₀ N) ≃ₗ[R] ι →₀ M ⊗[R] N :=
   congr (.refl R M) (finsuppLEquivDirectSum R N ι) ≪≫ₗ
     directSumRight R M (fun _ : ι ↦ N) ≪≫ₗ (finsuppLEquivDirectSum R _ ι).symm
+
+variable {R M N ι}
 
 lemma finsuppRight_apply_tmul (m : M) (p : ι →₀ N) :
     finsuppRight (m ⊗ₜ[R] p) = p.sum fun i n ↦ Finsupp.single i (m ⊗ₜ[R] n) := by

--- a/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/Finsupp.lean
@@ -70,9 +70,9 @@ open Set LinearMap Submodule
 
 section TensorProduct
 
-variable {R : Type*} [CommSemiring R]
-  {M : Type*} [AddCommMonoid M] [Module R M]
-  {N : Type*} [AddCommMonoid N] [Module R N]
+variable (R : Type*) [CommSemiring R]
+  (M : Type*) [AddCommMonoid M] [Module R M]
+  (N : Type*) [AddCommMonoid N] [Module R N]
 
 namespace TensorProduct
 
@@ -81,39 +81,30 @@ variable {ι : Type*} [DecidableEq ι]
 /-- The tensor product of `ι →₀ M` and `N` is linearly equivalent to `ι →₀ M ⊗[R] N` -/
 noncomputable def finsuppLeft :
     (ι →₀ M) ⊗[R] N ≃ₗ[R] ι →₀ M ⊗[R] N :=
-  congr (finsuppLEquivDirectSum R M ι) (LinearEquiv.refl R N) ≪≫ₗ
-    directSumLeft R (fun _ : ι => M) N ≪≫ₗ
-      (finsuppLEquivDirectSum R (M ⊗[R] N) ι).symm
+  congr (finsuppLEquivDirectSum R M ι) (.refl R N) ≪≫ₗ
+    directSumLeft R (fun _ ↦ M) N ≪≫ₗ (finsuppLEquivDirectSum R _ ι).symm
+
+variable {R M N}
 
 lemma finsuppLeft_apply_tmul (p : ι →₀ M) (n : N) :
     finsuppLeft (p ⊗ₜ[R] n) = p.sum fun i m ↦ Finsupp.single i (m ⊗ₜ[R] n) := by
-  simp only [finsuppLeft, LinearEquiv.trans_apply, congr_tmul, LinearEquiv.refl_apply]
-  conv_lhs => rw [← Finsupp.sum_single p]
-  rw [LinearEquiv.symm_apply_eq]
-  simp only [map_finsupp_sum]
-  simp only [finsuppLEquivDirectSum_single]
-  rw [← LinearEquiv.eq_symm_apply]
-  simp only [map_finsupp_sum]
-  simp only [directSumLeft_symm_lof_tmul]
-  simp only [Finsupp.sum, sum_tmul]
+  apply p.induction_linear
+  · simp
+  · intros f g hf hg; simp [add_tmul, map_add, hf, hg, Finsupp.sum_add_index]
+  · simp [finsuppLeft]
 
 @[simp]
 lemma finsuppLeft_apply_tmul_apply (p : ι →₀ M) (n : N) (i : ι) :
     finsuppLeft (p ⊗ₜ[R] n) i = p i ⊗ₜ[R] n := by
-  rw [finsuppLeft_apply_tmul]
-  simp only [Finsupp.sum_apply]
-  conv_rhs => rw [← Finsupp.single_eq_same (a := i) (b := p i ⊗ₜ[R] n)]
-  apply Finsupp.sum_eq_single i
-  · exact fun _ _ ↦ Finsupp.single_eq_of_ne
-  · intro _
-    simp
+  rw [finsuppLeft_apply_tmul, Finsupp.sum_apply,
+    Finsupp.sum_eq_single i (fun _ _ ↦ Finsupp.single_eq_of_ne) (by simp), Finsupp.single_eq_same]
 
 theorem finsuppLeft_apply (t : (ι →₀ M) ⊗[R] N) (i : ι) :
     finsuppLeft t i = rTensor N (Finsupp.lapply i) t := by
   induction t using TensorProduct.induction_on with
   | zero => simp
   | tmul f n => simp only [finsuppLeft_apply_tmul_apply, rTensor_tmul, Finsupp.lapply_apply]
-  | add x y hx hy => simp [LinearEquiv.map_add, hx, hy]
+  | add x y hx hy => simp [map_add, hx, hy]
 
 @[simp]
 lemma finsuppLeft_symm_apply_single (i : ι) (m : M) (n : N) :
@@ -124,37 +115,28 @@ lemma finsuppLeft_symm_apply_single (i : ι) (m : M) (n : N) :
 /-- The tensor product of `M` and `ι →₀ N` is linearly equivalent to `ι →₀ M ⊗[R] N` -/
 noncomputable def finsuppRight :
     M ⊗[R] (ι →₀ N) ≃ₗ[R] ι →₀ M ⊗[R] N :=
-  congr (LinearEquiv.refl R M) (finsuppLEquivDirectSum R N ι) ≪≫ₗ
-    directSumRight R M (fun _ : ι => N) ≪≫ₗ
-      (finsuppLEquivDirectSum R (M ⊗[R] N) ι).symm
+  congr (.refl R M) (finsuppLEquivDirectSum R N ι) ≪≫ₗ
+    directSumRight R M (fun _ : ι ↦ N) ≪≫ₗ (finsuppLEquivDirectSum R _ ι).symm
 
 lemma finsuppRight_apply_tmul (m : M) (p : ι →₀ N) :
     finsuppRight (m ⊗ₜ[R] p) = p.sum fun i n ↦ Finsupp.single i (m ⊗ₜ[R] n) := by
-  simp [finsuppRight]
-  conv_lhs => rw [← Finsupp.sum_single p]
-  rw [LinearEquiv.symm_apply_eq]
-  simp only [map_finsupp_sum, finsuppLEquivDirectSum_single]
-  rw [← LinearEquiv.eq_symm_apply]
-  simp only [map_finsupp_sum, directSumRight_symm_lof_tmul]
-  simp only [Finsupp.sum, tmul_sum]
+  apply p.induction_linear
+  · simp
+  · intros f g hf hg; simp [tmul_add, map_add, hf, hg, Finsupp.sum_add_index]
+  · simp [finsuppRight]
 
 @[simp]
 lemma finsuppRight_apply_tmul_apply (m : M) (p : ι →₀ N) (i : ι) :
     finsuppRight (m ⊗ₜ[R] p) i = m ⊗ₜ[R] p i := by
-  rw [finsuppRight_apply_tmul]
-  simp only [Finsupp.sum_apply]
-  conv_rhs => rw [← Finsupp.single_eq_same (a := i) (b := m ⊗ₜ[R] p i)]
-  apply Finsupp.sum_eq_single i
-  · exact fun _ _ ↦ Finsupp.single_eq_of_ne
-  · intro _
-    simp
+  rw [finsuppRight_apply_tmul, Finsupp.sum_apply,
+    Finsupp.sum_eq_single i (fun _ _ ↦ Finsupp.single_eq_of_ne) (by simp), Finsupp.single_eq_same]
 
 theorem finsuppRight_apply (t : M ⊗[R] (ι →₀ N)) (i : ι) :
     finsuppRight t i = lTensor M (Finsupp.lapply i) t := by
   induction t using TensorProduct.induction_on with
   | zero => simp
   | tmul m f => simp [finsuppRight_apply_tmul_apply]
-  | add x y hx hy => simp [LinearEquiv.map_add, hx, hy]
+  | add x y hx hy => simp [map_add, hx, hy]
 
 @[simp]
 lemma finsuppRight_symm_apply_single (i : ι) (m : M) (n : N) :
@@ -169,22 +151,15 @@ lemma finsuppLeft_smul' (s : S) (t : (ι →₀ M) ⊗[R] N) :
     finsuppLeft (s • t) = s • finsuppLeft t := by
   induction t using TensorProduct.induction_on with
   | zero => simp
-  | add x y hx hy =>
-    simp only [AddHom.toFun_eq_coe, coe_toAddHom, LinearEquiv.coe_coe, RingHom.id_apply] at hx hy ⊢
-    simp only [smul_add, map_add, hx, hy]
-  | tmul p n =>
-    simp only [smul_tmul', finsuppLeft_apply_tmul]
-    rw [Finsupp.smul_sum]
-    simp only [Finsupp.smul_single]
-    apply Finsupp.sum_smul_index'
-    simp
+  | add x y hx hy => simp [hx, hy]
+  | tmul p n => ext; simp [smul_tmul', finsuppLeft_apply_tmul_apply]
 
 /-- When `M` is also an `S`-module, then `TensorProduct.finsuppLeft R M N``
   is an `S`-linear equiv -/
 noncomputable def finsuppLeft' :
-    (ι →₀ M) ⊗[R] N ≃ₗ[S] ι →₀ M ⊗[R] N := {
-  finsuppLeft with
-  map_smul' := finsuppLeft_smul' }
+    (ι →₀ M) ⊗[R] N ≃ₗ[S] ι →₀ M ⊗[R] N where
+  __ := finsuppLeft
+  map_smul' := finsuppLeft_smul'
 
 lemma finsuppLeft'_apply (x : (ι →₀ M) ⊗[R] N) :
     finsuppLeft' (S := S) x = finsuppLeft x := rfl
@@ -194,7 +169,7 @@ noncomputable example :
     (ι →₀ M) ⊗[R] N ≃ₗ[S] ι →₀ (M ⊗[R] N) := by
   have f : (⨁ (i₁ : ι), M) ⊗[R] N ≃ₗ[S] ⨁ (i : ι), M ⊗[R] N := sorry
   exact (AlgebraTensorModule.congr
-    (finsuppLEquivDirectSum S M ι) (LinearEquiv.refl R N)).trans
+    (finsuppLEquivDirectSum S M ι) (.refl R N)).trans
     (f.trans (finsuppLEquivDirectSum S (M ⊗[R] N) ι).symm) -/
 
 /-- The tensor product of `ι →₀ R` and `N` is linearly equivalent to `ι →₀ N` -/
@@ -204,23 +179,14 @@ noncomputable def finsuppScalarLeft :
 
 @[simp]
 lemma finsuppScalarLeft_apply_tmul_apply (p : ι →₀ R) (n : N) (i : ι) :
-    finsuppScalarLeft (p ⊗ₜ[R] n) i = (p i) • n := by
-  simp only [finsuppScalarLeft, LinearEquiv.trans_apply, finsuppLeft_apply_tmul,
-    Finsupp.mapRange.linearEquiv_apply, Finsupp.mapRange.linearMap_apply, LinearEquiv.coe_coe,
-    Finsupp.mapRange_apply, Finsupp.sum_apply]
-  apply symm
-  rw [← LinearEquiv.symm_apply_eq, lid_symm_apply]
-  rw [Finsupp.sum_eq_single i (fun _ _ => Finsupp.single_eq_of_ne) (fun _ => by simp)]
-  simp only [Finsupp.single_eq_same]
-  rw [tmul_smul, smul_tmul', smul_eq_mul, mul_one]
+    finsuppScalarLeft (p ⊗ₜ[R] n) i = p i • n := by
+  simp [finsuppScalarLeft]
 
 lemma finsuppScalarLeft_apply_tmul (p : ι →₀ R) (n : N) :
     finsuppScalarLeft (p ⊗ₜ[R] n) = p.sum fun i m ↦ Finsupp.single i (m • n) := by
   ext i
-  rw [finsuppScalarLeft_apply_tmul_apply]
-  simp only [Finsupp.sum_apply]
-  rw [Finsupp.sum_eq_single i (fun _ _ => Finsupp.single_eq_of_ne) (fun _ => by simp)]
-  simp only [Finsupp.single_eq_same]
+  rw [finsuppScalarLeft_apply_tmul_apply, Finsupp.sum_apply,
+    Finsupp.sum_eq_single i (fun _ _ ↦ Finsupp.single_eq_of_ne) (by simp), Finsupp.single_eq_same]
 
 lemma finsuppScalarLeft_apply (pn : (ι →₀ R) ⊗[R] N) (i : ι) :
     finsuppScalarLeft pn i = TensorProduct.lid R N ((Finsupp.lapply i).rTensor N pn) := by
@@ -240,22 +206,13 @@ noncomputable def finsuppScalarRight :
 @[simp]
 lemma finsuppScalarRight_apply_tmul_apply (m : M) (p : ι →₀ R) (i : ι) :
     finsuppScalarRight (m ⊗ₜ[R] p) i = p i • m := by
-  simp only [finsuppScalarRight, LinearEquiv.trans_apply, finsuppRight_apply_tmul,
-    Finsupp.mapRange.linearEquiv_apply, Finsupp.mapRange.linearMap_apply, LinearEquiv.coe_coe,
-    Finsupp.mapRange_apply, Finsupp.sum_apply]
-  apply symm
-  rw [← LinearEquiv.symm_apply_eq, rid_symm_apply]
-  rw [Finsupp.sum_eq_single i (fun _ _ => Finsupp.single_eq_of_ne) (fun _ => by simp)]
-  simp only [Finsupp.single_eq_same]
-  rw [smul_tmul, smul_eq_mul, mul_one]
+  simp [finsuppScalarRight]
 
 lemma finsuppScalarRight_apply_tmul (m : M) (p : ι →₀ R) :
     finsuppScalarRight (m ⊗ₜ[R] p) = p.sum fun i n ↦ Finsupp.single i (n • m) := by
   ext i
-  rw [finsuppScalarRight_apply_tmul_apply]
-  simp only [Finsupp.sum_apply]
-  rw [Finsupp.sum_eq_single i (fun _ _ => Finsupp.single_eq_of_ne) (fun _ => by simp)]
-  simp only [Finsupp.single_eq_same]
+  rw [finsuppScalarRight_apply_tmul_apply, Finsupp.sum_apply,
+    Finsupp.sum_eq_single i (fun _ _ ↦ Finsupp.single_eq_of_ne) (by simp), Finsupp.single_eq_same]
 
 lemma finsuppScalarRight_apply (t : M ⊗[R] (ι →₀ R)) (i : ι) :
     finsuppScalarRight t i = TensorProduct.rid R M ((Finsupp.lapply i).lTensor M t) := by
@@ -279,15 +236,14 @@ open scoped Classical in
 noncomputable def finsuppTensorFinsupp :
     (ι →₀ M) ⊗[R] (κ →₀ N) ≃ₗ[R] ι × κ →₀ M ⊗[R] N :=
   TensorProduct.congr (finsuppLEquivDirectSum R M ι) (finsuppLEquivDirectSum R N κ) ≪≫ₗ
-    ((TensorProduct.directSum R (fun _ : ι => M) fun _ : κ => N) ≪≫ₗ
-      (finsuppLEquivDirectSum R (M ⊗[R] N) (ι × κ)).symm)
+    (TensorProduct.directSum R (fun _ ↦ M) fun _ ↦ N) ≪≫ₗ (finsuppLEquivDirectSum R _ _).symm
 #align finsupp_tensor_finsupp finsuppTensorFinsupp
 
 @[simp]
 theorem finsuppTensorFinsupp_single (i : ι) (m : M) (k : κ) (n : N) :
     finsuppTensorFinsupp R M N ι κ (Finsupp.single i m ⊗ₜ Finsupp.single k n) =
-      Finsupp.single (i, k) (m ⊗ₜ n) :=
-  by classical simp [finsuppTensorFinsupp]
+      Finsupp.single (i, k) (m ⊗ₜ n) := by
+  simp [finsuppTensorFinsupp]
 #align finsupp_tensor_finsupp_single finsuppTensorFinsupp_single
 
 @[simp]
@@ -297,19 +253,15 @@ theorem finsuppTensorFinsupp_apply (f : ι →₀ M) (g : κ →₀ N) (i : ι) 
   · simp
   · intro f₁ f₂ hf₁ hf₂
     simp [add_tmul, hf₁, hf₂]
-  · intro i' m
-    apply Finsupp.induction_linear g
-    · simp
-    · intro g₁ g₂ hg₁ hg₂
-      simp [tmul_add, hg₁, hg₂]
-    · intro k' n
-      simp only [finsuppTensorFinsupp_single]
-      -- split_ifs; finish can close the goal from here
-      by_cases h1 : (i', k') = (i, k)
-      · simp only [Prod.mk.inj_iff] at h1
-        simp [h1]
-      · simp only [Prod.mk.inj_iff, not_and_or] at h1
-        cases' h1 with h1 h1 <;> simp [h1]
+  intro i' m
+  apply Finsupp.induction_linear g
+  · simp
+  · intro g₁ g₂ hg₁ hg₂
+    simp [tmul_add, hg₁, hg₂]
+  intro k' n
+  classical
+  simp_rw [finsuppTensorFinsupp_single, Finsupp.single_apply, Prod.mk.inj_iff, ite_and]
+  split_ifs <;> simp
 #align finsupp_tensor_finsupp_apply finsuppTensorFinsupp_apply
 
 @[simp]


### PR DESCRIPTION
## Modules

* `TensorProduct.finsuppLeft`, the tensor product of `ι →₀ M` and `N` is linearly equivalent to `ι →₀ M ⊗[R] N`

* `TensorProduct.finsuppScalarLeft`, the tensor product of `ι →₀ R` and `N` is linearly equivalent to `ι →₀ N`

* `TensorProduct.finsuppRight`, the tensor product of `M` and `ι →₀ N` is linearly equivalent to `ι →₀ M ⊗[R] N`

* `TensorProduct.finsuppLeft'`, if `M` is an `S`-module, then the tensor product of `ι →₀ M` and `N` is `S`-linearly equivalent to `ι →₀ M ⊗[R] N`


This is the first part of PR #10824 which contains three applications of these functions to monoid algebras, polynomials and multivariate polynomials.

It has been split because this part is reasonably sound, while the three other files are more like propositions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
