### PR TITLE
[Merged by Bors] - chore(WittVector.Isocrystal): remove helper local instance

### DIFF
--- a/Mathlib/RingTheory/WittVector/Isocrystal.lean
+++ b/Mathlib/RingTheory/WittVector/Isocrystal.lean
@@ -153,12 +153,7 @@ open scoped Isocrystal
 
 /-! ### Classification of isocrystals in dimension 1 -/
 
-
-/-- A helper instance for type class inference. -/
-@[local instance]
-def FractionRing.module : Module K(p, k) K(p, k) :=
-  Semiring.toModule
-#align witt_vector.fraction_ring.module WittVector.FractionRing.module
+#noalign witt_vector.fraction_ring.module
 
 /-- Type synonym for `K(p, k)` to carry the standard 1-dimensional isocrystal structure
 of slope `m : ℤ`.


### PR DESCRIPTION
`WittVector.FractionRing.module` is `Semiring.toModule` under the hood. We seem fine without it now.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I timed the file before and after locally and noticed no change in user time. It is also a leaf file.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
