### PR TITLE
[Merged by Bors] - chore: reduce proof dependencies for Nat.factors_count_eq

### DIFF
--- a/Mathlib/Algebra/BigOperators/List/Lemmas.lean
+++ b/Mathlib/Algebra/BigOperators/List/Lemmas.lean
@@ -66,6 +66,12 @@ theorem dvd_prod [CommMonoid M] {a} {l : List M} (ha : a ∈ l) : a ∣ l.prod :
   exact dvd_mul_right _ _
 #align list.dvd_prod List.dvd_prod
 
+theorem Sublist.prod_dvd_prod [CommMonoid M] {l₁ l₂ : List M} (h : l₁ <+ l₂) :
+    l₁.prod ∣ l₂.prod := by
+  obtain ⟨l, hl⟩ := h.exists_perm_append
+  rw [hl.prod_eq, prod_append]
+  exact dvd_mul_right _ _
+
 section MonoidWithZero
 variable [MonoidWithZero M₀]
 

--- a/Mathlib/Algebra/Category/GroupCat/Injective.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Injective.lean
@@ -5,6 +5,7 @@ Authors: Jujian Zhang
 -/
 import Mathlib.Algebra.Category.GroupCat.ZModuleEquivalence
 import Mathlib.Algebra.Module.Injective
+import Mathlib.RingTheory.PrincipalIdealDomain
 import Mathlib.Topology.Instances.AddCircle
 import Mathlib.Topology.Instances.Rat
 

