### PR TITLE
[Merged by Bors] - feat(NumberTheory/EulerProduct/DirichletLSeries): use infinite product and L-series

### DIFF
--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -16,11 +16,12 @@ the Euler Product formula for the Riemann ζ function
 $$\prod_p \frac{1}{1 - p^{-s}}
    = \lim_{n \to \infty} \prod_{p < n} \frac{1}{1 - p^{-s}} = \zeta(s)$$
 for $s$ with real part $> 1$ ($p$ runs through the primes).
-The formalized statement is the second equality above, since infinite products are not yet
-available in Mathlib.
+This statement is the second equality above. There are versions `riemannZeta_eulerProduct_hasProd`
+and `riemannZeta_eulerProduct_tprod` in terms of `HasProd` and `tprod`, respectively.
 
-The second result is `dirichletLSeries_eulerProduct`, which is the analogous statement
-for Dirichlet L-functions.
+The second result is `dirichletLSeries_eulerProduct` (with variants
+`dirichletLSeries_eulerProduct_hasProd` and `dirichletLSeries_eulerProduct_tprod`),
+which is the analogous statement for Dirichlet L-series.
 -/
 
 open Complex

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -5,7 +5,7 @@ Authors: Michael Stoll
 -/
 import Mathlib.NumberTheory.DirichletCharacter.Bounds
 import Mathlib.NumberTheory.EulerProduct.Basic
-import Mathlib.NumberTheory.LSeries.Dirichlet
+import Mathlib.NumberTheory.LSeries.Basic
 import Mathlib.NumberTheory.ZetaFunction
 
 /-!

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -11,13 +11,13 @@ import Mathlib.NumberTheory.ZetaFunction
 /-!
 # The Euler Product for the Riemann Zeta Function and Dirichlet L-Series
 
-The first main result of this file is `riemannZeta_eulerProduct`, which states
-the Euler Product formula for the Riemann ζ function
+The first main result of this file is the Euler Product formula for the Riemann ζ function
 $$\prod_p \frac{1}{1 - p^{-s}}
    = \lim_{n \to \infty} \prod_{p < n} \frac{1}{1 - p^{-s}} = \zeta(s)$$
 for $s$ with real part $> 1$ ($p$ runs through the primes).
-This statement is the second equality above. There are versions `riemannZeta_eulerProduct_hasProd`
-and `riemannZeta_eulerProduct_tprod` in terms of `HasProd` and `tprod`, respectively.
+`riemannZeta_eulerProduct` is the second equality above. There are versions
+`riemannZeta_eulerProduct_hasProd` and `riemannZeta_eulerProduct_tprod` in terms of `HasProd`
+and `tprod`, respectively.
 
 The second result is `dirichletLSeries_eulerProduct` (with variants
 `dirichletLSeries_eulerProduct_hasProd` and `dirichletLSeries_eulerProduct_tprod`),

--- a/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
+++ b/Mathlib/NumberTheory/EulerProduct/DirichletLSeries.lean
@@ -91,7 +91,7 @@ This version is stated in terms of `HasProd`. -/
 theorem riemannZeta_eulerProduct_hasProd (hs : 1 < s.re) :
     HasProd (fun p : Primes ↦ (1 - (p : ℂ) ^ (-s))⁻¹) (riemannZeta s) := by
   rw [← tsum_riemannZetaSummand hs]
-  convert eulerProduct_completely_multiplicative_hasProd <| summable_riemannZetaSummand hs
+  apply eulerProduct_completely_multiplicative_hasProd <| summable_riemannZetaSummand hs
 
 /-- The Euler product for the Riemann ζ function, valid for `s.re > 1`.
 This version is stated in terms of `tprod`. -/
@@ -105,7 +105,7 @@ theorem riemannZeta_eulerProduct (hs : 1 < s.re) :
     Tendsto (fun n : ℕ ↦ ∏ p in primesBelow n, (1 - (p : ℂ) ^ (-s))⁻¹) atTop
       (𝓝 (riemannZeta s)) := by
   rw [← tsum_riemannZetaSummand hs]
-  convert eulerProduct_completely_multiplicative <| summable_riemannZetaSummand hs
+  apply eulerProduct_completely_multiplicative <| summable_riemannZetaSummand hs
 
 open scoped LSeries.notation
 
@@ -124,9 +124,10 @@ theorem dirichletLSeries_eulerProduct_tprod {N : ℕ} (χ : DirichletCharacter �
     ∏' p : Primes, (1 - χ p * (p : ℂ) ^ (-s))⁻¹ = L ↗χ s :=
   (dirichletLSeries_eulerProduct_hasProd χ hs).tprod_eq
 
-/-- The Euler product for Dirichlet L-series, valid for `s.re > 1`. -/
+/-- The Euler product for Dirichlet L-series, valid for `s.re > 1`.
+This version is stated in the form of convergence of finite partial products. -/
 theorem dirichletLSeries_eulerProduct {N : ℕ} (χ : DirichletCharacter ℂ N) (hs : 1 < s.re) :
     Tendsto (fun n : ℕ ↦ ∏ p in primesBelow n, (1 - χ p * (p : ℂ) ^ (-s))⁻¹) atTop
       (𝓝 (L ↗χ s)) := by
   rw [← tsum_dirichletSummand χ hs]
-  convert eulerProduct_completely_multiplicative <| summable_dirichletSummand χ hs
+  apply eulerProduct_completely_multiplicative <| summable_dirichletSummand χ hs


### PR DESCRIPTION
This is a follow-up to [#12161](https://github.com/leanprover-community/mathlib4/pull/12161).
It adds `HasProd` and `tsum` versions of the Euler Product statements for the Riemann zeta function and Dirichlet L-series (in the latter case, also replacing the explicit infinite sum by `L ↗χ s`).

See [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/L-series/near/438037266).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
