### PR TITLE
[Merged by Bors] - chore: update lean-pr-testing reporting logic, now that the linter always runs

### DIFF
--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -83,6 +83,8 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
     message="- 🟡 Mathlib branch $branch build against this PR was cancelled. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$CHECK_OUTCOME" == "success" ]; then
     message="- ✅ Mathlib branch $branch has successfully built against this PR. ($current_time) [View Log]($WORKFLOW_URL)"
+  elif [ "$BUILD_OUTCOME" == "failure" ] ; then
+    message="- 💥 Mathlib branch $branch build failed against this PR. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$CHECK_OUTCOME" == "failure" ]; then
     message="- ❌ Mathlib branch $branch built against this PR, but lean4checker failed. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$LINT_OUTCOME" == "failure" ]; then
@@ -95,8 +97,6 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
     message="- ❌ Mathlib branch $branch built against this PR, but was unexpectedly noisy. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$TEST_OUTCOME" == "failure" ]; then
     message="- ❌ Mathlib branch $branch built against this PR, but testing failed. ($current_time) [View Log]($WORKFLOW_URL)"
-  elif [ "$BUILD_OUTCOME" == "failure" ] ; then
-    message="- 💥 Mathlib branch $branch build failed against this PR. ($current_time) [View Log]($WORKFLOW_URL)"
   else
     message="- 🟡 Mathlib branch $branch build this PR didn't complete normally. ($current_time) [View Log]($WORKFLOW_URL)"
   fi


### PR DESCRIPTION
As reported [elsewhere](https://github.com/leanprover/lean4/pull/3808#issuecomment-2038473494).