### PR TITLE
[Merged by Bors] - chore: Move `CharP` lemmas about order of elements

### DIFF
--- a/Mathlib/Algebra/CharP/Basic.lean
+++ b/Mathlib/Algebra/CharP/Basic.lean
@@ -6,7 +6,6 @@ Authors: Kenny Lau, Joey van Langen, Casper Putz
 import Mathlib.Algebra.CharP.Defs
 import Mathlib.Data.Nat.Multiplicity
 import Mathlib.Data.Nat.Choose.Sum
-import Mathlib.GroupTheory.OrderOfElement
 
 #align_import algebra.char_p.basic from "leanprover-community/mathlib"@"47a1a73351de8dd6c8d3d32b569c8e434b03ca47"
 
@@ -14,6 +13,7 @@ import Mathlib.GroupTheory.OrderOfElement
 # Characteristic of semirings
 -/
 
+assert_not_exists orderOf
 
 universe u v
 
@@ -88,15 +88,6 @@ theorem exists_add_pow_prime_eq (hp : p.Prime) (x y : R) :
 end CommSemiring
 
 variable (R)
-
-@[simp]
-theorem CharP.cast_card_eq_zero [AddGroupWithOne R] [Fintype R] : (Fintype.card R : R) = 0 := by
-  rw [← nsmul_one, card_nsmul_eq_zero]
-#align char_p.cast_card_eq_zero CharP.cast_card_eq_zero
-
-theorem CharP.addOrderOf_one (R) [Semiring R] : CharP R (addOrderOf (1 : R)) :=
-  ⟨fun n => by rw [← Nat.smul_one_eq_cast, addOrderOf_dvd_iff_nsmul_eq_zero]⟩
-#align char_p.add_order_of_one CharP.addOrderOf_one
 
 theorem add_pow_char_of_commute [Semiring R] {p : ℕ} [hp : Fact p.Prime] [CharP R p] (x y : R)
     (h : Commute x y) : (x + y) ^ p = x ^ p + y ^ p := by
@@ -191,37 +182,3 @@ theorem char_is_prime (p : ℕ) [CharP R p] : p.Prime :=
 
 end Ring
 end CharP
-
-section
-
-variable [NonAssocRing R] [Fintype R] (n : ℕ)
-
-theorem charP_of_ne_zero (hn : Fintype.card R = n) (hR : ∀ i < n, (i : R) = 0 → i = 0) :
-    CharP R n :=
-  { cast_eq_zero_iff' := by
-      have H : (n : R) = 0 := by rw [← hn, CharP.cast_card_eq_zero]
-      intro k
-      constructor
-      · intro h
-        rw [← Nat.mod_add_div k n, Nat.cast_add, Nat.cast_mul, H, zero_mul,
-          add_zero] at h
-        rw [Nat.dvd_iff_mod_eq_zero]
-        apply hR _ (Nat.mod_lt _ _) h
-        rw [← hn, gt_iff_lt, Fintype.card_pos_iff]
-        exact ⟨0⟩
-      · rintro ⟨k, rfl⟩
-        rw [Nat.cast_mul, H, zero_mul] }
-#align char_p_of_ne_zero charP_of_ne_zero
-
-theorem charP_of_prime_pow_injective (R) [Ring R] [Fintype R] (p : ℕ) [hp : Fact p.Prime] (n : ℕ)
-    (hn : Fintype.card R = p ^ n) (hR : ∀ i ≤ n, (p : R) ^ i = 0 → i = n) : CharP R (p ^ n) := by
-  obtain ⟨c, hc⟩ := CharP.exists R
-  have hcpn : c ∣ p ^ n := by rw [← CharP.cast_eq_zero_iff R c, ← hn, CharP.cast_card_eq_zero]
-  obtain ⟨i, hi, hc⟩ : ∃ i ≤ n, c = p ^ i := by rwa [Nat.dvd_prime_pow hp.1] at hcpn
-  obtain rfl : i = n := by
-    apply hR i hi
-    rw [← Nat.cast_pow, ← hc, CharP.cast_eq_zero]
-  rwa [← hc]
-#align char_p_of_prime_pow_injective charP_of_prime_pow_injective
-
-end

