### PR TITLE
chore: recover `Lean.Expr.relSidesIfSymm?`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3678,6 +3678,7 @@ import Mathlib.Tactic.Recover
 import Mathlib.Tactic.ReduceModChar
 import Mathlib.Tactic.ReduceModChar.Ext
 import Mathlib.Tactic.Relation.Rfl
+import Mathlib.Tactic.Relation.Symm
 import Mathlib.Tactic.Relation.Trans
 import Mathlib.Tactic.Rename
 import Mathlib.Tactic.RenameBVar

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -152,6 +152,7 @@ import Mathlib.Tactic.Recover
 import Mathlib.Tactic.ReduceModChar
 import Mathlib.Tactic.ReduceModChar.Ext
 import Mathlib.Tactic.Relation.Rfl
+import Mathlib.Tactic.Relation.Symm
 import Mathlib.Tactic.Relation.Trans
 import Mathlib.Tactic.Rename
 import Mathlib.Tactic.RenameBVar

--- a/Mathlib/Tactic/Relation/Symm.lean
+++ b/Mathlib/Tactic/Relation/Symm.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2022 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Lean.Meta.Tactic.Symm
+
+/-!
+# `relSidesIfSymm?`
+-/
+
+set_option autoImplicit true
+
+open Lean Meta Symm
+
+namespace Mathlib.Tactic
+
+open Lean.Elab.Tactic
+
+/-- If `e` is the form `@R .. x y`, where `R` is a symmetric
+relation, return `some (R, x, y)`.
+As a special case, if `e` is `@HEq α a β b`, return ``some (`HEq, a, b)``. -/
+def _root_.Lean.Expr.relSidesIfSymm? (e : Expr) : MetaM (Option (Name × Expr × Expr)) := do
+  if let some (_, lhs, rhs) := e.eq? then
+    return (``Eq, lhs, rhs)
+  if let some (lhs, rhs) := e.iff? then
+    return (``Iff, lhs, rhs)
+  if let some (_, lhs, _, rhs) := e.heq? then
+    return (``HEq, lhs, rhs)
+  if let .app (.app rel lhs) rhs := e then
+    unless (← (symmExt.getState (← getEnv)).getMatch rel symmExt.config).isEmpty do
+      match rel.getAppFn.constName? with
+      | some n => return some (n, lhs, rhs)
+      | none => return none
+  return none


### PR DESCRIPTION
`Lean.Expr.relSidesIfSymm?` is removed in #11162, but this def is required for `cc` tactic, so we recover this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
