### PR TITLE
feat: add ContDiff.lipschitzOnWith

### DIFF
--- a/Mathlib/Analysis/Calculus/ContDiff/RCLike.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/RCLike.lean
@@ -127,7 +127,7 @@ theorem ContDiffWithinAt.exists_lipschitzOnWith
   exact ⟨K, t, hst, hft⟩
 #align cont_diff_within_at.exists_lipschitz_on_with ContDiffWithinAt.exists_lipschitzOnWith
 
-/-- If `f` is `C^1` at `x` and `K > ‖fderiv 𝕂 f x‖`, then `f` is `K`-Lipschitz in a neighborhood of
+/-- If `f` is `C^1` at `x` and `‖fderiv 𝕂 f x‖ < K`, then `f` is `K`-Lipschitz in a neighborhood of
 `x`. -/
 theorem ContDiffAt.exists_lipschitzOnWith_of_nnnorm_lt {f : E' → F'} {x : E'}
     (hf : ContDiffAt 𝕂 1 f x) (K : ℝ≥0) (hK : ‖fderiv 𝕂 f x‖₊ < K) :
@@ -146,6 +146,15 @@ lemma ContDiff.locallyLipschitz {f : E' → F'} (hf : ContDiff 𝕂 1 f) : Local
   intro x
   rcases hf.contDiffAt.exists_lipschitzOnWith with ⟨K, t, ht, hf⟩
   use K, t
+
+/-- A `C¹` function is Lipschitz on each convex compact set. -/
+theorem ContDiff.lipschitzOnWith {s : Set E} {f : E → F} {n} (hf : ContDiff ℝ n f) (hn : 1 ≤ n)
+    (hs : Convex ℝ s) (hs' : IsCompact s) : ∃ K, LipschitzOnWith K f s := by
+  rcases (bddAbove_iff_exists_ge 0).mp (hs'.image (hf.continuous_fderiv hn).norm).bddAbove
+    with ⟨M, M_nonneg, hM⟩
+  simp_rw [forall_mem_image] at hM
+  use ⟨M, M_nonneg⟩
+  exact Convex.lipschitzOnWith_of_nnnorm_fderiv_le (fun x _ ↦ hf.differentiable hn x) hM hs
 
 /-- A `C^1` function with compact support is Lipschitz. -/
 theorem ContDiff.lipschitzWith_of_hasCompactSupport {f : E' → F'} {n : ℕ∞}

--- a/Mathlib/Analysis/Calculus/ContDiff/RCLike.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/RCLike.lean
@@ -147,14 +147,24 @@ lemma ContDiff.locallyLipschitz {f : E' → F'} (hf : ContDiff 𝕂 1 f) : Local
   rcases hf.contDiffAt.exists_lipschitzOnWith with ⟨K, t, ht, hf⟩
   use K, t
 
-/-- A `C¹` function is Lipschitz on each convex compact set. -/
-theorem ContDiff.lipschitzOnWith {s : Set E} {f : E → F} {n} (hf : ContDiff ℝ n f) (hn : 1 ≤ n)
-    (hs : Convex ℝ s) (hs' : IsCompact s) : ∃ K, LipschitzOnWith K f s := by
-  rcases (bddAbove_iff_exists_ge 0).mp (hs'.image (hf.continuous_fderiv hn).norm).bddAbove
-    with ⟨M, M_nonneg, hM⟩
+/-- If `f` is `C¹` on a convex compact set `s`, it is Lipschitz on `s`. -/
+theorem ContDiffOn.exists_lipschitzOnWith {s : Set E} {f : E → F} {n} (hf : ContDiffOn ℝ n f s)
+    (hn : 1 ≤ n) (hs : Convex ℝ s) (hs' : IsCompact s) (hs'' : UniqueDiffOn ℝ s) :
+    ∃ K, LipschitzOnWith K f s := by
+  obtain ⟨M, M_nonneg, hM⟩ := (bddAbove_iff_exists_ge 0).mp
+    (hs'.image_of_continuousOn (hf.continuousOn_fderivWithin hs'' hn).norm).bddAbove
   simp_rw [forall_mem_image] at hM
   use ⟨M, M_nonneg⟩
-  exact Convex.lipschitzOnWith_of_nnnorm_fderiv_le (fun x _ ↦ hf.differentiable hn x) hM hs
+  exact Convex.lipschitzOnWith_of_nnnorm_fderivWithin_le (hf.differentiableOn hn) hM hs
+
+/-- A `C¹` function is Lipschitz on each convex compact set. -/
+theorem ContDiff.exists_lipschitzOnWith {s : Set E} {f : E → F} {n}
+    (hf : ContDiff ℝ n f) (hn : 1 ≤ n) (hs : Convex ℝ s) (hs' : IsCompact s) :
+    ∃ K, LipschitzOnWith K f s := by
+  have : UniqueDiffOn ℝ s := by
+    refine uniqueDiffOn_convex hs ?hs
+    sorry -- `s` has non-empty interior: is an extra condition!
+  exact hf.contDiffOn.exists_lipschitzOnWith hn hs hs' this
 
 /-- A `C^1` function with compact support is Lipschitz. -/
 theorem ContDiff.lipschitzWith_of_hasCompactSupport {f : E' → F'} {n : ℕ∞}

--- a/Mathlib/Analysis/Calculus/ContDiff/RCLike.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/RCLike.lean
@@ -26,8 +26,10 @@ section Real
   its extension fields such as `ℂ`).
 -/
 
-variable {n : ℕ∞} {𝕂 : Type*} [RCLike 𝕂] {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕂 E']
-  {F' : Type*} [NormedAddCommGroup F'] [NormedSpace 𝕂 F']
+variable {n : ℕ∞} {𝕂 : Type*} [RCLike 𝕂]
+  {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [NormedAddCommGroup F] [NormedSpace ℝ F]
+  {E' F' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕂 E']
+    [NormedAddCommGroup F'] [NormedSpace 𝕂 F']
 
 /-- If a function has a Taylor series at order at least 1, then at points in the interior of the
     domain of definition, the term of order 1 of this series is a strict derivative of `f`. -/
@@ -84,9 +86,8 @@ theorem ContDiff.hasStrictDerivAt {f : 𝕂 → F'} {x : 𝕂} (hf : ContDiff �
 
 /-- If `f` has a formal Taylor series `p` up to order `1` on `{x} ∪ s`, where `s` is a convex set,
 and `‖p x 1‖₊ < K`, then `f` is `K`-Lipschitz in a neighborhood of `x` within `s`. -/
-theorem HasFTaylorSeriesUpToOn.exists_lipschitzOnWith_of_nnnorm_lt {E F : Type*}
-    [NormedAddCommGroup E] [NormedSpace ℝ E] [NormedAddCommGroup F] [NormedSpace ℝ F] {f : E → F}
-    {p : E → FormalMultilinearSeries ℝ E F} {s : Set E} {x : E}
+theorem HasFTaylorSeriesUpToOn.exists_lipschitzOnWith_of_nnnorm_lt
+    {f : E → F} {p : E → FormalMultilinearSeries ℝ E F} {s : Set E} {x : E}
     (hf : HasFTaylorSeriesUpToOn 1 f p (insert x s)) (hs : Convex ℝ s) (K : ℝ≥0)
     (hK : ‖p x 1‖₊ < K) : ∃ t ∈ 𝓝[s] x, LipschitzOnWith K f t := by
   set f' := fun y => continuousMultilinearCurryFin1 ℝ E F (p y 1)
@@ -103,9 +104,8 @@ theorem HasFTaylorSeriesUpToOn.exists_lipschitzOnWith_of_nnnorm_lt {E F : Type*}
 
 /-- If `f` has a formal Taylor series `p` up to order `1` on `{x} ∪ s`, where `s` is a convex set,
 then `f` is Lipschitz in a neighborhood of `x` within `s`. -/
-theorem HasFTaylorSeriesUpToOn.exists_lipschitzOnWith {E F : Type*} [NormedAddCommGroup E]
-    [NormedSpace ℝ E] [NormedAddCommGroup F] [NormedSpace ℝ F] {f : E → F}
-    {p : E → FormalMultilinearSeries ℝ E F} {s : Set E} {x : E}
+theorem HasFTaylorSeriesUpToOn.exists_lipschitzOnWith
+    {f : E → F} {p : E → FormalMultilinearSeries ℝ E F} {s : Set E} {x : E}
     (hf : HasFTaylorSeriesUpToOn 1 f p (insert x s)) (hs : Convex ℝ s) :
     ∃ K, ∃ t ∈ 𝓝[s] x, LipschitzOnWith K f t :=
   (exists_gt _).imp <| hf.exists_lipschitzOnWith_of_nnnorm_lt hs
@@ -113,8 +113,8 @@ theorem HasFTaylorSeriesUpToOn.exists_lipschitzOnWith {E F : Type*} [NormedAddCo
 
 /-- If `f` is `C^1` within a convex set `s` at `x`, then it is Lipschitz on a neighborhood of `x`
 within `s`. -/
-theorem ContDiffWithinAt.exists_lipschitzOnWith {E F : Type*} [NormedAddCommGroup E]
-    [NormedSpace ℝ E] [NormedAddCommGroup F] [NormedSpace ℝ F] {f : E → F} {s : Set E} {x : E}
+theorem ContDiffWithinAt.exists_lipschitzOnWith
+    {f : E → F} {s : Set E} {x : E}
     (hf : ContDiffWithinAt ℝ 1 f s x) (hs : Convex ℝ s) :
     ∃ K : ℝ≥0, ∃ t ∈ 𝓝[s] x, LipschitzOnWith K f t := by
   rcases hf 1 le_rfl with ⟨t, hst, p, hp⟩


### PR DESCRIPTION
A C¹ function is Lipschitz on each convex compact set. From sphere-eversion.

--------

Commits can be reviewed independently.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
