### PR TITLE
[Merged by Bors] - chore(Topology/Algebra/ContinuousAffineMap): change notation

### DIFF
--- a/Mathlib/Analysis/Calculus/AffineMap.lean
+++ b/Mathlib/Analysis/Calculus/AffineMap.lean
@@ -27,7 +27,7 @@ variable [NormedAddCommGroup V] [NormedSpace 𝕜 V]
 variable [NormedAddCommGroup W] [NormedSpace 𝕜 W]
 
 /-- A continuous affine map between normed vector spaces is smooth. -/
-theorem contDiff {n : ℕ∞} (f : V →A[𝕜] W) : ContDiff 𝕜 n f := by
+theorem contDiff {n : ℕ∞} (f : V →ᴬ[𝕜] W) : ContDiff 𝕜 n f := by
   rw [f.decomp]
   apply f.contLinear.contDiff.add
   exact contDiff_const

--- a/Mathlib/Analysis/Convex/KreinMilman.lean
+++ b/Mathlib/Analysis/Convex/KreinMilman.lean
@@ -108,7 +108,7 @@ theorem closure_convexHull_extremePoints (hscomp : IsCompact s) (hAconv : Convex
 
 /-- A continuous affine map is surjective from the extreme points of a compact set to the extreme
 points of the image of that set. This inclusion is in general strict. -/
-lemma surjOn_extremePoints_image (f : E →A[ℝ] F) (hs : IsCompact s) :
+lemma surjOn_extremePoints_image (f : E →ᴬ[ℝ] F) (hs : IsCompact s) :
     SurjOn f (extremePoints ℝ s) (extremePoints ℝ (f '' s)) := by
   rintro w hw
   -- The fiber of `w` is nonempty and compact

--- a/Mathlib/Analysis/NormedSpace/AddTorsorBases.lean
+++ b/Mathlib/Analysis/NormedSpace/AddTorsorBases.lean
@@ -46,7 +46,7 @@ theorem continuous_barycentric_coord (i : ι) : Continuous (b.coord i) :=
 #align continuous_barycentric_coord continuous_barycentric_coord
 
 theorem smooth_barycentric_coord (b : AffineBasis ι 𝕜 E) (i : ι) : ContDiff 𝕜 ⊤ (b.coord i) :=
-  (⟨b.coord i, continuous_barycentric_coord b i⟩ : E →A[𝕜] 𝕜).contDiff
+  (⟨b.coord i, continuous_barycentric_coord b i⟩ : E →ᴬ[𝕜] 𝕜).contDiff
 #align smooth_barycentric_coord smooth_barycentric_coord
 
 end Barycentric

--- a/Mathlib/Analysis/NormedSpace/ContinuousAffineMap.lean
+++ b/Mathlib/Analysis/NormedSpace/ContinuousAffineMap.lean
@@ -16,9 +16,9 @@ This file develops the theory of continuous affine maps between affine spaces mo
 spaces.
 
 In the particular case that the affine spaces are just normed vector spaces `V`, `W`, we define a
-norm on the space of continuous affine maps by defining the norm of `f : V →A[𝕜] W` to be
+norm on the space of continuous affine maps by defining the norm of `f : V →ᴬ[𝕜] W` to be
 `‖f‖ = max ‖f 0‖ ‖f.cont_linear‖`. This is chosen so that we have a linear isometry:
-`(V →A[𝕜] W) ≃ₗᵢ[𝕜] W × (V →L[𝕜] W)`.
+`(V →ᴬ[𝕜] W) ≃ₗᵢ[𝕜] W × (V →L[𝕜] W)`.
 
 The abstract picture is that for an affine space `P` modelled on a vector space `V`, together with
 a vector space `W`, there is an exact sequence of `𝕜`-modules: `0 → C → A → L → 0` where `C`, `A`
@@ -51,46 +51,46 @@ variable [NormedField R] [NormedSpace R V] [NormedSpace R W] [NormedSpace R W₂
 variable [NontriviallyNormedField 𝕜] [NormedSpace 𝕜 V] [NormedSpace 𝕜 W] [NormedSpace 𝕜 W₂]
 
 /-- The linear map underlying a continuous affine map is continuous. -/
-def contLinear (f : P →A[R] Q) : V →L[R] W :=
+def contLinear (f : P →ᴬ[R] Q) : V →L[R] W :=
   { f.linear with
     toFun := f.linear
     cont := by rw [AffineMap.continuous_linear_iff]; exact f.cont }
 #align continuous_affine_map.cont_linear ContinuousAffineMap.contLinear
 
 @[simp]
-theorem coe_contLinear (f : P →A[R] Q) : (f.contLinear : V → W) = f.linear :=
+theorem coe_contLinear (f : P →ᴬ[R] Q) : (f.contLinear : V → W) = f.linear :=
   rfl
 #align continuous_affine_map.coe_cont_linear ContinuousAffineMap.coe_contLinear
 
 @[simp]
-theorem coe_contLinear_eq_linear (f : P →A[R] Q) :
+theorem coe_contLinear_eq_linear (f : P →ᴬ[R] Q) :
     (f.contLinear : V →ₗ[R] W) = (f : P →ᵃ[R] Q).linear := by ext; rfl
 #align continuous_affine_map.coe_cont_linear_eq_linear ContinuousAffineMap.coe_contLinear_eq_linear
 
 @[simp]
 theorem coe_mk_const_linear_eq_linear (f : P →ᵃ[R] Q) (h) :
-    ((⟨f, h⟩ : P →A[R] Q).contLinear : V → W) = f.linear :=
+    ((⟨f, h⟩ : P →ᴬ[R] Q).contLinear : V → W) = f.linear :=
   rfl
 #align continuous_affine_map.coe_mk_const_linear_eq_linear ContinuousAffineMap.coe_mk_const_linear_eq_linear
 
-theorem coe_linear_eq_coe_contLinear (f : P →A[R] Q) :
+theorem coe_linear_eq_coe_contLinear (f : P →ᴬ[R] Q) :
     ((f : P →ᵃ[R] Q).linear : V → W) = (⇑f.contLinear : V → W) :=
   rfl
 #align continuous_affine_map.coe_linear_eq_coe_cont_linear ContinuousAffineMap.coe_linear_eq_coe_contLinear
 
 @[simp]
-theorem comp_contLinear (f : P →A[R] Q) (g : Q →A[R] Q₂) :
+theorem comp_contLinear (f : P →ᴬ[R] Q) (g : Q →ᴬ[R] Q₂) :
     (g.comp f).contLinear = g.contLinear.comp f.contLinear :=
   rfl
 #align continuous_affine_map.comp_cont_linear ContinuousAffineMap.comp_contLinear
 
 @[simp]
-theorem map_vadd (f : P →A[R] Q) (p : P) (v : V) : f (v +ᵥ p) = f.contLinear v +ᵥ f p :=
+theorem map_vadd (f : P →ᴬ[R] Q) (p : P) (v : V) : f (v +ᵥ p) = f.contLinear v +ᵥ f p :=
   f.map_vadd' p v
 #align continuous_affine_map.map_vadd ContinuousAffineMap.map_vadd
 
 @[simp]
-theorem contLinear_map_vsub (f : P →A[R] Q) (p₁ p₂ : P) : f.contLinear (p₁ -ᵥ p₂) = f p₁ -ᵥ f p₂ :=
+theorem contLinear_map_vsub (f : P →ᴬ[R] Q) (p₁ p₂ : P) : f.contLinear (p₁ -ᵥ p₂) = f p₁ -ᵥ f p₂ :=
   f.toAffineMap.linearMap_vsub p₁ p₂
 #align continuous_affine_map.cont_linear_map_vsub ContinuousAffineMap.contLinear_map_vsub
 
@@ -99,7 +99,7 @@ theorem const_contLinear (q : Q) : (const R P q).contLinear = 0 :=
   rfl
 #align continuous_affine_map.const_cont_linear ContinuousAffineMap.const_contLinear
 
-theorem contLinear_eq_zero_iff_exists_const (f : P →A[R] Q) :
+theorem contLinear_eq_zero_iff_exists_const (f : P →ᴬ[R] Q) :
     f.contLinear = 0 ↔ ∃ q, f = const R P q := by
   have h₁ : f.contLinear = 0 ↔ (f : P →ᵃ[R] Q).linear = 0 := by
     refine' ⟨fun h => _, fun h => _⟩ <;> ext
@@ -121,31 +121,31 @@ theorem to_affine_map_contLinear (f : V →L[R] W) : f.toContinuousAffineMap.con
 #align continuous_affine_map.to_affine_map_cont_linear ContinuousAffineMap.to_affine_map_contLinear
 
 @[simp]
-theorem zero_contLinear : (0 : P →A[R] W).contLinear = 0 :=
+theorem zero_contLinear : (0 : P →ᴬ[R] W).contLinear = 0 :=
   rfl
 #align continuous_affine_map.zero_cont_linear ContinuousAffineMap.zero_contLinear
 
 @[simp]
-theorem add_contLinear (f g : P →A[R] W) : (f + g).contLinear = f.contLinear + g.contLinear :=
+theorem add_contLinear (f g : P →ᴬ[R] W) : (f + g).contLinear = f.contLinear + g.contLinear :=
   rfl
 #align continuous_affine_map.add_cont_linear ContinuousAffineMap.add_contLinear
 
 @[simp]
-theorem sub_contLinear (f g : P →A[R] W) : (f - g).contLinear = f.contLinear - g.contLinear :=
+theorem sub_contLinear (f g : P →ᴬ[R] W) : (f - g).contLinear = f.contLinear - g.contLinear :=
   rfl
 #align continuous_affine_map.sub_cont_linear ContinuousAffineMap.sub_contLinear
 
 @[simp]
-theorem neg_contLinear (f : P →A[R] W) : (-f).contLinear = -f.contLinear :=
+theorem neg_contLinear (f : P →ᴬ[R] W) : (-f).contLinear = -f.contLinear :=
   rfl
 #align continuous_affine_map.neg_cont_linear ContinuousAffineMap.neg_contLinear
 
 @[simp]
-theorem smul_contLinear (t : R) (f : P →A[R] W) : (t • f).contLinear = t • f.contLinear :=
+theorem smul_contLinear (t : R) (f : P →ᴬ[R] W) : (t • f).contLinear = t • f.contLinear :=
   rfl
 #align continuous_affine_map.smul_cont_linear ContinuousAffineMap.smul_contLinear
 
-theorem decomp (f : V →A[R] W) : (f : V → W) = f.contLinear + Function.const V (f 0) := by
+theorem decomp (f : V →ᴬ[R] W) : (f : V → W) = f.contLinear + Function.const V (f 0) := by
   rcases f with ⟨f, h⟩
   rw [coe_mk_const_linear_eq_linear, coe_mk, f.decomp, Pi.add_apply, LinearMap.map_zero, zero_add,
     ← Function.const_def]
@@ -153,11 +153,11 @@ theorem decomp (f : V →A[R] W) : (f : V → W) = f.contLinear + Function.const
 
 section NormedSpaceStructure
 
-variable (f : V →A[𝕜] W)
+variable (f : V →ᴬ[𝕜] W)
 
 /-- Note that unlike the operator norm for linear maps, this norm is _not_ submultiplicative:
 we do _not_ necessarily have `‖f.comp g‖ ≤ ‖f‖ * ‖g‖`. See `norm_comp_le` for what we can say. -/
-noncomputable instance hasNorm : Norm (V →A[𝕜] W) :=
+noncomputable instance hasNorm : Norm (V →ᴬ[𝕜] W) :=
   ⟨fun f => max ‖f 0‖ ‖f.contLinear‖⟩
 #align continuous_affine_map.has_norm ContinuousAffineMap.hasNorm
 
@@ -182,7 +182,7 @@ theorem norm_eq (h : f 0 = 0) : ‖f‖ = ‖f.contLinear‖ :=
 
 #align continuous_affine_map.norm_eq ContinuousAffineMap.norm_eq
 
-noncomputable instance : NormedAddCommGroup (V →A[𝕜] W) :=
+noncomputable instance : NormedAddCommGroup (V →ᴬ[𝕜] W) :=
   AddGroupNorm.toNormedAddCommGroup
     { toFun := fun f => max ‖f 0‖ ‖f.contLinear‖
       map_zero' := by simp [(ContinuousAffineMap.zero_apply)]
@@ -206,18 +206,18 @@ noncomputable instance : NormedAddCommGroup (V →A[𝕜] W) :=
           rw [h₂]
           rfl }
 
-instance : NormedSpace 𝕜 (V →A[𝕜] W) where
+instance : NormedSpace 𝕜 (V →ᴬ[𝕜] W) where
   norm_smul_le t f := by
     simp only [SMul.smul, norm_def, smul_contLinear, norm_smul]
     -- Porting note: previously all these rewrites were in the `simp only`,
     -- but now they don't fire.
     -- (in fact, `norm_smul` fires, but only once rather than twice!)
-    have : NormedAddCommGroup (V →A[𝕜] W) := inferInstance -- this is necessary for `norm_smul`
+    have : NormedAddCommGroup (V →ᴬ[𝕜] W) := inferInstance -- this is necessary for `norm_smul`
     rw [coe_smul, Pi.smul_apply, norm_smul, norm_smul _ (f.contLinear),
       ← mul_max_of_nonneg _ _ (norm_nonneg t)]
 
 
-theorem norm_comp_le (g : W₂ →A[𝕜] V) : ‖f.comp g‖ ≤ ‖f‖ * ‖g‖ + ‖f 0‖ := by
+theorem norm_comp_le (g : W₂ →ᴬ[𝕜] V) : ‖f.comp g‖ ≤ ‖f‖ * ‖g‖ + ‖f 0‖ := by
   rw [norm_def, max_le_iff]
   constructor
   · calc
@@ -242,7 +242,7 @@ variable (𝕜 V W)
 /-- The space of affine maps between two normed spaces is linearly isometric to the product of the
 codomain with the space of linear maps, by taking the value of the affine map at `(0 : V)` and the
 linear part. -/
-def toConstProdContinuousLinearMap : (V →A[𝕜] W) ≃ₗᵢ[𝕜] W × (V →L[𝕜] W) where
+def toConstProdContinuousLinearMap : (V →ᴬ[𝕜] W) ≃ₗᵢ[𝕜] W × (V →L[𝕜] W) where
   toFun f := ⟨f 0, f.contLinear⟩
   invFun p := p.2.toContinuousAffineMap + const 𝕜 V p.1
   left_inv f := by
@@ -256,13 +256,13 @@ def toConstProdContinuousLinearMap : (V →A[𝕜] W) ≃ₗᵢ[𝕜] W × (V �
 #align continuous_affine_map.to_const_prod_continuous_linear_map ContinuousAffineMap.toConstProdContinuousLinearMap
 
 @[simp]
-theorem toConstProdContinuousLinearMap_fst (f : V →A[𝕜] W) :
+theorem toConstProdContinuousLinearMap_fst (f : V →ᴬ[𝕜] W) :
     (toConstProdContinuousLinearMap 𝕜 V W f).fst = f 0 :=
   rfl
 #align continuous_affine_map.to_const_prod_continuous_linear_map_fst ContinuousAffineMap.toConstProdContinuousLinearMap_fst
 
 @[simp]
-theorem toConstProdContinuousLinearMap_snd (f : V →A[𝕜] W) :
+theorem toConstProdContinuousLinearMap_snd (f : V →ᴬ[𝕜] W) :
     (toConstProdContinuousLinearMap 𝕜 V W f).snd = f.contLinear :=
   rfl
 #align continuous_affine_map.to_const_prod_continuous_linear_map_snd ContinuousAffineMap.toConstProdContinuousLinearMap_snd

--- a/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
+++ b/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
@@ -26,7 +26,7 @@ topological affine spaces (since we have not defined these yet).
 
 ## Notation:
 
-We introduce the notation `P →A[R] Q` for `ContinuousAffineMap R P Q`. Note that this is parallel
+We introduce the notation `P →ᴬ[R] Q` for `ContinuousAffineMap R P Q`. Note that this is parallel
 to the notation `E →L[R] F` for `ContinuousLinearMap R E F`.
 -/
 
@@ -38,7 +38,7 @@ structure ContinuousAffineMap (R : Type*) {V W : Type*} (P Q : Type*) [Ring R] [
   cont : Continuous toFun
 #align continuous_affine_map ContinuousAffineMap
 
-notation:25 P " →A[" R "] " Q => ContinuousAffineMap R P Q
+notation:25 P " →ᴬ[" R "] " Q => ContinuousAffineMap R P Q
 
 namespace ContinuousAffineMap
 
@@ -46,96 +46,96 @@ variable {R V W P Q : Type*} [Ring R]
 variable [AddCommGroup V] [Module R V] [TopologicalSpace P] [AddTorsor V P]
 variable [AddCommGroup W] [Module R W] [TopologicalSpace Q] [AddTorsor W Q]
 
-instance : Coe (P →A[R] Q) (P →ᵃ[R] Q) :=
+instance : Coe (P →ᴬ[R] Q) (P →ᵃ[R] Q) :=
   ⟨toAffineMap⟩
 
-theorem to_affineMap_injective {f g : P →A[R] Q} (h : (f : P →ᵃ[R] Q) = (g : P →ᵃ[R] Q)) :
+theorem to_affineMap_injective {f g : P →ᴬ[R] Q} (h : (f : P →ᵃ[R] Q) = (g : P →ᵃ[R] Q)) :
     f = g := by
   cases f
   cases g
   congr
 #align continuous_affine_map.to_affine_map_injective ContinuousAffineMap.to_affineMap_injective
 
-instance : FunLike (P →A[R] Q) P Q where
+instance : FunLike (P →ᴬ[R] Q) P Q where
   coe f := f.toAffineMap
   coe_injective' _ _ h := to_affineMap_injective <| DFunLike.coe_injective h
 
-instance : ContinuousMapClass (P →A[R] Q) P Q where
+instance : ContinuousMapClass (P →ᴬ[R] Q) P Q where
   map_continuous := cont
 
-theorem toFun_eq_coe (f : P →A[R] Q) : f.toFun = ⇑f := rfl
+theorem toFun_eq_coe (f : P →ᴬ[R] Q) : f.toFun = ⇑f := rfl
 #align continuous_affine_map.to_fun_eq_coe ContinuousAffineMap.toFun_eq_coe
 
-theorem coe_injective : @Function.Injective (P →A[R] Q) (P → Q) (⇑) :=
+theorem coe_injective : @Function.Injective (P →ᴬ[R] Q) (P → Q) (⇑) :=
   DFunLike.coe_injective
 #align continuous_affine_map.coe_injective ContinuousAffineMap.coe_injective
 
 @[ext]
-theorem ext {f g : P →A[R] Q} (h : ∀ x, f x = g x) : f = g :=
+theorem ext {f g : P →ᴬ[R] Q} (h : ∀ x, f x = g x) : f = g :=
   DFunLike.ext _ _ h
 #align continuous_affine_map.ext ContinuousAffineMap.ext
 
-theorem ext_iff {f g : P →A[R] Q} : f = g ↔ ∀ x, f x = g x :=
+theorem ext_iff {f g : P →ᴬ[R] Q} : f = g ↔ ∀ x, f x = g x :=
   DFunLike.ext_iff
 #align continuous_affine_map.ext_iff ContinuousAffineMap.ext_iff
 
-theorem congr_fun {f g : P →A[R] Q} (h : f = g) (x : P) : f x = g x :=
+theorem congr_fun {f g : P →ᴬ[R] Q} (h : f = g) (x : P) : f x = g x :=
   DFunLike.congr_fun h _
 #align continuous_affine_map.congr_fun ContinuousAffineMap.congr_fun
 
 /-- Forgetting its algebraic properties, a continuous affine map is a continuous map. -/
-def toContinuousMap (f : P →A[R] Q) : C(P, Q) :=
+def toContinuousMap (f : P →ᴬ[R] Q) : C(P, Q) :=
   ⟨f, f.cont⟩
 #align continuous_affine_map.to_continuous_map ContinuousAffineMap.toContinuousMap
 
 -- Porting note: changed to CoeHead due to difficulty with synthesization order
-instance : CoeHead (P →A[R] Q) C(P, Q) :=
+instance : CoeHead (P →ᴬ[R] Q) C(P, Q) :=
   ⟨toContinuousMap⟩
 
 @[simp]
-theorem toContinuousMap_coe (f : P →A[R] Q) : f.toContinuousMap = ↑f := rfl
+theorem toContinuousMap_coe (f : P →ᴬ[R] Q) : f.toContinuousMap = ↑f := rfl
 #align continuous_affine_map.to_continuous_map_coe ContinuousAffineMap.toContinuousMap_coe
 
 @[simp] -- Porting note: removed `norm_cast`
-theorem coe_to_affineMap (f : P →A[R] Q) : ((f : P →ᵃ[R] Q) : P → Q) = f := rfl
+theorem coe_to_affineMap (f : P →ᴬ[R] Q) : ((f : P →ᵃ[R] Q) : P → Q) = f := rfl
 #align continuous_affine_map.coe_to_affine_map ContinuousAffineMap.coe_to_affineMap
 
 -- Porting note: removed `norm_cast` and `simp` since proof is `simp only [ContinuousMap.coe_mk]`
-theorem coe_to_continuousMap (f : P →A[R] Q) : ((f : C(P, Q)) : P → Q) = f := rfl
+theorem coe_to_continuousMap (f : P →ᴬ[R] Q) : ((f : C(P, Q)) : P → Q) = f := rfl
 #align continuous_affine_map.coe_to_continuous_map ContinuousAffineMap.coe_to_continuousMap
 
-theorem to_continuousMap_injective {f g : P →A[R] Q} (h : (f : C(P, Q)) = (g : C(P, Q))) :
+theorem to_continuousMap_injective {f g : P →ᴬ[R] Q} (h : (f : C(P, Q)) = (g : C(P, Q))) :
     f = g := by
   ext a
   exact ContinuousMap.congr_fun h a
 #align continuous_affine_map.to_continuous_map_injective ContinuousAffineMap.to_continuousMap_injective
 
 -- Porting note: removed `norm_cast`
-theorem coe_affineMap_mk (f : P →ᵃ[R] Q) (h) : ((⟨f, h⟩ : P →A[R] Q) : P →ᵃ[R] Q) = f := rfl
+theorem coe_affineMap_mk (f : P →ᵃ[R] Q) (h) : ((⟨f, h⟩ : P →ᴬ[R] Q) : P →ᵃ[R] Q) = f := rfl
 #align continuous_affine_map.coe_affine_map_mk ContinuousAffineMap.coe_affineMap_mk
 
 @[norm_cast]
-theorem coe_continuousMap_mk (f : P →ᵃ[R] Q) (h) : ((⟨f, h⟩ : P →A[R] Q) : C(P, Q)) = ⟨f, h⟩ := rfl
+theorem coe_continuousMap_mk (f : P →ᵃ[R] Q) (h) : ((⟨f, h⟩ : P →ᴬ[R] Q) : C(P, Q)) = ⟨f, h⟩ := rfl
 #align continuous_affine_map.coe_continuous_map_mk ContinuousAffineMap.coe_continuousMap_mk
 
 @[simp]
-theorem coe_mk (f : P →ᵃ[R] Q) (h) : ((⟨f, h⟩ : P →A[R] Q) : P → Q) = f := rfl
+theorem coe_mk (f : P →ᵃ[R] Q) (h) : ((⟨f, h⟩ : P →ᴬ[R] Q) : P → Q) = f := rfl
 #align continuous_affine_map.coe_mk ContinuousAffineMap.coe_mk
 
 @[simp]
-theorem mk_coe (f : P →A[R] Q) (h) : (⟨(f : P →ᵃ[R] Q), h⟩ : P →A[R] Q) = f := by
+theorem mk_coe (f : P →ᴬ[R] Q) (h) : (⟨(f : P →ᵃ[R] Q), h⟩ : P →ᴬ[R] Q) = f := by
   ext
   rfl
 #align continuous_affine_map.mk_coe ContinuousAffineMap.mk_coe
 
 @[continuity]
-protected theorem continuous (f : P →A[R] Q) : Continuous f := f.2
+protected theorem continuous (f : P →ᴬ[R] Q) : Continuous f := f.2
 #align continuous_affine_map.continuous ContinuousAffineMap.continuous
 
 variable (R P)
 
 /-- The constant map is a continuous affine map. -/
-def const (q : Q) : P →A[R] Q :=
+def const (q : Q) : P →ᴬ[R] Q :=
   { AffineMap.const R P q with
     toFun := AffineMap.const R P q
     cont := continuous_const }
@@ -145,23 +145,23 @@ def const (q : Q) : P →A[R] Q :=
 theorem coe_const (q : Q) : (const R P q : P → Q) = Function.const P q := rfl
 #align continuous_affine_map.coe_const ContinuousAffineMap.coe_const
 
-noncomputable instance : Inhabited (P →A[R] Q) :=
+noncomputable instance : Inhabited (P →ᴬ[R] Q) :=
   ⟨const R P <| Nonempty.some (by infer_instance : Nonempty Q)⟩
 
 variable {R P} {W₂ Q₂ : Type*}
 variable [AddCommGroup W₂] [Module R W₂] [TopologicalSpace Q₂] [AddTorsor W₂ Q₂]
 
 /-- The composition of morphisms is a morphism. -/
-def comp (f : Q →A[R] Q₂) (g : P →A[R] Q) : P →A[R] Q₂ :=
+def comp (f : Q →ᴬ[R] Q₂) (g : P →ᴬ[R] Q) : P →ᴬ[R] Q₂ :=
   { (f : Q →ᵃ[R] Q₂).comp (g : P →ᵃ[R] Q) with cont := f.cont.comp g.cont }
 #align continuous_affine_map.comp ContinuousAffineMap.comp
 
 @[simp, norm_cast]
-theorem coe_comp (f : Q →A[R] Q₂) (g : P →A[R] Q) :
+theorem coe_comp (f : Q →ᴬ[R] Q₂) (g : P →ᴬ[R] Q) :
     (f.comp g : P → Q₂) = (f : Q → Q₂) ∘ (g : P → Q) := rfl
 #align continuous_affine_map.coe_comp ContinuousAffineMap.coe_comp
 
-theorem comp_apply (f : Q →A[R] Q₂) (g : P →A[R] Q) (x : P) : f.comp g x = f (g x) := rfl
+theorem comp_apply (f : Q →ᴬ[R] Q₂) (g : P →ᴬ[R] Q) (x : P) : f.comp g x = f (g x) := rfl
 #align continuous_affine_map.comp_apply ContinuousAffineMap.comp_apply
 
 section ModuleValuedMaps
@@ -169,14 +169,14 @@ section ModuleValuedMaps
 variable {S : Type*}
 variable [TopologicalSpace W]
 
-instance : Zero (P →A[R] W) :=
+instance : Zero (P →ᴬ[R] W) :=
   ⟨ContinuousAffineMap.const R P 0⟩
 
 @[norm_cast, simp]
-theorem coe_zero : ((0 : P →A[R] W) : P → W) = 0 := rfl
+theorem coe_zero : ((0 : P →ᴬ[R] W) : P → W) = 0 := rfl
 #align continuous_affine_map.coe_zero ContinuousAffineMap.coe_zero
 
-theorem zero_apply (x : P) : (0 : P →A[R] W) x = 0 := rfl
+theorem zero_apply (x : P) : (0 : P →ᴬ[R] W) x = 0 := rfl
 #align continuous_affine_map.zero_apply ContinuousAffineMap.zero_apply
 
 section MulAction
@@ -184,67 +184,67 @@ section MulAction
 variable [Monoid S] [DistribMulAction S W] [SMulCommClass R S W]
 variable [ContinuousConstSMul S W]
 
-instance : SMul S (P →A[R] W) where
+instance : SMul S (P →ᴬ[R] W) where
   smul t f := { t • (f : P →ᵃ[R] W) with cont := f.continuous.const_smul t }
 
 @[norm_cast, simp]
-theorem coe_smul (t : S) (f : P →A[R] W) : ⇑(t • f) = t • ⇑f := rfl
+theorem coe_smul (t : S) (f : P →ᴬ[R] W) : ⇑(t • f) = t • ⇑f := rfl
 #align continuous_affine_map.coe_smul ContinuousAffineMap.coe_smul
 
-theorem smul_apply (t : S) (f : P →A[R] W) (x : P) : (t • f) x = t • f x := rfl
+theorem smul_apply (t : S) (f : P →ᴬ[R] W) (x : P) : (t • f) x = t • f x := rfl
 #align continuous_affine_map.smul_apply ContinuousAffineMap.smul_apply
 
-instance [DistribMulAction Sᵐᵒᵖ W] [IsCentralScalar S W] : IsCentralScalar S (P →A[R] W) where
+instance [DistribMulAction Sᵐᵒᵖ W] [IsCentralScalar S W] : IsCentralScalar S (P →ᴬ[R] W) where
   op_smul_eq_smul _ _ := ext fun _ ↦ op_smul_eq_smul _ _
 
-instance : MulAction S (P →A[R] W) :=
+instance : MulAction S (P →ᴬ[R] W) :=
   Function.Injective.mulAction _ coe_injective coe_smul
 
 end MulAction
 
 variable [TopologicalAddGroup W]
 
-instance : Add (P →A[R] W) where
+instance : Add (P →ᴬ[R] W) where
   add f g := { (f : P →ᵃ[R] W) + (g : P →ᵃ[R] W) with cont := f.continuous.add g.continuous }
 
 @[norm_cast, simp]
-theorem coe_add (f g : P →A[R] W) : ⇑(f + g) = f + g := rfl
+theorem coe_add (f g : P →ᴬ[R] W) : ⇑(f + g) = f + g := rfl
 #align continuous_affine_map.coe_add ContinuousAffineMap.coe_add
 
-theorem add_apply (f g : P →A[R] W) (x : P) : (f + g) x = f x + g x := rfl
+theorem add_apply (f g : P →ᴬ[R] W) (x : P) : (f + g) x = f x + g x := rfl
 #align continuous_affine_map.add_apply ContinuousAffineMap.add_apply
 
-instance : Sub (P →A[R] W) where
+instance : Sub (P →ᴬ[R] W) where
   sub f g := { (f : P →ᵃ[R] W) - (g : P →ᵃ[R] W) with cont := f.continuous.sub g.continuous }
 
 @[norm_cast, simp]
-theorem coe_sub (f g : P →A[R] W) : ⇑(f - g) = f - g := rfl
+theorem coe_sub (f g : P →ᴬ[R] W) : ⇑(f - g) = f - g := rfl
 #align continuous_affine_map.coe_sub ContinuousAffineMap.coe_sub
 
-theorem sub_apply (f g : P →A[R] W) (x : P) : (f - g) x = f x - g x := rfl
+theorem sub_apply (f g : P →ᴬ[R] W) (x : P) : (f - g) x = f x - g x := rfl
 #align continuous_affine_map.sub_apply ContinuousAffineMap.sub_apply
 
-instance : Neg (P →A[R] W) :=
+instance : Neg (P →ᴬ[R] W) :=
   { neg := fun f => { -(f : P →ᵃ[R] W) with cont := f.continuous.neg } }
 
 @[norm_cast, simp]
-theorem coe_neg (f : P →A[R] W) : ⇑(-f) = -f := rfl
+theorem coe_neg (f : P →ᴬ[R] W) : ⇑(-f) = -f := rfl
 #align continuous_affine_map.coe_neg ContinuousAffineMap.coe_neg
 
-theorem neg_apply (f : P →A[R] W) (x : P) : (-f) x = -f x := rfl
+theorem neg_apply (f : P →ᴬ[R] W) (x : P) : (-f) x = -f x := rfl
 #align continuous_affine_map.neg_apply ContinuousAffineMap.neg_apply
 
-instance : AddCommGroup (P →A[R] W) :=
+instance : AddCommGroup (P →ᴬ[R] W) :=
   coe_injective.addCommGroup _ coe_zero coe_add coe_neg coe_sub (fun _ _ ↦ coe_smul _ _) fun _ _ ↦
     coe_smul _ _
 
 instance [Monoid S] [DistribMulAction S W] [SMulCommClass R S W] [ContinuousConstSMul S W] :
-    DistribMulAction S (P →A[R] W) :=
+    DistribMulAction S (P →ᴬ[R] W) :=
   Function.Injective.distribMulAction ⟨⟨fun f ↦ f.toAffineMap.toFun, rfl⟩, coe_add⟩ coe_injective
     coe_smul
 
 instance [Semiring S] [Module S W] [SMulCommClass R S W] [ContinuousConstSMul S W] :
-    Module S (P →A[R] W) :=
+    Module S (P →ᴬ[R] W) :=
   Function.Injective.module S ⟨⟨fun f ↦ f.toAffineMap.toFun, rfl⟩, coe_add⟩ coe_injective coe_smul
 
 end ModuleValuedMaps
@@ -258,7 +258,7 @@ variable [AddCommGroup V] [Module R V] [TopologicalSpace V]
 variable [AddCommGroup W] [Module R W] [TopologicalSpace W]
 
 /-- A continuous linear map can be regarded as a continuous affine map. -/
-def toContinuousAffineMap (f : V →L[R] W) : V →A[R] W where
+def toContinuousAffineMap (f : V →L[R] W) : V →ᴬ[R] W where
   toFun := f
   linear := f
   map_vadd' := by simp

--- a/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
+++ b/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
@@ -38,6 +38,7 @@ structure ContinuousAffineMap (R : Type*) {V W : Type*} (P Q : Type*) [Ring R] [
   cont : Continuous toFun
 #align continuous_affine_map ContinuousAffineMap
 
+/-- A continuous map of affine spaces. -/
 notation:25 P " →ᴬ[" R "] " Q => ContinuousAffineMap R P Q
 
 namespace ContinuousAffineMap


### PR DESCRIPTION
We change the notation for `ContinuousAffineMap` from [→A](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Algebra/ContinuousAffineMap.html#ContinuousAffineMap) to `→ᴬ`, so that `→A` can be used for `ContinuousAlgHom` (see #12800).

This seems consistent with the Mathlib notations [→ᵃ](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/AffineSpace/AffineMap.html#AffineMap) for `AffineMap`  and [→ₐ](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Algebra/Hom.html#AlgHom) for `AlgHom`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
