### PR TITLE
[Merged by Bors] - feat: Corners, corner-free sets

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1620,6 +1620,7 @@ import Mathlib.CategoryTheory.WithTerminal
 import Mathlib.CategoryTheory.Yoneda
 import Mathlib.Combinatorics.Additive.AP.Three.Behrend
 import Mathlib.Combinatorics.Additive.AP.Three.Defs
+import Mathlib.Combinatorics.Additive.Corner.Defs
 import Mathlib.Combinatorics.Additive.ETransform
 import Mathlib.Combinatorics.Additive.Energy
 import Mathlib.Combinatorics.Additive.FreimanHom

--- a/Mathlib/Combinatorics/Additive/Corner/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Defs.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Combinatorics.Additive.FreimanHom
+
+/-!
+# Corners
+
+This file defines corners, namely triples of the form `(x, y), (x, y + d), (x + d, y)`, and the
+property of being corner-free the corners theorem and Roth's theorem.
+
+## References
+
+* [Yaël Dillies, Bhavik Mehta, *Formalising Szemerédi’s Regularity Lemma in Lean*][srl_itp]
+* [Wikipedia, *Corners theorem*](https://en.wikipedia.org/wiki/Corners_theorem)
+-/
+
+open Set
+
+variable {G H : Type*}
+
+section AddCommMonoid
+variable [AddCommMonoid G] [AddCommMonoid H] {A B : Set (G × G)} {s : Set G} {t : Set H} {f : G → H}
+  {a b c x₁ y₁ x₂ y₂ : G}
+
+/-- A **corner** of a set `A` in an abelian group is a triple of points of the form
+`(x, y), (x + d, y), (x, y + d)`. It is **nontrivial** if `d ≠ 0`.
+
+Here we define it as triples `(x₁, y₁), (x₂, y₁), (x₁, y₂)` where `x₁ + y₂ = x₂ + y₁` in order for
+the definition to make sense in `ℕ`. -/
+@[mk_iff]
+structure IsCorner (A : Set (G × G)) (x₁ y₁ x₂ y₂ : G) : Prop where
+  fst_fst_mem : (x₁, y₁) ∈ A
+  fst_snd_mem : (x₁, y₂) ∈ A
+  snd_fst_mem : (x₂, y₁) ∈ A
+  add_eq_add : x₁ + y₂ = x₂ + y₁
+
+/-- A **corner-free set** in an abelian group is a set containing no non-trivial corner. -/
+def IsCornerFree (A : Set (G × G)) : Prop := ∀ ⦃x₁ y₁ x₂ y₂⦄, IsCorner A x₁ y₁ x₂ y₂ → x₁ = x₂
+
+/-- A convenient restatement of corner-freeness in terms of an ambient product set. -/
+lemma isCornerFree_iff (hAs : A ⊆ s ×ˢ s) :
+    IsCornerFree A ↔ ∀ ⦃x₁⦄, x₁ ∈ s → ∀ ⦃y₁⦄, y₁ ∈ s → ∀ ⦃x₂⦄, x₂ ∈ s → ∀ ⦃y₂⦄, y₂ ∈ s →
+      IsCorner A x₁ y₁ x₂ y₂ → x₁ = x₂ where
+  mp hA _x₁ _ _y₁ _ _x₂ _ _y₂ _ hxy := hA hxy
+  mpr hA _x₁ _y₁ _x₂ _y₂ hxy := hA (hAs hxy.fst_fst_mem).1 (hAs hxy.fst_fst_mem).2
+    (hAs hxy.snd_fst_mem).1 (hAs hxy.fst_snd_mem).2 hxy
+
+lemma IsCorner.mono (hAB : A ⊆ B) (hA : IsCorner A x₁ y₁ x₂ y₂) : IsCorner B x₁ y₁ x₂ y₂ where
+  fst_fst_mem := hAB hA.fst_fst_mem
+  fst_snd_mem := hAB hA.fst_snd_mem
+  snd_fst_mem := hAB hA.snd_fst_mem
+  add_eq_add := hA.add_eq_add
+
+lemma IsCornerFree.mono (hst : A ⊆ B) (ht : IsCornerFree B) : IsCornerFree A :=
+  fun _x₁ _y₁ _x₂ _y₂ hxyd ↦ ht $ hxyd.mono hst
+
+@[simp] lemma not_isCorner_empty : ¬ IsCorner ∅ x₁ y₁ x₂ y₂ := by simp [isCorner_iff]
+@[simp] lemma isCornerFree_empty : IsCornerFree (∅ : Set (G × G)) := by simp [IsCornerFree]
+
+/-- Corners are preserved under `2`-Freiman homomorphisms. --/
+lemma IsCorner.image (hf : IsAddFreimanHom 2 s t f) (hAs : (A : Set (G × G)) ⊆ s ×ˢ s)
+    (hA : IsCorner A x₁ y₁ x₂ y₂) : IsCorner (Prod.map f f '' A) (f x₁) (f y₁) (f x₂) (f y₂) := by
+  obtain ⟨hx₁y₁, hx₁y₂, hx₂y₁, hxy⟩ := hA
+  exact ⟨mem_image_of_mem _ hx₁y₁, mem_image_of_mem _ hx₁y₂, mem_image_of_mem _ hx₂y₁,
+    hf.add_eq_add (hAs hx₁y₁).1 (hAs hx₁y₂).2 (hAs hx₂y₁).1 (hAs hx₁y₁).2 hxy⟩
+
+/-- Corners are preserved under `2`-Freiman homomorphisms. --/
+lemma IsCornerFree.of_image (hf : IsAddFreimanHom 2 s t f) (hf' : s.InjOn f)
+    (hAs : (A : Set (G × G)) ⊆ s ×ˢ s) (hA : IsCornerFree (Prod.map f f '' A)) : IsCornerFree A :=
+  fun _x₁ _y₁ _x₂ _y₂ hxy ↦
+    hf' (hAs hxy.fst_fst_mem).1 (hAs hxy.snd_fst_mem).1 $ hA $ hxy.image hf hAs
+
+lemma isCorner_image (hf : IsAddFreimanIso 2 s t f) (hAs : A ⊆ s ×ˢ s)
+    (hx₁ : x₁ ∈ s) (hy₁ : y₁ ∈ s) (hx₂ : x₂ ∈ s) (hy₂ : y₂ ∈ s) :
+    IsCorner (Prod.map f f '' A) (f x₁) (f y₁) (f x₂) (f y₂) ↔ IsCorner A x₁ y₁ x₂ y₂ := by
+  have hf' := hf.bijOn.injOn.prodMap hf.bijOn.injOn
+  rw [isCorner_iff, isCorner_iff]
+  congr!
+  · exact hf'.mem_image_iff hAs (mk_mem_prod hx₁ hy₁)
+  · exact hf'.mem_image_iff hAs (mk_mem_prod hx₁ hy₂)
+  · exact hf'.mem_image_iff hAs (mk_mem_prod hx₂ hy₁)
+  · exact hf.add_eq_add hx₁ hy₂ hx₂ hy₁
+
+lemma isCornerFree_image (hf : IsAddFreimanIso 2 s t f) (hAs : A ⊆ s ×ˢ s) :
+    IsCornerFree (Prod.map f f '' A) ↔ IsCornerFree A := by
+  have : Prod.map f f '' A ⊆ t ×ˢ t :=
+    ((hf.bijOn.mapsTo.prodMap hf.bijOn.mapsTo).mono hAs Subset.rfl).image_subset
+  rw [isCornerFree_iff hAs, isCornerFree_iff this]
+  simp (config := { contextual := true }) only
+    [hf.bijOn.forall, isCorner_image hf hAs, hf.bijOn.injOn.eq_iff]
+
+alias ⟨IsCorner.of_image, _⟩ := isCorner_image
+alias ⟨_, IsCornerFree.image⟩ := isCornerFree_image
+
+end AddCommMonoid

--- a/Mathlib/Combinatorics/Additive/Corner/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Defs.lean
@@ -29,7 +29,7 @@ variable [AddCommMonoid G] [AddCommMonoid H] {A B : Set (G × G)} {s : Set G} {t
 `(x, y), (x + d, y), (x, y + d)`. It is **nontrivial** if `d ≠ 0`.
 
 Here we define it as triples `(x₁, y₁), (x₂, y₁), (x₁, y₂)` where `x₁ + y₂ = x₂ + y₁` in order for
-the definition to make sense in `ℕ`. -/
+the definition to make sense in commutative monoids, the motivating example being `ℕ`. -/
 @[mk_iff]
 structure IsCorner (A : Set (G × G)) (x₁ y₁ x₂ y₂ : G) : Prop where
   fst_fst_mem : (x₁, y₁) ∈ A
@@ -54,11 +54,17 @@ lemma IsCorner.mono (hAB : A ⊆ B) (hA : IsCorner A x₁ y₁ x₂ y₂) : IsCo
   snd_fst_mem := hAB hA.snd_fst_mem
   add_eq_add := hA.add_eq_add
 
-lemma IsCornerFree.mono (hst : A ⊆ B) (ht : IsCornerFree B) : IsCornerFree A :=
-  fun _x₁ _y₁ _x₂ _y₂ hxyd ↦ ht $ hxyd.mono hst
+lemma IsCornerFree.mono (hAB : A ⊆ B) (hB : IsCornerFree B) : IsCornerFree A :=
+  fun _x₁ _y₁ _x₂ _y₂ hxyd ↦ hB $ hxyd.mono hAB
 
 @[simp] lemma not_isCorner_empty : ¬ IsCorner ∅ x₁ y₁ x₂ y₂ := by simp [isCorner_iff]
-@[simp] lemma isCornerFree_empty : IsCornerFree (∅ : Set (G × G)) := by simp [IsCornerFree]
+
+@[simp] lemma Set.Subsingleton.isCornerFree (hA : A.Subsingleton) : IsCornerFree A :=
+  fun _x₁ _y₁ _x₂ _y₂ hxyd ↦ by simpa using hA hxyd.fst_fst_mem hxyd.snd_fst_mem
+
+@[simp] lemma isCornerFree_empty : IsCornerFree (∅ : Set (G × G)) := subsingleton_empty.isCornerFree
+@[simp] lemma isCornerFree_singleton (x : G × G) : IsCornerFree {x} :=
+  subsingleton_singleton.isCornerFree
 
 /-- Corners are preserved under `2`-Freiman homomorphisms. --/
 lemma IsCorner.image (hf : IsAddFreimanHom 2 s t f) (hAs : (A : Set (G × G)) ⊆ s ×ˢ s)

--- a/Mathlib/Combinatorics/Additive/Corner/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Defs.lean
@@ -62,9 +62,8 @@ lemma IsCornerFree.mono (hAB : A ⊆ B) (hB : IsCornerFree B) : IsCornerFree A :
 @[simp] lemma Set.Subsingleton.isCornerFree (hA : A.Subsingleton) : IsCornerFree A :=
   fun _x₁ _y₁ _x₂ _y₂ hxyd ↦ by simpa using hA hxyd.fst_fst_mem hxyd.snd_fst_mem
 
-@[simp] lemma isCornerFree_empty : IsCornerFree (∅ : Set (G × G)) := subsingleton_empty.isCornerFree
-@[simp] lemma isCornerFree_singleton (x : G × G) : IsCornerFree {x} :=
-  subsingleton_singleton.isCornerFree
+lemma isCornerFree_empty : IsCornerFree (∅ : Set (G × G)) := subsingleton_empty.isCornerFree
+lemma isCornerFree_singleton (x : G × G) : IsCornerFree {x} := subsingleton_singleton.isCornerFree
 
 /-- Corners are preserved under `2`-Freiman homomorphisms. --/
 lemma IsCorner.image (hf : IsAddFreimanHom 2 s t f) (hAs : (A : Set (G × G)) ⊆ s ×ˢ s)


### PR DESCRIPTION
For `G` a commutative monoid and a set `A` in `G × G` , define corners of `A` as solutions to `x₁ + y₂ = x₂ + y₁` where `(x₁, y₁) ∈ A, (x₁, y₂) ∈ A, (x₂, y₁) ∈ A`.

Define corner-free sets as sets containing no non-trivial corners.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
