### PR TITLE
[Merged by Bors] - chore: Rename Salem-Spencer sets to 3AP-free sets

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1596,12 +1596,12 @@ import Mathlib.CategoryTheory.UnivLE
 import Mathlib.CategoryTheory.Whiskering
 import Mathlib.CategoryTheory.WithTerminal
 import Mathlib.CategoryTheory.Yoneda
+import Mathlib.Combinatorics.Additive.AP.Three
 import Mathlib.Combinatorics.Additive.Behrend
 import Mathlib.Combinatorics.Additive.ETransform
 import Mathlib.Combinatorics.Additive.Energy
 import Mathlib.Combinatorics.Additive.PluenneckeRuzsa
 import Mathlib.Combinatorics.Additive.RuzsaCovering
-import Mathlib.Combinatorics.Additive.SalemSpencer
 import Mathlib.Combinatorics.Colex
 import Mathlib.Combinatorics.Configuration
 import Mathlib.Combinatorics.Derangements.Basic

--- a/Mathlib/Combinatorics/Additive/AP/Three.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three.lean
@@ -10,34 +10,38 @@ import Mathlib.Analysis.Convex.StrictConvexSpace
 #align_import combinatorics.additive.salem_spencer from "leanprover-community/mathlib"@"acf5258c81d0bc7cb254ed026c1352e685df306c"
 
 /-!
-# Salem-Spencer sets and Roth numbers
+# Sets without arithmetic progressions of length three and Roth numbers
 
-This file defines Salem-Spencer sets and the Roth number of a set.
+This file defines sets without arithmetic progressions of length three, aka 3AP-free sets, and the
+Roth number of a set.
 
-A Salem-Spencer set is a set without arithmetic progressions of length `3`. Equivalently, the
-average of any two distinct elements is not in the set.
+The corresponding notion, sets without geometric progressions of length three, are called 3GP-free
+sets.
 
-The Roth number of a finset is the size of its biggest Salem-Spencer subset. This is a more general
+The Roth number of a finset is the size of its biggest 3AP-free subset. This is a more general
 definition than the one often found in mathematical literature, where the `n`-th Roth number is
-the size of the biggest Salem-Spencer subset of `{0, ..., n - 1}`.
+the size of the biggest 3AP-free subset of `{0, ..., n - 1}`.
 
 ## Main declarations
 
-* `MulSalemSpencer`: Predicate for a set to be multiplicative Salem-Spencer.
-* `AddSalemSpencer`: Predicate for a set to be additive Salem-Spencer.
+* `ThreeGPFree`: Predicate for a set to be 3GP-free.
+* `ThreeAPFree`: Predicate for a set to be 3AP-free.
 * `mulRothNumber`: The multiplicative Roth number of a finset.
 * `addRothNumber`: The additive Roth number of a finset.
-* `rothNumberNat`: The Roth number of a natural. This corresponds to
-  `addRothNumber (Finset.range n)`.
+* `rothNumberNat`: The Roth number of a natural, namely `addRothNumber (Finset.range n)`.
 
 ## TODO
 
