### PR TITLE
[Merged by Bors] - feat : apply Qq update to add lake manifest

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -13,7 +13,7 @@
   {"url": "https://github.com/leanprover-community/quote4",
    "type": "git",
    "subDir": null,
-   "rev": "64365c656d5e1bffa127d2a1795f471529ee0178",
+   "rev": "53156671405fbbd5402ed17a79bd129b961bd8d6",
    "name": "Qq",
    "manifestFile": "lake-manifest.json",
    "inputRev": "master",


### PR DESCRIPTION
Mathlib update corresponding to [Qq update PR 42](https://github.com/leanprover-community/quote4/pull/42). The corresponding Qq PR added lake-manifest files into the repository. This PR updates mathlib to this commit of the PR. This PR addresses the warning message `warning: Qq: ignoring missing dependency manifest '././.lake/packages/Qq/lake-manifest.json'` when running `lake update` on a math project. For discussion see [this zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Qq.20manifest.20warning.20in.20new.20math.20project/near/437228437)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
