### PR TITLE
[Merged by Bors] - fix: support more parsers in `#help`

### DIFF
--- a/Mathlib/Tactic/HelpCmd.lean
+++ b/Mathlib/Tactic/HelpCmd.lean
@@ -121,17 +121,36 @@ elab_rules : command
 that don't start with a string constant. -/
 partial def getHeadTk (e : Expr) : Option String :=
   match e.getAppFnArgs with
-  | (``ParserDescr.node, #[_, _, p]) => getHeadTk p
-  | (``ParserDescr.unary, #[.app _ (.lit (.strVal "withPosition")), p]) => getHeadTk p
-  | (``ParserDescr.unary, #[.app _ (.lit (.strVal "atomic")), p]) => getHeadTk p
-  | (``ParserDescr.binary, #[.app _ (.lit (.strVal "andthen")), p, _]) => getHeadTk p
-  | (``ParserDescr.nonReservedSymbol, #[.lit (.strVal tk), _]) => some tk
-  | (``ParserDescr.symbol, #[.lit (.strVal tk)]) => some tk
-  | (``Parser.withAntiquot, #[_, p]) => getHeadTk p
-  | (``Parser.leadingNode, #[_, _, p]) => getHeadTk p
-  | (``HAndThen.hAndThen, #[_, _, _, _, p, _]) => getHeadTk p
-  | (``Parser.nonReservedSymbol, #[.lit (.strVal tk), _]) => some tk
-  | (``Parser.symbol, #[.lit (.strVal tk)]) => some tk
+  | (``ParserDescr.node, #[_, _, p])
+  | (``ParserDescr.trailingNode, #[_, _, _, p])
+  | (``ParserDescr.unary, #[.app _ (.lit (.strVal "withPosition")), p])
+  | (``ParserDescr.unary, #[.app _ (.lit (.strVal "atomic")), p])
+  | (``ParserDescr.unary, #[.app _ (.lit (.strVal "ppRealGroup")), p])
+  | (``ParserDescr.unary, #[.app _ (.lit (.strVal "ppRealFill")), p])
+  | (``Parser.ppRealFill, #[p])
+  | (``Parser.withAntiquot, #[_, p])
+  | (``Parser.leadingNode, #[_, _, p])
+  | (``Parser.trailingNode, #[_, _, _, p])
+  | (``Parser.group, #[p])
+  | (``Parser.withCache, #[_, p])
+  | (``Parser.withResetCache, #[p])
+  | (``Parser.withPosition, #[p])
+  | (``Parser.withOpen, #[p])
+  | (``Parser.withPositionAfterLinebreak, #[p])
+  | (``Parser.suppressInsideQuot, #[p])
+  | (``Parser.ppRealGroup, #[p])
+  | (``Parser.ppIndent, #[p])
+  | (``Parser.ppDedent, #[p])
+    => getHeadTk p
+  | (``ParserDescr.binary, #[.app _ (.lit (.strVal "andthen")), p, q])
+  | (``HAndThen.hAndThen, #[_, _, _, _, p, .lam _ _ q _])
+    => getHeadTk p <|> getHeadTk q
+  | (``ParserDescr.nonReservedSymbol, #[.lit (.strVal tk), _])
+  | (``ParserDescr.symbol, #[.lit (.strVal tk)])
+  | (``Parser.nonReservedSymbol, #[.lit (.strVal tk), _])
+  | (``Parser.symbol, #[.lit (.strVal tk)])
+  | (``Parser.unicodeSymbol, #[.lit (.strVal tk), _])
+    => pure tk
   | _ => none
 
 /--

--- a/Mathlib/Tactic/SlimCheck.lean
+++ b/Mathlib/Tactic/SlimCheck.lean
@@ -177,22 +177,23 @@ elab_rules : tactic | `(tactic| slim_check $[$cfg]?) => withMainContext do
       || (← isTracingEnabledFor `slim_check.shrink.candidates) }
   let inst ← try
     synthInstance (← mkAppM ``Testable #[tgt'])
-  catch _ => throwError "Failed to create a `testable` instance for `{tgt}`.
-What to do:
-1. make sure that the types you are using have `SlimCheck.SampleableExt` instances
-   (you can use `#sample my_type` if you are unsure);
-2. make sure that the relations and predicates that your proposition use are decidable;
-3. make sure that instances of `SlimCheck.Testable` exist that, when combined,
-   apply to your decorated proposition:
-```
-{tgt'}
-```
-
-Use `set_option trace.Meta.synthInstance true` to understand what instances are missing.
-
-Try this:
-set_option trace.Meta.synthInstance true
-#synth SlimCheck.Testable ({tgt'})"
+  catch _ => throwError "\
+      Failed to create a `testable` instance for `{tgt}`.\
+    \nWhat to do:\
+    \n1. make sure that the types you are using have `SlimCheck.SampleableExt` instances\
+    \n  (you can use `#sample my_type` if you are unsure);\
+    \n2. make sure that the relations and predicates that your proposition use are decidable;\
+    \n3. make sure that instances of `SlimCheck.Testable` exist that, when combined,\
+    \n  apply to your decorated proposition:\
+    \n```\
+    \n{tgt'}\
+    \n```\
+    \n\
+    \nUse `set_option trace.Meta.synthInstance true` to understand what instances are missing.\
+    \n\
+    \nTry this:\
+    \nset_option trace.Meta.synthInstance true\
+    \n#synth SlimCheck.Testable ({tgt'})"
   let e ← mkAppOptM ``Testable.check #[tgt, toExpr cfg, tgt', inst]
   trace[slim_check.decoration] "[testable decoration]\n  {tgt'}"
   -- Porting note: I have not ported support for `trace.slim_check.instance`.

--- a/test/help_cmd.lean
+++ b/test/help_cmd.lean
@@ -2,3 +2,26 @@ import Mathlib.Tactic.HelpCmd
 #guard_msgs(error, drop info) in
 #help tactic
 def foo := 1
+
+/--
+info: syntax "#check"... [Lean.Parser.Command.check]
+
+syntax "#check_failure"... [Lean.Parser.Command.check_failure]
+
+syntax "#check_simp"... [Lean.Parser.checkSimp]
+  `#check_simp t ~> r` checks `simp` reduces `t` to `r`.
+
+syntax "#check_simp"... [Lean.Parser.checkSimpFailure]
+  `#check_simp t !~>` checks `simp` fails on reducing `t`.
+
+syntax "#check_tactic"... [Lean.Parser.checkTactic]
+  `#check_tactic t ~> r by commands` runs the tactic sequence `commands`
+  on a goal with `t` and sees if the resulting expression has reduced it
+  to `r`.
+
+syntax "#check_tactic_failure"... [Lean.Parser.checkTacticFailure]
+  `#check_tactic_failure t by tac` runs the tactic `tac`
+  on a goal with `t` and verifies it fails.
+-/
+#guard_msgs in
+#help command "#chec"


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/missing.20doc.20of.20.60.23check_failure.60/near/434466058), the `#help` command is out of date with respect to the parsers that can be obscuring the search for the "first token", used to power the search-by-token-prefix form of the command `#help tactic "measur"`. The list below has been tested against everything in lean, and the only things that fail to find a first token now are those that actually don't have a token like the ident parser.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
