### PR TITLE
[Merged by Bors] - feat: continuity of measure without monotonicity assumptions

### DIFF
--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -596,7 +596,7 @@ theorem tendsto_measure_iUnion [Preorder ι] [IsDirected ι (· ≤ ·)] [Counta
 /-- Continuity from below: the measure of the union of a sequence of (not necessarily measurable)
 sets is the limit of the measures of the partial unions. -/
 theorem tendsto_measure_iUnion' [Countable ι] [Preorder ι] [IsDirected ι (· ≤ ·)] {f : ι → Set α} :
-    Tendsto (fun i ↦ μ (⋃ j ∈ {j | j ≤ i}, f j)) atTop (𝓝 (μ (⋃ i, f i))) := by
+    Tendsto (fun i ↦ μ (⋃ j ≤ i, f j)) atTop (𝓝 (μ (⋃ i, f i))) := by
   rw [measure_iUnion_eq_iSup' (· ≤ ·) transitive_le]
   exact tendsto_atTop_iSup
     fun i j hij ↦ measure_mono <| biUnion_subset_biUnion_left fun k hki ↦ le_trans hki hij
@@ -614,7 +614,7 @@ theorem tendsto_measure_iInter [Countable ι] [Preorder ι] [IsDirected ι (· �
 sets such that one has finite measure is the limit of the measures of the partial intersections. -/
 theorem tendsto_measure_iInter' [Countable ι] [Preorder ι] [IsDirected ι (· ≤ ·)]
     {f : ι → Set α} (hm : ∀ i, MeasurableSet (f i)) (hf : ∃ i, μ (f i) ≠ ∞) :
-    Tendsto (fun i ↦ μ (⋂ j ∈ {j | j ≤ i}, f j)) atTop (𝓝 (μ (⋂ i, f i))) := by
+    Tendsto (fun i ↦ μ (⋂ j ≤ i, f j)) atTop (𝓝 (μ (⋂ i, f i))) := by
   rw [measure_iInter_eq_iInf' (· ≤ ·) transitive_le hm hf]
   exact tendsto_atTop_iInf
     fun i j hij ↦ measure_mono <| biInter_subset_biInter_left fun k hki ↦ le_trans hki hij

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -513,6 +513,24 @@ theorem measure_iUnion_eq_iSup [Countable ι] {s : ι → Set α} (hd : Directed
         _ ≤ ⨆ n, μ (t n) := le_iSup (μ ∘ t) N
 #align measure_theory.measure_Union_eq_supr MeasureTheory.measure_iUnion_eq_iSup
 
+/-- Continuity from below: the measure of the union of a sequence of
+(not necessarily measurable) sets is the supremum of the measures of the partial unions. -/
+theorem measure_iUnion_eq_iSup' (r : ι → ι → Prop) (r_trans : Transitive r) [Countable ι]
+    [IsDirected ι r] {f : ι → Set α} :
+    μ (⋃ i, f i) = ⨆ i, μ (⋃ j ∈ {j | r j i}, f j) := by
+  let s := fun i ↦ ⋃ j ∈ {j | r j i}, f j
+  have iUnion_eq : ⋃ i, f i = ⋃ i, s i := by
+    refine' le_antisymm (iUnion_subset <| fun i ↦ _)
+      (iUnion_subset <| biUnion_univ f ▸ fun i ↦ biUnion_subset_biUnion_left <| subset_univ _)
+    rcases directed_of r i i with ⟨j, hj, -⟩
+    exact subset_iUnion_of_subset j <| le_biSup f hj
+  have hd : Directed (· ⊆ ·) s := by
+    intro i j
+    rcases directed_of r i j with ⟨k, rik, rjk⟩
+    exact ⟨k, biUnion_subset_biUnion_left fun l rli ↦ r_trans rli rik,
+      biUnion_subset_biUnion_left fun l rlj ↦ r_trans rlj rjk⟩
+  exact iUnion_eq ▸ measure_iUnion_eq_iSup hd
+
 theorem measure_biUnion_eq_iSup {s : ι → Set α} {t : Set ι} (ht : t.Countable)
     (hd : DirectedOn ((· ⊆ ·) on s) t) : μ (⋃ i ∈ t, s i) = ⨆ i ∈ t, μ (s i) := by
   haveI := ht.toEncodable
@@ -542,6 +560,31 @@ theorem measure_iInter_eq_iInf [Countable ι] {s : ι → Set α} (h : ∀ i, Me
   · exact hd.mono_comp _ fun _ _ => diff_subset_diff_right
 #align measure_theory.measure_Inter_eq_infi MeasureTheory.measure_iInter_eq_iInf
 
+/-- Continuity from above: the measure of the intersection of a sequence of
+measurable sets is the infimum of the measures of the partial intersections. -/
+theorem measure_iInter_eq_iInf' (r : ι → ι → Prop) (r_trans : Transitive r) [Countable ι]
+    [IsDirected ι r] {f : ι → Set α} (hm : ∀ i, MeasurableSet (f i)) (hf : ∃ i, μ (f i) ≠ ∞) :
+    μ (⋂ i, f i) = ⨅ i, μ (⋂ j ∈ {j | r j i}, f j) := by
+  let s := fun i ↦ ⋂ j ∈ {j | r j i}, f j
+  have iInter_eq : ⋂ i, f i = ⋂ i, s i := by
+    ext x; simp [s]; constructor
+    · exact fun h _ j _ ↦ h j
+    · intro h i
+      rcases directed_of r i i with ⟨j, rij, -⟩
+      exact h j i rij
+  have ms : ∀ i, MeasurableSet (s i) :=
+    fun i ↦ MeasurableSet.biInter (countable_univ.mono <| subset_univ _) fun i _ ↦ hm i
+  have hd : Directed (· ⊇ ·) s := by
+    intro i j
+    rcases directed_of r i j with ⟨k, rik, rjk⟩
+    exact ⟨k, biInter_subset_biInter_left fun j rji ↦ r_trans rji rik,
+      biInter_subset_biInter_left fun i rij ↦ r_trans rij rjk⟩
+  have hfin' : ∃ i, μ (s i) ≠ ∞ := by
+    rcases hf with ⟨i, hi⟩
+    rcases directed_of r i i with ⟨j, rij, -⟩
+    exact ⟨j, ne_top_of_le_ne_top hi <| measure_mono <| biInter_subset_of_mem rij⟩
+  exact iInter_eq ▸ measure_iInter_eq_iInf ms hd hfin'
+
 /-- Continuity from below: the measure of the union of an increasing sequence of measurable sets
 is the limit of the measures. -/
 theorem tendsto_measure_iUnion [Preorder ι] [IsDirected ι (· ≤ ·)] [Countable ι]
@@ -549,6 +592,14 @@ theorem tendsto_measure_iUnion [Preorder ι] [IsDirected ι (· ≤ ·)] [Counta
   rw [measure_iUnion_eq_iSup hm.directed_le]
   exact tendsto_atTop_iSup fun n m hnm => measure_mono <| hm hnm
 #align measure_theory.tendsto_measure_Union MeasureTheory.tendsto_measure_iUnion
+
+/-- Continuity from below: the measure of the union of a sequence of (not necessarily measurable)
+sets is the limit of the measures of the partial unions. -/
+theorem tendsto_measure_iUnion' [Countable ι] [Preorder ι] [IsDirected ι (· ≤ ·)] {f : ι → Set α} :
+    Tendsto (fun i ↦ μ (⋃ j ∈ {j | j ≤ i}, f j)) atTop (𝓝 (μ (⋃ i, f i))) := by
+  rw [measure_iUnion_eq_iSup' (· ≤ ·) transitive_le]
+  exact tendsto_atTop_iSup
+    fun i j hij ↦ measure_mono <| biUnion_subset_biUnion_left fun k hki ↦ le_trans hki hij
 
 /-- Continuity from above: the measure of the intersection of a decreasing sequence of measurable
 sets is the limit of the measures. -/
@@ -558,6 +609,15 @@ theorem tendsto_measure_iInter [Countable ι] [Preorder ι] [IsDirected ι (· �
   rw [measure_iInter_eq_iInf hs hm.directed_ge hf]
   exact tendsto_atTop_iInf fun n m hnm => measure_mono <| hm hnm
 #align measure_theory.tendsto_measure_Inter MeasureTheory.tendsto_measure_iInter
+
+/-- Continuity from above: the measure of the intersection of a sequence of measurable
+sets such that one has finite measure is the limit of the measures of the partial intersections. -/
+theorem tendsto_measure_iInter' [Countable ι] [Preorder ι] [IsDirected ι (· ≤ ·)]
+    {f : ι → Set α} (hm : ∀ i, MeasurableSet (f i)) (hf : ∃ i, μ (f i) ≠ ∞) :
+    Tendsto (fun i ↦ μ (⋂ j ∈ {j | j ≤ i}, f j)) atTop (𝓝 (μ (⋂ i, f i))) := by
+  rw [measure_iInter_eq_iInf' (· ≤ ·) transitive_le hm hf]
+  exact tendsto_atTop_iInf
+    fun i j hij ↦ measure_mono <| biInter_subset_biInter_left fun k hki ↦ le_trans hki hij
 
 /-- The measure of the intersection of a decreasing sequence of measurable
 sets indexed by a linear order with first countable topology is the limit of the measures. -/

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -585,8 +585,8 @@ theorem measure_iInter_eq_iInf' (r : ι → ι → Prop) (r_trans : Transitive r
     exact ⟨j, ne_top_of_le_ne_top hi <| measure_mono <| biInter_subset_of_mem rij⟩
   exact iInter_eq ▸ measure_iInter_eq_iInf ms hd hfin'
 
-/-- Continuity from below: the measure of the union of an increasing sequence of measurable sets
-is the limit of the measures. -/
+/-- Continuity from below: the measure of the union of an increasing sequence of (not necessarily
+measurable) sets is the limit of the measures. -/
 theorem tendsto_measure_iUnion [Preorder ι] [IsDirected ι (· ≤ ·)] [Countable ι]
     {s : ι → Set α} (hm : Monotone s) : Tendsto (μ ∘ s) atTop (𝓝 (μ (⋃ n, s n))) := by
   rw [measure_iUnion_eq_iSup hm.directed_le]

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -520,7 +520,7 @@ theorem measure_iUnion_eq_iSup' (r : ι → ι → Prop) (r_trans : Transitive r
     μ (⋃ i, f i) = ⨆ i, μ (⋃ j ∈ {j | r j i}, f j) := by
   let s := fun i ↦ ⋃ j ∈ {j | r j i}, f j
   have iUnion_eq : ⋃ i, f i = ⋃ i, s i := by
-    refine' le_antisymm (iUnion_subset <| fun i ↦ _)
+    refine le_antisymm (iUnion_subset <| fun i ↦ ?_)
       (iUnion_subset <| biUnion_univ f ▸ fun i ↦ biUnion_subset_biUnion_left <| subset_univ _)
     rcases directed_of r i i with ⟨j, hj, -⟩
     exact subset_iUnion_of_subset j <| le_biSup f hj

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -515,21 +515,16 @@ theorem measure_iUnion_eq_iSup [Countable ι] {s : ι → Set α} (hd : Directed
 
 /-- Continuity from below: the measure of the union of a sequence of
 (not necessarily measurable) sets is the supremum of the measures of the partial unions. -/
-theorem measure_iUnion_eq_iSup' (r : ι → ι → Prop) (r_trans : Transitive r) [Countable ι]
-    [IsDirected ι r] {f : ι → Set α} :
-    μ (⋃ i, f i) = ⨆ i, μ (⋃ j ∈ {j | r j i}, f j) := by
-  let s := fun i ↦ ⋃ j ∈ {j | r j i}, f j
-  have iUnion_eq : ⋃ i, f i = ⋃ i, s i := by
-    refine le_antisymm (iUnion_subset <| fun i ↦ ?_)
-      (iUnion_subset <| biUnion_univ f ▸ fun i ↦ biUnion_subset_biUnion_left <| subset_univ _)
-    rcases directed_of r i i with ⟨j, hj, -⟩
-    exact subset_iUnion_of_subset j <| le_biSup f hj
-  have hd : Directed (· ⊆ ·) s := by
+theorem measure_iUnion_eq_iSup' {α ι : Type*} [MeasurableSpace α] {μ : Measure α}
+    [Countable ι] [Preorder ι] [IsDirected ι (· ≤ ·)]
+    {f : ι → Set α} : μ (⋃ i, f i) = ⨆ i, μ (Accumulate f i) := by
+  have hd : Directed (· ⊆ ·) (Accumulate f) := by
     intro i j
-    rcases directed_of r i j with ⟨k, rik, rjk⟩
-    exact ⟨k, biUnion_subset_biUnion_left fun l rli ↦ r_trans rli rik,
-      biUnion_subset_biUnion_left fun l rlj ↦ r_trans rlj rjk⟩
-  exact iUnion_eq ▸ measure_iUnion_eq_iSup hd
+    rcases directed_of (· ≤ ·) i j with ⟨k, rik, rjk⟩
+    exact ⟨k, biUnion_subset_biUnion_left fun l rli ↦ le_trans rli rik,
+      biUnion_subset_biUnion_left fun l rlj ↦ le_trans rlj rjk⟩
+  rw [← iUnion_accumulate]
+  exact measure_iUnion_eq_iSup hd
 
 theorem measure_biUnion_eq_iSup {s : ι → Set α} {t : Set ι} (ht : t.Countable)
     (hd : DirectedOn ((· ⊆ ·) on s) t) : μ (⋃ i ∈ t, s i) = ⨆ i ∈ t, μ (s i) := by
@@ -562,26 +557,27 @@ theorem measure_iInter_eq_iInf [Countable ι] {s : ι → Set α} (h : ∀ i, Me
 
 /-- Continuity from above: the measure of the intersection of a sequence of
 measurable sets is the infimum of the measures of the partial intersections. -/
-theorem measure_iInter_eq_iInf' (r : ι → ι → Prop) (r_trans : Transitive r) [Countable ι]
-    [IsDirected ι r] {f : ι → Set α} (hm : ∀ i, MeasurableSet (f i)) (hf : ∃ i, μ (f i) ≠ ∞) :
-    μ (⋂ i, f i) = ⨅ i, μ (⋂ j ∈ {j | r j i}, f j) := by
-  let s := fun i ↦ ⋂ j ∈ {j | r j i}, f j
+theorem measure_iInter_eq_iInf' {α ι : Type*} [MeasurableSpace α] {μ : Measure α}
+    [Countable ι] [Preorder ι] [IsDirected ι (· ≤ ·)]
+    {f : ι → Set α} (h : ∀ i, MeasurableSet (f i)) (hfin : ∃ i, μ (f i) ≠ ∞) :
+    μ (⋂ i, f i) = ⨅ i, μ (⋂ j ≤ i, f j) := by
+  let s := fun i ↦ ⋂ j ≤ i, f j
   have iInter_eq : ⋂ i, f i = ⋂ i, s i := by
     ext x; simp [s]; constructor
     · exact fun h _ j _ ↦ h j
     · intro h i
-      rcases directed_of r i i with ⟨j, rij, -⟩
+      rcases directed_of (· ≤ ·) i i with ⟨j, rij, -⟩
       exact h j i rij
   have ms : ∀ i, MeasurableSet (s i) :=
-    fun i ↦ MeasurableSet.biInter (countable_univ.mono <| subset_univ _) fun i _ ↦ hm i
+    fun i ↦ MeasurableSet.biInter (countable_univ.mono <| subset_univ _) fun i _ ↦ h i
   have hd : Directed (· ⊇ ·) s := by
     intro i j
-    rcases directed_of r i j with ⟨k, rik, rjk⟩
-    exact ⟨k, biInter_subset_biInter_left fun j rji ↦ r_trans rji rik,
-      biInter_subset_biInter_left fun i rij ↦ r_trans rij rjk⟩
+    rcases directed_of (· ≤ ·) i j with ⟨k, rik, rjk⟩
+    exact ⟨k, biInter_subset_biInter_left fun j rji ↦ le_trans rji rik,
+      biInter_subset_biInter_left fun i rij ↦ le_trans rij rjk⟩
   have hfin' : ∃ i, μ (s i) ≠ ∞ := by
-    rcases hf with ⟨i, hi⟩
-    rcases directed_of r i i with ⟨j, rij, -⟩
+    rcases hfin with ⟨i, hi⟩
+    rcases directed_of (· ≤ ·) i i with ⟨j, rij, -⟩
     exact ⟨j, ne_top_of_le_ne_top hi <| measure_mono <| biInter_subset_of_mem rij⟩
   exact iInter_eq ▸ measure_iInter_eq_iInf ms hd hfin'
 
@@ -595,11 +591,11 @@ theorem tendsto_measure_iUnion [Preorder ι] [IsDirected ι (· ≤ ·)] [Counta
 
 /-- Continuity from below: the measure of the union of a sequence of (not necessarily measurable)
 sets is the limit of the measures of the partial unions. -/
-theorem tendsto_measure_iUnion' [Countable ι] [Preorder ι] [IsDirected ι (· ≤ ·)] {f : ι → Set α} :
-    Tendsto (fun i ↦ μ (⋃ j ≤ i, f j)) atTop (𝓝 (μ (⋃ i, f i))) := by
-  rw [measure_iUnion_eq_iSup' (· ≤ ·) transitive_le]
-  exact tendsto_atTop_iSup
-    fun i j hij ↦ measure_mono <| biUnion_subset_biUnion_left fun k hki ↦ le_trans hki hij
+theorem tendsto_measure_iUnion' {α ι : Type*} [MeasurableSpace α] {μ : Measure α} [Countable ι]
+    [Preorder ι] [IsDirected ι (· ≤ ·)] {f : ι → Set α} :
+    Tendsto (fun i ↦ μ (Accumulate f i)) atTop (𝓝 (μ (⋃ i, f i))) := by
+  rw [measure_iUnion_eq_iSup']
+  exact tendsto_atTop_iSup fun i j hij ↦ measure_mono <| monotone_accumulate hij
 
 /-- Continuity from above: the measure of the intersection of a decreasing sequence of measurable
 sets is the limit of the measures. -/
@@ -612,10 +608,11 @@ theorem tendsto_measure_iInter [Countable ι] [Preorder ι] [IsDirected ι (· �
 
 /-- Continuity from above: the measure of the intersection of a sequence of measurable
 sets such that one has finite measure is the limit of the measures of the partial intersections. -/
-theorem tendsto_measure_iInter' [Countable ι] [Preorder ι] [IsDirected ι (· ≤ ·)]
-    {f : ι → Set α} (hm : ∀ i, MeasurableSet (f i)) (hf : ∃ i, μ (f i) ≠ ∞) :
-    Tendsto (fun i ↦ μ (⋂ j ≤ i, f j)) atTop (𝓝 (μ (⋂ i, f i))) := by
-  rw [measure_iInter_eq_iInf' (· ≤ ·) transitive_le hm hf]
+theorem tendsto_measure_iInter' {α ι : Type*} [MeasurableSpace α] {μ : Measure α} [Countable ι]
+    [Preorder ι] [IsDirected ι (· ≤ ·)] {f : ι → Set α} (hm : ∀ i, MeasurableSet (f i))
+    (hf : ∃ i, μ (f i) ≠ ∞) :
+    Tendsto (fun i ↦ μ (⋂ j ∈ {j | j ≤ i}, f j)) atTop (𝓝 (μ (⋂ i, f i))) := by
+  rw [measure_iInter_eq_iInf' hm hf]
   exact tendsto_atTop_iInf
     fun i j hij ↦ measure_mono <| biInter_subset_biInter_left fun k hki ↦ le_trans hki hij
 


### PR DESCRIPTION
Add four theorems about continuity from below/above of measures. Contrary to those already existing, no assumptions about the sequence of sets. Show that the measures of the partial unions/intersections converge to the measure of the union/intersection.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
