### PR TITLE
[Merged by Bors] - feat: exhibit lower adjoint for smallSets, use it to prove a better comap_smallSets

### DIFF
--- a/Mathlib/Analysis/LocallyConvex/Bounded.lean
+++ b/Mathlib/Analysis/LocallyConvex/Bounded.lean
@@ -160,9 +160,9 @@ alias ⟨IsVonNBounded.tendsto_smallSets_nhds, _⟩ := isVonNBounded_iff_tendsto
 lemma isVonNBounded_pi_iff {𝕜 ι : Type*} {E : ι → Type*} [NormedDivisionRing 𝕜]
     [∀ i, AddCommGroup (E i)] [∀ i, Module 𝕜 (E i)] [∀ i, TopologicalSpace (E i)]
     {S : Set (∀ i, E i)} : IsVonNBounded 𝕜 S ↔ ∀ i, IsVonNBounded 𝕜 (eval i '' S) := by
-  simp only [isVonNBounded_iff_tendsto_smallSets_nhds, nhds_pi, Filter.pi, smallSets_iInf,
-    smallSets_comap, tendsto_iInf, tendsto_lift', comp_apply, mem_powerset_iff, ← image_subset_iff,
-    ← image_smul, image_image, tendsto_smallSets_iff]; rfl
+  simp_rw [isVonNBounded_iff_tendsto_smallSets_nhds, nhds_pi, Filter.pi, smallSets_iInf,
+    smallSets_comap_eq_comap_image, tendsto_iInf, tendsto_comap_iff, Function.comp,
+    ← image_smul, image_image]; rfl
 
 section Image
 

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -2165,6 +2165,16 @@ theorem pure_bind (a : α) (m : α → Filter β) : bind (pure a) m = m a := by
   simp only [Bind.bind, bind, map_pure, join_pure]
 #align filter.pure_bind Filter.pure_bind
 
+@[simp]
+theorem map_bind {α β} (m : β → γ) (f : Filter α) (g : α → Filter β) :
+    map m (bind f g) = bind f (map m ∘ g) :=
+  rfl
+
+@[simp]
+theorem bind_map {α β} (m : α → β) (f : Filter α) (g : β → Filter γ) :
+    (bind (map m f) g) = bind f (g ∘ m) :=
+  rfl
+
 /-!
 ### `Filter` as a `Monad`
 

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -2165,12 +2165,10 @@ theorem pure_bind (a : α) (m : α → Filter β) : bind (pure a) m = m a := by
   simp only [Bind.bind, bind, map_pure, join_pure]
 #align filter.pure_bind Filter.pure_bind
 
-@[simp]
 theorem map_bind {α β} (m : β → γ) (f : Filter α) (g : α → Filter β) :
     map m (bind f g) = bind f (map m ∘ g) :=
   rfl
 
-@[simp]
 theorem bind_map {α β} (m : α → β) (f : Filter α) (g : β → Filter γ) :
     (bind (map m f) g) = bind f (g ∘ m) :=
   rfl

--- a/Mathlib/Order/Filter/SmallSets.lean
+++ b/Mathlib/Order/Filter/SmallSets.lean
@@ -42,6 +42,14 @@ theorem smallSets_eq_generate {f : Filter α} : f.smallSets = generate (powerset
   rfl
 #align filter.small_sets_eq_generate Filter.smallSets_eq_generate
 
+-- TODO: get more properties from the adjunction?
+-- TODO: is there a general way to get a lower adjoint for the lift of an upper adjoint?
+theorem bind_smallSets_gc :
+    GaloisConnection (fun L : Filter (Set α) ↦ L.bind principal) smallSets := by
+  intro L l
+  simp_rw [smallSets_eq_generate, le_generate_iff, image_subset_iff]
+  rfl
+
 protected theorem HasBasis.smallSets {p : ι → Prop} {s : ι → Set α} (h : HasBasis l p s) :
     HasBasis l.smallSets p fun i => 𝒫 s i :=
   h.lift' monotone_powerset
@@ -113,6 +121,11 @@ theorem smallSets_top : (⊤ : Filter α).smallSets = ⊤ := by
 theorem smallSets_principal (s : Set α) : (𝓟 s).smallSets = 𝓟 (𝒫 s) :=
   lift'_principal monotone_powerset
 #align filter.small_sets_principal Filter.smallSets_principal
+
+theorem smallSets_comap_eq_comap_image (l : Filter β) (f : α → β) :
+    (comap f l).smallSets = comap (image f) l.smallSets := by
+  refine (gc_map_comap _).u_comm_of_l_comm (gc_map_comap _) bind_smallSets_gc bind_smallSets_gc ?_
+  simp [Function.comp]
 
 theorem smallSets_comap (l : Filter β) (f : α → β) :
     (comap f l).smallSets = l.lift' (powerset ∘ preimage f) :=

--- a/Mathlib/Order/Filter/SmallSets.lean
+++ b/Mathlib/Order/Filter/SmallSets.lean
@@ -125,7 +125,7 @@ theorem smallSets_principal (s : Set α) : (𝓟 s).smallSets = 𝓟 (𝒫 s) :=
 theorem smallSets_comap_eq_comap_image (l : Filter β) (f : α → β) :
     (comap f l).smallSets = comap (image f) l.smallSets := by
   refine (gc_map_comap _).u_comm_of_l_comm (gc_map_comap _) bind_smallSets_gc bind_smallSets_gc ?_
-  simp [Function.comp]
+  simp [Function.comp, map_bind, bind_map]
 
 theorem smallSets_comap (l : Filter β) (f : α → β) :
     (comap f l).smallSets = l.lift' (powerset ∘ preimage f) :=

--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -191,12 +191,11 @@ instance tendstoIccClassNhdsPi {ι : Type*} {α : ι → Type*} [∀ i, Preorder
     TendstoIxxClass Icc (𝓝 f) (𝓝 f) := by
   constructor
   conv in (𝓝 f).smallSets => rw [nhds_pi, Filter.pi]
-  simp only [smallSets_iInf, smallSets_comap, tendsto_iInf, tendsto_lift', (· ∘ ·),
-    mem_powerset_iff]
-  intro i s hs
+  simp only [smallSets_iInf, smallSets_comap_eq_comap_image, tendsto_iInf, tendsto_comap_iff]
+  intro i
   have : Tendsto (fun g : ∀ i, α i => g i) (𝓝 f) (𝓝 (f i)) := (continuous_apply i).tendsto f
-  refine' (tendsto_lift'.1 ((this.comp tendsto_fst).Icc (this.comp tendsto_snd)) s hs).mono _
-  exact fun p hp g hg => hp ⟨hg.1 _, hg.2 _⟩
+  refine (this.comp tendsto_fst).Icc (this.comp tendsto_snd) |>.smallSets_mono ?_
+  filter_upwards [] using fun ⟨f, g⟩ ↦ image_subset_iff.mpr fun p hp ↦ ⟨hp.1 i, hp.2 i⟩
 #align tendsto_Icc_class_nhds_pi tendstoIccClassNhdsPi
 
 -- Porting note (#10756): new lemma


### PR DESCRIPTION
And use the new version to hide `Filter.lift'` where `comap_smallSets` was used.

I was writing an exercise about `Filter.smallSets` and noticed we didn't have this in Mathlib. So of course I had to formalize it to check, and I think it makes the API nicer.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
