### PR TITLE
[Merged by Bors] - feat(Mathlib/RingTheory/Ideal/Operations): simplify definition of radical

### DIFF
--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -582,9 +582,9 @@ theorem pow_mem_of_pow_mem {m n : ℕ} (ha : a ^ m ∈ I) (h : m ≤ n) : a ^ n 
   rw [← Nat.add_sub_of_le h, pow_add]
   exact I.mul_mem_right _ ha
 
-theorem add_pow_add_pred_mem_of_pow_mem  {m n : ℕ}
-    (ha : a ^ m ∈ I) (hb : b ^ n ∈ I) :
-    (a + b) ^ (m + n - 1) ∈ I := by
+theorem add_pow_mem_of_pow_mem_of_le {m n k : ℕ}
+    (ha : a ^ m ∈ I) (hb : b ^ n ∈ I) (hk : m + n ≤ k + 1) :
+    (a + b) ^ k ∈ I := by
   rw [add_pow]
   apply I.sum_mem
   intro c _
@@ -593,8 +593,15 @@ theorem add_pow_add_pred_mem_of_pow_mem  {m n : ℕ}
   · exact I.mul_mem_right _ (I.pow_mem_of_pow_mem ha h)
   · refine I.mul_mem_left _ (I.pow_mem_of_pow_mem hb ?_)
     simp only [not_le, Nat.lt_iff_add_one_le] at h
-    rw [Nat.sub_sub, add_comm 1, add_comm m, Nat.add_sub_assoc h]
-    apply Nat.le_add_right
+    rw [Nat.le_sub_iff_add_le, ← add_le_add_iff_right 1]
+    exact le_trans (by rwa [add_comm _ n, add_assoc, add_le_add_iff_left]) hk
+    rw [← add_le_add_iff_right 1]
+    exact le_trans h (le_trans (Nat.le_add_right _ _) hk)
+
+theorem add_pow_add_pred_mem_of_pow_mem  {m n : ℕ}
+    (ha : a ^ m ∈ I) (hb : b ^ n ∈ I) :
+    (a + b) ^ (m + n - 1) ∈ I :=
+  I.add_pow_mem_of_pow_mem_of_le ha hb <| by rw [← Nat.sub_le_iff_le_add]
 
 theorem IsPrime.mul_mem_iff_mem_or_mem {I : Ideal α} (hI : I.IsPrime) :
     ∀ {x y : α}, x * y ∈ I ↔ x ∈ I ∨ y ∈ I := @fun x y =>

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -593,10 +593,11 @@ theorem add_pow_mem_of_pow_mem_of_le {m n k : ℕ}
   · exact I.mul_mem_right _ (I.pow_mem_of_pow_mem ha h)
   · refine I.mul_mem_left _ (I.pow_mem_of_pow_mem hb ?_)
     simp only [not_le, Nat.lt_iff_add_one_le] at h
-    rw [Nat.le_sub_iff_add_le, ← add_le_add_iff_right 1]
+    have hck : c ≤ k := by
+      rw [← add_le_add_iff_right 1]
+      exact le_trans h (le_trans (Nat.le_add_right _ _) hk)
+    rw [Nat.le_sub_iff_add_le hck, ← add_le_add_iff_right 1]
     exact le_trans (by rwa [add_comm _ n, add_assoc, add_le_add_iff_left]) hk
-    rw [← add_le_add_iff_right 1]
-    exact le_trans h (le_trans (Nat.le_add_right _ _) hk)
 
 theorem add_pow_add_pred_mem_of_pow_mem  {m n : ℕ}
     (ha : a ^ m ∈ I) (hb : b ^ n ∈ I) :

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -578,6 +578,38 @@ theorem pow_mem_of_mem (ha : a ∈ I) (n : ℕ) (hn : 0 < n) : a ^ n ∈ I :=
     (fun m _hm => (pow_succ a m).symm ▸ I.mul_mem_right (a ^ m) ha) hn
 #align ideal.pow_mem_of_mem Ideal.pow_mem_of_mem
 
