### PR TITLE
feat: the `suffa` tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3709,6 +3709,7 @@ import Mathlib.Tactic.Spread
 import Mathlib.Tactic.Substs
 import Mathlib.Tactic.SuccessIfFailWithMsg
 import Mathlib.Tactic.SudoSetOption
+import Mathlib.Tactic.Suffa
 import Mathlib.Tactic.SuppressCompilation
 import Mathlib.Tactic.SwapVar
 import Mathlib.Tactic.TFAE

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -178,6 +178,7 @@ import Mathlib.Tactic.Spread
 import Mathlib.Tactic.Substs
 import Mathlib.Tactic.SuccessIfFailWithMsg
 import Mathlib.Tactic.SudoSetOption
+import Mathlib.Tactic.Suffa
 import Mathlib.Tactic.SuppressCompilation
 import Mathlib.Tactic.SwapVar
 import Mathlib.Tactic.TFAE

--- a/Mathlib/Tactic/Suffa.lean
+++ b/Mathlib/Tactic/Suffa.lean
@@ -83,8 +83,7 @@ elab "suffa " tk:"!"? tac:tacticSeq : tactic => do
                     | some _ => `(tactic| convert $ithis:term)
   let stxa : TSyntax ``tacticSeq := ⟨combine tac conclusion⟩
   let suffTac ← `(tacticSeq| suffices $stx by $stxa)
-  let sug : Suggestion := { suggestion := suffTac }
-  addSuggestion (← getRef) sug
+  addSuggestion (← getRef) { suggestion := suffTac }
   evalTactic tac
 
 macro "suffa!" tac:tacticSeq : tactic => `(tactic| suffa ! $tac)

--- a/Mathlib/Tactic/Suffa.lean
+++ b/Mathlib/Tactic/Suffa.lean
@@ -74,7 +74,7 @@ example {m n : Nat} (h : m = n) : 0 + m = n := by
   assumption
 ```
 -/
-elab "suffa " tk:"!"? tac:tacticSeq : tactic => do
+elab (name := suffaTac) "suffa " tk:"!"? tac:tacticSeq : tactic => do
   let finalTgt ← getTargetAfterTac tac
   let stx ← Meta.Tactic.TryThis.delabToRefinableSyntax finalTgt
   let ithis : Syntax.Term := ⟨mkIdent `this⟩
@@ -86,4 +86,5 @@ elab "suffa " tk:"!"? tac:tacticSeq : tactic => do
   addSuggestion (← getRef) { suggestion := suffTac }
   evalTactic tac
 
+@[inherit_doc suffaTac]
 macro "suffa!" tac:tacticSeq : tactic => `(tactic| suffa ! $tac)

--- a/Mathlib/Tactic/Suffa.lean
+++ b/Mathlib/Tactic/Suffa.lean
@@ -20,6 +20,7 @@ See the tactic docs for an example.
 * Better support for `fvar`s.
 * Allow `suff ... at ...`?
 * Allow `suff_all ...`?
+* If the last tactic in the sequence is `simp`, use `simpa` in the suggestion?
 -/
 
 namespace Mathlib.Tactic.Suffa

--- a/Mathlib/Tactic/Suffa.lean
+++ b/Mathlib/Tactic/Suffa.lean
@@ -12,6 +12,11 @@ import Lean.Meta.Tactic.TryThis
 of the form `suffices [target_after_tac] by tac; assumption`.
 
 See the tactic docs for an example.
+
+##  TODO
+* Better support for `fvar`s.
+* Allow `suff ... at ...`?
+* Allow `suff_all ...`?
 -/
 
 namespace Mathlib.Tactic.Suffa
@@ -66,7 +71,7 @@ example {m n : Nat} (h : m = n) : 0 + m = n := by
 elab "suffa " tac:tacticSeq : tactic => do
   let finalTgt ← getTargetAfterTac tac
   let stx ← Meta.Tactic.TryThis.delabToRefinableSyntax finalTgt
