### PR TITLE
Tests Polyrith

### DIFF
--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -422,7 +422,7 @@ elab_rules : tactic
   | `(tactic| polyrith%$tk $[only%$onlyTk]? $[[$hyps,*]]?) => do
     let hyps ← hyps.map (·.getElems) |>.getD #[] |>.mapM (elabTerm · none)
     let traceMe ← Lean.isTracingEnabledFor `Meta.Tactic.polyrith
-    match ← polyrith (← getMainGoal) tk.isNone hyps traceMe with
+    match ← polyrith (← getMainGoal) onlyTk.isNone hyps traceMe with
     | .ok stx =>
       replaceMainGoal []
       if !traceMe then Lean.Meta.Tactic.TryThis.addSuggestion tk stx

--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -422,7 +422,7 @@ elab_rules : tactic
   | `(tactic| polyrith%$tk $[only%$onlyTk]? $[[$hyps,*]]?) => do
     let hyps ← hyps.map (·.getElems) |>.getD #[] |>.mapM (elabTerm · none)
     let traceMe ← Lean.isTracingEnabledFor `Meta.Tactic.polyrith
-    match ← polyrith (← getMainGoal) onlyTk.isNone hyps traceMe with
+    match ← polyrith (← getMainGoal) onlyTk.isSome hyps traceMe with
     | .ok stx =>
       replaceMainGoal []
       if !traceMe then Lean.Meta.Tactic.TryThis.addSuggestion tk stx

--- a/test/polyrith.lean
+++ b/test/polyrith.lean
@@ -742,5 +742,5 @@ example (y a : ℤ) (k : ℕ) (h : a ^ k = 0) : a ^ k * y = 0 := by
   polyrith
 
 example (a b : ℤ) (h : a + b = 4) (h2 : a + b = 0) : a + b = 0 := by
-  try polyrith --should fail
+  fail_if_success polyrith -- should fail
   polyrith only [h2]

--- a/test/polyrith.lean
+++ b/test/polyrith.lean
@@ -727,15 +727,20 @@ by create_polyrith_test
 
 -/
 
--- example (a b : ℤ) (h : a + b = 4) : a + b = 0 := by
---   fail_if_success polyrith
---   -- polyrith failed to retrieve a solution from Sage!
---   -- ValueError: polynomial is not in the ideal
---   sorry
+example (a b : ℤ) (h : a + b = 4) : a + b = 0 := by
+  fail_if_success polyrith
+  -- polyrith failed to retrieve a solution from Sage!
+  -- ValueError: polynomial is not in the ideal
+  sorry
 
--- example (a : ℕ) : a = 0 := by
---   have := True.intro
---   polyrith -- polyrith did not find any relevant hypotheses and the goal is not provable by ring
+example (a : ℕ) : a = 0 := by
+  have := True.intro
+  fail_if_success polyrith -- polyrith did not find any relevant hypotheses and the goal is not provable by ring
+  sorry
 
--- example (y a : ℤ) (k : ℕ) (h : a ^ k = 0) : a ^ k * y = 0 := by
---   polyrith
+example (y a : ℤ) (k : ℕ) (h : a ^ k = 0) : a ^ k * y = 0 := by
+  polyrith
+
+example (a b : ℤ) (h : a + b = 4) (h2 : a + b = 0) : a + b = 0 := by
+  try polyrith --should fail
+  polyrith only [h2]


### PR DESCRIPTION
Change onlyTk.isNone to onlyTk.isSome according to
https://github.com/leanprover-community/mathlib4/pull/12754

Uncomment some tests for polyrith and added one
test which only works with the only keyword.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
