### PR TITLE
[Merged by Bors] - doc(Order): fix join/meet inversion for lattices

### DIFF
--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -14,9 +14,9 @@ import Mathlib.Tactic.GCongr.Core
 /-!
 # (Semi-)lattices
 
-Semilattices are partially ordered sets with join (greatest lower bound, or `sup`) or
-meet (least upper bound, or `inf`) operations. Lattices are posets that are both
-join-semilattices and meet-semilattices.
+Semilattices are partially ordered sets with join (least upper bound, or `sup`) or meet (greatest
+lower bound, or `inf`) operations. Lattices are posets that are both join-semilattices and
+meet-semilattices.
 
 Distributive lattices are lattices which satisfy any of four equivalent distributivity properties,
 of `sup` over `inf`, on the left or on the right.


### PR DESCRIPTION
Currently, this doc-string describes [Mathlib.Order.Lattice](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/Lattice.html): 
> Semilattices are partially ordered sets with join (greatest lower bound, or sup) or meet (least upper bound, or inf) operations.

It seems to be the other way around: https://en.wikipedia.org/wiki/Semilattice

This commit fixes this.