### PR TITLE
[Merged by Bors] - fix: use username to label new contributors

### DIFF
--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: Get PR author
       id: pr-author
-      run: echo "author=$(jq -r .head_commit.author.name "$GITHUB_EVENT_PATH")" >> "${GITHUB_OUTPUT}"
+      run: echo "author=$(jq -r .head_commit.author.username "$GITHUB_EVENT_PATH")" >> "${GITHUB_OUTPUT}"
       shell: bash
 
     - name: Check if user is new contributor


### PR DESCRIPTION
[Zulip message](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.60new-contributor.60.20labelling.20workflow.20broken.3F/near/429629879)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
