### PR TITLE
[Merged by Bors] - chore(Algebra/Category): make coe_of a simp lemma in CommGroupCat

### DIFF
--- a/Mathlib/Algebra/Category/GroupCat/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Adjunctions.lean
@@ -89,9 +89,8 @@ the monomorphisms in `AddCommGroup` are just the injective functions.
 
 (This proof works in all universes.)
 -/
--- Porting note: had to elaborate instance of Mono rather than just using `apply_instance`.
 example {G H : AddCommGroupCat.{u}} (f : G ⟶ H) [Mono f] : Function.Injective f :=
-  (mono_iff_injective (DFunLike.coe f)).mp (Functor.map_mono (forget AddCommGroupCat) f)
+  (mono_iff_injective (f : G → H)).mp (Functor.map_mono (forget AddCommGroupCat) f)
 
 
 end AddCommGroupCat

--- a/Mathlib/Algebra/Category/GroupCat/Basic.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Basic.lean
@@ -103,6 +103,18 @@ set_option linter.uppercaseLean3 false in
 set_option linter.uppercaseLean3 false in
 #align AddGroup.coe_of AddGroupCat.coe_of
 
+@[to_additive (attr := simp)]
+theorem coe_comp' {G H K : Type _} [Group G] [Group H] [Group K] (f : G →* H) (g : H →* K) :
+    @DFunLike.coe (G →* K) G (fun _ ↦ K) MonoidHom.instFunLike (CategoryStruct.comp
+      (X := GroupCat.of G) (Y := GroupCat.of H) (Z := GroupCat.of K) f g) = g ∘ f :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem coe_id' {G : Type _} [Group G] :
+    @DFunLike.coe (G →* G) G (fun _ ↦ G) MonoidHom.instFunLike
+      (CategoryStruct.id (X := GroupCat.of G)) = id :=
+  rfl
+
 @[to_additive]
 instance : Inhabited GroupCat :=
   ⟨GroupCat.of PUnit⟩
@@ -254,13 +266,26 @@ instance : Inhabited CommGroupCat :=
 -- Porting note: removed `@[simp]` here, as it makes it harder to tell when to apply
 -- bundled or unbundled lemmas.
 -- (This change seems dangerous!)
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem coe_of (R : Type u) [CommGroup R] : (CommGroupCat.of R : Type u) = R :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align CommGroup.coe_of CommGroupCat.coe_of
 set_option linter.uppercaseLean3 false in
 #align AddCommGroup.coe_of AddCommGroupCat.coe_of
+
+@[to_additive (attr := simp)]
+theorem coe_comp' {G H K : Type _} [CommGroup G] [CommGroup H] [CommGroup K]
+    (f : G →* H) (g : H →* K) :
+    @DFunLike.coe (G →* K) G (fun _ ↦ K) MonoidHom.instFunLike (CategoryStruct.comp
+      (X := CommGroupCat.of G) (Y := CommGroupCat.of H) (Z := CommGroupCat.of K) f g) = g ∘ f :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem coe_id' {G : Type _} [CommGroup G] :
+    @DFunLike.coe (G →* G) G (fun _ ↦ G) MonoidHom.instFunLike
+      (CategoryStruct.id (X := CommGroupCat.of G)) = id :=
+  rfl
 
 @[to_additive]
 instance ofUnique (G : Type*) [CommGroup G] [i : Unique G] : Unique (CommGroupCat.of G) :=
@@ -318,7 +343,7 @@ add_decl_doc AddCommGroupCat.ofHom
 
 @[to_additive (attr := simp)]
 theorem ofHom_apply {X Y : Type _} [CommGroup X] [CommGroup Y] (f : X →* Y) (x : X) :
-    (ofHom f) x = f x :=
+    @DFunLike.coe (X →* Y) X (fun _ ↦ Y) _ (ofHom f) x = f x :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align CommGroup.of_hom_apply CommGroupCat.ofHom_apply
@@ -344,7 +369,8 @@ set_option linter.uppercaseLean3 false in
 #align AddCommGroup.as_hom AddCommGroupCat.asHom
 
 @[simp]
-theorem asHom_apply {G : AddCommGroupCat.{0}} (g : G) (i : ℤ) : (asHom g) i = i • g :=
+theorem asHom_apply {G : AddCommGroupCat.{0}} (g : G) (i : ℤ) :
+    @DFunLike.coe (ℤ →+ ↑G) ℤ (fun _ ↦ ↑G) _ (asHom g) i = i • g :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align AddCommGroup.as_hom_apply AddCommGroupCat.asHom_apply

--- a/Mathlib/Algebra/Category/GroupCat/Basic.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Basic.lean
@@ -263,9 +263,6 @@ add_decl_doc AddCommGroupCat.of
 instance : Inhabited CommGroupCat :=
   ⟨CommGroupCat.of PUnit⟩
 
--- Porting note: removed `@[simp]` here, as it makes it harder to tell when to apply
--- bundled or unbundled lemmas.
--- (This change seems dangerous!)
 @[to_additive (attr := simp)]
 theorem coe_of (R : Type u) [CommGroup R] : (CommGroupCat.of R : Type u) = R :=
   rfl

