### PR TITLE
[Merged by Bors] - doc(NumberTheory/Harmonic): fix formatting glitch

### DIFF
--- a/Mathlib/NumberTheory/Harmonic/EulerMascheroni.lean
+++ b/Mathlib/NumberTheory/Harmonic/EulerMascheroni.lean
@@ -14,7 +14,7 @@ import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 We define the constant `γ`, and give upper and lower bounds for it.
 
-## Main definitions and results
+## Main definitions and results
 
 * `Real.eulerMascheroniConstant`: the constant `γ`
 * `Real.tendsto_harmonic_sub_log`: the sequence `n ↦ harmonic n - log n` tends to `γ` as `n → ∞`


### PR DESCRIPTION
Fix a rogue non-breaking space in file header

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
