### PR TITLE
[Merged by Bors] - doc(Tactic/ToAdditive): fix mathlib3 naming in the documentation

### DIFF
--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -47,7 +47,7 @@ has a doc string, a doc string for the additive version should be passed explici
 ```
 /-- Multiplication is commutative -/
 @[to_additive "Addition is commutative"]
-theorem mul_comm' {α} [comm_semigroup α] (x y : α) : x * y = y * x := comm_semigroup.mul_comm
+theorem mul_comm' {α} [CommSemigroup α] (x y : α) : x * y = y * x := CommSemigroup.mul_comm
 ```
 
 The transport tries to do the right thing in most cases using several
@@ -64,7 +64,7 @@ Use the `(attr := ...)` syntax to apply attributes to both the multiplicative an
 version:
 
 ```
-@[to_additive (attr := simp)] lemma mul_one' {G : Type*} [group G] (x : G) : x * 1 = x := mul_one x
+@[to_additive (attr := simp)] lemma mul_one' {G : Type*} [Group G] (x : G) : x * 1 = x := mul_one x
 ```
 
 For `simp` and `simps` this also ensures that some generated lemmas are added to the additive
@@ -90,9 +90,9 @@ that have previously been labeled with `to_additive`.
 
 In the `mul_comm'` example above, `to_additive` maps:
 * `mul_comm'` to `add_comm'`,
-* `comm_semigroup` to `add_comm_semigroup`,
+* `CommSemigroup` to `AddCommSemigroup`,
 * `x * y` to `x + y` and `y * x` to `y + x`, and
-* `comm_semigroup.mul_comm'` to `add_comm_semigroup.add_comm'`.
+* `CommSemigroup.mul_comm'` to `AddCommSemigroup.add_comm'`.
 
 ### Heuristics
 
@@ -214,18 +214,18 @@ In this case `to_additive` adds all structure fields to its mapping.
 
 * [todo] Namespaces can be transformed using `map_namespace`. For example:
   ```
-  run_cmd to_additive.map_namespace `quotient_group `quotient_add_group
+  run_cmd to_additive.map_namespace `QuotientGroup `QuotientAddGroup
   ```
 
-  Later uses of `to_additive` on declarations in the `quotient_group`
-  namespace will be created in the `quotient_add_group` namespaces.
+  Later uses of `to_additive` on declarations in the `QuotientGroup`
+  namespace will be created in the `QuotientAddGroup` namespaces.
 
 * If `@[to_additive]` is called with a `name` argument `new_name`
   /without a dot/, then `to_additive` updates the prefix as described
   above, then replaces the last part of the name with `new_name`.
 
 * If `@[to_additive]` is called with a `name` argument
-  `new_namespace.new_name` /with a dot/, then `to_additive` uses this
+  `NewNamespace.new_name` /with a dot/, then `to_additive` uses this
   new name as is.
 
 As a safety check, in the first case `to_additive` double checks
@@ -1296,7 +1296,7 @@ has a doc string, a doc string for the additive version should be passed explici
 ```
 /-- Multiplication is commutative -/
 @[to_additive "Addition is commutative"]
-theorem mul_comm' {α} [comm_semigroup α] (x y : α) : x * y = y * x := comm_semigroup.mul_comm
+theorem mul_comm' {α} [CommSemigroup α] (x y : α) : x * y = y * x := CommSemigroup.mul_comm
 ```
 
 The transport tries to do the right thing in most cases using several
@@ -1313,7 +1313,7 @@ Use the `(attr := ...)` syntax to apply attributes to both the multiplicative an
 version:
 
 ```
-@[to_additive (attr := simp)] lemma mul_one' {G : Type*} [group G] (x : G) : x * 1 = x := mul_one x
+@[to_additive (attr := simp)] lemma mul_one' {G : Type*} [Group G] (x : G) : x * 1 = x := mul_one x
 ```
 
 For `simp` and `simps` this also ensures that some generated lemmas are added to the additive
@@ -1339,9 +1339,9 @@ that have previously been labeled with `to_additive`.
 
 In the `mul_comm'` example above, `to_additive` maps:
 * `mul_comm'` to `add_comm'`,
-* `comm_semigroup` to `add_comm_semigroup`,
+* `CommSemigroup` to `AddCommSemigroup`,
 * `x * y` to `x + y` and `y * x` to `y + x`, and
-* `comm_semigroup.mul_comm'` to `add_comm_semigroup.add_comm'`.
+* `CommSemigroup.mul_comm'` to `AddCommSemigroup.add_comm'`.
 
 ### Heuristics
 
@@ -1463,18 +1463,18 @@ In this case `to_additive` adds all structure fields to its mapping.
 
 * [todo] Namespaces can be transformed using `map_namespace`. For example:
   ```
-  run_cmd to_additive.map_namespace `quotient_group `quotient_add_group
+  run_cmd to_additive.map_namespace `QuotientGroup `QuotientAddGroup
   ```
 
-  Later uses of `to_additive` on declarations in the `quotient_group`
-  namespace will be created in the `quotient_add_group` namespaces.
+  Later uses of `to_additive` on declarations in the `QuotientGroup`
+  namespace will be created in the `QuotientAddGroup` namespaces.
 
 * If `@[to_additive]` is called with a `name` argument `new_name`
   /without a dot/, then `to_additive` updates the prefix as described
   above, then replaces the last part of the name with `new_name`.
 
 * If `@[to_additive]` is called with a `name` argument
-  `new_namespace.new_name` /with a dot/, then `to_additive` uses this
+  `NewNamespace.new_name` /with a dot/, then `to_additive` uses this
   new name as is.
 
 As a safety check, in the first case `to_additive` double checks


### PR DESCRIPTION
---

Extends the ToAdditive changes in #11949. I do not know what I'm doing; it's possible this is incomplete.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
