### PR TITLE
[Merged by Bors] - fix: `extract_lets` was not processing unused let bindings correctly

### DIFF
--- a/Mathlib/Tactic/ExtractLets.lean
+++ b/Mathlib/Tactic/ExtractLets.lean
@@ -43,7 +43,7 @@ where
     -- Lift the let
     withLetDecl n' t' v' fun fvar => do
       let b' := b'.instantiate1 fvar
-      let ty' ← mkLetFVars #[fvar] <| mk b'
+      let ty' ← mkLetFVars (usedLetOnly := false) #[fvar] <| mk b'
       mvarId.change ty'
 
 /-- A more limited version of `Lean.MVarId.introN` that ensures the goal is a

--- a/test/ExtractLets.lean
+++ b/test/ExtractLets.lean
@@ -78,3 +78,23 @@ example (h : let x := 1; let y := 2; x + 1 = y) : let _z := 3; ∀ (_ : Nat), Tr
   guard_hyp h : let x := 1; let y := 2; x + 1 = y
   intro
   trivial
+
+/-!
+Issue reported at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.60extract_lets.60.20fails.20in.20a.20hypothesis.20if.20the.20name.20is.20unused/near/439675718
+Unused 'let' bindings were being miscounted.
+-/
+
+/--
+info: ok✝ : Prop := True
+_also_ok✝ : Prop := True
+_not_ok✝ : Prop := True
+h : ok✝
+⊢ True
+-/
+#guard_msgs in
+def a (h : let ok := True; let _not_ok := True; ok) : let _also_ok := True; True := by
+  extract_lets _ at h
+  extract_lets _
+  extract_lets _ at h
+  trace_state
+  trivial


### PR DESCRIPTION
By default `mkLetFVars` eliminates unused let bindings, but they need to be preserved for `extractLetsAt` to function properly.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
