### PR TITLE
[Merged by Bors] - chore(Tactic): solve `ERR_COP` style exceptions

### DIFF
--- a/Mathlib/Tactic/ApplyWith.lean
+++ b/Mathlib/Tactic/ApplyWith.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2022 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
 import Lean.Elab.Eval
 import Lean.Elab.Tactic.ElabTerm
 

--- a/Mathlib/Tactic/TypeCheck.lean
+++ b/Mathlib/Tactic/TypeCheck.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2022 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
 import Lean.Elab.Tactic.Basic
 
 open Lean Meta

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -120,11 +120,6 @@ Mathlib/SetTheory/Game/PGame.lean : line 1 : ERR_NUM_LIN : 2100 file contains 19
 Mathlib/SetTheory/Ordinal/Arithmetic.lean : line 1 : ERR_NUM_LIN : 2700 file contains 2593 lines, try to split it up
 Mathlib/SetTheory/Ordinal/Basic.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1606 lines, try to split it up
 Mathlib/SetTheory/ZFC/Basic.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1805 lines, try to split it up
-Mathlib/Tactic/ApplyWith.lean : line 1 : ERR_COP : Malformed or missing copyright header
-Mathlib/Tactic/ApplyWith.lean : line 1 : ERR_COP : Malformed or missing copyright header
-Mathlib/Tactic/ApplyWith.lean : line 2 : ERR_COP : Malformed or missing copyright header
-Mathlib/Tactic/ApplyWith.lean : line 3 : ERR_COP : Malformed or missing copyright header
-Mathlib/Tactic/ApplyWith.lean : line 5 : ERR_COP : Malformed or missing copyright header
 Mathlib/Tactic/ApplyWith.lean : line 5 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/Basic.lean : line 13 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/ByContra.lean : line 8 : ERR_MOD : Module docstring missing, or too late
@@ -139,9 +134,6 @@ Mathlib/Tactic/RenameBVar.lean : line 11 : ERR_MOD : Module docstring missing, o
 Mathlib/Tactic/Set.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/SimpRw.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/Substs.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/TypeCheck.lean : line 1 : ERR_COP : Malformed or missing copyright header
-Mathlib/Tactic/TypeCheck.lean : line 1 : ERR_COP : Malformed or missing copyright header
-Mathlib/Tactic/TypeCheck.lean : line 3 : ERR_COP : Malformed or missing copyright header
 Mathlib/Tactic/TypeCheck.lean : line 3 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Topology/Algebra/Group/Basic.lean : line 1 : ERR_NUM_LIN : 2400 file contains 2231 lines, try to split it up
 Mathlib/Topology/Algebra/Module/Basic.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2768 lines, try to split it up


### PR DESCRIPTION
This PR 

- [x] solves `ERR_COP` style exceptions by adding the copyright headers after having inspected the commit history of each file in Mathlib4 and in Mathlib3 
- [x] removes `ERR_COP` style exceptions from script
