### PR TITLE
[Merged by Bors] - refactor(Mathlib/Init/Data/List/Instances): deduplicate `Decidable (∀ x, x ∈ l → p x)` & `Decidable (∃ x, x ∈ l → p x)` instances

### DIFF
--- a/Mathlib/Data/Int/Range.lean
+++ b/Mathlib/Data/Int/Range.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kenny Lau
 -/
 import Mathlib.Algebra.Order.Ring.Int
-import Mathlib.Init.Data.List.Instances
 
 #align_import data.int.range from "leanprover-community/mathlib"@"7b78d1776212a91ecc94cf601f83bdcc46b04213"
 

--- a/Mathlib/Init/Data/List/Instances.lean
+++ b/Mathlib/Init/Data/List/Instances.lean
@@ -59,32 +59,8 @@ instance instAlternative : Alternative List.{u} where
 
 #noalign list.bin_tree_to_list
 
-variable {α : Type u} {p : α → Prop} [DecidablePred p]
+#align list.decidable_bex List.decidableBEx
 
--- To work around lean4#2552, we call specific `Decidable` instances and use `match` on them,
--- as opposed to using `if`.
-instance decidableExistsMem : ∀ (l : List α), Decidable (∃ x ∈ l, p x)
-  | []    => isFalse (by simp)
-  | x::xs =>
-    match ‹DecidablePred p› x with
-    | isTrue h₁ => isTrue ⟨x, mem_cons_self _ _, h₁⟩
-    | isFalse h₁ => match decidableExistsMem xs with
-      | isTrue h₂  => isTrue <| by
-        rcases h₂ with ⟨y, hm, hp⟩
-        exact ⟨y, mem_cons_of_mem _ hm, hp⟩
-      | isFalse h₂ => isFalse <| by
-        rintro ⟨y, hm, hp⟩
-        cases mem_cons.1 hm with
-        | inl h => rw [h] at hp; contradiction
-        | inr h => exact absurd ⟨y, h, hp⟩ h₂
-#align list.decidable_bex List.decidableExistsMem
-
-instance decidableForallMem (l : List α) : Decidable (∀ x ∈ l, p x) :=
-  match (inferInstance : Decidable <| ∃ x ∈ l, ¬ p x) with
-  | isFalse h => isTrue fun x hx => match ‹DecidablePred p› x with
-    | isTrue h' => h'
-    | isFalse h' => False.elim <| h ⟨x, hx, h'⟩
-  | isTrue h => isFalse <| let ⟨x, h, np⟩ := h; fun al => np (al x h)
-#align list.decidable_ball List.decidableForallMem
+#align list.decidable_ball List.decidableBAll
 
 end List


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Resolves #2910

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
