### PR TITLE
[Merged by Bors] - chore: use `@[deprecated (since := "YYYY-MM-DD")]`

### DIFF
--- a/Mathlib/Algebra/Associated.lean
+++ b/Mathlib/Algebra/Associated.lean
@@ -1040,7 +1040,7 @@ theorem mk_le_mk_of_dvd {a b : α} : a ∣ b → Associates.mk a ≤ Associates.
 theorem mk_le_mk_iff_dvd {a b : α} : Associates.mk a ≤ Associates.mk b ↔ a ∣ b := mk_dvd_mk
 #align associates.mk_le_mk_iff_dvd_iff Associates.mk_le_mk_iff_dvd
 
-@[deprecated] alias mk_le_mk_iff_dvd_iff := mk_le_mk_iff_dvd
+@[deprecated (since := "2024-03-16")] alias mk_le_mk_iff_dvd_iff := mk_le_mk_iff_dvd
 
 @[simp]
 theorem isPrimal_mk {a : α} : IsPrimal (Associates.mk a) ↔ IsPrimal a := by
@@ -1050,7 +1050,7 @@ theorem isPrimal_mk {a : α} : IsPrimal (Associates.mk a) ↔ IsPrimal a := by
     exact ⟨a₁, a₂ * u, h₁, Units.mul_right_dvd.mpr h₂, mul_assoc _ _ _⟩
   · exact ⟨a₁, a₂, h₁, h₂, congr_arg _ eq⟩
 
-@[deprecated] alias isPrimal_iff := isPrimal_mk -- 2024-03-16
+@[deprecated (since := "2024-03-16")] alias isPrimal_iff := isPrimal_mk
 
 @[simp]
 theorem decompositionMonoid_iff : DecompositionMonoid (Associates α) ↔ DecompositionMonoid α := by

--- a/Mathlib/Algebra/BigOperators/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Basic.lean
@@ -2675,5 +2675,5 @@ theorem toAdd_prod (s : Finset ι) (f : ι → Multiplicative α) :
 
 end AddCommMonoid
 
-@[deprecated] alias Equiv.prod_comp' := Fintype.prod_equiv -- 2023-12-23
-@[deprecated] alias Equiv.sum_comp' := Fintype.sum_equiv -- 2023-12-23
+@[deprecated (since := "2023-12-23")] alias Equiv.prod_comp' := Fintype.prod_equiv
+@[deprecated (since := "2023-12-23")] alias Equiv.sum_comp' := Fintype.sum_equiv

--- a/Mathlib/Algebra/Field/Subfield.lean
+++ b/Mathlib/Algebra/Field/Subfield.lean
@@ -114,10 +114,9 @@ lemma qsmul_mem (s : S) (q : ℚ) (hx : x ∈ s) : q • x ∈ s := by
   simpa only [Rat.smul_def] using mul_mem (ratCast_mem _ _) hx
 #align subfield_class.rat_smul_mem SubfieldClass.qsmul_mem
 
--- 2024-04-05
-@[deprecated] alias coe_rat_cast := coe_ratCast
-@[deprecated] alias coe_rat_mem := ratCast_mem
-@[deprecated] alias rat_smul_mem := qsmul_mem
+@[deprecated (since := "2024-04-05")] alias coe_rat_cast := coe_ratCast
+@[deprecated (since := "2024-04-05")] alias coe_rat_mem := ratCast_mem
+@[deprecated (since := "2024-04-05")] alias rat_smul_mem := qsmul_mem
 
 @[aesop safe apply (rule_sets := [SetLike])]
 lemma ofScientific_mem (s : S) {b : Bool} {n m : ℕ} :
@@ -330,8 +329,7 @@ protected theorem zsmul_mem {x : K} (hx : x ∈ s) (n : ℤ) : n • x ∈ s :=
 protected theorem intCast_mem (n : ℤ) : (n : K) ∈ s := intCast_mem s n
 #align subfield.coe_int_mem Subfield.intCast_mem
 
