### PR TITLE
[Merged by Bors] - refactor: nicer well-founded function definitions

### DIFF
--- a/Mathlib/Data/Int/GCD.lean
+++ b/Mathlib/Data/Int/GCD.lean
@@ -39,17 +39,11 @@ namespace Nat
 def xgcdAux : ℕ → ℤ → ℤ → ℕ → ℤ → ℤ → ℕ × ℤ × ℤ
   | 0, _, _, r', s', t' => (r', s', t')
   | succ k, s, t, r', s', t' =>
-    have : r' % succ k < succ k := mod_lt _ <| (succ_pos _).gt
     let q := r' / succ k
     xgcdAux (r' % succ k) (s' - q * s) (t' - q * t) (succ k) s t
+termination_by k => k
+decreasing_by exact mod_lt _ <| (succ_pos _).gt
 #align nat.xgcd_aux Nat.xgcdAux
-
--- Porting note: these are not in mathlib3; these equation lemmas are to fix
--- complaints by the Lean 4 `unusedHavesSuffices` linter obtained when `simp [xgcdAux]` is used.
-theorem xgcdAux_zero {s t : ℤ} {r' : ℕ} {s' t' : ℤ} : xgcdAux 0 s t r' s' t' = (r', s', t') := rfl
-
-theorem xgcdAux_succ {k : ℕ} {s t : ℤ} {r' : ℕ} {s' t' : ℤ} : xgcdAux (succ k) s t r' s' t' =
-    xgcdAux (r' % succ k) (s' - (r' / succ k) * s) (t' - (r' / succ k) * t) (succ k) s t := rfl
 
 @[simp]
 theorem xgcd_zero_left {s t r' s' t'} : xgcdAux 0 s t r' s' t' = (r', s', t') := by simp [xgcdAux]
@@ -58,7 +52,7 @@ theorem xgcd_zero_left {s t r' s' t'} : xgcdAux 0 s t r' s' t' = (r', s', t') :=
 theorem xgcdAux_rec {r s t r' s' t'} (h : 0 < r) :
     xgcdAux r s t r' s' t' = xgcdAux (r' % r) (s' - r' / r * s) (t' - r' / r * t) r s t := by
   obtain ⟨r, rfl⟩ := Nat.exists_eq_succ_of_ne_zero h.ne'
-  rfl
+  simp [xgcdAux]
 #align nat.xgcd_aux_rec Nat.xgcdAux_rec
 
 /-- Use the extended GCD algorithm to generate the `a` and `b` values
@@ -93,20 +87,16 @@ theorem gcdB_zero_left {s : ℕ} : gcdB 0 s = 1 := by
 theorem gcdA_zero_right {s : ℕ} (h : s ≠ 0) : gcdA s 0 = 1 := by
   unfold gcdA xgcd
   obtain ⟨s, rfl⟩ := Nat.exists_eq_succ_of_ne_zero h
-  -- Porting note (https://github.com/leanprover/lean4/issues/2330):
-  -- `simp [xgcdAux_succ]` crashes Lean here
-  rw [xgcdAux_succ]
-  rfl
+  rw [xgcdAux]
+  simp
 #align nat.gcd_a_zero_right Nat.gcdA_zero_right
 
 @[simp]
 theorem gcdB_zero_right {s : ℕ} (h : s ≠ 0) : gcdB s 0 = 0 := by
   unfold gcdB xgcd
   obtain ⟨s, rfl⟩ := Nat.exists_eq_succ_of_ne_zero h
-  -- Porting note (https://github.com/leanprover/lean4/issues/2330):
-  -- `simp [xgcdAux_succ]` crashes Lean here
-  rw [xgcdAux_succ]
-  rfl
+  rw [xgcdAux]
+  simp
 #align nat.gcd_b_zero_right Nat.gcdB_zero_right
 
 @[simp]

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -920,18 +920,19 @@ def reverseRecOn {motive : List α → Sort*} (l : List α) (nil : motive [])
   | [] => cast (congr_arg motive <| by simpa using congr(reverse $h.symm)) <|
       nil
   | head :: tail =>
-    have : tail.length < l.length := by
-      rw [← length_reverse l, h, length_cons]
-      simp [Nat.lt_succ]
     cast (congr_arg motive <| by simpa using congr(reverse $h.symm)) <|
       append_singleton _ head <| reverseRecOn (reverse tail) nil append_singleton
 termination_by l.length
+decreasing_by
+  simp_wf
+  rw [← length_reverse l, h, length_cons]
+  simp [Nat.lt_succ]
 #align list.reverse_rec_on List.reverseRecOn
 
 @[simp]
 theorem reverseRecOn_nil {motive : List α → Sort*} (nil : motive [])
     (append_singleton : ∀ (l : List α) (a : α), motive l → motive (l ++ [a])) :
-    reverseRecOn [] nil append_singleton = nil := rfl
+    reverseRecOn [] nil append_singleton = nil := reverseRecOn.eq_1 ..
 
 -- `unusedHavesSuffices` is getting confused by the unfolding of `reverseRecOn`
 @[simp, nolint unusedHavesSuffices]
@@ -977,15 +978,15 @@ termination_by l => l.length
 theorem bidirectionalRec_nil {motive : List α → Sort*}
     (nil : motive []) (singleton : ∀ a : α, motive [a])
     (cons_append : ∀ (a : α) (l : List α) (b : α), motive l → motive (a :: (l ++ [b]))) :
-    bidirectionalRec nil singleton cons_append [] = nil :=
-  rfl
+    bidirectionalRec nil singleton cons_append [] = nil := bidirectionalRec.eq_1 ..
+
 
 @[simp]
 theorem bidirectionalRec_singleton {motive : List α → Sort*}
     (nil : motive []) (singleton : ∀ a : α, motive [a])
     (cons_append : ∀ (a : α) (l : List α) (b : α), motive l → motive (a :: (l ++ [b]))) (a : α):
     bidirectionalRec nil singleton cons_append [a] = singleton a :=
-  rfl
+  by simp [bidirectionalRec]
 
 @[simp]
 theorem bidirectionalRec_cons_append {motive : List α → Sort*}

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -978,7 +978,8 @@ termination_by l => l.length
 theorem bidirectionalRec_nil {motive : List α → Sort*}
     (nil : motive []) (singleton : ∀ a : α, motive [a])
     (cons_append : ∀ (a : α) (l : List α) (b : α), motive l → motive (a :: (l ++ [b]))) :
-    bidirectionalRec nil singleton cons_append [] = nil := bidirectionalRec.eq_1 ..
+    bidirectionalRec nil singleton cons_append [] = nil := by
+  unfold bidirectionalRec; rfl
 
 
 @[simp]

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -932,7 +932,7 @@ decreasing_by
 @[simp]
 theorem reverseRecOn_nil {motive : List α → Sort*} (nil : motive [])
     (append_singleton : ∀ (l : List α) (a : α), motive l → motive (l ++ [a])) :
-    reverseRecOn [] nil append_singleton = nil := reverseRecOn.eq_1 ..
+    reverseRecOn [] nil append_singleton = nil := by unfold reverseRecOn; rfl
 
 -- `unusedHavesSuffices` is getting confused by the unfolding of `reverseRecOn`
 @[simp, nolint unusedHavesSuffices]

--- a/Mathlib/Data/Nat/MaxPowDiv.lean
+++ b/Mathlib/Data/Nat/MaxPowDiv.lean
@@ -30,11 +30,12 @@ Tail recursive function which returns the largest `k : ℕ` such that `p ^ k ∣
 def maxPowDiv (p n : ℕ) : ℕ :=
   go 0 p n
 where go (k p n : ℕ) : ℕ :=
-  if h : 1 < p ∧ 0 < n ∧ n % p = 0 then
-    have : n / p < n := by apply Nat.div_lt_self <;> aesop
+  if 1 < p ∧ 0 < n ∧ n % p = 0 then
     go (k+1) p (n / p)
   else
     k
+  termination_by n
+  decreasing_by apply Nat.div_lt_self <;> tauto
 
 attribute [inherit_doc maxPowDiv] maxPowDiv.go
 
@@ -42,38 +43,33 @@ end Nat
 
 namespace Nat.maxPowDiv
 
-theorem go_eq {k p n : ℕ} :
-    go k p n = if 1 < p ∧ 0 < n ∧ n % p = 0 then go (k+1) p (n / p) else k := by
-  dsimp [go, go._unary]
-  rw [WellFounded.fix_eq]
-  simp
-
 theorem go_succ {k p n : ℕ} : go (k+1) p n = go k p n + 1 := by
-  rw [go_eq]
-  conv_rhs => rw [go_eq]
-  by_cases h : (1 < p ∧ 0 < n ∧ n % p = 0); swap
-  · simp only [if_neg h]
-  · have : n / p < n := by apply Nat.div_lt_self <;> aesop
+  induction k, p, n using go.induct
+  case case1 h ih =>
+    unfold go
     simp only [if_pos h]
-    apply go_succ
+    exact ih
+  case case2 h =>
+    unfold go
+    simp only [if_neg h]
 
 @[simp]
 theorem zero_base {n : ℕ} : maxPowDiv 0 n = 0 := by
   dsimp [maxPowDiv]
-  rw [maxPowDiv.go_eq]
+  rw [maxPowDiv.go]
   simp
 
 @[simp]
 theorem zero {p : ℕ} : maxPowDiv p 0 = 0 := by
   dsimp [maxPowDiv]
-  rw [maxPowDiv.go_eq]
+  rw [maxPowDiv.go]
   simp
 
 theorem base_mul_eq_succ {p n : ℕ} (hp : 1 < p) (hn : 0 < n) :
     p.maxPowDiv (p*n) = p.maxPowDiv n + 1 := by
   have : 0 < p := lt_trans (b := 1) (by simp) hp
   dsimp [maxPowDiv]
-  rw [maxPowDiv.go_eq, if_pos, mul_div_right _ this]
+  rw [maxPowDiv.go, if_pos, mul_div_right _ this]
   · apply go_succ
   · refine ⟨hp, ?_, by simp⟩
     apply Nat.mul_pos this hn
@@ -90,7 +86,7 @@ theorem base_pow_mul {p n exp : ℕ} (hp : 1 < p) (hn : 0 < n) :
 
 theorem pow_dvd (p n : ℕ) : p ^ (p.maxPowDiv n) ∣ n := by
   dsimp [maxPowDiv]
-  rw [go_eq]
+  rw [go]
   by_cases h : (1 < p ∧ 0 < n ∧ n % p = 0)
   · have : n / p < n := by apply Nat.div_lt_self <;> aesop
     rw [if_pos h]

--- a/Mathlib/NumberTheory/Padics/PadicVal.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal.lean
@@ -141,7 +141,7 @@ theorem padicValNat_eq_maxPowDiv : @padicValNat = @maxPowDiv := by
       interval_cases p
       · simp [Classical.em]
       · dsimp [padicValNat, maxPowDiv]
-        rw [go_eq, if_neg, dif_neg] <;> simp
+        rw [go, if_neg, dif_neg] <;> simp
     · intro h
       simp [h]
 


### PR DESCRIPTION
by preferring `decreasing_by` over inline proofs, the resulting
equational theorems are nicer.

Also we can use functional induction in one case rather nicely.