### PR TITLE
[Merged by Bors] - feat: `Algebra.adjoin R s` is `span R {1} ⊔ s.toSubmodule`

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -570,7 +570,7 @@ theorem adjoin_induction₂ {s : Set A} {p : A → A → Prop} {a b : A} (ha : a
 
 /-- The difference with `NonUnitalAlgebra.adjoin_induction` is that this acts on the subtype. -/
 @[elab_as_elim]
-lemma adjoin_induction' {s : Set A} {p : adjoin R s → Prop} (a : adjoin R s)
+lemma adjoin_induction_subtype {s : Set A} {p : adjoin R s → Prop} (a : adjoin R s)
     (mem : ∀ x (h : x ∈ s), p ⟨x, subset_adjoin R h⟩)
     (add : ∀ x y, p x → p y → p (x + y)) (zero : p 0)
     (mul : ∀ x y, p x → p y → p (x * y)) (smul : ∀ (r : R) x, p x → p (r • x)) : p a :=
@@ -585,6 +585,17 @@ lemma adjoin_induction' {s : Set A} {p : adjoin R s → Prop} (a : adjoin R s)
         ⟨mul_mem hx' hy', mul _ _ hx hy⟩
     · exact fun r x hx => Exists.elim hx fun hx' hx =>
         ⟨SMulMemClass.smul_mem r hx', smul r _ hx⟩
+
+/-- A dependent version of `NonUnitalAlgebra.adjoin_induction`. -/
+theorem adjoin_induction' {s : Set A} {p : ∀ x, x ∈ adjoin R s → Prop}
+    (mem : ∀ (x) (h : x ∈ s), p x (subset_adjoin R h))
+    (add : ∀ x hx y hy, p x hx → p y hy → p (x + y) (add_mem ‹_› ‹_›))
+    (zero : p 0 (zero_mem _))
+    (mul : ∀ x hx y hy, p x hx → p y hy → p (x * y) (mul_mem ‹_› ‹_›))
+    (smul : ∀ (r : R) (x hx), p x hx → p (r • x) (SMulMemClass.smul_mem _ ‹_›))
+    {a} (ha : a ∈ adjoin R s) : p a ha :=
+  adjoin_induction_subtype ⟨a, ha⟩ (p := fun x ↦ p x.1 x.2) mem (fun x y ↦ add x.1 x.2 y.1 y.2)
+    zero (fun x y ↦ mul x.1 x.2 y.1 y.2) (fun r x ↦ smul r x.1 x.2)
 
 protected theorem gc : GaloisConnection (adjoin R : Set A → NonUnitalSubalgebra R A) (↑) :=
   fun s S =>
@@ -613,6 +624,29 @@ theorem adjoin_le_iff {S : NonUnitalSubalgebra R A} {s : Set A} : adjoin R s ≤
 theorem adjoin_union (s t : Set A) : adjoin R (s ∪ t) = adjoin R s ⊔ adjoin R t :=
   (NonUnitalAlgebra.gc : GaloisConnection _ ((↑) : NonUnitalSubalgebra R A → Set A)).l_sup
 
+lemma adjoin_eq (s : NonUnitalSubalgebra R A) : adjoin R (s : Set A) = s :=
+  le_antisymm (adjoin_le le_rfl) (subset_adjoin R)
+
+open Submodule in
+lemma adjoin_eq_span (s : Set A) : (adjoin R s).toSubmodule = span R (Subsemigroup.closure s) := by
+  apply le_antisymm
+  · intro x hx
+    induction hx using adjoin_induction' with
+    | mem x hx => exact subset_span <| Subsemigroup.subset_closure hx
+    | add x _ y _ hpx hpy => exact add_mem hpx hpy
+    | zero => exact zero_mem _
+    | mul x _ y _ hpx hpy =>
+      apply span_induction₂ hpx hpy ?Hs (by simp) (by simp) ?Hadd_l ?Hadd_r ?Hsmul_l ?Hsmul_r
+      case Hs => exact fun x hx y hy ↦ subset_span <| mul_mem hx hy
+      case Hadd_l => exact fun x y z hxz hyz ↦ by simpa [add_mul] using add_mem hxz hyz
+      case Hadd_r => exact fun x y z hxz hyz ↦ by simpa [mul_add] using add_mem hxz hyz
+      case Hsmul_l => exact fun r x y hxy ↦ by simpa [smul_mul_assoc] using smul_mem _ _ hxy
+      case Hsmul_r => exact fun r x y hxy ↦ by simpa [mul_smul_comm] using smul_mem _ _ hxy
+    | smul r x _ hpx => exact smul_mem _ _ hpx
+  · apply span_le.2 _
+    show Subsemigroup.closure s ≤ (adjoin R s).toSubsemigroup
+    exact Subsemigroup.closure_le.2 (subset_adjoin R)
+
 variable (R A)
 
 @[simp]
@@ -622,6 +656,16 @@ theorem adjoin_empty : adjoin R (∅ : Set A) = ⊥ :=
 @[simp]
 theorem adjoin_univ : adjoin R (Set.univ : Set A) = ⊤ :=
   eq_top_iff.2 fun _x hx => subset_adjoin R hx
+
+open NonUnitalSubalgebra in
+lemma map_adjoin (f : F) (s : Set A) : map f (adjoin R s) = adjoin R (f '' s) :=
+  Set.image_preimage.l_comm_of_u_comm (gc_map_comap f) NonUnitalAlgebra.gi.gc
+    NonUnitalAlgebra.gi.gc fun _t => rfl
+
+open NonUnitalSubalgebra in
+@[simp]
+lemma map_adjoin_singleton (f : F) (x : A) : map f (adjoin R {x}) = adjoin R {f x} := by
+  simp [map_adjoin]
 
 variable {R A}
 

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -647,6 +647,11 @@ lemma adjoin_eq_span (s : Set A) : (adjoin R s).toSubmodule = span R (Subsemigro
     show Subsemigroup.closure s ≤ (adjoin R s).toSubsemigroup
     exact Subsemigroup.closure_le.2 (subset_adjoin R)
 
+@[simp]
+lemma span_eq_toSubmodule (s : NonUnitalSubalgebra R A) :
+    Submodule.span R (s : Set A) = s.toSubmodule := by
+  simp [SetLike.ext'_iff, Submodule.coe_span_eq_self]
+
 variable (R A)
 
 @[simp]
@@ -658,14 +663,16 @@ theorem adjoin_univ : adjoin R (Set.univ : Set A) = ⊤ :=
   eq_top_iff.2 fun _x hx => subset_adjoin R hx
 
 open NonUnitalSubalgebra in
-lemma map_adjoin (f : F) (s : Set A) : map f (adjoin R s) = adjoin R (f '' s) :=
+lemma _root_.NonUnitalAlgHom.map_adjoin (f : F) (s : Set A) :
+    map f (adjoin R s) = adjoin R (f '' s) :=
   Set.image_preimage.l_comm_of_u_comm (gc_map_comap f) NonUnitalAlgebra.gi.gc
     NonUnitalAlgebra.gi.gc fun _t => rfl
 
 open NonUnitalSubalgebra in
 @[simp]
-lemma map_adjoin_singleton (f : F) (x : A) : map f (adjoin R {x}) = adjoin R {f x} := by
-  simp [map_adjoin]
+lemma _root_.NonUnitalAlgHom.map_adjoin_singleton (f : F) (x : A) :
+    map f (adjoin R {x}) = adjoin R {f x} := by
+  simp [NonUnitalAlgHom.map_adjoin]
 
 variable {R A}
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
@@ -74,6 +74,24 @@ theorem NonUnitalSubalgebra.toSubalgebra_toNonUnitalSubalgebra (S : NonUnitalSub
     (h1 : (1 : A) ∈ S) : (NonUnitalSubalgebra.toSubalgebra S h1).toNonUnitalSubalgebra = S := by
   cases S; rfl
 
+open Submodule in
+lemma Algebra.adjoin_nonUnitalSubalgebra_eq_span (s : NonUnitalSubalgebra R A) :
+    Subalgebra.toSubmodule (adjoin R (s : Set A)) = span R {1} ⊔ s.toSubmodule := by
+  rw [adjoin_eq_span, Submonoid.closure_eq_one_union, span_union, ← NonUnitalAlgebra.adjoin_eq_span,
+      NonUnitalAlgebra.adjoin_eq]
+
+variable (R)
+
+lemma NonUnitalAlgebra.adjoin_le_algebra_adjoin (s : Set A) :
+    adjoin R s ≤ (Algebra.adjoin R s).toNonUnitalSubalgebra :=
+  adjoin_le Algebra.subset_adjoin
+
+lemma Algebra.adjoin_nonUnitalSubalgebra (s : Set A) :
+    adjoin R (NonUnitalAlgebra.adjoin R s : Set A) = adjoin R s :=
+  le_antisymm
+    (adjoin_le <| NonUnitalAlgebra.adjoin_le_algebra_adjoin R s)
+    (adjoin_le <| (NonUnitalAlgebra.subset_adjoin R).trans subset_adjoin)
+
 end Subalgebra
 
 namespace Unitization
@@ -308,6 +326,24 @@ theorem NonUnitalStarSubalgebra.toStarSubalgebra_toNonUnitalStarSubalgebra
     (S : NonUnitalStarSubalgebra R A) (h1 : (1 : A) ∈ S) :
     (S.toStarSubalgebra h1).toNonUnitalStarSubalgebra = S := by
   cases S; rfl
+
+open Submodule in
+lemma StarAlgebra.adjoin_nonUnitalStarSubalgebra_eq_span (s : NonUnitalStarSubalgebra R A) :
+    Subalgebra.toSubmodule (adjoin R (s : Set A)).toSubalgebra = span R {1} ⊔ s.toSubmodule := by
+  rw [adjoin_eq_span, Submonoid.closure_eq_one_union, span_union,
+    ← NonUnitalStarAlgebra.adjoin_eq_span, NonUnitalStarAlgebra.adjoin_eq]
+
+variable (R)
+
+lemma NonUnitalStarAlgebra.adjoin_le_starAlgebra_adjoin (s : Set A) :
+    adjoin R s ≤ (StarAlgebra.adjoin R s).toNonUnitalStarSubalgebra :=
+  adjoin_le <| StarAlgebra.subset_adjoin R s
+
+lemma StarAlgebra.adjoin_nonUnitalStarSubalgebra (s : Set A) :
+    adjoin R (NonUnitalStarAlgebra.adjoin R s : Set A) = adjoin R s :=
+  le_antisymm
+    (adjoin_le <| NonUnitalStarAlgebra.adjoin_le_starAlgebra_adjoin R s)
+    (adjoin_le <| (NonUnitalStarAlgebra.subset_adjoin R s).trans <| subset_adjoin R _)
 
 end StarSubalgebra
 

--- a/Mathlib/Algebra/Group/Submonoid/Basic.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Basic.lean
@@ -489,7 +489,7 @@ theorem dense_induction {p : M → Prop} (x : M) {s : Set M} (hs : closure s = �
 #align submonoid.dense_induction Submonoid.dense_induction
 #align add_submonoid.dense_induction AddSubmonoid.dense_induction
 
-/-- The `Submonoid.closure` of a set is `1` union the its `Subsemigroup.closure`. -/
+/-- The `Submonoid.closure` of a set is the union of `{1}` and its `Subsemigroup.closure`. -/
 lemma closure_eq_one_union (s : Set M) :
     closure s = {(1 : M)} ∪ (Subsemigroup.closure s : Set M) := by
   apply le_antisymm

--- a/Mathlib/Algebra/Group/Submonoid/Basic.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Basic.lean
@@ -489,6 +489,23 @@ theorem dense_induction {p : M → Prop} (x : M) {s : Set M} (hs : closure s = �
 #align submonoid.dense_induction Submonoid.dense_induction
 #align add_submonoid.dense_induction AddSubmonoid.dense_induction
 
+/-- The `Submonoid.closure` of a set is `1` union the its `Subsemigroup.closure`. -/
+lemma closure_eq_one_union (s : Set M) :
+    closure s = {(1 : M)} ∪ (Subsemigroup.closure s : Set M) := by
+  apply le_antisymm
+  · intro x hx
+    induction hx using closure_induction' with
+    | mem x hx => exact Or.inr <| Subsemigroup.subset_closure hx
+    | one => exact Or.inl <| by simp
+    | mul x hx y hy hx hy =>
+      simp only [singleton_union, mem_insert_iff, SetLike.mem_coe] at hx hy
+      obtain ⟨(rfl | hx), (rfl | hy)⟩ := And.intro hx hy
+      all_goals simp_all
+      exact Or.inr <| mul_mem hx hy
+  · rintro x (hx | hx)
+    · exact (show x = 1 by simpa using hx) ▸ one_mem (closure s)
+    · exact Subsemigroup.closure_le.mpr subset_closure hx
+
 variable (M)
 
 /-- `closure` forms a Galois insertion with the coercion to set. -/

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -837,7 +837,8 @@ lemma _root_.NonUnitalStarAlgHom.map_adjoin (f : F) (s : Set A) :
     NonUnitalStarAlgebra.gi.gc fun _t => rfl
 
 @[simp]
-lemma map_adjoin_singleton (f : F) (x : A) : map f (adjoin R {x}) = adjoin R {f x} := by
+lemma _root_.NonUnitalStarAlgHom.map_adjoin_singleton (f : F) (x : A) :
+    map f (adjoin R {x}) = adjoin R {f x} := by
   simp [NonUnitalStarAlgHom.map_adjoin]
 
 instance subsingleton_of_subsingleton [Subsingleton A] :

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -646,6 +646,19 @@ theorem self_mem_adjoin_singleton (x : A) : x ∈ adjoin R ({x} : Set A) :=
 theorem star_self_mem_adjoin_singleton (x : A) : star x ∈ adjoin R ({x} : Set A) :=
   star_mem <| self_mem_adjoin_singleton R x
 
+@[elab_as_elim]
+lemma adjoin_induction' {s : Set A} {p : ∀ x, x ∈ adjoin R s → Prop} {a : A}
+    (ha : a ∈ adjoin R s) (mem : ∀ (x : A) (hx : x ∈ s), p x (subset_adjoin R s hx))
+    (add : ∀ x hx y hy, p x hx → p y hy → p (x + y) (add_mem hx hy))
+    (zero : p 0 (zero_mem _)) (mul : ∀ x hx y hy, p x hx → p y hy → p (x * y) (mul_mem hx hy))
+    (smul : ∀ (r : R) x hx, p x hx → p (r • x) (SMulMemClass.smul_mem r hx))
+    (star : ∀ x hx, p x hx → p (star x) (star_mem hx)) : p a ha := by
+  refine NonUnitalAlgebra.adjoin_induction' (fun x hx ↦ ?_) add zero mul smul ha
+  simp only [Set.mem_union, Set.mem_star] at hx
+  obtain (hx | hx) := hx
+  · exact mem x hx
+  · simpa using star _ (NonUnitalAlgebra.subset_adjoin R (by simpa using Or.inl hx)) (mem _ hx)
+
 variable {R}
 
 protected theorem gc : GaloisConnection (adjoin R : Set A → NonUnitalStarSubalgebra R A) (↑) := by
@@ -667,6 +680,18 @@ theorem adjoin_le {S : NonUnitalStarSubalgebra R A} {s : Set A} (hs : s ⊆ S) :
 
 theorem adjoin_le_iff {S : NonUnitalStarSubalgebra R A} {s : Set A} : adjoin R s ≤ S ↔ s ⊆ S :=
   NonUnitalStarAlgebra.gc _ _
+
+lemma adjoin_eq (s : NonUnitalStarSubalgebra R A) : adjoin R (s : Set A) = s :=
+  le_antisymm (adjoin_le le_rfl) (subset_adjoin R (s : Set A))
+
+lemma adjoin_eq_span (s : Set A) :
+    (adjoin R s).toSubmodule = Submodule.span R (Subsemigroup.closure (s ∪ star s)) := by
+  rw [adjoin_toNonUnitalSubalgebra, NonUnitalAlgebra.adjoin_eq_span]
+
+@[simp]
+lemma span_eq_toSubmodule (s : NonUnitalStarSubalgebra R A) :
+    Submodule.span R (s : Set A) = s.toSubmodule := by
+  simp [SetLike.ext'_iff, Submodule.coe_span_eq_self]
 
 theorem _root_.NonUnitalSubalgebra.starClosure_eq_adjoin (S : NonUnitalSubalgebra R A) :
     S.starClosure = adjoin R (S : Set A) :=
@@ -805,6 +830,15 @@ variable [NonUnitalSemiring B] [StarRing B]
 variable [Module R B] [IsScalarTower R B B] [SMulCommClass R B B] [StarModule R B]
 variable [FunLike F A B] [NonUnitalAlgHomClass F R A B] [NonUnitalStarAlgHomClass F R A B]
 variable (S : NonUnitalStarSubalgebra R A)
+
+lemma _root_.NonUnitalStarAlgHom.map_adjoin (f : F) (s : Set A) :
+    map f (adjoin R s) = adjoin R (f '' s) :=
+  Set.image_preimage.l_comm_of_u_comm (gc_map_comap f) NonUnitalStarAlgebra.gi.gc
+    NonUnitalStarAlgebra.gi.gc fun _t => rfl
+
+@[simp]
+lemma map_adjoin_singleton (f : F) (x : A) : map f (adjoin R {x}) = adjoin R {f x} := by
+  simp [NonUnitalStarAlgHom.map_adjoin]
 
 instance subsingleton_of_subsingleton [Subsingleton A] :
     Subsingleton (NonUnitalStarSubalgebra R A) :=

--- a/Mathlib/Algebra/Star/Subalgebra.lean
+++ b/Mathlib/Algebra/Star/Subalgebra.lean
@@ -482,6 +482,14 @@ theorem adjoin_le_iff {S : StarSubalgebra R A} {s : Set A} : adjoin R s ≤ S �
   StarAlgebra.gc _ _
 #align star_subalgebra.adjoin_le_iff StarAlgebra.adjoin_le_iff
 
+lemma adjoin_eq (S : StarSubalgebra R A) : adjoin R (S : Set A) = S :=
+  le_antisymm (adjoin_le le_rfl) (subset_adjoin R (S : Set A))
+
+open Submodule in
+lemma adjoin_eq_span (s : Set A) :
+    Subalgebra.toSubmodule (adjoin R s).toSubalgebra = span R (Submonoid.closure (s ∪ star s)) := by
+  rw [adjoin_toSubalgebra, Algebra.adjoin_eq_span]
+
 theorem _root_.Subalgebra.starClosure_eq_adjoin (S : Subalgebra R A) :
     S.starClosure = adjoin R (S : Set A) :=
   le_antisymm (Subalgebra.starClosure_le_iff.2 <| subset_adjoin R (S : Set A))

--- a/Mathlib/LinearAlgebra/Span.lean
+++ b/Mathlib/LinearAlgebra/Span.lean
@@ -99,6 +99,19 @@ theorem span_eq_span (hs : s ⊆ span R t) (ht : t ⊆ span R s) : span R s = sp
   le_antisymm (span_le.2 hs) (span_le.2 ht)
 #align submodule.span_eq_span Submodule.span_eq_span
 
+/-- A version of `Submodule.span_eq` for subobjects closed under addition and scalar multiplication
+and containing zero. In general, this should not be used directly, but can be used to quickly
+generate proofs for specific types of subobjects. -/
+lemma coe_span_eq_self [SetLike S M] [AddSubmonoidClass S M] [SMulMemClass S R M] (s : S) :
+    (span R (s : Set M) : Set M) = s := by
+  refine le_antisymm ?_ subset_span
+  let s' : Submodule R M :=
+    { carrier := s
+      add_mem' := add_mem
+      zero_mem' := zero_mem _
+      smul_mem' := SMulMemClass.smul_mem }
+  exact span_le (p := s') |>.mpr le_rfl
+
 /-- A version of `Submodule.span_eq` for when the span is by a smaller ring. -/
 @[simp]
 theorem span_coe_eq_restrictScalars [Semiring S] [SMul S R] [Module S M] [IsScalarTower S R M] :


### PR DESCRIPTION
This relates several unital and non-unital subobject closures to each other the to various counterparts.

This is one of the key steps towards establishing that `C(s, 𝕜)₀` is the closure of the non-unital star subalgebra generated by the identity function, when `s` is compact and `RCLike 𝕜`. This, in turn, is essential for writing instances of the continuous functional calculus for non-unital algebras.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
