### PR TITLE
[Merged by Bors] - fix: make sure tactics in DefEqTransformations do not reorder hypotheses

### DIFF
--- a/Mathlib/Tactic/DefEqTransformations.lean
+++ b/Mathlib/Tactic/DefEqTransformations.lean
@@ -17,6 +17,31 @@ namespace Mathlib.Tactic
 
 open Lean Meta Elab Elab.Tactic
 
+/--
+This is `Lean.MVarId.changeLocalDecl` but makes sure to preserve local variable order.
+-/
+def _root_.Lean.MVarId.changeLocalDecl' (mvarId : MVarId) (fvarId : FVarId) (typeNew : Expr)
+    (checkDefEq := true) : MetaM MVarId := do
+  mvarId.checkNotAssigned `changeLocalDecl
+  let lctx := (← mvarId.getDecl).lctx
+  let some decl := lctx.find? fvarId | throwTacticEx `changeLocalDecl mvarId m!"\
+    local variable {Expr.fvar fvarId} is not present in local context{mvarId}"
+  let toRevert := lctx.foldl (init := #[]) fun arr decl' =>
+    if decl.index ≤ decl'.index then arr.push decl'.fvarId else arr
+  let (_, mvarId) ← mvarId.withReverted toRevert fun mvarId fvars => mvarId.withContext do
+    let check (typeOld : Expr) : MetaM Unit := do
+      if checkDefEq then
+        unless ← isDefEq typeNew typeOld do
+          throwTacticEx `changeLocalDecl mvarId
+            m!"given type{indentExpr typeNew}\nis not definitionally equal to{indentExpr typeOld}"
+    let finalize (targetNew : Expr) := do
+      return ((), fvars.map .some, ← mvarId.replaceTargetDefEq targetNew)
+    match ← mvarId.getType with
+    | .forallE n d b bi => do check d; finalize (.forallE n typeNew b bi)
+    | .letE n t v b ndep => do check t; finalize (.letE n typeNew v b ndep)
+    | _ => throwTacticEx `changeLocalDecl mvarId "unexpected auxiliary target"
+  return mvarId
+
 /-- For the main goal, use `m` to transform the types of locations specified by `loc?`.
 If `loc?` is none, then transforms the type of target. `m` is provided with an expression
 with instantiated metavariables.
@@ -31,8 +56,12 @@ def runDefEqTactic (m : Expr → MetaM Expr)
     TacticM Unit := withMainContext do
   withLocation (expandOptLocation (Lean.mkOptionalNode loc?))
     (atLocal := fun h => liftMetaTactic1 fun mvarId => do
-      let ty ← instantiateMVars (← h.getType)
-      mvarId.changeLocalDecl (checkDefEq := checkDefEq) h (← m ty))
+      let ty ← h.getType
+      let ty' ← m (← instantiateMVars ty)
+      if Expr.equal ty ty' then
+        return mvarId
+      else
+        mvarId.changeLocalDecl' (checkDefEq := checkDefEq) h ty')
     (atTarget := liftMetaTactic1 fun mvarId => do
       let ty ← instantiateMVars (← mvarId.getType)
       mvarId.change (checkDefEq := checkDefEq) (← m ty))

--- a/test/DefEqTransformations.lean
+++ b/test/DefEqTransformations.lean
@@ -71,6 +71,22 @@ example : let x := 1; let y := 2 + x; y = 3 := by
   guard_target =ₛ 2 + 1 = 3
   rfl
 
+/-!
+Do not reorder hypotheses. (`unfold_let` makes a change)
+-/
+example : let ty := Int; ty → Nat → Nat := by
+  intro _ a a
+  unfold_let at *
+  exact a
+
+/-!
+Do not reorder hypotheses. (`unfold_let` does not make a change)
+-/
+set_option linter.unusedVariables false in
+example (a : Int) (a : Nat) : Nat := by
+  unfold_let at *
+  exact a
+
 example : 1 + 2 = 2 + 1 := by
   unfold_projs
   guard_target =ₛ Nat.add (nat_lit 1) (nat_lit 2) = Nat.add (nat_lit 2) (nat_lit 1)


### PR DESCRIPTION
Reported by Damiano Testa [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60unfold_let.60.20weirdness/near/432757494).

The upstream function `Lean.MVarId.changeLocalDecl` should probably be changed to preserve hypothesis order, but for now we add the `Lean.MVarId.changeLocalDecl'` variant.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