--- 2024-04-05
-@[deprecated] alias coe_int_mem := intCast_mem
+@[deprecated (since := "2024-04-05")] alias coe_int_mem := intCast_mem
 
 theorem zpow_mem {x : K} (hx : x ∈ s) (n : ℤ) : x ^ n ∈ s := by
   cases n

--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -1426,16 +1426,15 @@ theorem multiplicative_of_isTotal (p : α → Prop) (hswap : ∀ {a b}, p a → 
 
 end multiplicative
 
--- 2024-03-20
-@[deprecated] alias div_mul_cancel' := div_mul_cancel
-@[deprecated] alias mul_div_cancel'' := mul_div_cancel_right
+@[deprecated (since := "2024-03-20")] alias div_mul_cancel' := div_mul_cancel
+@[deprecated (since := "2024-03-20")] alias mul_div_cancel'' := mul_div_cancel_right
 -- The name `add_sub_cancel` was reused
--- @[deprecated] alias add_sub_cancel := add_sub_cancel_right
-@[deprecated] alias div_mul_cancel''' := div_mul_cancel_right
-@[deprecated] alias sub_add_cancel'' := sub_add_cancel_right
-@[deprecated] alias mul_div_cancel''' := mul_div_cancel_left
-@[deprecated] alias add_sub_cancel' := add_sub_cancel_left
-@[deprecated] alias mul_div_cancel'_right := mul_div_cancel
-@[deprecated] alias add_sub_cancel'_right := add_sub_cancel
-@[deprecated] alias div_mul_cancel'' := div_mul_cancel_left
-@[deprecated] alias sub_add_cancel' := sub_add_cancel_left
+-- @[deprecated (since := "2024-03-20")] alias add_sub_cancel := add_sub_cancel_right
+@[deprecated (since := "2024-03-20")] alias div_mul_cancel''' := div_mul_cancel_right
+@[deprecated (since := "2024-03-20")] alias sub_add_cancel'' := sub_add_cancel_right
+@[deprecated (since := "2024-03-20")] alias mul_div_cancel''' := mul_div_cancel_left
+@[deprecated (since := "2024-03-20")] alias add_sub_cancel' := add_sub_cancel_left
+@[deprecated (since := "2024-03-20")] alias mul_div_cancel'_right := mul_div_cancel
+@[deprecated (since := "2024-03-20")] alias add_sub_cancel'_right := add_sub_cancel
+@[deprecated (since := "2024-03-20")] alias div_mul_cancel'' := div_mul_cancel_left
+@[deprecated (since := "2024-03-20")] alias sub_add_cancel' := sub_add_cancel_left

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -1030,9 +1030,8 @@ theorem zpow_natCast (a : G) : ∀ n : ℕ, a ^ (n : ℤ) = a ^ n
 #align coe_nat_zsmul natCast_zsmul
 #align of_nat_zsmul natCast_zsmul
 
--- 2024-03-20
-@[deprecated] alias zpow_coe_nat := zpow_natCast
-@[deprecated] alias coe_nat_zsmul := natCast_zsmul
+@[deprecated (since := "2024-03-20")] alias zpow_coe_nat := zpow_natCast
+@[deprecated (since := "2024-03-20")] alias coe_nat_zsmul := natCast_zsmul
 
 -- See note [no_index around OfNat.ofNat]
 @[to_additive ofNat_zsmul]

--- a/Mathlib/Algebra/Group/UniqueProds.lean
+++ b/Mathlib/Algebra/Group/UniqueProds.lean
@@ -634,15 +634,22 @@ instance (priority := 100) of_covariant_left [IsLeftCancelMul G]
 
 end TwoUniqueProds
 
--- deprecated 2024-02-04
-@[deprecated] alias UniqueProds.mulHom_image_of_injective := UniqueProds.of_injective_mulHom
-@[deprecated] alias UniqueSums.addHom_image_of_injective := UniqueSums.of_injective_addHom
-@[deprecated] alias UniqueProds.mulHom_image_iff := MulEquiv.uniqueProds_iff
-@[deprecated] alias UniqueSums.addHom_image_iff := AddEquiv.uniqueSums_iff
-@[deprecated] alias TwoUniqueProds.mulHom_image_of_injective := TwoUniqueProds.of_injective_mulHom
-@[deprecated] alias TwoUniqueSums.addHom_image_of_injective := TwoUniqueSums.of_injective_addHom
-@[deprecated] alias TwoUniqueProds.mulHom_image_iff := MulEquiv.twoUniqueProds_iff
-@[deprecated] alias TwoUniqueSums.addHom_image_iff := AddEquiv.twoUniqueSums_iff
+@[deprecated (since := "2024-02-04")]
+alias UniqueProds.mulHom_image_of_injective := UniqueProds.of_injective_mulHom
+@[deprecated (since := "2024-02-04")]
+alias UniqueSums.addHom_image_of_injective := UniqueSums.of_injective_addHom
+@[deprecated (since := "2024-02-04")]
+alias UniqueProds.mulHom_image_iff := MulEquiv.uniqueProds_iff
+@[deprecated (since := "2024-02-04")]
+alias UniqueSums.addHom_image_iff := AddEquiv.uniqueSums_iff
+@[deprecated (since := "2024-02-04")]
+alias TwoUniqueProds.mulHom_image_of_injective := TwoUniqueProds.of_injective_mulHom
+@[deprecated (since := "2024-02-04")]
+alias TwoUniqueSums.addHom_image_of_injective := TwoUniqueSums.of_injective_addHom
+@[deprecated (since := "2024-02-04")]
+alias TwoUniqueProds.mulHom_image_iff := MulEquiv.twoUniqueProds_iff
+@[deprecated (since := "2024-02-04")]
+alias TwoUniqueSums.addHom_image_iff := AddEquiv.twoUniqueSums_iff
 
 instance {ι} (G : ι → Type*) [∀ i, AddZeroClass (G i)] [∀ i, TwoUniqueSums (G i)] :
     TwoUniqueSums (Π₀ i, G i) :=

--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -1214,13 +1214,13 @@ noncomputable def commGroupOfIsUnit [hM : CommMonoid M] (h : ∀ a : M, IsUnit a
 
 end NoncomputableDefs
 
--- 2024-03-20
-attribute [deprecated div_mul_cancel_right] IsUnit.div_mul_left
-attribute [deprecated sub_add_cancel_right] IsAddUnit.sub_add_left
-attribute [deprecated div_mul_cancel_left] IsUnit.div_mul_right
-attribute [deprecated sub_add_cancel_left] IsAddUnit.sub_add_right
+attribute [deprecated div_mul_cancel_right (since := "2024-03-20")] IsUnit.div_mul_left
+attribute [deprecated sub_add_cancel_right (since := "2024-03-20")] IsAddUnit.sub_add_left
+attribute [deprecated div_mul_cancel_left (since := "2024-03-20")] IsUnit.div_mul_right
+attribute [deprecated sub_add_cancel_left (since := "2024-03-20")] IsAddUnit.sub_add_right
 -- The names `IsUnit.mul_div_cancel` and `IsAddUnit.add_sub_cancel` have been reused
--- @[deprecated] alias IsUnit.mul_div_cancel := IsUnit.mul_div_cancel_right
--- @[deprecated] alias IsAddUnit.add_sub_cancel := IsAddUnit.add_sub_cancel_right
-@[deprecated] alias IsUnit.mul_div_cancel' := IsUnit.mul_div_cancel
-@[deprecated] alias IsAddUnit.add_sub_cancel' := IsAddUnit.add_sub_cancel
+-- @[deprecated (since := "2024-03-20")] alias IsUnit.mul_div_cancel := IsUnit.mul_div_cancel_right
+-- @[deprecated (since := "2024-03-20")]
+-- alias IsAddUnit.add_sub_cancel := IsAddUnit.add_sub_cancel_right
+@[deprecated (since := "2024-03-20")] alias IsUnit.mul_div_cancel' := IsUnit.mul_div_cancel
+@[deprecated (since := "2024-03-20")] alias IsAddUnit.add_sub_cancel' := IsAddUnit.add_sub_cancel


### PR DESCRIPTION
This is far from exhaustive, but perhaps can get the ball rolling.