### PR TITLE
[Merged by Bors] - feat: Continuous real-valued functions separate points in T3.5-spaces.

### DIFF
--- a/Mathlib/Topology/CompletelyRegular.lean
+++ b/Mathlib/Topology/CompletelyRegular.lean
@@ -95,3 +95,10 @@ instance T4Space.instT35Space [T4Space X] : T35Space X := by
   have : T1Space X := T2Space.t1Space
   have : CompletelyRegularSpace X := NormalSpace.instCompletelyRegularSpace
   exact {}
+
+lemma separatesPoints_continuous_of_T35Space [T35Space X] :
+    SeparatesPoints (Continuous : Set (X → ℝ)) := by
+  intro x y x_ne_y
+  obtain ⟨f, f_cont, f_zero, f_one⟩ :=
+    CompletelyRegularSpace.completely_regular x {y} isClosed_singleton x_ne_y
+  refine ⟨fun x ↦ f x, continuous_subtype_val.comp f_cont, by aesop⟩

--- a/Mathlib/Topology/CompletelyRegular.lean
+++ b/Mathlib/Topology/CompletelyRegular.lean
@@ -96,7 +96,7 @@ instance T4Space.instT35Space [T4Space X] : T35Space X := by
   have : CompletelyRegularSpace X := NormalSpace.instCompletelyRegularSpace
   exact {}
 
-lemma separatesPoints_continuous_of_T35Space [T35Space X] :
+lemma separatesPoints_continuous_of_t35Space [T35Space X] :
     SeparatesPoints (Continuous : Set (X → ℝ)) := by
   intro x y x_ne_y
   obtain ⟨f, f_cont, f_zero, f_one⟩ :=

--- a/Mathlib/Topology/CompletelyRegular.lean
+++ b/Mathlib/Topology/CompletelyRegular.lean
@@ -101,4 +101,4 @@ lemma separatesPoints_continuous_of_T35Space [T35Space X] :
   intro x y x_ne_y
   obtain ⟨f, f_cont, f_zero, f_one⟩ :=
     CompletelyRegularSpace.completely_regular x {y} isClosed_singleton x_ne_y
-  refine ⟨fun x ↦ f x, continuous_subtype_val.comp f_cont, by aesop⟩
+  exact ⟨fun x ↦ f x, continuous_subtype_val.comp f_cont, by aesop⟩


### PR DESCRIPTION
Continuous real-valued functions separate points in T3.5-spaces, spelled in terms of `SeparatesPoints`. There was a brief [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/separatesPoints_continuous/near/430510853).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
