### PR TITLE
[Merged by Bors] - feat(Order/RelSeries): add `snoc` construction

### DIFF
--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -162,7 +162,7 @@ lemma nonempty_of_infiniteDimensional [r.InfiniteDimensional] : Nonempty α :=
 instance membership : Membership α (RelSeries r) :=
   ⟨(· ∈ Set.range ·)⟩
 
-@[simp] theorem mem_def {x : α} {s : RelSeries r} : x ∈ s ↔ x ∈ Set.range s :=
+theorem mem_def {x : α} {s : RelSeries r} : x ∈ s ↔ x ∈ Set.range s :=
   Iff.rfl
 
 @[simp high] theorem mem_toList {s : RelSeries r} {x : α} : x ∈ s.toList ↔ x ∈ s := by
@@ -180,7 +180,7 @@ theorem length_ne_zero_of_nontrivial {s : RelSeries r} (h : {x | x ∈ s}.Nontri
 variable {r} in
 theorem length_ne_zero (irrefl : Irreflexive r) {s : RelSeries r} :
     s.length ≠ 0 ↔ {x | x ∈ s}.Nontrivial := by
-  refine ⟨fun h ↦ ⟨s 0, by simp, s 1, by simp, fun rid ↦ irrefl (s 0) ?_⟩,
+  refine ⟨fun h ↦ ⟨s 0, by simp [mem_def], s 1, by simp [mem_def], fun rid ↦ irrefl (s 0) ?_⟩,
     length_ne_zero_of_nontrivial⟩
   nth_rw 2 [rid]
   convert s.step ⟨0, by omega⟩
@@ -211,7 +211,7 @@ theorem length_eq_zero (irrefl : Irreflexive r) {s : RelSeries r} :
   refine ⟨subsingleton_of_length_eq_zero, fun h ↦ ?_⟩
   by_contra!
   refine irrefl (s 0) ?_
-  nth_rw 2 [@h (s 0) (by simp) (s 1) (by simp)]
+  nth_rw 2 [@h (s 0) (by simp [mem_def]) (s 1) (by simp [mem_def])]
   convert s.step ⟨0, by omega⟩
   ext
   simpa [Nat.pos_iff_ne_zero]
@@ -659,3 +659,5 @@ noncomputable def comap (p : LTSeries β) (f : α → β)
 end LTSeries
 
 end LTSeries
+
+#lint

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -87,12 +87,12 @@ lemma coe_ofLE (x : RelSeries r) {s : Rel α α} (h : r ≤ s) :
     (x.ofLE h : _ → _) = x := rfl
 
 /-- Every relation series gives a list -/
-abbrev toList (x : RelSeries r) : List α := List.ofFn x
+def toList (x : RelSeries r) : List α := List.ofFn x
 
 lemma toList_chain' (x : RelSeries r) : x.toList.Chain' r := by
   rw [List.chain'_iff_get]
   intros i h
-  convert x.step ⟨i, by simpa using h⟩ <;> apply List.get_ofFn
+  convert x.step ⟨i, by simpa [toList] using h⟩ <;> apply List.get_ofFn
 
 lemma toList_ne_empty (x : RelSeries r) : x.toList ≠ [] := fun m =>
   List.eq_nil_iff_forall_not_mem.mp m (x 0) <| (List.mem_ofFn _ _).mpr ⟨_, rfl⟩
@@ -109,11 +109,11 @@ corresponds to each other. -/
 protected def Equiv : RelSeries r ≃ {x : List α | x ≠ [] ∧ x.Chain' r} where
   toFun x := ⟨_, x.toList_ne_empty, x.toList_chain'⟩
   invFun x := fromListChain' _ x.2.1 x.2.2
-  left_inv x := ext (by simp) <| by ext; apply List.get_ofFn
+  left_inv x := ext (by simp [toList]) <| by ext; apply List.get_ofFn
   right_inv x := by
     refine Subtype.ext (List.ext_get ?_ fun n hn1 _ => List.get_ofFn _ _)
     have := Nat.succ_pred_eq_of_pos <| List.length_pos.mpr x.2.1
-    simp_all
+    simp_all [toList]
 
 -- TODO : build a similar bijection between `RelSeries α` and `Quiver.Path`
 
@@ -165,7 +165,7 @@ instance membership : Membership α (RelSeries r) :=
 theorem mem_def {x : α} {s : RelSeries r} : x ∈ s ↔ x ∈ Set.range s :=
   Iff.rfl
 
-@[simp high] theorem mem_toList {s : RelSeries r} {x : α} : x ∈ s.toList ↔ x ∈ s := by
+@[simp] theorem mem_toList {s : RelSeries r} {x : α} : x ∈ s.toList ↔ x ∈ s := by
   rw [RelSeries.toList, List.mem_ofFn, RelSeries.mem_def]
 
 variable {r} in
@@ -659,5 +659,3 @@ noncomputable def comap (p : LTSeries β) (f : α → β)
 end LTSeries
 
 end LTSeries
-
-#lint

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -409,7 +409,7 @@ def snoc (p : RelSeries r) (newLast : α) (rel : r p.last newLast) : RelSeries r
     (i : Fin (s.length + 1)) : snoc s a connect (Fin.castSucc i) = s i :=
   Fin.append_left _ _ i
 
-lemma mem_snoc (p : RelSeries r) (newLast : α) (rel : r p.last newLast) (x : α) :
+lemma mem_snoc {p : RelSeries r} {newLast : α} {rel : r p.last newLast} {x : α} :
     x ∈ p.snoc newLast rel ↔ x ∈ p ∨ x = newLast := by
   simp only [snoc, append, singleton_length, Nat.add_zero, Nat.reduceAdd, Fin.cast_refl,
     Function.comp_id, mem_def, id_eq, Set.mem_range]

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -165,7 +165,6 @@ instance membership : Membership α (RelSeries r) :=
 theorem mem_def {x : α} {s : RelSeries r} : x ∈ s ↔ x ∈ Set.range s :=
   Iff.rfl
 
-@[simp]
 theorem mem_toList {s : RelSeries r} {x : α} : x ∈ s.toList ↔ x ∈ s := by
   rw [RelSeries.toList, List.mem_ofFn, RelSeries.mem_def]
 

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -165,7 +165,7 @@ instance membership : Membership α (RelSeries r) :=
 @[simp] theorem mem_def {x : α} {s : RelSeries r} : x ∈ s ↔ x ∈ Set.range s :=
   Iff.rfl
 
-@[simp] theorem mem_toList {s : RelSeries r} {x : α} : x ∈ s.toList ↔ x ∈ s := by
+@[simp high] theorem mem_toList {s : RelSeries r} {x : α} : x ∈ s.toList ↔ x ∈ s := by
   rw [RelSeries.toList, List.mem_ofFn, RelSeries.mem_def]
 
 variable {r} in


### PR DESCRIPTION
Given a series `a₀ -r→ a₁ -r→ ... -r→ aₙ` and an `a` such that `aₙ -r→ a` holds, there is
a series of length `n+1`: `a₀ -r→ a₁ -r→ ... -r→ aₙ -r→ a`.

These and some other lemmas in this PR are all extracted from `Order/JordanHolder.lean`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
