### PR TITLE
[Merged by Bors] - chore: speed up a proof in FieldTheory/NormalClosure

### DIFF
--- a/Mathlib/FieldTheory/NormalClosure.lean
+++ b/Mathlib/FieldTheory/NormalClosure.lean
@@ -213,11 +213,11 @@ noncomputable def Algebra.IsAlgebraic.algHomEmbeddingOfSplits (alg : IsAlgebraic
       · exact splits_of_splits_of_dvd _ (minpoly.ne_zero iy)
           (h y) (minpoly.dvd F x (mem_rootSet.mp hx).2)
       · simp [minpoly.eq_zero iy] at hx
-  { toFun := (φ.comp <| inclusion <| normalClosure_le_iSup_adjoin alg).comp ∘
-      (normalClosure.algHomEquiv F K L').symm
+  let φ' := (φ.comp <| inclusion <| normalClosure_le_iSup_adjoin alg)
+  { toFun := φ'.comp ∘ (normalClosure.algHomEquiv F K L').symm
     inj' := fun _ _ h ↦ (normalClosure.algHomEquiv F K L').symm.injective <| by
       rw [DFunLike.ext'_iff] at h ⊢
-      exact (φ.comp _).injective.comp_left h }
+      exact φ'.injective.comp_left h }
 
 namespace IntermediateField
 


### PR DESCRIPTION
Speed up a proof which will otherwise timeout on nightly-testing.