### PR TITLE
[Merged by Bors] - feat(Algebra/BigOperators/Associated): add lemma divisor_closure_eq_closure

### DIFF
--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -105,8 +105,8 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α]
       refine multiset_prod_mem _ _ (Multiset.forall_mem_cons.2 ⟨subset_closure (Set.mem_def.2 ?_),
         Multiset.forall_mem_cons.2 ⟨subset_closure (Set.mem_def.2 ?_), (fun t ht =>
         subset_closure (hs t ht))⟩⟩)
-      left; exact isUnit_of_mul_eq_one_right _ _ hk
-      left; exact ha₁
+      · left; exact isUnit_of_mul_eq_one_right _ _ hk
+      · left; exact ha₁
       rw [← mul_one s.prod, ← hk, ← mul_assoc, ← mul_assoc, mul_eq_mul_right_iff, mul_comm]
       left; exact hprod
     · rcases ha₂.dvd_mul.1 (Dvd.intro _ hprod) with ⟨c, hc⟩ | ⟨c, hc⟩

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -86,6 +86,7 @@ divisor a ∈ H of b lies in S when it is multiplied by a unit. -/
 def Submonoid.divisor_closure [Monoid α] (S : Submonoid α) :=
   {b ∈ S | ∀ (a : α) (_ : ∃ k, b = a*k), ∃ z ∈ S, a ~ᵤ z}
 
+/-- A submonoid is said to be divisor-closed if it is equal to its divisor closure. -/
 def Submonoid.divisor_closed [Monoid α] (S : Submonoid α) : Prop := S = S.divisor_closure
 
 theorem top_divisor_closed [Monoid α] : (⊤ : Submonoid α).divisor_closed := by

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -110,12 +110,12 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α]
       rw [← mul_one s.prod, ← hk, ← mul_assoc, ← mul_assoc, mul_eq_mul_right_iff, mul_comm]
       left; exact hprod
     · rcases ha₂.dvd_mul.1 (Dvd.intro _ hprod) with ⟨c, hc⟩ | ⟨c, hc⟩
-      rw [hc]; rw [hc, mul_assoc] at hprod
-      refine' Submonoid.mul_mem _ (subset_closure (Set.mem_def.2 _))
-        (hind _ _ _ hs (mul_left_cancel₀ ha₂.ne_zero hprod))
-      right; exact ha₂
-      rw [← mul_left_cancel₀ ha₂.ne_zero hprod]
-      exact multiset_prod_mem _ _ (fun t ht => subset_closure (hs t ht))
+      · rw [hc]; rw [hc, mul_assoc] at hprod
+        refine Submonoid.mul_mem _ (subset_closure (Set.mem_def.2 ?_))
+          (hind _ _ ?_ hs (mul_left_cancel₀ ha₂.ne_zero hprod))
+        · right; exact ha₂
+        rw [← mul_left_cancel₀ ha₂.ne_zero hprod]
+        exact multiset_prod_mem _ _ (fun t ht => subset_closure (hs t ht))
       rw [hc, mul_comm x _, mul_assoc, mul_comm c _] at hprod
       refine hind x c ?_ hs (mul_left_cancel₀ ha₂.ne_zero hprod)
       rw [← mul_left_cancel₀ ha₂.ne_zero hprod]

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -84,10 +84,9 @@ theorem exists_associated_mem_of_dvd_prod [CancelCommMonoidWithZero α] {p : α}
 open Submonoid in
 /-- Let x, y ∈ α. If x * y can be written as a product of units and prime elements, then x can be
 written as a product of units and prime elements. -/
-theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α] :
-    ∀ x y, x * y ∈ closure { r : α | IsUnit r ∨ Prime r} →
+theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α]
+    (x y : α) (hxy : x * y ∈ closure { r : α | IsUnit r ∨ Prime r}) :
     x ∈ closure { r : α | IsUnit r ∨ Prime r} := by
