### PR TITLE
[Merged by Bors] - fix (LinearAlgebra/TensorProduct/Basic) : minor docstring typo

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -1198,7 +1198,7 @@ def lTensorHom : (N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] M ⊗[R] P where
     simp only [compr₂_apply, mk_apply, tmul_smul, smul_apply, lTensor_tmul]
 #align linear_map.ltensor_hom LinearMap.lTensorHom
 
-/-- `rTensorHom M` is the natural linear map that sends a linear map `f : N →ₗ P` to `M ⊗ f`. -/
+/-- `rTensorHom M` is the natural linear map that sends a linear map `f : N →ₗ P` to `f ⊗ M`. -/
 def rTensorHom : (N →ₗ[R] P) →ₗ[R] N ⊗[R] M →ₗ[R] P ⊗[R] M where
   toFun f := f.rTensor M
   map_add' f g := by


### PR DESCRIPTION
Switch `M ⊗ f` to `f ⊗ M` in `rTensorHom M` docstring.

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
