### PR TITLE
[Merged by Bors] - feat(Data/Matroid/*): add `Indep` as a structure field to `Matroid`. 

### DIFF
--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -180,9 +180,9 @@ def Matroid.ExistsMaximalSubsetProperty {α : Type _} (P : Set α → Prop) (X :
   `Base` of `M`. An `Indep`endent set is just a set contained in a base, but we include this
   predicate as a structure field for better definitional properties.
 
-  In most cases, using this definition directly is not the best way to define a matroid,
+  In most cases, using this definition directly is not the best way to construct a matroid,
   since it requires specifying both the bases and independent sets. If the bases are known,
-  use `Matroid.ofBase` or a variant. If just the independent sets are known, use
+  use `Matroid.ofBase` or a variant. If just the independent sets are known,
   define an `IndepMatroid`, and then use `IndepMatroid.matroid`.
   -/
 @[ext] structure Matroid (α : Type _) where

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -190,7 +190,7 @@ def Matroid.ExistsMaximalSubsetProperty {α : Type _} (P : Set α → Prop) (X :
   (E : Set α)
   /-- `M` has a predicate `Base` definining its bases -/
   (Base : Set α → Prop)
-  /-- `M` has a prediate `Indep` defining its independent sets -/
+  /-- `M` has a predicate `Indep` defining its independent sets -/
   (Indep : Set α → Prop)
   /-- the `Indep`endent sets are those contained in `Base`s. -/
   (indep_iff' : ∀ ⦃I⦄, Indep I ↔ ∃ B, Base B ∧ I ⊆ B)

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -177,26 +177,37 @@ def Matroid.ExistsMaximalSubsetProperty {α : Type _} (P : Set α → Prop) (X :
 
 /-- A `Matroid α` is a ground set `E` of type `Set α`, and a nonempty collection of its subsets
   satisfying the exchange property and the maximal subset property. Each such set is called a
-  `Base` of `M`. -/
+  `Base` of `M`. An `Indep`endent set is just a set contained in a base, but we include this
+  predicate as a structure field for better definitional properties.
+
+  In most cases, using this definition directly is not the best way to define a matroid,
+  since it requires specifying both the bases and independent sets. If the bases are known,
+  use `Matroid.ofBase` or a variant. If just the independent sets are known, use
+  define an `IndepMatroid`, and then use `IndepMatroid.matroid`.
+  -/
 @[ext] structure Matroid (α : Type _) where
   /-- `M` has a ground set `E`. -/
   (E : Set α)
   /-- `M` has a predicate `Base` definining its bases -/
   (Base : Set α → Prop)
+  /-- `M` has a prediate `Indep` defining its independent sets -/
+  (Indep : Set α → Prop)
+  /-- the `Indep`endent sets are those contained in `Base`s. -/
+  (indep_iff' : ∀ ⦃I⦄, Indep I ↔ ∃ B, Base B ∧ I ⊆ B)
   /-- There is at least one `Base` -/
   (exists_base : ∃ B, Base B)
   /-- For any bases `B`, `B'` and `e ∈ B \ B'`, there is some `f ∈ B' \ B` for which `B-e+f`
     is a base -/
   (base_exchange : Matroid.ExchangeProperty Base)
-  /-- Every subset `I` of a set `X` for which `I` is contained in a base is contained in a maximal
-    subset of `X` that is contained in a base. -/
-  (maximality : ∀ X, X ⊆ E → Matroid.ExistsMaximalSubsetProperty (∃ B, Base B ∧ · ⊆ B) X)
+  /-- Every independent subset `I` of a set `X` for is contained in a maximal independent
+    subset of `X`. -/
+  (maximality : ∀ X, X ⊆ E → Matroid.ExistsMaximalSubsetProperty Indep X)
   /-- every base is contained in the ground set -/
   (subset_ground : ∀ B, Base B → B ⊆ E)
 
 namespace Matroid
 
-variable {α : Type _} {M : Matroid α}
+variable {α : Type*} {M : Matroid α}
 
 /-- Typeclass for a matroid having finite ground set. Just a wrapper for `M.E.Finite`-/
 protected class Finite (M : Matroid α) : Prop where
@@ -430,11 +441,11 @@ theorem Base.diff_infinite_comm (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) :
   infinite_iff_infinite_of_encard_eq_encard (hB₁.encard_diff_comm hB₂)
 
 theorem eq_of_base_iff_base_forall {M₁ M₂ : Matroid α} (hE : M₁.E = M₂.E)
-    (h : ∀ B, B ⊆ M₁.E → (M₁.Base B ↔ M₂.Base B)) : M₁ = M₂ := by
-  apply Matroid.ext _ _ hE
-  ext B
-  exact ⟨fun h' ↦ (h _ h'.subset_ground).mp h',
-    fun h' ↦ (h _ (h'.subset_ground.trans_eq hE.symm)).mpr h'⟩
+    (h : ∀ ⦃B⦄, B ⊆ M₁.E → (M₁.Base B ↔ M₂.Base B)) : M₁ = M₂ := by
+  have h' : ∀ B, M₁.Base B ↔ M₂.Base B :=
+    fun B ↦ ⟨fun hB ↦ (h hB.subset_ground).1 hB,
+      fun hB ↦ (h <| hB.subset_ground.trans_eq hE.symm).2 hB⟩
+  ext <;> simp [hE, M₁.indep_iff', M₂.indep_iff', h']
 
 theorem base_compl_iff_mem_maximals_disjoint_base (hB : B ⊆ M.E := by aesop_mat) :
     M.Base (M.E \ B) ↔ B ∈ maximals (· ⊆ ·) {I | I ⊆ M.E ∧ ∃ B, M.Base B ∧ Disjoint I B} := by
@@ -453,15 +464,18 @@ theorem base_compl_iff_mem_maximals_disjoint_base (hB : B ⊆ M.E := by aesop_ma
 end Base
 section dep_indep
 
-/-- A set is `Indep`endent if it is contained in a `Base`.  -/
-@[pp_dot] def Indep (M : Matroid α) (I : Set α) : Prop := ∃ B, M.Base B ∧ I ⊆ B
-
 /-- A subset of `M.E` is `Dep`endent if it is not `Indep`endent . -/
-@[pp_dot] def Dep (M : Matroid α) (D : Set α) : Prop := ¬M.Indep D ∧ D ⊆ M.E
+def Dep (M : Matroid α) (D : Set α) : Prop := ¬M.Indep D ∧ D ⊆ M.E
 
-theorem indep_iff_subset_base : M.Indep I ↔ ∃ B, M.Base B ∧ I ⊆ B := Iff.rfl
+theorem indep_iff : M.Indep I ↔ ∃ B, M.Base B ∧ I ⊆ B :=
+  M.indep_iff' (I := I)
 
-theorem setOf_indep_eq (M : Matroid α) : {I | M.Indep I} = lowerClosure ({B | M.Base B}) := rfl
+theorem setOf_indep_eq (M : Matroid α) : {I | M.Indep I} = lowerClosure ({B | M.Base B}) := by
+  simp_rw [indep_iff]
+  rfl
+
+theorem Indep.exists_base_superset (hI : M.Indep I) : ∃ B, M.Base B ∧ I ⊆ B :=
+  indep_iff.1 hI
 
 theorem dep_iff : M.Dep D ↔ ¬M.Indep D ∧ D ⊆ M.E := Iff.rfl
 
@@ -469,7 +483,7 @@ theorem setOf_dep_eq (M : Matroid α) : {D | M.Dep D} = {I | M.Indep I}ᶜ ∩ I
 
 @[aesop unsafe 30% (rule_sets := [Matroid])]
 theorem Indep.subset_ground (hI : M.Indep I) : I ⊆ M.E := by
-  obtain ⟨B, hB, hIB⟩ := hI
+  obtain ⟨B, hB, hIB⟩ := hI.exists_base_superset
   exact hIB.trans hB.subset_ground
 
 @[aesop unsafe 20% (rule_sets := [Matroid])]
@@ -502,24 +516,24 @@ theorem indep_iff_not_dep : M.Indep I ↔ ¬M.Dep I ∧ I ⊆ M.E := by
   rw [dep_iff, not_and, not_imp_not]
   exact ⟨fun h ↦ ⟨fun _ ↦ h, h.subset_ground⟩, fun h ↦ h.1 h.2⟩
 
-theorem Indep.exists_base_superset (hI : M.Indep I) : ∃ B, M.Base B ∧ I ⊆ B :=
-  hI
-
-theorem Indep.subset (hJ : M.Indep J) (hIJ : I ⊆ J) : M.Indep I :=
-  let ⟨B, hB, hJB⟩ := hJ
-  ⟨B, hB, hIJ.trans hJB⟩
+theorem Indep.subset (hJ : M.Indep J) (hIJ : I ⊆ J) : M.Indep I := by
+  obtain ⟨B, hB, hJB⟩ := hJ.exists_base_superset
+  exact indep_iff.2 ⟨B, hB, hIJ.trans hJB⟩
 
 theorem Dep.superset (hD : M.Dep D) (hDX : D ⊆ X) (hXE : X ⊆ M.E := by aesop_mat) : M.Dep X :=
   dep_of_not_indep (fun hI ↦ (hI.subset hDX).not_dep hD)
 
+theorem Base.indep (hB : M.Base B) : M.Indep B :=
+  indep_iff.2 ⟨B, hB, subset_rfl⟩
+
 @[simp] theorem empty_indep (M : Matroid α) : M.Indep ∅ :=
-  Exists.elim M.exists_base (fun B hB ↦ ⟨_, hB, B.empty_subset⟩)
+  Exists.elim M.exists_base (fun _ hB ↦ hB.indep.subset (empty_subset _))
 
 theorem Dep.nonempty (hD : M.Dep D) : D.Nonempty := by
   rw [nonempty_iff_ne_empty]; rintro rfl; exact hD.not_indep M.empty_indep
 
 theorem Indep.finite [FiniteRk M] (hI : M.Indep I) : I.Finite :=
-  let ⟨_, hB, hIB⟩ := hI
+  let ⟨_, hB, hIB⟩ := hI.exists_base_superset
   hB.finite.subset hIB
 
 theorem Indep.rkPos_of_nonempty (hI : M.Indep I) (hne : I.Nonempty) : M.RkPos := by
@@ -535,17 +549,14 @@ theorem Indep.inter_left (hI : M.Indep I) (X : Set α) : M.Indep (X ∩ I) :=
 theorem Indep.diff (hI : M.Indep I) (X : Set α) : M.Indep (I \ X) :=
   hI.subset (diff_subset _ _)
 
-theorem Base.indep (hB : M.Base B) : M.Indep B :=
-  ⟨B, hB, subset_rfl⟩
-
 theorem Base.eq_of_subset_indep (hB : M.Base B) (hI : M.Indep I) (hBI : B ⊆ I) : B = I :=
-  let ⟨B', hB', hB'I⟩ := hI
+  let ⟨B', hB', hB'I⟩ := hI.exists_base_superset
   hBI.antisymm (by rwa [hB.eq_of_subset_base hB' (hBI.trans hB'I)])
 
 theorem base_iff_maximal_indep : M.Base B ↔ M.Indep B ∧ ∀ I, M.Indep I → B ⊆ I → B = I := by
-  refine' ⟨fun h ↦ ⟨h.indep, fun _ ↦ h.eq_of_subset_indep ⟩, fun h ↦ _⟩
-  obtain ⟨⟨B', hB', hBB'⟩, h⟩ := h
-  rwa [h _ hB'.indep hBB']
+  refine' ⟨fun h ↦ ⟨h.indep, fun _ ↦ h.eq_of_subset_indep ⟩, fun ⟨h, h'⟩ ↦ _⟩
+  obtain ⟨B', hB', hBB'⟩ := h.exists_base_superset
+  rwa [h' _ hB'.indep hBB']
 
 theorem setOf_base_eq_maximals_setOf_indep : {B | M.Base B} = maximals (· ⊆ ·) {I | M.Indep I} := by
   ext B; rw [mem_maximals_setOf_iff, mem_setOf, base_iff_maximal_indep]
@@ -603,10 +614,10 @@ theorem Indep.exists_insert_of_not_base (hI : M.Indep I) (hI' : ¬M.Base I) (hB 
   obtain ⟨B', hB', hIB'⟩ := hI.exists_base_superset
   obtain ⟨x, hxB', hx⟩ := exists_of_ssubset (hIB'.ssubset_of_ne (by (rintro rfl; exact hI' hB')))
   obtain (hxB | hxB) := em (x ∈ B)
-  · exact ⟨x, ⟨hxB, hx⟩ , ⟨B', hB', insert_subset hxB' hIB'⟩⟩
+  · exact ⟨x, ⟨hxB, hx⟩, hB'.indep.subset (insert_subset hxB' hIB') ⟩
   obtain ⟨e,he, hBase⟩ := hB'.exchange hB ⟨hxB',hxB⟩
   exact ⟨e, ⟨he.1, not_mem_subset hIB' he.2⟩,
-    ⟨_, hBase, insert_subset_insert (subset_diff_singleton hIB' hx)⟩⟩
+    indep_iff.2 ⟨_, hBase, insert_subset_insert (subset_diff_singleton hIB' hx)⟩⟩
 
 /-- This is the same as `Indep.exists_insert_of_not_base`, but phrased so that
   it is defeq to the augmentation axiom for independent sets. -/
@@ -658,7 +669,7 @@ instance finitary_of_finiteRk {M : Matroid α} [FiniteRk M] : Finitary M :=
   refine fun I hI ↦ I.finite_or_infinite.elim (hI _ Subset.rfl) (fun h ↦ False.elim ?_)
   obtain ⟨B, hB⟩ := M.exists_base
   obtain ⟨I₀, hI₀I, hI₀fin, hI₀card⟩ := h.exists_subset_ncard_eq (B.ncard + 1)
-  obtain ⟨B', hB', hI₀B'⟩ := hI _ hI₀I hI₀fin
+  obtain ⟨B', hB', hI₀B'⟩ := (hI _ hI₀I hI₀fin).exists_base_superset
   have hle := ncard_le_ncard hI₀B' hB'.finite
   rw [hI₀card, hB'.ncard_eq_ncard_of_base hB, Nat.add_one_le_iff] at hle
   exact hle.ne rfl ⟩
@@ -674,12 +685,12 @@ section Basis
 
 /-- A Basis for a set `X ⊆ M.E` is a maximal independent subset of `X`
   (Often in the literature, the word 'Basis' is used to refer to what we call a 'Base'). -/
-@[pp_dot] def Basis (M : Matroid α) (I X : Set α) : Prop :=
+def Basis (M : Matroid α) (I X : Set α) : Prop :=
   I ∈ maximals (· ⊆ ·) {A | M.Indep A ∧ A ⊆ X} ∧ X ⊆ M.E
 
 /-- A `Basis'` is a basis without the requirement that `X ⊆ M.E`. This is convenient for some
   API building, especially when working with rank and closure.  -/
-@[pp_dot] def Basis' (M : Matroid α) (I X : Set α) : Prop :=
+def Basis' (M : Matroid α) (I X : Set α) : Prop :=
   I ∈ maximals (· ⊆ ·) {A | M.Indep A ∧ A ⊆ X}
 
 theorem Basis'.indep (hI : M.Basis' I X) : M.Indep I :=
@@ -845,7 +856,7 @@ theorem Indep.eq_of_basis (hI : M.Indep I) (hJ : M.Basis J I) : J = I :=
   hJ.eq_of_subset_indep hI hJ.subset rfl.subset
 
 theorem Basis.exists_base (hI : M.Basis I X) : ∃ B, M.Base B ∧ I = B ∩ X :=
-  let ⟨B,hB, hIB⟩ := hI.indep
+  let ⟨B,hB, hIB⟩ := hI.indep.exists_base_superset
   ⟨B, hB, subset_antisymm (subset_inter hIB hI.subset)
     (by rw [hI.eq_of_subset_indep (hB.indep.inter_right X) (subset_inter hIB hI.subset)
     (inter_subset_right _ _)])⟩

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -65,8 +65,8 @@ There are a few design decisions worth discussing.
   and that all lack nice properties.
   Many different competing notions of infinite matroid were studied through the years;
   in fact, the problem of which definition is the best was only really solved in 2013,
-  when Bruhn et al. [2] showed that there is a unique 'reasonable' notion of an infinite matroid;
-  these objects had been previously called 'B-matroids'.
+  when Bruhn et al. [2] showed that there is a unique 'reasonable' notion of an infinite matroid
+  (these objects had previously defined by Higgs under the name 'B-matroid').
   These are defined by adding one carefully chosen axiom to the standard set,
   and adapting existing axioms to not mention set cardinalities;
   they enjoy nearly all the nice properties of standard finite matroids.
@@ -188,21 +188,21 @@ def Matroid.ExistsMaximalSubsetProperty {α : Type _} (P : Set α → Prop) (X :
 @[ext] structure Matroid (α : Type _) where
   /-- `M` has a ground set `E`. -/
   (E : Set α)
-  /-- `M` has a predicate `Base` definining its bases -/
+  /-- `M` has a predicate `Base` definining its bases. -/
   (Base : Set α → Prop)
-  /-- `M` has a predicate `Indep` defining its independent sets -/
+  /-- `M` has a predicate `Indep` defining its independent sets. -/
   (Indep : Set α → Prop)
-  /-- the `Indep`endent sets are those contained in `Base`s. -/
+  /-- The `Indep`endent sets are those contained in `Base`s. -/
   (indep_iff' : ∀ ⦃I⦄, Indep I ↔ ∃ B, Base B ∧ I ⊆ B)
-  /-- There is at least one `Base` -/
+  /-- There is at least one `Base`. -/
   (exists_base : ∃ B, Base B)
   /-- For any bases `B`, `B'` and `e ∈ B \ B'`, there is some `f ∈ B' \ B` for which `B-e+f`
-    is a base -/
+    is a base. -/
   (base_exchange : Matroid.ExchangeProperty Base)
   /-- Every independent subset `I` of a set `X` for is contained in a maximal independent
     subset of `X`. -/
   (maximality : ∀ X, X ⊆ E → Matroid.ExistsMaximalSubsetProperty Indep X)
-  /-- every base is contained in the ground set -/
+  /-- Every base is contained in the ground set. -/
   (subset_ground : ∀ B, Base B → B ⊆ E)
 
 namespace Matroid

--- a/Mathlib/Data/Matroid/Dual.lean
+++ b/Mathlib/Data/Matroid/Dual.lean
@@ -119,8 +119,7 @@ def dual (M : Matroid α) : Matroid α := M.dualIndepMatroid.matroid
   (This is distinct from the usual `*` symbol for multiplication, due to precedence issues. )-/
 postfix:max "✶" => Matroid.dual
 
-theorem dual_indep_iff_exists' : (M✶.Indep I) ↔ I ⊆ M.E ∧ (∃ B, M.Base B ∧ Disjoint I B) := by
-  simp [dual]
+theorem dual_indep_iff_exists' : (M✶.Indep I) ↔ I ⊆ M.E ∧ (∃ B, M.Base B ∧ Disjoint I B) := Iff.rfl
 
 @[simp] theorem dual_ground : M✶.E = M.E := rfl
 

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -71,7 +71,7 @@ for the inverse of `e`).
 * `IndepMatroid.ofFinset` constructs an `IndepMatroid α` whose corresponding matroid is `Finitary`
   from an independence predicate on `Finset α`.
 
-* `IndepMatroid.ofExistsMatroid` constructs a 'copy' of a matroid that is known only
+* `Matroid.ofExistsMatroid` constructs a 'copy' of a matroid that is known only
   existentially, but whose independence predicate is known explicitly.
 
 * `Matroid.ofExistsFiniteBase` constructs a matroid from its bases, if it is known that one
@@ -108,6 +108,13 @@ namespace IndepMatroid
 @[simps] protected def matroid (M : IndepMatroid α) : Matroid α where
   E := M.E
   Base := (· ∈ maximals (· ⊆ ·) {I | M.Indep I})
+  Indep := M.Indep
+  indep_iff' := by
+    refine fun I ↦ ⟨fun h ↦ ?_, fun ⟨B,⟨h,_⟩,hIB'⟩ ↦ M.indep_subset h hIB'⟩
+    obtain ⟨B, hB⟩ := M.indep_maximal M.E Subset.rfl I h (M.subset_ground I h)
+    simp only [mem_maximals_iff, mem_setOf_eq, and_imp] at hB ⊢
+    exact ⟨B, ⟨hB.1.1,fun J hJ hBJ ↦ hB.2 hJ (hB.1.2.1.trans hBJ) (M.subset_ground J hJ) hBJ⟩,
+      hB.1.2.1⟩
   exists_base := by
     obtain ⟨B, ⟨hB,-,-⟩, hB₁⟩ :=
       M.indep_maximal M.E rfl.subset ∅ M.indep_empty (empty_subset _)
@@ -130,27 +137,11 @@ namespace IndepMatroid
     obtain rfl := hxB.2.2 hxB.1
     rw [insert_comm, insert_diff_singleton, insert_eq_of_mem he.1] at hind
     exact not_mem_subset (hBmax hind (subset_insert _ _)) hfB' (mem_insert _ _)
-  maximality := by
-    rintro X hXE I ⟨hB, hB, hIB⟩ hIX
-    obtain ⟨J, ⟨hJ, hIJ, hJX⟩, hJmax⟩ := M.indep_maximal X hXE I (M.indep_subset hB.1 hIB) hIX
-    obtain ⟨BJ, hBJ⟩ := M.indep_maximal M.E rfl.subset J hJ (M.subset_ground J hJ)
-    refine' ⟨J, ⟨⟨BJ,_, hBJ.1.2.1⟩ ,hIJ,hJX⟩, _⟩
-    · exact ⟨hBJ.1.1, fun B' hB' hBJB' ↦ hBJ.2 ⟨hB',hBJ.1.2.1.trans hBJB',
-        M.subset_ground _ hB'⟩ hBJB'⟩
-    simp only [maximals, mem_setOf_eq, and_imp, forall_exists_index]
-    rintro A B' (hBi' : M.Indep _) - hB'' hIA hAX hJA
-    simp only [mem_setOf_eq, and_imp] at hJmax
-    exact hJmax (M.indep_subset hBi' hB'') hIA hAX hJA
+  maximality := M.indep_maximal
   subset_ground B hB := M.subset_ground B hB.1
 
 @[simp] theorem matroid_indep_iff {M : IndepMatroid α} {I : Set α} :
-    M.matroid.Indep I ↔ M.Indep I := by
-  simp only [IndepMatroid.matroid, indep_iff_subset_base]
-  refine ⟨fun ⟨_, ⟨hB,_⟩, hIB⟩ ↦ M.indep_subset hB hIB, fun h ↦ ?_⟩
-  obtain ⟨B, hB⟩ := M.indep_maximal _ rfl.subset I h (M.subset_ground _ h)
-  simp only [mem_maximals_setOf_iff, and_imp] at *
-  exact ⟨B, ⟨hB.1.1, fun J hJ hBJ ↦
-    hB.2 hJ (hB.1.2.1.trans hBJ) (M.subset_ground _ hJ) hBJ⟩, hB.1.2.1⟩
+    M.matroid.Indep I ↔ M.Indep I := Iff.rfl
 
 /-- An independence predicate satisfying the finite matroid axioms determines a matroid,
   provided independence is determined by its behaviour on finite sets.
@@ -435,10 +426,19 @@ theorem ofFinset_indep' [DecidableEq α] (E : Set α) Indep indep_empty indep_su
         ∀ (J : Finset α), (J : Set α) ⊆ I → Indep J := by
   simp only [IndepMatroid.ofFinset, ofFinitary_indep]
 
-/-- Construct an `IndepMatroid` from an independence predicate that agrees with that of some
-  matroid `M`. Computable even when `M` is not known constructively. -/
-@[simps E] protected def ofExistsMatroid (E : Set α) (Indep : Set α → Prop)
-    (hM : ∃ (M : Matroid α), E = M.E ∧ ∀ I, M.Indep I ↔ Indep I) : IndepMatroid α :=
+end IndepMatroid
+
+section Base
+
+namespace Matroid
+
+/-- Construct an `Matroid` from an independence predicate that agrees with that of some matroid `M`.
+  This is computable even if `M` is only known existentially, or when `M` exists for different
+  reasons in different cases. This can also be used to change the independence predicate to a
+  more useful definitional form. -/
+@[simps! E] protected def ofExistsMatroid (E : Set α) (Indep : Set α → Prop)
+    (hM : ∃ (M : Matroid α), E = M.E ∧ ∀ I, M.Indep I ↔ Indep I) : Matroid α :=
+  IndepMatroid.matroid <|
   have hex : ∃ (M : Matroid α), E = M.E ∧ M.Indep = Indep := by
     obtain ⟨M, rfl, h⟩ := hM; refine ⟨_, rfl, funext (by simp [h])⟩
   IndepMatroid.mk (E := E) (Indep := Indep)
@@ -448,28 +448,35 @@ theorem ofFinset_indep' [DecidableEq α] (E : Set α) Indep indep_empty indep_su
   (indep_maximal := by obtain ⟨M, rfl, rfl⟩ := hex; exact M.existsMaximalSubsetProperty_indep)
   (subset_ground := by obtain ⟨M, rfl, rfl⟩ := hex; exact fun I ↦ Indep.subset_ground)
 
-end IndepMatroid
-
-section Base
-
-namespace Matroid
-
-/-- A collection of bases with the exchange property and at least one finite member is a matroid -/
-@[simps E] protected def ofExistsFiniteBase (E : Set α) (Base : Set α → Prop)
-    (exists_finite_base : ∃ B, Base B ∧ B.Finite) (base_exchange : ExchangeProperty Base)
+/-- A matroid defined purely in terms of its bases. -/
+@[simps E] protected def ofBase (E : Set α) (Base : Set α → Prop) (exists_base : ∃ B, Base B)
+    (base_exchange : ExchangeProperty Base)
+    (maximality : ∀ X, X ⊆ E → Matroid.ExistsMaximalSubsetProperty (∃ B, Base B ∧ · ⊆ B) X)
     (subset_ground : ∀ B, Base B → B ⊆ E) : Matroid α where
   E := E
   Base := Base
-  exists_base := by
-    obtain ⟨B,h⟩ := exists_finite_base; exact ⟨B, h.1⟩
+  Indep I := (∃ B, Base B ∧ I ⊆ B)
+  indep_iff' _ := Iff.rfl
+  exists_base := exists_base
   base_exchange := base_exchange
-  maximality := by
+  maximality := maximality
+  subset_ground := subset_ground
+
+/-- A collection of bases with the exchange property and at least one finite member is a matroid -/
+@[simps! E] protected def ofExistsFiniteBase (E : Set α) (Base : Set α → Prop)
+    (exists_finite_base : ∃ B, Base B ∧ B.Finite) (base_exchange : ExchangeProperty Base)
+    (subset_ground : ∀ B, Base B → B ⊆ E) : Matroid α := Matroid.ofBase
+  (E := E)
+  (Base := Base)
+  (exists_base := by obtain ⟨B,h⟩ := exists_finite_base; exact ⟨B, h.1⟩)
+  (base_exchange := base_exchange)
+  (maximality := by
     obtain ⟨B, hB, hfin⟩ := exists_finite_base
     refine' fun X _ ↦ Matroid.existsMaximalSubsetProperty_of_bdd
       ⟨B.ncard, fun Y ⟨B', hB', hYB'⟩ ↦ _⟩ X
     rw [hfin.cast_ncard_eq, base_exchange.encard_base_eq hB hB']
-    exact encard_mono hYB'
-  subset_ground := subset_ground
+    exact encard_mono hYB')
+  (subset_ground := subset_ground)
 
 @[simp] theorem ofExistsFiniteBase_base (E : Set α) Base exists_finite_base
     base_exchange subset_ground : (Matroid.ofExistsFiniteBase

--- a/Mathlib/Data/Matroid/Restrict.lean
+++ b/Mathlib/Data/Matroid/Restrict.lean
@@ -120,8 +120,7 @@ def restrict (M : Matroid α) (R : Set α) : Matroid α := (M.restrictIndepMatro
 /-- `M ↾ R` means `M.restrict R`. -/
 scoped infixl:65  " ↾ " => Matroid.restrict
 
-@[simp] theorem restrict_indep_iff : (M ↾ R).Indep I ↔ M.Indep I ∧ I ⊆ R := by
-  simp [Matroid.restrict]
+@[simp] theorem restrict_indep_iff : (M ↾ R).Indep I ↔ M.Indep I ∧ I ⊆ R := Iff.rfl
 
 theorem Indep.indep_restrict_of_subset (h : M.Indep I) (hIR : I ⊆ R) : (M ↾ R).Indep I :=
   restrict_indep_iff.mpr ⟨h,hIR⟩


### PR DESCRIPTION
This PR slightly shuffles the design of `Matroid` to improve defeq. 

Specifically, we add `Indep` as a structure field of `Matroid` together with a rule that `Indep` relates correctly to `Base`, where previously `Matroid.Indep` was defined after the fact. This has the consequence that, when a matroid `M` is built using a user-supplied independence predicate `Indep` (via `IndepMatroid.matroid`) , the terms `M.Indep` and `Indep` are defeq, where previously this needed to be proved by `simp`. 

This turns a few proofs already appearing in mathlib into `Iff.rfl`, and this same benefit will apply to many future API additions, since the independence predicate is the most common way to construct a matroid in practice. 

The tradeoff is that independence is no longer definitionally the same as being a subset of a base, but this seems to be worth it; it is simply a matter of using `Indep.exists_base_superset` where needed. The fact that now `Matroid.mk` is a bit 'heavier' than before is almost irrelevant, since matroids are essentially always going to be defined in terms of one of the alternative constructors, which are unchanged. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
