### PR TITLE
[Merged by Bors] - feat: `refold_let` tactic

### DIFF
--- a/test/DefEqTransformations.lean
+++ b/test/DefEqTransformations.lean
@@ -87,6 +87,30 @@ example (a : Int) (a : Nat) : Nat := by
   unfold_let at *
   exact a
 
+set_option linter.unusedVariables false in
+example : let x := 1; let y := 2 + x; 2 + 1 = 3 := by
+  intro x y
+  refold_let x
+  guard_target =ₛ 2 + x = 3
+  refold_let y
+  guard_target =ₛ y = 3
+  rfl
+
+example : 5 = 5 := by
+  let x := 5
+  refold_let x
+  guard_target =ₛ x = x
+  rfl
+
+example : 2 + 1 = 3 := by
+  let a : Fin 1 := 0
+  let x := 1
+  let b : Fin 1 := 0
+  refold_let x at *
+  guard_hyp a :ₛ Fin 1 := 0
+  guard_hyp b :ₛ Fin x := 0
+  rfl
+
 example : 1 + 2 = 2 + 1 := by
   unfold_projs
   guard_target =ₛ Nat.add (nat_lit 1) (nat_lit 2) = Nat.add (nat_lit 2) (nat_lit 1)


### PR DESCRIPTION
If `x := v` is a local definition, the `refold_let x` tactic is roughly equivalent to `rw [show v = x from rfl]`. That's to say, it looks for instances of `v` and replaces them with `x`.

Adds location in formation in the `runDefEqTactic` interface so that defeq tactics can know which location is being changed, which is important for `refold_let` since `refold_let x at *` should only affect locations that come after `x`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
