### PR TITLE
[Merged by Bors] - feat: Inverses for TrivSqZeroExt

### DIFF
--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -85,7 +85,8 @@ theorem eps_mul_eps [Semiring R] : (ε * ε : R[ε]) = 0 :=
 #align dual_number.eps_mul_eps DualNumber.eps_mul_eps
 
 @[simp]
-theorem eps_inv [DivisionRing R] : (ε : R[ε])⁻¹ = (0 : R[ε]) := TrivSqZeroExt.inv_inr
+theorem eps_inv [DivisionRing R] : (ε : R[ε])⁻¹ = (0 : R[ε]) :=
+  TrivSqZeroExt.inv_inr
 
 @[simp]
 theorem one_inv [DivisionRing R] : (inl 1 : R[ε])⁻¹ = (inl 1 : R[ε]) := by

--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -85,12 +85,8 @@ theorem eps_mul_eps [Semiring R] : (ε * ε : R[ε]) = 0 :=
 #align dual_number.eps_mul_eps DualNumber.eps_mul_eps
 
 @[simp]
-theorem inv_eps [DivisionRing R] : (ε : R[ε])⁻¹ = (0 : R[ε]) :=
-  TrivSqZeroExt.inv_inr
-
-@[simp]
-protected theorem inv_one [DivisionRing R] : (inl 1 : R[ε])⁻¹ = (inl 1 : R[ε]) := by
-  rw [TrivSqZeroExt.inv_inl one_ne_zero, inv_one]
+theorem inv_eps [DivisionRing R] : (ε : R[ε])⁻¹ = 0 := by
+  exact TrivSqZeroExt.inv_inr 1
 
 @[simp]
 theorem inr_eq_smul_eps [MulZeroOneClass R] (r : R) : inr r = (r • ε : R[ε]) :=

--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -85,11 +85,11 @@ theorem eps_mul_eps [Semiring R] : (ε * ε : R[ε]) = 0 :=
 #align dual_number.eps_mul_eps DualNumber.eps_mul_eps
 
 @[simp]
-theorem eps_inv [DivisionRing R] : (ε : R[ε])⁻¹ = (0 : R[ε]) :=
+theorem inv_eps [DivisionRing R] : (ε : R[ε])⁻¹ = (0 : R[ε]) :=
   TrivSqZeroExt.inv_inr
 
 @[simp]
-theorem one_inv [DivisionRing R] : (inl 1 : R[ε])⁻¹ = (inl 1 : R[ε]) := by
+protected theorem inv_one [DivisionRing R] : (inl 1 : R[ε])⁻¹ = (inl 1 : R[ε]) := by
   rw [TrivSqZeroExt.inv_inl one_ne_zero, inv_one]
 
 @[simp]

--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -81,7 +81,15 @@ theorem snd_mul [Semiring R] (x y : R[ε]) : snd (x * y) = fst x * snd y + snd x
 @[simp]
 theorem eps_mul_eps [Semiring R] : (ε * ε : R[ε]) = 0 :=
   inr_mul_inr _ _ _
+
 #align dual_number.eps_mul_eps DualNumber.eps_mul_eps
+
+@[simp]
+theorem eps_inv [DivisionRing R] : (ε : R[ε])⁻¹ = (0 : R[ε]) := TrivSqZeroExt.inv_inr
+
+@[simp]
+theorem one_inv [DivisionRing R] : (inl 1 : R[ε])⁻¹ = (inl 1 : R[ε]) := by
+  rw [TrivSqZeroExt.inv_inl one_ne_zero, inv_one]
 
 @[simp]
 theorem inr_eq_smul_eps [MulZeroOneClass R] (r : R) : inr r = (r • ε : R[ε]) :=

--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -81,12 +81,11 @@ theorem snd_mul [Semiring R] (x y : R[ε]) : snd (x * y) = fst x * snd y + snd x
 @[simp]
 theorem eps_mul_eps [Semiring R] : (ε * ε : R[ε]) = 0 :=
   inr_mul_inr _ _ _
-
 #align dual_number.eps_mul_eps DualNumber.eps_mul_eps
 
 @[simp]
-theorem inv_eps [DivisionRing R] : (ε : R[ε])⁻¹ = 0 := by
-  exact TrivSqZeroExt.inv_inr 1
+theorem inv_eps [DivisionRing R] : (ε : R[ε])⁻¹ = 0 :=
+  TrivSqZeroExt.inv_inr 1
 
 @[simp]
 theorem inr_eq_smul_eps [MulZeroOneClass R] (r : R) : inr r = (r • ε : R[ε]) :=

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -435,9 +435,6 @@ instance one [One R] [Zero M] : One (tsze R M) :=
 instance mul [Mul R] [Add M] [SMul R M] [SMul Rᵐᵒᵖ M] : Mul (tsze R M) :=
   ⟨fun x y => (x.1 * y.1, x.1 •> y.2 + x.2 <• y.1)⟩
 
-instance div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] : Div (tsze R M) :=
-  ⟨fun a b => (a.1 / b.1, (a.2 <• b.1 - a.1 •> b.2) / (b.1 * b.1))⟩
-
 @[simp]
 theorem fst_one [One R] [Zero M] : (1 : tsze R M).fst = 1 :=
   rfl
@@ -459,16 +456,6 @@ theorem snd_mul [Mul R] [Add M] [SMul R M] [SMul Rᵐᵒᵖ M] (x₁ x₂ : tsze
     (x₁ * x₂).snd = x₁.fst •> x₂.snd + x₁.snd <• x₂.fst :=
   rfl
 #align triv_sq_zero_ext.snd_mul TrivSqZeroExt.snd_mul
-
-@[simp]
-theorem fst_div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] (x₁ x₂ : tsze R M) :
-    (x₁ / x₂).fst = x₁.fst / x₂.fst :=
-  rfl
-
-@[simp]
-theorem snd_div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] (x₁ x₂ : tsze R M) :
-    (x₁ / x₂).snd = (x₁.snd <• x₂.fst - x₁.fst •> x₂.snd) / (x₂.fst * x₂.fst):=
-  rfl
 
 section
 
@@ -750,6 +737,25 @@ def inlHom [Semiring R] [AddCommMonoid M] [Module R M] [Module Rᵐᵒᵖ M] : R
 #align triv_sq_zero_ext.inl_hom TrivSqZeroExt.inlHom
 
 end Mul
