### PR TITLE
[Merged by Bors] - fix: name collision on Countable.toSmall

### DIFF
--- a/Mathlib/Data/Countable/Small.lean
+++ b/Mathlib/Data/Countable/Small.lean
@@ -22,7 +22,7 @@ instance (priority := 100) Countable.toSmall (α : Type v) [Countable α] : Smal
   let ⟨_, hf⟩ := exists_injective_nat α
   small_of_injective hf
 #align small_of_countable Countable.toSmall
-#align small_of_fintype Countable.toSmall
+#align small_of_fintype Countable.toSmallₓ
 
 @[deprecated, nolint defLemma] -- 2024-03-20
 alias small_of_countable := Countable.toSmall

--- a/Mathlib/Data/Countable/Small.lean
+++ b/Mathlib/Data/Countable/Small.lean
@@ -22,7 +22,7 @@ instance (priority := 100) Countable.toSmall (α : Type v) [Countable α] : Smal
   let ⟨_, hf⟩ := exists_injective_nat α
   small_of_injective hf
 #align small_of_countable Countable.toSmall
-#align small_of_fintype Countable.toSmallₓ
+#align small_of_fintype Countable.toSmallₓ -- this alignment clashes with the one above
 
 @[deprecated, nolint defLemma] -- 2024-03-20
 alias small_of_countable := Countable.toSmall


### PR DESCRIPTION
This is currently causing mathport to fail, it's a new kind of name collision that has not occurred before: two definitions made in two different files are being `#align`ed to the same thing. Normally mathport will automatically rename one of them but in this case neither one imports the other so it doesn't know to avoid the situation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
