### PR TITLE
[Merged by Bors] - CI: add a step producing a "reduced diff"

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -98,6 +98,17 @@ jobs:
       - name: check that all files are imported
         run: git diff --exit-code
 
+  diff_thm_lemma:
+    if: github.repository == 'leanprover-community/mathlib4'
+    name: diff_thm_lemma
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: print_lost_declarations
+        run: |
+          ./scripts/no_lost_declarations.sh
+
   check_workflows:
     if: github.repository == 'leanprover-community/mathlib4'
     name: check workflows

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -98,17 +98,6 @@ jobs:
       - name: check that all files are imported
         run: git diff --exit-code
 
-  diff_thm_lemma:
-    if: github.repository == 'leanprover-community/mathlib4'
-    name: diff_thm_lemma
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: print_lost_declarations
-        run: |
-          ./scripts/no_lost_declarations.sh
-
   check_workflows:
     if: github.repository == 'leanprover-community/mathlib4'
     name: check workflows
@@ -157,6 +146,9 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - uses: actions/checkout@v4
+
+      - name: print_lost_declarations
+        run: ./scripts/no_lost_declarations.sh
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -117,6 +117,24 @@ jobs:
       - name: check that workflows were consistent
         run: git diff --exit-code
 
+  summarize_declarations:
+    if: github.repository == 'leanprover-community/mathlib4'
+    name: summarize_declarations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ## fetch the whole repository, useful to find a common fork
+          fetch-depth: 0
+      - name: print_lost_declarations
+        run: |
+          ## the branch name of the PR
+          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
+          ## back and forth to settle a "detached head" (maybe?)
+          git checkout -q master
+          git checkout -q "${prBranchName}"
+          ./scripts/no_lost_declarations.sh
+
   build:
     if: github.repository == 'leanprover-community/mathlib4'
     name: Build
@@ -146,21 +164,6 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - uses: actions/checkout@v4
-        with:
-          ## asks for the sha of the head commit, so that `merge-base` then works
-          ref: ${{ github.event.pull_request.head.sha }}
-          ## fetch the whole repository, useful to find a common fork
-          fetch-depth: 0
-
-      - name: print_lost_declarations
-        run: |
-          ## the branch name of the PR
-          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
-          ## back and forth to settle a "detached head" (maybe?)
-          git checkout master
-          git checkout "${prBranchName}"
-          ./scripts/no_lost_declarations.sh
-          exit 1
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -128,11 +128,9 @@ jobs:
           fetch-depth: 0
       - name: print_lost_declarations
         run: |
-          ## the branch name of the PR
-          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
           ## back and forth to settle a "detached head" (maybe?)
           git checkout -q master
-          git checkout -q "${prBranchName}"
+          git checkout -q -
           printf '###  Summary\n\n' > "${GITHUB_STEP_SUMMARY}"
           ./scripts/no_lost_declarations.sh >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -108,7 +108,8 @@ jobs:
           find . -name . -o -prune -exec rm -rf -- {} +
 
       - uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
       - name: update workflows
         run: |
           cd .github/workflows/

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -108,8 +108,7 @@ jobs:
           find . -name . -o -prune -exec rm -rf -- {} +
 
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
       - name: update workflows
         run: |
           cd .github/workflows/
@@ -149,7 +148,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: print_lost_declarations
-        run: ./scripts/no_lost_declarations.sh
+        run: git fetch origin master && ./scripts/no_lost_declarations.sh
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -133,7 +133,8 @@ jobs:
           ## back and forth to settle a "detached head" (maybe?)
           git checkout -q master
           git checkout -q "${prBranchName}"
