### PR TITLE
[Merged by Bors] - feat(Mathlib/Order/Ideal): ideals of sets are stable under directed unions and chains

### DIFF
--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -2043,6 +2043,9 @@ theorem directedOn_iUnion {r} {f : ι → Set α} (hd : Directed (· ⊆ ·) f)
     ⟨x, ⟨z, xf⟩, xa₁, xa₂⟩
 #align set.directed_on_Union Set.directedOn_iUnion
 
+@[deprecated (since := "2024-05-05")]
+alias directed_on_iUnion := directedOn_iUnion
+
 theorem directedOn_sUnion {r} {S : Set (Set α)} (hd : DirectedOn (· ⊆ ·) S)
     (h : ∀ x ∈ S, DirectedOn r x) : DirectedOn r (⋃₀ S) := by
   rw [sUnion_eq_iUnion]

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -534,23 +534,6 @@ theorem diff_iInter (s : Set β) (t : ι → Set β) : (s \ ⋂ i, t i) = ⋃ i,
   rw [diff_eq, compl_iInter, inter_iUnion]; rfl
 #align set.diff_Inter Set.diff_iInter
 
-theorem directed_on_iUnion {r} {f : ι → Set α} (hd : Directed (· ⊆ ·) f)
-    (h : ∀ x, DirectedOn r (f x)) : DirectedOn r (⋃ x, f x) := by
-  simp only [DirectedOn, exists_prop, mem_iUnion, exists_imp]
-  exact fun a₁ b₁ fb₁ a₂ b₂ fb₂ =>
-    let ⟨z, zb₁, zb₂⟩ := hd b₁ b₂
-    let ⟨x, xf, xa₁, xa₂⟩ := h z a₁ (zb₁ fb₁) a₂ (zb₂ fb₂)
-    ⟨x, ⟨z, xf⟩, xa₁, xa₂⟩
-#align set.directed_on_Union Set.directed_on_iUnion
-
-theorem directed_on_sUnion {r} {S : Set (Set α)} (hd : DirectedOn (· ⊆ ·) S)
-    (h : ∀ x ∈ S, DirectedOn r x) : DirectedOn r (⋃₀ S) := by
-  simp only [DirectedOn, mem_sUnion, exists_imp]
-  exact fun a₁ b₁ ⟨hb₁, ha₁⟩ a₂ b₂ ⟨hb₂, ha₂⟩ =>
-    let ⟨z, zS, zb₁, zb₂⟩ := hd b₁ hb₁ b₂ hb₂
-    let ⟨x, xz, xa₁, xa₂⟩ := (h z zS) a₁ (zb₁ ha₁) a₂ (zb₂ ha₂)
-    ⟨x, ⟨⟨z, ⟨zS, xz⟩⟩, xa₁, xa₂⟩⟩
-
 theorem iUnion_inter_subset {ι α} {s t : ι → Set α} : ⋃ i, s i ∩ t i ⊆ (⋃ i, s i) ∩ ⋃ i, t i :=
   le_iSup_inf_iSup s t
 #align set.Union_inter_subset Set.iUnion_inter_subset
