### PR TITLE
[Merged by Bors] - feat: make `notation3` delaborator not match instance arguments

### DIFF
--- a/Mathlib/Mathport/Notation.lean
+++ b/Mathlib/Mathport/Notation.lean
@@ -259,7 +259,7 @@ partial def exprToMatcher (boundFVars : HashMap FVarId Name) (localFVars : HashM
         fty ← whnf fty
         guard fty.isForall
         let bi := fty.bindingInfo!
-        fty := fty.instantiate1 arg
+        fty := fty.bindingBody!.instantiate1 arg
         if bi.isInstImplicit then
           -- Assumption: elaborated instances are canonical, so no need to match.
           -- The type of the instance is already accounted for by the previous arguments

--- a/Mathlib/Mathport/Notation.lean
+++ b/Mathlib/Mathport/Notation.lean
@@ -259,6 +259,7 @@ partial def exprToMatcher (boundFVars : HashMap FVarId Name) (localFVars : HashM
         fty ← whnf fty
         guard fty.isForall
         let bi := fty.bindingInfo!
+        fty := fty.instantiate1 arg
         if bi.isInstImplicit then
           -- Assumption: elaborated instances are canonical, so no need to match.
           -- The type of the instance is already accounted for by the previous arguments

--- a/Mathlib/Mathport/Notation.lean
+++ b/Mathlib/Mathport/Notation.lean
@@ -583,7 +583,7 @@ elab (name := notation3) doc:(docComment)? attrs?:(Parser.Term.attributes)? attr
       trace[notation3] "Matcher creation succeeded; assembling delaborator"
       let delabName := name ++ `delab
       let matcher ← ms.foldrM (fun m t => `($(m.2) >=> $t)) (← `(pure))
-      trace[notation3] "matcher: {indentD matcher}"
+      trace[notation3] "matcher:{indentD matcher}"
       let mut result ← `(`($pat))
       for (name, id) in boundIdents.toArray do
         match boundType.findD name .normal with

--- a/test/notation3.lean
+++ b/test/notation3.lean
@@ -176,3 +176,23 @@ open scoped MyNotation
 #guard_msgs in #check π
 
 end test_scoped
+
+/-!
+Verifying that delaborator does not match the exact `Inhabited` instance.
+Instead, it matches that it's an application of `Inhabited.default` whose first argument is `Nat`.
+-/
+/--
+info: [notation3] syntax declaration has name Test.termδNat
+[notation3] Generating matcher for pattern default
+[notation3] Matcher creation succeeded; assembling delaborator
+[notation3] matcher:
+      matchApp✝ (matchApp✝ (matchExpr✝ (Expr.isConstOf✝ · `Inhabited.default))
+(matchExpr✝ (Expr.isConstOf✝ · `Nat)))
+          pure✝ >=>
+        pure✝
+[notation3] Defined delaborator Test.termδNat.delab
+[notation3] Adding `delab` attribute for keys [app.Inhabited.default]
+-/
+#guard_msgs in
+set_option trace.notation3 true in
+notation3 "δNat" => (default : Nat)

--- a/test/notation3.lean
+++ b/test/notation3.lean
@@ -196,3 +196,8 @@ info: [notation3] syntax declaration has name Test.termδNat
 #guard_msgs in
 set_option trace.notation3 true in
 notation3 "δNat" => (default : Nat)
+
+/-- info: δNat : ℕ -/
+#guard_msgs in #check (default : Nat)
+/-- info: δNat : ℕ -/
+#guard_msgs in #check @default Nat (Inhabited.mk 5)


### PR DESCRIPTION
Instance arguments are supposed to be canonical in elaborated expressions, so there should be no harm in approximating matching by not matching instance arguments at all.

This makes the matchers more efficient. They are more likely to succeed in matching too, since the matchers do not take defeq into account: they only handle exact syntactic matches.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