--- a/Mathlib/Data/List/Lex.lean
+++ b/Mathlib/Data/List/Lex.lean
@@ -212,6 +212,12 @@ theorem lt_iff_lex_lt [LinearOrder α] (l l' : List α) : lt l l' ↔ Lex (· < 
     | @cons a as bs _ ih => apply lt.tail <;> simp [ih]
     | @rel a as b bs h => apply lt.head; assumption
 
+@[simp]
+theorem nil_le {α} [LinearOrder α] {l : List α} : [] ≤ l :=
+  match l with
+  | [] => le_rfl
+  | _ :: _ => le_of_lt <| nil_lt_cons _ _
+
 theorem head_le_of_lt [LinearOrder α] {a a' : α} {l l' : List α} (h : (a' :: l') < (a :: l)) :
     a' ≤ a := by
   by_contra hh

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -241,6 +241,19 @@ lemma subperm_iff : l₁ <+~ l₂ ↔ ∃ l, l ~ l₂ ∧ l₁ <+ l := by
   · rintro (rfl | rfl)
     exacts [nil_subperm, Subperm.refl _]
 
+attribute [simp] nil_subperm
+
+@[simp]
+theorem subperm_nil : List.Subperm l [] ↔ l = [] :=
+  match l with
+  | [] => by simp
+  | head :: tail => by
+    simp only [iff_false]
+    intro h
+    have := h.length_le
+    simp only [List.length_cons, List.length_nil, Nat.succ_ne_zero, ← Nat.not_lt, Nat.zero_lt_succ,
+      not_true_eq_false] at this
+
 #align list.perm.countp_eq List.Perm.countP_eq
 
 #align list.subperm.countp_le List.Subperm.countP_le
@@ -896,16 +909,3 @@ theorem nodup_permutations (s : List α) (hs : Nodup s) : Nodup s.permutations :
 end Permutations
 
 end List
-
-attribute [simp] List.nil_subperm
-
-@[simp]
-theorem _root_.List.subperm_nil {α : Type*} {l : List α} : List.Subperm l [] ↔ l = [] := by
-  cases l with
-  | [] => simp
-  | head :: tail =>
-    simp only [iff_false]
-    intro h
-    have := h.length_le
-    simp only [List.length_cons, List.length_nil, Nat.succ_ne_zero, ← Nat.not_lt, Nat.zero_lt_succ,
-      not_true_eq_false] at this

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -896,3 +896,16 @@ theorem nodup_permutations (s : List α) (hs : Nodup s) : Nodup s.permutations :
 end Permutations
 
 end List
+
+attribute [simp] List.nil_subperm
+
+@[simp]
+theorem _root_.List.subperm_nil {α : Type*} {l : List α} : List.Subperm l [] ↔ l = [] := by
+  cases l with
+  | [] => simp
+  | head :: tail =>
+    simp only [iff_false]
+    intro h
+    have := h.length_le
+    simp only [List.length_cons, List.length_nil, Nat.succ_ne_zero, ← Nat.not_lt, Nat.zero_lt_succ,
+      not_true_eq_false] at this

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -3,15 +3,10 @@ Copyright (c) 2021 Stuart Presnell. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stuart Presnell
 -/
-import Mathlib.Algebra.BigOperators.Finsupp
 import Mathlib.Data.Finsupp.Multiset
 import Mathlib.Data.Nat.PrimeFin
 import Mathlib.NumberTheory.Padics.PadicVal
 import Mathlib.Data.Nat.GCD.BigOperators
-import Mathlib.Data.Nat.Interval
-import Mathlib.Tactic.IntervalCases
-import Mathlib.Algebra.GroupPower.Order
-import Mathlib.RingTheory.Int.Basic
 
 #align_import data.nat.factorization.basic from "leanprover-community/mathlib"@"f694c7dead66f5d4c80f446c796a5aad14707f0e"
 
@@ -76,10 +71,15 @@ theorem factors_count_eq {n p : ℕ} : n.factors.count p = n.factorization p := 
   if pp : p.Prime then ?_ else
     rw [count_eq_zero_of_not_mem (mt prime_of_mem_factors pp)]
     simp [factorization, pp]
-  simp only [factorization, coe_mk, pp, if_true]
-  rw [← PartENat.natCast_inj, padicValNat_def' pp.ne_one hn0,
-    UniqueFactorizationMonoid.multiplicity_eq_count_normalizedFactors pp hn0.ne']
-  simp [factors_eq]
+  simp only [factorization_def _ pp]
+  apply _root_.le_antisymm
+  · rw [le_padicValNat_iff_replicate_subperm_factors pp hn0.ne']
+    exact List.le_count_iff_replicate_sublist.mp le_rfl |>.subperm
+  · rw [← lt_add_one_iff, lt_iff_not_ge, ge_iff_le,
+      le_padicValNat_iff_replicate_subperm_factors pp hn0.ne']
+    intro h
+    have := h.count_le p
+    simp at this
 #align nat.factors_count_eq Nat.factors_count_eq
 
 theorem factorization_eq_factors_multiset (n : ℕ) :

--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -253,6 +253,22 @@ theorem dvd_of_factors_subperm {a b : ℕ} (ha : a ≠ 0) (h : a.factors <+~ b.f
     Nat.prod_factors hb.ne']
 #align nat.dvd_of_factors_subperm Nat.dvd_of_factors_subperm
 
+theorem replicate_subperm_factors_iff {a b n : ℕ} (ha : Prime a) (hb : b ≠ 0) :
+    replicate n a <+~ factors b ↔ a ^ n ∣ b := by
+  induction n generalizing b with
+  | zero => simp
+  | succ n ih =>
+    constructor
+    · rw [List.subperm_iff]
+      rintro ⟨u, hu1, hu2⟩
+      rw [← Nat.prod_factors hb, ← hu1.prod_eq, ← prod_replicate]
+      exact hu2.prod_dvd_prod
+    · rintro ⟨c, rfl⟩
+      rw [Ne.def, pow_succ', mul_assoc, mul_eq_zero, _root_.not_or] at hb
+      rw [pow_succ', mul_assoc, replicate_succ, (Nat.perm_factors_mul hb.1 hb.2).subperm_left,
+        factors_prime ha, singleton_append, subperm_cons, ih hb.2]
+      exact dvd_mul_right _ _
+
 end
 
 theorem mem_factors_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) {p : ℕ} :

--- a/Mathlib/NumberTheory/Padics/PadicVal.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal.lean
@@ -302,6 +302,19 @@ theorem dvd_iff_padicValNat_ne_zero {p n : ℕ} [Fact p.Prime] (hn0 : n ≠ 0) :
     Classical.not_not.1 (mt padicValNat.eq_zero_of_not_dvd h)⟩
 #align dvd_iff_padic_val_nat_ne_zero dvd_iff_padicValNat_ne_zero
 
+open List
+
+theorem le_multiplicity_iff_replicate_subperm_factors {a b : ℕ} {n : ℕ} (ha : a.Prime)
+    (hb : b ≠ 0) :
+    ↑n ≤ multiplicity a b ↔ replicate n a <+~ b.factors :=
+  (replicate_subperm_factors_iff ha hb).trans multiplicity.pow_dvd_iff_le_multiplicity |>.symm
+
+theorem le_padicValNat_iff_replicate_subperm_factors {a b : ℕ} {n : ℕ} (ha : a.Prime)
+    (hb : b ≠ 0) :
+    n ≤ padicValNat a b ↔ replicate n a <+~ b.factors := by
+  rw [← le_multiplicity_iff_replicate_subperm_factors ha hb,
+    ← padicValNat_def' ha.ne_one (Nat.pos_of_ne_zero hb), Nat.cast_le]
+
 end padicValNat
 
 namespace padicValRat


### PR DESCRIPTION
This is a bit longer, partially duplicating the argument from UniqueFactorizationMonoid.multiplicity_eq_count_normalizedFactors, but it means we no longer need to depend on `RingTheory.Int.Basic` at this point.

The other added lemmas seem useful regardless.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
