### PR TITLE
[Merged by Bors] - feat: generalize `iSup_restrict_spanningSets`

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Typeclasses.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses.lean
@@ -673,27 +673,6 @@ instance (priority := 100) [SigmaFinite μ] : SFinite μ := by
 
 namespace Measure
 
-theorem iSup_restrict_spanningSets [SigmaFinite μ] (hs : MeasurableSet s) :
-    ⨆ i, μ.restrict (spanningSets μ i) s = μ s :=
-  calc
-    ⨆ i, μ.restrict (spanningSets μ i) s = μ.restrict (⋃ i, spanningSets μ i) s :=
-      (restrict_iUnion_apply_eq_iSup (monotone_spanningSets μ).directed_le hs).symm
-    _ = μ s := by rw [iUnion_spanningSets, restrict_univ]
-#align measure_theory.measure.supr_restrict_spanning_sets MeasureTheory.Measure.iSup_restrict_spanningSets
-
-/-- In a σ-finite space, any measurable set of measure `> r` contains a measurable subset of
-finite measure `> r`. -/
-theorem exists_subset_measure_lt_top [SigmaFinite μ] {r : ℝ≥0∞} (hs : MeasurableSet s)
-    (h's : r < μ s) : ∃ t, MeasurableSet t ∧ t ⊆ s ∧ r < μ t ∧ μ t < ∞ := by
-  rw [← iSup_restrict_spanningSets hs,
-    @lt_iSup_iff _ _ _ r fun i : ℕ => μ.restrict (spanningSets μ i) s] at h's
-  rcases h's with ⟨n, hn⟩
-  simp only [restrict_apply hs] at hn
-  refine'
-    ⟨s ∩ spanningSets μ n, hs.inter (measurable_spanningSets _ _), inter_subset_left _ _, hn, _⟩
-  exact (measure_mono (inter_subset_right _ _)).trans_lt (measure_spanningSets_lt_top _ _)
-#align measure_theory.measure.exists_subset_measure_lt_top MeasureTheory.Measure.exists_subset_measure_lt_top
-
 /-- A set in a σ-finite space has zero measure if and only if its intersection with
 all members of the countable family of finite measure spanning sets has zero measure. -/
 theorem forall_measure_inter_spanningSets_eq_zero [MeasurableSpace α] {μ : Measure α}
@@ -942,6 +921,35 @@ theorem restrict_toMeasurable_of_sFinite [SFinite μ] (s : Set α) :
     rw [restrict_apply ht, inter_comm t, measure_toMeasurable_inter_of_sFinite ht,
       restrict_apply ht, inter_comm t]
 #align measure_theory.measure.restrict_to_measurable_of_sigma_finite MeasureTheory.Measure.restrict_toMeasurable_of_sFinite
+
+theorem iSup_restrict_spanningSets_of_measurableSet [SigmaFinite μ] (hs : MeasurableSet s) :
+    ⨆ i, μ.restrict (spanningSets μ i) s = μ s :=
+  calc
+    ⨆ i, μ.restrict (spanningSets μ i) s = μ.restrict (⋃ i, spanningSets μ i) s :=
+      (restrict_iUnion_apply_eq_iSup (monotone_spanningSets μ).directed_le hs).symm
+    _ = μ s := by rw [iUnion_spanningSets, restrict_univ]
+#align measure_theory.measure.supr_restrict_spanning_sets MeasureTheory.Measure.iSup_restrict_spanningSets_of_measurableSet
+
+theorem iSup_restrict_spanningSets [SigmaFinite μ] (s : Set α) :
+    ⨆ i, μ.restrict (spanningSets μ i) s = μ s := by
+  rw [← measure_toMeasurable s,
+    ← iSup_restrict_spanningSets_of_measurableSet (measurableSet_toMeasurable _ _)]
+  simp_rw [restrict_apply' (measurable_spanningSets μ _), Set.inter_comm s,
+    ← restrict_apply (measurable_spanningSets μ _), ← restrict_toMeasurable_of_sFinite s,
+    restrict_apply (measurable_spanningSets μ _), Set.inter_comm _ (toMeasurable μ s)]
+
+/-- In a σ-finite space, any measurable set of measure `> r` contains a measurable subset of
+finite measure `> r`. -/
+theorem exists_subset_measure_lt_top [SigmaFinite μ] {r : ℝ≥0∞} (hs : MeasurableSet s)
+    (h's : r < μ s) : ∃ t, MeasurableSet t ∧ t ⊆ s ∧ r < μ t ∧ μ t < ∞ := by
+  rw [← iSup_restrict_spanningSets,
+    @lt_iSup_iff _ _ _ r fun i : ℕ => μ.restrict (spanningSets μ i) s] at h's
+  rcases h's with ⟨n, hn⟩
+  simp only [restrict_apply hs] at hn
+  refine'
+    ⟨s ∩ spanningSets μ n, hs.inter (measurable_spanningSets _ _), inter_subset_left _ _, hn, _⟩
+  exact (measure_mono (inter_subset_right _ _)).trans_lt (measure_spanningSets_lt_top _ _)
+#align measure_theory.measure.exists_subset_measure_lt_top MeasureTheory.Measure.exists_subset_measure_lt_top
 
 namespace FiniteSpanningSetsIn
 

--- a/Mathlib/MeasureTheory/Measure/Typeclasses.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses.lean
@@ -922,6 +922,7 @@ theorem restrict_toMeasurable_of_sFinite [SFinite μ] (s : Set α) :
       restrict_apply ht, inter_comm t]
 #align measure_theory.measure.restrict_to_measurable_of_sigma_finite MeasureTheory.Measure.restrict_toMeasurable_of_sFinite
 
+/-- Auxiliary lemma for `iSup_restrict_spanningSets`. -/
 theorem iSup_restrict_spanningSets_of_measurableSet [SigmaFinite μ] (hs : MeasurableSet s) :
     ⨆ i, μ.restrict (spanningSets μ i) s = μ s :=
   calc


### PR DESCRIPTION
The measurability assumption was not necessary.
I moved the lemma further down in the file to be able to use `restrict_toMeasurable_of_sFinite`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
