### PR TITLE
chore(Algebra/CharP): ensure `CharP.Defs` doesn't depend on `ring`

### DIFF
--- a/Mathlib/Algebra/CharP/Basic.lean
+++ b/Mathlib/Algebra/CharP/Basic.lean
@@ -105,10 +105,6 @@ theorem CharP.intCast_eq_intCast [AddGroupWithOne R] (p : ℕ) [CharP R p] {a b 
   rw [eq_comm, ← sub_eq_zero, ← Int.cast_sub, CharP.intCast_eq_zero_iff R p, Int.modEq_iff_dvd]
 #align char_p.int_cast_eq_int_cast CharP.intCast_eq_intCast
 
-theorem CharP.intCast_eq_intCast_mod [AddGroupWithOne R] (p : ℕ) [CharP R p] {a : ℤ} :
-    (a : R) = a % (p : ℤ) :=
-  (CharP.intCast_eq_intCast R p).mpr (Int.mod_modEq a p).symm
-
 theorem add_pow_char_of_commute [Semiring R] {p : ℕ} [hp : Fact p.Prime] [CharP R p] (x y : R)
     (h : Commute x y) : (x + y) ^ p = x ^ p + y ^ p := by
   let ⟨r, hr⟩ := h.exists_add_pow_prime_eq hp.out

--- a/Mathlib/Algebra/CharP/Basic.lean
+++ b/Mathlib/Algebra/CharP/Basic.lean
@@ -100,6 +100,15 @@ theorem CharP.addOrderOf_one (R) [Semiring R] : CharP R (addOrderOf (1 : R)) :=
   ⟨fun n => by rw [← Nat.smul_one_eq_cast, addOrderOf_dvd_iff_nsmul_eq_zero]⟩
 #align char_p.add_order_of_one CharP.addOrderOf_one
 
+theorem CharP.intCast_eq_intCast [AddGroupWithOne R] (p : ℕ) [CharP R p] {a b : ℤ} :
+    (a : R) = b ↔ a ≡ b [ZMOD p] := by
+  rw [eq_comm, ← sub_eq_zero, ← Int.cast_sub, CharP.intCast_eq_zero_iff R p, Int.modEq_iff_dvd]
+#align char_p.int_cast_eq_int_cast CharP.intCast_eq_intCast
+
+theorem CharP.intCast_eq_intCast_mod [AddGroupWithOne R] (p : ℕ) [CharP R p] {a : ℤ} :
+    (a : R) = a % (p : ℤ) :=
+  (CharP.intCast_eq_intCast R p).mpr (Int.mod_modEq a p).symm
+
 theorem add_pow_char_of_commute [Semiring R] {p : ℕ} [hp : Fact p.Prime] [CharP R p] (x y : R)
     (h : Commute x y) : (x + y) ^ p = x ^ p + y ^ p := by
   let ⟨r, hr⟩ := h.exists_add_pow_prime_eq hp.out

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -119,6 +119,10 @@ lemma charP_to_charZero [CharP R 0] : CharZero R :=
 lemma charP_zero_iff_charZero : CharP R 0 ↔ CharZero R :=
   ⟨fun _ ↦ charP_to_charZero R, fun _ ↦ ofCharZero R⟩
 
+theorem intCast_eq_intCast_mod : (a : R) = a % (p : ℤ) := by
+  rw [← sub_eq_zero, ← Int.cast_sub, CharP.intCast_eq_zero_iff R p]
+  exact Int.dvd_sub_of_emod_eq rfl
+
 end AddGroupWithOne
 
 section NonAssocSemiring

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -4,10 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Joey van Langen, Casper Putz
 -/
 import Mathlib.Algebra.Group.ULift
+import Mathlib.Algebra.Field.Basic
 import Mathlib.Data.Fin.Basic
-import Mathlib.Data.Int.ModEq
 import Mathlib.Data.Nat.Cast.Prod
 import Mathlib.Data.Nat.Prime
+import Mathlib.Data.PNat.Defs
+import Mathlib.Data.ULift
 
 #align_import algebra.char_p.basic from "leanprover-community/mathlib"@"47a1a73351de8dd6c8d3d32b569c8e434b03ca47"
 
@@ -16,6 +18,9 @@ import Mathlib.Data.Nat.Prime
 -/
 
 assert_not_exists Finset
+-- This file will be used in the implementation of the `ring` tactic,
+-- so we assert it has not been imported to avoid circular dependencies.
+assert_not_exists Mathlib.Tactic.Ring.proveEq
 
 variable (R : Type*)
 
@@ -106,13 +111,6 @@ lemma intCast_eq_zero_iff (a : ℤ) : (a : R) = 0 ↔ (p : ℤ) ∣ a := by
   · lift a to ℕ using le_of_lt h with b
     rw [Int.cast_natCast, CharP.cast_eq_zero_iff R p, Int.natCast_dvd_natCast]
 #align char_p.int_cast_eq_zero_iff CharP.intCast_eq_zero_iff
-
-lemma intCast_eq_intCast : (a : R) = b ↔ a ≡ b [ZMOD p] := by
-  rw [eq_comm, ← sub_eq_zero, ← Int.cast_sub, CharP.intCast_eq_zero_iff R p, Int.modEq_iff_dvd]
-#align char_p.int_cast_eq_int_cast CharP.intCast_eq_intCast
-
-lemma intCast_eq_intCast_mod : (a : R) = a % (p : ℤ) :=
-  (CharP.intCast_eq_intCast R p).mpr (Int.mod_modEq a p).symm
 
 lemma charP_to_charZero [CharP R 0] : CharZero R :=
   charZero_of_inj_zero fun n h0 => eq_zero_of_zero_dvd ((cast_eq_zero_iff R 0 n).mp h0)


### PR DESCRIPTION
I opened #10765 quite a few months ago and it didn't get any response :( In the meantime, Yaël correctly identified that the first step of #10765, which is to split off a `CharP.Defs` file with little imports, is a good idea in general, and got #12710 merged. Unfortunately, #12710 is not compatible with #10765, since `CharP.Defs` still transitively depends on the `ring` tactic. This PR fixes that by moving the one lemma that is incompatible to `CharP.Basic`, and changing the proof of another.

I literally put back the declaration of this lemma as they were before #12710. As far as I can tell, this doesn't revert anything.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
