### PR TITLE
[Merged by Bors] - feat: `try_this` macro + use in abel/ring

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3769,6 +3769,7 @@ import Mathlib.Tactic.ToAdditive
 import Mathlib.Tactic.ToExpr
 import Mathlib.Tactic.ToLevel
 import Mathlib.Tactic.Trace
+import Mathlib.Tactic.TryThis
 import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.TypeStar
 import Mathlib.Tactic.UnsetOption

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -187,6 +187,7 @@ import Mathlib.Tactic.ToAdditive
 import Mathlib.Tactic.ToExpr
 import Mathlib.Tactic.ToLevel
 import Mathlib.Tactic.Trace
+import Mathlib.Tactic.TryThis
 import Mathlib.Tactic.TypeCheck
 import Mathlib.Tactic.TypeStar
 import Mathlib.Tactic.UnsetOption

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Scott Morrison
 -/
 import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.TryThis
 import Mathlib.Util.AtomM
 
 /-!
@@ -544,9 +545,9 @@ example [AddCommGroup α] (a : α) : (3 : ℤ) • a = a + (2 : ℤ) • a := by
 ```
 -/
 macro (name := abel) "abel" : tactic =>
-  `(tactic| first | abel1 | abel_nf; trace "Try this: abel_nf")
+  `(tactic| first | abel1 | try_this abel_nf)
 @[inherit_doc abel] macro "abel!" : tactic =>
-  `(tactic| first | abel1! | abel_nf!; trace "Try this: abel_nf!")
+  `(tactic| first | abel1! | try_this abel_nf!)
 
 /--
 The tactic `abel` evaluates expressions in abelian groups.
@@ -555,6 +556,6 @@ This is the conv tactic version, which rewrites a target which is an abel equali
 See also the `abel` tactic.
 -/
 macro (name := abelConv) "abel" : conv =>
-  `(conv| first | discharge => abel1 | abel_nf; tactic => trace "Try this: abel_nf")
+  `(conv| first | discharge => abel1 | try_this abel_nf)
 @[inherit_doc abelConv] macro "abel!" : conv =>
-  `(conv| first | discharge => abel1! | abel_nf!; tactic => trace "Try this: abel_nf!")
+  `(conv| first | discharge => abel1! | try_this abel_nf!)

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Anne Baanen
 -/
 import Mathlib.Tactic.Ring.Basic
+import Mathlib.Tactic.TryThis
 import Mathlib.Tactic.Conv
 import Mathlib.Util.Qq
 
@@ -253,9 +254,9 @@ example (x y : ℕ) : x + id y = y + id x := by ring!
 ```
 -/
 macro (name := ring) "ring" : tactic =>
-  `(tactic| first | ring1 | ring_nf; trace "Try this: ring_nf")
+  `(tactic| first | ring1 | try_this ring_nf)
 @[inherit_doc ring] macro "ring!" : tactic =>
-  `(tactic| first | ring1! | ring_nf!; trace "Try this: ring_nf!")
+  `(tactic| first | ring1! | try_this ring_nf!)
 
 /--
 The tactic `ring` evaluates expressions in *commutative* (semi)rings.
@@ -264,6 +265,6 @@ This is the conv tactic version, which rewrites a target which is a ring equalit
 See also the `ring` tactic.
 -/
 macro (name := ringConv) "ring" : conv =>
-  `(conv| first | discharge => ring1 | ring_nf; tactic => trace "Try this: ring_nf")
+  `(conv| first | discharge => ring1 | try_this ring_nf)
 @[inherit_doc ringConv] macro "ring!" : conv =>
-  `(conv| first | discharge => ring1! | ring_nf!; tactic => trace "Try this: ring_nf!")
+  `(conv| first | discharge => ring1! | try_this ring_nf!)

--- a/Mathlib/Tactic/TryThis.lean
+++ b/Mathlib/Tactic/TryThis.lean
@@ -18,10 +18,10 @@ open Lean
 
 /-- Produces the text `Try this: <tac>` with the given tactic, and then executes it. -/
 elab tk:"try_this" tac:tactic : tactic => do
-  Meta.Tactic.TryThis.addSuggestion tk tac (origSpan? := ← getRef)
   Elab.Tactic.evalTactic tac
+  Meta.Tactic.TryThis.addSuggestion tk tac (origSpan? := ← getRef)
 
 /-- Produces the text `Try this: <tac>` with the given conv tactic, and then executes it. -/
 elab tk:"try_this" tac:conv : conv => do
-  Meta.Tactic.TryThis.addSuggestion tk tac (origSpan? := ← getRef)
   Elab.Tactic.evalTactic tac
+  Meta.Tactic.TryThis.addSuggestion tk tac (origSpan? := ← getRef)

--- a/Mathlib/Tactic/TryThis.lean
+++ b/Mathlib/Tactic/TryThis.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Lean
+
+/-!
+# 'Try this' tactic macro
+
+This is a convenient shorthand intended for macro authors to be able to generate "Try this"
+recommendations. (It is not the main implementation of 'Try this',
+which is implemented in Lean core, see `Lean.Meta.Tactic.TryThis`.)
+-/
+
+namespace Mathlib.Tactic
+open Lean
+
+/-- Produces the text `Try this: <tac>` with the given tactic, and then executes it. -/
+elab tk:"try_this" tac:tactic : tactic => do
+  Meta.Tactic.TryThis.addSuggestion tk tac (origSpan? := ← getRef)
+  Elab.Tactic.evalTactic tac
+
+/-- Produces the text `Try this: <tac>` with the given conv tactic, and then executes it. -/
+elab tk:"try_this" tac:conv : conv => do
+  Meta.Tactic.TryThis.addSuggestion tk tac (origSpan? := ← getRef)
+  Elab.Tactic.evalTactic tac

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -138,6 +138,7 @@
   "Mathlib.Tactic.ToExpr",
   "Mathlib.Tactic.ToLevel",
   "Mathlib.Tactic.Trace",
+  "Mathlib.Tactic.TryThis",
   "Mathlib.Tactic.TypeCheck",
   "Mathlib.Tactic.TypeStar",
   "Mathlib.Tactic.Use",


### PR DESCRIPTION
This adds a simple elab `try_this tac` which can be used to suggest `tac` from a macro. This is useful for the backup suggestions made by `ring` and `abel`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
