### PR TITLE
[Merged by Bors] - chore(RingTheory/FinitePresentation): make `Algebra.FinitePresentation` a class

### DIFF
--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -214,7 +214,8 @@ theorem mvPolynomial_of_finitePresentation (hfp : FinitePresentation.{w₁, w₂
 theorem trans [Algebra A B] [IsScalarTower R A B] [hfpA : FinitePresentation R A]
     [hfpB : FinitePresentation A B] : FinitePresentation R B := by
   obtain ⟨n, I, e, hfg⟩ := iff.1 hfpB
-  exact equiv (hfp := (mvPolynomial_of_finitePresentation hfpA _).quotient hfg) (e.restrictScalars R)
+  exact equiv (hfp := (mvPolynomial_of_finitePresentation hfpA _).quotient hfg)
+    (e.restrictScalars R)
 #align algebra.finite_presentation.trans Algebra.FinitePresentation.trans
 
 open MvPolynomial

--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -128,7 +128,7 @@ variable {R}
 
 /-- The quotient of a finitely presented algebra by a finitely generated ideal is finitely
 presented. -/
-protected instance quotient {I : Ideal A} (h : I.FG) [hfp : FinitePresentation R A] :
+protected theorem quotient {I : Ideal A} (h : I.FG) [hfp : FinitePresentation R A] :
     FinitePresentation R (A ⧸ I) where
   out := by
     obtain ⟨n, f, hf⟩ := hfp.out

--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -53,8 +53,8 @@ namespace FiniteType
 variable {R A B}
 
 /-- A finitely presented algebra is of finite type. -/
-instance of_finitePresentation [hfp : FinitePresentation R A] : FiniteType R A := by
-  obtain ⟨n, f, hf⟩ := hfp.out
+instance of_finitePresentation [FinitePresentation R A] : FiniteType R A := by
+  obtain ⟨n, f, hf⟩ := FinitePresentation.out (R := R) (A := A)
   apply FiniteType.iff_quotient_mvPolynomial''.2
   exact ⟨n, f, hf.1⟩
 #align algebra.finite_type.of_finite_presentation Algebra.FiniteType.of_finitePresentation
@@ -80,8 +80,8 @@ theorem of_finiteType [IsNoetherianRing R] : FiniteType R A ↔ FinitePresentati
 #align algebra.finite_presentation.of_finite_type Algebra.FinitePresentation.of_finiteType
 
 /-- If `e : A ≃ₐ[R] B` and `A` is finitely presented, then so is `B`. -/
-theorem equiv [hfp : FinitePresentation R A] (e : A ≃ₐ[R] B) : FinitePresentation R B := by
-  obtain ⟨n, f, hf⟩ := hfp.out
+theorem equiv [FinitePresentation R A] (e : A ≃ₐ[R] B) : FinitePresentation R B := by
+  obtain ⟨n, f, hf⟩ := FinitePresentation.out (R := R) (A := A)
   use n, AlgHom.comp (↑e) f
   constructor
   · rw [AlgHom.coe_comp]
@@ -121,17 +121,18 @@ instance self : FinitePresentation R R :=
 /-- `R[X]` is finitely presented as `R`-algebra. -/
 instance polynomial : FinitePresentation R R[X] :=
   -- Porting note: replaced `PUnit` with `Unit`
-  equiv (hfp := FinitePresentation.mvPolynomial R Unit) (MvPolynomial.pUnitAlgEquiv R)
+  letI := FinitePresentation.mvPolynomial R Unit
+  equiv (MvPolynomial.pUnitAlgEquiv R)
 #align algebra.finite_presentation.polynomial Algebra.FinitePresentation.polynomial
 
 variable {R}
 
 /-- The quotient of a finitely presented algebra by a finitely generated ideal is finitely
 presented. -/
-protected theorem quotient {I : Ideal A} (h : I.FG) [hfp : FinitePresentation R A] :
+protected theorem quotient {I : Ideal A} (h : I.FG) [FinitePresentation R A] :
     FinitePresentation R (A ⧸ I) where
   out := by
-    obtain ⟨n, f, hf⟩ := hfp.out
+    obtain ⟨n, f, hf⟩ := FinitePresentation.out (R := R) (A := A)
     refine' ⟨n, (Ideal.Quotient.mkₐ R I).comp f, _, _⟩
     · exact (Ideal.Quotient.mkₐ_surjective R I).comp hf.1
     · refine' Ideal.fg_ker_comp _ _ hf.2 _ hf.1
@@ -141,8 +142,9 @@ protected theorem quotient {I : Ideal A} (h : I.FG) [hfp : FinitePresentation R 
 /-- If `f : A →ₐ[R] B` is surjective with finitely generated kernel and `A` is finitely presented,
 then so is `B`. -/
 theorem of_surjective {f : A →ₐ[R] B} (hf : Function.Surjective f) (hker : f.toRingHom.ker.FG)
-    [hfp : FinitePresentation R A] : FinitePresentation R B :=
-  equiv (hfp := hfp.quotient hker) (Ideal.quotientKerAlgEquivOfSurjective hf)
+    [FinitePresentation R A] : FinitePresentation R B :=
+  letI : FinitePresentation R (A ⧸ RingHom.ker f) := FinitePresentation.quotient hker
+  equiv (Ideal.quotientKerAlgEquivOfSurjective hf)
 #align algebra.finite_presentation.of_surjective Algebra.FinitePresentation.of_surjective
 
 theorem iff :
@@ -152,7 +154,8 @@ theorem iff :
   · rintro ⟨n, f, hf⟩
     exact ⟨n, RingHom.ker f.toRingHom, Ideal.quotientKerAlgEquivOfSurjective hf.1, hf.2⟩
   · rintro ⟨n, I, e, hfg⟩
-    exact equiv (hfp := (FinitePresentation.mvPolynomial R _).quotient hfg) e
+    letI := (FinitePresentation.mvPolynomial R _).quotient hfg
+    exact equiv e
 #align algebra.finite_presentation.iff Algebra.FinitePresentation.iff
 
 /-- An algebra is finitely presented if and only if it is a quotient of a polynomial ring whose
@@ -187,9 +190,10 @@ theorem iff_quotient_mvPolynomial' :
 -- Porting note: make universe level explicit to ensure `ι, ι'` has the same universe level
 /-- If `A` is a finitely presented `R`-algebra, then `MvPolynomial (Fin n) A` is finitely presented
 as `R`-algebra. -/
-theorem mvPolynomial_of_finitePresentation (hfp : FinitePresentation.{w₁, w₂} R A)
+theorem mvPolynomial_of_finitePresentation [FinitePresentation.{w₁, w₂} R A]
     (ι : Type v) [Finite ι] :
     FinitePresentation.{w₁, max v w₂} R (MvPolynomial ι A) := by
+  have hfp : FinitePresentation.{w₁, w₂} R A := inferInstance
   rw [iff_quotient_mvPolynomial'] at hfp ⊢
   classical
   -- Porting note: use the same universe level
@@ -209,13 +213,17 @@ theorem mvPolynomial_of_finitePresentation (hfp : FinitePresentation.{w₁, w₂
     exact hf_ker.map MvPolynomial.C
 #align algebra.finite_presentation.mv_polynomial_of_finite_presentation Algebra.FinitePresentation.mvPolynomial_of_finitePresentation
 
+variable (R A B)
+
 /-- If `A` is an `R`-algebra and `S` is an `A`-algebra, both finitely presented, then `S` is
   finitely presented as `R`-algebra. -/
-theorem trans [Algebra A B] [IsScalarTower R A B] [hfpA : FinitePresentation R A]
-    [hfpB : FinitePresentation A B] : FinitePresentation R B := by
+theorem trans [Algebra A B] [IsScalarTower R A B] [FinitePresentation R A]
+    [FinitePresentation A B] : FinitePresentation R B := by
+  have hfpB : FinitePresentation A B := inferInstance
   obtain ⟨n, I, e, hfg⟩ := iff.1 hfpB
-  exact equiv (hfp := (mvPolynomial_of_finitePresentation hfpA _).quotient hfg)
-    (e.restrictScalars R)
+  letI : FinitePresentation R (MvPolynomial (Fin n) A ⧸ I) :=
+    (mvPolynomial_of_finitePresentation _).quotient hfg
+  exact equiv (e.restrictScalars R)
 #align algebra.finite_presentation.trans Algebra.FinitePresentation.trans
 
 open MvPolynomial
@@ -223,10 +231,10 @@ open MvPolynomial
 -- We follow the proof of https://stacks.math.columbia.edu/tag/0561
 -- TODO: extract out helper lemmas and tidy proof.
 theorem of_restrict_scalars_finitePresentation [Algebra A B] [IsScalarTower R A B]
-    [hRB : FinitePresentation.{w₁, w₃} R B] [hRA : FiniteType R A] :
+    [FinitePresentation.{w₁, w₃} R B] [FiniteType R A] :
     FinitePresentation.{w₂, w₃} A B := by
   classical
-  obtain ⟨n, f, hf, s, hs⟩ := hRB
+  obtain ⟨n, f, hf, s, hs⟩ := FinitePresentation.out (R := R) (A := B)
   letI RX := MvPolynomial (Fin n) R
   letI AX := MvPolynomial (Fin n) A
   refine' ⟨n, MvPolynomial.aeval (f ∘ X), _, _⟩
@@ -234,7 +242,7 @@ theorem of_restrict_scalars_finitePresentation [Algebra A B] [IsScalarTower R A 
       Set.range_comp f MvPolynomial.X, eq_top_iff, ← @adjoin_adjoin_of_tower R A B,
       adjoin_image, adjoin_range_X, Algebra.map_top, (Algebra.range_top_iff_surjective _).mpr hf]
     exact fun {x} => subset_adjoin ⟨⟩
-  · obtain ⟨t, ht⟩ := hRA.out
+  · obtain ⟨t, ht⟩ := FiniteType.out (R := R) (A := A)
     have := fun i : t => hf (algebraMap A B i)
     choose t' ht' using this
     have ht'' : Algebra.adjoin R (algebraMap A AX '' t ∪ Set.range (X : _ → AX)) = ⊤ := by
@@ -308,12 +316,14 @@ theorem of_restrict_scalars_finitePresentation [Algebra A B] [IsScalarTower R A 
     exact Set.mem_image_of_mem _ hx
 #align algebra.finite_presentation.of_restrict_scalars_finite_presentation Algebra.FinitePresentation.of_restrict_scalars_finitePresentation
 
+variable {R A B}
+
 -- TODO: extract out helper lemmas and tidy proof.
 /-- This is used to prove the strictly stronger `ker_fg_of_surjective`. Use it instead. -/
 theorem ker_fg_of_mvPolynomial {n : ℕ} (f : MvPolynomial (Fin n) R →ₐ[R] A)
-    (hf : Function.Surjective f) [hfp : FinitePresentation R A] : f.toRingHom.ker.FG := by
+    (hf : Function.Surjective f) [FinitePresentation R A] : f.toRingHom.ker.FG := by
   classical
-    obtain ⟨m, f', hf', s, hs⟩ := hfp
+    obtain ⟨m, f', hf', s, hs⟩ := FinitePresentation.out (R := R) (A := A)
     let RXn := MvPolynomial (Fin n) R
     let RXm := MvPolynomial (Fin m) R
     have := fun i : Fin n => hf' (f <| X i)
@@ -386,8 +396,8 @@ theorem ker_fg_of_mvPolynomial {n : ℕ} (f : MvPolynomial (Fin n) R →ₐ[R] A
 /-- If `f : A →ₐ[R] B` is a surjection between finitely-presented `R`-algebras, then the kernel of
 `f` is finitely generated. -/
 theorem ker_fG_of_surjective (f : A →ₐ[R] B) (hf : Function.Surjective f)
-    [hRA : FinitePresentation R A] [hRB : FinitePresentation R B] : f.toRingHom.ker.FG := by
-  obtain ⟨n, g, hg, _⟩ := hRA
+    [FinitePresentation R A] [FinitePresentation R B] : f.toRingHom.ker.FG := by
+  obtain ⟨n, g, hg, _⟩ := FinitePresentation.out (R := R) (A := A)
   convert (ker_fg_of_mvPolynomial (f.comp g) (hf.comp hg)).map g.toRingHom
   simp_rw [RingHom.ker_eq_comap_bot, AlgHom.toRingHom_eq_coe, AlgHom.comp_toRingHom]
   rw [← Ideal.comap_comap, Ideal.map_comap_of_surjective (g : MvPolynomial (Fin n) R →+* A) hg]
@@ -431,12 +441,13 @@ theorem comp_surjective {f : A →+* B} {g : B →+* C} (hf : f.FinitePresentati
     (hker : g.ker.FG) : (g.comp f).FinitePresentation :=
   letI := f.toAlgebra
   letI := (g.comp f).toAlgebra
+  letI : Algebra.FinitePresentation A B := hf
   Algebra.FinitePresentation.of_surjective
     (f :=
       { g with
         toFun := g
         commutes' := fun _ => rfl })
-    hg hker (hfp := hf)
+    hg hker
 #align ring_hom.finite_presentation.comp_surjective RingHom.FinitePresentation.comp_surjective
 
 theorem of_surjective (f : A →+* B) (hf : Surjective f) (hker : f.ker.FG) :
@@ -457,7 +468,9 @@ theorem comp {g : B →+* C} {f : A →+* B} (hg : g.FinitePresentation) (hf : f
   letI ins3 := RingHom.toAlgebra (g.comp f)
   letI ins4 : IsScalarTower A B C :=
     { smul_assoc := fun a b c => by simp [Algebra.smul_def, mul_assoc]; rfl }
-  Algebra.FinitePresentation.trans (hfpA := hf) (hfpB := hg)
+  letI : Algebra.FinitePresentation A B := hf
+  letI : Algebra.FinitePresentation B C := hg
+  Algebra.FinitePresentation.trans A B C
 #align ring_hom.finite_presentation.comp RingHom.FinitePresentation.comp
 
 theorem of_comp_finiteType (f : A →+* B) {g : B →+* C} (hg : (g.comp f).FinitePresentation)
@@ -468,7 +481,9 @@ theorem of_comp_finiteType (f : A →+* B) {g : B →+* C} (hg : (g.comp f).Fini
   letI ins3 := RingHom.toAlgebra (g.comp f)
   letI ins4 : IsScalarTower A B C :=
     { smul_assoc := fun a b c => by simp [Algebra.smul_def, mul_assoc]; rfl }
-  Algebra.FinitePresentation.of_restrict_scalars_finitePresentation (hRA := hf) (hRB := hg)
+  letI : Algebra.FinitePresentation A C := hg
+  letI : Algebra.FiniteType A B := hf
+  Algebra.FinitePresentation.of_restrict_scalars_finitePresentation A B C
 #align ring_hom.finite_presentation.of_comp_finite_type RingHom.FinitePresentation.of_comp_finiteType
 
 end FinitePresentation


### PR DESCRIPTION
Makes `Algebra.FinitePresentation` a class, matching `Algebra.FiniteType`. Changes theorems to instances where possible.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
