### PR TITLE
[Merged by Bors] - feat: First countability of topology is preserved in inducing, embedding, and taking subspaces.

### DIFF
--- a/Mathlib/Topology/Bases.lean
+++ b/Mathlib/Topology/Bases.lean
@@ -671,9 +671,37 @@ class _root_.FirstCountableTopology : Prop where
 
 attribute [instance] FirstCountableTopology.nhds_generated_countable
 
-namespace FirstCountableTopology
+/-- If `β` is a first-countable space, then its induced topology via `f` on `α` is also
+first-countable. -/
+theorem firstCountableTopology_induced (α β : Type*) [t : TopologicalSpace β]
+    [FirstCountableTopology β] (f : α → β) : @FirstCountableTopology α (t.induced f) := by
+  letI := t.induced f
+  refine ⟨fun a ↦ ?_⟩
+  have nhds_fa := @FirstCountableTopology.nhds_generated_countable β _ _ (f a)
+  rw [Filter.isCountablyGenerated_iff_exists_antitone_basis] at *
+  obtain ⟨B, hB⟩ := nhds_fa
+  refine ⟨fun n ↦ preimage f (B n), ⟨?_, fun _ _ le ↦ preimage_mono <| hB.2 le⟩⟩
+  rw [(@induced_iff_nhds_eq β α _ _ f).mp rfl a]
+  apply hB.toHasBasis.comap
 
 variable {α}
+
+instance Subtype.firstCountableTopology (s : Set α) [FirstCountableTopology α] :
+    FirstCountableTopology s :=
+  firstCountableTopology_induced s α (↑)
+
+protected theorem _root_.Inducing.firstCountableTopology {β : Type*}
+    [TopologicalSpace β] [FirstCountableTopology β] {f : α → β} (hf : Inducing f) :
+    FirstCountableTopology α := by
+  rw [hf.1]
+  exact firstCountableTopology_induced α β f
+
+protected theorem _root_.Embedding.firstCountableTopology {β : Type*}
+    [TopologicalSpace β] [FirstCountableTopology β] {f : α → β} (hf : Embedding f) :
+    FirstCountableTopology α :=
+  hf.1.firstCountableTopology
+
+namespace FirstCountableTopology
 
 /-- In a first-countable space, a cluster point `x` of a sequence
 is the limit of some subsequence. -/
@@ -683,8 +711,6 @@ theorem tendsto_subseq [FirstCountableTopology α] {u : ℕ → α} {x : α}
 #align topological_space.first_countable_topology.tendsto_subseq TopologicalSpace.FirstCountableTopology.tendsto_subseq
 
 end FirstCountableTopology
-
-variable {α}
 
 instance {β} [TopologicalSpace β] [FirstCountableTopology α] [FirstCountableTopology β] :
     FirstCountableTopology (α × β) :=

--- a/Mathlib/Topology/Bases.lean
+++ b/Mathlib/Topology/Bases.lean
@@ -674,15 +674,9 @@ attribute [instance] FirstCountableTopology.nhds_generated_countable
 /-- If `β` is a first-countable space, then its induced topology via `f` on `α` is also
 first-countable. -/
 theorem firstCountableTopology_induced (α β : Type*) [t : TopologicalSpace β]
-    [FirstCountableTopology β] (f : α → β) : @FirstCountableTopology α (t.induced f) := by
-  letI := t.induced f
-  refine ⟨fun a ↦ ?_⟩
-  have nhds_fa := @FirstCountableTopology.nhds_generated_countable β _ _ (f a)
-  rw [Filter.isCountablyGenerated_iff_exists_antitone_basis] at *
-  obtain ⟨B, hB⟩ := nhds_fa
-  refine ⟨fun n ↦ preimage f (B n), ⟨?_, fun _ _ le ↦ preimage_mono <| hB.2 le⟩⟩
-  rw [(@induced_iff_nhds_eq β α _ _ f).mp rfl a]
-  apply hB.toHasBasis.comap
+    [FirstCountableTopology β] (f : α → β) : @FirstCountableTopology α (t.induced f) :=
+  let _ := t.induced f;
+  ⟨fun x ↦ nhds_induced f x ▸ inferInstance⟩
 
 variable {α}
 


### PR DESCRIPTION
Add `firstCountableTopology_induced`, `Subtype.firstCountableTopology`, `Inducing.firstCountableTopology`, and `Embedding.firstCountableTopology`. These are pretty literal counterparts of the existing `secondCountableTopology_induced`, `Subtype.secondCountableTopology`, `Inducing.secondCountableTopology`, and `Embedding.secondCountableTopology`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
