### PR TITLE
[Merged by Bors] - feat: When the symmetric difference has finite measure

### DIFF
--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -259,7 +259,7 @@ theorem le_measure_diff : μ s₁ - μ s₂ ≤ μ (s₁ \ s₂) :=
 open scoped symmDiff in
 /-- If the measure of the symmetric difference of two measurable sets `s` and `t` is finite and
 `s` has finite measure, then so does `t`. -/
-lemma Ne.measure_ne_top_of_symmDiff (hs : MeasurableSet s) (ht : MeasurableSet t)
+theorem Ne.measure_ne_top_of_symmDiff (hs : MeasurableSet s) (ht : MeasurableSet t)
     (hμt : μ s ≠ ∞) (hμst : μ (s ∆ t) ≠ ∞) : μ t ≠ ∞ := by
   by_contra h
   apply hμst

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -86,7 +86,7 @@ open Set
 open Filter hiding map
 
 open Function MeasurableSpace
-open scoped Classical
+open scoped Classical symmDiff
 open Topology BigOperators Filter ENNReal NNReal Interval MeasureTheory
 
 variable {α β γ δ ι R R' : Type*}
@@ -137,12 +137,10 @@ theorem measure_union_add_inter' (hs : MeasurableSet s) (t : Set α) :
   rw [union_comm, inter_comm, measure_union_add_inter t hs, add_comm]
 #align measure_theory.measure_union_add_inter' MeasureTheory.measure_union_add_inter'
 
-open scoped symmDiff in
 lemma measure_symmDiff_eq (hs : MeasurableSet s) (ht : MeasurableSet t) :
     μ (s ∆ t) = μ (s \ t) + μ (t \ s) := by
   simpa only [symmDiff_def, sup_eq_union] using measure_union disjoint_sdiff_sdiff (ht.diff hs)
 
-open scoped symmDiff in
 lemma measure_symmDiff_le (s t u : Set α) :
     μ (s ∆ u) ≤ μ (s ∆ t) + μ (t ∆ u) :=
   le_trans (μ.mono <| symmDiff_triangle s t u) (measure_union_le (s ∆ t) (t ∆ u))
@@ -256,7 +254,6 @@ theorem le_measure_diff : μ s₁ - μ s₂ ≤ μ (s₁ \ s₂) :=
 
 #align measure_theory.le_measure_diff MeasureTheory.le_measure_diff
 
-open scoped symmDiff in
 /-- If the measure of the symmetric difference of two null measurable sets is finite,
 then one has infinite measure if and only if the other does. -/
 theorem Ne.measure_eq_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : NullMeasurableSet t μ)
@@ -274,7 +271,6 @@ theorem Ne.measure_eq_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : Nu
     ∞ = μ u - μ v :=(WithTop.sub_eq_top_iff.2 ⟨hμu, hμv⟩).symm
     _ ≤ μ (u \ v) := le_measure_diff
 
-open scoped symmDiff in
 /-- If the measure of the symmetric difference of two null measurable sets is finite,
 then one has finite measure if and only if the other does. -/
 theorem Ne.measure_ne_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : NullMeasurableSet t μ)

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -269,7 +269,7 @@ theorem measure_eq_top_iff_of_symmDiff (hμst : μ (s ∆ t) ≠ ∞) : μ s = �
     _ ≤ μ (u \ v ∪ v \ u) := measure_mono <| subset_union_left ..
 
 /-- If the measure of the symmetric difference of two sets is finite,
-then one has finite measure if and only if the other does. -/
+then one has finite measure if and only if the other one does. -/
 theorem measure_ne_top_iff_of_symmDiff (hμst : μ (s ∆ t) ≠ ∞) : μ s ≠ ∞ ↔ μ t ≠ ∞ :=
     (measure_eq_top_iff_of_symmDiff hμst).ne
 

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -271,7 +271,7 @@ theorem Ne.measure_eq_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : Nu
   left
   rw [eq_top_iff]
   calc
-    ∞ = μ u - μ v :=(WithTop.sub_eq_top_iff.2 ⟨hμu, hμv⟩).symm
+    ∞ = μ u - μ v := (WithTop.sub_eq_top_iff.2 ⟨hμu, hμv⟩).symm
     _ ≤ μ (u \ v) := le_measure_diff
 
 open scoped symmDiff in

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -256,6 +256,18 @@ theorem le_measure_diff : μ s₁ - μ s₂ ≤ μ (s₁ \ s₂) :=
 
 #align measure_theory.le_measure_diff MeasureTheory.le_measure_diff
 
