### PR TITLE
feat(Data/Matrix/Basic): add notation for `m×n`-Matrices

### DIFF
--- a/Mathlib/Algebra/Lie/CartanMatrix.lean
+++ b/Mathlib/Algebra/Lie/CartanMatrix.lean
@@ -207,7 +207,7 @@ The corresponding Dynkin diagram is:
 o --- o --- o --- o --- o
 ```
 -/
-def E₆ : Matrix (Fin 6) (Fin 6) ℤ :=
+def E₆ : Mat[6,6][ℤ] :=
   !![2, 0, -1, 0, 0, 0;
     0, 2, 0, -1, 0, 0;
     -1, 0, 2, -1, 0, 0;
@@ -225,7 +225,7 @@ The corresponding Dynkin diagram is:
 o --- o --- o --- o --- o --- o
 ```
 -/
-def E₇ : Matrix (Fin 7) (Fin 7) ℤ :=
+def E₇ : Mat[7,7][ℤ] :=
   !![2, 0, -1, 0, 0, 0, 0;
     0, 2, 0, -1, 0, 0, 0;
     -1, 0, 2, -1, 0, 0, 0;
@@ -244,7 +244,7 @@ The corresponding Dynkin diagram is:
 o --- o --- o --- o --- o --- o --- o
 ```
 -/
-def E₈ : Matrix (Fin 8) (Fin 8) ℤ :=
+def E₈ : Mat[8,8][ℤ] :=
   !![2, 0, -1, 0, 0, 0, 0, 0;
     0, 2, 0, -1, 0, 0, 0, 0;
     -1, 0, 2, -1, 0, 0, 0, 0;
@@ -262,7 +262,7 @@ The corresponding Dynkin diagram is:
 o --- o =>= o --- o
 ```
 -/
-def F₄ : Matrix (Fin 4) (Fin 4) ℤ :=
+def F₄ : Mat[4,4][ℤ] :=
   !![2, -1, 0, 0; -1, 2, -2, 0; 0, -1, 2, -1; 0, 0, -1, 2]
 #align cartan_matrix.F₄ CartanMatrix.F₄
 
@@ -274,7 +274,7 @@ o ≡>≡ o
 ```
 Actually we are using the transpose of Bourbaki's matrix. This is to make this matrix consistent
 with `CartanMatrix.F₄`, in the sense that all non-zero values below the diagonal are -1. -/
-def G₂ : Matrix (Fin 2) (Fin 2) ℤ :=
+def G₂ : Mat[2,2][ℤ] :=
   !![2, -3; -1, 2]
 #align cartan_matrix.G₂ CartanMatrix.G₂
 

--- a/Mathlib/Algebra/Lie/CartanMatrix.lean
+++ b/Mathlib/Algebra/Lie/CartanMatrix.lean
@@ -207,7 +207,7 @@ The corresponding Dynkin diagram is:
 o --- o --- o --- o --- o
 ```
 -/
-def E₆ : Mat[6,6][ℤ] :=
+def E₆ : Mat[6, 6][ℤ] :=
   !![2, 0, -1, 0, 0, 0;
     0, 2, 0, -1, 0, 0;
     -1, 0, 2, -1, 0, 0;
@@ -225,7 +225,7 @@ The corresponding Dynkin diagram is:
 o --- o --- o --- o --- o --- o
 ```
 -/
-def E₇ : Mat[7,7][ℤ] :=
+def E₇ : Mat[7, 7][ℤ] :=
   !![2, 0, -1, 0, 0, 0, 0;
     0, 2, 0, -1, 0, 0, 0;
     -1, 0, 2, -1, 0, 0, 0;
@@ -244,7 +244,7 @@ The corresponding Dynkin diagram is:
 o --- o --- o --- o --- o --- o --- o
 ```
 -/
-def E₈ : Mat[8,8][ℤ] :=
+def E₈ : Mat[8, 8][ℤ] :=
   !![2, 0, -1, 0, 0, 0, 0, 0;
     0, 2, 0, -1, 0, 0, 0, 0;
     -1, 0, 2, -1, 0, 0, 0, 0;
@@ -262,7 +262,7 @@ The corresponding Dynkin diagram is:
 o --- o =>= o --- o
 ```
 -/
-def F₄ : Mat[4,4][ℤ] :=
+def F₄ : Mat[4, 4][ℤ] :=
   !![2, -1, 0, 0; -1, 2, -2, 0; 0, -1, 2, -1; 0, 0, -1, 2]
 #align cartan_matrix.F₄ CartanMatrix.F₄
 
@@ -274,7 +274,7 @@ o ≡>≡ o
 ```
 Actually we are using the transpose of Bourbaki's matrix. This is to make this matrix consistent
 with `CartanMatrix.F₄`, in the sense that all non-zero values below the diagonal are -1. -/
-def G₂ : Mat[2,2][ℤ] :=
+def G₂ : Mat[2, 2][ℤ] :=
   !![2, -3; -1, 2]
 #align cartan_matrix.G₂ CartanMatrix.G₂
 

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -39,9 +39,9 @@ attribute [-instance] Matrix.GeneralLinearGroup.instCoeFun
 
 local notation "GL(" n ", " R ")" "⁺" => Matrix.GLPos (Fin n) R
 local notation:1024 "↑ₘ" A:1024 =>
-  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) _)
+  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Mat[2,2][_])
 local notation:1024 "↑ₘ[" R "]" A:1024 =>
-  ((A : GL (Fin 2) R) : Matrix (Fin 2) (Fin 2) R)
+  ((A : GL (Fin 2) R) : Mat[2,2][R])
 
 /-- The open upper half plane -/
 def UpperHalfPlane :=
@@ -211,7 +211,7 @@ theorem denom_ne_zero (g : GL(2, ℝ)⁺) (z : ℍ) : denom g z ≠ 0 := by
   cases' H1 with H1
   · simp only [H1, Complex.ofReal_zero, denom, zero_mul, zero_add,
       Complex.ofReal_eq_zero] at H
-    rw [Matrix.det_fin_two (↑ₘg : Matrix (Fin 2) (Fin 2) ℝ)] at DET
+    rw [Matrix.det_fin_two (↑ₘg : Mat[2,2][ℝ])] at DET
     simp only [H, H1, mul_zero, sub_zero, lt_self_iff_false] at DET
   · change z.im > 0 at hz
     linarith
