### PR TITLE
[Merged by Bors] - chore(Algebra/Ring/Int): add `CharZero` instance for `Int`

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Power.lean
+++ b/Mathlib/Algebra/GroupWithZero/Power.lean
@@ -5,8 +5,8 @@ Authors: Johan Commelin
 -/
 import Mathlib.Algebra.GroupWithZero.Commute
 import Mathlib.Algebra.Order.Ring.CharZero
-import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Algebra.Order.Ring.Nat
+import Mathlib.Algebra.Ring.Int
 
 #align_import algebra.group_with_zero.power from "leanprover-community/mathlib"@"46a64b5b4268c594af770c44d9e502afc6a515cb"
 

--- a/Mathlib/Algebra/Ring/Int.lean
+++ b/Mathlib/Algebra/Ring/Int.lean
@@ -3,6 +3,7 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
+import Mathlib.Algebra.CharZero.Defs
 import Mathlib.Algebra.Group.Int
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Data.Int.Cast.Basic
@@ -61,10 +62,13 @@ These also prevent non-computable instances like `Int.normedCommRing` being used
 these instances non-computably.
 -/
 
-instance instCommSemiring : CommSemiring ℤ := by infer_instance
-instance instSemiring     : Semiring ℤ     := by infer_instance
-instance instRingInt      : Ring ℤ         := by infer_instance
-instance instDistrib      : Distrib ℤ      := by infer_instance
+instance instCommSemiring : CommSemiring ℤ := inferInstance
+instance instSemiring     : Semiring ℤ     := inferInstance
+instance instRingInt      : Ring ℤ         := inferInstance
+instance instDistrib      : Distrib ℤ      := inferInstance
+
+instance instCharZero : CharZero ℤ where
+  cast_injective _ _ := ofNat.inj
 
 /-! ### Miscellaneous lemmas -/
 

--- a/Mathlib/Data/Int/Dvd/Basic.lean
+++ b/Mathlib/Data/Int/Dvd/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
-import Mathlib.Algebra.Order.Ring.CharZero
 import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Algebra.Ring.Divisibility.Basic
 import Mathlib.Data.Nat.Cast.Order

--- a/Mathlib/Data/Nat/Cast/SetInterval.lean
+++ b/Mathlib/Data/Nat/Cast/SetInterval.lean
@@ -3,7 +3,6 @@ Copyright (c) 2024 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Algebra.Order.Ring.CharZero
 import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Data.Nat.Cast.Order
 import Mathlib.Order.UpperLower.Basic

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Algebra.GroupWithZero.Basic
-import Mathlib.Algebra.Order.Ring.CharZero
 import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Data.Int.Cast.Defs
 import Mathlib.Data.Nat.Cast.Basic

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -3,8 +3,7 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import Mathlib.Algebra.Order.Ring.CharZero
-import Mathlib.Algebra.Order.Ring.Int
+import Mathlib.Algebra.Ring.Int
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Logic.Equiv.Defs
 


### PR DESCRIPTION
This adds a shortcut instance `CharZero ℤ` in the file `Algebra.Ring.Int` (which contains a few other shortcut instances for `ℤ` already). The hope is that this will result in a speed-up.

Note: This requires adding `import Mathlib.Algebra.CharZero.Defs`.

See [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/simp.20prefers.20CharP.2Ecast_eq_zero.20over.20Nat.2Ecast_zero/near/431803537) on Zulip.

There is a positive effect (-22.5 s) on type class inference, but no significant change overall. Still, I think it makes sense to have it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
