### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/TensorProduct/Finiteness): add some finiteness results of tensor product

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2684,6 +2684,7 @@ import Mathlib.LinearAlgebra.TensorPower
 import Mathlib.LinearAlgebra.TensorProduct.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 import Mathlib.LinearAlgebra.TensorProduct.DirectLimit
+import Mathlib.LinearAlgebra.TensorProduct.Finiteness
 import Mathlib.LinearAlgebra.TensorProduct.Graded.External
 import Mathlib.LinearAlgebra.TensorProduct.Graded.Internal
 import Mathlib.LinearAlgebra.TensorProduct.Matrix

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -863,6 +863,11 @@ def mapIncl (p : Submodule R P) (q : Submodule R Q) : p ⊗[R] q →ₗ[R] P ⊗
   map p.subtype q.subtype
 #align tensor_product.map_incl TensorProduct.mapIncl
 
+lemma range_mapIncl (p : Submodule R P) (q : Submodule R Q) :
+    LinearMap.range (mapIncl p q) = span R (Set.image2 (· ⊗ₜ ·) p q) := by
+  rw [mapIncl, map_range_eq_span_tmul]
+  congr; ext; simp
+
 section
 
 variable {P' Q' : Type*}
@@ -873,6 +878,11 @@ theorem map_comp (f₂ : P →ₗ[R] P') (f₁ : M →ₗ[R] P) (g₂ : Q →ₗ
     map (f₂.comp f₁) (g₂.comp g₁) = (map f₂ g₂).comp (map f₁ g₁) :=
   ext' fun _ _ => rfl
 #align tensor_product.map_comp TensorProduct.map_comp
+
+lemma range_mapIncl_mono {p p' : Submodule R P} {q q' : Submodule R Q} (hp : p ≤ p') (hq : q ≤ q') :
+    LinearMap.range (mapIncl p q) ≤ LinearMap.range (mapIncl p' q') := by
+  simp_rw [range_mapIncl]
+  exact span_mono (Set.image2_subset hp hq)
 
 theorem lift_comp_map (i : P →ₗ[R] Q →ₗ[R] Q') (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
     (lift i).comp (map f g) = lift ((i.comp f).compl₂ g) :=

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -864,7 +864,7 @@ def mapIncl (p : Submodule R P) (q : Submodule R Q) : p ⊗[R] q →ₗ[R] P ⊗
 #align tensor_product.map_incl TensorProduct.mapIncl
 
 lemma range_mapIncl (p : Submodule R P) (q : Submodule R Q) :
-    LinearMap.range (mapIncl p q) = span R (Set.image2 (· ⊗ₜ ·) p q) := by
+    LinearMap.range (mapIncl p q) = Submodule.span R (Set.image2 (· ⊗ₜ ·) p q) := by
   rw [mapIncl, map_range_eq_span_tmul]
   congr; ext; simp
 
@@ -882,7 +882,7 @@ theorem map_comp (f₂ : P →ₗ[R] P') (f₁ : M →ₗ[R] P) (g₂ : Q →ₗ
 lemma range_mapIncl_mono {p p' : Submodule R P} {q q' : Submodule R Q} (hp : p ≤ p') (hq : q ≤ q') :
     LinearMap.range (mapIncl p q) ≤ LinearMap.range (mapIncl p' q') := by
   simp_rw [range_mapIncl]
-  exact span_mono (Set.image2_subset hp hq)
+  exact Submodule.span_mono (Set.image2_subset hp hq)
 
 theorem lift_comp_map (i : P →ₗ[R] Q →ₗ[R] Q') (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
     (lift i).comp (map f g) = lift ((i.comp f).compl₂ g) :=

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -17,12 +17,17 @@ This file contains some finiteness results of tensor product.
   any element of `M ⊗[R] N` can be written as a finite sum of pure tensors.
   See also `TensorProduct.span_tmul_eq_top`.
 
-- `TensorProduct.exists_finite_submodule_left_of_fintype`,
-  `TensorProduct.exists_finite_submodule_right_of_fintype`,
-  `TensorProduct.exists_finite_submodule_of_fintype` and 21 more:
-  any finitely many elements `M ⊗[R] N` is contained in `M' ⊗[R] N'`
+- `TensorProduct.exists_finite_submodule_left_of_finite`,
+  `TensorProduct.exists_finite_submodule_right_of_finite`,
+  `TensorProduct.exists_finite_submodule_of_finite`:
+  any finite subset of `M ⊗[R] N` is contained in `M' ⊗[R] N`,
+  resp. `M ⊗[R] N'`, resp. `M' ⊗[R] N'`,
   for some finitely generated submodules `M'` and `N'` of `M` and `N`, respectively.
-  Each of these 3 functions has 8 variants.
+
+- `TensorProduct.exists_finite_submodule_left_of_finite'`,
+  `TensorProduct.exists_finite_submodule_right_of_finite'`,
+  `TensorProduct.exists_finite_submodule_of_finite'`:
+  variation of the above results where `M` and `N` are already submodules.
 
 ## Tags
 
@@ -38,7 +43,7 @@ variable {R M N : Type*}
 
 variable [CommSemiring R] [AddCommMonoid M] [AddCommMonoid N] [Module R M] [Module R N]
 
-variable {M₁ : Submodule R M} {N₁ : Submodule R N}
+variable {M₁ M₂ : Submodule R M} {N₁ N₂ : Submodule R N}
 
 namespace TensorProduct
 
@@ -87,218 +92,88 @@ theorem exists_finset (x : M ⊗[R] N) :
   rw [h, Finsupp.sum]
   refine' Finset.sum_nbij' (fun m ↦ ⟨m, S m⟩) Prod.fst .. <;> simp
 
-/-- If `x : ι → M ⊗[R] N` are finitely many elements, then there exists a finitely generated
-submodule `M'` of `M` and `x' : ι → M' ⊗[R] N`, whose image in `M ⊗[R] N` is equal to `x`.
-There are 8 variants of this function. -/
-theorem exists_finite_submodule_left_of_fintype {ι : Type*} [Fintype ι] (x : ι → M ⊗[R] N) :
-    ∃ (M' : Submodule R M) (x' : ι → M' ⊗[R] N), Module.Finite R M' ∧
-    ∀ (i : ι), M'.subtype.rTensor N (x' i) = x i := by
-  classical
-  choose S hS using fun i ↦ (x i).exists_multiset
-  let T := ((Finset.sum Finset.univ S).map Prod.fst).toFinset
-  let M' := span R (T : Set M)
-  let f (i : M × N) : M' ⊗[R] N := if h : i.1 ∈ T then ⟨i.1, subset_span h⟩ ⊗ₜ[R] i.2 else 0
-  let x' (i : ι) := ((S i).map f).sum
-  refine ⟨M', x', inferInstance, fun j ↦ ?_⟩
-  simp_rw [x', hS, map_multiset_sum, Multiset.map_map]
-  congr 1
-  refine Multiset.map_congr rfl fun i hi ↦ ?_
-  replace hi : i.1 ∈ T := by
-    simp only [Multiset.mem_toFinset, Multiset.mem_map, Prod.exists, exists_and_right,
-      exists_eq_right, T]
-    exact ⟨i.2, Multiset.mem_of_le (Finset.single_le_sum (by simp) (by simp)) hi⟩
-  simp_rw [Function.comp_apply, f, dif_pos hi]; rfl
+lemma range_mapIncl_mono (hM : M₁ ≤ M₂) (hN : N₁ ≤ N₂) :
+    LinearMap.range (mapIncl M₁ N₁) ≤ LinearMap.range (mapIncl M₂ N₂) := by
+  simp_rw [mapIncl, ← subtype_comp_inclusion _ _ hM, ← subtype_comp_inclusion _ _ hN, map_comp]
+  exact LinearMap.range_comp_le_range _ _
 
-/-- If `x : ι → M ⊗[R] N` are finitely many elements, then there exists a finitely generated
-submodule `N'` of `N` and `x' : ι → M ⊗[R] N'`, whose image in `M ⊗[R] N` is equal to `x`.
-There are 8 variants of this function. -/
-theorem exists_finite_submodule_right_of_fintype {ι : Type*} [Fintype ι] (x : ι → M ⊗[R] N) :
-    ∃ (N' : Submodule R N) (x' : ι → M ⊗[R] N'), Module.Finite R N' ∧
-    ∀ (i : ι), N'.subtype.lTensor M (x' i) = x i := by
-  obtain ⟨N', x', hfin, hx⟩ := exists_finite_submodule_left_of_fintype fun i ↦
-    TensorProduct.comm R M N (x i)
-  have key : N'.subtype.lTensor M ∘ₗ TensorProduct.comm R N' M =
-      (TensorProduct.comm R M N).symm ∘ₗ N'.subtype.rTensor M := ext' fun _ _ ↦ rfl
-  refine ⟨N', fun i ↦ TensorProduct.comm R N' M (x' i), hfin, fun i ↦ ?_⟩
-  replace hx := congr((TensorProduct.comm R M N).symm $(hx i))
-  rw [LinearEquiv.symm_apply_apply] at hx
-  simpa only [← hx] using congr($key (x' i))
+/-- For a finite subset `s` of `M ⊗[R] N`, there are finitely generated
+submodules `M'` and `N'` of `M` and `N`, respectively, such that `s` is contained in the image
+of `M' ⊗[R] N'` in `M ⊗[R] N`. -/
+theorem exists_finite_submodule_of_finite (s : Set (M ⊗[R] N)) (hs : s.Finite) :
+    ∃ (M' : Submodule R M) (N' : Submodule R N), Module.Finite R M' ∧ Module.Finite R N' ∧
+      s ⊆ LinearMap.range (mapIncl M' N') := by
+  simp_rw [Module.Finite.iff_fg]
+  refine hs.induction_on ⟨_, _, fg_bot, fg_bot, Set.empty_subset _⟩ ?_
+  rintro a s - - ⟨M', N', hM', hN', h⟩
+  refine TensorProduct.induction_on a ?_ (fun x y ↦ ?_) fun x y hx hy ↦ ?_
+  · exact ⟨M', N', hM', hN', Set.insert_subset (zero_mem _) h⟩
+  · refine ⟨_, _, hM'.sup (fg_span_singleton x),
+      hN'.sup (fg_span_singleton y), Set.insert_subset ?_ fun z hz ↦ ?_⟩
+    · exact ⟨⟨x, mem_sup_right (mem_span_singleton_self x)⟩ ⊗ₜ
+        ⟨y, mem_sup_right (mem_span_singleton_self y)⟩, rfl⟩
+    · exact range_mapIncl_mono le_sup_left le_sup_left (h hz)
+  · obtain ⟨M₁', N₁', hM₁', hN₁', h₁⟩ := hx
+    obtain ⟨M₂', N₂', hM₂', hN₂', h₂⟩ := hy
+    refine ⟨_, _, hM₁'.sup hM₂', hN₁'.sup hN₂', Set.insert_subset (add_mem ?_ ?_) fun z hz ↦ ?_⟩
+    · exact range_mapIncl_mono le_sup_left le_sup_left (h₁ (Set.mem_insert x s))
+    · exact range_mapIncl_mono le_sup_right le_sup_right (h₂ (Set.mem_insert y s))
+    · exact range_mapIncl_mono le_sup_left le_sup_left (h₁ (Set.subset_insert x s hz))
 
-/-- If `x : ι → M ⊗[R] N` are finitely many elements, then there are finitely generated
-submodules `M'` and `N'` of `M` and `N`, respectively, and `x' : ι → M' ⊗[R] N'`,
-whose image in `M ⊗[R] N` is equal to `x`. There are 8 variants of this function. -/
-theorem exists_finite_submodule_of_fintype {ι : Type*} [Fintype ι] (x : ι → M ⊗[R] N) :
-    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' : ι → M' ⊗[R] N'),
-    Module.Finite R M' ∧ Module.Finite R N' ∧
-    ∀ (i : ι), TensorProduct.map M'.subtype N'.subtype (x' i) = x i := by
-  obtain ⟨M', x', h1, hx⟩ := exists_finite_submodule_left_of_fintype x
-  obtain ⟨N', x'', h2, hx'⟩ := exists_finite_submodule_right_of_fintype x'
-  refine ⟨M', N', x'', h1, h2, fun i ↦ ?_⟩
-  rw [← hx, ← hx', ← LinearMap.rTensor_comp_lTensor]; rfl
+/-- For a finite subset `s` of `M ⊗[R] N`, there exists a finitely generated
+submodule `M'` of `M`, such that `s` is contained in the image
+of `M' ⊗[R] N` in `M ⊗[R] N`. -/
+theorem exists_finite_submodule_left_of_finite (s : Set (M ⊗[R] N)) (hs : s.Finite) :
+    ∃ (M' : Submodule R M), Module.Finite R M' ∧
+      s ⊆ LinearMap.range (M'.subtype.rTensor N) := by
+  obtain ⟨M', _, hfin, _, h⟩ := exists_finite_submodule_of_finite s hs
+  refine ⟨M', hfin, ?_⟩
+  rw [mapIncl, ← LinearMap.rTensor_comp_lTensor] at h
+  exact h.trans (LinearMap.range_comp_le_range _ _)
 
-theorem exists_finite_submodule_left_of_fintype' {ι : Type*} [Fintype ι] (x : ι → M₁ ⊗[R] N₁) :
-    ∃ (M' : Submodule R M) (x' : ι → M' ⊗[R] N₁) (hM : M' ≤ M₁), Module.Finite R M' ∧
-    ∀ (i : ι), (inclusion hM).rTensor N₁ (x' i) = x i := by
-  obtain ⟨M', x', hfin, hx⟩ := exists_finite_submodule_left_of_fintype x
-  refine ⟨_, (M₁.subtype.submoduleMap M').rTensor N₁ ∘ x', map_subtype_le _ _, .map _ _, fun i ↦ ?_⟩
-  have key : M'.subtype.rTensor N₁ =
-      (inclusion (map_subtype_le _ _)).rTensor N₁ ∘ₗ (M₁.subtype.submoduleMap M').rTensor N₁ :=
-    ext' fun _ _ ↦ rfl
-  rw [← hx, key]; rfl
+/-- For a finite subset `s` of `M ⊗[R] N`, there exists a finitely generated
+submodule `N'` of `N`, such that `s` is contained in the image
+of `M ⊗[R] N'` in `M ⊗[R] N`. -/
+theorem exists_finite_submodule_right_of_finite (s : Set (M ⊗[R] N)) (hs : s.Finite) :
+    ∃ (N' : Submodule R N), Module.Finite R N' ∧
+      s ⊆ LinearMap.range (N'.subtype.lTensor M) := by
+  obtain ⟨_, N', _, hfin, h⟩ := exists_finite_submodule_of_finite s hs
+  refine ⟨N', hfin, ?_⟩
+  rw [mapIncl, ← LinearMap.lTensor_comp_rTensor] at h
+  exact h.trans (LinearMap.range_comp_le_range _ _)
 
-theorem exists_finite_submodule_right_of_fintype' {ι : Type*} [Fintype ι] (x : ι → M₁ ⊗[R] N₁) :
-    ∃ (N' : Submodule R N) (x' : ι → M₁ ⊗[R] N') (hN : N' ≤ N₁), Module.Finite R N' ∧
-    ∀ (i : ι), (inclusion hN).lTensor M₁ (x' i) = x i := by
-  obtain ⟨N', x', hfin, hx⟩ := exists_finite_submodule_right_of_fintype x
-  refine ⟨_, (N₁.subtype.submoduleMap N').lTensor M₁ ∘ x', map_subtype_le _ _, .map _ _, fun i ↦ ?_⟩
-  have key : N'.subtype.lTensor M₁ =
-      (inclusion (map_subtype_le _ _)).lTensor M₁ ∘ₗ (N₁.subtype.submoduleMap N').lTensor M₁ :=
-    ext' fun _ _ ↦ rfl
-  rw [← hx, key]; rfl
+/-- Variation of `TensorProduct.exists_finite_submodule_of_finite` where `M` and `N` are
+already submodules. -/
+theorem exists_finite_submodule_of_finite' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
+    ∃ (M' : Submodule R M) (N' : Submodule R N) (hM : M' ≤ M₁) (hN : N' ≤ N₁),
+      Module.Finite R M' ∧ Module.Finite R N' ∧
+        s ⊆ LinearMap.range (TensorProduct.map (inclusion hM) (inclusion hN)) := by
+  obtain ⟨M', N', _, _, h⟩ := exists_finite_submodule_of_finite s hs
+  have hM := map_subtype_le M₁ M'
+  have hN := map_subtype_le N₁ N'
+  refine ⟨_, _, hM, hN, .map _ _, .map _ _, ?_⟩
+  rw [mapIncl, show M'.subtype = inclusion hM ∘ₗ M₁.subtype.submoduleMap M' from rfl,
+    show N'.subtype = inclusion hN ∘ₗ N₁.subtype.submoduleMap N' from rfl, map_comp] at h
+  exact h.trans (LinearMap.range_comp_le_range _ _)
 
-theorem exists_finite_submodule_of_fintype' {ι : Type*} [Fintype ι] (x : ι → M₁ ⊗[R] N₁) :
-    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' : ι → M' ⊗[R] N') (hM : M' ≤ M₁) (hN : N' ≤ N₁),
-    Module.Finite R M' ∧ Module.Finite R N' ∧
-    ∀ (i : ι), TensorProduct.map (inclusion hM) (inclusion hN) (x' i) = x i := by
-  obtain ⟨M', x', hM, h1, hx⟩ := exists_finite_submodule_left_of_fintype' x
-  obtain ⟨N', x'', hN, h2, hx'⟩ := exists_finite_submodule_right_of_fintype' x'
-  refine ⟨M', N', x'', hM, hN, h1, h2, fun i ↦ ?_⟩
-  rw [← hx, ← hx', ← LinearMap.rTensor_comp_lTensor]; rfl
+/-- Variation of `TensorProduct.exists_finite_submodule_left_of_finite` where `M` and `N` are
+already submodules. -/
+theorem exists_finite_submodule_left_of_finite' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
+    ∃ (M' : Submodule R M) (hM : M' ≤ M₁), Module.Finite R M' ∧
+      s ⊆ LinearMap.range ((inclusion hM).rTensor N₁) := by
+  obtain ⟨M', _, hM, _, hfin, _, h⟩ := exists_finite_submodule_of_finite' s hs
+  refine ⟨M', hM, hfin, ?_⟩
+  rw [← LinearMap.rTensor_comp_lTensor] at h
+  exact h.trans (LinearMap.range_comp_le_range _ _)
 
-theorem exists_finite_submodule_left_of_finsupp {ι : Type*} (x : ι →₀ M ⊗[R] N) :
-    ∃ (M' : Submodule R M) (x' : ι →₀ M' ⊗[R] N), Module.Finite R M' ∧
-    ∀ (i : ι), M'.subtype.rTensor N (x' i) = x i := by
-  classical
-  obtain ⟨M', x', hfin, hx⟩ := exists_finite_submodule_left_of_fintype fun i : x.support ↦ x i
-  refine ⟨M', (Finsupp.equivFunOnFinite.symm x').extendDomain, hfin, fun i ↦ ?_⟩
-  by_cases h : i ∈ x.support
-  · simp [h, hx]
-  simp [h, Finsupp.not_mem_support_iff.1 h]
-
-theorem exists_finite_submodule_right_of_finsupp {ι : Type*} (x : ι →₀ M ⊗[R] N) :
-    ∃ (N' : Submodule R N) (x' : ι →₀ M ⊗[R] N'), Module.Finite R N' ∧
-    ∀ (i : ι), N'.subtype.lTensor M (x' i) = x i := by
-  classical
-  obtain ⟨N', x', hfin, hx⟩ := exists_finite_submodule_right_of_fintype fun i : x.support ↦ x i
-  refine ⟨N', (Finsupp.equivFunOnFinite.symm x').extendDomain, hfin, fun i ↦ ?_⟩
-  by_cases h : i ∈ x.support
-  · simp [h, hx]
-  simp [h, Finsupp.not_mem_support_iff.1 h]
-
-theorem exists_finite_submodule_of_finsupp {ι : Type*} (x : ι →₀ M ⊗[R] N) :
-    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' : ι →₀ M' ⊗[R] N'),
-    Module.Finite R M' ∧ Module.Finite R N' ∧
-    ∀ (i : ι), TensorProduct.map M'.subtype N'.subtype (x' i) = x i := by
-  obtain ⟨M', x', h1, hx⟩ := exists_finite_submodule_left_of_finsupp x
-  obtain ⟨N', x'', h2, hx'⟩ := exists_finite_submodule_right_of_finsupp x'
-  refine ⟨M', N', x'', h1, h2, fun i ↦ ?_⟩
-  rw [← hx, ← hx', ← LinearMap.rTensor_comp_lTensor]; rfl
-
-theorem exists_finite_submodule_left_of_finsupp' {ι : Type*} (x : ι →₀ M₁ ⊗[R] N₁) :
-    ∃ (M' : Submodule R M) (x' : ι →₀ M' ⊗[R] N₁) (hM : M' ≤ M₁), Module.Finite R M' ∧
-    ∀ (i : ι), (inclusion hM).rTensor N₁ (x' i) = x i := by
-  classical
-  obtain ⟨M', x', hM, hfin, hx⟩ := exists_finite_submodule_left_of_fintype' fun i : x.support ↦ x i
-  refine ⟨M', (Finsupp.equivFunOnFinite.symm x').extendDomain, hM, hfin, fun i ↦ ?_⟩
-  by_cases h : i ∈ x.support
-  · simp [h, hx]
-  simp [h, Finsupp.not_mem_support_iff.1 h]
-
-theorem exists_finite_submodule_right_of_finsupp' {ι : Type*} (x : ι →₀ M₁ ⊗[R] N₁) :
-    ∃ (N' : Submodule R N) (x' : ι →₀ M₁ ⊗[R] N') (hN : N' ≤ N₁), Module.Finite R N' ∧
-    ∀ (i : ι), (inclusion hN).lTensor M₁ (x' i) = x i := by
-  classical
-  obtain ⟨N', x', hN, hfin, hx⟩ := exists_finite_submodule_right_of_fintype' fun i : x.support ↦ x i
-  refine ⟨N', (Finsupp.equivFunOnFinite.symm x').extendDomain, hN, hfin, fun i ↦ ?_⟩
-  by_cases h : i ∈ x.support
-  · simp [h, hx]
-  simp [h, Finsupp.not_mem_support_iff.1 h]
-
-theorem exists_finite_submodule_of_finsupp' {ι : Type*} (x : ι →₀ M₁ ⊗[R] N₁) :
-    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' : ι →₀ M' ⊗[R] N')
-    (hM : M' ≤ M₁) (hN : N' ≤ N₁), Module.Finite R M' ∧ Module.Finite R N' ∧
-    ∀ (i : ι), TensorProduct.map (inclusion hM) (inclusion hN) (x' i) = x i := by
-  obtain ⟨M', x', hM, h1, hx⟩ := exists_finite_submodule_left_of_finsupp' x
-  obtain ⟨N', x'', hN, h2, hx'⟩ := exists_finite_submodule_right_of_finsupp' x'
-  refine ⟨M', N', x'', hM, hN, h1, h2, fun i ↦ ?_⟩
-  rw [← hx, ← hx', ← LinearMap.rTensor_comp_lTensor]; rfl
-
-theorem exists_finite_submodule_left_of_pair (x y : M ⊗[R] N) :
-    ∃ (M' : Submodule R M) (x' y' : M' ⊗[R] N), Module.Finite R M' ∧
-    M'.subtype.rTensor N x' = x ∧ M'.subtype.rTensor N y' = y := by
-  obtain ⟨M', x', hfin, hx⟩ := exists_finite_submodule_left_of_fintype ![x, y]
-  exact ⟨M', x' 0, x' 1, hfin, hx 0, hx 1⟩
-
-theorem exists_finite_submodule_right_of_pair (x y : M ⊗[R] N) :
-    ∃ (N' : Submodule R N) (x' y' : M ⊗[R] N'), Module.Finite R N' ∧
-    N'.subtype.lTensor M x' = x ∧ N'.subtype.lTensor M y' = y := by
-  obtain ⟨N', x', hfin, hx⟩ := exists_finite_submodule_right_of_fintype ![x, y]
-  exact ⟨N', x' 0, x' 1, hfin, hx 0, hx 1⟩
-
-theorem exists_finite_submodule_of_pair (x y : M ⊗[R] N) :
-    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' y' : M' ⊗[R] N'),
-    Module.Finite R M' ∧ Module.Finite R N' ∧
-    TensorProduct.map M'.subtype N'.subtype x' = x ∧
-    TensorProduct.map M'.subtype N'.subtype y' = y := by
-  obtain ⟨M', N', x', h1, h2, hx⟩ := exists_finite_submodule_of_fintype ![x, y]
-  exact ⟨M', N', x' 0, x' 1, h1, h2, hx 0, hx 1⟩
-
-theorem exists_finite_submodule_left_of_pair' (x y : M₁ ⊗[R] N₁) :
-    ∃ (M' : Submodule R M) (x' y' : M' ⊗[R] N₁) (hM : M' ≤ M₁), Module.Finite R M' ∧
-    (inclusion hM).rTensor N₁ x' = x ∧ (inclusion hM).rTensor N₁ y' = y := by
-  obtain ⟨M', x', hM, hfin, hx⟩ := exists_finite_submodule_left_of_fintype' ![x, y]
-  exact ⟨M', x' 0, x' 1, hM, hfin, hx 0, hx 1⟩
-
-theorem exists_finite_submodule_right_of_pair' (x y : M₁ ⊗[R] N₁) :
-    ∃ (N' : Submodule R N) (x' y' : M₁ ⊗[R] N') (hN : N' ≤ N₁), Module.Finite R N' ∧
-    (inclusion hN).lTensor M₁ x' = x ∧ (inclusion hN).lTensor M₁ y' = y := by
-  obtain ⟨N', x', hN, hfin, hx⟩ := exists_finite_submodule_right_of_fintype' ![x, y]
-  exact ⟨N', x' 0, x' 1, hN, hfin, hx 0, hx 1⟩
-
-theorem exists_finite_submodule_of_pair' (x y : M₁ ⊗[R] N₁) :
-    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' y' : M' ⊗[R] N') (hM : M' ≤ M₁) (hN : N' ≤ N₁),
-    Module.Finite R M' ∧ Module.Finite R N' ∧
-    TensorProduct.map (inclusion hM) (inclusion hN) x' = x ∧
-    TensorProduct.map (inclusion hM) (inclusion hN) y' = y := by
-  obtain ⟨M', N', x', hM, hN, h1, h2, hx⟩ := exists_finite_submodule_of_fintype' ![x, y]
-  exact ⟨M', N', x' 0, x' 1, hM, hN, h1, h2, hx 0, hx 1⟩
-
-theorem exists_finite_submodule_left (x : M ⊗[R] N) :
-    ∃ (M' : Submodule R M) (x' : M' ⊗[R] N), Module.Finite R M' ∧
-    M'.subtype.rTensor N x' = x := by
-  obtain ⟨M', x', hfin, hx⟩ := exists_finite_submodule_left_of_fintype ![x]
-  exact ⟨M', x' 0, hfin, hx 0⟩
-
-theorem exists_finite_submodule_right (x : M ⊗[R] N) :
-    ∃ (N' : Submodule R N) (x' : M ⊗[R] N'), Module.Finite R N' ∧
-    N'.subtype.lTensor M x' = x := by
-  obtain ⟨N', x', hfin, hx⟩ := exists_finite_submodule_right_of_fintype ![x]
-  exact ⟨N', x' 0, hfin, hx 0⟩
-
-theorem exists_finite_submodule (x : M ⊗[R] N) :
-    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' : M' ⊗[R] N'),
-    Module.Finite R M' ∧ Module.Finite R N' ∧
-    TensorProduct.map M'.subtype N'.subtype x' = x := by
-  obtain ⟨M', N', x', h1, h2, hx⟩ := exists_finite_submodule_of_fintype ![x]
-  exact ⟨M', N', x' 0, h1, h2, hx 0⟩
-
-theorem exists_finite_submodule_left' (x : M₁ ⊗[R] N₁) :
-    ∃ (M' : Submodule R M) (x' : M' ⊗[R] N₁) (hM : M' ≤ M₁), Module.Finite R M' ∧
-    (inclusion hM).rTensor N₁ x' = x := by
-  obtain ⟨M', x', hM, hfin, hx⟩ := exists_finite_submodule_left_of_fintype' ![x]
-  exact ⟨M', x' 0, hM, hfin, hx 0⟩
-
-theorem exists_finite_submodule_right' (x : M₁ ⊗[R] N₁) :
-    ∃ (N' : Submodule R N) (x' : M₁ ⊗[R] N') (hN : N' ≤ N₁), Module.Finite R N' ∧
-    (inclusion hN).lTensor M₁ x' = x := by
-  obtain ⟨N', x', hN, hfin, hx⟩ := exists_finite_submodule_right_of_fintype' ![x]
-  exact ⟨N', x' 0, hN, hfin, hx 0⟩
-
-theorem exists_finite_submodule' (x : M₁ ⊗[R] N₁) :
-    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' : M' ⊗[R] N') (hM : M' ≤ M₁) (hN : N' ≤ N₁),
-    Module.Finite R M' ∧ Module.Finite R N' ∧
-    TensorProduct.map (inclusion hM) (inclusion hN) x' = x := by
-  obtain ⟨M', N', x', hM, hN, h1, h2, hx⟩ := exists_finite_submodule_of_fintype' ![x]
-  exact ⟨M', N', x' 0, hM, hN, h1, h2, hx 0⟩
+/-- Variation of `TensorProduct.exists_finite_submodule_right_of_finite` where `M` and `N` are
+already submodules. -/
+theorem exists_finite_submodule_right_of_finite' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
+    ∃ (N' : Submodule R N) (hN : N' ≤ N₁), Module.Finite R N' ∧
+      s ⊆ LinearMap.range ((inclusion hN).lTensor M₁) := by
+  obtain ⟨_, N', _, hN, _, hfin, h⟩ := exists_finite_submodule_of_finite' s hs
+  refine ⟨N', hN, hfin, ?_⟩
+  rw [← LinearMap.lTensor_comp_rTensor] at h
+  exact h.trans (LinearMap.range_comp_le_range _ _)
 
 end TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -1,0 +1,301 @@
+/-
+Copyright (c) 2024 Jz Pan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jz Pan
+-/
+import Mathlib.LinearAlgebra.TensorProduct.Basic
+import Mathlib.LinearAlgebra.Dimension.Finite
+
+/-!
+
+# Some finiteness results of tensor product
+
+This file contains some finiteness results of tensor product.
+
+- `TensorProduct.exists_multiset`, `TensorProduct.exists_finsupp_left`,
+  `TensorProduct.exists_finsupp_right`, `TensorProduct.exists_finset`:
+  any element of `M ⊗[R] N` can be written as a finite sum of pure tensors.
+  See also `TensorProduct.span_tmul_eq_top`.
+
+- `TensorProduct.exists_finite_submodule_left_of_fintype`,
+  `TensorProduct.exists_finite_submodule_right_of_fintype`,
+  `TensorProduct.exists_finite_submodule_of_fintype` and 21 more:
+  any finitely many elements `M ⊗[R] N` is contained in `M' ⊗[R] N'`
+  for some finitely generated submodules `M'` and `N'` of `M` and `N`, respectively.
+  Each of these 3 functions has 8 variants.
+
+## Tags
+
+tensor product, finitely generated
+
+-/
+
+open scoped Classical TensorProduct
+
+open Submodule
+
+noncomputable section
+
+variable {R M N : Type*}
+
+variable [CommSemiring R] [AddCommMonoid M] [AddCommMonoid N] [Module R M] [Module R N]
+
+variable {M₁ : Submodule R M} {N₁ : Submodule R N}
+
+namespace TensorProduct
+
+/-- For any element `x` of `M ⊗[R] N`, there exists a (finite) multiset `{ (m_i, n_i) }`
+of `M × N`, such that `x` is equal to the sum of `m_i ⊗ₜ[R] n_i`. -/
+theorem exists_multiset (x : M ⊗[R] N) :
+    ∃ S : Multiset (M × N), x = (S.map fun i ↦ i.1 ⊗ₜ[R] i.2).sum := by
+  induction x using TensorProduct.induction_on with
+  | zero => exact ⟨0, by simp⟩
+  | tmul x y => exact ⟨{(x, y)}, by simp⟩
+  | add x y hx hy =>
+    obtain ⟨Sx, hx⟩ := hx
+    obtain ⟨Sy, hy⟩ := hy
+    exact ⟨Sx + Sy, by rw [Multiset.map_add, Multiset.sum_add, hx, hy]⟩
+
+/-- For any element `x` of `M ⊗[R] N`, there exists a finite subset `{ (m_i, n_i) }`
+of `M × N` such that each `m_i` is distinct (we represent it as an element of `M →₀ N`),
+such that `x` is equal to the sum of `m_i ⊗ₜ[R] n_i`. -/
+theorem exists_finsupp_left (x : M ⊗[R] N) :
+    ∃ S : M →₀ N, x = S.sum fun m n ↦ m ⊗ₜ[R] n := by
+  induction x using TensorProduct.induction_on with
+  | zero => exact ⟨0, by simp⟩
+  | tmul x y => exact ⟨Finsupp.single x y, by simp⟩
+  | add x y hx hy =>
+    obtain ⟨Sx, hx⟩ := hx
+    obtain ⟨Sy, hy⟩ := hy
+    use Sx + Sy
+    rw [hx, hy]
+    exact (Finsupp.sum_add_index' (by simp) TensorProduct.tmul_add).symm
+
+/-- For any element `x` of `M ⊗[R] N`, there exists a finite subset `{ (m_i, n_i) }`
+of `M × N` such that each `n_i` is distinct (we represent it as an element of `N →₀ M`),
+such that `x` is equal to the sum of `m_i ⊗ₜ[R] n_i`. -/
+theorem exists_finsupp_right (x : M ⊗[R] N) :
+    ∃ S : N →₀ M, x = S.sum fun n m ↦ m ⊗ₜ[R] n := by
+  obtain ⟨S, h⟩ := exists_finsupp_left (TensorProduct.comm R M N x)
+  refine ⟨S, (TensorProduct.comm R M N).injective ?_⟩
+  simp_rw [h, Finsupp.sum, map_sum]; rfl
+
+/-- For any element `x` of `M ⊗[R] N`, there exists a finite subset `{ (m_i, n_i) }`
+of `M × N`, such that `x` is equal to the sum of `m_i ⊗ₜ[R] n_i`. -/
+theorem exists_finset (x : M ⊗[R] N) :
+    ∃ S : Finset (M × N), x = S.sum fun i ↦ i.1 ⊗ₜ[R] i.2 := by
+  obtain ⟨S, h⟩ := exists_finsupp_left x
+  use S.graph
+  rw [h, Finsupp.sum]
+  refine' Finset.sum_nbij' (fun m ↦ ⟨m, S m⟩) Prod.fst .. <;> simp
+
+/-- If `x : ι → M ⊗[R] N` are finitely many elements, then there exists a finitely generated
+submodule `M'` of `M` and `x' : ι → M' ⊗[R] N`, whose image in `M ⊗[R] N` is equal to `x`.
+There are 8 variants of this function. -/
+theorem exists_finite_submodule_left_of_fintype {ι : Type*} [Fintype ι] (x : ι → M ⊗[R] N) :
+    ∃ (M' : Submodule R M) (x' : ι → M' ⊗[R] N), Module.Finite R M' ∧
+    ∀ (i : ι), M'.subtype.rTensor N (x' i) = x i := by
+  choose S hS using fun i ↦ (x i).exists_multiset
+  let T := ((Finset.sum Finset.univ S).map Prod.fst).toFinset
+  let M' := span R (T : Set M)
+  let f (i : M × N) : M' ⊗[R] N := if h : i.1 ∈ T then ⟨i.1, subset_span h⟩ ⊗ₜ[R] i.2 else 0
+  let x' (i : ι) := ((S i).map f).sum
+  refine ⟨M', x', inferInstance, fun j ↦ ?_⟩
+  simp_rw [x', hS, map_multiset_sum, Multiset.map_map]
+  congr 1
+  refine Multiset.map_congr rfl fun i hi ↦ ?_
+  replace hi : i.1 ∈ T := by
+    simp only [Multiset.mem_toFinset, Multiset.mem_map, Prod.exists, exists_and_right,
+      exists_eq_right, T]
+    exact ⟨i.2, Multiset.mem_of_le (Finset.single_le_sum (by simp) (by simp)) hi⟩
+  simp_rw [Function.comp_apply, f, dif_pos hi]; rfl
+
+/-- If `x : ι → M ⊗[R] N` are finitely many elements, then there exists a finitely generated
+submodule `N'` of `N` and `x' : ι → M ⊗[R] N'`, whose image in `M ⊗[R] N` is equal to `x`.
+There are 8 variants of this function. -/
+theorem exists_finite_submodule_right_of_fintype {ι : Type*} [Fintype ι] (x : ι → M ⊗[R] N) :
+    ∃ (N' : Submodule R N) (x' : ι → M ⊗[R] N'), Module.Finite R N' ∧
+    ∀ (i : ι), N'.subtype.lTensor M (x' i) = x i := by
+  obtain ⟨N', x', hfin, hx⟩ := exists_finite_submodule_left_of_fintype fun i ↦
+    TensorProduct.comm R M N (x i)
+  have key : N'.subtype.lTensor M ∘ₗ TensorProduct.comm R N' M =
+      (TensorProduct.comm R M N).symm ∘ₗ N'.subtype.rTensor M := ext' fun _ _ ↦ rfl
+  refine ⟨N', fun i ↦ TensorProduct.comm R N' M (x' i), hfin, fun i ↦ ?_⟩
+  replace hx := congr((TensorProduct.comm R M N).symm $(hx i))
+  rw [LinearEquiv.symm_apply_apply] at hx
+  simpa only [← hx] using congr($key (x' i))
+
+/-- If `x : ι → M ⊗[R] N` are finitely many elements, then there are finitely generated
+submodules `M'` and `N'` of `M` and `N`, respectively, and `x' : ι → M' ⊗[R] N'`,
+whose image in `M ⊗[R] N` is equal to `x`. There are 8 variants of this function. -/
+theorem exists_finite_submodule_of_fintype {ι : Type*} [Fintype ι] (x : ι → M ⊗[R] N) :
+    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' : ι → M' ⊗[R] N'),
+    Module.Finite R M' ∧ Module.Finite R N' ∧
+    ∀ (i : ι), TensorProduct.map M'.subtype N'.subtype (x' i) = x i := by
+  obtain ⟨M', x', h1, hx⟩ := exists_finite_submodule_left_of_fintype x
+  obtain ⟨N', x'', h2, hx'⟩ := exists_finite_submodule_right_of_fintype x'
+  refine ⟨M', N', x'', h1, h2, fun i ↦ ?_⟩
+  rw [← hx, ← hx', ← LinearMap.rTensor_comp_lTensor]; rfl
+
+theorem exists_finite_submodule_left_of_fintype' {ι : Type*} [Fintype ι] (x : ι → M₁ ⊗[R] N₁) :
+    ∃ (M' : Submodule R M) (x' : ι → M' ⊗[R] N₁) (hM : M' ≤ M₁), Module.Finite R M' ∧
+    ∀ (i : ι), (inclusion hM).rTensor N₁ (x' i) = x i := by
+  obtain ⟨M', x', hfin, hx⟩ := exists_finite_submodule_left_of_fintype x
+  refine ⟨_, (M₁.subtype.submoduleMap M').rTensor N₁ ∘ x', map_subtype_le _ _, .map _ _, fun i ↦ ?_⟩
+  have key : M'.subtype.rTensor N₁ =
+      (inclusion (map_subtype_le _ _)).rTensor N₁ ∘ₗ (M₁.subtype.submoduleMap M').rTensor N₁ :=
+    ext' fun _ _ ↦ rfl
+  rw [← hx, key]; rfl
+
+theorem exists_finite_submodule_right_of_fintype' {ι : Type*} [Fintype ι] (x : ι → M₁ ⊗[R] N₁) :
+    ∃ (N' : Submodule R N) (x' : ι → M₁ ⊗[R] N') (hN : N' ≤ N₁), Module.Finite R N' ∧
+    ∀ (i : ι), (inclusion hN).lTensor M₁ (x' i) = x i := by
+  obtain ⟨N', x', hfin, hx⟩ := exists_finite_submodule_right_of_fintype x
+  refine ⟨_, (N₁.subtype.submoduleMap N').lTensor M₁ ∘ x', map_subtype_le _ _, .map _ _, fun i ↦ ?_⟩
+  have key : N'.subtype.lTensor M₁ =
+      (inclusion (map_subtype_le _ _)).lTensor M₁ ∘ₗ (N₁.subtype.submoduleMap N').lTensor M₁ :=
+    ext' fun _ _ ↦ rfl
+  rw [← hx, key]; rfl
+
+theorem exists_finite_submodule_of_fintype' {ι : Type*} [Fintype ι] (x : ι → M₁ ⊗[R] N₁) :
+    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' : ι → M' ⊗[R] N') (hM : M' ≤ M₁) (hN : N' ≤ N₁),
+    Module.Finite R M' ∧ Module.Finite R N' ∧
+    ∀ (i : ι), TensorProduct.map (inclusion hM) (inclusion hN) (x' i) = x i := by
+  obtain ⟨M', x', hM, h1, hx⟩ := exists_finite_submodule_left_of_fintype' x
+  obtain ⟨N', x'', hN, h2, hx'⟩ := exists_finite_submodule_right_of_fintype' x'
+  refine ⟨M', N', x'', hM, hN, h1, h2, fun i ↦ ?_⟩
+  rw [← hx, ← hx', ← LinearMap.rTensor_comp_lTensor]; rfl
+
+theorem exists_finite_submodule_left_of_finsupp {ι : Type*} (x : ι →₀ M ⊗[R] N) :
+    ∃ (M' : Submodule R M) (x' : ι →₀ M' ⊗[R] N), Module.Finite R M' ∧
+    ∀ (i : ι), M'.subtype.rTensor N (x' i) = x i := by
+  obtain ⟨M', x', hfin, hx⟩ := exists_finite_submodule_left_of_fintype fun i : x.support ↦ x i
+  refine ⟨M', (Finsupp.equivFunOnFinite.symm x').extendDomain, hfin, fun i ↦ ?_⟩
+  by_cases h : i ∈ x.support
+  · simp [h, hx]
+  simp [h, Finsupp.not_mem_support_iff.1 h]
+
+theorem exists_finite_submodule_right_of_finsupp {ι : Type*} (x : ι →₀ M ⊗[R] N) :
+    ∃ (N' : Submodule R N) (x' : ι →₀ M ⊗[R] N'), Module.Finite R N' ∧
+    ∀ (i : ι), N'.subtype.lTensor M (x' i) = x i := by
+  obtain ⟨N', x', hfin, hx⟩ := exists_finite_submodule_right_of_fintype fun i : x.support ↦ x i
+  refine ⟨N', (Finsupp.equivFunOnFinite.symm x').extendDomain, hfin, fun i ↦ ?_⟩
+  by_cases h : i ∈ x.support
+  · simp [h, hx]
+  simp [h, Finsupp.not_mem_support_iff.1 h]
+
+theorem exists_finite_submodule_of_finsupp {ι : Type*} (x : ι →₀ M ⊗[R] N) :
+    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' : ι →₀ M' ⊗[R] N'),
+    Module.Finite R M' ∧ Module.Finite R N' ∧
+    ∀ (i : ι), TensorProduct.map M'.subtype N'.subtype (x' i) = x i := by
+  obtain ⟨M', x', h1, hx⟩ := exists_finite_submodule_left_of_finsupp x
+  obtain ⟨N', x'', h2, hx'⟩ := exists_finite_submodule_right_of_finsupp x'
+  refine ⟨M', N', x'', h1, h2, fun i ↦ ?_⟩
+  rw [← hx, ← hx', ← LinearMap.rTensor_comp_lTensor]; rfl
+
+theorem exists_finite_submodule_left_of_finsupp' {ι : Type*} (x : ι →₀ M₁ ⊗[R] N₁) :
+    ∃ (M' : Submodule R M) (x' : ι →₀ M' ⊗[R] N₁) (hM : M' ≤ M₁), Module.Finite R M' ∧
+    ∀ (i : ι), (inclusion hM).rTensor N₁ (x' i) = x i := by
+  obtain ⟨M', x', hM, hfin, hx⟩ := exists_finite_submodule_left_of_fintype' fun i : x.support ↦ x i
+  refine ⟨M', (Finsupp.equivFunOnFinite.symm x').extendDomain, hM, hfin, fun i ↦ ?_⟩
+  by_cases h : i ∈ x.support
+  · simp [h, hx]
+  simp [h, Finsupp.not_mem_support_iff.1 h]
+
+theorem exists_finite_submodule_right_of_finsupp' {ι : Type*} (x : ι →₀ M₁ ⊗[R] N₁) :
+    ∃ (N' : Submodule R N) (x' : ι →₀ M₁ ⊗[R] N') (hN : N' ≤ N₁), Module.Finite R N' ∧
+    ∀ (i : ι), (inclusion hN).lTensor M₁ (x' i) = x i := by
+  obtain ⟨N', x', hN, hfin, hx⟩ := exists_finite_submodule_right_of_fintype' fun i : x.support ↦ x i
+  refine ⟨N', (Finsupp.equivFunOnFinite.symm x').extendDomain, hN, hfin, fun i ↦ ?_⟩
+  by_cases h : i ∈ x.support
+  · simp [h, hx]
+  simp [h, Finsupp.not_mem_support_iff.1 h]
+
+theorem exists_finite_submodule_of_finsupp' {ι : Type*} (x : ι →₀ M₁ ⊗[R] N₁) :
+    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' : ι →₀ M' ⊗[R] N')
+    (hM : M' ≤ M₁) (hN : N' ≤ N₁), Module.Finite R M' ∧ Module.Finite R N' ∧
+    ∀ (i : ι), TensorProduct.map (inclusion hM) (inclusion hN) (x' i) = x i := by
+  obtain ⟨M', x', hM, h1, hx⟩ := exists_finite_submodule_left_of_finsupp' x
+  obtain ⟨N', x'', hN, h2, hx'⟩ := exists_finite_submodule_right_of_finsupp' x'
+  refine ⟨M', N', x'', hM, hN, h1, h2, fun i ↦ ?_⟩
+  rw [← hx, ← hx', ← LinearMap.rTensor_comp_lTensor]; rfl
+
+theorem exists_finite_submodule_left_of_pair (x y : M ⊗[R] N) :
+    ∃ (M' : Submodule R M) (x' y' : M' ⊗[R] N), Module.Finite R M' ∧
+    M'.subtype.rTensor N x' = x ∧ M'.subtype.rTensor N y' = y := by
+  obtain ⟨M', x', hfin, hx⟩ := exists_finite_submodule_left_of_fintype ![x, y]
+  exact ⟨M', x' 0, x' 1, hfin, hx 0, hx 1⟩
+
+theorem exists_finite_submodule_right_of_pair (x y : M ⊗[R] N) :
+    ∃ (N' : Submodule R N) (x' y' : M ⊗[R] N'), Module.Finite R N' ∧
+    N'.subtype.lTensor M x' = x ∧ N'.subtype.lTensor M y' = y := by
+  obtain ⟨N', x', hfin, hx⟩ := exists_finite_submodule_right_of_fintype ![x, y]
+  exact ⟨N', x' 0, x' 1, hfin, hx 0, hx 1⟩
+
+theorem exists_finite_submodule_of_pair (x y : M ⊗[R] N) :
+    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' y' : M' ⊗[R] N'),
+    Module.Finite R M' ∧ Module.Finite R N' ∧
+    TensorProduct.map M'.subtype N'.subtype x' = x ∧
+    TensorProduct.map M'.subtype N'.subtype y' = y := by
+  obtain ⟨M', N', x', h1, h2, hx⟩ := exists_finite_submodule_of_fintype ![x, y]
+  exact ⟨M', N', x' 0, x' 1, h1, h2, hx 0, hx 1⟩
+
+theorem exists_finite_submodule_left_of_pair' (x y : M₁ ⊗[R] N₁) :
+    ∃ (M' : Submodule R M) (x' y' : M' ⊗[R] N₁) (hM : M' ≤ M₁), Module.Finite R M' ∧
+    (inclusion hM).rTensor N₁ x' = x ∧ (inclusion hM).rTensor N₁ y' = y := by
+  obtain ⟨M', x', hM, hfin, hx⟩ := exists_finite_submodule_left_of_fintype' ![x, y]
+  exact ⟨M', x' 0, x' 1, hM, hfin, hx 0, hx 1⟩
+
+theorem exists_finite_submodule_right_of_pair' (x y : M₁ ⊗[R] N₁) :
+    ∃ (N' : Submodule R N) (x' y' : M₁ ⊗[R] N') (hN : N' ≤ N₁), Module.Finite R N' ∧
+    (inclusion hN).lTensor M₁ x' = x ∧ (inclusion hN).lTensor M₁ y' = y := by
+  obtain ⟨N', x', hN, hfin, hx⟩ := exists_finite_submodule_right_of_fintype' ![x, y]
+  exact ⟨N', x' 0, x' 1, hN, hfin, hx 0, hx 1⟩
+
+theorem exists_finite_submodule_of_pair' (x y : M₁ ⊗[R] N₁) :
+    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' y' : M' ⊗[R] N') (hM : M' ≤ M₁) (hN : N' ≤ N₁),
+    Module.Finite R M' ∧ Module.Finite R N' ∧
+    TensorProduct.map (inclusion hM) (inclusion hN) x' = x ∧
+    TensorProduct.map (inclusion hM) (inclusion hN) y' = y := by
+  obtain ⟨M', N', x', hM, hN, h1, h2, hx⟩ := exists_finite_submodule_of_fintype' ![x, y]
+  exact ⟨M', N', x' 0, x' 1, hM, hN, h1, h2, hx 0, hx 1⟩
+
+theorem exists_finite_submodule_left (x : M ⊗[R] N) :
+    ∃ (M' : Submodule R M) (x' : M' ⊗[R] N), Module.Finite R M' ∧
+    M'.subtype.rTensor N x' = x := by
+  obtain ⟨M', x', hfin, hx⟩ := exists_finite_submodule_left_of_fintype ![x]
+  exact ⟨M', x' 0, hfin, hx 0⟩
+
+theorem exists_finite_submodule_right (x : M ⊗[R] N) :
+    ∃ (N' : Submodule R N) (x' : M ⊗[R] N'), Module.Finite R N' ∧
+    N'.subtype.lTensor M x' = x := by
+  obtain ⟨N', x', hfin, hx⟩ := exists_finite_submodule_right_of_fintype ![x]
+  exact ⟨N', x' 0, hfin, hx 0⟩
+
+theorem exists_finite_submodule (x : M ⊗[R] N) :
+    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' : M' ⊗[R] N'),
+    Module.Finite R M' ∧ Module.Finite R N' ∧
+    TensorProduct.map M'.subtype N'.subtype x' = x := by
+  obtain ⟨M', N', x', h1, h2, hx⟩ := exists_finite_submodule_of_fintype ![x]
+  exact ⟨M', N', x' 0, h1, h2, hx 0⟩
+
+theorem exists_finite_submodule_left' (x : M₁ ⊗[R] N₁) :
+    ∃ (M' : Submodule R M) (x' : M' ⊗[R] N₁) (hM : M' ≤ M₁), Module.Finite R M' ∧
+    (inclusion hM).rTensor N₁ x' = x := by
+  obtain ⟨M', x', hM, hfin, hx⟩ := exists_finite_submodule_left_of_fintype' ![x]
+  exact ⟨M', x' 0, hM, hfin, hx 0⟩
+
+theorem exists_finite_submodule_right' (x : M₁ ⊗[R] N₁) :
+    ∃ (N' : Submodule R N) (x' : M₁ ⊗[R] N') (hN : N' ≤ N₁), Module.Finite R N' ∧
+    (inclusion hN).lTensor M₁ x' = x := by
+  obtain ⟨N', x', hN, hfin, hx⟩ := exists_finite_submodule_right_of_fintype' ![x]
+  exact ⟨N', x' 0, hN, hfin, hx 0⟩
+
+theorem exists_finite_submodule' (x : M₁ ⊗[R] N₁) :
+    ∃ (M' : Submodule R M) (N' : Submodule R N) (x' : M' ⊗[R] N') (hM : M' ≤ M₁) (hN : N' ≤ N₁),
+    Module.Finite R M' ∧ Module.Finite R N' ∧
+    TensorProduct.map (inclusion hM) (inclusion hN) x' = x := by
+  obtain ⟨M', N', x', hM, hN, h1, h2, hx⟩ := exists_finite_submodule_of_fintype' ![x]
+  exact ⟨M', N', x' 0, hM, hN, h1, h2, hx 0⟩
+
+end TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -92,11 +92,6 @@ theorem exists_finset (x : M ⊗[R] N) :
   rw [h, Finsupp.sum]
   refine' Finset.sum_nbij' (fun m ↦ ⟨m, S m⟩) Prod.fst .. <;> simp
 
-lemma range_mapIncl_mono (hM : M₁ ≤ M₂) (hN : N₁ ≤ N₂) :
-    LinearMap.range (mapIncl M₁ N₁) ≤ LinearMap.range (mapIncl M₂ N₂) := by
-  simp_rw [mapIncl, ← subtype_comp_inclusion _ _ hM, ← subtype_comp_inclusion _ _ hN, map_comp]
-  exact LinearMap.range_comp_le_range _ _
-
 /-- For a finite subset `s` of `M ⊗[R] N`, there are finitely generated
 submodules `M'` and `N'` of `M` and `N`, respectively, such that `s` is contained in the image
 of `M' ⊗[R] N'` in `M ⊗[R] N`. -/

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jz Pan
 -/
 import Mathlib.LinearAlgebra.TensorProduct.Basic
-import Mathlib.LinearAlgebra.Dimension.Finite
+import Mathlib.RingTheory.Finiteness
 
 /-!
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -30,11 +30,9 @@ tensor product, finitely generated
 
 -/
 
-open scoped Classical TensorProduct
+open scoped TensorProduct
 
 open Submodule
-
-noncomputable section
 
 variable {R M N : Type*}
 
@@ -95,6 +93,7 @@ There are 8 variants of this function. -/
 theorem exists_finite_submodule_left_of_fintype {ι : Type*} [Fintype ι] (x : ι → M ⊗[R] N) :
     ∃ (M' : Submodule R M) (x' : ι → M' ⊗[R] N), Module.Finite R M' ∧
     ∀ (i : ι), M'.subtype.rTensor N (x' i) = x i := by
+  classical
   choose S hS using fun i ↦ (x i).exists_multiset
   let T := ((Finset.sum Finset.univ S).map Prod.fst).toFinset
   let M' := span R (T : Set M)
@@ -169,6 +168,7 @@ theorem exists_finite_submodule_of_fintype' {ι : Type*} [Fintype ι] (x : ι �
 theorem exists_finite_submodule_left_of_finsupp {ι : Type*} (x : ι →₀ M ⊗[R] N) :
     ∃ (M' : Submodule R M) (x' : ι →₀ M' ⊗[R] N), Module.Finite R M' ∧
     ∀ (i : ι), M'.subtype.rTensor N (x' i) = x i := by
+  classical
   obtain ⟨M', x', hfin, hx⟩ := exists_finite_submodule_left_of_fintype fun i : x.support ↦ x i
   refine ⟨M', (Finsupp.equivFunOnFinite.symm x').extendDomain, hfin, fun i ↦ ?_⟩
   by_cases h : i ∈ x.support
@@ -178,6 +178,7 @@ theorem exists_finite_submodule_left_of_finsupp {ι : Type*} (x : ι →₀ M �
 theorem exists_finite_submodule_right_of_finsupp {ι : Type*} (x : ι →₀ M ⊗[R] N) :
     ∃ (N' : Submodule R N) (x' : ι →₀ M ⊗[R] N'), Module.Finite R N' ∧
     ∀ (i : ι), N'.subtype.lTensor M (x' i) = x i := by
+  classical
   obtain ⟨N', x', hfin, hx⟩ := exists_finite_submodule_right_of_fintype fun i : x.support ↦ x i
   refine ⟨N', (Finsupp.equivFunOnFinite.symm x').extendDomain, hfin, fun i ↦ ?_⟩
   by_cases h : i ∈ x.support
@@ -196,6 +197,7 @@ theorem exists_finite_submodule_of_finsupp {ι : Type*} (x : ι →₀ M ⊗[R] 
 theorem exists_finite_submodule_left_of_finsupp' {ι : Type*} (x : ι →₀ M₁ ⊗[R] N₁) :
     ∃ (M' : Submodule R M) (x' : ι →₀ M' ⊗[R] N₁) (hM : M' ≤ M₁), Module.Finite R M' ∧
     ∀ (i : ι), (inclusion hM).rTensor N₁ (x' i) = x i := by
+  classical
   obtain ⟨M', x', hM, hfin, hx⟩ := exists_finite_submodule_left_of_fintype' fun i : x.support ↦ x i
   refine ⟨M', (Finsupp.equivFunOnFinite.symm x').extendDomain, hM, hfin, fun i ↦ ?_⟩
   by_cases h : i ∈ x.support
@@ -205,6 +207,7 @@ theorem exists_finite_submodule_left_of_finsupp' {ι : Type*} (x : ι →₀ M�
 theorem exists_finite_submodule_right_of_finsupp' {ι : Type*} (x : ι →₀ M₁ ⊗[R] N₁) :
     ∃ (N' : Submodule R N) (x' : ι →₀ M₁ ⊗[R] N') (hN : N' ≤ N₁), Module.Finite R N' ∧
     ∀ (i : ι), (inclusion hN).lTensor M₁ (x' i) = x i := by
+  classical
   obtain ⟨N', x', hN, hfin, hx⟩ := exists_finite_submodule_right_of_fintype' fun i : x.support ↦ x i
   refine ⟨N', (Finsupp.equivFunOnFinite.symm x').extendDomain, hN, hfin, fun i ↦ ?_⟩
   by_cases h : i ∈ x.support


### PR DESCRIPTION
- `TensorProduct.exists_multiset`, `TensorProduct.exists_finsupp_left`,
  `TensorProduct.exists_finsupp_right`, `TensorProduct.exists_finset`:
  any element of `M ⊗[R] N` can be written as a finite sum of pure tensors.
  See also `TensorProduct.span_tmul_eq_top`.

- `TensorProduct.exists_finite_submodule_left_of_finite`,
  `TensorProduct.exists_finite_submodule_right_of_finite`,
  `TensorProduct.exists_finite_submodule_of_finite` and 3 more:
  any finite subset of `M ⊗[R] N` is contained in `M' ⊗[R] N'`
  for some finitely generated submodules `M'` and `N'` of `M` and `N`, respectively.
  Each of these 3 functions has 2 variants.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
