### PR TITLE
[Merged by Bors] - feat: add `HasSum f a → HasProd (exp ∘ f) (exp a)`

### DIFF
--- a/Mathlib/Analysis/NormedSpace/Exponential.lean
+++ b/Mathlib/Analysis/NormedSpace/Exponential.lean
@@ -474,7 +474,7 @@ theorem exp_continuous : Continuous (exp 𝕂 : 𝔸 → 𝔸) := by
 #align exp_continuous NormedSpace.exp_continuous
 
 open Topology in
-lemma _root_.Filter.Tendsto.NormedSpace_exp {α : Type*} {l : Filter α} {f : α → 𝔸} {a : 𝔸}
+lemma _root_.Filter.Tendsto.exp {α : Type*} {l : Filter α} {f : α → 𝔸} {a : 𝔸}
     (hf : Tendsto f l (𝓝 a)) :
     Tendsto (fun x => exp 𝕂 (f x)) l (𝓝 (exp 𝕂 a)) :=
   (exp_continuous.tendsto _).comp hf

--- a/Mathlib/Analysis/NormedSpace/Exponential.lean
+++ b/Mathlib/Analysis/NormedSpace/Exponential.lean
@@ -473,6 +473,12 @@ theorem exp_continuous : Continuous (exp 𝕂 : 𝔸 → 𝔸) := by
   exact continuousOn_exp
 #align exp_continuous NormedSpace.exp_continuous
 
