### PR TITLE
[Merged by Bors] - chore: small splits of `RingTheory.Ideal.Operations`; clean imports

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3370,6 +3370,8 @@ import Mathlib.RingTheory.Henselian
 import Mathlib.RingTheory.HopfAlgebra
 import Mathlib.RingTheory.Ideal.AssociatedPrime
 import Mathlib.RingTheory.Ideal.Basic
+import Mathlib.RingTheory.Ideal.Basis
+import Mathlib.RingTheory.Ideal.Colon
 import Mathlib.RingTheory.Ideal.Cotangent
 import Mathlib.RingTheory.Ideal.IdempotentFG
 import Mathlib.RingTheory.Ideal.LocalRing

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Yury Kudryashov
 -/
 import Mathlib.Algebra.Algebra.Basic
+import Mathlib.Algebra.Algebra.Prod
 import Mathlib.Data.Set.UnionLift
 import Mathlib.LinearAlgebra.Finsupp
 import Mathlib.RingTheory.Ideal.Operations

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -7,6 +7,7 @@ import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
 import Mathlib.LinearAlgebra.FreeModule.PID
 import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
 import Mathlib.LinearAlgebra.QuotientPi
+import Mathlib.RingTheory.Ideal.Basis
 
 #align_import linear_algebra.free_module.ideal_quotient from "leanprover-community/mathlib"@"90b0d53ee6ffa910e5c2a977ce7e2fc704647974"
 

--- a/Mathlib/RingTheory/Adjoin/Basic.lean
+++ b/Mathlib/RingTheory/Adjoin/Basic.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau
 -/
 import Mathlib.Algebra.Algebra.Operations
 import Mathlib.Algebra.Algebra.Subalgebra.Tower
+import Mathlib.LinearAlgebra.Basis
 import Mathlib.LinearAlgebra.Prod
 import Mathlib.LinearAlgebra.Finsupp
 

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson, Scott Carnahan
 -/
-import Mathlib.Algebra.BigOperators.Finprod
 import Mathlib.RingTheory.HahnSeries.Addition
 import Mathlib.Algebra.Algebra.Subalgebra.Basic
 import Mathlib.Data.Finset.MulAntidiagonal

--- a/Mathlib/RingTheory/HahnSeries/Summable.lean
+++ b/Mathlib/RingTheory/HahnSeries/Summable.lean
@@ -3,9 +3,10 @@ Copyright (c) 2021 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
-import Mathlib.RingTheory.HahnSeries.Multiplication
+import Mathlib.Algebra.BigOperators.Finprod
 import Mathlib.Algebra.EuclideanDomain.Instances
 import Mathlib.Algebra.Order.Group.WithTop
+import Mathlib.RingTheory.HahnSeries.Multiplication
 import Mathlib.RingTheory.Valuation.Basic
 
 #align_import ring_theory.hahn_series from "leanprover-community/mathlib"@"a484a7d0eade4e1268f4fb402859b6686037f965"

--- a/Mathlib/RingTheory/Ideal/Basis.lean
+++ b/Mathlib/RingTheory/Ideal/Basis.lean
@@ -3,8 +3,9 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
+import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.LinearAlgebra.Basis
-import Mathlib.RingTheory.Ideal.Operations
+import Mathlib.RingTheory.Ideal.Basic
 
 #align_import ring_theory.ideal.operations from "leanprover-community/mathlib"@"e7f0ddbf65bd7181a85edb74b64bdc35ba4bdc74"
 