-          ./scripts/no_lost_declarations.sh
+          printf '###  Summary\n\n' > "${GITHUB_STEP_SUMMARY}"
+          ./scripts/no_lost_declarations.sh >> "${GITHUB_STEP_SUMMARY}"
 
   build:
     if: github.repository == 'leanprover-community/mathlib4'

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -146,9 +146,21 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - uses: actions/checkout@v4
+        with:
+          ## asks for the sha of the head commit, so that `merge-base` then works
+          ref: ${{ github.event.pull_request.head.sha }}
+          ## fetch the whole repository, useful to find a common fork
+          fetch-depth: 0
 
       - name: print_lost_declarations
-        run: git fetch origin master && ./scripts/no_lost_declarations.sh
+        run: |
+          ## the branch name of the PR
+          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
+          ## back and forth to settle a "detached head" (maybe?)
+          git checkout master
+          git checkout "${prBranchName}"
+          ./scripts/no_lost_declarations.sh
+          exit 1
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,8 @@ jobs:
           find . -name . -o -prune -exec rm -rf -- {} +
 
       - uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
       - name: update workflows
         run: |
           cd .github/workflows/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,24 @@ jobs:
       - name: check that workflows were consistent
         run: git diff --exit-code
 
+  summarize_declarations:
+    if: github.repository == 'leanprover-community/mathlib4'
+    name: summarize_declarations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ## fetch the whole repository, useful to find a common fork
+          fetch-depth: 0
+      - name: print_lost_declarations
+        run: |
+          ## the branch name of the PR
+          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
+          ## back and forth to settle a "detached head" (maybe?)
+          git checkout -q master
+          git checkout -q "${prBranchName}"
+          ./scripts/no_lost_declarations.sh
+
   build:
     if: github.repository == 'leanprover-community/mathlib4'
     name: Build
@@ -153,21 +171,6 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - uses: actions/checkout@v4
-        with:
-          ## asks for the sha of the head commit, so that `merge-base` then works
-          ref: ${{ github.event.pull_request.head.sha }}
-          ## fetch the whole repository, useful to find a common fork
-          fetch-depth: 0
-
-      - name: print_lost_declarations
-        run: |
-          ## the branch name of the PR
-          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
-          ## back and forth to settle a "detached head" (maybe?)
-          git checkout master
-          git checkout "${prBranchName}"
-          ./scripts/no_lost_declarations.sh
-          exit 1
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,17 @@ jobs:
       - name: check that all files are imported
         run: git diff --exit-code
 
+  diff_thm_lemma:
+    if: github.repository == 'leanprover-community/mathlib4'
+    name: diff_thm_lemma
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: print_lost_declarations
+        run: |
+          ./scripts/no_lost_declarations.sh
+
   check_workflows:
     if: github.repository == 'leanprover-community/mathlib4'
     name: check workflows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,9 +153,21 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - uses: actions/checkout@v4
+        with:
+          ## asks for the sha of the head commit, so that `merge-base` then works
+          ref: ${{ github.event.pull_request.head.sha }}
+          ## fetch the whole repository, useful to find a common fork
+          fetch-depth: 0
 
       - name: print_lost_declarations
-        run: git fetch origin master && ./scripts/no_lost_declarations.sh
+        run: |
+          ## the branch name of the PR
+          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
+          ## back and forth to settle a "detached head" (maybe?)
+          git checkout master
+          git checkout "${prBranchName}"
+          ./scripts/no_lost_declarations.sh
+          exit 1
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,17 +105,6 @@ jobs:
       - name: check that all files are imported
         run: git diff --exit-code
 
-  diff_thm_lemma:
-    if: github.repository == 'leanprover-community/mathlib4'
-    name: diff_thm_lemma
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: print_lost_declarations
-        run: |
-          ./scripts/no_lost_declarations.sh
-
   check_workflows:
     if: github.repository == 'leanprover-community/mathlib4'
     name: check workflows
@@ -164,6 +153,9 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - uses: actions/checkout@v4
+
+      - name: print_lost_declarations
+        run: ./scripts/no_lost_declarations.sh
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,8 @@ jobs:
           ## back and forth to settle a "detached head" (maybe?)
           git checkout -q master
           git checkout -q "${prBranchName}"
