### PR TITLE
[Merged by Bors] - ci: don't parse lean-toolchain twice

### DIFF
--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -111,18 +111,13 @@ jobs:
 
     # Next, determine if we should remind the humans to create a new PR to the `bump/v4.X.0` branch.
     # https://chat.openai.com/share/504882f9-9d98-4d8d-ad19-5161c4a24fe1
-    - name: Read lean-toolchain from current branch
-      id: current_version
-      run: |
-        sed -n 's|leanprover/lean4:nightly-|current_version=|p' lean-toolchain >> "${GITHUB_OUTPUT}"
 
     - name: Check for matching bump/nightly-YYYY-MM-DD branch
       id: check_branch
       uses: actions/github-script@v5
       with:
         script: |
-          const version = '${{ steps.current_version.outputs.current_version }}';
-          const branchName = `bump/nightly-${version}`;
+          const branchName = `bump/nightly-${process.env.NIGHTLY}`;
           const branches = await github.rest.repos.listBranches({
             owner: context.repo.owner,
             repo: context.repo.repo
@@ -176,7 +171,6 @@ jobs:
 
     - name: Compare versions and post a reminder.
       env:
-        CURRENT_VERSION: ${{ steps.current_version.outputs.current_version }}
         BUMP_VERSION: ${{ steps.bump_version.outputs.result }}
         BUMP_BRANCH: ${{ steps.latest_bump_branch.outputs.result }}
         ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
@@ -185,7 +179,7 @@ jobs:
         import os
         import zulip
         client = zulip.Client(email='github-mathlib4-bot@leanprover.zulipchat.com', api_key=os.getenv('ZULIP_API_KEY'), site='https://leanprover.zulipchat.com')
-        current_version = os.getenv('CURRENT_VERSION')
+        current_version = os.getenv('NIGHTLY')
         bump_version = os.getenv('BUMP_VERSION')
         bump_branch = os.getenv('BUMP_BRANCH')
         print(f'Current version: {current_version}, Bump version: {bump_version}')


### PR DESCRIPTION
For some reason that is not clear to me, the current code ends up with the empty string for the version. Easier than figuring out why that is, is using the environment variable that we'd set up earlier in this job.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
