### PR TITLE
[Merged by Bors] - fix: generalize std_basis_eq_basis_mul_basis

### DIFF
--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -85,7 +85,8 @@ theorem matrix_eq_sum_std_basis [Fintype m] [Fintype n] (x : Matrix m n α) :
 -- this is not completely trivial because we are indexing by two types, instead of one
 -- TODO: add `std_basis_vec`
 theorem std_basis_eq_basis_mul_basis (i : m) (j : n) :
-    stdBasisMatrix i j 1 = vecMulVec (fun i' => ite (i = i') 1 0) fun j' => ite (j = j') 1 0 := by
+    stdBasisMatrix i j (1 : α) =
+      vecMulVec (fun i' => ite (i = i') 1 0) fun j' => ite (j = j') 1 0 := by
   ext i' j'
   -- Porting note: was `norm_num [std_basis_matrix, vec_mul_vec]` though there are no numerals
   -- involved.


### PR DESCRIPTION
The 1 has been silently interpreted as a natural since it was added in https://github.com/leanprover-community/mathlib/pull/3244.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
