### PR TITLE
[Merged by Bors] - chore(Data/List/Forall): more migration nthLe -> get

### DIFF
--- a/Mathlib/Data/List/Forall2.lean
+++ b/Mathlib/Data/List/Forall2.lean
@@ -162,6 +162,10 @@ theorem Forall₂.get :
   | _, _, Forall₂.cons ha _, 0, _, _ => ha
   | _, _, Forall₂.cons _ hl, succ _, _, _ => hl.get _ _
 
+@[deprecated (since:="2024-05-05")] theorem Forall₂.nthLe {x y} (h : Forall₂ R x y) ⦃i : ℕ⦄
+    (hx : i < x.length) (hy : i < y.length) : R (x.nthLe i hx) (y.nthLe i hy) := h.get hx hy
+#align list.forall₂.nth_le List.Forall₂.nthLe
+
 theorem forall₂_of_length_eq_of_get :
     ∀ {x : List α} {y : List β},
       x.length = y.length → (∀ i h₁ h₂, R (x.get ⟨i, h₁⟩) (y.get ⟨i, h₂⟩)) → Forall₂ R x y
@@ -171,9 +175,19 @@ theorem forall₂_of_length_eq_of_get :
       (forall₂_of_length_eq_of_get (succ.inj hl) fun i h₁ h₂ =>
         h i.succ (succ_lt_succ h₁) (succ_lt_succ h₂))
 