--- a/Mathlib/RingTheory/Ideal/Basis.lean
+++ b/Mathlib/RingTheory/Ideal/Basis.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2018 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+import Mathlib.LinearAlgebra.Basis
+import Mathlib.RingTheory.Ideal.Operations
+
+#align_import ring_theory.ideal.operations from "leanprover-community/mathlib"@"e7f0ddbf65bd7181a85edb74b64bdc35ba4bdc74"
+
+/-!
+# The basis of ideals
+
+Some results involving `Ideal` and `Basis`.
+-/
+
+open BigOperators
+
+namespace Ideal
+
+variable {ι R S : Type*} [CommSemiring R] [CommRing S] [IsDomain S] [Algebra R S]
+
+/-- A basis on `S` gives a basis on `Ideal.span {x}`, by multiplying everything by `x`. -/
+noncomputable def basisSpanSingleton (b : Basis ι R S) {x : S} (hx : x ≠ 0) :
+    Basis ι R (span ({x} : Set S)) :=
+  b.map <|
+    LinearEquiv.ofInjective (Algebra.lmul R S x) (LinearMap.mul_injective hx) ≪≫ₗ
+        LinearEquiv.ofEq _ _
+          (by
+            ext
+            simp [mem_span_singleton', mul_comm]) ≪≫ₗ
+      (Submodule.restrictScalarsEquiv R S S (Ideal.span ({x} : Set S))).restrictScalars R
+#align ideal.basis_span_singleton Ideal.basisSpanSingleton
+
+@[simp]
+theorem basisSpanSingleton_apply (b : Basis ι R S) {x : S} (hx : x ≠ 0) (i : ι) :
+    (basisSpanSingleton b hx i : S) = x * b i := by
+  simp only [basisSpanSingleton, Basis.map_apply, LinearEquiv.trans_apply,
+    Submodule.restrictScalarsEquiv_apply, LinearEquiv.ofInjective_apply, LinearEquiv.coe_ofEq_apply,
+    LinearEquiv.restrictScalars_apply, Algebra.coe_lmul_eq_mul, LinearMap.mul_apply']
+  -- This used to be the end of the proof before leanprover/lean4#2644
+  erw [LinearEquiv.coe_ofEq_apply, LinearEquiv.ofInjective_apply, Algebra.coe_lmul_eq_mul,
+    LinearMap.mul_apply']
+#align ideal.basis_span_singleton_apply Ideal.basisSpanSingleton_apply
+
+@[simp]
+theorem constr_basisSpanSingleton {N : Type*} [Semiring N] [Module N S] [SMulCommClass R N S]
+    (b : Basis ι R S) {x : S} (hx : x ≠ 0) :
+    (b.constr N).toFun (((↑) : _ → S) ∘ (basisSpanSingleton b hx)) = Algebra.lmul R S x :=
+  b.ext fun i => by
+    erw [Basis.constr_basis, Function.comp_apply, basisSpanSingleton_apply, LinearMap.mul_apply']
+#align ideal.constr_basis_span_singleton Ideal.constr_basisSpanSingleton
+
+end Ideal
+
+-- Porting note: added explicit coercion `(b i : S)`
+/-- If `I : Ideal S` has a basis over `R`,
+`x ∈ I` iff it is a linear combination of basis vectors. -/
+theorem Basis.mem_ideal_iff {ι R S : Type*} [CommRing R] [CommRing S] [Algebra R S] {I : Ideal S}
+    (b : Basis ι R I) {x : S} : x ∈ I ↔ ∃ c : ι →₀ R, x = Finsupp.sum c fun i x => x • (b i : S) :=
+  (b.map ((I.restrictScalarsEquiv R _ _).restrictScalars R).symm).mem_submodule_iff
+#align basis.mem_ideal_iff Basis.mem_ideal_iff
+
+/-- If `I : Ideal S` has a finite basis over `R`,
+`x ∈ I` iff it is a linear combination of basis vectors. -/
+theorem Basis.mem_ideal_iff' {ι R S : Type*} [Fintype ι] [CommRing R] [CommRing S] [Algebra R S]
+    {I : Ideal S} (b : Basis ι R I) {x : S} : x ∈ I ↔ ∃ c : ι → R, x = ∑ i, c i • (b i : S) :=
+  (b.map ((I.restrictScalarsEquiv R _ _).restrictScalars R).symm).mem_submodule_iff'
+#align basis.mem_ideal_iff' Basis.mem_ideal_iff'

--- a/Mathlib/RingTheory/Ideal/Colon.lean
+++ b/Mathlib/RingTheory/Ideal/Colon.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2018 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+-/
+import Mathlib.LinearAlgebra.Quotient
+import Mathlib.RingTheory.Ideal.Operations
+
+/-!
+# The colon ideal
+
+This file defines `Submodule.colon N P` as the ideal of all elements `r : R` such that `r • P ⊆ N`.
+The normal notation for this would be `N : P` which has already been taken by type theory.
+
+-/
+
+namespace Submodule
+
+open BigOperators Pointwise
+
+variable {R M M' F G : Type*} [CommRing R] [AddCommGroup M] [Module R M]
+variable {N N₁ N₂ P P₁ P₂ : Submodule R M}
+
+/-- `N.colon P` is the ideal of all elements `r : R` such that `r • P ⊆ N`. -/
+def colon (N P : Submodule R M) : Ideal R :=
+  annihilator (P.map N.mkQ)
+#align submodule.colon Submodule.colon
+
+theorem mem_colon {r} : r ∈ N.colon P ↔ ∀ p ∈ P, r • p ∈ N :=
+  mem_annihilator.trans
+     ⟨fun H p hp => (Quotient.mk_eq_zero N).1 (H (Quotient.mk p) (mem_map_of_mem hp)),
+       fun H _ ⟨p, hp, hpm⟩ => hpm ▸ (N.mkQ.map_smul r p ▸ (Quotient.mk_eq_zero N).2 <| H p hp)⟩
+#align submodule.mem_colon Submodule.mem_colon
+
+theorem mem_colon' {r} : r ∈ N.colon P ↔ P ≤ comap (r • (LinearMap.id : M →ₗ[R] M)) N :=
+  mem_colon
+#align submodule.mem_colon' Submodule.mem_colon'
+
+@[simp]
+theorem colon_top {I : Ideal R} : I.colon ⊤ = I := by
+  simp_rw [SetLike.ext_iff, mem_colon, smul_eq_mul]
+  exact fun x ↦ ⟨fun h ↦ mul_one x ▸ h 1 trivial, fun h _ _ ↦ I.mul_mem_right _ h⟩
+
+@[simp]
+theorem colon_bot : colon ⊥ N = N.annihilator := by
+  simp_rw [SetLike.ext_iff, mem_colon, mem_annihilator, mem_bot, forall_const]
+
+theorem colon_mono (hn : N₁ ≤ N₂) (hp : P₁ ≤ P₂) : N₁.colon P₂ ≤ N₂.colon P₁ := fun _ hrnp =>
+  mem_colon.2 fun p₁ hp₁ => hn <| mem_colon.1 hrnp p₁ <| hp hp₁
+#align submodule.colon_mono Submodule.colon_mono
+
+theorem iInf_colon_iSup (ι₁ : Sort*) (f : ι₁ → Submodule R M) (ι₂ : Sort*)
+    (g : ι₂ → Submodule R M) : (⨅ i, f i).colon (⨆ j, g j) = ⨅ (i) (j), (f i).colon (g j) :=
+  le_antisymm (le_iInf fun _ => le_iInf fun _ => colon_mono (iInf_le _ _) (le_iSup _ _)) fun _ H =>
+    mem_colon'.2 <|
+      iSup_le fun j =>
+        map_le_iff_le_comap.1 <|
+          le_iInf fun i =>
+            map_le_iff_le_comap.2 <|
+              mem_colon'.1 <|
+                have := (mem_iInf _).1 H i
+                have := (mem_iInf _).1 this j
+                this
+#align submodule.infi_colon_supr Submodule.iInf_colon_iSup
+
+@[simp]
+theorem mem_colon_singleton {N : Submodule R M} {x : M} {r : R} :
+    r ∈ N.colon (Submodule.span R {x}) ↔ r • x ∈ N :=
+  calc
+    r ∈ N.colon (Submodule.span R {x}) ↔ ∀ a : R, r • a • x ∈ N := by
+      simp [Submodule.mem_colon, Submodule.mem_span_singleton]
+    _ ↔ r • x ∈ N := by simp_rw [fun (a : R) ↦ smul_comm r a x]; exact SetLike.forall_smul_mem_iff
+#align submodule.mem_colon_singleton Submodule.mem_colon_singleton
+
+@[simp]
+theorem _root_.Ideal.mem_colon_singleton {I : Ideal R} {x r : R} :
+    r ∈ I.colon (Ideal.span {x}) ↔ r * x ∈ I := by
+  simp only [← Ideal.submodule_span_eq, Submodule.mem_colon_singleton, smul_eq_mul]
+#align ideal.mem_colon_singleton Ideal.mem_colon_singleton
+
+theorem annihilator_quotient {N : Submodule R M} :
+    Module.annihilator R (M ⧸ N) = N.colon ⊤ := by
+  simp_rw [SetLike.ext_iff, Module.mem_annihilator, colon, mem_annihilator, map_top,
+    LinearMap.range_eq_top.mpr (mkQ_surjective N), mem_top, forall_true_left, forall_const]
+
+theorem _root_.Ideal.annihilator_quotient {I : Ideal R} : Module.annihilator R (R ⧸ I) = I := by
+  rw [Submodule.annihilator_quotient, colon_top]
+
+end Submodule

--- a/Mathlib/RingTheory/Ideal/Norm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm.lean
@@ -11,6 +11,7 @@ import Mathlib.Data.Int.Associated
 import Mathlib.LinearAlgebra.FreeModule.Determinant
 import Mathlib.LinearAlgebra.FreeModule.IdealQuotient
 import Mathlib.RingTheory.DedekindDomain.PID
+import Mathlib.RingTheory.Ideal.Basis
 import Mathlib.RingTheory.LocalProperties
 import Mathlib.RingTheory.Localization.NormTrace
 

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -11,7 +11,6 @@ import Mathlib.Data.Fintype.Lattice
 import Mathlib.RingTheory.Coprime.Lemmas
 import Mathlib.RingTheory.Ideal.Basic
 import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
-import Mathlib.LinearAlgebra.Quotient
 import Mathlib.Algebra.Order.Group.Action
 
 #align_import ring_theory.ideal.operations from "leanprover-community/mathlib"@"e7f0ddbf65bd7181a85edb74b64bdc35ba4bdc74"
@@ -384,78 +383,6 @@ theorem smul_comap_le_comap_smul (f : M →ₗ[R] M') (S : Submodule R M') (I : 
 #align submodule.smul_comap_le_comap_smul Submodule.smul_comap_le_comap_smul
 
 end CommSemiring
-
-section CommRing
-
-variable [CommRing R] [AddCommGroup M] [Module R M]
-variable {N N₁ N₂ P P₁ P₂ : Submodule R M}
-
-/-- `N.colon P` is the ideal of all elements `r : R` such that `r • P ⊆ N`. -/
-def colon (N P : Submodule R M) : Ideal R :=
-  annihilator (P.map N.mkQ)
-#align submodule.colon Submodule.colon
-
-theorem mem_colon {r} : r ∈ N.colon P ↔ ∀ p ∈ P, r • p ∈ N :=
-  mem_annihilator.trans
-     ⟨fun H p hp => (Quotient.mk_eq_zero N).1 (H (Quotient.mk p) (mem_map_of_mem hp)),
-       fun H _ ⟨p, hp, hpm⟩ => hpm ▸ (N.mkQ.map_smul r p ▸ (Quotient.mk_eq_zero N).2 <| H p hp)⟩
-#align submodule.mem_colon Submodule.mem_colon
-
-theorem mem_colon' {r} : r ∈ N.colon P ↔ P ≤ comap (r • (LinearMap.id : M →ₗ[R] M)) N :=
-  mem_colon
-#align submodule.mem_colon' Submodule.mem_colon'
-
-@[simp]
-theorem colon_top {I : Ideal R} : I.colon ⊤ = I := by
-  simp_rw [SetLike.ext_iff, mem_colon, smul_eq_mul]
-  exact fun x ↦ ⟨fun h ↦ mul_one x ▸ h 1 trivial, fun h _ _ ↦ I.mul_mem_right _ h⟩
-
-@[simp]
-theorem colon_bot : colon ⊥ N = N.annihilator := by
-  simp_rw [SetLike.ext_iff, mem_colon, mem_annihilator, mem_bot, forall_const]
-
-theorem colon_mono (hn : N₁ ≤ N₂) (hp : P₁ ≤ P₂) : N₁.colon P₂ ≤ N₂.colon P₁ := fun _ hrnp =>
-  mem_colon.2 fun p₁ hp₁ => hn <| mem_colon.1 hrnp p₁ <| hp hp₁
-#align submodule.colon_mono Submodule.colon_mono
-
-theorem iInf_colon_iSup (ι₁ : Sort w) (f : ι₁ → Submodule R M) (ι₂ : Sort x)
-    (g : ι₂ → Submodule R M) : (⨅ i, f i).colon (⨆ j, g j) = ⨅ (i) (j), (f i).colon (g j) :=
-  le_antisymm (le_iInf fun _ => le_iInf fun _ => colon_mono (iInf_le _ _) (le_iSup _ _)) fun _ H =>
-    mem_colon'.2 <|
-      iSup_le fun j =>
-        map_le_iff_le_comap.1 <|
-          le_iInf fun i =>
-            map_le_iff_le_comap.2 <|
-              mem_colon'.1 <|
-                have := (mem_iInf _).1 H i
-                have := (mem_iInf _).1 this j
-                this
-#align submodule.infi_colon_supr Submodule.iInf_colon_iSup
-
-@[simp]
-theorem mem_colon_singleton {N : Submodule R M} {x : M} {r : R} :
-    r ∈ N.colon (Submodule.span R {x}) ↔ r • x ∈ N :=
-  calc
-    r ∈ N.colon (Submodule.span R {x}) ↔ ∀ a : R, r • a • x ∈ N := by
-      simp [Submodule.mem_colon, Submodule.mem_span_singleton]
-    _ ↔ r • x ∈ N := by simp_rw [fun (a : R) ↦ smul_comm r a x]; exact SetLike.forall_smul_mem_iff
-#align submodule.mem_colon_singleton Submodule.mem_colon_singleton
-
-@[simp]
-theorem _root_.Ideal.mem_colon_singleton {I : Ideal R} {x r : R} :
-    r ∈ I.colon (Ideal.span {x}) ↔ r * x ∈ I := by
-  simp only [← Ideal.submodule_span_eq, Submodule.mem_colon_singleton, smul_eq_mul]
-#align ideal.mem_colon_singleton Ideal.mem_colon_singleton
-
-theorem annihilator_quotient {N : Submodule R M} :
-    Module.annihilator R (M ⧸ N) = N.colon ⊤ := by
-  simp_rw [SetLike.ext_iff, Module.mem_annihilator, colon, mem_annihilator, map_top,
-    LinearMap.range_eq_top.mpr (mkQ_surjective N), mem_top, forall_true_left, forall_const]
-
-theorem _root_.Ideal.annihilator_quotient {I : Ideal R} : Module.annihilator R (R ⧸ I) = I := by
-  rw [Submodule.annihilator_quotient, colon_top]
-
-end CommRing
 
 end Submodule
 

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -5,13 +5,9 @@ Authors: Kenny Lau
 -/
 import Mathlib.Algebra.Algebra.Operations
 import Mathlib.Algebra.Ring.Equiv
-import Mathlib.Data.Nat.Choose.Sum
-import Mathlib.Data.Nat.Interval
 import Mathlib.Data.Fintype.Lattice
 import Mathlib.RingTheory.Coprime.Lemmas
 import Mathlib.RingTheory.Ideal.Basic
-import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
-import Mathlib.Algebra.Order.Group.Action
 
 #align_import ring_theory.ideal.operations from "leanprover-community/mathlib"@"e7f0ddbf65bd7181a85edb74b64bdc35ba4bdc74"
 

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -15,6 +15,9 @@ import Mathlib.RingTheory.Ideal.Basic
 # More operations on modules and ideals
 -/
 
+assert_not_exists Basis -- See `RingTheory.Ideal.Basis`
+assert_not_exists Submodule.hasQuotient -- See `RingTheory.Ideal.QuotientOperations`
+
 universe u v w x
 
 open BigOperators Pointwise

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -11,7 +11,6 @@ import Mathlib.Data.Fintype.Lattice
 import Mathlib.RingTheory.Coprime.Lemmas
 import Mathlib.RingTheory.Ideal.Basic
 import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
-import Mathlib.LinearAlgebra.Basis
 import Mathlib.LinearAlgebra.Quotient
 import Mathlib.Algebra.Order.Group.Action
 
@@ -2030,43 +2029,6 @@ theorem range_finsuppTotal :
 
 end Total
 
-section Basis
-
-variable {ι R S : Type*} [CommSemiring R] [CommRing S] [IsDomain S] [Algebra R S]
-
-/-- A basis on `S` gives a basis on `Ideal.span {x}`, by multiplying everything by `x`. -/
-noncomputable def basisSpanSingleton (b : Basis ι R S) {x : S} (hx : x ≠ 0) :
-    Basis ι R (span ({x} : Set S)) :=
-  b.map <|
-    LinearEquiv.ofInjective (Algebra.lmul R S x) (LinearMap.mul_injective hx) ≪≫ₗ
-        LinearEquiv.ofEq _ _
-          (by
-            ext
-            simp [mem_span_singleton', mul_comm]) ≪≫ₗ
-      (Submodule.restrictScalarsEquiv R S S (Ideal.span ({x} : Set S))).restrictScalars R
-#align ideal.basis_span_singleton Ideal.basisSpanSingleton
-
-@[simp]
-theorem basisSpanSingleton_apply (b : Basis ι R S) {x : S} (hx : x ≠ 0) (i : ι) :
-    (basisSpanSingleton b hx i : S) = x * b i := by
-  simp only [basisSpanSingleton, Basis.map_apply, LinearEquiv.trans_apply,
-    Submodule.restrictScalarsEquiv_apply, LinearEquiv.ofInjective_apply, LinearEquiv.coe_ofEq_apply,
-    LinearEquiv.restrictScalars_apply, Algebra.coe_lmul_eq_mul, LinearMap.mul_apply']
-  -- This used to be the end of the proof before leanprover/lean4#2644
-  erw [LinearEquiv.coe_ofEq_apply, LinearEquiv.ofInjective_apply, Algebra.coe_lmul_eq_mul,
-    LinearMap.mul_apply']
-#align ideal.basis_span_singleton_apply Ideal.basisSpanSingleton_apply
-
-@[simp]
-theorem constr_basisSpanSingleton {N : Type*} [Semiring N] [Module N S] [SMulCommClass R N S]
-    (b : Basis ι R S) {x : S} (hx : x ≠ 0) :
-    (b.constr N).toFun (((↑) : _ → S) ∘ (basisSpanSingleton b hx)) = Algebra.lmul R S x :=
-  b.ext fun i => by
-    erw [Basis.constr_basis, Function.comp_apply, basisSpanSingleton_apply, LinearMap.mul_apply']
-#align ideal.constr_basis_span_singleton Ideal.constr_basisSpanSingleton
-
-end Basis
-
 end Ideal
 
 section span_range
@@ -2088,21 +2050,6 @@ theorem Associates.mk_ne_zero' {R : Type*} [CommSemiring R] {r : R} :
     Associates.mk (Ideal.span {r} : Ideal R) ≠ 0 ↔ r ≠ 0 := by
   rw [Associates.mk_ne_zero, Ideal.zero_eq_bot, Ne, Ideal.span_singleton_eq_bot]
 #align associates.mk_ne_zero' Associates.mk_ne_zero'
-
--- Porting note: added explicit coercion `(b i : S)`
-/-- If `I : Ideal S` has a basis over `R`,
-`x ∈ I` iff it is a linear combination of basis vectors. -/
-theorem Basis.mem_ideal_iff {ι R S : Type*} [CommRing R] [CommRing S] [Algebra R S] {I : Ideal S}
-    (b : Basis ι R I) {x : S} : x ∈ I ↔ ∃ c : ι →₀ R, x = Finsupp.sum c fun i x => x • (b i : S) :=
-  (b.map ((I.restrictScalarsEquiv R _ _).restrictScalars R).symm).mem_submodule_iff
-#align basis.mem_ideal_iff Basis.mem_ideal_iff
-
-/-- If `I : Ideal S` has a finite basis over `R`,
-`x ∈ I` iff it is a linear combination of basis vectors. -/
-theorem Basis.mem_ideal_iff' {ι R S : Type*} [Fintype ι] [CommRing R] [CommRing S] [Algebra R S]
-    {I : Ideal S} (b : Basis ι R I) {x : S} : x ∈ I ↔ ∃ c : ι → R, x = ∑ i, c i • (b i : S) :=
-  (b.map ((I.restrictScalarsEquiv R _ _).restrictScalars R).symm).mem_submodule_iff'
-#align basis.mem_ideal_iff' Basis.mem_ideal_iff'
 
 namespace RingHom
 

--- a/Mathlib/RingTheory/Nilpotent.lean
+++ b/Mathlib/RingTheory/Nilpotent.lean
@@ -3,13 +3,14 @@ Copyright (c) 2021 Oliver Nash. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
-import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.Algebra.GeomSum
-import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 import Mathlib.Algebra.GroupPower.Ring
-import Mathlib.RingTheory.Ideal.Operations
+import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
+import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.LinearAlgebra.Matrix.ToLin
+import Mathlib.LinearAlgebra.Quotient
+import Mathlib.RingTheory.Ideal.Operations
 
 #align_import ring_theory.nilpotent from "leanprover-community/mathlib"@"da420a8c6dd5bdfb85c4ced85c34388f633bc6ff"
 

--- a/Mathlib/RingTheory/PrincipalIdealDomain.lean
+++ b/Mathlib/RingTheory/PrincipalIdealDomain.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Morenikeji Neri
 -/
 import Mathlib.Algebra.EuclideanDomain.Instances
+import Mathlib.RingTheory.Ideal.Colon
 import Mathlib.RingTheory.UniqueFactorizationDomain
 
 #align_import ring_theory.principal_ideal_domain from "leanprover-community/mathlib"@"6010cf523816335f7bae7f8584cb2edaace73940"


### PR DESCRIPTION
This is based on seeing the import `RingTheory.Ideal.Operations` → `LinearAlgebra.Basis` on the [longest pole](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/The.20long.20pole.20in.20mathlib/near/432898637). It feels like `Ideal.Operations` is a bit of a chokepoint for compiling Mathlib since it imports many files and is imported by many files. So splitting out a few obvious parts should help with compile times. Moreover, there are a bunch of imports that I could remove and have the file still compile: presumably these are (were) transitive dependencies that shake does not remove.

The following results and their corollaries were split off:
 * `Ideal.basisSpanSingleton`
 * `Basis.mem_ideal_iff`
 * `Ideal.colon`

In particular, now `Ideal.Operations` should no longer need to know about `Basis` or submodule quotients.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
