### PR TITLE
[Merged by Bors] - chore: backport a faster proof in NewtonIdentities

### DIFF
--- a/Mathlib/RingTheory/MvPolynomial/NewtonIdentities.lean
+++ b/Mathlib/RingTheory/MvPolynomial/NewtonIdentities.lean
@@ -260,7 +260,7 @@ theorem psum_eq_mul_esymm_sub_sum (k : ℕ) (h : 0 < k) : psum σ R k =
   have : filter (fun a ↦ a.fst < k ∧ ¬0 < a.fst) (antidiagonal k) = {(0, k)} := by
     ext a
     rw [mem_filter, mem_antidiagonal, mem_singleton]
-    refine' ⟨_, fun ha ↦ by aesop⟩
+    refine' ⟨_, by rintro rfl; omega⟩
     rintro ⟨ha, ⟨_, ha0⟩⟩
     rw [← ha, Nat.eq_zero_of_not_pos ha0, zero_add, ← Nat.eq_zero_of_not_pos ha0]
   rw [this, sum_singleton] at sub_both_sides


### PR DESCRIPTION
This proof by `aesop` becomes even slower on `nightly-testing`. It should be by `omega` anyway, so we change that here.