### PR TITLE
[Merged by Bors] - chore: remove simp from Finset.filter_congr_decidable

### DIFF
--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -2617,7 +2617,7 @@ theorem filter_comm (s : Finset α) : (s.filter p).filter q = (s.filter q).filte
   simp_rw [filter_filter, and_comm]
 #align finset.filter_comm Finset.filter_comm
 
--- We can simplify an application of filter where the decidability is inferred in "the wrong way"
+-- We can replace an application of filter where the decidability is inferred in "the wrong way".
 theorem filter_congr_decidable (s : Finset α) (p : α → Prop) (h : DecidablePred p)
     [DecidablePred p] : @filter α p h s = s.filter p := by congr
 #align finset.filter_congr_decidable Finset.filter_congr_decidable

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -2618,7 +2618,6 @@ theorem filter_comm (s : Finset α) : (s.filter p).filter q = (s.filter q).filte
 #align finset.filter_comm Finset.filter_comm
 
 -- We can simplify an application of filter where the decidability is inferred in "the wrong way"
-@[simp]
 theorem filter_congr_decidable (s : Finset α) (p : α → Prop) (h : DecidablePred p)
     [DecidablePred p] : @filter α p h s = s.filter p := by congr
 #align finset.filter_congr_decidable Finset.filter_congr_decidable


### PR DESCRIPTION
* This isn't used by simp in Mathlib
* It's doing something weird, replacing an arbitrary `DecidablePred` by the one found by inference (this might have been relevant before, but isn't now that we reuse more instances via unification).
* The @[simp] had been removed on `bump/v4.8.0`, although I no longer remember why.

Let's just get rid of it.