### PR TITLE
[Merged by Bors] - chore(Data/Real/Sqrt): delete commented-out incomplete code

### DIFF
--- a/Mathlib/Data/Real/Sqrt.lean
+++ b/Mathlib/Data/Real/Sqrt.lean
@@ -26,9 +26,7 @@ theory of inverses of strictly monotone functions to prove that `NNReal.sqrt x` 
 effect, `NNReal.sqrt` is a bundled `OrderIso`, so for `NNReal` numbers we get continuity as well as
 theorems like `NNReal.sqrt x ≤ y ↔ x ≤ y * y` for free.
 
-Then we define `Real.sqrt x` to be `NNReal.sqrt (Real.toNNReal x)`. We also define a Cauchy sequence
-`Real.sqrtAux (f : CauSeq ℚ abs)` which converges to `Real.sqrt (mk f)` but do not prove (yet) that
-this sequence actually converges to `Real.sqrt (mk f)`.
+Then we define `Real.sqrt x` to be `NNReal.sqrt (Real.toNNReal x)`.
 
 ## Tags
 
@@ -125,35 +123,6 @@ alias ⟨_, sqrt_pos_of_pos⟩ := sqrt_pos
 end NNReal
 
 namespace Real
-
-/-- An auxiliary sequence of rational numbers that converges to `Real.sqrt (mk f)`.
-Currently this sequence is not used in `mathlib`.  -/
-def sqrtAux (f : CauSeq ℚ abs) : ℕ → ℚ
-  | 0 => mkRat (f 0).num.toNat.sqrt (f 0).den.sqrt
-  | n + 1 =>
-    let s := sqrtAux f n
-    max 0 <| (s + f (n + 1) / s) / 2
-#align real.sqrt_aux Real.sqrtAux
-
-theorem sqrtAux_nonneg (f : CauSeq ℚ abs) : ∀ i : ℕ, 0 ≤ sqrtAux f i
-  | 0 => by
-    rw [sqrtAux, Rat.mkRat_eq, Rat.divInt_eq_div]; apply div_nonneg <;>
-      exact Int.cast_nonneg.2 (Int.ofNat_nonneg _)
-  | n + 1 => le_max_left _ _
-#align real.sqrt_aux_nonneg Real.sqrtAux_nonneg
-
-/- TODO(Mario): finish the proof
-theorem sqrt_aux_converges (f : cau_seq ℚ abs) : ∃ h x, 0 ≤ x ∧ x * x = max 0 (mk f) ∧
-    mk ⟨sqrt_aux f, h⟩ = x :=
-begin
-  rcases sqrt_exists (le_max_left 0 (mk f)) with ⟨x, x0, hx⟩,
-  suffices : ∃ h, mk ⟨sqrt_aux f, h⟩ = x,
-  { exact this.imp (λ h e, ⟨x, x0, hx, e⟩) },
-  apply of_near,
-
-  rsuffices ⟨δ, δ0, hδ⟩ : ∃ δ > 0, ∀ i, abs (↑(sqrt_aux f i) - x) < δ / 2 ^ i,
-  { intros }
-end -/
 
 -- Porting note (#11215): TODO: was @[pp_nodot]
 /-- The square root of a real number. This returns 0 for negative inputs. -/


### PR DESCRIPTION
Delete the currently-unused `sqrtAux`, which is a doomed attempt at a computable definition of `Real.sqrt`.

---

Years-old discussion at https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Computable.20real.2Esqrt . The commented-out theorem is in fact false.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
