### PR TITLE
[Merged by Bors] - feat: add a rfl lemma about non negative norm seen as en ENNReal

### DIFF
--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -988,6 +988,12 @@ theorem norm_toNNReal' : ‖a‖.toNNReal = ‖a‖₊ :=
 #align norm_to_nnreal' norm_toNNReal'
 #align norm_to_nnreal norm_toNNReal
 
+/-- The non negative norm seen as an `ENNReal` and then as a `Real` is equal to the norm. -/
+@[to_additive ofNNReal_toReal_nnnorm "The non negative norm seen as an `ENNReal` and
+then as a `Real` is equal to the norm."]
+theorem ofNNReal_toReal_nnnorm' [SeminormedGroup E] (a : E) :
+    (‖a‖₊ : ℝ≥0∞).toReal = ‖a‖ := rfl
+
 @[to_additive]
 theorem nndist_eq_nnnorm_div (a b : E) : nndist a b = ‖a / b‖₊ :=
   NNReal.eq <| dist_eq_norm_div _ _

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -991,8 +991,7 @@ theorem norm_toNNReal' : ‖a‖.toNNReal = ‖a‖₊ :=
 /-- The non negative norm seen as an `ENNReal` and then as a `Real` is equal to the norm. -/
 @[to_additive ofNNReal_toReal_nnnorm "The non negative norm seen as an `ENNReal` and
 then as a `Real` is equal to the norm."]
-theorem ofNNReal_toReal_nnnorm' [SeminormedGroup E] (a : E) :
-    (‖a‖₊ : ℝ≥0∞).toReal = ‖a‖ := rfl
+theorem ofNNReal_toReal_nnnorm' : (‖a‖₊ : ℝ≥0∞).toReal = ‖a‖ := rfl
 
 @[to_additive]
 theorem nndist_eq_nnnorm_div (a b : E) : nndist a b = ‖a / b‖₊ :=

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -988,11 +988,6 @@ theorem norm_toNNReal' : ‖a‖.toNNReal = ‖a‖₊ :=
 #align norm_to_nnreal' norm_toNNReal'
 #align norm_to_nnreal norm_toNNReal
 
-/-- The non negative norm seen as an `ENNReal` and then as a `Real` is equal to the norm. -/
-@[to_additive ofNNReal_toReal_nnnorm "The non negative norm seen as an `ENNReal` and
-then as a `Real` is equal to the norm."]
-theorem ofNNReal_toReal_nnnorm' : (‖a‖₊ : ℝ≥0∞).toReal = ‖a‖ := rfl
-
 @[to_additive]
 theorem nndist_eq_nnnorm_div (a b : E) : nndist a b = ‖a / b‖₊ :=
   NNReal.eq <| dist_eq_norm_div _ _
@@ -1075,6 +1070,11 @@ theorem ofReal_norm_eq_coe_nnnorm' (a : E) : ENNReal.ofReal ‖a‖ = ‖a‖₊
   ENNReal.ofReal_eq_coe_nnreal _
 #align of_real_norm_eq_coe_nnnorm' ofReal_norm_eq_coe_nnnorm'
 #align of_real_norm_eq_coe_nnnorm ofReal_norm_eq_coe_nnnorm
+
+/-- The non negative norm seen as an `ENNReal` and then as a `Real` is equal to the norm. -/
+@[to_additive toReal_coe_nnnorm "The non negative norm seen as an `ENNReal` and
+then as a `Real` is equal to the norm."]
+theorem toReal_coe_nnnorm' (a : E) : (‖a‖₊ : ℝ≥0∞).toReal = ‖a‖ := rfl
 
 @[to_additive]
 theorem edist_eq_coe_nnnorm_div (a b : E) : edist a b = ‖a / b‖₊ := by


### PR DESCRIPTION
Add a rfl lemma about non negative norm seen as an ENNReal. Especially useful when dealing with the Lp norm of an indicatorConstLp.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