-          ./scripts/no_lost_declarations.sh
+          printf '###  Summary\n\n' > "${GITHUB_STEP_SUMMARY}"
+          ./scripts/no_lost_declarations.sh >> "${GITHUB_STEP_SUMMARY}"
 
   build:
     if: github.repository == 'leanprover-community/mathlib4'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,8 +115,7 @@ jobs:
           find . -name . -o -prune -exec rm -rf -- {} +
 
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
       - name: update workflows
         run: |
           cd .github/workflows/
@@ -156,7 +155,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: print_lost_declarations
-        run: ./scripts/no_lost_declarations.sh
+        run: git fetch origin master && ./scripts/no_lost_declarations.sh
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,11 +135,9 @@ jobs:
           fetch-depth: 0
       - name: print_lost_declarations
         run: |
-          ## the branch name of the PR
-          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
           ## back and forth to settle a "detached head" (maybe?)
           git checkout -q master
-          git checkout -q "${prBranchName}"
+          git checkout -q -
           printf '###  Summary\n\n' > "${GITHUB_STEP_SUMMARY}"
           ./scripts/no_lost_declarations.sh >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -94,7 +94,8 @@ jobs:
           find . -name . -o -prune -exec rm -rf -- {} +
 
       - uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
       - name: update workflows
         run: |
           cd .github/workflows/

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -84,17 +84,6 @@ jobs:
       - name: check that all files are imported
         run: git diff --exit-code
 
-  diff_thm_lemma:
-    if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'
-    name: diff_thm_lemma
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: print_lost_declarations
-        run: |
-          ./scripts/no_lost_declarations.sh
-
   check_workflows:
     if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'
     name: check workflowsJOB_NAME
@@ -143,6 +132,9 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - uses: actions/checkout@v4
+
+      - name: print_lost_declarations
+        run: ./scripts/no_lost_declarations.sh
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -132,9 +132,21 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - uses: actions/checkout@v4
+        with:
+          ## asks for the sha of the head commit, so that `merge-base` then works
+          ref: ${{ github.event.pull_request.head.sha }}
+          ## fetch the whole repository, useful to find a common fork
+          fetch-depth: 0
 
       - name: print_lost_declarations
-        run: git fetch origin master && ./scripts/no_lost_declarations.sh
+        run: |
+          ## the branch name of the PR
+          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
+          ## back and forth to settle a "detached head" (maybe?)
+          git checkout master
+          git checkout "${prBranchName}"
+          ./scripts/no_lost_declarations.sh
+          exit 1
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -94,8 +94,7 @@ jobs:
           find . -name . -o -prune -exec rm -rf -- {} +
 
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
       - name: update workflows
         run: |
           cd .github/workflows/
@@ -135,7 +134,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: print_lost_declarations
-        run: ./scripts/no_lost_declarations.sh
+        run: git fetch origin master && ./scripts/no_lost_declarations.sh
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -114,11 +114,9 @@ jobs:
           fetch-depth: 0
       - name: print_lost_declarations
         run: |
-          ## the branch name of the PR
-          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
           ## back and forth to settle a "detached head" (maybe?)
           git checkout -q master
-          git checkout -q "${prBranchName}"
+          git checkout -q -
           printf '###  Summary\n\n' > "${GITHUB_STEP_SUMMARY}"
           ./scripts/no_lost_declarations.sh >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -119,7 +119,8 @@ jobs:
           ## back and forth to settle a "detached head" (maybe?)
           git checkout -q master
           git checkout -q "${prBranchName}"
-          ./scripts/no_lost_declarations.sh
+          printf '###  Summary\n\n' > "${GITHUB_STEP_SUMMARY}"
+          ./scripts/no_lost_declarations.sh >> "${GITHUB_STEP_SUMMARY}"
 
   build:
     if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -103,6 +103,24 @@ jobs:
       - name: check that workflows were consistent
         run: git diff --exit-code
 
