### PR TITLE
[Merged by Bors] - chore: remove unused @[simp] from Fin.sub_one_lt_iff

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -1609,7 +1609,6 @@ theorem le_sub_one_iff {n : ℕ} {k : Fin (n + 1)} : k ≤ k - 1 ↔ k = 0 := by
   simp
 #align fin.le_sub_one_iff Fin.le_sub_one_iff
 
-@[simp]
 theorem sub_one_lt_iff {n : ℕ} {k : Fin (n + 1)} : k - 1 < k ↔ 0 < k :=
   not_iff_not.1 <| by simp only [not_lt, le_sub_one_iff, le_zero_iff]
 #align fin.sub_one_lt_iff Fin.sub_one_lt_iff


### PR DESCRIPTION
The @[simp] annotation is not used in mathlib, and triggered a linter failure that I don't care to investigate unnecessarily.