### PR TITLE
[Merged by Bors] - chore(Order.Copy): clean up structure instance constructions 

### DIFF
--- a/Mathlib/Order/Copy.lean
+++ b/Mathlib/Order/Copy.lean
@@ -22,8 +22,6 @@ universe u
 
 variable {α : Type u}
 
--- Porting note: mathlib3 proof uses `refine { top := top, bot := bot, .. }` but this does not work
--- anymore
 /-- A function to create a provable equal copy of a bounded order
 with possibly different definitional equalities. -/
 def BoundedOrder.copy {h : LE α} {h' : LE α} (c : @BoundedOrder α h')
@@ -34,51 +32,37 @@ def BoundedOrder.copy {h : LE α} {h' : LE α} (c : @BoundedOrder α h')
     (@OrderBot.mk α h { bot := bot } (fun _ ↦ by simp [eq_bot, le_eq]))
 #align bounded_order.copy BoundedOrder.copy
 
--- Porting note: original proof uses
--- `all_goals { abstract { subst_vars, casesI c, simp_rw le_eq, assumption } }`
 /-- A function to create a provable equal copy of a lattice
 with possibly different definitional equalities. -/
 def Lattice.copy (c : Lattice α)
     (le : α → α → Prop) (eq_le : le = (by infer_instance : LE α).le)
     (sup : α → α → α) (eq_sup : sup = (by infer_instance : Sup α).sup)
-    (inf : α → α → α) (eq_inf : inf = (by infer_instance : Inf α).inf) : Lattice α := by
-  refine' { le := le, sup := sup, inf := inf, lt := fun a b ↦ le a b ∧ ¬ le b a.. }
-  · intros; simp [eq_le]
-  · intro _ _ _ hab hbc; rw [eq_le] at hab hbc ⊢; exact le_trans hab hbc
-  · intros; simp [eq_le]
-  · intro _ _ hab hba; simp_rw [eq_le] at hab hba; exact le_antisymm hab hba
-  · intros; simp [eq_le, eq_sup]
-  · intros; simp [eq_le, eq_sup]
-  · intro _ _ _ hac hbc; simp_rw [eq_le] at hac hbc ⊢; simp [eq_sup, hac, hbc]
-  · intros; simp [eq_le, eq_inf]
-  · intros; simp [eq_le, eq_inf]
-  · intro _ _ _ hac hbc; simp_rw [eq_le] at hac hbc ⊢; simp [eq_inf, hac, hbc]
+    (inf : α → α → α) (eq_inf : inf = (by infer_instance : Inf α).inf) : Lattice α where
+  le := le
+  sup := sup
+  inf := inf
+  lt := fun a b ↦ le a b ∧ ¬ le b a
+  le_refl := by intros; simp [eq_le]
+  le_trans := by intro _ _ _ hab hbc; rw [eq_le] at hab hbc ⊢; exact le_trans hab hbc
+  le_antisymm := by intro _ _ hab hba; simp_rw [eq_le] at hab hba; exact le_antisymm hab hba
+  le_sup_left := by intros; simp [eq_le, eq_sup]
+  le_sup_right := by intros; simp [eq_le, eq_sup]
+  sup_le := by intro _ _ _ hac hbc; simp_rw [eq_le] at hac hbc ⊢; simp [eq_sup, hac, hbc]
+  inf_le_left := by intros; simp [eq_le, eq_inf]
+  inf_le_right := by intros; simp [eq_le, eq_inf]
+  le_inf := by intro _ _ _ hac hbc; simp_rw [eq_le] at hac hbc ⊢; simp [eq_inf, hac, hbc]
 #align lattice.copy Lattice.copy
 
--- Porting note: original proof uses
--- `all_goals { abstract { subst_vars, casesI c, simp_rw le_eq, assumption } }`
 /-- A function to create a provable equal copy of a distributive lattice
 with possibly different definitional equalities. -/
 def DistribLattice.copy (c : DistribLattice α)
     (le : α → α → Prop) (eq_le : le = (by infer_instance : LE α).le)
     (sup : α → α → α) (eq_sup : sup = (by infer_instance : Sup α).sup)
-    (inf : α → α → α) (eq_inf : inf = (by infer_instance : Inf α).inf) : DistribLattice α := by
-  refine' { le := le, sup := sup, inf := inf, lt := fun a b ↦ le a b ∧ ¬ le b a.. }
-  · intros; simp [eq_le]
-  · intro _ _ _ hab hbc; rw [eq_le] at hab hbc ⊢; exact le_trans hab hbc
-  · intros; simp [eq_le]
-  · intro _ _ hab hba; simp_rw [eq_le] at hab hba; exact le_antisymm hab hba
-  · intros; simp [eq_le, eq_sup]
-  · intros; simp [eq_le, eq_sup]
-  · intro _ _ _ hac hbc; simp_rw [eq_le] at hac hbc ⊢; simp [eq_sup, hac, hbc]
-  · intros; simp [eq_le, eq_inf]
-  · intros; simp [eq_le, eq_inf]
-  · intro _ _ _ hac hbc; simp_rw [eq_le] at hac hbc ⊢; simp [eq_inf, hac, hbc]
-  · intros; simp [eq_le, eq_inf, eq_sup, le_sup_inf]
+    (inf : α → α → α) (eq_inf : inf = (by infer_instance : Inf α).inf) : DistribLattice α where
+  toLattice := Lattice.copy (@DistribLattice.toLattice α c) le eq_le sup eq_sup inf eq_inf
+  le_sup_inf := by intros; simp [eq_le, eq_sup, eq_inf, le_sup_inf]
 #align distrib_lattice.copy DistribLattice.copy
 
