### PR TITLE
[Merged by Bors] - feat: Add `mixedEmbedding.norm`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -266,11 +266,21 @@ protected def norm  : (E K) →*₀ ℝ where
   map_mul' _ _ := by simp only [Prod.fst_mul, Pi.mul_apply, norm_mul, Real.norm_eq_abs,
       Finset.prod_mul_distrib, Prod.snd_mul, Complex.norm_eq_abs, mul_pow]; ring
 
+protected theorem norm_zero :
+    mixedEmbedding.norm (0 : E K) = 0 := mixedEmbedding.norm.map_zero'
+
+protected theorem norm_one :
+    mixedEmbedding.norm (1 : E K) = 1 := mixedEmbedding.norm.map_one'
+
+protected theorem norm_zero_iff {x : E K} :
+    mixedEmbedding.norm x = 0 ↔ (∃ w, x.1 w = 0) ∨ (∃ w, x.2 w = 0) := by
+  simp_rw [mixedEmbedding.norm, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, mul_eq_zero,
+    Finset.prod_eq_zero_iff, Finset.mem_univ, true_and, pow_eq_zero_iff two_ne_zero, norm_eq_zero]
+
 protected theorem norm_ne_zero_iff {x : E K} :
     mixedEmbedding.norm x ≠ 0 ↔ (∀ w, x.1 w ≠ 0) ∧ (∀ w, x.2 w ≠ 0) := by
-  simp_rw [mixedEmbedding.norm, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, mul_ne_zero_iff,
-    Finset.prod_ne_zero_iff, Finset.mem_univ, forall_true_left, pow_ne_zero_iff two_ne_zero,
-    norm_ne_zero_iff]
+  rw [← not_iff_not]
+  simp_rw [ne_eq, mixedEmbedding.norm_zero_iff, not_and_or, not_forall, not_not]
 
 theorem norm_real (c : ℝ) :
     mixedEmbedding.norm ((fun _ ↦ c, fun _ ↦ c) : (E K)) = |c| ^ finrank ℚ K := by

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -272,7 +272,7 @@ protected theorem norm_ne_zero_iff {x : E K} :
     Finset.prod_ne_zero_iff, Finset.mem_univ, forall_true_left, pow_ne_zero_iff two_ne_zero,
     norm_ne_zero_iff]
 
-theorem norm_const (c : ℝ) :
+theorem norm_real (c : ℝ) :
     mixedEmbedding.norm ((fun _ ↦ c, fun _ ↦ c) : (E K)) = |c| ^ finrank ℚ K := by
   simp_rw [mixedEmbedding.norm, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, Real.norm_eq_abs,
     Complex.norm_eq_abs, Complex.abs_ofReal, Finset.prod_const, ← pow_mul,
@@ -280,14 +280,14 @@ theorem norm_const (c : ℝ) :
 
 theorem norm_smul (c : ℝ) (x : E K) :
     mixedEmbedding.norm (c • x) = |c| ^ finrank ℚ K * (mixedEmbedding.norm x) := by
-  rw [show c • x = ((fun _ ↦ c, fun _ ↦ c) : (E K)) * x by rfl, map_mul, norm_const]
+  rw [show c • x = ((fun _ ↦ c, fun _ ↦ c) : (E K)) * x by rfl, map_mul, norm_real]
 
 @[simp]
 theorem norm_eq_norm (x : K) :
     mixedEmbedding.norm (mixedEmbedding K x) = |Algebra.norm ℚ x| := by
   simp_rw [← prod_eq_abs_norm, mixedEmbedding.norm, mixedEmbedding, RingHom.prod_apply,
     MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, Pi.ringHom_apply, norm_embedding_eq,
-    norm_embedding_eq_of_isReal]
+    norm_embedding_of_isReal]
   rw [← Fintype.prod_subtype_mul_prod_subtype (fun w : InfinitePlace K ↦ IsReal w)]
   congr 1
   · exact Finset.prod_congr rfl (fun w _ ↦ by rw [mult, if_pos w.prop, pow_one])

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -249,7 +249,7 @@ open BigOperators
 
 variable [NumberField K] {K}
 
