### PR TITLE
[Merged by Bors] - feat: make `generalize_proofs` handle proofs under binders

### DIFF
--- a/Mathlib/Algebra/Category/GroupCat/Limits.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Limits.lean
@@ -520,7 +520,6 @@ def kernelIsoKer {G H : AddCommGroupCat.{u}} (f : G ⟶ H) :
     refine equalizer.hom_ext ?_
     ext x
     dsimp
-    generalize_proofs
     apply DFunLike.congr_fun (kernel.lift_ι f _ _)
   inv_hom_id := by
     apply AddCommGroupCat.ext
@@ -528,7 +527,6 @@ def kernelIsoKer {G H : AddCommGroupCat.{u}} (f : G ⟶ H) :
     rintro ⟨x, mem⟩
     refine Subtype.ext ?_
     simp only [ZeroHom.coe_mk, Function.comp_apply, id_eq]
-    generalize_proofs
     apply DFunLike.congr_fun (kernel.lift_ι f _ _)
 set_option linter.uppercaseLean3 false in
 #align AddCommGroup.kernel_iso_ker AddCommGroupCat.kernelIsoKer

--- a/Mathlib/Algebra/Category/GroupCat/Limits.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Limits.lean
@@ -520,18 +520,16 @@ def kernelIsoKer {G H : AddCommGroupCat.{u}} (f : G ⟶ H) :
     refine equalizer.hom_ext ?_
     ext x
     dsimp
-    generalize_proofs _ h1 h2
-    erw [DFunLike.congr_fun (kernel.lift_ι f _ h1) ⟨_, h2⟩]
-    rfl
+    generalize_proofs
+    apply DFunLike.congr_fun (kernel.lift_ι f _ _)
   inv_hom_id := by
     apply AddCommGroupCat.ext
     simp only [AddMonoidHom.coe_mk, coe_id, coe_comp]
     rintro ⟨x, mem⟩
     refine Subtype.ext ?_
     simp only [ZeroHom.coe_mk, Function.comp_apply, id_eq]
