### PR TITLE
[Merged by Bors] - feat: moving some adjunctions of over categories to `CategoryTheory.Adjunction.Over`

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Over.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Over.lean
@@ -97,7 +97,7 @@ instance [HasBinaryProducts C] : (forget X).IsLeftAdjoint  :=
 
 end Over
 
-@[deprecated] noncomputable alias star := Over.star
+@[deprecated (since := "2024-05-18")] noncomputable alias star := Over.star
 
 @[deprecated] noncomputable alias forgetAdjStar := Over.forgetAdjStar
 

--- a/Mathlib/CategoryTheory/Adjunction/Over.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Over.lean
@@ -99,7 +99,7 @@ end Over
 
 @[deprecated (since := "2024-05-18")] noncomputable alias star := Over.star
 
-@[deprecated] noncomputable alias forgetAdjStar := Over.forgetAdjStar
+@[deprecated (since := "2024-05-18")] noncomputable alias forgetAdjStar := Over.forgetAdjStar
 
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Adjunction/Over.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Over.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Bhavik Mehta
+Authors: Bhavik Mehta, Andrew Yang, Emily Riehl
 -/
 import Mathlib.CategoryTheory.Comma.Over
 import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
@@ -34,8 +34,6 @@ variable {C : Type u} [Category.{v} C] (X : C)
 namespace Over
 
 open Limits
-
-variable {C : Type u} [Category.{v} C]
 
 -- Porting note: removed semireducible from the simps config
 /-- Given a morphism `f : X ⟶ Y`, the functor `baseChange f` takes morphisms over `Y` to morphisms
@@ -74,29 +72,34 @@ def mapAdjunction [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ base
         · simp
         · simpa using Over.w v |>.symm } }
 
-end Over
-
 /--
 The functor from `C` to `Over X` which sends `Y : C` to `π₁ : X ⨯ Y ⟶ X`, sometimes denoted `X*`.
 -/
 @[simps! obj_left obj_hom map_left]
 def star [HasBinaryProducts C] : C ⥤ Over X :=
   cofree _ ⋙ coalgebraToOver X
-#align category_theory.star CategoryTheory.star
+#align category_theory.star CategoryTheory.Over.star
 
 /-- The functor `Over.forget X : Over X ⥤ C` has a right adjoint given by `star X`.
 
 Note that the binary products assumption is necessary: the existence of a right adjoint to
 `Over.forget X` is equivalent to the existence of each binary product `X ⨯ -`.
 -/
-def forgetAdjStar [HasBinaryProducts C] : Over.forget X ⊣ star X :=
+def forgetAdjStar [HasBinaryProducts C] : forget X ⊣ star X :=
   (coalgebraEquivOver X).symm.toAdjunction.comp (adj _)
-#align category_theory.forget_adj_star CategoryTheory.forgetAdjStar
+#align category_theory.forget_adj_star CategoryTheory.Over.forgetAdjStar
 
 /-- Note that the binary products assumption is necessary: the existence of a right adjoint to
 `Over.forget X` is equivalent to the existence of each binary product `X ⨯ -`.
 -/
-instance [HasBinaryProducts C] : (Over.forget X).IsLeftAdjoint  :=
+instance [HasBinaryProducts C] : (forget X).IsLeftAdjoint  :=
   ⟨_, ⟨forgetAdjStar X⟩⟩
+
+end Over
+
+@[deprecated] noncomputable alias star := Over.star
+
+@[deprecated] noncomputable alias forgetAdjStar := Over.forgetAdjStar
+
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Adjunction/Over.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Over.lean
@@ -38,7 +38,8 @@ open Limits
 variable {C : Type u} [Category.{v} C]
 
 -- Porting note: removed semireducible from the simps config
