### PR TITLE
[Merged by Bors] - feat(NumberTheory/EulerProduct/Basic): use infinite products, golf

### DIFF
--- a/Mathlib/NumberTheory/EulerProduct/Basic.lean
+++ b/Mathlib/NumberTheory/EulerProduct/Basic.lean
@@ -13,7 +13,7 @@ import Mathlib.NumberTheory.SmoothNumbers
 
 The main result in this file is `EulerProduct.eulerProduct_hasProd`, which says that
 if `f : ℕ → R` is norm-summable, where `R` is a complete normed commutative ring and `f` is
-multiplicative on coprime arguments with `f 0 = 0` and `‖f ·‖` is summable, then
+multiplicative on coprime arguments with `f 0 = 0`, then
 `∏' p : Primes, ∑' e : ℕ, f (p^e)` converges to `∑' n, f n`.
 
 `ArithmeticFunction.IsMultiplicative.eulerProduct_hasProd` is a version
@@ -21,7 +21,7 @@ for multiplicative arithmetic functions in the sense of
 `ArithmeticFunction.IsMultiplicative`.
 
 There is also a version `EulerProduct.eulerProduct_completely_multiplicative_hasProd`,
-which states that `∏' p : Primes, (1 - f p)⁻¹` converges to `∑' n, f n` as `N`
+which states that `∏' p : Primes, (1 - f p)⁻¹` converges to `∑' n, f n`
 when `f` is completely multiplicative with values in a complete normed field `F`
 (implemented as `f : ℕ →*₀ F`).
 
@@ -91,10 +91,8 @@ lemma summable_and_hasSum_factoredNumbers_prod_filter_prime_tsum
   · rw [filter_insert]
     split_ifs with hpp
     · constructor
