### PR TITLE
[Merged by Bors] - chore: Separate algebraic multiset lemmas

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -32,15 +32,15 @@ import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.BigOperators.Finprod
 import Mathlib.Algebra.BigOperators.Finsupp
 import Mathlib.Algebra.BigOperators.Group.List
+import Mathlib.Algebra.BigOperators.Group.Multiset
 import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Algebra.BigOperators.Module
-import Mathlib.Algebra.BigOperators.Multiset.Basic
-import Mathlib.Algebra.BigOperators.Multiset.Lemmas
 import Mathlib.Algebra.BigOperators.NatAntidiagonal
 import Mathlib.Algebra.BigOperators.Option
 import Mathlib.Algebra.BigOperators.Pi
 import Mathlib.Algebra.BigOperators.Ring
 import Mathlib.Algebra.BigOperators.Ring.List
+import Mathlib.Algebra.BigOperators.Ring.Multiset
 import Mathlib.Algebra.BigOperators.RingEquiv
 import Mathlib.Algebra.BigOperators.WithTop
 import Mathlib.Algebra.Bounds

--- a/Mathlib/Algebra/BigOperators/Group/Multiset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Multiset.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Algebra.BigOperators.Group.List
-import Mathlib.Algebra.Divisibility.Basic
-import Mathlib.Algebra.Group.Hom.Basic
-import Mathlib.Algebra.Ring.Defs
+import Mathlib.Algebra.Group.Prod
 import Mathlib.Data.Multiset.Basic
 
 #align_import algebra.big_operators.multiset.basic from "leanprover-community/mathlib"@"6c5f73fd6f6cc83122788a80a27cdd54663609f4"
@@ -22,22 +20,17 @@ and sums indexed by finite sets.
 * `Multiset.prod`: `s.prod f` is the product of `f i` over all `i ∈ s`. Not to be mistaken with
   the cartesian product `Multiset.product`.
 * `Multiset.sum`: `s.sum f` is the sum of `f i` over all `i ∈ s`.
-
-## Implementation notes
-
-Nov 2022: To speed the Lean 4 port, lemmas requiring extra algebra imports
-(`data.list.big_operators.lemmas` rather than `.basic`) have been moved to a separate file,
-`algebra.big_operators.multiset.lemmas`.  This split does not need to be permanent.
 -/
 
+assert_not_exists Ring
 
-variable {ι α β γ : Type*}
+variable {F ι α β γ : Type*}
 
 namespace Multiset
 
 section CommMonoid
 
-variable [CommMonoid α] {s t : Multiset α} {a : α} {m : Multiset ι} {f g : ι → α}
+variable [CommMonoid α] [CommMonoid β] {s t : Multiset α} {a : α} {m : Multiset ι} {f g : ι → α}
 
 /-- Product of a multiset given a commutative monoid structure on `α`.
   `prod {a, b, c} = a * b * c` -/
@@ -250,6 +243,28 @@ theorem prod_dvd_prod_of_le (h : s ≤ t) : s.prod ∣ t.prod := by
   simp only [prod_add, dvd_mul_right]
 #align multiset.prod_dvd_prod_of_le Multiset.prod_dvd_prod_of_le
 
