### PR TITLE
[Merged by Bors] - feat(CategoryTheory/GradedObject): the right unitor

### DIFF
--- a/Mathlib/CategoryTheory/GradedObject/Unitor.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Unitor.lean
@@ -12,8 +12,10 @@ Given a bifunctor `F : C ⥤ D ⥤ D`, an object `X : C` such that `F.obj X ≅ 
 map `p : I × J → J` such that `hp : ∀ (j : J), p ⟨0, j⟩ = j`,
 we define an isomorphism of `J`-graded objects for any `Y : GradedObject J D`.
 `mapBifunctorLeftUnitor F X e p hp Y : mapBifunctorMapObj F p ((single₀ I).obj X) Y ≅ Y`.
+Under similar assumptions, we also obtain a right unitor isomorphism
+`mapBifunctorMapObj F p X ((single₀ I).obj Y) ≅ X`.
 
-TODO (@joelriou): define similarly a right unitor isomorphism and get the triangle identity.
+TODO (@joelriou): get the triangle identity.
 
 -/
 
@@ -97,7 +99,7 @@ noncomputable def mapBifunctorLeftUnitor : mapBifunctorMapObj F p ((single₀ I)
     (mapBifunctorLeftUnitorCofanIsColimit F X e p hp Y j)).symm)
 
 @[reassoc (attr := simp)]
-lemma ι_mapBifunctorLeftUnitor_hom (j : J) :
+lemma ι_mapBifunctorLeftUnitor_hom_apply (j : J) :
     ιMapBifunctorMapObj F p ((single₀ I).obj X) Y 0 j j (hp j) ≫
       (mapBifunctorLeftUnitor F X e p hp Y).hom j =
       (F.map (singleObjApplyIso (0 : I) X).hom).app _ ≫ e.hom.app (Y j) := by
@@ -133,6 +135,122 @@ lemma mapBifunctorLeftUnitor_naturality :
     comp_id, mapBifunctorLeftUnitor_inv_naturality, Iso.hom_inv_id_assoc]
 
 end LeftUnitor
+
+section RightUnitor
+
+variable {C D I J : Type*} [Category C] [Category D]
+  [Zero I] [DecidableEq I] [HasInitial C]
+  (F : D ⥤ C ⥤ D) (Y : C) (e : F.flip.obj Y ≅ 𝟭 D)
+  [∀ (X : D), PreservesColimit (Functor.empty.{0} C) (F.obj X)]
+  (p : J × I → J)
+  (hp : ∀ (j : J), p ⟨j, 0⟩ = j) (X X' : GradedObject J D) (φ : X ⟶ X')
+
+/-- Given `F : D ⥤ C ⥤ D`, `Y : C`, `e : F.flip.obj X ≅ 𝟭 D` and `X : GradedObject J D`,
+this is the isomorphism `((mapBifunctor F J I).obj X).obj ((single₀ I).obj Y) a ≅ Y a.2`
+when `a : J × I` is such that `a.2 = 0`. -/
+@[simps!]
+noncomputable def mapBifunctorObjObjSingle₀Iso (a : J × I) (ha : a.2 = 0) :
+    ((mapBifunctor F J I).obj X).obj ((single₀ I).obj Y) a ≅ X a.1 :=
+  Functor.mapIso _ (singleObjApplyIsoOfEq _ Y _ ha) ≪≫ e.app (X a.1)
+
+/-- Given `F : D ⥤ C ⥤ D`, `Y : C` and `X : GradedObject J D`,
+`((mapBifunctor F J I).obj X).obj ((single₀ I).obj X) a` is an initial when `a : J × I`
+is such that `a.2 ≠ 0`. -/
+noncomputable def mapBifunctorObjObjSingle₀IsInitial (a : J × I) (ha : a.2 ≠ 0) :
+    IsInitial (((mapBifunctor F J I).obj X).obj ((single₀ I).obj Y) a) :=
+  IsInitial.isInitialObj (F.obj (X a.1)) _ (isInitialSingleObjApply _ _ _ ha)
+
+/-- Given `F : D ⥤ C ⥤ D`, `Y : C`, `e : F.flip.obj Y ≅ 𝟭 D`, `X : GradedObject J D` and
+`p : J × I → J` such that `p ⟨j, 0⟩ = j` for all `j`,
+this is the (colimit) cofan which shall be used to construct the isomorphism
+`mapBifunctorMapObj F p X ((single₀ I).obj Y) ≅ X`, see `mapBifunctorRightUnitor`. -/
+noncomputable def mapBifunctorRightUnitorCofan (j : J) :
+    (((mapBifunctor F J I).obj X).obj ((single₀ I).obj Y)).CofanMapObjFun p j :=
+  CofanMapObjFun.mk _ _ _ (X j) (fun a ha =>
+    if ha : a.2 = 0 then
+      (mapBifunctorObjObjSingle₀Iso F Y e X a ha).hom ≫ eqToHom (by aesop)
+    else
+      (mapBifunctorObjObjSingle₀IsInitial F Y X a ha).to _)
+
+@[simp, reassoc]
+lemma mapBifunctorRightUnitorCofan_inj (j : J) :
+    (mapBifunctorRightUnitorCofan F Y e p hp X j).inj ⟨⟨j, 0⟩, hp j⟩ =
+      (F.obj (X j)).map (singleObjApplyIso (0 : I) Y).hom ≫ e.hom.app (X j) := by
+  simp [mapBifunctorRightUnitorCofan]
+
+/-- The cofan `mapBifunctorRightUnitorCofan F Y e p hp X j` is a colimit. -/
+noncomputable def mapBifunctorRightUnitorCofanIsColimit (j : J) :
+    IsColimit (mapBifunctorRightUnitorCofan F Y e p hp X j) :=
+  mkCofanColimit _
+    (fun s => e.inv.app (X j) ≫
+      (F.obj (X j)).map (singleObjApplyIso (0 : I) Y).inv ≫ s.inj ⟨⟨j, 0⟩, hp j⟩)
+    (fun s => by
+      rintro ⟨⟨j', i⟩, h⟩
+      by_cases hi : i = 0
+      · subst hi
+        simp only [Set.mem_preimage, hp, Set.mem_singleton_iff] at h
+        subst h
+        dsimp
+        rw [mapBifunctorRightUnitorCofan_inj, assoc, Iso.hom_inv_id_app_assoc,
+          ← Functor.map_comp_assoc, Iso.hom_inv_id, Functor.map_id, id_comp]
+      · apply IsInitial.hom_ext
+        exact mapBifunctorObjObjSingle₀IsInitial _ _ _ _ hi)
+    (fun s m hm => by
+      dsimp
+      rw [← hm ⟨⟨j, 0⟩, hp j⟩, mapBifunctorRightUnitorCofan_inj, assoc, ← Functor.map_comp_assoc,
+        Iso.inv_hom_id, Functor.map_id, id_comp, Iso.inv_hom_id_app_assoc])
+
+lemma mapBifunctorRightUnitor_hasMap :
+    HasMap (((mapBifunctor F J I).obj X).obj ((single₀ I).obj Y)) p :=
+  CofanMapObjFun.hasMap _ _ _ (mapBifunctorRightUnitorCofanIsColimit F Y e p hp X)
+
+variable [HasMap (((mapBifunctor F J I).obj X).obj ((single₀ I).obj Y)) p]
+  [HasMap (((mapBifunctor F J I).obj X').obj ((single₀ I).obj Y)) p]
+
+/-- Given `F : D ⥤ C ⥤ D`, `Y : C`, `e : F.flip.obj Y ≅ 𝟭 D`, `X : GradedObject J D` and
+`p : J × I → J` such that `p ⟨j, 0⟩ = j` for all `j`,
+this is the right unitor isomorphism `mapBifunctorMapObj F p X ((single₀ I).obj Y) ≅ X`. -/
+noncomputable def mapBifunctorRightUnitor : mapBifunctorMapObj F p X ((single₀ I).obj Y) ≅ X :=
+  isoMk _ _ (fun j => (CofanMapObjFun.iso
+    (mapBifunctorRightUnitorCofanIsColimit F Y e p hp X j)).symm)
+
+@[reassoc (attr := simp)]
+lemma ι_mapBifunctorRightUnitor_hom_apply (j : J) :
+    ιMapBifunctorMapObj F p X ((single₀ I).obj Y) j 0 j (hp j) ≫
+        (mapBifunctorRightUnitor F Y e p hp X).hom j =
+      (F.obj (X j)).map (singleObjApplyIso (0 : I) Y).hom ≫ e.hom.app (X j) := by
+  dsimp [mapBifunctorRightUnitor]
+  erw [CofanMapObjFun.ιMapObj_iso_inv]
+  rw [mapBifunctorRightUnitorCofan_inj]
+
+lemma mapBifunctorRightUnitor_inv_apply (j : J) :
+    (mapBifunctorRightUnitor F Y e p hp X).inv j =
+      e.inv.app (X j) ≫ (F.obj (X j)).map (singleObjApplyIso (0 : I) Y).inv ≫
+        ιMapBifunctorMapObj F p X ((single₀ I).obj Y) j 0 j (hp j) := rfl
+
+variable {Y Y'}
+
+@[reassoc]
+lemma mapBifunctorRightUnitor_inv_naturality :
+    φ ≫ (mapBifunctorRightUnitor F Y e p hp X').inv =
+      (mapBifunctorRightUnitor F Y e p hp X).inv ≫ mapBifunctorMapMap F p φ (𝟙 _):= by
+  ext j
+  dsimp
+  rw [mapBifunctorRightUnitor_inv_apply, mapBifunctorRightUnitor_inv_apply, assoc, assoc,
+    ι_mapBifunctorMapMap]
+  dsimp
+  rw [Functor.map_id, id_comp, NatTrans.naturality_assoc]
+  erw [← NatTrans.naturality_assoc]
+  rfl
+
+@[reassoc]
+lemma mapBifunctorRightUnitor_naturality :
+    mapBifunctorMapMap F p φ (𝟙 _) ≫ (mapBifunctorRightUnitor F Y e p hp X').hom =
+      (mapBifunctorRightUnitor F Y e p hp X).hom ≫ φ := by
+  rw [← cancel_mono (mapBifunctorRightUnitor F Y e p hp X').inv, assoc, assoc, Iso.hom_inv_id,
+    comp_id, mapBifunctorRightUnitor_inv_naturality, Iso.hom_inv_id_assoc]
+
+end RightUnitor
 
 end GradedObject
 


### PR DESCRIPTION
This PR defines a right unitor isomorphism for graded objects. The code is completely parallel to PR #10701.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
