### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Galois): prorepresentability of fiber functors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1280,6 +1280,7 @@ import Mathlib.CategoryTheory.Galois.Basic
 import Mathlib.CategoryTheory.Galois.Decomposition
 import Mathlib.CategoryTheory.Galois.Examples
 import Mathlib.CategoryTheory.Galois.GaloisObjects
+import Mathlib.CategoryTheory.Galois.Prorepresentability
 import Mathlib.CategoryTheory.Generator
 import Mathlib.CategoryTheory.GlueData
 import Mathlib.CategoryTheory.GradedObject

--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -195,27 +195,45 @@ instance nonempty_fiber_of_isConnected (X : C) [IsConnected X] : Nonempty (F.obj
 /-- The fiber of the equalizer of `f g : X ⟶ Y` is equivalent to the set of agreement of `f`
 and `g`. -/
 noncomputable def fiberEqualizerEquiv {X Y : C} (f g : X ⟶ Y) :
-    F.obj (equalizer f g) ≃ { x : F.obj X // F.map f x = F.map g x } := by
-  apply Iso.toEquiv
-  apply Iso.trans
-  · exact PreservesEqualizer.iso (F ⋙ FintypeCat.incl) f g
-  · exact Types.equalizerIso (F.map f) (F.map g)
+    F.obj (equalizer f g) ≃ { x : F.obj X // F.map f x = F.map g x } :=
+  (PreservesEqualizer.iso (F ⋙ FintypeCat.incl) f g ≪≫
+  Types.equalizerIso (F.map f) (F.map g)).toEquiv
+
+@[simp]
+lemma fiberEqualizerEquiv_symm_ι_apply {X Y : C} {f g : X ⟶ Y} (x : F.obj X)
+    (h : F.map f x = F.map g x) :
+    F.map (equalizer.ι f g) ((fiberEqualizerEquiv F f g).symm ⟨x, h⟩) = x := by
+  simp [fiberEqualizerEquiv]
+  change ((Types.equalizerIso _ _).inv ≫ _ ≫ (F ⋙ FintypeCat.incl).map (equalizer.ι f g)) _ = _
+  erw [PreservesEqualizer.iso_inv_ι, Types.equalizerIso_inv_comp_ι]
 
 /-- The fiber of the pullback is the fiber product of the fibers. -/
 noncomputable def fiberPullbackEquiv {X A B : C} (f : A ⟶ X) (g : B ⟶ X) :
-    F.obj (pullback f g) ≃ { p : F.obj A × F.obj B // F.map f p.1 = F.map g p.2 } := by
-  apply Iso.toEquiv
-  apply Iso.trans
-  · exact PreservesPullback.iso (F ⋙ FintypeCat.incl) f g
-  · exact Types.pullbackIsoPullback (F.map f) (F.map g)
+    F.obj (pullback f g) ≃ { p : F.obj A × F.obj B // F.map f p.1 = F.map g p.2 } :=
+  (PreservesPullback.iso (F ⋙ FintypeCat.incl) f g ≪≫
+  Types.pullbackIsoPullback (F.map f) (F.map g)).toEquiv
+
+@[simp]
+lemma fiberPullbackEquiv_symm_fst_apply {X A B : C} {f : A ⟶ X} {g : B ⟶ X}
+    (a : F.obj A) (b : F.obj B) (h : F.map f a = F.map g b) :
+    F.map pullback.fst ((fiberPullbackEquiv F f g).symm ⟨(a, b), h⟩) = a := by
+  simp [fiberPullbackEquiv]
+  change ((Types.pullbackIsoPullback _ _).inv ≫ _ ≫ (F ⋙ FintypeCat.incl).map pullback.fst) _ = _
+  erw [PreservesPullback.iso_inv_fst, Types.pullbackIsoPullback_inv_fst]
+
+@[simp]
+lemma fiberPullbackEquiv_symm_snd_apply {X A B : C} {f : A ⟶ X} {g : B ⟶ X}
+    (a : F.obj A) (b : F.obj B) (h : F.map f a = F.map g b) :
+    F.map pullback.snd ((fiberPullbackEquiv F f g).symm ⟨(a, b), h⟩) = b := by
+  simp [fiberPullbackEquiv]
+  change ((Types.pullbackIsoPullback _ _).inv ≫ _ ≫ (F ⋙ FintypeCat.incl).map pullback.snd) _ = _
+  erw [PreservesPullback.iso_inv_snd, Types.pullbackIsoPullback_inv_snd]
 
 /-- The fiber of the binary product is the binary product of the fibers. -/
 noncomputable def fiberBinaryProductEquiv (X Y : C) :
-    F.obj (X ⨯ Y) ≃ F.obj X × F.obj Y := by
-  apply Iso.toEquiv
-  apply Iso.trans
-  · exact PreservesLimitPair.iso (F ⋙ FintypeCat.incl) X Y
-  · exact Types.binaryProductIso (F.obj X) (F.obj Y)
+    F.obj (X ⨯ Y) ≃ F.obj X × F.obj Y :=
+  (PreservesLimitPair.iso (F ⋙ FintypeCat.incl) X Y ≪≫
+  Types.binaryProductIso (F.obj X) (F.obj Y)).toEquiv
 
 @[simp]
 lemma fiberBinaryProductEquiv_symm_fst_apply {X Y : C} (x : F.obj X) (y : F.obj Y) :
@@ -223,7 +241,7 @@ lemma fiberBinaryProductEquiv_symm_fst_apply {X Y : C} (x : F.obj X) (y : F.obj 
   simp only [fiberBinaryProductEquiv, comp_obj, FintypeCat.incl_obj, Iso.toEquiv_comp,
     Equiv.symm_trans_apply, Iso.toEquiv_symm_fun]
   change ((Types.binaryProductIso _ _).inv ≫ _ ≫ (F ⋙ FintypeCat.incl).map prod.fst) _ = _
-  erw [PreservesLimitPair.inv_fst, Types.binaryProductIso_inv_comp_fst]
+  erw [PreservesLimitPair.iso_inv_fst, Types.binaryProductIso_inv_comp_fst]
 
 @[simp]
 lemma fiberBinaryProductEquiv_symm_snd_apply {X Y : C} (x : F.obj X) (y : F.obj Y) :
@@ -231,10 +249,10 @@ lemma fiberBinaryProductEquiv_symm_snd_apply {X Y : C} (x : F.obj X) (y : F.obj 
   simp only [fiberBinaryProductEquiv, comp_obj, FintypeCat.incl_obj, Iso.toEquiv_comp,
     Equiv.symm_trans_apply, Iso.toEquiv_symm_fun]
   change ((Types.binaryProductIso _ _).inv ≫ _ ≫ (F ⋙ FintypeCat.incl).map prod.snd) _ = _
-  erw [PreservesLimitPair.inv_snd, Types.binaryProductIso_inv_comp_snd]
+  erw [PreservesLimitPair.iso_inv_snd, Types.binaryProductIso_inv_comp_snd]
 
 /-- The evaluation map is injective for connected objects. -/
-lemma evaluationInjective_of_isConnected (A X : C) [IsConnected A] (a : F.obj A) :
+lemma evaluation_injective_of_isConnected (A X : C) [IsConnected A] (a : F.obj A) :
     Function.Injective (fun (f : A ⟶ X) ↦ F.map f a) := by
   intro f g (h : F.map f a = F.map g a)
   haveI : IsIso (equalizer.ι f g) := by
@@ -247,19 +265,15 @@ lemma evaluation_aut_injective_of_isConnected (A : C) [IsConnected A] (a : F.obj
     Function.Injective (fun f : Aut A ↦ F.map (f.hom) a) := by
   show Function.Injective ((fun f : A ⟶ A ↦ F.map f a) ∘ (fun f : Aut A ↦ f.hom))
   apply Function.Injective.comp
-  · exact evaluationInjective_of_isConnected F A A a
+  · exact evaluation_injective_of_isConnected F A A a
   · exact @Aut.ext _ _ A
 
 /-- A morphism from an object `X` with non-empty fiber to a connected object `A` is an
 epimorphism. -/
 lemma epi_of_nonempty_of_isConnected {X A : C} [IsConnected A] [h : Nonempty (F.obj X)]
     (f : X ⟶ A) : Epi f := Epi.mk <| fun {Z} u v huv ↦ by
-  obtain ⟨x⟩ := h
-  apply evaluationInjective_of_isConnected F A Z (F.map f x)
-  convert_to F.map (f ≫ u) x = F.map (f ≫ v) x
-  rw [F.map_comp]; rfl
-  rw [F.map_comp]; rfl
-  rw [huv]
+  apply evaluation_injective_of_isConnected F A Z (F.map f (Classical.arbitrary _))
+  simpa using congr_fun (F.congr_map huv) _
 
 /-- An epimorphism induces a surjective map on fibers. -/
 lemma surjective_on_fiber_of_epi {X Y : C} (f : X ⟶ Y) [Epi f] : Function.Surjective (F.map f) :=
@@ -277,7 +291,7 @@ section CardFiber
 open ConcreteCategory
 
 /-- A mono between objects with equally sized fibers is an iso. -/
-lemma isIso_of_mono_of_eqCardFiber {X Y : C} (f : X ⟶ Y) [Mono f]
+lemma isIso_of_mono_of_eq_card_fiber {X Y : C} (f : X ⟶ Y) [Mono f]
     (h : Nat.card (F.obj X) = Nat.card (F.obj Y)) : IsIso f := by
   have : IsIso (F.map f) := by
     apply (ConcreteCategory.isIso_iff_bijective (F.map f)).mpr
@@ -287,11 +301,11 @@ lemma isIso_of_mono_of_eqCardFiber {X Y : C} (f : X ⟶ Y) [Mono f]
   exact isIso_of_reflects_iso f F
 
 /-- Along a mono that is not an iso, the cardinality of the fiber strictly increases. -/
-lemma ltCardFiber_of_mono_of_notIso {X Y : C} (f : X ⟶ Y) [Mono f]
+lemma lt_card_fiber_of_mono_of_notIso {X Y : C} (f : X ⟶ Y) [Mono f]
     (h : ¬ IsIso f) : Nat.card (F.obj X) < Nat.card (F.obj Y) := by
   by_contra hlt
   apply h
-  apply isIso_of_mono_of_eqCardFiber F f
+  apply isIso_of_mono_of_eq_card_fiber F f
   simp only [gt_iff_lt, not_lt] at hlt
   exact Nat.le_antisymm
     (Finite.card_le_of_injective (F.map f) (injective_of_mono_of_preservesPullback (F.map f))) hlt
@@ -305,7 +319,7 @@ lemma non_zero_card_fiber_of_not_initial (X : C) (h : IsInitial X → False) :
   exact Finite.card_eq_zero_iff.mp hzero
 
 /-- The cardinality of the fiber of a coproduct is the sum of the cardinalities of the fibers. -/
-lemma cardFiber_coprod_eq_sum (X Y : C) :
+lemma card_fiber_coprod_eq_sum (X Y : C) :
     Nat.card (F.obj (X ⨿ Y)) = Nat.card (F.obj X) + Nat.card (F.obj Y) := by
   let e : F.obj (X ⨿ Y) ≃ F.obj X ⊕ F.obj Y := Iso.toEquiv
     <| (PreservesColimitPair.iso (F ⋙ FintypeCat.incl) X Y).symm.trans
@@ -314,22 +328,20 @@ lemma cardFiber_coprod_eq_sum (X Y : C) :
   exact Nat.card_eq_of_bijective e.toFun (Equiv.bijective e)
 
 /-- The cardinality of the fiber is preserved under isomorphisms. -/
-lemma cardFiber_eq_of_iso {X Y : C} (i : X ≅ Y) : Nat.card (F.obj X) = Nat.card (F.obj Y) := by
+lemma card_fiber_eq_of_iso {X Y : C} (i : X ≅ Y) : Nat.card (F.obj X) = Nat.card (F.obj Y) := by
   have e : F.obj X ≃ F.obj Y := Iso.toEquiv (mapIso (F ⋙ FintypeCat.incl) i)
   exact Nat.card_eq_of_bijective e (Equiv.bijective e)
 
 /-- The cardinality of morphisms `A ⟶ X` is smaller than the cardinality of
 the fiber of the target if the source is connected. -/
-lemma cardHom_le_cardFiber_of_connected (A X : C) [IsConnected A] :
+lemma card_hom_le_card_fiber_of_connected (A X : C) [IsConnected A] :
     Nat.card (A ⟶ X) ≤ Nat.card (F.obj X) := by
-  have h : Nonempty (F.obj A) := inferInstance
-  obtain ⟨a⟩ := h
   apply Nat.card_le_card_of_injective
-  exact evaluationInjective_of_isConnected _ _ _ a
+  exact evaluation_injective_of_isConnected F A X (Classical.arbitrary _)
 
 /-- If `A` is connected, the cardinality of `Aut A` is smaller than the cardinality of the
 fiber of `A`. -/
-lemma cardAut_le_cardFiber_of_connected (A : C) [IsConnected A] :
+lemma card_aut_le_card_fiber_of_connected (A : C) [IsConnected A] :
     Nat.card (Aut A) ≤ Nat.card (F.obj A) := by
   have h : Nonempty (F.obj A) := inferInstance
   obtain ⟨a⟩ := h
@@ -364,7 +376,7 @@ instance (A X : C) [IsConnected A] : Finite (A ⟶ X) := by
   let F := GaloisCategory.getFiberFunctor C
   obtain ⟨a⟩ := nonempty_fiber_of_isConnected F A
   apply Finite.of_injective (fun f ↦ F.map f a)
-  exact evaluationInjective_of_isConnected F A X a
+  exact evaluation_injective_of_isConnected F A X a
 
 /-- In a `GaloisCategory` the set of automorphism of a connected object is finite. -/
 instance (A : C) [IsConnected A] : Finite (Aut A) := by

--- a/Mathlib/CategoryTheory/Galois/Decomposition.lean
+++ b/Mathlib/CategoryTheory/Galois/Decomposition.lean
@@ -86,11 +86,11 @@ private lemma has_decomp_connected_components_aux (F : C ⥤ FintypeCat.{w}) [Fi
     let t : ColimitCocone (pair Y Z) := { cocone := BinaryCofan.mk v u, isColimit := c }
     have hn1 : Nat.card (F.obj Y) < n := by
       rw [hn]
-      exact ltCardFiber_of_mono_of_notIso F v hvnoiso
+      exact lt_card_fiber_of_mono_of_notIso F v hvnoiso
     have i : X ≅ Y ⨿ Z := (colimit.isoColimitCocone t).symm
     have hnn : Nat.card (F.obj X) = Nat.card (F.obj Y) + Nat.card (F.obj Z) := by
-      rw [cardFiber_eq_of_iso F i]
-      exact cardFiber_coprod_eq_sum F Y Z
+      rw [card_fiber_eq_of_iso F i]
+      exact card_fiber_coprod_eq_sum F Y Z
     have hn2 : Nat.card (F.obj Z) < n := by
       rw [hn, hnn, lt_add_iff_pos_left]
       exact Nat.pos_of_ne_zero (non_zero_card_fiber_of_not_initial F Y hni)
@@ -228,7 +228,7 @@ private noncomputable def fiberPerm (b : F.obj A) : F.obj X ≃ F.obj X := by
   apply Finite.injective_iff_bijective.mp
   intro t s (hs : F.map (selfProdProj u t) b = F.map (selfProdProj u s) b)
   show id t = id s
-  have h' : selfProdProj u t = selfProdProj u s := evaluationInjective_of_isConnected F A X b hs
+  have h' : selfProdProj u t = selfProdProj u s := evaluation_injective_of_isConnected F A X b hs
   rw [← selfProdProj_fiber h s, ← selfProdProj_fiber h t, h']
 
 /-- Twisting `u` by `fiberPerm h b` yields an inclusion of `A` into `selfProd F X`. -/
@@ -278,7 +278,7 @@ lemma exists_galois_representative (X : C) : ∃ (A : C) (a : F.obj A),
     simp only [map_comp, FintypeCat.comp_apply]
     rw [hfi1, ← hfi2]
     exact congr_fun (F.mapIso fi2).hom_inv_id y
-  · refine ⟨evaluationInjective_of_isConnected F A X a, ?_⟩
+  · refine ⟨evaluation_injective_of_isConnected F A X a, ?_⟩
     intro x
     use u ≫ Pi.π _ x
     exact (selfProdProj_fiber h1) x

--- a/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
+++ b/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
@@ -103,6 +103,7 @@ theorem evaluation_aut_bijective_of_isGalois (A : C) [IsGalois A] (a : F.obj A) 
     Function.Bijective (fun f : Aut A ↦ F.map f.hom a) :=
   ⟨evaluation_aut_injective_of_isConnected F A a, evaluation_aut_surjective_of_isGalois F A a⟩
 
+/-- For Galois `A` and a point `a` of the fiber of `A`, the evaluation at `A` as an equivalence. -/
 noncomputable def evaluationEquivOfIsGalois (A : C) [IsGalois A] (a : F.obj A) : Aut A ≃ F.obj A :=
   Equiv.ofBijective _ (evaluation_aut_bijective_of_isGalois F A a)
 

--- a/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
+++ b/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
@@ -95,6 +95,28 @@ instance isPretransitive_of_isGalois (X : C) [IsGalois X] :
   rw [← isGalois_iff_pretransitive]
   infer_instance
 
+theorem evaluation_aut_surjective_of_isGalois (A : C) [IsGalois A] (a : F.obj A) :
+    Function.Surjective (fun f : Aut A ↦ F.map f.hom a) :=
+  MulAction.IsPretransitive.exists_smul_eq a
+
+theorem evaluation_aut_bijective_of_isGalois (A : C) [IsGalois A] (a : F.obj A) :
+    Function.Bijective (fun f : Aut A ↦ F.map f.hom a) :=
+  ⟨evaluation_aut_injective_of_isConnected F A a, evaluation_aut_surjective_of_isGalois F A a⟩
+
+noncomputable def evaluationEquivOfIsGalois (A : C) [IsGalois A] (a : F.obj A) : Aut A ≃ F.obj A :=
+  Equiv.ofBijective _ (evaluation_aut_bijective_of_isGalois F A a)
+
+@[simp]
+lemma evaluationEquivOfIsGalois_apply (A : C) [IsGalois A] (a : F.obj A) (φ : Aut A) :
+    evaluationEquivOfIsGalois F A a φ = F.map φ.hom a :=
+  rfl
+
+@[simp]
+lemma evaluationEquivOfIsGalois_symm_fiber (A : C) [IsGalois A] (a b : F.obj A) :
+    F.map ((evaluationEquivOfIsGalois F A a).symm b).hom a = b := by
+  change (evaluationEquivOfIsGalois F A a) _ = _
+  simp
+
 end PreGaloisCategory
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
+++ b/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
@@ -118,6 +118,83 @@ lemma evaluationEquivOfIsGalois_symm_fiber (A : C) [IsGalois A] (a b : F.obj A) 
   change (evaluationEquivOfIsGalois F A a) _ = _
   simp
 
+section AutMap
+
+/-- For a morphism from a connected object `A` to a Galois object `B` and an automorphism
+of `A`, there exists a unique automorphism of `B` making the canonical diagram commute. -/
+lemma exists_autMap {A B : C} (f : A ⟶ B) [IsConnected A] [IsGalois B] (σ : Aut A) :
+    ∃! (τ : Aut B), f ≫ τ.hom = σ.hom ≫ f := by
+  let F := GaloisCategory.getFiberFunctor C
+  obtain ⟨a⟩ := nonempty_fiber_of_isConnected F A
+  refine ⟨?_, ?_, ?_⟩
+  · exact (evaluationEquivOfIsGalois F B (F.map f a)).symm (F.map (σ.hom ≫ f) a)
+  · apply evaluation_injective_of_isConnected F A B a
+    simp
+  · intro τ hτ
+    apply evaluation_aut_injective_of_isConnected F B (F.map f a)
+    simpa using congr_fun (F.congr_map hτ) a
+
+/-- A morphism from a connected object to a Galois object induces a map on automorphism
+groups. This is a group homomorphism (see `autMapMul`). -/
+noncomputable def autMap {A B : C} [IsConnected A] [IsGalois B] (f : A ⟶ B) (σ : Aut A) :
+    Aut B :=
+  (exists_autMap f σ).choose
+
+@[simp]
+lemma comp_autMap {A B : C} [IsConnected A] [IsGalois B] (f : A ⟶ B) (σ : Aut A) :
+    f ≫ (autMap f σ).hom = σ.hom ≫ f :=
+  (exists_autMap f σ).choose_spec.left
+
+@[simp]
+lemma comp_autMap_apply {A B : C} [IsConnected A] [IsGalois B] (f : A ⟶ B) (σ : Aut A)
+    (a : F.obj A) :
+    F.map (autMap f σ).hom (F.map f a) = F.map f (F.map σ.hom a) := by
+  simpa [-comp_autMap] using congrFun (F.congr_map (comp_autMap f σ)) a
+
+/-- `autMap` is uniquely characterized by making the canonical diagram commute. -/
+lemma autMap_unique {A B : C} [IsConnected A] [IsGalois B] (f : A ⟶ B) (σ : Aut A)
+    (τ : Aut B) (h : f ≫ τ.hom = σ.hom ≫ f) :
+    autMap f σ = τ :=
+  ((exists_autMap f σ).choose_spec.right τ h).symm
+
+@[simp]
+lemma autMap_id {A : C} [IsGalois A] : autMap (𝟙 A) = id :=
+  funext fun σ ↦ autMap_unique (𝟙 A) σ _ (by simp)
+
+@[simp]
+lemma autMap_comp {X Y Z : C} [IsConnected X] [IsGalois Y] [IsGalois Z] (f : X ⟶ Y)
+    (g : Y ⟶ Z) : autMap (f ≫ g) = autMap g ∘ autMap f := by
+  refine funext fun σ ↦ autMap_unique _ σ _ ?_
+  rw [Function.comp_apply, Category.assoc, comp_autMap, ← Category.assoc]
+  simp
+
+/-- `autMap` is surjective, if the source is also Galois. -/
+lemma autMap_surjective_of_isGalois {A B : C} [IsGalois A] [IsGalois B] (f : A ⟶ B) :
+    Function.Surjective (autMap f) := by
+  intro σ
+  let F := GaloisCategory.getFiberFunctor C
+  obtain ⟨a⟩ := nonempty_fiber_of_isConnected F A
+  obtain ⟨a', ha'⟩ := surjective_of_nonempty_fiber_of_isConnected F f (F.map σ.hom (F.map f a))
+  obtain ⟨τ, (hτ : F.map τ.hom a = a')⟩ := MulAction.exists_smul_eq (Aut A) a a'
+  use τ
+  apply evaluation_aut_injective_of_isConnected F B (F.map f a)
+  simp [hτ, ha']
+
+@[simp]
+lemma autMap_apply_mul {A B : C} [IsConnected A] [IsGalois B] (f : A ⟶ B) (σ τ : Aut A) :
+    autMap f (σ * τ) = autMap f σ * autMap f τ := by
+  let F := GaloisCategory.getFiberFunctor C
+  obtain ⟨a⟩ := nonempty_fiber_of_isConnected F A
+  apply evaluation_aut_injective_of_isConnected F (B : C) (F.map f a)
+  simp [Aut.Aut_mul_def]
+
+/-- `MonoidHom` version of `autMap`. -/
+noncomputable def autMapMul {A B : C} [IsConnected A] [IsGalois B] (f : A ⟶ B) :
+     Aut A →* Aut B :=
+  MonoidHom.mk' (autMap f) (autMap_apply_mul f)
+
+end AutMap
+
 end PreGaloisCategory
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
+++ b/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
@@ -135,7 +135,7 @@ lemma exists_autMap {A B : C} (f : A ⟶ B) [IsConnected A] [IsGalois B] (σ : A
     simpa using congr_fun (F.congr_map hτ) a
 
 /-- A morphism from a connected object to a Galois object induces a map on automorphism
-groups. This is a group homomorphism (see `autMapMul`). -/
+groups. This is a group homomorphism (see `autMapHom`). -/
 noncomputable def autMap {A B : C} [IsConnected A] [IsGalois B] (f : A ⟶ B) (σ : Aut A) :
     Aut B :=
   (exists_autMap f σ).choose
@@ -189,7 +189,8 @@ lemma autMap_apply_mul {A B : C} [IsConnected A] [IsGalois B] (f : A ⟶ B) (σ 
   simp [Aut.Aut_mul_def]
 
 /-- `MonoidHom` version of `autMap`. -/
-noncomputable def autMapMul {A B : C} [IsConnected A] [IsGalois B] (f : A ⟶ B) :
+@[simps!]
+noncomputable def autMapHom {A B : C} [IsConnected A] [IsGalois B] (f : A ⟶ B) :
      Aut A →* Aut B :=
   MonoidHom.mk' (autMap f) (autMap_apply_mul f)
 

--- a/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
+++ b/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
@@ -3,10 +3,9 @@ Copyright (c) 2024 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
-import Mathlib.CategoryTheory.CofilteredSystem
+import Mathlib.Algebra.Category.GroupCat.Basic
 import Mathlib.CategoryTheory.Galois.Decomposition
 import Mathlib.CategoryTheory.Limits.FunctorCategory
-import Mathlib.Algebra.Category.GroupCat.Limits
 
 /-!
 # Pro-Representability of fiber functors
@@ -44,8 +43,11 @@ variable (F : C ⥤ FintypeCat.{u₂}) [FiberFunctor F]
 
 /-- A pointed Galois object is a Galois object with a fixed point of its fiber. -/
 structure PointedGaloisObject : Type (max u₁ u₂) where
+  /-- The underlying object of `C`. -/
   obj : C
+  /-- An element of the fiber of `obj`. -/
   pt : F.obj obj
+  /-- `obj` is Galois. -/
   isGalois : IsGalois obj := by infer_instance
 
 namespace PointedGaloisObject
@@ -56,8 +58,12 @@ instance (X : PointedGaloisObject F) : CoeDep (PointedGaloisObject F) X C where
   coe := X.obj
 
 variable {F} in
+/-- The type of homomorphisms between two pointed Galois objects. This is a homomorphism
+of the underlying objects of `C` that maps the distinguished points to each other. -/
 structure Hom (A B : PointedGaloisObject F) where
+  /-- The underlying homomorphism of `C`. -/
   val : A.obj ⟶ B.obj
+  /-- The distinguished point of `A` is mapped to the distinguished point of `B`. -/
   comp : F.map val A.pt = B.pt
 
 /-- The category of pointed Galois objects. -/
@@ -163,6 +169,8 @@ instance : HasColimit ((incl F).op ⋙ coyoneda) where
 
 variable {F}
 
+/-- A morphism of pointed Galois objects induces a map on automorphism groups
+of the underlying objects in `C`. This is a group homomorphism (see `autMapMul`). -/
 noncomputable def autMap {A B : PointedGaloisObject F} (f : A ⟶ B) (σ : Aut A.obj) : Aut B.obj :=
   (evaluationEquivOfIsGalois F B B.pt).symm (F.map (σ.hom ≫ f) A.pt)
 

--- a/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
+++ b/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
@@ -1,0 +1,227 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.CategoryTheory.CofilteredSystem
+import Mathlib.CategoryTheory.Galois.Decomposition
+import Mathlib.CategoryTheory.Limits.FunctorCategory
+import Mathlib.Algebra.Category.GroupCat.Limits
+
+/-!
+# Pro-Representability of fiber functors
+
+We show that any fiber functor is pro-representable, i.e. there exists a pro-object
+`X : I ⥤ C` such that `F` is naturally isomorphic to `X ⋙ coyoneda`.
+
+## Main definitions
+
+- `PointedGaloisObject`: the category of pointed Galois objects
+- `PointedGaloisObject.cocone`: a cocone on `(PointedGaloisObject.incl F).op ≫ coyoneda` with
+  point `F ⋙ FintypeCat.incl`.
+- `autGaloisSystem`: the system of automorphism groups indexed by the pointed Galois objects.
+
+## Main results
+
+- `PointedGaloisObject.isColimit`: the cocone `PointedGaloisObject.cocone` is a colimit cocone.
+
+## References
+
+* [lenstraGSchemes]: H. W. Lenstra. Galois theory for schemes.
+
+-/
+
+universe u₁ u₂ w
+
+namespace CategoryTheory
+
+namespace PreGaloisCategory
+
+open Limits Functor
+
+variable {C : Type u₁} [Category.{u₂} C] [GaloisCategory C]
+variable (F : C ⥤ FintypeCat.{u₂}) [FiberFunctor F]
+
+/-- A pointed Galois object is a Galois object with a fixed point of its fiber. -/
+structure PointedGaloisObject : Type (max u₁ u₂) where
+  obj : C
+  pt : F.obj obj
+  isGalois : IsGalois obj := by infer_instance
+
+namespace PointedGaloisObject
+
+attribute [instance] isGalois
+
+instance (X : PointedGaloisObject F) : CoeDep (PointedGaloisObject F) X C where
+  coe := X.obj
+
+variable {F} in
+structure Hom (A B : PointedGaloisObject F) where
+  val : A.obj ⟶ B.obj
+  comp : F.map val A.pt = B.pt
+
+/-- The category of pointed Galois objects. -/
+instance : Category.{u₂} (PointedGaloisObject F) where
+  Hom A B := Hom A B
+  id A := ⟨𝟙 (A : C), by simp⟩
+  comp {A B C} f g := by
+    refine ⟨f.val ≫ g.val, ?_⟩
+    simp only [F.map_comp, FintypeCat.comp_apply, f.comp, g.comp]
+
+instance {A B : PointedGaloisObject F} : Coe (Hom A B) (A.obj ⟶ B.obj) where
+  coe f := f.val
+
+variable {F}
+
+@[ext]
+lemma Hom.ext {A B : PointedGaloisObject F} {f g : A ⟶ B} (_ : f.val = g.val) : f = g :=
+  match f, g with | ⟨_, _⟩, ⟨_, _⟩ => by congr
+
+@[simp]
+lemma Hom.map_point {A B : PointedGaloisObject F} (f : A ⟶ B) :
+    F.map f A.pt = B.pt :=
+  f.comp
+
+@[simp]
+lemma id_val (A : PointedGaloisObject F) : 𝟙 A = 𝟙 A.obj :=
+  rfl
+
+@[simp]
+lemma comp_val {A B C : PointedGaloisObject F} (f : A ⟶ B) (g : B ⟶ C) :
+    (f ≫ g).val = f.val ≫ g.val :=
+  rfl
+
+variable (F)
+
+/-- The category of pointed Galois objects is cofiltered. -/
+instance : IsCofilteredOrEmpty (PointedGaloisObject F) where
+  cone_objs := fun ⟨A, a, _⟩ ⟨B, b, _⟩ ↦ by
+    obtain ⟨Z, f, z, hgal, hfz⟩ := exists_hom_from_galois_of_fiber F (A ⨯ B)
+      <| (fiberBinaryProductEquiv F A B).symm (a, b)
+    refine ⟨⟨Z, z, hgal⟩, ⟨f ≫ prod.fst, ?_⟩, ⟨f ≫ prod.snd, ?_⟩, trivial⟩
+    · simp only [F.map_comp, hfz, FintypeCat.comp_apply, fiberBinaryProductEquiv_symm_fst_apply]
+    · simp only [F.map_comp, hfz, FintypeCat.comp_apply, fiberBinaryProductEquiv_symm_snd_apply]
+  cone_maps := fun ⟨A, a, _⟩ ⟨B, b, _⟩ ⟨f, hf⟩ ⟨g, hg⟩ ↦ by
+    obtain ⟨Z, h, z, hgal, hhz⟩ := exists_hom_from_galois_of_fiber F A a
+    refine ⟨⟨Z, z, hgal⟩, ⟨h, hhz⟩, Hom.ext ?_⟩
+    apply evaluationInjective_of_isConnected F Z B z
+    show F.map (h ≫ f) z = F.map (h ≫ g) z
+    simp only [map_comp, FintypeCat.comp_apply, hhz, hf, hg]
+
+/-- The canonical functor from pointed Galois objects to `C`. -/
+def incl : PointedGaloisObject F ⥤ C where
+  obj := fun A ↦ A
+  map := fun ⟨f, _⟩ ↦ f
+
+@[simp]
+lemma incl_obj (A : PointedGaloisObject F) : (incl F).obj A = A :=
+  rfl
+
+@[simp]
+lemma incl_map {A B : PointedGaloisObject F} (f : A ⟶ B) : ((incl F).map f) = f.val :=
+  rfl
+
+/-- `F ⋙ FintypeCat.incl` as a cocone over `(can F).op ⋙ coyoneda`.
+This is a colimit cocone (see `PreGaloisCategory.isColimìt`) -/
+def cocone : Cocone ((incl F).op ⋙ coyoneda) where
+  pt := F ⋙ FintypeCat.incl
+  ι := {
+    app := fun ⟨A, a, _⟩ ↦ { app := fun X (f : (A : C) ⟶ X) ↦ F.map f a }
+    naturality := fun ⟨A, a, _⟩ ⟨B, b, _⟩ ⟨f, (hf : F.map f b = a)⟩ ↦ by
+      ext Y (g : (A : C) ⟶ Y)
+      suffices h : F.map g (F.map f b) = F.map g a by
+        simpa
+      rw [hf]
+  }
+
+@[simp]
+lemma cocone_app (A : PointedGaloisObject F) (B : C) (f : (A : C) ⟶ B) :
+    ((cocone F).ι.app ⟨A⟩).app B f = F.map f A.pt :=
+  rfl
+
+/-- `cocone F` is a colimit cocone, i.e. `F` is pro-represented by `incl F`. -/
+noncomputable def isColimit : IsColimit (cocone F) := by
+  refine evaluationJointlyReflectsColimits _ (fun X ↦ ?_)
+  refine Types.FilteredColimit.isColimitOf _ _ ?_ ?_
+  · intro (x : F.obj X)
+    obtain ⟨Y, i, y, h1, _, _⟩ := fiber_in_connected_component F X x
+    obtain ⟨Z, f, z, hgal, hfz⟩ := exists_hom_from_galois_of_fiber F Y y
+    refine ⟨⟨Z, z, hgal⟩, f ≫ i, ?_⟩
+    simp only [mapCocone_ι_app, evaluation_obj_map, cocone_app, map_comp,
+      ← h1, FintypeCat.comp_apply, hfz]
+  · intro ⟨A, a, _⟩ ⟨B, b, _⟩ (u : (A : C) ⟶ X) (v : (B : C) ⟶ X) (h : F.map u a = F.map v b)
+    obtain ⟨⟨Z, z, _⟩, ⟨f, hf⟩, ⟨g, hg⟩, _⟩ :=
+      @IsFilteredOrEmpty.cocone_objs (PointedGaloisObject F)ᵒᵖ _ _
+      ⟨{ obj := A, pt := a}⟩ ⟨{obj := B, pt := b}⟩
+    refine ⟨⟨{ obj := Z, pt := z }⟩, ⟨f, hf⟩, ⟨g, hg⟩, ?_⟩
+    apply evaluationInjective_of_isConnected F Z X z
+    change F.map (f ≫ u) z = F.map (g ≫ v) z
+    rw [map_comp, FintypeCat.comp_apply, hf, map_comp, FintypeCat.comp_apply, hg, h]
+
+instance : HasColimit ((incl F).op ⋙ coyoneda) where
+  exists_colimit := ⟨cocone F, isColimit F⟩
+
+variable {F}
+
+noncomputable def autMap {A B : PointedGaloisObject F} (f : A ⟶ B) (σ : Aut A.obj) : Aut B.obj :=
+  (evaluationEquivOfIsGalois F B B.pt).symm (F.map (σ.hom ≫ f) A.pt)
+
+@[simp]
+lemma autMap_eval {A B : PointedGaloisObject F} (f : A ⟶ B) (σ : Aut A.obj) :
+    F.map (autMap f σ).hom B.pt = F.map f (F.map σ.hom A.pt) := by
+  simp [autMap]
+
+lemma autMap_surjective {A B : PointedGaloisObject F} (f : A ⟶ B) :
+    Function.Surjective (autMap f) := by
+  intro σ
+  obtain ⟨a', ha'⟩ := surjective_of_nonempty_fiber_of_isConnected F f.val (F.map σ.hom B.pt)
+  obtain ⟨τ, (hτ : F.map τ.hom A.pt = a')⟩ := MulAction.exists_smul_eq (Aut A.obj) A.pt a'
+  use τ
+  apply evaluation_aut_injective_of_isConnected F B B.pt
+  simp [hτ, ha']
+
+@[simp]
+lemma comp_autMap {A B : PointedGaloisObject F} (f : A ⟶ B) (σ : Aut A.obj) :
+    f.val ≫ (autMap f σ).hom = σ.hom ≫ f := by
+  apply evaluationInjective_of_isConnected F A B A.pt
+  simp
+
+@[simp]
+lemma comp_autMap_apply {A B : PointedGaloisObject F} (f : A ⟶ B) (σ : Aut A.obj) (a : F.obj A) :
+    F.map (autMap f σ).hom (F.map f.val a) = F.map f.val (F.map σ.hom a) := by
+  simpa [-comp_autMap] using congrFun (congrArg F.map (comp_autMap f σ)) a
+
+@[simp]
+lemma autMap_apply_mul {A B : PointedGaloisObject F} (f : A ⟶ B) (σ τ : Aut A.obj) :
+    autMap f (σ * τ) = autMap f σ * autMap f τ := by
+  apply evaluation_aut_injective_of_isConnected F (B : C) B.pt
+  simp [Aut.Aut_mul_def]
+
+/-- `MonoidHom` version of `autMap`. -/
+noncomputable def autMapMul {A B : PointedGaloisObject F} (f : A ⟶ B) :
+     Aut (A : C) →* Aut (B : C) :=
+  MonoidHom.mk' (autMap f) (autMap_apply_mul f)
+
+end PointedGaloisObject
+
+open PointedGaloisObject
+
+/-- The diagram sending each pointed Galois object to its automorphism group
+as an object of `C`. -/
+noncomputable def autGaloisSystem : PointedGaloisObject F ⥤ GroupCat.{u₂} where
+  obj := fun A ↦ GroupCat.of <| Aut (A : C)
+  map := fun {A B} f ↦ (autMapMul f : Aut (A : C) →* Aut (B : C))
+  map_id := fun A ↦ by
+    ext (σ : Aut (A : C))
+    show autMap (𝟙 A) σ = σ
+    apply evaluation_aut_injective_of_isConnected F A A.pt
+    simp
+  map_comp {A B C} f g := by
+    ext (σ : Aut A.obj)
+    show autMap (f ≫ g) σ = autMap g (autMap f σ)
+    apply evaluation_aut_injective_of_isConnected F C C.pt
+    simp
+
+  end PreGaloisCategory
+
+  end CategoryTheory

--- a/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
+++ b/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
@@ -169,17 +169,15 @@ open PointedGaloisObject
 as an object of `C`. -/
 noncomputable def autGaloisSystem : PointedGaloisObject F ⥤ GroupCat.{u₂} where
   obj := fun A ↦ GroupCat.of <| Aut (A : C)
-  map := fun {A B} f ↦ (autMapMul f : Aut (A : C) →* Aut (B : C))
+  map := fun {A B} f ↦ (autMapHom f : Aut (A : C) →* Aut (B : C))
   map_id := fun A ↦ by
-    ext (σ : Aut (A : C))
-    show autMap (𝟙 A.obj) σ = σ
-    apply evaluation_aut_injective_of_isConnected F A A.pt
+    ext (σ : Aut A.obj)
     simp
+    rfl
   map_comp {A B C} f g := by
     ext (σ : Aut A.obj)
-    show autMap (f ≫ g).val σ = autMap g.val (autMap f.val σ)
-    apply evaluation_aut_injective_of_isConnected F C C.pt
     simp
+    rfl
 
 end PreGaloisCategory
 

--- a/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
+++ b/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
@@ -11,7 +11,7 @@ import Mathlib.CategoryTheory.Limits.FunctorCategory
 # Pro-Representability of fiber functors
 
 We show that any fiber functor is pro-representable, i.e. there exists a pro-object
-`X : I ⥤ C` such that `F` is naturally isomorphic to `X ⋙ coyoneda`.
+`X : I ⥤ C` such that `F` is naturally isomorphic to the colimit of `X ⋙ coyoneda`.
 
 ## Main definitions
 
@@ -60,19 +60,20 @@ instance (X : PointedGaloisObject F) : CoeDep (PointedGaloisObject F) X C where
 variable {F} in
 /-- The type of homomorphisms between two pointed Galois objects. This is a homomorphism
 of the underlying objects of `C` that maps the distinguished points to each other. -/
+@[ext]
 structure Hom (A B : PointedGaloisObject F) where
   /-- The underlying homomorphism of `C`. -/
   val : A.obj ⟶ B.obj
   /-- The distinguished point of `A` is mapped to the distinguished point of `B`. -/
-  comp : F.map val A.pt = B.pt
+  comp : F.map val A.pt = B.pt := by simp
+
+attribute [simp] Hom.comp
 
 /-- The category of pointed Galois objects. -/
 instance : Category.{u₂} (PointedGaloisObject F) where
   Hom A B := Hom A B
-  id A := ⟨𝟙 (A : C), by simp⟩
-  comp {A B C} f g := by
-    refine ⟨f.val ≫ g.val, ?_⟩
-    simp only [F.map_comp, FintypeCat.comp_apply, f.comp, g.comp]
+  id A := { val := 𝟙 (A : C) }
+  comp {A B C} f g := { val := f.val ≫ g.val }
 
 instance {A B : PointedGaloisObject F} : Coe (Hom A B) (A.obj ⟶ B.obj) where
   coe f := f.val
@@ -80,19 +81,14 @@ instance {A B : PointedGaloisObject F} : Coe (Hom A B) (A.obj ⟶ B.obj) where
 variable {F}
 
 @[ext]
-lemma Hom.ext {A B : PointedGaloisObject F} {f g : A ⟶ B} (_ : f.val = g.val) : f = g :=
-  match f, g with | ⟨_, _⟩, ⟨_, _⟩ => by congr
-
-@[simp]
-lemma Hom.map_point {A B : PointedGaloisObject F} (f : A ⟶ B) :
-    F.map f A.pt = B.pt :=
-  f.comp
+lemma hom_ext {A B : PointedGaloisObject F} {f g : A ⟶ B} (h : f.val = g.val) : f = g :=
+  Hom.ext f g h
 
 @[simp]
 lemma id_val (A : PointedGaloisObject F) : 𝟙 A = 𝟙 A.obj :=
   rfl
 
-@[simp]
+@[simp, reassoc]
 lemma comp_val {A B C : PointedGaloisObject F} (f : A ⟶ B) (g : B ⟶ C) :
     (f ≫ g).val = f.val ≫ g.val :=
   rfl
@@ -109,10 +105,9 @@ instance : IsCofilteredOrEmpty (PointedGaloisObject F) where
     · simp only [F.map_comp, hfz, FintypeCat.comp_apply, fiberBinaryProductEquiv_symm_snd_apply]
   cone_maps := fun ⟨A, a, _⟩ ⟨B, b, _⟩ ⟨f, hf⟩ ⟨g, hg⟩ ↦ by
     obtain ⟨Z, h, z, hgal, hhz⟩ := exists_hom_from_galois_of_fiber F A a
-    refine ⟨⟨Z, z, hgal⟩, ⟨h, hhz⟩, Hom.ext ?_⟩
-    apply evaluationInjective_of_isConnected F Z B z
-    show F.map (h ≫ f) z = F.map (h ≫ g) z
-    simp only [map_comp, FintypeCat.comp_apply, hhz, hf, hg]
+    refine ⟨⟨Z, z, hgal⟩, ⟨h, hhz⟩, hom_ext ?_⟩
+    apply evaluation_injective_of_isConnected F Z B z
+    simp [hhz, hf, hg]
 
 /-- The canonical functor from pointed Galois objects to `C`. -/
 def incl : PointedGaloisObject F ⥤ C where
@@ -124,7 +119,7 @@ lemma incl_obj (A : PointedGaloisObject F) : (incl F).obj A = A :=
   rfl
 
 @[simp]
-lemma incl_map {A B : PointedGaloisObject F} (f : A ⟶ B) : ((incl F).map f) = f.val :=
+lemma incl_map {A B : PointedGaloisObject F} (f : A ⟶ B) : (incl F).map f = f.val :=
   rfl
 
 /-- `F ⋙ FintypeCat.incl` as a cocone over `(can F).op ⋙ coyoneda`.
@@ -135,8 +130,7 @@ def cocone : Cocone ((incl F).op ⋙ coyoneda) where
     app := fun ⟨A, a, _⟩ ↦ { app := fun X (f : (A : C) ⟶ X) ↦ F.map f a }
     naturality := fun ⟨A, a, _⟩ ⟨B, b, _⟩ ⟨f, (hf : F.map f b = a)⟩ ↦ by
       ext Y (g : (A : C) ⟶ Y)
-      suffices h : F.map g (F.map f b) = F.map g a by
-        simpa
+      suffices h : F.map g (F.map f b) = F.map g a by simpa
       rw [hf]
   }
 
@@ -157,58 +151,15 @@ noncomputable def isColimit : IsColimit (cocone F) := by
       ← h1, FintypeCat.comp_apply, hfz]
   · intro ⟨A, a, _⟩ ⟨B, b, _⟩ (u : (A : C) ⟶ X) (v : (B : C) ⟶ X) (h : F.map u a = F.map v b)
     obtain ⟨⟨Z, z, _⟩, ⟨f, hf⟩, ⟨g, hg⟩, _⟩ :=
-      @IsFilteredOrEmpty.cocone_objs (PointedGaloisObject F)ᵒᵖ _ _
-      ⟨{ obj := A, pt := a}⟩ ⟨{obj := B, pt := b}⟩
+      IsFilteredOrEmpty.cocone_objs (C := (PointedGaloisObject F)ᵒᵖ)
+        ⟨{ obj := A, pt := a}⟩ ⟨{obj := B, pt := b}⟩
     refine ⟨⟨{ obj := Z, pt := z }⟩, ⟨f, hf⟩, ⟨g, hg⟩, ?_⟩
-    apply evaluationInjective_of_isConnected F Z X z
+    apply evaluation_injective_of_isConnected F Z X z
     change F.map (f ≫ u) z = F.map (g ≫ v) z
     rw [map_comp, FintypeCat.comp_apply, hf, map_comp, FintypeCat.comp_apply, hg, h]
 
 instance : HasColimit ((incl F).op ⋙ coyoneda) where
   exists_colimit := ⟨cocone F, isColimit F⟩
-
-variable {F}
-
-/-- A morphism of pointed Galois objects induces a map on automorphism groups
-of the underlying objects in `C`. This is a group homomorphism (see `autMapMul`). -/
-noncomputable def autMap {A B : PointedGaloisObject F} (f : A ⟶ B) (σ : Aut A.obj) : Aut B.obj :=
-  (evaluationEquivOfIsGalois F B B.pt).symm (F.map (σ.hom ≫ f) A.pt)
-
-@[simp]
-lemma autMap_eval {A B : PointedGaloisObject F} (f : A ⟶ B) (σ : Aut A.obj) :
-    F.map (autMap f σ).hom B.pt = F.map f (F.map σ.hom A.pt) := by
-  simp [autMap]
-
-lemma autMap_surjective {A B : PointedGaloisObject F} (f : A ⟶ B) :
-    Function.Surjective (autMap f) := by
-  intro σ
-  obtain ⟨a', ha'⟩ := surjective_of_nonempty_fiber_of_isConnected F f.val (F.map σ.hom B.pt)
-  obtain ⟨τ, (hτ : F.map τ.hom A.pt = a')⟩ := MulAction.exists_smul_eq (Aut A.obj) A.pt a'
-  use τ
-  apply evaluation_aut_injective_of_isConnected F B B.pt
-  simp [hτ, ha']
-
-@[simp]
-lemma comp_autMap {A B : PointedGaloisObject F} (f : A ⟶ B) (σ : Aut A.obj) :
-    f.val ≫ (autMap f σ).hom = σ.hom ≫ f := by
-  apply evaluationInjective_of_isConnected F A B A.pt
-  simp
-
-@[simp]
-lemma comp_autMap_apply {A B : PointedGaloisObject F} (f : A ⟶ B) (σ : Aut A.obj) (a : F.obj A) :
-    F.map (autMap f σ).hom (F.map f.val a) = F.map f.val (F.map σ.hom a) := by
-  simpa [-comp_autMap] using congrFun (congrArg F.map (comp_autMap f σ)) a
-
-@[simp]
-lemma autMap_apply_mul {A B : PointedGaloisObject F} (f : A ⟶ B) (σ τ : Aut A.obj) :
-    autMap f (σ * τ) = autMap f σ * autMap f τ := by
-  apply evaluation_aut_injective_of_isConnected F (B : C) B.pt
-  simp [Aut.Aut_mul_def]
-
-/-- `MonoidHom` version of `autMap`. -/
-noncomputable def autMapMul {A B : PointedGaloisObject F} (f : A ⟶ B) :
-     Aut (A : C) →* Aut (B : C) :=
-  MonoidHom.mk' (autMap f) (autMap_apply_mul f)
 
 end PointedGaloisObject
 
@@ -221,15 +172,15 @@ noncomputable def autGaloisSystem : PointedGaloisObject F ⥤ GroupCat.{u₂} wh
   map := fun {A B} f ↦ (autMapMul f : Aut (A : C) →* Aut (B : C))
   map_id := fun A ↦ by
     ext (σ : Aut (A : C))
-    show autMap (𝟙 A) σ = σ
+    show autMap (𝟙 A.obj) σ = σ
     apply evaluation_aut_injective_of_isConnected F A A.pt
     simp
   map_comp {A B C} f g := by
     ext (σ : Aut A.obj)
-    show autMap (f ≫ g) σ = autMap g (autMap f σ)
+    show autMap (f ≫ g).val σ = autMap g.val (autMap f.val σ)
     apply evaluation_aut_injective_of_isConnected F C C.pt
     simp
 
-  end PreGaloisCategory
+end PreGaloisCategory
 
-  end CategoryTheory
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/BinaryProducts.lean
@@ -96,6 +96,18 @@ theorem PreservesLimitPair.iso_hom : (PreservesLimitPair.iso G X Y).hom = prodCo
   rfl
 #align category_theory.limits.preserves_limit_pair.iso_hom CategoryTheory.Limits.PreservesLimitPair.iso_hom
 
+@[simp]
+theorem PreservesLimitPair.inv_fst :
+    (PreservesLimitPair.iso G X Y).inv ≫ G.map prod.fst = prod.fst := by
+  rw [← Iso.cancel_iso_hom_left (PreservesLimitPair.iso G X Y), ← Category.assoc, Iso.hom_inv_id]
+  simp
+
+@[simp]
+theorem PreservesLimitPair.inv_snd :
+    (PreservesLimitPair.iso G X Y).inv ≫ G.map prod.snd = prod.snd := by
+  rw [← Iso.cancel_iso_hom_left (PreservesLimitPair.iso G X Y), ← Category.assoc, Iso.hom_inv_id]
+  simp
+
 instance : IsIso (prodComparison G X Y) := by
   rw [← PreservesLimitPair.iso_hom]
   infer_instance

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/BinaryProducts.lean
@@ -97,13 +97,13 @@ theorem PreservesLimitPair.iso_hom : (PreservesLimitPair.iso G X Y).hom = prodCo
 #align category_theory.limits.preserves_limit_pair.iso_hom CategoryTheory.Limits.PreservesLimitPair.iso_hom
 
 @[simp]
-theorem PreservesLimitPair.inv_fst :
+theorem PreservesLimitPair.iso_inv_fst :
     (PreservesLimitPair.iso G X Y).inv ≫ G.map prod.fst = prod.fst := by
   rw [← Iso.cancel_iso_hom_left (PreservesLimitPair.iso G X Y), ← Category.assoc, Iso.hom_inv_id]
   simp
 
 @[simp]
-theorem PreservesLimitPair.inv_snd :
+theorem PreservesLimitPair.iso_inv_snd :
     (PreservesLimitPair.iso G X Y).inv ≫ G.map prod.snd = prod.snd := by
   rw [← Iso.cancel_iso_hom_left (PreservesLimitPair.iso G X Y), ← Category.assoc, Iso.hom_inv_id]
   simp

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Equalizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Equalizers.lean
@@ -100,6 +100,13 @@ theorem PreservesEqualizer.iso_hom :
   rfl
 #align category_theory.limits.preserves_equalizer.iso_hom CategoryTheory.Limits.PreservesEqualizer.iso_hom
 
+@[simp]
+theorem PreservesEqualizer.iso_inv_ι :
+    (PreservesEqualizer.iso G f g).inv ≫ G.map (equalizer.ι f g) =
+      equalizer.ι (G.map f) (G.map g) := by
+  rw [← Iso.cancel_iso_hom_left (PreservesEqualizer.iso G f g), ← Category.assoc, Iso.hom_inv_id]
+  simp
+
 instance : IsIso (equalizerComparison f g G) := by
   rw [← PreservesEqualizer.iso_hom]
   infer_instance


### PR DESCRIPTION
We show that a fiber functor of a Galois category is pro-represented by the system of pointed Galois objects. We also introduce the system of automorphism groups (seen as objects of `C`) of the pointed Galois objects.

This is used in a follow-up PR to establish a group isomorphism between the automorphism group of a fiber functor and the limit of the automorphism groups of the Galois objects.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
