### PR TITLE
[Merged by Bors] - docs(RingTheory/Flat/Basic): remove completed TODO

### DIFF
--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -50,6 +50,7 @@ the ring can be lifted to the universe of the module. It is unclear if this lemm
 when the module lives in a lower universe.
 
 ## TODO
+
 * Generalize flatness to noncommutative rings.
 
 -/

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -50,11 +50,6 @@ the ring can be lifted to the universe of the module. It is unclear if this lemm
 when the module lives in a lower universe.
 
 ## TODO
-
-* Show that flatness is stable under base change (aka extension of scalars)
-  Using the `IsBaseChange` predicate should allow us to treat both
-  `A[X]` and `A ⊗ R[X]` as the base change of `R[X]` to `A`.
-  (Similar examples exist with `Fin n → R`, `R × R`, `ℤ[i] ⊗ ℝ`, etc...)
 * Generalize flatness to noncommutative rings.
 
 -/


### PR DESCRIPTION
The stability of flatness under base change is in mathlib (in RingTheory/Flat/Stability). So, we remove the part of the docs that says that it isn't.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
