### PR TITLE
[Merged by Bors] - chore(Topology): make `LocallyConstant.comap` computable

### DIFF
--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -458,7 +458,7 @@ variable [TopologicalSpace Y]
 This definition only makes sense if `f` is continuous,
 in which case it sends locally constant functions to their precomposition with `f`.
 See also `LocallyConstant.coe_comap`. -/
-noncomputable def comap (f : C(X, Y)) (g : LocallyConstant Y Z) : LocallyConstant X Z :=
+def comap (f : C(X, Y)) (g : LocallyConstant Y Z) : LocallyConstant X Z :=
   ⟨g ∘ f, g.isLocallyConstant.comp_continuous f.continuous⟩
 #align locally_constant.comap LocallyConstant.comap
 

--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -449,15 +449,9 @@ theorem flip_unflip {X α β : Type*} [Finite α] [TopologicalSpace X]
 
 section Comap
 
-open scoped Classical
-
 variable [TopologicalSpace Y]
 
-/-- Pull back of locally constant maps under any map, by pre-composition.
-
-This definition only makes sense if `f` is continuous,
-in which case it sends locally constant functions to their precomposition with `f`.
-See also `LocallyConstant.coe_comap`. -/
+/-- Pull back of locally constant maps under a continuous map, by pre-composition. -/
 def comap (f : C(X, Y)) (g : LocallyConstant Y Z) : LocallyConstant X Z :=
   ⟨g ∘ f, g.isLocallyConstant.comp_continuous f.continuous⟩
 #align locally_constant.comap LocallyConstant.comap


### PR DESCRIPTION
After the recent refactor (#12136), the `noncomputable` modifier is unnecessary, and the docstring needed modification. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
