### PR TITLE
[Merged by Bors] - chore(Combinatorics/Additive/PluenneckeRuzsa): add @to_additive to various formulations of Ruzsa's triangle inequality

### DIFF
--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -41,7 +41,7 @@ variable {α : Type*} [CommGroup α] [DecidableEq α] {A B C : Finset α}
 
 /-- **Ruzsa's triangle inequality**. Division version. -/
 @[to_additive card_sub_mul_le_card_sub_mul_card_sub
-      "**Ruzsa's triangle inequality**. Subtraction version."]
+"**Ruzsa's triangle inequality**. Subtraction version."]
 theorem card_div_mul_le_card_div_mul_card_div (A B C : Finset α) :
     (A / C).card * B.card ≤ (A / B).card * (B / C).card := by
   rw [← card_product (A / B), ← mul_one ((A / B) ×ˢ (B / C)).card]
@@ -58,7 +58,7 @@ theorem card_div_mul_le_card_div_mul_card_div (A B C : Finset α) :
 
 /-- **Ruzsa's triangle inequality**. Div-mul-mul version. -/
 @[to_additive card_sub_mul_le_card_add_mul_card_add
-      "**Ruzsa's triangle inequality**. Sub-add-add version."]
+"**Ruzsa's triangle inequality**. Sub-add-add version."]
 theorem card_div_mul_le_card_mul_mul_card_mul (A B C : Finset α) :
     (A / C).card * B.card ≤ (A * B).card * (B * C).card := by
   rw [← div_inv_eq_mul, ← card_inv B, ← card_inv (B * C), mul_inv, ← div_eq_mul_inv]
@@ -68,7 +68,7 @@ theorem card_div_mul_le_card_mul_mul_card_mul (A B C : Finset α) :
 
 /-- **Ruzsa's triangle inequality**. Mul-div-div version. -/
 @[to_additive card_add_mul_le_card_sub_mul_card_add
-      "**Ruzsa's triangle inequality**. Add-sub-sub version."]
+"**Ruzsa's triangle inequality**. Add-sub-sub version."]
 theorem card_mul_mul_le_card_div_mul_card_mul (A B C : Finset α) :
     (A * C).card * B.card ≤ (A / B).card * (B * C).card := by
   rw [← div_inv_eq_mul, ← div_inv_eq_mul B]
@@ -78,7 +78,7 @@ theorem card_mul_mul_le_card_div_mul_card_mul (A B C : Finset α) :
 
 /-- **Ruzsa's triangle inequality**. Mul-mul-div version. -/
 @[to_additive card_add_mul_le_card_add_mul_card_sub
-      "**Ruzsa's triangle inequality**. Add-add-sub version."]
+"**Ruzsa's triangle inequality**. Add-add-sub version."]
 theorem card_mul_mul_le_card_mul_mul_card_div (A B C : Finset α) :
     (A * C).card * B.card ≤ (A * B).card * (B / C).card := by
   rw [← div_inv_eq_mul, div_eq_mul_inv B]
@@ -136,7 +136,7 @@ private theorem mul_aux (hA : A.Nonempty) (hAB : A ⊆ B)
 
 /-- **Ruzsa's triangle inequality**. Multiplication version. -/
 @[to_additive card_add_mul_card_le_card_add_mul_card_add
-      "**Ruzsa's triangle inequality**. Addition version."]
+"**Ruzsa's triangle inequality**. Addition version."]
 theorem card_mul_mul_card_le_card_mul_mul_card_mul (A B C : Finset α) :
     (A * C).card * B.card ≤ (A * B).card * (B * C).card := by
   obtain rfl | hB := B.eq_empty_or_nonempty
@@ -161,7 +161,7 @@ theorem card_mul_mul_card_le_card_mul_mul_card_mul (A B C : Finset α) :
 
 /-- **Ruzsa's triangle inequality**. Mul-div-div version. -/
 @[to_additive card_add_mul_le_card_sub_mul_card_sub
-      "**Ruzsa's triangle inequality**. Add-sub-sub version."]
+"**Ruzsa's triangle inequality**. Add-sub-sub version."]
 theorem card_mul_mul_le_card_div_mul_card_div (A B C : Finset α) :
     (A * C).card * B.card ≤ (A / B).card * (B / C).card := by
   rw [div_eq_mul_inv, ← card_inv B, ← card_inv (B / C), inv_div', div_inv_eq_mul]
@@ -170,7 +170,7 @@ theorem card_mul_mul_le_card_div_mul_card_div (A B C : Finset α) :
 
 /-- **Ruzsa's triangle inequality**. Div-mul-div version. -/
 @[to_additive card_sub_mul_le_card_add_mul_card_sub
-      "**Ruzsa's triangle inequality**. Sub-add-sub version."]
+"**Ruzsa's triangle inequality**. Sub-add-sub version."]
 theorem card_div_mul_le_card_mul_mul_card_div (A B C : Finset α) :
     (A / C).card * B.card ≤ (A * B).card * (B / C).card := by
   rw [div_eq_mul_inv, div_eq_mul_inv]
