### PR TITLE
[Merged by Bors] - ci: don't use 'return' in github action

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -260,7 +260,8 @@ jobs:
         run: |
           grep --after-context=1 "stdout" stdout.log && ret=0
           grep --after-context=1 "stderr" stdout.log && new=0
-          if [ "${ret}" == "0" ] || [ "${new}"  == "0" ]; then return 1; fi
+          if [ "${ret}" == "0" ] || [ "${new}"  == "0" ]; then exit 1; fi
+
       - name: check declarations in db files
         run: |
           python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,7 +267,8 @@ jobs:
         run: |
           grep --after-context=1 "stdout" stdout.log && ret=0
           grep --after-context=1 "stderr" stdout.log && new=0
-          if [ "${ret}" == "0" ] || [ "${new}"  == "0" ]; then return 1; fi
+          if [ "${ret}" == "0" ] || [ "${new}"  == "0" ]; then exit 1; fi
+
       - name: check declarations in db files
         run: |
           python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -246,7 +246,8 @@ jobs:
         run: |
           grep --after-context=1 "stdout" stdout.log && ret=0
           grep --after-context=1 "stderr" stdout.log && new=0
-          if [ "${ret}" == "0" ] || [ "${new}"  == "0" ]; then return 1; fi
+          if [ "${ret}" == "0" ] || [ "${new}"  == "0" ]; then exit 1; fi
+
       - name: check declarations in db files
         run: |
           python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -264,7 +264,8 @@ jobs:
         run: |
           grep --after-context=1 "stdout" stdout.log && ret=0
           grep --after-context=1 "stderr" stdout.log && new=0
-          if [ "${ret}" == "0" ] || [ "${new}"  == "0" ]; then return 1; fi
+          if [ "${ret}" == "0" ] || [ "${new}"  == "0" ]; then exit 1; fi
+
       - name: check declarations in db files
         run: |
           python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml


### PR DESCRIPTION
This causes an error:

line 3: return: can only `return' from a function or sourced script

which means we do report a failure as expected, but in a roundabout way.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Tested in https://github.com/leanprover-community/mathlib4/actions/runs/8627784129/job/23648431755

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
