### PR TITLE
[Merged by Bors] - feat(Algebra/Lie): define adjoint action and its ideal image

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -314,6 +314,7 @@ import Mathlib.Algebra.Lie.CartanMatrix
 import Mathlib.Algebra.Lie.CartanSubalgebra
 import Mathlib.Algebra.Lie.Character
 import Mathlib.Algebra.Lie.Classical
+import Mathlib.Algebra.Lie.Derivation.AdjointAction
 import Mathlib.Algebra.Lie.Derivation.Basic
 import Mathlib.Algebra.Lie.DirectSum
 import Mathlib.Algebra.Lie.Engel

--- a/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
+++ b/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
@@ -69,21 +69,15 @@ lemma lie_der_ad_eq_ad_der (D : LieDerivation R L L) (x : L) : ⁅D, ad R L x⁆
 variable (R L) in
 /-- The range of the adjoint action homomorphism from a Lie algebra `L` to the Lie algebra of its
 derivations is an ideal of the latter. -/
-lemma ad_isIdealMorphism : LieHom.IsIdealMorphism (ad R L) := by
+lemma ad_isIdealMorphism : (ad R L).IsIdealMorphism := by
   simp_rw [LieHom.isIdealMorphism_iff, lie_der_ad_eq_ad_der]
-  tauto
-
-/-- For every `x` in the Lie algebra `L`, `ad x` is in the ideal range of the adjoint action. -/
-lemma ad_mem_rangeAd (x : L) : ad R L x ∈ (ad R L).idealRange := by
-  rw [LieHom.mem_idealRange_iff (ad R L) (ad_isIdealMorphism R L)]
   tauto
 
 /-- A derivation `D` belongs to the ideal range of the adjoint action iff it is of the form `ad x`
 for some `x` in the Lie algebra `L`. -/
 lemma mem_rangeAd_iff {D : LieDerivation R L L} :
-    D ∈ (ad R L).idealRange ↔ ∃ x : L, D = ad R L x := by
-  rw [LieHom.mem_idealRange_iff (ad R L) (ad_isIdealMorphism R L)]
-  tauto
+    D ∈ (ad R L).idealRange ↔ ∃ x : L, ad R L x = D :=
+  (ad R L).mem_idealRange_iff (ad_isIdealMorphism R L)
 
 end AdjointAction
 

--- a/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
+++ b/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
@@ -75,7 +75,7 @@ lemma ad_isIdealMorphism : (ad R L).IsIdealMorphism := by
 
 /-- A derivation `D` belongs to the ideal range of the adjoint action iff it is of the form `ad x`
 for some `x` in the Lie algebra `L`. -/
-lemma mem_rangeAd_iff {D : LieDerivation R L L} :
+lemma mem_ad_idealRange_iff {D : LieDerivation R L L} :
     D ∈ (ad R L).idealRange ↔ ∃ x : L, ad R L x = D :=
   (ad R L).mem_idealRange_iff (ad_isIdealMorphism R L)
 

--- a/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
+++ b/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
@@ -53,6 +53,7 @@ variable {R L}
 /-- The definitions `LieDerivation.ad` and `LieAlgebra.ad` agree. -/
 @[simp] lemma coe_ad_apply_eq_ad_apply (x : L) : ad R L x = LieAlgebra.ad R L x := by ext; simp
 
+variable (R L) in
 /-- The kernel of the adjoint action on a Lie algebra is equal to its center. -/
 lemma ad_ker_eq_center : (ad R L).ker = LieAlgebra.center R L := by
   ext x

--- a/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
+++ b/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
@@ -81,8 +81,8 @@ lemma ad_zero : ad R L 0 = 0 := LieHom.map_zero (ad R L)
 lemma ad_apply (x y : L) : ad R L x y = ⁅x, y⁆ := by
   rw [ad, LieHom.coe_mk, inner_apply, lie_neg, lie_skew]
 
-lemma ad_lie (x y z : L) : (ad R L x) ⁅y, z⁆ = ⁅y, ad R L x z⁆ + ⁅ad R L x y, z⁆ := by
-  rw [apply_lie_eq_add (ad R L x)]
+lemma ad_lie (x y z : L) : ad R L x ⁅y, z⁆ = ⁅y, ad R L x z⁆ + ⁅ad R L x y, z⁆ := by
+  rw [apply_lie_eq_add]
 
 /-- For every `x` in the Lie algebra `L`, the derivation `ad(x)` defined in this file, is equal,
 when seen as an endomorphism of `L`, to the one defined in `LieAlgebra.ad`. -/

