### PR TITLE
[Merged by Bors] - chore(Data/Set/Intervals/OrdConnectedComponent): resolve porting note about lift not being …

### DIFF
--- a/Mathlib/Data/Set/Intervals/OrdConnectedComponent.lean
+++ b/Mathlib/Data/Set/Intervals/OrdConnectedComponent.lean
@@ -219,11 +219,10 @@ theorem disjoint_ordT5Nhd : Disjoint (ordT5Nhd s t) (ordT5Nhd t s) := by
   rcases le_total b x with hbx | hxb
   · exact ha (Icc_subset_uIcc ⟨hab, hbx⟩) hbt
   have h' : x ∈ ordSeparatingSet s t := ⟨mem_iUnion₂.2 ⟨a, has, ha⟩, mem_iUnion₂.2 ⟨b, hbt, hb⟩⟩
-  -- Porting note: lift not implemented yet
-  -- lift x to ordSeparatingSet s t using this
+  lift x to ordSeparatingSet s t using h'
   suffices ordConnectedComponent (ordSeparatingSet s t) x ⊆ [[a, b]] from
-    hsub (this <| ordConnectedProj_mem_ordConnectedComponent _ ⟨x, h'⟩) (mem_range_self _)
-  rintro y (hy : [[x, y]] ⊆ ordSeparatingSet s t)
+    hsub (this <| ordConnectedProj_mem_ordConnectedComponent _ x) (mem_range_self _)
+  rintro y hy
   rw [uIcc_of_le hab, mem_Icc, ← not_lt, ← not_lt]
   have sol1 := fun (hya : y < a) =>
       (disjoint_left (t := ordSeparatingSet s t)).1 disjoint_left_ordSeparatingSet has


### PR DESCRIPTION
…implemented

By now, it has been implemented; use it.

---

Suggestions for further proof tweaks are welcome. 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