+@[to_additive]
+lemma _root_.map_multiset_prod [FunLike F α β] [MonoidHomClass F α β] (f : F) (s : Multiset α) :
+    f s.prod = (s.map f).prod := (s.prod_hom f).symm
+#align map_multiset_prod map_multiset_prod
+#align map_multiset_sum map_multiset_sum
+
+@[to_additive]
+protected lemma _root_.MonoidHom.map_multiset_prod (f : α →* β) (s : Multiset α) :
+    f s.prod = (s.map f).prod := (s.prod_hom f).symm
+#align monoid_hom.map_multiset_prod MonoidHom.map_multiset_prod
+#align add_monoid_hom.map_multiset_sum AddMonoidHom.map_multiset_sum
+
+lemma dvd_prod : a ∈ s → a ∣ s.prod :=
+  Quotient.inductionOn s (fun l a h ↦ by simpa using List.dvd_prod h) a
+#align multiset.dvd_prod Multiset.dvd_prod
+
+@[to_additive] lemma fst_prod (s : Multiset (α × β)) : s.prod.1 = (s.map Prod.fst).prod :=
+  map_multiset_prod (MonoidHom.fst _ _) _
+
+@[to_additive] lemma snd_prod (s : Multiset (α × β)) : s.prod.2 = (s.map Prod.snd).prod :=
+  map_multiset_prod (MonoidHom.snd _ _) _
+
 end CommMonoid
 
 theorem prod_dvd_prod_of_dvd [CommMonoid β] {S : Multiset α} (g1 g2 : α → β)
@@ -311,20 +326,6 @@ theorem prod_map_zpow {n : ℤ} : (m.map fun i => f i ^ n).prod = (m.map f).prod
 
 end DivisionCommMonoid
 
-section NonUnitalNonAssocSemiring
-
-variable [NonUnitalNonAssocSemiring α] {a : α} {s : Multiset ι} {f : ι → α}
-
-theorem sum_map_mul_left : sum (s.map fun i => a * f i) = a * sum (s.map f) :=
-  Multiset.induction_on s (by simp) fun i s ih => by simp [ih, mul_add]
-#align multiset.sum_map_mul_left Multiset.sum_map_mul_left
-
-theorem sum_map_mul_right : sum (s.map fun i => f i * a) = sum (s.map f) * a :=
-  Multiset.induction_on s (by simp) fun a s ih => by simp [ih, add_mul]
-#align multiset.sum_map_mul_right Multiset.sum_map_mul_right
-
-end NonUnitalNonAssocSemiring
-
 @[simp]
 theorem sum_map_singleton (s : Multiset α) : (s.map fun a => ({a} : Multiset α)).sum = s :=
   Multiset.induction_on s (by simp) (by simp)
