### PR TITLE
[Merged by Bors] - chore(Data/Rat/Defs): Fix names of a few lemmas

### DIFF
--- a/Mathlib/Algebra/Module/CharacterModule.lean
+++ b/Mathlib/Algebra/Module/CharacterModule.lean
@@ -185,7 +185,7 @@ lemma eq_zero_of_ofSpanSingleton_apply_self (a : A)
     AddCircle.coe_eq_zero_iff] at h
   rcases h with ⟨n, hn⟩
   apply_fun Rat.den at hn
-  rw [zsmul_one, Rat.coe_int_den, Rat.inv_natCast_den_of_pos] at hn
+  rw [zsmul_one, Rat.den_intCast, Rat.inv_natCast_den_of_pos] at hn
   · split_ifs at hn
     · cases hn
     · rwa [eq_comm, AddMonoid.addOrderOf_eq_one_iff] at hn

--- a/Mathlib/Algebra/Order/Archimedean.lean
+++ b/Mathlib/Algebra/Order/Archimedean.lean
@@ -295,7 +295,7 @@ theorem exists_rat_btwn {x y : α} (h : x < y) : ∃ q : ℚ, x < q ∧ (q : α)
   rw [Int.cast_add, Int.cast_one]
   refine' lt_of_le_of_lt (add_le_add_right ((zh _).1 le_rfl) _) _
   rwa [← lt_sub_iff_add_lt', ← sub_mul, ← div_lt_iff' (sub_pos.2 h), one_div]
-  · rw [Rat.coe_int_den, Nat.cast_one]
+  · rw [Rat.den_intCast, Nat.cast_one]
     exact one_ne_zero
   · intro H
     rw [Rat.num_natCast, Int.cast_natCast, Nat.cast_eq_zero] at H

