### PR TITLE
chore: replace some use of > or ≥ by < or ≤

### DIFF
--- a/Archive/Imo/Imo1960Q1.lean
+++ b/Archive/Imo/Imo1960Q1.lean
@@ -81,7 +81,7 @@ theorem searchUpTo_step {c n} (H : SearchUpTo c n) {c' n'} (ec : c + 1 = c') (en
   obtain ⟨h₁, ⟨m, rfl⟩, h₂⟩ := id p
   by_cases h : 11 * m < c * 11; · exact H _ h p
   obtain rfl : m = c := by linarith
-  rw [Nat.mul_div_cancel_left _ (by norm_num : 11 > 0), mul_comm] at h₂
+  rw [Nat.mul_div_cancel_left _ (by norm_num : 0 < 11), mul_comm] at h₂
   refine' (H' h₂).imp _ _ <;> · rintro rfl; norm_num
 #align imo1960_q1.search_up_to_step Imo1960Q1.searchUpTo_step
 

--- a/Archive/Imo/Imo1962Q1.lean
+++ b/Archive/Imo/Imo1962Q1.lean
@@ -68,7 +68,7 @@ theorem case_1_digit {c n : ℕ} (h1 : (digits 10 c).length = 1) : ¬ProblemPred
   intro h2
   have h3 : 6 * 10 ^ 1 + c = 6 * 10 ^ (digits 10 c).length + c := by rw [h1]
   have h4 : 6 * 10 ^ 1 + c = 4 * (10 * c + 6) := by rw [h3, h2.right, h2.left]
-  have h6 : c > 0 := by linarith
+  have h6 : 0 < c := by linarith
   linarith
 #align imo1962_q1.case_1_digit Imo1962Q1.case_1_digit
 
@@ -76,7 +76,7 @@ theorem case_2_digit {c n : ℕ} (h1 : (digits 10 c).length = 2) : ¬ProblemPred
   intro h2
   have h3 : 6 * 10 ^ 2 + c = 6 * 10 ^ (digits 10 c).length + c := by rw [h1]
   have h4 : 6 * 10 ^ 2 + c = 4 * (10 * c + 6) := by rw [h3, h2.right, h2.left]
-  have h5 : c > 14 := by linarith
+  have h5 : 14 < c := by linarith
   linarith
 #align imo1962_q1.case_2_digit Imo1962Q1.case_2_digit
 

--- a/Archive/Imo/Imo1988Q6.lean
+++ b/Archive/Imo/Imo1988Q6.lean
@@ -232,7 +232,7 @@ theorem imo1988_q6 {a b : ℕ} (h : a * b + 1 ∣ a ^ 2 + b ^ 2) :
   · -- Show the descent step.
     intro x y hx x_lt_y _ _ z h_root _ hV₀
     constructor
-    · have hpos : z * z + x * x > 0 := by
+    · have hpos : 0 < z * z + x * x := by
         apply add_pos_of_nonneg_of_pos
         · apply mul_self_nonneg
         · apply mul_pos <;> exact mod_cast hx
@@ -240,8 +240,8 @@ theorem imo1988_q6 {a b : ℕ} (h : a * b + 1 ∣ a ^ 2 + b ^ 2) :
         rw [← sub_eq_zero, ← h_root]
         ring
       rw [hzx] at hpos
-      replace hpos : z * x + 1 > 0 := pos_of_mul_pos_left hpos (Int.ofNat_zero_le k)
-      replace hpos : z * x ≥ 0 := Int.le_of_lt_add_one hpos
+      replace hpos : 0 < z * x + 1 := pos_of_mul_pos_left hpos (Int.ofNat_zero_le k)
+      replace hpos : 0 ≤ z * x := Int.le_of_lt_add_one hpos
       apply nonneg_of_mul_nonneg_left hpos (mod_cast hx)
     · contrapose! hV₀ with x_lt_z
       apply ne_of_gt

