### PR TITLE
[Merged by Bors] - chore: remove two `by exact` leftover from porting

### DIFF
--- a/Mathlib/CategoryTheory/SingleObj.lean
+++ b/Mathlib/CategoryTheory/SingleObj.lean
@@ -241,12 +241,10 @@ namespace Units
 
 variable (M : Type u) [Monoid M]
 
--- Porting note: it was necessary to add `by exact` in this definition, presumably
--- so that Lean4 is not confused by the fact that `M` has two opposite multiplications
 /-- The units in a monoid are (multiplicatively) equivalent to
 the automorphisms of `star` when we think of the monoid as a single-object category. -/
 def toAut : Mˣ ≃* Aut (SingleObj.star M) :=
-  MulEquiv.trans (Units.mapEquiv (by exact SingleObj.toEnd M))
+  MulEquiv.trans (Units.mapEquiv (SingleObj.toEnd M))
     (Aut.unitsEndEquivAut (SingleObj.star M))
 set_option linter.uppercaseLean3 false in
 #align units.to_Aut Units.toAut

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -889,10 +889,9 @@ theorem isCoprime_biInf {J : ι → Ideal R} {s : Finset ι}
 def radical (I : Ideal R) : Ideal R where
   carrier := { r | ∃ n : ℕ, r ^ n ∈ I }
   zero_mem' := ⟨1, (pow_one (0 : R)).symm ▸ I.zero_mem⟩
-  add_mem' := fun {x y} ⟨m, hxmi⟩ ⟨n, hyni⟩ =>
+  add_mem' := fun {_ _} ⟨m, hxmi⟩ ⟨n, hyni⟩ =>
     ⟨m + n - 1, add_pow_add_pred_mem_of_pow_mem I hxmi hyni⟩
--- Porting note: Below gives weird errors without `by exact`
-  smul_mem' {r s} := by exact fun ⟨n, h⟩ ↦ ⟨n, (mul_pow r s n).symm ▸ I.mul_mem_left (r ^ n) h⟩
+  smul_mem' {r s} := fun ⟨n, h⟩ ↦ ⟨n, (mul_pow r s n).symm ▸ I.mul_mem_left (r ^ n) h⟩
 #align ideal.radical Ideal.radical
 
 theorem mem_radical_iff {r : R} : r ∈ I.radical ↔ ∃ n : ℕ, r ^ n ∈ I := Iff.rfl


### PR DESCRIPTION
drive-by: two unused variables


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
