### PR TITLE
[Merged by Bors] - feat: exclude aesop from nonterminal simp check

### DIFF
--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -219,7 +219,7 @@ def nonterminal_simp_check(lines, path):
             num_spaces = len(line) - len(line.lstrip())
             # Calculate the number of spaces before the first non-space character in the next line
             stripped_next_line = next_line.lstrip()
-            if not (next_line == '\n' or next_line.startswith("#") or stripped_next_line.startswith("--") or "rfl" in next_line):
+            if not (next_line == '\n' or next_line.startswith("#") or stripped_next_line.startswith("--") or "rfl" in next_line or "aesop" in next_line):
                 num_next_spaces = len(next_line) - len(stripped_next_line)
                 # Check if the number of leading spaces is the same
                 if num_spaces == num_next_spaces:


### PR DESCRIPTION
Should make it so that aesop on the next line causes a nonterminal simp not to trigger the linter.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