+
+section Div
+
+variable {R : Type u} {M : Type v}
+
+instance div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] : Div (tsze R M) :=
+  ⟨fun a b => (a.1 / b.1, (a.2 <• b.1 - a.1 •> b.2) / (b.1 * b.1))⟩
+
+@[simp]
+theorem fst_div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] (x₁ x₂ : tsze R M) :
+    (x₁ / x₂).fst = x₁.fst / x₂.fst :=
+  rfl
+
+@[simp]
+theorem snd_div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] (x₁ x₂ : tsze R M) :
+    (x₁ / x₂).snd = (x₁.snd <• x₂.fst - x₁.fst •> x₂.snd) / (x₂.fst * x₂.fst):=
+  rfl
+
+end Div
 
 section Algebra
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -767,19 +767,8 @@ protected theorem inv_mul_cancel [DivisionRing R] [AddCommGroup M]
     (hx : fst x ≠ 0) : x⁻¹ * x = 1 := by
   ext
   · rw [fst_mul, fst_inv, inv_mul_cancel hx, fst_one]
-
-  have op_smul_assoc' : ∀ a : M, ∀ b c : R, (a <• b) <• c = op (b * c) •> a   := by {
-    intro a b c
-    calc
-      _ = op c •> op b •> a := by rfl
-      _ = (op c •>  op b) •> a := by rw [smul_assoc]
-      _ = (op c * op b) •> a := by rw [smul_eq_mul]
-      _ = _ := by rw [← op_mul]
-  }
-
   rw [snd_mul, snd_inv, ← smul_comm, smul_neg]
-
-  rw [op_smul_assoc', inv_mul_cancel hx, op_one, one_smul]
+  rw [op_smul_op_smul, inv_mul_cancel hx, op_one, one_smul]
   rw [add_comm, fst_inv, add_left_neg, snd_one]
 
 end Inv

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -773,7 +773,7 @@ protected theorem inv_mul_cancel [DivisionRing R] [AddCommGroup M]
 
 protected theorem inv_inl [DivisionRing R] [AddCommGroup M]
     [Module Rᵐᵒᵖ M] [Module R M]
-    {r : R} :
+    (r : R) :
     (inl r)⁻¹ = (inl (r⁻¹ : R) : tsze R M) := by
   ext
   · rw [fst_inv, fst_inl, fst_inl]
@@ -782,12 +782,27 @@ protected theorem inv_inl [DivisionRing R] [AddCommGroup M]
 @[simp]
 theorem inv_inr [DivisionRing R] [AddCommGroup M]
     [Module Rᵐᵒᵖ M] [Module R M]
-    {m : M} :
+    (m : M) :
     (inr m)⁻¹ = (0 : tsze R M) := by
   ext
   · rw [fst_inv, fst_inr, fst_zero, inv_zero]
   rw [snd_inv, snd_inr, fst_inr]
   rw [inv_zero, zero_smul, snd_zero, neg_zero]
+
+@[simp]
+protected theorem inv_one [DivisionRing R][AddCommGroup M]
+    [Module Rᵐᵒᵖ M] [Module R M] : (inl 1 : tsze R M)⁻¹ = (inl 1 : tsze R M) := by
+  rw [TrivSqZeroExt.inv_inl, inv_one]
+
+-- protected theorem mul_inv_rev [DivisionRing R] [AddCommGroup M]
+--     [Module Rᵐᵒᵖ M] [Module R M]
+--     (a b : tsze R M) : (a * b)⁻¹ = b⁻¹ * a⁻¹ := by
+--     {
+--       ext
+--       · rw [fst_inv, fst_mul, fst_mul, mul_inv_rev (fst a : R) (fst b : R), fst_inv, fst_inv]
+--       rw [snd_inv, snd_mul, snd_mul, fst_mul, mul_inv_rev, mul_smul, smul_distrib_left]
+
+--     }
 
 end Inv
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -751,11 +751,11 @@ theorem fst_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] (x : tsze R M) :
 theorem snd_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] (x : tsze R M) :
   snd x⁻¹ = - ((fst x)⁻¹ •> (snd x <• (fst x)⁻¹)) := rfl
 
-theorem mul_inv_cancel [DivisionRing R] [AddCommGroup M] [Module Rᵐᵒᵖ M] [Module R M] {x : tsze R M} (hx : fst x ≠ 0) :
+theorem TrivEqZeroExt.mul_inv_cancel [DivisionRing R] [AddCommGroup M] [Module Rᵐᵒᵖ M] [Module R M] {x : tsze R M} (hx : fst x ≠ 0) :
   x * x⁻¹ = 1 := by
   ext
-  rw [fst_mul, fst_inv, fst_one, mul_inv_cancel hx]
-  rw [snd_mul, snd_inv, smul_neg, ← smul_assoc, smul_eq_mul, mul_inv_cancel hx, one_smul, fst_inv, add_left_neg, snd_one]
+  rw [fst_mul, fst_inv, fst_one, DivisionRing.mul_inv_cancel (fst x) hx]
+  rw [snd_mul, snd_inv, smul_neg, ← smul_assoc, smul_eq_mul, DivisionRing.mul_inv_cancel (fst x) hx, one_smul, fst_inv, add_left_neg, snd_one]
 
 end Inv
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -742,6 +742,7 @@ section Inv
 variable {R : Type u} {M : Type v}
 variable [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M]
 
+/-- Inversion of the trivial-square-zero extension, sending $r + m$ to $r^{-1} - r^{-1}mr^{-1}$. -/
 instance instInv : Inv (tsze R M) :=
   ⟨fun b => (b.1⁻¹, -(b.1⁻¹ •> b.2 <• b.1⁻¹))⟩
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -753,9 +753,9 @@ instance instInv : Inv (tsze R M) :=
 
 end Inv
 
-section DivisionRing
+section DivisionSemiring
 variable {R : Type u} {M : Type v}
-variable [DivisionRing R] [AddCommGroup M] [Module Rᵐᵒᵖ M] [Module R M] [SMulCommClass R Rᵐᵒᵖ M]
+variable [DivisionSemiring R] [AddCommGroup M] [Module Rᵐᵒᵖ M] [Module R M] [SMulCommClass R Rᵐᵒᵖ M]
 
 protected theorem inv_inl (r : R) :
     (inl r)⁻¹ = (inl (r⁻¹ : R) : tsze R M) := by