+open Topology in
+lemma _root_.Filter.Tendsto.NormedSpace_exp {α : Type*} {l : Filter α} {f : α → 𝔸} {a : 𝔸}
+    (hf : Tendsto f l (𝓝 a)) :
+    Tendsto (fun x => exp 𝕂 (f x)) l (𝓝 (exp 𝕂 a)) :=
+  (exp_continuous.tendsto _).comp hf
+
 theorem exp_analytic (x : 𝔸) : AnalyticAt 𝕂 (exp 𝕂) x :=
   analyticAt_exp_of_mem_ball x ((expSeries_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
 #align exp_analytic NormedSpace.exp_analytic

--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -136,23 +136,23 @@ variable {α : Type*}
 
 open Real
 
-theorem Filter.Tendsto.exp {l : Filter α} {f : α → ℝ} {z : ℝ} (hf : Tendsto f l (𝓝 z)) :
+theorem Filter.Tendsto.rexp {l : Filter α} {f : α → ℝ} {z : ℝ} (hf : Tendsto f l (𝓝 z)) :
     Tendsto (fun x => exp (f x)) l (𝓝 (exp z)) :=
   (continuous_exp.tendsto _).comp hf
-#align filter.tendsto.exp Filter.Tendsto.exp
+#align filter.tendsto.exp Filter.Tendsto.rexp
 
 variable [TopologicalSpace α] {f : α → ℝ} {s : Set α} {x : α}
 
 nonrec
 theorem ContinuousWithinAt.exp (h : ContinuousWithinAt f s x) :
     ContinuousWithinAt (fun y => exp (f y)) s x :=
-  h.exp
+  h.rexp
 #align continuous_within_at.exp ContinuousWithinAt.exp
 
 @[fun_prop]
 nonrec
 theorem ContinuousAt.exp (h : ContinuousAt f x) : ContinuousAt (fun y => exp (f y)) x :=
-  h.exp
+  h.rexp
 #align continuous_at.exp ContinuousAt.exp
 
 @[fun_prop]
@@ -445,7 +445,7 @@ end Real
 open Real in
 /-- If `f` has sum `a`, then `exp ∘ f` has product `exp a`. -/
 lemma HasSum.rexp {ι} {f : ι → ℝ} {a : ℝ} (h : HasSum f a) : HasProd (rexp ∘ f) (rexp a) :=
-  Tendsto.congr (fun s ↦ exp_sum s f) <| Tendsto.exp h
+  Tendsto.congr (fun s ↦ exp_sum s f) <| Filter.Tendsto.rexp h
 
 namespace Complex
 

--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -143,6 +143,7 @@ theorem Filter.Tendsto.rexp {l : Filter α} {f : α → ℝ} {z : ℝ} (hf : Ten
 
 variable [TopologicalSpace α] {f : α → ℝ} {s : Set α} {x : α}
 
+-- TODO: the two next theorems should be `rexp` as well
 nonrec
 theorem ContinuousWithinAt.exp (h : ContinuousWithinAt f s x) :
     ContinuousWithinAt (fun y => exp (f y)) s x :=

--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -445,7 +445,7 @@ end Real
 open Real in
 /-- If `f` has sum `a`, then `exp ∘ f` has product `exp a`. -/
 lemma HasSum.rexp {ι} {f : ι → ℝ} {a : ℝ} (h : HasSum f a) : HasProd (rexp ∘ f) (rexp a) :=
-  Tendsto.congr (fun s ↦ exp_sum s f) <| Filter.Tendsto.rexp h
+  Tendsto.congr (fun s ↦ exp_sum s f) <| Tendsto.rexp h
 
 namespace Complex
 

--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -442,6 +442,11 @@ lemma summable_pow_mul_exp_neg_nat_mul (k : ℕ) {r : ℝ} (hr : 0 < r) :
 
 end Real
 
+open Real in
+/-- If `f` has sum `a`, then `exp ∘ f` has product `exp a`. -/
+lemma HasSum.rexp {ι} {f : ι → ℝ} {a : ℝ} (h : HasSum f a) : HasProd (rexp ∘ f) (rexp a) :=
+  Tendsto.congr (fun s ↦ exp_sum s f) <| Tendsto.exp h
+
 namespace Complex
 
 @[simp]
@@ -486,3 +491,8 @@ theorem tendsto_exp_comap_re_atBot_nhdsWithin : Tendsto exp (comap re atBot) (�
 #align complex.tendsto_exp_comap_re_at_bot_nhds_within Complex.tendsto_exp_comap_re_atBot_nhdsWithin
 
 end Complex
+
+open Complex in
+/-- If `f` has sum `a`, then `exp ∘ f` has product `exp a`. -/
+lemma HasSum.cexp {ι : Type*} {f : ι → ℂ} {a : ℂ} (h : HasSum f a) : HasProd (cexp ∘ f) (cexp a) :=
+  Filter.Tendsto.congr (fun s ↦ exp_sum s f) <| Filter.Tendsto.cexp h

--- a/Mathlib/Analysis/SpecialFunctions/Exponential.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exponential.lean
@@ -421,3 +421,14 @@ theorem hasDerivAt_exp_smul_const' (x : 𝔸) (t : 𝕂) :
 end RCLike
 
 end exp_smul
+
+section tsum_tprod
+
+variable {𝕂 𝔸 : Type*} [RCLike 𝕂] [NormedCommRing 𝔸] [NormedAlgebra 𝕂 𝔸] [CompleteSpace 𝔸]
+
+/-- If `f` has sum `a`, then `exp ∘ f` has product `exp a`. -/
+lemma HasSum.NormedSpace_exp {ι : Type*} {f : ι → 𝔸} {a : 𝔸} (h : HasSum f a) :
+    HasProd (exp 𝕂 ∘ f) (exp 𝕂 a) :=
+  Tendsto.congr (fun s ↦ exp_sum s f) <| Tendsto.NormedSpace_exp h
+
+end tsum_tprod

--- a/Mathlib/Analysis/SpecialFunctions/Exponential.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exponential.lean
@@ -427,7 +427,7 @@ section tsum_tprod
 variable {𝕂 𝔸 : Type*} [RCLike 𝕂] [NormedCommRing 𝔸] [NormedAlgebra 𝕂 𝔸] [CompleteSpace 𝔸]
 
 /-- If `f` has sum `a`, then `exp ∘ f` has product `exp a`. -/
-lemma HasSum.NormedSpace_exp {ι : Type*} {f : ι → 𝔸} {a : 𝔸} (h : HasSum f a) :
+lemma HasSum.exp {ι : Type*} {f : ι → 𝔸} {a : 𝔸} (h : HasSum f a) :
     HasProd (exp 𝕂 ∘ f) (exp 𝕂 a) :=
   Tendsto.congr (fun s ↦ exp_sum s f) <| Tendsto.exp h
 

--- a/Mathlib/Analysis/SpecialFunctions/Exponential.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exponential.lean
@@ -429,6 +429,6 @@ variable {𝕂 𝔸 : Type*} [RCLike 𝕂] [NormedCommRing 𝔸] [NormedAlgebra 
 /-- If `f` has sum `a`, then `exp ∘ f` has product `exp a`. -/
 lemma HasSum.NormedSpace_exp {ι : Type*} {f : ι → 𝔸} {a : 𝔸} (h : HasSum f a) :
     HasProd (exp 𝕂 ∘ f) (exp 𝕂 a) :=
-  Tendsto.congr (fun s ↦ exp_sum s f) <| Tendsto.NormedSpace_exp h
+  Tendsto.congr (fun s ↦ exp_sum s f) <| Tendsto.exp h
 
 end tsum_tprod

--- a/Mathlib/NumberTheory/RamificationInertia.lean
+++ b/Mathlib/NumberTheory/RamificationInertia.lean
@@ -48,16 +48,6 @@ variable {R : Type u} [CommRing R]
 variable {S : Type v} [CommRing S] (f : R →+* S)
 variable (p : Ideal R) (P : Ideal S)
 
--- local instances to speed things up
-@[instance] private def instAlg [Algebra (R ⧸ p) (S ⧸ P)] : SMul (R ⧸ p) (S ⧸ P) :=
-  Algebra.toSMul
-@[instance] private def instAlg' [Algebra (R ⧸ p) (S ⧸ P)] : Module (R ⧸ p) (S ⧸ P) :=
-  Algebra.toModule
-@[instance] private def instAMHC (n : ℕ) :
-    AddMonoidHomClass (Matrix (Fin n) (Fin n) R →+* Matrix (Fin n) (Fin n) (R ⧸ p))
-      (Matrix (Fin n) (Fin n) R)
-      (Matrix (Fin n) (Fin n) (R ⧸ p)) := RingHomClass.toAddMonoidHomClass
-
 open FiniteDimensional
 
 open UniqueFactorizationMonoid
@@ -104,7 +94,7 @@ theorem ramificationIdx_spec {n : ℕ} (hle : map f p ≤ P ^ n) (hgt : ¬map f 
 
 theorem ramificationIdx_lt {n : ℕ} (hgt : ¬map f p ≤ P ^ n) : ramificationIdx f p P < n := by
   cases' n with n n
-  · simp only [Nat.zero_eq, pow_zero, one_eq_top, le_top, not_true_eq_false] at hgt
+  · simp at hgt
   · rw [Nat.lt_succ_iff]
     have : ∀ k, map f p ≤ P ^ k → k ≤ n := by
       refine fun k hk => le_of_not_lt fun hnk => ?_
@@ -120,7 +110,7 @@ theorem ramificationIdx_bot : ramificationIdx f ⊥ P = 0 :=
 
 @[simp]
 theorem ramificationIdx_of_not_le (h : ¬map f p ≤ P) : ramificationIdx f p P = 0 :=
-  ramificationIdx_spec (by simp) (by simpa only [zero_add, pow_one] using h)
+  ramificationIdx_spec (by simp) (by simpa using h)
 #align ideal.ramification_idx_of_not_le Ideal.ramificationIdx_of_not_le
 
 theorem ramificationIdx_ne_zero {e : ℕ} (he : e ≠ 0) (hle : map f p ≤ P ^ e)
@@ -183,7 +173,7 @@ end IsDedekindDomain
 
 variable (f p P)
 
-attribute [instance] Ideal.Quotient.field
+attribute [local instance] Ideal.Quotient.field
 
 /-- The inertia degree of `P : Ideal S` lying over `p : Ideal R` is the degree of the
 extension `(S / P) : (R / p)`.
@@ -216,15 +206,10 @@ theorem inertiaDeg_of_subsingleton [hp : p.IsMaximal] [hQ : Subsingleton (S ⧸ 
 theorem inertiaDeg_algebraMap [Algebra R S] [Algebra (R ⧸ p) (S ⧸ P)]
     [IsScalarTower R (R ⧸ p) (S ⧸ P)] [hp : p.IsMaximal] :
     inertiaDeg (algebraMap R S) p P = finrank (R ⧸ p) (S ⧸ P) := by
-  -- [0.209402s] ❌ Nontrivial (S ⧸ P)
-  -- nontriviality S ⧸ P using inertiaDeg_of_subsingleton, finrank_zero_of_subsingleton
-  rcases subsingleton_or_nontrivial (S ⧸ P) with H | H
-  · -- get `Subsingleton` case out of the way
-    rw [inertiaDeg_of_subsingleton, finrank_zero_of_subsingleton]
-  -- now we have `Nontrivial (S ⧸ P)`
+  nontriviality S ⧸ P using inertiaDeg_of_subsingleton, finrank_zero_of_subsingleton
   have := comap_eq_of_scalar_tower_quotient (algebraMap (R ⧸ p) (S ⧸ P)).injective
   rw [inertiaDeg, dif_pos this]
-  congr -- slow
+  congr
   refine' Algebra.algebra_ext _ _ fun x' => Quotient.inductionOn' x' fun x => _
   change Ideal.Quotient.lift p _ _ (Ideal.Quotient.mk p x) = algebraMap _ _ (Ideal.Quotient.mk p x)
   rw [Ideal.Quotient.lift_mk, ← Ideal.Quotient.algebraMap_eq P, ← IsScalarTower.algebraMap_eq,
@@ -338,9 +323,8 @@ theorem FinrankQuotientMap.span_eq_top [IsDomain R] [IsDomain S] [Algebra K L] [
   let B := A.adjugate
   have A_smul : ∀ i, ∑ j, A i j • a j = 0 := by
     intros
-    simp only [Matrix.sub_apply, Matrix.of_apply, Matrix.one_apply, sub_smul, ite_smul, one_smul,
-      zero_smul, Finset.sum_sub_distrib, hA', Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte,
-      sub_self, A]
+    simp [A, Matrix.sub_apply, Matrix.of_apply, ne_eq, Matrix.one_apply, sub_smul,
+      Finset.sum_sub_distrib, hA', sub_self]
   -- since `span S {det A} / M = 0`.
   have d_smul : ∀ i, A.det • a i = 0 := by
     intro i
@@ -412,8 +396,6 @@ theorem finrank_quotient_map [IsDomain S] [IsDedekindDomain R] [Algebra K L]
   -- We'll use the previous results to turn it into a basis on `[Frac(S) : Frac(R)]`.
   letI : Field (R ⧸ p) := Ideal.Quotient.field _
   let ι := Module.Free.ChooseBasisIndex (R ⧸ p) (S ⧸ map (algebraMap R S) p)
-  letI instFintype : Fintype ι :=
-    Module.Free.ChooseBasisIndex.fintype (R ⧸ p) (S ⧸ map (algebraMap R S) p)
   let b : Basis ι (R ⧸ p) (S ⧸ map (algebraMap R S) p) := Module.Free.chooseBasis _ _
   -- Namely, choose a representative `b' i : S` for each `b i : S / pS`.
   let b' : ι → S := fun i => (Ideal.Quotient.mk_surjective (b i)).choose
@@ -441,16 +423,13 @@ theorem finrank_quotient_map [IsDomain S] [IsDedekindDomain R] [Algebra K L]
       Submodule.restrictScalars_span R (R ⧸ p) Ideal.Quotient.mk_surjective, b_eq_b',
       Set.range_comp, ← Submodule.map_span] at mem_span_b
     obtain ⟨y, y_mem, y_eq⟩ := Submodule.mem_map.mp mem_span_b
-    suffices y + -(y - x) ∈ _ by simpa only [neg_sub, add_sub_cancel]
+    suffices y + -(y - x) ∈ _ by simpa
     rw [LinearMap.restrictScalars_apply, Submodule.mkQ_apply, Submodule.mkQ_apply,
       Submodule.Quotient.eq] at y_eq
     exact add_mem (Submodule.mem_sup_left y_mem) (neg_mem <| Submodule.mem_sup_right y_eq)
   · have := b.linearIndependent; rw [b_eq_b'] at this
-    -- slow convert
-    refine FinrankQuotientMap.linearIndependent_of_nontrivial K ?_
-        ((Algebra.linearMap S L).restrictScalars R) ?_ ((Submodule.mkQ _).restrictScalars R) this
-    -- convert FinrankQuotientMap.linearIndependent_of_nontrivial K _
-    --     ((Algebra.linearMap S L).restrictScalars R) _ ((Submodule.mkQ _).restrictScalars R) this
+    convert FinrankQuotientMap.linearIndependent_of_nontrivial K _
+        ((Algebra.linearMap S L).restrictScalars R) _ ((Submodule.mkQ _).restrictScalars R) this
     · rw [Quotient.algebraMap_eq, Ideal.mk_ker]
       exact hp.ne_top
     · exact IsFractionRing.injective S L
@@ -468,9 +447,9 @@ noncomputable instance Quotient.algebraQuotientPowRamificationIdx : Algebra (R �
   Quotient.algebraQuotientOfLEComap (Ideal.map_le_iff_le_comap.mp le_pow_ramificationIdx)
 #align ideal.quotient.algebra_quotient_pow_ramification_idx Ideal.Quotient.algebraQuotientPowRamificationIdx
 
-@[simp] -- elaboration took 12s --> fast by replacing `_` by `(P ^ e)`
+@[simp]
 theorem Quotient.algebraMap_quotient_pow_ramificationIdx (x : R) :
-    algebraMap (R ⧸ p) (S ⧸ P ^ e) (Ideal.Quotient.mk p x) = Ideal.Quotient.mk (P ^ e) (f x) := rfl
+    algebraMap (R ⧸ p) (S ⧸ P ^ e) (Ideal.Quotient.mk p x) = Ideal.Quotient.mk _ (f x) := rfl
 #align ideal.quotient.algebra_map_quotient_pow_ramification_idx Ideal.Quotient.algebraMap_quotient_pow_ramificationIdx
 
 variable [hfp : NeZero (ramificationIdx f p P)]
@@ -483,71 +462,32 @@ def Quotient.algebraQuotientOfRamificationIdxNeZero : Algebra (R ⧸ p) (S ⧸ P
   Quotient.algebraQuotientOfLEComap (le_comap_of_ramificationIdx_ne_zero hfp.out)
 #align ideal.quotient.algebra_quotient_of_ramification_idx_ne_zero Ideal.Quotient.algebraQuotientOfRamificationIdxNeZero
 
-set_option synthInstance.checkSynthOrder false in -- Porting note: this is okay by the remark below
+set_option synthInstance.checkSynthOrder false -- Porting note: this is okay by the remark below
 -- In this file, the value for `f` can be inferred.
-attribute [instance] Ideal.Quotient.algebraQuotientOfRamificationIdxNeZero
+attribute [local instance] Ideal.Quotient.algebraQuotientOfRamificationIdxNeZero
 
-@[simp] -- elaboration took 3.5s --> fast by replacing `_` by `P`
+@[simp]
 theorem Quotient.algebraMap_quotient_of_ramificationIdx_neZero (x : R) :
-    algebraMap (R ⧸ p) (S ⧸ P) (Ideal.Quotient.mk p x) = Ideal.Quotient.mk P (f x) := rfl
+    algebraMap (R ⧸ p) (S ⧸ P) (Ideal.Quotient.mk p x) = Ideal.Quotient.mk _ (f x) := rfl
 #align ideal.quotient.algebra_map_quotient_of_ramification_idx_ne_zero Ideal.Quotient.algebraMap_quotient_of_ramificationIdx_neZero
 
-@[local instance] private noncomputable def instMod_R_p' (i : ℕ) :
-    Module (R ⧸ p) ↥(Ideal.map (Ideal.Quotient.mk (P ^ e)) (P ^ i)) :=
-  Submodule.module' (map (Quotient.mk (P ^ e)) (P ^ i))
-
 /-- The inclusion `(P^(i + 1) / P^e) ⊂ (P^i / P^e)`. -/
--- @[simps] -- removing the attribute speeds this up by a factor of 5
--- (it toook a couple seconds to type-check)
--- compilation of Ideal.powQuotSuccInclusion took 508ms --> make `noncomputable`
-noncomputable def powQuotSuccInclusion (i : ℕ) :
+@[simps]
+def powQuotSuccInclusion (i : ℕ) :
     Ideal.map (Ideal.Quotient.mk (P ^ e)) (P ^ (i + 1)) →ₗ[R ⧸ p]
     Ideal.map (Ideal.Quotient.mk (P ^ e)) (P ^ i) where
-  toFun := fun x ↦ ⟨x.1, map_mono (pow_le_pow_right i.le_succ) x.2⟩
+  toFun x := ⟨x, Ideal.map_mono (Ideal.pow_le_pow_right i.le_succ) x.2⟩
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 #align ideal.pow_quot_succ_inclusion Ideal.powQuotSuccInclusion
 
--- add lemma manually (still not really fast...)
-@[simp]
-lemma powQuotSuccInclusion_apply_coe (i : ℕ) (x : ↥(map (Quotient.mk (P ^ e)) (P ^ (i + 1)))) :
-    ↑((powQuotSuccInclusion f p P i) x) = x.1 := by
-  -- `:= rfl` works, but is slow
-  simp only [powQuotSuccInclusion]
-  simp only [LinearMap.coe_mk]
-  simp only [AddHom.coe_mk]
-
--- type checking took 9.77s --> use `ZeroMemClass.coe_zero`
 theorem powQuotSuccInclusion_injective (i : ℕ) :
     Function.Injective (powQuotSuccInclusion f p P i) := by
   rw [← LinearMap.ker_eq_bot, LinearMap.ker_eq_bot']
   rintro ⟨x, hx⟩ hx0
-  simp only [Subtype.ext_iff, powQuotSuccInclusion_apply_coe, ZeroMemClass.coe_zero] at hx0 ⊢
-  convert hx0 -- `exact` is slow
+  rw [Subtype.ext_iff] at hx0 ⊢
+  rwa [powQuotSuccInclusion_apply_coe] at hx0
 #align ideal.pow_quot_succ_inclusion_injective Ideal.powQuotSuccInclusion_injective
-
--- local instances to speed things up
-@[instance] private def instMHC : MulHomClass (S →+* S ⧸ P ^ e) S (S ⧸ P ^ e) :=
-  NonUnitalRingHomClass.toMulHomClass
-@[instance] private def instAMHC' : AddMonoidHomClass (S →+* S ⧸ P ^ e) S (S ⧸ P ^ e) :=
-  RingHomClass.toAddMonoidHomClass
-@[instance] private noncomputable def instACG (i : ℕ) :
-    AddCommGroup (↥(Ideal.map (Ideal.Quotient.mk (P ^ e)) (P ^ i)) ⧸
-                    LinearMap.range (Ideal.powQuotSuccInclusion f p P i)) :=
-  Submodule.Quotient.addCommGroup (LinearMap.range (powQuotSuccInclusion f p P i))
-@[instance] private noncomputable def instACM (i : ℕ) :
-    AddCommMonoid (↥(Ideal.map (Ideal.Quotient.mk (P ^ e)) (P ^ i)) ⧸
-                       LinearMap.range (Ideal.powQuotSuccInclusion f p P i)) :=
-  AddCommGroup.toAddCommMonoid
-@[instance] private noncomputable def instModule_R_p (i : ℕ) :
-    Module (R ⧸ p)
-      (↥(Ideal.map (Ideal.Quotient.mk (P ^ e)) (P ^ i)) ⧸
-          LinearMap.range (Ideal.powQuotSuccInclusion f p P i)) :=
-  Submodule.Quotient.module (LinearMap.range (powQuotSuccInclusion f p P i))
-@[instance] private noncomputable def instAdd (i : ℕ) :
-    Add (↥(Ideal.map (Ideal.Quotient.mk (P ^ e)) (P ^ i)) ⧸
-           LinearMap.range (Ideal.powQuotSuccInclusion f p P i)) :=
-  AddCommMagma.toAdd
 
 /-- `S ⧸ P` embeds into the quotient by `P^(i+1) ⧸ P^e` as a subspace of `P^i ⧸ P^e`.
 See `quotientToQuotientRangePowQuotSucc` for this as a linear map,
@@ -577,13 +517,13 @@ noncomputable def quotientToQuotientRangePowQuotSucc {i : ℕ} {a : S} (a_mem : 
     S ⧸ P →ₗ[R ⧸ p]
       (P ^ i).map (Ideal.Quotient.mk (P ^ e)) ⧸ LinearMap.range (powQuotSuccInclusion f p P i) where
   toFun := quotientToQuotientRangePowQuotSuccAux f p P a_mem
-  map_add' := by -- slow `refine`
-    intro x y; refine Quotient.inductionOn' x fun x => Quotient.inductionOn' y fun y => ?_
+  map_add' := by
+    intro x y; refine' Quotient.inductionOn' x fun x => Quotient.inductionOn' y fun y => _
     simp only [Submodule.Quotient.mk''_eq_mk, ← Submodule.Quotient.mk_add,
       quotientToQuotientRangePowQuotSuccAux_mk, mul_add]
     exact congr_arg Submodule.Quotient.mk rfl
-  map_smul' := by -- slow `refine`
-    intro x y; refine Quotient.inductionOn' x fun x => Quotient.inductionOn' y fun y => ?_
+  map_smul' := by
+    intro x y; refine' Quotient.inductionOn' x fun x => Quotient.inductionOn' y fun y => _
     simp only [Submodule.Quotient.mk''_eq_mk, RingHom.id_apply,
       quotientToQuotientRangePowQuotSuccAux_mk]
     refine congr_arg Submodule.Quotient.mk ?_
@@ -677,11 +617,6 @@ theorem rank_pow_quot_aux [IsDedekindDomain S] [p.IsMaximal] [P.IsPrime] (hP0 : 
   exact (rank_quotient_add_rank (LinearMap.range (powQuotSuccInclusion f p P i))).symm
 #align ideal.rank_pow_quot_aux Ideal.rank_pow_quot_aux
 
-section
-
--- without un-instancing this, the proofs below break, likely because of some instance mismatch
-attribute [-instance] instMod_R_p'
-
 theorem rank_pow_quot [IsDedekindDomain S] [p.IsMaximal] [P.IsPrime] (hP0 : P ≠ ⊥)
     (i : ℕ) (hi : i ≤ e) :
     Module.rank (R ⧸ p) (Ideal.map (Ideal.Quotient.mk (P ^ e)) (P ^ i)) =
@@ -714,8 +649,6 @@ theorem rank_prime_pow_ramificationIdx [IsDedekindDomain S] [p.IsMaximal] [P.IsP
   rw [pow_zero, Nat.sub_zero, Ideal.one_eq_top, Ideal.map_top] at this
   exact (rank_top (R ⧸ p) _).symm.trans this
 #align ideal.rank_prime_pow_ramification_idx Ideal.rank_prime_pow_ramificationIdx
-
-end
 
 /-- If `p` is a maximal ideal of `R`, `S` extends `R` and `P^e` lies over `p`,
 then the dimension `[S/(P^e) : R/p]`, as a natural number, is equal to `e * [S/P : R/p]`. -/
@@ -773,15 +706,14 @@ instance Factors.fact_ramificationIdx_neZero (P : (factors (map (algebraMap R S)
 
 set_option synthInstance.checkSynthOrder false
 -- Porting note: this is okay since, as noted above, in this file the value of `f` can be inferred
-attribute [instance] Quotient.algebraQuotientOfRamificationIdxNeZero
+attribute [local instance] Quotient.algebraQuotientOfRamificationIdxNeZero
 
 instance Factors.isScalarTower (P : (factors (map (algebraMap R S) p)).toFinset) :
     IsScalarTower R (R ⧸ p) (S ⧸ (P : Ideal S)) :=
-  IsScalarTower.of_algebraMap_eq fun x => by simp only [Quotient.algebraMap_eq,
-    Quotient.algebraMap_quotient_of_ramificationIdx_neZero, Quotient.mk_algebraMap]
+  IsScalarTower.of_algebraMap_eq fun x => by simp
 #align ideal.factors.is_scalar_tower Ideal.Factors.isScalarTower
 
-attribute [instance] Ideal.Quotient.field
+attribute [local instance] Ideal.Quotient.field
 
 theorem Factors.finrank_pow_ramificationIdx [p.IsMaximal]
     (P : (factors (map (algebraMap R S) p)).toFinset) :


### PR DESCRIPTION
This adds lemmas saying that ` HasSum f a`  implies `HasProd (exp ∘ f) (exp a)` for `exp = rexp, cexp, NormedSpace.exp`.

While the `rexp`  and `cexp`  versions could be deduced from the `NormedSpace.exp` one, we give a direct proof (and so avoid needing to import stuff about `NormedSpace.exp` for these results; the proofs are also a bit faster that way).

Based on the discussion below, this also renames `Filter.Tendsto.exp` to `Filter.Tendsto.rexp` for the version specific to the real exponential function, so that `Filter.Tendsto.exp` can be used for the corresponding statement involving `NormedSpace.exp`.

See [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/exp.28tsum.29.20.3D.20tprod.28exp.29/near/436891747) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
