### PR TITLE
[Merged by Bors] - feat(Data/Complex/Basic): Adds imaginary number representation

### DIFF
--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -192,8 +192,8 @@ theorem lift_inlAlgHom_eps :
 
 /-- Show DualNumber with values x and y as an "x + y*ε" string -/
 instance instRepr [Repr R] : Repr (DualNumber R) where
-  reprPrec f p := 
-    if p > 65 then 
+  reprPrec f p :=
+    if p > 65 then
       Format.bracket "(" (reprPrec f.fst 65 ++ " + " ++ reprPrec f.snd 81 ++ "*ε") ")"
     else
       reprPrec f.fst 65 ++ " + " ++ reprPrec f.snd 81 ++ "*ε"

--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -192,7 +192,11 @@ theorem lift_inlAlgHom_eps :
 
 /-- Show DualNumber with values x and y as an "x + y*ε" string -/
 instance instRepr [Repr R] : Repr (DualNumber R) where
-  reprPrec f _p := Format.bracket "(" (repr f.fst ++ " + " ++ repr f.snd ++ "*ε") ")"
+  reprPrec f p := 
+    if p > 65 then 
+      Format.bracket "(" (reprPrec f.fst 65 ++ " + " ++ reprPrec f.snd 81 ++ "*ε") ")"
+    else
+      reprPrec f.fst 65 ++ " + " ++ reprPrec f.snd 81 ++ "*ε"
 
 end DualNumber
 

--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -193,10 +193,7 @@ theorem lift_inlAlgHom_eps :
 /-- Show DualNumber with values x and y as an "x + y*ε" string -/
 instance instRepr [Repr R] : Repr (DualNumber R) where
   reprPrec f p :=
-    if p > 65 then
-      Format.bracket "(" (reprPrec f.fst 65 ++ " + " ++ reprPrec f.snd 81 ++ "*ε") ")"
-    else
-      reprPrec f.fst 65 ++ " + " ++ reprPrec f.snd 81 ++ "*ε"
+    (if p > 65 then (Format.bracket "(" . ")") else (·)) <|
+      reprPrec f.fst 65 ++ " + " ++ reprPrec f.snd 70 ++ "*ε"
 
 end DualNumber
-

--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.TrivSqZeroExt
+import Init.Data.Format.Basic
 
 #align_import algebra.dual_number from "leanprover-community/mathlib"@"b8d2eaa69d69ce8f03179a5cda774fc0cde984e4"
 
@@ -56,7 +57,7 @@ scoped[DualNumber] notation "ε" => DualNumber.eps
 @[inherit_doc]
 scoped[DualNumber] postfix:1024 "[ε]" => DualNumber
 
-open DualNumber
+open DualNumber Std
 
 namespace DualNumber
 
@@ -189,4 +190,9 @@ theorem lift_inlAlgHom_eps :
   lift.apply_symm_apply <| AlgHom.id R A[ε]
 #align dual_number.lift_eps DualNumber.lift_inlAlgHom_epsₓ
 
+/-- Show DualNumber with values x and y as an "x + y*ε" string -/
+instance instRepr [Repr R] : Repr (DualNumber R) where
+  reprPrec f _p := Format.bracket "(" (repr f.fst ++ " + " ++ repr f.snd ++ "*ε") ")"
+
 end DualNumber
+

--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.TrivSqZeroExt
-import Init.Data.Format.Basic
 
 #align_import algebra.dual_number from "leanprover-community/mathlib"@"b8d2eaa69d69ce8f03179a5cda774fc0cde984e4"
 
@@ -57,7 +56,7 @@ scoped[DualNumber] notation "ε" => DualNumber.eps
 @[inherit_doc]
 scoped[DualNumber] postfix:1024 "[ε]" => DualNumber
 
-open DualNumber Std
+open DualNumber
 
 namespace DualNumber
 

