### PR TITLE
draft: syntax data linter

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3710,6 +3710,7 @@ import Mathlib.Tactic.SuccessIfFailWithMsg
 import Mathlib.Tactic.SudoSetOption
 import Mathlib.Tactic.SuppressCompilation
 import Mathlib.Tactic.SwapVar
+import Mathlib.Tactic.SyntaxDataLinter
 import Mathlib.Tactic.TFAE
 import Mathlib.Tactic.Tauto
 import Mathlib.Tactic.TermCongr

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -180,6 +180,7 @@ import Mathlib.Tactic.SuccessIfFailWithMsg
 import Mathlib.Tactic.SudoSetOption
 import Mathlib.Tactic.SuppressCompilation
 import Mathlib.Tactic.SwapVar
+import Mathlib.Tactic.SyntaxDataLinter
 import Mathlib.Tactic.TFAE
 import Mathlib.Tactic.Tauto
 import Mathlib.Tactic.TermCongr

--- a/Mathlib/Tactic/SyntaxDataLinter.lean
+++ b/Mathlib/Tactic/SyntaxDataLinter.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2024 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+import Lean.Elab.Command
+import Lean.Linter.Util
+
+/-!
+#  The "syntax data" linter
+-/
+
+/-- The rev-lexicographic order on pairs. -/
+def revLexOrd {α β} [Ord α] [Ord β] : Ord (α × β) where
+  compare p1 p2 := match compare p1.2 p2.2 with
+    | .eq => compare p1.1 p2.1
+    | o   => o
+
+open Lean Elab Parser Command
+
+namespace Mathlib.Linter
+
+/-- The "syntax data" linter prints range information for "syntax data". -/
+register_option linter.syntaxData : Bool := {
+  defValue := true
+  descr := "enable the syntax data linter"
+}
+
+namespace syntaxData
+
+/--  Checks if a declaration has a doc-string as part of its syntax.
+This misses out on doc-strings added post-hoc, such as via `add_decl_doc`. -/
+partial
+def hasDocs : Syntax → Bool
+  | .node _ ``docComment _ => true
+  | .node _ _ args => (args.map hasDocs).any (·)
+  | _ => false
+
+/-- Extract all `declId`s from the given syntax.
+Typically, there is at most one such `declId`: the name of a `theorem/lemma/def/instance/...`. -/
+partial
+def getIds : Syntax → Array Syntax
+  | .node _ `Std.Tactic.Alias.alias args => #[args[2]!]
+  | .node _ ``Command.export args => #[args[3]![0]]
+  | stx@(.node _ _ args) =>
+    ((args.map fun a => getIds a).foldl (· ++ ·) #[stx]).filter (·.getKind == ``declId)
+  | _ => default
+
+/-- scans the input `InfoTree` and accumulates `SyntaxNodeKinds` and `Range`s in a `HashSet`. -/
+partial
+def getRanges :
+    InfoTree → HashSet (SyntaxNodeKind × String.Range) → HashSet (SyntaxNodeKind × String.Range)
+  | .node k args, col =>
+    let rargs := (args.map (getRanges · col)).toArray
+    Id.run do
+    let mut tot : HashSet (SyntaxNodeKind × String.Range) := .empty
+    for r in rargs do
+      for (a, b) in r.toArray do tot := tot.insert (a, b)
+    if let .ofTacticInfo i := k then
+      let stx := i.stx
+      if let some rg := stx.getRange? then tot := tot.insert (stx.getKind, rg)
+      tot
+    else tot
+  | .context _ t, col => getRanges t col
+  | _, _ => default
+
+/-- print a range as the pair `(beginning, end)`. -/
+local instance : ToString String.Range where
+  toString rg := s!"{(rg.start, rg.stop)}"
+
+/-- Gets the value of the `linter.syntaxData` option. -/
+def getLinterHash (o : Options) : Bool := Linter.getLinterValue linter.syntaxData o
+
+/-- The main implementation of the terminal refine linter. -/
+def syntaxDataLinter : Linter where run := withSetOptionIn fun stx => do
+  unless getLinterHash (← getOptions) && (← getInfoState).enabled do
+    return
+  if (← MonadState.get).messages.hasErrors then
+    return
+  let trees ← getInfoTrees
+  let _ : Ord SyntaxNodeKind := ⟨(compare ·.toString ·.toString)⟩
+  let _ : Ord String.Range := ⟨(compare ·.start.byteIdx ·.start.byteIdx)⟩
+  let _ : Ord (SyntaxNodeKind × String.Range) := lexOrd
+  let mut msg := .empty
+  for t in trees.toArray do
+    msg := getRanges t msg
+  let dat := msg.toArray.qsort (compare · ·|>.isLT)
+  if dat != #[] then
+    Linter.logLint linter.syntaxData stx
+      m!"{getIds stx} {if ! hasDocs stx then "-- no docs" else ""}\n{dat}"
+
+initialize addLinter syntaxDataLinter

--- a/Mathlib/Tactic/SyntaxDataLinter.lean
+++ b/Mathlib/Tactic/SyntaxDataLinter.lean
@@ -106,7 +106,8 @@ def syntaxDataLinter : Linter where run := withSetOptionIn fun stx => do
     msg := getRanges t msg
   let dat := msg.toArray.qsort (compare · ·|>.isLT)
   if dat != #[] then
+    let ids ← (getIds stx).mapM fun d => resolveGlobalConstNoOverload d[0]
     Linter.logLint linter.syntaxData stx
-      m!"{getIds stx} {if ! hasDocs stx then "-- no docs" else ""}\n{dat}"
+      m!"{ids} {if ! hasDocs stx then "-- no docs" else ""}\n{dat}"
 
 initialize addLinter syntaxDataLinter

--- a/Mathlib/Tactic/SyntaxDataLinter.lean
+++ b/Mathlib/Tactic/SyntaxDataLinter.lean
@@ -63,7 +63,7 @@ abbrev exclusions : HashSet SyntaxNodeKind := HashSet.empty
   |>.insert `«]»
   |>.insert `«<;>»
 
-/-- scans the input `InfoTree` and accumulates `SyntaxNodeKinds` and `Range`s in a `HashSet`. -/
+/-- scans the input `InfoTree` and accumulates `Expr`s and `Range`s in a `HashSet`. -/
 partial
 def getTerms :
     InfoTree → HashSet (Expr × String.Range) → HashSet (Expr × String.Range)
@@ -84,7 +84,7 @@ def getTerms :
   | .context _ t, col => getTerms t col
   | _, _ => default
 
-/-- scans the input `InfoTree` and accumulates `SyntaxNodeKinds` and `Range`s in a `HashSet`. -/
+/-- scans the input `InfoTree` and accumulates `SyntaxNodeKind`s and `Range`s in a `HashSet`. -/
 partial
 def getRanges :
     InfoTree → HashSet (SyntaxNodeKind × String.Range) → HashSet (SyntaxNodeKind × String.Range)
@@ -93,9 +93,9 @@ def getRanges :
     Id.run do
     let mut tot := col
     for r in rargs do
-      for (a, b) in r.toArray do
+      for (a, rg) in r.toArray do
         if !exclusions.contains a then
-          tot := tot.insert (a, b)
+          tot := tot.insert (a, rg)
     if let .ofTacticInfo i := k then
       let stx := i.stx
       if let .original .. := stx.getHeadInfo then  -- make sure that the syntax is `original`


### PR DESCRIPTION
A linter that prints `SyntaxNodeKind`s and `Range`s for all the nodes of a command.

See this [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/undocumented.20things).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
