### PR TITLE
[Merged by Bors] - chore: remove porting notes about redundant binder updates

### DIFF
--- a/Mathlib/Algebra/CharP/Basic.lean
+++ b/Mathlib/Algebra/CharP/Basic.lean
@@ -455,7 +455,6 @@ end Semiring
 section Ring
 
 variable [Ring R] [NoZeroDivisors R] [Nontrivial R] [Finite R]
--- Porting note: removed redundant binder annotation update `(R)`
 
 theorem char_is_prime (p : ℕ) [CharP R p] : p.Prime :=
   Or.resolve_right (char_is_prime_or_zero R p) (char_ne_zero_of_finite R p)
@@ -539,7 +538,6 @@ end
 section
 
 variable [NonAssocRing R] [Fintype R] (n : ℕ)
--- Porting note: removed redundant binder annotation update `(R)`
 
 theorem charP_of_ne_zero (hn : Fintype.card R = n) (hR : ∀ i < n, (i : R) = 0 → i = 0) :
     CharP R n :=
@@ -621,7 +619,6 @@ end
 namespace NeZero
 
 variable [AddMonoidWithOne R] {r : R} {n p : ℕ} {a : ℕ+}
--- Porting note: removed redundant binder annotation update `(R)`
 
 theorem of_not_dvd [CharP R p] (h : ¬p ∣ n) : NeZero (n : R) :=
   ⟨(CharP.cast_eq_zero_iff R p n).not.mpr h⟩

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -172,8 +172,6 @@ def aeval : R[X] →ₐ[R] A :=
   eval₂AlgHom' (Algebra.ofId _ _) x (Algebra.commutes · _)
 #align polynomial.aeval Polynomial.aeval
 
--- Porting note: removed `variable` due to redundant binder annotation update
-
 @[simp]
 theorem adjoin_X : Algebra.adjoin R ({X} : Set R[X]) = ⊤ := by
   refine' top_unique fun p _hp => _

--- a/Mathlib/Algebra/Star/Subalgebra.lean
+++ b/Mathlib/Algebra/Star/Subalgebra.lean
@@ -291,7 +291,7 @@ end Map
 
 section Centralizer
 
-variable (R) -- Porting note: redundant binder annotation update
+variable (R)
 
 /-- The centralizer, or commutant, of the star-closure of a set as a star subalgebra. -/
 def centralizer (s : Set A) : StarSubalgebra R A where

--- a/Mathlib/CategoryTheory/Bicategory/Free.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Free.lean
@@ -84,9 +84,6 @@ inductive Hom₂ : ∀ {a b : FreeBicategory B}, (a ⟶ b) → (a ⟶ b) → Typ
 
 section
 
--- Porting note: commenting out redundant binder annotation update
--- variable {B}
-
 -- The following notations are only used in the definition of `Rel` to simplify the notation.
 local infixr:0 " ≫ " => Hom₂.vcomp
 
@@ -153,9 +150,6 @@ inductive Rel : ∀ {a b : FreeBicategory B} {f g : a ⟶ b}, Hom₂ f g → Hom
 #align category_theory.free_bicategory.rel CategoryTheory.FreeBicategory.Rel
 
 end
-
--- Porting note: commenting out redundant binder annotation update
--- variable {B}
 
 instance homCategory (a b : FreeBicategory B) : Category (a ⟶ b) where
   Hom f g := Quot (@Rel _ _ a b f g)