@@ -777,8 +777,7 @@ protected theorem inv_zero : (0 : tsze R M)⁻¹ = (0 : tsze R M) := by
 protected theorem inv_one : (1 : tsze R M)⁻¹ = (1 : tsze R M) := by
   rw [← inl_one, TrivSqZeroExt.inv_inl, inv_one]
 
-protected theorem mul_inv_cancel {x : tsze R M} (hx : fst x ≠ 0) :
-    x * x⁻¹ = 1 := by
+protected theorem mul_inv_cancel {x : tsze R M} (hx : fst x ≠ 0) : x * x⁻¹ = 1 := by
   ext
   · rw [fst_mul, fst_inv, fst_one, mul_inv_cancel hx]
   · rw [snd_mul, snd_inv, snd_one, smul_neg, smul_comm, smul_smul, mul_inv_cancel hx, one_smul,
@@ -812,6 +811,15 @@ protected theorem inv_inv {x : tsze R M} (hx : fst x ≠ 0) : x⁻¹⁻¹ = x :=
       rw [mul_assoc, TrivSqZeroExt.mul_inv_cancel, mul_one]
       rw [fst_inv]
       apply inv_ne_zero hx
+
+end DivisionSemiring
+
+section DivisionRing
+variable {R : Type u} {M : Type v}
+variable [DivisionRing R] [AddCommGroup M] [Module Rᵐᵒᵖ M] [Module R M] [SMulCommClass R Rᵐᵒᵖ M]
+
+protected theorem inv_neg {x : tsze R M} : (-x)⁻¹ = -(x⁻¹) := by
+  ext <;> simp [inv_neg]
 
 end DivisionRing
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -436,7 +436,7 @@ instance mul [Mul R] [Add M] [SMul R M] [SMul Rᵐᵒᵖ M] : Mul (tsze R M) :=
   ⟨fun x y => (x.1 * y.1, x.1 •> y.2 + x.2 <• y.1)⟩
 
 instance div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] : Div (tsze R M) :=
-  ⟨fun ⟨a, b⟩ ⟨c, d⟩ => ⟨(a/c), (b<•c - a•>d)/(c*c)⟩⟩
+  ⟨fun a b => (a.1 / b.1, (a.2 <• b.1 - a.1 •> b.2) / (b.1 * b.1))⟩
 
 @[simp]
 theorem fst_one [One R] [Zero M] : (1 : tsze R M).fst = 1 :=

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -771,6 +771,24 @@ protected theorem inv_mul_cancel [DivisionRing R] [AddCommGroup M]
   rw [op_smul_op_smul, inv_mul_cancel hx, op_one, one_smul]
   rw [add_comm, fst_inv, add_left_neg, snd_one]
 
+protected theorem inv_inl [DivisionRing R] [AddCommGroup M]
+    [Module Rᵐᵒᵖ M] [Module R M]
+    {r : R} (hr : r ≠ 0) :
+    (inl r)⁻¹ = (inl (r⁻¹ : R) : tsze R M) := by
+  ext
+  rw [fst_inv]
+  have : (fst (inl r)) * (fst (inl r⁻¹)) = 1 := by
+    rw [← fst_mul (inl r : tsze R M) (inl r⁻¹)]
+    rw [← inl_mul, fst_inl, mul_inv_cancel hr]
+  have : (fst (inl r))⁻¹ * ((fst (inl r)) * (fst (inl r⁻¹))) = (fst (inl r))⁻¹ := by
+    rw [this, mul_one (fst (inl r : tsze R M))⁻¹]
+  rw [← this, ← mul_assoc, inv_mul_cancel, one_mul]
+  rw [fst_inl]
+  exact hr
+
+  rw [snd_inv, snd_inl, snd_inl, fst_inl]
+  rw [smul_zero, smul_zero, neg_zero]
+
 end Inv
 
 section Algebra

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -746,16 +746,18 @@ instance inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] : Inv (tsze R M) :=
   ⟨fun b => (b.1⁻¹,  - (b.1⁻¹ •> (b.2 <• b.1⁻¹)))⟩
 
 theorem fst_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] (x : tsze R M) :
-  fst x⁻¹ = (fst x)⁻¹ := rfl
+  fst x⁻¹ = (fst x)⁻¹ :=
+    rfl
 
 theorem snd_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] (x : tsze R M) :
-  snd x⁻¹ = - ((fst x)⁻¹ •> (snd x <• (fst x)⁻¹)) := rfl
+  snd x⁻¹ = - ((fst x)⁻¹ •> (snd x <• (fst x)⁻¹)) :=
+    rfl
 
 theorem TrivEqZeroExt.mul_inv_cancel [DivisionRing R] [AddCommGroup M] [Module Rᵐᵒᵖ M] [Module R M] {x : tsze R M} (hx : fst x ≠ 0) :
   x * x⁻¹ = 1 := by
-  ext
-  rw [fst_mul, fst_inv, fst_one, DivisionRing.mul_inv_cancel (fst x) hx]
-  rw [snd_mul, snd_inv, smul_neg, ← smul_assoc, smul_eq_mul, DivisionRing.mul_inv_cancel (fst x) hx, one_smul, fst_inv, add_left_neg, snd_one]
+    ext
+    · rw [fst_mul, fst_inv, fst_one, DivisionRing.mul_inv_cancel (fst x) hx]
+    · rw [snd_mul, snd_inv, smul_neg, ← smul_assoc, smul_eq_mul, DivisionRing.mul_inv_cancel (fst x) hx, one_smul, fst_inv, add_left_neg, snd_one]
 
 end Inv
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -770,6 +770,10 @@ theorem inv_inr (m : M) : (inr m)⁻¹ = (0 : tsze R M) := by
   · rw [snd_inv, snd_inr, fst_inr, inv_zero, op_zero, zero_smul, snd_zero, neg_zero]
 
 @[simp]
+protected theorem inv_zero : (0 : tsze R M)⁻¹ = (0 : tsze R M) := by
+  rw [← inl_zero, TrivSqZeroExt.inv_inl, inv_zero]
+
+@[simp]
 protected theorem inv_one : (1 : tsze R M)⁻¹ = (1 : tsze R M) := by
   rw [← inl_one, TrivSqZeroExt.inv_inl, inv_one]
 
