### PR TITLE
[Merged by Bors] - feat(CategoryTheory): the adjunction between Over.map and Over.baseChange

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
@@ -352,7 +352,7 @@ theorem diagonalObjPullbackFstIso_inv_snd_snd {X Y Z : C} (f : X ⟶ Z) (g : Y �
 theorem diagonal_pullback_fst {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
     diagonal (pullback.fst : pullback f g ⟶ _) =
       (pullbackSymmetry _ _).hom ≫
-        ((baseChange f).map
+        ((Over.baseChange f).map
               (Over.homMk (diagonal g) : Over.mk g ⟶ Over.mk (pullback.snd ≫ g))).left ≫
           (diagonalObjPullbackFstIso f g).inv := by
   ext <;> dsimp <;> simp

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
@@ -27,9 +27,9 @@ noncomputable section
 
 open CategoryTheory
 
-namespace CategoryTheory.Limits
-
 universe w v₁ v₂ v u u₂
+
+namespace CategoryTheory.Limits
 
 -- attribute [local tidy] tactic.case_bash Porting note: no tidy, no local
 
@@ -2735,7 +2735,6 @@ namespace Over
 
 open Limits
 
-universe u v
 variable {C : Type u} [Category.{v} C]
 
 -- Porting note: removed semireducible from the simps config
@@ -2754,6 +2753,9 @@ def baseChange [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over Y ⥤ Over X wher
     · dsimp; simp
     · dsimp; simp
 #align category_theory.limits.base_change CategoryTheory.Over.baseChange
+
+-- deprecated on 2024-05-15
+@[deprecated] noncomputable alias Limits.baseChange := Over.baseChange
 
 /-- The adjunction `Over.map ⊣ baseChange` -/
 @[simps! homEquiv_apply homEquiv_symm_apply unit_app counit_app]

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
@@ -2778,3 +2778,5 @@ def mapAdjunction [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ base
               dsimp }}
 
 end Over
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
@@ -2729,7 +2729,14 @@ instance (priority := 100) hasPushouts_of_hasWidePushouts (D : Type u) [h : Cate
   haveI I := @hasWidePushouts_shrink.{0, w} D h h'
   infer_instance
 
-variable {C}
+end Limits
+
+namespace Over
+
+open Limits
+
+universe u v
+variable {C : Type u} [Category.{v} C]
 
 -- Porting note: removed semireducible from the simps config
 /-- Given a morphism `f : X ⟶ Y`, we can take morphisms over `Y` to morphisms over `X` via
@@ -2746,11 +2753,11 @@ def baseChange [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over Y ⥤ Over X wher
     apply Over.OverMorphism.ext; apply pullback.hom_ext
     · dsimp; simp
     · dsimp; simp
-#align category_theory.limits.base_change CategoryTheory.Limits.baseChange
+#align category_theory.limits.base_change CategoryTheory.Over.baseChange
 
 /-- The adjunction `Over.map ⊣ baseChange` -/
 
-def Over.mapAdjunction [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ baseChange f :=
+def mapAdjunction [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ baseChange f :=
   Adjunction.mkOfHomEquiv
     { homEquiv := fun x y ↦
         { toFun := fun u ↦ Over.homMk (pullback.lift u.left x.hom (by simp))
@@ -2768,4 +2775,4 @@ def Over.mapAdjunction [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣
             · rw [pullback.lift_snd, ← Over.w v]
               dsimp }}
 
-end CategoryTheory.Limits
+end Over

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
@@ -2756,7 +2756,6 @@ def baseChange [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over Y ⥤ Over X wher
 #align category_theory.limits.base_change CategoryTheory.Over.baseChange
 
 /-- The adjunction `Over.map ⊣ baseChange` -/
-
 @[simps! homEquiv_apply homEquiv_symm_apply unit_app counit_app]
 def mapAdjunction [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ baseChange f :=
   Adjunction.mkOfHomEquiv

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
@@ -2760,22 +2760,19 @@ def baseChange [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over Y ⥤ Over X wher
 /-- The adjunction `Over.map ⊣ baseChange` -/
 @[simps! unit_app counit_app]
 def mapAdjunction [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ baseChange f :=
-  Adjunction.mkOfHomEquiv
-    { homEquiv := fun x y ↦
-        { toFun := fun u ↦ Over.homMk (pullback.lift u.left x.hom (by simp))
-          invFun := fun v ↦ Over.homMk (v.left ≫ pullback.fst) (by
-            dsimp
-            rw [Category.assoc, pullback.condition, ← Over.w v, Category.assoc]
-            dsimp)
-          left_inv := by aesop_cat
-          right_inv := fun v ↦ by
-            dsimp
-            ext
-            dsimp
-            ext
-            · simp
-            · rw [pullback.lift_snd, ← Over.w v]
-              dsimp }}
+  .mkOfHomEquiv <| {
+    homEquiv := fun X Y => {
+      toFun := fun u => Over.homMk (pullback.lift u.left X.hom <| by simp)
+      invFun := fun v => Over.homMk (v.left ≫ pullback.fst) <|
+        by simp [← Over.w v, pullback.condition]
+      left_inv := by aesop_cat
+      right_inv := by
+        intro v
+        ext
+        dsimp
+        ext
+        · simp
+        · simpa using Over.w v |>.symm  } }
 
 end Over
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
@@ -2750,43 +2750,22 @@ def baseChange [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over Y ⥤ Over X wher
 
 /-- The adjunction `Over.map ⊣ baseChange` -/
 
-def hasPullbackOverAdj [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ baseChange f :=
-  Adjunction.mkOfHomEquiv {
-    homEquiv := fun x y ↦ {
-      toFun := fun u ↦ {
-        left := by
-          simp
-          fapply pullback.lift
-          · exact u.left
-          · exact x.hom
-          · aesop_cat
-        right := by
-          apply eqToHom
-          aesop
-        w := by simp}
-      invFun := fun v ↦ {
-        left := by
-          simp at*
-          exact v.left ≫ pullback.fst
-        right := by
-          apply eqToHom
-          aesop
-        w := by
-          simp
-          rw [pullback.condition]
-          rw [← Category.assoc]
-          apply eq_whisker
-          simpa using v.w}
-      left_inv := by aesop_cat
-      right_inv := fun v ↦ Over.OverMorphism.ext (by
-        simp
-        apply pullback.hom_ext
-        · aesop_cat
-        · rw [pullback.lift_snd]
-          have vtriangle := v.w
-          simp at vtriangle
-          exact vtriangle.symm)}
-    homEquiv_naturality_left_symm := by aesop_cat
-    homEquiv_naturality_right := by aesop_cat}
+def Over.mapAdjunction [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ baseChange f :=
+  Adjunction.mkOfHomEquiv
+    { homEquiv := fun x y ↦
+        { toFun := fun u ↦ Over.homMk (pullback.lift u.left x.hom (by simp))
+          invFun := fun v ↦ Over.homMk (v.left ≫ pullback.fst) (by
+            dsimp
+            rw [Category.assoc, pullback.condition, ← Over.w v, Category.assoc]
+            dsimp)
+          left_inv := by aesop_cat
+          right_inv := fun v ↦ by
+            dsimp
+            ext
+            dsimp
+            ext
+            · simp
+            · rw [pullback.lift_snd, ← Over.w v]
+              dsimp }}
 
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
@@ -2757,6 +2757,7 @@ def baseChange [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over Y ⥤ Over X wher
 
 /-- The adjunction `Over.map ⊣ baseChange` -/
 
+@[simps! homEquiv_apply homEquiv_symm_apply unit_app counit_app]
 def mapAdjunction [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ baseChange f :=
   Adjunction.mkOfHomEquiv
     { homEquiv := fun x y ↦

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
@@ -2758,7 +2758,7 @@ def baseChange [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over Y ⥤ Over X wher
 @[deprecated] noncomputable alias Limits.baseChange := Over.baseChange
 
 /-- The adjunction `Over.map ⊣ baseChange` -/
-@[simps! homEquiv_apply homEquiv_symm_apply unit_app counit_app]
+@[simps! unit_app counit_app]
 def mapAdjunction [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ baseChange f :=
   Adjunction.mkOfHomEquiv
     { homEquiv := fun x y ↦

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -76,17 +76,17 @@ theorem StableUnderBaseChange.snd {P : MorphismProperty C} (hP : StableUnderBase
 
 theorem StableUnderBaseChange.baseChange_obj [HasPullbacks C] {P : MorphismProperty C}
     (hP : StableUnderBaseChange P) {S S' : C} (f : S' ⟶ S) (X : Over S) (H : P X.hom) :
-    P ((baseChange f).obj X).hom :=
+    P ((Over.baseChange f).obj X).hom :=
   hP.snd X.hom f H
 #align category_theory.morphism_property.stable_under_base_change.base_change_obj CategoryTheory.MorphismProperty.StableUnderBaseChange.baseChange_obj
 
 theorem StableUnderBaseChange.baseChange_map [HasPullbacks C] {P : MorphismProperty C}
     (hP : StableUnderBaseChange P) {S S' : C} (f : S' ⟶ S) {X Y : Over S} (g : X ⟶ Y)
-    (H : P g.left) : P ((baseChange f).map g).left := by
+    (H : P g.left) : P ((Over.baseChange f).map g).left := by
   let e :=
     pullbackRightPullbackFstIso Y.hom f g.left ≪≫
       pullback.congrHom (g.w.trans (Category.comp_id _)) rfl
-  have : e.inv ≫ pullback.snd = ((baseChange f).map g).left := by
+  have : e.inv ≫ pullback.snd = ((Over.baseChange f).map g).left := by
     ext <;> dsimp [e] <;> simp
   rw [← this, hP.respectsIso.cancel_left_isIso]
   exact hP.snd _ _ H
@@ -102,9 +102,9 @@ theorem StableUnderBaseChange.pullback_map [HasPullbacks C] {P : MorphismPropert
     pullback.map f g f' g' i₁ i₂ (𝟙 _) ((Category.comp_id _).trans e₁)
         ((Category.comp_id _).trans e₂) =
       ((pullbackSymmetry _ _).hom ≫
-          ((baseChange _).map (Over.homMk _ e₂.symm : Over.mk g ⟶ Over.mk g')).left) ≫
+          ((Over.baseChange _).map (Over.homMk _ e₂.symm : Over.mk g ⟶ Over.mk g')).left) ≫
         (pullbackSymmetry _ _).hom ≫
-          ((baseChange g').map (Over.homMk _ e₁.symm : Over.mk f ⟶ Over.mk f')).left :=
+          ((Over.baseChange g').map (Over.homMk _ e₁.symm : Over.mk f ⟶ Over.mk f')).left :=
     by ext <;> dsimp <;> simp
   rw [this]
   apply P.comp_mem <;> rw [hP.respectsIso.cancel_left_isIso]


### PR DESCRIPTION
When a category has pullbacks, any morphism gives rise to an adjunction between over categories, with the left adjoint defined by composition and the right adjoint defined by pullback. This PR contains a definition of that adjunction.

---

This commit includes a single new definition completing a TODO listed at the end of the file. This is my first mathlib PR and I'm a new Lean user so I am sure there are many things that can be done better. Comments very welcome. 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
