### PR TITLE
[Merged by Bors] - feat(Complex/UpperHalfPlane): add vertical strips

### DIFF
--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -137,6 +137,7 @@ theorem ne_zero (z : ℍ) : (z : ℂ) ≠ 0 :=
   mt (congr_arg Complex.im) z.im_ne_zero
 #align upper_half_plane.ne_zero UpperHalfPlane.ne_zero
 
+/-- Define √-1 as an element on the upper half plane.-/
 def I : ℍ := ⟨Complex.I, by simp⟩
 
 @[simp]

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -137,6 +137,17 @@ theorem ne_zero (z : ℍ) : (z : ℂ) ≠ 0 :=
   mt (congr_arg Complex.im) z.im_ne_zero
 #align upper_half_plane.ne_zero UpperHalfPlane.ne_zero
 
+def I : ℍ := ⟨Complex.I, by simp⟩
+
+@[simp]
+lemma I_im : I.im = 1 := rfl
+
+@[simp]
+lemma I_re : I.re = 0 := rfl
+
+@[simp, norm_cast]
+lemma coe_I : I = Complex.I := rfl
+
 end UpperHalfPlane
 
 namespace Mathlib.Meta.Positivity

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -137,7 +137,7 @@ theorem ne_zero (z : ℍ) : (z : ℂ) ≠ 0 :=
   mt (congr_arg Complex.im) z.im_ne_zero
 #align upper_half_plane.ne_zero UpperHalfPlane.ne_zero
 
-/-- Define √-1 as an element on the upper half plane.-/
+/-- Define I := √-1 as an element on the upper half plane. -/
 def I : ℍ := ⟨Complex.I, by simp⟩
 
 @[simp]

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
@@ -385,22 +385,4 @@ instance : IsometricSMul SL(2, ℝ) ℍ :=
       exact
         (isometry_real_vadd w).comp (h₀.comp <| (isometry_real_vadd v).comp <| isometry_pos_mul u)⟩
 
-section slices
-
-/-- The vertical strip of width A and height B. -/
-def verticalStrip (A B : ℝ) := {z : ℍ | |z.re| ≤ A ∧ B ≤ z.im}
-
-theorem slice_mem_iff (A B : ℝ) (z : ℍ) : z ∈ verticalStrip A B ↔ |z.re| ≤ A ∧ B ≤ z.im :=
-  Iff.rfl
-
-lemma subset_slice_of_isCompact {K : Set ℍ} (hK : IsCompact K) :
-    ∃ A B : ℝ, 0 < B ∧ K ⊆ verticalStrip A B := by
-  rcases K.eq_empty_or_nonempty with rfl | hne
-  · exact ⟨1, 1, Real.zero_lt_one, empty_subset _⟩
-  obtain ⟨u, _, hu⟩ := hK.exists_isMinOn hne continuous_im.continuousOn
-  obtain ⟨v, _, hv⟩ := hK.exists_isMaxOn hne (_root_.continuous_abs.comp continuous_re).continuousOn
-  exact ⟨|re v|, im u, u.im_pos, fun k hk ↦ ⟨isMaxOn_iff.mp hv _ hk, isMinOn_iff.mp hu _ hk⟩⟩
-
-end slices
-
 end UpperHalfPlane

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
@@ -385,4 +385,22 @@ instance : IsometricSMul SL(2, ℝ) ℍ :=
       exact
         (isometry_real_vadd w).comp (h₀.comp <| (isometry_real_vadd v).comp <| isometry_pos_mul u)⟩
 
+section slices
+
+/-- The vertical strip of width A and height B. -/
+def verticalStrip (A B : ℝ) := {z : ℍ | |z.re| ≤ A ∧ B ≤ z.im}
+
+theorem slice_mem_iff (A B : ℝ) (z : ℍ) : z ∈ verticalStrip A B ↔ |z.re| ≤ A ∧ B ≤ z.im :=
+  Iff.rfl
+
+lemma subset_slice_of_isCompact {K : Set ℍ} (hK : IsCompact K) :
+    ∃ A B : ℝ, 0 < B ∧ K ⊆ verticalStrip A B := by
+  rcases K.eq_empty_or_nonempty with rfl | hne
+  · exact ⟨1, 1, Real.zero_lt_one, empty_subset _⟩
+  obtain ⟨u, _, hu⟩ := hK.exists_isMinOn hne continuous_im.continuousOn
+  obtain ⟨v, _, hv⟩ := hK.exists_isMaxOn hne (_root_.continuous_abs.comp continuous_re).continuousOn
+  exact ⟨|re v|, im u, u.im_pos, fun k hk ↦ ⟨isMaxOn_iff.mp hv _ hk, isMinOn_iff.mp hu _ hk⟩⟩
+
+end slices
+
 end UpperHalfPlane

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -74,15 +74,15 @@ instance : NoncompactSpace ℍ := by
 instance : LocallyCompactSpace ℍ :=
   openEmbedding_coe.locallyCompactSpace
 
