### PR TITLE
[Merged by Bors] - feat(Order/Hom): prove disjoint from order embedding

### DIFF
--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -751,36 +751,27 @@ section Disjoint
 
 variable [PartialOrder α] [PartialOrder β] (f : OrderEmbedding α β)
 
-/-- If the images by an order embedding of two elements are disjoint, then they are themselves
-disjoint. -/
+/-- If the images by an order embedding of two elements are disjoint,
+then they are themselves disjoint. -/
 lemma Disjoint.of_orderEmbedding [OrderBot α] [OrderBot β] {a₁ a₂ : α} :
     Disjoint (f a₁) (f a₂) → Disjoint a₁ a₂ := by
-  simp_rw [Disjoint]
   intro h x h₁ h₂
-  have hx₁ : f x ≤ f a₁ := (OrderEmbedding.le_iff_le f).mpr h₁
-  have hx₂ : f x ≤ f a₂ := (OrderEmbedding.le_iff_le f).mpr h₂
-  have hxb : f x ≤ ⊥ := h hx₁ hx₂
-  have hxeb : f x ≤ f ⊥ := le_trans hxb (OrderBot.bot_le (f ⊥))
-  exact (OrderEmbedding.le_iff_le f).mp hxeb
+  rw [← f.le_iff_le] at h₁ h₂ ⊢
+  calc
+    f x ≤ ⊥ := h h₁ h₂
+    _ ≤ f ⊥ := bot_le
 
-/-- If the images by an order embedding of two elements are codisjoint, then they are themselves
-codisjoint. -/
+/-- If the images by an order embedding of two elements are codisjoint,
+then they are themselves codisjoint. -/
 lemma Codisjoint.of_orderEmbedding [OrderTop α] [OrderTop β] {a₁ a₂ : α} :
-    Codisjoint (f a₁) (f a₂) → Codisjoint a₁ a₂ := by
-  simp_rw [Codisjoint]
-  intro h x h₁ h₂
-  have hx₁ : f a₁ ≤ f x := (OrderEmbedding.le_iff_le f).mpr h₁
-  have hx₂ : f a₂ ≤ f x := (OrderEmbedding.le_iff_le f).mpr h₂
-  have hxt : ⊤ ≤ f x := h hx₁ hx₂
-  have hxet : f ⊤ ≤ f x := le_trans (OrderTop.le_top (f ⊤)) hxt
-  exact (OrderEmbedding.le_iff_le f).mp hxet
+    Codisjoint (f a₁) (f a₂) → Codisjoint a₁ a₂ :=
+  Disjoint.of_orderEmbedding (α := αᵒᵈ) (β := βᵒᵈ) f.dual
 
-/-- If the images by an order embedding of two elements are complements, then they are themselves
-complements. -/
+/-- If the images by an order embedding of two elements are complements,
+then they are themselves complements. -/
 lemma IsCompl.of_orderEmbedding [BoundedOrder α] [BoundedOrder β] {a₁ a₂ : α} :
-    IsCompl (f a₁) (f a₂) → IsCompl a₁ a₂ := by
-  intro ⟨hd, hcd⟩
-  exact ⟨Disjoint.of_orderEmbedding f hd, Codisjoint.of_orderEmbedding f hcd⟩
+    IsCompl (f a₁) (f a₂) → IsCompl a₁ a₂ := fun ⟨hd, hcd⟩ ↦
+  ⟨Disjoint.of_orderEmbedding f hd, Codisjoint.of_orderEmbedding f hcd⟩
 
 end Disjoint
 

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -760,27 +760,27 @@ lemma Disjoint.of_orderEmbedding [OrderBot α] [OrderBot β] {a₁ a₂ : α} :
   have hx₁ : f x ≤ f a₁ := (OrderEmbedding.le_iff_le f).mpr h₁
   have hx₂ : f x ≤ f a₂ := (OrderEmbedding.le_iff_le f).mpr h₂
   have hxb : f x ≤ ⊥ := h hx₁ hx₂
-  have hxeb : f x ≤ e ⊥ := le_trans hxb (OrderBot.bot_le (e ⊥))
-  exact (OrderEmbedding.le_iff_le e).mp hxeb
+  have hxeb : f x ≤ f ⊥ := le_trans hxb (OrderBot.bot_le (f ⊥))
+  exact (OrderEmbedding.le_iff_le f).mp hxeb
 
 /-- If the images by an order embedding of two elements are codisjoint, then they are themselves
 codisjoint. -/
-lemma Codisjoint.of_orderEmbedding [OrderTop α] [OrderTop β] (e : OrderEmbedding α β) {a₁ a₂ : α} :
-    Codisjoint (e a₁) (e a₂) → Codisjoint a₁ a₂ := by
+lemma Codisjoint.of_orderEmbedding [OrderTop α] [OrderTop β] {a₁ a₂ : α} :
+    Codisjoint (f a₁) (f a₂) → Codisjoint a₁ a₂ := by
   simp_rw [Codisjoint]
   intro h x h₁ h₂
