### PR TITLE
[Merged by Bors] - feat(NumberTheory/SmoothNumbers): add material on numbers with prime factors in a given Finset

### DIFF
--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -74,9 +74,10 @@ instance (s : Finset ℕ) : DecidablePred (· ∈ factoredNumbers s) :=
 
 /-- A number that divides an `s`-factored number is itself `s`-factored. -/
 lemma mem_factoredNumbers_of_dvd {s : Finset ℕ} {m k : ℕ} (h : m ∈ factoredNumbers s)
-    (h' : k ∣ m) (hk : k ≠ 0) :
+    (h' : k ∣ m) :
     k ∈ factoredNumbers s := by
   obtain ⟨h₁, h₂⟩ := h
+  have hk := ne_zero_of_dvd_ne_zero h₁ h'
   refine ⟨hk, fun p hp ↦ h₂ p ?_⟩
   rw [mem_factors <| by assumption] at hp ⊢
   exact ⟨hp.1, hp.2.trans h'⟩
@@ -249,10 +250,10 @@ instance (n : ℕ) : DecidablePred (· ∈ smoothNumbers n) :=
   inferInstanceAs <| DecidablePred fun x ↦ x ∈ {m | m ≠ 0 ∧ ∀ p ∈ factors m, p < n}
 
 /-- A number that divides an `n`-smooth number is itself `n`-smooth. -/
-lemma mem_smoothNumbers_of_dvd {n m k : ℕ} (h : m ∈ smoothNumbers n) (h' : k ∣ m) (hk : k ≠ 0) :
+lemma mem_smoothNumbers_of_dvd {n m k : ℕ} (h : m ∈ smoothNumbers n) (h' : k ∣ m) :
     k ∈ smoothNumbers n := by
   simp only [smoothNumbers_eq_factoredNumbers] at h ⊢
-  exact mem_factoredNumbers_of_dvd h h' hk
+  exact mem_factoredNumbers_of_dvd h h'
 
 /-- `m` is `n`-smooth if and only if `m` is nonzero and all prime divisors `≤ m` of `m`
 are less than `n`. -/
@@ -373,8 +374,7 @@ lemma smoothNumbersUpTo_card_add_roughNumbersUpTo_card (N k : ℕ) :
 lemma eq_prod_primes_mul_sq_of_mem_smoothNumbers {n k : ℕ} (h : n ∈ smoothNumbers k) :
     ∃ s ∈ k.primesBelow.powerset, ∃ m, n = m ^ 2 * (s.prod id) := by
   obtain ⟨l, m, H₁, H₂⟩ := sq_mul_squarefree n
-  have hl : l ∈ smoothNumbers k :=
-    mem_smoothNumbers_of_dvd h (Dvd.intro_left (m ^ 2) H₁) <| Squarefree.ne_zero H₂
+  have hl : l ∈ smoothNumbers k := mem_smoothNumbers_of_dvd h (Dvd.intro_left (m ^ 2) H₁)
   refine ⟨l.factors.toFinset, ?_,  m, ?_⟩
   · simp only [toFinset_factors, Finset.mem_powerset]
     refine fun p hp ↦ mem_primesBelow.mpr ⟨?_, (mem_primeFactors.mp hp).1⟩

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -429,7 +429,11 @@ lemma roughNumbersUpTo_eq_biUnion (N k) :
     fun h₁ h₂ h₃ ↦ (le_of_dvd (Nat.pos_of_ne_zero h₁) h₂).trans_lt h₃
   have H₂ : m ≠ 0 → p ∣ m → ¬ m < p :=
     fun h₁ h₂ ↦ not_lt.mpr <| le_of_dvd (Nat.pos_of_ne_zero h₁) h₂
-  tauto -- ~ 6300 heartbeats
+  constructor
+  · rintro ⟨h₁, h₂, _, h₄, h₅, h₆⟩
+    exact ⟨⟨⟨H₁ h₂ h₅ h₁, h₄⟩, fun h _ ↦ h₆ h⟩, h₁, h₂, h₅⟩
+  · rintro ⟨⟨⟨_, h₂⟩, h₃⟩, h₄, h₅, h₆⟩
+    exact ⟨h₄, h₅, H₂ h₅ h₆, h₂, h₆, fun h ↦ h₃ h h₂⟩
 
 /-- The cardinality of the set of `k`-rough numbers `≤ N` is bounded by the sum of `⌊N/p⌋`
 over the primes `k ≤ p ≤ N`. -/

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -361,11 +361,13 @@ lemma smoothNumbersUpTo_card_add_roughNumbersUpTo_card (N k : ℕ) :
     ← Finset.card_union_of_disjoint <| Finset.disjoint_filter.mpr fun n _ hn₂ h ↦ h.2 hn₂,
     Finset.filter_union_right]
   suffices Finset.card (Finset.filter (fun x ↦ x ≠ 0) (Finset.range (succ N))) = N by
-    convert this with n
-    have hn : n ∈ smoothNumbers k → n ≠ 0 := ne_zero_of_mem_smoothNumbers
-    tauto
+    have hn' (n) : n ∈ smoothNumbers k ∨ n ≠ 0 ∧ n ∉ smoothNumbers k ↔ n ≠ 0 := by
+      have : n ∈ smoothNumbers k → n ≠ 0 := ne_zero_of_mem_smoothNumbers
+      refine ⟨fun H ↦ Or.elim H this fun H ↦ H.1, fun H ↦ ?_⟩
+      simp only [ne_eq, H, not_false_eq_true, true_and, or_not]
+    rwa [Finset.filter_congr (s := Finset.range (succ N)) fun n _ ↦ hn' n]
   rw [Finset.filter_ne', Finset.card_erase_of_mem <| Finset.mem_range_succ_iff.mpr <| zero_le N]
-  simp
+  simp only [Finset.card_range, succ_sub_succ_eq_sub, tsub_zero]
 
 /-- A `k`-smooth number can be written as a square times a product of distinct primes `< k`. -/
 lemma eq_prod_primes_mul_sq_of_mem_smoothNumbers {n k : ℕ} (h : n ∈ smoothNumbers k) :
@@ -408,7 +410,8 @@ lemma smoothNumbersUpTo_card_le (N k : ℕ) :
     (smoothNumbersUpTo N k).card ≤ 2 ^ k.primesBelow.card * N.sqrt := by
   convert (Finset.card_le_card <| smoothNumbersUpTo_subset_image N k).trans <|
     Finset.card_image_le
-  simp
+  simp only [Finset.card_product, Finset.card_powerset, Finset.mem_range, zero_lt_succ,
+    Finset.card_erase_of_mem, Finset.card_range, succ_sub_succ_eq_sub, tsub_zero]
 
 /-- The set of `k`-rough numbers `≤ N` can be written as the union of the sets of multiples `≤ N`
 of primes `k ≤ p ≤ N`. -/
@@ -427,7 +430,7 @@ lemma roughNumbersUpTo_eq_biUnion (N k) :
     fun h₁ h₂ h₃ ↦ (le_of_dvd (Nat.pos_of_ne_zero h₁) h₂).trans_lt h₃
   have H₂ : m ≠ 0 → p ∣ m → ¬ m < p :=
     fun h₁ h₂ ↦ not_lt.mpr <| le_of_dvd (Nat.pos_of_ne_zero h₁) h₂
-  tauto
+  tauto -- ~ 6300 heartbeats
 
 /-- The cardinality of the set of `k`-rough numbers `≤ N` is bounded by the sum of `⌊N/p⌋`
 over the primes `k ≤ p ≤ N`. -/

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -89,7 +89,7 @@ lemma mem_factoredNumbers_iff_forall_le {s : Finset ℕ} {m : ℕ} :
   simp_rw [mem_factoredNumbers, mem_factors']
   exact ⟨fun ⟨H₀, H₁⟩ ↦ ⟨H₀, fun p _ hp₂ hp₃ ↦ H₁ p ⟨hp₂, hp₃, H₀⟩⟩,
     fun ⟨H₀, H₁⟩ ↦
-      ⟨H₀, fun p ⟨hp₁, hp₂, hp₃⟩ ↦ H₁ p (Nat.le_of_dvd (Nat.pos_of_ne_zero hp₃) hp₂) hp₁ hp₂⟩⟩
+      ⟨H₀, fun p ⟨hp₁, hp₂, hp₃⟩ ↦ H₁ p (le_of_dvd (Nat.pos_of_ne_zero hp₃) hp₂) hp₁ hp₂⟩⟩
 
 /-- `m` is `s`-factored if and only if all prime divisors of `m` are in `s`. -/
 lemma mem_factoredNumbers' {s : Finset ℕ} {m : ℕ} :
@@ -255,7 +255,7 @@ lemma mem_smoothNumbers_of_dvd {n m k : ℕ} (h : m ∈ smoothNumbers n) (h' : k
 
 /-- `m` is `n`-smooth if and only if `m` is nonzero and all prime divisors `≤ m` of `m`
 are less than `n`. -/
-lemma mem_smoothNumbers_iff_forall_le  {n m : ℕ} :
+lemma mem_smoothNumbers_iff_forall_le {n m : ℕ} :
     m ∈ smoothNumbers n ↔ m ≠ 0 ∧ ∀ p ≤ m, p.Prime → p ∣ m → p < n := by
   simp only [smoothNumbers_eq_factoredNumbers, mem_factoredNumbers_iff_forall_le, Finset.mem_range]
 

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -65,7 +65,7 @@ numbers all of whose prime factors are in `s`. -/
 def factoredNumbers (s : Finset ℕ) : Set ℕ := {m | m ≠ 0 ∧ ∀ p ∈ factors m, p ∈ s}
 
 lemma mem_factoredNumbers {s : Finset ℕ} {m : ℕ} :
-     m ∈ factoredNumbers s ↔ m ≠ 0 ∧ ∀ p ∈ factors m, p ∈ s :=
+    m ∈ factoredNumbers s ↔ m ≠ 0 ∧ ∀ p ∈ factors m, p ∈ s :=
   Iff.rfl
 
 /-- Membership in `Nat.factoredNumbers n` is decidable. -/
@@ -218,12 +218,12 @@ def equivProdNatFactoredNumbers {s : Finset ℕ} {p : ℕ} (hp: p.Prime) (hs : p
 
 @[simp]
 lemma equivProdNatFactoredNumbers_apply {s : Finset ℕ} {m p e : ℕ} (hp: p.Prime) (hs : p ∉ s)
-      (hm : m ∈ factoredNumbers s) :
+    (hm : m ∈ factoredNumbers s) :
     equivProdNatFactoredNumbers hp hs (e, ⟨m, hm⟩) = p ^ e * m := rfl
 
 @[simp]
 lemma equivProdNatFactoredNumbers_apply' {s : Finset ℕ} {p : ℕ} (hp: p.Prime) (hs : p ∉ s)
-      (x : ℕ × factoredNumbers s) :
+    (x : ℕ × factoredNumbers s) :
     equivProdNatFactoredNumbers hp hs x = p ^ x.1 * x.2 := rfl
 
 

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -97,9 +97,11 @@ lemma mem_factoredNumbers' {s : Finset ℕ} {m : ℕ} :
   obtain ⟨p, hp₁, hp₂⟩ := exists_infinite_primes (1 + Finset.sup s id)
   rw [mem_factoredNumbers_iff_forall_le]
   refine ⟨fun ⟨H₀, H₁⟩ ↦ fun p hp₁ hp₂ ↦ H₁ p (Nat.le_of_dvd (Nat.pos_of_ne_zero H₀) hp₂) hp₁ hp₂,
-         fun H ↦ ⟨fun h ↦ ?_, fun p _ ↦ H p⟩⟩
-  exact ((Finset.le_sup (f := @id ℕ) <| (H p hp₂ <| h.symm ▸ dvd_zero p)).trans_lt (lt_one_add _)
-            |>.trans_le hp₁).false
+         fun H ↦ ⟨fun h ↦ lt_irrefl p ?_, fun p _ ↦ H p⟩⟩
+  calc
+    p ≤ s.sup id := Finset.le_sup (f := @id ℕ) <| (H p hp₂ <| h.symm ▸ dvd_zero p)
+    _ < 1 + s.sup id := lt_one_add _
+    _ ≤ p := hp₁
 
 lemma ne_zero_of_mem_factoredNumbers {s : Finset ℕ} {m : ℕ} (h : m ∈ factoredNumbers s) : m ≠ 0 :=
   h.1

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -217,7 +217,7 @@ def equivProdNatFactoredNumbers {s : Finset ℕ} {p : ℕ} (hp: p.Prime) (hs : p
     exact filter_append_perm (· ∈ s) (factors m)
 
 @[simp]
-lemma equivProdNatFactoredNumbers_apply {s : Finset ℕ} {m p e : ℕ} (hp: p.Prime) (hs : p ∉ s)
+lemma equivProdNatFactoredNumbers_apply {s : Finset ℕ} {p e m : ℕ} (hp: p.Prime) (hs : p ∉ s)
     (hm : m ∈ factoredNumbers s) :
     equivProdNatFactoredNumbers hp hs (e, ⟨m, hm⟩) = p ^ e * m := rfl
 
@@ -335,14 +335,6 @@ lemma equivProdNatSmoothNumbers_apply {p e m : ℕ} (hp: p.Prime) (hm : m ∈ p.
 lemma equivProdNatSmoothNumbers_apply' {p : ℕ} (hp: p.Prime) (x : ℕ × p.smoothNumbers) :
     equivProdNatSmoothNumbers hp x = p ^ x.1 * x.2 := rfl
 
-/-- The `k`-smooth numbers up to and including `N` as a `Finset` -/
-def smoothNumbersUpTo (N k : ℕ) : Finset ℕ :=
-    (Finset.range N.succ).filter (· ∈ smoothNumbers k)
-
-lemma mem_smoothNumbersUpTo {N k n : ℕ} :
-    n ∈ smoothNumbersUpTo N k ↔ n ≤ N ∧ n ∈ smoothNumbers k := by
-  simp [smoothNumbersUpTo, lt_succ]
-
 
 /-!
 ### Smooth and rough numbers up to a bound
@@ -350,6 +342,14 @@ lemma mem_smoothNumbersUpTo {N k n : ℕ} :
 We consider the sets of smooth and non-smooth ("rough") positive natural numbers `≤ N`
 and prove bounds for their sizes.
 -/
+
+/-- The `k`-smooth numbers up to and including `N` as a `Finset` -/
+def smoothNumbersUpTo (N k : ℕ) : Finset ℕ :=
+    (Finset.range N.succ).filter (· ∈ smoothNumbers k)
+
+lemma mem_smoothNumbersUpTo {N k n : ℕ} :
+    n ∈ smoothNumbersUpTo N k ↔ n ≤ N ∧ n ∈ smoothNumbers k := by
+  simp [smoothNumbersUpTo, lt_succ]
 
 /-- The positive non-`k`-smooth (so "`k`-rough") numbers up to and including `N` as a `Finset` -/
 def roughNumbersUpTo (N k : ℕ) : Finset ℕ :=

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -76,7 +76,6 @@ instance (s : Finset ℕ) : DecidablePred (· ∈ factoredNumbers s) :=
 lemma mem_factoredNumbers_of_dvd {s : Finset ℕ} {m k : ℕ} (h : m ∈ factoredNumbers s)
     (h' : k ∣ m) (hk : k ≠ 0) :
     k ∈ factoredNumbers s := by
-  rw [mem_factoredNumbers] at h ⊢
   obtain ⟨h₁, h₂⟩ := h
   refine ⟨hk, fun p hp ↦ h₂ p ?_⟩
   rw [mem_factors <| by assumption] at hp ⊢
@@ -129,7 +128,7 @@ lemma factoredNumbers_insert (s : Finset ℕ) {N : ℕ} (hN : ¬ N.Prime) :
     factoredNumbers (insert N s) = factoredNumbers s := by
   ext m
   refine ⟨fun hm ↦ ⟨hm.1, fun p hp ↦ ?_⟩,
-         fun hm ↦ ⟨hm.1, fun p hp ↦ Finset.mem_insert_of_mem <| hm.2 p hp⟩⟩
+          fun hm ↦ ⟨hm.1, fun p hp ↦ Finset.mem_insert_of_mem <| hm.2 p hp⟩⟩
   exact Finset.mem_of_mem_insert_of_ne (hm.2 p hp) fun h ↦ hN <| h ▸ prime_of_mem_factors hp
 
 @[gcongr] lemma factoredNumbers_mono {s t : Finset ℕ} (hst : s ≤ t) :
@@ -172,7 +171,7 @@ lemma Prime.factoredNumbers_coprime {s : Finset ℕ} {p n : ℕ} (hp : p.Prime) 
 /-- If `f : ℕ → F` is multiplicative on coprime arguments, `p ∉ s` is a prime and `m`
 is `s`-factored, then `f (p^e * m) = f (p^e) * f m`. -/
 lemma factoredNumbers.map_prime_pow_mul {F : Type*} [CommSemiring F] {f : ℕ → F}
-    (hmul : ∀ {m n}, Nat.Coprime m n → f (m * n) = f m * f n) {s : Finset ℕ} {p : ℕ}
+    (hmul : ∀ {m n}, Coprime m n → f (m * n) = f m * f n) {s : Finset ℕ} {p : ℕ}
     (hp : p.Prime) (hs : p ∉ s) (e : ℕ) {m : factoredNumbers s} :
     f (p ^ e * m) = f (p ^ e) * f m :=
   hmul <| Coprime.pow_left _ <| hp.factoredNumbers_coprime hs <| Subtype.mem m

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -105,11 +105,11 @@ lemma ne_zero_of_mem_factoredNumbers {s : Finset ℕ} {m : ℕ} (h : m ∈ facto
   h.1
 
 @[simp]
-lemma factoredNumbers_empty : factoredNumbers ⊥ = {1} := by
+lemma factoredNumbers_empty : factoredNumbers ∅ = {1} := by
   ext m
-  simp only [Set.mem_singleton_iff, mem_factoredNumbers, Finset.bot_eq_empty, Finset.not_mem_empty,
-    ← List.eq_nil_iff_forall_not_mem, factors_eq_nil, and_or_left, not_and_self_iff, false_or,
-    ne_and_eq_iff_right zero_ne_one]
+  simp only [mem_factoredNumbers, Finset.not_mem_empty, ← List.eq_nil_iff_forall_not_mem,
+    factors_eq_nil, and_or_left, not_and_self_iff, ne_and_eq_iff_right zero_ne_one, false_or,
+    Set.mem_singleton_iff]
 
 /-- The product of the prime factors of `n` that are in `s` is an `s`-factored number. -/
 lemma prod_mem_factoredNumbers (s : Finset ℕ) (n : ℕ) :
@@ -267,8 +267,7 @@ lemma ne_zero_of_mem_smoothNumbers {n m : ℕ} (h : m ∈ smoothNumbers n) : m �
 
 @[simp]
 lemma smoothNumbers_zero : smoothNumbers 0 = {1} := by
-  simp only [smoothNumbers_eq_factoredNumbers, Finset.range_zero, ← Finset.bot_eq_empty,
-    factoredNumbers_empty]
+  simp only [smoothNumbers_eq_factoredNumbers, Finset.range_zero, factoredNumbers_empty]
 
 /-- The product of the prime factors of `n` that are less than `N` is an `N`-smooth number. -/
 lemma prod_mem_smoothNumbers (n N : ℕ) : (n.factors.filter (· < N)).prod ∈ smoothNumbers N := by

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -9,14 +9,20 @@ import Mathlib.Data.Nat.Squarefree
 /-!
 # Smooth numbers
 
-We define the set `Nat.smoothNumbers n` consisting of the positive natural numbers all of
-whose prime factors are strictly less than `n`.
+For `s : Finset ℕ` we define the set `Nat.factoredNumbers s` of "`s`-factored numbers"
+consisting of the positive natural numbers all of whose prime factors are in `s`, and
+we provide some API for this.
+
+We then define the set `Nat.smoothNumbers n` consisting of the positive natural numbers all of
+whose prime factors are strictly less than `n`. This is the special case `s = Finset.range n`
+of the set of `s`-factored numbers.
 
 We also define the finite set `Nat.primesBelow n` to be the set of prime numbers less than `n`.
 
 The main definition `Nat.equivProdNatSmoothNumbers` establishes the bijection between
 `ℕ × (smoothNumbers p)` and `smoothNumbers (p+1)` given by sending `(e, n)` to `p^e * n`.
-Here `p` is a prime number.
+Here `p` is a prime number. It is obtained from the more general bijection between
+`ℕ × (factoredNumbers s)` and `factoredNumbers (s ∪ {p})`; see `Nat.equivProdNatFactoredNumbers`.
 
 Additionally, we define `Nat.smoothNumbersUpTo N n` as the `Finset` of `n`-smooth numbers
 up to and including `N`, and similarly `Nat.roughNumbersUpTo` for its complement in `{1, ..., N}`,
@@ -49,117 +55,135 @@ lemma primesBelow_succ (n : ℕ) :
 lemma not_mem_primesBelow (n : ℕ) : n ∉ primesBelow n :=
   fun hn ↦ (lt_of_mem_primesBelow hn).false
 
-/-- `smoothNumbers n` is the set of *`n`-smooth positive natural numbers*, i.e., the
-positive natural numbers all of whose prime factors are less than `n`. -/
-def smoothNumbers (n : ℕ) : Set ℕ := {m | m ≠ 0 ∧ ∀ p ∈ factors m, p < n}
 
-lemma mem_smoothNumbers {n m : ℕ} : m ∈ smoothNumbers n ↔ m ≠ 0 ∧ ∀ p ∈ factors m, p < n :=
+/-!
+### `s`-factored numbers
+-/
+
+/-- `factoredNumbers s`, for a finite set `s` of natural numbers, is the set of positive natural
+numbers all of whose prime factors are in `s`. -/
+def factoredNumbers (s : Finset ℕ) : Set ℕ := {m | m ≠ 0 ∧ ∀ p ∈ factors m, p ∈ s}
+
+lemma mem_factoredNumbers {s : Finset ℕ} {m : ℕ} :
+     m ∈ factoredNumbers s ↔ m ≠ 0 ∧ ∀ p ∈ factors m, p ∈ s :=
   Iff.rfl
 
-/-- Membership in `Nat.smoothNumbers n` is decidable. -/
-instance (n : ℕ) : DecidablePred (· ∈ smoothNumbers n) :=
-  inferInstanceAs <| DecidablePred fun x ↦ x ∈ {m | m ≠ 0 ∧ ∀ p ∈ factors m, p < n}
+/-- Membership in `Nat.factoredNumbers n` is decidable. -/
+instance (s : Finset ℕ) : DecidablePred (· ∈ factoredNumbers s) :=
+  inferInstanceAs <| DecidablePred fun x ↦ x ∈ {m | m ≠ 0 ∧ ∀ p ∈ factors m, p ∈ s}
 
-/-- A number that divides an `n`-smooth number is itself `n`-smooth. -/
-lemma mem_smoothNumbers_of_dvd {n m k : ℕ} (h : m ∈ smoothNumbers n) (h' : k ∣ m) (hk : k ≠ 0) :
-    k ∈ smoothNumbers n := by
-  rw [mem_smoothNumbers] at h ⊢
+/-- A number that divides an `s`-factored number is itself `s`-factored. -/
+lemma mem_factoredNumbers_of_dvd {s : Finset ℕ} {m k : ℕ} (h : m ∈ factoredNumbers s)
+    (h' : k ∣ m) (hk : k ≠ 0) :
+    k ∈ factoredNumbers s := by
+  rw [mem_factoredNumbers] at h ⊢
   obtain ⟨h₁, h₂⟩ := h
   refine ⟨hk, fun p hp ↦ h₂ p ?_⟩
   rw [mem_factors <| by assumption] at hp ⊢
   exact ⟨hp.1, hp.2.trans h'⟩
 
-/-- `m` is `n`-smooth if and only if `m` is nonzero and all prime divisors `≤ m` of `m`
-are less than `n`. -/
-lemma mem_smoothNumbers_iff_forall_le  {n m : ℕ} :
-    m ∈ smoothNumbers n ↔ m ≠ 0 ∧ ∀ p ≤ m, p.Prime → p ∣ m → p < n := by
-  simp_rw [mem_smoothNumbers, mem_factors']
+/-- `m` is `s`-factored if and only if `m` is nonzero and all prime divisors `≤ m` of `m`
+are in `s`. -/
+lemma mem_factoredNumbers_iff_forall_le {s : Finset ℕ} {m : ℕ} :
+    m ∈ factoredNumbers s ↔ m ≠ 0 ∧ ∀ p ≤ m, p.Prime → p ∣ m → p ∈ s := by
+  simp_rw [mem_factoredNumbers, mem_factors']
   exact ⟨fun ⟨H₀, H₁⟩ ↦ ⟨H₀, fun p _ hp₂ hp₃ ↦ H₁ p ⟨hp₂, hp₃, H₀⟩⟩,
     fun ⟨H₀, H₁⟩ ↦
       ⟨H₀, fun p ⟨hp₁, hp₂, hp₃⟩ ↦ H₁ p (Nat.le_of_dvd (Nat.pos_of_ne_zero hp₃) hp₂) hp₁ hp₂⟩⟩
 
-/-- `m` is `n`-smooth if and only if all prime divisors of `m` are less than `n`. -/
-lemma mem_smoothNumbers' {n m : ℕ} : m ∈ smoothNumbers n ↔ ∀ p, p.Prime → p ∣ m → p < n := by
-  obtain ⟨p, hp₁, hp₂⟩ := exists_infinite_primes n
-  rw [mem_smoothNumbers_iff_forall_le]
-  exact ⟨fun ⟨H₀, H₁⟩ ↦ fun p hp₁ hp₂ ↦ H₁ p (Nat.le_of_dvd (Nat.pos_of_ne_zero H₀) hp₂) hp₁ hp₂,
-         fun H ↦ ⟨fun h ↦ ((H p hp₂ <| h.symm ▸ dvd_zero p).trans_le hp₁).false, fun p _ ↦ H p⟩⟩
+/-- `m` is `s`-factored if and only if all prime divisors of `m` are in `s`. -/
+lemma mem_factoredNumbers' {s : Finset ℕ} {m : ℕ} :
+    m ∈ factoredNumbers s ↔ ∀ p, p.Prime → p ∣ m → p ∈ s := by
+  obtain ⟨p, hp₁, hp₂⟩ := exists_infinite_primes (1 + Finset.sup s id)
+  rw [mem_factoredNumbers_iff_forall_le]
+  refine ⟨fun ⟨H₀, H₁⟩ ↦ fun p hp₁ hp₂ ↦ H₁ p (Nat.le_of_dvd (Nat.pos_of_ne_zero H₀) hp₂) hp₁ hp₂,
+         fun H ↦ ⟨fun h ↦ ?_, fun p _ ↦ H p⟩⟩
+  exact ((Finset.le_sup (f := @id ℕ) <| (H p hp₂ <| h.symm ▸ dvd_zero p)).trans_lt (lt_one_add _)
+            |>.trans_le hp₁).false
 
-lemma ne_zero_of_mem_smoothNumbers {n m : ℕ} (h : m ∈ smoothNumbers n) : m ≠ 0 :=
-  (mem_smoothNumbers_iff_forall_le.mp h).1
+lemma ne_zero_of_mem_factoredNumbers {s : Finset ℕ} {m : ℕ} (h : m ∈ factoredNumbers s) : m ≠ 0 :=
+  h.1
 
 @[simp]
-lemma smoothNumbers_zero : smoothNumbers 0 = {1} := by
+lemma factoredNumbers_empty : factoredNumbers ⊥ = {1} := by
   ext m
-  rw [Set.mem_singleton_iff, mem_smoothNumbers]
-  simp_rw [not_lt_zero]
-  rw [← List.eq_nil_iff_forall_not_mem, factors_eq_nil, and_or_left, not_and_self_iff, false_or,
+  simp only [Set.mem_singleton_iff, mem_factoredNumbers, Finset.bot_eq_empty, Finset.not_mem_empty,
+    ← List.eq_nil_iff_forall_not_mem, factors_eq_nil, and_or_left, not_and_self_iff, false_or,
     ne_and_eq_iff_right zero_ne_one]
 
-/-- The product of the prime factors of `n` that are less than `N` is an `N`-smooth number. -/
-lemma prod_mem_smoothNumbers (n N : ℕ) : (n.factors.filter (· < N)).prod ∈ smoothNumbers N := by
-  have h₀ : (n.factors.filter (· < N)).prod ≠ 0 :=
+/-- The product of the prime factors of `n` that are in `s` is an `s`-factored number. -/
+lemma prod_mem_factoredNumbers (s : Finset ℕ) (n : ℕ) :
+    (n.factors.filter (· ∈ s)).prod ∈ factoredNumbers s := by
+  have h₀ : (n.factors.filter (· ∈ s)).prod ≠ 0 :=
     List.prod_ne_zero fun h ↦ (pos_of_mem_factors (List.mem_of_mem_filter h)).false
   refine ⟨h₀, fun p hp ↦ ?_⟩
   obtain ⟨H₁, H₂⟩ := (mem_factors h₀).mp hp
   simpa only [decide_eq_true_eq] using List.of_mem_filter <| mem_list_primes_of_dvd_prod H₁.prime
     (fun _ hq ↦ (prime_of_mem_factors (List.mem_of_mem_filter hq)).prime) H₂
 
-/-- The sets of `N`-smooth and of `(N+1)`-smooth numbers are the same when `N` is not prime.
-See `Nat.equivProdNatSmoothNumbers` for when `N` is prime. -/
-lemma smoothNumbers_succ {N : ℕ} (hN : ¬ N.Prime) : N.succ.smoothNumbers = N.smoothNumbers := by
+/-- The sets of `s`-factored and of `s ∪ {N}`-factored numbers are the same when `N` is not prime.
+See `Nat.equivProdNatFactoredNumbers` for when `N` is prime. -/
+lemma factoredNumbers_insert (s : Finset ℕ) {N : ℕ} (hN : ¬ N.Prime) :
+    factoredNumbers (insert N s) = factoredNumbers s := by
   ext m
   refine ⟨fun hm ↦ ⟨hm.1, fun p hp ↦ ?_⟩,
-         fun hm ↦ ⟨hm.1, fun p hp ↦ (hm.2 p hp).trans <| lt.base N⟩⟩
-  exact lt_of_le_of_ne (lt_succ.mp <| hm.2 p hp) fun h ↦ hN <| h ▸ prime_of_mem_factors hp
+         fun hm ↦ ⟨hm.1, fun p hp ↦ Finset.mem_insert_of_mem <| hm.2 p hp⟩⟩
+  exact Finset.mem_of_mem_insert_of_ne (hm.2 p hp) fun h ↦ hN <| h ▸ prime_of_mem_factors hp
 
-@[simp] lemma smoothNumbers_one : smoothNumbers 1 = {1} := by
-  simp (config := {decide := true}) [smoothNumbers_succ]
+@[gcongr] lemma factoredNumbers_mono {s t : Finset ℕ} (hst : s ≤ t) :
+    factoredNumbers s ⊆ factoredNumbers t :=
+  fun _ hx ↦ ⟨hx.1, fun p hp ↦ hst <| hx.2 p hp⟩
 
-@[gcongr] lemma smoothNumbers_mono {N M : ℕ} (hNM : N ≤ M) : N.smoothNumbers ⊆ M.smoothNumbers :=
-  fun _ hx ↦ ⟨hx.1, fun p hp => (hx.2 p hp).trans_le hNM⟩
-
-/-- The non-zero non-`N`-smooth numbers are `≥ N`. -/
-lemma smoothNumbers_compl (N : ℕ) : (N.smoothNumbers)ᶜ \ {0} ⊆ {n | N ≤ n} := by
+/-- The non-zero non-`s`-factored numbers are `≥ N` when `s` contains all primes less than `N`. -/
+lemma factoredNumbers_compl {N : ℕ} {s : Finset ℕ} (h : primesBelow N ≤ s) :
+    (factoredNumbers s)ᶜ \ {0} ⊆ {n | N ≤ n} := by
   intro n hn
-  simp only [Set.mem_compl_iff, mem_smoothNumbers, Set.mem_diff, ne_eq, not_and, not_forall,
+  simp only [Set.mem_compl_iff, mem_factoredNumbers, Set.mem_diff, ne_eq, not_and, not_forall,
     not_lt, exists_prop, Set.mem_singleton_iff] at hn
-  obtain ⟨m, hm₁, hm₂⟩ := hn.1 hn.2
-  exact hm₂.trans <| le_of_mem_factors hm₁
+  simp only [Set.mem_setOf_eq]
+  obtain ⟨p, hp₁, hp₂⟩ := hn.1 hn.2
+  have : N ≤ p := by
+    contrapose! hp₂
+    exact h <| mem_primesBelow.mpr ⟨hp₂, prime_of_mem_factors hp₁⟩
+  exact this.trans <| le_of_mem_factors hp₁
 
-/-- If `p` is positive and `n` is `p`-smooth, then every product `p^e * n` is `(p+1)`-smooth. -/
-lemma pow_mul_mem_smoothNumbers {p n : ℕ} (hp : p ≠ 0) (e : ℕ) (hn : n ∈ smoothNumbers p) :
-    p ^ e * n ∈ smoothNumbers (succ p) := by
-  have hp' := pow_ne_zero e hp
+/-- If `p` is a prime and `n` is `s`-factored, then every product `p^e * n`
+is `s ∪ {p}`-factored. -/
+lemma pow_mul_mem_factoredNumbers {s : Finset ℕ} {p n : ℕ} (hp : p.Prime) (e : ℕ)
+    (hn : n ∈ factoredNumbers s) :
+    p ^ e * n ∈ factoredNumbers (insert p s) := by
+  have hp' := pow_ne_zero e hp.ne_zero
   refine ⟨mul_ne_zero hp' hn.1, fun q hq ↦ ?_⟩
   rcases (mem_factors_mul hp' hn.1).mp hq with H | H
   · rw [mem_factors hp'] at H
-    exact lt_succ.mpr <| le_of_dvd hp.bot_lt <| H.1.dvd_of_dvd_pow H.2
-  · exact (hn.2 q H).trans <| lt_succ_self p
+    rw [(prime_dvd_prime_iff_eq H.1 hp).mp <| H.1.dvd_of_dvd_pow H.2]
+    exact Finset.mem_insert_self p s
+  · exact Finset.mem_insert_of_mem <| hn.2 _ H
 
-/-- If `p` is a prime and `n` is `p`-smooth, then `p` and `n` are coprime. -/
-lemma Prime.smoothNumbers_coprime {p n : ℕ} (hp : p.Prime) (hn : n ∈ smoothNumbers p) :
+/-- If `p ∉ s` is a prime and `n` is `s`-factored, then `p` and `n` are coprime. -/
+lemma Prime.factoredNumbers_coprime {s : Finset ℕ} {p n : ℕ} (hp : p.Prime) (hs : p ∉ s)
+    (hn : n ∈ factoredNumbers s) :
     Nat.Coprime p n := by
   rw [hp.coprime_iff_not_dvd, ← mem_factors_iff_dvd hn.1 hp]
-  exact fun H ↦ (hn.2 p H).false
+  exact fun H ↦ hs <| hn.2 p H
 
-/-- If `f : ℕ → F` is multiplicative on coprime arguments, `p` is a prime and `m` is `p`-smooth,
-then `f (p^e * m) = f (p^e) * f m`. -/
-lemma map_prime_pow_mul {F : Type*} [CommSemiring F] {f : ℕ → F}
-    (hmul : ∀ {m n}, Nat.Coprime m n → f (m * n) = f m * f n) {p : ℕ} (hp : p.Prime) (e : ℕ)
-    {m : p.smoothNumbers} :
+/-- If `f : ℕ → F` is multiplicative on coprime arguments, `p ∉ s` is a prime and `m`
+is `s`-factored, then `f (p^e * m) = f (p^e) * f m`. -/
+lemma factoredNumbers.map_prime_pow_mul {F : Type*} [CommSemiring F] {f : ℕ → F}
+    (hmul : ∀ {m n}, Nat.Coprime m n → f (m * n) = f m * f n) {s : Finset ℕ} {p : ℕ}
+    (hp : p.Prime) (hs : p ∉ s) (e : ℕ) {m : factoredNumbers s} :
     f (p ^ e * m) = f (p ^ e) * f m :=
-  hmul <| Coprime.pow_left _ <| hp.smoothNumbers_coprime <| Subtype.mem m
+  hmul <| Coprime.pow_left _ <| hp.factoredNumbers_coprime hs <| Subtype.mem m
 
 open List Perm in
-/-- We establish the bijection from `ℕ × smoothNumbers p` to `smoothNumbers (p+1)`
-given by `(e, n) ↦ p^e * n` when `p` is a prime. See `Nat.smoothNumbers_succ` for
+/-- We establish the bijection from `ℕ × factoredNumbers s` to `factoredNumbers (s ∪ {p})`
+given by `(e, n) ↦ p^e * n` when `p ∉ s` is a prime. See `Nat.factoredNumbers_insert` for
 when `p` is not prime. -/
-def equivProdNatSmoothNumbers {p : ℕ} (hp: p.Prime) :
-    ℕ × smoothNumbers p ≃ smoothNumbers p.succ where
-  toFun := fun ⟨e, n⟩ ↦ ⟨p ^ e * n, pow_mul_mem_smoothNumbers hp.ne_zero e n.2⟩
+def equivProdNatFactoredNumbers {s : Finset ℕ} {p : ℕ} (hp: p.Prime) (hs : p ∉ s) :
+    ℕ × factoredNumbers s ≃ factoredNumbers (insert p s) where
+  toFun := fun ⟨e, n⟩ ↦ ⟨p ^ e * n, pow_mul_mem_factoredNumbers hp e n.2⟩
   invFun := fun ⟨m, _⟩  ↦ (m.factorization p,
-                            ⟨(m.factors.filter (· < p)).prod, prod_mem_smoothNumbers ..⟩)
+                            ⟨(m.factors.filter (· ∈ s)).prod, prod_mem_factoredNumbers ..⟩)
   left_inv := by
     rintro ⟨e, m, hm₀, hm⟩
     simp (config := { etaStruct := .all }) only
@@ -170,24 +194,138 @@ def equivProdNatSmoothNumbers {p : ℕ} (hp: p.Prime) :
         Pi.natCast_def, cast_id, Pi.add_apply, Pi.mul_apply, hp.factorization_self,
         mul_one, add_right_eq_self]
       rw [← factors_count_eq, count_eq_zero]
-      exact fun H ↦ (hm p H).false
-    · nth_rw 2 [← prod_factors hm₀]
+      exact fun H ↦ hs (hm p H)
+    · nth_rewrite 2 [← prod_factors hm₀]
       refine prod_eq <| (filter _ <| perm_factors_mul (pow_ne_zero e hp.ne_zero) hm₀).trans ?_
       rw [filter_append, hp.factors_pow,
-          filter_eq_nil.mpr fun q hq ↦ by rw [mem_replicate] at hq; simp [hq.2],
-          nil_append, filter_eq_self.mpr fun q hq ↦ by simp [hm q hq]]
+          filter_eq_nil.mpr fun q hq ↦ by rw [mem_replicate] at hq; simp [hq.2, hs],
+          nil_append, filter_eq_self.mpr fun q hq ↦ by simp only [hm q hq, decide_True]]
   right_inv := by
     rintro ⟨m, hm₀, hm⟩
     simp only [Set.coe_setOf, Set.mem_setOf_eq, Subtype.mk.injEq]
     rw [← factors_count_eq, ← prod_replicate, ← prod_append]
-    nth_rw 3 [← prod_factors hm₀]
-    have : m.factors.filter (· = p) = m.factors.filter (¬ · < p) := by
+    nth_rewrite 3 [← prod_factors hm₀]
+    have : m.factors.filter (· = p) = m.factors.filter (¬ · ∈ s) := by
       refine (filter_congr' fun q hq ↦ ?_).symm
-      have H : ¬ p < q := fun hf ↦ Nat.lt_le_asymm hf <| Nat.lt_succ_iff.mp (hm q hq)
-      simp only [not_lt, le_iff_eq_or_lt, H, or_false, eq_comm, true_eq_decide_iff]
+      simp only [decide_not, Bool.not_eq_true', decide_eq_false_iff_not, decide_eq_true_eq]
+      rcases Finset.mem_insert.mp <| hm _ hq with h | h
+      · simp only [h, hs, not_false_eq_true]
+      · simp only [h, not_true_eq_false, false_iff]
+        exact fun H ↦ hs <| H ▸ h
     refine prod_eq <| (filter_eq m.factors p).symm ▸ this ▸ perm_append_comm.trans ?_
-    convert filter_append_perm ..
-    simp only [not_lt, decide_not, Bool.not_not, lt_iff_not_ge]
+    simp only [decide_not]
+    exact filter_append_perm (· ∈ s) (factors m)
+
+@[simp]
+lemma equivProdNatFactoredNumbers_apply {s : Finset ℕ} {m p e : ℕ} (hp: p.Prime) (hs : p ∉ s)
+      (hm : m ∈ factoredNumbers s) :
+    equivProdNatFactoredNumbers hp hs (e, ⟨m, hm⟩) = p ^ e * m := rfl
+
+@[simp]
+lemma equivProdNatFactoredNumbers_apply' {s : Finset ℕ} {p : ℕ} (hp: p.Prime) (hs : p ∉ s)
+      (x : ℕ × factoredNumbers s) :
+    equivProdNatFactoredNumbers hp hs x = p ^ x.1 * x.2 := rfl
+
+
+/-!
+### `n`-smooth numbers
+-/
+
+/-- `smoothNumbers n` is the set of *`n`-smooth positive natural numbers*, i.e., the
+positive natural numbers all of whose prime factors are less than `n`. -/
+def smoothNumbers (n : ℕ) : Set ℕ := {m | m ≠ 0 ∧ ∀ p ∈ factors m, p < n}
+
+lemma mem_smoothNumbers {n m : ℕ} : m ∈ smoothNumbers n ↔ m ≠ 0 ∧ ∀ p ∈ factors m, p < n :=
+  Iff.rfl
+
+/-- The `n`-smooth numbers agree with the `Finset.range n`-factored numbers. -/
+lemma smoothNumbers_eq_factoredNumbers (n : ℕ) :
+    smoothNumbers n = factoredNumbers (Finset.range n) := by
+  simp only [smoothNumbers, ne_eq, mem_factors', and_imp, factoredNumbers, Finset.mem_range]
+
+/-- Membership in `Nat.smoothNumbers n` is decidable. -/
+instance (n : ℕ) : DecidablePred (· ∈ smoothNumbers n) :=
+  inferInstanceAs <| DecidablePred fun x ↦ x ∈ {m | m ≠ 0 ∧ ∀ p ∈ factors m, p < n}
+
+/-- A number that divides an `n`-smooth number is itself `n`-smooth. -/
+lemma mem_smoothNumbers_of_dvd {n m k : ℕ} (h : m ∈ smoothNumbers n) (h' : k ∣ m) (hk : k ≠ 0) :
+    k ∈ smoothNumbers n := by
+  simp only [smoothNumbers_eq_factoredNumbers] at h ⊢
+  exact mem_factoredNumbers_of_dvd h h' hk
+
+/-- `m` is `n`-smooth if and only if `m` is nonzero and all prime divisors `≤ m` of `m`
+are less than `n`. -/
+lemma mem_smoothNumbers_iff_forall_le  {n m : ℕ} :
+    m ∈ smoothNumbers n ↔ m ≠ 0 ∧ ∀ p ≤ m, p.Prime → p ∣ m → p < n := by
+  simp only [smoothNumbers_eq_factoredNumbers, mem_factoredNumbers_iff_forall_le, Finset.mem_range]
+
+/-- `m` is `n`-smooth if and only if all prime divisors of `m` are less than `n`. -/
+lemma mem_smoothNumbers' {n m : ℕ} : m ∈ smoothNumbers n ↔ ∀ p, p.Prime → p ∣ m → p < n := by
+  simp only [smoothNumbers_eq_factoredNumbers, mem_factoredNumbers', Finset.mem_range]
+
+lemma ne_zero_of_mem_smoothNumbers {n m : ℕ} (h : m ∈ smoothNumbers n) : m ≠ 0 := h.1
+
+@[simp]
+lemma smoothNumbers_zero : smoothNumbers 0 = {1} := by
+  simp only [smoothNumbers_eq_factoredNumbers, Finset.range_zero, ← Finset.bot_eq_empty,
+    factoredNumbers_empty]
+
+/-- The product of the prime factors of `n` that are less than `N` is an `N`-smooth number. -/
+lemma prod_mem_smoothNumbers (n N : ℕ) : (n.factors.filter (· < N)).prod ∈ smoothNumbers N := by
+  simp only [smoothNumbers_eq_factoredNumbers, ← Finset.mem_range, prod_mem_factoredNumbers]
+
+/-- The sets of `N`-smooth and of `(N+1)`-smooth numbers are the same when `N` is not prime.
+See `Nat.equivProdNatSmoothNumbers` for when `N` is prime. -/
+lemma smoothNumbers_succ {N : ℕ} (hN : ¬ N.Prime) : N.succ.smoothNumbers = N.smoothNumbers := by
+  simp only [smoothNumbers_eq_factoredNumbers, Finset.range_succ, factoredNumbers_insert _ hN]
+
+@[simp] lemma smoothNumbers_one : smoothNumbers 1 = {1} := by
+  simp (config := { decide := true }) only [not_false_eq_true, smoothNumbers_succ,
+    smoothNumbers_zero]
+
+@[gcongr] lemma smoothNumbers_mono {N M : ℕ} (hNM : N ≤ M) : N.smoothNumbers ⊆ M.smoothNumbers :=
+  fun _ hx ↦ ⟨hx.1, fun p hp => (hx.2 p hp).trans_le hNM⟩
+
+/-- The non-zero non-`N`-smooth numbers are `≥ N`. -/
+lemma smoothNumbers_compl (N : ℕ) : (N.smoothNumbers)ᶜ \ {0} ⊆ {n | N ≤ n} := by
+  simpa only [smoothNumbers_eq_factoredNumbers]
+    using factoredNumbers_compl <| Finset.filter_subset _ (Finset.range N)
+
+/-- If `p` is positive and `n` is `p`-smooth, then every product `p^e * n` is `(p+1)`-smooth. -/
+lemma pow_mul_mem_smoothNumbers {p n : ℕ} (hp : p ≠ 0) (e : ℕ) (hn : n ∈ smoothNumbers p) :
+    p ^ e * n ∈ smoothNumbers (succ p) := by
+  -- This cannot be easily reduced to `pow_mul_mem_factoredNumbers`, as there `p.Prime` is needed.
+  have : NoZeroDivisors ℕ := inferInstance -- this is needed twice --> speed-up
+  have hp' := pow_ne_zero e hp
+  refine ⟨mul_ne_zero hp' hn.1, fun q hq ↦ ?_⟩
+  rcases (mem_factors_mul hp' hn.1).mp hq with H | H
+  · rw [mem_factors hp'] at H
+    exact lt_succ.mpr <| le_of_dvd hp.bot_lt <| H.1.dvd_of_dvd_pow H.2
+  · exact (hn.2 q H).trans <| lt_succ_self p
+
+/-- If `p` is a prime and `n` is `p`-smooth, then `p` and `n` are coprime. -/
+lemma Prime.smoothNumbers_coprime {p n : ℕ} (hp : p.Prime) (hn : n ∈ smoothNumbers p) :
+    Nat.Coprime p n := by
+  simp only [smoothNumbers_eq_factoredNumbers] at hn
+  exact hp.factoredNumbers_coprime Finset.not_mem_range_self hn
+
+/-- If `f : ℕ → F` is multiplicative on coprime arguments, `p` is a prime and `m` is `p`-smooth,
+then `f (p^e * m) = f (p^e) * f m`. -/
+lemma map_prime_pow_mul {F : Type*} [CommSemiring F] {f : ℕ → F}
+    (hmul : ∀ {m n}, Nat.Coprime m n → f (m * n) = f m * f n) {p : ℕ} (hp : p.Prime) (e : ℕ)
+    {m : p.smoothNumbers} :
+    f (p ^ e * m) = f (p ^ e) * f m :=
+  hmul <| Coprime.pow_left _ <| hp.smoothNumbers_coprime <| Subtype.mem m
+
+open List Perm Equiv in
+/-- We establish the bijection from `ℕ × smoothNumbers p` to `smoothNumbers (p+1)`
+given by `(e, n) ↦ p^e * n` when `p` is a prime. See `Nat.smoothNumbers_succ` for
+when `p` is not prime. -/
+def equivProdNatSmoothNumbers {p : ℕ} (hp: p.Prime) :
+    ℕ × smoothNumbers p ≃ smoothNumbers p.succ :=
+  ((prodCongrRight fun _ ↦ setCongr <| smoothNumbers_eq_factoredNumbers p).trans <|
+    equivProdNatFactoredNumbers hp Finset.not_mem_range_self).trans <|
+    setCongr <| (smoothNumbers_eq_factoredNumbers p.succ) ▸ Finset.range_succ ▸ rfl
 
 @[simp]
 lemma equivProdNatSmoothNumbers_apply {p e m : ℕ} (hp: p.Prime) (hm : m ∈ p.smoothNumbers) :
@@ -204,6 +342,14 @@ def smoothNumbersUpTo (N k : ℕ) : Finset ℕ :=
 lemma mem_smoothNumbersUpTo {N k n : ℕ} :
     n ∈ smoothNumbersUpTo N k ↔ n ≤ N ∧ n ∈ smoothNumbers k := by
   simp [smoothNumbersUpTo, lt_succ]
+
+
+/-!
+### Smooth and rough numbers up to a bound
+
+We consider the sets of smooth and non-smooth ("rough") positive natural numbers `≤ N`
+and prove bounds for their sizes.
+-/
 
 /-- The positive non-`k`-smooth (so "`k`-rough") numbers up to and including `N` as a `Finset` -/
 def roughNumbersUpTo (N k : ℕ) : Finset ℕ :=

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -96,7 +96,7 @@ lemma mem_factoredNumbers' {s : Finset ℕ} {m : ℕ} :
     m ∈ factoredNumbers s ↔ ∀ p, p.Prime → p ∣ m → p ∈ s := by
   obtain ⟨p, hp₁, hp₂⟩ := exists_infinite_primes (1 + Finset.sup s id)
   rw [mem_factoredNumbers_iff_forall_le]
-  refine ⟨fun ⟨H₀, H₁⟩ ↦ fun p hp₁ hp₂ ↦ H₁ p (Nat.le_of_dvd (Nat.pos_of_ne_zero H₀) hp₂) hp₁ hp₂,
+  refine ⟨fun ⟨H₀, H₁⟩ ↦ fun p hp₁ hp₂ ↦ H₁ p (le_of_dvd (Nat.pos_of_ne_zero H₀) hp₂) hp₁ hp₂,
          fun H ↦ ⟨fun h ↦ lt_irrefl p ?_, fun p _ ↦ H p⟩⟩
   calc
     p ≤ s.sup id := Finset.le_sup (f := @id ℕ) <| H p hp₂ <| h.symm ▸ dvd_zero p

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -99,7 +99,7 @@ lemma mem_factoredNumbers' {s : Finset ℕ} {m : ℕ} :
   refine ⟨fun ⟨H₀, H₁⟩ ↦ fun p hp₁ hp₂ ↦ H₁ p (Nat.le_of_dvd (Nat.pos_of_ne_zero H₀) hp₂) hp₁ hp₂,
          fun H ↦ ⟨fun h ↦ lt_irrefl p ?_, fun p _ ↦ H p⟩⟩
   calc
-    p ≤ s.sup id := Finset.le_sup (f := @id ℕ) <| (H p hp₂ <| h.symm ▸ dvd_zero p)
+    p ≤ s.sup id := Finset.le_sup (f := @id ℕ) <| H p hp₂ <| h.symm ▸ dvd_zero p
     _ < 1 + s.sup id := lt_one_add _
     _ ≤ p := hp₁
 


### PR DESCRIPTION
As a preparation for refactoring Euler products to use the new infinite products, this PR generalizes `Nat.smoothNumbers n` to `Nat.factoredNumbers s` where `s` is a `Finset` of natural numbers; this is the set of all positive natural numbers all of whose prime factors are in `s`. We correspondingly generalize the API and use the new statements to golf the proofs of the old ones. (We also eliminate a few fairly slow `convert`s and a `tauto`, so that the file should now be faster than before, even though it contains quite a few new declarations.)

See [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Infinite.20products/near/431508883) on Zulip.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
