### PR TITLE
[Merged by Bors] - chore(Topology/Category): remove `ProfiniteMax` and `CompHausMax`

### DIFF
--- a/Mathlib/Topology/Category/CompHaus/Basic.lean
+++ b/Mathlib/Topology/Category/CompHaus/Basic.lean
@@ -282,8 +282,7 @@ namespace CompHaus
 /-- An explicit limit cone for a functor `F : J ⥤ CompHaus`, defined in terms of
 `TopCat.limitCone`. -/
 def limitCone {J : Type v} [SmallCategory J] (F : J ⥤ CompHaus.{max v u}) : Limits.Cone F :=
-  -- Porting note: Exploit the `TopCatMax` trick.
-  letI FF : J ⥤ TopCatMax.{v,u} := F ⋙ compHausToTop
+  letI FF : J ⥤ TopCat := F ⋙ compHausToTop
   { pt := {
       toTop := (TopCat.limitCone FF).pt
       is_compact := by
@@ -321,7 +320,7 @@ set_option linter.uppercaseLean3 false in
 /-- The limit cone `CompHaus.limitCone F` is indeed a limit cone. -/
 def limitConeIsLimit {J : Type v} [SmallCategory J] (F : J ⥤ CompHaus.{max v u}) :
     Limits.IsLimit.{v} (limitCone.{v,u} F) :=
-  letI FF : J ⥤ TopCatMax.{v,u} := F ⋙ compHausToTop
+  letI FF : J ⥤ TopCat := F ⋙ compHausToTop
   { lift := fun S => (TopCat.limitConeIsLimit FF).lift (compHausToTop.mapCone S)
     fac := fun S => (TopCat.limitConeIsLimit FF).fac (compHausToTop.mapCone S)
     uniq := fun S => (TopCat.limitConeIsLimit FF).uniq (compHausToTop.mapCone S) }
@@ -390,15 +389,3 @@ set_option linter.uppercaseLean3 false in
 #align CompHaus.mono_iff_injective CompHaus.mono_iff_injective
 
 end CompHaus
-
-/--
-Many definitions involving universe inequalities in Mathlib are expressed through use of `max u v`.
-Unfortunately, this leads to unbound universes which cannot be solved for during unification, eg
-`max u v =?= max v ?`.
-The current solution is to wrap `Type max u v` in `TypeMax.{u,v}`
-to expose both universe parameters directly.
-Similarly, for other concrete categories for which we need to refer to the maximum of two universes
-(e.g. any category for which we are constructing limits), we need an analogous abbreviation.
--/
-@[nolint checkUnivs]
-abbrev CompHausMax.{w, w'} := CompHaus.{max w w'}

--- a/Mathlib/Topology/Category/CompHaus/Limits.lean
+++ b/Mathlib/Topology/Category/CompHaus/Limits.lean
@@ -138,7 +138,7 @@ end Pullbacks
 
 section FiniteCoproducts
 
-variable {α : Type w} [Finite α] (X : α → CompHausMax.{u, w})
+variable {α : Type w} [Finite α] (X : α → CompHaus)
 
 /--
 The coproduct of a finite family of objects in `CompHaus`, constructed as the disjoint
@@ -158,7 +158,7 @@ To construct a morphism from the explicit finite coproduct, it suffices to
 specify a morphism from each of its factors.
 This is essentially the universal property of the coproduct.
 -/
-def finiteCoproduct.desc {B : CompHausMax.{u, w}} (e : (a : α) → (X a ⟶ B)) :
+def finiteCoproduct.desc {B : CompHaus} (e : (a : α) → (X a ⟶ B)) :
     finiteCoproduct X ⟶ B where
   toFun := fun ⟨a,x⟩ => e a x
   continuous_toFun := by
@@ -166,10 +166,10 @@ def finiteCoproduct.desc {B : CompHausMax.{u, w}} (e : (a : α) → (X a ⟶ B))
     intro a; exact (e a).continuous
 
 @[reassoc (attr := simp)]
-lemma finiteCoproduct.ι_desc {B : CompHausMax.{u, w}} (e : (a : α) → (X a ⟶ B)) (a : α) :
+lemma finiteCoproduct.ι_desc {B : CompHaus} (e : (a : α) → (X a ⟶ B)) (a : α) :
     finiteCoproduct.ι X a ≫ finiteCoproduct.desc X e = e a := rfl
 
-lemma finiteCoproduct.hom_ext {B : CompHausMax.{u, w}} (f g : finiteCoproduct X ⟶ B)
+lemma finiteCoproduct.hom_ext {B : CompHaus} (f g : finiteCoproduct X ⟶ B)
     (h : ∀ a : α, finiteCoproduct.ι X a ≫ f = finiteCoproduct.ι X a ≫ g) : f = g := by
   ext ⟨a,x⟩
   specialize h a

--- a/Mathlib/Topology/Category/Profinite/Basic.lean
+++ b/Mathlib/Topology/Category/Profinite/Basic.lean
@@ -246,24 +246,11 @@ end DiscreteTopology
 
 end Profinite
 
-/--
-Many definitions involving universe inequalities in Mathlib are expressed through use of `max u v`.
-Unfortunately, this leads to unbound universes which cannot be solved for during unification, eg
-`max u v =?= max v ?`.
-The current solution is to wrap `Type max u v` in `TypeMax.{u,v}`
-to expose both universe parameters directly.
-
-Similarly, for other concrete categories for which we need to refer to the maximum of two universes
-(e.g. any category for which we are constructing limits), we need an analogous abbreviation.
--/
-@[nolint checkUnivs]
-abbrev ProfiniteMax.{w, w'} := Profinite.{max w w'}
-
 namespace Profinite
 
 /-- An explicit limit cone for a functor `F : J ⥤ Profinite`, defined in terms of
 `CompHaus.limitCone`, which is defined in terms of `TopCat.limitCone`. -/
-def limitCone {J : Type v} [SmallCategory J] (F : J ⥤ ProfiniteMax.{v, u}) : Limits.Cone F where
+def limitCone {J : Type v} [SmallCategory J] (F : J ⥤ Profinite.{max u v}) : Limits.Cone F where
   pt :=
     { toCompHaus := (CompHaus.limitCone.{v, u} (F ⋙ profiniteToCompHaus)).pt
       isTotallyDisconnected := by
@@ -279,7 +266,7 @@ def limitCone {J : Type v} [SmallCategory J] (F : J ⥤ ProfiniteMax.{v, u}) : L
 #align Profinite.limit_cone Profinite.limitCone
 
 /-- The limit cone `Profinite.limitCone F` is indeed a limit cone. -/
-def limitConeIsLimit {J : Type v} [SmallCategory J] (F : J ⥤ ProfiniteMax.{v, u}) :
+def limitConeIsLimit {J : Type v} [SmallCategory J] (F : J ⥤ Profinite.{max u v}) :
     Limits.IsLimit (limitCone F) where
   lift S :=
     (CompHaus.limitConeIsLimit.{v, u} (F ⋙ profiniteToCompHaus)).lift

--- a/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
@@ -34,7 +34,7 @@ open CategoryTheory.Limits
 
 universe u v
 
-variable {J : Type v} [SmallCategory J] [IsCofiltered J] {F : J ⥤ ProfiniteMax.{u, v}} (C : Cone F)
+variable {J : Type v} [SmallCategory J] [IsCofiltered J] {F : J ⥤ Profinite.{max u v}} (C : Cone F)
 
 /-- If `X` is a cofiltered limit of profinite sets, then any clopen subset of `X` arises from
 a clopen set in one of the terms in the limit.

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -20,19 +20,6 @@ set_option linter.uppercaseLean3 false
 
 open TopologicalSpace CategoryTheory CategoryTheory.Limits Opposite
 
-/--
-Universe inequalities in Mathlib 3 are expressed through use of `max u v`. Unfortunately,
-this leads to unbound universes which cannot be solved for during unification, eg
-`max u v =?= max v ?`.
-The current solution is to wrap `Type max u v` in `TypeMax.{u,v}`
-to expose both universe parameters directly.
-
-Similarly, for other concrete categories for which we need to refer to the maximum of two universes
-(e.g. any category for which we are constructing limits), we need an analogous abbreviation.
--/
-@[nolint checkUnivs]
-abbrev TopCatMax.{u, v} := TopCat.{max u v}
-
 universe v u w
 
 noncomputable section
@@ -47,7 +34,7 @@ local notation "forget" => forget TopCat
 Generally you should just use `limit.cone F`, unless you need the actual definition
 (which is in terms of `Types.limitCone`).
 -/
-def limitCone (F : J ⥤ TopCatMax.{v, u}) : Cone F where
+def limitCone (F : J ⥤ TopCat.{max v u}) : Cone F where
   pt := TopCat.of { u : ∀ j : J, F.obj j | ∀ {i j : J} (f : i ⟶ j), F.map f (u i) = u j }
   π :=
     { app := fun j =>
@@ -68,7 +55,7 @@ infimum of topologies infimum.
 Generally you should just use `limit.cone F`, unless you need the actual definition
 (which is in terms of `Types.limitCone`).
 -/
-def limitConeInfi (F : J ⥤ TopCatMax.{v, u}) : Cone F where
+def limitConeInfi (F : J ⥤ TopCat.{max v u}) : Cone F where
   pt :=
     ⟨(Types.limitCone.{v,u} (F ⋙ forget)).pt,
       ⨅ j, (F.obj j).str.induced ((Types.limitCone.{v,u} (F ⋙ forget)).π.app j)⟩
@@ -83,7 +70,7 @@ def limitConeInfi (F : J ⥤ TopCatMax.{v, u}) : Cone F where
 Generally you should just use `limit.isLimit F`, unless you need the actual definition
 (which is in terms of `Types.limitConeIsLimit`).
 -/
-def limitConeIsLimit (F : J ⥤ TopCatMax.{v, u}) : IsLimit (limitCone.{v,u} F) where
+def limitConeIsLimit (F : J ⥤ TopCat.{max v u}) : IsLimit (limitCone.{v,u} F) where
   lift S :=
     { toFun := fun x =>
         ⟨fun j => S.π.app _ x, fun f => by
@@ -106,7 +93,7 @@ def limitConeIsLimit (F : J ⥤ TopCatMax.{v, u}) : IsLimit (limitCone.{v,u} F) 
 Generally you should just use `limit.isLimit F`, unless you need the actual definition
 (which is in terms of `Types.limitConeIsLimit`).
 -/
-def limitConeInfiIsLimit (F : J ⥤ TopCatMax.{v, u}) : IsLimit (limitConeInfi.{v,u} F) := by
+def limitConeInfiIsLimit (F : J ⥤ TopCat.{max v u}) : IsLimit (limitConeInfi.{v,u} F) := by
   refine IsLimit.ofFaithful forget (Types.limitConeIsLimit.{v,u} (F ⋙ forget))
     -- Porting note: previously could infer all ?_ except continuity
     (fun s => ⟨fun v => ⟨fun j => (Functor.mapCone forget s).π.app j v, ?_⟩, ?_⟩) fun s => ?_
@@ -123,7 +110,7 @@ def limitConeInfiIsLimit (F : J ⥤ TopCatMax.{v, u}) : IsLimit (limitConeInfi.{
   · rfl
 #align Top.limit_cone_infi_is_limit TopCat.limitConeInfiIsLimit
 
-instance topCat_hasLimitsOfSize : HasLimitsOfSize.{v} TopCatMax.{v, u} where
+instance topCat_hasLimitsOfSize : HasLimitsOfSize.{v} TopCat.{max v u} where
   has_limits_of_shape _ :=
     { has_limit := fun F =>
         HasLimit.mk
@@ -150,7 +137,7 @@ instance forgetPreservesLimits : PreservesLimits forget :=
 Generally you should just use `colimit.cocone F`, unless you need the actual definition
 (which is in terms of `Types.colimitCocone`).
 -/
-def colimitCocone (F : J ⥤ TopCatMax.{v, u}) : Cocone F where
+def colimitCocone (F : J ⥤ TopCat.{max v u}) : Cocone F where
   pt :=
     ⟨(Types.TypeMax.colimitCocone.{v,u} (F ⋙ forget)).pt,
       ⨆ j, (F.obj j).str.coinduced ((Types.TypeMax.colimitCocone (F ⋙ forget)).ι.app j)⟩
@@ -168,7 +155,7 @@ def colimitCocone (F : J ⥤ TopCatMax.{v, u}) : Cocone F where
 Generally you should just use `colimit.isColimit F`, unless you need the actual definition
 (which is in terms of `Types.colimitCoconeIsColimit`).
 -/
-def colimitCoconeIsColimit (F : J ⥤ TopCatMax.{v, u}) : IsColimit (colimitCocone F) := by
+def colimitCoconeIsColimit (F : J ⥤ TopCat.{max v u}) : IsColimit (colimitCocone F) := by
   refine
     IsColimit.ofFaithful forget (Types.TypeMax.colimitCoconeIsColimit.{v, u} _) (fun s =>
     -- Porting note: it appears notation for forget breaks dot notation (also above)
@@ -187,7 +174,7 @@ def colimitCoconeIsColimit (F : J ⥤ TopCatMax.{v, u}) : IsColimit (colimitCoco
   · rfl
 #align Top.colimit_cocone_is_colimit TopCat.colimitCoconeIsColimit
 
-instance topCat_hasColimitsOfSize : HasColimitsOfSize.{v,v} TopCatMax.{v, u} where
+instance topCat_hasColimitsOfSize : HasColimitsOfSize.{v,v} TopCat.{max v u} where
   has_colimits_of_shape _ :=
     { has_colimit := fun F =>
         HasColimit.mk

--- a/Mathlib/Topology/Category/TopCat/Limits/Cofiltered.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Cofiltered.lean
@@ -33,7 +33,7 @@ namespace TopCat
 
 section CofilteredLimit
 
-variable {J : Type v} [SmallCategory J] [IsCofiltered J] (F : J ⥤ TopCatMax.{v, u}) (C : Cone F)
+variable {J : Type v} [SmallCategory J] [IsCofiltered J] (F : J ⥤ TopCat.{max v u}) (C : Cone F)
   (hC : IsLimit C)
 
 /-- Given a *compatible* collection of topological bases for the factors in a cofiltered limit

--- a/Mathlib/Topology/Category/TopCat/Limits/Konig.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Konig.lean
@@ -126,8 +126,8 @@ theorem partialSections.closed [∀ j : J, T2Space (F.obj j)] {G : Finset J}
 
 /-- Cofiltered limits of nonempty compact Hausdorff spaces are nonempty topological spaces.
 -/
--- Porting note: generalized from `TopCat.{u}` to `TopCatMax.{u,v}`
-theorem nonempty_limitCone_of_compact_t2_cofiltered_system (F : J ⥤ TopCatMax.{u,v})
+-- Porting note: generalized from `TopCat.{u}` to `TopCat.{max v u}`
+theorem nonempty_limitCone_of_compact_t2_cofiltered_system (F : J ⥤ TopCat.{max v u})
     [IsCofilteredOrEmpty J]
     [∀ j : J, Nonempty (F.obj j)] [∀ j : J, CompactSpace (F.obj j)] [∀ j : J, T2Space (F.obj j)] :
     Nonempty (TopCat.limitCone F).pt := by

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -33,18 +33,18 @@ namespace TopCat
 variable {J : Type v} [SmallCategory J]
 
 /-- The projection from the product as a bundled continuous map. -/
-abbrev piπ {ι : Type v} (α : ι → TopCatMax.{v, u}) (i : ι) : TopCat.of (∀ i, α i) ⟶ α i :=
+abbrev piπ {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) : TopCat.of (∀ i, α i) ⟶ α i :=
   ⟨fun f => f i, continuous_apply i⟩
 #align Top.pi_π TopCat.piπ
 
 /-- The explicit fan of a family of topological spaces given by the pi type. -/
 @[simps! pt π_app]
-def piFan {ι : Type v} (α : ι → TopCatMax.{v, u}) : Fan α :=
+def piFan {ι : Type v} (α : ι → TopCat.{max v u}) : Fan α :=
   Fan.mk (TopCat.of (∀ i, α i)) (piπ.{v,u} α)
 #align Top.pi_fan TopCat.piFan
 
 /-- The constructed fan is indeed a limit -/
-def piFanIsLimit {ι : Type v} (α : ι → TopCatMax.{v, u}) : IsLimit (piFan α) where
+def piFanIsLimit {ι : Type v} (α : ι → TopCat.{max v u}) : IsLimit (piFan α) where
   lift S :=
     { toFun := fun s i => S.π.app ⟨i⟩ s
       continuous_toFun := continuous_pi (fun i => (S.π.app ⟨i⟩).2) }
@@ -62,25 +62,26 @@ def piFanIsLimit {ι : Type v} (α : ι → TopCatMax.{v, u}) : IsLimit (piFan �
 /-- The product is homeomorphic to the product of the underlying spaces,
 equipped with the product topology.
 -/
-def piIsoPi {ι : Type v} (α : ι → TopCatMax.{v, u}) : ∏ α ≅ TopCat.of (∀ i, α i) :=
+def piIsoPi {ι : Type v} (α : ι → TopCat.{max v u}) : ∏ α ≅ TopCat.of (∀ i, α i) :=
+  have := topCat_hasLimitsOfSize
   (limit.isLimit _).conePointUniqueUpToIso (piFanIsLimit α)
 #align Top.pi_iso_pi TopCat.piIsoPi
 
 @[reassoc (attr := simp)]
-theorem piIsoPi_inv_π {ι : Type v} (α : ι → TopCatMax.{v, u}) (i : ι) :
+theorem piIsoPi_inv_π {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) :
     (piIsoPi α).inv ≫ Pi.π α i = piπ α i := by simp [piIsoPi]
 #align Top.pi_iso_pi_inv_π TopCat.piIsoPi_inv_π
 
 @[simp]
-theorem piIsoPi_inv_π_apply {ι : Type v} (α : ι → TopCatMax.{v, u}) (i : ι) (x : ∀ i, α i) :
+theorem piIsoPi_inv_π_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) (x : ∀ i, α i) :
     (Pi.π α i : _) ((piIsoPi α).inv x) = x i :=
   ConcreteCategory.congr_hom (piIsoPi_inv_π α i) x
 #align Top.pi_iso_pi_inv_π_apply TopCat.piIsoPi_inv_π_apply
 
--- Porting note: needing the type ascription on `∏ α : TopCatMax.{v, u}` is unfortunate.
+-- Porting note: needing the type ascription on `∏ α : TopCat.{max v u}` is unfortunate.
 @[simp]
-theorem piIsoPi_hom_apply {ι : Type v} (α : ι → TopCatMax.{v, u}) (i : ι)
-    (x : (∏ α : TopCatMax.{v, u})) : (piIsoPi α).hom x i = (Pi.π α i : _) x := by
+theorem piIsoPi_hom_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι)
+    (x : (∏ α : TopCat.{max v u})) : (piIsoPi α).hom x i = (Pi.π α i : _) x := by
   have := piIsoPi_inv_π α i
   rw [Iso.inv_comp_eq] at this
   exact ConcreteCategory.congr_hom this x
@@ -88,7 +89,7 @@ theorem piIsoPi_hom_apply {ι : Type v} (α : ι → TopCatMax.{v, u}) (i : ι)
 
 -- Porting note: Lean doesn't automatically reduce TopCat.of X|>.α to X now
 /-- The inclusion to the coproduct as a bundled continuous map. -/
-abbrev sigmaι {ι : Type v} (α : ι → TopCatMax.{v,u}) (i : ι) : α i ⟶ TopCat.of (Σi, α i) := by
+abbrev sigmaι {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) : α i ⟶ TopCat.of (Σi, α i) := by
   refine ContinuousMap.mk ?_ ?_
   · dsimp
     apply Sigma.mk i
@@ -97,12 +98,12 @@ abbrev sigmaι {ι : Type v} (α : ι → TopCatMax.{v,u}) (i : ι) : α i ⟶ T
 
 /-- The explicit cofan of a family of topological spaces given by the sigma type. -/
 @[simps! pt ι_app]
-def sigmaCofan {ι : Type v} (α : ι → TopCatMax.{v, u}) : Cofan α :=
+def sigmaCofan {ι : Type v} (α : ι → TopCat.{max v u}) : Cofan α :=
   Cofan.mk (TopCat.of (Σi, α i)) (sigmaι α)
 #align Top.sigma_cofan TopCat.sigmaCofan
 
 /-- The constructed cofan is indeed a colimit -/
-def sigmaCofanIsColimit {ι : Type v} (β : ι → TopCatMax.{v, u}) : IsColimit (sigmaCofan β) where
+def sigmaCofanIsColimit {ι : Type v} (β : ι → TopCat.{max v u}) : IsColimit (sigmaCofan β) where
   desc S :=
     { toFun := fun (s : of (Σ i, β i)) => S.ι.app ⟨s.1⟩ s.2
       continuous_toFun := continuous_sigma fun i => (S.ι.app ⟨i⟩).continuous_toFun }
@@ -118,30 +119,31 @@ def sigmaCofanIsColimit {ι : Type v} (β : ι → TopCatMax.{v, u}) : IsColimit
 
 /-- The coproduct is homeomorphic to the disjoint union of the topological spaces.
 -/
-def sigmaIsoSigma {ι : Type v} (α : ι → TopCatMax.{v, u}) : ∐ α ≅ TopCat.of (Σi, α i) :=
+def sigmaIsoSigma {ι : Type v} (α : ι → TopCat.{max v u}) : ∐ α ≅ TopCat.of (Σi, α i) :=
+  have := topCat_hasColimitsOfSize
   (colimit.isColimit _).coconePointUniqueUpToIso (sigmaCofanIsColimit α)
 #align Top.sigma_iso_sigma TopCat.sigmaIsoSigma
 
 @[reassoc (attr := simp)]
-theorem sigmaIsoSigma_hom_ι {ι : Type v} (α : ι → TopCatMax.{v, u}) (i : ι) :
+theorem sigmaIsoSigma_hom_ι {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) :
     Sigma.ι α i ≫ (sigmaIsoSigma α).hom = sigmaι α i := by simp [sigmaIsoSigma]
 #align Top.sigma_iso_sigma_hom_ι TopCat.sigmaIsoSigma_hom_ι
 
 @[simp]
-theorem sigmaIsoSigma_hom_ι_apply {ι : Type v} (α : ι → TopCatMax.{v, u}) (i : ι) (x : α i) :
+theorem sigmaIsoSigma_hom_ι_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) (x : α i) :
     (sigmaIsoSigma α).hom ((Sigma.ι α i : _) x) = Sigma.mk i x :=
   ConcreteCategory.congr_hom (sigmaIsoSigma_hom_ι α i) x
 #align Top.sigma_iso_sigma_hom_ι_apply TopCat.sigmaIsoSigma_hom_ι_apply
 
 @[simp]
-theorem sigmaIsoSigma_inv_apply {ι : Type v} (α : ι → TopCatMax.{v, u}) (i : ι) (x : α i) :
+theorem sigmaIsoSigma_inv_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) (x : α i) :
     (sigmaIsoSigma α).inv ⟨i, x⟩ = (Sigma.ι α i : _) x := by
   rw [← sigmaIsoSigma_hom_ι_apply, ← comp_app, ← comp_app, Iso.hom_inv_id,
     Category.comp_id]
 #align Top.sigma_iso_sigma_inv_apply TopCat.sigmaIsoSigma_inv_apply
 
 -- Porting note: cannot use .topologicalSpace in place .str
-theorem induced_of_isLimit {F : J ⥤ TopCatMax.{v, u}} (C : Cone F) (hC : IsLimit C) :
+theorem induced_of_isLimit {F : J ⥤ TopCat.{max v u}} (C : Cone F) (hC : IsLimit C) :
     C.pt.str = ⨅ j, (F.obj j).str.induced (C.π.app j) := by
   let homeo := homeoOfIso (hC.conePointUniqueUpToIso (limitConeInfiIsLimit F))
   refine' homeo.inducing.induced.trans _
@@ -150,7 +152,7 @@ theorem induced_of_isLimit {F : J ⥤ TopCatMax.{v, u}} (C : Cone F) (hC : IsLim
   rfl
 #align Top.induced_of_is_limit TopCat.induced_of_isLimit
 
-theorem limit_topology (F : J ⥤ TopCatMax.{v, u}) :
+theorem limit_topology (F : J ⥤ TopCat.{max v u}) :
     (limit F).str = ⨅ j, (F.obj j).str.induced (limit.π F j) :=
   induced_of_isLimit _ (limit.isLimit F)
 #align Top.limit_topology TopCat.limit_topology

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -63,8 +63,8 @@ def piFanIsLimit {ι : Type v} (α : ι → TopCat.{max v u}) : IsLimit (piFan �
 equipped with the product topology.
 -/
 def piIsoPi {ι : Type v} (α : ι → TopCat.{max v u}) : ∏ α ≅ TopCat.of (∀ i, α i) :=
-  have := topCat_hasLimitsOfSize -- This wasn't necessary when we had `TopCatMax` 
-  (limit.isLimit _).conePointUniqueUpToIso (piFanIsLimit α)
+  (limit.isLimit _).conePointUniqueUpToIso (piFanIsLimit.{v, u} α)
+  -- Specifying the universes in `piFanIsLimit` wasn't necessary when we had `TopCatMax` 
 #align Top.pi_iso_pi TopCat.piIsoPi
 
 @[reassoc (attr := simp)]
@@ -120,8 +120,8 @@ def sigmaCofanIsColimit {ι : Type v} (β : ι → TopCat.{max v u}) : IsColimit
 /-- The coproduct is homeomorphic to the disjoint union of the topological spaces.
 -/
 def sigmaIsoSigma {ι : Type v} (α : ι → TopCat.{max v u}) : ∐ α ≅ TopCat.of (Σi, α i) :=
-  have := topCat_hasColimitsOfSize -- This wasn't necessary when we used `TopCatMax`
-  (colimit.isColimit _).coconePointUniqueUpToIso (sigmaCofanIsColimit α)
+  (colimit.isColimit _).coconePointUniqueUpToIso (sigmaCofanIsColimit.{v, u} α)
+  -- Specifying the universes in `sigmaCofanIsColimit` wasn't necessary when we had `TopCatMax` 
 #align Top.sigma_iso_sigma TopCat.sigmaIsoSigma
 
 @[reassoc (attr := simp)]

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -63,7 +63,7 @@ def piFanIsLimit {ι : Type v} (α : ι → TopCat.{max v u}) : IsLimit (piFan �
 equipped with the product topology.
 -/
 def piIsoPi {ι : Type v} (α : ι → TopCat.{max v u}) : ∏ α ≅ TopCat.of (∀ i, α i) :=
-  have := topCat_hasLimitsOfSize
+  have := topCat_hasLimitsOfSize -- This wasn't necessary when we had `TopCatMax` 
   (limit.isLimit _).conePointUniqueUpToIso (piFanIsLimit α)
 #align Top.pi_iso_pi TopCat.piIsoPi
 
@@ -120,7 +120,7 @@ def sigmaCofanIsColimit {ι : Type v} (β : ι → TopCat.{max v u}) : IsColimit
 /-- The coproduct is homeomorphic to the disjoint union of the topological spaces.
 -/
 def sigmaIsoSigma {ι : Type v} (α : ι → TopCat.{max v u}) : ∐ α ≅ TopCat.of (Σi, α i) :=
-  have := topCat_hasColimitsOfSize
+  have := topCat_hasColimitsOfSize -- This wasn't necessary when we used `TopCatMax`
   (colimit.isColimit _).coconePointUniqueUpToIso (sigmaCofanIsColimit α)
 #align Top.sigma_iso_sigma TopCat.sigmaIsoSigma
 

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -424,7 +424,7 @@ theorem pullback_fst_image_snd_preimage (f : X ⟶ Z) (g : Y ⟶ Z) (U : Set Y) 
 end Pullback
 
 --TODO: Add analogous constructions for `pushout`.
-theorem coinduced_of_isColimit {F : J ⥤ TopCatMax.{v, u}} (c : Cocone F) (hc : IsColimit c) :
+theorem coinduced_of_isColimit {F : J ⥤ TopCat.{max v u}} (c : Cocone F) (hc : IsColimit c) :
     c.pt.str = ⨆ j, (F.obj j).str.coinduced (c.ι.app j) := by
   let homeo := homeoOfIso (hc.coconePointUniqueUpToIso (colimitCoconeIsColimit F))
   ext
@@ -432,12 +432,12 @@ theorem coinduced_of_isColimit {F : J ⥤ TopCatMax.{v, u}} (c : Cocone F) (hc :
   exact isOpen_iSup_iff
 #align Top.coinduced_of_is_colimit TopCat.coinduced_of_isColimit
 
-theorem colimit_topology (F : J ⥤ TopCatMax.{v, u}) :
+theorem colimit_topology (F : J ⥤ TopCat.{max v u}) :
     (colimit F).str = ⨆ j, (F.obj j).str.coinduced (colimit.ι F j) :=
   coinduced_of_isColimit _ (colimit.isColimit F)
 #align Top.colimit_topology TopCat.colimit_topology
 
-theorem colimit_isOpen_iff (F : J ⥤ TopCatMax.{v, u}) (U : Set ((colimit F : _) : Type max v u)) :
+theorem colimit_isOpen_iff (F : J ⥤ TopCat.{max v u}) (U : Set ((colimit F : _) : Type max v u)) :
     IsOpen U ↔ ∀ j, IsOpen (colimit.ι F j ⁻¹' U) := by
   dsimp [topologicalSpace_coe]
   conv_lhs => rw [colimit_topology F]


### PR DESCRIPTION
They are no longer necessary after [#3981](https://github.com/leanprover/lean4/pull/3981)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
