### PR TITLE
fix(Algebra.Algebra.Hom): simplify MulSemiringAction.toAlgHom term

### DIFF
--- a/Mathlib/Algebra/Algebra/Hom.lean
+++ b/Mathlib/Algebra/Algebra/Hom.lean
@@ -591,10 +591,9 @@ variable [Monoid M] [MulSemiringAction M A] [SMulCommClass M R A]
 
 This is a stronger version of `MulSemiringAction.toRingHom` and
 `DistribMulAction.toLinearMap`. -/
-@[simps]
+@[simps!]
 def toAlgHom (m : M) : A →ₐ[R] A :=
   { MulSemiringAction.toRingHom _ _ m with
-    toFun := fun a => m • a
     commutes' := smul_algebraMap _ }
 #align mul_semiring_action.to_alg_hom MulSemiringAction.toAlgHom
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This came from reviewing #11961 . On master right now we have
```lean
def MulSemiringAction.toAlgHom.{u_4, u_3, u_1} : [type] :=
fun {M} R A [CommSemiring R] [Semiring A] [Algebra R A] [Monoid M] [MulSemiringAction M A] [SMulCommClass M R A] m ↦
  let __src := toRingHom M A m;
  {
    toRingHom :=
      { toMonoidHom := { toOneHom := { toFun := fun a ↦ m • a, map_one' := ⋯ }, map_mul' := ⋯ }, map_zero' := ⋯,
        map_add' := ⋯ },
    commutes' := ⋯ }
```

and after this change it's

```lean
def MulSemiringAction.toAlgHom.{u_4, u_3, u_1} : [type] :=
fun {M} R A [CommSemiring R] [Semiring A] [Algebra R A] [Monoid M] [MulSemiringAction M A] [SMulCommClass M R A] m ↦
  let __src := toRingHom M A m;
  { toRingHom := __src, commutes' := ⋯ }
```

Isn't the latter what we're hoping for? Warning: I don't really know what I'm doing. If this is a step in the right direction then maybe #11961 needs to be changed accordingly.