### PR TITLE
[Merged by Bors] - Bugfix Polyrith.lean

### DIFF
--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -422,7 +422,7 @@ elab_rules : tactic
   | `(tactic| polyrith%$tk $[only%$onlyTk]? $[[$hyps,*]]?) => do
     let hyps ← hyps.map (·.getElems) |>.getD #[] |>.mapM (elabTerm · none)
     let traceMe ← Lean.isTracingEnabledFor `Meta.Tactic.polyrith
-    match ← polyrith (← getMainGoal) tk.isNone hyps traceMe with
+    match ← polyrith (← getMainGoal) onlyTk.isNone hyps traceMe with
     | .ok stx =>
       replaceMainGoal []
       if !traceMe then Lean.Meta.Tactic.TryThis.addSuggestion tk stx


### PR DESCRIPTION
Change tk to onlyTk cause we want to check if the only keyword has been used.
Currently the only keyword will be ignored cause
it isn't used anywhere. tk.isNone will always be None.

Reopened https://github.com/leanprover-community/mathlib4/pull/9069.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