-    generalize_proofs _ h1 h2
-    erw [DFunLike.congr_fun (kernel.lift_ι f _ h1) ⟨_, mem⟩]
-    rfl
+    generalize_proofs
+    apply DFunLike.congr_fun (kernel.lift_ι f _ _)
 set_option linter.uppercaseLean3 false in
 #align AddCommGroup.kernel_iso_ker AddCommGroupCat.kernelIsoKer
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -57,11 +57,11 @@ theorem RespectsIso.basicOpen_iff (hP : RespectsIso @P) {X Y : Scheme} [IsAffine
   congr
   delta IsLocalization.Away.map
   refine' IsLocalization.ringHom_ext (Submonoid.powers r) _
-  generalize_proofs h1 h2 h3
+  generalize_proofs
   haveI i1 := @isLocalization_away_of_isAffine X _ (Scheme.Γ.map f.op r)
   -- Porting note: needs to be very explicit here
   convert
-    (@IsLocalization.map_comp (hy := h3) (Y.presheaf.obj <| Opposite.op (Scheme.basicOpen Y r))
+    (@IsLocalization.map_comp (hy := ‹_ ≤ _›) (Y.presheaf.obj <| Opposite.op (Scheme.basicOpen Y r))
     _ _ (isLocalization_away_of_isAffine _) _ _ _ i1).symm using 1
   change Y.presheaf.map _ ≫ _ = _ ≫ X.presheaf.map _
   rw [f.val.c.naturality_assoc]

--- a/Mathlib/Combinatorics/SimpleGraph/Partition.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Partition.lean
@@ -147,7 +147,8 @@ theorem partitionable_iff_colorable {n : ℕ} : G.Partitionable n ↔ G.Colorabl
   · rintro ⟨C⟩
     refine' ⟨C.toPartition, C.colorClasses_finite, le_trans _ (Fintype.card_fin n).le⟩
     generalize_proofs h
-    haveI : Fintype C.colorClasses := C.colorClasses_finite.fintype
+    change Set.Finite (Coloring.colorClasses C) at h
+    have : Fintype C.colorClasses := C.colorClasses_finite.fintype
     rw [h.card_toFinset]
     exact C.card_colorClasses_le
 #align simple_graph.partitionable_iff_colorable SimpleGraph.partitionable_iff_colorable

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -334,16 +334,16 @@ def fixInduction {C : α → Sort*} {f : α →. Sum β α} {b : β} {a : α} (h
   have h : b ∈ f.fix a := Part.mem_assert_iff.2 ⟨⟨a, ha⟩, h₂⟩
   refine H a h fun a' fa' => IH a' fa' (Part.mem_assert_iff.1 (fix_fwd h fa')).snd
 #align pfun.fix_induction PFun.fixInduction
-
+--set_option trace.Tactic.generalize_proofs true
+set_option pp.proofs true
 theorem fixInduction_spec {C : α → Sort*} {f : α →. Sum β α} {b : β} {a : α} (h : b ∈ f.fix a)
     (H : ∀ a', b ∈ f.fix a' → (∀ a'', Sum.inr a'' ∈ f a' → C a'') → C a') :
     @fixInduction _ _ C _ _ _ h H = H a h fun a' h' => fixInduction (fix_fwd h h') H := by
   unfold fixInduction
-  dsimp -- TODO(kmill)
   generalize_proofs
   -- Porting note: `generalize` required to address `generalize_proofs` bug
   --generalize @fixInduction.proof_1 α β f b a h = ha
-  induction ha
+  induction ‹Acc _ _›
   rfl
 #align pfun.fix_induction_spec PFun.fixInduction_spec
 

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -334,20 +334,16 @@ def fixInduction {C : α → Sort*} {f : α →. Sum β α} {b : β} {a : α} (h
   have h : b ∈ f.fix a := Part.mem_assert_iff.2 ⟨⟨a, ha⟩, h₂⟩
   refine H a h fun a' fa' => IH a' fa' (Part.mem_assert_iff.1 (fix_fwd h fa')).snd
 #align pfun.fix_induction PFun.fixInduction
-set_option trace.Tactic.generalize_proofs true
-set_option pp.proofs true
+
 theorem fixInduction_spec {C : α → Sort*} {f : α →. Sum β α} {b : β} {a : α} (h : b ∈ f.fix a)
     (H : ∀ a', b ∈ f.fix a' → (∀ a'', Sum.inr a'' ∈ f a' → C a'') → C a') :
     @fixInduction _ _ C _ _ _ h H = H a h fun a' h' => fixInduction (fix_fwd h h') H := by
   unfold fixInduction
-  dsimp only
   generalize_proofs
-  -- Porting note: `generalize` required to address `generalize_proofs` bug
-  --generalize @fixInduction.proof_1 α β f b a h = ha
   induction ‹Acc _ _›
   rfl
 #align pfun.fix_induction_spec PFun.fixInduction_spec
-#exit
+
 /-- Another induction lemma for `b ∈ f.fix a` which allows one to prove a predicate `P` holds for
 `a` given that `f a` inherits `P` from `a` and `P` holds for preimages of `b`.
 -/

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -328,21 +328,21 @@ theorem fix_fwd {f : α →. Sum β α} {b : β} {a a' : α} (hb : b ∈ f.fix a
 def fixInduction {C : α → Sort*} {f : α →. Sum β α} {b : β} {a : α} (h : b ∈ f.fix a)
     (H : ∀ a', b ∈ f.fix a' → (∀ a'', Sum.inr a'' ∈ f a' → C a'') → C a') : C a := by
   have h₂ := (Part.mem_assert_iff.1 h).snd
-  -- Porting note: revert/intro trick required to address `generalize_proofs` bug
-  revert h₂
-  generalize_proofs h₁
-  intro h₂; clear h
-  induction' h₁ with a ha IH
+  generalize_proofs at h₂
+  clear h
+  induction' ‹Acc _ _› with a ha IH
   have h : b ∈ f.fix a := Part.mem_assert_iff.2 ⟨⟨a, ha⟩, h₂⟩
-  exact H a h fun a' fa' => IH a' fa' (Part.mem_assert_iff.1 (fix_fwd h fa')).snd
+  refine H a h fun a' fa' => IH a' fa' (Part.mem_assert_iff.1 (fix_fwd h fa')).snd
 #align pfun.fix_induction PFun.fixInduction
 
 theorem fixInduction_spec {C : α → Sort*} {f : α →. Sum β α} {b : β} {a : α} (h : b ∈ f.fix a)
     (H : ∀ a', b ∈ f.fix a' → (∀ a'', Sum.inr a'' ∈ f a' → C a'') → C a') :
     @fixInduction _ _ C _ _ _ h H = H a h fun a' h' => fixInduction (fix_fwd h h') H := by
   unfold fixInduction
+  dsimp -- TODO(kmill)
+  generalize_proofs
   -- Porting note: `generalize` required to address `generalize_proofs` bug
-  generalize @fixInduction.proof_1 α β f b a h = ha
+  --generalize @fixInduction.proof_1 α β f b a h = ha
   induction ha
   rfl
 #align pfun.fix_induction_spec PFun.fixInduction_spec

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -334,19 +334,20 @@ def fixInduction {C : α → Sort*} {f : α →. Sum β α} {b : β} {a : α} (h
   have h : b ∈ f.fix a := Part.mem_assert_iff.2 ⟨⟨a, ha⟩, h₂⟩
   refine H a h fun a' fa' => IH a' fa' (Part.mem_assert_iff.1 (fix_fwd h fa')).snd
 #align pfun.fix_induction PFun.fixInduction
---set_option trace.Tactic.generalize_proofs true
+set_option trace.Tactic.generalize_proofs true
 set_option pp.proofs true
 theorem fixInduction_spec {C : α → Sort*} {f : α →. Sum β α} {b : β} {a : α} (h : b ∈ f.fix a)
     (H : ∀ a', b ∈ f.fix a' → (∀ a'', Sum.inr a'' ∈ f a' → C a'') → C a') :
     @fixInduction _ _ C _ _ _ h H = H a h fun a' h' => fixInduction (fix_fwd h h') H := by
   unfold fixInduction
+  dsimp only
   generalize_proofs
   -- Porting note: `generalize` required to address `generalize_proofs` bug
   --generalize @fixInduction.proof_1 α β f b a h = ha
   induction ‹Acc _ _›
   rfl
 #align pfun.fix_induction_spec PFun.fixInduction_spec
-
+#exit
 /-- Another induction lemma for `b ∈ f.fix a` which allows one to prove a predicate `P` holds for
 `a` given that `f a` inherits `P` from `a` and `P` holds for preimages of `b`.
 -/

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -332,7 +332,7 @@ def fixInduction {C : α → Sort*} {f : α →. Sum β α} {b : β} {a : α} (h
   clear h
   induction' ‹Acc _ _› with a ha IH
   have h : b ∈ f.fix a := Part.mem_assert_iff.2 ⟨⟨a, ha⟩, h₂⟩
-  refine H a h fun a' fa' => IH a' fa' (Part.mem_assert_iff.1 (fix_fwd h fa')).snd
+  exact H a h fun a' fa' => IH a' fa' (Part.mem_assert_iff.1 (fix_fwd h fa')).snd
 #align pfun.fix_induction PFun.fixInduction
 
 theorem fixInduction_spec {C : α → Sort*} {f : α →. Sum β α} {b : β} {a : α} (h : b ∈ f.fix a)

--- a/Mathlib/NumberTheory/Cyclotomic/Gal.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Gal.lean
@@ -56,16 +56,10 @@ theorem autToPow_injective : Function.Injective <| hμ.autToPow K := by
   intro f g hfg
   apply_fun Units.val at hfg
   simp only [IsPrimitiveRoot.coe_autToPow_apply] at hfg
-  -- Porting note: was `generalize_proofs hf' hg' at hfg`
-  revert hfg
-  generalize_proofs hf' hg'
-  intro hfg
+  generalize_proofs hf' hg' at hfg
   have hf := hf'.choose_spec
   have hg := hg'.choose_spec
-  -- Porting note: was `generalize_proofs hζ at hf hg`
-  revert hf hg
-  generalize_proofs hζ
-  intro hf hg
+  generalize_proofs hζ at hf hg
   suffices f (hμ.toRootsOfUnity : Lˣ) = g (hμ.toRootsOfUnity : Lˣ) by
     apply AlgEquiv.coe_algHom_injective
     apply (hμ.powerBasis K).algHom_ext
@@ -154,13 +148,11 @@ noncomputable def fromZetaAut : L ≃ₐ[K] L :=
 
 theorem fromZetaAut_spec : fromZetaAut hμ h (zeta n K L) = μ := by
   simp_rw [fromZetaAut, autEquivPow_symm_apply]
--- Porting note: `generalize_proofs` did not generalize the same proofs, making the proof different.
-  generalize_proofs h1 h2
-  nth_rewrite 4 [← (zeta_spec n K L).powerBasis_gen K]
-  have := Exists.choose_spec ((zeta_spec n K L).eq_pow_of_pow_eq_one hμ.pow_eq_one n.pos)
-  rw [PowerBasis.equivOfMinpoly_gen, h1.powerBasis_gen K, ZMod.coe_unitOfCoprime,
-    ZMod.val_cast_of_lt this.1]
-  exact this.2
+  generalize_proofs hζ h _ hμ _
+  nth_rewrite 4 [← hζ.powerBasis_gen K]
+  rw [PowerBasis.equivOfMinpoly_gen, hμ.powerBasis_gen K]
+  convert h.choose_spec.2
+  exact ZMod.val_cast_of_lt h.choose_spec.1
 #align is_cyclotomic_extension.from_zeta_aut_spec IsCyclotomicExtension.fromZetaAut_spec
 
 end IsCyclotomicExtension

--- a/Mathlib/Tactic/GeneralizeProofs.lean
+++ b/Mathlib/Tactic/GeneralizeProofs.lean
@@ -37,6 +37,9 @@ initialize registerTraceClass `Tactic.generalize_proofs
 
 namespace GeneralizeProofs
 
+/--
+Configuration for the `generalize_proofs` tactic.
+-/
 structure Config where
   /-- The maximum recursion depth when generalizing proofs.
   When `maxDepth > 0`, then proofs are generalized from the types of the generalized proofs too. -/
@@ -48,6 +51,7 @@ structure Config where
   /-- (Debugging) When `true`, enables consistency checks. -/
   debug : Bool := true
 
+/-- Elaborates a `Parser.Tactic.config` for `generalize_proofs`. -/
 declare_config_elab elabConfig Config
 
 /-- State for the `MGen` monad. -/
@@ -148,6 +152,7 @@ def appArgExpectedTypes (f : Expr) (args : Array Expr) (ty? : Option Expr) :
     -- Try using the expected type, but (*) below might find a bad solution
     (guard ty?.isSome *> go f args ty?) <|> go f args none
 where
+  /-- Core implementation for `appArgExpectedTypes`.  -/
   go (f : Expr) (args : Array Expr) (ty? : Option Expr) : MetaM (Array (Option Expr)) := do
     -- Metavariables for each argument to `f`:
     let mut margs := #[]

--- a/Mathlib/Tactic/GeneralizeProofs.lean
+++ b/Mathlib/Tactic/GeneralizeProofs.lean
@@ -1,9 +1,10 @@
 /-
 Copyright (c) 2022 Alex J. Best. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alex J. Best
+Authors: Alex J. Best, Kyle Miller
 -/
 import Lean.Meta.AbstractNestedProofs
+import Lean.Meta.CollectFVars
 import Lean.Meta.Tactic.Generalize
 import Lean.Elab.Tactic.Location
 import Mathlib.Lean.Expr.Basic
@@ -11,108 +12,349 @@ import Mathlib.Lean.Expr.Basic
 /-!
 # The `generalize_proofs` tactic
 
-Generalize any proofs occurring in the goal or in chosen hypotheses, replacing them by
-named hypotheses so that they can be referred to later in the proof easily.
-Commonly useful when dealing with functions like `Classical.choose` that produce data from proofs.
+Generalize any proofs occurring in the goal or in chosen hypotheses,
+replacing them by local hypotheses.
+When these hypotheses are named, this makes it easy to refer to these proofs later in a proof,
+commonly useful when dealing with functions like `Classical.choose` that produce data from proofs.
+It is also useful to eliminate proof terms to handle issues with dependent types.
 
 For example:
 ```lean
-example : List.nthLe [1, 2] 1 dec_trivial = 2 := by
-  -- ⊢ [1, 2].nthLe 1 _ = 2
-  generalize_proofs h,
+example : List.nthLe [1, 2] 1 (by simp) = 2 := by
+  -- ⊢ [1, 2].nthLe 1 ⋯ = 2
+  generalize_proofs h
   -- h : 1 < [1, 2].length
   -- ⊢ [1, 2].nthLe 1 h = 2
 ```
 -/
 
-namespace Mathlib.Tactic.GeneralizeProofs
+namespace Mathlib.Tactic
 open Lean Meta Elab Parser.Tactic Elab.Tactic
 
-/- The following set up are the visit function are based on the file
-Lean.Meta.AbstractNestedProofs in core -/
+initialize registerTraceClass `Tactic.generalize_proofs
 
-/-- State for the generalize proofs tactic, contains the remaining names to be used and the
-list of generalizations so far -/
-structure State where
-  /-- The user provided names, may be anonymous -/
-  nextIdx : List (TSyntax ``binderIdent)
-  /-- The generalizations made so far -/
-  curIdx : Array GeneralizeArg := #[]
-
-/-- Monad used by the `generalizeProofs` tactic, carries an expr cache and state with
-names to use and previous generalizations -/
-abbrev M := MonadCacheT ExprStructEq Expr <| StateRefT State MetaM
-
-/-- generalize the given e -/
-private def mkGen (e : Expr) : M Unit := do
-  let s ← get
-  let t ← match s.nextIdx with
-  | [] => mkFreshUserName `h
-  | n :: rest =>
-    modify fun s ↦ { s with nextIdx := rest }
-    match n with
-    | `(binderIdent| $s:ident) => pure s.getId
-    | _ => mkFreshUserName `h
-  modify fun s ↦ { s with curIdx := s.curIdx.push ⟨e, t, none⟩ }
-
-/-- Recursively generalize proofs occurring in e -/
-partial def visit (e : Expr) : M Expr := do
-  if e.isAtomic then
-    pure e
-  else
-    let visitBinders (xs : Array Expr) (k : M Expr) : M Expr := do
-      let localInstances ← getLocalInstances
-      let mut lctx ← getLCtx
-      for x in xs do
-        let xFVarId := x.fvarId!
-        let localDecl ← xFVarId.getDecl
-        let type      ← visit localDecl.type
-        let localDecl := localDecl.setType type
-        let localDecl ← match localDecl.value? with
-           | some value => let value ← visit value; pure <| localDecl.setValue value
-           | none       => pure localDecl
-        lctx := lctx.modifyLocalDecl xFVarId fun _ ↦ localDecl
-      withLCtx lctx localInstances k
-    checkCache (e : ExprStructEq) fun _ ↦ do
-      if (← AbstractNestedProofs.isNonTrivialProof e) then
-        mkGen e
-        return e
-      else match e with
-        | .lam ..      => lambdaLetTelescope e fun xs b ↦ visitBinders xs do
-          mkLambdaFVars xs (← visit b) (usedLetOnly := false)
-        | .letE ..     => lambdaLetTelescope e fun xs b ↦ visitBinders xs do
-          mkLambdaFVars xs (← visit b) (usedLetOnly := false)
-        | .forallE ..  => forallTelescope e fun xs b ↦ visitBinders xs do
-          mkForallFVars xs (← visit b)
-        | .mdata _ b   => return e.updateMData! (← visit b)
-        | .proj _ _ b  => return e.updateProj! (← visit b)
-        | .app ..      => e.withApp fun f args ↦ return mkAppN f (← args.mapM visit)
-        | _            => pure e
+namespace GeneralizeProofs
 
 /--
-Generalize proofs in the goal, naming them with the provided list.
+State for the generalize proofs tactic.
+Contains the remaining names to be used and the list of generalizations so far.
+-/
+structure GState where
+  /-- Source of names to use for generalized proofs,
+  where `none` means to generate an inaccessible name. -/
+  nextNames : List (Option Name)
+  /-- Mapping from propositions to proofs, used to merge proofs.
+  These should all be valid with respect to the original local context. -/
+  propToProof : ExprMap Expr
+  /-- The fvar/prop/proof triples to add to the local context. -/
+  generalizations : Array (Name × Expr × Expr) := #[]
+
+/--
+Monad used to generalize proofs.
+Carries a state (`Mathlib.Tactic.GeneralizeProofs.State`) keeping track of current generalizations.
+-/
+abbrev MGen := StateRefT GState MetaM
+
+/-- Gets the next name from `State.nextNames`. Returns `none` if a name should be generated. -/
+def nextName? : MGen (Option Name) := do
+  let n? := (← get).nextNames.headD none
+  modify fun s ↦ { s with nextNames := s.nextNames.tail }
+  return n?
+
+/--
+Monad used to abstract proofs, to prepare for generalization.
+Wraps the `MGen` monad and has a cache mapping expressions
+to expressions that have had their proofs abstracted.
+-/
+abbrev MAbs := MonadCacheT Expr Expr <| MGen
+
+/--
+Abstract proofs occurring in the expression.
+A proof is *abstracted* if it is of the form `f a b ...` where `a b ...` are bound variables
+(that is, they are variables that are not present in the initial local context)
+and where `f` contains no bound variables.
+In this form, `f` can be immediately lifted to be a local variable and generalized.
+The abstracted proofs are recorded in the state.
+
+This function is careful to track the type of `e` based on where it's used,
+since the inferred type might be different.
+For example, `(by simp : 1 < [1, 2].length)` has `1 < Nat.succ 1` as the inferred type.
+-/
+partial def abstractProofs (e : Expr) (ty? : Option Expr) : MAbs Expr := do
+  visit (← instantiateMVars e) ty? #[] false
+where
+  /--
+  Core implementation of `abstractProofs`.
+  - `fvars` is the current list of bound variables.
+  - `hasLet` is whether any of the `fvars` is a let variable, for an optimization in `visitProof`.
+  -/
+  visit (e : Expr) (ty? : Option Expr) (fvars : Array Expr) (hasLet : Bool) : MAbs Expr := do
+    if e.isAtomic then
+      return e
+    else
+      checkCache e fun _ ↦ do
+        let ty ← ty?.getDM (inferType e)
+        if ← isProof e then
+          visitProof e ty fvars [] hasLet
+        else
+          match e with
+          | .forallE n t b i =>
+            withLocalDecl n i (← visit t none fvars hasLet) fun x ↦ do
+              mkForallFVars #[x] (← visit (b.instantiate1 x) none (fvars.push x) hasLet)
+          | .lam n t b i => do
+            withLocalDecl n i (← visit t none fvars hasLet) fun x ↦ do
+              let ty ← whnfD ty
+              if !ty.isForall then panic! "Expecting forall in abstractProofs .lam"
+              let ty' := ty.instantiate1 x
+              mkLambdaFVars #[x] (← visit (b.instantiate1 x) ty' (fvars.push x) hasLet)
+          | .letE n t v b _ =>
+            let t' ← visit t none fvars hasLet
+            withLetDecl n t' (← visit v t' fvars hasLet) fun x ↦ do
+              mkLetFVars #[x] (← visit (b.instantiate1 x) ty (fvars.push x) true)
+          | .app .. =>
+            e.withApp fun f args ↦ do
+              -- For simplicity, don't try to propagate the type into the function.
+              let f' ← visit f none fvars hasLet
+              let mut fty ← inferType f'
+              let mut args' := #[]
+              let mut unifiedTy := false
+              for i in [0:args.size] do
+                if args'.size ≤ i then
+                  let (args'', _, fty') ← forallMetaBoundedTelescope fty (args.size - i)
+                  if args''.isEmpty then panic! "Could not make progress in abstractProofs .app"
+                  fty := fty'
+                  args' := args' ++ args''
+                if !unifiedTy && args'.size == args.size then
+                  unifiedTy ← isDefEqGuarded fty ty
+                let argTy := (← instantiateMVars <| ← inferType args'[i]!).cleanupAnnotations
+                let arg' ← visit args[i]! argTy fvars hasLet
+                unless ← isDefEq argTy (← inferType arg') do
+                  panic! s!"failed isDefEq for .app {i}, {← ppExpr args'[i]!}, {← ppExpr args[i]!}"
+                args'[i]!.mvarId!.assign arg'
+              instantiateMVars <| mkAppN f' args'
+          | .mdata _ b  => return e.updateMData! (← visit b ty fvars hasLet)
+          -- Giving up propagating expected types for `.proj`, which we shouldn't see anyway
+          | .proj _ _ b => return e.updateProj! (← visit b none fvars hasLet)
+          | _           => unreachable!
+  /--
+  Core implementation of abstracting a proof.
+  The `ty` argument is the type of `mkAppN e appliedFVars`.
+  -/
+  visitProof (e ty : Expr) (fvars : Array Expr) (appliedFVars : List Expr) (hasLet : Bool) :
+      MAbs Expr := do
+    -- 0. eliminate mdata
+    if let .mdata _ e' := e then
+      return ← visitProof e' ty fvars appliedFVars hasLet
+    -- 1. peel off fvars corresponding to bound variables.
+    if let .app f x := e then
+      if fvars.contains x then
+        return ← visitProof f ty fvars (x :: appliedFVars) hasLet
+    -- 2. zeta reduce to ensure that there are no dependencies on lets from `fvars`.
+    let e ←
+      if hasLet then
+        Meta.transform (usedLetOnly := true) e fun node => do
+          match node with
+          | .fvar fvarId =>
+            if fvars.contains node then
+              if let some val ← fvarId.getValue? then
+                return .visit val
+            return .done node
+          | _ => return .continue
+      else
+        pure e
+    -- 3. if atomic, then no use in abstracting
+    if e.isAtomic then
+      trace[Tactic.generalize_proofs] "3 atomic"
+      return appliedFVars.foldl .app e
+    -- 4. abstract `fvars` out of `e` to make the abstracted proof `pf`
+    let usedFVars := (collectFVars {} e).fvarSet
+    let fvars' := fvars.filter (fun fvar => usedFVars.contains fvar.fvarId!)
+    let pf ← mkLambdaFVars fvars' e
+    -- this is a big approximation for type propagation:
+    let pfTy ← if appliedFVars.isEmpty then pure ty else instantiateMVars (← inferType pf)
+    -- 5. check if there is already a recorded proof for this proposition.
+    trace[Tactic.generalize_proofs] "finding {pfTy}"
+    if let some pf' := (← get).propToProof.find? pfTy then
+      trace[Tactic.generalize_proofs] "5 found proof"
+      return appliedFVars.foldl .app (mkAppN pf' fvars')
+    -- 6. record the proof in the state and return the proof.
+    let name ← (← nextName?).getDM (mkFreshUserName `h)
+    modify fun s =>
+      { s with
+        propToProof := s.propToProof.insert pfTy pf
+        generalizations := s.generalizations.push (name, pfTy, pf) }
+    trace[Tactic.generalize_proofs] "6 added"
+    return appliedFVars.foldl .app (mkAppN pf fvars')
+
+/--
+Create a mapping of all propositions in the local context to their fvars.
+-/
+def initialPropToProof : MetaM (ExprMap Expr) := do
+  -- Visit decls in reverse order so that in case there are duplicates,
+  -- earlier proofs are preferred
+  (← getLCtx).foldrM (init := {}) fun decl m => do
+    if !decl.isImplementationDetail then
+      let ty := (← instantiateMVars decl.type).cleanupAnnotations
+      if ← Meta.isProp ty then
+        return m.insert ty decl.toExpr
+    return m
+
+/--
+Generalizes the proofs in the type `e` and runs `k` in a local context with these propositions.
+This continuation `k` is passed
+1. an array of fvars for the propositions
+2. an array of proof terms (extracted from `e`) that prove these propositions
+3. the generalized `e`, which refers to these fvars
+
+The `generalizations` array in the `MGen` is completely managed by this function.
+The `propToProof` map is updated with the new proposition fvars.
+-/
+def withGeneralizedProofs {α : Type} [Inhabited α] (e : Expr) (ty? : Option Expr)
+    (k : Array Expr → Array Expr → Expr → MGen α) :
+    MGen α := do
+  let propToProof := (← get).propToProof
+  modify fun s => { s with generalizations := #[] }
+  trace[Tactic.generalize_proofs] "pre-abstracted{indentD e}\npropToProof: {propToProof.toArray}"
+  let e ← abstractProofs e ty? |>.run
+  trace[Tactic.generalize_proofs] "post-abstracted{indentD e}"
+  let generalizations := (← get).generalizations
+  trace[Tactic.generalize_proofs] "new generalizations: {generalizations}"
+  let decls := generalizations.map fun (name, ty, _) => (name, fun _ => pure ty)
+  withLocalDeclsD decls fun fvars => do
+    let mut propToProof := propToProof
+    let mut map : ExprMap Expr := {}
+    for (_, _, pf) in generalizations, x in fvars do
+      map := map.insert pf x
+      propToProof := propToProof.insert (← instantiateMVars (← inferType x)).cleanupAnnotations x
+    modify fun s => { s with propToProof }
+    trace[Tactic.generalize_proofs] "replacing. map: {map.toArray}\nbefore: e = {e}"
+    let e' := e.replace map.find?
+    trace[Tactic.generalize_proofs] "after: e = {e}"
+    k fvars (generalizations.map fun (_, _, pf) => pf) e'
+
+/--
+Main loop for `Lean.MVarId.generalizeProofs`.
+The `fvars` array is the array of fvars to generalize proofs for,
+and `rfvars` is the array of fvars that have been reverted.
+The `g` metavariable has all of these fvars reverted.
+-/
+partial def generalizeProofsCore
+    (g : MVarId) (fvars rfvars : Array FVarId) (target : Bool) :
+    MGen (Array FVarId × MVarId) :=
+  go g 0 #[]
+where
+  go (g : MVarId) (i : Nat) (hs : Array FVarId) : MGen (Array FVarId × MVarId) := g.withContext do
+    let tag ← g.getTag
+    if h : i < rfvars.size then
+      trace[Tactic.generalize_proofs] "generalizeProofsCore {i}{g}\n{(← get).propToProof.toArray}"
+      let fvar := rfvars[i]
+      if fvars.contains fvar then
+        let tgt ← instantiateMVars <| ← g.getType
+        let ty := tgt.bindingDomain!.cleanupAnnotations
+        if ← pure tgt.isLet <&&> Meta.isProp ty then
+          -- Clear the proof value (using proof irrelevance) and `go` again
+          let tgt' := Expr.forallE tgt.bindingName! ty tgt.bindingBody! tgt.bindingInfo!
+          let g' ← mkFreshExprSyntheticOpaqueMVar tgt' tag
+          g.assign <| .app g' tgt.letValue!
+          return ← go g'.mvarId! i hs
+        if let some pf := (← get).propToProof.find? ty then
+          -- Eliminate this local hypothesis using the pre-existing proof, using proof irrelevance
+          let tgt' := tgt.bindingBody!.instantiate1 pf
+          let g' ← mkFreshExprSyntheticOpaqueMVar tgt' tag
+          g.assign <| .lam tgt.bindingName! tgt.bindingDomain! g' tgt.bindingInfo!
+          return ← go g'.mvarId! (i + 1) hs
+        -- Now the main case, handling forall or let
+        match tgt with
+        | .forallE n t b bi =>
+          let prop ← Meta.isProp t
+          withGeneralizedProofs t none fun hs' pfs' t' => do
+            let t' := t'.cleanupAnnotations
+            let tgt' := Expr.forallE n t' b bi
+            let g' ← mkFreshExprSyntheticOpaqueMVar tgt' tag
+            g.assign <| mkAppN (← mkLambdaFVars hs' g') pfs'
+            let (fvar', g') ← g'.mvarId!.intro1P
+            g'.withContext do Elab.pushInfoLeaf <|
+              .ofFVarAliasInfo { id := fvar', baseId := fvar, userName := ← fvar'.getUserName }
+            if prop then
+              -- Make this prop available as a proof
+              modify fun s => { s with propToProof := s.propToProof.insert t' (.fvar fvar') }
+            go g' (i + 1) (hs ++ hs'.map Expr.fvarId!)
+        | .letE n t v b _ =>
+          withGeneralizedProofs t none fun hs' pfs' t' => do
+            withGeneralizedProofs v t' fun hs'' pfs'' v' => do
+              let tgt' := Expr.letE n t' v' b false
+              let g' ← mkFreshExprSyntheticOpaqueMVar tgt' tag
+              g.assign <| mkAppN (← mkLambdaFVars (hs' ++ hs'') g') (pfs' ++ pfs'')
+              let (fvar', g') ← g'.mvarId!.intro1P
+              g'.withContext do Elab.pushInfoLeaf <|
+                .ofFVarAliasInfo { id := fvar', baseId := fvar, userName := ← fvar'.getUserName }
+              go g' (i + 1) (hs ++ hs'.map Expr.fvarId! ++ hs''.map Expr.fvarId!)
+        | _ => unreachable!
+      else
+        let (fvar', g') ← g.intro1P
+        g'.withContext do Elab.pushInfoLeaf <|
+          .ofFVarAliasInfo { id := fvar', baseId := fvar, userName := ← fvar'.getUserName }
+        go g' (i + 1) hs
+    else if target then
+      trace[Tactic.generalize_proofs] "generalizeProofsCore target{g}\n{(← get).propToProof.toArray}"
+      withGeneralizedProofs (← g.getType) none fun hs' pfs' ty' => do
+        let g' ← mkFreshExprSyntheticOpaqueMVar ty' tag
+        g.assign <| mkAppN (← mkLambdaFVars hs' g') pfs'
+        return (hs ++ hs'.map Expr.fvarId!, g'.mvarId!)
+    else
+      return (hs, g)
+
+
+end GeneralizeProofs
+
+/--
+Generalize proofs in the hypotheses `fvars` and, if `target` is true, the target.
+Uses `names` for the names of the proofs that are generalized.
+
+If a hypothesis is a proposition and a `let` binding, this will clear the value of the let binding.
+
+If a hypothesis is a proposition that already appears in the local context, it will be eliminated.
+-/
+partial def _root_.Lean.MVarId.generalizeProofs
+    (g : MVarId) (fvars : Array FVarId) (target : Bool) (names : List (Option Name)) :
+    MetaM (Array FVarId × MVarId) := do
+  let (rfvars, g) ← g.revert fvars (clearAuxDeclsInsteadOfRevert := true)
+  g.withContext do
+    let s := { nextNames := names, propToProof := ← GeneralizeProofs.initialPropToProof }
+    GeneralizeProofs.generalizeProofsCore g fvars rfvars target |>.run' s
+
+/--
+Generalizes proofs in the current goal.
+- `generalize_proofs` generalizes proofs in the target.
+- `generalize_proofs at h₁ h₂ ⊢` generalized proofs in hypotheses `h₁` and `h₂` as well as the goal.
+- `generalize_proofs pf₁ pf₂ pf₃` uses names `pf₁`, `pf₂`, and `pf₃` for the generalized proofs.
+  These can be `_` to not name proofs.
+
+If a proof is already present in the local context, it will use that rather than generating a new
+local hypothesis.
+
+When doing `generalize_proofs at h`, if `h` is a let binding, its value is cleared,
+and furthermore if `h` is a duplicate of a preceding local hypothesis, it is eliminated.
 
 For example:
 ```lean
-example : List.nthLe [1, 2] 1 dec_trivial = 2 := by
-  -- ⊢ [1, 2].nthLe 1 _ = 2
-  generalize_proofs h,
+example : List.nthLe [1, 2] 1 (by simp) = 2 := by
+  -- ⊢ [1, 2].nthLe 1 ⋯ = 2
+  generalize_proofs h
   -- h : 1 < [1, 2].length
   -- ⊢ [1, 2].nthLe 1 h = 2
 ```
 -/
-elab (name := generalizeProofs) "generalize_proofs"
-    hs:(ppSpace colGt binderIdent)* loc:(location)? : tactic => do
-  let ou := if loc.isSome then
-    match expandLocation loc.get! with
-    | .wildcard => #[]
-    | .targets t _ => t
-  else #[]
-  let fvs ← getFVarIds ou
-  let goal ← getMainGoal
-  let ty ← instantiateMVars (← goal.getType)
-  let (_, ⟨_, out⟩) ← GeneralizeProofs.visit ty |>.run.run { nextIdx := hs.toList }
-  let (_, fvarIds, goal) ← goal.generalizeHyp out fvs
-  for h in hs, fvar in fvarIds do
-    goal.withContext <| (Expr.fvar fvar).addLocalVarInfoForBinderIdent h
-  replaceMainGoal [goal]
+elab (name := generalizeProofsElab) "generalize_proofs"
+    hs:(ppSpace colGt binderIdent)* loc?:(location)? : tactic => withMainContext do
+  let names := hs |>.map (fun | `(binderIdent| $s:ident) => some s.getId | _ => none) |>.toList
+  let loc := expandOptLocation (Lean.mkOptionalNode loc?)
+  let (fvars, target) ←
+    match loc with
+    | .wildcard => pure ((← getLCtx).getFVarIds, true)
+    | .targets t target => pure (← getFVarIds t, target)
+  liftMetaTactic1 fun g => do
+    let (pfs, g) ← g.generalizeProofs fvars target names
+    for h in hs, fvar in pfs do
+      g.withContext <| (Expr.fvar fvar).addLocalVarInfoForBinderIdent h
+    return g

--- a/Mathlib/Tactic/GeneralizeProofs.lean
+++ b/Mathlib/Tactic/GeneralizeProofs.lean
@@ -49,7 +49,7 @@ structure Config where
   When it is `false` then such proofs are left alone. -/
   abstract : Bool := true
   /-- (Debugging) When `true`, enables consistency checks. -/
-  debug : Bool := true
+  debug : Bool := false
 
 /-- Elaborates a `Parser.Tactic.config` for `generalize_proofs`. -/
 declare_config_elab elabConfig Config

--- a/test/GeneralizeProofs.lean
+++ b/test/GeneralizeProofs.lean
@@ -5,30 +5,51 @@ private axiom test_sorry : ∀ {α}, α
 set_option autoImplicit true
 noncomputable def List.nthLe (l : List α) (n) (_h : n < l.length) : α := test_sorry
 
+-- For debugging `generalize_proofs`
+-- set_option trace.Tactic.generalize_proofs true
+
 example : List.nthLe [1, 2] 1 (by simp) = 2 := by
-  -- ⊢ [1 2].nth_le 1 _ = 2
   generalize_proofs h
-  -- h : 1 < [1 2].length
-  -- ⊢ [1 2].nth_le 1 h = 2
+  guard_hyp h :ₛ 1 < List.length [1, 2]
+  guard_target =ₛ [1, 2].nthLe 1 h = 2
   exact test_sorry
 
 example (x : ℕ) (h : x < 2) : Classical.choose (⟨x, h⟩ : ∃ x, x < 2) < 2 := by
   generalize_proofs a
-  guard_hyp a : ∃ x, x < 2
-  guard_target = Classical.choose a < 2
+  guard_hyp a :ₛ ∃ x, x < 2
+  guard_target =ₛ Classical.choose a < 2
   exact Classical.choose_spec a
 
 example (x : ℕ) (h : x < 2) : Classical.choose (⟨x, h⟩ : ∃ x, x < 2) = Classical.choose (⟨x, h⟩ : ∃ x, x < 2) := by
   generalize_proofs a
-  guard_hyp a : ∃ x, x < 2
-  guard_target = Classical.choose a = Classical.choose a
+  guard_hyp a :ₛ ∃ x, x < 2
+  guard_target =ₛ Classical.choose a = Classical.choose a
+  rfl
+
+example (x : ℕ) (h : x < 2) (h' : x < 1) :
+    Classical.choose (⟨x, h⟩ : ∃ x, x < 2) = Classical.choose (⟨x, (by clear h; omega)⟩ : ∃ x, x < 2) := by
+  generalize_proofs a
+  guard_hyp a :ₛ ∃ x, x < 2
+  guard_target =ₛ Classical.choose a = Classical.choose a
+  rfl
+
+example (x : ℕ) (h h' : x < 2) :
+    Classical.choose (⟨x, h⟩ : ∃ x, x < 2) = Classical.choose (⟨x, h'⟩ : ∃ x, x < 2) := by
+  change _ at h'
+  fail_if_success guard_target =ₛ Classical.choose (⟨x, h⟩ : ∃ x, x < 2) = Classical.choose (⟨x, h⟩ : ∃ x, x < 2)
+  generalize_proofs at h'
+  fail_if_success change _ at h'
+  guard_target =ₛ Classical.choose (⟨x, h⟩ : ∃ x, x < 2) = Classical.choose (⟨x, h⟩ : ∃ x, x < 2)
+  generalize_proofs a
+  guard_target =ₛ Classical.choose a = Classical.choose a
   rfl
 
 example (x : ℕ) (h : x < 2) : Classical.choose (⟨x, h⟩ : ∃ x, x < 2) =
   Classical.choose (⟨x, Nat.lt_succ_of_lt h⟩ : ∃ x, x < 3) := by
-  generalize_proofs a
-  guard_hyp a : ∃ x, x < 2
-  guard_target = Classical.choose a = Classical.choose _
+  generalize_proofs a a'
+  guard_hyp a :ₛ ∃ x, x < 2
+  guard_hyp a' :ₛ ∃ x, x < 3
+  guard_target =ₛ Classical.choose a = Classical.choose a'
   exact test_sorry
 
 example (x : ℕ) (h : x < 2) : Classical.choose (⟨x, h⟩ : ∃ x, x < 2) =
@@ -46,33 +67,35 @@ example (x : ℕ) (h : x < 2) : Classical.choose (⟨x, h⟩ : ∃ x, x < 2) =
 
 example (a : ∃ x, x < 2) : Classical.choose a < 2 := by
   generalize_proofs
-  guard_target = Classical.choose a < 2
+  guard_target =ₛ Classical.choose a < 2
   exact Classical.choose_spec a
 
 example (a : ∃ x, x < 2) : Classical.choose a < 2 := by
   generalize_proofs t
-  guard_target = Classical.choose a < 2
+  guard_target =ₛ Classical.choose a < 2
   exact Classical.choose_spec a
 
 example (x : ℕ) (h : x < 2) (H : Classical.choose (⟨x, h⟩ : ∃ x, x < 2) < 2) :
     Classical.choose (⟨x, h⟩ : ∃ x, x < 2) < 2 := by
   generalize_proofs a at H ⊢
-  guard_hyp a : ∃ x, x < 2
-  guard_hyp H : Classical.choose a < 2
-  guard_target = Classical.choose a < 2
+  guard_hyp a :ₛ ∃ x, x < 2
+  guard_hyp H :ₛ Classical.choose a < 2
+  guard_target =ₛ Classical.choose a < 2
   exact H
 
--- FIXME: result is not type correct
--- example (H : ∀ y, ∃ (x : ℕ) (h : x < y), Classical.choose (⟨x, h⟩ : ∃ x, x < y) < y) :
---   ∀ y, ∃ (x : ℕ) (h : x < y), Classical.choose (⟨x, h⟩ : ∃ x, x < y) < y := by
---   generalize_proofs a at H ⊢
+example (H : ∀ y, ∃ (x : ℕ) (h : x < y), Classical.choose (⟨x, h⟩ : ∃ x, x < y) < y) :
+  ∀ y, ∃ (x : ℕ) (h : x < y), Classical.choose (⟨x, h⟩ : ∃ x, x < y) < y := by
+  generalize_proofs a at H ⊢
+  guard_hyp a :ₛ ∀ (y w : ℕ), w < y → ∃ x, x < y
+  guard_hyp H :ₛ ∀ (y : ℕ), ∃ x h, Classical.choose (a y x h) < y
+  guard_target =ₛ ∀ (y : ℕ), ∃ x h, Classical.choose (a y x h) < y
+  exact H
 
 attribute [local instance] Classical.propDecidable
 
 example (H : ∀ x, x = 1) : (if h : ∃ (k : ℕ), k = 1 then Classical.choose h else 0) = 1 := by
-  rw [dif_pos]
-  rotate_left
-  { exact ⟨1, rfl⟩ }
+  rw [dif_pos ?hc]
+  case hc => exact ⟨1, rfl⟩
   generalize_proofs h g
-  guard_target = Classical.choose h = 1
+  guard_target =ₛ Classical.choose h = 1
   apply H

--- a/test/GeneralizeProofs.lean
+++ b/test/GeneralizeProofs.lean
@@ -105,6 +105,26 @@ example (H : ∀ y, ∃ (x : ℕ) (h : x < y), Classical.choose (⟨x, h⟩ : �
   guard_target =ₛ ∀ (y : ℕ), ∃ x h, Classical.choose (a y x h) < y
   exact H
 
+namespace zulip1
+/-!
+https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.60generalize_proofs.60.20sometimes.20silently.20has.20no.20effect/near/407162574
+-/
+
+theorem t (x : Option Unit) : x.isSome = true := test_sorry
+def p : Unit → Prop := test_sorry
+
+theorem good (x : Option Unit) : p (Option.get x test_sorry) → x.isSome = true := by
+  generalize_proofs h
+  exact fun _ => h
+
+theorem was_bad (x : Option Unit) : p (Option.get x (t x)) → x.isSome = true := by
+  generalize_proofs h
+  exact fun _ => h
+
+end zulip1
+
+section
+
 attribute [local instance] Classical.propDecidable
 
 example (H : ∀ x, x = 1) : (if h : ∃ (k : ℕ), k = 1 then Classical.choose h else 0) = 1 := by
@@ -114,3 +134,5 @@ example (H : ∀ x, x = 1) : (if h : ∃ (k : ℕ), k = 1 then Classical.choose 
   guard_hyp h :ₛ ∃ x, x = 1
   guard_target =ₛ Classical.choose h = 1
   apply H
+
+end

--- a/test/GeneralizeProofs.lean
+++ b/test/GeneralizeProofs.lean
@@ -20,14 +20,16 @@ example (x : ℕ) (h : x < 2) : Classical.choose (⟨x, h⟩ : ∃ x, x < 2) < 2
   guard_target =ₛ Classical.choose a < 2
   exact Classical.choose_spec a
 
-example (x : ℕ) (h : x < 2) : Classical.choose (⟨x, h⟩ : ∃ x, x < 2) = Classical.choose (⟨x, h⟩ : ∃ x, x < 2) := by
+example (x : ℕ) (h : x < 2) :
+    Classical.choose (⟨x, h⟩ : ∃ x, x < 2) = Classical.choose (⟨x, h⟩ : ∃ x, x < 2) := by
   generalize_proofs a
   guard_hyp a :ₛ ∃ x, x < 2
   guard_target =ₛ Classical.choose a = Classical.choose a
   rfl
 
 example (x : ℕ) (h : x < 2) (h' : x < 1) :
-    Classical.choose (⟨x, h⟩ : ∃ x, x < 2) = Classical.choose (⟨x, (by clear h; omega)⟩ : ∃ x, x < 2) := by
+    Classical.choose (⟨x, h⟩ : ∃ x, x < 2)
+      = Classical.choose (⟨x, (by clear h; omega)⟩ : ∃ x, x < 2) := by
   generalize_proofs a
   guard_hyp a :ₛ ∃ x, x < 2
   guard_target =ₛ Classical.choose a = Classical.choose a
@@ -36,7 +38,8 @@ example (x : ℕ) (h : x < 2) (h' : x < 1) :
 example (x : ℕ) (h h' : x < 2) :
     Classical.choose (⟨x, h⟩ : ∃ x, x < 2) = Classical.choose (⟨x, h'⟩ : ∃ x, x < 2) := by
   change _ at h'
-  fail_if_success guard_target =ₛ Classical.choose (⟨x, h⟩ : ∃ x, x < 2) = Classical.choose (⟨x, h⟩ : ∃ x, x < 2)
+  fail_if_success guard_target =ₛ
+    Classical.choose (⟨x, h⟩ : ∃ x, x < 2) = Classical.choose (⟨x, h⟩ : ∃ x, x < 2)
   generalize_proofs at h'
   fail_if_success change _ at h'
   guard_target =ₛ Classical.choose (⟨x, h⟩ : ∃ x, x < 2) = Classical.choose (⟨x, h⟩ : ∃ x, x < 2)
@@ -44,8 +47,9 @@ example (x : ℕ) (h h' : x < 2) :
   guard_target =ₛ Classical.choose a = Classical.choose a
   rfl
 
-example (x : ℕ) (h : x < 2) : Classical.choose (⟨x, h⟩ : ∃ x, x < 2) =
-  Classical.choose (⟨x, Nat.lt_succ_of_lt h⟩ : ∃ x, x < 3) := by
+example (x : ℕ) (h : x < 2) :
+    Classical.choose (⟨x, h⟩ : ∃ x, x < 2)
+      = Classical.choose (⟨x, Nat.lt_succ_of_lt h⟩ : ∃ x, x < 3) := by
   generalize_proofs a a'
   guard_hyp a :ₛ ∃ x, x < 2
   guard_hyp a' :ₛ ∃ x, x < 3
@@ -84,8 +88,18 @@ example (x : ℕ) (h : x < 2) (H : Classical.choose (⟨x, h⟩ : ∃ x, x < 2) 
   exact H
 
 example (H : ∀ y, ∃ (x : ℕ) (h : x < y), Classical.choose (⟨x, h⟩ : ∃ x, x < y) < y) :
-  ∀ y, ∃ (x : ℕ) (h : x < y), Classical.choose (⟨x, h⟩ : ∃ x, x < y) < y := by
+    ∀ y, ∃ (x : ℕ) (h : x < y), Classical.choose (⟨x, h⟩ : ∃ x, x < y) < y := by
+  generalize_proofs (config := { abstract := false })
+  guard_target =ₛ ∀ y, ∃ (x : ℕ) (h : x < y), Classical.choose (⟨x, h⟩ : ∃ x, x < y) < y
   generalize_proofs a at H ⊢
+  guard_hyp a :ₛ ∀ (y w : ℕ), w < y → ∃ x, x < y
+  guard_hyp H :ₛ ∀ (y : ℕ), ∃ x h, Classical.choose (a y x h) < y
+  guard_target =ₛ ∀ (y : ℕ), ∃ x h, Classical.choose (a y x h) < y
+  exact H
+
+example (H : ∀ y, ∃ (x : ℕ) (h : x < y), Classical.choose (⟨x, h⟩ : ∃ x, x < y) < y) :
+    ∀ y, ∃ (x : ℕ) (h : x < y), Classical.choose (⟨x, h⟩ : ∃ x, x < y) < y := by
+  generalize_proofs a at *
   guard_hyp a :ₛ ∀ (y w : ℕ), w < y → ∃ x, x < y
   guard_hyp H :ₛ ∀ (y : ℕ), ∃ x h, Classical.choose (a y x h) < y
   guard_target =ₛ ∀ (y : ℕ), ∃ x h, Classical.choose (a y x h) < y
@@ -96,6 +110,7 @@ attribute [local instance] Classical.propDecidable
 example (H : ∀ x, x = 1) : (if h : ∃ (k : ℕ), k = 1 then Classical.choose h else 0) = 1 := by
   rw [dif_pos ?hc]
   case hc => exact ⟨1, rfl⟩
-  generalize_proofs h g
+  generalize_proofs h
+  guard_hyp h :ₛ ∃ x, x = 1
   guard_target =ₛ Classical.choose h = 1
   apply H


### PR DESCRIPTION
The `generalize_proofs` tactic had a bug where it would not generalize proofs that appeared under binders correctly, creating terms with fvars from the wrong context. The tactic has been refactored, and it now abstracts the proofs (universally quantifying all the bound variables that appear in the proof) before lifting them to the local context.

This feature can be controlled with the `abstract` option. Using `generalize_proofs (config := { abstract := false })` turns off proof abstraction and leaves alone those proofs that refer to bound variables.

Other new features:
- `generalize_proofs at h` for a let-bound local hypothesis `h` will clear its value.
- `generalize_proofs at h` for a duplicate proposition will eliminate `h` from the local context.
- Proofs are recursively generalized for each new local hypothesis. This can be turned off with `generalize_proofs (config := { maxDepth := 0 })`.
- `generalize_proofs at h` will no longer generalize proofs from the goal.
- The type of the generalized proof is carefully computed by propagating expected types, rather than by using `inferType`. This gives local hypotheses in more useful forms.

(This PR serves as a followup to [this comment](https://github.com/leanprover-community/mathlib4/pull/447#issuecomment-1306171602).)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