-  intros a b hab
   obtain ⟨m, hm⟩ := exists_multiset_of_mem_closure hab
   revert a b hm
   refine m.induction (p := fun m ↦ ∀ a b, a * b ∈ closure {r | IsUnit r ∨ Prime r} →

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -104,12 +104,10 @@ below, then `p` holds for all elements of the divisor closure of `s`.
 First condition: `p` holds for `1`.
 Second condition: `p` holds for all elements of `s`.
 Third condition: `p` is preserved under multiplication.
-Fourth condition: If `p` holds for an element x, then each divisor of x is the product of an element
-z for which `p` holds and a unit. -/
+Fourth condition: If `p` holds for an element x, then it holds for any divisor of x. -/
 theorem Submonoid.divisor_closure_induction [Monoid α] {s : Set α} {p : α → Prop} {x : α}
     (h : x ∈ Submonoid.divisor_closure s) (mem : ∀ x ∈ s, p x) (one : p 1)
-    (mul : ∀ x y, p x → p y → p (x*y))
-    (div : ∀ x (_ : p x), ∀ y k (_ : x = y*k), p y) : p x := by
+    (mul : ∀ x y, p x → p y → p (x*y)) (div : ∀ x (_ : p x), ∀ y k (_ : x = y*k), p y) : p x := by
   have := Submonoid.divisor_closure_le (s := s) (S := ⟨⟨_, fun hx hy => mul _ _ hx hy⟩, one⟩)
   simp only [IsDivisorClosed, coe_set_mk, Subsemigroup.coe_set_mk, and_imp, mem_mk,
     Subsemigroup.mem_mk, forall_exists_index] at this

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -109,11 +109,11 @@ z for which `p` holds and a unit. -/
 theorem Submonoid.divisor_closure_induction [Monoid α] {s : Set α} {p : α → Prop} {x : α}
     (h : x ∈ Submonoid.divisor_closure s) (mem : ∀ x ∈ s, p x) (one : p 1)
     (mul : ∀ x y, p x → p y → p (x*y))
-    (div : ∀ x (_ : p x), ∀ y k (_ : x = y*k), ∃ z ∈ {x | p x}, y ~ᵤ z) : p x := by
+    (div : ∀ x (_ : p x), ∀ y k (_ : x = y*k), p y) : p x := by
   have := Submonoid.divisor_closure_le (s := s) (S := ⟨⟨_, fun hx hy => mul _ _ hx hy⟩, one⟩)
   simp only [IsDivisorClosed, coe_set_mk, Subsemigroup.coe_set_mk, and_imp, mem_mk,
     Subsemigroup.mem_mk, forall_exists_index] at this
-  exact this mem div h
+  exact this mem (fun b hb a x hax => ⟨_, div b hb a x hax, Associated.refl a⟩) h
 
 theorem top_divisor_closed [Monoid α] : IsDivisorClosed (⊤ : Submonoid α) :=
   fun _ _ a _ => ⟨_, Submonoid.mem_top a, Associated.refl a⟩

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -125,7 +125,7 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α] :
   simp only [Set.mem_setOf_eq, exists_prop, and_imp, Multiset.prod_cons, Multiset.mem_cons,
     forall_eq_or_imp]
   intros a s hind x y _ hprime hprime₂ hprod
-  cases' hprime.dvd_mul.1 (Dvd.intro _ hprod) with h₁ h₂
+  rcases hprime.dvd_mul.1 (Dvd.intro _ hprod) with h₁ | h₂
   · rcases h₁ with ⟨c, h₁⟩
     rw [h₁, mul_assoc] at hprod
     have hprod₂ := mul_left_cancel₀ (hprime.ne_zero) hprod

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -91,6 +91,32 @@ all the submonoids which contain s and are divisor-closed. -/
 def Submonoid.divisor_closure [Monoid α] (s : Set α) :=
     sInf { S : Submonoid α | s ⊆ S ∧ IsDivisorClosed S }
 
