### PR TITLE
chore(Quiver.Opposite): make `Quiver.Hom.op/unop` `abbrev`'s 

### DIFF
--- a/Mathlib/Algebra/Homology/ShortComplex/Homology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Homology.lean
@@ -1041,8 +1041,11 @@ lemma homologyMap_op [HasHomology S₁] [HasHomology S₂] :
   dsimp only [Iso.symm, Iso.trans, Iso.op, Iso.refl, rightHomologyIso, leftHomologyIso,
     leftHomologyOpIso, leftHomologyMapIso', rightHomologyMapIso',
     LeftHomologyData.leftHomologyIso, homologyMap']
-  simp only [assoc, rightHomologyMap'_op, op_comp, ← leftHomologyMap'_comp_assoc, id_comp,
-    opMap_id, comp_id, HomologyData.op_left]
+  rw [assoc, op_comp, rightHomologyMap'_op]
+  simp only [HomologyData.op_left, RightHomologyData.op_H, opMap_id, assoc, op_comp, ←
+    leftHomologyMap'_comp_assoc, comp_id, id_comp]
+  rw [rightHomologyMap'_op]
+  simp only [opMap_id, ← leftHomologyMap'_comp_assoc, RightHomologyData.op_H, comp_id]
 
 variable (C)
 

--- a/Mathlib/Algebra/Homology/ShortComplex/RightHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/RightHomology.lean
@@ -978,7 +978,8 @@ lemma leftHomologyMap_op (φ : S₁ ⟶ S₂) [S₁.HasLeftHomology] [S₂.HasLe
       S₁.rightHomologyOpIso.hom := by
   dsimp [rightHomologyOpIso, RightHomologyData.rightHomologyIso, rightHomologyMap,
     leftHomologyMap]
-  simp only [← rightHomologyMap'_comp, comp_id, id_comp, leftHomologyMap'_op]
+  simp only [← rightHomologyMap'_comp, comp_id, id_comp]
+  rw [leftHomologyMap'_op]
 
 @[simp]
 lemma rightHomologyMap'_op
@@ -993,7 +994,8 @@ lemma rightHomologyMap_op (φ : S₁ ⟶ S₂) [S₁.HasRightHomology] [S₂.Has
       S₁.leftHomologyOpIso.hom := by
   dsimp [leftHomologyOpIso, LeftHomologyData.leftHomologyIso, leftHomologyMap,
     rightHomologyMap]
-  simp only [← leftHomologyMap'_comp, comp_id, id_comp, rightHomologyMap'_op]
+  simp only [← leftHomologyMap'_comp, comp_id, id_comp]
+  rw [rightHomologyMap'_op]
 
 namespace RightHomologyData
 

--- a/Mathlib/CategoryTheory/Idempotents/Basic.lean
+++ b/Mathlib/CategoryTheory/Idempotents/Basic.lean
@@ -192,7 +192,6 @@ theorem isIdempotentComplete_of_isIdempotentComplete_opposite (h : IsIdempotentC
   · simp only [← unop_comp, h₁]
     rfl
   · simp only [← unop_comp, h₂]
-    rfl
 #align category_theory.idempotents.is_idempotent_complete_of_is_idempotent_complete_opposite CategoryTheory.Idempotents.isIdempotentComplete_of_isIdempotentComplete_opposite
 
 theorem isIdempotentComplete_iff_opposite : IsIdempotentComplete Cᵒᵖ ↔ IsIdempotentComplete C := by

--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -1271,7 +1271,6 @@ def IsLimit.unop {t : Cone F.op} (P : IsLimit t) : IsColimit t.unop where
   uniq s m w := by
     dsimp
     rw [← P.uniq s.op m.op]
-    · rfl
     · dsimp
       intro j
       rw [← w]
@@ -1287,7 +1286,6 @@ def IsColimit.unop {t : Cocone F.op} (P : IsColimit t) : IsLimit t.unop where
   uniq s m w := by
     dsimp
     rw [← P.uniq s.op m.op]
-    · rfl
     · dsimp
       intro j
       rw [← w]

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -57,7 +57,7 @@ def isLimitConeLeftOpOfCocone (F : J ⥤ Cᵒᵖ) {c : Cocone F} (hc : IsColimit
         coconeOfConeLeftOp_ι_app, op_unop]
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, IsColimit.fac, coconeOfConeLeftOp_ι_app] using w (op j)
+    simpa [IsColimit.fac, coconeOfConeLeftOp_ι_app] using w (op j)
 #align category_theory.limits.is_limit_cone_left_op_of_cocone CategoryTheory.Limits.isLimitConeLeftOpOfCocone
 
 /-- Turn a limit of `F : J ⥤ Cᵒᵖ` into a colimit of `F.leftOp : Jᵒᵖ ⥤ C`. -/
@@ -72,7 +72,7 @@ def isColimitCoconeLeftOpOfCone (F : J ⥤ Cᵒᵖ) {c : Cone F} (hc : IsLimit c
         coneOfCoconeLeftOp_π_app, op_unop]
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, IsLimit.fac, coneOfCoconeLeftOp_π_app] using w (op j)
+    simpa [IsLimit.fac, coneOfCoconeLeftOp_π_app] using w (op j)
 #align category_theory.limits.is_colimit_cocone_left_op_of_cone CategoryTheory.Limits.isColimitCoconeLeftOpOfCone
 
 /-- Turn a colimit for `F : Jᵒᵖ ⥤ C` into a limit for `F.rightOp : J ⥤ Cᵒᵖ`. -/
@@ -108,7 +108,7 @@ def isLimitConeUnopOfCocone (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cocone F} (hc : IsCol
   fac s j := Quiver.Hom.op_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, IsColimit.fac] using w (unop j)
+    simpa [IsColimit.fac] using w (unop j)
 #align category_theory.limits.is_limit_cone_unop_of_cocone CategoryTheory.Limits.isLimitConeUnopOfCocone
 
 /-- Turn a limit of `F : Jᵒᵖ ⥤ Cᵒᵖ` into a colimit of `F.unop : J ⥤ C`. -/
@@ -120,7 +120,7 @@ def isColimitCoconeUnopOfCone (F : Jᵒᵖ ⥤ Cᵒᵖ) {c : Cone F} (hc : IsLim
   fac s j := Quiver.Hom.op_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, IsLimit.fac] using w (unop j)
+    simpa [IsLimit.fac] using w (unop j)
 #align category_theory.limits.is_colimit_cocone_unop_of_cone CategoryTheory.Limits.isColimitCoconeUnopOfCone
 
 /-- Turn a colimit for `F.leftOp : Jᵒᵖ ⥤ C` into a limit for `F : J ⥤ Cᵒᵖ`. -/
@@ -162,7 +162,7 @@ def isLimitConeOfCoconeRightOp (F : Jᵒᵖ ⥤ C) {c : Cocone F.rightOp} (hc : 
   fac s j := Quiver.Hom.op_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, IsColimit.fac] using w (op j)
+    simpa [IsColimit.fac] using w (op j)
 #align category_theory.limits.is_limit_cone_of_cocone_right_op CategoryTheory.Limits.isLimitConeOfCoconeRightOp
 
 /-- Turn a limit for `F.rightOp : J ⥤ Cᵒᵖ` into a limit for `F : Jᵒᵖ ⥤ C`. -/
@@ -174,7 +174,7 @@ def isColimitCoconeOfConeRightOp (F : Jᵒᵖ ⥤ C) {c : Cone F.rightOp} (hc : 
   fac s j := Quiver.Hom.op_inj (by simp)
   uniq s m w := by
     refine' Quiver.Hom.op_inj (hc.hom_ext fun j => Quiver.Hom.unop_inj _)
-    simpa only [Quiver.Hom.op_unop, IsLimit.fac] using w (op j)
+    simpa [IsLimit.fac] using w (op j)
 #align category_theory.limits.is_colimit_cocone_of_cone_right_op CategoryTheory.Limits.isColimitCoconeOfConeRightOp
 
 /-- Turn a colimit for `F.unop : J ⥤ C` into a limit for `F : Jᵒᵖ ⥤ Cᵒᵖ`. -/
@@ -888,7 +888,7 @@ def CokernelCofork.IsColimit.ofπUnop {X Y Q : Cᵒᵖ} (p : Y ⟶ Q) {f : X ⟶
     (fun x hx => (h.desc (CokernelCofork.ofπ x.op (Quiver.Hom.unop_inj hx))).unop)
     (fun x hx => Quiver.Hom.op_inj (Cofork.IsColimit.π_desc h))
     (fun x hx b hb => Quiver.Hom.op_inj (Cofork.IsColimit.hom_ext h
-      (by simpa only [Quiver.Hom.op_unop, Cofork.IsColimit.π_desc] using Quiver.Hom.unop_inj hb)))
+      (by simpa [CokernelCofork.ofπ, Cofork.ofπ] using Quiver.Hom.unop_inj hb)))
 
 /-- A limit kernel fork gives a colimit cokernel cofork in the opposite category -/
 def KernelFork.IsLimit.ofιOp {K X Y : C} (i : K ⟶ X) {f : X ⟶ Y}
@@ -911,7 +911,7 @@ def KernelFork.IsLimit.ofιUnop {K X Y : Cᵒᵖ} (i : K ⟶ X) {f : X ⟶ Y}
     (fun x hx => (h.lift (KernelFork.ofι x.op (Quiver.Hom.unop_inj hx))).unop)
     (fun x hx => Quiver.Hom.op_inj (Fork.IsLimit.lift_ι h))
     (fun x hx b hb => Quiver.Hom.op_inj (Fork.IsLimit.hom_ext h (by
-      simpa only [Quiver.Hom.op_unop, Fork.IsLimit.lift_ι] using Quiver.Hom.unop_inj hb)))
+      simpa [KernelFork.ofι, Fork.ofι, Fork.IsLimit.lift_ι] using Quiver.Hom.unop_inj hb)))
 
 end HasZeroMorphisms
 

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -44,7 +44,7 @@ theorem Quiver.Hom.unop_inj {X Y : Cᵒᵖ} :
   fun _ _ H => congr_arg Quiver.Hom.op H
 #align quiver.hom.unop_inj Quiver.Hom.unop_inj
 
-@[simp]
+@[simp, nolint simpVarHead]
 theorem Quiver.Hom.unop_op {X Y : C} (f : X ⟶ Y) : f.op.unop = f :=
   rfl
 #align quiver.hom.unop_op Quiver.Hom.unop_op

--- a/Mathlib/CategoryTheory/Sites/CoverLifting.lean
+++ b/Mathlib/CategoryTheory/Sites/CoverLifting.lean
@@ -238,7 +238,7 @@ theorem helper {V} (f : V ⟶ U) (y : X ⟶ ((ran G.op).obj ℱ.val).obj (op V))
   convert limit.w (Ran.diagram G.op ℱ.val (op V)) (StructuredArrow.homMk' W fV'.op)
   rw [StructuredArrow.map_mk]
   erw [Category.comp_id]
-  simp only [Quiver.Hom.unop_op, Functor.op_map, Quiver.Hom.op_unop]
+  simp
 set_option linter.uppercaseLean3 false in
 #align category_theory.Ran_is_sheaf_of_cover_lifting.helper CategoryTheory.RanIsSheafOfIsCocontinuous.helper
 

--- a/Mathlib/CategoryTheory/Subobject/Comma.lean
+++ b/Mathlib/CategoryTheory/Subobject/Comma.lean
@@ -184,20 +184,23 @@ theorem unop_left_comp_underlyingIso_hom_unop {A : CostructuredArrow S T}
 theorem lift_projectQuotient [HasColimits C] [PreservesColimits S] {A : CostructuredArrow S T} :
     ∀ (P : Subobject (op A)) {q} (hq : S.map (projectQuotient P).arrow.unop ≫ q = A.hom),
       liftQuotient (projectQuotient P) hq = P :=
-  Subobject.ind _
-    (by
-      intro P f hf q hq
+  Subobject.ind _ fun P f hf q hq => (by
       fapply Subobject.mk_eq_mk_of_comm
-      · refine' (Iso.op (isoMk _ _) : _ ≅ op (unop P))
+      · refine (Iso.op (isoMk ?_ ?_) : _ ≅ op (unop P))
         · exact (Subobject.underlyingIso f.unop.left.op).unop
-        · refine' (cancel_epi (S.map f.unop.left)).1 _
-          simpa [← Category.assoc, ← S.map_comp] using hq
-      · exact Quiver.Hom.unop_inj (by aesop_cat))
+        · refine (cancel_epi (S.map f.unop.left)).1 ?_
+          rw [← Category.assoc, ← S.map_comp]
+          erw [unop_left_comp_underlyingIso_hom_unop f]
+          simpa using hq
+      · exact Quiver.Hom.unop_inj (by
+          simp only [projectQuotient_mk, Iso.op_hom, unop_comp, Quiver.Hom.unop_op, hom_eq_iff,
+            mk_left, comp_left, isoMk_hom_left, Iso.unop_hom, homMk_left]
+          erw [unop_left_comp_underlyingIso_hom_unop] ))
 #align category_theory.costructured_arrow.lift_project_quotient CategoryTheory.CostructuredArrow.lift_projectQuotient
 
 /-- Technical lemma for `quotientEquiv`. -/
 theorem unop_left_comp_ofMkLEMk_unop {A : CostructuredArrow S T} {P Q : (CostructuredArrow S T)ᵒᵖ}
-    {f : P ⟶ op A} {g : Q ⟶ op A} [Mono f.unop.left.op] [Mono g.unop.left.op]
+    {f : P ⟶  op A} {g : Q ⟶  op A} [Mono f.unop.left.op] [Mono g.unop.left.op]
     (h : Subobject.mk f.unop.left.op ≤ Subobject.mk g.unop.left.op) :
     g.unop.left ≫ (Subobject.ofMkLEMk f.unop.left.op g.unop.left.op h).unop = f.unop.left := by
   conv_lhs =>
@@ -215,16 +218,17 @@ def quotientEquiv [HasColimits C] [PreservesColimits S] (A : CostructuredArrow S
   toFun P := ⟨projectQuotient P, projectQuotient_factors P⟩
   invFun P := liftQuotient P.val P.prop.choose_spec
   left_inv P := lift_projectQuotient _ _
-  right_inv P := Subtype.ext (by simp only [liftQuotient, Quiver.Hom.unop_op, homMk_left,
-      Quiver.Hom.op_unop, projectQuotient_mk, Subobject.mk_arrow])
+  right_inv P := Subtype.ext (by simp only [liftQuotient, Functor.const_obj_obj, projectQuotient_mk,
+    mk_left, op_unop, Quiver.Hom.unop_op, homMk_left, Subobject.mk_arrow])
   map_rel_iff' := by
     apply Subobject.ind₂
     intro P Q f g hf hg
     refine' ⟨fun h => Subobject.mk_le_mk_of_comm _ _, fun h => _⟩
     · refine' (homMk (Subobject.ofMkLEMk _ _ h).unop ((cancel_epi (S.map g.unop.left)).1 _)).op
       dsimp
-      simp only [← S.map_comp_assoc, unop_left_comp_ofMkLEMk_unop, unop_op, CommaMorphism.w,
-        Functor.const_obj_obj, right_eq_id, Functor.const_obj_map, Category.comp_id]
+      rw [← S.map_comp_assoc]
+      erw [unop_left_comp_ofMkLEMk_unop]
+      simp
     · apply Quiver.Hom.unop_inj
       ext
       exact unop_left_comp_ofMkLEMk_unop _

--- a/Mathlib/CategoryTheory/Triangulated/Opposite.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite.lean
@@ -219,8 +219,7 @@ noncomputable def functor : (Triangle C)ᵒᵖ ⥤ Triangle Cᵒᵖ where
       comm₃ := by
         dsimp
         rw [assoc, ← Functor.map_comp, ← op_comp, ← φ.unop.comm₃, op_comp, Functor.map_comp,
-          opShiftFunctorEquivalence_counitIso_inv_naturality_assoc]
-        rfl }
+          opShiftFunctorEquivalence_counitIso_inv_naturality_assoc] }
 
 /-- The functor which sends a triangle `X ⟶ Y ⟶ Z ⟶ X⟦1⟧` in `Cᵒᵖ` to the triangle
 `Z.unop ⟶ Y.unop ⟶ X.unop ⟶ Z.unop⟦1⟧` in `C` (without introducing signs). -/

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -145,15 +145,15 @@ namespace Quiver
 
 /-- `Vᵒᵖ` reverses the direction of all arrows of `V`. -/
 instance opposite {V} [Quiver V] : Quiver Vᵒᵖ :=
-  ⟨fun a b => (unop b ⟶ unop a)ᵒᵖ⟩
+  ⟨fun ⟨a⟩ ⟨b⟩ => (b ⟶  a)ᵒᵖ⟩
 #align quiver.opposite Quiver.opposite
 
 /-- The opposite of an arrow in `V`. -/
-def Hom.op {V} [Quiver V] {X Y : V} (f : X ⟶ Y) : op Y ⟶ op X := ⟨f⟩
+abbrev Hom.op {V} [Quiver V] {X Y : V} (f : X ⟶ Y) : op Y ⟶ op X := ⟨f⟩
 #align quiver.hom.op Quiver.Hom.op
 
 /-- Given an arrow in `Vᵒᵖ`, we can take the "unopposite" back in `V`. -/
-def Hom.unop {V} [Quiver V] {X Y : Vᵒᵖ} (f : X ⟶ Y) : unop Y ⟶ unop X := Opposite.unop f
+abbrev Hom.unop {V} [Quiver V] {X Y : Vᵒᵖ} (f : X ⟶ Y) : unop Y ⟶ unop X := Opposite.unop f
 #align quiver.hom.unop Quiver.Hom.unop
 
 /-- A type synonym for a quiver with no arrows. -/


### PR DESCRIPTION
These are wrappers around the constructor and projection for `Opposite Quiver.Hom _ _`. The projection itself is reducible and with structure eta built in to defeq it seems like we might be making Lean work harder than is necessary.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
