### PR TITLE
[Merged by Bors] - fix: label new contributors?

### DIFF
--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: Get PR author
       id: pr-author
-      run: echo "author=$(jq -r .pull_request.user.login "$GITHUB_EVENT_PATH")" >> "${GITHUB_OUTPUT}"
+      run: echo "author=$(jq -r .head_commit.author.name "$GITHUB_EVENT_PATH")" >> "${GITHUB_OUTPUT}"
       shell: bash
 
     - name: Check if user is new contributor
@@ -29,7 +29,7 @@ jobs:
             state: "closed",
             author
           })
-          return (prs.data.length < 5)
+          return (prs.data.length > 5)
 
     - name: Add label if new contributor
       if: steps.check-contributor.outputs.result == 'true'

--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -29,7 +29,7 @@ jobs:
             state: "closed",
             author
           })
-          return (prs.data.length > 5)
+          return (prs.data.length < 5)
 
     - name: Add label if new contributor
       if: steps.check-contributor.outputs.result == 'true'


### PR DESCRIPTION
This PR hopefully fixes the automatic labeling of new contributors.

I looked for the entry `.pull_request.user.login` but I could not find it.  For this reason, I switched to using the existing `.head_commit.author.name`.

You can look at the `install elan` step of [this CI run](https://github.com/leanprover-community/mathlib4/actions/runs/8419868223/job/23053404627?pr=11656) to see what are the available fields.

As a small sanity check, the first commit of this PR changed `< 5 PRs` to `> 5 PRs` and the bot added the `new-contributor` label to this PR.  The second commit reverted this change.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.60new-contributor.60.20labelling.20workflow.20broken.3F)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
