### PR TITLE
[Merged by Bors] - feat(CategoryTheory/CommSq): add basic CommSq lemmas

### DIFF
--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -78,7 +78,7 @@ theorem vert_inv {g : W ≅ Y} {h : X ≅ Z} (p : CommSq f g.hom h.hom i) :
 theorem horiz_inv {f : W ≅ X} {i : Y ≅ Z} (p : CommSq f.hom g h i.hom) :
     CommSq f.inv h g i.inv := flip (vert_inv (flip p))
 
-/-- The composite of two commutative squares as below is commutative.
+/-- The composite of two commutative squares as below is a commutative square.
 ```
   W ---f---> X ---f'--> X'
   |          |          |

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -87,9 +87,9 @@ theorem vert_inv {g : W ≅ Y} {h : X ≅ Z} (p : CommSq f g.hom h.hom i) :
 ```
 -/
 lemma CommSq_comp {W X X' Y Z Z' : C} {f : W ⟶ X} {f' : X ⟶ X'} {g : W ⟶ Y} {h : X ⟶ Z}
-  {h' : X' ⟶ Z'} {i : Y ⟶ Z} {i' : Z ⟶ Z'} (hsq₁ : CommSq f g h i) (hsq₂ : CommSq f' h h' i') :
-  CommSq (f ≫ f') g h' (i ≫ i') :=
-  ⟨by rw [←Category.assoc, Category.assoc, ←hsq₁.w, hsq₂.w, Category.assoc]⟩
+    {h' : X' ⟶ Z'} {i : Y ⟶ Z} {i' : Z ⟶ Z'} (hsq₁ : CommSq f g h i) (hsq₂ : CommSq f' h h' i') :
+    CommSq (f ≫ f') g h' (i ≫ i') :=
+  ⟨by rw [←Category.assoc, Category.assoc, ← hsq₁.w, hsq₂.w, Category.assoc]⟩
 
 /-- If the vertical morphisms of a commutative square are isomorphism, then we
   also get a commutative square by replacing them with there inverses -/

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -75,10 +75,13 @@ theorem vert_inv {g : W ≅ Y} {h : X ≅ Z} (p : CommSq f g.hom h.hom i) :
     CommSq i g.inv h.inv f :=
   ⟨by rw [Iso.comp_inv_eq, Category.assoc, Iso.eq_inv_comp, p.w]⟩
 
-/-- If the two inner squares below commute, then so does the outer square.
+theorem horiz_inv {f : W ≅ X} {i : Y ≅ Z} (p : CommSq f.hom g h i.hom) :
+    CommSq f.inv h g i.inv := flip (vert_inv (flip p))
+
+/-- The composite of two commutative squares as below is commutative.
 ```
   W ---f---> X ---f'--> X'
-  |          |         |
+  |          |          |
   g          h          h'
   |          |          |
   v          v          v
@@ -86,16 +89,10 @@ theorem vert_inv {g : W ≅ Y} {h : X ≅ Z} (p : CommSq f g.hom h.hom i) :
 
 ```
 -/
-lemma CommSq_comp {W X X' Y Z Z' : C} {f : W ⟶ X} {f' : X ⟶ X'} {g : W ⟶ Y} {h : X ⟶ Z}
+lemma comp {W X X' Y Z Z' : C} {f : W ⟶ X} {f' : X ⟶ X'} {g : W ⟶ Y} {h : X ⟶ Z}
     {h' : X' ⟶ Z'} {i : Y ⟶ Z} {i' : Z ⟶ Z'} (hsq₁ : CommSq f g h i) (hsq₂ : CommSq f' h h' i') :
     CommSq (f ≫ f') g h' (i ≫ i') :=
-  ⟨by rw [←Category.assoc, Category.assoc, ← hsq₁.w, hsq₂.w, Category.assoc]⟩
-
-/-- If the vertical morphisms of a commutative square are isomorphism, then we
-  also get a commutative square by replacing them with there inverses -/
-lemma CommSq_of_CommSq_of_vertical_isos (f : W ⟶ X) (i : Y ⟶ Z) (g : W ≅ Y) (h : X ≅ Z)
-    (hcomm : CommSq f g.hom h.hom i) : CommSq i g.inv h.inv f :=
-  ⟨by rw [Iso.comp_inv_eq, Category.assoc, Iso.eq_inv_comp]; exact hcomm.w.symm⟩
+  ⟨by rw [← Category.assoc, Category.assoc, ← hsq₁.w, hsq₂.w, Category.assoc]⟩
 
 end CommSq
 

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -76,7 +76,8 @@ theorem vert_inv {g : W ≅ Y} {h : X ≅ Z} (p : CommSq f g.hom h.hom i) :
   ⟨by rw [Iso.comp_inv_eq, Category.assoc, Iso.eq_inv_comp, p.w]⟩
 
 theorem horiz_inv {f : W ≅ X} {i : Y ≅ Z} (p : CommSq f.hom g h i.hom) :
-    CommSq f.inv h g i.inv := flip (vert_inv (flip p))
+    CommSq f.inv h g i.inv :=
+  flip (vert_inv (flip p))
 
 /-- The composite of two commutative squares as below is a commutative square.
 ```

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -90,10 +90,31 @@ theorem horiz_inv {f : W ≅ X} {i : Y ≅ Z} (p : CommSq f.hom g h i.hom) :
 
 ```
 -/
-lemma comp {W X X' Y Z Z' : C} {f : W ⟶ X} {f' : X ⟶ X'} {g : W ⟶ Y} {h : X ⟶ Z}
+lemma horiz_comp {W X X' Y Z Z' : C} {f : W ⟶ X} {f' : X ⟶ X'} {g : W ⟶ Y} {h : X ⟶ Z}
     {h' : X' ⟶ Z'} {i : Y ⟶ Z} {i' : Z ⟶ Z'} (hsq₁ : CommSq f g h i) (hsq₂ : CommSq f' h h' i') :
     CommSq (f ≫ f') g h' (i ≫ i') :=
   ⟨by rw [← Category.assoc, Category.assoc, ← hsq₁.w, hsq₂.w, Category.assoc]⟩
+
+/-- The composite of two commutative squares as below is a commutative square.
+```
+  W ---f---> X
+  |          |
+  g          h
+  |          |
+  v          v
+  Y ---i---> Z
+  |          |
+  g'         h'
+  |          |
+  v          v
+  Y'---i'--> Z'
+
+```
+-/
+lemma vert_comp {W X Y Y' Z Z' : C} {f : W ⟶ X} {g : W ⟶ Y} {g' : Y ⟶ Y'} {h : X ⟶ Z}
+    {h' : Z ⟶ Z'} {i : Y ⟶ Z} {i' : Y' ⟶ Z'} (hsq₁ : CommSq f g h i) (hsq₂ : CommSq i g' h' i') :
+    CommSq f (g ≫ g') (h ≫ h') i' :=
+  flip (horiz_comp (flip hsq₁) (flip hsq₂))
 
 end CommSq
 

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -79,7 +79,7 @@ theorem horiz_inv {f : W ≅ X} {i : Y ≅ Z} (p : CommSq f.hom g h i.hom) :
     CommSq f.inv h g i.inv :=
   flip (vert_inv (flip p))
 
-/-- The composite of two commutative squares as below is a commutative square.
+/-- The horizontal composition of two commutative squares as below is a commutative square.
 ```
   W ---f---> X ---f'--> X'
   |          |          |
@@ -95,7 +95,7 @@ lemma horiz_comp {W X X' Y Z Z' : C} {f : W ⟶ X} {f' : X ⟶ X'} {g : W ⟶ Y}
     CommSq (f ≫ f') g h' (i ≫ i') :=
   ⟨by rw [← Category.assoc, Category.assoc, ← hsq₁.w, hsq₂.w, Category.assoc]⟩
 
-/-- The composite of two commutative squares as below is a commutative square.
+/-- The vertical composition of two commutative squares as below is a commutative square.
 ```
   W ---f---> X
   |          |

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -97,8 +97,9 @@ lemma CommSq_of_CommSq_of_vertical_isos (f : W ⟶ X) (i : Y ⟶ Z) (g : W ≅ Y
     (hcomm : CommSq f g.hom h.hom i) : CommSq i g.inv h.inv f := by
   cases' hcomm with w
   constructor
-  rw [← @Iso.eq_comp_inv] at w
-  aesop_cat
+  rw [←@Iso.eq_comp_inv] at w
+  rw [Iso.eq_inv_comp, ←Category.assoc]
+  exact w.symm
 
 end CommSq
 

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -94,12 +94,8 @@ lemma CommSq_comp {W X X' Y Z Z' : C} {f : W ⟶ X} {f' : X ⟶ X'} {g : W ⟶ Y
 /-- If the vertical morphisms of a commutative square are isomorphism, then we
   also get a commutative square by replacing them with there inverses -/
 lemma CommSq_of_CommSq_of_vertical_isos (f : W ⟶ X) (i : Y ⟶ Z) (g : W ≅ Y) (h : X ≅ Z)
-    (hcomm : CommSq f g.hom h.hom i) : CommSq i g.inv h.inv f := by
-  cases' hcomm with w
-  constructor
-  rw [←@Iso.eq_comp_inv] at w
-  rw [Iso.eq_inv_comp, ←Category.assoc]
-  exact w.symm
+    (hcomm : CommSq f g.hom h.hom i) : CommSq i g.inv h.inv f :=
+  ⟨by rw [Iso.comp_inv_eq, Category.assoc, Iso.eq_inv_comp]; exact hcomm.w.symm⟩
 
 end CommSq
 

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -75,6 +75,31 @@ theorem vert_inv {g : W ≅ Y} {h : X ≅ Z} (p : CommSq f g.hom h.hom i) :
     CommSq i g.inv h.inv f :=
   ⟨by rw [Iso.comp_inv_eq, Category.assoc, Iso.eq_inv_comp, p.w]⟩
 
+/-- If the two inner squares below commute, then so does the outer square.
+```
+  W ---f---> X ---f'--> X'
+  |          |         |
+  g          h          h'
+  |          |          |
+  v          v          v
+  Y ---i---> Z ---i'--> Z'
+
+```
+-/
+lemma CommSq_comp {W X X' Y Z Z' : C} {f : W ⟶ X} {f' : X ⟶ X'} {g : W ⟶ Y} {h : X ⟶ Z}
+  {h' : X' ⟶ Z'} {i : Y ⟶ Z} {i' : Z ⟶ Z'} (hsq₁ : CommSq f g h i) (hsq₂ : CommSq f' h h' i') :
+  CommSq (f ≫ f') g h' (i ≫ i') :=
+  ⟨by rw [←Category.assoc, Category.assoc, ←hsq₁.w, hsq₂.w, Category.assoc]⟩
+
+/-- If the vertical morphisms of a commutative square are isomorphism, then we
+  also get a commutative square by replacing them with there inverses -/
+lemma CommSq_of_CommSq_of_vertical_isos (f : W ⟶ X) (i : Y ⟶ Z) (g : W ≅ Y) (h : X ≅ Z)
+    (hcomm : CommSq f g.hom h.hom i) : CommSq i g.inv h.inv f := by
+  cases' hcomm with w
+  constructor
+  rw [← @Iso.eq_comp_inv] at w
+  aesop_cat
+
 end CommSq
 
 namespace Functor


### PR DESCRIPTION
Add basic lemmas about CommSq:
-  Compositions of commutative squares are commutative
-  If the horizontal arrows of a commutative square are isomorphisms, then flipping these arrows also yields a commutative square.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