--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -192,7 +192,7 @@ theorem lift_inlAlgHom_eps :
 /-- Show DualNumber with values x and y as an "x + y*ε" string -/
 instance instRepr [Repr R] : Repr (DualNumber R) where
   reprPrec f p :=
-    (if p > 65 then (Format.bracket "(" . ")") else (·)) <|
+    (if p > 65 then (Std.Format.bracket "(" . ")") else (·)) <|
       reprPrec f.fst 65 ++ " + " ++ reprPrec f.snd 70 ++ "*ε"
 
 end DualNumber

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -948,8 +948,8 @@ Note that the Real numbers used for x and y will show as cauchy sequences due to
 numbers are represented.
 -/
 unsafe instance instRepr : Repr ℂ where
-  reprPrec f p := 
-    if p > 65 then 
+  reprPrec f p :=
+    if p > 65 then
       Format.bracket "(" (reprPrec f.re 65 ++ " + " ++ reprPrec f.im 66 ++ "*I") ")"
     else
       reprPrec f.re 65 ++ " + " ++ reprPrec f.im 66 ++ "*I"

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -8,7 +8,6 @@ import Mathlib.Algebra.GroupPower.Ring
 import Mathlib.Algebra.GroupWithZero.Bitwise
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Set.Image
-import Init.Data.Format.Basic
 
 #align_import data.complex.basic from "leanprover-community/mathlib"@"31c24aa72e7b3e5ed97a8412470e904f82b81004"
 
@@ -20,7 +19,7 @@ of characteristic zero. The result that the complex numbers are algebraically cl
 `FieldTheory.AlgebraicClosure`.
 -/
 
-open Set Function Std
+open Set Function
 
 /-! ### Definition and basic arithmetic -/
 
@@ -949,10 +948,8 @@ numbers are represented.
 -/
 unsafe instance instRepr : Repr ℂ where
   reprPrec f p :=
-    if p > 65 then
-      Format.bracket "(" (reprPrec f.re 65 ++ " + " ++ reprPrec f.im 66 ++ "*I") ")"
-    else
-      reprPrec f.re 65 ++ " + " ++ reprPrec f.im 66 ++ "*I"
+    (if p > 65 then (Format.bracket "(" . ")") else (·)) <|
+      reprPrec f.re 65 ++ " + " ++ reprPrec f.im 70 ++ "*I"
 
 end Complex
 

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.GroupPower.Ring
 import Mathlib.Algebra.GroupWithZero.Bitwise
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Set.Image
+import Init.Data.Format.Basic
 
 #align_import data.complex.basic from "leanprover-community/mathlib"@"31c24aa72e7b3e5ed97a8412470e904f82b81004"
 
@@ -19,7 +20,7 @@ of characteristic zero. The result that the complex numbers are algebraically cl
 `FieldTheory.AlgebraicClosure`.
 -/
 
-open Set Function
+open Set Function Std
 
 /-! ### Definition and basic arithmetic -/
 
@@ -947,7 +948,7 @@ Note that the Real numbers used for x and y will show as cauchy sequences due to
 numbers are represented.
 -/
 unsafe instance instRepr : Repr ℂ where
-  reprPrec f p := Repr.addAppParen (repr f.re ++ " + " ++ repr f.im ++ "*I") p
+  reprPrec f _p := Format.bracket "(" (repr f.re ++ " + " ++ repr f.im ++ "*I") ")"
 
 end Complex
 

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -948,7 +948,11 @@ Note that the Real numbers used for x and y will show as cauchy sequences due to
 numbers are represented.
 -/
 unsafe instance instRepr : Repr ℂ where
