### PR TITLE
[Merged by Bors] - fix(Mathlib/Tactic/IrreducibleDef): `irreducible_def` incorrectly jump-to-definition

### DIFF
--- a/Mathlib/Tactic/IrreducibleDef.lean
+++ b/Mathlib/Tactic/IrreducibleDef.lean
@@ -85,7 +85,7 @@ elab mods:declModifiers "irreducible_def" n_id:declId n_def:(irredDefLemma)?
   let us' := us.getD { elemsAndSeps := #[] }
   let n_def ← match n_def.getD ⟨mkNullNode⟩ with
     | `(irredDefLemma| (lemma := $id)) => pure id
-    | _ => pure <| mkIdent <| (·.review) <|
+    | _ => pure <| mkIdentFrom n <| (·.review) <|
       let scopes := extractMacroScopes n.getId
       { scopes with name := scopes.name.appendAfter "_def" }
   let `(Parser.Command.declModifiersF|


### PR DESCRIPTION
```lean
import Mathlib.Tactic.Common

irreducible_def foo := 1

#check foo_def
```
If you jump to the definition of `foo_def`, you go to the top of the file, not declaration foo.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Resolves #7752

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