+  summarize_declarations:
+    if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'
+    name: summarize_declarations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ## fetch the whole repository, useful to find a common fork
+          fetch-depth: 0
+      - name: print_lost_declarations
+        run: |
+          ## the branch name of the PR
+          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
+          ## back and forth to settle a "detached head" (maybe?)
+          git checkout -q master
+          git checkout -q "${prBranchName}"
+          ./scripts/no_lost_declarations.sh
+
   build:
     if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'
     name: BuildJOB_NAME
@@ -132,21 +150,6 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - uses: actions/checkout@v4
-        with:
-          ## asks for the sha of the head commit, so that `merge-base` then works
-          ref: ${{ github.event.pull_request.head.sha }}
-          ## fetch the whole repository, useful to find a common fork
-          fetch-depth: 0
-
-      - name: print_lost_declarations
-        run: |
-          ## the branch name of the PR
-          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
-          ## back and forth to settle a "detached head" (maybe?)
-          git checkout master
-          git checkout "${prBranchName}"
-          ./scripts/no_lost_declarations.sh
-          exit 1
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -84,6 +84,17 @@ jobs:
       - name: check that all files are imported
         run: git diff --exit-code
 
+  diff_thm_lemma:
+    if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'
+    name: diff_thm_lemma
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: print_lost_declarations
+        run: |
+          ./scripts/no_lost_declarations.sh
+
   check_workflows:
     if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'
     name: check workflowsJOB_NAME

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -102,6 +102,17 @@ jobs:
       - name: check that all files are imported
         run: git diff --exit-code
 
+  diff_thm_lemma:
+    if: github.repository != 'leanprover-community/mathlib4'
+    name: diff_thm_lemma
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: print_lost_declarations
+        run: |
+          ./scripts/no_lost_declarations.sh
+
   check_workflows:
     if: github.repository != 'leanprover-community/mathlib4'
     name: check workflows (fork)

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -112,8 +112,7 @@ jobs:
           find . -name . -o -prune -exec rm -rf -- {} +
 
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
       - name: update workflows
         run: |
           cd .github/workflows/
@@ -153,7 +152,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: print_lost_declarations
-        run: ./scripts/no_lost_declarations.sh
+        run: git fetch origin master && ./scripts/no_lost_declarations.sh
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -137,7 +137,8 @@ jobs:
           ## back and forth to settle a "detached head" (maybe?)
           git checkout -q master
           git checkout -q "${prBranchName}"
-          ./scripts/no_lost_declarations.sh
+          printf '###  Summary\n\n' > "${GITHUB_STEP_SUMMARY}"
+          ./scripts/no_lost_declarations.sh >> "${GITHUB_STEP_SUMMARY}"
 
   build:
     if: github.repository != 'leanprover-community/mathlib4'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -150,9 +150,21 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - uses: actions/checkout@v4
+        with:
+          ## asks for the sha of the head commit, so that `merge-base` then works
+          ref: ${{ github.event.pull_request.head.sha }}
+          ## fetch the whole repository, useful to find a common fork
+          fetch-depth: 0
 
       - name: print_lost_declarations
-        run: git fetch origin master && ./scripts/no_lost_declarations.sh
+        run: |
+          ## the branch name of the PR
+          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
+          ## back and forth to settle a "detached head" (maybe?)
+          git checkout master
+          git checkout "${prBranchName}"
+          ./scripts/no_lost_declarations.sh
+          exit 1
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -102,17 +102,6 @@ jobs:
       - name: check that all files are imported
         run: git diff --exit-code
 
-  diff_thm_lemma:
-    if: github.repository != 'leanprover-community/mathlib4'
-    name: diff_thm_lemma
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: print_lost_declarations
-        run: |
-          ./scripts/no_lost_declarations.sh
-
   check_workflows:
     if: github.repository != 'leanprover-community/mathlib4'
     name: check workflows (fork)
