### PR TITLE
[Merged by Bors] - chore(ConcreteCategory): remove refine' pattern 

### DIFF
--- a/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
@@ -62,8 +62,8 @@ Currently that is not a problem, as there are almost no instances of `BundledHom
 -/
 instance category : Category (Bundled c) where
   Hom := fun X Y => hom X.str Y.str
-  id := fun X => @BundledHom.id c hom 𝒞 X X.str
-  comp := @fun X Y Z f g => @BundledHom.comp c hom 𝒞 X Y Z X.str Y.str Z.str g f
+  id := fun X => BundledHom.id 𝒞 (α := X) X.str
+  comp := fun {X Y Z} f g => BundledHom.comp 𝒞 (α := X) (β := Y) (γ := Z) X.str Y.str Z.str g f
   comp_id _ := by apply 𝒞.hom_ext; simp
   assoc _ _ _ := by apply 𝒞.hom_ext; aesop_cat
   id_comp _ := by apply 𝒞.hom_ext; simp

--- a/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
@@ -60,14 +60,13 @@ set_option synthInstance.checkSynthOrder false in
 This instance generates the type-class problem `BundledHom ?m`.
 Currently that is not a problem, as there are almost no instances of `BundledHom`.
 -/
-instance category : Category (Bundled c) := by
-  refine' { Hom := fun X Y => @hom X Y X.str Y.str
-            id := fun X => @BundledHom.id c hom 𝒞 X X.str
-            comp := @fun X Y Z f g => @BundledHom.comp c hom 𝒞 X Y Z X.str Y.str Z.str g f
-            comp_id := _
-            id_comp := _
-            assoc := _ } <;> intros <;> apply 𝒞.hom_ext <;>
-    aesop_cat
+instance category : Category (Bundled c) where
+  Hom := fun X Y => hom X.str Y.str
+  id := fun X => @BundledHom.id c hom 𝒞 X X.str
+  comp := @fun X Y Z f g => @BundledHom.comp c hom 𝒞 X Y Z X.str Y.str Z.str g f
+  comp_id _ := by apply 𝒞.hom_ext; simp
+  assoc _ _ _ := by apply 𝒞.hom_ext; aesop_cat
+  id_comp _ := by apply 𝒞.hom_ext; simp
 #align category_theory.bundled_hom.category CategoryTheory.BundledHom.category
 
 /-- A category given by `BundledHom` is a concrete category. -/


### PR DESCRIPTION
Similar to #12729, we should avoid constructing data using the `refine' { foo := foo, bar := bar .. }` pattern.

Building data with tactics is always a dicey proposition and should be a last resort. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
