### PR TITLE
[Merged by Bors] - feat(RingTheory/MvPolynomial): freeness of `MvPolynomial`

### DIFF
--- a/Mathlib/RingTheory/MvPolynomial/Basic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Basic.lean
@@ -135,6 +135,10 @@ def basisMonomials : Basis (σ →₀ ℕ) R (MvPolynomial σ R) :=
   Finsupp.basisSingleOne
 #align mv_polynomial.basis_monomials MvPolynomial.basisMonomials
 
+/-- The `R`-module `MvPolynomial σ R` is free. -/
+instance : Module.Free R (MvPolynomial σ R) :=
+  Module.Free.of_basis (MvPolynomial.basisMonomials σ R)
+
 @[simp]
 theorem coe_basisMonomials :
     (basisMonomials σ R : (σ →₀ ℕ) → MvPolynomial σ R) = fun s => monomial s 1 :=

--- a/Mathlib/RingTheory/MvPolynomial/Basic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Basic.lean
@@ -135,15 +135,15 @@ def basisMonomials : Basis (σ →₀ ℕ) R (MvPolynomial σ R) :=
   Finsupp.basisSingleOne
 #align mv_polynomial.basis_monomials MvPolynomial.basisMonomials
 
-/-- The `R`-module `MvPolynomial σ R` is free. -/
-instance : Module.Free R (MvPolynomial σ R) :=
-  Module.Free.of_basis (MvPolynomial.basisMonomials σ R)
-
 @[simp]
 theorem coe_basisMonomials :
     (basisMonomials σ R : (σ →₀ ℕ) → MvPolynomial σ R) = fun s => monomial s 1 :=
   rfl
 #align mv_polynomial.coe_basis_monomials MvPolynomial.coe_basisMonomials
+
+/-- The `R`-module `MvPolynomial σ R` is free. -/
+instance : Module.Free R (MvPolynomial σ R) :=
+  Module.Free.of_basis (MvPolynomial.basisMonomials σ R)
 
 theorem linearIndependent_X : LinearIndependent R (X : σ → MvPolynomial σ R) :=
   (basisMonomials σ R).linearIndependent.comp (fun s : σ => Finsupp.single s 1)


### PR DESCRIPTION
Shows that a multivariable polynomial ring is a free module.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
