### PR TITLE
[Merged by Bors] - feat: More ways of bijecting finsets

### DIFF
--- a/Archive/Wiedijk100Theorems/Partition.lean
+++ b/Archive/Wiedijk100Theorems/Partition.lean
@@ -201,8 +201,8 @@ theorem partialGF_prop (α : Type*) [CommSemiring α] (n : ℕ) (s : Finset ℕ)
         simp only [smul_eq_mul, ne_eq, mul_eq_zero, Multiset.count_eq_zero]
         rw [not_or, not_not]
         simp only [Multiset.mem_toFinset, not_not, mem_filter] }
-  refine Finset.card_congr φ ?_ ?_ ?_
-  · intro a  ha
+  refine Finset.card_bij φ ?_ ?_ ?_
+  · intro a ha
     simp only [φ, not_forall, not_exists, not_and, exists_prop, mem_filter]
     rw [mem_piAntidiagonal']
     dsimp only [ne_eq, smul_eq_mul, id_eq, eq_mpr_eq_cast, le_eq_subset, Finsupp.coe_mk]
@@ -221,7 +221,7 @@ theorem partialGF_prop (α : Type*) [CommSemiring α] (n : ℕ) (s : Finset ℕ)
         apply ha.2
     · exact fun i _ => ⟨Multiset.count i a.parts, ha.1 i, rfl⟩
   · dsimp only
-    intro p₁ p₂ hp₁ hp₂ h
+    intro p₁ hp₁ p₂ hp₂ h
     apply Nat.Partition.ext
     simp only [true_and_iff, mem_univ, mem_filter] at hp₁ hp₂
     ext i

--- a/Mathlib/Combinatorics/Additive/Energy.lean
+++ b/Mathlib/Combinatorics/Additive/Energy.lean
@@ -134,9 +134,8 @@ variable {s t}
 #align finset.additive_energy_eq_zero_iff Finset.addEnergy_eq_zero_iff
 
 @[to_additive] lemma mulEnergy_eq_card_filter (s t : Finset α) :
-    Eₘ[s, t] = (((s ×ˢ t) ×ˢ s ×ˢ t).filter fun ((a, b), c, d) ↦ a * b = c * d).card := by
-  refine Finset.card_congr (fun ((a, b), c, d) _ ↦ ((a, c), b, d)) (by aesop) (by aesop)
-    fun ((a, b), c, d) h ↦ ⟨((a, c), b, d), by simpa [and_and_and_comm] using h⟩
+    Eₘ[s, t] = (((s ×ˢ t) ×ˢ s ×ˢ t).filter fun ((a, b), c, d) ↦ a * b = c * d).card :=
+  card_equiv (.prodProdProdComm _ _ _ _) (by simp [and_and_and_comm])
 
 @[to_additive] lemma mulEnergy_eq_sum_sq' (s t : Finset α) :
     Eₘ[s, t] = ∑ a in s * t, ((s ×ˢ t).filter fun (x, y) ↦ x * y = a).card ^ 2 := by

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -166,15 +166,15 @@ lemma IsTree.card_edgeFinset [Fintype V] [Fintype G.edgeSet] (hG : G.IsTree) :
     rw [Finset.card_compl, Finset.card_singleton, Nat.sub_add_cancel Fintype.card_pos]
   rw [← this, add_left_inj]
   choose f hf hf' using (hG.existsUnique_path · default)
-  refine Eq.symm <| Finset.card_congr
+  refine Eq.symm <| Finset.card_bij
           (fun w hw => ((f w).firstDart <| ?notNil).edge)
           (fun a ha => ?memEdges) ?inj ?surj
   case notNil => exact not_nil_of_ne (by simpa using hw)
   case memEdges => simp
   case inj =>
-    intros a b ha hb h
+    intros a ha b hb h
     wlog h' : (f a).length ≤ (f b).length generalizing a b
-    · exact Eq.symm (this _ _ hb ha h.symm (le_of_not_le h'))
+    · exact Eq.symm (this _ hb _ ha h.symm (le_of_not_le h'))
     rw [dart_edge_eq_iff] at h
     obtain (h | h) := h
     · exact (congrArg (·.fst) h)

--- a/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
@@ -118,8 +118,8 @@ theorem sum_degrees_eq_twice_card_edges : ∑ v, G.degree v = 2 * G.edgeFinset.c
 lemma two_mul_card_edgeFinset :
     2 * G.edgeFinset.card = (univ.filter fun (x, y) ↦ G.Adj x y).card := by
   rw [← dart_card_eq_twice_card_edges, ← card_univ]
-  refine card_congr (fun d _ ↦ (d.fst, d.snd)) (by simp) (by simp [Dart.ext_iff, ← and_imp]) ?_
-  exact fun xy h ↦ ⟨⟨xy, (mem_filter.1 h).2⟩, mem_univ _, Prod.mk.eta⟩
+  refine card_bij' (fun d _ ↦ (d.fst, d.snd)) (fun xy h ↦ ⟨xy, (mem_filter.1 h).2⟩) ?_ ?_ ?_ ?_
+    <;> simp
 
 end DegreeSum
 

--- a/Mathlib/Combinatorics/SimpleGraph/Density.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Density.lean
@@ -281,7 +281,7 @@ theorem mk_mem_interedges_comm : (a, b) ∈ interedges r s t ↔ (b, a) ∈ inte
 #align rel.mk_mem_interedges_comm Rel.mk_mem_interedges_comm
 
 theorem card_interedges_comm (s t : Finset α) : (interedges r s t).card = (interedges r t s).card :=
-  Finset.card_congr (fun (x : α × α) _ ↦ x.swap) (fun _ ↦ (swap_mem_interedges_iff hr).2)
+  Finset.card_bij (fun (x : α × α) _ ↦ x.swap) (fun _ ↦ (swap_mem_interedges_iff hr).2)
     (fun _ _ _ _ h ↦ Prod.swap_injective h) fun x h ↦
     ⟨x.swap, (swap_mem_interedges_iff hr).2 h, x.swap_swap⟩
 #align rel.card_interedges_comm Rel.card_interedges_comm

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -355,23 +355,88 @@ theorem card_eq_of_bijective (f : ∀ i, i < n → α) (hf : ∀ a ∈ s, ∃ i,
   exact Subtype.eq <| f_inj i j (mem_range.1 hi) (mem_range.1 hj) eq
 #align finset.card_eq_of_bijective Finset.card_eq_of_bijective
 
-theorem card_congr {t : Finset β} (f : ∀ a ∈ s, β) (h₁ : ∀ a ha, f a ha ∈ t)
-    (h₂ : ∀ a b ha hb, f a ha = f b hb → a = b) (h₃ : ∀ b ∈ t, ∃ a ha, f a ha = b) :
-    s.card = t.card := by
+section bij
+variable {t : Finset β}
+
+/-- Reorder a finset.
+
+The difference with `Finset.card_bij'` is that the bijection is specified as a surjective injection,
+rather than by an inverse function.
+
+The difference with `Finset.card_nbij` is that the bijection is allowed to use membership of the
+domain, rather than being a non-dependent function. -/
+lemma card_bij (i : ∀ a ∈ s, β) (hi : ∀ a ha, i a ha ∈ t)
+    (i_inj : ∀ a₁ ha₁ a₂ ha₂, i a₁ ha₁ = i a₂ ha₂ → a₁ = a₂)
+    (i_surj : ∀ b ∈ t, ∃ a ha, i a ha = b) : s.card = t.card := by
   classical
   calc
     s.card = s.attach.card := card_attach.symm
-    _      = (s.attach.image fun a : { a // a ∈ s } => f a.1 a.2).card := Eq.symm ?_
+    _      = (s.attach.image fun a : { a // a ∈ s } => i a.1 a.2).card := Eq.symm ?_
     _      = t.card := ?_
   · apply card_image_of_injective
     intro ⟨_, _⟩ ⟨_, _⟩ h
-    simpa using h₂ _ _ _ _ h
+    simpa using i_inj _ _ _ _ h
   · congr 1
     ext b
-    constructor
-    · intro h; obtain ⟨_, _, rfl⟩ := mem_image.1 h; apply h₁
-    · intro h; obtain ⟨a, ha, rfl⟩ := h₃ b h; exact mem_image.2 ⟨⟨a, ha⟩, by simp⟩
-#align finset.card_congr Finset.card_congr
+    constructor <;> intro h
+    · obtain ⟨_, _, rfl⟩ := mem_image.1 h; apply hi
+    · obtain ⟨a, ha, rfl⟩ := i_surj b h; exact mem_image.2 ⟨⟨a, ha⟩, by simp⟩
+#align finset.card_bij Finset.card_bij
+
+@[deprecated (since := "2024-05-04")] alias card_congr := card_bij
+
+/-- Reorder a finset.
+
+The difference with `Finset.card_bij` is that the bijection is specified with an inverse, rather
+than as a surjective injection.
+
+The difference with `Finset.card_nbij'` is that the bijection and its inverse are allowed to use
+membership of the domains, rather than being non-dependent functions. -/
+lemma card_bij' (i : ∀ a ∈ s, β) (j : ∀ a ∈ t, α) (hi : ∀ a ha, i a ha ∈ t)
+    (hj : ∀ a ha, j a ha ∈ s) (left_inv : ∀ a ha, j (i a ha) (hi a ha) = a)
+    (right_inv : ∀ a ha, i (j a ha) (hj a ha) = a) : s.card = t.card := by
+  refine card_bij i hi (fun a1 h1 a2 h2 eq ↦ ?_) (fun b hb ↦ ⟨_, hj b hb, right_inv b hb⟩)
+  rw [← left_inv a1 h1, ← left_inv a2 h2]
+  simp only [eq]
+
+/-- Reorder a finset.
+
+The difference with `Finset.card_nbij'` is that the bijection is specified as a surjective
+injection, rather than by an inverse function.
+
+The difference with `Finset.card_bij` is that the bijection is a non-dependent function, rather than
+being allowed to use membership of the domain. -/
+lemma card_nbij (i : α → β) (hi : ∀ a ∈ s, i a ∈ t) (i_inj : (s : Set α).InjOn i)
+    (i_surj : (s : Set α).SurjOn i t) : s.card = t.card :=
+  card_bij (fun a _ ↦ i a) hi i_inj (by simpa using i_surj)
+
+/-- Reorder a finset.
+
+The difference with `Finset.card_nbij` is that the bijection is specified with an inverse, rather
+than as a surjective injection.
+
+The difference with `Finset.card_bij'` is that the bijection and its inverse are non-dependent
+functions, rather than being allowed to use membership of the domains.
+
+The difference with `Finset.card_equiv` is that bijectivity is only required to hold on the domains,
+rather than on the entire types. -/
+lemma card_nbij' (i : α → β) (j : β → α) (hi : ∀ a ∈ s, i a ∈ t) (hj : ∀ a ∈ t, j a ∈ s)
+    (left_inv : ∀ a ∈ s, j (i a) = a) (right_inv : ∀ a ∈ t, i (j a) = a) : s.card = t.card :=
+  card_bij' (fun a _ ↦ i a) (fun b _ ↦ j b) hi hj left_inv right_inv
+
+/-- Specialization of `Finset.card_nbij'` that automatically fills in most arguments.
+
+See `Fintype.card_equiv` for the version where `s` and `t` are `univ`. -/
+lemma card_equiv (e : α ≃ β) (hst : ∀ i, i ∈ s ↔ e i ∈ t) : s.card = t.card := by
+  refine card_nbij' e e.symm ?_ ?_ ?_ ?_ <;> simp [hst]
+
+/-- Specialization of `Finset.card_nbij` that automatically fills in most arguments.
+
+See `Fintype.card_bijective` for the version where `s` and `t` are `univ`. -/
+lemma card_bijective (e : α → β) (he : e.Bijective) (hst : ∀ i, i ∈ s ↔ e i ∈ t) :
+    s.card = t.card := card_equiv (.ofBijective e he) hst
+
+end bij
 
 theorem card_le_card_of_inj_on {t : Finset β} (f : α → β) (hf : ∀ a ∈ s, f a ∈ t)
     (f_inj : ∀ a₁ ∈ s, ∀ a₂ ∈ s, f a₁ = f a₂ → a₁ = a₂) : s.card ≤ t.card := by

--- a/Mathlib/Data/Nat/Totient.lean
+++ b/Mathlib/Data/Nat/Totient.lean
@@ -156,7 +156,7 @@ theorem totient_div_of_dvd {n d : ℕ} (hnd : d ∣ n) :
   rcases d.eq_zero_or_pos with (rfl | hd0); · simp [eq_zero_of_zero_dvd hnd]
   rcases hnd with ⟨x, rfl⟩
   rw [Nat.mul_div_cancel_left x hd0]
-  apply Finset.card_congr fun k _ => d * k
+  apply Finset.card_bij fun k _ => d * k
   · simp only [mem_filter, mem_range, and_imp, Coprime]
     refine fun a ha1 ha2 => ⟨(mul_lt_mul_left hd0).2 ha1, ?_⟩
     rw [gcd_mul_left, ha2, mul_one]

--- a/Mathlib/Data/Sym/Card.lean
+++ b/Mathlib/Data/Sym/Card.lean
@@ -110,7 +110,9 @@ theorem card_sym_fin_eq_multichoose : ∀ n k : ℕ, card (Sym (Fin n) k) = mult
 theorem card_sym_eq_multichoose (α : Type*) (k : ℕ) [Fintype α] [Fintype (Sym α k)] :
     card (Sym α k) = multichoose (card α) k := by
   rw [← card_sym_fin_eq_multichoose]
-  exact card_congr (equivCongr (equivFin α))
+  -- FIXME: Without the `Fintype` namespace, why does it complain about `Finset.card_congr` being
+  -- deprecated?
+  exact Fintype.card_congr (equivCongr (equivFin α))
 #align sym.card_sym_eq_multichoose Sym.card_sym_eq_multichoose
 
 /-- The *stars and bars* lemma: the cardinality of `Sym α k` is equal to

--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -745,18 +745,16 @@ theorem IsCycle.isConj (hσ : IsCycle σ) (hτ : IsCycle τ) (h : σ.support.car
 #align equiv.perm.is_cycle.is_conj Equiv.Perm.IsCycle.isConj
 
 theorem IsCycle.isConj_iff (hσ : IsCycle σ) (hτ : IsCycle τ) :
-    IsConj σ τ ↔ σ.support.card = τ.support.card :=
-  ⟨by
-    intro h
+    IsConj σ τ ↔ σ.support.card = τ.support.card where
+  mp h := by
     obtain ⟨π, rfl⟩ := (_root_.isConj_iff).1 h
-    refine Finset.card_congr (fun a _ => π a) (fun _ ha => ?_) (fun _ _ _ _ ab => π.injective ab)
-        fun b hb => ?_
+    refine Finset.card_bij (fun a _ => π a) (fun _ ha => ?_) (fun _ _ _ _ ab => π.injective ab)
+        fun b hb ↦ ⟨π⁻¹ b, ?_, π.apply_inv_self b⟩
     · simp [mem_support.1 ha]
-    · refine ⟨π⁻¹ b, ⟨?_, π.apply_inv_self b⟩⟩
-      contrapose! hb
-      rw [mem_support, Classical.not_not] at hb
-      rw [mem_support, Classical.not_not, Perm.mul_apply, Perm.mul_apply, hb, Perm.apply_inv_self],
-    hσ.isConj hτ⟩
+    contrapose! hb
+    rw [mem_support, Classical.not_not] at hb
+    rw [mem_support, Classical.not_not, Perm.mul_apply, Perm.mul_apply, hb, Perm.apply_inv_self]
+  mpr := hσ.isConj hτ
 #align equiv.perm.is_cycle.is_conj_iff Equiv.Perm.IsCycle.isConj_iff
 
 end Conjugation

--- a/Mathlib/NumberTheory/LegendreSymbol/GaussEisensteinLemmas.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/GaussEisensteinLemmas.lean
@@ -181,16 +181,11 @@ private theorem sum_Ico_eq_card_lt {p q : ℕ} :
             _ ≤ _ := Nat.div_mul_div_le_div _ _ _
       _ = _ := by
         rw [← card_sigma]
-        exact card_congr (fun a _ => ⟨a.1, a.2⟩) (by
-          simp (config := { contextual := true }) only [mem_filter, mem_sigma, and_self_iff,
+        exact card_nbij' (fun a ↦ ⟨a.1, a.2⟩) (fun a ↦ ⟨a.1, a.2⟩)
+          (by simp (config := { contextual := true }) only [mem_filter, mem_sigma, and_self_iff,
             forall_true_iff, mem_product])
-          (fun ⟨_, _⟩ ⟨_, _⟩ => by
-            simp (config := { contextual := true }) only [Prod.mk.inj_iff, eq_self_iff_true,
-              and_self_iff, heq_iff_eq, forall_true_iff])
-          fun ⟨b₁, b₂⟩ h => ⟨⟨b₁, b₂⟩, by
-            revert h
-            simp (config := { contextual := true }) only [mem_filter, eq_self_iff_true,
-              exists_prop_of_true, mem_sigma, and_self_iff, forall_true_iff, mem_product]⟩
+          (by simp (config := { contextual := true }) only [mem_filter, mem_sigma, and_self_iff,
+            forall_true_iff, mem_product]) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 /-- Each of the sums in this lemma is the cardinality of the set of integer points in each of the
   two triangles formed by the diagonal of the rectangle `(0, p/2) × (0, q/2)`. Adding them
@@ -202,17 +197,10 @@ theorem sum_mul_div_add_sum_mul_div_eq_mul (p q : ℕ) [hp : Fact p.Prime] (hq0 
     ((Ico 1 (q / 2).succ ×ˢ Ico 1 (p / 2).succ).filter fun x : ℕ × ℕ => x.2 * q ≤ x.1 * p).card =
       ((Ico 1 (p / 2).succ ×ˢ Ico 1 (q / 2).succ).filter fun x : ℕ × ℕ =>
         x.1 * q ≤ x.2 * p).card :=
-    card_congr (fun x _ => Prod.swap x)
+    card_equiv (Equiv.prodComm _ _)
       (fun ⟨_, _⟩ => by
         simp (config := { contextual := true }) only [mem_filter, and_self_iff, Prod.swap_prod_mk,
-          forall_true_iff, mem_product])
-      (fun ⟨_, _⟩ ⟨_, _⟩ => by
-        simp (config := { contextual := true }) only [Prod.mk.inj_iff, eq_self_iff_true,
-          and_self_iff, Prod.swap_prod_mk, forall_true_iff])
-      fun ⟨x₁, x₂⟩ h => ⟨⟨x₂, x₁⟩, by
-        revert h
-        simp (config := { contextual := true }) only [mem_filter, eq_self_iff_true, and_self_iff,
-          exists_prop_of_true, Prod.swap_prod_mk, forall_true_iff, mem_product]⟩
+          forall_true_iff, mem_product, Equiv.prodComm_apply, and_assoc, and_left_comm])
   have hdisj :
     Disjoint ((Ico 1 (p / 2).succ ×ˢ Ico 1 (q / 2).succ).filter fun x : ℕ × ℕ => x.2 * p ≤ x.1 * q)
       ((Ico 1 (p / 2).succ ×ˢ Ico 1 (q / 2).succ).filter fun x : ℕ × ℕ => x.1 * q ≤ x.2 * p) := by

--- a/Mathlib/RingTheory/Discriminant.lean
+++ b/Mathlib/RingTheory/Discriminant.lean
@@ -197,7 +197,9 @@ theorem discr_powerBasis_eq_prod'' [IsSeparable K L] (e : Fin pb.dim ≃ (L →�
   rw [← Nat.cast_sum, ← @Finset.sum_range ℕ _ pb.dim fun i => i, sum_range_id]
   have hn : n = pb.dim := by
     rw [← AlgHom.card K L E, ← Fintype.card_fin pb.dim]
-    exact card_congr (Equiv.symm e)
+    -- FIXME: Without the `Fintype` namespace, why does it complain about `Finset.card_congr` being
+    -- deprecated?
+    exact Fintype.card_congr e.symm
   have h₂ : 2 ∣ pb.dim * (pb.dim - 1) := pb.dim.even_mul_pred_self.two_dvd
   have hne : ((2 : ℕ) : ℚ) ≠ 0 := by simp
   have hle : 1 ≤ pb.dim := by

--- a/Mathlib/RingTheory/IntegralDomain.lean
+++ b/Mathlib/RingTheory/IntegralDomain.lean
@@ -198,19 +198,7 @@ theorem card_fiber_eq_of_mem_range {H : Type*} [Group H] [DecidableEq H] (f : G 
     (univ.filter fun g => f g = x).card = (univ.filter fun g => f g = y).card := by
   rcases hx with ⟨x, rfl⟩
   rcases hy with ⟨y, rfl⟩
-  refine card_congr (fun g _ => g * x⁻¹ * y) ?_ ?_ fun g hg => ⟨g * y⁻¹ * x, ?_⟩
-  · simp (config := { contextual := true }) only [*, mem_filter, one_mul, MonoidHom.map_mul,
-      mem_univ, mul_right_inv, eq_self_iff_true, MonoidHom.map_mul_inv, and_self_iff,
-      forall_true_iff]
-    -- Porting note: added the following `simp`
-    simp only [true_and, map_inv, mul_right_inv, one_mul, and_self, implies_true, forall_const]
-  · simp only [mul_left_inj, imp_self, forall₂_true_iff]
-  · simp only [true_and_iff, mem_filter, mem_univ] at hg
-    simp only [hg, mem_filter, one_mul, MonoidHom.map_mul, mem_univ, mul_right_inv,
-      eq_self_iff_true, exists_prop_of_true, MonoidHom.map_mul_inv, and_self_iff,
-      mul_inv_cancel_right, inv_mul_cancel_right]
-    -- Porting note: added the next line.  It is weird!
-    simp only [map_inv, mul_right_inv, one_mul, and_self, exists_prop]
+  exact card_equiv (Equiv.mulRight (x⁻¹ * y)) (by simp [mul_inv_eq_one])
 #align card_fiber_eq_of_mem_range card_fiber_eq_of_mem_range
 
 /-- In an integral domain, a sum indexed by a nontrivial homomorphism from a finite group is zero.

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -952,13 +952,13 @@ theorem card_primitiveRoots {ζ : R} {k : ℕ} (h : IsPrimitiveRoot ζ k) :
   by_cases h0 : k = 0
   · simp [h0]
   symm
-  refine Finset.card_congr (fun i _ => ζ ^ i) ?_ ?_ ?_
+  refine Finset.card_bij (fun i _ ↦ ζ ^ i) ?_ ?_ ?_
   · simp only [true_and_iff, and_imp, mem_filter, mem_range, mem_univ]
     rintro i - hi
     rw [mem_primitiveRoots (Nat.pos_of_ne_zero h0)]
     exact h.pow_of_coprime i hi.symm
   · simp only [true_and_iff, and_imp, mem_filter, mem_range, mem_univ]
-    rintro i j hi - hj - H
+    rintro i hi - j hj - H
     exact h.pow_inj hi hj H
   · simp only [exists_prop, true_and_iff, mem_filter, mem_range, mem_univ]
     intro ξ hξ


### PR DESCRIPTION
It is still annoyingly painful to prove that two finsets have equal size by exhibiting a bijection between. This PR remedies this problem by copying over the lemmas that show that two finite sums/products are in bijection. Copy over the names. As a result, rename `Finset.card_congr` to `Finset.card_bij`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