+theorem pow_mem_of_pow_mem {m n : ℕ} (ha : a ^ m ∈ I) (h : m ≤ n) : a ^ n ∈ I := by
+  rw [← Nat.add_sub_of_le h, pow_add]
+  exact I.mul_mem_right _ ha
+
+theorem add_pow_add_mem_of_pow_mem  {m n : ℕ}
+    (ha : a ^ m ∈ I) (hb : b ^ n ∈ I) :
+    (a + b) ^ (m + n) ∈ I := by
+  rw [add_pow]
+  apply I.sum_mem
+  intro c _
+  apply mul_mem_right
+  by_cases h : m ≤ c
+  · exact I.mul_mem_right _ (I.pow_mem_of_pow_mem ha h)
+  · refine I.mul_mem_left _ (I.pow_mem_of_pow_mem hb ?_)
+    simp only [not_le] at h
+    rw [add_comm, Nat.add_sub_assoc (le_of_lt h)]
+    apply Nat.le_add_right
+
+theorem add_pow_add_succ_mem_of_pow_succ_mem  {m n : ℕ}
+    (ha : a ^ m.succ ∈ I) (hb : b ^ n.succ ∈ I) :
+    (a + b) ^ (m + n).succ ∈ I := by
+  rw [add_pow]
+  apply I.sum_mem
+  intro c _
+  apply mul_mem_right
+  by_cases h : m.succ ≤ c
+  · exact I.mul_mem_right _ (I.pow_mem_of_pow_mem ha h)
+  · refine I.mul_mem_left _ (I.pow_mem_of_pow_mem hb ?_)
+    simp only [not_le, ← Nat.succ_le_iff, Nat.succ_le_succ_iff] at h
+    rw [← Nat.add_succ, add_comm, Nat.add_sub_assoc h]
+    exact Nat.le_add_right (Nat.succ n) (m - c)
+
 theorem IsPrime.mul_mem_iff_mem_or_mem {I : Ideal α} (hI : I.IsPrime) :
     ∀ {x y : α}, x * y ∈ I ↔ x ∈ I ∨ y ∈ I := @fun x y =>
   ⟨hI.mem_or_mem, by

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -582,9 +582,9 @@ theorem pow_mem_of_pow_mem {m n : ℕ} (ha : a ^ m ∈ I) (h : m ≤ n) : a ^ n 
   rw [← Nat.add_sub_of_le h, pow_add]
   exact I.mul_mem_right _ ha
 
-theorem add_pow_add_mem_of_pow_mem  {m n : ℕ}
+theorem add_pow_add_pred_mem_of_pow_mem  {m n : ℕ}
     (ha : a ^ m ∈ I) (hb : b ^ n ∈ I) :
-    (a + b) ^ (m + n) ∈ I := by
+    (a + b) ^ (m + n - 1) ∈ I := by
   rw [add_pow]
   apply I.sum_mem
   intro c _
@@ -592,23 +592,9 @@ theorem add_pow_add_mem_of_pow_mem  {m n : ℕ}
   by_cases h : m ≤ c
   · exact I.mul_mem_right _ (I.pow_mem_of_pow_mem ha h)
   · refine I.mul_mem_left _ (I.pow_mem_of_pow_mem hb ?_)
-    simp only [not_le] at h
-    rw [add_comm, Nat.add_sub_assoc (le_of_lt h)]
+    simp only [not_le, Nat.lt_iff_add_one_le] at h
+    rw [Nat.sub_sub, add_comm 1, add_comm m, Nat.add_sub_assoc h]
     apply Nat.le_add_right
-
-theorem add_pow_add_succ_mem_of_pow_succ_mem  {m n : ℕ}
-    (ha : a ^ m.succ ∈ I) (hb : b ^ n.succ ∈ I) :
-    (a + b) ^ (m + n).succ ∈ I := by
-  rw [add_pow]
-  apply I.sum_mem
-  intro c _
-  apply mul_mem_right
-  by_cases h : m.succ ≤ c
-  · exact I.mul_mem_right _ (I.pow_mem_of_pow_mem ha h)
-  · refine I.mul_mem_left _ (I.pow_mem_of_pow_mem hb ?_)
-    simp only [not_le, ← Nat.succ_le_iff, Nat.succ_le_succ_iff] at h
-    rw [← Nat.add_succ, add_comm, Nat.add_sub_assoc h]
-    exact Nat.le_add_right (Nat.succ n) (m - c)
 
 theorem IsPrime.mul_mem_iff_mem_or_mem {I : Ideal α} (hI : I.IsPrime) :
     ∀ {x y : α}, x * y ∈ I ↔ x ∈ I ∨ y ∈ I := @fun x y =>

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -957,22 +957,8 @@ theorem isCoprime_biInf {J : ι → Ideal R} {s : Finset ι}
 def radical (I : Ideal R) : Ideal R where
   carrier := { r | ∃ n : ℕ, r ^ n ∈ I }
   zero_mem' := ⟨1, (pow_one (0 : R)).symm ▸ I.zero_mem⟩
