### PR TITLE
[Merged by Bors] - feat(Algebra/GroupWithZero): add `dvd_of_mul_dvd_mul`

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Divisibility.lean
+++ b/Mathlib/Algebra/GroupWithZero/Divisibility.lean
@@ -175,7 +175,7 @@ lemma dvd_of_mul_dvd_mul_left {c : α} (hc : c ≠ 0)
 
 lemma dvd_of_mul_dvd_mul_right {c : α} (hc : c ≠ 0)
     (H : a * c ∣ b * c) : a ∣ b := by
-    rw [mul_comm a c, mul_comm b c] at H
-    exact dvd_of_mul_dvd_mul_left hc H
+  rw [mul_comm a c, mul_comm b c] at H
+  exact dvd_of_mul_dvd_mul_left hc H
 
 end CancelCommMonoidWithZero

--- a/Mathlib/Algebra/GroupWithZero/Divisibility.lean
+++ b/Mathlib/Algebra/GroupWithZero/Divisibility.lean
@@ -168,4 +168,14 @@ theorem eq_of_forall_dvd' (h : ∀ c, c ∣ a ↔ c ∣ b) : a = b :=
   ((h _).1 dvd_rfl).antisymm <| (h _).2 dvd_rfl
 #align eq_of_forall_dvd' eq_of_forall_dvd'
 
+lemma dvd_of_mul_dvd_mul_left {c : α} (hc : c ≠ 0)
+    (H : c * a ∣ c * b) : a ∣ b := by
+  rcases H with ⟨d, hd⟩
+  exact ⟨d, by simpa [mul_assoc, hc] using hd⟩
+
+lemma dvd_of_mul_dvd_mul_right {c : α} (hc : c ≠ 0)
+    (H : a * c ∣ b * c) : a ∣ b := by
+    rw [mul_comm a c, mul_comm b c] at H
+    exact dvd_of_mul_dvd_mul_left hc H
+
 end CancelCommMonoidWithZero


### PR DESCRIPTION
`dvd_of_mul_dvd_mul_left` and `dvd_of_mul_dvd_mul_right` were implemented only for `Nat` and `Int`.

We've generalised it for `CancelCommMonoidWithZero`.