-  reprPrec f _p := Format.bracket "(" (repr f.re ++ " + " ++ repr f.im ++ "*I") ")"
+  reprPrec f p := 
+    if p > 65 then 
+      Format.bracket "(" (reprPrec f.re 65 ++ " + " ++ reprPrec f.im 66 ++ "*I") ")"
+    else
+      reprPrec f.re 65 ++ " + " ++ reprPrec f.im 66 ++ "*I"
 
 end Complex
 

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -941,15 +941,13 @@ theorem im_eq_sub_conj (z : ℂ) : (z.im : ℂ) = (z - conj z) / (2 * I) := by
     mul_div_cancel_left₀ _ (mul_ne_zero two_ne_zero I_ne_zero : 2 * I ≠ 0)]
 #align complex.im_eq_sub_conj Complex.im_eq_sub_conj
 
-
 /-- Show the imaginary number ⟨x, y⟩ as an "x + y*I" string
 
 Note that the Real numbers used for x and y will show as cauchy sequences due to the way Real
 numbers are represented.
 -/
-unsafe instance repr : Repr Complex where
-  reprPrec f p := Repr.addAppParen (_root_.repr f.re ++ " + " ++ _root_.repr f.im ++ "*I") p
-#align complex.has_repr Complex.repr
+unsafe instance instRepr : Repr ℂ where
+  reprPrec f p := Repr.addAppParen (repr f.re ++ " + " ++ repr f.im ++ "*I") p
 
 end Complex
 

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -941,6 +941,16 @@ theorem im_eq_sub_conj (z : ℂ) : (z.im : ℂ) = (z - conj z) / (2 * I) := by
     mul_div_cancel_left₀ _ (mul_ne_zero two_ne_zero I_ne_zero : 2 * I ≠ 0)]
 #align complex.im_eq_sub_conj Complex.im_eq_sub_conj
 
+
+/-- Show the imaginary number ⟨x, y⟩ as an "x + y*I" string
+
+Note that the Real numbers used for x and y will show as cauchy sequences due to the way Real
+numbers are represented.
+-/
+unsafe instance repr : Repr Complex where
+  reprPrec f p := Repr.addAppParen (_root_.repr f.re ++ " + " ++ _root_.repr f.im ++ "*I") p
+#align complex.has_repr Complex.repr
+
 end Complex
 
 assert_not_exists Multiset

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -948,7 +948,7 @@ numbers are represented.
 -/
 unsafe instance instRepr : Repr ℂ where
   reprPrec f p :=
-    (if p > 65 then (Format.bracket "(" . ")") else (·)) <|
+    (if p > 65 then (Std.Format.bracket "(" . ")") else (·)) <|
       reprPrec f.re 65 ++ " + " ++ reprPrec f.im 70 ++ "*I"
 
 end Complex

--- a/test/Complex.lean
+++ b/test/Complex.lean
@@ -3,18 +3,22 @@ import Mathlib.Algebra.DualNumber
 
 open DualNumber
 
-private axiom test_sorry : ∀ {α}, α
-unsafe def testRepr (c : ℂ) (s : String) : Lean.Elab.Command.CommandElabM Unit :=
-unless toString (repr c) = s do throwError "got {repr c}"
+/-- info: true -/
+#guard_msgs in
+#eval toString (repr (0 : ℂ)) = "Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I"
 
-unsafe def testDualNumberRepr (c : ℂ[ε]) (s : String) : Lean.Elab.Command.CommandElabM Unit :=
-unless toString (repr c) = s do throwError "got {repr c}"
+/-- info: true -/
+#guard_msgs in
+#eval toString (repr (1 : ℂ)) = "Real.ofCauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I"
 
--- Test base complex number representation
-run_cmd unsafe testRepr 0 "Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I"
-run_cmd unsafe testRepr 1 "Real.ofCauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I"
-run_cmd unsafe testRepr 4 "Real.ofCauchy (sorry /- 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I"
-run_cmd unsafe testRepr Complex.I "Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/)*I"
+/-- info: true -/
+#guard_msgs in
+#eval toString (repr (4 : ℂ)) = "Real.ofCauchy (sorry /- 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I"
 
