### PR TITLE
[Merged by Bors] - feat: add an `OfScientific` instance for `NNRat` and `NNReal`

### DIFF
--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -230,6 +230,11 @@ end Rat
 instance RatCast.toOfScientific [RatCast K] : OfScientific K where
   ofScientific (m : ℕ) (b : Bool) (d : ℕ) := Rat.ofScientific m b d
 
+/-- Make `OfScientific.ofScientific` the simp-normal form. -/
+@[simp]
+theorem Rat.ofScientific_eq_ofScientific :
+    Rat.ofScientific = OfScientific.ofScientific := rfl
+
 @[simp, norm_cast]
 theorem Rat.cast_ofScientific [RatCast K] (m : ℕ) (b : Bool) (d : ℕ) :
     (OfScientific.ofScientific m b d : ℚ) = (OfScientific.ofScientific m b d : K) := rfl

--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -229,3 +229,7 @@ end Rat
 
 instance RatCast.toOfScientific [RatCast K] : OfScientific K where
   ofScientific (m : ℕ) (b : Bool) (d : ℕ) := Rat.ofScientific m b d
+
+@[simp, norm_cast]
+theorem Rat.cast_ofScientific [RatCast K] (m : ℕ) (b : Bool) (d : ℕ) :
+    (OfScientific.ofScientific m b d : ℚ) = (OfScientific.ofScientific m b d : K) := rfl

--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -227,14 +227,7 @@ theorem smul_one_eq_coe (A : Type*) [DivisionRing A] (m : ℚ) : m • (1 : A) =
 
 end Rat
 
-instance RatCast.toOfScientific [RatCast K] : OfScientific K where
-  ofScientific (m : ℕ) (b : Bool) (d : ℕ) := Rat.ofScientific m b d
-
 /-- `OfScientific.ofScientific` is the simp-normal form. -/
 @[simp]
 theorem Rat.ofScientific_eq_ofScientific :
     Rat.ofScientific = OfScientific.ofScientific := rfl
-
-@[simp, norm_cast]
-theorem Rat.cast_ofScientific [RatCast K] (m : ℕ) (b : Bool) (d : ℕ) :
-    (OfScientific.ofScientific m b d : ℚ) = (OfScientific.ofScientific m b d : K) := rfl

--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -230,7 +230,7 @@ end Rat
 instance RatCast.toOfScientific [RatCast K] : OfScientific K where
   ofScientific (m : ℕ) (b : Bool) (d : ℕ) := Rat.ofScientific m b d
 
-/-- Make `OfScientific.ofScientific` the simp-normal form. -/
+/-- `OfScientific.ofScientific` is the simp-normal form. -/
 @[simp]
 theorem Rat.ofScientific_eq_ofScientific :
     Rat.ofScientific = OfScientific.ofScientific := rfl

--- a/Mathlib/Data/Rat/Cast/Lemmas.lean
+++ b/Mathlib/Data/Rat/Cast/Lemmas.lean
@@ -39,3 +39,19 @@ theorem cast_inv_int (n : ℤ) : ((n⁻¹ : ℚ) : α) = (n : α)⁻¹ := by
   · simp [ofInt_eq_cast, cast_inv_nat]
   · simp only [ofInt_eq_cast, Int.cast_negSucc, ← Nat.cast_succ, cast_neg, inv_neg, cast_inv_nat]
 #align rat.cast_inv_int Rat.cast_inv_int
