### PR TITLE
[Merged by Bors] - chore(EllipticDivisibilitySequence): backport change for nightly-testing

### DIFF
--- a/Mathlib/NumberTheory/EllipticDivisibilitySequence.lean
+++ b/Mathlib/NumberTheory/EllipticDivisibilitySequence.lean
@@ -125,24 +125,24 @@ def preNormEDS' (b c d : R) : ℕ → R
 variable (b c d : R)
 
 @[simp]
-lemma preNormEDS'_zero : preNormEDS' b c d 0 = 0 :=
-  rfl
+lemma preNormEDS'_zero : preNormEDS' b c d 0 = 0 := by
+  rw [preNormEDS']
 
 @[simp]
-lemma preNormEDS'_one : preNormEDS' b c d 1 = 1 :=
-  rfl
+lemma preNormEDS'_one : preNormEDS' b c d 1 = 1 := by
+  rw [preNormEDS']
 
 @[simp]
-lemma preNormEDS'_two : preNormEDS' b c d 2 = 1 :=
-  rfl
+lemma preNormEDS'_two : preNormEDS' b c d 2 = 1 := by
+  rw [preNormEDS']
 
 @[simp]
-lemma preNormEDS'_three : preNormEDS' b c d 3 = c :=
-  rfl
+lemma preNormEDS'_three : preNormEDS' b c d 3 = c := by
+  rw [preNormEDS']
 
 @[simp]
-lemma preNormEDS'_four : preNormEDS' b c d 4 = d :=
-  rfl
+lemma preNormEDS'_four : preNormEDS' b c d 4 = d := by
+  rw [preNormEDS']
 
 lemma preNormEDS'_odd (m : ℕ) : preNormEDS' b c d (2 * (m + 2) + 1) =
     preNormEDS' b c d (m + 4) * preNormEDS' b c d (m + 2) ^ 3 * (if Even m then b else 1) -


### PR DESCRIPTION
Because well-founded definitions will by default become irreducible in v4.9.0, we need to adjust some proofs here.

An alternative, which allows leaving the lemmas as by `rfl` (and hence eligible for `dsimp`) is to add `@[semireducible]` to `preNormEDS'`. However I think this is a better default.