### PR TITLE
[Merged by Bors] - feat(CompHaus): terminal objects

### DIFF
--- a/Mathlib/Topology/Category/CompHaus/Limits.lean
+++ b/Mathlib/Topology/Category/CompHaus/Limits.lean
@@ -244,4 +244,18 @@ instance : FinitaryExtensive CompHaus :=
 
 end FiniteCoproducts
 
+section Terminal
+
+/-- A one-element space is terminal in `CompHaus` -/
+def isTerminalPUnit : IsTerminal (CompHaus.of PUnit.{u + 1}) :=
+  haveI : ∀ X, Unique (X ⟶ CompHaus.of PUnit.{u + 1}) := fun X =>
+    ⟨⟨⟨fun _ => PUnit.unit, continuous_const⟩⟩, fun f => by ext; aesop⟩
+  Limits.IsTerminal.ofUnique _
+
+/-- The isomorphism from an arbitrary terminal object of `CompHaus` to a one-element space. -/
+noncomputable def terminalIsoPUnit : ⊤_ CompHaus.{u} ≅ CompHaus.of PUnit :=
+  terminalIsTerminal.uniqueUpToIso CompHaus.isTerminalPUnit
+
+end Terminal
+
 end CompHaus


### PR DESCRIPTION
We prove that the one element space in `CompHaus` is terminal. 

---
Corresponds precisely to the approach in `TopCat`

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