+@[deprecated (since:="2024-05-05")] theorem forall₂_of_length_eq_of_nthLe {x y}
+    (H : x.length = y.length) (H' : ∀ i h₁ h₂, R (x.nthLe i h₁) (y.nthLe i h₂)) :
+    Forall₂ R x y := forall₂_of_length_eq_of_get H H'
+#align list.forall₂_of_length_eq_of_nth_le List.forall₂_of_length_eq_of_nthLe
+
 theorem forall₂_iff_get {l₁ : List α} {l₂ : List β} :
     Forall₂ R l₁ l₂ ↔ l₁.length = l₂.length ∧ ∀ i h₁ h₂, R (l₁.get ⟨i, h₁⟩) (l₂.get ⟨i, h₂⟩) :=
   ⟨fun h => ⟨h.length_eq, h.get⟩, fun h => forall₂_of_length_eq_of_get h.1 h.2⟩
+
+@[deprecated (since:="2024-05-05")] theorem forall₂_iff_nthLe {l₁ : List α} {l₂ : List β} :
+    Forall₂ R l₁ l₂ ↔ l₁.length = l₂.length ∧ ∀ i h₁ h₂, R (l₁.nthLe i h₁) (l₂.nthLe i h₂) :=
+  forall₂_iff_get
+#align list.forall₂_iff_nth_le List.forall₂_iff_nthLe
 
 theorem forall₂_zip : ∀ {l₁ l₂}, Forall₂ R l₁ l₂ → ∀ {a b}, (a, b) ∈ zip l₁ l₂ → R a b
   | _, _, Forall₂.cons h₁ h₂, x, y, hx => by

--- a/Mathlib/Data/List/Forall2.lean
+++ b/Mathlib/Data/List/Forall2.lean
@@ -156,28 +156,24 @@ theorem Forall₂.length_eq : ∀ {l₁ l₂}, Forall₂ R l₁ l₂ → length 
   | _, _, Forall₂.cons _ h₂ => congr_arg succ (Forall₂.length_eq h₂)
 #align list.forall₂.length_eq List.Forall₂.length_eq
 
+theorem Forall₂.get :
+    ∀ {x : List α} {y : List β}, Forall₂ R x y →
+      ∀ ⦃i : ℕ⦄ (hx : i < x.length) (hy : i < y.length), R (x.get ⟨i, hx⟩) (y.get ⟨i, hy⟩)
+  | _, _, Forall₂.cons ha _, 0, _, _ => ha
+  | _, _, Forall₂.cons _ hl, succ _, _, _ => hl.get _ _
 
--- theorem Forall₂.nthLe :
---     ∀ {x : List α} {y : List β} (_ : Forall₂ R x y) ⦃i : ℕ⦄ (hx : i < x.length) (hy : i < y.length),
---       R (x.nthLe i hx) (y.nthLe i hy)
---   | _, _, Forall₂.cons ha _, 0, _, _ => ha
---   | _, _, Forall₂.cons _ hl, succ _, _, _ => hl.nthLe _ _
--- #align list.forall₂.nth_le List.Forall₂.nthLe
+theorem forall₂_of_length_eq_of_get :
+    ∀ {x : List α} {y : List β},
+      x.length = y.length → (∀ i h₁ h₂, R (x.get ⟨i, h₁⟩) (y.get ⟨i, h₂⟩)) → Forall₂ R x y
+  | [], [], _, _ => Forall₂.nil
+  | _ :: _, _ :: _, hl, h =>
+    Forall₂.cons (h 0 (Nat.zero_lt_succ _) (Nat.zero_lt_succ _))
+      (forall₂_of_length_eq_of_get (succ.inj hl) fun i h₁ h₂ =>
+        h i.succ (succ_lt_succ h₁) (succ_lt_succ h₂))
 
--- theorem forall₂_of_length_eq_of_nthLe :
---     ∀ {x : List α} {y : List β},
---       x.length = y.length → (∀ i h₁ h₂, R (x.nthLe i h₁) (y.nthLe i h₂)) → Forall₂ R x y
---   | [], [], _, _ => Forall₂.nil
---   | _ :: _, _ :: _, hl, h =>
---     Forall₂.cons (h 0 (Nat.zero_lt_succ _) (Nat.zero_lt_succ _))
---       (forall₂_of_length_eq_of_nthLe (succ.inj hl) fun i h₁ h₂ =>
---         h i.succ (succ_lt_succ h₁) (succ_lt_succ h₂))
--- #align list.forall₂_of_length_eq_of_nth_le List.forall₂_of_length_eq_of_nthLe
-
--- theorem forall₂_iff_nthLe {l₁ : List α} {l₂ : List β} :
---     Forall₂ R l₁ l₂ ↔ l₁.length = l₂.length ∧ ∀ i h₁ h₂, R (l₁.nthLe i h₁) (l₂.nthLe i h₂) :=
---   ⟨fun h => ⟨h.length_eq, h.nthLe⟩, fun h => forall₂_of_length_eq_of_nthLe h.1 h.2⟩
--- #align list.forall₂_iff_nth_le List.forall₂_iff_nthLe
+theorem forall₂_iff_get {l₁ : List α} {l₂ : List β} :
+    Forall₂ R l₁ l₂ ↔ l₁.length = l₂.length ∧ ∀ i h₁ h₂, R (l₁.get ⟨i, h₁⟩) (l₂.get ⟨i, h₂⟩) :=
+  ⟨fun h => ⟨h.length_eq, h.get⟩, fun h => forall₂_of_length_eq_of_get h.1 h.2⟩
 
 theorem forall₂_zip : ∀ {l₁ l₂}, Forall₂ R l₁ l₂ → ∀ {a b}, (a, b) ∈ zip l₁ l₂ → R a b
   | _, _, Forall₂.cons h₁ h₂, x, y, hx => by

--- a/Mathlib/Data/List/Forall2.lean
+++ b/Mathlib/Data/List/Forall2.lean
@@ -156,27 +156,28 @@ theorem Forall₂.length_eq : ∀ {l₁ l₂}, Forall₂ R l₁ l₂ → length 
   | _, _, Forall₂.cons _ h₂ => congr_arg succ (Forall₂.length_eq h₂)
 #align list.forall₂.length_eq List.Forall₂.length_eq
 
-theorem Forall₂.nthLe :
-    ∀ {x : List α} {y : List β} (_ : Forall₂ R x y) ⦃i : ℕ⦄ (hx : i < x.length) (hy : i < y.length),
-      R (x.nthLe i hx) (y.nthLe i hy)
-  | _, _, Forall₂.cons ha _, 0, _, _ => ha
-  | _, _, Forall₂.cons _ hl, succ _, _, _ => hl.nthLe _ _
-#align list.forall₂.nth_le List.Forall₂.nthLe
 
-theorem forall₂_of_length_eq_of_nthLe :
-    ∀ {x : List α} {y : List β},
-      x.length = y.length → (∀ i h₁ h₂, R (x.nthLe i h₁) (y.nthLe i h₂)) → Forall₂ R x y
-  | [], [], _, _ => Forall₂.nil
-  | _ :: _, _ :: _, hl, h =>
-    Forall₂.cons (h 0 (Nat.zero_lt_succ _) (Nat.zero_lt_succ _))
-      (forall₂_of_length_eq_of_nthLe (succ.inj hl) fun i h₁ h₂ =>
-        h i.succ (succ_lt_succ h₁) (succ_lt_succ h₂))
-#align list.forall₂_of_length_eq_of_nth_le List.forall₂_of_length_eq_of_nthLe
+-- theorem Forall₂.nthLe :
+--     ∀ {x : List α} {y : List β} (_ : Forall₂ R x y) ⦃i : ℕ⦄ (hx : i < x.length) (hy : i < y.length),
+--       R (x.nthLe i hx) (y.nthLe i hy)
+--   | _, _, Forall₂.cons ha _, 0, _, _ => ha
+--   | _, _, Forall₂.cons _ hl, succ _, _, _ => hl.nthLe _ _
+-- #align list.forall₂.nth_le List.Forall₂.nthLe
 
-theorem forall₂_iff_nthLe {l₁ : List α} {l₂ : List β} :
-    Forall₂ R l₁ l₂ ↔ l₁.length = l₂.length ∧ ∀ i h₁ h₂, R (l₁.nthLe i h₁) (l₂.nthLe i h₂) :=
-  ⟨fun h => ⟨h.length_eq, h.nthLe⟩, fun h => forall₂_of_length_eq_of_nthLe h.1 h.2⟩
-#align list.forall₂_iff_nth_le List.forall₂_iff_nthLe
+-- theorem forall₂_of_length_eq_of_nthLe :
+--     ∀ {x : List α} {y : List β},
+--       x.length = y.length → (∀ i h₁ h₂, R (x.nthLe i h₁) (y.nthLe i h₂)) → Forall₂ R x y
+--   | [], [], _, _ => Forall₂.nil
+--   | _ :: _, _ :: _, hl, h =>
+--     Forall₂.cons (h 0 (Nat.zero_lt_succ _) (Nat.zero_lt_succ _))
+--       (forall₂_of_length_eq_of_nthLe (succ.inj hl) fun i h₁ h₂ =>
+--         h i.succ (succ_lt_succ h₁) (succ_lt_succ h₂))
+-- #align list.forall₂_of_length_eq_of_nth_le List.forall₂_of_length_eq_of_nthLe
+
+-- theorem forall₂_iff_nthLe {l₁ : List α} {l₂ : List β} :
+--     Forall₂ R l₁ l₂ ↔ l₁.length = l₂.length ∧ ∀ i h₁ h₂, R (l₁.nthLe i h₁) (l₂.nthLe i h₂) :=
+--   ⟨fun h => ⟨h.length_eq, h.nthLe⟩, fun h => forall₂_of_length_eq_of_nthLe h.1 h.2⟩
+-- #align list.forall₂_iff_nth_le List.forall₂_iff_nthLe
 
 theorem forall₂_zip : ∀ {l₁ l₂}, Forall₂ R l₁ l₂ → ∀ {a b}, (a, b) ∈ zip l₁ l₂ → R a b
   | _, _, Forall₂.cons h₁ h₂, x, y, hx => by

--- a/Mathlib/Data/List/Forall2.lean
+++ b/Mathlib/Data/List/Forall2.lean
@@ -162,7 +162,7 @@ theorem Forall₂.get :
   | _, _, Forall₂.cons ha _, 0, _, _ => ha
   | _, _, Forall₂.cons _ hl, succ _, _, _ => hl.get _ _
 
-@[deprecated (since:="2024-05-05")] theorem Forall₂.nthLe {x y} (h : Forall₂ R x y) ⦃i : ℕ⦄
+@[deprecated (since := "2024-05-05")] theorem Forall₂.nthLe {x y} (h : Forall₂ R x y) ⦃i : ℕ⦄
     (hx : i < x.length) (hy : i < y.length) : R (x.nthLe i hx) (y.nthLe i hy) := h.get hx hy
 #align list.forall₂.nth_le List.Forall₂.nthLe
 
@@ -175,7 +175,7 @@ theorem forall₂_of_length_eq_of_get :
       (forall₂_of_length_eq_of_get (succ.inj hl) fun i h₁ h₂ =>
         h i.succ (succ_lt_succ h₁) (succ_lt_succ h₂))
 
-@[deprecated (since:="2024-05-05")] theorem forall₂_of_length_eq_of_nthLe {x y}
+@[deprecated (since := "2024-05-05")] theorem forall₂_of_length_eq_of_nthLe {x y}
     (H : x.length = y.length) (H' : ∀ i h₁ h₂, R (x.nthLe i h₁) (y.nthLe i h₂)) :
     Forall₂ R x y := forall₂_of_length_eq_of_get H H'
 #align list.forall₂_of_length_eq_of_nth_le List.forall₂_of_length_eq_of_nthLe
@@ -184,7 +184,7 @@ theorem forall₂_iff_get {l₁ : List α} {l₂ : List β} :
     Forall₂ R l₁ l₂ ↔ l₁.length = l₂.length ∧ ∀ i h₁ h₂, R (l₁.get ⟨i, h₁⟩) (l₂.get ⟨i, h₂⟩) :=
   ⟨fun h => ⟨h.length_eq, h.get⟩, fun h => forall₂_of_length_eq_of_get h.1 h.2⟩
 
-@[deprecated (since:="2024-05-05")] theorem forall₂_iff_nthLe {l₁ : List α} {l₂ : List β} :
+@[deprecated (since := "2024-05-05")] theorem forall₂_iff_nthLe {l₁ : List α} {l₂ : List β} :
     Forall₂ R l₁ l₂ ↔ l₁.length = l₂.length ∧ ∀ i h₁ h₂, R (l₁.nthLe i h₁) (l₂.nthLe i h₂) :=
   forall₂_iff_get
 #align list.forall₂_iff_nth_le List.forall₂_iff_nthLe


### PR DESCRIPTION
Rewrite `List.Forall₂.nthLe` and some related theorems in terms of `get`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I removed them instead of deprecating because these are in a little touched part of mathlib and the build went through with them removed

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