-  have hx₁ : e a₁ ≤ e x := (OrderEmbedding.le_iff_le e).mpr h₁
-  have hx₂ : e a₂ ≤ e x := (OrderEmbedding.le_iff_le e).mpr h₂
-  have hxt : ⊤ ≤ e x := h hx₁ hx₂
-  have hxet : e ⊤ ≤ e x := le_trans (OrderTop.le_top (e ⊤)) hxt
-  exact (OrderEmbedding.le_iff_le e).mp hxet
+  have hx₁ : f a₁ ≤ f x := (OrderEmbedding.le_iff_le f).mpr h₁
+  have hx₂ : f a₂ ≤ f x := (OrderEmbedding.le_iff_le f).mpr h₂
+  have hxt : ⊤ ≤ f x := h hx₁ hx₂
+  have hxet : f ⊤ ≤ f x := le_trans (OrderTop.le_top (f ⊤)) hxt
+  exact (OrderEmbedding.le_iff_le f).mp hxet
 
 /-- If the images by an order embedding of two elements are complements, then they are themselves
 complements. -/
-lemma IsCompl.of_orderEmbedding [BoundedOrder α] [BoundedOrder β] (e : OrderEmbedding α β)
-    {a₁ a₂ : α} : IsCompl (e a₁) (e a₂) → IsCompl a₁ a₂ := by
+lemma IsCompl.of_orderEmbedding [BoundedOrder α] [BoundedOrder β] {a₁ a₂ : α} :
+    IsCompl (f a₁) (f a₂) → IsCompl a₁ a₂ := by
   intro ⟨hd, hcd⟩
-  exact ⟨Disjoint.of_orderEmbedding e hd, Codisjoint.of_orderEmbedding e hcd⟩
+  exact ⟨Disjoint.of_orderEmbedding f hd, Codisjoint.of_orderEmbedding f hcd⟩
 
 end Disjoint
 

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -747,6 +747,43 @@ lemma coe_ofIsEmpty [IsEmpty α] : (ofIsEmpty : α ↪o β) = (isEmptyElim : α 
 
 end OrderEmbedding
 
+section Disjoint
+
+variable [PartialOrder α] [PartialOrder β] (f : OrderEmbedding α β)
+
+/-- If the images by an order embedding of two elements are disjoint, then they are themselves
+disjoint. -/
+lemma Disjoint.of_orderEmbedding [OrderBot α] [OrderBot β] {a₁ a₂ : α} :
+    Disjoint (f a₁) (f a₂) → Disjoint a₁ a₂ := by
+  simp_rw [Disjoint]
+  intro h x h₁ h₂
+  have hx₁ : f x ≤ f a₁ := (OrderEmbedding.le_iff_le f).mpr h₁
+  have hx₂ : f x ≤ f a₂ := (OrderEmbedding.le_iff_le f).mpr h₂
+  have hxb : f x ≤ ⊥ := h hx₁ hx₂
+  have hxeb : f x ≤ e ⊥ := le_trans hxb (OrderBot.bot_le (e ⊥))
+  exact (OrderEmbedding.le_iff_le e).mp hxeb
+
+/-- If the images by an order embedding of two elements are codisjoint, then they are themselves
+codisjoint. -/
+lemma Codisjoint.of_orderEmbedding [OrderTop α] [OrderTop β] (e : OrderEmbedding α β) {a₁ a₂ : α} :
+    Codisjoint (e a₁) (e a₂) → Codisjoint a₁ a₂ := by
+  simp_rw [Codisjoint]
+  intro h x h₁ h₂
+  have hx₁ : e a₁ ≤ e x := (OrderEmbedding.le_iff_le e).mpr h₁
+  have hx₂ : e a₂ ≤ e x := (OrderEmbedding.le_iff_le e).mpr h₂
+  have hxt : ⊤ ≤ e x := h hx₁ hx₂
+  have hxet : e ⊤ ≤ e x := le_trans (OrderTop.le_top (e ⊤)) hxt
+  exact (OrderEmbedding.le_iff_le e).mp hxet
+
+/-- If the images by an order embedding of two elements are complements, then they are themselves
+complements. -/
+lemma IsCompl.of_orderEmbedding [BoundedOrder α] [BoundedOrder β] (e : OrderEmbedding α β)
+    {a₁ a₂ : α} : IsCompl (e a₁) (e a₂) → IsCompl a₁ a₂ := by
+  intro ⟨hd, hcd⟩
+  exact ⟨Disjoint.of_orderEmbedding e hd, Codisjoint.of_orderEmbedding e hcd⟩
+
+end Disjoint
+
 section RelHom
 
 variable [PartialOrder α] [Preorder β]


### PR DESCRIPTION
This adds 3 lemmas which state that if you have an order embedding `f` such that `f a₁` and `f a₂` are disjoint/codisjoint/complements, then the same holds for `a₁` and `a₂`.

*Motivation*: For a project described [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Derivations.20on.20Lie.20algebras), I wanted to know that if two Lie ideals are complements as submodules, then they are complements as Lie ideals too. I realized that the correct level of generality was probably in the `Order.Hom.Basic` file.

*Caveats*: I am very much open to golfing/naming/redesign suggestions. Within the modified file, there was already a `Disjoint.map_orderIso` result, but it requires an `OrderIso` (not just a one-way embedding) and it requires a `SemilatticeInf` (whereas my version just uses `PartialOrder`).