### PR TITLE
[Merged by Bors] - chore: speed up a proof of Baire

### DIFF
--- a/Mathlib/Topology/Baire/LocallyCompactRegular.lean
+++ b/Mathlib/Topology/Baire/LocallyCompactRegular.lean
@@ -38,7 +38,8 @@ instance (priority := 100) BaireSpace.of_t2Space_locallyCompactSpace {X : Type*}
       rw [inter_comm]
       exact (hd n).inter_open_nonempty _ isOpen_interior K.interior_nonempty
     choose K_next hK_next using this
-    refine ⟨Nat.rec K₀ K_next, fun n ↦ ?_, fun n ↦ (hK_next n _).trans (inter_subset_left _ _), hK₀⟩
+    use Nat.rec K₀ K_next
+    refine ⟨fun n ↦ ?_, fun n ↦ (hK_next n _).trans (inter_subset_left _ _), hK₀⟩
     exact subset_closure.trans <| (hK_next _ _).trans <|
       (inter_subset_right _ _).trans interior_subset
   -- Prove that ̀`⋂ n : ℕ, closure (K n)` is inside `U ∩ ⋂ n : ℕ, f n`.

--- a/Mathlib/Topology/Baire/LocallyCompactRegular.lean
+++ b/Mathlib/Topology/Baire/LocallyCompactRegular.lean
@@ -38,6 +38,7 @@ instance (priority := 100) BaireSpace.of_t2Space_locallyCompactSpace {X : Type*}
       rw [inter_comm]
       exact (hd n).inter_open_nonempty _ isOpen_interior K.interior_nonempty
     choose K_next hK_next using this
+    -- The next two lines are faster than a single `refine`.
     use Nat.rec K₀ K_next
     refine ⟨fun n ↦ ?_, fun n ↦ (hK_next n _).trans (inter_subset_left _ _), hK₀⟩
     exact subset_closure.trans <| (hK_next _ _).trans <|


### PR DESCRIPTION
See the [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/trace.2Eprofiler.2Eoutput/near/438027363).

---

It would be nice to understand exactly what happened, but let us not keep this slow proof.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