--- a/Archive/Imo/Imo2005Q3.lean
+++ b/Archive/Imo/Imo2005Q3.lean
@@ -25,7 +25,7 @@ and then making use of `xyz ≥ 1` to show `(x^5-x^2)/(x^3*(x^2+y^2+z^2)) ≥ (x
 
 namespace Imo2005Q3
 
-theorem key_insight (x y z : ℝ) (hx : x > 0) (hy : y > 0) (hz : z > 0) (h : x * y * z ≥ 1) :
+theorem key_insight (x y z : ℝ) (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) (h : x * y * z ≥ 1) :
     (x ^ 5 - x ^ 2) / (x ^ 5 + y ^ 2 + z ^ 2) ≥ (x ^ 2 - y * z) / (x ^ 2 + y ^ 2 + z ^ 2) := by
   have key :
     (x ^ 5 - x ^ 2) / (x ^ 5 + y ^ 2 + z ^ 2) -
@@ -48,7 +48,7 @@ end Imo2005Q3
 
 open Imo2005Q3
 
-theorem imo2005_q3 (x y z : ℝ) (hx : x > 0) (hy : y > 0) (hz : z > 0) (h : x * y * z ≥ 1) :
+theorem imo2005_q3 (x y z : ℝ) (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) (h : x * y * z ≥ 1) :
     (x ^ 5 - x ^ 2) / (x ^ 5 + y ^ 2 + z ^ 2) + (y ^ 5 - y ^ 2) / (y ^ 5 + z ^ 2 + x ^ 2) +
         (z ^ 5 - z ^ 2) / (z ^ 5 + x ^ 2 + y ^ 2) ≥
       0 := by

--- a/Archive/Imo/Imo2008Q2.lean
+++ b/Archive/Imo/Imo2008Q2.lean
@@ -64,14 +64,14 @@ def rationalSolutions :=
 
 theorem imo2008_q2b : Set.Infinite rationalSolutions := by
   let W := {s : ℚ × ℚ × ℚ | ∃ x y z : ℚ, s = (x, y, z) ∧
-    ∃ t : ℚ, t > 0 ∧ x = -(t + 1) / t ^ 2 ∧ y = t / (t + 1) ^ 2 ∧ z = -t * (t + 1)}
+    ∃ t : ℚ, 0 < t ∧ x = -(t + 1) / t ^ 2 ∧ y = t / (t + 1) ^ 2 ∧ z = -t * (t + 1)}
   have hW_sub_S : W ⊆ rationalSolutions := by
     intro s hs_in_W
     rw [rationalSolutions]
     simp only [Set.mem_setOf_eq] at hs_in_W ⊢
     rcases hs_in_W with ⟨x, y, z, h₁, t, ht_gt_zero, hx_t, hy_t, hz_t⟩
     use x, y, z
-    have key_gt_zero : t ^ 2 + t + 1 > 0 := by linarith [pow_pos ht_gt_zero 2, ht_gt_zero]
+    have key_gt_zero : 0 < t ^ 2 + t + 1 := by linarith [pow_pos ht_gt_zero 2, ht_gt_zero]
     have h₂ : x ≠ 1 := by rw [hx_t]; field_simp; linarith [key_gt_zero]
     have h₃ : y ≠ 1 := by rw [hy_t]; field_simp; linarith [key_gt_zero]
     have h₄ : z ≠ 1 := by rw [hz_t]; linarith [key_gt_zero]

--- a/Archive/Imo/Imo2008Q4.lean
+++ b/Archive/Imo/Imo2008Q4.lean
@@ -36,7 +36,7 @@ end Imo2008Q4
 
 open Imo2008Q4
 
-theorem imo2008_q4 (f : ℝ → ℝ) (H₁ : ∀ x > 0, f x > 0) :
+theorem imo2008_q4 (f : ℝ → ℝ) (H₁ : ∀ x > 0, 0 < f x) :
     (∀ w x y z : ℝ, 0 < w → 0 < x → 0 < y → 0 < z → w * x = y * z →
       (f w ^ 2 + f x ^ 2) / (f (y ^ 2) + f (z ^ 2)) = (w ^ 2 + x ^ 2) / (y ^ 2 + z ^ 2)) ↔
     (∀ x > 0, f x = x) ∨ ∀ x > 0, f x = 1 / x := by

--- a/Archive/Imo/Imo2008Q4.lean
+++ b/Archive/Imo/Imo2008Q4.lean
@@ -73,7 +73,7 @@ theorem imo2008_q4 (f : ℝ → ℝ) (H₁ : ∀ x > 0, 0 < f x) :
   -- f(a) ≠ 1/a, f(a) = a
   obtain hfb₂ := Or.resolve_left (h₃ b hb) hfb₁
   -- f(b) ≠ b, f(b) = 1/b
-  have hab : a * b > 0 := mul_pos ha hb
+  have hab : 0 < a * b := mul_pos ha hb
   have habss : a * b = sqrt (a * b) * sqrt (a * b) := (mul_self_sqrt (le_of_lt hab)).symm
   specialize H₂ a b (sqrt (a * b)) (sqrt (a * b)) ha hb (sqrt_pos.mpr hab) (sqrt_pos.mpr hab) habss
   rw [sq_sqrt (le_of_lt hab), ← two_mul (f (a * b)), ← two_mul (a * b)] at H₂

--- a/Archive/Imo/Imo2011Q5.lean
+++ b/Archive/Imo/Imo2011Q5.lean
@@ -43,7 +43,7 @@ theorem imo2011_q5 (f : ℤ → ℤ) (hpos : ∀ n : ℤ, 0 < f n) (hdvd : ∀ m
       rw [← dvd_neg, neg_sub]
       exact hdvd m n
     have h_d_eq_zero : d = 0 := by
-      obtain hd | hd | hd : d > 0 ∨ d = 0 ∨ d < 0 := trichotomous d 0
+      obtain hd | hd | hd : 0 < d ∨ d = 0 ∨ d < 0 := trichotomous d 0
       · -- d > 0
         have h₁ : f n ≤ d := le_of_dvd hd h_fn_dvd_d
         have h₂ : ¬f n ≤ d := not_le.mpr h_d_lt_fn

--- a/Archive/Imo/Imo2019Q4.lean
+++ b/Archive/Imo/Imo2019Q4.lean
@@ -35,7 +35,7 @@ open Finset multiplicity
 
 namespace Imo2019Q4
 
-theorem upper_bound {k n : ℕ} (hk : k > 0)
+theorem upper_bound {k n : ℕ} (hk : 0 < k)
     (h : (k ! : ℤ) = ∏ i in range n, ((2:ℤ) ^ n - (2:ℤ) ^ i)) : n < 6 := by
   have h2 : ∑ i in range n, i < k := by
     suffices multiplicity 2 (k ! : ℤ) = ↑(∑ i in range n, i : ℕ) by

--- a/Archive/Imo/Imo2019Q4.lean
+++ b/Archive/Imo/Imo2019Q4.lean
@@ -80,7 +80,7 @@ theorem upper_bound {k n : ℕ} (hk : k > 0)
 
 end Imo2019Q4
 
-theorem imo2019_q4 {k n : ℕ} (hk : k > 0) (hn : n > 0) :
+theorem imo2019_q4 {k n : ℕ} (hk : 0 < k) (hn : 0 < n) :
     (k ! : ℤ) = ∏ i in range n, ((2:ℤ) ^ n - (2:ℤ) ^ i) ↔ (k, n) = (1, 1) ∨ (k, n) = (3, 2) := by
   -- The implication `←` holds.
   constructor

--- a/Archive/Wiedijk100Theorems/AreaOfACircle.lean
+++ b/Archive/Wiedijk100Theorems/AreaOfACircle.lean
@@ -109,7 +109,7 @@ theorem area_disc : volume (disc r) = NNReal.pi * r ^ 2 := by
               ((hasDerivAt_const x (r : ℝ)⁻¹).mul (hasDerivAt_id' x)))).add
         ((hasDerivAt_id' x).mul ((((hasDerivAt_id' x).pow 2).const_sub ((r : ℝ) ^ 2)).sqrt _))
       using 1
-    · have h₁ : (r:ℝ) ^ 2 - x ^ 2 > 0 := sub_pos_of_lt (sq_lt_sq' hx1 hx2)
+    · have h₁ : 0 < (r:ℝ) ^ 2 - x ^ 2 := sub_pos_of_lt (sq_lt_sq' hx1 hx2)
       have h : sqrt ((r:ℝ) ^ 2 - x ^ 2) ^ 3 = ((r:ℝ) ^ 2 - x ^ 2) * sqrt ((r: ℝ) ^ 2 - x ^ 2) := by
         rw [pow_three, ← mul_assoc, mul_self_sqrt (by positivity)]
       field_simp

--- a/Archive/Wiedijk100Theorems/BallotProblem.lean
+++ b/Archive/Wiedijk100Theorems/BallotProblem.lean
@@ -355,7 +355,7 @@ theorem ballot_problem' :
       (countedSequence_finite p (q + 1)) (countedSequence_nonempty _ _)
     haveI := condCount_isProbabilityMeasure
       (countedSequence_finite (p + 1) q) (countedSequence_nonempty _ _)
-    have h₃ : p + 1 + (q + 1) > 0 := Nat.add_pos_left (Nat.succ_pos _) _
+    have h₃ : 0 < p + 1 + (q + 1) := Nat.add_pos_left (Nat.succ_pos _) _
     rw [← condCount_add_compl_eq {l : List ℤ | l.headI = 1} _ (countedSequence_finite _ _),
       first_vote_pos _ _ h₃, first_vote_neg _ _ h₃, ballot_pos, ballot_neg _ _ qp]
     rw [ENNReal.toReal_add, ENNReal.toReal_mul, ENNReal.toReal_mul, ← Nat.cast_add,

--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -192,7 +192,7 @@ theorem lift_inlAlgHom_eps :
 /-- Show DualNumber with values x and y as an "x + y*ε" string -/
 instance instRepr [Repr R] : Repr (DualNumber R) where
   reprPrec f p :=
-    (if p > 65 then (Std.Format.bracket "(" · ")") else (·)) <|
+    (if 65 < p then (Std.Format.bracket "(" · ")") else (·)) <|
       reprPrec f.fst 65 ++ " + " ++ reprPrec f.snd 70 ++ "*ε"
 
 end DualNumber

--- a/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
+++ b/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
@@ -220,7 +220,7 @@ lemma series_ratio_test {f : ℕ → β} (n : ℕ) (r : α) (hr0 : 0 ≤ r) (hr1
   induction' k with k ih generalizing m n
   · rw [hk, Nat.zero_add, mul_right_comm, inv_pow _ _, ← div_eq_mul_inv, mul_div_cancel_right₀]
     positivity
-  · have kn : k + n.succ ≥ n.succ := by
+  · have kn : n.succ ≤ k + n.succ := by
       rw [← zero_add n.succ]; exact add_le_add (Nat.zero_le _) (by simp)
     erw [hk, Nat.succ_add, pow_succ r, ← mul_assoc]
     refine

--- a/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
+++ b/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
@@ -63,7 +63,7 @@ theorem _root_.cauchy_product (ha : IsCauSeq abs fun m ↦ ∑ n in range m, abv
   let ⟨P, hP⟩ := ha.bounded
   let ⟨Q, hQ⟩ := hb.bounded
   have hP0 : 0 < P := lt_of_le_of_lt (abs_nonneg _) (hP 0)
-  have hPε0 : 0 < ε / (2 * P) := div_pos ε0 (mul_pos (show (2 : α) > 0 by norm_num) hP0)
+  have hPε0 : 0 < ε / (2 * P) := div_pos ε0 (mul_pos (show 0 < (2 : α) by norm_num) hP0)
   let ⟨N, hN⟩ := hb.cauchy₂ hPε0
   have hQε0 : 0 < ε / (4 * Q) :=
     div_pos ε0 (mul_pos (show (0 : α) < 4 by norm_num) (lt_of_le_of_lt (abv_nonneg _ _) (hQ 0)))
@@ -157,7 +157,7 @@ lemma of_decreasing_bounded (f : ℕ → α) {a : α} {m : ℕ} (ham : ∀ n ≥
                 exact add_lt_add_of_le_of_lt hk (lt_of_le_of_lt hk (lt_add_of_pos_right _ ε0))))
         (neg_le.2 <| abs_neg (f n) ▸ le_abs_self _)⟩
   let l := Nat.find h
-  have hl : ∀ n : ℕ, n ≥ m → f n > a - l • ε := Nat.find_spec h
+  have hl : ∀ n ≥ m, a - l • ε < f n := Nat.find_spec h
   have hl0 : l ≠ 0 := fun hl0 ↦
     not_lt_of_ge (ham m le_rfl)
       (lt_of_lt_of_le (by have := hl m (le_refl m); simpa [hl0] using this) (le_abs_self (f m)))

--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -882,11 +882,11 @@ theorem neg_of_mul_neg_right (h : a * b < 0) (ha : 0 ≤ a) : b < 0 :=
 #align neg_of_mul_neg_right neg_of_mul_neg_right
 
 theorem nonpos_of_mul_nonpos_left (h : a * b ≤ 0) (hb : 0 < b) : a ≤ 0 :=
-  le_of_not_gt fun ha : a > 0 => (mul_pos ha hb).not_le h
+  le_of_not_gt fun ha : 0 < a => (mul_pos ha hb).not_le h
 #align nonpos_of_mul_nonpos_left nonpos_of_mul_nonpos_left
 
 theorem nonpos_of_mul_nonpos_right (h : a * b ≤ 0) (ha : 0 < a) : b ≤ 0 :=
-  le_of_not_gt fun hb : b > 0 => (mul_pos ha hb).not_le h
+  le_of_not_gt fun hb : 0 < b => (mul_pos ha hb).not_le h
 #align nonpos_of_mul_nonpos_right nonpos_of_mul_nonpos_right
 
 @[simp]

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -1306,7 +1306,7 @@ protected instance repr [Repr R] [DecidableEq R] : Repr R[X] :=
     | [(tprec, t)] => if tprec ≤ prec then Lean.Format.paren t else t
     | ts =>
       -- multiple terms, use `+` precedence
-      (if prec ≥ 65 then Lean.Format.paren else id)
+      (if 65 ≤ prec then Lean.Format.paren else id)
       (Lean.Format.fill
         (Lean.Format.joinSep (ts.map Prod.snd) (" +" ++ Lean.Format.line)))⟩
 #align polynomial.has_repr Polynomial.repr

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -1303,7 +1303,7 @@ protected instance repr [Repr R] [DecidableEq R] : Repr R[X] :=
       (p.support.sort (· ≤ ·));
     match termPrecAndReprs with
     | [] => "0"
-    | [(tprec, t)] => if trec ≤ prec then Lean.Format.paren t else t
+    | [(tprec, t)] => if tprec ≤ prec then Lean.Format.paren t else t
     | ts =>
       -- multiple terms, use `+` precedence
       (if prec ≥ 65 then Lean.Format.paren else id)

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -1303,7 +1303,7 @@ protected instance repr [Repr R] [DecidableEq R] : Repr R[X] :=
       (p.support.sort (· ≤ ·));
     match termPrecAndReprs with
     | [] => "0"
-    | [(tprec, t)] => if prec ≥ tprec then Lean.Format.paren t else t
+    | [(tprec, t)] => if trec ≤ prec then Lean.Format.paren t else t
     | ts =>
       -- multiple terms, use `+` precedence
       (if prec ≥ 65 then Lean.Format.paren else id)

--- a/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
@@ -602,8 +602,8 @@ theorem ne_zero_of_degree_gt {n : WithBot ℕ} (h : n < degree p) : p ≠ 0 :=
 
 theorem ne_zero_of_degree_ge_degree (hpq : p.degree ≤ q.degree) (hp : p ≠ 0) : q ≠ 0 :=
   Polynomial.ne_zero_of_degree_gt
-    (lt_of_lt_of_le (bot_lt_iff_ne_bot.mpr (by rwa [Ne, Polynomial.degree_eq_bot])) hpq :
-      q.degree > ⊥)
+    (lt_of_lt_of_le (bot_lt_iff_ne_bot.mpr (by rwa [Ne, Polynomial.degree_eq_bot]))
+      hpq : ⊥ < q.degree)
 #align polynomial.ne_zero_of_degree_ge_degree Polynomial.ne_zero_of_degree_ge_degree
 
 theorem ne_zero_of_natDegree_gt {n : ℕ} (h : n < natDegree p) : p ≠ 0 := fun H => by
@@ -752,7 +752,7 @@ theorem degree_add_eq_of_leadingCoeff_add_ne_zero (h : leadingCoeff p + leadingC
     | Or.inl hlt => by
       rw [degree_add_eq_right_of_degree_lt hlt, max_eq_right_of_lt hlt]
     | Or.inr (Or.inl HEq) =>
-      le_of_not_gt fun hlt : max (degree p) (degree q) > degree (p + q) =>
+      le_of_not_gt fun hlt : degree (p + q) < max (degree p) (degree q) =>
         h <|
           show leadingCoeff p + leadingCoeff q = 0 by
             rw [HEq, max_self] at hlt

--- a/Mathlib/Algebra/Star/CHSH.lean
+++ b/Mathlib/Algebra/Star/CHSH.lean
@@ -157,7 +157,7 @@ we prepare some easy lemmas about √2.
 -- defeated me. Thanks for the rescue from Shing Tak Lam!
 theorem tsirelson_inequality_aux : √2 * √2 ^ 3 = √2 * (2 * (√2)⁻¹ + 4 * ((√2)⁻¹ * 2⁻¹)) := by
   ring_nf
-  rw [mul_inv_cancel (ne_of_gt (Real.sqrt_pos.2 (show (2 : ℝ) > 0 by norm_num)))]
+  rw [mul_inv_cancel (ne_of_gt (Real.sqrt_pos.2 (show 0 < (2 : ℝ) by norm_num)))]
   convert congr_arg (· ^ 2) (@Real.sq_sqrt 2 (by norm_num)) using 1 <;>
     (try simp only [← pow_mul]) <;> norm_num
 #align tsirelson_inequality.tsirelson_inequality_aux TsirelsonInequality.tsirelson_inequality_aux

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -1347,7 +1347,7 @@ theorem changeOrigin_eval (h : (‖x‖₊ + ‖y‖₊ : ℝ≥0∞) < p.radius
 #align formal_multilinear_series.change_origin_eval FormalMultilinearSeries.changeOrigin_eval
 
 /-- Power series terms are analytic as we vary the origin -/
-theorem analyticAt_changeOrigin (p : FormalMultilinearSeries 𝕜 E F) (rp : p.radius > 0) (n : ℕ) :
+theorem analyticAt_changeOrigin (p : FormalMultilinearSeries 𝕜 E F) (rp : 0 < p.radius) (n : ℕ) :
     AnalyticAt 𝕜 (fun x ↦ p.changeOrigin x n) 0 :=
   (FormalMultilinearSeries.hasFPowerSeriesOnBall_changeOrigin p n rp).analyticAt
 

--- a/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
+++ b/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
@@ -243,7 +243,7 @@ theorem cauchy_map_of_uniformCauchySeqOn_fderiv {s : Set E} (hs : IsOpen s) (h's
   have st_nonempty : (s ∩ t).Nonempty := ⟨x₀, hx₀, ⟨hx₀, hfg⟩⟩
   suffices H : closure t ∩ s ⊆ t from h's.subset_of_closure_inter_subset open_t st_nonempty H
   rintro x ⟨xt, xs⟩
-  obtain ⟨ε, εpos, hε⟩ : ∃ (ε : ℝ), ε > 0 ∧ Metric.ball x ε ⊆ s := Metric.isOpen_iff.1 hs x xs
+  obtain ⟨ε, εpos, hε⟩ : ∃ (ε : ℝ), 0 < ε ∧ Metric.ball x ε ⊆ s := Metric.isOpen_iff.1 hs x xs
   obtain ⟨y, yt, hxy⟩ : ∃ (y : E), y ∈ t ∧ dist x y < ε / 2 :=
     Metric.mem_closure_iff.1 xt _ (half_pos εpos)
   have B : Metric.ball y (ε / 2) ⊆ Metric.ball x ε := by

--- a/Mathlib/Analysis/Complex/Hadamard.lean
+++ b/Mathlib/Analysis/Complex/Hadamard.lean
@@ -95,11 +95,11 @@ lemma sSupNormIm_nonneg (x : ℝ) : 0 ≤ sSupNormIm f x := by
 
 /-- `sSup` of `norm` translated by `ε > 0` is positive applied to the image of `f` on the
 vertical line `re z = x` -/
-lemma sSupNormIm_eps_pos {ε : ℝ} (hε : ε > 0) (x : ℝ) : 0 < ε + sSupNormIm f x := by
+lemma sSupNormIm_eps_pos {ε : ℝ} (hε : 0 < ε) (x : ℝ) : 0 < ε + sSupNormIm f x := by
    linarith [sSupNormIm_nonneg f x]
 
 /-- Useful rewrite for the absolute value of `invInterpStrip`-/
-lemma abs_invInterpStrip {ε : ℝ} (hε : ε > 0) :
+lemma abs_invInterpStrip {ε : ℝ} (hε : 0 < ε) :
     abs (invInterpStrip f z ε) =
     (ε + sSupNormIm f 0) ^ (z.re - 1) * (ε + sSupNormIm f 1) ^ (-z.re) := by
   simp only [invInterpStrip, map_mul]
@@ -108,7 +108,7 @@ lemma abs_invInterpStrip {ε : ℝ} (hε : ε > 0) :
   simp only [sub_re, one_re, neg_re]
 
 /-- The function `invInterpStrip` is `diffContOnCl`. -/
-lemma diffContOnCl_invInterpStrip {ε : ℝ} (hε : ε > 0) :
+lemma diffContOnCl_invInterpStrip {ε : ℝ} (hε : 0 < ε) :
     DiffContOnCl ℂ (fun z ↦ invInterpStrip f z ε) (verticalStrip 0 1) := by
   apply Differentiable.diffContOnCl
   apply Differentiable.mul
@@ -132,13 +132,13 @@ lemma norm_le_sSupNormIm (f : ℂ → E) (z : ℂ) (hD : z ∈ verticalClosedStr
     simp only [mem_preimage, mem_singleton]
 
 /-- Alternative version of `norm_le_sSupNormIm` with a strict inequality and a positive `ε`. -/
-lemma norm_lt_sSupNormIm_eps (f : ℂ → E) (ε : ℝ) (hε : ε > 0) (z : ℂ)
+lemma norm_lt_sSupNormIm_eps (f : ℂ → E) (ε : ℝ) (hε : 0 < ε) (z : ℂ)
     (hD : z ∈ verticalClosedStrip 0 1) (hB : BddAbove ((norm ∘ f) '' (verticalClosedStrip 0 1))) :
     ‖f z‖ < ε + sSupNormIm f (z.re) :=
   lt_add_of_pos_of_le hε (norm_le_sSupNormIm f z hD hB)
 
 /-- When the function `f` is bounded above on a vertical strip, then so is `F`. -/
-lemma F_BddAbove (f : ℂ → E) (ε : ℝ) (hε : ε > 0)
+lemma F_BddAbove (f : ℂ → E) (ε : ℝ) (hε : 0 < ε)
     (hB : BddAbove ((norm ∘ f) '' (verticalClosedStrip 0 1))) :
     BddAbove ((norm ∘ (F f ε)) '' (verticalClosedStrip 0 1)) := by
  -- Rewriting goal
@@ -178,7 +178,7 @@ lemma F_BddAbove (f : ℂ → E) (ε : ℝ) (hε : ε > 0)
         (le_of_lt hM1_one) (neg_le_neg_iff.mpr hset.2)]
 
 /-- Proof that `F` is bounded by one one the edges. -/
-lemma F_edge_le_one (f : ℂ → E) (ε : ℝ) (hε : ε > 0) (z : ℂ)
+lemma F_edge_le_one (f : ℂ → E) (ε : ℝ) (hε : 0 < ε) (z : ℂ)
     (hB : BddAbove ((norm ∘ f) '' (verticalClosedStrip 0 1))) (hz : z ∈ re ⁻¹' {0, 1}) :
     ‖F f ε z‖ ≤ 1 := by
   simp only [F, norm_smul, norm_eq_abs, map_mul, abs_cpow_eq_rpow_re_of_pos,
@@ -292,7 +292,7 @@ lemma diffContOnCl_interpStrip :
       · apply differentiableAt_id'
       · left; simp only [Ne, ofReal_eq_zero]; rwa [eq_comm]
 
-lemma norm_le_interpStrip_of_mem_verticalClosedStrip_eps (ε : ℝ) (hε : ε > 0) (z : ℂ)
+lemma norm_le_interpStrip_of_mem_verticalClosedStrip_eps (ε : ℝ) (hε : 0 < ε) (z : ℂ)
     (hB : BddAbove ((norm ∘ f) '' (verticalClosedStrip 0 1)))
     (hd : DiffContOnCl ℂ f (verticalStrip 0 1)) (hz : z ∈ verticalClosedStrip 0 1) :
     ‖f z‖ ≤  ‖((ε + sSupNormIm f 0) ^ (1-z) * (ε + sSupNormIm f 1) ^ z : ℂ)‖ := by

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -226,7 +226,7 @@ theorem denom_ne_zero (g : GL(2, ℝ)⁺) (z : ℍ) : denom g z ≠ 0 := by
       Complex.ofReal_eq_zero] at H
     rw [Matrix.det_fin_two (↑ₘg : Matrix (Fin 2) (Fin 2) ℝ)] at DET
     simp only [H, H1, mul_zero, sub_zero, lt_self_iff_false] at DET
-  · change z.im > 0 at hz
+  · change 0 < z.im at hz
     linarith
 #align upper_half_plane.denom_ne_zero UpperHalfPlane.denom_ne_zero
 

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -305,7 +305,7 @@ theorem norm_eq_iInf_iff_real_inner_eq_zero (K : Submodule ℝ F) {u : F} {v : F
           simp only [w', add_neg_cancel_right, sub_eq_add_neg]
         rw [h₂] at h₁
         exact h₁
-      have ge : ⟪u - v, w⟫_ℝ ≥ 0 := by
+      have ge : 0 ≤ ⟪u - v, w⟫_ℝ := by
         let w'' := -w + v
         have : w'' ∈ K := Submodule.add_mem _ (Submodule.neg_mem _ hw) hv
         have h₁ := h w'' this

--- a/Mathlib/Analysis/Normed/Group/ControlledClosure.lean
+++ b/Mathlib/Analysis/Normed/Group/ControlledClosure.lean
@@ -57,7 +57,7 @@ theorem controlled_closure_of_complete {f : NormedAddGroupHom G H} {K : AddSubgr
   set s : ℕ → G := fun n => ∑ k in range (n + 1), u k
   have : CauchySeq s := by
     apply NormedAddCommGroup.cauchy_series_of_le_geometric'' (by norm_num) one_half_lt_one
-    · rintro n (hn : n ≥ 1)
+    · rintro n (hn : 1 ≤ n)
       calc
         ‖u n‖ ≤ C * ‖v n‖ := hnorm_u n
         _ ≤ C * b n := by gcongr; exact (hv _ <| Nat.succ_le_iff.mp hn).le

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -458,7 +458,7 @@ on `[x₀, r * x₀)` and if `P` for `[x₀, r^n * x₀)` implies `P` for `[r^n 
 then `P` is true for all `x ≥ x₀`. -/
 lemma Real.induction_Ico_mul {P : ℝ → Prop} (x₀ r : ℝ) (hr : 1 < r) (hx₀ : 0 < x₀)
     (base : ∀ x ∈ Set.Ico x₀ (r * x₀), P x)
-    (step : ∀ n : ℕ, n ≥ 1 → (∀ z ∈ Set.Ico x₀ (r ^ n * x₀), P z) →
+    (step : ∀ (n : ℕ) ≥ 1, (∀ z ∈ Set.Ico x₀ (r ^ n * x₀), P z) →
       (∀ z ∈ Set.Ico (r ^ n * x₀) (r ^ (n+1) * x₀), P z)) :
     ∀ x ≥ x₀, P x := by
   suffices ∀ n : ℕ, ∀ x ∈ Set.Ico x₀ (r ^ (n + 1) * x₀), P x by

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -458,7 +458,7 @@ on `[x₀, r * x₀)` and if `P` for `[x₀, r^n * x₀)` implies `P` for `[r^n 
 then `P` is true for all `x ≥ x₀`. -/
 lemma Real.induction_Ico_mul {P : ℝ → Prop} (x₀ r : ℝ) (hr : 1 < r) (hx₀ : 0 < x₀)
     (base : ∀ x ∈ Set.Ico x₀ (r * x₀), P x)
-    (step : ∀ (n : ℕ) ≥ 1, (∀ z ∈ Set.Ico x₀ (r ^ n * x₀), P z) →
+    (step : ∀ (n : ℕ), 1 ≤ n → (∀ z ∈ Set.Ico x₀ (r ^ n * x₀), P z) →
       (∀ z ∈ Set.Ico (r ^ n * x₀) (r ^ (n+1) * x₀), P z)) :
     ∀ x ≥ x₀, P x := by
   suffices ∀ n : ℕ, ∀ x ∈ Set.Ico x₀ (r ^ (n + 1) * x₀), P x by

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -947,7 +947,7 @@ theorem sinOrderIso_apply (x : Icc (-(π / 2)) (π / 2)) : sinOrderIso x = ⟨si
 @[simp]
 theorem tan_pi_div_four : tan (π / 4) = 1 := by
   rw [tan_eq_sin_div_cos, cos_pi_div_four, sin_pi_div_four]
-  have h : √2 / 2 > 0 := by positivity
+  have h : 0 < √2 / 2 := by positivity
   exact div_self (ne_of_gt h)
 #align real.tan_pi_div_four Real.tan_pi_div_four
 

--- a/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
@@ -167,7 +167,7 @@ theorem exists_ne_odd_degree_of_exists_odd_degree [Fintype V] [DecidableRel G.Ad
     (h : Odd (G.degree v)) : ∃ w : V, w ≠ v ∧ Odd (G.degree w) := by
   haveI := Classical.decEq V
   rcases G.odd_card_odd_degree_vertices_ne v h with ⟨k, hg⟩
-  have hg' : (filter (fun w : V => w ≠ v ∧ Odd (G.degree w)) univ).card > 0 := by
+  have hg' : 0 < (filter (fun w : V => w ≠ v ∧ Odd (G.degree w)) univ).card := by
     rw [hg]
     apply Nat.succ_pos
   rcases card_pos.mp hg' with ⟨w, hw⟩

--- a/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
@@ -103,7 +103,7 @@ theorem lapMatrix_toLinearMap₂'_apply'_eq_zero_iff_forall_adj [LinearOrderedFi
   constructor
   · intro h i j
     by_contra! hn
-    suffices hc : toLinearMap₂' (G.lapMatrix α) x x > 0 from gt_irrefl _ (h ▸ hc)
+    suffices hc : 0 < toLinearMap₂' (G.lapMatrix α) x x from gt_irrefl _ (h ▸ hc)
     rw [lapMatrix_toLinearMap₂']
     refine div_pos (sum_pos' (fun k _ ↦ sum_nonneg' (fun l ↦ ?_)) ?_) two_pos
     · exact ite_nonneg (sq_nonneg _) le_rfl

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -951,7 +951,7 @@ numbers are represented.
 -/
 unsafe instance instRepr : Repr ℂ where
   reprPrec f p :=
-    (if p > 65 then (Std.Format.bracket "(" · ")") else (·)) <|
+    (if 65 < p then (Std.Format.bracket "(" · ")") else (·)) <|
       reprPrec f.re 65 ++ " + " ++ reprPrec f.im 70 ++ "*I"
 
 end Complex

--- a/Mathlib/Data/FP/Basic.lean
+++ b/Mathlib/Data/FP/Basic.lean
@@ -221,7 +221,7 @@ unsafe def ofRat : RMode → ℚ → Float
       if r = toRat _ hf then high
       else
         if lf : low.isFinite then
-          if r - toRat _ lf > toRat _ hf - r then high
+          if toRat _ hf - r < r - toRat _ lf then high
           else
             if r - toRat _ lf < toRat _ hf - r then low
             else

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -3575,7 +3575,7 @@ def proveFinsetNonempty {u : Level} {α : Q(Type u)} (s : Q(Finset $α)) :
     catch _ => return none
   -- Fail if there are open goals remaining, this serves as an extra check for the
   -- Aesop configuration option `terminal := true`.
-  if remainingGoals.size > 0 then return none
+  if 0 < remainingGoals.size then return none
   Lean.getExprMVarAssignment? mvar
 
 end Mathlib.Meta

--- a/Mathlib/Data/Finsupp/Notation.lean
+++ b/Mathlib/Data/Finsupp/Notation.lean
@@ -71,6 +71,6 @@ unsafe instance instRepr {α β} [Repr α] [Repr β] [Zero β] : Repr (α →₀
       let ret := "fun₀" ++
         Std.Format.join (f.support.val.unquot.map <|
           fun a => " | " ++ repr a ++ " => " ++ repr (f a))
-      if p ≥ leadPrec then Format.paren ret else ret
+      if leadPrec ≤ p then Format.paren ret else ret
 
 end Finsupp

--- a/Mathlib/Data/Nat/Dist.lean
+++ b/Mathlib/Data/Nat/Dist.lean
@@ -116,7 +116,7 @@ theorem dist_succ_succ {i j : Nat} : dist (succ i) (succ j) = dist i j := by
 theorem dist_pos_of_ne {i j : Nat} : i ≠ j → 0 < dist i j := fun hne =>
   Nat.ltByCases
     (fun h : i < j => by rw [dist_eq_sub_of_le (le_of_lt h)]; apply tsub_pos_of_lt h)
-    (fun h : i = j => by contradiction) fun h : i > j => by
+    (fun h : i = j => by contradiction) fun h : j < i => by
     rw [dist_eq_sub_of_le_right (le_of_lt h)]; apply tsub_pos_of_lt h
 #align nat.dist_pos_of_ne Nat.dist_pos_of_ne
 

--- a/Mathlib/Data/Nat/Lattice.lean
+++ b/Mathlib/Data/Nat/Lattice.lean
@@ -98,7 +98,7 @@ theorem nonempty_of_pos_sInf {s : Set ℕ} (h : 0 < sInf s) : s.Nonempty := by
 #align nat.nonempty_of_pos_Inf Nat.nonempty_of_pos_sInf
 
 theorem nonempty_of_sInf_eq_succ {s : Set ℕ} {k : ℕ} (h : sInf s = k + 1) : s.Nonempty :=
-  nonempty_of_pos_sInf (h.symm ▸ succ_pos k : sInf s > 0)
+  nonempty_of_pos_sInf (h.symm ▸ succ_pos k : 0 < sInf s)
 #align nat.nonempty_of_Inf_eq_succ Nat.nonempty_of_sInf_eq_succ
 
 theorem eq_Ici_of_nonempty_of_upward_closed {s : Set ℕ} (hs : s.Nonempty)

--- a/Mathlib/Data/Nat/Parity.lean
+++ b/Mathlib/Data/Nat/Parity.lean
@@ -373,7 +373,7 @@ theorem pow_eq_one_iff_cases : a ^ n = 1 ↔ n = 0 ∨ a = 1 ∨ a = -1 ∧ Even
 theorem pow_eq_neg_pow_iff (hb : b ≠ 0) : a ^ n = -b ^ n ↔ a = -b ∧ Odd n :=
   match n.even_or_odd with
   | .inl he =>
-    suffices a ^ n > -b ^ n by simpa [he] using this.ne'
+    suffices -b ^ n < a ^ n by simpa [he] using this.ne'
     lt_of_lt_of_le (by simp [he.pow_pos hb]) (he.pow_nonneg _)
   | .inr ho => by
     simp only [ho, and_true, ← ho.neg_pow, (ho.strictMono_pow (R := R)).injective.eq_iff]

--- a/Mathlib/Data/Nat/Upto.lean
+++ b/Mathlib/Data/Nat/Upto.lean
@@ -39,7 +39,6 @@ namespace Upto
 
 variable {p : ℕ → Prop}
 
-set_option linter.geOrGt false in
 /-- Lift the "greater than" relation on natural numbers to `Nat.Upto`. -/
 protected def GT (p) (x y : Upto p) : Prop :=
   x.1 > y.1

--- a/Mathlib/Data/Nat/Upto.lean
+++ b/Mathlib/Data/Nat/Upto.lean
@@ -39,6 +39,7 @@ namespace Upto
 
 variable {p : ℕ → Prop}
 
+set_option linter.geOrGt false in
 /-- Lift the "greater than" relation on natural numbers to `Nat.Upto`. -/
 protected def GT (p) (x y : Upto p) : Prop :=
   x.1 > y.1

--- a/Mathlib/Data/Ordmap/Ordset.lean
+++ b/Mathlib/Data/Ordmap/Ordset.lean
@@ -973,7 +973,6 @@ theorem Bounded.mem_lt : ∀ {t o} {x : α}, Bounded t o x → All (· < x) t
     ⟨h₁.mem_lt.imp fun _ h => lt_trans h h₂.to_lt, h₂.to_lt, h₂.mem_lt⟩
 #align ordnode.bounded.mem_lt Ordnode.Bounded.mem_lt
 
-set_option linter.geOrGt false in
 theorem Bounded.mem_gt : ∀ {t o} {x : α}, Bounded t x o → All (· > x) t
   | nil, _, _, _ => ⟨⟩
   | node _ _ _ _, _, _, ⟨h₁, h₂⟩ => ⟨h₁.mem_gt, h₁.to_lt, h₂.mem_gt.imp fun _ => lt_trans h₁.to_lt⟩
@@ -985,7 +984,6 @@ theorem Bounded.of_lt :
   | node _ _ _ _, _, _, _, ⟨h₁, h₂⟩, _, ⟨_, al₂, al₃⟩ => ⟨h₁, h₂.of_lt al₂ al₃⟩
 #align ordnode.bounded.of_lt Ordnode.Bounded.of_lt
 
-set_option linter.geOrGt false in
 theorem Bounded.of_gt :
     ∀ {t o₁ o₂} {x : α}, Bounded t o₁ o₂ → Bounded nil x o₂ → All (· > x) t → Bounded t x o₂
   | nil, _, _, _, _, hn, _ => hn
@@ -1052,7 +1050,6 @@ theorem Valid'.of_lt {t : Ordnode α} {x : α} {o₁ o₂} (H : Valid' o₁ t o�
   ⟨H.1.of_lt h₁ h₂, H.2, H.3⟩
 #align ordnode.valid'.of_lt Ordnode.Valid'.of_lt
 
-set_option linter.geOrGt false in
 theorem Valid'.of_gt {t : Ordnode α} {x : α} {o₁ o₂} (H : Valid' o₁ t o₂) (h₁ : Bounded nil x o₂)
     (h₂ : All (· > x) t) : Valid' x t o₂ :=
   ⟨H.1.of_gt h₁ h₂, H.2, H.3⟩
@@ -1422,7 +1419,6 @@ theorem eraseMax.valid {t} (h : @Valid α _ t) : Valid (eraseMax t) := by
   rw [Valid.dual_iff, dual_eraseMax]; exact eraseMin.valid h.dual
 #align ordnode.erase_max.valid Ordnode.eraseMax.valid
 
-set_option linter.geOrGt false in
 theorem Valid'.glue_aux {l r o₁ o₂} (hl : Valid' o₁ l o₂) (hr : Valid' o₁ r o₂)
     (sep : l.All fun x => r.All fun y => x < y) (bal : BalancedSz (size l) (size r)) :
     Valid' o₁ (@glue α l r) o₂ ∧ size (glue l r) = size l + size r := by

--- a/Mathlib/Data/PNat/Basic.lean
+++ b/Mathlib/Data/PNat/Basic.lean
@@ -377,7 +377,7 @@ theorem mod_le (m k : ℕ+) : mod m k ≤ m ∧ mod m k ≤ k := by
   change (mod m k : ℕ) ≤ (m : ℕ) ∧ (mod m k : ℕ) ≤ (k : ℕ)
   rw [mod_coe]
   split_ifs with h
-  · have hm : (m : ℕ) > 0 := m.pos
+  · have hm : 0 < (m : ℕ) := m.pos
     rw [← Nat.mod_add_div (m : ℕ) (k : ℕ), h, zero_add] at hm ⊢
     by_cases h₁ : (m : ℕ) / (k : ℕ) = 0
     · rw [h₁, mul_zero] at hm

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -110,11 +110,11 @@ namespace UInt8
 
 /-- Is this an uppercase ASCII letter? -/
 def isUpper (c : UInt8) : Bool :=
-  c ≥ 65 && c ≤ 90
+  65 ≤ c && c ≤ 90
 
 /-- Is this a lowercase ASCII letter? -/
 def isLower (c : UInt8) : Bool :=
-  c ≥ 97 && c ≤ 122
+  97 ≤ c && c ≤ 122
 
 /-- Is this an alphabetic ASCII character? -/
 def isAlpha (c : UInt8) : Bool :=
@@ -122,7 +122,7 @@ def isAlpha (c : UInt8) : Bool :=
 
 /-- Is this an ASCII digit character? -/
 def isDigit (c : UInt8) : Bool :=
-  c ≥ 48 && c ≤ 57
+  48 ≤ c && c ≤ 57
 
 /-- Is this an alphanumeric ASCII character? -/
 def isAlphanum (c : UInt8) : Bool :=

--- a/Mathlib/GroupTheory/Coxeter/Length.lean
+++ b/Mathlib/GroupTheory/Coxeter/Length.lean
@@ -229,7 +229,7 @@ theorem isReduced_take {ω : List B} (hω : cs.IsReduced ω) (j : ℕ) : cs.IsRe
 theorem isReduced_drop {ω : List B} (hω : cs.IsReduced ω) (j : ℕ) : cs.IsReduced (ω.drop j) :=
   (isReduced_take_and_drop _ hω _).2
 
-theorem not_isReduced_alternatingWord (i i' : B) {m : ℕ} (hM : M i i' ≠ 0) (hm : m > M i i') :
+theorem not_isReduced_alternatingWord (i i' : B) {m : ℕ} (hM : M i i' ≠ 0) (hm : M i i' < m) :
     ¬cs.IsReduced (alternatingWord i i' m) := by
   induction' hm with m _ ih
   · -- Base case; m = M i i' + 1

--- a/Mathlib/MeasureTheory/Constructions/Polish.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish.lean
@@ -478,10 +478,10 @@ theorem measurablySeparable_range_of_disjoint [T2Space α] [MeasurableSpace α]
     apply t2_separation
     exact disjoint_iff_forall_ne.1 h (mem_range_self _) (mem_range_self _)
   letI : MetricSpace (ℕ → ℕ) := metricSpaceNatNat
-  obtain ⟨εx, εxpos, hεx⟩ : ∃ (εx : ℝ), εx > 0 ∧ Metric.ball x εx ⊆ f ⁻¹' u := by
+  obtain ⟨εx, εxpos, hεx⟩ : ∃ (εx : ℝ), 0 < εx ∧ Metric.ball x εx ⊆ f ⁻¹' u := by
     apply Metric.mem_nhds_iff.1
     exact hf.continuousAt.preimage_mem_nhds (u_open.mem_nhds xu)
-  obtain ⟨εy, εypos, hεy⟩ : ∃ (εy : ℝ), εy > 0 ∧ Metric.ball y εy ⊆ g ⁻¹' v := by
+  obtain ⟨εy, εypos, hεy⟩ : ∃ (εy : ℝ), 0 < εy ∧ Metric.ball y εy ⊆ g ⁻¹' v := by
     apply Metric.mem_nhds_iff.1
     exact hg.continuousAt.preimage_mem_nhds (v_open.mem_nhds yv)
   obtain ⟨n, hn⟩ : ∃ n : ℕ, (1 / 2 : ℝ) ^ n < min εx εy :=

--- a/Mathlib/MeasureTheory/Covering/Besicovitch.lean
+++ b/Mathlib/MeasureTheory/Covering/Besicovitch.lean
@@ -1089,7 +1089,7 @@ theorem tendsto_filterAt (μ : Measure α) [SigmaFinite μ] (x : α) :
   intro s hs
   simp only [mem_map]
   obtain ⟨ε, εpos, hε⟩ :
-    ∃ (ε : ℝ), ε > 0 ∧
+    ∃ (ε : ℝ), 0 < ε ∧
       ∀ a : Set α, a ∈ (Besicovitch.vitaliFamily μ).setsAt x → a ⊆ closedBall x ε → a ∈ s :=
     (VitaliFamily.mem_filterAt_iff _).1 hs
   have : Ioc (0 : ℝ) ε ∈ 𝓝[>] (0 : ℝ) := Ioc_mem_nhdsWithin_Ioi ⟨le_rfl, εpos⟩

--- a/Mathlib/MeasureTheory/Covering/Vitali.lean
+++ b/Mathlib/MeasureTheory/Covering/Vitali.lean
@@ -414,7 +414,7 @@ protected def vitaliFamily [MetricSpace α] [MeasurableSpace α] [OpensMeasurabl
     let t : Set (ℝ × α × Set α) :=
       { p | p.2.2 ⊆ closedBall p.2.1 p.1 ∧ μ (closedBall p.2.1 (3 * p.1)) ≤ C * μ p.2.2 ∧
             (interior p.2.2).Nonempty ∧ IsClosed p.2.2 ∧ p.2.2 ∈ f p.2.1 ∧ p.2.1 ∈ s }
-    have A : ∀ x ∈ s, ∀ ε : ℝ, ε > 0 → ∃ p, p ∈ t ∧ p.1 ≤ ε ∧ p.2.1 = x := by
+    have A : ∀ x ∈ s, ∀ (ε : ℝ) > 0, ∃ p, p ∈ t ∧ p.1 ≤ ε ∧ p.2.1 = x := by
       intro x xs ε εpos
       rcases ffine x xs ε εpos with ⟨a, ha, h'a⟩
       rcases fsubset x xs ha with ⟨a_closed, a_int, ⟨r, ar, μr⟩⟩

--- a/Mathlib/MeasureTheory/Covering/Vitali.lean
+++ b/Mathlib/MeasureTheory/Covering/Vitali.lean
@@ -414,7 +414,7 @@ protected def vitaliFamily [MetricSpace α] [MeasurableSpace α] [OpensMeasurabl
     let t : Set (ℝ × α × Set α) :=
       { p | p.2.2 ⊆ closedBall p.2.1 p.1 ∧ μ (closedBall p.2.1 (3 * p.1)) ≤ C * μ p.2.2 ∧
             (interior p.2.2).Nonempty ∧ IsClosed p.2.2 ∧ p.2.2 ∈ f p.2.1 ∧ p.2.1 ∈ s }
-    have A : ∀ x ∈ s, ∀ (ε : ℝ) > 0, ∃ p, p ∈ t ∧ p.1 ≤ ε ∧ p.2.1 = x := by
+    have A : ∀ x ∈ s, ∀ ε > 0, ∃ p, p ∈ t ∧ p.1 ≤ ε ∧ p.2.1 = x := by
       intro x xs ε εpos
       rcases ffine x xs ε εpos with ⟨a, ha, h'a⟩
       rcases fsubset x xs ha with ⟨a_closed, a_int, ⟨r, ar, μr⟩⟩

--- a/Mathlib/MeasureTheory/Covering/VitaliFamily.lean
+++ b/Mathlib/MeasureTheory/Covering/VitaliFamily.lean
@@ -203,7 +203,7 @@ def enlarge (v : VitaliFamily μ) (δ : ℝ) (δpos : 0 < δ) : VitaliFamily μ 
   covering := by
     intro s f fset ffine
     let g : α → Set (Set α) := fun x => f x ∩ v.setsAt x
-    have : ∀ x ∈ s, ∀ ε : ℝ, ε > 0 → ∃ (a : Set α), a ∈ g x ∧ a ⊆ closedBall x ε := by
+    have : ∀ x ∈ s, ∀ (ε : ℝ), 0 < ε → ∃ (a : Set α), a ∈ g x ∧ a ⊆ closedBall x ε := by
       intro x hx ε εpos
       obtain ⟨a, af, ha⟩ : ∃ a ∈ f x, a ⊆ closedBall x (min ε δ) :=
         ffine x hx (min ε δ) (lt_min εpos δpos)

--- a/Mathlib/MeasureTheory/Integral/Layercake.lean
+++ b/Mathlib/MeasureTheory/Integral/Layercake.lean
@@ -582,7 +582,7 @@ theorem Integrable.integral_eq_integral_meas_lt
   have key := lintegral_eq_lintegral_meas_lt μ f_nn f_intble.aemeasurable
   have lhs_finite : ∫⁻ (ω : α), ENNReal.ofReal (f ω) ∂μ < ∞ := Integrable.lintegral_lt_top f_intble
   have rhs_finite : ∫⁻ (t : ℝ) in Set.Ioi 0, μ {a | t < f a} < ∞ := by simp only [← key, lhs_finite]
-  have rhs_integrand_finite : ∀ (t : ℝ), t > 0 → μ {a | t < f a} < ∞ :=
+  have rhs_integrand_finite : ∀ t > 0, μ {a | t < f a} < ∞ :=
     fun t ht ↦ measure_gt_lt_top f_intble ht
   convert (ENNReal.toReal_eq_toReal lhs_finite.ne rhs_finite.ne).mpr key
   · exact integral_eq_lintegral_of_nonneg_ae f_nn f_intble.aestronglyMeasurable

--- a/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
@@ -548,7 +548,7 @@ open NumberTheorySymbols jacobiSym
 
 /-- Computes `J(a | b)` (or `-J(a | b)` if `flip` is set to `true`) given assumptions, by reducing
 `a` to odd by repeated division and then using quadratic reciprocity to swap `a`, `b`. -/
-private def fastJacobiSymAux (a b : ℕ) (flip : Bool) (ha0 : a > 0) : ℤ :=
+private def fastJacobiSymAux (a b : ℕ) (flip : Bool) (ha0 : 0 < a) : ℤ :=
   if ha4 : a % 4 = 0 then
     fastJacobiSymAux (a / 4) b flip
       (a.div_pos (Nat.le_of_dvd ha0 (Nat.dvd_of_mod_eq_zero ha4)) (by decide))

--- a/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
@@ -567,8 +567,8 @@ decreasing_by
   · exact a.div_lt_self ha0 (by decide)
   · exact b.mod_lt ha0
 
-private theorem fastJacobiSymAux.eq_jacobiSym {a b : ℕ} {flip : Bool} {ha0 : a > 0}
-    (hb2 : b % 2 = 1) (hb1 : b > 1) :
+private theorem fastJacobiSymAux.eq_jacobiSym {a b : ℕ} {flip : Bool} {ha0 : 0 < a}
+    (hb2 : b % 2 = 1) (hb1 : 1 < b) :
     fastJacobiSymAux a b flip ha0 = if flip then -J(a | b) else J(a | b) := by
   induction' a using Nat.strongInductionOn with a IH generalizing b flip
   unfold fastJacobiSymAux

--- a/Mathlib/NumberTheory/Padics/Hensel.lean
+++ b/Mathlib/NumberTheory/Padics/Hensel.lean
@@ -374,7 +374,7 @@ private def soln_gen : ℤ_[p] := (newton_cau_seq hnorm).lim
 
 local notation "soln" => soln_gen hnorm
 
-private theorem soln_spec {ε : ℝ} (hε : ε > 0) :
+private theorem soln_spec {ε : ℝ} (hε : 0 < ε) :
     ∃ N : ℕ, ∀ {i : ℕ}, i ≥ N → ‖soln - newton_cau_seq hnorm i‖ < ε :=
   Setoid.symm (CauSeq.equiv_lim (newton_cau_seq hnorm)) _ hε
 

--- a/Mathlib/NumberTheory/Padics/Hensel.lean
+++ b/Mathlib/NumberTheory/Padics/Hensel.lean
@@ -273,7 +273,7 @@ private theorem newton_seq_succ_dist (n : ℕ) :
       ((div_le_div_right (deriv_norm_pos hnorm)).2 (newton_seq_norm_le hnorm _))
     _ = ‖F.derivative.eval a‖ * T ^ 2 ^ n := div_sq_cancel _ _
 
-private theorem T_pos : T > 0 := by
+private theorem T_pos : 0 < T := by
   rw [T_def]
   exact div_pos (norm_pos_iff.2 hnsol) (deriv_sq_norm_pos hnorm)
 
@@ -352,7 +352,7 @@ private theorem bound' : Tendsto (fun n : ℕ => ‖F.derivative.eval a‖ * T ^
         (Nat.tendsto_pow_atTop_atTop_of_one_lt (by norm_num)))
 
 private theorem bound :
-    ∀ {ε}, ε > 0 → ∃ N : ℕ, ∀ {n}, n ≥ N → ‖F.derivative.eval a‖ * T ^ 2 ^ n < ε := fun hε ↦
+    ∀ {ε}, 0 < ε → ∃ N : ℕ, ∀ {n}, N ≤ n → ‖F.derivative.eval a‖ * T ^ 2 ^ n < ε := fun hε ↦
   eventually_atTop.1 <| (bound' hnorm).eventually <| gt_mem_nhds hε
 
 private theorem bound'_sq :
@@ -375,7 +375,7 @@ private def soln_gen : ℤ_[p] := (newton_cau_seq hnorm).lim
 local notation "soln" => soln_gen hnorm
 
 private theorem soln_spec {ε : ℝ} (hε : 0 < ε) :
-    ∃ N : ℕ, ∀ {i : ℕ}, i ≥ N → ‖soln - newton_cau_seq hnorm i‖ < ε :=
+    ∃ N : ℕ, ∀ i ≥ N, ‖soln - newton_cau_seq hnorm i‖ < ε :=
   Setoid.symm (CauSeq.equiv_lim (newton_cau_seq hnorm)) _ hε
 
 private theorem soln_deriv_norm : ‖F.derivative.eval soln‖ = ‖F.derivative.eval a‖ :=

--- a/Mathlib/NumberTheory/Padics/PadicNorm.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNorm.lean
@@ -176,8 +176,8 @@ protected theorem of_int (z : ℤ) : padicNorm p z ≤ 1 :=
 
 private theorem nonarchimedean_aux {q r : ℚ} (h : padicValRat p q ≤ padicValRat p r) :
     padicNorm p (q + r) ≤ max (padicNorm p q) (padicNorm p r) :=
-  have hnqp : padicNorm p q ≥ 0 := padicNorm.nonneg _
-  have hnrp : padicNorm p r ≥ 0 := padicNorm.nonneg _
+  have hnqp : 0 ≤ padicNorm p q := padicNorm.nonneg _
+  have hnrp : 0 ≤ padicNorm p r := padicNorm.nonneg _
   if hq : q = 0 then by simp [hq, max_eq_right hnrp, le_max_right]
   else
     if hr : r = 0 then by simp [hr, max_eq_left hnqp, le_max_left]

--- a/Mathlib/NumberTheory/PellMatiyasevic.lean
+++ b/Mathlib/NumberTheory/PellMatiyasevic.lean
@@ -722,7 +722,7 @@ theorem eq_of_xn_modEq_lem3 {i n} (npos : 0 < n) :
                   rw [ile, a2, n1]; exact ⟨rfl, rfl, rfl, rfl⟩
           · rw [ein, Nat.mod_self, add_zero]
             exact strictMono_x _ (Nat.pred_lt npos.ne'))
-        fun jn : j > n =>
+        fun jn : n < j =>
         have lem1 : j ≠ n → xn a1 j % xn a1 n < xn a1 (j + 1) % xn a1 n →
             xn a1 i % xn a1 n < xn a1 (j + 1) % xn a1 n :=
           fun jn s =>

--- a/Mathlib/NumberTheory/Rayleigh.lean
+++ b/Mathlib/NumberTheory/Rayleigh.lean
@@ -85,7 +85,7 @@ private theorem no_anticollision :
   exact h₄.not_lt h₃
 
 /-- Let `0 < r ∈ ℝ` and `j ∈ ℤ`. Then either `j ∈ B_r` or `B_r` jumps over `j`. -/
-private theorem hit_or_miss (h : r > 0) :
+private theorem hit_or_miss (h : 0 < r) :
     j ∈ {beattySeq r k | k} ∨ ∃ k : ℤ, k < j / r ∧ (j + 1) / r ≤ k + 1 := by
   -- for both cases, the candidate is `k = ⌈(j + 1) / r⌉ - 1`
   cases lt_or_ge ((⌈(j + 1) / r⌉ - 1) * r) j
@@ -97,7 +97,7 @@ private theorem hit_or_miss (h : r > 0) :
     exact ⟨‹_›, Int.ceil_lt_add_one _⟩
 
 /-- Let `0 < r ∈ ℝ` and `j ∈ ℤ`. Then either `j ∈ B'_r` or `B'_r` jumps over `j`. -/
-private theorem hit_or_miss' (h : r > 0) :
+private theorem hit_or_miss' (h : 0 < r) :
     j ∈ {beattySeq' r k | k} ∨ ∃ k : ℤ, k ≤ j / r ∧ (j + 1) / r < k + 1 := by
   -- for both cases, the candidate is `k = ⌊(j + 1) / r⌋`
   cases le_or_gt (⌊(j + 1) / r⌋ * r) j

--- a/Mathlib/Probability/Process/Stopping.lean
+++ b/Mathlib/Probability/Process/Stopping.lean
@@ -177,7 +177,7 @@ theorem IsStoppingTime.measurableSet_lt_of_isLUB (hτ : IsStoppingTime f τ) (i 
     · rw [tendsto_atTop'] at h_tendsto
       have h_nhds : Set.Ici k ∈ 𝓝 i :=
         mem_nhds_iff.mpr ⟨Set.Ioi k, Set.Ioi_subset_Ici le_rfl, isOpen_Ioi, hk_lt_i⟩
-      obtain ⟨a, ha⟩ : ∃ a : ℕ, ∀ b : ℕ, b ≥ a → k ≤ seq b := h_tendsto (Set.Ici k) h_nhds
+      obtain ⟨a, ha⟩ : ∃ a : ℕ, ∀ b ≥ a, k ≤ seq b := h_tendsto (Set.Ici k) h_nhds
       exact ⟨a, ha a le_rfl⟩
     · obtain ⟨j, hk_seq_j⟩ := h_exists_k_le_seq
       exact hk_seq_j.trans_lt (h_bound j)

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -359,7 +359,6 @@ theorem cmp_compares : ∀ (a b : ONote) [NF a] [NF b], (cmp a b).Compares a b
       subst IHa; exact rfl
 #align onote.cmp_compares ONote.cmp_compares
 
-set_option linter.geOrGt false in
 theorem repr_inj {a b} [NF a] [NF b] : repr a = repr b ↔ a = b :=
   ⟨fun e => match cmp a b, cmp_compares a b with
     | Ordering.lt, (h : repr a < repr b) => (ne_of_lt h e).elim

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -359,6 +359,7 @@ theorem cmp_compares : ∀ (a b : ONote) [NF a] [NF b], (cmp a b).Compares a b
       subst IHa; exact rfl
 #align onote.cmp_compares ONote.cmp_compares
 
+set_option linter.geOrGt false in
 theorem repr_inj {a b} [NF a] [NF b] : repr a = repr b ↔ a = b :=
   ⟨fun e => match cmp a b, cmp_compares a b with
     | Ordering.lt, (h : repr a < repr b) => (ne_of_lt h e).elim

--- a/Mathlib/Tactic/CancelDenoms/Core.lean
+++ b/Mathlib/Tactic/CancelDenoms/Core.lean
@@ -320,7 +320,7 @@ example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
   cancel_denoms at h
   exact h
 
-example (h : a > 0) : a / 5 > 0 := by
+example (h : 0 < a) : a / 5 > 0 := by
   cancel_denoms
   exact h
 ```

--- a/Mathlib/Tactic/IntervalCases.lean
+++ b/Mathlib/Tactic/IntervalCases.lean
@@ -290,13 +290,13 @@ def intervalCases (g : MVarId) (e e' : Expr) (lbs ubs : Array Expr) (mustUseBoun
   let mut ub ← try? (m.initUB e)
   for pf in ubs do
     if let some ub1 ← try? (m.getBound e pf false) then
-      if ub.all (·.1.asUpper > ub1.1.asUpper) then
+      if ub.all (ub1.1.asUpper < ·.1.asUpper) then
         ub := some ub1
     else if mustUseBounds then
       throwError "interval_cases failed: provided bound '{← inferType pf}' cannot be evaluated"
   match lb, ub with
   | some (z1, e1, p1), some (z2, e2, p2) =>
-    if z1.asLower > z2.asUpper then
+    if z2.asUpper < z1.asLower then
       (← g.exfalso).assign (← m.inconsistentBounds z1 z2 e1 e2 p1 p2 e)
       pure #[]
     else

--- a/Mathlib/Tactic/Linarith/Lemmas.lean
+++ b/Mathlib/Tactic/Linarith/Lemmas.lean
@@ -40,12 +40,12 @@ theorem lt_of_lt_of_eq {α} [OrderedSemiring α] {a b : α} (ha : a < 0) (hb : b
   simp [*]
 
 theorem mul_neg {α} [StrictOrderedRing α] {a b : α} (ha : a < 0) (hb : 0 < b) : b * a < 0 :=
-  have : (-b)*a > 0 := mul_pos_of_neg_of_neg (neg_neg_of_pos hb) ha
+  have : 0 < (-b)*a := mul_pos_of_neg_of_neg (neg_neg_of_pos hb) ha
   neg_of_neg_pos (by simpa)
 
-theorem mul_nonpos {α} [OrderedRing α] {a b : α} (ha : a ≤ 0) (hb : 0 < b) : b * a ≤ 0 :=
-  have : (-b)*a ≥ 0 := mul_nonneg_of_nonpos_of_nonpos (le_of_lt (neg_neg_of_pos hb)) ha
-  by simpa
+theorem mul_nonpos {α} [OrderedRing α] {a b : α} (ha : a ≤ 0) (hb : 0 < b) : b * a ≤ 0 := by
+  have : 0 ≤ (-b) * a := mul_nonneg_of_nonpos_of_nonpos (le_of_lt (neg_neg_of_pos hb)) ha
+  simpa only [neg_mul, Left.nonneg_neg_iff]
 
 -- used alongside `mul_neg` and `mul_nonpos`, so has the same argument pattern for uniformity
 @[nolint unusedArguments]

--- a/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
@@ -117,6 +117,7 @@ structure PComp : Type where
   which appear in the `history` set. -/
   vars : RBSet ℕ Ord.compare
 
+set_option linter.geOrGt false in
 /--
 Any comparison whose history is not minimal is redundant,
 and need not be included in the new set of comparisons.
@@ -292,7 +293,7 @@ Returns `(pos, neg, notPresent)`.
 def splitSetByVarSign (a : ℕ) (comps : PCompSet) : PCompSet × PCompSet × PCompSet :=
   comps.foldl (fun ⟨pos, neg, notPresent⟩ pc =>
     let n := pc.c.coeffOf a
-    if n > 0 then ⟨pos.insert pc, neg, notPresent⟩
+    if 0 < n then ⟨pos.insert pc, neg, notPresent⟩
     else if n < 0 then ⟨pos, neg.insert pc, notPresent⟩
     else ⟨pos, neg, notPresent.insert pc⟩)
     ⟨RBSet.empty, RBSet.empty, RBSet.empty⟩

--- a/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
@@ -117,7 +117,6 @@ structure PComp : Type where
   which appear in the `history` set. -/
   vars : RBSet ℕ Ord.compare
 
-set_option linter.geOrGt false in
 /--
 Any comparison whose history is not minimal is redundant,
 and need not be included in the new set of comparisons.

--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -107,7 +107,7 @@ def proveNatGCD (ex ey : Q(ℕ)) : (ed : Q(ℕ)) × Q(Nat.gcd $ex $ey = $ed) :=
       have ea' : Q(ℕ) := mkRawNatLit a.natAbs
       have eb' : Q(ℕ) := mkRawNatLit b.natAbs
       if d = 1 then
-        if a ≥ 0 then
+        if 0 ≤ a then
           have pt : Q($ex * $ea' = $ey * $eb' + 1) := (q(Eq.refl ($ex * $ea')) : Expr)
           ⟨mkRawNatLit 1, q(nat_gcd_helper_2' $ex $ey $ea' $eb' $pt)⟩
         else
@@ -117,7 +117,7 @@ def proveNatGCD (ex ey : Q(ℕ)) : (ed : Q(ℕ)) × Q(Nat.gcd $ex $ey = $ed) :=
         have ed : Q(ℕ) := mkRawNatLit d
         have pu : Q(Nat.mod $ex $ed = 0) := (q(Eq.refl (nat_lit 0)) : Expr)
         have pv : Q(Nat.mod $ey $ed = 0) := (q(Eq.refl (nat_lit 0)) : Expr)
-        if a ≥ 0 then
+        if 0 ≤ a then
           have pt : Q($ex * $ea' = $ey * $eb' + $ed) := (q(Eq.refl ($ex * $ea')) : Expr)
           ⟨ed, q(nat_gcd_helper_2 $ed $ex $ey $ea' $eb' $pu $pv $pt)⟩
         else

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -147,7 +147,7 @@ such that `norm_num` successfully recognises `a`. -/
   core : Option (Result e) := do
     let ⟨qa, na, da, pa⟩ ← ra.toRat' dα
     let qb := qa⁻¹
-    if qa > 0 then
+    if 0 < qa then
       if let some i := i then
         have lit : Q(ℕ) := na.appArg!
         haveI : $na =Q Int.ofNat $lit := ⟨⟩

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -793,7 +793,7 @@ partial def evalPow₁ (va : ExSum sα a) (vb : ExProd sℕ b) : Result (ExSum s
     let ⟨_, vc, pc⟩ := evalPowProd sα va vb
     ⟨_, vc.toSum, q(single_pow $pc)⟩
   | va, vb =>
-    if vb.coeff > 1 then
+    if 1 < vb.coeff then
       let ⟨k, _, vc, pc⟩ := extractCoeff vb
       let ⟨_, vd, pd⟩ := evalPow₁ va vc
       let ⟨_, ve, pe⟩ := evalPowNat sα vd k

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -314,7 +314,7 @@ instance : IsWellFounded (Products I) (·<·) := by
     ext; exact lt_iff_lex_lt _ _
   rw [this]
   dsimp [Products]
-  rw [(by rfl : (·>· : I → _) = flip (·<·))]
+  rw [(by rfl : (· > · : I → _) = flip (·<·))]
   infer_instance
 
 /-- The evaluation `e C i₁ ··· e C iᵣ : C → ℤ`  of a formal product `[i₁, i₂, ..., iᵣ]`. -/
@@ -1556,7 +1556,7 @@ theorem max_eq_eval_unapply :
 
 theorem chain'_cons_of_lt (l : MaxProducts C ho)
     (q : Products I) (hq : q < l.val.Tail) :
-    List.Chain' (fun x x_1 ↦ x > x_1) (term I ho :: q.val) := by
+    List.Chain' (fun x x_1 ↦ x_1 < x) (term I ho :: q.val) := by
   have : Inhabited I := ⟨term I ho⟩
   rw [List.chain'_iff_pairwise]
   simp only [gt_iff_lt, List.pairwise_cons]

--- a/Mathlib/Topology/ContinuousFunction/Bounded.lean
+++ b/Mathlib/Topology/ContinuousFunction/Bounded.lean
@@ -530,7 +530,7 @@ theorem arzela_ascoli₁ [CompactSpace β] (A : Set (α →ᵇ β)) (closed : Is
     sets exist by compactness of the source and range. Then, to check that these
     data determine the function up to `ε`, one uses the control on the modulus of
     continuity to extend the closeness on tα to closeness everywhere. -/
-  have ε₂0 : ε₂ > 0 := half_pos (half_pos ε₁0)
+  have ε₂0 : 0 < ε₂ := half_pos (half_pos ε₁0)
   have : ∀ x : α, ∃ U, x ∈ U ∧ IsOpen U ∧
       ∀ y ∈ U, ∀ z ∈ U, ∀ {f : α →ᵇ β}, f ∈ A → dist (f y) (f z) < ε₂ := fun x =>
     let ⟨U, nhdsU, hU⟩ := H x _ ε₂0

--- a/Mathlib/Topology/MetricSpace/CauSeqFilter.lean
+++ b/Mathlib/Topology/MetricSpace/CauSeqFilter.lean
@@ -30,7 +30,7 @@ theorem CauSeq.tendsto_limit [NormedRing β] [hn : IsAbsoluteValue (norm : β �
   tendsto_nhds.mpr
     (by
       intro s os lfs
-      suffices ∃ a : ℕ, ∀ b : ℕ, b ≥ a → f b ∈ s by simpa using this
+      suffices ∃ a : ℕ, ∀ b ≥ a, f b ∈ s by simpa using this
       rcases Metric.isOpen_iff.1 os _ lfs with ⟨ε, ⟨hε, hεs⟩⟩
       cases' Setoid.symm (CauSeq.equiv_lim f) _ hε with N hN
       exists N
@@ -68,7 +68,7 @@ theorem CauSeq.cauchySeq (f : CauSeq β norm) : CauchySeq f := by
   refine' cauchy_iff.2 ⟨by infer_instance, fun s hs => _⟩
   rcases mem_uniformity_dist.1 hs with ⟨ε, ⟨hε, hεs⟩⟩
   cases' CauSeq.cauchy₂ f hε with N hN
-  exists { n | n ≥ N }.image f
+  exists { n | N ≤ n }.image f
   simp only [exists_prop, mem_atTop_sets, mem_map, mem_image, ge_iff_le, mem_setOf_eq]
   constructor
   · exists N

--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -89,6 +89,7 @@ theorem Closeds.edist_eq {s t : Closeds α} : edist s t = hausdorffEdist (s : Se
   rfl
 #align emetric.closeds.edist_eq EMetric.Closeds.edist_eq
 
+set_option linter.geOrGt false in
 /-- In a complete space, the type of closed subsets is complete for the
 Hausdorff edistance. -/
 instance Closeds.completeSpace [CompleteSpace α] : CompleteSpace (Closeds α) := by

--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -89,7 +89,6 @@ theorem Closeds.edist_eq {s t : Closeds α} : edist s t = hausdorffEdist (s : Se
   rfl
 #align emetric.closeds.edist_eq EMetric.Closeds.edist_eq
 
-set_option linter.geOrGt false in
 /-- In a complete space, the type of closed subsets is complete for the
 Hausdorff edistance. -/
 instance Closeds.completeSpace [CompleteSpace α] : CompleteSpace (Closeds α) := by

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -291,9 +291,9 @@ protected theorem IsSeqCompact.totallyBounded (h : IsSeqCompact s) : TotallyBoun
     simp only [not_subset, mem_iUnion₂, not_exists, exists_prop] at h
     simpa only [forall_and, forall_mem_image, not_and] using seq_of_forall_finite_exists h
   refine' ⟨u, u_in, fun x _ φ hφ huφ => _⟩
-  obtain ⟨N, hN⟩ : ∃ N, ∀ p ≥ N, ∀ q ≥ N, (u (φ p), u (φ q)) ∈ V
+  obtain ⟨N, hN⟩ : ∃ N, ∀ p q, N ≤ p → N ≤ q → (u (φ p), u (φ q)) ∈ V
   · exact huφ.cauchySeq.mem_entourage V_in
-  · exact hu (φ <| N + 1) (φ N) (hφ <| lt_add_one N) (hN (N + 1) N.le_succ N le_rfl)
+  · exact hu (φ <| N + 1) (φ N) (hφ <| lt_add_one N) (hN (N + 1) N N.le_succ le_rfl)
 #align is_seq_compact.totally_bounded IsSeqCompact.totallyBounded
 
 variable [IsCountablyGenerated (𝓤 X)]

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -291,9 +291,9 @@ protected theorem IsSeqCompact.totallyBounded (h : IsSeqCompact s) : TotallyBoun
     simp only [not_subset, mem_iUnion₂, not_exists, exists_prop] at h
     simpa only [forall_and, forall_mem_image, not_and] using seq_of_forall_finite_exists h
   refine' ⟨u, u_in, fun x _ φ hφ huφ => _⟩
-  obtain ⟨N, hN⟩ : ∃ N, ∀ p q, p ≥ N → q ≥ N → (u (φ p), u (φ q)) ∈ V
+  obtain ⟨N, hN⟩ : ∃ N, ∀ p ≥ N, ∀ q ≥ N, (u (φ p), u (φ q)) ∈ V
   · exact huφ.cauchySeq.mem_entourage V_in
-  · exact hu (φ <| N + 1) (φ N) (hφ <| lt_add_one N) (hN (N + 1) N N.le_succ le_rfl)
+  · exact hu (φ <| N + 1) (φ N) (hφ <| lt_add_one N) (hN (N + 1) N.le_succ N le_rfl)
 #align is_seq_compact.totally_bounded IsSeqCompact.totallyBounded
 
 variable [IsCountablyGenerated (𝓤 X)]

--- a/test/LibrarySearch/basic.lean
+++ b/test/LibrarySearch/basic.lean
@@ -37,7 +37,7 @@ example (n m k : Nat) : n ≤ m → n + k ≤ m + k := by apply?
 
 /- info: Try this: exact Nat.mul_dvd_mul_left a w -/
 #guard_msgs (drop info) in
-example (_ha : a > 0) (w : b ∣ c) : a * b ∣ a * c := by apply?
+example (_ha : 0 < a) (w : b ∣ c) : a * b ∣ a * c := by apply?
 
 -- Could be any number of results (`Int.one`, `Int.zero`, etc)
 #guard_msgs (drop info) in
@@ -99,16 +99,16 @@ section synonym
 
 /- info: Try this: exact Nat.add_pos_left ha b -/
 #guard_msgs (drop info) in
-example (a b : ℕ) (_ha : a > 0) (_hb : 0 < b) : 0 < a + b := by apply?
+example (a b : ℕ) (_ha : 0 < a) (_hb : 0 < b) : 0 < a + b := by apply?
 
 /-- info: Try this: exact Nat.le_of_dvd w h -/
 #guard_msgs in
-example (a b : ℕ) (h : a ∣ b) (w : b > 0) : a ≤ b :=
+example (a b : ℕ) (h : a ∣ b) (w : 0 < b) : a ≤ b :=
 by apply?
 
 /-- info: Try this: exact Nat.le_of_dvd w h -/
 #guard_msgs in
-example (a b : ℕ) (h : a ∣ b) (w : b > 0) : b ≥ a := by apply?
+example (a b : ℕ) (h : a ∣ b) (w : 0 < b) : b ≥ a := by apply?
 
 -- TODO: A lemma with head symbol `¬` can be used to prove `¬ p` or `⊥`
 /-- info: Try this: exact Nat.not_lt_zero a -/

--- a/test/Use.lean
+++ b/test/Use.lean
@@ -193,7 +193,7 @@ example (α : Type u) : Embedding α α × Unit := by
 -- Note(kmill): mathlib3 `use` would try to rewrite any lingering existentials with
 -- `exists_prop` to turn them into conjunctions. It did not do this recursively.
 
--- example : ∃ (n : Nat) (h : n > 0), n = n :=
+-- example : ∃ (n : Nat) (h : 0 < n), n = n :=
 -- by
 --   use 1
 --   -- goal should now be `1 > 0 ∧ 1 = 1`, whereas it would be `∃ (H : 1 > 0), 1 = 1` after existsi 1.
@@ -208,7 +208,7 @@ by
   decide
 
 -- The discharger knows about `exists_prop`.
-example (h1 : 1 > 0) : ∃ (n : Nat) (_h : n > 0), n = n := by
+example (h1 : 0 < 1) : ∃ (n : Nat) (_h : 0 < n), n = n := by
   use 1
 
 -- Regression test: `use` needs to ensure it does calculations inside the correct local contexts

--- a/test/cancel_denoms.lean
+++ b/test/cancel_denoms.lean
@@ -13,7 +13,7 @@ example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
   cancel_denoms at h
   exact h
 
-example (h : a > 0) : a / 5 > 0 := by
+example (h : 0 < a) : a / 5 > 0 := by
   cancel_denoms
   exact h
 
@@ -56,7 +56,7 @@ example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
   cancel_denoms at h
   exact h
 
-example (h : a > 0) : a / 5 > 0 := by
+example (h : 0 < a) : a / 5 > 0 := by
   cancel_denoms
   exact h
 
@@ -72,7 +72,7 @@ section
 variable (a b c d : ℚ)
 
 -- inspired by automated testing
-example : (1 : ℚ) > 0 := by
+example : 0 < (1 : ℚ) := by
   have := 0
   cancel_denoms
 
@@ -80,7 +80,7 @@ example (h : a / 5 + b / 4 < c) : 4*a + 5*b < 20*c := by
   cancel_denoms at h
   exact h
 
-example (h : a > 0) : a / 5 > 0 := by
+example (h : 0 < a) : 0 < a / 5 := by
   cancel_denoms
   exact h
 

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -69,17 +69,17 @@ example (A B : Rat) (h : 0 < A * B) : 0 < A*B/8 := by
 example (A B : Rat) (h : 0 < A * B) : 0 < A/8*B := by
   linarith
 
-example (ε : Rat) (h1 : ε > 0) : ε / 2 + ε / 3 + ε / 7 < ε :=
+example (ε : Rat) (h1 : 0 < ε) : ε / 2 + ε / 3 + ε / 7 < ε :=
  by linarith
 
 example (x y z : Rat) (h1 : 2*x < 3*y) (h2 : -4*x + z/2 < 0)
         (h3 : 12*y - z < 0)  : False :=
 by linarith
 
-example (ε : Rat) (h1 : ε > 0) : ε / 2 < ε :=
+example (ε : Rat) (h1 : 0 < ε) : ε / 2 < ε :=
 by linarith
 
-example (ε : Rat) (h1 : ε > 0) : ε / 3 + ε / 3 + ε / 3 = ε :=
+example (ε : Rat) (h1 : 0 < ε) : ε / 3 + ε / 3 + ε / 3 = ε :=
 by linarith
 
 -- Make sure special case for division by 1 is handled:
@@ -108,7 +108,7 @@ example (a b c : Rat) (h2 : b + 2 > 3 + b) : False := by
 -- example (a b c : ℚ) (x y : ℤ) (h1 : x ≤ 3*y) (h2 : b + 2 > 3 + b) : false :=
 -- by linarith (config := {restrict_type := ℚ})
 
-example (g v V c h : Rat) (h1 : h = 0) (h2 : v = V) (h3 : V > 0) (h4 : g > 0)
+example (g v V c h : Rat) (h1 : h = 0) (h2 : v = V) (h3 : 0 < V) (h4 : 0 < g)
     (h5 : 0 ≤ c) (h6 : c < 1) : v ≤ V := by
   linarith
 
@@ -119,10 +119,10 @@ example (x y z : ℤ) (h1 : 2*x < 3*y) (h2 : -4*x + 2*z < 0) (h3 : x*y < 5) (h3 
     False := by
   linarith
 
-example (a b c : Rat) (h1 : a > 0) (h2 : b > 5) (h3 : c < -10) (h4 : a + b - c < 3) : False := by
+example (a b c : Rat) (h1 : 0 < a) (h2 : b > 5) (h3 : c < -10) (h4 : a + b - c < 3) : False := by
   linarith
 
-example (a b c : Rat) (h2 : b > 0) (h3 : ¬ b ≥ 0) : False := by
+example (a b c : Rat) (h2 : 0 < b) (h3 : ¬ b ≥ 0) : False := by
   linarith
 
 example (x y z : Rat) (hx : x ≤ 3*y) (h2 : y ≤ 2*z) (h3 : x ≥ 6*z) : x = 3*y := by
@@ -167,10 +167,10 @@ example (w x y z : ℤ) (h1 : 4*x + (-3)*y + 6*w ≤ 0) (h2 : (-1)*x < 0) (h3 : 
 
 section term_arguments
 
-example (x : Rat) (hx : x > 0) (h : x.num < 0) : False := by
+example (x : Rat) (hx : 0 < x) (h : x.num < 0) : False := by
   linarith [Rat.num_pos.mpr hx, h]
 
-example (x : Rat) (hx : x > 0) (h : x.num < 0) : False := by
+example (x : Rat) (hx : 0 < x) (h : x.num < 0) : False := by
   fail_if_success
     linarith
   fail_if_success
@@ -185,10 +185,10 @@ example (i n : ℕ) (h : (2:ℤ) ^ i ≤ 2 ^ n) : (0:ℤ) ≤ 2 ^ n - 2 ^ i := b
   linarith
 
 -- Check we use `exfalso` on non-comparison goals.
-example (a b c : Rat) (h2 : b > 0) (h3 : b < 0) : Nat.prime 10 := by
+example (a b c : Rat) (h2 : 0 < b) (h3 : b < 0) : Nat.prime 10 := by
   linarith
 
-example (a b c : Rat) (h2 : (2 : Rat) > 3)  : a + b - c ≥ 3 :=
+example (a b c : Rat) (h2 : 3 < (2 : Rat))  : a + b - c ≥ 3 :=
 by linarith (config := {exfalso := false})
 
 -- Verify that we split conjunctions in hypotheses.

--- a/test/norm_cast.lean
+++ b/test/norm_cast.lean
@@ -70,7 +70,7 @@ example (h : (an : ℝ) = 0) : an = 0 := mod_cast h
 example (h : (an : ℝ) = 42) : an = 42 := mod_cast h
 example (h : (an + 42) ≠ 42) : (an : ℝ) + 42 ≠ 42 := mod_cast h
 
-example (n : ℤ) (h : n + 1 > 0) : ((n + 1 : ℤ) : ℚ) > 0 := mod_cast h
+example (n : ℤ) (h : 0 < n + 1) : 0 < ((n + 1 : ℤ) : ℚ) := mod_cast h
 
 -- testing the heuristic
 example (h : bn ≤ an) : an - bn = 1 ↔ (an - bn : ℤ) = 1 := by norm_cast


### PR DESCRIPTION
These were flagged by the linter in #12879: it is easy to simple avoid > or ≥ in hypotheses or `have`s.

---

- [x] depends on: #35346
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
