### PR TITLE
[Merged by Bors] - chore(Condensed): make the discrete-underlying adjunction more concrete

### DIFF
--- a/Mathlib/Condensed/Discrete.lean
+++ b/Mathlib/Condensed/Discrete.lean
@@ -10,7 +10,7 @@ import Mathlib.Condensed.Basic
 
 # Discrete-underlying adjunction
 
-Given a well-behaved concrete category `C`, we define a functor `C ⥤ Condensed C` which associates
+Given a well-behaved category `C`, we define a functor `C ⥤ Condensed C` which associates
 to an object of `C` the corresponding "discrete" condensed object (see `Condensed.discrete`).
 
 In `Condensed.discrete_underlying_adj` we prove that this functor is left adjoint to the forgetful
@@ -34,11 +34,12 @@ The underlying object of a condensed object in `C` is the condensed object eval
 This can be viewed as a sort of forgetful functor from `Condensed C` to `C`
 -/
 @[simps!]
-noncomputable def Condensed.underlying : Condensed.{u} C ⥤ C := (sheafSections _ _).obj (op (⊤_ _))
+noncomputable def Condensed.underlying : Condensed.{u} C ⥤ C :=
+  (sheafSections _ _).obj ⟨CompHaus.of PUnit.{u+1}⟩
 
 /--
 Discreteness is left adjoint to the forgetful functor. When `C` is `Type*`, this is analogous to
 `TopCat.adj₁ : TopCat.discrete ⊣ forget TopCat`.  
 -/
 noncomputable def Condensed.discrete_underlying_adj : discrete C ⊣ underlying C :=
-  constantSheafAdj _ _ terminalIsTerminal
+  constantSheafAdj _ _ CompHaus.isTerminalPUnit


### PR DESCRIPTION
This PR changes the definition of the "underlying set" of a condensed set to the value at `CompHaus.of PUnit` instead of an arbitrary terminal object. This specific terminal object has the nice definitional property of containing exactly one element.

---
This change makes the characterisation of discrete condensed sets in terms of sheaves of locally constant maps and colimits easier, see https://github.com/dagurtomas/LeanCondensed/blob/master/LeanCondensed/Mathlib/Condensed/Discrete/LocallyConstant.lean


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
