### PR TITLE
[Merged by Bors] - feat(FiberedCategory/HomLift): definition of IsHomLift

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1256,6 +1256,7 @@ import Mathlib.CategoryTheory.Equivalence
 import Mathlib.CategoryTheory.EssentialImage
 import Mathlib.CategoryTheory.EssentiallySmall
 import Mathlib.CategoryTheory.Extensive
+import Mathlib.CategoryTheory.FiberedCategory.HomLift
 import Mathlib.CategoryTheory.Filtered.Basic
 import Mathlib.CategoryTheory.Filtered.Connected
 import Mathlib.CategoryTheory.Filtered.Final

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -239,7 +239,7 @@ protected instance inv {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [I
 lifts `𝟙 S` -/
 instance lift_id_inv (S : 𝒮) {a b : 𝒳} (φ : a ⟶ b) [IsIso φ] [p.IsHomLift (𝟙 S) φ] :
     p.IsHomLift (𝟙 S) (inv φ) :=
-  (IsIso.inv_id (X:=S)) ▸ (IsHomLift.inv p _ φ)
+  (IsIso.inv_id (X := S)) ▸ (IsHomLift.inv p _ φ)
 
 end IsHomLift
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -119,7 +119,7 @@ instance comp {R S T : 𝒮} {a b c : 𝒳} (f : R ⟶ S) (g : S ⟶ T) (φ : a 
   apply CommSq.horiz_comp (commSq p f φ) (commSq p g ψ)
 
 /-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 R`, then so does `φ ≫ ψ` -/
-instance lift_id_comp {p : 𝒳 ⥤ 𝒮} (R : 𝒮) {a b c : 𝒳} (φ : a ⟶ b) (ψ : b ⟶ c)
+instance lift_id_comp (R : 𝒮) {a b c : 𝒳} (φ : a ⟶ b) (ψ : b ⟶ c)
     [p.IsHomLift (𝟙 R) φ] [p.IsHomLift (𝟙 R) ψ] : p.IsHomLift (𝟙 R) (φ ≫ ψ) :=
   comp_id (𝟙 R) ▸ comp p (𝟙 R) (𝟙 R) φ ψ
 
@@ -191,10 +191,14 @@ lemma lift_comp_eqToHom_iff {R S S' : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a �
   mp := fun hφ' => by subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
+section
+
+variable {R S : 𝒮} {a b : 𝒳}
+
 /-- Given a morphism `f : R ⟶ S`, and an isomorphism `φ : a ≅ b` lifting `f`, `isoOfIsoLift f φ` is
 the isomorphism `Φ : R ≅ S` with `Φ.hom = f` induced from `φ` -/
 @[simps hom]
-def isoOfIsoLift {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
+def isoOfIsoLift (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
     R ≅ S where
   hom := f
   inv := eqToHom (codomain_eq p f φ.hom).symm ≫ (p.mapIso φ).inv ≫ eqToHom (domain_eq p f φ.hom)
@@ -202,38 +206,39 @@ def isoOfIsoLift {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHom
   inv_hom_id := by subst_hom_lift p f φ.hom; simp [← p.map_comp]
 
 @[simp]
-lemma isoOfIsoLift_inv_hom_id {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
+lemma isoOfIsoLift_inv_hom_id (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
     (isoOfIsoLift p f φ).inv ≫ f = 𝟙 S :=
   (isoOfIsoLift p f φ).inv_hom_id
 
 @[simp]
-lemma isoOfIsoLift_hom_inv_id {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
+lemma isoOfIsoLift_hom_inv_id (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
     f ≫ (isoOfIsoLift p f φ).inv = 𝟙 R :=
   (isoOfIsoLift p f φ).hom_inv_id
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and `φ` is an isomorphism, then so is `f`. -/
-lemma isIso_of_lift_isIso {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ]
-    [IsIso φ] : IsIso f :=
+lemma isIso_of_lift_isIso (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ] [IsIso φ] : IsIso f :=
   (fac p f φ) ▸ inferInstance
 
 /-- Given `φ : a ≅ b` and `f : R ≅ S`, such that `φ.hom` lifts `f.hom`, then `φ.inv` lifts
 `f.inv`. -/
-protected instance inv_lift_inv {R S : 𝒮} {a b : 𝒳} (f : R ≅ S) (φ : a ≅ b)
-    [p.IsHomLift f.hom φ.hom] : p.IsHomLift f.inv φ.inv := by
+protected instance inv_lift_inv (f : R ≅ S) (φ : a ≅ b) [p.IsHomLift f.hom φ.hom] :
+    p.IsHomLift f.inv φ.inv := by
   apply of_commSq
   apply CommSq.horiz_inv (f:=p.mapIso φ) (commSq p f.hom φ.hom)
 
 /-- Given `φ : a ≅ b` and `f : R ⟶ S`, such that `φ.hom` lifts `f`, then `φ.inv` lifts the
 inverse of `f` given by `isoOfIsoLift`. -/
-protected instance inv_lift {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
+protected instance inv_lift (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
     p.IsHomLift (isoOfIsoLift p f φ).inv φ.inv := by
   apply of_commSq
   apply CommSq.horiz_inv (f:=p.mapIso φ) (by simpa using (commSq p f φ.hom))
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and both are isomorphisms, then `φ⁻¹` lifts `f⁻¹`. -/
-protected instance inv {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [IsIso f] [IsIso φ]
-    [p.IsHomLift f φ] : p.IsHomLift (inv f) (inv φ) :=
+protected instance inv (f : R ⟶ S) (φ : a ⟶ b) [IsIso f] [IsIso φ] [p.IsHomLift f φ] :
+    p.IsHomLift (inv f) (inv φ) :=
   @IsHomLift.inv_lift_inv _ _ _ _ p _ _ _ _ (asIso f) (asIso φ) (by aesop)
+
+end
 
 /-- If `φ : a ⟶ b` is an isomorphism, and lifts `𝟙 S` for some `S : 𝒮`, then `φ⁻¹` also
 lifts `𝟙 S` -/

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -96,9 +96,7 @@ lemma eq_of_isHomLift {a b : 𝒳} (f : p.obj a ⟶ p.obj b) (φ : a ⟶ b) [p.I
 
 lemma of_fac {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (ha : p.obj a = R) (hb : p.obj b = S)
     (h : f = eqToHom ha.symm ≫ p.map φ ≫ eqToHom hb) : p.IsHomLift f φ := by
-  subst ha hb
-  obtain rfl : f = p.map φ := by simpa using h
-  infer_instance
+  subst ha hb h; simp
 
 lemma of_fac' {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (ha : p.obj a = R) (hb : p.obj b = S)
     (h : p.map φ = eqToHom ha ≫ f ≫ eqToHom hb.symm) : p.IsHomLift f φ := by
@@ -153,19 +151,19 @@ lemma id_lift_eqToHom_codomain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S) {b
 
 instance comp_eqToHom_lift {R S : 𝒮} {a' a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : a' = a)
     [p.IsHomLift f φ] : p.IsHomLift f (eqToHom h ≫ φ) := by
-  subst h; aesop
+  subst h; simp_all
 
 instance eqToHom_comp_lift {R S : 𝒮} {a b b' : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : b = b')
     [p.IsHomLift f φ] : p.IsHomLift f (φ ≫ eqToHom h) := by
-  subst h; aesop
+  subst h; simp_all
 
 instance lift_eqToHom_comp {R' R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : R' = R)
     [p.IsHomLift f φ] : p.IsHomLift (eqToHom h ≫ f) φ := by
-  subst h; aesop
+  subst h; simp_all
 
 instance lift_comp_eqToHom {R S S': 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : S = S')
     [p.IsHomLift f φ] : p.IsHomLift (f ≫ eqToHom h) φ := by
-  subst h; aesop
+  subst h; simp_all
 
 @[simp]
 lemma comp_eqToHom_lift_iff {R S : 𝒮} {a' a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : a' = a) :
@@ -231,12 +229,13 @@ inverse of `f` given by `isoOfIsoLift`. -/
 protected instance inv_lift (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
     p.IsHomLift (isoOfIsoLift p f φ).inv φ.inv := by
   apply of_commSq
-  apply CommSq.horiz_inv (f:=p.mapIso φ) (by simpa using (commSq p f φ.hom))
+  apply CommSq.horiz_inv (f:=p.mapIso φ) (by apply commSq p f φ.hom)
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and both are isomorphisms, then `φ⁻¹` lifts `f⁻¹`. -/
 protected instance inv (f : R ⟶ S) (φ : a ⟶ b) [IsIso f] [IsIso φ] [p.IsHomLift f φ] :
     p.IsHomLift (inv f) (inv φ) :=
-  @IsHomLift.inv_lift_inv _ _ _ _ p _ _ _ _ (asIso f) (asIso φ) (by aesop)
+  have : p.IsHomLift (asIso f).hom (asIso φ).hom := by simp_all
+  IsHomLift.inv_lift_inv p (asIso f) (asIso φ)
 
 end
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -194,7 +194,7 @@ lemma lift_comp_eqToHom_iff {R S S' : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a �
 /-- Given a morphism `f : R ⟶ S`, and an isomorphism `φ : a ≅ b` lifting `f`, `isoOfIsoLift f φ` is
 the isomorphism `Φ : R ≅ S` with `Φ.hom = f` induced from `φ` -/
 @[simps hom]
-def isoOfIsoLift  {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
+def isoOfIsoLift {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
     R ≅ S where
   hom := f
   inv := eqToHom (codomain_eq p f φ.hom).symm ≫ (p.mapIso φ).inv ≫ eqToHom (domain_eq p f φ.hom)

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -76,7 +76,7 @@ variable {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f �
 lemma domain_eq : p.obj a = R := by
   subst_hom_lift p f φ; rfl
 
-lemma codomain_eq  : p.obj b = S := by
+lemma codomain_eq : p.obj b = S := by
   subst_hom_lift p f φ; rfl
 
 lemma fac : f = eqToHom (domain_eq p f φ).symm ≫ p.map φ ≫ eqToHom (codomain_eq p f φ) := by

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -146,7 +146,7 @@ instance lift_eqToHom_comp {R' R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a �
   id_comp φ ▸ comp (𝟙 a) φ
 
 instance lift_comp_eqToHom {R S S': 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : S = S')
-    [p.IsHomLift f φ] : p.IsHomLift (f ≫ (eqToHom h)) φ :=
+    [p.IsHomLift f φ] : p.IsHomLift (f ≫ eqToHom h) φ :=
   have := id_lift_eqToHom_domain h (codomain_eq p f φ)
   comp_id φ ▸ comp φ (𝟙 b)
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -76,7 +76,7 @@ lemma fac : f = eqToHom (domain_eq p f φ).symm ≫ p.map φ ≫ eqToHom (codoma
   Functor.IsHomLift.fac
 
 lemma fac' : p.map φ = eqToHom (domain_eq p f φ) ≫ f ≫
-      eqToHom (codomain_eq p f φ).symm := by
+    eqToHom (codomain_eq p f φ).symm := by
   simp [fac p f φ]
 
 lemma commSq : CommSq (p.map φ) (eqToHom (domain_eq p f φ))

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -118,7 +118,7 @@ lemma comp_lift_id_right {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : 
   codomain_eq := by rw [codomain_eq p (𝟙 T) ψ, ← domain_eq p (𝟙 T) ψ, codomain_eq p f φ]
   fac := by simp [fac p f φ, fac' p (𝟙 T) ψ]
 
-/-- If `φ : a ⟶ b` lifts `f` and `ψ : b ⟶ c` lifts `𝟙 T`, then `φ  ≫ ψ` lifts `f` -/
+/-- If `φ : a ⟶ b` lifts `𝟙 T` and `ψ : b ⟶ c` lifts `f`, then `φ  ≫ ψ` lifts `f` -/
 lemma comp_lift_id_left {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : S ⟶ T}
     {φ : a ⟶ b} [p.IsHomLift (𝟙 R) φ] {ψ : b ⟶ c} [hψ : p.IsHomLift f ψ] :
     p.IsHomLift f (φ ≫ ψ) where

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -51,10 +51,9 @@ often drawn as:
 class Functor.IsHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) : Prop where
   domain_eq : p.obj a = R := by aesop_cat
   codomain_eq : p.obj b = S := by aesop_cat
-  -- TODO: can I add eqToHom lemmas to aesop_cat here?
   fac : f = eqToHom domain_eq.symm ≫ p.map φ ≫ eqToHom codomain_eq := by aesop_cat
 
-namespace Functor.IsHomLift
+namespace IsHomLift
 
 /-- For any arrow `φ : a ⟶ b` in `𝒳`, `φ` lifts the arrow `p.map φ` in the base `𝒮`-/
 instance self (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (φ : a ⟶ b) : p.IsHomLift (p.map φ) φ where
@@ -64,46 +63,46 @@ instance (p : 𝒳 ⥤ 𝒮) (a : 𝒳) : p.IsHomLift (𝟙 (p.obj a)) (𝟙 a) 
 protected lemma id {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a : 𝒳} (ha : p.obj a = R) : p.IsHomLift (𝟙 R) (𝟙 a) where
 
 @[simp]
-lemma domain_eq_of_isHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
+lemma domain_eq (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
     [p.IsHomLift f φ] : p.obj a = R :=
-  domain_eq f φ
+  Functor.IsHomLift.domain_eq f φ
 
 @[simp]
-lemma codomain_eq_of_isHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
+lemma codomain_eq (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
     [p.IsHomLift f φ] : p.obj b = S :=
-  codomain_eq f φ
+  Functor.IsHomLift.codomain_eq f φ
 
 @[simp]
-lemma fac_of_isHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
-    [p.IsHomLift f φ] : f = eqToHom (domain_eq f φ).symm ≫ p.map φ ≫ eqToHom (codomain_eq f φ) :=
-  fac
+lemma fac (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
+    [p.IsHomLift f φ] : f = eqToHom (domain_eq p f φ).symm ≫ p.map φ ≫ eqToHom (codomain_eq p f φ) :=
+  Functor.IsHomLift.fac
 
 @[simp]
-lemma fac'_of_isHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
-    [hφ : p.IsHomLift f φ] : p.map φ = eqToHom (domain_eq f φ) ≫ f ≫
-      eqToHom (codomain_eq f φ).symm := by
-  simp [fac_of_isHomLift p f φ]
+lemma fac' (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
+    [p.IsHomLift f φ] : p.map φ = eqToHom (domain_eq p f φ) ≫ f ≫
+      eqToHom (codomain_eq p f φ).symm := by
+  simp [fac p f φ]
 
-lemma commSq_of_isHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
-    [p.IsHomLift f φ] : CommSq (p.map φ) (eqToHom (domain_eq f φ))
-      (eqToHom (codomain_eq f φ)) f where
-  w := by simp only [fac_of_isHomLift p f φ, eqToHom_trans_assoc, eqToHom_refl, id_comp]
+lemma commSq (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
+    [p.IsHomLift f φ] : CommSq (p.map φ) (eqToHom (domain_eq p f φ))
+      (eqToHom (codomain_eq p f φ)) f where
+  w := by simp only [fac p f φ, eqToHom_trans_assoc, eqToHom_refl, id_comp]
 
-lemma isHomLift_of_commSq {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
+lemma of_commSq {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
     (ha : p.obj a = R) (hb : p.obj b = S) (h : CommSq (p.map φ) (eqToHom ha) (eqToHom hb) f) :
       p.IsHomLift f φ where
   fac := by simp only [h.1, eqToHom_trans_assoc, eqToHom_refl, id_comp]
 
 @[simp]
 lemma eq_of_isHomLift {p : 𝒳 ⥤ 𝒮} (a b : 𝒳) {f : p.obj a ⟶ p.obj b} {φ : a ⟶ b}
-    [hφ : p.IsHomLift f φ] : f = p.map φ := by
-  simpa only [eqToHom_refl, comp_id, id_comp] using fac_of_isHomLift p f φ
+    [p.IsHomLift f φ] : f = p.map φ := by
+  simpa only [eqToHom_refl, comp_id, id_comp] using fac p f φ
 
 instance comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S} {g : S ⟶ T} (φ : a ⟶ b)
     (ψ : b ⟶ c) [p.IsHomLift f φ] [p.IsHomLift g ψ] : p.IsHomLift (f ≫ g) (φ ≫ ψ) := by
-  apply isHomLift_of_commSq
+  apply of_commSq
   rw [p.map_comp]
-  apply CommSq.horiz_comp (commSq_of_isHomLift p f φ) (commSq_of_isHomLift p g ψ)
+  apply CommSq.horiz_comp (commSq p f φ) (commSq p g ψ)
 
 /-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 S`, then so does `φ ≫ ψ` -/
 instance lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ b} {ψ : b ⟶ c}
@@ -112,12 +111,12 @@ instance lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ 
 
 /-- If `φ : a ⟶ b` lifts `f` and `ψ : b ⟶ c` lifts `𝟙 T`, then `φ  ≫ ψ` lifts `f` -/
 lemma comp_lift_id {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} [hφ : p.IsHomLift f φ] {ψ : b ⟶ c} [hψ : p.IsHomLift (𝟙 T) ψ] :
+    {φ : a ⟶ b} [p.IsHomLift f φ] {ψ : b ⟶ c} [hψ : p.IsHomLift (𝟙 T) ψ] :
     p.IsHomLift f (φ ≫ ψ) where
   -- TODO: this first one should be able to be automated?
-  domain_eq := hφ.domain_eq
-  codomain_eq := by rw [hψ.codomain_eq, ← hψ.domain_eq, hφ.codomain_eq]
-  fac := by simp [fac_of_isHomLift p f φ, fac'_of_isHomLift p (𝟙 T) ψ]
+  domain_eq := domain_eq p f φ
+  codomain_eq := by rw [codomain_eq p (𝟙 T) ψ, ← domain_eq p (𝟙 T) ψ, codomain_eq p f φ]
+  fac := by simp [fac p f φ, fac' p (𝟙 T) ψ]
 
 @[simp]
 lemma eqToHom_domain_lift_id (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (hab : a = b) {R : 𝒮}
@@ -141,22 +140,22 @@ lemma id_lift_eqToHom_codomain (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} (hRS : R = S)
 
 instance comp_eqToHom_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a' a b : 𝒳} {f : R ⟶ S}
     (φ : a ⟶ b) (h : a' = a) [p.IsHomLift f φ] : p.IsHomLift f (eqToHom h ≫ φ) :=
-  have := eqToHom_codomain_lift_id p h (domain_eq f φ)
+  have := eqToHom_codomain_lift_id p h (domain_eq p f φ)
   id_comp f ▸ comp (eqToHom h) φ
 
 instance eqToHom_comp_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b b' : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} {h : b = b'} [p.IsHomLift f φ] : p.IsHomLift f (φ ≫ eqToHom h) :=
-  have := eqToHom_domain_lift_id p h (codomain_eq f φ)
+  have := eqToHom_domain_lift_id p h (codomain_eq p f φ)
   comp_id f ▸ comp φ (eqToHom h)
 
 instance lift_eqToHom_comp {p : 𝒳 ⥤ 𝒮} {R' R S : 𝒮} {a b : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} (h : R' = R) [p.IsHomLift f φ] : p.IsHomLift ((eqToHom h) ≫ f) φ :=
-  have := id_lift_eqToHom_codomain p h (domain_eq f φ)
+  have := id_lift_eqToHom_codomain p h (domain_eq p f φ)
   id_comp φ ▸ comp (𝟙 a) φ
 
 instance lift_comp_eqToHom {p : 𝒳 ⥤ 𝒮} {R S S': 𝒮} {a b : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} (h : S = S') [p.IsHomLift f φ] : p.IsHomLift (f ≫ (eqToHom h)) φ :=
-  have := id_lift_eqToHom_domain p h (codomain_eq f φ)
+  have := id_lift_eqToHom_domain p h (codomain_eq p f φ)
   comp_id φ ▸ comp φ (𝟙 b)
 
 @[simp]
@@ -186,13 +185,13 @@ lemma lift_comp_eqToHom_iff {p : 𝒳 ⥤ 𝒮} {R S S': 𝒮} {a b : 𝒳} {f :
 /-- The isomorphism `R ≅ S` obtained from an isomorphism `φ : a ≅ b` lifting `f` -/
 def isoOfIsoLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b)
     [p.IsHomLift f φ.hom] : R ≅ S :=
-  eqToIso (domain_eq_of_isHomLift p f φ.hom).symm ≪≫ p.mapIso φ ≪≫
-    eqToIso (codomain_eq_of_isHomLift p f φ.hom)
+  eqToIso (domain_eq p f φ.hom).symm ≪≫ p.mapIso φ ≪≫
+    eqToIso (codomain_eq p f φ.hom)
 
 @[simp]
 lemma isoOfIsoLift_hom {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
     [p.IsHomLift f φ.hom] : (isoOfIsoLift p f φ).hom = f := by
-  simp [isoOfIsoLift, fac_of_isHomLift p f φ.hom]
+  simp [isoOfIsoLift, fac p f φ.hom]
 
 @[simp]
 lemma isoOfIsoLift_comp {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
@@ -209,21 +208,21 @@ lemma comp_isoOfIsoLift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and `φ` is an isomorphism, then so is `f`. -/
 lemma isIso_of_lift_isIso {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
     [p.IsHomLift f φ] [IsIso φ] : IsIso f :=
-  (fac_of_isHomLift p f φ) ▸ inferInstance
+  (fac p f φ) ▸ inferInstance
 
 /-- Given `φ : a ≅ b` and `f : R ≅ S`, such that `φ.hom` lifts `f.hom`, then `φ.inv` lifts
 `f.inv`. -/
 protected instance inv_lift_inv (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ≅ S) (φ : a ≅ b)
     [p.IsHomLift f.hom φ.hom] : p.IsHomLift f.inv φ.inv := by
-  apply isHomLift_of_commSq
-  apply CommSq.horiz_inv (f:=p.mapIso φ) (commSq_of_isHomLift p f.hom φ.hom)
+  apply of_commSq
+  apply CommSq.horiz_inv (f:=p.mapIso φ) (commSq p f.hom φ.hom)
 
 /-- Given `φ : a ≅ b` and `f : R ⟶ S`, such that `φ.hom` lifts `f`, then `φ.inv` lifts the
 inverse of `f` given by `isoOfIsoLift`. -/
 protected instance inv_lift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b)
     [p.IsHomLift f φ.hom] : p.IsHomLift (isoOfIsoLift p f φ).inv φ.inv := by
-  apply isHomLift_of_commSq
-  apply CommSq.horiz_inv (f:=p.mapIso φ) (by simpa using (commSq_of_isHomLift p f φ.hom))
+  apply of_commSq
+  apply CommSq.horiz_inv (f:=p.mapIso φ) (by simpa using (commSq p f φ.hom))
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and both are isomorphisms, then `φ⁻¹` lifts `f⁻¹`. -/
 protected instance inv (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
@@ -237,6 +236,6 @@ instance lift_id_inv {p : 𝒳 ⥤ 𝒮} {S : 𝒮} {a b : 𝒳} {φ : a ⟶ b} 
     [p.IsHomLift (𝟙 S) φ] : p.IsHomLift (𝟙 S) (CategoryTheory.inv φ) :=
   (IsIso.inv_id (X:=S)) ▸ (IsHomLift.inv p _ φ)
 
-end Functor.IsHomLift
+end IsHomLift
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -46,165 +46,179 @@ often drawn as:
   v        v
   R --f--> S
 ``` -/
-structure IsHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) : Prop where
-  (ObjLiftDomain : p.obj a = R)
-  (ObjLiftCodomain : p.obj b = S)
-  (HomLift : CommSq (p.map φ) (eqToHom ObjLiftDomain) (eqToHom ObjLiftCodomain) f)
+class Functor.IsHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) : Prop where
+  domain_eq : p.obj a = R
+  codomain_eq : p.obj b = S
+  homlift : CommSq (p.map φ) (eqToHom domain_eq) (eqToHom codomain_eq) f
 
-namespace IsHomLift
+namespace Functor.IsHomLift
 
 protected lemma hom_eq {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
-    (hφ : IsHomLift p f φ) : f = eqToHom hφ.ObjLiftDomain.symm ≫ p.map φ ≫
-      eqToHom hφ.ObjLiftCodomain :=
-  ((eqToHom_comp_iff hφ.ObjLiftDomain _ _).1 hφ.HomLift.w.symm)
+    [hφ : IsHomLift p f φ] : f = eqToHom hφ.domain_eq.symm ≫ p.map φ ≫
+      eqToHom hφ.codomain_eq :=
+  ((eqToHom_comp_iff hφ.domain_eq _ _).1 hφ.homlift.w.symm)
 
 protected lemma hom_eq' {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
-    (hφ : IsHomLift p f φ) : p.map φ = eqToHom hφ.ObjLiftDomain ≫ f ≫
-      eqToHom hφ.ObjLiftCodomain.symm := by
-  rw [← assoc, ← comp_eqToHom_iff hφ.ObjLiftCodomain _ _]
-  exact hφ.HomLift.w
+   [hφ : IsHomLift p f φ] : p.map φ = eqToHom hφ.domain_eq ≫ f ≫
+      eqToHom hφ.codomain_eq.symm := by
+  rw [← assoc, ← comp_eqToHom_iff hφ.codomain_eq _ _]
+  exact hφ.homlift.w
 
 lemma eq_of_IsHomLift {p : 𝒳 ⥤ 𝒮} (a b : 𝒳) {f : p.obj a ⟶ p.obj b} {φ : a ⟶ b}
-    (hφ : IsHomLift p f φ) : f = p.map φ := by
-  simpa using IsHomLift.hom_eq hφ
+   [hφ : IsHomLift p f φ] : f = p.map φ := by
+  simpa using hφ.hom_eq
 
 /-- For any arrow `φ : a ⟶ b` in `𝒳`, `φ` lifts the arrow `p.map φ` in the base `𝒮`-/
 @[simp]
 protected lemma self (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (φ : a ⟶ b) : IsHomLift p (p.map φ) φ where
-  ObjLiftDomain := rfl
-  ObjLiftCodomain := rfl
-  HomLift := ⟨by simp only [eqToHom_refl, comp_id, id_comp]⟩
+  domain_eq := rfl
+  codomain_eq := rfl
+  homlift := ⟨by simp only [eqToHom_refl, comp_id, id_comp]⟩
 
 @[simp]
 protected lemma id {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a : 𝒳} (ha : p.obj a = R) : IsHomLift p (𝟙 R) (𝟙 a) :=
   ha ▸ (p.map_id _ ▸ IsHomLift.self p (𝟙 a))
 
 protected lemma comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
-    {g : S ⟶ T} {φ : a ⟶ b} {ψ : b ⟶ c} (hφ : IsHomLift p f φ)
-    (hψ : IsHomLift p g ψ) : IsHomLift p (f ≫ g) (φ ≫ ψ) where
-  ObjLiftDomain := hφ.1
-  ObjLiftCodomain := hψ.2
-  HomLift := (p.map_comp _ _).symm ▸ CommSq.horiz_comp hφ.3 hψ.3
+    {g : S ⟶ T} {φ : a ⟶ b} {ψ : b ⟶ c} [hφ : IsHomLift p f φ]
+    [hψ : IsHomLift p g ψ] : IsHomLift p (f ≫ g) (φ ≫ ψ) where
+  domain_eq := hφ.1
+  codomain_eq := hψ.2
+  homlift := (p.map_comp _ _).symm ▸ CommSq.horiz_comp hφ.3 hψ.3
 
 /-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 S`, then so does `φ ≫ ψ` -/
 lemma lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ b} {ψ : b ⟶ c}
-    (hφ : IsHomLift p (𝟙 R) φ) (hψ : IsHomLift p (𝟙 R) ψ) : IsHomLift p (𝟙 R) (φ ≫ ψ) :=
-  comp_id (𝟙 R) ▸ IsHomLift.comp hφ hψ
+    (hφ : IsHomLift p (𝟙 R) φ) [IsHomLift p (𝟙 R) ψ] : IsHomLift p (𝟙 R) (φ ≫ ψ) :=
+  comp_id (𝟙 R) ▸ hφ.comp
 
 /-- If `φ : a ⟶ b` lifts `f` and `ψ : b ⟶ c` lifts `𝟙 T`, then `φ  ≫ ψ` lifts `f` -/
 lemma comp_lift_id {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} (hφ : IsHomLift p f φ) {ψ : b ⟶ c} (hψ : IsHomLift p (𝟙 T) ψ) :
+    {φ : a ⟶ b} [hφ : IsHomLift p f φ] {ψ : b ⟶ c} [hψ : IsHomLift p (𝟙 T) ψ] :
     IsHomLift p f (φ ≫ ψ) where
-  ObjLiftDomain := hφ.ObjLiftDomain
-  ObjLiftCodomain := by rw [hψ.ObjLiftCodomain, ← hψ.ObjLiftDomain, hφ.ObjLiftCodomain]
-  HomLift := ⟨by simp [IsHomLift.hom_eq' hψ, hφ.3.1]⟩
+  domain_eq := hφ.domain_eq
+  codomain_eq := by rw [hψ.codomain_eq, ← hψ.domain_eq, hφ.codomain_eq]
+  homlift := ⟨by simp [hψ.hom_eq', hφ.3.1]⟩
 
 @[simp]
 lemma eqToHom_domain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {R : 𝒮}
     (hR : p.obj a = R) : IsHomLift p (𝟙 R) (eqToHom hab) where
-      ObjLiftDomain := hR
-      ObjLiftCodomain := hab ▸ hR
-      HomLift := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
+  domain_eq := hR
+  codomain_eq := hab ▸ hR
+  homlift := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
 
 @[simp]
 lemma eqToHom_codomain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {S : 𝒮}
     (hS : p.obj b = S) : IsHomLift p (𝟙 S) (eqToHom hab) where
-      ObjLiftDomain := hab ▸ hS
-      ObjLiftCodomain := hS
-      HomLift := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
+  domain_eq := hab ▸ hS
+  codomain_eq := hS
+  homlift := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
 
 @[simp]
 lemma id_lift_eqToHom_domain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S)
     {a : 𝒳} (ha : p.obj a = R) : IsHomLift p (eqToHom hRS) (𝟙 a) where
-      ObjLiftDomain := ha
-      ObjLiftCodomain := hRS ▸ ha
-      HomLift := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
+  domain_eq := ha
+  codomain_eq := hRS ▸ ha
+  homlift := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
 
 @[simp]
 lemma id_lift_eqToHom_codomain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S)
     {b : 𝒳} (hb : p.obj b = S) : IsHomLift p (eqToHom hRS) (𝟙 b) where
-      ObjLiftDomain := hRS ▸ hb
-      ObjLiftCodomain := hb
-      HomLift := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
+  domain_eq := hRS ▸ hb
+  codomain_eq := hb
+  homlift := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
+
+instance comp_eqToHom_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a' a b : 𝒳} {f : R ⟶ S}
+    {φ : a ⟶ b} {h : a' = a} [hφ : IsHomLift p f φ] : IsHomLift p f (eqToHom h ≫ φ) :=
+  id_comp f ▸ (eqToHom_codomain_lift_id h hφ.domain_eq).comp
+
+instance eqToHom_comp_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b b' : 𝒳} {f : R ⟶ S}
+    {φ : a ⟶ b} {h : b = b'} [hφ : IsHomLift p f φ] : IsHomLift p f (φ ≫ eqToHom h) :=
+  comp_id f ▸ hφ.comp (hψ := eqToHom_domain_lift_id h hφ.codomain_eq)
+
+instance lift_eqToHom_comp {p : 𝒳 ⥤ 𝒮} {R' R S : 𝒮} {a b : 𝒳} {f : R ⟶ S}
+    {φ : a ⟶ b} (h : R' = R) [hφ : IsHomLift p f φ] : IsHomLift p ((eqToHom h) ≫ f) φ :=
+  id_comp φ ▸ (IsHomLift.id_lift_eqToHom_codomain h hφ.domain_eq).comp
+
+instance lift_comp_eqToHom {p : 𝒳 ⥤ 𝒮} {R S S': 𝒮} {a b : 𝒳} {f : R ⟶ S}
+    {φ : a ⟶ b} (h : S = S') [hφ : IsHomLift p f φ] : IsHomLift p (f ≫ (eqToHom h)) φ :=
+  comp_id φ ▸ hφ.comp (hψ := IsHomLift.id_lift_eqToHom_domain h hφ.codomain_eq)
 
 @[simp]
 lemma comp_eqToHom_lift_iff {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a' a b : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} {h : a' = a} : IsHomLift p f (eqToHom h ≫ φ) ↔ IsHomLift p f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
-  mpr := fun hφ => id_comp f ▸ IsHomLift.comp (eqToHom_codomain_lift_id h hφ.ObjLiftDomain) hφ
+  mpr := fun hφ => inferInstance
 
 @[simp]
 lemma eqToHom_comp_lift_iff {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b b' : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} {h : b = b'} : IsHomLift p f (φ ≫ eqToHom h) ↔ IsHomLift p f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
-  mpr := fun hφ => comp_id f ▸ IsHomLift.comp hφ (eqToHom_domain_lift_id h hφ.ObjLiftCodomain)
+  mpr := fun hφ => inferInstance
 
 @[simp]
 lemma lift_eqToHom_comp_iff {p : 𝒳 ⥤ 𝒮} {R' R S : 𝒮} {a b : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} (h : R' = R) : IsHomLift p ((eqToHom h) ≫ f) φ ↔ IsHomLift p f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
-  mpr := fun hφ =>
-    id_comp φ ▸ IsHomLift.comp (IsHomLift.id_lift_eqToHom_codomain h hφ.ObjLiftDomain) hφ
+  mpr := fun hφ => inferInstance
 
 @[simp]
 lemma lift_comp_eqToHom_iff {p : 𝒳 ⥤ 𝒮} {R S S': 𝒮} {a b : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} (h : S = S') : IsHomLift p (f ≫ (eqToHom h)) φ ↔ IsHomLift p f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
-  mpr := fun hφ =>
-    comp_id φ ▸ IsHomLift.comp hφ (IsHomLift.id_lift_eqToHom_domain h hφ.ObjLiftCodomain)
+  mpr := fun hφ => inferInstance
 
 /-- The isomorphism `R ≅ S` obtained from an isomorphism `φ : a ≅ b` lifting `f` -/
 def Iso_of_Iso_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    (hφ : IsHomLift p f φ.hom) : R ≅ S :=
-  eqToIso hφ.ObjLiftDomain.symm ≪≫ p.mapIso φ ≪≫ eqToIso hφ.ObjLiftCodomain
+    [hφ : IsHomLift p f φ.hom] : R ≅ S :=
+  eqToIso hφ.domain_eq.symm ≪≫ p.mapIso φ ≪≫ eqToIso hφ.codomain_eq
 
 @[simp]
 lemma Iso_of_Iso_lift_hom {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    (hφ : IsHomLift p f φ.hom) : (Iso_of_Iso_lift hφ).hom = f := by
-  simp [Iso_of_Iso_lift, IsHomLift.hom_eq hφ]
+    [hφ : IsHomLift p f φ.hom] : (hφ.Iso_of_Iso_lift).hom = f := by
+  simp [Iso_of_Iso_lift, hφ.hom_eq]
 
 @[simp]
 lemma Iso_of_Iso_lift_comp {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    (hφ : IsHomLift p f φ.hom) : (Iso_of_Iso_lift hφ).inv ≫ f = 𝟙 S := by
+    [hφ : IsHomLift p f φ.hom] : (hφ.Iso_of_Iso_lift).inv ≫ f = 𝟙 S := by
   rw [CategoryTheory.Iso.inv_comp_eq]
   simp only [Iso_of_Iso_lift_hom, comp_id]
 
 @[simp]
 lemma comp_Iso_of_Iso_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    (hφ : IsHomLift p f φ.hom) : f ≫ (Iso_of_Iso_lift hφ).inv = 𝟙 R := by
+    [hφ : IsHomLift p f φ.hom] : f ≫ (hφ.Iso_of_Iso_lift).inv = 𝟙 R := by
   rw [CategoryTheory.Iso.comp_inv_eq]
   simp only [Iso_of_Iso_lift_hom, id_comp]
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and `φ` is an isomorphism, then so is `f`. -/
 lemma IsIso_of_lift_IsIso {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
-    (hφ : IsHomLift p f φ) [IsIso φ] : IsIso f :=
-  (IsHomLift.hom_eq hφ) ▸ inferInstance
+   [hφ : IsHomLift p f φ] [IsIso φ] : IsIso f :=
+  hφ.hom_eq ▸ inferInstance
 
 /-- Given `φ : a ≅ b` and `f : R ≅ S`, such that `φ.hom` lifts `f.hom`, then `φ.inv` lifts
 `f.inv`. -/
-protected lemma inv_lift_inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ≅ S} {φ : a ≅ b}
-    (hφ : IsHomLift p f.hom φ.hom) : IsHomLift p f.inv φ.inv where
-  ObjLiftDomain := hφ.2
-  ObjLiftCodomain := hφ.1
-  HomLift := CommSq.horiz_inv (f:=p.mapIso φ) (i:=f) hφ.3
+protected instance inv_lift_inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ≅ S} {φ : a ≅ b}
+    [hφ : IsHomLift p f.hom φ.hom] : IsHomLift p f.inv φ.inv where
+  domain_eq := hφ.2
+  codomain_eq := hφ.1
+  homlift := CommSq.horiz_inv (f:=p.mapIso φ) (i:=f) hφ.3
 
 /-- Given `φ : a ≅ b` and `f : R ⟶ S`, such that `φ.hom` lifts `f`, then `φ.inv` lifts the
 inverse of `f` given by `Iso_of_Iso_lift`. -/
-protected lemma inv_lift_inv' {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    (hφ : IsHomLift p f φ.hom) : IsHomLift p (Iso_of_Iso_lift hφ).inv φ.inv where
-  ObjLiftDomain := hφ.2
-  ObjLiftCodomain := hφ.1
-  HomLift := CommSq.horiz_inv (f:=p.mapIso φ) (i:=Iso_of_Iso_lift hφ) (by simpa using hφ.3)
+protected instance inv_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
+    [hφ : IsHomLift p f φ.hom] : IsHomLift p (hφ.Iso_of_Iso_lift).inv φ.inv where
+  domain_eq := hφ.2
+  codomain_eq := hφ.1
+  homlift := CommSq.horiz_inv (f:=p.mapIso φ) (i:=hφ.Iso_of_Iso_lift) (by simpa using hφ.3)
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and both are isomorphisms, then `φ⁻¹` lifts `f⁻¹`. -/
-protected lemma inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
-    (hφ : IsHomLift p f φ) [IsIso φ] [IsIso f] : IsHomLift p (inv f) (inv φ) :=
-  IsHomLift.inv_lift_inv (f:=asIso f) (φ:= asIso φ) hφ
+protected instance inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
+    [hφ : IsHomLift p f φ] [IsIso φ] [IsIso f] : IsHomLift p (inv f) (inv φ) :=
+  IsHomLift.inv_lift_inv (f := asIso f) (φ := asIso φ) (hφ := hφ)
 
 /-- If `φ : a ⟶ b` is an isomorphism, and lifts `𝟙 S` for some `S : 𝒮`, then `φ⁻¹` also
 lifts `𝟙 S` -/
-lemma lift_id_inv {p : 𝒳 ⥤ 𝒮} {S : 𝒮} {a b : 𝒳} {φ : a ⟶ b} [IsIso φ]
-    (hφ : IsHomLift p (𝟙 S) φ) : IsHomLift p (𝟙 S) (inv φ) :=
-  (IsIso.inv_id (X:=S)) ▸ IsHomLift.inv hφ
+instance lift_id_inv {p : 𝒳 ⥤ 𝒮} {S : 𝒮} {a b : 𝒳} {φ : a ⟶ b} [IsIso φ]
+    [hφ : IsHomLift p (𝟙 S) φ] : IsHomLift p (𝟙 S) (inv φ) :=
+  (IsIso.inv_id (X:=S)) ▸ hφ.inv
 
-end IsHomLift
+end Functor.IsHomLift

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -73,8 +73,8 @@ lemma codomain_eq (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (�
   Functor.IsHomLift.codomain_eq f φ
 
 @[simp]
-lemma fac (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
-    [p.IsHomLift f φ] : f = eqToHom (domain_eq p f φ).symm ≫ p.map φ ≫ eqToHom (codomain_eq p f φ) :=
+lemma fac (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ] :
+    f = eqToHom (domain_eq p f φ).symm ≫ p.map φ ≫ eqToHom (codomain_eq p f φ) :=
   Functor.IsHomLift.fac
 
 @[simp]
@@ -225,15 +225,15 @@ protected instance inv_lift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R
   apply CommSq.horiz_inv (f:=p.mapIso φ) (by simpa using (commSq p f φ.hom))
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and both are isomorphisms, then `φ⁻¹` lifts `f⁻¹`. -/
-protected instance inv (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
-    [p.IsHomLift f φ] [IsIso φ] [IsIso f] : p.IsHomLift (CategoryTheory.inv f) (CategoryTheory.inv φ) :=
+protected instance inv (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [IsIso f]
+    [IsIso φ] [p.IsHomLift f φ] : p.IsHomLift (inv f) (inv φ) :=
   have : p.IsHomLift (asIso f).hom (asIso φ).hom := by simp; infer_instance
   IsHomLift.inv_lift_inv p (asIso f) (asIso φ)
 
 /-- If `φ : a ⟶ b` is an isomorphism, and lifts `𝟙 S` for some `S : 𝒮`, then `φ⁻¹` also
 lifts `𝟙 S` -/
-instance lift_id_inv {p : 𝒳 ⥤ 𝒮} {S : 𝒮} {a b : 𝒳} {φ : a ⟶ b} [IsIso φ]
-    [p.IsHomLift (𝟙 S) φ] : p.IsHomLift (𝟙 S) (CategoryTheory.inv φ) :=
+instance lift_id_inv {p : 𝒳 ⥤ 𝒮} {S : 𝒮} {a b : 𝒳} {φ : a ⟶ b} [IsIso φ] [p.IsHomLift (𝟙 S) φ] :
+    p.IsHomLift (𝟙 S) (inv φ) :=
   (IsIso.inv_id (X:=S)) ▸ (IsHomLift.inv p _ φ)
 
 end IsHomLift

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -67,7 +67,7 @@ instance {a b : 𝒳} (φ : a ⟶ b) : p.IsHomLift (p.map φ) φ where
 
 @[simp]
 instance (a : 𝒳) : p.IsHomLift (𝟙 (p.obj a)) (𝟙 a) := by
-  rw [←p.map_id]; infer_instance
+  rw [← p.map_id]; infer_instance
 
 namespace IsHomLift
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -209,7 +209,7 @@ lemma isoOfIsoLift_inv_hom_id {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a �
   (isoOfIsoLift p f φ).inv_hom_id
 
 @[simp]
-lemma comp_isoOfIsoLift {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
+lemma isoOfIsoLift_hom_inv_id {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
     f ≫ (isoOfIsoLift p f φ).inv = 𝟙 R :=
   (isoOfIsoLift p f φ).hom_inv_id
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -110,13 +110,21 @@ instance lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ 
   comp_id (𝟙 R) ▸ comp φ ψ
 
 /-- If `φ : a ⟶ b` lifts `f` and `ψ : b ⟶ c` lifts `𝟙 T`, then `φ  ≫ ψ` lifts `f` -/
-lemma comp_lift_id {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
+lemma comp_lift_id_right {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} [p.IsHomLift f φ] {ψ : b ⟶ c} [hψ : p.IsHomLift (𝟙 T) ψ] :
     p.IsHomLift f (φ ≫ ψ) where
   -- TODO: this first one should be able to be automated?
   domain_eq := domain_eq p f φ
   codomain_eq := by rw [codomain_eq p (𝟙 T) ψ, ← domain_eq p (𝟙 T) ψ, codomain_eq p f φ]
   fac := by simp [fac p f φ, fac' p (𝟙 T) ψ]
+
+/-- If `φ : a ⟶ b` lifts `f` and `ψ : b ⟶ c` lifts `𝟙 T`, then `φ  ≫ ψ` lifts `f` -/
+lemma comp_lift_id_left {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : S ⟶ T}
+    {φ : a ⟶ b} [p.IsHomLift (𝟙 R) φ] {ψ : b ⟶ c} [hψ : p.IsHomLift f ψ] :
+    p.IsHomLift f (φ ≫ ψ) where
+  domain_eq := by rw [domain_eq p (𝟙 R) φ, ← codomain_eq p (𝟙 R) φ, domain_eq p f ψ]
+  codomain_eq := codomain_eq p f ψ
+  fac := by simp [fac p f ψ, fac' p (𝟙 R) φ]
 
 @[simp]
 lemma eqToHom_domain_lift_id (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (hab : a = b) {R : 𝒮}

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -12,22 +12,17 @@ import Mathlib.CategoryTheory.CommSq
 # HomLift
 
 Given a functor `p : 𝒳 ⥤ 𝒮`, this file provides API for expressing the fact that `p(φ) = f`
-for given morphisms `φ` and `f`.
+for given morphisms `φ` and `f`. The reason this API is needed is because, in general, `p.map φ = f`
+does not make sense when the domain and/or codomain of `φ` and `f` are not definitionally equal.
 
 ## Main definition
 
-Given morphism `φ : a ⟶ b` in `𝒳` and `f : R ⟶ S` in `𝒮`, `p.IsHomLift f φ` is defined as a
-structure containing the data that `p(a) = R`, `p(b) = S` and the fact that the following square
-commutes
-```
-  p(a) --p(φ)--> p(b)
-  |               |
-  |               |
-  v               v
-  R -----f------> S
-```
-where the vertical arrows are given by `eqToHom` corresponding to the equalities `p(a) = R` and
-`p(b) = S`.
+Given morphism `φ : a ⟶ b` in `𝒳` and `f : R ⟶ S` in `𝒮`, `p.IsHomLift f φ` is a class, defined
+using the auxillary inductive type `IsHomLiftAux` which expresses the fact that `f = p(φ)`.
+
+We also define a macro `subst_hom_lift p f φ` which can be used to substitute `f` with `p(φ)` in a
+goal, this tactic is just short for `obtain ⟨⟩ := Functor.IsHomLift.cond (p:=p) (f:=f) (φ:=φ)`, and
+it is used to make the code more readable.
 
 -/
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -49,28 +49,28 @@ often drawn as:
 class Functor.IsHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) : Prop where
   domain_eq : p.obj a = R := by aesop_cat
   codomain_eq : p.obj b = S := by aesop_cat
-  homlift : CommSq (p.map φ) (eqToHom domain_eq) (eqToHom codomain_eq) f
+  commsq : CommSq (p.map φ) (eqToHom domain_eq) (eqToHom codomain_eq) f
 
 namespace Functor.IsHomLift
 
 protected lemma hom_eq {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
     [hφ : IsHomLift p f φ] : f = eqToHom hφ.domain_eq.symm ≫ p.map φ ≫
       eqToHom hφ.codomain_eq :=
-  ((eqToHom_comp_iff hφ.domain_eq _ _).1 hφ.homlift.w.symm)
+  ((eqToHom_comp_iff hφ.domain_eq _ _).1 hφ.commsq.w.symm)
 
 protected lemma hom_eq' {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
     [hφ : IsHomLift p f φ] : p.map φ = eqToHom hφ.domain_eq ≫ f ≫
       eqToHom hφ.codomain_eq.symm := by
   rw [← assoc, ← comp_eqToHom_iff hφ.codomain_eq _ _]
-  exact hφ.homlift.w
+  exact hφ.commsq.w
 
-lemma eq_of_IsHomLift {p : 𝒳 ⥤ 𝒮} (a b : 𝒳) {f : p.obj a ⟶ p.obj b} {φ : a ⟶ b}
+lemma eq_of_isHomLift {p : 𝒳 ⥤ 𝒮} (a b : 𝒳) {f : p.obj a ⟶ p.obj b} {φ : a ⟶ b}
     [hφ : IsHomLift p f φ] : f = p.map φ := by
   simpa only [eqToHom_refl, comp_id, id_comp] using hφ.hom_eq
 
 /-- For any arrow `φ : a ⟶ b` in `𝒳`, `φ` lifts the arrow `p.map φ` in the base `𝒮`-/
 instance self (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (φ : a ⟶ b) : IsHomLift p (p.map φ) φ where
-  homlift := ⟨by simp only [eqToHom_refl, comp_id, id_comp]⟩
+  commsq := ⟨by simp only [eqToHom_refl, comp_id, id_comp]⟩
 
 instance (p : 𝒳 ⥤ 𝒮) (a : 𝒳) : IsHomLift p (𝟙 (p.obj a)) (𝟙 a) :=
   p.map_id _ ▸ self p (𝟙 a)
@@ -84,7 +84,7 @@ instance comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
     [hψ : IsHomLift p g ψ] : IsHomLift p (f ≫ g) (φ ≫ ψ) where
   domain_eq := hφ.1
   codomain_eq := hψ.2
-  homlift := (p.map_comp _ _).symm ▸ CommSq.horiz_comp hφ.3 hψ.3
+  commsq := (p.map_comp _ _).symm ▸ CommSq.horiz_comp hφ.3 hψ.3
 
 /-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 S`, then so does `φ ≫ ψ` -/
 instance lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ b} {ψ : b ⟶ c}
@@ -97,27 +97,27 @@ lemma comp_lift_id {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ 
     IsHomLift p f (φ ≫ ψ) where
   domain_eq := hφ.domain_eq
   codomain_eq := by rw [hψ.codomain_eq, ← hψ.domain_eq, hφ.codomain_eq]
-  homlift := ⟨by simp only [map_comp, hψ.hom_eq', id_comp, eqToHom_trans, assoc, hφ.3.1]⟩
+  commsq := ⟨by simp only [map_comp, hψ.hom_eq', id_comp, eqToHom_trans, assoc, hφ.3.1]⟩
 
 @[simp]
 lemma eqToHom_domain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {R : 𝒮}
     (hR : p.obj a = R) : IsHomLift p (𝟙 R) (eqToHom hab) where
-  homlift := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
+  commsq := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
 
 @[simp]
 lemma eqToHom_codomain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {S : 𝒮}
     (hS : p.obj b = S) : IsHomLift p (𝟙 S) (eqToHom hab) where
-  homlift := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
+  commsq := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
 
 @[simp]
 lemma id_lift_eqToHom_domain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S)
     {a : 𝒳} (ha : p.obj a = R) : IsHomLift p (eqToHom hRS) (𝟙 a) where
-  homlift := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
+  commsq := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
 
 @[simp]
 lemma id_lift_eqToHom_codomain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S)
     {b : 𝒳} (hb : p.obj b = S) : IsHomLift p (eqToHom hRS) (𝟙 b) where
-  homlift := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
+  commsq := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
 
 instance comp_eqToHom_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a' a b : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} {h : a' = a} [hφ : IsHomLift p f φ] : IsHomLift p f (eqToHom h ≫ φ) :=
@@ -160,29 +160,29 @@ lemma lift_comp_eqToHom_iff {p : 𝒳 ⥤ 𝒮} {R S S': 𝒮} {a b : 𝒳} {f :
   mpr := fun hφ => inferInstance
 
 /-- The isomorphism `R ≅ S` obtained from an isomorphism `φ : a ≅ b` lifting `f` -/
-def Iso_of_Iso_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
+def isoOfIsoLift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
     [hφ : IsHomLift p f φ.hom] : R ≅ S :=
   eqToIso hφ.domain_eq.symm ≪≫ p.mapIso φ ≪≫ eqToIso hφ.codomain_eq
 
 @[simp]
-lemma Iso_of_Iso_lift_hom {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    [hφ : IsHomLift p f φ.hom] : (hφ.Iso_of_Iso_lift).hom = f := by
-  simp [Iso_of_Iso_lift, hφ.hom_eq]
+lemma isoOfIsoLift_hom {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
+    [hφ : IsHomLift p f φ.hom] : (hφ.isoOfIsoLift).hom = f := by
+  simp [isoOfIsoLift, hφ.hom_eq]
 
 @[simp]
-lemma Iso_of_Iso_lift_comp {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    [hφ : IsHomLift p f φ.hom] : (hφ.Iso_of_Iso_lift).inv ≫ f = 𝟙 S := by
+lemma isoOfIsoLift_comp {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
+    [hφ : IsHomLift p f φ.hom] : (hφ.isoOfIsoLift).inv ≫ f = 𝟙 S := by
   rw [CategoryTheory.Iso.inv_comp_eq]
-  simp only [Iso_of_Iso_lift_hom, comp_id]
+  simp only [isoOfIsoLift_hom, comp_id]
 
 @[simp]
-lemma comp_Iso_of_Iso_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    [hφ : IsHomLift p f φ.hom] : f ≫ (hφ.Iso_of_Iso_lift).inv = 𝟙 R := by
+lemma comp_isoOfIsoLift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
+    [hφ : IsHomLift p f φ.hom] : f ≫ (hφ.isoOfIsoLift).inv = 𝟙 R := by
   rw [CategoryTheory.Iso.comp_inv_eq]
-  simp only [Iso_of_Iso_lift_hom, id_comp]
+  simp only [isoOfIsoLift_hom, id_comp]
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and `φ` is an isomorphism, then so is `f`. -/
-lemma IsIso_of_lift_IsIso {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
+lemma isIso_of_lift_isIso {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
     [hφ : IsHomLift p f φ] [IsIso φ] : IsIso f :=
   hφ.hom_eq ▸ inferInstance
 
@@ -192,15 +192,15 @@ protected instance inv_lift_inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f
     [hφ : IsHomLift p f.hom φ.hom] : IsHomLift p f.inv φ.inv where
   domain_eq := hφ.2
   codomain_eq := hφ.1
-  homlift := CommSq.horiz_inv (f:=p.mapIso φ) (i:=f) hφ.3
+  commsq := CommSq.horiz_inv (f:=p.mapIso φ) (i:=f) hφ.3
 
 /-- Given `φ : a ≅ b` and `f : R ⟶ S`, such that `φ.hom` lifts `f`, then `φ.inv` lifts the
-inverse of `f` given by `Iso_of_Iso_lift`. -/
+inverse of `f` given by `isoOfIsoLift`. -/
 protected instance inv_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    [hφ : IsHomLift p f φ.hom] : IsHomLift p (hφ.Iso_of_Iso_lift).inv φ.inv where
+    [hφ : IsHomLift p f φ.hom] : IsHomLift p (hφ.isoOfIsoLift).inv φ.inv where
   domain_eq := hφ.2
   codomain_eq := hφ.1
-  homlift := CommSq.horiz_inv (f:=p.mapIso φ) (i:=hφ.Iso_of_Iso_lift) (by simpa using hφ.3)
+  commsq := CommSq.horiz_inv (f:=p.mapIso φ) (i:=hφ.isoOfIsoLift) (by simpa using hφ.3)
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and both are isomorphisms, then `φ⁻¹` lifts `f⁻¹`. -/
 protected instance inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -112,16 +112,16 @@ lemma of_commSq {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (ha : p.o
   obtain rfl : f = p.map φ := by simpa using h.1.symm
   infer_instance
 
-instance comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S} {g : S ⟶ T} (φ : a ⟶ b)
+instance comp {R S T : 𝒮} {a b c : 𝒳} (f : R ⟶ S) (g : S ⟶ T) (φ : a ⟶ b)
     (ψ : b ⟶ c) [p.IsHomLift f φ] [p.IsHomLift g ψ] : p.IsHomLift (f ≫ g) (φ ≫ ψ) := by
   apply of_commSq
   rw [p.map_comp]
   apply CommSq.horiz_comp (commSq p f φ) (commSq p g ψ)
 
 /-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 R`, then so does `φ ≫ ψ` -/
-instance lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ b} {ψ : b ⟶ c}
+instance lift_id_comp {p : 𝒳 ⥤ 𝒮} (R : 𝒮) {a b c : 𝒳} (φ : a ⟶ b) (ψ : b ⟶ c)
     [p.IsHomLift (𝟙 R) φ] [p.IsHomLift (𝟙 R) ψ] : p.IsHomLift (𝟙 R) (φ ≫ ψ) :=
-  comp_id (𝟙 R) ▸ comp φ ψ
+  comp_id (𝟙 R) ▸ comp p (𝟙 R) (𝟙 R) φ ψ
 
 /-- If `φ : a ⟶ b` lifts `f` and `ψ : b ⟶ c` lifts `𝟙 T`, then `φ  ≫ ψ` lifts `f` -/
 lemma comp_lift_id_right {R S : 𝒮} {a b c : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ]
@@ -130,8 +130,8 @@ lemma comp_lift_id_right {R S : 𝒮} {a b c : 𝒳} (f : R ⟶ S) (φ : a ⟶ b
   simpa using inferInstanceAs (p.IsHomLift (f ≫ 𝟙 S) (φ ≫ ψ))
 
 /-- If `φ : a ⟶ b` lifts `𝟙 T` and `ψ : b ⟶ c` lifts `f`, then `φ  ≫ ψ` lifts `f` -/
-lemma comp_lift_id_left {S T : 𝒮} {a b c : 𝒳} (f : S ⟶ T) (φ : a ⟶ b) (R : 𝒮)
-    [p.IsHomLift (𝟙 R) φ] (ψ : b ⟶ c) [p.IsHomLift f ψ] : p.IsHomLift f (φ ≫ ψ) := by
+lemma comp_lift_id_left {a b c : 𝒳} (R : 𝒮) (φ : a ⟶ b) [p.IsHomLift (𝟙 R) φ]
+    {S T : 𝒮} (f : S ⟶ T) (ψ : b ⟶ c) [p.IsHomLift f ψ] : p.IsHomLift f (φ ≫ ψ) := by
   obtain rfl : R = S := by rw [← codomain_eq p (𝟙 R) φ, domain_eq p f ψ]
   simpa using inferInstanceAs (p.IsHomLift (𝟙 R ≫ f) (φ ≫ ψ))
 
@@ -191,7 +191,8 @@ lemma lift_comp_eqToHom_iff {R S S' : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a �
   mp := fun hφ' => by subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
-/-- The isomorphism `R ≅ S` obtained from an isomorphism `φ : a ≅ b` lifting `f` -/
+/-- Given a morphism `f : R ⟶ S`, and an isomorphism `φ : a ≅ b` lifting `f`, `isoOfIsoLift f φ` is
+the isomorphism `Φ : R ≅ S` with `Φ.hom = f` induced from `φ` -/
 @[simps hom]
 def isoOfIsoLift  {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
     R ≅ S where
@@ -236,7 +237,7 @@ protected instance inv {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [I
 
 /-- If `φ : a ⟶ b` is an isomorphism, and lifts `𝟙 S` for some `S : 𝒮`, then `φ⁻¹` also
 lifts `𝟙 S` -/
-instance lift_id_inv {S : 𝒮} {a b : 𝒳} (φ : a ⟶ b) [IsIso φ] [p.IsHomLift (𝟙 S) φ] :
+instance lift_id_inv (S : 𝒮) {a b : 𝒳} (φ : a ⟶ b) [IsIso φ] [p.IsHomLift (𝟙 S) φ] :
     p.IsHomLift (𝟙 S) (inv φ) :=
   (IsIso.inv_id (X:=S)) ▸ (IsHomLift.inv p _ φ)
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -88,7 +88,7 @@ instance comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
 
 /-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 S`, then so does `φ ≫ ψ` -/
 instance lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ b} {ψ : b ⟶ c}
-    (hφ : IsHomLift p (𝟙 R) φ) [IsHomLift p (𝟙 R) ψ] : IsHomLift p (𝟙 R) (φ ≫ ψ) :=
+    [hφ : IsHomLift p (𝟙 R) φ] [IsHomLift p (𝟙 R) ψ] : IsHomLift p (𝟙 R) (φ ≫ ψ) :=
   comp_id (𝟙 R) ▸ hφ.comp
 
 /-- If `φ : a ⟶ b` lifts `f` and `ψ : b ⟶ c` lifts `𝟙 T`, then `φ  ≫ ψ` lifts `f` -/

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2024 Calle Sönne. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Lezeau, Calle Sönne
+-/
+import Mathlib.CategoryTheory.Functor.Category
+import Mathlib.CategoryTheory.CommSq
+/-!
+# HomLift
+Given a functor `p : 𝒳 ⥤ 𝒮`, this file provides API for expressing the fact that `p(φ) = f`
+for given morphisms `φ` and `f`.
+## Main definition
+Given morphism `φ : a ⟶ b` in `𝒳` and `f : R ⟶ S` in `𝒮`, `IsHomLift p f φ` is defined as a
+structure containing the data that `p(a) = R`, `p(b) = S` and the fact that the following square
+commutes:
+commutes
+```
+  p(a) --p(φ)--> p(b)
+  |               |
+  |               |
+  v               v
+  R -----f------> S
+```
+where the vertical arrows are given by `eqToHom` corresponding to the equalities `p(a) = R` and
+`p(b) = S`.
+-/
+universe u₁ v₁ u₂ v₂
+open CategoryTheory Functor Category
+variable {𝒮 : Type u₁} {𝒳 : Type u₂} [Category 𝒳] [Category 𝒮]
+/-- The proposition that an arrow a --φ--> b lifts an arrow R --f--> S in 𝒮 via p. This is
+often drawn as:
+```
+  a --φ--> b
+  -        -
+  |        |
+  v        v
+  R --f--> S
+``` -/
+structure IsHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) : Prop where
+  (ObjLiftDomain : p.obj a = R)
+  (ObjLiftCodomain : p.obj b = S)
+  (HomLift : CommSq (p.map φ) (eqToHom ObjLiftDomain) (eqToHom ObjLiftCodomain) f)
+namespace IsHomLift
+protected lemma hom_eq {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
+    (hφ : IsHomLift p f φ) : f = eqToHom hφ.ObjLiftDomain.symm ≫ p.map φ ≫
+      eqToHom hφ.ObjLiftCodomain :=
+  ((eqToHom_comp_iff hφ.ObjLiftDomain _ _).1 hφ.HomLift.w.symm)
+protected lemma hom_eq' {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
+    (hφ : IsHomLift p f φ) : p.map φ = eqToHom hφ.ObjLiftDomain ≫ f ≫
+      eqToHom hφ.ObjLiftCodomain.symm := by
+  rw [← assoc, ← comp_eqToHom_iff hφ.ObjLiftCodomain _ _]
+  exact hφ.HomLift.w
+lemma eq_of_IsHomLift {p : 𝒳 ⥤ 𝒮} (a b : 𝒳) {f : p.obj a ⟶ p.obj b} {φ : a ⟶ b}
+    (hφ : IsHomLift p f φ) : f = p.map φ := by
+  simpa using IsHomLift.hom_eq hφ
+/-- For any arrow `φ : a ⟶ b` in `𝒳`, `φ` lifts the arrow `p.map φ` in the base `𝒮`-/
+@[simp]
+protected lemma self (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (φ : a ⟶ b) : IsHomLift p (p.map φ) φ where
+  ObjLiftDomain := rfl
+  ObjLiftCodomain := rfl
+  HomLift := ⟨by simp only [eqToHom_refl, comp_id, id_comp]⟩
+@[simp]
+protected lemma id {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a : 𝒳} (ha : p.obj a = R) : IsHomLift p (𝟙 R) (𝟙 a) :=
+  ha ▸ (p.map_id _ ▸ IsHomLift.self p (𝟙 a))
+protected lemma comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
+    {g : S ⟶ T} {φ : a ⟶ b} {ψ : b ⟶ c} (hφ : IsHomLift p f φ)
+    (hψ : IsHomLift p g ψ) : IsHomLift p (f ≫ g) (φ ≫ ψ) where
+  ObjLiftDomain := hφ.1
+  ObjLiftCodomain := hψ.2
+  HomLift := (p.map_comp _ _).symm ▸ CommSq.horiz_comp hφ.3 hψ.3
+/-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 S`, then so does `φ ≫ ψ` -/
+lemma lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ b} {ψ : b ⟶ c}
+    (hφ : IsHomLift p (𝟙 R) φ) (hψ : IsHomLift p (𝟙 R) ψ) : IsHomLift p (𝟙 R) (φ ≫ ψ) :=
+  comp_id (𝟙 R) ▸ IsHomLift.comp hφ hψ
+/-- If `φ : a ⟶ b` lifts `f` and `ψ : b ⟶ c` lifts `𝟙 T`, then `φ  ≫ ψ` lifts `f` -/
+lemma comp_lift_id {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
+    {φ : a ⟶ b} (hφ : IsHomLift p f φ) {ψ : b ⟶ c} (hψ : IsHomLift p (𝟙 T) ψ) :
+    IsHomLift p f (φ ≫ ψ) where
+  ObjLiftDomain := hφ.ObjLiftDomain
+  ObjLiftCodomain := by rw [hψ.ObjLiftCodomain, ← hψ.ObjLiftDomain, hφ.ObjLiftCodomain]
+  HomLift := ⟨by simp [IsHomLift.hom_eq' hψ, hφ.3.1]⟩
+@[simp]
+lemma eqToHom_domain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {R : 𝒮}
+    (hR : p.obj a = R) : IsHomLift p (𝟙 R) (eqToHom hab) where
+      ObjLiftDomain := hR
+      ObjLiftCodomain := hab ▸ hR
+      HomLift := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
+@[simp]
+lemma eqToHom_codomain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {S : 𝒮}
+    (hS : p.obj b = S) : IsHomLift p (𝟙 S) (eqToHom hab) where
+      ObjLiftDomain := hab ▸ hS
+      ObjLiftCodomain := hS
+      HomLift := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
+@[simp]
+lemma id_lift_eqToHom_domain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S)
+    {a : 𝒳} (ha : p.obj a = R) : IsHomLift p (eqToHom hRS) (𝟙 a) where
+      ObjLiftDomain := ha
+      ObjLiftCodomain := hRS ▸ ha
+      HomLift := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
+@[simp]
+lemma id_lift_eqToHom_codomain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S)
+    {b : 𝒳} (hb : p.obj b = S) : IsHomLift p (eqToHom hRS) (𝟙 b) where
+      ObjLiftDomain := hRS ▸ hb
+      ObjLiftCodomain := hb
+      HomLift := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
+@[simp]
+lemma comp_eqToHom_lift_iff {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a' a b : 𝒳} {f : R ⟶ S}
+    {φ : a ⟶ b} {h : a' = a} : IsHomLift p f (eqToHom h ≫ φ) ↔ IsHomLift p f φ where
+  mp := by intro hφ'; subst h; simpa using hφ'
+  mpr := fun hφ => id_comp f ▸ IsHomLift.comp (eqToHom_codomain_lift_id h hφ.ObjLiftDomain) hφ
+@[simp]
+lemma eqToHom_comp_lift_iff {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b b' : 𝒳} {f : R ⟶ S}
+    {φ : a ⟶ b} {h : b = b'} : IsHomLift p f (φ ≫ eqToHom h) ↔ IsHomLift p f φ where
+  mp := by intro hφ'; subst h; simpa using hφ'
+  mpr := fun hφ => comp_id f ▸ IsHomLift.comp hφ (eqToHom_domain_lift_id h hφ.ObjLiftCodomain)
+@[simp]
+lemma lift_eqToHom_comp_iff {p : 𝒳 ⥤ 𝒮} {R' R S : 𝒮} {a b : 𝒳} {f : R ⟶ S}
+    {φ : a ⟶ b} (h : R' = R) : IsHomLift p ((eqToHom h) ≫ f) φ ↔ IsHomLift p f φ where
+  mp := by intro hφ'; subst h; simpa using hφ'
+  mpr := fun hφ =>
+    id_comp φ ▸ IsHomLift.comp (IsHomLift.id_lift_eqToHom_codomain h hφ.ObjLiftDomain) hφ
+@[simp]
+lemma lift_comp_eqToHom_iff {p : 𝒳 ⥤ 𝒮} {R S S': 𝒮} {a b : 𝒳} {f : R ⟶ S}
+    {φ : a ⟶ b} (h : S = S') : IsHomLift p (f ≫ (eqToHom h)) φ ↔ IsHomLift p f φ where
+  mp := by intro hφ'; subst h; simpa using hφ'
+  mpr := fun hφ =>
+    comp_id φ ▸ IsHomLift.comp hφ (IsHomLift.id_lift_eqToHom_domain h hφ.ObjLiftCodomain)
+/-- The isomorphism `R ≅ S` obtained from an isomorphism `φ : a ≅ b` lifting `f` -/
+def Iso_of_Iso_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
+    (hφ : IsHomLift p f φ.hom) : R ≅ S :=
+  eqToIso hφ.ObjLiftDomain.symm ≪≫ p.mapIso φ ≪≫ eqToIso hφ.ObjLiftCodomain
+@[simp]
+lemma Iso_of_Iso_lift_hom {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
+    (hφ : IsHomLift p f φ.hom) : (Iso_of_Iso_lift hφ).hom = f := by
+  simp [Iso_of_Iso_lift, IsHomLift.hom_eq hφ]
+@[simp]
+lemma Iso_of_Iso_lift_comp {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
+    (hφ : IsHomLift p f φ.hom) : (Iso_of_Iso_lift hφ).inv ≫ f = 𝟙 S := by
+  rw [CategoryTheory.Iso.inv_comp_eq]
+  simp only [Iso_of_Iso_lift_hom, comp_id]
+@[simp]
+lemma comp_Iso_of_Iso_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
+    (hφ : IsHomLift p f φ.hom) : f ≫ (Iso_of_Iso_lift hφ).inv = 𝟙 R := by
+  rw [CategoryTheory.Iso.comp_inv_eq]
+  simp only [Iso_of_Iso_lift_hom, id_comp]
+/-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and `φ` is an isomorphism, then so is `f`. -/
+lemma IsIso_of_lift_IsIso {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
+    (hφ : IsHomLift p f φ) [IsIso φ] : IsIso f :=
+  (IsHomLift.hom_eq hφ) ▸ inferInstance
+/-- Given `φ : a ≅ b` and `f : R ≅ S`, such that `φ.hom` lifts `f.hom`, then `φ.inv` lifts
+`f.inv`. -/
+protected lemma inv_lift_inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ≅ S} {φ : a ≅ b}
+    (hφ : IsHomLift p f.hom φ.hom) : IsHomLift p f.inv φ.inv where
+  ObjLiftDomain := hφ.2
+  ObjLiftCodomain := hφ.1
+  HomLift := CommSq.horiz_inv (f:=p.mapIso φ) (i:=f) hφ.3
+/-- Given `φ : a ≅ b` and `f : R ⟶ S`, such that `φ.hom` lifts `f`, then `φ.inv` lifts the
+inverse of `f` given by `Iso_of_Iso_lift`. -/
+protected lemma inv_lift_inv' {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
+    (hφ : IsHomLift p f φ.hom) : IsHomLift p (Iso_of_Iso_lift hφ).inv φ.inv where
+  ObjLiftDomain := hφ.2
+  ObjLiftCodomain := hφ.1
+  HomLift := CommSq.horiz_inv (f:=p.mapIso φ) (i:=Iso_of_Iso_lift hφ) (by simpa using hφ.3)
+/-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and both are isomorphisms, then `φ⁻¹` lifts `f⁻¹`. -/
+protected lemma inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
+    (hφ : IsHomLift p f φ) [IsIso φ] [IsIso f] : IsHomLift p (inv f) (inv φ) :=
+  IsHomLift.inv_lift_inv (f:=asIso f) (φ:= asIso φ) hφ
+/-- If `φ : a ⟶ b` is an isomorphism, and lifts `𝟙 S` for some `S : 𝒮`, then `φ⁻¹` also
+lifts `𝟙 S` -/
+lemma lift_id_inv {p : 𝒳 ⥤ 𝒮} {S : 𝒮} {a b : 𝒳} {φ : a ⟶ b} [IsIso φ]
+    (hφ : IsHomLift p (𝟙 S) φ) : IsHomLift p (𝟙 S) (inv φ) :=
+  (IsIso.inv_id (X:=S)) ▸ IsHomLift.inv hφ
+end IsHomLift

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -66,7 +66,7 @@ protected lemma hom_eq' {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶
 
 lemma eq_of_IsHomLift {p : 𝒳 ⥤ 𝒮} (a b : 𝒳) {f : p.obj a ⟶ p.obj b} {φ : a ⟶ b}
    [hφ : IsHomLift p f φ] : f = p.map φ := by
-  simpa using hφ.hom_eq
+  simpa only [eqToHom_refl, comp_id, id_comp] using hφ.hom_eq
 
 /-- For any arrow `φ : a ⟶ b` in `𝒳`, `φ` lifts the arrow `p.map φ` in the base `𝒮`-/
 @[simp]
@@ -97,7 +97,7 @@ lemma comp_lift_id {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ 
     IsHomLift p f (φ ≫ ψ) where
   domain_eq := hφ.domain_eq
   codomain_eq := by rw [hψ.codomain_eq, ← hψ.domain_eq, hφ.codomain_eq]
-  homlift := ⟨by simp [hψ.hom_eq', hφ.3.1]⟩
+  homlift := ⟨by simp only [map_comp, hψ.hom_eq', id_comp, eqToHom_trans, assoc, hφ.3.1]⟩
 
 @[simp]
 lemma eqToHom_domain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {R : 𝒮}

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -59,27 +59,27 @@ protected lemma hom_eq {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ 
   ((eqToHom_comp_iff hφ.domain_eq _ _).1 hφ.homlift.w.symm)
 
 protected lemma hom_eq' {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
-   [hφ : IsHomLift p f φ] : p.map φ = eqToHom hφ.domain_eq ≫ f ≫
+    [hφ : IsHomLift p f φ] : p.map φ = eqToHom hφ.domain_eq ≫ f ≫
       eqToHom hφ.codomain_eq.symm := by
   rw [← assoc, ← comp_eqToHom_iff hφ.codomain_eq _ _]
   exact hφ.homlift.w
 
 lemma eq_of_IsHomLift {p : 𝒳 ⥤ 𝒮} (a b : 𝒳) {f : p.obj a ⟶ p.obj b} {φ : a ⟶ b}
-   [hφ : IsHomLift p f φ] : f = p.map φ := by
+    [hφ : IsHomLift p f φ] : f = p.map φ := by
   simpa only [eqToHom_refl, comp_id, id_comp] using hφ.hom_eq
 
 /-- For any arrow `φ : a ⟶ b` in `𝒳`, `φ` lifts the arrow `p.map φ` in the base `𝒮`-/
-@[simp]
-protected lemma self (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (φ : a ⟶ b) : IsHomLift p (p.map φ) φ where
-  domain_eq := rfl
-  codomain_eq := rfl
+instance self (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (φ : a ⟶ b) : IsHomLift p (p.map φ) φ where
   homlift := ⟨by simp only [eqToHom_refl, comp_id, id_comp]⟩
+
+instance (p : 𝒳 ⥤ 𝒮) (a : 𝒳) : IsHomLift p (𝟙 (p.obj a)) (𝟙 a) :=
+  p.map_id _ ▸ self p (𝟙 a)
 
 @[simp]
 protected lemma id {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a : 𝒳} (ha : p.obj a = R) : IsHomLift p (𝟙 R) (𝟙 a) :=
-  ha ▸ (p.map_id _ ▸ IsHomLift.self p (𝟙 a))
+  ha ▸ (p.map_id _ ▸ self p (𝟙 a))
 
-protected lemma comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
+instance comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
     {g : S ⟶ T} {φ : a ⟶ b} {ψ : b ⟶ c} [hφ : IsHomLift p f φ]
     [hψ : IsHomLift p g ψ] : IsHomLift p (f ≫ g) (φ ≫ ψ) where
   domain_eq := hφ.1
@@ -87,7 +87,7 @@ protected lemma comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R �
   homlift := (p.map_comp _ _).symm ▸ CommSq.horiz_comp hφ.3 hψ.3
 
 /-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 S`, then so does `φ ≫ ψ` -/
-lemma lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ b} {ψ : b ⟶ c}
+instance lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ b} {ψ : b ⟶ c}
     (hφ : IsHomLift p (𝟙 R) φ) [IsHomLift p (𝟙 R) ψ] : IsHomLift p (𝟙 R) (φ ≫ ψ) :=
   comp_id (𝟙 R) ▸ hφ.comp
 
@@ -102,29 +102,21 @@ lemma comp_lift_id {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ 
 @[simp]
 lemma eqToHom_domain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {R : 𝒮}
     (hR : p.obj a = R) : IsHomLift p (𝟙 R) (eqToHom hab) where
-  domain_eq := hR
-  codomain_eq := hab ▸ hR
   homlift := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
 
 @[simp]
 lemma eqToHom_codomain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {S : 𝒮}
     (hS : p.obj b = S) : IsHomLift p (𝟙 S) (eqToHom hab) where
-  domain_eq := hab ▸ hS
-  codomain_eq := hS
   homlift := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
 
 @[simp]
 lemma id_lift_eqToHom_domain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S)
     {a : 𝒳} (ha : p.obj a = R) : IsHomLift p (eqToHom hRS) (𝟙 a) where
-  domain_eq := ha
-  codomain_eq := hRS ▸ ha
   homlift := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
 
 @[simp]
 lemma id_lift_eqToHom_codomain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S)
     {b : 𝒳} (hb : p.obj b = S) : IsHomLift p (eqToHom hRS) (𝟙 b) where
-  domain_eq := hRS ▸ hb
-  codomain_eq := hb
   homlift := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
 
 instance comp_eqToHom_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a' a b : 𝒳} {f : R ⟶ S}
@@ -191,7 +183,7 @@ lemma comp_Iso_of_Iso_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R 
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and `φ` is an isomorphism, then so is `f`. -/
 lemma IsIso_of_lift_IsIso {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
-   [hφ : IsHomLift p f φ] [IsIso φ] : IsIso f :=
+    [hφ : IsHomLift p f φ] [IsIso φ] : IsIso f :=
   hφ.hom_eq ▸ inferInstance
 
 /-- Given `φ : a ≅ b` and `f : R ≅ S`, such that `φ.hom` lifts `f.hom`, then `φ.inv` lifts

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -16,7 +16,7 @@ for given morphisms `φ` and `f`.
 
 ## Main definition
 
-Given morphism `φ : a ⟶ b` in `𝒳` and `f : R ⟶ S` in `𝒮`, `IsHomLift p f φ` is defined as a
+Given morphism `φ : a ⟶ b` in `𝒳` and `f : R ⟶ S` in `𝒮`, `p.IsHomLift f φ` is defined as a
 structure containing the data that `p(a) = R`, `p(b) = S` and the fact that the following square
 commutes
 ```
@@ -33,9 +33,11 @@ where the vertical arrows are given by `eqToHom` corresponding to the equalities
 
 universe u₁ v₁ u₂ v₂
 
-open CategoryTheory Functor Category
+open CategoryTheory Category
 
 variable {𝒮 : Type u₁} {𝒳 : Type u₂} [Category 𝒳] [Category 𝒮]
+
+namespace CategoryTheory
 
 /-- The proposition that an arrow a --φ--> b lifts an arrow R --f--> S in 𝒮 via p. This is
 often drawn as:
@@ -49,168 +51,192 @@ often drawn as:
 class Functor.IsHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) : Prop where
   domain_eq : p.obj a = R := by aesop_cat
   codomain_eq : p.obj b = S := by aesop_cat
-  commsq : CommSq (p.map φ) (eqToHom domain_eq) (eqToHom codomain_eq) f
+  -- TODO: can I add eqToHom lemmas to aesop_cat here?
+  fac : f = eqToHom domain_eq.symm ≫ p.map φ ≫ eqToHom codomain_eq := by aesop_cat
 
 namespace Functor.IsHomLift
 
-protected lemma hom_eq {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
-    [hφ : IsHomLift p f φ] : f = eqToHom hφ.domain_eq.symm ≫ p.map φ ≫
-      eqToHom hφ.codomain_eq :=
-  ((eqToHom_comp_iff hφ.domain_eq _ _).1 hφ.commsq.w.symm)
-
-protected lemma hom_eq' {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
-    [hφ : IsHomLift p f φ] : p.map φ = eqToHom hφ.domain_eq ≫ f ≫
-      eqToHom hφ.codomain_eq.symm := by
-  rw [← assoc, ← comp_eqToHom_iff hφ.codomain_eq _ _]
-  exact hφ.commsq.w
-
-lemma eq_of_isHomLift {p : 𝒳 ⥤ 𝒮} (a b : 𝒳) {f : p.obj a ⟶ p.obj b} {φ : a ⟶ b}
-    [hφ : IsHomLift p f φ] : f = p.map φ := by
-  simpa only [eqToHom_refl, comp_id, id_comp] using hφ.hom_eq
-
 /-- For any arrow `φ : a ⟶ b` in `𝒳`, `φ` lifts the arrow `p.map φ` in the base `𝒮`-/
-instance self (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (φ : a ⟶ b) : IsHomLift p (p.map φ) φ where
-  commsq := ⟨by simp only [eqToHom_refl, comp_id, id_comp]⟩
-
-instance (p : 𝒳 ⥤ 𝒮) (a : 𝒳) : IsHomLift p (𝟙 (p.obj a)) (𝟙 a) :=
-  p.map_id _ ▸ self p (𝟙 a)
+instance self (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (φ : a ⟶ b) : p.IsHomLift (p.map φ) φ where
+instance (p : 𝒳 ⥤ 𝒮) (a : 𝒳) : p.IsHomLift (𝟙 (p.obj a)) (𝟙 a) where
 
 @[simp]
-protected lemma id {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a : 𝒳} (ha : p.obj a = R) : IsHomLift p (𝟙 R) (𝟙 a) :=
-  ha ▸ (p.map_id _ ▸ self p (𝟙 a))
+protected lemma id {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a : 𝒳} (ha : p.obj a = R) : p.IsHomLift (𝟙 R) (𝟙 a) where
 
-instance comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
-    {g : S ⟶ T} {φ : a ⟶ b} {ψ : b ⟶ c} [hφ : IsHomLift p f φ]
-    [hψ : IsHomLift p g ψ] : IsHomLift p (f ≫ g) (φ ≫ ψ) where
-  domain_eq := hφ.1
-  codomain_eq := hψ.2
-  commsq := (p.map_comp _ _).symm ▸ CommSq.horiz_comp hφ.3 hψ.3
+@[simp]
+lemma domain_eq_of_isHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
+    [p.IsHomLift f φ] : p.obj a = R :=
+  domain_eq f φ
+
+@[simp]
+lemma codomain_eq_of_isHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
+    [p.IsHomLift f φ] : p.obj b = S :=
+  codomain_eq f φ
+
+@[simp]
+lemma fac_of_isHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
+    [p.IsHomLift f φ] : f = eqToHom (domain_eq f φ).symm ≫ p.map φ ≫ eqToHom (codomain_eq f φ) :=
+  fac
+
+@[simp]
+lemma fac'_of_isHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
+    [hφ : p.IsHomLift f φ] : p.map φ = eqToHom (domain_eq f φ) ≫ f ≫
+      eqToHom (codomain_eq f φ).symm := by
+  simp [fac_of_isHomLift p f φ]
+
+lemma commSq_of_isHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
+    [p.IsHomLift f φ] : CommSq (p.map φ) (eqToHom (domain_eq f φ))
+      (eqToHom (codomain_eq f φ)) f where
+  w := by simp only [fac_of_isHomLift p f φ, eqToHom_trans_assoc, eqToHom_refl, id_comp]
+
+lemma isHomLift_of_commSq {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
+    (ha : p.obj a = R) (hb : p.obj b = S) (h : CommSq (p.map φ) (eqToHom ha) (eqToHom hb) f) :
+      p.IsHomLift f φ where
+  fac := by simp only [h.1, eqToHom_trans_assoc, eqToHom_refl, id_comp]
+
+@[simp]
+lemma eq_of_isHomLift {p : 𝒳 ⥤ 𝒮} (a b : 𝒳) {f : p.obj a ⟶ p.obj b} {φ : a ⟶ b}
+    [hφ : p.IsHomLift f φ] : f = p.map φ := by
+  simpa only [eqToHom_refl, comp_id, id_comp] using fac_of_isHomLift p f φ
+
+instance comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S} {g : S ⟶ T} (φ : a ⟶ b)
+    (ψ : b ⟶ c) [p.IsHomLift f φ] [p.IsHomLift g ψ] : p.IsHomLift (f ≫ g) (φ ≫ ψ) := by
+  apply isHomLift_of_commSq
+  rw [p.map_comp]
+  apply CommSq.horiz_comp (commSq_of_isHomLift p f φ) (commSq_of_isHomLift p g ψ)
 
 /-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 S`, then so does `φ ≫ ψ` -/
 instance lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ b} {ψ : b ⟶ c}
-    [hφ : IsHomLift p (𝟙 R) φ] [IsHomLift p (𝟙 R) ψ] : IsHomLift p (𝟙 R) (φ ≫ ψ) :=
-  comp_id (𝟙 R) ▸ hφ.comp
+    [p.IsHomLift (𝟙 R) φ] [p.IsHomLift (𝟙 R) ψ] : p.IsHomLift (𝟙 R) (φ ≫ ψ) :=
+  comp_id (𝟙 R) ▸ comp φ ψ
 
 /-- If `φ : a ⟶ b` lifts `f` and `ψ : b ⟶ c` lifts `𝟙 T`, then `φ  ≫ ψ` lifts `f` -/
 lemma comp_lift_id {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} [hφ : IsHomLift p f φ] {ψ : b ⟶ c} [hψ : IsHomLift p (𝟙 T) ψ] :
-    IsHomLift p f (φ ≫ ψ) where
+    {φ : a ⟶ b} [hφ : p.IsHomLift f φ] {ψ : b ⟶ c} [hψ : p.IsHomLift (𝟙 T) ψ] :
+    p.IsHomLift f (φ ≫ ψ) where
+  -- TODO: this first one should be able to be automated?
   domain_eq := hφ.domain_eq
   codomain_eq := by rw [hψ.codomain_eq, ← hψ.domain_eq, hφ.codomain_eq]
-  commsq := ⟨by simp only [map_comp, hψ.hom_eq', id_comp, eqToHom_trans, assoc, hφ.3.1]⟩
+  fac := by simp [fac_of_isHomLift p f φ, fac'_of_isHomLift p (𝟙 T) ψ]
 
 @[simp]
-lemma eqToHom_domain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {R : 𝒮}
-    (hR : p.obj a = R) : IsHomLift p (𝟙 R) (eqToHom hab) where
-  commsq := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
+lemma eqToHom_domain_lift_id (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (hab : a = b) {R : 𝒮}
+    (hR : p.obj a = R) : p.IsHomLift (𝟙 R) (eqToHom hab) where
+  fac := by simp [eqToHom_map]
 
 @[simp]
-lemma eqToHom_codomain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {S : 𝒮}
-    (hS : p.obj b = S) : IsHomLift p (𝟙 S) (eqToHom hab) where
-  commsq := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
+lemma eqToHom_codomain_lift_id (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (hab : a = b) {S : 𝒮}
+    (hS : p.obj b = S) : p.IsHomLift (𝟙 S) (eqToHom hab) where
+  fac := by simp [eqToHom_map]
 
 @[simp]
-lemma id_lift_eqToHom_domain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S)
-    {a : 𝒳} (ha : p.obj a = R) : IsHomLift p (eqToHom hRS) (𝟙 a) where
-  commsq := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
+lemma id_lift_eqToHom_domain (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} (hRS : R = S)
+    {a : 𝒳} (ha : p.obj a = R) : p.IsHomLift (eqToHom hRS) (𝟙 a) where
+  fac := by simp [eqToHom_map]
 
 @[simp]
-lemma id_lift_eqToHom_codomain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S)
-    {b : 𝒳} (hb : p.obj b = S) : IsHomLift p (eqToHom hRS) (𝟙 b) where
-  commsq := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
+lemma id_lift_eqToHom_codomain (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} (hRS : R = S)
+    {b : 𝒳} (hb : p.obj b = S) : p.IsHomLift (eqToHom hRS) (𝟙 b) where
+  fac := by simp [eqToHom_map]
 
 instance comp_eqToHom_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a' a b : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} {h : a' = a} [hφ : IsHomLift p f φ] : IsHomLift p f (eqToHom h ≫ φ) :=
-  id_comp f ▸ (eqToHom_codomain_lift_id h hφ.domain_eq).comp
+    (φ : a ⟶ b) (h : a' = a) [p.IsHomLift f φ] : p.IsHomLift f (eqToHom h ≫ φ) :=
+  have := eqToHom_codomain_lift_id p h (domain_eq f φ)
+  id_comp f ▸ comp (eqToHom h) φ
 
 instance eqToHom_comp_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b b' : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} {h : b = b'} [hφ : IsHomLift p f φ] : IsHomLift p f (φ ≫ eqToHom h) :=
-  comp_id f ▸ hφ.comp (hψ := eqToHom_domain_lift_id h hφ.codomain_eq)
+    {φ : a ⟶ b} {h : b = b'} [p.IsHomLift f φ] : p.IsHomLift f (φ ≫ eqToHom h) :=
+  have := eqToHom_domain_lift_id p h (codomain_eq f φ)
+  comp_id f ▸ comp φ (eqToHom h)
 
 instance lift_eqToHom_comp {p : 𝒳 ⥤ 𝒮} {R' R S : 𝒮} {a b : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} (h : R' = R) [hφ : IsHomLift p f φ] : IsHomLift p ((eqToHom h) ≫ f) φ :=
-  id_comp φ ▸ (IsHomLift.id_lift_eqToHom_codomain h hφ.domain_eq).comp
+    {φ : a ⟶ b} (h : R' = R) [p.IsHomLift f φ] : p.IsHomLift ((eqToHom h) ≫ f) φ :=
+  have := id_lift_eqToHom_codomain p h (domain_eq f φ)
+  id_comp φ ▸ comp (𝟙 a) φ
 
 instance lift_comp_eqToHom {p : 𝒳 ⥤ 𝒮} {R S S': 𝒮} {a b : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} (h : S = S') [hφ : IsHomLift p f φ] : IsHomLift p (f ≫ (eqToHom h)) φ :=
-  comp_id φ ▸ hφ.comp (hψ := IsHomLift.id_lift_eqToHom_domain h hφ.codomain_eq)
+    {φ : a ⟶ b} (h : S = S') [p.IsHomLift f φ] : p.IsHomLift (f ≫ (eqToHom h)) φ :=
+  have := id_lift_eqToHom_domain p h (codomain_eq f φ)
+  comp_id φ ▸ comp φ (𝟙 b)
 
 @[simp]
 lemma comp_eqToHom_lift_iff {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a' a b : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} {h : a' = a} : IsHomLift p f (eqToHom h ≫ φ) ↔ IsHomLift p f φ where
+    {φ : a ⟶ b} {h : a' = a} : p.IsHomLift f (eqToHom h ≫ φ) ↔ p.IsHomLift f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
 @[simp]
 lemma eqToHom_comp_lift_iff {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b b' : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} {h : b = b'} : IsHomLift p f (φ ≫ eqToHom h) ↔ IsHomLift p f φ where
+    {φ : a ⟶ b} {h : b = b'} : p.IsHomLift f (φ ≫ eqToHom h) ↔ p.IsHomLift f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
 @[simp]
 lemma lift_eqToHom_comp_iff {p : 𝒳 ⥤ 𝒮} {R' R S : 𝒮} {a b : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} (h : R' = R) : IsHomLift p ((eqToHom h) ≫ f) φ ↔ IsHomLift p f φ where
+    {φ : a ⟶ b} (h : R' = R) : p.IsHomLift ((eqToHom h) ≫ f) φ ↔ p.IsHomLift f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
 @[simp]
 lemma lift_comp_eqToHom_iff {p : 𝒳 ⥤ 𝒮} {R S S': 𝒮} {a b : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} (h : S = S') : IsHomLift p (f ≫ (eqToHom h)) φ ↔ IsHomLift p f φ where
+    {φ : a ⟶ b} (h : S = S') : p.IsHomLift (f ≫ (eqToHom h)) φ ↔ p.IsHomLift f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
 /-- The isomorphism `R ≅ S` obtained from an isomorphism `φ : a ≅ b` lifting `f` -/
-def isoOfIsoLift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    [hφ : IsHomLift p f φ.hom] : R ≅ S :=
-  eqToIso hφ.domain_eq.symm ≪≫ p.mapIso φ ≪≫ eqToIso hφ.codomain_eq
+def isoOfIsoLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b)
+    [p.IsHomLift f φ.hom] : R ≅ S :=
+  eqToIso (domain_eq_of_isHomLift p f φ.hom).symm ≪≫ p.mapIso φ ≪≫
+    eqToIso (codomain_eq_of_isHomLift p f φ.hom)
 
 @[simp]
 lemma isoOfIsoLift_hom {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    [hφ : IsHomLift p f φ.hom] : (hφ.isoOfIsoLift).hom = f := by
-  simp [isoOfIsoLift, hφ.hom_eq]
+    [p.IsHomLift f φ.hom] : (isoOfIsoLift p f φ).hom = f := by
+  simp [isoOfIsoLift, fac_of_isHomLift p f φ.hom]
 
 @[simp]
 lemma isoOfIsoLift_comp {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    [hφ : IsHomLift p f φ.hom] : (hφ.isoOfIsoLift).inv ≫ f = 𝟙 S := by
+    [p.IsHomLift f φ.hom] : (isoOfIsoLift p f φ).inv ≫ f = 𝟙 S := by
   rw [CategoryTheory.Iso.inv_comp_eq]
   simp only [isoOfIsoLift_hom, comp_id]
 
 @[simp]
 lemma comp_isoOfIsoLift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    [hφ : IsHomLift p f φ.hom] : f ≫ (hφ.isoOfIsoLift).inv = 𝟙 R := by
+    [p.IsHomLift f φ.hom] : f ≫ (isoOfIsoLift p f φ).inv = 𝟙 R := by
   rw [CategoryTheory.Iso.comp_inv_eq]
   simp only [isoOfIsoLift_hom, id_comp]
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and `φ` is an isomorphism, then so is `f`. -/
 lemma isIso_of_lift_isIso {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
-    [hφ : IsHomLift p f φ] [IsIso φ] : IsIso f :=
-  hφ.hom_eq ▸ inferInstance
+    [p.IsHomLift f φ] [IsIso φ] : IsIso f :=
+  (fac_of_isHomLift p f φ) ▸ inferInstance
 
 /-- Given `φ : a ≅ b` and `f : R ≅ S`, such that `φ.hom` lifts `f.hom`, then `φ.inv` lifts
 `f.inv`. -/
-protected instance inv_lift_inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ≅ S} {φ : a ≅ b}
-    [hφ : IsHomLift p f.hom φ.hom] : IsHomLift p f.inv φ.inv where
-  domain_eq := hφ.2
-  codomain_eq := hφ.1
-  commsq := CommSq.horiz_inv (f:=p.mapIso φ) (i:=f) hφ.3
+protected instance inv_lift_inv (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ≅ S) (φ : a ≅ b)
+    [p.IsHomLift f.hom φ.hom] : p.IsHomLift f.inv φ.inv := by
+  apply isHomLift_of_commSq
+  apply CommSq.horiz_inv (f:=p.mapIso φ) (commSq_of_isHomLift p f.hom φ.hom)
 
 /-- Given `φ : a ≅ b` and `f : R ⟶ S`, such that `φ.hom` lifts `f`, then `φ.inv` lifts the
 inverse of `f` given by `isoOfIsoLift`. -/
-protected instance inv_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    [hφ : IsHomLift p f φ.hom] : IsHomLift p (hφ.isoOfIsoLift).inv φ.inv where
-  domain_eq := hφ.2
-  codomain_eq := hφ.1
-  commsq := CommSq.horiz_inv (f:=p.mapIso φ) (i:=hφ.isoOfIsoLift) (by simpa using hφ.3)
+protected instance inv_lift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b)
+    [p.IsHomLift f φ.hom] : p.IsHomLift (isoOfIsoLift p f φ).inv φ.inv := by
+  apply isHomLift_of_commSq
+  apply CommSq.horiz_inv (f:=p.mapIso φ) (by simpa using (commSq_of_isHomLift p f φ.hom))
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and both are isomorphisms, then `φ⁻¹` lifts `f⁻¹`. -/
-protected instance inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
-    [hφ : IsHomLift p f φ] [IsIso φ] [IsIso f] : IsHomLift p (inv f) (inv φ) :=
-  IsHomLift.inv_lift_inv (f := asIso f) (φ := asIso φ) (hφ := hφ)
+protected instance inv (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
+    [p.IsHomLift f φ] [IsIso φ] [IsIso f] : p.IsHomLift (CategoryTheory.inv f) (CategoryTheory.inv φ) :=
+  have : p.IsHomLift (asIso f).hom (asIso φ).hom := by simp; infer_instance
+  IsHomLift.inv_lift_inv p (asIso f) (asIso φ)
 
 /-- If `φ : a ⟶ b` is an isomorphism, and lifts `𝟙 S` for some `S : 𝒮`, then `φ⁻¹` also
 lifts `𝟙 S` -/
 instance lift_id_inv {p : 𝒳 ⥤ 𝒮} {S : 𝒮} {a b : 𝒳} {φ : a ⟶ b} [IsIso φ]
-    [hφ : IsHomLift p (𝟙 S) φ] : IsHomLift p (𝟙 S) (inv φ) :=
-  (IsIso.inv_id (X:=S)) ▸ hφ.inv
+    [p.IsHomLift (𝟙 S) φ] : p.IsHomLift (𝟙 S) (CategoryTheory.inv φ) :=
+  (IsIso.inv_id (X:=S)) ▸ (IsHomLift.inv p _ φ)
 
 end Functor.IsHomLift
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -75,12 +75,10 @@ lemma codomain_eq  : p.obj b = S :=
 lemma fac : f = eqToHom (domain_eq p f φ).symm ≫ p.map φ ≫ eqToHom (codomain_eq p f φ) :=
   Functor.IsHomLift.fac
 
-lemma fac' : p.map φ = eqToHom (domain_eq p f φ) ≫ f ≫
-    eqToHom (codomain_eq p f φ).symm := by
+lemma fac' : p.map φ = eqToHom (domain_eq p f φ) ≫ f ≫ eqToHom (codomain_eq p f φ).symm := by
   simp [fac p f φ]
 
-lemma commSq : CommSq (p.map φ) (eqToHom (domain_eq p f φ))
-    (eqToHom (codomain_eq p f φ)) f where
+lemma commSq : CommSq (p.map φ) (eqToHom (domain_eq p f φ)) (eqToHom (codomain_eq p f φ)) f where
   w := by simp only [fac p f φ, eqToHom_trans_assoc, eqToHom_refl, id_comp]
 
 end
@@ -89,8 +87,8 @@ lemma of_commSq {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (ha : p.o
     (h : CommSq (p.map φ) (eqToHom ha) (eqToHom hb) f) : p.IsHomLift f φ where
   fac := by simp only [h.1, eqToHom_trans_assoc, eqToHom_refl, id_comp]
 
-lemma eq_of_isHomLift {a b : 𝒳} (f : p.obj a ⟶ p.obj b) (φ : a ⟶ b)
-    [p.IsHomLift f φ] : f = p.map φ := by
+lemma eq_of_isHomLift {a b : 𝒳} (f : p.obj a ⟶ p.obj b) (φ : a ⟶ b) [p.IsHomLift f φ] :
+    f = p.map φ := by
   simpa only [eqToHom_refl, comp_id, id_comp] using fac p f φ
 
 instance comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S} {g : S ⟶ T} (φ : a ⟶ b)

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -182,26 +182,23 @@ lemma eqToHom_comp_lift_iff {R S : 𝒮} {a b b' : 𝒳} (f : R ⟶ S) (φ : a �
 @[simp]
 lemma lift_eqToHom_comp_iff {R' R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : R' = R) :
     p.IsHomLift (eqToHom h ≫ f) φ ↔ p.IsHomLift f φ where
-  mp := by intro hφ'; subst h; simpa using hφ'
+  mp := fun hφ' => by subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
 @[simp]
 lemma lift_comp_eqToHom_iff {R S S' : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : S = S') :
     p.IsHomLift (f ≫ eqToHom h) φ ↔ p.IsHomLift f φ where
-  mp := by intro hφ'; subst h; simpa using hφ'
+  mp := fun hφ' => by subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
 /-- The isomorphism `R ≅ S` obtained from an isomorphism `φ : a ≅ b` lifting `f` -/
+@[simps hom]
 def isoOfIsoLift  {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
     R ≅ S where
   hom := f
   inv := eqToHom (codomain_eq p f φ.hom).symm ≫ (p.mapIso φ).inv ≫ eqToHom (domain_eq p f φ.hom)
   hom_inv_id := by subst_hom_lift p f φ.hom; simp [← p.map_comp]
   inv_hom_id := by subst_hom_lift p f φ.hom; simp [← p.map_comp]
-
-@[simp]
-lemma isoOfIsoLift_hom {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
-    (isoOfIsoLift p f φ).hom = f := rfl
 
 @[simp]
 lemma isoOfIsoLift_inv_hom_id {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -141,7 +141,7 @@ instance eqToHom_comp_lift {R S : 𝒮} {a b b' : 𝒳} (f : R ⟶ S) (φ : a �
   comp_id f ▸ comp φ (eqToHom h)
 
 instance lift_eqToHom_comp {R' R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : R' = R)
-    [p.IsHomLift f φ] : p.IsHomLift ((eqToHom h) ≫ f) φ :=
+    [p.IsHomLift f φ] : p.IsHomLift (eqToHom h ≫ f) φ :=
   have := id_lift_eqToHom_codomain h (domain_eq p f φ)
   id_comp φ ▸ comp (𝟙 a) φ
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -47,8 +47,8 @@ often drawn as:
   R --f--> S
 ``` -/
 class Functor.IsHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) : Prop where
-  domain_eq : p.obj a = R
-  codomain_eq : p.obj b = S
+  domain_eq : p.obj a = R := by aesop_cat
+  codomain_eq : p.obj b = S := by aesop_cat
   homlift : CommSq (p.map φ) (eqToHom domain_eq) (eqToHom codomain_eq) f
 
 namespace Functor.IsHomLift

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -164,7 +164,7 @@ lemma eqToHom_comp_lift_iff {R S : 𝒮} {a b b' : 𝒳} (f : R ⟶ S) (φ : a �
 
 @[simp]
 lemma lift_eqToHom_comp_iff {R' R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : R' = R) :
-    p.IsHomLift ((eqToHom h) ≫ f) φ ↔ p.IsHomLift f φ where
+    p.IsHomLift (eqToHom h ≫ f) φ ↔ p.IsHomLift f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -170,7 +170,7 @@ lemma lift_eqToHom_comp_iff {R' R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a �
 
 @[simp]
 lemma lift_comp_eqToHom_iff {R S S' : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : S = S') :
-    p.IsHomLift (f ≫ (eqToHom h)) φ ↔ p.IsHomLift f φ where
+    p.IsHomLift (f ≫ eqToHom h) φ ↔ p.IsHomLift f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -3,13 +3,19 @@ Copyright (c) 2024 Calle Sönne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Lezeau, Calle Sönne
 -/
+
 import Mathlib.CategoryTheory.Functor.Category
 import Mathlib.CategoryTheory.CommSq
+
 /-!
+
 # HomLift
+
 Given a functor `p : 𝒳 ⥤ 𝒮`, this file provides API for expressing the fact that `p(φ) = f`
 for given morphisms `φ` and `f`.
+
 ## Main definition
+
 Given morphism `φ : a ⟶ b` in `𝒳` and `f : R ⟶ S` in `𝒮`, `IsHomLift p f φ` is defined as a
 structure containing the data that `p(a) = R`, `p(b) = S` and the fact that the following square
 commutes:
@@ -23,10 +29,15 @@ commutes
 ```
 where the vertical arrows are given by `eqToHom` corresponding to the equalities `p(a) = R` and
 `p(b) = S`.
+
 -/
+
 universe u₁ v₁ u₂ v₂
+
 open CategoryTheory Functor Category
+
 variable {𝒮 : Type u₁} {𝒳 : Type u₂} [Category 𝒳] [Category 𝒮]
+
 /-- The proposition that an arrow a --φ--> b lifts an arrow R --f--> S in 𝒮 via p. This is
 often drawn as:
 ```
@@ -40,38 +51,47 @@ structure IsHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) 
   (ObjLiftDomain : p.obj a = R)
   (ObjLiftCodomain : p.obj b = S)
   (HomLift : CommSq (p.map φ) (eqToHom ObjLiftDomain) (eqToHom ObjLiftCodomain) f)
+
 namespace IsHomLift
+
 protected lemma hom_eq {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
     (hφ : IsHomLift p f φ) : f = eqToHom hφ.ObjLiftDomain.symm ≫ p.map φ ≫
       eqToHom hφ.ObjLiftCodomain :=
   ((eqToHom_comp_iff hφ.ObjLiftDomain _ _).1 hφ.HomLift.w.symm)
+
 protected lemma hom_eq' {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
     (hφ : IsHomLift p f φ) : p.map φ = eqToHom hφ.ObjLiftDomain ≫ f ≫
       eqToHom hφ.ObjLiftCodomain.symm := by
   rw [← assoc, ← comp_eqToHom_iff hφ.ObjLiftCodomain _ _]
   exact hφ.HomLift.w
+
 lemma eq_of_IsHomLift {p : 𝒳 ⥤ 𝒮} (a b : 𝒳) {f : p.obj a ⟶ p.obj b} {φ : a ⟶ b}
     (hφ : IsHomLift p f φ) : f = p.map φ := by
   simpa using IsHomLift.hom_eq hφ
+
 /-- For any arrow `φ : a ⟶ b` in `𝒳`, `φ` lifts the arrow `p.map φ` in the base `𝒮`-/
 @[simp]
 protected lemma self (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (φ : a ⟶ b) : IsHomLift p (p.map φ) φ where
   ObjLiftDomain := rfl
   ObjLiftCodomain := rfl
   HomLift := ⟨by simp only [eqToHom_refl, comp_id, id_comp]⟩
+
 @[simp]
 protected lemma id {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a : 𝒳} (ha : p.obj a = R) : IsHomLift p (𝟙 R) (𝟙 a) :=
   ha ▸ (p.map_id _ ▸ IsHomLift.self p (𝟙 a))
+
 protected lemma comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
     {g : S ⟶ T} {φ : a ⟶ b} {ψ : b ⟶ c} (hφ : IsHomLift p f φ)
     (hψ : IsHomLift p g ψ) : IsHomLift p (f ≫ g) (φ ≫ ψ) where
   ObjLiftDomain := hφ.1
   ObjLiftCodomain := hψ.2
   HomLift := (p.map_comp _ _).symm ▸ CommSq.horiz_comp hφ.3 hψ.3
+
 /-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 S`, then so does `φ ≫ ψ` -/
 lemma lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ b} {ψ : b ⟶ c}
     (hφ : IsHomLift p (𝟙 R) φ) (hψ : IsHomLift p (𝟙 R) ψ) : IsHomLift p (𝟙 R) (φ ≫ ψ) :=
   comp_id (𝟙 R) ▸ IsHomLift.comp hφ hψ
+
 /-- If `φ : a ⟶ b` lifts `f` and `ψ : b ⟶ c` lifts `𝟙 T`, then `φ  ≫ ψ` lifts `f` -/
 lemma comp_lift_id {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} (hφ : IsHomLift p f φ) {ψ : b ⟶ c} (hψ : IsHomLift p (𝟙 T) ψ) :
@@ -79,74 +99,88 @@ lemma comp_lift_id {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ 
   ObjLiftDomain := hφ.ObjLiftDomain
   ObjLiftCodomain := by rw [hψ.ObjLiftCodomain, ← hψ.ObjLiftDomain, hφ.ObjLiftCodomain]
   HomLift := ⟨by simp [IsHomLift.hom_eq' hψ, hφ.3.1]⟩
+
 @[simp]
 lemma eqToHom_domain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {R : 𝒮}
     (hR : p.obj a = R) : IsHomLift p (𝟙 R) (eqToHom hab) where
       ObjLiftDomain := hR
       ObjLiftCodomain := hab ▸ hR
       HomLift := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
+
 @[simp]
 lemma eqToHom_codomain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {S : 𝒮}
     (hS : p.obj b = S) : IsHomLift p (𝟙 S) (eqToHom hab) where
       ObjLiftDomain := hab ▸ hS
       ObjLiftCodomain := hS
       HomLift := ⟨by simp only [eqToHom_map, eqToHom_trans, comp_id]⟩
+
 @[simp]
 lemma id_lift_eqToHom_domain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S)
     {a : 𝒳} (ha : p.obj a = R) : IsHomLift p (eqToHom hRS) (𝟙 a) where
       ObjLiftDomain := ha
       ObjLiftCodomain := hRS ▸ ha
       HomLift := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
+
 @[simp]
 lemma id_lift_eqToHom_codomain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S)
     {b : 𝒳} (hb : p.obj b = S) : IsHomLift p (eqToHom hRS) (𝟙 b) where
       ObjLiftDomain := hRS ▸ hb
       ObjLiftCodomain := hb
       HomLift := ⟨by simp only [map_id, id_comp, eqToHom_trans]⟩
+
 @[simp]
 lemma comp_eqToHom_lift_iff {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a' a b : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} {h : a' = a} : IsHomLift p f (eqToHom h ≫ φ) ↔ IsHomLift p f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ => id_comp f ▸ IsHomLift.comp (eqToHom_codomain_lift_id h hφ.ObjLiftDomain) hφ
+
 @[simp]
 lemma eqToHom_comp_lift_iff {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b b' : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} {h : b = b'} : IsHomLift p f (φ ≫ eqToHom h) ↔ IsHomLift p f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ => comp_id f ▸ IsHomLift.comp hφ (eqToHom_domain_lift_id h hφ.ObjLiftCodomain)
+
 @[simp]
 lemma lift_eqToHom_comp_iff {p : 𝒳 ⥤ 𝒮} {R' R S : 𝒮} {a b : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} (h : R' = R) : IsHomLift p ((eqToHom h) ≫ f) φ ↔ IsHomLift p f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ =>
     id_comp φ ▸ IsHomLift.comp (IsHomLift.id_lift_eqToHom_codomain h hφ.ObjLiftDomain) hφ
+
 @[simp]
 lemma lift_comp_eqToHom_iff {p : 𝒳 ⥤ 𝒮} {R S S': 𝒮} {a b : 𝒳} {f : R ⟶ S}
     {φ : a ⟶ b} (h : S = S') : IsHomLift p (f ≫ (eqToHom h)) φ ↔ IsHomLift p f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ =>
     comp_id φ ▸ IsHomLift.comp hφ (IsHomLift.id_lift_eqToHom_domain h hφ.ObjLiftCodomain)
+
 /-- The isomorphism `R ≅ S` obtained from an isomorphism `φ : a ≅ b` lifting `f` -/
 def Iso_of_Iso_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
     (hφ : IsHomLift p f φ.hom) : R ≅ S :=
   eqToIso hφ.ObjLiftDomain.symm ≪≫ p.mapIso φ ≪≫ eqToIso hφ.ObjLiftCodomain
+
 @[simp]
 lemma Iso_of_Iso_lift_hom {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
     (hφ : IsHomLift p f φ.hom) : (Iso_of_Iso_lift hφ).hom = f := by
   simp [Iso_of_Iso_lift, IsHomLift.hom_eq hφ]
+
 @[simp]
 lemma Iso_of_Iso_lift_comp {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
     (hφ : IsHomLift p f φ.hom) : (Iso_of_Iso_lift hφ).inv ≫ f = 𝟙 S := by
   rw [CategoryTheory.Iso.inv_comp_eq]
   simp only [Iso_of_Iso_lift_hom, comp_id]
+
 @[simp]
 lemma comp_Iso_of_Iso_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
     (hφ : IsHomLift p f φ.hom) : f ≫ (Iso_of_Iso_lift hφ).inv = 𝟙 R := by
   rw [CategoryTheory.Iso.comp_inv_eq]
   simp only [Iso_of_Iso_lift_hom, id_comp]
+
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and `φ` is an isomorphism, then so is `f`. -/
 lemma IsIso_of_lift_IsIso {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
     (hφ : IsHomLift p f φ) [IsIso φ] : IsIso f :=
   (IsHomLift.hom_eq hφ) ▸ inferInstance
+
 /-- Given `φ : a ≅ b` and `f : R ≅ S`, such that `φ.hom` lifts `f.hom`, then `φ.inv` lifts
 `f.inv`. -/
 protected lemma inv_lift_inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ≅ S} {φ : a ≅ b}
@@ -154,6 +188,7 @@ protected lemma inv_lift_inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : 
   ObjLiftDomain := hφ.2
   ObjLiftCodomain := hφ.1
   HomLift := CommSq.horiz_inv (f:=p.mapIso φ) (i:=f) hφ.3
+
 /-- Given `φ : a ≅ b` and `f : R ⟶ S`, such that `φ.hom` lifts `f`, then `φ.inv` lifts the
 inverse of `f` given by `Iso_of_Iso_lift`. -/
 protected lemma inv_lift_inv' {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
@@ -161,13 +196,16 @@ protected lemma inv_lift_inv' {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f :
   ObjLiftDomain := hφ.2
   ObjLiftCodomain := hφ.1
   HomLift := CommSq.horiz_inv (f:=p.mapIso φ) (i:=Iso_of_Iso_lift hφ) (by simpa using hφ.3)
+
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and both are isomorphisms, then `φ⁻¹` lifts `f⁻¹`. -/
 protected lemma inv {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
     (hφ : IsHomLift p f φ) [IsIso φ] [IsIso f] : IsHomLift p (inv f) (inv φ) :=
   IsHomLift.inv_lift_inv (f:=asIso f) (φ:= asIso φ) hφ
+
 /-- If `φ : a ⟶ b` is an isomorphism, and lifts `𝟙 S` for some `S : 𝒮`, then `φ⁻¹` also
 lifts `𝟙 S` -/
 lemma lift_id_inv {p : 𝒳 ⥤ 𝒮} {S : 𝒮} {a b : 𝒳} {φ : a ⟶ b} [IsIso φ]
     (hφ : IsHomLift p (𝟙 S) φ) : IsHomLift p (𝟙 S) (inv φ) :=
   (IsIso.inv_id (X:=S)) ▸ IsHomLift.inv hφ
+
 end IsHomLift

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -80,7 +80,7 @@ lemma fac' : p.map φ = eqToHom (domain_eq p f φ) ≫ f ≫
   simp [fac p f φ]
 
 lemma commSq : CommSq (p.map φ) (eqToHom (domain_eq p f φ))
-      (eqToHom (codomain_eq p f φ)) f where
+    (eqToHom (codomain_eq p f φ)) f where
   w := by simp only [fac p f φ, eqToHom_trans_assoc, eqToHom_refl, id_comp]
 
 end

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -97,7 +97,7 @@ instance comp {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S} {g
   rw [p.map_comp]
   apply CommSq.horiz_comp (commSq p f φ) (commSq p g ψ)
 
-/-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 S`, then so does `φ ≫ ψ` -/
+/-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 R`, then so does `φ ≫ ψ` -/
 instance lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ b} {ψ : b ⟶ c}
     [p.IsHomLift (𝟙 R) φ] [p.IsHomLift (𝟙 R) ψ] : p.IsHomLift (𝟙 R) (φ ≫ ψ) :=
   comp_id (𝟙 R) ▸ comp φ ψ

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -62,22 +62,18 @@ instance (p : 𝒳 ⥤ 𝒮) (a : 𝒳) : p.IsHomLift (𝟙 (p.obj a)) (𝟙 a) 
 @[simp]
 protected lemma id {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a : 𝒳} (ha : p.obj a = R) : p.IsHomLift (𝟙 R) (𝟙 a) where
 
-@[simp]
 lemma domain_eq (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
     [p.IsHomLift f φ] : p.obj a = R :=
   Functor.IsHomLift.domain_eq f φ
 
-@[simp]
 lemma codomain_eq (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
     [p.IsHomLift f φ] : p.obj b = S :=
   Functor.IsHomLift.codomain_eq f φ
 
-@[simp]
 lemma fac (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ] :
     f = eqToHom (domain_eq p f φ).symm ≫ p.map φ ≫ eqToHom (codomain_eq p f φ) :=
   Functor.IsHomLift.fac
 
-@[simp]
 lemma fac' (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
     [p.IsHomLift f φ] : p.map φ = eqToHom (domain_eq p f φ) ≫ f ≫
       eqToHom (codomain_eq p f φ).symm := by
@@ -93,7 +89,6 @@ lemma of_commSq {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ 
       p.IsHomLift f φ where
   fac := by simp only [h.1, eqToHom_trans_assoc, eqToHom_refl, id_comp]
 
-@[simp]
 lemma eq_of_isHomLift {p : 𝒳 ⥤ 𝒮} (a b : 𝒳) {f : p.obj a ⟶ p.obj b} {φ : a ⟶ b}
     [p.IsHomLift f φ] : f = p.map φ := by
   simpa only [eqToHom_refl, comp_id, id_comp] using fac p f φ
@@ -111,7 +106,7 @@ instance lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ 
 
 /-- If `φ : a ⟶ b` lifts `f` and `ψ : b ⟶ c` lifts `𝟙 T`, then `φ  ≫ ψ` lifts `f` -/
 lemma comp_lift_id_right {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} [p.IsHomLift f φ] {ψ : b ⟶ c} [hψ : p.IsHomLift (𝟙 T) ψ] :
+    {φ : a ⟶ b} [p.IsHomLift f φ] {ψ : b ⟶ c} [p.IsHomLift (𝟙 T) ψ] :
     p.IsHomLift f (φ ≫ ψ) where
   -- TODO: this first one should be able to be automated?
   domain_eq := domain_eq p f φ
@@ -120,7 +115,7 @@ lemma comp_lift_id_right {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : 
 
 /-- If `φ : a ⟶ b` lifts `𝟙 T` and `ψ : b ⟶ c` lifts `f`, then `φ  ≫ ψ` lifts `f` -/
 lemma comp_lift_id_left {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : S ⟶ T}
-    {φ : a ⟶ b} [p.IsHomLift (𝟙 R) φ] {ψ : b ⟶ c} [hψ : p.IsHomLift f ψ] :
+    {φ : a ⟶ b} [p.IsHomLift (𝟙 R) φ] {ψ : b ⟶ c} [p.IsHomLift f ψ] :
     p.IsHomLift f (φ ≫ ψ) where
   domain_eq := by rw [domain_eq p (𝟙 R) φ, ← codomain_eq p (𝟙 R) φ, domain_eq p f ψ]
   codomain_eq := codomain_eq p f ψ

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -18,7 +18,6 @@ for given morphisms `φ` and `f`.
 
 Given morphism `φ : a ⟶ b` in `𝒳` and `f : R ⟶ S` in `𝒮`, `IsHomLift p f φ` is defined as a
 structure containing the data that `p(a) = R`, `p(b) = S` and the fact that the following square
-commutes:
 commutes
 ```
   p(a) --p(φ)--> p(b)

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -35,12 +35,13 @@ universe u₁ v₁ u₂ v₂
 
 open CategoryTheory Category
 
-variable {𝒮 : Type u₁} {𝒳 : Type u₂} [Category 𝒳] [Category 𝒮]
+variable {𝒮 : Type u₁} {𝒳 : Type u₂} [Category.{v₁} 𝒳] [Category.{v₂} 𝒮] (p : 𝒳 ⥤ 𝒮)
 
 namespace CategoryTheory
 
-/-- The proposition that an arrow a --φ--> b lifts an arrow R --f--> S in 𝒮 via p. This is
-often drawn as:
+/-- Given a functor `p : 𝒳 ⥤ 𝒮`, an arrow `φ : a ⟶ b` in `𝒳` and an arrow `f : R ⟶ S` in `𝒮`,
+`p.IsHomLift f φ` expresses the fact that `φ` lifts `f` through `p`.
+This is often drawn as:
 ```
   a --φ--> b
   -        -
@@ -48,48 +49,47 @@ often drawn as:
   v        v
   R --f--> S
 ``` -/
-class Functor.IsHomLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) : Prop where
+class Functor.IsHomLift  {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) : Prop where
   domain_eq : p.obj a = R := by aesop_cat
   codomain_eq : p.obj b = S := by aesop_cat
   fac : f = eqToHom domain_eq.symm ≫ p.map φ ≫ eqToHom codomain_eq := by aesop_cat
 
+/-- For any arrow `φ : a ⟶ b` in `𝒳`, `φ` lifts the arrow `p.map φ` in the base `𝒮`-/
+instance  {a b : 𝒳} (φ : a ⟶ b) : p.IsHomLift (p.map φ) φ where
+instance  (a : 𝒳) : p.IsHomLift (𝟙 (p.obj a)) (𝟙 a) where
+
 namespace IsHomLift
 
-/-- For any arrow `φ : a ⟶ b` in `𝒳`, `φ` lifts the arrow `p.map φ` in the base `𝒮`-/
-instance self (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (φ : a ⟶ b) : p.IsHomLift (p.map φ) φ where
-instance (p : 𝒳 ⥤ 𝒮) (a : 𝒳) : p.IsHomLift (𝟙 (p.obj a)) (𝟙 a) where
-
-@[simp]
 protected lemma id {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a : 𝒳} (ha : p.obj a = R) : p.IsHomLift (𝟙 R) (𝟙 a) where
 
-lemma domain_eq (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
-    [p.IsHomLift f φ] : p.obj a = R :=
+section
+
+variable {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ]
+
+lemma domain_eq : p.obj a = R :=
   Functor.IsHomLift.domain_eq f φ
 
-lemma codomain_eq (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
-    [p.IsHomLift f φ] : p.obj b = S :=
+lemma codomain_eq  : p.obj b = S :=
   Functor.IsHomLift.codomain_eq f φ
 
-lemma fac (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ] :
-    f = eqToHom (domain_eq p f φ).symm ≫ p.map φ ≫ eqToHom (codomain_eq p f φ) :=
+lemma fac : f = eqToHom (domain_eq p f φ).symm ≫ p.map φ ≫ eqToHom (codomain_eq p f φ) :=
   Functor.IsHomLift.fac
 
-lemma fac' (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
-    [p.IsHomLift f φ] : p.map φ = eqToHom (domain_eq p f φ) ≫ f ≫
+lemma fac' : p.map φ = eqToHom (domain_eq p f φ) ≫ f ≫
       eqToHom (codomain_eq p f φ).symm := by
   simp [fac p f φ]
 
-lemma commSq (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b)
-    [p.IsHomLift f φ] : CommSq (p.map φ) (eqToHom (domain_eq p f φ))
+lemma commSq : CommSq (p.map φ) (eqToHom (domain_eq p f φ))
       (eqToHom (codomain_eq p f φ)) f where
   w := by simp only [fac p f φ, eqToHom_trans_assoc, eqToHom_refl, id_comp]
 
-lemma of_commSq {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
-    (ha : p.obj a = R) (hb : p.obj b = S) (h : CommSq (p.map φ) (eqToHom ha) (eqToHom hb) f) :
-      p.IsHomLift f φ where
+end
+
+lemma of_commSq {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (ha : p.obj a = R) (hb : p.obj b = S)
+    (h : CommSq (p.map φ) (eqToHom ha) (eqToHom hb) f) : p.IsHomLift f φ where
   fac := by simp only [h.1, eqToHom_trans_assoc, eqToHom_refl, id_comp]
 
-lemma eq_of_isHomLift {p : 𝒳 ⥤ 𝒮} (a b : 𝒳) {f : p.obj a ⟶ p.obj b} {φ : a ⟶ b}
+lemma eq_of_isHomLift {a b : 𝒳} (f : p.obj a ⟶ p.obj b) (φ : a ⟶ b)
     [p.IsHomLift f φ] : f = p.map φ := by
   simpa only [eqToHom_refl, comp_id, id_comp] using fac p f φ
 
@@ -105,137 +105,128 @@ instance lift_id_comp {p : 𝒳 ⥤ 𝒮} {R : 𝒮} {a b c : 𝒳} {φ : a ⟶ 
   comp_id (𝟙 R) ▸ comp φ ψ
 
 /-- If `φ : a ⟶ b` lifts `f` and `ψ : b ⟶ c` lifts `𝟙 T`, then `φ  ≫ ψ` lifts `f` -/
-lemma comp_lift_id_right {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} [p.IsHomLift f φ] {ψ : b ⟶ c} [p.IsHomLift (𝟙 T) ψ] :
-    p.IsHomLift f (φ ≫ ψ) where
-  -- TODO: this first one should be able to be automated?
-  domain_eq := domain_eq p f φ
-  codomain_eq := by rw [codomain_eq p (𝟙 T) ψ, ← domain_eq p (𝟙 T) ψ, codomain_eq p f φ]
-  fac := by simp [fac p f φ, fac' p (𝟙 T) ψ]
+lemma comp_lift_id_right {R S : 𝒮} {a b c : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ]
+    (T : 𝒮) (ψ : b ⟶ c) [p.IsHomLift (𝟙 T) ψ] : p.IsHomLift f (φ ≫ ψ) := by
+  obtain rfl : S = T := by rw [← codomain_eq p f φ, domain_eq p (𝟙 T) ψ]
+  simpa using inferInstanceAs (p.IsHomLift (f ≫ 𝟙 S) (φ ≫ ψ))
 
 /-- If `φ : a ⟶ b` lifts `𝟙 T` and `ψ : b ⟶ c` lifts `f`, then `φ  ≫ ψ` lifts `f` -/
-lemma comp_lift_id_left {p : 𝒳 ⥤ 𝒮} {R S T : 𝒮} {a b c : 𝒳} {f : S ⟶ T}
-    {φ : a ⟶ b} [p.IsHomLift (𝟙 R) φ] {ψ : b ⟶ c} [p.IsHomLift f ψ] :
-    p.IsHomLift f (φ ≫ ψ) where
-  domain_eq := by rw [domain_eq p (𝟙 R) φ, ← codomain_eq p (𝟙 R) φ, domain_eq p f ψ]
-  codomain_eq := codomain_eq p f ψ
-  fac := by simp [fac p f ψ, fac' p (𝟙 R) φ]
+lemma comp_lift_id_left {S T : 𝒮} {a b c : 𝒳} (f : S ⟶ T) (φ : a ⟶ b) (R : 𝒮)
+    [p.IsHomLift (𝟙 R) φ] (ψ : b ⟶ c) [p.IsHomLift f ψ] : p.IsHomLift f (φ ≫ ψ) := by
+  obtain rfl : R = S := by rw [← codomain_eq p (𝟙 R) φ, domain_eq p f ψ]
+  simpa using inferInstanceAs (p.IsHomLift (𝟙 R ≫ f) (φ ≫ ψ))
 
-@[simp]
-lemma eqToHom_domain_lift_id (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (hab : a = b) {R : 𝒮}
-    (hR : p.obj a = R) : p.IsHomLift (𝟙 R) (eqToHom hab) where
+lemma eqToHom_domain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {R : 𝒮} (hR : p.obj a = R) :
+    p.IsHomLift (𝟙 R) (eqToHom hab) where
   fac := by simp [eqToHom_map]
 
-@[simp]
-lemma eqToHom_codomain_lift_id (p : 𝒳 ⥤ 𝒮) {a b : 𝒳} (hab : a = b) {S : 𝒮}
-    (hS : p.obj b = S) : p.IsHomLift (𝟙 S) (eqToHom hab) where
+lemma eqToHom_codomain_lift_id {p : 𝒳 ⥤ 𝒮} {a b : 𝒳} (hab : a = b) {S : 𝒮} (hS : p.obj b = S) :
+    p.IsHomLift (𝟙 S) (eqToHom hab) where
   fac := by simp [eqToHom_map]
 
-@[simp]
-lemma id_lift_eqToHom_domain (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} (hRS : R = S)
-    {a : 𝒳} (ha : p.obj a = R) : p.IsHomLift (eqToHom hRS) (𝟙 a) where
+lemma id_lift_eqToHom_domain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S) {a : 𝒳} (ha : p.obj a = R) :
+    p.IsHomLift (eqToHom hRS) (𝟙 a) where
   fac := by simp [eqToHom_map]
 
-@[simp]
-lemma id_lift_eqToHom_codomain (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} (hRS : R = S)
-    {b : 𝒳} (hb : p.obj b = S) : p.IsHomLift (eqToHom hRS) (𝟙 b) where
+lemma id_lift_eqToHom_codomain {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} (hRS : R = S) {b : 𝒳} (hb : p.obj b = S) :
+    p.IsHomLift (eqToHom hRS) (𝟙 b) where
   fac := by simp [eqToHom_map]
 
-instance comp_eqToHom_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a' a b : 𝒳} {f : R ⟶ S}
-    (φ : a ⟶ b) (h : a' = a) [p.IsHomLift f φ] : p.IsHomLift f (eqToHom h ≫ φ) :=
-  have := eqToHom_codomain_lift_id p h (domain_eq p f φ)
+instance comp_eqToHom_lift {R S : 𝒮} {a' a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : a' = a)
+    [p.IsHomLift f φ] : p.IsHomLift f (eqToHom h ≫ φ) :=
+  have := eqToHom_codomain_lift_id h (domain_eq p f φ)
   id_comp f ▸ comp (eqToHom h) φ
 
-instance eqToHom_comp_lift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b b' : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} {h : b = b'} [p.IsHomLift f φ] : p.IsHomLift f (φ ≫ eqToHom h) :=
-  have := eqToHom_domain_lift_id p h (codomain_eq p f φ)
+instance eqToHom_comp_lift {R S : 𝒮} {a b b' : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : b = b')
+    [p.IsHomLift f φ] : p.IsHomLift f (φ ≫ eqToHom h) :=
+  have := eqToHom_domain_lift_id h (codomain_eq p f φ)
   comp_id f ▸ comp φ (eqToHom h)
 
-instance lift_eqToHom_comp {p : 𝒳 ⥤ 𝒮} {R' R S : 𝒮} {a b : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} (h : R' = R) [p.IsHomLift f φ] : p.IsHomLift ((eqToHom h) ≫ f) φ :=
-  have := id_lift_eqToHom_codomain p h (domain_eq p f φ)
+instance lift_eqToHom_comp {R' R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : R' = R)
+    [p.IsHomLift f φ] : p.IsHomLift ((eqToHom h) ≫ f) φ :=
+  have := id_lift_eqToHom_codomain h (domain_eq p f φ)
   id_comp φ ▸ comp (𝟙 a) φ
 
-instance lift_comp_eqToHom {p : 𝒳 ⥤ 𝒮} {R S S': 𝒮} {a b : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} (h : S = S') [p.IsHomLift f φ] : p.IsHomLift (f ≫ (eqToHom h)) φ :=
-  have := id_lift_eqToHom_domain p h (codomain_eq p f φ)
+instance lift_comp_eqToHom {R S S': 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : S = S')
+    [p.IsHomLift f φ] : p.IsHomLift (f ≫ (eqToHom h)) φ :=
+  have := id_lift_eqToHom_domain h (codomain_eq p f φ)
   comp_id φ ▸ comp φ (𝟙 b)
 
 @[simp]
-lemma comp_eqToHom_lift_iff {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a' a b : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} {h : a' = a} : p.IsHomLift f (eqToHom h ≫ φ) ↔ p.IsHomLift f φ where
+lemma comp_eqToHom_lift_iff {R S : 𝒮} {a' a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : a' = a) :
+    p.IsHomLift f (eqToHom h ≫ φ) ↔ p.IsHomLift f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
 @[simp]
-lemma eqToHom_comp_lift_iff {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b b' : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} {h : b = b'} : p.IsHomLift f (φ ≫ eqToHom h) ↔ p.IsHomLift f φ where
+lemma eqToHom_comp_lift_iff {R S : 𝒮} {a b b' : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : b = b') :
+    p.IsHomLift f (φ ≫ eqToHom h) ↔ p.IsHomLift f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
 @[simp]
-lemma lift_eqToHom_comp_iff {p : 𝒳 ⥤ 𝒮} {R' R S : 𝒮} {a b : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} (h : R' = R) : p.IsHomLift ((eqToHom h) ≫ f) φ ↔ p.IsHomLift f φ where
+lemma lift_eqToHom_comp_iff {R' R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : R' = R) :
+    p.IsHomLift ((eqToHom h) ≫ f) φ ↔ p.IsHomLift f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
 @[simp]
-lemma lift_comp_eqToHom_iff {p : 𝒳 ⥤ 𝒮} {R S S': 𝒮} {a b : 𝒳} {f : R ⟶ S}
-    {φ : a ⟶ b} (h : S = S') : p.IsHomLift (f ≫ (eqToHom h)) φ ↔ p.IsHomLift f φ where
+lemma lift_comp_eqToHom_iff {R S S' : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : S = S') :
+    p.IsHomLift (f ≫ (eqToHom h)) φ ↔ p.IsHomLift f φ where
   mp := by intro hφ'; subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
 /-- The isomorphism `R ≅ S` obtained from an isomorphism `φ : a ≅ b` lifting `f` -/
-def isoOfIsoLift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b)
-    [p.IsHomLift f φ.hom] : R ≅ S :=
+def isoOfIsoLift  {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
+    R ≅ S :=
   eqToIso (domain_eq p f φ.hom).symm ≪≫ p.mapIso φ ≪≫
     eqToIso (codomain_eq p f φ.hom)
 
 @[simp]
-lemma isoOfIsoLift_hom {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    [p.IsHomLift f φ.hom] : (isoOfIsoLift p f φ).hom = f := by
+lemma isoOfIsoLift_hom {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
+    (isoOfIsoLift p f φ).hom = f := by
   simp [isoOfIsoLift, fac p f φ.hom]
 
 @[simp]
-lemma isoOfIsoLift_comp {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    [p.IsHomLift f φ.hom] : (isoOfIsoLift p f φ).inv ≫ f = 𝟙 S := by
+lemma isoOfIsoLift_comp {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
+    (isoOfIsoLift p f φ).inv ≫ f = 𝟙 S := by
   rw [CategoryTheory.Iso.inv_comp_eq]
   simp only [isoOfIsoLift_hom, comp_id]
 
 @[simp]
-lemma comp_isoOfIsoLift {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ≅ b}
-    [p.IsHomLift f φ.hom] : f ≫ (isoOfIsoLift p f φ).inv = 𝟙 R := by
+lemma comp_isoOfIsoLift {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
+    f ≫ (isoOfIsoLift p f φ).inv = 𝟙 R := by
   rw [CategoryTheory.Iso.comp_inv_eq]
   simp only [isoOfIsoLift_hom, id_comp]
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and `φ` is an isomorphism, then so is `f`. -/
-lemma isIso_of_lift_isIso {p : 𝒳 ⥤ 𝒮} {R S : 𝒮} {a b : 𝒳} {f : R ⟶ S} {φ : a ⟶ b}
-    [p.IsHomLift f φ] [IsIso φ] : IsIso f :=
+lemma isIso_of_lift_isIso {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ]
+    [IsIso φ] : IsIso f :=
   (fac p f φ) ▸ inferInstance
 
 /-- Given `φ : a ≅ b` and `f : R ≅ S`, such that `φ.hom` lifts `f.hom`, then `φ.inv` lifts
 `f.inv`. -/
-protected instance inv_lift_inv (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ≅ S) (φ : a ≅ b)
+protected instance inv_lift_inv {R S : 𝒮} {a b : 𝒳} (f : R ≅ S) (φ : a ≅ b)
     [p.IsHomLift f.hom φ.hom] : p.IsHomLift f.inv φ.inv := by
   apply of_commSq
   apply CommSq.horiz_inv (f:=p.mapIso φ) (commSq p f.hom φ.hom)
 
 /-- Given `φ : a ≅ b` and `f : R ⟶ S`, such that `φ.hom` lifts `f`, then `φ.inv` lifts the
 inverse of `f` given by `isoOfIsoLift`. -/
-protected instance inv_lift (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b)
-    [p.IsHomLift f φ.hom] : p.IsHomLift (isoOfIsoLift p f φ).inv φ.inv := by
+protected instance inv_lift {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ≅ b) [p.IsHomLift f φ.hom] :
+    p.IsHomLift (isoOfIsoLift p f φ).inv φ.inv := by
   apply of_commSq
   apply CommSq.horiz_inv (f:=p.mapIso φ) (by simpa using (commSq p f φ.hom))
 
 /-- If `φ : a ⟶ b` lifts `f : R ⟶ S` and both are isomorphisms, then `φ⁻¹` lifts `f⁻¹`. -/
-protected instance inv (p : 𝒳 ⥤ 𝒮) {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [IsIso f]
-    [IsIso φ] [p.IsHomLift f φ] : p.IsHomLift (inv f) (inv φ) :=
+protected instance inv {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [IsIso f] [IsIso φ]
+    [p.IsHomLift f φ] : p.IsHomLift (inv f) (inv φ) :=
   have : p.IsHomLift (asIso f).hom (asIso φ).hom := by simp; infer_instance
   IsHomLift.inv_lift_inv p (asIso f) (asIso φ)
 
 /-- If `φ : a ⟶ b` is an isomorphism, and lifts `𝟙 S` for some `S : 𝒮`, then `φ⁻¹` also
 lifts `𝟙 S` -/
-instance lift_id_inv {p : 𝒳 ⥤ 𝒮} {S : 𝒮} {a b : 𝒳} {φ : a ⟶ b} [IsIso φ] [p.IsHomLift (𝟙 S) φ] :
+instance lift_id_inv {S : 𝒮} {a b : 𝒳} (φ : a ⟶ b) [IsIso φ] [p.IsHomLift (𝟙 S) φ] :
     p.IsHomLift (𝟙 S) (inv φ) :=
   (IsIso.inv_id (X:=S)) ▸ (IsHomLift.inv p _ φ)
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -170,13 +170,13 @@ instance lift_comp_eqToHom {R S S': 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶
 @[simp]
 lemma comp_eqToHom_lift_iff {R S : 𝒮} {a' a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : a' = a) :
     p.IsHomLift f (eqToHom h ≫ φ) ↔ p.IsHomLift f φ where
-  mp := by intro hφ'; subst h; simpa using hφ'
+  mp := fun hφ' => by subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
 @[simp]
 lemma eqToHom_comp_lift_iff {R S : 𝒮} {a b b' : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (h : b = b') :
     p.IsHomLift f (φ ≫ eqToHom h) ↔ p.IsHomLift f φ where
-  mp := by intro hφ'; subst h; simpa using hφ'
+  mp := fun hφ' => by subst h; simpa using hφ'
   mpr := fun hφ => inferInstance
 
 @[simp]


### PR DESCRIPTION
We define the notion `IsHomLift` which aims to provide API for working with equalities `p(\phi) = f` for a functor `p` and morphisms `\phi`, `f`. This API is extensively used in an upcoming PR defining the notion of fibered categories. See the repository [Stacks-project](https://github.com/Paul-Lez/Stacks-project) for WIP using this notion.

Co-authored-by: Paul Lezau <paul.lezeau@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
