### PR TITLE
[Merged by Bors] - feat(Order/Minimals, Order/RelIso/Set): four `RelIso` lemmas

### DIFF
--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -6,6 +6,7 @@ Authors: Yaël Dillies
 import Mathlib.Order.Antichain
 import Mathlib.Order.UpperLower.Basic
 import Mathlib.Order.Interval.Set.Basic
+import Mathlib.Order.RelIso.Set
 
 #align_import order.minimal from "leanprover-community/mathlib"@"59694bd07f0a39c5beccba34bd9f413a160782bf"
 
@@ -426,6 +427,14 @@ theorem RelEmbedding.minimals_preimage_eq (f : r ↪r s) (y : Set β) :
   convert (f.inter_preimage_minimals_eq univ y).symm
   · simp [univ_inter]
   · simp [inter_comm]
+
+theorem RelIso.minimals_preimage_eq (f : r ≃r s) (y : Set β) :
+    minimals r (f ⁻¹' y) = f ⁻¹' (minimals s y) := by
+  convert f.toRelEmbedding.minimals_preimage_eq y; simp
+
+theorem RelIso.maximals_preimage_eq (f : r ≃r s) (y : Set β) :
+    maximals r (f ⁻¹' y) = f ⁻¹' (maximals s y) :=
+  f.swap.minimals_preimage_eq y
 
 theorem inter_maximals_preimage_inter_eq_of_rel_iff_rel_on
     (hf : ∀ ⦃a a'⦄, a ∈ x → a' ∈ x → (r a a' ↔ s (f a) (f a'))) (y : Set β) :

--- a/Mathlib/Order/RelIso/Set.lean
+++ b/Mathlib/Order/RelIso/Set.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Order.RelIso.Basic
 import Mathlib.Logic.Embedding.Set
+import Mathlib.Logic.Equiv.Set
 
 #align_import order.rel_iso.set from "leanprover-community/mathlib"@"ee0c179cd3c8a45aa5bffbf1b41d8dbede452865"
 
@@ -99,3 +100,15 @@ theorem RelEmbedding.codRestrict_apply (p) (f : r ↪r s) (H a) :
     RelEmbedding.codRestrict p f H a = ⟨f a, H a⟩ :=
   rfl
 #align rel_embedding.cod_restrict_apply RelEmbedding.codRestrict_apply
+
+section image
+
+variable {α β : Type*} {r : α → α → Prop} {s : β → β → Prop}
+
+theorem RelIso.image_eq_preimage_symm (e : r ≃r s) (t : Set α) : e '' t = e.symm ⁻¹' t :=
+  e.toEquiv.image_eq_preimage t
+
+theorem RelIso.preimage_eq_image_symm (e : r ≃r s) (t : Set β) : e ⁻¹' t = e.symm '' t := by
+  rw [e.symm.image_eq_preimage_symm]; rfl
+
+end image


### PR DESCRIPTION
This PR proves four rewrite lemmas about `RelIso` for statements that were previously a little awkward to navigate. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
