### PR TITLE
[Merged by Bors] - feat: FloorRing.exists_prime_mul_pow_div_factorial_lt_one

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -399,6 +399,7 @@ import Mathlib.Algebra.Order.Field.Pi
 import Mathlib.Algebra.Order.Field.Power
 import Mathlib.Algebra.Order.Floor
 import Mathlib.Algebra.Order.Floor.Div
+import Mathlib.Algebra.Order.Floor.Prime
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Group.Bounds
 import Mathlib.Algebra.Order.Group.Cone

--- a/Mathlib/Algebra/Order/Floor/Prime.lean
+++ b/Mathlib/Algebra/Order/Floor/Prime.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2022 Yuyang Zhao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yuyang Zhao
+-/
+
+import Mathlib.Algebra.Order.Floor
+import Mathlib.Data.Nat.Prime
+
+/-!
+# Existence of a sufficiently large prime for which `a * c ^ p / (p - 1)! < 1`
+
+This is a technical result used in the proof of the Lindemann-Weierstrass theorem.
+-/
+
+namespace FloorRing
+
+open scoped Nat
+
+variable {K : Type*}
+
+theorem exists_prime_mul_pow_lt_factorial [LinearOrderedRing K] [FloorRing K] (n : ℕ) (a c : K) :
+    ∃ p > n, p.Prime ∧ a * c ^ p < (p - 1)! := by
+  obtain ⟨p, pn, pp, h⟩ := n.exists_prime_mul_pow_lt_factorial ⌈|a|⌉.natAbs ⌈|c|⌉.natAbs
+  use p, pn, pp
+  calc a * c ^ p
+    _ ≤ |a * c ^ p| := le_abs_self _
+    _ ≤ ⌈|a|⌉ * (⌈|c|⌉ : K) ^ p := ?_
+    _ = ↑(Int.natAbs ⌈|a|⌉ * Int.natAbs ⌈|c|⌉ ^ p) := ?_
+    _ < ↑(p - 1)! := Nat.cast_lt.mpr h
+  · rw [abs_mul, abs_pow]
+    gcongr <;> try first | positivity | apply Int.le_ceil
+  · simp_rw [Nat.cast_mul, Nat.cast_pow, Int.cast_natAbs,
+      abs_eq_self.mpr (Int.ceil_nonneg (abs_nonneg (_ : K)))]
+
+theorem exists_prime_mul_pow_div_factorial_lt_one [LinearOrderedField K] [FloorRing K]
+    (n : ℕ) (a c : K) :
+    ∃ p > n, p.Prime ∧ a * c ^ p / (p - 1)! < 1 := by
+  simp_rw [div_lt_one (α := K) (Nat.cast_pos.mpr (Nat.factorial_pos _))]
+  exact exists_prime_mul_pow_lt_factorial ..
+
+end FloorRing

--- a/Mathlib/Data/Nat/Prime.lean
+++ b/Mathlib/Data/Nat/Prime.lean
@@ -757,6 +757,37 @@ lemma Prime.pow_inj {p q m n : ℕ} (hp : p.Prime) (hq : q.Prime)
     (Prime.dvd_of_dvd_pow hq <| h.symm ▸ dvd_pow_self q (succ_ne_zero n))
   exact ⟨H, succ_inj'.mp <| Nat.pow_right_injective hq.two_le (H ▸ h)⟩
 
+theorem exists_pow_lt_factorial (c : ℕ) : ∃ n0 > 1, ∀ n ≥ n0, c ^ n < (n - 1)! := by
+  refine ⟨2 * (c ^ 2 + 1), ?_, ?_⟩
+  · omega
+  intro n hn
+  obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le hn
+  obtain (rfl | c0) := c.eq_zero_or_pos
+  · simp [Nat.factorial_pos]
+  refine (Nat.le_mul_of_pos_right _ (pow_pos c0 d)).trans_lt ?_
+  convert_to (c ^ 2) ^ (c ^ 2 + d + 1) < (c ^ 2 + (c ^ 2 + d + 1))!
+  · rw [← pow_mul, ← pow_add]
+    congr 1
+    omega
+  · congr
+    omega
+  refine lt_of_lt_of_le ?_ Nat.factorial_mul_pow_le_factorial
+  rw [← one_mul (_ ^ _ : ℕ)]
+  exact Nat.mul_lt_mul_of_le_of_lt (Nat.one_le_of_lt (Nat.factorial_pos _))
+    (Nat.pow_lt_pow_left (Nat.lt_succ_self _) (Nat.succ_ne_zero _)) (Nat.factorial_pos _)
+
+theorem exists_mul_pow_lt_factorial (a : ℕ) (c : ℕ) : ∃ n0, ∀ n ≥ n0, a * c ^ n < (n - 1)! := by
+  obtain ⟨n0, hn, h⟩ := Nat.exists_pow_lt_factorial (a * c)
+  refine ⟨n0, fun n hn => lt_of_le_of_lt ?_ (h n hn)⟩
+  rw [mul_pow]
+  refine Nat.mul_le_mul_right _ (Nat.le_self_pow ?_ _)
+  omega
+
+theorem exists_prime_mul_pow_lt_factorial (n a c : ℕ) : ∃ p > n, p.Prime ∧ a * c ^ p < (p - 1)! :=
+  have ⟨n0, h⟩ := Nat.exists_mul_pow_lt_factorial a c
+  have ⟨p, hp, prime_p⟩ := (max (n + 1) n0).exists_infinite_primes
+  ⟨p, (le_max_left _ _).trans hp, prime_p, h _ <| le_of_max_le_right hp⟩
+
 /-- The type of prime numbers -/
 def Primes :=
   { p : ℕ // p.Prime }


### PR DESCRIPTION
A few technical lemmas in support of Lindemann-Weierstrass.

Co-authored-by: negiizhao <egresf@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

From #6718.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
