### PR TITLE
[Merged by Bors] - perf(AlgebraicGeometry.Spec): add explicit universe annotations

### DIFF
--- a/Mathlib/AlgebraicGeometry/Spec.lean
+++ b/Mathlib/AlgebraicGeometry/Spec.lean
@@ -34,8 +34,6 @@ The adjunction `Γ ⊣ Spec` is constructed in `Mathlib/AlgebraicGeometry/GammaS
 
 -/
 
-set_option profiler true
-
 noncomputable section
 
 universe u v

--- a/Mathlib/AlgebraicGeometry/Spec.lean
+++ b/Mathlib/AlgebraicGeometry/Spec.lean
@@ -34,6 +34,7 @@ The adjunction `Γ ⊣ Spec` is constructed in `Mathlib/AlgebraicGeometry/GammaS
 
 -/
 
+set_option profiler true
 
 noncomputable section
 
@@ -51,25 +52,25 @@ open Spec (structureSheaf)
 
 /-- The spectrum of a commutative ring, as a topological space.
 -/
-def Spec.topObj (R : CommRingCat) : TopCat :=
+def Spec.topObj (R : CommRingCat.{u}) : TopCat :=
   TopCat.of (PrimeSpectrum R)
 set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.Spec.Top_obj AlgebraicGeometry.Spec.topObj
 
 /-- The induced map of a ring homomorphism on the ring spectra, as a morphism of topological spaces.
 -/
-def Spec.topMap {R S : CommRingCat} (f : R ⟶ S) : Spec.topObj S ⟶ Spec.topObj R :=
+def Spec.topMap {R S : CommRingCat.{u}} (f : R ⟶ S) : Spec.topObj S ⟶ Spec.topObj R :=
   PrimeSpectrum.comap f
 set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.Spec.Top_map AlgebraicGeometry.Spec.topMap
 
 @[simp]
-theorem Spec.topMap_id (R : CommRingCat) : Spec.topMap (𝟙 R) = 𝟙 (Spec.topObj R) :=
+theorem Spec.topMap_id (R : CommRingCat.{u}) : Spec.topMap (𝟙 R) = 𝟙 (Spec.topObj R) :=
   PrimeSpectrum.comap_id
 set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.Spec.Top_map_id AlgebraicGeometry.Spec.topMap_id
 
-theorem Spec.topMap_comp {R S T : CommRingCat} (f : R ⟶ S) (g : S ⟶ T) :
+theorem Spec.topMap_comp {R S T : CommRingCat.{u}} (f : R ⟶ S) (g : S ⟶ T) :
     Spec.topMap (f ≫ g) = Spec.topMap g ≫ Spec.topMap f :=
   PrimeSpectrum.comap_comp _ _
 set_option linter.uppercaseLean3 false in
@@ -80,7 +81,7 @@ set_option linter.uppercaseLean3 false in
 /-- The spectrum, as a contravariant functor from commutative rings to topological spaces.
 -/
 @[simps! obj map]
-def Spec.toTop : CommRingCatᵒᵖ ⥤ TopCat where
+def Spec.toTop : CommRingCat.{u}ᵒᵖ ⥤ TopCat where
   obj R := Spec.topObj (unop R)
   map {R S} f := Spec.topMap f.unop
   map_id R := by dsimp; rw [Spec.topMap_id]
@@ -91,7 +92,7 @@ set_option linter.uppercaseLean3 false in
 /-- The spectrum of a commutative ring, as a `SheafedSpace`.
 -/
 @[simps]
-def Spec.sheafedSpaceObj (R : CommRingCat) : SheafedSpace CommRingCat where
+def Spec.sheafedSpaceObj (R : CommRingCat.{u}) : SheafedSpace CommRingCat where
   carrier := Spec.topObj R
   presheaf := (structureSheaf R).1
   IsSheaf := (structureSheaf R).2
@@ -112,7 +113,7 @@ set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.Spec.SheafedSpace_map AlgebraicGeometry.Spec.sheafedSpaceMap
 
 @[simp]
-theorem Spec.sheafedSpaceMap_id {R : CommRingCat} :
+theorem Spec.sheafedSpaceMap_id {R : CommRingCat.{u}} :
     Spec.sheafedSpaceMap (𝟙 R) = 𝟙 (Spec.sheafedSpaceObj R) :=
   AlgebraicGeometry.PresheafedSpace.Hom.ext _ _ (Spec.topMap_id R) <| by
     ext U
