### PR TITLE
[Merged by Bors] - feat: generalize kernel Radon-Nikodym derivative to `CountableOrCountablyGenerated`

### DIFF
--- a/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
@@ -397,7 +397,7 @@ lemma integral_toReal_rnDeriv [SigmaFinite μ] [SigmaFinite ν] (hμν : μ ≪ 
 
 end integral
 
-lemma rnDeriv_mul_rnDeriv {μ ν κ : Measure α} [SigmaFinite μ] [SigmaFinite ν] [SigmaFinite κ]
+lemma rnDeriv_mul_rnDeriv {κ : Measure α} [SigmaFinite μ] [SigmaFinite ν] [SigmaFinite κ]
     (hμν : μ ≪ ν) :
     μ.rnDeriv ν * ν.rnDeriv κ =ᵐ[κ] μ.rnDeriv κ := by
   refine (rnDeriv_withDensity_left ?_ ?_ ?_).symm.trans ?_
@@ -405,6 +405,12 @@ lemma rnDeriv_mul_rnDeriv {μ ν κ : Measure α} [SigmaFinite μ] [SigmaFinite 
   · exact (Measure.measurable_rnDeriv _ _).aemeasurable
   · exact rnDeriv_ne_top _ _
   · rw [Measure.withDensity_rnDeriv_eq _ _ hμν]
+
+lemma rnDeriv_le_one_of_le (hμν : μ ≤ ν) [SigmaFinite ν] : μ.rnDeriv ν ≤ᵐ[ν] 1 := by
+  refine ae_le_of_forall_set_lintegral_le_of_sigmaFinite (μ.measurable_rnDeriv ν) measurable_const
+    (fun s _ _ ↦ ?_)
+  simp only [Pi.one_apply, MeasureTheory.set_lintegral_one]
+  exact (Measure.set_lintegral_rnDeriv_le s).trans (hμν s)
 
 end Measure
 

--- a/Mathlib/Probability/Kernel/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/RadonNikodym.lean
@@ -9,8 +9,8 @@ import Mathlib.Probability.Kernel.WithDensity
 /-!
 # Radon-Nikodym derivative and Lebesgue decomposition for kernels
 
-Let `α` and `γ` be two measurable space, where either `α` is countable or `γ` is countably generated.
-Let `κ, η : kernel α γ` be finite kernels.
+Let `α` and `γ` be two measurable space, where either `α` is countable or `γ` is
+countably generated. Let `κ, η : kernel α γ` be finite kernels.
 Then there exists a function `kernel.rnDeriv κ η : α → γ → ℝ≥0∞` jointly measurable on `α × γ`
 and a kernel `kernel.singularPart κ η : kernel α γ` such that
 * `κ = kernel.withDensity η (kernel.rnDeriv κ η) + kernel.singularPart κ η`,

--- a/Mathlib/Probability/Kernel/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/RadonNikodym.lean
@@ -9,7 +9,7 @@ import Mathlib.Probability.Kernel.WithDensity
 /-!
 # Radon-Nikodym derivative and Lebesgue decomposition for kernels
 
-Let `α` and `γ` be two measurable space, where either `α` is countable or `γ` is countably genrated.
+Let `α` and `γ` be two measurable space, where either `α` is countable or `γ` is countably generated.
 Let `κ, η : kernel α γ` be finite kernels.
 Then there exists a function `kernel.rnDeriv κ η : α → γ → ℝ≥0∞` jointly measurable on `α × γ`
 and a kernel `kernel.singularPart κ η : kernel α γ` such that

--- a/Mathlib/Probability/Kernel/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/RadonNikodym.lean
@@ -9,7 +9,8 @@ import Mathlib.Probability.Kernel.WithDensity
 /-!
 # Radon-Nikodym derivative and Lebesgue decomposition for kernels
 
-Let `γ` be a countably generated measurable space and `κ, η : kernel α γ` be finite kernels.
+Let `α` and `γ` be two measurable space, where either `α` is countable or `γ` is countably genrated.
+Let `κ, η : kernel α γ` be finite kernels.
 Then there exists a function `kernel.rnDeriv κ η : α → γ → ℝ≥0∞` jointly measurable on `α × γ`
 and a kernel `kernel.singularPart κ η : kernel α γ` such that
 * `κ = kernel.withDensity η (kernel.rnDeriv κ η) + kernel.singularPart κ η`,
@@ -19,10 +20,10 @@ and a kernel `kernel.singularPart κ η : kernel α γ` such that
 
 Furthermore, the sets `{a | κ a ≪ η a}` and `{a | κ a ⟂ₘ η a}` are measurable.
 
-The construction of the derivative starts from `kernel.density`: for two finite kernels
-`κ' : kernel α (γ × β)` and `η' : kernel α γ` with `fst κ' ≤ η'`, the function
-`density κ' η' : α → γ → Set β → ℝ` is jointly measurable in the first two arguments and satisfies
-that for all `a : α` and all measurable sets `s : Set β` and `A : Set γ`,
+When `γ` is countably generated, the construction of the derivative starts from `kernel.density`:
+for two finite kernels `κ' : kernel α (γ × β)` and `η' : kernel α γ` with `fst κ' ≤ η'`,
+the function `density κ' η' : α → γ → Set β → ℝ` is jointly measurable in the first two arguments
+and satisfies that for all `a : α` and all measurable sets `s : Set β` and `A : Set γ`,
 `∫ x in A, density κ' η' a x s ∂(η' a) = (κ' a (A ×ˢ s)).toReal`.
 We use that definition for `β = Unit` and `κ' = map κ (fun a ↦ (a, ()))`. We can't choose `η' = η`
 in general because we might not have `κ ≤ η`, but if we could, we would get a measurable function
@@ -36,8 +37,9 @@ Up to some conversions between `ℝ` and `ℝ≥0`, the singular part is
 The countably generated measurable space assumption is not needed to have a decomposition for
 measures, but the additional difficulty with kernels is to obtain joint measurability of the
 derivative. This is why we can't simply define `rnDeriv κ η` by `a ↦ (κ a).rnDeriv (ν a)`
-everywhere (although `rnDeriv κ η` has that value almost everywhere). See the construction of
-`kernel.density` for details on how the countably generated hypothesis is used.
+everywhere unless `α` is countable (although `rnDeriv κ η` has that value almost everywhere).
+See the construction of `kernel.density` for details on how the countably generated hypothesis
+is used.
 
 ## Main definitions
 
@@ -73,9 +75,10 @@ open scoped NNReal ENNReal MeasureTheory Topology ProbabilityTheory
 
 namespace ProbabilityTheory.kernel
 
-variable {α γ : Type*} {mα : MeasurableSpace α} {mγ : MeasurableSpace γ}
-  [MeasurableSpace.CountablyGenerated γ] {κ η : kernel α γ}
+variable {α γ : Type*} {mα : MeasurableSpace α} {mγ : MeasurableSpace γ} {κ η : kernel α γ}
+  [hαγ : MeasurableSpace.CountableOrCountablyGenerated α γ]
 
+open Classical in
 /-- Auxiliary function used to define `ProbabilityTheory.kernel.rnDeriv` and
 `ProbabilityTheory.kernel.singularPart`.
 
@@ -83,18 +86,45 @@ This has the properties we want for a Radon-Nikodym derivative only if `κ ≪ �
 `rnDeriv κ η` will be built from `rnDerivAux κ (κ + η)`. -/
 noncomputable
 def rnDerivAux (κ η : kernel α γ) (a : α) (x : γ) : ℝ :=
-  density (map κ (fun a ↦ (a, ()))
-    (@measurable_prod_mk_right γ Unit _ inferInstance _)) η a x univ
+  if hα : Countable α then ((κ a).rnDeriv (η a) x).toReal
+  else haveI := hαγ.countableOrCountablyGenerated.resolve_left hα
+    density (map κ (fun a ↦ (a, ()))
+      (@measurable_prod_mk_right γ Unit _ inferInstance _)) η a x univ
 
-lemma rnDerivAux_nonneg (hκη : κ ≤ η) {a : α} {x : γ} : 0 ≤ rnDerivAux κ η a x :=
-  density_nonneg ((fst_map_id_prod _ measurable_const).trans_le hκη) _ _ _
+lemma rnDerivAux_nonneg (hκη : κ ≤ η) {a : α} {x : γ} : 0 ≤ rnDerivAux κ η a x := by
+  rw [rnDerivAux]
+  split_ifs with hα
+  · exact ENNReal.toReal_nonneg
+  · have := hαγ.countableOrCountablyGenerated.resolve_left hα
+    exact density_nonneg ((fst_map_id_prod _ measurable_const).trans_le hκη) _ _ _
 
-lemma rnDerivAux_le_one (hκη : κ ≤ η) {a : α} {x : γ} : rnDerivAux κ η a x ≤ 1 :=
-  density_le_one ((fst_map_id_prod _ measurable_const).trans_le hκη) _ _ _
+lemma rnDerivAux_le_one [IsFiniteKernel η] (hκη : κ ≤ η) {a : α} :
+    rnDerivAux κ η a ≤ᵐ[η a] 1 := by
+  filter_upwards [Measure.rnDeriv_le_one_of_le (hκη a)] with x hx_le_one
+  simp_rw [rnDerivAux]
+  split_ifs with hα
+  · refine ENNReal.toReal_le_of_le_ofReal zero_le_one ?_
+    simp only [Pi.one_apply, ENNReal.ofReal_one]
+    exact hx_le_one
+  · have := hαγ.countableOrCountablyGenerated.resolve_left hα
+    exact density_le_one ((fst_map_id_prod _ measurable_const).trans_le hκη) _ _ _
 
 lemma measurable_rnDerivAux (κ η : kernel α γ) :
-    Measurable (fun p : α × γ ↦ kernel.rnDerivAux κ η p.1 p.2) :=
-  measurable_density _ η MeasurableSet.univ
+    Measurable (fun p : α × γ ↦ kernel.rnDerivAux κ η p.1 p.2) := by
+  simp_rw [rnDerivAux]
+  split_ifs with hα
+  · refine Measurable.ennreal_toReal ?_
+    change Measurable ((fun q : γ × α ↦ (κ q.2).rnDeriv (η q.2) q.1) ∘ Prod.swap)
+    refine (measurable_from_prod_countable' (fun a ↦ ?_) ?_).comp measurable_swap
+    · exact Measure.measurable_rnDeriv (κ a) (η a)
+    · intro a a' c ha'_mem_a
+      have h_eq : ∀ κ : kernel α γ, κ a' = κ a := fun κ ↦ by
+        ext s hs
+        exact mem_of_mem_measurableAtom ha'_mem_a
+          (kernel.measurable_coe κ hs (measurableSet_singleton (κ a s))) rfl
+      rw [h_eq κ, h_eq η]
+  · have := hαγ.countableOrCountablyGenerated.resolve_left hα
+    exact measurable_density _ η MeasurableSet.univ
 
 lemma measurable_rnDerivAux_right (κ η : kernel α γ) (a : α) :
     Measurable (fun x : γ ↦ rnDerivAux κ η a x) := by
@@ -106,10 +136,17 @@ lemma set_lintegral_rnDerivAux (κ η : kernel α γ) [IsFiniteKernel κ] [IsFin
     ∫⁻ x in s, ENNReal.ofReal (rnDerivAux κ (κ + η) a x) ∂(κ + η) a = κ a s := by
   have h_le : κ ≤ κ + η := le_add_of_nonneg_right bot_le
   simp_rw [rnDerivAux]
-  rw [set_lintegral_density ((fst_map_id_prod _ measurable_const).trans_le h_le) _
-    MeasurableSet.univ hs, map_apply' _ _ _ (hs.prod MeasurableSet.univ)]
-  congr with x
-  simp
+  split_ifs with hα
+  · have h_ac : κ a ≪ (κ + η) a := Measure.absolutelyContinuous_of_le (h_le a)
+    rw [← Measure.set_lintegral_rnDeriv h_ac]
+    refine set_lintegral_congr_fun hs ?_
+    filter_upwards [Measure.rnDeriv_lt_top (κ a) ((κ + η) a)] with x hx_lt _
+    rw [ENNReal.ofReal_toReal hx_lt.ne]
+  · have := hαγ.countableOrCountablyGenerated.resolve_left hα
+    rw [set_lintegral_density ((fst_map_id_prod _ measurable_const).trans_le h_le) _
+      MeasurableSet.univ hs, map_apply' _ _ _ (hs.prod MeasurableSet.univ)]
+    congr with x
+    simp
 
 lemma withDensity_rnDerivAux (κ η : kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η] :
     withDensity (κ + η) (fun a x ↦ Real.toNNReal (rnDerivAux κ (κ + η) a x)) = κ := by
@@ -142,13 +179,14 @@ lemma withDensity_one_sub_rnDerivAux (κ η : kernel α γ) [IsFiniteKernel κ] 
   · rw [withDensity_one']
   · exact measurable_const
   · exact (measurable_rnDerivAux _ _).ennreal_ofReal
-  · refine fun a ↦ ae_of_all _ (fun x ↦ ?_)
+  · intro a
+    filter_upwards [rnDerivAux_le_one h_le] with x hx
     simp only [ENNReal.ofReal_le_one]
-    exact density_le_one ((fst_map_id_prod _ measurable_const).trans_le h_le) _ _ _
+    exact hx
 
 /-- A set of points in `α × γ` related to the absolute continuity / mutual singularity of
 `κ` and `η`. -/
-def mutuallySingularSet (κ η : kernel α γ) : Set (α × γ) := {p | rnDerivAux κ (κ + η) p.1 p.2 = 1}
+def mutuallySingularSet (κ η : kernel α γ) : Set (α × γ) := {p | 1 ≤ rnDerivAux κ (κ + η) p.1 p.2}
 
 /-- A set of points in `α × γ` related to the absolute continuity / mutual singularity of
 `κ` and `η`. That is,
@@ -156,11 +194,19 @@ def mutuallySingularSet (κ η : kernel α γ) : Set (α × γ) := {p | rnDerivA
 * `singularPart κ η a (mutuallySingularSetSlice κ η a)ᶜ = 0`.
  -/
 def mutuallySingularSetSlice (κ η : kernel α γ) (a : α) : Set γ :=
-  {x | rnDerivAux κ (κ + η) a x = 1}
+  {x | 1 ≤ rnDerivAux κ (κ + η) a x}
+
+lemma mem_mutuallySingularSetSlice (κ η : kernel α γ) (a : α) (x : γ) :
+    x ∈ mutuallySingularSetSlice κ η a ↔ 1 ≤ rnDerivAux κ (κ + η) a x := by
+  rw [mutuallySingularSetSlice]; rfl
+
+lemma not_mem_mutuallySingularSetSlice (κ η : kernel α γ) (a : α) (x : γ) :
+    x ∉ mutuallySingularSetSlice κ η a ↔ rnDerivAux κ (κ + η) a x < 1 := by
+  simp [mutuallySingularSetSlice]
 
 lemma measurableSet_mutuallySingularSet (κ η : kernel α γ) :
     MeasurableSet (mutuallySingularSet κ η) :=
-  measurable_rnDerivAux κ (κ + η) (measurableSet_singleton 1)
+  measurable_rnDerivAux κ (κ + η) measurableSet_Ici
 
 lemma measurableSet_mutuallySingularSetSlice (κ η : kernel α γ) (a : α) :
     MeasurableSet (mutuallySingularSetSlice κ η a) :=
@@ -171,7 +217,7 @@ lemma measure_mutuallySingularSetSlice (κ η : kernel α γ) [IsFiniteKernel κ
     η a (mutuallySingularSetSlice κ η a) = 0 := by
   have h_coe : ∀ b, (Real.toNNReal b : ℝ≥0∞) = ENNReal.ofReal b := fun _ ↦ rfl
   suffices withDensity (κ + η) (fun a x ↦ Real.toNNReal
-      (1 - rnDerivAux κ (κ + η) a x)) a {x | rnDerivAux κ (κ + η) a x = 1} = 0 by
+      (1 - rnDerivAux κ (κ + η) a x)) a {x | 1 ≤ rnDerivAux κ (κ + η) a x} = 0 by
     rwa [withDensity_one_sub_rnDerivAux κ η] at this
   simp_rw [h_coe]
   rw [kernel.withDensity_apply', lintegral_eq_zero_iff, EventuallyEq, ae_restrict_iff]
@@ -210,9 +256,8 @@ lemma rnDeriv_eq_top_iff (κ η : kernel α γ) (a : α) (x : γ) :
     rnDeriv κ η a x = ∞ ↔ (a, x) ∈ mutuallySingularSet κ η := by
   simp only [rnDeriv, ENNReal.div_eq_top, ne_eq, ENNReal.ofReal_eq_zero, not_le,
     tsub_le_iff_right, zero_add, ENNReal.ofReal_ne_top, not_false_eq_true, and_true, or_false,
-    mutuallySingularSet, mem_setOf_eq]
-  exact ⟨fun h ↦ le_antisymm (rnDerivAux_le_one (le_add_of_nonneg_right bot_le)) h.2,
-    fun h ↦ by simp [h]⟩
+    mutuallySingularSet, mem_setOf_eq, and_iff_right_iff_imp]
+  exact fun h ↦ zero_lt_one.trans_le h
 
 lemma rnDeriv_eq_top_iff' (κ η : kernel α γ) (a : α) (x : γ) :
     rnDeriv κ η a x = ∞ ↔ x ∈ mutuallySingularSetSlice κ η a := by
@@ -259,9 +304,12 @@ lemma singularPart_compl_mutuallySingularSetSlice (κ η : kernel α γ) [IsSFin
     mul_inv_cancel, one_mul, tsub_self]
   · rfl
   · rw [ne_eq, sub_eq_zero]
-    exact Ne.symm hx
-  · simp [rnDerivAux_le_one (le_add_of_nonneg_right bot_le)]
-  · simp [lt_of_le_of_ne (rnDerivAux_le_one (le_add_of_nonneg_right bot_le)) hx]
+    rw [not_mem_mutuallySingularSetSlice] at hx
+    exact hx.ne'
+  · rw [not_mem_mutuallySingularSetSlice] at hx
+    simp [hx.le]
+  · simp only [sub_pos]
+    exact not_le.mp hx
 
 lemma singularPart_of_subset_compl_mutuallySingularSetSlice [IsFiniteKernel κ]
     [IsFiniteKernel η] {a : α} {s : Set γ} (hs : s ⊆ (mutuallySingularSetSlice κ η a)ᶜ) :
@@ -272,7 +320,7 @@ lemma singularPart_of_subset_mutuallySingularSetSlice [IsFiniteKernel κ]
     [IsFiniteKernel η] {a : α} {s : Set γ} (hsm : MeasurableSet s)
     (hs : s ⊆ mutuallySingularSetSlice κ η a) :
     singularPart κ η a s = κ a s := by
-  have hs' : ∀ x ∈ s, rnDerivAux κ (κ + η) a x = 1 := fun _ hx ↦ hs hx
+  have hs' : ∀ x ∈ s, 1 ≤ rnDerivAux κ (κ + η) a x := fun _ hx ↦ hs hx
   rw [singularPart, kernel.withDensity_apply']
   swap; · exact measurable_singularPart_fun κ η
   calc
@@ -280,8 +328,11 @@ lemma singularPart_of_subset_mutuallySingularSetSlice [IsFiniteKernel κ]
       ↑(Real.toNNReal (1 - rnDerivAux κ (κ + η) a x)) * rnDeriv κ η a x
       ∂(κ + η) a
     = ∫⁻ _ in s, 1 ∂(κ + η) a := by
-        refine set_lintegral_congr_fun hsm (ae_of_all _ fun x hx ↦ ?_)
-        simp [hs' x hx]
+        refine set_lintegral_congr_fun hsm ?_
+        have h_le : κ ≤ κ + η := le_add_of_nonneg_right bot_le
+        filter_upwards [rnDerivAux_le_one h_le] with x hx hxs
+        have h_eq_one : rnDerivAux κ (κ + η) a x = 1 := le_antisymm hx (hs' x hxs)
+        simp [h_eq_one]
   _ = (κ + η) a s := by simp
   _ = κ a s := by
         suffices η a s = 0 by simp [this]
@@ -318,8 +369,9 @@ lemma withDensity_rnDeriv_of_subset_compl_mutuallySingularSetSlice
   · exact (measurable_const.sub (measurable_rnDerivAux _ _)).real_toNNReal
   · exact measurable_rnDeriv _ _
   simp_rw [rnDeriv]
-  have hs' : ∀ x ∈ s, rnDerivAux κ (κ + η) a x < 1 :=
-    fun x hx ↦ lt_of_le_of_ne (rnDerivAux_le_one (le_add_of_nonneg_right bot_le)) (hs hx)
+  have hs' : ∀ x ∈ s, rnDerivAux κ (κ + η) a x < 1 := by
+    simp_rw [← not_mem_mutuallySingularSetSlice]
+    exact fun x hx hx_mem ↦ hs hx hx_mem
   calc
     ∫⁻ x in s, ↑(Real.toNNReal (1 - rnDerivAux κ (κ + η) a x)) *
       (ENNReal.ofReal (rnDerivAux κ (κ + η) a x) /


### PR DESCRIPTION
Radon-Nikodym derivatives of finite kernels `kernel α γ` are currently defined under the assumption that `γ` is countably generated. We extend the construction to the case that either `α` is countable or `γ` is countably generated.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
