### PR TITLE
[Merged by Bors] - Feat (Analysis/Normed/Ring/Seminorm): add equivalence of MulRingNorms

### DIFF
--- a/Mathlib/Analysis/Normed/Ring/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Ring/Seminorm.lean
@@ -333,12 +333,12 @@ def equiv (f : MulRingNorm R) (g : MulRingNorm R) :=
 
 /- Equivalence of multiplicative ring norms is an equivalence relation
   1. is reflexive-/
-lemma equiv_refl {R : Type*} [Ring R] (f : MulRingNorm R) : equiv f f := by
+lemma equiv_refl (f : MulRingNorm R) : equiv f f := by
   exact ⟨1, by linarith, by simp only [Real.rpow_one]⟩
 
 /- Equivalence of multiplicative ring norms is an equivalence relation
  2. is symmetric-/
-lemma equiv_symm {R : Type*} [Ring R] (f g : MulRingNorm R) (hfg : equiv f g) : equiv g f := by
+lemma equiv_symm (f g : MulRingNorm R) (hfg : equiv f g) : equiv g f := by
   rcases hfg with ⟨c, hcpos, h⟩
   use 1/c
   constructor
@@ -348,7 +348,7 @@ lemma equiv_symm {R : Type*} [Ring R] (f g : MulRingNorm R) (hfg : equiv f g) : 
 
 /- Equivalence of multiplicative ring norms is an equivalence relation
  3. is transitive-/
-lemma equiv_trans {R : Type*} [Ring R] (f g k : MulRingNorm R) (hfg : equiv f g) (hgk : equiv g k) :
+lemma equiv_trans (f g k : MulRingNorm R) (hfg : equiv f g) (hgk : equiv g k) :
     equiv f k := by
   rcases hfg with ⟨c, hcPos, hfg⟩
   rcases hgk with ⟨d, hdPos, hgk⟩
@@ -384,7 +384,6 @@ def normRingNorm (R : Type*) [NonUnitalNormedRing R] : RingNorm R :=
 #align norm_ring_norm normRingNorm
 
 
-/-A multiplicative ring norm with value in the rationals satisfies `f n ≤ n` for every `n : ℕ`-/
 /-A multiplicative ring norm with value in the rationals satisfies `f n ≤ n` for every `n : ℕ`-/
 lemma MulRingNorm_nat_le_nat {R : Type*} [Ring R] (n : ℕ) (f : MulRingNorm R) : f n ≤ n := by
   induction n with

--- a/Mathlib/Analysis/Normed/Ring/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Ring/Seminorm.lean
@@ -321,8 +321,7 @@ instance : Inhabited (MulRingNorm R) :=
   ⟨1⟩
 
 
-variable {R : Type*}
-variable [Ring R]
+variable {R : Type*} [Ring R]
 
 /-- Two multiplicative ring norms `f, g` on `R` are equivalent if there exists a positive constant
   `c` such that for all `x ∈ R`, `(f x)^c = g x`.
@@ -391,6 +390,6 @@ lemma MulRingNorm_nat_le_nat {R : Type*} [Ring R] (n : ℕ) (f : MulRingNorm R) 
   | succ n hn =>
     simp only [Nat.cast_succ]
     calc
-      f (↑n + 1) ≤ f (↑n) + f 1 := f.add_le' ↑n 1
-      _ = f (↑n) + 1 := by rw [map_one]
-      _ ≤ ↑n + 1 := add_le_add_right hn 1
+      f (n + 1) ≤ f (n) + f 1 := f.add_le' ↑n 1
+      _ = f (n) + 1 := by rw [map_one]
+      _ ≤ n + 1 := add_le_add_right hn 1

--- a/Mathlib/Analysis/Normed/Ring/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Ring/Seminorm.lean
@@ -328,7 +328,7 @@ variable {R : Type*} [Ring R]
   This could be generalised to RingNorm, but MulRingNorm does not extend this. -/
 
 def equiv (f : MulRingNorm R) (g : MulRingNorm R) :=
