### PR TITLE
[Merged by Bors] - chore(Vector): migrate `List.nthLe` → `List.get`

### DIFF
--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -54,7 +54,6 @@ open Nat
 
 /-- The first element of a vector with length at least `1`. -/
 def head : Vector α (Nat.succ n) → α
-  | ⟨[], h⟩ => by contradiction
   | ⟨a :: _, _⟩ => a
 #align vector.head Vector.head
 
@@ -86,10 +85,9 @@ def toList (v : Vector α n) : List α :=
   v.1
 #align vector.to_list Vector.toList
 
--- Porting note: align to `List` API
 /-- nth element of a vector, indexed by a `Fin` type. -/
-def get : ∀ _ : Vector α n, Fin n → α
-  | ⟨l, h⟩, i => l.nthLe i.1 (by rw [h]; exact i.2)
+def get (l : Vector α n) (i : Fin n) : α :=
+  l.1.get <| i.cast l.2.symm
 #align vector.nth Vector.get
 
 /-- Appending a vector to another. -/

--- a/Mathlib/Data/Vector.lean
+++ b/Mathlib/Data/Vector.lean
@@ -6,7 +6,6 @@ Authors: Leonardo de Moura
 import Mathlib.Mathport.Rename
 import Std.Data.List.Basic
 import Std.Data.List.Lemmas
-import Mathlib.Init.Data.List.Basic
 import Mathlib.Init.Data.List.Lemmas
 import Mathlib.Algebra.Order.Ring.Nat
 

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -120,12 +120,6 @@ theorem get_eq_get (v : Vector α n) (i : Fin n) :
   rfl
 #align vector.nth_eq_nth_le Vector.get_eq_getₓ
 
--- Porting note: `nthLe` deprecated for `get`
-@[deprecated get_eq_get]
-theorem nth_eq_nthLe :
-    ∀ (v : Vector α n) (i), get v i = v.toList.nthLe i.1 (by rw [toList_length]; exact i.2)
-  | ⟨_, _⟩, _ => rfl
-
 @[simp]
 theorem get_replicate (a : α) (i : Fin n) : (Vector.replicate n a).get i = a := by
   apply List.get_replicate

--- a/Mathlib/Data/Vector/Zip.lean
+++ b/Mathlib/Data/Vector/Zip.lean
@@ -33,8 +33,7 @@ theorem zipWith_toList (x : Vector α n) (y : Vector β n) :
 theorem zipWith_get (x : Vector α n) (y : Vector β n) (i) :
     (Vector.zipWith f x y).get i = f (x.get i) (y.get i) := by
   dsimp only [Vector.zipWith, Vector.get]
-  cases x; cases y
-  simp only [List.nthLe_zipWith]
+  simp only [List.get_zipWith, Fin.cast]
 #align vector.zip_with_nth Vector.zipWith_get
 
 @[simp]


### PR DESCRIPTION
This drops the deprecated `nth_eq_nthLe` lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