+theorem Submonoid.subset_divisor_closure [Monoid α] {s : Set α} :
+    s ⊆ (Submonoid.divisor_closure s) := by
+  unfold divisor_closure
+  simp only [coe_sInf, Set.mem_setOf_eq, Set.subset_iInter_iff, and_imp]
+  exact (fun _ hi _ => hi)
+
+theorem Submonoid.divisor_closure_le [Monoid α] {s : Set α} {S : Submonoid α} :
+    s ⊆ S ∧ IsDivisorClosed S → Submonoid.divisor_closure s ≤ S := fun h => sInf_le h
+
+/-- An induction principle for divisor closure membership. If `p` satisfies the four conditions
+below, then `p` holds for all elements of the divisor closure of `s`.
+First condition: `p` holds for `1`.
+Second condition: `p` holds for all elements of `s`.
+Third condition: `p` is preserved under multiplication.
+Fourth condition: If `p` holds for an element x, then each divisor of x is the product of an element
+z for which `p` holds and a unit. -/
+theorem Submonoid.divisor_closure_induction [Monoid α] {s : Set α} {p : α → Prop} {x : α}
+    (h : x ∈ Submonoid.divisor_closure s) (mem : ∀ x ∈ s, p x) (one : p 1)
+    (mul : ∀ x y, p x → p y → p (x*y))
+    (div : ∀ x (_ : p x), ∀ y k (_ : x = y*k), ∃ z ∈ {x | p x}, y ~ᵤ z) : p x := by
+  have := Submonoid.divisor_closure_le (s := s) (S := ⟨⟨_, fun hx hy => mul _ _ hx hy⟩, one⟩)
+  unfold IsDivisorClosed at this
+  simp only [coe_set_mk, Subsemigroup.coe_set_mk, and_imp, mem_mk, Subsemigroup.mem_mk,
+    forall_exists_index] at this
+  exact this mem div h
+
 theorem top_divisor_closed [Monoid α] : IsDivisorClosed (⊤ : Submonoid α) :=
   fun _ _ a _ => ⟨_, Submonoid.mem_top a, Associated.refl a⟩
 

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -81,6 +81,11 @@ theorem exists_associated_mem_of_dvd_prod [CancelCommMonoidWithZero α] {p : α}
       exact ⟨q, Multiset.mem_cons.2 (Or.inr hq₁), hq₂⟩
 #align exists_associated_mem_of_dvd_prod exists_associated_mem_of_dvd_prod
 
+--TODO: change the definitions to
+--def IsDivisorClosed  {α : Type*}  [Monoid α] (S : Submonoid α) := sorry
+--def Submonoid.divisor_closure  {α : Type*}  [Monoid α] (S : Set α) : Submonoid α := sorry
+--where Submonoid.divisor_closure is defined using sInf
+
 /-- The divisor closure of a submonoid S is defined as the set of elements b ∈ S such that every
 divisor a ∈ H of b lies in S when it is multiplied by a unit. -/
 def Submonoid.divisor_closure [Monoid α] (S : Submonoid α) :=

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -93,8 +93,7 @@ def Submonoid.divisor_closure [Monoid α] (s : Set α) :=
 
 theorem Submonoid.subset_divisor_closure [Monoid α] {s : Set α} :
     s ⊆ (Submonoid.divisor_closure s) := by
-  unfold divisor_closure
-  simp only [coe_sInf, Set.mem_setOf_eq, Set.subset_iInter_iff, and_imp]
+  simp only [divisor_closure, coe_sInf, Set.mem_setOf_eq, Set.subset_iInter_iff, and_imp]
   exact (fun _ hi _ => hi)
 
 theorem Submonoid.divisor_closure_le [Monoid α] {s : Set α} {S : Submonoid α} :
