### PR TITLE
[Merged by Bors] - feat: add the Loewner partial order on continuous linear maps on a Hilbert space

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Positive.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Positive.lean
@@ -125,4 +125,34 @@ theorem isPositive_iff_complex (T : E' →L[ℂ] E') :
 
 end Complex
 
+section PartialOrder
+
+/-- The (Loewner) partial order on continuous linear maps on a Hilbert space determined by
+`f ≤ g` if and only if `g - f` is a positive linear map (in the sense of
+`ContinuousLinearMap.IsPositive`). With this partial order, the continuous linear maps form a
+`StarOrderedRing`. -/
+instance instLoewnerPartialOrder : PartialOrder (E →L[𝕜] E) where
+  le f g := (g - f).IsPositive
+  le_refl _ := by simpa using isPositive_zero
+  le_trans _ _ _ h₁ h₂ := by simpa using h₁.add h₂
+  le_antisymm f₁ f₂ h₁ h₂ := by
+    rw [← sub_eq_zero]
+    have h_isSymm := isSelfAdjoint_iff_isSymmetric.mp h₂.isSelfAdjoint
+    exact_mod_cast h_isSymm.inner_map_self_eq_zero.mp fun x ↦ by
+      apply RCLike.ext
+      · rw [map_zero]
+        apply le_antisymm
+        · rw [← neg_nonneg, ← map_neg, ← inner_neg_left]
+          simpa using h₁.inner_nonneg_left _
+        · exact h₂.inner_nonneg_left _
+      · rw [coe_sub, LinearMap.sub_apply, coe_coe, coe_coe, map_zero, ← sub_apply,
+          ← h_isSymm.coe_reApplyInnerSelf_apply (T := f₁ - f₂) x, RCLike.ofReal_im]
+
+lemma le_def (f g : E →L[𝕜] E) : f ≤ g ↔ (g - f).IsPositive := Iff.rfl
+
+lemma nonneg_iff_isPositive (f : E →L[𝕜] E) : 0 ≤ f ↔ f.IsPositive := by
+  simpa using le_def 0 f
+
+end PartialOrder
+
 end ContinuousLinearMap


### PR DESCRIPTION
The (Loewner) partial order on continuous linear maps on a Hilbert space determined by `f ≤ g` if and only if `g - f` is a positive linear map (in the sense of `ContinuousLinearMap.IsPositive`). With this partial order, the continuous linear maps form a `StarOrderedRing`.

---

The fact that this forms a `StarOrderedRing` will be established in a future PR.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
