### PR TITLE
[Merged by Bors] - chore(Logic): reduce use of autoImplicit

### DIFF
--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -668,8 +668,8 @@ variable {α β : Sort*} {p q : α → Prop}
 theorem forall_swap {p : α → β → Prop} : (∀ x y, p x y) ↔ ∀ y x, p x y := ⟨swap, swap⟩
 #align forall_swap forall_swap
 
-set_option autoImplicit true in
-theorem forall₂_swap {κ₁ : ι₁ → Sort*} {κ₂ : ι₂ → Sort*} {p : ∀ i₁, κ₁ i₁ → ∀ i₂, κ₂ i₂ → Prop} :
+theorem forall₂_swap
+    {ι₁ ι₂ : Sort*} {κ₁ : ι₁ → Sort*} {κ₂ : ι₂ → Sort*} {p : ∀ i₁, κ₁ i₁ → ∀ i₂, κ₂ i₂ → Prop} :
     (∀ i₁ j₁ i₂ j₂, p i₁ j₁ i₂ j₂) ↔ ∀ i₂ j₂ i₁ j₁, p i₁ j₁ i₂ j₂ := ⟨swap₂, swap₂⟩
 #align forall₂_swap forall₂_swap
 
@@ -712,8 +712,8 @@ lemma forall_or_exists_not (P : α → Prop) : (∀ a, P a) ∨ ∃ a, ¬ P a :=
 lemma exists_or_forall_not (P : α → Prop) : (∃ a, P a) ∨ ∀ a, ¬ P a := by
   rw [← not_exists]; exact em _
 
-set_option autoImplicit true in
-theorem forall_imp_iff_exists_imp [ha : Nonempty α] : (∀ x, p x) → b ↔ ∃ x, p x → b := by
+theorem forall_imp_iff_exists_imp {α : Sort*} {p : α → Prop} {b : Prop} [ha : Nonempty α] :
+    (∀ x, p x) → b ↔ ∃ x, p x → b := by
   let ⟨a⟩ := ha
   refine ⟨fun h ↦ not_forall_not.1 fun h' ↦ ?_, fun ⟨x, hx⟩ h ↦ hx (h x)⟩
   exact if hb : b then h' a fun _ ↦ hb else hb <| h fun x ↦ (not_imp.1 (h' x)).1
@@ -747,8 +747,7 @@ theorem forall₃_true_iff {β : α → Sort*} {γ : ∀ a, β a → Sort*} :
 
 #align exists_const exists_const
 
-set_option autoImplicit true in
-theorem exists_unique_const (α) [i : Nonempty α] [Subsingleton α] :
+theorem exists_unique_const {b : Prop} (α : Sort*) [i : Nonempty α] [Subsingleton α] :
     (∃! _ : α, b) ↔ b := by simp
 #align exists_unique_const exists_unique_const
 
@@ -838,8 +837,8 @@ theorem forall_eq_apply_imp_iff' {f : α → β} {p : β → Prop} :
 
 #align exists_comm exists_comm
 
-set_option autoImplicit true in
-theorem exists₂_comm {κ₁ : ι₁ → Sort*} {κ₂ : ι₂ → Sort*} {p : ∀ i₁, κ₁ i₁ → ∀ i₂, κ₂ i₂ → Prop} :
+theorem exists₂_comm
+    {ι₁ ι₂ : Sort*} {κ₁ : ι₁ → Sort*} {κ₂ : ι₂ → Sort*} {p : ∀ i₁, κ₁ i₁ → ∀ i₂, κ₂ i₂ → Prop} :
     (∃ i₁ j₁ i₂ j₂, p i₁ j₁ i₂ j₂) ↔ ∃ i₂ j₂ i₁ j₁, p i₁ j₁ i₂ j₂ := by
   simp only [@exists_comm (κ₁ _), @exists_comm ι₁]
 #align exists₂_comm exists₂_comm
@@ -848,8 +847,9 @@ theorem And.exists {p q : Prop} {f : p ∧ q → Prop} : (∃ h, f h) ↔ ∃ hp
   ⟨fun ⟨h, H⟩ ↦ ⟨h.1, h.2, H⟩, fun ⟨hp, hq, H⟩ ↦ ⟨⟨hp, hq⟩, H⟩⟩
 #align and.exists And.exists
 
-set_option autoImplicit true in
-theorem forall_or_of_or_forall (h : b ∨ ∀ x, p x) (x) : b ∨ p x := h.imp_right fun h₂ ↦ h₂ x
+theorem forall_or_of_or_forall {α : Sort*} {p : α → Prop} {b : Prop} (h : b ∨ ∀ x, p x) (x : α) :
+    b ∨ p x :=
+  h.imp_right fun h₂ ↦ h₂ x
 #align forall_or_of_or_forall forall_or_of_or_forall
 
 -- See Note [decidable namespace]
@@ -950,16 +950,14 @@ lemma imp_congr_eq {a b c d : Prop} (h₁ : a = c) (h₂ : b = d) : (a → b) = 
 lemma imp_congr_ctx_eq {a b c d : Prop} (h₁ : a = c) (h₂ : c → b = d) : (a → b) = (c → d) :=
   propext (imp_congr_ctx h₁.to_iff fun hc ↦ (h₂ hc).to_iff)
 
-set_option autoImplicit true in
-lemma eq_true_intro (h : a) : a = True := propext (iff_true_intro h)
-set_option autoImplicit true in
-lemma eq_false_intro (h : ¬a) : a = False := propext (iff_false_intro h)
+lemma eq_true_intro {a : Prop} (h : a) : a = True := propext (iff_true_intro h)
+
+lemma eq_false_intro {a : Prop} (h : ¬a) : a = False := propext (iff_false_intro h)
 
 -- FIXME: `alias` creates `def Iff.eq := propext` instead of `lemma Iff.eq := propext`
 @[nolint defLemma] alias Iff.eq := propext
 
-set_option autoImplicit true in
-lemma iff_eq_eq : (a ↔ b) = (a = b) := propext ⟨propext, Eq.to_iff⟩
+lemma iff_eq_eq {a b : Prop} : (a ↔ b) = (a = b) := propext ⟨propext, Eq.to_iff⟩
 
 -- They were not used in Lean 3 and there are already lemmas with those names in Lean 4
 #noalign eq_false
