### PR TITLE
[Merged by Bors] - fix: make congruence lemma generator handle dependence

### DIFF
--- a/Mathlib/Lean/Meta/CongrTheorems.lean
+++ b/Mathlib/Lean/Meta/CongrTheorems.lean
@@ -36,7 +36,7 @@ where
   - `cthm` is the original `CongrTheorem`, modified only after visiting every argument.
   - `type` is type of the congruence theorem, after all the parameters so far have been applied.
   - `argKinds` is the list of `CongrArgKind`s, which this function recurses on.
-  - `argKings'` is the accumulated array of `CongrArgKind`s, which is the original array but
+  - `argKinds'` is the accumulated array of `CongrArgKind`s, which is the original array but
     with some kinds replaced by `.subsingletonInst`.
   - `params` is the *new* list of parameters, as fvars that need to be abstracted at the end.
   - `args` is the list of arguments (fvars) to supply to `cthm.proof` before abstracting `params`.

--- a/Mathlib/Lean/Meta/CongrTheorems.lean
+++ b/Mathlib/Lean/Meta/CongrTheorems.lean
@@ -63,7 +63,7 @@ where
           -- See if we can prove `eq` from previous parameters.
           let g := (← mkFreshExprMVar (← inferType eq)).mvarId!
           let g ← g.clear eq.fvarId!
-          if (← observing? <| prove g params).isSome then
+          if (← observing? <| prove g args).isSome then
             let eqPf ← instantiateMVars (.mvar g)
             process cthm type' argKinds (argKinds'.push .subsingletonInst)
               (params := params ++ #[x, y]) (args := args ++ params')

--- a/test/TermCongr.lean
+++ b/test/TermCongr.lean
@@ -119,6 +119,20 @@ example (f g : Nat → Nat → Prop) (h : f = g) :
     (∀ x, ∃ y, f x y) ↔ (∀ x, ∃ y, g x y) :=
   congr(∀ _, ∃ _, $(by rw [h]))
 
+namespace SubsingletonDependence
+/-!
+The congruence theorem generator had a bug that leaked fvars.
+Reported at https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/what.20the.20heq.2C.20PosSemidef/near/434202080
+-/
+
+def f {α : Type} [DecidableEq α] (n : α) (_ : n = n) : α := n
+
+lemma test (n n' : Nat) (h : n = n') (hn : n = n) (hn' : n' = n') :
+    f n hn = f n' hn' := by
+  exact congr(f $h ‹_›)
+
+end SubsingletonDependence
+
 section limitations
 /-! Tests to document current limitations. -/
 

--- a/test/TermCongr.lean
+++ b/test/TermCongr.lean
@@ -129,7 +129,8 @@ def f {α : Type} [DecidableEq α] (n : α) (_ : n = n) : α := n
 
 lemma test (n n' : Nat) (h : n = n') (hn : n = n) (hn' : n' = n') :
     f n hn = f n' hn' := by
-  exact congr(f $h ‹_›)
+  have := congr(f $h ‹_›) -- without expected type
+  exact congr(f $h _) -- with expected type
 
 end SubsingletonDependence
 


### PR DESCRIPTION
There was a bug in the congruence lemma generator used by `congr(...)` and `congrm` that would create congruence lemmas with unbound free variables if there were arguments after subsingleton instances.

Reported by Jireh Loreaux on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/what.20the.20heq.2C.20PosSemidef/near/434202080)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
