### PR TITLE
[Merged by Bors] - chore: remove unnecessary imports

### DIFF
--- a/Mathlib/Algebra/Order/Field/Subfield.lean
+++ b/Mathlib/Algebra/Order/Field/Subfield.lean
@@ -6,7 +6,6 @@ Authors: Damiano Testa
 
 import Mathlib.Algebra.Order.Field.InjSurj
 import Mathlib.Algebra.Field.Subfield
-import Mathlib.Algebra.Ring.Subring.Order
 
 /-!
 # Ordered instances on subfields

--- a/Mathlib/Algebra/Ring/Subring/Order.lean
+++ b/Mathlib/Algebra/Ring/Subring/Order.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 import Mathlib.Algebra.Ring.Subring.Basic
-import Mathlib.Algebra.Ring.Subsemiring.Order
 import Mathlib.Algebra.Order.Hom.Ring
 
 /-!


### PR DESCRIPTION
This removes an import each from two files, as suggested by `shake` in [#12778](https://github.com/leanprover-community/mathlib4/pull/12778).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
