### PR TITLE
[Merged by Bors] - feat: operations on indicatorConstLp

### DIFF
--- a/Mathlib/Algebra/Order/Support.lean
+++ b/Mathlib/Algebra/Order/Support.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Function.Indicator
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
+import Mathlib.Analysis.Normed.Group.Basic
 
 /-!
 # Support of a function in an order
@@ -241,4 +242,18 @@ lemma abs_indicator_symmDiff (s t : Set α) (f : α → M) (x : α) :
   apply_indicator_symmDiff abs_neg s t f x
 
 end LinearOrderedAddCommGroup
+
+section NormedAddCommGroup
+variable [NormedAddCommGroup M]
+
+open scoped symmDiff
+
+/-- The norm of an indicator of the symmetric difference is equal to the norm of the difference of
+the two indicators. -/
+lemma norm_indicator_symmDiff (s t : Set α) {f : α → M} :
+    (fun x ↦ ‖(indicator (s ∆ t) f) x‖) = fun x ↦ ‖(indicator s f - indicator t f) x‖ := by
+  ext x
+  apply apply_indicator_symmDiff norm_neg
+
+end NormedAddCommGroup
 end Set

--- a/Mathlib/Algebra/Order/Support.lean
+++ b/Mathlib/Algebra/Order/Support.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Function.Indicator
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
-import Mathlib.Analysis.Normed.Group.Basic
 
 /-!
 # Support of a function in an order

--- a/Mathlib/Algebra/Order/Support.lean
+++ b/Mathlib/Algebra/Order/Support.lean
@@ -242,18 +242,4 @@ lemma abs_indicator_symmDiff (s t : Set α) (f : α → M) (x : α) :
   apply_indicator_symmDiff abs_neg s t f x
 
 end LinearOrderedAddCommGroup
-
-section NormedAddCommGroup
-variable [NormedAddCommGroup M]
-
-open scoped symmDiff
-
-/-- The norm of an indicator of the symmetric difference is equal to the norm of the difference of
-the two indicators. -/
-lemma norm_indicator_symmDiff (s t : Set α) {f : α → M} :
-    (fun x ↦ ‖(indicator (s ∆ t) f) x‖) = fun x ↦ ‖(indicator s f - indicator t f) x‖ := by
-  ext x
-  apply apply_indicator_symmDiff norm_neg
-
-end NormedAddCommGroup
 end Set

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -306,6 +306,8 @@ protected theorem edist_dist (f g : Lp E p μ) : edist f g = .ofReal (dist f g) 
 protected theorem dist_edist (f g : Lp E p μ) : dist f g = (edist f g).toReal :=
   MeasureTheory.Lp.dist_def ..
 
+theorem dist_eq_norm (f g : Lp E p μ) : dist f g = ‖f - g‖ := rfl
+
 @[simp]
 theorem edist_toLp_toLp (f g : α → E) (hf : Memℒp f p μ) (hg : Memℒp g p μ) :
     edist (hf.toLp f) (hg.toLp g) = snorm (f - g) p μ := by
@@ -819,26 +821,16 @@ theorem norm_indicatorConstLp_le :
     ENNReal.toReal_rpow, ENNReal.ofReal_toReal]
   exact ENNReal.rpow_ne_top_of_nonneg (by positivity) hμs
 
-theorem edist_indicatorConstLp_eq_nnnorm {t : Set α} (ht : MeasurableSet t) (hμt : μ t ≠ ∞) :
+theorem edist_indicatorConstLp_eq_nnnorm {t : Set α} {ht : MeasurableSet t} {hμt : μ t ≠ ∞} :
     edist (indicatorConstLp p hs hμs c) (indicatorConstLp p ht hμt c) =
       ‖indicatorConstLp p (hs.symmDiff ht) (measure_symmDiff_ne_top hμs hμt) c‖₊ := by
   unfold indicatorConstLp
   rw [Lp.edist_toLp_toLp, snorm_indicator_sub_indicator, Lp.coe_nnnorm_toLp]
 
