### PR TITLE
[Merged by Bors] - feat: add `of_eq` versions for lemmas on composition of derivatives

### DIFF
--- a/Mathlib/Analysis/Calculus/Deriv/Comp.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Comp.lean
@@ -229,12 +229,22 @@ theorem HasDerivAtFilter.comp (hh₂ : HasDerivAtFilter h₂ h₂' (h x) L')
   exact hh₂.scomp x hh hL
 #align has_deriv_at_filter.comp HasDerivAtFilter.comp
 
+theorem HasDerivAtFilter.comp_of_eq (hh₂ : HasDerivAtFilter h₂ h₂' y L')
+    (hh : HasDerivAtFilter h h' x L) (hL : Tendsto h L L') (hy : y = h x) :
+    HasDerivAtFilter (h₂ ∘ h) (h₂' * h') x L := by
+  rw [hy] at hh₂; exact hh₂.comp x hh hL
+
 theorem HasDerivWithinAt.comp (hh₂ : HasDerivWithinAt h₂ h₂' s' (h x))
     (hh : HasDerivWithinAt h h' s x) (hst : MapsTo h s s') :
     HasDerivWithinAt (h₂ ∘ h) (h₂' * h') s x := by
   rw [mul_comm]
   exact hh₂.scomp x hh hst
 #align has_deriv_within_at.comp HasDerivWithinAt.comp
+
+theorem HasDerivWithinAt.comp_of_eq (hh₂ : HasDerivWithinAt h₂ h₂' s' y)
+    (hh : HasDerivWithinAt h h' s x) (hst : MapsTo h s s') (hy : y = h x) :
+    HasDerivWithinAt (h₂ ∘ h) (h₂' * h') s x := by
+  rw [hy] at hh₂; exact hh₂.comp x hh hst
 
 /-- The chain rule.
 
@@ -254,11 +264,6 @@ theorem HasDerivAt.comp_of_eq
     HasDerivAt (h₂ ∘ h) (h₂' * h') x := by
   rw [hy] at hh₂; exact hh₂.comp x hh
 
-theorem HasDerivAtFilter.comp_of_eq (hh₂ : HasDerivAtFilter h₂ h₂' y L')
-    (hh : HasDerivAtFilter h h' x L) (hL : Tendsto h L L') (hy : y = h x) :
-    HasDerivAtFilter (h₂ ∘ h) (h₂' * h') x L := by
-  rw [hy] at hh₂; exact hh₂.comp x hh hL
-
 theorem HasStrictDerivAt.comp (hh₂ : HasStrictDerivAt h₂ h₂' (h x)) (hh : HasStrictDerivAt h h' x) :
     HasStrictDerivAt (h₂ ∘ h) (h₂' * h') x := by
   rw [mul_comm]
@@ -269,11 +274,6 @@ theorem HasStrictDerivAt.comp_of_eq
     (hh₂ : HasStrictDerivAt h₂ h₂' y) (hh : HasStrictDerivAt h h' x) (hy : y = h x) :
     HasStrictDerivAt (h₂ ∘ h) (h₂' * h') x := by
   rw [hy] at hh₂; exact hh₂.comp x hh
