### PR TITLE
[Merged by Bors] - feat: All `m`, `0 < m < n` are `n`-smooth numbers

### DIFF
--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -287,15 +287,10 @@ lemma smoothNumbers_succ {N : ℕ} (hN : ¬ N.Prime) : N.succ.smoothNumbers = N.
 @[gcongr] lemma smoothNumbers_mono {N M : ℕ} (hNM : N ≤ M) : N.smoothNumbers ⊆ M.smoothNumbers :=
   fun _ hx ↦ ⟨hx.1, fun p hp => (hx.2 p hp).trans_le hNM⟩
 
-/-- All $m$, $0 < m < n$ are $n$-smooth numbers -/
-lemma mem_smoothNumbers_of_lt (m n : ℕ) (hm : 0 < m) (hmn : m < n) : m ∈ n.smoothNumbers := by
-  rw [smoothNumbers_eq_factoredNumbers]
-  constructor
-  · exact not_eq_zero_of_lt hm
-  · intro p; intro h
-    apply Nat.le_of_mem_factors at h
-    rw [Finset.mem_range]
-    exact Nat.lt_of_le_of_lt h hmn
+/-- All `m`, `0 < m < n` are `n`-smooth numbers -/
+lemma mem_smoothNumbers_of_lt {m n : ℕ} (hm : 0 < m) (hmn : m < n) : m ∈ n.smoothNumbers :=
+  smoothNumbers_eq_factoredNumbers _ ▸ ⟨not_eq_zero_of_lt hm,
+  fun _ h => Finset.mem_range.mpr <| lt_of_le_of_lt (le_of_mem_factors h) hmn⟩
 
 /-- The non-zero non-`N`-smooth numbers are `≥ N`. -/
 lemma smoothNumbers_compl (N : ℕ) : (N.smoothNumbers)ᶜ \ {0} ⊆ {n | N ≤ n} := by

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -287,6 +287,16 @@ lemma smoothNumbers_succ {N : ℕ} (hN : ¬ N.Prime) : N.succ.smoothNumbers = N.
 @[gcongr] lemma smoothNumbers_mono {N M : ℕ} (hNM : N ≤ M) : N.smoothNumbers ⊆ M.smoothNumbers :=
   fun _ hx ↦ ⟨hx.1, fun p hp => (hx.2 p hp).trans_le hNM⟩
 
+/-- All $m$, $0 < m < n$ are $n$-smooth numbers -/
+lemma mem_smoothNumbers_of_lt (m n : ℕ) (hm : 0 < m) (hmn : m < n) : m ∈ n.smoothNumbers := by
+  rw [smoothNumbers_eq_factoredNumbers]
+  constructor
+  . exact not_eq_zero_of_lt hm
+  . intro p; intro h
+    apply Nat.le_of_mem_factors at h
+    rw [Finset.mem_range]
+    exact Nat.lt_of_le_of_lt h hmn
+
 /-- The non-zero non-`N`-smooth numbers are `≥ N`. -/
 lemma smoothNumbers_compl (N : ℕ) : (N.smoothNumbers)ᶜ \ {0} ⊆ {n | N ≤ n} := by
   simpa only [smoothNumbers_eq_factoredNumbers]

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -291,8 +291,8 @@ lemma smoothNumbers_succ {N : ℕ} (hN : ¬ N.Prime) : N.succ.smoothNumbers = N.
 lemma mem_smoothNumbers_of_lt (m n : ℕ) (hm : 0 < m) (hmn : m < n) : m ∈ n.smoothNumbers := by
   rw [smoothNumbers_eq_factoredNumbers]
   constructor
-  . exact not_eq_zero_of_lt hm
-  . intro p; intro h
+  · exact not_eq_zero_of_lt hm
+  · intro p; intro h
     apply Nat.le_of_mem_factors at h
     rw [Finset.mem_range]
     exact Nat.lt_of_le_of_lt h hmn


### PR DESCRIPTION
This lemma is needed several times in a formal BOOK proof.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
