### PR TITLE
[Merged by Bors] - chore(Tactic/TypeStar): reduce imports

### DIFF
--- a/Mathlib/Data/List/TFAE.lean
+++ b/Mathlib/Data/List/TFAE.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Simon Hudon
 -/
 import Std.Data.List.Lemmas
+import Std.Tactic.Classical
 import Mathlib.Tactic.TypeStar
 import Mathlib.Mathport.Rename
 

--- a/Mathlib/Data/UnionFind.lean
+++ b/Mathlib/Data/UnionFind.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Init.Order.LinearOrder
+import Std.Data.Array.Lemmas
 
 set_option autoImplicit true
 

--- a/Mathlib/Init/Order/Defs.lean
+++ b/Mathlib/Init/Order/Defs.lean
@@ -8,6 +8,7 @@ import Mathlib.Init.Algebra.Classes
 import Mathlib.Init.Data.Ordering.Basic
 import Mathlib.Tactic.SplitIfs
 import Mathlib.Tactic.TypeStar
+import Std.Classes.Order
 
 #align_import init.algebra.order from "leanprover-community/lean"@"c2bcdbcbe741ed37c361a30d38e179182b989f76"
 

--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -6,6 +6,8 @@ Authors: Mario Carneiro, Heather Macbeth
 import Mathlib.Init.Order.Defs
 import Mathlib.Tactic.Core
 import Mathlib.Tactic.GCongr.ForwardAttr
+import Std.Lean.Except
+import Std.Tactic.Exact
 
 /-!
 # The `gcongr` ("generalized congruence") tactic

--- a/Mathlib/Tactic/TypeStar.lean
+++ b/Mathlib/Tactic/TypeStar.lean
@@ -3,10 +3,7 @@ Copyright (c) 2023 Matthew Ballard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Matthew Ballard
 -/
-import Lean
-import Std
-import Mathlib.Tactic.PPWithUniv
-import Mathlib.Tactic.ExtendDoc
+import Lean.Elab.Term
 
 /-!
 # Support for `Sort*` and `Type*`.

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -318,6 +318,7 @@
   "Mathlib.Data.Vector.Basic": ["Mathlib.Control.Applicative"],
   "Mathlib.Data.Rat.Init": ["Std.Data.Rat.Basic"],
   "Mathlib.Data.Multiset.Bind": ["Mathlib.GroupTheory.GroupAction.Defs"],
+  "Mathlib.Data.List.TFAE": ["Std.Tactic.Classical"],
   "Mathlib.Data.List.Lemmas": ["Mathlib.Data.List.InsertNth"],
   "Mathlib.Data.List.EditDistance.Defs": ["Mathlib.Data.Nat.Basic"],
   "Mathlib.Data.List.Basic": ["Mathlib.Data.Option.Basic", "Mathlib.Init.Core"],


### PR DESCRIPTION
I noticed that this doesn't actually use `Std` or in fact any of its other imports.

The downstream fallout is pretty small because `Mathlib.Tactic.Basic` imports `Std` anyway, so this only impacts files not downstream of that.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