-
-theorem HasDerivWithinAt.comp_of_eq (hh₂ : HasDerivWithinAt h₂ h₂' s' y)
-    (hh : HasDerivWithinAt h h' s x) (hst : MapsTo h s s') (hy : y = h x) :
-    HasDerivWithinAt (h₂ ∘ h) (h₂' * h') s x := by
-  rw [hy] at hh₂; exact hh₂.comp x hh hst
 
 theorem HasDerivAt.comp_hasDerivWithinAt (hh₂ : HasDerivAt h₂ h₂' (h x))
     (hh : HasDerivWithinAt h h' s x) : HasDerivWithinAt (h₂ ∘ h) (h₂' * h') s x :=

--- a/Mathlib/Analysis/Calculus/Deriv/Comp.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Comp.lean
@@ -239,7 +239,7 @@ theorem HasDerivWithinAt.comp (hh₂ : HasDerivWithinAt h₂ h₂' s' (h x))
 /-- The chain rule.
 
 Note that the function `h₂` is a function on an algebra. If you are looking for the chain rule
-with `h₂` taking values in a vector space, use `HAsDerivAt.scomp`. -/
+with `h₂` taking values in a vector space, use `HasDerivAt.scomp`. -/
 nonrec theorem HasDerivAt.comp (hh₂ : HasDerivAt h₂ h₂' (h x)) (hh : HasDerivAt h h' x) :
     HasDerivAt (h₂ ∘ h) (h₂' * h') x :=
   hh₂.comp x hh hh.continuousAt
@@ -248,7 +248,7 @@ nonrec theorem HasDerivAt.comp (hh₂ : HasDerivAt h₂ h₂' (h x)) (hh : HasDe
 /-- The chain rule.
 
 Note that the function `h₂` is a function on an algebra. If you are looking for the chain rule
-with `h₂` taking values in a vector space, use `HAsDerivAt.scomp_of_eq`. -/
+with `h₂` taking values in a vector space, use `HasDerivAt.scomp_of_eq`. -/
 theorem HasDerivAt.comp_of_eq
     (hh₂ : HasDerivAt h₂ h₂' y) (hh : HasDerivAt h h' x) (hy : y = h x) :
     HasDerivAt (h₂ ∘ h) (h₂' * h') x := by

--- a/Mathlib/Analysis/Calculus/Deriv/Comp.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Comp.lean
@@ -21,6 +21,10 @@ In this file we prove the chain rule for the following cases:
 Here `𝕜` is the base normed field, `E` and `F` are normed spaces over `𝕜` and `𝕜'` is an algebra
 over `𝕜` (e.g., `𝕜'=𝕜` or `𝕜=ℝ`, `𝕜'=ℂ`).
 
+We also give versions with the `of_eq` suffix, which require an equality proof instead
+of definitional equality of the different points used in the composition. These versions are
+often more flexible to use.
+
 For a more detailed overview of one-dimensional derivatives in mathlib, see the module docstring of
 `analysis/calculus/deriv/basic`.
 
@@ -65,7 +69,7 @@ usual multiplication in `comp` lemmas.
 get confused since there are too many possibilities for composition -/
 variable {𝕜' : Type*} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] [NormedSpace 𝕜' F]
   [IsScalarTower 𝕜 𝕜' F] {s' t' : Set 𝕜'} {h : 𝕜 → 𝕜'} {h₁ : 𝕜 → 𝕜} {h₂ : 𝕜' → 𝕜'} {h' h₂' : 𝕜'}
-  {h₁' : 𝕜} {g₁ : 𝕜' → F} {g₁' : F} {L' : Filter 𝕜'} (x)
+  {h₁' : 𝕜} {g₁ : 𝕜' → F} {g₁' : F} {L' : Filter 𝕜'} {y : 𝕜'} (x)
 
 theorem HasDerivAtFilter.scomp (hg : HasDerivAtFilter g₁ g₁' (h x) L')
     (hh : HasDerivAtFilter h h' x L) (hL : Tendsto h L L') :
@@ -73,10 +77,20 @@ theorem HasDerivAtFilter.scomp (hg : HasDerivAtFilter g₁ g₁' (h x) L')
   simpa using ((hg.restrictScalars 𝕜).comp x hh hL).hasDerivAtFilter
 #align has_deriv_at_filter.scomp HasDerivAtFilter.scomp
 
+theorem HasDerivAtFilter.scomp_of_eq (hg : HasDerivAtFilter g₁ g₁' y L')
+    (hh : HasDerivAtFilter h h' x L) (hy : y = h x) (hL : Tendsto h L L') :
+    HasDerivAtFilter (g₁ ∘ h) (h' • g₁') x L := by
+  rw [hy] at hg; exact hg.scomp x hh hL
+
 theorem HasDerivWithinAt.scomp_hasDerivAt (hg : HasDerivWithinAt g₁ g₁' s' (h x))
     (hh : HasDerivAt h h' x) (hs : ∀ x, h x ∈ s') : HasDerivAt (g₁ ∘ h) (h' • g₁') x :=
   hg.scomp x hh <| tendsto_inf.2 ⟨hh.continuousAt, tendsto_principal.2 <| eventually_of_forall hs⟩
 #align has_deriv_within_at.scomp_has_deriv_at HasDerivWithinAt.scomp_hasDerivAt
+
+theorem HasDerivWithinAt.scomp_hasDerivAt_of_eq (hg : HasDerivWithinAt g₁ g₁' s' y)
+    (hh : HasDerivAt h h' x) (hs : ∀ x, h x ∈ s') (hy : y = h x) :
+    HasDerivAt (g₁ ∘ h) (h' • g₁') x := by
+  rw [hy] at hg; exact hg.scomp_hasDerivAt x hh hs
 
 nonrec theorem HasDerivWithinAt.scomp (hg : HasDerivWithinAt g₁ g₁' t' (h x))
     (hh : HasDerivWithinAt h h' s x) (hst : MapsTo h s t') :
@@ -84,21 +98,42 @@ nonrec theorem HasDerivWithinAt.scomp (hg : HasDerivWithinAt g₁ g₁' t' (h x)
   hg.scomp x hh <| hh.continuousWithinAt.tendsto_nhdsWithin hst
 #align has_deriv_within_at.scomp HasDerivWithinAt.scomp
 
+theorem HasDerivWithinAt.scomp_of_eq (hg : HasDerivWithinAt g₁ g₁' t' y)
+    (hh : HasDerivWithinAt h h' s x) (hst : MapsTo h s t') (hy : y = h x) :
+    HasDerivWithinAt (g₁ ∘ h) (h' • g₁') s x := by
+  rw [hy] at hg; exact hg.scomp x hh hst
+
 /-- The chain rule. -/
 nonrec theorem HasDerivAt.scomp (hg : HasDerivAt g₁ g₁' (h x)) (hh : HasDerivAt h h' x) :
     HasDerivAt (g₁ ∘ h) (h' • g₁') x :=
   hg.scomp x hh hh.continuousAt
 #align has_deriv_at.scomp HasDerivAt.scomp
 
+/-- The chain rule. -/
+theorem HasDerivAt.scomp_of_eq
+    (hg : HasDerivAt g₁ g₁' y) (hh : HasDerivAt h h' x) (hy : y = h x) :
+    HasDerivAt (g₁ ∘ h) (h' • g₁') x := by
+  rw [hy] at hg; exact hg.scomp x hh
+
 theorem HasStrictDerivAt.scomp (hg : HasStrictDerivAt g₁ g₁' (h x)) (hh : HasStrictDerivAt h h' x) :
     HasStrictDerivAt (g₁ ∘ h) (h' • g₁') x := by
   simpa using ((hg.restrictScalars 𝕜).comp x hh).hasStrictDerivAt
 #align has_strict_deriv_at.scomp HasStrictDerivAt.scomp
 
+theorem HasStrictDerivAt.scomp_of_eq
+    (hg : HasStrictDerivAt g₁ g₁' y) (hh : HasStrictDerivAt h h' x) (hy : y = h x) :
+    HasStrictDerivAt (g₁ ∘ h) (h' • g₁') x := by
+  rw [hy] at hg; exact hg.scomp x hh
+
 theorem HasDerivAt.scomp_hasDerivWithinAt (hg : HasDerivAt g₁ g₁' (h x))
     (hh : HasDerivWithinAt h h' s x) : HasDerivWithinAt (g₁ ∘ h) (h' • g₁') s x :=
   HasDerivWithinAt.scomp x hg.hasDerivWithinAt hh (mapsTo_univ _ _)
 #align has_deriv_at.scomp_has_deriv_within_at HasDerivAt.scomp_hasDerivWithinAt
+
+theorem HasDerivAt.scomp_hasDerivWithinAt_of_eq (hg : HasDerivAt g₁ g₁' y)
+    (hh : HasDerivWithinAt h h' s x) (hy : y = h x) :
+    HasDerivWithinAt (g₁ ∘ h) (h' • g₁') s x := by
+  rw [hy] at hg; exact hg.scomp_hasDerivWithinAt x hh
 
 theorem derivWithin.scomp (hg : DifferentiableWithinAt 𝕜' g₁ t' (h x))
     (hh : DifferentiableWithinAt 𝕜 h s x) (hs : MapsTo h s t') (hxs : UniqueDiffWithinAt 𝕜 s x) :
@@ -106,13 +141,23 @@ theorem derivWithin.scomp (hg : DifferentiableWithinAt 𝕜' g₁ t' (h x))
   (HasDerivWithinAt.scomp x hg.hasDerivWithinAt hh.hasDerivWithinAt hs).derivWithin hxs
 #align deriv_within.scomp derivWithin.scomp
 
+theorem derivWithin.scomp_of_eq (hg : DifferentiableWithinAt 𝕜' g₁ t' y)
+    (hh : DifferentiableWithinAt 𝕜 h s x) (hs : MapsTo h s t') (hxs : UniqueDiffWithinAt 𝕜 s x)
+    (hy : y = h x) :
+    derivWithin (g₁ ∘ h) s x = derivWithin h s x • derivWithin g₁ t' (h x) := by
+  rw [hy] at hg; exact derivWithin.scomp x hg hh hs hxs
+
 theorem deriv.scomp (hg : DifferentiableAt 𝕜' g₁ (h x)) (hh : DifferentiableAt 𝕜 h x) :
     deriv (g₁ ∘ h) x = deriv h x • deriv g₁ (h x) :=
   (HasDerivAt.scomp x hg.hasDerivAt hh.hasDerivAt).deriv
 #align deriv.scomp deriv.scomp
 
-/-! ### Derivative of the composition of a scalar and vector functions -/
+theorem deriv.scomp_of_eq
+    (hg : DifferentiableAt 𝕜' g₁ y) (hh : DifferentiableAt 𝕜 h x) (hy : y = h x) :
+    deriv (g₁ ∘ h) x = deriv h x • deriv g₁ (h x) := by
+  rw [hy] at hg; exact deriv.scomp x hg hh
 
+/-! ### Derivative of the composition of a scalar and vector functions -/
 
 theorem HasDerivAtFilter.comp_hasFDerivAtFilter {f : E → 𝕜'} {f' : E →L[𝕜] 𝕜'} (x) {L'' : Filter E}
     (hh₂ : HasDerivAtFilter h₂ h₂' (f x) L') (hf : HasFDerivAtFilter f f' x L'')
@@ -121,6 +166,12 @@ theorem HasDerivAtFilter.comp_hasFDerivAtFilter {f : E → 𝕜'} {f' : E →L[�
   ext x
   simp [mul_comm]
 #align has_deriv_at_filter.comp_has_fderiv_at_filter HasDerivAtFilter.comp_hasFDerivAtFilter
+
+theorem HasDerivAtFilter.comp_hasFDerivAtFilter_of_eq
+    {f : E → 𝕜'} {f' : E →L[𝕜] 𝕜'} (x) {L'' : Filter E}
+    (hh₂ : HasDerivAtFilter h₂ h₂' y L') (hf : HasFDerivAtFilter f f' x L'')
+    (hL : Tendsto f L'' L') (hy : y = f x) : HasFDerivAtFilter (h₂ ∘ f) (h₂' • f') x L'' := by
+  rw [hy] at hh₂; exact hh₂.comp_hasFDerivAtFilter x hf hL
 
 theorem HasStrictDerivAt.comp_hasStrictFDerivAt {f : E → 𝕜'} {f' : E →L[𝕜] 𝕜'} (x)
     (hh : HasStrictDerivAt h₂ h₂' (f x)) (hf : HasStrictFDerivAt f f' x) :
@@ -131,10 +182,20 @@ theorem HasStrictDerivAt.comp_hasStrictFDerivAt {f : E → 𝕜'} {f' : E →L[�
   simp [mul_comm]
 #align has_strict_deriv_at.comp_has_strict_fderiv_at HasStrictDerivAt.comp_hasStrictFDerivAt
 
+theorem HasStrictDerivAt.comp_hasStrictFDerivAt_of_eq {f : E → 𝕜'} {f' : E →L[𝕜] 𝕜'} (x)
+    (hh : HasStrictDerivAt h₂ h₂' y) (hf : HasStrictFDerivAt f f' x) (hy : y = f x) :
+    HasStrictFDerivAt (h₂ ∘ f) (h₂' • f') x := by
+  rw [hy] at hh; exact hh.comp_hasStrictFDerivAt x hf
+
 theorem HasDerivAt.comp_hasFDerivAt {f : E → 𝕜'} {f' : E →L[𝕜] 𝕜'} (x)
     (hh : HasDerivAt h₂ h₂' (f x)) (hf : HasFDerivAt f f' x) : HasFDerivAt (h₂ ∘ f) (h₂' • f') x :=
   hh.comp_hasFDerivAtFilter x hf hf.continuousAt
 #align has_deriv_at.comp_has_fderiv_at HasDerivAt.comp_hasFDerivAt
+
+theorem HasDerivAt.comp_hasFDerivAt_of_eq {f : E → 𝕜'} {f' : E →L[𝕜] 𝕜'} (x)
+    (hh : HasDerivAt h₂ h₂' y) (hf : HasFDerivAt f f' x) (hy : y = f x) :
+    HasFDerivAt (h₂ ∘ f) (h₂' • f') x := by
+  rw [hy] at hh; exact hh.comp_hasFDerivAt x hf
 
 theorem HasDerivAt.comp_hasFDerivWithinAt {f : E → 𝕜'} {f' : E →L[𝕜] 𝕜'} {s} (x)
     (hh : HasDerivAt h₂ h₂' (f x)) (hf : HasFDerivWithinAt f f' s x) :
@@ -142,11 +203,22 @@ theorem HasDerivAt.comp_hasFDerivWithinAt {f : E → 𝕜'} {f' : E →L[𝕜] �
   hh.comp_hasFDerivAtFilter x hf hf.continuousWithinAt
 #align has_deriv_at.comp_has_fderiv_within_at HasDerivAt.comp_hasFDerivWithinAt
 
+theorem HasDerivAt.comp_hasFDerivWithinAt_of_eq {f : E → 𝕜'} {f' : E →L[𝕜] 𝕜'} {s} (x)
+    (hh : HasDerivAt h₂ h₂' y) (hf : HasFDerivWithinAt f f' s x) (hy : y = f x) :
+    HasFDerivWithinAt (h₂ ∘ f) (h₂' • f') s x := by
+  rw [hy] at hh; exact hh.comp_hasFDerivWithinAt x hf
+
 theorem HasDerivWithinAt.comp_hasFDerivWithinAt {f : E → 𝕜'} {f' : E →L[𝕜] 𝕜'} {s t} (x)
     (hh : HasDerivWithinAt h₂ h₂' t (f x)) (hf : HasFDerivWithinAt f f' s x) (hst : MapsTo f s t) :
     HasFDerivWithinAt (h₂ ∘ f) (h₂' • f') s x :=
   hh.comp_hasFDerivAtFilter x hf <| hf.continuousWithinAt.tendsto_nhdsWithin hst
 #align has_deriv_within_at.comp_has_fderiv_within_at HasDerivWithinAt.comp_hasFDerivWithinAt
+
+theorem HasDerivWithinAt.comp_hasFDerivWithinAt_of_eq {f : E → 𝕜'} {f' : E →L[𝕜] 𝕜'} {s t} (x)
+    (hh : HasDerivWithinAt h₂ h₂' t y) (hf : HasFDerivWithinAt f f' s x) (hst : MapsTo f s t)
+    (hy : y = f x) :
+    HasFDerivWithinAt (h₂ ∘ f) (h₂' • f') s x := by
+  rw [hy] at hh; exact hh.comp_hasFDerivWithinAt x hf hst
 
 /-! ### Derivative of the composition of two scalar functions -/
 
@@ -164,11 +236,28 @@ theorem HasDerivWithinAt.comp (hh₂ : HasDerivWithinAt h₂ h₂' s' (h x))
   exact hh₂.scomp x hh hst
 #align has_deriv_within_at.comp HasDerivWithinAt.comp
 
-/-- The chain rule. -/
+/-- The chain rule.
+
+Note that the function `h₂` is a function on an algebra. If you are looking for the chain rule
+with `h₂` taking values in a vector space, use `HAsDerivAt.scomp`. -/
 nonrec theorem HasDerivAt.comp (hh₂ : HasDerivAt h₂ h₂' (h x)) (hh : HasDerivAt h h' x) :
     HasDerivAt (h₂ ∘ h) (h₂' * h') x :=
   hh₂.comp x hh hh.continuousAt
 #align has_deriv_at.comp HasDerivAt.comp
+
+/-- The chain rule.
+
+Note that the function `h₂` is a function on an algebra. If you are looking for the chain rule
+with `h₂` taking values in a vector space, use `HAsDerivAt.scomp_of_eq`. -/
+theorem HasDerivAt.comp_of_eq
+    (hh₂ : HasDerivAt h₂ h₂' y) (hh : HasDerivAt h h' x) (hy : y = h x) :
+    HasDerivAt (h₂ ∘ h) (h₂' * h') x := by
+  rw [hy] at hh₂; exact hh₂.comp x hh
+
+theorem HasDerivAtFilter.comp_of_eq (hh₂ : HasDerivAtFilter h₂ h₂' y L')
+    (hh : HasDerivAtFilter h h' x L) (hL : Tendsto h L L') (hy : y = h x) :
+    HasDerivAtFilter (h₂ ∘ h) (h₂' * h') x L := by
+  rw [hy] at hh₂; exact hh₂.comp x hh hL
 
 theorem HasStrictDerivAt.comp (hh₂ : HasStrictDerivAt h₂ h₂' (h x)) (hh : HasStrictDerivAt h h' x) :
     HasStrictDerivAt (h₂ ∘ h) (h₂' * h') x := by
@@ -176,10 +265,25 @@ theorem HasStrictDerivAt.comp (hh₂ : HasStrictDerivAt h₂ h₂' (h x)) (hh : 
   exact hh₂.scomp x hh
 #align has_strict_deriv_at.comp HasStrictDerivAt.comp
 
+theorem HasStrictDerivAt.comp_of_eq
+    (hh₂ : HasStrictDerivAt h₂ h₂' y) (hh : HasStrictDerivAt h h' x) (hy : y = h x) :
+    HasStrictDerivAt (h₂ ∘ h) (h₂' * h') x := by
+  rw [hy] at hh₂; exact hh₂.comp x hh
+
+theorem HasDerivWithinAt.comp_of_eq (hh₂ : HasDerivWithinAt h₂ h₂' s' y)
+    (hh : HasDerivWithinAt h h' s x) (hst : MapsTo h s s') (hy : y = h x) :
+    HasDerivWithinAt (h₂ ∘ h) (h₂' * h') s x := by
+  rw [hy] at hh₂; exact hh₂.comp x hh hst
+
 theorem HasDerivAt.comp_hasDerivWithinAt (hh₂ : HasDerivAt h₂ h₂' (h x))
     (hh : HasDerivWithinAt h h' s x) : HasDerivWithinAt (h₂ ∘ h) (h₂' * h') s x :=
   hh₂.hasDerivWithinAt.comp x hh (mapsTo_univ _ _)
 #align has_deriv_at.comp_has_deriv_within_at HasDerivAt.comp_hasDerivWithinAt
+
+theorem HasDerivAt.comp_hasDerivWithinAt_of_eq (hh₂ : HasDerivAt h₂ h₂' y)
+    (hh : HasDerivWithinAt h h' s x) (hy : y = h x) :
+    HasDerivWithinAt (h₂ ∘ h) (h₂' * h') s x := by
+  rw [hy] at hh₂; exact hh₂.comp_hasDerivWithinAt x hh
 
 theorem derivWithin.comp (hh₂ : DifferentiableWithinAt 𝕜' h₂ s' (h x))
     (hh : DifferentiableWithinAt 𝕜 h s x) (hs : MapsTo h s s') (hxs : UniqueDiffWithinAt 𝕜 s x) :
@@ -187,10 +291,21 @@ theorem derivWithin.comp (hh₂ : DifferentiableWithinAt 𝕜' h₂ s' (h x))
   (hh₂.hasDerivWithinAt.comp x hh.hasDerivWithinAt hs).derivWithin hxs
 #align deriv_within.comp derivWithin.comp
 
+theorem derivWithin.comp_of_eq (hh₂ : DifferentiableWithinAt 𝕜' h₂ s' y)
+    (hh : DifferentiableWithinAt 𝕜 h s x) (hs : MapsTo h s s') (hxs : UniqueDiffWithinAt 𝕜 s x)
+    (hy : y = h x) :
+    derivWithin (h₂ ∘ h) s x = derivWithin h₂ s' (h x) * derivWithin h s x := by
+  rw [hy] at hh₂; exact derivWithin.comp x hh₂ hh hs hxs
+
 theorem deriv.comp (hh₂ : DifferentiableAt 𝕜' h₂ (h x)) (hh : DifferentiableAt 𝕜 h x) :
     deriv (h₂ ∘ h) x = deriv h₂ (h x) * deriv h x :=
   (hh₂.hasDerivAt.comp x hh.hasDerivAt).deriv
 #align deriv.comp deriv.comp
+
+theorem deriv.comp_of_eq (hh₂ : DifferentiableAt 𝕜' h₂ y) (hh : DifferentiableAt 𝕜 h x)
+    (hy : y = h x) :
+    deriv (h₂ ∘ h) x = deriv h₂ (h x) * deriv h x := by
+  rw [hy] at hh₂; exact deriv.comp x hh₂ hh
 
 protected nonrec theorem HasDerivAtFilter.iterate {f : 𝕜 → 𝕜} {f' : 𝕜}
     (hf : HasDerivAtFilter f f' x L) (hL : Tendsto f L L) (hx : f x = x) (n : ℕ) :
@@ -225,7 +340,7 @@ section CompositionVector
 
 open ContinuousLinearMap
 
-variable {l : F → E} {l' : F →L[𝕜] E}
+variable {l : F → E} {l' : F →L[𝕜] E} {y : F}
 variable (x)
 
 /-- The composition `l ∘ f` where `l : F → E` and `f : 𝕜 → F`, has a derivative within a set
@@ -237,10 +352,23 @@ theorem HasFDerivWithinAt.comp_hasDerivWithinAt {t : Set F} (hl : HasFDerivWithi
     (hl.comp x hf.hasFDerivWithinAt hst).hasDerivWithinAt
 #align has_fderiv_within_at.comp_has_deriv_within_at HasFDerivWithinAt.comp_hasDerivWithinAt
 
+/-- The composition `l ∘ f` where `l : F → E` and `f : 𝕜 → F`, has a derivative within a set
+equal to the Fréchet derivative of `l` applied to the derivative of `f`. -/
+theorem HasFDerivWithinAt.comp_hasDerivWithinAt_of_eq {t : Set F}
+    (hl : HasFDerivWithinAt l l' t y)
+    (hf : HasDerivWithinAt f f' s x) (hst : MapsTo f s t) (hy : y = f x) :
+    HasDerivWithinAt (l ∘ f) (l' f') s x := by
+  rw [hy] at hl; exact hl.comp_hasDerivWithinAt x hf hst
+
 theorem HasFDerivAt.comp_hasDerivWithinAt (hl : HasFDerivAt l l' (f x))
     (hf : HasDerivWithinAt f f' s x) : HasDerivWithinAt (l ∘ f) (l' f') s x :=
   hl.hasFDerivWithinAt.comp_hasDerivWithinAt x hf (mapsTo_univ _ _)
 #align has_fderiv_at.comp_has_deriv_within_at HasFDerivAt.comp_hasDerivWithinAt
+
+theorem HasFDerivAt.comp_hasDerivWithinAt_of_eq (hl : HasFDerivAt l l' y)
+    (hf : HasDerivWithinAt f f' s x) (hy : y = f x) :
+    HasDerivWithinAt (l ∘ f) (l' f') s x := by
+  rw [hy] at hl; exact hl.comp_hasDerivWithinAt x hf
 
 /-- The composition `l ∘ f` where `l : F → E` and `f : 𝕜 → F`, has a derivative equal to the
 Fréchet derivative of `l` applied to the derivative of `f`. -/
@@ -249,11 +377,23 @@ theorem HasFDerivAt.comp_hasDerivAt (hl : HasFDerivAt l l' (f x)) (hf : HasDeriv
   hasDerivWithinAt_univ.mp <| hl.comp_hasDerivWithinAt x hf.hasDerivWithinAt
 #align has_fderiv_at.comp_has_deriv_at HasFDerivAt.comp_hasDerivAt
 
+/-- The composition `l ∘ f` where `l : F → E` and `f : 𝕜 → F`, has a derivative equal to the
+Fréchet derivative of `l` applied to the derivative of `f`. -/
+theorem HasFDerivAt.comp_hasDerivAt_of_eq
+    (hl : HasFDerivAt l l' y) (hf : HasDerivAt f f' x) (hy : y = f x) :
+    HasDerivAt (l ∘ f) (l' f') x := by
+  rw [hy] at hl; exact hl.comp_hasDerivAt x hf
+
 theorem HasStrictFDerivAt.comp_hasStrictDerivAt (hl : HasStrictFDerivAt l l' (f x))
     (hf : HasStrictDerivAt f f' x) : HasStrictDerivAt (l ∘ f) (l' f') x := by
   simpa only [one_apply, one_smul, smulRight_apply, coe_comp', (· ∘ ·)] using
     (hl.comp x hf.hasStrictFDerivAt).hasStrictDerivAt
 #align has_strict_fderiv_at.comp_has_strict_deriv_at HasStrictFDerivAt.comp_hasStrictDerivAt
+
+theorem HasStrictFDerivAt.comp_hasStrictDerivAt_of_eq (hl : HasStrictFDerivAt l l' y)
+    (hf : HasStrictDerivAt f f' x) (hy : y = f x) :
+    HasStrictDerivAt (l ∘ f) (l' f') x := by
+  rw [hy] at hl; exact hl.comp_hasStrictDerivAt x hf
 
 theorem fderivWithin.comp_derivWithin {t : Set F} (hl : DifferentiableWithinAt 𝕜 l t (f x))
     (hf : DifferentiableWithinAt 𝕜 f s x) (hs : MapsTo f s t) (hxs : UniqueDiffWithinAt 𝕜 s x) :
@@ -261,9 +401,20 @@ theorem fderivWithin.comp_derivWithin {t : Set F} (hl : DifferentiableWithinAt �
   (hl.hasFDerivWithinAt.comp_hasDerivWithinAt x hf.hasDerivWithinAt hs).derivWithin hxs
 #align fderiv_within.comp_deriv_within fderivWithin.comp_derivWithin
 
+theorem fderivWithin.comp_derivWithin_of_eq {t : Set F} (hl : DifferentiableWithinAt 𝕜 l t y)
+    (hf : DifferentiableWithinAt 𝕜 f s x) (hs : MapsTo f s t) (hxs : UniqueDiffWithinAt 𝕜 s x)
+    (hy : y = f x) :
+    derivWithin (l ∘ f) s x = (fderivWithin 𝕜 l t (f x) : F → E) (derivWithin f s x) := by
+  rw [hy] at hl; exact fderivWithin.comp_derivWithin x hl hf hs hxs
+
 theorem fderiv.comp_deriv (hl : DifferentiableAt 𝕜 l (f x)) (hf : DifferentiableAt 𝕜 f x) :
     deriv (l ∘ f) x = (fderiv 𝕜 l (f x) : F → E) (deriv f x) :=
   (hl.hasFDerivAt.comp_hasDerivAt x hf.hasDerivAt).deriv
 #align fderiv.comp_deriv fderiv.comp_deriv
+
+theorem fderiv.comp_deriv_of_eq (hl : DifferentiableAt 𝕜 l y) (hf : DifferentiableAt 𝕜 f x)
+    (hy : y = f x) :
+    deriv (l ∘ f) x = (fderiv 𝕜 l (f x) : F → E) (deriv f x) := by
+  rw [hy] at hl; exact fderiv.comp_deriv x hl hf
 
 end CompositionVector


### PR DESCRIPTION
The versions we have assume that `f` is differentiable at `h x` and `h` is differentiable at `x`, to deduce that `f o h` is differentiable at `x`. In many applications, we have that `f` is differentiable at some point which happens to be equal to `h x`, but not definitionally, so one needs to jump through some hoops to apply the composition lemma. We add `of_eq` versions assuming instead that `f` is differentiable at `y` and that `y = h x`, which is much more flexible in practice.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This could be done throughout the library for many composition-like lemmas. I'm only doing it in the file `Deriv.Comp` in this PR.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