--- a/Mathlib/Combinatorics/Configuration.lean
+++ b/Mathlib/Combinatorics/Configuration.lean
@@ -168,7 +168,6 @@ theorem Nondegenerate.exists_injective_of_card_le [Nondegenerate P L] [Fintype P
 #align configuration.nondegenerate.exists_injective_of_card_le Configuration.Nondegenerate.exists_injective_of_card_le
 
 -- If `s < univ`, then consequence of `hs₂`
--- Porting note: left out {P} to avoid redundant binder annotation
 variable (L)
 
 /-- Number of points on a given line. -/
@@ -183,7 +182,6 @@ noncomputable def pointCount (l : L) : ℕ :=
   Nat.card { p : P // p ∈ l }
 #align configuration.point_count Configuration.pointCount
 
--- Porting note: left out (P) to avoid redundant binder annotation
 variable (L)
 
 theorem sum_lineCount_eq_sum_pointCount [Fintype P] [Fintype L] :
@@ -375,7 +373,6 @@ theorem card_points_eq_card_lines [Fintype P] [Fintype L] : Fintype.card P = Fin
   le_antisymm (HasLines.card_le P L) (HasPoints.card_le P L)
 #align configuration.projective_plane.card_points_eq_card_lines Configuration.ProjectivePlane.card_points_eq_card_lines
 
--- Porting note: left out (L) to avoid redundant binder annotation
 variable {P}
 
 theorem lineCount_eq_lineCount [Finite P] [Finite L] (p q : P) : lineCount L p = lineCount L q := by
@@ -405,7 +402,6 @@ theorem pointCount_eq_pointCount [Finite P] [Finite L] (l m : L) :
   apply lineCount_eq_lineCount (Dual P)
 #align configuration.projective_plane.point_count_eq_point_count Configuration.ProjectivePlane.pointCount_eq_pointCount
 
--- Porting note: left out {L} to avoid redundant binder annotation
 variable {P}
 
 theorem lineCount_eq_pointCount [Finite P] [Finite L] (p : P) (l : L) :
@@ -423,7 +419,6 @@ theorem Dual.order [Finite P] [Finite L] : order (Dual L) (Dual P) = order P L :
   congr_arg (fun n => n - 1) (lineCount_eq_pointCount _ _)
 #align configuration.projective_plane.dual.order Configuration.ProjectivePlane.Dual.order
 
--- Porting note: left out (L) to avoid redundant binder annotation
 variable {P}
 
 theorem lineCount_eq [Finite P] [Finite L] (p : P) : lineCount L p = order P L + 1 := by
@@ -467,7 +462,6 @@ theorem two_lt_pointCount [Finite P] [Finite L] (l : L) : 2 < pointCount P l := 
   simpa only [pointCount_eq P l, Nat.succ_lt_succ_iff] using one_lt_order P L
 #align configuration.projective_plane.two_lt_point_count Configuration.ProjectivePlane.two_lt_pointCount
 
--- Porting note: left out (P) to avoid redundant binder annotation
 variable (L)
 
 theorem card_points [Fintype P] [Finite L] : Fintype.card P = order P L ^ 2 + order P L + 1 := by

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -1460,8 +1460,6 @@ theorem LinearIndependent.linearIndependent_extend (hs : LinearIndependent K (fu
   hli
 #align linear_independent.linear_independent_extend LinearIndependent.linearIndependent_extend
 
--- variable {K V} -- Porting note: Redundant binder annotation update.
-
 -- TODO(Mario): rewrite?
 theorem exists_of_linearIndependent_of_finite_span {t : Finset V}
     (hs : LinearIndependent K (fun x => x : s → V)) (hst : s ⊆ (span K ↑t : Submodule K V)) :

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -145,9 +145,6 @@ lemma right_ne_zero_of_mem_divisorsAntidiagonal {p : ℕ × ℕ} (hp : p ∈ n.d
     p.2 ≠ 0 :=
   (ne_zero_of_mem_divisorsAntidiagonal hp).2
 
--- Porting note: Redundant binder annotation update
--- variable {n}
-
 theorem divisor_le {m : ℕ} : n ∈ divisors m → n ≤ m := by
   cases' m with m
   · simp


### PR DESCRIPTION
All these are about some code (now commented out) which performs a (now) redundant binder information update. I don't see how this is useful information going forward, hence propose simply deleting them.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
