### PR TITLE
[Merged by Bors] - doc: fix abbreviation for Span.lean

### DIFF
--- a/Mathlib/LinearAlgebra/Span.lean
+++ b/Mathlib/LinearAlgebra/Span.lean
@@ -21,7 +21,7 @@ import Mathlib.Order.OmegaCompletePartialOrder
 ## Notations
 
 * We introduce the notation `R ∙ v` for the span of a singleton, `Submodule.span R {v}`.  This is
-  `\.`, not the same as the scalar multiplication `•`/`\bub`.
+  `\span`, not the same as the scalar multiplication `•`/`\bub`.
 
 -/
 


### PR DESCRIPTION
The documentation for `Mathlib.LinearAlgebra.Span.lean` is incorrect -- there currently is no abbreviation for `∙` and `\.` is incorrect.

This PR depends on an external PR (https://github.com/leanprover/vscode-lean4/pull/447) to add the suggested abbreviation.