--- a/Mathlib/Algebra/CharP/CharAndCard.lean
+++ b/Mathlib/Algebra/CharP/CharAndCard.lean
@@ -63,7 +63,7 @@ theorem prime_dvd_char_iff_dvd_card {R : Type*} [CommRing R] [Fintype R] (p : �
       h.trans <|
         Int.natCast_dvd_natCast.mp <|
           (CharP.intCast_eq_zero_iff R (ringChar R) (Fintype.card R)).mp <|
-            mod_cast CharP.cast_card_eq_zero R,
+            mod_cast Nat.cast_card_eq_zero R,
       fun h => ?_⟩
   by_contra h₀
   rcases exists_prime_addOrderOf_dvd_card p h with ⟨r, hr⟩

--- a/Mathlib/Algebra/CharP/Quotient.lean
+++ b/Mathlib/Algebra/CharP/Quotient.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Eric Wieser
 -/
-import Mathlib.Algebra.CharP.Basic
+import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.RingTheory.Ideal.Maps
 import Mathlib.RingTheory.Ideal.Quotient
 
@@ -63,5 +63,5 @@ theorem Ideal.Quotient.index_eq_zero {R : Type*} [CommRing R] (I : Ideal R) :
   split_ifs with hq; swap
   · simp
   letI : Fintype (R ⧸ I) := @Fintype.ofFinite _ hq
-  exact CharP.cast_card_eq_zero (R ⧸ I)
+  exact Nat.cast_card_eq_zero (R ⧸ I)
 #align ideal.quotient.index_eq_zero Ideal.Quotient.index_eq_zero

--- a/Mathlib/Algebra/CharP/Two.lean
+++ b/Mathlib/Algebra/CharP/Two.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.CharP.ExpChar
+import Mathlib.GroupTheory.OrderOfElement
 
 #align_import algebra.char_p.two from "leanprover-community/mathlib"@"7f1ba1a333d66eed531ecb4092493cd1b6715450"
 

--- a/Mathlib/Algebra/Module/Defs.lean
+++ b/Mathlib/Algebra/Module/Defs.lean
@@ -634,13 +634,13 @@ end NoZeroSMulDivisors
 
 -- Porting note (#10618): simp can prove this
 --@[simp]
-theorem Nat.smul_one_eq_cast {R : Type*} [Semiring R] (m : ℕ) : m • (1 : R) = ↑m := by
+theorem Nat.smul_one_eq_cast {R : Type*} [NonAssocSemiring R] (m : ℕ) : m • (1 : R) = ↑m := by
   rw [nsmul_eq_mul, mul_one]
 #align nat.smul_one_eq_coe Nat.smul_one_eq_cast
 
 -- Porting note (#10618): simp can prove this
 --@[simp]
-theorem Int.smul_one_eq_cast {R : Type*} [Ring R] (m : ℤ) : m • (1 : R) = ↑m := by
+theorem Int.smul_one_eq_cast {R : Type*} [NonAssocRing R] (m : ℤ) : m • (1 : R) = ↑m := by
   rw [zsmul_eq_mul, mul_one]
 #align int.smul_one_eq_coe Int.smul_one_eq_cast
 

--- a/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
@@ -3,11 +3,9 @@ Copyright (c) 2020 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import Mathlib.Algebra.BigOperators.Group.Finset
-import Mathlib.Algebra.Order.Ring.Abs
+import Mathlib.Algebra.BigOperators.Ring
 import Mathlib.Combinatorics.SimpleGraph.Dart
 import Mathlib.Combinatorics.SimpleGraph.Finite
-import Mathlib.Data.Finset.Sym
 import Mathlib.Data.ZMod.Parity
 
 #align_import combinatorics.simple_graph.degree_sum from "leanprover-community/mathlib"@"90659cbe25e59ec302e2fb92b00e9732160cc620"

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -58,7 +58,7 @@ variable [AddGroupWithOne α]
 @[simp] lemma coe_castAddHom : ⇑(castAddHom α) = fun x : ℤ => (x : α) := rfl
 #align int.coe_cast_add_hom Int.coe_castAddHom
 
-lemma Even.intCast {n : ℤ} (h : Even n) : Even (n : α) := h.map (castAddHom α)
+lemma _root_.Even.intCast {n : ℤ} (h : Even n) : Even (n : α) := h.map (castAddHom α)
 
 variable [CharZero α] {m n : ℤ}
 
@@ -119,11 +119,6 @@ lemma cast_comm (n : ℤ) (x : α) : n * x = x * n := (cast_commute ..).eq
 lemma commute_cast (a : α) (n : ℤ) : Commute a n := (cast_commute ..).symm
 #align int.commute_cast Int.commute_cast
 
-end NonAssocRing
-
-section Ring
-variable [Ring α]
-
 @[simp] lemma _root_.zsmul_eq_mul (a : α) : ∀ n : ℤ, n • a = n * a
   | (n : ℕ) => by rw [natCast_zsmul, nsmul_eq_mul, Int.cast_natCast]
   | -[n+1] => by simp [Nat.cast_succ, neg_add_rev, Int.cast_negSucc, add_mul]
@@ -133,8 +128,12 @@ lemma _root_.zsmul_eq_mul' (a : α) (n : ℤ) : n • a = a * n := by
   rw [zsmul_eq_mul, (n.cast_commute a).eq]
 #align zsmul_eq_mul' zsmul_eq_mul'
 
-lemma _root_.Odd.intCast {n : ℤ} (hn : Odd n) : Odd (n : α) :=
-  hn.map (castRingHom α)
+end NonAssocRing
+
+section Ring
+variable [Ring α] {n : ℤ}
+
+lemma _root_.Odd.intCast (hn : Odd n) : Odd (n : α) := hn.map (castRingHom α)
 
 end Ring
 

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import Mathlib.Algebra.CharP.Basic
 import Mathlib.Algebra.Ring.Prod
+import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.Tactic.FinCases
 
 #align_import data.zmod.basic from "leanprover-community/mathlib"@"74ad1c88c77e799d2fea62801d1dbbd698cff1b7"

--- a/Mathlib/Data/ZMod/Factorial.lean
+++ b/Mathlib/Data/ZMod/Factorial.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Moritz Firsching. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Moritz Firsching
 -/
+import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Data.Nat.Factorial.BigOperators
 import Mathlib.Data.ZMod.Basic
 

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -366,7 +366,7 @@ theorem roots_X_pow_card_sub_X : roots (X ^ q - X : K[X]) = Finset.univ.val := b
     apply nodup_roots
     rw [separable_def]
     convert isCoprime_one_right.neg_right (R := K[X]) using 1
-    rw [derivative_sub, derivative_X, derivative_X_pow, CharP.cast_card_eq_zero K, C_0,
+    rw [derivative_sub, derivative_X, derivative_X_pow, Nat.cast_card_eq_zero K, C_0,
       zero_mul, zero_sub]
 set_option linter.uppercaseLean3 false in
 #align finite_field.roots_X_pow_card_sub_X FiniteField.roots_X_pow_card_sub_X

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Julian Kuelshammer
 -/
+import Mathlib.Algebra.CharP.Defs
 import Mathlib.Algebra.GroupPower.IterateHom
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Data.Int.ModEq
@@ -1305,3 +1306,41 @@ theorem IsOfFinOrder.prod_mk : IsOfFinOrder a → IsOfFinOrder b → IsOfFinOrde
 end Prod
 
 -- TODO: Corresponding `pi` lemmas. We cannot currently state them here because of import cycles
+
+@[simp]
+lemma Nat.cast_card_eq_zero (R) [AddGroupWithOne R] [Fintype R] : (Fintype.card R : R) = 0 := by
+  rw [← nsmul_one, card_nsmul_eq_zero]
+#align char_p.cast_card_eq_zero Nat.cast_card_eq_zero
+
+section NonAssocRing
+variable (R : Type*) [NonAssocRing R] [Fintype R] (p : ℕ)
+
+lemma CharP.addOrderOf_one : CharP R (addOrderOf (1 : R)) where
+  cast_eq_zero_iff' n := by rw [← Nat.smul_one_eq_cast, addOrderOf_dvd_iff_nsmul_eq_zero]
+#align char_p.add_order_of_one CharP.addOrderOf_one
+
+variable {R} in
+lemma charP_of_ne_zero (hn : card R = p) (hR : ∀ i < p, (i : R) = 0 → i = 0) : CharP R p where
+  cast_eq_zero_iff' n := by
+    have H : (p : R) = 0 := by rw [← hn, Nat.cast_card_eq_zero]
+    constructor
+    · intro h
+      rw [← Nat.mod_add_div n p, Nat.cast_add, Nat.cast_mul, H, zero_mul, add_zero] at h
+      rw [Nat.dvd_iff_mod_eq_zero]
+      apply hR _ (Nat.mod_lt _ _) h
+      rw [← hn, gt_iff_lt, Fintype.card_pos_iff]
+      exact ⟨0⟩
+    · rintro ⟨n, rfl⟩
+      rw [Nat.cast_mul, H, zero_mul]
+#align char_p_of_ne_zero charP_of_ne_zero
+
+end NonAssocRing
+
+lemma charP_of_prime_pow_injective (R) [Ring R] [Fintype R] (p n : ℕ) [hp : Fact p.Prime]
+    (hn : card R = p ^ n) (hR : ∀ i ≤ n, (p : R) ^ i = 0 → i = n) : CharP R (p ^ n) := by
+  obtain ⟨c, hc⟩ := CharP.exists R
+  have hcpn : c ∣ p ^ n := by rw [← CharP.cast_eq_zero_iff R c, ← hn, Nat.cast_card_eq_zero]
+  obtain ⟨i, hi, rfl⟩ : ∃ i ≤ n, c = p ^ i := by rwa [Nat.dvd_prime_pow hp.1] at hcpn
+  obtain rfl : i = n := hR i hi $ by rw [← Nat.cast_pow, CharP.cast_eq_zero]
+  assumption
+#align char_p_of_prime_pow_injective charP_of_prime_pow_injective

--- a/Mathlib/NumberTheory/Harmonic/Int.lean
+++ b/Mathlib/NumberTheory/Harmonic/Int.lean
@@ -3,8 +3,6 @@ Copyright (c) 2023 Koundinya Vajjha. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Koundinya Vajjha, Thomas Browning
 -/
-
-import Mathlib.Algebra.CharP.Basic
 import Mathlib.NumberTheory.Harmonic.Defs
 import Mathlib.NumberTheory.Padics.PadicNumbers
 

--- a/Mathlib/NumberTheory/MulChar/Basic.lean
+++ b/Mathlib/NumberTheory/MulChar/Basic.lean
@@ -5,6 +5,7 @@ Authors: Michael Stoll
 -/
 import Mathlib.Algebra.CharP.Basic
 import Mathlib.Data.Fintype.Units
+import Mathlib.GroupTheory.OrderOfElement
 
 #align_import number_theory.legendre_symbol.mul_character from "leanprover-community/mathlib"@"f0c8bf9245297a541f468be517f1bde6195105e9"
 


### PR DESCRIPTION
By swapping the order of imports between `Algebra.CharP.Basic` and `GroupTheory.OrderOfElement`, the first one goes from 944 dependencies to 812, and the second one from 912 to 915.

Also generalise a few lemmas from semirings to non-associative semirings.

This swap is justified by the fact that `CharP` is a purely algebraic concept while `OrderOf` is group-theoretic. Nevertheless,  `GroupTheory.OrderOfElement` should be split in a future PR, in which case the `CharP` lemmas might move back.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
