### PR TITLE
[Merged by Bors] - chore: redefine Filter.curry in terms of Filter.bind

### DIFF
--- a/Mathlib/Order/Filter/Curry.lean
+++ b/Mathlib/Order/Filter/Curry.lean
@@ -21,11 +21,15 @@ yields the quantifier order `∃ ∀ ∃ ∀`. For instance,
 This is different from a product filter, which instead yields a quantifier order `∃ ∃ ∀ ∀`. For
 instance, `∀ᶠ n in at_top ×ˢ at_top, p n ↔ ∃ M, ∃ N, ∀ m ≥ M, ∀ n ≥ N, p (m, n)`. This makes it
 clear that if something eventually occurs on the product filter, it eventually occurs on the curried
-filter (see `Filter.curry_le_prod` and `Filter.eventually.curry`), but the converse is not true.
+filter (see `Filter.curry_le_prod` and `Filter.Eventually.curry`), but the converse is not true.
 
 Another way to think about the curried versus the product filter is that tending to some limit on
 the product filter is a version of uniform convergence (see `tendsto_prod_filter_iff`) whereas
 tending to some limit on a curried filter is just iterated limits (see `Filter.Tendsto.curry`).
+
+In the "generalized set" intuition, `Filter.prod` and `Filter.curry` correspond to two ways of
+describing the product of two sets, namely `s ×ˢ t = fst ⁻¹' s ∩ snd ⁻¹' t` and
+`s ×ˢ t = ⋃ x ∈ s, (x, ·) '' t`.
 
 ## Main definitions
 
@@ -51,13 +55,8 @@ variable {α β γ : Type*}
 `(∀ᶠ (x : α × β) in f.curry g, p x) ↔ ∀ᶠ (x : α) in f, ∀ᶠ (y : β) in g, p (x, y)`. Useful
 in adding quantifiers to the middle of `Tendsto`s. See
 `hasFDerivAt_of_tendstoUniformlyOnFilter`. -/
-def curry (f : Filter α) (g : Filter β) : Filter (α × β) where
-  sets := { s | ∀ᶠ a : α in f, ∀ᶠ b : β in g, (a, b) ∈ s }
-  univ_sets := by simp only [Set.mem_setOf_eq, Set.mem_univ, eventually_true]
-  sets_of_superset := fun hx hxy =>
-    hx.mono fun a ha => ha.mono fun b hb => Set.mem_of_subset_of_mem hxy hb
-  inter_sets := fun hx hy =>
-    (hx.and hy).mono fun a ha => (ha.1.and ha.2).mono fun b hb => hb
+def curry (f : Filter α) (g : Filter β) : Filter (α × β) :=
+  bind f fun a ↦ map (a, ·) g
 #align filter.curry Filter.curry
 
 theorem eventually_curry_iff {f : Filter α} {g : Filter β} {p : α × β → Prop} :


### PR DESCRIPTION
This is not super helpful in itself, but I think 1) it makes the definition a bit more natural and 2) it can probably help to make some proofs more efficient and intuitive here and there.

---

This is easy from the Lean point of view (the lemma below the definition shows no defeq has changed) but I also added some motivation to the docstring so I'm not tagging this as "easy".

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
