### PR TITLE
[Merged by Bors] - chore(RingTheory): delete useless lemma

### DIFF
--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -33,7 +33,6 @@ and `RingTheory.Derivation.ToSquareZero` for
 -/
 
 open Algebra
-open scoped BigOperators
 
 /-- `D : Derivation R A M` is an `R`-linear map from `A` to `M` that satisfies the `leibniz`
 equality. We also require that `D 1 = 0`. See `Derivation.mk'` for a constructor that deduces this
@@ -129,10 +128,7 @@ theorem leibniz : D (a * b) = a • D b + b • D a :=
   D.leibniz' _ _
 #align derivation.leibniz Derivation.leibniz
 
-nonrec theorem map_sum {ι : Type*} (s : Finset ι) (f : ι → A) :
-    D (∑ i in s, f i) = ∑ i in s, D (f i) :=
-  map_sum D _ _
-#align derivation.map_sum Derivation.map_sum
+#noalign derivation.map_sum
 
 @[simp]
 theorem map_smul_of_tower {S : Type*} [SMul S A] [SMul S M] [LinearMap.CompatibleSMul A M S R]

--- a/Mathlib/RingTheory/Polynomial/Bernstein.lean
+++ b/Mathlib/RingTheory/Polynomial/Bernstein.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
+import Mathlib.Algebra.BigOperators.Basic
 import Mathlib.Data.Polynomial.Derivative
 import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.RingTheory.Polynomial.Pochhammer
@@ -324,7 +325,7 @@ theorem sum_smul (n : ℕ) :
         simp only [← nat_cast_mul, Nat.succ_eq_add_one, Nat.add_succ_sub_one, add_zero, pow_succ]
         push_cast
         ring
-    rw [add_pow, (pderiv true).map_sum, (MvPolynomial.aeval e).map_sum, Finset.sum_mul]
+    rw [add_pow, map_sum (pderiv true), (MvPolynomial.aeval e).map_sum, Finset.sum_mul]
     -- Step inside the sum:
     refine' Finset.sum_congr rfl fun k _ => (w k).trans _
     simp only [x, y, e, pderiv_true_x, pderiv_true_y, Algebra.id.smul_eq_mul, nsmul_eq_mul,
@@ -363,7 +364,7 @@ theorem sum_mul_smul (n : ℕ) :
         simp only [← nat_cast_mul, Nat.succ_eq_add_one, Nat.add_succ_sub_one, add_zero, pow_succ]
         push_cast
         ring
-    rw [add_pow, (pderiv true).map_sum, (pderiv true).map_sum, (MvPolynomial.aeval e).map_sum,
+    rw [add_pow, map_sum (pderiv true), map_sum (pderiv true), (MvPolynomial.aeval e).map_sum,
       Finset.sum_mul]
     -- Step inside the sum:
     refine' Finset.sum_congr rfl fun k _ => (w k).trans _

--- a/Mathlib/RingTheory/Polynomial/Bernstein.lean
+++ b/Mathlib/RingTheory/Polynomial/Bernstein.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Algebra.BigOperators.Basic
 import Mathlib.Data.Polynomial.Derivative
 import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.RingTheory.Polynomial.Pochhammer
@@ -325,7 +324,7 @@ theorem sum_smul (n : ℕ) :
         simp only [← nat_cast_mul, Nat.succ_eq_add_one, Nat.add_succ_sub_one, add_zero, pow_succ]
         push_cast
         ring
-    rw [add_pow, map_sum (pderiv true), (MvPolynomial.aeval e).map_sum, Finset.sum_mul]
+    rw [add_pow, map_sum (pderiv true), map_sum (MvPolynomial.aeval e), Finset.sum_mul]
     -- Step inside the sum:
     refine' Finset.sum_congr rfl fun k _ => (w k).trans _
     simp only [x, y, e, pderiv_true_x, pderiv_true_y, Algebra.id.smul_eq_mul, nsmul_eq_mul,
@@ -364,7 +363,7 @@ theorem sum_mul_smul (n : ℕ) :
         simp only [← nat_cast_mul, Nat.succ_eq_add_one, Nat.add_succ_sub_one, add_zero, pow_succ]
         push_cast
         ring
-    rw [add_pow, map_sum (pderiv true), map_sum (pderiv true), (MvPolynomial.aeval e).map_sum,
+    rw [add_pow, map_sum (pderiv true), map_sum (pderiv true), map_sum (MvPolynomial.aeval e),
       Finset.sum_mul]
     -- Step inside the sum:
     refine' Finset.sum_congr rfl fun k _ => (w k).trans _


### PR DESCRIPTION
As discussed in https://github.com/leanprover-community/mathlib4/pull/11790 for the case of Lie derivations, it seems that this `map_sum` lemma is not useful since we can use the generic version.