### PR TITLE
[Merged by Bors] - feat: add 3 lemmas linking iSup and symmDiff

### DIFF
--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -479,11 +479,8 @@ lemma iSup_symmDiff_iSup_le {α : Type*} {ι : Sort*} [CompleteBooleanAlgebra α
 lemma biSup_symmDiff_biSup_le {α : Type*} {ι : Sort*} [CompleteBooleanAlgebra α] {p : ι → Prop}
     {f g : (i : ι) → p i → α} :
     symmDiff (⨆ i, ⨆ (h : p i), f i h) (⨆ i, ⨆ (h : p i), g i h) ≤
-    ⨆ i, ⨆ (h : p i), (symmDiff (f i h) (g i h)) := by
-  calc
-    symmDiff (⨆ i, ⨆ (h : p i), f i h) (⨆ i, ⨆ (h : p i), g i h)
-      ≤ ⨆ i, symmDiff (⨆ (h : p i), f i h) (⨆ (h : p i), g i h) := iSup_symmDiff_iSup_le
-    _ ≤ ⨆ i, ⨆ (h : p i), (symmDiff (f i h) (g i h)) := iSup_mono (fun i ↦ iSup_symmDiff_iSup_le)
+    ⨆ i, ⨆ (h : p i), (symmDiff (f i h) (g i h)) :=
+  le_trans iSup_symmDiff_iSup_le (iSup_mono (fun i ↦ iSup_symmDiff_iSup_le))
 
 end CompleteBooleanAlgebra
 

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -470,6 +470,21 @@ theorem compl_sSup' : (sSup s)ᶜ = sInf (HasCompl.compl '' s) :=
   compl_sSup.trans sInf_image.symm
 #align compl_Sup' compl_sSup'
 
+lemma iSup_symmDiff_iSup_le {α : Type*} {ι : Sort*} [CompleteBooleanAlgebra α] {f g : ι → α} :
+    symmDiff (⨆ i, f i) (⨆ i, g i) ≤ ⨆ i, (symmDiff (f i) (g i)) := by
+  simp_rw [symmDiff_le_iff, ← iSup_sup_eq]
+  exact ⟨iSup_mono (fun i ↦ sup_comm (α := α) .. ▸ le_symmDiff_sup ..),
+    iSup_mono fun i ↦ sup_comm (α := α) .. ▸ symmDiff_comm (α := α) .. ▸ le_symmDiff_sup ..⟩
+
+lemma biSup_symmDiff_biSup_le {α : Type*} {ι : Sort*} [CompleteBooleanAlgebra α] {p : ι → Prop}
+    {f g : (i : ι) → p i → α} :
+    symmDiff (⨆ i, ⨆ (h : p i), f i h) (⨆ i, ⨆ (h : p i), g i h) ≤
+    ⨆ i, ⨆ (h : p i), (symmDiff (f i h) (g i h)) := by
+  calc
+    symmDiff (⨆ i, ⨆ (h : p i), f i h) (⨆ i, ⨆ (h : p i), g i h)
+      ≤ ⨆ i, symmDiff (⨆ (h : p i), f i h) (⨆ (h : p i), g i h) := iSup_symmDiff_iSup_le
+    _ ≤ ⨆ i, ⨆ (h : p i), (symmDiff (f i h) (g i h)) := iSup_mono (fun i ↦ iSup_symmDiff_iSup_le)
+
 end CompleteBooleanAlgebra
 
 /--

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -480,7 +480,7 @@ lemma biSup_symmDiff_biSup_le {α : Type*} {ι : Sort*} [CompleteBooleanAlgebra 
     {f g : (i : ι) → p i → α} :
     symmDiff (⨆ i, ⨆ (h : p i), f i h) (⨆ i, ⨆ (h : p i), g i h) ≤
     ⨆ i, ⨆ (h : p i), (symmDiff (f i h) (g i h)) :=
-  le_trans iSup_symmDiff_iSup_le (iSup_mono (fun i ↦ iSup_symmDiff_iSup_le))
+  le_trans iSup_symmDiff_iSup_le (iSup_mono (fun _ ↦ iSup_symmDiff_iSup_le))
 
 end CompleteBooleanAlgebra
 

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -470,16 +470,20 @@ theorem compl_sSup' : (sSup s)ᶜ = sInf (HasCompl.compl '' s) :=
   compl_sSup.trans sInf_image.symm
 #align compl_Sup' compl_sSup'
 
-theorem iSup_symmDiff_iSup_le {α : Type*} {ι : Sort*} [CompleteBooleanAlgebra α] {f g : ι → α} :
-    symmDiff (⨆ i, f i) (⨆ i, g i) ≤ ⨆ i, (symmDiff (f i) (g i)) := by
+open scoped symmDiff in
+/-- The symmetric difference of two `iSup`s is less or esual to
+the `iSup` of the symmetric differences. -/
+theorem iSup_symmDiff_iSup_le {g : ι → α} :
+    (⨆ i, f i) ∆ (⨆ i, g i) ≤ ⨆ i, ((f i) ∆ (g i)) := by
   simp_rw [symmDiff_le_iff, ← iSup_sup_eq]
   exact ⟨iSup_mono (fun i ↦ sup_comm (α := α) .. ▸ le_symmDiff_sup ..),
     iSup_mono fun i ↦ sup_comm (α := α) .. ▸ symmDiff_comm (α := α) .. ▸ le_symmDiff_sup ..⟩
 
-theorem biSup_symmDiff_biSup_le {α : Type*} {ι : Sort*} [CompleteBooleanAlgebra α] {p : ι → Prop}
-    {f g : (i : ι) → p i → α} :
-    symmDiff (⨆ i, ⨆ (h : p i), f i h) (⨆ i, ⨆ (h : p i), g i h) ≤
-    ⨆ i, ⨆ (h : p i), (symmDiff (f i h) (g i h)) :=
+open scoped symmDiff in
+/-- A `biSup` version of `iSup_symmDiff_iSup_le`. -/
+theorem biSup_symmDiff_biSup_le {p : ι → Prop} {f g : (i : ι) → p i → α} :
+    (⨆ i, ⨆ (h : p i), f i h) ∆ (⨆ i, ⨆ (h : p i), g i h) ≤
+    ⨆ i, ⨆ (h : p i), ((f i h) ∆ (g i h)) :=
   le_trans iSup_symmDiff_iSup_le (iSup_mono (fun _ ↦ iSup_symmDiff_iSup_le))
 
 end CompleteBooleanAlgebra

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -470,13 +470,13 @@ theorem compl_sSup' : (sSup s)ᶜ = sInf (HasCompl.compl '' s) :=
   compl_sSup.trans sInf_image.symm
 #align compl_Sup' compl_sSup'
 
-lemma iSup_symmDiff_iSup_le {α : Type*} {ι : Sort*} [CompleteBooleanAlgebra α] {f g : ι → α} :
+theorem iSup_symmDiff_iSup_le {α : Type*} {ι : Sort*} [CompleteBooleanAlgebra α] {f g : ι → α} :
     symmDiff (⨆ i, f i) (⨆ i, g i) ≤ ⨆ i, (symmDiff (f i) (g i)) := by
   simp_rw [symmDiff_le_iff, ← iSup_sup_eq]
   exact ⟨iSup_mono (fun i ↦ sup_comm (α := α) .. ▸ le_symmDiff_sup ..),
     iSup_mono fun i ↦ sup_comm (α := α) .. ▸ symmDiff_comm (α := α) .. ▸ le_symmDiff_sup ..⟩
 
-lemma biSup_symmDiff_biSup_le {α : Type*} {ι : Sort*} [CompleteBooleanAlgebra α] {p : ι → Prop}
+theorem biSup_symmDiff_biSup_le {α : Type*} {ι : Sort*} [CompleteBooleanAlgebra α] {p : ι → Prop}
     {f g : (i : ι) → p i → α} :
     symmDiff (⨆ i, ⨆ (h : p i), f i h) (⨆ i, ⨆ (h : p i), g i h) ≤
     ⨆ i, ⨆ (h : p i), (symmDiff (f i h) (g i h)) :=

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -471,20 +471,18 @@ theorem compl_sSup' : (sSup s)ᶜ = sInf (HasCompl.compl '' s) :=
 #align compl_Sup' compl_sSup'
 
 open scoped symmDiff in
-/-- The symmetric difference of two `iSup`s is less or esual to
-the `iSup` of the symmetric differences. -/
-theorem iSup_symmDiff_iSup_le {g : ι → α} :
-    (⨆ i, f i) ∆ (⨆ i, g i) ≤ ⨆ i, ((f i) ∆ (g i)) := by
+/-- The symmetric difference of two `iSup`s is at most the `iSup` of the symmetric differences. -/
+theorem iSup_symmDiff_iSup_le {g : ι → α} : (⨆ i, f i) ∆ (⨆ i, g i) ≤ ⨆ i, ((f i) ∆ (g i)) := by
   simp_rw [symmDiff_le_iff, ← iSup_sup_eq]
-  exact ⟨iSup_mono (fun i ↦ sup_comm (α := α) .. ▸ le_symmDiff_sup ..),
-    iSup_mono fun i ↦ sup_comm (α := α) .. ▸ symmDiff_comm (α := α) .. ▸ le_symmDiff_sup ..⟩
+  exact ⟨iSup_mono fun i ↦ sup_comm (g i) _ ▸ le_symmDiff_sup_right ..,
+    iSup_mono fun i ↦ sup_comm (f i) _ ▸ symmDiff_comm (f i) _ ▸ le_symmDiff_sup_right ..⟩
 
 open scoped symmDiff in
 /-- A `biSup` version of `iSup_symmDiff_iSup_le`. -/
 theorem biSup_symmDiff_biSup_le {p : ι → Prop} {f g : (i : ι) → p i → α} :
     (⨆ i, ⨆ (h : p i), f i h) ∆ (⨆ i, ⨆ (h : p i), g i h) ≤
     ⨆ i, ⨆ (h : p i), ((f i h) ∆ (g i h)) :=
-  le_trans iSup_symmDiff_iSup_le (iSup_mono (fun _ ↦ iSup_symmDiff_iSup_le))
+  le_trans iSup_symmDiff_iSup_le <|iSup_mono fun _ ↦ iSup_symmDiff_iSup_le
 
 end CompleteBooleanAlgebra
 

--- a/Mathlib/Order/SymmDiff.lean
+++ b/Mathlib/Order/SymmDiff.lean
@@ -215,6 +215,11 @@ theorem symmDiff_triangle : a ∆ c ≤ a ∆ b ⊔ b ∆ c := by
   rw [sup_comm (c \ b), sup_sup_sup_comm, symmDiff, symmDiff]
 #align symm_diff_triangle symmDiff_triangle
 
+lemma le_symmDiff_sup {α : Type*} [GeneralizedCoheytingAlgebra α] (x y : α) : x ≤ (x ∆ y) ⊔ y := by
+  rw (config := {occs := .pos [1]}) [← symmDiff_bot x]
+  rw (config := {occs := .pos [2]}) [← symmDiff_bot y]
+  exact symmDiff_triangle ..
+
 end GeneralizedCoheytingAlgebra
 
 section GeneralizedHeytingAlgebra

--- a/Mathlib/Order/SymmDiff.lean
+++ b/Mathlib/Order/SymmDiff.lean
@@ -215,10 +215,11 @@ theorem symmDiff_triangle : a ∆ c ≤ a ∆ b ⊔ b ∆ c := by
   rw [sup_comm (c \ b), sup_sup_sup_comm, symmDiff, symmDiff]
 #align symm_diff_triangle symmDiff_triangle
 
-lemma le_symmDiff_sup {α : Type*} [GeneralizedCoheytingAlgebra α] (x y : α) : x ≤ (x ∆ y) ⊔ y := by
-  rw (config := {occs := .pos [1]}) [← symmDiff_bot x]
-  rw (config := {occs := .pos [2]}) [← symmDiff_bot y]
-  exact symmDiff_triangle ..
+theorem le_symmDiff_sup_right (a b : α) : a ≤ (a ∆ b) ⊔ b := by
+  convert symmDiff_triangle a b ⊥ <;> rw [symmDiff_bot]
+
+theorem le_symmDiff_sup_left (a b : α) : b ≤ (a ∆ b) ⊔ a :=
+  symmDiff_comm a b ▸ le_symmDiff_sup_right ..
 
 end GeneralizedCoheytingAlgebra
 


### PR DESCRIPTION
Add 3 lemmas to show that the symmetric difference of two `iSup`s/`biSup`s is less or equal to the `iSup`/`biSup` of the symmetric differences.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
