### PR TITLE
feat: `conv%`

### DIFF
--- a/Mathlib/Tactic/Conv.lean
+++ b/Mathlib/Tactic/Conv.lean
@@ -72,7 +72,7 @@ open Elab Term Tactic
 /--
 The term elaborator `conv% tac => e` will run a conv tactic `tac` on `e`, and display the resulting
 expression (discarding the proof).
-For example, `conv% rw [true_and] => True ∧ False` elaborates to `False`.
+For example, `conv% True ∧ False => rw [true_and]` elaborates to `False`.
 
 `conv%? tac => e` shows the resulting term.
 
@@ -82,7 +82,7 @@ There are also shorthand term elaborators for several common conv tactics:
 * `norm_num% e` is short for `conv% norm_num => e`
 * `push_neg% e` is short for `conv% push_neg => e`
 -/
-syntax (name := convTerm) "conv% " term " => " conv : term
+syntax (name := convTerm) "conv% " term " => " colGt convSeq : term
 
 /-- Elaborates syntax of the form `conv% $conv:conv => $e:term`. -/
 @[term_elab convTerm]
@@ -101,7 +101,8 @@ def elabConvTerm : Term.TermElab
   | _, _ => throwUnsupportedSyntax
 
 @[inherit_doc convTerm]
-macro tk:"conv%? " e:term " => " conv:conv : term => `(term|show_term conv%%$tk $e => $conv)
+macro tk:"conv%? " e:term " => " colGt conv:convSeq : term =>
+  `(term|show_term conv%%$tk $e => $conv)
 
 /--
 The command `#conv e => tac` will run a conv tactic `tac` on `e`, and display the resulting
@@ -114,7 +115,7 @@ There are also shorthand commands for several common conv tactics:
 * `#norm_num e` is short for `#conv e => norm_num`
 * `#push_neg e` is short for `#conv e => push_neg`
 -/
-elab tk:"#conv " e:term " => " conv:conv : command =>
+elab tk:"#conv " e:term " => " colGt conv:convSeq : command =>
   Command.runTermElabM fun _ ↦ do
     let e' ← elabConvTerm (← `(term|conv% $e => $conv)) none
     logInfoAt tk e'

--- a/Mathlib/Tactic/Conv.lean
+++ b/Mathlib/Tactic/Conv.lean
@@ -70,17 +70,17 @@ macro "refine " e:term : conv => `(conv| tactic => refine $e)
 
 open Elab Term Tactic
 /--
-The term elaborator `conv% tac => e` will run a conv tactic `tac` on `e`, and display the resulting
+The term elaborator `conv% e => tac` will run a conv tactic `tac` on `e`, and display the resulting
 expression (discarding the proof).
 For example, `conv% True ∧ False => rw [true_and]` elaborates to `False`.
 
-`conv%? tac => e` shows the resulting term.
+`conv%? e => tac` shows the resulting term.
 
 There are also shorthand term elaborators for several common conv tactics:
 
-* `simp% e` is short for `conv% simp => e`
-* `norm_num% e` is short for `conv% norm_num => e`
-* `push_neg% e` is short for `conv% push_neg => e`
+* `simp% e` is short for `conv% e => simp`
+* `norm_num% e` is short for `conv% e => norm_num`
+* `push_neg% e` is short for `conv% e => push_neg`
 -/
 syntax (name := convTerm) "conv% " term " => " colGt convSeq : term
 

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -340,21 +340,55 @@ open Lean Elab Tactic
   Conv.applySimpResult (← deriveSimp ctx (← instantiateMVars (← Conv.getLhs)) (useSimp := true))
 
 /--
+`norm_num% e`, where `e` is an expression, will elaborate to the normalized form of `e`.
+
+Syntax: `norm_num%` (config)? (`only`)? (`[` simp lemma list `]`)? ` on`? expression
+
+`norm_num1% e` runs `norm_num1` on `e`, and does not use (or accept) any simp lemmas.
+
+`norm_num%?` (and `norm_num1%?`) displays the normalized value using `show_term`.
+
+This accepts the same options as the `simp%` elaborator.
+You can specify additional simp lemmas as usual, for example using `norm_num% [f, g] on e`.
+(The `on` is optional but helpful for the parser.)
+The `only` restricts `norm_num` to using only the provided lemmas, and so
+`norm_num% only on e` behaves similarly to `norm_num1`.
+
+Unlike `norm_num`, this elaborator does not fail when no simplifications are made.
+
+`norm_num%` understands local variables, so you can use them to introduce parameters.
+-/
+macro (name := normNumTerm) "norm_num%" cfg:(config)? o:(&" only")?
+    args:(Parser.Tactic.simpArgs)? " on"? ppSpace e:term : term =>
+  `(term| conv% $e:term => norm_num $(cfg)? $[only%$o]? $(args)? )
+
+@[inherit_doc normNumTerm]
+macro "norm_num%?" cfg:(config)? o:(&" only")?
+    args:(Parser.Tactic.simpArgs)? " on"? ppSpace e:term : term =>
+  `(term| conv%? $e:term => norm_num $(cfg)? $[only%$o]? $(args)? )
+
+@[inherit_doc normNumTerm] macro "norm_num1% "  e:term : term => `(term|conv%  $e => norm_num1)
+@[inherit_doc normNumTerm] macro "norm_num1%? " e:term : term => `(term|conv%? $e => norm_num1)
+
+/--
 The basic usage is `#norm_num e`, where `e` is an expression,
 which will print the `norm_num` form of `e`.
 