@@ -1000,14 +998,15 @@ theorem ExistsUnique.unique₂ {α : Sort*} {p : α → Sort*} [∀ x, Subsingle
 end Quantifiers
 
 /-! ### Classical lemmas -/
-set_option autoImplicit true
+
 namespace Classical
-variable {p : α → Prop}
 
 -- use shortened names to avoid conflict when classical namespace is open.
 /-- Any prop `p` is decidable classically. A shorthand for `Classical.propDecidable`. -/
 noncomputable def dec (p : Prop) : Decidable p := by infer_instance
 #align classical.dec Classical.dec
+
+variable {α : Sort*} {p : α → Prop}
 
 /-- Any predicate `p` is decidable classically. -/
 noncomputable def decPred (p : α → Prop) : DecidablePred p := by infer_instance
@@ -1018,13 +1017,13 @@ noncomputable def decRel (p : α → α → Prop) : DecidableRel p := by infer_i
 #align classical.dec_rel Classical.decRel
 
 /-- Any type `α` has decidable equality classically. -/
-noncomputable def decEq (α : Sort u) : DecidableEq α := by infer_instance
+noncomputable def decEq (α : Sort*) : DecidableEq α := by infer_instance
 #align classical.dec_eq Classical.decEq
 
 /-- Construct a function from a default value `H0`, and a function to use if there exists a value
 satisfying the predicate. -/
 -- @[elab_as_elim] -- FIXME
-noncomputable def existsCases (H0 : C) (H : ∀ a, p a → C) : C :=
+noncomputable def existsCases {α C : Sort*} {p : α → Prop} (H0 : C) (H : ∀ a, p a → C) : C :=
   if h : ∃ a, p a then H (Classical.choose h) (Classical.choose_spec h) else H0
 #align classical.exists_cases Classical.existsCases
 
@@ -1049,6 +1048,7 @@ def choice_of_byContradiction' {α : Sort*} (contra : ¬(α → False) → α) :
 
 end Classical
 
+set_option autoImplicit true in
 /-- This function has the same type as `Exists.recOn`, and can be used to case on an equality,
 but `Exists.recOn` can only eliminate into Prop, while this version eliminates into any universe
 using the axiom of choice. -/
@@ -1058,9 +1058,9 @@ noncomputable def Exists.classicalRecOn {p : α → Prop} (h : ∃ a, p a) {C} (
 #align exists.classical_rec_on Exists.classicalRecOn
 
 /-! ### Declarations about bounded quantifiers -/
-
 section BoundedQuantifiers
-variable {r p q : α → Prop} {P Q : ∀ x, p x → Prop} {b : Prop}
+
+variable {α : Sort*} {r p q : α → Prop} {P Q : ∀ x, p x → Prop} {b : Prop}
 
 theorem bex_def : (∃ (x : _) (_ : p x), q x) ↔ ∃ x, p x ∧ q x :=
   ⟨fun ⟨x, px, qx⟩ ↦ ⟨x, px, qx⟩, fun ⟨x, px, qx⟩ ↦ ⟨x, px, qx⟩⟩
@@ -1180,7 +1180,7 @@ end BoundedQuantifiers
 
 section ite
 
-variable {σ : α → Sort*} (f : α → β) {P Q R : Prop} [Decidable P] [Decidable Q]
+variable {α : Sort*} {σ : α → Sort*} {P Q R : Prop} [Decidable P] [Decidable Q]
   {a b c : α} {A : P → α} {B : ¬P → α}
 
 theorem dite_eq_iff : dite P A B = c ↔ (∃ h, A h = c) ∨ ∃ h, B h = c := by
@@ -1270,15 +1270,15 @@ theorem ite_eq_or_eq : ite P a b = a ∨ ite P a b = b :=
 
 /-- A two-argument function applied to two `dite`s is a `dite` of that two-argument function
 applied to each of the branches. -/
-theorem apply_dite₂ (f : α → β → γ) (P : Prop) [Decidable P] (a : P → α) (b : ¬P → α)
-    (c : P → β) (d : ¬P → β) :
+theorem apply_dite₂ {α β γ : Sort*} (f : α → β → γ) (P : Prop) [Decidable P]
+    (a : P → α) (b : ¬P → α) (c : P → β) (d : ¬P → β) :
     f (dite P a b) (dite P c d) = dite P (fun h ↦ f (a h) (c h)) fun h ↦ f (b h) (d h) := by
   by_cases h : P <;> simp [h]
 #align apply_dite2 apply_dite₂
 
 /-- A two-argument function applied to two `ite`s is a `ite` of that two-argument function
 applied to each of the branches. -/
-theorem apply_ite₂ (f : α → β → γ) (P : Prop) [Decidable P] (a b : α) (c d : β) :
+theorem apply_ite₂ {α β γ : Sort*} (f : α → β → γ) (P : Prop) [Decidable P] (a b : α) (c d : β) :
     f (ite P a b) (ite P c d) = ite P (f a c) (f b d) :=
   apply_dite₂ f P (fun _ ↦ a) (fun _ ↦ b) (fun _ ↦ c) fun _ ↦ d
 #align apply_ite2 apply_ite₂
@@ -1344,15 +1344,15 @@ theorem dite_prop_iff_and {Q : P → Prop} {R : ¬P → Prop} [Decidable P] :
 
 end ite
 
-theorem not_beq_of_ne [BEq α] [LawfulBEq α] {a b : α} (ne : a ≠ b) : ¬(a == b) :=
+theorem not_beq_of_ne {α : Type*} [BEq α] [LawfulBEq α] {a b : α} (ne : a ≠ b) : ¬(a == b) :=
   fun h => ne (eq_of_beq h)
 
-theorem beq_eq_decide [BEq α] [LawfulBEq α] {a b : α} : (a == b) = decide (a = b) := by
+theorem beq_eq_decide {α : Type*} [BEq α] [LawfulBEq α] {a b : α} : (a == b) = decide (a = b) := by
   rw [← beq_iff_eq a b]
   cases a == b <;> simp
 
 @[ext]
-theorem beq_ext (inst1 : BEq α) (inst2 : BEq α)
+theorem beq_ext {α : Type*} (inst1 : BEq α) (inst2 : BEq α)
     (h : ∀ x y, @BEq.beq _ inst1 x y = @BEq.beq _ inst2 x y) :
     inst1 = inst2 := by
   have ⟨beq1⟩ := inst1
@@ -1361,7 +1361,7 @@ theorem beq_ext (inst1 : BEq α) (inst2 : BEq α)
   funext x y
   exact h x y
 
-theorem lawful_beq_subsingleton (inst1 : BEq α) (inst2 : BEq α)
+theorem lawful_beq_subsingleton {α : Type*} (inst1 : BEq α) (inst2 : BEq α)
     [@LawfulBEq α inst1] [@LawfulBEq α inst2] :
     inst1 = inst2 := by
   apply beq_ext

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -45,11 +45,13 @@ as done in the `elide` and `unelide` tactics. -/
 @[reducible] def hidden {α : Sort*} {a : α} := a
 #align hidden hidden
 
-instance (priority := 10) decidableEq_of_subsingleton {α : Sort*} [Subsingleton α] : DecidableEq α :=
+variable {α : Sort*}
+
+instance (priority := 10) decidableEq_of_subsingleton [Subsingleton α] : DecidableEq α :=
   fun a b ↦ isTrue (Subsingleton.elim a b)
 #align decidable_eq_of_subsingleton decidableEq_of_subsingleton
 
-instance (α : Sort*) [Subsingleton α] (p : α → Prop) : Subsingleton (Subtype p) :=
+instance [Subsingleton α] (p : α → Prop) : Subsingleton (Subtype p) :=
   ⟨fun ⟨x, _⟩ ⟨y, _⟩ ↦ by cases Subsingleton.elim x y; rfl⟩
 
 #align pempty PEmpty
@@ -59,7 +61,7 @@ theorem congr_heq {α β γ : Sort _} {f : α → γ} {g : β → γ} {x : α} {
   cases h₂; cases h₁; rfl
 #align congr_heq congr_heq
 
-theorem congr_arg_heq {α} {β : α → Sort*} (f : ∀ a, β a) :
+theorem congr_arg_heq {β : α → Sort*} (f : ∀ a, β a) :
     ∀ {a₁ a₂ : α}, a₁ = a₂ → HEq (f a₁) (f a₂)
   | _, _, rfl => HEq.rfl
 #align congr_arg_heq congr_arg_heq
@@ -72,23 +74,23 @@ theorem ULift.down_injective {α : Sort _} : Function.Injective (@ULift.down α)
   ⟨fun h ↦ ULift.down_injective h, fun h ↦ by rw [h]⟩
 #align ulift.down_inj ULift.down_inj
 
-theorem PLift.down_injective {α : Sort*} : Function.Injective (@PLift.down α)
+theorem PLift.down_injective : Function.Injective (@PLift.down α)
   | ⟨a⟩, ⟨b⟩, _ => by congr
 #align plift.down_injective PLift.down_injective
 
-@[simp] theorem PLift.down_inj {α : Sort*} {a b : PLift α} : a.down = b.down ↔ a = b :=
+@[simp] theorem PLift.down_inj {a b : PLift α} : a.down = b.down ↔ a = b :=
   ⟨fun h ↦ PLift.down_injective h, fun h ↦ by rw [h]⟩
 #align plift.down_inj PLift.down_inj
 
-@[simp] theorem eq_iff_eq_cancel_left {α : Sort*} {b c : α} : (∀ {a}, a = b ↔ a = c) ↔ b = c :=
+@[simp] theorem eq_iff_eq_cancel_left {b c : α} : (∀ {a}, a = b ↔ a = c) ↔ b = c :=
   ⟨fun h ↦ by rw [← h], fun h a ↦ by rw [h]⟩
 #align eq_iff_eq_cancel_left eq_iff_eq_cancel_left
 
-@[simp] theorem eq_iff_eq_cancel_right {α : Sort*} {a b : α} : (∀ {c}, a = c ↔ b = c) ↔ a = b :=
+@[simp] theorem eq_iff_eq_cancel_right {a b : α} : (∀ {c}, a = c ↔ b = c) ↔ a = b :=
   ⟨fun h ↦ by rw [h], fun h a ↦ by rw [h]⟩
 #align eq_iff_eq_cancel_right eq_iff_eq_cancel_right
 
-lemma ne_and_eq_iff_right {α : Sort*} {a b c : α} (h : b ≠ c) : a ≠ b ∧ a = c ↔ a = c :=
+lemma ne_and_eq_iff_right {a b c : α} (h : b ≠ c) : a ≠ b ∧ a = c ↔ a = c :=
   and_iff_right_of_imp (fun h2 => h2.symm ▸ h.symm)
 #align ne_and_eq_iff_right ne_and_eq_iff_right
 

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -23,8 +23,6 @@ Theorems that require decidability hypotheses are in the namespace `Decidable`.
 Classical versions are in the namespace `Classical`.
 -/
 
-set_option autoImplicit true
-
 open Function
 attribute [local instance 10] Classical.propDecidable
 
@@ -47,7 +45,7 @@ as done in the `elide` and `unelide` tactics. -/
 @[reducible] def hidden {α : Sort*} {a : α} := a
 #align hidden hidden
 
-instance (priority := 10) decidableEq_of_subsingleton [Subsingleton α] : DecidableEq α :=
+instance (priority := 10) decidableEq_of_subsingleton {α : Sort*} [Subsingleton α] : DecidableEq α :=
   fun a b ↦ isTrue (Subsingleton.elim a b)
 #align decidable_eq_of_subsingleton decidableEq_of_subsingleton
 
@@ -82,11 +80,11 @@ theorem PLift.down_injective {α : Sort*} : Function.Injective (@PLift.down α)
   ⟨fun h ↦ PLift.down_injective h, fun h ↦ by rw [h]⟩
 #align plift.down_inj PLift.down_inj
 
-@[simp] theorem eq_iff_eq_cancel_left {b c : α} : (∀ {a}, a = b ↔ a = c) ↔ b = c :=
+@[simp] theorem eq_iff_eq_cancel_left {α : Sort*} {b c : α} : (∀ {a}, a = b ↔ a = c) ↔ b = c :=
   ⟨fun h ↦ by rw [← h], fun h a ↦ by rw [h]⟩
 #align eq_iff_eq_cancel_left eq_iff_eq_cancel_left
 
-@[simp] theorem eq_iff_eq_cancel_right {a b : α} : (∀ {c}, a = c ↔ b = c) ↔ a = b :=
+@[simp] theorem eq_iff_eq_cancel_right {α : Sort*} {a b : α} : (∀ {c}, a = c ↔ b = c) ↔ a = b :=
   ⟨fun h ↦ by rw [h], fun h a ↦ by rw [h]⟩
 #align eq_iff_eq_cancel_right eq_iff_eq_cancel_right
 
@@ -129,7 +127,7 @@ theorem fact_iff {p : Prop} : Fact p ↔ p := ⟨fun h ↦ h.1, fun h ↦ ⟨h�
 #align fact.elim Fact.elim
 
 /-- Swaps two pairs of arguments to a function. -/
-@[reducible] def Function.swap₂ {κ₁ : ι₁ → Sort*} {κ₂ : ι₂ → Sort*}
+@[reducible] def Function.swap₂ {ι₁ ι₂ : Sort*} {κ₁ : ι₁ → Sort*} {κ₂ : ι₂ → Sort*}
     {φ : ∀ i₁, κ₁ i₁ → ∀ i₂, κ₂ i₂ → Sort*} (f : ∀ i₁ j₁ i₂ j₂, φ i₁ j₁ i₂ j₂)
     (i₂ j₂ i₁ j₁) : φ i₁ j₁ i₂ j₂ := f i₁ j₁ i₂ j₂
 #align function.swap₂ Function.swap₂
@@ -172,14 +170,14 @@ alias Iff.imp := imp_congr
 #align imp_iff_right imp_iff_rightₓ -- reorder implicits
 #align imp_iff_not imp_iff_notₓ -- reorder implicits
 
-@[simp] theorem imp_iff_right_iff : (a → b ↔ b) ↔ a ∨ b := Decidable.imp_iff_right_iff
+@[simp] theorem imp_iff_right_iff {a b : Prop} : (a → b ↔ b) ↔ a ∨ b := Decidable.imp_iff_right_iff
 #align imp_iff_right_iff imp_iff_right_iff
 
-@[simp] theorem and_or_imp : a ∧ b ∨ (a → c) ↔ a → b ∨ c := Decidable.and_or_imp
+@[simp] theorem and_or_imp {a b c : Prop} : a ∧ b ∨ (a → c) ↔ a → b ∨ c := Decidable.and_or_imp
 #align and_or_imp and_or_imp
 
 /-- Provide modus tollens (`mt`) as dot notation for implications. -/
-protected theorem Function.mt : (a → b) → ¬b → ¬a := mt
+protected theorem Function.mt {a b : Prop} : (a → b) → ¬b → ¬a := mt
 #align function.mt Function.mt
 
 /-! ### Declarations about `not` -/
@@ -199,23 +197,25 @@ theorem em' (p : Prop) : ¬p ∨ p := (em p).symm
 theorem or_not {p : Prop} : p ∨ ¬p := em _
 #align or_not or_not
 
-theorem Decidable.eq_or_ne (x y : α) [Decidable (x = y)] : x = y ∨ x ≠ y := dec_em <| x = y
+theorem Decidable.eq_or_ne {α : Sort*} (x y : α) [Decidable (x = y)] : x = y ∨ x ≠ y :=
+  dec_em <| x = y
 #align decidable.eq_or_ne Decidable.eq_or_ne
 
-theorem Decidable.ne_or_eq (x y : α) [Decidable (x = y)] : x ≠ y ∨ x = y := dec_em' <| x = y
+theorem Decidable.ne_or_eq {α : Sort*} (x y : α) [Decidable (x = y)] : x ≠ y ∨ x = y :=
+  dec_em' <| x = y
 #align decidable.ne_or_eq Decidable.ne_or_eq
 
-theorem eq_or_ne (x y : α) : x = y ∨ x ≠ y := em <| x = y
+theorem eq_or_ne {α : Sort*} (x y : α) : x = y ∨ x ≠ y := em <| x = y
 #align eq_or_ne eq_or_ne
 
-theorem ne_or_eq (x y : α) : x ≠ y ∨ x = y := em' <| x = y
+theorem ne_or_eq {α : Sort*} (x y : α) : x ≠ y ∨ x = y := em' <| x = y
 #align ne_or_eq ne_or_eq
 
-theorem by_contradiction : (¬p → False) → p := Decidable.by_contradiction
+theorem by_contradiction {p : Prop} : (¬p → False) → p := Decidable.by_contradiction
 #align classical.by_contradiction by_contradiction
 #align by_contradiction by_contradiction
 
-theorem by_cases {q : Prop} (hpq : p → q) (hnpq : ¬p → q) : q :=
+theorem by_cases {p q : Prop} (hpq : p → q) (hnpq : ¬p → q) : q :=
 if hp : p then hpq hp else hnpq hp
 #align classical.by_cases by_cases
 
@@ -246,13 +246,15 @@ export Classical (not_not)
 attribute [simp] not_not
 #align not_not Classical.not_not
 
-theorem of_not_not : ¬¬a → a := by_contra
+variable {a b : Prop}
+
+theorem of_not_not {a : Prop} : ¬¬a → a := by_contra
 #align of_not_not of_not_not
 
-theorem not_ne_iff : ¬a ≠ b ↔ a = b := not_not
+theorem not_ne_iff {α : Sort*} {a b : α} : ¬a ≠ b ↔ a = b := not_not
 #align not_ne_iff not_ne_iff
 
-theorem of_not_imp {a b : Prop} : ¬(a → b) → a := Decidable.of_not_imp
+theorem of_not_imp : ¬(a → b) → a := Decidable.of_not_imp
 #align of_not_imp of_not_imp
 
 alias Not.decidable_imp_symm := Decidable.not_imp_symm
@@ -267,7 +269,7 @@ theorem not_imp_comm : ¬a → b ↔ ¬b → a := Decidable.not_imp_comm
 @[simp] theorem not_imp_self : ¬a → a ↔ a := Decidable.not_imp_self
 #align not_imp_self not_imp_self
 
-theorem Imp.swap : a → b → c ↔ b → a → c := ⟨Function.swap, Function.swap⟩
+theorem Imp.swap {a b : Sort*} {c : Prop} : a → b → c ↔ b → a → c := ⟨Function.swap, Function.swap⟩
 #align imp.swap Imp.swap
 
 alias Iff.not := not_congr
@@ -300,7 +302,7 @@ lemma Iff.ne_right {α β : Sort*} {a b : α} {c d : β} : (a ≠ b ↔ c = d) �
 @[simp] theorem xor_false : Xor' False = id := by ext; simp [Xor']
 #align xor_false xor_false
 
-theorem xor_comm (a b) : Xor' a b = Xor' b a := by simp [Xor', and_comm, or_comm]
+theorem xor_comm (a b : Prop) : Xor' a b = Xor' b a := by simp [Xor', and_comm, or_comm]
 #align xor_comm xor_comm
 
 instance : Std.Commutative Xor' := ⟨xor_comm⟩
@@ -334,8 +336,8 @@ alias ⟨And.rotate, _⟩ := and_rotate
 #align and.congr_right_iff and_congr_right_iff
 #align and.congr_left_iff and_congr_left_iffₓ -- reorder implicits
 
-theorem and_symm_right (a b : α) (p : Prop) : p ∧ a = b ↔ p ∧ b = a := by simp [eq_comm]
-theorem and_symm_left (a b : α) (p : Prop) : a = b ∧ p ↔ b = a ∧ p := by simp [eq_comm]
+theorem and_symm_right {α : Sort*} (a b : α) (p : Prop) : p ∧ a = b ↔ p ∧ b = a := by simp [eq_comm]
+theorem and_symm_left {α : Sort*} (a b : α) (p : Prop) : a = b ∧ p ↔ b = a ∧ p := by simp [eq_comm]
 
 /-! ### Declarations about `or` -/
 
@@ -348,22 +350,22 @@ alias ⟨Or.rotate, _⟩ := or_rotate
 #align or.rotate Or.rotate
 
 @[deprecated Or.imp]
-theorem or_of_or_of_imp_of_imp (h₁ : a ∨ b) (h₂ : a → c) (h₃ : b → d) : c ∨ d := Or.imp h₂ h₃ h₁
+theorem or_of_or_of_imp_of_imp {a b c d : Prop} (h₁ : a ∨ b) (h₂ : a → c) (h₃ : b → d) : c ∨ d := Or.imp h₂ h₃ h₁
 #align or_of_or_of_imp_of_imp or_of_or_of_imp_of_imp
 
 @[deprecated Or.imp_left]
-theorem or_of_or_of_imp_left (h₁ : a ∨ c) (h : a → b) : b ∨ c := Or.imp_left h h₁
+theorem or_of_or_of_imp_left {a c b : Prop} (h₁ : a ∨ c) (h : a → b) : b ∨ c := Or.imp_left h h₁
 #align or_of_or_of_imp_left or_of_or_of_imp_left
 
 @[deprecated Or.imp_right]
-theorem or_of_or_of_imp_right (h₁ : c ∨ a) (h : a → b) : c ∨ b := Or.imp_right h h₁
+theorem or_of_or_of_imp_right {c a b : Prop} (h₁ : c ∨ a) (h : a → b) : c ∨ b := Or.imp_right h h₁
 #align or_of_or_of_imp_right or_of_or_of_imp_right
 
-theorem Or.elim3 {d : Prop} (h : a ∨ b ∨ c) (ha : a → d) (hb : b → d) (hc : c → d) : d :=
+theorem Or.elim3 {c d : Prop} (h : a ∨ b ∨ c) (ha : a → d) (hb : b → d) (hc : c → d) : d :=
   Or.elim h ha fun h₂ ↦ Or.elim h₂ hb hc
 #align or.elim3 Or.elim3
 
-theorem Or.imp3 (had : a → d) (hbe : b → e) (hcf : c → f) : a ∨ b ∨ c → d ∨ e ∨ f :=
+theorem Or.imp3 {d e c f : Prop} (had : a → d) (hbe : b → e) (hcf : c → f) : a ∨ b ∨ c → d ∨ e ∨ f :=
   Or.imp had <| Or.imp hbe hcf
 #align or.imp3 Or.imp3
 
@@ -387,7 +389,7 @@ theorem or_not_of_imp : (a → b) → b ∨ ¬a := Decidable.or_not_of_imp
 theorem imp_iff_not_or : a → b ↔ ¬a ∨ b := Decidable.imp_iff_not_or
 #align imp_iff_not_or imp_iff_not_or
 
-theorem imp_iff_or_not : b → a ↔ a ∨ ¬b := Decidable.imp_iff_or_not
+theorem imp_iff_or_not {b a : Prop} : b → a ↔ a ∨ ¬b := Decidable.imp_iff_or_not
 #align imp_iff_or_not imp_iff_or_not
 
 theorem not_imp_not : ¬a → ¬b ↔ b → a := Decidable.not_imp_not
@@ -406,10 +408,10 @@ protected theorem Function.mtr : (¬a → ¬b) → b → a := not_imp_not.mp
 #align decidable.or_iff_not_imp_right Decidable.or_iff_not_imp_rightₓ -- reorder implicits
 #align decidable.imp_iff_or_not Decidable.imp_iff_or_notₓ -- reorder implicits
 
-theorem or_congr_left' (h : ¬c → (a ↔ b)) : a ∨ c ↔ b ∨ c := Decidable.or_congr_left' h
+theorem or_congr_left' {c a b : Prop} (h : ¬c → (a ↔ b)) : a ∨ c ↔ b ∨ c := Decidable.or_congr_left' h
 #align or_congr_left or_congr_left'
 
-theorem or_congr_right' (h : ¬a → (b ↔ c)) : a ∨ b ↔ a ∨ c := Decidable.or_congr_right' h
+theorem or_congr_right' {c : Prop} (h : ¬a → (b ↔ c)) : a ∨ b ↔ a ∨ c := Decidable.or_congr_right' h
 #align or_congr_right or_congr_right'ₓ -- reorder implicits
 
 #align or_iff_left or_iff_leftₓ -- reorder implicits
@@ -427,7 +429,7 @@ alias Iff.iff := iff_congr
 #align iff.iff Iff.iff
 
 -- @[simp] -- FIXME simp ignores proof rewrites
-theorem iff_mpr_iff_true_intro (h : P) : Iff.mpr (iff_true_intro h) True.intro = h := rfl
+theorem iff_mpr_iff_true_intro {P : Prop} (h : P) : Iff.mpr (iff_true_intro h) True.intro = h := rfl
 #align iff_mpr_iff_true_intro iff_mpr_iff_true_intro
 
 #align decidable.imp_or_distrib Decidable.imp_or
@@ -437,7 +439,7 @@ theorem imp_or {a b c : Prop} : a → b ∨ c ↔ (a → b) ∨ (a → c) := Dec
 
 #align decidable.imp_or_distrib' Decidable.imp_or'
 
-theorem imp_or' : a → b ∨ c ↔ (a → b) ∨ (a → c) := Decidable.imp_or'
+theorem imp_or' {a : Sort*} {b c : Prop} : a → b ∨ c ↔ (a → b) ∨ (a → c) := Decidable.imp_or'
 #align imp_or_distrib' imp_or'ₓ -- universes
 
 theorem not_imp : ¬(a → b) ↔ a ∧ ¬b := Decidable.not_imp_iff_and_not
@@ -533,15 +535,15 @@ theorem forall_mem_comm {α β} [Membership α β] {s : β} {p : α → α → P
 
 #align ne_of_apply_ne ne_of_apply_ne
 
-lemma ne_of_eq_of_ne (h₁ : a = b) (h₂ : b ≠ c) : a ≠ c := h₁.symm ▸ h₂
-lemma ne_of_ne_of_eq (h₁ : a ≠ b) (h₂ : b = c) : a ≠ c := h₂ ▸ h₁
+lemma ne_of_eq_of_ne {α : Sort*} {a b c : α} (h₁ : a = b) (h₂ : b ≠ c) : a ≠ c := h₁.symm ▸ h₂
+lemma ne_of_ne_of_eq {α : Sort*} {a b c : α} (h₁ : a ≠ b) (h₂ : b = c) : a ≠ c := h₂ ▸ h₁
 
 alias Eq.trans_ne := ne_of_eq_of_ne
 alias Ne.trans_eq := ne_of_ne_of_eq
 #align eq.trans_ne Eq.trans_ne
 #align ne.trans_eq Ne.trans_eq
 
-theorem eq_equivalence : Equivalence (@Eq α) :=
+theorem eq_equivalence {α : Sort*} : Equivalence (@Eq α) :=
   ⟨Eq.refl, @Eq.symm _, @Eq.trans _⟩
 #align eq_equivalence eq_equivalence
 
@@ -553,25 +555,28 @@ attribute [simp] eq_mp_eq_cast eq_mpr_eq_cast
 #align cast_cast cast_cast
 
 -- @[simp] -- FIXME simp ignores proof rewrites
-theorem congr_refl_left (f : α → β) {a b : α} (h : a = b) :
+theorem congr_refl_left {α β : Sort*} (f : α → β) {a b : α} (h : a = b) :
     congr (Eq.refl f) h = congr_arg f h := rfl
 #align congr_refl_left congr_refl_left
 
 -- @[simp] -- FIXME simp ignores proof rewrites
-theorem congr_refl_right {f g : α → β} (h : f = g) (a : α) :
+theorem congr_refl_right {α β : Sort*} {f g : α → β} (h : f = g) (a : α) :
     congr h (Eq.refl a) = congr_fun h a := rfl
 #align congr_refl_right congr_refl_right
 
 -- @[simp] -- FIXME simp ignores proof rewrites
-theorem congr_arg_refl (f : α → β) (a : α) : congr_arg f (Eq.refl a) = Eq.refl (f a) := rfl
+theorem congr_arg_refl {α β : Sort*} (f : α → β) (a : α) :
+    congr_arg f (Eq.refl a) = Eq.refl (f a) :=
+  rfl
 #align congr_arg_refl congr_arg_refl
 
 -- @[simp] -- FIXME simp ignores proof rewrites
-theorem congr_fun_rfl (f : α → β) (a : α) : congr_fun (Eq.refl f) a = Eq.refl (f a) := rfl
+theorem congr_fun_rfl {α β : Sort*} (f : α → β) (a : α) : congr_fun (Eq.refl f) a = Eq.refl (f a) :=
+  rfl
 #align congr_fun_rfl congr_fun_rfl
 
 -- @[simp] -- FIXME simp ignores proof rewrites
-theorem congr_fun_congr_arg (f : α → β → γ) {a a' : α} (p : a = a') (b : β) :
+theorem congr_fun_congr_arg {α β γ : Sort*} (f : α → β → γ) {a a' : α} (p : a = a') (b : β) :
     congr_fun (congr_arg f p) b = congr_arg (fun a ↦ f a b) p := rfl
 #align congr_fun_congr_arg congr_fun_congr_arg
 
@@ -582,19 +587,22 @@ theorem Eq.rec_eq_cast {α : Sort _} {P : α → Sort _} {x y : α} (h : x = y) 
     h ▸ z = cast (congr_arg P h) z := by induction h; rfl
 
 -- Porting note (#10756): new theorem. More general version of `eqRec_heq`
-theorem eqRec_heq' {α : Sort u_1} {a' : α} {motive : (a : α) → a' = a → Sort u}
+theorem eqRec_heq' {α : Sort*} {a' : α} {motive : (a : α) → a' = a → Sort*}
     (p : motive a' (rfl : a' = a')) {a : α} (t : a' = a) :
     HEq (@Eq.rec α a' motive p a t) p :=
   by subst t; rfl
 
+set_option autoImplicit true in
 theorem rec_heq_of_heq {C : α → Sort*} {x : C a} {y : β} (e : a = b) (h : HEq x y) :
     HEq (e ▸ x) y := by subst e; exact h
 #align rec_heq_of_heq rec_heq_of_heq
 
+set_option autoImplicit true in
 theorem rec_heq_iff_heq {C : α → Sort*} {x : C a} {y : β} {e : a = b} :
     HEq (e ▸ x) y ↔ HEq x y := by subst e; rfl
 #align rec_heq_iff_heq rec_heq_iff_heq
 
+set_option autoImplicit true in
 theorem heq_rec_iff_heq {C : α → Sort*} {x : β} {y : C a} {e : a = b} :
     HEq x (e ▸ y) ↔ HEq x y := by subst e; rfl
 #align heq_rec_iff_heq heq_rec_iff_heq
@@ -604,8 +612,6 @@ theorem heq_rec_iff_heq {C : α → Sort*} {x : β} {y : C a} {e : a = b} :
 #align eq.congr_right Eq.congr_right
 #align congr_arg2 congr_arg₂
 
-variable {β : α → Sort*} {γ : ∀ a, β a → Sort*} {δ : ∀ a b, γ a b → Sort*}
-
 #align congr_fun₂ congr_fun₂
 #align congr_fun₃ congr_fun₃
 #align funext₂ funext₂
@@ -614,12 +620,10 @@ variable {β : α → Sort*} {γ : ∀ a, β a → Sort*} {δ : ∀ a b, γ a b 
 end Equality
 
 /-! ### Declarations about quantifiers -/
-
-
 section Quantifiers
 section Dependent
 
-variable {β : α → Sort*} {γ : ∀ a, β a → Sort*} {δ : ∀ a b, γ a b → Sort*}
+variable {α : Sort*} {β : α → Sort*} {γ : ∀ a, β a → Sort*} {δ : ∀ a b, γ a b → Sort*}
   {ε : ∀ a b c, δ a b c → Sort*}
 
 theorem pi_congr {β' : α → Sort _} (h : ∀ a, β a = β' a) : (∀ a, β a) = ∀ a, β' a :=
@@ -651,13 +655,14 @@ theorem Exists₃.imp {p q : ∀ a b, γ a b → Prop} (h : ∀ a b c, p a b c �
 
 end Dependent
 
-variable {κ : ι → Sort*} {p q : α → Prop}
+variable {α β : Sort*} {p q : α → Prop}
 
 #align exists_imp_exists' Exists.imp'
 
 theorem forall_swap {p : α → β → Prop} : (∀ x y, p x y) ↔ ∀ y x, p x y := ⟨swap, swap⟩
 #align forall_swap forall_swap
 
+set_option autoImplicit true in
 theorem forall₂_swap {κ₁ : ι₁ → Sort*} {κ₂ : ι₂ → Sort*} {p : ∀ i₁, κ₁ i₁ → ∀ i₂, κ₂ i₂ → Prop} :
     (∀ i₁ j₁ i₂ j₂, p i₁ j₁ i₂ j₂) ↔ ∀ i₂ j₂ i₁ j₁, p i₁ j₁ i₂ j₂ := ⟨swap₂, swap₂⟩
 #align forall₂_swap forall₂_swap
@@ -701,6 +706,7 @@ lemma forall_or_exists_not (P : α → Prop) : (∀ a, P a) ∨ ∃ a, ¬ P a :=
 lemma exists_or_forall_not (P : α → Prop) : (∃ a, P a) ∨ ∀ a, ¬ P a := by
   rw [← not_exists]; exact em _
 
+set_option autoImplicit true in
 theorem forall_imp_iff_exists_imp [ha : Nonempty α] : (∀ x, p x) → b ↔ ∃ x, p x → b := by
   let ⟨a⟩ := ha
   refine ⟨fun h ↦ not_forall_not.1 fun h' ↦ ?_, fun ⟨x, hx⟩ h ↦ hx (h x)⟩
@@ -735,6 +741,7 @@ theorem forall₃_true_iff {β : α → Sort*} {γ : ∀ a, β a → Sort*} :
 
 #align exists_const exists_const
 
+set_option autoImplicit true in
 theorem exists_unique_const (α) [i : Nonempty α] [Subsingleton α] :
     (∃! _ : α, b) ↔ b := by simp
 #align exists_unique_const exists_unique_const
@@ -825,6 +832,7 @@ theorem forall_eq_apply_imp_iff' {f : α → β} {p : β → Prop} :
 
 #align exists_comm exists_comm
 
+set_option autoImplicit true in
 theorem exists₂_comm {κ₁ : ι₁ → Sort*} {κ₂ : ι₂ → Sort*} {p : ∀ i₁, κ₁ i₁ → ∀ i₂, κ₂ i₂ → Prop} :
     (∃ i₁ j₁ i₂ j₂, p i₁ j₁ i₂ j₂) ↔ ∃ i₂ j₂ i₁ j₁, p i₁ j₁ i₂ j₂ := by
   simp only [@exists_comm (κ₁ _), @exists_comm ι₁]
@@ -834,6 +842,7 @@ theorem And.exists {p q : Prop} {f : p ∧ q → Prop} : (∃ h, f h) ↔ ∃ hp
   ⟨fun ⟨h, H⟩ ↦ ⟨h.1, h.2, H⟩, fun ⟨hp, hq, H⟩ ↦ ⟨⟨hp, hq⟩, H⟩⟩
 #align and.exists And.exists
 
+set_option autoImplicit true in
 theorem forall_or_of_or_forall (h : b ∨ ∀ x, p x) (x) : b ∨ p x := h.imp_right fun h₂ ↦ h₂ x
 #align forall_or_of_or_forall forall_or_of_or_forall
 
@@ -935,12 +944,15 @@ lemma imp_congr_eq {a b c d : Prop} (h₁ : a = c) (h₂ : b = d) : (a → b) = 
 lemma imp_congr_ctx_eq {a b c d : Prop} (h₁ : a = c) (h₂ : c → b = d) : (a → b) = (c → d) :=
   propext (imp_congr_ctx h₁.to_iff fun hc ↦ (h₂ hc).to_iff)
 
+set_option autoImplicit true in
 lemma eq_true_intro (h : a) : a = True := propext (iff_true_intro h)
+set_option autoImplicit true in
 lemma eq_false_intro (h : ¬a) : a = False := propext (iff_false_intro h)
 
 -- FIXME: `alias` creates `def Iff.eq := propext` instead of `lemma Iff.eq := propext`
 @[nolint defLemma] alias Iff.eq := propext
 
+set_option autoImplicit true in
 lemma iff_eq_eq : (a ↔ b) = (a = b) := propext ⟨propext, Eq.to_iff⟩
 
 -- They were not used in Lean 3 and there are already lemmas with those names in Lean 4
@@ -982,7 +994,7 @@ theorem ExistsUnique.unique₂ {α : Sort*} {p : α → Sort*} [∀ x, Subsingle
 end Quantifiers
 
 /-! ### Classical lemmas -/
-
+set_option autoImplicit true
 namespace Classical
 variable {p : α → Prop}
 

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -350,7 +350,9 @@ alias ⟨Or.rotate, _⟩ := or_rotate
 #align or.rotate Or.rotate
 
 @[deprecated Or.imp]
-theorem or_of_or_of_imp_of_imp {a b c d : Prop} (h₁ : a ∨ b) (h₂ : a → c) (h₃ : b → d) : c ∨ d := Or.imp h₂ h₃ h₁
+theorem or_of_or_of_imp_of_imp {a b c d : Prop} (h₁ : a ∨ b) (h₂ : a → c) (h₃ : b → d) :
+    c ∨ d :=
+  Or.imp h₂ h₃ h₁
 #align or_of_or_of_imp_of_imp or_of_or_of_imp_of_imp
 
 @[deprecated Or.imp_left]
@@ -365,7 +367,8 @@ theorem Or.elim3 {c d : Prop} (h : a ∨ b ∨ c) (ha : a → d) (hb : b → d) 
   Or.elim h ha fun h₂ ↦ Or.elim h₂ hb hc
 #align or.elim3 Or.elim3
 
-theorem Or.imp3 {d e c f : Prop} (had : a → d) (hbe : b → e) (hcf : c → f) : a ∨ b ∨ c → d ∨ e ∨ f :=
+theorem Or.imp3 {d e c f : Prop} (had : a → d) (hbe : b → e) (hcf : c → f) :
+    a ∨ b ∨ c → d ∨ e ∨ f :=
   Or.imp had <| Or.imp hbe hcf
 #align or.imp3 Or.imp3
 
@@ -408,7 +411,8 @@ protected theorem Function.mtr : (¬a → ¬b) → b → a := not_imp_not.mp
 #align decidable.or_iff_not_imp_right Decidable.or_iff_not_imp_rightₓ -- reorder implicits
 #align decidable.imp_iff_or_not Decidable.imp_iff_or_notₓ -- reorder implicits
 
-theorem or_congr_left' {c a b : Prop} (h : ¬c → (a ↔ b)) : a ∨ c ↔ b ∨ c := Decidable.or_congr_left' h
+theorem or_congr_left' {c a b : Prop} (h : ¬c → (a ↔ b)) : a ∨ c ↔ b ∨ c :=
+  Decidable.or_congr_left' h
 #align or_congr_left or_congr_left'
 
 theorem or_congr_right' {c : Prop} (h : ¬a → (b ↔ c)) : a ∨ b ↔ a ∨ c := Decidable.or_congr_right' h

--- a/Mathlib/Logic/Embedding/Basic.lean
+++ b/Mathlib/Logic/Embedding/Basic.lean
@@ -13,9 +13,6 @@ import Mathlib.Logic.Equiv.Basic
 # Injective functions
 -/
 
-set_option autoImplicit true
-
-
 universe u v w x
 
 namespace Function
@@ -45,12 +42,12 @@ initialize_simps_projections Embedding (toFun → apply)
 -- Porting note: this needs `tactic.lift`.
 --instance {α β : Sort*} : CanLift (α → β) (α ↪ β) coeFn Injective where prf f hf := ⟨⟨f, hf⟩, rfl⟩
 
-theorem exists_surjective_iff :
+theorem exists_surjective_iff {α β : Sort*} :
     (∃ f : α → β, Surjective f) ↔ Nonempty (α → β) ∧ Nonempty (β ↪ α) :=
   ⟨fun ⟨f, h⟩ ↦ ⟨⟨f⟩, ⟨⟨_, injective_surjInv h⟩⟩⟩, fun ⟨h, ⟨e⟩⟩ ↦ (nonempty_fun.mp h).elim
     (fun _ ↦ ⟨isEmptyElim, (isEmptyElim <| e ·)⟩) fun _ ↦ ⟨_, invFun_surjective e.inj'⟩⟩
 
-instance : CanLift (α → β) (α ↪ β) (↑) Injective where
+instance {α β : Sort*} : CanLift (α → β) (α ↪ β) (↑) Injective where
   prf _ h := ⟨⟨_, h⟩, rfl⟩
 
 end Function
@@ -413,7 +410,7 @@ open Function Embedding
 /-- Given an equivalence to a subtype, produce an embedding to the elements of the corresponding
 set. -/
 @[simps!]
-def asEmbedding {p : β → Prop} (e : α ≃ Subtype p) : α ↪ β :=
+def asEmbedding {β α : Sort*} {p : β → Prop} (e : α ≃ Subtype p) : α ↪ β :=
   e.toEmbedding.trans (subtype p)
 #align equiv.as_embedding Equiv.asEmbedding
 #align equiv.as_embedding_apply Equiv.asEmbedding_apply

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -53,9 +53,6 @@ Many more such isomorphisms and operations are defined in `Logic.Equiv.Basic`.
 equivalence, congruence, bijective map
 -/
 
-set_option autoImplicit true
-
-
 open Function
 
 universe u v w z
@@ -320,7 +317,7 @@ theorem Perm.coe_subsingleton {α : Type*} [Subsingleton α] (e : Perm α) : (e 
 theorem apply_eq_iff_eq (f : α ≃ β) {x y : α} : f x = f y ↔ x = y := EquivLike.apply_eq_iff_eq f
 #align equiv.apply_eq_iff_eq Equiv.apply_eq_iff_eq
 
-theorem apply_eq_iff_eq_symm_apply (f : α ≃ β) : f x = y ↔ x = f.symm y := by
+theorem apply_eq_iff_eq_symm_apply {x : α} {y : β}(f : α ≃ β) : f x = y ↔ x = f.symm y := by
   conv_lhs => rw [← apply_symm_apply f y]
   rw [apply_eq_iff_eq]
 #align equiv.apply_eq_iff_eq_symm_apply Equiv.apply_eq_iff_eq_symm_apply
@@ -408,7 +405,7 @@ theorem comp_bijective (f : α → β) (e : β ≃ γ) : Bijective (e ∘ f) ↔
 
 /-- If `α` is equivalent to `β` and `γ` is equivalent to `δ`, then the type of equivalences `α ≃ γ`
 is equivalent to the type of equivalences `β ≃ δ`. -/
-def equivCongr (ab : α ≃ β) (cd : γ ≃ δ) : (α ≃ γ) ≃ (β ≃ δ) where
+def equivCongr {δ : Sort*} (ab : α ≃ β) (cd : γ ≃ δ) : (α ≃ γ) ≃ (β ≃ δ) where
   toFun ac := (ab.symm.trans ac).trans cd
   invFun bd := ab.trans <| bd.trans <| cd.symm
   left_inv ac := by ext x; simp only [trans_apply, comp_apply, symm_apply_apply]
@@ -549,10 +546,12 @@ theorem arrowCongr_comp {α₁ β₁ γ₁ α₂ β₂ γ₂ : Sort*} (ea : α�
     arrowCongr (Equiv.refl α) (Equiv.refl β) = Equiv.refl (α → β) := rfl
 #align equiv.arrow_congr_refl Equiv.arrowCongr_refl
 
+set_option autoImplicit true in
 @[simp] theorem arrowCongr_trans (e₁ : α₁ ≃ α₂) (e₁' : β₁ ≃ β₂) (e₂ : α₂ ≃ α₃) (e₂' : β₂ ≃ β₃) :
     arrowCongr (e₁.trans e₂) (e₁'.trans e₂') = (arrowCongr e₁ e₁').trans (arrowCongr e₂ e₂') := rfl
 #align equiv.arrow_congr_trans Equiv.arrowCongr_trans
 
+set_option autoImplicit true in
 @[simp] theorem arrowCongr_symm (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) :
     (arrowCongr e₁ e₂).symm = arrowCongr e₁.symm e₂.symm := rfl
 #align equiv.arrow_congr_symm Equiv.arrowCongr_symm
@@ -573,13 +572,13 @@ def arrowCongr' {α₁ β₁ α₂ β₂ : Type*} (hα : α₁ ≃ α₂) (hβ :
     arrowCongr' (Equiv.refl α) (Equiv.refl β) = Equiv.refl (α → β) := rfl
 #align equiv.arrow_congr'_refl Equiv.arrowCongr'_refl
 
-@[simp] theorem arrowCongr'_trans
+@[simp] theorem arrowCongr'_trans {α₁ α₂ β₁ β₂ α₃ β₃ : Type*}
     (e₁ : α₁ ≃ α₂) (e₁' : β₁ ≃ β₂) (e₂ : α₂ ≃ α₃) (e₂' : β₂ ≃ β₃) :
     arrowCongr' (e₁.trans e₂) (e₁'.trans e₂') = (arrowCongr' e₁ e₁').trans (arrowCongr' e₂ e₂') :=
   rfl
 #align equiv.arrow_congr'_trans Equiv.arrowCongr'_trans
 
-@[simp] theorem arrowCongr'_symm (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) :
+@[simp] theorem arrowCongr'_symm {α₁ α₂ β₁ β₂ : Type*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) :
     (arrowCongr' e₁ e₂).symm = arrowCongr' e₁.symm e₂.symm := rfl
 #align equiv.arrow_congr'_symm Equiv.arrowCongr'_symm
 
@@ -812,6 +811,7 @@ namespace Perm
 
 end Perm
 
+set_option autoImplicit true in
 /-- An equivalence `f : α₁ ≃ α₂` generates an equivalence between `Σ a, β (f a)` and `Σ a, β a`. -/
 @[simps apply] def sigmaCongrLeft {β : α₂ → Sort _} (e : α₁ ≃ α₂) :
     (Σ a : α₁, β (e a)) ≃ Σ a : α₂, β a where
@@ -902,22 +902,26 @@ protected theorem forall_congr' {p : α → Prop} {q : β → Prop} (f : α ≃ 
 -- (Stopping at ternary functions seems reasonable: at least in 1-categorical mathematics,
 -- it's rare to have axioms involving more than 3 elements at once.)
 
+set_option autoImplicit true in
 protected theorem forall₂_congr {p : α₁ → β₁ → Prop} {q : α₂ → β₂ → Prop} (eα : α₁ ≃ α₂)
     (eβ : β₁ ≃ β₂) (h : ∀ {x y}, p x y ↔ q (eα x) (eβ y)) : (∀ x y, p x y) ↔ ∀ x y, q x y :=
   Equiv.forall_congr _ <| Equiv.forall_congr _ h
 #align equiv.forall₂_congr Equiv.forall₂_congr
 
+set_option autoImplicit true in
 protected theorem forall₂_congr' {p : α₁ → β₁ → Prop} {q : α₂ → β₂ → Prop}
     (eα : α₁ ≃ α₂) (eβ : β₁ ≃ β₂) (h : ∀ {x y}, p (eα.symm x) (eβ.symm y) ↔ q x y) :
     (∀ x y, p x y) ↔ ∀ x y, q x y := (Equiv.forall₂_congr eα.symm eβ.symm h.symm).symm
 #align equiv.forall₂_congr' Equiv.forall₂_congr'
 
+set_option autoImplicit true in
 protected theorem forall₃_congr {p : α₁ → β₁ → γ₁ → Prop} {q : α₂ → β₂ → γ₂ → Prop}
     (eα : α₁ ≃ α₂) (eβ : β₁ ≃ β₂) (eγ : γ₁ ≃ γ₂) (h : ∀ {x y z}, p x y z ↔ q (eα x) (eβ y) (eγ z)) :
     (∀ x y z, p x y z) ↔ ∀ x y z, q x y z :=
   Equiv.forall₂_congr _ _ <| Equiv.forall_congr _ h
 #align equiv.forall₃_congr Equiv.forall₃_congr
 
+set_option autoImplicit true in
 protected theorem forall₃_congr' {p : α₁ → β₁ → γ₁ → Prop} {q : α₂ → β₂ → γ₂ → Prop}
     (eα : α₁ ≃ α₂) (eβ : β₁ ≃ β₂) (eγ : γ₁ ≃ γ₂)
     (h : ∀ {x y z}, p (eα.symm x) (eβ.symm y) (eγ.symm z) ↔ q x y z) :

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -317,7 +317,7 @@ theorem Perm.coe_subsingleton {α : Type*} [Subsingleton α] (e : Perm α) : (e 
 theorem apply_eq_iff_eq (f : α ≃ β) {x y : α} : f x = f y ↔ x = y := EquivLike.apply_eq_iff_eq f
 #align equiv.apply_eq_iff_eq Equiv.apply_eq_iff_eq
 
-theorem apply_eq_iff_eq_symm_apply {x : α} {y : β}(f : α ≃ β) : f x = y ↔ x = f.symm y := by
+theorem apply_eq_iff_eq_symm_apply {x : α} {y : β} (f : α ≃ β) : f x = y ↔ x = f.symm y := by
   conv_lhs => rw [← apply_symm_apply f y]
   rw [apply_eq_iff_eq]
 #align equiv.apply_eq_iff_eq_symm_apply Equiv.apply_eq_iff_eq_symm_apply
@@ -546,13 +546,12 @@ theorem arrowCongr_comp {α₁ β₁ γ₁ α₂ β₂ γ₂ : Sort*} (ea : α�
     arrowCongr (Equiv.refl α) (Equiv.refl β) = Equiv.refl (α → β) := rfl
 #align equiv.arrow_congr_refl Equiv.arrowCongr_refl
 
-set_option autoImplicit true in
-@[simp] theorem arrowCongr_trans (e₁ : α₁ ≃ α₂) (e₁' : β₁ ≃ β₂) (e₂ : α₂ ≃ α₃) (e₂' : β₂ ≃ β₃) :
+@[simp] theorem arrowCongr_trans {α₁ α₂ α₃ β₁ β₂ β₃ : Sort*}
+    (e₁ : α₁ ≃ α₂) (e₁' : β₁ ≃ β₂) (e₂ : α₂ ≃ α₃) (e₂' : β₂ ≃ β₃) :
     arrowCongr (e₁.trans e₂) (e₁'.trans e₂') = (arrowCongr e₁ e₁').trans (arrowCongr e₂ e₂') := rfl
 #align equiv.arrow_congr_trans Equiv.arrowCongr_trans
 
-set_option autoImplicit true in
-@[simp] theorem arrowCongr_symm (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) :
+@[simp] theorem arrowCongr_symm {α₁ α₂ β₁ β₂ : Sort*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) :
     (arrowCongr e₁ e₂).symm = arrowCongr e₁.symm e₂.symm := rfl
 #align equiv.arrow_congr_symm Equiv.arrowCongr_symm
 
@@ -811,9 +810,8 @@ namespace Perm
 
 end Perm
 
-set_option autoImplicit true in
 /-- An equivalence `f : α₁ ≃ α₂` generates an equivalence between `Σ a, β (f a)` and `Σ a, β a`. -/
-@[simps apply] def sigmaCongrLeft {β : α₂ → Sort _} (e : α₁ ≃ α₂) :
+@[simps apply] def sigmaCongrLeft {α₁ α₂ : Type*} {β : α₂ → Sort _} (e : α₁ ≃ α₂) :
     (Σ a : α₁, β (e a)) ≃ Σ a : α₂, β a where
   toFun a := ⟨e a.1, a.2⟩
   invFun a := ⟨e.symm a.1, (e.right_inv' a.1).symm ▸ a.2⟩
@@ -902,27 +900,26 @@ protected theorem forall_congr' {p : α → Prop} {q : β → Prop} (f : α ≃ 
 -- (Stopping at ternary functions seems reasonable: at least in 1-categorical mathematics,
 -- it's rare to have axioms involving more than 3 elements at once.)
 
-set_option autoImplicit true in
-protected theorem forall₂_congr {p : α₁ → β₁ → Prop} {q : α₂ → β₂ → Prop} (eα : α₁ ≃ α₂)
-    (eβ : β₁ ≃ β₂) (h : ∀ {x y}, p x y ↔ q (eα x) (eβ y)) : (∀ x y, p x y) ↔ ∀ x y, q x y :=
+protected theorem forall₂_congr {α₁ α₂ β₁ β₂ : Sort*} {p : α₁ → β₁ → Prop} {q : α₂ → β₂ → Prop}
+    (eα : α₁ ≃ α₂) (eβ : β₁ ≃ β₂) (h : ∀ {x y}, p x y ↔ q (eα x) (eβ y)) :
+    (∀ x y, p x y) ↔ ∀ x y, q x y :=
   Equiv.forall_congr _ <| Equiv.forall_congr _ h
 #align equiv.forall₂_congr Equiv.forall₂_congr
 
-set_option autoImplicit true in
-protected theorem forall₂_congr' {p : α₁ → β₁ → Prop} {q : α₂ → β₂ → Prop}
+protected theorem forall₂_congr' {α₁ α₂ β₁ β₂ : Sort*} {p : α₁ → β₁ → Prop} {q : α₂ → β₂ → Prop}
     (eα : α₁ ≃ α₂) (eβ : β₁ ≃ β₂) (h : ∀ {x y}, p (eα.symm x) (eβ.symm y) ↔ q x y) :
     (∀ x y, p x y) ↔ ∀ x y, q x y := (Equiv.forall₂_congr eα.symm eβ.symm h.symm).symm
 #align equiv.forall₂_congr' Equiv.forall₂_congr'
 
-set_option autoImplicit true in
-protected theorem forall₃_congr {p : α₁ → β₁ → γ₁ → Prop} {q : α₂ → β₂ → γ₂ → Prop}
+protected theorem forall₃_congr
+    {α₁ α₂ β₁ β₂ γ₁ γ₂ : Sort*} {p : α₁ → β₁ → γ₁ → Prop} {q : α₂ → β₂ → γ₂ → Prop}
     (eα : α₁ ≃ α₂) (eβ : β₁ ≃ β₂) (eγ : γ₁ ≃ γ₂) (h : ∀ {x y z}, p x y z ↔ q (eα x) (eβ y) (eγ z)) :
     (∀ x y z, p x y z) ↔ ∀ x y z, q x y z :=
   Equiv.forall₂_congr _ _ <| Equiv.forall_congr _ h
 #align equiv.forall₃_congr Equiv.forall₃_congr
 
-set_option autoImplicit true in
-protected theorem forall₃_congr' {p : α₁ → β₁ → γ₁ → Prop} {q : α₂ → β₂ → γ₂ → Prop}
+protected theorem forall₃_congr'
+    {α₁ α₂ β₁ β₂ γ₁ γ₂ : Sort*} {p : α₁ → β₁ → γ₁ → Prop} {q : α₂ → β₂ → γ₂ → Prop}
     (eα : α₁ ≃ α₂) (eβ : β₁ ≃ β₂) (eγ : γ₁ ≃ γ₂)
     (h : ∀ {x y z}, p (eα.symm x) (eβ.symm y) (eγ.symm z) ↔ q x y z) :
     (∀ x y z, p x y z) ↔ ∀ x y z, q x y z :=

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -1011,10 +1011,12 @@ end Sometimes
 
 end Function
 
+variable {α β : Sort*}
+
 /-- A relation `r : α → β → Prop` is "function-like"
 (for each `a` there exists a unique `b` such that `r a b`)
 if and only if it is `(f · = ·)` for some function `f`. -/
-lemma forall_existsUnique_iff {α β : Sort*} {r : α → β → Prop} :
+lemma forall_existsUnique_iff {r : α → β → Prop} :
     (∀ a, ∃! b, r a b) ↔ ∃ f : α → β, ∀ {a b}, r a b ↔ f a = b := by
   refine ⟨fun h ↦ ?_, ?_⟩
   · refine ⟨fun a ↦ (h a).choose, fun hr ↦ ?_, fun h' ↦ h' ▸ ?_⟩
@@ -1025,14 +1027,14 @@ lemma forall_existsUnique_iff {α β : Sort*} {r : α → β → Prop} :
 /-- A relation `r : α → β → Prop` is "function-like"
 (for each `a` there exists a unique `b` such that `r a b`)
 if and only if it is `(f · = ·)` for some function `f`. -/
-lemma forall_existsUnique_iff' {α β : Sort*} {r : α → β → Prop} :
+lemma forall_existsUnique_iff' {r : α → β → Prop} :
     (∀ a, ∃! b, r a b) ↔ ∃ f : α → β, r = (f · = ·) := by
   simp [forall_existsUnique_iff, Function.funext_iff]
 
 /-- A symmetric relation `r : α → α → Prop` is "function-like"
 (for each `a` there exists a unique `b` such that `r a b`)
 if and only if it is `(f · = ·)` for some involutive function `f`. -/
-protected lemma Symmetric.forall_existsUnique_iff' {α : Sort*} {r : α → α → Prop} (hr : Symmetric r) :
+protected lemma Symmetric.forall_existsUnique_iff' {r : α → α → Prop} (hr : Symmetric r) :
     (∀ a, ∃! b, r a b) ↔ ∃ f : α → α, Involutive f ∧ r = (f · = ·) := by
   refine ⟨fun h ↦ ?_, fun ⟨f, _, hf⟩ ↦ forall_existsUnique_iff'.2 ⟨f, hf⟩⟩
   rcases forall_existsUnique_iff'.1 h with ⟨f, rfl : r = _⟩
@@ -1041,7 +1043,7 @@ protected lemma Symmetric.forall_existsUnique_iff' {α : Sort*} {r : α → α �
 /-- A symmetric relation `r : α → α → Prop` is "function-like"
 (for each `a` there exists a unique `b` such that `r a b`)
 if and only if it is `(f · = ·)` for some involutive function `f`. -/
-protected lemma Symmetric.forall_existsUnique_iff {α : Sort*} {r : α → α → Prop} (hr : Symmetric r) :
+protected lemma Symmetric.forall_existsUnique_iff {r : α → α → Prop} (hr : Symmetric r) :
     (∀ a, ∃! b, r a b) ↔ ∃ f : α → α, Involutive f ∧ ∀ {a b}, r a b ↔ f a = b := by
   simp [hr.forall_existsUnique_iff', funext_iff]
 
@@ -1051,10 +1053,10 @@ def Set.piecewise {α : Type u} {β : α → Sort v} (s : Set α) (f g : ∀ i, 
   fun i ↦ if i ∈ s then f i else g i
 #align set.piecewise Set.piecewise
 
+
 /-! ### Bijectivity of `Eq.rec`, `Eq.mp`, `Eq.mpr`, and `cast` -/
 
-
-theorem eq_rec_on_bijective {α : Sort*} {C : α → Sort*} :
+theorem eq_rec_on_bijective {C : α → Sort*} :
     ∀ {a a' : α} (h : a = a'), Function.Bijective (@Eq.ndrec _ _ C · _ h)
   | _, _, rfl => ⟨fun _ _ ↦ id, fun x ↦ ⟨x, rfl⟩⟩
 #align eq_rec_on_bijective eq_rec_on_bijective
@@ -1079,9 +1081,8 @@ theorem cast_bijective {α β : Sort _} (h : α = β) : Function.Bijective (cast
 /-! Note these lemmas apply to `Type*` not `Sort*`, as the latter interferes with `simp`, and
 is trivial anyway. -/
 
-
 @[simp]
-theorem eq_rec_inj {α : Sort*} {a a' : α} (h : a = a') {C : α → Type*} (x y : C a) :
+theorem eq_rec_inj {a a' : α} (h : a = a') {C : α → Type*} (x y : C a) :
     (Eq.ndrec x h : C a') = Eq.ndrec y h ↔ x = y :=
   (eq_rec_on_bijective h).injective.eq_iff
 #align eq_rec_inj eq_rec_inj
@@ -1091,21 +1092,21 @@ theorem cast_inj {α β : Type u} (h : α = β) {x y : α} : cast h x = cast h y
   (cast_bijective h).injective.eq_iff
 #align cast_inj cast_inj
 
-theorem Function.LeftInverse.eq_rec_eq {α β : Sort*} {γ : β → Sort v} {f : α → β} {g : β → α}
+theorem Function.LeftInverse.eq_rec_eq {γ : β → Sort v} {f : α → β} {g : β → α}
     (h : Function.LeftInverse g f) (C : ∀ a : α, γ (f a)) (a : α) :
     -- TODO: mathlib3 uses `(congr_arg f (h a)).rec (C (g (f a)))` for LHS
     @Eq.rec β (f (g (f a))) (fun x _ ↦ γ x) (C (g (f a))) (f a) (congr_arg f (h a)) = C a :=
   eq_of_heq <| (eq_rec_heq _ _).trans <| by rw [h]
 #align function.left_inverse.eq_rec_eq Function.LeftInverse.eq_rec_eq
 
-theorem Function.LeftInverse.eq_rec_on_eq {α β : Sort*} {γ : β → Sort v} {f : α → β} {g : β → α}
+theorem Function.LeftInverse.eq_rec_on_eq {γ : β → Sort v} {f : α → β} {g : β → α}
     (h : Function.LeftInverse g f) (C : ∀ a : α, γ (f a)) (a : α) :
     -- TODO: mathlib3 uses `(congr_arg f (h a)).recOn (C (g (f a)))` for LHS
     @Eq.recOn β (f (g (f a))) (fun x _ ↦ γ x) (f a) (congr_arg f (h a)) (C (g (f a))) = C a :=
   h.eq_rec_eq _ _
 #align function.left_inverse.eq_rec_on_eq Function.LeftInverse.eq_rec_on_eq
 
-theorem Function.LeftInverse.cast_eq {α β : Sort*} {γ : β → Sort v} {f : α → β} {g : β → α}
+theorem Function.LeftInverse.cast_eq {γ : β → Sort v} {f : α → β} {g : β → α}
     (h : Function.LeftInverse g f) (C : ∀ a : α, γ (f a)) (a : α) :
     cast (congr_arg (fun a ↦ γ (f a)) (h a)) (C (g (f a))) = C a := by
   rw [cast_eq_iff_heq, h]
@@ -1117,7 +1118,7 @@ def Set.SeparatesPoints {α β : Type*} (A : Set (α → β)) : Prop :=
   ∀ ⦃x y : α⦄, x ≠ y → ∃ f ∈ A, (f x : β) ≠ f y
 #align set.separates_points Set.SeparatesPoints
 
-theorem IsSymmOp.flip_eq {α β} (op) [IsSymmOp α β op] : flip op = op :=
+theorem IsSymmOp.flip_eq (op) [IsSymmOp α β op] : flip op = op :=
   funext fun a ↦ funext fun b ↦ (IsSymmOp.symm_op a b).symm
 #align is_symm_op.flip_eq IsSymmOp.flip_eq
 

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -446,8 +446,7 @@ theorem invFun_eq (h : ∃ a, f a = b) : f (invFun f b) = b :=
   by simp only [invFun, dif_pos h, h.choose_spec]
 #align function.inv_fun_eq Function.invFun_eq
 
-set_option autoImplicit true in
-theorem apply_invFun_apply {α : Type u₁} {β : Type u₂} {f : α → β} {a : α} :
+theorem apply_invFun_apply {α β : Type*} {f : α → β} {a : α} :
     f (@invFun _ _ ⟨a⟩ f (f a)) = f a :=
   @invFun_eq _ _ ⟨a⟩ _ _ ⟨_, rfl⟩
 
@@ -806,16 +805,13 @@ end Extend
 
 namespace FactorsThrough
 
-set_option autoImplicit true in
-protected theorem rfl {f : α → β} : FactorsThrough f f := fun _ _ ↦ id
+protected theorem rfl {α β : Sort*} {f : α → β} : FactorsThrough f f := fun _ _ ↦ id
 
-set_option autoImplicit true in
-theorem comp_left {f : α → β} {g : α → γ}  (h : FactorsThrough g f) (g' : γ → δ) :
+theorem comp_left {α β γ δ : Sort*} {f : α → β} {g : α → γ} (h : FactorsThrough g f) (g' : γ → δ) :
     FactorsThrough (g' ∘ g) f := fun _x _y hxy ↦
   congr_arg g' (h hxy)
 
-set_option autoImplicit true in
-theorem comp_right {f : α → β} {g : α → γ} (h : FactorsThrough g f) (g' : δ → α) :
+theorem comp_right {α β γ δ : Sort*} {f : α → β} {g : α → γ} (h : FactorsThrough g f) (g' : δ → α) :
     FactorsThrough (g ∘ g') (f ∘ g') := fun _x _y hxy ↦
   h hxy
 
@@ -937,15 +933,14 @@ lemma not_injective : Injective Not := not_involutive.injective
 lemma not_surjective : Surjective Not := not_involutive.surjective
 lemma not_bijective : Bijective Not := not_involutive.bijective
 
-set_option autoImplicit true in
 @[simp]
-lemma symmetric_apply_eq_iff {f : α → α} : Symmetric (f · = ·) ↔ Involutive f := by
+lemma symmetric_apply_eq_iff {α : Sort*} {f : α → α} : Symmetric (f · = ·) ↔ Involutive f := by
   simp [Symmetric, Involutive]
 
 /-- The property of a binary function `f : α → β → γ` being injective.
 Mathematically this should be thought of as the corresponding function `α × β → γ` being injective.
 -/
-def Injective2 {α β γ} (f : α → β → γ) : Prop :=
+def Injective2 {α β γ : Sort*} (f : α → β → γ) : Prop :=
   ∀ ⦃a₁ a₂ b₁ b₂⦄, f a₁ b₁ = f a₂ b₂ → a₁ = a₂ ∧ b₁ = b₂
 #align function.injective2 Function.Injective2
 

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -13,8 +13,6 @@ import Mathlib.Logic.Basic
 # Miscellaneous function constructions and lemmas
 -/
 
-set_option autoImplicit true
-
 open Function
 
 universe u v w
@@ -448,6 +446,7 @@ theorem invFun_eq (h : ∃ a, f a = b) : f (invFun f b) = b :=
   by simp only [invFun, dif_pos h, h.choose_spec]
 #align function.inv_fun_eq Function.invFun_eq
 
+set_option autoImplicit true in
 theorem apply_invFun_apply {α : Type u₁} {β : Type u₂} {f : α → β} {a : α} :
     f (@invFun _ _ ⟨a⟩ f (f a)) = f a :=
   @invFun_eq _ _ ⟨a⟩ _ _ ⟨_, rfl⟩
@@ -807,12 +806,15 @@ end Extend
 
 namespace FactorsThrough
 
+set_option autoImplicit true in
 protected theorem rfl {f : α → β} : FactorsThrough f f := fun _ _ ↦ id
 
-theorem comp_left {f : α → β} {g : α → γ} (h : FactorsThrough g f) (g' : γ → δ) :
+set_option autoImplicit true in
+theorem comp_left {f : α → β} {g : α → γ}  (h : FactorsThrough g f) (g' : γ → δ) :
     FactorsThrough (g' ∘ g) f := fun _x _y hxy ↦
   congr_arg g' (h hxy)
 
+set_option autoImplicit true in
 theorem comp_right {f : α → β} {g : α → γ} (h : FactorsThrough g f) (g' : δ → α) :
     FactorsThrough (g ∘ g') (f ∘ g') := fun _x _y hxy ↦
   h hxy
@@ -935,6 +937,7 @@ lemma not_injective : Injective Not := not_involutive.injective
 lemma not_surjective : Surjective Not := not_involutive.surjective
 lemma not_bijective : Bijective Not := not_involutive.bijective
 
+set_option autoImplicit true in
 @[simp]
 lemma symmetric_apply_eq_iff {f : α → α} : Symmetric (f · = ·) ↔ Involutive f := by
   simp [Symmetric, Involutive]
@@ -1011,7 +1014,7 @@ end Function
 /-- A relation `r : α → β → Prop` is "function-like"
 (for each `a` there exists a unique `b` such that `r a b`)
 if and only if it is `(f · = ·)` for some function `f`. -/
-lemma forall_existsUnique_iff {r : α → β → Prop} :
+lemma forall_existsUnique_iff {α β : Sort*} {r : α → β → Prop} :
     (∀ a, ∃! b, r a b) ↔ ∃ f : α → β, ∀ {a b}, r a b ↔ f a = b := by
   refine ⟨fun h ↦ ?_, ?_⟩
   · refine ⟨fun a ↦ (h a).choose, fun hr ↦ ?_, fun h' ↦ h' ▸ ?_⟩
@@ -1022,14 +1025,14 @@ lemma forall_existsUnique_iff {r : α → β → Prop} :
 /-- A relation `r : α → β → Prop` is "function-like"
 (for each `a` there exists a unique `b` such that `r a b`)
 if and only if it is `(f · = ·)` for some function `f`. -/
-lemma forall_existsUnique_iff' {r : α → β → Prop} :
+lemma forall_existsUnique_iff' {α β : Sort*} {r : α → β → Prop} :
     (∀ a, ∃! b, r a b) ↔ ∃ f : α → β, r = (f · = ·) := by
   simp [forall_existsUnique_iff, Function.funext_iff]
 
 /-- A symmetric relation `r : α → α → Prop` is "function-like"
 (for each `a` there exists a unique `b` such that `r a b`)
 if and only if it is `(f · = ·)` for some involutive function `f`. -/
-protected lemma Symmetric.forall_existsUnique_iff' {r : α → α → Prop} (hr : Symmetric r) :
+protected lemma Symmetric.forall_existsUnique_iff' {α : Sort*} {r : α → α → Prop} (hr : Symmetric r) :
     (∀ a, ∃! b, r a b) ↔ ∃ f : α → α, Involutive f ∧ r = (f · = ·) := by
   refine ⟨fun h ↦ ?_, fun ⟨f, _, hf⟩ ↦ forall_existsUnique_iff'.2 ⟨f, hf⟩⟩
   rcases forall_existsUnique_iff'.1 h with ⟨f, rfl : r = _⟩
@@ -1038,7 +1041,7 @@ protected lemma Symmetric.forall_existsUnique_iff' {r : α → α → Prop} (hr 
 /-- A symmetric relation `r : α → α → Prop` is "function-like"
 (for each `a` there exists a unique `b` such that `r a b`)
 if and only if it is `(f · = ·)` for some involutive function `f`. -/
-protected lemma Symmetric.forall_existsUnique_iff {r : α → α → Prop} (hr : Symmetric r) :
+protected lemma Symmetric.forall_existsUnique_iff {α : Sort*} {r : α → α → Prop} (hr : Symmetric r) :
     (∀ a, ∃! b, r a b) ↔ ∃ f : α → α, Involutive f ∧ ∀ {a b}, r a b ↔ f a = b := by
   simp [hr.forall_existsUnique_iff', funext_iff]
 

--- a/Mathlib/Logic/IsEmpty.lean
+++ b/Mathlib/Logic/IsEmpty.lean
@@ -17,9 +17,6 @@ In this file we define a typeclass `IsEmpty`, which expresses that a type has no
 * `IsEmpty`: a typeclass that expresses that a type is empty.
 -/
 
-set_option autoImplicit true
-
-
 variable {α β γ : Sort*}
 
 /-- `IsEmpty α` expresses that `α` is empty. -/
@@ -108,6 +105,7 @@ namespace IsEmpty
 
 open Function
 
+universe u in
 /-- Eliminate out of a type that `IsEmpty` (using projection notation). -/
 @[elab_as_elim]
 protected def elim {α : Sort u} (_ : IsEmpty α) {p : α → Sort*} (a : α) : p a :=

--- a/Mathlib/Logic/Nonempty.lean
+++ b/Mathlib/Logic/Nonempty.lean
@@ -20,10 +20,7 @@ This file proves a few extra facts about `Nonempty`, which is defined in core Le
   instance.
 -/
 
-set_option autoImplicit true
-
-
-variable {γ : α → Type*}
+variable {α β : Type*} {γ : α → Type*}
 
 instance (priority := 20) Zero.instNonempty [Zero α] : Nonempty α :=
   ⟨0⟩

--- a/Mathlib/Logic/Relator.lean
+++ b/Mathlib/Logic/Relator.lean
@@ -12,8 +12,6 @@ import Mathlib.Init.Function
 # Relator for functions, pairs, sums, and lists.
 -/
 
-set_option autoImplicit true
-
 namespace Relator
 universe u₁ u₂ v₁ v₂
 
@@ -140,6 +138,9 @@ lemma rel_eq {r : α → β → Prop} (hr : BiUnique r) : (r ⇒ r ⇒ (·↔·)
 
 open Function
 
+variable {α : Type*} {r₁₁ : α → α → Prop} {r₁₂ : α → β → Prop} {r₂₁ : β → α → Prop}
+  {r₂₃ : β → γ → Prop} {r₁₃ : α → γ → Prop}
+
 namespace LeftTotal
 
 protected lemma refl (hr : ∀ a : α, r₁₁ a a) :
@@ -158,8 +159,7 @@ end LeftTotal
 
 namespace RightTotal
 
-protected lemma refl (hr : ∀ a : α, r₁₁ a a) :
-    RightTotal r₁₁ :=
+protected lemma refl (hr : ∀ a : α, r₁₁ a a) : RightTotal r₁₁ :=
   LeftTotal.refl hr
 
 protected lemma symm (hr : ∀ (a : α) (b : β), r₁₂ a b → r₂₁ b a) :

--- a/Mathlib/Logic/Small/Basic.lean
+++ b/Mathlib/Logic/Small/Basic.lean
@@ -14,9 +14,6 @@ import Mathlib.Logic.Equiv.Set
 In particular we prove `small_of_injective` and `small_of_surjective`.
 -/
 
-set_option autoImplicit true
-
-
 universe u w v v'
 
 section

--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -23,9 +23,6 @@ If `α ≃ β`, then `Small.{w} α ↔ Small.{w} β`.
 See `Mathlib.Logic.Small.Basic` for further instances and theorems.
 -/
 
-set_option autoImplicit true
-
-
 universe u w v v'
 
 /-- A type is `Small.{w}` if there exists an equivalence to some `S : Type w`.
@@ -64,7 +61,7 @@ theorem Shrink.ext {α : Type v} [Small.{w} α] {x y : Shrink α}
 -- https://github.com/JLimperg/aesop/issues/59
 -- is resolved.
 @[eliminator]
-protected noncomputable def Shrink.rec [Small.{w} α] {F : Shrink α → Sort v}
+protected noncomputable def Shrink.rec {α : Type*} [Small.{w} α] {F : Shrink α → Sort v}
     (h : ∀ X, F (equivShrink _ X)) : ∀ X, F X :=
   fun X => ((equivShrink _).apply_symm_apply X) ▸ (h _)
 

--- a/Mathlib/Logic/Unique.lean
+++ b/Mathlib/Logic/Unique.lean
@@ -42,8 +42,6 @@ for good definitional properties of the default term.
 
 -/
 
-set_option autoImplicit true
-
 universe u v w
 
 /-- `Unique α` expresses that `α` is a type with a unique term `default`.
@@ -115,7 +113,7 @@ open Function
 
 section
 
-variable [Unique α]
+variable {α : Sort*} [Unique α]
 
 -- see Note [lower instance priority]
 instance (priority := 100) : Inhabited α :=
@@ -143,6 +141,8 @@ theorem exists_iff {p : α → Prop} : Exists p ↔ p default :=
 
 end
 
+variable {α : Sort*}
+
 @[ext]
 protected theorem subsingleton_unique' : ∀ h₁ h₂ : Unique α, h₁ = h₂
   | ⟨⟨x⟩, h⟩, ⟨⟨y⟩, _⟩ => by congr; rw [h x, h y]
@@ -166,6 +166,8 @@ theorem unique_iff_subsingleton_and_nonempty (α : Sort u) :
    fun ⟨hs, hn⟩ ↦ ⟨by inhabit α; exact Unique.mk' α⟩⟩
 #align unique_iff_subsingleton_and_nonempty unique_iff_subsingleton_and_nonempty
 
+variable {α : Sort*}
+
 @[simp]
 theorem Pi.default_def {β : α → Sort v} [∀ a, Inhabited (β a)] :
     @default (∀ a, β a) _ = fun a : α ↦ @default (β a) _ :=
@@ -185,11 +187,11 @@ instance Pi.uniqueOfIsEmpty [IsEmpty α] (β : α → Sort v) : Unique (∀ a, �
   default := isEmptyElim
   uniq _ := funext isEmptyElim
 
-theorem eq_const_of_subsingleton [Subsingleton α] (f : α → β) (a : α) :
+theorem eq_const_of_subsingleton {β : Sort*} [Subsingleton α] (f : α → β) (a : α) :
     f = Function.const α (f a) :=
   funext fun x ↦ Subsingleton.elim x a ▸ rfl
 
-theorem eq_const_of_unique [Unique α] (f : α → β) : f = Function.const α (f default) :=
+theorem eq_const_of_unique {β : Sort*} [Unique α] (f : α → β) : f = Function.const α (f default) :=
   eq_const_of_subsingleton ..
 #align eq_const_of_unique eq_const_of_unique
 
@@ -200,7 +202,7 @@ theorem heq_const_of_unique [Unique α] {β : α → Sort v} (f : ∀ a, β a) :
 
 namespace Function
 
-variable {f : α → β}
+variable {β : Sort*} {f : α → β}
 
 /-- If the codomain of an injective function is a subsingleton, then the domain
 is a subsingleton as well. -/
@@ -216,7 +218,7 @@ protected theorem Surjective.subsingleton [Subsingleton α] (hf : Surjective f) 
 
 /-- If the domain of a surjective function is a singleton,
 then the codomain is a singleton as well. -/
-protected def Surjective.unique (f : α → β) (hf : Surjective f) [Unique.{u} α] : Unique β :=
+protected def Surjective.unique {α : Sort u} (f : α → β) (hf : Surjective f) [Unique.{u} α] : Unique β :=
   @Unique.mk' _ ⟨f default⟩ hf.subsingleton
 #align function.surjective.unique Function.Surjective.unique
 
@@ -246,7 +248,7 @@ theorem uniqueElim_default {_ : Unique ι} (x : α (default : ι)) : uniqueElim 
   rfl
 
 @[simp]
-theorem uniqueElim_const {_ : Unique ι} (x : β) (i : ι) : uniqueElim (α := fun _ ↦ β) x i = x :=
+theorem uniqueElim_const {ι β : Sort*} {_ : Unique ι} (x : β) (i : ι) : uniqueElim (α := fun _ ↦ β) x i = x :=
   rfl
 
 end Pi

--- a/Mathlib/Logic/Unique.lean
+++ b/Mathlib/Logic/Unique.lean
@@ -218,7 +218,8 @@ protected theorem Surjective.subsingleton [Subsingleton α] (hf : Surjective f) 
 
 /-- If the domain of a surjective function is a singleton,
 then the codomain is a singleton as well. -/
-protected def Surjective.unique {α : Sort u} (f : α → β) (hf : Surjective f) [Unique.{u} α] : Unique β :=
+protected def Surjective.unique {α : Sort u} (f : α → β) (hf : Surjective f) [Unique.{u} α] :
+    Unique β :=
   @Unique.mk' _ ⟨f default⟩ hf.subsingleton
 #align function.surjective.unique Function.Surjective.unique
 
@@ -238,6 +239,7 @@ end Function
 section Pi
 
 variable {ι : Sort*} {α : ι → Sort*}
+
 /-- Given one value over a unique, we get a dependent function. -/
 def uniqueElim [Unique ι] (x : α (default : ι)) (i : ι) : α i := by
   rw [Unique.eq_default i]
@@ -248,7 +250,8 @@ theorem uniqueElim_default {_ : Unique ι} (x : α (default : ι)) : uniqueElim 
   rfl
 
 @[simp]
-theorem uniqueElim_const {ι β : Sort*} {_ : Unique ι} (x : β) (i : ι) : uniqueElim (α := fun _ ↦ β) x i = x :=
+theorem uniqueElim_const {β : Sort*} {_ : Unique ι} (x : β) (i : ι) :
+    uniqueElim (α := fun _ ↦ β) x i = x :=
   rfl
 
 end Pi

--- a/Mathlib/Mathport/Notation.lean
+++ b/Mathlib/Mathport/Notation.lean
@@ -25,8 +25,6 @@ initialize registerTraceClass `notation3
 
 /-! ### Syntaxes supporting `notation3` -/
 
-set_option autoImplicit true
-
 /--
 Expands binders into nested combinators.
 For example, the familiar exists is given by:
@@ -116,6 +114,7 @@ def MatchState.empty : MatchState where
   scopeState := none
   foldState := {}
 
+set_option autoImplicit true in
 /-- Evaluate `f` with the given variable's value as the `SubExpr` and within that subexpression's
 saved context. Fails if the variable has no value. -/
 def MatchState.withVar (s : MatchState) (name : Name)

--- a/Mathlib/Mathport/Notation.lean
+++ b/Mathlib/Mathport/Notation.lean
@@ -114,10 +114,9 @@ def MatchState.empty : MatchState where
   scopeState := none
   foldState := {}
 
-set_option autoImplicit true in
 /-- Evaluate `f` with the given variable's value as the `SubExpr` and within that subexpression's
 saved context. Fails if the variable has no value. -/
-def MatchState.withVar (s : MatchState) (name : Name)
+def MatchState.withVar {α : Type} (s : MatchState) (name : Name)
     (m : DelabM α) : DelabM α := do
   let some (se, lctx, linsts) := s.vars.find? name | failure
   withLCtx lctx linsts <| withTheReader SubExpr (fun _ => se) <| m

--- a/Mathlib/Mathport/Rename.lean
+++ b/Mathlib/Mathport/Rename.lean
@@ -6,8 +6,6 @@ Authors: Daniel Selsam
 import Lean.Elab.Command
 import Lean.Linter.Util
 
-set_option autoImplicit true
-
 namespace Mathlib.Prelude.Rename
 
 open Lean
@@ -55,6 +53,7 @@ def RenameMap.insert (m : RenameMap) (e : NameEntry) : RenameMap :=
 /-- Look up a lean 4 name from the lean 3 name. Also return the `dubious` error message. -/
 def RenameMap.find? (m : RenameMap) : Name → Option (String × Name) := m.toLean4.find?
 
+set_option autoImplicit true in
 -- TODO: upstream into core/std
 instance [Inhabited α] : Inhabited (Thunk α) where
   default := .pure default
@@ -126,6 +125,7 @@ these reasons, you should use `#align` on any theorem that needs to be renamed f
 -/
 syntax (name := align) "#align " ident ppSpace ident : command
 
+set_option autoImplicit true in
 /-- Checks that `id` has not already been `#align`ed or `#noalign`ed. -/
 def ensureUnused [Monad m] [MonadEnv m] [MonadError m] (id : Name) : m Unit := do
   if let some (_, n) := (renameExtension.getState (← getEnv)).get.toLean4.find? id then

--- a/Mathlib/Mathport/Rename.lean
+++ b/Mathlib/Mathport/Rename.lean
@@ -125,9 +125,8 @@ these reasons, you should use `#align` on any theorem that needs to be renamed f
 -/
 syntax (name := align) "#align " ident ppSpace ident : command
 
-set_option autoImplicit true in
 /-- Checks that `id` has not already been `#align`ed or `#noalign`ed. -/
-def ensureUnused [Monad m] [MonadEnv m] [MonadError m] (id : Name) : m Unit := do
+def ensureUnused {m : Type → Type} [Monad m] [MonadEnv m] [MonadError m] (id : Name) : m Unit := do
   if let some (_, n) := (renameExtension.getState (← getEnv)).get.toLean4.find? id then
     if n.isAnonymous then
       throwError "{id} has already been no-aligned"


### PR DESCRIPTION
In one case, replacing this naively errored, so I just merged the single declaration using it.

Delete two unused variables in Logic/Basic.


---

Commits can be reviewed individually.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
