### PR TITLE
[Merged by Bors] - Allow users of `field_simp` to increase `cfg.maxDischargeDepth`

### DIFF
--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -154,7 +154,7 @@ elab_rules : tactic
   -- The `field_simp` discharger relies on recursively calling the discharger.
   -- Prior to https://github.com/leanprover/lean4/pull/3523,
   -- the maxDischargeDepth wasn't actually being checked: now we have to set it higher.
-  let cfg := { cfg with maxDischargeDepth := 7 }
+  let cfg := { cfg with maxDischargeDepth := max cfg.maxDischargeDepth 7 }
   let loc := expandOptLocation (mkOptionalNode loc)
 
   let dis ← match dis with


### PR DESCRIPTION
Usage: `field_simp (config := { maxDischargeDepth := 11 })`. This was always valid syntax, but previously the `11` was ignored.

---
[Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/.60Field.60.20tactic/near/434001518)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
