### PR TITLE
[Merged by Bors] - feat: make `rank_mul_eq_left_of_isUnit_det` into an effective `simp` lemma

### DIFF
--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -100,6 +100,7 @@ theorem rank_of_isUnit [StrongRankCondition R] [DecidableEq n] (A : Matrix n n R
 #align matrix.rank_of_is_unit Matrix.rank_of_isUnit
 
 /-- Right multiplying by an invertible matrix does not change the rank -/
+@[simp]
 lemma rank_mul_eq_left_of_isUnit_det [DecidableEq n]
     (A : Matrix n n R) (B : Matrix m n R) (hA : IsUnit A.det) :
     (B * A).rank = B.rank := by
@@ -110,6 +111,7 @@ lemma rank_mul_eq_left_of_isUnit_det [DecidableEq n]
   exact ⟨(A⁻¹).mulVecLin v, by simp [mul_nonsing_inv _ hA]⟩
 
 /-- Left multiplying by an invertible matrix does not change the rank -/
+@[simp]
 lemma rank_mul_eq_right_of_isUnit_det [Fintype m] [DecidableEq m]
     (A : Matrix m m R) (B : Matrix m n R) (hA : IsUnit A.det) :
     (A * B).rank = B.rank := by
@@ -118,16 +120,6 @@ lemma rank_mul_eq_right_of_isUnit_det [Fintype m] [DecidableEq m]
     convert hA; rw [← LinearEquiv.eq_symm_apply]; rfl
   have hAB : mulVecLin (A * B) = (LinearEquiv.ofIsUnitDet hA).comp (mulVecLin B) := by ext; simp
   rw [rank, rank, hAB, LinearMap.range_comp, LinearEquiv.finrank_map_eq]
-
-@[simp]
-theorem rank_mul_units [DecidableEq n] (A : (Matrix n n R)ˣ) (B : Matrix m n R) :
-    rank (B * (A : Matrix n n R)) = rank B :=
-  rank_mul_eq_left_of_isUnit_det _ _ <| A.isUnit.map detMonoidHom
-
-@[simp]
-theorem rank_units_mul [Fintype m] [DecidableEq n] (A : (Matrix n n R)ˣ) (B : Matrix n m R) :
-    rank ((A : Matrix n n R) * B) = rank B :=
-  rank_mul_eq_right_of_isUnit_det _ _ <| A.isUnit.map detMonoidHom
 
 /-- Taking a subset of the rows and permuting the columns reduces the rank. -/
 theorem rank_submatrix_le [StrongRankCondition R] [Fintype m] (f : n → m) (e : n ≃ m)

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -119,7 +119,6 @@ lemma rank_mul_eq_right_of_isUnit_det [Fintype m] [DecidableEq m]
   have hAB : mulVecLin (A * B) = (LinearEquiv.ofIsUnitDet hA).comp (mulVecLin B) := by ext; simp
   rw [rank, rank, hAB, LinearMap.range_comp, LinearEquiv.finrank_map_eq]
 
-
 @[simp]
 theorem rank_mul_units [DecidableEq n] (A : (Matrix n n R)ˣ) (B : Matrix m n R) :
     rank (B * (A : Matrix n n R)) = rank B :=

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -119,6 +119,18 @@ lemma rank_mul_eq_right_of_isUnit_det [Fintype m] [DecidableEq m]
   have hAB : mulVecLin (A * B) = (LinearEquiv.ofIsUnitDet hA).comp (mulVecLin B) := by ext; simp
   rw [rank, rank, hAB, LinearMap.range_comp, LinearEquiv.finrank_map_eq]
 
+variable {m n R : Type*} [Fintype n] [CommRing R] [DecidableEq n]
+
+@[simp]
+theorem rank_mul_units (A : (Matrix n n R)ˣ) (B : Matrix m n R) :
+    rank (B * (A : Matrix n n R)) = rank B :=
+  rank_mul_eq_left_of_isUnit_det _ _ <| A.isUnit.map detMonoidHom
+
+@[simp]
+theorem rank_units_mul [Fintype m] (A : (Matrix n n R)ˣ) (B : Matrix n m R) :
+    rank ((A : Matrix n n R) * B) = rank B :=
+  rank_mul_eq_right_of_isUnit_det _ _ <| A.isUnit.map detMonoidHom
+
 /-- Taking a subset of the rows and permuting the columns reduces the rank. -/
 theorem rank_submatrix_le [StrongRankCondition R] [Fintype m] (f : n → m) (e : n ≃ m)
     (A : Matrix m m R) : rank (A.submatrix f e) ≤ rank A := by

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -119,15 +119,14 @@ lemma rank_mul_eq_right_of_isUnit_det [Fintype m] [DecidableEq m]
   have hAB : mulVecLin (A * B) = (LinearEquiv.ofIsUnitDet hA).comp (mulVecLin B) := by ext; simp
   rw [rank, rank, hAB, LinearMap.range_comp, LinearEquiv.finrank_map_eq]
 
-variable {m n R : Type*} [Fintype n] [CommRing R] [DecidableEq n]
 
 @[simp]
-theorem rank_mul_units (A : (Matrix n n R)ˣ) (B : Matrix m n R) :
+theorem rank_mul_units [DecidableEq n] (A : (Matrix n n R)ˣ) (B : Matrix m n R) :
     rank (B * (A : Matrix n n R)) = rank B :=
   rank_mul_eq_left_of_isUnit_det _ _ <| A.isUnit.map detMonoidHom
 
 @[simp]
-theorem rank_units_mul [Fintype m] (A : (Matrix n n R)ˣ) (B : Matrix n m R) :
+theorem rank_units_mul [Fintype m] [DecidableEq n] (A : (Matrix n n R)ˣ) (B : Matrix n m R) :
     rank ((A : Matrix n n R) * B) = rank B :=
   rank_mul_eq_right_of_isUnit_det _ _ <| A.isUnit.map detMonoidHom
 

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -152,6 +152,10 @@ theorem isUnit_iff_isUnit_det : IsUnit A ↔ IsUnit A.det := by
   simp only [← nonempty_invertible_iff_isUnit, (invertibleEquivDetInvertible A).nonempty_congr]
 #align matrix.is_unit_iff_is_unit_det Matrix.isUnit_iff_isUnit_det
 
+@[simp]
+theorem isUnits_det_units (A : (Matrix n n α)ˣ) : IsUnit (A : Matrix n n α).det :=
+  isUnit_iff_isUnit_det _ |>.mp A.isUnit
+
 /-! #### Variants of the statements above with `IsUnit`-/
 
 

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -20,24 +20,7 @@ the spectral theorem for linear maps (`LinearMap.IsSymmetric.eigenvectorBasis_ap
 spectral theorem, diagonalization theorem
 
 -/
-section RankMulUnitaryTheorems
 
-variable {m n R : Type*} [Fintype n] [CommRing R] [StarRing R] [DecidableEq n]
-namespace Matrix
-
-@[simp]
-theorem rank_mul_unitary (A : unitaryGroup n R) (B : Matrix m n R) :
-    rank (B * (A : Matrix n n R)) = rank B :=
-  rank_mul_units (unitary.toUnits A) _
-
-@[simp]
-theorem rank_unitary_mul [Fintype m] (A : unitaryGroup n R)
-    (B : Matrix n m R) : rank ((A : Matrix n n R) * B) = rank B :=
-  rank_units_mul (unitary.toUnits A) _
-
-end Matrix
-
-end RankMulUnitaryTheorems
 
 namespace Matrix
 

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -39,6 +39,7 @@ theorem rank_mul_unitary [Fintype m] (A : unitaryGroup n R)
 end Matrix
 
 end RankMulUnitaryTheorems
+
 namespace Matrix
 
 variable {𝕜 : Type*} [RCLike 𝕜] {n : Type*} [Fintype n]

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -26,12 +26,12 @@ variable {m n R : Type*} [Fintype n] [CommRing R] [StarRing R] [DecidableEq n]
 namespace Matrix
 
 @[simp]
-theorem rank_unitary_mul (A : unitaryGroup n R) (B : Matrix m n R) :
+theorem rank_mul_unitary (A : unitaryGroup n R) (B : Matrix m n R) :
     rank (B * (A : Matrix n n R)) = rank B :=
   rank_mul_units (unitary.toUnits A) _
 
 @[simp]
-theorem rank_mul_unitary [Fintype m] (A : unitaryGroup n R)
+theorem rank_unitary_mul [Fintype m] (A : unitaryGroup n R)
     (B : Matrix n m R) : rank ((A : Matrix n n R) * B) = rank B :=
   rank_units_mul (unitary.toUnits A) _
 

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -148,6 +148,19 @@ lemma spectral_theorem' :
   simpa [ ← Matrix.mul_assoc, hA.eigenvectorMatrix_mul_inv, Matrix.one_mul] using
     congr_arg (hA.eigenvectorMatrix * ·) hA.spectral_theorem
 
+
+@[simp]
+theorem rank_unitary_mul {m n R : Type*} [Fintype n] [CommRing R] [DecidableEq n] [StarRing R]
+    (A : unitaryGroup n R) (B : Matrix m n R) :
+    rank (B * (A : Matrix n n R)) = rank B :=
+  rank_mul_units (unitary.toUnits A) _
+
+@[simp]
+theorem rank_mul_unitary {m n R : Type*} [Fintype n] [CommRing R] [DecidableEq n][Fintype m]
+    [StarRing R] (A : unitaryGroup n R)(B : Matrix n m R) :
+    rank ((A : Matrix n n R) * B) = rank B :=
+  rank_units_mul (unitary.toUnits A) _
+
 /-- rank of a hermitian matrix is the rank of after diagonalization by the eigenvector matrix -/
 lemma rank_eq_rank_diagonal : A.rank = (Matrix.diagonal hA.eigenvalues).rank := by
   conv_lhs => rw [hA.spectral_theorem']

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -41,16 +41,16 @@ end Matrix
 end RankMulUnitaryTheorems
 namespace Matrix
 
-variable {m n : Type*} {𝕜 : Type*} [RCLike 𝕜] [Fintype n]
-         {A : Matrix n n 𝕜}
+variable {𝕜 : Type*} [RCLike 𝕜] {n : Type*} [Fintype n]
+variable {A : Matrix n n 𝕜}
 
 open scoped BigOperators
+
 namespace IsHermitian
 
 section DecidableEq
 
 variable [DecidableEq n]
-
 variable (hA : A.IsHermitian)
 
 /-- The eigenvalues of a hermitian matrix, indexed by `Fin (Fintype.card n)` where `n` is the index

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -45,9 +45,8 @@ theorem rank_unitary_mul (A : unitaryGroup n R) (B : Matrix m n R) :
   rank_mul_units (unitary.toUnits A) _
 
 @[simp]
-theorem rank_mul_unitary [CommRing R][Fintype m]
-    [StarRing R] (A : unitaryGroup n R)(B : Matrix n m R) :
-    rank ((A : Matrix n n R) * B) = rank B :=
+theorem rank_mul_unitary [CommRing R] [Fintype m] [StarRing R] (A : unitaryGroup n R)
+    (B : Matrix n m R) : rank ((A : Matrix n n R) * B) = rank B :=
   rank_units_mul (unitary.toUnits A) _
 
 end RankMulUnitaryTheorems

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -22,8 +22,7 @@ spectral theorem, diagonalization theorem
 -/
 section RankMulUnitaryTheorems
 
-variable {m n R : Type*} {𝕜 : Type*} [RCLike 𝕜] [Fintype n]
-         {A : Matrix n n 𝕜} [CommRing R] [StarRing R][DecidableEq n]
+variable {m n R : Type*} [Fintype n] [CommRing R] [StarRing R] [DecidableEq n]
 namespace Matrix
 
 @[simp]

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -20,22 +20,11 @@ the spectral theorem for linear maps (`LinearMap.IsSymmetric.eigenvectorBasis_ap
 spectral theorem, diagonalization theorem
 
 -/
-
-namespace Matrix
-
-variable {m n : Type*} {𝕜 : Type*} [RCLike 𝕜] [Fintype n]
-         {A : Matrix n n 𝕜}
-
-open scoped BigOperators
-namespace IsHermitian
-
-section DecidableEq
-
-variable [DecidableEq n]
-
 section RankMulUnitaryTheorems
 
-variable {R : Type*}[CommRing R] [StarRing R]
+variable {m n R : Type*} {𝕜 : Type*} [RCLike 𝕜] [Fintype n]
+         {A : Matrix n n 𝕜} [CommRing R] [StarRing R][DecidableEq n]
+namespace Matrix
 
 @[simp]
 theorem rank_unitary_mul (A : unitaryGroup n R) (B : Matrix m n R) :
@@ -47,7 +36,20 @@ theorem rank_mul_unitary [Fintype m] (A : unitaryGroup n R)
     (B : Matrix n m R) : rank ((A : Matrix n n R) * B) = rank B :=
   rank_units_mul (unitary.toUnits A) _
 
+end Matrix
+
 end RankMulUnitaryTheorems
+namespace Matrix
+
+variable {m n : Type*} {𝕜 : Type*} [RCLike 𝕜] [Fintype n]
+         {A : Matrix n n 𝕜}
+
+open scoped BigOperators
+namespace IsHermitian
+
+section DecidableEq
+
+variable [DecidableEq n]
 
 variable (hA : A.IsHermitian)
 

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -165,7 +165,6 @@ lemma spectral_theorem' :
   simpa [ ← Matrix.mul_assoc, hA.eigenvectorMatrix_mul_inv, Matrix.one_mul] using
     congr_arg (hA.eigenvectorMatrix * ·) hA.spectral_theorem
 
-
 /-- rank of a hermitian matrix is the rank of after diagonalization by the eigenvector matrix -/
 lemma rank_eq_rank_diagonal : A.rank = (Matrix.diagonal hA.eigenvalues).rank := by
   conv_lhs => rw [hA.spectral_theorem']

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -40,8 +40,7 @@ section RankMulUnitaryTheorems
 variable {m R : Type*} [CommRing R] [StarRing R]
 
 @[simp]
-theorem rank_unitary_mul
-    (A : unitaryGroup n R) (B : Matrix m n R) :
+theorem rank_unitary_mul (A : unitaryGroup n R) (B : Matrix m n R) :
     rank (B * (A : Matrix n n R)) = rank B :=
   rank_mul_units (unitary.toUnits A) _
 

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -45,7 +45,7 @@ theorem rank_unitary_mul (A : unitaryGroup n R) (B : Matrix m n R) :
   rank_mul_units (unitary.toUnits A) _
 
 @[simp]
-theorem rank_mul_unitary [CommRing R] [Fintype m] [StarRing R] (A : unitaryGroup n R)
+theorem rank_mul_unitary [Fintype m] (A : unitaryGroup n R)
     (B : Matrix n m R) : rank ((A : Matrix n n R) * B) = rank B :=
   rank_units_mul (unitary.toUnits A) _
 

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -34,6 +34,25 @@ namespace IsHermitian
 section DecidableEq
 
 variable [DecidableEq n]
+
+section RankMulUnitaryTheorems
+
+variable {m R : Type*} [CommRing R] [StarRing R]
+
+@[simp]
+theorem rank_unitary_mul
+    (A : unitaryGroup n R) (B : Matrix m n R) :
+    rank (B * (A : Matrix n n R)) = rank B :=
+  rank_mul_units (unitary.toUnits A) _
+
+@[simp]
+theorem rank_mul_unitary [CommRing R][Fintype m]
+    [StarRing R] (A : unitaryGroup n R)(B : Matrix n m R) :
+    rank ((A : Matrix n n R) * B) = rank B :=
+  rank_units_mul (unitary.toUnits A) _
+
+end RankMulUnitaryTheorems
+
 variable (hA : A.IsHermitian)
 
 /-- The eigenvalues of a hermitian matrix, indexed by `Fin (Fintype.card n)` where `n` is the index
@@ -148,18 +167,6 @@ lemma spectral_theorem' :
   simpa [ ← Matrix.mul_assoc, hA.eigenvectorMatrix_mul_inv, Matrix.one_mul] using
     congr_arg (hA.eigenvectorMatrix * ·) hA.spectral_theorem
 
-
-@[simp]
-theorem rank_unitary_mul {m n R : Type*} [Fintype n] [CommRing R] [DecidableEq n] [StarRing R]
-    (A : unitaryGroup n R) (B : Matrix m n R) :
-    rank (B * (A : Matrix n n R)) = rank B :=
-  rank_mul_units (unitary.toUnits A) _
-
-@[simp]
-theorem rank_mul_unitary {m n R : Type*} [Fintype n] [CommRing R] [DecidableEq n][Fintype m]
-    [StarRing R] (A : unitaryGroup n R)(B : Matrix n m R) :
-    rank ((A : Matrix n n R) * B) = rank B :=
-  rank_units_mul (unitary.toUnits A) _
 
 /-- rank of a hermitian matrix is the rank of after diagonalization by the eigenvector matrix -/
 lemma rank_eq_rank_diagonal : A.rank = (Matrix.diagonal hA.eigenvalues).rank := by

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -21,14 +21,12 @@ spectral theorem, diagonalization theorem
 
 -/
 
-
 namespace Matrix
 
-variable {𝕜 : Type*} [RCLike 𝕜] {n : Type*} [Fintype n]
-variable {A : Matrix n n 𝕜}
+variable {m n : Type*} {𝕜 : Type*} [RCLike 𝕜] [Fintype n]
+         {A : Matrix n n 𝕜}
 
 open scoped BigOperators
-
 namespace IsHermitian
 
 section DecidableEq
@@ -37,7 +35,7 @@ variable [DecidableEq n]
 
 section RankMulUnitaryTheorems
 
-variable {m R : Type*} [CommRing R] [StarRing R]
+variable {R : Type*}[CommRing R] [StarRing R]
 
 @[simp]
 theorem rank_unitary_mul (A : unitaryGroup n R) (B : Matrix m n R) :

--- a/Mathlib/LinearAlgebra/UnitaryGroup.lean
+++ b/Mathlib/LinearAlgebra/UnitaryGroup.lean
@@ -111,6 +111,10 @@ theorem star_mul_self (A : unitaryGroup n α) : star A.1 * A.1 = 1 :=
   A.2.1
 #align matrix.unitary_group.star_mul_self Matrix.UnitaryGroup.star_mul_self
 
+@[simp]
+theorem det_isUnit (A : unitaryGroup n α) : IsUnit (A : Matrix n n α).det :=
+  isUnit_iff_isUnit_det _ |>.mp <| (unitary.toUnits A).isUnit
+
 section CoeLemmas
 
 variable (A B : unitaryGroup n α)


### PR DESCRIPTION
These theorems give that if A is a unit, or a unitary, in the n x n matrices over a commutative ring R, and B is an m x n matrix over R, that multiplying B by A on the left or right doesn't change the rank of B. To facilitate this, added `isUnits_det_units` and `det_isUnit` lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
