### PR TITLE
[Merged by Bors] - feat(RingTheory/PowerSeries/Inverse): add two lemmas on the normalization of `(X  : PowerSeries k)`

### DIFF
--- a/Mathlib/RingTheory/PowerSeries/Inverse.lean
+++ b/Mathlib/RingTheory/PowerSeries/Inverse.lean
@@ -372,8 +372,8 @@ theorem normUnit_X : normUnit (PowerSeries.X : PowerSeries k) = 1 := by
   rw [inv_eq_one, ← Units.val_eq_one, Unit_of_divided_by_X_pow_order_nonzero,
     divided_by_X_pow_order_of_X_eq_one]
 
-theorem X_eq_normalizeX : (PowerSeries.X : PowerSeries k) = normalize PowerSeries.X := by
-  simp only [normalize_apply, PowerSeries.normUnit_X, Units.val_one, mul_one]
+theorem X_eq_normalizeX : (X : PowerSeries k) = normalize X := by
+  simp only [normalize_apply, normUnit_X, Units.val_one, mul_one]
 
 open LocalRing
 

--- a/Mathlib/RingTheory/PowerSeries/Inverse.lean
+++ b/Mathlib/RingTheory/PowerSeries/Inverse.lean
@@ -368,7 +368,7 @@ instance : NormalizationMonoid k⟦X⟧ where
     exact ((eq_divided_by_X_pow_order_Iff_Unit h₀.ne_zero).mpr h₀).symm
 
 theorem normUnit_X : normUnit (PowerSeries.X : PowerSeries k) = 1 := by
-  dsimp only [normUnit];
+  dsimp only [normUnit]
   rw [inv_eq_one, ← Units.val_eq_one, Unit_of_divided_by_X_pow_order_nonzero,
     divided_by_X_pow_order_of_X_eq_one]
 

--- a/Mathlib/RingTheory/PowerSeries/Inverse.lean
+++ b/Mathlib/RingTheory/PowerSeries/Inverse.lean
@@ -367,6 +367,14 @@ instance : NormalizationMonoid k⟦X⟧ where
     rw [inv_inj, Units.ext_iff, ← hu, Unit_of_divided_by_X_pow_order_nonzero h₀.ne_zero]
     exact ((eq_divided_by_X_pow_order_Iff_Unit h₀.ne_zero).mpr h₀).symm
 
+theorem normUnit_X : normUnit (PowerSeries.X : PowerSeries k) = 1 := by
+  dsimp only [normUnit];
+  rw [inv_eq_one, ← Units.val_eq_one, Unit_of_divided_by_X_pow_order_nonzero,
+    divided_by_X_pow_order_of_X_eq_one]
+
+theorem X_eq_normalizeX : (PowerSeries.X : PowerSeries k) = normalize PowerSeries.X := by
+  simp only [normalize_apply, PowerSeries.normUnit_X, Units.val_one, mul_one]
+
 open LocalRing
 
 theorem ker_coeff_eq_max_ideal : RingHom.ker (constantCoeff k) = maximalIdeal _ :=

--- a/Mathlib/RingTheory/PowerSeries/Inverse.lean
+++ b/Mathlib/RingTheory/PowerSeries/Inverse.lean
@@ -367,10 +367,8 @@ instance : NormalizationMonoid k⟦X⟧ where
     rw [inv_inj, Units.ext_iff, ← hu, Unit_of_divided_by_X_pow_order_nonzero h₀.ne_zero]
     exact ((eq_divided_by_X_pow_order_Iff_Unit h₀.ne_zero).mpr h₀).symm
 
-theorem normUnit_X : normUnit (PowerSeries.X : PowerSeries k) = 1 := by
-  dsimp only [normUnit]
-  rw [inv_eq_one, ← Units.val_eq_one, Unit_of_divided_by_X_pow_order_nonzero,
-    divided_by_X_pow_order_of_X_eq_one]
+theorem normUnit_X : normUnit (X : PowerSeries k) = 1 := by
+  simp [normUnit, ← Units.val_eq_one, Unit_of_divided_by_X_pow_order_nonzero]
 
 theorem X_eq_normalizeX : (X : PowerSeries k) = normalize X := by
   simp only [normalize_apply, normUnit_X, Units.val_one, mul_one]


### PR DESCRIPTION
Add two lemmas about the element `X` as term of the normalization monoid $k[[X]]$ for a field `k`.

Co-authored-by: María Inés de Frutos-Fernández @mariainesdff 
