### PR TITLE
[Merged by Bors] - feat(RingTheory/Smooth): smooth algebras are flat

### DIFF
--- a/Mathlib/RingTheory/Smooth/Flat.lean
+++ b/Mathlib/RingTheory/Smooth/Flat.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.RingTheory.AdicCompletion.AsTensorProduct
 public import Mathlib.RingTheory.Flat.Stability
 public import Mathlib.RingTheory.Smooth.AdicCompletion
+public import Mathlib.RingTheory.Smooth.NoetherianDescent
 
 /-!
 # Smooth algebras are flat
@@ -20,7 +21,7 @@ The proof proceeds in two steps:
   of the canonical map `AdicCompletion I R[X₁, ..., Xₙ] →ₐ[R] R[X₁, ..., Xₙ] ⧸ I ≃ₐ[R] A`.
   Since `R` is Noetherian, `AdicCompletion I R` is `R`-flat so `A` is a retract
   of a flat `R`-module and hence flat.
-2. (TODO @chrisflav): In the general case, we choose a model of `A` over a finitely generated
+2. In the general case, we choose a model of `A` over a finitely generated
   `ℤ`-subalgebra of `R` and apply 1.
 
 
@@ -43,11 +44,18 @@ lemma FormallySmooth.flat_of_algHom_of_isNoetherianRing (f : S →ₐ[R] A) (hf 
   exact .of_retract g.toLinearMap
     (AdicCompletion.kerProj hf).toLinearMap (LinearMap.ext fun x ↦ congr($hg x))
 
-variable (R A) in
+variable (R A)
+
 /-- If `A` is `R`-smooth and `R` is Noetherian, then `A` is `R`-flat. -/
 instance Smooth.flat_of_isNoetherianRing [IsNoetherianRing R] [Algebra.Smooth R A] :
     Module.Flat R A := by
   obtain ⟨k, f, hf⟩ := (FiniteType.iff_quotient_mvPolynomial'' (R := R) (S := A)).mp inferInstance
   exact FormallySmooth.flat_of_algHom_of_isNoetherianRing f hf
+
+/-- Any smooth algebra is flat. -/
+instance Smooth.flat [Algebra.Smooth R A] : Module.Flat R A := by
+  obtain ⟨A₀, B₀, _, _, _, _, _, _, _, _, ⟨e⟩⟩ := exists_finiteType ℤ R A
+  have : IsNoetherianRing A₀ := Algebra.FiniteType.isNoetherianRing ℤ _
+  exact .of_linearEquiv e.toLinearEquiv
 
 end Algebra


### PR DESCRIPTION
We show that smooth ring homomorphisms are flat. The strategy for a smooth `A`-algebra `B` is the following:

- first we find a model of `B` over a Noetherian base ring
- if `A` is Noetherian, we identify `B` as a retract of the adic completion of a polynomial ring over `A`, which is flat

This is the summary PR which will be split in several parts.

Co-authored-by: Judith Ludwig <ludwig@mathi.uni-heidelberg.de>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #32064 
- [x] depends on: #25143 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
