### PR TITLE
[Merged by Bors] - chore: remove temporary reviewdog fix

### DIFF
--- a/.github/workflows/lint_and_suggest_pr.yml
+++ b/.github/workflows/lint_and_suggest_pr.yml
@@ -27,8 +27,6 @@ jobs:
           ./scripts/lint-style.sh --fix
 
       - name: suggester / lint-style
-        # temporary fix for https://github.com/reviewdog/reviewdog/issues/1696#issue-2206596164
-        if: ${{ github.event.pull_request.changed_files < 301 }}
         uses: reviewdog/action-suggester@v1
         with:
           tool_name: lint-style
@@ -44,8 +42,6 @@ jobs:
           ./scripts/lint-bib.sh
 
       - name: suggester / lint-bib
-        # temporary fix for https://github.com/reviewdog/reviewdog/issues/1696#issue-2206596164
-        if: ${{ github.event.pull_request.changed_files < 301 }}
         uses: reviewdog/action-suggester@v1
         with:
           tool_name: lint-bib
@@ -82,8 +78,6 @@ jobs:
           git ls-files 'Archive/*.lean' | LC_ALL=C sort | sed 's/\.lean//;s,/,.,g;s/^/import /' > Archive.lean
 
       - name: suggester / import list
-        # temporary fix for https://github.com/reviewdog/reviewdog/issues/1696#issue-2206596164
-        if: ${{ github.event.pull_request.changed_files < 301 }}
         uses: reviewdog/action-suggester@v1
         with:
           tool_name: imports


### PR DESCRIPTION
 - [x] depends on: https://github.com/reviewdog/action-suggester/pull/52


This reverts #12280 after the upstream fix
 https://github.com/reviewdog/reviewdog/issues/1696
has propagated to reviewdog/action-suggester@v1. This should happen when 
https://github.com/reviewdog/action-suggester/releases
has a release that uses [v0.17.4](https://github.com/reviewdog/reviewdog/releases/tag/v0.17.4) or higher.

When this happens, rebase this pull request and re-trigger to see that it doesn't fail with the 300 dummy files. Then remove the dummy files and merge this pull request.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