@@ -2048,6 +2031,24 @@ theorem iUnion_univ_pi {ι : α → Type*} (t : (a : α) → ι a → Set (π a)
 #align set.Union_univ_pi Set.iUnion_univ_pi
 
 end Pi
+
+section Directed
+
+theorem directedOn_iUnion {r} {f : ι → Set α} (hd : Directed (· ⊆ ·) f)
+    (h : ∀ x, DirectedOn r (f x)) : DirectedOn r (⋃ x, f x) := by
+  simp only [DirectedOn, exists_prop, mem_iUnion, exists_imp]
+  exact fun a₁ b₁ fb₁ a₂ b₂ fb₂ =>
+    let ⟨z, zb₁, zb₂⟩ := hd b₁ b₂
+    let ⟨x, xf, xa₁, xa₂⟩ := h z a₁ (zb₁ fb₁) a₂ (zb₂ fb₂)
+    ⟨x, ⟨z, xf⟩, xa₁, xa₂⟩
+#align set.directed_on_Union Set.directedOn_iUnion
+
+theorem directedOn_sUnion {r} {S : Set (Set α)} (hd : DirectedOn (· ⊆ ·) S)
+    (h : ∀ x ∈ S, DirectedOn r x) : DirectedOn r (⋃₀ S) := by
+  rw [sUnion_eq_iUnion]
+  exact directedOn_iUnion (directedOn_iff_directed.mp hd) (fun i ↦ h i.1 i.2)
+
+end Directed
 
 end Set
 

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -543,6 +543,14 @@ theorem directed_on_iUnion {r} {f : ι → Set α} (hd : Directed (· ⊆ ·) f)
     ⟨x, ⟨z, xf⟩, xa₁, xa₂⟩
 #align set.directed_on_Union Set.directed_on_iUnion
 
+theorem directed_on_sUnion {r} {S : Set (Set α)} (hd : DirectedOn (· ⊆ ·) S)
+    (h : ∀ x ∈ S, DirectedOn r x) : DirectedOn r (⋃₀ S) := by
+  simp only [DirectedOn, mem_sUnion, exists_imp]
+  exact fun a₁ b₁ ⟨hb₁, ha₁⟩ a₂ b₂ ⟨hb₂, ha₂⟩ =>
+    let ⟨z, zS, zb₁, zb₂⟩ := hd b₁ hb₁ b₂ hb₂
+    let ⟨x, xz, xa₁, xa₂⟩ := (h z zS) a₁ (zb₁ ha₁) a₂ (zb₂ ha₂)
+    ⟨x, ⟨⟨z, ⟨zS, xz⟩⟩, xa₁, xa₂⟩⟩
+
 theorem iUnion_inter_subset {ι α} {s t : ι → Set α} : ⋃ i, s i ∩ t i ⊆ (⋃ i, s i) ∩ ⋃ i, t i :=
   le_iSup_inf_iSup s t
 #align set.Union_inter_subset Set.iUnion_inter_subset

--- a/Mathlib/Order/Ideal.lean
+++ b/Mathlib/Order/Ideal.lean
@@ -609,7 +609,7 @@ variable [Preorder P]
 lemma isIdeal_sUnion_of_directedOn {C : Set (Set P)} (hidl : ∀ I ∈ C, IsIdeal I)
     (hD : DirectedOn (· ⊆ ·) C) (hNe : C.Nonempty) : IsIdeal C.sUnion := by
   refine ⟨isLowerSet_sUnion (fun I hI ↦ (hidl I hI).1), Set.nonempty_sUnion.2 ?_,
-  directedOn_sUnion hD (fun J hJ => (hidl J hJ).3)⟩
+    directedOn_sUnion hD (fun J hJ => (hidl J hJ).3)⟩
   let ⟨I, hI⟩ := hNe
   exact ⟨I, ⟨hI, (hidl I hI).2⟩⟩
 

--- a/Mathlib/Order/Ideal.lean
+++ b/Mathlib/Order/Ideal.lean
@@ -606,7 +606,7 @@ section sUnion
 variable [Preorder P]
 
 /-- A non-empty directed union of ideals of sets in a preorder is an ideal. -/
-lemma isIdeal_sUnion_directed {C : Set (Set P)} (hidl : ∀ I ∈ C, IsIdeal I)
+lemma isIdeal_sUnion_of_directedOn {C : Set (Set P)} (hidl : ∀ I ∈ C, IsIdeal I)
     (hD : DirectedOn (· ⊆ ·) C) (hNe : C.Nonempty) : IsIdeal C.sUnion := by
   refine ⟨isLowerSet_sUnion (fun I hI ↦ (hidl I hI).1), Set.nonempty_sUnion.2 ?_,
   directedOn_sUnion hD (fun J hJ => (hidl J hJ).3)⟩
@@ -614,9 +614,9 @@ lemma isIdeal_sUnion_directed {C : Set (Set P)} (hidl : ∀ I ∈ C, IsIdeal I)
   exact ⟨I, ⟨hI, (hidl I hI).2⟩⟩
 
 /-- A union of a nonempty chain of ideals of sets is an ideal. -/
-lemma isIdeal_sUnion_nechain {C : Set (Set P)} (hidl : ∀ I ∈ C, IsIdeal I)
-    (hC : IsChain (· ⊆ ·) C) (hne : C.Nonempty) : IsIdeal C.sUnion :=
-  isIdeal_sUnion_directed hidl hC.directedOn hne
+lemma isIdeal_sUnion_of_isChain {C : Set (Set P)} (hidl : ∀ I ∈ C, IsIdeal I)
+    (hC : IsChain (· ⊆ ·) C) (hNe : C.Nonempty) : IsIdeal C.sUnion :=
+  isIdeal_sUnion_of_directedOn hidl hC.directedOn hNe
 
 end sUnion
 end Order

--- a/Mathlib/Order/Ideal.lean
+++ b/Mathlib/Order/Ideal.lean
@@ -609,7 +609,7 @@ variable [Preorder P]
 lemma isIdeal_sUnion_directed {C : Set (Set P)} (hidl : ∀ I ∈ C, IsIdeal I)
     (hD : DirectedOn (· ⊆ ·) C) (hNe : C.Nonempty) : IsIdeal C.sUnion := by
   refine ⟨isLowerSet_sUnion (fun I hI ↦ (hidl I hI).1), Set.nonempty_sUnion.2 ?_,
-  directed_on_sUnion hD (fun J hJ => (hidl J hJ).3)⟩
+  directedOn_sUnion hD (fun J hJ => (hidl J hJ).3)⟩
   let ⟨I, hI⟩ := hNe
   exact ⟨I, ⟨hI, (hidl I hI).2⟩⟩
 

--- a/Mathlib/Order/Ideal.lean
+++ b/Mathlib/Order/Ideal.lean
@@ -5,6 +5,7 @@ Authors: David Wärn
 -/
 import Mathlib.Logic.Encodable.Basic
 import Mathlib.Order.Atoms
+import Mathlib.Order.Chain
 import Mathlib.Order.UpperLower.Basic
 import Mathlib.Data.Set.Subsingleton
 
@@ -600,4 +601,22 @@ theorem cofinal_meets_idealOfCofinals (i : ι) : ∃ x : P, x ∈ 𝒟 i ∧ x �
 
 end IdealOfCofinals
 
+section sUnion
+
+variable [Preorder P]
+
+/-- A non-empty directed union of ideals of sets in a preorder is an ideal. -/
+lemma isIdeal_sUnion_directed {C : Set (Set P)} (hidl : ∀ I ∈ C, IsIdeal I)
+    (hD : DirectedOn (· ⊆ ·) C) (hNe : C.Nonempty) : IsIdeal C.sUnion := by
+  refine ⟨isLowerSet_sUnion (fun I hI ↦ (hidl I hI).1), Set.nonempty_sUnion.2 ?_,
+  directed_on_sUnion hD (fun J hJ => (hidl J hJ).3)⟩
+  let ⟨I, hI⟩ := hNe
+  exact ⟨I, ⟨hI, (hidl I hI).2⟩⟩
+
+/-- A union of a nonempty chain of ideals of sets is an ideal. -/
+lemma isIdeal_sUnion_nechain {C : Set (Set P)} (hidl : ∀ I ∈ C, IsIdeal I)
+    (hC : IsChain (· ⊆ ·) C) (hne : C.Nonempty) : IsIdeal C.sUnion :=
+  isIdeal_sUnion_directed hidl hC.directedOn hne
+
+end sUnion
 end Order


### PR DESCRIPTION
We prove that the directed union of a non-empty directed union of ideals of subsets of a preorder is an ideal, and in particular ideals of subsets of a preorder are stable under unions. In order to prove it, we also add `directed_on_sUnion`, a variant of `directed_on_iUnion`. 

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