-section slices
+section strips
 
 /-- The vertical strip of width A and height B. -/
 def verticalStrip (A B : ℝ) := {z : ℍ | |z.re| ≤ A ∧ B ≤ z.im}
 
-theorem slice_mem_iff (A B : ℝ) (z : ℍ) : z ∈ verticalStrip A B ↔ |z.re| ≤ A ∧ B ≤ z.im :=
+theorem strip_mem_iff (A B : ℝ) (z : ℍ) : z ∈ verticalStrip A B ↔ |z.re| ≤ A ∧ B ≤ z.im :=
   Iff.rfl
 
-lemma subset_slice_of_isCompact {K : Set ℍ} (hK : IsCompact K) :
+lemma subset_strip_of_isCompact {K : Set ℍ} (hK : IsCompact K) :
     ∃ A B : ℝ, 0 < B ∧ K ⊆ verticalStrip A B := by
   rcases K.eq_empty_or_nonempty with rfl | hne
   · exact ⟨1, 1, Real.zero_lt_one, empty_subset _⟩
@@ -90,6 +90,6 @@ lemma subset_slice_of_isCompact {K : Set ℍ} (hK : IsCompact K) :
   obtain ⟨v, _, hv⟩ := hK.exists_isMaxOn hne (_root_.continuous_abs.comp continuous_re).continuousOn
   exact ⟨|re v|, im u, u.im_pos, fun k hk ↦ ⟨isMaxOn_iff.mp hv _ hk, isMinOn_iff.mp hu _ hk⟩⟩
 
-end slices
+end strips
 
 end UpperHalfPlane

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -74,4 +74,22 @@ instance : NoncompactSpace ℍ := by
 instance : LocallyCompactSpace ℍ :=
   openEmbedding_coe.locallyCompactSpace
 
+section slices
+
+/-- The vertical strip of width A and height B. -/
+def verticalStrip (A B : ℝ) := {z : ℍ | |z.re| ≤ A ∧ B ≤ z.im}
+
+theorem slice_mem_iff (A B : ℝ) (z : ℍ) : z ∈ verticalStrip A B ↔ |z.re| ≤ A ∧ B ≤ z.im :=
+  Iff.rfl
+
+lemma subset_slice_of_isCompact {K : Set ℍ} (hK : IsCompact K) :
+    ∃ A B : ℝ, 0 < B ∧ K ⊆ verticalStrip A B := by
+  rcases K.eq_empty_or_nonempty with rfl | hne
+  · exact ⟨1, 1, Real.zero_lt_one, empty_subset _⟩
+  obtain ⟨u, _, hu⟩ := hK.exists_isMinOn hne continuous_im.continuousOn
+  obtain ⟨v, _, hv⟩ := hK.exists_isMaxOn hne (_root_.continuous_abs.comp continuous_re).continuousOn
+  exact ⟨|re v|, im u, u.im_pos, fun k hk ↦ ⟨isMaxOn_iff.mp hv _ hk, isMinOn_iff.mp hu _ hk⟩⟩
+
+end slices
+
 end UpperHalfPlane

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -80,10 +80,10 @@ section strips
 value less than or equal to `A` and imaginary part is at least `B`. -/
 def verticalStrip (A B : ℝ) := {z : ℍ | |z.re| ≤ A ∧ B ≤ z.im}
 
-theorem strip_mem_iff (A B : ℝ) (z : ℍ) : z ∈ verticalStrip A B ↔ |z.re| ≤ A ∧ B ≤ z.im :=
+theorem mem_verticalStrip_iff (A B : ℝ) (z : ℍ) : z ∈ verticalStrip A B ↔ |z.re| ≤ A ∧ B ≤ z.im :=
   Iff.rfl
 