@@ -161,6 +150,9 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - uses: actions/checkout@v4
+
+      - name: print_lost_declarations
+        run: ./scripts/no_lost_declarations.sh
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -112,7 +112,8 @@ jobs:
           find . -name . -o -prune -exec rm -rf -- {} +
 
       - uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
       - name: update workflows
         run: |
           cd .github/workflows/

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -132,11 +132,9 @@ jobs:
           fetch-depth: 0
       - name: print_lost_declarations
         run: |
-          ## the branch name of the PR
-          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
           ## back and forth to settle a "detached head" (maybe?)
           git checkout -q master
-          git checkout -q "${prBranchName}"
+          git checkout -q -
           printf '###  Summary\n\n' > "${GITHUB_STEP_SUMMARY}"
           ./scripts/no_lost_declarations.sh >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -121,6 +121,24 @@ jobs:
       - name: check that workflows were consistent
         run: git diff --exit-code
 
+  summarize_declarations:
+    if: github.repository != 'leanprover-community/mathlib4'
+    name: summarize_declarations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ## fetch the whole repository, useful to find a common fork
+          fetch-depth: 0
+      - name: print_lost_declarations
+        run: |
+          ## the branch name of the PR
+          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
+          ## back and forth to settle a "detached head" (maybe?)
+          git checkout -q master
+          git checkout -q "${prBranchName}"
+          ./scripts/no_lost_declarations.sh
+
   build:
     if: github.repository != 'leanprover-community/mathlib4'
     name: Build (fork)
@@ -150,21 +168,6 @@ jobs:
           echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
       - uses: actions/checkout@v4
-        with:
-          ## asks for the sha of the head commit, so that `merge-base` then works
-          ref: ${{ github.event.pull_request.head.sha }}
-          ## fetch the whole repository, useful to find a common fork
-          fetch-depth: 0
-
-      - name: print_lost_declarations
-        run: |
-          ## the branch name of the PR
-          prBranchName="$(git rev-parse --abbrev-ref HEAD)"
-          ## back and forth to settle a "detached head" (maybe?)
-          git checkout master
-          git checkout "${prBranchName}"
-          ./scripts/no_lost_declarations.sh
-          exit 1
 
       # We update `Mathlib.lean` as a convenience here,
       # but verify that this didn't change anything in the `check_imported` job.

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+## we narrow the diff to lines beginning with `theorem`, `lemma` and a few other commands
+begs="\(theorem\|lemma\|inductive\|structure\|def\|class\|instance\)"
+
+## the reference commit:
+## * it *should* be the version of master from the last merge
+## * it probably is the commit from where the PR branched from master
+if [ -n "${1}" ]; then
+  commit="${1}"
+else
+  commit="$( git merge-base master "$( git rev-parse --abbrev-ref HEAD )" )"
+fi;
+
+## extract lines that begin with '[+-]' followed by the input `theorem` or `lemma`
+## in the `git diff`
+git diff --unified=0 "${commit}" |
+  grep "^[+-]${begs}" |
+  sed 's=^\(.\)\(.*\)$=\2 \1=' |
+  awk '{
+    pm=$NF
+    gsub(/..$/, "")
+    acc[$0]=acc[$0] pm
+  } END {
+    fin=""
+    for(res in acc) {
+      pm=acc[res]
+      if(pm != "-+") {
+        mismatched++
+        fin=fin sprintf("%s%s\n", pm == "+" ? pm "\\" : pm "\\", res)
+      } else paired++
+    }
+    print fin| "sort -k2"
+    printf("---\n%s  mismatched declarations\n%s  paired declarations", mismatched, paired)
+  }' |
+  column -s'\' -t
+printf $'\nReference commit: %s\n\nYou can run this locally using
+./scripts/no_lost_declarations.sh <optional_commit>\n' "${commit}"

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -3,18 +3,14 @@
 ## we narrow the diff to lines beginning with `theorem`, `lemma` and a few other commands
 begs="(theorem|lemma|inductive|structure|def|class|instance)"
 