@@ -347,18 +348,3 @@ theorem prod_int_mod (s : Multiset ℤ) (n : ℤ) : s.prod % n = (s.map (· % n)
 #align multiset.prod_int_mod Multiset.prod_int_mod
 
 end Multiset
-
-@[to_additive]
-theorem map_multiset_prod [CommMonoid α] [CommMonoid β] {F : Type*} [FunLike F α β]
-    [MonoidHomClass F α β] (f : F)
-    (s : Multiset α) : f s.prod = (s.map f).prod :=
-  (s.prod_hom f).symm
-#align map_multiset_prod map_multiset_prod
-#align map_multiset_sum map_multiset_sum
-
-@[to_additive]
-protected theorem MonoidHom.map_multiset_prod [CommMonoid α] [CommMonoid β] (f : α →* β)
-    (s : Multiset α) : f s.prod = (s.map f).prod :=
-  (s.prod_hom f).symm
-#align monoid_hom.map_multiset_prod MonoidHom.map_multiset_prod
-#align add_monoid_hom.map_multiset_sum AddMonoidHom.map_multiset_sum

--- a/Mathlib/Algebra/BigOperators/Group/Multiset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Multiset.lean
@@ -23,6 +23,8 @@ and sums indexed by finite sets.
 -/
 
 assert_not_exists Ring
+-- TODO: After #12974,
+-- assert_not_exists MonoidWithZero
 
 variable {F ι α β γ : Type*}
 

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.BigOperators.Basic
-import Mathlib.Algebra.BigOperators.Multiset.Lemmas
+import Mathlib.Algebra.BigOperators.Ring.Multiset
 import Mathlib.Algebra.Field.Defs
 import Mathlib.Data.Fintype.Powerset
 import Mathlib.Data.Int.Cast.Lemmas

--- a/Mathlib/Algebra/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Multiset.lean
@@ -3,34 +3,25 @@ Copyright (c) 2019 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Bhavik Mehta, Eric Wieser
 -/
-import Mathlib.Algebra.BigOperators.Multiset.Basic
+import Mathlib.Algebra.BigOperators.Group.Multiset
 import Mathlib.Algebra.BigOperators.Ring.List
-import Mathlib.Algebra.Group.Prod
+import Mathlib.Data.Multiset.Antidiagonal
+import Mathlib.Data.Multiset.Sections
 
 #align_import algebra.big_operators.multiset.lemmas from "leanprover-community/mathlib"@"0a0ec35061ed9960bf0e7ffb0335f44447b58977"
 
 /-! # Lemmas about `Multiset.sum` and `Multiset.prod` requiring extra algebra imports -/
 
 
-variable {α β : Type*}
+variable {ι α β : Type*}
 
 namespace Multiset
 section CommMonoid
-variable [CommMonoid α] [CommMonoid β] {s : Multiset α} {a : α}
+variable [CommMonoid α] [HasDistribNeg α]
 
-lemma dvd_prod : a ∈ s → a ∣ s.prod :=
-  Quotient.inductionOn s (fun l a h => by simpa using List.dvd_prod h) a
-#align multiset.dvd_prod Multiset.dvd_prod
-
-@[simp] lemma prod_map_neg [HasDistribNeg α] (s : Multiset α) :
-    (s.map Neg.neg).prod = (-1) ^ card s * s.prod := Quotient.inductionOn s (by simp)
+@[simp] lemma prod_map_neg (s : Multiset α) : (s.map Neg.neg).prod = (-1) ^ card s * s.prod :=
+  Quotient.inductionOn s (by simp)
 #align multiset.prod_map_neg Multiset.prod_map_neg
-
-@[to_additive] lemma fst_prod (s : Multiset (α × β)) : s.prod.1 = (s.map Prod.fst).prod :=
-  map_multiset_prod (MonoidHom.fst _ _) _
-
-@[to_additive] lemma snd_prod (s : Multiset (α × β)) : s.prod.2 = (s.map Prod.snd).prod :=
-  map_multiset_prod (MonoidHom.snd _ _) _
 
 end CommMonoid
 
@@ -52,6 +43,19 @@ lemma prod_ne_zero (h : (0 : α) ∉ s) : s.prod ≠ 0 := mt prod_eq_zero_iff.1 
 
 end CommMonoidWithZero
 
+section NonUnitalNonAssocSemiring
+variable [NonUnitalNonAssocSemiring α] {a : α} {s : Multiset ι} {f : ι → α}
+
+lemma sum_map_mul_left : sum (s.map fun i ↦ a * f i) = a * sum (s.map f) :=
+  Multiset.induction_on s (by simp) fun i s ih => by simp [ih, mul_add]
+#align multiset.sum_map_mul_left Multiset.sum_map_mul_left
+
+lemma sum_map_mul_right : sum (s.map fun i ↦ f i * a) = sum (s.map f) * a :=
+  Multiset.induction_on s (by simp) fun a s ih => by simp [ih, add_mul]
+#align multiset.sum_map_mul_right Multiset.sum_map_mul_right
+
+end NonUnitalNonAssocSemiring
+
 section NonUnitalSemiring
 variable [NonUnitalSemiring α] {s : Multiset α} {a : α}
 
@@ -62,6 +66,28 @@ lemma dvd_sum : (∀ x ∈ s, a ∣ x) → a ∣ s.sum :=
 #align multiset.dvd_sum Multiset.dvd_sum
 
 end NonUnitalSemiring
+
+section CommSemiring
+variable [CommSemiring α]
+
+lemma prod_map_sum {s : Multiset (Multiset α)} :
+    prod (s.map sum) = sum ((Sections s).map prod) :=
+  Multiset.induction_on s (by simp) fun a s ih ↦ by
+    simp [ih, map_bind, sum_map_mul_left, sum_map_mul_right]
+#align multiset.prod_map_sum Multiset.prod_map_sum
+
+lemma prod_map_add {s : Multiset ι} {f g : ι → α} :
+    prod (s.map fun i ↦ f i + g i) =
+      sum ((antidiagonal s).map fun p ↦ (p.1.map f).prod * (p.2.map g).prod) := by
+  refine s.induction_on ?_ fun a s ih ↦ ?_
+  · simp only [map_zero, prod_zero, antidiagonal_zero, map_singleton, mul_one, sum_singleton]
+  · simp only [map_cons, prod_cons, ih, sum_map_mul_left.symm, add_mul, mul_left_comm (f a),
+      mul_left_comm (g a), sum_map_add, antidiagonal_cons, Prod_map, id_eq, map_add, map_map,
+      Function.comp_apply, mul_assoc, sum_add]
+    exact add_comm _ _
+#align multiset.prod_map_add Multiset.prod_map_add
+
+end CommSemiring
 end Multiset
 
 open Multiset

--- a/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
@@ -16,6 +16,10 @@ This file contains the results concerning the interaction of multiset big operat
 groups.
 -/
 
+assert_not_exists Ring
+-- TODO: After #12974,
+-- assert_not_exists MonoidWithZero
+
 variable {ι α β : Type*}
 
 namespace Multiset

--- a/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import Mathlib.Algebra.BigOperators.Multiset.Basic
+import Mathlib.Algebra.BigOperators.Group.Multiset
 import Mathlib.Algebra.Order.BigOperators.Group.List
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Data.List.MinMax

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Ruben Van de Velde. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ruben Van de Velde
 -/
-import Mathlib.Algebra.BigOperators.Multiset.Basic
+import Mathlib.Algebra.BigOperators.Group.Multiset
 import Mathlib.Algebra.Order.BigOperators.Ring.List
 
 /-!

--- a/Mathlib/Combinatorics/Additive/FreimanHom.lean
+++ b/Mathlib/Combinatorics/Additive/FreimanHom.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.BigOperators.Multiset.Basic
+import Mathlib.Algebra.BigOperators.Group.Multiset
 import Mathlib.Data.FunLike.Basic
 import Mathlib.Data.Set.Pointwise.Basic
 

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -26,9 +26,7 @@ This defines the cardinality of a `Finset` and provides induction principles for
 * `Finset.Nonempty.strong_induction`
 -/
 
--- TODO: After #12845,
--- assert_not_exists Ring
--- TODO: After #11855,
+-- TODO: After #12974,
 -- assert_not_exists MonoidWithZero
 -- TODO: After a lot more work,
 -- assert_not_exists OrderedCommMonoid

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -26,6 +26,7 @@ This defines the cardinality of a `Finset` and provides induction principles for
 * `Finset.Nonempty.strong_induction`
 -/
 
+assert_not_exists Ring
 -- TODO: After #12974,
 -- assert_not_exists MonoidWithZero
 -- TODO: After a lot more work,

--- a/Mathlib/Data/Multiset/Antidiagonal.lean
+++ b/Mathlib/Data/Multiset/Antidiagonal.lean
@@ -14,6 +14,8 @@ The antidiagonal of a multiset `s` consists of all pairs `(t₁, t₂)`
 such that `t₁ + t₂ = s`. These pairs are counted with multiplicities.
 -/
 
+assert_not_exists Ring
+
 universe u
 
 namespace Multiset
@@ -102,17 +104,5 @@ theorem card_antidiagonal (s : Multiset α) : card (antidiagonal s) = 2 ^ card s
   have := card_powerset s
   rwa [← antidiagonal_map_fst, card_map] at this
 #align multiset.card_antidiagonal Multiset.card_antidiagonal
-
-theorem prod_map_add [CommSemiring β] {s : Multiset α} {f g : α → β} :
-    prod (s.map fun a ↦ f a + g a) =
-      sum ((antidiagonal s).map fun p ↦ (p.1.map f).prod * (p.2.map g).prod) := by
-  refine' s.induction_on _ _
-  · simp only [map_zero, prod_zero, antidiagonal_zero, map_singleton, mul_one, sum_singleton]
-  · intro a s ih
-    simp only [map_cons, prod_cons, ih, sum_map_mul_left.symm, add_mul, mul_left_comm (f a),
-      mul_left_comm (g a), sum_map_add, antidiagonal_cons, Prod_map, id_eq, map_add, map_map,
-      Function.comp_apply, mul_assoc, sum_add]
-    exact add_comm _ _
-#align multiset.prod_map_add Multiset.prod_map_add
 
 end Multiset

--- a/Mathlib/Data/Multiset/Bind.lean
+++ b/Mathlib/Data/Multiset/Bind.lean
@@ -22,6 +22,10 @@ This file defines a few basic operations on `Multiset`, notably the monadic bind
 * `Multiset.sigma`: Disjoint sum of multisets in a sigma type.
 -/
 
+assert_not_exists Ring
+-- TODO: After #12974,
+-- assert_not_exists MonoidWithZero
+
 universe v
 
 variable {α : Type*} {β : Type v} {γ δ : Type*}

--- a/Mathlib/Data/Multiset/Bind.lean
+++ b/Mathlib/Data/Multiset/Bind.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Algebra.BigOperators.Multiset.Basic
+import Mathlib.Algebra.BigOperators.Group.Multiset
 import Mathlib.GroupTheory.GroupAction.Defs
 import Mathlib.Data.Multiset.Dedup
 

--- a/Mathlib/Data/Multiset/Sections.lean
+++ b/Mathlib/Data/Multiset/Sections.lean
@@ -11,6 +11,7 @@ import Mathlib.Data.Multiset.Bind
 # Sections of a multiset
 -/
 
+assert_not_exists Ring
 
 namespace Multiset
 
@@ -66,12 +67,6 @@ theorem mem_sections {s : Multiset (Multiset α)} :
 theorem card_sections {s : Multiset (Multiset α)} : card (Sections s) = prod (s.map card) :=
   Multiset.induction_on s (by simp) (by simp (config := { contextual := true }))
 #align multiset.card_sections Multiset.card_sections
-
-theorem prod_map_sum [CommSemiring α] {s : Multiset (Multiset α)} :
-    prod (s.map sum) = sum ((Sections s).map prod) :=
-  Multiset.induction_on s (by simp) fun a s ih => by
-    simp [ih, map_bind, sum_map_mul_left, sum_map_mul_right]
-#align multiset.prod_map_sum Multiset.prod_map_sum
 
 end Sections
 

--- a/Mathlib/Data/PNat/Factors.lean
+++ b/Mathlib/Data/PNat/Factors.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Neil Strickland. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Neil Strickland
 -/
-import Mathlib.Algebra.BigOperators.Multiset.Basic
+import Mathlib.Algebra.BigOperators.Group.Multiset
 import Mathlib.Data.PNat.Prime
 import Mathlib.Data.Nat.Factors
 import Mathlib.Data.Multiset.Sort


### PR DESCRIPTION
Resplit `Algebra.BigOperators.Multiset.Basic` and `Algebra.BigOperators.Multiset.Lemmas` into two new files:
* `Algebra.BigOperators.Group.Multiset` for lemmas that require group-like structures (`Monoid`, `Group`, ...)
* `Algebra.BigOperators.Ring.Multiset` for lemmas that require ring-like structures (`MonoidWithZero`, `Ring`, ...)

Add `assert_not_exists Ring` in the former. Once #12974 lands, it will be strenghtenable to `assert_not_exists MonoidWithZero`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #12836

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
