### PR TITLE
fix: reset cache

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/std4",
    "type": "git",
    "subDir": null,
-   "rev": "3025cb124492b423070f20cf0a70636f757d117f",
+   "rev":  "3025cb124492b423070f20cf0a70636f757d117f",
    "name": "std",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
The cache is currently broken, see [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/cache.20not.20working.20after.20bump.20to.20.20v4.2E8.2E0-rc1v.3F/near/436842898). This should refresh the bad cache files. Everyone with PRs that fail to get cache hits should rebase on top of this commit.

 ---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