-* Can `addSalemSpencer_iff_eq_right` be made more general?
-* Generalize `MulSalemSpencer.image` to Freiman homs
+* Can `threeAPFree_iff_eq_right` be made more general?
+* Generalize `ThreeGPFree.image` to Freiman homs
+
+## References
+
+* [Wikipedia, *Salem-Spencer set*](https://en.wikipedia.org/wiki/Salem–Spencer_set)
 
 ## Tags
 
-Salem-Spencer, Roth, arithmetic progression, average, three-free
+3AP-free, Salem-Spencer, Roth, arithmetic progression, average, three-free
 -/
 
 
@@ -47,7 +51,7 @@ open Pointwise
 
 variable {F α β 𝕜 E : Type*}
 
-section SalemSpencer
+section ThreeAPFree
 
 open Set
 
@@ -55,61 +59,64 @@ section Monoid
 
 variable [Monoid α] [Monoid β] (s t : Set α)
 
-/-- A multiplicative Salem-Spencer, aka non averaging, set `s` in a monoid is a set such that the
-multiplicative average of any two distinct elements is not in the set. -/
-@[to_additive "A Salem-Spencer, aka non averaging, set `s` in an additive monoid
-is a set such that the average of any two distinct elements is not in the set."]
-def MulSalemSpencer : Prop :=
-  ∀ ⦃a b c⦄, a ∈ s → b ∈ s → c ∈ s → a * b = c * c → a = b
-#align mul_salem_spencer MulSalemSpencer
-#align add_salem_spencer AddSalemSpencer
+/-- A set is **3GP-free** if it does not contain any non-trivial geometric progression of length
+three.
 
-/-- Whether a given finset is Salem-Spencer is decidable. -/
-@[to_additive "Whether a given finset is Salem-Spencer is decidable."]
-instance {α : Type*} [DecidableEq α] [Monoid α] {s : Finset α} :
-    Decidable (MulSalemSpencer (s : Set α)) :=
+This is also sometimes called a **non averaging set** or **Salem-Spencer set**. -/
+@[to_additive "A set is **3AP-free** if it does not contain any non-trivial geometric progression of
+length three.
+
+This is also sometimes called a **non averaging set** or **Salem-Spencer set**."]
+def ThreeGPFree : Prop := ∀ ⦃a b c⦄, a ∈ s → b ∈ s → c ∈ s → a * b = c * c → a = b
+#align mul_salem_spencer ThreeGPFree
+#align add_salem_spencer ThreeAPFree
+
+/-- Whether a given finset is 3GP-free is decidable. -/
+@[to_additive "Whether a given finset is 3AP-free is decidable."]
+instance ThreeGPFree.instDecidable [DecidableEq α] {s : Finset α} :
+    Decidable (ThreeGPFree (s : Set α)) :=
   decidable_of_iff (∀ a ∈ s, ∀ b ∈ s, ∀ c ∈ s, a * b = c * c → a = b)
     ⟨fun h a b c ha hb hc => h a ha b hb c hc, fun h _ ha _ hb _ hc => h ha hb hc⟩
 
 variable {s t}
 
 @[to_additive]
-theorem MulSalemSpencer.mono (h : t ⊆ s) (hs : MulSalemSpencer s) : MulSalemSpencer t :=
+theorem ThreeGPFree.mono (h : t ⊆ s) (hs : ThreeGPFree s) : ThreeGPFree t :=
   fun _ _ _ ha hb hc => hs (h ha) (h hb) (h hc)
-#align mul_salem_spencer.mono MulSalemSpencer.mono
-#align add_salem_spencer.mono AddSalemSpencer.mono
+#align mul_salem_spencer.mono ThreeGPFree.mono
+#align add_salem_spencer.mono ThreeAPFree.mono
 
 @[to_additive (attr := simp)]
-theorem mulSalemSpencer_empty : MulSalemSpencer (∅ : Set α) := fun _ _ _ ha => ha.elim
-#align mul_salem_spencer_empty mulSalemSpencer_empty
-#align add_salem_spencer_empty addSalemSpencer_empty
+theorem threeGPFree_empty : ThreeGPFree (∅ : Set α) := fun _ _ _ ha => ha.elim
+#align mul_salem_spencer_empty threeGPFree_empty
+#align add_salem_spencer_empty threeAPFree_empty
 
 @[to_additive]
-theorem Set.Subsingleton.mulSalemSpencer (hs : s.Subsingleton) : MulSalemSpencer s :=
+theorem Set.Subsingleton.threeGPFree (hs : s.Subsingleton) : ThreeGPFree s :=
   fun _ _ _ ha hb _ _ => hs ha hb
-#align set.subsingleton.mul_salem_spencer Set.Subsingleton.mulSalemSpencer
-#align set.subsingleton.add_salem_spencer Set.Subsingleton.addSalemSpencer
+#align set.subsingleton.mul_salem_spencer Set.Subsingleton.threeGPFree
+#align set.subsingleton.add_salem_spencer Set.Subsingleton.threeAPFree
 
 @[to_additive (attr := simp)]
-theorem mulSalemSpencer_singleton (a : α) : MulSalemSpencer ({a} : Set α) :=
-  subsingleton_singleton.mulSalemSpencer
-#align mul_salem_spencer_singleton mulSalemSpencer_singleton
-#align add_salem_spencer_singleton addSalemSpencer_singleton
+theorem threeGPFree_singleton (a : α) : ThreeGPFree ({a} : Set α) :=
+  subsingleton_singleton.threeGPFree
+#align mul_salem_spencer_singleton threeGPFree_singleton
+#align add_salem_spencer_singleton threeAPFree_singleton
 
-@[to_additive AddSalemSpencer.prod]
-theorem MulSalemSpencer.prod {t : Set β} (hs : MulSalemSpencer s) (ht : MulSalemSpencer t) :
-    MulSalemSpencer (s ×ˢ t) := fun _ _ _ ha hb hc h =>
+@[to_additive ThreeAPFree.prod]
+theorem ThreeGPFree.prod {t : Set β} (hs : ThreeGPFree s) (ht : ThreeGPFree t) :
+    ThreeGPFree (s ×ˢ t) := fun _ _ _ ha hb hc h =>
   Prod.ext (hs ha.1 hb.1 hc.1 (Prod.ext_iff.1 h).1) (ht ha.2 hb.2 hc.2 (Prod.ext_iff.1 h).2)
-#align mul_salem_spencer.prod MulSalemSpencer.prod
-#align add_salem_spencer.prod AddSalemSpencer.prod
+#align mul_salem_spencer.prod ThreeGPFree.prod
+#align add_salem_spencer.prod ThreeAPFree.prod
 
 @[to_additive]
-theorem mulSalemSpencer_pi {ι : Type*} {α : ι → Type*} [∀ i, Monoid (α i)] {s : ∀ i, Set (α i)}
-    (hs : ∀ i, MulSalemSpencer (s i)) : MulSalemSpencer ((univ : Set ι).pi s) :=
+theorem threeGPFree_pi {ι : Type*} {α : ι → Type*} [∀ i, Monoid (α i)] {s : ∀ i, Set (α i)}
+    (hs : ∀ i, ThreeGPFree (s i)) : ThreeGPFree ((univ : Set ι).pi s) :=
   fun _ _ _ ha hb hc h =>
   funext fun i => hs i (ha i trivial) (hb i trivial) (hc i trivial) <| congr_fun h i
-#align mul_salem_spencer_pi mulSalemSpencer_pi
-#align add_salem_spencer_pi addSalemSpencer_pi
+#align mul_salem_spencer_pi threeGPFree_pi
+#align add_salem_spencer_pi threeAPFree_pi
 
 end Monoid
 
@@ -118,22 +125,22 @@ section CommMonoid
 variable [CommMonoid α] [CommMonoid β] {s : Set α} {a : α}
 
 @[to_additive]
-theorem MulSalemSpencer.of_image [FunLike F α β] [FreimanHomClass F s β 2] (f : F)
-    (hf : s.InjOn f) (h : MulSalemSpencer (f '' s)) : MulSalemSpencer s :=
+theorem ThreeGPFree.of_image [FunLike F α β] [FreimanHomClass F s β 2] (f : F)
+    (hf : s.InjOn f) (h : ThreeGPFree (f '' s)) : ThreeGPFree s :=
   fun _ _ _ ha hb hc habc => hf ha hb <|
     h (mem_image_of_mem _ ha) (mem_image_of_mem _ hb) (mem_image_of_mem _ hc) <|
       map_mul_map_eq_map_mul_map f ha hb hc hc habc
-#align mul_salem_spencer.of_image MulSalemSpencer.of_image
-#align add_salem_spencer.of_image AddSalemSpencer.of_image
+#align mul_salem_spencer.of_image ThreeGPFree.of_image
+#align add_salem_spencer.of_image ThreeAPFree.of_image
 
 -- TODO: Generalize to Freiman homs
 @[to_additive]
-theorem MulSalemSpencer.image [FunLike F α β] [MulHomClass F α β] (f : F) (hf : (s * s).InjOn f)
-    (h : MulSalemSpencer s) : MulSalemSpencer (f '' s) := by
+theorem ThreeGPFree.image [FunLike F α β] [MulHomClass F α β] (f : F) (hf : (s * s).InjOn f)
+    (h : ThreeGPFree s) : ThreeGPFree (f '' s) := by
   rintro _ _ _ ⟨a, ha, rfl⟩ ⟨b, hb, rfl⟩ ⟨c, hc, rfl⟩ habc
   rw [h ha hb hc (hf (mul_mem_mul ha hb) (mul_mem_mul hc hc) <| by rwa [map_mul, map_mul])]
-#align mul_salem_spencer.image MulSalemSpencer.image
-#align add_salem_spencer.image AddSalemSpencer.image
+#align mul_salem_spencer.image ThreeGPFree.image
+#align add_salem_spencer.image ThreeAPFree.image
 
 end CommMonoid
 
@@ -142,7 +149,7 @@ section CancelCommMonoid
 variable [CancelCommMonoid α] {s : Set α} {a : α}
 
 @[to_additive]
-theorem mulSalemSpencer_insert : MulSalemSpencer (insert a s) ↔ MulSalemSpencer s ∧
+theorem threeGPFree_insert : ThreeGPFree (insert a s) ↔ ThreeGPFree s ∧
     (∀ ⦃b c⦄, b ∈ s → c ∈ s → a * b = c * c → a = b) ∧
     ∀ ⦃b c⦄, b ∈ s → c ∈ s → b * c = a * a → b = c := by
   refine' ⟨fun hs => ⟨hs.mono (subset_insert _ _),
@@ -159,55 +166,55 @@ theorem mulSalemSpencer_insert : MulSalemSpencer (insert a s) ↔ MulSalemSpence
   · exact (ha hb hd <| (mul_comm _ _).trans h).symm
   · exact ha' hb hc h
   · exact hs hb hc hd h
-#align mul_salem_spencer_insert mulSalemSpencer_insert
-#align add_salem_spencer_insert addSalemSpencer_insert
+#align mul_salem_spencer_insert threeGPFree_insert
+#align add_salem_spencer_insert threeAPFree_insert
 
 @[to_additive (attr := simp)]
-theorem mulSalemSpencer_pair (a b : α) : MulSalemSpencer ({a, b} : Set α) := by
-  rw [mulSalemSpencer_insert]
-  refine' ⟨mulSalemSpencer_singleton _, _, _⟩
+theorem threeGPFree_pair (a b : α) : ThreeGPFree ({a, b} : Set α) := by
+  rw [threeGPFree_insert]
+  refine' ⟨threeGPFree_singleton _, _, _⟩
   · rintro c d (rfl : c = b) (rfl : d = c)
     exact mul_right_cancel
   · rintro c d (rfl : c = b) (rfl : d = c) _
     rfl
-#align mul_salem_spencer_pair mulSalemSpencer_pair
-#align add_salem_spencer_pair addSalemSpencer_pair
+#align mul_salem_spencer_pair threeGPFree_pair
+#align add_salem_spencer_pair threeAPFree_pair
 
 @[to_additive]
-theorem MulSalemSpencer.mul_left (hs : MulSalemSpencer s) : MulSalemSpencer ((a * ·) '' s) := by
+theorem ThreeGPFree.mul_left (hs : ThreeGPFree s) : ThreeGPFree ((a * ·) '' s) := by
   rintro _ _ _ ⟨b, hb, rfl⟩ ⟨c, hc, rfl⟩ ⟨d, hd, rfl⟩ h
   rw [mul_mul_mul_comm, mul_mul_mul_comm a d] at h
   rw [hs hb hc hd (mul_left_cancel h)]
-#align mul_salem_spencer.mul_left MulSalemSpencer.mul_left
-#align add_salem_spencer.add_left AddSalemSpencer.add_left
+#align mul_salem_spencer.mul_left ThreeGPFree.mul_left
+#align add_salem_spencer.add_left ThreeAPFree.add_left
 
 @[to_additive]
-theorem MulSalemSpencer.mul_right (hs : MulSalemSpencer s) : MulSalemSpencer ((· * a) '' s) := by
+theorem ThreeGPFree.mul_right (hs : ThreeGPFree s) : ThreeGPFree ((· * a) '' s) := by
   rintro _ _ _ ⟨b, hb, rfl⟩ ⟨c, hc, rfl⟩ ⟨d, hd, rfl⟩ h
   rw [mul_mul_mul_comm, mul_mul_mul_comm d] at h
   rw [hs hb hc hd (mul_right_cancel h)]
-#align mul_salem_spencer.mul_right MulSalemSpencer.mul_right
-#align add_salem_spencer.add_right AddSalemSpencer.add_right
+#align mul_salem_spencer.mul_right ThreeGPFree.mul_right
+#align add_salem_spencer.add_right ThreeAPFree.add_right
 
 @[to_additive]
-theorem mulSalemSpencer_mul_left_iff : MulSalemSpencer ((a * ·) '' s) ↔ MulSalemSpencer s :=
+theorem threeGPFree_mul_left_iff : ThreeGPFree ((a * ·) '' s) ↔ ThreeGPFree s :=
   ⟨fun hs b c d hb hc hd h =>
     mul_left_cancel
       (hs (mem_image_of_mem _ hb) (mem_image_of_mem _ hc) (mem_image_of_mem _ hd) <| by
         rw [mul_mul_mul_comm, h, mul_mul_mul_comm]),
-    MulSalemSpencer.mul_left⟩
-#align mul_salem_spencer_mul_left_iff mulSalemSpencer_mul_left_iff
-#align add_salem_spencer_add_left_iff addSalemSpencer_add_left_iff
+    ThreeGPFree.mul_left⟩
+#align mul_salem_spencer_mul_left_iff threeGPFree_mul_left_iff
+#align add_salem_spencer_add_left_iff threeAPFree_add_left_iff
 
 @[to_additive]
-theorem mulSalemSpencer_mul_right_iff : MulSalemSpencer ((· * a) '' s) ↔ MulSalemSpencer s :=
+theorem threeGPFree_mul_right_iff : ThreeGPFree ((· * a) '' s) ↔ ThreeGPFree s :=
   ⟨fun hs b c d hb hc hd h =>
     mul_right_cancel
       (hs (Set.mem_image_of_mem _ hb) (Set.mem_image_of_mem _ hc) (Set.mem_image_of_mem _ hd) <| by
         rw [mul_mul_mul_comm, h, mul_mul_mul_comm]),
-    MulSalemSpencer.mul_right⟩
-#align mul_salem_spencer_mul_right_iff mulSalemSpencer_mul_right_iff
-#align add_salem_spencer_add_right_iff addSalemSpencer_add_right_iff
+    ThreeGPFree.mul_right⟩
+#align mul_salem_spencer_mul_right_iff threeGPFree_mul_right_iff
+#align add_salem_spencer_add_right_iff threeAPFree_add_right_iff
 
 end CancelCommMonoid
 
@@ -216,14 +223,14 @@ section OrderedCancelCommMonoid
 variable [OrderedCancelCommMonoid α] {s : Set α} {a : α}
 
 @[to_additive]
-theorem mulSalemSpencer_insert_of_lt (hs : ∀ i ∈ s, i < a) :
-    MulSalemSpencer (insert a s) ↔
-      MulSalemSpencer s ∧ ∀ ⦃b c⦄, b ∈ s → c ∈ s → a * b = c * c → a = b := by
-  refine' mulSalemSpencer_insert.trans _
+theorem threeGPFree_insert_of_lt (hs : ∀ i ∈ s, i < a) :
+    ThreeGPFree (insert a s) ↔
+      ThreeGPFree s ∧ ∀ ⦃b c⦄, b ∈ s → c ∈ s → a * b = c * c → a = b := by
+  refine' threeGPFree_insert.trans _
   rw [← and_assoc]
   exact and_iff_left fun b c hb hc h => ((mul_lt_mul_of_lt_of_lt (hs _ hb) (hs _ hc)).ne h).elim
-#align mul_salem_spencer_insert_of_lt mulSalemSpencer_insert_of_lt
-#align add_salem_spencer_insert_of_lt addSalemSpencer_insert_of_lt
+#align mul_salem_spencer_insert_of_lt threeGPFree_insert_of_lt
+#align add_salem_spencer_insert_of_lt threeAPFree_insert_of_lt
 
 end OrderedCancelCommMonoid
 
@@ -231,78 +238,78 @@ section CancelCommMonoidWithZero
 
 variable [CancelCommMonoidWithZero α] [NoZeroDivisors α] {s : Set α} {a : α}
 
-theorem MulSalemSpencer.mul_left₀ (hs : MulSalemSpencer s) (ha : a ≠ 0) :
-    MulSalemSpencer ((a * ·) '' s) := by
+theorem ThreeGPFree.mul_left₀ (hs : ThreeGPFree s) (ha : a ≠ 0) :
+    ThreeGPFree ((a * ·) '' s) := by
   rintro _ _ _ ⟨b, hb, rfl⟩ ⟨c, hc, rfl⟩ ⟨d, hd, rfl⟩ h
   rw [mul_mul_mul_comm, mul_mul_mul_comm a d] at h
   rw [hs hb hc hd (mul_left_cancel₀ (mul_ne_zero ha ha) h)]
-#align mul_salem_spencer.mul_left₀ MulSalemSpencer.mul_left₀
+#align mul_salem_spencer.mul_left₀ ThreeGPFree.mul_left₀
 
-theorem MulSalemSpencer.mul_right₀ (hs : MulSalemSpencer s) (ha : a ≠ 0) :
-    MulSalemSpencer ((· * a) '' s) := by
+theorem ThreeGPFree.mul_right₀ (hs : ThreeGPFree s) (ha : a ≠ 0) :
+    ThreeGPFree ((· * a) '' s) := by
   rintro _ _ _ ⟨b, hb, rfl⟩ ⟨c, hc, rfl⟩ ⟨d, hd, rfl⟩ h
   rw [mul_mul_mul_comm, mul_mul_mul_comm d] at h
   rw [hs hb hc hd (mul_right_cancel₀ (mul_ne_zero ha ha) h)]
-#align mul_salem_spencer.mul_right₀ MulSalemSpencer.mul_right₀
+#align mul_salem_spencer.mul_right₀ ThreeGPFree.mul_right₀
 
-theorem mulSalemSpencer_mul_left_iff₀ (ha : a ≠ 0) :
-    MulSalemSpencer ((a * ·) '' s) ↔ MulSalemSpencer s :=
+theorem threeGPFree_mul_left_iff₀ (ha : a ≠ 0) :
+    ThreeGPFree ((a * ·) '' s) ↔ ThreeGPFree s :=
   ⟨fun hs b c d hb hc hd h =>
     mul_left_cancel₀ ha
       (hs (Set.mem_image_of_mem _ hb) (Set.mem_image_of_mem _ hc) (Set.mem_image_of_mem _ hd) <| by
         rw [mul_mul_mul_comm, h, mul_mul_mul_comm]),
     fun hs => hs.mul_left₀ ha⟩
-#align mul_salem_spencer_mul_left_iff₀ mulSalemSpencer_mul_left_iff₀
+#align mul_salem_spencer_mul_left_iff₀ threeGPFree_mul_left_iff₀
 
-theorem mulSalemSpencer_mul_right_iff₀ (ha : a ≠ 0) :
-    MulSalemSpencer ((· * a) '' s) ↔ MulSalemSpencer s :=
+theorem threeGPFree_mul_right_iff₀ (ha : a ≠ 0) :
+    ThreeGPFree ((· * a) '' s) ↔ ThreeGPFree s :=
   ⟨fun hs b c d hb hc hd h =>
     mul_right_cancel₀ ha
       (hs (Set.mem_image_of_mem _ hb) (Set.mem_image_of_mem _ hc) (Set.mem_image_of_mem _ hd) <| by
         rw [mul_mul_mul_comm, h, mul_mul_mul_comm]),
     fun hs => hs.mul_right₀ ha⟩
-#align mul_salem_spencer_mul_right_iff₀ mulSalemSpencer_mul_right_iff₀
+#align mul_salem_spencer_mul_right_iff₀ threeGPFree_mul_right_iff₀
 
 end CancelCommMonoidWithZero
 
 section Nat
 
-theorem addSalemSpencer_iff_eq_right {s : Set ℕ} :
-    AddSalemSpencer s ↔ ∀ ⦃a b c⦄, a ∈ s → b ∈ s → c ∈ s → a + b = c + c → a = c := by
+theorem threeAPFree_iff_eq_right {s : Set ℕ} :
+    ThreeAPFree s ↔ ∀ ⦃a b c⦄, a ∈ s → b ∈ s → c ∈ s → a + b = c + c → a = c := by
   refine' forall₄_congr fun a b c _ => forall₃_congr fun _ _ habc => ⟨_, _⟩
   · rintro rfl
     simp_rw [← two_mul] at habc
     exact mul_left_cancel₀ two_ne_zero habc
   · rintro rfl
     exact (add_left_cancel habc).symm
-#align add_salem_spencer_iff_eq_right addSalemSpencer_iff_eq_right
+#align add_salem_spencer_iff_eq_right threeAPFree_iff_eq_right
 
 end Nat
 
 /-- The frontier of a closed strictly convex set only contains trivial arithmetic progressions.
 The idea is that an arithmetic progression is contained on a line and the frontier of a strictly
 convex set does not contain lines. -/
-theorem addSalemSpencer_frontier [LinearOrderedField 𝕜] [TopologicalSpace E] [AddCommMonoid E]
+theorem threeAPFree_frontier [LinearOrderedField 𝕜] [TopologicalSpace E] [AddCommMonoid E]
     [Module 𝕜 E] {s : Set E} (hs₀ : IsClosed s) (hs₁ : StrictConvex 𝕜 s) :
-    AddSalemSpencer (frontier s) := by
+    ThreeAPFree (frontier s) := by
   intro a b c ha hb hc habc
   obtain rfl : (1 / 2 : 𝕜) • a + (1 / 2 : 𝕜) • b = c := by
     rwa [← smul_add, one_div, inv_smul_eq_iff₀ (show (2 : 𝕜) ≠ 0 by norm_num), two_smul]
   exact
     hs₁.eq (hs₀.frontier_subset ha) (hs₀.frontier_subset hb) one_half_pos one_half_pos
       (add_halves _) hc.2
-#align add_salem_spencer_frontier addSalemSpencer_frontier
+#align add_salem_spencer_frontier threeAPFree_frontier
 
-theorem addSalemSpencer_sphere [NormedAddCommGroup E] [NormedSpace ℝ E] [StrictConvexSpace ℝ E]
-    (x : E) (r : ℝ) : AddSalemSpencer (sphere x r) := by
+theorem threeAPFree_sphere [NormedAddCommGroup E] [NormedSpace ℝ E] [StrictConvexSpace ℝ E]
+    (x : E) (r : ℝ) : ThreeAPFree (sphere x r) := by
   obtain rfl | hr := eq_or_ne r 0
   · rw [sphere_zero]
-    exact addSalemSpencer_singleton _
-  · convert addSalemSpencer_frontier isClosed_ball (strictConvex_closedBall ℝ x r)
+    exact threeAPFree_singleton _
+  · convert threeAPFree_frontier isClosed_ball (strictConvex_closedBall ℝ x r)
     exact (frontier_closedBall _ hr).symm
-#align add_salem_spencer_sphere addSalemSpencer_sphere
+#align add_salem_spencer_sphere threeAPFree_sphere
 
-end SalemSpencer
+end ThreeAPFree
 
 open Finset
 
@@ -314,13 +321,13 @@ section Monoid
 
 variable [Monoid α] [DecidableEq β] [Monoid β] (s t : Finset α)
 
-/-- The multiplicative Roth number of a finset is the cardinality of its biggest multiplicative
-Salem-Spencer subset. -/
-@[to_additive "The additive Roth number of a finset is the cardinality of its biggest additive
-Salem-Spencer subset. The usual Roth number corresponds to `addRothNumber (Finset.range n)`, see
-`rothNumberNat`. "]
+/-- The multiplicative Roth number of a finset is the cardinality of its biggest 3GP-free subset. -/
+@[to_additive "The additive Roth number of a finset is the cardinality of its biggest 3AP-free
+subset.
+
+The usual Roth number corresponds to `addRothNumber (Finset.range n)`, see `rothNumberNat`."]
 def mulRothNumber : Finset α →o ℕ :=
-  ⟨fun s ↦ Nat.findGreatest (fun m ↦ ∃ t ⊆ s, t.card = m ∧ MulSalemSpencer (t : Set α)) s.card, by
+  ⟨fun s ↦ Nat.findGreatest (fun m ↦ ∃ t ⊆ s, t.card = m ∧ ThreeGPFree (t : Set α)) s.card, by
     rintro t u htu
     refine' Nat.findGreatest_mono (fun m => _) (card_le_card htu)
     rintro ⟨v, hvt, hv⟩
@@ -335,27 +342,27 @@ theorem mulRothNumber_le : mulRothNumber s ≤ s.card := Nat.findGreatest_le s.c
 
 @[to_additive]
 theorem mulRothNumber_spec :
-    ∃ t ⊆ s, t.card = mulRothNumber s ∧ MulSalemSpencer (t : Set α) :=
-  Nat.findGreatest_spec (P := fun m ↦ ∃ t ⊆ s, t.card = m ∧ MulSalemSpencer (t : Set α))
-    (Nat.zero_le _) ⟨∅, empty_subset _, card_empty, by norm_cast; exact mulSalemSpencer_empty⟩
+    ∃ t ⊆ s, t.card = mulRothNumber s ∧ ThreeGPFree (t : Set α) :=
+  Nat.findGreatest_spec (P := fun m ↦ ∃ t ⊆ s, t.card = m ∧ ThreeGPFree (t : Set α))
+    (Nat.zero_le _) ⟨∅, empty_subset _, card_empty, by norm_cast; exact threeGPFree_empty⟩
 #align mul_roth_number_spec mulRothNumber_spec
 #align add_roth_number_spec addRothNumber_spec
 
 variable {s t} {n : ℕ}
 
 @[to_additive]
-theorem MulSalemSpencer.le_mulRothNumber (hs : MulSalemSpencer (s : Set α)) (h : s ⊆ t) :
+theorem ThreeGPFree.le_mulRothNumber (hs : ThreeGPFree (s : Set α)) (h : s ⊆ t) :
     s.card ≤ mulRothNumber t :=
   le_findGreatest (card_le_card h) ⟨s, h, rfl, hs⟩
-#align mul_salem_spencer.le_mul_roth_number MulSalemSpencer.le_mulRothNumber
-#align add_salem_spencer.le_add_roth_number AddSalemSpencer.le_addRothNumber
+#align mul_salem_spencer.le_mul_roth_number ThreeGPFree.le_mulRothNumber
+#align add_salem_spencer.le_add_roth_number ThreeAPFree.le_addRothNumber
 
 @[to_additive]
-theorem MulSalemSpencer.roth_number_eq (hs : MulSalemSpencer (s : Set α)) :
+theorem ThreeGPFree.roth_number_eq (hs : ThreeGPFree (s : Set α)) :
     mulRothNumber s = s.card :=
   (mulRothNumber_le _).antisymm <| hs.le_mulRothNumber <| Subset.refl _
-#align mul_salem_spencer.roth_number_eq MulSalemSpencer.roth_number_eq
-#align add_salem_spencer.roth_number_eq AddSalemSpencer.roth_number_eq
+#align mul_salem_spencer.roth_number_eq ThreeGPFree.roth_number_eq
+#align add_salem_spencer.roth_number_eq ThreeAPFree.roth_number_eq
 
 @[to_additive (attr := simp)]
 theorem mulRothNumber_empty : mulRothNumber (∅ : Finset α) = 0 :=
@@ -365,9 +372,9 @@ theorem mulRothNumber_empty : mulRothNumber (∅ : Finset α) = 0 :=
 
 @[to_additive (attr := simp)]
 theorem mulRothNumber_singleton (a : α) : mulRothNumber ({a} : Finset α) = 1 := by
-  refine' MulSalemSpencer.roth_number_eq _
+  refine' ThreeGPFree.roth_number_eq _
   rw [coe_singleton]
-  exact mulSalemSpencer_singleton a
+  exact threeGPFree_singleton a
 #align mul_roth_number_singleton mulRothNumber_singleton
 #align add_roth_number_singleton addRothNumber_singleton
 
@@ -391,23 +398,23 @@ theorem le_mulRothNumber_product (s : Finset α) (t : Finset β) :
   obtain ⟨u, hus, hucard, hu⟩ := mulRothNumber_spec s
   obtain ⟨v, hvt, hvcard, hv⟩ := mulRothNumber_spec t
   rw [← hucard, ← hvcard, ← card_product]
-  refine' MulSalemSpencer.le_mulRothNumber _ (product_subset_product hus hvt)
+  refine' ThreeGPFree.le_mulRothNumber _ (product_subset_product hus hvt)
   rw [coe_product]
   exact hu.prod hv
 #align le_mul_roth_number_product le_mulRothNumber_product
 #align le_add_roth_number_product le_addRothNumber_product
 
 @[to_additive]
-theorem mulRothNumber_lt_of_forall_not_mulSalemSpencer
-    (h : ∀ t ∈ powersetCard n s, ¬MulSalemSpencer ((t : Finset α) : Set α)) :
+theorem mulRothNumber_lt_of_forall_not_threeGPFree
+    (h : ∀ t ∈ powersetCard n s, ¬ThreeGPFree ((t : Finset α) : Set α)) :
     mulRothNumber s < n := by
   obtain ⟨t, hts, hcard, ht⟩ := mulRothNumber_spec s
   rw [← hcard, ← not_le]
   intro hn
   obtain ⟨u, hut, rfl⟩ := exists_smaller_set t n hn
   exact h _ (mem_powersetCard.2 ⟨hut.trans hts, rfl⟩) (ht.mono hut)
-#align mul_roth_number_lt_of_forall_not_mul_salem_spencer mulRothNumber_lt_of_forall_not_mulSalemSpencer
-#align add_roth_number_lt_of_forall_not_add_salem_spencer addRothNumber_lt_of_forall_not_addSalemSpencer
+#align mul_roth_number_lt_of_forall_not_mul_salem_spencer mulRothNumber_lt_of_forall_not_threeGPFree
+#align add_roth_number_lt_of_forall_not_add_salem_spencer addRothNumber_lt_of_forall_not_threeAPFree
 
 end Monoid
 
@@ -424,9 +431,9 @@ theorem mulRothNumber_map_mul_left :
     obtain ⟨u, hus, rfl⟩ := hus
     rw [coe_map] at hu
     rw [← hcard, card_map]
-    exact (mulSalemSpencer_mul_left_iff.1 hu).le_mulRothNumber hus
+    exact (threeGPFree_mul_left_iff.1 hu).le_mulRothNumber hus
   · obtain ⟨u, hus, hcard, hu⟩ := mulRothNumber_spec s
-    have h : MulSalemSpencer (u.map <| mulLeftEmbedding a : Set α) := by
+    have h : ThreeGPFree (u.map <| mulLeftEmbedding a : Set α) := by
       rw [coe_map]
       exact hu.mul_left
     convert h.le_mulRothNumber (map_subset_map.2 hus) using 1
@@ -469,16 +476,16 @@ theorem rothNumberNat_le (N : ℕ) : rothNumberNat N ≤ N :=
 #align roth_number_nat_le rothNumberNat_le
 
 theorem rothNumberNat_spec (n : ℕ) :
-    ∃ t ⊆ range n, t.card = rothNumberNat n ∧ AddSalemSpencer (t : Set ℕ) :=
+    ∃ t ⊆ range n, t.card = rothNumberNat n ∧ ThreeAPFree (t : Set ℕ) :=
   addRothNumber_spec _
 #align roth_number_nat_spec rothNumberNat_spec
 
-/-- A verbose specialization of `addSalemSpencer.le_addRothNumber`, sometimes convenient in
+/-- A verbose specialization of `threeAPFree.le_addRothNumber`, sometimes convenient in
 practice. -/
-theorem AddSalemSpencer.le_rothNumberNat (s : Finset ℕ) (hs : AddSalemSpencer (s : Set ℕ))
+theorem ThreeAPFree.le_rothNumberNat (s : Finset ℕ) (hs : ThreeAPFree (s : Set ℕ))
     (hsn : ∀ x ∈ s, x < n) (hsk : s.card = k) : k ≤ rothNumberNat n :=
   hsk.ge.trans <| hs.le_addRothNumber fun x hx => mem_range.2 <| hsn x hx
-#align add_salem_spencer.le_roth_number_nat AddSalemSpencer.le_rothNumberNat
+#align add_salem_spencer.le_roth_number_nat ThreeAPFree.le_rothNumberNat
 
 /-- The Roth number is a subadditive function. Note that by Fekete's lemma this shows that
 the limit `rothNumberNat N / N` exists, but Roth's theorem gives the stronger result that this

--- a/Mathlib/Combinatorics/Additive/AP/Three.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three.lean
@@ -60,11 +60,9 @@ section Monoid
 variable [Monoid α] [Monoid β] (s t : Set α)
 
 /-- A set is **3GP-free** if it does not contain any non-trivial geometric progression of length
-three.
-
-This is also sometimes called a **non averaging set** or **Salem-Spencer set**. -/
-@[to_additive "A set is **3AP-free** if it does not contain any non-trivial geometric progression of
-length three.
+three. -/
+@[to_additive "A set is **3AP-free** if it does not contain any non-trivial arithmetic progression
+of length three.
 
 This is also sometimes called a **non averaging set** or **Salem-Spencer set**."]
 def ThreeGPFree : Prop := ∀ ⦃a b c⦄, a ∈ s → b ∈ s → c ∈ s → a * b = c * c → a = b

--- a/Mathlib/Combinatorics/Additive/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/Behrend.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
 import Mathlib.Analysis.InnerProductSpace.PiL2
-import Mathlib.Combinatorics.Additive.SalemSpencer
+import Mathlib.Combinatorics.Additive.AP.Three
 import Mathlib.Combinatorics.Pigeonhole
 import Mathlib.Data.Complex.ExponentialBounds
 
@@ -41,7 +41,7 @@ integer points on that sphere and map them onto `ℕ` in a way that preserves ar
 
 ## Tags
 
-Salem-Spencer, Behrend construction, arithmetic progression, sphere, strictly convex
+3AP-free, Salem-Spencer, Behrend construction, arithmetic progression, sphere, strictly convex
 -/
 
 
@@ -56,12 +56,12 @@ namespace Behrend
 variable {α β : Type*} {n d k N : ℕ} {x : Fin n → ℕ}
 
 /-!
-### Turning the sphere into a Salem-Spencer set
+### Turning the sphere into 3AP-free set
 
 We define `Behrend.sphere`, the intersection of the $L^2$ sphere with the positive quadrant of
 integer points. Because the $L^2$ closed ball is strictly convex, the $L^2$ sphere and
-`Behrend.sphere` are Salem-Spencer (`addSalemSpencer_sphere`). Then we can turn this set in
-`Fin n → ℕ` into a set in `ℕ` using `Behrend.map`, which preserves `AddSalemSpencer` because it is
+`Behrend.sphere` are 3AP-free (`threeAPFree_sphere`). Then we can turn this set in
+`Fin n → ℕ` into a set in `ℕ` using `Behrend.map`, which preserves `ThreeAPFree` because it is
 an additive monoid homomorphism.
 -/
 
@@ -167,23 +167,23 @@ theorem map_le_of_mem_box (hx : x ∈ box n d) :
   map_monotone (2 * d - 1) fun _ => Nat.le_sub_one_of_lt <| mem_box.1 hx _
 #align behrend.map_le_of_mem_box Behrend.map_le_of_mem_box
 
-nonrec theorem addSalemSpencer_sphere : AddSalemSpencer (sphere n d k : Set (Fin n → ℕ)) := by
+nonrec theorem threeAPFree_sphere : ThreeAPFree (sphere n d k : Set (Fin n → ℕ)) := by
   set f : (Fin n → ℕ) →+ EuclideanSpace ℝ (Fin n) :=
     { toFun := fun f => ((↑) : ℕ → ℝ) ∘ f
       map_zero' := funext fun _ => cast_zero
       map_add' := fun _ _ => funext fun _ => cast_add _ _ }
-  refine' AddSalemSpencer.of_image (f.toAddFreimanHom (sphere n d k : Set (Fin n → ℕ)) 2) _ _
+  refine' ThreeAPFree.of_image (f.toAddFreimanHom (sphere n d k : Set (Fin n → ℕ)) 2) _ _
   · exact cast_injective.comp_left.injOn _
-  refine' (addSalemSpencer_sphere 0 (√↑k)).mono (Set.image_subset_iff.2 fun x => _)
+  refine' (threeAPFree_sphere 0 (√↑k)).mono (Set.image_subset_iff.2 fun x => _)
   rw [Set.mem_preimage, mem_sphere_zero_iff_norm]
   exact norm_of_mem_sphere
-#align behrend.add_salem_spencer_sphere Behrend.addSalemSpencer_sphere
+#align behrend.add_salem_spencer_sphere Behrend.threeAPFree_sphere
 
-theorem addSalemSpencer_image_sphere :
-    AddSalemSpencer ((sphere n d k).image (map (2 * d - 1)) : Set ℕ) := by
+theorem threeAPFree_image_sphere :
+    ThreeAPFree ((sphere n d k).image (map (2 * d - 1)) : Set ℕ) := by
   rw [coe_image]
-  refine' AddSalemSpencer.image (α := Fin n → ℕ) (β := ℕ) (s := sphere n d k) (map (2 * d - 1))
-    (map_injOn.mono _) addSalemSpencer_sphere
+  refine' ThreeAPFree.image (α := Fin n → ℕ) (β := ℕ) (s := sphere n d k) (map (2 * d - 1))
+    (map_injOn.mono _) threeAPFree_sphere
   · exact x
   rw [Set.add_subset_iff]
   rintro a ha b hb i
@@ -191,7 +191,7 @@ theorem addSalemSpencer_image_sphere :
   have hbi := mem_box.1 (sphere_subset_box hb) i
   rw [lt_tsub_iff_right, ← succ_le_iff, two_mul]
   exact (add_add_add_comm _ _ 1 1).trans_le (_root_.add_le_add hai hbi)
-#align behrend.add_salem_spencer_image_sphere Behrend.addSalemSpencer_image_sphere
+#align behrend.add_salem_spencer_image_sphere Behrend.threeAPFree_image_sphere
 
 theorem sum_sq_le_of_mem_box (hx : x ∈ box n d) : ∑ i : Fin n, x i ^ 2 ≤ n * (d - 1) ^ 2 := by
   rw [mem_box] at hx
@@ -216,7 +216,7 @@ theorem card_sphere_le_rothNumberNat (n d k : ℕ) :
   · dsimp; refine' (card_le_univ _).trans_eq _; rfl
   cases d
   · simp
-  refine' addSalemSpencer_image_sphere.le_rothNumberNat _ _ (card_image_of_injOn _)
+  refine' threeAPFree_image_sphere.le_rothNumberNat _ _ (card_image_of_injOn _)
   · intro; assumption
   · simp only [subset_iff, mem_image, and_imp, forall_exists_index, mem_range,
       forall_apply_eq_imp_iff₂, sphere, mem_filter]
@@ -231,7 +231,7 @@ theorem card_sphere_le_rothNumberNat (n d k : ℕ) :
 /-!
 ### Optimization
 
-Now that we know how to turn the integer points of any sphere into a Salem-Spencer set, we find a
+Now that we know how to turn the integer points of any sphere into a 3AP-free set, we find a
 sphere containing many integer points by the pigeonhole principle. This gives us an implicit bound
 that we then optimize by tweaking the parameters. The (almost) optimal parameters are
 `Behrend.nValue` and `Behrend.dValue`.

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -947,6 +947,7 @@ def nameDict : String → List String
   | "zpowers"     => ["zmultiples"]
   | "powers"      => ["multiples"]
   | "multipliable"=> ["summable"]
+  | "threegpfree" => ["threeAPFree"]
   | x             => [x]
 
 /--

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -947,7 +947,6 @@ def nameDict : String → List String
   | "zpowers"     => ["zmultiples"]
   | "powers"      => ["multiples"]
   | "multipliable"=> ["summable"]
-  | "threegpfree" => ["threeAPFree"]
   | x             => [x]
 
 /--
@@ -1032,6 +1031,8 @@ def fixAbbreviation : List String → List String
                                       => "function" :: "_" :: "commute" :: fixAbbreviation s
   | "zero" :: "Le" :: "Part" :: s         => "posPart" :: fixAbbreviation s
   | "le" :: "Zero" :: "Part" :: s         => "negPart" :: fixAbbreviation s
+  | "three" :: "GPFree" :: s         => "three" :: "APFree" :: fixAbbreviation s
+  | "Three" :: "GPFree" :: s         => "Three" :: "APFree" :: fixAbbreviation s
   | x :: s                            => x :: fixAbbreviation s
   | []                                => []
 


### PR DESCRIPTION
Salem and Spencer were neither the first to write a paper on them, nor gave the best bounds, hence the current choice of name is a bit odd (and so is the Wikipedia page).

This PR renames `MulSalemSpencer` to `ThreeGPFree` and `AddSalemSpencer` to `ThreeAPFree`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