@@ -123,7 +124,7 @@ theorem Spec.sheafedSpaceMap_id {R : CommRingCat} :
 set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.Spec.SheafedSpace_map_id AlgebraicGeometry.Spec.sheafedSpaceMap_id
 
-theorem Spec.sheafedSpaceMap_comp {R S T : CommRingCat} (f : R ⟶ S) (g : S ⟶ T) :
+theorem Spec.sheafedSpaceMap_comp {R S T : CommRingCat.{u}} (f : R ⟶ S) (g : S ⟶ T) :
     Spec.sheafedSpaceMap (f ≫ g) = Spec.sheafedSpaceMap g ≫ Spec.sheafedSpaceMap f :=
   AlgebraicGeometry.PresheafedSpace.Hom.ext _ _ (Spec.topMap_comp f g) <| by
     ext
@@ -138,7 +139,7 @@ set_option linter.uppercaseLean3 false in
 /-- Spec, as a contravariant functor from commutative rings to sheafed spaces.
 -/
 @[simps]
-def Spec.toSheafedSpace : CommRingCatᵒᵖ ⥤ SheafedSpace CommRingCat where
+def Spec.toSheafedSpace : CommRingCat.{u}ᵒᵖ ⥤ SheafedSpace CommRingCat where
   obj R := Spec.sheafedSpaceObj (unop R)
   map f := Spec.sheafedSpaceMap f.unop
   map_id R := by dsimp; rw [Spec.sheafedSpaceMap_id]
@@ -148,32 +149,32 @@ set_option linter.uppercaseLean3 false in
 
 /-- Spec, as a contravariant functor from commutative rings to presheafed spaces.
 -/
-def Spec.toPresheafedSpace : CommRingCatᵒᵖ ⥤ PresheafedSpace.{_, _, u} CommRingCat :=
+def Spec.toPresheafedSpace : CommRingCat.{u}ᵒᵖ ⥤ PresheafedSpace CommRingCat :=
   Spec.toSheafedSpace ⋙ SheafedSpace.forgetToPresheafedSpace
 set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.Spec.to_PresheafedSpace AlgebraicGeometry.Spec.toPresheafedSpace
 
 @[simp]
-theorem Spec.toPresheafedSpace_obj (R : CommRingCatᵒᵖ) :
+theorem Spec.toPresheafedSpace_obj (R : CommRingCat.{u}ᵒᵖ) :
     Spec.toPresheafedSpace.obj R = (Spec.sheafedSpaceObj (unop R)).toPresheafedSpace :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.Spec.to_PresheafedSpace_obj AlgebraicGeometry.Spec.toPresheafedSpace_obj
 
-theorem Spec.toPresheafedSpace_obj_op (R : CommRingCat) :
+theorem Spec.toPresheafedSpace_obj_op (R : CommRingCat.{u}) :
     Spec.toPresheafedSpace.obj (op R) = (Spec.sheafedSpaceObj R).toPresheafedSpace :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.Spec.to_PresheafedSpace_obj_op AlgebraicGeometry.Spec.toPresheafedSpace_obj_op
 
 @[simp]
-theorem Spec.toPresheafedSpace_map (R S : CommRingCatᵒᵖ) (f : R ⟶ S) :
+theorem Spec.toPresheafedSpace_map (R S : CommRingCat.{u}ᵒᵖ) (f : R ⟶ S) :
     Spec.toPresheafedSpace.map f = Spec.sheafedSpaceMap f.unop :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.Spec.to_PresheafedSpace_map AlgebraicGeometry.Spec.toPresheafedSpace_map
 
-theorem Spec.toPresheafedSpace_map_op (R S : CommRingCat) (f : R ⟶ S) :
+theorem Spec.toPresheafedSpace_map_op (R S : CommRingCat.{u}) (f : R ⟶ S) :
     Spec.toPresheafedSpace.map f.op = Spec.sheafedSpaceMap f :=
   rfl
 set_option linter.uppercaseLean3 false in
@@ -201,7 +202,7 @@ set_option linter.uppercaseLean3 false in
 /-- The spectrum of a commutative ring, as a `LocallyRingedSpace`.
 -/
 @[simps! toSheafedSpace]
