### PR TITLE
chore(CategoryTheory): better names for multiequalizers

### DIFF
--- a/Mathlib/AlgebraicGeometry/Gluing.lean
+++ b/Mathlib/AlgebraicGeometry/Gluing.lean
@@ -364,7 +364,7 @@ def fromGlued : 𝒰.gluedCover.glued ⟶ X := by
 
 @[simp, reassoc]
 theorem ι_fromGlued (x : 𝒰.J) : 𝒰.gluedCover.ι x ≫ 𝒰.fromGlued = 𝒰.map x :=
-  Multicoequalizer.π_desc _ _ _ _ _
+  Multicoequalizer.inj_desc _ _ _ _ _
 #align algebraic_geometry.Scheme.open_cover.ι_from_glued AlgebraicGeometry.Scheme.OpenCover.ι_fromGlued
 
 theorem fromGlued_injective : Function.Injective 𝒰.fromGlued.1.base := by
@@ -466,15 +466,15 @@ theorem ι_glueMorphisms {Y : Scheme} (f : ∀ x, 𝒰.obj x ⟶ Y)
     (hf : ∀ x y, (pullback.fst : pullback (𝒰.map x) (𝒰.map y) ⟶ _) ≫ f x = pullback.snd ≫ f y)
     (x : 𝒰.J) : 𝒰.map x ≫ 𝒰.glueMorphisms f hf = f x := by
   rw [← ι_fromGlued, Category.assoc]
-  erw [IsIso.hom_inv_id_assoc, Multicoequalizer.π_desc]
+  erw [IsIso.hom_inv_id_assoc, Multicoequalizer.inj_desc]
 #align algebraic_geometry.Scheme.open_cover.ι_glue_morphisms AlgebraicGeometry.Scheme.OpenCover.ι_glueMorphisms
 
 theorem hom_ext {Y : Scheme} (f₁ f₂ : X ⟶ Y) (h : ∀ x, 𝒰.map x ≫ f₁ = 𝒰.map x ≫ f₂) : f₁ = f₂ := by
   rw [← cancel_epi 𝒰.fromGlued]
   apply Multicoequalizer.hom_ext
   intro x
-  erw [Multicoequalizer.π_desc_assoc]
-  erw [Multicoequalizer.π_desc_assoc]
+  erw [Multicoequalizer.inj_desc_assoc]
+  erw [Multicoequalizer.inj_desc_assoc]
   exact h x
 #align algebraic_geometry.Scheme.open_cover.hom_ext AlgebraicGeometry.Scheme.OpenCover.hom_ext
 

--- a/Mathlib/AlgebraicGeometry/Pullbacks.lean
+++ b/Mathlib/AlgebraicGeometry/Pullbacks.lean
@@ -291,7 +291,7 @@ def p2 : (gluing 𝒰 f g).glued ⟶ Y := by
 theorem p_comm : p1 𝒰 f g ≫ f = p2 𝒰 f g ≫ g := by
   apply Multicoequalizer.hom_ext
   intro i
-  erw [Multicoequalizer.π_desc_assoc, Multicoequalizer.π_desc_assoc]
+  erw [Multicoequalizer.inj_desc_assoc, Multicoequalizer.inj_desc_assoc]
   rw [Category.assoc, pullback.condition]
 #align algebraic_geometry.Scheme.pullback.p_comm AlgebraicGeometry.Scheme.Pullback.p_comm
 
@@ -371,13 +371,13 @@ theorem gluedLift_p1 : gluedLift 𝒰 f g s ≫ p1 𝒰 f g = s.fst := by
   rw [← cancel_epi (𝒰.pullbackCover s.fst).fromGlued]
   apply Multicoequalizer.hom_ext
   intro b
-  erw [Multicoequalizer.π_desc_assoc, Multicoequalizer.π_desc_assoc]
+  erw [Multicoequalizer.inj_desc_assoc, Multicoequalizer.inj_desc_assoc]
   delta gluedLift
   simp_rw [← Category.assoc]
   rw [(𝒰.pullbackCover s.fst).ι_glueMorphisms]
   simp_rw [Category.assoc]
   -- Porting note: `Category.comp_id` is no longer necessary, don't know where `𝟙 _` has gone
-  erw [Multicoequalizer.π_desc, pullback.lift_fst_assoc, pullback.condition]
+  erw [Multicoequalizer.inj_desc, pullback.lift_fst_assoc, pullback.condition]
   rw [pullbackSymmetry_hom_comp_snd_assoc]
   rfl
 #align algebraic_geometry.Scheme.pullback.glued_lift_p1 AlgebraicGeometry.Scheme.Pullback.gluedLift_p1
@@ -386,12 +386,12 @@ theorem gluedLift_p2 : gluedLift 𝒰 f g s ≫ p2 𝒰 f g = s.snd := by
   rw [← cancel_epi (𝒰.pullbackCover s.fst).fromGlued]
   apply Multicoequalizer.hom_ext
   intro b
-  erw [Multicoequalizer.π_desc_assoc, Multicoequalizer.π_desc_assoc]
+  erw [Multicoequalizer.inj_desc_assoc, Multicoequalizer.inj_desc_assoc]
   delta gluedLift
   simp_rw [← Category.assoc]
   rw [(𝒰.pullbackCover s.fst).ι_glueMorphisms]
   simp_rw [Category.assoc]
-  erw [Multicoequalizer.π_desc, pullback.lift_snd]
+  erw [Multicoequalizer.inj_desc, pullback.lift_snd]
   rw [pullbackSymmetry_hom_comp_snd_assoc]
   rfl
 #align algebraic_geometry.Scheme.pullback.glued_lift_p2 AlgebraicGeometry.Scheme.Pullback.gluedLift_p2
@@ -405,7 +405,7 @@ def pullbackFstιToV (i j : 𝒰.J) :
     pullback (pullback.fst : pullback (p1 𝒰 f g) (𝒰.map i) ⟶ _) ((gluing 𝒰 f g).ι j) ⟶
       v 𝒰 f g j i :=
   (pullbackSymmetry _ _ ≪≫ pullbackRightPullbackFstIso (p1 𝒰 f g) (𝒰.map i) _).hom ≫
-    (pullback.congrHom (Multicoequalizer.π_desc _ _ _ _ _) rfl).hom
+    (pullback.congrHom (Multicoequalizer.inj_desc _ _ _ _ _) rfl).hom
 #align algebraic_geometry.Scheme.pullback.pullback_fst_ι_to_V AlgebraicGeometry.Scheme.Pullback.pullbackFstιToV
 
 @[simp, reassoc]
@@ -454,7 +454,7 @@ theorem lift_comp_ι (i : 𝒰.J) :
     -- Porting note: in the following two bullet points, `rfl` was not necessary
     · rw [t_fst_fst, pullback.lift_fst, pullbackFstιToV_snd]; rfl
     · rw [t_fst_snd, pullback.lift_snd, pullbackFstιToV_fst_assoc, pullback.condition_assoc]
-      erw [Multicoequalizer.π_desc]
+      erw [Multicoequalizer.inj_desc]
       rfl
   · rw [pullback.condition, ← Category.assoc]
     congr 1
@@ -471,14 +471,14 @@ def pullbackP1Iso (i : 𝒰.J) : pullback (p1 𝒰 f g) (𝒰.map i) ≅ pullbac
   · exact
       pullback.lift pullback.snd (pullback.fst ≫ p2 𝒰 f g)
         (by rw [← pullback.condition_assoc, Category.assoc, p_comm])
-  · refine' pullback.lift ((gluing 𝒰 f g).ι i) pullback.fst (by erw [Multicoequalizer.π_desc])
+  · refine' pullback.lift ((gluing 𝒰 f g).ι i) pullback.fst (by erw [Multicoequalizer.inj_desc])
   · apply pullback.hom_ext
     · simpa using lift_comp_ι 𝒰 f g i
     · simp only [Category.assoc, pullback.lift_snd, pullback.lift_fst, Category.id_comp]
   · apply pullback.hom_ext
     · simp only [Category.assoc, pullback.lift_fst, pullback.lift_snd, Category.id_comp]
     · simp only [Category.assoc, pullback.lift_snd, pullback.lift_fst_assoc, Category.id_comp]
-      erw [Multicoequalizer.π_desc]
+      erw [Multicoequalizer.inj_desc]
 #align algebraic_geometry.Scheme.pullback.pullback_p1_iso AlgebraicGeometry.Scheme.Pullback.pullbackP1Iso
 
 @[simp, reassoc]
@@ -616,7 +616,7 @@ def openCoverOfLeft (𝒰 : OpenCover X) (f : X ⟶ Z) (g : Y ⟶ Z) : OpenCover
     simp only [limit.isoLimitCone_inv_π, PullbackCone.mk_π_app_left, Category.comp_id,
       PullbackCone.mk_π_app_right, Category.assoc, pullback.lift_fst, pullback.lift_snd]
     symm
-    exact Multicoequalizer.π_desc _ _ _ _ _
+    exact Multicoequalizer.inj_desc _ _ _ _ _
 #align algebraic_geometry.Scheme.pullback.open_cover_of_left AlgebraicGeometry.Scheme.Pullback.openCoverOfLeft
 
 /-- Given an open cover `{ Yᵢ }` of `Y`, then `X ×[Z] Y` is covered by `X ×[Z] Yᵢ`. -/

--- a/Mathlib/CategoryTheory/GlueData.lean
+++ b/Mathlib/CategoryTheory/GlueData.lean
@@ -199,7 +199,7 @@ def glued : C :=
 
 /-- The map `D.U i ⟶ D.glued` for each `i`. -/
 def ι (i : D.J) : D.U i ⟶ D.glued :=
-  Multicoequalizer.π D.diagram i
+  Multicoequalizer.inj D.diagram i
 #align category_theory.glue_data.ι CategoryTheory.GlueData.ι
 
 @[elementwise (attr := simp)]

