### PR TITLE
style: Change Subtype.val to (↑)

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -944,7 +944,7 @@ containing it. -/
 theorem exists_maximal_orthonormal {s : Set E} (hs : Orthonormal 𝕜 ((↑) : s → E)) :
     ∃ w ⊇ s, Orthonormal 𝕜 ((↑) : w → E) ∧
       ∀ u ⊇ w, Orthonormal 𝕜 ((↑) : u → E) → u = w := by
-  have := zorn_subset_nonempty { b | Orthonormal 𝕜 ((↑) : b → E) } ?_ _ hs
+  have := zorn_subset_nonempty { b | Orthonormal 𝕜 (Subtype.val : b → E) } ?_ _ hs
   · obtain ⟨b, bi, sb, h⟩ := this
     refine' ⟨b, sb, bi, _⟩
     exact fun u hus hu => h u hu hus

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -760,7 +760,7 @@ theorem orthonormal_iff_ite [DecidableEq ι] {v : ι → E} :
 /-- `if ... then ... else` characterization of a set of vectors being orthonormal.  (Inner product
 equals Kronecker delta.) -/
 theorem orthonormal_subtype_iff_ite [DecidableEq E] {s : Set E} :
-    Orthonormal 𝕜 (Subtype.val : s → E) ↔ ∀ v ∈ s, ∀ w ∈ s, ⟪v, w⟫ = if v = w then 1 else 0 := by
+    Orthonormal 𝕜 ((↑) : s → E) ↔ ∀ v ∈ s, ∀ w ∈ s, ⟪v, w⟫ = if v = w then 1 else 0 := by
   rw [orthonormal_iff_ite]
   constructor
   · intro h v hv w hw
