### PR TITLE
[Merged by Bors] - chore: add flexible tactics to nonterminal simp linter

### DIFF
--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -203,6 +203,8 @@ def four_spaces_in_second_line(lines, path):
         newlines.append((next_line_nr, new_next_line))
     return errors, newlines
 
+flexible_tactics = ["rfl", "ring", "aesop", "norm_num", "positivity", "abel", "omega"]
+
 def nonterminal_simp_check(lines, path):
     errors = []
     newlines = []
@@ -219,7 +221,8 @@ def nonterminal_simp_check(lines, path):
             num_spaces = len(line) - len(line.lstrip())
             # Calculate the number of spaces before the first non-space character in the next line
             stripped_next_line = next_line.lstrip()
-            if not (next_line == '\n' or next_line.startswith("#") or stripped_next_line.startswith("--") or "rfl" in next_line or "aesop" in next_line):
+
+            if not (next_line == '\n' or next_line.startswith("#") or stripped_next_line.startswith("--") or any(f in next_line for f in flexible_tactics)):
                 num_next_spaces = len(next_line) - len(stripped_next_line)
                 # Check if the number of leading spaces is the same
                 if num_spaces == num_next_spaces:

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -203,7 +203,7 @@ def four_spaces_in_second_line(lines, path):
         newlines.append((next_line_nr, new_next_line))
     return errors, newlines
 
-flexible_tactics = ["rfl", "ring", "aesop", "norm_num", "positivity", "abel", "omega"]
+flexible_tactics = ["rfl", "ring", "aesop", "norm_num", "positivity", "abel", "omega", "linarith", "nlinarith"]
 
 def nonterminal_simp_check(lines, path):
     errors = []


### PR DESCRIPTION
This PR makes it so that the existing string-based nonterminal simp linter will not trigger when a simp is followed by one of a few "flexible" tactics.

See [this](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/False.20ERR_NSP.20positive/near/437054148) thread for discussion of places where this linter was being too sensitive.

Most of the list was decided by poll [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.60simp.60.20followers).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