@@ -112,9 +111,8 @@ theorem Submonoid.divisor_closure_induction [Monoid α] {s : Set α} {p : α →
     (mul : ∀ x y, p x → p y → p (x*y))
     (div : ∀ x (_ : p x), ∀ y k (_ : x = y*k), ∃ z ∈ {x | p x}, y ~ᵤ z) : p x := by
   have := Submonoid.divisor_closure_le (s := s) (S := ⟨⟨_, fun hx hy => mul _ _ hx hy⟩, one⟩)
-  unfold IsDivisorClosed at this
-  simp only [coe_set_mk, Subsemigroup.coe_set_mk, and_imp, mem_mk, Subsemigroup.mem_mk,
-    forall_exists_index] at this
+  simp only [IsDivisorClosed, coe_set_mk, Subsemigroup.coe_set_mk, and_imp, mem_mk,
+    Subsemigroup.mem_mk, forall_exists_index] at this
   exact this mem div h
 
 theorem top_divisor_closed [Monoid α] : IsDivisorClosed (⊤ : Submonoid α) :=

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -87,15 +87,18 @@ written as a product of units and prime elements. -/
 theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α]
     (x y : α) (hxy : x * y ∈ closure { r : α | IsUnit r ∨ Prime r}) :
     x ∈ closure { r : α | IsUnit r ∨ Prime r} := by
-  obtain ⟨m, hm⟩ := exists_multiset_of_mem_closure hab
-  revert a b hm
-  refine m.induction (p := fun m ↦ ∀ a b, a * b ∈ closure {r | IsUnit r ∨ Prime r} →
-    (∃ (_ : ∀ y ∈ m, y ∈ {r | IsUnit r ∨ Prime r}), m.prod = a * b) →
-    a ∈ closure {r | IsUnit r ∨ Prime r}) (fun _ _ _ hprod => subset_closure (Set.mem_def.2 ?_)) ?_
-  · left; exact isUnit_of_mul_eq_one _ _ hprod.2.symm
-  · simp only [exists_prop, and_imp, Multiset.prod_cons, Multiset.mem_cons, forall_eq_or_imp]
-    intros _ s hind x y _ ha hs hprod
-    rcases ha with ha₁ | ha₂
+  obtain ⟨m, hm, hprod⟩ := exists_multiset_of_mem_closure hxy
+  induction m using Multiset.induction generalizing x y with
+  | empty =>
+    apply subset_closure
+    simp only [Set.mem_setOf]
+    simp only [Multiset.prod_zero] at hprod
+    left; exact isUnit_of_mul_eq_one _ _ hprod.symm
+  | @cons c s hind =>
+    simp only [Multiset.mem_cons, forall_eq_or_imp, Set.mem_setOf] at hm
+    simp only [Multiset.prod_cons] at hprod
+    simp only [Set.mem_setOf_eq] at hind
+    obtain ⟨ha₁ | ha₂, hs⟩ := hm
     · rcases ha₁.exists_right_inv with ⟨k, hk⟩
       refine hind x (y*k) ?_ hs ?_
       simp only [← mul_assoc, ← hprod, ← Multiset.prod_cons, mul_comm]

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -117,7 +117,7 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α]
       rw [← mul_left_cancel₀ ha₂.ne_zero hprod]
       exact multiset_prod_mem _ _ (fun t ht => subset_closure (hs t ht))
       rw [hc, mul_comm x _, mul_assoc, mul_comm c _] at hprod