@@ -798,6 +802,16 @@ protected theorem mul_inv_rev (a b : tsze R M) :
     obtain hb0 | hb := eq_or_ne (fst b) 0
     · simp [hb0]
     rw [inv_mul_cancel_right₀ ha, mul_inv_cancel_left₀ hb]
+
+protected theorem inv_inv {x : tsze R M} (hx : fst x ≠ 0) : x⁻¹⁻¹ = x :=
+  -- adapted from `Matrix.nonsing_inv_nonsing_inv`
+  calc
+    x⁻¹⁻¹ = 1 * x⁻¹⁻¹ := by rw [one_mul]
+    _ = x * x⁻¹ * x⁻¹⁻¹ := by rw [TrivSqZeroExt.mul_inv_cancel hx]
+    _ = x := by
+      rw [mul_assoc, TrivSqZeroExt.mul_inv_cancel, mul_one]
+      rw [fst_inv]
+      apply inv_ne_zero hx
 
 end DivisionRing
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -745,19 +745,19 @@ variable {R : Type u} {M : Type v}
 instance inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] : Inv (tsze R M) :=
   ⟨fun b => (b.1⁻¹,  - (b.1⁻¹ •> (b.2 <• b.1⁻¹)))⟩
 
-theorem fst_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] (x : tsze R M) :
-  fst x⁻¹ = (fst x)⁻¹ :=
-    rfl
+theorem fst_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M]
+    (x : tsze R M) : fst x⁻¹ = (fst x)⁻¹ :=
+      rfl
 
 theorem snd_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] (x : tsze R M) :
-  snd x⁻¹ = - ((fst x)⁻¹ •> (snd x <• (fst x)⁻¹)) :=
-    rfl
+    snd x⁻¹ = - ((fst x)⁻¹ •> (snd x <• (fst x)⁻¹)) :=
+      rfl
 
-theorem TrivEqZeroExt.mul_inv_cancel [DivisionRing R] [AddCommGroup M] [Module Rᵐᵒᵖ M] [Module R M] {x : tsze R M} (hx : fst x ≠ 0) :
-  x * x⁻¹ = 1 := by
-    ext
-    · rw [fst_mul, fst_inv, fst_one, DivisionRing.mul_inv_cancel (fst x) hx]
-    · rw [snd_mul, snd_inv, smul_neg, ← smul_assoc, smul_eq_mul, DivisionRing.mul_inv_cancel (fst x) hx, one_smul, fst_inv, add_left_neg, snd_one]
+theorem TrivEqZeroExt.mul_inv_cancel [DivisionRing R] [AddCommGroup M] [Module Rᵐᵒᵖ M] [Module R M] {x : tsze R M}
+    (hx : fst x ≠ 0) : x * x⁻¹ = 1 := by
+      ext
+      · rw [fst_mul, fst_inv, fst_one, DivisionRing.mul_inv_cancel (fst x) hx]
+      · rw [snd_mul, snd_inv, smul_neg, ← smul_assoc, smul_eq_mul, DivisionRing.mul_inv_cancel (fst x) hx, one_smul, fst_inv, add_left_neg, snd_one]
 
 end Inv
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -753,15 +753,14 @@ theorem snd_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] (x : tsze R M) :
     snd x⁻¹ = - ((fst x)⁻¹ •> (snd x <• (fst x)⁻¹)) :=
       rfl
 
-theorem TrivEqZeroExt.mul_inv_cancel [DivisionRing R] [AddCommGroup M] [Module Rᵐᵒᵖ M] [Module R M] {x : tsze R M}
+theorem TrivEqZeroExt.mul_inv_cancel [DivisionRing R] [AddCommGroup M]
+    [Module Rᵐᵒᵖ M] [Module R M] {x : tsze R M}
     (hx : fst x ≠ 0) : x * x⁻¹ = 1 := by
       ext
       · rw [fst_mul, fst_inv, fst_one, DivisionRing.mul_inv_cancel (fst x) hx]
-      · rw [
-          snd_mul, snd_inv, smul_neg, ← smul_assoc,
-          smul_eq_mul, DivisionRing.mul_inv_cancel (fst x) hx,
-          one_smul, fst_inv, add_left_neg, snd_one
-        ]
+      rw [snd_mul, snd_inv, smul_neg, ← smul_assoc]
+      rw [smul_eq_mul, DivisionRing.mul_inv_cancel (fst x) hx]
+      rw [one_smul, fst_inv, add_left_neg, snd_one]
 
 end Inv
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -7,9 +7,6 @@ import Mathlib.Algebra.Algebra.Basic
 import Mathlib.GroupTheory.GroupAction.BigOperators
 import Mathlib.LinearAlgebra.Prod
 
-import Mathlib.Tactic
-
-
 #align_import algebra.triv_sq_zero_ext from "leanprover-community/mathlib"@"ce7e9d53d4bbc38065db3b595cd5bd73c323bc1d"
 
 /-!

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -460,6 +460,16 @@ theorem snd_mul [Mul R] [Add M] [SMul R M] [SMul Rᵐᵒᵖ M] (x₁ x₂ : tsze
   rfl
 #align triv_sq_zero_ext.snd_mul TrivSqZeroExt.snd_mul
 
+@[simp]
+theorem fst_div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] (x₁ x₂ : tsze R M) :
+    (x₁ / x₂).fst = x₁.fst / x₂.fst :=
+  rfl
+
+@[simp]
+theorem snd_div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] (x₁ x₂ : tsze R M) :
+    (x₁ / x₂).snd = (x₁.snd <• x₂.fst - x₁.fst •> x₂.snd) / (x₂.fst * x₂.fst):=
+  rfl
+
 section
 
 variable (M)

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -768,21 +768,19 @@ protected theorem inv_mul_cancel [DivisionRing R] [AddCommGroup M]
   ext
   · rw [fst_mul, fst_inv, inv_mul_cancel hx, fst_one]
 
-  have op_smul_smul : ((fst x)⁻¹ •> (snd x <• (fst x)⁻¹)) <• fst x  = (fst x)⁻¹ •> ((snd x <• (fst x)⁻¹) <• fst x) := by rw [smul_comm]
-  have op_smul_assoc' : (snd x <• (fst x)⁻¹ <• fst x) = (op ((fst x)⁻¹ * fst x)) •> snd x := by {
+  have op_smul_assoc' : ∀ a : M, ∀ b c : R, (a <• b) <• c = op (b * c) •> a   := by {
+    intro a b c
     calc
