### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Localization): left resolutions for localizer morphisms

### DIFF
--- a/Mathlib/CategoryTheory/Localization/LocalizerMorphism.lean
+++ b/Mathlib/CategoryTheory/Localization/LocalizerMorphism.lean
@@ -63,6 +63,8 @@ def comp (Φ : LocalizerMorphism W₁ W₂) (Ψ : LocalizerMorphism W₂ W₃) :
 
 variable (Φ : LocalizerMorphism W₁ W₂)
 
+/-- The opposite localizer morphism `LocalizerMorphism W₁.op W₂.op` deduced
+from `Φ : LocalizerMorphism W₁ W₂`. -/
 @[simps]
 def op : LocalizerMorphism W₁.op W₂.op where
   functor := Φ.functor.op

--- a/Mathlib/CategoryTheory/Localization/LocalizerMorphism.lean
+++ b/Mathlib/CategoryTheory/Localization/LocalizerMorphism.lean
@@ -61,8 +61,14 @@ def comp (Φ : LocalizerMorphism W₁ W₂) (Ψ : LocalizerMorphism W₂ W₃) :
   functor := Φ.functor ⋙ Ψ.functor
   map _ _ _ hf := Ψ.map _ (Φ.map _ hf)
 
-variable (Φ : LocalizerMorphism W₁ W₂) (L₁ : C₁ ⥤ D₁) [L₁.IsLocalization W₁]
-  (L₂ : C₂ ⥤ D₂) [L₂.IsLocalization W₂]
+variable (Φ : LocalizerMorphism W₁ W₂)
+
+@[simps]
+def op : LocalizerMorphism W₁.op W₂.op where
+  functor := Φ.functor.op
+  map _ _ _ hf := Φ.map _ hf
+
+variable (L₁ : C₁ ⥤ D₁) [L₁.IsLocalization W₁] (L₂ : C₂ ⥤ D₂) [L₂.IsLocalization W₂]
 
 lemma inverts : W₁.IsInvertedBy (Φ.functor ⋙ L₂) :=
   fun _ _ _ hf => Localization.inverts L₂ W₂ _ (Φ.map _ hf)

--- a/Mathlib/CategoryTheory/Localization/Resolution.lean
+++ b/Mathlib/CategoryTheory/Localization/Resolution.lean
@@ -19,6 +19,8 @@ A right resolution consists of an object `X₁ : C₁` and a morphism
 The type of right resolutions `Φ.RightResolution X₂` is endowed with a category
 structure when the morphism property `W₁` is multiplicative.
 
+Similiar definitions are done from left resolutions.
+
 ## Future works
 
 * formalize right derivability structures as localizer morphisms admitting right resolutions
@@ -47,7 +49,8 @@ namespace LocalizerMorphism
 
 variable (Φ : LocalizerMorphism W₁ W₂)
 
-/-- The category of resolutions of an object in the target category of a localizer morphism. -/
+/-- The category of right resolutions of an object in the target category
+of a localizer morphism. -/
 structure RightResolution (X₂ : C₂) where
   /-- an object in the source category -/
   {X₁ : C₁}
@@ -55,13 +58,30 @@ structure RightResolution (X₂ : C₂) where
   w : X₂ ⟶ Φ.functor.obj X₁
   hw : W₂ w
 
+/-- The category of left resolutions of an object in the target category
+of a localizer morphism. -/
+structure LeftResolution (X₂ : C₂) where
+  /-- an object in the source category -/
+  {X₁ : C₁}
+  /-- a morphism from an object of the form `Φ.functor.obj X₁` -/
+  w : Φ.functor.obj X₁ ⟶ X₂
+  hw : W₂ w
+
 variable {Φ X₂} in
 lemma RightResolution.mk_surjective (R : Φ.RightResolution X₂) :
     ∃ (X₁ : C₁) (w : X₂ ⟶ Φ.functor.obj X₁) (hw : W₂ w), R = RightResolution.mk w hw :=
   ⟨_, R.w, R.hw, rfl⟩
 
