### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits): add classes `ReflectsFiniteLimits` and friends

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
@@ -340,4 +340,3 @@ noncomputable instance (F : C ⥤ D) [ReflectsFiniteColimits F] : ReflectsFinite
   reflects _ _ := inferInstance
 
 end CategoryTheory.Limits
-#lint

--- a/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
@@ -87,10 +87,6 @@ def preservesFiniteLimitsOfPreservesFiniteLimitsOfSize (F : C ⥤ D)
         exact preservesLimitsOfShapeOfEquiv (ULiftHomULiftCategory.equiv J).symm F
 #align category_theory.limits.preserves_finite_limits_of_preserves_finite_limits_of_size CategoryTheory.Limits.preservesFiniteLimitsOfPreservesFiniteLimitsOfSize
 
-noncomputable instance idPreservesFiniteLimits : PreservesFiniteLimits (𝟭 C) :=
-  inferInstance -- should this still be stated explicitly an instance?
-#align category_theory.limits.id_preserves_finite_limits CategoryTheory.Limits.idPreservesFiniteLimits
-
 /-- The composition of two left exact functors is left exact. -/
 def compPreservesFiniteLimits (F : C ⥤ D) (G : D ⥤ E) [PreservesFiniteLimits F]
     [PreservesFiniteLimits G] : PreservesFiniteLimits (F ⋙ G) :=
@@ -238,10 +234,6 @@ def preservesFiniteColimitsOfPreservesFiniteColimitsOfSize (F : C ⥤ D)
         haveI := h (ULiftHom (ULift J)) CategoryTheory.finCategoryUlift
         exact preservesColimitsOfShapeOfEquiv (ULiftHomULiftCategory.equiv J).symm F
 #align category_theory.limits.preserves_finite_colimits_of_preserves_finite_colimits_of_size CategoryTheory.Limits.preservesFiniteColimitsOfPreservesFiniteColimitsOfSize
-
-noncomputable instance idPreservesFiniteColimits : PreservesFiniteColimits (𝟭 C) :=
-  inferInstance -- should this still be stated explicitly an instance?
-#align category_theory.limits.id_preserves_finite_colimits CategoryTheory.Limits.idPreservesFiniteColimits
 
 /-- The composition of two right exact functors is right exact. -/
 def compPreservesFiniteColimits (F : C ⥤ D) (G : D ⥤ E) [PreservesFiniteColimits F]

--- a/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
 import Mathlib.CategoryTheory.Limits.Preserves.Basic
-import Mathlib.CategoryTheory.FinCategory.AsType
+import Mathlib.CategoryTheory.Limits.Shapes.FiniteProducts
 
 #align_import category_theory.limits.preserves.finite from "leanprover-community/mathlib"@"3974a774a707e2e06046a14c0eaef4654584fada"
 
