### PR TITLE
chore: apply `apply` instead of `refine`

### DIFF
--- a/Archive/Imo/Imo2019Q2.lean
+++ b/Archive/Imo/Imo2019Q2.lean
@@ -311,7 +311,7 @@ theorem A₁_ne_B : cfg.A₁ ≠ cfg.B := by
   have haQ : (2 : ℤ) • ∡ cfg.C cfg.B cfg.Q = (2 : ℤ) • ∡ cfg.C cfg.B cfg.A := by
     rw [Collinear.two_zsmul_oangle_eq_right _ cfg.A_ne_B cfg.Q_ne_B]
     rw [Set.pair_comm, Set.insert_comm]
-    refine' collinear_insert_of_mem_affineSpan_pair _
+    apply collinear_insert_of_mem_affineSpan_pair
     rw [← hPQ]
     exact right_mem_affineSpan_pair _ _ _
   have ha : (2 : ℤ) • ∡ cfg.C cfg.B cfg.Q = (2 : ℤ) • ∡ cfg.C cfg.Q₁ cfg.Q := by

--- a/Counterexamples/CliffordAlgebra_not_injective.lean
+++ b/Counterexamples/CliffordAlgebra_not_injective.lean
@@ -95,7 +95,7 @@ def K : Type _ := _ ⧸ kIdeal
 instance : CommRing K := Ideal.Quotient.commRing _
 
 theorem comap_C_kIdeal : kIdeal.comap (C : ZMod 2 →+* MvPolynomial (Fin 3) (ZMod 2)) = ⊥ := by
-  refine bot_unique ?_
+  apply bot_unique
   refine (Ideal.comap_le_map_of_inverse _ _ _ (constantCoeff_C _)).trans ?_
   rw [kIdeal, Ideal.map_span]
   refine (Ideal.span_le).2 ?_

--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -614,7 +614,7 @@ theorem finprod_mul_distrib (hf : (mulSupport f).Finite) (hg : (mulSupport g).Fi
     rw [finprod_eq_prod_of_mulSupport_toFinset_subset _ hf (Finset.subset_union_left _ _),
       finprod_eq_prod_of_mulSupport_toFinset_subset _ hg (Finset.subset_union_right _ _), ←
       Finset.prod_mul_distrib]
-    refine' finprod_eq_prod_of_mulSupport_subset _ _
+    apply finprod_eq_prod_of_mulSupport_subset
     simp only [Finset.coe_union, Finite.coe_toFinset, mulSupport_subset_iff,
       mem_union, mem_mulSupport]
     intro x

--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -325,7 +325,7 @@ instance (priority := 100) GroupWithZero.toDivisionMonoid : DivisionMonoid G₀ 
       by_cases hb : b = 0
       · simp [hb]
 
-      refine' inv_eq_of_mul _
+      apply inv_eq_of_mul
       simp [mul_assoc, ha, hb],
     inv_eq_of_mul := fun _ _ => inv_eq_of_mul }
 #align group_with_zero.to_division_monoid GroupWithZero.toDivisionMonoid

