### PR TITLE
[Merged by Bors] - fix: improve proofs in QuadraticModuleCat.Monoidal

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Basic.lean
@@ -181,6 +181,8 @@ instance ofUnique {X : Type v} [AddCommGroup X] [Module R X] [i : Unique X] : Un
   i
 #align Module.of_unique ModuleCat.ofUnique
 
+@[simp] theorem of_coe (X : ModuleCat R) : of R X = X := rfl
+
 -- Porting note: the simpNF linter complains, but we really need this?!
 -- @[simp, nolint simpNF]
 theorem coe_of (X : Type v) [AddCommGroup X] [Module R X] : (of R X : Type v) = X :=

--- a/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat.lean
@@ -30,6 +30,10 @@ open QuadraticForm
 instance : CoeSort (QuadraticModuleCat.{v} R) (Type v) :=
   ⟨(·.carrier)⟩
 
+@[simp] theorem moduleCat_of_toModuleCat (X : QuadraticModuleCat.{v} R) :
+    ModuleCat.of R X.toModuleCat = X.toModuleCat :=
+  rfl
+
 /-- The object in the category of quadratic R-modules associated to a quadratic R-module. -/
 @[simps form]
 def of {X : Type v} [AddCommGroup X] [Module R X] (Q : QuadraticForm R X) :

--- a/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat/Monoidal.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat/Monoidal.lean
@@ -68,6 +68,9 @@ instance : MonoidalCategoryStruct (QuadraticModuleCat.{u} R) where
   leftUnitor X := ofIso (tensorLId X.form)
   rightUnitor X := ofIso (tensorRId X.form)
 
+@[simp] theorem toModuleCat_tensor (X Y : QuadraticModuleCat.{u} R) :
+    (X ⊗ Y).toModuleCat = X.toModuleCat ⊗ Y.toModuleCat := rfl
+
 theorem forget₂_map_associator_hom (X Y Z : QuadraticModuleCat.{u} R) :
     (forget₂ (QuadraticModuleCat R) (ModuleCat R)).map (α_ X Y Z).hom =
       (α_ X.toModuleCat Y.toModuleCat Z.toModuleCat).hom := rfl
@@ -84,19 +87,25 @@ noncomputable instance instMonoidalCategory : MonoidalCategory (QuadraticModuleC
       leftUnitor_eq := fun X => by
         simp only [forget₂_obj, forget₂_map, Iso.refl_symm, Iso.trans_assoc, Iso.trans_hom,
           Iso.refl_hom, tensorIso_hom, MonoidalCategory.tensorHom_id]
-        erw [MonoidalCategory.id_whiskerRight, Category.id_comp, Category.id_comp]
+        dsimp only [toModuleCat_tensor, ModuleCat.of_coe]
+        erw [MonoidalCategory.id_whiskerRight]
+        simp
         rfl
       rightUnitor_eq := fun X => by
         simp only [forget₂_obj, forget₂_map, Iso.refl_symm, Iso.trans_assoc, Iso.trans_hom,
           Iso.refl_hom, tensorIso_hom, MonoidalCategory.id_tensorHom]
-        erw [MonoidalCategory.whiskerLeft_id, Category.id_comp, Category.id_comp]
+        dsimp only [toModuleCat_tensor, ModuleCat.of_coe]
+        erw [MonoidalCategory.whiskerLeft_id]
+        simp
         rfl
       associator_eq := fun X Y Z => by
         dsimp only [forget₂_obj, forget₂_map_associator_hom]
         simp only [eqToIso_refl, Iso.refl_trans, Iso.refl_symm, Iso.trans_hom, tensorIso_hom,
           Iso.refl_hom, MonoidalCategory.tensor_id]
-        erw [Category.id_comp, Category.comp_id, MonoidalCategory.tensor_id, Category.id_comp]
-        rfl }
+        dsimp only [toModuleCat_tensor, ModuleCat.of_coe]
+        rw [Category.id_comp, Category.id_comp, Category.comp_id, MonoidalCategory.tensor_id,
+          Category.id_comp] }
+
 
 variable (R) in
 /-- `forget₂ (QuadraticModuleCat R) (ModuleCat R)` as a monoidal functor. -/


### PR DESCRIPTION
These time out on nightly-testing, but are fixed by these changes.