-theorem dist_indicatorConstLp_eq_norm {t : Set α} (ht : MeasurableSet t) (hμt : μ t ≠ ∞) :
+theorem dist_indicatorConstLp_eq_norm {t : Set α} {ht : MeasurableSet t} {hμt : μ t ≠ ∞} :
     dist (indicatorConstLp p hs hμs c) (indicatorConstLp p ht hμt c) =
       ‖indicatorConstLp p (hs.symmDiff ht) (measure_symmDiff_ne_top hμs hμt) c‖ := by
   rw [Lp.dist_edist, edist_indicatorConstLp_eq_nnnorm, ENNReal.coe_toReal, Lp.coe_nnnorm]
-
-open scoped symmDiff in
-/-- Compute the `ℒᵖ` norm of the difference of two constant indicators of sets with finite measure
-and same constant using symmetric difference. -/
-theorem norm_indicatorConstLp_sub {t : Set α} {ht : MeasurableSet t} {hμt : μ t ≠ ∞}
-    (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) :
-    ‖indicatorConstLp p hs hμs c - indicatorConstLp p ht hμt c‖ =
-    ‖c‖ * (μ (s ∆ t)).toReal ^ (1 / p.toReal) := by
-  conv_lhs => change dist (indicatorConstLp p hs hμs c) (indicatorConstLp p ht hμt c)
-  rw [dist_indicatorConstLp_eq_norm ht hμt, norm_indicatorConstLp hp_ne_zero hp_ne_top]
 
 @[simp]
 theorem indicatorConstLp_empty :

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -807,7 +807,7 @@ theorem norm_indicatorConstLp_top (hμs_ne_zero : μ s ≠ 0) :
 open scoped symmDiff in
 /-- Compute the `ℒᵖ` norm of the difference of two constant indicators of sets with finite measure
 and same constant using symmetric difference. -/
-theorem norm_indicatorConstLp_sub {t : Set α} (ht : MeasurableSet t) (hμt : μ t ≠ ∞)
+theorem norm_indicatorConstLp_sub {t : Set α} {ht : MeasurableSet t} {hμt : μ t ≠ ∞}
     (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) :
     ‖indicatorConstLp p hs hμs c - indicatorConstLp p ht hμt c‖ =
     ‖c‖ * (μ (s ∆ t)).toReal ^ (1 / p.toReal) := by

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -809,7 +809,7 @@ theorem norm_indicatorConstLp_top (hμs_ne_zero : μ s ≠ 0) :
 open scoped symmDiff in
 /-- Compute the `ℒᵖ` norm of the difference of two constant indicators of sets with finite measure
 and same constant using symmetric difference. -/
