### PR TITLE
[Merged by Bors] - feat(Algebra/Lie): prove that IsKilling transfers by isomorphisms

### DIFF
--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -598,6 +598,9 @@ theorem one_apply (x : L₁) : (1 : L₁ ≃ₗ⁅R⁆ L₁) x = x :=
 instance : Inhabited (L₁ ≃ₗ⁅R⁆ L₁) :=
   ⟨1⟩
 
+lemma map_lie (e : L₁ ≃ₗ⁅R⁆ L₂) (x y : L₁) : e ⁅x, y⁆ = ⁅e x, e y⁆ :=
+  LieHom.map_lie e.toLieHom x y
+
 /-- Lie algebra equivalences are reflexive. -/
 def refl : L₁ ≃ₗ⁅R⁆ L₁ :=
   1

--- a/Mathlib/Algebra/Lie/Killing.lean
+++ b/Mathlib/Algebra/Lie/Killing.lean
@@ -592,6 +592,47 @@ lemma ker_weight_inf_rootSpaceProductNegSelf_eq_bot [CharZero K] (α : weight K 
 
 end IsKilling
 
+section LieAlgebraEquiv
+
+variable {R L L' : Type*} [Field R]
+  [LieRing L] [LieAlgebra R L]
+  [LieRing L'] [LieAlgebra R L']
+
+/-- Given an equivalence `e` of Lie algebras from `L` to `L'`, and elements `x y : L`, the
+respective Killing forms of `L` and `L'` satisfy `κ'(e x, e y) = κ(x, y)`. -/
+lemma killingForm_of_equiv_apply (e : L ≃ₗ⁅R⁆ L') (x y : L) :
+    killingForm R L' (e x) (e y) = killingForm R L x y := by
+  simp_rw [LieModule.traceForm_apply_apply]
+  rw [← ad, ← ad]
+  simp_rw [← LieAlgebra.conj_ad_apply]
+  rw [← LinearEquiv.conj_comp]
+  rw [LinearMap.trace_conj']
+
+/-- Given a Killing Lie algebra `L`, if `L'` is isomorphic to `L`, then `L'` is Killing too. -/
+lemma isKilling_of_equiv [h : IsKilling R L] (e : L ≃ₗ⁅R⁆ L') : IsKilling R L' := by
+  constructor
+  ext x'
+  rw [LieIdeal.mem_killingCompl]
+  constructor
+  case mp =>
+    intro hx'
+    -- Given x' in the kernel of the Killing form over L', we will use the hypothesis to show that
+    -- e⁻¹(x') is in the kernel of the Killing form over L, so is zero, x' is zero.
+    have hx : ∀ y ∈ (⊤ : Submodule R L), killingForm R L (e.symm x') y = 0 := by
+      intro y hy
+      rw [← killingForm_of_equiv_apply e]
+      rw [LieEquiv.apply_symm_apply]
+      exact hx' (e y) hy
+    apply (LieIdeal.mem_killingCompl R L ⊤).mpr at hx
+    rw [h.killingCompl_top_eq_bot] at hx
+    exact (LinearEquiv.map_eq_zero_iff e.symm.toLinearEquiv (x := x')).mp hx
+  case mpr =>
+    intro hx y _
+    rw [hx]
+    exact LinearMap.map_zero₂ (killingForm R L') y
+
+end LieAlgebraEquiv
+
 end LieAlgebra
 
 end Field

--- a/Mathlib/Algebra/Lie/Killing.lean
+++ b/Mathlib/Algebra/Lie/Killing.lean
@@ -592,7 +592,7 @@ lemma ker_weight_inf_rootSpaceProductNegSelf_eq_bot [CharZero K] (α : weight K 
 
 end IsKilling
 
-section LieAlgebraEquiv
+section LieEquiv
 
 variable {R L L' : Type*} [Field R]
   [LieRing L] [LieAlgebra R L]
@@ -631,7 +631,9 @@ lemma isKilling_of_equiv [h : IsKilling R L] (e : L ≃ₗ⁅R⁆ L') : IsKillin
     rw [hx]
     exact LinearMap.map_zero₂ (killingForm R L') y
 
-end LieAlgebraEquiv
+alias _root_.LieEquiv.isKilling := LieAlgebra.isKilling_of_equiv
+
+end LieEquiv
 
 end LieAlgebra
 

--- a/Mathlib/Algebra/Lie/OfAssociative.lean
+++ b/Mathlib/Algebra/Lie/OfAssociative.lean
@@ -429,10 +429,10 @@ open LieEquiv
 
 /-- Given an equivalence `e` of Lie algebras from `L` to `L'`, and an element `x : L`, the conjugate
 of the endomorphism `ad(x)` of `L` by `e` is the endomorphism `ad(e x)` of `L'`. -/
+@[simp]
 lemma conj_ad_apply (e : L ≃ₗ⁅R⁆ L') (x : L) : LinearEquiv.conj e (ad R L x) = ad R L' (e x) := by
   ext y'
-  rw [LinearEquiv.conj_apply_apply, ad_apply, ad_apply]
-  rw [coe_to_linearEquiv, ← coe_to_lieHom, LieHom.map_lie, coe_to_lieHom, ← coe_to_linearEquiv]
-  rw [LinearEquiv.apply_symm_apply]
+  rw [LinearEquiv.conj_apply_apply, ad_apply, ad_apply, coe_to_linearEquiv, map_lie,
+    ← coe_to_linearEquiv, LinearEquiv.apply_symm_apply]
 
 end LieAlgebra

--- a/Mathlib/Algebra/Lie/OfAssociative.lean
+++ b/Mathlib/Algebra/Lie/OfAssociative.lean
@@ -418,3 +418,21 @@ theorem toLieEquiv_symm_apply (x : A₂) : e.toLieEquiv.symm x = e.symm x :=
 #align alg_equiv.to_lie_equiv_symm_apply AlgEquiv.toLieEquiv_symm_apply
 
 end AlgEquiv
+
+namespace LieAlgebra
+
+variable {R L L' : Type*} [CommRing R]
+  [LieRing L] [LieAlgebra R L]
+  [LieRing L'] [LieAlgebra R L']
+
+open LieEquiv
+
+/-- Given an equivalence `e` of Lie algebras from `L` to `L'`, and an element `x : L`, the conjugate
+of the endomorphism `ad(x)` of `L` by `e` is the endomorphism `ad(e x)` of `L'`. -/
+lemma conj_ad_apply (e : L ≃ₗ⁅R⁆ L') (x : L) : LinearEquiv.conj e (ad R L x) = ad R L' (e x) := by
+  ext y'
+  rw [LinearEquiv.conj_apply_apply, ad_apply, ad_apply]
+  rw [coe_to_linearEquiv, ← coe_to_lieHom, LieHom.map_lie, coe_to_lieHom, ← coe_to_linearEquiv]
+  rw [LinearEquiv.apply_symm_apply]
+
+end LieAlgebra


### PR DESCRIPTION
This proves `isKilling_of_equiv`, which states that if a Lie algebra is isomorphic to a Killing Lie algebra, then it is Killing too.

This is a step towards the proof that all derivations over a finite dimensional semisimple Lie algebra are inner (see [this thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Derivations.20on.20Lie.20algebras)). Indeed, the proof that I have formalized relies on the fact that such a Lie algebra `L` is isomorphic to `ad(L)`, from which I want to infer that `ad(L)` is Killing.