@@ -75,8 +75,6 @@ noncomputable instance (priority := 120) PreservesLimits.preservesFiniteLimits (
   PreservesLimitsOfSize.preservesFiniteLimits F
 #align category_theory.limits.preserves_limits.preserves_finite_limits CategoryTheory.Limits.PreservesLimits.preservesFiniteLimits
 
--- Porting note: is this unnecessary given the instance
--- `PreservesLimitsOfSize0.preservesFiniteLimits`?
 /-- We can always derive `PreservesFiniteLimits C` by showing that we are preserving limits at an
 arbitrary universe. -/
 def preservesFiniteLimitsOfPreservesFiniteLimitsOfSize (F : C ⥤ D)
@@ -90,13 +88,13 @@ def preservesFiniteLimitsOfPreservesFiniteLimitsOfSize (F : C ⥤ D)
 #align category_theory.limits.preserves_finite_limits_of_preserves_finite_limits_of_size CategoryTheory.Limits.preservesFiniteLimitsOfPreservesFiniteLimitsOfSize
 
 noncomputable instance idPreservesFiniteLimits : PreservesFiniteLimits (𝟭 C) :=
-  ⟨fun _ _ _ => by infer_instance⟩
+  inferInstance -- should this still be stated explicitly an instance?
 #align category_theory.limits.id_preserves_finite_limits CategoryTheory.Limits.idPreservesFiniteLimits
 
 /-- The composition of two left exact functors is left exact. -/
 def compPreservesFiniteLimits (F : C ⥤ D) (G : D ⥤ E) [PreservesFiniteLimits F]
     [PreservesFiniteLimits G] : PreservesFiniteLimits (F ⋙ G) :=
-  ⟨fun _ _ _ => by infer_instance⟩
+  ⟨fun _ _ _ => inferInstance⟩
 #align category_theory.limits.comp_preserves_finite_limits CategoryTheory.Limits.compPreservesFiniteLimits
 
 /- Porting note: adding this class because quantified classes don't behave well
@@ -111,10 +109,73 @@ attribute [instance] PreservesFiniteProducts.preserves
 instance compPreservesFiniteProducts (F : C ⥤ D) (G : D ⥤ E)
     [PreservesFiniteProducts F] [PreservesFiniteProducts G] :
     PreservesFiniteProducts (F ⋙ G) where
-  preserves _ _ := by infer_instance
+  preserves _ _ := inferInstance
 
 noncomputable instance (F : C ⥤ D) [PreservesFiniteLimits F] : PreservesFiniteProducts F where
-  preserves _ _ := by infer_instance
+  preserves _ _ := inferInstance
+
+/--
+A functor is said to reflect finite limits, if it reflects all limits of shape `J`,
+where `J : Type` is a finite category.
+-/
+class ReflectsFiniteLimits (F : C ⥤ D) where
+  reflects : ∀ (J : Type) [SmallCategory J] [FinCategory J], ReflectsLimitsOfShape J F := by
+    infer_instance
+
+attribute [instance] ReflectsFiniteLimits.reflects
+
+/- Similarly to preserving finite products, quantified classes don't behave well. -/
+/--
+A functor `F` preserves finite products if it reflects limits of shape `Discrete J` for finite `J`
+-/
+class ReflectsFiniteProducts (F : C ⥤ D) where
+  reflects : ∀ (J : Type) [Fintype J], ReflectsLimitsOfShape (Discrete J) F
+
+attribute [instance] ReflectsFiniteProducts.reflects
+
+-- This is a dangerous instance as it has unbound universe variables.
+/-- If we reflect limits of some arbitrary size, then we reflect all finite limits. -/
+noncomputable def ReflectsLimitsOfSize.reflectsFiniteLimits
+    (F : C ⥤ D) [ReflectsLimitsOfSize.{w, w₂} F] : ReflectsFiniteLimits F where
+  reflects J (sJ : SmallCategory J) fJ := by
+    haveI := reflectsSmallestLimitsOfReflectsLimits F
+    exact reflectsLimitsOfShapeOfEquiv (FinCategory.equivAsType J) F
+
+-- Added as a specialization of the dangerous instance above, for colimits indexed in Type 0.
+noncomputable instance (priority := 120) (F : C ⥤ D) [ReflectsLimitsOfSize.{0, 0} F] :
+    ReflectsFiniteLimits F :=
+  ReflectsLimitsOfSize.reflectsFiniteLimits F
+
+-- An alternative specialization of the dangerous instance for small colimits.
+noncomputable instance (priority := 120) (F : C ⥤ D)
+    [ReflectsLimits F] : ReflectsFiniteLimits F :=
+  ReflectsLimitsOfSize.reflectsFiniteLimits F
+
+def preservesFiniteLimitsOfReflectsOfPreserves (F : C ⥤ D) (G : D ⥤ E)
+    [PreservesFiniteLimits (F ⋙ G)] [ReflectsFiniteLimits G] : PreservesFiniteLimits F where
+  preservesFiniteLimits _ _ _ := preservesLimitsOfShapeOfReflectsOfPreserves F G
+
+def preservesFiniteProductsOfReflectsOfPreserves (F : C ⥤ D) (G : D ⥤ E)
+    [PreservesFiniteProducts (F ⋙ G)] [ReflectsFiniteProducts G] : PreservesFiniteProducts F where
+  preserves _ _ := preservesLimitsOfShapeOfReflectsOfPreserves F G
+
+noncomputable instance reflectsFiniteLimitsOfReflectsIsomorphisms (F : C ⥤ D)
+    [F.ReflectsIsomorphisms] [HasFiniteLimits C] [PreservesFiniteLimits F] :
+      ReflectsFiniteLimits F where
+  reflects _ _ _ := reflectsLimitsOfShapeOfReflectsIsomorphisms
+
+noncomputable instance reflectsFiniteProductsOfReflectsIsomorphisms (F : C ⥤ D)
+    [F.ReflectsIsomorphisms] [HasFiniteProducts C] [PreservesFiniteProducts F] :
+      ReflectsFiniteProducts F where
+  reflects _ _ := reflectsLimitsOfShapeOfReflectsIsomorphisms
+
+instance compReflectsFiniteProducts (F : C ⥤ D) (G : D ⥤ E)
+    [ReflectsFiniteProducts F] [ReflectsFiniteProducts G] :
+    ReflectsFiniteProducts (F ⋙ G) where
+  reflects _ _ := inferInstance
+
+noncomputable instance (F : C ⥤ D) [ReflectsFiniteLimits F] : ReflectsFiniteProducts F where
+  reflects _ _ := inferInstance
 
 /-- A functor is said to preserve finite colimits, if it preserves all colimits of
 shape `J`, where `J : Type` is a finite category.
@@ -122,13 +183,15 @@ shape `J`, where `J : Type` is a finite category.
 class PreservesFiniteColimits (F : C ⥤ D) where
   preservesFiniteColimits :
     ∀ (J : Type) [SmallCategory J] [FinCategory J], PreservesColimitsOfShape J F := by
-    infer_instance
+      infer_instance
 #align category_theory.limits.preserves_finite_colimits CategoryTheory.Limits.PreservesFiniteColimits
 
 attribute [instance] PreservesFiniteColimits.preservesFiniteColimits
 
-/-- Preserving finite limits also implies preserving limits over finite shapes in higher universes,
-though through a noncomputable instance. -/
+/--
+Preserving finite colimits also implies preserving colimits over finite shapes in higher
+universes, though through a noncomputable instance.
+-/
 noncomputable instance (priority := 100) preservesColimitsOfShapeOfPreservesFiniteColimits
     (F : C ⥤ D) [PreservesFiniteColimits F] (J : Type w) [SmallCategory J] [FinCategory J] :
     PreservesColimitsOfShape J F := by
@@ -156,8 +219,6 @@ noncomputable instance (priority := 120) PreservesColimits.preservesFiniteColimi
   PreservesColimitsOfSize.preservesFiniteColimits F
 #align category_theory.limits.preserves_colimits.preserves_finite_colimits CategoryTheory.Limits.PreservesColimits.preservesFiniteColimits
 
--- Porting note: is this unnecessary given the instance
--- `PreservesColimitsOfSize0.preservesFiniteColimits`?
 /-- We can always derive `PreservesFiniteColimits C`
 by showing that we are preserving colimits at an arbitrary universe. -/
 def preservesFiniteColimitsOfPreservesFiniteColimitsOfSize (F : C ⥤ D)
@@ -170,17 +231,14 @@ def preservesFiniteColimitsOfPreservesFiniteColimitsOfSize (F : C ⥤ D)
         exact preservesColimitsOfShapeOfEquiv (ULiftHomULiftCategory.equiv J).symm F
 #align category_theory.limits.preserves_finite_colimits_of_preserves_finite_colimits_of_size CategoryTheory.Limits.preservesFiniteColimitsOfPreservesFiniteColimitsOfSize
 
--- Porting note: the proof `⟨fun _ _ _ => by infer_instance⟩` used for `idPreservesFiniteLimits`
--- did not work here because of universe problems, could this be solved by tweaking the priorities
--- of some instances?
 noncomputable instance idPreservesFiniteColimits : PreservesFiniteColimits (𝟭 C) :=
-  PreservesColimits.preservesFiniteColimits.{v₁, v₁} _
+  inferInstance -- should this still be stated explicitly an instance?
 #align category_theory.limits.id_preserves_finite_colimits CategoryTheory.Limits.idPreservesFiniteColimits
 
 /-- The composition of two right exact functors is right exact. -/
 def compPreservesFiniteColimits (F : C ⥤ D) (G : D ⥤ E) [PreservesFiniteColimits F]
     [PreservesFiniteColimits G] : PreservesFiniteColimits (F ⋙ G) :=
-  ⟨fun _ _ _ => by infer_instance⟩
+  ⟨fun _ _ _ => inferInstance⟩
 #align category_theory.limits.comp_preserves_finite_colimits CategoryTheory.Limits.compPreservesFiniteColimits
 
 /- Porting note: adding this class because quantified classes don't behave well
@@ -195,9 +253,74 @@ attribute [instance] PreservesFiniteCoproducts.preserves
 instance compPreservesFiniteCoproducts (F : C ⥤ D) (G : D ⥤ E)
     [PreservesFiniteCoproducts F] [PreservesFiniteCoproducts G] :
     PreservesFiniteCoproducts (F ⋙ G) where
-  preserves _ _ := by infer_instance
+  preserves _ _ := inferInstance
 
 noncomputable instance (F : C ⥤ D) [PreservesFiniteColimits F] : PreservesFiniteCoproducts F where
-  preserves _ _ := by infer_instance
+  preserves _ _ := inferInstance
+
+/--
+A functor is said to reflect finite colimits, if it reflects all colimits of shape `J`,
+where `J : Type` is a finite category.
+-/
+class ReflectsFiniteColimits (F : C ⥤ D) where
+  reflects : ∀ (J : Type) [SmallCategory J] [FinCategory J], ReflectsColimitsOfShape J F := by
+    infer_instance
+
+attribute [instance] ReflectsFiniteColimits.reflects
+
+-- This is a dangerous instance as it has unbound universe variables.
+/-- If we reflect colimits of some arbitrary size, then we reflect all finite colimits. -/
+noncomputable def ReflectsColimitsOfSize.reflectsFiniteColimits
+    (F : C ⥤ D) [ReflectsColimitsOfSize.{w, w₂} F] : ReflectsFiniteColimits F where
+  reflects J (sJ : SmallCategory J) fJ := by
+    haveI := reflectsSmallestColimitsOfReflectsColimits F
+    exact reflectsColimitsOfShapeOfEquiv (FinCategory.equivAsType J) F
+
+-- Added as a specialization of the dangerous instance above, for colimits indexed in Type 0.
+noncomputable instance (priority := 120) (F : C ⥤ D) [ReflectsColimitsOfSize.{0, 0} F] :
+    ReflectsFiniteColimits F :=
+  ReflectsColimitsOfSize.reflectsFiniteColimits F
+
+-- An alternative specialization of the dangerous instance for small colimits.
+noncomputable instance (priority := 120) (F : C ⥤ D)
+    [ReflectsColimits F] : ReflectsFiniteColimits F :=
+  ReflectsColimitsOfSize.reflectsFiniteColimits F
+
+/- Similarly to preserving finite coproducts, quantified classes don't behave well. -/
+/--
+A functor `F` preserves finite coproducts if it reflects colimits of shape `Discrete J` for
+finite `J`
+-/
+class ReflectsFiniteCoproducts (F : C ⥤ D) where
+  reflects : ∀ (J : Type) [Fintype J], ReflectsColimitsOfShape (Discrete J) F
+
+attribute [instance] ReflectsFiniteCoproducts.reflects
+
+def preservesFiniteColimitsOfReflectsOfPreserves (F : C ⥤ D) (G : D ⥤ E)
+    [PreservesFiniteColimits (F ⋙ G)] [ReflectsFiniteColimits G] : PreservesFiniteColimits F where
+  preservesFiniteColimits _ _ _ := preservesColimitsOfShapeOfReflectsOfPreserves F G
+
+def preservesFiniteCoproductsOfReflectsOfPreserves (F : C ⥤ D) (G : D ⥤ E)
+    [PreservesFiniteCoproducts (F ⋙ G)] [ReflectsFiniteCoproducts G] :
+    PreservesFiniteCoproducts F where
+  preserves _ _ := preservesColimitsOfShapeOfReflectsOfPreserves F G
+
+noncomputable instance reflectsFiniteColimitsOfReflectsIsomorphisms (F : C ⥤ D)
+    [F.ReflectsIsomorphisms] [HasFiniteColimits C] [PreservesFiniteColimits F] :
+      ReflectsFiniteColimits F where
+  reflects _ _ _ := reflectsColimitsOfShapeOfReflectsIsomorphisms
+
+noncomputable instance reflectsFiniteCoproductsOfReflectsIsomorphisms (F : C ⥤ D)
+    [F.ReflectsIsomorphisms] [HasFiniteCoproducts C] [PreservesFiniteCoproducts F] :
+      ReflectsFiniteCoproducts F where
+  reflects _ _ := reflectsColimitsOfShapeOfReflectsIsomorphisms
+
+instance compReflectsFiniteCoproducts (F : C ⥤ D) (G : D ⥤ E)
+    [ReflectsFiniteCoproducts F] [ReflectsFiniteCoproducts G] :
+    ReflectsFiniteCoproducts (F ⋙ G) where
+  reflects _ _ := inferInstance
+
+noncomputable instance (F : C ⥤ D) [ReflectsFiniteColimits F] : ReflectsFiniteCoproducts F where
+  reflects _ _ := inferInstance
 
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
@@ -151,10 +151,18 @@ noncomputable instance (priority := 120) (F : C ⥤ D)
     [ReflectsLimits F] : ReflectsFiniteLimits F :=
   ReflectsLimitsOfSize.reflectsFiniteLimits F
 
+/--
+If `F ⋙ G` preserves finite limits and `G` reflects finite limits, then `F` preserves
+finite limits.
+-/
 def preservesFiniteLimitsOfReflectsOfPreserves (F : C ⥤ D) (G : D ⥤ E)
     [PreservesFiniteLimits (F ⋙ G)] [ReflectsFiniteLimits G] : PreservesFiniteLimits F where
   preservesFiniteLimits _ _ _ := preservesLimitsOfShapeOfReflectsOfPreserves F G
 
+/--
+If `F ⋙ G` preserves finite products and `G` reflects finite products, then `F` preserves
+finite products.
+-/
 def preservesFiniteProductsOfReflectsOfPreserves (F : C ⥤ D) (G : D ⥤ E)
     [PreservesFiniteProducts (F ⋙ G)] [ReflectsFiniteProducts G] : PreservesFiniteProducts F where
   preserves _ _ := preservesLimitsOfShapeOfReflectsOfPreserves F G
@@ -296,10 +304,18 @@ class ReflectsFiniteCoproducts (F : C ⥤ D) where
 
 attribute [instance] ReflectsFiniteCoproducts.reflects
 
+/--
+If `F ⋙ G` preserves finite colimits and `G` reflects finite colimits, then `F` preserves finite
+colimits.
+-/
 def preservesFiniteColimitsOfReflectsOfPreserves (F : C ⥤ D) (G : D ⥤ E)
     [PreservesFiniteColimits (F ⋙ G)] [ReflectsFiniteColimits G] : PreservesFiniteColimits F where
   preservesFiniteColimits _ _ _ := preservesColimitsOfShapeOfReflectsOfPreserves F G
 
+/--
+If `F ⋙ G` preserves finite coproducts and `G` reflects finite coproducts, then `F` preserves
+finite coproducts.
+-/
 def preservesFiniteCoproductsOfReflectsOfPreserves (F : C ⥤ D) (G : D ⥤ E)
     [PreservesFiniteCoproducts (F ⋙ G)] [ReflectsFiniteCoproducts G] :
     PreservesFiniteCoproducts F where
@@ -324,3 +340,4 @@ noncomputable instance (F : C ⥤ D) [ReflectsFiniteColimits F] : ReflectsFinite
   reflects _ _ := inferInstance
 
 end CategoryTheory.Limits
+#lint


### PR DESCRIPTION
This PR adds classes `ReflectsFiniteLimits`, `ReflectsFiniteProducts` and their duals, and relates them to existing classes.

It also cleans up the file `CategoryTheory.Limits.Preserves.Finite` a bit and removes some porting notes that are no longer relevant.

---
This is used in #12870 to prove that to check the coherent sheaf condition on a finitary extensive preregular category, it is enough to check after postcomposition with a finite-limit-reflecting functor.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