+open scoped symmDiff in
+/-- If the measure of the symmetric difference of two measurable sets `s` and `t` is finite and
+`s` has finite measure, then so does `t`. -/
+lemma Ne.measure_ne_top_of_symmDiff (hs : MeasurableSet s) (ht : MeasurableSet t)
+    (hμt : μ s ≠ ∞) (hμst : μ (s ∆ t) ≠ ∞) : μ t ≠ ∞ := by
+  by_contra h
+  apply hμst
+  rw [measure_symmDiff_eq hs ht, add_eq_top]
+  right
+  rw [eq_top_iff, ← sub_eq_top_iff.2 ⟨h, hμt⟩]
+  exact le_measure_diff
+
 theorem measure_diff_lt_of_lt_add (hs : MeasurableSet s) (hst : s ⊆ t) (hs' : μ s ≠ ∞) {ε : ℝ≥0∞}
     (h : μ t < μ s + ε) : μ (t \ s) < ε := by
   rw [measure_diff hst hs hs']; rw [add_comm] at h

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -257,29 +257,28 @@ theorem le_measure_diff : μ s₁ - μ s₂ ≤ μ (s₁ \ s₂) :=
 #align measure_theory.le_measure_diff MeasureTheory.le_measure_diff
 
 open scoped symmDiff in
-/-- If the measure of the symmetric difference of two measurable sets is finite,
-then one has finite measure if and only if the other does. -/
-theorem Ne.measure_ne_top_iff_of_symmDiff (hs : MeasurableSet s) (ht : MeasurableSet t)
-    (hμst : μ (s ∆ t) ≠ ⊤) : μ s ≠ ⊤ ↔ μ t ≠ ⊤ := by
-  suffices h : ∀ u v, MeasurableSet u → MeasurableSet v → μ (u ∆ v) ≠ ⊤ → μ u ≠ ⊤ → μ v ≠ ⊤
+/-- If the measure of the symmetric difference of two null measurable sets is finite,
+then one has infinite measure if and only if the other does. -/
+theorem Ne.measure_eq_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : NullMeasurableSet t μ)
+    (hμst : μ (s ∆ t) ≠ ∞) : μ s = ∞ ↔ μ t = ∞ := by
+  suffices h : ∀ u v, NullMeasurableSet u μ → NullMeasurableSet v μ
+    → μ (u ∆ v) ≠ ∞ → μ u = ∞ → μ v = ∞
     from ⟨h s t hs ht hμst, h t s ht hs (symmDiff_comm s t ▸ hμst)⟩
   intro u v hu hv hμuv hμu
-  by_contra h
+  by_contra! hμv
   apply hμuv
-  rw [measure_symmDiff_eq hu hv, add_eq_top]
-  right
-  rw [eq_top_iff, ← sub_eq_top_iff.2 ⟨h, hμu⟩]
-  exact le_measure_diff
+  rw [Set.symmDiff_def, measure_union₀ (hv.diff hu) disjoint_sdiff_sdiff.aedisjoint, add_eq_top]
+  left
+  rw [eq_top_iff]
+  calc
+    ∞ = μ u - μ v :=(WithTop.sub_eq_top_iff.2 ⟨hμu, hμv⟩).symm
+    _ ≤ μ (u \ v) := le_measure_diff
 
 open scoped symmDiff in
-theorem Ne.measure_ne_top_of_symmDiff_right (hs : MeasurableSet s) (ht : MeasurableSet t)
-    (hμst : μ (s ∆ t) ≠ ⊤) (hμs : μ s ≠ ⊤) : μ t ≠ ⊤ :=
-  (Ne.measure_ne_top_iff_of_symmDiff hs ht hμst).1 hμs
-
-open scoped symmDiff in
-theorem Ne.measure_ne_top_of_symmDiff_left (hs : MeasurableSet s) (ht : MeasurableSet t)
-    (hμst : μ (s ∆ t) ≠ ⊤) (hμt : μ t ≠ ⊤) : μ s ≠ ⊤ :=
-  (Ne.measure_ne_top_iff_of_symmDiff hs ht hμst).2 hμt
+/-- If the measure of the symmetric difference of two null measurable sets is finite,
+then one has finite measure if and only if the other does. -/
+theorem Ne.measure_ne_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : NullMeasurableSet t μ)
+    (hμst : μ (s ∆ t) ≠ ∞) : μ s ≠ ∞ ↔ μ t ≠ ∞ := (measure_eq_top_iff_of_symmDiff hs ht hμst).ne
 
 theorem measure_diff_lt_of_lt_add (hs : MeasurableSet s) (hst : s ⊆ t) (hs' : μ s ≠ ∞) {ε : ℝ≥0∞}
     (h : μ t < μ s + ε) : μ (t \ s) < ε := by

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -257,16 +257,29 @@ theorem le_measure_diff : μ s₁ - μ s₂ ≤ μ (s₁ \ s₂) :=
 #align measure_theory.le_measure_diff MeasureTheory.le_measure_diff
 
 open scoped symmDiff in
-/-- If the measure of the symmetric difference of two measurable sets `s` and `t` is finite and
-`s` has finite measure, then so does `t`. -/
-theorem Ne.measure_ne_top_of_symmDiff (hs : MeasurableSet s) (ht : MeasurableSet t)
-    (hμt : μ s ≠ ∞) (hμst : μ (s ∆ t) ≠ ∞) : μ t ≠ ∞ := by
+/-- If the measure of the symmetric difference of two measurable sets is finite,
+then one has finite measure if and only if the other does. -/
+theorem Ne.measure_ne_top_iff_of_symmDiff (hs : MeasurableSet s) (ht : MeasurableSet t)
+    (hμst : μ (s ∆ t) ≠ ⊤) : μ s ≠ ⊤ ↔ μ t ≠ ⊤ := by
+  suffices h : ∀ u v, MeasurableSet u → MeasurableSet v → μ (u ∆ v) ≠ ⊤ → μ u ≠ ⊤ → μ v ≠ ⊤
+    from ⟨h s t hs ht hμst, h t s ht hs (symmDiff_comm s t ▸ hμst)⟩
+  intro u v hu hv hμuv hμu
   by_contra h
-  apply hμst
-  rw [measure_symmDiff_eq hs ht, add_eq_top]
+  apply hμuv
+  rw [measure_symmDiff_eq hu hv, add_eq_top]
   right
-  rw [eq_top_iff, ← sub_eq_top_iff.2 ⟨h, hμt⟩]
+  rw [eq_top_iff, ← sub_eq_top_iff.2 ⟨h, hμu⟩]
   exact le_measure_diff
+
+open scoped symmDiff in
+theorem Ne.measure_ne_top_of_symmDiff_right (hs : MeasurableSet s) (ht : MeasurableSet t)
+    (hμst : μ (s ∆ t) ≠ ⊤) (hμs : μ s ≠ ⊤) : μ t ≠ ⊤ :=
+  (Ne.measure_ne_top_iff_of_symmDiff hs ht hμst).1 hμs
+
+open scoped symmDiff in
+theorem Ne.measure_ne_top_of_symmDiff_left (hs : MeasurableSet s) (ht : MeasurableSet t)
+    (hμst : μ (s ∆ t) ≠ ⊤) (hμt : μ t ≠ ⊤) : μ s ≠ ⊤ :=
+  (Ne.measure_ne_top_iff_of_symmDiff hs ht hμst).2 hμt
 
 theorem measure_diff_lt_of_lt_add (hs : MeasurableSet s) (hst : s ⊆ t) (hs' : μ s ≠ ∞) {ε : ℝ≥0∞}
     (h : μ t < μ s + ε) : μ (t \ s) < ε := by

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -255,7 +255,7 @@ theorem le_measure_diff : μ s₁ - μ s₂ ≤ μ (s₁ \ s₂) :=
 #align measure_theory.le_measure_diff MeasureTheory.le_measure_diff
 
 /-- If the measure of the symmetric difference of two sets is finite,
-then one has infinite measure if and only if the other does. -/
+then one has infinite measure if and only if the other one does. -/
 theorem measure_eq_top_iff_of_symmDiff (hμst : μ (s ∆ t) ≠ ∞) : μ s = ∞ ↔ μ t = ∞ := by
   suffices h : ∀ u v, μ (u ∆ v) ≠ ∞ → μ u = ∞ → μ v = ∞
     from ⟨h s t hμst, h t s (symmDiff_comm s t ▸ hμst)⟩

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -256,7 +256,7 @@ theorem le_measure_diff : μ s₁ - μ s₂ ≤ μ (s₁ \ s₂) :=
 
 /-- If the measure of the symmetric difference of two null measurable sets is finite,
 then one has infinite measure if and only if the other does. -/
-theorem Ne.measure_eq_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : NullMeasurableSet t μ)
+theorem measure_eq_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : NullMeasurableSet t μ)
     (hμst : μ (s ∆ t) ≠ ∞) : μ s = ∞ ↔ μ t = ∞ := by
   suffices h : ∀ u v, NullMeasurableSet u μ → NullMeasurableSet v μ
     → μ (u ∆ v) ≠ ∞ → μ u = ∞ → μ v = ∞
