### PR TITLE
[Merged by Bors] - Add simple lemmas about integrability

### DIFF
--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -698,19 +698,6 @@ theorem integrable_neg_iff {f : α → β} : Integrable (-f) μ ↔ Integrable f
 #align measure_theory.integrable_neg_iff MeasureTheory.integrable_neg_iff
 
 @[simp]
-lemma integrable_add_const_iff [IsFiniteMeasure μ] {f : α → β} {c : β} :
-    Integrable (fun x ↦ f x + c) μ ↔ Integrable f μ :=
-  ⟨fun h ↦ show f = fun x ↦ f x + c + (-c) by simp only [add_neg_cancel_right]
-    ▸ h.add (integrable_const _), fun h ↦ h.add (integrable_const _)⟩
-
-@[simp]
-lemma integrable_const_add_iff [IsFiniteMeasure μ] {f : α → β} {c : β} :
-    Integrable (fun x ↦ c + f x) μ ↔ Integrable f μ :=
-  ⟨fun h ↦ show f = fun x ↦ (c + f x) + (-c)
-    by simp only [add_neg_cancel_comm] ▸ Integrable.add h (integrable_const (-c)),
-    fun h ↦ Integrable.add (integrable_const _) h⟩
-
-@[simp]
 lemma integrable_add_iff_integrable_right {f g : α → β} (hf : Integrable f μ) :
     Integrable (f + g) μ ↔ Integrable g μ :=
   ⟨fun h ↦ show g = f + g + (-f) by simp only [add_neg_cancel_comm] ▸ h.add hf.neg,
@@ -718,9 +705,18 @@ lemma integrable_add_iff_integrable_right {f g : α → β} (hf : Integrable f �
 
 @[simp]
 lemma integrable_add_iff_integrable_left {f g : α → β} (hf : Integrable f μ) :
-    Integrable (g + f) μ ↔ Integrable g μ :=
-  ⟨fun h ↦ show g = g + f + (-f) by simp only [add_neg_cancel_right] ▸ h.add hf.neg,
-    fun h ↦ h.add hf⟩
+    Integrable (g + f) μ ↔ Integrable g μ := by
+  rw [add_comm, integrable_add_iff_integrable_right hf]
+
+@[simp]
+lemma integrable_add_const_iff [IsFiniteMeasure μ] {f : α → β} {c : β} :
+    Integrable (fun x ↦ f x + c) μ ↔ Integrable f μ :=
+  integrable_add_iff_integrable_left (integrable_const _)
+
+@[simp]
+lemma integrable_const_add_iff [IsFiniteMeasure μ] {f : α → β} {c : β} :
+    Integrable (fun x ↦ c + f x) μ ↔ Integrable f μ :=
+  integrable_add_iff_integrable_right (integrable_const _)
 
 theorem Integrable.sub {f g : α → β} (hf : Integrable f μ) (hg : Integrable g μ) :
     Integrable (f - g) μ := by simpa only [sub_eq_add_neg] using hf.add hg.neg

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -700,8 +700,8 @@ theorem integrable_neg_iff {f : α → β} : Integrable (-f) μ ↔ Integrable f
 @[simp]
 lemma integrable_add_const_iff [IsFiniteMeasure μ] {f : α → β} {c : β} :
     Integrable (fun x ↦ f x + c) μ ↔ Integrable f μ :=
-  ⟨fun h ↦ show f = fun x ↦ f x + c + (-c)
-    by simp only [add_neg_cancel_right] ▸ h.add (integrable_const _), fun h ↦ h.add (integrable_const _)⟩
+  ⟨fun h ↦ show f = fun x ↦ f x + c + (-c) by simp only [add_neg_cancel_right]
+    ▸ h.add (integrable_const _), fun h ↦ h.add (integrable_const _)⟩
 
 @[simp]
 lemma integrable_const_add_iff [IsFiniteMeasure μ] {f : α → β} {c : β} :

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -697,6 +697,31 @@ theorem integrable_neg_iff {f : α → β} : Integrable (-f) μ ↔ Integrable f
   ⟨fun h => neg_neg f ▸ h.neg, Integrable.neg⟩
 #align measure_theory.integrable_neg_iff MeasureTheory.integrable_neg_iff
 
+@[simp]
+lemma integrable_add_const_iff [IsFiniteMeasure μ] {f : α → β} {c : β} :
+    Integrable (fun x ↦ f x + c) μ ↔ Integrable f μ :=
+  ⟨fun h ↦ show f = fun x ↦ f x + c + (-c)
+    by simp only [add_neg_cancel_right] ▸ h.add (integrable_const _), fun h ↦ h.add (integrable_const _)⟩
+
+@[simp]
+lemma integrable_const_add_iff [IsFiniteMeasure μ] {f : α → β} {c : β} :
+    Integrable (fun x ↦ c + f x) μ ↔ Integrable f μ :=
+  ⟨fun h ↦ show f = fun x ↦ (c + f x) + (-c)
+    by simp only [add_neg_cancel_comm] ▸ Integrable.add h (integrable_const (-c)),
+    fun h ↦ Integrable.add (integrable_const _) h⟩
+
+@[simp]
+lemma integrable_add_iff_integrable_right {f g : α → β} (hf : Integrable f μ) :
+    Integrable (f + g) μ ↔ Integrable g μ :=
+  ⟨fun h ↦ show g = f + g + (-f) by simp only [add_neg_cancel_comm] ▸ h.add hf.neg,
+    fun h ↦ hf.add h⟩
+
+@[simp]
+lemma integrable_add_iff_integrable_left {f g : α → β} (hf : Integrable f μ) :
+    Integrable (g + f) μ ↔ Integrable g μ :=
+  ⟨fun h ↦ show g = g + f + (-f) by simp only [add_neg_cancel_right] ▸ h.add hf.neg,
+    fun h ↦ h.add hf⟩
+
 theorem Integrable.sub {f g : α → β} (hf : Integrable f μ) (hg : Integrable g μ) :
     Integrable (f - g) μ := by simpa only [sub_eq_add_neg] using hf.add hg.neg
 #align measure_theory.integrable.sub MeasureTheory.Integrable.sub


### PR DESCRIPTION
I add 4 iff lemmas about the integrability a function to the MeasureTheory.Function.L1Space file. 

The first two lemmas are about the integrability of the sum of function and a constant under a finite measure. 
The other two are about the integrability of the sum of a function and an integrable function.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
