### PR TITLE
[Merged by Bors] - chore: make instSMulRealComplex scoped

### DIFF
--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -351,8 +351,12 @@ instance : Nontrivial ℂ :=
 `RestrictScalars.module ℝ ℂ ℂ = Complex.module` definitionally. -/
 -- instance made local to avoid situations like instance synthesis
 -- of `SMul ℂ ℂ` trying to proceed via `SMul ℂ ℝ`.
-local instance instSMulRealComplex {R : Type*} [SMul R ℝ] : SMul R ℂ where
+namespace SMul
+scoped instance instSMulRealComplex {R : Type*} [SMul R ℝ] : SMul R ℂ where
   smul r x := ⟨r • x.re - 0 * x.im, r • x.im + 0 * x.re⟩
+end SMul
+
+open scoped SMul
 
 section SMul
 

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -348,12 +348,14 @@ instance : Nontrivial ℂ :=
 -- Porting note: moved from `Module/Data/Complex/Basic.lean`
 namespace SMul
 
+-- The useless `0` multiplication in `smul` is to make sure that
+-- `RestrictScalars.module ℝ ℂ ℂ = Complex.module` definitionally.
 -- instance made scoped to avoid situations like instance synthesis
 -- of `SMul ℂ ℂ` trying to proceed via `SMul ℂ ℝ`.
-scoped
-/- The useless `0` multiplication in `smul` is to make sure that
-`RestrictScalars.module ℝ ℂ ℂ = Complex.module` definitionally. -/
-instance instSMulRealComplex {R : Type*} [SMul R ℝ] : SMul R ℂ where
+/-- Scalar multiplication by `R` on `ℝ` extends to `ℂ`. This is used here and in
+`Matlib.Data.Complex.Module` to transfer instances from `ℝ` to `ℂ`, but is not
+needed outside, so we make it scoped. -/
+scoped instance instSMulRealComplex {R : Type*} [SMul R ℝ] : SMul R ℂ where
   smul r x := ⟨r • x.re - 0 * x.im, r • x.im + 0 * x.re⟩
 
 end SMul

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -125,6 +125,7 @@ def Set.reProdIm (s t : Set ℝ) : Set ℂ :=
   re ⁻¹' s ∩ im ⁻¹' t
 #align set.re_prod_im Complex.Set.reProdIm
 
+@[inherit_doc]
 infixl:72 " ×ℂ " => Set.reProdIm
 
 theorem mem_reProdIm {z : ℂ} {s t : Set ℝ} : z ∈ s ×ℂ t ↔ z.re ∈ s ∧ z.im ∈ t :=
@@ -355,7 +356,7 @@ namespace SMul
 /-- Scalar multiplication by `R` on `ℝ` extends to `ℂ`. This is used here and in
 `Matlib.Data.Complex.Module` to transfer instances from `ℝ` to `ℂ`, but is not
 needed outside, so we make it scoped. -/
-scoped instance instSMulRealComplex {R : Type*} [SMul R ℝ] : SMul R ℂ where
+@[nolint docBlame] scoped instance instSMulRealComplex {R : Type*} [SMul R ℝ] : SMul R ℂ where
   smul r x := ⟨r • x.re - 0 * x.im, r • x.im + 0 * x.re⟩
 
 end SMul

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -346,17 +346,17 @@ instance : Nontrivial ℂ :=
   pullback_nonzero re rfl rfl
 
 -- Porting note: moved from `Module/Data/Complex/Basic.lean`
-section SMul
-
-variable {R : Type*} [SMul R ℝ]
 
 /- The useless `0` multiplication in `smul` is to make sure that
 `RestrictScalars.module ℝ ℂ ℂ = Complex.module` definitionally. -/
--- priority manually adjusted in #12070, to avoid situations like instance synthesis
+-- instance made local to avoid situations like instance synthesis
 -- of `SMul ℂ ℂ` trying to proceed via `SMul ℂ ℝ`.
--- See issue #11692.
-instance (priority := 90) instSMulRealComplex : SMul R ℂ where
+local instance instSMulRealComplex {R : Type*} [SMul R ℝ] : SMul R ℂ where
   smul r x := ⟨r • x.re - 0 * x.im, r • x.im + 0 * x.re⟩