-  let stxa : TSyntax ``tacticSeq := ⟨combine tac (← `(tactic| assumption))⟩
+  let stxa : TSyntax ``tacticSeq := ⟨combine tac (← `(tactic| exact $(mkIdent `this)))⟩
   let suffTac ← `(tacticSeq| suffices $stx by $stxa)
   let sug : Suggestion := { suggestion := suffTac }
   addSuggestion (← getRef) sug

--- a/Mathlib/Tactic/Suffa.lean
+++ b/Mathlib/Tactic/Suffa.lean
@@ -69,7 +69,7 @@ suggests the replacement
 example {m n : Nat} (h : m = n) : 0 + m = n := by
   suffices m = n by
       rewrite [Nat.zero_add]
-      assumption
+      exact this
   assumption
 ```
 -/

--- a/Mathlib/Tactic/Suffa.lean
+++ b/Mathlib/Tactic/Suffa.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2024 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+import Lean.Meta.Tactic.TryThis
+
+/-!
+#  The `suffa` tactic
+
+`suffa tac` runs the tactic sequence `tac` and returns a `Try this:` suggestion
+of the form `suffices [target_after_tac] by tac; assumption`.
+
+See the tactic docs for an example.
+-/
+
+namespace Mathlib.Tactic.Suffa
+
+open Lean Parser.Tactic in
+/-- combines two `Syntaxes` `t1 t2`, assuming that
+* `t1` is a `tacticSeq` and
+* `t2` is a single tactic to be added as a tail of `t1`.
+
+Returns `t1` otherwise.
+-/
+def combine (t1 t2 : Syntax) : Syntax :=
+  -- we check if `t1` is a `tacticSeq` and further split on whether it ends in `;` or not
+  match t1 with
+    | .node n1 ``tacticSeq #[.node n2 ``tacticSeq1Indented #[.node n3 `null args]] =>
+      let nargs := (if args.size % 2 == 0 then args else args.push mkNullNode).push t2
+      .node n1 ``tacticSeq #[.node n2 ``tacticSeq1Indented #[.node n3 `null nargs]]
+    | _ => t1
+
+open Lean Parser Elab Tactic
+
+variable (tac : TSyntax `Lean.Parser.Tactic.tacticSeq) in
+/--
+Run a tactic, optionally restoring the original state, and report the final target expression.
+-/
+def getTargetAfterTac (revert : Bool := true) : TacticM Expr := do
+  let s ← saveState
+  evalTactic tac
+  let tgt ← getMainTarget
+  if revert then restoreState s
+  return tgt
+
+open Meta.Tactic.TryThis in
+/-- `suffa tac` runs the tactic sequence `tac` and returns a `Try this:` suggestion
+of the form `suffices [target_after_tac] by tac; assumption`.
+
+For example
+```lean
+example {m n : Nat} (h : m = n) : 0 + m = n := by
+  suffa rewrite [Nat.zero_add]
+  assumption
+```
+suggests the replacement
+```lean
+example {m n : Nat} (h : m = n) : 0 + m = n := by
+  suffices m = n by
+      rewrite [Nat.zero_add]
+      assumption
+  assumption
+```
+-/
+elab "suffa " tac:tacticSeq : tactic => do
+  let finalTgt ← getTargetAfterTac tac
+  let stx ← Meta.Tactic.TryThis.delabToRefinableSyntax finalTgt
+  let stxa : TSyntax ``tacticSeq := ⟨combine tac (← `(tactic| assumption))⟩
+  let suffTac ← `(tacticSeq| suffices $stx by $stxa)
+  let sug : Suggestion := { suggestion := suffTac }
+  addSuggestion (← getRef) sug
+  evalTactic tac

--- a/test/Suffa.lean
+++ b/test/Suffa.lean
@@ -3,7 +3,7 @@ import Mathlib.Tactic.Suffa
 /--
 info: Try this: suffices 1 = 0 by
     rw [Nat.zero_add]
-    assumption
+    exact this
 -/
 #guard_msgs in
 example {h : False} : 0 + 1 = 0 := by
@@ -14,7 +14,7 @@ example {h : False} : 0 + 1 = 0 := by
 /--
 info: Try this: suffices False by
     rw [Nat.zero_add]
-    simp; assumption
+    simp; exact this
 -/
 #guard_msgs in
 example {h : False} : 0 + 1 = 0 := by
@@ -26,7 +26,7 @@ example {h : False} : 0 + 1 = 0 := by
 info: Try this: suffices False by
     rw [Nat.zero_add]
     simp
-    assumption
+    exact this
 -/
 #guard_msgs in
 example {h : False} : 0 + 1 = 0 := by

--- a/test/Suffa.lean
+++ b/test/Suffa.lean
@@ -1,0 +1,35 @@
+import Mathlib.Tactic.Suffa
+
+/--
+info: Try this: suffices 1 = 0 by
+    rw [Nat.zero_add]
+    assumption
+-/
+#guard_msgs in
+example {h : False} : 0 + 1 = 0 := by
+  suffa rw [Nat.zero_add]
+  simp;
+  exact h.elim
+
+/--
+info: Try this: suffices False by
+    rw [Nat.zero_add]
+    simp; assumption
+-/
+#guard_msgs in
+example {h : False} : 0 + 1 = 0 := by
+  suffa rw [Nat.zero_add]
+        simp;
+  exact h.elim
+
+/--
+info: Try this: suffices False by
+    rw [Nat.zero_add]
+    simp
+    assumption
+-/
+#guard_msgs in
+example {h : False} : 0 + 1 = 0 := by
+  suffa rw [Nat.zero_add]
+        simp
+  exact h.elim

--- a/test/Suffa.lean
+++ b/test/Suffa.lean
@@ -33,3 +33,37 @@ example {h : False} : 0 + 1 = 0 := by
   suffa rw [Nat.zero_add]
         simp
   exact h.elim
+
+/--
+info: Try this: suffices 1 = 0 by
+    rw [Nat.zero_add]
+    convert this
+-/
+#guard_msgs in
+example {h : False} : 0 + 1 = 0 := by
+  suffa! rw [Nat.zero_add]
+  simp;
+  exact h.elim
+
+/--
+info: Try this: suffices False by
+    rw [Nat.zero_add]
+    simp; convert this
+-/
+#guard_msgs in
+example {h : False} : 0 + 1 = 0 + 0 := by
+  suffa!  rw [Nat.zero_add]
+          simp;
+  exact h.elim
+
+/--
+info: Try this: suffices False by
+    rw [Nat.zero_add]
+    simp
+    convert this
+-/
+#guard_msgs in
+example {h : False} : 0 + 1 = 0 := by
+  suffa! rw [Nat.zero_add]
+         simp
+  exact h.elim


### PR DESCRIPTION
The `suffa` tactic.

`suffa tac` runs the tactic sequence `tac` and returns a `Try this:` suggestion
of the form `suffices [target_after_tac] by tac; assumption`.

For example
```lean
example {m n : Nat} (h : m = n) : 0 + m = n := by
  suffa rewrite [Nat.zero_add]
  assumption
```
suggests the replacement
```lean
example {m n : Nat} (h : m = n) : 0 + m = n := by
  suffices m = n by
      rewrite [Nat.zero_add]
      assumption
  assumption
```

See [this thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Try.20this.3A.20suffices.20simpa) as well as [this message](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2311822.20flexible.20tactics.20linter/near/431895664).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
