### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Localization): dualize results for right calculus of fractions

### DIFF
--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-import Mathlib.CategoryTheory.Localization.Predicate
+import Mathlib.CategoryTheory.Localization.Opposite
 
 /-!
 # Calculus of fractions
@@ -17,6 +17,8 @@ there exists an auxiliary object `Y' : C` and morphisms `g : X ⟶ Y'` and `s : 
 with `W s`, such that the given morphism is a sort of fraction `g / s`,
 or more precisely of the form `L.map g ≫ (Localization.isoOfHom L W s hs).inv`.
 We also show that the functor `L.mapArrow : Arrow C ⥤ Arrow D` is essentially surjective.
+
+Similar results are obtained when `W` has a right calculus of fractions.
 
 ## References
 
@@ -761,6 +763,208 @@ lemma Localization.essSurj_mapArrow_of_hasLeftCalculusofFractions :
     dsimp
     simp only [← cancel_epi eX.hom, Iso.hom_inv_id_assoc, reassoc_of% hφ,
       MorphismProperty.LeftFraction.map_comp_map_s]
+
+end
+
+
+namespace MorphismProperty
+
+variable {W}
+
+/-- The right fraction in the opposite category corresponding to a left fraction. -/
+@[simps]
+def LeftFraction.op {X Y : C} (φ : W.LeftFraction X Y) :
+    W.op.RightFraction (Opposite.op Y) (Opposite.op X) where
+  X' := Opposite.op φ.Y'
+  s := φ.s.op
+  hs := φ.hs
+  f := φ.f.op
+
+/-- The left fraction in the opposite category corresponding to a right fraction. -/
+@[simps]
+def RightFraction.op {X Y : C} (φ : W.RightFraction X Y) :
+    W.op.LeftFraction (Opposite.op Y) (Opposite.op X) where
+  Y' := Opposite.op φ.X'
+  s := φ.s.op
+  hs := φ.hs
+  f := φ.f.op
+
+/-- The right fraction corresponding to a left fraction in the opposite category. -/
+@[simps]
+def LeftFraction.unop {W : MorphismProperty Cᵒᵖ}
+    {X Y : Cᵒᵖ} (φ : W.LeftFraction X Y) :
+    W.unop.RightFraction (Opposite.unop Y) (Opposite.unop X) where
+  X' := Opposite.unop φ.Y'
+  s := φ.s.unop
+  hs := φ.hs
+  f := φ.f.unop
+
+/-- The left fraction corresponding to a right fraction in the opposite category. -/
+@[simps]
+def RightFraction.unop {W : MorphismProperty Cᵒᵖ}
+    {X Y : Cᵒᵖ} (φ : W.RightFraction X Y) :
+    W.unop.LeftFraction (Opposite.unop Y) (Opposite.unop X) where
+  Y' := Opposite.unop φ.X'
+  s := φ.s.unop
+  hs := φ.hs
+  f := φ.f.unop
+
+lemma RightFraction.op_map
+    {X Y : C} (φ : W.RightFraction X Y) (L : C ⥤ D) (hL : W.IsInvertedBy L) :
+    (φ.map L hL).op = φ.op.map L.op hL.op := by
+  dsimp [map, LeftFraction.map]
+  rw [op_inv]
+
+lemma LeftFraction.op_map
+    {X Y : C} (φ : W.LeftFraction X Y) (L : C ⥤ D) (hL : W.IsInvertedBy L) :
+    (φ.map L hL).op = φ.op.map L.op hL.op := by
+  dsimp [map, RightFraction.map]
+  rw [op_inv]
+
+instance [h : W.HasLeftCalculusOfFractions] : W.op.HasRightCalculusOfFractions where
+  exists_rightFraction X Y φ := by
+    obtain ⟨ψ, eq⟩ := h.exists_leftFraction φ.unop
+    exact ⟨ψ.op, Quiver.Hom.unop_inj eq⟩
+  ext X Y Y' f₁ f₂ s hs eq := by
+    obtain ⟨X', t, ht, fac⟩ := h.ext f₁.unop f₂.unop s.unop hs (Quiver.Hom.op_inj eq)
+    exact ⟨Opposite.op X', t.op, ht, Quiver.Hom.unop_inj fac⟩
+
+instance [h : W.HasRightCalculusOfFractions] : W.op.HasLeftCalculusOfFractions where
+  exists_leftFraction X Y φ := by
+    obtain ⟨ψ, eq⟩ := h.exists_rightFraction φ.unop
+    exact ⟨ψ.op, Quiver.Hom.unop_inj eq⟩
+  ext X' X Y f₁ f₂ s hs eq := by
+    obtain ⟨Y', t, ht, fac⟩ := h.ext f₁.unop f₂.unop s.unop hs (Quiver.Hom.op_inj eq)
+    exact ⟨Opposite.op Y', t.op, ht, Quiver.Hom.unop_inj fac⟩
+
+instance (W : MorphismProperty Cᵒᵖ) [h : W.HasLeftCalculusOfFractions] :
+    W.unop.HasRightCalculusOfFractions where
+  exists_rightFraction X Y φ := by
+    obtain ⟨ψ, eq⟩ := h.exists_leftFraction φ.op
+    exact ⟨ψ.unop, Quiver.Hom.op_inj eq⟩
+  ext X Y Y' f₁ f₂ s hs eq := by
+    obtain ⟨X', t, ht, fac⟩ := h.ext f₁.op f₂.op s.op hs (Quiver.Hom.unop_inj eq)
+    exact ⟨Opposite.unop X', t.unop, ht, Quiver.Hom.op_inj fac⟩
+
+instance (W : MorphismProperty Cᵒᵖ) [h : W.HasRightCalculusOfFractions] :
+    W.unop.HasLeftCalculusOfFractions where
+  exists_leftFraction X Y φ := by
+    obtain ⟨ψ, eq⟩ := h.exists_rightFraction φ.op
+    exact ⟨ψ.unop, Quiver.Hom.op_inj eq⟩
+  ext X' X Y f₁ f₂ s hs eq := by
+    obtain ⟨Y', t, ht, fac⟩ := h.ext f₁.op f₂.op s.op hs (Quiver.Hom.unop_inj eq)
+    exact ⟨Opposite.unop Y', t.unop, ht, Quiver.Hom.op_inj fac⟩
+
+/-- The equivalence relation on right fractions for a morphism property `W`. -/
+def RightFractionRel {X Y : C} (z₁ z₂ : W.RightFraction X Y) : Prop :=
+  ∃ (Z : C)  (t₁ : Z ⟶ z₁.X') (t₂ : Z ⟶ z₂.X') (_ : t₁ ≫ z₁.s = t₂ ≫ z₂.s)
+    (_ : t₁ ≫ z₁.f = t₂ ≫ z₂.f), W (t₁ ≫ z₁.s)
+
+lemma RightFractionRel.op {X Y : C} {z₁ z₂ : W.RightFraction X Y}
+    (h : RightFractionRel z₁ z₂) : LeftFractionRel z₁.op z₂.op := by
+  obtain ⟨Z, t₁, t₂, hs, hf, ht⟩ := h
+  exact ⟨Opposite.op Z, t₁.op, t₂.op, Quiver.Hom.unop_inj hs,
+    Quiver.Hom.unop_inj hf, ht⟩
+
+lemma RightFractionRel.unop {W : MorphismProperty Cᵒᵖ} {X Y : Cᵒᵖ}
+    {z₁ z₂ : W.RightFraction X Y}
+    (h : RightFractionRel z₁ z₂) : LeftFractionRel z₁.unop z₂.unop := by
+  obtain ⟨Z, t₁, t₂, hs, hf, ht⟩ := h
+  exact ⟨Opposite.unop Z, t₁.unop, t₂.unop, Quiver.Hom.op_inj hs,
+    Quiver.Hom.op_inj hf, ht⟩
+
+lemma LeftFractionRel.op {X Y : C} {z₁ z₂ : W.LeftFraction X Y}
+    (h : LeftFractionRel z₁ z₂) : RightFractionRel z₁.op z₂.op := by
+  obtain ⟨Z, t₁, t₂, hs, hf, ht⟩ := h
+  exact ⟨Opposite.op Z, t₁.op, t₂.op, Quiver.Hom.unop_inj hs,
+    Quiver.Hom.unop_inj hf, ht⟩
+
+lemma LeftFractionRel.unop {W : MorphismProperty Cᵒᵖ} {X Y : Cᵒᵖ}
+    {z₁ z₂ : W.LeftFraction X Y}
+    (h : LeftFractionRel z₁ z₂) : RightFractionRel z₁.unop z₂.unop := by
+  obtain ⟨Z, t₁, t₂, hs, hf, ht⟩ := h
+  exact ⟨Opposite.unop Z, t₁.unop, t₂.unop, Quiver.Hom.op_inj hs,
+    Quiver.Hom.op_inj hf, ht⟩
+
+lemma leftFractionRel_op_iff
+    {X Y : C} (z₁ z₂ : W.RightFraction X Y) :
+    LeftFractionRel z₁.op z₂.op ↔ RightFractionRel z₁ z₂ :=
+  ⟨fun h => h.unop, fun h => h.op⟩
+
+lemma rightFractionRel_op_iff
+    {X Y : C} (z₁ z₂ : W.LeftFraction X Y) :
+    RightFractionRel z₁.op z₂.op ↔ LeftFractionRel z₁ z₂ :=
+  ⟨fun h => h.unop, fun h => h.op⟩
+
+namespace RightFractionRel
+
+lemma refl {X Y : C} (z : W.RightFraction X Y) : RightFractionRel z z :=
+  (LeftFractionRel.refl z.op).unop
+
+lemma symm {X Y : C} {z₁ z₂ : W.RightFraction X Y} (h : RightFractionRel z₁ z₂) :
+    RightFractionRel z₂ z₁ :=
+  h.op.symm.unop
+
+lemma trans {X Y : C} {z₁ z₂ z₃ : W.RightFraction X Y}
+    [HasRightCalculusOfFractions W]
+    (h₁₂ : RightFractionRel z₁ z₂) (h₂₃ : RightFractionRel z₂ z₃) :
+    RightFractionRel z₁ z₃ :=
+  (h₁₂.op.trans h₂₃.op).unop
+
+end RightFractionRel
+
+lemma equivalenceRightFractionRel (X Y : C) [HasRightCalculusOfFractions W] :
+    @_root_.Equivalence (W.RightFraction X Y) RightFractionRel where
+  refl := RightFractionRel.refl
+  symm := RightFractionRel.symm
+  trans := RightFractionRel.trans
+
+end MorphismProperty
+
+section
+
+variable [W.HasRightCalculusOfFractions]
+
+lemma Localization.exists_rightFraction {X Y : C} (f : L.obj X ⟶ L.obj Y) :
+    ∃ (φ : W.RightFraction X Y), f = φ.map L (Localization.inverts L W) := by
+  obtain ⟨φ, eq⟩ := Localization.exists_leftFraction L.op W.op f.op
+  refine' ⟨φ.unop, Quiver.Hom.op_inj _⟩
+  rw [eq, MorphismProperty.RightFraction.op_map]
+  rfl
+
+lemma MorphismProperty.RightFraction.map_eq_iff
+    {X Y : C} (φ ψ : W.RightFraction X Y) :
+    φ.map L (Localization.inverts _ _) = ψ.map L (Localization.inverts _ _) ↔
+      RightFractionRel φ ψ := by
+  rw [← leftFractionRel_op_iff, ← LeftFraction.map_eq_iff L.op W.op φ.op ψ.op,
+    ← φ.op_map L (Localization.inverts _ _), ← ψ.op_map L (Localization.inverts _ _)]
+  constructor
+  · apply Quiver.Hom.unop_inj
+  · apply Quiver.Hom.op_inj
+
+lemma MorphismProperty.map_eq_iff_precomp {Y Z : C} (f₁ f₂ : Y ⟶ Z) :
+    L.map f₁ = L.map f₂ ↔ ∃ (X : C) (s : X ⟶ Y) (_ : W s), s ≫ f₁ = s ≫ f₂ := by
+  constructor
+  · intro h
+    rw [← RightFraction.map_ofHom W _ L (Localization.inverts _ _),
+      ← RightFraction.map_ofHom W _ L (Localization.inverts _ _),
+      RightFraction.map_eq_iff] at h
+    obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
+    dsimp at t₁ t₂ hst hft ht
+    simp only [comp_id] at hst
+    exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
+  · rintro ⟨Z, s, hs, fac⟩
+    simp only [← cancel_epi (Localization.isoOfHom L W s hs).hom,
+      Localization.isoOfHom_hom, ← L.map_comp, fac]
+
+lemma Localization.essSurj_mapArrow_of_hasRightCalculusofFractions :
+    EssSurj L.mapArrow where
+  mem_essImage f := by
+    have := Localization.essSurj_mapArrow_of_hasLeftCalculusofFractions L.op W.op
+    obtain ⟨g, ⟨e⟩⟩ : ∃ (g : _), Nonempty (L.op.mapArrow.obj g ≅ Arrow.mk f.hom.op) :=
+      ⟨_, ⟨Functor.objObjPreimageIso _ _⟩⟩
+    exact ⟨Arrow.mk g.hom.unop, ⟨Arrow.isoMk (Arrow.rightFunc.mapIso e.symm).unop
+      (Arrow.leftFunc.mapIso e.symm).unop (Quiver.Hom.op_inj e.inv.w.symm)⟩⟩
 
 end
 


### PR DESCRIPTION
In this PR, the results for the left calculus of fractions are dualized in order to obtain similar results for the right calculus of fractions

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