-/-- Given a morphism `f : X ⟶ Y`, the functor `baseChange f` takes morphisms over `Y` to morphisms over `X` via pullbacks. -/
+/-- Given a morphism `f : X ⟶ Y`, the functor `baseChange f` takes morphisms over `Y` to morphisms
+over `X` via pullbacks. -/
 @[simps! (config := { simpRhs := true}) obj_left obj_hom map_left]
 def baseChange [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over Y ⥤ Over X where
   obj g := Over.mk (pullback.snd : pullback g.hom f ⟶ _)

--- a/Mathlib/CategoryTheory/Adjunction/Over.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Over.lean
@@ -5,6 +5,7 @@ Authors: Bhavik Mehta
 -/
 import Mathlib.CategoryTheory.Comma.Over
 import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
+import Mathlib.CategoryTheory.Limits.Shapes.Pullbacks
 import Mathlib.CategoryTheory.Monad.Products
 
 #align_import category_theory.adjunction.over from "leanprover-community/mathlib"@"cea27692b3fdeb328a2ddba6aabf181754543184"
@@ -28,6 +29,51 @@ namespace CategoryTheory
 open Category Limits Comonad
 
 variable {C : Type u} [Category.{v} C] (X : C)
+
+
+namespace Over
+
+open Limits
+
+variable {C : Type u} [Category.{v} C]
+
+-- Porting note: removed semireducible from the simps config
+/-- Given a morphism `f : X ⟶ Y`, the functor `baseChange f` takes morphisms over `Y` to morphisms over `X` via pullbacks. -/
+@[simps! (config := { simpRhs := true}) obj_left obj_hom map_left]
+def baseChange [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over Y ⥤ Over X where
+  obj g := Over.mk (pullback.snd : pullback g.hom f ⟶ _)
+  map i := Over.homMk (pullback.map _ _ _ _ i.left (𝟙 _) (𝟙 _) (by simp) (by simp))
+  map_id Z := by
+    apply Over.OverMorphism.ext; apply pullback.hom_ext
+    · dsimp; simp
+    · dsimp; simp
+  map_comp f g := by
+    apply Over.OverMorphism.ext; apply pullback.hom_ext
+    · dsimp; simp
+    · dsimp; simp
+#align category_theory.limits.base_change CategoryTheory.Over.baseChange
+
+-- deprecated on 2024-05-15
+@[deprecated] noncomputable alias Limits.baseChange := Over.baseChange
+
+/-- The adjunction `Over.map ⊣ baseChange` -/
+@[simps! unit_app counit_app]
+def mapAdjunction [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ baseChange f :=
+  .mkOfHomEquiv <| {
+    homEquiv := fun X Y => {
+      toFun := fun u => Over.homMk (pullback.lift u.left X.hom <| by simp)
+      invFun := fun v => Over.homMk (v.left ≫ pullback.fst) <|
+        by simp [← Over.w v, pullback.condition]
+      left_inv := by aesop_cat
+      right_inv := by
+        intro v
+        ext
+        dsimp
+        ext
+        · simp
+        · simpa using Over.w v |>.symm } }
+
+end Over
 
 /--
 The functor from `C` to `Over X` which sends `Y : C` to `π₁ : X ⨯ Y ⟶ X`, sometimes denoted `X*`.

--- a/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
@@ -3,9 +3,9 @@ Copyright (c) 2022 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.CategoryTheory.Limits.Shapes.Pullbacks
 import Mathlib.CategoryTheory.Limits.Shapes.KernelPair
 import Mathlib.CategoryTheory.Limits.Shapes.CommSq
+import Mathlib.CategoryTheory.Adjunction.Over
 
 #align_import category_theory.limits.shapes.diagonal from "leanprover-community/mathlib"@"f6bab67886fb92c3e2f539cc90a83815f69a189d"
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullbacks.lean
@@ -2731,49 +2731,4 @@ instance (priority := 100) hasPushouts_of_hasWidePushouts (D : Type u) [h : Cate
 
 end Limits
 
-namespace Over
-
-open Limits
-
-variable {C : Type u} [Category.{v} C]
-
--- Porting note: removed semireducible from the simps config
-/-- Given a morphism `f : X ⟶ Y`, we can take morphisms over `Y` to morphisms over `X` via
-pullbacks. -/
-@[simps! (config := { simpRhs := true}) obj_left obj_hom map_left]
-def baseChange [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over Y ⥤ Over X where
-  obj g := Over.mk (pullback.snd : pullback g.hom f ⟶ _)
-  map i := Over.homMk (pullback.map _ _ _ _ i.left (𝟙 _) (𝟙 _) (by simp) (by simp))
-  map_id Z := by
-    apply Over.OverMorphism.ext; apply pullback.hom_ext
-    · dsimp; simp
-    · dsimp; simp
-  map_comp f g := by
-    apply Over.OverMorphism.ext; apply pullback.hom_ext
-    · dsimp; simp
-    · dsimp; simp
-#align category_theory.limits.base_change CategoryTheory.Over.baseChange
-
--- deprecated on 2024-05-15
-@[deprecated] noncomputable alias Limits.baseChange := Over.baseChange
-
-/-- The adjunction `Over.map ⊣ baseChange` -/
-@[simps! unit_app counit_app]
-def mapAdjunction [HasPullbacks C] {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ baseChange f :=
-  .mkOfHomEquiv <| {
-    homEquiv := fun X Y => {
-      toFun := fun u => Over.homMk (pullback.lift u.left X.hom <| by simp)
-      invFun := fun v => Over.homMk (v.left ≫ pullback.fst) <|
-        by simp [← Over.w v, pullback.condition]
-      left_inv := by aesop_cat
-      right_inv := by
-        intro v
-        ext
-        dsimp
-        ext
-        · simp
-        · simpa using Over.w v |>.symm  } }
-
-end Over
-
 end CategoryTheory


### PR DESCRIPTION
We move the functor `CategoryTheory.Over.baseChange` and the adjunction `CategoryTheory.Over.mapAdjunction` to `CategoryTheory.Adjunction.Over`. 

Note that we already have 
```
def forgetAdjStar [HasBinaryProducts C] : Over.forget X ⊣ star X
```
in the file `CategoryTheory.Adjunction.Over` and it would make sense to have the facts about adjunction of Over categories in one place. This change also reduces the length of the file `CategoryTheory.Limits.Shapes.Pullbacks` which is almost 3k LOC. 


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
