### PR TITLE
[Merged by Bors] - feat(Algebra/GroupWithZero): remove already existing lemmas

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Divisibility.lean
+++ b/Mathlib/Algebra/GroupWithZero/Divisibility.lean
@@ -168,14 +168,4 @@ theorem eq_of_forall_dvd' (h : ∀ c, c ∣ a ↔ c ∣ b) : a = b :=
   ((h _).1 dvd_rfl).antisymm <| (h _).2 dvd_rfl
 #align eq_of_forall_dvd' eq_of_forall_dvd'
 
-lemma dvd_of_mul_dvd_mul_left {c : α} (hc : c ≠ 0)
-    (H : c * a ∣ c * b) : a ∣ b := by
-  rcases H with ⟨d, hd⟩
-  exact ⟨d, by simpa [mul_assoc, hc] using hd⟩
-
-lemma dvd_of_mul_dvd_mul_right {c : α} (hc : c ≠ 0)
-    (H : a * c ∣ b * c) : a ∣ b := by
-  rw [mul_comm a c, mul_comm b c] at H
-  exact dvd_of_mul_dvd_mul_left hc H
-
 end CancelCommMonoidWithZero


### PR DESCRIPTION
Undo #11677 since we have found out that the lemmas

https://github.com/leanprover-community/mathlib4/blob/044f1333d4e273d0d45e7fdeaf07266d7e043c32/Mathlib/Algebra/GroupWithZero/Divisibility.lean#L171-L179

already exist in the same file with different names `mul_dvd_mul_iff_left` and `mul_dvd_mul_iff_right`: 

https://github.com/leanprover-community/mathlib4/blob/0f2ac6785f4ecb39c798a30eee01dafa63c828d7/Mathlib/Algebra/GroupWithZero/Divisibility.lean#L46-L58