### PR TITLE
[Merged by Bors] - feat: add a class to encode that the spectrum of nonnegative elements is nonnegative

### DIFF
--- a/Mathlib/Algebra/Algebra/Quasispectrum.lean
+++ b/Mathlib/Algebra/Algebra/Quasispectrum.lean
@@ -321,3 +321,29 @@ lemma quasispectrum_eq_spectrum_inr' (R S : Type*) {A : Type*} [Semifield R]
   rw [← Set.union_eq_self_of_subset_right this, ← quasispectrum_eq_spectrum_union_zero]
   apply forall_congr' fun x ↦ ?_
   rw [not_iff_not, Units.smul_def, Units.smul_def, ← inr_smul, ← inr_neg, isQuasiregular_inr_iff]
+
+end Unitization
+
+/-- A class for `𝕜`-algebras with a partial order where the ordering is compatible with the
+(quasi)spectrum. -/
+class NonnegSpectrumClass (𝕜 A : Type*) [OrderedCommRing 𝕜] [NonUnitalRing A] [PartialOrder A]
+    [Module 𝕜 A] : Prop where
+  quasispectrum_nonneg_of_nonneg : ∀ a : A, 0 ≤ a → ∀ x ∈ quasispectrum 𝕜 a, 0 ≤ x
+
+export NonnegSpectrumClass (quasispectrum_nonneg_of_nonneg)
+
+namespace NonnegSpectrumClass
+
+lemma iff_spectrum_nonneg {𝕜 A : Type*} [LinearOrderedField 𝕜] [Ring A] [PartialOrder A] [Algebra 𝕜 A] :
+    NonnegSpectrumClass 𝕜 A ↔ ∀ a : A, 0 ≤ a → ∀ x ∈ spectrum 𝕜 a, 0 ≤ x := by
+  simp [show NonnegSpectrumClass 𝕜 A ↔ _ from ⟨fun ⟨h⟩ ↦ h, (⟨·⟩)⟩,
+    quasispectrum_eq_spectrum_union_zero]
+
+alias ⟨_, of_spectrum_nonneg⟩ := iff_spectrum_nonneg
+
+end NonnegSpectrumClass
+
+lemma spectrum_nonneg_of_nonneg {𝕜 A : Type*} [LinearOrderedField 𝕜] [Ring A] [PartialOrder A]
+    [Algebra 𝕜 A] [NonnegSpectrumClass 𝕜 A] ⦃a : A⦄ (ha : 0 ≤ a) ⦃x : 𝕜⦄ (hx : x ∈ spectrum 𝕜 a) :
+    0 ≤ x :=
+  NonnegSpectrumClass.iff_spectrum_nonneg.mp inferInstance a ha x hx

--- a/Mathlib/Algebra/Algebra/Quasispectrum.lean
+++ b/Mathlib/Algebra/Algebra/Quasispectrum.lean
@@ -334,8 +334,8 @@ export NonnegSpectrumClass (quasispectrum_nonneg_of_nonneg)
 
 namespace NonnegSpectrumClass
 
-lemma iff_spectrum_nonneg {𝕜 A : Type*} [LinearOrderedField 𝕜] [Ring A] [PartialOrder A] [Algebra 𝕜 A] :
-    NonnegSpectrumClass 𝕜 A ↔ ∀ a : A, 0 ≤ a → ∀ x ∈ spectrum 𝕜 a, 0 ≤ x := by
+lemma iff_spectrum_nonneg {𝕜 A : Type*} [LinearOrderedField 𝕜] [Ring A] [PartialOrder A]
+    [Algebra 𝕜 A] : NonnegSpectrumClass 𝕜 A ↔ ∀ a : A, 0 ≤ a → ∀ x ∈ spectrum 𝕜 a, 0 ≤ x := by
   simp [show NonnegSpectrumClass 𝕜 A ↔ _ from ⟨fun ⟨h⟩ ↦ h, (⟨·⟩)⟩,
     quasispectrum_eq_spectrum_union_zero]
 

--- a/Mathlib/Analysis/NormedSpace/Spectrum.lean
+++ b/Mathlib/Analysis/NormedSpace/Spectrum.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Jireh Loreaux. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
+import Mathlib.Algebra.Algebra.Quasispectrum
 import Mathlib.FieldTheory.IsAlgClosed.Spectrum
 import Mathlib.Analysis.Complex.Liouville
 import Mathlib.Analysis.Complex.Polynomial
@@ -617,6 +618,11 @@ lemma nnreal_iff [Algebra ℝ A] {a : A} :
     exact coe_nonneg x
   · exact .of_subset_range_algebraMap _ _ (fun _ ↦ Real.toNNReal_coe)
       fun x hx ↦ ⟨⟨x, h x hx⟩, rfl⟩
+
+lemma nnreal_of_nonneg {A : Type*} [Ring A] [PartialOrder A] [Algebra ℝ A]
+    [NonnegSpectrumClass ℝ A] {a : A} (ha : 0 ≤ a) :
+    SpectrumRestricts a ContinuousMap.realToNNReal :=
+  nnreal_iff.mpr <| spectrum_nonneg_of_nonneg ha
 
 lemma real_iff [Algebra ℂ A] {a : A} :
     SpectrumRestricts a Complex.reCLM ↔ ∀ x ∈ spectrum ℂ a, x = x.re := by


### PR DESCRIPTION
When working with the continuous functional calculus generically, it is currently hard to establish lemmas that work well for positive across the board. 

This is in part due to the fact that one cannot conclude from the continuous functional calculus alone that the spectrum of nonnegative elements in a star-ordered ring is nonnegative. So, we use a type class to encode this, and this type class actually uses the quasispectrum, because for unital algebras the two notions are equivalent.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