+variable {Φ X₂} in
+lemma LeftResolution.mk_surjective (L : Φ.LeftResolution X₂) :
+    ∃ (X₁ : C₁) (w : Φ.functor.obj X₁ ⟶ X₂) (hw : W₂ w), L = LeftResolution.mk w hw :=
+  ⟨_, L.w, L.hw, rfl⟩
+
 /-- A localizer morphism has right resolutions when any object has a right resolution. -/
 abbrev HasRightResolutions := ∀ (X₂ : C₂), Nonempty (Φ.RightResolution X₂)
+
+/-- A localizer morphism has right resolutions when any object has a right resolution. -/
+abbrev HasLeftResolutions := ∀ (X₂ : C₂), Nonempty (Φ.LeftResolution X₂)
 
 namespace RightResolution
 
@@ -112,17 +132,156 @@ lemma hom_ext {R R' : Φ.RightResolution X₂} {φ₁ φ₂ : R ⟶ R'} (h : φ�
 
 end RightResolution
 
+namespace LeftResolution
+
+variable {Φ} {X₂ : C₂}
+
+/-- The type of morphisms in the category `Φ.LeftResolution X₂` (when `W₁` is multiplicative). -/
+@[ext]
+structure Hom (L L' : Φ.LeftResolution X₂) where
+  /-- a morphism in the source category -/
+  f : L.X₁ ⟶ L'.X₁
+  hf : W₁ f
+  comm : Φ.functor.map f ≫ L'.w = L.w := by aesop_cat
+
+attribute [reassoc (attr := simp)] Hom.comm
+
+/-- The identity of a object in `Φ.LeftResolution X₂`. -/
+@[simps]
+def Hom.id [W₁.ContainsIdentities] (L : Φ.LeftResolution X₂) : Hom L L where
+  f := 𝟙 _
+  hf := W₁.id_mem _
+
+variable [W₁.IsMultiplicative]
+
+/-- The composition of morphisms in `Φ.LeftResolution X₂`. -/
+@[simps]
+def Hom.comp {L L' L'' : Φ.LeftResolution X₂}
+    (φ : Hom L L') (ψ : Hom L' L'') :
+    Hom L L'' where
+  f := φ.f ≫ ψ.f
+  hf := W₁.comp_mem _ _ φ.hf ψ.hf
+
+instance : Category (Φ.LeftResolution X₂) where
+  Hom := Hom
+  id := Hom.id
+  comp := Hom.comp
+
+@[simp]
+lemma id_f (L : Φ.LeftResolution X₂) : Hom.f (𝟙 L) = 𝟙 L.X₁ := rfl
+
+@[simp, reassoc]
+lemma comp_f {L L' L'' : Φ.LeftResolution X₂} (φ : L ⟶ L') (ψ : L' ⟶ L'') :
+    (φ ≫ ψ).f = φ.f ≫ ψ.f := rfl
+
+@[ext]
+lemma hom_ext {L L' : Φ.LeftResolution X₂} {φ₁ φ₂ : L ⟶ L'} (h : φ₁.f = φ₂.f) :
+    φ₁ = φ₂ :=
+  Hom.ext _ _ h
+
+end LeftResolution
+
+variable {Φ}
+
+/-- The canonical map `Φ.LeftResolution X₂ → Φ.op.RightResolution (Opposite.op X₂)`. -/
+@[simps]
+def LeftResolution.op {X₂ : C₂} (L : Φ.LeftResolution X₂) :
+    Φ.op.RightResolution (Opposite.op X₂) where
+  X₁ := Opposite.op L.X₁
+  w := L.w.op
+  hw := L.hw
+
+/-- The canonical map `Φ.op.LeftResolution X₂ → Φ.RightResolution X₂`. -/
+@[simps]
+def LeftResolution.unop {X₂ : C₂ᵒᵖ} (L : Φ.op.LeftResolution X₂) :
+    Φ.RightResolution X₂.unop where
+  X₁ := Opposite.unop L.X₁
+  w := L.w.unop
+  hw := L.hw
+
+/-- The canonical map `Φ.RightResolution X₂ → Φ.op.LeftResolution (Opposite.op X₂)`. -/
+@[simps]
+def RightResolution.op {X₂ : C₂} (L : Φ.RightResolution X₂) :
+    Φ.op.LeftResolution (Opposite.op X₂) where
+  X₁ := Opposite.op L.X₁
+  w := L.w.op
+  hw := L.hw
+
+/-- The canonical map `Φ.op.RightResolution X₂ → Φ.LeftResolution X₂`. -/
+@[simps]
+def RightResolution.unop {X₂ : C₂ᵒᵖ} (L : Φ.op.RightResolution X₂) :
+    Φ.LeftResolution X₂.unop where
+  X₁ := Opposite.unop L.X₁
+  w := L.w.unop
+  hw := L.hw
+
+variable (Φ)
+
+lemma nonempty_leftResolution_iff_op (X₂ : C₂) :
+    Nonempty (Φ.LeftResolution X₂) ↔ Nonempty (Φ.op.RightResolution (Opposite.op X₂)) :=
+  Equiv.nonempty_congr
+    { toFun := fun L => L.op
+      invFun := fun R => R.unop
+      left_inv := fun _ => rfl
+      right_inv := fun _ => rfl }
+
+lemma nonempty_rightResolution_iff_op (X₂ : C₂) :
+    Nonempty (Φ.RightResolution X₂) ↔ Nonempty (Φ.op.LeftResolution (Opposite.op X₂)) :=
+  Equiv.nonempty_congr
+    { toFun := fun R => R.op
+      invFun := fun L => L.unop
+      left_inv := fun _ => rfl
+      right_inv := fun _ => rfl }
+
+lemma hasLeftResolutions_iff_op : Φ.HasLeftResolutions ↔ Φ.op.HasRightResolutions :=
+  ⟨fun _ X₂ => ⟨(Classical.arbitrary (Φ.LeftResolution X₂.unop)).op⟩,
+    fun _ X₂ => ⟨(Classical.arbitrary (Φ.op.RightResolution (Opposite.op X₂))).unop⟩⟩
+
+lemma hasRightResolutions_iff_op : Φ.HasRightResolutions ↔ Φ.op.HasLeftResolutions :=
+  ⟨fun _ X₂ => ⟨(Classical.arbitrary (Φ.RightResolution X₂.unop)).op⟩,
+    fun _ X₂ => ⟨(Classical.arbitrary (Φ.op.LeftResolution (Opposite.op X₂))).unop⟩⟩
+
+/-- The functor `(Φ.LeftResolution X₂)ᵒᵖ ⥤ Φ.op.RightResolution (Opposite.op X₂)`. -/
+@[simps]
+def LeftResolution.opFunctor (X₂ : C₂) [W₁.IsMultiplicative] :
+    (Φ.LeftResolution X₂)ᵒᵖ ⥤ Φ.op.RightResolution (Opposite.op X₂) where
+  obj L := L.unop.op
+  map φ :=
+    { f := φ.unop.f.op
+      hf := φ.unop.hf
+      comm := Quiver.Hom.unop_inj φ.unop.comm }
+
+/-- The functor `(Φ.op.RightResolution X₂)ᵒᵖ ⥤ Φ.LeftResolution X₂.unop`. -/
+@[simps]
+def RightResolution.unopFunctor (X₂ : C₂ᵒᵖ) [W₁.IsMultiplicative] :
+    (Φ.op.RightResolution X₂)ᵒᵖ ⥤ Φ.LeftResolution X₂.unop where
+  obj R := R.unop.unop
+  map φ :=
+    { f := φ.unop.f.unop
+      hf := φ.unop.hf
+      comm := Quiver.Hom.op_inj φ.unop.comm }
+
+/-- The equivalence of categories
+`(Φ.LeftResolution X₂)ᵒᵖ ≌ Φ.op.RightResolution (Opposite.op X₂)`. -/
+@[simps]
+def LeftResolution.opEquivalence (X₂ : C₂) [W₁.IsMultiplicative] :
+    (Φ.LeftResolution X₂)ᵒᵖ ≌ Φ.op.RightResolution (Opposite.op X₂) where
+  functor := LeftResolution.opFunctor Φ X₂
+  inverse := (RightResolution.unopFunctor Φ (Opposite.op X₂)).rightOp
+  unitIso := Iso.refl _
+  counitIso := Iso.refl _
+
 section
 
-variable [Φ.HasRightResolutions] (L₂ : C₂ ⥤ D₂) [L₂.IsLocalization W₂]
+variable (L₂ : C₂ ⥤ D₂) [L₂.IsLocalization W₂]
 
-lemma essSurj_of_hasRightResolutions : (Φ.functor ⋙ L₂).EssSurj where
+lemma essSurj_of_hasRightResolutions [Φ.HasRightResolutions] : (Φ.functor ⋙ L₂).EssSurj where
   mem_essImage X₂ := by
     have := Localization.essSurj L₂ W₂
     have R : Φ.RightResolution (L₂.objPreimage X₂) := Classical.arbitrary _
     exact ⟨R.X₁, ⟨(Localization.isoOfHom L₂ W₂ _ R.hw).symm ≪≫ L₂.objObjPreimageIso X₂⟩⟩
 
-lemma isIso_iff_of_hasRightResolutions {F G : D₂ ⥤ H} (α : F ⟶ G) :
+lemma isIso_iff_of_hasRightResolutions [Φ.HasRightResolutions] {F G : D₂ ⥤ H} (α : F ⟶ G) :
     IsIso α ↔ ∀ (X₁ : C₁), IsIso (α.app (L₂.obj (Φ.functor.obj X₁))) := by
   constructor
   · intros
@@ -130,6 +289,24 @@ lemma isIso_iff_of_hasRightResolutions {F G : D₂ ⥤ H} (α : F ⟶ G) :
   · intro hα
     have : ∀ (X₂ : D₂), IsIso (α.app X₂) := fun X₂ => by
       have := Φ.essSurj_of_hasRightResolutions L₂
+      rw [← NatTrans.isIso_app_iff_of_iso α ((Φ.functor ⋙ L₂).objObjPreimageIso X₂)]
+      apply hα
+    exact NatIso.isIso_of_isIso_app α
+
+lemma essSurj_of_hasLeftResolutions [Φ.HasLeftResolutions] : (Φ.functor ⋙ L₂).EssSurj where
+  mem_essImage X₂ := by
+    have := Localization.essSurj L₂ W₂
+    have L : Φ.LeftResolution (L₂.objPreimage X₂) := Classical.arbitrary _
+    exact ⟨L.X₁, ⟨Localization.isoOfHom L₂ W₂ _ L.hw ≪≫ L₂.objObjPreimageIso X₂⟩⟩
+
+lemma isIso_iff_of_hasLeftResolutions [Φ.HasLeftResolutions] {F G : D₂ ⥤ H} (α : F ⟶ G) :
+    IsIso α ↔ ∀ (X₁ : C₁), IsIso (α.app (L₂.obj (Φ.functor.obj X₁))) := by
+  constructor
+  · intros
+    infer_instance
+  · intro hα
+    have : ∀ (X₂ : D₂), IsIso (α.app X₂) := fun X₂ => by
+      have := Φ.essSurj_of_hasLeftResolutions L₂
       rw [← NatTrans.isIso_app_iff_of_iso α ((Φ.functor ⋙ L₂).objObjPreimageIso X₂)]
       apply hα
     exact NatIso.isIso_of_isIso_app α


### PR DESCRIPTION
The left resolutions of a localizer morphism are defined, and it is shown that this is the dual notion to that of right resolutions for the opposite localizer morphism.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
