### PR TITLE
doc: add @[inherit_doc] to some local notation

### DIFF
--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -19,7 +19,8 @@ and products of multisets, finsets, and finsupps.
 
 variable {α β γ δ : Type*}
 
--- the same local notation used in `Algebra.Associated`
+/-- Notation for two elements of a monoid are associated, i.e.
+if one of them is another one multiplied by a unit on the right.-/
 local infixl:50 " ~ᵤ " => Associated
 
 open BigOperators

--- a/Mathlib/Algebra/Lie/Free.lean
+++ b/Mathlib/Algebra/Lie/Free.lean
@@ -59,11 +59,11 @@ variable (R : Type u) (X : Type v) [CommRing R]
 
 /- We save characters by using Bourbaki's name `lib` (as in «libre») for
 `FreeNonUnitalNonAssocAlgebra` in this file. -/
-local notation "lib" => FreeNonUnitalNonAssocAlgebra
+@[inherit_doc] local notation "lib" => FreeNonUnitalNonAssocAlgebra
 
-local notation "lib.lift" => FreeNonUnitalNonAssocAlgebra.lift
+@[inherit_doc] local notation "lib.lift" => FreeNonUnitalNonAssocAlgebra.lift
 
-local notation "lib.of" => FreeNonUnitalNonAssocAlgebra.of
+@[inherit_doc] local notation "lib.of" => FreeNonUnitalNonAssocAlgebra.of
 
 local notation "lib.lift_of_apply" => FreeNonUnitalNonAssocAlgebra.lift_of_apply
 

--- a/Mathlib/Algebra/MonoidAlgebra/Division.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Division.lean
@@ -54,7 +54,7 @@ noncomputable def divOf (x : k[G]) (g : G) : k[G] :=
   @Finsupp.comapDomain.addMonoidHom _ _ _ _ (g + ·) (add_right_injective g) x
 #align add_monoid_algebra.div_of AddMonoidAlgebra.divOf
 
