### PR TITLE
feat: tweak the definition of semicontinuity to behave better in nonlinear orders

### DIFF
--- a/Mathlib/Analysis/BoundedVariation.lean
+++ b/Mathlib/Analysis/BoundedVariation.lean
@@ -207,6 +207,7 @@ singletons of elements of `s`.
 -/
 protected theorem lowerSemicontinuous (s : Set α) :
     LowerSemicontinuous fun f : α →ᵤ[s.image singleton] E => eVariationOn f s := fun f ↦ by
+  rw [lowerSemicontinuousAt_iff_eventually_lt]
   apply @lowerSemicontinuous_aux _ _ _ _ (UniformOnFun α E (s.image singleton)) id (𝓝 f) f s _
   simpa only [UniformOnFun.tendsto_iff_tendstoUniformlyOn, mem_image, forall_exists_index, and_imp,
     forall_apply_eq_imp_iff₂, tendstoUniformlyOn_singleton_iff_tendsto] using @tendsto_id _ (𝓝 f)
@@ -215,6 +216,7 @@ protected theorem lowerSemicontinuous (s : Set α) :
 /-- The map `(eVariationOn · s)` is lower semicontinuous for uniform convergence on `s`.  -/
 theorem lowerSemicontinuous_uniformOn (s : Set α) :
     LowerSemicontinuous fun f : α →ᵤ[{s}] E => eVariationOn f s := fun f ↦ by
+  rw [lowerSemicontinuousAt_iff_eventually_lt]
   apply @lowerSemicontinuous_aux _ _ _ _ (UniformOnFun α E {s}) id (𝓝 f) f s _
   have := @tendsto_id _ (𝓝 f)
   rw [UniformOnFun.tendsto_iff_tendstoUniformlyOn] at this

