### PR TITLE
[Merged by Bors] - chore: speed up a proof that breaks later

### DIFF
--- a/Mathlib/FieldTheory/Extension.lean
+++ b/Mathlib/FieldTheory/Extension.lean
@@ -123,7 +123,9 @@ theorem exists_algHom_adjoin_of_splits' :
       inclusion (?_ : (adjoin L S).restrictScalars F ≤ (adjoin L' S).restrictScalars F), ?_⟩
     · simp_rw [← SetLike.coe_subset_coe, coe_restrictScalars, adjoin_subset_adjoin_iff]
       exact ⟨subset_adjoin_of_subset_left S (F := L'.toSubfield) le_rfl, subset_adjoin _ _⟩
-    · ext x; exact congr($hφ _).trans (congr_arg f <| AlgEquiv.symm_apply_apply _ _)
+    · ext x
+      rw [AlgHom.comp_assoc]
+      exact congr($hφ _).trans (congr_arg f <| AlgEquiv.symm_apply_apply _ _)
   letI : Algebra L L' := (AlgEquiv.ofInjectiveField _).toRingEquiv.toRingHom.toAlgebra
   have : IsScalarTower L L' E := IsScalarTower.of_algebraMap_eq' rfl
   refine ⟨(hK s hs).1.tower_top, (hK s hs).1.minpoly_splits_tower_top' ?_⟩


### PR DESCRIPTION
Help a proof along by expliciting rewriting by an associativity lemma, rather than relying on the defeq (which causes a timeout on nightly-testing).