-  add_mem' :=
-  fun {x y} ⟨m, hxmi⟩ ⟨n, hyni⟩ =>
-    ⟨m + n,
-      (add_pow x y (m + n)).symm ▸ I.sum_mem <|
-        show
-          ∀ c ∈ Finset.range (Nat.succ (m + n)), x ^ c * y ^ (m + n - c) * Nat.choose (m + n) c ∈ I
-          from fun c _ =>
-          Or.casesOn (le_total c m) (fun hcm =>
-              I.mul_mem_right _ <|
-                I.mul_mem_left _ <|
-                  Nat.add_comm n m ▸
-                    (add_tsub_assoc_of_le hcm n).symm ▸
-                      (pow_add y n (m - c)).symm ▸ I.mul_mem_right _ hyni) (fun hmc =>
-               I.mul_mem_right _ <|
-                I.mul_mem_right _ <|
-                  add_tsub_cancel_of_le hmc ▸ (pow_add x m (c - m)).symm ▸ I.mul_mem_right _ hxmi)⟩
+  add_mem' := fun {x y} ⟨m, hxmi⟩ ⟨n, hyni⟩ =>
+    ⟨m + n, add_pow_add_mem_of_pow_mem I hxmi hyni⟩
 -- Porting note: Below gives weird errors without `by exact`
   smul_mem' {r s} := by exact fun ⟨n, h⟩ ↦ ⟨n, (mul_pow r s n).symm ▸ I.mul_mem_left (r ^ n) h⟩
 #align ideal.radical Ideal.radical

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -958,7 +958,7 @@ def radical (I : Ideal R) : Ideal R where
   carrier := { r | ∃ n : ℕ, r ^ n ∈ I }
   zero_mem' := ⟨1, (pow_one (0 : R)).symm ▸ I.zero_mem⟩
   add_mem' := fun {x y} ⟨m, hxmi⟩ ⟨n, hyni⟩ =>
-    ⟨m + n, add_pow_add_mem_of_pow_mem I hxmi hyni⟩
+    ⟨m + n - 1, add_pow_add_pred_mem_of_pow_mem I hxmi hyni⟩
 -- Porting note: Below gives weird errors without `by exact`
   smul_mem' {r s} := by exact fun ⟨n, h⟩ ↦ ⟨n, (mul_pow r s n).symm ▸ I.mul_mem_left (r ^ n) h⟩
 #align ideal.radical Ideal.radical

--- a/Mathlib/RingTheory/Nilpotent.lean
+++ b/Mathlib/RingTheory/Nilpotent.lean
@@ -311,17 +311,20 @@ section Semiring
 
 variable [Semiring R] (h_comm : Commute x y)
 