--- Porting note: original proof uses
--- `all_goals { abstract { subst_vars, casesI c, simp_rw le_eq, assumption } }`
 /-- A function to create a provable equal copy of a complete lattice
 with possibly different definitional equalities. -/
 def CompleteLattice.copy (c : CompleteLattice α)
@@ -89,19 +73,20 @@ def CompleteLattice.copy (c : CompleteLattice α)
     (inf : α → α → α) (eq_inf : inf = (by infer_instance : Inf α).inf)
     (sSup : Set α → α) (eq_sSup : sSup = (by infer_instance : SupSet α).sSup)
     (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) :
-    CompleteLattice α := by
-  refine' { Lattice.copy (@CompleteLattice.toLattice α c) le eq_le sup eq_sup inf eq_inf with
-    le := le, top := top, bot := bot, sup := sup, inf := inf, sSup := sSup, sInf := sInf.. }
-  · intro _ _ h; simp [eq_le, eq_sSup, le_sSup _ _ h]
-  · intro _ _ h; simpa [eq_le, eq_sSup] using h
-  · intro _ _ h; simp [eq_le, eq_sInf, sInf_le _ _ h]
-  · intro _ _ h; simpa [eq_le, eq_sInf] using h
-  · intros; simp [eq_le, eq_top]
-  · intros; simp [eq_le, eq_bot]
+    CompleteLattice α where
+  toLattice := Lattice.copy (@CompleteLattice.toLattice α c) le eq_le sup eq_sup inf eq_inf
+  top := top
+  bot := bot
+  sSup := sSup
+  sInf := sInf
+  le_sSup := by intro _ _ h; simp [eq_le, eq_sSup, le_sSup _ _ h]
+  sSup_le := by intro _ _ h; simpa [eq_le, eq_sSup] using h
+  sInf_le := by intro _ _ h; simp [eq_le, eq_sInf, sInf_le _ _ h]
+  le_sInf := by intro _ _ h; simpa [eq_le, eq_sInf] using h
+  le_top := by intros; simp [eq_le, eq_top]
+  bot_le := by intros; simp [eq_le, eq_bot]
 #align complete_lattice.copy CompleteLattice.copy
 
--- Porting note: original proof uses
--- `all_goals { abstract { subst_vars, casesI c, simp_rw le_eq, assumption } }`
 /-- A function to create a provable equal copy of a frame with possibly different definitional
 equalities. -/
 def Frame.copy (c : Frame α) (le : α → α → Prop) (eq_le : le = (by infer_instance : LE α).le)
