### PR TITLE
[Merged by Bors] - chore: Split `Algebra.GroupPower.Order`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -256,7 +256,6 @@ import Mathlib.Algebra.Group.Units.Hom
 import Mathlib.Algebra.Group.WithOne.Basic
 import Mathlib.Algebra.Group.WithOne.Defs
 import Mathlib.Algebra.GroupPower.IterateHom
-import Mathlib.Algebra.GroupPower.Order
 import Mathlib.Algebra.GroupWithZero.Basic
 import Mathlib.Algebra.GroupWithZero.Commute
 import Mathlib.Algebra.GroupWithZero.Conj
@@ -484,6 +483,7 @@ import Mathlib.Algebra.Order.Floor.Div
 import Mathlib.Algebra.Order.Floor.Prime
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Group.Action
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Group.Bounds
 import Mathlib.Algebra.Order.Group.Cone
 import Mathlib.Algebra.Order.Group.Defs
@@ -549,6 +549,7 @@ import Mathlib.Algebra.Order.Positive.Field
 import Mathlib.Algebra.Order.Positive.Ring
 import Mathlib.Algebra.Order.Rearrangement
 import Mathlib.Algebra.Order.Ring.Abs
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Algebra.Order.Ring.Canonical
 import Mathlib.Algebra.Order.Ring.Cast
 import Mathlib.Algebra.Order.Ring.CharZero

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
@@ -4,9 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Kappelmann
 -/
 import Mathlib.Algebra.ContinuedFractions.Computation.CorrectnessTerminating
+import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Data.Nat.Fib.Basic
 import Mathlib.Tactic.Monotonicity
-import Mathlib.Algebra.GroupPower.Order
 
 #align_import algebra.continued_fractions.computation.approximations from "leanprover-community/mathlib"@"a7e36e48519ab281320c4d192da6a7b348ce40ad"
 

--- a/Mathlib/Algebra/Order/Chebyshev.lean
+++ b/Mathlib/Algebra/Order/Chebyshev.lean
@@ -3,9 +3,10 @@ Copyright (c) 2023 Mantas Bakšys, Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mantas Bakšys, Yaël Dillies
 -/
-import Mathlib.Algebra.GroupPower.Order
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Rearrangement
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.GroupTheory.Perm.Cycle.Basic
 
 #align_import algebra.order.chebyshev from "leanprover-community/mathlib"@"b7399344324326918d65d0c74e9571e3a8cb9199"

