### PR TITLE
[Merged by Bors] - feat(Probability/Independence): add `IndepFun.neg`

### DIFF
--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -672,6 +672,14 @@ theorem IndepFun.comp {_mβ : MeasurableSpace β} {_mβ' : MeasurableSpace β'}
   kernel.IndepFun.comp hfg hφ hψ
 #align probability_theory.indep_fun.comp ProbabilityTheory.IndepFun.comp
 
+theorem IndepFun.neg_right {_mβ : MeasurableSpace β} {_mβ' : MeasurableSpace β'} [Neg β']
+    [MeasurableNeg β'] (hfg : IndepFun f g μ) :
+    IndepFun f (-g) μ := hfg.comp measurable_id measurable_neg
+
+theorem IndepFun.neg_left {_mβ : MeasurableSpace β} {_mβ' : MeasurableSpace β'} [Neg β]
+    [MeasurableNeg β] (hfg : IndepFun f g μ) :
+    IndepFun (-f) g μ := hfg.comp measurable_neg measurable_id
+
 section iIndepFun
 variable {β : ι → Type*} {m : ∀ i, MeasurableSpace (β i)} {f : ∀ i, Ω → β i}
 

--- a/Mathlib/Probability/Independence/Conditional.lean
+++ b/Mathlib/Probability/Independence/Conditional.lean
@@ -703,6 +703,14 @@ theorem CondIndepFun.comp {γ γ' : Type*} {_mβ : MeasurableSpace β} {_mβ' : 
     CondIndepFun m' hm' (φ ∘ f) (ψ ∘ g) μ :=
   kernel.IndepFun.comp hfg hφ hψ
 
+theorem CondIndepFun.neg_right {_mβ : MeasurableSpace β} {_mβ' : MeasurableSpace β'} [Neg β']
+    [MeasurableNeg β'] (hfg : CondIndepFun m' hm' f g μ)  :
+    CondIndepFun m' hm' f (-g) μ := hfg.comp measurable_id measurable_neg
+
+theorem CondIndepFun.neg_left {_mβ : MeasurableSpace β} {_mβ' : MeasurableSpace β'} [Neg β]
+    [MeasurableNeg β] (hfg : CondIndepFun m' hm' f g μ) :
+    CondIndepFun m' hm' (-f) g μ := hfg.comp measurable_neg measurable_id
+
 section iCondIndepFun
 variable {β : ι → Type*} {m : ∀ i, MeasurableSpace (β i)} {f : ∀ i, Ω → β i}
 

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -809,6 +809,14 @@ theorem IndepFun.comp {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
   · exact ⟨φ ⁻¹' A, hφ hA, Set.preimage_comp.symm⟩
   · exact ⟨ψ ⁻¹' B, hψ hB, Set.preimage_comp.symm⟩
 
+theorem IndepFun.neg_right {_mβ : MeasurableSpace β} {_mβ' : MeasurableSpace β'} [Neg β']
+    [MeasurableNeg β'] (hfg : IndepFun f g κ μ)  :
+    IndepFun f (-g) κ μ := hfg.comp measurable_id measurable_neg
+
+theorem IndepFun.neg_left {_mβ : MeasurableSpace β} {_mβ' : MeasurableSpace β'} [Neg β]
+    [MeasurableNeg β] (hfg : IndepFun f g κ μ) :
+    IndepFun (-f) g κ μ := hfg.comp measurable_neg measurable_id
+
 section iIndepFun
 variable {β : ι → Type*} {m : ∀ i, MeasurableSpace (β i)} {f : ∀ i, Ω → β i}
 


### PR DESCRIPTION
In order to enhance findability we have added:
- [x] `IndepFun.neg_right`
- [x] `IndepFun.neg_left`

Co-Authored-By: Lorenzo Luccioli <71074618+LorenzoLuccioli@users.noreply.github.com>