### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Action): category of continuous actions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3346,6 +3346,7 @@ import Mathlib.Probability.StrongLaw
 import Mathlib.Probability.Variance
 import Mathlib.RepresentationTheory.Action.Basic
 import Mathlib.RepresentationTheory.Action.Concrete
+import Mathlib.RepresentationTheory.Action.Continuous
 import Mathlib.RepresentationTheory.Action.Limits
 import Mathlib.RepresentationTheory.Action.Monoidal
 import Mathlib.RepresentationTheory.Basic

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -38,7 +38,7 @@ related work.
 -/
 
 
-universe w w' v v' u u'
+universe w w' v v' v'' u u' u''
 
 namespace CategoryTheory
 
@@ -284,6 +284,16 @@ def HasForget₂.mk' {C : Type u} {D : Type u'} [Category.{v} C] [ConcreteCatego
   forget₂ := Functor.Faithful.div _ _ _ @h_obj _ @h_map
   forget_comp := by apply Functor.Faithful.div_comp
 #align category_theory.has_forget₂.mk' CategoryTheory.HasForget₂.mk'
+
+/-- Composition of `HasForget₂` instances. -/
+def HasForget₂.trans (C : Type u) [Category.{v} C] [ConcreteCategory.{w} C]
+    (D : Type u') [Category.{v'} D] [ConcreteCategory.{w} D]
+    (E : Type u'') [Category.{v''} E] [ConcreteCategory.{w} E]
+    [HasForget₂ C D] [HasForget₂ D E] : HasForget₂ C E where
+  forget₂ := CategoryTheory.forget₂ C D ⋙ CategoryTheory.forget₂ D E
+  forget_comp := by
+    show (CategoryTheory.forget₂ _ D) ⋙ (CategoryTheory.forget₂ D E ⋙ CategoryTheory.forget E) = _
+    simp only [HasForget₂.forget_comp]
 
 /-- Every forgetful functor factors through the identity functor. This is not a global instance as
     it is prone to creating type class resolution loops. -/

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -286,6 +286,7 @@ def HasForget₂.mk' {C : Type u} {D : Type u'} [Category.{v} C] [ConcreteCatego
 #align category_theory.has_forget₂.mk' CategoryTheory.HasForget₂.mk'
 
 /-- Composition of `HasForget₂` instances. -/
+@[reducible]
 def HasForget₂.trans (C : Type u) [Category.{v} C] [ConcreteCategory.{w} C]
     (D : Type u') [Category.{v'} D] [ConcreteCategory.{w} D]
     (E : Type u'') [Category.{v''} E] [ConcreteCategory.{w} E]

