### PR TITLE
[Merged by Bors] - feat: add `move-decls`-driven action and shorter PR diff

### DIFF
--- a/.github/workflows/move_decl.yaml
+++ b/.github/workflows/move_decl.yaml
@@ -14,16 +14,16 @@ jobs:
         with:
           ## fetch the whole repository, useful to find a common fork
           fetch-depth: 0
-      - id: message
+      - id: short_diff
         run: |
           ## back and forth to settle a "detached head" (maybe?)
           git checkout -q master
           git checkout -q -
-          printf $'some_output<<EOF\n%s\nEOF' "$(./scripts/no_lost_declarations.sh short)" >> "$GITHUB_OUTPUT"
+          printf $'summary<<EOF\n%s\nEOF' "$(./scripts/no_lost_declarations.sh short)" >> "$GITHUB_OUTPUT"
       - name: Add comment
         run: gh pr comment "$NUMBER" --body "$BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.pull_request.number }}
-          BODY: ${{ steps.message.outputs.some_output }}
+          BODY: ${{ steps.short_diff.outputs.summary }}

--- a/.github/workflows/move_decl.yaml
+++ b/.github/workflows/move_decl.yaml
@@ -1,0 +1,29 @@
+name: Add comment
+on:
+  pull_request:
+    types:
+      - labeled
+jobs:
+  add-comment:
+    if: github.event.label.name == 'move-decls'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ## fetch the whole repository, useful to find a common fork
+          fetch-depth: 0
+      - id: message
+        run: |
+          ## back and forth to settle a "detached head" (maybe?)
+          git checkout -q master
+          git checkout -q -
+          printf $'some_output<<EOF\n%s\nEOF' "$(./scripts/no_lost_declarations.sh short)" >> "$GITHUB_OUTPUT"
+      - name: Add comment
+        run: gh pr comment "$NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          BODY: ${{ steps.message.outputs.some_output }}

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -51,7 +51,7 @@ Running
 ./scripts/no_lost_declarations.sh short <optional_commit>
 ```
 produces a diff of just the declaration names.
-')$
+')
 
 if [ "${short}" == "0" ]
 then

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -3,12 +3,20 @@
 ## we narrow the diff to lines beginning with `theorem`, `lemma` and a few other commands
 begs="(theorem|lemma|inductive|structure|def|class|instance)"
 
+if [ "${1}" == "short" ]
+then
+  short=1
+  shift
+else short=0
+fi
+
 ## if an input commit is given, compute the diff with that, otherwise, use the git-magic `...`
-if [ -n "${1}" ]; then
+full_output=$(if [ -n "${1}" ]; then
   git diff --unified=0 "${1}"
 else
   git diff origin/master...HEAD
 fi |
+  sed 's=@\[[^]]*\] ==' |
   ## extract lines that begin with '[+-]' followed by the input `theorem` or `lemma`
   ## in the `git diff`
   awk -v regex="^[+-]${begs}" 'BEGIN{ paired=0; added=0; removed=0 }
@@ -37,9 +45,31 @@ printf $'\n---\n\nYou can run this locally using
 ```bash
 ./scripts/no_lost_declarations.sh <optional_commit>
 ```
-'
+
+Running
+```bash
+./scripts/no_lost_declarations.sh short <optional_commit>
+```
+produces a diff of just the declaration names.
+')$
+
+if [ "${short}" == "0" ]
+then
+  echo "${full_output}"
+else
+  echo "${full_output}" |
+  awk '{ acc[$7]=acc[$7] $4 } END{
+    for(d in acc) {
+      if ((acc[d] == "`+``-`") || (acc[d] == "`-``+`")) {
+        printf "" } else { printf("%s %s\n", acc[d], d)
+      }
+    }
+  }' |
+  sort | uniq -c | grep -v "^ *2 " |
+  grep '\(`+`\|`-`\)' | sed 's=^ *1 =* ='
+fi
 
  : <<ReferenceTest
-theorem hello
-inductives counted even if it is inductives, rather than inductive
+theorem oh hello
+inductive counts even if it is not lean code
 ReferenceTest


### PR DESCRIPTION
Adding the label `move-decls` triggers an action that comments on the PR a guess of which declarations have been added/removed in the current PR.

The expectation is that for a PR that just moves declarations around, the `move-decls`-reported diff will be (ideally) empty.  In practice, since the script is text-based, this may not be the case, but it should still help focus the effort of the reviewers.

As an example, you can see what the script would report for the current PR that fakes a modification of two declarations.

Finally, you can run this locally using
```bash
./scripts/no_lost_declarations.sh short
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
