### PR TITLE
feat: `mul_le_mul` and `smul_le_smul` variant

### DIFF
--- a/Mathlib/Algebra/Order/Module/Defs.lean
+++ b/Mathlib/Algebra/Order/Module/Defs.lean
@@ -361,6 +361,11 @@ lemma smul_le_smul' [PosSMulMono α β] [SMulPosMono α β] (ha : a₁ ≤ a₂)
     (h₁ : 0 ≤ b₁) : a₁ • b₁ ≤ a₂ • b₂ :=
   (smul_le_smul_of_nonneg_right ha h₁).trans (smul_le_smul_of_nonneg_left hb h₂)
 
+lemma smul_le_smul'' [PosSMulMono α β] [SMulPosMono α β] (ha : a₁ ≤ a₂) (hb : b₁ ≤ b₂)
+    (h0a : 0 ≤ a₁) (h0b : 0 ≤ b₁) :
+    a₁ • b₁ ≤ a₂ • b₂ :=
+  smul_le_smul ha hb h0a (h0b.trans hb)
+
 end LeftRight
 end Preorder
 

--- a/Mathlib/Algebra/Order/Ring/Lemmas.lean
+++ b/Mathlib/Algebra/Order/Ring/Lemmas.lean
@@ -474,6 +474,10 @@ theorem mul_le_mul [PosMulMono α] [MulPosMono α] (h₁ : a ≤ b) (h₂ : c �
   (mul_le_mul_of_nonneg_right h₁ c0).trans <| mul_le_mul_of_nonneg_left h₂ b0
 #align mul_le_mul mul_le_mul
 
+theorem mul_le_mul'' [PosMulMono α] [MulPosMono α] (h₁ : a ≤ b) (h₂ : c ≤ d) (c0 : 0 ≤ c)
+    (a0 : 0 ≤ a) : a * c ≤ b * d :=
+  mul_le_mul h₁ h₂ c0 (a0.trans h₁)
+
 theorem mul_self_le_mul_self [PosMulMono α] [MulPosMono α] (ha : 0 ≤ a) (hab : a ≤ b) :
     a * a ≤ b * b :=
   mul_le_mul hab hab ha <| ha.trans hab


### PR DESCRIPTION
These two trivial lemmas address the following `exact?` failures:
```lean
import Mathlib

example {x y : ℚ} {m n : ℤ} (hx : 0 ≤ x) (hm : 0 ≤ m) (hxy : x ≤ y) (hmn : m ≤ n) :
    m • x ≤ n • y := by
  exact?

example {x y m n : ℚ} (hx : 0 ≤ x) (hm : 0 ≤ m) (hxy : x ≤ y) (hmn : m ≤ n) :
    m * x ≤ n * y := by
  exact?
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