--- Test whether the parentheses are properly shown around a complex number when required
-run_cmd unsafe testDualNumberRepr (2 : ℂ[ε]) "Real.ofCauchy (sorry /- 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I + (Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I)*ε"
+/-- info: true -/
+#guard_msgs in
+#eval toString (repr (Complex.I : ℂ)) = "Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/)*I"
+
+/-- info: true -/
+#guard_msgs in
+#eval toString (repr (0 : ℂ[ε])) = "Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I + (Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I)*ε"

--- a/test/Complex.lean
+++ b/test/Complex.lean
@@ -1,0 +1,20 @@
+import Mathlib.Data.Complex.Basic
+import Mathlib.Algebra.DualNumber
+
+open DualNumber
+
+private axiom test_sorry : ∀ {α}, α
+unsafe def testRepr (c : ℂ) (s : String) : Lean.Elab.Command.CommandElabM Unit :=
+unless toString (repr c) = s do throwError "got {repr c}"
+
+unsafe def testDualNumberRepr (c : ℂ[ε]) (s : String) : Lean.Elab.Command.CommandElabM Unit :=
+unless toString (repr c) = s do throwError "got {repr c}"
+
+-- Test base complex number representation
+run_cmd unsafe testRepr 0 "Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I"
+run_cmd unsafe testRepr 1 "Real.ofCauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I"
+run_cmd unsafe testRepr 4 "Real.ofCauchy (sorry /- 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I"
+run_cmd unsafe testRepr Complex.I "Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/)*I"
+
+-- Test whether the parentheses are properly shown around a complex number when required
+run_cmd unsafe testDualNumberRepr (2 : ℂ[ε]) "Real.ofCauchy (sorry /- 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I + (Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I)*ε"

--- a/test/Complex.lean
+++ b/test/Complex.lean
@@ -3,22 +3,32 @@ import Mathlib.Algebra.DualNumber
 
 open DualNumber
 
-/-- info: true -/
+/--
+info: Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I
+-/
 #guard_msgs in
-#eval toString (repr (0 : ℂ)) = "Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I"
+#eval (0 : ℂ)
 
-/-- info: true -/
+/--
+info: Real.ofCauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I
+-/
 #guard_msgs in
-#eval toString (repr (1 : ℂ)) = "Real.ofCauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I"
+#eval (1 : ℂ)
 
-/-- info: true -/
+/--
+info: Real.ofCauchy (sorry /- 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I
+-/
 #guard_msgs in
-#eval toString (repr (4 : ℂ)) = "Real.ofCauchy (sorry /- 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I"
+#eval (4 : ℂ)
 
-/-- info: true -/
+/--
+info: Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/)*I
+-/
 #guard_msgs in
-#eval toString (repr (Complex.I : ℂ)) = "Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/)*I"
+#eval (Complex.I : ℂ)
 
-/-- info: true -/
+/--
+info: Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I + (Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I)*ε
+-/
 #guard_msgs in
-#eval toString (repr (0 : ℂ[ε])) = "Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I + (Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) + Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)*I)*ε"
+#eval (0 : ℂ[ε])

--- a/test/DualNumber.lean
+++ b/test/DualNumber.lean
@@ -6,16 +6,13 @@ open DualNumber
 #guard_msgs in
 #eval (0 : ℕ[ε])
 
-
 /-- info: 2 + 0*ε -/
 #guard_msgs in
 #eval (2 : ℕ[ε])
 
-
 /-- info: 6 + 0*ε -/
 #guard_msgs in
 #eval (2 + 4 : ℕ[ε])
-
 
 /-- info: 2 + 0*ε + (0 + 0*ε)*ε -/
 #guard_msgs in

