### PR TITLE
[Merged by Bors] - feat(Mathlib.NumberTheory.FLT.Three): add `FermatLastTheoremForThree_of_FermatLastTheoremThreeGen`

### DIFF
--- a/Mathlib/NumberTheory/Cyclotomic/Rat.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Rat.lean
@@ -448,7 +448,7 @@ lemma toInteger_sub_one_dvd_prime [hcycl : IsCyclotomicExtension {p ^ (k + 1)} �
 
 /-- In a `p`-th cyclotomic extension of `ℚ`, we have that `ζ - 1` divides `p` in `𝓞 K`. -/
 lemma toInteger_sub_one_dvd_prime' [hcycl : IsCyclotomicExtension {p} ℚ K]
-  (hζ : IsPrimitiveRoot ζ ↑p) : ((hζ.toInteger - 1)) ∣ p := by
+    (hζ : IsPrimitiveRoot ζ ↑p) : ((hζ.toInteger - 1)) ∣ p := by
   have : IsCyclotomicExtension {p ^ (0 + 1)} ℚ K := by simpa using hcycl
   replace hζ : IsPrimitiveRoot ζ (p ^ (0 + 1)) := by simpa using hζ
   exact toInteger_sub_one_dvd_prime hζ

--- a/Mathlib/NumberTheory/Cyclotomic/Rat.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Rat.lean
@@ -422,6 +422,37 @@ lemma prime_norm_toInteger_sub_one_of_prime_ne_two' [hcycl : IsCyclotomicExtensi
   replace hζ : IsPrimitiveRoot ζ (p ^ (0 + 1)) := by simpa using hζ
   exact hζ.prime_norm_toInteger_sub_one_of_prime_ne_two hodd
 
+/-- In a `p ^ (k + 1)`-th cyclotomic extension of `ℚ`, we have that
+  `ζ - 1` divides `p` in `𝓞 K`. -/
+lemma toInteger_sub_one_dvd_prime [hcycl : IsCyclotomicExtension {p ^ (k + 1)} ℚ K]
+  (hζ : IsPrimitiveRoot ζ ↑(p ^ (k + 1))) : ((hζ.toInteger - 1)) ∣ p := by
+  by_cases htwo : p ^ (k + 1) = 2
+  · replace htwo : (p : ℕ) ^ (k + 1) = 2 := by exact_mod_cast htwo
+    have ⟨hp2, hk⟩ := (Nat.Prime.pow_eq_iff Nat.prime_two).1 htwo
+    simp only [add_left_eq_self] at hk
+    have hζ' : ζ = -1 := by
+      refine IsPrimitiveRoot.eq_neg_one_of_two_right ?_
+      rwa [hk, zero_add, pow_one, hp2] at hζ
+    replace hζ' : hζ.toInteger = -1 := by
+      ext
+      exact hζ'
+    rw [hζ', hp2]
+    exact ⟨-1, by ring⟩
+  suffices (hζ.toInteger - 1) ∣ (p : ℤ) by simpa
+  have := IsCyclotomicExtension.numberField {p ^ (k + 1)} ℚ K
+  have H := hζ.norm_toInteger_pow_sub_one_of_prime_pow_ne_two (zero_le _) htwo
+  rw [pow_zero, pow_one] at H
+  rw [← Ideal.norm_dvd_iff, H]
+  · simp
+  · exact prime_norm_toInteger_sub_one_of_prime_pow_ne_two hζ htwo
+
+/-- In a `p`-th cyclotomic extension of `ℚ`, we have that `ζ - 1` divides `p` in `𝓞 K`. -/
+lemma toInteger_sub_one_dvd_prime' [hcycl : IsCyclotomicExtension {p} ℚ K]
+  (hζ : IsPrimitiveRoot ζ ↑p) : ((hζ.toInteger - 1)) ∣ p := by
+  have : IsCyclotomicExtension {p ^ (0 + 1)} ℚ K := by simpa using hcycl
+  replace hζ : IsPrimitiveRoot ζ (p ^ (0 + 1)) := by simpa using hζ
+  exact toInteger_sub_one_dvd_prime hζ
+
 end IsPrimitiveRoot
 
 section absdiscr

--- a/Mathlib/NumberTheory/Cyclotomic/Rat.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Rat.lean
@@ -425,7 +425,7 @@ lemma prime_norm_toInteger_sub_one_of_prime_ne_two' [hcycl : IsCyclotomicExtensi
 /-- In a `p ^ (k + 1)`-th cyclotomic extension of `ℚ`, we have that
   `ζ - 1` divides `p` in `𝓞 K`. -/
 lemma toInteger_sub_one_dvd_prime [hcycl : IsCyclotomicExtension {p ^ (k + 1)} ℚ K]
-  (hζ : IsPrimitiveRoot ζ ↑(p ^ (k + 1))) : ((hζ.toInteger - 1)) ∣ p := by
+    (hζ : IsPrimitiveRoot ζ ↑(p ^ (k + 1))) : ((hζ.toInteger - 1)) ∣ p := by
   by_cases htwo : p ^ (k + 1) = 2
   · replace htwo : (p : ℕ) ^ (k + 1) = 2 := by exact_mod_cast htwo
     have ⟨hp2, hk⟩ := (Nat.Prime.pow_eq_iff Nat.prime_two).1 htwo

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -5,6 +5,7 @@ Authors: Riccardo Brasca
 -/
 import Mathlib.NumberTheory.FLT.Basic
 import Mathlib.Data.ZMod.Basic
+import Mathlib.NumberTheory.Cyclotomic.Rat
 import Mathlib.RingTheory.Int.Basic
 
 /-!
@@ -112,5 +113,40 @@ theorem fermatLastTheoremThree_of_three_dvd_only_c
       ?_ H hF
     rw [Finset.Insert.comm (-c), Finset.pair_comm (-c) b]
     simp only [← Hgcd, Insert.comm, gcd_insert, gcd_singleton, id_eq, ← abs_eq_normalize, abs_neg]
+
+section eisenstein
+
+open NumberField
+
+variable {K : Type*} [Field K] [NumberField K] [IsCyclotomicExtension {3} ℚ K]
+variable {ζ : K} (hζ : IsPrimitiveRoot ζ (3 : ℕ+))
+
+local notation3 "η" => hζ.toInteger
+local notation3 "λ" => η - 1
+
+/-- `FermatLastTheoremForThreeGen` is the statement that `a ^ 3 + b ^ 3 = u * c ^ 3` has no
+nontrivial solutions in `𝓞 K` for all `u : (𝓞 K)ˣ` such that `¬ λ ∣ a`, `¬ λ ∣ b` and `λ ∣ c`.
+The reason to consider `FermatLastTheoremForThreeGen` is to make a descent argument working. -/
+def FermatLastTheoremForThreeGen : Prop :=
+  ∀ a b c : 𝓞 K, ∀ u : (𝓞 K)ˣ, c ≠ 0 → ¬ λ ∣ a → ¬ λ ∣ b  → λ ∣ c → IsCoprime a b →
+    a ^ 3 + b ^ 3 ≠ u * c ^ 3
+
+/-- To prove `FermatLastTheoremFor 3`, it is enough to prove `FermatLastTheoremForThreeGen`. -/
+lemma FermatLastTheoremForThree_of_FermatLastTheoremThreeGen :
+    FermatLastTheoremForThreeGen hζ → FermatLastTheoremFor 3 := by
+  intro H
+  refine fermatLastTheoremThree_of_three_dvd_only_c (fun a b c hc ha hb ⟨x, hx⟩ hcoprime h ↦ ?_)
+  refine H a b c 1 (by simp [hc]) (fun hdvd ↦ ha ?_) (fun hdvd ↦ hb ?_) ?_ ?_ ?_
+  · rwa [← Ideal.norm_dvd_iff (hζ.prime_norm_toInteger_sub_one_of_prime_ne_two' (by decide)),
+      hζ.norm_toInteger_sub_one_of_prime_ne_two' (by decide)] at hdvd
+  · rwa [← Ideal.norm_dvd_iff (hζ.prime_norm_toInteger_sub_one_of_prime_ne_two' (by decide)),
+      hζ.norm_toInteger_sub_one_of_prime_ne_two' (by decide)] at hdvd
+  · exact dvd_trans hζ.toInteger_sub_one_dvd_prime' ⟨x, by simp [hx]⟩
+  · rw [show a = algebraMap _ (𝓞 K) a by simp, show b = algebraMap _ (𝓞 K) b by simp]
+    exact hcoprime.map _
+  · simp only [Units.val_one, one_mul]
+    exact_mod_cast h
+
+end eisenstein
 
 end case2


### PR DESCRIPTION
We add `FermatLastTheoremForThree_of_FermatLastTheoremThreeGen`: o prove `FermatLastTheoremFor 3`, it is enough to prove `FermatLastTheoremForThreeGen`. Here `FermatLastTheoremForThreeGen` is more general than `FermatLastTheoremFor 3`, but it is needed to make a descent argument working.

From the flt3 project at LFTCM2024.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
