### PR TITLE
[Merged by Bors] - Add constantCoeff_smul to RingTheory.PowerSeries.Basic

### DIFF
--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -355,6 +355,11 @@ theorem coeff_smul {S : Type*} [Semiring S] [Module R S] (n : ℕ) (φ : PowerSe
   rfl
 #align power_series.coeff_smul PowerSeries.coeff_smul
 
+@[simp]
+theorem constantCoeff_smul {S : Type*} [Semiring S] [Module R S] (φ : PowerSeries S) (a : R) :
+    (constantCoeff S) (a • φ) = a • (constantCoeff S) φ :=
+  rfl
+
 theorem smul_eq_C_mul (f : R⟦X⟧) (a : R) : a • f = C R a * f := by
   ext
   simp

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -357,7 +357,7 @@ theorem coeff_smul {S : Type*} [Semiring S] [Module R S] (n : ℕ) (φ : PowerSe
 
 @[simp]
 theorem constantCoeff_smul {S : Type*} [Semiring S] [Module R S] (φ : PowerSeries S) (a : R) :
-    (constantCoeff S) (a • φ) = a • (constantCoeff S) φ :=
+    constantCoeff S (a • φ) = a • constantCoeff S φ :=
   rfl
 
 theorem smul_eq_C_mul (f : R⟦X⟧) (a : R) : a • f = C R a * f := by


### PR DESCRIPTION
```
example : (constantCoeff ℝ) ((2:ℝ)•X) = 0 := by simp
```
simp doesn't solve the above because there is no lemma constantCoeff_smul tagged simp. This PR adds it to RingTheory.PowerSeries.Basic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