@@ -273,7 +273,7 @@ theorem Ne.measure_eq_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : Nu
 
 /-- If the measure of the symmetric difference of two null measurable sets is finite,
 then one has finite measure if and only if the other does. -/
-theorem Ne.measure_ne_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : NullMeasurableSet t μ)
+theorem measure_ne_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : NullMeasurableSet t μ)
     (hμst : μ (s ∆ t) ≠ ∞) : μ s ≠ ∞ ↔ μ t ≠ ∞ := (measure_eq_top_iff_of_symmDiff hs ht hμst).ne
 
 theorem measure_diff_lt_of_lt_add (hs : MeasurableSet s) (hst : s ⊆ t) (hs' : μ s ≠ ∞) {ε : ℝ≥0∞}

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -254,27 +254,24 @@ theorem le_measure_diff : μ s₁ - μ s₂ ≤ μ (s₁ \ s₂) :=
 
 #align measure_theory.le_measure_diff MeasureTheory.le_measure_diff
 
-/-- If the measure of the symmetric difference of two null measurable sets is finite,
+/-- If the measure of the symmetric difference of two sets is finite,
 then one has infinite measure if and only if the other does. -/
-theorem measure_eq_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : NullMeasurableSet t μ)
-    (hμst : μ (s ∆ t) ≠ ∞) : μ s = ∞ ↔ μ t = ∞ := by
-  suffices h : ∀ u v, NullMeasurableSet u μ → NullMeasurableSet v μ
-    → μ (u ∆ v) ≠ ∞ → μ u = ∞ → μ v = ∞
-    from ⟨h s t hs ht hμst, h t s ht hs (symmDiff_comm s t ▸ hμst)⟩
-  intro u v hu hv hμuv hμu
+theorem measure_eq_top_iff_of_symmDiff (hμst : μ (s ∆ t) ≠ ∞) : μ s = ∞ ↔ μ t = ∞ := by
+  suffices h : ∀ u v, μ (u ∆ v) ≠ ∞ → μ u = ∞ → μ v = ∞
+    from ⟨h s t hμst, h t s (symmDiff_comm s t ▸ hμst)⟩
+  intro u v hμuv hμu
   by_contra! hμv
   apply hμuv
