### PR TITLE
[Merged by Bors] - fix: remove MathlibExtras from mk_all.sh

### DIFF
--- a/scripts/mk_all.sh
+++ b/scripts/mk_all.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 cd "$(git rev-parse --show-toplevel)" || exit 1
-for gp in Mathlib MathlibExtras Mathlib/Tactic Counterexamples Archive
+for gp in Mathlib Mathlib/Tactic Counterexamples Archive
 do
   git ls-files "$gp/*.lean" | LC_ALL=C sort | sed 's/\.lean//;s,/,.,g;s/^/import /' > "$gp.lean"
 done


### PR DESCRIPTION
This directory was removed in #12548.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