--- a/Mathlib/Algebra/Category/GroupCat/Biproducts.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Biproducts.lean
@@ -97,7 +97,10 @@ variable {J : Type w} (f : J → AddCommGroupCat.{max w u})
 /-- The map from an arbitrary cone over an indexed family of abelian groups
 to the cartesian product of those groups.
 -/
-@[simps]
+-- This was marked `@[simps]` until we made `AddCommGroupCat.coe_of` a simp lemma,
+-- after which the simp normal form linter complains.
+-- Possible solution: higher priority function coercions that remove the `of`?
+-- @[simps]
 def lift (s : Fan f) : s.pt ⟶ AddCommGroupCat.of (∀ j, f j) where
   toFun x j := s.π.app ⟨j⟩ x
   map_zero' := by

--- a/Mathlib/Algebra/Category/GroupCat/Biproducts.lean
+++ b/Mathlib/Algebra/Category/GroupCat/Biproducts.lean
@@ -99,6 +99,7 @@ to the cartesian product of those groups.
 -/
 -- This was marked `@[simps]` until we made `AddCommGroupCat.coe_of` a simp lemma,
 -- after which the simp normal form linter complains.
+-- The generated simp lemmas were not used in Mathlib.
 -- Possible solution: higher priority function coercions that remove the `of`?
 -- @[simps]
 def lift (s : Fan f) : s.pt ⟶ AddCommGroupCat.of (∀ j, f j) where

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -562,9 +562,10 @@ open HomComplex
 
 /-- The cochain complex of homomorphisms between two cochain complexes `F` and `G`.
 In degree `n : ℤ`, it consists of the abelian group `HomComplex.Cochain F G n`. -/
--- We also constructed the `d_apply` lemmas using `@[simps]`
+-- We also constructed the `d_apply` lemma using `@[simps]`
 -- until we made `AddCommGroupCat.coe_of` a simp lemma,
 -- after which the simp normal form linter complains.
+-- It was not used a simp lemma in Mathlib.
 -- Possible solution: higher priority function coercions that remove the `of`?
 -- @[simp]
 @[simps! X]

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -562,7 +562,12 @@ open HomComplex
 
 /-- The cochain complex of homomorphisms between two cochain complexes `F` and `G`.
 In degree `n : ℤ`, it consists of the abelian group `HomComplex.Cochain F G n`. -/
-@[simps! X d_apply]
+-- We also constructed the `d_apply` lemmas using `@[simps]`
+-- until we made `AddCommGroupCat.coe_of` a simp lemma,
+-- after which the simp normal form linter complains.
+-- Possible solution: higher priority function coercions that remove the `of`?
+-- @[simp]
+@[simps! X]
 def HomComplex : CochainComplex AddCommGroupCat ℤ where
   X i := AddCommGroupCat.of (Cochain F G i)
   d i j := AddCommGroupCat.ofHom (δ_hom ℤ F G i j)

--- a/Mathlib/Algebra/Homology/ShortComplex/Ab.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Ab.lean
@@ -71,7 +71,10 @@ the abstract `S.cycles` of the homology API and the more concrete description as
 noncomputable def abCyclesIso : S.cycles ≅ AddCommGroupCat.of (AddMonoidHom.ker S.g) :=
   S.abLeftHomologyData.cyclesIso
 
-@[simp]
+-- This was a simp lemma until we made `AddCommGroupCat.coe_of` a simp lemma,
+-- after which the simp normal form linter complains.
+-- Possible solution: higher priority function coercions that remove the `of`?
+-- @[simp]
 lemma abCyclesIso_inv_apply_iCycles (x : AddMonoidHom.ker S.g) :
     S.iCycles (S.abCyclesIso.inv x) = x := by
   dsimp only [abCyclesIso]

--- a/Mathlib/Algebra/Homology/ShortComplex/Ab.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Ab.lean
@@ -73,6 +73,7 @@ noncomputable def abCyclesIso : S.cycles ≅ AddCommGroupCat.of (AddMonoidHom.ke
 
 -- This was a simp lemma until we made `AddCommGroupCat.coe_of` a simp lemma,
 -- after which the simp normal form linter complains.
+-- It was not used a simp lemma in Mathlib.
 -- Possible solution: higher priority function coercions that remove the `of`?
 -- @[simp]
 lemma abCyclesIso_inv_apply_iCycles (x : AddMonoidHom.ker S.g) :

--- a/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
+++ b/Mathlib/CategoryTheory/Galois/Prorepresentability.lean
@@ -173,11 +173,9 @@ noncomputable def autGaloisSystem : PointedGaloisObject F ⥤ GroupCat.{u₂} wh
   map_id := fun A ↦ by
     ext (σ : Aut A.obj)
     simp
-    rfl
   map_comp {A B C} f g := by
     ext (σ : Aut A.obj)
     simp
-    rfl
 
 end PreGaloisCategory
 


### PR DESCRIPTION
This tried to make the concrete category developments more uniform: whether `coe_of` was a simp lemma or not seems to have been decided differently in different files during porting.

Also adds some lemmas to improve confluence.