### PR TITLE
[Merged by Bors] - chore: Remove positivity extension for `Finset.card` stub

### DIFF
--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -1293,31 +1293,3 @@ theorem Fintype.induction_subsingleton_or_nontrivial {P : ∀ (α) [Fintype α],
     rw [hn] at hlt
     exact ih (Fintype.card β) hlt _ rfl
 #align fintype.induction_subsingleton_or_nontrivial Fintype.induction_subsingleton_or_nontrivial
-
-namespace Tactic
-
---open Positivity
-
-private theorem card_univ_pos (α : Type*) [Fintype α] [Nonempty α] :
-    0 < (Finset.univ : Finset α).card :=
-  Finset.univ_nonempty.card_pos
-
---Porting note(https://github.com/leanprover-community/mathlib4/issues/6038): restore
--- /-- Extension for the `positivity` tactic: `Finset.card s` is positive if `s` is nonempty. -/
--- @[positivity]
--- unsafe def positivity_finset_card : expr → tactic strictness
---   | q(Finset.card $(s)) => do
---     let p
---       ← -- TODO: Partial decision procedure for `Finset.nonempty`
---             to_expr
---             ``(Finset.Nonempty $(s)) >>=
---           find_assumption
---     positive <$> mk_app `` Finset.Nonempty.card_pos [p]
---   | q(@Fintype.card $(α) $(i)) => positive <$> mk_mapp `` Fintype.card_pos [α, i, none]
---   | e =>
---     pp e >>=
---       fail ∘
---       format.bracket "The expression `" "` isn't of the form `Finset.card s` or `Fintype.card α`"
--- #align tactic.positivity_finset_card tactic.positivity_finset_card
-
-end Tactic


### PR DESCRIPTION
The extension was already implemented in #10610.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