-  ∃ c : ℝ, 0 < c ∧ (λ x : R => (f x) ^ c) = g
+  ∃ c : ℝ, 0 < c ∧ (fun x => (f x) ^ c) = g
 
 /- Equivalence of multiplicative ring norms is an equivalence relation
   1. is reflexive-/

--- a/Mathlib/Analysis/Normed/Ring/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Ring/Seminorm.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: María Inés de Frutos-Fernández, Yaël Dillies
 -/
 import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 #align_import analysis.normed.ring.seminorm from "leanprover-community/mathlib"@"7ea604785a41a0681eac70c5a82372493dbefc68"
 
@@ -319,6 +320,42 @@ theorem apply_one (x : R) : (1 : MulRingNorm R) x = if x = 0 then 0 else 1 :=
 instance : Inhabited (MulRingNorm R) :=
   ⟨1⟩
 
+
+/-- Two multiplicative ring norms `f, g` on `R` are equivalent if there exists a positive constant
+  `c` such that for all `x ∈ R`, `(f x)^c = g x`.
+  This could be generalised to RingNorm, but MulRingNorm does not extend this. -/
+def equiv {R : Type*} [Ring R] (f : MulRingNorm R) (g : MulRingNorm R) :=
+  ∃ c : ℝ, 0 < c ∧ (λ x : R => (f x) ^ c) = g
+
+/- Equivalence of multiplicative ring norms is an equivalence relation
+  1. is reflexive-/
+lemma equiv_refl {R : Type*} [Ring R] (f : MulRingNorm R) : equiv f f := by
+  refine ⟨1, by linarith, by simp only [Real.rpow_one]⟩
+
+/- Equivalence of multiplicative ring norms is an equivalence relation
+ 2. is symmetric-/
+lemma equiv_symm {R : Type*} [Ring R] (f g : MulRingNorm R) (hfg : equiv f g) : equiv g f := by
+  rcases hfg with ⟨c, hcpos, h⟩
+  use 1/c
+  constructor
+  · simp only [one_div, inv_pos, hcpos]
+  · replace h := congr_fun h
+    ext x
+    rw [← h x]
+    simp only [AddGroupSeminorm.toFun_eq_coe, MulRingSeminorm.toFun_eq_coe, one_div, map_nonneg]
+    exact Real.rpow_rpow_inv (apply_nonneg f x) (ne_of_lt hcpos).symm
+
+/- Equivalence of multiplicative ring norms is an equivalence relation
+ 3. is transitive-/
+lemma equiv_trans {R : Type*} [Ring R] (f g k : MulRingNorm R) (hfg : equiv f g) (hgk : equiv g k) :
+    equiv f k := by
+  rcases hfg with ⟨c, hcPos, hfg⟩
+  rcases hgk with ⟨d, hdPos, hgk⟩
+  refine ⟨c*d, (mul_pos_iff_of_pos_left hcPos).mpr hdPos, ?_⟩
+  ext x
+  rw [Real.rpow_mul (apply_nonneg f x), congr_fun hfg x, congr_fun hgk x]
+
+
 end MulRingNorm
 
 /-- A nonzero ring seminorm on a field `K` is a ring norm. -/
