### PR TITLE
[Merged by Bors] - chore(CategoryTheory): fix hasFiniteLimits_of_hasLimitsOfSize

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
@@ -121,6 +121,7 @@ theorem hasLimit_of_equalizer_and_product (F : J ⥤ C) [HasLimit (Discrete.func
 /-- A limit can be realised as a subobject of a product. -/
 noncomputable def limitSubobjectProduct [HasLimitsOfSize.{w, w} C] (F : J ⥤ C) :
     limit F ⟶ ∏ fun j => F.obj j :=
+  have := hasFiniteLimits_of_hasLimitsOfSize C
   (limit.isoLimitCone (limitConeOfEqualizerAndProduct F)).hom ≫ equalizer.ι _ _
 #align category_theory.limits.limit_subobject_product CategoryTheory.Limits.limitSubobjectProduct
 
@@ -349,6 +350,7 @@ theorem hasColimit_of_coequalizer_and_coproduct (F : J ⥤ C) [HasColimit (Discr
 /-- A colimit can be realised as a quotient of a coproduct. -/
 noncomputable def colimitQuotientCoproduct [HasColimitsOfSize.{w, w} C] (F : J ⥤ C) :
     ∐ (fun j => F.obj j) ⟶ colimit F :=
+  have := hasFiniteColimits_of_hasColimitsOfSize C
   coequalizer.π _ _ ≫ (colimit.isoColimitCocone (colimitCoconeOfCoequalizerAndCoproduct F)).inv
 #align category_theory.limits.colimit_quotient_coproduct CategoryTheory.Limits.colimitQuotientCoproduct
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
@@ -48,7 +48,7 @@ instance (priority := 100) hasLimitsOfShape_of_hasFiniteLimits (J : Type w) [Sma
   apply HasFiniteLimits.out
 #align category_theory.limits.has_limits_of_shape_of_has_finite_limits CategoryTheory.Limits.hasLimitsOfShape_of_hasFiniteLimits
 
-instance (priority := 100) hasFiniteLimits_of_hasLimitsOfSize [HasLimitsOfSize.{v', u'} C] :
+lemma hasFiniteLimits_of_hasLimitsOfSize [HasLimitsOfSize.{v', u'} C] :
     HasFiniteLimits C where
   out := fun J hJ hJ' =>
     haveI := hasLimitsOfSizeShrink.{0, 0} C
@@ -59,8 +59,12 @@ instance (priority := 100) hasFiniteLimits_of_hasLimitsOfSize [HasLimitsOfSize.{
 
 /-- If `C` has all limits, it has finite limits. -/
 instance (priority := 100) hasFiniteLimits_of_hasLimits [HasLimits C] : HasFiniteLimits C :=
-  inferInstance
+  hasFiniteLimits_of_hasLimitsOfSize C
 #align category_theory.limits.has_finite_limits_of_has_limits CategoryTheory.Limits.hasFiniteLimits_of_hasLimits
+
+instance (priority := 90) hasFiniteLimits_of_hasLimitsOfSize₀ [HasLimitsOfSize.{0, 0} C] :
+    HasFiniteLimits C :=
+  hasFiniteLimits_of_hasLimitsOfSize C
 
 /-- We can always derive `HasFiniteLimits C` by providing limits at an
 arbitrary universe. -/
@@ -98,7 +102,7 @@ instance (priority := 100) hasColimitsOfShape_of_hasFiniteColimits (J : Type w) 
   apply HasFiniteColimits.out
 #align category_theory.limits.has_colimits_of_shape_of_has_finite_colimits CategoryTheory.Limits.hasColimitsOfShape_of_hasFiniteColimits
 
-instance (priority := 100) hasFiniteColimits_of_hasColimitsOfSize [HasColimitsOfSize.{v', u'} C] :
+lemma hasFiniteColimits_of_hasColimitsOfSize [HasColimitsOfSize.{v', u'} C] :
     HasFiniteColimits C where
   out := fun J hJ hJ' =>
     haveI := hasColimitsOfSizeShrink.{0, 0} C
@@ -108,7 +112,11 @@ instance (priority := 100) hasFiniteColimits_of_hasColimitsOfSize [HasColimitsOf
 #align category_theory.limits.has_finite_colimits_of_has_colimits_of_size CategoryTheory.Limits.hasFiniteColimits_of_hasColimitsOfSize
 
 instance (priority := 100) hasFiniteColimits_of_hasColimits [HasColimits C] : HasFiniteColimits C :=
-  inferInstance
+  hasFiniteColimits_of_hasColimitsOfSize C
+
+instance (priority := 90) hasFiniteColimits_of_hasColimits₀ [HasColimitsOfSize.{0, 0} C] :
+    HasFiniteColimits C :=
+  hasFiniteColimits_of_hasColimitsOfSize C
 
 /-- We can always derive `HasFiniteColimits C` by providing colimits at an
 arbitrary universe. -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
@@ -114,7 +114,7 @@ lemma hasFiniteColimits_of_hasColimitsOfSize [HasColimitsOfSize.{v', u'} C] :
 instance (priority := 100) hasFiniteColimits_of_hasColimits [HasColimits C] : HasFiniteColimits C :=
   hasFiniteColimits_of_hasColimitsOfSize C
 
-instance (priority := 90) hasFiniteColimits_of_hasColimits₀ [HasColimitsOfSize.{0, 0} C] :
+instance (priority := 90) hasFiniteColimits_of_hasColimitsOfSize₀ [HasColimitsOfSize.{0, 0} C] :
     HasFiniteColimits C :=
   hasFiniteColimits_of_hasColimitsOfSize C
 


### PR DESCRIPTION
Given a category `C`, `hasFiniteLimits_of_hasLimitsOfSize` (and the dual statement for colimits) involves two universes `u'` and `v'` which may be unrelated to the two universes `u` and `v` involved in the category `C : Type u` (and `[Category.{v} C]`). For general universes, it is made a lemma instead of an instance. It is made an instance only in the `_hasLimits` case (which corresponds to `u'=v'=v`) and the `u'=v'=0` case.

This fixes the behavior observed in https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/invalid.20occurrence.20of.20universe.20level.20'u_1'/near/437497392

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