-theorem norm_indicatorConstLp_sub {t : Set α} (ht : MeasurableSet t) (hμt : μ t ≠ ⊤)
+theorem norm_indicatorConstLp_sub {t : Set α} (ht : MeasurableSet t) (hμt : μ t ≠ ∞)
     (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) :
     ‖indicatorConstLp p hs hμs c - indicatorConstLp p ht hμt c‖ =
     ‖c‖ * (μ (s ∆ t)).toReal ^ (1 / p.toReal) := by

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -766,9 +766,7 @@ def indicatorConstLp (p : ℝ≥0∞) (hs : MeasurableSet s) (hμs : μ s ≠ �
 theorem indicatorConstLp_add (hμs : μ s ≠ ∞) (c' : E) :
     indicatorConstLp p hs hμs c + indicatorConstLp p hs hμs c' =
     indicatorConstLp p hs hμs (c + c') := by
-  simp_rw [indicatorConstLp, ← Memℒp.toLp_add]
-  congr
-  rw [indicator_add]
+  simp_rw [indicatorConstLp, ← Memℒp.toLp_add, indicator_add]
   rfl
 
 /-- A version of `Set.indicator_sub` for `MeasureTheory.indicatorConstLp`.-/

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -762,6 +762,24 @@ def indicatorConstLp (p : ℝ≥0∞) (hs : MeasurableSet s) (hμs : μ s ≠ �
   Memℒp.toLp (s.indicator fun _ => c) (memℒp_indicator_const p hs c (Or.inr hμs))
 #align measure_theory.indicator_const_Lp MeasureTheory.indicatorConstLp
 
+/-- A version of `Set.indicator_add` for `MeasureTheory.indicatorConstLp`.-/
+theorem indicatorConstLp_add (hμs : μ s ≠ ∞) (c' : E) :
+    indicatorConstLp p hs hμs c + indicatorConstLp p hs hμs c' =
+    indicatorConstLp p hs hμs (c + c') := by
+  simp_rw [indicatorConstLp, ← Memℒp.toLp_add]
+  congr
+  rw [indicator_add]
+  rfl
+
+/-- A version of `Set.indicator_sub` for `MeasureTheory.indicatorConstLp`.-/
+theorem indicatorConstLp_sub (hμs : μ s ≠ ∞) (c' : E) :
+    indicatorConstLp p hs hμs c - indicatorConstLp p hs hμs c' =
+    indicatorConstLp p hs hμs (c - c') := by
+  simp_rw [indicatorConstLp, ← Memℒp.toLp_sub]
+  congr
+  rw [indicator_sub]
+  rfl
+
 theorem indicatorConstLp_coeFn : ⇑(indicatorConstLp p hs hμs c) =ᵐ[μ] s.indicator fun _ => c :=
   Memℒp.coeFn_toLp (memℒp_indicator_const p hs c (Or.inr hμs))
 #align measure_theory.indicator_const_Lp_coe_fn MeasureTheory.indicatorConstLp_coeFn
@@ -787,6 +805,18 @@ theorem norm_indicatorConstLp_top (hμs_ne_zero : μ s ≠ 0) :
     snorm_indicator_const' hs hμs_ne_zero ENNReal.top_ne_zero, ENNReal.top_toReal, _root_.div_zero,
     ENNReal.rpow_zero, mul_one, ENNReal.coe_toReal, coe_nnnorm]
 #align measure_theory.norm_indicator_const_Lp_top MeasureTheory.norm_indicatorConstLp_top
+
+open scoped symmDiff in
+/-- Compute the `ℒᵖ` norm of the difference of two constant indicators of sets with finite measure
+and same constant using symmetric difference. -/
+theorem norm_indicatorConstLp_sub {t : Set α} (ht : MeasurableSet t) (hμt : μ t ≠ ⊤)
+    (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) :
+    ‖indicatorConstLp p hs hμs c - indicatorConstLp p ht hμt c‖ =
+    ‖c‖ * (μ (s ∆ t)).toReal ^ (1 / p.toReal) := by
+  rw [indicatorConstLp, indicatorConstLp, ← Memℒp.toLp_sub, Lp.norm_toLp,
+    ← snorm_norm, ← norm_indicator_symmDiff, snorm_norm,
+    snorm_indicator_const (hs.symmDiff ht) hp_ne_zero hp_ne_top, ENNReal.toReal_mul,
+    toReal_coe_nnnorm, ← ENNReal.toReal_rpow]
 
 theorem norm_indicatorConstLp' (hp_pos : p ≠ 0) (hμs_pos : μ s ≠ 0) :
     ‖indicatorConstLp p hs hμs c‖ = ‖c‖ * (μ s).toReal ^ (1 / p.toReal) := by

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -802,18 +802,6 @@ theorem norm_indicatorConstLp_top (hμs_ne_zero : μ s ≠ 0) :
     ENNReal.rpow_zero, mul_one, ENNReal.coe_toReal, coe_nnnorm]
 #align measure_theory.norm_indicator_const_Lp_top MeasureTheory.norm_indicatorConstLp_top
 
-open scoped symmDiff in
-/-- Compute the `ℒᵖ` norm of the difference of two constant indicators of sets with finite measure
-and same constant using symmetric difference. -/
-theorem norm_indicatorConstLp_sub {t : Set α} {ht : MeasurableSet t} {hμt : μ t ≠ ∞}
-    (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) :
-    ‖indicatorConstLp p hs hμs c - indicatorConstLp p ht hμt c‖ =
-    ‖c‖ * (μ (s ∆ t)).toReal ^ (1 / p.toReal) := by
-  simp_rw [indicatorConstLp, ← Memℒp.toLp_sub, Lp.norm_toLp, ← snorm_norm (F := E),
-    Pi.sub_apply, ← apply_indicator_symmDiff norm_neg, snorm_norm,
-    snorm_indicator_const (hs.symmDiff ht) hp_ne_zero hp_ne_top, ENNReal.toReal_mul,
-    toReal_coe_nnnorm, ← ENNReal.toReal_rpow]
-
 theorem norm_indicatorConstLp' (hp_pos : p ≠ 0) (hμs_pos : μ s ≠ 0) :
     ‖indicatorConstLp p hs hμs c‖ = ‖c‖ * (μ s).toReal ^ (1 / p.toReal) := by
   by_cases hp_top : p = ∞
@@ -841,6 +829,16 @@ theorem dist_indicatorConstLp_eq_norm {t : Set α} (ht : MeasurableSet t) (hμt 
     dist (indicatorConstLp p hs hμs c) (indicatorConstLp p ht hμt c) =
       ‖indicatorConstLp p (hs.symmDiff ht) (measure_symmDiff_ne_top hμs hμt) c‖ := by
   rw [Lp.dist_edist, edist_indicatorConstLp_eq_nnnorm, ENNReal.coe_toReal, Lp.coe_nnnorm]
+
+open scoped symmDiff in
+/-- Compute the `ℒᵖ` norm of the difference of two constant indicators of sets with finite measure
+and same constant using symmetric difference. -/
+theorem norm_indicatorConstLp_sub {t : Set α} {ht : MeasurableSet t} {hμt : μ t ≠ ∞}
+    (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) :
+    ‖indicatorConstLp p hs hμs c - indicatorConstLp p ht hμt c‖ =
+    ‖c‖ * (μ (s ∆ t)).toReal ^ (1 / p.toReal) := by
+  conv_lhs => change dist (indicatorConstLp p hs hμs c) (indicatorConstLp p ht hμt c)
+  rw [dist_indicatorConstLp_eq_norm ht hμt, norm_indicatorConstLp hp_ne_zero hp_ne_top]
 
 @[simp]
 theorem indicatorConstLp_empty :

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -811,9 +811,9 @@ theorem norm_indicatorConstLp_sub {t : Set α} (ht : MeasurableSet t) (hμt : μ
     (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) :
     ‖indicatorConstLp p hs hμs c - indicatorConstLp p ht hμt c‖ =
     ‖c‖ * (μ (s ∆ t)).toReal ^ (1 / p.toReal) := by
-  rw [indicatorConstLp, indicatorConstLp, ← Memℒp.toLp_sub, Lp.norm_toLp, ← snorm_norm]
-  simp_rw [Pi.sub_apply, ← Set.apply_indicator_symmDiff norm_neg]
-  rw [snorm_norm, snorm_indicator_const (hs.symmDiff ht) hp_ne_zero hp_ne_top, ENNReal.toReal_mul,
+  simp_rw [indicatorConstLp, ← Memℒp.toLp_sub, Lp.norm_toLp, ← snorm_norm (F := E),
+    Pi.sub_apply, ← apply_indicator_symmDiff norm_neg, snorm_norm, 
+    snorm_indicator_const (hs.symmDiff ht) hp_ne_zero hp_ne_top, ENNReal.toReal_mul,
     toReal_coe_nnnorm, ← ENNReal.toReal_rpow]
 
 theorem norm_indicatorConstLp' (hp_pos : p ≠ 0) (hμs_pos : μ s ≠ 0) :

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -1632,7 +1632,7 @@ theorem ae_tendsto_of_cauchy_snorm [CompleteSpace E] {f : ℕ → α → E}
     refine' cauchySeq_of_le_tendsto_0 (fun n => (B n).toReal) _ _
     · intro n m N hnN hmN
       specialize hx N n m hnN hmN
-      rw [dist_eq_norm, ← ENNReal.toReal_ofReal (norm_nonneg _),
+      rw [_root_.dist_eq_norm, ← ENNReal.toReal_ofReal (norm_nonneg _),
         ENNReal.toReal_le_toReal ENNReal.ofReal_ne_top (ENNReal.ne_top_of_tsum_ne_top hB N)]
       rw [← ofReal_norm_eq_coe_nnnorm] at hx
       exact hx.le

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -813,9 +813,9 @@ theorem norm_indicatorConstLp_sub {t : Set α} (ht : MeasurableSet t) (hμt : μ
     (hp_ne_zero : p ≠ 0) (hp_ne_top : p ≠ ∞) :
     ‖indicatorConstLp p hs hμs c - indicatorConstLp p ht hμt c‖ =
     ‖c‖ * (μ (s ∆ t)).toReal ^ (1 / p.toReal) := by
-  rw [indicatorConstLp, indicatorConstLp, ← Memℒp.toLp_sub, Lp.norm_toLp,
-    ← snorm_norm, ← norm_indicator_symmDiff, snorm_norm,
-    snorm_indicator_const (hs.symmDiff ht) hp_ne_zero hp_ne_top, ENNReal.toReal_mul,
+  rw [indicatorConstLp, indicatorConstLp, ← Memℒp.toLp_sub, Lp.norm_toLp, ← snorm_norm]
+  simp_rw [Pi.sub_apply, ← Set.apply_indicator_symmDiff norm_neg]
+  rw [snorm_norm, snorm_indicator_const (hs.symmDiff ht) hp_ne_zero hp_ne_top, ENNReal.toReal_mul,
     toReal_coe_nnnorm, ← ENNReal.toReal_rpow]
 
 theorem norm_indicatorConstLp' (hp_pos : p ≠ 0) (hμs_pos : μ s ≠ 0) :

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -763,19 +763,17 @@ def indicatorConstLp (p : ℝ≥0∞) (hs : MeasurableSet s) (hμs : μ s ≠ �
 #align measure_theory.indicator_const_Lp MeasureTheory.indicatorConstLp
 
 /-- A version of `Set.indicator_add` for `MeasureTheory.indicatorConstLp`.-/
-theorem indicatorConstLp_add (hμs : μ s ≠ ∞) (c' : E) :
+theorem indicatorConstLp_add {c' : E} :
     indicatorConstLp p hs hμs c + indicatorConstLp p hs hμs c' =
     indicatorConstLp p hs hμs (c + c') := by
   simp_rw [indicatorConstLp, ← Memℒp.toLp_add, indicator_add]
   rfl
 
 /-- A version of `Set.indicator_sub` for `MeasureTheory.indicatorConstLp`.-/
-theorem indicatorConstLp_sub (hμs : μ s ≠ ∞) (c' : E) :
+theorem indicatorConstLp_sub {c' : E} :
     indicatorConstLp p hs hμs c - indicatorConstLp p hs hμs c' =
     indicatorConstLp p hs hμs (c - c') := by
-  simp_rw [indicatorConstLp, ← Memℒp.toLp_sub]
-  congr
-  rw [indicator_sub]
+  simp_rw [indicatorConstLp, ← Memℒp.toLp_sub, indicator_sub]
   rfl
 
 theorem indicatorConstLp_coeFn : ⇑(indicatorConstLp p hs hμs c) =ᵐ[μ] s.indicator fun _ => c :=

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -812,7 +812,7 @@ theorem norm_indicatorConstLp_sub {t : Set α} {ht : MeasurableSet t} {hμt : μ
     ‖indicatorConstLp p hs hμs c - indicatorConstLp p ht hμt c‖ =
     ‖c‖ * (μ (s ∆ t)).toReal ^ (1 / p.toReal) := by
   simp_rw [indicatorConstLp, ← Memℒp.toLp_sub, Lp.norm_toLp, ← snorm_norm (F := E),
-    Pi.sub_apply, ← apply_indicator_symmDiff norm_neg, snorm_norm, 
+    Pi.sub_apply, ← apply_indicator_symmDiff norm_neg, snorm_norm,
     snorm_indicator_const (hs.symmDiff ht) hp_ne_zero hp_ne_top, ENNReal.toReal_mul,
     toReal_coe_nnnorm, ← ENNReal.toReal_rpow]
 


### PR DESCRIPTION
Add lemmas to rewrite the sum/difference of two `indicatorConstLp` with same support. The distance between to Lp functions is the same as the norm of their difference (even if $p < 1$ and it's not a norm).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
