### PR TITLE
test: `have` to `let`

### DIFF
--- a/Archive/Wiedijk100Theorems/CubingACube.lean
+++ b/Archive/Wiedijk100Theorems/CubingACube.lean
@@ -296,7 +296,7 @@ theorem t_le_t (hi : i ∈ bcubes cs c) (j : Fin n) :
 /-- Every cube in the valley must be smaller than it -/
 theorem w_lt_w (hi : i ∈ bcubes cs c) : (cs i).w < c.w := by
   apply lt_of_le_of_ne _ (v.2.2 i hi.1)
-  have j : Fin n := ⟨1, Nat.le_of_succ_le_succ h.three_le⟩
+  let j : Fin n := ⟨1, Nat.le_of_succ_le_succ h.three_le⟩
   rw [← add_le_add_iff_left ((cs i).b j.succ)]
   apply le_trans (t_le_t hi j); rw [add_le_add_iff_right]; apply b_le_b hi
 #align theorems_100.«82».w_lt_w Theorems100.«82».w_lt_w

--- a/Archive/Wiedijk100Theorems/FriendshipGraphs.lean
+++ b/Archive/Wiedijk100Theorems/FriendshipGraphs.lean
@@ -144,7 +144,7 @@ variable [Nonempty V]
   neither is adjacent to, and then using transitivity. -/
 theorem isRegularOf_not_existsPolitician (hG' : ¬ExistsPolitician G) :
     ∃ d : ℕ, G.IsRegularOfDegree d := by
-  have v := Classical.arbitrary V
+  let v := Classical.arbitrary V
   use G.degree v
   intro x
   by_cases hvx : G.Adj v x; swap; · exact (degree_eq_of_not_adj hG hvx).symm
@@ -177,7 +177,7 @@ theorem isRegularOf_not_existsPolitician (hG' : ¬ExistsPolitician G) :
 
   This essentially means that the graph has `d ^ 2 - d + 1` vertices. -/
 theorem card_of_regular (hd : G.IsRegularOfDegree d) : d + (Fintype.card V - 1) = d * d := by
-  have v := Classical.arbitrary V
+  let v := Classical.arbitrary V
   trans ((G.adjMatrix ℕ ^ 2) *ᵥ (fun _ => 1)) v
   · rw [adjMatrix_sq_of_regular hG hd, mulVec, dotProduct, ← insert_erase (mem_univ v)]
     simp only [sum_insert, mul_one, if_true, Nat.cast_id, eq_self_iff_true, mem_erase, not_true,
@@ -306,7 +306,7 @@ theorem neighborFinset_eq_of_degree_eq_two (hd : G.IsRegularOfDegree 2) (v : V) 
 #align theorems_100.friendship.neighbor_finset_eq_of_degree_eq_two Theorems100.Friendship.neighborFinset_eq_of_degree_eq_two
 
 theorem existsPolitician_of_degree_eq_two (hd : G.IsRegularOfDegree 2) : ExistsPolitician G := by
-  have v := Classical.arbitrary V
+  let v := Classical.arbitrary V
   use v
   intro w hvw
   rw [← mem_neighborFinset, neighborFinset_eq_of_degree_eq_two hG hd v, Finset.mem_erase]

--- a/Mathlib/Algebra/Algebra/Tower.lean
+++ b/Mathlib/Algebra/Algebra/Tower.lean
@@ -133,7 +133,7 @@ theorem algebraMap_apply (x : R) : algebraMap R A x = algebraMap S A (algebraMap
 
 @[ext]
 theorem Algebra.ext {S : Type u} {A : Type v} [CommSemiring S] [Semiring A] (h1 h2 : Algebra S A)
-    (h : ∀ (r : S) (x : A), (by have I := h1; exact r • x) = r • x) : h1 = h2 :=
+    (h : ∀ (r : S) (x : A), (by let I := h1; exact r • x) = r • x) : h1 = h2 :=
   Algebra.algebra_ext _ _ fun r => by
     simpa only [@Algebra.smul_def _ _ _ _ h1, @Algebra.smul_def _ _ _ _ h2, mul_one] using h r 1
 #align is_scalar_tower.algebra.ext IsScalarTower.Algebra.ext

--- a/Mathlib/Algebra/BigOperators/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Basic.lean
@@ -373,7 +373,7 @@ theorem prod_union [DecidableEq α] (h : Disjoint s₁ s₂) :
 theorem prod_filter_mul_prod_filter_not
     (s : Finset α) (p : α → Prop) [DecidablePred p] [∀ x, Decidable (¬p x)] (f : α → β) :
     (∏ x in s.filter p, f x) * ∏ x in s.filter fun x => ¬p x, f x = ∏ x in s, f x := by
-  have := Classical.decEq α
+  let _ := Classical.decEq α
   rw [← prod_union (disjoint_filter_filter_neg s s p), filter_union_filter_neg_eq]
 #align finset.prod_filter_mul_prod_filter_not Finset.prod_filter_mul_prod_filter_not
 #align finset.sum_filter_add_sum_filter_not Finset.sum_filter_add_sum_filter_not

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -697,7 +697,7 @@ theorem of.zero_exact_aux [Nonempty ι] [IsDirected ι (· ≤ ·)] {x : FreeCom
         IsSupported x s ∧
           ∀ [DecidablePred (· ∈ s)],
             lift (fun ix : s => f' ix.1.1 j (H ix ix.2) ix.1.2) (restriction s x) = (0 : G j) := by
-  have := Classical.decEq
+  let _ := Classical.decEq
   refine' span_induction (Ideal.Quotient.eq_zero_iff_mem.1 H) _ _ _ _
   · rintro x (⟨i, j, hij, x, rfl⟩ | ⟨i, rfl⟩ | ⟨i, x, y, rfl⟩ | ⟨i, x, y, rfl⟩)
     · refine'

--- a/Mathlib/Algebra/Homology/HomologicalComplexBiprod.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplexBiprod.lean
@@ -26,11 +26,11 @@ instance (i : ι) : HasBinaryBiproduct ((eval C c i).obj K) ((eval C c i).obj L)
   infer_instance
 
 instance (i : ι) : HasLimit ((pair K L) ⋙ (eval C c i)) := by
-  have e : _ ≅ pair (K.X i) (L.X i) := diagramIsoPair (pair K L ⋙ eval C c i)
+  let e : _ ≅ pair (K.X i) (L.X i) := diagramIsoPair (pair K L ⋙ eval C c i)
   exact hasLimitOfIso e.symm
 
 instance (i : ι) : HasColimit ((pair K L) ⋙ (eval C c i)) := by
-  have e : _ ≅ pair (K.X i) (L.X i) := diagramIsoPair (pair K L ⋙ eval C c i)
+  let e : _ ≅ pair (K.X i) (L.X i) := diagramIsoPair (pair K L ⋙ eval C c i)
   exact hasColimitOfIso e
 
 instance : HasBinaryBiproduct K L := HasBinaryBiproduct.of_hasBinaryProduct _ _

--- a/Mathlib/Algebra/Homology/HomologySequence.lean
+++ b/Mathlib/Algebra/Homology/HomologySequence.lean
@@ -171,11 +171,11 @@ lemma opcycles_right_exact (S : ShortComplex (HomologicalComplex C c)) (hS : S.E
     (ShortComplex.mk (opcyclesMap S.f i) (opcyclesMap S.g i)
       (by rw [← opcyclesMap_comp, S.zero, opcyclesMap_zero])).Exact := by
   have : Epi (ShortComplex.map S (eval C c i)).g := by dsimp; infer_instance
-  have hj := (hS.map (HomologicalComplex.eval C c i)).gIsCokernel
+  let hj := (hS.map (HomologicalComplex.eval C c i)).gIsCokernel
   apply ShortComplex.exact_of_g_is_cokernel
   refine' CokernelCofork.IsColimit.ofπ' _ _  (fun {A} k hk => by
     dsimp at k hk ⊢
-    have H := CokernelCofork.IsColimit.desc' hj (S.X₂.pOpcycles i ≫ k) (by
+    let H := CokernelCofork.IsColimit.desc' hj (S.X₂.pOpcycles i ≫ k) (by
       dsimp
       rw [← p_opcyclesMap_assoc, hk, comp_zero])
     dsimp at H
@@ -193,11 +193,11 @@ lemma cycles_left_exact (S : ShortComplex (HomologicalComplex C c)) (hS : S.Exac
     (ShortComplex.mk (cyclesMap S.f i) (cyclesMap S.g i)
       (by rw [← cyclesMap_comp, S.zero, cyclesMap_zero])).Exact := by
   have : Mono (ShortComplex.map S (eval C c i)).f := by dsimp; infer_instance
-  have hi := (hS.map (HomologicalComplex.eval C c i)).fIsKernel
+  let hi := (hS.map (HomologicalComplex.eval C c i)).fIsKernel
   apply ShortComplex.exact_of_f_is_kernel
   exact KernelFork.IsLimit.ofι' _ _ (fun {A} k hk => by
     dsimp at k hk ⊢
-    have H := KernelFork.IsLimit.lift' hi (k ≫ S.X₂.iCycles i) (by
+    let H := KernelFork.IsLimit.lift' hi (k ≫ S.X₂.iCycles i) (by
       dsimp
       rw [assoc, ← cyclesMap_i, reassoc_of% hk, zero_comp])
     dsimp at H
@@ -292,7 +292,7 @@ lemma homology_exact₂ : (ShortComplex.mk (HomologicalComplex.homologyMap S.f i
   · have := hS.epi_g
     have : ∀ (K : HomologicalComplex C c), IsIso (K.homologyι i) :=
       fun K => ShortComplex.isIso_homologyι (K.sc i) (K.shape _ _ h)
-    have e : S.map (HomologicalComplex.homologyFunctor C c i) ≅
+    let e : S.map (HomologicalComplex.homologyFunctor C c i) ≅
         S.map (HomologicalComplex.opcyclesFunctor C c i) :=
       ShortComplex.isoMk (asIso (S.X₁.homologyι i))
         (asIso (S.X₂.homologyι i)) (asIso (S.X₃.homologyι i)) (by aesop_cat) (by aesop_cat)

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
@@ -437,7 +437,7 @@ lemma complete_distinguished_triangle_morphism
     b' = e₁.inv.hom₂ ≫ b ≫ e₂.hom.hom₂ := ⟨_, rfl⟩
   obtain ⟨a'', rfl⟩ := (quotient _ _).map_surjective a'
   obtain ⟨b'', rfl⟩ := (quotient _ _).map_surjective b'
-  have H : Homotopy (φ₁ ≫ b'') (a'' ≫ φ₂) := homotopyOfEq _ _ (by
+  let H : Homotopy (φ₁ ≫ b'') (a'' ≫ φ₂) := homotopyOfEq _ _ (by
     have comm₁₁ := e₁.inv.comm₁
     have comm₁₂ := e₂.hom.comm₁
     dsimp at comm₁₁ comm₁₂

--- a/Mathlib/Algebra/Homology/Localization.lean
+++ b/Mathlib/Algebra/Homology/Localization.lean
@@ -220,7 +220,7 @@ def ComplexShape.strictUniversalPropertyFixedTargetQuotient (E : Type*) [Categor
   inverts := HomotopyCategory.quotient_inverts_homotopyEquivalences C c
   lift F hF := CategoryTheory.Quotient.lift _ F (by
     intro K L f g ⟨h⟩
-    have : DecidableRel c.Rel := by classical infer_instance
+    let _ : DecidableRel c.Rel := by classical infer_instance
     exact h.map_eq_of_inverts_homotopyEquivalences hc F hF)
   fac F hF := rfl
   uniq F₁ F₂ h := Quotient.lift_unique' _ _ _ h
@@ -234,7 +234,7 @@ lemma ComplexShape.quotient_isLocalization :
 lemma ComplexShape.QFactorsThroughHomotopy_of_exists_prev [CategoryWithHomology C] :
     c.QFactorsThroughHomotopy C where
   areEqualizedByLocalization {K L f g} h := by
-    have : DecidableRel c.Rel := by classical infer_instance
+    let _ : DecidableRel c.Rel := by classical infer_instance
     exact h.map_eq_of_inverts_homotopyEquivalences hc _
       (MorphismProperty.IsInvertedBy.of_subset _ _ _
         (Localization.inverts _ (HomologicalComplex.quasiIso C _))

--- a/Mathlib/Algebra/Homology/ShortComplex/Abelian.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Abelian.lean
@@ -86,7 +86,7 @@ noncomputable def ofAbelian : S.LeftHomologyData := by
   have fac : f' = Abelian.factorThruImage S.f ≫ e.hom ≫ kernel.ι γ := by
     rw [hf', he]
     simp only [f', kernel.lift_ι, abelianImageToKernel, ← cancel_mono (kernel.ι S.g), assoc]
-  have hπ : IsColimit (CokernelCofork.ofπ _ wπ) :=
+  let hπ : IsColimit (CokernelCofork.ofπ _ wπ) :=
     CokernelCofork.IsColimit.ofπ _ _
     (fun x hx => cokernel.desc _ x (by
       simpa only [← cancel_epi e.hom, ← cancel_epi (Abelian.factorThruImage S.f),
@@ -153,7 +153,7 @@ noncomputable def ofAbelian : S.RightHomologyData := by
     rw [hg', reassoc_of% he]
     simp only [g', cokernel.π_desc, ← cancel_epi (cokernel.π S.f),
       cokernel_π_comp_cokernelToAbelianCoimage_assoc]
-  have hι : IsLimit (KernelFork.ofι _ wι) :=
+  let hι : IsLimit (KernelFork.ofι _ wι) :=
     KernelFork.IsLimit.ofι _ _
       (fun x hx => kernel.lift _ x (by
         simpa only [← cancel_mono e.hom, ← cancel_mono (Abelian.factorThruCoimage S.g), assoc,

--- a/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ConcreteCategory.lean
@@ -52,7 +52,7 @@ lemma Preadditive.mono_iff_injective' {X Y : C} (f : X ⟶ Y) :
     Mono f ↔ Function.Injective ((forget C).map f) := by
   simp only [mono_iff_injective, ← CategoryTheory.mono_iff_injective]
   apply (MorphismProperty.RespectsIso.monomorphisms (Type w)).arrow_mk_iso_iff
-  have e : forget₂ C Ab ⋙ forget Ab ≅ forget C := eqToIso (HasForget₂.forget_comp)
+  let e : forget₂ C Ab ⋙ forget Ab ≅ forget C := eqToIso (HasForget₂.forget_comp)
   exact Arrow.isoOfNatIso e (Arrow.mk f)
 
 lemma Preadditive.epi_iff_surjective {X Y : C} (f : X ⟶ Y) :
@@ -67,7 +67,7 @@ lemma Preadditive.epi_iff_surjective' {X Y : C} (f : X ⟶ Y) :
     Epi f ↔ Function.Surjective ((forget C).map f) := by
   simp only [epi_iff_surjective, ← CategoryTheory.epi_iff_surjective]
   apply (MorphismProperty.RespectsIso.epimorphisms (Type w)).arrow_mk_iso_iff
-  have e : forget₂ C Ab ⋙ forget Ab ≅ forget C := eqToIso (HasForget₂.forget_comp)
+  let e : forget₂ C Ab ⋙ forget Ab ≅ forget C := eqToIso (HasForget₂.forget_comp)
   exact Arrow.isoOfNatIso e (Arrow.mk f)
 
 namespace ShortComplex
@@ -134,8 +134,8 @@ variable (D : SnakeInput C)
 lemma δ_apply (x₃ : D.L₀.X₃) (x₂ : D.L₁.X₂) (x₁ : D.L₂.X₁)
     (h₂ : D.L₁.g x₂ = D.v₀₁.τ₃ x₃) (h₁ : D.L₂.f x₁ = D.v₁₂.τ₂ x₂) :
     D.δ x₃ = D.v₂₃.τ₁ x₁ := by
-  have := (forget₂ C Ab).preservesFiniteLimitsOfPreservesHomology
-  have : PreservesFiniteLimits (forget C) := by
+  let _ := (forget₂ C Ab).preservesFiniteLimitsOfPreservesHomology
+  let _ : PreservesFiniteLimits (forget C) := by
     have : forget₂ C Ab ⋙ forget Ab = forget C := HasForget₂.forget_comp
     simpa only [← this] using compPreservesFiniteLimits _ _
   have eq := congr_fun ((forget C).congr_map D.snd_δ)
@@ -159,7 +159,7 @@ lemma δ_apply' (x₃ : (forget₂ C Ab).obj D.L₀.X₃)
     (h₂ : (forget₂ C Ab).map D.L₁.g x₂ = (forget₂ C Ab).map D.v₀₁.τ₃ x₃)
     (h₁ : (forget₂ C Ab).map D.L₂.f x₁ = (forget₂ C Ab).map D.v₁₂.τ₂ x₂) :
     (forget₂ C Ab).map D.δ x₃ = (forget₂ C Ab).map D.v₂₃.τ₁ x₁ := by
-  have e : forget₂ C Ab ⋙ forget Ab ≅ forget C := eqToIso (HasForget₂.forget_comp)
+  let e : forget₂ C Ab ⋙ forget Ab ≅ forget C := eqToIso (HasForget₂.forget_comp)
   apply (mono_iff_injective (e.hom.app _)).1 inferInstance
   refine (congr_hom (e.hom.naturality D.δ) x₃).trans
     ((D.δ_apply (e.hom.app _ x₃) (e.hom.app _ x₂) (e.hom.app _ x₁) ?_ ?_ ).trans

--- a/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
@@ -550,7 +550,7 @@ lemma ext_s (s s' : S.Splitting) (h : s.s = s'.s) : s = s' := by
 @[simps]
 noncomputable def leftHomologyData [HasZeroObject C] (s : S.Splitting) :
     LeftHomologyData S := by
-  have hi := KernelFork.IsLimit.ofι S.f S.zero
+  let hi := KernelFork.IsLimit.ofι S.f S.zero
     (fun x _ => x ≫ s.r)
     (fun x hx => by simp only [assoc, s.r_f, comp_sub, comp_id,
       sub_eq_self, reassoc_of% hx, zero_comp])
@@ -562,7 +562,7 @@ noncomputable def leftHomologyData [HasZeroObject C] (s : S.Splitting) :
     erw [Fork.IsLimit.lift_ι hi]
     simp only [Fork.ι_ofι, id_comp]
   have wπ : f' ≫ (0 : S.X₁ ⟶ 0) = 0 := comp_zero
-  have hπ : IsColimit (CokernelCofork.ofπ 0 wπ) := CokernelCofork.IsColimit.ofEpiOfIsZero _
+  let hπ : IsColimit (CokernelCofork.ofπ 0 wπ) := CokernelCofork.IsColimit.ofEpiOfIsZero _
       (by rw [hf']; infer_instance) (isZero_zero _)
   exact
     { K := S.X₁
@@ -578,7 +578,7 @@ noncomputable def leftHomologyData [HasZeroObject C] (s : S.Splitting) :
 @[simps]
 noncomputable def rightHomologyData [HasZeroObject C] (s : S.Splitting) :
     RightHomologyData S := by
-  have hp := CokernelCofork.IsColimit.ofπ S.g S.zero
+  let hp := CokernelCofork.IsColimit.ofπ S.g S.zero
     (fun x _ => s.s ≫ x)
     (fun x hx => by simp only [s.g_s_assoc, sub_comp, id_comp, sub_eq_self, assoc, hx, comp_zero])
     (fun x _ b hb => by simp only [← hb, s.s_g_assoc])
@@ -589,7 +589,7 @@ noncomputable def rightHomologyData [HasZeroObject C] (s : S.Splitting) :
     erw [Cofork.IsColimit.π_desc hp]
     simp only [Cofork.π_ofπ, comp_id]
   have wι : (0 : 0 ⟶ S.X₃) ≫ g' = 0 := zero_comp
-  have hι : IsLimit (KernelFork.ofι 0 wι) := KernelFork.IsLimit.ofMonoOfIsZero _
+  let hι : IsLimit (KernelFork.ofι 0 wι) := KernelFork.IsLimit.ofMonoOfIsZero _
       (by rw [hg']; dsimp; infer_instance) (isZero_zero _)
   exact
     { Q := S.X₃

--- a/Mathlib/Algebra/Homology/ShortComplex/ExactFunctor.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ExactFunctor.lean
@@ -29,7 +29,7 @@ variable {C D : Type*} [Category C] [Category D] [Preadditive C] [Preadditive D]
 /-- An additive functor which preserves homology preserves finite limits. -/
 noncomputable def preservesFiniteLimitsOfPreservesHomology
     [HasFiniteProducts C] [HasKernels C] : PreservesFiniteLimits F := by
-  have := fun {X Y : C} (f : X ⟶ Y) => PreservesHomology.preservesKernel F f
+  let _ := fun {X Y : C} (f : X ⟶ Y) => PreservesHomology.preservesKernel F f
   have : HasBinaryBiproducts C := HasBinaryBiproducts.of_hasBinaryProducts
   have : HasEqualizers C := Preadditive.hasEqualizers_of_hasKernels
   have : HasZeroObject D :=
@@ -39,7 +39,7 @@ noncomputable def preservesFiniteLimitsOfPreservesHomology
 /-- An additive which preserves homology preserves finite colimits. -/
 noncomputable def preservesFiniteColimitsOfPreservesHomology
     [HasFiniteCoproducts C] [HasCokernels C] : PreservesFiniteColimits F := by
-  have := fun {X Y : C} (f : X ⟶ Y) => PreservesHomology.preservesCokernel F f
+  let _ := fun {X Y : C} (f : X ⟶ Y) => PreservesHomology.preservesCokernel F f
   have : HasBinaryBiproducts C := HasBinaryBiproducts.of_hasBinaryCoproducts
   have : HasCoequalizers C := Preadditive.hasCoequalizers_of_hasCokernels
   have : HasZeroObject D :=

--- a/Mathlib/Algebra/Homology/ShortComplex/Homology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Homology.lean
@@ -463,7 +463,7 @@ lemma homologyMap_eq :
     homologyMap φ = h₁.homologyIso.hom ≫ γ.φH ≫ h₂.homologyIso.inv := by
   dsimp [homologyMap, homologyMap', RightHomologyData.homologyIso,
     rightHomologyIso, RightHomologyData.rightHomologyIso]
-  have γ' : HomologyMapData φ S₁.homologyData S₂.homologyData := default
+  let γ' : HomologyMapData φ S₁.homologyData S₂.homologyData := default
   simp only [← γ.rightHomologyMap'_eq, assoc, ← rightHomologyMap'_comp_assoc,
     id_comp, comp_id, γ'.left.leftHomologyMap'_eq, γ'.right.rightHomologyMap'_eq, ← γ'.comm_assoc,
     Iso.hom_inv_id]
@@ -1028,7 +1028,7 @@ lemma homologyMap'_op : (homologyMap' φ h₁ h₂).op =
     h₂.iso.inv.op ≫ homologyMap' (opMap φ) h₂.op h₁.op ≫ h₁.iso.hom.op :=
   Quiver.Hom.unop_inj (by
     dsimp
-    have γ : HomologyMapData φ h₁ h₂ := default
+    let γ : HomologyMapData φ h₁ h₂ := default
     simp only [γ.homologyMap'_eq, γ.op.homologyMap'_eq, HomologyData.op_left,
       HomologyMapData.op_left, RightHomologyMapData.op_φH, Quiver.Hom.unop_op, assoc,
       ← γ.comm_assoc, Iso.hom_inv_id, comp_id])

--- a/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
@@ -805,7 +805,7 @@ noncomputable def ofEpiOfIsIsoOfMono (φ : S₁ ⟶ S₂) (h : LeftHomologyData 
     [Epi φ.τ₁] [IsIso φ.τ₂] [Mono φ.τ₃] : LeftHomologyData S₂ := by
   let i : h.K ⟶ S₂.X₂ := h.i ≫ φ.τ₂
   have wi : i ≫ S₂.g = 0 := by simp only [i, assoc, φ.comm₂₃, h.wi_assoc, zero_comp]
-  have hi : IsLimit (KernelFork.ofι i wi) := KernelFork.IsLimit.ofι _ _
+  let hi : IsLimit (KernelFork.ofι i wi) := KernelFork.IsLimit.ofι _ _
     (fun x hx => h.liftK (x ≫ inv φ.τ₂) (by rw [assoc, ← cancel_mono φ.τ₃, assoc,
       assoc, ← φ.comm₂₃, IsIso.inv_hom_id_assoc, hx, zero_comp]))
     (fun x hx => by simp [i]) (fun x hx b hb => by
@@ -819,7 +819,7 @@ noncomputable def ofEpiOfIsIsoOfMono (φ : S₁ ⟶ S₂) (h : LeftHomologyData 
     rw [← cancel_mono h.i, ← cancel_mono φ.τ₂, assoc, assoc, eq, f'_i, φ.comm₁₂]
   have wπ : f' ≫ h.π = 0 := by
     rw [← cancel_epi φ.τ₁, comp_zero, reassoc_of% hf', h.f'_π]
-  have hπ : IsColimit (CokernelCofork.ofπ h.π wπ) := CokernelCofork.IsColimit.ofπ _ _
+  let hπ : IsColimit (CokernelCofork.ofπ h.π wπ) := CokernelCofork.IsColimit.ofπ _ _
     (fun x hx => h.descH x (by rw [← hf', assoc, hx, comp_zero]))
     (fun x hx => by simp) (fun x hx b hb => by rw [← cancel_epi h.π, π_descH, hb])
   exact ⟨h.K, h.H, i, h.π, wi, hi, wπ, hπ⟩
@@ -840,7 +840,7 @@ noncomputable def ofEpiOfIsIsoOfMono' (φ : S₁ ⟶ S₂) (h : LeftHomologyData
   have wi : i ≫ S₁.g = 0 := by
     rw [assoc, ← cancel_mono φ.τ₃, zero_comp, assoc, assoc, ← φ.comm₂₃,
       IsIso.inv_hom_id_assoc, h.wi]
-  have hi : IsLimit (KernelFork.ofι i wi) := KernelFork.IsLimit.ofι _ _
+  let hi : IsLimit (KernelFork.ofι i wi) := KernelFork.IsLimit.ofι _ _
     (fun x hx => h.liftK (x ≫ φ.τ₂)
       (by rw [assoc, φ.comm₂₃, reassoc_of% hx, zero_comp]))
     (fun x hx => by simp [i])
@@ -852,7 +852,7 @@ noncomputable def ofEpiOfIsIsoOfMono' (φ : S₁ ⟶ S₂) (h : LeftHomologyData
     rw [← cancel_mono h.i, ← cancel_mono (inv φ.τ₂), assoc, assoc, assoc, hf', f'_i_assoc,
       φ.comm₁₂_assoc, IsIso.hom_inv_id, comp_id]
   have wπ : f' ≫ h.π = 0 := by simp only [hf'', assoc, f'_π, comp_zero]
-  have hπ : IsColimit (CokernelCofork.ofπ h.π wπ) := CokernelCofork.IsColimit.ofπ _ _
+  let hπ : IsColimit (CokernelCofork.ofπ h.π wπ) := CokernelCofork.IsColimit.ofπ _ _
     (fun x hx => h.descH x (by rw [← cancel_epi φ.τ₁, ← reassoc_of% hf'', hx, comp_zero]))
     (fun x hx => π_descH _ _ _)
     (fun x hx b hx => by rw [← cancel_epi h.π, π_descH, hx])

--- a/Mathlib/Algebra/Homology/ShortComplex/Linear.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Linear.lean
@@ -70,13 +70,13 @@ variable (a : R)
 @[simp]
 lemma leftHomologyMap'_smul :
     leftHomologyMap' (a • φ) h₁ h₂ = a • leftHomologyMap' φ h₁ h₂ := by
-  have γ : LeftHomologyMapData φ h₁ h₂ := default
+  let γ : LeftHomologyMapData φ h₁ h₂ := default
   simp only [(γ.smul a).leftHomologyMap'_eq, LeftHomologyMapData.smul_φH, γ.leftHomologyMap'_eq]
 
 @[simp]
 lemma cyclesMap'_smul :
     cyclesMap' (a • φ) h₁ h₂ = a • cyclesMap' φ h₁ h₂ := by
-  have γ : LeftHomologyMapData φ h₁ h₂ := default
+  let γ : LeftHomologyMapData φ h₁ h₂ := default
   simp only [(γ.smul a).cyclesMap'_eq, LeftHomologyMapData.smul_φK, γ.cyclesMap'_eq]
 
 section
@@ -124,13 +124,13 @@ variable (a : R)
 @[simp]
 lemma rightHomologyMap'_smul :
     rightHomologyMap' (a • φ) h₁ h₂ = a • rightHomologyMap' φ h₁ h₂ := by
-  have γ : RightHomologyMapData φ h₁ h₂ := default
+  let γ : RightHomologyMapData φ h₁ h₂ := default
   simp only [(γ.smul a).rightHomologyMap'_eq, RightHomologyMapData.smul_φH, γ.rightHomologyMap'_eq]
 
 @[simp]
 lemma opcyclesMap'_smul :
     opcyclesMap' (a • φ) h₁ h₂ = a • opcyclesMap' φ h₁ h₂ := by
-  have γ : RightHomologyMapData φ h₁ h₂ := default
+  let γ : RightHomologyMapData φ h₁ h₂ := default
   simp only [(γ.smul a).opcyclesMap'_eq, RightHomologyMapData.smul_φQ, γ.opcyclesMap'_eq]
 
 section

--- a/Mathlib/Algebra/Homology/ShortComplex/Preadditive.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Preadditive.lean
@@ -96,21 +96,21 @@ variable (h₁ h₂)
 @[simp]
 lemma leftHomologyMap'_neg :
     leftHomologyMap' (-φ) h₁ h₂ = -leftHomologyMap' φ h₁ h₂ := by
-  have γ : LeftHomologyMapData φ h₁ h₂ := default
+  let γ : LeftHomologyMapData φ h₁ h₂ := default
   simp only [γ.leftHomologyMap'_eq, γ.neg.leftHomologyMap'_eq, LeftHomologyMapData.neg_φH]
 
 @[simp]
 lemma cyclesMap'_neg :
     cyclesMap' (-φ) h₁ h₂ = -cyclesMap' φ h₁ h₂ := by
-  have γ : LeftHomologyMapData φ h₁ h₂ := default
+  let γ : LeftHomologyMapData φ h₁ h₂ := default
   simp only [γ.cyclesMap'_eq, γ.neg.cyclesMap'_eq, LeftHomologyMapData.neg_φK]
 
 @[simp]
 lemma leftHomologyMap'_add :
     leftHomologyMap' (φ + φ') h₁ h₂ = leftHomologyMap' φ h₁ h₂ +
       leftHomologyMap' φ' h₁ h₂ := by
-  have γ : LeftHomologyMapData φ h₁ h₂ := default
-  have γ' : LeftHomologyMapData φ' h₁ h₂ := default
+  let γ : LeftHomologyMapData φ h₁ h₂ := default
+  let γ' : LeftHomologyMapData φ' h₁ h₂ := default
   simp only [γ.leftHomologyMap'_eq, γ'.leftHomologyMap'_eq,
     (γ.add γ').leftHomologyMap'_eq, LeftHomologyMapData.add_φH]
 
@@ -118,8 +118,8 @@ lemma leftHomologyMap'_add :
 lemma cyclesMap'_add :
     cyclesMap' (φ + φ') h₁ h₂ = cyclesMap' φ h₁ h₂ +
       cyclesMap' φ' h₁ h₂ := by
-  have γ : LeftHomologyMapData φ h₁ h₂ := default
-  have γ' : LeftHomologyMapData φ' h₁ h₂ := default
+  let γ : LeftHomologyMapData φ h₁ h₂ := default
+  let γ' : LeftHomologyMapData φ' h₁ h₂ := default
   simp only [γ.cyclesMap'_eq, γ'.cyclesMap'_eq,
     (γ.add γ').cyclesMap'_eq, LeftHomologyMapData.add_φK]
 
@@ -205,21 +205,21 @@ variable (h₁ h₂)
 @[simp]
 lemma rightHomologyMap'_neg :
     rightHomologyMap' (-φ) h₁ h₂ = -rightHomologyMap' φ h₁ h₂ := by
-  have γ : RightHomologyMapData φ h₁ h₂ := default
+  let γ : RightHomologyMapData φ h₁ h₂ := default
   simp only [γ.rightHomologyMap'_eq, γ.neg.rightHomologyMap'_eq, RightHomologyMapData.neg_φH]
 
 @[simp]
 lemma opcyclesMap'_neg :
     opcyclesMap' (-φ) h₁ h₂ = -opcyclesMap' φ h₁ h₂ := by
-  have γ : RightHomologyMapData φ h₁ h₂ := default
+  let γ : RightHomologyMapData φ h₁ h₂ := default
   simp only [γ.opcyclesMap'_eq, γ.neg.opcyclesMap'_eq, RightHomologyMapData.neg_φQ]
 
 @[simp]
 lemma rightHomologyMap'_add :
     rightHomologyMap' (φ + φ') h₁ h₂ = rightHomologyMap' φ h₁ h₂ +
       rightHomologyMap' φ' h₁ h₂ := by
-  have γ : RightHomologyMapData φ h₁ h₂ := default
-  have γ' : RightHomologyMapData φ' h₁ h₂ := default
+  let γ : RightHomologyMapData φ h₁ h₂ := default
+  let γ' : RightHomologyMapData φ' h₁ h₂ := default
   simp only [γ.rightHomologyMap'_eq, γ'.rightHomologyMap'_eq,
     (γ.add γ').rightHomologyMap'_eq, RightHomologyMapData.add_φH]
 
@@ -227,8 +227,8 @@ lemma rightHomologyMap'_add :
 lemma opcyclesMap'_add :
     opcyclesMap' (φ + φ') h₁ h₂ = opcyclesMap' φ h₁ h₂ +
       opcyclesMap' φ' h₁ h₂ := by
-  have γ : RightHomologyMapData φ h₁ h₂ := default
-  have γ' : RightHomologyMapData φ' h₁ h₂ := default
+  let γ : RightHomologyMapData φ h₁ h₂ := default
+  let γ' : RightHomologyMapData φ' h₁ h₂ := default
   simp only [γ.opcyclesMap'_eq, γ'.opcyclesMap'_eq,
     (γ.add γ').opcyclesMap'_eq, RightHomologyMapData.add_φQ]
 

--- a/Mathlib/Algebra/Homology/ShortComplex/PreservesHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/PreservesHomology.lean
@@ -98,16 +98,16 @@ def IsPreservedBy.hf' : PreservesColimit (parallelPair h.f' 0) F := IsPreservedB
 this is the induced left homology data `h.map F` for the short complex `S.map F`. -/
 @[simps]
 noncomputable def map : (S.map F).LeftHomologyData := by
-  have := IsPreservedBy.hg h F
-  have := IsPreservedBy.hf' h F
+  let _ := IsPreservedBy.hg h F
+  let _ := IsPreservedBy.hf' h F
   have wi : F.map h.i ≫ F.map S.g = 0 := by rw [← F.map_comp, h.wi, F.map_zero]
-  have hi := KernelFork.mapIsLimit _ h.hi F
+  let hi := KernelFork.mapIsLimit _ h.hi F
   let f' : F.obj S.X₁ ⟶ F.obj h.K := hi.lift (KernelFork.ofι (S.map F).f (S.map F).zero)
   have hf' : f' = F.map h.f' := Fork.IsLimit.hom_ext hi (by
     rw [Fork.IsLimit.lift_ι hi]
     simp only [KernelFork.map_ι, Fork.ι_ofι, map_f, ← F.map_comp, f'_i])
   have wπ : f' ≫ F.map h.π = 0 := by rw [hf', ← F.map_comp, f'_π, F.map_zero]
-  have hπ : IsColimit (CokernelCofork.ofπ (F.map h.π) wπ) := by
+  let hπ : IsColimit (CokernelCofork.ofπ (F.map h.π) wπ) := by
     let e : parallelPair f' 0 ≅ parallelPair (F.map h.f') 0 :=
       parallelPair.ext (Iso.refl _) (Iso.refl _) (by simpa using hf') (by simp)
     refine' IsColimit.precomposeInvEquiv e _
@@ -178,17 +178,17 @@ def IsPreservedBy.hg' : PreservesLimit (parallelPair h.g' 0) F :=
 this is the induced right homology data `h.map F` for the short complex `S.map F`. -/
 @[simps]
 noncomputable def map : (S.map F).RightHomologyData := by
-  have := IsPreservedBy.hf h F
-  have := IsPreservedBy.hg' h F
+  let _ := IsPreservedBy.hf h F
+  let _ := IsPreservedBy.hg' h F
   have wp : F.map S.f ≫ F.map h.p = 0 := by rw [← F.map_comp, h.wp, F.map_zero]
-  have hp := CokernelCofork.mapIsColimit _ h.hp F
+  let hp := CokernelCofork.mapIsColimit _ h.hp F
   let g' : F.obj h.Q ⟶ F.obj S.X₃ := hp.desc (CokernelCofork.ofπ (S.map F).g (S.map F).zero)
   have hg' : g' = F.map h.g' := by
     apply Cofork.IsColimit.hom_ext hp
     rw [Cofork.IsColimit.π_desc hp]
     simp only [Cofork.π_ofπ, CokernelCofork.map_π, map_g, ← F.map_comp, p_g']
   have wι : F.map h.ι ≫ g' = 0 := by rw [hg', ← F.map_comp, ι_g', F.map_zero]
-  have hι : IsLimit (KernelFork.ofι (F.map h.ι) wι) := by
+  let hι : IsLimit (KernelFork.ofι (F.map h.ι) wι) := by
     let e : parallelPair g' 0 ≅ parallelPair (F.map h.g') 0 :=
       parallelPair.ext (Iso.refl _) (Iso.refl _) (by simpa using hg') (by simp)
     refine' IsLimit.postcomposeHomEquiv e _
@@ -281,7 +281,7 @@ def PreservesLeftHomologyOf.mk' (h : S.LeftHomologyData) [h.IsPreservedBy F] :
   isPreservedBy h' :=
     { g := ShortComplex.LeftHomologyData.IsPreservedBy.hg h F
       f' := by
-        have := ShortComplex.LeftHomologyData.IsPreservedBy.hf' h F
+        let _ := ShortComplex.LeftHomologyData.IsPreservedBy.hf' h F
         let e : parallelPair h.f' 0 ≅ parallelPair h'.f' 0 :=
           parallelPair.ext (Iso.refl _) (ShortComplex.cyclesMapIso' (Iso.refl S) h h')
             (by simp) (by simp)
@@ -294,7 +294,7 @@ def PreservesRightHomologyOf.mk' (h : S.RightHomologyData) [h.IsPreservedBy F] :
   isPreservedBy h' :=
     { f := ShortComplex.RightHomologyData.IsPreservedBy.hf h F
       g' := by
-        have := ShortComplex.RightHomologyData.IsPreservedBy.hg' h F
+        let _ := ShortComplex.RightHomologyData.IsPreservedBy.hg' h F
         let e : parallelPair h.g' 0 ≅ parallelPair h'.g' 0 :=
           parallelPair.ext (ShortComplex.opcyclesMapIso' (Iso.refl S) h h') (Iso.refl _)
             (by simp) (by simp)
@@ -359,12 +359,12 @@ variable [hl₁.IsPreservedBy F] [hl₂.IsPreservedBy F]
 
 lemma map_cyclesMap' : F.map (ShortComplex.cyclesMap' φ hl₁ hl₂) =
     ShortComplex.cyclesMap' (F.mapShortComplex.map φ) (hl₁.map F) (hl₂.map F) := by
-  have γ : ShortComplex.LeftHomologyMapData φ hl₁ hl₂ := default
+  let γ : ShortComplex.LeftHomologyMapData φ hl₁ hl₂ := default
   rw [γ.cyclesMap'_eq, (γ.map F).cyclesMap'_eq,  ShortComplex.LeftHomologyMapData.map_φK]
 
 lemma map_leftHomologyMap' : F.map (ShortComplex.leftHomologyMap' φ hl₁ hl₂) =
     ShortComplex.leftHomologyMap' (F.mapShortComplex.map φ) (hl₁.map F) (hl₂.map F) := by
-  have γ : ShortComplex.LeftHomologyMapData φ hl₁ hl₂ := default
+  let γ : ShortComplex.LeftHomologyMapData φ hl₁ hl₂ := default
   rw [γ.leftHomologyMap'_eq, (γ.map F).leftHomologyMap'_eq,
     ShortComplex.LeftHomologyMapData.map_φH]
 
@@ -376,12 +376,12 @@ variable [hr₁.IsPreservedBy F] [hr₂.IsPreservedBy F]
 
 lemma map_opcyclesMap' : F.map (ShortComplex.opcyclesMap' φ hr₁ hr₂) =
     ShortComplex.opcyclesMap' (F.mapShortComplex.map φ) (hr₁.map F) (hr₂.map F) := by
-  have γ : ShortComplex.RightHomologyMapData φ hr₁ hr₂ := default
+  let γ : ShortComplex.RightHomologyMapData φ hr₁ hr₂ := default
   rw [γ.opcyclesMap'_eq, (γ.map F).opcyclesMap'_eq,  ShortComplex.RightHomologyMapData.map_φQ]
 
 lemma map_rightHomologyMap' : F.map (ShortComplex.rightHomologyMap' φ hr₁ hr₂) =
     ShortComplex.rightHomologyMap' (F.mapShortComplex.map φ) (hr₁.map F) (hr₂.map F) := by
-  have γ : ShortComplex.RightHomologyMapData φ hr₁ hr₂ := default
+  let γ : ShortComplex.RightHomologyMapData φ hr₁ hr₂ := default
   rw [γ.rightHomologyMap'_eq, (γ.map F).rightHomologyMap'_eq,
     ShortComplex.RightHomologyMapData.map_φH]
 
@@ -619,7 +619,7 @@ lemma mapHomologyIso'_eq_mapHomologyIso [S.HasHomology] [F.PreservesLeftHomology
     Functor.map_id, LeftHomologyData.map_H, leftHomologyMapIso'_inv, leftHomologyMapIso'_hom,
     LeftHomologyData.map_leftHomologyMap', ← rightHomologyMap'_comp_assoc, ← leftHomologyMap'_comp,
     ← leftHomologyMap'_comp_assoc, id_comp]
-  have γ : HomologyMapData (𝟙 (S.map F)) (map S F).homologyData (S.homologyData.map F) := default
+  let γ : HomologyMapData (𝟙 (S.map F)) (map S F).homologyData (S.homologyData.map F) := default
   have eq := γ.comm
   rw [← γ.left.leftHomologyMap'_eq, ← γ.right.rightHomologyMap'_eq] at eq
   dsimp at eq
@@ -754,7 +754,7 @@ variable (φ) [S₁.HasHomology] [S₂.HasHomology]
 instance quasiIso_map_of_preservesLeftHomology
     [F.PreservesLeftHomologyOf S₁] [F.PreservesLeftHomologyOf S₂]
     [QuasiIso φ] : QuasiIso (F.mapShortComplex.map φ) := by
-  have γ : LeftHomologyMapData φ S₁.leftHomologyData S₂.leftHomologyData := default
+  let γ : LeftHomologyMapData φ S₁.leftHomologyData S₂.leftHomologyData := default
   have : IsIso γ.φH := by
     rw [← γ.quasiIso_iff]
     infer_instance
@@ -765,7 +765,7 @@ lemma quasiIso_map_iff_of_preservesLeftHomology
     [F.PreservesLeftHomologyOf S₁] [F.PreservesLeftHomologyOf S₂]
     [F.ReflectsIsomorphisms] :
     QuasiIso (F.mapShortComplex.map φ) ↔ QuasiIso φ := by
-  have γ : LeftHomologyMapData φ S₁.leftHomologyData S₂.leftHomologyData := default
+  let γ : LeftHomologyMapData φ S₁.leftHomologyData S₂.leftHomologyData := default
   rw [γ.quasiIso_iff, (γ.map F).quasiIso_iff, LeftHomologyMapData.map_φH]
   constructor
   · intro
@@ -776,7 +776,7 @@ lemma quasiIso_map_iff_of_preservesLeftHomology
 instance quasiIso_map_of_preservesRightHomology
     [F.PreservesRightHomologyOf S₁] [F.PreservesRightHomologyOf S₂]
     [QuasiIso φ] : QuasiIso (F.mapShortComplex.map φ) := by
-  have γ : RightHomologyMapData φ S₁.rightHomologyData S₂.rightHomologyData := default
+  let γ : RightHomologyMapData φ S₁.rightHomologyData S₂.rightHomologyData := default
   have : IsIso γ.φH := by
     rw [← γ.quasiIso_iff]
     infer_instance
@@ -787,7 +787,7 @@ lemma quasiIso_map_iff_of_preservesRightHomology
     [F.PreservesRightHomologyOf S₁] [F.PreservesRightHomologyOf S₂]
     [F.ReflectsIsomorphisms] :
     QuasiIso (F.mapShortComplex.map φ) ↔ QuasiIso φ := by
-  have γ : RightHomologyMapData φ S₁.rightHomologyData S₂.rightHomologyData := default
+  let γ : RightHomologyMapData φ S₁.rightHomologyData S₂.rightHomologyData := default
   rw [γ.quasiIso_iff, (γ.map F).quasiIso_iff, RightHomologyMapData.map_φH]
   constructor
   · intro

--- a/Mathlib/Algebra/Homology/ShortComplex/QuasiIso.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/QuasiIso.lean
@@ -121,13 +121,13 @@ lemma RightHomologyMapData.quasiIso_iff {φ : S₁ ⟶ S₂} {h₁ : S₁.RightH
 lemma quasiIso_iff_isIso_leftHomologyMap' (φ : S₁ ⟶ S₂)
     (h₁ : S₁.LeftHomologyData) (h₂ : S₂.LeftHomologyData) :
     QuasiIso φ ↔ IsIso (leftHomologyMap' φ h₁ h₂) := by
-  have γ : LeftHomologyMapData φ h₁ h₂ := default
+  let γ : LeftHomologyMapData φ h₁ h₂ := default
   rw [γ.quasiIso_iff, γ.leftHomologyMap'_eq]
 
 lemma quasiIso_iff_isIso_rightHomologyMap' (φ : S₁ ⟶ S₂)
     (h₁ : S₁.RightHomologyData) (h₂ : S₂.RightHomologyData) :
     QuasiIso φ ↔ IsIso (rightHomologyMap' φ h₁ h₂) := by
-  have γ : RightHomologyMapData φ h₁ h₂ := default
+  let γ : RightHomologyMapData φ h₁ h₂ := default
   rw [γ.quasiIso_iff, γ.rightHomologyMap'_eq]
 
 lemma quasiIso_iff_isIso_homologyMap' (φ : S₁ ⟶ S₂)
@@ -143,7 +143,7 @@ lemma quasiIso_of_epi_of_isIso_of_mono (φ : S₁ ⟶ S₂) [Epi φ.τ₁] [IsIs
 
 lemma quasiIso_opMap_iff (φ : S₁ ⟶ S₂) :
     QuasiIso (opMap φ) ↔ QuasiIso φ := by
-  have γ : HomologyMapData φ S₁.homologyData S₂.homologyData := default
+  let γ : HomologyMapData φ S₁.homologyData S₂.homologyData := default
   rw [γ.left.quasiIso_iff, γ.op.right.quasiIso_iff]
   dsimp
   constructor

--- a/Mathlib/Algebra/Lie/Engel.lean
+++ b/Mathlib/Algebra/Lie/Engel.lean
@@ -209,7 +209,7 @@ theorem LieAlgebra.exists_engelian_lieSubalgebra_of_lt_normalizer {K : LieSubalg
     rw [← LieIdeal.coe_to_lieSubalgebra_to_submodule R K' I, hI₁]
     apply Submodule.map_injective_of_injective (K' : Submodule R L).injective_subtype
     simp
-  have e : K ≃ₗ⁅R⁆ I :=
+  let e : K ≃ₗ⁅R⁆ I :=
     (LieSubalgebra.equivOfLe hKK').trans
       (LieEquiv.ofEq _ _ ((LieSubalgebra.coe_set_eq _ _).mpr hI₁.symm))
   have hI₃ : LieAlgebra.IsEngelian R I := e.isEngelian_iff.mp hK₁

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -185,7 +185,7 @@ theorem torsion_by_prime_power_decomposition (hN : Module.IsTorsion' N (Submonoi
       ⟨⟨0⟩, fun x => by dsimp; rw [← Submodule.mem_bot R, hs]; exact Submodule.mem_top⟩
     haveI : IsEmpty (Fin Nat.zero) := inferInstanceAs (IsEmpty (Fin 0))
     exact ⟨0⟩
-  · have : ∀ x : N, Decidable (x = 0) := fun _ => by classical infer_instance
+  · let _ : ∀ x : N, Decidable (x = 0) := fun _ => by classical infer_instance
     obtain ⟨j, hj⟩ := exists_isTorsionBy hN d.succ d.succ_ne_zero s hs
     let s' : Fin d → N ⧸ R ∙ s j := Submodule.Quotient.mk ∘ s ∘ j.succAbove
     -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5732):

--- a/Mathlib/Algebra/Module/Zlattice.lean
+++ b/Mathlib/Algebra/Module/Zlattice.lean
@@ -433,7 +433,7 @@ theorem Zlattice.FG [hs : IsZlattice K L] : AddSubgroup.FG L := by
       rw [← hs.span_top, ← h_span]
       exact span_mono (by simp only [Subtype.range_coe_subtype, Set.setOf_mem_eq, subset_rfl]))
     rw [show span ℤ s = span ℤ (Set.range b) by simp [b, Basis.coe_mk, Subtype.range_coe_subtype]]
-    have : Fintype s := h_lind.setFinite.fintype
+    let _ : Fintype s := h_lind.setFinite.fintype
     refine Set.Finite.of_finite_image (f := ((↑) : _ →  E) ∘ Zspan.quotientEquiv b) ?_
       (Function.Injective.injOn (Subtype.coe_injective.comp (Zspan.quotientEquiv b).injective) _)
     have : Set.Finite ((Zspan.fundamentalDomain b) ∩ L) :=
@@ -479,7 +479,7 @@ instance instModuleFinite_of_discrete_addSubgroup {E : Type*} [NormedAddCommGrou
 
 theorem Zlattice.module_free [IsZlattice K L] : Module.Free ℤ L := by
   have : Module.Finite ℤ L := module_finite K L
-  have : Module ℚ E := Module.compHom E (algebraMap ℚ K)
+  let _ : Module ℚ E := Module.compHom E (algebraMap ℚ K)
   have : NoZeroSMulDivisors ℤ E := RatModule.noZeroSMulDivisors
   have : NoZeroSMulDivisors ℤ L := by
     change NoZeroSMulDivisors ℤ (AddSubgroup.toIntSubmodule L)
@@ -489,7 +489,7 @@ theorem Zlattice.module_free [IsZlattice K L] : Module.Free ℤ L := by
 instance instModuleFree__of_discrete_addSubgroup {E : Type*} [NormedAddCommGroup E]
     [NormedSpace ℝ E] [FiniteDimensional ℝ E] (L : AddSubgroup E) [DiscreteTopology L] :
     Module.Free ℤ L := by
-  have : Module ℚ E := Module.compHom E (algebraMap ℚ ℝ)
+  let _ : Module ℚ E := Module.compHom E (algebraMap ℚ ℝ)
   have : NoZeroSMulDivisors ℤ E := RatModule.noZeroSMulDivisors
   have : NoZeroSMulDivisors ℤ L := by
     change NoZeroSMulDivisors ℤ (AddSubgroup.toIntSubmodule L)
@@ -500,7 +500,7 @@ theorem Zlattice.rank [hs : IsZlattice K L] : finrank ℤ L = finrank K E := by
   classical
   have : Module.Finite ℤ L := module_finite K L
   have : Module.Free ℤ L := module_free K L
-  have : Module ℚ E := Module.compHom E (algebraMap ℚ K)
+  let _ : Module ℚ E := Module.compHom E (algebraMap ℚ K)
   let b₀ := Module.Free.chooseBasis ℤ L
   -- Let `b` be a `ℤ`-basis of `L` formed of vectors of `E`
   let b := Subtype.val ∘ b₀
@@ -528,7 +528,7 @@ theorem Zlattice.rank [hs : IsZlattice K L] : finrank ℤ L = finrank K E := by
     obtain ⟨t, ⟨ht_inc, ⟨ht_span, ht_lin⟩⟩⟩ := exists_linearIndependent K (Set.range b)
     -- `e` is a `K`-basis of `E` formed of vectors of `b`
     let e : Basis t K E := Basis.mk ht_lin (by simp [ht_span, h_spanE])
-    have : Fintype t := Set.Finite.fintype ((Set.range b).toFinite.subset ht_inc)
+    let _ : Fintype t := Set.Finite.fintype ((Set.range b).toFinite.subset ht_inc)
     have h : LinearIndependent ℤ (fun x : (Set.range b) => (x : E)) := by
       rwa [linearIndependent_subtype_range (Subtype.coe_injective.comp b₀.injective)]
     contrapose! h
@@ -587,7 +587,7 @@ def Basis.ofZlatticeBasis :
   have : Finite ℤ L := Zlattice.module_finite K L
   have : Free ℤ L := Zlattice.module_free K L
   let e :=  Basis.indexEquiv (Free.chooseBasis ℤ L) b
-  have : Fintype ι := Fintype.ofEquiv _ e
+  let _ : Fintype ι := Fintype.ofEquiv _ e
   refine basisOfTopLeSpanOfCardEqFinrank (L.subtype.toIntLinearMap ∘ b) ?_ ?_
   · rw [← span_span_of_tower ℤ, Set.range_comp, ← map_span, Basis.span_eq, Submodule.map_top,
       top_le_iff, AddMonoidHom.coe_toIntLinearMap_range, AddSubgroup.subtype_range,

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -1394,7 +1394,7 @@ open Cardinal in
 lemma eq_zero_of_forall_eval_zero_of_natDegree_lt_card
     (f : R[X]) (hf : ∀ r, f.eval r = 0) (hfR : f.natDegree < #R) : f = 0 := by
   obtain hR|hR := finite_or_infinite R
-  · have := Fintype.ofFinite R
+  · let _ := Fintype.ofFinite R
     apply eq_zero_of_natDegree_lt_card_of_eval_eq_zero f Function.injective_id hf
     simpa only [mk_fintype, Nat.cast_lt] using hfR
   · exact zero_of_eval_zero _ hf

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
@@ -133,7 +133,7 @@ theorem isCompact_basicOpen (X : Scheme) {U : Opens X.carrier} (hU : IsCompact (
   let g : s → X.affineOpens := by
     intro V
     use V.1 ⊓ X.basicOpen f
-    have : V.1.1 ⟶ U := by
+    let this : V.1.1 ⟶ U := by
       apply homOfLE; change _ ⊆ (U : Set X.carrier); rw [e]
       convert @Set.subset_iUnion₂ _ _ _
         (fun (U : X.affineOpens) (_ : U ∈ s) => ↑U) V V.prop using 1

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -95,7 +95,7 @@ theorem quasi_compact_affineProperty_iff_quasiSeparatedSpace {X Y : Scheme} [IsA
       pullback.fst ≫ X.ofRestrict _
     -- Porting note: `inferInstance` does not work here
     have : IsOpenImmersion g := PresheafedSpace.IsOpenImmersion.comp _ _
-    have e := Homeomorph.ofEmbedding _ this.base_open.toEmbedding
+    let e := Homeomorph.ofEmbedding _ this.base_open.toEmbedding
     rw [IsOpenImmersion.range_pullback_to_base_of_left] at e
     erw [Subtype.range_coe, Subtype.range_coe] at e
     rw [isCompact_iff_compactSpace]
@@ -104,7 +104,7 @@ theorem quasi_compact_affineProperty_iff_quasiSeparatedSpace {X Y : Scheme} [IsA
     let g : pullback f₁ f₂ ⟶ X := pullback.fst ≫ f₁
     -- Porting note: `inferInstance` does not work here
     have : IsOpenImmersion g := PresheafedSpace.IsOpenImmersion.comp _ _
-    have e := Homeomorph.ofEmbedding _ this.base_open.toEmbedding
+    let e := Homeomorph.ofEmbedding _ this.base_open.toEmbedding
     rw [IsOpenImmersion.range_pullback_to_base_of_left] at e
     simp_rw [isCompact_iff_compactSpace] at H
     exact

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -631,7 +631,7 @@ lemma toSpec_fromSpec {f : A} {m : ℕ} (f_deg : f ∈ 𝒜 m) (hm : 0 < m) (x :
     simp only [smul_eq_mul, SetLike.coe_gnpow, GradedAlgebra.proj_apply,
       DirectSum.decompose_of_mem_same 𝒜 s_mem]
     by_cases ineq : f^k = 0
-    · have := IsLocalization.uniqueOfZeroMem (M := Submonoid.powers f) (S := Localization.Away f)
+    · let _ := IsLocalization.uniqueOfZeroMem (M := Submonoid.powers f) (S := Localization.Away f)
         ⟨k, ineq⟩
       exact Subsingleton.elim _ _
     · simp_rw [← pow_mul]; congr
@@ -654,7 +654,7 @@ lemma toSpec_fromSpec {f : A} {m : ℕ} (f_deg : f ∈ 𝒜 m) (hm : 0 < m) (x :
       rw [HomogeneousLocalization.ext_iff_val, HomogeneousLocalization.val_mk'',
         HomogeneousLocalization.pow_val, z.eq_num_div_den, Localization.mk_pow]
       by_cases ineq : f^k = 0
-      · have := IsLocalization.uniqueOfZeroMem (M := Submonoid.powers f) (S := Localization.Away f)
+      · let _ := IsLocalization.uniqueOfZeroMem (M := Submonoid.powers f) (S := Localization.Away f)
           ⟨k, ineq⟩
         exact Subsingleton.elim _ _
       · dsimp; congr 2

--- a/Mathlib/AlgebraicGeometry/Pullbacks.lean
+++ b/Mathlib/AlgebraicGeometry/Pullbacks.lean
@@ -523,7 +523,7 @@ def gluedIsLimit : IsLimit (PullbackCone.mk _ _ (p_comm 𝒰 f g)) := by
   apply (𝒰.pullbackCover s.fst).hom_ext
   intro i
   rw [OpenCover.pullbackCover_map]
-  have := pullbackRightPullbackFstIso (p1 𝒰 f g) (𝒰.map i) m ≪≫ pullback.congrHom h₁ rfl
+  let _ := pullbackRightPullbackFstIso (p1 𝒰 f g) (𝒰.map i) m ≪≫ pullback.congrHom h₁ rfl
   erw [(𝒰.pullbackCover s.fst).ι_glueMorphisms]
   rw [←
     cancel_epi
@@ -573,7 +573,7 @@ instance left_affine_comp_pullback_hasPullback {X Y Z : Scheme} (f : X ⟶ Z) (g
   let Xᵢ := pullback f (Z.affineCover.map i)
   let Yᵢ := pullback g (Z.affineCover.map i)
   let W := pullback (pullback.snd : Yᵢ ⟶ _) (pullback.snd : Xᵢ ⟶ _)
-  have :=
+  let this :=
     bigSquareIsPullback (pullback.fst : W ⟶ _) (pullback.fst : Yᵢ ⟶ _) (pullback.snd : Xᵢ ⟶ _)
       (Z.affineCover.map i) pullback.snd pullback.snd g pullback.condition.symm
       pullback.condition.symm (PullbackCone.isLimitOfFlip <| pullbackIsPullback _ _)
@@ -656,7 +656,7 @@ def openCoverOfBase' (𝒰 : OpenCover Z) (f : X ⟶ Z) (g : Y ⟶ Z) : OpenCove
   let Xᵢ := pullback f (𝒰.map i)
   let Yᵢ := pullback g (𝒰.map i)
   let W := pullback (pullback.snd : Yᵢ ⟶ _) (pullback.snd : Xᵢ ⟶ _)
-  have :=
+  let this :=
     bigSquareIsPullback (pullback.fst : W ⟶ _) (pullback.fst : Yᵢ ⟶ _) (pullback.snd : Xᵢ ⟶ _)
       (𝒰.map i) pullback.snd pullback.snd g pullback.condition.symm pullback.condition.symm
       (PullbackCone.isLimitOfFlip <| pullbackIsPullback _ _)

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -706,7 +706,7 @@ theorem locally_const_basicOpen (U : Opens (PrimeSpectrum.Top R))
   rw [← pow_succ, Ideal.mem_span_singleton'] at hn
   cases' hn with c hc
   have basic_opens_eq := PrimeSpectrum.basicOpen_pow h (n + 1) (by omega)
-  have i_basic_open := eqToHom basic_opens_eq ≫ homOfLE hDhV
+  let i_basic_open := eqToHom basic_opens_eq ≫ homOfLE hDhV
   -- We claim that `(f * c) / h ^ (n+1)` is our desired representation
   use f * c, h ^ (n + 1), i_basic_open ≫ iVU, (basic_opens_eq.symm.le : _) hxDh
   rw [op_comp, Functor.map_comp] --, comp_apply, ← s_eq, res_const]

--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -638,9 +638,9 @@ theorem ContDiffOn.comp {s : Set E} {t : Set F} {g : F → G} {f : E → F} (hg 
   let Fu : Type max uE uF uG := ULift.{max uE uG} F
   let Gu : Type max uE uF uG := ULift.{max uE uF} G
   -- declare the isomorphisms
-  have isoE : Eu ≃L[𝕜] E := ContinuousLinearEquiv.ulift
-  have isoF : Fu ≃L[𝕜] F := ContinuousLinearEquiv.ulift
-  have isoG : Gu ≃L[𝕜] G := ContinuousLinearEquiv.ulift
+  let isoE : Eu ≃L[𝕜] E := ContinuousLinearEquiv.ulift
+  let isoF : Fu ≃L[𝕜] F := ContinuousLinearEquiv.ulift
+  let isoG : Gu ≃L[𝕜] G := ContinuousLinearEquiv.ulift
   -- lift the functions to the new spaces, check smoothness there, and then go back.
   let fu : Eu → Fu := (isoF.symm ∘ f) ∘ isoE
   have fu_diff : ContDiffOn 𝕜 n fu (isoE ⁻¹' s) := by

--- a/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
@@ -138,10 +138,10 @@ theorem ContinuousLinearMap.norm_iteratedFDerivWithin_le_of_bilinear (B : E →L
   let Eu : Type max uD uE uF uG := ULift.{max uD uF uG, uE} E
   let Fu : Type max uD uE uF uG := ULift.{max uD uE uG, uF} F
   let Gu : Type max uD uE uF uG := ULift.{max uD uE uF, uG} G
-  have isoD : Du ≃ₗᵢ[𝕜] D := LinearIsometryEquiv.ulift 𝕜 D
-  have isoE : Eu ≃ₗᵢ[𝕜] E := LinearIsometryEquiv.ulift 𝕜 E
-  have isoF : Fu ≃ₗᵢ[𝕜] F := LinearIsometryEquiv.ulift 𝕜 F
-  have isoG : Gu ≃ₗᵢ[𝕜] G := LinearIsometryEquiv.ulift 𝕜 G
+  let isoD : Du ≃ₗᵢ[𝕜] D := LinearIsometryEquiv.ulift 𝕜 D
+  let isoE : Eu ≃ₗᵢ[𝕜] E := LinearIsometryEquiv.ulift 𝕜 E
+  let isoF : Fu ≃ₗᵢ[𝕜] F := LinearIsometryEquiv.ulift 𝕜 F
+  let isoG : Gu ≃ₗᵢ[𝕜] G := LinearIsometryEquiv.ulift 𝕜 G
   -- lift `f` and `g` to versions `fu` and `gu` on the lifted spaces.
   set fu : Du → Eu := isoE.symm ∘ f ∘ isoD with hfu
   set gu : Du → Fu := isoF.symm ∘ g ∘ isoD with hgu
@@ -482,8 +482,8 @@ theorem norm_iteratedFDerivWithin_comp_le {g : F → G} {f : E → F} {n : ℕ} 
     to a common universe. These linear isometries preserve the norm of the iterated derivative. -/
   let Fu : Type max uF uG := ULift.{uG, uF} F
   let Gu : Type max uF uG := ULift.{uF, uG} G
-  have isoF : Fu ≃ₗᵢ[𝕜] F := LinearIsometryEquiv.ulift 𝕜 F
-  have isoG : Gu ≃ₗᵢ[𝕜] G := LinearIsometryEquiv.ulift 𝕜 G
+  let isoF : Fu ≃ₗᵢ[𝕜] F := LinearIsometryEquiv.ulift 𝕜 F
+  let isoG : Gu ≃ₗᵢ[𝕜] G := LinearIsometryEquiv.ulift 𝕜 G
   -- lift `f` and `g` to versions `fu` and `gu` on the lifted spaces.
   let fu : E → Fu := isoF.symm ∘ f
   let gu : Fu → Gu := isoG.symm ∘ g ∘ isoF

--- a/Mathlib/Analysis/Calculus/Rademacher.lean
+++ b/Mathlib/Analysis/Calculus/Rademacher.lean
@@ -239,7 +239,7 @@ theorem ae_lineDeriv_sum_eq
 theorem ae_exists_fderiv_of_countable
     (hf : LipschitzWith C f) {s : Set E} (hs : s.Countable) :
     ∀ᵐ x ∂μ, ∃ (L : E →L[ℝ] ℝ), ∀ v ∈ s, HasLineDerivAt ℝ f (L v) x v := by
-  have B := Basis.ofVectorSpace ℝ E
+  let B := Basis.ofVectorSpace ℝ E
   have I1 : ∀ᵐ (x : E) ∂μ, ∀ v ∈ s, lineDeriv ℝ f x (∑ i, (B.repr v i) • B i) =
                                   ∑ i, B.repr v i • lineDeriv ℝ f x (B i) :=
     (ae_ball_iff hs).2 (fun v _ ↦ hf.ae_lineDeriv_sum_eq _ _ _)
@@ -353,7 +353,7 @@ theorem ae_differentiableWithinAt_of_mem_pi
 Lipschitz on a set is differentiable almost everywere in this set. -/
 theorem ae_differentiableWithinAt_of_mem {f : E → F} (hf : LipschitzOnWith C f s) :
     ∀ᵐ x ∂μ, x ∈ s → DifferentiableWithinAt ℝ f s x := by
-  have A := (Basis.ofVectorSpace ℝ F).equivFun.toContinuousLinearEquiv
+  let A := (Basis.ofVectorSpace ℝ F).equivFun.toContinuousLinearEquiv
   suffices H : ∀ᵐ x ∂μ, x ∈ s → DifferentiableWithinAt ℝ (A ∘ f) s x by
     filter_upwards [H] with x hx xs
     have : f = (A.symm ∘ A) ∘ f := by

--- a/Mathlib/Analysis/Complex/Tietze.lean
+++ b/Mathlib/Analysis/Complex/Tietze.lean
@@ -51,7 +51,7 @@ instance Set.instTietzeExtensionUnitBall {𝕜 : Type v} [RCLike 𝕜] {E : Type
 instance Set.instTietzeExtensionUnitClosedBall {𝕜 : Type v} [RCLike 𝕜] {E : Type w}
     [NormedAddCommGroup E] [NormedSpace 𝕜 E] [FiniteDimensional 𝕜 E] :
     TietzeExtension.{u, w} (Metric.closedBall (0 : E) 1) := by
-  have : NormedSpace ℝ E := NormedSpace.restrictScalars ℝ 𝕜 E
+  let _ : NormedSpace ℝ E := NormedSpace.restrictScalars ℝ 𝕜 E
   have : IsScalarTower ℝ 𝕜 E := Real.isScalarTower
   -- I didn't find this retract in Mathlib.
   let g : E → E := fun x ↦ ‖x‖⁻¹ • x

--- a/Mathlib/Analysis/Convolution.lean
+++ b/Mathlib/Analysis/Convolution.lean
@@ -1311,10 +1311,10 @@ theorem contDiffOn_convolution_right_with_param {f : G → E} {n : ℕ∞} (L : 
   let eE' : Type max uE' uG uF uP := ULift.{max uG uF uP} E'
   let eF : Type max uF uG uE' uP := ULift.{max uG uE' uP} F
   let eP : Type max uP uG uE' uF := ULift.{max uG uE' uF} P
-  have isoG : eG ≃L[𝕜] G := ContinuousLinearEquiv.ulift
-  have isoE' : eE' ≃L[𝕜] E' := ContinuousLinearEquiv.ulift
-  have isoF : eF ≃L[𝕜] F := ContinuousLinearEquiv.ulift
-  have isoP : eP ≃L[𝕜] P := ContinuousLinearEquiv.ulift
+  let isoG : eG ≃L[𝕜] G := ContinuousLinearEquiv.ulift
+  let isoE' : eE' ≃L[𝕜] E' := ContinuousLinearEquiv.ulift
+  let isoF : eF ≃L[𝕜] F := ContinuousLinearEquiv.ulift
+  let isoP : eP ≃L[𝕜] P := ContinuousLinearEquiv.ulift
   let ef := f ∘ isoG
   let eμ : MeasureTheory.Measure eG := Measure.map isoG.symm μ
   let eg : eP → eG → eE' := fun ep ex => isoE'.symm (g (isoP ep) (isoG ex))
@@ -1332,9 +1332,6 @@ theorem contDiffOn_convolution_right_with_param {f : G → E} {n : ℕ∞} (L : 
       exact hgs _ _ hp hx
     · apply (locallyIntegrable_map_homeomorph isoG.symm.toHomeomorph).2
       convert hf
-      ext1 x
-      simp only [ef, ContinuousLinearEquiv.coe_toHomeomorph, (· ∘ ·),
-        ContinuousLinearEquiv.apply_symm_apply]
     · apply isoE'.symm.contDiff.comp_contDiffOn
       apply hg.comp (isoP.prod isoG).contDiff.contDiffOn
       rintro ⟨p, x⟩ ⟨hp, -⟩
@@ -1355,11 +1352,6 @@ theorem contDiffOn_convolution_right_with_param {f : G → E} {n : ℕ∞} (L : 
     rw [ClosedEmbedding.integral_map, ← isoF.integral_comp_comm]
     swap; · exact isoG.symm.toHomeomorph.closedEmbedding
     congr 1
-    ext1 a
-    simp only [ef, eg, eL, (· ∘ ·), ContinuousLinearEquiv.apply_symm_apply, coe_comp',
-      ContinuousLinearEquiv.prod_apply, ContinuousLinearEquiv.map_sub,
-      ContinuousLinearEquiv.arrowCongr, ContinuousLinearEquiv.arrowCongrSL_symm_apply,
-      ContinuousLinearEquiv.coe_coe, Function.comp_apply, ContinuousLinearEquiv.apply_symm_apply]
   simp_rw [this] at A
   exact A
 #align cont_diff_on_convolution_right_with_param contDiffOn_convolution_right_with_param

--- a/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
+++ b/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
@@ -272,7 +272,7 @@ theorem tendsto_integral_exp_smul_cocompact (μ : Measure V) [μ.IsAddHaarMeasur
   -- refer to the inner product. So we choose an arbitrary inner-product space isomorphic to V
   -- and port the result over from there.
   let V' := EuclideanSpace ℝ (Fin (finrank ℝ V))
-  have A : V ≃L[ℝ] V' := toEuclidean
+  let A : V ≃L[ℝ] V' := toEuclidean
   borelize V'
   -- various equivs derived from A
   let Aₘ : MeasurableEquiv V V' := A.toHomeomorph.toMeasurableEquiv

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -850,7 +850,7 @@ irreducible_def stdOrthonormalBasis : OrthonormalBasis (Fin (finrank 𝕜 E)) �
 /-- An orthonormal basis of `ℝ` is made either of the vector `1`, or of the vector `-1`. -/
 theorem orthonormalBasis_one_dim (b : OrthonormalBasis ι ℝ ℝ) :
     (⇑b = fun _ => (1 : ℝ)) ∨ ⇑b = fun _ => (-1 : ℝ) := by
-  have : Unique ι := b.toBasis.unique
+  let _ : Unique ι := b.toBasis.unique
   have : b default = 1 ∨ b default = -1 := by
     have : ‖b default‖ = 1 := b.orthonormal.1 _
     rwa [Real.norm_eq_abs, abs_eq (zero_le_one' ℝ)] at this
@@ -932,7 +932,7 @@ noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[
   -- Build an isometry from Sᗮ to L(S)ᗮ through `EuclideanSpace`
   let d := finrank 𝕜 Sᗮ
   let LS := LinearMap.range L.toLinearMap
-  have E : Sᗮ ≃ₗᵢ[𝕜] LSᗮ := by
+  let E : Sᗮ ≃ₗᵢ[𝕜] LSᗮ := by
     have dim_LS_perp : finrank 𝕜 LSᗮ = d :=
       calc
         finrank 𝕜 LSᗮ = finrank 𝕜 V - finrank 𝕜 LS := by

--- a/Mathlib/Analysis/NormedSpace/ContinuousAffineMap.lean
+++ b/Mathlib/Analysis/NormedSpace/ContinuousAffineMap.lean
@@ -212,7 +212,7 @@ instance : NormedSpace 𝕜 (V →A[𝕜] W) where
     -- Porting note: previously all these rewrites were in the `simp only`,
     -- but now they don't fire.
     -- (in fact, `norm_smul` fires, but only once rather than twice!)
-    have : NormedAddCommGroup (V →A[𝕜] W) := inferInstance -- this is necessary for `norm_smul`
+    let _ : NormedAddCommGroup (V →A[𝕜] W) := inferInstance -- this is necessary for `norm_smul`
     rw [coe_smul, Pi.smul_apply, norm_smul, norm_smul _ (f.contLinear),
       ← mul_max_of_nonneg _ _ (norm_nonneg t)]
 

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Completeness.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Completeness.lean
@@ -250,7 +250,7 @@ theorem opNorm_extend_le :
   · cases le_total 0 N with
     | inl hN => exact mul_nonneg hN (norm_nonneg _)
     | inr hN =>
-      have : Unique E := ⟨⟨0⟩, fun x ↦ norm_le_zero_iff.mp <|
+      let _ : Unique E := ⟨⟨0⟩, fun x ↦ norm_le_zero_iff.mp <|
         (h_e x).trans (mul_nonpos_of_nonpos_of_nonneg hN (norm_nonneg _))⟩
       obtain rfl : f = 0 := Subsingleton.elim ..
       simp

--- a/Mathlib/CategoryTheory/Abelian/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Basic.lean
@@ -621,7 +621,7 @@ instance epi_pullback_of_epi_f [Epi f] : Epi (pullback.snd : pullback f g ⟶ Y)
     have hu : PullbackToBiproductIsKernel.pullbackToBiproduct f g ≫ u = 0 := by simpa [u]
     -- pullback_to_biproduct f g is a kernel of (f, -g), so (f, -g) is a
     -- cokernel of pullback_to_biproduct f g
-    have :=
+    let this :=
       epiIsCokernelOfKernel _
         (PullbackToBiproductIsKernel.isLimitPullbackToBiproduct f g)
     -- We use this fact to obtain a factorization of u through (f, -g) via some d : Z ⟶ R.
@@ -654,7 +654,7 @@ instance epi_pullback_of_epi_g [Epi g] : Epi (pullback.fst : pullback f g ⟶ X)
     have hu : PullbackToBiproductIsKernel.pullbackToBiproduct f g ≫ u = 0 := by simpa [u]
     -- pullback_to_biproduct f g is a kernel of (f, -g), so (f, -g) is a
     -- cokernel of pullback_to_biproduct f g
-    have :=
+    let this :=
       epiIsCokernelOfKernel _
         (PullbackToBiproductIsKernel.isLimitPullbackToBiproduct f g)
     -- We use this fact to obtain a factorization of u through (f, -g) via some d : Z ⟶ R.
@@ -707,7 +707,7 @@ instance mono_pushout_of_mono_f [Mono f] : Mono (pushout.inr : Z ⟶ pushout f g
   mono_of_cancel_zero _ fun {R} e h => by
     let u := biprod.lift (0 : R ⟶ Y) e
     have hu : u ≫ BiproductToPushoutIsCokernel.biproductToPushout f g = 0 := by simpa [u]
-    have :=
+    let this :=
       monoIsKernelOfCokernel _
         (BiproductToPushoutIsCokernel.isColimitBiproductToPushout f g)
     obtain ⟨d, hd⟩ := KernelFork.IsLimit.lift' this u hu
@@ -730,7 +730,7 @@ instance mono_pushout_of_mono_g [Mono g] : Mono (pushout.inl : Y ⟶ pushout f g
   mono_of_cancel_zero _ fun {R} e h => by
     let u := biprod.lift e (0 : R ⟶ Z)
     have hu : u ≫ BiproductToPushoutIsCokernel.biproductToPushout f g = 0 := by simpa [u]
-    have :=
+    let this :=
       monoIsKernelOfCokernel _
         (BiproductToPushoutIsCokernel.isColimitBiproductToPushout f g)
     obtain ⟨d, hd⟩ := KernelFork.IsLimit.lift' this u hu

--- a/Mathlib/CategoryTheory/Abelian/Exact.lean
+++ b/Mathlib/CategoryTheory/Abelian/Exact.lean
@@ -407,7 +407,7 @@ def preservesKernelsOfMapExact (X Y : A) (f : X ⟶ Y) : PreservesLimit (paralle
     letI := preservesZeroMorphisms_of_map_exact L h
     letI := preservesMonomorphisms_of_map_exact L h
     letI := mono_of_isLimit_fork ic
-    have hf :=
+    let hf :=
       (isLimitMapConeForkEquiv' L (KernelFork.condition c)).symm
         (isLimitOfExactOfMono (L.map (Fork.ι c)) (L.map f)
           (h (exact_of_is_kernel (Fork.ι c) f (KernelFork.condition c)
@@ -422,7 +422,7 @@ def preservesCokernelsOfMapExact (X Y : A) (f : X ⟶ Y) :
     letI := preservesZeroMorphisms_of_map_exact L h
     letI := preservesEpimorphisms_of_map_exact L h
     letI := epi_of_isColimit_cofork ic
-    have hf :=
+    let hf :=
       (isColimitMapCoconeCoforkEquiv' L (CokernelCofork.condition c)).symm
         (isColimitOfExactOfEpi (L.map f) (L.map (Cofork.π c))
           (h (exact_of_is_cokernel f (Cofork.π c) (CokernelCofork.condition c)

--- a/Mathlib/CategoryTheory/Abelian/Transfer.lean
+++ b/Mathlib/CategoryTheory/Abelian/Transfer.lean
@@ -63,7 +63,7 @@ theorem hasKernels [PreservesFiniteLimits G] : HasKernels C :=
 /-- No point making this an instance, as it requires `i` and `adj`. -/
 theorem hasCokernels : HasCokernels C :=
   { has_colimit := fun f => by
-      have : PreservesColimits G := adj.leftAdjointPreservesColimits
+      let _ : PreservesColimits G := adj.leftAdjointPreservesColimits
       have := NatIso.naturality_1 i f
       simp? at this says
         simp only [Functor.id_obj, Functor.comp_obj, Functor.comp_map, Functor.id_map] at this
@@ -78,7 +78,7 @@ variable [Limits.HasCokernels C]
 def cokernelIso {X Y : C} (f : X ⟶ Y) : G.obj (cokernel (F.map f)) ≅ cokernel f := by
   -- We have to write an explicit `PreservesColimits` type here,
   -- as `leftAdjointPreservesColimits` has universe variables.
-  have : PreservesColimits G := adj.leftAdjointPreservesColimits
+  let _ : PreservesColimits G := adj.leftAdjointPreservesColimits
   calc
     G.obj (cokernel (F.map f)) ≅ cokernel (G.map (F.map f)) :=
       (asIso (cokernelComparison _ G)).symm
@@ -92,7 +92,7 @@ variable [Limits.HasKernels C] [PreservesFiniteLimits G]
 /-- Auxiliary construction for `coimageIsoImage` -/
 def coimageIsoImageAux {X Y : C} (f : X ⟶ Y) :
     kernel (G.map (cokernel.π (F.map f))) ≅ kernel (cokernel.π f) := by
-  have : PreservesColimits G := adj.leftAdjointPreservesColimits
+  let _ : PreservesColimits G := adj.leftAdjointPreservesColimits
   calc
     kernel (G.map (cokernel.π (F.map f))) ≅
         kernel (cokernel.π (G.map (F.map f)) ≫ cokernelComparison (F.map f) G) :=
@@ -118,7 +118,7 @@ variable [Functor.PreservesZeroMorphisms F]
 We still need to check that this agrees with the canonical morphism.
 -/
 def coimageIsoImage {X Y : C} (f : X ⟶ Y) : Abelian.coimage f ≅ Abelian.image f := by
-  have : PreservesLimits F := adj.rightAdjointPreservesLimits
+  let _ : PreservesLimits F := adj.rightAdjointPreservesLimits
   calc
     Abelian.coimage f ≅ cokernel (kernel.ι f) := Iso.refl _
     _ ≅ G.obj (cokernel (F.map (kernel.ι f))) := (cokernelIso _ _ i adj _).symm

--- a/Mathlib/CategoryTheory/Adhesive.lean
+++ b/Mathlib/CategoryTheory/Adhesive.lean
@@ -320,8 +320,8 @@ theorem adhesive_of_reflective [HasPullbacks D] [Adhesive C] [HasPullbacks C] [H
     {Gl : C ⥤ D} {Gr : D ⥤ C} (adj : Gl ⊣ Gr) [Gr.Full] [Gr.Faithful]
     [PreservesLimitsOfShape WalkingCospan Gl] :
     Adhesive D := by
-  have := adj.leftAdjointPreservesColimits
-  have := adj.rightAdjointPreservesLimits
+  let _ := adj.leftAdjointPreservesColimits
+  let _ := adj.rightAdjointPreservesLimits
   apply Adhesive.mk (hasPushout_of_mono_left := H₂)
   intro W X Y Z f g h i _ H
   have := Adhesive.van_kampen (IsPushout.of_hasPushout (Gr.map f) (Gr.map g))

--- a/Mathlib/CategoryTheory/Closed/Cartesian.lean
+++ b/Mathlib/CategoryTheory/Closed/Cartesian.lean
@@ -409,8 +409,8 @@ def cartesianClosedOfEquiv (e : C ≌ D) [h : CartesianClosed C] : CartesianClos
   closed X :=
     { isAdj := by
         haveI q : Exponentiable (e.inverse.obj X) := inferInstance
-        have : IsLeftAdjoint (prod.functor.obj (e.inverse.obj X)) := q.isAdj
-        have : e.functor ⋙ prod.functor.obj X ⋙ e.inverse ≅
+        let _ : IsLeftAdjoint (prod.functor.obj (e.inverse.obj X)) := q.isAdj
+        let this : e.functor ⋙ prod.functor.obj X ⋙ e.inverse ≅
             prod.functor.obj (e.inverse.obj X) := by
           apply NatIso.ofComponents _ _
           · intro Y
@@ -421,11 +421,11 @@ def cartesianClosedOfEquiv (e : C ≌ D) [h : CartesianClosed C] : CartesianClos
             simp [prodComparison, prod.comp_lift, ← e.inverse.map_comp, ← e.inverse.map_comp_assoc]
             -- I wonder if it would be a good idea to
             -- make `map_comp` a simp lemma the other way round
-        · have : IsLeftAdjoint (e.functor ⋙ prod.functor.obj X ⋙ e.inverse) :=
+        · let _ : IsLeftAdjoint (e.functor ⋙ prod.functor.obj X ⋙ e.inverse) :=
             Adjunction.leftAdjointOfNatIso this.symm
-          have : IsLeftAdjoint (e.inverse ⋙ e.functor ⋙ prod.functor.obj X ⋙ e.inverse) :=
+          let _ : IsLeftAdjoint (e.inverse ⋙ e.functor ⋙ prod.functor.obj X ⋙ e.inverse) :=
             Adjunction.leftAdjointOfComp e.inverse _
-          have :
+          let this :
             (e.inverse ⋙ e.functor ⋙ prod.functor.obj X ⋙ e.inverse) ⋙ e.functor ≅
               prod.functor.obj X := by
             apply isoWhiskerRight e.counitIso (prod.functor.obj X ⋙ e.inverse ⋙ e.functor) ≪≫ _

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -310,7 +310,7 @@ noncomputable def ofEquiv (F : MonoidalFunctor C D) [F.IsEquivalence]
     { isAdj := by
         haveI q : Closed (F.obj X) := inferInstance
         haveI : IsLeftAdjoint (tensorLeft (F.obj X)) := q.isAdj
-        have i := (MonoidalFunctor.commTensorLeft F X).compInvIso
+        let i := (MonoidalFunctor.commTensorLeft F X).compInvIso
         exact Adjunction.leftAdjointOfNatIso i }
 #align category_theory.monoidal_closed.of_equiv CategoryTheory.MonoidalClosed.ofEquiv
 

--- a/Mathlib/CategoryTheory/EffectiveEpi/Extensive.lean
+++ b/Mathlib/CategoryTheory/EffectiveEpi/Extensive.lean
@@ -33,7 +33,7 @@ variable (F : C ⥤ D) [PreservesFiniteCoproducts F]
 
 instance [F.ReflectsEffectiveEpis] : F.ReflectsFiniteEffectiveEpiFamilies where
   reflects {α _ B} X π h := by
-    have : Fintype α := Fintype.ofFinite _
+    let _ : Fintype α := Fintype.ofFinite _
     simp only [← effectiveEpi_desc_iff_effectiveEpiFamily]
     apply F.effectiveEpi_of_map
     convert (inferInstance :
@@ -42,7 +42,7 @@ instance [F.ReflectsEffectiveEpis] : F.ReflectsFiniteEffectiveEpiFamilies where
 
 instance [F.PreservesEffectiveEpis] : F.PreservesFiniteEffectiveEpiFamilies where
   preserves {α _ B} X π h := by
-    have : Fintype α := Fintype.ofFinite _
+    let _ : Fintype α := Fintype.ofFinite _
     simp only [← effectiveEpi_desc_iff_effectiveEpiFamily]
     convert (inferInstance :
       EffectiveEpi ((sigmaComparison F X) ≫ (F.map (Sigma.desc π))))

--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -421,12 +421,12 @@ theorem finitaryExtensive_of_reflective
     [∀ X Y (f : X ⟶ Gl.obj Y), PreservesLimit (cospan (Gr.map f) (adj.unit.app Y)) Gl]
     [PreservesPullbacksOfInclusions Gl] :
     FinitaryExtensive D := by
-  have : PreservesColimitsOfSize Gl := adj.leftAdjointPreservesColimits
+  let _ : PreservesColimitsOfSize Gl := adj.leftAdjointPreservesColimits
   constructor
   intros X Y c hc
   apply (IsVanKampenColimit.precompose_isIso_iff
     (isoWhiskerLeft _ (asIso adj.counit) ≪≫ Functor.rightUnitor _).hom).mp
-  have : ∀ (Z : C) (i : Discrete WalkingPair) (f : Z ⟶ (colimit.cocone (pair X Y ⋙ Gr)).pt),
+  let _ : ∀ (Z : C) (i : Discrete WalkingPair) (f : Z ⟶ (colimit.cocone (pair X Y ⋙ Gr)).pt),
         PreservesLimit (cospan f ((colimit.cocone (pair X Y ⋙ Gr)).ι.app i)) Gl := by
     have : pair X Y ⋙ Gr = pair (Gr.obj X) (Gr.obj Y) := by
       apply Functor.hext
@@ -466,7 +466,7 @@ theorem finitaryExtensive_of_preserves_and_reflects (F : C ⥤ D) [FinitaryExten
   constructor
   intros X Y c hc
   refine IsVanKampenColimit.of_iso ?_ (hc.uniqueUpToIso (coprodIsCoprod X Y)).symm
-  have (i : Discrete WalkingPair) (Z : C) (f : Z ⟶ X ⨿ Y) :
+  let _ (i : Discrete WalkingPair) (Z : C) (f : Z ⟶ X ⨿ Y) :
     PreservesLimit (cospan f ((BinaryCofan.mk coprod.inl coprod.inr).ι.app i)) F := by
     rcases i with ⟨_|_⟩ <;> dsimp <;> infer_instance
   refine (FinitaryExtensive.vanKampen _

--- a/Mathlib/CategoryTheory/Functor/EpiMono.lean
+++ b/Mathlib/CategoryTheory/Functor/EpiMono.lean
@@ -338,7 +338,7 @@ theorem strongEpi_map_iff_strongEpi_of_isEquivalence [IsEquivalence F] :
     StrongEpi (F.map f) ↔ StrongEpi f := by
   constructor
   · intro
-    have e : Arrow.mk f ≅ Arrow.mk (F.inv.map (F.map f)) :=
+    let e : Arrow.mk f ≅ Arrow.mk (F.inv.map (F.map f)) :=
       Arrow.isoOfNatIso F.asEquivalence.unitIso (Arrow.mk f)
     rw [StrongEpi.iff_of_arrow_iso e]
     infer_instance

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -240,7 +240,7 @@ variable (L L' : C ⥤ H) (iso₁ : L ≅ L') (F F' : C ⥤ D) (e : H ≌ H') (i
 when `e` is an equivalence. -/
 noncomputable def rightExtensionEquivalenceOfPostcomp₁ :
     RightExtension (L ⋙ e.functor) F ≌ RightExtension L F := by
-  have := CostructuredArrow.isEquivalencePre ((whiskeringLeft H H' D).obj e.functor)
+  let _ := CostructuredArrow.isEquivalencePre ((whiskeringLeft H H' D).obj e.functor)
     ((whiskeringLeft C H D).obj L) F
   exact Functor.asEquivalence (CostructuredArrow.pre ((whiskeringLeft H H' D).obj e.functor)
     ((whiskeringLeft C H D).obj L) F)
@@ -253,7 +253,7 @@ lemma hasRightExtension_iff_postcomp₁ :
 when `e` is an equivalence. -/
 noncomputable def leftExtensionEquivalenceOfPostcomp₁ :
     LeftExtension (L ⋙ e.functor) F ≌ LeftExtension L F := by
-  have := StructuredArrow.isEquivalencePre F ((whiskeringLeft H H' D).obj e.functor)
+  let _ := StructuredArrow.isEquivalencePre F ((whiskeringLeft H H' D).obj e.functor)
     ((whiskeringLeft C H D).obj L)
   exact Functor.asEquivalence (StructuredArrow.pre F ((whiskeringLeft H H' D).obj e.functor)
     ((whiskeringLeft C H D).obj L))

--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -189,7 +189,7 @@ lemma has_non_trivial_subobject_of_not_isConnected_of_not_initial (X : C) (hc : 
 /-- The fiber of a connected object is nonempty. -/
 instance nonempty_fiber_of_isConnected (X : C) [IsConnected X] : Nonempty (F.obj X) := by
   by_contra h
-  have ⟨hin⟩ : Nonempty (IsInitial X) := (initial_iff_fiber_empty F X).mpr (not_nonempty_iff.mp h)
+  let ⟨hin⟩ : Nonempty (IsInitial X) := (initial_iff_fiber_empty F X).mpr (not_nonempty_iff.mp h)
   exact IsConnected.notInitial hin
 
 /-- The fiber of the equalizer of `f g : X ⟶ Y` is equivalent to the set of agreement of `f`
@@ -270,7 +270,7 @@ lemma cardFiber_coprod_eq_sum (X Y : C) :
 
 /-- The cardinality of the fiber is preserved under isomorphisms. -/
 lemma cardFiber_eq_of_iso {X Y : C} (i : X ≅ Y) : Nat.card (F.obj X) = Nat.card (F.obj Y) := by
-  have e : F.obj X ≃ F.obj Y := Iso.toEquiv (mapIso (F ⋙ FintypeCat.incl) i)
+  let e : F.obj X ≃ F.obj Y := Iso.toEquiv (mapIso (F ⋙ FintypeCat.incl) i)
   exact Nat.card_eq_of_bijective e (Equiv.bijective e)
 
 end CardFiber

--- a/Mathlib/CategoryTheory/Galois/Decomposition.lean
+++ b/Mathlib/CategoryTheory/Galois/Decomposition.lean
@@ -87,7 +87,7 @@ private lemma has_decomp_connected_components_aux (F : C ⥤ FintypeCat.{w}) [Fi
     have hn1 : Nat.card (F.obj Y) < n := by
       rw [hn]
       exact ltCardFiber_of_mono_of_notIso F v hvnoiso
-    have i : X ≅ Y ⨿ Z := (colimit.isoColimitCocone t).symm
+    let i : X ≅ Y ⨿ Z := (colimit.isoColimitCocone t).symm
     have hnn : Nat.card (F.obj X) = Nat.card (F.obj Y) + Nat.card (F.obj Z) := by
       rw [cardFiber_eq_of_iso F i]
       exact cardFiber_coprod_eq_sum F Y Z
@@ -126,7 +126,7 @@ variable (F : C ⥤ FintypeCat.{w}) [FiberFunctor F]
 lemma fiber_in_connected_component (X : C) (x : F.obj X) : ∃ (Y : C) (i : Y ⟶ X) (y : F.obj Y),
     F.map i y = x ∧ IsConnected Y ∧ Mono i := by
   obtain ⟨ι, f, g, hl, hc, he⟩ := has_decomp_connected_components X
-  have : Fintype ι := Fintype.ofFinite ι
+  let _ : Fintype ι := Fintype.ofFinite ι
   let s : Cocone (Discrete.functor f ⋙ F) := F.mapCocone (Cofan.mk X g)
   let s' : IsColimit s := isColimitOfPreserves F hl
   obtain ⟨⟨j⟩, z, h⟩ := Concrete.isColimit_exists_rep _ s' x

--- a/Mathlib/CategoryTheory/Galois/Examples.lean
+++ b/Mathlib/CategoryTheory/Galois/Examples.lean
@@ -107,7 +107,7 @@ theorem Action.pretransitive_of_isConnected (X : Action FintypeCat (MonCat.of G)
     /- We show that the `G`-orbit of `x` is a non-initial subobject of `X` and hence by
     connectedness, the orbit equals `X.V`. -/
     let T : Set X.V := MulAction.orbit G x
-    have : Fintype T := Fintype.ofFinite T
+    let _ : Fintype T := Fintype.ofFinite T
     letI : MulAction G (FintypeCat.of T) := MulAction.instMulActionElemOrbit
     let T' : Action FintypeCat (MonCat.of G) := Action.FintypeCat.ofMulAction G (FintypeCat.of T)
     let i : T' ⟶ X := ⟨Subtype.val, fun _ ↦ rfl⟩

--- a/Mathlib/CategoryTheory/GradedObject/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Trifunctor.lean
@@ -299,14 +299,14 @@ variable [H : HasGoodTrifunctor₁₂Obj F₁₂ G ρ₁₂ X₁ X₂ X₃]
 noncomputable def isColimitCofan₃MapBifunctor₁₂BifunctorMapObj (j : J) :
     IsColimit (cofan₃MapBifunctor₁₂BifunctorMapObj F₁₂ G ρ₁₂ X₁ X₂ X₃ j) := by
   let c₁₂ := fun i₁₂ => (((mapBifunctor F₁₂ I₁ I₂).obj X₁).obj X₂).cofanMapObj ρ₁₂.p i₁₂
-  have h₁₂ : ∀ i₁₂, IsColimit (c₁₂ i₁₂) := fun i₁₂ =>
+  let h₁₂ : ∀ i₁₂, IsColimit (c₁₂ i₁₂) := fun i₁₂ =>
     (((mapBifunctor F₁₂ I₁ I₂).obj X₁).obj X₂).isColimitCofanMapObj ρ₁₂.p i₁₂
   let c := (((mapBifunctor G ρ₁₂.I₁₂ I₃).obj
     (mapBifunctorMapObj F₁₂ ρ₁₂.p X₁ X₂)).obj X₃).cofanMapObj ρ₁₂.q j
-  have hc : IsColimit c := (((mapBifunctor G ρ₁₂.I₁₂ I₃).obj
+  let hc : IsColimit c := (((mapBifunctor G ρ₁₂.I₁₂ I₃).obj
     (mapBifunctorMapObj F₁₂ ρ₁₂.p X₁ X₂)).obj X₃).isColimitCofanMapObj ρ₁₂.q j
   let c₁₂' := fun (i : ρ₁₂.q ⁻¹' {j}) => (G.flip.obj (X₃ i.1.2)).mapCocone (c₁₂ i.1.1)
-  have hc₁₂' : ∀ i, IsColimit (c₁₂' i) := fun i => isColimitOfPreserves _ (h₁₂ i.1.1)
+  let hc₁₂' : ∀ i, IsColimit (c₁₂' i) := fun i => isColimitOfPreserves _ (h₁₂ i.1.1)
   let Z := (((mapTrifunctor (bifunctorComp₁₂ F₁₂ G) I₁ I₂ I₃).obj X₁).obj X₂).obj X₃
   let p' : I₁ × I₂ × I₃ → ρ₁₂.I₁₂ × I₃ := fun ⟨i₁, i₂, i₃⟩ => ⟨ρ₁₂.p ⟨i₁, i₂⟩, i₃⟩
   let e : ∀ (i₁₂ : ρ₁₂.I₁₂) (i₃ : I₃), p' ⁻¹' {(i₁₂, i₃)} ≃ ρ₁₂.p ⁻¹' {i₁₂} := fun i₁₂ i₃ =>
@@ -324,7 +324,7 @@ noncomputable def isColimitCofan₃MapBifunctor₁₂BifunctorMapObj (j : J) :
         (G.obj ((F₁₂.obj (X₁ i₁)).obj (X₂ i₂))).mapIso (eqToIso _)))
       obtain rfl : i₃' = i₃ := congr_arg _root_.Prod.snd hi
       rfl
-  have h₁₂'' : ∀ i, IsColimit (c₁₂'' i) := fun _ =>
+  let h₁₂'' : ∀ i, IsColimit (c₁₂'' i) := fun _ =>
     (IsColimit.precomposeHomEquiv _ _).symm (IsColimit.whiskerEquivalenceEquiv _ (hc₁₂' _))
   refine' IsColimit.ofIsoColimit (isColimitCofanMapObjComp Z p' ρ₁₂.q r ρ₁₂.hpq j
     (fun ⟨i₁₂, i₃⟩ h => c₁₂'' ⟨⟨i₁₂, i₃⟩, h⟩) (fun ⟨i₁₂, i₃⟩ h => h₁₂'' ⟨⟨i₁₂, i₃⟩, h⟩) c hc)
@@ -440,14 +440,14 @@ variable [H : HasGoodTrifunctor₂₃Obj F G₂₃ ρ₂₃ X₁ X₂ X₃]
 noncomputable def isColimitCofan₃MapBifunctorBifunctor₂₃MapObj (j : J) :
     IsColimit (cofan₃MapBifunctorBifunctor₂₃MapObj F G₂₃ ρ₂₃ X₁ X₂ X₃ j) := by
   let c₂₃ := fun i₂₃ => (((mapBifunctor G₂₃ I₂ I₃).obj X₂).obj X₃).cofanMapObj ρ₂₃.p i₂₃
-  have h₂₃ : ∀ i₂₃, IsColimit (c₂₃ i₂₃) := fun i₂₃ =>
+  let h₂₃ : ∀ i₂₃, IsColimit (c₂₃ i₂₃) := fun i₂₃ =>
     (((mapBifunctor G₂₃ I₂ I₃).obj X₂).obj X₃).isColimitCofanMapObj ρ₂₃.p i₂₃
   let c := (((mapBifunctor F I₁ ρ₂₃.I₂₃).obj X₁).obj
     (mapBifunctorMapObj G₂₃ ρ₂₃.p X₂ X₃)).cofanMapObj ρ₂₃.q j
-  have hc : IsColimit c := (((mapBifunctor F I₁ ρ₂₃.I₂₃).obj X₁).obj
+  let hc : IsColimit c := (((mapBifunctor F I₁ ρ₂₃.I₂₃).obj X₁).obj
     (mapBifunctorMapObj G₂₃ ρ₂₃.p X₂ X₃)).isColimitCofanMapObj ρ₂₃.q j
   let c₂₃' := fun (i : ρ₂₃.q ⁻¹' {j}) => (F.obj (X₁ i.1.1)).mapCocone (c₂₃ i.1.2)
-  have hc₂₃' : ∀ i, IsColimit (c₂₃' i) := fun i => isColimitOfPreserves _ (h₂₃ i.1.2)
+  let hc₂₃' : ∀ i, IsColimit (c₂₃' i) := fun i => isColimitOfPreserves _ (h₂₃ i.1.2)
   let Z := (((mapTrifunctor (bifunctorComp₂₃ F G₂₃) I₁ I₂ I₃).obj X₁).obj X₂).obj X₃
   let p' : I₁ × I₂ × I₃ → I₁ × ρ₂₃.I₂₃ := fun ⟨i₁, i₂, i₃⟩ => ⟨i₁, ρ₂₃.p ⟨i₂, i₃⟩⟩
   let e : ∀ (i₁ : I₁) (i₂₃ : ρ₂₃.I₂₃) , p' ⁻¹' {(i₁, i₂₃)} ≃ ρ₂₃.p ⁻¹' {i₂₃} := fun i₁ i₂₃ =>
@@ -464,7 +464,7 @@ noncomputable def isColimitCofan₃MapBifunctorBifunctor₂₃MapObj (j : J) :
       refine' Discrete.natIso (fun ⟨⟨i₁', i₂, i₃⟩, hi⟩ => eqToIso _)
       obtain rfl : i₁' = i₁ := congr_arg _root_.Prod.fst hi
       rfl
-  have h₂₃'' : ∀ i, IsColimit (c₂₃'' i) := fun _ =>
+  let h₂₃'' : ∀ i, IsColimit (c₂₃'' i) := fun _ =>
     (IsColimit.precomposeHomEquiv _ _).symm (IsColimit.whiskerEquivalenceEquiv _ (hc₂₃' _))
   refine' IsColimit.ofIsoColimit (isColimitCofanMapObjComp Z p' ρ₂₃.q r ρ₂₃.hpq j
     (fun ⟨i₁, i₂₃⟩ h => c₂₃'' ⟨⟨i₁, i₂₃⟩, h⟩) (fun ⟨i₁, i₂₃⟩ h => h₂₃'' ⟨⟨i₁, i₂₃⟩, h⟩) c hc)

--- a/Mathlib/CategoryTheory/Limits/Constructions/EpiMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/EpiMono.lean
@@ -31,7 +31,7 @@ variable (F : C ⥤ D)
 /-- If `F` preserves pullbacks, then it preserves monomorphisms. -/
 theorem preserves_mono_of_preservesLimit {X Y : C} (f : X ⟶ Y) [PreservesLimit (cospan f f) F]
     [Mono f] : Mono (F.map f) := by
-  have := isLimitPullbackConeMapOfIsLimit F _ (PullbackCone.isLimitMkIdId f)
+  let this := isLimitPullbackConeMapOfIsLimit F _ (PullbackCone.isLimitMkIdId f)
   simp_rw [F.map_id] at this
   apply PullbackCone.mono_of_isLimitMkIdId _ this
 #align category_theory.preserves_mono_of_preserves_limit CategoryTheory.preserves_mono_of_preservesLimit
@@ -44,7 +44,7 @@ instance (priority := 100) preservesMonomorphisms_of_preservesLimitsOfShape
 /-- If `F` reflects pullbacks, then it reflects monomorphisms. -/
 theorem reflects_mono_of_reflectsLimit {X Y : C} (f : X ⟶ Y) [ReflectsLimit (cospan f f) F]
     [Mono (F.map f)] : Mono f := by
-  have := PullbackCone.isLimitMkIdId (F.map f)
+  let this := PullbackCone.isLimitMkIdId (F.map f)
   simp_rw [← F.map_id] at this
   apply PullbackCone.mono_of_isLimitMkIdId _ (isLimitOfIsLimitPullbackConeMap F _ this)
 #align category_theory.reflects_mono_of_reflects_limit CategoryTheory.reflects_mono_of_reflectsLimit
@@ -57,7 +57,7 @@ instance (priority := 100) reflectsMonomorphisms_of_reflectsLimitsOfShape
 /-- If `F` preserves pushouts, then it preserves epimorphisms. -/
 theorem preserves_epi_of_preservesColimit {X Y : C} (f : X ⟶ Y) [PreservesColimit (span f f) F]
     [Epi f] : Epi (F.map f) := by
-  have := isColimitPushoutCoconeMapOfIsColimit F _ (PushoutCocone.isColimitMkIdId f)
+  let this := isColimitPushoutCoconeMapOfIsColimit F _ (PushoutCocone.isColimitMkIdId f)
   simp_rw [F.map_id] at this
   apply PushoutCocone.epi_of_isColimitMkIdId _ this
 #align category_theory.preserves_epi_of_preserves_colimit CategoryTheory.preserves_epi_of_preservesColimit
@@ -70,7 +70,7 @@ instance (priority := 100) preservesEpimorphisms_of_preservesColimitsOfShape
 /-- If `F` reflects pushouts, then it reflects epimorphisms. -/
 theorem reflects_epi_of_reflectsColimit {X Y : C} (f : X ⟶ Y) [ReflectsColimit (span f f) F]
     [Epi (F.map f)] : Epi f := by
-  have := PushoutCocone.isColimitMkIdId (F.map f)
+  let this := PushoutCocone.isColimitMkIdId (F.map f)
   simp_rw [← F.map_id] at this
   apply
     PushoutCocone.epi_of_isColimitMkIdId _

--- a/Mathlib/CategoryTheory/Limits/Constructions/WeaklyInitial.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/WeaklyInitial.lean
@@ -48,7 +48,7 @@ theorem hasInitial_of_weakly_initial_and_hasWideEqualizers [HasWideEqualizers.{v
   let endos := T ⟶ T
   let i := wideEqualizer.ι (id : endos → endos)
   haveI : Nonempty endos := ⟨𝟙 _⟩
-  have : ∀ X : C, Unique (wideEqualizer (id : endos → endos) ⟶ X) := by
+  let _ : ∀ X : C, Unique (wideEqualizer (id : endos → endos) ⟶ X) := by
     intro X
     refine' ⟨⟨i ≫ Classical.choice (hT X)⟩, fun a => _⟩
     let E := equalizer a (i ≫ Classical.choice (hT _))

--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -159,6 +159,7 @@ open CategoryTheory.Prod
 
 variable [IsFiltered K]
 
+set_option linter.haveLet false in  -- `clear_value` complains
 /-- This follows this proof from
 * Borceux, Handbook of categorical algebra 1, Theorem 2.13.4
 although with different names.
@@ -187,6 +188,7 @@ theorem colimitLimitToLimitColimit_surjective :
     -- As a first step, we use that `K` is filtered to pick some point `k' : K` above all the `k j`
     let k' : K := IsFiltered.sup (Finset.univ.image k) ∅
     -- and name the morphisms as `g j : k j ⟶ k'`.
+    -- changing `have` to `let` causes `clear_value k'` to complain
     have g : ∀ j, k j ⟶ k' := fun j => IsFiltered.toSup (Finset.univ.image k) ∅ (by simp)
     clear_value k'
     -- Recalling that the components of `x`, which are indexed by `j : J`, are "coherent",

--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -159,7 +159,6 @@ open CategoryTheory.Prod
 
 variable [IsFiltered K]
 
-set_option linter.haveLet false in  -- `clear_value` complains
 /-- This follows this proof from
 * Borceux, Handbook of categorical algebra 1, Theorem 2.13.4
 although with different names.
@@ -188,7 +187,6 @@ theorem colimitLimitToLimitColimit_surjective :
     -- As a first step, we use that `K` is filtered to pick some point `k' : K` above all the `k j`
     let k' : K := IsFiltered.sup (Finset.univ.image k) ∅
     -- and name the morphisms as `g j : k j ⟶ k'`.
-    -- changing `have` to `let` causes `clear_value k'` to complain
     have g : ∀ j, k j ⟶ k' := fun j => IsFiltered.toSup (Finset.univ.image k) ∅ (by simp)
     clear_value k'
     -- Recalling that the components of `x`, which are indexed by `j : J`, are "coherent",

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -408,7 +408,6 @@ theorem zigzag_of_eqvGen_quot_rel {F : C ⥤ D} {d : D} {f₁ f₂ : ΣX, d ⟶ 
 
 end Final
 
-set_option linter.haveLet false in  -- have := (I d).inv PUnit.unit
 /-- If `colimit (F ⋙ coyoneda.obj (op d)) ≅ PUnit` for all `d : D`, then `F` is cofinal.
 -/
 theorem cofinal_of_colimit_comp_coyoneda_iso_pUnit

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -408,6 +408,7 @@ theorem zigzag_of_eqvGen_quot_rel {F : C ⥤ D} {d : D} {f₁ f₂ : ΣX, d ⟶ 
 
 end Final
 
+set_option linter.haveLet false in  -- have := (I d).inv PUnit.unit
 /-- If `colimit (F ⋙ coyoneda.obj (op d)) ≅ PUnit` for all `d : D`, then `F` is cofinal.
 -/
 theorem cofinal_of_colimit_comp_coyoneda_iso_pUnit

--- a/Mathlib/CategoryTheory/Limits/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/Limits/FintypeCat.lean
@@ -32,7 +32,7 @@ instance {J : Type} [SmallCategory J] (K : J ⥤ FintypeCat.{u}) (j : J) :
 has a finite limit. -/
 noncomputable instance finiteLimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J]
     (K : J ⥤ Type*) [∀ j, Finite (K.obj j)] : Fintype (limit K) := by
-  have : Fintype (sections K) := Fintype.ofFinite (sections K)
+  let _ : Fintype (sections K) := Fintype.ofFinite (sections K)
   exact Fintype.ofEquiv (sections K) (Types.limitEquivSections K).symm
 
 noncomputable instance inclusionCreatesFiniteLimits {J : Type} [SmallCategory J] [FinCategory J] :
@@ -65,7 +65,7 @@ has a finite colimit. -/
 noncomputable instance finiteColimitOfFiniteDiagram {J : Type} [SmallCategory J] [FinCategory J]
     (K : J ⥤ Type*) [∀ j, Finite (K.obj j)] : Fintype (colimit K) := by
   have : Finite (Types.Quot K) := Quot.finite (Types.Quot.Rel K)
-  have : Fintype (Types.Quot K) := Fintype.ofFinite (Types.Quot K)
+  let _ : Fintype (Types.Quot K) := Fintype.ofFinite (Types.Quot K)
   exact Fintype.ofEquiv (Types.Quot K) (Types.colimitEquivQuot K).symm
 
 noncomputable instance inclusionCreatesFiniteColimits {J : Type} [SmallCategory J] [FinCategory J] :

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -279,8 +279,8 @@ noncomputable def limitUncurryIsoLimitCompLim : limit (uncurry.obj F) ≅ limit 
   let P : IsLimit c := limit.isLimit _
   let G := DiagramOfCones.mkOfHasLimits F
   let Q : ∀ j, IsLimit (G.obj j) := fun j => limit.isLimit _
-  have Q' := coneOfConeUncurryIsLimit Q P
-  have Q'' := limit.isLimit (F ⋙ lim)
+  let Q' := coneOfConeUncurryIsLimit Q P
+  let Q'' := limit.isLimit (F ⋙ lim)
   exact IsLimit.conePointUniqueUpToIso Q' Q''
 #align category_theory.limits.limit_uncurry_iso_limit_comp_lim CategoryTheory.Limits.limitUncurryIsoLimitCompLim
 
@@ -338,8 +338,8 @@ noncomputable def colimitUncurryIsoColimitCompColim :
   let P : IsColimit c := colimit.isColimit _
   let G := DiagramOfCocones.mkOfHasColimits F
   let Q : ∀ j, IsColimit (G.obj j) := fun j => colimit.isColimit _
-  have Q' := coconeOfCoconeUncurryIsColimit Q P
-  have Q'' := colimit.isColimit (F ⋙ colim)
+  let Q' := coconeOfCoconeUncurryIsColimit Q P
+  let Q'' := colimit.isColimit (F ⋙ colim)
   exact IsColimit.coconePointUniqueUpToIso Q' Q''
 
 @[simp, reassoc]
@@ -443,7 +443,7 @@ showing that the limit of `G` can be computed as
 the limit of the limits of the functors `G.obj (j, _)`.
 -/
 noncomputable def limitIsoLimitCurryCompLim : limit G ≅ limit (curry.obj G ⋙ lim) := by
-  have i : G ≅ uncurry.obj ((@curry J _ K _ C _).obj G) := currying.symm.unitIso.app G
+  let i : G ≅ uncurry.obj ((@curry J _ K _ C _).obj G) := currying.symm.unitIso.app G
   haveI : Limits.HasLimit (uncurry.obj ((@curry J _ K _ C _).obj G)) := hasLimitOfIso i
   trans limit (uncurry.obj ((@curry J _ K _ C _).obj G))
   · apply HasLimit.isoOfNatIso i
@@ -479,7 +479,7 @@ showing that the colimit of `G` can be computed as
 the colimit of the colimits of the functors `G.obj (j, _)`.
 -/
 noncomputable def colimitIsoColimitCurryCompColim : colimit G ≅ colimit (curry.obj G ⋙ colim) := by
-  have i : G ≅ uncurry.obj ((@curry J _ K _ C _).obj G) := currying.symm.unitIso.app G
+  let i : G ≅ uncurry.obj ((@curry J _ K _ C _).obj G) := currying.symm.unitIso.app G
   haveI : Limits.HasColimit (uncurry.obj ((@curry J _ K _ C _).obj G)) := hasColimitOfIso i.symm
   trans colimit (uncurry.obj ((@curry J _ K _ C _).obj G))
   apply HasColimit.isoOfNatIso i

--- a/Mathlib/CategoryTheory/Limits/IsLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/IsLimit.lean
@@ -1024,7 +1024,7 @@ def homOfCocone (s : Cocone F) : X ⟶ s.pt :=
 @[simp]
 theorem coconeOfHom_homOfCocone (s : Cocone F) : coconeOfHom h (homOfCocone h s) = s := by
   dsimp [coconeOfHom, homOfCocone];
-  have ⟨s_pt,s_ι⟩ := s
+  let ⟨s_pt,s_ι⟩ := s
   congr; dsimp
   convert congrFun (congrFun (congrArg NatTrans.app h.inv_hom_id) s_pt) s_ι using 1
 #align category_theory.limits.is_colimit.of_nat_iso.cocone_of_hom_of_cocone CategoryTheory.Limits.IsColimit.OfNatIso.coconeOfHom_homOfCocone

--- a/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
@@ -239,7 +239,7 @@ def preservesLimitOfIsoDiagram {K₁ K₂ : J ⥤ C} (F : C ⥤ D) (h : K₁ ≅
     PreservesLimit K₂ F where
   preserves {c} t := by
     apply IsLimit.postcomposeInvEquiv (isoWhiskerRight h F : _) _ _
-    have := (IsLimit.postcomposeInvEquiv h c).symm t
+    let this := (IsLimit.postcomposeInvEquiv h c).symm t
     apply IsLimit.ofIsoLimit (isLimitOfPreserves F this)
     exact Cones.ext (Iso.refl _)
 #align category_theory.limits.preserves_limit_of_iso_diagram CategoryTheory.Limits.preservesLimitOfIsoDiagram
@@ -268,7 +268,7 @@ def preservesLimitsOfShapeOfEquiv {J' : Type w₂} [Category.{w₂'} J'] (e : J 
   preservesLimit {K} :=
     { preserves := fun {c} t => by
         let equ := e.invFunIdAssoc (K ⋙ F)
-        have := (isLimitOfPreserves F (t.whiskerEquivalence e)).whiskerEquivalence e.symm
+        let this := (isLimitOfPreserves F (t.whiskerEquivalence e)).whiskerEquivalence e.symm
         apply ((IsLimit.postcomposeHomEquiv equ _).symm this).ofIsoLimit
         refine' Cones.ext (Iso.refl _) fun j => _
         · dsimp
@@ -307,7 +307,7 @@ def preservesColimitOfIsoDiagram {K₁ K₂ : J ⥤ C} (F : C ⥤ D) (h : K₁ �
     PreservesColimit K₂ F where
   preserves {c} t := by
     apply IsColimit.precomposeHomEquiv (isoWhiskerRight h F : _) _ _
-    have := (IsColimit.precomposeHomEquiv h c).symm t
+    let this := (IsColimit.precomposeHomEquiv h c).symm t
     apply IsColimit.ofIsoColimit (isColimitOfPreserves F this)
     exact Cocones.ext (Iso.refl _)
 #align category_theory.limits.preserves_colimit_of_iso_diagram CategoryTheory.Limits.preservesColimitOfIsoDiagram
@@ -337,7 +337,7 @@ def preservesColimitsOfShapeOfEquiv {J' : Type w₂} [Category.{w₂'} J'] (e : 
     {
       preserves := fun {c} t => by
         let equ := e.invFunIdAssoc (K ⋙ F)
-        have := (isColimitOfPreserves F (t.whiskerEquivalence e)).whiskerEquivalence e.symm
+        let this := (isColimitOfPreserves F (t.whiskerEquivalence e)).whiskerEquivalence e.symm
         apply ((IsColimit.precomposeInvEquiv equ _).symm this).ofIsoColimit
         refine' Cocones.ext (Iso.refl _) fun j => _
         · dsimp

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
@@ -69,7 +69,7 @@ theorem hasFiniteLimits_of_hasFiniteLimits_of_size
     HasFiniteLimits C where
   out := fun J hJ hhJ => by
     haveI := h (ULiftHom.{w} (ULift.{w} J)) <| @CategoryTheory.finCategoryUlift J hJ hhJ
-    have l : @Equivalence J (ULiftHom (ULift J)) hJ
+    let l : @Equivalence J (ULiftHom (ULift J)) hJ
                           (@ULiftHom.category (ULift J) (@uliftCategory J hJ)) :=
       @ULiftHomULiftCategory.equiv J hJ
     apply @hasLimitsOfShape_of_equivalence (ULiftHom (ULift J))
@@ -117,7 +117,7 @@ theorem hasFiniteColimits_of_hasFiniteColimits_of_size
     HasFiniteColimits C where
   out := fun J hJ hhJ => by
     haveI := h (ULiftHom.{w} (ULift.{w} J)) <| @CategoryTheory.finCategoryUlift J hJ hhJ
-    have l : @Equivalence J (ULiftHom (ULift J)) hJ
+    let l : @Equivalence J (ULiftHom (ULift J)) hJ
                            (@ULiftHom.category (ULift J) (@uliftCategory J hJ)) :=
       @ULiftHomULiftCategory.equiv J hJ
     apply @hasColimitsOfShape_of_equivalence (ULiftHom (ULift J))

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -313,8 +313,8 @@ theorem IsUniversalColimit.map_reflective
     [∀ X (f : X ⟶ Gl.obj c.pt), HasPullback (Gr.map f) (adj.unit.app c.pt)]
     [∀ X (f : X ⟶ Gl.obj c.pt), PreservesLimit (cospan (Gr.map f) (adj.unit.app c.pt)) Gl] :
     IsUniversalColimit (Gl.mapCocone c) := by
-  have := adj.rightAdjointPreservesLimits
-  have : PreservesColimitsOfSize.{u', v'} Gl := adj.leftAdjointPreservesColimits
+  let _ := adj.rightAdjointPreservesLimits
+  let _ : PreservesColimitsOfSize.{u', v'} Gl := adj.leftAdjointPreservesColimits
   intros F' c' α f h hα hc'
   have : HasPullback (Gl.map (Gr.map f)) (Gl.map (adj.unit.app c.pt)) :=
     ⟨⟨_, isLimitPullbackConeMapOfIsLimit _ pullback.condition
@@ -384,7 +384,7 @@ theorem IsUniversalColimit.map_reflective
     rw [← IsIso.eq_comp_inv] at this
     rw [this]
     infer_instance
-  have ⟨Hc''⟩ := H c'' (whiskerRight α' Gr) pullback.snd ?_ (hα'.whiskerRight Gr) ?_
+  let ⟨Hc''⟩ := H c'' (whiskerRight α' Gr) pullback.snd ?_ (hα'.whiskerRight Gr) ?_
   · exact ⟨IsColimit.precomposeHomEquiv β c' <|
       (isColimitOfPreserves Gl Hc'').ofIsoColimit (asIso cf).symm⟩
   · ext j
@@ -416,8 +416,8 @@ theorem IsVanKampenColimit.map_reflective [HasColimitsOfShape J C]
     [∀ X (f : X ⟶ Gl.obj c.pt), PreservesLimit (cospan (Gr.map f) (adj.unit.app c.pt)) Gl]
     [∀ X i (f : X ⟶ c.pt), PreservesLimit (cospan f (c.ι.app i)) Gl] :
     IsVanKampenColimit (Gl.mapCocone c) := by
-  have := adj.rightAdjointPreservesLimits
-  have : PreservesColimitsOfSize.{u', v'} Gl := adj.leftAdjointPreservesColimits
+  let _ := adj.rightAdjointPreservesLimits
+  let _ : PreservesColimitsOfSize.{u', v'} Gl := adj.leftAdjointPreservesColimits
   intro F' c' α f h hα
   refine ⟨?_, H.isUniversal.map_reflective adj c' α f h hα⟩
   intro ⟨hc'⟩ j
@@ -486,8 +486,8 @@ theorem hasStrictInitial_of_isUniversal [HasInitial C]
 
 theorem isVanKampenColimit_of_isEmpty [HasStrictInitialObjects C] [IsEmpty J] {F : J ⥤ C}
     (c : Cocone F) (hc : IsColimit c) : IsVanKampenColimit c := by
-  have : IsInitial c.pt := by
-    have := (IsColimit.precomposeInvEquiv (Functor.uniqueFromEmpty _) _).symm
+  let this : IsInitial c.pt := by
+    let this := (IsColimit.precomposeInvEquiv (Functor.uniqueFromEmpty _) _).symm
       (hc.whiskerEquivalence (equivalenceOfIsEmpty (Discrete PEmpty.{1}) J))
     exact IsColimit.ofIsoColimit this (Cocones.ext (Iso.refl c.pt) (fun {X} ↦ isEmptyElim X))
   replace this := IsInitial.isVanKampenColimit this

--- a/Mathlib/CategoryTheory/Localization/LocalizerMorphism.lean
+++ b/Mathlib/CategoryTheory/Localization/LocalizerMorphism.lean
@@ -149,7 +149,7 @@ localization functor for `W₁`, then `Φ` is a localized equivalence. -/
 lemma IsLocalizedEquivalence.of_isLocalization_of_isLocalization
     [(Φ.functor ⋙ L₂).IsLocalization W₁] :
     IsLocalizedEquivalence Φ := by
-  have : CatCommSq Φ.functor (Φ.functor ⋙ L₂) L₂ (𝟭 D₂) :=
+  let _ : CatCommSq Φ.functor (Φ.functor ⋙ L₂) L₂ (𝟭 D₂) :=
     CatCommSq.mk (Functor.rightUnitor _).symm
   exact IsLocalizedEquivalence.mk' Φ (Φ.functor ⋙ L₂) L₂ (𝟭 D₂)
 

--- a/Mathlib/CategoryTheory/Localization/Pi.lean
+++ b/Mathlib/CategoryTheory/Localization/Pi.lean
@@ -79,7 +79,7 @@ instance {J : Type} [Finite J] {C : Type u₁} {D : Type u₂} [Category.{v₁} 
   let E' := piEquivalenceFunctorDiscrete J D
   let L₂ := (whiskeringRight (Discrete J) C D).obj L
   let L₁ := Functor.pi (fun (_ : J) => L)
-  have : CatCommSq E.functor L₁ L₂ E'.functor :=
+  let _ : CatCommSq E.functor L₁ L₂ E'.functor :=
     ⟨(Functor.rightUnitor _).symm ≪≫ isoWhiskerLeft _ E'.counitIso.symm ≪≫
       Functor.associator _ _ _≪≫ isoWhiskerLeft _ ((Functor.associator _ _ _).symm ≪≫
       isoWhiskerRight (by exact Iso.refl _) _) ≪≫ (Functor.associator _ _ _).symm ≪≫

--- a/Mathlib/CategoryTheory/Localization/Resolution.lean
+++ b/Mathlib/CategoryTheory/Localization/Resolution.lean
@@ -119,7 +119,7 @@ variable [Φ.HasRightResolutions] (L₂ : C₂ ⥤ D₂) [L₂.IsLocalization W�
 lemma essSurj_of_hasRightResolutions : (Φ.functor ⋙ L₂).EssSurj where
   mem_essImage X₂ := by
     have := Localization.essSurj L₂ W₂
-    have R : Φ.RightResolution (L₂.objPreimage X₂) := Classical.arbitrary _
+    let R : Φ.RightResolution (L₂.objPreimage X₂) := Classical.arbitrary _
     exact ⟨R.X₁, ⟨(Localization.isoOfHom L₂ W₂ _ R.hw).symm ≪≫ L₂.objObjPreimageIso X₂⟩⟩
 
 lemma isIso_iff_of_hasRightResolutions {F G : D₂ ⥤ H} (α : F ⟶ G) :

--- a/Mathlib/CategoryTheory/PUnit.lean
+++ b/Mathlib/CategoryTheory/PUnit.lean
@@ -76,8 +76,8 @@ theorem equiv_punit_iff_unique :
   · rintro ⟨h⟩
     refine' ⟨⟨h.inverse.obj ⟨⟨⟩⟩⟩, fun x y => Nonempty.intro _⟩
     let f : x ⟶ y := by
-      have hx : x ⟶ h.inverse.obj ⟨⟨⟩⟩ := by convert h.unit.app x
-      have hy : h.inverse.obj ⟨⟨⟩⟩ ⟶ y := by convert h.unitInv.app y
+      let hx : x ⟶ h.inverse.obj ⟨⟨⟩⟩ := by convert h.unit.app x
+      let hy : h.inverse.obj ⟨⟨⟩⟩ ⟶ y := by convert h.unitInv.app y
       exact hx ≫ hy
     suffices sub : Subsingleton (x ⟶ y) from uniqueOfSubsingleton f
     have : ∀ z, z = h.unit.app x ≫ (h.functor ⋙ h.inverse).map z ≫ h.unitInv.app y := by

--- a/Mathlib/CategoryTheory/Sites/Coherent/CoherentSheaves.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/CoherentSheaves.lean
@@ -44,7 +44,7 @@ namespace coherentTopology
 theorem isSheaf_yoneda_obj (W : C) : Presieve.IsSheaf (coherentTopology C) (yoneda.obj W) := by
   rw [isSheaf_coherent]
   intro X α _ Y π H
-  have h_colim := isColimitOfEffectiveEpiFamilyStruct Y π H.effectiveEpiFamily.some
+  let h_colim := isColimitOfEffectiveEpiFamilyStruct Y π H.effectiveEpiFamily.some
   rw [← Sieve.generateFamily_eq] at h_colim
   intro x hx
   let x_ext := Presieve.FamilyOfElements.sieveExtend x

--- a/Mathlib/CategoryTheory/Sites/Coherent/RegularSheaves.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/RegularSheaves.lean
@@ -243,7 +243,7 @@ lemma isSheaf_yoneda_obj [Preregular C] (W : C)  :
   intro X S ⟨_, hS⟩
   have : S.regular := ⟨_, hS⟩
   obtain ⟨Y, f, rfl, hf⟩ := Presieve.regular.single_epi (R := S)
-  have h_colim := isColimitOfEffectiveEpiStruct f hf.effectiveEpi.some
+  let h_colim := isColimitOfEffectiveEpiStruct f hf.effectiveEpi.some
   rw [← Sieve.generateSingleton_eq, ← Presieve.ofArrows_pUnit] at h_colim
   intro x hx
   let x_ext := Presieve.FamilyOfElements.sieveExtend x

--- a/Mathlib/CategoryTheory/Sites/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Sites/LeftExact.lean
@@ -206,7 +206,7 @@ instance preserveFiniteLimits_plusFunctor
     PreservesFiniteLimits (J.plusFunctor D) := by
   apply preservesFiniteLimitsOfPreservesFiniteLimitsOfSize.{max v u}
   intro K _ _
-  have : ReflectsLimitsOfShape K (forget D) := reflectsLimitsOfShapeOfReflectsIsomorphisms
+  let _ : ReflectsLimitsOfShape K (forget D) := reflectsLimitsOfShapeOfReflectsIsomorphisms
   apply preservesLimitsOfShape_plusFunctor.{w, v, u}
 
 instance preservesLimitsOfShape_sheafification
@@ -247,10 +247,10 @@ instance preservesLimitsOfShape_presheafToSheaf :
   refine @preservesLimitsOfShapeOfEquiv _ _ _ _ _ _ _ _ e.symm _ (show _ from ?_)
   constructor; intro F; constructor; intro S hS
   apply isLimitOfReflects (sheafToPresheaf J D)
-  have : ReflectsLimitsOfShape (AsSmall.{max v u} (FinCategory.AsType K)) (forget D) :=
+  let _ : ReflectsLimitsOfShape (AsSmall.{max v u} (FinCategory.AsType K)) (forget D) :=
     reflectsLimitsOfShapeOfReflectsIsomorphisms
   -- Porting note: the mathlib proof was by `apply is_limit_of_preserves (J.sheafification D) hS`
-  have : PreservesLimitsOfShape (AsSmall.{max v u} (FinCategory.AsType K))
+  let _ : PreservesLimitsOfShape (AsSmall.{max v u} (FinCategory.AsType K))
       (plusPlusSheaf J D ⋙ sheafToPresheaf J D) :=
     preservesLimitsOfShapeOfNatIso (J.sheafificationIsoPresheafToSheafCompSheafToPreasheaf D)
   exact isLimitOfPreserves (plusPlusSheaf J D ⋙ sheafToPresheaf J D) hS

--- a/Mathlib/CategoryTheory/Sites/Preserves.lean
+++ b/Mathlib/CategoryTheory/Sites/Preserves.lean
@@ -87,7 +87,7 @@ theorem firstMap_eq_secondMap : Equalizer.Presieve.Arrows.firstMap F X c.inj =
     Equalizer.Presieve.Arrows.secondMap]
   by_cases hi : i = j
   · rw [hi, Mono.right_cancellation _ _ pullback.condition]
-  · have := preservesTerminalOfIsSheafForEmpty F hF hI
+  · let _ := preservesTerminalOfIsSheafForEmpty F hF hI
     apply_fun (F.mapIso ((hd hi).isoPullback).op ≪≫ F.mapIso (terminalIsoIsTerminal
       (terminalOpOfInitial initialIsInitial)).symm ≪≫ (PreservesTerminal.iso F)).hom using
       injective_of_mono _

--- a/Mathlib/CategoryTheory/Sites/Pullback.lean
+++ b/Mathlib/CategoryTheory/Sites/Pullback.lean
@@ -59,7 +59,7 @@ def Functor.sheafPullback : Sheaf J A ⥤ Sheaf K A :=
 #align category_theory.sites.pushforward CategoryTheory.Functor.sheafPullback
 
 instance [RepresentablyFlat G] : PreservesFiniteLimits (G.sheafPullback A J K) := by
-  have : PreservesFiniteLimits (lan (Functor.op G) ⋙ presheafToSheaf K A) :=
+  let _ : PreservesFiniteLimits (lan (Functor.op G) ⋙ presheafToSheaf K A) :=
     compPreservesFiniteLimits _ _
   apply compPreservesFiniteLimits
 

--- a/Mathlib/CategoryTheory/Sites/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheaf.lean
@@ -687,7 +687,7 @@ hold.
 theorem isSheaf_iff_isSheaf_forget (s : A' ⥤ Type max v₁ u₁) [HasLimits A'] [PreservesLimits s]
     [s.ReflectsIsomorphisms] : IsSheaf J P' ↔ IsSheaf J (P' ⋙ s) := by
   have : HasLimitsOfSize.{v₁, max v₁ u₁} A' := hasLimitsOfSizeShrink.{_, _, u₁, 0} A'
-  have : PreservesLimitsOfSize.{v₁, max v₁ u₁} s := preservesLimitsOfSizeShrink.{_, 0, _, u₁} s
+  let _ : PreservesLimitsOfSize.{v₁, max v₁ u₁} s := preservesLimitsOfSizeShrink.{_, 0, _, u₁} s
   apply isSheaf_iff_isSheaf_comp
 #align category_theory.presheaf.is_sheaf_iff_is_sheaf_forget CategoryTheory.Presheaf.isSheaf_iff_isSheaf_forget
 

--- a/Mathlib/Combinatorics/SetFamily/Kleitman.lean
+++ b/Mathlib/Combinatorics/SetFamily/Kleitman.lean
@@ -37,7 +37,7 @@ each further intersecting family takes at most half of the sets that are in no p
 theorem Finset.card_biUnion_le_of_intersecting (s : Finset ι) (f : ι → Finset (Finset α))
     (hf : ∀ i ∈ s, (f i : Set (Finset α)).Intersecting) :
     (s.biUnion f).card ≤ 2 ^ Fintype.card α - 2 ^ (Fintype.card α - s.card) := by
-  have : DecidableEq ι := by
+  let _ : DecidableEq ι := by
     classical
     infer_instance
   obtain hs | hs := le_total (Fintype.card α) s.card

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -253,7 +253,7 @@ noncomputable def topEmbeddingOfNotCliqueFree {n : ℕ} (h : ¬G.CliqueFree n) :
     (⊤ : SimpleGraph (Fin n)) ↪g G := by
   simp only [CliqueFree, isNClique_iff, isClique_iff_induce_eq, not_forall, Classical.not_not] at h
   obtain ⟨ha, hb⟩ := h.choose_spec
-  have : (⊤ : SimpleGraph (Fin h.choose.card)) ≃g (⊤ : SimpleGraph h.choose) := by
+  let this : (⊤ : SimpleGraph (Fin h.choose.card)) ≃g (⊤ : SimpleGraph h.choose) := by
     apply Iso.completeGraph
     simpa using (Fintype.equivFin h.choose).symm
   rw [← ha] at this

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -250,7 +250,7 @@ theorem colorable_iff_exists_bdd_nat_coloring (n : ℕ) :
     G.Colorable n ↔ ∃ C : G.Coloring ℕ, ∀ v, C v < n := by
   constructor
   · rintro hc
-    have C : G.Coloring (Fin n) := hc.toColoring (by simp)
+    let C : G.Coloring (Fin n) := hc.toColoring (by simp)
     let f := Embedding.completeGraph (@Fin.valEmbedding n)
     use f.toHom.comp C
     intro v
@@ -451,8 +451,8 @@ theorem CompleteBipartiteGraph.chromaticNumber {V W : Type*} [Nonempty V] [Nonem
   rw [← Nat.cast_two, chromaticNumber_eq_iff_forall_surjective
     (by simpa using (CompleteBipartiteGraph.bicoloring V W).colorable)]
   intro C b
-  have v := Classical.arbitrary V
-  have w := Classical.arbitrary W
+  let v := Classical.arbitrary V
+  let w := Classical.arbitrary W
   have h : (completeBipartiteGraph V W).Adj (Sum.inl v) (Sum.inr w) := by simp
   by_cases he : C (Sum.inl v) = b
   · exact ⟨_, he⟩
@@ -467,7 +467,7 @@ theorem CompleteBipartiteGraph.chromaticNumber {V W : Type*} [Nonempty V] [Nonem
 theorem IsClique.card_le_of_coloring {s : Finset V} (h : G.IsClique s) [Fintype α]
     (C : G.Coloring α) : s.card ≤ Fintype.card α := by
   rw [isClique_iff_induce_eq] at h
-  have f : G.induce ↑s ↪g G := Embedding.comap (Function.Embedding.subtype fun x => x ∈ ↑s) G
+  let f : G.induce ↑s ↪g G := Embedding.comap (Function.Embedding.subtype fun x => x ∈ ↑s) G
   rw [h] at f
   convert Fintype.card_le_of_injective _ (C.comp f.toHom).injective_of_top_hom using 1
   simp

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -595,13 +595,12 @@ theorem end_mem_tail_support_of_ne {u v : V} (h : u ≠ v) (p : G.Walk u v) : v 
   simp
 #align simple_graph.walk.end_mem_tail_support_of_ne SimpleGraph.Walk.end_mem_tail_support_of_ne
 
-@[simp, nolint unusedHavesSuffices]
+@[simp]
 theorem mem_support_append_iff {t u v w : V} (p : G.Walk u v) (p' : G.Walk v w) :
     t ∈ (p.append p').support ↔ t ∈ p.support ∨ t ∈ p'.support := by
   simp only [mem_support_iff, mem_tail_support_append_iff]
   obtain rfl | h := eq_or_ne t v <;> obtain rfl | h' := eq_or_ne t u <;>
-    -- this `have` triggers the unusedHavesSuffices linter:
-    (try have := h'.symm) <;> simp [*]
+    (try let _ := h'.symm) <;> simp [*]
 #align simple_graph.walk.mem_support_append_iff SimpleGraph.Walk.mem_support_append_iff
 
 @[simp]

--- a/Mathlib/Combinatorics/SimpleGraph/Finsubgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finsubgraph.lean
@@ -142,9 +142,9 @@ theorem nonempty_hom_of_forall_finite_subgraph_hom [Finite W]
     simp only
     /- The homomorphism for each edge's singleton subgraph agrees with those for its source and
         target vertices. -/
-    have hv : Opposite.op (finsubgraphOfAdj e) ⟶ Opposite.op (singletonFinsubgraph v) :=
+    let hv : Opposite.op (finsubgraphOfAdj e) ⟶ Opposite.op (singletonFinsubgraph v) :=
       Quiver.Hom.op (CategoryTheory.homOfLE singletonFinsubgraph_le_adj_left)
-    have hv' : Opposite.op (finsubgraphOfAdj e) ⟶ Opposite.op (singletonFinsubgraph v') :=
+    let hv' : Opposite.op (finsubgraphOfAdj e) ⟶ Opposite.op (singletonFinsubgraph v') :=
       Quiver.Hom.op (CategoryTheory.homOfLE singletonFinsubgraph_le_adj_right)
     rw [← hu hv, ← hu hv']
     -- Porting note: was `apply Hom.map_adj`

--- a/Mathlib/Combinatorics/SimpleGraph/Partition.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Partition.lean
@@ -141,7 +141,7 @@ instance : Inhabited (Partition G) := ⟨G.selfColoring.toPartition⟩
 theorem partitionable_iff_colorable {n : ℕ} : G.Partitionable n ↔ G.Colorable n := by
   constructor
   · rintro ⟨P, hf, hc⟩
-    have : Fintype P.parts := hf.fintype
+    let _ : Fintype P.parts := hf.fintype
     rw [Set.Finite.card_toFinset hf] at hc
     apply P.colorable.mono hc
   · rintro ⟨C⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Trails.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Trails.lean
@@ -139,7 +139,7 @@ theorem IsEulerian.even_degree_iff {x u v : V} {p : G.Walk u v} (ht : p.IsEuleri
   change Multiset.card _ = _
   congr 1
   convert_to _ = (ht.isTrail.edgesFinset.filter (Membership.mem x)).val
-  have : Fintype G.edgeSet := fintypeEdgeSet ht
+  let _ : Fintype G.edgeSet := fintypeEdgeSet ht
   rw [ht.edgesFinset_eq, G.incidenceFinset_eq_filter x]
 #align simple_graph.walk.is_eulerian.even_degree_iff SimpleGraph.Walk.IsEulerian.even_degree_iff
 

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -1482,7 +1482,7 @@ theorem sqrt : @Primrec' 1 fun v => v.head.sqrt := by
     have :=
       @prec' 1 _ _
         (fun v => by
-          have x := v.head; have y := v.tail.head;
+          let x := v.head; let y := v.tail.head;
             exact if x.succ < y.succ * y.succ then y else y.succ)
         head (const 0) ?_
     · exact this

--- a/Mathlib/Condensed/TopComparison.lean
+++ b/Mathlib/Condensed/TopComparison.lean
@@ -92,15 +92,15 @@ the extensive topology.
 noncomputable instance [PreservesFiniteCoproducts G] :
     PreservesFiniteProducts (yonedaPresheaf G X) := by
   change PreservesFiniteProducts (G.op ⋙ yonedaPresheaf' X)
-  have h' : PreservesFiniteProducts (yonedaPresheaf' X) := inferInstance
-  have h : PreservesFiniteProducts G.op :=
+  let h' : PreservesFiniteProducts (yonedaPresheaf' X) := inferInstance
+  let h : PreservesFiniteProducts G.op :=
     { preserves := fun J _ => by
         apply (config := { allowSynthFailures := true }) preservesLimitsOfShapeOp
         exact preservesColimitsOfShapeOfEquiv (Discrete.opposite J).symm _ }
   constructor
   intro J _
-  have := h.1 J
-  have := h'.1 J
+  let _ := h.1 J
+  let _ := h'.1 J
   exact compPreservesLimitsOfShape _ _
 
 /--

--- a/Mathlib/Data/Countable/Basic.lean
+++ b/Mathlib/Data/Countable/Basic.lean
@@ -131,7 +131,7 @@ instance [Finite α] [∀ a, Countable (π a)] : Countable (∀ a, π a) := by
     · haveI := ihn
       exact Countable.of_equiv (ℕ × (Fin n → ℕ)) (Equiv.piFinSucc _ _).symm
   rcases Finite.exists_equiv_fin α with ⟨n, ⟨e⟩⟩
-  have f := fun a => (nonempty_embedding_nat (π a)).some
+  let f := fun a => (nonempty_embedding_nat (π a)).some
   exact ((Embedding.piCongrRight f).trans (Equiv.piCongrLeft' _ e).toEmbedding).countable
 
 end sort

--- a/Mathlib/Data/Finite/Card.lean
+++ b/Mathlib/Data/Finite/Card.lean
@@ -36,7 +36,7 @@ variable {α β γ : Type*}
 
 /-- There is (noncomputably) an equivalence between a finite type `α` and `Fin (Nat.card α)`. -/
 def Finite.equivFin (α : Type*) [Finite α] : α ≃ Fin (Nat.card α) := by
-  have := (Finite.exists_equiv_fin α).choose_spec.some
+  let this := (Finite.exists_equiv_fin α).choose_spec.some
   rwa [Nat.card_eq_of_equiv_fin this]
 #align finite.equiv_fin Finite.equivFin
 
@@ -218,8 +218,8 @@ namespace Finite
 variable {s t : Set α} (ht : t.Finite)
 
 theorem card_lt_card (hsub : s ⊂ t) : Nat.card s < Nat.card t := by
-  have : Fintype t := Finite.fintype ht
-  have : Fintype s := Finite.fintype (subset ht (subset_of_ssubset hsub))
+  let _ : Fintype t := Finite.fintype ht
+  let _ : Fintype s := Finite.fintype (subset ht (subset_of_ssubset hsub))
   simp only [Nat.card_eq_fintype_card]
   exact Set.card_lt_card hsub
 

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -640,7 +640,7 @@ variable [Finite α]
 -- Porting note (#10756): new theorem
 theorem surjective_of_injective {f : α → α} (hinj : Injective f) : Surjective f := by
   intro x
-  have := Classical.propDecidable
+  let _ := Classical.propDecidable
   cases nonempty_fintype α
   have h₁ : image f univ = univ :=
     eq_of_subset_of_card_le (subset_univ _)

--- a/Mathlib/Data/Fintype/Units.lean
+++ b/Mathlib/Data/Fintype/Units.lean
@@ -42,7 +42,7 @@ theorem Fintype.card_eq_card_units_add_one [GroupWithZero α] [Fintype α] [Deci
 
 theorem Nat.card_eq_card_units_add_one [GroupWithZero α] [Finite α] :
     Nat.card α = Nat.card αˣ + 1 := by
-  have : Fintype α := Fintype.ofFinite α
+  let _ : Fintype α := Fintype.ofFinite α
   classical
     rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, Fintype.card_eq_card_units_add_one]
 

--- a/Mathlib/Data/LazyList/Basic.lean
+++ b/Mathlib/Data/LazyList/Basic.lean
@@ -219,7 +219,7 @@ instance Mem.decidable {α} [DecidableEq α] (x : α) : ∀ xs : LazyList α, De
       simp only [Membership.mem, LazyList.Mem]
       exact Or.inl h
     else by
-      have := Mem.decidable x ys.get
+      let _ := Mem.decidable x ys.get
       have : (x ∈ ys.get) ↔ (x ∈ cons y ys) := by simp [(· ∈ ·), LazyList.Mem, h]
       exact decidable_of_decidable_of_iff this
 #align lazy_list.mem.decidable LazyList.Mem.decidable

--- a/Mathlib/Data/Nat/ChineseRemainder.lean
+++ b/Mathlib/Data/Nat/ChineseRemainder.lean
@@ -63,8 +63,8 @@ def chineseRemainderOfList : (l : List ι) → l.Pairwise (Coprime on s) →
         forall_apply_eq_imp_iff₂]
       intro j hj
       exact (List.pairwise_cons.mp co).1 j hj
-    have ih := chineseRemainderOfList l co.of_cons
-    have k := chineseRemainder this (a i) ih
+    let ih := chineseRemainderOfList l co.of_cons
+    let k := chineseRemainder this (a i) ih
     use k
     simp only [List.mem_cons, forall_eq_or_imp, k.prop.1, true_and]
     intro j hj

--- a/Mathlib/Data/Nat/Choose/Multinomial.lean
+++ b/Mathlib/Data/Nat/Choose/Multinomial.lean
@@ -245,7 +245,7 @@ theorem sum_pow_of_commute [Semiring R] (x : α → R)
       rw [_root_.pow_zero, Fintype.sum_subsingleton]
       swap
         -- Porting note: Lean cannot infer this instance by itself
-      · have : Zero (Sym α 0) := Sym.instZeroSym
+      · let _ : Zero (Sym α 0) := Sym.instZeroSym
         exact ⟨0, by simp [eq_iff_true_of_subsingleton]⟩
       convert (@one_mul R _ _).symm
       dsimp only

--- a/Mathlib/Data/PNat/Find.lean
+++ b/Mathlib/Data/PNat/Find.lean
@@ -29,7 +29,7 @@ instance decidablePredExistsNat : DecidablePred fun n' : ℕ => ∃ (n : ℕ+) (
 /-- The `PNat` version of `Nat.findX` -/
 protected def findX : { n // p n ∧ ∀ m : ℕ+, m < n → ¬p m } := by
   have : ∃ (n' : ℕ) (n : ℕ+) (_ : n' = n), p n := Exists.elim h fun n hn => ⟨n, n, rfl, hn⟩
-  have n := Nat.findX this
+  let n := Nat.findX this
   refine' ⟨⟨n, _⟩, _, fun m hm pm => _⟩
   · obtain ⟨n', hn', -⟩ := n.prop.1
     rw [hn']

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -71,7 +71,7 @@ theorem encard_univ (α : Type*) :
   rw [encard, PartENat.card_congr (Equiv.Set.univ α)]
 
 theorem Finite.encard_eq_coe_toFinset_card (h : s.Finite) : s.encard = h.toFinset.card := by
-  have := h.fintype
+  let _ := h.fintype
   rw [encard, PartENat.card_eq_coe_fintype_card,
     PartENat.withTopEquiv_natCast, toFinite_toFinset, toFinset_card]
 
@@ -110,7 +110,7 @@ theorem encard_ne_zero : s.encard ≠ 0 ↔ s.Nonempty := by
 
 theorem encard_union_eq (h : Disjoint s t) : (s ∪ t).encard = s.encard + t.encard := by
   classical
-  have e := (Equiv.Set.union (by rwa [subset_empty_iff, ← disjoint_iff_inter_eq_empty])).symm
+  let e := (Equiv.Set.union (by rwa [subset_empty_iff, ← disjoint_iff_inter_eq_empty])).symm
   simp [encard, ← PartENat.card_congr e, PartENat.card_sum, PartENat.withTopEquiv]
 
 theorem encard_insert_of_not_mem {a : α} (has : a ∉ s) : (insert a s).encard = s.encard + 1 := by
@@ -479,7 +479,7 @@ theorem Finite.cast_ncard_eq (hs : s.Finite) : s.ncard = s.encard := by
 
 theorem Nat.card_coe_set_eq (s : Set α) : Nat.card s = s.ncard := by
   obtain (h | h) := s.finite_or_infinite
-  · have := h.fintype
+  · let _ := h.fintype
     rw [ncard, h.encard_eq_coe_toFinset_card, Nat.card_eq_fintype_card,
       toFinite_toFinset, toFinset_card, ENat.toNat_coe]
   have := infinite_coe_iff.2 h
@@ -525,7 +525,7 @@ theorem ncard_mono [Finite α] : @Monotone (Set α) _ _ _ ncard := fun _ _ ↦ n
 
 theorem ncard_univ (α : Type*) : (univ : Set α).ncard = Nat.card α := by
   cases' finite_or_infinite α with h h
-  · have hft := Fintype.ofFinite α
+  · let hft := Fintype.ofFinite α
     rw [ncard_eq_toFinset_card, Finite.toFinset_univ, Finset.card_univ, Nat.card_eq_fintype_card]
   rw [Nat.card_eq_zero_of_infinite, Infinite.ncard]
   exact infinite_univ
@@ -795,8 +795,8 @@ theorem surj_on_of_inj_on_of_ncard_le {t : Set β} (f : ∀ a ∈ s, β) (hf : �
     rintro ⟨x, hx⟩ ⟨y, hy⟩ hxy
     simp only [f', Subtype.mk.injEq] at hxy ⊢
     apply hinj _ _ hx hy hxy
-  have hft := ht.fintype
-  have hft' := Fintype.ofInjective f' finj
+  let hft := ht.fintype
+  let hft' := Fintype.ofInjective f' finj
   set f'' : ∀ a, a ∈ s.toFinset → β := fun a h ↦ f a (by simpa using h)
   convert @Finset.surj_on_of_inj_on_of_card_le _ _ _ t.toFinset f'' _ _ _ _ (by simpa)
   · simp
@@ -995,7 +995,7 @@ theorem exists_subset_or_subset_of_two_mul_lt_ncard {n : ℕ} (hst : 2 * n < (s 
 
 @[simp] theorem ncard_eq_one : s.ncard = 1 ↔ ∃ a, s = {a} := by
   refine' ⟨fun h ↦ _, by rintro ⟨a, rfl⟩; rw [ncard_singleton]⟩
-  have hft := (finite_of_ncard_ne_zero (ne_zero_of_eq_one h)).fintype
+  let hft := (finite_of_ncard_ne_zero (ne_zero_of_eq_one h)).fintype
   simp_rw [ncard_eq_toFinset_card', @Finset.card_eq_one _ (toFinset s)] at h
   refine' h.imp fun a ha ↦ _
   simp_rw [Set.ext_iff, mem_singleton_iff]

--- a/Mathlib/Data/Set/Pointwise/Finite.lean
+++ b/Mathlib/Data/Set/Pointwise/Finite.lean
@@ -193,7 +193,7 @@ theorem card_pow_eq_card_pow_card_univ [∀ k : ℕ, DecidablePred (· ∈ S ^ k
   refine' card_pow_eq_card_pow_card_univ_aux mono (fun n ↦ set_fintype_card_le_univ (S ^ n))
     fun n h ↦ le_antisymm (mono (n + 1).le_succ) (key a⁻¹ (S ^ (n + 2)) (S ^ (n + 1)) _)
   replace h₂ : S ^ n * {a} = S ^ (n + 1) := by
-    have : Fintype (S ^ n * Set.singleton a) := by
+    let _ : Fintype (S ^ n * Set.singleton a) := by
       classical!
       apply fintypeMul
     refine' Set.eq_of_subset_of_card_le _ (le_trans (ge_of_eq h) _)

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -283,7 +283,7 @@ theorem sum_pow_units [DecidableEq K] (i : ℕ) :
     { toFun := fun x => x ^ i
       map_one' := by simp
       map_mul' := by intros; simp [mul_pow] }
-  have : Decidable (φ = 1) := by classical infer_instance
+  let _ : Decidable (φ = 1) := by classical infer_instance
   calc (∑ x : Kˣ, φ x) = if φ = 1 then Fintype.card Kˣ else 0 := sum_hom_units φ
       _ = if q - 1 ∣ i then -1 else 0 := by
         suffices q - 1 ∣ i ↔ φ = 1 by

--- a/Mathlib/FieldTheory/Finite/GaloisField.lean
+++ b/Mathlib/FieldTheory/Finite/GaloisField.lean
@@ -202,6 +202,7 @@ namespace FiniteField
 
 variable {K : Type*} [Field K] [Fintype K] {K' : Type*} [Field K'] [Fintype K']
 
+set_option linter.unusedVariables false in  -- `hK'Gal` gets flagged as unused
 /-- Uniqueness of finite fields:
   Any two finite fields of the same cardinality are (possibly non canonically) isomorphic-/
 def algEquivOfCardEq (p : ℕ) [h_prime : Fact p.Prime] [Algebra (ZMod p) K] [Algebra (ZMod p) K']
@@ -211,8 +212,8 @@ def algEquivOfCardEq (p : ℕ) [h_prime : Fact p.Prime] [Algebra (ZMod p) K] [Al
   choose n a hK using FiniteField.card K p
   choose n' a' hK' using FiniteField.card K' p
   rw [hK, hK'] at hKK'
-  have hGalK := GaloisField.algEquivGaloisField p n hK
-  have hK'Gal := (GaloisField.algEquivGaloisField p n' hK').symm
+  let hGalK := GaloisField.algEquivGaloisField p n hK
+  let hK'Gal := (GaloisField.algEquivGaloisField p n' hK').symm
   rw [Nat.pow_right_injective h_prime.out.one_lt hKK'] at *
   exact AlgEquiv.trans hGalK hK'Gal
 #align finite_field.alg_equiv_of_card_eq FiniteField.algEquivOfCardEq

--- a/Mathlib/FieldTheory/Galois.lean
+++ b/Mathlib/FieldTheory/Galois.lean
@@ -374,7 +374,7 @@ theorem of_separable_splitting_field_aux [hFE : FiniteDimensional F E] [sp : p.I
     change (K⟮x⟯ →ₐ[F] E) ≃ Σ f : K →ₐ[F] E, _
     exact algHomEquivSigma
   haveI : ∀ f : K →ₐ[F] E, Fintype (@AlgHom K K⟮x⟯ E _ _ _ _ (RingHom.toAlgebra f)) := fun f => by
-    have := Fintype.ofEquiv _ key_equiv
+    let _ := Fintype.ofEquiv _ key_equiv
     apply Fintype.ofInjective (Sigma.mk f) fun _ _ H => eq_of_heq (Sigma.ext_iff.mp H).2
   rw [Fintype.card_congr key_equiv, Fintype.card_sigma, IntermediateField.adjoin.finrank h]
   apply Finset.sum_const_nat

--- a/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
@@ -109,7 +109,7 @@ def equivOfTranscendenceBasis [IsAlgClosed K] [IsAlgClosed L] (e : ι ≃ κ)
     (hv : IsTranscendenceBasis R v) (hw : IsTranscendenceBasis R w) : K ≃+* L := by
   letI := isAlgClosure_of_transcendence_basis v hv
   letI := isAlgClosure_of_transcendence_basis w hw
-  have e : Algebra.adjoin R (Set.range v) ≃+* Algebra.adjoin R (Set.range w) := by
+  let e : Algebra.adjoin R (Set.range v) ≃+* Algebra.adjoin R (Set.range w) := by
     refine' hv.1.aevalEquiv.symm.toRingEquiv.trans _
     refine' (AlgEquiv.ofAlgHom (MvPolynomial.rename e)
       (MvPolynomial.rename e.symm) _ _).toRingEquiv.trans _

--- a/Mathlib/FieldTheory/NormalClosure.lean
+++ b/Mathlib/FieldTheory/NormalClosure.lean
@@ -132,14 +132,14 @@ variable (F K L)
 
 instance isNormalClosure_normalClosure [ne : Nonempty (K →ₐ[F] L)] [h : Normal F L] :
     IsNormalClosure F K (normalClosure F K L) := by
-  have ⟨φ⟩ := ne
+  let ⟨φ⟩ := ne
   apply (h.isAlgebraic'.of_injective φ φ.injective).isNormalClosure_normalClosure
   simp_rw [← minpoly.algHom_eq _ φ.injective]
   exact fun _ ↦ h.splits _
 
 theorem normalClosure_eq_iSup_adjoin' [ne : Nonempty (K →ₐ[F] L)] [h : Normal F L] :
     normalClosure F K L = ⨆ x : K, adjoin F ((minpoly F x).rootSet L) := by
-  have ⟨φ⟩ := ne
+  let ⟨φ⟩ := ne
   refine h.isAlgebraic'.of_injective φ φ.injective
     |>.normalClosure_eq_iSup_adjoin_of_splits fun x ↦ ?_
   rw [← minpoly.algHom_eq _ φ.injective]

--- a/Mathlib/FieldTheory/PolynomialGaloisGroup.lean
+++ b/Mathlib/FieldTheory/PolynomialGaloisGroup.lean
@@ -287,7 +287,7 @@ def restrictProd : (p * q).Gal →* p.Gal × q.Gal :=
 /-- `Polynomial.Gal.restrictProd` is actually a subgroup embedding. -/
 theorem restrictProd_injective : Function.Injective (restrictProd p q) := by
   by_cases hpq : p * q = 0
-  · have : Unique (p * q).Gal := by rw [hpq]; infer_instance
+  · let _ : Unique (p * q).Gal := by rw [hpq]; infer_instance
     exact fun f g _ => Eq.trans (Unique.eq_default f) (Unique.eq_default g).symm
   intro f g hfg
   classical

--- a/Mathlib/Geometry/Euclidean/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Basic.lean
@@ -94,8 +94,8 @@ in terms of the pairwise distances between the points in that
 combination. -/
 theorem dist_affineCombination {ι : Type*} {s : Finset ι} {w₁ w₂ : ι → ℝ} (p : ι → P)
     (h₁ : ∑ i in s, w₁ i = 1) (h₂ : ∑ i in s, w₂ i = 1) : by
-      have a₁ := s.affineCombination ℝ p w₁
-      have a₂ := s.affineCombination ℝ p w₂
+      let a₁ := s.affineCombination ℝ p w₁
+      let a₂ := s.affineCombination ℝ p w₂
       exact dist a₁ a₂ * dist a₁ a₂ = (-∑ i₁ in s, ∑ i₂ in s,
         (w₁ - w₂) i₁ * (w₁ - w₂) i₂ * (dist (p i₁) (p i₂) * dist (p i₁) (p i₂))) / 2 := by
   dsimp only

--- a/Mathlib/Geometry/Euclidean/Circumcenter.lean
+++ b/Mathlib/Geometry/Euclidean/Circumcenter.lean
@@ -210,7 +210,7 @@ theorem _root_.AffineIndependent.existsUnique_dist_eq {ι : Type*} [hne : Nonemp
         simp? [Set.singleton_subset_iff] at hdist says
           simp only [Set.singleton_subset_iff, Metric.mem_sphere, dist_self] at hdist
         rw [hi default, hdist]
-    · have i := hne.some
+    · let i := hne.some
       let ι2 := { x // x ≠ i }
       have hc : Fintype.card ι2 = m + 1 := by
         rw [Fintype.card_of_subtype (Finset.univ.filter fun x => x ≠ i)]
@@ -364,7 +364,7 @@ theorem circumradius_pos {n : ℕ} (s : Simplex ℝ P (n + 1)) : 0 < s.circumrad
 /-- The circumcenter of a 0-simplex equals its unique point. -/
 theorem circumcenter_eq_point (s : Simplex ℝ P 0) (i : Fin 1) : s.circumcenter = s.points i := by
   have h := s.circumcenter_mem_affineSpan
-  have : Unique (Fin 1) := ⟨⟨0, by decide⟩, fun a => by simp only [Fin.eq_zero]⟩
+  let _ : Unique (Fin 1) := ⟨⟨0, by decide⟩, fun a => by simp only [Fin.eq_zero]⟩
   simp only [Set.range_unique, AffineSubspace.mem_affineSpan_singleton] at h
   rw [h]
   congr

--- a/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
+++ b/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
@@ -765,7 +765,7 @@ instance forgetCreatesPullbackOfRight : CreatesLimit (cospan g f) forget :=
 instance sheafedSpaceForgetPreservesOfLeft : PreservesLimit (cospan f g) (SheafedSpace.forget C) :=
   @Limits.compPreservesLimit _ _ _ _ _ _ (cospan f g) _ _ forget (PresheafedSpace.forget C)
     inferInstance <| by
-      have : PreservesLimit
+      let _ : PreservesLimit
         (cospan ((cospan f g ⋙ forget).map Hom.inl)
           ((cospan f g ⋙ forget).map Hom.inr)) (PresheafedSpace.forget C) := by
         dsimp
@@ -1073,13 +1073,13 @@ instance forgetToTopPreservesPullbackOfLeft :
     PresheafedSpace.forget _
   -- Porting note: was `apply (config := { instances := False }) ...`
   -- See https://github.com/leanprover/lean4/issues/2273
-  have : PreservesLimit
+  let _ : PreservesLimit
       (cospan ((cospan f g ⋙ forgetToSheafedSpace ⋙ SheafedSpace.forgetToPresheafedSpace).map
         WalkingCospan.Hom.inl)
       ((cospan f g ⋙ forgetToSheafedSpace ⋙ SheafedSpace.forgetToPresheafedSpace).map
         WalkingCospan.Hom.inr)) (PresheafedSpace.forget CommRingCat) := by
     dsimp; infer_instance
-  have : PreservesLimit (cospan f g ⋙ forgetToSheafedSpace ⋙ SheafedSpace.forgetToPresheafedSpace)
+  let _ : PreservesLimit (cospan f g ⋙ forgetToSheafedSpace ⋙ SheafedSpace.forgetToPresheafedSpace)
       (PresheafedSpace.forget CommRingCat) := by
     apply preservesLimitOfIsoDiagram _ (diagramIsoCospan _).symm
   apply Limits.compPreservesLimit

--- a/Mathlib/GroupTheory/FiniteAbelian.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian.lean
@@ -134,7 +134,7 @@ theorem equiv_directSum_zmod_of_finite [Finite G] :
   cases nonempty_fintype G
   obtain ⟨n, ι, fι, p, hp, e, ⟨f⟩⟩ := equiv_free_prod_directSum_zmod G
   cases' n with n
-  · have : Unique (Fin Nat.zero →₀ ℤ) :=
+  · let _ : Unique (Fin Nat.zero →₀ ℤ) :=
       { uniq := by simp only [Nat.zero_eq, eq_iff_true_of_subsingleton]; trivial }
     exact ⟨ι, fι, p, hp, e, ⟨f.trans AddEquiv.uniqueProd⟩⟩
   · haveI := @Fintype.prodLeft _ _ _ (Fintype.ofEquiv G f.toEquiv) _

--- a/Mathlib/GroupTheory/FixedPointFree.lean
+++ b/Mathlib/GroupTheory/FixedPointFree.lean
@@ -81,7 +81,7 @@ theorem orderOf_ne_two_of_involutive (g : G) : orderOf g ≠ 2 := by
   contradiction
 
 theorem odd_card_of_involutive : Odd (Nat.card G) := by
-  have := Fintype.ofFinite G
+  let _ := Fintype.ofFinite G
   by_contra h
   rw [← Nat.even_iff_not_odd, even_iff_two_dvd, Nat.card_eq_fintype_card] at h
   obtain ⟨g, hg⟩ := exists_prime_orderOf_dvd_card 2 h

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1015,10 +1015,10 @@ open QuotientGroup
 @[to_additive]
 theorem orderOf_dvd_card : orderOf x ∣ Fintype.card G := by
   classical
-    have ft_prod : Fintype ((G ⧸ zpowers x) × zpowers x) :=
+    let ft_prod : Fintype ((G ⧸ zpowers x) × zpowers x) :=
       Fintype.ofEquiv G groupEquivQuotientProdSubgroup
-    have ft_s : Fintype (zpowers x) := @Fintype.prodRight _ _ _ ft_prod _
-    have ft_cosets : Fintype (G ⧸ zpowers x) :=
+    let ft_s : Fintype (zpowers x) := @Fintype.prodRight _ _ _ ft_prod _
+    let ft_cosets : Fintype (G ⧸ zpowers x) :=
       @Fintype.prodLeft _ _ _ ft_prod ⟨⟨1, (zpowers x).one_mem⟩⟩
     have eq₁ : Fintype.card G = @Fintype.card _ ft_cosets * @Fintype.card _ ft_s :=
       calc

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -332,7 +332,7 @@ theorem card_sylow_modEq_one [Fact p.Prime] [Fintype (Sylow p G)] :
         _ ↔ Q.1 = P.1 := ⟨P.3 Q.2, ge_of_eq⟩
         _ ↔ Q ∈ {P} := Sylow.ext_iff.symm.trans Set.mem_singleton_iff.symm
 
-  have fin : Fintype (fixedPoints P.1 (Sylow p G)) := by
+  let fin : Fintype (fixedPoints P.1 (Sylow p G)) := by
     rw [this]
     infer_instance
   have : card (fixedPoints P.1 (Sylow p G)) = 1 := by simp [this]
@@ -552,7 +552,7 @@ theorem card_quotient_normalizer_modEq_card_quotient [Fintype G] {p : ℕ} {n : 
   normalizer of `H` is congruent mod `p ^ (n + 1)` to the cardinality of `G`.  -/
 theorem card_normalizer_modEq_card [Fintype G] {p : ℕ} {n : ℕ} [hp : Fact p.Prime] {H : Subgroup G}
     (hH : Fintype.card H = p ^ n) : card (normalizer H) ≡ card G [MOD p ^ (n + 1)] := by
-  have : H.subgroupOf (normalizer H) ≃ H := (subgroupOfEquivOfLe le_normalizer).toEquiv
+  let this : H.subgroupOf (normalizer H) ≃ H := (subgroupOfEquivOfLe le_normalizer).toEquiv
   rw [card_eq_card_quotient_mul_card_subgroup H,
     card_eq_card_quotient_mul_card_subgroup (H.subgroupOf (normalizer H)), Fintype.card_congr this,
     hH, pow_succ']

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -629,8 +629,8 @@ variable {k V}
 theorem map_affineCombination {V₂ P₂ : Type*} [AddCommGroup V₂] [Module k V₂] [AffineSpace V₂ P₂]
     (p : ι → P) (w : ι → k) (hw : s.sum w = 1) (f : P →ᵃ[k] P₂) :
     f (s.affineCombination k p w) = s.affineCombination k (f ∘ p) w := by
-  have b := Classical.choice (inferInstance : AffineSpace V P).nonempty
-  have b₂ := Classical.choice (inferInstance : AffineSpace V₂ P₂).nonempty
+  let b := Classical.choice (inferInstance : AffineSpace V P).nonempty
+  let b₂ := Classical.choice (inferInstance : AffineSpace V₂ P₂).nonempty
   rw [s.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one w p hw b,
     s.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one w (f ∘ p) hw b₂, ←
     s.weightedVSubOfPoint_vadd_eq_of_sum_eq_one w (f ∘ p) hw (f b) b₂]

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -572,7 +572,7 @@ theorem exists_subset_affineIndependent_affineSpan_eq_top {s : Set P}
     (h : AffineIndependent k (fun p => p : s → P)) :
     ∃ t : Set P, s ⊆ t ∧ AffineIndependent k (fun p => p : t → P) ∧ affineSpan k t = ⊤ := by
   rcases s.eq_empty_or_nonempty with (rfl | ⟨p₁, hp₁⟩)
-  · have p₁ : P := AddTorsor.nonempty.some
+  · let p₁ : P := AddTorsor.nonempty.some
     let hsv := Basis.ofVectorSpace k V
     have hsvi := hsv.linearIndependent
     have hsvt := hsv.span_eq

--- a/Mathlib/LinearAlgebra/Basis.lean
+++ b/Mathlib/LinearAlgebra/Basis.lean
@@ -1350,7 +1350,7 @@ def Submodule.inductionOnRankAux (b : Basis ι R M) (P : Submodule R M → Sort*
     (rank_le : ∀ {m : ℕ} (v : Fin m → N), LinearIndependent R ((↑) ∘ v : Fin m → M) → m ≤ n) :
     P N := by
   haveI : DecidableEq M := Classical.decEq M
-  have Pbot : P ⊥ := by
+  let Pbot : P ⊥ := by
     apply ih
     intro N _ x x_mem x_ortho
     exfalso

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Fold.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Fold.lean
@@ -174,8 +174,8 @@ theorem left_induction {P : CliffordAlgebra Q → Prop} (algebraMap : ∀ r : R,
 /-- Auxiliary definition for `CliffordAlgebra.foldr'` -/
 def foldr'Aux (f : M →ₗ[R] CliffordAlgebra Q × N →ₗ[R] N) :
     M →ₗ[R] Module.End R (CliffordAlgebra Q × N) := by
-  have v_mul := (Algebra.lmul R (CliffordAlgebra Q)).toLinearMap ∘ₗ ι Q
-  have l := v_mul.compl₂ (LinearMap.fst _ _ N)
+  let v_mul := (Algebra.lmul R (CliffordAlgebra Q)).toLinearMap ∘ₗ ι Q
+  let l := v_mul.compl₂ (LinearMap.fst _ _ N)
   exact
     { toFun := fun m => (l m).prod (f m)
       map_add' := fun v₂ v₂ =>

--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -285,7 +285,7 @@ theorem det_zero {𝕜 : Type*} [Field 𝕜] {M : Type*} [AddCommGroup M] [Modul
 
 theorem det_eq_one_of_subsingleton [Subsingleton M] (f : M →ₗ[R] M) :
     LinearMap.det (f : M →ₗ[R] M) = 1 := by
-  have b : Basis (Fin 0) R M := Basis.empty M
+  let b : Basis (Fin 0) R M := Basis.empty M
   rw [← f.det_toMatrix b]
   exact Matrix.det_isEmpty
 #align linear_map.det_eq_one_of_subsingleton LinearMap.det_eq_one_of_subsingleton

--- a/Mathlib/LinearAlgebra/Dimension/DivisionRing.lean
+++ b/Mathlib/LinearAlgebra/Dimension/DivisionRing.lean
@@ -435,7 +435,7 @@ theorem rank_dual_eq_card_dual_of_aleph0_le_rank' {V : Type*} [AddCommGroup V] [
     (h : ℵ₀ ≤ Module.rank K V) : Module.rank Kᵐᵒᵖ (V →ₗ[K] K) = #(V →ₗ[K] K) := by
   obtain ⟨⟨ι, b⟩⟩ := Module.Free.exists_basis (R := K) (M := V)
   rw [← b.mk_eq_rank'', aleph0_le_mk_iff] at h
-  have e := (b.constr Kᵐᵒᵖ (M' := K)).symm.trans
+  let e := (b.constr Kᵐᵒᵖ (M' := K)).symm.trans
     (LinearEquiv.piCongrRight fun _ ↦ MulOpposite.opLinearEquiv Kᵐᵒᵖ)
   rw [e.rank_eq, e.toEquiv.cardinal_eq]
   apply rank_fun_infinite
@@ -445,7 +445,7 @@ theorem rank_dual_eq_card_dual_of_aleph0_le_rank {K V} [Field K] [AddCommGroup V
     (h : ℵ₀ ≤ Module.rank K V) : Module.rank K (V →ₗ[K] K) = #(V →ₗ[K] K) := by
   obtain ⟨⟨ι, b⟩⟩ := Module.Free.exists_basis (R := K) (M := V)
   rw [← b.mk_eq_rank'', aleph0_le_mk_iff] at h
-  have e := (b.constr K (M' := K)).symm
+  let e := (b.constr K (M' := K)).symm
   rw [e.rank_eq, e.toEquiv.cardinal_eq]
   apply rank_fun_infinite
 

--- a/Mathlib/LinearAlgebra/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Finsupp.lean
@@ -1334,7 +1334,7 @@ lemma mem_span_set' {m : M} {s : Set M} :
       ∑ i, f i • (g i : M) = m := by
   refine ⟨fun h ↦ ?_, ?_⟩
   · rcases mem_span_set.1 h with ⟨c, cs, rfl⟩
-    have A : c.support ≃ Fin c.support.card := Finset.equivFin _
+    let A : c.support ≃ Fin c.support.card := Finset.equivFin _
     refine ⟨_, fun i ↦ c (A.symm i), fun i ↦ ⟨A.symm i, cs (A.symm i).2⟩, ?_⟩
     rw [Finsupp.sum, ← Finset.sum_coe_sort c.support]
     exact Fintype.sum_equiv A.symm _ (fun j ↦ c j • (j : M)) (fun i ↦ rfl)

--- a/Mathlib/LinearAlgebra/LinearPMap.lean
+++ b/Mathlib/LinearAlgebra/LinearPMap.lean
@@ -611,7 +611,7 @@ private theorem sSup_aux (c : Set (E →ₗ.[R] F)) (hc : DirectedOn (· ≤ ·)
     simp
   have hdir : DirectedOn (· ≤ ·) (domain '' c) :=
     directedOn_image.2 (hc.mono @(domain_mono.monotone))
-  have P : ∀ x : ↥(sSup (domain '' c)), { p : c // (x : E) ∈ p.val.domain } := by
+  let P : ∀ x : ↥(sSup (domain '' c)), { p : c // (x : E) ∈ p.val.domain } := by
     rintro x
     apply Classical.indefiniteDescription
     have := (mem_sSup_of_directed (cne.image _) hdir).1 x.2

--- a/Mathlib/LinearAlgebra/Matrix/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant.lean
@@ -120,7 +120,7 @@ theorem det_unique {n : Type*} [Unique n] [DecidableEq n] [Fintype n] (A : Matri
 
 theorem det_eq_elem_of_subsingleton [Subsingleton n] (A : Matrix n n R) (k : n) :
     det A = A k k := by
-  have := uniqueOfSubsingleton k
+  let _ := uniqueOfSubsingleton k
   convert det_unique A
 #align matrix.det_eq_elem_of_subsingleton Matrix.det_eq_elem_of_subsingleton
 

--- a/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Diagonal.lean
@@ -88,7 +88,7 @@ theorem rank_diagonal [DecidableEq m] [DecidableEq K] (w : m → K) :
   have hu : univ ⊆ { i : m | w i = 0 }ᶜ ∪ { i : m | w i = 0 } := by rw [Set.compl_union_self]
   have hd : Disjoint { i : m | w i ≠ 0 } { i : m | w i = 0 } := disjoint_compl_left
   have B₁ := iSup_range_stdBasis_eq_iInf_ker_proj K (fun _ : m => K) hd hu (Set.toFinite _)
-  have B₂ := iInfKerProjEquiv K (fun _ ↦ K) hd hu
+  let B₂ := iInfKerProjEquiv K (fun _ ↦ K) hd hu
   rw [LinearMap.rank, range_diagonal, B₁, ← @rank_fun' K]
   apply LinearEquiv.rank_eq
   apply B₂

--- a/Mathlib/LinearAlgebra/Matrix/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Transvection.lean
@@ -669,7 +669,7 @@ theorem exists_list_transvec_mul_mul_list_transvec_eq_diagonal_aux (n : Type) [F
     ext i j
     rw [Fintype.card_eq_zero_iff] at hn
     exact hn.elim' i
-  · have e : n ≃ Sum (Fin r) Unit := by
+  · let e : n ≃ Sum (Fin r) Unit := by
       refine' Fintype.equivOfCardEq _
       rw [hn]
       rw [@Fintype.card_sum (Fin r) Unit _ _]
@@ -684,7 +684,7 @@ theorem exists_list_transvec_mul_mul_list_transvec_eq_diagonal_aux (n : Type) [F
 theorem exists_list_transvec_mul_mul_list_transvec_eq_diagonal (M : Matrix n n 𝕜) :
     ∃ (L L' : List (TransvectionStruct n 𝕜)) (D : n → 𝕜),
       (L.map toMatrix).prod * M * (L'.map toMatrix).prod = diagonal D := by
-  have e : n ≃ Fin (Fintype.card n) := Fintype.equivOfCardEq (by simp)
+  let e : n ≃ Fin (Fintype.card n) := Fintype.equivOfCardEq (by simp)
   apply reindex_exists_list_transvec_mul_mul_list_transvec_eq_diagonal M e
   apply exists_list_transvec_mul_mul_list_transvec_eq_diagonal_aux
 #align matrix.pivot.exists_list_transvec_mul_mul_list_transvec_eq_diagonal Matrix.Pivot.exists_list_transvec_mul_mul_list_transvec_eq_diagonal

--- a/Mathlib/LinearAlgebra/Multilinear/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/FiniteDimensional.lean
@@ -57,7 +57,7 @@ private theorem free_and_finite :
   have := @free_and_finite_fin R M₂ _ _ _ _ _ (Fintype.card ι)
     (fun x => M₁ ((Fintype.equivFin ι).symm x))
   cases' this with l r
-  have e := domDomCongrLinearEquiv' R R M₁ M₂ (Fintype.equivFin ι)
+  let e := domDomCongrLinearEquiv' R R M₁ M₂ (Fintype.equivFin ι)
   exact ⟨Module.Free.of_equiv e.symm, Module.Finite.equiv e.symm⟩
 
 instance _root_.Module.Finite.multilinearMap : Module.Finite R (MultilinearMap R M₁ M₂) :=

--- a/Mathlib/LinearAlgebra/Orientation.lean
+++ b/Mathlib/LinearAlgebra/Orientation.lean
@@ -370,7 +370,7 @@ open FiniteDimensional
 equal or negations. -/
 theorem eq_or_eq_neg (x₁ x₂ : Orientation R M ι) (h : Fintype.card ι = finrank R M) :
     x₁ = x₂ ∨ x₁ = -x₂ := by
-  have e := (finBasis R M).reindex (Fintype.equivFinOfCardEq h).symm
+  let e := (finBasis R M).reindex (Fintype.equivFinOfCardEq h).symm
   letI := Classical.decEq ι
   -- Porting note: this needs to be made explicit for the simp below
   have orientation_neg_neg :

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
@@ -77,8 +77,8 @@ local notation "ℬ𝒜" => (fun i : ι × ι => ℬ (Prod.fst i) ⊗[R] 𝒜 (P
 This operates on direct sums of tensors instead of tensors of direct sums. -/
 def gradedCommAux : DirectSum _ 𝒜ℬ →ₗ[R] DirectSum _ ℬ𝒜 := by
   refine DirectSum.toModule R _ _ fun i => ?_
-  have o := DirectSum.lof R _ ℬ𝒜 i.swap
-  have s : ℤˣ := ((-1 : ℤˣ)^(i.1* i.2 : ι) : ℤˣ)
+  let o := DirectSum.lof R _ ℬ𝒜 i.swap
+  let s : ℤˣ := ((-1 : ℤˣ)^(i.1* i.2 : ι) : ℤˣ)
   exact (s • o) ∘ₗ (TensorProduct.comm R _ _).toLinearMap
 
 @[simp]

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/Internal.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/Internal.lean
@@ -141,9 +141,8 @@ theorem auxEquiv_symm_one : (auxEquiv R 𝒜 ℬ).symm 1 = 1 :=
 `\smul`. -/
 noncomputable def mulHom : (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ) := by
   letI fAB1 := auxEquiv R 𝒜 ℬ
-  have := ((gradedMul R (𝒜 ·) (ℬ ·)).compl₁₂ fAB1.toLinearMap fAB1.toLinearMap).compr₂
+  exact ((gradedMul R (𝒜 ·) (ℬ ·)).compl₁₂ fAB1.toLinearMap fAB1.toLinearMap).compr₂
     fAB1.symm.toLinearMap
-  exact this
 
 theorem mulHom_apply (x y : 𝒜 ᵍ⊗[R] ℬ) :
     mulHom 𝒜 ℬ x y

--- a/Mathlib/LinearAlgebra/Trace.lean
+++ b/Mathlib/LinearAlgebra/Trace.lean
@@ -187,7 +187,7 @@ theorem trace_eq_contract' :
 theorem trace_one : trace R M 1 = (finrank R M : R) := by
   cases subsingleton_or_nontrivial R
   · simp [eq_iff_true_of_subsingleton]
-  have b := Module.Free.chooseBasis R M
+  let b := Module.Free.chooseBasis R M
   rw [trace_eq_matrix_trace R b, toMatrix_one, finrank_eq_card_chooseBasisIndex]
   simp
 #align linear_map.trace_one LinearMap.trace_one

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -224,7 +224,7 @@ variable {δ : Type*} {π : δ → Type*} [∀ x, MeasurableSpace (π x)]
 protected def tprod (l : List δ) (μ : ∀ i, Measure (π i)) : Measure (TProd π l) := by
   induction' l with i l ih
   · exact dirac PUnit.unit
-  · have := (μ i).prod (α := π i) ih
+  · let this := (μ i).prod (α := π i) ih
     exact this
 #align measure_theory.measure.tprod MeasureTheory.Measure.tprod
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
@@ -299,7 +299,7 @@ lemma measurableSet_generateFrom_memPartition_iff (t : ℕ → Set α) (n : ℕ)
           rw [← sUnion_memPartition t n, union_comm, ← sUnion_union, union_diff_cancel hS_subset]
     · intro f h
       choose S hS_subset hS_eq using h
-      have : Fintype (⋃ n, (S n : Set (Set α))) := by
+      let _ : Fintype (⋃ n, (S n : Set (Set α))) := by
         refine (Finite.subset (finite_memPartition t n) ?_).fintype
         simp only [iUnion_subset_iff]
         exact hS_subset

--- a/Mathlib/MeasureTheory/Measure/Haar/InnerProductSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/InnerProductSpace.lean
@@ -33,7 +33,7 @@ parallelepiped associated to any orthonormal basis. This is a rephrasing of
 `abs_volumeForm_apply_of_orthonormal` in terms of measures. -/
 theorem Orientation.measure_orthonormalBasis (o : Orientation ℝ F (Fin n))
     (b : OrthonormalBasis ι ℝ F) : o.volumeForm.measure (parallelepiped b) = 1 := by
-  have e : ι ≃ Fin n := by
+  let e : ι ≃ Fin n := by
     refine' Fintype.equivFinOfCardEq _
     rw [← _i.out, finrank_eq_card_basis b.toBasis]
   have A : ⇑b = b.reindex e ∘ e := by

--- a/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
@@ -97,7 +97,7 @@ theorem parallelepiped_comp_equiv (v : ι → E) (e : ι' ≃ ι) :
 -- The parallelepiped associated to an orthonormal basis of `ℝ` is either `[0, 1]` or `[-1, 0]`.
 theorem parallelepiped_orthonormalBasis_one_dim (b : OrthonormalBasis ι ℝ ℝ) :
     parallelepiped b = Icc 0 1 ∨ parallelepiped b = Icc (-1) 0 := by
-  have e : ι ≃ Fin 1 := by
+  let e : ι ≃ Fin 1 := by
     apply Fintype.equivFinOfCardEq
     simp only [← finrank_eq_card_basis b.toBasis, finrank_self]
   have B : parallelepiped (b.reindex e) = parallelepiped b := by

--- a/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
@@ -881,7 +881,7 @@ second countable group. -/
 theorem absolutelyContinuous_isHaarMeasure [LocallyCompactSpace G]
     [SecondCountableTopology G] (μ ν : Measure G)
     [SigmaFinite μ] [IsMulLeftInvariant μ] [IsHaarMeasure ν] : μ ≪ ν := by
-  have K : PositiveCompacts G := Classical.arbitrary _
+  let K : PositiveCompacts G := Classical.arbitrary _
   have h : haarMeasure K = (haarScalarFactor (haarMeasure K) ν : ℝ≥0∞) • ν :=
     isMulLeftInvariant_eq_smul (haarMeasure K) ν
   rw [haarMeasure_unique μ K, h, smul_smul]
@@ -909,7 +909,7 @@ instance (priority := 100) IsHaarMeasure.isInvInvariant_of_regular
   have μeq : μ = c ^ 2 • μ := by
     rw [map_map continuous_inv.measurable continuous_inv.measurable] at this
     simpa only [inv_involutive, Involutive.comp_self, Measure.map_id]
-  have K : PositiveCompacts G := Classical.arbitrary _
+  let K : PositiveCompacts G := Classical.arbitrary _
   have : c ^ 2 * μ K = 1 ^ 2 * μ K := by
     conv_rhs => rw [μeq]
     simp
@@ -936,7 +936,7 @@ instance (priority := 100) IsHaarMeasure.isInvInvariant_of_innerRegular
   have μeq : μ = c ^ 2 • μ := by
     rw [map_map continuous_inv.measurable continuous_inv.measurable] at this
     simpa only [inv_involutive, Involutive.comp_self, Measure.map_id]
-  have K : PositiveCompacts G := Classical.arbitrary _
+  let K : PositiveCompacts G := Classical.arbitrary _
   have : c ^ 2 * μ K = 1 ^ 2 * μ K := by
     conv_rhs => rw [μeq]
     simp

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean
@@ -245,7 +245,7 @@ theorem map_linearMap_addHaar_eq_smul_addHaar {f : E →ₗ[ℝ] E} (hf : Linear
   let ι := Fin (finrank ℝ E)
   haveI : FiniteDimensional ℝ (ι → ℝ) := by infer_instance
   have : finrank ℝ E = finrank ℝ (ι → ℝ) := by simp [ι]
-  have e : E ≃ₗ[ℝ] ι → ℝ := LinearEquiv.ofFinrankEq E (ι → ℝ) this
+  let e : E ≃ₗ[ℝ] ι → ℝ := LinearEquiv.ofFinrankEq E (ι → ℝ) this
   -- next line is to avoid `g` getting reduced by `simp`.
   obtain ⟨g, hg⟩ : ∃ g, g = (e : E →ₗ[ℝ] ι → ℝ).comp (f.comp (e.symm : (ι → ℝ) →ₗ[ℝ] E)) := ⟨_, rfl⟩
   have gdet : LinearMap.det g = LinearMap.det f := by rw [hg]; exact LinearMap.det_conj f e

--- a/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
@@ -114,7 +114,7 @@ protected theorem iUnion (m : OuterMeasure α) {β} [Countable β] (s : β → S
 theorem biUnion_null_iff (m : OuterMeasure α) {s : Set β} (hs : s.Countable) {t : β → Set α} :
     m (⋃ i ∈ s, t i) = 0 ↔ ∀ i ∈ s, m (t i) = 0 := by
   refine ⟨fun h i hi ↦ m.mono_null (subset_biUnion_of_mem hi) h, fun h ↦ ?_⟩
-  have _ := hs.toEncodable
+  let _ := hs.toEncodable
   simpa [h] using m.iUnion fun x : s ↦ t x
 #align measure_theory.outer_measure.bUnion_null_iff MeasureTheory.OuterMeasure.biUnion_null_iff
 

--- a/Mathlib/ModelTheory/Fraisse.lean
+++ b/Mathlib/ModelTheory/Fraisse.lean
@@ -195,7 +195,7 @@ theorem age_directLimit {ι : Type w} [Preorder ι] [IsDirected ι (· ≤ ·)] 
     obtain ⟨s, hs⟩ := Mfg.range e.toHom
     let out := @Quotient.out _ (DirectLimit.setoid G f)
     obtain ⟨i, hi⟩ := Finset.exists_le (s.image (Sigma.fst ∘ out))
-    have e' := (DirectLimit.of L ι G f i).equivRange.symm.toEmbedding
+    let e' := (DirectLimit.of L ι G f i).equivRange.symm.toEmbedding
     refine' ⟨i, Mfg, ⟨e'.comp ((Substructure.inclusion _).comp e.equivRange.toEmbedding)⟩⟩
     rw [← hs, closure_le]
     intro x hx

--- a/Mathlib/Order/Birkhoff.lean
+++ b/Mathlib/Order/Birkhoff.lean
@@ -157,7 +157,7 @@ variable [SemilatticeSup α] [OrderBot α] [Finite α]
   obtain ⟨s, hs⟩ := s
   obtain ⟨a, rfl⟩ := supIrred_iff_of_finite.1 hs
   cases nonempty_fintype α
-  have : LocallyFiniteOrder α := Fintype.toLocallyFiniteOrder
+  let _ : LocallyFiniteOrder α := Fintype.toLocallyFiniteOrder
   simp [symm_apply_eq]
 
 end SemilatticeSup
@@ -171,7 +171,7 @@ variable [SemilatticeInf α] [OrderTop α] [Finite α]
   obtain ⟨s, hs⟩ := s
   obtain ⟨a, rfl⟩ := infIrred_iff_of_finite.1 hs
   cases nonempty_fintype α
-  have : LocallyFiniteOrder α := Fintype.toLocallyFiniteOrder
+  let _ : LocallyFiniteOrder α := Fintype.toLocallyFiniteOrder
   simp [symm_apply_eq]
 
 end SemilatticeInf
@@ -211,7 +211,7 @@ noncomputable def birkhoffSet : α ↪o Set {a : α // SupIrred a} := by
   by_cases h : IsEmpty α
   · exact OrderEmbedding.ofIsEmpty
   rw [not_isEmpty_iff] at h
-  have := Fintype.toOrderBot α
+  let _ := Fintype.toOrderBot α
   exact OrderIso.lowerSetSupIrred.toOrderEmbedding.trans ⟨⟨_, SetLike.coe_injective⟩, Iff.rfl⟩
 
 /-- **Birkhoff's Representation Theorem**. Any finite distributive lattice can be embedded in a

--- a/Mathlib/Order/SupIndep.lean
+++ b/Mathlib/Order/SupIndep.lean
@@ -67,7 +67,7 @@ instance [DecidableEq ι] [DecidableEq α] : Decidable (SupIndep s f) := by
   rintro t -
   refine @Finset.decidableDforallFinset _ _ _ (?_)
   rintro i -
-  have : Decidable (Disjoint (f i) (sup t f)) := decidable_of_iff' (_ = ⊥) disjoint_iff
+  let _ : Decidable (Disjoint (f i) (sup t f)) := decidable_of_iff' (_ = ⊥) disjoint_iff
   infer_instance
 
 theorem SupIndep.subset (ht : t.SupIndep f) (h : s ⊆ t) : s.SupIndep f := fun _ hu _ hi =>

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -74,7 +74,7 @@ variable {f : β → α} {s t : Set α} {x y : α}
 
 theorem wellFoundedOn_iff :
     s.WellFoundedOn r ↔ WellFounded fun a b : α => r a b ∧ a ∈ s ∧ b ∈ s := by
-  have f : RelEmbedding (fun (a : s) (b : s) => r a b) fun a b : α => r a b ∧ a ∈ s ∧ b ∈ s :=
+  let f : RelEmbedding (fun (a : s) (b : s) => r a b) fun a b : α => r a b ∧ a ∈ s ∧ b ∈ s :=
     ⟨⟨(↑), Subtype.coe_injective⟩, by simp⟩
   refine' ⟨fun h => _, f.wellFounded⟩
   rw [WellFounded.wellFounded_iff_has_min]

--- a/Mathlib/Probability/Moments.lean
+++ b/Mathlib/Probability/Moments.lean
@@ -54,7 +54,7 @@ def moment (X : Ω → ℝ) (p : ℕ) (μ : Measure Ω) : ℝ :=
 
 /-- Central moment of a real random variable, `μ[(X - μ[X]) ^ p]`. -/
 def centralMoment (X : Ω → ℝ) (p : ℕ) (μ : Measure Ω) : ℝ := by
-  have m := fun (x : Ω) => μ[X] -- Porting note: Lean deems `μ[(X - fun x => μ[X]) ^ p]` ambiguous
+  let m := fun (x : Ω) => μ[X] -- Porting note: Lean deems `μ[(X - fun x => μ[X]) ^ p]` ambiguous
   exact μ[(X - m) ^ p]
 #align probability_theory.central_moment ProbabilityTheory.centralMoment
 

--- a/Mathlib/RepresentationTheory/Action/Limits.lean
+++ b/Mathlib/RepresentationTheory/Action/Limits.lean
@@ -83,7 +83,7 @@ def preservesLimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
     [Category.{w₂} J] (K : J ⥤ C)
     (h : PreservesLimit K (F ⋙ Action.forget V G)) : PreservesLimit K F := by
   let F' : C ⥤ SingleObj G ⥤ V := F ⋙ (Action.functorCategoryEquivalence V G).functor
-  have : PreservesLimit K F' := SingleObj.preservesLimit _ _ h
+  let _ : PreservesLimit K F' := SingleObj.preservesLimit _ _ h
   apply preservesLimitOfReflectsOfPreserves F (Action.functorCategoryEquivalence V G).functor
 
 /-- `F : C ⥤ Action V G` preserves limits of some shape `J`
@@ -122,7 +122,7 @@ def preservesColimitOfPreserves (F : C ⥤ Action V G) {J : Type w₁}
     [Category.{w₂} J] (K : J ⥤ C)
     (h : PreservesColimit K (F ⋙ Action.forget V G)) : PreservesColimit K F := by
   let F' : C ⥤ SingleObj G ⥤ V := F ⋙ (Action.functorCategoryEquivalence V G).functor
-  have : PreservesColimit K F' := SingleObj.preservesColimit _ _ h
+  let _ : PreservesColimit K F' := SingleObj.preservesColimit _ _ h
   apply preservesColimitOfReflectsOfPreserves F (Action.functorCategoryEquivalence V G).functor
 
 /-- `F : C ⥤ Action V G` preserves colimits of some shape `J`
@@ -164,7 +164,7 @@ noncomputable instance {J : Type w₁} [Category.{w₂} J] [HasColimitsOfShape J
 noncomputable instance [HasFiniteLimits V] : PreservesFiniteLimits (Action.forget V G) := by
   show PreservesFiniteLimits ((Action.functorCategoryEquivalence V G).functor ⋙
     (evaluation (SingleObj G) V).obj (SingleObj.star G))
-  have : PreservesFiniteLimits ((evaluation (SingleObj G) V).obj (SingleObj.star G)) := by
+  let _ : PreservesFiniteLimits ((evaluation (SingleObj G) V).obj (SingleObj.star G)) := by
     constructor
     intro _ _ _
     infer_instance
@@ -173,7 +173,7 @@ noncomputable instance [HasFiniteLimits V] : PreservesFiniteLimits (Action.forge
 noncomputable instance [HasFiniteColimits V] : PreservesFiniteColimits (Action.forget V G) := by
   show PreservesFiniteColimits ((Action.functorCategoryEquivalence V G).functor ⋙
     (evaluation (SingleObj G) V).obj (SingleObj.star G))
-  have : PreservesFiniteColimits ((evaluation (SingleObj G) V).obj (SingleObj.star G)) := by
+  let _ : PreservesFiniteColimits ((evaluation (SingleObj G) V).obj (SingleObj.star G)) := by
     constructor
     intro _ _ _
     infer_instance

--- a/Mathlib/RingTheory/Artinian.lean
+++ b/Mathlib/RingTheory/Artinian.lean
@@ -176,7 +176,7 @@ theorem IsArtinian.finite_of_linearIndependent [Nontrivial R] [IsArtinian R M] {
     (hs : LinearIndependent R ((↑) : s → M)) : s.Finite := by
   refine' by_contradiction fun hf => (RelEmbedding.wellFounded_iff_no_descending_seq.1
     (wellFounded_submodule_lt (R := R) (M := M))).elim' _
-  have f : ℕ ↪ s := Set.Infinite.natEmbedding s hf
+  let f : ℕ ↪ s := Set.Infinite.natEmbedding s hf
   have : ∀ n, (↑) ∘ f '' { m | n ≤ m } ⊆ s := by
     rintro n x ⟨y, _, rfl⟩
     exact (f y).2

--- a/Mathlib/RingTheory/Discriminant.lean
+++ b/Mathlib/RingTheory/Discriminant.lean
@@ -216,7 +216,7 @@ theorem discr_powerBasis_eq_norm [IsSeparable K L] :
       norm K (aeval pb.gen (derivative (R := K) (minpoly K pb.gen))) := by
   let E := AlgebraicClosure L
   letI := fun a b : E => Classical.propDecidable (Eq a b)
-  have e : Fin pb.dim ≃ (L →ₐ[K] E) := by
+  let e : Fin pb.dim ≃ (L →ₐ[K] E) := by
     refine' equivOfCardEq _
     rw [Fintype.card_fin, AlgHom.card]
     exact (PowerBasis.finrank pb).symm

--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -176,7 +176,7 @@ theorem iff_quotient_mvPolynomial' :
     -- convert Submodule.fg_bot
     -- exact RingHom.ker_coe_equiv ulift_var.toRingEquiv
   · rintro ⟨ι, hfintype, f, hf⟩
-    have equiv := MvPolynomial.renameEquiv R (Fintype.equivFin ι)
+    let equiv := MvPolynomial.renameEquiv R (Fintype.equivFin ι)
     refine'
       ⟨Fintype.card ι, f.comp equiv.symm, hf.1.comp (AlgEquiv.symm equiv).surjective,
         Ideal.fg_ker_comp _ f _ hf.2 equiv.symm.surjective⟩

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -194,7 +194,7 @@ theorem iff_quotient_mvPolynomial'' :
   constructor
   · rw [iff_quotient_mvPolynomial']
     rintro ⟨ι, hfintype, ⟨f, hsur⟩⟩
-    have equiv := MvPolynomial.renameEquiv R (Fintype.equivFin ι)
+    let equiv := MvPolynomial.renameEquiv R (Fintype.equivFin ι)
     exact ⟨Fintype.card ι, AlgHom.comp f equiv.symm.toAlgHom, by simpa using hsur⟩
   · rintro ⟨n, ⟨f, hsur⟩⟩
     exact FiniteType.of_surjective (FiniteType.mvPolynomial R (Fin n)) f hsur

--- a/Mathlib/RingTheory/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralRestrict.lean
@@ -236,7 +236,7 @@ lemma Algebra.intTrace_eq_of_isLocalization
     (x : B) :
     algebraMap A Aₘ (Algebra.intTrace A B x) = Algebra.intTrace Aₘ Bₘ (algebraMap B Bₘ x) := by
   by_cases hM : 0 ∈ M
-  · have := IsLocalization.uniqueOfZeroMem (S := Aₘ) hM
+  · let _ := IsLocalization.uniqueOfZeroMem (S := Aₘ) hM
     exact Subsingleton.elim _ _
   replace hM : M ≤ A⁰ := fun x hx ↦ mem_nonZeroDivisors_iff_ne_zero.mpr (fun e ↦ hM (e ▸ hx))
   let K := FractionRing A
@@ -399,7 +399,7 @@ variable [IsSeparable (FractionRing Aₘ) (FractionRing Bₘ)]
 lemma Algebra.intNorm_eq_of_isLocalization (x : B) :
     algebraMap A Aₘ (Algebra.intNorm A B x) = Algebra.intNorm Aₘ Bₘ (algebraMap B Bₘ x) := by
   by_cases hM : 0 ∈ M
-  · have := IsLocalization.uniqueOfZeroMem (S := Aₘ) hM
+  · let _ := IsLocalization.uniqueOfZeroMem (S := Aₘ) hM
     exact Subsingleton.elim _ _
   replace hM : M ≤ A⁰ := fun x hx ↦ mem_nonZeroDivisors_iff_ne_zero.mpr (fun e ↦ hM (e ▸ hx))
   let K := FractionRing A

--- a/Mathlib/RingTheory/Jacobson.lean
+++ b/Mathlib/RingTheory/Jacobson.lean
@@ -699,7 +699,7 @@ theorem comp_C_integral_of_surjective_of_jacobson {R : Type*} [CommRing R] [IsJa
     {σ : Type*} [Finite σ] {S : Type*} [Field S] (f : MvPolynomial σ R →+* S)
     (hf : Function.Surjective ↑f) : (f.comp C).IsIntegral := by
   cases nonempty_fintype σ
-  have e := (Fintype.equivFin σ).symm
+  let e := (Fintype.equivFin σ).symm
   let f' : MvPolynomial (Fin _) R →+* S := f.comp (renameEquiv R e).toRingEquiv.toRingHom
   have hf' := Function.Surjective.comp hf (renameEquiv R e).surjective
   change Function.Surjective ↑f' at hf'

--- a/Mathlib/RingTheory/Localization/Integral.lean
+++ b/Mathlib/RingTheory/Localization/Integral.lean
@@ -395,7 +395,7 @@ theorem isAlgebraic_iff' [Field K] [IsDomain R] [IsDomain S] [Algebra R K] [Alge
           Polynomial.degree_map_eq_of_injective
             (NoZeroSMulDivisors.algebraMap_injective R (FractionRing R)),
           Polynomial.degree_eq_bot]
-      · have : Invertible (algebraMap S K b) :=
+      · let _ : Invertible (algebraMap S K b) :=
           IsUnit.invertible
             (isUnit_of_mem_nonZeroDivisors
               (mem_nonZeroDivisors_iff_ne_zero.2 fun h =>

--- a/Mathlib/RingTheory/Noetherian.lean
+++ b/Mathlib/RingTheory/Noetherian.lean
@@ -82,7 +82,7 @@ theorem isNoetherian_submodule {N : Submodule R M} :
     have : s ≤ LinearMap.range N.subtype := N.range_subtype.symm ▸ hs
     Submodule.map_comap_eq_self this ▸ (hn _).map _,
     fun h => ⟨fun s => ?_⟩⟩
-  have f := (Submodule.equivMapOfInjective N.subtype Subtype.val_injective s).symm
+  let f := (Submodule.equivMapOfInjective N.subtype Subtype.val_injective s).symm
   have h₁ := h (s.map N.subtype) (Submodule.map_subtype_le N s)
   have h₂ : (⊤ : Submodule R (s.map N.subtype)).map f = ⊤ := by simp
   have h₃ := ((Submodule.fg_top _).2 h₁).map (↑f : _ →ₗ[R] s)

--- a/Mathlib/RingTheory/Nullstellensatz.lean
+++ b/Mathlib/RingTheory/Nullstellensatz.lean
@@ -114,7 +114,7 @@ theorem mem_vanishingIdeal_singleton_iff (x : σ → k) (p : MvPolynomial σ k) 
 
 instance vanishingIdeal_singleton_isMaximal {x : σ → k} :
     (vanishingIdeal {x} : Ideal (MvPolynomial σ k)).IsMaximal := by
-  have : MvPolynomial σ k ⧸ vanishingIdeal {x} ≃+* k :=
+  let this : MvPolynomial σ k ⧸ vanishingIdeal {x} ≃+* k :=
     RingEquiv.ofBijective
       (Ideal.Quotient.lift _ (eval x) fun p h => (mem_vanishingIdeal_singleton_iff x p).mp h)
       (by

--- a/Mathlib/RingTheory/SimpleModule.lean
+++ b/Mathlib/RingTheory/SimpleModule.lean
@@ -156,7 +156,7 @@ always a two-sided prime ideal, but mathlib's `Ideal.IsPrime` is not the correct
 for noncommutative rings. -/
 theorem IsSimpleModule.annihilator_isMaximal {R} [CommRing R] [Module R M]
     [simple : IsSimpleModule R M] : (Module.annihilator R M).IsMaximal := by
-  have ⟨I, max, ⟨e⟩⟩ := isSimpleModule_iff_quot_maximal.mp simple
+  let ⟨I, max, ⟨e⟩⟩ := isSimpleModule_iff_quot_maximal.mp simple
   rwa [e.annihilator_eq, I.annihilator_quotient]
 
 theorem isSimpleModule_iff_toSpanSingleton_surjective : IsSimpleModule R M ↔

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -1850,7 +1850,7 @@ variable {c : Cardinal}
 /-- **König's theorem** -/
 theorem sum_lt_prod {ι} (f g : ι → Cardinal) (H : ∀ i, f i < g i) : sum f < prod g :=
   lt_of_not_ge fun ⟨F⟩ => by
-    have : Inhabited (∀ i : ι, (g i).out) := by
+    let _ : Inhabited (∀ i : ι, (g i).out) := by
       refine' ⟨fun i => Classical.choice <| mk_ne_zero_iff.1 _⟩
       rw [mk_out]
       exact (H i).ne_bot

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -765,7 +765,7 @@ theorem cof_univ : cof univ.{u, v} = Cardinal.univ.{u, v} :=
       cases' Cardinal.lift_down h with a e
       refine' Quotient.inductionOn a (fun α e => _) e
       cases' Quotient.exact e with f
-      have f := Equiv.ulift.symm.trans f
+      let f := Equiv.ulift.symm.trans f
       let g a := (f a).1
       let o := succ (sup.{u, u} g)
       rcases H o with ⟨b, h, l⟩

--- a/Mathlib/SetTheory/Cardinal/CountableCover.lean
+++ b/Mathlib/SetTheory/Cardinal/CountableCover.lean
@@ -40,7 +40,7 @@ lemma mk_subtype_le_of_countable_eventually_mem_aux {α ι : Type u} {a : Cardin
     have A : ∀ x ∈ s, ∀ᶠ i in l, x ∈ f i := fun x hx ↦ ht x (hs hx)
     have B : ∀ᶠ i in l, ∀ x ∈ s, x ∈ f i := (s.eventually_all).2 A
     rcases B.exists with ⟨i, hi⟩
-    have : ∀ i, Fintype (f i) := fun i ↦ (lt_aleph0_iff_fintype.1 ((h'f i).trans_lt ha)).some
+    let _ : ∀ i, Fintype (f i) := fun i ↦ (lt_aleph0_iff_fintype.1 ((h'f i).trans_lt ha)).some
     let u : Finset α := (f i).toFinset
     have I1 : s.card ≤ u.card := by
       have : s ⊆ u := fun x hx ↦ by simpa only [u, Set.mem_toFinset] using hi x hx

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -112,8 +112,8 @@ lemma card_image_le (hs : s.Finite) : Nat.card (f '' s) ≤ Nat.card s :=
 lemma card_image_of_injOn (hf : s.InjOn f) : Nat.card (f '' s) = Nat.card s := by
   classical
   obtain hs | hs := s.finite_or_infinite
-  · have := hs.fintype
-    have := fintypeImage s f
+  · let _ := hs.fintype
+    let _ := fintypeImage s f
     simp_rw [Nat.card_eq_fintype_card, Set.card_image_of_inj_on hf]
   · have := hs.to_subtype
     have := (hs.image hf).to_subtype
@@ -166,8 +166,8 @@ theorem card_eq_two_iff' (x : α) : Nat.card α = 2 ↔ ∃! y, y ≠ x :=
 
 @[simp]
 theorem card_sum [Finite α] [Finite β] : Nat.card (α ⊕ β) = Nat.card α + Nat.card β := by
-  have := Fintype.ofFinite α
-  have := Fintype.ofFinite β
+  let _ := Fintype.ofFinite α
+  let _ := Fintype.ofFinite β
   simp_rw [Nat.card_eq_fintype_card, Fintype.card_sum]
 
 @[simp]

--- a/Mathlib/SetTheory/Game/Basic.lean
+++ b/Mathlib/SetTheory/Game/Basic.lean
@@ -263,7 +263,7 @@ instance : Mul PGame.{u} :=
   ⟨fun x y => by
     induction' x with xl xr _ _ IHxl IHxr generalizing y
     induction' y with yl yr yL yR IHyl IHyr
-    have y := mk yl yr yL yR
+    let y := mk yl yr yL yR
     refine' ⟨Sum (xl × yl) (xr × yr), Sum (xl × yr) (xr × yl), _, _⟩ <;> rintro (⟨i, j⟩ | ⟨i, j⟩)
     · exact IHxl i y + IHyl j - IHxl i (yL j)
     · exact IHxr i y + IHyr j - IHxr i (yR j)

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1484,7 +1484,7 @@ instance : Add PGame.{u} :=
   ⟨fun x y => by
     induction' x with xl xr _ _ IHxl IHxr generalizing y
     induction' y with yl yr yL yR IHyl IHyr
-    have y := mk yl yr yL yR
+    let y := mk yl yr yL yR
     refine' ⟨Sum xl yl, Sum xr yr, Sum.rec _ _, Sum.rec _ _⟩
     · exact fun i => IHxl i y
     · exact IHyl

--- a/Mathlib/SetTheory/Game/Short.lean
+++ b/Mathlib/SetTheory/Game/Short.lean
@@ -170,8 +170,8 @@ theorem short_birthday (x : PGame.{u}) : [Short x] → x.birthday < Ordinal.omeg
 
 /-- This leads to infinite loops if made into an instance. -/
 def Short.ofIsEmpty {l r xL xR} [IsEmpty l] [IsEmpty r] : Short (PGame.mk l r xL xR) := by
-  have : Fintype l := Fintype.ofIsEmpty
-  have : Fintype r := Fintype.ofIsEmpty
+  let _ : Fintype l := Fintype.ofIsEmpty
+  let _ : Fintype r := Fintype.ofIsEmpty
   exact Short.mk isEmptyElim isEmptyElim
 #align pgame.short.of_is_empty SetTheory.PGame.Short.ofIsEmpty
 

--- a/Mathlib/SetTheory/Game/State.lean
+++ b/Mathlib/SetTheory/Game/State.lean
@@ -157,7 +157,7 @@ def relabellingMoveLeftAux (n : ℕ) {s : S} (h : turnBound s ≤ n)
         (turnBound_of_left ((leftMovesOfStateAux n h) t).2 (n - 1)
           (Nat.le_trans h le_tsub_add))) := by
   induction n
-  · have t' := (leftMovesOfStateAux 0 h) t
+  · let t' := (leftMovesOfStateAux 0 h) t
     exfalso; exact turnBound_ne_zero_of_left_move t'.2 (nonpos_iff_eq_zero.mp h)
   · rfl
 #align pgame.relabelling_move_left_aux SetTheory.PGame.relabellingMoveLeftAux
@@ -182,7 +182,7 @@ def relabellingMoveRightAux (n : ℕ) {s : S} (h : turnBound s ≤ n)
         (turnBound_of_right ((rightMovesOfStateAux n h) t).2 (n - 1)
           (Nat.le_trans h le_tsub_add))) := by
   induction n
-  · have t' := (rightMovesOfStateAux 0 h) t
+  · let t' := (rightMovesOfStateAux 0 h) t
     exfalso; exact turnBound_ne_zero_of_right_move t'.2 (nonpos_iff_eq_zero.mp h)
   · rfl
 #align pgame.relabelling_move_right_aux SetTheory.PGame.relabellingMoveRightAux
@@ -211,11 +211,11 @@ instance shortOfStateAux : ∀ (n : ℕ) {s : S} (h : turnBound s ≤ n), Short 
   | 0, s, h =>
     Short.mk'
       (fun i => by
-        have i := (leftMovesOfStateAux _ _).toFun i
+        let i := (leftMovesOfStateAux _ _).toFun i
         exfalso
         exact turnBound_ne_zero_of_left_move i.2 (nonpos_iff_eq_zero.mp h))
       fun j => by
-      have j := (rightMovesOfStateAux _ _).toFun j
+      let j := (rightMovesOfStateAux _ _).toFun j
       exfalso
       exact turnBound_ne_zero_of_right_move j.2 (nonpos_iff_eq_zero.mp h)
   | n + 1, s, h =>

--- a/Mathlib/SetTheory/Lists.lean
+++ b/Mathlib/SetTheory/Lists.lean
@@ -276,7 +276,7 @@ def inductionMut (C : Lists α → Sort*) (D : Lists' α true → Sort*)
   induction' l with a b a l IH₁ IH
   · exact ⟨C0 _, ⟨⟩⟩
   · exact ⟨C1 _ D0, D0⟩
-  · have : D (Lists'.cons' a l) := D1 ⟨_, _⟩ _ IH₁.1 IH.2
+  · let this : D (Lists'.cons' a l) := D1 ⟨_, _⟩ _ IH₁.1 IH.2
     exact ⟨C1 _ this, this⟩
 #align lists.induction_mut Lists.inductionMut
 

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -788,7 +788,7 @@ theorem lift_down' {a : Cardinal.{u}} {b : Ordinal.{max u v}}
         rw [card_type, ← Cardinal.lift_id'.{max u v, u} #β, ← Cardinal.lift_umax.{u, v},
           lift_mk_eq.{u, max u v, max u v}] at e'
         cases' e' with f
-        have g := RelIso.preimage f s
+        let g := RelIso.preimage f s
         haveI := (g : f ⁻¹'o s ↪r s).isWellOrder
         have := lift_type_eq.{u, max u v, max u v}.2 ⟨g⟩
         rw [lift_id, lift_umax.{u, v}] at this
@@ -1346,7 +1346,7 @@ theorem ord_le {c o} : ord c ≤ o ↔ c ≤ o.card :=
           let ⟨f⟩ := h
           ⟨f.toEmbedding⟩
       · cases' h with f
-        have g := RelEmbedding.preimage f s
+        let g := RelEmbedding.preimage f s
         haveI := RelEmbedding.isWellOrder g
         exact le_trans (ord_le_type _) g.ordinal_type_le
 #align cardinal.ord_le Cardinal.ord_le

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -405,8 +405,8 @@ theorem nfBelow_iff_topBelow {b} [NF b] : ∀ {o}, NFBelow o (repr b) ↔ NF o �
 instance decidableNF : DecidablePred NF
   | 0 => isTrue NF.zero
   | oadd e n a => by
-    have := decidableNF e
-    have := decidableNF a
+    let _ := decidableNF e
+    let _ := decidableNF a
     apply decidable_of_iff (NF e ∧ NF a ∧ TopBelow e a)
     rw [← and_congr_right fun h => @nfBelow_iff_topBelow _ h _]
     exact ⟨fun ⟨h₁, h₂⟩ => NF.oadd h₁ n h₂, fun h => ⟨h.fst, h.snd'⟩⟩

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -618,7 +618,7 @@ noncomputable def allDefinable : ∀ {n} (F : OfArity ZFSet ZFSet n), Definable 
     let p := @Quotient.exists_rep PSet _ F
     @Definable.EqMk 0 ⟨choose p, Equiv.rfl⟩ _ (choose_spec p)
   | n + 1, (F : OfArity ZFSet ZFSet (n + 1)) => by
-    have I : (x : ZFSet) → Definable (Nat.add n 0) (F x) := fun x => allDefinable (F x)
+    let I : (x : ZFSet) → Definable (Nat.add n 0) (F x) := fun x => allDefinable (F x)
     refine' @Definable.EqMk (n + 1) ⟨fun x : PSet => (@Definable.Resp _ _ (I ⟦x⟧)).1, _⟩ _ _
     · dsimp [Arity.Equiv]
       intro x y h

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -181,8 +181,8 @@ theorem isRat_add {α} [Ring α] {f : α → α → α} {a b : α} {na nb nc : �
     Nat.mul da db = Nat.mul k dc →
     IsRat (f a b) nc dc := by
   rintro rfl ⟨_, rfl⟩ ⟨_, rfl⟩ (h₁ : na * db + nb * da = k * nc) (h₂ : da * db = k * dc)
-  have : Invertible (↑(da * db) : α) := by simpa using invertibleMul (da:α) db
-  have := invertibleOfMul' (α := α) h₂
+  let _ : Invertible (↑(da * db) : α) := by simpa using invertibleMul (da:α) db
+  let this := invertibleOfMul' (α := α) h₂
   use this
   have H := (Nat.cast_commute (α := α) da db).invOf_left.invOf_right.right_comm
   have h₁ := congr_arg (↑· * (⅟↑da * ⅟↑db : α)) h₁
@@ -364,8 +364,8 @@ theorem isRat_mul {α} [Ring α] {f : α → α → α} {a b : α} {na nb nc : �
     Nat.mul da db = Nat.mul k dc →
     IsRat (f a b) nc dc := by
   rintro rfl ⟨_, rfl⟩ ⟨_, rfl⟩ (h₁ : na * nb = k * nc) (h₂ : da * db = k * dc)
-  have : Invertible (↑(da * db) : α) := by simpa using invertibleMul (da:α) db
-  have := invertibleOfMul' (α := α) h₂
+  let _ : Invertible (↑(da * db) : α) := by simpa using invertibleMul (da:α) db
+  let this := invertibleOfMul' (α := α) h₂
   refine ⟨this, ?_⟩
   have H := (Nat.cast_commute (α := α) da db).invOf_left.invOf_right.right_comm
   have h₁ := congr_arg (Int.cast (R := α)) h₁

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -106,7 +106,7 @@ recognizes `q`, returning the cast of `q`. -/
 theorem isRat_inv_pos {α} [DivisionRing α] [CharZero α] {a : α} {n d : ℕ} :
     IsRat a (.ofNat (Nat.succ n)) d → IsRat a⁻¹ (.ofNat d) (Nat.succ n) := by
   rintro ⟨_, rfl⟩
-  have := invertibleOfNonzero (α := α) (Nat.cast_ne_zero.2 (Nat.succ_ne_zero n))
+  let this := invertibleOfNonzero (α := α) (Nat.cast_ne_zero.2 (Nat.succ_ne_zero n))
   exact ⟨this, by simp⟩
 
 theorem isRat_inv_one {α} [DivisionRing α] : {a : α} →
@@ -121,10 +121,12 @@ theorem isRat_inv_neg_one {α} [DivisionRing α] : {a : α} →
     IsInt a (.negOfNat (nat_lit 1)) → IsInt a⁻¹ (.negOfNat (nat_lit 1))
   | _, ⟨rfl⟩ => ⟨by simp [inv_neg_one]⟩
 
+set_option linter.haveLet false in
 theorem isRat_inv_neg {α} [DivisionRing α] [CharZero α] {a : α} {n d : ℕ} :
     IsRat a (.negOfNat (Nat.succ n)) d → IsRat a⁻¹ (.negOfNat d) (Nat.succ n) := by
   rintro ⟨_, rfl⟩
   simp only [Int.negOfNat_eq]
+  -- changing `have` to `let`, makes the following `generalize` fail
   have := invertibleOfNonzero (α := α) (Nat.cast_ne_zero.2 (Nat.succ_ne_zero n))
   generalize Nat.succ n = n at *
   use this; simp only [Int.ofNat_eq_coe, Int.cast_neg,

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -121,12 +121,10 @@ theorem isRat_inv_neg_one {α} [DivisionRing α] : {a : α} →
     IsInt a (.negOfNat (nat_lit 1)) → IsInt a⁻¹ (.negOfNat (nat_lit 1))
   | _, ⟨rfl⟩ => ⟨by simp [inv_neg_one]⟩
 
-set_option linter.haveLet false in
 theorem isRat_inv_neg {α} [DivisionRing α] [CharZero α] {a : α} {n d : ℕ} :
     IsRat a (.negOfNat (Nat.succ n)) d → IsRat a⁻¹ (.negOfNat d) (Nat.succ n) := by
   rintro ⟨_, rfl⟩
   simp only [Int.negOfNat_eq]
-  -- changing `have` to `let`, makes the following `generalize` fail
   have := invertibleOfNonzero (α := α) (Nat.cast_ne_zero.2 (Nat.succ_ne_zero n))
   generalize Nat.succ n = n at *
   use this; simp only [Int.ofNat_eq_coe, Int.cast_neg,

--- a/Mathlib/Tactic/NormNum/Pow.lean
+++ b/Mathlib/Tactic/NormNum/Pow.lean
@@ -157,7 +157,7 @@ theorem isRat_pow {α} [Ring α] {f : α → ℕ → α} {a : α} {an cn : ℤ} 
     Int.pow an b' = cn → Nat.pow ad b' = cd →
     IsRat (f a b) cn cd := by
   rintro rfl ⟨_, rfl⟩ ⟨rfl⟩ (rfl : an ^ b = _) (rfl : ad ^ b = _)
-  have := invertiblePow (ad:α) b
+  let this := invertiblePow (ad:α) b
   rw [← Nat.cast_pow] at this
   use this; simp [invOf_pow, Commute.mul_pow]
 

--- a/Mathlib/Topology/Algebra/Group/OpenMapping.lean
+++ b/Mathlib/Topology/Algebra/Group/OpenMapping.lean
@@ -53,7 +53,7 @@ theorem smul_singleton_mem_nhds_of_sigmaCompact
   let F : ℕ × s → Set X := fun p ↦ (K p.1 ∩ (p.2 : G) • V) • ({x} : Set X)
   obtain ⟨⟨n, ⟨g, hg⟩⟩, hi⟩ : ∃ i, (interior (F i)).Nonempty := by
     have : Nonempty X := ⟨x⟩
-    have : Encodable s := Countable.toEncodable s_count
+    let _ : Encodable s := Countable.toEncodable s_count
     apply nonempty_interior_of_iUnion_of_closed
     · rintro ⟨n, ⟨g, hg⟩⟩
       apply IsCompact.isClosed

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -301,7 +301,7 @@ theorem Finite.of_summable_const [LinearOrderedAddCommGroup α] [TopologicalSpac
   obtain ⟨n, hn⟩ := Archimedean.arch (∑' _ : ι, b) hb
   have : ∀ s : Finset ι, s.card ≤ n := fun s ↦ by
     simpa [nsmul_le_nsmul_iff_left hb] using (H s).trans hn
-  have : Fintype ι := fintypeOfFinsetCardLe n this
+  let _ : Fintype ι := fintypeOfFinsetCardLe n this
   infer_instance
 
 theorem Set.Finite.of_summable_const [LinearOrderedAddCommGroup α] [TopologicalSpace α]

--- a/Mathlib/Topology/Algebra/Module/Cardinality.lean
+++ b/Mathlib/Topology/Algebra/Module/Cardinality.lean
@@ -83,7 +83,7 @@ lemma cardinal_eq_of_mem_nhds_zero
     exact (mem_smul_set_iff_inv_smul_mem₀ (cn_ne n) _ _).2 hn
   have B : ∀ n, #(c^n • s :) = #s := by
     intro n
-    have : (c^n • s :) ≃ s :=
+    let this : (c^n • s :) ≃ s :=
     { toFun := fun x ↦ ⟨(c^n)⁻¹ • x.1, (mem_smul_set_iff_inv_smul_mem₀ (cn_ne n) _ _).1 x.2⟩
       invFun := fun x ↦ ⟨(c^n) • x.1, smul_mem_smul_set x.2⟩
       left_inv := fun x ↦ by simp [smul_smul, mul_inv_cancel (cn_ne n)]

--- a/Mathlib/Topology/Category/Compactum.lean
+++ b/Mathlib/Topology/Category/Compactum.lean
@@ -479,7 +479,7 @@ theorem essSurj : compactumToCompHaus.EssSurj :=
 
 /-- The functor `compactumToCompHaus` is an equivalence of categories. -/
 noncomputable instance isEquivalence : compactumToCompHaus.IsEquivalence := by
-  have := compactumToCompHaus.full
+  let _ := compactumToCompHaus.full
   have := compactumToCompHaus.faithful
   have := compactumToCompHaus.essSurj
   apply Functor.IsEquivalence.ofFullyFaithfullyEssSurj _

--- a/Mathlib/Topology/Category/LightProfinite/Basic.lean
+++ b/Mathlib/Topology/Category/LightProfinite/Basic.lean
@@ -51,7 +51,7 @@ namespace LightProfinite
 @[ext]
 theorem ext {Y : LightProfinite} {a b : Y.cone.pt}
     (h : ∀ n, Y.cone.π.app n a = Y.cone.π.app n b) : a = b := by
-  have : PreservesLimitsOfSize.{0, 0} (forget Profinite) := preservesLimitsOfSizeShrink _
+  let _ : PreservesLimitsOfSize.{0, 0} (forget Profinite) := preservesLimitsOfSizeShrink _
   exact Concrete.isLimit_ext _ Y.isLimit _ _ h
 
 /--

--- a/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
@@ -219,8 +219,8 @@ theorem exists_locallyConstant {α : Type*} (hC : IsLimit C) (f : LocallyConstan
       (F ⋙ Profinite.toTopCat)
     suffices Nonempty C.pt from IsEmpty.false (S.proj this.some)
     let D := Profinite.toTopCat.mapCone C
-    have hD : IsLimit D := isLimitOfPreserves Profinite.toTopCat hC
-    have CD := (hD.conePointUniqueUpToIso (TopCat.limitConeIsLimit.{v, max u v} _)).inv
+    let hD : IsLimit D := isLimitOfPreserves Profinite.toTopCat hC
+    let CD := (hD.conePointUniqueUpToIso (TopCat.limitConeIsLimit.{v, max u v} _)).inv
     exact cond.map CD
   · let f' : LocallyConstant C.pt S := ⟨S.proj, S.proj_isLocallyConstant⟩
     obtain ⟨j, g', hj⟩ := exists_locallyConstant_finite_nonempty _ hC f'

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -1555,7 +1555,7 @@ theorem max_eq_eval_unapply :
 theorem chain'_cons_of_lt (l : MaxProducts C ho)
     (q : Products I) (hq : q < l.val.Tail) :
     List.Chain' (fun x x_1 ↦ x > x_1) (term I ho :: q.val) := by
-  have : Inhabited I := ⟨term I ho⟩
+  let _ : Inhabited I := ⟨term I ho⟩
   rw [List.chain'_iff_pairwise]
   simp only [gt_iff_lt, List.pairwise_cons]
   refine ⟨fun a ha ↦ lt_of_le_of_lt (Products.rel_head!_of_mem ha) ?_,
@@ -1570,7 +1570,7 @@ theorem chain'_cons_of_lt (l : MaxProducts C ho)
 
 theorem good_lt_maxProducts (q : GoodProducts (π C (ord I · < o)))
     (l : MaxProducts C ho) : List.Lex (·<·) q.val.val l.val.val := by
-  have : Inhabited I := ⟨term I ho⟩
+  let _ : Inhabited I := ⟨term I ho⟩
   by_cases h : q.val.val = []
   · rw [h, max_eq_o_cons_tail C hsC ho l]
     exact List.Lex.nil
@@ -1587,7 +1587,7 @@ Removing the leading `o` from a term of `MaxProducts C` yields a list which `is
 theorem maxTail_isGood (l : MaxProducts C ho)
     (h₁: ⊤ ≤ Submodule.span ℤ (Set.range (eval (π C (ord I · < o))))) :
     l.val.Tail.isGood (C' C ho) := by
-  have : Inhabited I := ⟨term I ho⟩
+  let _ : Inhabited I := ⟨term I ho⟩
   -- Write `l.Tail` as a linear combination of smaller products:
   intro h
   rw [Finsupp.mem_span_image_iff_total, ← max_eq_eval C hsC ho] at h

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -327,7 +327,7 @@ instance : PreservesPullbacksOfInclusions Stonean.toCompHaus.{u} where
     intros X Y Z f
     apply (config := { allowSynthFailures := true }) preservesPullbackSymmetry
     have : OpenEmbedding (coprod.inl : X ⟶ X ⨿ Y) := Stonean.Sigma.openEmbedding_ι _ _
-    have := Stonean.createsPullbacksOfOpenEmbedding f this
+    let _ := Stonean.createsPullbacksOfOpenEmbedding f this
     exact preservesLimitOfReflectsOfPreserves Stonean.toCompHaus compHausToTop
 
 instance : FinitaryExtensive Stonean.{u} :=

--- a/Mathlib/Topology/Category/TopCat/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/TopCat/EffectiveEpi.lean
@@ -57,7 +57,7 @@ theorem effectiveEpi_iff_quotientMap {B X : TopCat.{u}} (π : X ⟶ B) :
   /- Since `TopCat` has pullbacks, `π` is in fact a `RegularEpi`. This means that it exhibits `B` as
     a coequalizer of two maps into `X`. It suffices to prove that `π` followed by the isomorphism to
     an arbitrary coequalizer is a quotient map. -/
-  have hπ : RegularEpi π := inferInstance
+  let hπ : RegularEpi π := inferInstance
   let F := parallelPair hπ.left hπ.right
   let i : B ≅ colimit F := hπ.isColimit.coconePointUniqueUpToIso (colimit.isColimit _)
   suffices QuotientMap (homeoOfIso i ∘ π) by

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -106,11 +106,11 @@ theorem eq_toGHSpace_iff {X : Type u} [MetricSpace X] [CompactSpace X] [Nonempty
   simp only [toGHSpace, Quotient.eq]
   refine' ⟨fun h => _, _⟩
   · rcases Setoid.symm h with ⟨e⟩
-    have f := (kuratowskiEmbedding.isometry X).isometryEquivOnRange.trans e
+    let f := (kuratowskiEmbedding.isometry X).isometryEquivOnRange.trans e
     use fun x => f x, isometry_subtype_coe.comp f.isometry
     erw [range_comp, f.range_eq_univ, Set.image_univ, Subtype.range_coe]
   · rintro ⟨Ψ, ⟨isomΨ, rangeΨ⟩⟩
-    have f :=
+    let f :=
       ((kuratowskiEmbedding.isometry X).isometryEquivOnRange.symm.trans
           isomΨ.isometryEquivOnRange).symm
     have E : (range Ψ ≃ᵢ NonemptyCompacts.kuratowskiEmbedding X)
@@ -158,13 +158,13 @@ theorem toGHSpace_eq_toGHSpace_iff_isometryEquiv {X : Type u} [MetricSpace X] [C
       (NonemptyCompacts.kuratowskiEmbedding X ≃ᵢ NonemptyCompacts.kuratowskiEmbedding Y) =
         (range (kuratowskiEmbedding X) ≃ᵢ range (kuratowskiEmbedding Y)) := by
       dsimp only [NonemptyCompacts.kuratowskiEmbedding]; rfl
-    have f := (kuratowskiEmbedding.isometry X).isometryEquivOnRange
-    have g := (kuratowskiEmbedding.isometry Y).isometryEquivOnRange.symm
+    let f := (kuratowskiEmbedding.isometry X).isometryEquivOnRange
+    let g := (kuratowskiEmbedding.isometry Y).isometryEquivOnRange.symm
     exact ⟨f.trans <| (cast I e).trans g⟩, by
     rintro ⟨e⟩
     simp only [toGHSpace, Quotient.eq']
-    have f := (kuratowskiEmbedding.isometry X).isometryEquivOnRange.symm
-    have g := (kuratowskiEmbedding.isometry Y).isometryEquivOnRange
+    let f := (kuratowskiEmbedding.isometry X).isometryEquivOnRange.symm
+    let g := (kuratowskiEmbedding.isometry Y).isometryEquivOnRange
     have I :
       (range (kuratowskiEmbedding X) ≃ᵢ range (kuratowskiEmbedding Y)) =
         (NonemptyCompacts.kuratowskiEmbedding X ≃ᵢ NonemptyCompacts.kuratowskiEmbedding Y) := by
@@ -463,8 +463,8 @@ instance : MetricSpace GHSpace where
       · exact hausdorffEdist_ne_top_of_nonempty_of_bounded (range_nonempty _) (range_nonempty _)
           hΦ.isBounded hΨ.isBounded
     have T : (range Ψ ≃ᵢ y.Rep) = (range Φ ≃ᵢ y.Rep) := by rw [this]
-    have eΨ := cast T Ψisom.isometryEquivOnRange.symm
-    have e := Φisom.isometryEquivOnRange.trans eΨ
+    let eΨ := cast T Ψisom.isometryEquivOnRange.symm
+    let e := Φisom.isometryEquivOnRange.trans eΨ
     rw [← x.toGHSpace_rep, ← y.toGHSpace_rep, toGHSpace_eq_toGHSpace_iff_isometryEquiv]
     exact ⟨e⟩
   dist_triangle x y z := by

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -544,7 +544,7 @@ set_option linter.uppercaseLean3 false in
 #align real.dimH_univ_pi_fin Real.dimH_univ_pi_fin
 
 theorem dimH_of_mem_nhds {x : E} {s : Set E} (h : s ∈ 𝓝 x) : dimH s = finrank ℝ E := by
-  have e : E ≃L[ℝ] Fin (finrank ℝ E) → ℝ :=
+  let e : E ≃L[ℝ] Fin (finrank ℝ E) → ℝ :=
     ContinuousLinearEquiv.ofFinrankEq (FiniteDimensional.finrank_fin_fun ℝ).symm
   rw [← e.dimH_image]
   refine le_antisymm ?_ ?_

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -343,7 +343,7 @@ def pullbackObjObjOfImageOpen {X Y : TopCat.{v}} (f : X ⟶ Y) (ℱ : Y.Presheaf
     (H : IsOpen (f '' SetLike.coe U)) : (pullbackObj f ℱ).obj (op U) ≅ ℱ.obj (op ⟨_, H⟩) := by
   let x : CostructuredArrow (Opens.map f).op (op U) := CostructuredArrow.mk
     (@homOfLE _ _ _ ((Opens.map f).obj ⟨_, H⟩) (Set.image_preimage.le_u_l _)).op
-  have hx : IsTerminal x :=
+  let hx : IsTerminal x :=
     { lift := fun s ↦ by
         fapply CostructuredArrow.homMk
         change op (unop _) ⟶ op (⟨_, H⟩ : Opens _)

--- a/Mathlib/Topology/TietzeExtension.lean
+++ b/Mathlib/Topology/TietzeExtension.lean
@@ -466,7 +466,7 @@ real-valued function `g : C(Y, ℝ)` such that `g y ∈ t` for all `y` and `g �
 theorem exists_extension_forall_mem_of_closedEmbedding (f : C(X, ℝ)) {t : Set ℝ} {e : X → Y}
     [hs : OrdConnected t] (hf : ∀ x, f x ∈ t) (hne : t.Nonempty) (he : ClosedEmbedding e) :
     ∃ g : C(Y, ℝ), (∀ y, g y ∈ t) ∧ g ∘ e = f := by
-  have h : ℝ ≃o Ioo (-1 : ℝ) 1 := orderIsoIooNegOneOne ℝ
+  let h : ℝ ≃o Ioo (-1 : ℝ) 1 := orderIsoIooNegOneOne ℝ
   let F : X →ᵇ ℝ :=
     { toFun := (↑) ∘ h ∘ f
       continuous_toFun := continuous_subtype_val.comp (h.continuous.comp f.continuous)


### PR DESCRIPTION
Test the performance effect of replacing non-`Prop`-valued `have`s to `let`s.

See #12157 for the PR with the linter.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
