### PR TITLE
[Merged by Bors] - refactor: Move `AddCircle.toCircle` to earlier file

### DIFF
--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -71,52 +71,10 @@ variable {T : ℝ}
 
 namespace AddCircle
 
-/-! ### Map from `AddCircle` to `Circle` -/
-
-
-theorem scaled_exp_map_periodic : Function.Periodic (fun x => expMapCircle (2 * π / T * x)) T := by
-  -- The case T = 0 is not interesting, but it is true, so we prove it to save hypotheses
-  rcases eq_or_ne T 0 with (rfl | hT)
-  · intro x; simp
-  · intro x; simp_rw [mul_add]; rw [div_mul_cancel₀ _ hT, periodic_expMapCircle]
-#align add_circle.scaled_exp_map_periodic AddCircle.scaled_exp_map_periodic
-
-/-- The canonical map `fun x => exp (2 π i x / T)` from `ℝ / ℤ • T` to the unit circle in `ℂ`.
-If `T = 0` we understand this as the constant function 1. -/
-def toCircle : AddCircle T → circle :=
-  (@scaled_exp_map_periodic T).lift
-#align add_circle.to_circle AddCircle.toCircle
-
-theorem toCircle_add (x : AddCircle T) (y : AddCircle T) :
-    @toCircle T (x + y) = toCircle x * toCircle y := by
-  induction x using QuotientAddGroup.induction_on'
-  induction y using QuotientAddGroup.induction_on'
-  rw [← QuotientAddGroup.mk_add]
-  simp_rw [toCircle, Function.Periodic.lift_coe, mul_add, expMapCircle_add]
-#align add_circle.to_circle_add AddCircle.toCircle_add
-
-theorem continuous_toCircle : Continuous (@toCircle T) :=
-  continuous_coinduced_dom.mpr (expMapCircle.continuous.comp <| continuous_const.mul continuous_id')
-#align add_circle.continuous_to_circle AddCircle.continuous_toCircle
-
-theorem injective_toCircle (hT : T ≠ 0) : Function.Injective (@toCircle T) := by
-  intro a b h
-  induction a using QuotientAddGroup.induction_on'
-  induction b using QuotientAddGroup.induction_on'
-  simp_rw [toCircle, Function.Periodic.lift_coe] at h
-  obtain ⟨m, hm⟩ := expMapCircle_eq_expMapCircle.mp h.symm
-  rw [QuotientAddGroup.eq]; simp_rw [AddSubgroup.mem_zmultiples_iff, zsmul_eq_mul]
-  use m
-  field_simp at hm
-  rw [← mul_right_inj' Real.two_pi_pos.ne']
-  linarith
-#align add_circle.injective_to_circle AddCircle.injective_toCircle
-
 /-! ### Measure on `AddCircle T`
 
 In this file we use the Haar measure on `AddCircle T` normalised to have total measure 1 (which is
 **not** the same as the standard measure defined in `Topology.Instances.AddCircle`). -/
-
 
 variable [hT : Fact (0 < T)]
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -5,7 +5,6 @@ Authors: Yury G. Kudryashov
 -/
 import Mathlib.Analysis.Complex.Circle
 import Mathlib.Analysis.SpecialFunctions.Complex.Log
-import Mathlib.Topology.Instances.AddCircle
 
 #align_import analysis.special_functions.complex.circle from "leanprover-community/mathlib"@"f333194f5ecd1482191452c5ea60b37d4d6afa08"
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -5,6 +5,7 @@ Authors: Yury G. Kudryashov
 -/
 import Mathlib.Analysis.Complex.Circle
 import Mathlib.Analysis.SpecialFunctions.Complex.Log
+import Mathlib.Topology.Instances.AddCircle
 
 #align_import analysis.special_functions.complex.circle from "leanprover-community/mathlib"@"f333194f5ecd1482191452c5ea60b37d4d6afa08"
 
@@ -150,3 +151,49 @@ theorem Real.Angle.arg_expMapCircle (θ : Real.Angle) :
   rw [Real.Angle.expMapCircle_coe, expMapCircle_apply, exp_mul_I, ← ofReal_cos, ← ofReal_sin, ←
     Real.Angle.cos_coe, ← Real.Angle.sin_coe, arg_cos_add_sin_mul_I_coe_angle]
 #align real.angle.arg_exp_map_circle Real.Angle.arg_expMapCircle
+
+namespace AddCircle
+
+variable {T : ℝ}
+
+/-! ### Map from `AddCircle` to `Circle` -/
+
+theorem scaled_exp_map_periodic : Function.Periodic (fun x => expMapCircle (2 * π / T * x)) T := by
+  -- The case T = 0 is not interesting, but it is true, so we prove it to save hypotheses
+  rcases eq_or_ne T 0 with (rfl | hT)
+  · intro x; simp
+  · intro x; simp_rw [mul_add]; rw [div_mul_cancel₀ _ hT, periodic_expMapCircle]
+#align add_circle.scaled_exp_map_periodic AddCircle.scaled_exp_map_periodic
+
+/-- The canonical map `fun x => exp (2 π i x / T)` from `ℝ / ℤ • T` to the unit circle in `ℂ`.
+If `T = 0` we understand this as the constant function 1. -/
+noncomputable def toCircle : AddCircle T → circle :=
+  (@scaled_exp_map_periodic T).lift
+#align add_circle.to_circle AddCircle.toCircle
+
+theorem toCircle_add (x : AddCircle T) (y : AddCircle T) :
+    @toCircle T (x + y) = toCircle x * toCircle y := by
+  induction x using QuotientAddGroup.induction_on'
+  induction y using QuotientAddGroup.induction_on'
+  rw [← QuotientAddGroup.mk_add]
+  simp_rw [toCircle, Function.Periodic.lift_coe, mul_add, expMapCircle_add]
+#align add_circle.to_circle_add AddCircle.toCircle_add
+
+theorem continuous_toCircle : Continuous (@toCircle T) :=
+  continuous_coinduced_dom.mpr (expMapCircle.continuous.comp <| continuous_const.mul continuous_id')
+#align add_circle.continuous_to_circle AddCircle.continuous_toCircle
+
+theorem injective_toCircle (hT : T ≠ 0) : Function.Injective (@toCircle T) := by
+  intro a b h
+  induction a using QuotientAddGroup.induction_on'
+  induction b using QuotientAddGroup.induction_on'
+  simp_rw [toCircle, Function.Periodic.lift_coe] at h
+  obtain ⟨m, hm⟩ := expMapCircle_eq_expMapCircle.mp h.symm
+  rw [QuotientAddGroup.eq]; simp_rw [AddSubgroup.mem_zmultiples_iff, zsmul_eq_mul]
+  use m
+  field_simp at hm
+  rw [← mul_right_inj' Real.two_pi_pos.ne']
+  linarith
+#align add_circle.injective_to_circle AddCircle.injective_toCircle
+
+end AddCircle


### PR DESCRIPTION
This PR moves `AddCircle.toCircle` to the earlier file `Analysis/SpecialFunctions/Complex/Circle` since `AddCircle.toCircle` only depends on `periodic_expMapCircle` and not the heavy imports of `Analysis/Fourier/AddCircle`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
