### PR TITLE
style: replace preimage_val with ↓∩ notation

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -1422,9 +1422,9 @@ theorem maximal_orthonormal_iff_orthogonalComplement_eq_bot (hv : Orthonormal �
     intro x hxu
     refine' ((mt (h x)) (hu.ne_zero ⟨x, hxu⟩)).imp_symm _
     intro hxv y hy
-    have hxv' : (⟨x, hxu⟩ : u) ∉ ((↑) ⁻¹' v : Set u) := by simp [huv, hxv]
+    have hxv' : ⟨x, hxu⟩ ∉ u ↓∩ v := by simp [huv, hxv]
     obtain ⟨l, hl, rfl⟩ :
-      ∃ l ∈ Finsupp.supported 𝕜 𝕜 ((↑) ⁻¹' v : Set u), (Finsupp.total (↥u) E 𝕜 (↑)) l = y := by
+      ∃ l ∈ Finsupp.supported 𝕜 𝕜 (u ↓∩ v), (Finsupp.total (↥u) E 𝕜 (↑)) l = y := by
       rw [← Finsupp.mem_span_image_iff_total]
       simp [huv, inter_eq_self_of_subset_right, hy]
     exact hu.inner_finsupp_eq_zero hxv' hl

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -72,7 +72,7 @@ theorem range_restrict (f : α → β) (s : Set α) : Set.range (s.restrict f) =
 #align set.range_restrict Set.range_restrict
 
 theorem image_restrict (f : α → β) (s t : Set α) :
-    s.restrict f '' (Subtype.val ⁻¹' t) = f '' (t ∩ s) := by
+    s.restrict f '' (s ↓∩ t) = f '' (t ∩ s) := by
   rw [restrict_eq, image_comp, image_preimage_eq_inter_range, Subtype.range_coe]
 #align set.image_restrict Set.image_restrict
 
@@ -381,7 +381,7 @@ theorem MapsTo.coe_restrict (h : Set.MapsTo f s t) :
 #align set.maps_to.coe_restrict Set.MapsTo.coe_restrict
 
 theorem MapsTo.range_restrict (f : α → β) (s : Set α) (t : Set β) (h : MapsTo f s t) :
-    range (h.restrict f s t) = Subtype.val ⁻¹' (f '' s) :=
+    range (h.restrict f s t) = t ↓∩ (f '' s) :=
   Set.range_subtype_map f h
 #align set.maps_to.range_restrict Set.MapsTo.range_restrict
 
@@ -570,13 +570,13 @@ variable (t)
 
 variable (f s) in
 theorem image_restrictPreimage :
-    t.restrictPreimage f '' (Subtype.val ⁻¹' s) = Subtype.val ⁻¹' (f '' s) := by
+    t.restrictPreimage f '' ((f ⁻¹' t) ↓∩ s) = t ↓∩ (f '' s) := by
   delta Set.restrictPreimage
   rw [← (Subtype.coe_injective).image_injective.eq_iff, ← image_comp, MapsTo.restrict_commutes,
     image_comp, Subtype.image_preimage_coe, Subtype.image_preimage_coe, image_preimage_inter]
 
 variable (f) in
-theorem range_restrictPreimage : range (t.restrictPreimage f) = Subtype.val ⁻¹' range f := by
+theorem range_restrictPreimage : range (t.restrictPreimage f) = t ↓∩ range f := by
   simp only [← image_univ, ← image_restrictPreimage, preimage_univ]
 #align set.range_restrict_preimage Set.range_restrictPreimage
 

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -40,6 +40,15 @@ variable {α β γ : Type*} {ι ι' : Sort*}
 
 /-! ### Inverse image -/
 
+/--
+Given two sets `A` and `B`, `A ↓∩ B` denotes the intersection of `A` and `B` as a set in `Set A`.
+
+The notation is short for `((↑) ⁻¹' B : Set A)`, while giving hints to the elaborator
+that both `A` and `B` are terms of `Set α` for the same `α`.
+This set is the same as `{x : ↑A | ↑x ∈ B}`.
+-/
+notation3 A:67 " ↓∩ " B:67 => (Subtype.val ⁻¹' (B : type_of% A) : Set (A : Set _))
+
 
 section Preimage
 
@@ -165,7 +174,7 @@ theorem preimage_preimage {g : β → γ} {f : α → β} {s : Set γ} :
 #align set.preimage_preimage Set.preimage_preimage
 
 theorem eq_preimage_subtype_val_iff {p : α → Prop} {s : Set (Subtype p)} {t : Set α} :
-    s = Subtype.val ⁻¹' t ↔ ∀ (x) (h : p x), (⟨x, h⟩ : Subtype p) ∈ s ↔ x ∈ t :=
+    s = {x | p x} ↓∩ t ↔ ∀ (x) (h : p x), (⟨x, h⟩ : Subtype p) ∈ s ↔ x ∈ t :=
   ⟨fun s_eq x h => by
     rw [s_eq]
     simp, fun h => ext fun ⟨x, hx⟩ => by simp [h]⟩
@@ -184,7 +193,7 @@ theorem nonempty_of_nonempty_preimage {s : Set β} {f : α → β} (hf : (f ⁻�
 #align set.preimage_singleton_false Set.preimage_singleton_false
 
 theorem preimage_subtype_coe_eq_compl {s u v : Set α} (hsuv : s ⊆ u ∪ v)
-    (H : s ∩ (u ∩ v) = ∅) : ((↑) : s → α) ⁻¹' u = ((↑) ⁻¹' v)ᶜ := by
+    (H : s ∩ (u ∩ v) = ∅) : s ↓∩ u = (s ↓∩ v)ᶜ := by
   ext ⟨x, x_in_s⟩
   constructor
   · intro x_in_u x_in_v
@@ -998,7 +1007,7 @@ theorem range_const : ∀ [Nonempty ι] {c : α}, (range fun _ : ι => c) = {c}
 #align set.range_const Set.range_const
 
 theorem range_subtype_map {p : α → Prop} {q : β → Prop} (f : α → β) (h : ∀ x, p x → q (f x)) :
-    range (Subtype.map f h) = (↑) ⁻¹' (f '' { x | p x }) := by
+    range (Subtype.map f h) = { x | q x } ↓∩ (f '' { x | p x }) := by
   ext ⟨x, hx⟩
   rw [mem_preimage, mem_range, mem_image, Subtype.exists, Subtype.coe_mk]
   apply Iff.intro
@@ -1387,7 +1396,7 @@ theorem range_coe_subtype {p : α → Prop} : range ((↑) : Subtype p → α) =
 #align subtype.range_coe_subtype Subtype.range_coe_subtype
 
 @[simp]
-theorem coe_preimage_self (s : Set α) : ((↑) : s → α) ⁻¹' s = univ := by
+theorem coe_preimage_self (s : Set α) : s ↓∩ s = univ := by
   rw [← preimage_range, range_coe]
 #align subtype.coe_preimage_self Subtype.coe_preimage_self
 
@@ -1405,37 +1414,37 @@ theorem coe_image_univ (s : Set α) : ((↑) : s → α) '' Set.univ = s :=
 #align subtype.coe_image_univ Subtype.coe_image_univ
 
 @[simp]
-theorem image_preimage_coe (s t : Set α) : ((↑) : s → α) '' (((↑) : s → α) ⁻¹' t) = s ∩ t :=
+theorem image_preimage_coe (s t : Set α) : ((↑) : s → α) '' (s ↓∩ t) = s ∩ t :=
   image_preimage_eq_range_inter.trans <| congr_arg (· ∩ t) range_coe
 #align subtype.image_preimage_coe Subtype.image_preimage_coe
 
-theorem image_preimage_val (s t : Set α) : (Subtype.val : s → α) '' (Subtype.val ⁻¹' t) = s ∩ t :=
+theorem image_preimage_val (s t : Set α) : (Subtype.val : s → α) '' (s ↓∩ t) = s ∩ t :=
   image_preimage_coe s t
 #align subtype.image_preimage_val Subtype.image_preimage_val
 
 theorem preimage_coe_eq_preimage_coe_iff {s t u : Set α} :
-    ((↑) : s → α) ⁻¹' t = ((↑) : s → α) ⁻¹' u ↔ s ∩ t = s ∩ u := by
+    s ↓∩ t = s ↓∩ u ↔ s ∩ t = s ∩ u := by
   rw [← image_preimage_coe, ← image_preimage_coe, coe_injective.image_injective.eq_iff]
 #align subtype.preimage_coe_eq_preimage_coe_iff Subtype.preimage_coe_eq_preimage_coe_iff
 
 theorem preimage_coe_self_inter (s t : Set α) :
-    ((↑) : s → α) ⁻¹' (s ∩ t) = ((↑) : s → α) ⁻¹' t := by
+    s ↓∩ (s ∩ t) = s ↓∩ t := by
   rw [preimage_coe_eq_preimage_coe_iff, ← inter_assoc, inter_self]
 
 -- Porting note:
 -- @[simp] `simp` can prove this
 theorem preimage_coe_inter_self (s t : Set α) :
-    ((↑) : s → α) ⁻¹' (t ∩ s) = ((↑) : s → α) ⁻¹' t := by
+    s ↓∩ (t ∩ s) = s ↓∩ t := by
   rw [inter_comm, preimage_coe_self_inter]
 #align subtype.preimage_coe_inter_self Subtype.preimage_coe_inter_self
 
 theorem preimage_val_eq_preimage_val_iff (s t u : Set α) :
-    (Subtype.val : s → α) ⁻¹' t = Subtype.val ⁻¹' u ↔ s ∩ t = s ∩ u :=
+    s ↓∩ t = s ↓∩ u ↔ s ∩ t = s ∩ u :=
   preimage_coe_eq_preimage_coe_iff
 #align subtype.preimage_val_eq_preimage_val_iff Subtype.preimage_val_eq_preimage_val_iff
 
 lemma preimage_val_subset_preimage_val_iff (s t u : Set α) :
-    (Subtype.val ⁻¹' t : Set s) ⊆ Subtype.val ⁻¹' u ↔ s ∩ t ⊆ s ∩ u := by
+    s ↓∩ t ⊆ s ↓∩ u ↔ s ∩ t ⊆ s ∩ u := by
   constructor
   · rw [← image_preimage_coe, ← image_preimage_coe]
     exact image_subset _
@@ -1452,17 +1461,17 @@ theorem forall_set_subtype {t : Set α} (p : Set α → Prop) :
   rw [← forall_subset_range_iff, range_coe]
 
 theorem preimage_coe_nonempty {s t : Set α} :
-    (((↑) : s → α) ⁻¹' t).Nonempty ↔ (s ∩ t).Nonempty := by
+    (s ↓∩ t).Nonempty ↔ (s ∩ t).Nonempty := by
   rw [← image_preimage_coe, image_nonempty]
 #align subtype.preimage_coe_nonempty Subtype.preimage_coe_nonempty
 
-theorem preimage_coe_eq_empty {s t : Set α} : ((↑) : s → α) ⁻¹' t = ∅ ↔ s ∩ t = ∅ := by
+theorem preimage_coe_eq_empty {s t : Set α} : s ↓∩ t = ∅ ↔ s ∩ t = ∅ := by
   simp [← not_nonempty_iff_eq_empty, preimage_coe_nonempty]
 #align subtype.preimage_coe_eq_empty Subtype.preimage_coe_eq_empty
 
 -- Porting note:
 -- @[simp] `simp` can prove this
-theorem preimage_coe_compl (s : Set α) : ((↑) : s → α) ⁻¹' sᶜ = ∅ :=
+theorem preimage_coe_compl (s : Set α) : s ↓∩ sᶜ = ∅ :=
   preimage_coe_eq_empty.2 (inter_compl_self s)
 #align subtype.preimage_coe_compl Subtype.preimage_coe_compl
 

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -174,7 +174,7 @@ theorem preimage_preimage {g : β → γ} {f : α → β} {s : Set γ} :
 #align set.preimage_preimage Set.preimage_preimage
 
 theorem eq_preimage_subtype_val_iff {p : α → Prop} {s : Set (Subtype p)} {t : Set α} :
-    s = _ ↓∩ t ↔ ∀ (x) (h : p x), (⟨x, h⟩ : Subtype p) ∈ s ↔ x ∈ t :=
+    s = Subtype.val ⁻¹' t ↔ ∀ (x) (h : p x), (⟨x, h⟩ : Subtype p) ∈ s ↔ x ∈ t :=
   ⟨fun s_eq x h => by
     rw [s_eq]
     simp, fun h => ext fun ⟨x, hx⟩ => by simp [h]⟩
@@ -1007,7 +1007,7 @@ theorem range_const : ∀ [Nonempty ι] {c : α}, (range fun _ : ι => c) = {c}
 #align set.range_const Set.range_const
 
 theorem range_subtype_map {p : α → Prop} {q : β → Prop} (f : α → β) (h : ∀ x, p x → q (f x)) :
-    range (Subtype.map f h) = _ ↓∩ (f '' { x | p x }) := by
+    range (Subtype.map f h) = (↑) ⁻¹' (f '' { x | p x }) := by
   ext ⟨x, hx⟩
   rw [mem_preimage, mem_range, mem_image, Subtype.exists, Subtype.coe_mk]
   apply Iff.intro

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -174,7 +174,7 @@ theorem preimage_preimage {g : β → γ} {f : α → β} {s : Set γ} :
 #align set.preimage_preimage Set.preimage_preimage
 
 theorem eq_preimage_subtype_val_iff {p : α → Prop} {s : Set (Subtype p)} {t : Set α} :
-    s = {x | p x} ↓∩ t ↔ ∀ (x) (h : p x), (⟨x, h⟩ : Subtype p) ∈ s ↔ x ∈ t :=
+    s = _ ↓∩ t ↔ ∀ (x) (h : p x), (⟨x, h⟩ : Subtype p) ∈ s ↔ x ∈ t :=
   ⟨fun s_eq x h => by
     rw [s_eq]
     simp, fun h => ext fun ⟨x, hx⟩ => by simp [h]⟩
@@ -1007,7 +1007,7 @@ theorem range_const : ∀ [Nonempty ι] {c : α}, (range fun _ : ι => c) = {c}
 #align set.range_const Set.range_const
 
 theorem range_subtype_map {p : α → Prop} {q : β → Prop} (f : α → β) (h : ∀ x, p x → q (f x)) :
-    range (Subtype.map f h) = { x | q x } ↓∩ (f '' { x | p x }) := by
+    range (Subtype.map f h) = _ ↓∩ (f '' { x | p x }) := by
   ext ⟨x, hx⟩
   rw [mem_preimage, mem_range, mem_image, Subtype.exists, Subtype.coe_mk]
   apply Iff.intro

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -590,7 +590,7 @@ theorem Function.Injective.preimage_pullbackDiagonal {f : X → Y} {g : Z → X}
   ext fun _ ↦ inj.eq_iff
 
 theorem image_toPullbackDiag (f : X → Y) (s : Set X) :
-    toPullbackDiag f '' s = pullbackDiagonal f ∩ Subtype.val ⁻¹' s ×ˢ s := by
+    toPullbackDiag f '' s = pullbackDiagonal f ∩ { x | f _ = f _ } ↓∩ s ×ˢ s := by
   ext x
   constructor
   · rintro ⟨x, hx, rfl⟩

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -590,7 +590,7 @@ theorem Function.Injective.preimage_pullbackDiagonal {f : X → Y} {g : Z → X}
   ext fun _ ↦ inj.eq_iff
 
 theorem image_toPullbackDiag (f : X → Y) (s : Set X) :
-    toPullbackDiag f '' s = pullbackDiagonal f ∩ { x | f _ = f _ } ↓∩ s ×ˢ s := by
+    toPullbackDiag f '' s = pullbackDiagonal f ∩ Subtype.val ⁻¹' s ×ˢ s := by
   ext x
   constructor
   · rintro ⟨x, hx, rfl⟩

--- a/Mathlib/Data/Set/Subset.lean
+++ b/Mathlib/Data/Set/Subset.lean
@@ -3,7 +3,6 @@ Copyright (c) 2024 Miguel Marco. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Miguel Marco
 -/
-import Mathlib.Data.Set.Function
 import Mathlib.Data.Set.Functor
 
 /-!
@@ -41,19 +40,6 @@ open Set
 
 variable {ι : Sort*} {α : Type*} {A B C : Set α} {D E : Set A}
 variable {S : Set (Set α)} {T : Set (Set A)} {s : ι → Set α} {t : ι → Set A}
-
-namespace Set.Notation
-
-/--
-Given two sets `A` and `B`, `A ↓∩ B` denotes the intersection of `A` and `B` as a set in `Set A`.
-
-The notation is short for `((↑) ⁻¹' B : Set A)`, while giving hints to the elaborator
-that both `A` and `B` are terms of `Set α` for the same `α`.
-This set is the same as `{x : ↑A | ↑x ∈ B}`.
--/
-scoped notation3 A:67 " ↓∩ " B:67 => (Subtype.val ⁻¹' (B : type_of% A) : Set (A : Set _))
-
-end Set.Notation
 
 namespace Set
 

--- a/Mathlib/MeasureTheory/Constructions/Polish.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish.lean
@@ -579,9 +579,9 @@ if and only if the set is measurable in `Set.range f`. -/
 theorem measurableSet_preimage_iff_preimage_val {f : X → Z}
     [HasCountableSeparatingOn (range f) MeasurableSet univ]
     (hf : Measurable f) {s : Set Z} :
-    MeasurableSet (f ⁻¹' s) ↔ MeasurableSet ((↑) ⁻¹' s : Set (range f)) :=
+    MeasurableSet (f ⁻¹' s) ↔ MeasurableSet (range f ↓∩ s) :=
   have hf' : Measurable (rangeFactorization f) := hf.subtype_mk
-  hf'.measurableSet_preimage_iff_of_surjective (s := Subtype.val ⁻¹' s) surjective_onto_range
+  hf'.measurableSet_preimage_iff_of_surjective (s := range f ↓∩ s) surjective_onto_range
 #align measurable.measurable_set_preimage_iff_preimage_coe Measurable.measurableSet_preimage_iff_preimage_val
 
 /-- If `f : X → Z` is a Borel measurable map from a standard Borel space to a

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -641,7 +641,7 @@ theorem measurable_inclusion {s t : Set α} (h : s ⊆ t) : Measurable (inclusio
   measurable_id.subtype_map h
 
 theorem MeasurableSet.image_inclusion' {s t : Set α} (h : s ⊆ t) {u : Set s}
-    (hs : MeasurableSet (Subtype.val ⁻¹' s : Set t)) (hu : MeasurableSet u) :
+    (hs : MeasurableSet (t ↓∩ s)) (hu : MeasurableSet u) :
     MeasurableSet (inclusion h '' u) := by
   rcases hu with ⟨u, hu, rfl⟩
   convert (measurable_subtype_coe hu).inter hs
@@ -654,8 +654,8 @@ theorem MeasurableSet.image_inclusion {s t : Set α} (h : s ⊆ t) {u : Set s}
   (measurable_subtype_coe hs).image_inclusion' h hu
 
 theorem MeasurableSet.of_union_cover {s t u : Set α} (hs : MeasurableSet s) (ht : MeasurableSet t)
-    (h : univ ⊆ s ∪ t) (hsu : MeasurableSet (((↑) : s → α) ⁻¹' u))
-    (htu : MeasurableSet (((↑) : t → α) ⁻¹' u)) : MeasurableSet u := by
+    (h : univ ⊆ s ∪ t) (hsu : MeasurableSet (s ↓∩ u))
+    (htu : MeasurableSet (t ↓∩ u)) : MeasurableSet u := by
   convert (hs.subtype_image hsu).union (ht.subtype_image htu)
   simp [image_preimage_eq_inter_range, ← inter_union_distrib_left, univ_subset_iff.1 h]
 

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -811,7 +811,7 @@ theorem MeasurableSet.nullMeasurableSet_subtype_coe {t : Set s} (hs : NullMeasur
   rw [Subtype.instMeasurableSpace, comap_eq_generateFrom] at ht
   refine'
     generateFrom_induction (p := fun t : Set s => NullMeasurableSet ((↑) '' t) μ)
-      { t : Set s | ∃ s' : Set α, MeasurableSet s' ∧ (↑) ⁻¹' s' = t } _ _ _ _ ht
+      { t | ∃ s' : Set α, MeasurableSet s' ∧ s ↓∩ s' = t } _ _ _ _ ht
   · rintro t' ⟨s', hs', rfl⟩
     rw [Subtype.image_preimage_coe]
     exact hs.inter (hs'.nullMeasurableSet)
@@ -989,7 +989,7 @@ theorem volume_image_subtype_coe {s : Set α} (hs : MeasurableSet s) (t : Set s)
 
 @[simp]
 theorem volume_preimage_coe (hs : NullMeasurableSet s) (ht : MeasurableSet t) :
-    volume (((↑) : s → α) ⁻¹' t) = volume (t ∩ s) := by
+    volume (s ↓∩ t) = volume (t ∩ s) := by
   rw [volume_set_coe_def,
     comap_apply₀ _ _ Subtype.coe_injective
       (fun h => MeasurableSet.nullMeasurableSet_subtype_coe hs)

--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -202,10 +202,10 @@ alias ⟨_, IsLowerSet.ofDual⟩ := isUpperSet_preimage_toDual_iff
 #align is_lower_set.of_dual IsLowerSet.ofDual
 
 lemma IsUpperSet.isLowerSet_preimage_coe (hs : IsUpperSet s) :
-    IsLowerSet ((↑) ⁻¹' t : Set s) ↔ ∀ b ∈ s, ∀ c ∈ t, b ≤ c → b ∈ t := by aesop
+    IsLowerSet (s ↓∩ t) ↔ ∀ b ∈ s, ∀ c ∈ t, b ≤ c → b ∈ t := by aesop
 
 lemma IsLowerSet.isUpperSet_preimage_coe (hs : IsLowerSet s) :
-    IsUpperSet ((↑) ⁻¹' t : Set s) ↔ ∀ b ∈ s, ∀ c ∈ t, c ≤ b → b ∈ t := by aesop
+    IsUpperSet (s ↓∩ t) ↔ ∀ b ∈ s, ∀ c ∈ t, c ≤ b → b ∈ t := by aesop
 
 lemma IsUpperSet.sdiff (hs : IsUpperSet s) (ht : ∀ b ∈ s, ∀ c ∈ t, b ≤ c → b ∈ t) :
     IsUpperSet (s \ t) :=

--- a/Mathlib/Topology/Bases.lean
+++ b/Mathlib/Topology/Bases.lean
@@ -898,7 +898,7 @@ theorem countable_cover_nhds [SecondCountableTopology α] {f : α → Set α} (h
 
 theorem countable_cover_nhdsWithin [SecondCountableTopology α] {f : α → Set α} {s : Set α}
     (hf : ∀ x ∈ s, f x ∈ 𝓝[s] x) : ∃ t ⊆ s, t.Countable ∧ s ⊆ ⋃ x ∈ t, f x := by
-  have : ∀ x : s, (↑) ⁻¹' f x ∈ 𝓝 x := fun x => preimage_coe_mem_nhds_subtype.2 (hf x x.2)
+  have : ∀ x : s, s ↓∩ f x ∈ 𝓝 x := fun x => preimage_coe_mem_nhds_subtype.2 (hf x x.2)
   rcases countable_cover_nhds this with ⟨t, htc, htU⟩
   refine' ⟨(↑) '' t, Subtype.coe_image_subset _ _, htc.image _, fun x hx => _⟩
   simp only [biUnion_image, eq_univ_iff_forall, ← preimage_iUnion, mem_preimage] at htU ⊢

--- a/Mathlib/Topology/Clopen.lean
+++ b/Mathlib/Topology/Clopen.lean
@@ -149,7 +149,7 @@ theorem continuous_boolIndicator_iff_isClopen (U : Set X) :
 #align continuous_bool_indicator_iff_clopen continuous_boolIndicator_iff_isClopen
 
 theorem continuousOn_boolIndicator_iff_isClopen (s U : Set X) :
-    ContinuousOn U.boolIndicator s ↔ IsClopen (((↑) : s → X) ⁻¹' U) := by
+    ContinuousOn U.boolIndicator s ↔ IsClopen (s ↓∩ U) := by
   rw [continuousOn_iff_continuous_restrict, ← continuous_boolIndicator_iff_isClopen]
   rfl
 #align continuous_on_indicator_iff_clopen continuousOn_boolIndicator_iff_isClopen

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -639,10 +639,10 @@ theorem IsPreconnected.subset_connectedComponent {x : α} {s : Set α} (H1 : IsP
 
 theorem IsPreconnected.subset_connectedComponentIn {x : α} {F : Set α} (hs : IsPreconnected s)
     (hxs : x ∈ s) (hsF : s ⊆ F) : s ⊆ connectedComponentIn F x := by
-  have : IsPreconnected (((↑) : F → α) ⁻¹' s) := by
+  have : IsPreconnected (F ↓∩ s) := by
     refine' inducing_subtype_val.isPreconnected_image.mp _
     rwa [Subtype.image_preimage_coe, inter_eq_right.mpr hsF]
-  have h2xs : (⟨x, hsF hxs⟩ : F) ∈ (↑) ⁻¹' s := by
+  have h2xs : ⟨x, hsF hxs⟩ ∈ F ↓∩ s := by
     rw [mem_preimage]
     exact hxs
   have := this.subset_connectedComponent h2xs

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -1044,7 +1044,7 @@ theorem IsPathConnected.union {U V : Set X} (hU : IsPathConnected U) (hV : IsPat
 /-- If a set `W` is path-connected, then it is also path-connected when seen as a set in a smaller
 ambient type `U` (when `U` contains `W`). -/
 theorem IsPathConnected.preimage_coe {U W : Set X} (hW : IsPathConnected W) (hWU : W ⊆ U) :
-    IsPathConnected (((↑) : U → X) ⁻¹' W) := by
+    IsPathConnected (U ↓∩ W) := by
   rcases hW with ⟨x, x_in, hx⟩
   use ⟨x, hWU x_in⟩, by simp [x_in]
   rintro ⟨y, hyU⟩ hyW
@@ -1307,7 +1307,7 @@ theorem locPathConnected_of_isOpen [LocPathConnectedSpace X] {U : Set X} (h : Is
     rw [(HasBasis.comap ((↑) : U → X) (pathConnected_subset_basis h x_in)).mem_iff]
     constructor
     · rintro ⟨W, ⟨W_in, hW, hWU⟩, hWV⟩
-      exact ⟨Subtype.val ⁻¹' W, ⟨⟨preimage_mem_comap W_in, hW.preimage_coe hWU⟩, hWV⟩⟩
+      exact ⟨U ↓∩ W, ⟨⟨preimage_mem_comap W_in, hW.preimage_coe hWU⟩, hWV⟩⟩
     · rintro ⟨W, ⟨W_in, hW⟩, hWV⟩
       refine'
         ⟨(↑) '' W,

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -225,7 +225,7 @@ variable [TopologicalSpace X]
 The 𝓝 filter and the subspace topology.
 -/
 theorem mem_nhds_subtype (s : Set X) (x : { x // x ∈ s }) (t : Set { x // x ∈ s }) :
-    t ∈ 𝓝 x ↔ ∃ u ∈ 𝓝 (x : X), Subtype.val ⁻¹' u ⊆ t :=
+    t ∈ 𝓝 x ↔ ∃ u ∈ 𝓝 (x : X), s ↓∩ u ⊆ t :=
   mem_nhds_induced _ x t
 #align mem_nhds_subtype mem_nhds_subtype
 
@@ -234,7 +234,7 @@ theorem nhds_subtype (s : Set X) (x : { x // x ∈ s }) : 𝓝 x = comap (↑) (
 #align nhds_subtype nhds_subtype
 
 theorem nhdsWithin_subtype_eq_bot_iff {s t : Set X} {x : s} :
-    𝓝[((↑) : s → X) ⁻¹' t] x = ⊥ ↔ 𝓝[t] (x : X) ⊓ 𝓟 s = ⊥ := by
+    𝓝[s ↓∩ t] x = ⊥ ↔ 𝓝[t] (x : X) ⊓ 𝓟 s = ⊥ := by
   rw [inf_principal_eq_bot_iff_comap, nhdsWithin, nhdsWithin, comap_inf, comap_principal,
     nhds_induced]
 #align nhds_within_subtype_eq_bot_iff nhdsWithin_subtype_eq_bot_iff

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -500,7 +500,7 @@ theorem mem_nhds_subtype_iff_nhdsWithin {s : Set α} {a : s} {t : Set s} :
   rw [← map_nhds_subtype_val, image_mem_map_iff Subtype.val_injective]
 #align mem_nhds_subtype_iff_nhds_within mem_nhds_subtype_iff_nhdsWithin
 
-theorem preimage_coe_mem_nhds_subtype {s t : Set α} {a : s} : (↑) ⁻¹' t ∈ 𝓝 a ↔ t ∈ 𝓝[s] ↑a := by
+theorem preimage_coe_mem_nhds_subtype {s t : Set α} {a : s} : s ↓∩ t ∈ 𝓝 a ↔ t ∈ 𝓝[s] ↑a := by
   rw [← map_nhds_subtype_val, mem_map]
 #align preimage_coe_mem_nhds_subtype preimage_coe_mem_nhds_subtype
 

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -66,8 +66,8 @@ alias ClosedEmbedding.restrictPreimage := Set.restrictPreimage_closedEmbedding
 theorem IsClosedMap.restrictPreimage (H : IsClosedMap f) (s : Set β) :
     IsClosedMap (s.restrictPreimage f) := by
   intro t
-  suffices ∀ u, IsClosed u → Subtype.val ⁻¹' u = t →
-    ∃ v, IsClosed v ∧ Subtype.val ⁻¹' v = s.restrictPreimage f '' t by
+  suffices ∀ u, IsClosed u → (f ⁻¹' s) ↓∩ u = t →
+    ∃ v, IsClosed v ∧ s ↓∩ v = s.restrictPreimage f '' t by
       simpa [isClosed_induced_iff]
   exact fun u hu e => ⟨f '' u, H u hu, by simp [← e, image_restrictPreimage]⟩
 
@@ -78,8 +78,8 @@ theorem Set.restrictPreimage_isClosedMap (s : Set β) (H : IsClosedMap f) :
 theorem IsOpenMap.restrictPreimage (H : IsOpenMap f) (s : Set β) :
     IsOpenMap (s.restrictPreimage f) := by
   intro t
-  suffices ∀ u, IsOpen u → Subtype.val ⁻¹' u = t →
-    ∃ v, IsOpen v ∧ Subtype.val ⁻¹' v = s.restrictPreimage f '' t by
+  suffices ∀ u, IsOpen u → (f ⁻¹' s) ↓∩ u = t →
+    ∃ v, IsOpen v ∧ s ↓∩ v = s.restrictPreimage f '' t by
       simpa [isOpen_induced_iff]
   exact fun u hu e => ⟨f '' u, H u hu, by simp [← e, image_restrictPreimage]⟩
 

--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -641,7 +641,7 @@ noncomputable def piecewise' {C₀ C₁ C₂ : Set X} (h₀ : C₀ ⊆ C₁ ∪ 
     (h₂ : IsClosed C₂) (f₁ : LocallyConstant C₁ Z) (f₂ : LocallyConstant C₂ Z)
     [DecidablePred (· ∈ C₁)] (hf : ∀ x (hx : x ∈ C₁ ∩ C₂), f₁ ⟨x, hx.1⟩ = f₂ ⟨x, hx.2⟩) :
     LocallyConstant C₀ Z :=
-  letI : ∀ j : C₀, Decidable (j ∈ Subtype.val ⁻¹' C₁) := fun j ↦ decidable_of_iff (↑j ∈ C₁) Iff.rfl
+  letI : ∀ j : C₀, Decidable (j ∈ C₀ ↓∩ C₁) := fun j ↦ decidable_of_iff (↑j ∈ C₁) Iff.rfl
   piecewise (h₁.preimage continuous_subtype_val) (h₂.preimage continuous_subtype_val)
     (by simpa [eq_univ_iff_forall] using h₀)
     (f₁.comap ⟨(restrictPreimage C₁ ((↑) : C₀ → X)), continuous_subtype_val.restrictPreimage⟩)
@@ -655,7 +655,7 @@ lemma piecewise'_apply_left {C₀ C₁ C₂ : Set X} (h₀ : C₀ ⊆ C₁ ∪ C
     [DecidablePred (· ∈ C₁)] (hf : ∀ x (hx : x ∈ C₁ ∩ C₂), f₁ ⟨x, hx.1⟩ = f₂ ⟨x, hx.2⟩)
     (x : C₀) (hx : x.val ∈ C₁) :
     piecewise' h₀ h₁ h₂ f₁ f₂ hf x = f₁ ⟨x.val, hx⟩ := by
-  letI : ∀ j : C₀, Decidable (j ∈ Subtype.val ⁻¹' C₁) := fun j ↦ decidable_of_iff (↑j ∈ C₁) Iff.rfl
+  letI : ∀ j : C₀, Decidable (j ∈ C₀ ↓∩ C₁) := fun j ↦ decidable_of_iff (↑j ∈ C₁) Iff.rfl
   rw [piecewise', piecewise_apply_left (f := (f₁.comap
     ⟨(restrictPreimage C₁ ((↑) : C₀ → X)), continuous_subtype_val.restrictPreimage⟩))
     (hx := hx)]
@@ -667,7 +667,7 @@ lemma piecewise'_apply_right {C₀ C₁ C₂ : Set X} (h₀ : C₀ ⊆ C₁ ∪ 
     [DecidablePred (· ∈ C₁)] (hf : ∀ x (hx : x ∈ C₁ ∩ C₂), f₁ ⟨x, hx.1⟩ = f₂ ⟨x, hx.2⟩)
     (x : C₀) (hx : x.val ∈ C₂) :
     piecewise' h₀ h₁ h₂ f₁ f₂ hf x = f₂ ⟨x.val, hx⟩ := by
-  letI : ∀ j : C₀, Decidable (j ∈ Subtype.val ⁻¹' C₁) := fun j ↦ decidable_of_iff (↑j ∈ C₁) Iff.rfl
+  letI : ∀ j : C₀, Decidable (j ∈ C₀ ↓∩ C₁) := fun j ↦ decidable_of_iff (↑j ∈ C₁) Iff.rfl
   rw [piecewise', piecewise_apply_right (f := (f₁.comap
     ⟨(restrictPreimage C₁ ((↑) : C₀ → X)), continuous_subtype_val.restrictPreimage⟩))
     (hx := hx)]

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -2445,14 +2445,14 @@ theorem loc_compact_Haus_tot_disc_of_zero_dim [TotallyDisconnectedSpace H] :
     IsTopologicalBasis { s : Set H | IsClopen s } := by
   refine isTopologicalBasis_of_isOpen_of_nhds (fun u hu => hu.2) fun x U memU hU => ?_
   obtain ⟨s, comp, xs, sU⟩ := exists_compact_subset hU memU
-  let u : Set s := ((↑) : s → H) ⁻¹' interior s
+  let u : Set s := s ↓∩ interior s
   have u_open_in_s : IsOpen u := isOpen_interior.preimage continuous_subtype_val
   lift x to s using interior_subset xs
   haveI : CompactSpace s := isCompact_iff_compactSpace.1 comp
   obtain ⟨V : Set s, VisClopen, Vx, V_sub⟩ := compact_exists_isClopen_in_isOpen u_open_in_s xs
   have VisClopen' : IsClopen (((↑) : s → H) '' V) := by
     refine' ⟨comp.isClosed.closedEmbedding_subtype_val.closed_iff_image_closed.1 VisClopen.1, _⟩
-    let v : Set u := ((↑) : u → s) ⁻¹' V
+    let v : Set u := u ↓∩ V
     have : ((↑) : u → H) = ((↑) : s → H) ∘ ((↑) : u → s) := rfl
     have f0 : Embedding ((↑) : u → H) := embedding_subtype_val.comp embedding_subtype_val
     have f1 : OpenEmbedding ((↑) : u → H) := by

--- a/Mathlib/Topology/Sober.lean
+++ b/Mathlib/Topology/Sober.lean
@@ -224,9 +224,9 @@ theorem quasiSober_of_open_cover (S : Set (Set α)) (hS : ∀ s : S, IsOpen (s :
     rw [hS'']
     trivial
   haveI : QuasiSober U := hS' ⟨U, hU⟩
-  have H : IsPreirreducible ((↑) ⁻¹' t : Set U) :=
+  have H : IsPreirreducible (U ↓∩ t) :=
     h.2.preimage (hS ⟨U, hU⟩).openEmbedding_subtype_val
-  replace H : IsIrreducible ((↑) ⁻¹' t : Set U) := ⟨⟨⟨x, hU'⟩, by simpa using hx⟩, H⟩
+  replace H : IsIrreducible (U ↓∩ t) := ⟨⟨⟨x, hU'⟩, by simpa using hx⟩, H⟩
   use H.genericPoint
   have := continuous_subtype_val.closure_preimage_subset _ H.genericPoint_spec.mem
   rw [h'.closure_eq] at this


### PR DESCRIPTION
---
This is a rough draft of what the new `↓∩` notation would look like within mathlib. I believe this is an improvement in clarity and would like to have `↓∩` as a standard notation (along with `''`, `⁻¹'`, `↑`, etc...). As `↓∩` is specialized for `Set`s, I have only changed `preimage_val` when the left-hand side of `↓∩` is a `Set`.

The introduction of the `↓∩` notation to Data.Set.Image is temporary as it isn't possible to import Data.Set.Subset directly. If we want `↓∩` unscoped, where would be the best place to define it? An option is Data.Set.Defs, but the notation cannot be defined without additional imports as the file does not import `notation3`.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
