### PR TITLE
[Merged by Bors] - doc(RingTheory/Flat/Stability): fix docstring in composition

### DIFF
--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -39,12 +39,12 @@ Let `R` be a ring, `S` a flat `R`-algebra and `M` a flat `S`-module. To show tha
 as an `R`-module, we show that the inclusion of an `R`-ideal `I` into `R` tensored on the left with
 `M` is injective. For this consider the composition of natural maps
 
-`M ⊗[R] I ≃ M ⊗[S] (S ⊗[R] I) ≃ M ⊗[S] J → M ⊗[S] S → M ≃ M ⊗[R] R`
+`M ⊗[R] I ≃ M ⊗[S] (S ⊗[R] I) ≃ M ⊗[S] J → M ⊗[S] S ≃ M ≃ M ⊗[R] R`
 
 where `J` is the image of `S ⊗[R] I` under the (by flatness of `S`) injective map
 `S ⊗[R] I → S`. One checks that this composition is precisely `I → R` tensored on the left
-with `M` and the former is injective as a composition of injective maps (note that
-`M ⊗[S] S → M` is injective because `M` is `S`-flat).
+with `M` and it is injective as a composition of injective maps (note that
+`M ⊗[S] J → M ⊗[S] S` is injective because `M` is `S`-flat).
 -/
 
 variable (R : Type u) (S : Type v) (M : Type w)


### PR DESCRIPTION
Corrects docstring on strategy to show flatness is stable under composition.

--- 
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