--- a/Mathlib/Algebra/Order/Group/Basic.lean
+++ b/Mathlib/Algebra/Order/Group/Basic.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2015 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Robert Y. Lewis
+-/
+import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
+
+#align_import algebra.group_power.order from "leanprover-community/mathlib"@"00f91228655eecdcd3ac97a7fd8dbcb139fe990a"
+
+/-!
+# Lemmas about the interaction of power operations with order
+-/
+
+-- We should need only a minimal development of sets in order to get here.
+assert_not_exists Set.Subsingleton
+
+open Function Int
+
+variable {α M R : Type*}
+
+section OrderedCommGroup
+variable [OrderedCommGroup α] {m n : ℤ} {a b : α}
+
+@[to_additive zsmul_pos] lemma one_lt_zpow' (ha : 1 < a) (hn : 0 < n) : 1 < a ^ n := by
+  obtain ⟨n, rfl⟩ := Int.eq_ofNat_of_zero_le hn.le
+  rw [zpow_natCast]
+  refine one_lt_pow' ha ?_
+  rintro rfl
+  simp at hn
+#align one_lt_zpow' one_lt_zpow'
+#align zsmul_pos zsmul_pos
+
+@[to_additive zsmul_strictMono_left]
+lemma zpow_right_strictMono (ha : 1 < a) : StrictMono fun n : ℤ ↦ a ^ n := fun m n h ↦
+  calc
+    a ^ m = a ^ m * 1 := (mul_one _).symm
+    _ < a ^ m * a ^ (n - m) := mul_lt_mul_left' (one_lt_zpow' ha <| Int.sub_pos_of_lt h) _
+    _ = a ^ n := by simp [← zpow_add, m.add_comm]
+#align zpow_strict_mono_right zpow_right_strictMono
+#align zsmul_strict_mono_left zsmul_strictMono_left
+
+@[to_additive zsmul_mono_left]
+lemma zpow_mono_right (ha : 1 ≤ a) : Monotone fun n : ℤ ↦ a ^ n := fun m n h ↦
+  calc
+    a ^ m = a ^ m * 1 := (mul_one _).symm
+    _ ≤ a ^ m * a ^ (n - m) := mul_le_mul_left' (one_le_zpow ha <| Int.sub_nonneg_of_le h) _
+    _ = a ^ n := by simp [← zpow_add, m.add_comm]
+#align zpow_mono_right zpow_mono_right
+#align zsmul_mono_left zsmul_mono_left
+
+@[to_additive (attr := gcongr)]
+lemma zpow_le_zpow (ha : 1 ≤ a) (h : m ≤ n) : a ^ m ≤ a ^ n := zpow_mono_right ha h
+#align zpow_le_zpow zpow_le_zpow
+#align zsmul_le_zsmul zsmul_le_zsmul
+
+@[to_additive (attr := gcongr)]
+lemma zpow_lt_zpow (ha : 1 < a) (h : m < n) : a ^ m < a ^ n := zpow_right_strictMono ha h
+#align zpow_lt_zpow zpow_lt_zpow
+#align zsmul_lt_zsmul zsmul_lt_zsmul
+
+@[to_additive]
+lemma zpow_le_zpow_iff (ha : 1 < a) : a ^ m ≤ a ^ n ↔ m ≤ n := (zpow_right_strictMono ha).le_iff_le
+#align zpow_le_zpow_iff zpow_le_zpow_iff
+#align zsmul_le_zsmul_iff zsmul_le_zsmul_iff
+
+@[to_additive]
+lemma zpow_lt_zpow_iff (ha : 1 < a) : a ^ m < a ^ n ↔ m < n := (zpow_right_strictMono ha).lt_iff_lt
+#align zpow_lt_zpow_iff zpow_lt_zpow_iff
+#align zsmul_lt_zsmul_iff zsmul_lt_zsmul_iff
+
+variable (α)
+
+@[to_additive zsmul_strictMono_right]
+lemma zpow_strictMono_left (hn : 0 < n) : StrictMono ((· ^ n) : α → α) := fun a b hab => by
+  rw [← one_lt_div', ← div_zpow]; exact one_lt_zpow' (one_lt_div'.2 hab) hn
+#align zpow_strict_mono_left zpow_strictMono_left
+#align zsmul_strict_mono_right zsmul_strictMono_right
+
+@[to_additive zsmul_mono_right]
+lemma zpow_mono_left (hn : 0 ≤ n) : Monotone ((· ^ n) : α → α) := fun a b hab => by
+  rw [← one_le_div', ← div_zpow]; exact one_le_zpow (one_le_div'.2 hab) hn
+#align zpow_mono_left zpow_mono_left
+#align zsmul_mono_right zsmul_mono_right
+
+variable {α}
+
+@[to_additive (attr := gcongr)]
+lemma zpow_le_zpow' (hn : 0 ≤ n) (h : a ≤ b) : a ^ n ≤ b ^ n := zpow_mono_left α hn h
+#align zpow_le_zpow' zpow_le_zpow'
+#align zsmul_le_zsmul' zsmul_le_zsmul'
+
+@[to_additive (attr := gcongr)]
+lemma zpow_lt_zpow' (hn : 0 < n) (h : a < b) : a ^ n < b ^ n := zpow_strictMono_left α hn h
+#align zpow_lt_zpow' zpow_lt_zpow'
+#align zsmul_lt_zsmul' zsmul_lt_zsmul'
+
+end OrderedCommGroup
+
+section LinearOrderedCommGroup
+
+variable [LinearOrderedCommGroup α] {n : ℤ} {a b : α}
+
+@[to_additive] lemma zpow_le_zpow_iff' (hn : 0 < n) : a ^ n ≤ b ^ n ↔ a ≤ b :=
+  (zpow_strictMono_left α hn).le_iff_le
+#align zpow_le_zpow_iff' zpow_le_zpow_iff'
+#align zsmul_le_zsmul_iff' zsmul_le_zsmul_iff'
+
+@[to_additive] lemma zpow_lt_zpow_iff' (hn : 0 < n) : a ^ n < b ^ n ↔ a < b :=
+  (zpow_strictMono_left α hn).lt_iff_lt
+#align zpow_lt_zpow_iff' zpow_lt_zpow_iff'
+#align zsmul_lt_zsmul_iff' zsmul_lt_zsmul_iff'
+
+@[to_additive zsmul_right_injective
+"See also `smul_right_injective`. TODO: provide a `NoZeroSMulDivisors` instance. We can't do
+that here because importing that definition would create import cycles."]
+lemma zpow_left_injective (hn : n ≠ 0) : Injective ((· ^ n) : α → α) := by
+  obtain hn | hn := hn.lt_or_lt
+  · refine fun a b (hab : a ^ n = b ^ n) ↦
+      (zpow_strictMono_left _ $ Int.neg_pos_of_neg hn).injective ?_
+    rw [zpow_neg, zpow_neg, hab]
+  · exact (zpow_strictMono_left _ hn).injective
+#align zpow_left_injective zpow_left_injective
+#align zsmul_right_injective zsmul_right_injective
+
+@[to_additive zsmul_right_inj]
+lemma zpow_left_inj (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := (zpow_left_injective hn).eq_iff
+#align zpow_left_inj zpow_left_inj
+#align zsmul_right_inj zsmul_right_inj
+
+/-- Alias of `zpow_left_inj`, for ease of discovery alongside `zsmul_le_zsmul_iff'` and
+`zsmul_lt_zsmul_iff'`. -/
+@[to_additive "Alias of `zsmul_right_inj`, for ease of discovery alongside `zsmul_le_zsmul_iff'` and
+`zsmul_lt_zsmul_iff'`."]
+lemma zpow_eq_zpow_iff' (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := zpow_left_inj hn
+#align zpow_eq_zpow_iff' zpow_eq_zpow_iff'
+#align zsmul_eq_zsmul_iff' zsmul_eq_zsmul_iff'
+
+end LinearOrderedCommGroup

--- a/Mathlib/Algebra/Order/Group/Nat.lean
+++ b/Mathlib/Algebra/Order/Group/Nat.lean
@@ -49,4 +49,15 @@ instance instOrderedSub : OrderedSub ℕ := by
 
 theorem _root_.NeZero.one_le {n : ℕ} [NeZero n] : 1 ≤ n := one_le_iff_ne_zero.mpr (NeZero.ne n)
 
+variable {α : Type*} {n : ℕ} {f : α → ℕ}
+
+/-- See also `pow_left_strictMonoOn`. -/
+protected lemma pow_left_strictMono (hn : n ≠ 0) : StrictMono (· ^ n : ℕ → ℕ) :=
+  fun _ _ h ↦ Nat.pow_lt_pow_left h hn
+#align nat.pow_left_strict_mono Nat.pow_left_strictMono
+
+lemma _root_.StrictMono.nat_pow [Preorder α] (hn : n ≠ 0) (hf : StrictMono f) :
+    StrictMono (f · ^ n) := (Nat.pow_left_strictMono hn).comp hf
+#align strict_mono.nat_pow StrictMono.nat_pow
+
 end Nat

--- a/Mathlib/Algebra/Order/Interval/Set/Group.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Group.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy Degenne
 -/
 import Mathlib.Algebra.Order.Group.Abs
-import Mathlib.Algebra.Order.Group.OrderIso
 import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Group.OrderIso
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.Order.Interval.Set.Basic

--- a/Mathlib/Algebra/Order/Interval/Set/Group.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Group.lean
@@ -3,9 +3,10 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy Degenne
 -/
-import Mathlib.Algebra.GroupPower.Order
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Group.OrderIso
+import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.Order.Interval.Set.Basic
 import Mathlib.Logic.Pairwise

--- a/Mathlib/Algebra/Order/Interval/Set/Instances.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Instances.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Stuart Presnell. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stuart Presnell, Eric Wieser, Yaël Dillies, Patrick Massot, Scott Morrison
 -/
-import Mathlib.Algebra.GroupPower.Order
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Algebra.Ring.Regular
 import Mathlib.Order.Interval.Set.Basic
 

--- a/Mathlib/Algebra/Order/Ring/Abs.lean
+++ b/Mathlib/Algebra/Order/Ring/Abs.lean
@@ -3,7 +3,7 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
 -/
-import Mathlib.Algebra.GroupPower.Order
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Algebra.Order.Ring.CharZero
 import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Algebra.Ring.Divisibility.Basic

--- a/Mathlib/Algebra/Order/Ring/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Basic.lean
@@ -4,12 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis
 -/
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
-import Mathlib.Algebra.Order.Ring.Canonical
+import Mathlib.Algebra.Order.Ring.Defs
+import Mathlib.Algebra.Ring.Parity
 
 #align_import algebra.group_power.order from "leanprover-community/mathlib"@"00f91228655eecdcd3ac97a7fd8dbcb139fe990a"
 
 /-!
-# Lemmas about the interaction of power operations with order
+# Basic lemmas about ordered rings
 -/
 
 -- We should need only a minimal development of sets in order to get here.
@@ -19,134 +20,22 @@ open Function Int
 
 variable {α M R : Type*}
 
-section OrderedCommGroup
-variable [OrderedCommGroup α] {m n : ℤ} {a b : α}
+namespace MonoidHom
 
-@[to_additive zsmul_pos] lemma one_lt_zpow' (ha : 1 < a) (hn : 0 < n) : 1 < a ^ n := by
-  obtain ⟨n, rfl⟩ := Int.eq_ofNat_of_zero_le hn.le
-  rw [zpow_natCast]
-  refine one_lt_pow' ha ?_
-  rintro rfl
-  simp at hn
-#align one_lt_zpow' one_lt_zpow'
-#align zsmul_pos zsmul_pos
+variable [Ring R] [Monoid M] [LinearOrder M] [CovariantClass M M (· * ·) (· ≤ ·)] (f : R →* M)
 
-@[to_additive zsmul_strictMono_left]
-lemma zpow_right_strictMono (ha : 1 < a) : StrictMono fun n : ℤ ↦ a ^ n := fun m n h ↦
-  calc
-    a ^ m = a ^ m * 1 := (mul_one _).symm
-    _ < a ^ m * a ^ (n - m) := mul_lt_mul_left' (one_lt_zpow' ha <| Int.sub_pos_of_lt h) _
-    _ = a ^ n := by simp [← zpow_add, m.add_comm]
-#align zpow_strict_mono_right zpow_right_strictMono
-#align zsmul_strict_mono_left zsmul_strictMono_left
+theorem map_neg_one : f (-1) = 1 :=
+  (pow_eq_one_iff (Nat.succ_ne_zero 1)).1 <| by rw [← map_pow, neg_one_sq, map_one]
+#align monoid_hom.map_neg_one MonoidHom.map_neg_one
 
-@[to_additive zsmul_mono_left]
-lemma zpow_mono_right (ha : 1 ≤ a) : Monotone fun n : ℤ ↦ a ^ n := fun m n h ↦
-  calc
-    a ^ m = a ^ m * 1 := (mul_one _).symm
-    _ ≤ a ^ m * a ^ (n - m) := mul_le_mul_left' (one_le_zpow ha <| Int.sub_nonneg_of_le h) _
-    _ = a ^ n := by simp [← zpow_add, m.add_comm]
-#align zpow_mono_right zpow_mono_right
-#align zsmul_mono_left zsmul_mono_left
+@[simp]
+theorem map_neg (x : R) : f (-x) = f x := by rw [← neg_one_mul, map_mul, map_neg_one, one_mul]
+#align monoid_hom.map_neg MonoidHom.map_neg
 
-@[to_additive (attr := gcongr)]
-lemma zpow_le_zpow (ha : 1 ≤ a) (h : m ≤ n) : a ^ m ≤ a ^ n := zpow_mono_right ha h
-#align zpow_le_zpow zpow_le_zpow
-#align zsmul_le_zsmul zsmul_le_zsmul
+theorem map_sub_swap (x y : R) : f (x - y) = f (y - x) := by rw [← map_neg, neg_sub]
+#align monoid_hom.map_sub_swap MonoidHom.map_sub_swap
 
-@[to_additive (attr := gcongr)]
-lemma zpow_lt_zpow (ha : 1 < a) (h : m < n) : a ^ m < a ^ n := zpow_right_strictMono ha h
-#align zpow_lt_zpow zpow_lt_zpow
-#align zsmul_lt_zsmul zsmul_lt_zsmul
-
-@[to_additive]
-lemma zpow_le_zpow_iff (ha : 1 < a) : a ^ m ≤ a ^ n ↔ m ≤ n := (zpow_right_strictMono ha).le_iff_le
-#align zpow_le_zpow_iff zpow_le_zpow_iff
-#align zsmul_le_zsmul_iff zsmul_le_zsmul_iff
-
-@[to_additive]
-lemma zpow_lt_zpow_iff (ha : 1 < a) : a ^ m < a ^ n ↔ m < n := (zpow_right_strictMono ha).lt_iff_lt
-#align zpow_lt_zpow_iff zpow_lt_zpow_iff
-#align zsmul_lt_zsmul_iff zsmul_lt_zsmul_iff
-
-variable (α)
-
-@[to_additive zsmul_strictMono_right]
-lemma zpow_strictMono_left (hn : 0 < n) : StrictMono ((· ^ n) : α → α) := fun a b hab => by
-  rw [← one_lt_div', ← div_zpow]; exact one_lt_zpow' (one_lt_div'.2 hab) hn
-#align zpow_strict_mono_left zpow_strictMono_left
-#align zsmul_strict_mono_right zsmul_strictMono_right
-
-@[to_additive zsmul_mono_right]
-lemma zpow_mono_left (hn : 0 ≤ n) : Monotone ((· ^ n) : α → α) := fun a b hab => by
-  rw [← one_le_div', ← div_zpow]; exact one_le_zpow (one_le_div'.2 hab) hn
-#align zpow_mono_left zpow_mono_left
-#align zsmul_mono_right zsmul_mono_right
-
-variable {α}
-
-@[to_additive (attr := gcongr)]
-lemma zpow_le_zpow' (hn : 0 ≤ n) (h : a ≤ b) : a ^ n ≤ b ^ n := zpow_mono_left α hn h
-#align zpow_le_zpow' zpow_le_zpow'
-#align zsmul_le_zsmul' zsmul_le_zsmul'
-
-@[to_additive (attr := gcongr)]
-lemma zpow_lt_zpow' (hn : 0 < n) (h : a < b) : a ^ n < b ^ n := zpow_strictMono_left α hn h
-#align zpow_lt_zpow' zpow_lt_zpow'
-#align zsmul_lt_zsmul' zsmul_lt_zsmul'
-
-end OrderedCommGroup
-
-section LinearOrderedCommGroup
-
-variable [LinearOrderedCommGroup α] {n : ℤ} {a b : α}
-
-@[to_additive] lemma zpow_le_zpow_iff' (hn : 0 < n) : a ^ n ≤ b ^ n ↔ a ≤ b :=
-  (zpow_strictMono_left α hn).le_iff_le
-#align zpow_le_zpow_iff' zpow_le_zpow_iff'
-#align zsmul_le_zsmul_iff' zsmul_le_zsmul_iff'
-
-@[to_additive] lemma zpow_lt_zpow_iff' (hn : 0 < n) : a ^ n < b ^ n ↔ a < b :=
-  (zpow_strictMono_left α hn).lt_iff_lt
-#align zpow_lt_zpow_iff' zpow_lt_zpow_iff'
-#align zsmul_lt_zsmul_iff' zsmul_lt_zsmul_iff'
-
-@[to_additive zsmul_right_injective
-"See also `smul_right_injective`. TODO: provide a `NoZeroSMulDivisors` instance. We can't do
-that here because importing that definition would create import cycles."]
-lemma zpow_left_injective (hn : n ≠ 0) : Injective ((· ^ n) : α → α) := by
-  obtain hn | hn := hn.lt_or_lt
-  · refine fun a b (hab : a ^ n = b ^ n) ↦
-      (zpow_strictMono_left _ $ Int.neg_pos_of_neg hn).injective ?_
-    rw [zpow_neg, zpow_neg, hab]
-  · exact (zpow_strictMono_left _ hn).injective
-#align zpow_left_injective zpow_left_injective
-#align zsmul_right_injective zsmul_right_injective
-
-@[to_additive zsmul_right_inj]
-lemma zpow_left_inj (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := (zpow_left_injective hn).eq_iff
-#align zpow_left_inj zpow_left_inj
-#align zsmul_right_inj zsmul_right_inj
-
-/-- Alias of `zpow_left_inj`, for ease of discovery alongside `zsmul_le_zsmul_iff'` and
-`zsmul_lt_zsmul_iff'`. -/
-@[to_additive "Alias of `zsmul_right_inj`, for ease of discovery alongside `zsmul_le_zsmul_iff'` and
-`zsmul_lt_zsmul_iff'`."]
-lemma zpow_eq_zpow_iff' (hn : n ≠ 0) : a ^ n = b ^ n ↔ a = b := zpow_left_inj hn
-#align zpow_eq_zpow_iff' zpow_eq_zpow_iff'
-#align zsmul_eq_zsmul_iff' zsmul_eq_zsmul_iff'
-
-end LinearOrderedCommGroup
-
-namespace CanonicallyOrderedCommSemiring
-
-variable [CanonicallyOrderedCommSemiring R]
-
-theorem pow_pos {a : R} (H : 0 < a) (n : ℕ) : 0 < a ^ n :=
-  pos_iff_ne_zero.2 <| pow_ne_zero _ H.ne'
-#align canonically_ordered_comm_semiring.pow_pos CanonicallyOrderedCommSemiring.pow_pos
-
-end CanonicallyOrderedCommSemiring
+end MonoidHom
 
 section OrderedSemiring
 
@@ -543,37 +432,6 @@ lemma strictMono_pow_bit1 (n : ℕ) : StrictMono (· ^ bit1 n : R → R) := (odd
 end deprecated
 end LinearOrderedSemiring
 
-namespace MonoidHom
-
-variable [Ring R] [Monoid M] [LinearOrder M] [CovariantClass M M (· * ·) (· ≤ ·)] (f : R →* M)
-
-theorem map_neg_one : f (-1) = 1 :=
-  (pow_eq_one_iff (Nat.succ_ne_zero 1)).1 <| by rw [← map_pow, neg_one_sq, map_one]
-#align monoid_hom.map_neg_one MonoidHom.map_neg_one
-
-@[simp]
-theorem map_neg (x : R) : f (-x) = f x := by rw [← neg_one_mul, map_mul, map_neg_one, one_mul]
-#align monoid_hom.map_neg MonoidHom.map_neg
-
-theorem map_sub_swap (x y : R) : f (x - y) = f (y - x) := by rw [← map_neg, neg_sub]
-#align monoid_hom.map_sub_swap MonoidHom.map_sub_swap
-
-end MonoidHom
-
-namespace Nat
-variable {n : ℕ} {f : α → ℕ}
-
-/-- See also `pow_left_strictMonoOn`. -/
-protected lemma pow_left_strictMono (hn : n ≠ 0) : StrictMono (· ^ n : ℕ → ℕ) :=
-  fun _ _ h ↦ Nat.pow_lt_pow_left h hn
-#align nat.pow_left_strict_mono Nat.pow_left_strictMono
-
-lemma _root_.StrictMono.nat_pow [Preorder α] (hn : n ≠ 0) (hf : StrictMono f) :
-    StrictMono (f · ^ n) := (Nat.pow_left_strictMono hn).comp hf
-#align strict_mono.nat_pow StrictMono.nat_pow
-
-end Nat
-
 /-!
 ### Deprecated lemmas
 
@@ -596,8 +454,6 @@ Those lemmas have been deprecated on 2023-12-23.
 @[deprecated] alias lt_of_pow_lt_pow := lt_of_pow_lt_pow_left
 @[deprecated] alias le_of_pow_le_pow := le_of_pow_le_pow_left
 @[deprecated] alias self_le_pow := le_self_pow
-@[deprecated] alias Nat.pow_lt_pow_of_lt_left := Nat.pow_lt_pow_left
-@[deprecated] alias Nat.pow_le_iff_le_left := Nat.pow_le_pow_iff_left
 @[deprecated] alias Nat.pow_lt_pow_of_lt_right := pow_lt_pow_right
 @[deprecated] protected alias Nat.pow_right_strictMono := pow_right_strictMono
 @[deprecated] alias Nat.pow_le_iff_le_right := pow_le_pow_iff_right

--- a/Mathlib/Algebra/Order/Ring/Canonical.lean
+++ b/Mathlib/Algebra/Order/Ring/Canonical.lean
@@ -80,6 +80,9 @@ protected theorem mul_pos : 0 < a * b ↔ 0 < a ∧ 0 < b := by
   simp only [pos_iff_ne_zero, ne_eq, mul_eq_zero, not_or]
 #align canonically_ordered_comm_semiring.mul_pos CanonicallyOrderedCommSemiring.mul_pos
 
+lemma pow_pos (ha : 0 < a) (n : ℕ) : 0 < a ^ n := pos_iff_ne_zero.2 <| pow_ne_zero _ ha.ne'
+#align canonically_ordered_comm_semiring.pow_pos CanonicallyOrderedCommSemiring.pow_pos
+
 protected lemma mul_lt_mul_of_lt_of_lt [PosMulStrictMono α] (hab : a < b) (hcd : c < d) :
     a * c < b * d := by
   -- TODO: This should be an instance but it currently times out

--- a/Mathlib/Algebra/Polynomial/Degree/CardPowDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/CardPowDegree.lean
@@ -3,8 +3,9 @@ Copyright (c) 2021 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
-import Mathlib.Algebra.GroupPower.Order
 import Mathlib.Algebra.Order.EuclideanAbsoluteValue
+import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Algebra.Polynomial.FieldDivision
 
 #align_import data.polynomial.degree.card_pow_degree from "leanprover-community/mathlib"@"85d9f2189d9489f9983c0d01536575b0233bd305"

--- a/Mathlib/Algebra/Polynomial/HasseDeriv.lean
+++ b/Mathlib/Algebra/Polynomial/HasseDeriv.lean
@@ -49,8 +49,6 @@ open Nat Polynomial
 
 open Function
 
-open Nat hiding nsmul_eq_mul
-
 variable {R : Type*} [Semiring R] (k : ℕ) (f : R[X])
 
 /-- The `k`th Hasse derivative of a polynomial `∑ a_i X^i` is `∑ (i.choose k) a_i X^(i-k)`.

--- a/Mathlib/Analysis/Convex/Mul.lean
+++ b/Mathlib/Analysis/Convex/Mul.lean
@@ -3,9 +3,9 @@ Copyright (c) 2023 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Analysis.Convex.Function
-import Mathlib.Algebra.GroupPower.Order
 import Mathlib.Algebra.Order.Monovary
+import Mathlib.Algebra.Order.Ring.Basic
+import Mathlib.Analysis.Convex.Function
 import Mathlib.Tactic.FieldSimp
 
 /-!

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -3,7 +3,8 @@ Copyright (c) 2022 Yaël Dillies, George Shakan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, George Shakan
 -/
-import Mathlib.Algebra.GroupPower.Order
+import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Combinatorics.Enumerative.DoubleCounting
 import Mathlib.Data.Finset.Pointwise
 import Mathlib.Tactic.GCongr

--- a/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
+++ b/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
@@ -3,9 +3,9 @@ Copyright (c) 2023 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.GroupPower.Order
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.Pi
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Data.Finset.Sups
 import Mathlib.Data.Set.Subsingleton
 import Mathlib.Order.Birkhoff

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Energy.lean
@@ -3,9 +3,9 @@ Copyright (c) 2022 Yaël Dillies, Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
-import Mathlib.Algebra.GroupPower.Order
 import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Combinatorics.SimpleGraph.Density
 import Mathlib.Data.Rat.BigOperators
 

--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
-import Mathlib.Algebra.GroupPower.Order
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Computability.Primrec
 import Mathlib.Tactic.Ring
 import Mathlib.Tactic.Linarith

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -46,8 +46,6 @@ open Encodable Denumerable
 
 namespace Nat.Partrec
 
-open Nat (pair)
-
 theorem rfind' {f} (hf : Nat.Partrec f) :
     Nat.Partrec
       (Nat.unpaired fun a m =>
@@ -91,10 +89,6 @@ compile_inductive% Code
 end Nat.Partrec
 
 namespace Nat.Partrec.Code
-
-open Nat (pair unpair)
-
-open Nat.Partrec (Code)
 
 instance instInhabited : Inhabited Code :=
   ⟨zero⟩

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -742,6 +742,9 @@ protected lemma pow_lt_pow_iff_left (hn : n ≠ 0) : a ^ n < b ^ n ↔ a < b := 
   simp only [← Nat.not_le, Nat.pow_le_pow_iff_left hn]
 #align nat.pow_lt_iff_lt_left Nat.pow_lt_pow_iff_left
 
+@[deprecated (since := "2023-12-23")] alias pow_lt_pow_of_lt_left := Nat.pow_lt_pow_left
+@[deprecated (since := "2023-12-23")] alias pow_le_iff_le_left := Nat.pow_le_pow_iff_left
+
 lemma pow_left_injective (hn : n ≠ 0) : Injective (fun a : ℕ ↦ a ^ n) := by
   simp [Injective, le_antisymm_iff, Nat.pow_le_pow_iff_left hn]
 #align nat.pow_left_injective Nat.pow_left_injective

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -6,7 +6,6 @@ Authors: Aaron Anderson
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Data.Nat.Factors
-import Mathlib.Order.GameAdd
 import Mathlib.Order.Interval.Finset.Nat
 
 #align_import number_theory.divisors from "leanprover-community/mathlib"@"e8638a0fcaf73e4500469f368ef9494e495099b3"

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -3,9 +3,10 @@ Copyright (c) 2020 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
-import Mathlib.Algebra.GroupPower.Order
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Data.Nat.Factors
+import Mathlib.Order.GameAdd
 import Mathlib.Order.Interval.Finset.Nat
 
 #align_import number_theory.divisors from "leanprover-community/mathlib"@"e8638a0fcaf73e4500469f368ef9494e495099b3"

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -3,12 +3,14 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Scott Morrison, Ainsley Pahljina
 -/
+import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Ring.Abs
+import Mathlib.Algebra.Order.Ring.Basic
+import Mathlib.Algebra.Ring.Nat
 import Mathlib.Data.ZMod.Basic
 import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.RingTheory.Fintype
 import Mathlib.Tactic.IntervalCases
-import Mathlib.Algebra.GroupPower.Order
 
 #align_import number_theory.lucas_lehmer from "leanprover-community/mathlib"@"10b4e499f43088dd3bb7b5796184ad5216648ab1"
 

--- a/Mathlib/NumberTheory/Multiplicity.lean
+++ b/Mathlib/NumberTheory/Multiplicity.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tian Chen, Mantas Bakšys
 -/
 import Mathlib.Algebra.GeomSum
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Algebra.Ring.Int
 import Mathlib.NumberTheory.Padics.PadicVal
-import Mathlib.Algebra.GroupPower.Order
 import Mathlib.RingTheory.Ideal.Quotient
 
 #align_import number_theory.multiplicity from "leanprover-community/mathlib"@"e8638a0fcaf73e4500469f368ef9494e495099b3"

--- a/Mathlib/NumberTheory/PellMatiyasevic.lean
+++ b/Mathlib/NumberTheory/PellMatiyasevic.lean
@@ -3,11 +3,12 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Algebra.Star.Unitary
 import Mathlib.Data.Nat.ModEq
 import Mathlib.NumberTheory.Zsqrtd.Basic
 import Mathlib.Tactic.Monotonicity
-import Mathlib.Algebra.GroupPower.Order
 
 #align_import number_theory.pell_matiyasevic from "leanprover-community/mathlib"@"795b501869b9fa7aa716d5fdadd00c03f983a605"
 

--- a/Mathlib/NumberTheory/PythagoreanTriples.lean
+++ b/Mathlib/NumberTheory/PythagoreanTriples.lean
@@ -4,12 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul van Wamelen
 -/
 import Mathlib.Algebra.Field.Basic
+import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.RingTheory.Int.Basic
 import Mathlib.Tactic.Ring
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Data.Int.NatPrime
 import Mathlib.Data.ZMod.Basic
-import Mathlib.Algebra.GroupPower.Order
 
 #align_import number_theory.pythagorean_triples from "leanprover-community/mathlib"@"e8638a0fcaf73e4500469f368ef9494e495099b3"
 

--- a/Mathlib/Order/Filter/AtTopBot.lean
+++ b/Mathlib/Order/Filter/AtTopBot.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jeremy Avigad, Yury Kudryashov, Patrick Massot
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset
-import Mathlib.Algebra.GroupPower.Order
 import Mathlib.Algebra.Order.Field.Defs
 import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Algebra.Order.Group.MinMax
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Data.Finset.Preimage
 import Mathlib.Order.Interval.Set.Disjoint
 import Mathlib.Order.Interval.Set.OrderIso

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -3,7 +3,8 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard, Johan Commelin, Patrick Massot
 -/
-import Mathlib.Algebra.GroupPower.Order
+import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.RingTheory.Ideal.Maps
 import Mathlib.Tactic.TFAE
 

--- a/Mathlib/SetTheory/Surreal/Dyadic.lean
+++ b/Mathlib/SetTheory/Surreal/Dyadic.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Apurva Nakade
 -/
 import Mathlib.Algebra.Algebra.Defs
-import Mathlib.Algebra.GroupPower.Order
+import Mathlib.Algebra.Order.Group.Basic
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.RingTheory.Localization.Basic
 import Mathlib.SetTheory.Game.Birthday
 import Mathlib.SetTheory.Surreal.Basic

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Mario Carneiro, Heather Macbeth. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Heather Macbeth, Yaël Dillies
 -/
-import Mathlib.Algebra.GroupPower.Order
 import Mathlib.Algebra.Order.Group.PosPart
+import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Algebra.Order.Ring.Rat
 import Mathlib.Data.Int.CharZero
 import Mathlib.Data.Nat.Factorial.Basic


### PR DESCRIPTION
Move its lemmas (mostly) to two new files:
* `Algebra.Order.Group.Basic` for the lemmas about group-like objects
* `Algebra.Order.Ring.Basic` for the lemmas about ring-like objects


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #12957

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
