### PR TITLE
[Merged by Bors] - feat(scripts/lint-style): more useful line numbers

### DIFF
--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -359,7 +359,7 @@ def output_message(path, line_nr, code, msg):
             msg_type = "warning"
         # We are outputting for github. We duplicate path, line_nr and code,
         # so that they are also visible in the plaintext output.
-        print(f"::{msg_type} file={path},line={line_nr},code={code}::{path}#L{line_nr}: {code}: {msg}")
+        print(f"::{msg_type} file={path},line={line_nr},code={code}::{path}:{line_nr} {code}: {msg}")
 
 def format_errors(errors):
     global new_exceptions


### PR DESCRIPTION
This changes slighlty the output of the linter from
```
[...]Mathlib/My/File.lean#L285: ERR_LIN: Line has more than 100 characters
```
to
```
[...]Mathlib/My/File.lean:285 ERR_LIN: Line has more than 100 characters
```

If one then copies the path with the line number and uses that when opening the file in vs code with Ctrl-p, it will set to cursor to the correct line number in question. Also other tools will work with that format, it is also used by pylint, clang etc.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