--- a/Mathlib/Data/NNRat/Defs.lean
+++ b/Mathlib/Data/NNRat/Defs.lean
@@ -407,6 +407,6 @@ lemma add_def (q r : ℚ≥0) : q + r = divNat (q.num * r.den + r.num * q.den) (
   ext; simp [Rat.add_def', Rat.mkRat_eq_divInt, num_coe, den_coe]
 
 lemma mul_def (q r : ℚ≥0) : q * r = divNat (q.num * r.num) (q.den * r.den) := by
-  ext; simp [Rat.mul_def', Rat.mkRat_eq_divInt, num_coe, den_coe]
+  ext; simp [Rat.mul_eq_mkRat, Rat.mkRat_eq_divInt, num_coe, den_coe]
 
 end NNRat

--- a/Mathlib/Data/NNRat/Defs.lean
+++ b/Mathlib/Data/NNRat/Defs.lean
@@ -404,9 +404,9 @@ def numDenCasesOn.{u} {C : ℚ≥0 → Sort u} (q) (H : ∀ n d, d ≠ 0 → n.C
     C q := by rw [← q.num_divNat_den]; exact H _ _ q.den_ne_zero q.coprime_num_den
 
 lemma add_def (q r : ℚ≥0) : q + r = divNat (q.num * r.den + r.num * q.den) (q.den * r.den) := by
-  ext; simp [Rat.add_def', Rat.mkRat_eq, num_coe, den_coe]
+  ext; simp [Rat.add_def', Rat.mkRat_eq_divInt, num_coe, den_coe]
 
 lemma mul_def (q r : ℚ≥0) : q * r = divNat (q.num * r.num) (q.den * r.den) := by
-  ext; simp [Rat.mul_def', Rat.mkRat_eq, num_coe, den_coe]
+  ext; simp [Rat.mul_def', Rat.mkRat_eq_divInt, num_coe, den_coe]
 
 end NNRat

--- a/Mathlib/Data/Rat/Cast/Defs.lean
+++ b/Mathlib/Data/Rat/Cast/Defs.lean
@@ -194,7 +194,7 @@ lemma cast_add_of_ne_zero {q r : ℚ} (hq : (q.den : α) ≠ 0) (hr : (r.den : �
 
 @[norm_cast] lemma cast_mul_of_ne_zero (hp : (p.den : α) ≠ 0) (hq : (q.den : α) ≠ 0) :
     ↑(p * q) = (p * q : α) := by
-  rw [mul_def', cast_mkRat_of_ne_zero, cast_def, cast_def,
+  rw [mul_eq_mkRat, cast_mkRat_of_ne_zero, cast_def, cast_def,
     (Nat.commute_cast _ _).div_mul_div_comm (Int.commute_cast _ _)]
   push_cast
   rfl

--- a/Mathlib/Data/Rat/Cast/Defs.lean
+++ b/Mathlib/Data/Rat/Cast/Defs.lean
@@ -172,7 +172,7 @@ lemma cast_divInt_of_ne_zero (a : ℤ) {b : ℤ} (b0 : (b : α) ≠ 0) : (a /. b
 
 @[norm_cast]
 lemma cast_mkRat_of_ne_zero (a : ℤ) {b : ℕ} (hb : (b : α) ≠ 0) : (mkRat a b : α) = a / b := by
-  rw [Rat.mkRat_eq, cast_divInt_of_ne_zero, Int.cast_natCast]; rwa [Int.cast_natCast]
+  rw [Rat.mkRat_eq_divInt, cast_divInt_of_ne_zero, Int.cast_natCast]; rwa [Int.cast_natCast]
 
 @[norm_cast]
 lemma cast_add_of_ne_zero {q r : ℚ} (hq : (q.den : α) ≠ 0) (hr : (r.den : α) ≠ 0) :

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -223,12 +223,6 @@ attribute [simp] mkRat_mul_mkRat
 lemma mul_eq_mkRat (q r : ℚ) : q * r = mkRat (q.num * r.num) (q.den * r.den) := by
   rw [mul_def, normalize_eq_mkRat]
 
-lemma mk'_mul_mk' (n₁ n₂ : ℤ) (d₁ d₂ : ℕ) (hd₁ hd₂ hnd₁ hnd₂) (h₁₂ : n₁.natAbs.Coprime d₂)
-    (h₂₁ : n₂.natAbs.Coprime d₁) :
-    mk' n₁ d₁ hd₁ hnd₁ * mk' n₂ d₂ hd₂ hnd₂ = mk' (n₁ * n₂) (d₁ * d₂) (Nat.mul_ne_zero hd₁ hd₂) (by
-      rw [Int.natAbs_mul]; exact (hnd₁.mul h₂₁).mul_right (h₁₂.mul hnd₂)) := by
-  rw [mul_def]; dsimp; rw [mk_eq_normalize]
-
 -- TODO: Rename `divInt_eq_iff` in Std to `divInt_eq_divInt`
 alias divInt_eq_divInt := divInt_eq_iff
 

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -44,6 +44,8 @@ theorem pos (a : ℚ) : 0 < a.den := Nat.pos_of_ne_zero a.den_nz
 
 #align rat.of_int Rat.ofInt
 
+lemma mk'_num_den (q : ℚ) : mk' q.num q.den q.den_nz q.reduced = q := rfl
+
 @[simp]
 theorem ofInt_eq_cast (n : ℤ) : ofInt n = Int.cast n :=
   rfl
@@ -54,43 +56,45 @@ theorem ofInt_eq_cast (n : ℤ) : ofInt n = Int.cast n :=
 @[simp] lemma num_ofNat (n : ℕ) : num (no_index (OfNat.ofNat n)) = OfNat.ofNat n := rfl
 @[simp] lemma den_ofNat (n : ℕ) : den (no_index (OfNat.ofNat n)) = 1 := rfl
 
-@[simp, norm_cast]
-theorem coe_int_num (n : ℤ) : (n : ℚ).num = n :=
-  rfl
-#align rat.coe_int_num Rat.coe_int_num
+@[simp, norm_cast] lemma num_natCast (n : ℕ) : num n = n := rfl
+#align rat.coe_nat_num Rat.num_natCast
 
-@[simp, norm_cast]
-theorem coe_int_den (n : ℤ) : (n : ℚ).den = 1 :=
-  rfl
-#align rat.coe_int_denom Rat.coe_int_den
+@[simp, norm_cast] lemma den_natCast (n : ℕ) : den n = 1 := rfl
+#align rat.coe_nat_denom Rat.den_natCast
+
+-- TODO: Replace `intCast_num`/`intCast_den` the names in Std
+@[simp, norm_cast] lemma num_intCast (n : ℤ) : (n : ℚ).num = n := rfl
+#align rat.coe_int_num Rat.num_intCast
+
+@[simp, norm_cast] lemma den_intCast (n : ℤ) : (n : ℚ).den = 1 := rfl
+#align rat.coe_int_denom Rat.den_intCast
+
+-- 2024-04-29
+@[deprecated] alias coe_int_num := num_intCast
+@[deprecated] alias coe_int_den := den_intCast
 
 #noalign rat.mk_pnat
+#noalign rat.mk_pnat_eq
+#noalign rat.zero_mk_pnat
 
 -- Porting note (#11215): TODO Should this be namespaced?
 #align rat.mk_nat mkRat
 
-#noalign rat.mk_pnat_eq
-
-theorem mkRat_eq (n d) : mkRat n d = n /. d :=
-  rfl
-#align rat.mk_nat_eq Rat.mkRat_eq
+lemma mkRat_eq_divInt (n d) : mkRat n d = n /. d := rfl
+#align rat.mk_nat_eq Rat.mkRat_eq_divInt
 
 #align rat.mk_zero Rat.divInt_zero
-
-@[simp]
-theorem zero_mk (d) (h : d ≠ 0) (w) : mk' 0 d h w = 0 := by congr
-
-#noalign rat.zero_mk_pnat
-
 #align rat.zero_mk_nat Rat.zero_mkRat
 #align rat.zero_mk Rat.zero_divInt
+
+@[simp] lemma mk'_zero (d) (h : d ≠ 0) (w) : mk' 0 d h w = 0 := by congr
 
 @[simp]
 lemma num_eq_zero {q : ℚ} : q.num = 0 ↔ q = 0 := by
   induction q
   constructor
   · rintro rfl
-    exact zero_mk _ _ _
+    exact mk'_zero _ _ _
   · exact congr_arg num
 
 lemma num_ne_zero {q : ℚ} : q.num ≠ 0 ↔ q ≠ 0 := num_eq_zero.not
@@ -216,11 +220,20 @@ lemma divInt_mul_divInt' (n₁ d₁ n₂ d₂ : ℤ) : (n₁ /. d₁) * (n₂ /.
 
 attribute [simp] mkRat_mul_mkRat
 
-lemma mul_def' (q r : ℚ) : q * r = mkRat (q.num * r.num) (q.den * r.den) := by
+lemma mul_eq_mkRat (q r : ℚ) : q * r = mkRat (q.num * r.num) (q.den * r.den) := by
   rw [mul_def, normalize_eq_mkRat]
 
-@[deprecated] alias mul_num_den := mul_def'
-#align rat.mul_num_denom Rat.mul_def'
+lemma mk'_mul_mk' (n₁ n₂ : ℤ) (d₁ d₂ : ℕ) (hd₁ hd₂ hnd₁ hnd₂) (h₁₂ : n₁.natAbs.Coprime d₂)
+    (h₂₁ : n₂.natAbs.Coprime d₁) :
+    mk' n₁ d₁ hd₁ hnd₁ * mk' n₂ d₂ hd₂ hnd₂ = mk' (n₁ * n₂) (d₁ * d₂) (Nat.mul_ne_zero hd₁ hd₂) (by
+      rw [Int.natAbs_mul]; exact (hnd₁.mul h₂₁).mul_right (h₁₂.mul hnd₂)) := by
+  rw [mul_def]; dsimp; rw [mk_eq_normalize]
+
+-- TODO: Rename `divInt_eq_iff` in Std to `divInt_eq_divInt`
+alias divInt_eq_divInt := divInt_eq_iff
+
+@[deprecated] alias mul_num_den := mul_eq_mkRat
+#align rat.mul_num_denom Rat.mul_eq_mkRat
 
 #align rat.inv Rat.inv
 
@@ -230,7 +243,7 @@ instance : Inv ℚ :=
 @[simp] lemma inv_divInt' (a b : ℤ) : (a /. b)⁻¹ = b /. a := inv_divInt ..
 #align rat.inv_def Rat.inv_divInt
 
-@[simp] lemma inv_mkRat (a : ℤ) (b : ℕ) : (mkRat a b)⁻¹ = b /. a := by rw [mkRat_eq, inv_divInt']
+@[simp] lemma inv_mkRat (a : ℤ) (b : ℕ) : (mkRat a b)⁻¹ = b /. a := by rw [mkRat_eq_divInt, inv_divInt']
 
 lemma inv_def' (q : ℚ) : q⁻¹ = q.den /. q.num := by rw [← inv_divInt', num_divInt_den]
 #align rat.inv_def' Rat.inv_def'
@@ -273,7 +286,7 @@ protected lemma add_left_neg : -a + a = 0 := by simp [add_def, normalize_eq_mkRa
 #align rat.mk_zero_one Rat.zero_divInt
 
 @[simp] lemma divInt_one (n : ℤ) : n /. 1 = n := by simp [divInt, mkRat, normalize]
-@[simp] lemma mkRat_one (n : ℤ) : mkRat n 1 = n := by simp [mkRat_eq]
+@[simp] lemma mkRat_one (n : ℤ) : mkRat n 1 = n := by simp [mkRat_eq_divInt]
 
 lemma divInt_one_one : 1 /. 1 = 1 := by rw [divInt_one]; rfl
 #align rat.mk_one_one Rat.divInt_one_one
@@ -315,7 +328,7 @@ attribute [simp] mkRat_eq_zero
 protected theorem mul_inv_cancel : a ≠ 0 → a * a⁻¹ = 1 :=
   numDenCasesOn' a fun n d hd hn ↦ by
     simp [hd] at hn;
-    simp [-divInt_ofNat, mkRat_eq, mul_comm, mul_ne_zero hn (Int.ofNat_ne_zero.2 hd)]
+    simp [-divInt_ofNat, mkRat_eq_divInt, mul_comm, mul_ne_zero hn (Int.ofNat_ne_zero.2 hd)]
 #align rat.mul_inv_cancel Rat.mul_inv_cancel
 
 protected theorem inv_mul_cancel (h : a ≠ 0) : a⁻¹ * a = 1 :=
@@ -513,7 +526,7 @@ lemma eq_num_of_isInt {q : ℚ} (h : q.isInt) : q = q.num := by
   exact (Rat.coe_int_num_of_den_eq_one h).symm
 
 theorem den_eq_one_iff (r : ℚ) : r.den = 1 ↔ ↑r.num = r :=
-  ⟨Rat.coe_int_num_of_den_eq_one, fun h => h ▸ Rat.coe_int_den r.num⟩
+  ⟨Rat.coe_int_num_of_den_eq_one, fun h => h ▸ Rat.den_intCast r.num⟩
 #align rat.denom_eq_one_iff Rat.den_eq_one_iff
 
 instance canLift : CanLift ℚ ℤ (↑) fun q => q.den = 1 :=
@@ -529,16 +542,6 @@ theorem natCast_eq_divInt (n : ℕ) : ↑n = n /. 1 := by
 @[deprecated] alias coe_int_div_eq_divInt := intCast_div_eq_divInt
 @[deprecated] alias coe_nat_eq_divInt := natCast_eq_divInt
 
-@[simp, norm_cast] lemma num_natCast (n : ℕ) : num n = n := rfl
-#align rat.coe_nat_num Rat.num_natCast
-
-@[simp, norm_cast] lemma den_natCast (n : ℕ) : den n = 1 := rfl
-#align rat.coe_nat_denom Rat.den_natCast
-
--- TODO: Fix the names in Std
-alias num_intCast := intCast_num
-alias den_intCast := intCast_den
-
 -- Will be subsumed by `Int.coe_inj` after we have defined
 -- `LinearOrderedField ℚ` (which implies characteristic zero).
 theorem coe_int_inj (m n : ℤ) : (m : ℚ) = n ↔ m = n :=
@@ -548,6 +551,6 @@ theorem coe_int_inj (m n : ℤ) : (m : ℚ) = n ↔ m = n :=
 end Casts
 
 theorem mkRat_eq_div (n : ℤ) (d : ℕ) : mkRat n d = n / d := by
-  simp only [mkRat_eq, divInt_eq_div, Int.cast_natCast]
+  simp only [mkRat_eq_divInt, divInt_eq_div, Int.cast_natCast]
 
 end Rat

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -44,8 +44,6 @@ theorem pos (a : ℚ) : 0 < a.den := Nat.pos_of_ne_zero a.den_nz
 
 #align rat.of_int Rat.ofInt
 
-lemma mk'_num_den (q : ℚ) : mk' q.num q.den q.den_nz q.reduced = q := rfl
-
 @[simp]
 theorem ofInt_eq_cast (n : ℤ) : ofInt n = Int.cast n :=
   rfl
@@ -237,7 +235,8 @@ instance : Inv ℚ :=
 @[simp] lemma inv_divInt' (a b : ℤ) : (a /. b)⁻¹ = b /. a := inv_divInt ..
 #align rat.inv_def Rat.inv_divInt
 
-@[simp] lemma inv_mkRat (a : ℤ) (b : ℕ) : (mkRat a b)⁻¹ = b /. a := by rw [mkRat_eq_divInt, inv_divInt']
+@[simp] lemma inv_mkRat (a : ℤ) (b : ℕ) : (mkRat a b)⁻¹ = b /. a := by
+  rw [mkRat_eq_divInt, inv_divInt']
 
 lemma inv_def' (q : ℚ) : q⁻¹ = q.den /. q.num := by rw [← inv_divInt', num_divInt_den]
 #align rat.inv_def' Rat.inv_def'

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -191,7 +191,7 @@ theorem den_div_cast_eq_one_iff (m n : ℤ) (hn : n ≠ 0) : ((m : ℚ) / n).den
     simp_rw [eq_div_iff_mul_eq hn, ← Int.cast_mul] at hk
     rwa [mul_comm, eq_comm, coe_int_inj] at hk
   · rintro ⟨d, rfl⟩
-    rw [Int.cast_mul, mul_comm, mul_div_cancel_right₀ _ hn, Rat.coe_int_den]
+    rw [Int.cast_mul, mul_comm, mul_div_cancel_right₀ _ hn, Rat.den_intCast]
 #align rat.denom_div_cast_eq_one_iff Rat.den_div_cast_eq_one_iff
 
 theorem num_div_eq_of_coprime {a b : ℤ} (hb0 : 0 < b) (h : Nat.Coprime a.natAbs b.natAbs) :

--- a/Mathlib/NumberTheory/DiophantineApproximation.lean
+++ b/Mathlib/NumberTheory/DiophantineApproximation.lean
@@ -586,7 +586,7 @@ theorem exists_rat_eq_convergent {q : ℚ} (h : |ξ - q| < 1 / (2 * (q.den : ℝ
   refine' q.num_div_den ▸ exists_rat_eq_convergent' ⟨_, fun hd => _, _⟩
   · exact coprime_iff_nat_coprime.mpr (natAbs_ofNat q.den ▸ q.reduced)
   · rw [← q.den_eq_one_iff.mp (Nat.cast_eq_one.mp hd)] at h
-    simpa only [Rat.coe_int_den, Nat.cast_one, one_pow, mul_one] using (abs_lt.mp h).1
+    simpa only [Rat.den_intCast, Nat.cast_one, one_pow, mul_one] using (abs_lt.mp h).1
   · obtain ⟨hq₀, hq₁⟩ := aux₀ (Nat.cast_pos.mpr q.pos)
     replace hq₁ := mul_pos hq₀ hq₁
     have hq₂ : (0 : ℝ) < 2 * (q.den * q.den) := mul_pos zero_lt_two (mul_pos hq₀ hq₀)

--- a/Mathlib/NumberTheory/Padics/PadicVal.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal.lean
@@ -354,7 +354,7 @@ protected theorem defn (p : ℕ) [hp : Fact p.Prime] {q : ℚ} {n d : ℤ} (hqz 
 protected theorem mul {q r : ℚ} (hq : q ≠ 0) (hr : r ≠ 0) :
     padicValRat p (q * r) = padicValRat p q + padicValRat p r := by
   have : q * r = (q.num * r.num) /. (q.den * r.den) := by
-    rw [Rat.mul_def', Rat.mkRat_eq, Nat.cast_mul]
+    rw [Rat.mul_def', Rat.mkRat_eq_divInt, Nat.cast_mul]
   have hq' : q.num /. q.den ≠ 0 := by rwa [Rat.num_divInt_den]
   have hr' : r.num /. r.den ≠ 0 := by rwa [Rat.num_divInt_den]
   have hp' : Prime (p : ℤ) := Nat.prime_iff_prime_int.1 hp.1

--- a/Mathlib/NumberTheory/Padics/PadicVal.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal.lean
@@ -354,7 +354,7 @@ protected theorem defn (p : ℕ) [hp : Fact p.Prime] {q : ℚ} {n d : ℤ} (hqz 
 protected theorem mul {q r : ℚ} (hq : q ≠ 0) (hr : r ≠ 0) :
     padicValRat p (q * r) = padicValRat p q + padicValRat p r := by
   have : q * r = (q.num * r.num) /. (q.den * r.den) := by
-    rw [Rat.mul_def', Rat.mkRat_eq_divInt, Nat.cast_mul]
+    rw [Rat.mul_eq_mkRat, Rat.mkRat_eq_divInt, Nat.cast_mul]
   have hq' : q.num /. q.den ≠ 0 := by rwa [Rat.num_divInt_den]
   have hr' : r.num /. r.den ≠ 0 := by rwa [Rat.num_divInt_den]
   have hp' : Prime (p : ℤ) := Nat.prime_iff_prime_int.1 hp.1

--- a/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
+++ b/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
@@ -203,7 +203,7 @@ See `wittStructureInt_prop` for this property,
 and `wittStructureInt_existsUnique` for the fact that `wittStructureInt`
 gives the unique family of polynomials with this property. -/
 noncomputable def wittStructureInt (Φ : MvPolynomial idx ℤ) (n : ℕ) : MvPolynomial (idx × ℕ) ℤ :=
-  Finsupp.mapRange Rat.num (Rat.coe_int_num 0) (wittStructureRat p (map (Int.castRingHom ℚ) Φ) n)
+  Finsupp.mapRange Rat.num (Rat.num_intCast 0) (wittStructureRat p (map (Int.castRingHom ℚ) Φ) n)
 #align witt_structure_int wittStructureInt
 
 variable {p}


### PR DESCRIPTION
There are more wrong lemmas in Std, but it's out of my scope


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