@@ -110,11 +95,11 @@ def Frame.copy (c : Frame α) (le : α → α → Prop) (eq_le : le = (by infer_
     (sup : α → α → α) (eq_sup : sup = (by infer_instance : Sup α).sup)
     (inf : α → α → α) (eq_inf : inf = (by infer_instance : Inf α).inf)
     (sSup : Set α → α) (eq_sSup : sSup = (by infer_instance : SupSet α).sSup)
-    (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) : Frame α :=
-  { CompleteLattice.copy (@Frame.toCompleteLattice α c) le eq_le top eq_top bot eq_bot
-      sup eq_sup inf eq_inf sSup eq_sSup sInf eq_sInf with
-    inf_sSup_le_iSup_inf := fun a s => by
-      simp [eq_le, eq_sup, eq_inf, eq_sSup, @Order.Frame.inf_sSup_le_iSup_inf α _ a s] }
+    (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) : Frame α where
+  toCompleteLattice := CompleteLattice.copy (@Frame.toCompleteLattice α c)
+    le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf sSup eq_sSup sInf eq_sInf
+  inf_sSup_le_iSup_inf := fun a s => by
+    simp [eq_le, eq_sup, eq_inf, eq_sSup, @Order.Frame.inf_sSup_le_iSup_inf α _ a s]
 #align frame.copy Frame.copy
 
 -- Porting note: original proof uses
@@ -127,11 +112,11 @@ def Coframe.copy (c : Coframe α) (le : α → α → Prop) (eq_le : le = (by in
     (sup : α → α → α) (eq_sup : sup = (by infer_instance : Sup α).sup)
     (inf : α → α → α) (eq_inf : inf = (by infer_instance : Inf α).inf)
     (sSup : Set α → α) (eq_sSup : sSup = (by infer_instance : SupSet α).sSup)
-    (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) : Coframe α :=
-  { CompleteLattice.copy (@Coframe.toCompleteLattice α c) le eq_le top eq_top bot eq_bot sup
-        eq_sup inf eq_inf sSup eq_sSup sInf eq_sInf with
-    iInf_sup_le_sup_sInf := fun a s => by
-      simp [eq_le, eq_sup, eq_inf, eq_sInf, @Order.Coframe.iInf_sup_le_sup_sInf α _ a s] }
+    (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) : Coframe α where
+  toCompleteLattice := CompleteLattice.copy (@Coframe.toCompleteLattice α c)
+    le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf sSup eq_sSup sInf eq_sInf
+  iInf_sup_le_sup_sInf := fun a s => by
+    simp [eq_le, eq_sup, eq_inf, eq_sInf, @Order.Coframe.iInf_sup_le_sup_sInf α _ a s]
 #align coframe.copy Coframe.copy
 
 /-- A function to create a provable equal copy of a complete distributive lattice
@@ -144,11 +129,11 @@ def CompleteDistribLattice.copy (c : CompleteDistribLattice α)
     (inf : α → α → α) (eq_inf : inf = (by infer_instance : Inf α).inf)
     (sSup : Set α → α) (eq_sSup : sSup = (by infer_instance : SupSet α).sSup)
     (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) :
-    CompleteDistribLattice α :=
-  { Frame.copy (@CompleteDistribLattice.toFrame α c) le eq_le top eq_top bot eq_bot sup eq_sup inf
-      eq_inf sSup eq_sSup sInf eq_sInf,
-    Coframe.copy (@CompleteDistribLattice.toCoframe α c) le eq_le top eq_top bot eq_bot sup eq_sup
-      inf eq_inf sSup eq_sSup sInf eq_sInf with }
+    CompleteDistribLattice α where
+  toFrame := Frame.copy (@CompleteDistribLattice.toFrame α c)
+    le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf sSup eq_sSup sInf eq_sInf
+  __ := Coframe.copy (@CompleteDistribLattice.toCoframe α c)
+    le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf sSup eq_sSup sInf eq_sInf
 #align complete_distrib_lattice.copy CompleteDistribLattice.copy
 
 -- Porting note: original proof uses
@@ -161,21 +146,13 @@ def ConditionallyCompleteLattice.copy (c : ConditionallyCompleteLattice α)
     (inf : α → α → α) (eq_inf : inf = (by infer_instance : Inf α).inf)
     (sSup : Set α → α) (eq_sSup : sSup = (by infer_instance : SupSet α).sSup)
     (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) :
-    ConditionallyCompleteLattice α := by
-  refine' { le := le, sup := sup, inf := inf, sSup := sSup, sInf := sInf.. }
-  · intro a b; exact le a b ∧ ¬ le b a
-  · intros; simp [eq_le]
-  · intro _ _ _ hab hbc; rw [eq_le] at hab hbc ⊢; exact le_trans hab hbc
-  · intros; simp [eq_le]
-  · intro _ _ hab hba; simp_rw [eq_le] at hab hba; exact le_antisymm hab hba
-  · intros; simp [eq_le, eq_sup]
-  · intros; simp [eq_le, eq_sup]
-  · intro _ _ _ hac hbc; simp_rw [eq_le] at hac hbc ⊢; simp [eq_sup, hac, hbc]
-  · intros; simp [eq_le, eq_inf]
-  · intros; simp [eq_le, eq_inf]
-  · intro _ _ _ hac hbc; simp_rw [eq_le] at hac hbc ⊢; simp [eq_inf, hac, hbc]
-  · intro _ _ hb h; subst_vars; exact le_csSup _ _ hb h
-  · intro _ _ hb h; subst_vars; exact csSup_le _ _ hb h
-  · intro _ _ hb h; subst_vars; exact csInf_le _ _ hb h
-  · intro _ _ hb h; subst_vars; exact le_csInf _ _ hb h
+    ConditionallyCompleteLattice α where
+  toLattice := Lattice.copy (@ConditionallyCompleteLattice.toLattice α c)
+    le eq_le sup eq_sup inf eq_inf
+  sSup := sSup
+  sInf := sInf
+  le_csSup := by intro _ _ hb h; subst_vars; exact le_csSup _ _ hb h
+  csSup_le := by intro _ _ hb h; subst_vars; exact csSup_le _ _ hb h
+  csInf_le := by intro _ _ hb h; subst_vars; exact csInf_le _ _ hb h
+  le_csInf := by intro _ _ hb h; subst_vars; exact le_csInf _ _ hb h
 #align conditionally_complete_lattice.copy ConditionallyCompleteLattice.copy


### PR DESCRIPTION
After the port, this used a `refine' {foo := foo, bar := bar, ..}` pattern to build the instances. We clean this up.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
