### PR TITLE
[Merged by Bors] - chore(Data): solve `ERR_COP` style exceptions

### DIFF
--- a/Mathlib/Data/Array/Basic.lean
+++ b/Mathlib/Data/Array/Basic.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2021 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
 import Std.Tactic.Alias
 
 attribute [simp] Array.toArrayAux_eq

--- a/Mathlib/Data/ByteArray.lean
+++ b/Mathlib/Data/ByteArray.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2021 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Char
 import Mathlib.Data.UInt

--- a/Mathlib/Data/List/Card.lean
+++ b/Mathlib/Data/List/Card.lean
@@ -1,5 +1,12 @@
 /-
+Copyright (c) 2021 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
+-/
+import Mathlib.Data.Nat.Order.Basic
+
+/-!
+# Cardinality of Lists
 
 This is a makeshift theory of the cardinality of a list. Any list can be taken to represent the
 finite set of its elements. Cardinality counts the number of distinct elements. Cardinality
@@ -7,8 +14,6 @@ respects equivalence and is preserved by any mapping that is injective on its el
 
 It might make sense to remove this when we have a proper theory of finite sets.
 -/
-import Mathlib.Data.Nat.Order.Basic
-
 set_option autoImplicit true
 
 namespace List

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2021 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Fin.Basic
 import Mathlib.Algebra.Group.Defs


### PR DESCRIPTION
This PR solves `ERR_COP` style exceptions by adding the copyright headers after having inspected the commit history of each file in Mathlib4 and in Mathlib3.