-## the reference commit:
-## * it *should* be the version of master from the last merge
-## * it probably is the commit from where the PR branched from master
+## if an input commit is given, compute the diff with that, otherwise, use the git-magic `...`
 if [ -n "${1}" ]; then
-  commit="${1}"
+  git diff --unified=0 "${1}"
 else
-  commit="$( git merge-base origin/master -- "origin/$( git rev-parse --abbrev-ref HEAD )" )"
-fi;
-
-## extract lines that begin with '[+-]' followed by the input `theorem` or `lemma`
-## in the `git diff`
-git diff --unified=0 "${commit}" |
+  git diff origin/master...HEAD
+fi |
+  ## extract lines that begin with '[+-]' followed by the input `theorem` or `lemma`
+  ## in the `git diff`
   awk -v regex="^[+-]${begs}" 'BEGIN{ paired=0; added=0; removed=0 }
     ($0 ~ regex){
       pm=substr($0, 1, 1)
@@ -33,11 +29,11 @@ git diff --unified=0 "${commit}" |
     print fin| "sort -k3"; close("sort -k3")
     printf("---\n* %s  added declarations\n* %s  removed declarations\n* %s  paired declarations", added, removed, paired)
   }'
-printf $'\n---\n\nReference commit: `%s`\n\n---\n\nYou can run this locally using
+printf $'\n---\n\nYou can run this locally using
 ```bash
 ./scripts/no_lost_declarations.sh <optional_commit>
 ```
-' "${commit}"
+'
 
  : <<ReferenceTest
 theorem hello

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -21,10 +21,10 @@ fi |
     fin=""
     for(res in acc) {
       pm=acc[res]
-      if(pm != "-+") {
+      if(pm == "-+" || pm == "+-") { paired++ } else {
         if(pm == "+") { added++ } else removed++
         fin=fin sprintf("* `%s` `%s`\n", pm, res)
-      } else paired++
+      }
     }
     print fin| "sort -k3"; close("sort -k3")
     printf("---\n* %s  added declarations\n* %s  removed declarations\n* %s  paired declarations", added, removed, paired)

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -17,7 +17,7 @@ fi;
 git diff --unified=0 "${commit}" |
   grep "^[+-]${begs}" |
   sed 's=^\(.\)\(.*\)$=\2 \1=' |
-  awk '{
+  awk 'BEGIN{ paired=0; mismatched=0 }{
     pm=$NF
     gsub(/..$/, "")
     acc[$0]=acc[$0] pm
@@ -30,7 +30,7 @@ git diff --unified=0 "${commit}" |
         fin=fin sprintf("%s%s\n", pm == "+" ? pm "\\" : pm "\\", res)
       } else paired++
     }
-    print fin| "sort -k2"
+    print fin| "sort -k2"; close("sort -k2")
     printf("---\n%s  mismatched declarations\n%s  paired declarations", mismatched, paired)
   }' |
   column -s'\' -t

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -9,7 +9,7 @@ begs="(theorem|lemma|inductive|structure|def|class|instance)"
 if [ -n "${1}" ]; then
   commit="${1}"
 else
-  commit="$( git merge-base origin/master "origin/$( git rev-parse --abbrev-ref HEAD )" )"
+  commit="$( git merge-base origin/master -- "origin/$( git rev-parse --abbrev-ref HEAD )" )"
 fi;
 
 ## extract lines that begin with '[+-]' followed by the input `theorem` or `lemma`

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -27,7 +27,7 @@ git diff --unified=0 "${commit}" |
       pm=acc[res]
       if(pm != "-+") {
         if(pm == "+") { added++ } else removed++
-        fin=fin sprintf("* `%s` `%s`\n", pm == "+" ? pm : pm, res)
+        fin=fin sprintf("* `%s` `%s`\n", pm, res)
       } else paired++
     }
     print fin| "sort -k3"; close("sort -k3")

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -15,7 +15,7 @@ fi;
 ## extract lines that begin with '[+-]' followed by the input `theorem` or `lemma`
 ## in the `git diff`
 git diff --unified=0 "${commit}" |
