### PR TITLE
[Merged by Bors] - feat (SpecificLimits/Basic) : add geometric lemma

### DIFF
--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -371,6 +371,14 @@ theorem ENNReal.tsum_geometric (r : ℝ≥0∞) : ∑' n : ℕ, r ^ n = (1 - r)�
       _ ≤ ∑ i in range n, r ^ i := by gcongr; apply one_le_pow_of_one_le' hr
 #align ennreal.tsum_geometric ENNReal.tsum_geometric
 
+theorem ENNReal.tsum_geometric_add_one (r : ℝ≥0∞) : ∑' n : ℕ, r ^ (n + 1) = r * (1 - r)⁻¹ := by
+  calc ∑' n : ℕ, r ^ (n + 1)
+  _ = ∑' n : ℕ, r * r ^ (n) := by
+        congr with n
+        exact pow_succ' r n
+  _ = r * ∑' n : ℕ, r ^ n := by rw [ENNReal.tsum_mul_left]
+  _ = r * (1 - r)⁻¹ := by rw [ENNReal.tsum_geometric r]
+
 end Geometric
 
 /-!

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -372,12 +372,7 @@ theorem ENNReal.tsum_geometric (r : ℝ≥0∞) : ∑' n : ℕ, r ^ n = (1 - r)�
 #align ennreal.tsum_geometric ENNReal.tsum_geometric
 
 theorem ENNReal.tsum_geometric_add_one (r : ℝ≥0∞) : ∑' n : ℕ, r ^ (n + 1) = r * (1 - r)⁻¹ := by
-  calc ∑' n : ℕ, r ^ (n + 1)
-  _ = ∑' n : ℕ, r * r ^ (n) := by
-        congr with n
-        exact pow_succ' r n
-  _ = r * ∑' n : ℕ, r ^ n := by rw [ENNReal.tsum_mul_left]
-  _ = r * (1 - r)⁻¹ := by rw [ENNReal.tsum_geometric r]
+  simp only [pow_succ', ENNReal.tsum_mul_left, ENNReal.tsum_geometric]
 
 end Geometric
 

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -372,7 +372,7 @@ theorem ENNReal.tsum_geometric (r : ℝ≥0∞) : ∑' n : ℕ, r ^ n = (1 - r)�
 #align ennreal.tsum_geometric ENNReal.tsum_geometric
 
 theorem ENNReal.tsum_geometric_add_one (r : ℝ≥0∞) : ∑' n : ℕ, r ^ (n + 1) = r * (1 - r)⁻¹ := by
-  simp only [pow_succ', ENNReal.tsum_mul_left, ENNReal.tsum_geometric]
+  simp only [_root_.pow_succ', ENNReal.tsum_mul_left, ENNReal.tsum_geometric]
 
 end Geometric
 


### PR DESCRIPTION
Add ENNReal.tsum_geometric_add_one, which is a slightly modified version of ENNReal.tsum_geometric. It is natural to need the former in some cases where we use (n+1) to effectively run through the positive integers rather than natural numbers. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
