### PR TITLE
[Merged by Bors] - feat: order embedding is fully faithful as a functor

### DIFF
--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -143,6 +143,10 @@ theorem Monotone.functor_obj {f : X → Y} (h : Monotone f) : h.functor.obj = f 
   rfl
 #align monotone.functor_obj Monotone.functor_obj
 
+-- Faithfulness is automatic because preorder categories are thin
+instance (f : X ↪o Y) : f.monotone.functor.Full where
+  preimage {x y} h := homOfLE (f.map_rel_iff.1 h.le)
+
 end
 
 namespace CategoryTheory

--- a/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
@@ -282,6 +282,8 @@ theorem Faithful.of_comp [(F ⋙ G).Faithful] : F.Faithful :=
   { map_injective := fun {_ _} => Function.Injective.of_comp (F ⋙ G).map_injective }
 #align category_theory.faithful.of_comp CategoryTheory.Functor.Faithful.of_comp
 
+instance (priority := 100) [Quiver.IsThin C] : F.Faithful where
+
 section
 
 variable {F F'}


### PR DESCRIPTION
As discussed [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Free.20Walking.20Arrow.20Category).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
