### PR TITLE
[Merged by Bors] - feat(Limits/TypesFiltered): remove existence of colimit assumption

### DIFF
--- a/Mathlib/CategoryTheory/Limits/TypesFiltered.lean
+++ b/Mathlib/CategoryTheory/Limits/TypesFiltered.lean
@@ -79,6 +79,7 @@ noncomputable def isColimitOf (t : Cocone F) (hsurj : ∀ x : t.pt, ∃ i xi, x 
         dsimp
         nth_rw 1 [hf x]
         rw [← hm, types_comp_apply] }
+#align category_theory.limits.types.filtered_colimit.is_colimit_of CategoryTheory.Limits.Types.FilteredColimit.isColimitOf
 
 variable [IsFilteredOrEmpty J]
 

--- a/Mathlib/CategoryTheory/Limits/TypesFiltered.lean
+++ b/Mathlib/CategoryTheory/Limits/TypesFiltered.lean
@@ -57,39 +57,6 @@ theorem eqvGen_quot_rel_of_rel (x y : Σ j, F.obj j) :
 
 --attribute [local elab_without_expected_type] nat_trans.app
 
-/-- Recognizing filtered colimits of types (auxiliary definition). See
-`Limits.Types.FilteredColimit.isColimitOf` for a version without the `HasColimit F` assumption. -/
-noncomputable def isColimitOf' (t : Cocone F) (hsurj : ∀ x : t.pt, ∃ i xi, x = t.ι.app i xi)
-    (hinj :
-      ∀ i j xi xj,
-        t.ι.app i xi = t.ι.app j xj → ∃ (k : _) (f : i ⟶ k) (g : j ⟶ k), F.map f xi = F.map g xj) :
-    IsColimit t := by
-  -- Strategy: Prove that the map from "the" colimit of F (defined above) to t.X
-  -- is a bijection.
-  apply IsColimit.ofIsoColimit (colimit.isColimit F)
-  refine' Cocones.ext (Equiv.toIso (Equiv.ofBijective _ _)) _
-  · exact colimit.desc F t
-  · constructor
-    · show Function.Injective _
-      intro a b h
-      rcases jointly_surjective F (colimit.isColimit F) a with ⟨i, xi, rfl⟩
-      rcases jointly_surjective F (colimit.isColimit F) b with ⟨j, xj, rfl⟩
-      replace h : (colimit.ι F i ≫ colimit.desc F t) xi = (colimit.ι F j ≫ colimit.desc F t) xj := h
-      rw [colimit.ι_desc, colimit.ι_desc] at h
-      rcases hinj i j xi xj h with ⟨k, f, g, h'⟩
-      change colimit.ι F i xi = colimit.ι F j xj
-      rw [← colimit.w F f, ← colimit.w F g]
-      change colimit.ι F k (F.map f xi) = colimit.ι F k (F.map g xj)
-      rw [h']
-    · show Function.Surjective _
-      intro x
-      rcases hsurj x with ⟨i, xi, rfl⟩
-      use colimit.ι F i xi
-      apply Colimit.ι_desc_apply
-  · intro j
-    apply colimit.ι_desc
-#align category_theory.limits.types.filtered_colimit.is_colimit_of CategoryTheory.Limits.Types.FilteredColimit.isColimitOf'
-
 /-- Recognizing filtered colimits of types. -/
 noncomputable def isColimitOf (t : Cocone F) (hsurj : ∀ x : t.pt, ∃ i xi, x = t.ι.app i xi)
     (hinj :

--- a/Mathlib/CategoryTheory/Limits/TypesFiltered.lean
+++ b/Mathlib/CategoryTheory/Limits/TypesFiltered.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Reid Barton
 -/
+import Mathlib.CategoryTheory.Limits.Preserves.Basic
 import Mathlib.CategoryTheory.Limits.Types
 import Mathlib.CategoryTheory.Filtered.Basic
 
@@ -56,8 +57,9 @@ theorem eqvGen_quot_rel_of_rel (x y : Σ j, F.obj j) :
 
 --attribute [local elab_without_expected_type] nat_trans.app
 
-/-- Recognizing filtered colimits of types. -/
-noncomputable def isColimitOf (t : Cocone F) (hsurj : ∀ x : t.pt, ∃ i xi, x = t.ι.app i xi)
+/-- Recognizing filtered colimits of types (auxiliary definition). See
+`Limits.Types.FilteredColimit.isColimitOf` for a version without the `HasColimit F` assumption. -/
+noncomputable def isColimitOf' (t : Cocone F) (hsurj : ∀ x : t.pt, ∃ i xi, x = t.ι.app i xi)
     (hinj :
       ∀ i j xi xj,
         t.ι.app i xi = t.ι.app j xj → ∃ (k : _) (f : i ⟶ k) (g : j ⟶ k), F.map f xi = F.map g xj) :
@@ -86,7 +88,24 @@ noncomputable def isColimitOf (t : Cocone F) (hsurj : ∀ x : t.pt, ∃ i xi, x 
       apply Colimit.ι_desc_apply
   · intro j
     apply colimit.ι_desc
-#align category_theory.limits.types.filtered_colimit.is_colimit_of CategoryTheory.Limits.Types.FilteredColimit.isColimitOf
+#align category_theory.limits.types.filtered_colimit.is_colimit_of CategoryTheory.Limits.Types.FilteredColimit.isColimitOf'
+
+/-- Recognizing filtered colimits of types. -/
+noncomputable def isColimitOf (t : Cocone F) (hsurj : ∀ x : t.pt, ∃ i xi, x = t.ι.app i xi)
+    (hinj :
+      ∀ i j xi xj,
+        t.ι.app i xi = t.ι.app j xj → ∃ (k : _) (f : i ⟶ k) (g : j ⟶ k), F.map f xi = F.map g xj) :
+    IsColimit t := by
+  apply isColimitOfReflects (uliftFunctor.{max v u, u})
+  apply Types.FilteredColimit.isColimitOf'.{v, max v u, w}
+    (F ⋙ uliftFunctor.{max v u, u}) (uliftFunctor.mapCocone t)
+  · intro (x : ULift t.pt)
+    obtain ⟨i, xi, h⟩ := hsurj x.down
+    exact ⟨i, ULift.up xi, congrArg ULift.up h⟩
+  · intro i j (xi : ULift (F.obj i)) (xj : ULift (F.obj j))
+      (h : ULift.up (t.ι.app i xi.down) = ULift.up (t.ι.app j xj.down))
+    obtain ⟨k, f, g, hfg⟩ := hinj i j xi.down xj.down (congrArg ULift.down h)
+    exact ⟨k, f, g, congrArg ULift.up hfg⟩
 
 variable [IsFilteredOrEmpty J]
 

--- a/Mathlib/CategoryTheory/Limits/TypesFiltered.lean
+++ b/Mathlib/CategoryTheory/Limits/TypesFiltered.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Reid Barton
 -/
-import Mathlib.CategoryTheory.Limits.Preserves.Basic
 import Mathlib.CategoryTheory.Limits.Types
 import Mathlib.CategoryTheory.Filtered.Basic
 

--- a/Mathlib/CategoryTheory/Limits/TypesFiltered.lean
+++ b/Mathlib/CategoryTheory/Limits/TypesFiltered.lean
@@ -96,16 +96,23 @@ noncomputable def isColimitOf (t : Cocone F) (hsurj : ∀ x : t.pt, ∃ i xi, x 
       ∀ i j xi xj,
         t.ι.app i xi = t.ι.app j xj → ∃ (k : _) (f : i ⟶ k) (g : j ⟶ k), F.map f xi = F.map g xj) :
     IsColimit t := by
-  apply isColimitOfReflects (uliftFunctor.{max v u, u})
-  apply Types.FilteredColimit.isColimitOf'.{v, max v u, w}
-    (F ⋙ uliftFunctor.{max v u, u}) (uliftFunctor.mapCocone t)
-  · intro (x : ULift t.pt)
-    obtain ⟨i, xi, h⟩ := hsurj x.down
-    exact ⟨i, ULift.up xi, congrArg ULift.up h⟩
-  · intro i j (xi : ULift (F.obj i)) (xj : ULift (F.obj j))
-      (h : ULift.up (t.ι.app i xi.down) = ULift.up (t.ι.app j xj.down))
-    obtain ⟨k, f, g, hfg⟩ := hinj i j xi.down xj.down (congrArg ULift.down h)
-    exact ⟨k, f, g, congrArg ULift.up hfg⟩
+  let α : t.pt → J := fun x => (hsurj x).choose
+  let f : ∀ (x : t.pt), F.obj (α x) := fun x => (hsurj x).choose_spec.choose
+  have hf : ∀ (x : t.pt), x = t.ι.app _ (f x) := fun x => (hsurj x).choose_spec.choose_spec
+  exact
+    { desc := fun s x => s.ι.app _ (f x)
+      fac := fun s j => by
+        ext y
+        obtain ⟨k, l, g, eq⟩ := hinj _ _ _ _ (hf (t.ι.app j y))
+        have h := congr_fun (s.ι.naturality g) (f (t.ι.app j y))
+        have h' := congr_fun (s.ι.naturality l) y
+        dsimp at h h' ⊢
+        rw [← h, ← eq, h']
+      uniq := fun s m hm => by
+        ext x
+        dsimp
+        nth_rw 1 [hf x]
+        rw [← hm, types_comp_apply] }
 
 variable [IsFilteredOrEmpty J]
 


### PR DESCRIPTION
Removes a `HasColimit F` assumption in recognition of filtered colimits in category of types.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
