### PR TITLE
[Merged by Bors] - chore: Move monoid with zero instances on pi types

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -242,6 +242,7 @@ import Mathlib.Algebra.GroupWithZero.Hom
 import Mathlib.Algebra.GroupWithZero.InjSurj
 import Mathlib.Algebra.GroupWithZero.NeZero
 import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
+import Mathlib.Algebra.GroupWithZero.Pi
 import Mathlib.Algebra.GroupWithZero.Power
 import Mathlib.Algebra.GroupWithZero.Semiconj
 import Mathlib.Algebra.GroupWithZero.Units.Basic

--- a/Mathlib/Algebra/Group/Hom/End.lean
+++ b/Mathlib/Algebra/Group/Hom/End.lean
@@ -40,7 +40,6 @@ lemma natCast_apply [AddCommMonoid M] (n : ℕ) (m : M) : (↑n : AddMonoid.End 
 @[simp] lemma ofNat_apply [AddCommMonoid M] (n : ℕ) [n.AtLeastTwo] (m : M) :
     (no_index (OfNat.ofNat n : AddMonoid.End M)) m = n • m := rfl
 
-
 instance instSemiring [AddCommMonoid M] : Semiring (AddMonoid.End M) :=
   { AddMonoid.End.monoid M, AddMonoidHom.addCommMonoid, AddMonoid.End.instAddMonoidWithOne M with
     zero_mul := fun _ => AddMonoidHom.ext fun _ => rfl,

--- a/Mathlib/Algebra/Group/Hom/End.lean
+++ b/Mathlib/Algebra/Group/Hom/End.lean
@@ -24,20 +24,37 @@ universe uM uN uP uQ
 
 variable {M : Type uM} {N : Type uN} {P : Type uP} {Q : Type uQ}
 
+namespace AddMonoid.End
 
-instance AddMonoid.End.instSemiring [AddCommMonoid M] : Semiring (AddMonoid.End M) :=
+instance instAddMonoidWithOne (M) [AddCommMonoid M] : AddMonoidWithOne (AddMonoid.End M) where
+  natCast n := n • (1 : AddMonoid.End M)
+  natCast_zero := AddMonoid.nsmul_zero _
+  natCast_succ n := AddMonoid.nsmul_succ n 1
+
+/-- See also `AddMonoid.End.natCast_def`. -/
+@[simp]
+lemma natCast_apply [AddCommMonoid M] (n : ℕ) (m : M) : (↑n : AddMonoid.End M) m = n • m := rfl
+#align add_monoid.End.nat_cast_apply AddMonoid.End.natCast_apply
+
+-- See note [no_index around OfNat.ofNat]
+@[simp] lemma ofNat_apply [AddCommMonoid M] (n : ℕ) [n.AtLeastTwo] (m : M) :
+    (no_index (OfNat.ofNat n : AddMonoid.End M)) m = n • m := rfl
+
+
+instance instSemiring [AddCommMonoid M] : Semiring (AddMonoid.End M) :=
   { AddMonoid.End.monoid M, AddMonoidHom.addCommMonoid, AddMonoid.End.instAddMonoidWithOne M with
     zero_mul := fun _ => AddMonoidHom.ext fun _ => rfl,
     mul_zero := fun _ => AddMonoidHom.ext fun _ => AddMonoidHom.map_zero _,
     left_distrib := fun _ _ _ => AddMonoidHom.ext fun _ => AddMonoidHom.map_add _ _ _,
     right_distrib := fun _ _ _ => AddMonoidHom.ext fun _ => rfl }
 
-instance AddMonoid.End.instRing [AddCommGroup M] : Ring (AddMonoid.End M) :=
+instance instRing [AddCommGroup M] : Ring (AddMonoid.End M) :=
   { AddMonoid.End.instSemiring, AddMonoid.End.instAddCommGroup with
     intCast := fun z => z • (1 : AddMonoid.End M),
     intCast_ofNat := natCast_zsmul _,
     intCast_negSucc := negSucc_zsmul _ }
 
+end AddMonoid.End
 
 /-!
 ### Miscellaneous definitions

--- a/Mathlib/Algebra/Group/Hom/Instances.lean
+++ b/Mathlib/Algebra/Group/Hom/Instances.lean
@@ -6,7 +6,6 @@ Authors: Patrick Massot, Kevin Buzzard, Scott Morrison, Johan Commelin, Chris Hu
 -/
 import Mathlib.Algebra.Group.Hom.Basic
 import Mathlib.Algebra.GroupPower.Basic
-import Mathlib.Data.Nat.Cast.Defs
 
 #align_import algebra.hom.group_instances from "leanprover-community/mathlib"@"2ed7e4aec72395b6a7c3ac4ac7873a7a43ead17c"
 
@@ -23,6 +22,7 @@ operations.
 Finally, we provide the `Ring` structure on `AddMonoid.End`.
 -/
 
+assert_not_exists AddMonoidWithOne
 
 universe uM uN uP uQ
 
@@ -76,31 +76,12 @@ instance MonoidHom.commGroup {M G} [MulOneClass M] [CommGroup G] : CommGroup (M 
 instance AddMonoid.End.instAddCommMonoid [AddCommMonoid M] : AddCommMonoid (AddMonoid.End M) :=
   AddMonoidHom.addCommMonoid
 
-instance AddMonoid.End.instAddMonoidWithOne (M) [AddCommMonoid M] :
-    AddMonoidWithOne (AddMonoid.End M) :=
-  { natCast := fun n => n • (1 : AddMonoid.End M),
-    natCast_zero := AddMonoid.nsmul_zero _,
-    natCast_succ := fun n => AddMonoid.nsmul_succ n 1 }
-
-/-- See also `AddMonoid.End.natCast_def`. -/
-@[simp]
-theorem AddMonoid.End.natCast_apply [AddCommMonoid M] (n : ℕ) (m : M) :
-    (↑n : AddMonoid.End M) m = n • m :=
-  rfl
-#align add_monoid.End.nat_cast_apply AddMonoid.End.natCast_apply
-
 @[simp]
 theorem AddMonoid.End.zero_apply [AddCommMonoid M] (m : M) : (0 : AddMonoid.End M) m = 0 :=
   rfl
 
 -- Note: `@[simp]` omitted because `(1 : AddMonoid.End M) = id` by `AddMonoid.coe_one`
 theorem AddMonoid.End.one_apply [AddCommMonoid M] (m : M) : (1 : AddMonoid.End M) m = m :=
-  rfl
-
--- See note [no_index around OfNat.ofNat]
-@[simp]
-theorem AddMonoid.End.ofNat_apply [AddCommMonoid M] (n : ℕ) [n.AtLeastTwo] (m : M) :
-    (no_index (OfNat.ofNat n : AddMonoid.End M)) m = n • m :=
   rfl
 
 instance AddMonoid.End.instAddCommGroup [AddCommGroup M] : AddCommGroup (AddMonoid.End M) :=

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 -/
 import Mathlib.Algebra.Group.Hom.Instances
-import Mathlib.Data.Int.Cast.Defs
 import Mathlib.Data.Set.Function
 import Mathlib.Logic.Pairwise
 
@@ -16,6 +15,10 @@ import Mathlib.Logic.Pairwise
 This file proves lemmas about the instances defined in `Algebra.Group.Pi.Basic` that require more
 imports.
 -/
+
+assert_not_exists AddMonoidWithOne
+-- TODO (after #11855)
+-- assert_not_exists MulZeroClass
 
 universe u v w
 
@@ -34,49 +37,6 @@ theorem Set.preimage_one {α β : Type*} [One β] (s : Set β) [Decidable ((1 : 
   Set.preimage_const 1 s
 #align set.preimage_one Set.preimage_one
 #align set.preimage_zero Set.preimage_zero
-
-namespace Pi
-
-instance addMonoidWithOne [∀ i, AddMonoidWithOne <| f i] : AddMonoidWithOne (∀ i : I, f i) :=
-  { addMonoid with
-    natCast := fun n _ => n
-    natCast_zero := funext fun _ => AddMonoidWithOne.natCast_zero
-    natCast_succ := fun n => funext fun _ => AddMonoidWithOne.natCast_succ n
-  }
-
-instance addGroupWithOne [∀ i, AddGroupWithOne <| f i] : AddGroupWithOne (∀ i : I, f i) :=
-  { addGroup, addMonoidWithOne with
-    intCast := fun z _ => z
-    intCast_ofNat := fun n => funext fun _ => AddGroupWithOne.intCast_ofNat n
-    intCast_negSucc := fun n => funext fun _ => AddGroupWithOne.intCast_negSucc n
-  }
-
-instance mulZeroClass [∀ i, MulZeroClass <| f i] : MulZeroClass (∀ i : I, f i) :=
-  { zero := (0 : ∀ i, f i)
-    mul := (· * ·)
-    --pi_instance
-    zero_mul := by intros; ext; exact zero_mul _
-    mul_zero := by intros; ext; exact mul_zero _
-}
-#align pi.mul_zero_class Pi.mulZeroClass
-
-instance mulZeroOneClass [∀ i, MulZeroOneClass <| f i] : MulZeroOneClass (∀ i : I, f i) :=
-  { mulZeroClass, mulOneClass with }
-#align pi.mul_zero_one_class Pi.mulZeroOneClass
-
-instance monoidWithZero [∀ i, MonoidWithZero <| f i] : MonoidWithZero (∀ i : I, f i) :=
-  { monoid, mulZeroClass with }
-#align pi.monoid_with_zero Pi.monoidWithZero
-
-instance commMonoidWithZero [∀ i, CommMonoidWithZero <| f i] : CommMonoidWithZero (∀ i : I, f i) :=
-  { monoidWithZero, commMonoid with }
-#align pi.comm_monoid_with_zero Pi.commMonoidWithZero
-
-instance semigroupWithZero [∀ i, SemigroupWithZero <| f i] : SemigroupWithZero (∀ i : I, f i) :=
-  { semigroup, mulZeroClass with }
-#align pi.semigroup_with_zero Pi.semigroupWithZero
-
-end Pi
 
 namespace MulHom
 
@@ -305,17 +265,6 @@ theorem MonoidHom.single_apply [∀ i, MulOneClass <| f i] (i : I) (x : f i) :
 #align monoid_hom.single_apply MonoidHom.single_apply
 #align add_monoid_hom.single_apply AddMonoidHom.single_apply
 
-/-- The multiplicative homomorphism including a single `MulZeroClass`
-into a dependent family of `MulZeroClass`es, as functions supported at a point.
-
-This is the `MulHom` version of `Pi.single`. -/
-@[simps]
-def MulHom.single [∀ i, MulZeroClass <| f i] (i : I) : f i →ₙ* ∀ i, f i where
-  toFun := Pi.single i
-  map_mul' := Pi.single_op₂ (fun _ => (· * ·)) (fun _ => zero_mul _) _
-#align mul_hom.single MulHom.single
-#align mul_hom.single_apply MulHom.single_apply
-
 variable {f}
 
 @[to_additive]
@@ -352,31 +301,6 @@ theorem Pi.single_div [∀ i, Group <| f i] (i : I) (x y : f i) :
   (MonoidHom.single f i).map_div x y
 #align pi.single_div Pi.single_div
 #align pi.single_sub Pi.single_sub
-
-theorem Pi.single_mul [∀ i, MulZeroClass <| f i] (i : I) (x y : f i) :
-    single i (x * y) = single i x * single i y :=
-  (MulHom.single f i).map_mul x y
-#align pi.single_mul Pi.single_mul
-
-theorem Pi.single_mul_left_apply [∀ i, MulZeroClass <| f i] (a : f i) :
-    Pi.single i (a * x i) j = Pi.single i a j * x j :=
-  (Pi.apply_single (fun i => (· * x i)) (fun _ => zero_mul _) _ _ _).symm
-#align pi.single_mul_left_apply Pi.single_mul_left_apply
-
-theorem Pi.single_mul_right_apply [∀ i, MulZeroClass <| f i] (a : f i) :
-    Pi.single i (x i * a) j = x j * Pi.single i a j :=
-  (Pi.apply_single (fun i => (· * ·) (x i)) (fun _ => mul_zero _) _ _ _).symm
-#align pi.single_mul_right_apply Pi.single_mul_right_apply
-
-theorem Pi.single_mul_left [∀ i, MulZeroClass <| f i] (a : f i) :
-    Pi.single i (a * x i) = Pi.single i a * x :=
-  funext fun _ => Pi.single_mul_left_apply _ _ _ _
-#align pi.single_mul_left Pi.single_mul_left
-
-theorem Pi.single_mul_right [∀ i, MulZeroClass <| f i] (a : f i) :
-    Pi.single i (x i * a) = x * Pi.single i a :=
-  funext fun _ => Pi.single_mul_right_apply _ _ _ _
-#align pi.single_mul_right Pi.single_mul_right
 
 section
 variable [∀ i, Mul <| f i]

--- a/Mathlib/Algebra/GroupWithZero/Pi.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pi.lean
@@ -34,14 +34,14 @@ into a dependent family of `MulZeroClass`es, as functions supported at a point.
 
 This is the `MulHom` version of `Pi.single`. -/
 @[simps]
-def singleMulHom (i : ι) : α i →ₙ* ∀ i, α i where
+def _root_.MulHom.single (i : ι) : α i →ₙ* ∀ i, α i where
   toFun := Pi.single i
   map_mul' := Pi.single_op₂ (fun _ ↦ (· * ·)) (fun _ ↦ zero_mul _) _
-#align mul_hom.single Pi.singleMulHom
-#align mul_hom.single_apply Pi.singleMulHom_apply
+#align mul_hom.single MulHom.single
+#align mul_hom.single_apply MulHom.single_apply
 
 lemma single_mul (i : ι) (x y : α i) : single i (x * y) = single i x * single i y :=
-  (singleMulHom _).map_mul _ _
+  (MulHom.single _).map_mul _ _
 #align pi.single_mul Pi.single_mul
 
 lemma single_mul_left_apply (i j : ι) (a : α i) (f : ∀ i, α i) :

--- a/Mathlib/Algebra/GroupWithZero/Pi.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pi.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2020 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.Algebra.GroupWithZero.Defs
+import Mathlib.Algebra.Group.Hom.Defs
+import Mathlib.Algebra.Group.Pi.Basic
+
+/-!
+# Pi instances for groups with zero
+
+This file defines monoid with zero, group with zero, and related structure instances for pi types.
+-/
+
+-- Porting note: All these instances used `refine_struct` and `pi_instance_derive_field`
+
+open Function Pi
+
+variable {ι : Type*} {α : ι → Type*}
+
+namespace Pi
+
+section MulZeroClass
+variable [∀ i, MulZeroClass (α i)] [DecidableEq ι] {i j : ι} {f : ∀ i, α i}
+
+instance mulZeroClass : MulZeroClass (∀ i, α i) where
+    zero_mul := by intros; ext; exact zero_mul _
+    mul_zero := by intros; ext; exact mul_zero _
+#align pi.mul_zero_class Pi.mulZeroClass
+
+/-- The multiplicative homomorphism including a single `MulZeroClass`
+into a dependent family of `MulZeroClass`es, as functions supported at a point.
+
+This is the `MulHom` version of `Pi.single`. -/
+@[simps]
+def singleMulHom (i : ι) : α i →ₙ* ∀ i, α i where
+  toFun := Pi.single i
+  map_mul' := Pi.single_op₂ (fun _ ↦ (· * ·)) (fun _ ↦ zero_mul _) _
+#align mul_hom.single Pi.singleMulHom
+#align mul_hom.single_apply Pi.singleMulHom_apply
+
+lemma single_mul (i : ι) (x y : α i) : single i (x * y) = single i x * single i y :=
+  (singleMulHom _).map_mul _ _
+#align pi.single_mul Pi.single_mul
+
+lemma single_mul_left_apply (i j : ι) (a : α i) (f : ∀ i, α i) :
+    single i (a * f i) j = single i a j * f j :=
+  (apply_single (fun i ↦ (· * f i)) (fun _ ↦ zero_mul _) _ _ _).symm
+#align pi.single_mul_left_apply Pi.single_mul_left_apply
+
+lemma single_mul_right_apply (i j : ι) (f : ∀ i, α i) (a : α i) :
+    single i (f i * a) j = f j * single i a j :=
+  (apply_single (f · * ·) (fun _ ↦ mul_zero _) _ _ _).symm
+#align pi.single_mul_right_apply Pi.single_mul_right_apply
+
+lemma single_mul_left (a : α i) : single i (a * f i) = single i a * f :=
+  funext fun _ ↦ single_mul_left_apply _ _ _ _
+#align pi.single_mul_left Pi.single_mul_left
+
+lemma single_mul_right (a : α i) : single i (f i * a) = f * single i a :=
+  funext fun _ ↦ single_mul_right_apply _ _ _ _
+#align pi.single_mul_right Pi.single_mul_right
+
+end MulZeroClass
+
+instance mulZeroOneClass [∀ i, MulZeroOneClass (α i)] : MulZeroOneClass (∀ i, α i) where
+  __ := mulZeroClass
+  __ := mulOneClass
+#align pi.mul_zero_one_class Pi.mulZeroOneClass
+
+instance monoidWithZero [∀ i, MonoidWithZero (α i)] : MonoidWithZero (∀ i, α i) where
+  __ := monoid
+  __ := mulZeroClass
+#align pi.monoid_with_zero Pi.monoidWithZero
+
+instance commMonoidWithZero [∀ i, CommMonoidWithZero (α i)] : CommMonoidWithZero (∀ i, α i) where
+  __ := monoidWithZero
+  __ := commMonoid
+#align pi.comm_monoid_with_zero Pi.commMonoidWithZero
+
+instance semigroupWithZero [∀ i, SemigroupWithZero (α i)] : SemigroupWithZero (∀ i, α i) where
+  __ := semigroup
+  __ := mulZeroClass
+#align pi.semigroup_with_zero Pi.semigroupWithZero
+
+end Pi

--- a/Mathlib/Algebra/GroupWithZero/Pi.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pi.lean
@@ -25,8 +25,8 @@ section MulZeroClass
 variable [∀ i, MulZeroClass (α i)] [DecidableEq ι] {i j : ι} {f : ∀ i, α i}
 
 instance mulZeroClass : MulZeroClass (∀ i, α i) where
-    zero_mul := by intros; ext; exact zero_mul _
-    mul_zero := by intros; ext; exact mul_zero _
+  zero_mul := by intros; ext; exact zero_mul _
+  mul_zero := by intros; ext; exact mul_zero _
 #align pi.mul_zero_class Pi.mulZeroClass
 
 /-- The multiplicative homomorphism including a single `MulZeroClass`

--- a/Mathlib/Algebra/Ring/Pi.lean
+++ b/Mathlib/Algebra/Ring/Pi.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 -/
 import Mathlib.Algebra.Group.Pi.Lemmas
+import Mathlib.Algebra.GroupWithZero.Pi
 import Mathlib.Algebra.Ring.CompTypeclasses
 import Mathlib.Algebra.Ring.Hom.Defs
 
@@ -41,6 +42,18 @@ instance distrib [∀ i, Distrib <| f i] : Distrib (∀ i : I, f i) :=
 instance hasDistribNeg [∀ i, Mul (f i)] [∀ i, HasDistribNeg (f i)] : HasDistribNeg (∀ i, f i) where
   neg_mul _ _ := funext fun _ ↦ neg_mul _ _
   mul_neg _ _ := funext fun _ ↦ mul_neg _ _
+
+instance addMonoidWithOne [∀ i, AddMonoidWithOne (f i)] : AddMonoidWithOne (∀ i, f i) where
+  natCast n _ := n
+  natCast_zero := funext fun _ ↦ AddMonoidWithOne.natCast_zero
+  natCast_succ n := funext fun _ ↦ AddMonoidWithOne.natCast_succ n
+
+instance addGroupWithOne [∀ i, AddGroupWithOne (f i)] : AddGroupWithOne (∀ i, f i) where
+  __ := addGroup
+  __ := addMonoidWithOne
+  intCast n _ := n
+  intCast_ofNat n := funext fun _ ↦ AddGroupWithOne.intCast_ofNat n
+  intCast_negSucc n := funext fun _ ↦ AddGroupWithOne.intCast_negSucc n
 
 instance nonUnitalNonAssocSemiring [∀ i, NonUnitalNonAssocSemiring <| f i] :
     NonUnitalNonAssocSemiring (∀ i : I, f i) :=

--- a/Mathlib/Probability/Moments.lean
+++ b/Mathlib/Probability/Moments.lean
@@ -61,7 +61,7 @@ def centralMoment (X : Ω → ℝ) (p : ℕ) (μ : Measure Ω) : ℝ := by
 @[simp]
 theorem moment_zero (hp : p ≠ 0) : moment 0 p μ = 0 := by
   simp only [moment, hp, zero_pow, Ne, not_false_iff, Pi.zero_apply, integral_const,
-    smul_eq_mul, mul_zero]
+    smul_eq_mul, mul_zero, integral_zero]
 #align probability_theory.moment_zero ProbabilityTheory.moment_zero
 
 @[simp]


### PR DESCRIPTION
Move everything that can't be additivised out of `Algebra.Group.Pi.Lemmas`:
* `MulZeroClass`, `MulZeroOneClass`, etc... instances go to a new `Algebra.GroupWithZero.Pi` file. I credit Eric W. for https://github.com/leanprover-community/mathlib/pull/4766.
* `AddMonoidWithOne`, `AddGroupWithOne` instances go to `Algebra.Ring.Pi`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
