### PR TITLE
[Merged by Bors] - chore(Game/Short): drop `SetTheory.PGame.listShortGet`

### DIFF
--- a/Mathlib/SetTheory/Game/Short.lean
+++ b/Mathlib/SetTheory/Game/Short.lean
@@ -200,7 +200,6 @@ instance ListShort.cons (hd : PGame.{u}) [short_hd : Short hd]
   cons' short_hd short_tl
 #align pgame.list_short.cons SetTheory.PGame.ListShort.cons
 
--- Porting note: use `List.get` instead of `List.nthLe` because it has been deprecated
 instance listShortGet :
     ∀ (L : List PGame.{u}) [ListShort L] (i : Fin (List.length L)), Short (List.get L i)
   | [], _, n => by
@@ -209,14 +208,7 @@ instance listShortGet :
   | _::_, ListShort.cons' S _, ⟨0, _⟩ => S
   | hd::tl, ListShort.cons' _ S, ⟨n + 1, h⟩ =>
     @listShortGet tl S ⟨n, (add_lt_add_iff_right 1).mp h⟩
-
-set_option linter.deprecated false in
-@[deprecated listShortGet]
-instance listShortNthLe (L : List PGame.{u}) [ListShort L] (i : Fin (List.length L)) :
-    Short (List.nthLe L i i.is_lt) := by
-  rw [List.nthLe_eq]
-  apply listShortGet
-#align pgame.list_short_nth_le SetTheory.PGame.listShortNthLe
+#align pgame.list_short_nth_le SetTheory.PGame.listShortGet
 
 instance shortOfLists : ∀ (L R : List PGame) [ListShort L] [ListShort R], Short (PGame.ofLists L R)
   | L, R, _, _ => by


### PR DESCRIPTION
It was deprecated during port on 2023-07-01

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)