### PR TITLE
[Merged by Bors] - feat: BoundedSub class to generalize subtraction of bounded continuous functions.

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3895,6 +3895,7 @@ import Mathlib.Topology.Bases
 import Mathlib.Topology.Basic
 import Mathlib.Topology.Bornology.Absorbs
 import Mathlib.Topology.Bornology.Basic
+import Mathlib.Topology.Bornology.BoundedOperation
 import Mathlib.Topology.Bornology.Constructions
 import Mathlib.Topology.Bornology.Hom
 import Mathlib.Topology.Category.Born

--- a/Mathlib/Topology/Bornology/BoundedOperation.lean
+++ b/Mathlib/Topology/Bornology/BoundedOperation.lean
@@ -23,8 +23,6 @@ TODO:
 
 section bounded_sub
 
-variable {R : Type*}
-
 open Pointwise
 
 /-- A typeclass saying that `p : R × R ↦ r.1 - r.2` maps any pair of bounded sets to a bounded set.
@@ -34,7 +32,9 @@ class BoundedSub (R : Type*) [Bornology R] [Sub R] : Prop where
   isBounded_sub : ∀ {s t : Set R},
     Bornology.IsBounded s → Bornology.IsBounded t → Bornology.IsBounded (s - t)
 
-lemma isBounded_sub {R : Type*} [Bornology R] [Sub R] [BoundedSub R] {s t : Set R}
+variable {R : Type*}
+
+lemma isBounded_sub [Bornology R] [Sub R] [BoundedSub R] {s t : Set R}
     (hs : Bornology.IsBounded s) (ht : Bornology.IsBounded t):
     Bornology.IsBounded (s - t) := BoundedSub.isBounded_sub hs ht
 