@@ -239,7 +239,7 @@ theorem smulAux'_im (g : GL(2, ℝ)⁺) (z : ℍ) :
   rw [smulAux', Complex.div_im]
   field_simp [smulAux', num, denom]
   -- Porting note: the local notation still didn't work here
-  rw [Matrix.det_fin_two ((g : GL (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) ℝ)]
+  rw [Matrix.det_fin_two ((g : GL (Fin 2) ℝ) : Mat[2,2][ℝ])]
   ring
 #align upper_half_plane.smul_aux'_im UpperHalfPlane.smulAux'_im
 
@@ -442,7 +442,7 @@ nonrec theorem im_smul_eq_div_normSq :
 #align upper_half_plane.special_linear_group.im_smul_eq_div_norm_sq UpperHalfPlane.ModularGroup.im_smul_eq_div_normSq
 
 theorem denom_apply (g : SL(2, ℤ)) (z : ℍ) :
-    denom g z = (↑g : Matrix (Fin 2) (Fin 2) ℤ) 1 0 * z + (↑g : Matrix (Fin 2) (Fin 2) ℤ) 1 1 := by
+    denom g z = (↑g : Mat[2,2][ℤ]) 1 0 * z + (↑g : Mat[2,2][ℤ]) 1 1 := by
   simp [denom, coe']
 #align upper_half_plane.denom_apply UpperHalfPlane.ModularGroup.denom_apply
 

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -39,9 +39,9 @@ attribute [-instance] Matrix.GeneralLinearGroup.instCoeFun
 
 local notation "GL(" n ", " R ")" "⁺" => Matrix.GLPos (Fin n) R
 local notation:1024 "↑ₘ" A:1024 =>
-  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Mat[2,2][_])
+  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Mat[2, 2][_])
 local notation:1024 "↑ₘ[" R "]" A:1024 =>
-  ((A : GL (Fin 2) R) : Mat[2,2][R])
+  ((A : GL (Fin 2) R) : Mat[2, 2][R])
 
 /-- The open upper half plane -/
 def UpperHalfPlane :=
@@ -211,7 +211,7 @@ theorem denom_ne_zero (g : GL(2, ℝ)⁺) (z : ℍ) : denom g z ≠ 0 := by
   cases' H1 with H1
   · simp only [H1, Complex.ofReal_zero, denom, zero_mul, zero_add,
       Complex.ofReal_eq_zero] at H
-    rw [Matrix.det_fin_two (↑ₘg : Mat[2,2][ℝ])] at DET
+    rw [Matrix.det_fin_two (↑ₘg : Mat[2, 2][ℝ])] at DET
     simp only [H, H1, mul_zero, sub_zero, lt_self_iff_false] at DET
   · change z.im > 0 at hz
     linarith
@@ -239,7 +239,7 @@ theorem smulAux'_im (g : GL(2, ℝ)⁺) (z : ℍ) :
   rw [smulAux', Complex.div_im]
   field_simp [smulAux', num, denom]
   -- Porting note: the local notation still didn't work here
-  rw [Matrix.det_fin_two ((g : GL (Fin 2) ℝ) : Mat[2,2][ℝ])]
+  rw [Matrix.det_fin_two ((g : GL (Fin 2) ℝ) : Mat[2, 2][ℝ])]
   ring
 #align upper_half_plane.smul_aux'_im UpperHalfPlane.smulAux'_im
 
@@ -442,7 +442,7 @@ nonrec theorem im_smul_eq_div_normSq :
 #align upper_half_plane.special_linear_group.im_smul_eq_div_norm_sq UpperHalfPlane.ModularGroup.im_smul_eq_div_normSq
 
 theorem denom_apply (g : SL(2, ℤ)) (z : ℍ) :
-    denom g z = (↑g : Mat[2,2][ℤ]) 1 0 * z + (↑g : Mat[2,2][ℤ]) 1 1 := by
+    denom g z = (↑g : Mat[2, 2][ℤ]) 1 0 * z + (↑g : Mat[2, 2][ℤ]) 1 1 := by
   simp [denom, coe']
 #align upper_half_plane.denom_apply UpperHalfPlane.ModularGroup.denom_apply
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -25,7 +25,7 @@ This file defines basic properties of matrices.
 
 Matrices with rows indexed by `m`, columns indexed by `n`, and entries of type `α` are represented
 with `Matrix m n α`. For the typical approach of counting rows and columns,
-`Matrix (Fin m) (Fin n) α` can be used.
+`Mat[a,b][α]` (i.e. `Matrix (Fin a) (Fin b) α`) can be used for `(a b : ℕ)`.
 
 ## Notation
 
@@ -65,6 +65,10 @@ variable {l m n o : Type*} {m' : o → Type*} {n' : o → Type*}
 variable {R : Type*} {S : Type*} {α : Type v} {β : Type w} {γ : Type*}
 
 namespace Matrix
+
+/-- Notation for `m x n`-Matrices, where `(m n : ℕ)`.
+Short form of `Matrix (Fin m) (Fin n) α`. -/
+notation (name := concreteMatrix) "Mat["m","n"]["α"]" => Matrix (Fin m) (Fin n) α
 
 section Ext
 
@@ -972,7 +976,7 @@ theorem sum_apply [AddCommMonoid α] (i : m) (j : n) (s : Finset β) (g : β →
   (congr_fun (s.sum_apply i g) j).trans (s.sum_apply j _)
 #align matrix.sum_apply Matrix.sum_apply
 
-theorem two_mul_expl {R : Type*} [CommRing R] (A B : Matrix (Fin 2) (Fin 2) R) :
+theorem two_mul_expl {R : Type*} [CommRing R] (A B : Mat[2,2][R]) :
     (A * B) 0 0 = A 0 0 * B 0 0 + A 0 1 * B 1 0 ∧
     (A * B) 0 1 = A 0 0 * B 0 1 + A 0 1 * B 1 1 ∧
     (A * B) 1 0 = A 1 0 * B 0 0 + A 1 1 * B 1 0 ∧
@@ -2653,53 +2657,53 @@ theorem submatrix_mul_transpose_submatrix [Fintype m] [Fintype n] [AddCommMonoid
 
 /-- The left `n × l` part of an `n × (l+r)` matrix. -/
 @[reducible]
-def subLeft {m l r : Nat} (A : Matrix (Fin m) (Fin (l + r)) α) : Matrix (Fin m) (Fin l) α :=
+def subLeft {m l r : Nat} (A : Mat[m,(l + r)][α]) : Mat[m,l][α] :=
   submatrix A id (Fin.castAdd r)
 #align matrix.sub_left Matrix.subLeft
 
 /-- The right `n × r` part of an `n × (l+r)` matrix. -/
 @[reducible]
-def subRight {m l r : Nat} (A : Matrix (Fin m) (Fin (l + r)) α) : Matrix (Fin m) (Fin r) α :=
+def subRight {m l r : Nat} (A : Mat[m,(l + r)][α]) : Mat[m,r][α] :=
   submatrix A id (Fin.natAdd l)
 #align matrix.sub_right Matrix.subRight
 
 /-- The top `u × n` part of a `(u+d) × n` matrix. -/
 @[reducible]
-def subUp {d u n : Nat} (A : Matrix (Fin (u + d)) (Fin n) α) : Matrix (Fin u) (Fin n) α :=
+def subUp {d u n : Nat} (A : Mat[(u + d),n][α]) : Mat[u,n][α] :=
   submatrix A (Fin.castAdd d) id
 #align matrix.sub_up Matrix.subUp
 
 /-- The bottom `d × n` part of a `(u+d) × n` matrix. -/
 @[reducible]
-def subDown {d u n : Nat} (A : Matrix (Fin (u + d)) (Fin n) α) : Matrix (Fin d) (Fin n) α :=
+def subDown {d u n : Nat} (A : Mat[(u + d),n][α]) : Mat[d,n][α] :=
   submatrix A (Fin.natAdd u) id
 #align matrix.sub_down Matrix.subDown
 
 /-- The top-right `u × r` part of a `(u+d) × (l+r)` matrix. -/
 @[reducible]
-def subUpRight {d u l r : Nat} (A : Matrix (Fin (u + d)) (Fin (l + r)) α) :
-    Matrix (Fin u) (Fin r) α :=
+def subUpRight {d u l r : Nat} (A : Mat[(u + d),(l + r)][α]) :
+    Mat[u,r][α] :=
   subUp (subRight A)
 #align matrix.sub_up_right Matrix.subUpRight
 
 /-- The bottom-right `d × r` part of a `(u+d) × (l+r)` matrix. -/
 @[reducible]
-def subDownRight {d u l r : Nat} (A : Matrix (Fin (u + d)) (Fin (l + r)) α) :
-    Matrix (Fin d) (Fin r) α :=
+def subDownRight {d u l r : Nat} (A : Mat[(u + d),(l + r)][α]) :
+    Mat[d,r][α] :=
   subDown (subRight A)
 #align matrix.sub_down_right Matrix.subDownRight
 
 /-- The top-left `u × l` part of a `(u+d) × (l+r)` matrix. -/
 @[reducible]
-def subUpLeft {d u l r : Nat} (A : Matrix (Fin (u + d)) (Fin (l + r)) α) :
-    Matrix (Fin u) (Fin l) α :=
+def subUpLeft {d u l r : Nat} (A : Mat[(u + d),(l + r)][α]) :
+    Mat[u,l][α] :=
   subUp (subLeft A)
 #align matrix.sub_up_left Matrix.subUpLeft
 
 /-- The bottom-left `d × l` part of a `(u+d) × (l+r)` matrix. -/
 @[reducible]
-def subDownLeft {d u l r : Nat} (A : Matrix (Fin (u + d)) (Fin (l + r)) α) :
-    Matrix (Fin d) (Fin l) α :=
+def subDownLeft {d u l r : Nat} (A : Mat[(u + d),(l + r)][α]) :
+    Mat[d,l][α] :=
   subDown (subLeft A)
 #align matrix.sub_down_left Matrix.subDownLeft
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -25,7 +25,7 @@ This file defines basic properties of matrices.
 
 Matrices with rows indexed by `m`, columns indexed by `n`, and entries of type `α` are represented
 with `Matrix m n α`. For the typical approach of counting rows and columns,
-`Mat[a,b][α]` (i.e. `Matrix (Fin a) (Fin b) α`) can be used for `(a b : ℕ)`.
+`Mat[a, b][α]` (i.e. `Matrix (Fin a) (Fin b) α`) can be used for `(a b : ℕ)`.
 
 ## Notation
 
@@ -976,7 +976,7 @@ theorem sum_apply [AddCommMonoid α] (i : m) (j : n) (s : Finset β) (g : β →
   (congr_fun (s.sum_apply i g) j).trans (s.sum_apply j _)
 #align matrix.sum_apply Matrix.sum_apply
 
-theorem two_mul_expl {R : Type*} [CommRing R] (A B : Mat[2,2][R]) :
+theorem two_mul_expl {R : Type*} [CommRing R] (A B : Mat[2, 2][R]) :
     (A * B) 0 0 = A 0 0 * B 0 0 + A 0 1 * B 1 0 ∧
     (A * B) 0 1 = A 0 0 * B 0 1 + A 0 1 * B 1 1 ∧
     (A * B) 1 0 = A 1 0 * B 0 0 + A 1 1 * B 1 0 ∧
@@ -2657,53 +2657,53 @@ theorem submatrix_mul_transpose_submatrix [Fintype m] [Fintype n] [AddCommMonoid
 
 /-- The left `n × l` part of an `n × (l+r)` matrix. -/
 @[reducible]
-def subLeft {m l r : Nat} (A : Mat[m,(l + r)][α]) : Mat[m,l][α] :=
+def subLeft {m l r : Nat} (A : Mat[m, (l + r)][α]) : Mat[m, l][α] :=
   submatrix A id (Fin.castAdd r)
 #align matrix.sub_left Matrix.subLeft
 
 /-- The right `n × r` part of an `n × (l+r)` matrix. -/
 @[reducible]
-def subRight {m l r : Nat} (A : Mat[m,(l + r)][α]) : Mat[m,r][α] :=
+def subRight {m l r : Nat} (A : Mat[m, (l + r)][α]) : Mat[m, r][α] :=
   submatrix A id (Fin.natAdd l)
 #align matrix.sub_right Matrix.subRight
 
 /-- The top `u × n` part of a `(u+d) × n` matrix. -/
 @[reducible]
-def subUp {d u n : Nat} (A : Mat[(u + d),n][α]) : Mat[u,n][α] :=
+def subUp {d u n : Nat} (A : Mat[u + d, n][α]) : Mat[u, n][α] :=
   submatrix A (Fin.castAdd d) id
 #align matrix.sub_up Matrix.subUp
 
 /-- The bottom `d × n` part of a `(u+d) × n` matrix. -/
 @[reducible]
-def subDown {d u n : Nat} (A : Mat[(u + d),n][α]) : Mat[d,n][α] :=
+def subDown {d u n : Nat} (A : Mat[u + d, n][α]) : Mat[d, n][α] :=
   submatrix A (Fin.natAdd u) id
 #align matrix.sub_down Matrix.subDown
 
 /-- The top-right `u × r` part of a `(u+d) × (l+r)` matrix. -/
 @[reducible]
-def subUpRight {d u l r : Nat} (A : Mat[(u + d),(l + r)][α]) :
-    Mat[u,r][α] :=
+def subUpRight {d u l r : Nat} (A : Mat[u + d, l + r][α]) :
+    Mat[u, r][α] :=
   subUp (subRight A)
 #align matrix.sub_up_right Matrix.subUpRight
 
 /-- The bottom-right `d × r` part of a `(u+d) × (l+r)` matrix. -/
 @[reducible]
-def subDownRight {d u l r : Nat} (A : Mat[(u + d),(l + r)][α]) :
-    Mat[d,r][α] :=
+def subDownRight {d u l r : Nat} (A : Mat[u + d, l + r][α]) :
+    Mat[d, r][α] :=
   subDown (subRight A)
 #align matrix.sub_down_right Matrix.subDownRight
 
 /-- The top-left `u × l` part of a `(u+d) × (l+r)` matrix. -/
 @[reducible]
-def subUpLeft {d u l r : Nat} (A : Mat[(u + d),(l + r)][α]) :
-    Mat[u,l][α] :=
+def subUpLeft {d u l r : Nat} (A : Mat[u + d, l + r][α]) :
+    Mat[u, l][α] :=
   subUp (subLeft A)
 #align matrix.sub_up_left Matrix.subUpLeft
 
 /-- The bottom-left `d × l` part of a `(u+d) × (l+r)` matrix. -/
 @[reducible]
-def subDownLeft {d u l r : Nat} (A : Mat[(u + d),(l + r)][α]) :
-    Mat[d,l][α] :=
+def subDownLeft {d u l r : Nat} (A : Mat[u + d, l + r][α]) :
+    Mat[d, l][α] :=
   subDown (subLeft A)
 #align matrix.sub_down_left Matrix.subDownLeft
 

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -18,8 +18,8 @@ of the matrix notation `![a, b] = vecCons a (vecCons b vecEmpty)` defined in
 `Data.Fin.VecNotation`.
 
 This also provides the new notation `!![a, b; c, d] = Matrix.of ![![a, b], ![c, d]]`.
-This notation also works for empty matrices; `!![,,,] : Matrix (Fin 0) (Fin 3)` and
-`!![;;;] : Matrix (Fin 3) (Fin 0)`.
+This notation also works for empty matrices; `!![,,,] : Mat[0,3][α]` and
+`!![;;;] : Mat[3,0][α]`.
 
 ## Implementation notes
 
@@ -72,18 +72,18 @@ end toExpr
 section Parser
 open Lean Elab Term Macro TSyntax
 
-/-- Notation for m×n matrices, aka `Matrix (Fin m) (Fin n) α`.
+/-- Notation for m×n matrices, aka `Mat[m,n][α]`.
 
 For instance:
 * `!![a, b, c; d, e, f]` is the matrix with two rows and three columns, of type
-  `Matrix (Fin 2) (Fin 3) α`
-* `!![a, b, c]` is a row vector of type `Matrix (Fin 1) (Fin 3) α` (see also `Matrix.row`).
-* `!![a; b; c]` is a column vector of type `Matrix (Fin 3) (Fin 1) α` (see also `Matrix.col`).
+  `Mat[2,3][α]`
+* `!![a, b, c]` is a row vector of type `Mat[1,3][α]` (see also `Matrix.row`).
+* `!![a; b; c]` is a column vector of type `Mat[3,1][α]` (see also `Matrix.col`).
 
 This notation implements some special cases:
 
-* `![,,]`, with `n` `,`s, is a term of type `Matrix (Fin 0) (Fin n) α`
-* `![;;]`, with `m` `;`s, is a term of type `Matrix (Fin m) (Fin 0) α`
+* `![,,]`, with `n` `,`s, is a term of type `Mat[0,n][α]`
+* `![;;]`, with `m` `;`s, is a term of type `Mat[m,0][α]`
 * `![]` is the 0×0 matrix
 
 Note that vector notation is provided elsewhere (by `Matrix.vecNotation`) as `![a, b, c]`.
@@ -124,7 +124,7 @@ variable (a b : ℕ)
 #eval !![1, 2; 3, 4] + !![3, 4; 5, 6]  -- !![4, 6; 8, 10]
 ```
 -/
-instance repr [Repr α] : Repr (Matrix (Fin m) (Fin n) α) where
+instance repr [Repr α] : Repr (Mat[m,n][α]) where
   reprPrec f _p :=
     (Std.Format.bracket "!![" · "]") <|
       (Std.Format.joinSep · (";" ++ Std.Format.line)) <|
@@ -418,12 +418,12 @@ section One
 
 variable [Zero α] [One α]
 
-theorem one_fin_two : (1 : Matrix (Fin 2) (Fin 2) α) = !![1, 0; 0, 1] := by
+theorem one_fin_two : (1 : Mat[2,2][α]) = !![1, 0; 0, 1] := by
   ext i j
   fin_cases i <;> fin_cases j <;> rfl
 #align matrix.one_fin_two Matrix.one_fin_two
 
-theorem one_fin_three : (1 : Matrix (Fin 3) (Fin 3) α) = !![1, 0, 0; 0, 1, 0; 0, 0, 1] := by
+theorem one_fin_three : (1 : Mat[3,3][α]) = !![1, 0, 0; 0, 1, 0; 0, 0, 1] := by
   ext i j
   fin_cases i <;> fin_cases j <;> rfl
 #align matrix.one_fin_three Matrix.one_fin_three
@@ -433,35 +433,35 @@ end One
 section AddMonoidWithOne
 variable [AddMonoidWithOne α]
 
-theorem natCast_fin_two (n : ℕ) : (n : Matrix (Fin 2) (Fin 2) α) = !![↑n, 0; 0, ↑n] := by
+theorem natCast_fin_two (n : ℕ) : (n : Mat[2,2][α]) = !![↑n, 0; 0, ↑n] := by
   ext i j
   fin_cases i <;> fin_cases j <;> rfl
 
 theorem natCast_fin_three (n : ℕ) :
-    (n : Matrix (Fin 3) (Fin 3) α) = !![↑n, 0, 0; 0, ↑n, 0; 0, 0, ↑n] := by
+    (n : Mat[3,3][α]) = !![↑n, 0, 0; 0, ↑n, 0; 0, 0, ↑n] := by
   ext i j
   fin_cases i <;> fin_cases j <;> rfl
 
 -- See note [no_index around OfNat.ofNat]
 theorem ofNat_fin_two (n : ℕ) [n.AtLeastTwo] :
-    (no_index (OfNat.ofNat n) : Matrix (Fin 2) (Fin 2) α) =
+    (no_index (OfNat.ofNat n) : Mat[2,2][α]) =
       !![OfNat.ofNat n, 0; 0, OfNat.ofNat n] :=
   natCast_fin_two _
 
 -- See note [no_index around OfNat.ofNat]
 theorem ofNat_fin_three (n : ℕ) [n.AtLeastTwo] :
-    (no_index (OfNat.ofNat n) : Matrix (Fin 3) (Fin 3) α) =
+    (no_index (OfNat.ofNat n) : Mat[3,3][α]) =
       !![OfNat.ofNat n, 0, 0; 0, OfNat.ofNat n, 0; 0, 0, OfNat.ofNat n] :=
   natCast_fin_three _
 
 end AddMonoidWithOne
 
-theorem eta_fin_two (A : Matrix (Fin 2) (Fin 2) α) : A = !![A 0 0, A 0 1; A 1 0, A 1 1] := by
+theorem eta_fin_two (A : Mat[2,2][α]) : A = !![A 0 0, A 0 1; A 1 0, A 1 1] := by
   ext i j
   fin_cases i <;> fin_cases j <;> rfl
 #align matrix.eta_fin_two Matrix.eta_fin_two
 
-theorem eta_fin_three (A : Matrix (Fin 3) (Fin 3) α) :
+theorem eta_fin_three (A : Mat[3,3][α]) :
     A = !![A 0 0, A 0 1, A 0 2;
            A 1 0, A 1 1, A 1 2;
            A 2 0, A 2 1, A 2 2] := by

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -18,8 +18,8 @@ of the matrix notation `![a, b] = vecCons a (vecCons b vecEmpty)` defined in
 `Data.Fin.VecNotation`.
 
 This also provides the new notation `!![a, b; c, d] = Matrix.of ![![a, b], ![c, d]]`.
-This notation also works for empty matrices; `!![,,,] : Mat[0,3][α]` and
-`!![;;;] : Mat[3,0][α]`.
+This notation also works for empty matrices; `!![,,,] : Mat[0, 3][α]` and
+`!![;;;] : Mat[3, 0][α]`.
 
 ## Implementation notes
 
@@ -72,18 +72,18 @@ end toExpr
 section Parser
 open Lean Elab Term Macro TSyntax
 
-/-- Notation for m×n matrices, aka `Mat[m,n][α]`.
+/-- Notation for m×n matrices, aka `Mat[m, n][α]`.
 
 For instance:
 * `!![a, b, c; d, e, f]` is the matrix with two rows and three columns, of type
-  `Mat[2,3][α]`
-* `!![a, b, c]` is a row vector of type `Mat[1,3][α]` (see also `Matrix.row`).
-* `!![a; b; c]` is a column vector of type `Mat[3,1][α]` (see also `Matrix.col`).
+  `Mat[2, 3][α]`
+* `!![a, b, c]` is a row vector of type `Mat[1, 3][α]` (see also `Matrix.row`).
+* `!![a; b; c]` is a column vector of type `Mat[3, 1][α]` (see also `Matrix.col`).
 
 This notation implements some special cases:
 
-* `![,,]`, with `n` `,`s, is a term of type `Mat[0,n][α]`
-* `![;;]`, with `m` `;`s, is a term of type `Mat[m,0][α]`
+* `![,,]`, with `n` `,`s, is a term of type `Mat[0, n][α]`
+* `![;;]`, with `m` `;`s, is a term of type `Mat[m, 0][α]`
 * `![]` is the 0×0 matrix
 
 Note that vector notation is provided elsewhere (by `Matrix.vecNotation`) as `![a, b, c]`.
@@ -124,7 +124,7 @@ variable (a b : ℕ)
 #eval !![1, 2; 3, 4] + !![3, 4; 5, 6]  -- !![4, 6; 8, 10]
 ```
 -/
-instance repr [Repr α] : Repr (Mat[m,n][α]) where
+instance repr [Repr α] : Repr (Mat[m, n][α]) where
   reprPrec f _p :=
     (Std.Format.bracket "!![" · "]") <|
       (Std.Format.joinSep · (";" ++ Std.Format.line)) <|
@@ -418,12 +418,12 @@ section One
 
 variable [Zero α] [One α]
 
-theorem one_fin_two : (1 : Mat[2,2][α]) = !![1, 0; 0, 1] := by
+theorem one_fin_two : (1 : Mat[2, 2][α]) = !![1, 0; 0, 1] := by
   ext i j
   fin_cases i <;> fin_cases j <;> rfl
 #align matrix.one_fin_two Matrix.one_fin_two
 
-theorem one_fin_three : (1 : Mat[3,3][α]) = !![1, 0, 0; 0, 1, 0; 0, 0, 1] := by
+theorem one_fin_three : (1 : Mat[3, 3][α]) = !![1, 0, 0; 0, 1, 0; 0, 0, 1] := by
   ext i j
   fin_cases i <;> fin_cases j <;> rfl
 #align matrix.one_fin_three Matrix.one_fin_three
@@ -433,35 +433,35 @@ end One
 section AddMonoidWithOne
 variable [AddMonoidWithOne α]
 
-theorem natCast_fin_two (n : ℕ) : (n : Mat[2,2][α]) = !![↑n, 0; 0, ↑n] := by
+theorem natCast_fin_two (n : ℕ) : (n : Mat[2, 2][α]) = !![↑n, 0; 0, ↑n] := by
   ext i j
   fin_cases i <;> fin_cases j <;> rfl
 
 theorem natCast_fin_three (n : ℕ) :
-    (n : Mat[3,3][α]) = !![↑n, 0, 0; 0, ↑n, 0; 0, 0, ↑n] := by
+    (n : Mat[3, 3][α]) = !![↑n, 0, 0; 0, ↑n, 0; 0, 0, ↑n] := by
   ext i j
   fin_cases i <;> fin_cases j <;> rfl
 
 -- See note [no_index around OfNat.ofNat]
 theorem ofNat_fin_two (n : ℕ) [n.AtLeastTwo] :
-    (no_index (OfNat.ofNat n) : Mat[2,2][α]) =
+    (no_index (OfNat.ofNat n) : Mat[2, 2][α]) =
       !![OfNat.ofNat n, 0; 0, OfNat.ofNat n] :=
   natCast_fin_two _
 
 -- See note [no_index around OfNat.ofNat]
 theorem ofNat_fin_three (n : ℕ) [n.AtLeastTwo] :
-    (no_index (OfNat.ofNat n) : Mat[3,3][α]) =
+    (no_index (OfNat.ofNat n) : Mat[3, 3][α]) =
       !![OfNat.ofNat n, 0, 0; 0, OfNat.ofNat n, 0; 0, 0, OfNat.ofNat n] :=
   natCast_fin_three _
 
 end AddMonoidWithOne
 
-theorem eta_fin_two (A : Mat[2,2][α]) : A = !![A 0 0, A 0 1; A 1 0, A 1 1] := by
+theorem eta_fin_two (A : Mat[2, 2][α]) : A = !![A 0 0, A 0 1; A 1 0, A 1 1] := by
   ext i j
   fin_cases i <;> fin_cases j <;> rfl
 #align matrix.eta_fin_two Matrix.eta_fin_two
 
-theorem eta_fin_three (A : Mat[3,3][α]) :
+theorem eta_fin_three (A : Mat[3, 3][α]) :
     A = !![A 0 0, A 0 1, A 0 2;
            A 1 0, A 1 1, A 1 2;
            A 2 0, A 2 1, A 2 2] := by

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -63,7 +63,7 @@ theorem rank_le_card_width [StrongRankCondition R] (A : Matrix m n R) :
   exact A.mulVecLin.finrank_range_le.trans_eq (finrank_pi _)
 #align matrix.rank_le_card_width Matrix.rank_le_card_width
 
-theorem rank_le_width [StrongRankCondition R] {m n : ℕ} (A : Matrix (Fin m) (Fin n) R) :
+theorem rank_le_width [StrongRankCondition R] {m n : ℕ} (A : Mat[m,n][R]) :
     A.rank ≤ n :=
   A.rank_le_card_width.trans <| (Fintype.card_fin n).le
 #align matrix.rank_le_width Matrix.rank_le_width
@@ -170,7 +170,7 @@ theorem rank_le_card_height [Fintype m] [StrongRankCondition R] (A : Matrix m n 
   exact (Submodule.finrank_le _).trans (finrank_pi R).le
 #align matrix.rank_le_card_height Matrix.rank_le_card_height
 
-theorem rank_le_height [StrongRankCondition R] {m n : ℕ} (A : Matrix (Fin m) (Fin n) R) :
+theorem rank_le_height [StrongRankCondition R] {m n : ℕ} (A : Mat[m,n][R]) :
     A.rank ≤ m :=
   A.rank_le_card_height.trans <| (Fintype.card_fin m).le
 #align matrix.rank_le_height Matrix.rank_le_height

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -63,7 +63,7 @@ theorem rank_le_card_width [StrongRankCondition R] (A : Matrix m n R) :
   exact A.mulVecLin.finrank_range_le.trans_eq (finrank_pi _)
 #align matrix.rank_le_card_width Matrix.rank_le_card_width
 
-theorem rank_le_width [StrongRankCondition R] {m n : ℕ} (A : Mat[m,n][R]) :
+theorem rank_le_width [StrongRankCondition R] {m n : ℕ} (A : Mat[m, n][R]) :
     A.rank ≤ n :=
   A.rank_le_card_width.trans <| (Fintype.card_fin n).le
 #align matrix.rank_le_width Matrix.rank_le_width
@@ -170,7 +170,7 @@ theorem rank_le_card_height [Fintype m] [StrongRankCondition R] (A : Matrix m n 
   exact (Submodule.finrank_le _).trans (finrank_pi R).le
 #align matrix.rank_le_card_height Matrix.rank_le_card_height
 
-theorem rank_le_height [StrongRankCondition R] {m n : ℕ} (A : Mat[m,n][R]) :
+theorem rank_le_height [StrongRankCondition R] {m n : ℕ} (A : Mat[m, n][R]) :
     A.rank ≤ m :=
   A.rank_le_card_height.trans <| (Fintype.card_fin m).le
 #align matrix.rank_le_height Matrix.rank_le_height

--- a/Mathlib/Data/Matrix/Reflection.lean
+++ b/Mathlib/Data/Matrix/Reflection.lean
@@ -10,7 +10,7 @@ import Mathlib.Data.Fin.Tuple.Reflection
 #align_import data.matrix.reflection from "leanprover-community/mathlib"@"820b22968a2bc4a47ce5cf1d2f36a9ebe52510aa"
 
 /-!
-# Lemmas for concrete matrices `Matrix (Fin m) (Fin n) α`
+# Lemmas for concrete matrices `Mat[m,n][α`]
 
 This file contains alternative definitions of common operators on matrices that expand
 definitionally to the expected expression when evaluated on `!![]` notation.
@@ -40,56 +40,56 @@ namespace Matrix
 
 variable {l m n : ℕ} {α β : Type*}
 
-/-- `∀` with better defeq for `∀ x : Matrix (Fin m) (Fin n) α, P x`. -/
-def Forall : ∀ {m n} (_ : Matrix (Fin m) (Fin n) α → Prop), Prop
+/-- `∀` with better defeq for `∀ x : Mat[m,n][α,] P x`. -/
+def Forall : ∀ {m n} (_ : Mat[m,n][α] → Prop), Prop
   | 0, _, P => P (of ![])
   | _ + 1, _, P => FinVec.Forall fun r => Forall fun A => P (of (Matrix.vecCons r A))
 #align matrix.forall Matrix.Forall
 
 /-- This can be use to prove
 ```lean
-example (P : Matrix (Fin 2) (Fin 3) α → Prop) :
+example (P : Mat[2,3][α] → Prop) :
   (∀ x, P x) ↔ ∀ a b c d e f, P !![a, b, c; d, e, f] :=
 (forall_iff _).symm
 ```
 -/
-theorem forall_iff : ∀ {m n} (P : Matrix (Fin m) (Fin n) α → Prop), Forall P ↔ ∀ x, P x
+theorem forall_iff : ∀ {m n} (P : Mat[m,n][α] → Prop), Forall P ↔ ∀ x, P x
   | 0, n, P => Iff.symm Fin.forall_fin_zero_pi
   | m + 1, n, P => by
     simp only [Forall, FinVec.forall_iff, forall_iff]
     exact Iff.symm Fin.forall_fin_succ_pi
 #align matrix.forall_iff Matrix.forall_iff
 
-example (P : Matrix (Fin 2) (Fin 3) α → Prop) :
+example (P : Mat[2,3][α] → Prop) :
     (∀ x, P x) ↔ ∀ a b c d e f, P !![a, b, c; d, e, f] :=
   (forall_iff _).symm
 
-/-- `∃` with better defeq for `∃ x : Matrix (Fin m) (Fin n) α, P x`. -/
-def Exists : ∀ {m n} (_ : Matrix (Fin m) (Fin n) α → Prop), Prop
+/-- `∃` with better defeq for `∃ x : Mat[m,n][α,] P x`. -/
+def Exists : ∀ {m n} (_ : Mat[m,n][α] → Prop), Prop
   | 0, _, P => P (of ![])
   | _ + 1, _, P => FinVec.Exists fun r => Exists fun A => P (of (Matrix.vecCons r A))
 #align matrix.exists Matrix.Exists
 
 /-- This can be use to prove
 ```lean
-example (P : Matrix (Fin 2) (Fin 3) α → Prop) :
+example (P : Mat[2,3][α] → Prop) :
   (∃ x, P x) ↔ ∃ a b c d e f, P !![a, b, c; d, e, f] :=
 (exists_iff _).symm
 ```
 -/
-theorem exists_iff : ∀ {m n} (P : Matrix (Fin m) (Fin n) α → Prop), Exists P ↔ ∃ x, P x
+theorem exists_iff : ∀ {m n} (P : Mat[m,n][α] → Prop), Exists P ↔ ∃ x, P x
   | 0, n, P => Iff.symm Fin.exists_fin_zero_pi
   | m + 1, n, P => by
     simp only [Exists, FinVec.exists_iff, exists_iff]
     exact Iff.symm Fin.exists_fin_succ_pi
 #align matrix.exists_iff Matrix.exists_iff
 
-example (P : Matrix (Fin 2) (Fin 3) α → Prop) :
+example (P : Mat[2,3][α] → Prop) :
     (∃ x, P x) ↔ ∃ a b c d e f, P !![a, b, c; d, e, f] :=
   (exists_iff _).symm
 
 /-- `Matrix.transpose` with better defeq for `Fin` -/
-def transposeᵣ : ∀ {m n}, Matrix (Fin m) (Fin n) α → Matrix (Fin n) (Fin m) α
+def transposeᵣ : ∀ {m n}, Mat[m,n][α] → Mat[n,m][α]
   | _, 0, _ => of ![]
   | _, _ + 1, A =>
     of <| vecCons (FinVec.map (fun v : Fin _ → α => v 0) A) (transposeᵣ (A.submatrix id Fin.succ))
@@ -101,7 +101,7 @@ example (a b c d : α) : transpose !![a, b; c, d] = !![a, c; b, d] := (transpose
 ```
 -/
 @[simp]
-theorem transposeᵣ_eq : ∀ {m n} (A : Matrix (Fin m) (Fin n) α), transposeᵣ A = transpose A
+theorem transposeᵣ_eq : ∀ {m n} (A : Mat[m,n][α]), transposeᵣ A = transpose A
   | _, 0, A => Subsingleton.elim _ _
   | m, n + 1, A =>
     Matrix.ext fun i j => by
@@ -139,8 +139,8 @@ example (a b c d : α) [Mul α] [AddCommMonoid α] : dotProduct ![a, b] ![c, d] 
   (dotProductᵣ_eq _ _).symm
 
 /-- `Matrix.mul` with better defeq for `Fin` -/
-def mulᵣ [Mul α] [Add α] [Zero α] (A : Matrix (Fin l) (Fin m) α) (B : Matrix (Fin m) (Fin n) α) :
-    Matrix (Fin l) (Fin n) α :=
+def mulᵣ [Mul α] [Add α] [Zero α] (A : Mat[l,m][α]) (B : Mat[m,n][α]) :
+    Mat[l,n][α] :=
   of <| FinVec.map (fun v₁ => FinVec.map (fun v₂ => dotProductᵣ v₁ v₂) Bᵀ) A
 #align matrix.mulᵣ Matrix.mulᵣ
 
@@ -156,8 +156,8 @@ example [AddCommMonoid α] [Mul α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁₁ b�
 ```
 -/
 @[simp]
-theorem mulᵣ_eq [Mul α] [AddCommMonoid α] (A : Matrix (Fin l) (Fin m) α)
-    (B : Matrix (Fin m) (Fin n) α) : mulᵣ A B = A * B := by
+theorem mulᵣ_eq [Mul α] [AddCommMonoid α] (A : Mat[l,m][α])
+    (B : Mat[m,n][α]) : mulᵣ A B = A * B := by
   simp [mulᵣ, Function.comp, Matrix.transpose]
   rfl
 #align matrix.mulᵣ_eq Matrix.mulᵣ_eq
@@ -169,7 +169,7 @@ example [AddCommMonoid α] [Mul α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁₁ b�
   (mulᵣ_eq _ _).symm
 
 /-- `Matrix.mulVec` with better defeq for `Fin` -/
-def mulVecᵣ [Mul α] [Add α] [Zero α] (A : Matrix (Fin l) (Fin m) α) (v : Fin m → α) : Fin l → α :=
+def mulVecᵣ [Mul α] [Add α] [Zero α] (A : Mat[l,m][α]) (v : Fin m → α) : Fin l → α :=
   FinVec.map (fun a => dotProductᵣ a v) A
 #align matrix.mul_vecᵣ Matrix.mulVecᵣ
 
@@ -182,7 +182,7 @@ example [NonUnitalNonAssocSemiring α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁ b�
 ```
 -/
 @[simp]
-theorem mulVecᵣ_eq [NonUnitalNonAssocSemiring α] (A : Matrix (Fin l) (Fin m) α) (v : Fin m → α) :
+theorem mulVecᵣ_eq [NonUnitalNonAssocSemiring α] (A : Mat[l,m][α]) (v : Fin m → α) :
     mulVecᵣ A v = A *ᵥ v := by
   simp [mulVecᵣ, Function.comp]
   rfl
@@ -193,7 +193,7 @@ example [NonUnitalNonAssocSemiring α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁ b�
   (mulVecᵣ_eq _ _).symm
 
 /-- `Matrix.vecMul` with better defeq for `Fin` -/
-def vecMulᵣ [Mul α] [Add α] [Zero α] (v : Fin l → α) (A : Matrix (Fin l) (Fin m) α) : Fin m → α :=
+def vecMulᵣ [Mul α] [Add α] [Zero α] (v : Fin l → α) (A : Mat[l,m][α]) : Fin m → α :=
   FinVec.map (fun a => dotProductᵣ v a) Aᵀ
 #align matrix.vec_mulᵣ Matrix.vecMulᵣ
 
@@ -206,7 +206,7 @@ example [NonUnitalNonAssocSemiring α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁ b�
 ```
 -/
 @[simp]
-theorem vecMulᵣ_eq [NonUnitalNonAssocSemiring α] (v : Fin l → α) (A : Matrix (Fin l) (Fin m) α) :
+theorem vecMulᵣ_eq [NonUnitalNonAssocSemiring α] (v : Fin l → α) (A : Mat[l,m][α]) :
     vecMulᵣ v A = v ᵥ* A := by
   simp [vecMulᵣ, Function.comp]
   rfl
@@ -217,25 +217,25 @@ example [NonUnitalNonAssocSemiring α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁ b�
   (vecMulᵣ_eq _ _).symm
 
 /-- Expand `A` to `!![A 0 0, ...; ..., A m n]` -/
-def etaExpand {m n} (A : Matrix (Fin m) (Fin n) α) : Matrix (Fin m) (Fin n) α :=
+def etaExpand {m n} (A : Mat[m,n][α]) : Mat[m,n][α] :=
   Matrix.of (FinVec.etaExpand fun i => FinVec.etaExpand fun j => A i j)
 #align matrix.eta_expand Matrix.etaExpand
 
 /-- This can be used to prove
 ```lean
-example (A : Matrix (Fin 2) (Fin 2) α) :
+example (A : Mat[2,2][α]) :
   A = !![A 0 0, A 0 1;
          A 1 0, A 1 1] :=
 (etaExpand_eq _).symm
 ```
 -/
-theorem etaExpand_eq {m n} (A : Matrix (Fin m) (Fin n) α) : etaExpand A = A := by
+theorem etaExpand_eq {m n} (A : Mat[m,n][α]) : etaExpand A = A := by
   simp_rw [etaExpand, FinVec.etaExpand_eq, Matrix.of]
   -- This to be in the above `simp_rw` before leanprover/lean4#2644
   erw [Equiv.refl_apply]
 #align matrix.eta_expand_eq Matrix.etaExpand_eq
 
-example (A : Matrix (Fin 2) (Fin 2) α) : A = !![A 0 0, A 0 1; A 1 0, A 1 1] :=
+example (A : Mat[2,2][α]) : A = !![A 0 0, A 0 1; A 1 0, A 1 1] :=
   (etaExpand_eq _).symm
 
 end Matrix

--- a/Mathlib/Data/Matrix/Reflection.lean
+++ b/Mathlib/Data/Matrix/Reflection.lean
@@ -10,7 +10,7 @@ import Mathlib.Data.Fin.Tuple.Reflection
 #align_import data.matrix.reflection from "leanprover-community/mathlib"@"820b22968a2bc4a47ce5cf1d2f36a9ebe52510aa"
 
 /-!
-# Lemmas for concrete matrices `Mat[m,n][α`]
+# Lemmas for concrete matrices `Mat[m, n][α`]
 
 This file contains alternative definitions of common operators on matrices that expand
 definitionally to the expected expression when evaluated on `!![]` notation.
@@ -40,56 +40,56 @@ namespace Matrix
 
 variable {l m n : ℕ} {α β : Type*}
 
-/-- `∀` with better defeq for `∀ x : Mat[m,n][α,] P x`. -/
-def Forall : ∀ {m n} (_ : Mat[m,n][α] → Prop), Prop
+/-- `∀` with better defeq for `∀ x : Mat[m, n][α,] P x`. -/
+def Forall : ∀ {m n} (_ : Mat[m, n][α] → Prop), Prop
   | 0, _, P => P (of ![])
   | _ + 1, _, P => FinVec.Forall fun r => Forall fun A => P (of (Matrix.vecCons r A))
 #align matrix.forall Matrix.Forall
 
 /-- This can be use to prove
 ```lean
-example (P : Mat[2,3][α] → Prop) :
+example (P : Mat[2, 3][α] → Prop) :
   (∀ x, P x) ↔ ∀ a b c d e f, P !![a, b, c; d, e, f] :=
 (forall_iff _).symm
 ```
 -/
-theorem forall_iff : ∀ {m n} (P : Mat[m,n][α] → Prop), Forall P ↔ ∀ x, P x
+theorem forall_iff : ∀ {m n} (P : Mat[m, n][α] → Prop), Forall P ↔ ∀ x, P x
   | 0, n, P => Iff.symm Fin.forall_fin_zero_pi
   | m + 1, n, P => by
     simp only [Forall, FinVec.forall_iff, forall_iff]
     exact Iff.symm Fin.forall_fin_succ_pi
 #align matrix.forall_iff Matrix.forall_iff
 
-example (P : Mat[2,3][α] → Prop) :
+example (P : Mat[2, 3][α] → Prop) :
     (∀ x, P x) ↔ ∀ a b c d e f, P !![a, b, c; d, e, f] :=
   (forall_iff _).symm
 
-/-- `∃` with better defeq for `∃ x : Mat[m,n][α,] P x`. -/
-def Exists : ∀ {m n} (_ : Mat[m,n][α] → Prop), Prop
+/-- `∃` with better defeq for `∃ x : Mat[m, n][α,] P x`. -/
+def Exists : ∀ {m n} (_ : Mat[m, n][α] → Prop), Prop
   | 0, _, P => P (of ![])
   | _ + 1, _, P => FinVec.Exists fun r => Exists fun A => P (of (Matrix.vecCons r A))
 #align matrix.exists Matrix.Exists
 
 /-- This can be use to prove
 ```lean
-example (P : Mat[2,3][α] → Prop) :
+example (P : Mat[2, 3][α] → Prop) :
   (∃ x, P x) ↔ ∃ a b c d e f, P !![a, b, c; d, e, f] :=
 (exists_iff _).symm
 ```
 -/
-theorem exists_iff : ∀ {m n} (P : Mat[m,n][α] → Prop), Exists P ↔ ∃ x, P x
+theorem exists_iff : ∀ {m n} (P : Mat[m, n][α] → Prop), Exists P ↔ ∃ x, P x
   | 0, n, P => Iff.symm Fin.exists_fin_zero_pi
   | m + 1, n, P => by
     simp only [Exists, FinVec.exists_iff, exists_iff]
     exact Iff.symm Fin.exists_fin_succ_pi
 #align matrix.exists_iff Matrix.exists_iff
 
-example (P : Mat[2,3][α] → Prop) :
+example (P : Mat[2, 3][α] → Prop) :
     (∃ x, P x) ↔ ∃ a b c d e f, P !![a, b, c; d, e, f] :=
   (exists_iff _).symm
 
 /-- `Matrix.transpose` with better defeq for `Fin` -/
-def transposeᵣ : ∀ {m n}, Mat[m,n][α] → Mat[n,m][α]
+def transposeᵣ : ∀ {m n}, Mat[m, n][α] → Mat[n, m][α]
   | _, 0, _ => of ![]
   | _, _ + 1, A =>
     of <| vecCons (FinVec.map (fun v : Fin _ → α => v 0) A) (transposeᵣ (A.submatrix id Fin.succ))
@@ -101,7 +101,7 @@ example (a b c d : α) : transpose !![a, b; c, d] = !![a, c; b, d] := (transpose
 ```
 -/
 @[simp]
-theorem transposeᵣ_eq : ∀ {m n} (A : Mat[m,n][α]), transposeᵣ A = transpose A
+theorem transposeᵣ_eq : ∀ {m n} (A : Mat[m, n][α]), transposeᵣ A = transpose A
   | _, 0, A => Subsingleton.elim _ _
   | m, n + 1, A =>
     Matrix.ext fun i j => by
@@ -139,8 +139,8 @@ example (a b c d : α) [Mul α] [AddCommMonoid α] : dotProduct ![a, b] ![c, d] 
   (dotProductᵣ_eq _ _).symm
 
 /-- `Matrix.mul` with better defeq for `Fin` -/
-def mulᵣ [Mul α] [Add α] [Zero α] (A : Mat[l,m][α]) (B : Mat[m,n][α]) :
-    Mat[l,n][α] :=
+def mulᵣ [Mul α] [Add α] [Zero α] (A : Mat[l, m][α]) (B : Mat[m, n][α]) :
+    Mat[l, n][α] :=
   of <| FinVec.map (fun v₁ => FinVec.map (fun v₂ => dotProductᵣ v₁ v₂) Bᵀ) A
 #align matrix.mulᵣ Matrix.mulᵣ
 
@@ -156,8 +156,8 @@ example [AddCommMonoid α] [Mul α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁₁ b�
 ```
 -/
 @[simp]
-theorem mulᵣ_eq [Mul α] [AddCommMonoid α] (A : Mat[l,m][α])
-    (B : Mat[m,n][α]) : mulᵣ A B = A * B := by
+theorem mulᵣ_eq [Mul α] [AddCommMonoid α] (A : Mat[l, m][α])
+    (B : Mat[m, n][α]) : mulᵣ A B = A * B := by
   simp [mulᵣ, Function.comp, Matrix.transpose]
   rfl
 #align matrix.mulᵣ_eq Matrix.mulᵣ_eq
@@ -169,7 +169,7 @@ example [AddCommMonoid α] [Mul α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁₁ b�
   (mulᵣ_eq _ _).symm
 
 /-- `Matrix.mulVec` with better defeq for `Fin` -/
-def mulVecᵣ [Mul α] [Add α] [Zero α] (A : Mat[l,m][α]) (v : Fin m → α) : Fin l → α :=
+def mulVecᵣ [Mul α] [Add α] [Zero α] (A : Mat[l, m][α]) (v : Fin m → α) : Fin l → α :=
   FinVec.map (fun a => dotProductᵣ a v) A
 #align matrix.mul_vecᵣ Matrix.mulVecᵣ
 
@@ -182,7 +182,7 @@ example [NonUnitalNonAssocSemiring α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁ b�
 ```
 -/
 @[simp]
-theorem mulVecᵣ_eq [NonUnitalNonAssocSemiring α] (A : Mat[l,m][α]) (v : Fin m → α) :
+theorem mulVecᵣ_eq [NonUnitalNonAssocSemiring α] (A : Mat[l, m][α]) (v : Fin m → α) :
     mulVecᵣ A v = A *ᵥ v := by
   simp [mulVecᵣ, Function.comp]
   rfl
@@ -193,7 +193,7 @@ example [NonUnitalNonAssocSemiring α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁ b�
   (mulVecᵣ_eq _ _).symm
 
 /-- `Matrix.vecMul` with better defeq for `Fin` -/
-def vecMulᵣ [Mul α] [Add α] [Zero α] (v : Fin l → α) (A : Mat[l,m][α]) : Fin m → α :=
+def vecMulᵣ [Mul α] [Add α] [Zero α] (v : Fin l → α) (A : Mat[l, m][α]) : Fin m → α :=
   FinVec.map (fun a => dotProductᵣ v a) Aᵀ
 #align matrix.vec_mulᵣ Matrix.vecMulᵣ
 
@@ -206,7 +206,7 @@ example [NonUnitalNonAssocSemiring α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁ b�
 ```
 -/
 @[simp]
-theorem vecMulᵣ_eq [NonUnitalNonAssocSemiring α] (v : Fin l → α) (A : Mat[l,m][α]) :
+theorem vecMulᵣ_eq [NonUnitalNonAssocSemiring α] (v : Fin l → α) (A : Mat[l, m][α]) :
     vecMulᵣ v A = v ᵥ* A := by
   simp [vecMulᵣ, Function.comp]
   rfl
@@ -217,25 +217,25 @@ example [NonUnitalNonAssocSemiring α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁ b�
   (vecMulᵣ_eq _ _).symm
 
 /-- Expand `A` to `!![A 0 0, ...; ..., A m n]` -/
-def etaExpand {m n} (A : Mat[m,n][α]) : Mat[m,n][α] :=
+def etaExpand {m n} (A : Mat[m, n][α]) : Mat[m, n][α] :=
   Matrix.of (FinVec.etaExpand fun i => FinVec.etaExpand fun j => A i j)
 #align matrix.eta_expand Matrix.etaExpand
 
 /-- This can be used to prove
 ```lean
-example (A : Mat[2,2][α]) :
+example (A : Mat[2, 2][α]) :
   A = !![A 0 0, A 0 1;
          A 1 0, A 1 1] :=
 (etaExpand_eq _).symm
 ```
 -/
-theorem etaExpand_eq {m n} (A : Mat[m,n][α]) : etaExpand A = A := by
+theorem etaExpand_eq {m n} (A : Mat[m, n][α]) : etaExpand A = A := by
   simp_rw [etaExpand, FinVec.etaExpand_eq, Matrix.of]
   -- This to be in the above `simp_rw` before leanprover/lean4#2644
   erw [Equiv.refl_apply]
 #align matrix.eta_expand_eq Matrix.etaExpand_eq
 
-example (A : Mat[2,2][α]) : A = !![A 0 0, A 0 1; A 1 0, A 1 1] :=
+example (A : Mat[2, 2][α]) : A = !![A 0 0, A 0 1; A 1 0, A 1 1] :=
   (etaExpand_eq _).symm
 
 end Matrix

--- a/Mathlib/GroupTheory/Coxeter/Matrix.lean
+++ b/Mathlib/GroupTheory/Coxeter/Matrix.lean
@@ -44,7 +44,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o ⬝ ⬝ ⬝ ⬝ o --- o
 ```
 -/
-abbrev Aₙ : Mat[n,n][ℕ] :=
+abbrev Aₙ : Mat[n, n][ℕ] :=
   Matrix.of fun i j : Fin n =>
     if i = j then 1
       else (if (j : ℕ) + 1 = i ∨ (i : ℕ) + 1 = j then 3 else 2)
@@ -61,7 +61,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o ⬝ ⬝ ⬝ ⬝ o --- o
 ```
 -/
-abbrev Bₙ : Mat[n,n][ℕ] :=
+abbrev Bₙ : Mat[n, n][ℕ] :=
   Matrix.of fun i j : Fin n =>
     if i = j then 1
       else (if i = n - 1 ∧ j = n - 2 ∨ j = n - 1 ∧ i = n - 2 then 4
@@ -81,7 +81,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o
 ```
 -/
-abbrev Dₙ : Mat[n,n][ℕ] :=
+abbrev Dₙ : Mat[n, n][ℕ] :=
   Matrix.of fun i j : Fin n =>
     if i = j then 1
       else (if i = n - 1 ∧ j = n - 3 ∨ j = n - 1 ∧ i = n - 3 then 3
@@ -98,7 +98,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o
 ```
 -/
-abbrev I₂ₘ (m : ℕ) : Mat[2,2][ℕ] :=
+abbrev I₂ₘ (m : ℕ) : Mat[2, 2][ℕ] :=
   Matrix.of fun i j => if i = j then 1 else m + 2
 
 theorem I₂ₘIsCoxeter (m : ℕ) : IsCoxeter (I₂ₘ m) where
@@ -113,7 +113,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o --- o --- o
 ```
 -/
-def E₆ : Mat[6,6][ℕ] :=
+def E₆ : Mat[6, 6][ℕ] :=
   !![1, 2, 3, 2, 2, 2;
      2, 1, 2, 3, 2, 2;
      3, 2, 1, 3, 2, 2;
@@ -132,7 +132,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o --- o --- o --- o
 ```
 -/
-def E₇ : Mat[7,7][ℕ] :=
+def E₇ : Mat[7, 7][ℕ] :=
   !![1, 2, 3, 2, 2, 2, 2;
      2, 1, 2, 3, 2, 2, 2;
      3, 2, 1, 3, 2, 2, 2;
@@ -152,7 +152,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o --- o --- o --- o --- o
 ```
 -/
-def E₈ : Mat[8,8][ℕ] :=
+def E₈ : Mat[8, 8][ℕ] :=
   !![1, 2, 3, 2, 2, 2, 2, 2;
      2, 1, 2, 3, 2, 2, 2, 2;
      3, 2, 1, 3, 2, 2, 2, 2;
@@ -172,7 +172,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o --- o
 ```
 -/
-def F₄ : Mat[4,4][ℕ] :=
+def F₄ : Mat[4, 4][ℕ] :=
   !![1, 3, 2, 2;
      3, 1, 4, 2;
      2, 4, 1, 3;
@@ -188,7 +188,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o
 ```
 -/
-def G₂ : Mat[2,2][ℕ] :=
+def G₂ : Mat[2, 2][ℕ] :=
   !![1, 6;
      6, 1]
 
@@ -202,7 +202,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o
 ```
 -/
-def H₃ : Mat[3,3][ℕ] :=
+def H₃ : Mat[3, 3][ℕ] :=
   !![1, 3, 2;
      3, 1, 5;
      2, 5, 1]
@@ -217,7 +217,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o --- o
 ```
 -/
-def H₄ : Mat[4,4][ℕ] :=
+def H₄ : Mat[4, 4][ℕ] :=
   !![1, 3, 2, 2;
      3, 1, 3, 2;
      2, 3, 1, 5;

--- a/Mathlib/GroupTheory/Coxeter/Matrix.lean
+++ b/Mathlib/GroupTheory/Coxeter/Matrix.lean
@@ -44,7 +44,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o ⬝ ⬝ ⬝ ⬝ o --- o
 ```
 -/
-abbrev Aₙ : Matrix (Fin n) (Fin n) ℕ :=
+abbrev Aₙ : Mat[n,n][ℕ] :=
   Matrix.of fun i j : Fin n =>
     if i = j then 1
       else (if (j : ℕ) + 1 = i ∨ (i : ℕ) + 1 = j then 3 else 2)
@@ -61,7 +61,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o ⬝ ⬝ ⬝ ⬝ o --- o
 ```
 -/
-abbrev Bₙ : Matrix (Fin n) (Fin n) ℕ :=
+abbrev Bₙ : Mat[n,n][ℕ] :=
   Matrix.of fun i j : Fin n =>
     if i = j then 1
       else (if i = n - 1 ∧ j = n - 2 ∨ j = n - 1 ∧ i = n - 2 then 4
@@ -81,7 +81,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o
 ```
 -/
-abbrev Dₙ : Matrix (Fin n) (Fin n) ℕ :=
+abbrev Dₙ : Mat[n,n][ℕ] :=
   Matrix.of fun i j : Fin n =>
     if i = j then 1
       else (if i = n - 1 ∧ j = n - 3 ∨ j = n - 1 ∧ i = n - 3 then 3
@@ -98,7 +98,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o
 ```
 -/
-abbrev I₂ₘ (m : ℕ) : Matrix (Fin 2) (Fin 2) ℕ :=
+abbrev I₂ₘ (m : ℕ) : Mat[2,2][ℕ] :=
   Matrix.of fun i j => if i = j then 1 else m + 2
 
 theorem I₂ₘIsCoxeter (m : ℕ) : IsCoxeter (I₂ₘ m) where
@@ -113,7 +113,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o --- o --- o
 ```
 -/
-def E₆ : Matrix (Fin 6) (Fin 6) ℕ :=
+def E₆ : Mat[6,6][ℕ] :=
   !![1, 2, 3, 2, 2, 2;
      2, 1, 2, 3, 2, 2;
      3, 2, 1, 3, 2, 2;
@@ -132,7 +132,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o --- o --- o --- o
 ```
 -/
-def E₇ : Matrix (Fin 7) (Fin 7) ℕ :=
+def E₇ : Mat[7,7][ℕ] :=
   !![1, 2, 3, 2, 2, 2, 2;
      2, 1, 2, 3, 2, 2, 2;
      3, 2, 1, 3, 2, 2, 2;
@@ -152,7 +152,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o --- o --- o --- o --- o
 ```
 -/
-def E₈ : Matrix (Fin 8) (Fin 8) ℕ :=
+def E₈ : Mat[8,8][ℕ] :=
   !![1, 2, 3, 2, 2, 2, 2, 2;
      2, 1, 2, 3, 2, 2, 2, 2;
      3, 2, 1, 3, 2, 2, 2, 2;
@@ -172,7 +172,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o --- o
 ```
 -/
-def F₄ : Matrix (Fin 4) (Fin 4) ℕ :=
+def F₄ : Mat[4,4][ℕ] :=
   !![1, 3, 2, 2;
      3, 1, 4, 2;
      2, 4, 1, 3;
@@ -188,7 +188,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o
 ```
 -/
-def G₂ : Matrix (Fin 2) (Fin 2) ℕ :=
+def G₂ : Mat[2,2][ℕ] :=
   !![1, 6;
      6, 1]
 
@@ -202,7 +202,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o
 ```
 -/
-def H₃ : Matrix (Fin 3) (Fin 3) ℕ :=
+def H₃ : Mat[3,3][ℕ] :=
   !![1, 3, 2;
      3, 1, 5;
      2, 5, 1]
@@ -217,7 +217,7 @@ The corresponding Coxeter-Dynkin diagram is:
     o --- o --- o --- o
 ```
 -/
-def H₄ : Matrix (Fin 4) (Fin 4) ℕ :=
+def H₄ : Mat[4,4][ℕ] :=
   !![1, 3, 2, 2;
      3, 1, 3, 2;
      2, 3, 1, 5;

--- a/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
@@ -389,23 +389,23 @@ theorem det_adjugate (A : Matrix n n α) : (adjugate A).det = A.det ^ (Fintype.c
 #align matrix.det_adjugate Matrix.det_adjugate
 
 @[simp]
-theorem adjugate_fin_zero (A : Matrix (Fin 0) (Fin 0) α) : adjugate A = 0 :=
+theorem adjugate_fin_zero (A : Mat[0,0][α]) : adjugate A = 0 :=
   Subsingleton.elim _ _
 #align matrix.adjugate_fin_zero Matrix.adjugate_fin_zero
 
 @[simp]
-theorem adjugate_fin_one (A : Matrix (Fin 1) (Fin 1) α) : adjugate A = 1 :=
+theorem adjugate_fin_one (A : Mat[1,1][α]) : adjugate A = 1 :=
   adjugate_subsingleton A
 #align matrix.adjugate_fin_one Matrix.adjugate_fin_one
 
-theorem adjugate_fin_succ_eq_det_submatrix {n : ℕ} (A : Matrix (Fin n.succ) (Fin n.succ) α) (i j) :
+theorem adjugate_fin_succ_eq_det_submatrix {n : ℕ} (A : Mat[n.succ,n.succ][α]) (i j) :
     adjugate A i j = (-1) ^ (j + i : ℕ) * det (A.submatrix j.succAbove i.succAbove) := by
   simp_rw [adjugate_apply, det_succ_row _ j, updateRow_self, submatrix_updateRow_succAbove]
   rw [Fintype.sum_eq_single i fun h hjk => ?_, Pi.single_eq_same, mul_one]
   rw [Pi.single_eq_of_ne hjk, mul_zero, zero_mul]
 #align matrix.adjugate_fin_succ_eq_det_submatrix Matrix.adjugate_fin_succ_eq_det_submatrix
 
-theorem adjugate_fin_two (A : Matrix (Fin 2) (Fin 2) α) :
+theorem adjugate_fin_two (A : Mat[2,2][α]) :
     adjugate A = !![A 1 1, -A 0 1; -A 1 0, A 0 0] := by
   ext i j
   rw [adjugate_fin_succ_eq_det_submatrix]
@@ -417,7 +417,7 @@ theorem adjugate_fin_two_of (a b c d : α) : adjugate !![a, b; c, d] = !![d, -b;
   adjugate_fin_two _
 #align matrix.adjugate_fin_two_of Matrix.adjugate_fin_two_of
 
-theorem adjugate_fin_three (A : Matrix (Fin 3) (Fin 3) α) :
+theorem adjugate_fin_three (A : Mat[3,3][α]) :
     adjugate A =
     !![A 1 1 * A 2 2 - A 1 2 * A 2 1,
       -(A 0 1 * A 2 2) + A 0 2 * A 2 1,

--- a/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
@@ -389,23 +389,23 @@ theorem det_adjugate (A : Matrix n n α) : (adjugate A).det = A.det ^ (Fintype.c
 #align matrix.det_adjugate Matrix.det_adjugate
 
 @[simp]
-theorem adjugate_fin_zero (A : Mat[0,0][α]) : adjugate A = 0 :=
+theorem adjugate_fin_zero (A : Mat[0, 0][α]) : adjugate A = 0 :=
   Subsingleton.elim _ _
 #align matrix.adjugate_fin_zero Matrix.adjugate_fin_zero
 
 @[simp]
-theorem adjugate_fin_one (A : Mat[1,1][α]) : adjugate A = 1 :=
+theorem adjugate_fin_one (A : Mat[1, 1][α]) : adjugate A = 1 :=
   adjugate_subsingleton A
 #align matrix.adjugate_fin_one Matrix.adjugate_fin_one
 
-theorem adjugate_fin_succ_eq_det_submatrix {n : ℕ} (A : Mat[n.succ,n.succ][α]) (i j) :
+theorem adjugate_fin_succ_eq_det_submatrix {n : ℕ} (A : Mat[n.succ, n.succ][α]) (i j) :
     adjugate A i j = (-1) ^ (j + i : ℕ) * det (A.submatrix j.succAbove i.succAbove) := by
   simp_rw [adjugate_apply, det_succ_row _ j, updateRow_self, submatrix_updateRow_succAbove]
   rw [Fintype.sum_eq_single i fun h hjk => ?_, Pi.single_eq_same, mul_one]
   rw [Pi.single_eq_of_ne hjk, mul_zero, zero_mul]
 #align matrix.adjugate_fin_succ_eq_det_submatrix Matrix.adjugate_fin_succ_eq_det_submatrix
 
-theorem adjugate_fin_two (A : Mat[2,2][α]) :
+theorem adjugate_fin_two (A : Mat[2, 2][α]) :
     adjugate A = !![A 1 1, -A 0 1; -A 1 0, A 0 0] := by
   ext i j
   rw [adjugate_fin_succ_eq_det_submatrix]
@@ -417,7 +417,7 @@ theorem adjugate_fin_two_of (a b c d : α) : adjugate !![a, b; c, d] = !![d, -b;
   adjugate_fin_two _
 #align matrix.adjugate_fin_two_of Matrix.adjugate_fin_two_of
 
-theorem adjugate_fin_three (A : Mat[3,3][α]) :
+theorem adjugate_fin_three (A : Mat[3, 3][α]) :
     adjugate A =
     !![A 1 1 * A 2 2 - A 1 2 * A 2 1,
       -(A 0 1 * A 2 2) + A 0 2 * A 2 1,

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
@@ -196,7 +196,7 @@ lemma eval_det_add_X_smul (A : Matrix n n R[X]) (M : Matrix n n R) :
   simp only [Algebra.algebraMap_eq_smul_one, matPolyEquiv_smul_one, map_X, X_mul, eval_mul_X,
     mul_zero, add_zero]
 
-lemma derivative_det_one_add_X_smul_aux {n} (M : Mat[n,n][R]) :
+lemma derivative_det_one_add_X_smul_aux {n} (M : Mat[n, n][R]) :
     (derivative <| det (1 + (X : R[X]) • M.map C)).eval 0 = trace M := by
   induction n with
   | zero => simp

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
@@ -196,7 +196,7 @@ lemma eval_det_add_X_smul (A : Matrix n n R[X]) (M : Matrix n n R) :
   simp only [Algebra.algebraMap_eq_smul_one, matPolyEquiv_smul_one, map_X, X_mul, eval_mul_X,
     mul_zero, add_zero]
 
-lemma derivative_det_one_add_X_smul_aux {n} (M : Matrix (Fin n) (Fin n) R) :
+lemma derivative_det_one_add_X_smul_aux {n} (M : Mat[n,n][R]) :
     (derivative <| det (1 + (X : R[X]) • M.map C)).eval 0 = trace M := by
   induction n with
   | zero => simp

--- a/Mathlib/LinearAlgebra/Matrix/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant.lean
@@ -516,7 +516,7 @@ theorem det_eq_of_forall_row_eq_smul_add_const {A B : Matrix n n R} (c : n → R
 
 theorem det_eq_of_forall_row_eq_smul_add_pred_aux {n : ℕ} (k : Fin (n + 1)) :
     ∀ (c : Fin n → R) (_hc : ∀ i : Fin n, k < i.succ → c i = 0)
-      {M N : Matrix (Fin n.succ) (Fin n.succ) R} (_h0 : ∀ j, M 0 j = N 0 j)
+      {M N : Mat[n.succ,n.succ][R}] (_h0 : ∀ j, M 0 j = N 0 j)
       (_hsucc : ∀ (i : Fin n) (j), M i.succ j = N i.succ j + c i * M (Fin.castSucc i) j),
       det M = det N := by
   refine' Fin.induction _ (fun k ih => _) k <;> intro c hc M N h0 hsucc
@@ -553,7 +553,7 @@ theorem det_eq_of_forall_row_eq_smul_add_pred_aux {n : ℕ} (k : Fin (n + 1)) :
 #align matrix.det_eq_of_forall_row_eq_smul_add_pred_aux Matrix.det_eq_of_forall_row_eq_smul_add_pred_aux
 
 /-- If you add multiples of previous rows to the next row, the determinant doesn't change. -/
-theorem det_eq_of_forall_row_eq_smul_add_pred {n : ℕ} {A B : Matrix (Fin (n + 1)) (Fin (n + 1)) R}
+theorem det_eq_of_forall_row_eq_smul_add_pred {n : ℕ} {A B : Mat[(n + 1),(n + 1)][R}]
     (c : Fin n → R) (A_zero : ∀ j, A 0 j = B 0 j)
     (A_succ : ∀ (i : Fin n) (j), A i.succ j = B i.succ j + c i * A (Fin.castSucc i) j) :
     det A = det B :=
@@ -562,7 +562,7 @@ theorem det_eq_of_forall_row_eq_smul_add_pred {n : ℕ} {A B : Matrix (Fin (n + 
 #align matrix.det_eq_of_forall_row_eq_smul_add_pred Matrix.det_eq_of_forall_row_eq_smul_add_pred
 
 /-- If you add multiples of previous columns to the next columns, the determinant doesn't change. -/
-theorem det_eq_of_forall_col_eq_smul_add_pred {n : ℕ} {A B : Matrix (Fin (n + 1)) (Fin (n + 1)) R}
+theorem det_eq_of_forall_col_eq_smul_add_pred {n : ℕ} {A B : Mat[(n + 1),(n + 1)][R}]
     (c : Fin n → R) (A_zero : ∀ i, A i 0 = B i 0)
     (A_succ : ∀ (i) (j : Fin n), A i j.succ = B i j.succ + c j * A i (Fin.castSucc j)) :
     det A = det B := by
@@ -707,7 +707,7 @@ theorem det_fromBlocks_zero₁₂ (A : Matrix m m R) (C : Matrix n m R) (D : Mat
 #align matrix.det_from_blocks_zero₁₂ Matrix.det_fromBlocks_zero₁₂
 
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along column 0. -/
-theorem det_succ_column_zero {n : ℕ} (A : Matrix (Fin n.succ) (Fin n.succ) R) :
+theorem det_succ_column_zero {n : ℕ} (A : Mat[n.succ,n.succ][R]) :
     det A = ∑ i : Fin n.succ, (-1) ^ (i : ℕ) * A i 0 * det (A.submatrix i.succAbove Fin.succ) := by
   rw [Matrix.det_apply, Finset.univ_perm_fin_succ, ← Finset.univ_product_univ]
   simp only [Finset.sum_map, Equiv.toEmbedding_apply, Finset.sum_product, Matrix.submatrix]
@@ -739,7 +739,7 @@ theorem det_succ_column_zero {n : ℕ} (A : Matrix (Fin n.succ) (Fin n.succ) R) 
 #align matrix.det_succ_column_zero Matrix.det_succ_column_zero
 
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along row 0. -/
-theorem det_succ_row_zero {n : ℕ} (A : Matrix (Fin n.succ) (Fin n.succ) R) :
+theorem det_succ_row_zero {n : ℕ} (A : Mat[n.succ,n.succ][R]) :
     det A = ∑ j : Fin n.succ, (-1) ^ (j : ℕ) * A 0 j * det (A.submatrix Fin.succ j.succAbove) := by
   rw [← det_transpose A, det_succ_column_zero]
   refine' Finset.sum_congr rfl fun i _ => _
@@ -748,7 +748,7 @@ theorem det_succ_row_zero {n : ℕ} (A : Matrix (Fin n.succ) (Fin n.succ) R) :
 #align matrix.det_succ_row_zero Matrix.det_succ_row_zero
 
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along row `i`. -/
-theorem det_succ_row {n : ℕ} (A : Matrix (Fin n.succ) (Fin n.succ) R) (i : Fin n.succ) :
+theorem det_succ_row {n : ℕ} (A : Mat[n.succ,n.succ][R]) (i : Fin n.succ) :
     det A =
       ∑ j : Fin n.succ, (-1) ^ (i + j : ℕ) * A i j * det (A.submatrix i.succAbove j.succAbove) := by
   simp_rw [pow_add, mul_assoc, ← mul_sum]
@@ -769,7 +769,7 @@ theorem det_succ_row {n : ℕ} (A : Matrix (Fin n.succ) (Fin n.succ) R) (i : Fin
 #align matrix.det_succ_row Matrix.det_succ_row
 
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along column `j`. -/
-theorem det_succ_column {n : ℕ} (A : Matrix (Fin n.succ) (Fin n.succ) R) (j : Fin n.succ) :
+theorem det_succ_column {n : ℕ} (A : Mat[n.succ,n.succ][R]) (j : Fin n.succ) :
     det A =
       ∑ i : Fin n.succ, (-1) ^ (i + j : ℕ) * A i j * det (A.submatrix i.succAbove j.succAbove) := by
   rw [← det_transpose, det_succ_row _ j]
@@ -779,12 +779,12 @@ theorem det_succ_column {n : ℕ} (A : Matrix (Fin n.succ) (Fin n.succ) R) (j : 
 
 /-- Determinant of 0x0 matrix -/
 @[simp]
-theorem det_fin_zero {A : Matrix (Fin 0) (Fin 0) R} : det A = 1 :=
+theorem det_fin_zero {A : Mat[0,0][R}] : det A = 1 :=
   det_isEmpty
 #align matrix.det_fin_zero Matrix.det_fin_zero
 
 /-- Determinant of 1x1 matrix -/
-theorem det_fin_one (A : Matrix (Fin 1) (Fin 1) R) : det A = A 0 0 :=
+theorem det_fin_one (A : Mat[1,1][R]) : det A = A 0 0 :=
   det_unique A
 #align matrix.det_fin_one Matrix.det_fin_one
 
@@ -793,7 +793,7 @@ theorem det_fin_one_of (a : R) : det !![a] = a :=
 #align matrix.det_fin_one_of Matrix.det_fin_one_of
 
 /-- Determinant of 2x2 matrix -/
-theorem det_fin_two (A : Matrix (Fin 2) (Fin 2) R) : det A = A 0 0 * A 1 1 - A 0 1 * A 1 0 := by
+theorem det_fin_two (A : Mat[2,2][R]) : det A = A 0 0 * A 1 1 - A 0 1 * A 1 0 := by
   simp only [det_succ_row_zero, det_unique, Fin.default_eq_zero, submatrix_apply,
     Fin.succ_zero_eq_one, Fin.sum_univ_succ, Fin.val_zero, Fin.zero_succAbove, univ_unique,
     Fin.val_succ, Fin.coe_fin_one, Fin.succ_succAbove_zero, sum_singleton]
@@ -806,7 +806,7 @@ theorem det_fin_two_of (a b c d : R) : Matrix.det !![a, b; c, d] = a * d - b * c
 #align matrix.det_fin_two_of Matrix.det_fin_two_of
 
 /-- Determinant of 3x3 matrix -/
-theorem det_fin_three (A : Matrix (Fin 3) (Fin 3) R) :
+theorem det_fin_three (A : Mat[3,3][R]) :
     det A =
       A 0 0 * A 1 1 * A 2 2 - A 0 0 * A 1 2 * A 2 1
       - A 0 1 * A 1 0 * A 2 2 + A 0 1 * A 1 2 * A 2 0

--- a/Mathlib/LinearAlgebra/Matrix/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant.lean
@@ -516,7 +516,7 @@ theorem det_eq_of_forall_row_eq_smul_add_const {A B : Matrix n n R} (c : n → R
 
 theorem det_eq_of_forall_row_eq_smul_add_pred_aux {n : ℕ} (k : Fin (n + 1)) :
     ∀ (c : Fin n → R) (_hc : ∀ i : Fin n, k < i.succ → c i = 0)
-      {M N : Mat[n.succ,n.succ][R}] (_h0 : ∀ j, M 0 j = N 0 j)
+      {M N : Mat[n.succ,n.succ][R]} (_h0 : ∀ j, M 0 j = N 0 j)
       (_hsucc : ∀ (i : Fin n) (j), M i.succ j = N i.succ j + c i * M (Fin.castSucc i) j),
       det M = det N := by
   refine' Fin.induction _ (fun k ih => _) k <;> intro c hc M N h0 hsucc
@@ -553,7 +553,7 @@ theorem det_eq_of_forall_row_eq_smul_add_pred_aux {n : ℕ} (k : Fin (n + 1)) :
 #align matrix.det_eq_of_forall_row_eq_smul_add_pred_aux Matrix.det_eq_of_forall_row_eq_smul_add_pred_aux
 
 /-- If you add multiples of previous rows to the next row, the determinant doesn't change. -/
-theorem det_eq_of_forall_row_eq_smul_add_pred {n : ℕ} {A B : Mat[(n + 1),(n + 1)][R}]
+theorem det_eq_of_forall_row_eq_smul_add_pred {n : ℕ} {A B : Mat[(n + 1),(n + 1)][R]}
     (c : Fin n → R) (A_zero : ∀ j, A 0 j = B 0 j)
     (A_succ : ∀ (i : Fin n) (j), A i.succ j = B i.succ j + c i * A (Fin.castSucc i) j) :
     det A = det B :=
@@ -562,7 +562,7 @@ theorem det_eq_of_forall_row_eq_smul_add_pred {n : ℕ} {A B : Mat[(n + 1),(n + 
 #align matrix.det_eq_of_forall_row_eq_smul_add_pred Matrix.det_eq_of_forall_row_eq_smul_add_pred
 
 /-- If you add multiples of previous columns to the next columns, the determinant doesn't change. -/
-theorem det_eq_of_forall_col_eq_smul_add_pred {n : ℕ} {A B : Mat[(n + 1),(n + 1)][R}]
+theorem det_eq_of_forall_col_eq_smul_add_pred {n : ℕ} {A B : Mat[(n + 1),(n + 1)][R]}
     (c : Fin n → R) (A_zero : ∀ i, A i 0 = B i 0)
     (A_succ : ∀ (i) (j : Fin n), A i j.succ = B i j.succ + c j * A i (Fin.castSucc j)) :
     det A = det B := by
@@ -779,7 +779,7 @@ theorem det_succ_column {n : ℕ} (A : Mat[n.succ,n.succ][R]) (j : Fin n.succ) :
 
 /-- Determinant of 0x0 matrix -/
 @[simp]
-theorem det_fin_zero {A : Mat[0,0][R}] : det A = 1 :=
+theorem det_fin_zero {A : Mat[0,0][R]} : det A = 1 :=
   det_isEmpty
 #align matrix.det_fin_zero Matrix.det_fin_zero
 

--- a/Mathlib/LinearAlgebra/Matrix/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant.lean
@@ -516,7 +516,7 @@ theorem det_eq_of_forall_row_eq_smul_add_const {A B : Matrix n n R} (c : n → R
 
 theorem det_eq_of_forall_row_eq_smul_add_pred_aux {n : ℕ} (k : Fin (n + 1)) :
     ∀ (c : Fin n → R) (_hc : ∀ i : Fin n, k < i.succ → c i = 0)
-      {M N : Mat[n.succ,n.succ][R]} (_h0 : ∀ j, M 0 j = N 0 j)
+      {M N : Mat[n.succ, n.succ][R]} (_h0 : ∀ j, M 0 j = N 0 j)
       (_hsucc : ∀ (i : Fin n) (j), M i.succ j = N i.succ j + c i * M (Fin.castSucc i) j),
       det M = det N := by
   refine' Fin.induction _ (fun k ih => _) k <;> intro c hc M N h0 hsucc
@@ -553,7 +553,7 @@ theorem det_eq_of_forall_row_eq_smul_add_pred_aux {n : ℕ} (k : Fin (n + 1)) :
 #align matrix.det_eq_of_forall_row_eq_smul_add_pred_aux Matrix.det_eq_of_forall_row_eq_smul_add_pred_aux
 
 /-- If you add multiples of previous rows to the next row, the determinant doesn't change. -/
-theorem det_eq_of_forall_row_eq_smul_add_pred {n : ℕ} {A B : Mat[(n + 1),(n + 1)][R]}
+theorem det_eq_of_forall_row_eq_smul_add_pred {n : ℕ} {A B : Mat[(n + 1), (n + 1)][R]}
     (c : Fin n → R) (A_zero : ∀ j, A 0 j = B 0 j)
     (A_succ : ∀ (i : Fin n) (j), A i.succ j = B i.succ j + c i * A (Fin.castSucc i) j) :
     det A = det B :=
@@ -562,7 +562,7 @@ theorem det_eq_of_forall_row_eq_smul_add_pred {n : ℕ} {A B : Mat[(n + 1),(n + 
 #align matrix.det_eq_of_forall_row_eq_smul_add_pred Matrix.det_eq_of_forall_row_eq_smul_add_pred
 
 /-- If you add multiples of previous columns to the next columns, the determinant doesn't change. -/
-theorem det_eq_of_forall_col_eq_smul_add_pred {n : ℕ} {A B : Mat[(n + 1),(n + 1)][R]}
+theorem det_eq_of_forall_col_eq_smul_add_pred {n : ℕ} {A B : Mat[(n + 1), (n + 1)][R]}
     (c : Fin n → R) (A_zero : ∀ i, A i 0 = B i 0)
     (A_succ : ∀ (i) (j : Fin n), A i j.succ = B i j.succ + c j * A i (Fin.castSucc j)) :
     det A = det B := by
@@ -707,7 +707,7 @@ theorem det_fromBlocks_zero₁₂ (A : Matrix m m R) (C : Matrix n m R) (D : Mat
 #align matrix.det_from_blocks_zero₁₂ Matrix.det_fromBlocks_zero₁₂
 
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along column 0. -/
-theorem det_succ_column_zero {n : ℕ} (A : Mat[n.succ,n.succ][R]) :
+theorem det_succ_column_zero {n : ℕ} (A : Mat[n.succ, n.succ][R]) :
     det A = ∑ i : Fin n.succ, (-1) ^ (i : ℕ) * A i 0 * det (A.submatrix i.succAbove Fin.succ) := by
   rw [Matrix.det_apply, Finset.univ_perm_fin_succ, ← Finset.univ_product_univ]
   simp only [Finset.sum_map, Equiv.toEmbedding_apply, Finset.sum_product, Matrix.submatrix]
@@ -739,7 +739,7 @@ theorem det_succ_column_zero {n : ℕ} (A : Mat[n.succ,n.succ][R]) :
 #align matrix.det_succ_column_zero Matrix.det_succ_column_zero
 
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along row 0. -/
-theorem det_succ_row_zero {n : ℕ} (A : Mat[n.succ,n.succ][R]) :
+theorem det_succ_row_zero {n : ℕ} (A : Mat[n.succ, n.succ][R]) :
     det A = ∑ j : Fin n.succ, (-1) ^ (j : ℕ) * A 0 j * det (A.submatrix Fin.succ j.succAbove) := by
   rw [← det_transpose A, det_succ_column_zero]
   refine' Finset.sum_congr rfl fun i _ => _
@@ -748,7 +748,7 @@ theorem det_succ_row_zero {n : ℕ} (A : Mat[n.succ,n.succ][R]) :
 #align matrix.det_succ_row_zero Matrix.det_succ_row_zero
 
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along row `i`. -/
-theorem det_succ_row {n : ℕ} (A : Mat[n.succ,n.succ][R]) (i : Fin n.succ) :
+theorem det_succ_row {n : ℕ} (A : Mat[n.succ, n.succ][R]) (i : Fin n.succ) :
     det A =
       ∑ j : Fin n.succ, (-1) ^ (i + j : ℕ) * A i j * det (A.submatrix i.succAbove j.succAbove) := by
   simp_rw [pow_add, mul_assoc, ← mul_sum]
@@ -769,7 +769,7 @@ theorem det_succ_row {n : ℕ} (A : Mat[n.succ,n.succ][R]) (i : Fin n.succ) :
 #align matrix.det_succ_row Matrix.det_succ_row
 
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along column `j`. -/
-theorem det_succ_column {n : ℕ} (A : Mat[n.succ,n.succ][R]) (j : Fin n.succ) :
+theorem det_succ_column {n : ℕ} (A : Mat[n.succ, n.succ][R]) (j : Fin n.succ) :
     det A =
       ∑ i : Fin n.succ, (-1) ^ (i + j : ℕ) * A i j * det (A.submatrix i.succAbove j.succAbove) := by
   rw [← det_transpose, det_succ_row _ j]
@@ -779,12 +779,12 @@ theorem det_succ_column {n : ℕ} (A : Mat[n.succ,n.succ][R]) (j : Fin n.succ) :
 
 /-- Determinant of 0x0 matrix -/
 @[simp]
-theorem det_fin_zero {A : Mat[0,0][R]} : det A = 1 :=
+theorem det_fin_zero {A : Mat[0, 0][R]} : det A = 1 :=
   det_isEmpty
 #align matrix.det_fin_zero Matrix.det_fin_zero
 
 /-- Determinant of 1x1 matrix -/
-theorem det_fin_one (A : Mat[1,1][R]) : det A = A 0 0 :=
+theorem det_fin_one (A : Mat[1, 1][R]) : det A = A 0 0 :=
   det_unique A
 #align matrix.det_fin_one Matrix.det_fin_one
 
@@ -793,7 +793,7 @@ theorem det_fin_one_of (a : R) : det !![a] = a :=
 #align matrix.det_fin_one_of Matrix.det_fin_one_of
 
 /-- Determinant of 2x2 matrix -/
-theorem det_fin_two (A : Mat[2,2][R]) : det A = A 0 0 * A 1 1 - A 0 1 * A 1 0 := by
+theorem det_fin_two (A : Mat[2, 2][R]) : det A = A 0 0 * A 1 1 - A 0 1 * A 1 0 := by
   simp only [det_succ_row_zero, det_unique, Fin.default_eq_zero, submatrix_apply,
     Fin.succ_zero_eq_one, Fin.sum_univ_succ, Fin.val_zero, Fin.zero_succAbove, univ_unique,
     Fin.val_succ, Fin.coe_fin_one, Fin.succ_succAbove_zero, sum_singleton]
@@ -806,7 +806,7 @@ theorem det_fin_two_of (a b c d : R) : Matrix.det !![a, b; c, d] = a * d - b * c
 #align matrix.det_fin_two_of Matrix.det_fin_two_of
 
 /-- Determinant of 3x3 matrix -/
-theorem det_fin_three (A : Mat[3,3][R]) :
+theorem det_fin_three (A : Mat[3, 3][R]) :
     det A =
       A 0 0 * A 1 1 * A 2 2 - A 0 0 * A 1 2 * A 2 1
       - A 0 1 * A 1 0 * A 2 2 + A 0 1 * A 1 2 * A 2 0

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -402,7 +402,7 @@ theorem fin_two_induction (P : SL(2, R) → Prop)
 #align matrix.special_linear_group.fin_two_induction Matrix.SpecialLinearGroup.fin_two_induction
 
 theorem fin_two_exists_eq_mk_of_apply_zero_one_eq_zero {R : Type*} [Field R] (g : SL(2, R))
-    (hg : (g : Mat[2,2][R]) 1 0 = 0) :
+    (hg : (g : Mat[2, 2][R]) 1 0 = 0) :
     ∃ (a b : R) (h : a ≠ 0), g = (⟨!![a, b; 0, a⁻¹], by simp [h]⟩ : SL(2, R)) := by
   induction' g using Matrix.SpecialLinearGroup.fin_two_induction with a b c d h_det
   replace hg : c = 0 := by simpa using hg
@@ -481,7 +481,7 @@ open MatrixGroups
 
 open Matrix Matrix.SpecialLinearGroup
 
-local notation:1024 "↑ₘ" A:1024 => ((A : SL(2, ℤ)) : Mat[2,2][ℤ])
+local notation:1024 "↑ₘ" A:1024 => ((A : SL(2, ℤ)) : Mat[2, 2][ℤ])
 
 set_option linter.uppercaseLean3 false
 

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -402,7 +402,7 @@ theorem fin_two_induction (P : SL(2, R) → Prop)
 #align matrix.special_linear_group.fin_two_induction Matrix.SpecialLinearGroup.fin_two_induction
 
 theorem fin_two_exists_eq_mk_of_apply_zero_one_eq_zero {R : Type*} [Field R] (g : SL(2, R))
-    (hg : (g : Matrix (Fin 2) (Fin 2) R) 1 0 = 0) :
+    (hg : (g : Mat[2,2][R]) 1 0 = 0) :
     ∃ (a b : R) (h : a ≠ 0), g = (⟨!![a, b; 0, a⁻¹], by simp [h]⟩ : SL(2, R)) := by
   induction' g using Matrix.SpecialLinearGroup.fin_two_induction with a b c d h_det
   replace hg : c = 0 := by simpa using hg
@@ -481,7 +481,7 @@ open MatrixGroups
 
 open Matrix Matrix.SpecialLinearGroup
 
-local notation:1024 "↑ₘ" A:1024 => ((A : SL(2, ℤ)) : Matrix (Fin 2) (Fin 2) ℤ)
+local notation:1024 "↑ₘ" A:1024 => ((A : SL(2, ℤ)) : Mat[2,2][ℤ])
 
 set_option linter.uppercaseLean3 false
 

--- a/Mathlib/LinearAlgebra/Matrix/Trace.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Trace.lean
@@ -190,7 +190,7 @@ theorem trace_col_mul_row [NonUnitalNonAssocSemiring R] (a b : n → R) :
 end Mul
 
 lemma trace_submatrix_succ {n : ℕ} [NonUnitalNonAssocSemiring R]
-    (M : Matrix (Fin n.succ) (Fin n.succ) R) :
+    (M : Mat[n.succ,n.succ][R]) :
     M 0 0 + trace (submatrix M Fin.succ Fin.succ) = trace M := by
   delta trace
   rw [← (finSuccEquiv n).symm.sum_comp]
@@ -207,19 +207,19 @@ with `Matrix.det_fin_two` etc.
 -/
 
 
-theorem trace_fin_zero (A : Matrix (Fin 0) (Fin 0) R) : trace A = 0 :=
+theorem trace_fin_zero (A : Mat[0,0][R]) : trace A = 0 :=
   rfl
 #align matrix.trace_fin_zero Matrix.trace_fin_zero
 
-theorem trace_fin_one (A : Matrix (Fin 1) (Fin 1) R) : trace A = A 0 0 :=
+theorem trace_fin_one (A : Mat[1,1][R]) : trace A = A 0 0 :=
   add_zero _
 #align matrix.trace_fin_one Matrix.trace_fin_one
 
-theorem trace_fin_two (A : Matrix (Fin 2) (Fin 2) R) : trace A = A 0 0 + A 1 1 :=
+theorem trace_fin_two (A : Mat[2,2][R]) : trace A = A 0 0 + A 1 1 :=
   congr_arg (_ + ·) (add_zero (A 1 1))
 #align matrix.trace_fin_two Matrix.trace_fin_two
 
-theorem trace_fin_three (A : Matrix (Fin 3) (Fin 3) R) : trace A = A 0 0 + A 1 1 + A 2 2 := by
+theorem trace_fin_three (A : Mat[3,3][R]) : trace A = A 0 0 + A 1 1 + A 2 2 := by
   rw [← add_zero (A 2 2), add_assoc]
   rfl
 #align matrix.trace_fin_three Matrix.trace_fin_three

--- a/Mathlib/LinearAlgebra/Matrix/Trace.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Trace.lean
@@ -190,7 +190,7 @@ theorem trace_col_mul_row [NonUnitalNonAssocSemiring R] (a b : n → R) :
 end Mul
 
 lemma trace_submatrix_succ {n : ℕ} [NonUnitalNonAssocSemiring R]
-    (M : Mat[n.succ,n.succ][R]) :
+    (M : Mat[n.succ, n.succ][R]) :
     M 0 0 + trace (submatrix M Fin.succ Fin.succ) = trace M := by
   delta trace
   rw [← (finSuccEquiv n).symm.sum_comp]
@@ -207,19 +207,19 @@ with `Matrix.det_fin_two` etc.
 -/
 
 
-theorem trace_fin_zero (A : Mat[0,0][R]) : trace A = 0 :=
+theorem trace_fin_zero (A : Mat[0, 0][R]) : trace A = 0 :=
   rfl
 #align matrix.trace_fin_zero Matrix.trace_fin_zero
 
-theorem trace_fin_one (A : Mat[1,1][R]) : trace A = A 0 0 :=
+theorem trace_fin_one (A : Mat[1, 1][R]) : trace A = A 0 0 :=
   add_zero _
 #align matrix.trace_fin_one Matrix.trace_fin_one
 
-theorem trace_fin_two (A : Mat[2,2][R]) : trace A = A 0 0 + A 1 1 :=
+theorem trace_fin_two (A : Mat[2, 2][R]) : trace A = A 0 0 + A 1 1 :=
   congr_arg (_ + ·) (add_zero (A 1 1))
 #align matrix.trace_fin_two Matrix.trace_fin_two
 
-theorem trace_fin_three (A : Mat[3,3][R]) : trace A = A 0 0 + A 1 1 + A 2 2 := by
+theorem trace_fin_three (A : Mat[3, 3][R]) : trace A = A 0 0 + A 1 1 + A 2 2 := by
   rw [← add_zero (A 2 2), add_assoc]
   rfl
 #align matrix.trace_fin_three Matrix.trace_fin_three

--- a/Mathlib/LinearAlgebra/Matrix/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Transvection.lean
@@ -609,7 +609,7 @@ theorem exists_isTwoBlockDiagonal_list_transvec_mul_mul_list_transvec
 diagonal form by elementary operations, then one deduces it for matrices over `Fin r ⊕ Unit`. -/
 theorem exists_list_transvec_mul_mul_list_transvec_eq_diagonal_induction
     (IH :
-      ∀ M : Matrix (Fin r) (Fin r) 𝕜,
+      ∀ M : Mat[r,r][𝕜,]
         ∃ (L₀ L₀' : List (TransvectionStruct (Fin r) 𝕜)) (D₀ : Fin r → 𝕜),
           (L₀.map toMatrix).prod * M * (L₀'.map toMatrix).prod = diagonal D₀)
     (M : Matrix (Sum (Fin r) Unit) (Sum (Fin r) Unit) 𝕜) :

--- a/Mathlib/LinearAlgebra/Matrix/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Transvection.lean
@@ -609,7 +609,7 @@ theorem exists_isTwoBlockDiagonal_list_transvec_mul_mul_list_transvec
 diagonal form by elementary operations, then one deduces it for matrices over `Fin r ⊕ Unit`. -/
 theorem exists_list_transvec_mul_mul_list_transvec_eq_diagonal_induction
     (IH :
-      ∀ M : Mat[r,r][𝕜],
+      ∀ M : Mat[r, r][𝕜],
         ∃ (L₀ L₀' : List (TransvectionStruct (Fin r) 𝕜)) (D₀ : Fin r → 𝕜),
           (L₀.map toMatrix).prod * M * (L₀'.map toMatrix).prod = diagonal D₀)
     (M : Matrix (Sum (Fin r) Unit) (Sum (Fin r) Unit) 𝕜) :

--- a/Mathlib/LinearAlgebra/Matrix/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Transvection.lean
@@ -609,7 +609,7 @@ theorem exists_isTwoBlockDiagonal_list_transvec_mul_mul_list_transvec
 diagonal form by elementary operations, then one deduces it for matrices over `Fin r ⊕ Unit`. -/
 theorem exists_list_transvec_mul_mul_list_transvec_eq_diagonal_induction
     (IH :
-      ∀ M : Mat[r,r][𝕜,]
+      ∀ M : Mat[r,r][𝕜],
         ∃ (L₀ L₀' : List (TransvectionStruct (Fin r) 𝕜)) (D₀ : Fin r → 𝕜),
           (L₀.map toMatrix).prod * M * (L₀'.map toMatrix).prod = diagonal D₀)
     (M : Matrix (Sum (Fin r) Unit) (Sum (Fin r) Unit) 𝕜) :

--- a/Mathlib/LinearAlgebra/PID.lean
+++ b/Mathlib/LinearAlgebra/PID.lean
@@ -37,7 +37,7 @@ lemma trace_restrict_eq_of_forall_mem [IsDomain R] [IsPrincipalIdealRing R]
   let ι := Module.Free.ChooseBasisIndex R M
   obtain ⟨n, snf : Basis.SmithNormalForm p ι n⟩ := p.smithNormalForm (Module.Free.chooseBasis R M)
   rw [trace_eq_matrix_trace R snf.bM, trace_eq_matrix_trace R snf.bN]
-  set A : Mat[n,n][R] := toMatrix snf.bN snf.bN (f.restrict hf')
+  set A : Mat[n, n][R] := toMatrix snf.bN snf.bN (f.restrict hf')
   set B : Matrix ι ι R := toMatrix snf.bM snf.bM f
   have aux : ∀ i, B i i ≠ 0 → i ∈ Set.range snf.f := fun i hi ↦ by
     contrapose! hi; exact snf.repr_eq_zero_of_nmem_range ⟨_, (hf _)⟩ hi

--- a/Mathlib/LinearAlgebra/PID.lean
+++ b/Mathlib/LinearAlgebra/PID.lean
@@ -37,7 +37,7 @@ lemma trace_restrict_eq_of_forall_mem [IsDomain R] [IsPrincipalIdealRing R]
   let ι := Module.Free.ChooseBasisIndex R M
   obtain ⟨n, snf : Basis.SmithNormalForm p ι n⟩ := p.smithNormalForm (Module.Free.chooseBasis R M)
   rw [trace_eq_matrix_trace R snf.bM, trace_eq_matrix_trace R snf.bN]
-  set A : Matrix (Fin n) (Fin n) R := toMatrix snf.bN snf.bN (f.restrict hf')
+  set A : Mat[n,n][R] := toMatrix snf.bN snf.bN (f.restrict hf')
   set B : Matrix ι ι R := toMatrix snf.bM snf.bM f
   have aux : ∀ i, B i i ≠ 0 → i ∈ Set.range snf.f := fun i hi ↦ by
     contrapose! hi; exact snf.repr_eq_zero_of_nmem_range ⟨_, (hf _)⟩ hi

--- a/Mathlib/LinearAlgebra/Vandermonde.lean
+++ b/Mathlib/LinearAlgebra/Vandermonde.lean
@@ -37,7 +37,7 @@ namespace Matrix
 
 /-- `vandermonde v` is the square matrix with `i`th row equal to `1, v i, v i ^ 2, v i ^ 3, ...`.
 -/
-def vandermonde {n : ℕ} (v : Fin n → R) : Matrix (Fin n) (Fin n) R := fun i j => v i ^ (j : ℕ)
+def vandermonde {n : ℕ} (v : Fin n → R) : Mat[n,n][R] := fun i j => v i ^ (j : ℕ)
 #align matrix.vandermonde Matrix.vandermonde
 
 @[simp]

--- a/Mathlib/LinearAlgebra/Vandermonde.lean
+++ b/Mathlib/LinearAlgebra/Vandermonde.lean
@@ -37,7 +37,7 @@ namespace Matrix
 
 /-- `vandermonde v` is the square matrix with `i`th row equal to `1, v i, v i ^ 2, v i ^ 3, ...`.
 -/
-def vandermonde {n : ℕ} (v : Fin n → R) : Mat[n,n][R] := fun i j => v i ^ (j : ℕ)
+def vandermonde {n : ℕ} (v : Fin n → R) : Mat[n, n][R] := fun i j => v i ^ (j : ℕ)
 #align matrix.vandermonde Matrix.vandermonde
 
 @[simp]

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -71,7 +71,7 @@ noncomputable section
 
 local notation "SL(" n ", " R ")" => SpecialLinearGroup (Fin n) R
 
-local macro "↑ₘ" t:term:80 : term => `(term| ($t : Matrix (Fin 2) (Fin 2) ℤ))
+local macro "↑ₘ" t:term:80 : term => `(term| ($t : Mat[2,2][ℤ]))
 
 open scoped UpperHalfPlane ComplexConjugate
 
@@ -83,8 +83,8 @@ section BottomRow
 
 /-- The two numbers `c`, `d` in the "bottom_row" of `g=[[*,*],[c,d]]` in `SL(2, ℤ)` are coprime. -/
 theorem bottom_row_coprime {R : Type*} [CommRing R] (g : SL(2, R)) :
-    IsCoprime ((↑g : Matrix (Fin 2) (Fin 2) R) 1 0) ((↑g : Matrix (Fin 2) (Fin 2) R) 1 1) := by
-  use -(↑g : Matrix (Fin 2) (Fin 2) R) 0 1, (↑g : Matrix (Fin 2) (Fin 2) R) 0 0
+    IsCoprime ((↑g : Mat[2,2][R]) 1 0) ((↑g : Mat[2,2][R]) 1 1) := by
+  use -(↑g : Mat[2,2][R]) 0 1, (↑g : Mat[2,2][R]) 0 0
   rw [add_comm, neg_mul, ← sub_eq_add_neg, ← det_fin_two]
   exact g.det_coe
 #align modular_group.bottom_row_coprime ModularGroup.bottom_row_coprime
@@ -92,7 +92,7 @@ theorem bottom_row_coprime {R : Type*} [CommRing R] (g : SL(2, R)) :
 /-- Every pair `![c, d]` of coprime integers is the "bottom_row" of some element `g=[[*,*],[c,d]]`
 of `SL(2,ℤ)`. -/
 theorem bottom_row_surj {R : Type*} [CommRing R] :
-    Set.SurjOn (fun g : SL(2, R) => (↑g : Matrix (Fin 2) (Fin 2) R) 1) Set.univ
+    Set.SurjOn (fun g : SL(2, R) => (↑g : Mat[2,2][R]) 1) Set.univ
       {cd | IsCoprime (cd 0) (cd 1)} := by
   rintro cd ⟨b₀, a, gcd_eqn⟩
   let A := of ![![a, -b₀], cd]
@@ -164,14 +164,14 @@ theorem tendsto_normSq_coprime_pair :
 /-- Given `coprime_pair` `p=(c,d)`, the matrix `[[a,b],[*,*]]` is sent to `a*c+b*d`.
   This is the linear map version of this operation.
 -/
-def lcRow0 (p : Fin 2 → ℤ) : Matrix (Fin 2) (Fin 2) ℝ →ₗ[ℝ] ℝ :=
+def lcRow0 (p : Fin 2 → ℤ) : Mat[2,2][ℝ] →ₗ[ℝ] ℝ :=
   ((p 0 : ℝ) • LinearMap.proj (0 : Fin 2) +
       (p 1 : ℝ) • LinearMap.proj (1 : Fin 2) : (Fin 2 → ℝ) →ₗ[ℝ] ℝ).comp
     (LinearMap.proj 0)
 #align modular_group.lc_row0 ModularGroup.lcRow0
 
 @[simp]
-theorem lcRow0_apply (p : Fin 2 → ℤ) (g : Matrix (Fin 2) (Fin 2) ℝ) :
+theorem lcRow0_apply (p : Fin 2 → ℤ) (g : Mat[2,2][ℝ]) :
     lcRow0 p g = p 0 * g 0 0 + p 1 * g 0 1 :=
   rfl
 #align modular_group.lc_row0_apply ModularGroup.lcRow0_apply
@@ -180,7 +180,7 @@ theorem lcRow0_apply (p : Fin 2 → ℤ) (g : Matrix (Fin 2) (Fin 2) ℝ) :
 some fixed `(c₀, d₀)`. -/
 @[simps!]
 def lcRow0Extend {cd : Fin 2 → ℤ} (hcd : IsCoprime (cd 0) (cd 1)) :
-    Matrix (Fin 2) (Fin 2) ℝ ≃ₗ[ℝ] Matrix (Fin 2) (Fin 2) ℝ :=
+    Mat[2,2][ℝ] ≃ₗ[ℝ] Mat[2,2][ℝ] :=
   LinearEquiv.piCongrRight
     ![by
       refine'
@@ -199,16 +199,16 @@ attribute [nolint simpNF] lcRow0Extend_apply lcRow0Extend_symm_apply
 theorem tendsto_lcRow0 {cd : Fin 2 → ℤ} (hcd : IsCoprime (cd 0) (cd 1)) :
     Tendsto (fun g : { g : SL(2, ℤ) // (↑ₘg) 1 = cd } => lcRow0 cd ↑(↑g : SL(2, ℝ))) cofinite
       (cocompact ℝ) := by
-  let mB : ℝ → Matrix (Fin 2) (Fin 2) ℝ := fun t => of ![![t, (-(1 : ℤ) : ℝ)], (↑) ∘ cd]
+  let mB : ℝ → Mat[2,2][ℝ] := fun t => of ![![t, (-(1 : ℤ) : ℝ)], (↑) ∘ cd]
   have hmB : Continuous mB := by
     refine' continuous_matrix _
     simp only [mB, Fin.forall_fin_two, continuous_const, continuous_id', of_apply, cons_val_zero,
       cons_val_one, and_self_iff]
   refine' Filter.Tendsto.of_tendsto_comp _ (comap_cocompact_le hmB)
-  let f₁ : SL(2, ℤ) → Matrix (Fin 2) (Fin 2) ℝ := fun g =>
+  let f₁ : SL(2, ℤ) → Mat[2,2][ℝ] := fun g =>
     Matrix.map (↑g : Matrix _ _ ℤ) ((↑) : ℤ → ℝ)
   have cocompact_ℝ_to_cofinite_ℤ_matrix :
-    Tendsto (fun m : Matrix (Fin 2) (Fin 2) ℤ => Matrix.map m ((↑) : ℤ → ℝ)) cofinite
+    Tendsto (fun m : Mat[2,2][ℤ] => Matrix.map m ((↑) : ℤ → ℝ)) cofinite
       (cocompact _) := by
     simpa only [coprodᵢ_cofinite, coprodᵢ_cocompact] using
       Tendsto.pi_map_coprodᵢ fun _ : Fin 2 =>
@@ -248,7 +248,7 @@ theorem smul_eq_lcRow0_add {p : Fin 2 → ℤ} (hp : IsCoprime (p 0) (p 1)) (hg 
   have nonZ2 : (p 0 : ℂ) * z + p 1 ≠ 0 := by simpa using linear_ne_zero _ z this
   field_simp [nonZ1, nonZ2, denom_ne_zero, num]
   rw [(by simp :
-    (p 1 : ℂ) * z - p 0 = (p 1 * z - p 0) * ↑(Matrix.det (↑g : Matrix (Fin 2) (Fin 2) ℤ)))]
+    (p 1 : ℂ) * z - p 0 = (p 1 * z - p 0) * ↑(Matrix.det (↑g : Mat[2,2][ℤ])))]
   rw [← hg, det_fin_two]
   simp only [Int.coe_castRingHom, coe_matrix_coe, Int.cast_mul, ofReal_int_cast, map_apply, denom,
     Int.cast_sub, coe_GLPos_coe_GL_coe_matrix, coe'_apply_complex]

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -71,7 +71,7 @@ noncomputable section
 
 local notation "SL(" n ", " R ")" => SpecialLinearGroup (Fin n) R
 
-local macro "↑ₘ" t:term:80 : term => `(term| ($t : Mat[2,2][ℤ]))
+local macro "↑ₘ" t:term:80 : term => `(term| ($t : Mat[2, 2][ℤ]))
 
 open scoped UpperHalfPlane ComplexConjugate
 
@@ -83,8 +83,8 @@ section BottomRow
 
 /-- The two numbers `c`, `d` in the "bottom_row" of `g=[[*,*],[c,d]]` in `SL(2, ℤ)` are coprime. -/
 theorem bottom_row_coprime {R : Type*} [CommRing R] (g : SL(2, R)) :
-    IsCoprime ((↑g : Mat[2,2][R]) 1 0) ((↑g : Mat[2,2][R]) 1 1) := by
-  use -(↑g : Mat[2,2][R]) 0 1, (↑g : Mat[2,2][R]) 0 0
+    IsCoprime ((↑g : Mat[2, 2][R]) 1 0) ((↑g : Mat[2, 2][R]) 1 1) := by
+  use -(↑g : Mat[2, 2][R]) 0 1, (↑g : Mat[2, 2][R]) 0 0
   rw [add_comm, neg_mul, ← sub_eq_add_neg, ← det_fin_two]
   exact g.det_coe
 #align modular_group.bottom_row_coprime ModularGroup.bottom_row_coprime
@@ -92,7 +92,7 @@ theorem bottom_row_coprime {R : Type*} [CommRing R] (g : SL(2, R)) :
 /-- Every pair `![c, d]` of coprime integers is the "bottom_row" of some element `g=[[*,*],[c,d]]`
 of `SL(2,ℤ)`. -/
 theorem bottom_row_surj {R : Type*} [CommRing R] :
-    Set.SurjOn (fun g : SL(2, R) => (↑g : Mat[2,2][R]) 1) Set.univ
+    Set.SurjOn (fun g : SL(2, R) => (↑g : Mat[2, 2][R]) 1) Set.univ
       {cd | IsCoprime (cd 0) (cd 1)} := by
   rintro cd ⟨b₀, a, gcd_eqn⟩
   let A := of ![![a, -b₀], cd]
@@ -164,14 +164,14 @@ theorem tendsto_normSq_coprime_pair :
 /-- Given `coprime_pair` `p=(c,d)`, the matrix `[[a,b],[*,*]]` is sent to `a*c+b*d`.
   This is the linear map version of this operation.
 -/
-def lcRow0 (p : Fin 2 → ℤ) : Mat[2,2][ℝ] →ₗ[ℝ] ℝ :=
+def lcRow0 (p : Fin 2 → ℤ) : Mat[2, 2][ℝ] →ₗ[ℝ] ℝ :=
   ((p 0 : ℝ) • LinearMap.proj (0 : Fin 2) +
       (p 1 : ℝ) • LinearMap.proj (1 : Fin 2) : (Fin 2 → ℝ) →ₗ[ℝ] ℝ).comp
     (LinearMap.proj 0)
 #align modular_group.lc_row0 ModularGroup.lcRow0
 
 @[simp]
-theorem lcRow0_apply (p : Fin 2 → ℤ) (g : Mat[2,2][ℝ]) :
+theorem lcRow0_apply (p : Fin 2 → ℤ) (g : Mat[2, 2][ℝ]) :
     lcRow0 p g = p 0 * g 0 0 + p 1 * g 0 1 :=
   rfl
 #align modular_group.lc_row0_apply ModularGroup.lcRow0_apply
@@ -180,7 +180,7 @@ theorem lcRow0_apply (p : Fin 2 → ℤ) (g : Mat[2,2][ℝ]) :
 some fixed `(c₀, d₀)`. -/
 @[simps!]
 def lcRow0Extend {cd : Fin 2 → ℤ} (hcd : IsCoprime (cd 0) (cd 1)) :
-    Mat[2,2][ℝ] ≃ₗ[ℝ] Mat[2,2][ℝ] :=
+    Mat[2, 2][ℝ] ≃ₗ[ℝ] Mat[2, 2][ℝ] :=
   LinearEquiv.piCongrRight
     ![by
       refine'
@@ -199,16 +199,16 @@ attribute [nolint simpNF] lcRow0Extend_apply lcRow0Extend_symm_apply
 theorem tendsto_lcRow0 {cd : Fin 2 → ℤ} (hcd : IsCoprime (cd 0) (cd 1)) :
     Tendsto (fun g : { g : SL(2, ℤ) // (↑ₘg) 1 = cd } => lcRow0 cd ↑(↑g : SL(2, ℝ))) cofinite
       (cocompact ℝ) := by
-  let mB : ℝ → Mat[2,2][ℝ] := fun t => of ![![t, (-(1 : ℤ) : ℝ)], (↑) ∘ cd]
+  let mB : ℝ → Mat[2, 2][ℝ] := fun t => of ![![t, (-(1 : ℤ) : ℝ)], (↑) ∘ cd]
   have hmB : Continuous mB := by
     refine' continuous_matrix _
     simp only [mB, Fin.forall_fin_two, continuous_const, continuous_id', of_apply, cons_val_zero,
       cons_val_one, and_self_iff]
   refine' Filter.Tendsto.of_tendsto_comp _ (comap_cocompact_le hmB)
-  let f₁ : SL(2, ℤ) → Mat[2,2][ℝ] := fun g =>
+  let f₁ : SL(2, ℤ) → Mat[2, 2][ℝ] := fun g =>
     Matrix.map (↑g : Matrix _ _ ℤ) ((↑) : ℤ → ℝ)
   have cocompact_ℝ_to_cofinite_ℤ_matrix :
-    Tendsto (fun m : Mat[2,2][ℤ] => Matrix.map m ((↑) : ℤ → ℝ)) cofinite
+    Tendsto (fun m : Mat[2, 2][ℤ] => Matrix.map m ((↑) : ℤ → ℝ)) cofinite
       (cocompact _) := by
     simpa only [coprodᵢ_cofinite, coprodᵢ_cocompact] using
       Tendsto.pi_map_coprodᵢ fun _ : Fin 2 =>
@@ -248,7 +248,7 @@ theorem smul_eq_lcRow0_add {p : Fin 2 → ℤ} (hp : IsCoprime (p 0) (p 1)) (hg 
   have nonZ2 : (p 0 : ℂ) * z + p 1 ≠ 0 := by simpa using linear_ne_zero _ z this
   field_simp [nonZ1, nonZ2, denom_ne_zero, num]
   rw [(by simp :
-    (p 1 : ℂ) * z - p 0 = (p 1 * z - p 0) * ↑(Matrix.det (↑g : Mat[2,2][ℤ])))]
+    (p 1 : ℂ) * z - p 0 = (p 1 * z - p 0) * ↑(Matrix.det (↑g : Mat[2, 2][ℤ])))]
   rw [← hg, det_fin_two]
   simp only [Int.coe_castRingHom, coe_matrix_coe, Int.cast_mul, ofReal_int_cast, map_apply, denom,
     Int.cast_sub, coe_GLPos_coe_GL_coe_matrix, coe'_apply_complex]

--- a/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -25,7 +25,7 @@ local notation "SL(" n ", " R ")" => Matrix.SpecialLinearGroup (Fin n) R
 
 attribute [-instance] Matrix.SpecialLinearGroup.instCoeFun
 
-local notation:1024 "↑ₘ" A:1024 => ((A : SL(2, ℤ)) : Mat[2,2][ℤ])
+local notation:1024 "↑ₘ" A:1024 => ((A : SL(2, ℤ)) : Mat[2, 2][ℤ])
 
 open Matrix.SpecialLinearGroup Matrix
 
@@ -38,7 +38,7 @@ set_option linter.uppercaseLean3 false
 
 @[simp]
 theorem SL_reduction_mod_hom_val (N : ℕ) (γ : SL(2, ℤ)) :
-    ∀ i j : Fin 2, (SLMOD(N) γ : Mat[2,2][ZMod N]) i j = ((↑ₘγ i j : ℤ) : ZMod N) :=
+    ∀ i j : Fin 2, (SLMOD(N) γ : Mat[2, 2][ZMod N]) i j = ((↑ₘγ i j : ℤ) : ZMod N) :=
   fun _ _ => rfl
 #align SL_reduction_mod_hom_val SL_reduction_mod_hom_val
 

--- a/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -38,7 +38,7 @@ set_option linter.uppercaseLean3 false
 
 @[simp]
 theorem SL_reduction_mod_hom_val (N : ℕ) (γ : SL(2, ℤ)) :
-    ∀ i j : Fin 2, (SLMOD(N) γ : Mat[2,2][(ZMod] N)) i j = ((↑ₘγ i j : ℤ) : ZMod N) :=
+    ∀ i j : Fin 2, (SLMOD(N) γ : Mat[2,2][ZMod N]) i j = ((↑ₘγ i j : ℤ) : ZMod N) :=
   fun _ _ => rfl
 #align SL_reduction_mod_hom_val SL_reduction_mod_hom_val
 

--- a/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -25,7 +25,7 @@ local notation "SL(" n ", " R ")" => Matrix.SpecialLinearGroup (Fin n) R
 
 attribute [-instance] Matrix.SpecialLinearGroup.instCoeFun
 
-local notation:1024 "↑ₘ" A:1024 => ((A : SL(2, ℤ)) : Matrix (Fin 2) (Fin 2) ℤ)
+local notation:1024 "↑ₘ" A:1024 => ((A : SL(2, ℤ)) : Mat[2,2][ℤ])
 
 open Matrix.SpecialLinearGroup Matrix
 
@@ -38,7 +38,7 @@ set_option linter.uppercaseLean3 false
 
 @[simp]
 theorem SL_reduction_mod_hom_val (N : ℕ) (γ : SL(2, ℤ)) :
-    ∀ i j : Fin 2, (SLMOD(N) γ : Matrix (Fin 2) (Fin 2) (ZMod N)) i j = ((↑ₘγ i j : ℤ) : ZMod N) :=
+    ∀ i j : Fin 2, (SLMOD(N) γ : Mat[2,2][(ZMod] N)) i j = ((↑ₘγ i j : ℤ) : ZMod N) :=
   fun _ _ => rfl
 #align SL_reduction_mod_hom_val SL_reduction_mod_hom_val
 

--- a/Mathlib/NumberTheory/ModularForms/SlashActions.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashActions.lean
@@ -34,10 +34,10 @@ local notation "GL(" n ", " R ")" "⁺" => Matrix.GLPos (Fin n) R
 local notation "SL(" n ", " R ")" => Matrix.SpecialLinearGroup (Fin n) R
 
 local notation:1024 "↑ₘ" A:1024 =>
-  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Mat[2,2][_])
+  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Mat[2, 2][_])
 -- like `↑ₘ`, but allows the user to specify the ring `R`. Useful to help Lean elaborate.
 local notation:1024 "↑ₘ[" R "]" A:1024 =>
-  ((A : GL (Fin 2) R) : Mat[2,2][R])
+  ((A : GL (Fin 2) R) : Mat[2, 2][R])
 
 /-- A general version of the slash action of the space of modular forms. -/
 class SlashAction (β G α γ : Type*) [Group G] [AddMonoid α] [SMul γ α] where
@@ -113,10 +113,10 @@ private theorem slash_mul (k : ℤ) (A B : GL(2, ℝ)⁺) (f : ℍ → ℂ) :
     UpperHalfPlane.coe_smul, Units.val_mul, Matrix.det_mul,
     UpperHalfPlane.smulAux, UpperHalfPlane.smulAux', UpperHalfPlane.coe_mk] at *
   field_simp
-  have : (((↑(↑A : GL (Fin 2) ℝ) : Mat[2,2][ℝ]).det : ℂ) *
-      ((↑(↑B : GL (Fin 2) ℝ) : Mat[2,2][ℝ]).det : ℂ)) ^ (k - 1) =
-      ((↑(↑A : GL (Fin 2) ℝ) : Mat[2,2][ℝ]).det : ℂ) ^ (k - 1) *
-        ((↑(↑B : GL (Fin 2) ℝ) : Mat[2,2][ℝ]).det : ℂ) ^ (k - 1) := by
+  have : (((↑(↑A : GL (Fin 2) ℝ) : Mat[2, 2][ℝ]).det : ℂ) *
+      ((↑(↑B : GL (Fin 2) ℝ) : Mat[2, 2][ℝ]).det : ℂ)) ^ (k - 1) =
+      ((↑(↑A : GL (Fin 2) ℝ) : Mat[2, 2][ℝ]).det : ℂ) ^ (k - 1) *
+        ((↑(↑B : GL (Fin 2) ℝ) : Mat[2, 2][ℝ]).det : ℂ) ^ (k - 1) := by
     rw [← mul_zpow]
   simp_rw [this, ← mul_assoc, ← mul_zpow]
 

--- a/Mathlib/NumberTheory/ModularForms/SlashActions.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashActions.lean
@@ -34,10 +34,10 @@ local notation "GL(" n ", " R ")" "⁺" => Matrix.GLPos (Fin n) R
 local notation "SL(" n ", " R ")" => Matrix.SpecialLinearGroup (Fin n) R
 
 local notation:1024 "↑ₘ" A:1024 =>
-  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) _)
+  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Mat[2,2][_])
 -- like `↑ₘ`, but allows the user to specify the ring `R`. Useful to help Lean elaborate.
 local notation:1024 "↑ₘ[" R "]" A:1024 =>
-  ((A : GL (Fin 2) R) : Matrix (Fin 2) (Fin 2) R)
+  ((A : GL (Fin 2) R) : Mat[2,2][R])
 
 /-- A general version of the slash action of the space of modular forms. -/
 class SlashAction (β G α γ : Type*) [Group G] [AddMonoid α] [SMul γ α] where
@@ -113,10 +113,10 @@ private theorem slash_mul (k : ℤ) (A B : GL(2, ℝ)⁺) (f : ℍ → ℂ) :
     UpperHalfPlane.coe_smul, Units.val_mul, Matrix.det_mul,
     UpperHalfPlane.smulAux, UpperHalfPlane.smulAux', UpperHalfPlane.coe_mk] at *
   field_simp
-  have : (((↑(↑A : GL (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) ℝ).det : ℂ) *
-      ((↑(↑B : GL (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) ℝ).det : ℂ)) ^ (k - 1) =
-      ((↑(↑A : GL (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) ℝ).det : ℂ) ^ (k - 1) *
-        ((↑(↑B : GL (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) ℝ).det : ℂ) ^ (k - 1) := by
+  have : (((↑(↑A : GL (Fin 2) ℝ) : Mat[2,2][ℝ]).det : ℂ) *
+      ((↑(↑B : GL (Fin 2) ℝ) : Mat[2,2][ℝ]).det : ℂ)) ^ (k - 1) =
+      ((↑(↑A : GL (Fin 2) ℝ) : Mat[2,2][ℝ]).det : ℂ) ^ (k - 1) *
+        ((↑(↑B : GL (Fin 2) ℝ) : Mat[2,2][ℝ]).det : ℂ) ^ (k - 1) := by
     rw [← mul_zpow]
   simp_rw [this, ← mul_assoc, ← mul_zpow]
 

--- a/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
@@ -27,10 +27,10 @@ local notation "GL(" n ", " R ")" "⁺" => Matrix.GLPos (Fin n) R
 local notation "SL(" n ", " R ")" => Matrix.SpecialLinearGroup (Fin n) R
 
 local notation:1024 "↑ₘ" A:1024 =>
-  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Mat[2,2][_])
+  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Mat[2, 2][_])
 -- like `↑ₘ`, but allows the user to specify the ring `R`. Useful to help Lean elaborate.
 local notation:1024 "↑ₘ[" R "]" A:1024 =>
-  ((A : GL (Fin 2) R) : Mat[2,2][R])
+  ((A : GL (Fin 2) R) : Mat[2, 2][R])
 
 section SlashInvariantForms
 

--- a/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
@@ -27,10 +27,10 @@ local notation "GL(" n ", " R ")" "⁺" => Matrix.GLPos (Fin n) R
 local notation "SL(" n ", " R ")" => Matrix.SpecialLinearGroup (Fin n) R
 
 local notation:1024 "↑ₘ" A:1024 =>
-  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Matrix (Fin 2) (Fin 2) _)
+  (((A : GL(2, ℝ)⁺) : GL (Fin 2) ℝ) : Mat[2,2][_])
 -- like `↑ₘ`, but allows the user to specify the ring `R`. Useful to help Lean elaborate.
 local notation:1024 "↑ₘ[" R "]" A:1024 =>
-  ((A : GL (Fin 2) R) : Matrix (Fin 2) (Fin 2) R)
+  ((A : GL (Fin 2) R) : Mat[2,2][R])
 
 section SlashInvariantForms
 

--- a/Mathlib/NumberTheory/RamificationInertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia.lean
@@ -364,8 +364,8 @@ theorem FinrankQuotientMap.span_eq_top [IsDomain R] [IsDomain S] [Algebra K L] [
         rw [RingHom.map_det]
       _ = Matrix.det ((Ideal.Quotient.mk p).mapMatrix (Matrix.of A' - 1)) := rfl
       _ = Matrix.det fun i j =>
-          (Ideal.Quotient.mk p) (A' i j) - (1 : Mat[n,n][(R] ⧸ p)) i j := ?_
-      _ = Matrix.det (-1 : Mat[n,n][(R] ⧸ p)) := ?_
+          (Ideal.Quotient.mk p) (A' i j) - (1 : Mat[n,n][R ⧸ p]) i j := ?_
+      _ = Matrix.det (-1 : Mat[n,n][R ⧸ p]) := ?_
       _ = (-1 : R ⧸ p) ^ n := by rw [Matrix.det_neg, Fintype.card_fin, Matrix.det_one, mul_one]
       _ ≠ 0 := IsUnit.ne_zero (isUnit_one.neg.pow _)
     · refine congr_arg Matrix.det (Matrix.ext fun i j => ?_)

--- a/Mathlib/NumberTheory/RamificationInertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia.lean
@@ -319,7 +319,7 @@ theorem FinrankQuotientMap.span_eq_top [IsDomain R] [IsDomain S] [Algebra K L] [
       exact fun _ => zero_smul _ _
   choose A' hA'p hA' using fun i => exists_sum (a i)
   -- This gives us a(n invertible) matrix `A` such that `det A ∈ (M = span R b)`,
-  let A : Mat[n,n][R] := Matrix.of A' - 1
+  let A : Mat[n, n][R] := Matrix.of A' - 1
   let B := A.adjugate
   have A_smul : ∀ i, ∑ j, A i j • a j = 0 := by
     intros
@@ -364,8 +364,8 @@ theorem FinrankQuotientMap.span_eq_top [IsDomain R] [IsDomain S] [Algebra K L] [
         rw [RingHom.map_det]
       _ = Matrix.det ((Ideal.Quotient.mk p).mapMatrix (Matrix.of A' - 1)) := rfl
       _ = Matrix.det fun i j =>
-          (Ideal.Quotient.mk p) (A' i j) - (1 : Mat[n,n][R ⧸ p]) i j := ?_
-      _ = Matrix.det (-1 : Mat[n,n][R ⧸ p]) := ?_
+          (Ideal.Quotient.mk p) (A' i j) - (1 : Mat[n, n][R ⧸ p]) i j := ?_
+      _ = Matrix.det (-1 : Mat[n, n][R ⧸ p]) := ?_
       _ = (-1 : R ⧸ p) ^ n := by rw [Matrix.det_neg, Fintype.card_fin, Matrix.det_one, mul_one]
       _ ≠ 0 := IsUnit.ne_zero (isUnit_one.neg.pow _)
     · refine congr_arg Matrix.det (Matrix.ext fun i j => ?_)

--- a/Mathlib/NumberTheory/RamificationInertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia.lean
@@ -319,7 +319,7 @@ theorem FinrankQuotientMap.span_eq_top [IsDomain R] [IsDomain S] [Algebra K L] [
       exact fun _ => zero_smul _ _
   choose A' hA'p hA' using fun i => exists_sum (a i)
   -- This gives us a(n invertible) matrix `A` such that `det A ∈ (M = span R b)`,
-  let A : Matrix (Fin n) (Fin n) R := Matrix.of A' - 1
+  let A : Mat[n,n][R] := Matrix.of A' - 1
   let B := A.adjugate
   have A_smul : ∀ i, ∑ j, A i j • a j = 0 := by
     intros
@@ -364,8 +364,8 @@ theorem FinrankQuotientMap.span_eq_top [IsDomain R] [IsDomain S] [Algebra K L] [
         rw [RingHom.map_det]
       _ = Matrix.det ((Ideal.Quotient.mk p).mapMatrix (Matrix.of A' - 1)) := rfl
       _ = Matrix.det fun i j =>
-          (Ideal.Quotient.mk p) (A' i j) - (1 : Matrix (Fin n) (Fin n) (R ⧸ p)) i j := ?_
-      _ = Matrix.det (-1 : Matrix (Fin n) (Fin n) (R ⧸ p)) := ?_
+          (Ideal.Quotient.mk p) (A' i j) - (1 : Mat[n,n][(R] ⧸ p)) i j := ?_
+      _ = Matrix.det (-1 : Mat[n,n][(R] ⧸ p)) := ?_
       _ = (-1 : R ⧸ p) ^ n := by rw [Matrix.det_neg, Fintype.card_fin, Matrix.det_one, mul_one]
       _ ≠ 0 := IsUnit.ne_zero (isUnit_one.neg.pow _)
     · refine congr_arg Matrix.det (Matrix.ext fun i j => ?_)

--- a/Mathlib/RingTheory/SimpleModule.lean
+++ b/Mathlib/RingTheory/SimpleModule.lean
@@ -350,7 +350,7 @@ universe u in
 proof_wanted isSemisimpleRing_iff_pi_matrix_divisionRing {R : Type u} [Ring R] :
     IsSemisimpleRing R ↔
     ∃ (n : ℕ) (S : Fin n → Type u) (d : Fin n → ℕ) (_ : ∀ i, DivisionRing (S i)),
-      Nonempty (R ≃+* ∀ i, Mat[(d i),(d i)][(S] i))
+      Nonempty (R ≃+* ∀ i, Mat[(d i),(d i)][S i])
 
 variable {ι R}
 

--- a/Mathlib/RingTheory/SimpleModule.lean
+++ b/Mathlib/RingTheory/SimpleModule.lean
@@ -350,7 +350,7 @@ universe u in
 proof_wanted isSemisimpleRing_iff_pi_matrix_divisionRing {R : Type u} [Ring R] :
     IsSemisimpleRing R ↔
     ∃ (n : ℕ) (S : Fin n → Type u) (d : Fin n → ℕ) (_ : ∀ i, DivisionRing (S i)),
-      Nonempty (R ≃+* ∀ i, Mat[(d i),(d i)][S i])
+      Nonempty (R ≃+* ∀ i, Mat[(d i), (d i)][S i])
 
 variable {ι R}
 

--- a/Mathlib/RingTheory/SimpleModule.lean
+++ b/Mathlib/RingTheory/SimpleModule.lean
@@ -350,7 +350,7 @@ universe u in
 proof_wanted isSemisimpleRing_iff_pi_matrix_divisionRing {R : Type u} [Ring R] :
     IsSemisimpleRing R ↔
     ∃ (n : ℕ) (S : Fin n → Type u) (d : Fin n → ℕ) (_ : ∀ i, DivisionRing (S i)),
-      Nonempty (R ≃+* ∀ i, Matrix (Fin (d i)) (Fin (d i)) (S i))
+      Nonempty (R ≃+* ∀ i, Mat[(d i),(d i)][(S] i))
 
 variable {ι R}
 

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -60,15 +60,15 @@ def mkColumnVector (elems : Array Term) : Term := Unhygienic.run `(!![$[$elems];
 
 -- Check that the `!![$[$[$rows],*];*]` case can deal with empty arrays even though it uses sepBy1
 run_cmd liftTermElabM do
-  let e ← Term.elabTerm (mkMatrix #[]) q(Mat[0,0][Nat])
+  let e ← Term.elabTerm (mkMatrix #[]) q(Mat[0, 0][Nat])
   Term.synthesizeSyntheticMVarsUsingDefault
   let e ← instantiateMVars e
-  guard <| e == q(!![] : Mat[0,0][Nat])
+  guard <| e == q(!![] : Mat[0, 0][Nat])
 
-  let e ← Term.elabTerm (mkColumnVector #[]) q(Mat[0,0][Nat])
+  let e ← Term.elabTerm (mkColumnVector #[]) q(Mat[0, 0][Nat])
   Term.synthesizeSyntheticMVarsUsingDefault
   let e ← instantiateMVars e
-  guard <| e == q(!![] : Mat[0,0][Nat])
+  guard <| e == q(!![] : Mat[0, 0][Nat])
 
 end safety
 

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -60,15 +60,15 @@ def mkColumnVector (elems : Array Term) : Term := Unhygienic.run `(!![$[$elems];
 
 -- Check that the `!![$[$[$rows],*];*]` case can deal with empty arrays even though it uses sepBy1
 run_cmd liftTermElabM do
-  let e ← Term.elabTerm (mkMatrix #[]) q(Matrix (Fin 0) (Fin 0) Nat)
+  let e ← Term.elabTerm (mkMatrix #[]) q(Mat[0,0][Nat])
   Term.synthesizeSyntheticMVarsUsingDefault
   let e ← instantiateMVars e
-  guard <| e == q(!![] : Matrix (Fin 0) (Fin 0) Nat)
+  guard <| e == q(!![] : Mat[0,0][Nat])
 
-  let e ← Term.elabTerm (mkColumnVector #[]) q(Matrix (Fin 0) (Fin 0) Nat)
+  let e ← Term.elabTerm (mkColumnVector #[]) q(Mat[0,0][Nat])
   Term.synthesizeSyntheticMVarsUsingDefault
   let e ← instantiateMVars e
-  guard <| e == q(!![] : Matrix (Fin 0) (Fin 0) Nat)
+  guard <| e == q(!![] : Mat[0,0][Nat])
 
 end safety
 


### PR DESCRIPTION
Introduce the notation `Mat[m,n][R]` for `Matrix (Fin m) (Fin n) R`.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Why.20does.20.60Matrix.2Erow.60.20use.20.20.60Unit.60.20instead.20of.20.60Fin.201.60.3F/near/427949223)

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
