### PR TITLE
[Merged by Bors] - feat(Topology): stoneCechUnit injective for T35Space

### DIFF
--- a/Mathlib/Topology/CompletelyRegular.lean
+++ b/Mathlib/Topology/CompletelyRegular.lean
@@ -109,5 +109,5 @@ lemma injective_stoneCechUnit_of_t35Space [T35Space X] :
     Function.Injective (stoneCechUnit : X → StoneCech X) := by
   intros a b hab
   contrapose hab
-  obtain ⟨f, fc, fab⟩ := separatesPoints_continuous_of_t35Space_icc hab
+  obtain ⟨f, fc, fab⟩ := separatesPoints_continuous_of_t35Space_Icc hab
   exact fun q ↦ fab (eq_if_stoneCechUnit_eq fc q)

--- a/Mathlib/Topology/CompletelyRegular.lean
+++ b/Mathlib/Topology/CompletelyRegular.lean
@@ -98,7 +98,7 @@ lemma separatesPoints_continuous_of_t35Space [T35Space X] :
     CompletelyRegularSpace.completely_regular x {y} isClosed_singleton x_ne_y
   exact ⟨fun x ↦ f x, continuous_subtype_val.comp f_cont, by aesop⟩
 
-lemma separatesPoints_continuous_of_t35Space_icc [T35Space X] :
+lemma separatesPoints_continuous_of_t35Space_Icc [T35Space X] :
     SeparatesPoints (Continuous : Set (X → I)) := by
   intro x y x_ne_y
   obtain ⟨f, f_cont, f_zero, f_one⟩ :=

--- a/Mathlib/Topology/CompletelyRegular.lean
+++ b/Mathlib/Topology/CompletelyRegular.lean
@@ -5,6 +5,7 @@ Authors: Matias Heikkilä
 -/
 import Mathlib.Topology.UrysohnsLemma
 import Mathlib.Topology.UnitInterval
+import Mathlib.Topology.StoneCech
 
 /-!
 # Completely regular topological spaces.
@@ -86,15 +87,9 @@ instance NormalSpace.instCompletelyRegularSpace [NormalSpace X] : CompletelyRegu
 @[mk_iff]
 class T35Space (X : Type u) [TopologicalSpace X] extends T1Space X, CompletelyRegularSpace X : Prop
 
-instance T35Space.instT3space [T35Space X] : T3Space X := by
-  have : T0Space X := T1Space.t0Space
-  have : RegularSpace X := CompletelyRegularSpace.instRegularSpace
-  exact {}
+instance T35Space.instT3space [T35Space X] : T3Space X := {}
 
-instance T4Space.instT35Space [T4Space X] : T35Space X := by
-  have : T1Space X := T2Space.t1Space
-  have : CompletelyRegularSpace X := NormalSpace.instCompletelyRegularSpace
-  exact {}
+instance T4Space.instT35Space [T4Space X] : T35Space X := {}
 
 lemma separatesPoints_continuous_of_t35Space [T35Space X] :
     SeparatesPoints (Continuous : Set (X → ℝ)) := by
@@ -102,3 +97,17 @@ lemma separatesPoints_continuous_of_t35Space [T35Space X] :
   obtain ⟨f, f_cont, f_zero, f_one⟩ :=
     CompletelyRegularSpace.completely_regular x {y} isClosed_singleton x_ne_y
   exact ⟨fun x ↦ f x, continuous_subtype_val.comp f_cont, by aesop⟩
+
+lemma separatesPoints_continuous_of_t35Space_icc [T35Space X] :
+    SeparatesPoints (Continuous : Set (X → I)) := by
+  intro x y x_ne_y
+  obtain ⟨f, f_cont, f_zero, f_one⟩ :=
+    CompletelyRegularSpace.completely_regular x {y} isClosed_singleton x_ne_y
+  exact ⟨f, f_cont, by aesop⟩
+
+lemma injective_stoneCechUnit_of_t35Space [T35Space X] :
+    Function.Injective (stoneCechUnit : X → StoneCech X) := by
+  intros a b hab
+  contrapose hab
+  obtain ⟨f, fc, fab⟩ := separatesPoints_continuous_of_t35Space_icc hab
+  exact fun q ↦ fab (eq_if_stoneCechUnit_eq fc q)

--- a/Mathlib/Topology/StoneCech.lean
+++ b/Mathlib/Topology/StoneCech.lean
@@ -382,6 +382,11 @@ theorem continuous_stoneCechExtend : Continuous (stoneCechExtend hg) :=
   continuous_coinduced_dom.mpr (continuous_preStoneCechExtend hg)
 #align continuous_stone_cech_extend continuous_stoneCechExtend
 
+lemma eq_if_stoneCechUnit_eq {a b : α} {f : α → β} (hcf : Continuous f)
+    (h : stoneCechUnit a = stoneCechUnit b) : f a = f b := by
+  rw [← congrFun (stoneCechExtend_extends hcf), ← congrFun (stoneCechExtend_extends hcf)]
+  exact congrArg (stoneCechExtend hcf) h
+
 theorem stoneCech_hom_ext {g₁ g₂ : StoneCech α → β} (h₁ : Continuous g₁) (h₂ : Continuous g₂)
     (h : g₁ ∘ stoneCechUnit = g₂ ∘ stoneCechUnit) : g₁ = g₂ := by
   apply h₁.ext_on denseRange_stoneCechUnit h₂


### PR DESCRIPTION
The map`stoneCechUnit` is injective when the underlying space is a `T35Space`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
