### PR TITLE
[Merged by Bors] - feat(Data/Matroid/Dual): change dual notation

### DIFF
--- a/Mathlib/Data/Matroid/Dual.lean
+++ b/Mathlib/Data/Matroid/Dual.lean
@@ -13,18 +13,18 @@ collection of bases of another matroid on `E` called the 'dual' of `M`.
 The map from `M` to its dual is an involution, interacts nicely with minors,
 and preserves many important matroid properties such as representability and connectivity.
 
-This file defines the dual matroid `M﹡` of `M`, and gives associated API. The definition
+This file defines the dual matroid `M✶` of `M`, and gives associated API. The definition
 is in terms of its independent sets, using `IndepMatroid.matroid`.
 
 We also define 'Co-independence' (independence in the dual) of a set as a predicate `M.Coindep X`.
-This is an abbreviation for `M﹡.Indep X`, but has its own name for the sake of dot notation.
+This is an abbreviation for `M✶.Indep X`, but has its own name for the sake of dot notation.
 
 ## Main Definitions
 
-* `M.Dual`, written `M﹡`, is the matroid in which a set `B` is a base if and only if `B ⊆ M.E`
+* `M.Dual`, written `M✶`, is the matroid in which a set `B` is a base if and only if `B ⊆ M.E`
   and `M.E \ B` is a base for `M`.
 
-* `M.Coindep X` means `M﹡.Indep X`, or equivalently that `X` is contained in `M.E \ B` for some
+* `M.Coindep X` means `M✶.Indep X`, or equivalently that `X` is contained in `M.E \ B` for some
   base `B` of `M`.
 -/
 
@@ -115,46 +115,46 @@ section dual
 /-- The dual of a matroid; the bases are the complements (w.r.t `M.E`) of the bases of `M`. -/
 def dual (M : Matroid α) : Matroid α := M.dualIndepMatroid.matroid
 
-/-- The `﹡` symbol, which denotes matroid duality.
+/-- The `✶` symbol, which denotes matroid duality.
   (This is distinct from the usual `*` symbol for multiplication, due to precedence issues. )-/
-postfix:max "﹡" => Matroid.dual
+postfix:max "✶" => Matroid.dual
 
-theorem dual_indep_iff_exists' : (M﹡.Indep I) ↔ I ⊆ M.E ∧ (∃ B, M.Base B ∧ Disjoint I B) := by
+theorem dual_indep_iff_exists' : (M✶.Indep I) ↔ I ⊆ M.E ∧ (∃ B, M.Base B ∧ Disjoint I B) := by
   simp [dual]
 
-@[simp] theorem dual_ground : M﹡.E = M.E := rfl
+@[simp] theorem dual_ground : M✶.E = M.E := rfl
 
 @[simp] theorem dual_indep_iff_exists (hI : I ⊆ M.E := by aesop_mat) :
