### PR TITLE
[Merged by Bors] - refactor(LinearAlgebra): replace Submodule.restrictBilinear by BilinForm.restrict

### DIFF
--- a/Mathlib/Algebra/Module/Submodule/Bilinear.lean
+++ b/Mathlib/Algebra/Module/Submodule/Bilinear.lean
@@ -168,17 +168,3 @@ theorem map₂_span_singleton_eq_map_flip (f : M →ₗ[R] N →ₗ[R] P) (s : S
 #align submodule.map₂_span_singleton_eq_map_flip Submodule.map₂_span_singleton_eq_map_flip
 
 end Submodule
-
-lemma LinearMap.ker_restrictBilinear_eq_of_codisjoint
-    {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
-    {p q : Submodule R M} (hpq : Codisjoint p q)
-    {B : LinearMap.BilinForm R M} (hB : ∀ x ∈ p, ∀ y ∈ q, B x y = 0) :
-    LinearMap.ker (p.restrictBilinear B) = (LinearMap.ker B).comap p.subtype := by
-  ext ⟨z, hz⟩
-  simp only [LinearMap.mem_ker, Submodule.mem_comap, Submodule.coeSubtype]
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · ext w
-    obtain ⟨x, hx, y, hy, rfl⟩ := Submodule.exists_add_eq_of_codisjoint hpq w
-    simpa [hB z hz y hy] using LinearMap.congr_fun h ⟨x, hx⟩
-  · ext ⟨x, hx⟩
-    simpa using LinearMap.congr_fun h x

--- a/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
@@ -273,7 +273,7 @@ end flip
 
 /-- The restriction of a bilinear form on a submodule. -/
 @[simps! apply]
-abbrev restrict (B : BilinForm R M) (W : Submodule R M) : BilinForm R W :=
+def restrict (B : BilinForm R M) (W : Submodule R M) : BilinForm R W :=
   LinearMap.domRestrict₁₂ B W W
 #align bilin_form.restrict LinearMap.BilinForm.restrict
 

--- a/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
@@ -265,15 +265,15 @@ theorem flip_flip :
 
 /-- The `flip` of a bilinear form over a commutative ring, obtained by exchanging the left and
 right arguments. -/
-abbrev flip : BilinForm R M ≃ₗ[R] BilinForm R M :=
-  flipHom
+abbrev flip (B : BilinForm R M) :=
+  flipHom B
 #align bilin_form.flip LinearMap.BilinForm.flip
 
 end flip
 
 /-- The restriction of a bilinear form on a submodule. -/
 @[simps! apply]
-def restrict (B : BilinForm R M) (W : Submodule R M) : BilinForm R W :=
+abbrev restrict (B : BilinForm R M) (W : Submodule R M) : BilinForm R W :=
   LinearMap.domRestrict₁₂ B W W
 #align bilin_form.restrict LinearMap.BilinForm.restrict
 

--- a/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -302,6 +302,18 @@ theorem toLin_restrict_range_dualCoannihilator_eq_orthogonal (B : BilinForm K V)
     exact hx w hw
 #align bilin_form.to_lin_restrict_range_dual_coannihilator_eq_orthogonal LinearMap.BilinForm.toLin_restrict_range_dualCoannihilator_eq_orthogonal
 
+lemma ker_restrict_eq_of_codisjoint {p q : Submodule R M} (hpq : Codisjoint p q)
+    {B : LinearMap.BilinForm R M} (hB : ∀ x ∈ p, ∀ y ∈ q, B x y = 0) :
+    LinearMap.ker (B.restrict p) = (LinearMap.ker B).comap p.subtype := by
+  ext ⟨z, hz⟩
+  simp only [LinearMap.mem_ker, Submodule.mem_comap, Submodule.coeSubtype]
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · ext w
+    obtain ⟨x, hx, y, hy, rfl⟩ := Submodule.exists_add_eq_of_codisjoint hpq w
+    simpa [hB z hz y hy] using LinearMap.congr_fun h ⟨x, hx⟩
+  · ext ⟨x, hx⟩
+    simpa using LinearMap.congr_fun h x
+
 variable [FiniteDimensional K V]
 
 open FiniteDimensional Submodule

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -403,15 +403,8 @@ theorem lsmul_apply (r : R) (m : M) : lsmul R M r m = r • m := rfl
 #align linear_map.lsmul_apply LinearMap.lsmul_apply
 
 variable (R M) in
-/-- For convenience, a shorthand for the type of bilinear forms from `M` to `R`.
-
-This should eventually replace `_root_.BilinForm`. -/
+/-- For convenience, a shorthand for the type of bilinear forms from `M` to `R`. -/
 protected abbrev BilinForm : Type _ := M →ₗ[R] M →ₗ[R] R
-
-/-- The restriction of a bilinear form to a submodule. -/
-abbrev _root_.Submodule.restrictBilinear (p : Submodule R M) (f : LinearMap.BilinForm R M) :
-    LinearMap.BilinForm R p :=
-  f.compl₁₂ p.subtype p.subtype
 
 end CommSemiring
 


### PR DESCRIPTION
As discussed in [this thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Next.20steps.20for.20BilinForm), there were 3 different definitions for the restriction of a bilinear form to a subspace. This PR deletes the definition `Submodule.restrictBilinear`, and replaces all its occurrences by the `LinearMap.BilinForm.restrict` one.


---


Surprisingly, I ran into issues with `BilinForm.flip` when performing this refactoring (if someone can explain ...). After quite some amount of fiddling, I ended up with what I think is a good enough solution (see commit). In particular, I had to change the `ker_restrict_eq_of_codisjoint` lemma to another file which seems better suited now.

Also, I did not change `LinearMap.BilinForm.restrict` to be an `abbrev` (instead of `def`) of `LinearMap.domRestrict₁₂`, because GitHub Actions complained about the `@[simps! apply]` annotation in this case.