-      refine' hind x c _ hs (mul_left_cancel₀ ha₂.ne_zero hprod)
+      refine hind x c ?_ hs (mul_left_cancel₀ ha₂.ne_zero hprod)
       rw [← mul_left_cancel₀ ha₂.ne_zero hprod]
       exact multiset_prod_mem _ _ (fun t ht => subset_closure (hs t ht))
 

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -91,7 +91,7 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α] :
   obtain ⟨m, hm⟩ := exists_multiset_of_mem_closure hab
   revert a b hm
   refine m.induction (p := fun m ↦ ∀ a b, a * b ∈ closure {r | IsUnit r ∨ Prime r} →
-    (∃ (_ : ∀ y ∈ m, y ∈ {r | IsUnit r ∨ Prime r}), m.prod = a * b) →
+  · left; exact isUnit_of_mul_eq_one _ _ hprod.2.symm
     a ∈ closure {r | IsUnit r ∨ Prime r}) (fun _ _ _ hprod => subset_closure (Set.mem_def.2 ?_)) ?_
   · left ; exact isUnit_of_mul_eq_one _ _ hprod.2.symm
   · simp only [exists_prop, and_imp, Multiset.prod_cons, Multiset.mem_cons, forall_eq_or_imp]

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -91,7 +91,7 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α] :
   obtain ⟨m, hm⟩ := exists_multiset_of_mem_closure hab
   revert a b hm
   refine m.induction (p := fun m ↦ ∀ a b, a * b ∈ closure {r | IsUnit r ∨ Prime r} →
-  · left; exact isUnit_of_mul_eq_one _ _ hprod.2.symm
+    (∃ (_ : ∀ y ∈ m, y ∈ {r | IsUnit r ∨ Prime r}), m.prod = a * b) →
     a ∈ closure {r | IsUnit r ∨ Prime r}) (fun _ _ _ hprod => subset_closure (Set.mem_def.2 ?_)) ?_
   · left ; exact isUnit_of_mul_eq_one _ _ hprod.2.symm
   · simp only [exists_prop, and_imp, Multiset.prod_cons, Multiset.mem_cons, forall_eq_or_imp]

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -93,7 +93,7 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α] :
   refine m.induction (p := fun m ↦ ∀ a b, a * b ∈ closure {r | IsUnit r ∨ Prime r} →
     (∃ (_ : ∀ y ∈ m, y ∈ {r | IsUnit r ∨ Prime r}), m.prod = a * b) →
     a ∈ closure {r | IsUnit r ∨ Prime r}) (fun _ _ _ hprod => subset_closure (Set.mem_def.2 ?_)) ?_
-  · left ; exact isUnit_of_mul_eq_one _ _ hprod.2.symm
+  · left; exact isUnit_of_mul_eq_one _ _ hprod.2.symm
   · simp only [exists_prop, and_imp, Multiset.prod_cons, Multiset.mem_cons, forall_eq_or_imp]
     intros _ s hind x y _ ha hs hprod
     rcases ha with ha₁ | ha₂
@@ -103,15 +103,15 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α] :
       refine multiset_prod_mem _ _ (Multiset.forall_mem_cons.2 ⟨subset_closure (Set.mem_def.2 ?_),
         Multiset.forall_mem_cons.2 ⟨subset_closure (Set.mem_def.2 ?_), (fun t ht =>
         subset_closure (hs t ht))⟩⟩)
-      left ; exact isUnit_of_mul_eq_one_right _ _ hk
-      left ; exact ha₁
+      left; exact isUnit_of_mul_eq_one_right _ _ hk
+      left; exact ha₁
       rw [← mul_one s.prod, ← hk, ← mul_assoc, ← mul_assoc, mul_eq_mul_right_iff, mul_comm]
-      left ; exact hprod
+      left; exact hprod
     · rcases ha₂.dvd_mul.1 (Dvd.intro _ hprod) with ⟨c, hc⟩ | ⟨c, hc⟩
-      rw [hc] ; rw [hc, mul_assoc] at hprod
+      rw [hc]; rw [hc, mul_assoc] at hprod
       refine' Submonoid.mul_mem _ (subset_closure (Set.mem_def.2 _))
         (hind _ _ _ hs (mul_left_cancel₀ ha₂.ne_zero hprod))