-theorem isNilpotent_add (hx : IsNilpotent x) (hy : IsNilpotent y) : IsNilpotent (x + y) := by
-  obtain ⟨n, hn⟩ := hx
-  obtain ⟨m, hm⟩ := hy
-  use n + m - 1
+theorem add_pow_add_pred_eq_zero_of_add_pow_eq_zero {m n : ℕ} (hx : x ^ m = 0) (hy : y ^ n = 0) :
+    (x + y) ^ (m + n - 1) = 0 := by
   rw [h_comm.add_pow']
   apply Finset.sum_eq_zero
   rintro ⟨i, j⟩ hij
   suffices x ^ i * y ^ j = 0 by simp only [this, nsmul_eq_mul, mul_zero]
   cases' Nat.le_or_le_of_add_eq_add_pred (Finset.mem_antidiagonal.mp hij) with hi hj
-  · rw [pow_eq_zero_of_le hi hn, zero_mul]
-  · rw [pow_eq_zero_of_le hj hm, mul_zero]
+  · rw [pow_eq_zero_of_le hi hx, zero_mul]
+  · rw [pow_eq_zero_of_le hj hy, mul_zero]
+
+theorem isNilpotent_add (hx : IsNilpotent x) (hy : IsNilpotent y) : IsNilpotent (x + y) := by
+  obtain ⟨n, hn⟩ := hx
+  obtain ⟨m, hm⟩ := hy
+  exact ⟨_, add_pow_add_pred_eq_zero_of_add_pow_eq_zero h_comm hn hm⟩
 #align commute.is_nilpotent_add Commute.isNilpotent_add
 
 protected lemma isNilpotent_sum {ι : Type*} {s : Finset ι} {f : ι → R}

--- a/Mathlib/RingTheory/Nilpotent.lean
+++ b/Mathlib/RingTheory/Nilpotent.lean
@@ -326,7 +326,7 @@ theorem add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero {m n k : ℕ}
 theorem add_pow_add_eq_zero_of_pow_eq_zero {m n : ℕ}
     (hx : x ^ m = 0) (hy : y ^ n = 0) :
     (x + y) ^ (m + n - 1) = 0 :=
-  h_comm.add_pow_of_add_le_succ_eq_zero_of_pow_eq_zero hx hy <| by rw [← Nat.sub_le_iff_le_add]
+  h_comm.add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero hx hy <| by rw [← Nat.sub_le_iff_le_add]
 
 theorem isNilpotent_add (hx : IsNilpotent x) (hy : IsNilpotent y) : IsNilpotent (x + y) := by
   obtain ⟨n, hn⟩ := hx

--- a/Mathlib/RingTheory/Nilpotent.lean
+++ b/Mathlib/RingTheory/Nilpotent.lean
@@ -311,7 +311,7 @@ section Semiring
 
 variable [Semiring R] (h_comm : Commute x y)
 
-theorem add_pow_of_add_le_succ_eq_zero_of_pow_eq_zero {m n k : ℕ}
+theorem add_pow_eq_zero_of_add_le_succ_of_pow_eq_zero {m n k : ℕ}
     (hx : x ^ m = 0) (hy : y ^ n = 0) (h : m + n ≤ k + 1) :
     (x + y) ^ k = 0 := by
   rw [h_comm.add_pow']

--- a/Mathlib/RingTheory/Nilpotent.lean
+++ b/Mathlib/RingTheory/Nilpotent.lean
@@ -311,20 +311,27 @@ section Semiring
 
 variable [Semiring R] (h_comm : Commute x y)
 
-theorem add_pow_add_pred_eq_zero_of_add_pow_eq_zero {m n : ℕ} (hx : x ^ m = 0) (hy : y ^ n = 0) :
-    (x + y) ^ (m + n - 1) = 0 := by
+theorem add_pow_of_add_le_succ_eq_zero_of_pow_eq_zero {m n k : ℕ}
+    (hx : x ^ m = 0) (hy : y ^ n = 0) (h : m + n ≤ k + 1) :
+    (x + y) ^ k = 0 := by
   rw [h_comm.add_pow']
   apply Finset.sum_eq_zero
   rintro ⟨i, j⟩ hij
   suffices x ^ i * y ^ j = 0 by simp only [this, nsmul_eq_mul, mul_zero]
-  cases' Nat.le_or_le_of_add_eq_add_pred (Finset.mem_antidiagonal.mp hij) with hi hj
-  · rw [pow_eq_zero_of_le hi hx, zero_mul]
-  · rw [pow_eq_zero_of_le hj hy, mul_zero]
+  by_cases hi : m ≤ i
+  rw [pow_eq_zero_of_le hi hx, zero_mul]
+  rw [pow_eq_zero_of_le ?_ hy, mul_zero]
+  linarith [Finset.mem_antidiagonal.mp hij]
+
+theorem add_pow_add_eq_zero_of_pow_eq_zero {m n : ℕ}
+    (hx : x ^ m = 0) (hy : y ^ n = 0) :
+    (x + y) ^ (m + n - 1) = 0 :=
+  h_comm.add_pow_of_add_le_succ_eq_zero_of_pow_eq_zero hx hy <| by rw [← Nat.sub_le_iff_le_add]
 
 theorem isNilpotent_add (hx : IsNilpotent x) (hy : IsNilpotent y) : IsNilpotent (x + y) := by
   obtain ⟨n, hn⟩ := hx
   obtain ⟨m, hm⟩ := hy
-  exact ⟨_, add_pow_add_pred_eq_zero_of_add_pow_eq_zero h_comm hn hm⟩
+  exact ⟨_, add_pow_add_eq_zero_of_pow_eq_zero h_comm hn hm⟩
 #align commute.is_nilpotent_add Commute.isNilpotent_add
 
 protected lemma isNilpotent_sum {ι : Type*} {s : Finset ι} {f : ι → R}


### PR DESCRIPTION
* `add_pow_mem_of_pow_mem_of_le` says that (a + b) ^ k belongs to an ideal I if a ^ m and b ^ n belong to that ideal, and `m + n ≤ k + 1`.
* `Commute.add_pow_of_add_le_succ_eq_zero_of_pow_eq_zero` says that `(a + b) ^ k = 0` if `a ^ m = 0`, `b^ n = 0`, and `m + n ≤ k + 1`.
* this is used to simplify the definition of docs#Ideal.radical and the definition of docs#Commute.isNilpotent_add


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
