### PR TITLE
[Merged by Bors] - Typo correction in CantorSet.lean

### DIFF
--- a/Mathlib/Topology/Instances/CantorSet.lean
+++ b/Mathlib/Topology/Instances/CantorSet.lean
@@ -17,14 +17,14 @@ This file defines the Cantor ternary set and proves a few properties.
 ## Main Definitions
 
 * `preCantorSet n`: The order `n` pre-Cantor set, defined inductively as the union of the images
-  under the functions `(· / 3)` and `(2 * · / 3)`, with `preCantorSet 0 := Set.Icc 0 1`, i.e.
+  under the functions `(· / 3)` and `((2 + ·) / 3)`, with `preCantorSet 0 := Set.Icc 0 1`, i.e.
   `preCantorSet 0` is the unit interval [0,1].
 * `cantorSet`: The ternary Cantor set, defined as the intersection of all pre-Cantor sets.
 -/
 
 /-- The order `n` pre-Cantor set, defined starting from `[0, 1]` and successively removing the
     middle third of each interval. Formally, the order `n + 1` pre-Cantor set is the
-    union of the images under the functions `(· / 3)` and `(2 * · / 3)` of `preCantorSet n`.
+    union of the images under the functions `(· / 3)` and `((2 + ·) / 3)` of `preCantorSet n`.
 -/
 def preCantorSet : ℕ → Set ℝ
   | 0 => Set.Icc 0 1


### PR DESCRIPTION
Correcting a typo in a doc-string of CantorSet.lean where the function description did not match the formal specification.

---

Co-authored-by: Ruben Van de Velde <65514131+Ruben-VandeVelde@users.noreply.github.com>

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