-lemma subset_strip_of_isCompact {K : Set ℍ} (hK : IsCompact K) :
+lemma subset_verticalStrip_of_isCompact {K : Set ℍ} (hK : IsCompact K) :
     ∃ A B : ℝ, 0 < B ∧ K ⊆ verticalStrip A B := by
   rcases K.eq_empty_or_nonempty with rfl | hne
   · exact ⟨1, 1, Real.zero_lt_one, empty_subset _⟩

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -77,7 +77,7 @@ instance : LocallyCompactSpace ℍ :=
 section strips
 
 /-- The vertical strip of width `A` and height `B`, defined by elements whose real part has absolute
-value less than `A` and the imaginary part is at least `B`. -/
+value less than or equal to `A` and imaginary part is at least `B`. -/
 def verticalStrip (A B : ℝ) := {z : ℍ | |z.re| ≤ A ∧ B ≤ z.im}
 
 theorem strip_mem_iff (A B : ℝ) (z : ℍ) : z ∈ verticalStrip A B ↔ |z.re| ≤ A ∧ B ≤ z.im :=
@@ -87,9 +87,9 @@ lemma subset_strip_of_isCompact {K : Set ℍ} (hK : IsCompact K) :
     ∃ A B : ℝ, 0 < B ∧ K ⊆ verticalStrip A B := by
   rcases K.eq_empty_or_nonempty with rfl | hne
   · exact ⟨1, 1, Real.zero_lt_one, empty_subset _⟩
-  obtain ⟨u, _, hu⟩ := hK.exists_isMinOn hne continuous_im.continuousOn
-  obtain ⟨v, _, hv⟩ := hK.exists_isMaxOn hne (_root_.continuous_abs.comp continuous_re).continuousOn
-  exact ⟨|re v|, im u, u.im_pos, fun k hk ↦ ⟨isMaxOn_iff.mp hv _ hk, isMinOn_iff.mp hu _ hk⟩⟩
+  obtain ⟨v, _, hv⟩ := hK.exists_isMinOn hne continuous_im.continuousOn
+  obtain ⟨u, _, hu⟩ := hK.exists_isMaxOn hne (_root_.continuous_abs.comp continuous_re).continuousOn
+  exact ⟨|re u|, im v, v.im_pos, fun k hk ↦ ⟨isMaxOn_iff.mp hu _ hk, isMinOn_iff.mp hv _ hk⟩⟩
 
 end strips
 

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -87,8 +87,8 @@ lemma subset_strip_of_isCompact {K : Set ℍ} (hK : IsCompact K) :
     ∃ A B : ℝ, 0 < B ∧ K ⊆ verticalStrip A B := by
   rcases K.eq_empty_or_nonempty with rfl | hne
   · exact ⟨1, 1, Real.zero_lt_one, empty_subset _⟩
-  obtain ⟨v, _, hv⟩ := hK.exists_isMinOn hne continuous_im.continuousOn
   obtain ⟨u, _, hu⟩ := hK.exists_isMaxOn hne (_root_.continuous_abs.comp continuous_re).continuousOn
+  obtain ⟨v, _, hv⟩ := hK.exists_isMinOn hne continuous_im.continuousOn
   exact ⟨|re u|, im v, v.im_pos, fun k hk ↦ ⟨isMaxOn_iff.mp hu _ hk, isMinOn_iff.mp hv _ hk⟩⟩
 
 end strips

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -76,7 +76,8 @@ instance : LocallyCompactSpace ℍ :=
 
 section strips
 
-/-- The vertical strip of width A and height B. -/
+/-- The vertical strip of width `A` and height `B`, defined by elements whose real part has absolute
+value less than `A` and the imaginary part is at least `B`. -/
 def verticalStrip (A B : ℝ) := {z : ℍ | |z.re| ≤ A ∧ B ≤ z.im}
 
 theorem strip_mem_iff (A B : ℝ) (z : ℍ) : z ∈ verticalStrip A B ↔ |z.re| ≤ A ∧ B ≤ z.im :=


### PR DESCRIPTION
We define the vertical strips that are needed for proving Eisenstein series are modular forms #10377 . We also add the definition of sqrt{-1} as an elements of the upper half plane. Note that this is no longer needed for the modular forms PRs but its good to have.

Sorry about the typo in the PR name, its not my day!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
