### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/InfiniteSum/Order): Add tprod_subtype_le

### DIFF
--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -83,7 +83,7 @@ theorem tprod_le_tprod_of_inj {g : κ → α} (e : ι → κ) (he : Injective e)
 
 @[to_additive]
 lemma tprod_subtype_le {κ γ : Type*} [OrderedCommGroup γ] [UniformSpace γ] [UniformGroup γ]
-    [OrderClosedTopology γ ] [ CompleteSpace γ] (f : κ → γ) (β : Set κ) (h : ∀ a : κ, 1 ≤ f a)
+    [OrderClosedTopology γ] [ CompleteSpace γ] (f : κ → γ) (β : Set κ) (h : ∀ a : κ, 1 ≤ f a)
     (hf : Multipliable f) : (∏' (b : β), f b) ≤ (∏' (a : κ), f a) := by
   apply tprod_le_tprod_of_inj _ (Subtype.coe_injective) (by simp only [Subtype.range_coe_subtype,
     Set.setOf_mem_eq, h, implies_true]) (by simp only [le_refl,

--- a/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Order.lean
@@ -82,6 +82,15 @@ theorem tprod_le_tprod_of_inj {g : κ → α} (e : ι → κ) (he : Injective e)
 #align tsum_le_tsum_of_inj tsum_le_tsum_of_inj
 
 @[to_additive]
+lemma tprod_subtype_le {κ γ : Type*} [OrderedCommGroup γ] [UniformSpace γ] [UniformGroup γ]
+    [OrderClosedTopology γ ] [ CompleteSpace γ] (f : κ → γ) (β : Set κ) (h : ∀ a : κ, 1 ≤ f a)
+    (hf : Multipliable f) : (∏' (b : β), f b) ≤ (∏' (a : κ), f a) := by
+  apply tprod_le_tprod_of_inj _ (Subtype.coe_injective) (by simp only [Subtype.range_coe_subtype,
+    Set.setOf_mem_eq, h, implies_true]) (by simp only [le_refl,
+    Subtype.forall, implies_true]) (by apply hf.subtype)
+  apply hf
+
+@[to_additive]
 theorem prod_le_hasProd (s : Finset ι) (hs : ∀ i, i ∉ s → 1 ≤ f i) (hf : HasProd f a) :
     ∏ i in s, f i ≤ a :=
   ge_of_tendsto hf (eventually_atTop.2


### PR DESCRIPTION
We add a lemma that says the tprod/tsum over a subtype is less than the full sum. Needed for #12456 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