+
+@[simp, norm_cast]
+theorem cast_nnratCast {K} [DivisionRing K] (q : ℚ≥0) :
+    ((q : ℚ) : K) = (q : K) := by
+  rw [Rat.cast_def, NNRat.cast_def, NNRat.cast_def]
+  have hn := @num_div_eq_of_coprime q.num q.den ?hdp q.coprime_num_den
+  have hd := @den_div_eq_of_coprime q.num q.den ?hdp q.coprime_num_den
+  case hdp => simpa only [Nat.cast_pos] using q.den_pos
+  simp only [Int.cast_natCast, Nat.cast_inj] at hn hd
+  rw [hn, hd, Int.cast_natCast]
+
+/-- Casting a scientific literal via `ℚ` is the same as casting directly. -/
+@[simp, norm_cast]
+theorem cast_ofScientific {K} [DivisionRing K] (m : ℕ) (b : Bool) (d : ℕ) :
+    (OfScientific.ofScientific m b d : ℚ) = (OfScientific.ofScientific m b d : K) := by
+  rw [← NNRat.cast_ofScientific (K := K), ← NNRat.cast_ofScientific, cast_nnratCast]

--- a/Mathlib/Data/Rat/Cast/Lemmas.lean
+++ b/Mathlib/Data/Rat/Cast/Lemmas.lean
@@ -52,10 +52,12 @@ theorem cast_nnratCast {K} [DivisionRing K] (q : ℚ≥0) :
 
 /-- Casting a scientific literal via `ℚ` is the same as casting directly. -/
 @[simp, norm_cast]
-theorem cast_ofScientific {K} [DivisionRing K] (m : ℕ) (b : Bool) (d : ℕ) :
-    (OfScientific.ofScientific m b d : ℚ) = (OfScientific.ofScientific m b d : K) := by
+theorem cast_ofScientific {K} [DivisionRing K] (m : ℕ) (s : Bool) (e : ℕ) :
+    (OfScientific.ofScientific m s e : ℚ) = (OfScientific.ofScientific m s e : K) := by
   rw [← NNRat.cast_ofScientific (K := K), ← NNRat.cast_ofScientific, cast_nnratCast]
 
+end Rat
+
 open OfScientific in