+
+section SMul
+
+variable {R : Type*} [SMul R ℝ]
 
 theorem smul_re (r : R) (z : ℂ) : (r • z).re = r • z.re := by simp [(· • ·), SMul.smul]
 #align complex.smul_re Complex.smul_re

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -346,14 +346,16 @@ instance : Nontrivial ℂ :=
   pullback_nonzero re rfl rfl
 
 -- Porting note: moved from `Module/Data/Complex/Basic.lean`
+namespace SMul
 
+-- instance made scoped to avoid situations like instance synthesis
+-- of `SMul ℂ ℂ` trying to proceed via `SMul ℂ ℝ`.
+scoped
 /- The useless `0` multiplication in `smul` is to make sure that
 `RestrictScalars.module ℝ ℂ ℂ = Complex.module` definitionally. -/
--- instance made local to avoid situations like instance synthesis
--- of `SMul ℂ ℂ` trying to proceed via `SMul ℂ ℝ`.
-namespace SMul
-scoped instance instSMulRealComplex {R : Type*} [SMul R ℝ] : SMul R ℂ where
+instance instSMulRealComplex {R : Type*} [SMul R ℝ] : SMul R ℂ where
   smul r x := ⟨r • x.re - 0 * x.im, r • x.im + 0 * x.re⟩
+
 end SMul
 
 open scoped SMul

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -356,7 +356,7 @@ namespace SMul
 /-- Scalar multiplication by `R` on `ℝ` extends to `ℂ`. This is used here and in
 `Matlib.Data.Complex.Module` to transfer instances from `ℝ` to `ℂ`, but is not
 needed outside, so we make it scoped. -/
-@[nolint docBlame] scoped instance instSMulRealComplex {R : Type*} [SMul R ℝ] : SMul R ℂ where
+scoped instance instSMulRealComplex {R : Type*} [SMul R ℝ] : SMul R ℂ where
   smul r x := ⟨r • x.re - 0 * x.im, r • x.im + 0 * x.re⟩
 
 end SMul

--- a/Mathlib/Data/Complex/Module.lean
+++ b/Mathlib/Data/Complex/Module.lean
@@ -48,12 +48,14 @@ namespace Complex
 
 open ComplexConjugate
 
+open scoped SMul
+
 variable {R : Type*} {S : Type*}
 
 attribute [local ext] Complex.ext
 
 -- Test that the `SMul ℚ ℂ` instance is correct.
-example : (Complex.instSMulRealComplex : SMul ℚ ℂ) = (Algebra.toSMul : SMul ℚ ℂ) := rfl
+example : (Complex.SMul.instSMulRealComplex : SMul ℚ ℂ) = (Algebra.toSMul : SMul ℚ ℂ) := rfl
 
 /- The priority of the following instances has been manually lowered, as when they don't apply
 they lead Lean to a very costly path, and most often they don't apply (most actions on `ℂ` don't

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -22,7 +22,7 @@ section SMul
 
 open scoped Polynomial
 
-example : (SubNegMonoid.SMulInt : SMul ℤ ℂ) = (Complex.instSMulRealComplex : SMul ℤ ℂ) := by
+example : (SubNegMonoid.SMulInt : SMul ℤ ℂ) = (Complex.SMul.instSMulRealComplex : SMul ℤ ℂ) := by
   with_reducible_and_instances rfl
 
 example : RestrictScalars.module ℝ ℂ ℂ = Complex.instModule := by


### PR DESCRIPTION
This scopes and moves to `Complex.SMul` the instance `instSMulRealComplex`.
Rationale: This instance is used in `Data.Complex.{Basic|Module}` to bootstrap `SMul` instances from the reals, but afterwards, instances `SMul R ℂ` should not need to rely on that (rather be obtained via `Algebra R ℂ`, for example). This speeds up the two mentioned files a bit (in fact, it reverts a slow-down caused by reducing the instance priority in #12070) and does not seem to have any adverse effects.

I think this is a cleaner solution compared to just reducing the instance priority.

See [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/simp.20prefers.20CharP.2Ecast_eq_zero.20over.20Nat.2Ecast_zero/near/432855625) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
