### PR TITLE
[Merged by Bors] - fix: make sure that `simp_rw` focuses

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -285,13 +285,14 @@ theorem Complex.volume_sum_rpow_lt [Nonempty ι] {p : ℝ} (hp : 1 ≤ p) (r : �
     rw [this, measure_empty, ← zero_eq_ofReal.mpr hr, zero_pow Fin.size_pos'.ne', zero_mul]
   · rw [← Complex.volume_sum_rpow_lt_one _ hp, ← ENNReal.ofReal_pow (le_of_lt hr)]
     convert addHaar_smul_of_nonneg volume (le_of_lt hr) {x : ι → ℂ |  ∑ i, ‖x i‖ ^ p < 1} using 2
-    simp_rw [← Set.preimage_smul_inv₀ (ne_of_gt hr), Set.preimage_setOf_eq, Pi.smul_apply,
-      norm_smul, mul_rpow (norm_nonneg _) (norm_nonneg _), Real.norm_eq_abs, abs_inv, inv_rpow
-      (abs_nonneg _), ← Finset.mul_sum, abs_eq_self.mpr (le_of_lt hr), inv_mul_lt_iff
-      (rpow_pos_of_pos hr _), mul_one, ← rpow_lt_rpow_iff (rpow_nonneg (h₁ _) _)
-      (le_of_lt hr) (by linarith : 0 < p), ← rpow_mul (h₁ _), div_mul_cancel₀ _
-      (ne_of_gt (by linarith) : p ≠ 0), Real.rpow_one, finrank_pi_fintype ℝ,
-      Complex.finrank_real_complex, Finset.sum_const, smul_eq_mul, mul_comm, Fintype.card]
+    · simp_rw [← Set.preimage_smul_inv₀ (ne_of_gt hr), Set.preimage_setOf_eq, Pi.smul_apply,
+        norm_smul, mul_rpow (norm_nonneg _) (norm_nonneg _), Real.norm_eq_abs, abs_inv, inv_rpow
+        (abs_nonneg _), ← Finset.mul_sum, abs_eq_self.mpr (le_of_lt hr), inv_mul_lt_iff
+        (rpow_pos_of_pos hr _), mul_one, ← rpow_lt_rpow_iff (rpow_nonneg (h₁ _) _)
+        (le_of_lt hr) (by linarith : 0 < p), ← rpow_mul (h₁ _), div_mul_cancel₀ _
+        (ne_of_gt (by linarith) : p ≠ 0), Real.rpow_one]
+    · simp_rw [finrank_pi_fintype ℝ, Complex.finrank_real_complex, Finset.sum_const, smul_eq_mul,
+        mul_comm, Fintype.card]
 
 theorem Complex.volume_sum_rpow_le [Nonempty ι] {p : ℝ} (hp : 1 ≤ p) (r : ℝ) :
     volume {x : ι → ℂ | (∑ i, ‖x i‖ ^ p) ^ (1 / p) ≤ r} = (.ofReal r) ^ (2 * card ι) *

--- a/Mathlib/Tactic/SimpRw.lean
+++ b/Mathlib/Tactic/SimpRw.lean
@@ -53,7 +53,7 @@ example {a : ℕ}
 by simp_rw [h1, h2]
 ```
 -/
-elab s:"simp_rw " cfg:(config)? rws:rwRuleSeq g:(location)? : tactic => do
+elab s:"simp_rw " cfg:(config)? rws:rwRuleSeq g:(location)? : tactic => focus do
   let cfg' : TSyntax `Lean.Parser.Tactic.config ← do
     match cfg with
     | Option.none =>

--- a/test/SimpRw.lean
+++ b/test/SimpRw.lean
@@ -41,3 +41,12 @@ example : 1 = 2 := by
   simp_rw (config := {zeta := false}) []
   guard_target =ₛ 1 = a
   exact test_sorry
+
+/--
+error: no goals to be solved
+-/
+-- check that `simp_rw` does not "spill over" goals
+#guard_msgs in
+example {n : Nat} (hn : n = 0) : (n = 0) ∧ (n = 0) := by
+  constructor
+  simp_rw [hn, hn]  -- does this work?


### PR DESCRIPTION
This used to work before the fix.  The fix breaks it.

```lean
import Mathlib.Tactic

example {n : Nat} (hn : n = 0) : (n = 0) ∧ (n = 0) := by
  constructor
  simp_rw [hn, hn]  -- does this work?
```

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.60simp_rw.60.20puzzle)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