@@ -344,3 +381,14 @@ def RingSeminorm.toRingNorm {K : Type*} [Field K] (f : RingSeminorm K) (hnt : f 
 def normRingNorm (R : Type*) [NonUnitalNormedRing R] : RingNorm R :=
   { normAddGroupNorm R, normRingSeminorm R with }
 #align norm_ring_norm normRingNorm
+
+
+/-A multiplicative ring norm with value in the rationals satisfies `f n ≤ n` for every `n : ℕ`-/
+lemma MulRingNorm_nat_le_nat (n : ℕ) (f : MulRingNorm ℚ) : f n ≤ n := by
+  induction' n with n hn
+  · simp only [Nat.zero_eq, CharP.cast_eq_zero, map_zero, le_refl]
+  · simp only [Nat.cast_succ]
+    calc
+      f (↑n + 1) ≤ f (↑n) + f 1 := f.add_le' ↑n 1
+      _ = f (↑n) + 1 := by rw [map_one]
+      _ ≤ ↑n + 1 := add_le_add_right hn 1

--- a/Mathlib/Analysis/Normed/Ring/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Ring/Seminorm.lean
@@ -321,16 +321,20 @@ instance : Inhabited (MulRingNorm R) :=
   ⟨1⟩
 
 
+variable {R : Type*}
+variable [Ring R]
+
 /-- Two multiplicative ring norms `f, g` on `R` are equivalent if there exists a positive constant
   `c` such that for all `x ∈ R`, `(f x)^c = g x`.
   This could be generalised to RingNorm, but MulRingNorm does not extend this. -/
-def equiv {R : Type*} [Ring R] (f : MulRingNorm R) (g : MulRingNorm R) :=
+
+def equiv (f : MulRingNorm R) (g : MulRingNorm R) :=
   ∃ c : ℝ, 0 < c ∧ (λ x : R => (f x) ^ c) = g
 
 /- Equivalence of multiplicative ring norms is an equivalence relation
   1. is reflexive-/
 lemma equiv_refl {R : Type*} [Ring R] (f : MulRingNorm R) : equiv f f := by
-  refine ⟨1, by linarith, by simp only [Real.rpow_one]⟩
+  exact ⟨1, by linarith, by simp only [Real.rpow_one]⟩
 
 /- Equivalence of multiplicative ring norms is an equivalence relation
  2. is symmetric-/
@@ -339,11 +343,8 @@ lemma equiv_symm {R : Type*} [Ring R] (f g : MulRingNorm R) (hfg : equiv f g) : 
   use 1/c
   constructor
   · simp only [one_div, inv_pos, hcpos]
-  · replace h := congr_fun h
-    ext x
-    rw [← h x]
-    simp only [AddGroupSeminorm.toFun_eq_coe, MulRingSeminorm.toFun_eq_coe, one_div, map_nonneg]
-    exact Real.rpow_rpow_inv (apply_nonneg f x) (ne_of_lt hcpos).symm
+  ext x
+  simpa [← congr_fun h x] using Real.rpow_rpow_inv (apply_nonneg f x) (ne_of_lt hcpos).symm
 
 /- Equivalence of multiplicative ring norms is an equivalence relation
  3. is transitive-/
@@ -384,10 +385,12 @@ def normRingNorm (R : Type*) [NonUnitalNormedRing R] : RingNorm R :=
 
 
 /-A multiplicative ring norm with value in the rationals satisfies `f n ≤ n` for every `n : ℕ`-/
-lemma MulRingNorm_nat_le_nat (n : ℕ) (f : MulRingNorm ℚ) : f n ≤ n := by
-  induction' n with n hn
-  · simp only [Nat.zero_eq, CharP.cast_eq_zero, map_zero, le_refl]
-  · simp only [Nat.cast_succ]
+/-A multiplicative ring norm with value in the rationals satisfies `f n ≤ n` for every `n : ℕ`-/
+lemma MulRingNorm_nat_le_nat {R : Type*} [Ring R] (n : ℕ) (f : MulRingNorm R) : f n ≤ n := by
+  induction n with
+  | zero => simp only [Nat.cast_zero, map_zero, le_refl]
+  | succ n hn =>
+    simp only [Nat.cast_succ]
     calc
       f (↑n + 1) ≤ f (↑n) + f 1 := f.add_le' ↑n 1
       _ = f (↑n) + 1 := by rw [map_one]

--- a/Mathlib/Analysis/Normed/Ring/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Ring/Seminorm.lean
@@ -324,20 +324,20 @@ instance : Inhabited (MulRingNorm R) :=
 variable {R : Type*} [Ring R]
 
 /-- Two multiplicative ring norms `f, g` on `R` are equivalent if there exists a positive constant
-  `c` such that for all `x ∈ R`, `(f x)^c = g x`.
-  This could be generalised to RingNorm, but MulRingNorm does not extend this. -/
+  `c` such that for all `x ∈ R`, `(f x)^c = g x`.  -/
 
 def equiv (f : MulRingNorm R) (g : MulRingNorm R) :=
   ∃ c : ℝ, 0 < c ∧ (fun x => (f x) ^ c) = g
 
 /- Equivalence of multiplicative ring norms is an equivalence relation
+
   1. is reflexive-/
 lemma equiv_refl (f : MulRingNorm R) : equiv f f := by
-  exact ⟨1, by linarith, by simp only [Real.rpow_one]⟩
-
+    exact ⟨1, Real.zero_lt_one, by simp only [Real.rpow_one]⟩
 /- Equivalence of multiplicative ring norms is an equivalence relation
+
  2. is symmetric-/
-lemma equiv_symm (f g : MulRingNorm R) (hfg : equiv f g) : equiv g f := by
+lemma equiv_symm {f g : MulRingNorm R} (hfg : equiv f g) : equiv g f := by
   rcases hfg with ⟨c, hcpos, h⟩
   use 1/c
   constructor
@@ -346,8 +346,9 @@ lemma equiv_symm (f g : MulRingNorm R) (hfg : equiv f g) : equiv g f := by
   simpa [← congr_fun h x] using Real.rpow_rpow_inv (apply_nonneg f x) (ne_of_lt hcpos).symm
 
 /- Equivalence of multiplicative ring norms is an equivalence relation
+
  3. is transitive-/
-lemma equiv_trans (f g k : MulRingNorm R) (hfg : equiv f g) (hgk : equiv g k) :
+lemma equiv_trans {f g k : MulRingNorm R} (hfg : equiv f g) (hgk : equiv g k) :
     equiv f k := by
   rcases hfg with ⟨c, hcPos, hfg⟩
   rcases hgk with ⟨d, hdPos, hgk⟩
@@ -383,7 +384,7 @@ def normRingNorm (R : Type*) [NonUnitalNormedRing R] : RingNorm R :=
 #align norm_ring_norm normRingNorm
 
 
-/-A multiplicative ring norm with value in the rationals satisfies `f n ≤ n` for every `n : ℕ`-/
+/-A multiplicative ring norm satisfies `f n ≤ n` for every `n : ℕ`-/
 lemma MulRingNorm_nat_le_nat {R : Type*} [Ring R] (n : ℕ) (f : MulRingNorm R) : f n ≤ n := by
   induction n with
   | zero => simp only [Nat.cast_zero, map_zero, le_refl]


### PR DESCRIPTION
Include the definition of equivalence of `MulRingNorms` and the lemmas proving it is an equivalence relation. For this we add a new import (to `Mathlib.Analysis.SpecialFunctions.Pow.Real`).
We also include a lemma describing the values of a multiplicative ring norm on the naturals, stating that for all `n : ℕ` if `f : MulRingNorm R` then `f n ≤ n`

Co-authored-by: 
- David Kurniadi Angdinata <dka31@cantab.ac.uk>
- Fabrizio Barroero <fabrizio.barroero@uniroma3.it>
- Laura Capuano <laura.capuano@uniroma3.it>
- Nirvana Coppola <nirvanac93@gmail.com>
- María Inés de Frutos Fernández <maria.defrutos@uam.es>
- Silvain Rideau-Kikuchi <silvain.rideau-kikuchi@ens.fr>
- Sam van Gool <vangool@irif.fr>
- Francesco Veneziano <veneziano@dima.unige.it>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