-  rw [Set.symmDiff_def, measure_union₀ (hv.diff hu) disjoint_sdiff_sdiff.aedisjoint, add_eq_top]
-  left
-  rw [eq_top_iff]
+  rw [Set.symmDiff_def, eq_top_iff]
   calc
     ∞ = μ u - μ v := (WithTop.sub_eq_top_iff.2 ⟨hμu, hμv⟩).symm
     _ ≤ μ (u \ v) := le_measure_diff
+    _ ≤ μ (u \ v ∪ v \ u) := measure_mono <| subset_union_left ..
 
-/-- If the measure of the symmetric difference of two null measurable sets is finite,
+/-- If the measure of the symmetric difference of two sets is finite,
 then one has finite measure if and only if the other does. -/
-theorem measure_ne_top_iff_of_symmDiff (hs : NullMeasurableSet s μ) (ht : NullMeasurableSet t μ)
-    (hμst : μ (s ∆ t) ≠ ∞) : μ s ≠ ∞ ↔ μ t ≠ ∞ := (measure_eq_top_iff_of_symmDiff hs ht hμst).ne
+theorem measure_ne_top_iff_of_symmDiff (hμst : μ (s ∆ t) ≠ ∞) : μ s ≠ ∞ ↔ μ t ≠ ∞ :=
+    (measure_eq_top_iff_of_symmDiff hμst).ne
 
 theorem measure_diff_lt_of_lt_add (hs : MeasurableSet s) (hst : s ⊆ t) (hs' : μ s ≠ ∞) {ε : ℝ≥0∞}
     (h : μ t < μ s + ε) : μ (t \ s) < ε := by


### PR DESCRIPTION
Add the following lemma: is `s` and `t` are two measurable sets such that `s` and `s ∆ t` have finite measures, then so does `t`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
