### PR TITLE
[Merged by Bors] - chore: run lean4checker cron on hoskinson

### DIFF
--- a/.github/workflows/lean4checker.yml
+++ b/.github/workflows/lean4checker.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-lean4checker:
-    runs-on: ubuntu-latest
+    runs-on: pr
     steps:
 
       - name: cleanup


### PR DESCRIPTION
The job was being cancelled, possibly because it consumes more memory than allowed on a github runner. This PR moves the job to the Hoskinson machines.