-theorem Nonneg.val_ofScientific {K} [LinearOrderedField K] (m s e) :
+theorem Nonneg.coe_ofScientific {K} [LinearOrderedField K] (m : ℕ) (s : Bool) (e : ℕ) :
     (ofScientific m s e : {x : K // 0 ≤ x}).val = ofScientific m s e := rfl

--- a/Mathlib/Data/Rat/Cast/Lemmas.lean
+++ b/Mathlib/Data/Rat/Cast/Lemmas.lean
@@ -55,3 +55,7 @@ theorem cast_nnratCast {K} [DivisionRing K] (q : ℚ≥0) :
 theorem cast_ofScientific {K} [DivisionRing K] (m : ℕ) (b : Bool) (d : ℕ) :
     (OfScientific.ofScientific m b d : ℚ) = (OfScientific.ofScientific m b d : K) := by
   rw [← NNRat.cast_ofScientific (K := K), ← NNRat.cast_ofScientific, cast_nnratCast]
+
+open OfScientific in
+theorem Nonneg.val_ofScientific {K} [LinearOrderedField K] (m s e) :
+    (ofScientific m s e : {x : K // 0 ≤ x}).val = ofScientific m s e := rfl

--- a/Mathlib/Data/Rat/Order.lean
+++ b/Mathlib/Data/Rat/Order.lean
@@ -49,6 +49,26 @@ variable {a b c : ℚ}
 @[simp] lemma mkRat_nonneg {a : ℤ} (ha : 0 ≤ a) (b : ℕ) : 0 ≤ mkRat a b := by
   simpa using divInt_nonneg ha b.cast_nonneg
 
+
+/-- An `NNRat` version of `Rat.ofScientific` -/
+def _root_.NNRat.ofScientific (m : ℕ) (s : Bool) (e : ℕ) : ℚ≥0 :=
+  ⟨.ofScientific m s e, by
+    rw [Rat.ofScientific]
+    cases s
+    · rw [if_neg (by decide)]
+      refine num_nonneg.mp ?_
+      rw [num_natCast]
+      exact Nat.cast_nonneg _
+    · rw [if_pos rfl, normalize_eq_mkRat]
+      exact Rat.mkRat_nonneg (Nat.cast_nonneg _) _⟩
+
+theorem _root_.NNRat.coe_ofScientific (m : ℕ) (s : Bool) (e : ℕ) :
+    NNRat.ofScientific m s e = Rat.ofScientific m s e :=
+  rfl
+
+instance NNRatCast.toOfScientific {K} [NNRatCast K] : OfScientific K where
+  ofScientific (m : ℕ) (b : Bool) (d : ℕ) := NNRat.ofScientific m b d
+
 protected lemma add_nonneg : 0 ≤ a → 0 ≤ b → 0 ≤ a + b :=
   numDenCasesOn' a fun n₁ d₁ h₁ ↦ numDenCasesOn' b fun n₂ d₂ h₂ ↦ by
     have d₁0 : 0 < (d₁ : ℤ) := mod_cast h₁.bot_lt

--- a/Mathlib/Data/Rat/Order.lean
+++ b/Mathlib/Data/Rat/Order.lean
@@ -64,6 +64,7 @@ instance _root_.NNRatCast.toOfScientific {K} [NNRatCast K] : OfScientific K wher
   ofScientific (m : ℕ) (b : Bool) (d : ℕ) :=
     NNRat.cast ⟨Rat.ofScientific m b d, ofScientific_nonneg m b d⟩
 
+/-- Casting a scientific literal via `ℚ≥0` is the same as casting directly. -/
 @[simp, norm_cast]
 theorem _root_.NNRat.cast_ofScientific {K} [NNRatCast K] (m : ℕ) (s : Bool) (e : ℕ) :
     (OfScientific.ofScientific m s e : ℚ≥0) = (OfScientific.ofScientific m s e : K) :=

--- a/Mathlib/Data/Rat/Order.lean
+++ b/Mathlib/Data/Rat/Order.lean
@@ -60,13 +60,13 @@ theorem ofScientific_nonneg (m : ℕ) (s : Bool) (e : ℕ) :
   · rw [if_pos rfl, normalize_eq_mkRat]
     exact Rat.mkRat_nonneg (Nat.cast_nonneg _) _
 
-instance NNRatCast.toOfScientific {K} [NNRatCast K] : OfScientific K where
+instance _root_.NNRatCast.toOfScientific {K} [NNRatCast K] : OfScientific K where
   ofScientific (m : ℕ) (b : Bool) (d : ℕ) :=
     NNRat.cast ⟨Rat.ofScientific m b d, ofScientific_nonneg m b d⟩
 
 @[simp, norm_cast]
-theorem _root_.NNRat.cast_ofScientific (m : ℕ) (s : Bool) (e : ℕ) :
-    (OfScientific.ofScientific m s e : ℚ≥0) = (OfScientific.ofScientific m s e : ℚ) :=
+theorem _root_.NNRat.cast_ofScientific {K} [NNRatCast K] (m : ℕ) (s : Bool) (e : ℕ) :
+    (OfScientific.ofScientific m s e : ℚ≥0) = (OfScientific.ofScientific m s e : K) :=
   rfl
 
 protected lemma add_nonneg : 0 ≤ a → 0 ≤ b → 0 ≤ a + b :=

--- a/Mathlib/Data/Rat/Order.lean
+++ b/Mathlib/Data/Rat/Order.lean
@@ -49,25 +49,25 @@ variable {a b c : ℚ}
 @[simp] lemma mkRat_nonneg {a : ℤ} (ha : 0 ≤ a) (b : ℕ) : 0 ≤ mkRat a b := by
   simpa using divInt_nonneg ha b.cast_nonneg
 
-
-/-- An `NNRat` version of `Rat.ofScientific` -/
-def _root_.NNRat.ofScientific (m : ℕ) (s : Bool) (e : ℕ) : ℚ≥0 :=
-  ⟨.ofScientific m s e, by
-    rw [Rat.ofScientific]
-    cases s
-    · rw [if_neg (by decide)]
-      refine num_nonneg.mp ?_
-      rw [num_natCast]
-      exact Nat.cast_nonneg _
-    · rw [if_pos rfl, normalize_eq_mkRat]
-      exact Rat.mkRat_nonneg (Nat.cast_nonneg _) _⟩
-
-theorem _root_.NNRat.coe_ofScientific (m : ℕ) (s : Bool) (e : ℕ) :
-    NNRat.ofScientific m s e = Rat.ofScientific m s e :=
-  rfl
+theorem ofScientific_nonneg (m : ℕ) (s : Bool) (e : ℕ) :
+    0 ≤ Rat.ofScientific m s e := by
+  rw [Rat.ofScientific]
+  cases s
+  · rw [if_neg (by decide)]
+    refine num_nonneg.mp ?_
+    rw [num_natCast]
+    exact Nat.cast_nonneg _
+  · rw [if_pos rfl, normalize_eq_mkRat]
+    exact Rat.mkRat_nonneg (Nat.cast_nonneg _) _
 
 instance NNRatCast.toOfScientific {K} [NNRatCast K] : OfScientific K where
-  ofScientific (m : ℕ) (b : Bool) (d : ℕ) := NNRat.ofScientific m b d
+  ofScientific (m : ℕ) (b : Bool) (d : ℕ) :=
+    NNRat.cast ⟨Rat.ofScientific m b d, ofScientific_nonneg m b d⟩
+
+@[simp, norm_cast]
+theorem _root_.NNRat.cast_ofScientific (m : ℕ) (s : Bool) (e : ℕ) :
+    (OfScientific.ofScientific m s e : ℚ≥0) = (OfScientific.ofScientific m s e : ℚ) :=
+  rfl
 
 protected lemma add_nonneg : 0 ≤ a → 0 ≤ b → 0 ≤ a + b :=
   numDenCasesOn' a fun n₁ d₁ h₁ ↦ numDenCasesOn' b fun n₂ d₂ h₂ ↦ by

--- a/Mathlib/Data/Real/NNReal.lean
+++ b/Mathlib/Data/Real/NNReal.lean
@@ -364,6 +364,11 @@ protected theorem coe_ofNat (n : ℕ) [n.AtLeastTwo] :
     (no_index (OfNat.ofNat n : ℝ≥0) : ℝ) = OfNat.ofNat n :=
   rfl
 
+@[simp, norm_cast]
+protected theorem coe_ofScientific (m s e) :
+    ↑(OfScientific.ofScientific m s e : ℝ≥0) = (OfScientific.ofScientific m s e : ℝ) :=
+  rfl
+
 noncomputable example : LinearOrder ℝ≥0 := by infer_instance
 
 @[simp, norm_cast] lemma coe_le_coe : (r₁ : ℝ) ≤ r₂ ↔ r₁ ≤ r₂ := Iff.rfl

--- a/Mathlib/Data/Real/NNReal.lean
+++ b/Mathlib/Data/Real/NNReal.lean
@@ -365,7 +365,7 @@ protected theorem coe_ofNat (n : ℕ) [n.AtLeastTwo] :
   rfl
 
 @[simp, norm_cast]
-protected theorem coe_ofScientific (m s e) :
+protected theorem coe_ofScientific (m : ℕ) (s : Bool) (e : ℕ) :
     ↑(OfScientific.ofScientific m s e : ℝ≥0) = (OfScientific.ofScientific m s e : ℝ) :=
   rfl
 

--- a/Mathlib/FieldTheory/Subfield.lean
+++ b/Mathlib/FieldTheory/Subfield.lean
@@ -120,8 +120,15 @@ lemma qsmul_mem (s : S) (q : ℚ) (hx : x ∈ s) : q • x ∈ s := by
 
 @[aesop safe apply (rule_sets := [SetLike])]
 lemma ofScientific_mem (s : S) {b : Bool} {n m : ℕ} :
-    (OfScientific.ofScientific n b m : K) ∈ s :=
-  SubfieldClass.ratCast_mem ..
+    (OfScientific.ofScientific n b m : K) ∈ s := by
+  have := SubfieldClass.ratCast_mem s (OfScientific.ofScientific n b m)
+  convert this
+  dsimp
+  rw [RatCast.toOfScientific, OfScientific.ofScientific, OfScientific.ofScientific,]
+  -- dsimp [RatCast.toOfScientific]
+  rfl
+
+#exit
 
 instance instSMulNNRat (s : S) : SMul ℚ≥0 s where smul q x := ⟨q • x, nnqsmul_mem s q x.2⟩
 instance instSMulRat (s : S) : SMul ℚ s where smul q x := ⟨q • x, qsmul_mem s q x.2⟩

--- a/Mathlib/FieldTheory/Subfield.lean
+++ b/Mathlib/FieldTheory/Subfield.lean
@@ -120,15 +120,8 @@ lemma qsmul_mem (s : S) (q : ℚ) (hx : x ∈ s) : q • x ∈ s := by
 
 @[aesop safe apply (rule_sets := [SetLike])]
 lemma ofScientific_mem (s : S) {b : Bool} {n m : ℕ} :
-    (OfScientific.ofScientific n b m : K) ∈ s := by
-  have := SubfieldClass.ratCast_mem s (OfScientific.ofScientific n b m)
-  convert this
-  dsimp
-  rw [RatCast.toOfScientific, OfScientific.ofScientific, OfScientific.ofScientific,]
-  -- dsimp [RatCast.toOfScientific]
-  rfl
-
-#exit
+    (OfScientific.ofScientific n b m : K) ∈ s :=
+  SubfieldClass.nnratCast_mem s (OfScientific.ofScientific n b m)
 
 instance instSMulNNRat (s : S) : SMul ℚ≥0 s where smul q x := ⟨q • x, nnqsmul_mem s q x.2⟩
 instance instSMulRat (s : S) : SMul ℚ s where smul q x := ⟨q • x, qsmul_mem s q x.2⟩

--- a/Mathlib/Tactic/NormNum/OfScientific.lean
+++ b/Mathlib/Tactic/NormNum/OfScientific.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Thomas Murrills
 -/
 import Mathlib.Tactic.NormNum.Basic
-import Mathlib.Data.Rat.Cast.Defs
+import Mathlib.Data.Rat.Cast.Lemmas
 
 /-!
 ## `norm_num` plugin for scientific notation.
@@ -19,25 +19,20 @@ open Meta
 namespace Meta.NormNum
 open Qq
 
-/-- Helper function to synthesize a typed `OfScientific α` expression given `DivisionRing α`. -/
-def inferOfScientific (α : Q(Type u)) : MetaM Q(OfScientific $α) :=
-  return ← synthInstanceQ (q(OfScientific $α) : Q(Type u)) <|>
-    throwError "does not support scientific notation"
-
 -- see note [norm_num lemma function equality]
-theorem isRat_ofScientific_of_true [DivisionRing α] (σα : OfScientific α) :
+theorem isRat_ofScientific_of_true [DivisionRing α] :
     {m e : ℕ} → {n : ℤ} → {d : ℕ} →
-    @OfScientific.ofScientific α σα = (fun m s e ↦ (Rat.ofScientific m s e : α)) →
-    IsRat (mkRat m (10 ^ e) : α) n d → IsRat (@OfScientific.ofScientific α σα m true e) n d
-  | _, _, _, _, σh, ⟨_, eq⟩ => ⟨_, by simp only [σh, Rat.ofScientific_true_def]; exact eq⟩
+    IsRat (mkRat m (10 ^ e) : α) n d → IsRat (OfScientific.ofScientific m true e : α) n d
+  | _, _, _, _, ⟨_, eq⟩ => ⟨_, by
+    rwa [← Rat.cast_ofScientific, ← Rat.ofScientific_eq_ofScientific, Rat.ofScientific_true_def]⟩
 
 -- see note [norm_num lemma function equality]
-theorem isNat_ofScientific_of_false [DivisionRing α] (σα : OfScientific α) : {m e nm ne n : ℕ} →
-    @OfScientific.ofScientific α σα = (fun m s e ↦ (Rat.ofScientific m s e : α)) →
+theorem isNat_ofScientific_of_false [DivisionRing α] : {m e nm ne n : ℕ} →
     IsNat m nm → IsNat e ne → n = Nat.mul nm ((10 : ℕ) ^ ne) →
-    IsNat (@OfScientific.ofScientific α σα m false e : α) n
-  | _, _, _, _, _, σh, ⟨rfl⟩, ⟨rfl⟩, h => ⟨by
-    simp only [Nat.cast_id, σh, Rat.ofScientific_false_def, Nat.cast_mul, Nat.cast_pow,
+    IsNat (OfScientific.ofScientific m false e : α) n
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, h => ⟨by
+    rw [← Rat.cast_ofScientific, ← Rat.ofScientific_eq_ofScientific]
+    simp only [Nat.cast_id, Rat.ofScientific_false_def, Nat.cast_mul, Nat.cast_pow,
       Nat.cast_ofNat, h, Nat.mul_eq]
     norm_cast⟩
 
@@ -48,15 +43,13 @@ to rat casts if the scientific notation is inherited from the one for rationals.
   let .app (.app (.app f (m : Q(ℕ))) (b : Q(Bool))) (exp : Q(ℕ)) ← whnfR e | failure
   let dα ← inferDivisionRing α
   guard <|← withNewMCtxDepth <| isDefEq f q(OfScientific.ofScientific (α := $α))
-  let σα ← inferOfScientific α
   assumeInstancesCommute
   haveI' : $e =Q OfScientific.ofScientific $m $b $exp := ⟨⟩
-  haveI' lh : @OfScientific.ofScientific $α $σα =Q (fun m s e ↦ (Rat.ofScientific m s e : $α)) := ⟨⟩
   match b with
   | ~q(true) =>
     let rme ← derive (q(mkRat $m (10 ^ $exp)) : Q($α))
     let some ⟨q, n, d, p⟩ := rme.toRat' dα | failure
-    return .isRat' dα q n d q(isRat_ofScientific_of_true $σα $lh $p)
+    return .isRat' dα q n d q(isRat_ofScientific_of_true $p)
   | ~q(false) =>
     let ⟨nm, pm⟩ ← deriveNat m q(AddCommMonoidWithOne.toAddMonoidWithOne)
     let ⟨ne, pe⟩ ← deriveNat exp q(AddCommMonoidWithOne.toAddMonoidWithOne)
@@ -67,4 +60,4 @@ to rat casts if the scientific notation is inherited from the one for rationals.
     let n' := Nat.mul m' (Nat.pow (10 : ℕ) exp')
     have n : Q(ℕ) := mkRawNatLit n'
     haveI : $n =Q Nat.mul $nm ((10 : ℕ) ^ $ne) := ⟨⟩
-    return .isNat _ n q(isNat_ofScientific_of_false $σα $lh $pm $pe (.refl $n))
+    return .isNat _ n q(isNat_ofScientific_of_false $pm $pe (.refl $n))


### PR DESCRIPTION
The existing `RatCast.toOfScientific` instance has to be removed since it forms a non-defeq diamond (there is nothing enforcing that `nnratCast` and `ratCast`  are defeq).

The `norm_num` extension also needs some fixes, though the old design didn't make much sense anyway, as it synthesize the instances separately, thus losing important defeqs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

~~This is probably not quite in the right place: unfortunately I can't put it next to `RatCast.toOfScientific` as there don't seem to be suitable lemmas there.~~

Nevermind, this instance doesn't exist any more.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
