### PR TITLE
[Merged by Bors] - feat: add `image_restrictPreimage`

### DIFF
--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -564,18 +564,17 @@ section
 
 variable (s t f)
 
-theorem range_restrictPreimage : range (t.restrictPreimage f) = Subtype.val ⁻¹' range f := by
-  delta Set.restrictPreimage
-  rw [MapsTo.range_restrict, Set.image_preimage_eq_inter_range, Set.preimage_inter,
-    Subtype.coe_preimage_self, Set.univ_inter]
-#align set.range_restrict_preimage Set.range_restrictPreimage
-
 theorem image_restrictPreimage :
     t.restrictPreimage f '' (Subtype.val ⁻¹' s) = Subtype.val ⁻¹' (f '' s) := by
   delta Set.restrictPreimage
   rw [← preimage_image_eq  (_ '' (_ ⁻¹' s)) (Subtype.coe_injective), ← image_comp,
     MapsTo.restrict_commutes, image_comp, image_preimage_eq_inter_range, Subtype.range_coe,
     image_inter_preimage, inter_comm, Subtype.preimage_coe_self_inter]
+
+theorem range_restrictPreimage : range (t.restrictPreimage f) = Subtype.val ⁻¹' range f := by
+  simp only [← image_univ, ← image_restrictPreimage]
+  rfl
+#align set.range_restrict_preimage Set.range_restrictPreimage
 
 variable {f} {U : ι → Set β}
 

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -570,7 +570,8 @@ theorem range_restrictPreimage : range (t.restrictPreimage f) = Subtype.val ⁻�
     Subtype.coe_preimage_self, Set.univ_inter]
 #align set.range_restrict_preimage Set.range_restrictPreimage
 
-theorem image_restrictPreimage : t.restrictPreimage f '' (Subtype.val ⁻¹' s) = Subtype.val ⁻¹' (f '' s) := by
+theorem image_restrictPreimage :
+    t.restrictPreimage f '' (Subtype.val ⁻¹' s) = Subtype.val ⁻¹' (f '' s) := by
   delta Set.restrictPreimage
   rw [← preimage_image_eq  (_ '' (_ ⁻¹' s)) (Subtype.coe_injective), ← image_comp,
     MapsTo.restrict_commutes, image_comp, image_preimage_eq_inter_range, Subtype.range_coe,

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -572,8 +572,7 @@ theorem image_restrictPreimage :
     image_inter_preimage, inter_comm, Subtype.preimage_coe_self_inter]
 
 theorem range_restrictPreimage : range (t.restrictPreimage f) = Subtype.val ⁻¹' range f := by
-  simp only [← image_univ, ← image_restrictPreimage]
-  rfl
+  simp only [← image_univ, ← image_restrictPreimage, preimage_univ]
 #align set.range_restrict_preimage Set.range_restrictPreimage
 
 variable {f} {U : ι → Set β}

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -562,13 +562,19 @@ theorem MapsTo.mem_iff (h : MapsTo f s t) (hc : MapsTo f sᶜ tᶜ) {x} : f x �
 
 section
 
-variable (t f)
+variable (s t f)
 
 theorem range_restrictPreimage : range (t.restrictPreimage f) = Subtype.val ⁻¹' range f := by
   delta Set.restrictPreimage
   rw [MapsTo.range_restrict, Set.image_preimage_eq_inter_range, Set.preimage_inter,
     Subtype.coe_preimage_self, Set.univ_inter]
 #align set.range_restrict_preimage Set.range_restrictPreimage
+
+theorem image_restrictPreimage : t.restrictPreimage f '' (Subtype.val ⁻¹' s) = Subtype.val ⁻¹' (f '' s) := by
+  delta Set.restrictPreimage
+  rw [← preimage_image_eq  (_ '' (_ ⁻¹' s)) (Subtype.coe_injective), ← image_comp,
+    MapsTo.restrict_commutes, image_comp, image_preimage_eq_inter_range, Subtype.range_coe,
+    image_inter_preimage, inter_comm, Subtype.preimage_coe_self_inter]
 
 variable {f} {U : ι → Set β}
 

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -567,9 +567,8 @@ variable (s t f)
 theorem image_restrictPreimage :
     t.restrictPreimage f '' (Subtype.val ⁻¹' s) = Subtype.val ⁻¹' (f '' s) := by
   delta Set.restrictPreimage
-  rw [← preimage_image_eq  (_ '' (_ ⁻¹' s)) (Subtype.coe_injective), ← image_comp,
-    MapsTo.restrict_commutes, image_comp, image_preimage_eq_inter_range, Subtype.range_coe,
-    image_inter_preimage, inter_comm, Subtype.preimage_coe_self_inter]
+  rw [← (Subtype.coe_injective).image_injective.eq_iff, ← image_comp, MapsTo.restrict_commutes,
+    image_comp, Subtype.image_preimage_coe, Subtype.image_preimage_coe, image_preimage_inter]
 
 theorem range_restrictPreimage : range (t.restrictPreimage f) = Subtype.val ⁻¹' range f := by
   simp only [← image_univ, ← image_restrictPreimage, preimage_univ]

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -562,8 +562,9 @@ theorem MapsTo.mem_iff (h : MapsTo f s t) (hc : MapsTo f sᶜ tᶜ) {x} : f x �
 
 section
 
-variable (s t f)
+variable (t f)
 
+variable (s) in
 theorem image_restrictPreimage :
     t.restrictPreimage f '' (Subtype.val ⁻¹' s) = Subtype.val ⁻¹' (f '' s) := by
   delta Set.restrictPreimage

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1089,17 +1089,6 @@ theorem IsOpenMap.restrict {f : X → Y} (hf : IsOpenMap f) {s : Set X} (hs : Is
   hf.comp hs.isOpenMap_subtype_val
 #align is_open_map.restrict IsOpenMap.restrict
 
-lemma IsClosedMap.restrictPreimage {f : X → Y} (hcl : IsClosedMap f) (T : Set Y) :
-    IsClosedMap (T.restrictPreimage f) := by
-  rw [isClosedMap_iff_clusterPt] at hcl ⊢
-  intro A ⟨y, hyT⟩ hy
-  rw [Set.restrictPreimage, MapClusterPt, ← inducing_subtype_val.mapClusterPt_iff, MapClusterPt,
-      map_map, MapsTo.restrict_commutes, ← map_map, ← MapClusterPt, map_principal] at hy
-  rcases hcl _ y hy with ⟨x, hxy, hx⟩
-  have hxT : f x ∈ T := hxy ▸ hyT
-  refine ⟨⟨x, hxT⟩, Subtype.ext hxy, ?_⟩
-  rwa [← inducing_subtype_val.mapClusterPt_iff, MapClusterPt, map_principal]
-
 nonrec theorem IsClosed.closedEmbedding_subtype_val {s : Set X} (hs : IsClosed s) :
     ClosedEmbedding ((↑) : s → X) :=
   closedEmbedding_subtype_val hs

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -65,15 +65,9 @@ alias ClosedEmbedding.restrictPreimage := Set.restrictPreimage_closedEmbedding
 
 theorem Set.restrictPreimage_isClosedMap (s : Set β) (H : IsClosedMap f) :
     IsClosedMap (s.restrictPreimage f) := by
-  rintro t ⟨u, hu, e⟩
-  refine' ⟨⟨_, (H _ (IsOpen.isClosed_compl hu)).1, _⟩⟩
-  rw [← (congr_arg HasCompl.compl e).trans (compl_compl t)]
-  simp only [Set.preimage_compl, compl_inj_iff]
-  ext ⟨x, hx⟩
-  suffices (∃ y, y ∉ u ∧ f y = x) ↔ ∃ y, y ∉ u ∧ f y ∈ s ∧ f y = x by
-    simpa [Set.restrictPreimage, ← Subtype.coe_inj]
-  exact ⟨fun ⟨a, b, c⟩ => ⟨a, b, c.symm ▸ hx, c⟩, fun ⟨a, b, _, c⟩ => ⟨a, b, c⟩⟩
-#align set.restrict_preimage_is_closed_map Set.restrictPreimage_isClosedMap
+  intro t ⟨u, hu, e⟩
+  refine' ⟨(f '' uᶜ)ᶜ, isOpen_compl_iff.2 (H uᶜ (IsOpen.isClosed_compl hu)), _⟩
+  simp [e, ← image_restrictPreimage]
 
 theorem Set.restrictPreimage_isOpenMap (s : Set β) (H : IsOpenMap f) :
     IsOpenMap (s.restrictPreimage f) := by

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -75,6 +75,15 @@ theorem Set.restrictPreimage_isClosedMap (s : Set β) (H : IsClosedMap f) :
   exact ⟨fun ⟨a, b, c⟩ => ⟨a, b, c.symm ▸ hx, c⟩, fun ⟨a, b, _, c⟩ => ⟨a, b, c⟩⟩
 #align set.restrict_preimage_is_closed_map Set.restrictPreimage_isClosedMap
 
+theorem Set.restrictPreimage_isOpenMap (s : Set β) (H : IsOpenMap f) :
+    IsOpenMap (s.restrictPreimage f) := by
+  intro t ⟨u, hu, e⟩
+  refine' ⟨f '' u, H u hu, _⟩
+  unfold restrictPreimage
+  rw [← preimage_image_eq  (_ '' t) (Subtype.coe_injective), ← image_comp, MapsTo.restrict_commutes,
+    ← e, image_comp, image_preimage_eq_inter_range, Subtype.range_coe, image_inter_preimage,
+    inter_comm, Subtype.preimage_coe_self_inter]
+
 theorem isOpen_iff_inter_of_iSup_eq_top (s : Set β) : IsOpen s ↔ ∀ i, IsOpen (s ∩ U i) := by
   constructor
   · exact fun H i => H.inter (U i).2

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -64,13 +64,16 @@ alias ClosedEmbedding.restrictPreimage := Set.restrictPreimage_closedEmbedding
 #align closed_embedding.restrict_preimage ClosedEmbedding.restrictPreimage
 
 theorem Set.restrictPreimage_isClosedMap (s : Set β) (H : IsClosedMap f) :
-    IsClosedMap (s.restrictPreimage f) :=
-  fun t ⟨u, hu, e⟩ =>  ⟨(f '' uᶜ)ᶜ, isOpen_compl_iff.2 (H uᶜ (IsOpen.isClosed_compl hu)),
-    by simp [e, ← image_restrictPreimage]⟩
+    IsClosedMap (s.restrictPreimage f) := by
+  intro t
+  simp [isClosed_induced_iff]
+  exact fun u hu e => ⟨f '' u, H u hu, by simp [← e, image_restrictPreimage]⟩
 
 theorem Set.restrictPreimage_isOpenMap (s : Set β) (H : IsOpenMap f) :
-    IsOpenMap (s.restrictPreimage f) :=
-  fun t ⟨u, hu, e⟩ => ⟨f '' u, H u hu, by rw [← e, image_restrictPreimage]⟩
+    IsOpenMap (s.restrictPreimage f) := by
+  intro t
+  simp [isOpen_induced_iff]
+  exact fun u hu e => ⟨f '' u, H u hu, by simp [← e, image_restrictPreimage]⟩
 
 theorem isOpen_iff_inter_of_iSup_eq_top (s : Set β) : IsOpen s ↔ ∀ i, IsOpen (s ∩ U i) := by
   constructor

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -79,10 +79,7 @@ theorem Set.restrictPreimage_isOpenMap (s : Set β) (H : IsOpenMap f) :
     IsOpenMap (s.restrictPreimage f) := by
   intro t ⟨u, hu, e⟩
   refine' ⟨f '' u, H u hu, _⟩
-  unfold restrictPreimage
-  rw [← preimage_image_eq  (_ '' t) (Subtype.coe_injective), ← image_comp, MapsTo.restrict_commutes,
-    ← e, image_comp, image_preimage_eq_inter_range, Subtype.range_coe, image_inter_preimage,
-    inter_comm, Subtype.preimage_coe_self_inter]
+  rw [← e, image_restrictPreimage]
 
 theorem isOpen_iff_inter_of_iSup_eq_top (s : Set β) : IsOpen s ↔ ∀ i, IsOpen (s ∩ U i) := by
   constructor

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -64,16 +64,13 @@ alias ClosedEmbedding.restrictPreimage := Set.restrictPreimage_closedEmbedding
 #align closed_embedding.restrict_preimage ClosedEmbedding.restrictPreimage
 
 theorem Set.restrictPreimage_isClosedMap (s : Set β) (H : IsClosedMap f) :
-    IsClosedMap (s.restrictPreimage f) := by
-  intro t ⟨u, hu, e⟩
-  refine' ⟨(f '' uᶜ)ᶜ, isOpen_compl_iff.2 (H uᶜ (IsOpen.isClosed_compl hu)), _⟩
-  simp [e, ← image_restrictPreimage]
+    IsClosedMap (s.restrictPreimage f) :=
+  fun t ⟨u, hu, e⟩ =>  ⟨(f '' uᶜ)ᶜ, isOpen_compl_iff.2 (H uᶜ (IsOpen.isClosed_compl hu)),
+    by simp [e, ← image_restrictPreimage]⟩
 
 theorem Set.restrictPreimage_isOpenMap (s : Set β) (H : IsOpenMap f) :
-    IsOpenMap (s.restrictPreimage f) := by
-  intro t ⟨u, hu, e⟩
-  refine' ⟨f '' u, H u hu, _⟩
-  rw [← e, image_restrictPreimage]
+    IsOpenMap (s.restrictPreimage f) :=
+  fun t ⟨u, hu, e⟩ => ⟨f '' u, H u hu, by rw [← e, image_restrictPreimage]⟩
 
 theorem isOpen_iff_inter_of_iSup_eq_top (s : Set β) : IsOpen s ↔ ∀ i, IsOpen (s ∩ U i) := by
   constructor

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -63,7 +63,7 @@ theorem Set.restrictPreimage_closedEmbedding (s : Set β) (h : ClosedEmbedding f
 alias ClosedEmbedding.restrictPreimage := Set.restrictPreimage_closedEmbedding
 #align closed_embedding.restrict_preimage ClosedEmbedding.restrictPreimage
 
-theorem Set.restrictPreimage_isClosedMap (s : Set β) (H : IsClosedMap f) :
+theorem IsClosedMap.restrictPreimage (H : IsClosedMap f) (s : Set β) :
     IsClosedMap (s.restrictPreimage f) := by
   intro t
   suffices ∀ u, IsClosed u → Subtype.val ⁻¹' u = t →
@@ -71,13 +71,21 @@ theorem Set.restrictPreimage_isClosedMap (s : Set β) (H : IsClosedMap f) :
       simpa [isClosed_induced_iff]
   exact fun u hu e => ⟨f '' u, H u hu, by simp [← e, image_restrictPreimage]⟩
 
-theorem Set.restrictPreimage_isOpenMap (s : Set β) (H : IsOpenMap f) :
+@[deprecated] -- since 2024-04-02
+theorem Set.restrictPreimage_isClosedMap (s : Set β) (H : IsClosedMap f) :
+    IsClosedMap (s.restrictPreimage f) := H.restrictPreimage s
+
+theorem IsOpenMap.restrictPreimage (H : IsOpenMap f) (s : Set β) :
     IsOpenMap (s.restrictPreimage f) := by
   intro t
   suffices ∀ u, IsOpen u → Subtype.val ⁻¹' u = t →
     ∃ v, IsOpen v ∧ Subtype.val ⁻¹' v = s.restrictPreimage f '' t by
       simpa [isOpen_induced_iff]
   exact fun u hu e => ⟨f '' u, H u hu, by simp [← e, image_restrictPreimage]⟩
+
+@[deprecated] -- since 2024-04-02
+theorem Set.restrictPreimage_isOpenMap (s : Set β) (H : IsOpenMap f) :
+    IsOpenMap (s.restrictPreimage f) := H.restrictPreimage s
 
 theorem isOpen_iff_inter_of_iSup_eq_top (s : Set β) : IsOpen s ↔ ∀ i, IsOpen (s ∩ U i) := by
   constructor
@@ -107,7 +115,7 @@ theorem isClosed_iff_coe_preimage_of_iSup_eq_top (s : Set β) :
 
 theorem isClosedMap_iff_isClosedMap_of_iSup_eq_top :
     IsClosedMap f ↔ ∀ i, IsClosedMap ((U i).1.restrictPreimage f) := by
-  refine' ⟨fun h i => Set.restrictPreimage_isClosedMap _ h, _⟩
+  refine' ⟨fun h i => h.restrictPreimage _, _⟩
   rintro H s hs
   rw [isClosed_iff_coe_preimage_of_iSup_eq_top hU]
   intro i

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -66,13 +66,17 @@ alias ClosedEmbedding.restrictPreimage := Set.restrictPreimage_closedEmbedding
 theorem Set.restrictPreimage_isClosedMap (s : Set β) (H : IsClosedMap f) :
     IsClosedMap (s.restrictPreimage f) := by
   intro t
-  simp [isClosed_induced_iff]
+  suffices ∀ u, IsClosed u → Subtype.val ⁻¹' u = t →
+    ∃ v, IsClosed v ∧ Subtype.val ⁻¹' v = s.restrictPreimage f '' t by
+      simpa [isClosed_induced_iff]
   exact fun u hu e => ⟨f '' u, H u hu, by simp [← e, image_restrictPreimage]⟩
 
 theorem Set.restrictPreimage_isOpenMap (s : Set β) (H : IsOpenMap f) :
     IsOpenMap (s.restrictPreimage f) := by
   intro t
-  simp [isOpen_induced_iff]
+  suffices ∀ u, IsOpen u → Subtype.val ⁻¹' u = t →
+    ∃ v, IsOpen v ∧ Subtype.val ⁻¹' v = s.restrictPreimage f '' t by
+      simpa [isOpen_induced_iff]
   exact fun u hu e => ⟨f '' u, H u hu, by simp [← e, image_restrictPreimage]⟩
 
 theorem isOpen_iff_inter_of_iSup_eq_top (s : Set β) : IsOpen s ↔ ∀ i, IsOpen (s ∩ U i) := by


### PR DESCRIPTION
- add the theorem `image_restrictPreimage`; use it to simplify the proof of `Set.restrictPreimage_isClosedMap`
- add the equivalent for open maps `Set.restrictPreimage_isOpenMap`.
- delete `IsClosedMap.restrictPreimage`, which duplicates `Set.restrictPreimage_isClosedMap`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This PR adds the theorem `image_restrictPreimage` and uses it to simplify the proof of `Set.restrictPreimage_isClosedMap`. It also adds the equivalent for open maps `Set.restrictPreimage_isOpenMap`.
The duplicate `IsClosedMap.restrictPreimage` of `Set.restrictPreimage_isClosedMap` has been deleted.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
