### PR TITLE
[Merged by Bors] - feat(NumberTheory/LSeries): Odd Hurwitz zeta functions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3038,6 +3038,7 @@ import Mathlib.NumberTheory.LSeries.Convolution
 import Mathlib.NumberTheory.LSeries.Deriv
 import Mathlib.NumberTheory.LSeries.Dirichlet
 import Mathlib.NumberTheory.LSeries.HurwitzZetaEven
+import Mathlib.NumberTheory.LSeries.HurwitzZetaOdd
 import Mathlib.NumberTheory.LSeries.Linearity
 import Mathlib.NumberTheory.LSeries.MellinEqDirichlet
 import Mathlib.NumberTheory.LegendreSymbol.AddCharacter

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -332,6 +332,14 @@ theorem I_mul_im (z : ℂ) : (I * z).im = z.re := by simp
 set_option linter.uppercaseLean3 false in
 #align complex.I_mul_im Complex.I_mul_im
 
+lemma ofReal_mul_I_im (x : ℝ) : (x * I).im = x := by simp
+
+lemma I_mul_ofReal_im (x : ℝ) : (I * x).im = x := by simp
+
+lemma ofReal_mul_I_re (x : ℝ) : (x * I).re = 0 := by simp
+
+lemma I_mul_ofReal_re (x : ℝ) : (I * x).re = 0 := by simp
+
 @[simp]
 theorem equivRealProd_symm_apply (p : ℝ × ℝ) : equivRealProd.symm p = p.1 + p.2 * I := by
   ext <;> simp [Complex.equivRealProd, ofReal']

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -332,14 +332,6 @@ theorem I_mul_im (z : ℂ) : (I * z).im = z.re := by simp
 set_option linter.uppercaseLean3 false in
 #align complex.I_mul_im Complex.I_mul_im
 
-lemma ofReal_mul_I_im (x : ℝ) : (x * I).im = x := by simp
-
-lemma I_mul_ofReal_im (x : ℝ) : (I * x).im = x := by simp
-
-lemma ofReal_mul_I_re (x : ℝ) : (x * I).re = 0 := by simp
-
-lemma I_mul_ofReal_re (x : ℝ) : (I * x).re = 0 := by simp
-
 @[simp]
 theorem equivRealProd_symm_apply (p : ℝ × ℝ) : equivRealProd.symm p = p.1 + p.2 * I := by
   ext <;> simp [Complex.equivRealProd, ofReal']

--- a/Mathlib/Data/Sign.lean
+++ b/Mathlib/Data/Sign.lean
@@ -281,6 +281,11 @@ lemma coe_neg {α : Type*} [One α] [SubtractionMonoid α] (s : SignType) :
     (↑(-s) : α) = -↑s := by
   cases s <;> simp
 
+/-- Casting `SignType → ℤ → α` is the same as casting directly `SignType → α`. -/
+@[simp, norm_cast]
+lemma intCast_cast {α : Type*} [AddGroupWithOne α] (s : SignType) : ((s : ℤ) : α) = s :=
+  map_cast' _ Int.cast_one Int.cast_zero (@Int.cast_one α _ ▸ Int.cast_neg 1) _
+
 end cast
 
 /-- `SignType.cast` as a `MulWithZeroHom`. -/
@@ -417,6 +422,16 @@ theorem sign_one : sign (1 : α) = 1 :=
 #align sign_one sign_one
 
 end OrderedSemiring
+
+section OrderedRing
+
+@[simp]
+lemma sign_intCast {α : Type*} [OrderedRing α] [Nontrivial α]
+    [DecidableRel ((· < ·) : α → α → Prop)] (n : ℤ) :
+    sign (n : α) = sign n := by
+  simp only [sign_apply, Int.cast_pos, Int.cast_lt_zero]
+
+end OrderedRing
 
 section LinearOrderedRing
 

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
@@ -237,7 +237,7 @@ lemma hasSum_nat_cosKernel₀ (a : ℝ) {t : ℝ} (ht : 0 < t) :
 `a = 0` and `L = 0` otherwise. -/
 lemma isBigO_atTop_evenKernel_sub (a : UnitAddCircle) : ∃ p : ℝ, 0 < p ∧
     (evenKernel a · - (if a = 0 then 1 else 0)) =O[atTop] (rexp <| -p * ·) := by
-  obtain ⟨b, _, rfl⟩ := a.eq_coe_Ico
+  induction' a using QuotientAddGroup.induction_on with b
   obtain ⟨p, hp, hp'⟩ := HurwitzKernelBounds.isBigO_atTop_F_int_zero_sub b
   refine ⟨p, hp, (EventuallyEq.isBigO ?_).trans hp'⟩
   filter_upwards [eventually_gt_atTop 0] with t ht

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
@@ -78,7 +78,7 @@ lemma evenKernel_def (a x : ℝ) :
 
 /-- For `x ≤ 0` the defining sum diverges, so the kernel is 0. -/
 lemma evenKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : evenKernel a x = 0 := by
-  have : (I * ↑x).im ≤ 0 := by rwa [I_mul_im, ofReal_re]
+  have : (I * ↑x).im ≤ 0 := by rwa [I_mul_ofReal_im]
   induction' a using QuotientAddGroup.induction_on' with a'
   rw [← ofReal_inj, evenKernel_def, jacobiTheta₂_undef _ this, mul_zero, ofReal_zero]
 
@@ -95,8 +95,7 @@ lemma cosKernel_def (a x : ℝ) : ↑(cosKernel ↑a x) = jacobiTheta₂ a (I * 
 
 lemma cosKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : cosKernel a x = 0 := by
   induction' a using QuotientAddGroup.induction_on' with a'
-  rw [← ofReal_inj, cosKernel_def, jacobiTheta₂_undef, ofReal_zero]
-  rwa [I_mul_im, ofReal_re]
+  rw [← ofReal_inj, cosKernel_def, jacobiTheta₂_undef _ (I_mul_ofReal_im _ ▸ hx), ofReal_zero]
 
 /-- For `a = 0`, both kernels agree. -/
 lemma evenKernel_eq_cosKernel_of_zero : evenKernel 0 = cosKernel 0 := by
@@ -174,7 +173,7 @@ lemma hasSum_int_evenKernel (a : ℝ) {t : ℝ} (ht : 0 < t) :
     ring_nf
     simp only [I_sq, mul_neg, neg_mul, mul_one]
   simp only [this]
-  exact (hasSum_jacobiTheta₂_term _ (by rwa [I_mul_im, ofReal_re])).mul_left _
+  apply (hasSum_jacobiTheta₂_term _ (I_mul_ofReal_im _ ▸ ht)).mul_left
 
 lemma hasSum_int_cosKernel (a : ℝ) {t : ℝ} (ht : 0 < t) :
     HasSum (fun n : ℤ ↦ cexp (2 * π * I * a * n) * rexp (-π * n ^ 2 * t)) ↑(cosKernel a t) := by
@@ -186,7 +185,7 @@ lemma hasSum_int_cosKernel (a : ℝ) {t : ℝ} (ht : 0 < t) :
     ring_nf
     simp only [I_sq, mul_neg, neg_mul, mul_one, sub_eq_add_neg]
   simp only [this]
-  exact hasSum_jacobiTheta₂_term a (by rwa [I_mul_im, ofReal_re] : 0 < im (I * t))
+  exact hasSum_jacobiTheta₂_term _ (I_mul_ofReal_im _ ▸ ht)
 
 /-- Modified version of `hasSum_int_evenKernel` omitting the constant term at `∞`. -/
 lemma hasSum_int_evenKernel₀ (a : ℝ) {t : ℝ} (ht : 0 < t) :

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
@@ -78,7 +78,7 @@ lemma evenKernel_def (a x : ℝ) :
 
 /-- For `x ≤ 0` the defining sum diverges, so the kernel is 0. -/
 lemma evenKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : evenKernel a x = 0 := by
-  have : (I * ↑x).im ≤ 0 := by rwa [I_mul_ofReal_im]
+  have : (I * ↑x).im ≤ 0 := by rwa [I_mul_im, ofReal_re]
   induction' a using QuotientAddGroup.induction_on' with a'
   rw [← ofReal_inj, evenKernel_def, jacobiTheta₂_undef _ this, mul_zero, ofReal_zero]
 
@@ -95,7 +95,7 @@ lemma cosKernel_def (a x : ℝ) : ↑(cosKernel ↑a x) = jacobiTheta₂ a (I * 
 
 lemma cosKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : cosKernel a x = 0 := by
   induction' a using QuotientAddGroup.induction_on' with a'
-  rw [← ofReal_inj, cosKernel_def, jacobiTheta₂_undef _ (I_mul_ofReal_im _ ▸ hx), ofReal_zero]
+  rw [← ofReal_inj, cosKernel_def, jacobiTheta₂_undef _ (by rwa [I_mul_im, ofReal_re]), ofReal_zero]
 
 /-- For `a = 0`, both kernels agree. -/
 lemma evenKernel_eq_cosKernel_of_zero : evenKernel 0 = cosKernel 0 := by
@@ -173,7 +173,7 @@ lemma hasSum_int_evenKernel (a : ℝ) {t : ℝ} (ht : 0 < t) :
     ring_nf
     simp only [I_sq, mul_neg, neg_mul, mul_one]
   simp only [this]
-  apply (hasSum_jacobiTheta₂_term _ (I_mul_ofReal_im _ ▸ ht)).mul_left
+  apply (hasSum_jacobiTheta₂_term _ (by rwa [I_mul_im, ofReal_re])).mul_left
 
 lemma hasSum_int_cosKernel (a : ℝ) {t : ℝ} (ht : 0 < t) :
     HasSum (fun n : ℤ ↦ cexp (2 * π * I * a * n) * rexp (-π * n ^ 2 * t)) ↑(cosKernel a t) := by
@@ -185,7 +185,7 @@ lemma hasSum_int_cosKernel (a : ℝ) {t : ℝ} (ht : 0 < t) :
     ring_nf
     simp only [I_sq, mul_neg, neg_mul, mul_one, sub_eq_add_neg]
   simp only [this]
-  exact hasSum_jacobiTheta₂_term _ (I_mul_ofReal_im _ ▸ ht)
+  exact hasSum_jacobiTheta₂_term _ (by rwa [I_mul_im, ofReal_re])
 
 /-- Modified version of `hasSum_int_evenKernel` omitting the constant term at `∞`. -/
 lemma hasSum_int_evenKernel₀ (a : ℝ) {t : ℝ} (ht : 0 < t) :

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -408,8 +408,7 @@ lemma hasSum_int_completedSinZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
       rwa [summable_one_div_nat_rpow]
   refine (mellin_div_const .. ▸ hasSum_mellin_pi_mul_sq' (zero_lt_one.trans hs) hF h_sum).congr_fun
     fun n ↦ ?_
-  simp only [Int.sign_eq_sign n, SignType.intCast_cast, SignType.sign_intCast, ← Int.cast_abs,
-    ofReal_intCast]
+  simp only [Int.sign_eq_sign, SignType.intCast_cast, sign_intCast, ← Int.cast_abs, ofReal_intCast]
   ring
 
 /-- Formula for `completedSinZeta` as a Dirichlet series in the convergence range

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -64,8 +64,6 @@ lemma jacobiTheta₂''_conj (z τ : ℂ) :
 /-- Restatement of `jacobiTheta₂'_add_left'`: the function `jacobiTheta₂''` is 1-periodic in `z`. -/
 lemma jacobiTheta₂''_add_left (z τ : ℂ) : jacobiTheta₂'' (z + 1) τ = jacobiTheta₂'' z τ := by
   simp only [jacobiTheta₂'', add_mul z 1, one_mul, jacobiTheta₂'_add_left', jacobiTheta₂_add_left']
-  -- this proof should ideally be done using `field_simp` and `ring_nf` but these are unusably
-  -- slow at the time of writing
   generalize jacobiTheta₂ (z * τ) τ = J
   generalize jacobiTheta₂' (z * τ) τ = J'
   -- clear denominator
@@ -506,12 +504,9 @@ lemma differentiableAt_sinZeta (a : UnitAddCircle) :
 /-- Formula for `hurwitzZetaOdd` as a Dirichlet series in the convergence range (sum over `ℤ`). -/
 theorem hasSum_int_hurwitzZetaOdd (a : ℝ) {s : ℂ} (hs : 1 < re s) :
     HasSum (fun n : ℤ ↦ SignType.sign (n + a) / (↑|n + a| : ℂ) ^ s / 2) (hurwitzZetaOdd a s) := by
-  rw [hurwitzZetaOdd]
   refine ((hasSum_int_completedHurwitzZetaOdd a hs).div_const (Gammaℝ _)).congr_fun fun n ↦ ?_
-  simp_rw [div_right_comm _ _ (Gammaℝ _)]
-  rw [mul_div_cancel_left₀ _ (Gammaℝ_ne_zero_of_re_pos ?_)]
-  rw [add_re, one_re]
-  positivity
+  have : 0 < re (s + 1) := by rw [add_re, one_re]; positivity
+  simp only [div_right_comm _ _ (Gammaℝ _), mul_div_cancel_left₀ _ (Gammaℝ_ne_zero_of_re_pos this)]
 
 /-- Formula for `hurwitzZetaOdd` as a Dirichlet series in the convergence range, with sum over `ℕ`
 (version with absolute values) -/
@@ -540,22 +535,19 @@ lemma hasSum_nat_hurwitzZetaOdd_of_mem_Icc {a : ℝ} (ha : a ∈ Icc 0 1) {s : �
 
 /-- Formula for `sinZeta` as a Dirichlet series in the convergence range, with sum over `ℤ`. -/
 theorem hasSum_int_sinZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
-    HasSum (fun n : ℤ ↦ -I * Int.sign n * cexp (2 * π * I * a * n) / ↑|n| ^ s / 2)
-    (sinZeta a s) := by
+    HasSum (fun n : ℤ ↦ -I * n.sign * cexp (2 * π * I * a * n) / ↑|n| ^ s / 2) (sinZeta a s) := by
   rw [sinZeta]
   refine ((hasSum_int_completedSinZeta a hs).div_const (Gammaℝ (s + 1))).congr_fun fun n ↦ ?_
-  simp_rw [mul_assoc, div_right_comm _ _ (Gammaℝ _)]
-  rw [mul_div_cancel_left₀ _ (Gammaℝ_ne_zero_of_re_pos (?_ : 0 < (s + 1).re))]
-  rw [add_re, one_re]
-  positivity
+  have : 0 < re (s + 1) := by rw [add_re, one_re]; positivity
+  simp only [mul_assoc, div_right_comm _ _ (Gammaℝ _),
+    mul_div_cancel_left₀ _ (Gammaℝ_ne_zero_of_re_pos this)]
 
 /-- Formula for `sinZeta` as a Dirichlet series in the convergence range, with sum over `ℕ`. -/
 lemma hasSum_nat_sinZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
     HasSum (fun n : ℕ ↦ Real.sin (2 * π * a * n) / (n : ℂ) ^ s) (sinZeta a s) := by
-  have hs' : s ≠ 0 := (fun h ↦ (not_lt.mpr zero_le_one) ((zero_re ▸ h ▸ hs)))
   have := (hasSum_int_sinZeta a hs).sum_nat_of_sum_int
-  simp_rw [abs_neg, Int.sign_neg, Int.cast_neg, Nat.abs_cast, Int.cast_natCast, mul_neg,
-    abs_zero, Int.cast_zero, zero_cpow hs', div_zero, zero_div, add_zero] at this
+  simp_rw [abs_neg, Int.sign_neg, Int.cast_neg, Nat.abs_cast, Int.cast_natCast, mul_neg, abs_zero,
+    Int.cast_zero, zero_cpow (ne_zero_of_one_lt_re hs), div_zero, zero_div, add_zero] at this
   simp_rw [push_cast, Complex.sin]
   refine this.congr_fun fun n ↦ ?_
   rcases ne_or_eq n 0 with h | rfl

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -67,10 +67,10 @@ lemma jacobiTheta₂''_add_left (z τ : ℂ) : jacobiTheta₂'' (z + 1) τ = jac
   generalize jacobiTheta₂ (z * τ) τ = J
   generalize jacobiTheta₂' (z * τ) τ = J'
   -- clear denominator
-  simp_rw [div_add' _ _ _ two_pi_I_ne_zero,  ← mul_div_assoc]
+  simp_rw [div_add' _ _ _ two_pi_I_ne_zero, ← mul_div_assoc]
   refine congr_arg (· / (2 * π * I)) ?_
   -- get all exponential terms to left
-  rw [← mul_assoc _ (cexp _), mul_comm z (cexp _), mul_assoc (cexp _), ← mul_add,
+  rw [mul_left_comm _ (cexp _),, ← mul_add,
     mul_assoc (cexp _), ← mul_add, ← mul_assoc (cexp _), ← Complex.exp_add]
   congrm (cexp ?_ * ?_) <;> ring
 
@@ -82,10 +82,11 @@ lemma jacobiTheta₂'_functional_equation' (z τ : ℂ) :
     jacobiTheta₂' z τ = (-2 * π) / (-I * τ) ^ (3 / 2 : ℂ) * jacobiTheta₂'' z (-1 / τ) := by
   rcases eq_or_ne τ 0 with rfl | hτ
   · rw [jacobiTheta₂'_undef _ (by simp), mul_zero, zero_cpow (by norm_num), div_zero, zero_mul]
-  have aux1 : (-2 * π : ℂ) / (2 * π * I) = I := by rw [div_eq_iff two_pi_I_ne_zero, mul_comm I,
-    mul_assoc _ I I, I_mul_I, neg_mul, mul_neg, mul_one]
-  rw [jacobiTheta₂'_functional_equation, ← mul_one_div _ τ, mul_assoc _ (cexp _), mul_comm (cexp _),
-    ← mul_assoc, (by rw [cpow_one, ← div_div, div_self (neg_ne_zero.mpr I_ne_zero)] :
+  have aux1 : (-2 * π : ℂ) / (2 * π * I) = I := by
+    rw [div_eq_iff two_pi_I_ne_zero, mul_comm I, mul_assoc _ I I, I_mul_I, neg_mul, mul_neg,
+      mul_one]
+  rw [jacobiTheta₂'_functional_equation, ← mul_one_div _ τ, mul_right_comm _ (cexp _),
+    (by rw [cpow_one, ← div_div, div_self (neg_ne_zero.mpr I_ne_zero)] :
       1 / τ = -I / (-I * τ) ^ (1 : ℂ)), div_mul_div_comm,
     ← cpow_add _ _ (mul_ne_zero (neg_ne_zero.mpr I_ne_zero) hτ), ← div_mul_eq_mul_div,
     (by norm_num : (1 / 2  + 1 : ℂ) = 3 / 2), mul_assoc (1 / _), mul_assoc (1 / _),
@@ -130,8 +131,7 @@ for the defining sum. -/
 
 lemma sinKernel_def (a x : ℝ) : ↑(sinKernel ↑a x) = jacobiTheta₂' a (I * x) / (-2 * π) := by
   rw [sinKernel, Function.Periodic.lift_coe, re_eq_add_conj, map_div₀, jacobiTheta₂'_conj]
-  simp_rw [map_mul, conj_I, conj_ofReal, map_neg, map_ofNat, neg_mul, neg_neg]
-  ring
+  simp_rw [map_mul, conj_I, conj_ofReal, map_neg, map_ofNat, neg_mul, neg_neg, half_add_self]
 
 lemma sinKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : sinKernel a x = 0 := by
   induction' a using QuotientAddGroup.induction_on' with a'
@@ -162,11 +162,9 @@ lemma continuousOn_oddKernel (a : UnitAddCircle) : ContinuousOn (oddKernel a) (I
     (continuous_re.comp_continuousOn this).congr fun a _ ↦ (ofReal_re _).symm
   simp_rw [oddKernel_def' a]
   refine fun x hx ↦ ((Continuous.continuousAt ?_).mul ?_).continuousWithinAt
-  · exact continuous_exp.comp (continuous_const.mul continuous_ofReal)
+  · fun_prop
   · have hx' : 0 < im (I * x) := by rwa [I_mul_im, ofReal_re]
-    have hf : Continuous fun u : ℝ ↦ (a * I * u, I * u) := by
-      rw [continuous_prod_mk]
-      constructor <;> exact continuous_const.mul continuous_ofReal
+    have hf : Continuous fun u : ℝ ↦ (a * I * u, I * u) := by fun_prop
     apply ContinuousAt.add
     · exact ((continuousAt_jacobiTheta₂' (a * I * x) hx').comp
         (f := fun u : ℝ ↦ (a * I * u, I * u)) hf.continuousAt).div_const _
@@ -180,8 +178,7 @@ lemma continuousOn_sinKernel (a : UnitAddCircle) : ContinuousOn (sinKernel a) (I
   simp_rw [sinKernel_def]
   apply (ContinuousAt.continuousOn (fun x hx ↦ ?_)).div_const
   have h := continuousAt_jacobiTheta₂' a (by rwa [I_mul_im, ofReal_re] : 0 < im (I * x))
-  exact h.comp (f := fun u : ℝ ↦ ((a : ℂ), I * u)) (continuous_prod_mk.mpr ⟨continuous_const,
-    continuous_const.mul continuous_ofReal⟩).continuousAt
+  fun_prop
 
 lemma oddKernel_functional_equation (a : UnitAddCircle) (x : ℝ) :
     oddKernel a x = 1 / x ^ (3 / 2 : ℝ) * sinKernel a (1 / x) := by
@@ -202,8 +199,7 @@ lemma oddKernel_functional_equation (a : UnitAddCircle) (x : ℝ) :
   rw [one_div (x : ℂ), inv_cpow _ _ h4, div_inv_eq_mul, one_div, ofReal_inv, ofReal_cpow hx.le,
     ofReal_div, ofReal_ofNat, ofReal_ofNat, ← mul_div_assoc _ _ (-2 * π : ℂ),
     eq_div_iff <| mul_ne_zero (neg_ne_zero.mpr two_ne_zero) (ofReal_ne_zero.mpr pi_ne_zero),
-    ← div_eq_inv_mul, eq_div_iff h3, mul_comm J _, mul_assoc (-2 * π : ℂ) ((x : ℂ) ^ _),
-    mul_comm ((x : ℂ) ^ _) J, ← mul_assoc]
+    ← div_eq_inv_mul, eq_div_iff h3, mul_comm J _, mul_right_comm]
 
 end kernel_defs
 
@@ -221,8 +217,7 @@ lemma hasSum_int_oddKernel (a : ℝ) {x : ℝ} (hx : 0 < x) :
   refine (((h2.div_const (2 * π * I)).add (h1.mul_left ↑a)).mul_left
     (cexp (-π * a ^ 2 * x))).congr_fun (fun n ↦ ?_)
   rw [jacobiTheta₂'_term, mul_assoc (2 * π * I), mul_div_cancel_left₀ _ two_pi_I_ne_zero, ← add_mul,
-    ← mul_assoc, mul_comm _ (n + a : ℂ), mul_assoc (n + a : ℂ), jacobiTheta₂_term,
-    ← Complex.exp_add]
+    mul_left_comm, jacobiTheta₂_term, ← Complex.exp_add]
   push_cast
   congr 2
   simp only [← mul_assoc, ← add_mul]

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -419,9 +419,8 @@ lemma hasSum_int_completedSinZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
     rw [← SignType.map_cast (f := Int.castRingHom ℂ), Int.coe_castRingHom, Int.cast_inj,
       ← eq_intCast (Int.castRingHom ℝ) n, StrictMono.sign_comp, Int.sign_eq_sign n]
     simp_rw [strictMono_iff_map_pos, Int.coe_castRingHom, Int.cast_pos, imp_self, forall_const]
-  rw [this, ← mul_div_assoc, div_mul_eq_mul_div, div_right_comm, mul_assoc (Gammaℝ _),
-    mul_assoc (Gammaℝ _), mul_assoc (Gammaℝ _), mul_assoc (-I), mul_assoc (-I),
-    mul_comm (cexp _)]
+  rw [this]
+  ring
 
 /-- Formula for `completedSinZeta` as a Dirichlet series in the convergence range
 (second version, with sum over `ℕ`). -/

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -70,8 +70,8 @@ lemma jacobiTheta₂''_add_left (z τ : ℂ) : jacobiTheta₂'' (z + 1) τ = jac
   simp_rw [div_add' _ _ _ two_pi_I_ne_zero, ← mul_div_assoc]
   refine congr_arg (· / (2 * π * I)) ?_
   -- get all exponential terms to left
-  rw [mul_left_comm _ (cexp _),, ← mul_add,
-    mul_assoc (cexp _), ← mul_add, ← mul_assoc (cexp _), ← Complex.exp_add]
+  rw [mul_left_comm _ (cexp _), ← mul_add, mul_assoc (cexp _), ← mul_add, ← mul_assoc (cexp _),
+    ← Complex.exp_add]
   congrm (cexp ?_ * ?_) <;> ring
 
 lemma jacobiTheta₂''_neg_left (z τ : ℂ) : jacobiTheta₂'' (-z) τ = -jacobiTheta₂'' z τ := by

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -230,7 +230,7 @@ lemma hasSum_int_oddKernel (a : ℝ) {x : ℝ} (hx : 0 < x) :
 lemma hasSum_int_sinKernel (a : ℝ) {t : ℝ} (ht : 0 < t) : HasSum
     (fun n : ℤ ↦ -I * n * cexp (2 * π * I * a * n) * rexp (-π * n ^ 2 * t)) ↑(sinKernel a t) := by
   have h : -2 * (π : ℂ) ≠ (0 : ℂ) := by
-    simp? [pi_ne_zero] says simp only [neg_mul, ne_eq, neg_eq_zero, mul_eq_zero,
+    simp only [neg_mul, ne_eq, neg_eq_zero, mul_eq_zero,
       OfNat.ofNat_ne_zero, ofReal_eq_zero, pi_ne_zero, or_self, not_false_eq_true]
   rw [sinKernel_def]
   have := hasSum_jacobiTheta₂'_term a (by rwa [I_mul_im, ofReal_re])
@@ -269,8 +269,8 @@ section asymp
 /-- The function `oddKernel a` has exponential decay at `+∞`, for any `a`. -/
 lemma isBigO_atTop_oddKernel (a : UnitAddCircle) :
     ∃ p, 0 < p ∧ IsBigO atTop (oddKernel a) (fun x ↦ Real.exp (-p * x)) := by
-  obtain ⟨b, _, rfl⟩ := a.eq_coe_Ico
-  let ⟨p, hp, hp'⟩ := HurwitzKernelBounds.isBigO_atTop_F_int_one b
+  induction' a using QuotientAddGroup.induction_on with b
+  obtain ⟨p, hp, hp'⟩ := HurwitzKernelBounds.isBigO_atTop_F_int_one b
   refine ⟨p, hp, (Eventually.isBigO ?_).trans hp'⟩
   filter_upwards [eventually_gt_atTop 0] with t ht
   simpa only [← (hasSum_int_oddKernel b ht).tsum_eq, Real.norm_eq_abs, HurwitzKernelBounds.F_int,
@@ -298,7 +298,7 @@ end asymp
 
 section FEPair
 /-!
-## Construction of a FE-pair
+## Construction of an FE-pair
 -/
 
 /-- A `StrongFEPair` structure with `f = oddKernel a` and `g = sinKernel a`. -/
@@ -314,9 +314,9 @@ def hurwitzOddFEPair (a : UnitAddCircle) : StrongFEPair ℂ where
   hk := by norm_num
   hε := one_ne_zero
   f₀ := 0
-  hf₀ := by rfl
+  hf₀ := rfl
   g₀ := 0
-  hg₀ := by rfl
+  hg₀ := rfl
   hf_top r := by
     let ⟨v, hv, hv'⟩ := isBigO_atTop_oddKernel a
     rw [← isBigO_norm_left] at hv' ⊢
@@ -405,8 +405,7 @@ lemma hasSum_int_completedSinZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
   have hF t (ht : 0 < t) :
       HasSum (fun n ↦ c n * n * rexp (-π * n ^ 2 * t)) (sinKernel a t / 2) := by
     refine ((hasSum_int_sinKernel a ht).div_const 2).congr_fun fun n ↦ ?_
-    rw [div_mul_eq_mul_div, div_mul_eq_mul_div, mul_assoc (-I), mul_assoc (-I),
-      mul_assoc (-I), mul_assoc (-I), mul_comm (cexp _)]
+    rw [div_mul_eq_mul_div, div_mul_eq_mul_div, mul_right_comm (-I)]
   have h_sum : Summable fun i ↦ ‖c i‖ / |↑i| ^ s.re := by
     simp_rw [hc, div_right_comm]
     apply Summable.div_const
@@ -578,8 +577,8 @@ lemma hurwitzZetaOdd_one_sub (a : UnitAddCircle) {s : ℂ} (hs : ∀ (n : ℕ), 
     inv_Gammaℝ_two_sub hs, completedHurwitzZetaOdd_one_sub, sinZeta, ← div_eq_mul_inv,
     ← mul_div_assoc, ← mul_div_assoc, mul_comm]
 
-/-- If `s` is not in `-ℕ`, then `hurwitzZetaOdd a (1 - s)` is an explicit multiple of
-`sinZeta s`. -/
+/-- If `s` is not in `-ℕ`, then `sinZeta a (1 - s)` is an explicit multiple of
+`hurwitzZetaOdd s`. -/
 lemma sinZeta_one_sub (a : UnitAddCircle) {s : ℂ} (hs : ∀ (n : ℕ), s ≠ -n) :
     sinZeta a (1 - s) = 2 * (2 * π) ^ (-s) * Gamma s * sin (π * s / 2) * hurwitzZetaOdd a s := by
   rw [← Gammaℂ, sinZeta, (by ring : 1 - s + 1 = 2 - s), div_eq_mul_inv, inv_Gammaℝ_two_sub hs,

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -120,7 +120,7 @@ lemma oddKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : oddKernel a
   induction' a using QuotientAddGroup.induction_on' with a'
   rw [← ofReal_eq_zero, oddKernel_def', jacobiTheta₂_undef, jacobiTheta₂'_undef, zero_div, zero_add,
     mul_zero, mul_zero] <;>
-  rwa [I_mul_ofReal_im]
+  rwa [I_mul_im, ofReal_re]
 
 /-- Auxiliary function appearing in the functional equation for the odd Hurwitz zeta kernel, equal
 to `∑ (n : ℕ), 2 * n * sin (2 * π * n * a) * exp (-π * n ^ 2 * x)`. See `hasSum_nat_sinKernel`
@@ -135,7 +135,8 @@ lemma sinKernel_def (a x : ℝ) : ↑(sinKernel ↑a x) = jacobiTheta₂' a (I *
 
 lemma sinKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : sinKernel a x = 0 := by
   induction' a using QuotientAddGroup.induction_on' with a'
-  rw [← ofReal_eq_zero, sinKernel_def, jacobiTheta₂'_undef _ (I_mul_ofReal_im _ ▸ hx), zero_div]
+  rw [← ofReal_eq_zero, sinKernel_def, jacobiTheta₂'_undef _ (by rwa [I_mul_im, ofReal_re]),
+    zero_div]
 
 lemma oddKernel_neg (a : UnitAddCircle) (x : ℝ) : oddKernel (-a) x = -oddKernel a x := by
   induction' a using QuotientAddGroup.induction_on' with a'
@@ -164,10 +165,10 @@ lemma continuousOn_oddKernel (a : UnitAddCircle) : ContinuousOn (oddKernel a) (I
   · fun_prop
   · have hf : Continuous fun u : ℝ ↦ (a * I * u, I * u) := by fun_prop
     apply ContinuousAt.add
-    · exact ((continuousAt_jacobiTheta₂' (a * I * x) (I_mul_ofReal_im _ ▸ hx)).comp
+    · exact ((continuousAt_jacobiTheta₂' (a * I * x) (by rwa [I_mul_im, ofReal_re])).comp
         (f := fun u : ℝ ↦ (a * I * u, I * u)) hf.continuousAt).div_const _
     · exact continuousAt_const.mul <| (continuousAt_jacobiTheta₂ (a * I * x)
-        (I_mul_ofReal_im _ ▸ hx)).comp (f := fun u : ℝ ↦ (a * I * u, I * u)) hf.continuousAt
+        (by rwa [I_mul_im, ofReal_re])).comp (f := fun u : ℝ ↦ (a * I * u, I * u)) hf.continuousAt
 
 lemma continuousOn_sinKernel (a : UnitAddCircle) : ContinuousOn (sinKernel a) (Ioi 0) := by
   induction' a using QuotientAddGroup.induction_on' with a
@@ -175,7 +176,7 @@ lemma continuousOn_sinKernel (a : UnitAddCircle) : ContinuousOn (sinKernel a) (I
     (continuous_re.comp_continuousOn this).congr fun a _ ↦ (ofReal_re _).symm
   simp_rw [sinKernel_def]
   apply (ContinuousAt.continuousOn (fun x hx ↦ ?_)).div_const
-  have h := continuousAt_jacobiTheta₂' a <| (I_mul_ofReal_im x).symm ▸ hx
+  have h := continuousAt_jacobiTheta₂' a (by rwa [I_mul_im, ofReal_re])
   fun_prop
 
 lemma oddKernel_functional_equation (a : UnitAddCircle) (x : ℝ) :
@@ -210,8 +211,8 @@ section sum_formulas
 lemma hasSum_int_oddKernel (a : ℝ) {x : ℝ} (hx : 0 < x) :
     HasSum (fun n : ℤ ↦ (n + a) * rexp (-π * (n + a) ^ 2 * x)) (oddKernel ↑a x) := by
   rw [← hasSum_ofReal, oddKernel_def' a x]
-  have h1 := hasSum_jacobiTheta₂_term (a * I * x) ((I_mul_ofReal_im x).symm ▸ hx)
-  have h2 := hasSum_jacobiTheta₂'_term (a * I * x) ((I_mul_ofReal_im x).symm ▸ hx)
+  have h1 := hasSum_jacobiTheta₂_term (a * I * x) (by rwa [I_mul_im, ofReal_re])
+  have h2 := hasSum_jacobiTheta₂'_term (a * I * x) (by rwa [I_mul_im, ofReal_re])
   refine (((h2.div_const (2 * π * I)).add (h1.mul_left ↑a)).mul_left
     (cexp (-π * a ^ 2 * x))).congr_fun (fun n ↦ ?_)
   rw [jacobiTheta₂'_term, mul_assoc (2 * π * I), mul_div_cancel_left₀ _ two_pi_I_ne_zero, ← add_mul,
@@ -228,7 +229,8 @@ lemma hasSum_int_sinKernel (a : ℝ) {t : ℝ} (ht : 0 < t) : HasSum
     simp only [neg_mul, ne_eq, neg_eq_zero, mul_eq_zero,
       OfNat.ofNat_ne_zero, ofReal_eq_zero, pi_ne_zero, or_self, not_false_eq_true]
   rw [sinKernel_def]
-  refine ((hasSum_jacobiTheta₂'_term a (I_mul_ofReal_im _ ▸ ht)).div_const _).congr_fun fun n ↦ ?_
+  refine ((hasSum_jacobiTheta₂'_term a
+    (by rwa [I_mul_im, ofReal_re])).div_const _).congr_fun fun n ↦ ?_
   rw [jacobiTheta₂'_term, jacobiTheta₂_term, ofReal_exp, mul_assoc (-I * n), ← Complex.exp_add,
     eq_div_iff h, ofReal_mul, ofReal_mul, ofReal_pow, ofReal_neg, ofReal_intCast,
     mul_comm _ (-2 * π : ℂ), ← mul_assoc]

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -275,7 +275,7 @@ lemma isBigO_atTop_oddKernel (a : UnitAddCircle) :
   filter_upwards [eventually_gt_atTop 0] with t ht
   simpa only [← (hasSum_int_oddKernel b ht).tsum_eq, Real.norm_eq_abs, HurwitzKernelBounds.F_int,
     HurwitzKernelBounds.f_int, pow_one, norm_mul, abs_of_nonneg (exp_pos _).le] using
-    (norm_tsum_le_tsum_norm (hasSum_int_oddKernel b ht).summable.norm)
+    norm_tsum_le_tsum_norm (hasSum_int_oddKernel b ht).summable.norm
 
 /-- The function `sinKernel a` has exponential decay at `+∞`, for any `a`. -/
 lemma isBigO_atTop_sinKernel (a : UnitAddCircle) :

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -1,0 +1,600 @@
+/-
+Copyright (c) 2024 David Loeffler. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David Loeffler
+-/
+import Mathlib.NumberTheory.LSeries.AbstractFuncEq
+import Mathlib.NumberTheory.ModularForms.JacobiTheta.Bounds
+import Mathlib.NumberTheory.LSeries.MellinEqDirichlet
+import Mathlib.NumberTheory.LSeries.Basic
+
+/-!
+# Odd Hurwitz zeta functions
+
+In this file we study the functions on `ℂ` which are the analytic continuation of the following
+series (convergent for `1 < re s`), where `a ∈ ℝ` is a parameter:
+
+`hurwitzZetaOdd a s = 1 / 2 * ∑' n : ℤ, sgn (n + a) / |n + a| ^ s`
+
+and
+
+`sinZeta a s = ∑' n : ℕ, sin (2 * π * a * n) / n ^ s`.
+
+The term for `n = -a` in the first sum is understood as 0 if `a` is an integer, as is the term for
+`n = 0` in the second sum (for all `a`). Note that these functions are differentiable everywhere,
+unlike their even counterparts which have poles.
+
+Of course, we cannot *define* these functions by the above formulae (since existence of the
+analytic continuation is not at all obvious); we in fact construct them as Mellin transforms of
+various versions of the Jacobi theta function.
+
+## Main definitions and theorems
+
+* `completedHurwitzZetaOdd`: the completed Hurwitz zeta function
+* `completedSinZeta`: the completed cosine zeta function
+* `differentiable_completedHurwitzZetaOdd` and `differentiable_completedSinZeta`:
+  differentiability on `ℂ`
+* `completedHurwitzZetaOdd_one_sub`: the functional equation
+  `completedHurwitzZetaOdd a (1 - s) = completedSinZeta a s`
+* `hasSum_int_hurwitzZetaOdd` and `hasSum_nat_sinZeta`: relation between
+  the zeta functions and corresponding Dirichlet series for `1 < re s`
+-/
+
+noncomputable section
+
+open Complex hiding abs_of_nonneg
+open Filter Topology Asymptotics Real Set MeasureTheory
+open scoped ComplexConjugate
+
+section kernel_defs
+/-!
+## Definitions and elementary properties of kernels
+-/
+
+/-- Variant of `jacobiTheta₂'` which we introduce to simplify some formulae. -/
+def jacobiTheta₂'' (z τ : ℂ) : ℂ :=
+  cexp (π * I * z ^ 2 * τ) * (jacobiTheta₂' (z * τ) τ / (2 * π * I) + z * jacobiTheta₂ (z * τ) τ)
+
+lemma jacobiTheta₂''_conj (z τ : ℂ) :
+    conj (jacobiTheta₂'' z τ) = jacobiTheta₂'' (conj z) (-conj τ) := by
+  simp only [jacobiTheta₂'', jacobiTheta₂'_conj, jacobiTheta₂_conj,
+    ← exp_conj, conj_ofReal, conj_I, map_mul, map_add, map_div₀, mul_neg, map_pow, map_ofNat,
+    neg_mul, div_neg, neg_div, jacobiTheta₂'_neg_left, jacobiTheta₂_neg_left]
+
+/-- Restatement of `jacobiTheta₂'_add_left'`: the function `jacobiTheta₂''` is 1-periodic in `z`. -/
+lemma jacobiTheta₂''_add_left (z τ : ℂ) : jacobiTheta₂'' (z + 1) τ = jacobiTheta₂'' z τ := by
+  simp only [jacobiTheta₂'', add_mul z 1, one_mul, jacobiTheta₂'_add_left', jacobiTheta₂_add_left']
+  -- this proof should ideally be done using `field_simp` and `ring_nf` but these are unusably
+  -- slow at the time of writing
+  generalize jacobiTheta₂ (z * τ) τ = J
+  generalize jacobiTheta₂' (z * τ) τ = J'
+  -- clear denominator
+  simp_rw [div_add' _ _ _ two_pi_I_ne_zero,  ← mul_div_assoc]
+  refine congr_arg (· / (2 * π * I)) ?_
+  -- get all exponential terms to left
+  rw [← mul_assoc _ (cexp _), mul_comm z (cexp _), mul_assoc (cexp _), ← mul_add,
+    mul_assoc (cexp _), ← mul_add, ← mul_assoc (cexp _), ← Complex.exp_add]
+  congrm (cexp ?_ * ?_) <;> ring
+
+lemma jacobiTheta₂''_neg_left (z τ : ℂ) : jacobiTheta₂'' (-z) τ = -jacobiTheta₂'' z τ := by
+  simp only [jacobiTheta₂'', jacobiTheta₂'_neg_left, jacobiTheta₂_neg_left,
+    neg_mul, neg_div, ← neg_add, mul_neg, neg_sq]
+
+lemma jacobiTheta₂'_functional_equation' (z τ : ℂ) :
+    jacobiTheta₂' z τ = (-2 * π) / (-I * τ) ^ (3 / 2 : ℂ) * jacobiTheta₂'' z (-1 / τ) := by
+  rcases eq_or_ne τ 0 with rfl | hτ
+  · rw [jacobiTheta₂'_undef _ (by simp), mul_zero, zero_cpow (by norm_num), div_zero, zero_mul]
+  have aux1 : (-2 * π : ℂ) / (2 * π * I) = I := by rw [div_eq_iff two_pi_I_ne_zero, mul_comm I,
+    mul_assoc _ I I, I_mul_I, neg_mul, mul_neg, mul_one]
+  rw [jacobiTheta₂'_functional_equation, ← mul_one_div _ τ, mul_assoc _ (cexp _), mul_comm (cexp _),
+    ← mul_assoc, (by rw [cpow_one, ← div_div, div_self (neg_ne_zero.mpr I_ne_zero)] :
+      1 / τ = -I / (-I * τ) ^ (1 : ℂ)), div_mul_div_comm,
+    ← cpow_add _ _ (mul_ne_zero (neg_ne_zero.mpr I_ne_zero) hτ), ← div_mul_eq_mul_div,
+    (by norm_num : (1 / 2  + 1 : ℂ) = 3 / 2), mul_assoc (1 / _), mul_assoc (1 / _),
+    ← mul_one_div (-2 * π : ℂ), mul_comm _ (1 / _), mul_assoc (1 / _)]
+  congr 1
+  rw [jacobiTheta₂'', div_add' _ _ _ two_pi_I_ne_zero, ← mul_div_assoc, ← mul_div_assoc,
+    ← div_mul_eq_mul_div (-2 * π : ℂ), mul_assoc, aux1, mul_div z (-1), mul_neg_one, neg_div τ z,
+    jacobiTheta₂_neg_left, jacobiTheta₂'_neg_left, neg_mul, ← mul_neg, ← mul_neg,
+    mul_div, mul_neg_one, neg_div, neg_mul, neg_mul, neg_div]
+  congr 2
+  rw [neg_sub, ← sub_eq_neg_add, mul_comm _ (_ * I), ← mul_assoc]
+
+/-- Odd Hurwitz zeta kernel (function whose Mellin transform will be the odd part of the completed
+Hurwitz zeta function). See `oddKernel_def` for the defining formula, and `hasSum_int_oddKernel`
+for an expression as a sum over `ℤ`.
+-/
+@[irreducible] def oddKernel (a : UnitAddCircle) (x : ℝ) : ℝ :=
+  (show Function.Periodic (fun a : ℝ ↦ re (jacobiTheta₂'' a (I * x))) 1 by
+    intro a; simp only [ofReal_add, ofReal_one, jacobiTheta₂''_add_left]).lift a
+
+lemma oddKernel_def (a x : ℝ) : ↑(oddKernel a x) = jacobiTheta₂'' a (I * x) := by
+  rw [oddKernel, Function.Periodic.lift_coe, ← conj_eq_iff_re, jacobiTheta₂''_conj, map_mul,
+    conj_I, neg_mul, neg_neg, conj_ofReal, conj_ofReal]
+
+lemma oddKernel_def' (a x : ℝ) : ↑(oddKernel ↑a x) = cexp (-π * a ^ 2 * x) *
+    (jacobiTheta₂' (a * I * x) (I * x) / (2 * π * I) + a * jacobiTheta₂ (a * I * x) (I * x)) := by
+  rw [oddKernel_def, jacobiTheta₂'', ← mul_assoc ↑a I x,
+    (by ring : ↑π * I * ↑a ^ 2 * (I * ↑x) = I ^ 2 * ↑π * ↑a ^ 2 * x), I_sq, neg_one_mul]
+
+lemma oddKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : oddKernel a x = 0 := by
+  induction' a using QuotientAddGroup.induction_on' with a'
+  rw [← ofReal_eq_zero, oddKernel_def', jacobiTheta₂_undef, jacobiTheta₂'_undef, zero_div, zero_add,
+    mul_zero, mul_zero] <;>
+  rwa [I_mul_im, ofReal_re]
+
+/-- Auxiliary function appearing in the functional equation for the odd Hurwitz zeta kernel, equal
+to `∑ (n : ℕ), 2 * n * sin (2 * π * n * a) * exp (-π * n ^ 2 * x)`. See `hasSum_nat_sinKernel`
+for the defining sum. -/
+@[irreducible] def sinKernel (a : UnitAddCircle) (x : ℝ) : ℝ :=
+  (show Function.Periodic (fun ξ : ℝ ↦ re (jacobiTheta₂' ξ (I * x) / (-2 * π))) 1 by
+    intro ξ; simp_rw [ofReal_add, ofReal_one, jacobiTheta₂'_add_left]).lift a
+
+lemma sinKernel_def (a x : ℝ) : ↑(sinKernel ↑a x) = jacobiTheta₂' a (I * x) / (-2 * π) := by
+  rw [sinKernel, Function.Periodic.lift_coe, re_eq_add_conj, map_div₀, jacobiTheta₂'_conj]
+  simp_rw [map_mul, conj_I, conj_ofReal, map_neg, map_ofNat, neg_mul, neg_neg]
+  ring
+
+lemma sinKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : sinKernel a x = 0 := by
+  induction' a using QuotientAddGroup.induction_on' with a'
+  rw [← ofReal_eq_zero, sinKernel_def, jacobiTheta₂'_undef, zero_div]
+  rwa [I_mul_im, ofReal_re]
+
+lemma oddKernel_neg (a : UnitAddCircle) (x : ℝ) : oddKernel (-a) x = -oddKernel a x := by
+  induction' a using QuotientAddGroup.induction_on' with a'
+  rw [← ofReal_inj, ← QuotientAddGroup.mk_neg, oddKernel_def, ofReal_neg, ofReal_neg, oddKernel_def,
+    jacobiTheta₂''_neg_left]
+
+lemma oddKernel_zero (x : ℝ) : oddKernel 0 x = 0 := by
+  simpa only [neg_zero, eq_neg_self_iff] using oddKernel_neg 0 x
+
+lemma sinKernel_neg (a : UnitAddCircle) (x : ℝ) :
+    sinKernel (-a) x = -sinKernel a x := by
+  induction' a using QuotientAddGroup.induction_on' with a'
+  rw [← ofReal_inj, ← QuotientAddGroup.mk_neg, ofReal_neg, sinKernel_def, sinKernel_def, ofReal_neg,
+    jacobiTheta₂'_neg_left, neg_div]
+
+lemma sinKernel_zero (x : ℝ) : sinKernel 0 x = 0 := by
+  simpa only [neg_zero, eq_neg_self_iff] using sinKernel_neg 0 x
+
+/-- The odd kernel is continuous on `Ioi 0`. -/
+lemma continuousOn_oddKernel (a : UnitAddCircle) : ContinuousOn (oddKernel a) (Ioi 0) := by
+  induction' a using QuotientAddGroup.induction_on' with a
+  suffices ContinuousOn (fun x ↦ (oddKernel a x : ℂ)) (Ioi 0) from
+    (continuous_re.comp_continuousOn this).congr fun a _ ↦ (ofReal_re _).symm
+  simp_rw [oddKernel_def' a]
+  refine fun x hx ↦ ((Continuous.continuousAt ?_).mul ?_).continuousWithinAt
+  · exact continuous_exp.comp (continuous_const.mul continuous_ofReal)
+  · have hx' : 0 < im (I * x) := by rwa [I_mul_im, ofReal_re]
+    have hf : Continuous fun u : ℝ ↦ (a * I * u, I * u) := by
+      rw [continuous_prod_mk]
+      constructor <;> exact continuous_const.mul continuous_ofReal
+    apply ContinuousAt.add
+    · exact ((continuousAt_jacobiTheta₂' (a * I * x) hx').comp
+        (f := fun u : ℝ ↦ (a * I * u, I * u)) hf.continuousAt).div_const _
+    · exact continuousAt_const.mul <| (continuousAt_jacobiTheta₂ (a * I * x) hx').comp
+        (f := fun u : ℝ ↦ (a * I * u, I * u)) hf.continuousAt
+
+lemma continuousOn_sinKernel (a : UnitAddCircle) : ContinuousOn (sinKernel a) (Ioi 0) := by
+  induction' a using QuotientAddGroup.induction_on' with a
+  suffices ContinuousOn (fun x ↦ (sinKernel a x : ℂ)) (Ioi 0) from
+    (continuous_re.comp_continuousOn this).congr fun a _ ↦ (ofReal_re _).symm
+  simp_rw [sinKernel_def]
+  apply (ContinuousAt.continuousOn (fun x hx ↦ ?_)).div_const
+  have h := continuousAt_jacobiTheta₂' a (by rwa [I_mul_im, ofReal_re] : 0 < im (I * x))
+  exact h.comp (f := fun u : ℝ ↦ ((a : ℂ), I * u)) (continuous_prod_mk.mpr ⟨continuous_const,
+    continuous_const.mul continuous_ofReal⟩).continuousAt
+
+lemma oddKernel_functional_equation (a : UnitAddCircle) (x : ℝ) :
+    oddKernel a x = 1 / x ^ (3 / 2 : ℝ) * sinKernel a (1 / x) := by
+  -- first reduce to `0 < x`
+  rcases le_or_lt x 0 with hx | hx
+  · rw [oddKernel_undef _ hx, sinKernel_undef _ (one_div_nonpos.mpr hx), mul_zero]
+  induction' a using QuotientAddGroup.induction_on' with a
+  have h1 : -1 / (I * ↑(1 / x)) = I * x := by rw [one_div, ofReal_inv, mul_comm, ← div_div,
+    div_inv_eq_mul, div_eq_mul_inv, inv_I, mul_neg, neg_one_mul, neg_mul, neg_neg, mul_comm]
+  have h2 : (-I * (I * ↑(1 / x))) = 1 / x := by
+    rw [← mul_assoc, neg_mul, I_mul_I, neg_neg, one_mul, ofReal_div, ofReal_one]
+  have h3 : (x : ℂ) ^ (3 / 2 : ℂ) ≠ 0 := by
+    simp only [Ne, cpow_eq_zero_iff, ofReal_eq_zero, hx.ne', false_and, not_false_eq_true]
+  have h4 : arg x ≠ π := by rw [arg_ofReal_of_nonneg hx.le]; exact pi_ne_zero.symm
+  rw [← ofReal_inj, oddKernel_def, ofReal_mul, sinKernel_def, jacobiTheta₂'_functional_equation',
+    h1, h2]
+  generalize jacobiTheta₂'' a (I * ↑x) = J
+  rw [one_div (x : ℂ), inv_cpow _ _ h4, div_inv_eq_mul, one_div, ofReal_inv, ofReal_cpow hx.le,
+    ofReal_div, ofReal_ofNat, ofReal_ofNat, ← mul_div_assoc _ _ (-2 * π : ℂ),
+    eq_div_iff <| mul_ne_zero (neg_ne_zero.mpr two_ne_zero) (ofReal_ne_zero.mpr pi_ne_zero),
+    ← div_eq_inv_mul, eq_div_iff h3, mul_comm J _, mul_assoc (-2 * π : ℂ) ((x : ℂ) ^ _),
+    mul_comm ((x : ℂ) ^ _) J, ← mul_assoc]
+
+end kernel_defs
+
+section sum_formulas
+
+/-!
+## Formulae for the kernels as sums
+-/
+
+lemma hasSum_int_oddKernel (a : ℝ) {x : ℝ} (hx : 0 < x) :
+    HasSum (fun n : ℤ ↦ (n + a) * rexp (-π * (n + a) ^ 2 * x)) (oddKernel ↑a x) := by
+  rw [← hasSum_ofReal, oddKernel_def' a x]
+  have h1 := hasSum_jacobiTheta₂_term (a * I * x) (by rwa [I_mul_im, ofReal_re] : 0 < im (I * x))
+  have h2 := hasSum_jacobiTheta₂'_term (a * I * x) (by rwa [I_mul_im, ofReal_re] : 0 < im (I * x))
+  refine (((h2.div_const (2 * π * I)).add (h1.mul_left ↑a)).mul_left
+    (cexp (-π * a ^ 2 * x))).congr_fun (fun n ↦ ?_)
+  rw [jacobiTheta₂'_term, mul_assoc (2 * π * I), mul_div_cancel_left₀ _ two_pi_I_ne_zero, ← add_mul,
+    ← mul_assoc, mul_comm _ (n + a : ℂ), mul_assoc (n + a : ℂ), jacobiTheta₂_term,
+    ← Complex.exp_add]
+  push_cast
+  congr 2
+  simp only [← mul_assoc, ← add_mul]
+  congr 1
+  simp_rw [mul_assoc _ I, mul_comm I _, ← mul_assoc _ _ I, mul_assoc _ I, mul_comm I _,
+    ← mul_assoc _ _ I, add_mul, mul_assoc _ _ I, I_mul_I, mul_neg, mul_one,
+    mul_comm (2 : ℂ) π, mul_assoc, ← neg_mul, ← mul_add]
+  rw [← add_assoc, add_comm, mul_comm (n : ℂ) a, ← mul_assoc, add_sq]
+
+lemma hasSum_int_sinKernel (a : ℝ) {t : ℝ} (ht : 0 < t) : HasSum
+    (fun n : ℤ ↦ -I * n * cexp (2 * π * I * a * n) * rexp (-π * n ^ 2 * t)) ↑(sinKernel a t) := by
+  have h : -2 * (π : ℂ) ≠ (0 : ℂ) := by
+    simp? [pi_ne_zero] says simp only [neg_mul, ne_eq, neg_eq_zero, mul_eq_zero,
+      OfNat.ofNat_ne_zero, ofReal_eq_zero, pi_ne_zero, or_self, not_false_eq_true]
+  rw [sinKernel_def]
+  have := hasSum_jacobiTheta₂'_term a (by rwa [I_mul_im, ofReal_re])
+  refine (this.div_const (-2 * π : ℂ)).congr_fun fun n ↦ ?_
+  rw [jacobiTheta₂'_term, jacobiTheta₂_term, ofReal_exp, mul_assoc (-I * n), ← Complex.exp_add,
+    eq_div_iff h, ofReal_mul, ofReal_mul, ofReal_pow, ofReal_neg, ofReal_intCast,
+    mul_comm _ (-2 * π : ℂ), ← mul_assoc]
+  congrm ?_ * cexp (?_ + ?_)
+  · simp only [neg_mul, mul_neg, neg_neg, mul_assoc]
+  · exact mul_right_comm (2 * π * I) a n
+  · simp only [← mul_assoc, mul_comm _ I, I_mul_I, neg_one_mul]
+
+lemma hasSum_nat_sinKernel (a : ℝ) {t : ℝ} (ht : 0 < t) :
+    HasSum (fun n : ℕ ↦ 2 * n * Real.sin (2 * π * a * n) * rexp (-π * n ^ 2 * t))
+    (sinKernel ↑a t) := by
+  rw [← hasSum_ofReal]
+  have := (hasSum_int_sinKernel a ht).sum_nat_of_sum_int
+  simp only [Int.cast_zero, sq (0 : ℂ), zero_mul, mul_zero, add_zero] at this
+  refine this.congr_fun fun n ↦ ?_
+  simp_rw [Int.cast_neg, neg_sq, mul_neg, ofReal_mul, Int.cast_natCast, ofReal_natCast,
+      ofReal_ofNat, ← add_mul, ofReal_sin, Complex.sin]
+  push_cast
+  congr 1
+  rw [← mul_div_assoc, ← div_mul_eq_mul_div, ← div_mul_eq_mul_div, div_self two_ne_zero, one_mul,
+    neg_mul, neg_mul, neg_neg, mul_comm _ I, ← mul_assoc, mul_comm _ I, neg_mul,
+    ← sub_eq_neg_add, mul_sub]
+  congr 3 <;> ring
+
+end sum_formulas
+
+section asymp
+/-!
+## Asymptotics of the kernels as `t → ∞`
+-/
+
+/-- The function `oddKernel a` has exponential decay at `+∞`, for any `a`. -/
+lemma isBigO_atTop_oddKernel (a : UnitAddCircle) :
+    ∃ p, 0 < p ∧ IsBigO atTop (oddKernel a) (fun x ↦ Real.exp (-p * x)) := by
+  obtain ⟨b, _, rfl⟩ := a.eq_coe_Ico
+  let ⟨p, hp, hp'⟩ := HurwitzKernelBounds.isBigO_atTop_F_int_one b
+  refine ⟨p, hp, (Eventually.isBigO ?_).trans hp'⟩
+  filter_upwards [eventually_gt_atTop 0] with t ht
+  simpa only [← (hasSum_int_oddKernel b ht).tsum_eq, Real.norm_eq_abs, HurwitzKernelBounds.F_int,
+    HurwitzKernelBounds.f_int, pow_one, norm_mul, abs_of_nonneg (exp_pos _).le] using
+    (norm_tsum_le_tsum_norm (hasSum_int_oddKernel b ht).summable.norm)
+
+/-- The function `sinKernel a` has exponential decay at `+∞`, for any `a`. -/
+lemma isBigO_atTop_sinKernel (a : UnitAddCircle) :
+    ∃ p, 0 < p ∧ IsBigO atTop (sinKernel a) (fun x ↦ Real.exp (-p * x)) := by
+  induction' a using QuotientAddGroup.induction_on with a
+  obtain ⟨p, hp, hp'⟩ := HurwitzKernelBounds.isBigO_atTop_F_nat_one (le_refl 0)
+  refine ⟨p, hp, (Eventually.isBigO ?_).trans (hp'.const_mul_left 2)⟩
+  filter_upwards [eventually_gt_atTop 0] with t ht
+  rw [HurwitzKernelBounds.F_nat, ← (hasSum_nat_sinKernel a ht).tsum_eq]
+  apply tsum_of_norm_bounded (g := fun n ↦ 2 * HurwitzKernelBounds.f_nat 1 0 t n)
+  · exact (HurwitzKernelBounds.summable_f_nat 1 0 ht).hasSum.mul_left _
+  · intro n
+    rw [norm_mul, norm_mul, norm_mul, norm_two, mul_assoc, mul_assoc,
+      mul_le_mul_iff_of_pos_left two_pos, HurwitzKernelBounds.f_nat, pow_one, add_zero,
+      norm_of_nonneg (exp_pos _).le, Real.norm_eq_abs, Nat.abs_cast, ← mul_assoc,
+      mul_le_mul_iff_of_pos_right (exp_pos _)]
+    exact mul_le_of_le_one_right (Nat.cast_nonneg _) (abs_sin_le_one _)
+
+end asymp
+
+section FEPair
+/-!
+## Construction of a FE-pair
+-/
+
+/-- A `StrongFEPair` structure with `f = oddKernel a` and `g = sinKernel a`. -/
+@[simps]
+def hurwitzOddFEPair (a : UnitAddCircle) : StrongFEPair ℂ where
+  f := ofReal' ∘ oddKernel a
+  g := ofReal' ∘ sinKernel a
+  hf_int := (continuous_ofReal.comp_continuousOn (continuousOn_oddKernel a)).locallyIntegrableOn
+    measurableSet_Ioi
+  hg_int := (continuous_ofReal.comp_continuousOn (continuousOn_sinKernel a)).locallyIntegrableOn
+    measurableSet_Ioi
+  k := 3 / 2
+  hk := by norm_num
+  hε := one_ne_zero
+  f₀ := 0
+  hf₀ := by rfl
+  g₀ := 0
+  hg₀ := by rfl
+  hf_top r := by
+    let ⟨v, hv, hv'⟩ := isBigO_atTop_oddKernel a
+    rw [← isBigO_norm_left] at hv' ⊢
+    simp_rw [Function.comp_def, sub_zero, norm_real]
+    exact hv'.trans (isLittleO_exp_neg_mul_rpow_atTop hv _).isBigO
+  hg_top r := by
+    let ⟨v, hv, hv'⟩ := isBigO_atTop_sinKernel a
+    rw [← isBigO_norm_left] at hv' ⊢
+    simp_rw [Function.comp_def, sub_zero, norm_real]
+    exact hv'.trans (isLittleO_exp_neg_mul_rpow_atTop hv _).isBigO
+  h_feq x hx := by simp_rw [Function.comp_apply, one_mul, smul_eq_mul, ← ofReal_mul,
+    oddKernel_functional_equation a, one_div x, one_div x⁻¹, inv_rpow (le_of_lt hx), one_div,
+    inv_inv]
+
+/-!
+## Definition of the completed odd Hurwitz zeta function
+-/
+
+/-- The entire function of `s` which agrees with
+`1 / 2 * Gamma ((s + 1) / 2) * π ^ (-(s + 1) / 2) * ∑' (n : ℤ), sgn (n + a) / |n + a| ^ s`
+for `1 < re s`.
+-/
+def completedHurwitzZetaOdd (a : UnitAddCircle) (s : ℂ) : ℂ :=
+  ((hurwitzOddFEPair a).Λ ((s + 1) / 2)) / 2
+
+lemma differentiable_completedHurwitzZetaOdd (a : UnitAddCircle) :
+    Differentiable ℂ (completedHurwitzZetaOdd a) :=
+  ((hurwitzOddFEPair a).differentiable_Λ.comp
+    ((differentiable_id.add_const 1).div_const 2)).div_const 2
+
+/-- The entire function of `s` which agrees with
+` Gamma ((s + 1) / 2) * π ^ (-(s + 1) / 2) * ∑' (n : ℕ), sin (2 * π * a * n) / n ^ s`
+for `1 < re s`.
+-/
+def completedSinZeta (a : UnitAddCircle) (s : ℂ) : ℂ :=
+  ((hurwitzOddFEPair a).symm.Λ ((s + 1) / 2)) / 2
+
+lemma differentiable_completedSinZeta (a : UnitAddCircle) :
+    Differentiable ℂ (completedSinZeta a) :=
+  ((hurwitzOddFEPair a).symm.differentiable_Λ.comp
+    ((differentiable_id.add_const 1).div_const 2)).div_const 2
+
+/-!
+## Parity and functional equations
+-/
+
+lemma completedHurwitzZetaOdd_neg (a : UnitAddCircle) (s : ℂ) :
+    completedHurwitzZetaOdd (-a) s = -completedHurwitzZetaOdd a s := by
+  simp only [completedHurwitzZetaOdd, StrongFEPair.Λ, hurwitzOddFEPair, mellin, Function.comp_def,
+    oddKernel_neg, ofReal_neg, smul_neg]
+  rw [integral_neg, neg_div]
+
+lemma completedSinZeta_neg (a : UnitAddCircle) (s : ℂ) :
+    completedSinZeta (-a) s = -completedSinZeta a s := by
+  simp only [completedSinZeta, StrongFEPair.Λ, mellin, StrongFEPair.symm, WeakFEPair.symm,
+    hurwitzOddFEPair, Function.comp_def, sinKernel_neg, ofReal_neg, smul_neg]
+  rw [integral_neg, neg_div]
+
+
+/-- Functional equation for the odd Hurwitz zeta function. -/
+theorem completedHurwitzZetaOdd_one_sub (a : UnitAddCircle) (s : ℂ) :
+    completedHurwitzZetaOdd a (1 - s) = completedSinZeta a s := by
+  rw [completedHurwitzZetaOdd, completedSinZeta,
+    (by { push_cast; ring } : (1 - s + 1) / 2 = ↑(3 / 2 : ℝ) - (s + 1) / 2),
+    ← hurwitzOddFEPair_k, (hurwitzOddFEPair a).functional_equation ((s + 1) / 2),
+    hurwitzOddFEPair_ε, one_smul]
+
+/-- Functional equation for the odd Hurwitz zeta function (alternative form). -/
+lemma completedSinZeta_one_sub (a : UnitAddCircle) (s : ℂ) :
+    completedSinZeta a (1 - s) = completedHurwitzZetaOdd a s := by
+  rw [← completedHurwitzZetaOdd_one_sub, sub_sub_cancel]
+
+/-!
+## Relation to the Dirichlet series for `1 < re s`
+-/
+
+/-- Formula for `completedSinZeta` as a Dirichlet series in the convergence range
+(first version, with sum over `ℤ`). -/
+lemma hasSum_int_completedSinZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
+    HasSum (fun n : ℤ ↦ Gammaℝ (s + 1) * (-I) * Int.sign n *
+    cexp (2 * π * I * a * n) / (↑|n| : ℂ) ^ s / 2) (completedSinZeta a s) := by
+  let c (n : ℤ) : ℂ := -I * cexp (2 * π * I * a * n) / 2
+  have hc (n : ℤ) : ‖c n‖ = 1 / 2 := by
+    simp_rw [c, (by { push_cast; ring } : 2 * π * I * a * n = ↑(2 * π * a * n) * I), norm_div,
+      RCLike.norm_ofNat, norm_mul, norm_neg, norm_I, one_mul, norm_exp_ofReal_mul_I]
+  have hF t (ht : 0 < t) :
+      HasSum (fun n ↦ c n * n * rexp (-π * n ^ 2 * t)) (sinKernel a t / 2) := by
+    refine ((hasSum_int_sinKernel a ht).div_const 2).congr_fun fun n ↦ ?_
+    rw [div_mul_eq_mul_div, div_mul_eq_mul_div, mul_assoc (-I), mul_assoc (-I),
+      mul_assoc (-I), mul_assoc (-I), mul_comm (cexp _)]
+  have h_sum : Summable fun i ↦ ‖c i‖ / |↑i| ^ s.re := by
+    simp_rw [hc, div_right_comm]
+    apply Summable.div_const
+    apply Summable.of_nat_of_neg <;>
+    · simp only [Int.cast_neg, abs_neg, Int.cast_natCast, Nat.abs_cast]
+      rwa [summable_one_div_nat_rpow]
+  have := mellin_div_const .. ▸ hasSum_mellin_pi_mul_sq' (zero_lt_one.trans hs) hF h_sum
+  refine this.congr_fun fun n ↦ ?_
+  rw [← Int.cast_abs, ofReal_intCast]
+  have : (Int.sign n : ℂ) = SignType.sign (n : ℝ) := by
+    rw [← SignType.map_cast (f := Int.castRingHom ℂ), Int.coe_castRingHom, Int.cast_inj,
+      ← eq_intCast (Int.castRingHom ℝ) n, StrictMono.sign_comp, Int.sign_eq_sign n]
+    simp_rw [strictMono_iff_map_pos, Int.coe_castRingHom, Int.cast_pos, imp_self, forall_const]
+  rw [this, ← mul_div_assoc, div_mul_eq_mul_div, div_right_comm, mul_assoc (Gammaℝ _),
+    mul_assoc (Gammaℝ _), mul_assoc (Gammaℝ _), mul_assoc (-I), mul_assoc (-I),
+    mul_comm (cexp _)]
+
+/-- Formula for `completedSinZeta` as a Dirichlet series in the convergence range
+(second version, with sum over `ℕ`). -/
+lemma hasSum_nat_completedSinZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
+    HasSum (fun n : ℕ ↦ Gammaℝ (s + 1) * Real.sin (2 * π * a * n) / (n : ℂ) ^ s)
+    (completedSinZeta a s) := by
+  have := (hasSum_int_completedSinZeta a hs).sum_nat_of_sum_int
+  simp_rw [Int.sign_zero, Int.cast_zero, mul_zero, zero_mul, zero_div, add_zero, abs_neg,
+    Int.sign_neg, Nat.abs_cast, Int.cast_neg, Int.cast_natCast, ← add_div] at this
+  refine this.congr_fun fun n ↦ ?_
+  rw [div_right_comm]
+  rcases eq_or_ne n 0 with rfl | h
+  · simp only [Nat.cast_zero, mul_zero, Real.sin_zero, ofReal_zero, zero_div, mul_neg,
+      Int.sign_zero, Int.cast_zero, Complex.exp_zero, mul_one, neg_zero, add_zero]
+  simp_rw [Int.sign_natCast_of_ne_zero h, Int.cast_one, ofReal_sin, Complex.sin]
+  simp only [← mul_div_assoc, push_cast, mul_assoc (Gammaℝ _), ← mul_add]
+  congr 3
+  rw [mul_one, mul_neg_one, neg_neg, neg_mul I, ← sub_eq_neg_add, ← mul_sub, mul_comm,
+    mul_neg, neg_mul]
+  congr 3 <;> ring
+
+/-- Formula for `completedHurwitzZetaOdd` as a Dirichlet series in the convergence range. -/
+lemma hasSum_int_completedHurwitzZetaOdd (a : ℝ) {s : ℂ} (hs : 1 < re s) :
+    HasSum (fun n : ℤ ↦ Gammaℝ (s + 1) * SignType.sign (n + a) / (↑|n + a| : ℂ) ^ s / 2)
+    (completedHurwitzZetaOdd a s) := by
+  let r (n : ℤ) : ℝ := n + a
+  let c (n : ℤ) : ℂ := 1 / 2
+  have hF t (ht : 0 < t) : HasSum (fun n ↦ c n * r n * rexp (-π * (r n) ^ 2 * t))
+      (oddKernel a t / 2) := by
+    refine ((hasSum_ofReal.mpr (hasSum_int_oddKernel a ht)).div_const 2).congr_fun fun n ↦ ?_
+    simp only [r, c, push_cast, div_mul_eq_mul_div, one_mul]
+  have h_sum : Summable fun i ↦ ‖c i‖ / |r i| ^ s.re := by
+    simp_rw [c, ← mul_one_div ‖_‖]
+    apply Summable.mul_left
+    rwa [summable_one_div_int_add_rpow]
+  have := mellin_div_const .. ▸ hasSum_mellin_pi_mul_sq' (zero_lt_one.trans hs) hF h_sum
+  refine this.congr_fun fun n ↦ ?_
+  simp only [c, mul_one_div, div_mul_eq_mul_div, div_right_comm]
+
+/-!
+## Non-completed zeta functions
+-/
+
+/-- The odd part of the Hurwitz zeta function, i.e. the meromorphic function of `s` which agrees
+with `1 / 2 * ∑' (n : ℤ), sign (n + a) / |n + a| ^ s` for `1 < re s`-/
+noncomputable def hurwitzZetaOdd (a : UnitAddCircle) (s : ℂ) :=
+  completedHurwitzZetaOdd a s / Gammaℝ (s + 1)
+
+lemma hurwitzZetaOdd_neg (a : UnitAddCircle) (s : ℂ) :
+    hurwitzZetaOdd (-a) s = -hurwitzZetaOdd a s := by
+  simp_rw [hurwitzZetaOdd, completedHurwitzZetaOdd_neg, neg_div]
+
+/-- The odd Hurwitz zeta function is differentiable everywhere. -/
+lemma differentiable_hurwitzZetaOdd (a : UnitAddCircle) :
+    Differentiable ℂ (hurwitzZetaOdd a) :=
+  (differentiable_completedHurwitzZetaOdd a).mul <| differentiable_Gammaℝ_inv.comp <|
+    differentiable_id.add <| differentiable_const _
+
+/-- The sine zeta function, i.e. the meromorphic function of `s` which agrees
+with `∑' (n : ℕ), sin (2 * π * a * n) / n ^ s` for `1 < re s`. -/
+noncomputable def sinZeta (a : UnitAddCircle) (s : ℂ) :=
+  completedSinZeta a s / Gammaℝ (s + 1)
+
+lemma sinZeta_neg (a : UnitAddCircle) (s : ℂ) :
+    sinZeta (-a) s = -sinZeta a s := by
+  simp_rw [sinZeta, completedSinZeta_neg, neg_div]
+
+/-- The sine zeta function is differentiable everywhere. -/
+lemma differentiableAt_sinZeta (a : UnitAddCircle) :
+    Differentiable ℂ (sinZeta a) :=
+  (differentiable_completedSinZeta a).mul <| differentiable_Gammaℝ_inv.comp <|
+    differentiable_id.add <| differentiable_const _
+
+/-- Formula for `hurwitzZetaOdd` as a Dirichlet series in the convergence range (sum over `ℤ`). -/
+theorem hasSum_int_hurwitzZetaOdd (a : ℝ) {s : ℂ} (hs : 1 < re s) :
+    HasSum (fun n : ℤ ↦ SignType.sign (n + a) / (↑|n + a| : ℂ) ^ s / 2) (hurwitzZetaOdd a s) := by
+  rw [hurwitzZetaOdd]
+  refine ((hasSum_int_completedHurwitzZetaOdd a hs).div_const (Gammaℝ _)).congr_fun fun n ↦ ?_
+  simp_rw [div_right_comm _ _ (Gammaℝ _)]
+  rw [mul_div_cancel_left₀ _ (Gammaℝ_ne_zero_of_re_pos ?_)]
+  rw [add_re, one_re]
+  positivity
+
+/-- Formula for `hurwitzZetaOdd` as a Dirichlet series in the convergence range, with sum over `ℕ`
+(version with absolute values) -/
+lemma hasSum_nat_hurwitzZetaOdd (a : ℝ) {s : ℂ} (hs : 1 < re s) :
+    HasSum (fun n : ℕ ↦ (SignType.sign (n + a) / (↑|n + a| : ℂ) ^ s
+      - SignType.sign (n + 1 - a) / (↑|n + 1 - a| : ℂ) ^ s) / 2) (hurwitzZetaOdd a s) := by
+  refine (hasSum_int_hurwitzZetaOdd a hs).nat_add_neg_add_one.congr_fun fun n ↦ ?_
+  rw [Int.cast_neg, Int.cast_add, Int.cast_one, sub_div, sub_eq_add_neg, Int.cast_natCast]
+  have : -(n + 1) + a = -(n + 1 - a) := by { push_cast; ring_nf }
+  rw [this, Left.sign_neg, abs_neg, SignType.coe_neg, neg_div, neg_div]
+
+/-- Formula for `hurwitzZetaOdd` as a Dirichlet series in the convergence range, with sum over `ℕ`
+(version without absolute values, assuming `a ∈ Icc 0 1`) -/
+lemma hasSum_nat_hurwitzZetaOdd_of_mem_Icc {a : ℝ} (ha : a ∈ Icc 0 1) {s : ℂ} (hs : 1 < re s) :
+    HasSum (fun n : ℕ ↦ (1 / (n + a : ℂ) ^ s - 1 / (n + 1 - a : ℂ) ^ s) / 2)
+    (hurwitzZetaOdd a s) := by
+  refine (hasSum_nat_hurwitzZetaOdd a hs).congr_fun fun n ↦ ?_
+  suffices ∀ (b : ℝ) (_ : 0 ≤ b), SignType.sign (n + b) / (↑|n + b| : ℂ) ^ s = 1 / (n + b) ^ s by
+    simp only [add_sub_assoc, this a ha.1, this (1 - a) (sub_nonneg.mpr ha.2), push_cast]
+  intro b hb
+  rw [abs_of_nonneg (by positivity), (by simp : (n : ℂ) + b = ↑(n + b))]
+  rcases lt_or_eq_of_le (by positivity : 0 ≤ n + b) with hb | hb
+  · rw [sign_pos hb, SignType.coe_one]
+  · rw [← hb, ofReal_zero, zero_cpow ((not_lt.mpr zero_le_one) ∘ (zero_re ▸ · ▸ hs)),
+      div_zero, div_zero]
+
+/-- Formula for `sinZeta` as a Dirichlet series in the convergence range, with sum over `ℤ`. -/
+theorem hasSum_int_sinZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
+    HasSum (fun n : ℤ ↦ -I * Int.sign n * cexp (2 * π * I * a * n) / ↑|n| ^ s / 2)
+    (sinZeta a s) := by
+  rw [sinZeta]
+  refine ((hasSum_int_completedSinZeta a hs).div_const (Gammaℝ (s + 1))).congr_fun fun n ↦ ?_
+  simp_rw [mul_assoc, div_right_comm _ _ (Gammaℝ _)]
+  rw [mul_div_cancel_left₀ _ (Gammaℝ_ne_zero_of_re_pos (?_ : 0 < (s + 1).re))]
+  rw [add_re, one_re]
+  positivity
+
+/-- Formula for `sinZeta` as a Dirichlet series in the convergence range, with sum over `ℕ`. -/
+lemma hasSum_nat_sinZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
+    HasSum (fun n : ℕ ↦ Real.sin (2 * π * a * n) / (n : ℂ) ^ s) (sinZeta a s) := by
+  have hs' : s ≠ 0 := (fun h ↦ (not_lt.mpr zero_le_one) ((zero_re ▸ h ▸ hs)))
+  have := (hasSum_int_sinZeta a hs).sum_nat_of_sum_int
+  simp_rw [abs_neg, Int.sign_neg, Int.cast_neg, Nat.abs_cast, Int.cast_natCast, mul_neg,
+    abs_zero, Int.cast_zero, zero_cpow hs', div_zero, zero_div, add_zero] at this
+  simp_rw [push_cast, Complex.sin]
+  refine this.congr_fun fun n ↦ ?_
+  rcases ne_or_eq n 0 with h | rfl
+  · simp only [neg_mul, sub_mul, div_right_comm _ (2 : ℂ), Int.sign_natCast_of_ne_zero h,
+      Int.cast_one, mul_one, mul_comm I, neg_neg, ← add_div, ← sub_eq_neg_add]
+    congr 5 <;> ring
+  · simp only [Nat.cast_zero, Int.sign_zero, Int.cast_zero, mul_zero, zero_mul, neg_zero,
+      sub_self, zero_div, zero_add]
+
+/-- Reformulation of `hasSum_nat_cosZeta` using `LSeriesHasSum`. -/
+lemma LSeriesHasSum_sin (a : ℝ) {s : ℂ} (hs : 1 < re s) :
+    LSeriesHasSum (Real.sin <| 2 * π * a * ·) s (sinZeta a s) := by
+  refine (hasSum_nat_sinZeta a hs).congr_fun (fun n ↦ ?_)
+  rcases eq_or_ne n 0 with rfl | hn
+  · rw [LSeries.term_zero, Nat.cast_zero, mul_zero, Real.sin_zero, ofReal_zero, zero_div]
+  · apply LSeries.term_of_ne_zero hn
+
+/-- The trivial zeroes of the odd Hurwitz zeta function. -/
+theorem hurwitzZetaOdd_neg_two_mul_nat_sub_one (a : UnitAddCircle) (n : ℕ) :
+    hurwitzZetaOdd a (-2 * n - 1) = 0 := by
+  rw [hurwitzZetaOdd, Gammaℝ_eq_zero_iff.mpr ⟨n, by rw [neg_mul, sub_add_cancel]⟩, div_zero]
+
+/-- The trivial zeroes of the sine zeta function. -/
+theorem sinZeta_neg_two_mul_nat_sub_one (a : UnitAddCircle) (n : ℕ) :
+    sinZeta a (-2 * n - 1) = 0 := by
+  rw [sinZeta, Gammaℝ_eq_zero_iff.mpr ⟨n, by rw [neg_mul, sub_add_cancel]⟩, div_zero]
+
+/-- If `s` is not in `-ℕ`, then `hurwitzZetaOdd a (1 - s)` is an explicit multiple of
+`sinZeta s`. -/
+lemma hurwitzZetaOdd_one_sub (a : UnitAddCircle) {s : ℂ} (hs : ∀ (n : ℕ), s ≠ -n) :
+    hurwitzZetaOdd a (1 - s) = 2 * (2 * π) ^ (-s) * Gamma s * sin (π * s / 2) * sinZeta a s := by
+  rw [← Gammaℂ, hurwitzZetaOdd, (by ring : 1 - s + 1 = 2 - s), div_eq_mul_inv,
+    inv_Gammaℝ_two_sub hs, completedHurwitzZetaOdd_one_sub, sinZeta, ← div_eq_mul_inv,
+    ← mul_div_assoc, ← mul_div_assoc, mul_comm]
+
+/-- If `s` is not in `-ℕ`, then `hurwitzZetaOdd a (1 - s)` is an explicit multiple of
+`sinZeta s`. -/
+lemma sinZeta_one_sub (a : UnitAddCircle) {s : ℂ} (hs : ∀ (n : ℕ), s ≠ -n) :
+    sinZeta a (1 - s) = 2 * (2 * π) ^ (-s) * Gamma s * sin (π * s / 2) * hurwitzZetaOdd a s := by
+  rw [← Gammaℂ, sinZeta, (by ring : 1 - s + 1 = 2 - s), div_eq_mul_inv, inv_Gammaℝ_two_sub hs,
+    completedSinZeta_one_sub, hurwitzZetaOdd, ← div_eq_mul_inv, ← mul_div_assoc, ← mul_div_assoc,
+    mul_comm]


### PR DESCRIPTION
This PR adds the analytic continuation and functional equation for the odd part of the Hurwitz zeta function.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