-      _ = op (fst x) •> op ((fst x)⁻¹) •> snd x := rfl
-      _ = (op (fst x) •> op ((fst x)⁻¹)) •> snd x := by rw [smul_assoc]
-      _ = (op (fst x) * op ((fst x)⁻¹)) •> snd x := by rw [smul_eq_mul]
+      _ = op c •> op b •> a := by rfl
+      _ = (op c •>  op b) •> a := by rw [smul_assoc]
+      _ = (op c * op b) •> a := by rw [smul_eq_mul]
       _ = _ := by rw [← op_mul]
   }
-  have op_smul_one : (snd x) <• (1:R) = snd x := by simp only [op_one, one_smul]
 
-  rw [snd_mul, snd_inv]
-  simp [op]
+  rw [snd_mul, snd_inv, ← smul_comm, smul_neg]
 
-  rw [← op, op_smul_smul, op_smul_assoc', inv_mul_cancel hx]
-  rw [op_smul_one, add_comm, fst_inv, add_left_neg]
+  rw [op_smul_assoc', inv_mul_cancel hx, op_one, one_smul]
+  rw [add_comm, fst_inv, add_left_neg, snd_one]
 
 end Inv
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -757,38 +757,29 @@ protected theorem mul_inv_cancel [DivisionRing R] [AddCommGroup M]
     [Module Rᵐᵒᵖ M] [Module R M] {x : tsze R M}
     (hx : fst x ≠ 0) : x * x⁻¹ = 1 := by
   ext
-  · rw [fst_mul, fst_inv, fst_one, DivisionRing.mul_inv_cancel (fst x) hx]
-  rw [snd_mul, snd_inv, smul_neg, ← smul_assoc]
-  rw [smul_eq_mul, DivisionRing.mul_inv_cancel (fst x) hx]
-  rw [one_smul, fst_inv, add_left_neg, snd_one]
+  · rw [fst_mul, fst_inv, fst_one, mul_inv_cancel hx]
+  · rw [snd_mul, snd_inv, snd_one, smul_neg, smul_smul,
+    mul_inv_cancel hx, one_smul, fst_inv,add_left_neg]
+
 
 protected theorem inv_mul_cancel [DivisionRing R] [AddCommGroup M]
     [Module Rᵐᵒᵖ M] [Module R M] [SMulCommClass Rᵐᵒᵖ R M] {x : tsze R M}
     (hx : fst x ≠ 0) : x⁻¹ * x = 1 := by
   ext
   · rw [fst_mul, fst_inv, inv_mul_cancel hx, fst_one]
-  rw [snd_mul, snd_inv, ← smul_comm, smul_neg]
-  rw [op_smul_op_smul, inv_mul_cancel hx, op_one, one_smul]
-  rw [add_comm, fst_inv, add_left_neg, snd_one]
+  · rw [snd_mul, snd_inv, snd_one, smul_neg, smul_comm, op_smul_op_smul,
+    inv_mul_cancel hx, op_one, one_smul, fst_inv, add_right_neg]
+
 
 protected theorem inv_inl [DivisionRing R] [AddCommGroup M]
     [Module Rᵐᵒᵖ M] [Module R M]
-    {r : R} (hr : r ≠ 0) :
+    {r : R} :
     (inl r)⁻¹ = (inl (r⁻¹ : R) : tsze R M) := by
   ext
-  rw [fst_inv]
-  have : (fst (inl r)) * (fst (inl r⁻¹)) = 1 := by
-    rw [← fst_mul (inl r : tsze R M) (inl r⁻¹)]
-    rw [← inl_mul, fst_inl, mul_inv_cancel hr]
-  have : (fst (inl r))⁻¹ * ((fst (inl r)) * (fst (inl r⁻¹))) = (fst (inl r))⁻¹ := by
-    rw [this, mul_one (fst (inl r : tsze R M))⁻¹]
-  rw [← this, ← mul_assoc, inv_mul_cancel, one_mul]
-  rw [fst_inl]
-  exact hr
+  · rw [fst_inv, fst_inl, fst_inl]
+  · rw [snd_inv, fst_inl, snd_inl, snd_inl, smul_zero, smul_zero, neg_zero]
 
-  rw [snd_inv, snd_inl, snd_inl, fst_inl]
-  rw [smul_zero, smul_zero, neg_zero]
-
+@[simp]
 theorem inv_inr [DivisionRing R] [AddCommGroup M]
     [Module Rᵐᵒᵖ M] [Module R M]
     {m : M} :

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -742,8 +742,20 @@ section Inv
 
 variable {R : Type u} {M : Type v}
 
-instance inv [Field R] [Semiring M] [SMul Rᵐᵒᵖ M] [SMul R M] : Inv (tsze R M) :=
-  ⟨fun b => (b.1⁻¹, (b.1 * (b.1 * b.1)⁻¹)  •> (1:M) + (b.2 <• (b.1 * b.1)⁻¹))⟩
+instance inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] : Inv (tsze R M) :=
+  ⟨fun b => (b.1⁻¹,  - (b.1⁻¹ •> (b.2 <• b.1⁻¹)))⟩
+
+theorem fst_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] (x : tsze R M) :
+  fst x⁻¹ = (fst x)⁻¹ := rfl
+
+theorem snd_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] (x : tsze R M) :
+  snd x⁻¹ = - ((fst x)⁻¹ •> (snd x <• (fst x)⁻¹)) := rfl
+
+theorem mul_inv_cancel [DivisionRing R] [AddCommGroup M] [Module Rᵐᵒᵖ M] [Module R M] {x : tsze R M} (hx : fst x ≠ 0) :
+  x * x⁻¹ = 1 := by
+  ext
+  rw [fst_mul, fst_inv, fst_one, mul_inv_cancel hx]
+  rw [snd_mul, snd_inv, smul_neg, ← smul_assoc, smul_eq_mul, mul_inv_cancel hx, one_smul, fst_inv, add_left_neg, snd_one]
 
 end Inv
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -435,6 +435,9 @@ instance one [One R] [Zero M] : One (tsze R M) :=
 instance mul [Mul R] [Add M] [SMul R M] [SMul Rᵐᵒᵖ M] : Mul (tsze R M) :=
   ⟨fun x y => (x.1 * y.1, x.1 •> y.2 + x.2 <• y.1)⟩
 
