### PR TITLE
perf: Move powers lemmas into `GroupTheory.Exponent`

### DIFF
--- a/Mathlib/Data/ZMod/Quotient.lean
+++ b/Mathlib/Data/ZMod/Quotient.lean
@@ -195,34 +195,3 @@ instance minimalPeriod_pos [Finite <| orbit (zpowers a) b] :
 #align add_action.minimal_period_pos AddAction.minimalPeriod_pos
 
 end MulAction
-
-section Group
-
-open Subgroup
-
-variable {α : Type*} [Group α] (a : α)
-
-/-- See also `Fintype.card_zpowers`. -/
-@[to_additive (attr := simp) "See also `Fintype.card_zmultiples`."]
-theorem Nat.card_zpowers : Nat.card (zpowers a) = orderOf a := by
-  have := Nat.card_congr (MulAction.orbitZPowersEquiv a (1 : α))
-  rwa [Nat.card_zmod, orbit_subgroup_one_eq_self] at this
-#align order_eq_card_zpowers' Nat.card_zpowersₓ
-#align add_order_eq_card_zmultiples' Nat.card_zmultiplesₓ
-
-variable {a}
-
-@[to_additive (attr := simp)]
-lemma finite_zpowers : (zpowers a : Set α).Finite ↔ IsOfFinOrder a := by
-  simp only [← orderOf_pos_iff, ← Nat.card_zpowers, Nat.card_pos_iff, ← SetLike.coe_sort_coe,
-    nonempty_coe_sort, Nat.card_pos_iff, Set.finite_coe_iff, Subgroup.coe_nonempty, true_and]
-
-@[to_additive (attr := simp)]
-lemma infinite_zpowers : (zpowers a : Set α).Infinite ↔ ¬IsOfFinOrder a := finite_zpowers.not
-
-@[to_additive]
-protected alias ⟨_, IsOfFinOrder.finite_zpowers⟩ := finite_zpowers
-#align is_of_fin_order.finite_zpowers IsOfFinOrder.finite_zpowers
-#align is_of_fin_add_order.finite_zmultiples IsOfFinAddOrder.finite_zmultiples
-
-end Group

--- a/Mathlib/GroupTheory/Exponent.lean
+++ b/Mathlib/GroupTheory/Exponent.lean
@@ -576,6 +576,37 @@ theorem Subgroup.pow_exponent_eq_one {H : Subgroup G} {g : G} (g_in_H : g ∈ H)
 
 end Group
 
+section Group
+
+open Subgroup
+
+variable {α : Type*} [Group α] (a : α)
+
+/-- See also `Fintype.card_zpowers`. -/
+@[to_additive (attr := simp) "See also `Fintype.card_zmultiples`."]
+theorem Nat.card_zpowers : Nat.card (zpowers a) = orderOf a := by
+  have := Nat.card_congr (MulAction.orbitZPowersEquiv a (1 : α))
+  rwa [Nat.card_zmod, orbit_subgroup_one_eq_self] at this
+#align order_eq_card_zpowers' Nat.card_zpowersₓ
+#align add_order_eq_card_zmultiples' Nat.card_zmultiplesₓ
+
+variable {a}
+
+@[to_additive (attr := simp)]
+lemma finite_zpowers : (zpowers a : Set α).Finite ↔ IsOfFinOrder a := by
+  simp only [← orderOf_pos_iff, ← Nat.card_zpowers, Nat.card_pos_iff, ← SetLike.coe_sort_coe,
+    Set.nonempty_coe_sort, Nat.card_pos_iff, Set.finite_coe_iff, Subgroup.coe_nonempty, true_and]
+
+@[to_additive (attr := simp)]
+lemma infinite_zpowers : (zpowers a : Set α).Infinite ↔ ¬IsOfFinOrder a := finite_zpowers.not
+
+@[to_additive]
+protected alias ⟨_, IsOfFinOrder.finite_zpowers⟩ := finite_zpowers
+#align is_of_fin_order.finite_zpowers IsOfFinOrder.finite_zpowers
+#align is_of_fin_add_order.finite_zmultiples IsOfFinAddOrder.finite_zmultiples
+
+end Group
+
 section CommGroup
 
 open Subgroup


### PR DESCRIPTION
This moves some files from the end of `Mathlib.Data.ZMod.Quotient` to the point in `Mathlib.GroupTheory.Exponent` where they are needed. This has the effect of

* Making it unnecessary to have an import between these files?
* Shortening the longest pole?

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