--- a/test/DualNumber.lean
+++ b/test/DualNumber.lean
@@ -1,0 +1,17 @@
+import Mathlib.Algebra.DualNumber
+
+open DualNumber
+
+unsafe def testRepr (c : ℕ[ε]) (s : String) : Lean.Elab.Command.CommandElabM Unit :=
+unless toString (repr c) = s do throwError "got {repr c}"
+
+unsafe def testNestedRepr (c : (ℕ[ε])[ε]) (s : String) : Lean.Elab.Command.CommandElabM Unit :=
+unless toString (repr c) = s do throwError "got {repr c}"
+
+-- Test base dual number representation
+run_cmd unsafe testRepr 0 "0 + 0*ε"
+run_cmd unsafe testRepr 2 "2 + 0*ε"
+run_cmd unsafe testRepr (2 + 4) "6 + 0*ε"
+
+-- Test whether the parentheses are properly shown around a dual number when required
+run_cmd unsafe testNestedRepr (2 : (ℕ[ε])[ε]) "2 + 0*ε + (0 + 0*ε)*ε"

--- a/test/DualNumber.lean
+++ b/test/DualNumber.lean
@@ -2,21 +2,21 @@ import Mathlib.Algebra.DualNumber
 
 open DualNumber
 
-/-- info: true -/
+/-- info: 0 + 0*ε -/
 #guard_msgs in
-#eval toString (repr (0 : ℕ[ε])) = "0 + 0*ε"
+#eval (0 : ℕ[ε])
 
 
-/-- info: true -/
+/-- info: 2 + 0*ε -/
 #guard_msgs in
-#eval toString (repr (2 : ℕ[ε])) = "2 + 0*ε"
+#eval (2 : ℕ[ε])
 
 
-/-- info: true -/
+/-- info: 6 + 0*ε -/
 #guard_msgs in
-#eval toString (repr (2 + 4 : ℕ[ε])) = "6 + 0*ε"
+#eval (2 + 4 : ℕ[ε])
 
 
-/-- info: true -/
+/-- info: 2 + 0*ε + (0 + 0*ε)*ε -/
 #guard_msgs in
-#eval toString (repr (2 : (ℕ[ε])[ε])) = "2 + 0*ε + (0 + 0*ε)*ε"
+#eval (2 : (ℕ[ε])[ε])

--- a/test/DualNumber.lean
+++ b/test/DualNumber.lean
@@ -2,16 +2,21 @@ import Mathlib.Algebra.DualNumber
 
 open DualNumber
 
-unsafe def testRepr (c : ℕ[ε]) (s : String) : Lean.Elab.Command.CommandElabM Unit :=
-unless toString (repr c) = s do throwError "got {repr c}"
+/-- info: true -/
+#guard_msgs in
+#eval toString (repr (0 : ℕ[ε])) = "0 + 0*ε"
 
-unsafe def testNestedRepr (c : (ℕ[ε])[ε]) (s : String) : Lean.Elab.Command.CommandElabM Unit :=
-unless toString (repr c) = s do throwError "got {repr c}"
 
--- Test base dual number representation
-run_cmd unsafe testRepr 0 "0 + 0*ε"
-run_cmd unsafe testRepr 2 "2 + 0*ε"
-run_cmd unsafe testRepr (2 + 4) "6 + 0*ε"
+/-- info: true -/
+#guard_msgs in
+#eval toString (repr (2 : ℕ[ε])) = "2 + 0*ε"
 
--- Test whether the parentheses are properly shown around a dual number when required
-run_cmd unsafe testNestedRepr (2 : (ℕ[ε])[ε]) "2 + 0*ε + (0 + 0*ε)*ε"
+
+/-- info: true -/
+#guard_msgs in
+#eval toString (repr (2 + 4 : ℕ[ε])) = "6 + 0*ε"
+
+
+/-- info: true -/
+#guard_msgs in
+#eval toString (repr (2 : (ℕ[ε])[ε])) = "2 + 0*ε + (0 + 0*ε)*ε"


### PR DESCRIPTION
Adds a representation for Complex numbers and DualNumber so they can be used in #eval statements.


---

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Representing.20Rational.20as.20Float.20.28for.20Complex.20representation.29).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
