### PR TITLE
[Merged by Bors] - feat: bijectivity criteria for continuous linear maps

### DIFF
--- a/Mathlib/Analysis/NormedSpace/Banach.lean
+++ b/Mathlib/Analysis/NormedSpace/Banach.lean
@@ -5,7 +5,7 @@ Authors: Sébastien Gouëzel
 -/
 import Mathlib.Topology.Baire.Lemmas
 import Mathlib.Topology.Baire.CompleteMetrizable
-import Mathlib.Analysis.NormedSpace.OperatorNorm.Basic
+import Mathlib.Analysis.NormedSpace.OperatorNorm.NormedSpace
 import Mathlib.Analysis.NormedSpace.AffineIsometry
 import Mathlib.Analysis.Normed.Group.InfiniteSum
 
@@ -545,3 +545,43 @@ theorem coe_ofSeqClosedGraph
 end ContinuousLinearMap
 
 end ClosedGraphThm
+
+section BijectivityCriteria
+
+namespace ContinuousLinearMap
+
+variable [CompleteSpace E]
+
+lemma closed_range_of_antilipschitz {f : E →SL[σ] F} {c : ℝ≥0} (hf : AntilipschitzWith c f) :
+    (LinearMap.range f).topologicalClosure = LinearMap.range f :=
+  SetLike.ext'_iff.mpr <| (hf.isClosed_range f.uniformContinuous).closure_eq
+
+open Function
+lemma bijective_iff_dense_range_and_antilipschitz (f : E →SL[σ] F) :
+    Bijective f ↔ (LinearMap.range f).topologicalClosure = ⊤ ∧ ∃ c, AntilipschitzWith c f := by
+  refine ⟨fun h ↦ ⟨?eq_top, ?anti⟩, fun ⟨hd, c, hf⟩ ↦ ⟨hf.injective, ?surj⟩⟩
+  case eq_top => simpa [SetLike.ext'_iff] using h.2.denseRange.closure_eq
+  case anti =>
+    have := ContinuousLinearEquiv.ofBijective f ?_ ?_ |>.antilipschitz
+    · exact ⟨_, by simpa⟩
+    all_goals simp only [LinearMap.range_eq_top, LinearMapClass.ker_eq_bot]
+    exacts [h.1, h.2]
+  case surj => rwa [← LinearMap.range_eq_top, ← closed_range_of_antilipschitz hf]
+
+lemma _root_.AntilipschitzWith.completeSpace_range_clm {f : E →SL[σ] F} {c : ℝ≥0}
+    (hf : AntilipschitzWith c f) : CompleteSpace (LinearMap.range f) :=
+  IsClosed.completeSpace_coe <| hf.isClosed_range f.uniformContinuous
+
+lemma isUnit_iff_bijective {f : E →L[𝕜] E} : IsUnit f ↔ Bijective f := by
+  constructor
+  · rintro ⟨f, rfl⟩
+    exact ContinuousLinearEquiv.unitsEquiv 𝕜 E f |>.bijective
+  · intro h
+    let e := ContinuousLinearEquiv.ofBijective f ?_ ?_
+    · exact ⟨ContinuousLinearEquiv.unitsEquiv 𝕜 E |>.symm e, rfl⟩
+    all_goals simp only [LinearMap.range_eq_top, LinearMapClass.ker_eq_bot]
+    exacts [h.1, h.2]
+
+end ContinuousLinearMap
+
+end BijectivityCriteria

--- a/Mathlib/Analysis/NormedSpace/Banach.lean
+++ b/Mathlib/Analysis/NormedSpace/Banach.lean
@@ -411,6 +411,14 @@ theorem ofBijective_apply_symm_apply (f : E →SL[σ] F) (hinj : ker f = ⊥)
   (ofBijective f hinj hsurj).apply_symm_apply y
 #align continuous_linear_equiv.of_bijective_apply_symm_apply ContinuousLinearEquiv.ofBijective_apply_symm_apply
 
+lemma _root_.ContinuousLinearMap.isUnit_iff_bijective {f : E →L[𝕜] E} :
+    IsUnit f ↔ Bijective f := by
+  constructor
+  · rintro ⟨f, rfl⟩
+    exact ofUnit f |>.bijective
+  · refine fun h ↦ ⟨toUnit <| .ofBijective f ?_ ?_, rfl⟩ <;>
+    simp only [LinearMap.range_eq_top, LinearMapClass.ker_eq_bot, h.1, h.2]
+
 end ContinuousLinearEquiv
 
 namespace ContinuousLinearMap
@@ -569,14 +577,6 @@ lemma bijective_iff_dense_range_and_antilipschitz (f : E →SL[σ] F) :
 lemma _root_.AntilipschitzWith.completeSpace_range_clm {f : E →SL[σ] F} {c : ℝ≥0}
     (hf : AntilipschitzWith c f) : CompleteSpace (LinearMap.range f) :=
   IsClosed.completeSpace_coe <| hf.isClosed_range f.uniformContinuous
-
-lemma isUnit_iff_bijective {f : E →L[𝕜] E} : IsUnit f ↔ Bijective f := by
-  constructor
-  · rintro ⟨f, rfl⟩
-    exact ContinuousLinearEquiv.ofUnit f |>.bijective
-  · intro h
-    refine ⟨ContinuousLinearEquiv.toUnit <| .ofBijective f ?_ ?_, rfl⟩ <;>
-    simp only [LinearMap.range_eq_top, LinearMapClass.ker_eq_bot, h.1, h.2]
 
 end ContinuousLinearMap
 

--- a/Mathlib/Analysis/NormedSpace/Banach.lean
+++ b/Mathlib/Analysis/NormedSpace/Banach.lean
@@ -562,10 +562,8 @@ lemma bijective_iff_dense_range_and_antilipschitz (f : E →SL[σ] F) :
   refine ⟨fun h ↦ ⟨?eq_top, ?anti⟩, fun ⟨hd, c, hf⟩ ↦ ⟨hf.injective, ?surj⟩⟩
   case eq_top => simpa [SetLike.ext'_iff] using h.2.denseRange.closure_eq
   case anti =>
-    have := ContinuousLinearEquiv.ofBijective f ?_ ?_ |>.antilipschitz
-    · exact ⟨_, by simpa⟩
-    all_goals simp only [LinearMap.range_eq_top, LinearMapClass.ker_eq_bot]
-    exacts [h.1, h.2]
+    refine ⟨_, ContinuousLinearEquiv.ofBijective f ?_ ?_ |>.antilipschitz⟩ <;>
+    simp only [LinearMap.range_eq_top, LinearMapClass.ker_eq_bot, h.1, h.2]
   case surj => rwa [← LinearMap.range_eq_top, ← closed_range_of_antilipschitz hf]
 
 lemma _root_.AntilipschitzWith.completeSpace_range_clm {f : E →SL[σ] F} {c : ℝ≥0}
@@ -575,12 +573,10 @@ lemma _root_.AntilipschitzWith.completeSpace_range_clm {f : E →SL[σ] F} {c : 
 lemma isUnit_iff_bijective {f : E →L[𝕜] E} : IsUnit f ↔ Bijective f := by
   constructor
   · rintro ⟨f, rfl⟩
-    exact ContinuousLinearEquiv.unitsEquiv 𝕜 E f |>.bijective
+    exact ContinuousLinearEquiv.ofUnit f |>.bijective
   · intro h
-    let e := ContinuousLinearEquiv.ofBijective f ?_ ?_
-    · exact ⟨ContinuousLinearEquiv.unitsEquiv 𝕜 E |>.symm e, rfl⟩
-    all_goals simp only [LinearMap.range_eq_top, LinearMapClass.ker_eq_bot]
-    exacts [h.1, h.2]
+    refine ⟨ContinuousLinearEquiv.toUnit <| .ofBijective f ?_ ?_, rfl⟩ <;>
+    simp only [LinearMap.range_eq_top, LinearMapClass.ker_eq_bot, h.1, h.2]
 
 end ContinuousLinearMap
 


### PR DESCRIPTION
This establishes some common bijectivity criteria (antilipschitz and dense range) for continuous (semi)linear maps between Banach spaces.

---

The additional import was necessary because we're using `ContinuousLinearEquiv.antilipschitz`, but I couldn't think of a better file in which to place these results.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