--- a/Mathlib/RepresentationTheory/Action/Continuous.lean
+++ b/Mathlib/RepresentationTheory/Action/Continuous.lean
@@ -48,9 +48,13 @@ instance (X : Action V G) : MulAction G ((CategoryTheory.forget₂ _ TopCat).obj
     rw [← Functor.map_comp, map_mul]
     rfl
 
+/-- For `HasForget₂ V TopCat` a predicate on an `X : Action V G` saying that the induced action on
+the underlying topological space is continuous. -/
 def IsContinuous (X : Action V G) : Prop :=
   ContinuousSMul G ((CategoryTheory.forget₂ _ TopCat).obj X)
 
+/-- For `HasForget₂ V TopCat`, this is the full subcategory of `Action V G` where the induced
+action is continuous. -/
 def ContAction : Type _ := FullSubcategory (IsContinuous V G)
 
 instance : Category (ContAction V G) :=

--- a/Mathlib/RepresentationTheory/Action/Continuous.lean
+++ b/Mathlib/RepresentationTheory/Action/Continuous.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.RepresentationTheory.Action.Concrete
+import Mathlib.Topology.Algebra.MulAction
+import Mathlib.Topology.Category.TopCat.Basic
+import Mathlib.Topology.Algebra.Group.Basic
+
+/-!
+
+# Topological subcategories of `Action V G`
+
+For a concrete category `V` and a monoid `G`, equipped with a topological space instance,
+we define the subcategory `ContAction V G` of all objects of `Action V G` with a
+`TopologicalSpace` instance on the underlying type such that the induced action
+is continuouos.
+
+We also define a category `DiscreteContAction V G` as the full subcategory of `ContAction V G`,
+where the underlying topological space is discrete.
+
+Finally we define inclusion functors into `Action V G` and `TopCat`.
+
+-/
+
+universe u v
+
+open CategoryTheory Limits
+
+namespace Action
+
+variable (V : Type (u + 1)) [LargeCategory V] [ConcreteCategory V]
+variable (G : MonCat.{u}) [TopologicalSpace G]
+
+/-- The subcategory of `Action V G` where the underlying types are equipped with a
+`TopologicalSpace` instance and the action of `G` is continuous. -/
+structure ContAction extends Action V G where
+  /-- The topological space structure on the underlying type. -/
+  topologicalSpace : TopologicalSpace ((CategoryTheory.forget _).obj toAction)
+  actionContinuous : ContinuousSMul G ((CategoryTheory.forget _).obj toAction)
+
+namespace ContAction
+
+instance : Coe (ContAction V G) (Action V G) where
+  coe X := X.toAction
+
+variable {V} {G}
+
+attribute [instance] topologicalSpace actionContinuous
+
+/-- A homomorphisms between two objects of `ContAction V G` is a continuous homomorphism
+of the underlying objects in `Action V G`. -/
+@[ext]
+structure Hom (X Y : ContAction V G) where
+  /-- The underlying homomorphism of objects of `Action V G`. -/
+  hom : X.toAction ⟶ Y.toAction
+  isContinuous : Continuous ((CategoryTheory.forget (Action V G)).map hom)
+
+/-- The identity homomorphism in `ContAction V G`. -/
+@[simps]
+def Hom.id (X : ContAction V G) : Hom X X where
+  hom := 𝟙 X.toAction
+  isContinuous := by
+    rw [CategoryTheory.Functor.map_id]
+    exact continuous_id
+
+/-- Composition of homomorphisms in `ContAction V G`. -/
+@[simps]
+def Hom.comp {X Y Z : ContAction V G} (f : Hom X Y) (g : Hom Y Z) : Hom X Z where
+  hom := f.hom ≫ g.hom
+  isContinuous := by
+    rw [Functor.map_comp, types_comp]
+    exact Continuous.comp g.isContinuous f.isContinuous
+
+variable (V G) in
+instance category : Category (ContAction V G) where
+  Hom X Y := Hom X Y
+  id X := Hom.id X
+  comp f g := Hom.comp f g
+
+@[ext]
+lemma hom_ext {X Y : ContAction V G} {f g : X ⟶ Y} (h : f.hom = g.hom) : f = g :=
+  Hom.ext f g h
+
+@[simp]
+lemma id_hom (X : ContAction V G) : Hom.hom (𝟙 X) = 𝟙 X.toAction :=
+  rfl
+
+@[simp]
+lemma comp_hom {X Y Z : ContAction V G} (f : X ⟶ Y) (g : Y ⟶ Z) : (f ≫ g).hom = f.hom ≫ g.hom :=
+  rfl
+
+variable (V G)
+
+/-- The forgetful functor from `ContAction V G` to types. Do not use this directly, but use the
+`ConcreteCategory` API instead. -/
+@[simps]
+def forget : ContAction V G ⥤ Type u where
+  obj X := (CategoryTheory.forget (Action V G)).obj X
+  map {X Y} f := (CategoryTheory.forget (Action V G)).map f.hom
+
+instance : Functor.Faithful (forget V G) where
+  map_injective {_ _} _ _ h :=
+    hom_ext <| (CategoryTheory.forget (Action V G)).map_injective h
+
+instance concreteCategory : ConcreteCategory (ContAction V G) where
+  forget := forget V G
+
+variable {V G}
+
+instance (X : ContAction V G) : TopologicalSpace ((CategoryTheory.forget _).obj X) :=
+  X.topologicalSpace
+
+variable (V G)
+
+section Inclusions
+
+/-- The canonical inclusion in `Action V G`. -/
+@[simps]
+def incl : ContAction V G ⥤ Action V G where
+  obj X := X
+  map {X Y} f := f.hom
+
+instance : HasForget₂ (ContAction V G) (Action V G) where
+  forget₂ := incl V G
+
+/-- The canonical inclusion in `TopCat`. -/
+@[simps]
+def toTopCat : ContAction V G ⥤ TopCat where
+  obj X := TopCat.of ((CategoryTheory.forget (ContAction V G)).obj X)
+  map {X Y} f := ⟨(CategoryTheory.forget (ContAction V G)).map f, f.isContinuous⟩
+
+instance : HasForget₂ (ContAction V G) TopCat where
+  forget₂ := toTopCat V G
+
+end Inclusions
+
+section Discrete
+
+/-- A predicate on an `X : ContAction V G` saying that the topology on the underlying type of `X`
+is discrete. -/
+def isDiscrete (X : ContAction V G) : Prop := DiscreteTopology ((CategoryTheory.forget _).obj X)
+
+/-- The subcategory of `ContAction V G` where the topology is discrete. -/
+def DiscreteContAction : Type _ := FullSubcategory (isDiscrete V G)
+
+namespace DiscreteContAction
+
+instance : Category (DiscreteContAction V G) :=
+  FullSubcategory.category (isDiscrete V G)
+
+instance : ConcreteCategory (DiscreteContAction V G) :=
+  FullSubcategory.concreteCategory (isDiscrete V G)
+
+variable {V G}
+
+instance (X : DiscreteContAction V G) : TopologicalSpace ((CategoryTheory.forget _).obj X) :=
+  X.obj.topologicalSpace
+
+instance (X : DiscreteContAction V G) : DiscreteTopology ((CategoryTheory.forget _).obj X) :=
+  X.property
+
+end DiscreteContAction
+
+end Discrete
+
+end ContAction

--- a/Mathlib/RepresentationTheory/Action/Continuous.lean
+++ b/Mathlib/RepresentationTheory/Action/Continuous.lean
@@ -14,7 +14,7 @@ import Mathlib.Topology.Category.TopCat.Basic
 For a concrete category `V`, where the forgetful functor factors via `TopCat`,
 and a monoid `G`, equipped with a topological space instance,
 we define the full subcategory `ContAction V G` of all objects of `Action V G`
-where the induced action is continuouos.
+where the induced action is continuous.
 
 We also define a category `DiscreteContAction V G` as the full subcategory of `ContAction V G`,
 where the underlying topological space is discrete.
@@ -28,10 +28,10 @@ universe u v
 
 open CategoryTheory Limits
 
-namespace Action
-
 variable (V : Type (u + 1)) [LargeCategory V] [ConcreteCategory V] [HasForget₂ V TopCat]
 variable (G : MonCat.{u}) [TopologicalSpace G]
+
+namespace Action
 
 instance : HasForget₂ (Action V G) TopCat :=
   HasForget₂.trans (Action V G) V TopCat
@@ -53,9 +53,15 @@ the underlying topological space is continuous. -/
 def IsContinuous (X : Action V G) : Prop :=
   ContinuousSMul G ((CategoryTheory.forget₂ _ TopCat).obj X)
 
+end Action
+
+open Action
+
 /-- For `HasForget₂ V TopCat`, this is the full subcategory of `Action V G` where the induced
 action is continuous. -/
 def ContAction : Type _ := FullSubcategory (IsContinuous V G)
+
+namespace ContAction
 
 instance : Category (ContAction V G) :=
   FullSubcategory.category (IsContinuous V G)
@@ -72,17 +78,17 @@ instance : HasForget₂ (ContAction V G) V :=
 instance : HasForget₂ (ContAction V G) TopCat :=
   HasForget₂.trans (ContAction V G) (Action V G) TopCat
 
-namespace ContAction
-
 instance : Coe (ContAction V G) (Action V G) where
   coe X := X.obj
-
-section Discrete
 
 /-- A predicate on an `X : ContAction V G` saying that the topology on the underlying type of `X`
 is discrete. -/
 def IsDiscrete (X : ContAction V G) : Prop :=
   DiscreteTopology ((CategoryTheory.forget₂ _ TopCat).obj X)
+
+end ContAction
+
+open ContAction
 
 /-- The subcategory of `ContAction V G` where the topology is discrete. -/
 def DiscreteContAction : Type _ := FullSubcategory (IsDiscrete V G)
@@ -108,7 +114,3 @@ instance (X : DiscreteContAction V G) :
   X.property
 
 end DiscreteContAction
-
-end Discrete
-
-end ContAction

--- a/Mathlib/RepresentationTheory/Action/Continuous.lean
+++ b/Mathlib/RepresentationTheory/Action/Continuous.lean
@@ -125,10 +125,15 @@ instance : HasForget₂ (ContAction V G) (Action V G) where
   forget₂ := incl V G
 
 /-- The canonical inclusion in `TopCat`. -/
-@[simps]
 def toTopCat : ContAction V G ⥤ TopCat where
   obj X := TopCat.of ((CategoryTheory.forget (ContAction V G)).obj X)
   map {X Y} f := ⟨(CategoryTheory.forget (ContAction V G)).map f, f.isContinuous⟩
+
+@[simp]
+lemma toTopCat_map_apply {X Y : ContAction V G} (f : X ⟶ Y)
+    (a : (CategoryTheory.forget (ContAction V G)).obj X) :
+    (toTopCat V G).map f a = (CategoryTheory.forget (ContAction V G)).map f a := by
+  rfl
 
 instance : HasForget₂ (ContAction V G) TopCat where
   forget₂ := toTopCat V G

--- a/Mathlib/RepresentationTheory/Action/Continuous.lean
+++ b/Mathlib/RepresentationTheory/Action/Continuous.lean
@@ -43,14 +43,16 @@ instance (X : Action V G) : MulAction G ((CategoryTheory.forget₂ _ TopCat).obj
     simp
   mul_smul g h x := by
     show (CategoryTheory.forget₂ _ TopCat).map (X.ρ (g * h)) x =
-      ((CategoryTheory.forget₂ _ TopCat).map (X.ρ h)
-        ≫ (CategoryTheory.forget₂ _ TopCat).map (X.ρ g)) x
+      ((CategoryTheory.forget₂ _ TopCat).map (X.ρ h) ≫
+        (CategoryTheory.forget₂ _ TopCat).map (X.ρ g)) x
     rw [← Functor.map_comp, map_mul]
     rfl
 
+variable {V G}
+
 /-- For `HasForget₂ V TopCat` a predicate on an `X : Action V G` saying that the induced action on
 the underlying topological space is continuous. -/
-def IsContinuous (X : Action V G) : Prop :=
+abbrev IsContinuous (X : Action V G) : Prop :=
   ContinuousSMul G ((CategoryTheory.forget₂ _ TopCat).obj X)
 
 end Action
@@ -59,18 +61,18 @@ open Action
 
 /-- For `HasForget₂ V TopCat`, this is the full subcategory of `Action V G` where the induced
 action is continuous. -/
-def ContAction : Type _ := FullSubcategory (IsContinuous V G)
+def ContAction : Type _ := FullSubcategory (IsContinuous (V := V) (G := G))
 
 namespace ContAction
 
 instance : Category (ContAction V G) :=
-  FullSubcategory.category (IsContinuous V G)
+  FullSubcategory.category (IsContinuous (V := V) (G := G))
 
 instance : ConcreteCategory (ContAction V G) :=
-  FullSubcategory.concreteCategory (IsContinuous V G)
+  FullSubcategory.concreteCategory (IsContinuous (V := V) (G := G))
 
 instance : HasForget₂ (ContAction V G) (Action V G) :=
-  FullSubcategory.hasForget₂ (IsContinuous V G)
+  FullSubcategory.hasForget₂ (IsContinuous (V := V) (G := G))
 
 instance : HasForget₂ (ContAction V G) V :=
   HasForget₂.trans (ContAction V G) (Action V G) V
@@ -81,9 +83,11 @@ instance : HasForget₂ (ContAction V G) TopCat :=
 instance : Coe (ContAction V G) (Action V G) where
   coe X := X.obj
 
+variable {V G}
+
 /-- A predicate on an `X : ContAction V G` saying that the topology on the underlying type of `X`
 is discrete. -/
-def IsDiscrete (X : ContAction V G) : Prop :=
+abbrev IsDiscrete (X : ContAction V G) : Prop :=
   DiscreteTopology ((CategoryTheory.forget₂ _ TopCat).obj X)
 
 end ContAction
@@ -91,18 +95,18 @@ end ContAction
 open ContAction
 
 /-- The subcategory of `ContAction V G` where the topology is discrete. -/
-def DiscreteContAction : Type _ := FullSubcategory (IsDiscrete V G)
+def DiscreteContAction : Type _ := FullSubcategory (IsDiscrete (V := V) (G := G))
 
 namespace DiscreteContAction
 
 instance : Category (DiscreteContAction V G) :=
-  FullSubcategory.category (IsDiscrete V G)
+  FullSubcategory.category (IsDiscrete (V := V) (G := G))
 
 instance : ConcreteCategory (DiscreteContAction V G) :=
-  FullSubcategory.concreteCategory (IsDiscrete V G)
+  FullSubcategory.concreteCategory (IsDiscrete (V := V) (G := G))
 
 instance : HasForget₂ (DiscreteContAction V G) (ContAction V G) :=
-  FullSubcategory.hasForget₂ (IsDiscrete V G)
+  FullSubcategory.hasForget₂ (IsDiscrete (V := V) (G := G))
 
 instance : HasForget₂ (DiscreteContAction V G) TopCat :=
   HasForget₂.trans (DiscreteContAction V G) (ContAction V G) TopCat

--- a/Mathlib/RepresentationTheory/Action/Continuous.lean
+++ b/Mathlib/RepresentationTheory/Action/Continuous.lean
@@ -6,7 +6,6 @@ Authors: Christian Merten
 import Mathlib.RepresentationTheory.Action.Concrete
 import Mathlib.Topology.Algebra.MulAction
 import Mathlib.Topology.Category.TopCat.Basic
-import Mathlib.Topology.Algebra.Group.Basic
 
 /-!
 

--- a/Mathlib/RepresentationTheory/Action/Continuous.lean
+++ b/Mathlib/RepresentationTheory/Action/Continuous.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
-import Mathlib.RepresentationTheory.Action.Concrete
+import Mathlib.RepresentationTheory.Action.Basic
 import Mathlib.Topology.Algebra.MulAction
 import Mathlib.Topology.Category.TopCat.Basic
 


### PR DESCRIPTION
Introduces the category `ContAction V G` for any concrete category `V` with a forgetful functor to `TopCat` and monoid `G`. It is realized as a full subcategory of `Action V G` where the induced action is continuous.

Also introduces the full subcategory `DiscreteContAction V G` where the underlying topological space is discrete.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is an alternative design of #12878. The difference is that instead of bundling a topological space instance in `ContAction`, we require `V` to have a `HasForget₂ V TopCat` instance. Examples could be:

- `V = TopCat`: category of topological `G`-sets
- `V = TopCommRingCat`: category of topological `G`-rings

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