-Syntax: `#norm_num` (`only`)? (`[` simp lemma list `]`)? `:`? expression
+Syntax: `#norm_num` (config)? (`only`)? (`[` simp lemma list `]`)? ` on`? expression
 
 This accepts the same options as the `#simp` command.
-You can specify additional simp lemmas as usual, for example using `#norm_num [f, g] : e`.
-(The colon is optional but helpful for the parser.)
+You can specify additional simp lemmas as usual, for example using `#norm_num [f, g] on e`.
+(The `on` is optional but helpful for the parser.)
 The `only` restricts `norm_num` to using only the provided lemmas, and so
-`#norm_num only : e` behaves similarly to `norm_num1`.
+`#norm_num1 only on e` behaves similarly to `norm_num1`.
 
 Unlike `norm_num`, this command does not fail when no simplifications are made.
 
 `#norm_num` understands local variables, so you can use them to introduce parameters.
 -/
 macro (name := normNumCmd) "#norm_num" cfg:(config)? o:(&" only")?
-    args:(Parser.Tactic.simpArgs)? " :"? ppSpace e:term : command =>
-  `(command| #conv norm_num $(cfg)? $[only%$o]? $(args)? => $e)
+    args:(Parser.Tactic.simpArgs)? " on"? ppSpace e:term : command =>
+  `(command| #conv $e => norm_num $(cfg)? $[only%$o]? $(args)?)
+
+@[inherit_doc normNumCmd]
+macro "#norm_num1 " e:term : command => `(command| #conv $e => norm_num1)

--- a/Mathlib/Tactic/PushNeg.lean
+++ b/Mathlib/Tactic/PushNeg.lean
@@ -170,12 +170,25 @@ syntax (name := pushNegConv) "push_neg" : conv
   Conv.applySimpResult (← pushNegCore (← instantiateMVars (← Conv.getLhs)))
 
 /--
+The syntax `push_neg% e`, where `e` is an expression,
+will elaborate to the `push_neg` form of `e`.
+
+`push_neg%` understands local variables, so you can use them to introduce parameters.
+
+`push_neg%?` will show the resulting expression using `show_term`.
+-/
+macro (name := pushNegTerm) tk:"push_neg% " e:term : term => `(term| conv%%$tk $e => push_neg)
+
+@[inherit_doc pushNegTerm]
+macro tk:"push_neg%? " e:term : term => `(term| conv%?%$tk $e => push_neg)
+
+/--
 The syntax is `#push_neg e`, where `e` is an expression,
 which will print the `push_neg` form of `e`.
 
 `#push_neg` understands local variables, so you can use them to introduce parameters.
 -/
-macro (name := pushNeg) tk:"#push_neg " e:term : command => `(command| #conv%$tk push_neg => $e)
+macro (name := pushNeg) tk:"#push_neg " e:term : command => `(command| #conv%$tk $e => push_neg)
 
 /-- Execute main loop of `push_neg` at the main goal. -/
 def pushNegTarget : TacticM Unit := withMainContext do

--- a/docs/Conv/Guide.lean
+++ b/docs/Conv/Guide.lean
@@ -228,9 +228,13 @@ and expands all local variables).
 * `conv' ... => ...` is like `conv` but assumes the goal is already annotated as a `conv` goal.
   Used internally to go back and forth between tactic mode and conv mode.
 
-* `#conv convTactic => e` is a command to apply the `convTactic` to the expression `e`, yielding
-  the converted expression (and dropping the generated proof).
-  This is used to implement `#simp`, `#whnf`, `#norm_num`, and `#push_neg`. (Mathlib)
+* `conv% e => convTactic` is a term elaborator which applies `convTactic` to the expression `e`,
+  yielding the converted expresion (and dropping the generated proof).
+  This is used to implement `simp%`, `norm_num%`, and `push_neg%`.
+  `conv%?` shows the resulting term using `show_term`. (Mathlib)
+
+* `#conv e => convTactic` elaborates `conv% e => convTactic` and displays the resulting expression.
+  (Mathlib)
 
 
 -/


### PR DESCRIPTION
This PR introduces `conv% e => tac`, along with `simp%`, `norm_num%`, and `push_neg%`, which are defined in terms of `conv%`.

It also introduces `conv%?` (and `simp%?`, `norm_num%?`, and `push_neg%?`) as shortcuts for `show_term ...`.

This is a relatively straightforward refactor of code already present in the implementation of `#conv`, and otherwise relies entirely on simple macros.

This PR also introduces some modifications to existing command syntax for `#conv`, `#simp`, and `#norm_num`:

* The syntax for `#conv` was `#conv tac => e`; however, this is inconsistent with the tactic syntax, and so this has been flipped to `#conv e => tac`. Likewise, `conv%` uses the same (new) syntax `conv% e => tac`.
* `#simp` and `#norm_num` separated their config and `only` syntax from the expression by an optional `=>` (for `#simp`) and an optional `:` (for `#norm_num`) (e.g. `#simp only [lem] => e`). These have both been replaced with an optional`on` (e.g. `#simp only [lem] on e`) which is also used for `simp%` and `norm_num%`.

Although `#whnf` is implemented in terms of `#conv`, this PR doesn't introduce `whnf%` in the same way, as that's probably better off being implemented directly instead of through `conv`.

---
WIP: needs tests.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