-  awk -v regex="^[+-]${begs}" 'BEGIN{ paired=0; mismatched=0 }
+  awk -v regex="^[+-]${begs}" 'BEGIN{ paired=0; added=0; removed=0 }
     ($0 ~ regex){
       pm=substr($0, 1, 1)
       rest=substr($0, 2)
@@ -26,14 +26,14 @@ git diff --unified=0 "${commit}" |
     for(res in acc) {
       pm=acc[res]
       if(pm != "-+") {
-        mismatched++
-        fin=fin sprintf("%s/%s\n", pm == "+" ? pm : pm, res)
+        if(pm == "+") { added++ } else removed++
+        fin=fin sprintf("%s %s\n", pm == "+" ? pm : pm, res)
       } else paired++
     }
-    print fin| "sort -k2 | column -s/ -t"; close("sort -k2 | column -s/ -t")
-    printf("---\n%s  mismatched declarations\n%s  paired declarations", mismatched, paired)
+    print fin| "sort -k3"; close("sort -k3")
+    printf("---\n%s  added declarations\n%s  removed declarations\n%s  paired declarations", added, removed, paired)
   }'
-printf $'\nReference commit: %s\n\nYou can run this locally using
+printf $'\n---\nReference commit: %s\n---\nYou can run this locally using
 ./scripts/no_lost_declarations.sh <optional_commit>\n' "${commit}"
 
  : <<ReferenceTest

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -36,7 +36,7 @@ git diff --unified=0 "${commit}" |
 printf $'\nReference commit: %s\n\nYou can run this locally using
 ./scripts/no_lost_declarations.sh <optional_commit>\n' "${commit}"
 
- : <<BYE
+ : <<ReferenceTest
 theorem hello
-inductives counted even if it is
-BYE
+inductives counted even if it is inductives, rather than inductive
+ReferenceTest

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -9,7 +9,7 @@ begs="(theorem|lemma|inductive|structure|def|class|instance)"
 if [ -n "${1}" ]; then
   commit="${1}"
 else
-  commit="$( git merge-base master "$( git rev-parse --abbrev-ref HEAD )" )"
+  commit="$( git merge-base origin/master "$( git rev-parse --abbrev-ref HEAD )" )"
 fi;
 
 ## extract lines that begin with '[+-]' followed by the input `theorem` or `lemma`

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -27,14 +27,17 @@ git diff --unified=0 "${commit}" |
       pm=acc[res]
       if(pm != "-+") {
         if(pm == "+") { added++ } else removed++
-        fin=fin sprintf("%s %s\n", pm == "+" ? pm : pm, res)
+        fin=fin sprintf("* `%s` `%s`\n", pm == "+" ? pm : pm, res)
       } else paired++
     }
     print fin| "sort -k3"; close("sort -k3")
-    printf("---\n%s  added declarations\n%s  removed declarations\n%s  paired declarations", added, removed, paired)
+    printf("---\n* %s  added declarations\n* %s  removed declarations\n* %s  paired declarations", added, removed, paired)
   }'
-printf $'\n---\nReference commit: %s\n---\nYou can run this locally using
-./scripts/no_lost_declarations.sh <optional_commit>\n' "${commit}"
+printf $'\n---\n\nReference commit: `%s`\n\n---\n\nYou can run this locally using
+```bash
+./scripts/no_lost_declarations.sh <optional_commit>
+```
+' "${commit}"
 
  : <<ReferenceTest
 theorem hello

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ## we narrow the diff to lines beginning with `theorem`, `lemma` and a few other commands
-begs="\(theorem\|lemma\|inductive\|structure\|def\|class\|instance\)"
+begs="(theorem|lemma|inductive|structure|def|class|instance)"
 
 ## the reference commit:
 ## * it *should* be the version of master from the last merge
