### PR TITLE
[Merged by Bors] - chore: `refine'` => `refine`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Basic.lean
@@ -973,7 +973,7 @@ theorem prod_filter (p : α → Prop) [DecidablePred p] (f : α → β) :
     ∏ a ∈ s.filter p, f a = ∏ a ∈ s.filter p, if p a then f a else 1 :=
       prod_congr rfl fun a h => by rw [if_pos]; simpa using (mem_filter.1 h).2
     _ = ∏ a ∈ s, if p a then f a else 1 := by
-      { refine' prod_subset (filter_subset _ s) fun x hs h => _
+      { refine prod_subset (filter_subset _ s) fun x hs h => ?_
         rw [mem_filter, not_and] at h
         exact if_neg (by simpa using h hs) }
 #align finset.prod_filter Finset.prod_filter

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -251,13 +251,13 @@ theorem equiv_directSum_of_isTorsion [h' : Module.Finite R N] (hN : Module.IsTor
       torsion_by_prime_power_decomposition.{u, v} (hp i)
         ((isTorsion'_powers_iff <| p i).mpr fun x => ⟨e i, smul_torsionBy _ _⟩)
   classical
-  refine'
+  refine
     ⟨Σ i, Fin (this i).choose, inferInstance, fun ⟨i, _⟩ => p i, fun ⟨i, _⟩ => hp i, fun ⟨i, j⟩ =>
       (this i).choose_spec.choose j,
       ⟨(LinearEquiv.ofBijective (DirectSum.coeLinearMap _) h).symm.trans <|
           (DFinsupp.mapRange.linearEquiv fun i => (this i).choose_spec.choose_spec.some).trans <|
             (DirectSum.sigmaLcurryEquiv R).symm.trans
-              (DFinsupp.mapRange.linearEquiv fun i => quotEquivOfEq _ _ _)⟩⟩
+              (DFinsupp.mapRange.linearEquiv fun i => quotEquivOfEq _ _ ?_)⟩⟩
   cases' i with i j
   simp only
 #align module.equiv_direct_sum_of_is_torsion Module.equiv_directSum_of_isTorsion
@@ -275,9 +275,9 @@ theorem equiv_free_prod_directSum [h' : Module.Finite R N] :
   obtain ⟨n, ⟨g⟩⟩ := @Module.basisOfFiniteTypeTorsionFree' R _ _ _ (N ⧸ torsion R N) _ _ _ _
   haveI : Module.Projective R (N ⧸ torsion R N) := Module.Projective.of_basis ⟨g⟩
   obtain ⟨f, hf⟩ := Module.projective_lifting_property _ LinearMap.id (torsion R N).mkQ_surjective
-  refine'
+  refine
     ⟨n, I, fI, p, hp, e,
-      ⟨(lequivProdOfRightSplitExact (torsion R N).injective_subtype _ hf).symm.trans <|
+      ⟨(lequivProdOfRightSplitExact (torsion R N).injective_subtype ?_ hf).symm.trans <|
           (h.prod g).trans <| LinearEquiv.prodComm.{u, u} R _ (Fin n →₀ R) ⟩⟩
   rw [range_subtype, ker_mkQ]
 #align module.equiv_free_prod_direct_sum Module.equiv_free_prod_directSum

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -182,7 +182,7 @@ def Scheme.affineOpens (X : Scheme) : Set (Opens X) :=
 
 theorem rangeIsAffineOpenOfOpenImmersion {X Y : Scheme} [IsAffine X] (f : X ⟶ Y)
     [H : IsOpenImmersion f] : IsAffineOpen (Scheme.Hom.opensRange f) := by
-  refine' isAffineOfIso (IsOpenImmersion.isoOfRangeEq f (Y.ofRestrict _) _).inv
+  refine isAffineOfIso (IsOpenImmersion.isoOfRangeEq f (Y.ofRestrict _) ?_).inv
   exact Subtype.range_val.symm
 #align algebraic_geometry.range_is_affine_open_of_open_immersion AlgebraicGeometry.rangeIsAffineOpenOfOpenImmersion
 
@@ -299,8 +299,8 @@ theorem imageIsOpenImmersion (f : X ⟶ Y) [H : IsOpenImmersion f] :
 theorem _root_.AlgebraicGeometry.Scheme.Hom.isAffineOpen_iff_of_isOpenImmersion
     (f : AlgebraicGeometry.Scheme.Hom X Y) [H : IsOpenImmersion f] {U : Opens X} :
     IsAffineOpen (f.opensFunctor.obj U) ↔ IsAffineOpen U := by
-  refine' ⟨fun hU => @isAffineOfIso _ _
-    (IsOpenImmersion.isoOfRangeEq (X.ofRestrict U.openEmbedding ≫ f) (Y.ofRestrict _) _).hom ?_ hU,
+  refine ⟨fun hU => @isAffineOfIso _ _
+    (IsOpenImmersion.isoOfRangeEq (X.ofRestrict U.openEmbedding ≫ f) (Y.ofRestrict _) ?_).hom ?_ hU,
     fun hU => hU.imageIsOpenImmersion f⟩
   · rw [Scheme.comp_val_base, coe_comp, Set.range_comp]
     dsimp [Opens.coe_inclusion, Scheme.restrict]

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -294,7 +294,7 @@ theorem AffineTargetMorphismProperty.isLocalOfOpenCoverImply (P : AffineTargetMo
     haveI : IsAffine _ := (topIsAffineOpen Y).basicOpenIsAffine r
     delta morphismRestrict
     rw [affine_cancel_left_isIso hP]
-    refine' @H _ _ f ⟨Scheme.openCoverOfIsIso (𝟙 Y), _, _⟩ _ (Y.ofRestrict _) _ _
+    refine @H _ _ f ⟨Scheme.openCoverOfIsIso (𝟙 Y), ?_, ?_⟩ _ (Y.ofRestrict _) _ _
     · intro i; dsimp; infer_instance
     · intro i; dsimp
       rwa [← Category.comp_id pullback.snd, ← pullback.condition, affine_cancel_left_isIso hP]

--- a/Mathlib/CategoryTheory/Monoidal/Bimod.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimod.lean
@@ -248,7 +248,7 @@ set_option linter.uppercaseLean3 false in
 #align Bimod.tensor_Bimod.id_tensor_π_act_left Bimod.TensorBimod.whiskerLeft_π_actLeft
 
 theorem one_act_left' : (R.one ▷ _) ≫ actLeft P Q = (λ_ _).hom := by
-  refine' (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 ?_
   dsimp [X]
   -- Porting note: had to replace `rw` by `erw`
   slice_lhs 1 2 => erw [whisker_exchange]
@@ -262,7 +262,7 @@ set_option linter.uppercaseLean3 false in
 
 theorem left_assoc' :
     (R.mul ▷ _) ≫ actLeft P Q = (α_ R.X R.X _).hom ≫ (R.X ◁ actLeft P Q) ≫ actLeft P Q := by
-  refine' (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 ?_
   dsimp [X]
   slice_lhs 1 2 => rw [whisker_exchange]
   slice_lhs 2 3 => rw [whiskerLeft_π_actLeft]
@@ -315,7 +315,7 @@ set_option linter.uppercaseLean3 false in
 #align Bimod.tensor_Bimod.π_tensor_id_act_right Bimod.TensorBimod.π_tensor_id_actRight
 
 theorem actRight_one' : (_ ◁ T.one) ≫ actRight P Q = (ρ_ _).hom := by
-  refine' (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 ?_
   dsimp [X]
   -- Porting note: had to replace `rw` by `erw`
   slice_lhs 1 2 =>erw [← whisker_exchange]
@@ -329,7 +329,7 @@ set_option linter.uppercaseLean3 false in
 theorem right_assoc' :
     (_ ◁ T.mul) ≫ actRight P Q =
       (α_ _ T.X T.X).inv ≫ (actRight P Q ▷ T.X) ≫ actRight P Q := by
-  refine' (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 ?_
   dsimp [X]
   -- Porting note: had to replace some `rw` by `erw`
   slice_lhs 1 2 => rw [← whisker_exchange]
@@ -355,7 +355,7 @@ variable [∀ X : C, PreservesColimitsOfSize.{0, 0} (tensorRight X)]
 theorem middle_assoc' :
     (actLeft P Q ▷ T.X) ≫ actRight P Q =
       (α_ R.X _ T.X).hom ≫ (R.X ◁ actRight P Q) ≫ actLeft P Q := by
-  refine' (cancel_epi ((tensorLeft _ ⋙ tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorLeft _ ⋙ tensorRight _).map (coequalizer.π _ _))).1 ?_
   dsimp [X]
   slice_lhs 1 2 => rw [← comp_whiskerRight, whiskerLeft_π_actLeft, comp_whiskerRight,
     comp_whiskerRight]
@@ -409,7 +409,7 @@ noncomputable def whiskerLeft {X Y Z : Mon_ C} (M : Bimod X Y) {N₁ N₂ : Bimo
           slice_lhs 1 2 => rw [← MonoidalCategory.whiskerLeft_comp, Hom.left_act_hom]
           simp))
   left_act_hom := by
-    refine' (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 _
+    refine (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 ?_
     dsimp
     slice_lhs 1 2 => rw [TensorBimod.whiskerLeft_π_actLeft]
     slice_lhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]
@@ -420,7 +420,7 @@ noncomputable def whiskerLeft {X Y Z : Mon_ C} (M : Bimod X Y) {N₁ N₂ : Bimo
     slice_rhs 2 3 => rw [whisker_exchange]
     simp
   right_act_hom := by
-    refine' (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 _
+    refine (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 ?_
     dsimp
     slice_lhs 1 2 => rw [TensorBimod.π_tensor_id_actRight]
     slice_lhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]
@@ -442,7 +442,7 @@ noncomputable def whiskerRight {X Y Z : Mon_ C} {M₁ M₂ : Bimod X Y} (f : M�
           slice_lhs 2 3 => rw [whisker_exchange]
           simp))
   left_act_hom := by
-    refine' (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 _
+    refine (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 ?_
     dsimp
     slice_lhs 1 2 => rw [TensorBimod.whiskerLeft_π_actLeft]
     slice_lhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]
@@ -453,7 +453,7 @@ noncomputable def whiskerRight {X Y Z : Mon_ C} {M₁ M₂ : Bimod X Y} (f : M�
     slice_rhs 1 2 => rw [associator_inv_naturality_middle]
     simp
   right_act_hom := by
-    refine' (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 _
+    refine (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 ?_
     dsimp
     slice_lhs 1 2 => rw [TensorBimod.π_tensor_id_actRight]
     slice_lhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]
@@ -495,7 +495,7 @@ noncomputable def hom :
   coequalizer.desc (homAux P Q L)
     (by
       dsimp [homAux]
-      refine' (cancel_epi ((tensorRight _ ⋙ tensorRight _).map (coequalizer.π _ _))).1 _
+      refine (cancel_epi ((tensorRight _ ⋙ tensorRight _).map (coequalizer.π _ _))).1 ?_
       dsimp [TensorBimod.X]
       slice_lhs 1 2 => rw [← comp_whiskerRight, TensorBimod.π_tensor_id_actRight,
         comp_whiskerRight, comp_whiskerRight]
@@ -515,13 +515,13 @@ theorem hom_left_act_hom' :
     ((P.tensorBimod Q).tensorBimod L).actLeft ≫ hom P Q L =
       (R.X ◁ hom P Q L) ≫ (P.tensorBimod (Q.tensorBimod L)).actLeft := by
   dsimp; dsimp [hom, homAux]
-  refine' (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 ?_
   rw [tensorLeft_map]
   slice_lhs 1 2 => rw [TensorBimod.whiskerLeft_π_actLeft]
   slice_lhs 3 4 => rw [coequalizer.π_desc]
   slice_rhs 1 2 => rw [← MonoidalCategory.whiskerLeft_comp, coequalizer.π_desc,
     MonoidalCategory.whiskerLeft_comp]
-  refine' (cancel_epi ((tensorRight _ ⋙ tensorLeft _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _ ⋙ tensorLeft _).map (coequalizer.π _ _))).1 ?_
   dsimp; dsimp [TensorBimod.X]
   slice_lhs 1 2 => rw [associator_inv_naturality_middle]
   slice_lhs 2 3 =>
@@ -544,12 +544,12 @@ theorem hom_right_act_hom' :
     ((P.tensorBimod Q).tensorBimod L).actRight ≫ hom P Q L =
       (hom P Q L ▷ U.X) ≫ (P.tensorBimod (Q.tensorBimod L)).actRight := by
   dsimp; dsimp [hom, homAux]
-  refine' (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 ?_
   rw [tensorRight_map]
   slice_lhs 1 2 => rw [TensorBimod.π_tensor_id_actRight]
   slice_lhs 3 4 => rw [coequalizer.π_desc]
   slice_rhs 1 2 => rw [← comp_whiskerRight, coequalizer.π_desc, comp_whiskerRight]
-  refine' (cancel_epi ((tensorRight _ ⋙ tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _ ⋙ tensorRight _).map (coequalizer.π _ _))).1 ?_
   dsimp; dsimp [TensorBimod.X]
   slice_lhs 1 2 => rw [associator_naturality_left]
   slice_lhs 2 3 => rw [← whisker_exchange]
@@ -595,7 +595,7 @@ noncomputable def inv :
   coequalizer.desc (invAux P Q L)
     (by
       dsimp [invAux]
-      refine' (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 _
+      refine (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 ?_
       dsimp [TensorBimod.X]
       slice_lhs 1 2 => rw [whisker_exchange]
       slice_lhs 2 4 => rw [id_tensor_π_preserves_coequalizer_inv_desc]
@@ -616,7 +616,7 @@ theorem hom_inv_id : hom P Q L ≫ inv P Q L = 𝟙 _ := by
   dsimp [hom, homAux, inv, invAux]
   apply coequalizer.hom_ext
   slice_lhs 1 2 => rw [coequalizer.π_desc]
-  refine' (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 ?_
   rw [tensorRight_map]
   slice_lhs 1 3 => rw [π_tensor_id_preserves_coequalizer_inv_desc]
   slice_lhs 3 4 => rw [coequalizer.π_desc]
@@ -632,7 +632,7 @@ theorem inv_hom_id : inv P Q L ≫ hom P Q L = 𝟙 _ := by
   dsimp [hom, homAux, inv, invAux]
   apply coequalizer.hom_ext
   slice_lhs 1 2 => rw [coequalizer.π_desc]
-  refine' (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 ?_
   rw [tensorLeft_map]
   slice_lhs 1 3 => rw [id_tensor_π_preserves_coequalizer_inv_desc]
   slice_lhs 3 4 => rw [coequalizer.π_desc]
@@ -690,7 +690,7 @@ variable [∀ X : C, PreservesColimitsOfSize.{0, 0} (tensorRight X)]
 theorem hom_left_act_hom' :
     ((regular R).tensorBimod P).actLeft ≫ hom P = (R.X ◁ hom P) ≫ P.actLeft := by
   dsimp; dsimp [hom, TensorBimod.actLeft, regular]
-  refine' (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 ?_
   dsimp
   slice_lhs 1 4 => rw [id_tensor_π_preserves_coequalizer_inv_colimMap_desc]
   slice_lhs 2 3 => rw [left_assoc]
@@ -702,7 +702,7 @@ set_option linter.uppercaseLean3 false in
 theorem hom_right_act_hom' :
     ((regular R).tensorBimod P).actRight ≫ hom P = (hom P ▷ S.X) ≫ P.actRight := by
   dsimp; dsimp [hom, TensorBimod.actRight, regular]
-  refine' (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 ?_
   dsimp
   slice_lhs 1 4 => rw [π_tensor_id_preserves_coequalizer_inv_colimMap_desc]
   slice_rhs 1 2 => rw [← comp_whiskerRight, coequalizer.π_desc]
@@ -756,7 +756,7 @@ variable [∀ X : C, PreservesColimitsOfSize.{0, 0} (tensorRight X)]
 theorem hom_left_act_hom' :
     (P.tensorBimod (regular S)).actLeft ≫ hom P = (R.X ◁ hom P) ≫ P.actLeft := by
   dsimp; dsimp [hom, TensorBimod.actLeft, regular]
-  refine' (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 ?_
   dsimp
   slice_lhs 1 4 => rw [id_tensor_π_preserves_coequalizer_inv_colimMap_desc]
   slice_lhs 2 3 => rw [middle_assoc]
@@ -768,7 +768,7 @@ set_option linter.uppercaseLean3 false in
 theorem hom_right_act_hom' :
     (P.tensorBimod (regular S)).actRight ≫ hom P = (hom P ▷ S.X) ≫ P.actRight := by
   dsimp; dsimp [hom, TensorBimod.actRight, regular]
-  refine' (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 ?_
   dsimp
   slice_lhs 1 4 => rw [π_tensor_id_preserves_coequalizer_inv_colimMap_desc]
   slice_lhs 2 3 => rw [right_assoc]
@@ -879,7 +879,7 @@ theorem comp_whiskerLeft_bimod {W X Y Z : Mon_ C} (M : Bimod W X) (N : Bimod X Y
   dsimp [TensorBimod.X, AssociatorBimod.hom]
   slice_rhs 1 2 => rw [coequalizer.π_desc]
   dsimp [AssociatorBimod.homAux, AssociatorBimod.inv]
-  refine' (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 ?_
   rw [tensorRight_map]
   slice_rhs 1 3 => rw [π_tensor_id_preserves_coequalizer_inv_desc]
   slice_rhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]
@@ -936,7 +936,7 @@ theorem whiskerRight_comp_bimod {W X Y Z : Mon_ C} {M M' : Bimod W X} (f : M ⟶
   dsimp [TensorBimod.X, AssociatorBimod.inv]
   slice_rhs 1 2 => rw [coequalizer.π_desc]
   dsimp [AssociatorBimod.invAux, AssociatorBimod.hom]
-  refine' (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 ?_
   rw [tensorLeft_map]
   slice_rhs 1 3 => rw [id_tensor_π_preserves_coequalizer_inv_desc]
   slice_rhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]
@@ -965,7 +965,7 @@ theorem whisker_assoc_bimod {W X Y Z : Mon_ C} (M : Bimod W X) {N N' : Bimod X Y
   dsimp [AssociatorBimod.hom]
   slice_rhs 1 2 => rw [coequalizer.π_desc]
   dsimp [AssociatorBimod.homAux]
-  refine' (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 ?_
   rw [tensorRight_map]
   slice_lhs 1 2 => rw [← comp_whiskerRight, ι_colimMap, parallelPairHom_app_one]
   slice_rhs 1 3 => rw [π_tensor_id_preserves_coequalizer_inv_desc]
@@ -1013,12 +1013,12 @@ theorem pentagon_bimod {V W X Y Z : Mon_ C} (M : Bimod V W) (N : Bimod W X) (P :
   slice_lhs 2 3 => rw [coequalizer.π_desc]
   slice_rhs 1 2 => rw [coequalizer.π_desc]
   dsimp [AssociatorBimod.homAux]
-  refine' (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 ?_
   dsimp
   slice_lhs 1 2 => rw [← comp_whiskerRight, coequalizer.π_desc]
   slice_rhs 1 3 => rw [π_tensor_id_preserves_coequalizer_inv_desc]
   slice_rhs 3 4 => rw [coequalizer.π_desc]
-  refine' (cancel_epi ((tensorRight _ ⋙ tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _ ⋙ tensorRight _).map (coequalizer.π _ _))).1 ?_
   dsimp
   slice_lhs 1 2 =>
     rw [← comp_whiskerRight, π_tensor_id_preserves_coequalizer_inv_desc, comp_whiskerRight,
@@ -1052,7 +1052,7 @@ theorem triangle_bimod {X Y Z : Mon_ C} (M : Bimod X Y) (N : Bimod Y Z) :
   dsimp [AssociatorBimod.homAux]
   slice_rhs 1 2 => rw [ι_colimMap, parallelPairHom_app_one]
   dsimp [RightUnitorBimod.hom]
-  refine' (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 _
+  refine (cancel_epi ((tensorRight _).map (coequalizer.π _ _))).1 ?_
   dsimp [regular]
   slice_lhs 1 3 => rw [π_tensor_id_preserves_coequalizer_inv_desc]
   slice_lhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]

--- a/Mathlib/LinearAlgebra/StdBasis.lean
+++ b/Mathlib/LinearAlgebra/StdBasis.lean
@@ -125,9 +125,9 @@ theorem iInf_ker_proj_le_iSup_range_stdBasis {I : Finset ι} {J : Set ι} (hu : 
 theorem iSup_range_stdBasis_eq_iInf_ker_proj {I J : Set ι} (hd : Disjoint I J)
     (hu : Set.univ ⊆ I ∪ J) (hI : Set.Finite I) :
     ⨆ i ∈ I, range (stdBasis R φ i) = ⨅ i ∈ J, ker (proj i : (∀ i, φ i) →ₗ[R] φ i) := by
-  refine' le_antisymm (iSup_range_stdBasis_le_iInf_ker_proj _ _ _ _ hd) _
+  refine le_antisymm (iSup_range_stdBasis_le_iInf_ker_proj _ _ _ _ hd) ?_
   have : Set.univ ⊆ ↑hI.toFinset ∪ J := by rwa [hI.coe_toFinset]
-  refine' le_trans (iInf_ker_proj_le_iSup_range_stdBasis R φ this) (iSup_mono fun i => _)
+  refine le_trans (iInf_ker_proj_le_iSup_range_stdBasis R φ this) (iSup_mono fun i => ?_)
   rw [Set.Finite.mem_toFinset]
 #align linear_map.supr_range_std_basis_eq_infi_ker_proj LinearMap.iSup_range_stdBasis_eq_iInf_ker_proj
 
@@ -141,9 +141,9 @@ theorem iSup_range_stdBasis [Finite ι] : ⨆ i, range (stdBasis R φ i) = ⊤ :
 
 theorem disjoint_stdBasis_stdBasis (I J : Set ι) (h : Disjoint I J) :
     Disjoint (⨆ i ∈ I, range (stdBasis R φ i)) (⨆ i ∈ J, range (stdBasis R φ i)) := by
-  refine'
+  refine
     Disjoint.mono (iSup_range_stdBasis_le_iInf_ker_proj _ _ _ _ <| disjoint_compl_right)
-      (iSup_range_stdBasis_le_iInf_ker_proj _ _ _ _ <| disjoint_compl_right) _
+      (iSup_range_stdBasis_le_iInf_ker_proj _ _ _ _ <| disjoint_compl_right) ?_
   simp only [disjoint_iff_inf_le, SetLike.le_def, mem_iInf, mem_inf, mem_ker, mem_bot, proj_apply,
     funext_iff]
   rintro b ⟨hI, hJ⟩ i

--- a/Mathlib/MeasureTheory/Constructions/Polish.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish.lean
@@ -335,7 +335,7 @@ theorem _root_.Measurable.exists_continuous {α β : Type*} [t : TopologicalSpac
   obtain ⟨t', t'T, t't, t'_polish⟩ :
       ∃ t' : TopologicalSpace α, (∀ i, t' ≤ T i) ∧ t' ≤ t ∧ @PolishSpace α t' :=
     exists_polishSpace_forall_le T Tt Tpolish
-  refine' ⟨t', t't, _, t'_polish⟩
+  refine ⟨t', t't, ?_, t'_polish⟩
   have : Continuous[t', _] (rangeFactorization f) :=
     hb.continuous_iff.2 fun s hs => t'T ⟨s, hs⟩ _ (Topen ⟨s, hs⟩)
   exact continuous_subtype_val.comp this

--- a/Mathlib/MeasureTheory/Constructions/Prod/Integral.lean
+++ b/Mathlib/MeasureTheory/Constructions/Prod/Integral.lean
@@ -85,13 +85,13 @@ theorem MeasureTheory.StronglyMeasurable.integral_prod_right [SigmaFinite ν] �
   let s' : ℕ → α → SimpleFunc β E := fun n x => (s n).comp (Prod.mk x) measurable_prod_mk_left
   let f' : ℕ → α → E := fun n => {x | Integrable (f x) ν}.indicator fun x => (s' n x).integral ν
   have hf' : ∀ n, StronglyMeasurable (f' n) := by
-    intro n; refine' StronglyMeasurable.indicator _ (measurableSet_integrable hf)
+    intro n; refine StronglyMeasurable.indicator ?_ (measurableSet_integrable hf)
     have : ∀ x, ((s' n x).range.filter fun x => x ≠ 0) ⊆ (s n).range := by
-      intro x; refine' Finset.Subset.trans (Finset.filter_subset _ _) _; intro y
+      intro x; refine Finset.Subset.trans (Finset.filter_subset _ _) ?_; intro y
       simp_rw [SimpleFunc.mem_range]; rintro ⟨z, rfl⟩; exact ⟨(x, z), rfl⟩
     simp only [SimpleFunc.integral_eq_sum_of_subset (this _)]
-    refine' Finset.stronglyMeasurable_sum _ fun x _ => _
-    refine' (Measurable.ennreal_toReal _).stronglyMeasurable.smul_const _
+    refine Finset.stronglyMeasurable_sum _ fun x _ => ?_
+    refine (Measurable.ennreal_toReal ?_).stronglyMeasurable.smul_const _
     simp only [s', SimpleFunc.coe_comp, preimage_comp]
     apply measurable_measure_prod_mk_left
     exact (s n).measurableSet_fiber x
@@ -104,14 +104,14 @@ theorem MeasureTheory.StronglyMeasurable.integral_prod_right [SigmaFinite ν] �
         simp_rw [s', SimpleFunc.coe_comp]; exact SimpleFunc.norm_approxOn_zero_le _ _ (x, y) n
       simp only [f', hfx, SimpleFunc.integral_eq_integral _ (this _), indicator_of_mem,
         mem_setOf_eq]
-      refine'
+      refine
         tendsto_integral_of_dominated_convergence (fun y => ‖f x y‖ + ‖f x y‖)
-          (fun n => (s' n x).aestronglyMeasurable) (hfx.norm.add hfx.norm) _ _
+          (fun n => (s' n x).aestronglyMeasurable) (hfx.norm.add hfx.norm) ?_ ?_
       · refine' fun n => eventually_of_forall fun y => SimpleFunc.norm_approxOn_zero_le _ _ (x, y) n
         -- Porting note: Lean 3 solved the following two subgoals on its own
         · exact hf.measurable
         · simp
-      · refine' eventually_of_forall fun y => SimpleFunc.tendsto_approxOn _ _ _
+      · refine eventually_of_forall fun y => SimpleFunc.tendsto_approxOn ?_ ?_ ?_
         -- Porting note: Lean 3 solved the following two subgoals on its own
         · exact hf.measurable.of_uncurry_left
         · simp

--- a/Mathlib/ModelTheory/Satisfiability.lean
+++ b/Mathlib/ModelTheory/Satisfiability.lean
@@ -324,13 +324,13 @@ theorem models_sentence_of_mem {φ : L.Sentence} (h : φ ∈ T) : T ⊨ᵇ φ :=
 
 theorem models_iff_not_satisfiable (φ : L.Sentence) : T ⊨ᵇ φ ↔ ¬IsSatisfiable (T ∪ {φ.not}) := by
   rw [models_sentence_iff, IsSatisfiable]
-  refine'
+  refine
     ⟨fun h1 h2 =>
       (Sentence.realize_not _).1
         (realize_sentence_of_mem (T ∪ {Formula.not φ})
           (Set.subset_union_right _ _ (Set.mem_singleton _)))
         (h1 (h2.some.subtheoryModel (Set.subset_union_left _ _))),
-      fun h M => _⟩
+      fun h M => ?_⟩
   contrapose! h
   rw [← Sentence.realize_not] at h
   refine'

--- a/Mathlib/NumberTheory/Bertrand.lean
+++ b/Mathlib/NumberTheory/Bertrand.lean
@@ -168,19 +168,19 @@ theorem centralBinom_le_of_no_bertrand_prime (n : ℕ) (n_large : 2 < n)
   rw [centralBinom_factorization_small n n_large no_prime, ← this, ←
     Finset.prod_filter_mul_prod_filter_not S (· ≤ sqrt (2 * n))]
   apply mul_le_mul'
-  · refine' (Finset.prod_le_prod' fun p _ => (_ : f p ≤ 2 * n)).trans _
+  · refine (Finset.prod_le_prod' fun p _ => (?_ : f p ≤ 2 * n)).trans ?_
     · exact pow_factorization_choose_le (mul_pos two_pos n_pos)
     have : (Finset.Icc 1 (sqrt (2 * n))).card = sqrt (2 * n) := by rw [card_Icc, Nat.add_sub_cancel]
     rw [Finset.prod_const]
-    refine' pow_le_pow_right n2_pos ((Finset.card_le_card fun x hx => _).trans this.le)
+    refine pow_le_pow_right n2_pos ((Finset.card_le_card fun x hx => ?_).trans this.le)
     obtain ⟨h1, h2⟩ := Finset.mem_filter.1 hx
     exact Finset.mem_Icc.mpr ⟨(Finset.mem_filter.1 h1).2.one_lt.le, h2⟩
-  · refine' le_trans _ (primorial_le_4_pow (2 * n / 3))
-    refine' (Finset.prod_le_prod' fun p hp => (_ : f p ≤ p)).trans _
+  · refine le_trans ?_ (primorial_le_4_pow (2 * n / 3))
+    refine (Finset.prod_le_prod' fun p hp => (?_ : f p ≤ p)).trans ?_
     · obtain ⟨h1, h2⟩ := Finset.mem_filter.1 hp
-      refine' (pow_le_pow_right (Finset.mem_filter.1 h1).2.one_lt.le _).trans (pow_one p).le
+      refine (pow_le_pow_right (Finset.mem_filter.1 h1).2.one_lt.le ?_).trans (pow_one p).le
       exact Nat.factorization_choose_le_one (sqrt_lt'.mp <| not_le.1 h2)
-    refine' Finset.prod_le_prod_of_subset_of_one_le' (Finset.filter_subset _ _) _
+    refine Finset.prod_le_prod_of_subset_of_one_le' (Finset.filter_subset _ _) ?_
     exact fun p hp _ => (Finset.mem_filter.1 hp).2.one_lt.le
 #align central_binom_le_of_no_bertrand_prime centralBinom_le_of_no_bertrand_prime
 

--- a/Mathlib/Order/Partition/Finpartition.lean
+++ b/Mathlib/Order/Partition/Finpartition.lean
@@ -631,10 +631,10 @@ def atomise (s : Finset α) (F : Finset (Finset α)) : Finpartition s :=
         obtain ⟨A, _, rfl⟩ := ht
         exact s.filter_subset _
       · rw [mem_sup]
-        refine'
+        refine
           ⟨s.filter fun i ↦ ∀ t, t ∈ F → ((t ∈ F.filter fun u ↦ a ∈ u) ↔ i ∈ t),
             mem_image_of_mem _ (mem_powerset.2 <| filter_subset _ _),
-            mem_filter.2 ⟨ha, fun t ht ↦ _⟩⟩
+            mem_filter.2 ⟨ha, fun t ht ↦ ?_⟩⟩
         rw [mem_filter]
         exact and_iff_right ht)
 #align finpartition.atomise Finpartition.atomise

--- a/Mathlib/Probability/Kernel/MeasurableIntegral.lean
+++ b/Mathlib/Probability/Kernel/MeasurableIntegral.lean
@@ -272,7 +272,7 @@ theorem StronglyMeasurable.integral_kernel_prod_right ⦃f : α → β → E⦄
   have hf' : ∀ n, StronglyMeasurable (f' n) := by
     intro n; refine' StronglyMeasurable.indicator _ (measurableSet_kernel_integrable hf)
     have : ∀ x, ((s' n x).range.filter fun x => x ≠ 0) ⊆ (s n).range := by
-      intro x; refine' Finset.Subset.trans (Finset.filter_subset _ _) _; intro y
+      intro x; refine Finset.Subset.trans (Finset.filter_subset _ _) ?_; intro y
       simp_rw [SimpleFunc.mem_range]; rintro ⟨z, rfl⟩; exact ⟨(x, z), rfl⟩
     simp only [SimpleFunc.integral_eq_sum_of_subset (this _)]
     refine' Finset.stronglyMeasurable_sum _ fun x _ => _

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -283,9 +283,9 @@ theorem order_eq_multiplicity_X {R : Type*} [Semiring R] [@DecidableRel R⟦X⟧
   · simp [hφ] at ho
   have hn : φ.order.get (order_finite_iff_ne_zero.mpr hφ) = n := by simp [ho]
   rw [← hn]
-  refine'
+  refine
     le_antisymm (le_multiplicity_of_pow_dvd <| X_pow_order_dvd (order_finite_iff_ne_zero.mpr hφ))
-      (PartENat.find_le _ _ _)
+      (PartENat.find_le _ _ ?_)
   rintro ⟨ψ, H⟩
   have := congr_arg (coeff R n) H
   rw [← (ψ.commute_X.pow_right _).eq, coeff_mul_of_lt_order, ← hn] at this

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -275,7 +275,7 @@ theorem aleph_zero : aleph 0 = ℵ₀ := by rw [aleph, add_zero, aleph'_omega]
 theorem aleph_limit {o : Ordinal} (ho : o.IsLimit) : aleph o = ⨆ a : Iio o, aleph a := by
   apply le_antisymm _ (ciSup_le' _)
   · rw [aleph, aleph'_limit (ho.add _)]
-    refine' ciSup_mono' (bddAbove_of_small _) _
+    refine ciSup_mono' (bddAbove_of_small _) ?_
     rintro ⟨i, hi⟩
     cases' lt_or_le i ω with h h
     · rcases lt_omega.1 h with ⟨n, rfl⟩

--- a/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Group.lean
@@ -270,7 +270,7 @@ theorem Multipliable.multipliable_of_eq_one_or_self (hf : Multipliable f)
           ∏ b in t.filter fun b ↦ g b = f b, f b = ∏ b in t.filter fun b ↦ g b = f b, g b :=
             Finset.prod_congr rfl fun b hb ↦ (Finset.mem_filter.1 hb).2.symm
           _ = ∏ b in t, g b := by
-           {refine' Finset.prod_subset (Finset.filter_subset _ _) _
+           {refine Finset.prod_subset (Finset.filter_subset _ _) ?_
             intro b hbt hb
             simp only [Finset.mem_filter, and_iff_right hbt] at hb
             exact (h b).resolve_right hb}

--- a/Mathlib/Topology/VectorBundle/Basic.lean
+++ b/Mathlib/Topology/VectorBundle/Basic.lean
@@ -433,7 +433,7 @@ def continuousLinearMapAt (e : Trivialization F (π F E)) [e.IsLinear R] (b : B)
     cont := by
       dsimp
       rw [e.coe_linearMapAt b]
-      refine' continuous_if_const _ (fun hb => _) fun _ => continuous_zero
+      refine continuous_if_const _ (fun hb => ?_) fun _ => continuous_zero
       exact (e.continuousOn.comp_continuous (FiberBundle.totalSpaceMk_inducing F E b).continuous
         fun x => e.mem_source.mpr hb).snd }
 #align trivialization.continuous_linear_map_at Trivialization.continuousLinearMapAt


### PR DESCRIPTION
These `refine'` calls were convincing typeclass synthesis to cache answers that contained meta-variables. In the current design, this leads to unexpected behavior. `refine` seems to behave fine in this regard. See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Subgroups.20are.20empty).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
