### PR TITLE
[Merged by Bors] - feat(Algebra/Divisibility): generalise `mul_dvd_mul_left` to `Monoid`

### DIFF
--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -238,7 +238,7 @@ theorem mul_dvd_mul_right (h : a ∣ b) (c : α) : a * c ∣ b * c :=
   mul_dvd_mul h (dvd_refl c)
 #align mul_dvd_mul_right mul_dvd_mul_right
 
-theorem pow_dvd_pow_of_dvd (h : a ∣ b) : ∀ n : ℕ, a ^ n ∣ b ^ n
+theorem pow_dvd_pow_of_dvd {a b : α} (h : a ∣ b) : ∀ n : ℕ, a ^ n ∣ b ^ n
   | 0 => by rw [pow_zero, pow_zero]
   | n + 1 => by
     rw [pow_succ, pow_succ]

--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -130,7 +130,7 @@ theorem exists_dvd_and_dvd_of_dvd_mul [DecompositionMonoid α] {b c a : α} (H :
 end Semigroup
 
 section Monoid
-variable [Monoid α] {a b : α} {m n : ℕ}
+variable [Monoid α] {a b c : α} {m n : ℕ}
 
 @[refl, simp]
 theorem dvd_refl (a : α) : a ∣ a :=
@@ -166,6 +166,12 @@ alias Dvd.dvd.pow := dvd_pow
 
 lemma dvd_pow_self (a : α) {n : ℕ} (hn : n ≠ 0) : a ∣ a ^ n := dvd_rfl.pow hn
 #align dvd_pow_self dvd_pow_self
+
+theorem mul_dvd_mul_left (h : b ∣ c) : a * b ∣ a * c := by
+  obtain ⟨d, rfl⟩ := h
+  use d
+  rw [mul_assoc]
+#align mul_dvd_mul_left mul_dvd_mul_left
 
 end Monoid
 
@@ -228,15 +234,11 @@ section CommMonoid
 
 variable [CommMonoid α] {a b : α}
 
-theorem mul_dvd_mul_left (a : α) {b c : α} (h : b ∣ c) : a * b ∣ a * c :=
-  mul_dvd_mul (dvd_refl a) h
-#align mul_dvd_mul_left mul_dvd_mul_left
-
 theorem mul_dvd_mul_right (h : a ∣ b) (c : α) : a * c ∣ b * c :=
   mul_dvd_mul h (dvd_refl c)
 #align mul_dvd_mul_right mul_dvd_mul_right
 
-theorem pow_dvd_pow_of_dvd {a b : α} (h : a ∣ b) : ∀ n : ℕ, a ^ n ∣ b ^ n
+theorem pow_dvd_pow_of_dvd (h : a ∣ b) : ∀ n : ℕ, a ^ n ∣ b ^ n
   | 0 => by rw [pow_zero, pow_zero]
   | n + 1 => by
     rw [pow_succ, pow_succ]

--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -130,7 +130,7 @@ theorem exists_dvd_and_dvd_of_dvd_mul [DecompositionMonoid α] {b c a : α} (H :
 end Semigroup
 
 section Monoid
-variable [Monoid α] {a b c : α} {m n : ℕ}
+variable [Monoid α] {a b : α} {m n : ℕ}
 
 @[refl, simp]
 theorem dvd_refl (a : α) : a ∣ a :=
@@ -167,7 +167,7 @@ alias Dvd.dvd.pow := dvd_pow
 lemma dvd_pow_self (a : α) {n : ℕ} (hn : n ≠ 0) : a ∣ a ^ n := dvd_rfl.pow hn
 #align dvd_pow_self dvd_pow_self
 
-theorem mul_dvd_mul_left (h : b ∣ c) : a * b ∣ a * c := by
+theorem mul_dvd_mul_left {c : α} (h : b ∣ c) : a * b ∣ a * c := by
   obtain ⟨d, rfl⟩ := h
   use d
   rw [mul_assoc]

--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -130,7 +130,7 @@ theorem exists_dvd_and_dvd_of_dvd_mul [DecompositionMonoid α] {b c a : α} (H :
 end Semigroup
 
 section Monoid
-variable [Monoid α] {a b : α} {m n : ℕ}
+variable [Monoid α] {a b c : α} {m n : ℕ}
 
 @[refl, simp]
 theorem dvd_refl (a : α) : a ∣ a :=
@@ -167,7 +167,7 @@ alias Dvd.dvd.pow := dvd_pow
 lemma dvd_pow_self (a : α) {n : ℕ} (hn : n ≠ 0) : a ∣ a ^ n := dvd_rfl.pow hn
 #align dvd_pow_self dvd_pow_self
 
-theorem mul_dvd_mul_left (a : α) {b c : α} (h : b ∣ c) : a * b ∣ a * c := by
+theorem mul_dvd_mul_left (a : α) (h : b ∣ c) : a * b ∣ a * c := by
   obtain ⟨d, rfl⟩ := h
   use d
   rw [mul_assoc]
@@ -238,7 +238,7 @@ theorem mul_dvd_mul_right (h : a ∣ b) (c : α) : a * c ∣ b * c :=
   mul_dvd_mul h (dvd_refl c)
 #align mul_dvd_mul_right mul_dvd_mul_right
 
-theorem pow_dvd_pow_of_dvd {a b : α} (h : a ∣ b) : ∀ n : ℕ, a ^ n ∣ b ^ n
+theorem pow_dvd_pow_of_dvd (h : a ∣ b) : ∀ n : ℕ, a ^ n ∣ b ^ n
   | 0 => by rw [pow_zero, pow_zero]
   | n + 1 => by
     rw [pow_succ, pow_succ]

--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -167,7 +167,7 @@ alias Dvd.dvd.pow := dvd_pow
 lemma dvd_pow_self (a : α) {n : ℕ} (hn : n ≠ 0) : a ∣ a ^ n := dvd_rfl.pow hn
 #align dvd_pow_self dvd_pow_self
 
-theorem mul_dvd_mul_left {a b c : α} (h : b ∣ c) : a * b ∣ a * c := by
+theorem mul_dvd_mul_left {c : α} (h : b ∣ c) : a * b ∣ a * c := by
   obtain ⟨d, rfl⟩ := h
   use d
   rw [mul_assoc]

--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -167,7 +167,7 @@ alias Dvd.dvd.pow := dvd_pow
 lemma dvd_pow_self (a : α) {n : ℕ} (hn : n ≠ 0) : a ∣ a ^ n := dvd_rfl.pow hn
 #align dvd_pow_self dvd_pow_self
 
-theorem mul_dvd_mul_left {c : α} (h : b ∣ c) : a * b ∣ a * c := by
+theorem mul_dvd_mul_left (a : α) {b c : α} (h : b ∣ c) : a * b ∣ a * c := by
   obtain ⟨d, rfl⟩ := h
   use d
   rw [mul_assoc]

--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -167,7 +167,7 @@ alias Dvd.dvd.pow := dvd_pow
 lemma dvd_pow_self (a : α) {n : ℕ} (hn : n ≠ 0) : a ∣ a ^ n := dvd_rfl.pow hn
 #align dvd_pow_self dvd_pow_self
 
-theorem mul_dvd_mul_left {c : α} (h : b ∣ c) : a * b ∣ a * c := by
+theorem mul_dvd_mul_left {a b c : α} (h : b ∣ c) : a * b ∣ a * c := by
   obtain ⟨d, rfl⟩ := h
   use d
   rw [mul_assoc]

--- a/Mathlib/Algebra/Divisibility/Units.lean
+++ b/Mathlib/Algebra/Divisibility/Units.lean
@@ -228,7 +228,7 @@ theorem IsRelPrime.dvd_of_dvd_mul_left_of_isPrimal (H1 : IsRelPrime x y) (H2 : x
 theorem IsRelPrime.mul_dvd_of_right_isPrimal (H : IsRelPrime x y) (H1 : x ∣ z) (H2 : y ∣ z)
     (hy : IsPrimal y) : x * y ∣ z := by
   obtain ⟨w, rfl⟩ := H1
-  exact mul_dvd_mul_left (H.symm.dvd_of_dvd_mul_left_of_isPrimal H2 hy)
+  exact mul_dvd_mul_left x (H.symm.dvd_of_dvd_mul_left_of_isPrimal H2 hy)
 
 theorem IsRelPrime.mul_dvd_of_left_isPrimal (H : IsRelPrime x y) (H1 : x ∣ z) (H2 : y ∣ z)
     (hx : IsPrimal x) : x * y ∣ z := by

--- a/Mathlib/Algebra/Divisibility/Units.lean
+++ b/Mathlib/Algebra/Divisibility/Units.lean
@@ -228,7 +228,7 @@ theorem IsRelPrime.dvd_of_dvd_mul_left_of_isPrimal (H1 : IsRelPrime x y) (H2 : x
 theorem IsRelPrime.mul_dvd_of_right_isPrimal (H : IsRelPrime x y) (H1 : x ∣ z) (H2 : y ∣ z)
     (hy : IsPrimal y) : x * y ∣ z := by
   obtain ⟨w, rfl⟩ := H1
-  exact mul_dvd_mul_left x (H.symm.dvd_of_dvd_mul_left_of_isPrimal H2 hy)
+  exact mul_dvd_mul_left (H.symm.dvd_of_dvd_mul_left_of_isPrimal H2 hy)
 
 theorem IsRelPrime.mul_dvd_of_left_isPrimal (H : IsRelPrime x y) (H1 : x ∣ z) (H2 : y ∣ z)
     (hx : IsPrimal x) : x * y ∣ z := by


### PR DESCRIPTION
`mul_dvd_mul_left` was implemented for `CommMonoid`.

We have generalised it to `Monoid`.