### PR TITLE
feat: the terminal refine linter

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4127,6 +4127,7 @@ import Mathlib.Tactic.Linter.MinImports
 import Mathlib.Tactic.Linter.OldObtain
 import Mathlib.Tactic.Linter.RefineLinter
 import Mathlib.Tactic.Linter.Style
+import Mathlib.Tactic.Linter.TerminalRefineLinter
 import Mathlib.Tactic.Linter.TextBased
 import Mathlib.Tactic.Linter.UnusedTactic
 import Mathlib.Tactic.Measurability

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -127,6 +127,7 @@ import Mathlib.Tactic.Linter.MinImports
 import Mathlib.Tactic.Linter.OldObtain
 import Mathlib.Tactic.Linter.RefineLinter
 import Mathlib.Tactic.Linter.Style
+import Mathlib.Tactic.Linter.TerminalRefineLinter
 import Mathlib.Tactic.Linter.TextBased
 import Mathlib.Tactic.Linter.UnusedTactic
 import Mathlib.Tactic.Measurability

--- a/Mathlib/Tactic/Linter/TerminalRefineLinter.lean
+++ b/Mathlib/Tactic/Linter/TerminalRefineLinter.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2024 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+import Lean.Elab.Command
+import Lean.Linter.Util
+
+/-!
+#  The "terminal refine" linter
+
+The "terminal refine" linter flags terminal usages of `refine`.
+-/
+
+open Lean Elab
+
+namespace Mathlib.Linter
+
+/-- The terminal refine linter emits a warning on terminal usages of `refine`. -/
+register_option linter.terminalRefine : Bool := {
+  defValue := true
+  descr := "enable the terminal refine linter"
+}
+
+namespace TerminalRefine
+
+/-- `refine? stx` detects whether the input syntax `stx` is `refine` or `refine'`. -/
+def refine? : Syntax → Bool
+  | .node _ ``Lean.Parser.Tactic.refine' _ => true
+  | .node _ ``Lean.Parser.Tactic.refine _  => true
+  | _ => false
+
+/-- `SyntaxNodeKinds` that "contain" a `refine` and that the linter should ignore. -/
+abbrev ignore : HashSet SyntaxNodeKind := HashSet.empty
+  |>.insert `Mathlib.Tactic.useSyntax
+  |>.insert `Mathlib.Tactic.«tacticUse!___,,»
+  |>.insert `Mathlib.Tactic.congrM
+
+/-- `refine_tree t` returns all terminal usages of `refine/refine'` in the input infotree. -/
+partial
+def refine_tree : InfoTree → Array Syntax
+  | .node k args =>
+    let rargs := (args.map refine_tree).toArray.flatten
+    if let .ofTacticInfo i := k then
+      let stx := i.stx
+      if ! ignore.contains stx.getKind then
+        if (refine? stx) &&
+          (i.goalsAfter.length + 1 == i.goalsBefore.length &&  -- would `<` be enough?
+            (i.goalsAfter.map i.goalsBefore.contains).all (·)) then rargs.push stx
+        else rargs
+      else #[]
+    else rargs
+  | .context _ t => refine_tree t
+  | _ => default
+
+/-- Gets the value of the `linter.terminalRefine` option. -/
+def getLinterHash (o : Options) : Bool := Linter.getLinterValue linter.terminalRefine o
+
+@[inherit_doc linter.terminalRefine]
+def terminalRefineLinter : Linter where run := withSetOptionIn fun _stx => do
+  unless getLinterHash (← getOptions) do
+    return
+  if (← MonadState.get).messages.hasErrors then
+    return
+  let trees ← getInfoTrees
+  for t in trees.toArray do
+    for stx in (refine_tree t) do
+      Linter.logLint linter.terminalRefine stx
+        m!"Please, use `exact` instead of `{stx.getKind.components.getLastD `refine}`!"
+
+initialize addLinter terminalRefineLinter
+
+end TerminalRefine
+
+end Mathlib.Linter


### PR DESCRIPTION
A linter that warns on usages of `refine` and `refine'` as a finishing tactic.

See this [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Usage.20of.20refine').

###  Conclusion of the experiment
Systematic replacements of terminal `refine` with `exact` leads to an overall slow-down.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [ ] depends on: #15616 (disable the linter in downstream projects)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
