### PR TITLE
[Merged by Bors] - fix: remove consecutive backticks

### DIFF
--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -66,7 +66,7 @@ else
     }
   }' |
   sort | uniq -c | grep -v "^ *2 " |
-  grep '\(`+`\|`-`\)' | sed 's=^ *1 =* ='
+  grep '\(`+`\|`-`\)' | sed 's=^ *1 =* =; s=``==g'
 fi
 
  : <<ReferenceTest


### PR DESCRIPTION
Fixes a formatting issue in the output of `move-decls`.

As reported in #12829.

On that PR, the new script reports

***

* `+` Additive.instDecidablePredEven
* `--` [DecidablePred
* `-` even_abs
* `+` isSquare_mabs
* `+` Multiplicative.instDecidablePredIsSquare


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
