### PR TITLE
[Merged by Bors] - style(test/polyrith): adapt to mathlib4 style

### DIFF
--- a/test/polyrith.lean
+++ b/test/polyrith.lean
@@ -249,8 +249,8 @@ A full test suite is provided at the bottom of the file.
 --   "(((((var0 * var0) * var1) + ((var1 * var0) * var1)) + (6 * var0)) - (((3 * var0) * var1) + 14))"]
 --   "linear_combination x * y * h1 + 2 * h2"
 
--- example (x y z w : ℚ) (hzw : z = w) : x*z + 2*y*z = x*w + 2*y*w :=
--- by test_polyrith
+-- example (x y z w : ℚ) (hzw : z = w) : x*z + 2*y*z = x*w + 2*y*w := by
+--   test_polyrith
 --   "{\"data\":[\"(poly.add (poly.var 0) (poly.mul (poly.const 2/1) (poly.var 2)))\"],\"success\":true}"
 --   ["ff",
 --   "rat",
@@ -262,8 +262,8 @@ A full test suite is provided at the bottom of the file.
 -- /-! ### Cases with non-hypothesis inputs/input restrictions -/
 
 -- example (a b : ℝ) (ha : 2*a = 4) (hab : 2*b = a - b) (hignore : 3 = a + b) :
---   b = 2 / 3 :=
--- by test_polyrith only [ha, hab]
+--   b = 2 / 3 := by
+--   test_polyrith only [ha, hab]
 --   "{\"data\":[\"(poly.const 1/6)\",\"(poly.const 1/3)\"],\"success\":true}"
 --   ["ff",
 --   "real",
@@ -274,8 +274,8 @@ A full test suite is provided at the bottom of the file.
 
 -- constant term : ∀ a b : ℚ, a + b = 0
 
--- example (a b c d : ℚ) (h : a + b = 0) (h2: b + c = 0): a + b + c + d = 0 :=
--- by test_polyrith only [term c d, h]
+-- example (a b c d : ℚ) (h : a + b = 0) (h2: b + c = 0): a + b + c + d = 0 := by
+--   test_polyrith only [term c d, h]
 --   "{\"data\":[\"(poly.const 1/1)\",\"(poly.const 1/1)\"],\"success\":true}"
 --   ["ff",
 --   "rat",
@@ -286,8 +286,8 @@ A full test suite is provided at the bottom of the file.
 
 -- constants (qc : ℚ) (hqc : qc = 2*qc)
 
--- example (a b : ℚ) (h : ∀ p q : ℚ, p = q) : 3*a + qc = 3*b + 2*qc :=
--- by test_polyrith [h a b, hqc]
+-- example (a b : ℚ) (h : ∀ p q : ℚ, p = q) : 3*a + qc = 3*b + 2*qc := by
+--   test_polyrith [h a b, hqc]
 --   "{\"data\":[\"(poly.const 3/1)\",\"(poly.const 1/1)\"],\"success\":true}"
 --   ["ff",
 --   "rat",
@@ -298,8 +298,8 @@ A full test suite is provided at the bottom of the file.
 
 -- constant bad (q : ℚ) : q = 0
 
--- example (a b : ℚ) : a + b^3 = 0 :=
--- by test_polyrith [bad a, bad (b^2)]
+-- example (a b : ℚ) : a + b^3 = 0 := by
+--   test_polyrith [bad a, bad (b^2)]
 --   "{\"data\":[\"(poly.const 1/1)\",\"(poly.var 1)\"],\"success\":true}"
 --   ["ff",
 --   "rat",
@@ -311,8 +311,8 @@ A full test suite is provided at the bottom of the file.
 -- /-! ### Case over arbitrary field/ring -/
 
 -- example {α} [h : CommRing α] {a b c d e f : α} (h1 : a*d = b*c) (h2 : c*f = e*d) :
---   c * (a*f - b*e) = 0 :=
--- by test_polyrith
+--   c * (a*f - b*e) = 0 := by
+--   test_polyrith
 --   "{\"data\":[\"(poly.var 4)\",\"(poly.var 1)\"],\"success\":true}"
 --   ["ff",
 --   "α",
@@ -377,8 +377,8 @@ A full test suite is provided at the bottom of the file.
 --   "(var0 - 1)"]
 --   "linear_combination hs / 3"
 
--- example {x : ℤ} (h1 : x + 4 = 2) : x = -2 :=
--- by test_polyrith
+-- example {x : ℤ} (h1 : x + 4 = 2) : x = -2 := by
+--   test_polyrith
 --   "{\"data\":[\"(poly.const 1/1)\"],\"success\":true}"
 --   ["ff",
 --   "int",
@@ -387,8 +387,8 @@ A full test suite is provided at the bottom of the file.
 --   "(var0 - -2)"]
 --   "linear_combination h1"
 
--- example {w : ℚ} (h1 : 3 * w + 1 = 4) : w = 1 :=
--- by test_polyrith
+-- example {w : ℚ} (h1 : 3 * w + 1 = 4) : w = 1 := by
+--   test_polyrith
 --   "{\"data\":[\"(poly.const 1/3)\"],\"success\":true}"
 --   ["ff",
 --   "rat",
@@ -397,8 +397,8 @@ A full test suite is provided at the bottom of the file.
 --   "(var0 - 1)"]
 --   "linear_combination h1 / 3"
 
--- example {x : ℤ} (h1 : 2 * x + 3 = x) : x = -3 :=
--- by test_polyrith
+-- example {x : ℤ} (h1 : 2 * x + 3 = x) : x = -3 := by
+--   test_polyrith
 --   "{\"data\":[\"(poly.const 1/1)\"],\"success\":true}"
 --   ["ff",
 --   "int",
@@ -407,8 +407,8 @@ A full test suite is provided at the bottom of the file.
 --   "(var0 - -3)"]
 --   "linear_combination h1"
 
--- example {c : ℚ} (h1 : 4 * c + 1 = 3 * c - 2) : c = -3 :=
--- by test_polyrith
+-- example {c : ℚ} (h1 : 4 * c + 1 = 3 * c - 2) : c = -3 := by
+--   test_polyrith
 --   "{\"data\":[\"(poly.const 1/1)\"],\"success\":true}"
 --   ["ff",
 --   "rat",
@@ -417,8 +417,8 @@ A full test suite is provided at the bottom of the file.
 --   "(var0 - -3)"]
 --   "linear_combination h1"
 
--- example (z : ℤ) (h1 : z + 1 = 2) (h2 : z + 2 = 2) : (1 : ℤ) = 2 :=
--- by test_polyrith
+-- example (z : ℤ) (h1 : z + 1 = 2) (h2 : z + 2 = 2) : (1 : ℤ) = 2 := by
+--   test_polyrith
 --   "{\"data\":[\"(poly.const 1/1)\",\"(poly.const -1/1)\"],\"success\":true}"
 --   ["ff",
 --   "int",
@@ -427,8 +427,8 @@ A full test suite is provided at the bottom of the file.
 --   "(1 - 2)"]
 --   "linear_combination h1 - h2"
 
--- example {R} [CommRing R] (x : R) (h2 : (2 : R) = 0) : x + x = 0 :=
--- by test_polyrith
+-- example {R} [CommRing R] (x : R) (h2 : (2 : R) = 0) : x + x = 0 := by
+--   test_polyrith
 --   "{\"data\":[\"(poly.var 0)\"],\"success\":true}"
 --   ["ff",
 --   "R",
@@ -437,8 +437,8 @@ A full test suite is provided at the bottom of the file.
 --   "((var0 + var0) - 0)"]
 --   "linear_combination x * h2"
 
--- example {R} [CommRing R] (_x : R) (h : (2 : R) = 4) : (0 : R) = 2 :=
--- by test_polyrith
+-- example {R} [CommRing R] (_x : R) (h : (2 : R) = 4) : (0 : R) = 2 := by
+--   test_polyrith
 --   "{\"data\":[\"(poly.const 1/1)\"],\"success\":true}"
 --   ["ff",
 --   "R",
@@ -453,62 +453,58 @@ A full test suite is provided at the bottom of the file.
 
 /-! ### Standard Cases over ℤ, ℚ, and ℝ -/
 
-example (x y : ℤ) (h1 : 3*x + 2*y = 10):
-  3*x + 2*y = 10 :=
-by polyrith
+example (x y : ℤ) (h1 : 3*x + 2*y = 10): 3*x + 2*y = 10 := by
+  polyrith
 
-example (x y : ℚ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
-  x*y = -2*y + 1 :=
-by polyrith
+example (x y : ℚ) (h1 : x*y + 2*x = 1) (h2 : x = y) : x*y = -2*y + 1 := by
+  polyrith
 
 -- example (x y : ℝ) (h1 : x + 2 = -3) (h2 : y = 10) :
---   -y + 2*x + 4 = -16 :=
--- by polyrith
+--   -y + 2*x + 4 = -16 := by
+--   polyrith
 
 -- example (x y z : ℝ) (ha : x + 2*y - z = 4) (hb : 2*x + y + z = -2)
 --     (hc : x + 2*y + z = 2) :
---   -3*x - 3*y - 4*z = 2 :=
--- by polyrith
+--    -3*x - 3*y - 4*z = 2 := by
+--  polyrith
 
 -- example (w x y z : ℝ) (h1 : x + 2.1*y + 2*z = 2) (h2 : x + 8*z + 5*w = -6.5)
 --     (h3 : x + y + 5*z + 5*w = 3) :
---   x + 2.2*y + 2*z - 5*w = -8.5 :=
--- by polyrith
+--    x + 2.2*y + 2*z - 5*w = -8.5 := by
+--  polyrith
 
 example (a b c d : ℚ) (h1 : a = 4) (h2 : 3 = b) (h3 : c*3 = d) (h4 : -d = a) :
-  2*a - 3 + 9*c + 3*d = 8 - b + 3*d - 3*a :=
-by polyrith
+    2*a - 3 + 9*c + 3*d = 8 - b + 3*d - 3*a := by
+  polyrith
 
 /-! ### Case with ambiguous identifiers-/
 -- set_option trace.Meta.Tactic.polyrith true
 example («def evil» y : ℤ) (h1 : 3*«def evil» + 2*y = 10):
-  3*«def evil» + 2*y = 10 :=
-by polyrith
+    3*«def evil» + 2*y = 10 := by
+  polyrith
 
 example («¥» y : ℤ) (h1 : 3*«¥» + 2*y = 10):
-  «¥» * (3*«¥» + 2*y) = 10 * «¥» :=
-by polyrith
+    «¥» * (3*«¥» + 2*y) = 10 * «¥» := by
+  polyrith
 
 /-! ### Cases with arbitrary coefficients -/
 
-example (a b : ℤ) (h : a = b) :
-  a * a = a * b :=
-by polyrith
+example (a b : ℤ) (h : a = b) : a * a = a * b := by
+  polyrith
 
-example (a b c : ℤ) (h : a = b) :
-  a * c = b * c :=
-by polyrith
+example (a b c : ℤ) (h : a = b) : a * c = b * c := by
+  polyrith
 
 example (a b c : ℤ) (h1 : a = b) (h2 : b = 1) :
-  c * a + b = c * b + 1 :=
-by polyrith
+    c * a + b = c * b + 1 := by
+  polyrith
 
 example (x y : ℚ) (h1 : x + y = 3) (h2 : 3*x = 7) :
-  x*x*y + y*x*y + 6*x = 3*x*y + 14 :=
-by polyrith
+    x*x*y + y*x*y + 6*x = 3*x*y + 14 :=
+  polyrith
 
-example (x y z w : ℚ) (hzw : z = w) : x*z + 2*y*z = x*w + 2*y*w :=
-by polyrith
+example (x y z w : ℚ) (hzw : z = w) : x*z + 2*y*z = x*w + 2*y*w := by
+  polyrith
 
 
 /-! ### Cases with non-hypothesis inputs/input restrictions -/
@@ -519,25 +515,25 @@ by polyrith
 
 axiom term : ∀ a b : ℚ, a + b = 0
 
-example (a b c d : ℚ) (h : a + b = 0) (h2: b + c = 0): a + b + c + d = 0 :=
-by polyrith only [term c d, h]
+example (a b c d : ℚ) (h : a + b = 0) (h2: b + c = 0): a + b + c + d = 0 := by
+  polyrith only [term c d, h]
 
 axiom qc : ℚ
 axiom hqc : qc = 2*qc
 
-example (a b : ℚ) (h : ∀ p q : ℚ, p = q) : 3*a + qc = 3*b + 2*qc :=
-by polyrith [h a b, hqc]
+example (a b : ℚ) (h : ∀ p q : ℚ, p = q) : 3*a + qc = 3*b + 2*qc := by
+  polyrith [h a b, hqc]
 
 axiom bad (q : ℚ) : q = 0
 
-example (a b : ℚ) : a + b^3 = 0 :=
-by polyrith [bad a, bad (b^2)]
+example (a b : ℚ) : a + b^3 = 0 := by
+  polyrith [bad a, bad (b^2)]
 
 /-! ### Case over arbitrary field/ring -/
 
 example {α} [h : CommRing α] {a b c d e f : α} (h1 : a*d = b*c) (h2 : c*f = e*d) :
-  c * (a*f - b*e) = 0 :=
-by polyrith
+    c * (a*f - b*e) = 0 := by
+  polyrith
 
 -- example {K : Type*} [Field K] [Invertible 2] [Invertible 3]
 --   {ω p q r s t x: K} (hp_nonzero : p ≠ 0) (hr : r ^ 2 = q ^ 2 + p ^ 3) (hs3 : s ^ 3 = q + r)
@@ -607,82 +603,77 @@ example (a b : ℚ) (h : ∀ p q : ℚ, p = q) : 3*a + qc = 3*b + 2*qc := by
 /-! ### Standard Cases over ℤ, ℚ, and ℝ -/
 
 example (x y : ℤ) (h1 : 3*x + 2*y = 10):
-  3*x + 2*y = 10 :=
-by create_polyrith_test
+    3*x + 2*y = 10 := by
+  create_polyrith_test
 
 example (x y : ℚ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
-  x*y = -2*y + 1 :=
-by create_polyrith_test
+    x*y = -2*y + 1 := by
+  create_polyrith_test
 
-example (x y : ℝ) (h1 : x + 2 = -3) (h2 : y = 10) :
-  -y + 2*x + 4 = -16 :=
-by create_polyrith_test
+example (x y : ℝ) (h1 : x + 2 = -3) (h2 : y = 10) : -y + 2*x + 4 = -16 := by
+  create_polyrith_test
 
 example (x y z : ℝ) (ha : x + 2*y - z = 4) (hb : 2*x + y + z = -2)
     (hc : x + 2*y + z = 2) :
-  -3*x - 3*y - 4*z = 2 :=
-by create_polyrith_test
+    -3*x - 3*y - 4*z = 2 := by
+  create_polyrith_test
 
 example (w x y z : ℝ) (h1 : x + 2.1*y + 2*z = 2) (h2 : x + 8*z + 5*w = -6.5)
     (h3 : x + y + 5*z + 5*w = 3) :
-  x + 2.2*y + 2*z - 5*w = -8.5 :=
-by create_polyrith_test
+    x + 2.2*y + 2*z - 5*w = -8.5 := by
+  create_polyrith_test
 
 example (a b c d : ℚ) (h1 : a = 4) (h2 : 3 = b) (h3 : c*3 = d) (h4 : -d = a) :
-  2*a - 3 + 9*c + 3*d = 8 - b + 3*d - 3*a :=
-by create_polyrith_test
+    2*a - 3 + 9*c + 3*d = 8 - b + 3*d - 3*a := by
+  create_polyrith_test
 
 /-! ### Case with ambiguous identifiers-/
 
 example («def evil» y : ℤ) (h1 : 3*«def evil» + 2*y = 10):
-  3*«def evil» + 2*y = 10 :=
-by create_polyrith_test
+    3*«def evil» + 2*y = 10 := by
+  create_polyrith_test
 
 example («¥» y : ℤ) (h1 : 3*«¥» + 2*y = 10):
-  «¥» * (3*«¥» + 2*y) = 10 * «¥» :=
-by create_polyrith_test
+    «¥» * (3*«¥» + 2*y) = 10 * «¥» := by
+  create_polyrith_test
 
 /-! ### Cases with arbitrary coefficients -/
 
-example (a b : ℤ) (h : a = b) :
-  a * a = a * b :=
-by create_polyrith_test
+example (a b : ℤ) (h : a = b) : a * a = a * b := by
+  create_polyrith_test
 
-example (a b c : ℤ) (h : a = b) :
-  a * c = b * c :=
-by create_polyrith_test
+example (a b c : ℤ) (h : a = b) : a * c = b * c := by
+  create_polyrith_test
 
-example (a b c : ℤ) (h1 : a = b) (h2 : b = 1) :
-  c * a + b = c * b + 1 :=
-by create_polyrith_test
+example (a b c : ℤ) (h1 : a = b) (h2 : b = 1) : c * a + b = c * b + 1 := by
+  create_polyrith_test
 
 example (x y : ℚ) (h1 : x + y = 3) (h2 : 3*x = 7) :
-  x*x*y + y*x*y + 6*x = 3*x*y + 14 :=
-by create_polyrith_test
+    x*x*y + y*x*y + 6*x = 3*x*y + 14 := by
+  create_polyrith_test
 
-example (x y z w : ℚ) (hzw : z = w) : x*z + 2*y*z = x*w + 2*y*w :=
-by create_polyrith_test
+example (x y z w : ℚ) (hzw : z = w) : x*z + 2*y*z = x*w + 2*y*w := by
+  create_polyrith_test
 
 /-! ### Cases with non-hypothesis inputs/input restrictions -/
 
 example (a b : ℝ) (ha : 2*a = 4) (hab : 2*b = a - b) (hignore : 3 = a + b) :
-  b = 2 / 3 :=
-by create_polyrith_test only [ha, hab]
+    b = 2 / 3 := by
+  create_polyrith_test only [ha, hab]
 
 constant term : ∀ a b : ℚ, a + b = 0
 
-example (a b c d : ℚ) (h : a + b = 0) (h2: b + c = 0): a + b + c + d = 0 :=
-by create_polyrith_test only [term c d, h]
+example (a b c d : ℚ) (h : a + b = 0) (h2: b + c = 0): a + b + c + d = 0 := by
+  create_polyrith_test only [term c d, h]
 
 constants (qc : ℚ) (hqc : qc = 2*qc)
 
-example (a b : ℚ) (h : ∀ p q : ℚ, p = q) : 3*a + qc = 3*b + 2*qc :=
-by create_polyrith_test [h a b, hqc]
+example (a b : ℚ) (h : ∀ p q : ℚ, p = q) : 3*a + qc = 3*b + 2*qc := by
+  create_polyrith_test [h a b, hqc]
 
 constant bad (q : ℚ) : q = 0
 
-example (a b : ℚ) : a + b^3 = 0 :=
-by create_polyrith_test [bad a, bad (b^2)]
+example (a b : ℚ) : a + b^3 = 0 := by create_polyrith_test [bad a, bad (b^2)]
 
 /-! ### Case over arbitrary field/ring -/
 
@@ -709,21 +700,20 @@ example {K : Type*} [Field K] [Invertible 2] [Invertible 3]
 example {K : Type*} [Field K] [CharZero K] {s : K} (hs : 3 * s + 1 = 4) : s = 1 := by
   create_polyrith_test
 
-example {x : ℤ} (h1 : x + 4 = 2) : x = -2 :=
-by create_polyrith_test
+example {x : ℤ} (h1 : x + 4 = 2) : x = -2 := by
+  create_polyrith_test
 
-example {w : ℚ} (h1 : 3 * w + 1 = 4) : w = 1 :=
-by create_polyrith_test
+example {w : ℚ} (h1 : 3 * w + 1 = 4) : w = 1 := by
+  create_polyrith_test
 
-example {x : ℤ} (h1 : 2 * x + 3 = x) : x = -3 :=
-by create_polyrith_test
+example {x : ℤ} (h1 : 2 * x + 3 = x) : x = -3 := by
+  create_polyrith_test
 
-example {c : ℚ} (h1 : 4 * c + 1 = 3 * c - 2) : c = -3 :=
-by create_polyrith_test
+example {c : ℚ} (h1 : 4 * c + 1 = 3 * c - 2) : c = -3 := by
+  create_polyrith_test
 
-example (z : ℤ) (h1 : z + 1 = 2) (h2 : z + 2 = 2) : (1 : ℤ) = 2 :=
-by create_polyrith_test
-
+example (z : ℤ) (h1 : z + 1 = 2) (h2 : z + 2 = 2) : (1 : ℤ) = 2 := by
+  create_polyrith_test
 
 -/
 

--- a/test/polyrith.lean
+++ b/test/polyrith.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Dhruv Bhatia. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author(s): Dhruv Bhatia, Robert Y. Lewis, Mario Carneiro
+Authors: Dhruv Bhatia, Robert Y. Lewis, Mario Carneiro
 -/
 import Mathlib.Tactic.Polyrith
 
@@ -111,7 +111,7 @@ A full test suite is provided at the bottom of the file.
 
 -- /-! ### Standard Cases over ℤ, ℚ, and ℝ -/
 
--- example (x y : ℤ) (h1 : 3*x + 2*y = 10):
+-- example (x y : ℤ) (h1 : 3*x + 2*y = 10) :
 --   3*x + 2*y = 10 :=
 -- by test_polyrith
 --   "{\"data\":[\"(poly.const 1/1)\"],\"success\":true}"
@@ -181,7 +181,7 @@ A full test suite is provided at the bottom of the file.
 
 -- /-! ### Case with ambiguous identifiers-/
 
--- example («def evil» y : ℤ) (h1 : 3*«def evil» + 2*y = 10):
+-- example («def evil» y : ℤ) (h1 : 3*«def evil» + 2*y = 10) :
 --   3*«def evil» + 2*y = 10 :=
 -- by test_polyrith
 --   "{\"data\":[\"(poly.const 1/1)\"],\"success\":true}"
@@ -192,7 +192,7 @@ A full test suite is provided at the bottom of the file.
 --   "(((3 * var0) + (2 * var1)) - 10)"]
 --   "linear_combination h1"
 
--- example («¥» y : ℤ) (h1 : 3*«¥» + 2*y = 10):
+-- example («¥» y : ℤ) (h1 : 3*«¥» + 2*y = 10) :
 --   «¥» * (3*«¥» + 2*y) = 10 * «¥» :=
 -- by test_polyrith
 --   "{\"data\":[\"(poly.var 0)\"],\"success\":true}"
@@ -274,7 +274,7 @@ A full test suite is provided at the bottom of the file.
 
 -- constant term : ∀ a b : ℚ, a + b = 0
 
--- example (a b c d : ℚ) (h : a + b = 0) (h2: b + c = 0): a + b + c + d = 0 := by
+-- example (a b c d : ℚ) (h : a + b = 0) (h2 : b + c = 0) : a + b + c + d = 0 := by
 --   test_polyrith only [term c d, h]
 --   "{\"data\":[\"(poly.const 1/1)\",\"(poly.const 1/1)\"],\"success\":true}"
 --   ["ff",
@@ -322,7 +322,7 @@ A full test suite is provided at the bottom of the file.
 --   "linear_combination e * h1 + a * h2"
 
 -- example {K : Type*} [Field K] [Invertible 2] [Invertible 3]
---   {ω p q r s t x: K} (hp_nonzero : p ≠ 0) (hr : r ^ 2 = q ^ 2 + p ^ 3) (hs3 : s ^ 3 = q + r)
+--   {ω p q r s t x : K} (hp_nonzero : p ≠ 0) (hr : r ^ 2 = q ^ 2 + p ^ 3) (hs3 : s ^ 3 = q + r)
 --   (ht : t * s = p) (x : K) (H : 1 + ω + ω ^ 2 = 0) :
 --   x ^ 3 + 3 * p * x - 2 * q =
 --     (x - (s - t)) * (x - (s * ω - t * ω ^ 2)) * (x - (s * ω ^ 2 - t * ω)) := by
@@ -453,7 +453,7 @@ A full test suite is provided at the bottom of the file.
 
 /-! ### Standard Cases over ℤ, ℚ, and ℝ -/
 
-example (x y : ℤ) (h1 : 3*x + 2*y = 10): 3*x + 2*y = 10 := by
+example (x y : ℤ) (h1 : 3*x + 2*y = 10) : 3*x + 2*y = 10 := by
   polyrith
 
 example (x y : ℚ) (h1 : x*y + 2*x = 1) (h2 : x = y) : x*y = -2*y + 1 := by
@@ -479,11 +479,11 @@ example (a b c d : ℚ) (h1 : a = 4) (h2 : 3 = b) (h3 : c*3 = d) (h4 : -d = a) :
 
 /-! ### Case with ambiguous identifiers-/
 -- set_option trace.Meta.Tactic.polyrith true
-example («def evil» y : ℤ) (h1 : 3*«def evil» + 2*y = 10):
+example («def evil» y : ℤ) (h1 : 3*«def evil» + 2*y = 10) :
     3*«def evil» + 2*y = 10 := by
   polyrith
 
-example («¥» y : ℤ) (h1 : 3*«¥» + 2*y = 10):
+example («¥» y : ℤ) (h1 : 3*«¥» + 2*y = 10) :
     «¥» * (3*«¥» + 2*y) = 10 * «¥» := by
   polyrith
 
@@ -515,7 +515,7 @@ example (x y z w : ℚ) (hzw : z = w) : x*z + 2*y*z = x*w + 2*y*w := by
 
 axiom term : ∀ a b : ℚ, a + b = 0
 
-example (a b c d : ℚ) (h : a + b = 0) (h2: b + c = 0): a + b + c + d = 0 := by
+example (a b c d : ℚ) (h : a + b = 0) (h2 : b + c = 0) : a + b + c + d = 0 := by
   polyrith only [term c d, h]
 
 axiom qc : ℚ
@@ -536,7 +536,7 @@ example {α} [h : CommRing α] {a b c d e f : α} (h1 : a*d = b*c) (h2 : c*f = e
   polyrith
 
 -- example {K : Type*} [Field K] [Invertible 2] [Invertible 3]
---   {ω p q r s t x: K} (hp_nonzero : p ≠ 0) (hr : r ^ 2 = q ^ 2 + p ^ 3) (hs3 : s ^ 3 = q + r)
+--   {ω p q r s t x : K} (hp_nonzero : p ≠ 0) (hr : r ^ 2 = q ^ 2 + p ^ 3) (hs3 : s ^ 3 = q + r)
 --   (ht : t * s = p) (x : K) (H : 1 + ω + ω ^ 2 = 0) :
 --   x ^ 3 + 3 * p * x - 2 * q =
 --     (x - (s - t)) * (x - (s * ω - t * ω ^ 2)) * (x - (s * ω ^ 2 - t * ω)) := by
@@ -585,7 +585,7 @@ example (a b c : ℤ) (h1 : a = b) (h2 : b = 1) : c * a + b = c * b + 1 := by
   polyrith
   linear_combination c * h1 + h2
 
-example (a b c d : ℚ) (h : a + b = 0) (h2: b + c = 0): a + b + c + d = 0 := by
+example (a b c d : ℚ) (h : a + b = 0) (h2 : b + c = 0) : a + b + c + d = 0 := by
   polyrith only [term c d, h]
   linear_combination term c d + h
 
@@ -602,7 +602,7 @@ example (a b : ℚ) (h : ∀ p q : ℚ, p = q) : 3*a + qc = 3*b + 2*qc := by
 
 /-! ### Standard Cases over ℤ, ℚ, and ℝ -/
 
-example (x y : ℤ) (h1 : 3*x + 2*y = 10):
+example (x y : ℤ) (h1 : 3*x + 2*y = 10) :
     3*x + 2*y = 10 := by
   create_polyrith_test
 
@@ -629,11 +629,11 @@ example (a b c d : ℚ) (h1 : a = 4) (h2 : 3 = b) (h3 : c*3 = d) (h4 : -d = a) :
 
 /-! ### Case with ambiguous identifiers-/
 
-example («def evil» y : ℤ) (h1 : 3*«def evil» + 2*y = 10):
+example («def evil» y : ℤ) (h1 : 3*«def evil» + 2*y = 10) :
     3*«def evil» + 2*y = 10 := by
   create_polyrith_test
 
-example («¥» y : ℤ) (h1 : 3*«¥» + 2*y = 10):
+example («¥» y : ℤ) (h1 : 3*«¥» + 2*y = 10) :
     «¥» * (3*«¥» + 2*y) = 10 * «¥» := by
   create_polyrith_test
 
@@ -663,7 +663,7 @@ example (a b : ℝ) (ha : 2*a = 4) (hab : 2*b = a - b) (hignore : 3 = a + b) :
 
 constant term : ∀ a b : ℚ, a + b = 0
 
-example (a b c d : ℚ) (h : a + b = 0) (h2: b + c = 0): a + b + c + d = 0 := by
+example (a b c d : ℚ) (h : a + b = 0) (h2 : b + c = 0) : a + b + c + d = 0 := by
   create_polyrith_test only [term c d, h]
 
 constants (qc : ℚ) (hqc : qc = 2*qc)
@@ -682,7 +682,7 @@ example {α} [h : CommRing α] {a b c d e f : α} (h1 : a*d = b*c) (h2 : c*f = e
   create_polyrith_test
 
 example {K : Type*} [Field K] [Invertible 2] [Invertible 3]
-  {ω p q r s t x: K} (hp_nonzero : p ≠ 0) (hr : r ^ 2 = q ^ 2 + p ^ 3) (hs3 : s ^ 3 = q + r)
+  {ω p q r s t x : K} (hp_nonzero : p ≠ 0) (hr : r ^ 2 = q ^ 2 + p ^ 3) (hs3 : s ^ 3 = q + r)
   (ht : t * s = p) (x : K) (H : 1 + ω + ω ^ 2 = 0) :
   x ^ 3 + 3 * p * x - 2 * q =
     (x - (s - t)) * (x - (s * ω - t * ω ^ 2)) * (x - (s * ω ^ 2 - t * ω)) := by


### PR DESCRIPTION
Adapt indentation to mathlib4 conventions. Found when clearing out old branches.

---------

The first 250 lines are not handled; I think that developping an auto-formatter for Lean is a better use of time than fixing these by hand.

The diff in the last lines is slightly confusing; there are only indentation changes.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