@@ -179,7 +179,7 @@ theorem card_div_mul_le_card_mul_mul_card_div (A B C : Finset α) :
 
 /-- **Ruzsa's triangle inequality**. Div-div-mul version. -/
 @[to_additive card_sub_mul_le_card_sub_mul_card_add
-      "**Ruzsa's triangle inequality**. Sub-sub-add version."]
+"**Ruzsa's triangle inequality**. Sub-sub-add version."]
 theorem card_div_mul_le_card_div_mul_card_mul (A B C : Finset α) :
     (A / C).card * B.card ≤ (A / B).card * (B * C).card := by
   rw [← div_inv_eq_mul, div_eq_mul_inv]

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -159,21 +159,27 @@ theorem card_mul_mul_card_le_card_mul_mul_card_mul (A B C : Finset α) :
 #align finset.card_mul_mul_card_le_card_mul_mul_card_mul Finset.card_mul_mul_card_le_card_mul_mul_card_mul
 #align finset.card_add_mul_card_le_card_add_mul_card_add Finset.card_add_mul_card_le_card_add_mul_card_add
 
-/-- **Ruzsa's triangle inequality**. Add-sub-sub version. -/
+/-- **Ruzsa's triangle inequality**. Mul-div-div version. -/
+@[to_additive card_add_mul_card_le_card_sub_mul_card_sub
+      "**Ruzsa's triangle inequality**. Add-sub-sub version."]
 theorem card_mul_mul_le_card_div_mul_card_div (A B C : Finset α) :
     (A * C).card * B.card ≤ (A / B).card * (B / C).card := by
   rw [div_eq_mul_inv, ← card_inv B, ← card_inv (B / C), inv_div', div_inv_eq_mul]
   exact card_mul_mul_card_le_card_mul_mul_card_mul _ _ _
 #align finset.card_mul_mul_le_card_div_mul_card_div Finset.card_mul_mul_le_card_div_mul_card_div
 
-/-- **Ruzsa's triangle inequality**. Sub-add-sub version. -/
+/-- **Ruzsa's triangle inequality**. Div-mul-div version. -/
+@[to_additive card_sub_mul_card_le_card_add_mul_card_sub
+      "**Ruzsa's triangle inequality**. Sub-add-sub version."]
 theorem card_div_mul_le_card_mul_mul_card_div (A B C : Finset α) :
     (A / C).card * B.card ≤ (A * B).card * (B / C).card := by
   rw [div_eq_mul_inv, div_eq_mul_inv]
   exact card_mul_mul_card_le_card_mul_mul_card_mul _ _ _
 #align finset.card_div_mul_le_card_mul_mul_card_div Finset.card_div_mul_le_card_mul_mul_card_div
 
-/-- **Ruzsa's triangle inequality**. Sub-sub-add version. -/
+/-- **Ruzsa's triangle inequality**. Div-div-mul version. -/
+@[to_additive card_sub_mul_card_le_card_sub_mul_card_add
+      "**Ruzsa's triangle inequality**. Sub-sub-add version."]
 theorem card_div_mul_le_card_div_mul_card_mul (A B C : Finset α) :
     (A / C).card * B.card ≤ (A / B).card * (B * C).card := by
   rw [← div_inv_eq_mul, div_eq_mul_inv]

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -160,7 +160,7 @@ theorem card_mul_mul_card_le_card_mul_mul_card_mul (A B C : Finset α) :
 #align finset.card_add_mul_card_le_card_add_mul_card_add Finset.card_add_mul_card_le_card_add_mul_card_add
 
 /-- **Ruzsa's triangle inequality**. Mul-div-div version. -/
-@[to_additive card_add_mul_card_le_card_sub_mul_card_sub
+@[to_additive card_add_mul_le_card_sub_mul_card_sub
       "**Ruzsa's triangle inequality**. Add-sub-sub version."]
 theorem card_mul_mul_le_card_div_mul_card_div (A B C : Finset α) :
     (A * C).card * B.card ≤ (A / B).card * (B / C).card := by
@@ -169,7 +169,7 @@ theorem card_mul_mul_le_card_div_mul_card_div (A B C : Finset α) :
 #align finset.card_mul_mul_le_card_div_mul_card_div Finset.card_mul_mul_le_card_div_mul_card_div
 
 /-- **Ruzsa's triangle inequality**. Div-mul-div version. -/
-@[to_additive card_sub_mul_card_le_card_add_mul_card_sub
+@[to_additive card_sub_mul_le_card_add_mul_card_sub
       "**Ruzsa's triangle inequality**. Sub-add-sub version."]
 theorem card_div_mul_le_card_mul_mul_card_div (A B C : Finset α) :
     (A / C).card * B.card ≤ (A * B).card * (B / C).card := by
@@ -178,7 +178,7 @@ theorem card_div_mul_le_card_mul_mul_card_div (A B C : Finset α) :
 #align finset.card_div_mul_le_card_mul_mul_card_div Finset.card_div_mul_le_card_mul_mul_card_div
 
 /-- **Ruzsa's triangle inequality**. Div-div-mul version. -/
-@[to_additive card_sub_mul_card_le_card_sub_mul_card_add
+@[to_additive card_sub_mul_le_card_sub_mul_card_add
       "**Ruzsa's triangle inequality**. Sub-sub-add version."]
 theorem card_div_mul_le_card_div_mul_card_mul (A B C : Finset α) :
     (A / C).card * B.card ≤ (A / B).card * (B * C).card := by


### PR DESCRIPTION
Add `@to_additive` to `card_mul_mul_le_card_div_mul_card_div`, `card_div_mul_le_card_mul_mul_card_div` and `card_sub_mul_card_le_card_sub_mul_card_add` and correct their documentation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
