### PR TITLE
[Merged by Bors] - refactor: Make `CompleteLinearOrder` extend `BiheytingAlgebra`

### DIFF
--- a/Mathlib/Data/Fintype/Order.lean
+++ b/Mathlib/Data/Fintype/Order.lean
@@ -118,7 +118,7 @@ noncomputable abbrev toCompleteDistribLattice [DistribLattice α] [BoundedOrder 
 /-- A finite bounded linear order is complete. -/
 noncomputable abbrev toCompleteLinearOrder
     [LinearOrder α] [BoundedOrder α] : CompleteLinearOrder α :=
-  { toCompleteLattice α, ‹LinearOrder α› with }
+  { toCompleteLattice α, ‹LinearOrder α›, LinearOrder.toBiheytingAlgebra with }
 #align fintype.to_complete_linear_order Fintype.toCompleteLinearOrder
 
 -- See note [reducible non-instances]
@@ -151,8 +151,9 @@ noncomputable abbrev toCompleteLatticeOfNonempty [Lattice α] : CompleteLattice 
 /-- A nonempty finite linear order is complete. If the linear order is already a `BoundedOrder`,
 then use `Fintype.toCompleteLinearOrder` instead, as this gives definitional equality for `⊥` and
 `⊤`. -/
-noncomputable abbrev toCompleteLinearOrderOfNonempty [LinearOrder α] : CompleteLinearOrder α :=
-  { toCompleteLatticeOfNonempty α, ‹LinearOrder α› with }
+noncomputable abbrev toCompleteLinearOrderOfNonempty [LinearOrder α] : CompleteLinearOrder α := by
+  let _ := toBoundedOrder α
+  exact { toCompleteLatticeOfNonempty α, ‹LinearOrder α›, LinearOrder.toBiheytingAlgebra with }
 #align fintype.to_complete_linear_order_of_nonempty Fintype.toCompleteLinearOrderOfNonempty
 
 end Nonempty

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -889,13 +889,7 @@ noncomputable instance : LinearOrderedAddCommMonoidWithTop PartENat :=
     top_add' := top_add }
 
 noncomputable instance : CompleteLinearOrder PartENat :=
-  { PartENat.lattice, withTopOrderIso.symm.toGaloisInsertion.liftCompleteLattice,
-    PartENat.linearOrder with
-    inf := (· ⊓ ·)
-    sup := (· ⊔ ·)
-    top := ⊤
-    bot := ⊥
-    le := (· ≤ ·)
-    lt := (· < ·) }
+  { lattice, withTopOrderIso.symm.toGaloisInsertion.liftCompleteLattice,
+    linearOrder, LinearOrder.toBiheytingAlgebra with }
 
 end PartENat

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -606,9 +606,6 @@ instance instCompleteAtomicBooleanAlgebra : CompleteAtomicBooleanAlgebra PUnit :
 
 instance instCompleteBooleanAlgebra : CompleteBooleanAlgebra PUnit := inferInstance
 
-instance instCompleteLinearOrder : CompleteLinearOrder PUnit :=
-  { PUnit.instCompleteBooleanAlgebra, PUnit.instLinearOrder with }
-
 @[simp]
 theorem sSup_eq : sSup s = unit :=
   rfl

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -308,7 +308,7 @@ def completeLatticeOfCompleteSemilatticeSup (α : Type*) [CompleteSemilatticeSup
 -- Instead we add the fields by hand, and write a manual instance.
 
 /-- A complete linear order is a linear order whose lattice structure is complete. -/
-class CompleteLinearOrder (α : Type*) extends CompleteLattice α where
+class CompleteLinearOrder (α : Type*) extends CompleteLattice α, BiheytingAlgebra α where
   /-- A linear order is total. -/
   le_total (a b : α) : a ≤ b ∨ b ≤ a
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
@@ -344,6 +344,7 @@ instance instCompleteLattice [CompleteLattice α] : CompleteLattice αᵒᵈ whe
 
 instance instCompleteLinearOrder [CompleteLinearOrder α] : CompleteLinearOrder αᵒᵈ where
   __ := instCompleteLattice
+  __ := instBiheytingAlgebra
   __ := instLinearOrder α
 
 end OrderDual
@@ -1698,6 +1699,7 @@ instance Prop.instCompleteLattice : CompleteLattice Prop where
 noncomputable instance Prop.instCompleteLinearOrder : CompleteLinearOrder Prop where
   __ := Prop.instCompleteLattice
   __ := Prop.linearOrder
+  __ := BooleanAlgebra.toBiheytingAlgebra
 #align Prop.complete_linear_order Prop.instCompleteLinearOrder
 
 @[simp]

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -1991,3 +1991,14 @@ instance instCompleteLattice [CompleteLattice Î±] : CompleteLattice (ULift.{v} Î
     (fun s => by rw [sInf_eq_iInf', down_iInf, iInf_subtype'']) down_top down_bot
 
 end ULift
+
+namespace PUnit
+
+instance instCompleteLinearOrder : CompleteLinearOrder PUnit := by
+  refine'
+    { instBooleanAlgebra, instLinearOrder with
+      sSup := fun _ => unit
+      sInf := fun _ => unit
+      .. } <;> intros <;> trivial
+
+end PUnit

--- a/Mathlib/Order/CompleteLatticeIntervals.lean
+++ b/Mathlib/Order/CompleteLatticeIntervals.lean
@@ -216,8 +216,9 @@ noncomputable def Set.Icc.completeLattice [ConditionallyCompleteLattice α]
 
 /-- Complete linear order structure on `Set.Icc` -/
 noncomputable def Set.Icc.completeLinearOrder [ConditionallyCompleteLinearOrder α]
-    {a b : α} (h : a ≤ b) : CompleteLinearOrder (Set.Icc a b) :=
-  { Set.Icc.completeLattice h, Subtype.instLinearOrder _ with }
+    {a b : α} (h : a ≤ b) : CompleteLinearOrder (Set.Icc a b) := by
+  let _ := completeLattice h
+  exact { completeLattice h, Subtype.instLinearOrder _, LinearOrder.toBiheytingAlgebra with }
 
 lemma Set.Icc.coe_sSup [ConditionallyCompleteLattice α] {a b : α} (h : a ≤ b)
     {S : Set (Set.Icc a b)} (hS : S.Nonempty) : letI := Set.Icc.completeLattice h

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -1380,14 +1380,13 @@ theorem isGLB_sInf (s : Set (WithTop α)) : IsGLB s (sInf s) := by
     exact bot_le
 #align with_top.is_glb_Inf WithTop.isGLB_sInf
 
-noncomputable instance : CompleteLinearOrder (WithTop α) :=
-  { WithTop.linearOrder, WithTop.lattice, WithTop.orderTop, WithTop.orderBot with
-    sup := Sup.sup
-    le_sSup := fun s => (isLUB_sSup s).1
-    sSup_le := fun s => (isLUB_sSup s).2
-    inf := Inf.inf
-    le_sInf := fun s => (isGLB_sInf s).2
-    sInf_le := fun s => (isGLB_sInf s).1 }
+noncomputable instance : CompleteLinearOrder (WithTop α) where
+  __ := linearOrder
+  __ := LinearOrder.toBiheytingAlgebra
+  le_sSup s := (isLUB_sSup s).1
+  sSup_le s := (isLUB_sSup s).2
+  le_sInf s := (isGLB_sInf s).2
+  sInf_le s := (isGLB_sInf s).1
 
 /-- A version of `WithTop.coe_sSup'` with a more convenient but less general statement. -/
 @[norm_cast]
@@ -1683,7 +1682,8 @@ noncomputable instance WithTop.WithBot.completeLattice {α : Type*}
 
 noncomputable instance WithTop.WithBot.completeLinearOrder {α : Type*}
     [ConditionallyCompleteLinearOrder α] : CompleteLinearOrder (WithTop (WithBot α)) :=
-  { WithTop.WithBot.completeLattice, WithTop.linearOrder with }
+  -- FIXME: Spread notation doesn't work
+  { completeLattice, linearOrder, LinearOrder.toBiheytingAlgebra with }
 #align with_top.with_bot.complete_linear_order WithTop.WithBot.completeLinearOrder
 
 noncomputable instance WithBot.WithTop.completeLattice {α : Type*}
@@ -1697,7 +1697,7 @@ noncomputable instance WithBot.WithTop.completeLattice {α : Type*}
 
 noncomputable instance WithBot.WithTop.completeLinearOrder {α : Type*}
     [ConditionallyCompleteLinearOrder α] : CompleteLinearOrder (WithBot (WithTop α)) :=
-  { WithBot.WithTop.completeLattice, WithBot.linearOrder with }
+  { completeLattice, linearOrder, LinearOrder.toBiheytingAlgebra with }
 #align with_bot.with_top.complete_linear_order WithBot.WithTop.completeLinearOrder
 
 namespace WithTop

--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -1028,19 +1028,27 @@ instance UpperSet.isTotal_le : IsTotal (UpperSet α) (· ≤ ·) := ⟨fun s t =
 instance LowerSet.isTotal_le : IsTotal (LowerSet α) (· ≤ ·) := ⟨fun s t => s.lower.total t.lower⟩
 #align lower_set.is_total_le LowerSet.isTotal_le
 
-noncomputable instance : CompleteLinearOrder (UpperSet α) :=
-  { UpperSet.completelyDistribLattice with
-    le_total := IsTotal.total
-    decidableLE := Classical.decRel _
-    decidableEq := Classical.decRel _
-    decidableLT := Classical.decRel _ }
+noncomputable instance UpperSet.instLinearOrder : LinearOrder (UpperSet α) := by
+  classical exact Lattice.toLinearOrder _
 
-noncomputable instance : CompleteLinearOrder (LowerSet α) :=
-  { LowerSet.completelyDistribLattice with
-    le_total := IsTotal.total
-    decidableLE := Classical.decRel _
-    decidableEq := Classical.decRel _
-    decidableLT := Classical.decRel _ }
+noncomputable instance LowerSet.instLinearOrder : LinearOrder (LowerSet α) := by
+  classical exact Lattice.toLinearOrder _
+
+noncomputable instance UpperSet.instCompleteLinearOrder : CompleteLinearOrder (UpperSet α) where
+  __ := completelyDistribLattice
+  __ := LinearOrder.toBiheytingAlgebra
+  le_total := IsTotal.total
+  decidableLE := Classical.decRel _
+  decidableEq := Classical.decRel _
+  decidableLT := Classical.decRel _
+
+noncomputable instance LowerSet.instCompleteLinearOrder : CompleteLinearOrder (LowerSet α) where
+  __ := completelyDistribLattice
+  __ := LinearOrder.toBiheytingAlgebra
+  le_total := IsTotal.total
+  decidableLE := Classical.decRel _
+  decidableEq := Classical.decRel _
+  decidableLT := Classical.decRel _
 
 end LinearOrder
 

--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -1034,21 +1034,11 @@ noncomputable instance UpperSet.instLinearOrder : LinearOrder (UpperSet α) := b
 noncomputable instance LowerSet.instLinearOrder : LinearOrder (LowerSet α) := by
   classical exact Lattice.toLinearOrder _
 
-noncomputable instance UpperSet.instCompleteLinearOrder : CompleteLinearOrder (UpperSet α) where
-  __ := completelyDistribLattice
-  __ := LinearOrder.toBiheytingAlgebra
-  le_total := IsTotal.total
-  decidableLE := Classical.decRel _
-  decidableEq := Classical.decRel _
-  decidableLT := Classical.decRel _
+noncomputable instance UpperSet.instCompleteLinearOrder : CompleteLinearOrder (UpperSet α) :=
+  { completelyDistribLattice, instLinearOrder, LinearOrder.toBiheytingAlgebra with }
 
-noncomputable instance LowerSet.instCompleteLinearOrder : CompleteLinearOrder (LowerSet α) where
-  __ := completelyDistribLattice
-  __ := LinearOrder.toBiheytingAlgebra
-  le_total := IsTotal.total
-  decidableLE := Classical.decRel _
-  decidableEq := Classical.decRel _
-  decidableLT := Classical.decRel _
+noncomputable instance LowerSet.instCompleteLinearOrder : CompleteLinearOrder (LowerSet α) :=
+  { completelyDistribLattice, instLinearOrder, LinearOrder.toBiheytingAlgebra with }
 
 end LinearOrder
 


### PR DESCRIPTION
In fact, linear orders themselves are biheyting algebras, but registering this as an instance causes a bit of a chicken and the egg problem which I'm not willing to try solving. `CompleteLinearOrder` really does need to extend `BiheytingAlgebra` if we are going to make `Frame` extend `HeytingAlgebra`.

This is a step towards #10560

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
