### PR TITLE
[Merged by Bors] - chore: deprecate redundant lemma List.find?_mem

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -2693,16 +2693,8 @@ attribute [simp] find?_eq_none
 
 #align list.find_some List.find?_some
 
-@[simp]
-theorem find?_mem (H : find? p l = some a) : a ∈ l := by
-  induction' l with b l IH; · contradiction
-  by_cases h : p b
-  · rw [find?_cons_of_pos _ h] at H
-    cases H
-    apply mem_cons_self
-  · rw [find?_cons_of_neg _ h] at H
-    exact mem_cons_of_mem _ (IH H)
-#align list.find_mem List.find?_mem
+@[deprecated] alias find?_mem := mem_of_find?_eq_some -- 2024-05-05
+#align list.find_mem List.mem_of_find?_eq_some
 
 end find?
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -2693,7 +2693,7 @@ attribute [simp] find?_eq_none
 
 #align list.find_some List.find?_some
 
-@[deprecated] alias find?_mem := mem_of_find?_eq_some -- 2024-05-05
+@[deprecated (since := "2024-05-05")] alias find?_mem := mem_of_find?_eq_some
 #align list.find_mem List.mem_of_find?_eq_some
 
 end find?


### PR DESCRIPTION
Deprecates `List.find?_mem`, which duplicates `List.mem_of_find?_eq_some` from Std:
https://github.com/leanprover/std4/blob/80cf5a1f2d8ed48753e8ff783bf0f7b6872bb007/Std/Data/List/Lemmas.lean#L1755-L1759

The lemmas only differ in the ordering of the implicit arguments `l` and `a`.

```lean
List.find?_mem.{u} {α : Type u} {p : α → Bool} {l : List α} {a : α} (H : List.find? p l = some a) : a ∈ l
List.mem_of_find?_eq_some.{u_1} : ∀ {α : Type u_1} {p : α → Bool} {a : α} {l : List α}, List.find? p l = some a → a ∈ l
```
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