+instance div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] : Div (tsze R M) :=
+  ⟨fun ⟨a, b⟩ ⟨c, d⟩ => ⟨(a/c), (b<•c - a•>d)/(c*c)⟩⟩
+
 @[simp]
 theorem fst_one [One R] [Zero M] : (1 : tsze R M).fst = 1 :=
   rfl

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -7,6 +7,9 @@ import Mathlib.Algebra.Algebra.Basic
 import Mathlib.GroupTheory.GroupAction.BigOperators
 import Mathlib.LinearAlgebra.Prod
 
+import Mathlib.Tactic
+
+
 #align_import algebra.triv_sq_zero_ext from "leanprover-community/mathlib"@"ce7e9d53d4bbc38065db3b595cd5bd73c323bc1d"
 
 /-!
@@ -747,20 +750,42 @@ instance inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] : Inv (tsze R M) :=
 
 theorem fst_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M]
     (x : tsze R M) : fst x⁻¹ = (fst x)⁻¹ :=
-      rfl
+  rfl
 
 theorem snd_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] (x : tsze R M) :
     snd x⁻¹ = - ((fst x)⁻¹ •> (snd x <• (fst x)⁻¹)) :=
-      rfl
+  rfl
 
-theorem mul_inv_cancel [DivisionRing R] [AddCommGroup M]
+protected theorem mul_inv_cancel [DivisionRing R] [AddCommGroup M]
     [Module Rᵐᵒᵖ M] [Module R M] {x : tsze R M}
     (hx : fst x ≠ 0) : x * x⁻¹ = 1 := by
-      ext
-      · rw [fst_mul, fst_inv, fst_one, DivisionRing.mul_inv_cancel (fst x) hx]
-      rw [snd_mul, snd_inv, smul_neg, ← smul_assoc]
-      rw [smul_eq_mul, DivisionRing.mul_inv_cancel (fst x) hx]
-      rw [one_smul, fst_inv, add_left_neg, snd_one]
+  ext
+  · rw [fst_mul, fst_inv, fst_one, DivisionRing.mul_inv_cancel (fst x) hx]
+  rw [snd_mul, snd_inv, smul_neg, ← smul_assoc]
+  rw [smul_eq_mul, DivisionRing.mul_inv_cancel (fst x) hx]
+  rw [one_smul, fst_inv, add_left_neg, snd_one]
+
+protected theorem inv_mul_cancel [DivisionRing R] [AddCommGroup M]
+    [Module Rᵐᵒᵖ M] [Module R M] [SMulCommClass Rᵐᵒᵖ R M] {x : tsze R M}
+    (hx : fst x ≠ 0) : x⁻¹ * x = 1 := by
+  ext
+  · rw [fst_mul, fst_inv, inv_mul_cancel hx, fst_one]
+
+  have op_smul_smul : ((fst x)⁻¹ •> (snd x <• (fst x)⁻¹)) <• fst x  = (fst x)⁻¹ •> ((snd x <• (fst x)⁻¹) <• fst x) := by rw [smul_comm]
+  have op_smul_assoc' : (snd x <• (fst x)⁻¹ <• fst x) = (op ((fst x)⁻¹ * fst x)) •> snd x := by {
+    calc
+      _ = op (fst x) •> op ((fst x)⁻¹) •> snd x := rfl
+      _ = (op (fst x) •> op ((fst x)⁻¹)) •> snd x := by rw [smul_assoc]
+      _ = (op (fst x) * op ((fst x)⁻¹)) •> snd x := by rw [smul_eq_mul]
+      _ = _ := by rw [← op_mul]
+  }
+  have op_smul_one : (snd x) <• (1:R) = snd x := by simp only [op_one, one_smul]
+
+  rw [snd_mul, snd_inv]
+  simp [op]
+
+  rw [← op, op_smul_smul, op_smul_assoc', inv_mul_cancel hx]
+  rw [op_smul_one, add_comm, fst_inv, add_left_neg]
 
 end Inv
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -742,7 +742,7 @@ section Inv
 
 variable {R : Type u} {M : Type v}
 
-instance inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] : Inv (tsze R M) :=
+instance instInv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] : Inv (tsze R M) :=
   ⟨fun b => (b.1⁻¹,  - (b.1⁻¹ •> (b.2 <• b.1⁻¹)))⟩
 
 theorem fst_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M]

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -791,8 +791,8 @@ theorem inv_inr [DivisionRing R] [AddCommGroup M]
 
 @[simp]
 protected theorem inv_one [DivisionRing R][AddCommGroup M]
-    [Module Rᵐᵒᵖ M] [Module R M] : (inl 1 : tsze R M)⁻¹ = (inl 1 : tsze R M) := by
-  rw [TrivSqZeroExt.inv_inl, inv_one]
+    [Module Rᵐᵒᵖ M] [Module R M] : (1 : tsze R M)⁻¹ = (1 : tsze R M) := by
+  rw [← inl_one, TrivSqZeroExt.inv_inl, inv_one]
 
 -- protected theorem mul_inv_rev [DivisionRing R] [AddCommGroup M]
 --     [Module Rᵐᵒᵖ M] [Module R M]

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -738,24 +738,14 @@ def inlHom [Semiring R] [AddCommMonoid M] [Module R M] [Module Rᵐᵒᵖ M] : R
 
 end Mul
 
-section Div
+section Inv
 
 variable {R : Type u} {M : Type v}
 
-instance div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] : Div (tsze R M) :=
-  ⟨fun a b => (a.1 / b.1, (a.2 <• b.1 - a.1 •> b.2) / (b.1 * b.1))⟩
+instance inv [Field R] [Semiring M] [SMul Rᵐᵒᵖ M] [SMul R M] : Inv (tsze R M) :=
+  ⟨fun b => (b.1⁻¹, (b.1 * (b.1 * b.1)⁻¹)  •> (1:M) + (b.2 <• (b.1 * b.1)⁻¹))⟩
 