@@ -873,7 +873,7 @@ theorem Orthonormal.comp {ι' : Type*} {v : ι → E} (hv : Orthonormal 𝕜 v) 
 /-- An injective family `v : ι → E` is orthonormal if and only if `Subtype.val : (range v) → E` is
 orthonormal. -/
 theorem orthonormal_subtype_range {v : ι → E} (hv : Function.Injective v) :
-    Orthonormal 𝕜 (Subtype.val : Set.range v → E) ↔ Orthonormal 𝕜 v := by
+    Orthonormal 𝕜 ((↑) : Set.range v → E) ↔ Orthonormal 𝕜 v := by
   let f : ι ≃ Set.range v := Equiv.ofInjective v hv
   refine' ⟨fun h => h.comp f f.injective, fun h => _⟩
   rw [← Equiv.self_comp_ofInjective_symm hv]
@@ -883,7 +883,7 @@ theorem orthonormal_subtype_range {v : ι → E} (hv : Function.Injective v) :
 /-- If `v : ι → E` is an orthonormal family, then `Subtype.val : (range v) → E` is an orthonormal
 family. -/
 theorem Orthonormal.toSubtypeRange {v : ι → E} (hv : Orthonormal 𝕜 v) :
-    Orthonormal 𝕜 (Subtype.val : Set.range v → E) :=
+    Orthonormal 𝕜 ((↑) : Set.range v → E) :=
   (orthonormal_subtype_range hv.linearIndependent.injective).2 hv
 #align orthonormal.to_subtype_range Orthonormal.toSubtypeRange
 
@@ -941,10 +941,10 @@ theorem orthonormal_sUnion_of_directed {s : Set (Set E)} (hs : DirectedOn (· �
 
 /-- Given an orthonormal set `v` of vectors in `E`, there exists a maximal orthonormal set
 containing it. -/
-theorem exists_maximal_orthonormal {s : Set E} (hs : Orthonormal 𝕜 (Subtype.val : s → E)) :
-    ∃ w ⊇ s, Orthonormal 𝕜 (Subtype.val : w → E) ∧
-      ∀ u ⊇ w, Orthonormal 𝕜 (Subtype.val : u → E) → u = w := by
-  have := zorn_subset_nonempty { b | Orthonormal 𝕜 (Subtype.val : b → E) } ?_ _ hs
+theorem exists_maximal_orthonormal {s : Set E} (hs : Orthonormal 𝕜 ((↑) : s → E)) :
+    ∃ w ⊇ s, Orthonormal 𝕜 ((↑) : w → E) ∧
+      ∀ u ⊇ w, Orthonormal 𝕜 ((↑) : u → E) → u = w := by
+  have := zorn_subset_nonempty { b | Orthonormal 𝕜 ((↑) : b → E) } ?_ _ hs
   · obtain ⟨b, bi, sb, h⟩ := this
     refine' ⟨b, sb, bi, _⟩
     exact fun u hus hu => h u hu hus

--- a/Mathlib/Analysis/Normed/Group/Hom.lean
+++ b/Mathlib/Analysis/Normed/Group/Hom.lean
@@ -715,7 +715,7 @@ variable {V W V₁ V₂ V₃ : Type*} [SeminormedAddCommGroup V] [SeminormedAddC
 /-- The inclusion of an `AddSubgroup`, as bounded group homomorphism. -/
 @[simps!]
 def incl (s : AddSubgroup V) : NormedAddGroupHom s V where
-  toFun := (Subtype.val : s → V)
+  toFun := ((↑) : s → V)
   map_add' v w := AddSubgroup.coe_add _ _ _
   bound' := ⟨1, fun v => by rw [one_mul, AddSubgroup.coe_norm]⟩
 #align normed_add_group_hom.incl NormedAddGroupHom.incl

--- a/Mathlib/CategoryTheory/Generator.lean
+++ b/Mathlib/CategoryTheory/Generator.lean
@@ -284,11 +284,11 @@ theorem hasInitial_of_isCoseparating [WellPowered C] [HasLimits C] {𝒢 : Set C
     (h𝒢 : IsCoseparating 𝒢) : HasInitial C := by
   haveI : HasProductsOfShape 𝒢 C := hasProductsOfShape_of_small C 𝒢
   haveI := fun A => hasProductsOfShape_of_small.{v₁} C (ΣG : 𝒢, A ⟶ (G : C))
-  letI := completeLatticeOfCompleteSemilatticeInf (Subobject (piObj (Subtype.val : 𝒢 → C)))
-  suffices ∀ A : C, Unique (((⊥ : Subobject (piObj (Subtype.val : 𝒢 → C))) : C) ⟶ A) by
-    exact hasInitial_of_unique ((⊥ : Subobject (piObj (Subtype.val : 𝒢 → C))) : C)
+  letI := completeLatticeOfCompleteSemilatticeInf (Subobject (piObj ((↑) : 𝒢 → C)))
+  suffices ∀ A : C, Unique (((⊥ : Subobject (piObj ((↑) : 𝒢 → C))) : C) ⟶ A) by
+    exact hasInitial_of_unique ((⊥ : Subobject (piObj ((↑) : 𝒢 → C))) : C)
   refine' fun A => ⟨⟨_⟩, fun f => _⟩
-  · let s := Pi.lift fun f : ΣG : 𝒢, A ⟶ (G : C) => id (Pi.π (Subtype.val : 𝒢 → C)) f.1
+  · let s := Pi.lift fun f : ΣG : 𝒢, A ⟶ (G : C) => id (Pi.π ((↑) : 𝒢 → C)) f.1
     let t := Pi.lift (@Sigma.snd 𝒢 fun G => A ⟶ (G : C))
     haveI : Mono t := (isCoseparating_iff_mono 𝒢).1 h𝒢 A
     exact Subobject.ofLEMk _ (pullback.fst : pullback s t ⟶ _) bot_le ≫ pullback.snd

--- a/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
@@ -358,7 +358,7 @@ theorem binaryCofan_isColimit_iff {X Y : Type u} (c : BinaryCofan X Y) :
 
 /-- Any monomorphism in `Type` is a coproduct injection. -/
 noncomputable def isCoprodOfMono {X Y : Type u} (f : X ⟶ Y) [Mono f] :
-    IsColimit (BinaryCofan.mk f (Subtype.val : ↑(Set.range f)ᶜ → Y)) := by
+    IsColimit (BinaryCofan.mk f ((↑) : ↑(Set.range f)ᶜ → Y)) := by
   apply Nonempty.some
   rw [binaryCofan_isColimit_iff]
   refine' ⟨(mono_iff_injective f).mp inferInstance, Subtype.val_injective, _⟩
@@ -524,7 +524,7 @@ theorem type_equalizer_iff_unique :
 
 /-- Show that the subtype `{x : Y // g x = h x}` is an equalizer for the pair `(g,h)`. -/
 def equalizerLimit : Limits.LimitCone (parallelPair g h) where
-  cone := Fork.ofι (Subtype.val : { x : Y // g x = h x } → Y) (funext Subtype.prop)
+  cone := Fork.ofι ((↑) : { x : Y // g x = h x } → Y) (funext Subtype.prop)
   isLimit :=
     Fork.IsLimit.mk' _ fun s =>
       ⟨fun i => ⟨s.ι i, by apply congr_fun s.condition i⟩, rfl, fun hm =>

--- a/Mathlib/CategoryTheory/Subobject/Types.lean
+++ b/Mathlib/CategoryTheory/Subobject/Types.lean
@@ -30,7 +30,7 @@ open CategoryTheory
 
 open CategoryTheory.Subobject
 
-theorem subtype_val_mono {α : Type u} (s : Set α) : Mono (↾(Subtype.val : s → α)) :=
+theorem subtype_val_mono {α : Type u} (s : Set α) : Mono (↾((↑) : s → α)) :=
   (mono_iff_injective _).mpr Subtype.val_injective
 #align subtype_val_mono subtype_val_mono
 
@@ -48,7 +48,7 @@ noncomputable def Types.monoOverEquivalenceSet (α : Type u) : MonoOver α ≌ S
             rintro a ⟨x, rfl⟩
             exact ⟨t.1 x, congr_fun t.w x⟩) }
   inverse :=
-    { obj := fun s => MonoOver.mk' (Subtype.val : s → α)
+    { obj := fun s => MonoOver.mk' ((↑) : s → α)
       map := fun {s t} b => MonoOver.homMk (fun w => ⟨w.1, Set.mem_of_mem_of_subset w.2 b.le⟩) }
   unitIso :=
     NatIso.ofComponents fun f =>

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -490,7 +490,7 @@ are equal. -/
 theorem strictMono_unique {f g : Fin n → α} (hf : StrictMono f) (hg : StrictMono g)
     (h : range f = range g) : f = g :=
   have : (hf.orderIso f).trans (OrderIso.setCongr _ _ h) = hg.orderIso g := Subsingleton.elim _ _
-  congr_arg (Function.comp (Subtype.val : range g → α)) (funext <| RelIso.ext_iff.1 this)
+  congr_arg (Function.comp ((↑) : range g → α)) (funext <| RelIso.ext_iff.1 this)
 #align fin.strict_mono_unique Fin.strictMono_unique
 
 /-- Two order embeddings of `Fin n` are equal provided that their ranges are equal. -/

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -322,22 +322,22 @@ theorem _root_.StrictAntiOn.mono (h : StrictAntiOn f s) (h' : s₂ ⊆ s) : Stri
 #align strict_anti_on.mono StrictAntiOn.mono
 
 protected theorem _root_.MonotoneOn.monotone (h : MonotoneOn f s) :
-    Monotone (f ∘ Subtype.val : s → β) :=
+    Monotone (f ∘ (↑) : s → β) :=
   fun x y hle => h x.coe_prop y.coe_prop hle
 #align monotone_on.monotone MonotoneOn.monotone
 
 protected theorem _root_.AntitoneOn.monotone (h : AntitoneOn f s) :
-    Antitone (f ∘ Subtype.val : s → β) :=
+    Antitone (f ∘ (↑) : s → β) :=
   fun x y hle => h x.coe_prop y.coe_prop hle
 #align antitone_on.monotone AntitoneOn.monotone
 
 protected theorem _root_.StrictMonoOn.strictMono (h : StrictMonoOn f s) :
-    StrictMono (f ∘ Subtype.val : s → β) :=
+    StrictMono (f ∘ (↑) : s → β) :=
   fun x y hlt => h x.coe_prop y.coe_prop hlt
 #align strict_mono_on.strict_mono StrictMonoOn.strictMono
 
 protected theorem _root_.StrictAntiOn.strictAnti (h : StrictAntiOn f s) :
-    StrictAnti (f ∘ Subtype.val : s → β) :=
+    StrictAnti (f ∘ (↑) : s → β) :=
   fun x y hlt => h x.coe_prop y.coe_prop hlt
 #align strict_anti_on.strict_anti StrictAntiOn.strictAnti
 

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -1374,7 +1374,7 @@ theorem range_coe {s : Set α} : range ((↑) : s → α) = s := by
 /-- A variant of `range_coe`. Try to use `range_coe` if possible.
   This version is useful when defining a new type that is defined as the subtype of something.
   In that case, the coercion doesn't fire anymore. -/
-theorem range_val {s : Set α} : range (Subtype.val : s → α) = s :=
+theorem range_val {s : Set α} : range ((↑) : s → α) = s :=
   range_coe
 #align subtype.range_val Subtype.range_val
 
@@ -1391,7 +1391,7 @@ theorem coe_preimage_self (s : Set α) : ((↑) : s → α) ⁻¹' s = univ := b
   rw [← preimage_range, range_coe]
 #align subtype.coe_preimage_self Subtype.coe_preimage_self
 
-theorem range_val_subtype {p : α → Prop} : range (Subtype.val : Subtype p → α) = { x | p x } :=
+theorem range_val_subtype {p : α → Prop} : range ((↑) : Subtype p → α) = { x | p x } :=
   range_coe
 #align subtype.range_val_subtype Subtype.range_val_subtype
 
@@ -1409,7 +1409,7 @@ theorem image_preimage_coe (s t : Set α) : ((↑) : s → α) '' (((↑) : s �
   image_preimage_eq_range_inter.trans <| congr_arg (· ∩ t) range_coe
 #align subtype.image_preimage_coe Subtype.image_preimage_coe
 
-theorem image_preimage_val (s t : Set α) : (Subtype.val : s → α) '' (Subtype.val ⁻¹' t) = s ∩ t :=
+theorem image_preimage_val (s t : Set α) : ((↑) : s → α) '' (Subtype.val ⁻¹' t) = s ∩ t :=
   image_preimage_coe s t
 #align subtype.image_preimage_val Subtype.image_preimage_val
 
@@ -1430,7 +1430,7 @@ theorem preimage_coe_inter_self (s t : Set α) :
 #align subtype.preimage_coe_inter_self Subtype.preimage_coe_inter_self
 
 theorem preimage_val_eq_preimage_val_iff (s t u : Set α) :
-    (Subtype.val : s → α) ⁻¹' t = Subtype.val ⁻¹' u ↔ s ∩ t = s ∩ u :=
+    ((↑) : s → α) ⁻¹' t = Subtype.val ⁻¹' u ↔ s ∩ t = s ∩ u :=
   preimage_coe_eq_preimage_coe_iff
 #align subtype.preimage_val_eq_preimage_val_iff Subtype.preimage_val_eq_preimage_val_iff
 

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -446,7 +446,7 @@ def correspondence (r : Setoid α) : { s // r ≤ s } ≃o Setoid (Quotient r) w
 /-- Given two equivalence relations with `r ≤ s`, a bijection between the sum of the quotients by
 `r` on each equivalence class by `s` and the quotient by `r`. -/
 def sigmaQuotientEquivOfLe {r s : Setoid α} (hle : r ≤ s) :
-    (Σ q : Quotient s, Quotient (r.comap (Subtype.val : Quotient.mk s ⁻¹' {q} → α))) ≃
+    (Σ q : Quotient s, Quotient (r.comap ((↑) : Quotient.mk s ⁻¹' {q} → α))) ≃
       Quotient r :=
   .trans (.symm <| .sigmaCongrRight fun _ ↦ .subtypeQuotientEquivQuotientSubtype
       (s₁ := r) (s₂ := r.comap Subtype.val) _ (fun _ ↦ Iff.rfl) fun _ _ ↦ Iff.rfl)

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -365,7 +365,7 @@ theorem contMdiffAt_subtype_iff {n : ℕ∞} {U : Opens M} {f : M → M'} {x : U
     ContMDiffAt I I' n (fun x : U ↦ f x) x ↔ ContMDiffAt I I' n f x :=
   ((contDiffWithinAt_localInvariantProp I I' n).liftPropAt_iff_comp_subtype_val _ _).symm
 
-theorem contMDiff_subtype_val {n : ℕ∞} {U : Opens M} : ContMDiff I I n (Subtype.val : U → M) :=
+theorem contMDiff_subtype_val {n : ℕ∞} {U : Opens M} : ContMDiff I I n ((↑) : U → M) :=
   fun _ ↦ contMdiffAt_subtype_iff.mpr contMDiffAt_id
 
 @[to_additive]
@@ -391,7 +391,7 @@ theorem contMDiff_inclusion {n : ℕ∞} {U V : Opens M} (h : U ≤ V) :
 theorem smooth_subtype_iff {U : Opens M} {f : M → M'} {x : U} :
     SmoothAt I I' (fun x : U ↦ f x) x ↔ SmoothAt I I' f x := contMdiffAt_subtype_iff
 
-theorem smooth_subtype_val {U : Opens M} : Smooth I I (Subtype.val : U → M) := contMDiff_subtype_val
+theorem smooth_subtype_val {U : Opens M} : Smooth I I ((↑) : U → M) := contMDiff_subtype_val
 
 @[to_additive]
 theorem Smooth.extend_one [T2Space M] [One M'] {U : Opens M} {f : U → M'}

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -513,7 +513,7 @@ theorem range_mfderiv_coe_sphere {n : ℕ} [Fact (finrank ℝ E = n + 1)] (v : s
     simp only [AddEquivClass.map_eq_zero_iff]
     apply stereographic_neg_apply
   have :
-    HasFDerivAt (stereoInvFunAux (-v : E) ∘ (Subtype.val : (ℝ ∙ (↑(-v) : E))ᗮ → E))
+    HasFDerivAt (stereoInvFunAux (-v : E) ∘ ((↑) : (ℝ ∙ (↑(-v) : E))ᗮ → E))
       (ℝ ∙ (↑(-v) : E))ᗮ.subtypeL (U.symm 0) := by
     convert hasFDerivAt_stereoInvFunAux_comp_coe (-v : E)
     simp
@@ -550,7 +550,7 @@ theorem mfderiv_coe_sphere_injective {n : ℕ} [Fact (finrank ℝ E = n + 1)] (v
     dsimp [stereographic']
     simp only [AddEquivClass.map_eq_zero_iff]
     apply stereographic_neg_apply
-  have : HasFDerivAt (stereoInvFunAux (-v : E) ∘ (Subtype.val : (ℝ ∙ (↑(-v) : E))ᗮ → E))
+  have : HasFDerivAt (stereoInvFunAux (-v : E) ∘ ((↑) : (ℝ ∙ (↑(-v) : E))ᗮ → E))
       (ℝ ∙ (↑(-v) : E))ᗮ.subtypeL (U.symm 0) := by
     convert hasFDerivAt_stereoInvFunAux_comp_coe (-v : E)
     simp

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -556,7 +556,7 @@ theorem mfderiv_coe_sphere_injective {n : ℕ} [Fact (finrank ℝ E = n + 1)] (v
     simp
   have := congr_arg DFunLike.coe <| (this.comp 0 U.symm.toContinuousLinearEquiv.hasFDerivAt).fderiv
   refine Eq.subst this.symm ?_
-  rw [ContinuousLinearMap.coe_comp', ContinuousLinearEquiv.coe_coe]
+  rw [ContinuousLinearMap.coe_comp']
   simpa using Subtype.coe_injective
 #align mfderiv_coe_sphere_injective mfderiv_coe_sphere_injective
 

--- a/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
+++ b/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
@@ -560,7 +560,7 @@ theorem liftPropAt_iff_comp_inclusion (hG : LocalInvariantProp G G' P) {U V : Op
 
 theorem liftProp_subtype_val {Q : (H → H) → Set H → H → Prop} (hG : LocalInvariantProp G G Q)
     (hQ : ∀ y, Q id univ y) (U : Opens M) :
-    LiftProp Q (Subtype.val : U → M) := by
+    LiftProp Q ((↑) : U → M) := by
   intro x
   show LiftPropAt Q (id ∘ Subtype.val) x
   rw [← hG.liftPropAt_iff_comp_subtype_val]

--- a/Mathlib/GroupTheory/Subsemigroup/Operations.lean
+++ b/Mathlib/GroupTheory/Subsemigroup/Operations.lean
@@ -621,7 +621,7 @@ theorem coe_equivMapOfInjective_apply (f : M →ₙ* N) (hf : Function.Injective
 
 @[to_additive (attr := simp)]
 theorem closure_closure_coe_preimage {s : Set M} :
-    closure ((Subtype.val : closure s → M) ⁻¹' s) = ⊤ :=
+    closure (((↑) : closure s → M) ⁻¹' s) = ⊤ :=
   eq_top_iff.2 fun x =>
     Subtype.recOn x fun x hx _ => by
       refine' closure_induction' _ (fun g hg => subset_closure hg) (fun g₁ g₂ hg₁ hg₂ => _) hx

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -241,7 +241,7 @@ theorem LinearIndependent.comp (h : LinearIndependent R v) (f : ι' → ι) (hf 
 /-- A family is linearly independent if and only if all of its finite subfamily is
 linearly independent. -/
 theorem linearIndependent_iff_finset_linearIndependent :
-    LinearIndependent R v ↔ ∀ (s : Finset ι), LinearIndependent R (v ∘ (Subtype.val : s → ι)) :=
+    LinearIndependent R v ↔ ∀ (s : Finset ι), LinearIndependent R (v ∘ ((↑) : s → ι)) :=
   ⟨fun H _ ↦ H.comp _ Subtype.val_injective, fun H ↦ linearIndependent_iff'.2 fun s g hg i hi ↦
     Fintype.linearIndependent_iff.1 (H s) (g ∘ Subtype.val)
       (hg ▸ Finset.sum_attach s fun j ↦ g j • v j) ⟨i, hi⟩⟩

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -55,7 +55,7 @@ def DirectedOn (s : Set α) :=
 
 variable {r r'}
 
-theorem directedOn_iff_directed {s} : @DirectedOn α r s ↔ Directed r (Subtype.val : s → α) := by
+theorem directedOn_iff_directed {s} : @DirectedOn α r s ↔ Directed r ((↑) : s → α) := by
   simp only [DirectedOn, Directed, Subtype.exists, exists_and_left, exists_prop, Subtype.forall]
   exact forall₂_congr fun x _ => by simp [And.comm, and_assoc]
 #align directed_on_iff_directed directedOn_iff_directed

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -208,7 +208,7 @@ infixl:25 " ↪r " => RelEmbedding
 
 /-- The induced relation on a subtype is an embedding under the natural inclusion. -/
 def Subtype.relEmbedding {X : Type*} (r : X → X → Prop) (p : X → Prop) :
-    (Subtype.val : Subtype p → X) ⁻¹'o r ↪r r :=
+    ((↑) : Subtype p → X) ⁻¹'o r ↪r r :=
   ⟨Embedding.subtype p, Iff.rfl⟩
 #align subtype.rel_embedding Subtype.relEmbedding
 

--- a/Mathlib/Order/RelIso/Set.lean
+++ b/Mathlib/Order/RelIso/Set.lean
@@ -52,7 +52,7 @@ end RelIso
 
 /-- `Subrel r p` is the inherited relation on a subset. -/
 def Subrel (r : α → α → Prop) (p : Set α) : p → p → Prop :=
-  (Subtype.val : p → α) ⁻¹'o r
+  ((↑) : p → α) ⁻¹'o r
 #align subrel Subrel
 
 @[simp]

--- a/Mathlib/RingTheory/Artinian.lean
+++ b/Mathlib/RingTheory/Artinian.lean
@@ -526,7 +526,7 @@ variable (R) in
 lemma primeSpectrum_finite : {I : Ideal R | I.IsPrime}.Finite := by
   set Spec := {I : Ideal R | I.IsPrime}
   obtain ⟨_, ⟨s, rfl⟩, H⟩ := set_has_minimal
-    (range (Finset.inf · Subtype.val : Finset Spec → Ideal R)) ⟨⊤, ∅, by simp⟩
+    (range (Finset.inf · (↑) : Finset Spec → Ideal R)) ⟨⊤, ∅, by simp⟩
   refine Set.finite_def.2 ⟨s, fun p ↦ ?_⟩
   classical
   obtain ⟨q, hq1, hq2⟩ := p.2.inf_le'.mp <| inf_eq_right.mp <|

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -819,7 +819,7 @@ theorem infinite_pigeonhole {β α : Type u} (f : β → α) (h₁ : ℵ₀ ≤ 
 theorem infinite_pigeonhole_card {β α : Type u} (f : β → α) (θ : Cardinal) (hθ : θ ≤ #β)
     (h₁ : ℵ₀ ≤ θ) (h₂ : #α < θ.ord.cof) : ∃ a : α, θ ≤ #(f ⁻¹' {a}) := by
   rcases le_mk_iff_exists_set.1 hθ with ⟨s, rfl⟩
-  cases' infinite_pigeonhole (f ∘ Subtype.val : s → α) h₁ h₂ with a ha
+  cases' infinite_pigeonhole (f ∘ (↑) : s → α) h₁ h₂ with a ha
   use a; rw [← ha, @preimage_comp _ _ _ Subtype.val f]
   exact mk_preimage_of_injective _ _ Subtype.val_injective
 #align ordinal.infinite_pigeonhole_card Ordinal.infinite_pigeonhole_card

--- a/Mathlib/SetTheory/Game/Basic.lean
+++ b/Mathlib/SetTheory/Game/Basic.lean
@@ -211,7 +211,7 @@ lemma bddAbove_range_of_small {ι : Type*} [Small.{u} ι] (f : ι → Game.{u}) 
 
 /-- A small set of games is bounded above. -/
 lemma bddAbove_of_small (s : Set Game.{u}) [Small.{u} s] : BddAbove s := by
-  simpa using bddAbove_range_of_small (Subtype.val : s → Game.{u})
+  simpa using bddAbove_range_of_small ((↑) : s → Game.{u})
 #align game.bdd_above_of_small SetTheory.Game.bddAbove_of_small
 
 /-- A small family of games is bounded below. -/
@@ -223,7 +223,7 @@ lemma bddBelow_range_of_small {ι : Type*} [Small.{u} ι] (f : ι → Game.{u}) 
 
 /-- A small set of games is bounded below. -/
 lemma bddBelow_of_small (s : Set Game.{u}) [Small.{u} s] : BddBelow s := by
-  simpa using bddBelow_range_of_small (Subtype.val : s → Game.{u})
+  simpa using bddBelow_range_of_small ((↑) : s → Game.{u})
 #align game.bdd_below_of_small SetTheory.Game.bddBelow_of_small
 
 end Game

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -744,7 +744,7 @@ lemma bddAbove_range_of_small [Small.{u} ι] (f : ι → PGame.{u}) : BddAbove (
 
 /-- A small set of pre-games is bounded above. -/
 lemma bddAbove_of_small (s : Set PGame.{u}) [Small.{u} s] : BddAbove s := by
-  simpa using bddAbove_range_of_small (Subtype.val : s → PGame.{u})
+  simpa using bddAbove_range_of_small ((↑) : s → PGame.{u})
 #align pgame.bdd_above_of_small SetTheory.PGame.bddAbove_of_small
 
 #noalign pgame.lower_bound
@@ -762,7 +762,7 @@ lemma bddBelow_range_of_small [Small.{u} ι] (f : ι → PGame.{u}) : BddBelow (
 
 /-- A small set of pre-games is bounded below. -/
 lemma bddBelow_of_small (s : Set PGame.{u}) [Small.{u} s] : BddBelow s := by
-  simpa using bddBelow_range_of_small (Subtype.val : s → PGame.{u})
+  simpa using bddBelow_range_of_small ((↑) : s → PGame.{u})
 #align pgame.bdd_below_of_small SetTheory.PGame.bddBelow_of_small
 
 /-- The equivalence relation on pre-games. Two pre-games `x`, `y` are equivalent if `x ≤ y` and

--- a/Mathlib/SetTheory/Surreal/Basic.lean
+++ b/Mathlib/SetTheory/Surreal/Basic.lean
@@ -412,7 +412,7 @@ lemma bddAbove_range_of_small {ι : Type*} [Small.{u} ι] (f : ι → Surreal.{u
 
 /-- A small set of surreals is bounded above. -/
 lemma bddAbove_of_small (s : Set Surreal.{u}) [Small.{u} s] : BddAbove s := by
-  simpa using bddAbove_range_of_small (Subtype.val : s → Surreal.{u})
+  simpa using bddAbove_range_of_small ((↑) : s → Surreal.{u})
 #align surreal.bdd_above_of_small Surreal.bddAbove_of_small
 
 /-- A small family of surreals is bounded below. -/
@@ -434,7 +434,7 @@ lemma bddBelow_range_of_small {ι : Type*} [Small.{u} ι] (f : ι → Surreal.{u
 
 /-- A small set of surreals is bounded below. -/
 lemma bddBelow_of_small (s : Set Surreal.{u}) [Small.{u} s] : BddBelow s := by
-  simpa using bddBelow_range_of_small (Subtype.val : s → Surreal.{u})
+  simpa using bddBelow_range_of_small ((↑) : s → Surreal.{u})
 #align surreal.bdd_below_of_small Surreal.bddBelow_of_small
 
 end Surreal

--- a/Mathlib/Topology/Bornology/Constructions.lean
+++ b/Mathlib/Topology/Bornology/Constructions.lean
@@ -42,7 +42,7 @@ def Bornology.induced {α β : Type*} [Bornology β] (f : α → β) : Bornology
 #align bornology.induced Bornology.induced
 
 instance {p : α → Prop} : Bornology (Subtype p) :=
-  Bornology.induced (Subtype.val : Subtype p → α)
+  Bornology.induced ((↑) : Subtype p → α)
 
 namespace Bornology
 

--- a/Mathlib/Topology/EMetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/EMetricSpace/Lipschitz.lean
@@ -191,7 +191,7 @@ protected theorem id : LipschitzWith 1 (@id α) :=
 #align lipschitz_with.id LipschitzWith.id
 
 /-- The inclusion of a subset is 1-Lipschitz. -/
-protected theorem subtype_val (s : Set α) : LipschitzWith 1 (Subtype.val : s → α) :=
+protected theorem subtype_val (s : Set α) : LipschitzWith 1 ((↑) : s → α) :=
   LipschitzWith.of_edist_le fun _ _ => le_rfl
 #align lipschitz_with.subtype_val LipschitzWith.subtype_val
 #align lipschitz_with.subtype_coe LipschitzWith.subtype_val

--- a/Mathlib/Topology/Germ.lean
+++ b/Mathlib/Topology/Germ.lean
@@ -143,7 +143,7 @@ theorem sliceRight_coe [TopologicalSpace Y] {y : Y} (f : X × Y → Z) :
 
 lemma isConstant_comp_subtype {s : Set X} {f : X → Y} {x : s}
     (hf : (f : Germ (𝓝 (x : X)) Y).IsConstant) :
-    ((f ∘ Subtype.val : s → Y) : Germ (𝓝 x) Y).IsConstant :=
+    ((f ∘ (↑) : s → Y) : Germ (𝓝 x) Y).IsConstant :=
   isConstant_comp_tendsto hf continuousAt_subtype_val
 
 end Filter.Germ

--- a/Mathlib/Topology/Sets/Opens.lean
+++ b/Mathlib/Topology/Sets/Opens.lean
@@ -260,7 +260,7 @@ instance : Frame (Opens α) :=
     inf_sSup_le_iSup_inf := fun a s =>
       (ext <| by simp only [coe_inf, coe_iSup, coe_sSup, Set.inter_iUnion₂]).le }
 
-theorem openEmbedding' (U : Opens α) : OpenEmbedding ((↑) : U → α) :=
+theorem openEmbedding' (U : Opens α) : OpenEmbedding (Subtype.val : U → α) :=
   U.isOpen.openEmbedding_subtype_val
 
 theorem openEmbedding_of_le {U V : Opens α} (i : U ≤ V) :

--- a/Mathlib/Topology/Sets/Opens.lean
+++ b/Mathlib/Topology/Sets/Opens.lean
@@ -260,7 +260,7 @@ instance : Frame (Opens α) :=
     inf_sSup_le_iSup_inf := fun a s =>
       (ext <| by simp only [coe_inf, coe_iSup, coe_sSup, Set.inter_iUnion₂]).le }
 
-theorem openEmbedding' (U : Opens α) : OpenEmbedding (Subtype.val : U → α) :=
+theorem openEmbedding' (U : Opens α) : OpenEmbedding ((↑) : U → α) :=
   U.isOpen.openEmbedding_subtype_val
 
 theorem openEmbedding_of_le {U V : Opens α} (i : U ≤ V) :

--- a/Mathlib/Topology/UniformSpace/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Basic.lean
@@ -1469,7 +1469,7 @@ theorem map_uniformity_set_coe {s : Set α} [UniformSpace α] :
   rw [uniformity_setCoe, map_comap, range_prod_map, Subtype.range_val]
 
 theorem uniformContinuous_subtype_val {p : α → Prop} [UniformSpace α] :
-    UniformContinuous (Subtype.val : { a : α // p a } → α) :=
+    UniformContinuous ((↑) : { a : α // p a } → α) :=
   uniformContinuous_comap
 #align uniform_continuous_subtype_val uniformContinuous_subtype_val
 #align uniform_continuous_subtype_coe uniformContinuous_subtype_val

--- a/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
@@ -995,7 +995,7 @@ protected def uniformEquivPiComm : (α →ᵤ[𝔖] ((i:ι) → δ i)) ≃ᵤ ((
 Then the set of continuous functions is closed
 in the topology of uniform convergence on the sets of `𝔖`. -/
 theorem isClosed_setOf_continuous_of_le [t : TopologicalSpace α]
-    (h : t ≤ ⨆ s ∈ 𝔖, .coinduced (Subtype.val : s → α) inferInstance) :
+    (h : t ≤ ⨆ s ∈ 𝔖, .coinduced ((↑) : s → α) inferInstance) :
     IsClosed {f : α →ᵤ[𝔖] β | Continuous (toFun 𝔖 f)} := by
   refine isClosed_iff_forall_filter.2 fun f u _ hu huf ↦ ?_
   rw [← tendsto_id', UniformOnFun.tendsto_iff_tendstoUniformlyOn] at huf

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -165,7 +165,7 @@ theorem Filter.HasBasis.uniformEmbedding_iff {ι ι'} {p : ι → Prop} {p' : ι
 #align filter.has_basis.uniform_embedding_iff Filter.HasBasis.uniformEmbedding_iff
 
 theorem uniformEmbedding_subtype_val {p : α → Prop} :
-    UniformEmbedding (Subtype.val : Subtype p → α) :=
+    UniformEmbedding ((↑) : Subtype p → α) :=
   { comap_uniformity := rfl
     inj := Subtype.val_injective }
 #align uniform_embedding_subtype_val uniformEmbedding_subtype_val


### PR DESCRIPTION
---
This is a test to see replacing `Subtype.val` with `(↑)` where appropriate.

After performing the rewrite, some of the types subtly changed in a difficult to detect manner.
Before the change, `openEmbedding' _` had type `OpenEmbedding Subtype.val` where `Subtype.val` expanded as `@Subtype.val α fun x ↦ x ∈ U : ↥U → α`. After the change, `Subtype.val` expands to `@Subtype.val α fun x ↦ x ∈ ↑U : { x // x ∈ ↑U } → α`. This caused some later proofs to fail due to the different definition.

In a similar case, within the proof of `mfderiv_coe_sphere_injective` on line 553 `Subtype.val` expanded as `@Subtype.val E fun x ↦ x ∈ (Submodule.span ℝ {↑(-v)})ᗮ : ↥(Submodule.span ℝ {↑(-v)})ᗮ → E`.
After changing to `(↑)`, it expanded to `@Subtype.val E fun x ↦ x ∈ ↑(Submodule.span ℝ {↑(-v)})ᗮ : { x // x ∈ ↑(Submodule.span ℝ {↑(-v)})ᗮ } → E`. One benefit to using `(↑)`  was that it lead to a shorter proof as `ContinuousLinearEquiv.coe_coe` could be removed on line 559.

In general, this subtle change in types is basically impossible to detect without a tool like leaff.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