@@ -15,24 +15,28 @@ fi;
 ## extract lines that begin with '[+-]' followed by the input `theorem` or `lemma`
 ## in the `git diff`
 git diff --unified=0 "${commit}" |
-  grep "^[+-]${begs}" |
-  sed 's=^\(.\)\(.*\)$=\2 \1=' |
-  awk 'BEGIN{ paired=0; mismatched=0 }{
-    pm=$NF
-    gsub(/..$/, "")
-    acc[$0]=acc[$0] pm
-  } END {
+  awk -v regex="^[+-]${begs}" 'BEGIN{ paired=0; mismatched=0 }
+    ($0 ~ regex){
+      pm=substr($0, 1, 1)
+      rest=substr($0, 2)
+      acc[rest]=acc[rest] pm
+    }
+  END {
     fin=""
     for(res in acc) {
       pm=acc[res]
       if(pm != "-+") {
         mismatched++
-        fin=fin sprintf("%s%s\n", pm == "+" ? pm "\\" : pm "\\", res)
+        fin=fin sprintf("%s/%s\n", pm == "+" ? pm : pm, res)
       } else paired++
     }
-    print fin| "sort -k2"; close("sort -k2")
+    print fin| "sort -k2 | column -s/ -t"; close("sort -k2 | column -s/ -t")
     printf("---\n%s  mismatched declarations\n%s  paired declarations", mismatched, paired)
-  }' |
-  column -s'\' -t
+  }'
 printf $'\nReference commit: %s\n\nYou can run this locally using
 ./scripts/no_lost_declarations.sh <optional_commit>\n' "${commit}"
+
+ : <<BYE
+theorem hello
+inductives counted even if it is
+BYE

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -12,21 +12,25 @@ fi |
   ## extract lines that begin with '[+-]' followed by the input `theorem` or `lemma`
   ## in the `git diff`
   awk -v regex="^[+-]${begs}" 'BEGIN{ paired=0; added=0; removed=0 }
+    /^--- a\//    { minusFile=$2 }
+    /^\+\+\+ b\// { plusFile=$2 }
     ($0 ~ regex){
       pm=substr($0, 1, 1)
       rest=substr($0, 2)
+      fil[rest]= (pm == "+") ? plusFile : minusFile
       acc[rest]=acc[rest] pm
     }
   END {
+    printf "|File|+-|Declaration|\n|-|-|-|"
     fin=""
     for(res in acc) {
       pm=acc[res]
       if(pm == "-+" || pm == "+-") { paired++ } else {
         if(pm == "+") { added++ } else removed++
-        fin=fin sprintf("* `%s` `%s`\n", pm, res)
+        fin=fin sprintf("| %s | `%s` | `%s` |\n", fil[res], pm, res)
       }
     }
-    print fin| "sort -k3"; close("sort -k3")
+    print fin| "sort -k6 -k8"; close("sort -k6 -k8")
     printf("---\n* %s  added declarations\n* %s  removed declarations\n* %s  paired declarations", added, removed, paired)
   }'
 printf $'\n---\n\nYou can run this locally using

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -9,7 +9,7 @@ begs="(theorem|lemma|inductive|structure|def|class|instance)"
 if [ -n "${1}" ]; then
   commit="${1}"
 else
-  commit="$( git merge-base origin/master "$( git rev-parse --abbrev-ref HEAD )" )"
+  commit="$( git merge-base origin/master "origin/$( git rev-parse --abbrev-ref HEAD )" )"
 fi;
 
 ## extract lines that begin with '[+-]' followed by the input `theorem` or `lemma`


### PR DESCRIPTION
Add an extra CI step whose purpose is to produce a summary of declarations that have been added, removed or simply moved around unchanged.

This can help review "moving" PRs, whose sole purpose is to move code around.

The script is text-based, so that it can run right away and does not have to wait for the output of `lake build`.  As a consequence, it is easy to fool, but also gives out answers quickly!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