-/-- The norm of `x` is `∏ w real, ‖x‖_w, ∏ w complex, ‖x‖_w ^ 2`. It is defined such that
+/-- The norm of `x` is `∏ w real, ‖x‖_w * ∏ w complex, ‖x‖_w ^ 2`. It is defined such that
 the norm of `mixedEmbedding K a` for `a : K` is equal to the absolute value of the norm of `a`
 over `ℚ`, see `norm_eq_norm`. -/
 protected def norm  : (E K) →*₀ ℝ where
@@ -265,12 +265,6 @@ protected def norm  : (E K) →*₀ ℝ where
     exact ne_of_gt finrank_pos this
   map_mul' _ _ := by simp only [Prod.fst_mul, Pi.mul_apply, norm_mul, Real.norm_eq_abs,
       Finset.prod_mul_distrib, Prod.snd_mul, Complex.norm_eq_abs, mul_pow]; ring
-
-protected theorem norm_zero :
-    mixedEmbedding.norm (0 : E K) = 0 := mixedEmbedding.norm.map_zero'
-
-protected theorem norm_one :
-    mixedEmbedding.norm (1 : E K) = 1 := mixedEmbedding.norm.map_one'
 
 protected theorem norm_eq_zero_iff {x : E K} :
     mixedEmbedding.norm x = 0 ↔ (∃ w, x.1 w = 0) ∨ (∃ w, x.2 w = 0) := by

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -241,9 +241,73 @@ theorem disjoint_span_commMap_ker [NumberField K] :
 
 end commMap
 
