### PR TITLE
perf: disable #align and friends to see what this gains in performance

### DIFF
--- a/Mathlib/Mathport/Rename.lean
+++ b/Mathlib/Mathport/Rename.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Daniel Selsam
 -/
 import Lean.Elab.Command
-import Lean.Linter.Util
+-- import Lean.Linter.Util
 
 namespace Mathlib.Prelude.Rename
 

--- a/Mathlib/Mathport/Rename.lean
+++ b/Mathlib/Mathport/Rename.lean
@@ -150,8 +150,9 @@ def suspiciousLean3Name (s : String) : Bool := Id.run do
 
 /-- Elaborate an `#align` command. -/
 @[command_elab align] def elabAlign : CommandElab
-  | `(#align $id3:ident $id4:ident) => do
-    if (← getInfoState).enabled then
+  | `(#align $_id3:ident $_id4:ident) => do
+    pure PUnit.unit
+    /- if (← getInfoState).enabled then
       addCompletionInfo <| CompletionInfo.id id4 id4.getId (danglingDot := false) {} none
       let c := removeX id4.getId
       if (← getEnv).contains c then
@@ -172,7 +173,7 @@ def suspiciousLean3Name (s : String) : Bool := Id.run do
              If the Lean 3 name is correct, then above this line, add:\n\
              set_option linter.uppercaseLean3 false in\n"
     withRef id3 <| ensureUnused id3.getId
-    liftCoreM <| addNameAlignment id3.getId id4.getId
+    liftCoreM <| addNameAlignment id3.getId id4.getId -/
   | _ => throwUnsupportedSyntax
 
 /--
@@ -185,9 +186,10 @@ syntax (name := noalign) "#noalign " ident : command
 
 /-- Elaborate a `#noalign` command. -/
 @[command_elab noalign] def elabNoAlign : CommandElab
-  | `(#noalign $id3:ident) => do
-    withRef id3 <| ensureUnused id3.getId
-    liftCoreM <| addNameAlignment id3.getId .anonymous
+  | `(#noalign $_id3:ident) => do
+    pure PUnit.unit
+    /- withRef id3 <| ensureUnused id3.getId
+    liftCoreM <| addNameAlignment id3.getId .anonymous -/
   | _ => throwUnsupportedSyntax
 
 /-- Show information about the alignment status of a lean 3 definition. -/
@@ -249,8 +251,9 @@ syntax (name := alignImport) "#align_import " ident (" from " str "@" str)? : co
 
 /-- Elaborate a `#align_import` command. -/
 @[command_elab alignImport] def elabAlignImport : CommandElab
-  | `(#align_import $mod3 $[from $repo @ $sha]?) => do
-    let origin ← repo.mapM fun repo => do
+  | `(#align_import $_mod3 $[from $repo @ $sha]?) => do
+    pure PUnit.unit
+    /- let origin ← repo.mapM fun repo => do
       let sha := sha.get!
       let shaStr := sha.getString
       if !shaStr.all ("abcdef0123456789".contains) then
@@ -260,5 +263,5 @@ syntax (name := alignImport) "#align_import " ident (" from " str "@" str)? : co
       else
         pure (repo.getString, shaStr)
     modifyEnv fun env =>
-      renameImportExtension.addEntry env (env.header.mainModule, { mod3 := mod3.getId, origin })
+      renameImportExtension.addEntry env (env.header.mainModule, { mod3 := mod3.getId, origin }) -/
   | _ => throwUnsupportedSyntax


### PR DESCRIPTION
This is an experiment: we change `#align`, `#noalign` and `#align_import` to no-ops and compare the build time for Mathlib before and after.

This was prompted by building Mathlib with the option `profiler: true` set in the lakefile and noticing lots of lines like
```
interpretation of Mathlib.Prelude.Rename.initFn._@.Mathlib.Mathport.Rename._hyg.247._lambda_3 took 679ms
```
which I figured were caused by `#align_import`. Multiply by 4000, and we end up at a non-negligible fraction of build time.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
