### PR TITLE
[Merged by Bors] - chore: Fix `Decidable` instance for `LT` on `Rat`

### DIFF
--- a/Mathlib/Data/Rat/Order.lean
+++ b/Mathlib/Data/Rat/Order.lean
@@ -172,7 +172,8 @@ instance linearOrder : LinearOrder ℚ where
     have := eq_neg_of_add_eq_zero_left (Rat.nonneg_antisymm hba hab)
     rwa [neg_neg] at this
   le_total _ _ := Rat.le_total
-  decidableLE _ _ := by infer_instance
+  decidableLE := inferInstance
+  decidableLT := inferInstance
   lt_iff_le_not_le _ _ := by rw [← Rat.not_le, and_iff_right_of_imp Rat.le_total.resolve_left]
 #align rat.le_refl le_refl
 #align rat.le_antisymm le_antisymm

--- a/Mathlib/Data/Rat/Order.lean
+++ b/Mathlib/Data/Rat/Order.lean
@@ -172,6 +172,7 @@ instance linearOrder : LinearOrder ℚ where
     have := eq_neg_of_add_eq_zero_left (Rat.nonneg_antisymm hba hab)
     rwa [neg_neg] at this
   le_total _ _ := Rat.le_total
+  decidableEq := inferInstance
   decidableLE := inferInstance
   decidableLT := inferInstance
   lt_iff_le_not_le _ _ := by rw [← Rat.not_le, and_iff_right_of_imp Rat.le_total.resolve_left]


### PR DESCRIPTION
The default instance was conflicting with the existing one. Same for `DecidableEq`.

Reported on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Conflicting.20decidableLT.20instances).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