--- a/Mathlib/Algebra/Homology/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplex.lean
@@ -176,7 +176,7 @@ theorem next (α : Type*) [AddGroup α] [One α] (i : α) : (ComplexShape.down �
 @[simp]
 theorem next_nat_zero : (ComplexShape.down ℕ).next 0 = 0 := by
   classical
-    refine' dif_neg _
+    apply dif_neg
     push_neg
     intro
     apply Nat.noConfusion
@@ -205,7 +205,7 @@ theorem next (α : Type*) [AddRightCancelSemigroup α] [One α] (i : α) :
 @[simp]
 theorem prev_nat_zero : (ComplexShape.up ℕ).prev 0 = 0 := by
   classical
-    refine' dif_neg _
+    apply dif_neg
     push_neg
     intro
     apply Nat.noConfusion

--- a/Mathlib/Algebra/Module/Zlattice/Basic.lean
+++ b/Mathlib/Algebra/Module/Zlattice/Basic.lean
@@ -522,7 +522,7 @@ theorem Zlattice.rank [hs : IsZlattice K L] : finrank ℤ L = finrank K E := by
     exact Subtype.coe_injective.comp (Basis.injective _)
   rw [finrank_eq_card_chooseBasisIndex]
     -- We prove that `finrank ℤ L ≤ finrank K E` and `finrank K E ≤ finrank ℤ L`
-  refine le_antisymm ?_ ?_
+  apply le_antisymm
   · -- To prove that `finrank ℤ L ≤ finrank K E`, we proceed by contradiction and prove that, in
     -- this case, there is a ℤ-relation between the vectors of `b`
     obtain ⟨t, ⟨ht_inc, ⟨ht_span, ht_lin⟩⟩⟩ := exists_linearIndependent K (Set.range b)
@@ -560,7 +560,7 @@ theorem Zlattice.rank [hs : IsZlattice K L] : finrank ℤ L = finrank K E := by
       refine ⟨fun _ ↦ mem_closedBall_zero_iff.mpr (Zspan.norm_fract_le e _), fun _ => ?_⟩
       · change _ ∈ AddSubgroup.toIntSubmodule L
         rw [← h_spanL]
-        refine sub_mem ?_ ?_
+        apply sub_mem
         · exact zsmul_mem (subset_span (Set.diff_subset _ _ hv)) _
         · exact span_mono (by simp [e, ht_inc]) (coe_mem _)
     have h_finite : Set.Finite (Metric.closedBall 0 (∑ i, ‖e i‖) ∩ (L : Set E)) :=

--- a/Mathlib/Algebra/MvPolynomial/Variables.lean
+++ b/Mathlib/Algebra/MvPolynomial/Variables.lean
@@ -317,7 +317,7 @@ theorem exists_rename_eq_of_vars_subset_range (p : MvPolynomial σ R) (f : τ �
   ⟨aeval (fun i : σ => Option.elim' 0 X <| partialInv f i) p,
     by
       show (rename f).toRingHom.comp _ p = RingHom.id _ p
-      refine' hom_congr_vars _ _ _
+      apply hom_congr_vars
       · ext1
         simp [algebraMap_eq]
       · intro i hip _

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -110,7 +110,7 @@ lemma prod_add_prod_le {i : ι} {f g h : ι → R} (hi : i ∈ s) (h2i : g i + h
   refine le_trans ?_ (mul_le_mul_of_nonneg_right h2i ?_)
   · rw [right_distrib]
     refine add_le_add ?_ ?_ <;>
-    · refine mul_le_mul_of_nonneg_left ?_ ?_
+    · apply mul_le_mul_of_nonneg_left
       · refine prod_le_prod ?_ ?_ <;> simp (config := { contextual := true }) [*]
       · try apply_assumption
         try assumption

--- a/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
+++ b/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
@@ -185,7 +185,7 @@ lemma of_mono_bounded (f : ℕ → α) {a : α} {m : ℕ} (ham : ∀ n ≥ m, |f
 lemma geo_series [Nontrivial β] (x : β) (hx1 : abv x < 1) :
     IsCauSeq abv fun n ↦ ∑ m in range n, x ^ m := by
   have hx1' : abv x ≠ 1 := fun h ↦ by simp [h, lt_irrefl] at hx1
-  refine of_abv ?_
+  apply of_abv
   simp only [abv_pow abv, geom_sum_eq hx1']
   conv in _ / _ => rw [← neg_div_neg_eq, neg_sub, neg_sub]
   have : 0 < 1 - abv x := sub_pos.2 hx1

--- a/Mathlib/Algebra/Order/ToIntervalMod.lean
+++ b/Mathlib/Algebra/Order/ToIntervalMod.lean
@@ -238,7 +238,7 @@ theorem toIcoDiv_add_zsmul (a b : α) (m : ℤ) : toIcoDiv hp a (b + m • p) = 
 @[simp]
 theorem toIcoDiv_add_zsmul' (a b : α) (m : ℤ) :
     toIcoDiv hp (a + m • p) b = toIcoDiv hp a b - m := by
-  refine' toIcoDiv_eq_of_sub_zsmul_mem_Ico _ _
+  apply toIcoDiv_eq_of_sub_zsmul_mem_Ico
   rw [sub_smul, ← sub_add, add_right_comm]
   simpa using sub_toIcoDiv_zsmul_mem_Ico hp a b
 #align to_Ico_div_add_zsmul' toIcoDiv_add_zsmul'
@@ -252,7 +252,7 @@ theorem toIocDiv_add_zsmul (a b : α) (m : ℤ) : toIocDiv hp a (b + m • p) = 
 @[simp]
 theorem toIocDiv_add_zsmul' (a b : α) (m : ℤ) :
     toIocDiv hp (a + m • p) b = toIocDiv hp a b - m := by
-  refine' toIocDiv_eq_of_sub_zsmul_mem_Ioc _ _
+  apply toIocDiv_eq_of_sub_zsmul_mem_Ioc
   rw [sub_smul, ← sub_add, add_right_comm]
   simpa using sub_toIocDiv_zsmul_mem_Ioc hp a b
 #align to_Ioc_div_add_zsmul' toIocDiv_add_zsmul'

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -228,7 +228,7 @@ theorem natDegree_sum_eq_of_disjoint (f : S → R[X]) (s : Finset S)
   by_cases H : ∃ x ∈ s, f x ≠ 0
   · obtain ⟨x, hx, hx'⟩ := H
     have hs : s.Nonempty := ⟨x, hx⟩
-    refine' natDegree_eq_of_degree_eq_some _
+    apply natDegree_eq_of_degree_eq_some
     rw [degree_sum_eq_of_disjoint]
     · rw [← Finset.sup'_eq_sup hs, ← Finset.sup'_eq_sup hs,
         Nat.cast_withBot, Finset.coe_sup' hs, ←

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -233,7 +233,7 @@ theorem natDegree_sum_eq_of_disjoint (f : S → R[X]) (s : Finset S)
     · rw [← Finset.sup'_eq_sup hs, ← Finset.sup'_eq_sup hs,
         Nat.cast_withBot, Finset.coe_sup' hs, ←
         Finset.sup'_eq_sup hs]
-      refine' le_antisymm _ _
+      apply le_antisymm
       · rw [Finset.sup'_le_iff]
         intro b hb
         by_cases hb' : f b = 0

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -360,7 +360,7 @@ theorem degree_derivative_eq [NoZeroSMulDivisors ℕ R] (p : R[X]) (hp : 0 < nat
     intro n hn
     apply le_trans (degree_C_mul_X_pow_le _ _) (WithBot.coe_le_coe.2 (tsub_le_tsub_right _ _))
     apply le_natDegree_of_mem_supp _ hn
-  · refine' le_sup _
+  · apply le_sup
     rw [mem_support_derivative, tsub_add_cancel_of_le, mem_support_iff]
     · rw [coeff_natDegree, Ne, leadingCoeff_eq_zero]
       intro h

--- a/Mathlib/Algebra/Polynomial/Eval.lean
+++ b/Mathlib/Algebra/Polynomial/Eval.lean
@@ -903,7 +903,7 @@ theorem degree_map_eq_of_leadingCoeff_ne_zero (f : R →+* S) (hf : f (leadingCo
     have hp0 : p ≠ 0 :=
       leadingCoeff_ne_zero.mp fun hp0 => hf (_root_.trans (congr_arg _ hp0) f.map_zero)
     rw [degree_eq_natDegree hp0]
-    refine' le_degree_of_ne_zero _
+    apply le_degree_of_ne_zero
     rw [coeff_map]
     exact hf
 #align polynomial.degree_map_eq_of_leading_coeff_ne_zero Polynomial.degree_map_eq_of_leadingCoeff_ne_zero

--- a/Mathlib/Algebra/Polynomial/Expand.lean
+++ b/Mathlib/Algebra/Polynomial/Expand.lean
@@ -167,7 +167,7 @@ theorem natDegree_expand (p : ℕ) (f : R[X]) : (expand R p f).natDegree = f.nat
       erw [WithBot.coe_le_coe, ← Nat.div_mul_cancel hpn]
       exact Nat.mul_le_mul_right p hn
     · rfl
-  · refine' le_degree_of_ne_zero _
+  · apply le_degree_of_ne_zero
     erw [coeff_expand_mul hp, ← leadingCoeff]
     exact mt leadingCoeff_eq_zero.1 hf
 #align polynomial.nat_degree_expand Polynomial.natDegree_expand

--- a/Mathlib/Algebra/Polynomial/HasseDeriv.lean
+++ b/Mathlib/Algebra/Polynomial/HasseDeriv.lean
@@ -213,7 +213,7 @@ theorem natDegree_hasseDeriv [NoZeroSMulDivisors ℕ R] (p : R[X]) (n : ℕ) :
     natDegree (hasseDeriv n p) = natDegree p - n := by
   cases' lt_or_le p.natDegree n with hn hn
   · simpa [hasseDeriv_eq_zero_of_lt_natDegree, hn] using (tsub_eq_zero_of_le hn.le).symm
-  · refine' map_natDegree_eq_sub _ _
+  · apply map_natDegree_eq_sub
     · exact fun h => hasseDeriv_eq_zero_of_lt_natDegree _ _
     · classical
         simp only [ite_eq_right_iff, Ne, natDegree_monomial, hasseDeriv_monomial]

--- a/Mathlib/Algebra/Polynomial/Monic.lean
+++ b/Mathlib/Algebra/Polynomial/Monic.lean
@@ -495,7 +495,7 @@ theorem Monic.isRegular {R : Type*} [Ring R] {p : R[X]} (hp : Monic p) : IsRegul
 
 theorem degree_smul_of_smul_regular {S : Type*} [Monoid S] [DistribMulAction S R] {k : S}
     (p : R[X]) (h : IsSMulRegular R k) : (k • p).degree = p.degree := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · rw [degree_le_iff_coeff_zero]
     intro m hm
     rw [degree_lt_iff_coeff_zero] at hm

--- a/Mathlib/Algebra/Polynomial/Monic.lean
+++ b/Mathlib/Algebra/Polynomial/Monic.lean
@@ -329,7 +329,7 @@ theorem Monic.degree_map [Semiring S] [Nontrivial S] {P : R[X]} (hmo : P.Monic) 
   · simp [hP]
   · refine' le_antisymm (degree_map_le _ _) _
     rw [degree_eq_natDegree hP]
-    refine' le_degree_of_ne_zero _
+    apply le_degree_of_ne_zero
     rw [coeff_map, Monic.coeff_natDegree hmo, RingHom.map_one]
     exact one_ne_zero
 #align polynomial.monic.degree_map Polynomial.Monic.degree_map
@@ -503,7 +503,7 @@ theorem degree_smul_of_smul_regular {S : Type*} [Monoid S] [DistribMulAction S R
   · rw [degree_le_iff_coeff_zero]
     intro m hm
     rw [degree_lt_iff_coeff_zero] at hm
-    refine' h _
+    apply h
     simpa using hm m le_rfl
 #align polynomial.degree_smul_of_smul_regular Polynomial.degree_smul_of_smul_regular
 
@@ -555,7 +555,7 @@ theorem isUnit_leadingCoeff_mul_left_eq_zero_iff (h : IsUnit p.leadingCoeff) {q 
     replace hp := congr_arg (· * C ↑h.unit⁻¹) hp
     simp only [zero_mul] at hp
     rwa [mul_assoc, Monic.mul_left_eq_zero_iff] at hp
-    refine' monic_mul_C_of_leadingCoeff_mul_eq_one _
+    apply monic_mul_C_of_leadingCoeff_mul_eq_one
     simp [Units.mul_inv_eq_iff_eq_mul, IsUnit.unit_spec]
   · rintro rfl
     rw [zero_mul]

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -466,7 +466,7 @@ theorem rootMultiplicity_eq_natTrailingDegree' {p : R[X]} :
     p.rootMultiplicity 0 = p.natTrailingDegree := by
   by_cases h : p = 0
   · simp only [h, rootMultiplicity_zero, natTrailingDegree_zero]
-  refine le_antisymm ?_ ?_
+  apply le_antisymm
   · rw [rootMultiplicity_le_iff h, map_zero, sub_zero, X_pow_dvd_iff, not_forall]
     exact ⟨p.natTrailingDegree,
       fun h' ↦ trailingCoeff_nonzero_iff_nonzero.2 h <| h' <| Nat.lt.base _⟩
@@ -509,7 +509,7 @@ end nonZeroDivisors
 theorem rootMultiplicity_mul_X_sub_C_pow {p : R[X]} {a : R} {n : ℕ} (h : p ≠ 0) :
     (p * (X - C a) ^ n).rootMultiplicity a = p.rootMultiplicity a + n := by
   have h2 := monic_X_sub_C a |>.pow n |>.mul_left_ne_zero h
-  refine le_antisymm ?_ ?_
+  apply le_antisymm
   · rw [rootMultiplicity_le_iff h2, add_assoc, add_comm n, ← add_assoc, pow_add,
       dvd_cancel_right_mem_nonZeroDivisors (monic_X_sub_C a |>.pow n |>.mem_nonZeroDivisors)]
     exact pow_rootMultiplicity_not_dvd h a

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -131,7 +131,7 @@ variable [Semiring R] [NoZeroDivisors R] {p q : R[X]}
 instance : NoZeroDivisors R[X] where
   eq_zero_or_eq_zero_of_mul_eq_zero h := by
     rw [← leadingCoeff_eq_zero, ← leadingCoeff_eq_zero]
-    refine' eq_zero_or_eq_zero_of_mul_eq_zero _
+    apply eq_zero_or_eq_zero_of_mul_eq_zero
     rw [← leadingCoeff_zero, ← leadingCoeff_mul, h]
 
 theorem natDegree_mul (hp : p ≠ 0) (hq : q ≠ 0) : (p*q).natDegree = p.natDegree + q.natDegree := by

--- a/Mathlib/Algebra/Polynomial/Taylor.lean
+++ b/Mathlib/Algebra/Polynomial/Taylor.lean
@@ -96,7 +96,7 @@ theorem taylor_coeff_one : (taylor r f).coeff 1 = f.derivative.eval r := by
 
 @[simp]
 theorem natDegree_taylor (p : R[X]) (r : R) : natDegree (taylor r p) = natDegree p := by
-  refine' map_natDegree_eq_natDegree _ _
+  apply map_natDegree_eq_natDegree
   nontriviality R
   intro n c c0
   simp [taylor_monomial, natDegree_C_mul_eq_of_mul_ne_zero, natDegree_pow_X_add_C, c0]

--- a/Mathlib/Algebra/SMulWithZero.lean
+++ b/Mathlib/Algebra/SMulWithZero.lean
@@ -215,7 +215,7 @@ theorem smul_inv₀ [SMulCommClass α β β] [IsScalarTower α β β] (c : α) (
   · simp only [inv_zero, zero_smul]
   obtain rfl | hx := eq_or_ne x 0
   · simp only [inv_zero, smul_zero]
-  · refine' inv_eq_of_mul_eq_one_left _
+  · apply inv_eq_of_mul_eq_one_left
     rw [smul_mul_smul, inv_mul_cancel hc, inv_mul_cancel hx, one_smul]
 #align smul_inv₀ smul_inv₀
 

--- a/Mathlib/Analysis/BoundedVariation.lean
+++ b/Mathlib/Analysis/BoundedVariation.lean
@@ -517,7 +517,7 @@ theorem comp_le_of_monotoneOn (f : α → E) {s : Set α} {t : Set β} (φ : β 
 
 theorem comp_le_of_antitoneOn (f : α → E) {s : Set α} {t : Set β} (φ : β → α) (hφ : AntitoneOn φ t)
     (φst : MapsTo φ t s) : eVariationOn (f ∘ φ) t ≤ eVariationOn f s := by
-  refine' iSup_le _
+  apply iSup_le
   rintro ⟨n, u, hu, ut⟩
   rw [← Finset.sum_range_reflect]
   refine' (Finset.sum_congr rfl fun x hx => _).trans_le <| le_iSup_of_le

--- a/Mathlib/Analysis/BoundedVariation.lean
+++ b/Mathlib/Analysis/BoundedVariation.lean
@@ -477,7 +477,7 @@ theorem union (f : α → E) {s t : Set α} {x : α} (hs : IsGreatest s x) (ht :
           ∑ j in Finset.Ico N m, edist (f (v (j + 1))) (f (v j)) :=
       by rw [Finset.range_eq_Ico, Finset.sum_Ico_consecutive _ (zero_le _) hN.le]
     _ ≤ eVariationOn f s + eVariationOn f t := by
-      refine' add_le_add _ _
+      apply add_le_add
       · apply sum_le_of_monotoneOn_Icc _ (hv.monotoneOn _) fun i hi => ?_
         rcases vst i with (h | h); · exact h
         have : v i = x := by

--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -751,7 +751,7 @@ theorem HasIntegral.of_bRiemann_eq_false_of_forall_isLittleO (hl : l.bRiemann = 
   rw [← g.sum_partition_boxes le_rfl hπp, mem_closedBall, integralSum,
     ← sum_filter_add_sum_filter_not π.boxes fun J => π.tag J ∈ s,
     ← sum_filter_add_sum_filter_not π.boxes fun J => π.tag J ∈ s, ← add_halves ε]
-  refine' dist_add_add_le_of_le _ _
+  apply dist_add_add_le_of_le
   · rcases s.eq_empty_or_nonempty with (rfl | hsne); · simp [ε0'.le]
     /- For the boxes such that `π.tag J ∈ s`, we use the fact that at most `2 ^ #ι` boxes have the
         same tag. -/

--- a/Mathlib/Analysis/BoxIntegral/Integrability.lean
+++ b/Mathlib/Analysis/BoxIntegral/Integrability.lean
@@ -255,7 +255,7 @@ theorem IntegrableOn.hasBoxIntegral [CompleteSpace E] {f : (ι → ℝ) → E} {
   refine' (dist_triangle4 _ (∑ J in π.boxes, (μ J).toReal • f (Nx <| π.tag J) (π.tag J))
     (∑ J in π.boxes, ∫ x in J, f (Nx <| π.tag J) x ∂μ) _).trans _
   rw [add_mul, add_mul, one_mul]
-  refine' add_le_add_three _ _ _
+  apply add_le_add_three
   · /- Since each `f (Nx <| π.tag J)` is `ε`-close to `g (π.tag J)`, replacing the latter with
         the former in the formula for the integral sum changes the sum at most by `μ I * ε`. -/
     rw [← hπp.iUnion_eq, π.measure_iUnion_toReal, sum_mul, integralSum]

--- a/Mathlib/Analysis/BoxIntegral/Partition/Split.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Split.lean
@@ -323,7 +323,7 @@ theorem eventually_splitMany_inf_eq_filter (π : Prepartition I) :
       π ⊓ splitMany I t = (splitMany I t).filter fun J => ↑J ⊆ π.iUnion := by
   refine' (eventually_not_disjoint_imp_le_of_mem_splitMany π.boxes).mono fun t ht => _
   refine' le_antisymm ((biUnion_le_iff _).2 fun J hJ => _) (le_inf (fun J hJ => _) (filter_le _ _))
-  · refine' ofWithBot_mono _
+  · apply ofWithBot_mono
     simp only [Finset.mem_image, exists_prop, mem_boxes, mem_filter]
     rintro _ ⟨J₁, h₁, rfl⟩ hne
     refine' ⟨_, ⟨J₁, ⟨h₁, Subset.trans _ (π.subset_iUnion hJ)⟩, rfl⟩, le_rfl⟩

--- a/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
@@ -326,7 +326,7 @@ theorem norm_iteratedFDerivWithin_prod_le [DecidableEq ι] [NormOneClass A'] {u 
     refine Finset.sum_le_sum ?_
     simp only [Finset.mem_univ, forall_true_left, Subtype.forall, Finset.mem_sym_iff]
     intro p hp
-    refine le_of_eq ?_
+    apply le_of_eq
     rw [Finset.prod_insert hi]
     have hip : i ∉ p := mt (hp i) hi
     rw [Sym.count_coe_fill_self_of_not_mem hip, Sym.multinomial_coe_fill_of_not_mem hip]

--- a/Mathlib/Analysis/Calculus/Taylor.lean
+++ b/Mathlib/Analysis/Calculus/Taylor.lean
@@ -132,7 +132,7 @@ theorem continuousOn_taylorWithinEval {f : ℝ → E} {x : ℝ} {n : ℕ} {s : S
   cases' hf with hf_left
   specialize hf_left i
   simp only [Finset.mem_range] at hi
-  refine' hf_left _
+  apply hf_left
   simp only [WithTop.coe_le_coe, Nat.cast_le, Nat.lt_succ_iff.mp hi]
 #align continuous_on_taylor_within_eval continuousOn_taylorWithinEval
 

--- a/Mathlib/Analysis/Calculus/Taylor.lean
+++ b/Mathlib/Analysis/Calculus/Taylor.lean
@@ -271,7 +271,7 @@ theorem taylor_mean_remainder_lagrange {f : ℝ → ℝ} {x x₀ : ℝ} {n : ℕ
     exact (continuous_const.sub continuous_id').pow _ -- Porting note: was `continuity`
   have xy_ne : ∀ y : ℝ, y ∈ Ioo x₀ x → (x - y) ^ n ≠ 0 := by
     intro y hy
-    refine' pow_ne_zero _ _
+    apply pow_ne_zero
     rw [mem_Ioo] at hy
     rw [sub_ne_zero]
     exact hy.2.ne'

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -101,7 +101,7 @@ theorem isConformalMap_iff_is_complex_or_conj_linear :
   constructor
   · exact fun h => ⟨h.is_complex_or_conj_linear, h.ne_zero⟩
   · rintro ⟨⟨map, rfl⟩ | ⟨map, hmap⟩, h₂⟩
-    · refine' isConformalMap_complex_linear _
+    · apply isConformalMap_complex_linear
       contrapose! h₂ with w
       simp only [w, restrictScalars_zero]
     · have minor₁ : g = map.restrictScalars ℝ ∘L ↑conjCLE := by
@@ -109,7 +109,7 @@ theorem isConformalMap_iff_is_complex_or_conj_linear :
         simp only [hmap, coe_comp', ContinuousLinearEquiv.coe_coe, Function.comp_apply,
           conjCLE_apply, starRingEnd_self_apply]
       rw [minor₁] at h₂ ⊢
-      refine' isConformalMap_complex_linear_conj _
+      apply isConformalMap_complex_linear_conj
       contrapose! h₂ with w
       simp only [w, restrictScalars_zero, zero_comp]
 #align is_conformal_map_iff_is_complex_or_conj_linear isConformalMap_iff_is_complex_or_conj_linear

--- a/Mathlib/Analysis/Convex/Independent.lean
+++ b/Mathlib/Analysis/Convex/Independent.lean
@@ -188,7 +188,7 @@ theorem convexIndependent_iff_finset {p : ι → E} :
   simp_rw [Set.mem_iUnion] at hx
   obtain ⟨t, ht, hx⟩ := hx
   rw [← hp.mem_set_image]
-  refine' ht _
+  apply ht
   suffices x ∈ t.preimage p (hp.injOn _) by rwa [mem_preimage, ← mem_coe] at this
   refine' h _ x _
   rwa [t.image_preimage p (hp.injOn _), filter_true_of_mem]

--- a/Mathlib/Analysis/Convex/Uniform.lean
+++ b/Mathlib/Analysis/Convex/Uniform.lean
@@ -101,7 +101,7 @@ theorem exists_forall_closed_ball_dist_add_le_two_sub (hε : 0 < ε) :
     _ ≤ 2 - δ' := by
       dsimp [δ']
       rw [← le_sub_iff_add_le, ← le_sub_iff_add_le, sub_sub, sub_sub]
-      refine' sub_le_sub_left _ _
+      apply sub_le_sub_left
       ring_nf
       rw [← mul_div_cancel₀ δ three_ne_zero]
       set_option tactic.skipAssignedInstances false in norm_num

--- a/Mathlib/Analysis/Convolution.lean
+++ b/Mathlib/Analysis/Convolution.lean
@@ -1325,7 +1325,7 @@ theorem contDiffOn_convolution_right_with_param {f : G → E} {n : ℕ∞} (L : 
   have R_contdiff : ContDiffOn 𝕜 n R ((isoP ⁻¹' s) ×ˢ univ) := by
     have hek : IsCompact (isoG ⁻¹' k) := isoG.toHomeomorph.closedEmbedding.isCompact_preimage hk
     have hes : IsOpen (isoP ⁻¹' s) := isoP.continuous.isOpen_preimage _ hs
-    refine' contDiffOn_convolution_right_with_param_aux eL hes hek _ _ _
+    apply contDiffOn_convolution_right_with_param_aux eL hes hek
     · intro p x hp hx
       simp only [eg, (· ∘ ·), ContinuousLinearEquiv.prod_apply, LinearIsometryEquiv.coe_coe,
         ContinuousLinearEquiv.map_eq_zero_iff]

--- a/Mathlib/Analysis/Convolution.lean
+++ b/Mathlib/Analysis/Convolution.lean
@@ -946,7 +946,7 @@ theorem convolution_assoc' (hL : ∀ (x : E) (y : E') (z : E''), L₂ (L x y) z 
       rw [eq_comm, ← integral_sub_right_eq_self _ t]
       simp_rw [sub_sub_sub_cancel_right]
     _ = ∫ s, L₃ (f s) (∫ u, L₄ (g u) (k (x₀ - s - u)) ∂μ) ∂ν := by
-      refine' integral_congr_ae _
+      apply integral_congr_ae
       refine' ((quasiMeasurePreserving_sub_left_of_right_invariant ν x₀).ae hgk).mono fun t ht => _
       exact (L₃ (f t)).integral_comp_comm ht
     _ = (f ⋆[L₃, ν] g ⋆[L₄, μ] k) x₀ := rfl

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -851,7 +851,7 @@ def compCLM {g : D → E} (hg : g.HasTemperateGrowth)
       rcases hg.norm_iteratedFDeriv_le_uniform_aux n with ⟨l, C, hC, hgrowth⟩
       rcases hg_upper with ⟨kg, Cg, hg_upper'⟩
       have hCg : 1 ≤ 1 + Cg := by
-        refine' le_add_of_nonneg_right _
+        apply le_add_of_nonneg_right
         specialize hg_upper' 0
         rw [norm_zero] at hg_upper'
         exact nonneg_of_mul_nonneg_left hg_upper' (by positivity)

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -199,7 +199,7 @@ def fourierSubalgebra : StarSubalgebra ℂ C(AddCircle T, ℂ) where
   star_mem' := by
     show Algebra.adjoin ℂ (range (fourier (T := T))) ≤
       star (Algebra.adjoin ℂ (range (fourier (T := T))))
-    refine adjoin_le ?_
+    apply adjoin_le
     rintro - ⟨n, rfl⟩
     exact subset_adjoin ⟨-n, ext fun _ => fourier_neg⟩
 

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -97,7 +97,7 @@ theorem adjointAux_adjointAux (A : E →L[𝕜] F) : adjointAux (adjointAux A) =
 
 @[simp]
 theorem adjointAux_norm (A : E →L[𝕜] F) : ‖adjointAux A‖ = ‖A‖ := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · refine' ContinuousLinearMap.opNorm_le_bound _ (norm_nonneg _) fun x => _
     rw [adjointAux_apply, LinearIsometryEquiv.norm_map]
     exact toSesqForm_apply_norm_le
@@ -222,7 +222,7 @@ theorem isSelfAdjoint_iff' {A : E →L[𝕜] E} : IsSelfAdjoint A ↔ Continuous
 
 theorem norm_adjoint_comp_self (A : E →L[𝕜] F) :
     ‖ContinuousLinearMap.adjoint A ∘L A‖ = ‖A‖ * ‖A‖ := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · calc
       ‖A† ∘L A‖ ≤ ‖A†‖ * ‖A‖ := opNorm_comp_le _ _
       _ = ‖A‖ * ‖A‖ := by rw [LinearIsometryEquiv.norm_map]

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -1183,7 +1183,7 @@ instance (priority := 100) InnerProductSpace.toUniformConvexSpace : UniformConve
     · norm_num
       exact pow_pos hε _
     rw [sub_sub_cancel]
-    refine' le_sqrt_of_sq_le _
+    apply le_sqrt_of_sq_le
     rw [sq, eq_sub_iff_add_eq.2 (parallelogram_law_with_norm ℝ x y), ← sq ‖x - y‖, hx, hy]
     ring_nf
     exact sub_le_sub_left (pow_le_pow_left hε.le hxy _) 4⟩
@@ -1921,7 +1921,7 @@ theorem Orthonormal.inner_products_summable (hv : Orthonormal 𝕜 v) :
   apply hasSum_of_isLUB_of_nonneg
   · intro b
     simp only [norm_nonneg, pow_nonneg]
-  · refine' isLUB_ciSup _
+  · apply isLUB_ciSup
     use ‖x‖ ^ 2
     rintro y ⟨s, rfl⟩
     exact hv.sum_inner_products_le x

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -834,7 +834,7 @@ structure inherited from `PiLp 2 (fun _ : ℕ ↦ ℝ)`. Let `K` be the subspace
 of all elements equal to zero. Then `Kᗮ = ⊥`, `Kᗮᗮ = ⊤`.  -/
 theorem Submodule.orthogonal_orthogonal_eq_closure [CompleteSpace E] :
     Kᗮᗮ = K.topologicalClosure := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · convert Submodule.orthogonal_orthogonal_monotone K.le_topologicalClosure using 1
     rw [K.topologicalClosure.orthogonal_orthogonal]
   · exact K.topologicalClosure_minimal K.le_orthogonal_orthogonal Kᗮ.isClosed_orthogonal

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -253,7 +253,7 @@ theorem norm_eq_iInf_iff_real_inner_le_zero {K : Set F} (h : Convex ℝ K) {u : 
         ‖u - v‖ * ‖u - v‖ ≤ ‖u - v‖ * ‖u - v‖ - 2 * inner (u - v) ((w : F) - v) := by linarith
         _ ≤ ‖u - v‖ ^ 2 - 2 * inner (u - v) ((w : F) - v) + ‖(w : F) - v‖ ^ 2 := by
           rw [sq]
-          refine' le_add_of_nonneg_right _
+          apply le_add_of_nonneg_right
           exact sq_nonneg _
         _ = ‖u - v - (w - v)‖ ^ 2 := (@norm_sub_sq ℝ _ _ _ _ _ _).symm
         _ = ‖u - w‖ * ‖u - w‖ := by
@@ -1210,7 +1210,7 @@ theorem LinearIsometryEquiv.reflections_generate_dim_aux [FiniteDimensional ℝ 
       intro w hw
       apply hV
       rw [hW w hw]
-      refine' reflection_mem_subspace_eq_self _
+      apply reflection_mem_subspace_eq_self
       rw [Submodule.mem_orthogonal_singleton_iff_inner_left]
       exact Submodule.sub_mem _ v.prop hφv _ hw
     -- `v` is also fixed by `φ.trans ρ`

--- a/Mathlib/Analysis/InnerProductSpace/TwoDim.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TwoDim.lean
@@ -211,7 +211,7 @@ def rightAngleRotationAux₂ : E →ₗᵢ[ℝ] E :=
   { o.rightAngleRotationAux₁ with
     norm_map' := fun x => by
       dsimp
-      refine' le_antisymm _ _
+      apply le_antisymm
       · cases' eq_or_lt_of_le (norm_nonneg (o.rightAngleRotationAux₁ x)) with h h
         · rw [← h]
           positivity

--- a/Mathlib/Analysis/InnerProductSpace/l2Space.lean
+++ b/Mathlib/Analysis/InnerProductSpace/l2Space.lean
@@ -245,7 +245,7 @@ protected theorem range_linearIsometry [∀ i, CompleteSpace (G i)] :
     LinearMap.range hV.linearIsometry.toLinearMap =
       (⨆ i, LinearMap.range (V i).toLinearMap).topologicalClosure := by
     -- Porting note: dot notation broken
-  refine' le_antisymm _ _
+  apply le_antisymm
   · rintro x ⟨f, rfl⟩
     refine' mem_closure_of_tendsto (hV.hasSum_linearIsometry f) (eventually_of_forall _)
     intro s

--- a/Mathlib/Analysis/InnerProductSpace/l2Space.lean
+++ b/Mathlib/Analysis/InnerProductSpace/l2Space.lean
@@ -250,12 +250,12 @@ protected theorem range_linearIsometry [∀ i, CompleteSpace (G i)] :
     refine' mem_closure_of_tendsto (hV.hasSum_linearIsometry f) (eventually_of_forall _)
     intro s
     rw [SetLike.mem_coe]
-    refine' sum_mem _
+    apply sum_mem
     intro i _
     refine' mem_iSup_of_mem i _
     exact LinearMap.mem_range_self _ (f i)
   · apply topologicalClosure_minimal
-    · refine' iSup_le _
+    · apply iSup_le
       rintro i x ⟨x, rfl⟩
       use lp.single 2 i x
       exact hV.linearIsometry_apply_single x
@@ -467,7 +467,7 @@ protected theorem dense_span (b : HilbertBasis ι 𝕜 E) :
     refine' mem_closure_of_tendsto (b.hasSum_repr x) (eventually_of_forall _)
     intro s
     simp only [SetLike.mem_coe]
-    refine' sum_mem _
+    apply sum_mem
     rintro i -
     apply smul_mem
     exact subset_span ⟨i, rfl⟩

--- a/Mathlib/Analysis/InnerProductSpace/l2Space.lean
+++ b/Mathlib/Analysis/InnerProductSpace/l2Space.lean
@@ -469,7 +469,7 @@ protected theorem dense_span (b : HilbertBasis ι 𝕜 E) :
     simp only [SetLike.mem_coe]
     refine' sum_mem _
     rintro i -
-    refine' smul_mem _ _ _
+    apply smul_mem
     exact subset_span ⟨i, rfl⟩
 #align hilbert_basis.dense_span HilbertBasis.dense_span
 

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -337,7 +337,7 @@ private theorem inner_le_Lp_mul_Lp_of_norm_le_one (f g : ι → ℝ≥0) {p q : 
     _ = (∑ i in s, f i ^ p) / Real.toNNReal p + (∑ i in s, g i ^ q) / Real.toNNReal q := by
       rw [sum_add_distrib, sum_div, sum_div]
     _ ≤ 1 / Real.toNNReal p + 1 / Real.toNNReal q := by
-      refine' add_le_add _ _
+      apply add_le_add
       · rwa [div_le_iff hp_ne_zero, div_mul_cancel₀ _ hp_ne_zero]
       · rwa [div_le_iff hq_ne_zero, div_mul_cancel₀ _ hq_ne_zero]
     _ = 1 := by simp_rw [one_div, hpq.toNNReal.inv_add_inv_conj]
@@ -372,7 +372,7 @@ theorem inner_le_Lp_mul_Lq (f g : ι → ℝ≥0) {p q : ℝ} (hpq : p.IsConjExp
   suffices (∑ i in s, f' i * g' i) ≤ 1 by
     simp_rw [f', g', div_mul_div_comm, ← sum_div] at this
     rwa [div_le_iff, one_mul] at this
-    refine' mul_ne_zero _ _
+    apply mul_ne_zero
     · rw [Ne, rpow_eq_zero_iff, not_and_or]
       exact Or.inl hF_zero
     · rw [Ne, rpow_eq_zero_iff, not_and_or]

--- a/Mathlib/Analysis/MeanInequalitiesPow.lean
+++ b/Mathlib/Analysis/MeanInequalitiesPow.lean
@@ -237,7 +237,7 @@ theorem rpow_arith_mean_le_arith_mean_rpow (w z : ι → ℝ≥0∞) (hw' : ∑ 
   have hp_not_neg : ¬p < 0 := by simp [hp_nonneg]
   have h_top_iff_rpow_top : ∀ (i : ι), i ∈ s → (w i * z i = ⊤ ↔ w i * z i ^ p = ⊤) := by
     simp [ENNReal.mul_eq_top, hp_pos, hp_nonneg, hp_not_neg]
-  refine' le_of_top_imp_top_of_toNNReal_le _ _
+  apply le_of_top_imp_top_of_toNNReal_le
   · -- first, prove `(∑ i in s, w i * z i) ^ p = ⊤ → ∑ i in s, (w i * z i ^ p) = ⊤`
     rw [rpow_eq_top_iff, sum_eq_top_iff, sum_eq_top_iff]
     intro h

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGroupCat/Kernels.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGroupCat/Kernels.lean
@@ -288,7 +288,7 @@ theorem explicitCokernelDesc_comp_eq_desc {X Y Z W : SemiNormedGroupCat.{u}} {f 
     explicitCokernelDesc cond' ≫ h =
       explicitCokernelDesc
         (show f ≫ g ≫ h = 0 by rw [← CategoryTheory.Category.assoc, cond', Limits.zero_comp]) := by
-  refine' explicitCokernelDesc_unique _ _ _
+  apply explicitCokernelDesc_unique
   rw [← CategoryTheory.Category.assoc, explicitCokernelπ_desc]
 set_option linter.uppercaseLean3 false in
 #align SemiNormedGroup.explicit_cokernel_desc_comp_eq_desc SemiNormedGroupCat.explicitCokernelDesc_comp_eq_desc

--- a/Mathlib/Analysis/NormedSpace/CompactOperator.lean
+++ b/Mathlib/Analysis/NormedSpace/CompactOperator.lean
@@ -399,7 +399,7 @@ theorem isClosed_setOf_isCompactOperator {𝕜₁ 𝕜₂ : Type*} [Nontrivially
     [AddCommGroup M₂] [NormedSpace 𝕜₁ M₁] [Module 𝕜₂ M₂] [UniformSpace M₂] [UniformAddGroup M₂]
     [ContinuousConstSMul 𝕜₂ M₂] [T2Space M₂] [CompleteSpace M₂] :
     IsClosed { f : M₁ →SL[σ₁₂] M₂ | IsCompactOperator f } := by
-  refine' isClosed_of_closure_subset _
+  apply isClosed_of_closure_subset
   rintro u hu
   rw [mem_closure_iff_nhds_zero] at hu
   suffices TotallyBounded (u '' Metric.closedBall 0 1) by

--- a/Mathlib/Analysis/NormedSpace/MStructure.lean
+++ b/Mathlib/Analysis/NormedSpace/MStructure.lean
@@ -148,7 +148,7 @@ theorem mul [FaithfulSMul M X] {P Q : M} (h₁ : IsLprojection X P) (h₂ : IsLp
     IsLprojection X (P * Q) := by
   refine' ⟨IsIdempotentElem.mul_of_commute (h₁.commute h₂) h₁.proj h₂.proj, _⟩
   intro x
-  refine' le_antisymm _ _
+  apply le_antisymm
   · calc
       ‖x‖ = ‖(P * Q) • x + (x - (P * Q) • x)‖ := by rw [add_sub_cancel ((P * Q) • x) x]
       _ ≤ ‖(P * Q) • x‖ + ‖x - (P * Q) • x‖ := by apply norm_add_le

--- a/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
@@ -890,7 +890,7 @@ theorem norm_mkPiAlgebraFin_le_of_pos (hn : 0 < n) :
 #align continuous_multilinear_map.norm_mk_pi_algebra_fin_le_of_pos ContinuousMultilinearMap.norm_mkPiAlgebraFin_le_of_pos
 
 theorem norm_mkPiAlgebraFin_zero : ‖ContinuousMultilinearMap.mkPiAlgebraFin 𝕜 0 A‖ = ‖(1 : A)‖ := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · refine opNorm_le_bound _ (norm_nonneg (1 : A)) ?_
     simp
   · convert ratio_le_opNorm (ContinuousMultilinearMap.mkPiAlgebraFin 𝕜 0 A) fun _ => (1 : A)
@@ -914,7 +914,7 @@ end
 @[simp]
 theorem nnnorm_smulRight (f : ContinuousMultilinearMap 𝕜 E 𝕜) (z : G) :
     ‖f.smulRight z‖₊ = ‖f‖₊ * ‖z‖₊ := by
-  refine le_antisymm ?_ ?_
+  apply le_antisymm
   · refine (opNNNorm_le_iff _ |>.2 fun m => (nnnorm_smul_le _ _).trans ?_)
     rw [mul_right_comm]
     gcongr

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
@@ -114,7 +114,7 @@ alias op_norm_zero_iff :=
 /-- If a normed space is non-trivial, then the norm of the identity equals `1`. -/
 @[simp]
 theorem norm_id [Nontrivial E] : ‖id 𝕜 E‖ = 1 := by
-  refine' norm_id_of_nontrivial_seminorm _
+  apply norm_id_of_nontrivial_seminorm
   obtain ⟨x, hx⟩ := exists_ne (0 : E)
   exact ⟨x, ne_of_gt (norm_pos_iff.2 hx)⟩
 #align continuous_linear_map.norm_id ContinuousLinearMap.norm_id

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
@@ -201,7 +201,7 @@ theorem opNorm_comp_linearIsometryEquiv (f : F →SL[σ₂₃] G) (g : F' ≃ₛ
   cases subsingleton_or_nontrivial F'
   · haveI := g.symm.toLinearEquiv.toEquiv.subsingleton
     simp
-  refine' le_antisymm _ _
+  apply le_antisymm
   · convert f.opNorm_comp_le g.toLinearIsometry.toContinuousLinearMap
     simp [g.toLinearIsometry.norm_toContinuousLinearMap]
   · convert (f.comp g.toLinearIsometry.toContinuousLinearMap).opNorm_comp_le
@@ -220,7 +220,7 @@ alias op_norm_comp_linearIsometryEquiv :=
 is the product of the norms. -/
 @[simp]
 theorem norm_smulRight_apply (c : E →L[𝕜] 𝕜) (f : Fₗ) : ‖smulRight c f‖ = ‖c‖ * ‖f‖ := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · refine' opNorm_le_bound _ (mul_nonneg (norm_nonneg _) (norm_nonneg _)) fun x => _
     calc
       ‖c x • f‖ = ‖c x‖ * ‖f‖ := norm_smul _ _

--- a/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
@@ -206,7 +206,7 @@ theorem norm_eval_le_injectiveSeminorm (f : ContinuousMultilinearMap 𝕜 E F) (
 theorem injectiveSeminorm_le_projectiveSeminorm :
     injectiveSeminorm (𝕜 := 𝕜) (E := E) ≤ projectiveSeminorm := by
   rw [injectiveSeminorm]
-  refine csSup_le ?_ ?_
+  apply csSup_le
   · existsi 0
     simp only [Set.mem_setOf_eq]
     existsi PUnit, inferInstance, inferInstance
@@ -270,7 +270,7 @@ noncomputable def liftIsometry  : ContinuousMultilinearMap 𝕜 E F ≃ₗᵢ[�
   { liftEquiv 𝕜 E F with
     norm_map' := by
       intro f
-      refine le_antisymm ?_ ?_
+      apply le_antisymm
       · simp only [liftEquiv, lift_symm, LinearEquiv.coe_mk]
         exact LinearMap.mkContinuous_norm_le _ (norm_nonneg f) _
       · conv_lhs => rw [← (liftEquiv 𝕜 E F).left_inv f]

--- a/Mathlib/Analysis/NormedSpace/PiTensorProduct/ProjectiveSeminorm.lean
+++ b/Mathlib/Analysis/NormedSpace/PiTensorProduct/ProjectiveSeminorm.lean
@@ -116,7 +116,7 @@ noncomputable def projectiveSeminorm : Seminorm 𝕜 (⨂[𝕜] i, E i) := by
   · intro a x
     letI := nonempty_subtype.mpr (nonempty_lifts x)
     rw [Real.mul_iInf_of_nonneg (norm_nonneg _)]
-    refine le_ciInf ?_
+    apply le_ciInf
     intro p
     rw [← projectiveSeminormAux_smul]
     exact ciInf_le_of_le (bddBelow_projectiveSemiNormAux _)
@@ -138,7 +138,7 @@ theorem norm_eval_le_projectiveSeminorm (x : ⨂[𝕜] i, E i) (G : Type*) [Semi
     ‖lift f.toMultilinearMap x‖ ≤ projectiveSeminorm x * ‖f‖ := by
   letI := nonempty_subtype.mpr (nonempty_lifts x)
   rw [projectiveSeminorm_apply, Real.iInf_mul_of_nonneg (norm_nonneg _), projectiveSeminormAux]
-  refine le_ciInf ?_
+  apply le_ciInf
   intro ⟨p, hp⟩
   rw [mem_lifts_iff] at hp
   conv_lhs => rw [← hp, ← List.sum_map_hom, ← Multiset.sum_coe]

--- a/Mathlib/Analysis/NormedSpace/PiTensorProduct/ProjectiveSeminorm.lean
+++ b/Mathlib/Analysis/NormedSpace/PiTensorProduct/ProjectiveSeminorm.lean
@@ -97,7 +97,7 @@ of `∑ j, Π i, ‖mⱼ i‖`.
 -/
 noncomputable def projectiveSeminorm : Seminorm 𝕜 (⨂[𝕜] i, E i) := by
   refine Seminorm.ofSMulLE (fun x ↦ iInf (fun (p : lifts x) ↦ projectiveSeminormAux p.1)) ?_ ?_ ?_
-  · refine le_antisymm ?_ ?_
+  · apply le_antisymm
     · refine ciInf_le_of_le (bddBelow_projectiveSemiNormAux (0 : ⨂[𝕜] i, E i)) ⟨0, lifts_zero⟩ ?_
       simp only [projectiveSeminormAux, Function.comp_apply]
       rw [List.sum_eq_zero]

--- a/Mathlib/Analysis/NormedSpace/Pointwise.lean
+++ b/Mathlib/Analysis/NormedSpace/Pointwise.lean
@@ -263,7 +263,7 @@ theorem infEdist_thickening (hδ : 0 < δ) (s : Set E) (x : E) :
   · exact add_lt_top.2 ⟨lt_top_iff_ne_top.2 <| infEdist_ne_top ⟨z, self_subset_thickening hδ _ hz⟩,
       ofReal_lt_top⟩
   have hr : 0 < ↑r - δ := by
-    refine' sub_pos_of_lt _
+    apply sub_pos_of_lt
     have := hs.trans_lt ((infEdist_le_edist_of_mem hz).trans_lt h)
     rw [ofReal_eq_coe_nnreal hδ.le, some_eq_coe] at this
     exact mod_cast this

--- a/Mathlib/Analysis/NormedSpace/Spectrum.lean
+++ b/Mathlib/Analysis/NormedSpace/Spectrum.lean
@@ -309,7 +309,7 @@ theorem isUnit_one_sub_smul_of_lt_inv_radius {a : A} {z : 𝕜} (h : ↑‖z‖�
     suffices hu : IsUnit (u⁻¹ • (1 : A) - a) by
       rwa [IsUnit.smul_sub_iff_sub_inv_smul, inv_inv u] at hu
     rw [Units.smul_def, ← Algebra.algebraMap_eq_smul_one, ← mem_resolventSet_iff]
-    refine mem_resolventSet_of_spectralRadius_lt ?_
+    apply mem_resolventSet_of_spectralRadius_lt
     rwa [Units.val_inv_eq_inv_val, nnnorm_inv,
       coe_inv (nnnorm_ne_zero_iff.mpr (Units.val_mk0 hz ▸ hz : (u : 𝕜) ≠ 0)), lt_inv_iff_lt_inv]
 #align spectrum.is_unit_one_sub_smul_of_lt_inv_radius spectrum.isUnit_one_sub_smul_of_lt_inv_radius

--- a/Mathlib/Analysis/NormedSpace/Star/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Basic.lean
@@ -171,7 +171,7 @@ instance _root_.Prod.cstarRing : CstarRing (R₁ × R₂) where
   norm_star_mul_self {x} := by
     dsimp only [norm]
     simp only [Prod.fst_mul, Prod.fst_star, Prod.snd_mul, Prod.snd_star, norm_star_mul_self, ← sq]
-    refine' le_antisymm _ _
+    apply le_antisymm
     · refine' max_le _ _ <;> rw [sq_le_sq, abs_of_nonneg (norm_nonneg _)]
       exact (le_max_left _ _).trans (le_abs_self _)
       exact (le_max_right _ _).trans (le_abs_self _)
@@ -222,7 +222,7 @@ theorem norm_of_mem_unitary [Nontrivial E] {U : E} (hU : U ∈ unitary E) : ‖U
 @[simp]
 theorem norm_coe_unitary_mul (U : unitary E) (A : E) : ‖(U : E) * A‖ = ‖A‖ := by
   nontriviality E
-  refine' le_antisymm _ _
+  apply le_antisymm
   · calc
       _ ≤ ‖(U : E)‖ * ‖A‖ := norm_mul_le _ _
       _ = ‖A‖ := by rw [norm_coe_unitary, one_mul]

--- a/Mathlib/Analysis/NormedSpace/Unitization.lean
+++ b/Mathlib/Analysis/NormedSpace/Unitization.lean
@@ -150,7 +150,7 @@ theorem lipschitzWith_addEquiv :
   rw [← Real.toNNReal_ofNat]
   refine AddMonoidHomClass.lipschitz_of_bound (Unitization.addEquiv 𝕜 A) 2 fun x => ?_
   rw [norm_eq_sup, Prod.norm_def]
-  refine' max_le ?_ ?_
+  apply max_le
   · rw [sup_eq_max, mul_max_of_nonneg _ _ (zero_le_two : (0 : ℝ) ≤ 2)]
     exact le_max_of_le_left ((le_add_of_nonneg_left (norm_nonneg _)).trans_eq (two_mul _).symm)
   · nontriviality A
@@ -167,7 +167,7 @@ theorem antilipschitzWith_addEquiv :
     AntilipschitzWith 2 (addEquiv 𝕜 A) := by
   refine AddMonoidHomClass.antilipschitz_of_bound (addEquiv 𝕜 A) fun x => ?_
   rw [norm_eq_sup, Prod.norm_def, NNReal.coe_two]
-  refine max_le ?_ ?_
+  apply max_le
   · rw [mul_max_of_nonneg _ _ (zero_le_two : (0 : ℝ) ≤ 2)]
     exact le_max_of_le_left ((le_add_of_nonneg_left (norm_nonneg _)).trans_eq (two_mul _).symm)
   · nontriviality A

--- a/Mathlib/Analysis/SpecialFunctions/Log/Monotone.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Monotone.lean
@@ -66,7 +66,7 @@ theorem log_div_self_rpow_antitoneOn {a : ℝ} (ha : 0 < a) :
   rw [← div_self (ne_of_lt ha).symm, div_eq_mul_one_div a a, rpow_mul y_nonneg, rpow_mul x_nonneg,
     log_rpow (rpow_pos_of_pos y_pos a), log_rpow (rpow_pos_of_pos x_pos a), mul_div_assoc,
     mul_div_assoc, mul_le_mul_left (one_div_pos.mpr ha)]
-  · refine' log_div_self_antitoneOn _ _ _
+  · apply log_div_self_antitoneOn
     · simp only [Set.mem_setOf_eq]
       convert rpow_le_rpow _ hex (le_of_lt ha) using 1
       rw [← exp_mul]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
@@ -72,11 +72,11 @@ theorem continuousOn_tan_Ioo : ContinuousOn tan (Ioo (-(π / 2)) (π / 2)) := by
   rintro hx_gt hx_lt ⟨r, hxr_eq⟩
   rcases le_or_lt 0 r with h | h
   · rw [lt_iff_not_ge] at hx_lt
-    refine' hx_lt _
+    apply hx_lt
     rw [hxr_eq, ← one_mul (π / 2), mul_div_assoc, ge_iff_le, mul_le_mul_right (half_pos pi_pos)]
     simp [h]
   · rw [lt_iff_not_ge] at hx_gt
-    refine' hx_gt _
+    apply hx_gt
     rw [hxr_eq, ← one_mul (π / 2), mul_div_assoc, ge_iff_le, neg_mul_eq_neg_mul,
       mul_le_mul_right (half_pos pi_pos)]
     have hr_le : r ≤ -1 := by rwa [Int.lt_iff_add_one_le, ← le_neg_iff_add_nonpos_right] at h

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean
@@ -139,7 +139,7 @@ theorem arcsin_neg (x : ℝ) : arcsin (-x) = -arcsin x := by
   · rw [arcsin_of_le_neg_one hx₁, neg_neg, arcsin_of_one_le (le_neg.2 hx₁)]
   rcases le_total 1 x with hx₂ | hx₂
   · rw [arcsin_of_one_le hx₂, arcsin_of_le_neg_one (neg_le_neg hx₂)]
-  refine' arcsin_eq_of_sin_eq _ _
+  apply arcsin_eq_of_sin_eq
   · rw [sin_neg, sin_arcsin hx₁ hx₂]
   · exact ⟨neg_le_neg (arcsin_le_pi_div_two _), neg_le.2 (neg_pi_div_two_le_arcsin _)⟩
 #align real.arcsin_neg Real.arcsin_neg

--- a/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
@@ -62,7 +62,7 @@ noncomputable def sheafificationWhiskerLeftIso (P : Cᵒᵖ ⥤ D)
     (whiskeringLeft _ _ E).obj (J.sheafify P) ≅
     (whiskeringLeft _ _ _).obj P ⋙ J.sheafification E := by
   refine' J.plusFunctorWhiskerLeftIso _ ≪≫ _ ≪≫ Functor.associator _ _ _
-  refine' isoWhiskerRight _ _
+  apply isoWhiskerRight
   exact J.plusFunctorWhiskerLeftIso _
 #align category_theory.grothendieck_topology.sheafification_whisker_left_iso CategoryTheory.GrothendieckTopology.sheafificationWhiskerLeftIso
 

--- a/Mathlib/Combinatorics/Additive/SalemSpencer.lean
+++ b/Mathlib/Combinatorics/Additive/SalemSpencer.lean
@@ -418,7 +418,7 @@ variable [CancelCommMonoid α] (s : Finset α) (a : α)
 @[to_additive (attr := simp)]
 theorem mulRothNumber_map_mul_left :
     mulRothNumber (s.map <| mulLeftEmbedding a) = mulRothNumber s := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · obtain ⟨u, hus, hcard, hu⟩ := mulRothNumber_spec (s.map <| mulLeftEmbedding a)
     rw [subset_map_iff] at hus
     obtain ⟨u, hus, rfl⟩ := hus

--- a/Mathlib/Combinatorics/Schnirelmann.lean
+++ b/Mathlib/Combinatorics/Schnirelmann.lean
@@ -220,7 +220,7 @@ lemma schnirelmannDensity_setOf_mod_eq_one {m : ℕ} (hm : m ≠ 1) :
     schnirelmannDensity {n | n % m = 1} = (m⁻¹ : ℝ) := by
   rcases m.eq_zero_or_pos with rfl | hm'
   · simp only [Nat.cast_zero, inv_zero]
-    refine schnirelmannDensity_finite ?_
+    apply schnirelmannDensity_finite
     simp
   apply le_antisymm (schnirelmannDensity_le_of_le m hm'.ne' _) _
   · rw [← one_div, ← @Nat.cast_one ℝ]

--- a/Mathlib/Combinatorics/SetFamily/AhlswedeZhang.lean
+++ b/Mathlib/Combinatorics/SetFamily/AhlswedeZhang.lean
@@ -395,7 +395,7 @@ lemma supSum_of_not_univ_mem (h𝒜₁ : 𝒜.Nonempty) (h𝒜₂ : univ ∉ �
   induction' m using Nat.strong_induction_on with m ih generalizing 𝒜
   replace ih := fun 𝒜 h𝒜 h𝒜₁ h𝒜₂ ↦ @ih _ h𝒜 𝒜 h𝒜₁ h𝒜₂ rfl
   obtain ⟨a, rfl⟩ | h𝒜₃ := h𝒜₁.exists_eq_singleton_or_nontrivial
-  · refine' supSum_singleton _
+  · apply supSum_singleton
     simpa [eq_comm] using h𝒜₂
   cases m
   · cases h𝒜₁.card_pos.ne hm

--- a/Mathlib/Combinatorics/SetFamily/LYM.lean
+++ b/Mathlib/Combinatorics/SetFamily/LYM.lean
@@ -67,7 +67,7 @@ theorem card_mul_le_card_shadow_mul (h𝒜 : (𝒜 : Set (Finset α)).Sized r) :
   let i : DecidableRel ((· ⊆ ·) : Finset α → Finset α → Prop) := fun _ _ => Classical.dec _
   refine' card_mul_le_card_mul' (· ⊆ ·) (fun s hs => _) (fun s hs => _)
   · rw [← h𝒜 hs, ← card_image_of_injOn s.erase_injOn]
-    refine' card_le_card _
+    apply card_le_card
     simp_rw [image_subset_iff, mem_bipartiteBelow]
     exact fun a ha => ⟨erase_mem_shadow hs ha, erase_subset _ _⟩
   refine' le_trans _ tsub_tsub_le_tsub_add

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -159,7 +159,7 @@ protected theorem IsNClique.map (h : G.IsNClique n s) {f : α ↪ β} :
 @[simp]
 theorem isNClique_bot_iff : (⊥ : SimpleGraph α).IsNClique n s ↔ n ≤ 1 ∧ s.card = n := by
   rw [isNClique_iff, isClique_bot_iff]
-  refine' and_congr_left _
+  apply and_congr_left
   rintro rfl
   exact card_le_one.symm
 #align simple_graph.is_n_clique_bot_iff SimpleGraph.isNClique_bot_iff

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
@@ -159,7 +159,7 @@ private theorem one_sub_eps_mul_card_nonuniformWitness_le_card_star (hV : V ∈ 
         ↑2 ^ P.parts.card * m / (U.card * ε) * (G.nonuniformWitness ε U V).card := by
       rw [sub_mul, one_mul]
     _ ≤ (G.nonuniformWitness ε U V).card - ↑2 ^ (P.parts.card - 1) * m := by
-      refine' sub_le_sub_left _ _
+      apply sub_le_sub_left
       have : (2 : ℝ) ^ P.parts.card = ↑2 ^ (P.parts.card - 1) * 2 := by
         rw [← _root_.pow_succ, tsub_add_cancel_of_le (succ_le_iff.2 hP₁)]
       rw [← mul_div_right_comm, this, mul_right_comm _ (2 : ℝ), mul_assoc, le_div_iff]

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
@@ -175,7 +175,7 @@ theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ P.parts.card)
         · rw [← mul_div_right_comm, div_le_iff (by norm_num), offDiag_card]
           norm_cast
           rw [tsub_mul]
-          refine le_tsub_of_add_le_left ?_
+          apply le_tsub_of_add_le_left
           nlinarith
         · norm_num
     _ = (P.parts.offDiag.card * ε * (ε ^ 4 / 3) - P.parts.offDiag.card * (ε ^ 5 / 25)) := by ring

--- a/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
+++ b/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
@@ -1021,7 +1021,7 @@ lemma rpow_p_mul_one_sub_smoothingFn_le :
                 h_main_norm
          _ =ᶠ[atTop] fun (n:ℕ) => (b i) ^ (p a b) * n ^ (p a b) * (ε (b i * n) - ε n) := by
                 filter_upwards [eventually_gt_atTop ⌈(b i)⁻¹⌉₊, eventually_gt_atTop 1] with n hn hn'
-                refine norm_of_nonneg ?_
+                apply norm_of_nonneg
                 have h₁ := R.b_pos i
                 have h₂ : 0 ≤ ε (b i * n) - ε n := by
                   refine sub_nonneg_of_le <|
@@ -1115,7 +1115,7 @@ lemma rpow_p_mul_one_add_smoothingFn_ge :
               h_main_norm
          _ =ᶠ[atTop] fun (n:ℕ) => (b i) ^ (p a b) * n ^ (p a b) * (ε (b i * n) - ε n) := by
               filter_upwards [eventually_gt_atTop ⌈(b i)⁻¹⌉₊, eventually_gt_atTop 1] with n hn hn'
-              refine norm_of_nonneg ?_
+              apply norm_of_nonneg
               have h₁ := R.b_pos i
               have h₂ : 0 ≤ ε (b i * n) - ε n := by
                 refine sub_nonneg_of_le <|
@@ -1248,7 +1248,7 @@ lemma T_isBigO_smoothingFn_mul_asympBound :
                 * ((1 + ((∑ u in range n, g u / u ^ ((p a b) + 1))
                 - (∑ u in Finset.Ico (r i n) n, g u / u ^ ((p a b) + 1))))))) + g n := by
             congr; ext i; congr
-            refine eq_sub_of_add_eq ?_
+            apply eq_sub_of_add_eq
             rw [add_comm]
             exact add_eq_of_eq_sub <| Finset.sum_Ico_eq_sub _
               <| le_of_lt <| R.r_lt_n i n <| n₀_ge_Rn₀.trans hn
@@ -1393,7 +1393,7 @@ lemma smoothingFn_mul_asympBound_isBigO_T :
                   * ((1 + ((∑ u in range n, g u / u ^ ((p a b) + 1))
                   - (∑ u in Finset.Ico (r i n) n, g u / u ^ ((p a b) + 1))))))) + g n := by
               congr; ext i; congr
-              refine eq_sub_of_add_eq ?_
+              apply eq_sub_of_add_eq
               rw [add_comm]
               exact add_eq_of_eq_sub <| Finset.sum_Ico_eq_sub _
                 <| le_of_lt <| R.r_lt_n i n <| n₀_ge_Rn₀.trans hn
@@ -1424,7 +1424,7 @@ lemma smoothingFn_mul_asympBound_isBigO_T :
               rw [sub_nonneg]
               calc C * c₁ * (1 + ε n) ≤ C * c₁ * 2 := by
                         gcongr
-                        refine one_add_smoothingFn_le_two ?_
+                        apply one_add_smoothingFn_le_two
                         calc exp 1 ≤ ⌈exp 1⌉₊ := by exact Nat.le_ceil _
                                  _ ≤ n := by exact_mod_cast h_exp n hn
                     _ = C * (2 * c₁) := by ring

--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -489,7 +489,7 @@ lemma GrowsPolynomially.add_isLittleO {f g : ℝ → ℝ} (hf : GrowsPolynomiall
            _ ≥ f u + 1/2 * f u := by
                   rw [sub_eq_add_neg]
                   gcongr
-                  refine le_of_neg_le_neg ?_
+                  apply le_of_neg_le_neg
                   rwa [neg_neg, ← neg_mul, ← neg_div]
            _ = 3/2 * f u := by ring
            _ ≥ 3/2 * (c₁ * f x) := by gcongr; exact (hf₁ u ⟨hu_lb, hu_ub⟩).1

--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -2003,7 +2003,7 @@ variable {ι' : Sort*} [CompleteLattice α]
 that works for `ι : Sort*`. -/
 theorem iSup_eq_iSup_finset (s : ι → α) : ⨆ i, s i = ⨆ t : Finset ι, ⨆ i ∈ t, s i := by
   classical
-  refine le_antisymm ?_ ?_
+  apply le_antisymm
   · exact iSup_le fun b => le_iSup_of_le {b} <| le_iSup_of_le b <| le_iSup_of_le (by simp) <| le_rfl
   · exact iSup_le fun t => iSup_le fun b => iSup_le fun _ => le_iSup _ _
 #align supr_eq_supr_finset iSup_eq_iSup_finset

--- a/Mathlib/Data/Finset/LocallyFinite/Box.lean
+++ b/Mathlib/Data/Finset/LocallyFinite/Box.lean
@@ -77,7 +77,7 @@ lemma card_box : ∀ {n}, n ≠ 0 → (box n : Finset (ℤ × ℤ)).card = 8 * n
   | n + 1, _ => by
     simp_rw [Prod.card_box_succ, card_Icc, sub_neg_eq_add]
     norm_cast
-    refine tsub_eq_of_eq_add ?_
+    apply tsub_eq_of_eq_add
     zify
     ring
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -2097,7 +2097,7 @@ def foldlRecOn {C : β → Sort*} (l : List α) (op : β → α → β) (b : β)
   induction l generalizing b with
   | nil => exact hb
   | cons hd tl IH =>
-    refine' IH _ _ _
+    apply IH
     · exact hl b hb hd (mem_cons_self hd tl)
     · intro y hy x hx
       exact hl y hy x (mem_cons_of_mem hd hx)
@@ -2537,7 +2537,7 @@ theorem splitOn_intercalate [DecidableEq α] (x : α) (hx : ∀ l ∈ ls, x ∉ 
   induction' ls with hd tl ih; · contradiction
   cases tl
   · suffices hd.splitOn x = [hd] by simpa [join]
-    refine' splitOnP_eq_single _ _ _
+    apply splitOnP_eq_single
     intro y hy H
     rw [eq_of_beq H] at hy
     refine' hx hd _ hy

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -2083,7 +2083,7 @@ def foldrRecOn {C : β → Sort*} (l : List α) (op : α → β → β) (b : β)
   | nil => exact hb
   | cons hd tl IH =>
     refine' hl _ _ hd (mem_cons_self hd tl)
-    refine' IH _
+    apply IH
     intro y hy x hx
     exact hl y hy x (mem_cons_of_mem hd hx)
 #align list.foldr_rec_on List.foldrRecOn

--- a/Mathlib/Data/Nat/Cast/Field.lean
+++ b/Mathlib/Data/Nat/Cast/Field.lean
@@ -69,13 +69,13 @@ theorem one_div_pos_of_nat {n : ℕ} : 0 < 1 / ((n : α) + 1) := by
 #align nat.one_div_pos_of_nat Nat.one_div_pos_of_nat
 
 theorem one_div_le_one_div {n m : ℕ} (h : n ≤ m) : 1 / ((m : α) + 1) ≤ 1 / ((n : α) + 1) := by
-  refine' one_div_le_one_div_of_le _ _
+  apply one_div_le_one_div_of_le
   exact Nat.cast_add_one_pos _
   simpa
 #align nat.one_div_le_one_div Nat.one_div_le_one_div
 
 theorem one_div_lt_one_div {n m : ℕ} (h : n < m) : 1 / ((m : α) + 1) < 1 / ((n : α) + 1) := by
-  refine' one_div_lt_one_div_of_lt _ _
+  apply one_div_lt_one_div_of_lt
   exact Nat.cast_add_one_pos _
   simpa
 #align nat.one_div_lt_one_div Nat.one_div_lt_one_div

--- a/Mathlib/Data/Nat/Choose/Multinomial.lean
+++ b/Mathlib/Data/Nat/Choose/Multinomial.lean
@@ -288,7 +288,7 @@ theorem multinomial_coe_fill_of_not_mem {m : Fin (n + 1)} {s : Sym α (n - m)} {
   rw [← mem_coe] at hx
   refine congrArg₂ _ ?_ ?_
   · rw [card_coe, count_coe_fill_self_of_not_mem hx]
-  · refine congrArg _ ?_
+  · apply congrArg
     rw [coe_fill, coe_replicate, Multiset.filter_add]
     rw [Multiset.filter_eq_self.mpr]
     · rw [add_right_eq_self]

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -660,7 +660,7 @@ lemma div_eq_self : m / n = m ↔ m = 0 ∨ n = 1 := by
     | n+2 =>
       left
       have : m / (n + 2) ≤ m / 2 := div_le_div_left (by simp) (by decide)
-      refine eq_zero_of_le_half ?_
+      apply eq_zero_of_le_half
       simp_all
   · rintro (rfl | rfl) <;> simp
 #align nat.div_eq_self Nat.div_eq_self

--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -169,7 +169,7 @@ theorem le_of_mem_factors {n p : ℕ} (h : p ∈ n.factors) : p ≤ n := by
 /-- **Fundamental theorem of arithmetic**-/
 theorem factors_unique {n : ℕ} {l : List ℕ} (h₁ : prod l = n) (h₂ : ∀ p ∈ l, Prime p) :
     l ~ factors n := by
-  refine' perm_of_prod_eq_prod _ _ _
+  apply perm_of_prod_eq_prod
   · rw [h₁]
     refine' (prod_factors _).symm
     rintro rfl

--- a/Mathlib/Data/Nat/Multiplicity.lean
+++ b/Mathlib/Data/Nat/Multiplicity.lean
@@ -287,7 +287,7 @@ end Prime
 
 theorem multiplicity_two_factorial_lt : ∀ {n : ℕ} (_ : n ≠ 0), multiplicity 2 n ! < n := by
   have h2 := prime_two.prime
-  refine' binaryRec _ _
+  apply binaryRec
   · exact fun h => False.elim <| h rfl
   · intro b n ih h
     by_cases hn : n = 0

--- a/Mathlib/Data/Nat/Multiplicity.lean
+++ b/Mathlib/Data/Nat/Multiplicity.lean
@@ -235,7 +235,7 @@ theorem multiplicity_le_multiplicity_choose_add {p : ℕ} (hp : p.Prime) :
   | 0, _ + 1 => by simp
   | n + 1, k + 1 => by
     rw [← hp.multiplicity_mul]
-    refine' multiplicity_le_multiplicity_of_dvd_right _
+    apply multiplicity_le_multiplicity_of_dvd_right
     rw [← succ_mul_choose_eq]
     exact dvd_mul_right _ _
 #align nat.prime.multiplicity_le_multiplicity_choose_add Nat.Prime.multiplicity_le_multiplicity_choose_add

--- a/Mathlib/Data/QPF/Multivariate/Constructions/Cofix.lean
+++ b/Mathlib/Data/QPF/Multivariate/Constructions/Cofix.lean
@@ -522,8 +522,9 @@ theorem corec_roll {α : TypeVec n} {X Y} {x₀ : X} (f : X → Y) (g : Y → F 
   mv_bisim x₀ with R a b x Ha Hb
   rw [Ha, Hb, Cofix.dest_corec, Cofix.dest_corec, Function.comp_apply, Function.comp_apply]
   rw [MvFunctor.map_map, ← appendFun_comp_id]
-  refine' liftR_map_last _ _ _ _ _
-  intro a; refine' ⟨a, rfl, rfl⟩
+  apply liftR_map_last
+  intro a
+  refine' ⟨a, rfl, rfl⟩
 #align mvqpf.corec_roll MvQPF.corec_roll
 
 theorem Cofix.dest_corec' {α : TypeVec.{u} n} {β : Type u}

--- a/Mathlib/Data/Set/Intervals/Disjoint.lean
+++ b/Mathlib/Data/Set/Intervals/Disjoint.lean
@@ -276,7 +276,7 @@ theorem iInter_Iic_eq_empty_iff : ⋂ i, Iic (f i) = ∅ ↔ ¬ BddBelow (range 
   simp [not_bddBelow_iff, Set.eq_empty_iff_forall_not_mem]
 
 theorem iInter_Iio_of_not_bddBelow_range (hf : ¬ BddBelow (range f)) : ⋂ i, Iio (f i) = ∅ := by
-  refine' eq_empty_of_subset_empty _
+  apply eq_empty_of_subset_empty
   rw [← iInter_Iic_eq_empty_iff.mpr hf]
   gcongr
   exact Iio_subset_Iic_self

--- a/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
+++ b/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
@@ -867,7 +867,7 @@ theorem map_lt_of_translationNumber_lt_nat {n : ℕ} (h : τ f < n) (x : ℝ) : 
 theorem map_lt_add_floor_translationNumber_add_one (x : ℝ) : f x < x + ⌊τ f⌋ + 1 := by
   rw [add_assoc]
   norm_cast
-  refine' map_lt_of_translationNumber_lt_int _ _ _
+  apply map_lt_of_translationNumber_lt_int
   push_cast
   exact lt_floor_add_one _
 #align circle_deg1_lift.map_lt_add_floor_translation_number_add_one CircleDeg1Lift.map_lt_add_floor_translationNumber_add_one

--- a/Mathlib/FieldTheory/Minpoly/MinpolyDiv.lean
+++ b/Mathlib/FieldTheory/Minpoly/MinpolyDiv.lean
@@ -139,7 +139,7 @@ lemma coeff_minpolyDiv_sub_pow_mem_span {i} (hi : i ≤ natDegree (minpolyDiv R 
   | zero => simp [(minpolyDiv_monic hx).leadingCoeff]
   | succ i IH =>
     rw [coeff_minpolyDiv, add_sub_assoc, pow_succ, ← sub_mul, Algebra.algebraMap_eq_smul_one]
-    refine add_mem ?_ ?_
+    apply add_mem
     · apply Submodule.smul_mem
       apply Submodule.subset_span
       exact ⟨0, Nat.zero_lt_succ _, pow_zero _⟩

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/RightAngle.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/RightAngle.lean
@@ -80,7 +80,7 @@ theorem angle_add_eq_arcsin_of_inner_eq_zero {x y : V} (h : ⟪x, y⟫ = 0) (h0 
     angle x (x + y) = Real.arcsin (‖y‖ / ‖x + y‖) := by
   have hxy : ‖x + y‖ ^ 2 ≠ 0 := by
     rw [pow_two, norm_add_sq_eq_norm_sq_add_norm_sq_real h, ne_comm]
-    refine' ne_of_lt _
+    apply ne_of_lt
     rcases h0 with (h0 | h0)
     · exact
         Left.add_pos_of_pos_of_nonneg (mul_self_pos.2 (norm_ne_zero_iff.2 h0)) (mul_self_nonneg _)

--- a/Mathlib/Geometry/Euclidean/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Basic.lean
@@ -153,7 +153,7 @@ theorem eq_of_dist_eq_of_dist_eq_of_mem_of_finrank_eq_two {s : AffineSubspace �
     inner_vsub_vsub_of_dist_eq_of_dist_eq (hp₁c₁.trans hpc₁.symm) (hp₁c₂.trans hpc₂.symm)
   let b : Fin 2 → V := ![c₂ -ᵥ c₁, p₂ -ᵥ p₁]
   have hb : LinearIndependent ℝ b := by
-    refine' linearIndependent_of_ne_zero_of_inner_eq_zero _ _
+    apply linearIndependent_of_ne_zero_of_inner_eq_zero
     · intro i
       fin_cases i <;> simp [b, hc.symm, hp.symm]
     · intro i j hij
@@ -162,7 +162,7 @@ theorem eq_of_dist_eq_of_dist_eq_of_mem_of_finrank_eq_two {s : AffineSubspace �
       · rw [real_inner_comm]
         exact ho
   have hbs : Submodule.span ℝ (Set.range b) = s.direction := by
-    refine' eq_of_le_of_finrank_eq _ _
+    apply eq_of_le_of_finrank_eq
     · rw [Submodule.span_le, Set.range_subset_iff]
       intro i
       fin_cases i

--- a/Mathlib/Geometry/Euclidean/MongePoint.lean
+++ b/Mathlib/Geometry/Euclidean/MongePoint.lean
@@ -416,7 +416,7 @@ theorem affineSpan_pair_eq_altitude_iff {n : ℕ} (s : Simplex ℝ P (n + 1)) (i
     rw [vectorSpan_eq_span_vsub_set_left_ne ℝ (Set.mem_insert _ _),
       Set.insert_diff_of_mem _ (Set.mem_singleton _),
       Set.diff_singleton_eq_self fun h => hne (Set.mem_singleton_iff.1 h), Set.image_singleton]
-    refine' eq_of_le_of_finrank_eq _ _
+    apply eq_of_le_of_finrank_eq
     · rw [Submodule.span_le]
       simpa using h
     · rw [finrank_direction_altitude, finrank_span_set_eq_card]

--- a/Mathlib/Geometry/Euclidean/MongePoint.lean
+++ b/Mathlib/Geometry/Euclidean/MongePoint.lean
@@ -421,7 +421,7 @@ theorem affineSpan_pair_eq_altitude_iff {n : ℕ} (s : Simplex ℝ P (n + 1)) (i
       simpa using h
     · rw [finrank_direction_altitude, finrank_span_set_eq_card]
       · simp
-      · refine' linearIndependent_singleton _
+      · apply linearIndependent_singleton
         simpa using hne
 #align affine.simplex.affine_span_pair_eq_altitude_iff Affine.Simplex.affineSpan_pair_eq_altitude_iff
 
@@ -563,7 +563,7 @@ theorem dist_orthocenter_reflection_circumcenter_finset (t : Triangle ℝ P) {i�
 the altitude. -/
 theorem affineSpan_orthocenter_point_le_altitude (t : Triangle ℝ P) (i : Fin 3) :
     line[ℝ, t.orthocenter, t.points i] ≤ t.altitude i := by
-  refine' spanPoints_subset_coe_of_subset_coe _
+  apply spanPoints_subset_coe_of_subset_coe
   rw [Set.insert_subset_iff, Set.singleton_subset_iff]
   exact ⟨t.orthocenter_mem_altitude, t.mem_altitude i⟩
 #align affine.triangle.affine_span_orthocenter_point_le_altitude Affine.Triangle.affineSpan_orthocenter_point_le_altitude

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
@@ -203,7 +203,7 @@ theorem snd_invApp_t_app' (i j k : D.J) (U : Opens (pullback (D.f i j) (D.f i k)
     · refine Function.HasLeftInverse.injective ⟨(D.t i k).base, fun x => ?_⟩
       rw [← comp_apply, ← comp_base, D.t_inv, id_base, id_apply]
     refine congr_arg (_ '' ·) ?_
-    refine congr_fun ?_ _
+    apply congr_fun
     refine Set.image_eq_preimage_of_inverse ?_ ?_
     · intro x
       rw [← comp_apply, ← comp_base, IsIso.inv_hom_id, id_base, id_apply]

--- a/Mathlib/GroupTheory/Exponent.lean
+++ b/Mathlib/GroupTheory/Exponent.lean
@@ -639,7 +639,7 @@ constituent monoids. -/
 exponents of the constituent additive monoids."]
 theorem Monoid.exponent_pi {ι : Type*} [Fintype ι] {M : ι → Type*} [∀ i, Monoid (M i)] :
     exponent ((i : ι) → M i) = lcm univ (exponent <| M ·) := by
-  refine dvd_antisymm ?_ ?_
+  apply dvd_antisymm
   · refine exponent_dvd_of_forall_pow_eq_one fun m ↦ ?_
     ext i
     rw [Pi.pow_apply, Pi.one_apply, ← orderOf_dvd_iff_pow_eq_one]

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -311,7 +311,7 @@ theorem smul_cancel_of_non_zero_divisor {M R : Type*} [Monoid M] [NonUnitalNonAs
     [DistribMulAction M R] (k : M) (h : ∀ x : R, k • x = 0 → x = 0) {a b : R} (h' : k • a = k • b) :
     a = b := by
   rw [← sub_eq_zero]
-  refine' h _ _
+  apply h
   rw [smul_sub, h', sub_self]
 #align smul_cancel_of_non_zero_divisor smul_cancel_of_non_zero_divisor
 

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -208,7 +208,7 @@ theorem upperCentralSeries_isAscendingCentralSeries :
 #align upper_central_series_is_ascending_central_series upperCentralSeries_isAscendingCentralSeries
 
 theorem upperCentralSeries_mono : Monotone (upperCentralSeries G) := by
-  refine' monotone_nat_of_le_succ _
+  apply monotone_nat_of_le_succ
   intro n x hx y
   rw [mul_assoc, mul_assoc, ← mul_assoc y x⁻¹ y⁻¹]
   exact mul_mem hx (Normal.conj_mem (upperCentralSeries_normal G n) x⁻¹ (inv_mem hx) y)

--- a/Mathlib/GroupTheory/NoncommPiCoprod.lean
+++ b/Mathlib/GroupTheory/NoncommPiCoprod.lean
@@ -168,7 +168,7 @@ theorem noncommPiCoprod_mrange :
     apply Submonoid.mem_sSup_of_mem
     · use i
     simp
-  · refine' iSup_le _
+  · apply iSup_le
     rintro i x ⟨y, rfl⟩
     exact ⟨Pi.mulSingle i y, noncommPiCoprod_mulSingle _ _ _⟩
 #align monoid_hom.noncomm_pi_coprod_mrange MonoidHom.noncommPiCoprod_mrange
@@ -202,7 +202,7 @@ theorem noncommPiCoprod_range : (noncommPiCoprod ϕ hcomm).range = ⨆ i : ι, (
     apply Subgroup.mem_sSup_of_mem
     · use i
     simp
-  · refine' iSup_le _
+  · apply iSup_le
     rintro i x ⟨y, rfl⟩
     exact ⟨Pi.mulSingle i y, noncommPiCoprod_mulSingle _ _ _⟩
 #align monoid_hom.noncomm_pi_coprod_range MonoidHom.noncommPiCoprod_range

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -400,7 +400,7 @@ def toCycle (f : Perm α) (hf : IsCycle f) : Cycle α :=
     (fun x _ l => if f x = x then l else toList f x)
     (by
       intro x y _ s
-      refine' heq_of_eq _
+      apply heq_of_eq
       split_ifs with hx hy hy <;> try rfl
       · have hc : SameCycle f x y := IsCycle.sameCycle hf hx hy
         exact Quotient.sound' hc.toList_isRotated)

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -290,7 +290,7 @@ theorem nodup_toList (p : Perm α) (x : α) : Nodup (toList p x) := by
   have hm' : ¬orderOf (p.cycleOf x) ∣ m.succ := Nat.not_dvd_of_pos_of_lt m.zero_lt_succ hm
   rw [← hc.support_pow_eq_iff] at hn' hm'
   rw [← Nat.mod_eq_of_lt hn, ← Nat.mod_eq_of_lt hm, ← pow_inj_mod]
-  refine' support_congr _ _
+  apply support_congr
   · rw [hm', hn']
   · rw [hm']
     intro y hy

--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -185,7 +185,7 @@ theorem orderOf_cycleOf_dvd_orderOf (f : Perm α) (x : α) : orderOf (cycleOf f 
   by_cases hx : f x = x
   · rw [← cycleOf_eq_one_iff] at hx
     simp [hx]
-  · refine dvd_of_mem_cycleType ?_
+  · apply dvd_of_mem_cycleType
     rw [cycleType, Multiset.mem_map]
     refine' ⟨f.cycleOf x, _, _⟩
     · rwa [← Finset.mem_def, cycleOf_mem_cycleFactorsFinset_iff, mem_support]
@@ -223,7 +223,7 @@ theorem cycleType_le_of_mem_cycleFactorsFinset {f g : Perm α} (hf : f ∈ g.cyc
     f.cycleType ≤ g.cycleType := by
   have hf' := mem_cycleFactorsFinset_iff.1 hf
   rw [cycleType_def, cycleType_def, hf'.left.cycleFactorsFinset_eq_singleton]
-  refine map_le_map ?_
+  apply map_le_map
   simpa only [Finset.singleton_val, singleton_le, Finset.mem_val] using hf
 #align equiv.perm.cycle_type_le_of_mem_cycle_factors_finset Equiv.Perm.cycleType_le_of_mem_cycleFactorsFinset
 

--- a/Mathlib/GroupTheory/Perm/List.lean
+++ b/Mathlib/GroupTheory/Perm/List.lean
@@ -456,7 +456,7 @@ theorem formPerm_pow_length_eq_one_of_nodup (hl : Nodup l) : formPerm l ^ length
     simp [formPerm_pow_apply_nthLe _ hl, Nat.mod_eq_of_lt hk]
   · have : x ∉ { x | (l.formPerm ^ l.length) x ≠ x } := by
       intro H
-      refine' hx _
+      apply hx
       replace H := set_support_zpow_subset l.formPerm l.length H
       simpa using support_formPerm_le' _ H
     simpa using this

--- a/Mathlib/GroupTheory/SchurZassenhaus.lean
+++ b/Mathlib/GroupTheory/SchurZassenhaus.lean
@@ -207,7 +207,7 @@ private theorem step2 (K : Subgroup G) [K.Normal] (hK : K ≤ N) : K = ⊥ ∨ K
   obtain ⟨H, hH⟩ := h2 (G ⧸ K) h5 h6
   refine' ⟨H.comap (QuotientGroup.mk' K), _, _⟩
   · have key : (N.map (QuotientGroup.mk' K)).comap (QuotientGroup.mk' K) = N := by
-      refine' comap_map_eq_self _
+      apply comap_map_eq_self
       rwa [QuotientGroup.ker_mk']
     rwa [← key, comap_sup_eq, hH.symm.sup_eq_top, comap_top]
   · rw [← comap_top (QuotientGroup.mk' K)]

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
@@ -239,7 +239,7 @@ theorem normalClosure_finRotate_five : normalClosure ({⟨finRotate 5,
         IsThreeCycle (Fin.cycleRange 2 * finRotate 5 * (Fin.cycleRange 2)⁻¹ * (finRotate 5)⁻¹) :=
         card_support_eq_three_iff.1 (by decide)
       rw [← h3.alternating_normalClosure (by rw [card_fin])]
-      refine' normalClosure_le_normal _
+      apply normalClosure_le_normal
       rw [Set.singleton_subset_iff, SetLike.mem_coe]
       have h :
         (⟨finRotate 5, finRotate_bit1_mem_alternatingGroup (n := 2)⟩ : alternatingGroup (Fin 5)) ∈
@@ -266,7 +266,7 @@ theorem normalClosure_swap_mul_swap_five :
     simp only [Fin.val_mk, Subgroup.coe_mul, Subgroup.coe_inv, Fin.val_mk]
     decide
   rw [eq_top_iff, ← normalClosure_finRotate_five]
-  refine' normalClosure_le_normal _
+  apply normalClosure_le_normal
   rw [Set.singleton_subset_iff, SetLike.mem_coe, ← h5]
   have h : g2 ∈ normalClosure {g2} :=
     SetLike.mem_coe.1 (subset_normalClosure (Set.mem_singleton _))
@@ -338,7 +338,7 @@ instance isSimpleGroup_five : IsSimpleGroup (alternatingGroup (Fin 5)) :=
     -- `g^2` is in the normal closure of `g`, so that normal closure must be $A_5$.
     · rw [eq_top_iff, ← (isThreeCycle_sq_of_three_mem_cycleType_five ng).alternating_normalClosure
         (by rw [card_fin])]
-      refine' normalClosure_le_normal _
+      apply normalClosure_le_normal
       rw [Set.singleton_subset_iff, SetLike.mem_coe]
       have h := SetLike.mem_coe.1 (subset_normalClosure
         (G := alternatingGroup (Fin 5)) (Set.mem_singleton ⟨g, gA⟩))

--- a/Mathlib/GroupTheory/Subgroup/Basic.lean
+++ b/Mathlib/GroupTheory/Subgroup/Basic.lean
@@ -2725,7 +2725,7 @@ theorem subgroupOf_range_eq_of_le {G₁ G₂ : Type*} [Group G₁] [Group G₂] 
     (f : G₁ →* G₂) (h : f.range ≤ K) :
     f.range.subgroupOf K = (f.codRestrict K fun x => h ⟨x, rfl⟩).range := by
   ext k
-  refine' exists_congr _
+  apply exists_congr
   simp [Subtype.ext_iff]
 #align monoid_hom.subgroup_of_range_eq_of_le MonoidHom.subgroupOf_range_eq_of_le
 #align add_monoid_hom.add_subgroup_of_range_eq_of_le AddMonoidHom.addSubgroupOf_range_eq_of_le

--- a/Mathlib/GroupTheory/Subgroup/Pointwise.lean
+++ b/Mathlib/GroupTheory/Subgroup/Pointwise.lean
@@ -364,7 +364,7 @@ theorem conj_smul_le_of_le {P H : Subgroup G} (hP : P ≤ H) (h : H) :
 
 theorem conj_smul_subgroupOf {P H : Subgroup G} (hP : P ≤ H) (h : H) :
     MulAut.conj h • P.subgroupOf H = (MulAut.conj (h : G) • P).subgroupOf H := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · rintro - ⟨g, hg, rfl⟩
     exact ⟨g, hg, rfl⟩
   · rintro p ⟨g, hg, hp⟩

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean
@@ -283,7 +283,7 @@ vectors subtracting that point on the right. -/
 theorem coe_direction_eq_vsub_set_right {s : AffineSubspace k P} {p : P} (hp : p ∈ s) :
     (s.direction : Set V) = (· -ᵥ p) '' s := by
   rw [coe_direction_eq_vsub_set ⟨p, hp⟩]
-  refine' le_antisymm _ _
+  apply le_antisymm
   · rintro v ⟨p1, hp1, p2, hp2, rfl⟩
     exact ⟨p1 -ᵥ p2 +ᵥ p, vadd_mem_of_mem_direction (vsub_mem_direction hp1 hp2) hp, vadd_vsub _ _⟩
   · rintro v ⟨p2, hp2, rfl⟩
@@ -1445,7 +1445,7 @@ variable {k : Type*} {V : Type*} {P : Type*} [Ring k] [AddCommGroup V] [Module k
 of any one difference between points in the two subspaces. -/
 theorem direction_sup {s1 s2 : AffineSubspace k P} {p1 p2 : P} (hp1 : p1 ∈ s1) (hp2 : p2 ∈ s2) :
     (s1 ⊔ s2).direction = s1.direction ⊔ s2.direction ⊔ k ∙ p2 -ᵥ p1 := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · change (affineSpan k ((s1 : Set P) ∪ s2)).direction ≤ _
     rw [← mem_coe] at hp1
     rw [direction_affineSpan, vectorSpan_eq_span_vsub_set_right k (Set.mem_union_left _ hp1),

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -476,7 +476,7 @@ theorem affineCombination_of_eq_one_of_eq_zero (w : ι → k) (p : ι → P) {i 
   rw [s.affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one w p h1 (p i),
     weightedVSubOfPoint_apply]
   convert zero_vadd V (p i)
-  refine sum_eq_zero ?_
+  apply sum_eq_zero
   intro i2 hi2
   by_cases h : i2 = i
   · simp [h]
@@ -806,7 +806,7 @@ theorem sum_centroidWeights_eq_one_of_card_ne_zero [CharZero k] (h : card s ≠ 
     ∑ i in s, s.centroidWeights k i = 1 := by
   -- Porting note: `simp` cannot find `mul_inv_cancel` and does not use `norm_cast`
   simp only [centroidWeights_apply, sum_const, nsmul_eq_mul, ne_eq, Nat.cast_eq_zero, card_eq_zero]
-  refine mul_inv_cancel ?_
+  apply mul_inv_cancel
   norm_cast
 #align finset.sum_centroid_weights_eq_one_of_card_ne_zero Finset.sum_centroidWeights_eq_one_of_card_ne_zero
 

--- a/Mathlib/LinearAlgebra/Dimension/LinearMap.lean
+++ b/Mathlib/LinearAlgebra/Dimension/LinearMap.lean
@@ -49,7 +49,7 @@ theorem rank_zero [Nontrivial K] : rank (0 : V →ₗ[K] V') = 0 := by
 variable [AddCommGroup V''] [Module K V'']
 
 theorem rank_comp_le_left (g : V →ₗ[K] V') (f : V' →ₗ[K] V'') : rank (f.comp g) ≤ rank f := by
-  refine' rank_le_of_submodule _ _ _
+  apply rank_le_of_submodule
   rw [LinearMap.range_comp]
   exact LinearMap.map_le_range
 #align linear_map.rank_comp_le_left LinearMap.rank_comp_le_left
@@ -90,7 +90,7 @@ variable [AddCommGroup V'] [Module K V']
 theorem rank_add_le (f g : V →ₗ[K] V') : rank (f + g) ≤ rank f + rank g :=
   calc
     rank (f + g) ≤ Module.rank K (LinearMap.range f ⊔ LinearMap.range g : Submodule K V') := by
-      refine' rank_le_of_submodule _ _ _
+      apply rank_le_of_submodule
       exact LinearMap.range_le_iff_comap.2 <| eq_top_iff'.2 fun x =>
         show f x + g x ∈ (LinearMap.range f ⊔ LinearMap.range g : Submodule K V') from
         mem_sup.2 ⟨_, ⟨x, rfl⟩, _, ⟨x, rfl⟩, rfl⟩

--- a/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
@@ -50,11 +50,11 @@ protected def directSum :
     ((⨁ i₁, M₁ i₁) ⊗[R] ⨁ i₂, M₂ i₂) ≃ₗ[R] ⨁ i : ι₁ × ι₂, M₁ i.1 ⊗[R] M₂ i.2 := by
   -- Porting note: entirely rewritten to allow unification to happen one step at a time
   refine LinearEquiv.ofLinear (R := R) (R₂ := R) ?toFun ?invFun ?left ?right
-  · refine lift ?_
+  · apply lift
     refine DirectSum.toModule R _ _ fun i₁ => ?_
     refine LinearMap.flip ?_
     refine DirectSum.toModule R _ _ fun i₂ => LinearMap.flip <| ?_
-    refine curry ?_
+    apply curry
     exact DirectSum.lof R (ι₁ × ι₂) (fun i => M₁ i.1 ⊗[R] M₂ i.2) (i₁, i₂)
   · refine DirectSum.toModule R _ _ fun i => ?_
     exact map (DirectSum.lof R _ M₁ i.1) (DirectSum.lof R _ M₂ i.2)

--- a/Mathlib/LinearAlgebra/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Finsupp.lean
@@ -805,7 +805,7 @@ theorem span_image_eq_map_total (s : Set α) :
       · simp [(Finsupp.mem_supported' R _).1 hz _ h]
     -- Porting note: `rw` is required to infer metavariables in `sum_mem`.
     rw [mem_comap, total_apply]
-    refine' sum_mem _
+    apply sum_mem
     simp [this]
 #align finsupp.span_image_eq_map_total Finsupp.span_image_eq_map_total
 

--- a/Mathlib/LinearAlgebra/LinearPMap.lean
+++ b/Mathlib/LinearAlgebra/LinearPMap.lean
@@ -968,7 +968,7 @@ section SubmoduleToLinearPMap
 theorem existsUnique_from_graph {g : Submodule R (E × F)}
     (hg : ∀ {x : E × F} (_hx : x ∈ g) (_hx' : x.fst = 0), x.snd = 0) {a : E}
     (ha : a ∈ g.map (LinearMap.fst R E F)) : ∃! b : F, (a, b) ∈ g := by
-  refine' exists_unique_of_exists_of_unique _ _
+  apply exists_unique_of_exists_of_unique
   · convert ha
     simp
   intro y₁ y₂ hy₁ hy₂

--- a/Mathlib/LinearAlgebra/LinearPMap.lean
+++ b/Mathlib/LinearAlgebra/LinearPMap.lean
@@ -928,7 +928,7 @@ theorem le_of_le_graph {f g : E →ₗ.[R] F} (h : f.graph ≤ g.graph) : f ≤ 
     exact h hx
   rintro ⟨x, hx⟩ ⟨y, hy⟩ hxy
   rw [image_iff]
-  refine' h _
+  apply h
   simp only [Submodule.coe_mk] at hxy
   rw [hxy] at hx
   rw [← image_iff hx]

--- a/Mathlib/LinearAlgebra/Matrix/Block.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Block.lean
@@ -229,7 +229,7 @@ protected theorem BlockTriangular.det [DecidableEq α] [LinearOrder α] (hM : Bl
       rw [insert_erase]
       apply max'_mem
     rw [this, prod_insert (not_mem_erase _ _)]
-    refine' congr_arg _ _
+    apply congr_arg
     let b' := fun i : { a // b a ≠ k } => b ↑i
     have h' : BlockTriangular (M.toSquareBlockProp fun i => b i ≠ k) b' := hM.submatrix
     have hb' : image b' univ = (image b univ).erase k := by

--- a/Mathlib/LinearAlgebra/Matrix/Gershgorin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Gershgorin.lean
@@ -63,7 +63,7 @@ theorem det_ne_zero_of_sum_row_lt_diag (h : ∀ k, ∑ j in Finset.univ.erase k,
   contrapose! h
   suffices ∃ k, 0 ∈ Metric.closedBall (A k k) (∑ j in Finset.univ.erase k, ‖A k j‖) by
     exact this.imp (fun a h ↦ by rwa [mem_closedBall_iff_norm', sub_zero] at h)
-  refine eigenvalue_mem_ball ?_
+  apply eigenvalue_mem_ball
   rw [Module.End.HasEigenvalue,  Module.End.eigenspace_zero, ne_comm]
   exact ne_of_lt (LinearMap.bot_lt_ker_of_det_eq_zero (by rwa [LinearMap.det_toLin']))
 

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -590,7 +590,7 @@ theorem inv_smul' (k : αˣ) (h : IsUnit A.det) : (k • A)⁻¹ = k⁻¹ • A�
 #align matrix.inv_smul' Matrix.inv_smul'
 
 theorem inv_adjugate (A : Matrix n n α) (h : IsUnit A.det) : (adjugate A)⁻¹ = h.unit⁻¹ • A := by
-  refine' inv_eq_left_inv _
+  apply inv_eq_left_inv
   rw [smul_mul, mul_adjugate, Units.smul_def, smul_smul, h.val_inv_mul, one_smul]
 #align matrix.inv_adjugate Matrix.inv_adjugate
 

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -556,7 +556,7 @@ theorem right_inv_eq_left_inv (h : A * B = 1) (g : C * A = 1) : B = C := by
 theorem inv_inj (h : A⁻¹ = B⁻¹) (h' : IsUnit A.det) : A = B := by
   refine' left_inv_eq_left_inv (mul_nonsing_inv _ h') _
   rw [h]
-  refine' mul_nonsing_inv _ _
+  apply mul_nonsing_inv
   rwa [← isUnit_nonsing_inv_det_iff, ← h, isUnit_nonsing_inv_det_iff]
 #align matrix.inv_inj Matrix.inv_inj
 
@@ -574,7 +574,7 @@ theorem inv_zero : (0 : Matrix n n α)⁻¹ = 0 := by
     ext i
     exact (IsEmpty.false i).elim
   · have hn : Nonempty n := Fintype.card_pos_iff.mp hc
-    refine' nonsing_inv_apply_not_isUnit _ _
+    apply nonsing_inv_apply_not_isUnit
     simp [hn]
 #align matrix.inv_zero Matrix.inv_zero
 

--- a/Mathlib/LinearAlgebra/Matrix/ToLinearEquiv.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLinearEquiv.lean
@@ -237,7 +237,7 @@ lemma det_ne_zero_of_sum_row_pos [DecidableEq n] {S : Type*} [LinearOrderedCommR
     {A : Matrix n n S} (h1 : Pairwise fun i j => A i j < 0) (h2 : ∀ i, 0 < ∑ j, A i j) :
     A.det ≠ 0 := by
   rw [← Matrix.det_transpose]
-  refine det_ne_zero_of_sum_col_pos ?_ ?_
+  apply det_ne_zero_of_sum_col_pos
   · simp_rw [Matrix.transpose_apply]
     exact fun i j h => h1 h.symm
   · simp_rw [Matrix.transpose_apply]

--- a/Mathlib/LinearAlgebra/Matrix/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Transvection.lean
@@ -238,7 +238,7 @@ theorem prod_mul_reverse_inv_prod (L : List (TransvectionStruct n R)) :
 theorem _root_.Matrix.mem_range_scalar_of_commute_transvectionStruct {M : Matrix n n R}
     (hM : ∀ t : TransvectionStruct n R, Commute t.toMatrix M) :
     M ∈ Set.range (Matrix.scalar n) := by
-  refine mem_range_scalar_of_commute_stdBasisMatrix ?_
+  apply mem_range_scalar_of_commute_stdBasisMatrix
   intro i j hij
   simpa [transvection, mul_add, add_mul] using (hM ⟨i, j, hij, 1⟩).eq
 

--- a/Mathlib/Logic/Denumerable.lean
+++ b/Mathlib/Logic/Denumerable.lean
@@ -105,7 +105,7 @@ theorem ofEquiv_ofNat (α) {β} [Denumerable α] (e : β ≃ α) (n) :
     @ofNat β (ofEquiv _ e) n = e.symm (ofNat α n) := by
   -- Porting note: added `letI`
   letI := ofEquiv _ e
-  refine ofNat_of_decode ?_
+  apply ofNat_of_decode
   rw [decode_ofEquiv e]
   simp
 #align denumerable.of_equiv_of_nat Denumerable.ofEquiv_ofNat
@@ -291,7 +291,7 @@ theorem ofNat_surjective_aux : ∀ {x : ℕ} (hx : x ∈ s), ∃ n, ofNat s n = 
       rwa [← List.maximum_eq_none.1 hmax, hmt]
     cases' ofNat_surjective_aux m.2 with a ha
     refine ⟨a + 1, le_antisymm ?_ ?_⟩ <;> rw [ofNat]
-    · refine succ_le_of_lt ?_
+    · apply succ_le_of_lt
       rw [ha]
       exact wf _ hmax
     · refine le_succ_of_forall_lt_le fun z hz => ?_

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -125,7 +125,7 @@ theorem borel_eq_generateFrom_Iio : borel α = .generateFrom (range Iio) := by
   · rw [borel_eq_generateFrom_of_subbasis (@OrderTopology.topology_eq_generate_intervals α _ _ _)]
     letI : MeasurableSpace α := MeasurableSpace.generateFrom (range Iio)
     have H : ∀ a : α, MeasurableSet (Iio a) := fun a => GenerateMeasurable.basic _ ⟨_, rfl⟩
-    refine' generateFrom_le _
+    apply generateFrom_le
     rintro _ ⟨a, rfl | rfl⟩
     · rcases em (∃ b, a ⋖ b) with ⟨b, hb⟩ | hcovBy
       · rw [hb.Ioi_eq, ← compl_Iio]

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -150,7 +150,7 @@ theorem borel_eq_generateFrom_Ioi : borel α = .generateFrom (range Ioi) :=
 theorem borel_eq_generateFrom_Iic :
     borel α = MeasurableSpace.generateFrom (range Iic) := by
   rw [borel_eq_generateFrom_Ioi]
-  refine' le_antisymm _ _
+  apply le_antisymm
   · refine' MeasurableSpace.generateFrom_le fun t ht => _
     obtain ⟨u, rfl⟩ := ht
     rw [← compl_Iic]
@@ -1127,7 +1127,7 @@ theorem pi_le_borel_pi {ι : Type*} {π : ι → Type*} [∀ i, TopologicalSpace
 
 theorem prod_le_borel_prod : Prod.instMeasurableSpace ≤ borel (α × β) := by
   rw [‹BorelSpace α›.measurable_eq, ‹BorelSpace β›.measurable_eq]
-  refine' sup_le _ _
+  apply sup_le
   · exact comap_le_iff_le_map.mpr continuous_fst.borel_measurable
   · exact comap_le_iff_le_map.mpr continuous_snd.borel_measurable
 #align prod_le_borel_prod prod_le_borel_prod

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -281,7 +281,7 @@ end Encodable
 
 theorem pi_caratheodory :
     MeasurableSpace.pi ≤ (OuterMeasure.pi fun i => (μ i).toOuterMeasure).caratheodory := by
-  refine' iSup_le _
+  apply iSup_le
   intro i s hs
   rw [MeasurableSpace.comap] at hs
   rcases hs with ⟨s, hs, rfl⟩

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -309,7 +309,7 @@ instance _root_.MeasureTheory.MeasureSpace.pi {α : ι → Type*} [∀ i, Measur
 
 theorem pi_pi_aux [∀ i, SigmaFinite (μ i)] (s : ∀ i, Set (α i)) (hs : ∀ i, MeasurableSet (s i)) :
     Measure.pi μ (pi univ s) = ∏ i, μ i (s i) := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · rw [Measure.pi, toMeasure_apply _ _ (MeasurableSet.pi countable_univ fun i _ => hs i)]
     apply OuterMeasure.pi_pi_le
   · haveI : Encodable ι := Fintype.toEncodable ι

--- a/Mathlib/MeasureTheory/Constructions/Prod/Integral.lean
+++ b/Mathlib/MeasureTheory/Constructions/Prod/Integral.lean
@@ -356,7 +356,7 @@ theorem integral_fn_integral_add ⦃f g : α × β → E⦄ (F : E → E') (hf :
     (hg : Integrable g (μ.prod ν)) :
     (∫ x, F (∫ y, f (x, y) + g (x, y) ∂ν) ∂μ) =
       ∫ x, F ((∫ y, f (x, y) ∂ν) + ∫ y, g (x, y) ∂ν) ∂μ := by
-  refine' integral_congr_ae _
+  apply integral_congr_ae
   filter_upwards [hf.prod_right_ae, hg.prod_right_ae] with _ h2f h2g
   simp [integral_add h2f h2g]
 #align measure_theory.integral_fn_integral_add MeasureTheory.integral_fn_integral_add
@@ -367,7 +367,7 @@ theorem integral_fn_integral_sub ⦃f g : α × β → E⦄ (F : E → E') (hf :
     (hg : Integrable g (μ.prod ν)) :
     (∫ x, F (∫ y, f (x, y) - g (x, y) ∂ν) ∂μ) =
       ∫ x, F ((∫ y, f (x, y) ∂ν) - ∫ y, g (x, y) ∂ν) ∂μ := by
-  refine' integral_congr_ae _
+  apply integral_congr_ae
   filter_upwards [hf.prod_right_ae, hg.prod_right_ae] with _ h2f h2g
   simp [integral_sub h2f h2g]
 #align measure_theory.integral_fn_integral_sub MeasureTheory.integral_fn_integral_sub
@@ -378,7 +378,7 @@ theorem lintegral_fn_integral_sub ⦃f g : α × β → E⦄ (F : E → ℝ≥0�
     (hg : Integrable g (μ.prod ν)) :
     (∫⁻ x, F (∫ y, f (x, y) - g (x, y) ∂ν) ∂μ) =
       ∫⁻ x, F ((∫ y, f (x, y) ∂ν) - ∫ y, g (x, y) ∂ν) ∂μ := by
-  refine' lintegral_congr_ae _
+  apply lintegral_congr_ae
   filter_upwards [hf.prod_right_ae, hg.prod_right_ae] with _ h2f h2g
   simp [integral_sub h2f h2g]
 #align measure_theory.lintegral_fn_integral_sub MeasureTheory.lintegral_fn_integral_sub

--- a/Mathlib/MeasureTheory/Covering/Differentiation.lean
+++ b/Mathlib/MeasureTheory/Covering/Differentiation.lean
@@ -657,7 +657,7 @@ theorem le_mul_withDensity {s : Set α} (hs : MeasurableSet s) {t : ℝ≥0} (ht
 
 theorem withDensity_limRatioMeas_eq : μ.withDensity (v.limRatioMeas hρ) = ρ := by
   ext1 s hs
-  refine' le_antisymm _ _
+  apply le_antisymm
   · have : Tendsto (fun t : ℝ≥0 =>
         ((t : ℝ≥0∞) ^ 2 * ρ s : ℝ≥0∞)) (𝓝[>] 1) (𝓝 ((1 : ℝ≥0∞) ^ 2 * ρ s)) := by
       refine' ENNReal.Tendsto.mul _ _ tendsto_const_nhds _

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -221,7 +221,7 @@ lemma absolutelyContinuous_withDensity_rnDeriv [HaveLebesgueDecomposition ν μ]
   refine le_antisymm ((measure_union_le (s ∩ t) (s ∩ tᶜ)).trans ?_) (zero_le _)
   simp only [nonpos_iff_eq_zero, add_eq_zero]
   constructor
-  · refine hμν ?_
+  · apply hμν
     simp only [add_toOuterMeasure, OuterMeasure.coe_add, Pi.add_apply, add_eq_zero]
     constructor
     · exact measure_mono_null (Set.inter_subset_right _ _) ht1
@@ -708,7 +708,7 @@ theorem exists_positive_of_not_mutuallySingular (μ ν : Measure α) [IsFiniteMe
         exact h' (not_le.2 (NNReal.half_lt_self h))
       intro c hc
       have : ∃ n : ℕ, 1 / (n + 1 : ℝ) < c * (νA : ℝ)⁻¹ := by
-        refine exists_nat_one_div_lt ?_
+        apply exists_nat_one_div_lt
         positivity
       rcases this with ⟨n, hn⟩
       have hb₁ : (0 : ℝ) < (νA : ℝ)⁻¹ := by rw [_root_.inv_pos]; exact hb
@@ -874,7 +874,7 @@ theorem haveLebesgueDecomposition_of_finiteMeasure [IsFiniteMeasure μ] [IsFinit
       rw [lintegral_iSup (fun i ↦ (iSup_mem_measurableLE _ hf₁ i).1) (iSup_monotone _)]
       exact iSup_le fun i ↦ (iSup_mem_measurableLE _ hf₁ i).2 B hB
     have : IsFiniteMeasure (ν.withDensity ξ) := by
-      refine isFiniteMeasure_withDensity ?_
+      apply isFiniteMeasure_withDensity
       have hle' := hle univ
       rw [withDensity_apply _ MeasurableSet.univ, Measure.restrict_univ] at hle'
       exact ne_top_of_le_ne_top (measure_ne_top _ _) hle'

--- a/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
@@ -131,7 +131,7 @@ lemma rnDeriv_withDensity_left_of_absolutelyContinuous {ν : Measure α} [SigmaF
     · congr with x
       rw [mul_comm]
       simp only [Pi.mul_apply]
-    · refine ae_restrict_of_ae ?_
+    · apply ae_restrict_of_ae
       exact Measure.rnDeriv_lt_top _ _
     · exact (Measure.measurable_rnDeriv _ _).aemeasurable
 
@@ -168,7 +168,7 @@ lemma rnDeriv_withDensity_right_of_absolutelyContinuous {ν : Measure α} [Sigma
         filter_upwards [hf_ne_zero, hf_ne_top] with x hx1 hx2
         simp [← mul_assoc, ENNReal.mul_inv_cancel, hx1, hx2]
       rw [lintegral_congr_ae (ae_restrict_of_ae this)]
-    · refine ae_restrict_of_ae ?_
+    · apply ae_restrict_of_ae
       filter_upwards [hf_ne_top] with x hx using hx.lt_top
     · exact hf.restrict
 

--- a/Mathlib/MeasureTheory/Decomposition/SignedHahn.lean
+++ b/Mathlib/MeasureTheory/Decomposition/SignedHahn.lean
@@ -242,7 +242,7 @@ private theorem exists_subset_restrict_nonpos' (hi₁ : MeasurableSet i) (hi₂ 
     suffices 0 ≤ ∑' l : ℕ, s (⋃ _ : l < k, restrictNonposSeq s i l) by
       rw [sub_neg]
       exact lt_of_lt_of_le hi₂ this
-    refine' tsum_nonneg _
+    apply tsum_nonneg
     intro l; by_cases h : l < k
     · convert h₁ _ h
       ext x
@@ -355,7 +355,7 @@ theorem bddBelow_measureOfNegatives : BddBelow s.measureOfNegatives := by
     refine' le_trans _ (le_of_lt (h_lt _))
     rw [hA, ← Set.diff_union_of_subset (Set.subset_iUnion _ n),
       of_union Set.disjoint_sdiff_left _ (hmeas n)]
-    · refine' add_le_of_nonpos_left _
+    · apply add_le_of_nonpos_left
       have : s ≤[A] 0 := restrict_le_restrict_iUnion _ _ hmeas hr
       refine' nonpos_of_restrict_le_zero _ (restrict_le_zero_subset _ _ (Set.diff_subset _ _) this)
       exact MeasurableSet.iUnion hmeas
@@ -381,7 +381,7 @@ theorem exists_compl_positive_negative (s : SignedMeasure α) :
     · refine' le_of_tendsto_of_tendsto tendsto_const_nhds hf₂ (eventually_of_forall fun n => _)
       rw [← (hB n).2, hA, ← Set.diff_union_of_subset (Set.subset_iUnion _ n),
         of_union Set.disjoint_sdiff_left _ (hB₁ n)]
-      · refine' add_le_of_nonpos_left _
+      · apply add_le_of_nonpos_left
         have : s ≤[A] 0 :=
           restrict_le_restrict_iUnion _ _ hB₁ fun m =>
             let ⟨_, h⟩ := (hB m).1

--- a/Mathlib/MeasureTheory/Decomposition/SignedLebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/SignedLebesgue.lean
@@ -255,7 +255,7 @@ theorem toJordanDecomposition_eq_of_eq_add_withDensity {f : α → ℝ} (hf : Me
         (jordanDecomposition_add_withDensity_mutuallySingular hf htμ) := by
   haveI := isFiniteMeasure_withDensity_ofReal hfi.2
   haveI := isFiniteMeasure_withDensity_ofReal hfi.neg.2
-  refine' toJordanDecomposition_eq _
+  apply toJordanDecomposition_eq
   simp_rw [JordanDecomposition.toSignedMeasure, hadd]
   ext i hi
   rw [VectorMeasure.sub_apply, toSignedMeasure_apply_measurable hi,
@@ -338,12 +338,12 @@ theorem singularPart_neg (s : SignedMeasure α) (μ : Measure α) :
   have h₁ :
     ((-s).toJordanDecomposition.posPart.singularPart μ).toSignedMeasure =
       (s.toJordanDecomposition.negPart.singularPart μ).toSignedMeasure := by
-    refine' toSignedMeasure_congr _
+    apply toSignedMeasure_congr
     rw [toJordanDecomposition_neg, JordanDecomposition.neg_posPart]
   have h₂ :
     ((-s).toJordanDecomposition.negPart.singularPart μ).toSignedMeasure =
       (s.toJordanDecomposition.posPart.singularPart μ).toSignedMeasure := by
-    refine' toSignedMeasure_congr _
+    apply toSignedMeasure_congr
     rw [toJordanDecomposition_neg, JordanDecomposition.neg_negPart]
   rw [singularPart, singularPart, neg_sub, h₁, h₂]
 #align measure_theory.signed_measure.singular_part_neg MeasureTheory.SignedMeasure.singularPart_neg

--- a/Mathlib/MeasureTheory/Decomposition/UnsignedHahn.lean
+++ b/Mathlib/MeasureTheory/Decomposition/UnsignedHahn.lean
@@ -139,7 +139,7 @@ theorem hahn_decomposition [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
             tendsto_pow_atTop_nhds_zero_of_lt_one (le_of_lt <| half_pos <| zero_lt_one)
               (half_lt_self zero_lt_one)
     have hd : Tendsto (fun m => d (⋂ n, f m n)) atTop (𝓝 (d (⋃ m, ⋂ n, f m n))) := by
-      refine' d_Union _ _
+      apply d_Union
       exact fun n m hnm =>
         subset_iInter fun i => Subset.trans (iInter_subset (f n) i) <| f_subset_f hnm <| le_rfl
     refine' le_of_tendsto_of_tendsto' hγ hd fun m => _

--- a/Mathlib/MeasureTheory/Decomposition/UnsignedHahn.lean
+++ b/Mathlib/MeasureTheory/Decomposition/UnsignedHahn.lean
@@ -144,7 +144,7 @@ theorem hahn_decomposition [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
         subset_iInter fun i => Subset.trans (iInter_subset (f n) i) <| f_subset_f hnm <| le_rfl
     refine' le_of_tendsto_of_tendsto' hγ hd fun m => _
     have : Tendsto (fun n => d (f m n)) atTop (𝓝 (d (⋂ n, f m n))) := by
-      refine' d_Inter _ _ _
+      apply d_Inter
       · intro n
         exact hf _ _
       · intro n m hnm

--- a/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
@@ -509,7 +509,7 @@ theorem AEFinStronglyMeasurable.ae_eq_zero_of_forall_setIntegral_eq_zero {f : α
   suffices f =ᵐ[μ.restrict t] 0 from
     ae_of_ae_restrict_of_ae_restrict_compl _ this hf.ae_eq_zero_compl
   haveI : SigmaFinite (μ.restrict t) := hf.sigmaFinite_restrict
-  refine' ae_eq_zero_of_forall_setIntegral_eq_of_sigmaFinite _ _
+  apply ae_eq_zero_of_forall_setIntegral_eq_of_sigmaFinite
   · intro s hs hμs
     rw [IntegrableOn, Measure.restrict_restrict hs]
     rw [Measure.restrict_apply hs] at hμs
@@ -583,7 +583,7 @@ theorem ae_eq_zero_of_forall_setIntegral_eq_of_finStronglyMeasurable_trim (hm : 
   suffices f =ᵐ[μ.restrict t] 0 from
     ae_of_ae_restrict_of_ae_restrict_compl _ this htf_zero
   refine' measure_eq_zero_of_trim_eq_zero hm _
-  refine' ae_eq_zero_of_forall_setIntegral_eq_of_sigmaFinite _ _
+  apply ae_eq_zero_of_forall_setIntegral_eq_of_sigmaFinite
   · intro s hs hμs
     unfold IntegrableOn
     rw [restrict_trim hm (μ.restrict t) hs, Measure.restrict_restrict (hm s hs)]

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL1.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL1.lean
@@ -507,7 +507,7 @@ theorem condexpL1CLM_lpMeas (f : lpMeas F' ℝ m 1 μ) :
     rw [LinearIsometryEquiv.map_add]
     push_cast
     rw [map_add, hf_eq, hg_eq]
-  · refine' isClosed_eq _ _
+  · apply isClosed_eq
     · refine' (condexpL1CLM F' hm μ).continuous.comp (continuous_induced_dom.comp _)
       exact LinearIsometryEquiv.continuous _
     · refine' continuous_induced_dom.comp _

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL1.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL1.lean
@@ -135,7 +135,7 @@ theorem norm_condexpIndL1Fin_le (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x 
   swap; · rw [← memℒp_one_iff_integrable]; exact Lp.memℒp _
   have h_eq :
     ∫⁻ a, ‖condexpIndL1Fin hm hs hμs x a‖₊ ∂μ = ∫⁻ a, ‖condexpIndSMul hm hs hμs x a‖₊ ∂μ := by
-    refine' lintegral_congr_ae _
+    apply lintegral_congr_ae
     refine' (condexpIndL1Fin_ae_eq_condexpIndSMul hm hs hμs x).mono fun z hz => _
     dsimp only
     rw [hz]

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
@@ -507,7 +507,7 @@ theorem condexpL2_indicator_nonneg (hm : m ≤ m0) (hs : MeasurableSet s) (hμs 
     aeStronglyMeasurable'_condexpL2 _ _
   refine' EventuallyLE.trans_eq _ h.ae_eq_mk.symm
   refine' @ae_le_of_ae_le_trim _ _ _ _ _ _ hm (0 : α → ℝ) _ _
-  refine' ae_nonneg_of_forall_setIntegral_nonneg_of_sigmaFinite _ _
+  apply ae_nonneg_of_forall_setIntegral_nonneg_of_sigmaFinite
   · rintro t - -
     refine @Integrable.integrableOn _ _ m _ _ _ _ ?_
     refine' Integrable.trim hm _ _

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
@@ -259,7 +259,7 @@ theorem integral_condexpL2_eq (hm : m ≤ m0) (f : Lp E' 2 μ) (hs : MeasurableS
   rw [← sub_eq_zero, lpMeas_coe, ←
     integral_sub' (integrableOn_Lp_of_measure_ne_top _ fact_one_le_two_ennreal.elim hμs)
       (integrableOn_Lp_of_measure_ne_top _ fact_one_le_two_ennreal.elim hμs)]
-  refine' integral_eq_zero_of_forall_integral_inner_eq_zero 𝕜 _ _ _
+  apply integral_eq_zero_of_forall_integral_inner_eq_zero 𝕜
   · rw [integrable_congr (ae_restrict_of_ae (Lp.coeFn_sub (↑(condexpL2 E' 𝕜 hm f)) f).symm)]
     exact integrableOn_Lp_of_measure_ne_top _ fact_one_le_two_ennreal.elim hμs
   intro c

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Real.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Real.lean
@@ -40,7 +40,7 @@ variable {α : Type*} {m m0 : MeasurableSpace α} {μ : Measure α}
 theorem rnDeriv_ae_eq_condexp {hm : m ≤ m0} [hμm : SigmaFinite (μ.trim hm)] {f : α → ℝ}
     (hf : Integrable f μ) :
     SignedMeasure.rnDeriv ((μ.withDensityᵥ f).trim hm) (μ.trim hm) =ᵐ[μ] μ[f|m] := by
-  refine' ae_eq_condexp_of_forall_setIntegral_eq hm hf _ _ _
+  apply ae_eq_condexp_of_forall_setIntegral_eq hm hf
   · exact fun _ _ _ => (integrable_of_integrable_trim hm
       (SignedMeasure.integrable_rnDeriv ((μ.withDensityᵥ f).trim hm) (μ.trim hm))).integrableOn
   · intro s hs _

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Real.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Real.lean
@@ -65,7 +65,7 @@ theorem snorm_one_condexp_le_snorm (f : α → ℝ) : snorm (μ[f|m]) 1 μ ≤ s
   swap; · rw [condexp_of_not_sigmaFinite hm hsig, snorm_zero]; exact zero_le _
   calc
     snorm (μ[f|m]) 1 μ ≤ snorm (μ[(|f|)|m]) 1 μ := by
-      refine' snorm_mono_ae _
+      apply snorm_mono_ae
       filter_upwards [condexp_mono hf hf.abs
         (ae_of_all μ (fun x => le_abs_self (f x) : ∀ x, f x ≤ |f x|)),
         EventuallyLE.trans (condexp_neg f).symm.le
@@ -80,7 +80,7 @@ theorem snorm_one_condexp_le_snorm (f : α → ℝ) : snorm (μ[f|m]) 1 μ ≤ s
         ← integral_norm_eq_lintegral_nnnorm hf.1]
       simp_rw [Real.norm_eq_abs]
       rw [← integral_condexp hm hf.abs]
-      refine' integral_congr_ae _
+      apply integral_congr_ae
       have : 0 ≤ᵐ[μ] μ[(|f|)|m] := by
         rw [← condexp_zero]
         exact condexp_mono (integrable_zero _ _ _) hf.abs
@@ -126,7 +126,7 @@ theorem setIntegral_abs_condexp_le {s : Set α} (hs : MeasurableSet[m] s) (f : �
     positivity
   have : ∫ x in s, |(μ[f|m]) x| ∂μ = ∫ x, |(μ[s.indicator f|m]) x| ∂μ := by
     rw [← integral_indicator (hnm _ hs)]
-    refine' integral_congr_ae _
+    apply integral_congr_ae
     have : (fun x => |(μ[s.indicator f|m]) x|) =ᵐ[μ] fun x => |s.indicator (μ[f|m]) x| :=
       (condexp_indicator hfint hs).fun_comp abs
     refine' EventuallyEq.trans (eventually_of_forall fun x => _) this.symm

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Unique.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Unique.lean
@@ -197,7 +197,7 @@ theorem integral_norm_le_of_forall_fin_meas_integral_eq (hm : m ≤ m0) {f g : �
     hg.measurableSet_le (@stronglyMeasurable_const _ _ m _ _)
   have h_meas_nonpos_f : MeasurableSet {x | f x ≤ 0} :=
     hf.measurableSet_le stronglyMeasurable_const
-  refine' sub_le_sub _ _
+  apply sub_le_sub
   · rw [Measure.restrict_restrict (hm _ h_meas_nonneg_g), Measure.restrict_restrict h_meas_nonneg_f,
       hgf _ (@MeasurableSet.inter α m _ _ h_meas_nonneg_g hs)
         ((measure_mono (Set.inter_subset_right _ _)).trans_lt (lt_top_iff_ne_top.mpr hμs)),

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -74,7 +74,7 @@ protected theorem congr' (h_left : ∀ᶠ i in l, f i =ᵐ[μ] f' i) (h_right : 
     rw [tendsto_congr' this]
     exact h_tendsto ε hε
   filter_upwards [h_left] with i h_ae_eq
-  refine' measure_congr _
+  apply measure_congr
   filter_upwards [h_ae_eq, h_right] with x hxf hxg
   rw [eq_iff_iff]
   change ε ≤ dist (f' i x) (g' x) ↔ ε ≤ dist (f i x) (g x)

--- a/Mathlib/MeasureTheory/Function/EssSup.lean
+++ b/Mathlib/MeasureTheory/Function/EssSup.lean
@@ -249,7 +249,7 @@ theorem essSup_map_measure_of_measurable (hg : Measurable g) (hf : AEMeasurable 
 theorem essSup_map_measure (hg : AEMeasurable g (Measure.map f μ)) (hf : AEMeasurable f μ) :
     essSup g (Measure.map f μ) = essSup (g ∘ f) μ := by
   rw [essSup_congr_ae hg.ae_eq_mk, essSup_map_measure_of_measurable hg.measurable_mk hf]
-  refine' essSup_congr_ae _
+  apply essSup_congr_ae
   have h_eq := ae_of_ae_map hf hg.ae_eq_mk
   rw [← EventuallyEq] at h_eq
   exact h_eq.symm

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -397,7 +397,7 @@ theorem HasFiniteIntegral.smul [NormedAddCommGroup 𝕜] [SMulZeroClass 𝕜 β]
   simp only [HasFiniteIntegral]; intro hfi
   calc
     (∫⁻ a : α, ‖c • f a‖₊ ∂μ) ≤ ∫⁻ a : α, ‖c‖₊ * ‖f a‖₊ ∂μ := by
-      refine' lintegral_mono _
+      apply lintegral_mono
       intro i
       -- After leanprover/lean4#2734, we need to do beta reduction `exact mod_cast`
       beta_reduce

--- a/Mathlib/MeasureTheory/Function/LpOrder.lean
+++ b/Mathlib/MeasureTheory/Function/LpOrder.lean
@@ -108,7 +108,7 @@ noncomputable instance instNormedLatticeAddCommGroup [Fact (1 ≤ p)] :
     solid := fun f g hfg => by
       rw [← coeFn_le] at hfg
       simp_rw [Lp.norm_def, ENNReal.toReal_le_toReal (Lp.snorm_ne_top f) (Lp.snorm_ne_top g)]
-      refine' snorm_mono_ae _
+      apply snorm_mono_ae
       filter_upwards [hfg, Lp.coeFn_abs f, Lp.coeFn_abs g] with x hx hxf hxg
       rw [hxf, hxg] at hx
       exact HasSolidNorm.solid hx }

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -1021,7 +1021,7 @@ theorem snorm_indicator_ge_of_bdd_below (hp : p ≠ 0) (hp' : p ≠ ∞) {f : α
     ENNReal.mul_rpow_of_nonneg _ _ ENNReal.toReal_nonneg, ← ENNReal.rpow_mul,
     one_div_mul_cancel (ENNReal.toReal_pos hp hp').ne.symm, ENNReal.rpow_one, ← set_lintegral_const,
     ← lintegral_indicator _ hs]
-  refine' lintegral_mono_ae _
+  apply lintegral_mono_ae
   filter_upwards [hf] with x hx
   rw [nnnorm_indicator_eq_indicator_nnnorm]
   by_cases hxs : x ∈ s

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/ChebyshevMarkov.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/ChebyshevMarkov.lean
@@ -32,7 +32,7 @@ theorem mul_meas_ge_le_pow_snorm (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞)
     (hf : AEStronglyMeasurable f μ) (ε : ℝ≥0∞) :
     ε * μ { x | ε ≤ (‖f x‖₊ : ℝ≥0∞) ^ p.toReal } ≤ snorm f p μ ^ p.toReal := by
   have : 1 / p.toReal * p.toReal = 1 := by
-    refine' one_div_mul_cancel _
+    apply one_div_mul_cancel
     rw [Ne, ENNReal.toReal_eq_zero_iff]
     exact not_or_of_not hp_ne_zero hp_ne_top
   rw [← ENNReal.rpow_one (ε * μ { x | ε ≤ (‖f x‖₊ : ℝ≥0∞) ^ p.toReal }), ← this, ENNReal.rpow_mul]

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/CompareExp.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/CompareExp.lean
@@ -50,7 +50,7 @@ theorem snorm'_le_snorm'_mul_rpow_measure_univ {p q : ℝ} (hp0_lt : 0 < p) (hpq
 theorem snorm'_le_snormEssSup_mul_rpow_measure_univ {q : ℝ} (hq_pos : 0 < q) :
     snorm' f q μ ≤ snormEssSup f μ * μ Set.univ ^ (1 / q) := by
   have h_le : (∫⁻ a : α, (‖f a‖₊ : ℝ≥0∞) ^ q ∂μ) ≤ ∫⁻ _ : α, snormEssSup f μ ^ q ∂μ := by
-    refine' lintegral_mono_ae _
+    apply lintegral_mono_ae
     have h_nnnorm_le_snorm_ess_sup := coe_nnnorm_ae_le_snormEssSup f μ
     exact h_nnnorm_le_snorm_ess_sup.mono fun x hx => by gcongr
   rw [snorm', ← ENNReal.rpow_one (snormEssSup f μ)]
@@ -182,7 +182,7 @@ theorem snorm_le_snorm_top_mul_snorm (p : ℝ≥0∞) (f : α → E) {g : α →
         (∫⁻ x, essSup (fun x => (‖f x‖₊ : ℝ≥0∞)) μ ^ p.toReal * (‖g x‖₊ : ℝ≥0∞) ^ p.toReal ∂μ) ^
           (1 / p.toReal) := by
       gcongr ?_ ^ _
-      refine' lintegral_mono_ae _
+      apply lintegral_mono_ae
       filter_upwards [@ENNReal.ae_le_essSup _ _ μ fun x => (‖f x‖₊ : ℝ≥0∞)] with x hx
       gcongr
     _ = essSup (fun x => (‖f x‖₊ : ℝ≥0∞)) μ *

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -291,7 +291,7 @@ theorem coe_nnnorm_toLp {f : α → E} (hf : Memℒp f p μ) : (‖hf.toLp f‖�
 
 theorem dist_def (f g : Lp E p μ) : dist f g = (snorm (⇑f - ⇑g) p μ).toReal := by
   simp_rw [dist, norm_def]
-  refine congr_arg _ ?_
+  apply congr_arg
   apply snorm_congr_ae (coeFn_sub _ _)
 #align measure_theory.Lp.dist_def MeasureTheory.Lp.dist_def
 

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -688,7 +688,7 @@ theorem unifIntegrable_of' (hp : 1 ≤ p) (hp' : p ≠ ∞) {f : ι → α → �
       rwa [ENNReal.rpow_one_div_le_iff (ENNReal.toReal_pos hpzero hp'),
         ENNReal.ofReal_rpow_of_pos (div_pos hε (mul_pos two_pos (NNReal.coe_pos.2 hCpos)))]
     _ ≤ ENNReal.ofReal (ε / 2) + ENNReal.ofReal (ε / 2) := by
-      refine' add_le_add_left _ _
+      apply add_le_add_left
       rw [← ENNReal.ofReal_coe_nnreal, ← ENNReal.ofReal_mul (NNReal.coe_nonneg _), ← div_div,
         mul_div_cancel₀ _ (NNReal.coe_pos.2 hCpos).ne.symm]
     _ ≤ ENNReal.ofReal ε := by

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -223,7 +223,7 @@ theorem Memℒp.integral_indicator_norm_ge_nonneg_le (hf : Memℒp f 1 μ) {ε :
   obtain ⟨M, hM_pos, hfM⟩ :=
     hf_mk.integral_indicator_norm_ge_nonneg_le_of_meas hf.1.stronglyMeasurable_mk hε
   refine' ⟨M, hM_pos, (le_of_eq _).trans hfM⟩
-  refine' lintegral_congr_ae _
+  apply lintegral_congr_ae
   filter_upwards [hf.1.ae_eq_mk] with x hx
   simp only [Set.indicator_apply, coe_nnnorm, Set.mem_setOf_eq, ENNReal.coe_inj, hx.symm]
 #align measure_theory.mem_ℒp.integral_indicator_norm_ge_nonneg_le MeasureTheory.Memℒp.integral_indicator_norm_ge_nonneg_le

--- a/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
+++ b/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
@@ -549,7 +549,7 @@ theorem essSup_measure_restrict (hs : IsFundamentalDomain G s μ) {f : α → �
     (hf : ∀ γ : G, ∀ x : α, f (γ • x) = f x) : essSup f (μ.restrict s) = essSup f μ := by
   refine' le_antisymm (essSup_mono_measure' Measure.restrict_le_self) _
   rw [essSup_eq_sInf (μ.restrict s) f, essSup_eq_sInf μ f]
-  refine' sInf_le_sInf _
+  apply sInf_le_sInf
   rintro a (ha : (μ.restrict s) {x : α | a < f x} = 0)
   rw [Measure.restrict_apply₀' hs.nullMeasurableSet] at ha
   refine' measure_zero_of_invariant hs _ _ ha

--- a/Mathlib/MeasureTheory/Group/Prod.lean
+++ b/Mathlib/MeasureTheory/Group/Prod.lean
@@ -329,7 +329,7 @@ theorem measure_lintegral_div_measure [IsMulLeftInvariant ν] (sm : MeasurableSe
   have hg : Measurable g :=
     (hf.comp measurable_inv).div ((measurable_measure_mul_right ν sm).comp measurable_inv)
   simp_rw [measure_mul_lintegral_eq μ ν sm g hg, g, inv_inv]
-  refine' lintegral_congr_ae _
+  apply lintegral_congr_ae
   refine' (ae_measure_preimage_mul_right_lt_top_of_ne_zero μ ν sm h2s h3s).mono fun x hx => _
   simp_rw [ENNReal.mul_div_cancel' (measure_mul_right_ne_zero ν h2s _) hx.ne]
 #align measure_theory.measure_lintegral_div_measure MeasureTheory.measure_lintegral_div_measure

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -1315,7 +1315,7 @@ lemma integral_tendsto_of_tendsto_of_monotone {μ : Measure α} {f : ℕ → α 
     exact ENNReal.ofReal_ne_top
   refine h_cont.tendsto.comp ?_
   -- use the result for the Lebesgue integral
-  refine lintegral_tendsto_of_tendsto_of_monotone ?_ ?_ ?_
+  apply lintegral_tendsto_of_tendsto_of_monotone
   · exact fun n ↦ ((hf n).sub (hf 0)).aemeasurable.ennreal_ofReal
   · filter_upwards [h_mono] with x hx n m hnm
     refine ENNReal.ofReal_le_ofReal ?_

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -1867,15 +1867,15 @@ theorem integral_mul_le_Lp_mul_Lq_of_nonneg {p q : ℝ} (hpq : p.IsConjExponent 
     (hg : Memℒp g (ENNReal.ofReal q) μ) :
     ∫ a, f a * g a ∂μ ≤ (∫ a, f a ^ p ∂μ) ^ (1 / p) * (∫ a, g a ^ q ∂μ) ^ (1 / q) := by
   have h_left : ∫ a, f a * g a ∂μ = ∫ a, ‖f a‖ * ‖g a‖ ∂μ := by
-    refine' integral_congr_ae _
+    apply integral_congr_ae
     filter_upwards [hf_nonneg, hg_nonneg] with x hxf hxg
     rw [Real.norm_of_nonneg hxf, Real.norm_of_nonneg hxg]
   have h_right_f : ∫ a, f a ^ p ∂μ = ∫ a, ‖f a‖ ^ p ∂μ := by
-    refine' integral_congr_ae _
+    apply integral_congr_ae
     filter_upwards [hf_nonneg] with x hxf
     rw [Real.norm_of_nonneg hxf]
   have h_right_g : ∫ a, g a ^ q ∂μ = ∫ a, ‖g a‖ ^ q ∂μ := by
-    refine' integral_congr_ae _
+    apply integral_congr_ae
     filter_upwards [hg_nonneg] with x hxg
     rw [Real.norm_of_nonneg hxg]
   rw [h_left, h_right_f, h_right_g]

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -172,7 +172,7 @@ theorem _root_.Antitone.tendsto_setIntegral (hsm : ∀ i, MeasurableSet (s i)) (
     funext fun i => (integral_indicator (hsm i)).symm
   rw [h_int_eq]
   rw [← integral_indicator (MeasurableSet.iInter hsm)]
-  refine' tendsto_integral_of_dominated_convergence bound _ _ _ _
+  apply tendsto_integral_of_dominated_convergence bound
   · intro n
     rw [aestronglyMeasurable_indicator_iff (hsm n)]
     exact (IntegrableOn.mono_set hfi (h_anti (zero_le n))).1

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -395,7 +395,7 @@ theorem lintegral_iSup {f : ℕ → α → ℝ≥0∞} (hf : ∀ n, Measurable (
       rw [restrict_lintegral _ (h_meas n)]
       · refine' le_of_eq (Finset.sum_congr rfl fun r _ => _)
         congr 2 with a
-        refine' and_congr_right _
+        apply and_congr_right
         simp (config := { contextual := true })
     _ ≤ ⨆ n, ∫⁻ a, f n a ∂μ := by
       gcongr with n
@@ -436,7 +436,7 @@ theorem lintegral_tendsto_of_tendsto_of_monotone {f : ℕ → α → ℝ≥0∞}
     rw [key]
     exact tendsto_atTop_iSup this
   rw [← lintegral_iSup' hf h_mono]
-  refine' lintegral_congr_ae _
+  apply lintegral_congr_ae
   filter_upwards [h_mono, h_tendsto] with _ hx_mono hx_tendsto using
     tendsto_nhds_unique hx_tendsto (tendsto_atTop_iSup hx_mono)
 #align measure_theory.lintegral_tendsto_of_tendsto_of_monotone MeasureTheory.lintegral_tendsto_of_tendsto_of_monotone
@@ -1217,7 +1217,7 @@ theorem lintegral_tendsto_of_tendsto_of_antitone {f : ℕ → α → ℝ≥0∞}
     rw [key]
     exact tendsto_atTop_iInf this
   rw [← lintegral_iInf' hf h_anti h0]
-  refine lintegral_congr_ae ?_
+  apply lintegral_congr_ae
   filter_upwards [h_anti, h_tendsto] with _ hx_anti hx_tendsto
     using tendsto_nhds_unique hx_tendsto (tendsto_atTop_iInf hx_anti)
 

--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -141,7 +141,7 @@ theorem ae_eq_zero_of_lintegral_rpow_eq_zero {p : ℝ} (hp0 : 0 ≤ p) {f : α �
 theorem lintegral_mul_eq_zero_of_lintegral_rpow_eq_zero {p : ℝ} (hp0 : 0 ≤ p) {f g : α → ℝ≥0∞}
     (hf : AEMeasurable f μ) (hf_zero : ∫⁻ a, f a ^ p ∂μ = 0) : (∫⁻ a, (f * g) a ∂μ) = 0 := by
   rw [← @lintegral_zero_fun α _ μ]
-  refine' lintegral_congr_ae _
+  apply lintegral_congr_ae
   suffices h_mul_zero : f * g =ᵐ[μ] 0 * g by rwa [zero_mul] at h_mul_zero
   have hf_eq_zero : f =ᵐ[μ] 0 := ae_eq_zero_of_lintegral_rpow_eq_zero hp0 hf hf_zero
   exact hf_eq_zero.mul (ae_eq_refl g)
@@ -355,7 +355,7 @@ theorem lintegral_mul_rpow_le_lintegral_rpow_mul_lintegral_rpow {p q : ℝ}
     exact zero_le _
   have hf_top_rpow : (∫⁻ a : α, f a ^ p ∂μ) ^ (1 / p) ≠ ⊤ := by
     by_contra h
-    refine' hf_top _
+    apply hf_top
     have hp_not_neg : ¬p < 0 := by simp [hpq.nonneg]
     simpa [hpq.pos, hp_not_neg] using h
   refine' (ENNReal.mul_le_mul_left hf_zero_rpow hf_top_rpow).mpr (le_of_eq _)
@@ -379,7 +379,7 @@ theorem lintegral_rpow_add_le_add_snorm_mul_lintegral_rpow_add {p q : ℝ}
       by_cases h_top : (f + g) a = ⊤
       · rw [h_top, ENNReal.top_rpow_of_pos hpq.sub_one_pos, ENNReal.top_mul_top]
         exact le_top
-      refine' le_of_eq _
+      apply le_of_eq
       nth_rw 2 [← ENNReal.rpow_one ((f + g) a)]
       rw [← ENNReal.rpow_add _ _ h_zero h_top, add_sub_cancel]
     _ = (∫⁻ a : α, f a * (f + g) a ^ (p - 1) ∂μ) + ∫⁻ a : α, g a * (f + g) a ^ (p - 1) ∂μ := by
@@ -444,7 +444,7 @@ theorem lintegral_Lp_add_le {p : ℝ} {f g : α → ℝ≥0∞} (hf : AEMeasurab
   by_cases hg_top : ∫⁻ a, g a ^ p ∂μ = ⊤
   · simp [hg_top, hp_pos]
   by_cases h1 : p = 1
-  · refine' le_of_eq _
+  · apply le_of_eq
     simp_rw [h1, one_div_one, ENNReal.rpow_one]
     exact lintegral_add_left' hf _
   have hp1_lt : 1 < p := by

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -330,7 +330,7 @@ theorem setIntegral_eq_zero_of_ae_eq_zero (ht_eq : ∀ᵐ x ∂μ, x ∈ t → f
     contrapose! hf
     exact hf.1
   have : ∫ x in t, hf.mk f x ∂μ = 0 := by
-    refine' integral_eq_zero_of_ae _
+    apply integral_eq_zero_of_ae
     rw [EventuallyEq,
       ae_restrict_iff (hf.stronglyMeasurable_mk.measurableSet_eq_fun stronglyMeasurable_zero)]
     filter_upwards [ae_imp_of_ae_restrict hf.ae_eq_mk, ht_eq] with x hx h'x h''x
@@ -502,7 +502,7 @@ theorem setIntegral_neg_eq_setIntegral_nonpos [LinearOrder E] {f : X → E}
   have B : NullMeasurableSet {x | f x = 0} μ :=
     hf.nullMeasurableSet_eq_fun aestronglyMeasurable_zero
   symm
-  refine' integral_union_eq_left_of_ae _
+  apply integral_union_eq_left_of_ae
   filter_upwards [ae_restrict_mem₀ B] with x hx using hx
 #align measure_theory.set_integral_neg_eq_set_integral_nonpos MeasureTheory.setIntegral_neg_eq_setIntegral_nonpos
 

--- a/Mathlib/MeasureTheory/Integral/SetToL1.lean
+++ b/Mathlib/MeasureTheory/Integral/SetToL1.lean
@@ -1512,7 +1512,7 @@ theorem tendsto_setToFun_of_L1 (hT : DominatedFinMeasAdditive μ T C) {ι} (f : 
       simp_rw [snorm_one_eq_lintegral_nnnorm, Pi.sub_apply]
       refine' (tendsto_congr' _).mp hfs
       filter_upwards [hfsi] with i hi
-      refine' lintegral_congr_ae _
+      apply lintegral_congr_ae
       filter_upwards [hi.coeFn_toL1, hfi.coeFn_toL1] with x hxi hxf
       simp_rw [F_lp, dif_pos hi, hxi, hxf]
     suffices Tendsto (fun i => setToFun μ T hT (F_lp i)) l (𝓝 (setToFun μ T hT f)) by
@@ -1737,7 +1737,7 @@ theorem tendsto_setToFun_of_dominated_convergence (hT : DominatedFinMeasAdditive
   convert lintegral_norm_tendsto_zero with n
   rw [L1.norm_def]
   congr 1
-  refine' lintegral_congr_ae _
+  apply lintegral_congr_ae
   rw [← Integrable.toL1_sub]
   refine' ((fs_int n).sub f_int).coeFn_toL1.mono fun x hx => _
   dsimp only

--- a/Mathlib/MeasureTheory/Integral/VitaliCaratheodory.lean
+++ b/Mathlib/MeasureTheory/Integral/VitaliCaratheodory.lean
@@ -251,7 +251,7 @@ theorem exists_lt_lowerSemicontinuous_lintegral_ge_of_aemeasurable [SigmaFinite 
       ∫⁻ x, g0 x + g1 x ∂μ = (∫⁻ x, g0 x ∂μ) + ∫⁻ x, g1 x ∂μ :=
         lintegral_add_left g0_cont.measurable _
       _ ≤ (∫⁻ x, f x ∂μ) + ε / 2 + (0 + ε / 2) := by
-        refine' add_le_add _ _
+        apply add_le_add
         · convert g0_int using 2
           exact lintegral_congr_ae (fmeas.ae_eq_mk.fun_comp _)
         · convert g1_int

--- a/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
@@ -283,7 +283,7 @@ lemma measurableSet_succ_memPartition (t : ℕ → Set α) (n : ℕ) {s : Set α
     MeasurableSet[generateFrom (memPartition t (n + 1))] s := by
   rw [← diff_union_inter s (t n)]
   refine MeasurableSet.union ?_ ?_ <;>
-    · refine measurableSet_generateFrom ?_
+    · apply measurableSet_generateFrom
       rw [memPartition_succ]
       exact ⟨s, hs, by simp⟩
 
@@ -335,7 +335,7 @@ lemma measurableSet_generateFrom_memPartition (t : ℕ → Set α) (n : ℕ) :
     simp_rw [← iUnion_inter, ← sUnion_eq_biUnion, sUnion_memPartition, univ_inter]
   rw [this]
   refine MeasurableSet.biUnion (finite_memPartition _ _).countable (fun v hv ↦ ?_)
-  refine measurableSet_generateFrom ?_
+  apply measurableSet_generateFrom
   rw [memPartition_succ]
   exact ⟨v, hv, Or.inl rfl⟩
 

--- a/Mathlib/MeasureTheory/Measure/Content.lean
+++ b/Mathlib/MeasureTheory/Measure/Content.lean
@@ -454,7 +454,7 @@ variable [MeasurableSpace G] [R1Space G] [BorelSpace G]
   on compact sets. -/
 theorem measure_eq_content_of_regular (H : MeasureTheory.Content.ContentRegular μ)
     (K : TopologicalSpace.Compacts G) : μ.measure ↑K = μ K := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · apply ENNReal.le_of_forall_pos_le_add
     intro ε εpos _
     obtain ⟨K', K'_hyp⟩ := contentRegular_exists_compact μ H K (ne_bot_of_gt εpos)

--- a/Mathlib/MeasureTheory/Measure/Content.lean
+++ b/Mathlib/MeasureTheory/Measure/Content.lean
@@ -360,7 +360,7 @@ theorem borel_le_caratheodory : S ≤ μ.outerMeasure.caratheodory := by
   rw [Opens.coe_mk]
   haveI : Nonempty { L : Compacts G // (L : Set G) ⊆ U' ∩ U } := ⟨⟨⊥, empty_subset _⟩⟩
   rw [ENNReal.iSup_add]
-  refine' iSup_le _
+  apply iSup_le
   rintro ⟨L, hL⟩
   let L' : Compacts G := ⟨closure L, L.isCompact.closure⟩
   suffices μ L' + μ.outerMeasure (↑U' \ U) ≤ μ.outerMeasure U' by
@@ -376,7 +376,7 @@ theorem borel_le_caratheodory : S ≤ μ.outerMeasure.caratheodory := by
   rw [Opens.coe_mk]
   haveI : Nonempty { M : Compacts G // (M : Set G) ⊆ ↑U' \ closure L } := ⟨⟨⊥, empty_subset _⟩⟩
   rw [ENNReal.add_iSup]
-  refine' iSup_le _
+  apply iSup_le
   rintro ⟨M, hM⟩
   let M' : Compacts G := ⟨closure M, M.isCompact.closure⟩
   suffices μ L' + μ M' ≤ μ.outerMeasure U' by

--- a/Mathlib/MeasureTheory/Measure/Hausdorff.lean
+++ b/Mathlib/MeasureTheory/Measure/Hausdorff.lean
@@ -325,7 +325,7 @@ theorem mkMetric'_isMetric (m : Set X → ℝ≥0∞) : (mkMetric' m).IsMetric :
   rw [← pos_iff_ne_zero] at r0
   filter_upwards [Ioo_mem_nhdsWithin_Ioi ⟨le_rfl, r0⟩]
   rintro ε ⟨_, εr⟩
-  refine' boundedBy_union_of_top_of_nonempty_inter _
+  apply boundedBy_union_of_top_of_nonempty_inter
   rintro u ⟨x, hxs, hxu⟩ ⟨y, hyt, hyu⟩
   have : ε < diam u := εr.trans_le ((hr x hxs y hyt).trans <| edist_le_diam_of_mem hxu hyu)
   exact iInf_eq_top.2 fun h => (this.not_le h).elim

--- a/Mathlib/MeasureTheory/Measure/NullMeasurable.lean
+++ b/Mathlib/MeasureTheory/Measure/NullMeasurable.lean
@@ -299,7 +299,7 @@ theorem measure_union₀_aux (hs : NullMeasurableSet s μ) (ht : NullMeasurableS
 `μ (s ∩ t) + μ (s \ t) = μ s`. -/
 theorem measure_inter_add_diff₀ (s : Set α) (ht : NullMeasurableSet t μ) :
     μ (s ∩ t) + μ (s \ t) = μ s := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · rcases exists_measurable_superset μ s with ⟨s', hsub, hs'm, hs'⟩
     replace hs'm : NullMeasurableSet s' μ := hs'm.nullMeasurableSet
     calc

--- a/Mathlib/MeasureTheory/Measure/Sub.lean
+++ b/Mathlib/MeasureTheory/Measure/Sub.lean
@@ -108,7 +108,7 @@ theorem restrict_sub_eq_restrict_sub_restrict (h_meas_s : MeasurableSet s) :
   have h_nonempty : { d | μ ≤ d + ν }.Nonempty := ⟨μ, Measure.le_add_right le_rfl⟩
   rw [restrict_sInf_eq_sInf_restrict h_nonempty h_meas_s]
   apply le_antisymm
-  · refine' sInf_le_sInf_of_forall_exists_le _
+  · apply sInf_le_sInf_of_forall_exists_le
     intro ν' h_ν'_in
     rw [mem_setOf_eq] at h_ν'_in
     refine' ⟨ν'.restrict s, _, restrict_le_self⟩
@@ -128,7 +128,7 @@ theorem restrict_sub_eq_restrict_sub_restrict (h_meas_s : MeasurableSet s) :
         exact Measure.le_iff'.1 h_mu_le_add_top _
     · ext1 t h_meas_t
       simp [restrict_apply h_meas_t, restrict_apply (h_meas_t.inter h_meas_s), inter_assoc]
-  · refine' sInf_le_sInf_of_forall_exists_le _
+  · apply sInf_le_sInf_of_forall_exists_le
     refine' forall_mem_image.2 fun t h_t_in => ⟨t.restrict s, _, le_rfl⟩
     rw [Set.mem_setOf_eq, ← restrict_add]
     exact restrict_mono Subset.rfl h_t_in

--- a/Mathlib/MeasureTheory/Measure/Sub.lean
+++ b/Mathlib/MeasureTheory/Measure/Sub.lean
@@ -116,7 +116,7 @@ theorem restrict_sub_eq_restrict_sub_restrict (h_meas_s : MeasurableSet s) :
     · rw [mem_setOf_eq, add_right_comm, Measure.le_iff]
       intro t h_meas_t
       repeat' rw [← measure_inter_add_diff t h_meas_s]
-      refine' add_le_add _ _
+      apply add_le_add
       · rw [add_apply, add_apply]
         apply le_add_right _
         rw [← restrict_eq_self μ (inter_subset_right _ _),

--- a/Mathlib/MeasureTheory/Measure/Tilted.lean
+++ b/Mathlib/MeasureTheory/Measure/Tilted.lean
@@ -46,7 +46,7 @@ lemma tilted_of_not_integrable (hf : ¬ Integrable (fun x ↦ exp (f x)) μ) : �
 
 @[simp]
 lemma tilted_of_not_aemeasurable (hf : ¬ AEMeasurable f μ) : μ.tilted f = 0 := by
-  refine tilted_of_not_integrable ?_
+  apply tilted_of_not_integrable
   suffices ¬ AEMeasurable (fun x ↦ exp (f x)) μ by exact fun h ↦ this h.1.aemeasurable
   exact fun h ↦ hf (aemeasurable_of_aemeasurable_exp h)
 
@@ -81,10 +81,10 @@ lemma tilted_zero (μ : Measure α) [IsProbabilityMeasure μ] : μ.tilted 0 = μ
 lemma tilted_congr {g : α → ℝ} (hfg : f =ᵐ[μ] g) :
     μ.tilted f = μ.tilted g := by
   have h_int_eq : ∫ x, exp (f x) ∂μ = ∫ x, exp (g x) ∂μ := by
-    refine integral_congr_ae ?_
+    apply integral_congr_ae
     filter_upwards [hfg] with x hx
     rw [hx]
-  refine withDensity_congr_ae ?_
+  apply withDensity_congr_ae
   filter_upwards [hfg] with x hx
   rw [h_int_eq, hx]
 
@@ -125,7 +125,7 @@ lemma tilted_apply_eq_ofReal_integral [SFinite μ] (f : α → ℝ) (s : Set α)
 
 instance isFiniteMeasure_tilted : IsFiniteMeasure (μ.tilted f) := by
   by_cases hf : Integrable (fun x ↦ exp (f x)) μ
-  · refine isFiniteMeasure_withDensity_ofReal ?_
+  · apply isFiniteMeasure_withDensity_ofReal
     suffices Integrable (fun x ↦ exp (f x) / ∫ x, exp (f x) ∂μ) μ by exact this.2
     exact hf.div_const _
   · simp only [hf, not_false_eq_true, tilted_of_not_integrable]

--- a/Mathlib/MeasureTheory/Measure/VectorMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/VectorMeasure.lean
@@ -895,7 +895,7 @@ variable (v w : VectorMeasure α M)
 nonrec theorem neg_le_neg {i : Set α} (hi : MeasurableSet i) (h : v ≤[i] w) : -w ≤[i] -v := by
   intro j hj₁
   rw [restrict_apply _ hi hj₁, restrict_apply _ hi hj₁, neg_apply, neg_apply]
-  refine' neg_le_neg _
+  apply neg_le_neg
   rw [← restrict_apply _ hi hj₁, ← restrict_apply _ hi hj₁]
   exact h j hj₁
 #align measure_theory.vector_measure.neg_le_neg MeasureTheory.VectorMeasure.neg_le_neg

--- a/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
@@ -1136,7 +1136,7 @@ theorem sInfGen_def (m : Set (OuterMeasure α)) (t : Set α) :
 
 theorem sInf_eq_boundedBy_sInfGen (m : Set (OuterMeasure α)) :
     sInf m = OuterMeasure.boundedBy (sInfGen m) := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · refine' le_boundedBy.2 fun s => le_iInf₂ fun μ hμ => _
     apply sInf_le hμ
   · refine' le_sInf _

--- a/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
@@ -1139,7 +1139,7 @@ theorem sInf_eq_boundedBy_sInfGen (m : Set (OuterMeasure α)) :
   apply le_antisymm
   · refine' le_boundedBy.2 fun s => le_iInf₂ fun μ hμ => _
     apply sInf_le hμ
-  · refine' le_sInf _
+  · apply le_sInf
     intro μ hμ t
     exact le_trans (boundedBy_le t) (iInf₂_le μ hμ)
 #align measure_theory.outer_measure.Inf_eq_bounded_by_Inf_gen MeasureTheory.OuterMeasure.sInf_eq_boundedBy_sInfGen
@@ -1389,7 +1389,7 @@ end Subadditive
 section Mono
 
 theorem extend_mono' ⦃s₁ s₂ : Set α⦄ (h₁ : P s₁) (hs : s₁ ⊆ s₂) : extend m s₁ ≤ extend m s₂ := by
-  refine' le_iInf _
+  apply le_iInf
   intro h₂
   rw [extend_eq m h₁]
   exact m_mono h₁ h₂ hs
@@ -1462,12 +1462,12 @@ theorem inducedOuterMeasure_eq_iInf (s : Set α) :
     intro t ht hs
     refine' le_trans (mono' _ hs) _
     exact le_of_eq (inducedOuterMeasure_eq' _ msU m_mono _)
-  · refine' le_iInf _
+  · apply le_iInf
     intro f
-    refine' le_iInf _
+    apply le_iInf
     intro hf
     refine' le_trans _ (extend_iUnion_le_tsum_nat' _ msU _)
-    refine' le_iInf _
+    apply le_iInf
     intro h2f
     exact iInf_le_of_le _ (iInf_le_of_le h2f <| iInf_le _ hf)
 #align measure_theory.induced_outer_measure_eq_infi MeasureTheory.inducedOuterMeasure_eq_iInf
@@ -1512,11 +1512,11 @@ theorem inducedOuterMeasure_caratheodory (s : Set α) :
     exact h t
   · intro h u
     conv_rhs => rw [inducedOuterMeasure_eq_iInf _ msU m_mono]
-    refine' le_iInf _
+    apply le_iInf
     intro t
-    refine' le_iInf _
+    apply le_iInf
     intro ht
-    refine' le_iInf _
+    apply le_iInf
     intro h2t
     refine' le_trans _ (le_trans (h t ht) <| le_of_eq <| inducedOuterMeasure_eq' _ msU m_mono ht)
     refine'

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -471,7 +471,7 @@ theorem piiUnionInter_mono_right {π : ι → Set (Set α)} {S T : Set ι} (hST 
 
 theorem generateFrom_piiUnionInter_le {m : MeasurableSpace α} (π : ι → Set (Set α))
     (h : ∀ n, generateFrom (π n) ≤ m) (S : Set ι) : generateFrom (piiUnionInter π S) ≤ m := by
-  refine' generateFrom_le _
+  apply generateFrom_le
   rintro t ⟨ht_p, _, ft, hft_mem_pi, rfl⟩
   refine' Finset.measurableSet_biInter _ fun x hx_mem => (h x) _ _
   exact measurableSet_generateFrom (hft_mem_pi x hx_mem)

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -511,7 +511,7 @@ theorem measurableSet_iSup_of_mem_piiUnionInter (m : ι → MeasurableSpace α) 
 
 theorem generateFrom_piiUnionInter_measurableSet (m : ι → MeasurableSpace α) (S : Set ι) :
     generateFrom (piiUnionInter (fun n => { s | MeasurableSet[m n] s }) S) = ⨆ i ∈ S, m i := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · rw [← @generateFrom_measurableSet α (⨆ i ∈ S, m i)]
     exact generateFrom_mono (measurableSet_iSup_of_mem_piiUnionInter m S)
   · refine' iSup₂_le fun i hi => _

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -177,7 +177,7 @@ lemma exists_disjoint_finset_diff_eq (hC : IsSetSemiring C) (hs : s ∈ C) (hI :
       intro x _ y _ hxy
       have hxy_disj : Disjoint (x : Set α) y := by
         by_contra h_contra
-        refine hxy ?_
+        apply hxy
         refine Subtype.ext ?_
         exact h_dis.elim x.prop y.prop h_contra
       convert hJu_disj' (x : Set α) (h_ss x.prop) y (h_ss y.prop) hxy_disj

--- a/Mathlib/ModelTheory/Satisfiability.lean
+++ b/Mathlib/ModelTheory/Satisfiability.lean
@@ -684,7 +684,7 @@ theorem Categorical.isComplete (h : κ.Categorical T) (h1 : ℵ₀ ≤ κ)
     by_contra! con
     obtain ⟨⟨MF, hMF⟩, MT, hMT⟩ := con
     rw [Sentence.realize_not, Classical.not_not] at hMT
-    refine' hMF _
+    apply hMF
     haveI := hT MT
     haveI := hT MF
     obtain ⟨NT, MNT, hNT⟩ := exists_elementarilyEquivalent_card_eq L MT κ h1 h2

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -1349,7 +1349,7 @@ theorem sum_eq_iff_sum_mul_moebius_eq_on [Ring R] {f g : ℕ → R}
         (∑ x : ℕ × ℕ in n.divisorsAntidiagonal, (μ x.fst : R) * g x.snd) = f n := by
   rw [sum_eq_iff_sum_smul_moebius_eq_on s hs]
   apply forall_congr'
-  intro a; refine' imp_congr_right _
+  intro a; apply imp_congr_right
   refine' fun _ => imp_congr_right fun _ => (sum_congr rfl fun x _hx => _).congr_left
   rw [zsmul_eq_mul]
 

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -177,7 +177,7 @@ theorem union_right [h : IsCyclotomicExtension (S ∪ T) A B] :
   have : {b : B | ∃ n : ℕ+, n ∈ S ∪ T ∧ b ^ (n : ℕ) = 1} =
       {b : B | ∃ n : ℕ+, n ∈ S ∧ b ^ (n : ℕ) = 1} ∪
         {b : B | ∃ n : ℕ+, n ∈ T ∧ b ^ (n : ℕ) = 1} := by
-    refine' le_antisymm _ _
+    apply le_antisymm
     · rintro x ⟨n, hn₁ | hn₂, hnpow⟩
       · left; exact ⟨n, hn₁, hnpow⟩
       · right; exact ⟨n, hn₂, hnpow⟩

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -421,7 +421,7 @@ theorem _root_.IsPrimitiveRoot.adjoin_isCyclotomicExtension {ζ : B} {n : ℕ+}
           (x := x) (fun b hb => ?_) (fun a => ?_) (fun b₁ b₂ hb₁ hb₂ => ?_)
           (fun b₁ b₂ hb₁ hb₂ => ?_)
       · rw [Set.mem_singleton_iff] at hb
-        refine' subset_adjoin _
+        apply subset_adjoin
         simp only [mem_singleton_iff, exists_eq_left, mem_setOf_eq, hb]
         rw [← Subalgebra.coe_eq_one, Subalgebra.coe_pow, Subtype.coe_mk]
         exact ((IsPrimitiveRoot.iff_def ζ n).1 h).1
@@ -659,7 +659,7 @@ instance isCyclotomicExtension [NeZero ((n : ℕ) : A)] :
   adjoin_roots x := by
     refine'
       adjoin_induction' (fun y hy => _) (fun a => _) (fun y z hy hz => _) (fun y z hy hz => _) x
-    · refine' subset_adjoin _
+    · apply subset_adjoin
       simp only [mem_singleton_iff, exists_eq_left, mem_setOf_eq]
       rwa [← Subalgebra.coe_eq_one, Subalgebra.coe_pow, Subtype.coe_mk]
     · exact Subalgebra.algebraMap_mem _ a

--- a/Mathlib/NumberTheory/Liouville/Measure.lean
+++ b/Mathlib/NumberTheory/Liouville/Measure.lean
@@ -83,7 +83,7 @@ theorem volume_iUnion_setOf_liouvilleWith :
   generalize hr : (2 + 1 / n : ℝ) = r
   replace hr : 2 < r := by simp [← hr, zero_lt_one.trans_le hn]
   clear hn n
-  refine' measure_setOf_frequently_eq_zero _
+  apply measure_setOf_frequently_eq_zero
   simp only [setOf_exists, ← exists_prop, ← Real.dist_eq, ← mem_ball, setOf_mem_eq]
   set B : ℤ → ℕ → Set ℝ := fun a b => ball (a / b) (1 / (b : ℝ) ^ r)
   have hB : ∀ a b, volume (B a b) = ↑((2 : ℝ≥0) / (b : ℝ≥0) ^ r) := fun a b ↦ by

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -201,7 +201,7 @@ theorem tendsto_lcRow0 {cd : Fin 2 → ℤ} (hcd : IsCoprime (cd 0) (cd 1)) :
       (cocompact ℝ) := by
   let mB : ℝ → Matrix (Fin 2) (Fin 2) ℝ := fun t => of ![![t, (-(1 : ℤ) : ℝ)], (↑) ∘ cd]
   have hmB : Continuous mB := by
-    refine' continuous_matrix _
+    apply continuous_matrix
     simp only [mB, Fin.forall_fin_two, continuous_const, continuous_id', of_apply, cons_val_zero,
       cons_val_one, and_self_iff]
   refine' Filter.Tendsto.of_tendsto_comp _ (comap_cocompact_le hmB)

--- a/Mathlib/NumberTheory/Multiplicity.lean
+++ b/Mathlib/NumberTheory/Multiplicity.lean
@@ -143,7 +143,7 @@ theorem odd_sq_dvd_geom_sum₂_sub (hp : Odd p) :
           Nat.mul_div_assoc p (even_iff_two_dvd.mp (Nat.Odd.sub_odd hp odd_one))]
       ring_nf
       rw [mul_assoc, mul_assoc]
-      refine' mul_eq_zero_of_left _ _
+      apply mul_eq_zero_of_left
       refine' Ideal.Quotient.eq_zero_iff_mem.mpr _
       simp [mem_span_singleton]
 #align odd_sq_dvd_geom_sum₂_sub odd_sq_dvd_geom_sum₂_sub

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -77,7 +77,7 @@ theorem norm_le_iff [NumberField K] (x : K) (r : ℝ) :
     ‖canonicalEmbedding K x‖ ≤ r ↔ ∀ φ : K →+* ℂ, ‖φ x‖ ≤ r := by
   obtain hr | hr := lt_or_le r 0
   · obtain ⟨φ⟩ := (inferInstance : Nonempty (K →+* ℂ))
-    refine iff_of_false ?_ ?_
+    apply iff_of_false
     exact (hr.trans_le (norm_nonneg _)).not_le
     exact fun h => hr.not_le (le_trans (norm_nonneg _) (h φ))
   · lift r to NNReal using hr

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -282,7 +282,7 @@ noncomputable abbrev convexBodySumFun (x : E K) : ℝ := ∑ w, ‖x.1 w‖ + 2 
 
 theorem convexBodySumFun_nonneg (x : E K) :
     0 ≤ convexBodySumFun x := by
-  refine add_nonneg ?_ ?_
+  apply add_nonneg
   · exact Finset.sum_nonneg (fun _ _ => norm_nonneg _)
   · exact mul_nonneg zero_le_two (Finset.sum_nonneg (fun _ _ => norm_nonneg _))
 
@@ -321,13 +321,13 @@ theorem convexBodySumFun_eq_zero_iff (x : E K) :
       Prod.snd_zero, mul_zero, add_zero]
 
 theorem norm_le_convexBodySumFun (x : E K) : ‖x‖ ≤ convexBodySumFun x := by
-  refine max_le ?_ ?_
+  apply max_le
   · refine (pi_norm_le_iff_of_nonneg (convexBodySumFun_nonneg x)).mpr (fun w => ?_)
-    refine le_add_of_le_of_nonneg ?_ ?_
+    apply le_add_of_le_of_nonneg
     · exact Finset.single_le_sum (fun z _ => norm_nonneg (x.1 z)) (Finset.mem_univ w)
     · exact mul_nonneg zero_le_two <| Finset.sum_nonneg (fun w _ => norm_nonneg (x.2 w))
   · refine (pi_norm_le_iff_of_nonneg (convexBodySumFun_nonneg x)).mpr (fun w => ?_)
-    refine le_add_of_nonneg_of_le ?_ ?_
+    apply le_add_of_nonneg_of_le
     · exact Finset.sum_nonneg (fun w _ => norm_nonneg (x.1 w))
     · rw [Finset.mul_sum]
       refine le_trans (by linarith [norm_nonneg (x.2 w)] : ‖x.2 w‖ ≤ 2 * ‖x.2 w‖) ?_
@@ -587,7 +587,7 @@ theorem exists_primitive_element_lt_of_isComplex {w₀ : InfinitePlace K} (hw₀
       dsimp only at h_le₀
       rw [h_eq, ← norm_embedding_eq, Real.lt_sqrt (norm_nonneg _), ← Complex.re_add_im
         (embedding w₀ a), Complex.norm_eq_abs, Complex.abs_add_mul_I, Real.sq_sqrt (by positivity)]
-      refine add_lt_add ?_ ?_
+      apply add_lt_add
       · rw [← sq_abs, sq_lt_one_iff (abs_nonneg _)]
         exact h_le₀.1
       · rw [sq_lt_sq, NNReal.abs_eq, ← NNReal.sq_sqrt B]

--- a/Mathlib/NumberTheory/NumberField/Discriminant.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant.lean
@@ -109,7 +109,7 @@ theorem exists_ne_zero_mem_ideal_of_norm_le_mul_sqrt_discr (I : (FractionalIdeal
   -- The smallest possible value for `exists_ne_zero_mem_ideal_of_norm_le`
   let B := (minkowskiBound K I * (convexBodySumFactor K)⁻¹).toReal ^ (1 / (finrank ℚ K : ℝ))
   have h_le : (minkowskiBound K I) ≤ volume (convexBodySum K B) := by
-    refine le_of_eq ?_
+    apply le_of_eq
     rw [convexBodySum_volume, ← ENNReal.ofReal_pow (by positivity), ← Real.rpow_natCast,
       ← Real.rpow_mul toReal_nonneg, div_mul_cancel₀, Real.rpow_one, ofReal_toReal, mul_comm,
       mul_assoc, ← coe_mul, inv_mul_cancel (convexBodySumFactor_ne_zero K), ENNReal.coe_one,

--- a/Mathlib/NumberTheory/NumberField/Units.lean
+++ b/Mathlib/NumberTheory/NumberField/Units.lean
@@ -332,7 +332,7 @@ theorem seq_next {x : 𝓞 K} (hx : x ≠ 0) :
       calc
         _ = ∏ w : InfinitePlace K, w y ^ mult w := (prod_eq_abs_norm (y : K)).symm
         _ ≤ ∏ w : InfinitePlace K, (g w : ℝ) ^ mult w := by
-          refine prod_le_prod ?_ ?_
+          apply prod_le_prod
           · exact fun _ _ => pow_nonneg (by positivity) _
           · exact fun w _ => pow_le_pow_left (by positivity) (le_of_lt (h_yle w)) (mult w)
         _ ≤ (B : ℝ) := by
@@ -442,7 +442,7 @@ theorem unitLattice_span_eq_top :
   simp_rw [Real.norm_eq_abs, B, Basis.coePiBasisFun.toMatrix_eq_transpose, Matrix.transpose_apply]
   rw [← sub_pos, sum_congr rfl (fun x hx => abs_of_neg ?_), sum_neg_distrib, sub_neg_eq_add,
     sum_erase_eq_sub (mem_univ _), ← add_comm_sub]
-  refine add_pos_of_nonneg_of_pos ?_ ?_
+  apply add_pos_of_nonneg_of_pos
   · rw [sub_nonneg]
     exact le_abs_self _
   · rw [sum_logEmbedding_component (exists_unit K w).choose]

--- a/Mathlib/NumberTheory/NumberField/Units.lean
+++ b/Mathlib/NumberTheory/NumberField/Units.lean
@@ -467,7 +467,7 @@ open dirichletUnitTheorem FiniteDimensional
 def rank : ℕ := Fintype.card (InfinitePlace K) - 1
 
 instance instDiscrete_unitLattice : DiscreteTopology (unitLattice K) := by
-  refine discreteTopology_of_isOpen_singleton_zero ?_
+  apply discreteTopology_of_isOpen_singleton_zero
   refine isOpen_singleton_of_finite_mem_nhds 0 (s := Metric.closedBall 0 1) ?_ ?_
   · exact Metric.closedBall_mem_nhds _ (by norm_num)
   · refine Set.Finite.of_finite_image ?_ (Set.injOn_of_injective Subtype.val_injective _)

--- a/Mathlib/NumberTheory/Padics/PadicNorm.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNorm.lean
@@ -166,7 +166,7 @@ protected theorem of_int (z : ℤ) : padicNorm p z ≤ 1 :=
   else by
     unfold padicNorm
     rw [if_neg _]
-    · refine' zpow_le_one_of_nonpos _ _
+    · apply zpow_le_one_of_nonpos
       · exact mod_cast le_of_lt hp.1.one_lt
       · rw [padicValRat.of_int, neg_nonpos]
         norm_cast

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -1070,7 +1070,7 @@ instance isAtomistic [∀ i, CompleteLattice (π i)] [∀ i, IsAtomistic (π i)]
       refine le_sSup ⟨⟨_, ⟨_, _, ha, rfl⟩, fun j => ?_⟩, by simp⟩
       if hij : j = i then subst hij; simpa else simp [hij]
     case ge =>
-      refine sSup_le ?_
+      apply sSup_le
       rintro _ ⟨⟨_, ⟨j, a, ha, rfl⟩, hle⟩, rfl⟩
       if hij : i = j then ?_ else simp [Function.update_noteq hij]
       subst hij; simp only [Function.update_same]

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -585,7 +585,7 @@ theorem exists_lub_Iio (i : γ) : ∃ j, IsLUB (Iio i) j := by
   · refine' ⟨i, fun j hj => le_of_lt hj, _⟩
     rw [mem_lowerBounds]
     by_contra h
-    refine' h_exists_lt _
+    apply h_exists_lt
     push_neg at h
     exact h
 #align exists_lub_Iio exists_lub_Iio

--- a/Mathlib/Order/Filter/Lift.lean
+++ b/Mathlib/Order/Filter/Lift.lean
@@ -400,7 +400,7 @@ theorem lift'_iInf_of_map_univ {f : ι → Filter α} {g : Set α → Set β}
 theorem lift'_inf (f g : Filter α) {s : Set α → Set β} (hs : ∀ t₁ t₂, s (t₁ ∩ t₂) = s t₁ ∩ s t₂) :
     (f ⊓ g).lift' s = f.lift' s ⊓ g.lift' s := by
   rw [inf_eq_iInf, inf_eq_iInf, lift'_iInf hs]
-  refine iInf_congr ?_
+  apply iInf_congr
   rintro (_|_) <;> rfl
 #align filter.lift'_inf Filter.lift'_inf
 

--- a/Mathlib/Order/Heyting/Basic.lean
+++ b/Mathlib/Order/Heyting/Basic.lean
@@ -902,7 +902,7 @@ theorem compl_compl_inf_distrib (a b : α) : (a ⊓ b)ᶜᶜ = aᶜᶜ ⊓ bᶜ�
 #align compl_compl_inf_distrib compl_compl_inf_distrib
 
 theorem compl_compl_himp_distrib (a b : α) : (a ⇨ b)ᶜᶜ = aᶜᶜ ⇨ bᶜᶜ := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · rw [le_himp_iff, ← compl_compl_inf_distrib]
     exact compl_anti (compl_anti himp_inf_le)
   · refine' le_compl_comm.1 ((compl_anti compl_sup_le_himp).trans _)
@@ -1082,7 +1082,7 @@ theorem hnot_hnot_sup_distrib (a b : α) : ￢￢(a ⊔ b) = ￢￢a ⊔ ￢￢b
 #align hnot_hnot_sup_distrib hnot_hnot_sup_distrib
 
 theorem hnot_hnot_sdiff_distrib (a b : α) : ￢￢(a \ b) = ￢￢a \ ￢￢b := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · refine' hnot_le_comm.1 ((hnot_anti sdiff_le_inf_hnot).trans' _)
     rw [hnot_inf_distrib, hnot_le_iff_codisjoint_right, codisjoint_left_comm, ←
       hnot_le_iff_codisjoint_right]

--- a/Mathlib/Order/Heyting/Boundary.lean
+++ b/Mathlib/Order/Heyting/Boundary.lean
@@ -109,10 +109,10 @@ theorem boundary_le_boundary_sup_sup_boundary_inf_left : ∂ a ≤ ∂ (a ⊔ b)
   simp only [boundary, sup_inf_left, sup_inf_right, sup_right_idem, le_inf_iff, sup_assoc,
     sup_comm _ a]
   refine ⟨⟨⟨?_, ?_⟩, ⟨?_, ?_⟩⟩, ?_, ?_⟩ <;> try { exact le_sup_of_le_left inf_le_left } <;>
-    refine inf_le_of_right_le ?_
+    apply inf_le_of_right_le
   · rw [hnot_le_iff_codisjoint_right, codisjoint_left_comm]
     exact codisjoint_hnot_left
-  · refine le_sup_of_le_right ?_
+  · apply le_sup_of_le_right
     rw [hnot_le_iff_codisjoint_right]
     exact codisjoint_hnot_right.mono_right (hnot_anti inf_le_left)
 #align coheyting.boundary_le_boundary_sup_sup_boundary_inf_left Coheyting.boundary_le_boundary_sup_sup_boundary_inf_left

--- a/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
+++ b/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
@@ -171,7 +171,7 @@ instance (priority := 100) LinearOrder.isPredArchimedean_of_isSuccArchimedean [S
     · rw [pred_succ_iterate_of_not_isMax]
       rw [Nat.succ_sub_succ_eq_sub, tsub_zero]
       suffices succ^[n] i < succ^[n.succ] i from not_isMax_of_lt this
-      refine' lt_of_le_of_ne _ _
+      apply lt_of_le_of_ne
       · rw [Function.iterate_succ']
         exact le_succ _
       · rw [hn_eq]
@@ -225,7 +225,7 @@ theorem toZ_nonneg (hi : i0 ≤ i) : 0 ≤ toZ i0 i := by
 #align to_Z_nonneg toZ_nonneg
 
 theorem toZ_neg (hi : i < i0) : toZ i0 i < 0 := by
-  refine' lt_of_le_of_ne _ _
+  apply lt_of_le_of_ne
   · rw [toZ_of_lt hi, neg_nonpos]
     exact Nat.cast_nonneg _
   · by_contra h
@@ -431,7 +431,7 @@ def orderIsoRangeOfLinearSuccPredArch [OrderBot ι] [OrderTop ι] :
   right_inv n := by
     ext1
     simp only [Subtype.coe_mk]
-    refine' le_antisymm _ _
+    apply le_antisymm
     · rw [Int.toNat_le]
       exact toZ_iterate_succ_le _
     by_cases hn_max : IsMax (succ^[↑n] (⊥ : ι))

--- a/Mathlib/Order/SupIndep.lean
+++ b/Mathlib/Order/SupIndep.lean
@@ -189,7 +189,7 @@ theorem supIndep_attach : (s.attach.SupIndep fun a => f a) ↔ s.SupIndep f := b
   classical
   convert h (filter_subset (fun (i : { x // x ∈ s }) => (i : ι) ∈ t) _) (mem_attach _ ⟨i, ‹_›⟩)
     fun hi => hit <| by simpa using hi using 1
-  refine' eq_of_forall_ge_iff _
+  apply eq_of_forall_ge_iff
   simp only [Finset.sup_le_iff, mem_filter, mem_attach, true_and_iff, Function.comp_apply,
     Subtype.forall, Subtype.coe_mk]
   exact fun a => forall_congr' fun j => ⟨fun h _ => h, fun h hj => h (ht hj) hj⟩

--- a/Mathlib/Probability/Independence/Conditional.lean
+++ b/Mathlib/Probability/Independence/Conditional.lean
@@ -176,7 +176,7 @@ lemma iCondIndepSets_iff (π : ι → Set (Set Ω)) (hπ : ∀ i s (_hs : s ∈ 
     rw [← h_inter_eq, h', ENNReal.toReal_prod, Finset.prod_apply]
     exact Finset.prod_congr rfl h_eq
   · refine (ae_eq_trim_iff hm' ?_ ?_).mpr ?_
-    · refine stronglyMeasurable_condexpKernel ?_
+    · apply stronglyMeasurable_condexpKernel
       exact MeasurableSet.biInter (Finset.countable_toSet _) (fun i hi ↦ hπ i _ (hf i hi))
     · refine Measurable.stronglyMeasurable ?_
       exact Finset.measurable_prod s (fun i hi ↦ measurable_condexpKernel (hπ i _ (hf i hi)))

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -419,7 +419,7 @@ theorem IndepSets.indep {m1 m2 m : MeasurableSpace Ω} {κ : kernel α Ω} {μ :
       Filter.eventually_true]
   · intros t ht_mem_p1
     have ht1 : MeasurableSet[m] t := by
-      refine h1 _ ?_
+      apply h1
       rw [hpm1]
       exact measurableSet_generateFrom ht_mem_p1
     exact IndepSets.indep_aux h2 hp2 hpm2 hyp ht_mem_p1 ht1 ht2

--- a/Mathlib/Probability/Independence/ZeroOne.lean
+++ b/Mathlib/Probability/Independence/ZeroOne.lean
@@ -131,7 +131,7 @@ theorem condIndep_biSup_limsup [StandardBorelSpace Ω] [Nonempty Ω]
 theorem kernel.indep_iSup_directed_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα)
     (hf : ∀ t, p t → tᶜ ∈ f) (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) :
     Indep (⨆ a, ⨆ n ∈ ns a, s n) (limsup s f) κ μα := by
-  refine' indep_iSup_of_directed_le _ _ _ _
+  apply indep_iSup_of_directed_le
   · exact fun a => indep_biSup_limsup h_le h_indep hf (hnsp a)
   · exact fun a => iSup₂_le fun n _ => h_le n
   · exact limsup_le_iSup.trans (iSup_le h_le)

--- a/Mathlib/Probability/Kernel/CondDistrib.lean
+++ b/Mathlib/Probability/Kernel/CondDistrib.lean
@@ -135,7 +135,7 @@ theorem integrable_toReal_condDistrib (hX : AEMeasurable X μ) (hs : MeasurableS
     Integrable (fun a => (condDistrib Y X μ (X a) s).toReal) μ := by
   apply integrable_toReal_of_lintegral_ne_top
   · exact Measurable.comp_aemeasurable (kernel.measurable_coe _ hs) hX
-  · refine' ne_of_lt _
+  · apply ne_of_lt
     calc
       ∫⁻ a, condDistrib Y X μ (X a) s ∂μ ≤ ∫⁻ _, 1 ∂μ := lintegral_mono fun a => prob_le_one
       _ = μ univ := lintegral_one

--- a/Mathlib/Probability/Kernel/CondDistrib.lean
+++ b/Mathlib/Probability/Kernel/CondDistrib.lean
@@ -133,7 +133,7 @@ section Integrability
 
 theorem integrable_toReal_condDistrib (hX : AEMeasurable X μ) (hs : MeasurableSet s) :
     Integrable (fun a => (condDistrib Y X μ (X a) s).toReal) μ := by
-  refine' integrable_toReal_of_lintegral_ne_top _ _
+  apply integrable_toReal_of_lintegral_ne_top
   · exact Measurable.comp_aemeasurable (kernel.measurable_coe _ hs) hX
   · refine' ne_of_lt _
     calc

--- a/Mathlib/Probability/Kernel/CondDistrib.lean
+++ b/Mathlib/Probability/Kernel/CondDistrib.lean
@@ -125,7 +125,7 @@ theorem condDistrib_ae_eq_of_measure_eq_compProd (hX : Measurable X) (hY : Measu
     rw [Measure.map_apply hX hs, Measure.fst_apply hs, Measure.map_apply]
     exacts [rfl, Measurable.prod hX hY, measurable_fst hs]
   rw [heq, condDistrib]
-  refine eq_condKernel_of_measure_eq_compProd _ ?_
+  apply eq_condKernel_of_measure_eq_compProd
   convert hκ
   exact heq.symm
 

--- a/Mathlib/Probability/Kernel/Disintegration/CdfToKernel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/CdfToKernel.lean
@@ -191,7 +191,7 @@ lemma integrable_stieltjesOfMeasurableRat [IsFiniteKernel κ] (hf : IsRatCondKer
     rw [ENNReal.toReal_ofReal]
     exact stieltjesOfMeasurableRat_nonneg _ _ _
   rw [this]
-  refine integrable_toReal_of_lintegral_ne_top ?_ ?_
+  apply integrable_toReal_of_lintegral_ne_top
   · refine (Measurable.ennreal_ofReal ?_).aemeasurable
     exact (measurable_stieltjesOfMeasurableRat hf.measurable x).comp measurable_prod_mk_left
   · rw [lintegral_stieltjesOfMeasurableRat hf]
@@ -360,7 +360,7 @@ lemma _root_.MeasureTheory.Measure.iInf_rat_gt_prod_Iic {ρ : Measure (α × ℝ
 lemma IsRatCondKernelCDFAux.setIntegral_iInf_rat_gt (hf : IsRatCondKernelCDFAux f κ ν)
     [IsFiniteKernel κ] [IsFiniteKernel ν] (a : α) (q : ℚ) {A : Set β} (hA : MeasurableSet A) :
     ∫ t in A, ⨅ r : Ioi q, f (a, t) r ∂(ν a) = (κ a (A ×ˢ Iic (q : ℝ))).toReal := by
-  refine le_antisymm ?_ ?_
+  apply le_antisymm
   · have h : ∀ r : Ioi q, ∫ t in A, ⨅ r' : Ioi q, f (a, t) r' ∂(ν a)
         ≤ (κ a (A ×ˢ Iic (r : ℝ))).toReal := by
       intro r

--- a/Mathlib/Probability/Kernel/Disintegration/CdfToKernel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/CdfToKernel.lean
@@ -334,10 +334,10 @@ lemma IsRatCondKernelCDFAux.integrable_iInf_rat_gt (hf : IsRatCondKernelCDFAux f
   · filter_upwards [hf.bddBelow_range a, hf.nonneg a, hf.le_one a]
       with t hbdd_below h_nonneg h_le_one
     rw [Real.norm_eq_abs, abs_of_nonneg]
-    · refine ciInf_le_of_le ?_ ?_ ?_
+    · apply ciInf_le_of_le
       · exact hbdd_below _
-      · exact ⟨q + 1, by simp⟩
       · exact h_le_one _
+      · exact ⟨q + 1, by simp⟩
     · exact le_ciInf fun r ↦ h_nonneg _
 
 lemma _root_.MeasureTheory.Measure.iInf_rat_gt_prod_Iic {ρ : Measure (α × ℝ)} [IsFiniteMeasure ρ]
@@ -365,7 +365,7 @@ lemma IsRatCondKernelCDFAux.setIntegral_iInf_rat_gt (hf : IsRatCondKernelCDFAux 
         ≤ (κ a (A ×ˢ Iic (r : ℝ))).toReal := by
       intro r
       rw [← hf.setIntegral a hA]
-      refine setIntegral_mono_ae ?_ ?_ ?_
+      apply setIntegral_mono_ae
       · exact (hf.integrable_iInf_rat_gt _ _).integrableOn
       · exact (hf.integrable _ _).integrableOn
       · filter_upwards [hf.bddBelow_range a] with t ht using ciInf_le (ht _) r
@@ -375,7 +375,7 @@ lemma IsRatCondKernelCDFAux.setIntegral_iInf_rat_gt (hf : IsRatCondKernelCDFAux 
         rw [← Measure.iInf_rat_gt_prod_Iic hA q]
         exact (ENNReal.toReal_iInf (fun r ↦ measure_ne_top _ _)).symm
   · rw [← hf.setIntegral a hA]
-    refine setIntegral_mono_ae ?_ ?_ ?_
+    apply setIntegral_mono_ae
     · exact (hf.integrable _ _).integrableOn
     · exact (hf.integrable_iInf_rat_gt _ _).integrableOn
     · filter_upwards [hf.mono a] with c h_mono using le_ciInf (fun r ↦ h_mono (le_of_lt r.prop))

--- a/Mathlib/Probability/Kernel/Disintegration/CondCdf.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/CondCdf.lean
@@ -205,7 +205,7 @@ lemma setIntegral_preCDF_fst (ρ : Measure (α × ℝ)) (r : ℚ) {s : Set α} (
   rw [integral_toReal]
   · rw [set_lintegral_preCDF_fst _ _ hs]
   · exact measurable_preCDF.aemeasurable
-  · refine ae_restrict_of_ae ?_
+  · apply ae_restrict_of_ae
     filter_upwards [preCDF_le_one ρ] with a ha
     exact (ha r).trans_lt ENNReal.one_lt_top
 

--- a/Mathlib/Probability/Kernel/Disintegration/Density.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Density.lean
@@ -111,7 +111,7 @@ lemma measurable_densityProcess_countableFiltration_aux (κ : kernel α (γ × �
     refine Measurable.div ?_ ?_
     · refine measurable_from_prod_countable (fun t ↦ ?_)
       exact kernel.measurable_coe _ ((measurableSet_countablePartition _ t.prop).prod hs)
-    · refine measurable_from_prod_countable ?_
+    · apply measurable_from_prod_countable
       rintro ⟨t, ht⟩
       exact kernel.measurable_coe _ (measurableSet_countablePartition _ ht)
   refine h1.comp (measurable_fst.prod_mk ?_)
@@ -531,7 +531,7 @@ lemma tendsto_setIntegral_densityProcess (hκν : fst κ ≤ ν)
     (integrable_density hκν a hs) (F := fun i x ↦ densityProcess κ ν i a x s) (l := atTop)
     (eventually_of_forall (fun n ↦ integrable_densityProcess hκν _ _ hs)) ?_ A
   refine (tendsto_congr fun n ↦ ?_).mp (tendsto_snorm_one_densityProcess_limitProcess hκν a hs)
-  refine snorm_congr_ae ?_
+  apply snorm_congr_ae
   exact EventuallyEq.rfl.sub (density_ae_eq_limitProcess hκν a hs).symm
 
 @[deprecated]

--- a/Mathlib/Probability/Kernel/Disintegration/Density.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Density.lean
@@ -489,7 +489,7 @@ lemma measurable_density_right (κ : kernel α (γ × β)) (ν : kernel α γ)
 
 lemma density_mono_set (hκν : fst κ ≤ ν) (a : α) (x : γ) {s s' : Set β} (h : s ⊆ s') :
     density κ ν a x s ≤ density κ ν a x s' := by
-  refine limsup_le_limsup ?_ ?_ ?_
+  apply limsup_le_limsup
   · exact eventually_of_forall (fun n ↦ densityProcess_mono_set hκν n a x h)
   · exact isCoboundedUnder_le_of_le atTop (fun i ↦ densityProcess_nonneg _ _ _ _ _ _)
   · exact isBoundedUnder_of ⟨1, fun n ↦ densityProcess_le_one hκν _ _ _ _⟩

--- a/Mathlib/Probability/Kernel/Disintegration/Density.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Density.lean
@@ -496,13 +496,13 @@ lemma density_mono_set (hκν : fst κ ≤ ν) (a : α) (x : γ) {s s' : Set β}
 
 lemma density_nonneg (hκν : fst κ ≤ ν) (a : α) (x : γ) (s : Set β) :
     0 ≤ density κ ν a x s := by
-  refine le_limsup_of_frequently_le ?_ ?_
+  apply le_limsup_of_frequently_le
   · exact frequently_of_forall (fun n ↦ densityProcess_nonneg _ _ _ _ _ _)
   · exact isBoundedUnder_of ⟨1, fun n ↦ densityProcess_le_one hκν _ _ _ _⟩
 
 lemma density_le_one (hκν : fst κ ≤ ν) (a : α) (x : γ) (s : Set β) :
     density κ ν a x s ≤ 1 := by
-  refine limsup_le_of_le ?_ ?_
+  apply limsup_le_of_le
   · exact isCoboundedUnder_le_of_le atTop (fun i ↦ densityProcess_nonneg _ _ _ _ _ _)
   · exact eventually_of_forall (fun n ↦ densityProcess_le_one hκν _ _ _ _)
 

--- a/Mathlib/Probability/Kernel/Disintegration/MeasurableStieltjes.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/MeasurableStieltjes.lean
@@ -192,7 +192,7 @@ lemma iInf_rat_gt_defaultRatCDF (t : ℚ) :
       rwa [Subtype.coe_mk]
     · split_ifs
       exacts [le_rfl, zero_le_one]
-  · refine le_antisymm ?_ ?_
+  · apply le_antisymm
     · refine (ciInf_le h_bdd ⟨t + 1, lt_add_one t⟩).trans ?_
       split_ifs
       exacts [zero_le_one, le_rfl]

--- a/Mathlib/Probability/Kernel/IntegralCompProd.lean
+++ b/Mathlib/Probability/Kernel/IntegralCompProd.lean
@@ -52,7 +52,7 @@ theorem hasFiniteIntegral_prod_mk_left (a : α) {s : Set (β × γ)} (h2s : (κ 
   calc
     ∫⁻ b, ENNReal.ofReal (η (a, b) (Prod.mk b ⁻¹' s)).toReal ∂κ a
     _ ≤ ∫⁻ b, η (a, b) (Prod.mk b ⁻¹' t) ∂κ a := by
-      refine' lintegral_mono_ae _
+      apply lintegral_mono_ae
       filter_upwards [ae_kernel_lt_top a h2s] with b hb
       rw [ofReal_toReal hb.ne]
       exact measure_mono (preimage_mono (subset_toMeasurable _ _))
@@ -159,7 +159,7 @@ theorem kernel.integral_fn_integral_add ⦃f g : β × γ → E⦄ (F : E → E'
     (hf : Integrable f ((κ ⊗ₖ η) a)) (hg : Integrable g ((κ ⊗ₖ η) a)) :
     ∫ x, F (∫ y, f (x, y) + g (x, y) ∂η (a, x)) ∂κ a =
       ∫ x, F (∫ y, f (x, y) ∂η (a, x) + ∫ y, g (x, y) ∂η (a, x)) ∂κ a := by
-  refine' integral_congr_ae _
+  apply integral_congr_ae
   filter_upwards [hf.compProd_mk_left_ae, hg.compProd_mk_left_ae] with _ h2f h2g
   simp [integral_add h2f h2g]
 #align probability_theory.kernel.integral_fn_integral_add ProbabilityTheory.kernel.integral_fn_integral_add
@@ -168,7 +168,7 @@ theorem kernel.integral_fn_integral_sub ⦃f g : β × γ → E⦄ (F : E → E'
     (hf : Integrable f ((κ ⊗ₖ η) a)) (hg : Integrable g ((κ ⊗ₖ η) a)) :
     ∫ x, F (∫ y, f (x, y) - g (x, y) ∂η (a, x)) ∂κ a =
       ∫ x, F (∫ y, f (x, y) ∂η (a, x) - ∫ y, g (x, y) ∂η (a, x)) ∂κ a := by
-  refine' integral_congr_ae _
+  apply integral_congr_ae
   filter_upwards [hf.compProd_mk_left_ae, hg.compProd_mk_left_ae] with _ h2f h2g
   simp [integral_sub h2f h2g]
 #align probability_theory.kernel.integral_fn_integral_sub ProbabilityTheory.kernel.integral_fn_integral_sub
@@ -177,7 +177,7 @@ theorem kernel.lintegral_fn_integral_sub ⦃f g : β × γ → E⦄ (F : E → �
     (hf : Integrable f ((κ ⊗ₖ η) a)) (hg : Integrable g ((κ ⊗ₖ η) a)) :
     ∫⁻ x, F (∫ y, f (x, y) - g (x, y) ∂η (a, x)) ∂κ a =
       ∫⁻ x, F (∫ y, f (x, y) ∂η (a, x) - ∫ y, g (x, y) ∂η (a, x)) ∂κ a := by
-  refine' lintegral_congr_ae _
+  apply lintegral_congr_ae
   filter_upwards [hf.compProd_mk_left_ae, hg.compProd_mk_left_ae] with _ h2f h2g
   simp [integral_sub h2f h2g]
 #align probability_theory.kernel.lintegral_fn_integral_sub ProbabilityTheory.kernel.lintegral_fn_integral_sub

--- a/Mathlib/Probability/Martingale/OptionalStopping.lean
+++ b/Mathlib/Probability/Martingale/OptionalStopping.lean
@@ -118,7 +118,7 @@ theorem smul_le_stoppedValue_hitting [IsFiniteMeasure μ] (hsub : Submartingale 
       (ε : ℝ) ≤ stoppedValue f (hitting f {y : ℝ | ↑ε ≤ y} 0 n) ω := by
     intro x hx
     simp_rw [le_sup'_iff, mem_range, Nat.lt_succ_iff] at hx
-    refine' stoppedValue_hitting_mem _
+    apply stoppedValue_hitting_mem
     simp only [Set.mem_setOf_eq, exists_prop, hn]
     exact
       let ⟨j, hj₁, hj₂⟩ := hx

--- a/Mathlib/Probability/Process/Filtration.lean
+++ b/Mathlib/Probability/Process/Filtration.lean
@@ -296,7 +296,7 @@ theorem filtrationOfSet_eq_natural [MulZeroOneClass β] [Nontrivial β] {s : ι 
       MeasurableSet[MeasurableSpace.comap ((s n).indicator (fun _ => 1 : Ω → β)) mβ] t} ≤
         MeasurableSpace.generateFrom {t | ∃ (j : ι), j ≤ i ∧ s j = t} by
       exact this _ ht
-    refine' generateFrom_le _
+    apply generateFrom_le
     rintro t ⟨hn, u, _, hu'⟩
     obtain heq | heq | heq | heq := Set.indicator_const_preimage (s n) u (1 : β)
     pick_goal 4; rw [Set.mem_singleton_iff] at heq

--- a/Mathlib/Probability/Process/Stopping.lean
+++ b/Mathlib/Probability/Process/Stopping.lean
@@ -585,7 +585,7 @@ protected theorem measurable_of_le [TopologicalSpace ι] [MeasurableSpace ι] [B
 
 theorem measurableSpace_min (hτ : IsStoppingTime f τ) (hπ : IsStoppingTime f π) :
     (hτ.min hπ).measurableSpace = hτ.measurableSpace ⊓ hπ.measurableSpace := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · exact le_inf (measurableSpace_mono _ hτ fun _ => min_le_left _ _)
       (measurableSpace_mono _ hπ fun _ => min_le_right _ _)
   · intro s

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -81,7 +81,7 @@ theorem evariance_eq_top [IsFiniteMeasure μ] (hXm : AEStronglyMeasurable X μ) 
     rw [snorm_eq_lintegral_rpow_nnnorm two_ne_zero ENNReal.two_ne_top]
     simp only [coe_two, ENNReal.one_toReal, ENNReal.rpow_two, Ne]
     exact ENNReal.rpow_lt_top_of_nonneg (by linarith) h.ne
-  refine' hX _
+  apply hX
   -- Porting note: `μ[X]` without whitespace is ambiguous as it could be GetElem,
   -- and `convert` cannot disambiguate based on typeclass inference failure.
   convert this.add (memℒp_const <| μ [X])

--- a/Mathlib/RingTheory/Adjoin/Basic.lean
+++ b/Mathlib/RingTheory/Adjoin/Basic.lean
@@ -322,7 +322,7 @@ theorem adjoin_adjoin_of_tower (s : Set A) : adjoin S (adjoin R s : Set A) = adj
   apply le_antisymm (adjoin_le _)
   · exact adjoin_mono subset_adjoin
   · change adjoin R s ≤ (adjoin S s).restrictScalars R
-    refine' adjoin_le _
+    apply adjoin_le
     -- Porting note: unclear why this was broken
     have : (Subalgebra.restrictScalars R (adjoin S s) : Set A) = adjoin S s := rfl
     rw [this]

--- a/Mathlib/RingTheory/Adjoin/FG.lean
+++ b/Mathlib/RingTheory/Adjoin/FG.lean
@@ -76,7 +76,7 @@ theorem fg_trans (h1 : (adjoin R s).toSubmodule.FG) (h2 : (adjoin (adjoin R s) t
     intro t ht
     change _ * _ ∈ _
     rw [smul_mul_assoc]
-    refine' smul_mem _ _ _
+    apply smul_mem
     exact subset_span ⟨t, hlp ht, z, hlq hz, rfl⟩
 #align algebra.fg_trans Algebra.fg_trans
 

--- a/Mathlib/RingTheory/Adjoin/FG.lean
+++ b/Mathlib/RingTheory/Adjoin/FG.lean
@@ -63,7 +63,7 @@ theorem fg_trans (h1 : (adjoin R s).toSubmodule.FG) (h2 : (adjoin (adjoin R s) t
     rcases hr with ⟨l, hlq, rfl⟩
     have := @Finsupp.total_apply A A (adjoin R s)
     rw [this, Finsupp.sum]
-    refine' sum_mem _
+    apply sum_mem
     intro z hz
     change (l z).1 * _ ∈ _
     have : (l z).1 ∈ Subalgebra.toSubmodule (adjoin R s) := (l z).2
@@ -72,7 +72,7 @@ theorem fg_trans (h1 : (adjoin R s).toSubmodule.FG) (h2 : (adjoin (adjoin R s) t
     have := @Finsupp.total_apply A A R
     rw [this] at hl
     rw [← hl, Finsupp.sum_mul]
-    refine' sum_mem _
+    apply sum_mem
     intro t ht
     change _ * _ ∈ _
     rw [smul_mul_assoc]

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -416,7 +416,7 @@ theorem map_intCast (n : ℤ) : D (n : A) = 0 := by
 
 theorem leibniz_of_mul_eq_one {a b : A} (h : a * b = 1) : D a = -a ^ 2 • D b := by
   rw [neg_smul]
-  refine' eq_neg_of_add_eq_zero_left _
+  apply eq_neg_of_add_eq_zero_left
   calc
     D a + a ^ 2 • D b = a • b • D a + a • a • D b := by simp only [smul_smul, h, one_smul, sq]
     _ = a • D (a * b) := by rw [leibniz, smul_add, add_comm]

--- a/Mathlib/RingTheory/EisensteinCriterion.lean
+++ b/Mathlib/RingTheory/EisensteinCriterion.lean
@@ -73,7 +73,7 @@ theorem isUnit_of_natDegree_eq_zero_of_isPrimitive {p q : R[X]}
     -- Porting note: stated using `IsPrimitive` which is defeq to old statement.
     (hu : IsPrimitive (p * q)) (hpm : p.natDegree = 0) : IsUnit p := by
   rw [eq_C_of_degree_le_zero (natDegree_eq_zero_iff_degree_le_zero.1 hpm), isUnit_C]
-  refine' hu _ _
+  apply hu
   rw [← eq_C_of_degree_le_zero (natDegree_eq_zero_iff_degree_le_zero.1 hpm)]
   exact dvd_mul_right _ _
 #align polynomial.eisenstein_criterion_aux.is_unit_of_nat_degree_eq_zero_of_forall_dvd_is_unit Polynomial.EisensteinCriterionAux.isUnit_of_natDegree_eq_zero_of_isPrimitive

--- a/Mathlib/RingTheory/EisensteinCriterion.lean
+++ b/Mathlib/RingTheory/EisensteinCriterion.lean
@@ -103,7 +103,7 @@ theorem irreducible_of_eisenstein_criterion {f : R[X]} {P : Ideal R} (hP : P.IsP
       ⟨m, n, b, c, hmnd, hbc, hp, hq⟩
     have hmn : 0 < m → 0 < n → False := by
       intro hm0 hn0
-      refine' h0 _
+      apply h0
       rw [coeff_zero_eq_eval_zero, eval_mul, sq]
       exact
         Ideal.mul_mem_mul (eval_zero_mem_ideal_of_eq_mul_X_pow hp hm0.ne')

--- a/Mathlib/RingTheory/GradedAlgebra/Radical.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/Radical.lean
@@ -164,7 +164,7 @@ theorem Ideal.IsHomogeneous.radical_eq {I : Ideal A} (hI : I.IsHomogeneous 𝒜)
   rw [Ideal.radical_eq_sInf]
   apply le_antisymm
   · exact sInf_le_sInf fun J => And.right
-  · refine sInf_le_sInf_of_forall_exists_le ?_
+  · apply sInf_le_sInf_of_forall_exists_le
     rintro J ⟨HJ₁, HJ₂⟩
     refine ⟨(J.homogeneousCore 𝒜).toIdeal, ?_, J.toIdeal_homogeneousCore_le _⟩
     refine ⟨HomogeneousIdeal.isHomogeneous _, ?_, HJ₂.homogeneousCore⟩

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -671,7 +671,7 @@ theorem span_pow_eq_top (s : Set α) (hs : span s = ⊤) (n : ℕ) :
   have : span ({(x:α) ^ (n + 1)} : Set α) ≤ span ((fun x : α => x ^ (n + 1)) '' s) := by
     rw [span_le, Set.singleton_subset_iff]
     exact subset_span ⟨x, x.prop, rfl⟩
-  refine' this _
+  apply this
   rw [mul_pow, mem_span_singleton]
   exact ⟨f x ^ (n + 1), mul_comm _ _⟩
 #align ideal.span_pow_eq_top Ideal.span_pow_eq_top

--- a/Mathlib/RingTheory/Ideal/Norm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm.lean
@@ -623,7 +623,7 @@ theorem spanNorm_mul (I J : Ideal S) : spanNorm R (I * J) = spanNorm R I * spanN
   cases subsingleton_or_nontrivial S
   · have : ∀ I : Ideal S, I = ⊤ := fun I => Subsingleton.elim I ⊤
     simp [this I, this J, this (I * J)]
-  refine eq_of_localization_maximal ?_
+  apply eq_of_localization_maximal
   intro P hP
   by_cases hP0 : P = ⊥
   · subst hP0

--- a/Mathlib/RingTheory/JacobsonIdeal.lean
+++ b/Mathlib/RingTheory/JacobsonIdeal.lean
@@ -209,7 +209,7 @@ theorem comap_jacobson {f : R →+* S} {K : Ideal S} :
 theorem comap_jacobson_of_surjective {f : R →+* S} (hf : Function.Surjective f) {K : Ideal S} :
     comap f K.jacobson = (comap f K).jacobson := by
   unfold Ideal.jacobson
-  refine' le_antisymm _ _
+  apply le_antisymm
   · rw [← top_inf_eq (sInf _), ← sInf_insert, comap_sInf', sInf_eq_iInf]
     refine' iInf_le_iInf_of_subset fun J hJ => _
     have : comap f (map f J) = J :=

--- a/Mathlib/RingTheory/Localization/Integral.lean
+++ b/Mathlib/RingTheory/Localization/Integral.lean
@@ -191,7 +191,7 @@ theorem RingHom.isIntegralElem_localization_at_leadingCoeff {R S : Type*} [CommR
   haveI : Nontrivial Rₘ := nontrivial_of_ne 1 0 triv
   obtain ⟨b, hb⟩ := isUnit_iff_exists_inv.mp (map_units Rₘ ⟨p.leadingCoeff, hM⟩)
   refine' ⟨p.map (algebraMap R Rₘ) * C b, ⟨_, _⟩⟩
-  · refine' monic_mul_C_of_leadingCoeff_mul_eq_one _
+  · apply monic_mul_C_of_leadingCoeff_mul_eq_one
     rwa [leadingCoeff_map_of_leadingCoeff_ne_zero (algebraMap R Rₘ)]
     refine' fun hfp => zero_ne_one
       (_root_.trans (zero_mul b).symm (hfp ▸ hb) : (0 : Rₘ) = 1)

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric.lean
@@ -288,7 +288,7 @@ theorem degrees_esymm [Nontrivial R] (n : ℕ) (hpos : 0 < n) (hn : n ≤ Fintyp
     rw [degrees_def, support_esymm, sup_image, this]
     have : ((powersetCard n univ).sup (fun (x : Finset σ) => x)).val
         = sup (powersetCard n univ) val := by
-      refine' comp_sup_eq_sup_comp _ _ _
+      apply comp_sup_eq_sup_comp
       · intros
         simp only [union_val, sup_eq_union]
         congr

--- a/Mathlib/RingTheory/MvPowerSeries/Trunc.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Trunc.lean
@@ -88,7 +88,7 @@ theorem trunc_one (n : σ →₀ ℕ) (hnn : n ≠ 0) : trunc R n 1 = 1 :=
       exact if_neg (Ne.symm H')
     · symm
       rw [MvPolynomial.coeff_one]
-      refine' if_neg _
+      apply if_neg
       rintro rfl
       apply H
       exact Ne.bot_lt hnn

--- a/Mathlib/RingTheory/Polynomial/GaussLemma.lean
+++ b/Mathlib/RingTheory/Polynomial/GaussLemma.lean
@@ -175,7 +175,7 @@ theorem Monic.irreducible_iff_irreducible_map_fraction_map [IsIntegrallyClosed R
         (Exists.intro (C a.leadingCoeff) <| by rw [← C_mul, this, C_1]))
   · exact Polynomial.map_injective _ (IsFractionRing.injective R K) H
   · by_contra h_contra
-    refine' hₐ _
+    apply hₐ _
     rw [← ha, ← Polynomial.coe_mapRingHom]
     exact
       IsUnit.mul (IsUnit.map _ h_contra)

--- a/Mathlib/RingTheory/Polynomial/Nilpotent.lean
+++ b/Mathlib/RingTheory/Polynomial/Nilpotent.lean
@@ -141,7 +141,7 @@ theorem coeff_isUnit_isNilpotent_of_isUnit (hunit : IsUnit P) :
     have hPQ : degree (f P) = 0 ∧ degree (f Q) = 0 := by
       rw [← Nat.WithBot.add_eq_zero_iff, ← degree_mul, ← _root_.map_mul, hQ, map_one, degree_one]
     have hcoeff : (f P).coeff n = 0 := by
-      refine' coeff_eq_zero_of_degree_lt _
+      apply coeff_eq_zero_of_degree_lt
       rw [hPQ.1]
       exact WithBot.coe_pos.2 hn.bot_lt
     rw [coe_mapRingHom, coeff_map, ← RingHom.mem_ker, Ideal.mk_ker] at hcoeff

--- a/Mathlib/RingTheory/Polynomial/Quotient.lean
+++ b/Mathlib/RingTheory/Polynomial/Quotient.lean
@@ -212,7 +212,7 @@ theorem eval₂_C_mk_eq_zero {I : Ideal R} {a : MvPolynomial σ R}
   rw [coe_eval₂Hom, eval₂_sum]
   refine' Finset.sum_eq_zero fun n _ => _
   simp only [eval₂_monomial, Function.comp_apply, RingHom.coe_comp]
-  refine' mul_eq_zero_of_left _ _
+  apply mul_eq_zero_of_left
   suffices coeff n a ∈ I by
     rw [← @Ideal.mk_ker R _ I, RingHom.mem_ker] at this
     simp only [this, C_0]

--- a/Mathlib/RingTheory/PowerBasis.lean
+++ b/Mathlib/RingTheory/PowerBasis.lean
@@ -508,7 +508,7 @@ theorem adjoin_gen_eq_top (B : PowerBasis R S) : adjoin R ({B.gen} : Set S) = �
 theorem adjoin_eq_top_of_gen_mem_adjoin {B : PowerBasis R S} {x : S}
     (hx : B.gen ∈ adjoin R ({x} : Set S)) : adjoin R ({x} : Set S) = ⊤ := by
   rw [_root_.eq_top_iff, ← B.adjoin_gen_eq_top]
-  refine' adjoin_le _
+  apply adjoin_le
   simp [hx]
 #align power_basis.adjoin_eq_top_of_gen_mem_adjoin PowerBasis.adjoin_eq_top_of_gen_mem_adjoin
 

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -268,7 +268,7 @@ theorem X_pow_order_dvd (h : (order φ).Dom) : X ^ (order φ).get h ∣ φ := by
   split_ifs with hn
   · simp [tsub_add_cancel_of_le hn]
   · simp only [Finset.sum_empty]
-    refine' coeff_of_lt_order _ _
+    apply coeff_of_lt_order
     simpa [PartENat.coe_lt_iff] using fun _ => hn
 set_option linter.uppercaseLean3 false in
 #align power_series.X_pow_order_dvd PowerSeries.X_pow_order_dvd

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -159,7 +159,7 @@ theorem order_eq {φ : R⟦X⟧} {n : PartENat} :
 /-- The order of the sum of two formal power series
  is at least the minimum of their orders. -/
 theorem le_order_add (φ ψ : R⟦X⟧) : min (order φ) (order ψ) ≤ order (φ + ψ) := by
-  refine' le_order _ _ _
+  apply le_order
   simp (config := { contextual := true }) [coeff_of_lt_order]
 #align power_series.le_order_add PowerSeries.le_order_add
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -1608,7 +1608,7 @@ open Classical in
 theorem sup_mul_inf (a b : Associates α) : (a ⊔ b) * (a ⊓ b) = a * b :=
   show (a.factors ⊔ b.factors).prod * (a.factors ⊓ b.factors).prod = a * b by
     nontriviality α
-    refine' eq_of_factors_eq_factors _
+    apply eq_of_factors_eq_factors
     rw [← prod_add, prod_factors, factors_mul, FactorSet.sup_add_inf_eq_add]
 #align associates.sup_mul_inf Associates.sup_mul_inf
 

--- a/Mathlib/RingTheory/WittVector/MulCoeff.lean
+++ b/Mathlib/RingTheory/WittVector/MulCoeff.lean
@@ -75,7 +75,7 @@ theorem wittPolyProdRemainder_vars (n : ℕ) :
   rw [biUnion_subset]
   intro x hx
   apply Subset.trans (vars_mul _ _)
-  refine' union_subset _ _
+  apply union_subset
   · apply Subset.trans (vars_pow _ _)
     have : (p : 𝕄) = C (p : ℤ) := by simp only [Int.cast_natCast, eq_intCast]
     rw [this, vars_C]
@@ -199,7 +199,7 @@ theorem mul_polyOfInterest_vars (n : ℕ) :
     ((p : 𝕄) ^ (n + 1) * polyOfInterest p n).vars ⊆ univ ×ˢ range (n + 1) := by
   rw [mul_polyOfInterest_aux5]
   apply Subset.trans (vars_sub_subset _)
-  refine' union_subset _ _
+  apply union_subset
   · apply remainder_vars
   · apply wittPolyProdRemainder_vars
 #align witt_vector.mul_poly_of_interest_vars WittVector.mul_polyOfInterest_vars

--- a/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
+++ b/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
@@ -317,7 +317,7 @@ theorem eq_wittStructureInt (Φ : MvPolynomial idx ℤ) (φ : ℕ → MvPolynomi
   rw [map_wittStructureInt]
   -- Porting note: was `refine' congr_fun _ k`
   revert k
-  refine' congr_fun _
+  apply congr_fun
   apply ExistsUnique.unique (wittStructureRat_existsUnique p (map (Int.castRingHom ℚ) Φ))
   · intro n
     specialize h n

--- a/Mathlib/Topology/Algebra/Module/LinearPMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearPMap.lean
@@ -118,7 +118,7 @@ theorem IsClosable.graph_closure_eq_closure_graph {f : E →ₗ.[R] F} (hf : f.I
 /-- A `LinearPMap` is contained in its closure. -/
 theorem le_closure (f : E →ₗ.[R] F) : f ≤ f.closure := by
   by_cases hf : f.IsClosable
-  · refine' le_of_le_graph _
+  · apply le_of_le_graph
     rw [← hf.graph_closure_eq_closure_graph]
     exact (graph f).le_topologicalClosure
   rw [closure_def' hf]
@@ -126,7 +126,7 @@ theorem le_closure (f : E →ₗ.[R] F) : f ≤ f.closure := by
 
 theorem IsClosable.closure_mono {f g : E →ₗ.[R] F} (hg : g.IsClosable) (h : f ≤ g) :
     f.closure ≤ g.closure := by
-  refine' le_of_le_graph _
+  apply le_of_le_graph
   rw [← (hg.leIsClosable h).graph_closure_eq_closure_graph]
   rw [← hg.graph_closure_eq_closure_graph]
   exact Submodule.topologicalClosure_mono (le_graph_of_le h)

--- a/Mathlib/Topology/Algebra/Module/LocallyConvex.lean
+++ b/Mathlib/Topology/Algebra/Module/LocallyConvex.lean
@@ -164,7 +164,7 @@ theorem locallyConvexSpace_sInf {ts : Set (TopologicalSpace E)}
 theorem locallyConvexSpace_iInf {ts' : ι → TopologicalSpace E}
     (h' : ∀ i, @LocallyConvexSpace 𝕜 E _ _ _ (ts' i)) :
     @LocallyConvexSpace 𝕜 E _ _ _ (⨅ i, ts' i) := by
-  refine' locallyConvexSpace_sInf _
+  apply locallyConvexSpace_sInf
   rwa [forall_mem_range]
 #align locally_convex_space_infi locallyConvexSpace_iInf
 

--- a/Mathlib/Topology/Algebra/Order/LiminfLimsup.lean
+++ b/Mathlib/Topology/Algebra/Order/LiminfLimsup.lean
@@ -537,7 +537,7 @@ theorem limsup_eq_tendsto_sum_indicator_nat_atTop (s : ℕ → Set α) :
         le_antisymm (h i) hi
       refine' not_lt.2 (h <| j + 1) _
       rw [← Finset.sum_range_add_sum_Ico _ (i.le_succ.trans (hj₁.trans j.le_succ)), hi]
-      refine' lt_add_of_pos_right _ _
+      apply lt_add_of_pos_right
       rw [(Finset.sum_const_zero.symm : 0 = ∑ k in Finset.Ico i (j + 1), 0)]
       refine' Finset.sum_lt_sum (fun m _ ↦ Set.indicator_nonneg (fun _ _ ↦ zero_le_one) _)
         ⟨j - 1, Finset.mem_Ico.2 ⟨(Nat.le_sub_iff_add_le (le_trans ((le_add_iff_nonneg_left _).2

--- a/Mathlib/Topology/Algebra/UniformGroup.lean
+++ b/Mathlib/Topology/Algebra/UniformGroup.lean
@@ -826,7 +826,7 @@ open DenseInducing
 ℤ-bilinear continuous maps from dense images into a complete Hausdorff group extend by continuity.
 Note: Bourbaki assumes that α and β are also complete Hausdorff, but this is not necessary. -/
 theorem extend_Z_bilin : Continuous (extend (de.prod df) (fun p : β × δ => φ p.1 p.2)) := by
-  refine' continuous_extend_of_cauchy _ _
+  apply continuous_extend_of_cauchy
   rintro ⟨x₀, y₀⟩
   constructor
   · apply NeBot.map

--- a/Mathlib/Topology/Bases.lean
+++ b/Mathlib/Topology/Bases.lean
@@ -572,7 +572,7 @@ protected theorem IsTopologicalBasis.iInf {β : Type*} {ι : Type*} {t : ι → 
     IsTopologicalBasis (t := ⨅ i, t i)
       { S | ∃ (U : ι → Set β) (F : Finset ι), (∀ i, i ∈ F → U i ∈ T i) ∧ S = ⋂ i ∈ F, U i } := by
   let _ := ⨅ i, t i
-  refine isTopologicalBasis_of_isOpen_of_nhds ?_ ?_
+  apply isTopologicalBasis_of_isOpen_of_nhds
   · rintro - ⟨U, F, hU, rfl⟩
     refine isOpen_biInter_finset fun i hi ↦
       (h_basis i).isOpen (t := t i) (hU i hi) |>.mono (iInf_le _ _)

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -1774,7 +1774,7 @@ open scoped Classical in
 theorem Nobeling.embedding : ClosedEmbedding (Nobeling.ι S) := by
   apply Continuous.closedEmbedding
   · dsimp (config := { unfoldPartialApp := true }) [ι]
-    refine continuous_pi ?_
+    apply continuous_pi
     intro C
     rw [← IsLocallyConstant.iff_continuous]
     refine ((IsLocallyConstant.tfae _).out 0 3).mpr ?_

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -186,7 +186,7 @@ theorem IsPreconnected.biUnion_of_reflTransGen {ι : Type*} {t : Set ι} {s : ι
       refine (H k hj).union' (hjk.1.mono ?_) hp
       rw [inter_comm]
       exact inter_subset_inter_right _ (subset_biUnion_of_mem hjp)
-  refine' isPreconnected_of_forall_pair _
+  apply isPreconnected_of_forall_pair
   intro x hx y hy
   obtain ⟨i : ι, hi : i ∈ t, hxi : x ∈ s i⟩ := mem_iUnion₂.1 hx
   obtain ⟨j : ι, hj : j ∈ t, hyj : y ∈ s j⟩ := mem_iUnion₂.1 hy

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -1498,7 +1498,7 @@ theorem pi_generateFrom_eq {π : ι → Type*} {g : ∀ a, Set (Set (π a))} :
     (@Pi.topologicalSpace ι π fun a => generateFrom (g a)) =
       generateFrom
         { t | ∃ (s : ∀ a, Set (π a)) (i : Finset ι), (∀ a ∈ i, s a ∈ g a) ∧ t = pi (↑i) s } := by
-  refine le_antisymm ?_ ?_
+  apply le_antisymm
   · apply le_generateFrom
     rintro _ ⟨s, i, hi, rfl⟩
     letI := fun a => generateFrom (g a)

--- a/Mathlib/Topology/ContinuousFunction/Algebra.lean
+++ b/Mathlib/Topology/ContinuousFunction/Algebra.lean
@@ -332,7 +332,7 @@ instance [CommMonoidWithZero β] [ContinuousMul β] : CommMonoidWithZero C(α, �
 @[to_additive]
 instance [LocallyCompactSpace α] [Mul β] [ContinuousMul β] : ContinuousMul C(α, β) :=
   ⟨by
-    refine' continuous_of_continuous_uncurry _ _
+    apply continuous_of_continuous_uncurry
     have h1 : Continuous fun x : (C(α, β) × C(α, β)) × α => x.fst.fst x.snd :=
       continuous_eval.comp (continuous_fst.prod_map continuous_id)
     have h2 : Continuous fun x : (C(α, β) × C(α, β)) × α => x.fst.snd x.snd :=
@@ -603,7 +603,7 @@ instance [LocallyCompactSpace α] [SMul R M] [ContinuousConstSMul R M] :
 instance [LocallyCompactSpace α] [TopologicalSpace R] [SMul R M] [ContinuousSMul R M] :
     ContinuousSMul R C(α, M) :=
   ⟨by
-    refine' continuous_of_continuous_uncurry _ _
+    apply continuous_of_continuous_uncurry
     have h : Continuous fun x : (R × C(α, M)) × α => x.fst.snd x.snd :=
       continuous_eval.comp (continuous_snd.prod_map continuous_id)
     exact (continuous_fst.comp continuous_fst).smul h⟩

--- a/Mathlib/Topology/ContinuousFunction/Bounded.lean
+++ b/Mathlib/Topology/ContinuousFunction/Bounded.lean
@@ -1478,7 +1478,7 @@ variable [CstarRing β]
 
 instance instCstarRing : CstarRing (α →ᵇ β) where
   norm_star_mul_self {f} := by
-    refine' le_antisymm _ _
+    apply le_antisymm
     · rw [← sq, norm_le (sq_nonneg _)]
       dsimp [star_apply]
       intro x

--- a/Mathlib/Topology/ContinuousFunction/Compact.lean
+++ b/Mathlib/Topology/ContinuousFunction/Compact.lean
@@ -532,7 +532,7 @@ variable [TopologicalSpace α] [NormedRing β] [StarRing β]
 
 instance [CompactSpace α] [CstarRing β] : CstarRing C(α, β) where
   norm_star_mul_self {f} := by
-    refine' le_antisymm _ _
+    apply le_antisymm
     · rw [← sq, ContinuousMap.norm_le _ (sq_nonneg _)]
       intro x
       simp only [ContinuousMap.coe_mul, coe_star, Pi.mul_apply, Pi.star_apply,

--- a/Mathlib/Topology/Gluing.lean
+++ b/Mathlib/Topology/Gluing.lean
@@ -295,7 +295,7 @@ theorem preimage_image_eq_image' (i j : D.J) (U : Set (𝖣.U i)) :
   show (fun x => ((forget TopCat).map _ ((forget TopCat).map _ x))) '' _ = _
   rw [← Set.image_image]
   -- Porting note: `congr 1` was here, instead of `congr_arg`, however, it did nothing.
-  refine congr_arg ?_ ?_
+  apply congr_arg
   rw [← Set.eq_preimage_iff_image_eq, Set.preimage_preimage]
   change _ = (D.t i j ≫ D.t j i ≫ _) ⁻¹' _
   rw [𝖣.t_inv_assoc]

--- a/Mathlib/Topology/List.lean
+++ b/Mathlib/Topology/List.lean
@@ -25,7 +25,7 @@ instance : TopologicalSpace (List α) :=
   TopologicalSpace.mkOfNhds (traverse nhds)
 
 theorem nhds_list (as : List α) : 𝓝 as = traverse 𝓝 as := by
-  refine' nhds_mkOfNhds _ _ _ _
+  apply nhds_mkOfNhds
   · intro l
     induction l with
     | nil => exact le_rfl

--- a/Mathlib/Topology/List.lean
+++ b/Mathlib/Topology/List.lean
@@ -114,7 +114,7 @@ theorem tendsto_nhds {β : Type*} {f : List α → β} {r : List α → Filter �
 
 theorem continuousAt_length : ∀ l : List α, ContinuousAt List.length l := by
   simp only [ContinuousAt, nhds_discrete]
-  refine' tendsto_nhds _ _
+  apply tendsto_nhds
   · exact tendsto_pure_pure _ _
   · intro l a ih
     dsimp only [List.length]

--- a/Mathlib/Topology/MetricSpace/CantorScheme.lean
+++ b/Mathlib/Topology/MetricSpace/CantorScheme.lean
@@ -172,7 +172,7 @@ theorem ClosureAntitone.map_of_vanishingDiam [CompleteSpace α] (hdiam : Vanishi
   choose u hu using fun n => hnonempty (res x n)
   have umem : ∀ n m : ℕ, n ≤ m → u m ∈ A (res x n) := by
     have : Antitone fun n : ℕ => A (res x n) := by
-      refine' antitone_nat_of_succ_le _
+      apply antitone_nat_of_succ_le
       intro n
       apply hanti.antitone
     intro n m hnm

--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -207,7 +207,7 @@ instance Closeds.compactSpace [CompactSpace α] : CompactSpace (Closeds α) :=
       intro u
       let v := { x : α | x ∈ s ∧ ∃ y ∈ u, edist x y < δ }
       exists v, (fun x hx => hx.1 : v ⊆ s)
-      refine' hausdorffEdist_le_of_mem_edist _ _
+      apply hausdorffEdist_le_of_mem_edist
       · intro x hx
         have : x ∈ ⋃ y ∈ s, ball y δ := hs (by simp)
         rcases mem_iUnion₂.1 this with ⟨y, ys, dy⟩

--- a/Mathlib/Topology/MetricSpace/Gluing.lean
+++ b/Mathlib/Topology/MetricSpace/Gluing.lean
@@ -461,7 +461,7 @@ protected theorem completeSpace [∀ i, CompleteSpace (E i)] : CompleteSpace (Σ
     exact (isometry_mk i).uniformInducing.isComplete_range
   have hd : ∀ (i j), ∀ x ∈ s i, ∀ y ∈ s j, (x, y) ∈ U → i = j := fun i j x hx y hy hxy =>
     (Eq.symm hx).trans ((fst_eq_of_dist_lt_one _ _ hxy).trans hy)
-  refine' completeSpace_of_isComplete_univ _
+  apply completeSpace_of_isComplete_univ
   convert isComplete_iUnion_separated hc (dist_mem_uniformity zero_lt_one) hd
   simp only [s, ← preimage_iUnion, iUnion_of_singleton, preimage_univ]
 #align metric.sigma.complete_space Metric.Sigma.completeSpace

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -691,7 +691,7 @@ instance : SecondCountableTopology GHSpace := by
   -- Use the almost isometry `Φ` to show that `p.rep` and `q.rep`
   -- are within controlled Gromov-Hausdorff distance.
   have main : ghDist p.Rep q.Rep ≤ ε + ε / 2 + ε := by
-    refine' ghDist_le_of_approx_subsets Φ _ _ _
+    apply ghDist_le_of_approx_subsets Φ
     show ∀ x : p.Rep, ∃ y ∈ s p, dist x y ≤ ε
     · -- by construction, `s p` is `ε`-dense
       intro x

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -386,7 +386,7 @@ theorem hausdorffDist_optimal {X : Type u} [MetricSpace X] [CompactSpace X] [Non
           hausdorffDist_optimal_le_HD _ _ candidatesBDist_mem_candidatesB
         _ ≤ diam (univ : Set X) + 1 + diam (univ : Set Y) := HD_candidatesBDist_le
         _ ≤ hausdorffDist (p : Set ℓ_infty_ℝ) q := not_lt.1 h
-  refine' le_antisymm _ _
+  apply le_antisymm
   · apply le_csInf
     · refine' (Set.Nonempty.prod _ _).image _ <;> exact ⟨_, rfl⟩
     · rintro b ⟨⟨p, q⟩, ⟨hp, hq⟩, rfl⟩
@@ -419,7 +419,7 @@ instance : MetricSpace GHSpace where
   edist_dist _ _ := by exact ENNReal.coe_nnreal_eq _
   dist_self x := by
     rcases exists_rep x with ⟨y, hy⟩
-    refine' le_antisymm _ _
+    apply le_antisymm
     · apply csInf_le
       · exact ⟨0, by rintro b ⟨⟨u, v⟩, -, rfl⟩; exact hausdorffDist_nonneg⟩
       · simp only [mem_image, mem_prod, mem_setOf_eq, Prod.exists]

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -547,7 +547,7 @@ theorem dimH_of_mem_nhds {x : E} {s : Set E} (h : s ∈ 𝓝 x) : dimH s = finra
   have e : E ≃L[ℝ] Fin (finrank ℝ E) → ℝ :=
     ContinuousLinearEquiv.ofFinrankEq (FiniteDimensional.finrank_fin_fun ℝ).symm
   rw [← e.dimH_image]
-  refine le_antisymm ?_ ?_
+  apply le_antisymm
   · exact (dimH_mono (subset_univ _)).trans_eq (dimH_univ_pi_fin _)
   · have : e '' s ∈ 𝓝 (e x) := by rw [← e.map_nhds_eq]; exact image_mem_map h
     rcases Metric.nhds_basis_ball.mem_iff.1 this with ⟨r, hr0, hr⟩

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -174,7 +174,7 @@ set_option linter.uppercaseLean3 false in
 theorem dimH_subsingleton {s : Set X} (h : s.Subsingleton) : dimH s = 0 := by
   borelize X
   apply le_antisymm _ (zero_le _)
-  refine dimH_le_of_hausdorffMeasure_ne_top ?_
+  apply dimH_le_of_hausdorffMeasure_ne_top
   exact ((hausdorffMeasure_le_one_of_subsingleton h le_rfl).trans_lt ENNReal.one_lt_top).ne
 set_option linter.uppercaseLean3 false in
 #align dimH_subsingleton dimH_subsingleton

--- a/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
@@ -362,7 +362,7 @@ theorem hausdorffEdist_le_ediam (hs : s.Nonempty) (ht : t.Nonempty) :
     hausdorffEdist s t ≤ diam (s ∪ t) := by
   rcases hs with ⟨x, xs⟩
   rcases ht with ⟨y, yt⟩
-  refine' hausdorffEdist_le_of_mem_edist _ _
+  apply hausdorffEdist_le_of_mem_edist
   · intro z hz
     exact ⟨y, yt, edist_le_diam_of_mem (subset_union_left _ _ hz) (subset_union_right _ _ yt)⟩
   · intro z hz
@@ -407,7 +407,7 @@ theorem hausdorffEdist_self_closure : hausdorffEdist s (closure s) = 0 := by
 /-- Replacing a set by its closure does not change the Hausdorff edistance. -/
 @[simp]
 theorem hausdorffEdist_closure₁ : hausdorffEdist (closure s) t = hausdorffEdist s t := by
-  refine' le_antisymm _ _
+  apply le_antisymm
   · calc
       _ ≤ hausdorffEdist (closure s) s + hausdorffEdist s t := hausdorffEdist_triangle
       _ = hausdorffEdist s t := by simp [hausdorffEdist_comm]

--- a/Mathlib/Topology/Order/LeftRightLim.lean
+++ b/Mathlib/Topology/Order/LeftRightLim.lean
@@ -114,7 +114,7 @@ theorem leftLim_le (h : x ≤ y) : leftLim f x ≤ f y := by
   · simpa [leftLim, h'] using hf h
   haveI A : NeBot (𝓝[<] x) := neBot_iff.2 h'
   rw [leftLim_eq_sSup hf h']
-  refine' csSup_le _ _
+  apply csSup_le
   · simp only [image_nonempty]
     exact (forall_mem_nonempty_iff_neBot.2 A) _ self_mem_nhdsWithin
   · simp only [mem_image, mem_Iio, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]

--- a/Mathlib/Topology/Order/T5.lean
+++ b/Mathlib/Topology/Order/T5.lean
@@ -33,7 +33,7 @@ theorem ordConnectedComponent_mem_nhds : ordConnectedComponent s a ∈ 𝓝 a �
 theorem compl_section_ordSeparatingSet_mem_nhdsWithin_Ici (hd : Disjoint s (closure t))
     (ha : a ∈ s) : (ordConnectedSection (ordSeparatingSet s t))ᶜ ∈ 𝓝[≥] a := by
   have hmem : tᶜ ∈ 𝓝[≥] a := by
-    refine' mem_nhdsWithin_of_mem_nhds _
+    apply mem_nhdsWithin_of_mem_nhds
     rw [← mem_interior_iff_mem_nhds, interior_compl]
     exact disjoint_left.1 hd ha
   rcases exists_Icc_mem_subset_of_mem_nhdsWithin_Ici hmem with ⟨b, hab, hmem', hsub⟩

--- a/Mathlib/Topology/Sets/Opens.lean
+++ b/Mathlib/Topology/Sets/Opens.lean
@@ -305,7 +305,7 @@ theorem isBasis_iff_nbhd {B : Set (Opens α)} :
     dsimp at H₂
     subst H₂
     exact hsV
-  · refine' isTopologicalBasis_of_isOpen_of_nhds _ _
+  · apply isTopologicalBasis_of_isOpen_of_nhds
     · rintro sU ⟨U, -, rfl⟩
       exact U.2
     · intro x sU hx hsU

--- a/Mathlib/Topology/Sheaves/SheafCondition/Sites.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/Sites.lean
@@ -58,7 +58,7 @@ to `R` really is _covering_, i.e. the union of all open sets equals `U`.
 theorem iSup_eq_of_mem_grothendieck (hR : Sieve.generate R ∈ Opens.grothendieckTopology X U) :
     iSup (coveringOfPresieve U R) = U := by
   apply le_antisymm
-  · refine' iSup_le _
+  · apply iSup_le
     intro f
     exact f.2.1.le
   intro x hxU


### PR DESCRIPTION
We replace `refine foo ?_ ?_` by `apply foo`, and similar cases in order to avoid many underscores.
For instance
```
refine' liftR_map_last _ _ _ _ _
```
is replaced with 
```
apply liftR_map_last
```
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