--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -251,7 +251,7 @@ variable [ConcreteCategory.{max w v} C]
 
 theorem multiequalizer_ext {I : MulticospanIndex.{w} C} [HasMultiequalizer I]
     [PreservesLimit I.multicospan (forget C)] (x y : ↑(multiequalizer I))
-    (h : ∀ t : I.L, Multiequalizer.ι I t x = Multiequalizer.ι I t y) : x = y := by
+    (h : ∀ t : I.L, Multiequalizer.proj I t x = Multiequalizer.proj I t y) : x = y := by
   apply Concrete.limit_ext
   rintro (a | b)
   · apply h
@@ -307,7 +307,7 @@ noncomputable def multiequalizerEquiv (I : MulticospanIndex.{w} C) [HasMultiequa
 @[simp]
 theorem multiequalizerEquiv_apply (I : MulticospanIndex.{w} C) [HasMultiequalizer I]
     [PreservesLimit I.multicospan (forget C)] (x : ↑(multiequalizer I)) (i : I.L) :
-    ((Concrete.multiequalizerEquiv I) x : ∀ i : I.L, I.left i) i = Multiequalizer.ι I i x :=
+    ((Concrete.multiequalizerEquiv I) x : ∀ i : I.L, I.left i) i = Multiequalizer.proj I i x :=
   rfl
 #align category_theory.limits.concrete.multiequalizer_equiv_apply CategoryTheory.Limits.Concrete.multiequalizerEquiv_apply
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -337,62 +337,63 @@ namespace Multifork
 variable {I : MulticospanIndex.{w} C} (K : Multifork I)
 
 /-- The maps from the cone point of a multifork to the objects on the left. -/
-def ι (a : I.L) : K.pt ⟶ I.left a :=
+def proj (a : I.L) : K.pt ⟶ I.left a :=
   K.π.app (WalkingMulticospan.left _)
-#align category_theory.limits.multifork.ι CategoryTheory.Limits.Multifork.ι
+#align category_theory.limits.multifork.ι CategoryTheory.Limits.Multifork.proj
 
 @[simp]
-theorem app_left_eq_ι (a) : K.π.app (WalkingMulticospan.left a) = K.ι a :=
+theorem app_left_eq_proj (a) : K.π.app (WalkingMulticospan.left a) = K.proj a :=
   rfl
-#align category_theory.limits.multifork.app_left_eq_ι CategoryTheory.Limits.Multifork.app_left_eq_ι
+#align category_theory.limits.multifork.app_left_eq_ι CategoryTheory.Limits.Multifork.app_left_eq_proj
 
 @[simp]
-theorem app_right_eq_ι_comp_fst (b) :
-    K.π.app (WalkingMulticospan.right b) = K.ι (I.fstTo b) ≫ I.fst b := by
+theorem app_right_eq_proj_comp_fst (b) :
+    K.π.app (WalkingMulticospan.right b) = K.proj (I.fstTo b) ≫ I.fst b := by
   rw [← K.w (WalkingMulticospan.Hom.fst b)]
   rfl
-#align category_theory.limits.multifork.app_right_eq_ι_comp_fst CategoryTheory.Limits.Multifork.app_right_eq_ι_comp_fst
+#align category_theory.limits.multifork.app_right_eq_ι_comp_fst CategoryTheory.Limits.Multifork.app_right_eq_proj_comp_fst
 
 @[reassoc]
-theorem app_right_eq_ι_comp_snd (b) :
-    K.π.app (WalkingMulticospan.right b) = K.ι (I.sndTo b) ≫ I.snd b := by
+theorem app_right_eq_proj_comp_snd (b) :
+    K.π.app (WalkingMulticospan.right b) = K.proj (I.sndTo b) ≫ I.snd b := by
   rw [← K.w (WalkingMulticospan.Hom.snd b)]
   rfl
-#align category_theory.limits.multifork.app_right_eq_ι_comp_snd CategoryTheory.Limits.Multifork.app_right_eq_ι_comp_snd
+#align category_theory.limits.multifork.app_right_eq_ι_comp_snd CategoryTheory.Limits.Multifork.app_right_eq_proj_comp_snd
 
 @[reassoc (attr := simp)]
-theorem hom_comp_ι (K₁ K₂ : Multifork I) (f : K₁ ⟶ K₂) (j : I.L) : f.hom ≫ K₂.ι j = K₁.ι j :=
+theorem hom_comp_ι (K₁ K₂ : Multifork I) (f : K₁ ⟶ K₂) (j : I.L) : f.hom ≫ K₂.proj j = K₁.proj j :=
   f.w _
 #align category_theory.limits.multifork.hom_comp_ι CategoryTheory.Limits.Multifork.hom_comp_ι
 
-/-- Construct a multifork using a collection `ι` of morphisms. -/
+/-- Construct a multifork using a collection `proj` of morphisms. -/
 @[simps]
-def ofι (I : MulticospanIndex.{w} C) (P : C) (ι : ∀ a, P ⟶ I.left a)
-    (w : ∀ b, ι (I.fstTo b) ≫ I.fst b = ι (I.sndTo b) ≫ I.snd b) : Multifork I where
+def ofProj (I : MulticospanIndex.{w} C) (P : C) (proj : ∀ a, P ⟶ I.left a)
+    (w : ∀ b, proj (I.fstTo b) ≫ I.fst b = proj (I.sndTo b) ≫ I.snd b) : Multifork I where
   pt := P
   π :=
     { app := fun x =>
         match x with
-        | WalkingMulticospan.left a => ι _
-        | WalkingMulticospan.right b => ι (I.fstTo b) ≫ I.fst b
+        | WalkingMulticospan.left a => proj _
+        | WalkingMulticospan.right b => proj (I.fstTo b) ≫ I.fst b
       naturality := by
         rintro (_ | _) (_ | _) (_ | _ | _) <;>
           dsimp <;>
           simp only [Category.id_comp, Category.comp_id, Functor.map_id,
             MulticospanIndex.multicospan_obj_left, MulticospanIndex.multicospan_obj_right]
         apply w }
-#align category_theory.limits.multifork.of_ι CategoryTheory.Limits.Multifork.ofι
+#align category_theory.limits.multifork.of_ι CategoryTheory.Limits.Multifork.ofProj
 
 @[reassoc (attr := simp)]
-theorem condition (b) : K.ι (I.fstTo b) ≫ I.fst b = K.ι (I.sndTo b) ≫ I.snd b := by
-  rw [← app_right_eq_ι_comp_fst, ← app_right_eq_ι_comp_snd]
+theorem condition (b) : K.proj (I.fstTo b) ≫ I.fst b = K.proj (I.sndTo b) ≫ I.snd b := by
+  rw [← app_right_eq_proj_comp_fst, ← app_right_eq_proj_comp_snd]
 #align category_theory.limits.multifork.condition CategoryTheory.Limits.Multifork.condition
 
 /-- This definition provides a convenient way to show that a multifork is a limit. -/
 @[simps]
 def IsLimit.mk (lift : ∀ E : Multifork I, E.pt ⟶ K.pt)
-    (fac : ∀ (E : Multifork I) (i : I.L), lift E ≫ K.ι i = E.ι i)
-    (uniq : ∀ (E : Multifork I) (m : E.pt ⟶ K.pt), (∀ i : I.L, m ≫ K.ι i = E.ι i) → m = lift E) :
+    (fac : ∀ (E : Multifork I) (i : I.L), lift E ≫ K.proj i = E.proj i)
+    (uniq : ∀ (E : Multifork I) (m : E.pt ⟶ K.pt),
+      (∀ i : I.L, m ≫ K.proj i = E.proj i) → m = lift E) :
     IsLimit K :=
   { lift
     fac := by
@@ -409,10 +410,34 @@ def IsLimit.mk (lift : ∀ E : Multifork I, E.pt ⟶ K.pt)
       apply hm }
 #align category_theory.limits.multifork.is_limit.mk CategoryTheory.Limits.Multifork.IsLimit.mk
 
+variable {K}
+
+lemma IsLimit.hom_ext (hK : IsLimit K) {T : C} {f g : T ⟶ K.pt}
+    (h : ∀ a, f ≫ K.proj a = g ≫ K.proj a) : f = g := by
+  apply hK.hom_ext
+  rintro (_|b)
+  · apply h
+  · dsimp
+    simp only [app_right_eq_proj_comp_fst, reassoc_of% h]
+
+/-- Constructor for morphisms to the point of a limit multifork. -/
+def IsLimit.lift (hK : IsLimit K) {T : C} (k : ∀ a, T ⟶ I.left a)
+    (hk : ∀ b, k (I.fstTo b) ≫ I.fst b = k (I.sndTo b) ≫ I.snd b) :
+    T ⟶ K.pt :=
+  hK.lift (Multifork.ofProj _ _ k hk)
+
+@[reassoc (attr := simp)]
+lemma IsLimit.fac (hK : IsLimit K) {T : C} (k : ∀ a, T ⟶ I.left a)
+    (hk : ∀ b, k (I.fstTo b) ≫ I.fst b = k (I.sndTo b) ≫ I.snd b) (a : I.L):
+    IsLimit.lift hK k hk ≫ K.proj a = k a :=
+  hK.fac _ _
+
+variable (K)
+
 variable [HasProduct I.left] [HasProduct I.right]
 
 @[reassoc (attr := simp)]
-theorem pi_condition : Pi.lift K.ι ≫ I.fstPiMap = Pi.lift K.ι ≫ I.sndPiMap := by
+theorem pi_condition : Pi.lift K.proj ≫ I.fstPiMap = Pi.lift K.proj ≫ I.sndPiMap := by
   ext
   simp
 #align category_theory.limits.multifork.pi_condition CategoryTheory.Limits.Multifork.pi_condition
@@ -424,8 +449,8 @@ noncomputable def toPiFork (K : Multifork I) : Fork I.fstPiMap I.sndPiMap where
   π :=
     { app := fun x =>
         match x with
-        | WalkingParallelPair.zero => Pi.lift K.ι
-        | WalkingParallelPair.one => Pi.lift K.ι ≫ I.fstPiMap
+        | WalkingParallelPair.zero => Pi.lift K.proj
+        | WalkingParallelPair.one => Pi.lift K.proj ≫ I.fstPiMap
       naturality := by
         rintro (_ | _) (_ | _) (_ | _ | _) <;>
           dsimp <;>
@@ -434,12 +459,12 @@ noncomputable def toPiFork (K : Multifork I) : Fork I.fstPiMap I.sndPiMap where
 #align category_theory.limits.multifork.to_pi_fork CategoryTheory.Limits.Multifork.toPiFork
 
 @[simp]
-theorem toPiFork_π_app_zero : K.toPiFork.ι = Pi.lift K.ι :=
+theorem toPiFork_π_app_zero : K.toPiFork.ι = Pi.lift K.proj :=
   rfl
 #align category_theory.limits.multifork.to_pi_fork_π_app_zero CategoryTheory.Limits.Multifork.toPiFork_π_app_zero
 
 @[simp, nolint simpNF] -- Porting note (#10675): dsimp cannot prove this
-theorem toPiFork_π_app_one : K.toPiFork.π.app WalkingParallelPair.one = Pi.lift K.ι ≫ I.fstPiMap :=
+theorem toPiFork_π_app_one : K.toPiFork.π.app WalkingParallelPair.one = Pi.lift K.proj ≫ I.fstPiMap :=
   rfl
 #align category_theory.limits.multifork.to_pi_fork_π_app_one CategoryTheory.Limits.Multifork.toPiFork_π_app_one
 
@@ -463,10 +488,10 @@ noncomputable def ofPiFork (c : Fork I.fstPiMap I.sndPiMap) : Multifork I where
 #align category_theory.limits.multifork.of_pi_fork CategoryTheory.Limits.Multifork.ofPiFork
 
 @[simp]
-theorem ofPiFork_π_app_left (c : Fork I.fstPiMap I.sndPiMap) (a) :
-    (ofPiFork I c).ι a = c.ι ≫ Pi.π _ _ :=
+theorem ofPiFork_proj (c : Fork I.fstPiMap I.sndPiMap) (a) :
+    (ofPiFork I c).proj a = c.ι ≫ Pi.π _ _ :=
   rfl
-#align category_theory.limits.multifork.of_pi_fork_π_app_left CategoryTheory.Limits.Multifork.ofPiFork_π_app_left
+#align category_theory.limits.multifork.of_pi_fork_π_app_left CategoryTheory.Limits.Multifork.ofPiFork_proj
 
 @[simp, nolint simpNF] -- Porting note (#10675): dsimp cannot prove this
 theorem ofPiFork_π_app_right (c : Fork I.fstPiMap I.sndPiMap) (a) :
@@ -532,59 +557,59 @@ namespace Multicofork
 variable {I : MultispanIndex.{w} C} (K : Multicofork I)
 
 /-- The maps to the cocone point of a multicofork from the objects on the right. -/
-def π (b : I.R) : I.right b ⟶ K.pt :=
+def inj (b : I.R) : I.right b ⟶ K.pt :=
   K.ι.app (WalkingMultispan.right _)
-#align category_theory.limits.multicofork.π CategoryTheory.Limits.Multicofork.π
+#align category_theory.limits.multicofork.π CategoryTheory.Limits.Multicofork.inj
 
 @[simp]
-theorem π_eq_app_right (b) : K.ι.app (WalkingMultispan.right _) = K.π b :=
+theorem app_right_eq_inj (b) : K.ι.app (WalkingMultispan.right _) = K.inj b :=
   rfl
-#align category_theory.limits.multicofork.π_eq_app_right CategoryTheory.Limits.Multicofork.π_eq_app_right
+#align category_theory.limits.multicofork.π_eq_app_right CategoryTheory.Limits.Multicofork.app_right_eq_inj
 
 @[simp]
-theorem fst_app_right (a) : K.ι.app (WalkingMultispan.left a) = I.fst a ≫ K.π _ := by
+theorem app_right_eq_fst_comp_inj (a) : K.ι.app (WalkingMultispan.left a) = I.fst a ≫ K.inj _ := by
   rw [← K.w (WalkingMultispan.Hom.fst a)]
   rfl
-#align category_theory.limits.multicofork.fst_app_right CategoryTheory.Limits.Multicofork.fst_app_right
+#align category_theory.limits.multicofork.fst_app_right CategoryTheory.Limits.Multicofork.app_right_eq_fst_comp_inj
 
 @[reassoc]
-theorem snd_app_right (a) : K.ι.app (WalkingMultispan.left a) = I.snd a ≫ K.π _ := by
+theorem snd_app_right (a) : K.ι.app (WalkingMultispan.left a) = I.snd a ≫ K.inj _ := by
   rw [← K.w (WalkingMultispan.Hom.snd a)]
   rfl
 #align category_theory.limits.multicofork.snd_app_right CategoryTheory.Limits.Multicofork.snd_app_right
 
 @[reassoc (attr := simp)] -- Porting note (#10756): added simp lemma
-lemma π_comp_hom (K₁ K₂ : Multicofork I) (f : K₁ ⟶ K₂) (b : I.R) : K₁.π b ≫ f.hom = K₂.π b :=
+lemma inj_comp_hom (K₁ K₂ : Multicofork I) (f : K₁ ⟶ K₂) (b : I.R) : K₁.inj b ≫ f.hom = K₂.inj b :=
   f.w _
 
-/-- Construct a multicofork using a collection `π` of morphisms. -/
+/-- Construct a multicofork using a collection `inj` of morphisms. -/
 @[simps]
-def ofπ (I : MultispanIndex.{w} C) (P : C) (π : ∀ b, I.right b ⟶ P)
-    (w : ∀ a, I.fst a ≫ π (I.fstFrom a) = I.snd a ≫ π (I.sndFrom a)) : Multicofork I where
+def ofInj (I : MultispanIndex.{w} C) (P : C) (inj : ∀ b, I.right b ⟶ P)
+    (w : ∀ a, I.fst a ≫ inj (I.fstFrom a) = I.snd a ≫ inj (I.sndFrom a)) : Multicofork I where
   pt := P
   ι :=
     { app := fun x =>
         match x with
-        | WalkingMultispan.left a => I.fst a ≫ π _
-        | WalkingMultispan.right b => π _
+        | WalkingMultispan.left a => I.fst a ≫ inj _
+        | WalkingMultispan.right b => inj _
       naturality := by
         rintro (_ | _) (_ | _) (_ | _ | _) <;> dsimp <;>
           simp only [Functor.map_id, MultispanIndex.multispan_obj_left,
             Category.id_comp, Category.comp_id, MultispanIndex.multispan_obj_right]
         symm
         apply w }
-#align category_theory.limits.multicofork.of_π CategoryTheory.Limits.Multicofork.ofπ
+#align category_theory.limits.multicofork.of_π CategoryTheory.Limits.Multicofork.ofInj
 
 @[reassoc (attr := simp)]
-theorem condition (a) : I.fst a ≫ K.π (I.fstFrom a) = I.snd a ≫ K.π (I.sndFrom a) := by
-  rw [← K.snd_app_right, ← K.fst_app_right]
+theorem condition (a) : I.fst a ≫ K.inj (I.fstFrom a) = I.snd a ≫ K.inj (I.sndFrom a) := by
+  rw [← K.snd_app_right, ← K.app_right_eq_fst_comp_inj]
 #align category_theory.limits.multicofork.condition CategoryTheory.Limits.Multicofork.condition
 
 /-- This definition provides a convenient way to show that a multicofork is a colimit. -/
 @[simps]
 def IsColimit.mk (desc : ∀ E : Multicofork I, K.pt ⟶ E.pt)
-    (fac : ∀ (E : Multicofork I) (i : I.R), K.π i ≫ desc E = E.π i)
-    (uniq : ∀ (E : Multicofork I) (m : K.pt ⟶ E.pt), (∀ i : I.R, K.π i ≫ m = E.π i) → m = desc E) :
+    (fac : ∀ (E : Multicofork I) (i : I.R), K.inj i ≫ desc E = E.inj i)
+    (uniq : ∀ (E : Multicofork I) (m : K.pt ⟶ E.pt), (∀ i : I.R, K.inj i ≫ m = E.inj i) → m = desc E) :
     IsColimit K :=
   { desc
     fac := by
@@ -601,10 +626,34 @@ def IsColimit.mk (desc : ∀ E : Multicofork I, K.pt ⟶ E.pt)
       apply hm }
 #align category_theory.limits.multicofork.is_colimit.mk CategoryTheory.Limits.Multicofork.IsColimit.mk
 
+variable {K}
+
+lemma IsColimit.hom_ext (hK : IsColimit K) {T : C} {f g : K.pt ⟶ T}
+    (h : ∀ a, K.inj a ≫ f = K.inj a ≫ g) : f = g := by
+  apply hK.hom_ext
+  rintro (_|_)
+  · simp [h]
+  · apply h
+
+/-- Constructor for morphisms from the point of a colimit multicofork. -/
+def IsColimit.desc (hK : IsColimit K) {T : C} (k : ∀ a, I.right a ⟶ T)
+    (hk : ∀ a, I.fst a ≫ k (I.fstFrom a) = I.snd a ≫ k (I.sndFrom a)) :
+    K.pt ⟶ T :=
+  hK.desc (Multicofork.ofInj _ _ k hk)
+
+@[reassoc (attr := simp)]
+lemma IsColimit.fac (hK : IsColimit K) {T : C} (k : ∀ a, I.right a ⟶ T)
+    (hk : ∀ a, I.fst a ≫ k (I.fstFrom a) = I.snd a ≫ k (I.sndFrom a)) (a : I.R) :
+    K.inj a ≫ IsColimit.desc hK k hk = k a :=
+  hK.fac _ _
+
+variable (K)
+
 variable [HasCoproduct I.left] [HasCoproduct I.right]
 
 @[reassoc (attr := simp)]
-theorem sigma_condition : I.fstSigmaMap ≫ Sigma.desc K.π = I.sndSigmaMap ≫ Sigma.desc K.π := by
+theorem sigma_condition :
+    I.fstSigmaMap ≫ Sigma.desc K.inj = I.sndSigmaMap ≫ Sigma.desc K.inj := by
   ext
   simp
 #align category_theory.limits.multicofork.sigma_condition CategoryTheory.Limits.Multicofork.sigma_condition
@@ -616,8 +665,8 @@ noncomputable def toSigmaCofork (K : Multicofork I) : Cofork I.fstSigmaMap I.snd
   ι :=
     { app := fun x =>
         match x with
-        | WalkingParallelPair.zero => I.fstSigmaMap ≫ Sigma.desc K.π
-        | WalkingParallelPair.one => Sigma.desc K.π
+        | WalkingParallelPair.zero => I.fstSigmaMap ≫ Sigma.desc K.inj
+        | WalkingParallelPair.one => Sigma.desc K.inj
       naturality := by
         rintro (_ | _) (_ | _) (_ | _ | _) <;> dsimp <;>
           simp only [Functor.map_id, parallelPair_obj_zero,
@@ -625,7 +674,7 @@ noncomputable def toSigmaCofork (K : Multicofork I) : Cofork I.fstSigmaMap I.snd
 #align category_theory.limits.multicofork.to_sigma_cofork CategoryTheory.Limits.Multicofork.toSigmaCofork
 
 @[simp]
-theorem toSigmaCofork_π : K.toSigmaCofork.π = Sigma.desc K.π :=
+theorem toSigmaCofork_π : K.toSigmaCofork.π = Sigma.desc K.inj :=
   rfl
 #align category_theory.limits.multicofork.to_sigma_cofork_π CategoryTheory.Limits.Multicofork.toSigmaCofork_π
 
@@ -656,16 +705,11 @@ theorem ofSigmaCofork_ι_app_left (c : Cofork I.fstSigmaMap I.sndSigmaMap) (a) :
   rfl
 #align category_theory.limits.multicofork.of_sigma_cofork_ι_app_left CategoryTheory.Limits.Multicofork.ofSigmaCofork_ι_app_left
 
--- @[simp] -- Porting note: LHS simplifies to obtain the normal form below
-theorem ofSigmaCofork_ι_app_right (c : Cofork I.fstSigmaMap I.sndSigmaMap) (b) :
-    (ofSigmaCofork I c).ι.app (WalkingMultispan.right b) = (Sigma.ι I.right b : _) ≫ c.π :=
-  rfl
-#align category_theory.limits.multicofork.of_sigma_cofork_ι_app_right CategoryTheory.Limits.Multicofork.ofSigmaCofork_ι_app_right
-
 @[simp]
-theorem ofSigmaCofork_ι_app_right' (c : Cofork I.fstSigmaMap I.sndSigmaMap) (b) :
-    π (ofSigmaCofork I c) b = (Sigma.ι I.right b : _) ≫ c.π :=
+theorem ofSigmaCofork_inj (c : Cofork I.fstSigmaMap I.sndSigmaMap) (b) :
+    (ofSigmaCofork I c).inj b = (Sigma.ι I.right b : _) ≫ c.π :=
   rfl
+#align category_theory.limits.multicofork.of_sigma_cofork_ι_app_right CategoryTheory.Limits.Multicofork.ofSigmaCofork_inj
 
 end Multicofork
 
@@ -695,15 +739,7 @@ noncomputable def ofSigmaCoforkFunctor : Cofork I.fstSigmaMap I.sndSigmaMap ⥤ 
   obj := Multicofork.ofSigmaCofork I
   map {K₁ K₂} f :=
     { hom := f.hom
-      w := by --sorry --by rintro (_ | _) <;> simp
-        rintro (_ | _)
-        -- porting note; in mathlib3, `simp` worked. What seems to be happening is that
-        -- the `simp` set is not confluent, and mathlib3 found
-        -- `Multicofork.ofSigmaCofork_ι_app_left` before `Multicofork.fst_app_right`,
-        -- but mathlib4 finds `Multicofork.fst_app_right` first.
-        { simp [-Multicofork.fst_app_right] }
-        -- Porting note: similarly here, the `simp` set seems to be non-confluent
-        { simp [-Multicofork.ofSigmaCofork_pt] } }
+      w := by rintro (_ | _) <;> simp }
 
 /--
 The category of multicoforks is equivalent to the category of coforks over `∐ I.left ⇉ ∐ I.right`.
@@ -759,9 +795,9 @@ namespace Multiequalizer
 variable (I : MulticospanIndex.{w} C) [HasMultiequalizer I]
 
 /-- The canonical map from the multiequalizer to the objects on the left. -/
-abbrev ι (a : I.L) : multiequalizer I ⟶ I.left a :=
+abbrev proj (a : I.L) : multiequalizer I ⟶ I.left a :=
   limit.π _ (WalkingMulticospan.left a)
-#align category_theory.limits.multiequalizer.ι CategoryTheory.Limits.Multiequalizer.ι
+#align category_theory.limits.multiequalizer.ι CategoryTheory.Limits.Multiequalizer.proj
 
 /-- The multifork associated to the multiequalizer. -/
 abbrev multifork : Multifork I :=
@@ -769,43 +805,39 @@ abbrev multifork : Multifork I :=
 #align category_theory.limits.multiequalizer.multifork CategoryTheory.Limits.Multiequalizer.multifork
 
 @[simp]
-theorem multifork_ι (a) : (Multiequalizer.multifork I).ι a = Multiequalizer.ι I a :=
+theorem multifork_proj (a) : (Multiequalizer.multifork I).proj a = Multiequalizer.proj I a :=
   rfl
-#align category_theory.limits.multiequalizer.multifork_ι CategoryTheory.Limits.Multiequalizer.multifork_ι
+#align category_theory.limits.multiequalizer.multifork_ι CategoryTheory.Limits.Multiequalizer.multifork_proj
 
 @[simp]
 theorem multifork_π_app_left (a) :
-    (Multiequalizer.multifork I).π.app (WalkingMulticospan.left a) = Multiequalizer.ι I a :=
+    (Multiequalizer.multifork I).π.app (WalkingMulticospan.left a) = Multiequalizer.proj I a :=
   rfl
 #align category_theory.limits.multiequalizer.multifork_π_app_left CategoryTheory.Limits.Multiequalizer.multifork_π_app_left
 
 @[reassoc]
 theorem condition (b) :
-    Multiequalizer.ι I (I.fstTo b) ≫ I.fst b = Multiequalizer.ι I (I.sndTo b) ≫ I.snd b :=
+    Multiequalizer.proj I (I.fstTo b) ≫ I.fst b = Multiequalizer.proj I (I.sndTo b) ≫ I.snd b :=
   Multifork.condition _ _
 #align category_theory.limits.multiequalizer.condition CategoryTheory.Limits.Multiequalizer.condition
 
 /-- Construct a morphism to the multiequalizer from its universal property. -/
 abbrev lift (W : C) (k : ∀ a, W ⟶ I.left a)
     (h : ∀ b, k (I.fstTo b) ≫ I.fst b = k (I.sndTo b) ≫ I.snd b) : W ⟶ multiequalizer I :=
-  limit.lift _ (Multifork.ofι I _ k h)
+  limit.lift _ (Multifork.ofProj I _ k h)
 #align category_theory.limits.multiequalizer.lift CategoryTheory.Limits.Multiequalizer.lift
 
 @[reassoc] -- Porting note (#10618): simp can prove this, removed attribute
-theorem lift_ι (W : C) (k : ∀ a, W ⟶ I.left a)
+theorem lift_proj (W : C) (k : ∀ a, W ⟶ I.left a)
     (h : ∀ b, k (I.fstTo b) ≫ I.fst b = k (I.sndTo b) ≫ I.snd b) (a) :
-    Multiequalizer.lift I _ k h ≫ Multiequalizer.ι I a = k _ :=
+    Multiequalizer.lift I _ k h ≫ Multiequalizer.proj I a = k _ :=
   limit.lift_π _ _
-#align category_theory.limits.multiequalizer.lift_ι CategoryTheory.Limits.Multiequalizer.lift_ι
+#align category_theory.limits.multiequalizer.lift_ι CategoryTheory.Limits.Multiequalizer.lift_proj
 
 @[ext]
 theorem hom_ext {W : C} (i j : W ⟶ multiequalizer I)
-    (h : ∀ a, i ≫ Multiequalizer.ι I a = j ≫ Multiequalizer.ι I a) : i = j :=
-  limit.hom_ext
-    (by
-      rintro (a | b)
-      · apply h
-      simp_rw [← limit.w I.multicospan (WalkingMulticospan.Hom.fst b), ← Category.assoc, h])
+    (h : ∀ a, i ≫ Multiequalizer.proj I a = j ≫ Multiequalizer.proj I a) : i = j :=
+  Multifork.IsLimit.hom_ext (limit.isLimit _) h
 #align category_theory.limits.multiequalizer.hom_ext CategoryTheory.Limits.Multiequalizer.hom_ext
 
 variable [HasProduct I.left] [HasProduct I.right]
@@ -825,7 +857,7 @@ def ιPi : multiequalizer I ⟶ ∏ I.left :=
 #align category_theory.limits.multiequalizer.ι_pi CategoryTheory.Limits.Multiequalizer.ιPi
 
 @[reassoc (attr := simp)]
-theorem ιPi_π (a) : ιPi I ≫ Pi.π I.left a = ι I a := by
+theorem ιPi_π (a) : ιPi I ≫ Pi.π I.left a = proj I a := by
   rw [ιPi, Category.assoc, ← Iso.eq_inv_comp, isoEqualizer]
   simp
 #align category_theory.limits.multiequalizer.ι_pi_π CategoryTheory.Limits.Multiequalizer.ιPi_π
@@ -839,9 +871,9 @@ namespace Multicoequalizer
 variable (I : MultispanIndex.{w} C) [HasMulticoequalizer I]
 
 /-- The canonical map from the multiequalizer to the objects on the left. -/
-abbrev π (b : I.R) : I.right b ⟶ multicoequalizer I :=
+abbrev inj (b : I.R) : I.right b ⟶ multicoequalizer I :=
   colimit.ι I.multispan (WalkingMultispan.right _)
-#align category_theory.limits.multicoequalizer.π CategoryTheory.Limits.Multicoequalizer.π
+#align category_theory.limits.multicoequalizer.π CategoryTheory.Limits.Multicoequalizer.inj
 
 /-- The multicofork associated to the multicoequalizer. -/
 abbrev multicofork : Multicofork I :=
@@ -849,43 +881,43 @@ abbrev multicofork : Multicofork I :=
 #align category_theory.limits.multicoequalizer.multicofork CategoryTheory.Limits.Multicoequalizer.multicofork
 
 @[simp]
-theorem multicofork_π (b) : (Multicoequalizer.multicofork I).π b = Multicoequalizer.π I b :=
+theorem multicofork_inj (b) : (Multicoequalizer.multicofork I).inj b = Multicoequalizer.inj I b :=
   rfl
-#align category_theory.limits.multicoequalizer.multicofork_π CategoryTheory.Limits.Multicoequalizer.multicofork_π
+#align category_theory.limits.multicoequalizer.multicofork_π CategoryTheory.Limits.Multicoequalizer.multicofork_inj
 
 -- @[simp] -- Porting note: LHS simplifies to obtain the normal form below
 theorem multicofork_ι_app_right (b) :
-    (Multicoequalizer.multicofork I).ι.app (WalkingMultispan.right b) = Multicoequalizer.π I b :=
+    (Multicoequalizer.multicofork I).ι.app (WalkingMultispan.right b) = Multicoequalizer.inj I b :=
   rfl
 #align category_theory.limits.multicoequalizer.multicofork_ι_app_right CategoryTheory.Limits.Multicoequalizer.multicofork_ι_app_right
 
 @[simp]
 theorem multicofork_ι_app_right' (b) :
-    colimit.ι (MultispanIndex.multispan I) (WalkingMultispan.right b) = π I b :=
+    colimit.ι (MultispanIndex.multispan I) (WalkingMultispan.right b) = inj I b :=
   rfl
 
 @[reassoc]
 theorem condition (a) :
-    I.fst a ≫ Multicoequalizer.π I (I.fstFrom a) = I.snd a ≫ Multicoequalizer.π I (I.sndFrom a) :=
+    I.fst a ≫ Multicoequalizer.inj I (I.fstFrom a) = I.snd a ≫ Multicoequalizer.inj I (I.sndFrom a) :=
   Multicofork.condition _ _
 #align category_theory.limits.multicoequalizer.condition CategoryTheory.Limits.Multicoequalizer.condition
 
 /-- Construct a morphism from the multicoequalizer from its universal property. -/
 abbrev desc (W : C) (k : ∀ b, I.right b ⟶ W)
     (h : ∀ a, I.fst a ≫ k (I.fstFrom a) = I.snd a ≫ k (I.sndFrom a)) : multicoequalizer I ⟶ W :=
-  colimit.desc _ (Multicofork.ofπ I _ k h)
+  colimit.desc _ (Multicofork.ofInj I _ k h)
 #align category_theory.limits.multicoequalizer.desc CategoryTheory.Limits.Multicoequalizer.desc
 
 @[reassoc] -- Porting note (#10618): simp can prove this, removed attribute
-theorem π_desc (W : C) (k : ∀ b, I.right b ⟶ W)
+theorem inj_desc (W : C) (k : ∀ b, I.right b ⟶ W)
     (h : ∀ a, I.fst a ≫ k (I.fstFrom a) = I.snd a ≫ k (I.sndFrom a)) (b) :
-    Multicoequalizer.π I b ≫ Multicoequalizer.desc I _ k h = k _ :=
+    Multicoequalizer.inj I b ≫ Multicoequalizer.desc I _ k h = k _ :=
   colimit.ι_desc _ _
-#align category_theory.limits.multicoequalizer.π_desc CategoryTheory.Limits.Multicoequalizer.π_desc
+#align category_theory.limits.multicoequalizer.π_desc CategoryTheory.Limits.Multicoequalizer.inj_desc
 
 @[ext]
 theorem hom_ext {W : C} (i j : multicoequalizer I ⟶ W)
-    (h : ∀ b, Multicoequalizer.π I b ≫ i = Multicoequalizer.π I b ≫ j) : i = j :=
+    (h : ∀ b, Multicoequalizer.inj I b ≫ i = Multicoequalizer.inj I b ≫ j) : i = j :=
   colimit.hom_ext
     (by
       rintro (a | b)
@@ -914,12 +946,9 @@ def sigmaπ : ∐ I.right ⟶ multicoequalizer I :=
 #align category_theory.limits.multicoequalizer.sigma_π CategoryTheory.Limits.Multicoequalizer.sigmaπ
 
 @[reassoc (attr := simp)]
-theorem ι_sigmaπ (b) : Sigma.ι I.right b ≫ sigmaπ I = π I b := by
+theorem ι_sigmaπ (b) : Sigma.ι I.right b ≫ sigmaπ I = inj I b := by
   rw [sigmaπ, ← Category.assoc, Iso.comp_inv_eq, isoCoequalizer]
-  simp only [MultispanIndex.multicoforkEquivSigmaCofork_inverse,
-    MultispanIndex.ofSigmaCoforkFunctor_obj, colimit.isoColimitCocone_ι_hom,
-    Multicofork.ofSigmaCofork_pt, colimit.cocone_x, Multicofork.π_eq_app_right]
-  rfl
+  simp
 #align category_theory.limits.multicoequalizer.ι_sigma_π CategoryTheory.Limits.Multicoequalizer.ι_sigmaπ
 
 instance : Epi (sigmaπ I) := epi_comp _ _

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -464,7 +464,8 @@ theorem toPiFork_π_app_zero : K.toPiFork.ι = Pi.lift K.proj :=
 #align category_theory.limits.multifork.to_pi_fork_π_app_zero CategoryTheory.Limits.Multifork.toPiFork_π_app_zero
 
 @[simp, nolint simpNF] -- Porting note (#10675): dsimp cannot prove this
-theorem toPiFork_π_app_one : K.toPiFork.π.app WalkingParallelPair.one = Pi.lift K.proj ≫ I.fstPiMap :=
+theorem toPiFork_π_app_one :
+    K.toPiFork.π.app WalkingParallelPair.one = Pi.lift K.proj ≫ I.fstPiMap :=
   rfl
 #align category_theory.limits.multifork.to_pi_fork_π_app_one CategoryTheory.Limits.Multifork.toPiFork_π_app_one
 
@@ -609,7 +610,8 @@ theorem condition (a) : I.fst a ≫ K.inj (I.fstFrom a) = I.snd a ≫ K.inj (I.s
 @[simps]
 def IsColimit.mk (desc : ∀ E : Multicofork I, K.pt ⟶ E.pt)
     (fac : ∀ (E : Multicofork I) (i : I.R), K.inj i ≫ desc E = E.inj i)
-    (uniq : ∀ (E : Multicofork I) (m : K.pt ⟶ E.pt), (∀ i : I.R, K.inj i ≫ m = E.inj i) → m = desc E) :
+    (uniq : ∀ (E : Multicofork I) (m : K.pt ⟶ E.pt),
+      (∀ i : I.R, K.inj i ≫ m = E.inj i) → m = desc E) :
     IsColimit K :=
   { desc
     fac := by
@@ -898,7 +900,8 @@ theorem multicofork_ι_app_right' (b) :
 
 @[reassoc]
 theorem condition (a) :
-    I.fst a ≫ Multicoequalizer.inj I (I.fstFrom a) = I.snd a ≫ Multicoequalizer.inj I (I.sndFrom a) :=
+    I.fst a ≫ Multicoequalizer.inj I (I.fstFrom a) =
+      I.snd a ≫ Multicoequalizer.inj I (I.sndFrom a) :=
   Multicofork.condition _ _
 #align category_theory.limits.multicoequalizer.condition CategoryTheory.Limits.Multicoequalizer.condition
 

--- a/Mathlib/CategoryTheory/Sites/CompatiblePlus.lean
+++ b/Mathlib/CategoryTheory/Sites/CompatiblePlus.lean
@@ -50,21 +50,21 @@ def diagramCompIso (X : C) : J.diagram P X ⋙ F ≅ J.diagram (P ⋙ F) X :=
       apply Multiequalizer.hom_ext
       dsimp
       simp only [Functor.mapCone_π_app, Multiequalizer.multifork_π_app_left, Iso.symm_hom,
-        Multiequalizer.lift_ι, eqToHom_refl, Category.comp_id,
+        Multiequalizer.lift_proj, eqToHom_refl, Category.comp_id,
         limit.conePointUniqueUpToIso_hom_comp,
         GrothendieckTopology.Cover.multicospanComp_hom_inv_left, HasLimit.isoOfNatIso_hom_π,
         Category.assoc]
-      simp only [← F.map_comp, limit.lift_π, Multifork.ofι_π_app, implies_true])
+      simp only [← F.map_comp, limit.lift_π, Multifork.ofProj_π_app, implies_true])
 #align category_theory.grothendieck_topology.diagram_comp_iso CategoryTheory.GrothendieckTopology.diagramCompIso
 
 @[reassoc (attr := simp)]
-theorem diagramCompIso_hom_ι (X : C) (W : (J.Cover X)ᵒᵖ) (i : W.unop.Arrow) :
-    (J.diagramCompIso F P X).hom.app W ≫ Multiequalizer.ι ((unop W).index (P ⋙ F)) i =
-  F.map (Multiequalizer.ι _ _) := by
+theorem diagramCompIso_hom_proj (X : C) (W : (J.Cover X)ᵒᵖ) (i : W.unop.Arrow) :
+    (J.diagramCompIso F P X).hom.app W ≫ Multiequalizer.proj ((unop W).index (P ⋙ F)) i =
+  F.map (Multiequalizer.proj _ _) := by
   delta diagramCompIso
   dsimp
   simp
-#align category_theory.grothendieck_topology.diagram_comp_iso_hom_ι CategoryTheory.GrothendieckTopology.diagramCompIso_hom_ι
+#align category_theory.grothendieck_topology.diagram_comp_iso_hom_ι CategoryTheory.GrothendieckTopology.diagramCompIso_hom_proj
 
 variable [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
 variable [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ E]
@@ -107,8 +107,8 @@ def plusCompIso : J.plusObj P ⋙ F ≅ J.plusObj (P ⋙ F) :=
       ext
       dsimp
       simp only [Category.assoc]
-      erw [Multiequalizer.lift_ι, diagramCompIso_hom_ι, diagramCompIso_hom_ι, ← F.map_comp,
-        Multiequalizer.lift_ι])
+      erw [Multiequalizer.lift_proj, diagramCompIso_hom_proj, diagramCompIso_hom_proj,
+        ← F.map_comp, Multiequalizer.lift_proj])
 #align category_theory.grothendieck_topology.plus_comp_iso CategoryTheory.GrothendieckTopology.plusCompIso
 
 @[reassoc (attr := simp)]
@@ -120,12 +120,8 @@ theorem ι_plusCompIso_hom (X) (W) :
     Cocones.forget_map, Iso.trans_hom, NatIso.ofComponents_hom_app, Functor.mapIso_hom, ←
     Category.assoc]
   erw [(isColimitOfPreserves F (colimit.isColimit (J.diagram P (unop X)))).fac]
-  simp only [Category.assoc, HasLimit.isoOfNatIso_hom_π, Iso.symm_hom,
-    Cover.multicospanComp_hom_inv_left, eqToHom_refl, Category.comp_id,
-    limit.conePointUniqueUpToIso_hom_comp, Functor.mapCone_π_app,
-    Multiequalizer.multifork_π_app_left, Multiequalizer.lift_ι, Functor.map_comp, eq_self_iff_true,
-    Category.assoc, Iso.trans_hom, Iso.cancel_iso_hom_left, NatIso.ofComponents_hom_app,
-    colimit.cocone_ι, Category.assoc, HasColimit.isoOfNatIso_ι_hom]
+  simp only [diagram_obj, colimit.cocone_x, colimit.cocone_ι, Functor.comp_obj,
+    HasColimit.isoOfNatIso_ι_hom, NatIso.ofComponents_hom_app, Iso.trans_hom, Category.assoc]
 #align category_theory.grothendieck_topology.ι_plus_comp_iso_hom CategoryTheory.GrothendieckTopology.ι_plusCompIso_hom
 
 @[reassoc (attr := simp)]
@@ -186,9 +182,9 @@ theorem plusCompIso_whiskerRight {P Q : Cᵒᵖ ⥤ D} (η : P ⟶ Q) :
   apply Multiequalizer.hom_ext
   intro a
   dsimp
-  simp only [diagramCompIso_hom_ι_assoc, Multiequalizer.lift_ι, diagramCompIso_hom_ι,
+  simp only [diagramCompIso_hom_proj_assoc, Multiequalizer.lift_proj, diagramCompIso_hom_proj,
     Category.assoc]
-  simp only [← F.map_comp, Multiequalizer.lift_ι]
+  simp only [← F.map_comp, Multiequalizer.lift_proj]
 #align category_theory.grothendieck_topology.plus_comp_iso_whisker_right CategoryTheory.GrothendieckTopology.plusCompIso_whiskerRight
 
 /-- The isomorphism between `P⁺ ⋙ F` and `(P ⋙ F)⁺`, functorially in `P`. -/
@@ -209,8 +205,8 @@ theorem whiskerRight_toPlus_comp_plusCompIso_hom :
   congr 1
   -- See https://github.com/leanprover-community/mathlib4/issues/5229
   apply Multiequalizer.hom_ext; intro a
-  rw [Category.assoc, diagramCompIso_hom_ι, ← F.map_comp]
-  simp only [unop_op, limit.lift_π, Multifork.ofι_π_app, Functor.comp_obj, Functor.comp_map]
+  rw [Category.assoc, diagramCompIso_hom_proj, ← F.map_comp]
+  simp only [unop_op, limit.lift_π, Multifork.ofProj_π_app, Functor.comp_obj, Functor.comp_map]
 #align category_theory.grothendieck_topology.whisker_right_to_plus_comp_plus_comp_iso_hom CategoryTheory.GrothendieckTopology.whiskerRight_toPlus_comp_plusCompIso_hom
 
 @[simp]

--- a/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
@@ -122,14 +122,14 @@ noncomputable def equiv {X : C} (P : Cᵒᵖ ⥤ D) (S : J.Cover X) [HasMultiequ
 @[simp]
 theorem equiv_apply {X : C} {P : Cᵒᵖ ⥤ D} {S : J.Cover X} [HasMultiequalizer (S.index P)]
     (x : (multiequalizer (S.index P) : D)) (I : S.Arrow) :
-    equiv P S x I = Multiequalizer.ι (S.index P) I x :=
+    equiv P S x I = Multiequalizer.proj (S.index P) I x :=
   rfl
 #align category_theory.meq.equiv_apply CategoryTheory.Meq.equiv_apply
 
 @[simp]
 theorem equiv_symm_eq_apply {X : C} {P : Cᵒᵖ ⥤ D} {S : J.Cover X} [HasMultiequalizer (S.index P)]
     (x : Meq P S) (I : S.Arrow) :
-    Multiequalizer.ι (S.index P) I ((Meq.equiv P S).symm x) = x I := by
+    Multiequalizer.proj (S.index P) I ((Meq.equiv P S).symm x) = x I := by
   rw [← equiv_apply]
   simp
 #align category_theory.meq.equiv_symm_eq_apply CategoryTheory.Meq.equiv_symm_eq_apply
@@ -166,7 +166,7 @@ theorem res_mk_eq_mk_pullback {Y X : C} {P : Cᵒᵖ ⥤ D} {S : J.Cover X} (x :
   ext i
   simp only [Functor.op_obj, unop_op, pullback_obj, diagram_obj, Functor.comp_obj,
     diagramPullback_app, Meq.equiv_apply, Meq.pullback_apply]
-  erw [← comp_apply, Multiequalizer.lift_ι, Meq.equiv_symm_eq_apply]
+  erw [← comp_apply, Multiequalizer.lift_proj, Meq.equiv_symm_eq_apply]
   cases i; rfl
 #align category_theory.grothendieck_topology.plus.res_mk_eq_mk_pullback CategoryTheory.GrothendieckTopology.Plus.res_mk_eq_mk_pullback
 
@@ -181,7 +181,7 @@ theorem toPlus_mk {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : P.obj (op X))
   dsimp [diagram]
   apply Concrete.multiequalizer_ext
   intro i
-  simp only [← comp_apply, Category.assoc, Multiequalizer.lift_ι, Category.comp_id,
+  simp only [← comp_apply, Category.assoc, Multiequalizer.lift_proj, Category.comp_id,
     Meq.equiv_symm_eq_apply]
   rfl
 #align category_theory.grothendieck_topology.plus.to_plus_mk CategoryTheory.GrothendieckTopology.Plus.toPlus_mk
@@ -201,8 +201,8 @@ theorem toPlus_apply {X : C} {P : Cᵒᵖ ⥤ D} (S : J.Cover X) (x : Meq P S) (
   apply Concrete.multiequalizer_ext
   intro i
   dsimp [diagram]
-  rw [← comp_apply, ← comp_apply, ← comp_apply, Multiequalizer.lift_ι, Multiequalizer.lift_ι,
-    Multiequalizer.lift_ι]
+  rw [← comp_apply, ← comp_apply, ← comp_apply, Multiequalizer.lift_proj,
+    Multiequalizer.lift_proj, Multiequalizer.lift_proj]
   erw [Meq.equiv_symm_eq_apply]
   let RR : S.Relation :=
     ⟨_, _, _, i.f, 𝟙 _, I.f, i.f ≫ I.f, I.hf, Sieve.downward_closed _ I.hf _, by simp⟩
@@ -219,7 +219,7 @@ theorem toPlus_eq_mk {X : C} {P : Cᵒᵖ ⥤ D} (x : P.obj (op X)) :
   apply congr_arg
   apply (Meq.equiv P ⊤).injective
   ext i
-  rw [Meq.equiv_apply, Equiv.apply_symm_apply, ← comp_apply, Multiequalizer.lift_ι]
+  rw [Meq.equiv_apply, Equiv.apply_symm_apply, ← comp_apply, Multiequalizer.lift_proj]
   rfl
 #align category_theory.grothendieck_topology.plus.to_plus_eq_mk CategoryTheory.GrothendieckTopology.Plus.toPlus_eq_mk
 
@@ -241,11 +241,11 @@ theorem eq_mk_iff_exists {X : C} {P : Cᵒᵖ ⥤ D} {S T : J.Cover X} (x : Meq 
     obtain ⟨W, h1, h2, hh⟩ := Concrete.colimit_exists_of_rep_eq.{u} _ _ _ h
     use W.unop, h1.unop, h2.unop
     ext I
-    apply_fun Multiequalizer.ι (W.unop.index P) I at hh
+    apply_fun Multiequalizer.proj (W.unop.index P) I at hh
     convert hh
     all_goals
       dsimp [diagram]
-      erw [← comp_apply, Multiequalizer.lift_ι, Meq.equiv_symm_eq_apply]
+      erw [← comp_apply, Multiequalizer.lift_proj, Meq.equiv_symm_eq_apply]
       cases I; rfl
   · rintro ⟨S, h1, h2, e⟩
     apply Concrete.colimit_rep_eq_of_exists
@@ -256,7 +256,7 @@ theorem eq_mk_iff_exists {X : C} {P : Cᵒᵖ ⥤ D} {S T : J.Cover X} (x : Meq 
     convert e
     all_goals
       dsimp [diagram]
-      rw [← comp_apply, Multiequalizer.lift_ι]
+      rw [← comp_apply, Multiequalizer.lift_proj]
       erw [Meq.equiv_symm_eq_apply]
       cases i; rfl
 #align category_theory.grothendieck_topology.plus.eq_mk_iff_exists CategoryTheory.GrothendieckTopology.Plus.eq_mk_iff_exists
@@ -427,7 +427,7 @@ theorem isSheaf_of_sep (P : Cᵒᵖ ⥤ D)
     intro I
     apply_fun Meq.equiv _ _ at h
     apply_fun fun e => e I at h
-    convert h <;> erw [Meq.equiv_apply, ← comp_apply, Multiequalizer.lift_ι] <;> rfl
+    convert h <;> erw [Meq.equiv_apply, ← comp_apply, Multiequalizer.lift_proj] <;> rfl
   · rintro (x : (multiequalizer (S.index _) : D))
     obtain ⟨t, ht⟩ := exists_of_sep P hsep X S (Meq.equiv _ _ x)
     use t
@@ -436,7 +436,7 @@ theorem isSheaf_of_sep (P : Cᵒᵖ ⥤ D)
     ext i
     dsimp
     erw [← comp_apply]
-    rw [Multiequalizer.lift_ι]
+    rw [Multiequalizer.lift_proj]
     rfl
 #align category_theory.grothendieck_topology.plus.is_sheaf_of_sep CategoryTheory.GrothendieckTopology.Plus.isSheaf_of_sep
 

--- a/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -690,7 +690,7 @@ using this.
 -/
 abbrev multifork {D : Type u₁} [Category.{v₁} D] (S : J.Cover X) (P : Cᵒᵖ ⥤ D) :
     Limits.Multifork (S.index P) :=
-  Limits.Multifork.ofι _ (P.obj (Opposite.op X)) (fun I => P.map I.f.op)
+  Limits.Multifork.ofProj _ (P.obj (Opposite.op X)) (fun I => P.map I.f.op)
     (by
       intro I
       dsimp [index]

--- a/Mathlib/CategoryTheory/Sites/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Sites/LeftExact.lean
@@ -37,13 +37,13 @@ def coneCompEvaluationOfConeCompDiagramFunctorCompEvaluation {X : C} {K : Type m
     Cone (F ⋙ (evaluation _ _).obj (op i.Y)) where
   pt := E.pt
   π :=
-    { app := fun k => E.π.app k ≫ Multiequalizer.ι (W.index (F.obj k)) i
+    { app := fun k => E.π.app k ≫ Multiequalizer.proj (W.index (F.obj k)) i
       naturality := by
         intro a b f
         dsimp
         rw [Category.id_comp, Category.assoc, ← E.w f]
         dsimp [diagramNatTrans]
-        simp only [Multiequalizer.lift_ι, Category.assoc] }
+        simp only [Multiequalizer.lift_proj, Category.assoc] }
 #align category_theory.grothendieck_topology.cone_comp_evaluation_of_cone_comp_diagram_functor_comp_evaluation CategoryTheory.GrothendieckTopology.coneCompEvaluationOfConeCompDiagramFunctorCompEvaluation
 
 /-- An auxiliary definition to be used in the proof of the fact that
@@ -79,7 +79,7 @@ instance preservesLimit_diagramFunctor
           intro E k
           dsimp [diagramNatTrans]
           refine' Multiequalizer.hom_ext _ _ _ (fun a => _)
-          simp only [Multiequalizer.lift_ι, Multiequalizer.lift_ι_assoc, Category.assoc]
+          simp only [Multiequalizer.lift_proj, Multiequalizer.lift_proj_assoc, Category.assoc]
           change (_ ≫ _) ≫ _ = _
           dsimp [evaluateCombinedCones]
           erw [Category.comp_id, Category.assoc, ← NatTrans.comp_app, limit.lift_π, limit.lift_π]
@@ -88,7 +88,7 @@ instance preservesLimit_diagramFunctor
           intro E m hm
           refine' Multiequalizer.hom_ext _ _ _ (fun a => limit_obj_ext (fun j => _))
           delta liftToDiagramLimitObj
-          erw [Multiequalizer.lift_ι, Category.assoc]
+          erw [Multiequalizer.lift_proj, Category.assoc]
           change _ = (_ ≫ _) ≫ _
           dsimp [evaluateCombinedCones]
           erw [Category.comp_id, Category.assoc, ← NatTrans.comp_app, limit.lift_π, limit.lift_π]

--- a/Mathlib/CategoryTheory/Sites/Limits.lean
+++ b/Mathlib/CategoryTheory/Sites/Limits.lean
@@ -64,7 +64,7 @@ def multiforkEvaluationCone (F : K ⥤ Sheaf J D) (E : Cone (F ⋙ sheafToPreshe
   pt := S.pt
   π :=
     { app := fun k => (Presheaf.isLimitOfIsSheaf J (F.obj k).1 W (F.obj k).2).lift <|
-        Multifork.ofι _ S.pt (fun i => S.ι i ≫ (E.π.app k).app (op i.Y))
+        Multifork.ofProj _ S.pt (fun i => S.proj i ≫ (E.π.app k).app (op i.Y))
           (by
             intro i
             simp only [Category.assoc]
@@ -81,7 +81,7 @@ def multiforkEvaluationCone (F : K ⥤ Sheaf J D) (E : Cone (F ⋙ sheafToPreshe
         intro ii
         rw [Presheaf.IsSheaf.amalgamate_map, Category.assoc, ← (F.map f).val.naturality, ←
           Category.assoc, Presheaf.IsSheaf.amalgamate_map]
-        dsimp [Multifork.ofι]
+        dsimp [Multifork.ofProj]
         erw [Category.assoc, ← E.w f]
         aesop_cat }
 set_option linter.uppercaseLean3 false in
@@ -104,7 +104,7 @@ def isLimitMultiforkOfIsLimit (F : K ⥤ Sheaf J D) (E : Cone (F ⋙ sheafToPres
       intro S i
       apply (isLimitOfPreserves ((evaluation Cᵒᵖ D).obj (op i.Y)) hE).hom_ext
       intro k
-      dsimp [Multifork.ofι]
+      dsimp [Multifork.ofProj]
       erw [Category.assoc, (E.π.app k).naturality]
       dsimp
       rw [← Category.assoc]
@@ -123,8 +123,8 @@ def isLimitMultiforkOfIsLimit (F : K ⥤ Sheaf J D) (E : Cone (F ⋙ sheafToPres
       intro i
       dsimp only [multiforkEvaluationCone, Presheaf.isLimitOfIsSheaf]
       rw [(F.obj k).cond.amalgamate_map]
-      dsimp [Multifork.ofι]
-      change _ = S.ι i ≫ _
+      dsimp [Multifork.ofProj]
+      change _ = S.proj i ≫ _
       erw [← hm, Category.assoc, ← (E.π.app k).naturality, Category.assoc]
       rfl)
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/CategoryTheory/Sites/OneHypercover.lean
+++ b/Mathlib/CategoryTheory/Sites/OneHypercover.lean
@@ -130,7 +130,7 @@ def multicospanIndex (F : Cᵒᵖ ⥤ A) : MulticospanIndex A where
 /-- The multifork attached to a presheaf `F : Cᵒᵖ ⥤ A`, `S : C` and `E : PreOneHypercover S`. -/
 def multifork (F : Cᵒᵖ ⥤ A) :
     Multifork (E.multicospanIndex F) :=
-  Multifork.ofι _ (F.obj (Opposite.op S)) (fun i₀ => F.map (E.f i₀).op) (by
+  Multifork.ofProj _ (F.obj (Opposite.op S)) (fun i₀ => F.map (E.f i₀).op) (by
     rintro ⟨⟨i₁, i₂⟩, (j : E.I₁ i₁ i₂)⟩
     dsimp
     simp only [← F.map_comp, ← op_comp, E.w])
@@ -182,7 +182,7 @@ variable (c : Multifork (E.multicospanIndex F.val))
 
 /-- Auxiliary definition of `isLimitMultifork`. -/
 noncomputable def multiforkLift : c.pt ⟶ F.val.obj (Opposite.op S) :=
-  F.cond.amalgamateOfArrows _ E.mem₀ c.ι (fun W i₁ i₂ p₁ p₂ w => by
+  F.cond.amalgamateOfArrows _ E.mem₀ c.proj (fun W i₁ i₂ p₁ p₂ w => by
     apply F.cond.hom_ext ⟨_, E.mem₁ _ _ _ _ w⟩
     rintro ⟨T, g, j, h, fac₁, fac₂⟩
     dsimp
@@ -191,7 +191,7 @@ noncomputable def multiforkLift : c.pt ⟶ F.val.obj (Opposite.op S) :=
     simpa using c.condition ⟨⟨i₁, i₂⟩, j⟩ =≫ F.val.map h.op)
 
 @[reassoc]
-lemma multiforkLift_map (i₀ : E.I₀) : multiforkLift c ≫ F.val.map (E.f i₀).op = c.ι i₀ := by
+lemma multiforkLift_map (i₀ : E.I₀) : multiforkLift c ≫ F.val.map (E.f i₀).op = c.proj i₀ := by
   simp [multiforkLift]
 
 end

--- a/Mathlib/CategoryTheory/Sites/Plus.lean
+++ b/Mathlib/CategoryTheory/Sites/Plus.lean
@@ -42,7 +42,7 @@ variable (P : Cᵒᵖ ⥤ D)
 def diagram (X : C) : (J.Cover X)ᵒᵖ ⥤ D where
   obj S := multiequalizer (S.unop.index P)
   map {S _} f :=
-    Multiequalizer.lift _ _ (fun I => Multiequalizer.ι (S.unop.index P) (I.map f.unop)) fun I =>
+    Multiequalizer.lift _ _ (fun I => Multiequalizer.proj (S.unop.index P) (I.map f.unop)) fun I =>
       Multiequalizer.condition (S.unop.index P) (I.map f.unop)
 #align category_theory.grothendieck_topology.diagram CategoryTheory.GrothendieckTopology.diagram
 
@@ -50,7 +50,7 @@ def diagram (X : C) : (J.Cover X)ᵒᵖ ⥤ D where
 @[simps]
 def diagramPullback {X Y : C} (f : X ⟶ Y) : J.diagram P Y ⟶ (J.pullback f).op ⋙ J.diagram P X where
   app S :=
-    Multiequalizer.lift _ _ (fun I => Multiequalizer.ι (S.unop.index P) I.base) fun I =>
+    Multiequalizer.lift _ _ (fun I => Multiequalizer.proj (S.unop.index P) I.base) fun I =>
       Multiequalizer.condition (S.unop.index P) I.base
   naturality S T f := Multiequalizer.hom_ext _ _ _ (fun I => by dsimp; simp; rfl)
 #align category_theory.grothendieck_topology.diagram_pullback CategoryTheory.GrothendieckTopology.diagramPullback
@@ -60,7 +60,7 @@ between diagrams whose colimits define the values of `plus`. -/
 @[simps]
 def diagramNatTrans {P Q : Cᵒᵖ ⥤ D} (η : P ⟶ Q) (X : C) : J.diagram P X ⟶ J.diagram Q X where
   app W :=
-    Multiequalizer.lift _ _ (fun i => Multiequalizer.ι _ _ ≫ η.app _) (fun i => by
+    Multiequalizer.lift _ _ (fun i => Multiequalizer.proj _ _ ≫ η.app _) (fun i => by
       dsimp only
       erw [Category.assoc, Category.assoc, ← η.naturality, ← η.naturality,
         Multiequalizer.condition_assoc]
@@ -73,7 +73,7 @@ theorem diagramNatTrans_id (X : C) (P : Cᵒᵖ ⥤ D) :
   ext : 2
   refine' Multiequalizer.hom_ext _ _ _ (fun i => _)
   dsimp
-  simp only [limit.lift_π, Multifork.ofι_pt, Multifork.ofι_π_app, Category.id_comp]
+  simp only [limit.lift_π, Multifork.ofProj_pt, Multifork.ofProj_π_app, Category.id_comp]
   erw [Category.comp_id]
 #align category_theory.grothendieck_topology.diagram_nat_trans_id CategoryTheory.GrothendieckTopology.diagramNatTrans_id
 
@@ -81,9 +81,7 @@ theorem diagramNatTrans_id (X : C) (P : Cᵒᵖ ⥤ D) :
 theorem diagramNatTrans_zero [Preadditive D] (X : C) (P Q : Cᵒᵖ ⥤ D) :
     J.diagramNatTrans (0 : P ⟶ Q) X = 0 := by
   ext : 2
-  refine' Multiequalizer.hom_ext _ _ _ (fun i => _)
-  dsimp
-  rw [zero_comp, Multiequalizer.lift_ι, comp_zero]
+  exact Multiequalizer.hom_ext _ _ _ (by simp)
 #align category_theory.grothendieck_topology.diagram_nat_trans_zero CategoryTheory.GrothendieckTopology.diagramNatTrans_zero
 
 @[simp]
@@ -123,7 +121,7 @@ def plusObj : Cᵒᵖ ⥤ D where
     convert Category.id_comp (colimit.ι (diagram J P (unop X)) S)
     refine' Multiequalizer.hom_ext _ _ _ (fun I => _)
     dsimp
-    simp only [Multiequalizer.lift_ι, Category.id_comp, Category.assoc]
+    simp only [Multiequalizer.lift_proj, Category.id_comp, Category.assoc]
     dsimp [Cover.Arrow.map, Cover.Arrow.base]
     cases I
     congr
@@ -140,7 +138,7 @@ def plusObj : Cᵒᵖ ⥤ D where
     congr 1
     refine' Multiequalizer.hom_ext _ _ _ (fun I => _)
     dsimp
-    simp only [Multiequalizer.lift_ι, Category.assoc]
+    simp only [Multiequalizer.lift_proj, Category.assoc]
     cases I
     dsimp only [Cover.Arrow.base, Cover.Arrow.map]
     congr 2
@@ -211,7 +209,7 @@ def toPlus : P ⟶ J.plusObj P where
     rw [← colimit.w _ e.op, ← Category.assoc, ← Category.assoc, ← Category.assoc]
     congr 1
     refine' Multiequalizer.hom_ext _ _ _ (fun I => _)
-    simp only [Multiequalizer.lift_ι, Category.assoc]
+    simp only [Multiequalizer.lift_proj, Category.assoc]
     dsimp [Cover.Arrow.base]
     simp
 #align category_theory.grothendieck_topology.to_plus CategoryTheory.GrothendieckTopology.toPlus
@@ -248,9 +246,9 @@ theorem plusMap_toPlus : J.plusMap (J.toPlus P) = J.toPlus (J.plusObj P) := by
   rw [ι_colimMap, ← colimit.w _ e.op, ← Category.assoc, ← Category.assoc]
   congr 1
   refine' Multiequalizer.hom_ext _ _ _ (fun I => _)
-  erw [Multiequalizer.lift_ι]
+  erw [Multiequalizer.lift_proj]
   simp only [unop_op, op_unop, diagram_map, Category.assoc, limit.lift_π,
-    Multifork.ofι_π_app]
+    Multifork.ofProj_π_app]
   let ee : (J.pullback (I.map e).f).obj S.unop ⟶ ⊤ := homOfLE (OrderTop.le_top _)
   erw [← colimit.w _ ee.op, ι_colimMap_assoc, colimit.ι_pre, diagramPullback_app,
     ← Category.assoc, ← Category.assoc]
@@ -261,10 +259,10 @@ theorem plusMap_toPlus : J.plusMap (J.toPlus P) = J.toPlus (J.plusObj P) := by
         Sieve.downward_closed _ I.hf _, by simp⟩) using 1
   · dsimp [diagram]
     cases I
-    simp only [Category.assoc, limit.lift_π, Multifork.ofι_pt, Multifork.ofι_π_app,
+    simp only [Category.assoc, limit.lift_π, Multifork.ofProj_pt, Multifork.ofProj_π_app,
       Cover.Arrow.map_Y, Cover.Arrow.map_f]
     rfl
-  · erw [Multiequalizer.lift_ι]
+  · erw [Multiequalizer.lift_proj]
     dsimp [Cover.index]
     simp only [Functor.map_id, Category.comp_id]
     rfl

--- a/Mathlib/CategoryTheory/Sites/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheaf.lean
@@ -531,7 +531,7 @@ section MultiequalizerConditions
 
 /-- When `P` is a sheaf and `S` is a cover, the associated multifork is a limit. -/
 def isLimitOfIsSheaf {X : C} (S : J.Cover X) (hP : IsSheaf J P) : IsLimit (S.multifork P) where
-  lift := fun E : Multifork _ => hP.amalgamate S (fun I => E.ι _) fun I => E.condition _
+  lift := fun E : Multifork _ => hP.amalgamate S (fun I => E.proj _) fun I => E.condition _
   fac := by
     rintro (E : Multifork _) (a | b)
     · apply hP.amalgamate_map
@@ -554,7 +554,8 @@ theorem isSheaf_iff_multifork :
   intro h E X S hS x hx
   let T : J.Cover X := ⟨S, hS⟩
   obtain ⟨hh⟩ := h _ T
-  let K : Multifork (T.index P) := Multifork.ofι _ E (fun I => x I.f I.hf) fun I => hx _ _ _ _ I.w
+  let K : Multifork (T.index P) := Multifork.ofProj _ E (fun I => x I.f I.hf)
+    fun I => hx _ _ _ _ I.w
   use hh.lift K
   dsimp; constructor
   · intro Y f hf

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
@@ -423,7 +423,7 @@ theorem ιInvApp_π {i : D.J} (U : Opens (D.U i).carrier) :
     refine ⟨fun h => ⟨_, h, rfl⟩, ?_⟩
     rintro ⟨y, h1, h2⟩
     convert h1 using 1
-    delta ι Multicoequalizer.π at h2
+    delta ι Multicoequalizer.inj at h2
     apply_fun (D.ι _).base
     · exact h2.symm
     · have := D.ι_gluedIso_inv (PresheafedSpace.forget _) i

--- a/Mathlib/Topology/Gluing.lean
+++ b/Mathlib/Topology/Gluing.lean
@@ -470,7 +470,7 @@ set_option linter.uppercaseLean3 false in
 @[simp, elementwise nosimp]
 theorem ι_fromOpenSubsetsGlue (i : J) :
     (ofOpenSubsets U).toGlueData.ι i ≫ fromOpenSubsetsGlue U = Opens.inclusion _ :=
-  Multicoequalizer.π_desc _ _ _ _ _
+  Multicoequalizer.inj_desc _ _ _ _ _
 set_option linter.uppercaseLean3 false in
 #align Top.glue_data.ι_from_open_subsets_glue TopCat.GlueData.ι_fromOpenSubsetsGlue
 


### PR DESCRIPTION
This PR renames the confusing `Multiequalizer.ι` as `Multiequalizer.proj`, etc. Lemmas and definitions `IsLimit.hom_ext`, `IsLimit.lift` and `IsLimit.fac` have also been added for multiequalizer shapes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
