### PR TITLE
[Merged by Bors] - chore: change the definition of `unitLatticeEquiv` to term mode 

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Units/DirichletTheorem.lean
+++ b/Mathlib/NumberTheory/NumberField/Units/DirichletTheorem.lean
@@ -374,23 +374,30 @@ theorem unitLattice_rank :
     finrank ℤ (unitLattice K) = Units.rank K := by
   rw [← Units.finrank_eq_rank, Zlattice.rank ℝ]
 
+private theorem unitLatticeEquiv_aux1 :
+    (logEmbedding K).ker = (MonoidHom.toAdditive (QuotientGroup.mk' (torsion K))).ker := by
+  ext
+  rw [MonoidHom.coe_toAdditive_ker, QuotientGroup.ker_mk', AddMonoidHom.mem_ker,
+    logEmbedding_eq_zero_iff]
+  rfl
+
+private theorem unitLatticeEquiv_aux2 :
+    Function.Surjective (MonoidHom.toAdditive (QuotientGroup.mk' (torsion K))) := by
+  intro x
+  refine ⟨Additive.ofMul x.out', ?_⟩
+  simp only [MonoidHom.toAdditive_apply_apply, toMul_ofMul, QuotientGroup.mk'_apply,
+      QuotientGroup.out_eq']
+  rfl
+
 /-- The linear equivalence between `unitLattice` and `(𝓞 K)ˣ ⧸ (torsion K)` as an additive
 `ℤ`-module. -/
-def unitLatticeEquiv : (unitLattice K) ≃ₗ[ℤ] Additive ((𝓞 K)ˣ ⧸ (torsion K)) := by
-  refine AddEquiv.toIntLinearEquiv ?_
-  rw [unitLattice, ← AddMonoidHom.range_eq_map (logEmbedding K)]
-  refine (QuotientAddGroup.quotientKerEquivRange (logEmbedding K)).symm.trans ?_
-  refine (QuotientAddGroup.quotientAddEquivOfEq ?_).trans
-    (QuotientAddGroup.quotientKerEquivOfSurjective
-      (MonoidHom.toAdditive (QuotientGroup.mk' (torsion K))) (fun x => ?_))
-  · ext
-    rw [MonoidHom.coe_toAdditive_ker, QuotientGroup.ker_mk', AddMonoidHom.mem_ker,
-      logEmbedding_eq_zero_iff]
-    rfl
-  · refine ⟨Additive.ofMul x.out', ?_⟩
-    simp only [MonoidHom.toAdditive_apply_apply, toMul_ofMul, QuotientGroup.mk'_apply,
-      QuotientGroup.out_eq']
-    rfl
+def unitLatticeEquiv : (unitLattice K) ≃ₗ[ℤ] Additive ((𝓞 K)ˣ ⧸ (torsion K)) :=
+  AddEquiv.toIntLinearEquiv <|
+    AddMonoidHom.range_eq_map (logEmbedding K) ▸ (QuotientAddGroup.quotientKerEquivRange
+      (logEmbedding K)).symm.trans <|
+        (QuotientAddGroup.quotientAddEquivOfEq (unitLatticeEquiv_aux1  K)).trans
+          (QuotientAddGroup.quotientKerEquivOfSurjective
+            (MonoidHom.toAdditive (QuotientGroup.mk' (torsion K))) (unitLatticeEquiv_aux2 K))
 
 instance : Module.Free ℤ (Additive ((𝓞 K)ˣ ⧸ (torsion K))) :=
   Module.Free.of_equiv (unitLatticeEquiv K)

--- a/Mathlib/NumberTheory/NumberField/Units/DirichletTheorem.lean
+++ b/Mathlib/NumberTheory/NumberField/Units/DirichletTheorem.lean
@@ -393,11 +393,11 @@ private theorem unitLatticeEquiv_aux2 :
 `ℤ`-module. -/
 def unitLatticeEquiv : (unitLattice K) ≃ₗ[ℤ] Additive ((𝓞 K)ˣ ⧸ (torsion K)) :=
   AddEquiv.toIntLinearEquiv <|
-    AddMonoidHom.range_eq_map (logEmbedding K) ▸ (QuotientAddGroup.quotientKerEquivRange
-      (logEmbedding K)).symm.trans <|
-        (QuotientAddGroup.quotientAddEquivOfEq (unitLatticeEquiv_aux1  K)).trans
-          (QuotientAddGroup.quotientKerEquivOfSurjective
-            (MonoidHom.toAdditive (QuotientGroup.mk' (torsion K))) (unitLatticeEquiv_aux2 K))
+    (AddEquiv.addSubgroupCongr (AddMonoidHom.range_eq_map (logEmbedding K)).symm).trans <|
+      (QuotientAddGroup.quotientKerEquivRange (logEmbedding K)).symm.trans <|
+          (QuotientAddGroup.quotientAddEquivOfEq (unitLatticeEquiv_aux1  K)).trans <|
+            QuotientAddGroup.quotientKerEquivOfSurjective
+              (MonoidHom.toAdditive (QuotientGroup.mk' (torsion K))) (unitLatticeEquiv_aux2 K)
 
 instance : Module.Free ℤ (Additive ((𝓞 K)ˣ ⧸ (torsion K))) :=
   Module.Free.of_equiv (unitLatticeEquiv K)


### PR DESCRIPTION
See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/tactics.20in.20construction.20of.20.60unitLatticeEquiv.60/near/437929609)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