-    M﹡.Indep I ↔ (∃ B, M.Base B ∧ Disjoint I B) := by
+    M✶.Indep I ↔ (∃ B, M.Base B ∧ Disjoint I B) := by
   rw [dual_indep_iff_exists', and_iff_right hI]
 
-theorem dual_dep_iff_forall : (M﹡.Dep I) ↔ (∀ B, M.Base B → (I ∩ B).Nonempty) ∧ I ⊆ M.E := by
+theorem dual_dep_iff_forall : (M✶.Dep I) ↔ (∀ B, M.Base B → (I ∩ B).Nonempty) ∧ I ⊆ M.E := by
   simp_rw [dep_iff, dual_indep_iff_exists', dual_ground, and_congr_left_iff, not_and,
     not_exists, not_and, not_disjoint_iff_nonempty_inter, imp_iff_right_iff, iff_true_intro Or.inl]
 
-instance dual_finite [M.Finite] : M﹡.Finite :=
+instance dual_finite [M.Finite] : M✶.Finite :=
   ⟨M.ground_finite⟩
 
-instance dual_nonempty [M.Nonempty] : M﹡.Nonempty :=
+instance dual_nonempty [M.Nonempty] : M✶.Nonempty :=
   ⟨M.ground_nonempty⟩
 
-@[simp] theorem dual_base_iff (hB : B ⊆ M.E := by aesop_mat) : M﹡.Base B ↔ M.Base (M.E \ B) := by
+@[simp] theorem dual_base_iff (hB : B ⊆ M.E := by aesop_mat) : M✶.Base B ↔ M.Base (M.E \ B) := by
   rw [base_compl_iff_mem_maximals_disjoint_base, base_iff_maximal_indep, dual_indep_iff_exists',
     mem_maximals_setOf_iff]
   simp [dual_indep_iff_exists']
 
-theorem dual_base_iff' : M﹡.Base B ↔ M.Base (M.E \ B) ∧ B ⊆ M.E :=
+theorem dual_base_iff' : M✶.Base B ↔ M.Base (M.E \ B) ∧ B ⊆ M.E :=
   (em (B ⊆ M.E)).elim (fun h ↦ by rw [dual_base_iff, and_iff_left h])
     (fun h ↦ iff_of_false (h ∘ (fun h' ↦ h'.subset_ground)) (h ∘ And.right))
 
-theorem setOf_dual_base_eq : {B | M﹡.Base B} = (fun X ↦ M.E \ X) '' {B | M.Base B} := by
+theorem setOf_dual_base_eq : {B | M✶.Base B} = (fun X ↦ M.E \ X) '' {B | M.Base B} := by
   ext B
   simp only [mem_setOf_eq, mem_image, dual_base_iff']
   refine' ⟨fun h ↦ ⟨_, h.1, diff_diff_cancel_left h.2⟩,
     fun ⟨B', hB', h⟩ ↦ ⟨_,h.symm.trans_subset (diff_subset _ _)⟩⟩
   rwa [← h, diff_diff_cancel_left hB'.subset_ground]
 
-@[simp] theorem dual_dual (M : Matroid α) : M﹡﹡ = M :=
+@[simp] theorem dual_dual (M : Matroid α) : M✶✶ = M :=
   eq_of_base_iff_base_forall rfl (fun B (h : B ⊆ M.E) ↦
     by rw [dual_base_iff, dual_base_iff, dual_ground, diff_diff_cancel_left h])
 
@@ -163,23 +163,23 @@ theorem dual_involutive : Function.Involutive (dual : Matroid α → Matroid α)
 theorem dual_injective : Function.Injective (dual : Matroid α → Matroid α) :=
   dual_involutive.injective
 
-@[simp] theorem dual_inj {M₁ M₂ : Matroid α} : M₁﹡ = M₂﹡ ↔ M₁ = M₂ :=
+@[simp] theorem dual_inj {M₁ M₂ : Matroid α} : M₁✶ = M₂✶ ↔ M₁ = M₂ :=
   dual_injective.eq_iff
 
-theorem eq_dual_comm {M₁ M₂ : Matroid α} : M₁ = M₂﹡ ↔ M₂ = M₁﹡ := by
+theorem eq_dual_comm {M₁ M₂ : Matroid α} : M₁ = M₂✶ ↔ M₂ = M₁✶ := by
   rw [← dual_inj, dual_dual, eq_comm]
 
-theorem eq_dual_iff_dual_eq {M₁ M₂ : Matroid α} : M₁ = M₂﹡ ↔ M₁﹡ = M₂ :=
+theorem eq_dual_iff_dual_eq {M₁ M₂ : Matroid α} : M₁ = M₂✶ ↔ M₁✶ = M₂ :=
   dual_involutive.eq_iff.symm
 
-theorem Base.compl_base_of_dual (h : M﹡.Base B) : M.Base (M.E \ B) :=
+theorem Base.compl_base_of_dual (h : M✶.Base B) : M.Base (M.E \ B) :=
   (dual_base_iff'.1 h).1
 
-theorem Base.compl_base_dual (h : M.Base B) : M﹡.Base (M.E \ B) := by
+theorem Base.compl_base_dual (h : M.Base B) : M✶.Base (M.E \ B) := by
   rwa [dual_base_iff, diff_diff_cancel_left h.subset_ground]
 
 theorem Base.compl_inter_basis_of_inter_basis (hB : M.Base B) (hBX : M.Basis (B ∩ X) X) :
-    M﹡.Basis ((M.E \ B) ∩ (M.E \ X)) (M.E \ X) := by
+    M✶.Basis ((M.E \ B) ∩ (M.E \ X)) (M.E \ X) := by
   refine' Indep.basis_of_forall_insert _ (inter_subset_right _ _) (fun e he ↦ _)
   · rw [dual_indep_iff_exists]
     exact ⟨B, hB, disjoint_of_subset_left (inter_subset_left _ _) disjoint_sdiff_left⟩
@@ -200,37 +200,37 @@ theorem Base.compl_inter_basis_of_inter_basis (hB : M.Base B) (hBX : M.Basis (B 
   exact hfb.2 (hBX.mem_of_insert_indep (Or.elim (hem.1 hfb.1) (False.elim ∘ hfb.2) id) hi).1
 
 theorem Base.inter_basis_iff_compl_inter_basis_dual (hB : M.Base B) (hX : X ⊆ M.E := by aesop_mat):
-    M.Basis (B ∩ X) X ↔ M﹡.Basis ((M.E \ B) ∩ (M.E \ X)) (M.E \ X) := by
+    M.Basis (B ∩ X) X ↔ M✶.Basis ((M.E \ B) ∩ (M.E \ X)) (M.E \ X) := by
   refine' ⟨hB.compl_inter_basis_of_inter_basis, fun h ↦ _⟩
   simpa [inter_eq_self_of_subset_right hX, inter_eq_self_of_subset_right hB.subset_ground] using
     hB.compl_base_dual.compl_inter_basis_of_inter_basis h
 
 theorem base_iff_dual_base_compl (hB : B ⊆ M.E := by aesop_mat) :
-    M.Base B ↔ M﹡.Base (M.E \ B) := by
+    M.Base B ↔ M✶.Base (M.E \ B) := by
   rw [dual_base_iff, diff_diff_cancel_left hB]
 
-theorem ground_not_base (M : Matroid α) [h : RkPos M﹡] : ¬M.Base M.E := by
+theorem ground_not_base (M : Matroid α) [h : RkPos M✶] : ¬M.Base M.E := by
   rwa [rkPos_iff_empty_not_base, dual_base_iff, diff_empty] at h
 
-theorem Base.ssubset_ground [h : RkPos M﹡] (hB : M.Base B) : B ⊂ M.E :=
+theorem Base.ssubset_ground [h : RkPos M✶] (hB : M.Base B) : B ⊂ M.E :=
   hB.subset_ground.ssubset_of_ne (by rintro rfl; exact M.ground_not_base hB)
 
-theorem Indep.ssubset_ground [h : RkPos M﹡] (hI : M.Indep I) : I ⊂ M.E := by
+theorem Indep.ssubset_ground [h : RkPos M✶] (hI : M.Indep I) : I ⊂ M.E := by
   obtain ⟨B, hB⟩ := hI.exists_base_superset; exact hB.2.trans_ssubset hB.1.ssubset_ground
 
-/-- A coindependent set of `M` is an independent set of the dual of `M﹡`. we give it a separate
+/-- A coindependent set of `M` is an independent set of the dual of `M✶`. we give it a separate
   definition to enable dot notation. Which spelling is better depends on context. -/
-abbrev Coindep (M : Matroid α) (I : Set α) : Prop := M﹡.Indep I
+abbrev Coindep (M : Matroid α) (I : Set α) : Prop := M✶.Indep I
 
-theorem coindep_def : M.Coindep X ↔ M﹡.Indep X := Iff.rfl
+theorem coindep_def : M.Coindep X ↔ M✶.Indep X := Iff.rfl
 
-theorem Coindep.indep (hX : M.Coindep X) : M﹡.Indep X :=
+theorem Coindep.indep (hX : M.Coindep X) : M✶.Indep X :=
   hX
 
-@[simp] theorem dual_coindep_iff : M﹡.Coindep X ↔ M.Indep X := by
+@[simp] theorem dual_coindep_iff : M✶.Coindep X ↔ M.Indep X := by
   rw [Coindep, dual_dual]
 
-theorem Indep.coindep (hI : M.Indep I) : M﹡.Coindep I :=
+theorem Indep.coindep (hI : M.Indep I) : M✶.Coindep I :=
   dual_coindep_iff.2 hI
 
 theorem coindep_iff_exists' : M.Coindep X ↔ (∃ B, M.Base B ∧ B ⊆ M.E \ X) ∧ X ⊆ M.E := by

--- a/Mathlib/Data/Matroid/Restrict.lean
+++ b/Mathlib/Data/Matroid/Restrict.lean
@@ -88,7 +88,7 @@ section restrict
       rw [union_subset_iff, and_iff_left (subset_union_right _ _), union_comm]
       exact hBIB'.trans (union_subset_union_left _ (subset_inter hIY hI.subset_ground))
 
-    have hi : M﹡.Indep (M.E \ (B ∪ (R ∩ M.E))) := by
+    have hi : M✶.Indep (M.E \ (B ∪ (R ∩ M.E))) := by
       rw [dual_indep_iff_exists]
       exact ⟨B, hB, disjoint_of_subset_right (subset_union_left _ _) disjoint_sdiff_left⟩
 


### PR DESCRIPTION
This PR changes the symbol for matroid duality from `﹡` to `✶`. This is because there is a VSCode font rendering bug (discussed [here](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Very.20strange.20VScode.20font.20bug)) that causes `﹡` to display incorrectly when combined with certain other unicode symbols. 

Since the particular star `﹡` is only used for matroid duality in mathlib, this change is cosmetic and inconsequential. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
