### PR TITLE
[Merged by Bors] - refactor(LinearAlgebra/BilinearForm/Basic): Deprecate coercions

### DIFF
--- a/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
@@ -64,6 +64,7 @@ namespace BilinForm
 
 #noalign bilin_form.coe_fn_mk
 
+@[deprecated]
 theorem coeFn_congr : ∀ {x x' y y' : M}, x = x' → y = y' → B x y = B x' y'
   | _, _, _, _, rfl, rfl => rfl
 #align bilin_form.coe_fn_congr LinearMap.BilinForm.coeFn_congr
@@ -115,6 +116,7 @@ lemma smul_right_of_tower (r : S) (x y : M) : B x (r • y) = r • B x y := by
 variable {D : BilinForm R M} {D₁ : BilinForm R₁ M₁}
 
 -- TODO: instantiate `FunLike`
+@[deprecated]
 theorem coe_injective : Function.Injective ((fun B x y => B x y) : BilinForm R M → M → M → R) :=
   fun B D h => by
     ext x y
@@ -122,10 +124,7 @@ theorem coe_injective : Function.Injective ((fun B x y => B x y) : BilinForm R M
 #align bilin_form.coe_injective LinearMap.BilinForm.coe_injective
 
 @[ext]
-theorem ext (H : ∀ x y : M, B x y = D x y) : B = D :=
-  coe_injective <| by
-    funext
-    exact H _ _
+theorem ext (H : ∀ x y : M, B x y = D x y) : B = D := ext₂ H
 #align bilin_form.ext LinearMap.BilinForm.ext
 
 theorem congr_fun (h : B = D) (x y : M) : B x y = D x y :=
@@ -136,6 +135,7 @@ theorem ext_iff : B = D ↔ ∀ x y, B x y = D x y :=
   ⟨congr_fun, ext₂⟩
 #align bilin_form.ext_iff LinearMap.BilinForm.ext_iff
 
+@[deprecated]
 theorem coe_zero : ⇑(0 : BilinForm R M) = 0 :=
   rfl
 #align bilin_form.coe_zero LinearMap.BilinForm.coe_zero
@@ -147,6 +147,7 @@ theorem zero_apply (x y : M) : (0 : BilinForm R M) x y = 0 :=
 
 variable (B D B₁ D₁)
 
+@[deprecated]
 theorem coe_add : ⇑(B + D) = B + D :=
   rfl
 #align bilin_form.coe_add LinearMap.BilinForm.coe_add
@@ -159,6 +160,7 @@ theorem add_apply (x y : M) : (B + D) x y = B x y + D x y :=
 #noalign bilin_form.coe_smul
 #noalign bilin_form.smul_apply
 
+@[deprecated]
 theorem coe_neg : ⇑(-B₁) = -B₁ :=
   rfl
 #align bilin_form.coe_neg LinearMap.BilinForm.coe_neg
@@ -168,6 +170,7 @@ theorem neg_apply (x y : M₁) : (-B₁) x y = -B₁ x y :=
   rfl
 #align bilin_form.neg_apply LinearMap.BilinForm.neg_apply
 
+@[deprecated]
 theorem coe_sub : ⇑(B₁ - D₁) = B₁ - D₁ :=
   rfl
 #align bilin_form.coe_sub LinearMap.BilinForm.coe_sub
@@ -178,6 +181,7 @@ theorem sub_apply (x y : M₁) : (B₁ - D₁) x y = B₁ x y - D₁ x y :=
 #align bilin_form.sub_apply LinearMap.BilinForm.sub_apply
 
 /-- `coeFn` as an `AddMonoidHom` -/
+@[deprecated]
 def coeFnAddMonoidHom : BilinForm R M →+ M → M → R where
   toFun := (fun B x y => B x y)
   map_zero' := rfl

--- a/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
@@ -116,7 +116,6 @@ lemma smul_right_of_tower (r : S) (x y : M) : B x (r • y) = r • B x y := by
 variable {D : BilinForm R M} {D₁ : BilinForm R₁ M₁}
 
 -- TODO: instantiate `FunLike`
-@[deprecated]
 theorem coe_injective : Function.Injective ((fun B x y => B x y) : BilinForm R M → M → M → R) :=
   fun B D h => by
     ext x y
@@ -181,7 +180,6 @@ theorem sub_apply (x y : M₁) : (B₁ - D₁) x y = B₁ x y - D₁ x y :=
 #align bilin_form.sub_apply LinearMap.BilinForm.sub_apply
 
 /-- `coeFn` as an `AddMonoidHom` -/
-@[deprecated]
 def coeFnAddMonoidHom : BilinForm R M →+ M → M → R where
   toFun := (fun B x y => B x y)
   map_zero' := rfl

--- a/Mathlib/LinearAlgebra/BilinearForm/Hom.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Hom.lean
@@ -87,9 +87,7 @@ theorem sum_right {α} (t : Finset α) (w : M) (g : α → M) :
 
 theorem sum_apply {α} (t : Finset α) (B : α → BilinForm R M) (v w : M) :
     (∑ i in t, B i) v w = ∑ i in t, B i v w := by
-  show coeFnAddMonoidHom (∑ i in t, B i) v w = _
-  rw [map_sum, Finset.sum_apply, Finset.sum_apply]
-  rfl
+  simp only [coeFn_sum, Finset.sum_apply]
 
 variable {B}
 


### PR DESCRIPTION
Following #11278 the coercions in `LinearAlgebra/BilinearForm/Basic` are no longer useful. This PR deprecates them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