--- a/Mathlib/MeasureTheory/Integral/FundThmCalculus.lean
+++ b/Mathlib/MeasureTheory/Integral/FundThmCalculus.lean
@@ -1049,7 +1049,7 @@ theorem sub_le_integral_of_hasDeriv_right_of_le_Ico (hab : a ≤ b)
     -- bound from below the increase of `∫ x in a..u, G' x` on the right of `t`, using the lower
     -- semicontinuity of `G'`.
     have I1 : ∀ᶠ u in 𝓝[>] t, (u - t) * y ≤ ∫ w in t..u, (G' w).toReal := by
-      have B : ∀ᶠ u in 𝓝 t, (y : EReal) < G' u := G'cont.lowerSemicontinuousAt _ _ y_lt_G'
+      have B : ∀ᶠ u in 𝓝 t, (y : EReal) < G' u := G'cont.eventually_lt _ _ y_lt_G'
       rcases mem_nhds_iff_exists_Ioo_subset.1 B with ⟨m, M, ⟨hm, hM⟩, H⟩
       have : Ioo t (min M b) ∈ 𝓝[>] t := Ioo_mem_nhdsWithin_Ioi' (lt_min hM ht.right.right)
       filter_upwards [this] with u hu

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -1366,6 +1366,9 @@ theorem frequently_true_iff_neBot (f : Filter α) : (∃ᶠ _ in f, True) ↔ Ne
 theorem frequently_false (f : Filter α) : ¬∃ᶠ _ in f, False := by simp
 #align filter.frequently_false Filter.frequently_false
 
+lemma Frequently.out_of_const {l : Filter α} {p : Prop} (H : ∃ᶠ _x in l, p) : p :=
+  let ⟨_, h⟩ := H.exists; h
+
 @[simp]
 theorem frequently_const {f : Filter α} [NeBot f] {p : Prop} : (∃ᶠ _ in f, p) ↔ p :=
   by_cases (fun h : p => by simpa [h] ) fun h => by simp [h]

--- a/Mathlib/Topology/Semicontinuous.lean
+++ b/Mathlib/Topology/Semicontinuous.lean
@@ -72,6 +72,12 @@ open Topology BigOperators ENNReal
 
 open Set Function Filter
 
+-- MOVE ME; RENAME ME
+lemma Filter.Frequently.out_of_const {α : Type*} {l : Filter α} {p : Prop}
+    (H : ∃ᶠ _x in l, p) : p :=
+  let ⟨_, h⟩ := H.exists
+  h
+
 variable {α : Type*} [TopologicalSpace α] {β : Type*} [Preorder β] {f g : α → β} {x : α}
   {s t : Set α} {y z : β}
 
@@ -82,7 +88,7 @@ variable {α : Type*} [TopologicalSpace α] {β : Type*} [Preorder β] {f g : α
 `x'` close enough to `x` in `s`, then `f x'` is at least `f x - ε`. We formulate this in a general
 preordered space, using an arbitrary `y < f x` instead of `f x - ε`. -/
 def LowerSemicontinuousWithinAt (f : α → β) (s : Set α) (x : α) :=
-  ∀ y < f x, ∀ᶠ x' in 𝓝[s] x, y < f x'
+  ∀ y, (∃ᶠ x' in 𝓝[s] x, f x' ≤ y) → f x ≤ y
 #align lower_semicontinuous_within_at LowerSemicontinuousWithinAt
 
 /-- A real function `f` is lower semicontinuous on a set `s` if, for any `ε > 0`, for any `x ∈ s`,
@@ -96,7 +102,7 @@ def LowerSemicontinuousOn (f : α → β) (s : Set α) :=
 enough to `x`, then `f x'` is at least `f x - ε`. We formulate this in a general preordered space,
 using an arbitrary `y < f x` instead of `f x - ε`. -/
 def LowerSemicontinuousAt (f : α → β) (x : α) :=
-  ∀ y < f x, ∀ᶠ x' in 𝓝 x, y < f x'
+  ∀ y, (∃ᶠ x' in 𝓝 x, f x' ≤ y) → f x ≤ y
 #align lower_semicontinuous_at LowerSemicontinuousAt
 
 /-- A real function `f` is lower semicontinuous if, for any `ε > 0`, for any `x`, for all `x'` close
@@ -110,7 +116,7 @@ def LowerSemicontinuous (f : α → β) :=
 `x'` close enough to `x` in `s`, then `f x'` is at most `f x + ε`. We formulate this in a general
 preordered space, using an arbitrary `y > f x` instead of `f x + ε`. -/
 def UpperSemicontinuousWithinAt (f : α → β) (s : Set α) (x : α) :=
-  ∀ y, f x < y → ∀ᶠ x' in 𝓝[s] x, f x' < y
+  ∀ y, (∃ᶠ x' in 𝓝[s] x, y ≤ f x') → y ≤ f x
 #align upper_semicontinuous_within_at UpperSemicontinuousWithinAt
 
 /-- A real function `f` is upper semicontinuous on a set `s` if, for any `ε > 0`, for any `x ∈ s`,
@@ -124,7 +130,7 @@ def UpperSemicontinuousOn (f : α → β) (s : Set α) :=
 enough to `x`, then `f x'` is at most `f x + ε`. We formulate this in a general preordered space,
 using an arbitrary `y > f x` instead of `f x + ε`. -/
 def UpperSemicontinuousAt (f : α → β) (x : α) :=
-  ∀ y, f x < y → ∀ᶠ x' in 𝓝 x, f x' < y
+  ∀ y, (∃ᶠ x' in 𝓝 x, y ≤ f x') → y ≤ f x
 #align upper_semicontinuous_at UpperSemicontinuousAt
 
 /-- A real function `f` is upper semicontinuous if, for any `ε > 0`, for any `x`, for all `x'`
@@ -142,9 +148,37 @@ def UpperSemicontinuous (f : α → β) :=
 /-! #### Basic dot notation interface for lower semicontinuity -/
 
 
+theorem lowerSemicontinuousWithinAt_iff_le_of_frequently :
+    LowerSemicontinuousWithinAt f s x ↔ ∀ y, (∃ᶠ x' in 𝓝[s] x, f x' ≤ y) → f x ≤ y :=
+  Iff.rfl
+
+alias ⟨LowerSemicontinuousWithinAt.le_of_frequently, _⟩ :=
+  lowerSemicontinuousWithinAt_iff_le_of_frequently
+
+theorem lowerSemicontinuousOn_iff_le_of_frequently :
+    LowerSemicontinuousOn f s ↔ ∀ x ∈ s, ∀ y, (∃ᶠ x' in 𝓝[s] x, f x' ≤ y) → f x ≤ y :=
+  Iff.rfl
+
+alias ⟨LowerSemicontinuousOn.le_of_frequently, _⟩ :=
+  lowerSemicontinuousOn_iff_le_of_frequently
+
+theorem lowerSemicontinuousAt_iff_le_of_frequently :
+    LowerSemicontinuousAt f x ↔ ∀ y, (∃ᶠ x' in 𝓝 x, f x' ≤ y) → f x ≤ y :=
+  Iff.rfl
+
+alias ⟨LowerSemicontinuousAt.le_of_frequently, _⟩ :=
+  lowerSemicontinuousAt_iff_le_of_frequently
+
+theorem lowerSemicontinuous_iff_le_of_frequently :
+    LowerSemicontinuous f ↔ ∀ x y, (∃ᶠ x' in 𝓝 x, f x' ≤ y) → f x ≤ y :=
+  Iff.rfl
+
+alias ⟨LowerSemicontinuous.le_of_frequently, _⟩ :=
+  lowerSemicontinuous_iff_le_of_frequently
+
 theorem LowerSemicontinuousWithinAt.mono (h : LowerSemicontinuousWithinAt f s x) (hst : t ⊆ s) :
     LowerSemicontinuousWithinAt f t x := fun y hy =>
-  Filter.Eventually.filter_mono (nhdsWithin_mono _ hst) (h y hy)
+  h y <| hy.filter_mono <| nhdsWithin_mono _ hst
 #align lower_semicontinuous_within_at.mono LowerSemicontinuousWithinAt.mono
 
 theorem lowerSemicontinuousWithinAt_univ_iff :
@@ -154,7 +188,7 @@ theorem lowerSemicontinuousWithinAt_univ_iff :
 
 theorem LowerSemicontinuousAt.lowerSemicontinuousWithinAt (s : Set α)
     (h : LowerSemicontinuousAt f x) : LowerSemicontinuousWithinAt f s x := fun y hy =>
-  Filter.Eventually.filter_mono nhdsWithin_le_nhds (h y hy)
+  h y <| hy.filter_mono nhdsWithin_le_nhds
 #align lower_semicontinuous_at.lower_semicontinuous_within_at LowerSemicontinuousAt.lowerSemicontinuousWithinAt
 
 theorem LowerSemicontinuousOn.lowerSemicontinuousWithinAt (h : LowerSemicontinuousOn f s)
@@ -188,11 +222,11 @@ theorem LowerSemicontinuous.lowerSemicontinuousOn (h : LowerSemicontinuous f) (s
 
 
 theorem lowerSemicontinuousWithinAt_const : LowerSemicontinuousWithinAt (fun _x => z) s x :=
-  fun _y hy => Filter.eventually_of_forall fun _x => hy
+  fun _y hy => hy.out_of_const
 #align lower_semicontinuous_within_at_const lowerSemicontinuousWithinAt_const
 
-theorem lowerSemicontinuousAt_const : LowerSemicontinuousAt (fun _x => z) x := fun _y hy =>
-  Filter.eventually_of_forall fun _x => hy
+theorem lowerSemicontinuousAt_const : LowerSemicontinuousAt (fun _x => z) x :=
+  fun _y hy => hy.out_of_const
 #align lower_semicontinuous_at_const lowerSemicontinuousAt_const
 
 theorem lowerSemicontinuousOn_const : LowerSemicontinuousOn (fun _x => z) s := fun _x _hx =>
@@ -203,6 +237,96 @@ theorem lowerSemicontinuous_const : LowerSemicontinuous fun _x : α => z := fun 
   lowerSemicontinuousAt_const
 #align lower_semicontinuous_const lowerSemicontinuous_const
 
+/-! #### Characterization in terms of strict order -/
+
+
+section
+
+variable {γ : Type*} [LinearOrder γ]
+
+theorem lowerSemicontinuousWithinAt_iff_eventually_lt {f : α → γ} :
+    LowerSemicontinuousWithinAt f s x ↔ (∀ y < f x, ∀ᶠ x' in 𝓝[s] x, y < f x') := by
+  simp_rw [LowerSemicontinuousWithinAt, lt_iff_not_le, ← not_frequently, not_imp_not]
+
+alias ⟨LowerSemicontinuousWithinAt.eventually_lt, _⟩ :=
+  lowerSemicontinuousWithinAt_iff_eventually_lt
+
+theorem lowerSemicontinuousOn_iff_eventually_lt {f : α → γ} :
+    LowerSemicontinuousOn f s ↔ ∀ x ∈ s, ∀ y < f x, ∀ᶠ x' in 𝓝[s] x, y < f x' :=
+  forall₂_congr fun _ _ ↦ lowerSemicontinuousWithinAt_iff_eventually_lt
+
+alias ⟨LowerSemicontinuousOn.eventually_lt, _⟩ :=
+  lowerSemicontinuousOn_iff_eventually_lt
+
+theorem lowerSemicontinuousAt_iff_eventually_lt {f : α → γ} :
+    LowerSemicontinuousAt f x ↔ ∀ y < f x, ∀ᶠ x' in 𝓝 x, y < f x' := by
+  simp_rw [LowerSemicontinuousAt, lt_iff_not_le, ← not_frequently, not_imp_not]
+
+alias ⟨LowerSemicontinuousAt.eventually_lt, _⟩ :=
+  lowerSemicontinuousAt_iff_eventually_lt
+
+theorem lowerSemicontinuous_iff_eventually_lt {f : α → γ} :
+    LowerSemicontinuous f ↔ ∀ x, ∀ y < f x, ∀ᶠ x' in 𝓝 x, y < f x' :=
+  forall_congr' fun _ ↦ lowerSemicontinuousAt_iff_eventually_lt
+
+alias ⟨LowerSemicontinuous.eventually_lt, _⟩ :=
+  lowerSemicontinuous_iff_eventually_lt
+
+end
+
+/-! #### Relationship with continuity -/
+
+
+theorem lowerSemicontinuous_iff_isClosed_preimage :
+    LowerSemicontinuous f ↔ ∀ y, IsClosed (f ⁻¹' Iic y) :=
+  ⟨fun H y ↦ isClosed_iff_frequently.mpr fun x ↦ H x y, fun H _x y hx ↦ hx.mem_of_closed (H y)⟩
+#align lower_semicontinuous_iff_is_closed_preimage lowerSemicontinuous_iff_isClosed_preimage
+
+theorem LowerSemicontinuous.isClosed_preimage (hf : LowerSemicontinuous f) (y : β) :
+    IsClosed (f ⁻¹' Iic y) :=
+  lowerSemicontinuous_iff_isClosed_preimage.1 hf y
+#align lower_semicontinuous.is_closed_preimage LowerSemicontinuous.isClosed_preimage
+
+section
+
+-- TODO : the results below are equivalences if we have `Topology.IsLower β`.
+variable [TopologicalSpace β] [ClosedIicTopology β]
+
+theorem ContinuousWithinAt.lowerSemicontinuousWithinAt (h : ContinuousWithinAt f s x) :
+    LowerSemicontinuousWithinAt f s x := fun _y hy ↦ (h.frequently hy).mem_of_closed isClosed_Iic
+#align continuous_within_at.lower_semicontinuous_within_at ContinuousWithinAt.lowerSemicontinuousWithinAt
+
+theorem ContinuousAt.lowerSemicontinuousAt {f : α → β} (h : ContinuousAt f x) :
+    LowerSemicontinuousAt f x := fun _y hy ↦ (h.frequently hy).mem_of_closed isClosed_Iic
+#align continuous_at.lower_semicontinuous_at ContinuousAt.lowerSemicontinuousAt
+
+theorem ContinuousOn.lowerSemicontinuousOn {f : α → β} (h : ContinuousOn f s) :
+    LowerSemicontinuousOn f s := fun x hx => (h x hx).lowerSemicontinuousWithinAt
+#align continuous_on.lower_semicontinuous_on ContinuousOn.lowerSemicontinuousOn
+
+theorem Continuous.lowerSemicontinuous {f : α → β} (h : Continuous f) : LowerSemicontinuous f :=
+  fun _x => h.continuousAt.lowerSemicontinuousAt
+#align continuous.lower_semicontinuous Continuous.lowerSemicontinuous
+
+end
+
+section
+
+variable {γ : Type*} [LinearOrder γ]
+
+theorem lowerSemicontinuous_iff_isOpen_preimage {f : α → γ} :
+    LowerSemicontinuous f ↔ ∀ y, IsOpen (f ⁻¹' Ioi y) := by
+  rw [lowerSemicontinuous_iff_isClosed_preimage]
+  simp only [← isOpen_compl_iff, ← preimage_compl, compl_Iic]
+#align lower_semicontinuous_iff_is_open_preimage lowerSemicontinuous_iff_isOpen_preimage
+
+theorem LowerSemicontinuous.isOpen_preimage {f : α → γ} (hf : LowerSemicontinuous f) (y : γ) :
+    IsOpen (f ⁻¹' Ioi y) :=
+  lowerSemicontinuous_iff_isOpen_preimage.1 hf y
+#align lower_semicontinuous.is_open_preimage LowerSemicontinuous.isOpen_preimage
+
+end
+
 /-! #### Indicators -/
 
 
@@ -212,12 +336,11 @@ variable [Zero β]
 
 theorem IsOpen.lowerSemicontinuous_indicator (hs : IsOpen s) (hy : 0 ≤ y) :
     LowerSemicontinuous (indicator s fun _x => y) := by
-  intro x z hz
-  by_cases h : x ∈ s <;> simp [h] at hz
-  · filter_upwards [hs.mem_nhds h]
-    simp (config := { contextual := true }) [hz]
-  · refine Filter.eventually_of_forall fun x' => ?_
-    by_cases h' : x' ∈ s <;> simp [h', hz.trans_le hy, hz]
+  simp_rw [lowerSemicontinuous_iff_isClosed_preimage, indicator_preimage, Iic, preimage_setOf_eq]
+  intro z
+  by_cases hyz : y ≤ z
+  · simp [hyz, le_trans hy hyz]
+  · by_cases h0z : 0 ≤ z <;> simp [hyz, h0z, ← compl_eq_univ_diff, hs]
 #align is_open.lower_semicontinuous_indicator IsOpen.lowerSemicontinuous_indicator
 
 theorem IsOpen.lowerSemicontinuousOn_indicator (hs : IsOpen s) (hy : 0 ≤ y) :
@@ -237,12 +360,11 @@ theorem IsOpen.lowerSemicontinuousWithinAt_indicator (hs : IsOpen s) (hy : 0 ≤
 
 theorem IsClosed.lowerSemicontinuous_indicator (hs : IsClosed s) (hy : y ≤ 0) :
     LowerSemicontinuous (indicator s fun _x => y) := by
-  intro x z hz
-  by_cases h : x ∈ s <;> simp [h] at hz
-  · refine Filter.eventually_of_forall fun x' => ?_
-    by_cases h' : x' ∈ s <;> simp [h', hz, hz.trans_le hy]
-  · filter_upwards [hs.isOpen_compl.mem_nhds h]
-    simp (config := { contextual := true }) [hz]
+  simp_rw [lowerSemicontinuous_iff_isClosed_preimage, indicator_preimage, Iic, preimage_setOf_eq]
+  intro z
+  by_cases h0z : 0 ≤ z
+  · simp [h0z, le_trans hy h0z]
+  · by_cases hyz : y ≤ z <;> simp [hyz, h0z, hs]
 #align is_closed.lower_semicontinuous_indicator IsClosed.lowerSemicontinuous_indicator
 
 theorem IsClosed.lowerSemicontinuousOn_indicator (hs : IsClosed s) (hy : y ≤ 0) :
@@ -262,55 +384,6 @@ theorem IsClosed.lowerSemicontinuousWithinAt_indicator (hs : IsClosed s) (hy : y
 
 end
 
-/-! #### Relationship with continuity -/
-
-
-theorem lowerSemicontinuous_iff_isOpen_preimage :
-    LowerSemicontinuous f ↔ ∀ y, IsOpen (f ⁻¹' Ioi y) :=
-  ⟨fun H y => isOpen_iff_mem_nhds.2 fun x hx => H x y hx, fun H _x y y_lt =>
-    IsOpen.mem_nhds (H y) y_lt⟩
-#align lower_semicontinuous_iff_is_open_preimage lowerSemicontinuous_iff_isOpen_preimage
-
-theorem LowerSemicontinuous.isOpen_preimage (hf : LowerSemicontinuous f) (y : β) :
-    IsOpen (f ⁻¹' Ioi y) :=
-  lowerSemicontinuous_iff_isOpen_preimage.1 hf y
-#align lower_semicontinuous.is_open_preimage LowerSemicontinuous.isOpen_preimage
-
-section
-
-variable {γ : Type*} [LinearOrder γ]
-
-theorem lowerSemicontinuous_iff_isClosed_preimage {f : α → γ} :
-    LowerSemicontinuous f ↔ ∀ y, IsClosed (f ⁻¹' Iic y) := by
-  rw [lowerSemicontinuous_iff_isOpen_preimage]
-  simp only [← isOpen_compl_iff, ← preimage_compl, compl_Iic]
-#align lower_semicontinuous_iff_is_closed_preimage lowerSemicontinuous_iff_isClosed_preimage
-
-theorem LowerSemicontinuous.isClosed_preimage {f : α → γ} (hf : LowerSemicontinuous f) (y : γ) :
-    IsClosed (f ⁻¹' Iic y) :=
-  lowerSemicontinuous_iff_isClosed_preimage.1 hf y
-#align lower_semicontinuous.is_closed_preimage LowerSemicontinuous.isClosed_preimage
-
-variable [TopologicalSpace γ] [OrderTopology γ]
-
-theorem ContinuousWithinAt.lowerSemicontinuousWithinAt {f : α → γ} (h : ContinuousWithinAt f s x) :
-    LowerSemicontinuousWithinAt f s x := fun _y hy => h (Ioi_mem_nhds hy)
-#align continuous_within_at.lower_semicontinuous_within_at ContinuousWithinAt.lowerSemicontinuousWithinAt
-
-theorem ContinuousAt.lowerSemicontinuousAt {f : α → γ} (h : ContinuousAt f x) :
-    LowerSemicontinuousAt f x := fun _y hy => h (Ioi_mem_nhds hy)
-#align continuous_at.lower_semicontinuous_at ContinuousAt.lowerSemicontinuousAt
-
-theorem ContinuousOn.lowerSemicontinuousOn {f : α → γ} (h : ContinuousOn f s) :
-    LowerSemicontinuousOn f s := fun x hx => (h x hx).lowerSemicontinuousWithinAt
-#align continuous_on.lower_semicontinuous_on ContinuousOn.lowerSemicontinuousOn
-
-theorem Continuous.lowerSemicontinuous {f : α → γ} (h : Continuous f) : LowerSemicontinuous f :=
-  fun _x => h.continuousAt.lowerSemicontinuousAt
-#align continuous.lower_semicontinuous Continuous.lowerSemicontinuous
-
-end
-
 /-! #### Equivalent definitions -/
 
 section
@@ -323,9 +396,8 @@ theorem lowerSemicontinuousWithinAt_iff_le_liminf {f : α → γ} :
   · intro hf; unfold LowerSemicontinuousWithinAt at hf
     contrapose! hf
     obtain ⟨y, lty, ylt⟩ := exists_between hf; use y
-    exact ⟨ylt, fun h => lty.not_le
-      (le_liminf_of_le (by isBoundedDefault) (h.mono fun _ hx => le_of_lt hx))⟩
-  exact fun hf y ylt => eventually_lt_of_lt_liminf (ylt.trans_le hf)
+    exact ⟨frequently_lt_of_liminf_lt (by isBoundedDefault) lty |>.mono fun x hx ↦ hx.le, ylt⟩
+  exact fun hf y hy ↦ le_trans hf <| liminf_le_of_frequently_le hy
 
 alias ⟨LowerSemicontinuousWithinAt.le_liminf, _⟩ := lowerSemicontinuousWithinAt_iff_le_liminf
 

--- a/Mathlib/Topology/Semicontinuous.lean
+++ b/Mathlib/Topology/Semicontinuous.lean
@@ -72,12 +72,6 @@ open Topology BigOperators ENNReal
 
 open Set Function Filter
 
--- MOVE ME; RENAME ME
-lemma Filter.Frequently.out_of_const {α : Type*} {l : Filter α} {p : Prop}
-    (H : ∃ᶠ _x in l, p) : p :=
-  let ⟨_, h⟩ := H.exists
-  h
-
 variable {α : Type*} [TopologicalSpace α] {β : Type*} [Preorder β] {f g : α → β} {x : α}
   {s t : Set α} {y z : β}
 

--- a/Mathlib/Topology/Semicontinuous.lean
+++ b/Mathlib/Topology/Semicontinuous.lean
@@ -289,7 +289,7 @@ theorem LowerSemicontinuous.isClosed_preimage (hf : LowerSemicontinuous f) (y : 
 
 section
 
--- TODO : the results below are equivalences if we have `Topology.IsLower β`.
+-- TODO : the results below are equivalences if we have `Topology.IsUpper β`.
 variable [TopologicalSpace β] [ClosedIicTopology β]
 
 theorem ContinuousWithinAt.lowerSemicontinuousWithinAt (h : ContinuousWithinAt f s x) :
@@ -829,10 +829,37 @@ end
 
 /-! #### Basic dot notation interface for upper semicontinuity -/
 
+theorem upperSemicontinuousWithinAt_iff_le_of_frequently :
+    UpperSemicontinuousWithinAt f s x ↔ ∀ y, (∃ᶠ x' in 𝓝[s] x, y ≤ f x') → y ≤ f x :=
+  Iff.rfl
+
+alias ⟨UpperSemicontinuousWithinAt.le_of_frequently, _⟩ :=
+  upperSemicontinuousWithinAt_iff_le_of_frequently
+
+theorem upperSemicontinuousOn_iff_le_of_frequently :
+    UpperSemicontinuousOn f s ↔ ∀ x ∈ s, ∀ y, (∃ᶠ x' in 𝓝[s] x, y ≤ f x') → y ≤ f x :=
+  Iff.rfl
+
+alias ⟨UpperSemicontinuousOn.le_of_frequently, _⟩ :=
+  upperSemicontinuousOn_iff_le_of_frequently
+
+theorem upperSemicontinuousAt_iff_le_of_frequently :
+    UpperSemicontinuousAt f x ↔ ∀ y, (∃ᶠ x' in 𝓝 x, y ≤ f x') → y ≤ f x :=
+  Iff.rfl
+
+alias ⟨UpperSemicontinuousAt.le_of_frequently, _⟩ :=
+  upperSemicontinuousAt_iff_le_of_frequently
+
+theorem upperSemicontinuous_iff_le_of_frequently :
+    UpperSemicontinuous f ↔ ∀ x y, (∃ᶠ x' in 𝓝 x, y ≤ f x') → y ≤ f x :=
+  Iff.rfl
+
+alias ⟨UpperSemicontinuous.le_of_frequently, _⟩ :=
+  upperSemicontinuous_iff_le_of_frequently
 
 theorem UpperSemicontinuousWithinAt.mono (h : UpperSemicontinuousWithinAt f s x) (hst : t ⊆ s) :
     UpperSemicontinuousWithinAt f t x := fun y hy =>
-  Filter.Eventually.filter_mono (nhdsWithin_mono _ hst) (h y hy)
+  h y <| hy.filter_mono <| nhdsWithin_mono _ hst
 #align upper_semicontinuous_within_at.mono UpperSemicontinuousWithinAt.mono
 
 theorem upperSemicontinuousWithinAt_univ_iff :
@@ -842,7 +869,7 @@ theorem upperSemicontinuousWithinAt_univ_iff :
 
 theorem UpperSemicontinuousAt.upperSemicontinuousWithinAt (s : Set α)
     (h : UpperSemicontinuousAt f x) : UpperSemicontinuousWithinAt f s x := fun y hy =>
-  Filter.Eventually.filter_mono nhdsWithin_le_nhds (h y hy)
+  h y <| hy.filter_mono nhdsWithin_le_nhds
 #align upper_semicontinuous_at.upper_semicontinuous_within_at UpperSemicontinuousAt.upperSemicontinuousWithinAt
 
 theorem UpperSemicontinuousOn.upperSemicontinuousWithinAt (h : UpperSemicontinuousOn f s)
@@ -876,11 +903,11 @@ theorem UpperSemicontinuous.upperSemicontinuousOn (h : UpperSemicontinuous f) (s
 
 
 theorem upperSemicontinuousWithinAt_const : UpperSemicontinuousWithinAt (fun _x => z) s x :=
-  fun _y hy => Filter.eventually_of_forall fun _x => hy
+  fun _y hy ↦ hy.out_of_const
 #align upper_semicontinuous_within_at_const upperSemicontinuousWithinAt_const
 
 theorem upperSemicontinuousAt_const : UpperSemicontinuousAt (fun _x => z) x := fun _y hy =>
-  Filter.eventually_of_forall fun _x => hy
+  hy.out_of_const
 #align upper_semicontinuous_at_const upperSemicontinuousAt_const
 
 theorem upperSemicontinuousOn_const : UpperSemicontinuousOn (fun _x => z) s := fun _x _hx =>
@@ -890,6 +917,97 @@ theorem upperSemicontinuousOn_const : UpperSemicontinuousOn (fun _x => z) s := f
 theorem upperSemicontinuous_const : UpperSemicontinuous fun _x : α => z := fun _x =>
   upperSemicontinuousAt_const
 #align upper_semicontinuous_const upperSemicontinuous_const
+
+/-! #### Characterization in terms of strict order -/
+
+
+section
+
+variable {γ : Type*} [LinearOrder γ]
+
+theorem upperSemicontinuousWithinAt_iff_eventually_lt {f : α → γ} :
+    UpperSemicontinuousWithinAt f s x ↔ (∀ y, f x < y → ∀ᶠ x' in 𝓝[s] x, f x' < y) := by
+  simp_rw [UpperSemicontinuousWithinAt, lt_iff_not_le, ← not_frequently, not_imp_not]
+
+alias ⟨UpperSemicontinuousWithinAt.eventually_lt, _⟩ :=
+  upperSemicontinuousWithinAt_iff_eventually_lt
+
+theorem upperSemicontinuousOn_iff_eventually_lt {f : α → γ} :
+    UpperSemicontinuousOn f s ↔ ∀ x ∈ s, ∀ y, f x < y → ∀ᶠ x' in 𝓝[s] x, f x' < y :=
+  forall₂_congr fun _ _ ↦ upperSemicontinuousWithinAt_iff_eventually_lt
+
+alias ⟨UpperSemicontinuousOn.eventually_lt, _⟩ :=
+  upperSemicontinuousOn_iff_eventually_lt
+
+theorem upperSemicontinuousAt_iff_eventually_lt {f : α → γ} :
+    UpperSemicontinuousAt f x ↔ ∀ y, f x < y → ∀ᶠ x' in 𝓝 x, f x' < y := by
+  simp_rw [UpperSemicontinuousAt, lt_iff_not_le, ← not_frequently, not_imp_not]
+
+alias ⟨UpperSemicontinuousAt.eventually_lt, _⟩ :=
+  upperSemicontinuousAt_iff_eventually_lt
+
+theorem upperSemicontinuous_iff_eventually_lt {f : α → γ} :
+    UpperSemicontinuous f ↔ ∀ x, ∀ y, f x < y → ∀ᶠ x' in 𝓝 x, f x' < y :=
+  forall_congr' fun _ ↦ upperSemicontinuousAt_iff_eventually_lt
+
+alias ⟨UpperSemicontinuous.eventually_lt, _⟩ :=
+  upperSemicontinuous_iff_eventually_lt
+
+end
+
+/-! #### Relationship with continuity -/
+
+
+theorem upperSemicontinuous_iff_isClosed_preimage :
+    UpperSemicontinuous f ↔ ∀ y, IsClosed (f ⁻¹' Ici y) :=
+  ⟨fun H y ↦ isClosed_iff_frequently.mpr fun x ↦ H x y, fun H _x y hx ↦ hx.mem_of_closed (H y)⟩
+#align upper_semicontinuous_iff_is_closed_preimage upperSemicontinuous_iff_isClosed_preimage
+
+theorem UpperSemicontinuous.isClosed_preimage (hf : UpperSemicontinuous f) (y : β) :
+    IsClosed (f ⁻¹' Ici y) :=
+  upperSemicontinuous_iff_isClosed_preimage.1 hf y
+#align upper_semicontinuous.is_closed_preimage UpperSemicontinuous.isClosed_preimage
+
+section
+
+-- TODO : the results below are equivalences if we have `Topology.IsLower β`.
+variable [TopologicalSpace β] [ClosedIciTopology β]
+
+theorem ContinuousWithinAt.upperSemicontinuousWithinAt (h : ContinuousWithinAt f s x) :
+    UpperSemicontinuousWithinAt f s x := fun _y hy ↦ (h.frequently hy).mem_of_closed isClosed_Ici
+#align continuous_within_at.upper_semicontinuous_within_at ContinuousWithinAt.upperSemicontinuousWithinAt
+
+theorem ContinuousAt.upperSemicontinuousAt {f : α → β} (h : ContinuousAt f x) :
+    UpperSemicontinuousAt f x := fun _y hy ↦ (h.frequently hy).mem_of_closed isClosed_Ici
+#align continuous_at.upper_semicontinuous_at ContinuousAt.upperSemicontinuousAt
+
+theorem ContinuousOn.upperSemicontinuousOn {f : α → β} (h : ContinuousOn f s) :
+    UpperSemicontinuousOn f s := fun x hx => (h x hx).upperSemicontinuousWithinAt
+#align continuous_on.upper_semicontinuous_on ContinuousOn.upperSemicontinuousOn
+
+theorem Continuous.upperSemicontinuous {f : α → β} (h : Continuous f) : UpperSemicontinuous f :=
+  fun _x => h.continuousAt.upperSemicontinuousAt
+#align continuous.upper_semicontinuous Continuous.upperSemicontinuous
+
+end
+
+section
+
+variable {γ : Type*} [LinearOrder γ]
+
+theorem upperSemicontinuous_iff_isOpen_preimage {f : α → γ} :
+    UpperSemicontinuous f ↔ ∀ y, IsOpen (f ⁻¹' Iio y) := by
+  rw [upperSemicontinuous_iff_isClosed_preimage]
+  simp only [← isOpen_compl_iff, ← preimage_compl, compl_Ici]
+#align upper_semicontinuous_iff_is_open_preimage upperSemicontinuous_iff_isOpen_preimage
+
+theorem UpperSemicontinuous.isOpen_preimage {f : α → γ} (hf : UpperSemicontinuous f) (y : γ) :
+    IsOpen (f ⁻¹' Iio y) :=
+  upperSemicontinuous_iff_isOpen_preimage.1 hf y
+#align upper_semicontinuous.is_open_preimage UpperSemicontinuous.isOpen_preimage
+
+end
+
 
 /-! #### Indicators -/
 
@@ -937,55 +1055,6 @@ theorem IsClosed.upperSemicontinuousWithinAt_indicator (hs : IsClosed s) (hy : 0
     UpperSemicontinuousWithinAt (indicator s fun _x => y) t x :=
   (hs.upperSemicontinuous_indicator hy).upperSemicontinuousWithinAt t x
 #align is_closed.upper_semicontinuous_within_at_indicator IsClosed.upperSemicontinuousWithinAt_indicator
-
-end
-
-/-! #### Relationship with continuity -/
-
-
-theorem upperSemicontinuous_iff_isOpen_preimage :
-    UpperSemicontinuous f ↔ ∀ y, IsOpen (f ⁻¹' Iio y) :=
-  ⟨fun H y => isOpen_iff_mem_nhds.2 fun x hx => H x y hx, fun H _x y y_lt =>
-    IsOpen.mem_nhds (H y) y_lt⟩
-#align upper_semicontinuous_iff_is_open_preimage upperSemicontinuous_iff_isOpen_preimage
-
-theorem UpperSemicontinuous.isOpen_preimage (hf : UpperSemicontinuous f) (y : β) :
-    IsOpen (f ⁻¹' Iio y) :=
-  upperSemicontinuous_iff_isOpen_preimage.1 hf y
-#align upper_semicontinuous.is_open_preimage UpperSemicontinuous.isOpen_preimage
-
-section
-
-variable {γ : Type*} [LinearOrder γ]
-
-theorem upperSemicontinuous_iff_isClosed_preimage {f : α → γ} :
-    UpperSemicontinuous f ↔ ∀ y, IsClosed (f ⁻¹' Ici y) := by
-  rw [upperSemicontinuous_iff_isOpen_preimage]
-  simp only [← isOpen_compl_iff, ← preimage_compl, compl_Ici]
-#align upper_semicontinuous_iff_is_closed_preimage upperSemicontinuous_iff_isClosed_preimage
-
-theorem UpperSemicontinuous.isClosed_preimage {f : α → γ} (hf : UpperSemicontinuous f) (y : γ) :
-    IsClosed (f ⁻¹' Ici y) :=
-  upperSemicontinuous_iff_isClosed_preimage.1 hf y
-#align upper_semicontinuous.is_closed_preimage UpperSemicontinuous.isClosed_preimage
-
-variable [TopologicalSpace γ] [OrderTopology γ]
-
-theorem ContinuousWithinAt.upperSemicontinuousWithinAt {f : α → γ} (h : ContinuousWithinAt f s x) :
-    UpperSemicontinuousWithinAt f s x := fun _y hy => h (Iio_mem_nhds hy)
-#align continuous_within_at.upper_semicontinuous_within_at ContinuousWithinAt.upperSemicontinuousWithinAt
-
-theorem ContinuousAt.upperSemicontinuousAt {f : α → γ} (h : ContinuousAt f x) :
-    UpperSemicontinuousAt f x := fun _y hy => h (Iio_mem_nhds hy)
-#align continuous_at.upper_semicontinuous_at ContinuousAt.upperSemicontinuousAt
-
-theorem ContinuousOn.upperSemicontinuousOn {f : α → γ} (h : ContinuousOn f s) :
-    UpperSemicontinuousOn f s := fun x hx => (h x hx).upperSemicontinuousWithinAt
-#align continuous_on.upper_semicontinuous_on ContinuousOn.upperSemicontinuousOn
-
-theorem Continuous.upperSemicontinuous {f : α → γ} (h : Continuous f) : UpperSemicontinuous f :=
-  fun _x => h.continuousAt.upperSemicontinuousAt
-#align continuous.upper_semicontinuous Continuous.upperSemicontinuous
 
 end
 
@@ -1083,7 +1152,7 @@ theorem Continuous.comp_upperSemicontinuous_antitone {g : γ → δ} {f : α →
 theorem UpperSemicontinuousAt.comp_continuousAt {f : α → β} {g : ι → α} {x : ι}
     (hf : UpperSemicontinuousAt f (g x)) (hg : ContinuousAt g x) :
     UpperSemicontinuousAt (fun x ↦ f (g x)) x :=
-  fun _ lt ↦ hg.eventually (hf _ lt)
+  fun _ lt ↦ hf _ <| hg.frequently lt
 
 theorem UpperSemicontinuousAt.comp_continuousAt_of_eq {f : α → β} {g : ι → α} {y : α} {x : ι}
     (hf : UpperSemicontinuousAt f y) (hg : ContinuousAt g x) (hy : g x = y) :
@@ -1291,6 +1360,7 @@ theorem continuousWithinAt_iff_lower_upperSemicontinuousWithinAt {f : α → γ}
     ContinuousWithinAt f s x ↔
       LowerSemicontinuousWithinAt f s x ∧ UpperSemicontinuousWithinAt f s x := by
   refine' ⟨fun h => ⟨h.lowerSemicontinuousWithinAt, h.upperSemicontinuousWithinAt⟩, _⟩
+  rw [lowerSemicontinuousWithinAt_iff_eventually_lt, upperSemicontinuousWithinAt_iff_eventually_lt]
   rintro ⟨h₁, h₂⟩
   intro v hv
   simp only [Filter.mem_map]

--- a/Mathlib/Topology/Semicontinuous.lean
+++ b/Mathlib/Topology/Semicontinuous.lean
@@ -457,6 +457,7 @@ variable {ι : Type*} [TopologicalSpace ι]
 theorem ContinuousAt.comp_lowerSemicontinuousWithinAt {g : γ → δ} {f : α → γ}
     (hg : ContinuousAt g (f x)) (hf : LowerSemicontinuousWithinAt f s x) (gmon : Monotone g) :
     LowerSemicontinuousWithinAt (g ∘ f) s x := by
+  rw [lowerSemicontinuousWithinAt_iff_eventually_lt] at hf ⊢
   intro y hy
   by_cases h : ∃ l, l < f x
   · obtain ⟨z, zlt, hz⟩ : ∃ z < f x, Ioc z (f x) ⊆ g ⁻¹' Ioi y :=
@@ -511,7 +512,7 @@ theorem Continuous.comp_lowerSemicontinuous_antitone {g : γ → δ} {f : α →
 theorem LowerSemicontinuousAt.comp_continuousAt {f : α → β} {g : ι → α} {x : ι}
     (hf : LowerSemicontinuousAt f (g x)) (hg : ContinuousAt g x) :
     LowerSemicontinuousAt (fun x ↦ f (g x)) x :=
-  fun _ lt ↦ hg.eventually (hf _ lt)
+  fun _ lt ↦ hf _ <| hg.frequently lt
 
 theorem LowerSemicontinuousAt.comp_continuousAt_of_eq {f : α → β} {g : ι → α} {y : α} {x : ι}
     (hf : LowerSemicontinuousAt f y) (hg : ContinuousAt g x) (hy : g x = y) :
@@ -540,6 +541,7 @@ theorem LowerSemicontinuousWithinAt.add' {f g : α → γ} (hf : LowerSemicontin
     (hg : LowerSemicontinuousWithinAt g s x)
     (hcont : ContinuousAt (fun p : γ × γ => p.1 + p.2) (f x, g x)) :
     LowerSemicontinuousWithinAt (fun z => f z + g z) s x := by
+  rw [lowerSemicontinuousWithinAt_iff_eventually_lt] at hf hg ⊢
   intro y hy
   obtain ⟨u, v, u_open, xu, v_open, xv, h⟩ :
     ∃ u v : Set γ,
@@ -716,7 +718,8 @@ theorem lowerSemicontinuousWithinAt_ciSup {f : ι → α → δ'}
     LowerSemicontinuousWithinAt (fun x' => ⨆ i, f i x') s x := by
   cases isEmpty_or_nonempty ι
   · simpa only [iSup_of_empty'] using lowerSemicontinuousWithinAt_const
-  · intro y hy
+  · simp_rw [lowerSemicontinuousWithinAt_iff_eventually_lt] at h ⊢
+    intro y hy
     rcases exists_lt_of_lt_ciSup hy with ⟨i, hi⟩
     filter_upwards [h i y hi, bdd] with y hy hy' using hy.trans_le (le_ciSup hy' i)
 #align lower_semicontinuous_within_at_csupr lowerSemicontinuousWithinAt_ciSup


### PR DESCRIPTION
Summary of the changes:
- change definitions to make [lowerSemicontinuous_iff_isClosed_preimage](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Semicontinuous.html#lowerSemicontinuous_iff_isClosed_preimage) true without assuming `LinearOrder`, so that semicontinuity corresponds to continuity for lower/upper order topology on the codomain. See discussion on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Semicontinuity.20definition.20for.20non-linear.20orders/near/432898278)
- add new `iff` lemmas for unfolding the definition
- add `iff` lemmas with the old definition in the linearly ordered case
- some basic lemmas need to be changed in an easy way
- minimize assumptions for continuity => semicontinuity
- prove the semicontinuity criterion for indicators using "preimage of Ici/Iic" instead of a direct proof, because the proof is more natural (especially because we have no `filter_upwards` for `Frequently`)
- in the rest of the file (which is about linear orders anyway), we don't touch the statements and just rewrite to the old definition. Some of these could be generalized, but we keep that for a later PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
