### PR TITLE
[Merged by Bors] - refactor: Make `CompleteDistribLattice` extend `Coframe`

### DIFF
--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -76,18 +76,11 @@ open Order
 
 /-- A complete distributive lattice is a complete lattice whose `⊔` and `⊓` respectively
 distribute over `⨅` and `⨆`. -/
-class CompleteDistribLattice (α : Type*) extends Frame α where
-  iInf_sup_le_sup_sInf : ∀ a s, ⨅ b ∈ s, a ⊔ b ≤ a ⊔ sInf s
+class CompleteDistribLattice (α : Type*) extends Frame α, Coframe α
 #align complete_distrib_lattice CompleteDistribLattice
 
 /-- In a complete distributive lattice, `⊔` distributes over `⨅`. -/
 add_decl_doc CompleteDistribLattice.iInf_sup_le_sup_sInf
-
--- See note [lower instance priority]
-instance (priority := 100) CompleteDistribLattice.toCoframe [CompleteDistribLattice α] :
-    Coframe α :=
-  { ‹CompleteDistribLattice α› with }
-#align complete_distrib_lattice.to_coframe CompleteDistribLattice.toCoframe
 
 /-- A completely distributive lattice is a complete lattice whose `⨅` and `⨆`
 distribute over each other. -/


### PR DESCRIPTION
This spares us to write one instance by hand and also reduces the diff of #10560 a bit (after which we really need that `extends` clause)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
