### PR TITLE
[Merged by Bors] - chore: remove unnecessary outParam

### DIFF
--- a/Mathlib/Algebra/AddTorsor.lean
+++ b/Mathlib/Algebra/AddTorsor.lean
@@ -44,7 +44,7 @@ acted on by an `AddGroup G` with a transitive and free action given
 by the `+ᵥ` operation and a corresponding subtraction given by the
 `-ᵥ` operation. In the case of a vector space, it is an affine
 space. -/
-class AddTorsor (G : outParam (Type*)) (P : Type*) [outParam <| AddGroup G] extends AddAction G P,
+class AddTorsor (G : outParam Type*) (P : Type*) [AddGroup G] extends AddAction G P,
   VSub G P where
   [nonempty : Nonempty P]
   /-- Torsor subtraction and addition with the same element cancels out. -/

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -30,7 +30,7 @@ structure and require the distance to be the same as results from the
 norm (which in fact implies the distance yields a pseudometric space, but
 bundling just the distance and using an instance for the pseudometric space
 results in type class problems). -/
-class NormedAddTorsor (V : outParam <| Type*) (P : Type*) [outParam <| SeminormedAddCommGroup V]
+class NormedAddTorsor (V : outParam Type*) (P : Type*) [SeminormedAddCommGroup V]
   [PseudoMetricSpace P] extends AddTorsor V P where
   dist_eq_norm' : ∀ x y : P, dist x y = ‖(x -ᵥ y : V)‖
 #align normed_add_torsor NormedAddTorsor


### PR DESCRIPTION
I spotted an `outParam` in an instance argument of a class. The purpose of `outParam` is to fill in the value during type class search. However, since this is an instance argument, it must already have been synthesised at this point, so this has no purpose.

I looked at the old Zulip conversation on this topic, and there didn't seem to be a good reason for putting this `outParam` in the instance argument, other than simply that it worked.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
