### PR TITLE
[Merged by Bors] - chore: remove last use of classical!

### DIFF
--- a/Mathlib/Data/String/Lemmas.lean
+++ b/Mathlib/Data/String/Lemmas.lean
@@ -12,12 +12,6 @@ namespace String
 lemma congr_append : ∀ (a b : String), a ++ b = String.mk (a.data ++ b.data)
   | ⟨_⟩, ⟨_⟩ => rfl
 
-@[simp] lemma length_append : ∀ (as bs : String), (as ++ bs).length = as.length + bs.length
-  | ⟨as⟩, ⟨bs⟩ => by
-    rw [congr_append]
-    simp only [String.length]
-    exact List.length_append as bs
-
 @[simp] lemma length_replicate (n : ℕ) (c : Char) : (replicate n c).length = n := by
   simp only [String.length, String.replicate, List.length_replicate]
 

--- a/Mathlib/Tactic/Tauto.lean
+++ b/Mathlib/Tactic/Tauto.lean
@@ -15,7 +15,7 @@ The `tauto` tactic.
 
 namespace Mathlib.Tactic.Tauto
 
-open Lean Elab.Tactic Parser.Tactic Lean.Meta MVarId
+open Lean Elab.Tactic Parser.Tactic Lean.Meta MVarId Std.Tactic
 open Qq
 
 initialize registerTraceClass `tauto
@@ -186,12 +186,12 @@ def finishingConstructorMatcher (e : Q(Prop)) : MetaM Bool :=
 
 /-- Implementation of the `tauto` tactic. -/
 def tautology : TacticM Unit := focusAndDoneWithScope "tauto" do
-  evalTactic (← `(tactic| classical!))
-  tautoCore
-  allGoals (iterateUntilFailure
-    (evalTactic (← `(tactic| rfl)) <|>
-     evalTactic (← `(tactic| solve_by_elim)) <|>
-     liftMetaTactic (constructorMatching · finishingConstructorMatcher)))
+  classical do
+    tautoCore
+    allGoals (iterateUntilFailure
+      (evalTactic (← `(tactic| rfl)) <|>
+      evalTactic (← `(tactic| solve_by_elim)) <|>
+      liftMetaTactic (constructorMatching · finishingConstructorMatcher)))
 
 /--
 `tauto` breaks down assumptions of the form `_ ∧ _`, `_ ∨ _`, `_ ↔ _` and `∃ _, _`

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/std4",
    "type": "git",
    "subDir": null,
-   "rev": "cb172855f1712a9e906e91f3e14541960562fb78",
+   "rev": "e840c18f7334c751efbd4cfe531476e10c943cdb",
    "name": "std",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
The `classical!` tactic is always replaceable by the `classical` tactic. This removes the last use of it, which required adding in Std the plumbing-level implementation of `classical`.

- [x] Depends on: #12256 