### PR TITLE
[Merged by Bors] - feat: translations of ample sets are ample

### DIFF
--- a/Mathlib/Analysis/Convex/AmpleSet.lean
+++ b/Mathlib/Analysis/Convex/AmpleSet.lean
@@ -91,7 +91,7 @@ theorem image_iff {s : Set E} (L : E ≃ᵃL[ℝ] F) :
     AmpleSet (L '' s) ↔ AmpleSet s :=
   ⟨fun h ↦ (L.symm_image_image s) ▸ h.image L.symm, fun h ↦ h.image L⟩
 
-/-- Preimages of ample sets under continuous affine equivalences are ample. -/
+/-- Pre-images of ample sets under continuous affine equivalences are ample. -/
 theorem preimage {s : Set F} (h : AmpleSet s) (L : E ≃ᵃL[ℝ] F) : AmpleSet (L ⁻¹' s) := by
   rw [← L.image_symm_eq_preimage]
   exact h.image L.symm
@@ -108,6 +108,7 @@ theorem vadd [ContinuousAdd E] {s : Set E} (h : AmpleSet s) {y : E} :
     AmpleSet (y +ᵥ s) :=
   h.image (ContinuousAffineEquiv.constVAdd ℝ E y)
 
+/-- A set is ample iff its affine translation is. -/
 theorem vadd_iff [ContinuousAdd E] {s : Set E} {y : E} :
     AmpleSet (y +ᵥ s) ↔ AmpleSet s :=
   AmpleSet.image_iff (ContinuousAffineEquiv.constVAdd ℝ E y)

--- a/Mathlib/Analysis/Convex/AmpleSet.lean
+++ b/Mathlib/Analysis/Convex/AmpleSet.lean
@@ -100,13 +100,12 @@ theorem AmpleSet.preimage_iff {s : Set F} (L : E ≃ᵃL[ℝ] F) :
   ⟨fun h ↦ L.image_preimage s ▸ h.image L, fun h ↦ h.preimage L⟩
 
 open scoped Pointwise
+
 /-- Affine translations of ample sets are ample. -/
 theorem AmpleSet.vadd [ContinuousAdd E] {s : Set E} (h : AmpleSet s) {y : E} :
     AmpleSet (y +ᵥ s) :=
   h.image (ContinuousAffineEquiv.constVAdd ℝ E y)
 
 theorem AmpleSet.vadd_iff [ContinuousAdd E] {s : Set E} {y : E} :
-    AmpleSet (y +ᵥ s) ↔ AmpleSet s := by
-  refine ⟨fun h ↦ ?_, fun h ↦ h.vadd⟩
-  convert h.vadd (E := E) (y := -y)
-  rw [neg_vadd_vadd]
+    AmpleSet (y +ᵥ s) ↔ AmpleSet s := 
+  AmpleSet.image_iff (ContinuousAffineEquiv.constVAdd ℝ E y)

--- a/Mathlib/Analysis/Convex/AmpleSet.lean
+++ b/Mathlib/Analysis/Convex/AmpleSet.lean
@@ -60,8 +60,10 @@ theorem ampleSet_univ {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F] :
 @[simp]
 theorem ampleSet_empty : AmpleSet (∅ : Set F) := fun _ ↦ False.elim
 
+namespace AmpleSet
+
 /-- The union of two ample sets is ample. -/
-theorem AmpleSet.union {s t : Set F} (hs : AmpleSet s) (ht : AmpleSet t) : AmpleSet (s ∪ t) := by
+theorem union {s t : Set F} (hs : AmpleSet s) (ht : AmpleSet t) : AmpleSet (s ∪ t) := by
   intro x hx
   rcases hx with (h | h) <;>
   -- The connected component of `x ∈ s` in `s ∪ t` contains the connected component of `x` in `s`,
@@ -75,7 +77,7 @@ theorem AmpleSet.union {s t : Set F} (hs : AmpleSet s) (ht : AmpleSet t) : Ample
 variable {E : Type*} [AddCommGroup E] [Module ℝ E] [TopologicalSpace E]
 
 /-- Images of ample sets under continuous affine equivalences are ample. -/
-theorem AmpleSet.image {s : Set E} (h : AmpleSet s) (L : E ≃ᵃL[ℝ] F) :
+theorem image {s : Set E} (h : AmpleSet s) (L : E ≃ᵃL[ℝ] F) :
     AmpleSet (L '' s) := forall_mem_image.mpr fun x hx ↦
   calc (convexHull ℝ) (connectedComponentIn (L '' s) (L x))
     _ = (convexHull ℝ) (L '' (connectedComponentIn s x)) :=
@@ -85,27 +87,29 @@ theorem AmpleSet.image {s : Set E} (h : AmpleSet s) (L : E ≃ᵃL[ℝ] F) :
     _ = univ := by rw [h x hx, image_univ, L.surjective.range_eq]
 
 /-- A set is ample iff its image under a continuous affine equivalence is. -/
-theorem AmpleSet.image_iff {s : Set E} (L : E ≃ᵃL[ℝ] F) :
+theorem image_iff {s : Set E} (L : E ≃ᵃL[ℝ] F) :
     AmpleSet (L '' s) ↔ AmpleSet s :=
   ⟨fun h ↦ (L.symm_image_image s) ▸ h.image L.symm, fun h ↦ h.image L⟩
 
 /-- Preimages of ample sets under continuous affine equivalences are ample. -/
-theorem AmpleSet.preimage {s : Set F} (h : AmpleSet s) (L : E ≃ᵃL[ℝ] F) : AmpleSet (L ⁻¹' s) := by
+theorem preimage {s : Set F} (h : AmpleSet s) (L : E ≃ᵃL[ℝ] F) : AmpleSet (L ⁻¹' s) := by
   rw [← L.image_symm_eq_preimage]
   exact h.image L.symm
 
 /-- A set is ample iff its pre-image under a continuous affine equivalence is. -/
-theorem AmpleSet.preimage_iff {s : Set F} (L : E ≃ᵃL[ℝ] F) :
+theorem preimage_iff {s : Set F} (L : E ≃ᵃL[ℝ] F) :
     AmpleSet (L ⁻¹' s) ↔ AmpleSet s :=
   ⟨fun h ↦ L.image_preimage s ▸ h.image L, fun h ↦ h.preimage L⟩
 
 open scoped Pointwise
 
 /-- Affine translations of ample sets are ample. -/
-theorem AmpleSet.vadd [ContinuousAdd E] {s : Set E} (h : AmpleSet s) {y : E} :
+theorem vadd [ContinuousAdd E] {s : Set E} (h : AmpleSet s) {y : E} :
     AmpleSet (y +ᵥ s) :=
   h.image (ContinuousAffineEquiv.constVAdd ℝ E y)
 
-theorem AmpleSet.vadd_iff [ContinuousAdd E] {s : Set E} {y : E} :
-    AmpleSet (y +ᵥ s) ↔ AmpleSet s := 
+theorem vadd_iff [ContinuousAdd E] {s : Set E} {y : E} :
+    AmpleSet (y +ᵥ s) ↔ AmpleSet s :=
   AmpleSet.image_iff (ContinuousAffineEquiv.constVAdd ℝ E y)
+
+end AmpleSet

--- a/Mathlib/Analysis/Convex/AmpleSet.lean
+++ b/Mathlib/Analysis/Convex/AmpleSet.lean
@@ -104,3 +104,9 @@ open scoped Pointwise
 theorem AmpleSet.vadd [ContinuousAdd E] {s : Set E} (h : AmpleSet s) {y : E} :
     AmpleSet (y +ᵥ s) :=
   h.image (ContinuousAffineEquiv.constVAdd ℝ E y)
+
+theorem AmpleSet.vadd_iff [ContinuousAdd E] {s : Set E} {y : E} :
+    AmpleSet (y +ᵥ s) ↔ AmpleSet s := by
+  refine ⟨fun h ↦ ?_, fun h ↦ h.vadd⟩
+  convert h.vadd (E := E) (y := -y)
+  rw [neg_vadd_vadd]

--- a/Mathlib/Analysis/Convex/AmpleSet.lean
+++ b/Mathlib/Analysis/Convex/AmpleSet.lean
@@ -16,7 +16,8 @@ differential relations.
 ## Main results
 - `ampleSet_empty` and `ampleSet_univ`: the empty set and `univ` are ample
 - `AmpleSet.union`: the union of two ample sets is ample
-- `AmpleSet.{pre}image`: being ample is invariant under continuous affine equivalences
+- `AmpleSet.{pre}image`: being ample is invariant under continuous affine equivalences;
+  `AmpleSet.{pre}image_iff` are "iff" versions of these
 - `AmpleSet.vadd`: in particular, ample-ness is invariant under affine translations
 
 ## TODO
@@ -97,3 +98,9 @@ theorem AmpleSet.preimage {s : Set F} (h : AmpleSet s) (L : E ≃ᵃL[ℝ] F) : 
 theorem AmpleSet.preimage_iff {s : Set F} (L : E ≃ᵃL[ℝ] F) :
     AmpleSet (L ⁻¹' s) ↔ AmpleSet s :=
   ⟨fun h ↦ L.image_preimage s ▸ h.image L, fun h ↦ h.preimage L⟩
+
+open scoped Pointwise
+/-- Affine translations of ample sets are ample. -/
+theorem AmpleSet.vadd [ContinuousAdd E] {s : Set E} (h : AmpleSet s) {y : E} :
+    AmpleSet (y +ᵥ s) :=
+  h.image (ContinuousAffineEquiv.constVAdd ℝ E y)


### PR DESCRIPTION
This was supposed to be included in #11344, as even the module docstring shows

Inspired by the sphere-eversion project (but golfed and slightly extended).
Also, use namespace AmpleSet in the file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