-local infixl:70 " /ᵒᶠ " => divOf
+@[inherit_doc] local infixl:70 " /ᵒᶠ " => divOf
 
 @[simp]
 theorem divOf_apply (g : G) (x : k[G]) (g' : G) : (x /ᵒᶠ g) g' = x (g + g') :=
@@ -127,7 +127,7 @@ noncomputable def modOf (x : k[G]) (g : G) : k[G] :=
   x.filter fun g₁ => ¬∃ g₂, g₁ = g + g₂
 #align add_monoid_algebra.mod_of AddMonoidAlgebra.modOf
 
-local infixl:70 " %ᵒᶠ " => modOf
+@[inherit_doc] local infixl:70 " %ᵒᶠ " => modOf
 
 @[simp]
 theorem modOf_apply_of_not_exists_add (x : k[G]) (g : G) (g' : G)

--- a/Mathlib/Algebra/MvPolynomial/Division.lean
+++ b/Mathlib/Algebra/MvPolynomial/Division.lean
@@ -45,7 +45,7 @@ noncomputable def divMonomial (p : MvPolynomial σ R) (s : σ →₀ ℕ) : MvPo
   AddMonoidAlgebra.divOf p s
 #align mv_polynomial.div_monomial MvPolynomial.divMonomial
 
-local infixl:70 " /ᵐᵒⁿᵒᵐⁱᵃˡ " => divMonomial
+@[inherit_doc] local infixl:70 " /ᵐᵒⁿᵒᵐⁱᵃˡ " => divMonomial
 
 @[simp]
 theorem coeff_divMonomial (s : σ →₀ ℕ) (x : MvPolynomial σ R) (s' : σ →₀ ℕ) :
@@ -100,7 +100,7 @@ noncomputable def modMonomial (x : MvPolynomial σ R) (s : σ →₀ ℕ) : MvPo
   x.modOf s
 #align mv_polynomial.mod_monomial MvPolynomial.modMonomial
 
-local infixl:70 " %ᵐᵒⁿᵒᵐⁱᵃˡ " => modMonomial
+@[inherit_doc] local infixl:70 " %ᵐᵒⁿᵒᵐⁱᵃˡ " => modMonomial
 
 @[simp]
 theorem coeff_modMonomial_of_not_le {s' s : σ →₀ ℕ} (x : MvPolynomial σ R) (h : ¬s ≤ s') :
@@ -153,9 +153,9 @@ end CopiedDeclarations
 
 section XLemmas
 
-local infixl:70 " /ᵐᵒⁿᵒᵐⁱᵃˡ " => divMonomial
+@[inherit_doc] local infixl:70 " /ᵐᵒⁿᵒᵐⁱᵃˡ " => divMonomial
 
-local infixl:70 " %ᵐᵒⁿᵒᵐⁱᵃˡ " => modMonomial
+@[inherit_doc] local infixl:70 " %ᵐᵒⁿᵒᵐⁱᵃˡ " => modMonomial
 
 @[simp]
 theorem X_mul_divMonomial (i : σ) (x : MvPolynomial σ R) :

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -384,7 +384,7 @@ section UFD
 
 attribute [local instance] PrincipalIdealRing.to_uniqueFactorizationMonoid
 
-local infixl:50 " ~ᵤ " => Associated
+@[inherit_doc] local infixl:50 " ~ᵤ " => Associated
 
 open UniqueFactorizationMonoid Associates
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -66,7 +66,7 @@ def TrivSqZeroExt (R : Type u) (M : Type v) :=
   R × M
 #align triv_sq_zero_ext TrivSqZeroExt
 
-local notation "tsze" => TrivSqZeroExt
+@[inherit_doc] local notation "tsze" => TrivSqZeroExt
 
 open scoped BigOperators RightActions
 

--- a/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
@@ -76,7 +76,7 @@ inductive Hom : F C → F C → Type u
   | tensor {W X Y Z} (f : Hom W Y) (g : Hom X Z) : Hom (W.tensor X) (Y.tensor Z)
 #align category_theory.free_monoidal_category.hom CategoryTheory.FreeMonoidalCategory.Hom
 
-local infixr:10 " ⟶ᵐ " => Hom
+@[inherit_doc] local infixr:10 " ⟶ᵐ " => Hom
 
 /-- The morphisms of the free monoidal category satisfy 21 relations ensuring that the resulting
     category is in fact a category and that it is monoidal. -/

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -63,7 +63,7 @@ end
 
 @[inherit_doc] local notation "F" => FreeMonoidalCategory
 
-@[inherit_doc] local notation "N" => Discrete ∘ NormalMonoidalObject
+local notation "N" => Discrete ∘ NormalMonoidalObject
 
 @[inherit_doc] local infixr:10 " ⟶ᵐ " => Hom
 

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -61,11 +61,11 @@ inductive NormalMonoidalObject : Type u
 
 end
 
-local notation "F" => FreeMonoidalCategory
+@[inherit_doc] local notation "F" => FreeMonoidalCategory
 
-local notation "N" => Discrete ∘ NormalMonoidalObject
+@[inherit_doc] local notation "N" => Discrete ∘ NormalMonoidalObject
 
-local infixr:10 " ⟶ᵐ " => Hom
+@[inherit_doc] local infixr:10 " ⟶ᵐ " => Hom
 
 -- Porting note: this was automatic in mathlib 3
 instance (x y : N C) : Subsingleton (x ⟶ y) := Discrete.instSubsingletonDiscreteHom _ _

--- a/Mathlib/Combinatorics/SimpleGraph/Finsubgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finsubgraph.lean
@@ -51,7 +51,7 @@ abbrev FinsubgraphHom (G' : G.Finsubgraph) (F : SimpleGraph W) :=
   G'.val.coe →g F
 #align simple_graph.finsubgraph_hom SimpleGraph.FinsubgraphHom
 
-local infixl:50 " →fg " => FinsubgraphHom
+@[inherit_doc] local infixl:50 " →fg " => FinsubgraphHom
 
 instance : OrderBot G.Finsubgraph where
   bot := ⟨⊥, finite_empty⟩

--- a/Mathlib/Computability/Reduce.lean
+++ b/Mathlib/Computability/Reduce.lean
@@ -287,7 +287,7 @@ theorem manyOneEquiv_up {α} [Primcodable α] {p : α → Prop} : ManyOneEquiv (
   ManyOneEquiv.of_equiv ULower.down_computable.symm
 #align many_one_equiv_up manyOneEquiv_up
 
-local infixl:1001 " ⊕' " => Sum.elim
+@[inherit_doc] local infixl:1001 " ⊕' " => Sum.elim
 
 open Nat.Primrec
 

--- a/Mathlib/Data/Holor.lean
+++ b/Mathlib/Data/Holor.lean
@@ -176,7 +176,7 @@ def mul [Mul α] (x : Holor α ds₁) (y : Holor α ds₂) : Holor α (ds₁ ++ 
   x t.take * y t.drop
 #align holor.mul Holor.mul
 
-local infixl:70 " ⊗ " => mul
+@[inherit_doc] local infixl:70 " ⊗ " => mul
 
 theorem cast_type (eq : ds₁ = ds₂) (a : Holor α ds₁) :
     cast (congr_arg (Holor α) eq) a = fun t => a (cast (congr_arg HolorIndex eq.symm) t) := by

--- a/Mathlib/Data/List/Duplicate.lean
+++ b/Mathlib/Data/List/Duplicate.lean
@@ -31,7 +31,7 @@ inductive Duplicate (x : α) : List α → Prop
   | cons_duplicate {y : α} {l : List α} : Duplicate x l → Duplicate x (y :: l)
 #align list.duplicate List.Duplicate
 
-local infixl:50 " ∈+ " => List.Duplicate
+@[inherit_doc] local infixl:50 " ∈+ " => List.Duplicate
 
 variable {l : List α} {x : α}
 

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -137,7 +137,7 @@ open Relator
 
 variable {γ : Type*} {δ : Type*} {r : α → β → Prop} {p : γ → δ → Prop}
 
-local infixr:80 " ∘r " => Relation.Comp
+@[inherit_doc] local infixr:80 " ∘r " => Relation.Comp
 
 theorem perm_comp_perm : (Perm ∘r Perm : List α → List α → Prop) = Perm := by
   funext a c; apply propext

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -271,7 +271,7 @@ section Bisim
 
 variable (R : Computation α → Computation α → Prop)
 
-/-- bisimilarity relation-/
+/-- bisimilarity relation -/
 local infixl:50 " ~ " => R
 
 /-- Bisimilarity over a sum of `Computation`s-/

--- a/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
+++ b/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
@@ -641,7 +641,7 @@ end
 
 -- TODO: choose two different symbols for `CircleDeg1Lift.translationNumber` and the future
 -- `circle_mono_homeo.rotation_number`, then make them `localized notation`s
-local notation "τ" => translationNumber
+@[inherit_doc] local notation "τ" => translationNumber
 
 theorem transnumAuxSeq_def : f.transnumAuxSeq = fun n : ℕ => (f ^ (2 ^ n : ℕ)) 0 / 2 ^ n :=
   rfl

--- a/Mathlib/FieldTheory/ChevalleyWarning.lean
+++ b/Mathlib/FieldTheory/ChevalleyWarning.lean
@@ -50,7 +50,7 @@ open Finset FiniteField
 
 variable {K σ ι : Type*} [Fintype K] [Field K] [Fintype σ] [DecidableEq σ]
 
-local notation "q" => Fintype.card K
+@[inherit_doc] local notation "q" => Fintype.card K
 
 theorem MvPolynomial.sum_eval_eq_zero (f : MvPolynomial σ K)
     (h : f.totalDegree < (q - 1) * Fintype.card σ) : ∑ x, eval x f = 0 := by

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -46,7 +46,7 @@ diamonds, as `Fintype` carries data.
 
 variable {K : Type*} {R : Type*}
 
-local notation "q" => Fintype.card K
+@[inherit_doc] local notation "q" => Fintype.card K
 
 open Finset
 

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Contraction.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Contraction.lean
@@ -235,9 +235,9 @@ lemma contractRight_contractLeft (x : CliffordAlgebra Q) : (d ⌋ x) ⌊ d' = d 
 -/
 end contractLeft
 
-local infixl:70 "⌋" => contractLeft
+@[inherit_doc] local infixl:70 "⌋" => contractLeft
 
-local infixl:70 "⌊" => contractRight
+@[inherit_doc] local infixl:70 "⌊" => contractRight
 
 /-- Auxiliary construction for `CliffordAlgebra.changeForm` -/
 @[simps!]

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -49,7 +49,7 @@ structure SimpleFunc.{u, v} (α : Type u) [MeasurableSpace α] (β : Type v) whe
 #align measure_theory.simple_func.measurable_set_fiber' MeasureTheory.SimpleFunc.measurableSet_fiber'
 #align measure_theory.simple_func.finite_range' MeasureTheory.SimpleFunc.finite_range'
 
-local infixr:25 " →ₛ " => SimpleFunc
+@[inherit_doc] local infixr:25 " →ₛ " => SimpleFunc
 
 namespace SimpleFunc
 

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDense.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDense.lean
@@ -45,7 +45,7 @@ noncomputable section
 
 namespace MeasureTheory
 
-local infixr:25 " →ₛ " => SimpleFunc
+@[inherit_doc] local infixr:25 " →ₛ " => SimpleFunc
 
 namespace SimpleFunc
 

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -67,7 +67,7 @@ variable {α β γ ι : Type*} [Countable ι]
 
 namespace MeasureTheory
 
-local infixr:25 " →ₛ " => SimpleFunc
+@[inherit_doc] local infixr:25 " →ₛ " => SimpleFunc
 
 section Definitions
 

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lp.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lp.lean
@@ -32,7 +32,7 @@ open scoped ENNReal Topology MeasureTheory
 
 namespace MeasureTheory
 
-local infixr:25 " →ₛ " => SimpleFunc
+@[inherit_doc] local infixr:25 " →ₛ " => SimpleFunc
 
 variable {α G : Type*} {p : ℝ≥0∞} {m m0 : MeasurableSpace α} {μ : Measure α} [NormedAddCommGroup G]
   {f : α → G}

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -253,7 +253,7 @@ theorem weightedSMul_nonneg (s : Set α) (x : ℝ) (hx : 0 ≤ x) : 0 ≤ weight
 
 end WeightedSMul
 
-local infixr:25 " →ₛ " => SimpleFunc
+@[inherit_doc] local infixr:25 " →ₛ " => SimpleFunc
 
 namespace SimpleFunc
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -47,7 +47,7 @@ open Topology BigOperators NNReal ENNReal MeasureTheory
 
 namespace MeasureTheory
 
-local infixr:25 " →ₛ " => SimpleFunc
+@[inherit_doc] local infixr:25 " →ₛ " => SimpleFunc
 
 variable {α β γ δ : Type*}
 

--- a/Mathlib/MeasureTheory/Integral/SetToL1.lean
+++ b/Mathlib/MeasureTheory/Integral/SetToL1.lean
@@ -82,7 +82,7 @@ variable {α E F F' G 𝕜 : Type*} {p : ℝ≥0∞} [NormedAddCommGroup E] [Nor
   [NormedAddCommGroup F] [NormedSpace ℝ F] [NormedAddCommGroup F'] [NormedSpace ℝ F']
   [NormedAddCommGroup G] {m : MeasurableSpace α} {μ : Measure α}
 
-local infixr:25 " →ₛ " => SimpleFunc
+@[inherit_doc] local infixr:25 " →ₛ " => SimpleFunc
 
 open Finset
 

--- a/Mathlib/MeasureTheory/Integral/VitaliCaratheodory.lean
+++ b/Mathlib/MeasureTheory/Integral/VitaliCaratheodory.lean
@@ -81,7 +81,7 @@ variable {α : Type*} [TopologicalSpace α] [MeasurableSpace α] [BorelSpace α]
 
 namespace MeasureTheory
 
-local infixr:25 " →ₛ " => SimpleFunc
+@[inherit_doc] local infixr:25 " →ₛ " => SimpleFunc
 
 /-! ### Lower semicontinuous upper bound for nonnegative functions -/
 

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -54,9 +54,9 @@ Matiyasevic's theorem, Hilbert's tenth problem
 
 open Fin2 Function Nat Sum
 
-local infixr:67 " ::ₒ " => Option.elim'
+@[inherit_doc] local infixr:67 " ::ₒ " => Option.elim'
 
-local infixr:65 " ⊗ " => Sum.elim
+@[inherit_doc] local infixr:65 " ⊗ " => Sum.elim
 
 universe u
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -29,7 +29,7 @@ import Mathlib.RingTheory.Multiplicity
 
 variable {α : Type*}
 
-local infixl:50 " ~ᵤ " => Associated
+@[inherit_doc] local infixl:50 " ~ᵤ " => Associated
 
 /-- Well-foundedness of the strict version of |, which is equivalent to the descending chain
 condition on divisibility and to the ascending chain condition on

--- a/Mathlib/SetTheory/Game/Basic.lean
+++ b/Mathlib/SetTheory/Game/Basic.lean
@@ -104,7 +104,7 @@ def LF : Game → Game → Prop :=
   Quotient.lift₂ PGame.LF fun _ _ _ _ hx hy => propext (lf_congr hx hy)
 #align game.lf SetTheory.Game.LF
 
-local infixl:50 " ⧏ " => LF
+@[inherit_doc] local infixl:50 " ⧏ " => LF
 
 /-- On `Game`, simp-normal inequalities should use as few negations as possible. -/
 @[simp]
@@ -157,7 +157,7 @@ def Fuzzy : Game → Game → Prop :=
   Quotient.lift₂ PGame.Fuzzy fun _ _ _ _ hx hy => propext (fuzzy_congr hx hy)
 #align game.fuzzy SetTheory.Game.Fuzzy
 
-local infixl:50 " ‖ " => Fuzzy
+@[inherit_doc] local infixl:50 " ‖ " => Fuzzy
 
 theorem PGame.fuzzy_iff_game_fuzzy {x y : PGame} : PGame.Fuzzy x y ↔ ⟦x⟧ ‖ ⟦y⟧ :=
   Iff.rfl

--- a/Mathlib/Topology/Homotopy/Product.lean
+++ b/Mathlib/Topology/Homotopy/Product.lean
@@ -115,7 +115,7 @@ namespace Path.Homotopic
 
 attribute [local instance] Path.Homotopic.setoid
 
-local infixl:70 " ⬝ " => Quotient.comp
+@[inherit_doc] local infixl:70 " ⬝ " => Quotient.comp
 
 section Pi
 

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -239,7 +239,7 @@ theorem Continuous.specialization_monotone (hf : Continuous f) :
 ### `Inseparable` relation
 -/
 
-local infixl:0 " ~ᵢ " => Inseparable
+@[inherit_doc] local infixl:0 " ~ᵢ " => Inseparable
 
 theorem inseparable_def : (x ~ᵢ y) ↔ 𝓝 x = 𝓝 y :=
   Iff.rfl


### PR DESCRIPTION
---------

My understanding is that because these are local notation, @eric-wieser's comment [on zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/undocumented.20things/near/431494164) doesn't apply.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