-def Spec.locallyRingedSpaceObj (R : CommRingCat) : LocallyRingedSpace :=
+def Spec.locallyRingedSpaceObj (R : CommRingCat.{u}) : LocallyRingedSpace :=
   { Spec.sheafedSpaceObj R with
     localRing := fun x =>
       RingEquiv.localRing (A := Localization.AtPrime x.asIdeal)
@@ -210,7 +211,7 @@ set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.Spec.LocallyRingedSpace_obj AlgebraicGeometry.Spec.locallyRingedSpaceObj
 
 @[elementwise]
-theorem stalkMap_toStalk {R S : CommRingCat} (f : R ⟶ S) (p : PrimeSpectrum S) :
+theorem stalkMap_toStalk {R S : CommRingCat.{u}} (f : R ⟶ S) (p : PrimeSpectrum S) :
     toStalk R (PrimeSpectrum.comap f p) ≫ PresheafedSpace.stalkMap (Spec.sheafedSpaceMap f) p =
       f ≫ toStalk S p := by
   erw [← toOpen_germ S ⊤ ⟨p, trivial⟩, ← toOpen_germ R ⊤ ⟨PrimeSpectrum.comap f p, trivial⟩,
@@ -224,7 +225,7 @@ set_option linter.uppercaseLean3 false in
 to the induced local ring homomorphism `Localization.localRingHom`.
 -/
 @[elementwise]
-theorem localRingHom_comp_stalkIso {R S : CommRingCat} (f : R ⟶ S) (p : PrimeSpectrum S) :
+theorem localRingHom_comp_stalkIso {R S : CommRingCat.{u}} (f : R ⟶ S) (p : PrimeSpectrum S) :
     (stalkIso R (PrimeSpectrum.comap f p)).hom ≫
         @CategoryStruct.comp _ _
           (CommRingCat.of (Localization.AtPrime (PrimeSpectrum.comap f p).asIdeal))
@@ -246,7 +247,7 @@ set_option linter.uppercaseLean3 false in
 The induced map of a ring homomorphism on the prime spectra, as a morphism of locally ringed spaces.
 -/
 @[simps]
-def Spec.locallyRingedSpaceMap {R S : CommRingCat} (f : R ⟶ S) :
+def Spec.locallyRingedSpaceMap {R S : CommRingCat.{u}} (f : R ⟶ S) :
     Spec.locallyRingedSpaceObj S ⟶ Spec.locallyRingedSpaceObj R :=
   LocallyRingedSpace.Hom.mk (Spec.sheafedSpaceMap f) fun p =>
     IsLocalRingHom.mk fun a ha => by
@@ -267,14 +268,14 @@ set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.Spec.LocallyRingedSpace_map AlgebraicGeometry.Spec.locallyRingedSpaceMap
 
 @[simp]
-theorem Spec.locallyRingedSpaceMap_id (R : CommRingCat) :
+theorem Spec.locallyRingedSpaceMap_id (R : CommRingCat.{u}) :
     Spec.locallyRingedSpaceMap (𝟙 R) = 𝟙 (Spec.locallyRingedSpaceObj R) :=
   LocallyRingedSpace.Hom.ext _ _ <| by
     rw [Spec.locallyRingedSpaceMap_val, Spec.sheafedSpaceMap_id]; rfl
 set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.Spec.LocallyRingedSpace_map_id AlgebraicGeometry.Spec.locallyRingedSpaceMap_id
 
-theorem Spec.locallyRingedSpaceMap_comp {R S T : CommRingCat} (f : R ⟶ S) (g : S ⟶ T) :
+theorem Spec.locallyRingedSpaceMap_comp {R S T : CommRingCat.{u}} (f : R ⟶ S) (g : S ⟶ T) :
     Spec.locallyRingedSpaceMap (f ≫ g) =
       Spec.locallyRingedSpaceMap g ≫ Spec.locallyRingedSpaceMap f :=
   LocallyRingedSpace.Hom.ext _ _ <| by
@@ -285,7 +286,7 @@ set_option linter.uppercaseLean3 false in
 /-- Spec, as a contravariant functor from commutative rings to locally ringed spaces.
 -/
 @[simps]
-def Spec.toLocallyRingedSpace : CommRingCatᵒᵖ ⥤ LocallyRingedSpace where
+def Spec.toLocallyRingedSpace : CommRingCat.{u}ᵒᵖ ⥤ LocallyRingedSpace where
   obj R := Spec.locallyRingedSpaceObj (unop R)
   map f := Spec.locallyRingedSpaceMap f.unop
   map_id R := by dsimp; rw [Spec.locallyRingedSpaceMap_id]
@@ -299,7 +300,7 @@ open AlgebraicGeometry.LocallyRingedSpace
 
 /-- The counit morphism `R ⟶ Γ(Spec R)` given by `AlgebraicGeometry.StructureSheaf.toOpen`.  -/
 @[simps!]
-def toSpecΓ (R : CommRingCat) : R ⟶ Γ.obj (op (Spec.toLocallyRingedSpace.obj (op R))) :=
+def toSpecΓ (R : CommRingCat.{u}) : R ⟶ Γ.obj (op (Spec.toLocallyRingedSpace.obj (op R))) :=
   StructureSheaf.toOpen R ⊤
 set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.to_Spec_Γ AlgebraicGeometry.toSpecΓ
@@ -307,13 +308,13 @@ set_option linter.uppercaseLean3 false in
 -- These lemmas have always been bad (#7657), but leanprover/lean4#2644 made `simp` start noticing
 attribute [nolint simpNF] AlgebraicGeometry.toSpecΓ_apply_coe
 
-instance isIso_toSpecΓ (R : CommRingCat) : IsIso (toSpecΓ R) := by
+instance isIso_toSpecΓ (R : CommRingCat.{u}) : IsIso (toSpecΓ R) := by
   cases R; apply StructureSheaf.isIso_to_global
 set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.is_iso_to_Spec_Γ AlgebraicGeometry.isIso_toSpecΓ
 
 @[reassoc]
-theorem Spec_Γ_naturality {R S : CommRingCat} (f : R ⟶ S) :
+theorem Spec_Γ_naturality {R S : CommRingCat.{u}} (f : R ⟶ S) :
     f ≫ toSpecΓ S = toSpecΓ R ≫ Γ.map (Spec.toLocallyRingedSpace.map f.op).op := by
   -- Porting note: `ext` failed to pick up one of the three lemmas
   refine RingHom.ext fun x => Subtype.ext <| funext fun x' => ?_; symm;
@@ -324,7 +325,7 @@ set_option linter.uppercaseLean3 false in
 /-- The counit (`SpecΓIdentity.inv.op`) of the adjunction `Γ ⊣ Spec` is an isomorphism. -/
 @[simps! hom_app inv_app]
 def SpecΓIdentity : Spec.toLocallyRingedSpace.rightOp ⋙ Γ ≅ 𝟭 _ :=
-  Iso.symm <| NatIso.ofComponents (fun R =>
+  Iso.symm <| NatIso.ofComponents.{u,u} (fun R =>
     -- Porting note: In Lean3, this `IsIso` is synthesized automatically
     letI : IsIso (toSpecΓ R) := StructureSheaf.isIso_to_global _
     asIso (toSpecΓ R)) fun {X Y} f => by convert Spec_Γ_naturality (R := X) (S := Y) f
@@ -334,7 +335,7 @@ set_option linter.uppercaseLean3 false in
 end SpecΓ
 
 /-- The stalk map of `Spec M⁻¹R ⟶ Spec R` is an iso for each `p : Spec M⁻¹R`. -/
-theorem Spec_map_localization_isIso (R : CommRingCat) (M : Submonoid R)
+theorem Spec_map_localization_isIso (R : CommRingCat.{u}) (M : Submonoid R)
     (x : PrimeSpectrum (Localization M)) :
     IsIso
       (PresheafedSpace.stalkMap

--- a/Mathlib/AlgebraicGeometry/Spec.lean
+++ b/Mathlib/AlgebraicGeometry/Spec.lean
@@ -323,7 +323,7 @@ set_option linter.uppercaseLean3 false in
 /-- The counit (`SpecΓIdentity.inv.op`) of the adjunction `Γ ⊣ Spec` is an isomorphism. -/
 @[simps! hom_app inv_app]
 def SpecΓIdentity : Spec.toLocallyRingedSpace.rightOp ⋙ Γ ≅ 𝟭 _ :=
-  Iso.symm <| NatIso.ofComponents.{u,u} (fun R =>
+  Iso.symm <| NatIso.ofComponents.{u,u,u+1,u+1} (fun R =>
     -- Porting note: In Lean3, this `IsIso` is synthesized automatically
     letI : IsIso (toSpecΓ R) := StructureSheaf.isIso_to_global _
     asIso (toSpecΓ R)) fun {X Y} f => by convert Spec_Γ_naturality (R := X) (S := Y) f


### PR DESCRIPTION
Following #12469 and #12494, we add explicit universe levels in `AlgebraicGeometry.Spec` to speed up the file now and forestall greater slowdowns with the next version of Lean.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