+noncomputable section norm
+
+open scoped Classical
+
+open BigOperators
+
+variable [NumberField K] {K}
+
+/-- The norm of `x` is `∏ w real, ‖x‖_w, ∏ w complex, ‖x‖_w ^ 2`. It is defined such that
+the norm of `mixedEmbedding K a` for `a : K` is equal to the absolute value of the norm of `a`
+over `ℚ`, see `norm_eq_norm`. -/
+protected def norm  : (E K) →*₀ ℝ where
+  toFun := fun x ↦ (∏ w, ‖x.1 w‖) * ∏ w, ‖x.2 w‖ ^ 2
+  map_one' := by simp only [Prod.fst_one, Pi.one_apply, norm_one, Finset.prod_const_one,
+    Prod.snd_one, one_pow, mul_one]
+  map_zero' := by
+    simp_rw [Prod.fst_zero, Prod.snd_zero, Pi.zero_apply, norm_zero, zero_pow (two_ne_zero),
+      mul_eq_zero, Finset.prod_const, pow_eq_zero_iff', true_and, Finset.card_univ]
+    by_contra!
+    have : finrank ℚ K = 0 := by
+      rw [← card_add_two_mul_card_eq_rank, NrRealPlaces, NrComplexPlaces, this.1, this.2]
+    exact ne_of_gt finrank_pos this
+  map_mul' _ _ := by simp only [Prod.fst_mul, Pi.mul_apply, norm_mul, Real.norm_eq_abs,
+      Finset.prod_mul_distrib, Prod.snd_mul, Complex.norm_eq_abs, mul_pow]; ring
+
+protected theorem norm_ne_zero_iff {x : E K} :
+    mixedEmbedding.norm x ≠ 0 ↔ (∀ w, x.1 w ≠ 0) ∧ (∀ w, x.2 w ≠ 0) := by
+  simp_rw [mixedEmbedding.norm, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, mul_ne_zero_iff,
+    Finset.prod_ne_zero_iff, Finset.mem_univ, forall_true_left, pow_ne_zero_iff two_ne_zero,
+    norm_ne_zero_iff]
+
+theorem norm_const (c : ℝ) :
+    mixedEmbedding.norm ((fun _ ↦ c, fun _ ↦ c) : (E K)) = |c| ^ finrank ℚ K := by
+  simp_rw [mixedEmbedding.norm, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, Real.norm_eq_abs,
+    Complex.norm_eq_abs, Complex.abs_ofReal, Finset.prod_const, ← pow_mul,
+    ← card_add_two_mul_card_eq_rank, Finset.card_univ, pow_add]
+
+theorem norm_smul (c : ℝ) (x : E K) :
+    mixedEmbedding.norm (c • x) = |c| ^ finrank ℚ K * (mixedEmbedding.norm x) := by
+  rw [show c • x = ((fun _ ↦ c, fun _ ↦ c) : (E K)) * x by rfl, map_mul, norm_const]
+
+@[simp]
+theorem norm_eq_norm (x : K) :
+    mixedEmbedding.norm (mixedEmbedding K x) = |Algebra.norm ℚ x| := by
+  simp_rw [← prod_eq_abs_norm, mixedEmbedding.norm, mixedEmbedding, RingHom.prod_apply,
+    MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, Pi.ringHom_apply, norm_embedding_eq,
+    norm_embedding_eq_of_isReal]
+  rw [← Fintype.prod_subtype_mul_prod_subtype (fun w : InfinitePlace K ↦ IsReal w)]
+  congr 1
+  · exact Finset.prod_congr rfl (fun w _ ↦ by rw [mult, if_pos w.prop, pow_one])
+  · refine (Fintype.prod_equiv (Equiv.subtypeEquivRight ?_) _ _ (fun w ↦ ?_)).symm
+    · exact fun _ ↦ not_isReal_iff_isComplex
+    · rw [Equiv.subtypeEquivRight_apply_coe, mult, if_neg w.prop]
+
+theorem norm_ne_zero {x : E K} (hx : x ∈ Set.range (mixedEmbedding K)) (hx' : x ≠ 0) :
+    mixedEmbedding.norm x ≠ 0 := by
+  obtain ⟨a, rfl⟩ := hx
+  rw [norm_eq_norm, Rat.cast_abs, ne_eq, abs_eq_zero, Rat.cast_eq_zero, Algebra.norm_eq_zero_iff]
+  contrapose! hx'
+  rw [hx', map_zero]
+
+end norm
+
 noncomputable section stdBasis
 
 open scoped Classical
+
 open Complex MeasureTheory MeasureTheory.Measure Zspan Matrix BigOperators
   ComplexConjugate
 

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -272,7 +272,7 @@ protected theorem norm_zero :
 protected theorem norm_one :
     mixedEmbedding.norm (1 : E K) = 1 := mixedEmbedding.norm.map_one'
 
-protected theorem norm_zero_iff {x : E K} :
+protected theorem norm_eq_zero_iff {x : E K} :
     mixedEmbedding.norm x = 0 ↔ (∃ w, x.1 w = 0) ∨ (∃ w, x.2 w = 0) := by
   simp_rw [mixedEmbedding.norm, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, mul_eq_zero,
     Finset.prod_eq_zero_iff, Finset.mem_univ, true_and, pow_eq_zero_iff two_ne_zero, norm_eq_zero]
@@ -280,7 +280,7 @@ protected theorem norm_zero_iff {x : E K} :
 protected theorem norm_ne_zero_iff {x : E K} :
     mixedEmbedding.norm x ≠ 0 ↔ (∀ w, x.1 w ≠ 0) ∧ (∀ w, x.2 w ≠ 0) := by
   rw [← not_iff_not]
-  simp_rw [ne_eq, mixedEmbedding.norm_zero_iff, not_and_or, not_forall, not_not]
+  simp_rw [ne_eq, mixedEmbedding.norm_eq_zero_iff, not_and_or, not_forall, not_not]
 
 theorem norm_real (c : ℝ) :
     mixedEmbedding.norm ((fun _ ↦ c, fun _ ↦ c) : (E K)) = |c| ^ finrank ℚ K := by
@@ -305,12 +305,11 @@ theorem norm_eq_norm (x : K) :
     · exact fun _ ↦ not_isReal_iff_isComplex
     · rw [Equiv.subtypeEquivRight_apply_coe, mult, if_neg w.prop]
 
-theorem norm_ne_zero {x : E K} (hx : x ∈ Set.range (mixedEmbedding K)) (hx' : x ≠ 0) :
-    mixedEmbedding.norm x ≠ 0 := by
+theorem norm_eq_zero_iff' {x : E K} (hx : x ∈ Set.range (mixedEmbedding K)) :
+    mixedEmbedding.norm x = 0 ↔ x = 0 := by
   obtain ⟨a, rfl⟩ := hx
-  rw [norm_eq_norm, Rat.cast_abs, ne_eq, abs_eq_zero, Rat.cast_eq_zero, Algebra.norm_eq_zero_iff]
-  contrapose! hx'
-  rw [hx', map_zero]
+  rw [norm_eq_norm, Rat.cast_abs, abs_eq_zero, Rat.cast_eq_zero, Algebra.norm_eq_zero_iff,
+    map_eq_zero]
 
 end norm
 

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -431,6 +431,11 @@ theorem embedding_of_isReal_apply {w : InfinitePlace K} (hw : IsReal w) (x : K) 
   ComplexEmbedding.IsReal.coe_embedding_apply (isReal_iff.mp hw) x
 
 @[simp]
+theorem norm_embedding_eq_of_isReal {w : InfinitePlace K} (hw : IsReal w) (x : K) :
+    ‖embedding_of_isReal hw x‖ = w x := by
+  rw [← norm_embedding_eq, ← embedding_of_isReal_apply hw, Complex.norm_real]
+
+@[simp]
 theorem isReal_of_mk_isReal {φ : K →+* ℂ} (h : IsReal (mk φ)) :
     ComplexEmbedding.IsReal φ := by
   contrapose! h

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -430,7 +430,7 @@ theorem embedding_of_isReal_apply {w : InfinitePlace K} (hw : IsReal w) (x : K) 
     ((embedding_of_isReal hw) x : ℂ) = (embedding w) x :=
   ComplexEmbedding.IsReal.coe_embedding_apply (isReal_iff.mp hw) x
 
-theorem norm_embedding_eq_of_isReal {w : InfinitePlace K} (hw : IsReal w) (x : K) :
+theorem norm_embedding_of_isReal {w : InfinitePlace K} (hw : IsReal w) (x : K) :
     ‖embedding_of_isReal hw x‖ = w x := by
   rw [← norm_embedding_eq, ← embedding_of_isReal_apply hw, Complex.norm_real]
 

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -430,7 +430,6 @@ theorem embedding_of_isReal_apply {w : InfinitePlace K} (hw : IsReal w) (x : K) 
     ((embedding_of_isReal hw) x : ℂ) = (embedding w) x :=
   ComplexEmbedding.IsReal.coe_embedding_apply (isReal_iff.mp hw) x
 
-@[simp]
 theorem norm_embedding_eq_of_isReal {w : InfinitePlace K} (hw : IsReal w) (x : K) :
     ‖embedding_of_isReal hw x‖ = w x := by
   rw [← norm_embedding_eq, ← embedding_of_isReal_apply hw, Complex.norm_real]


### PR DESCRIPTION
Define a norm of the mixed space `ℝ^r₁ × ℂ^r₂` associated to a number field `K` of signature `(r₁, r₂)`. The norm is defined such that the norm of `mixedEmbedding K a` for `a : K` is equal to the absolute value of the norm of `a`
over `ℚ`. 

This norm will be used in a future PR about the quotient of the mixed space by the action of the units of `K`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