-      right ; exact ha₂
+      right; exact ha₂
       rw [← mul_left_cancel₀ ha₂.ne_zero hprod]
       exact multiset_prod_mem _ _ (fun t ht => subset_closure (hs t ht))
       rw [hc, mul_comm x _, mul_assoc, mul_comm c _] at hprod

--- a/Mathlib/GroupTheory/Submonoid/Membership.lean
+++ b/Mathlib/GroupTheory/Submonoid/Membership.lean
@@ -412,6 +412,18 @@ theorem exists_multiset_of_mem_closure {M : Type*} [CommMonoid M] {s : Set M} {x
 #align submonoid.exists_multiset_of_mem_closure Submonoid.exists_multiset_of_mem_closure
 #align add_submonoid.exists_multiset_of_mem_closure AddSubmonoid.exists_multiset_of_mem_closure
 
+@[to_additive]
+theorem mem_closure_of_exists_multiset {M : Type*} [CommMonoid M] {s : Set M} {x : M}
+    (hx : ∃ (l : Multiset M) (_ : ∀ y ∈ l, y ∈ s), l.prod = x) : x ∈ closure s := by
+  rcases hx with ⟨_, hl, hprod⟩
+  rw [← hprod]
+  exact multiset_prod_mem _ _ (fun a ha => Set.mem_of_subset_of_mem subset_closure (hl a ha))
+
+@[to_additive]
+theorem mem_closure_iff_exists_multiset {M : Type*} [CommMonoid M] {s : Set M} {x : M} :
+    x ∈ closure s ↔ ∃ (l : Multiset M) (_ : ∀ y ∈ l, y ∈ s), l.prod = x :=
+  ⟨exists_multiset_of_mem_closure, mem_closure_of_exists_multiset⟩
+
 @[to_additive (attr := elab_as_elim)]
 theorem closure_induction_left {s : Set M} {p : (m : M) → m ∈ closure s → Prop}
     (one : p 1 (one_mem _))

--- a/Mathlib/GroupTheory/Submonoid/Membership.lean
+++ b/Mathlib/GroupTheory/Submonoid/Membership.lean
@@ -412,18 +412,6 @@ theorem exists_multiset_of_mem_closure {M : Type*} [CommMonoid M] {s : Set M} {x
 #align submonoid.exists_multiset_of_mem_closure Submonoid.exists_multiset_of_mem_closure
 #align add_submonoid.exists_multiset_of_mem_closure AddSubmonoid.exists_multiset_of_mem_closure
 
-@[to_additive]
-theorem mem_closure_of_exists_multiset {M : Type*} [CommMonoid M] {s : Set M} {x : M}
-    (hx : ∃ (l : Multiset M) (_ : ∀ y ∈ l, y ∈ s), l.prod = x) : x ∈ closure s := by
-  rcases hx with ⟨_, hl, hprod⟩
-  rw [← hprod]
-  exact multiset_prod_mem _ _ (fun a ha => Set.mem_of_subset_of_mem subset_closure (hl a ha))
-
-@[to_additive]
-theorem mem_closure_iff_exists_multiset {M : Type*} [CommMonoid M] {s : Set M} {x : M} :
-    x ∈ closure s ↔ ∃ (l : Multiset M) (_ : ∀ y ∈ l, y ∈ s), l.prod = x :=
-  ⟨exists_multiset_of_mem_closure, mem_closure_of_exists_multiset⟩
-
 @[to_additive (attr := elab_as_elim)]
 theorem closure_induction_left {s : Set M} {p : (m : M) → m ∈ closure s → Prop}
     (one : p 1 (one_mem _))


### PR DESCRIPTION
We add `divisor_closure_eq_closure`: 
Let x, y be elements of a `CancelCommMonoidWithZero`. If x * y can be written as a product of units and prime elements, then x can be written as a product of units and prime elements.

We later use `divisor_closure_eq_closure` to prove Kaplansky's criterion (which we plan to add in a future PR). 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