-@[simp]
-theorem fst_div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] (x₁ x₂ : tsze R M) :
-    (x₁ / x₂).fst = x₁.fst / x₂.fst :=
-  rfl
-
-@[simp]
-theorem snd_div [Sub M] [Mul R] [Div R] [HDiv M R M] [SMul Rᵐᵒᵖ M] [SMul R M] (x₁ x₂ : tsze R M) :
-    (x₁ / x₂).snd = (x₁.snd <• x₂.fst - x₁.fst •> x₂.snd) / (x₂.fst * x₂.fst):=
-  rfl
-
-end Div
+end Inv
 
 section Algebra
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -739,75 +739,67 @@ def inlHom [Semiring R] [AddCommMonoid M] [Module R M] [Module Rᵐᵒᵖ M] : R
 end Mul
 
 section Inv
-
 variable {R : Type u} {M : Type v}
+variable [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M]
 
-instance instInv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] : Inv (tsze R M) :=
-  ⟨fun b => (b.1⁻¹,  - (b.1⁻¹ •> (b.2 <• b.1⁻¹)))⟩
+instance instInv : Inv (tsze R M) :=
+  ⟨fun b => (b.1⁻¹, -(b.1⁻¹ •> b.2 <• b.1⁻¹))⟩
 
-theorem fst_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M]
-    (x : tsze R M) : fst x⁻¹ = (fst x)⁻¹ :=
+@[simp] theorem fst_inv (x : tsze R M) : fst x⁻¹ = (fst x)⁻¹ :=
   rfl
 
-theorem snd_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] (x : tsze R M) :
-    snd x⁻¹ = - ((fst x)⁻¹ •> (snd x <• (fst x)⁻¹)) :=
+@[simp] theorem snd_inv (x : tsze R M) : snd x⁻¹ = -((fst x)⁻¹ •> snd x <• (fst x)⁻¹) :=
   rfl
 
-protected theorem mul_inv_cancel [DivisionRing R] [AddCommGroup M]
-    [Module Rᵐᵒᵖ M] [Module R M] {x : tsze R M}
-    (hx : fst x ≠ 0) : x * x⁻¹ = 1 := by
-  ext
-  · rw [fst_mul, fst_inv, fst_one, mul_inv_cancel hx]
-  · rw [snd_mul, snd_inv, snd_one, smul_neg, smul_smul,
-    mul_inv_cancel hx, one_smul, fst_inv,add_left_neg]
+end Inv
 
+section DivisionRing
+variable {R : Type u} {M : Type v}
+variable [DivisionRing R] [AddCommGroup M] [Module Rᵐᵒᵖ M] [Module R M] [SMulCommClass R Rᵐᵒᵖ M]
 
-protected theorem inv_mul_cancel [DivisionRing R] [AddCommGroup M]
-    [Module Rᵐᵒᵖ M] [Module R M] [SMulCommClass Rᵐᵒᵖ R M] {x : tsze R M}
-    (hx : fst x ≠ 0) : x⁻¹ * x = 1 := by
-  ext
-  · rw [fst_mul, fst_inv, inv_mul_cancel hx, fst_one]
-  · rw [snd_mul, snd_inv, snd_one, smul_neg, smul_comm, op_smul_op_smul,
-    inv_mul_cancel hx, op_one, one_smul, fst_inv, add_right_neg]
-
-
-protected theorem inv_inl [DivisionRing R] [AddCommGroup M]
-    [Module Rᵐᵒᵖ M] [Module R M]
-    (r : R) :
+protected theorem inv_inl (r : R) :
     (inl r)⁻¹ = (inl (r⁻¹ : R) : tsze R M) := by
   ext
   · rw [fst_inv, fst_inl, fst_inl]
   · rw [snd_inv, fst_inl, snd_inl, snd_inl, smul_zero, smul_zero, neg_zero]
 
 @[simp]
-theorem inv_inr [DivisionRing R] [AddCommGroup M]
-    [Module Rᵐᵒᵖ M] [Module R M]
-    (m : M) :
-    (inr m)⁻¹ = (0 : tsze R M) := by
+theorem inv_inr (m : M) : (inr m)⁻¹ = (0 : tsze R M) := by
   ext
   · rw [fst_inv, fst_inr, fst_zero, inv_zero]
-  rw [snd_inv, snd_inr, fst_inr]
-  rw [inv_zero, zero_smul, snd_zero, neg_zero]
+  · rw [snd_inv, snd_inr, fst_inr, inv_zero, op_zero, zero_smul, snd_zero, neg_zero]
 
 @[simp]
-protected theorem inv_one [DivisionRing R][AddCommGroup M]
-    [Module Rᵐᵒᵖ M] [Module R M] : (1 : tsze R M)⁻¹ = (1 : tsze R M) := by
+protected theorem inv_one : (1 : tsze R M)⁻¹ = (1 : tsze R M) := by
   rw [← inl_one, TrivSqZeroExt.inv_inl, inv_one]
 
-protected theorem mul_inv_rev [DivisionRing R] [AddCommGroup M]
-    [Module Rᵐᵒᵖ M] [Module R M] [SMulCommClass Rᵐᵒᵖ R M] (a b : tsze R M) :
+protected theorem mul_inv_cancel {x : tsze R M} (hx : fst x ≠ 0) :
+    x * x⁻¹ = 1 := by
+  ext
+  · rw [fst_mul, fst_inv, fst_one, mul_inv_cancel hx]
+  · rw [snd_mul, snd_inv, snd_one, smul_neg, smul_comm, smul_smul, mul_inv_cancel hx, one_smul,
+      fst_inv, add_left_neg]
+
+protected theorem inv_mul_cancel {x : tsze R M} (hx : fst x ≠ 0) : x⁻¹ * x = 1 := by
+  ext
+  · rw [fst_mul, fst_inv, inv_mul_cancel hx, fst_one]
+  · rw [snd_mul, snd_inv, snd_one, smul_neg, op_smul_op_smul, inv_mul_cancel hx, op_one, one_smul,
+      fst_inv, add_right_neg]
+
+protected theorem mul_inv_rev (a b : tsze R M) :
     (a * b)⁻¹ = b⁻¹ * a⁻¹ := by
   ext
   · rw [fst_inv, fst_mul, fst_mul, mul_inv_rev, fst_inv, fst_inv]