--- a/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
+++ b/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
@@ -21,10 +21,11 @@ values in the endormophisms of `L`.
 
 ## Main statements
 
-- `LieDerivation.ad_eq_ad`: when seen as endomorphisms, both definitions coincide,
+- `LieDerivation.coe_ad_apply_eq_ad_apply`: when seen as endomorphisms, both definitions coincide,
 - `LieDerivation.ad_ker_eq_center`: the kernel of the adjoint action is the center of `L`,
-- `LieDerivation.lie_der_ad_eq_ad_der`: the commutator of a derivation `D` and `ad(x)` is `ad(D x)`,
-- `LieDerivation.imageAd`: the image of the adjoint action is an ideal of the derivations.
+- `LieDerivation.lie_der_ad_eq_ad_der`: the commutator of a derivation `D` and `ad x` is `ad (D x)`,
+- `LieDerivation.ad_isIdealMorphism`: the range of the adjoint action is an ideal of the
+derivations.
 -/
 
 namespace LieDerivation
@@ -35,7 +36,8 @@ variable (R L : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]
 
 /-- The adjoint action of a Lie algebra `L` on itself, seen as a morphism of Lie algebras from
 `L` to its derivations.
-Note the minus sign: this is chosen to so that `ad(⁅x, y⁆) = ⁅ad(x), ad(y)⁆)`. -/
+Note the minus sign: this is chosen to so that `ad ⁅x, y⁆ = ⁅ad x, ad y⁆`. -/
+@[simps!]
 def ad : L →ₗ⁅R⁆ LieDerivation R L L :=
   { __ := - inner R L L
     map_lie' := by
@@ -48,64 +50,39 @@ def ad : L →ₗ⁅R⁆ LieDerivation R L L :=
 
 variable {R L}
 
-lemma ad_zero : ad R L 0 = 0 := LieHom.map_zero (ad R L)
-
-@[simp]
-lemma ad_apply (x y : L) : ad R L x y = ⁅x, y⁆ := by
-  rw [ad, LieHom.coe_mk, AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, LinearMap.neg_apply, coe_neg,
-    Pi.neg_apply, inner_apply_apply, lie_skew]
-
-lemma ad_lie (x y z : L) : ad R L x ⁅y, z⁆ = ⁅y, ad R L x z⁆ + ⁅ad R L x y, z⁆ := by
-  rw [apply_lie_eq_add]
-
-/-- For every `x` in the Lie algebra `L`, the derivation `ad(x)` defined in this file, is equal,
-when seen as an endomorphism of `L`, to the one defined in `LieAlgebra.ad`. -/
-@[simp]
-lemma ad_eq_ad (x : L) : ad R L x = LieAlgebra.ad R L x := by
-  ext y
-  rw [coeFn_coe, ad_apply, LieAlgebra.ad_apply]
-
-/-- The kernel of the adjoint action on a Lie algebra is equal to the kernel of its action on
-itself. -/
-lemma ad_ker_eq_self_module_ker : (ad R L).ker = LieModule.ker R L L := by
-  ext x
-  rw [LieHom.mem_ker, LieModule.mem_ker, DFunLike.ext_iff]
-  simp_rw [ad_apply, zero_apply]
+/-- The definitions `LieDerivation.ad` and `LieAlgebra.ad` agree. -/
+@[simp] lemma coe_ad_apply_eq_ad_apply (x : L) : ad R L x = LieAlgebra.ad R L x := by ext; simp
 
 /-- The kernel of the adjoint action on a Lie algebra is equal to its center. -/
 lemma ad_ker_eq_center : (ad R L).ker = LieAlgebra.center R L := by
   ext x
-  rw [ad_ker_eq_self_module_ker, LieAlgebra.self_module_ker_eq_center]
+  rw [← LieAlgebra.self_module_ker_eq_center, LieHom.mem_ker, LieModule.mem_ker]
+  simp [DFunLike.ext_iff]
 
-/-- The commutator of a derivation `D` and a derivation of the form `ad(x)` is `ad(D x)`. -/
+/-- The commutator of a derivation `D` and a derivation of the form `ad x` is `ad (D x)`. -/
 lemma lie_der_ad_eq_ad_der (D : LieDerivation R L L) (x : L) : ⁅D, ad R L x⁆ = ad R L (D x) := by
   ext a
-  rw [commutator_apply, ad_apply, ad_apply, ad_apply, apply_lie_eq_add, add_sub_cancel_left]
+  rw [commutator_apply, ad_apply_apply, ad_apply_apply, ad_apply_apply, apply_lie_eq_add,
+    add_sub_cancel_left]
 
 variable (R L) in
-/-- The image of the adjoint action homomorphism from a Lie algebra `L` to the Lie algebra of its
+/-- The range of the adjoint action homomorphism from a Lie algebra `L` to the Lie algebra of its
 derivations is an ideal of the latter. -/
-def imageAd : LieIdeal R (LieDerivation R L L) where
-  __ := Submodule.map (ad R L).toLinearMap (⊤ : Submodule R L)
-  carrier := Submodule.map (ad R L).toLinearMap (⊤ : Submodule R L)
-  add_mem' := add_mem
-  zero_mem' := zero_mem _
-  smul_mem' := SMulMemClass.smul_mem
-  lie_mem := by
-    intro D Dx hDx
-    obtain ⟨x, hx⟩ := Set.mem_range_of_mem_image (ad R L) Set.univ hDx
-    rw [← hx, lie_der_ad_eq_ad_der D x]
-    exact Set.mem_image_of_mem (ad R L) trivial
+lemma ad_isIdealMorphism : LieHom.IsIdealMorphism (ad R L) := by
+  simp_rw [LieHom.isIdealMorphism_iff, lie_der_ad_eq_ad_der]
+  tauto
 
-/-- For every `x` in the Lie algebra `L`, `ad(x)` is in the image of the adjoint action. -/
-lemma ad_mem_imageAd (x : L) : ad R L x ∈ imageAd R L := Exists.intro x ⟨trivial, rfl⟩
+/-- For every `x` in the Lie algebra `L`, `ad x` is in the ideal range of the adjoint action. -/
+lemma ad_mem_rangeAd (x : L) : ad R L x ∈ (ad R L).idealRange := by
+  rw [LieHom.mem_idealRange_iff (ad R L) (ad_isIdealMorphism R L)]
+  tauto
 
-/-- A derivation `D` belongs to the image of the adjoint action iff it is of the form `ad(x)` for
-some `x` in the Lie algebra `L`. -/
-lemma mem_imageAd_iff {D : LieDerivation R L L} : D ∈ imageAd R L ↔ ∃ x : L, D = ad R L x := by
-  constructor
-  · intro ⟨y, _⟩; use y; tauto
-  · intro ⟨x, hx⟩; rw [hx]; exact ad_mem_imageAd x
+/-- A derivation `D` belongs to the ideal range of the adjoint action iff it is of the form `ad x`
+for some `x` in the Lie algebra `L`. -/
+lemma mem_rangeAd_iff {D : LieDerivation R L L} :
+    D ∈ (ad R L).idealRange ↔ ∃ x : L, D = ad R L x := by
+  rw [LieHom.mem_idealRange_iff (ad R L) (ad_isIdealMorphism R L)]
+  tauto
 
 end AdjointAction
 

--- a/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
+++ b/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
@@ -1,0 +1,139 @@
+/-
+Copyright © 2024 Frédéric Marbach. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frédéric Marbach
+-/
+import Mathlib.Algebra.Lie.Abelian
+import Mathlib.Algebra.Lie.Derivation.Basic
+import Mathlib.Algebra.Lie.OfAssociative
+
+/-!
+# Adjoint action of a Lie algebra on itself
+
+This file defines the *adjoint action* of a Lie algebra on itself, and establishes basic properties.
+
+## Main definitions
+
+- `LieDerivation.ad` : The adjoint action of a Lie algebra `L` on itself, seen as an homomorphism
+of Lie algebras from `L` to the Lie algebra of its derivations. The adjoint action is also defined
+in the `Mathlib.Algebra.Lie.OfAssociative.lean` file, under the name `LieAlgebra.ad`, as the
+homomorphism with values in the endormophisms of `L`.
+
+## Main statements
+
+- `LieDerivation.ad_eq_ad`: when seen as endomorphisms, both definitions coincide,
+- `LieDerivation.ad_ker_eq_center`: the kernel of the adjoint action is the center of `L`,
+- `LieDerivation.lie_der_ad_eq_ad_der`: the commutator of a derivation `D` and `ad(x)` is `ad(D x)`,
+- `LieDerivation.imageAd`: the image of the adjoint action is an ideal of the derivations.
+-/
+
+namespace LieDerivation
+
+section Inner
+
+variable (R L M : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]
+    [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
+
+/-- The inner derivation from the Lie algebra `L` to the Lie module `M`, associated with the right
+action of an element `m : M`. -/
+def inner (m : M) : LieDerivation R L M where
+  __ := (LieModule.toEndomorphism R L M : L →ₗ[R] Module.End R M).flip m
+  leibniz' := by
+    simp only [LinearMap.flip_apply, LieHom.coe_toLinearMap, LieHom.map_lie, LieHom.lie_apply,
+      LieModule.toEndomorphism_apply_apply, Module.End.lie_apply, forall_const]
+
+variable {R L M}
+
+lemma inner_apply (m : M) (a : L) : inner R L M m a = ⁅a, m⁆ := by
+  simp only [inner, LieDerivation.mk_coe, LinearMap.flip_apply, LieHom.coe_toLinearMap,
+    LieModule.toEndomorphism_apply_apply]
+
+end Inner
+
+section AdjointAction
+
+variable (R L : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]
+
+/-- The adjoint action of a Lie algebra `L` on itself, seen as an homomorphism of Lie algebras from
+`L` to the Lie algebra of its derivations. This corresponds to the left action of `L` on itself, ie.
+such that, for `x y : L`, `ad(x) y = ⁅x, y⁆`. See also `LieAlgebra.ad` for the homomorphism with
+values in the endormophisms of `L`. -/
+def ad : L →ₗ⁅R⁆ LieDerivation R L L where
+  toFun := fun m ↦ inner R L L (- m)
+  map_add' := by
+    intro x y; ext a;
+    simp only [neg_add_rev, add_apply, inner_apply, lie_add]
+    abel
+  map_smul' := by
+    intro r x; ext a;
+    simp only [smul_apply, inner_apply, RingHom.id_apply, smul_neg, lie_smul, lie_neg]
+  map_lie' := by
+    intro x y; ext a;
+    simp only [commutator_apply, inner_apply, lie_neg]
+    rw [leibniz_lie, neg_lie, neg_lie, ← lie_skew x]
+    abel
+
+variable {R L}
+
+@[simp]
+lemma ad_zero : ad R L 0 = 0 := LieHom.map_zero (ad R L)
+
+@[simp]
+lemma ad_apply (x y : L) : ad R L x y = ⁅x, y⁆ := by
+  rw [ad, LieHom.coe_mk, inner_apply, lie_neg, lie_skew]
+
+lemma ad_lie (x y z : L) : (ad R L x) ⁅y, z⁆ = ⁅y, ad R L x z⁆ + ⁅ad R L x y, z⁆ := by
+  rw [apply_lie_eq_add (ad R L x)]
+
+/-- For every `x` in the Lie algebra `L`, the derivation `ad(x)` defined in this file, is equal,
+when seen as an endomorphism of `L`, to the one defined in `LieAlgebra.ad`. -/
+@[simp]
+lemma ad_eq_ad (x : L) : ad R L x = LieAlgebra.ad R L x := by
+  ext y
+  rw [coeFn_coe, ad_apply, LieAlgebra.ad_apply]
+
+/-- The kernel of the adjoint action on a Lie algebra is equal to the kernel of its action on
+itself. -/
+lemma ad_ker_eq_self_module_ker : (ad R L).ker = LieModule.ker R L L := by
+  ext x
+  rw [LieHom.mem_ker, LieModule.mem_ker, DFunLike.ext_iff]
+  simp_rw [ad_apply, zero_apply]
+
+/-- The kernel of the adjoint action on a Lie algebra is equal to its center. -/
+lemma ad_ker_eq_center : (ad R L).ker = LieAlgebra.center R L := by
+  ext x
+  rw [ad_ker_eq_self_module_ker, LieAlgebra.self_module_ker_eq_center]
+
+/-- The commutator of a derivation `D` and a derivation of the form `ad(x)` is `ad(D x)`. -/
+lemma lie_der_ad_eq_ad_der (D : LieDerivation R L L) (x : L) : ⁅D, ad R L x⁆ = ad R L (D x) := by
+  ext a
+  rw [commutator_apply, ad_apply, ad_apply, ad_apply, apply_lie_eq_add, add_sub_cancel_left]
+
+variable (R L) in
+/-- The image of the adjoint action homomorphism from a Lie algebra `L` to the Lie algebra of its
+derivations is an ideal of the latter. -/
+def imageAd : LieIdeal R (LieDerivation R L L) where
+  __ := Submodule.map (ad R L).toLinearMap (⊤ : Submodule R L)
+  carrier := Submodule.map (ad R L).toLinearMap (⊤ : Submodule R L)
+  add_mem' := add_mem
+  zero_mem' := zero_mem _
+  smul_mem' := SMulMemClass.smul_mem
+  lie_mem := by
+    intro D Dx hDx
+    obtain ⟨x, hx⟩ := Set.mem_range_of_mem_image (ad R L) Set.univ hDx
+    rw [← hx, lie_der_ad_eq_ad_der D x]
+    exact Set.mem_image_of_mem (ad R L) trivial
+
+/-- For every `x` in the Lie algebra `L`, `ad(x)` is in the image of the adjoint action. -/
+lemma ad_mem_imageAd (x : L) : ad R L x ∈ imageAd R L := Exists.intro x ⟨trivial, rfl⟩
+
+/-- A derivation `D` belongs to the image of the adjoint action iff it is of the form `ad(x)` for
+some `x` in the Lie algebra `L`. -/
+lemma mem_imageAd_iff {D : LieDerivation R L L} : D ∈ imageAd R L ↔ ∃ x : L, D = ad R L x := by
+  constructor
+  · intro ⟨y, _⟩; use y; tauto
+  · intro ⟨x, hx⟩; rw [hx]; exact ad_mem_imageAd x
+
+end AdjointAction
+
+end LieDerivation

--- a/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
+++ b/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
@@ -75,7 +75,6 @@ def ad : L →ₗ⁅R⁆ LieDerivation R L L where
 
 variable {R L}
 
-@[simp]
 lemma ad_zero : ad R L 0 = 0 := LieHom.map_zero (ad R L)
 
 @[simp]

--- a/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
+++ b/Mathlib/Algebra/Lie/Derivation/AdjointAction.lean
@@ -14,10 +14,10 @@ This file defines the *adjoint action* of a Lie algebra on itself, and establish
 
 ## Main definitions
 
-- `LieDerivation.ad` : The adjoint action of a Lie algebra `L` on itself, seen as an homomorphism
-of Lie algebras from `L` to the Lie algebra of its derivations. The adjoint action is also defined
-in the `Mathlib.Algebra.Lie.OfAssociative.lean` file, under the name `LieAlgebra.ad`, as the
-homomorphism with values in the endormophisms of `L`.
+- `LieDerivation.ad`: The adjoint action of a Lie algebra `L` on itself, seen as a morphism of Lie
+algebras from `L` to the Lie algebra of its derivations. The adjoint action is also defined in the
+`Mathlib.Algebra.Lie.OfAssociative.lean` file, under the name `LieAlgebra.ad`, as the morphism with
+values in the endormophisms of `L`.
 
 ## Main statements
 
@@ -29,49 +29,22 @@ homomorphism with values in the endormophisms of `L`.
 
 namespace LieDerivation
 
-section Inner
-
-variable (R L M : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]
-    [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
-
-/-- The inner derivation from the Lie algebra `L` to the Lie module `M`, associated with the right
-action of an element `m : M`. -/
-def inner (m : M) : LieDerivation R L M where
-  __ := (LieModule.toEndomorphism R L M : L →ₗ[R] Module.End R M).flip m
-  leibniz' := by
-    simp only [LinearMap.flip_apply, LieHom.coe_toLinearMap, LieHom.map_lie, LieHom.lie_apply,
-      LieModule.toEndomorphism_apply_apply, Module.End.lie_apply, forall_const]
-
-variable {R L M}
-
-lemma inner_apply (m : M) (a : L) : inner R L M m a = ⁅a, m⁆ := by
-  simp only [inner, LieDerivation.mk_coe, LinearMap.flip_apply, LieHom.coe_toLinearMap,
-    LieModule.toEndomorphism_apply_apply]
-
-end Inner
-
 section AdjointAction
 
 variable (R L : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]
 
-/-- The adjoint action of a Lie algebra `L` on itself, seen as an homomorphism of Lie algebras from
-`L` to the Lie algebra of its derivations. This corresponds to the left action of `L` on itself, ie.
-such that, for `x y : L`, `ad(x) y = ⁅x, y⁆`. See also `LieAlgebra.ad` for the homomorphism with
-values in the endormophisms of `L`. -/
-def ad : L →ₗ⁅R⁆ LieDerivation R L L where
-  toFun := fun m ↦ inner R L L (- m)
-  map_add' := by
-    intro x y; ext a;
-    simp only [neg_add_rev, add_apply, inner_apply, lie_add]
-    abel
-  map_smul' := by
-    intro r x; ext a;
-    simp only [smul_apply, inner_apply, RingHom.id_apply, smul_neg, lie_smul, lie_neg]
-  map_lie' := by
-    intro x y; ext a;
-    simp only [commutator_apply, inner_apply, lie_neg]
-    rw [leibniz_lie, neg_lie, neg_lie, ← lie_skew x]
-    abel
+/-- The adjoint action of a Lie algebra `L` on itself, seen as a morphism of Lie algebras from
+`L` to its derivations.
+Note the minus sign: this is chosen to so that `ad(⁅x, y⁆) = ⁅ad(x), ad(y)⁆)`. -/
+def ad : L →ₗ⁅R⁆ LieDerivation R L L :=
+  { __ := - inner R L L
+    map_lie' := by
+      intro x y
+      ext z
+      simp only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, LinearMap.neg_apply, coe_neg,
+        Pi.neg_apply, inner_apply_apply, commutator_apply]
+      rw [leibniz_lie, neg_lie, neg_lie, ← lie_skew x]
+      abel }
 
 variable {R L}
 
@@ -79,7 +52,8 @@ lemma ad_zero : ad R L 0 = 0 := LieHom.map_zero (ad R L)
 
 @[simp]
 lemma ad_apply (x y : L) : ad R L x y = ⁅x, y⁆ := by
-  rw [ad, LieHom.coe_mk, inner_apply, lie_neg, lie_skew]
+  rw [ad, LieHom.coe_mk, AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, LinearMap.neg_apply, coe_neg,
+    Pi.neg_apply, inner_apply_apply, lie_skew]
 
 lemma ad_lie (x y z : L) : ad R L x ⁅y, z⁆ = ⁅y, ad R L x z⁆ + ⁅ad R L x y, z⁆ := by
   rw [apply_lie_eq_add]

--- a/Mathlib/Algebra/Lie/Derivation/Basic.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Basic.lean
@@ -14,8 +14,9 @@ This file defines *Lie derivations* and establishes some basic properties.
 
 ## Main definitions
 
-- `LieDerivation` : A Lie derivation `D` from the Lie `R`-algebra `L` to the `L`-module `M` is an
+- `LieDerivation`: A Lie derivation `D` from the Lie `R`-algebra `L` to the `L`-module `M` is an
 `R`-linear map that satisfies the Leibniz rule `D [a, b] = [a, D b] - [b, D a]`.
+- `LieDerivation.inner`: The natural map from a Lie module to the derivations taking values in it.
 
 ## Main statements
 
@@ -224,6 +225,8 @@ theorem coe_smul_linearMap (r : S) (D : LieDerivation R L M) : ↑(r • D) = r 
 theorem smul_apply (r : S) (D : LieDerivation R L M) : (r • D) a = r • D a :=
   rfl
 
+instance instSMulBase : SMulBracketCommClass R L M := ⟨fun s l a ↦ (lie_smul s l a).symm⟩
+
 instance instSMulNat : SMulBracketCommClass ℕ L M := ⟨fun s l a => (lie_nsmul l a s).symm⟩
 
 instance instSMulInt : SMulBracketCommClass ℤ L M := ⟨fun s l a => (lie_zsmul l a s).symm⟩
@@ -284,8 +287,6 @@ instance : LieRing (LieDerivation R L L) where
   leibniz_lie d e f := by
     ext a; simp only [commutator_apply, add_apply, sub_apply, map_sub]; abel
 
-instance : SMulBracketCommClass R L L := ⟨fun s x y => (lie_smul s x y).symm⟩
-
 /-- The set of Lie derivations from a Lie algebra `L` to itself is a Lie algebra. -/
 instance instLieAlgebra : LieAlgebra R (LieDerivation R L L) where
   lie_smul := fun r d e => by ext a; simp only [commutator_apply, map_smul, smul_sub, smul_apply]
@@ -312,5 +313,21 @@ instance instNoetherian [IsNoetherian R L] : IsNoetherian R (LieDerivation R L L
   isNoetherian_of_linearEquiv (LinearEquiv.ofInjective _ (toLinearMapLieHom_injective R L)).symm
 
 end
+
+section Inner
+
+variable (R L M : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]
+    [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
+
+/-- The natural map from a Lie module to the derivations taking values in it. -/
+@[simps!]
+def inner : M →ₗ[R] LieDerivation R L M where
+  toFun m :=
+    { __ := (LieModule.toEndomorphism R L M : L →ₗ[R] Module.End R M).flip m
+      leibniz' := by simp }
+  map_add' m n := by ext; simp
+  map_smul' t m := by ext; simp
+
+end Inner
 
 end LieDerivation

--- a/Mathlib/Algebra/Lie/IdealOperations.lean
+++ b/Mathlib/Algebra/Lie/IdealOperations.lean
@@ -310,9 +310,9 @@ theorem comap_bracket_eq {J₁ J₂ : LieIdeal R L'} (h : f.IsIdealMorphism) :
     simp only [hz₁, hz₂, Submodule.coe_mk, LieHom.map_lie]
   · rintro ⟨x, ⟨⟨z₁, hz₁⟩, ⟨z₂, hz₂⟩, hx⟩, hy⟩; rw [← hy, ← hx]
     have hz₁' : f z₁ ∈ f.idealRange ⊓ J₁ := by
-      rw [LieSubmodule.mem_inf]; exact ⟨f.mem_idealRange, hz₁⟩
+      rw [LieSubmodule.mem_inf]; exact ⟨f.mem_idealRange z₁, hz₁⟩
     have hz₂' : f z₂ ∈ f.idealRange ⊓ J₂ := by
-      rw [LieSubmodule.mem_inf]; exact ⟨f.mem_idealRange, hz₂⟩
+      rw [LieSubmodule.mem_inf]; exact ⟨f.mem_idealRange z₂, hz₂⟩
     use ⟨f z₁, hz₁'⟩, ⟨f z₂, hz₂'⟩; simp only [Submodule.coe_mk, LieHom.map_lie]
 #align lie_ideal.comap_bracket_eq LieIdeal.comap_bracket_eq
 

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -1104,7 +1104,7 @@ theorem idealRange_eq_map : f.idealRange = LieIdeal.map f ⊤ := by
   rfl
 #align lie_hom.ideal_range_eq_map LieHom.idealRange_eq_map
 
-/-- The condition that the image of a morphism of Lie algebras is an ideal. -/
+/-- The condition that the range of a morphism of Lie algebras is an ideal. -/
 def IsIdealMorphism : Prop :=
   (f.idealRange : LieSubalgebra R L') = f.range
 #align lie_hom.is_ideal_morphism LieHom.IsIdealMorphism

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -1149,7 +1149,7 @@ theorem mem_ker {x : L} : x ∈ ker f ↔ f x = 0 :=
     simp only [ker_coeSubmodule, LinearMap.mem_ker, coe_toLinearMap]
 #align lie_hom.mem_ker LieHom.mem_ker
 
-theorem mem_idealRange {x : L} : f x ∈ idealRange f := by
+theorem mem_idealRange (x : L) : f x ∈ idealRange f := by
   rw [idealRange_eq_map]
   exact LieIdeal.mem_map (LieSubmodule.mem_top x)
 #align lie_hom.mem_ideal_range LieHom.mem_idealRange


### PR DESCRIPTION
This defines the *adjoint action* of a Lie algebra `L` on itself, when seen as an homomorphism of Lie algebras from `L` to the Lie algebra of its derivations. 

The adjoint action was also defined in the `Mathlib.Algebra.Lie.OfAssociative.lean` file, under the name `LieAlgebra.ad`, as the homomorphism with values in the endormophisms of `L`. We make the link between both. This design choice was discussed in [this thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Derivations.20on.20Lie.20algebras).

We also establish elementary properties, such as the fact that the image of the adjoint action is an ideal of the derivations.

This is the penultimate step towards proving that all derivations of a finite-dimensional semisimple Lie algebra are inner, a goal described in [this thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Derivations.20on.20Lie.20algebras).

