### PR TITLE
[Merged by Bors] - chore: remove the ProofWidgets import

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,20 +2,20 @@ SHELL=/usr/bin/env -S bash -o pipefail
 
 TESTS := $(shell find test -name '*.lean')
 
-.PHONY: all build test lint
+.PHONY: all build test lint testdeps
 
 all: build test
 
 build:
 	lake build
 
-testdeps:
+testdeps: build
 	# add any extra targets that tests depend on here
 	lake build ProofWidgets
 
 test: $(addsuffix .run, $(TESTS))
 
-test/%.run: build testdeps
+test/%.run: testdeps
 	lake env lean test/$* | scripts/check_silent.sh test/$*.log
 
 lint: build

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,11 +9,13 @@ all: build test
 build:
 	lake build
 
-test: $(addsuffix .run, $(TESTS))
+testdeps:
 	# add any extra targets that tests depend on here
 	lake build ProofWidgets
 
-test/%.run: build
+test: $(addsuffix .run, $(TESTS))
+
+test/%.run: build testdeps
 	lake env lean test/$* | scripts/check_silent.sh test/$*.log
 
 lint: build

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,6 +10,8 @@ build:
 	lake build
 
 test: $(addsuffix .run, $(TESTS))
+	# add any extra targets that tests depend on here
+	lake build ProofWidgets
 
 test/%.run: build
 	lake env lean test/$* | scripts/check_silent.sh test/$*.log

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -11,11 +11,6 @@ import Qq
 -- Tools for analysing imports, like `#find_home`, `#minimize_imports`, ...
 import ImportGraph.Imports
 
--- Currently we don't need to import all of ProofWidgets,
--- but without this, if you don't run `lake build ProofWidgets` then `make test` will fail.
--- Hopefully `lake` will be able to handle tests later.
-import ProofWidgets
-
 -- Now import all tactics defined in Mathlib that do not require theory files.
 import Mathlib.Mathport.Rename
 import Mathlib.Tactic.ApplyCongr


### PR DESCRIPTION
This follows on from #11350, following an alternative suggestion by @digama0.

One argument for this pattern is that it also works for tests that import `ProofWidgets.Demos.*`, and any other auxiliary content in upstream packages that is not part of the top-level package.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
