### PR TITLE
[Merged by Bors] - chore (CategoryTheory): remove references to `restate_axiom` and porting notes about `reassoc.1`

### DIFF
--- a/Mathlib/Algebra/Homology/Homology.lean
+++ b/Mathlib/Algebra/Homology/Homology.lean
@@ -208,7 +208,6 @@ abbrev cycles'Map (f : C₁ ⟶ C₂) (i : ι) : (C₁.cycles' i : V) ⟶ (C₂.
   Subobject.factorThru _ ((C₁.cycles' i).arrow ≫ f.f i) (kernelSubobject_factors _ _ (by simp))
 #align cycles_map cycles'Map
 
--- Porting note: Originally `@[simp, reassoc.1, elementwise]`
 @[reassoc, elementwise] -- @[simp] -- Porting note (#10618): simp can prove this
 theorem cycles'Map_arrow (f : C₁ ⟶ C₂) (i : ι) :
     cycles'Map f i ≫ (C₂.cycles' i).arrow = (C₁.cycles' i).arrow ≫ f.f i := by simp
@@ -273,7 +272,6 @@ section
 variable [HasEqualizers V] [HasImages V] [HasImageMaps V]
 variable {C₁ C₂ : HomologicalComplex V c} (f : C₁ ⟶ C₂)
 
--- Porting note: Originally `@[simp, reassoc.1]`
 @[reassoc (attr := simp)]
 theorem boundariesToCycles'_naturality (i : ι) :
     boundariesMap f i ≫ C₂.boundariesToCycles' i =

--- a/Mathlib/CategoryTheory/Abelian/InjectiveResolution.lean
+++ b/Mathlib/CategoryTheory/Abelian/InjectiveResolution.lean
@@ -202,12 +202,12 @@ def homotopyEquiv {X : C} (I J : InjectiveResolution X) :
     simpa [id_comp] using descIdHomotopy _ _
 #align category_theory.InjectiveResolution.homotopy_equiv CategoryTheory.InjectiveResolution.homotopyEquiv
 
-@[reassoc (attr := simp)] -- Porting note: Originally `@[simp, reassoc.1]`
+@[reassoc (attr := simp)]
 theorem homotopyEquiv_hom_ι {X : C} (I J : InjectiveResolution X) :
     I.ι ≫ (homotopyEquiv I J).hom = J.ι := by simp [homotopyEquiv]
 #align category_theory.InjectiveResolution.homotopy_equiv_hom_ι CategoryTheory.InjectiveResolution.homotopyEquiv_hom_ι
 
-@[reassoc (attr := simp)] -- Porting note: Originally `@[simp, reassoc.1]`
+@[reassoc (attr := simp)]
 theorem homotopyEquiv_inv_ι {X : C} (I J : InjectiveResolution X) :
     J.ι ≫ (homotopyEquiv I J).inv = I.ι := by simp [homotopyEquiv]
 #align category_theory.InjectiveResolution.homotopy_equiv_inv_ι CategoryTheory.InjectiveResolution.homotopyEquiv_inv_ι

--- a/Mathlib/CategoryTheory/Bicategory/Functor.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor.lean
@@ -206,14 +206,10 @@ initialize_simps_projections OplaxFunctor (+toPrelaxFunctor, -obj, -map, -map₂
 
 namespace OplaxFunctor
 
-/- Porting note: removed primes from field names and remove `restate_axiom` since
-that is no longer needed in Lean 4 -/
-
 -- Porting note: more stuff was tagged `simp` here in lean 3 but `reassoc (attr := simp)`
 -- is doing this job a couple of lines below this.
 attribute [simp] map₂_id
 
--- Porting note: was auto-ported as `attribute [reassoc.1]` for some reason
 attribute [reassoc (attr := simp)]
   mapComp_naturality_left mapComp_naturality_right map₂_associator
 
@@ -395,7 +391,6 @@ initialize_simps_projections Pseudofunctor (+toPrelaxFunctor, -obj, -map, -map�
 
 namespace Pseudofunctor
 
--- Porting note: was `[reassoc.1]` for some reason?
 attribute [reassoc]
   map₂_comp map₂_whisker_left map₂_whisker_right map₂_associator map₂_left_unitor map₂_right_unitor
 

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation.lean
@@ -75,9 +75,6 @@ attribute [nolint docBlame] CategoryTheory.OplaxNatTrans.app
   CategoryTheory.OplaxNatTrans.naturality_id
   CategoryTheory.OplaxNatTrans.naturality_comp
 
-/- Porting note: removed primes from field names and removed `restate_axiom` since that is no longer
-  needed in Lean 4 -/
-
 attribute [reassoc (attr := simp)] OplaxNatTrans.naturality_naturality OplaxNatTrans.naturality_id
   OplaxNatTrans.naturality_comp
 

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -172,10 +172,6 @@ class Category (obj : Type u) extends CategoryStruct.{v} obj : Type max u (v + 1
 #align category_theory.category.comp_id CategoryTheory.Category.comp_id
 #align category_theory.category.id_comp CategoryTheory.Category.id_comp
 
--- Porting note: `restate_axiom` should not be necessary in lean4
--- Hopefully we can just remove the backticks from field names,
--- then delete the invocation of `restate_axiom`.
-
 attribute [simp] Category.id_comp Category.comp_id Category.assoc
 attribute [trans] CategoryStruct.comp
 

--- a/Mathlib/CategoryTheory/Endofunctor/Algebra.lean
+++ b/Mathlib/CategoryTheory/Endofunctor/Algebra.lean
@@ -68,10 +68,6 @@ structure Hom (A₀ A₁ : Algebra F) where
   h : F.map f ≫ A₁.str = A₀.str ≫ f := by aesop_cat
 #align category_theory.endofunctor.algebra.hom CategoryTheory.Endofunctor.Algebra.Hom
 
--- Porting note: No need to restate axiom
--- restate_axiom Hom.h'
-
--- Porting note: Originally `[simp, reassoc.1]`
 attribute [reassoc (attr := simp)] Hom.h
 
 namespace Hom
@@ -291,10 +287,6 @@ structure Hom (V₀ V₁ : Coalgebra F) where
   h : V₀.str ≫ F.map f = f ≫ V₁.str := by aesop_cat
 #align category_theory.endofunctor.coalgebra.hom CategoryTheory.Endofunctor.Coalgebra.Hom
 
--- Porting note: no need for restate_axiom any more
--- restate_axiom hom.h'
-
--- Porting note: Originally `[simp, reassoc.1]`
 attribute [reassoc (attr := simp)] Hom.h
 
 namespace Hom

--- a/Mathlib/CategoryTheory/Enriched/Basic.lean
+++ b/Mathlib/CategoryTheory/Enriched/Basic.lean
@@ -75,7 +75,6 @@ def eComp (X Y Z : C) : ((X ⟶[V] Y) ⊗ Y ⟶[V] Z) ⟶ X ⟶[V] Z :=
   EnrichedCategory.comp X Y Z
 #align category_theory.e_comp CategoryTheory.eComp
 
--- We don't just use `restate_axiom` here; that would leave `V` as an implicit argument.
 @[reassoc (attr := simp)]
 theorem e_id_comp (X Y : C) :
     (λ_ (X ⟶[V] Y)).inv ≫ eId V X ▷ _ ≫ eComp V X X Y = 𝟙 (X ⟶[V] Y) :=

--- a/Mathlib/CategoryTheory/Monad/Algebra.lean
+++ b/Mathlib/CategoryTheory/Monad/Algebra.lean
@@ -56,12 +56,6 @@ set_option linter.uppercaseLean3 false in
 #align category_theory.monad.algebra.unit CategoryTheory.Monad.Algebra.unit
 #align category_theory.monad.algebra.assoc CategoryTheory.Monad.Algebra.assoc
 
--- Porting note: no need to restate axioms in lean4.
-
---restate_axiom algebra.unit'
-
---restate_axiom algebra.assoc'
-
 attribute [reassoc] Algebra.unit Algebra.assoc
 
 namespace Algebra

--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -96,7 +96,6 @@ structure LaxMonoidalFunctor extends C ⥤ D where
 -- This may require waiting on https://github.com/leanprover-community/mathlib4/pull/2936
 initialize_simps_projections LaxMonoidalFunctor (+toFunctor, -obj, -map)
 
--- Porting note: was `[simp, reassoc.1]`
 attribute [reassoc (attr := simp)] LaxMonoidalFunctor.μ_natural_left
 attribute [reassoc (attr := simp)] LaxMonoidalFunctor.μ_natural_right
 
@@ -104,7 +103,6 @@ attribute [simp] LaxMonoidalFunctor.left_unitality
 
 attribute [simp] LaxMonoidalFunctor.right_unitality
 
--- Porting note: was `[simp, reassoc.1]`
 attribute [reassoc (attr := simp)] LaxMonoidalFunctor.associativity
 
 -- When `rewrite_search` lands, add @[search] attributes to
@@ -165,7 +163,6 @@ def LaxMonoidalFunctor.ofTensorHom (F : C ⥤ D)
   right_unitality := fun X => by
     simp_rw [← id_tensorHom, right_unitality]
 
--- Porting note: was `[simp, reassoc.1]`
 @[reassoc (attr := simp)]
 theorem LaxMonoidalFunctor.left_unitality_inv (F : LaxMonoidalFunctor C D) (X : C) :
     (λ_ (F.obj X)).inv ≫ F.ε ▷ F.obj X ≫ F.μ (𝟙_ C) X = F.map (λ_ X).inv := by
@@ -173,7 +170,6 @@ theorem LaxMonoidalFunctor.left_unitality_inv (F : LaxMonoidalFunctor C D) (X : 
     Iso.hom_inv_id, F.toFunctor.map_id, comp_id]
 #align category_theory.lax_monoidal_functor.left_unitality_inv CategoryTheory.LaxMonoidalFunctor.left_unitality_inv
 
--- Porting note: was `[simp, reassoc.1]`
 @[reassoc (attr := simp)]
 theorem LaxMonoidalFunctor.right_unitality_inv (F : LaxMonoidalFunctor C D) (X : C) :
     (ρ_ (F.obj X)).inv ≫ F.obj X ◁ F.ε ≫ F.μ X (𝟙_ C) = F.map (ρ_ X).inv := by
@@ -181,7 +177,6 @@ theorem LaxMonoidalFunctor.right_unitality_inv (F : LaxMonoidalFunctor C D) (X :
     Iso.hom_inv_id, F.toFunctor.map_id, comp_id]
 #align category_theory.lax_monoidal_functor.right_unitality_inv CategoryTheory.LaxMonoidalFunctor.right_unitality_inv
 
--- Porting note: was `[simp, reassoc.1]`
 @[reassoc (attr := simp)]
 theorem LaxMonoidalFunctor.associativity_inv (F : LaxMonoidalFunctor C D) (X Y Z : C) :
     F.obj X ◁ F.μ Y Z ≫ F.μ X (Y ⊗ Z) ≫ F.map (α_ X Y Z).inv =
@@ -302,7 +297,6 @@ theorem μIso_hom (X Y : C) : (F.μIso X Y).hom = F.μ X Y :=
   rfl
 #align category_theory.monoidal_functor.μ_iso_hom CategoryTheory.MonoidalFunctor.μIso_hom
 
--- Porting note: was `[simp, reassoc.1]`
 @[reassoc (attr := simp)]
 theorem μ_inv_hom_id (X Y : C) : (F.μIso X Y).inv ≫ F.μ X Y = 𝟙 _ :=
   (F.μIso X Y).inv_hom_id
@@ -318,7 +312,6 @@ theorem εIso_hom : F.εIso.hom = F.ε :=
   rfl
 #align category_theory.monoidal_functor.ε_iso_hom CategoryTheory.MonoidalFunctor.εIso_hom
 
--- Porting note: was `[simp, reassoc.1]`
 @[reassoc (attr := simp)]
 theorem ε_inv_hom_id : F.εIso.inv ≫ F.ε = 𝟙 _ :=
   F.εIso.inv_hom_id


### PR DESCRIPTION
As noted by @semorrison early in the port:  `restate_axiom` should not be necessary in lean4. Hopefully we can just remove the backticks from field names, then delete the invocation of `restate_axiom`. We delete these references to `restate_axiom` in this PR. We also delete porting notes which just note that `reassoc` syntax is different in lean4.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
