### PR TITLE
[Merged by Bors] - chore: add full-ci label to Lean PRs that break Mathlib

### DIFF
--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -58,14 +58,14 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
       -H "Authorization: Bearer $TOKEN" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       https://api.github.com/repos/leanprover/lean4/issues/$pr_number/labels/builds-mathlib
-    echo "Adding labels breaks-mathlib"
+    echo "Adding labels breaks-mathlib and full-ci"
     curl -L -s \
       -X POST \
       -H "Accept: application/vnd.github+json" \
       -H "Authorization: Bearer $TOKEN" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       https://api.github.com/repos/leanprover/lean4/issues/$pr_number/labels \
-      -d '{"labels":["breaks-mathlib"]}'
+      -d '{"labels":["breaks-mathlib", "full-ci"]}'
   fi
 
   # Use GitHub API to check if a comment already exists


### PR DESCRIPTION
This makes the turnaround for local testing faster, by ensuring that toolchains for all platforms are built.