### PR TITLE
chore: solve some `ERR_MOD` style exceptions

### DIFF
--- a/Mathlib/Data/Array/Basic.lean
+++ b/Mathlib/Data/Array/Basic.lean
@@ -5,6 +5,12 @@ Authors: Mario Carneiro
 -/
 import Std.Tactic.Alias
 
+/-!
+# Arrays
+
+This file contains basic properties of arrays.
+-/
+
 attribute [simp] Array.toArrayAux_eq
 
 alias List.toArray_data := Array.data_toArray

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -18,7 +18,9 @@ import Mathlib.Tactic.Common
 #align_import data.list.basic from "leanprover-community/mathlib"@"65a1391a0106c9204fe45bc73a039f056558cb83"
 
 /-!
-# Basic properties of lists
+# Lists
+
+This file contains basic properties of lists.
 -/
 
 assert_not_exists Set.range

--- a/Mathlib/Init/Data/Int/Basic.lean
+++ b/Mathlib/Init/Data/Int/Basic.lean
@@ -2,12 +2,16 @@
 Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
-
-The integers, with addition, multiplication, and subtraction.
 -/
 import Mathlib.Mathport.Rename
 import Mathlib.Init.Data.Nat.Notation
 import Std.Data.Int.Order
+
+/-!
+# Integers
+
+This file contains basic properties of integers with addition, multiplication, and subtraction.
+-/
 
 open Nat
 
@@ -62,6 +66,10 @@ protected theorem ofNat_add_one_out (n : ℕ) : ↑n + (1 : ℤ) = ↑(succ n) :
 #align int.neg_succ_of_nat_inj_iff Int.negSucc_inj
 #align int.neg_succ_of_nat_eq Int.negSucc_eq
 
+/--
+  Let `a` and `b` be in `ℤ`.
+  If `-a = -b`, then `a = b`.
+-/
 protected theorem neg_eq_neg {a b : ℤ} (h : -a = -b) : a = b := Int.neg_inj.1 h
 #align int.neg_inj Int.neg_eq_neg
 

--- a/Mathlib/Init/Data/Nat/Basic.lean
+++ b/Mathlib/Init/Data/Nat/Basic.lean
@@ -7,6 +7,12 @@ import Mathlib.Init.ZeroOne
 import Mathlib.Init.Data.Nat.Notation
 import Mathlib.Util.CompileInductive
 
+/-!
+# Natural numbers
+
+This file contains basic properties of natural numbers.
+-/
+
 namespace Nat
 
 set_option linter.deprecated false

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -10,6 +10,12 @@ import Mathlib.Tactic.ExtendDoc
 import Mathlib.Tactic.Lemma
 import Mathlib.Tactic.TypeStar
 
+/-!
+# Tactics
+
+This file contains basic tactics and utilities for tactic programming.
+-/
+
 set_option autoImplicit true
 
 namespace Mathlib.Tactic

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -17,7 +17,6 @@ Mathlib/Combinatorics/SimpleGraph/Connectivity.lean : line 1 : ERR_NUM_LIN : 280
 Mathlib/Computability/Primrec.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1568 lines, try to split it up
 Mathlib/Computability/TMToPartrec.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2069 lines, try to split it up
 Mathlib/Computability/TuringMachine.lean : line 1 : ERR_NUM_LIN : 3000 file contains 2821 lines, try to split it up
-Mathlib/Data/Array/Basic.lean : line 3 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Data/BinaryHeap.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Data/ByteArray.lean : line 5 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Data/Complex/Exponential.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1743 lines, try to split it up
@@ -54,8 +53,6 @@ Mathlib/GroupTheory/MonoidLocalization.lean : line 1 : ERR_NUM_LIN : 2300 file c
 Mathlib/GroupTheory/Perm/Cycle/Basic.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1980 lines, try to split it up
 Mathlib/GroupTheory/Subgroup/Basic.lean : line 1 : ERR_NUM_LIN : 4000 file contains 3878 lines, try to split it up
 Mathlib/GroupTheory/Submonoid/Operations.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1504 lines, try to split it up
-Mathlib/Init/Data/Int/Basic.lean : line 12 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Init/Data/Nat/Basic.lean : line 10 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Init/Data/Nat/Lemmas.lean : line 13 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Init/Logic.lean : line 17 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Init/Meta/WellFoundedTactics.lean : line 13 : ERR_MOD : Module docstring missing, or too late
@@ -106,7 +103,6 @@ Mathlib/SetTheory/Ordinal/Arithmetic.lean : line 1 : ERR_NUM_LIN : 2700 file con
 Mathlib/SetTheory/Ordinal/Basic.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1606 lines, try to split it up
 Mathlib/SetTheory/ZFC/Basic.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1805 lines, try to split it up
 Mathlib/Tactic/ApplyWith.lean : line 5 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/Basic.lean : line 13 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/ByContra.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/ClearExcept.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/Coe.lean : line 8 : ERR_MOD : Module docstring missing, or too late


### PR DESCRIPTION
This PR solves some `ERR_MOD` style exceptions by adding brief module docstrings in `Basic.lean` files and removes the associated lines in `scripts/style-exceptions.txt` accordingly.
