### PR TITLE
[Merged by Bors] - chore(scripts): remove solved style exceptions

### DIFF
--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -28,8 +28,6 @@ Mathlib/Data/Finset/Lattice.lean : line 1 : ERR_NUM_LIN : 2400 file contains 224
 Mathlib/Data/Finset/Pointwise.lean : line 1 : ERR_NUM_LIN : 2700 file contains 2550 lines, try to split it up
 Mathlib/Data/Finsupp/Basic.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1956 lines, try to split it up
 Mathlib/Data/List/Basic.lean : line 1 : ERR_NUM_LIN : 4500 file contains 4309 lines, try to split it up
-Mathlib/Data/List/Card.lean : line 1 : ERR_COP : Malformed or missing copyright header
-Mathlib/Data/List/Card.lean : line 12 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Data/Matrix/Basic.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2715 lines, try to split it up
 Mathlib/Data/Multiset/Basic.lean : line 1 : ERR_NUM_LIN : 3300 file contains 3196 lines, try to split it up
 Mathlib/Data/MvPolynomial/Basic.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1705 lines, try to split it up


### PR DESCRIPTION
This PR removes solved `ERR_COP ` and `ERR_MOD` style exceptions.