### PR TITLE
[Merged by Bors] - chore: move `FiniteDimensional.trans` higher up the import hierarchy

### DIFF
--- a/Mathlib/Analysis/RCLike/Lemmas.lean
+++ b/Mathlib/Analysis/RCLike/Lemmas.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis
 -/
 import Mathlib.Analysis.NormedSpace.FiniteDimension
-import Mathlib.FieldTheory.Tower
 import Mathlib.Analysis.RCLike.Basic
 
 #align_import data.is_R_or_C.lemmas from "leanprover-community/mathlib"@"468b141b14016d54b479eb7a0fff1e360b7e3cf6"

--- a/Mathlib/Data/Complex/Module.lean
+++ b/Mathlib/Data/Complex/Module.lean
@@ -3,11 +3,11 @@ Copyright (c) 2020 Alexander Bentkamp, Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bentkamp, Sébastien Gouëzel, Eric Wieser
 -/
+import Mathlib.Algebra.CharP.Invertible
 import Mathlib.Algebra.Order.Module.OrderedSMul
 import Mathlib.Data.Complex.Cardinality
 import Mathlib.Data.Fin.VecNotation
-import Mathlib.FieldTheory.Tower
-import Mathlib.Algebra.CharP.Invertible
+import Mathlib.LinearAlgebra.FiniteDimensional
 
 #align_import data.complex.module from "leanprover-community/mathlib"@"c7bce2818663f456335892ddbdd1809f111a5b72"
 

--- a/Mathlib/FieldTheory/Tower.lean
+++ b/Mathlib/FieldTheory/Tower.lean
@@ -48,10 +48,6 @@ namespace FiniteDimensional
 
 open IsNoetherian
 
-theorem trans [FiniteDimensional F K] [FiniteDimensional K A] : FiniteDimensional F A :=
-  Module.Finite.trans K A
-#align finite_dimensional.trans FiniteDimensional.trans
-
 /-- In a tower of field extensions `A / K / F`, if `A / F` is finite, so is `K / F`.
 
 (In fact, it suffices that `A` is a nontrivial ring.)

--- a/Mathlib/LinearAlgebra/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional.lean
@@ -344,6 +344,17 @@ theorem range_basisSingleton (ι : Type*) [Unique ι] (h : finrank K V = 1) (v :
 
 end DivisionRing
 
+section Tower
+
+variable (F K A : Type*) [DivisionRing F] [DivisionRing K] [AddCommGroup A]
+variable [Module F K] [Module K A] [Module F A] [IsScalarTower F K A]
+
+theorem trans [FiniteDimensional F K] [FiniteDimensional K A] : FiniteDimensional F A :=
+  Module.Finite.trans K A
+#align finite_dimensional.trans FiniteDimensional.trans
+
+end Tower
+
 end FiniteDimensional
 
 section ZeroRank


### PR DESCRIPTION
@YaelDillies pointed out that the import `Data.Complex.Module → FieldTheory.Tower` brings with it too many things. The only declaration from `FieldTheory.Tower` needed for `Data.Complex.Module` is `FiniteDimensional.trans`, which we can easily move up the import hierarchy (14 imports higher, in fact). So this means we can cut the long pole of Mathlib by up to 13 files.

Specific Zulip discussion starts here: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/The.20long.20pole.20in.20mathlib/near/432796670


---

I'm still awaiting the results of `shake`. Hopefully we can optimize a few more imports with this change.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
