### PR TITLE
[Merged by Bors] - ci: look at all the branches

### DIFF
--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -143,7 +143,7 @@ jobs:
       uses: actions/github-script@v5
       with:
         script: |
-          const branches = await github.rest.repos.listBranches({
+          const branches = await github.paginate(github.rest.repos.listBranches, {
             owner: context.repo.owner,
             repo: context.repo.repo
           });
@@ -151,6 +151,9 @@ jobs:
             .map(branch => branch.name)
             .filter(name => name.match(/^bump\/v4\.\d+\.0$/))
             .sort((a, b) => b.localeCompare(a, undefined, {numeric: true, sensitivity: 'base'}));
+          if (!bumpBranches.length) {
+            throw new Exception("Did not find any bump/v4.x.0 branch")
+          }
           const latestBranch = bumpBranches[0];
           return latestBranch;
 


### PR DESCRIPTION
By default, github only returns the first thirty branches from this API, notably excluding any that we're looking for.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

We can also avoid loading all the branches into a single array, but that's probably overengineered for our purpose. Leaving the code here for posterity:
```js
const iterator = github.paginate.iterator(github.rest.repos.listBranches, {
  owner: context.repo.owner,
  repo: context.repo.repo,
  "per_page": 100
});
const bumpBranches = [];
for await (const { data } of iterator) {
  for (const { name } of data) {
    if (name.match(/^bump\/v4\.\d+\.0$/)) {
      bumpBranches.push(name)
    }
  }
}
bumpBranches
  .sort((a, b) => b.localeCompare(a, undefined, {numeric: true, sensitivity: 'base'}));
```

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