-  · rw [snd_inv, snd_mul, snd_mul, fst_mul, mul_inv_rev, smul_add, op_smul_op_smul]
-    simp only [smul_comm, smul_smul, ← op_mul, smul_add, fst_inv, snd_inv, smul_neg]
+  · simp only [snd_inv, snd_mul, fst_mul, fst_inv]
+    simp only [neg_smul, smul_neg, smul_add]
+    simp_rw [mul_inv_rev, smul_comm (_ : R), op_smul_op_smul, smul_smul, add_comm, neg_add]
     obtain ha0 | ha := eq_or_ne (fst a) 0
     · simp [ha0]
     obtain hb0 | hb := eq_or_ne (fst b) 0
     · simp [hb0]
-    rw [inv_mul_cancel_right₀ ha, add_comm, mul_inv_cancel_left₀ hb, neg_add]
+    rw [inv_mul_cancel_right₀ ha, mul_inv_cancel_left₀ hb]
 
-end Inv
+end DivisionRing
 
 section Algebra
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -753,7 +753,7 @@ theorem snd_inv [Neg M] [Inv R] [SMul Rᵐᵒᵖ M] [SMul R M] (x : tsze R M) :
     snd x⁻¹ = - ((fst x)⁻¹ •> (snd x <• (fst x)⁻¹)) :=
       rfl
 
-theorem TrivEqZeroExt.mul_inv_cancel [DivisionRing R] [AddCommGroup M]
+theorem mul_inv_cancel [DivisionRing R] [AddCommGroup M]
     [Module Rᵐᵒᵖ M] [Module R M] {x : tsze R M}
     (hx : fst x ≠ 0) : x * x⁻¹ = 1 := by
       ext

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -789,6 +789,15 @@ protected theorem inv_inl [DivisionRing R] [AddCommGroup M]
   rw [snd_inv, snd_inl, snd_inl, fst_inl]
   rw [smul_zero, smul_zero, neg_zero]
 
+protected theorem inv_inr [DivisionRing R] [AddCommGroup M]
+    [Module Rᵐᵒᵖ M] [Module R M]
+    {m : M} :
+    (inr m)⁻¹ = (0 : tsze R M) := by
+  ext
+  · rw [fst_inv, fst_inr, fst_zero, inv_zero]
+  rw [snd_inv, snd_inr, fst_inr]
+  rw [inv_zero, zero_smul, snd_zero, neg_zero]
+
 end Inv
 
 section Algebra

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -794,15 +794,18 @@ protected theorem inv_one [DivisionRing R][AddCommGroup M]
     [Module Rᵐᵒᵖ M] [Module R M] : (1 : tsze R M)⁻¹ = (1 : tsze R M) := by
   rw [← inl_one, TrivSqZeroExt.inv_inl, inv_one]
 
--- protected theorem mul_inv_rev [DivisionRing R] [AddCommGroup M]
---     [Module Rᵐᵒᵖ M] [Module R M]
---     (a b : tsze R M) : (a * b)⁻¹ = b⁻¹ * a⁻¹ := by
---     {
---       ext
---       · rw [fst_inv, fst_mul, fst_mul, mul_inv_rev (fst a : R) (fst b : R), fst_inv, fst_inv]
---       rw [snd_inv, snd_mul, snd_mul, fst_mul, mul_inv_rev, mul_smul, smul_distrib_left]
-
---     }
+protected theorem mul_inv_rev [DivisionRing R] [AddCommGroup M]
+    [Module Rᵐᵒᵖ M] [Module R M] [SMulCommClass Rᵐᵒᵖ R M] (a b : tsze R M) :
+    (a * b)⁻¹ = b⁻¹ * a⁻¹ := by
+  ext
+  · rw [fst_inv, fst_mul, fst_mul, mul_inv_rev, fst_inv, fst_inv]
+  · rw [snd_inv, snd_mul, snd_mul, fst_mul, mul_inv_rev, smul_add, op_smul_op_smul]
+    simp only [smul_comm, smul_smul, ← op_mul, smul_add, fst_inv, snd_inv, smul_neg]
+    obtain ha0 | ha := eq_or_ne (fst a) 0
+    · simp [ha0]
+    obtain hb0 | hb := eq_or_ne (fst b) 0
+    · simp [hb0]
+    rw [inv_mul_cancel_right₀ ha, add_comm, mul_inv_cancel_left₀ hb, neg_add]
 
 end Inv
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -757,7 +757,11 @@ theorem TrivEqZeroExt.mul_inv_cancel [DivisionRing R] [AddCommGroup M] [Module R
     (hx : fst x ≠ 0) : x * x⁻¹ = 1 := by
       ext
       · rw [fst_mul, fst_inv, fst_one, DivisionRing.mul_inv_cancel (fst x) hx]
-      · rw [snd_mul, snd_inv, smul_neg, ← smul_assoc, smul_eq_mul, DivisionRing.mul_inv_cancel (fst x) hx, one_smul, fst_inv, add_left_neg, snd_one]
+      · rw [
+          snd_mul, snd_inv, smul_neg, ← smul_assoc,
+          smul_eq_mul, DivisionRing.mul_inv_cancel (fst x) hx,
+          one_smul, fst_inv, add_left_neg, snd_one
+        ]
 
 end Inv
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -789,7 +789,7 @@ protected theorem inv_inl [DivisionRing R] [AddCommGroup M]
   rw [snd_inv, snd_inl, snd_inl, fst_inl]
   rw [smul_zero, smul_zero, neg_zero]
 
-protected theorem inv_inr [DivisionRing R] [AddCommGroup M]
+theorem inv_inr [DivisionRing R] [AddCommGroup M]
     [Module Rᵐᵒᵖ M] [Module R M]
     {m : M} :
     (inr m)⁻¹ = (0 : tsze R M) := by


### PR DESCRIPTION

Defined inverses for TrivEqExtZero in a way that is consitent with DualNumbers.

Note that $(a + b\epsilon)^{-1} = \frac{1(a - b\epsilon)}{(a + b\epsilon)(a - b\epsilon)} = \frac{a - b\epsilon}{a^2}$
Which becomes $\frac{1}{a} - \frac{b}{a^2}\epsilon$.
We want to be able have left multiplicative inverses $x x^{-1} = 0$
So we write $\frac{b}{a^2} = a^{-1} \cdot b \cdot a^{-1}$

Also included a proof that $x \cdot x^{-1} = 1$ when $\text{fst } x \neq 0$