-      · rw [← (equivProdNatFactoredNumbers hpp hp).summable_iff, Function.comp_def]
-        conv =>
-          enter[1, x]
-          rw [equivProdNatFactoredNumbers_apply', factoredNumbers.map_prime_pow_mul hmul hpp hp]
+      · simp only [← (equivProdNatFactoredNumbers hpp hp).summable_iff, Function.comp_def, 
+          equivProdNatFactoredNumbers_apply', factoredNumbers.map_prime_pow_mul hmul hpp hp]
         refine Summable.of_nonneg_of_le (fun _ ↦ norm_nonneg _) (fun _ ↦ norm_mul_le ..) ?_
         apply summable_mul_of_summable_norm (f := fun x : ℕ ↦ ‖f (p ^ x)‖)
           (g := fun x : factoredNumbers s ↦ ‖f x.val‖) <;>

--- a/Mathlib/NumberTheory/EulerProduct/Basic.lean
+++ b/Mathlib/NumberTheory/EulerProduct/Basic.lean
@@ -11,26 +11,35 @@ import Mathlib.NumberTheory.SmoothNumbers
 /-!
 # Euler Products
 
-The main result in this file is `EulerProduct.eulerProduct`, which says that
+The main result in this file is `EulerProduct.eulerProduct_hasProd`, which says that
 if `f : ℕ → R` is norm-summable, where `R` is a complete normed commutative ring and `f` is
-multiplicative on coprime arguments with `f 0 = 0`, then
-`∏ p in primesBelow N, ∑' e : ℕ, f (p^e)` tends to `∑' n, f n` as `N` tends to infinity.
-`ArithmeticFunction.IsMultiplicative.eulerProduct` is a version of
-`EulerProduct.eulerProduct` for multiplicative arithmetic functions in the sense of
+multiplicative on coprime arguments with `f 0 = 0` and `‖f ·‖` is summable, then
+`∏' p : Primes, ∑' e : ℕ, f (p^e)` converges to `∑' n, f n`.
+
+`ArithmeticFunction.IsMultiplicative.eulerProduct_hasProd` is a version
+for multiplicative arithmetic functions in the sense of
 `ArithmeticFunction.IsMultiplicative`.
 
-There is also a version `EulerProduct.eulerProduct_completely_multiplicative`, which states that
-`∏ p in primesBelow N, (1 - f p)⁻¹` tends to `∑' n, f n` as `N` tends to infinity,
+There is also a version `EulerProduct.eulerProduct_completely_multiplicative_hasProd`,
+which states that `∏' p : Primes, (1 - f p)⁻¹` converges to `∑' n, f n` as `N`
 when `f` is completely multiplicative with values in a complete normed field `F`
 (implemented as `f : ℕ →*₀ F`).
 
-An intermediate step is `EulerProduct.summable_and_hasSum_smoothNumbers_prod_primesBelow_tsum`
-(and its variant `EulerProduct.summable_and_hasSum_smoothNumbers_prod_primesBelow_tsum_geometric`),
-which relates the finite product over primes to the sum of `f n` over `N`-smooth `n`.
+There are variants stating the equality of the infinite product and the infinite sum
+(`EulerProduct.eulerProduct_tprod`, `ArithmeticFunction.IsMultiplicative.eulerProduct_tprod`,
+`EulerProduct.eulerProduct_completely_multiplicative_tprod`) and also variants stating
+the convergence of the sequence of partial products over primes `< n`
+(`EulerProduct.eulerProduct`, `ArithmeticFunction.IsMultiplicative.eulerProduct`,
+`EulerProduct.eulerProduct_completely_multiplicative`.)
+
+An intermediate step is `EulerProduct.summable_and_hasSum_factoredNumbers_prod_filter_prime_tsum`
+(and its variant `EulerProduct.summable_and_hasSum_factoredNumbers_prod_filter_prime_geometric`),
+which relates the finite product over primes `p ∈ s` to the sum of `f n` over `s`-factored `n`,
+for `s : Finset ℕ`.
 
 ## Tags
 
-Euler product
+Euler product, multiplicative function
 -/
 
 /-- If `f` is multiplicative and summable, then its values at natural numbers `> 1`
@@ -44,9 +53,7 @@ lemma Summable.norm_lt_one {F : Type*} [NormedField F] [CompleteSpace F] {f : �
 
 open scoped Topology
 
-open Nat BigOperators
-
-namespace EulerProduct
+open Nat Finset BigOperators
 
 section General
 
@@ -60,36 +67,87 @@ where `R` is a complete normed commutative ring. The main result is `EulerProduc
 variable {R : Type*} [NormedCommRing R] [CompleteSpace R] {f : ℕ → R}
 variable (hf₁ : f 1 = 1) (hmul : ∀ {m n}, Nat.Coprime m n → f (m * n) = f m * f n)
 
+-- local instances to speed up typeclass search
+@[nolint defLemma docBlame] local instance : TopologicalSpace R := UniformSpace.toTopologicalSpace
+@[nolint defLemma docBlame] local instance : T0Space R := MetricSpace.instT0Space
+@[nolint defLemma docBlame] local instance : RegularSpace R := TopologicalAddGroup.regularSpace R
+@[nolint defLemma docBlame] local instance : TopologicalSpace.MetrizableSpace R :=
+  MetricSpace.toMetrizableSpace
+@[nolint defLemma docBlame] local instance : T2Space R :=
+  TopologicalSpace.t2Space_of_metrizableSpace
+
+namespace EulerProduct
+
+/-- We relate a finite product over primes in `s` to an infinite sum over `s`-factored numbers. -/
+lemma summable_and_hasSum_factoredNumbers_prod_filter_prime_tsum
+    (hsum : ∀ {p : ℕ}, p.Prime → Summable (fun n : ℕ ↦ ‖f (p ^ n)‖)) (s : Finset ℕ) :
+    Summable (fun m : factoredNumbers s ↦ ‖f m‖) ∧
+      HasSum (fun m : factoredNumbers s ↦ f m)
+        (∏ p in s.filter Nat.Prime, ∑' n : ℕ, f (p ^ n)) := by
+  induction' s using Finset.induction with p s hp ih
+  · rw [factoredNumbers_empty]
+    simp only [not_mem_empty, IsEmpty.forall_iff, forall_const, filter_true_of_mem, prod_empty]
+    exact ⟨(Set.finite_singleton 1).summable (‖f ·‖), hf₁ ▸ hasSum_singleton 1 f⟩
+  · rw [filter_insert]
+    split_ifs with hpp
+    · constructor
+      · rw [← (equivProdNatFactoredNumbers hpp hp).summable_iff, Function.comp_def]
+        conv =>
+          enter[1, x]
+          rw [equivProdNatFactoredNumbers_apply', factoredNumbers.map_prime_pow_mul hmul hpp hp]
+        refine Summable.of_nonneg_of_le (fun _ ↦ norm_nonneg _) (fun _ ↦ norm_mul_le ..) ?_
+        apply summable_mul_of_summable_norm (f := fun x : ℕ ↦ ‖f (p ^ x)‖)
+          (g := fun x : factoredNumbers s ↦ ‖f x.val‖) <;>
+          simp_rw [norm_norm]
+        exacts [hsum hpp, ih.1]
+      · have hp' : p ∉ s.filter Nat.Prime := mt (mem_of_mem_filter p) hp
+        rw [prod_insert hp', ← (equivProdNatFactoredNumbers hpp hp).hasSum_iff, Function.comp_def]
+        conv =>
+          enter [1, x]
+          rw [equivProdNatFactoredNumbers_apply', factoredNumbers.map_prime_pow_mul hmul hpp hp]
+        have : T3Space R := instT3Space -- speeds up the following
+        apply (hsum hpp).of_norm.hasSum.mul ih.2
+        -- `exact summable_mul_of_summable_norm (hsum hpp) ih.1` gives a time-out
+        convert summable_mul_of_summable_norm (hsum hpp) ih.1
+    · rwa [factoredNumbers_insert s hpp]
+
+/-- A version of `EulerProduct.summable_and_hasSum_factoredNumbers_prod_filter_prime_tsum`
+in terms of the value of the series. -/
+lemma prod_filter_prime_tsum_eq_tsum_factoredNumbers (hsum : Summable (‖f ·‖)) (s : Finset ℕ) :
+    ∏ p in s.filter Nat.Prime, ∑' n : ℕ, f (p ^ n) = ∑' m : factoredNumbers s, f m :=
+  (summable_and_hasSum_factoredNumbers_prod_filter_prime_tsum hf₁ hmul
+    (fun hp ↦ hsum.comp_injective <| Nat.pow_right_injective hp.one_lt) _).2.tsum_eq.symm
+
+/-- The following statement says that summing over `s`-factored numbers such that
+`s` contains `primesBelow N` for large enough `N` gets us arbitrarily close to the sum
+over all natural numbers (assuming `f` is summable and `f 0 = 0`; the latter since
+`0` is not `s`-factored). -/
+lemma norm_tsum_factoredNumbers_sub_tsum_lt (hsum : Summable f) (hf₀ : f 0 = 0) {ε : ℝ}
+    (εpos : 0 < ε) :
+    ∃ N : ℕ, ∀ s : Finset ℕ, primesBelow N ≤ s →
+      ‖(∑' m : ℕ, f m) - ∑' m : factoredNumbers s, f m‖ < ε := by
+  obtain ⟨N, hN⟩ :=
+    summable_iff_nat_tsum_vanishing.mp hsum (Metric.ball 0 ε) <| Metric.ball_mem_nhds 0 εpos
+  simp_rw [mem_ball_zero_iff] at hN
+  refine ⟨N, fun s hs ↦ ?_⟩
+  have := hN _ <| factoredNumbers_compl hs
+  rwa [← tsum_subtype_add_tsum_subtype_compl hsum (factoredNumbers s),
+    add_sub_cancel_left, tsum_eq_tsum_diff_singleton (factoredNumbers s)ᶜ hf₀]
+
+-- Versions of the three lemmas above for `smoothNumbers N`
+
 /-- We relate a finite product over primes to an infinite sum over smooth numbers. -/
 lemma summable_and_hasSum_smoothNumbers_prod_primesBelow_tsum
     (hsum : ∀ {p : ℕ}, p.Prime → Summable (fun n : ℕ ↦ ‖f (p ^ n)‖)) (N : ℕ) :
     Summable (fun m : N.smoothNumbers ↦ ‖f m‖) ∧
-      HasSum (fun m : N.smoothNumbers ↦ f m) (∏ p in N.primesBelow, ∑' (n : ℕ), f (p ^ n)) := by
-  induction' N with N ih
-  · rw [smoothNumbers_zero, primesBelow_zero, Finset.prod_empty]
-    exact ⟨(Set.finite_singleton 1).summable (‖f ·‖), hf₁ ▸ hasSum_singleton 1 f⟩
-  · rw [primesBelow_succ]
-    split_ifs with hN
-    · constructor
-      · simp_rw [← (equivProdNatSmoothNumbers hN).summable_iff, Function.comp_def,
-                 equivProdNatSmoothNumbers_apply', map_prime_pow_mul hmul hN]
-        refine Summable.of_nonneg_of_le (fun _ ↦ norm_nonneg _) (fun _ ↦ norm_mul_le ..) ?_
-        apply summable_mul_of_summable_norm (f := fun (x : ℕ) ↦ ‖f (N ^ x)‖)
-          (g := fun (x : N.smoothNumbers) ↦ ‖f x.val‖) <;>
-          simp_rw [norm_norm]
-        exacts [hsum hN, ih.1]
-      · simp_rw [Finset.prod_insert (not_mem_primesBelow N),
-                 ← (equivProdNatSmoothNumbers hN).hasSum_iff, Function.comp_def,
-                 equivProdNatSmoothNumbers_apply', map_prime_pow_mul hmul hN]
-        apply (hsum hN).of_norm.hasSum.mul ih.2
-        -- `exact summable_mul_of_summable_norm (hsum hN) ih.1` gives a time-out
-        convert summable_mul_of_summable_norm (hsum hN) ih.1
-    · rwa [smoothNumbers_succ hN]
+      HasSum (fun m : N.smoothNumbers ↦ f m) (∏ p in N.primesBelow, ∑' n : ℕ, f (p ^ n)) := by
+  rw [smoothNumbers_eq_factoredNumbers, primesBelow]
+  exact summable_and_hasSum_factoredNumbers_prod_filter_prime_tsum hf₁ hmul hsum _
 
 /-- A version of `EulerProduct.summable_and_hasSum_smoothNumbers_prod_primesBelow_tsum`
 in terms of the value of the series. -/
 lemma prod_primesBelow_tsum_eq_tsum_smoothNumbers (hsum : Summable (‖f ·‖)) (N : ℕ) :
-    ∏ p in N.primesBelow, ∑' (n : ℕ), f (p ^ n) = ∑' m : N.smoothNumbers, f m :=
+    ∏ p in N.primesBelow, ∑' n : ℕ, f (p ^ n) = ∑' m : N.smoothNumbers, f m :=
   (summable_and_hasSum_smoothNumbers_prod_primesBelow_tsum hf₁ hmul
     (fun hp ↦ hsum.comp_injective <| Nat.pow_right_injective hp.one_lt) _).2.tsum_eq.symm
 
@@ -98,44 +156,106 @@ for large enough `N` gets us arbitrarily close to the sum over all natural numbe
 (assuming `f` is norm-summable and `f 0 = 0`; the latter since `0` is not smooth). -/
 lemma norm_tsum_smoothNumbers_sub_tsum_lt (hsum : Summable f) (hf₀ : f 0 = 0)
     {ε : ℝ} (εpos : 0 < ε) :
-    ∃ N₀ : ℕ, ∀ N ≥ N₀, ‖(∑' m : ℕ, f m) - (∑' m : N.smoothNumbers, f m)‖ < ε := by
-  obtain ⟨N₀, hN₀⟩ :=
-    summable_iff_nat_tsum_vanishing.mp hsum (Metric.ball 0 ε) <| Metric.ball_mem_nhds 0 εpos
-  simp_rw [mem_ball_zero_iff] at hN₀
-  refine ⟨N₀, fun N hN₁ ↦ ?_⟩
-  convert hN₀ _ <| N.smoothNumbers_compl.trans fun _ ↦ hN₁.le.trans
-  simp_rw [← tsum_subtype_add_tsum_subtype_compl hsum N.smoothNumbers,
-    add_sub_cancel_left, tsum_eq_tsum_diff_singleton (N.smoothNumbers)ᶜ hf₀]
+    ∃ N₀ : ℕ, ∀ N ≥ N₀, ‖(∑' m : ℕ, f m) - ∑' m : N.smoothNumbers, f m‖ < ε := by
+  conv => enter [1, N₀, N]; rw [smoothNumbers_eq_factoredNumbers]
+  obtain ⟨N₀, hN₀⟩ := norm_tsum_factoredNumbers_sub_tsum_lt hsum hf₀ εpos
+  refine ⟨N₀, fun N hN ↦ hN₀ (range N) fun p hp ↦ ?_⟩
+  exact mem_range.mpr <| (lt_of_mem_primesBelow hp).trans_le hN
 
-open Filter
 
 /-- The *Euler Product* for multiplicative (on coprime arguments) functions.
-If `f : ℕ → R`, where `R` is a complete normed commutative ring, `f 0 = 0`,
-`f 1 = 1`, `f` is multiplicative on coprime arguments,
-and `‖f ·‖` is summable, then `∏' p : {p : ℕ | p.Prime}, ∑' e, f (p ^ e) = ∑' n, f n`.
-Since there are no infinite products yet in Mathlib, we state it in the form of
-convergence of finite partial products. -/
--- TODO: Change to use `∏'` once infinite products are in Mathlib
+
+If `f : ℕ → R`, where `R` is a complete normed commutative ring, `f 0 = 0`, `f 1 = 1`, `f` is
+multiplicative on coprime arguments, and `‖f ·‖` is summable, then
+`∏' p : Nat.Primes, ∑' e, f (p ^ e) = ∑' n, f n`. This version is stated using `HasProd`. -/
+theorem eulerProduct_hasProd (hsum : Summable (‖f ·‖)) (hf₀ : f 0 = 0) :
+    HasProd (fun p : Primes ↦ ∑' e, f (p ^ e)) (∑' n, f n) := by
+  let F : ℕ → R := fun n ↦ ∑' e, f (n ^ e)
+  change HasProd (F ∘ Subtype.val) _
+  rw [hasProd_subtype_iff_mulIndicator, HasProd, Metric.tendsto_atTop]
+  intro ε hε
+  obtain ⟨N₀, hN₀⟩ := norm_tsum_factoredNumbers_sub_tsum_lt hsum.of_norm hf₀ hε
+  refine ⟨range N₀, fun s hs ↦ ?_⟩
+  have : ∏ p in s, Set.mulIndicator (fun p ↦ Irreducible p) F p = ∏ p in s.filter Nat.Prime, F p :=
+    prod_mulIndicator_eq_prod_filter s (fun _ ↦ F) (fun _ ↦ {p | Nat.Prime p}) id
+  rw [this, dist_eq_norm, prod_filter_prime_tsum_eq_tsum_factoredNumbers hf₁ hmul hsum,
+    norm_sub_rev]
+  exact hN₀ s fun p hp ↦ hs <| mem_range.mpr <| lt_of_mem_primesBelow hp
+
+/-- The *Euler Product* for multiplicative (on coprime arguments) functions.
+
+If `f : ℕ → R`, where `R` is a complete normed commutative ring, `f 0 = 0`, `f 1 = 1`, `f` i
+multiplicative on coprime arguments, and `‖f ·‖` is summable, then
+`∏' p : ℕ, if p.Prime then ∑' e, f (p ^ e) else 1 = ∑' n, f n`.
+This version is stated using `HasProd` and `Set.mulIndicator`. -/
+theorem eulerProduct_hasProd_mulIndicator (hsum : Summable (‖f ·‖)) (hf₀ : f 0 = 0) :
+    HasProd (Set.mulIndicator {p | Nat.Prime p} fun p ↦  ∑' e, f (p ^ e)) (∑' n, f n) := by
+  rw [← hasProd_subtype_iff_mulIndicator]
+  exact eulerProduct_hasProd hf₁ hmul hsum hf₀
+
+open Filter in
+/-- The *Euler Product* for multiplicative (on coprime arguments) functions.
+
+If `f : ℕ → R`, where `R` is a complete normed commutative ring, `f 0 = 0`, `f 1 = 1`, `f` is
+multiplicative on coprime arguments, and `‖f ·‖` is summable, then
+`∏' p : {p : ℕ | p.Prime}, ∑' e, f (p ^ e) = ∑' n, f n`.
+This is a version using convergence of finite partial products. -/
 theorem eulerProduct (hsum : Summable (‖f ·‖)) (hf₀ : f 0 = 0) :
     Tendsto (fun n : ℕ ↦ ∏ p in primesBelow n, ∑' e, f (p ^ e)) atTop (𝓝 (∑' n, f n)) := by
-  rw [Metric.tendsto_nhds]
-  intro ε εpos
-  simp only [Finset.mem_range, eventually_atTop, ge_iff_le]
-  obtain ⟨N₀, hN₀⟩ := norm_tsum_smoothNumbers_sub_tsum_lt hsum.of_norm hf₀ εpos
-  use N₀
-  convert hN₀ using 3 with m
-  rw [dist_eq_norm, norm_sub_rev, prod_primesBelow_tsum_eq_tsum_smoothNumbers hf₁ hmul hsum m]
+  have := (eulerProduct_hasProd_mulIndicator hf₁ hmul hsum hf₀).tendsto_prod_nat
+  let F : ℕ → R := fun p ↦ ∑' (e : ℕ), f (p ^ e)
+  have H (n : ℕ) : ∏ i in range n, Set.mulIndicator {p | Nat.Prime p} F i =
+                     ∏ p in primesBelow n, ∑' (e : ℕ), f (p ^ e) :=
+    prod_mulIndicator_eq_prod_filter (range n) (fun _ ↦ F) (fun _ ↦ {p | Nat.Prime p}) id
+  simpa only [H]
+
+/-- The *Euler Product* for multiplicative (on coprime arguments) functions.
+
+If `f : ℕ → R`, where `R` is a complete normed commutative ring, `f 0 = 0`, `f 1 = 1`, `f` is
+multiplicative on coprime arguments, and `‖f ·‖` is summable, then
+`∏' p : {p : ℕ | p.Prime}, ∑' e, f (p ^ e) = ∑' n, f n`. -/
+theorem eulerProduct_tprod (hsum : Summable (‖f ·‖)) (hf₀ : f 0 = 0) :
+    ∏' p : Primes, ∑' e, f (p ^ e) = ∑' n, f n :=
+  (eulerProduct_hasProd hf₁ hmul hsum hf₀).tprod_eq
+
+end EulerProduct
+
+/-!
+### Versions for arithmetic functions
+-/
+
+namespace ArithmeticFunction
+
+open EulerProduct
 
 /-- The *Euler Product* for a multiplicative arithmetic function `f` with values in a
 complete normed commutative ring `R`: if `‖f ·‖` is summable, then
-`∏' p : {p : ℕ | p.Prime}, ∑' e, f (p ^ e) = ∑' n, f n`.
-Since there are no infinite products yet in Mathlib, we state it in the form of
-convergence of finite partial products. -/
--- TODO: Change to use `∏'` once infinite products are in Mathlib
-nonrec theorem _root_.ArithmeticFunction.IsMultiplicative.eulerProduct
-    {f : ArithmeticFunction R} (hf : f.IsMultiplicative) (hsum : Summable (‖f ·‖)) :
+`∏' p : Nat.Primes, ∑' e, f (p ^ e) = ∑' n, f n`.
+This version is stated in terms of `HasProd`. -/
+nonrec theorem IsMultiplicative.eulerProduct_hasProd {f : ArithmeticFunction R}
+    (hf : f.IsMultiplicative) (hsum : Summable (‖f ·‖)) :
+    HasProd (fun p : Primes ↦ ∑' e, f (p ^ e)) (∑' n, f n) :=
+  eulerProduct_hasProd hf.1 hf.2 hsum f.map_zero
+
+open Filter in
+/-- The *Euler Product* for a multiplicative arithmetic function `f` with values in a
+complete normed commutative ring `R`: if `‖f ·‖` is summable, then
+`∏' p : Nat.Primes, ∑' e, f (p ^ e) = ∑' n, f n`.
+This version is stated in the form of convergence of finite partial products. -/
+nonrec theorem IsMultiplicative.eulerProduct {f : ArithmeticFunction R} (hf : f.IsMultiplicative)
+    (hsum : Summable (‖f ·‖)) :
     Tendsto (fun n : ℕ ↦ ∏ p in primesBelow n, ∑' e, f (p ^ e)) atTop (𝓝 (∑' n, f n)) :=
   eulerProduct hf.1 hf.2 hsum f.map_zero
+
+/-- The *Euler Product* for a multiplicative arithmetic function `f` with values in a
+complete normed commutative ring `R`: if `‖f ·‖` is summable, then
+`∏' p : Nat.Primes, ∑' e, f (p ^ e) = ∑' n, f n`. -/
+nonrec theorem IsMultiplicative.eulerProduct_tprod {f : ArithmeticFunction R}
+    (hf : f.IsMultiplicative) (hsum : Summable (‖f ·‖)) :
+    ∏' p : Primes, ∑' e, f (p ^ e) = ∑' n, f n :=
+  eulerProduct_tprod hf.1 hf.2 hsum f.map_zero
+
+end ArithmeticFunction
 
 end General
 
@@ -146,10 +266,60 @@ section CompletelyMultiplicative
 
 We now assume that `f` is completely multiplicative and has values in a complete normed field `F`.
 Then we can use the formula for geometric series to simplify the statement. This leads to
-`EulerProduct.eulerProduct_completely_multiplicative`.
+`EulerProduct.eulerProduct_completely_multiplicative_hasProd` and variants.
 -/
 
 variable {F : Type*} [NormedField F] [CompleteSpace F]
+
+-- local instances to speed up typeclass search
+@[nolint defLemma docBlame] local instance : TopologicalSpace.MetrizableSpace F :=
+  MetricSpace.toMetrizableSpace
+@[nolint defLemma docBlame] local instance : T2Space F :=
+  TopologicalSpace.t2Space_of_metrizableSpace
+@[nolint defLemma docBlame] local instance : One F := Semiring.toOne
+@[nolint defLemma docBlame]  local instance : MonoidHomClass (ℕ →*₀ F) ℕ F :=
+  MonoidWithZeroHomClass.toMonoidHomClass
+
+namespace EulerProduct
+
+-- a helper lemma that is useful below
+lemma one_sub_inv_eq_geometric_of_summable_norm {f : ℕ →*₀ F} {p : ℕ} (hp : p.Prime)
+    (hsum : Summable fun x ↦ ‖f x‖) :
+    (1 - f p)⁻¹ = ∑' (e : ℕ), f (p ^ e) := by
+  simp only [map_pow]
+  refine (tsum_geometric_of_norm_lt_one <| summable_geometric_iff_norm_lt_one.mp ?_).symm
+  refine Summable.of_norm ?_
+  simpa only [Function.comp_def, map_pow]
+    using hsum.comp_injective <| Nat.pow_right_injective hp.one_lt
+
+/-- Given a (completely) multiplicative function `f : ℕ → F`, where `F` is a normed field,
+such that `‖f p‖ < 1` for all primes `p`, we can express the sum of `f n` over all `s`-factored
+positive integers `n` as a product of `(1 - f p)⁻¹` over the primes `p ∈ s`. At the same time,
+we show that the sum involved converges absolutely. -/
+lemma summable_and_hasSum_factoredNumbers_prod_filter_prime_geometric {f : ℕ →* F}
+    (h : ∀ {p : ℕ}, p.Prime → ‖f p‖ < 1) (s : Finset ℕ) :
+    Summable (fun m : factoredNumbers s ↦ ‖f m‖) ∧
+      HasSum (fun m : factoredNumbers s ↦ f m) (∏ p in s.filter Nat.Prime, (1 - f p)⁻¹) := by
+  have hmul {m n} (_ : Nat.Coprime m n) := f.map_mul m n
+  have H₁ :
+      ∏ p in s.filter Nat.Prime, ∑' n : ℕ, f (p ^ n) = ∏ p in s.filter Nat.Prime, (1 - f p)⁻¹ := by
+    refine prod_congr rfl fun p hp ↦ ?_
+    simp only [map_pow]
+    exact tsum_geometric_of_norm_lt_one <| h (mem_filter.mp hp).2
+  have H₂ : ∀ {p : ℕ}, p.Prime → Summable fun n ↦ ‖f (p ^ n)‖ := by
+    intro p hp
+    simp only [map_pow]
+    refine Summable.of_nonneg_of_le (fun _ ↦ norm_nonneg _) (fun _ ↦ norm_pow_le ..) ?_
+    exact summable_geometric_iff_norm_lt_one.mpr <| (norm_norm (f p)).symm ▸ h hp
+  exact H₁ ▸ summable_and_hasSum_factoredNumbers_prod_filter_prime_tsum f.map_one hmul H₂ s
+
+/-- A version of `EulerProduct.summable_and_hasSum_factoredNumbers_prod_filter_prime_geometric`
+in terms of the value of the series. -/
+lemma prod_filter_prime_geometric_eq_tsum_factoredNumbers {f : ℕ →* F} (hsum : Summable f)
+    (s : Finset ℕ) :
+    ∏ p in s.filter Nat.Prime, (1 - f p)⁻¹ = ∑' m : factoredNumbers s, f m := by
+  refine (summable_and_hasSum_factoredNumbers_prod_filter_prime_geometric ?_ s).2.tsum_eq.symm
+  exact fun {_} hp ↦ hsum.norm_lt_one hp.one_lt
 
 /-- Given a (completely) multiplicative function `f : ℕ → F`, where `F` is a normed field,
 such that `‖f p‖ < 1` for all primes `p`, we can express the sum of `f n` over all `N`-smooth
@@ -159,37 +329,55 @@ lemma summable_and_hasSum_smoothNumbers_prod_primesBelow_geometric {f : ℕ →*
     (h : ∀ {p : ℕ}, p.Prime → ‖f p‖ < 1) (N : ℕ) :
     Summable (fun m : N.smoothNumbers ↦ ‖f m‖) ∧
       HasSum (fun m : N.smoothNumbers ↦ f m) (∏ p in N.primesBelow, (1 - f p)⁻¹) := by
-  have hmul {m n} (_ : Nat.Coprime m n) := f.map_mul m n
-  convert summable_and_hasSum_smoothNumbers_prod_primesBelow_tsum f.map_one hmul ?_ N with M hM <;>
-    simp_rw [map_pow]
-  · exact (tsum_geometric_of_norm_lt_one <| h <| prime_of_mem_primesBelow hM).symm
-  · intro p hp
-    refine Summable.of_nonneg_of_le (fun _ ↦ norm_nonneg _) (fun _ ↦ norm_pow_le ..) ?_
-    exact summable_geometric_iff_norm_lt_one.mpr <| (norm_norm (f p)).symm ▸ h hp
+  rw [smoothNumbers_eq_factoredNumbers, primesBelow]
+  exact summable_and_hasSum_factoredNumbers_prod_filter_prime_geometric h _
 
 /-- A version of `EulerProduct.summable_and_hasSum_smoothNumbers_prod_primesBelow_geometric`
 in terms of the value of the series. -/
 lemma prod_primesBelow_geometric_eq_tsum_smoothNumbers {f : ℕ →* F} (hsum : Summable f) (N : ℕ) :
     ∏ p in N.primesBelow, (1 - f p)⁻¹ = ∑' m : N.smoothNumbers, f m := by
-  refine (summable_and_hasSum_smoothNumbers_prod_primesBelow_geometric ?_ N).2.tsum_eq.symm
-  exact fun {_} hp ↦ hsum.norm_lt_one hp.one_lt
+  rw [smoothNumbers_eq_factoredNumbers, primesBelow]
+  exact prod_filter_prime_geometric_eq_tsum_factoredNumbers hsum _
+
+/-- The *Euler Product* for completely multiplicative functions.
+
+If `f : ℕ →*₀ F`, where `F` is a complete normed field and `‖f ·‖` is summable, then
+`∏' p : Nat.Primes, (1 - f p)⁻¹ = ∑' n, f n`.
+This version is stated in terms of `HasProd`. -/
+theorem eulerProduct_completely_multiplicative_hasProd {f : ℕ →*₀ F} (hsum : Summable (‖f ·‖)) :
+    HasProd (fun p : Primes ↦ (1 - f p)⁻¹) (∑' n, f n) := by
+  have H : (fun p : Primes ↦ (1 - f p)⁻¹) = fun p : Primes ↦ ∑' (e : ℕ), f (p ^ e) :=
+    funext <| fun p ↦ one_sub_inv_eq_geometric_of_summable_norm p.prop hsum
+  simpa only [map_pow, H]
+    using eulerProduct_hasProd f.map_one (fun {m n} _ ↦ f.map_mul m n) hsum f.map_zero
+
+/-- The *Euler Product* for completely multiplicative functions.
+
+If `f : ℕ →*₀ F`, where `F` is a complete normed field and `‖f ·‖` is summable, then
+`∏' p : Nat.Primes, (1 - f p)⁻¹ = ∑' n, f n`. -/
+theorem eulerProduct_completely_multiplicative_tprod {f : ℕ →*₀ F} (hsum : Summable (‖f ·‖)) :
+    ∏' p : Primes, (1 - f p)⁻¹ = ∑' n, f n :=
+  (eulerProduct_completely_multiplicative_hasProd hsum).tprod_eq
 
 open Filter in
 /-- The *Euler Product* for completely multiplicative functions.
-If `f : ℕ →*₀ F`, where `F` is a complete normed field
-and `‖f ·‖` is summable, then `∏' p : {p : ℕ | p.Prime}, (1 - f p)⁻¹ = ∑' n, f n`.
-Since there are no infinite products yet in Mathlib, we state it in the form of
-convergence of finite partial products. -/
--- TODO: Change to use `∏'` once infinite products are in Mathlib
-theorem eulerProduct_completely_multiplicative {f : ℕ →*₀ F} (hsum : Summable fun x => ‖f x‖) :
-    Tendsto (fun n : ℕ ↦ ∏ p in primesBelow n, (1 - f p)⁻¹) atTop (𝓝 (∑' n, f n)) := by
-  convert eulerProduct f.map_one (fun {m n} _ ↦ f.map_mul m n) hsum f.map_zero with N p hN
-  simp_rw [map_pow]
-  refine (tsum_geometric_of_norm_lt_one <| summable_geometric_iff_norm_lt_one.mp ?_).symm
-  refine Summable.of_norm ?_
-  convert hsum.comp_injective <| Nat.pow_right_injective (prime_of_mem_primesBelow hN).one_lt
-  simp only [norm_pow, Function.comp_apply, map_pow]
 
-end CompletelyMultiplicative
+If `f : ℕ →*₀ F`, where `F` is a complete normed field and `‖f ·‖` is summable, then
+`∏' p : Nat.Primes, (1 - f p)⁻¹ = ∑' n, f n`.
+This version is stated in the form of convergence of finite partial products. -/
+theorem eulerProduct_completely_multiplicative {f : ℕ →*₀ F} (hsum : Summable (‖f ·‖)) :
+    Tendsto (fun n : ℕ ↦ ∏ p in primesBelow n, (1 - f p)⁻¹) atTop (𝓝 (∑' n, f n)) := by
+  have hmul {m n} (_ : Nat.Coprime m n) := f.map_mul m n
+  have := (eulerProduct_hasProd_mulIndicator f.map_one hmul hsum f.map_zero).tendsto_prod_nat
+  have H (n : ℕ) : ∏ p in range n, {p | Nat.Prime p}.mulIndicator (fun p ↦ (1 - f p)⁻¹) p =
+                     ∏ p in primesBelow n, (1 - f p)⁻¹ :=
+    prod_mulIndicator_eq_prod_filter
+      (range n) (fun _ ↦ fun p ↦ (1 - f p)⁻¹) (fun _ ↦ {p | Nat.Prime p}) id
+  have H' : {p | Nat.Prime p}.mulIndicator (fun p ↦ (1 - f p)⁻¹) =
+              {p | Nat.Prime p}.mulIndicator (fun p ↦ ∑' e : ℕ, f (p ^ e)) :=
+    Set.mulIndicator_congr fun p hp ↦ one_sub_inv_eq_geometric_of_summable_norm hp hsum
+  simpa only [← H, H'] using this
 
 end EulerProduct
+
+end CompletelyMultiplicative

--- a/Mathlib/NumberTheory/EulerProduct/Basic.lean
+++ b/Mathlib/NumberTheory/EulerProduct/Basic.lean
@@ -67,14 +67,9 @@ where `R` is a complete normed commutative ring. The main result is `EulerProduc
 variable {R : Type*} [NormedCommRing R] [CompleteSpace R] {f : ℕ → R}
 variable (hf₁ : f 1 = 1) (hmul : ∀ {m n}, Nat.Coprime m n → f (m * n) = f m * f n)
 
--- local instances to speed up typeclass search
-@[nolint defLemma docBlame] local instance : TopologicalSpace R := UniformSpace.toTopologicalSpace
-@[nolint defLemma docBlame] local instance : T0Space R := MetricSpace.instT0Space
-@[nolint defLemma docBlame] local instance : RegularSpace R := TopologicalAddGroup.regularSpace R
-@[nolint defLemma docBlame] local instance : TopologicalSpace.MetrizableSpace R :=
-  MetricSpace.toMetrizableSpace
-@[nolint defLemma docBlame] local instance : T2Space R :=
-  TopologicalSpace.t2Space_of_metrizableSpace
+-- local instance to speed up typeclass search
+@[nolint defLemma docBlame] -- workaround for linter bug
+local instance : T0Space R := MetricSpace.instT0Space
 
 namespace EulerProduct
 
@@ -267,15 +262,6 @@ Then we can use the formula for geometric series to simplify the statement. This
 -/
 
 variable {F : Type*} [NormedField F] [CompleteSpace F]
-
--- local instances to speed up typeclass search
-@[nolint defLemma docBlame] local instance : TopologicalSpace.MetrizableSpace F :=
-  MetricSpace.toMetrizableSpace
-@[nolint defLemma docBlame] local instance : T2Space F :=
-  TopologicalSpace.t2Space_of_metrizableSpace
-@[nolint defLemma docBlame] local instance : One F := Semiring.toOne
-@[nolint defLemma docBlame]  local instance : MonoidHomClass (ℕ →*₀ F) ℕ F :=
-  MonoidWithZeroHomClass.toMonoidHomClass
 
 namespace EulerProduct
 

--- a/Mathlib/NumberTheory/EulerProduct/Basic.lean
+++ b/Mathlib/NumberTheory/EulerProduct/Basic.lean
@@ -68,8 +68,7 @@ variable {R : Type*} [NormedCommRing R] [CompleteSpace R] {f : ℕ → R}
 variable (hf₁ : f 1 = 1) (hmul : ∀ {m n}, Nat.Coprime m n → f (m * n) = f m * f n)
 
 -- local instance to speed up typeclass search
-@[nolint defLemma docBlame] -- workaround for linter bug
-local instance : T0Space R := MetricSpace.instT0Space
+@[local instance] private lemma instT0Space : T0Space R := MetricSpace.instT0Space
 
 namespace EulerProduct
 

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -2056,7 +2056,7 @@ a T₂.₅ space.  -/
 class T3Space (X : Type u) [TopologicalSpace X] extends T0Space X, RegularSpace X : Prop
 #align t3_space T3Space
 
-instance (priority := 90) [T0Space X] [RegularSpace X] : T3Space X := ⟨⟩
+instance (priority := 90) instT3Space [T0Space X] [RegularSpace X] : T3Space X := ⟨⟩
 
 theorem RegularSpace.t3Space_iff_t0Space [RegularSpace X] : T3Space X ↔ T0Space X := by
   constructor <;> intro <;> infer_instance


### PR DESCRIPTION
This adds versions of the various Euler product statements in terms of the new topological products, namely `HasProd (fun p : Primes ↦ ∑' e, f (p ^ e)) (∑' n, f n)` and `∏' p : Primes, ∑' e, f (p ^ e) = ∑' n, f n` (and similar for completely multiplicative `f` in terms of `(1 - f p)⁻¹`).

At the same time, I have reworked the proofs to some extent (in particular removing a few slow `convert`s). I also added a bunch of local instances that speed up instance synthesis by a factor of 2 (from 1.4 to 0.7 seconds on my laptop).

Unfortunately, this means that the diff is fairly large.

See [here](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/L-series/near/432666616) and [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Infinite.20products/near/431508883) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