--- a/Mathlib/Topology/Bornology/BoundedOperation.lean
+++ b/Mathlib/Topology/Bornology/BoundedOperation.lean
@@ -57,12 +57,8 @@ lemma sub_bounded_of_bounded_of_bounded {X : Type*} [PseudoMetricSpace R] [Sub R
     {f g : X → R} (f_bdd : ∃ C, ∀ x y, dist (f x) (f y) ≤ C)
     (g_bdd : ∃ C, ∀ x y, dist (g x) (g y) ≤ C) :
     ∃ C, ∀ x y, dist ((f - g) x) ((f - g) y) ≤ C := by
-  obtain ⟨Cf, hf⟩ := f_bdd
-  obtain ⟨Cg, hg⟩ := g_bdd
-  have key := isBounded_sub (Metric.isBounded_range_iff.mpr ⟨Cf, hf⟩)
-                            (Metric.isBounded_range_iff.mpr ⟨Cg, hg⟩)
-  rw [Metric.isBounded_iff] at key
-  obtain ⟨C, hC⟩ := key
+  obtain ⟨C, hC⟩ := Metric.isBounded_iff.mp <|
+    isBounded_sub (Metric.isBounded_range_iff.mpr f_bdd) (Metric.isBounded_range_iff.mpr g_bdd)
   use C
   intro x y
   exact hC (Set.sub_mem_sub (Set.mem_range_self (f := f) x) (Set.mem_range_self (f := g) x))
@@ -81,16 +77,14 @@ instance [SeminormedAddCommGroup R] : BoundedSub R where
     obtain ⟨Cg, hg⟩ := ht
     use Cf + Cg
     intro z hz w hw
-    rw [Set.mem_sub] at hz hw
-    obtain ⟨x₁, hx₁, y₁, hy₁, z_eq⟩ := hz
-    obtain ⟨x₂, hx₂, y₂, hy₂, w_eq⟩ := hw
+    obtain ⟨x₁, hx₁, y₁, hy₁, z_eq⟩ := Set.mem_sub.mp hz
+    obtain ⟨x₂, hx₂, y₂, hy₂, w_eq⟩ := Set.mem_sub.mp hw
     rw [← w_eq, ← z_eq, dist_eq_norm]
     calc  ‖x₁ - y₁ - (x₂ - y₂)‖
-     _  = ‖x₁ - x₂ + (y₂ - y₁)‖ := by
-        congr
+     _  = ‖x₁ - x₂ + (y₂ - y₁)‖     := by
         rw [sub_sub_sub_comm, sub_eq_add_neg, neg_sub]
-     _  ≤ ‖x₁ - x₂‖ + ‖y₂ - y₁‖ := norm_add_le _ _
-     _  ≤ Cf + Cg               :=
+     _  ≤ ‖x₁ - x₂‖ + ‖y₂ - y₁‖     := norm_add_le _ _
+     _  ≤ Cf + Cg                   :=
         add_le_add (mem_closedBall_iff_norm.mp (hf hx₁ hx₂))
                    (mem_closedBall_iff_norm.mp (hg hy₂ hy₁))
 

--- a/Mathlib/Topology/Bornology/BoundedOperation.lean
+++ b/Mathlib/Topology/Bornology/BoundedOperation.lean
@@ -5,6 +5,24 @@ Authors: Kalle Kytölä
 -/
 import Mathlib.Topology.ContinuousFunction.Bounded
 
+/-!
+# Bounded operations
+
+This file introduces type classes for bornologically bounded operations. Together with type classes
+which guarantee continuous operations, these enable to equip bounded continuous functions with the
+respective operations, in particular.
+
+## Main definitions
+
+* `BoundedSub R`: a class guaranteeing boundedness of subtraction.
+
+TODO:
+* Add bounded multiplication. (So that, e.g., multiplication works in `X →ᵇ ℝ≥0`.)
+
+-/
+
+section bounded_sub
+
 variable {R : Type*}
 
 lemma bounded_sub_iff_isBounded_image_sub [PseudoMetricSpace R] [Sub R] (s t : Set R) :
@@ -24,7 +42,10 @@ lemma bounded_sub_iff_isBounded_image_sub [PseudoMetricSpace R] [Sub R] (s t : S
 
 open Pointwise
 
-class BoundedSub (R : Type*) [Bornology R] [Sub R] where
+/-- A typeclass saying that `p : R × R ↦ r.1 - r.2` maps any pair of bounded sets to a bounded set.
+This property automatically holds for seminormed additive groups, but it also holds, e.g.,
+for `ℝ≥0`. -/
+class BoundedSub (R : Type*) [Bornology R] [Sub R] : Prop where
   isBounded_sub : ∀ {s t : Set R},
     Bornology.IsBounded s → Bornology.IsBounded t → Bornology.IsBounded (s - t)
 
@@ -74,3 +95,5 @@ instance instSub' {X R : Type*} [TopologicalSpace X] [PseudoMetricSpace R]
   sub f g :=
     { toFun := fun x ↦ (f x - g x),
       map_bounded' := sub_bounded_of_bounded_of_bounded f.map_bounded' g.map_bounded' }
+
+end bounded_sub

--- a/Mathlib/Topology/Bornology/BoundedOperation.lean
+++ b/Mathlib/Topology/Bornology/BoundedOperation.lean
@@ -91,7 +91,8 @@ instance [SeminormedAddCommGroup R] : BoundedSub R where
         rw [sub_sub_sub_comm, sub_eq_add_neg, neg_sub]
      _  ≤ ‖x₁ - x₂‖ + ‖y₂ - y₁‖ := norm_add_le _ _
      _  ≤ Cf + Cg               :=
-        add_le_add (mem_closedBall_iff_norm.mp (hf hx₁ hx₂)) (mem_closedBall_iff_norm.mp (hg hy₂ hy₁))
+        add_le_add (mem_closedBall_iff_norm.mp (hf hx₁ hx₂))
+                   (mem_closedBall_iff_norm.mp (hg hy₂ hy₁))
 
 section NNReal
 

--- a/Mathlib/Topology/Bornology/BoundedOperation.lean
+++ b/Mathlib/Topology/Bornology/BoundedOperation.lean
@@ -8,9 +8,10 @@ import Mathlib.Analysis.Normed.Group.Basic
 /-!
 # Bounded operations
 
-This file introduces type classes for bornologically bounded operations. Together with type classes
-which guarantee continuous operations, these enable to equip bounded continuous functions with the
-respective operations, in particular.
+This file introduces type classes for bornologically bounded operations.
+
+In particular, when combined with type classes which guarantee continuity of the same operations,
+we can equip bounded continuous functions with the corresponding operations.
 
 ## Main definitions
 
@@ -22,11 +23,14 @@ TODO:
 -/
 
 section bounded_sub
+/-!
+### Bounded subtraction
+-/
 
 open Pointwise
 
-/-- A typeclass saying that `p : R × R ↦ r.1 - r.2` maps any pair of bounded sets to a bounded set.
-This property automatically holds for seminormed additive groups, but it also holds, e.g.,
+/-- A typeclass saying that `(p : R × R) ↦ p.1 - p.2` maps any pair of bounded sets to a bounded
+set. This property automatically holds for seminormed additive groups, but it also holds, e.g.,
 for `ℝ≥0`. -/
 class BoundedSub (R : Type*) [Bornology R] [Sub R] : Prop where
   isBounded_sub : ∀ {s t : Set R},
@@ -49,12 +53,21 @@ lemma sub_bounded_of_bounded_of_bounded {X : Type*} [PseudoMetricSpace R] [Sub R
   exact hC (Set.sub_mem_sub (Set.mem_range_self (f := f) x) (Set.mem_range_self (f := g) x))
            (Set.sub_mem_sub (Set.mem_range_self (f := f) y) (Set.mem_range_self (f := g) y))
 
-lemma SeminormedAddCommGroup.lipschitzWith_sub [SeminormedAddCommGroup R] :
+end bounded_sub
+
+section SeminormedAddCommGroup
+/-!
+### Bounded operations in seminormed additive commutative groups
+-/
+
+variable {R : Type*} [SeminormedAddCommGroup R]
+
+lemma SeminormedAddCommGroup.lipschitzWith_sub :
     LipschitzWith 2 (fun (p : R × R) ↦ p.1 - p.2) := by
   convert LipschitzWith.prod_fst.sub LipschitzWith.prod_snd
   norm_num
 
-instance [SeminormedAddCommGroup R] : BoundedSub R where
+instance : BoundedSub R where
   isBounded_sub := by
     intro s t hs ht
     rw [Metric.isBounded_iff] at hs ht ⊢
@@ -73,7 +86,12 @@ instance [SeminormedAddCommGroup R] : BoundedSub R where
         add_le_add (mem_closedBall_iff_norm.mp (hf hx₁ hx₂))
                    (mem_closedBall_iff_norm.mp (hg hy₂ hy₁))
 
+end SeminormedAddCommGroup
+
 section NNReal
+/-!
+### Bounded operations in ℝ≥0
+-/
 
 open scoped NNReal
 
@@ -90,5 +108,3 @@ noncomputable instance : BoundedSub ℝ≥0 where
     exact tsub_lt_of_lt key
 
 end NNReal
-
-end bounded_sub

--- a/Mathlib/Topology/Bornology/BoundedOperation.lean
+++ b/Mathlib/Topology/Bornology/BoundedOperation.lean
@@ -25,21 +25,6 @@ section bounded_sub
 
 variable {R : Type*}
 
-lemma bounded_sub_iff_isBounded_image_sub [PseudoMetricSpace R] [Sub R] (s t : Set R) :
-    (∃ κ, ∀ x₁ ∈ s, ∀ x₂ ∈ s, ∀ y₁ ∈ t, ∀ y₂ ∈ t, dist (x₁ - y₁) (x₂ - y₂) ≤ κ)
-      ↔ (Bornology.IsBounded ((fun p ↦ p.fst - p.snd) '' s ×ˢ t)) := by
-  rw [Metric.isBounded_iff]
-  constructor <;> intro h
-  · rcases h with ⟨c, hc⟩
-    use c
-    intro z ⟨p, ⟨p_mem_st, hpz⟩⟩ w ⟨q, ⟨q_mem_st, hqw⟩⟩
-    simp only [Set.mem_prod] at p_mem_st q_mem_st
-    simpa [hqw, hpz] using hc p.1 p_mem_st.1 q.1 q_mem_st.1 p.2 p_mem_st.2 q.2 q_mem_st.2
-  · rcases h with ⟨c, hc⟩
-    use c
-    intro x₁ x₁_in_s x₂ x₂_in_s y₁ y₁_in_t y₂ y₂_in_t
-    exact hc ⟨⟨x₁, y₁⟩, by aesop⟩ ⟨⟨x₂, y₂⟩, by aesop⟩
-
 open Pointwise
 
 /-- A typeclass saying that `p : R × R ↦ r.1 - r.2` maps any pair of bounded sets to a bounded set.

--- a/Mathlib/Topology/Bornology/BoundedOperation.lean
+++ b/Mathlib/Topology/Bornology/BoundedOperation.lean
@@ -39,7 +39,7 @@ class BoundedSub (R : Type*) [Bornology R] [Sub R] : Prop where
 variable {R : Type*}
 
 lemma isBounded_sub [Bornology R] [Sub R] [BoundedSub R] {s t : Set R}
-    (hs : Bornology.IsBounded s) (ht : Bornology.IsBounded t):
+    (hs : Bornology.IsBounded s) (ht : Bornology.IsBounded t) :
     Bornology.IsBounded (s - t) := BoundedSub.isBounded_sub hs ht
 
 lemma sub_bounded_of_bounded_of_bounded {X : Type*} [PseudoMetricSpace R] [Sub R] [BoundedSub R]

--- a/Mathlib/Topology/Bornology/BoundedSub.lean
+++ b/Mathlib/Topology/Bornology/BoundedSub.lean
@@ -54,24 +54,6 @@ lemma SeminormedAddCommGroup.lipschitzWith_sub [SeminormedAddCommGroup R] :
 
 open scoped NNReal
 
-lemma NNReal.closedBall_zero_eq_Icc' (c : ℝ≥0) :
-    Metric.closedBall (0 : ℝ≥0) c.toReal = Set.Icc 0 c := by ext x; simp
-
-lemma NNReal.closedBall_zero_eq_Icc {c : ℝ} (c_nn : 0 ≤ c) :
-    Metric.closedBall (0 : ℝ≥0) c = Set.Icc 0 c.toNNReal := by
-  convert NNReal.closedBall_zero_eq_Icc' ⟨c, c_nn⟩
-  simp [Real.toNNReal, c_nn]
-
-lemma NNReal.ball_zero_eq_Ico' (c : ℝ≥0) :
-    Metric.ball (0 : ℝ≥0) c.toReal = Set.Ico 0 c := by ext x; simp
-
-lemma NNReal.ball_zero_eq_Ico (c : ℝ) :
-    Metric.ball (0 : ℝ≥0) c = Set.Ico 0 c.toNNReal := by
-  by_cases c_pos : 0 < c
-  · convert NNReal.ball_zero_eq_Ico' ⟨c, c_pos.le⟩
-    simp [Real.toNNReal, c_pos.le]
-  simp [not_lt.mp c_pos]
-
 noncomputable instance : BoundedSub ℝ≥0 where
   isBounded_sub := by
     intro s t hs _

--- a/Mathlib/Topology/Bornology/BoundedSub.lean
+++ b/Mathlib/Topology/Bornology/BoundedSub.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2024 Kalle Kytölä
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kalle Kytölä
+-/
+import Mathlib.Topology.ContinuousFunction.Bounded
+
+variable {R : Type*}
+
+lemma bounded_sub_iff_isBounded_image_sub [PseudoMetricSpace R] [Sub R] (s t : Set R) :
+    (∃ κ, ∀ x₁ ∈ s, ∀ x₂ ∈ s, ∀ y₁ ∈ t, ∀ y₂ ∈ t, dist (x₁ - y₁) (x₂ - y₂) ≤ κ)
+      ↔ (Bornology.IsBounded ((fun p ↦ p.fst - p.snd) '' s ×ˢ t)) := by
+  rw [Metric.isBounded_iff]
+  constructor <;> intro h
+  · rcases h with ⟨c, hc⟩
+    use c
+    intro z ⟨p, ⟨p_mem_st, hpz⟩⟩ w ⟨q, ⟨q_mem_st, hqw⟩⟩
+    simp only [Set.mem_prod] at p_mem_st q_mem_st
+    simpa [hqw, hpz] using hc p.1 p_mem_st.1 q.1 q_mem_st.1 p.2 p_mem_st.2 q.2 q_mem_st.2
+  · rcases h with ⟨c, hc⟩
+    use c
+    intro x₁ x₁_in_s x₂ x₂_in_s y₁ y₁_in_t y₂ y₂_in_t
+    exact hc ⟨⟨x₁, y₁⟩, by aesop⟩ ⟨⟨x₂, y₂⟩, by aesop⟩
+
+open Pointwise
+
+class BoundedSub (R : Type*) [Bornology R] [Sub R] where
+  isBounded_sub : ∀ {s t : Set R},
+    Bornology.IsBounded s → Bornology.IsBounded t → Bornology.IsBounded (s - t)
+
+lemma isBounded_sub {R : Type*} [Bornology R] [Sub R] [BoundedSub R] {s t : Set R}
+    (hs : Bornology.IsBounded s) (ht : Bornology.IsBounded t):
+    Bornology.IsBounded (s - t) := BoundedSub.isBounded_sub hs ht
+
+lemma sub_bounded_of_bounded_of_bounded {X : Type*} [PseudoMetricSpace R] [Sub R] [BoundedSub R]
+    {f g : X → R} (f_bdd : ∃ C, ∀ x y, dist (f x) (f y) ≤ C)
+    (g_bdd : ∃ C, ∀ x y, dist (g x) (g y) ≤ C) :
+    ∃ C, ∀ x y, dist ((f - g) x) ((f - g) y) ≤ C := by
+  obtain ⟨Cf, hf⟩ := f_bdd
+  obtain ⟨Cg, hg⟩ := g_bdd
+  have key := isBounded_sub (Metric.isBounded_range_iff.mpr ⟨Cf, hf⟩)
+                            (Metric.isBounded_range_iff.mpr ⟨Cg, hg⟩)
+  rw [Metric.isBounded_iff] at key
+  obtain ⟨C, hC⟩ := key
+  use C
+  intro x y
+  exact hC (Set.sub_mem_sub (Set.mem_range_self (f := f) x) (Set.mem_range_self (f := g) x))
+           (Set.sub_mem_sub (Set.mem_range_self (f := f) y) (Set.mem_range_self (f := g) y))
+
+lemma SeminormedAddCommGroup.lipschitzWith_sub [SeminormedAddCommGroup R] :
+    LipschitzWith 2 (fun (p : R × R) ↦ p.1 - p.2) := by
+  convert LipschitzWith.prod_fst.sub LipschitzWith.prod_snd
+  norm_num
+
+open scoped NNReal
+
+lemma NNReal.closedBall_zero_eq_Icc' (c : ℝ≥0) :
+    Metric.closedBall (0 : ℝ≥0) c.toReal = Set.Icc 0 c := by ext x; simp
+
+lemma NNReal.closedBall_zero_eq_Icc {c : ℝ} (c_nn : 0 ≤ c) :
+    Metric.closedBall (0 : ℝ≥0) c = Set.Icc 0 c.toNNReal := by
+  convert NNReal.closedBall_zero_eq_Icc' ⟨c, c_nn⟩
+  simp [Real.toNNReal, c_nn]
+
+lemma NNReal.ball_zero_eq_Ico' (c : ℝ≥0) :
+    Metric.ball (0 : ℝ≥0) c.toReal = Set.Ico 0 c := by ext x; simp
+
+lemma NNReal.ball_zero_eq_Ico (c : ℝ) :
+    Metric.ball (0 : ℝ≥0) c = Set.Ico 0 c.toNNReal := by
+  by_cases c_pos : 0 < c
+  · convert NNReal.ball_zero_eq_Ico' ⟨c, c_pos.le⟩
+    simp [Real.toNNReal, c_pos.le]
+  simp [not_lt.mp c_pos]
+
+noncomputable instance : BoundedSub ℝ≥0 where
+  isBounded_sub := by
+    intro s t hs _
+    obtain ⟨c, hc⟩ := (Metric.isBounded_iff_subset_ball 0).mp hs
+    apply (Metric.isBounded_iff_subset_ball 0).mpr
+    use c
+    intro z hz
+    obtain ⟨a, a_in_s, b, _, z_eq⟩ := Set.mem_sub.mp hz
+    have key := hc a_in_s
+    simp [NNReal.ball_zero_eq_Ico, ←z_eq] at *
+    exact tsub_lt_of_lt key
+
+open scoped BoundedContinuousFunction NNReal
+
+instance instSub' {X R : Type*} [TopologicalSpace X] [PseudoMetricSpace R]
+    [Sub R] [BoundedSub R] [ContinuousSub R] :
+    Sub (X →ᵇ R) where
+  sub f g :=
+    { toFun := fun x ↦ (f x - g x),
+      map_bounded' := sub_bounded_of_bounded_of_bounded f.map_bounded' g.map_bounded' }

--- a/Mathlib/Topology/ContinuousFunction/Bounded.lean
+++ b/Mathlib/Topology/ContinuousFunction/Bounded.lean
@@ -770,13 +770,22 @@ end CommHasLipschitzAdd
 
 section sub
 
+variable [TopologicalSpace α]
+variable {R : Type*} [PseudoMetricSpace R] [Sub R] [BoundedSub R] [ContinuousSub R]
+variable (f g : α →ᵇ R)
+
 /-- The pointwise difference of two bounded continuous functions is again bounded continuous. -/
-instance instSub {X R : Type*} [TopologicalSpace X] [PseudoMetricSpace R]
-    [Sub R] [BoundedSub R] [ContinuousSub R] :
-    Sub (X →ᵇ R) where
+instance instSub : Sub (α →ᵇ R) where
   sub f g :=
     { toFun := fun x ↦ (f x - g x),
       map_bounded' := sub_bounded_of_bounded_of_bounded f.map_bounded' g.map_bounded' }
+
+theorem sub_apply {x : α} : (f - g) x = f x - g x := rfl
+#align bounded_continuous_function.sub_apply BoundedContinuousFunction.sub_apply
+
+@[simp]
+theorem coe_sub : ⇑(f - g) = f - g := rfl
+#align bounded_continuous_function.coe_sub BoundedContinuousFunction.coe_sub
 
 end sub
 
@@ -947,13 +956,6 @@ theorem coe_neg : ⇑(-f) = -f := rfl
 
 theorem neg_apply : (-f) x = -f x := rfl
 #align bounded_continuous_function.neg_apply BoundedContinuousFunction.neg_apply
-
-@[simp]
-theorem coe_sub : ⇑(f - g) = f - g := rfl
-#align bounded_continuous_function.coe_sub BoundedContinuousFunction.coe_sub
-
-theorem sub_apply : (f - g) x = f x - g x := rfl
-#align bounded_continuous_function.sub_apply BoundedContinuousFunction.sub_apply
 
 @[simp]
 theorem mkOfCompact_neg [CompactSpace α] (f : C(α, β)) : mkOfCompact (-f) = -mkOfCompact f := rfl

--- a/Mathlib/Topology/ContinuousFunction/Bounded.lean
+++ b/Mathlib/Topology/ContinuousFunction/Bounded.lean
@@ -9,6 +9,7 @@ import Mathlib.Analysis.Normed.Order.Lattice
 import Mathlib.Analysis.NormedSpace.OperatorNorm.Basic
 import Mathlib.Analysis.NormedSpace.Star.Basic
 import Mathlib.Analysis.NormedSpace.ContinuousLinearMap
+import Mathlib.Topology.Bornology.BoundedOperation
 
 #align_import topology.continuous_function.bounded from "leanprover-community/mathlib"@"5dc275ec639221ca4d5f56938eb966f6ad9bc89f"
 
@@ -767,6 +768,18 @@ theorem sum_apply {ι : Type*} (s : Finset ι) (f : ι → α →ᵇ β) (a : α
 
 end CommHasLipschitzAdd
 
+section sub
+
+/-- The pointwise difference of two bounded continuous functions is again bounded continuous. -/
+instance instSub {X R : Type*} [TopologicalSpace X] [PseudoMetricSpace R]
+    [Sub R] [BoundedSub R] [ContinuousSub R] :
+    Sub (X →ᵇ R) where
+  sub f g :=
+    { toFun := fun x ↦ (f x - g x),
+      map_bounded' := sub_bounded_of_bounded_of_bounded f.map_bounded' g.map_bounded' }
+
+end sub
+
 section NormedAddCommGroup
 
 /- In this section, if `β` is a normed group, then we show that the space of bounded
@@ -927,14 +940,6 @@ instance : Neg (α →ᵇ β) :=
   ⟨fun f =>
     ofNormedAddCommGroup (-f) f.continuous.neg ‖f‖ fun x =>
       norm_neg ((⇑f) x) ▸ f.norm_coe_le_norm x⟩
-
-/-- The pointwise difference of two bounded continuous functions is again bounded continuous. -/
-instance instSub : Sub (α →ᵇ β) :=
-  ⟨fun f g =>
-    ofNormedAddCommGroup (f - g) (f.continuous.sub g.continuous) (‖f‖ + ‖g‖) fun x => by
-      simp only [sub_eq_add_neg]
-      exact le_trans (norm_add_le _ _)
-        (add_le_add (f.norm_coe_le_norm x) <| norm_neg ((⇑g) x) ▸ g.norm_coe_le_norm x)⟩
 
 @[simp]
 theorem coe_neg : ⇑(-f) = -f := rfl

--- a/Mathlib/Topology/MetricSpace/PseudoMetric.lean
+++ b/Mathlib/Topology/MetricSpace/PseudoMetric.lean
@@ -1599,6 +1599,24 @@ theorem NNReal.le_add_nndist (a b : ℝ≥0) : a ≤ b + nndist a b := by
   exact le_of_abs_le (dist_eq a b).ge
 #align nnreal.le_add_nndist NNReal.le_add_nndist
 
+lemma NNReal.ball_zero_eq_Ico' (c : ℝ≥0) :
+    Metric.ball (0 : ℝ≥0) c.toReal = Set.Ico 0 c := by ext x; simp
+
+lemma NNReal.ball_zero_eq_Ico (c : ℝ) :
+    Metric.ball (0 : ℝ≥0) c = Set.Ico 0 c.toNNReal := by
+  by_cases c_pos : 0 < c
+  · convert NNReal.ball_zero_eq_Ico' ⟨c, c_pos.le⟩
+    simp [Real.toNNReal, c_pos.le]
+  simp [not_lt.mp c_pos]
+
+lemma NNReal.closedBall_zero_eq_Icc' (c : ℝ≥0) :
+    Metric.closedBall (0 : ℝ≥0) c.toReal = Set.Icc 0 c := by ext x; simp
+
+lemma NNReal.closedBall_zero_eq_Icc {c : ℝ} (c_nn : 0 ≤ c) :
+    Metric.closedBall (0 : ℝ≥0) c = Set.Icc 0 c.toNNReal := by
+  convert NNReal.closedBall_zero_eq_Icc' ⟨c, c_nn⟩
+  simp [Real.toNNReal, c_nn]
+
 end NNReal
 
 section ULift


### PR DESCRIPTION
Introduce type class `BoundedSub`, which allows to generalize subtraction of `BoundedContinuousFunction` to the case where the values are not necessarily in `SeminormedAddGroup`. The most important case for measure theory applications that is allowed by the generalization is bounded continuous functions with values in `ℝ≥0`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
