### PR TITLE
[Merged by Bors] - chore(Algebra/Lie/*): rename toEndomorphism to toEnd

### DIFF
--- a/Mathlib/Algebra/Lie/Abelian.lean
+++ b/Mathlib/Algebra/Lie/Abelian.lean
@@ -107,13 +107,13 @@ namespace LieModule
 
 /-- The kernel of the action of a Lie algebra `L` on a Lie module `M` as a Lie ideal in `L`. -/
 protected def ker : LieIdeal R L :=
-  (toEndomorphism R L M).ker
+  (toEnd R L M).ker
 #align lie_module.ker LieModule.ker
 
 @[simp]
 protected theorem mem_ker (x : L) : x ∈ LieModule.ker R L M ↔ ∀ m : M, ⁅x, m⁆ = 0 := by
   simp only [LieModule.ker, LieHom.mem_ker, LinearMap.ext_iff, LinearMap.zero_apply,
-    toEndomorphism_apply_apply]
+    toEnd_apply_apply]
 #align lie_module.mem_ker LieModule.mem_ker
 
 /-- The largest submodule of a Lie module `M` on which the Lie algebra `L` acts trivially. -/
@@ -287,13 +287,13 @@ namespace LieModule
 variable {R L}
 variable {x : L} (hx : x ∈ LieAlgebra.center R L) (y : L)
 
-lemma commute_toEndomorphism_of_mem_center_left :
-    Commute (toEndomorphism R L M x) (toEndomorphism R L M y) := by
+lemma commute_toEnd_of_mem_center_left :
+    Commute (toEnd R L M x) (toEnd R L M y) := by
   rw [Commute.symm_iff, commute_iff_lie_eq, ← LieHom.map_lie, hx y, LieHom.map_zero]
 
-lemma commute_toEndomorphism_of_mem_center_right :
-    Commute (toEndomorphism R L M y) (toEndomorphism R L M x) :=
-  (LieModule.commute_toEndomorphism_of_mem_center_left M hx y).symm
+lemma commute_toEnd_of_mem_center_right :
+    Commute (toEnd R L M y) (toEnd R L M x) :=
+  (LieModule.commute_toEnd_of_mem_center_left M hx y).symm
 
 end LieModule
 

--- a/Mathlib/Algebra/Lie/BaseChange.lean
+++ b/Mathlib/Algebra/Lie/BaseChange.lean
@@ -153,8 +153,8 @@ variable [CommRing R] [LieRing L] [LieAlgebra R L]
   [CommRing A] [Algebra R A]
 
 @[simp]
-lemma LieModule.toEndomorphism_baseChange (x : L) :
-    toEndomorphism A (A ⊗[R] L) (A ⊗[R] M) (1 ⊗ₜ x) = (toEndomorphism R L M x).baseChange A := by
+lemma LieModule.toEnd_baseChange (x : L) :
+    toEnd A (A ⊗[R] L) (A ⊗[R] M) (1 ⊗ₜ x) = (toEnd R L M x).baseChange A := by
   ext; simp
 
 namespace LieSubmodule
@@ -176,8 +176,8 @@ def baseChange : LieSubmodule A (A ⊗[R] L) (A ⊗[R] M) :=
         Submodule.mem_toAddSubmonoid] at hm ⊢
       obtain ⟨c, rfl⟩ := (Finsupp.mem_span_iff_total _ _ _).mp hm
       refine x.induction_on (by simp) (fun a y ↦ ?_) (fun y z hy hz ↦ ?_)
-      · change toEndomorphism A (A ⊗[R] L) (A ⊗[R] M) _ _ ∈ _
-        simp_rw [Finsupp.total_apply, Finsupp.sum, map_sum, map_smul, toEndomorphism_apply_apply]
+      · change toEnd A (A ⊗[R] L) (A ⊗[R] M) _ _ ∈ _
+        simp_rw [Finsupp.total_apply, Finsupp.sum, map_sum, map_smul, toEnd_apply_apply]
         suffices ∀ n : (N : Submodule R M).map (TensorProduct.mk R A M 1),
             ⁅a ⊗ₜ[R] y, (n : A ⊗[R] M)⁆ ∈ (N : Submodule R M).baseChange A by
           exact Submodule.sum_mem _ fun n _ ↦ Submodule.smul_mem _ _ (this n)

--- a/Mathlib/Algebra/Lie/CartanExists.lean
+++ b/Mathlib/Algebra/Lie/CartanExists.lean
@@ -66,7 +66,7 @@ variable (x y : L)
 
 open LieModule LinearMap
 
-local notation "φ" => LieModule.toEndomorphism R L M
+local notation "φ" => LieModule.toEnd R L M
 
 /-- Let `x` and `y` be elements of a Lie `R`-algebra `L`, and `M` a Lie module over `M`.
 Then the characteristic polynomials of the family of endomorphisms `⁅r • y + x, _⁆` of `M`
@@ -174,7 +174,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
     simp_rw [Polynomial.map_pow, map_X, χ, lieCharpoly_map_eval, one_smul, u, sub_add_cancel,
       -- and therefore the endomorphism `⁅y, _⁆` acts nilpotently on `E`.
       r, LinearMap.charpoly_eq_X_pow_iff,
-      Subtype.ext_iff, coe_toEndomorphism_pow, ZeroMemClass.coe_zero] at this
+      Subtype.ext_iff, coe_toEnd_pow, ZeroMemClass.coe_zero] at this
     -- We ultimately want to show `engel K x ≤ engel K y`
     intro z hz
     -- which holds by definition of Engel subalgebra and the nilpotency that we just established.
@@ -235,7 +235,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
       apply_fun (evalRingHom 0) at H
       rw [constantCoeff_apply, ← coeff_map, lieCharpoly_map_eval,
         ← constantCoeff_apply, map_zero, LinearMap.charpoly_constantCoeff_eq_zero_iff] at H
-      simpa only [coe_bracket_of_module, ne_eq, zero_smul, zero_add, toEndomorphism_apply_apply]
+      simpa only [coe_bracket_of_module, ne_eq, zero_smul, zero_add, toEnd_apply_apply]
         using H
     -- It suffices to show `z = 0` (in `Q`) to obtain a contradiction.
     apply hz0
@@ -301,7 +301,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
     replace this : engel K x ≤ engel K (v : L) := (hmin ⟨_, v, v.2, rfl⟩ this).ge
     intro z
     -- And so we are done, by the definition of Engel subalgebra.
-    simpa only [mem_engel_iff, Subtype.ext_iff, coe_toEndomorphism_pow] using this z.2
+    simpa only [mem_engel_iff, Subtype.ext_iff, coe_toEnd_pow] using this z.2
   -- Now we are in good shape.
   -- Fix an element `z` in the Engel subalgebra of `y`.
   intro z hz
@@ -311,7 +311,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
   -- We denote the image of `z` in `Q` by `z'`.
   set z' : Q := LieSubmodule.Quotient.mk' E z
   -- First we observe that `z'` is killed by a power of `⁅v, _⁆`.
-  have hz' : ∃ n : ℕ, (toEndomorphism K U Q v ^ n) z' = 0 := by
+  have hz' : ∃ n : ℕ, (toEnd K U Q v ^ n) z' = 0 := by
     rw [mem_engel_iff] at hz
     obtain ⟨n, hn⟩ := hz
     use n
@@ -325,7 +325,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
   classical
   -- Now let `n` be the smallest power such that `⁅v, _⁆ ^ n` kills `z'`.
   set n := Nat.find hz' with _hn
-  have hn : (toEndomorphism K U Q v ^ n) z' = 0 := Nat.find_spec hz'
+  have hn : (toEnd K U Q v ^ n) z' = 0 := Nat.find_spec hz'
   -- If `n = 0`, then we are done.
   obtain hn₀|⟨k, hk⟩ : n = 0 ∨ ∃ k, n = k + 1 := by cases n <;> simp
   · simpa only [hn₀, pow_zero, LinearMap.one_apply] using hn
@@ -338,7 +338,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
   -- We deduce from this that `z' = 0`, arguing by contraposition.
   contrapose! hsψ
   -- Indeed `⁅v, _⁆` kills `⁅v, _⁆ ^ k` applied to `z'`.
-  use (toEndomorphism K U Q v ^ k) z'
+  use (toEnd K U Q v ^ k) z'
   refine ⟨?_, ?_⟩
   · -- And `⁅v, _⁆ ^ k` applied to `z'` is non-zero by definition of `n`.
     apply Nat.find_min hz'; omega

--- a/Mathlib/Algebra/Lie/Derivation/Basic.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Basic.lean
@@ -327,7 +327,7 @@ variable (R L M : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]
 @[simps!]
 def inner : M →ₗ[R] LieDerivation R L M where
   toFun m :=
-    { __ := (LieModule.toEndomorphism R L M : L →ₗ[R] Module.End R M).flip m
+    { __ := (LieModule.toEnd R L M : L →ₗ[R] Module.End R M).flip m
       leibniz' := by simp }
   map_add' m n := by ext; simp
   map_smul' t m := by ext; simp

--- a/Mathlib/Algebra/Lie/Engel.lean
+++ b/Mathlib/Algebra/Lie/Engel.lean
@@ -88,9 +88,9 @@ theorem exists_smul_add_of_span_sup_eq_top (y : L) : ∃ t : R, ∃ z ∈ I, y =
 
 theorem lie_top_eq_of_span_sup_eq_top (N : LieSubmodule R L M) :
     (↑⁅(⊤ : LieIdeal R L), N⁆ : Submodule R M) =
-      (N : Submodule R M).map (toEndomorphism R L M x) ⊔ (↑⁅I, N⁆ : Submodule R M) := by
+      (N : Submodule R M).map (toEnd R L M x) ⊔ (↑⁅I, N⁆ : Submodule R M) := by
   simp only [lieIdeal_oper_eq_linear_span', Submodule.sup_span, mem_top, exists_prop,
-    true_and, Submodule.map_coe, toEndomorphism_apply_apply]
+    true_and, Submodule.map_coe, toEnd_apply_apply]
   refine' le_antisymm (Submodule.span_le.mpr _) (Submodule.span_mono fun z hz => _)
   · rintro z ⟨y, n, hn : n ∈ N, rfl⟩
     obtain ⟨t, z, hz, rfl⟩ := exists_smul_add_of_span_sup_eq_top hxI y
@@ -103,12 +103,12 @@ theorem lie_top_eq_of_span_sup_eq_top (N : LieSubmodule R L M) :
 #align lie_submodule.lie_top_eq_of_span_sup_eq_top LieSubmodule.lie_top_eq_of_span_sup_eq_top
 
 theorem lcs_le_lcs_of_is_nilpotent_span_sup_eq_top {n i j : ℕ}
-    (hxn : toEndomorphism R L M x ^ n = 0) (hIM : lowerCentralSeries R L M i ≤ I.lcs M j) :
+    (hxn : toEnd R L M x ^ n = 0) (hIM : lowerCentralSeries R L M i ≤ I.lcs M j) :
     lowerCentralSeries R L M (i + n) ≤ I.lcs M (j + 1) := by
   suffices
     ∀ l,
       ((⊤ : LieIdeal R L).lcs M (i + l) : Submodule R M) ≤
-        (I.lcs M j : Submodule R M).map (toEndomorphism R L M x ^ l) ⊔
+        (I.lcs M j : Submodule R M).map (toEnd R L M x ^ l) ⊔
           (I.lcs M (j + 1) : Submodule R M)
     by simpa only [bot_sup_eq, LieIdeal.incl_coe, Submodule.map_zero, hxn] using this n
   intro l
@@ -120,12 +120,12 @@ theorem lcs_le_lcs_of_is_nilpotent_span_sup_eq_top {n i j : ℕ}
     refine' ⟨(Submodule.map_mono ih).trans _, le_sup_of_le_right _⟩
     · rw [Submodule.map_sup, ← Submodule.map_comp, ← LinearMap.mul_eq_comp, ← pow_succ', ←
         I.lcs_succ]
-      exact sup_le_sup_left coe_map_toEndomorphism_le _
+      exact sup_le_sup_left coe_map_toEnd_le _
     · refine' le_trans (mono_lie_right _ _ I _) (mono_lie_right _ _ I hIM)
       exact antitone_lowerCentralSeries R L M le_self_add
 #align lie_submodule.lcs_le_lcs_of_is_nilpotent_span_sup_eq_top LieSubmodule.lcs_le_lcs_of_is_nilpotent_span_sup_eq_top
 
-theorem isNilpotentOfIsNilpotentSpanSupEqTop (hnp : IsNilpotent <| toEndomorphism R L M x)
+theorem isNilpotentOfIsNilpotentSpanSupEqTop (hnp : IsNilpotent <| toEnd R L M x)
     (hIM : IsNilpotent R I M) : IsNilpotent R L M := by
   obtain ⟨n, hn⟩ := hnp
   obtain ⟨k, hk⟩ := hIM
@@ -157,7 +157,7 @@ Engel's theorem `LieAlgebra.isEngelian_of_isNoetherian` states that any Noetheri
 Engelian. -/
 def LieAlgebra.IsEngelian : Prop :=
   ∀ (M : Type u₄) [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M],
-    (∀ x : L, _root_.IsNilpotent (toEndomorphism R L M x)) → LieModule.IsNilpotent R L M
+    (∀ x : L, _root_.IsNilpotent (toEnd R L M x)) → LieModule.IsNilpotent R L M
 #align lie_algebra.is_engelian LieAlgebra.IsEngelian
 
 variable {R L}
@@ -175,7 +175,7 @@ theorem Function.Surjective.isEngelian {f : L →ₗ⁅R⁆ L₂} (hf : Function
   intro M _i1 _i2 _i3 _i4 h'
   letI : LieRingModule L M := LieRingModule.compLieHom M f
   letI : LieModule R L M := compLieHom M f
-  have hnp : ∀ x, IsNilpotent (toEndomorphism R L M x) := fun x => h' (f x)
+  have hnp : ∀ x, IsNilpotent (toEnd R L M x) := fun x => h' (f x)
   have surj_id : Function.Surjective (LinearMap.id : M →ₗ[R] M) := Function.surjective_id
   haveI : LieModule.IsNilpotent R L M := h M hnp
   apply hf.lieModuleIsNilpotent surj_id
@@ -225,8 +225,8 @@ Note that this implies all traditional forms of Engel's theorem via
 `LieAlgebra.isNilpotent_iff_forall`. -/
 theorem LieAlgebra.isEngelian_of_isNoetherian [IsNoetherian R L] : LieAlgebra.IsEngelian R L := by
   intro M _i1 _i2 _i3 _i4 h
-  rw [← isNilpotent_range_toEndomorphism_iff]
-  let L' := (toEndomorphism R L M).range
+  rw [← isNilpotent_range_toEnd_iff]
+  let L' := (toEnd R L M).range
   replace h : ∀ y : L', _root_.IsNilpotent (y : Module.End R M) := by
     rintro ⟨-, ⟨y, rfl⟩⟩
     simp [h]
@@ -236,7 +236,7 @@ theorem LieAlgebra.isEngelian_of_isNoetherian [IsNoetherian R L] : LieAlgebra.Is
   suffices ⊤ ∈ s by
     rw [← isNilpotent_of_top_iff]
     apply this M
-    simp [LieSubalgebra.toEndomorphism_eq, h]
+    simp [LieSubalgebra.toEnd_eq, h]
   have : ∀ K ∈ s, K ≠ ⊤ → ∃ K' ∈ s, K < K' := by
     rintro K (hK₁ : LieAlgebra.IsEngelian R K) hK₂
     apply LieAlgebra.exists_engelian_lieSubalgebra_of_lt_normalizer hK₁
@@ -264,11 +264,11 @@ theorem LieAlgebra.isEngelian_of_isNoetherian [IsNoetherian R L] : LieAlgebra.Is
     exact nontrivial_max_triv_of_isNilpotent R K (L' ⧸ K.toLieSubmodule)
   haveI _i5 : IsNoetherian R L' := by
     -- Porting note: was
-    -- isNoetherian_of_surjective L _ (LinearMap.range_rangeRestrict (toEndomorphism R L M))
+    -- isNoetherian_of_surjective L _ (LinearMap.range_rangeRestrict (toEnd R L M))
     -- abusing the relation between `LieHom.rangeRestrict` and `LinearMap.rangeRestrict`
-    refine isNoetherian_of_surjective L (LieHom.rangeRestrict (toEndomorphism R L M)) ?_
+    refine isNoetherian_of_surjective L (LieHom.rangeRestrict (toEnd R L M)) ?_
     simp only [LieHom.range_coeSubmodule, LieHom.coe_toLinearMap, LinearMap.range_eq_top]
-    exact LieHom.surjective_rangeRestrict (toEndomorphism R L M)
+    exact LieHom.surjective_rangeRestrict (toEnd R L M)
   obtain ⟨K, hK₁, hK₂⟩ := (LieSubalgebra.wellFounded_of_noetherian R L').has_min s hs
   have hK₃ : K = ⊤ := by
     by_contra contra
@@ -281,15 +281,15 @@ theorem LieAlgebra.isEngelian_of_isNoetherian [IsNoetherian R L] : LieAlgebra.Is
 
 See also `LieModule.isNilpotent_iff_forall'` which assumes that `M` is Noetherian instead of `L`. -/
 theorem LieModule.isNilpotent_iff_forall [IsNoetherian R L] :
-    LieModule.IsNilpotent R L M ↔ ∀ x, _root_.IsNilpotent <| toEndomorphism R L M x :=
-  ⟨fun _ ↦ isNilpotent_toEndomorphism_of_isNilpotent R L M,
+    LieModule.IsNilpotent R L M ↔ ∀ x, _root_.IsNilpotent <| toEnd R L M x :=
+  ⟨fun _ ↦ isNilpotent_toEnd_of_isNilpotent R L M,
    fun h => LieAlgebra.isEngelian_of_isNoetherian M h⟩
 #align lie_module.is_nilpotent_iff_forall LieModule.isNilpotent_iff_forall
 
 /-- Engel's theorem. -/
 theorem LieModule.isNilpotent_iff_forall' [IsNoetherian R M] :
-    LieModule.IsNilpotent R L M ↔ ∀ x, _root_.IsNilpotent <| toEndomorphism R L M x := by
-  rw [← isNilpotent_range_toEndomorphism_iff, LieModule.isNilpotent_iff_forall]; simp
+    LieModule.IsNilpotent R L M ↔ ∀ x, _root_.IsNilpotent <| toEnd R L M x := by
+  rw [← isNilpotent_range_toEnd_iff, LieModule.isNilpotent_iff_forall]; simp
 
 /-- Engel's theorem. -/
 theorem LieAlgebra.isNilpotent_iff_forall [IsNoetherian R L] :

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -163,23 +163,23 @@ theorem trivial_iff_lower_central_eq_bot : IsTrivial L M ↔ lowerCentralSeries 
     exact ⟨x, m, rfl⟩
 #align lie_module.trivial_iff_lower_central_eq_bot LieModule.trivial_iff_lower_central_eq_bot
 
-theorem iterate_toEndomorphism_mem_lowerCentralSeries (x : L) (m : M) (k : ℕ) :
-    (toEndomorphism R L M x)^[k] m ∈ lowerCentralSeries R L M k := by
+theorem iterate_toEnd_mem_lowerCentralSeries (x : L) (m : M) (k : ℕ) :
+    (toEnd R L M x)^[k] m ∈ lowerCentralSeries R L M k := by
   induction' k with k ih
   · simp only [Nat.zero_eq, Function.iterate_zero, lowerCentralSeries_zero, LieSubmodule.mem_top]
   · simp only [lowerCentralSeries_succ, Function.comp_apply, Function.iterate_succ',
-      toEndomorphism_apply_apply]
+      toEnd_apply_apply]
     exact LieSubmodule.lie_mem_lie _ _ (LieSubmodule.mem_top x) ih
-#align lie_module.iterate_to_endomorphism_mem_lower_central_series LieModule.iterate_toEndomorphism_mem_lowerCentralSeries
+#align lie_module.iterate_to_endomorphism_mem_lower_central_series LieModule.iterate_toEnd_mem_lowerCentralSeries
 
-theorem iterate_toEndomorphism_mem_lowerCentralSeries₂ (x y : L) (m : M) (k : ℕ) :
-    (toEndomorphism R L M x ∘ₗ toEndomorphism R L M y)^[k] m ∈
+theorem iterate_toEnd_mem_lowerCentralSeries₂ (x y : L) (m : M) (k : ℕ) :
+    (toEnd R L M x ∘ₗ toEnd R L M y)^[k] m ∈
       lowerCentralSeries R L M (2 * k) := by
   induction' k with k ih
   · simp
   have hk : 2 * k.succ = (2 * k + 1) + 1 := rfl
   simp only [lowerCentralSeries_succ, Function.comp_apply, Function.iterate_succ', hk,
-      toEndomorphism_apply_apply, LinearMap.coe_comp, toEndomorphism_apply_apply]
+      toEnd_apply_apply, LinearMap.coe_comp, toEnd_apply_apply]
   refine' LieSubmodule.lie_mem_lie _ _ (LieSubmodule.mem_top x) _
   exact LieSubmodule.lie_mem_lie _ _ (LieSubmodule.mem_top y) ih
 
@@ -252,37 +252,37 @@ instance (priority := 100) trivialIsNilpotent [IsTrivial L M] : IsNilpotent R L 
   ⟨by use 1; change ⁅⊤, ⊤⁆ = ⊥; simp⟩
 #align lie_module.trivial_is_nilpotent LieModule.trivialIsNilpotent
 
-theorem exists_forall_pow_toEndomorphism_eq_zero [hM : IsNilpotent R L M] :
-    ∃ k : ℕ, ∀ x : L, toEndomorphism R L M x ^ k = 0 := by
+theorem exists_forall_pow_toEnd_eq_zero [hM : IsNilpotent R L M] :
+    ∃ k : ℕ, ∀ x : L, toEnd R L M x ^ k = 0 := by
   obtain ⟨k, hM⟩ := hM
   use k
   intro x; ext m
   rw [LinearMap.pow_apply, LinearMap.zero_apply, ← @LieSubmodule.mem_bot R L M, ← hM]
-  exact iterate_toEndomorphism_mem_lowerCentralSeries R L M x m k
-#align lie_module.nilpotent_endo_of_nilpotent_module LieModule.exists_forall_pow_toEndomorphism_eq_zero
+  exact iterate_toEnd_mem_lowerCentralSeries R L M x m k
+#align lie_module.nilpotent_endo_of_nilpotent_module LieModule.exists_forall_pow_toEnd_eq_zero
 
-theorem isNilpotent_toEndomorphism_of_isNilpotent [IsNilpotent R L M] (x : L) :
-    _root_.IsNilpotent (toEndomorphism R L M x) := by
-  change ∃ k, toEndomorphism R L M x ^ k = 0
-  have := exists_forall_pow_toEndomorphism_eq_zero R L M
+theorem isNilpotent_toEnd_of_isNilpotent [IsNilpotent R L M] (x : L) :
+    _root_.IsNilpotent (toEnd R L M x) := by
+  change ∃ k, toEnd R L M x ^ k = 0
+  have := exists_forall_pow_toEnd_eq_zero R L M
   tauto
 
-theorem isNilpotent_toEndomorphism_of_isNilpotent₂ [IsNilpotent R L M] (x y : L) :
-    _root_.IsNilpotent (toEndomorphism R L M x ∘ₗ toEndomorphism R L M y) := by
+theorem isNilpotent_toEnd_of_isNilpotent₂ [IsNilpotent R L M] (x y : L) :
+    _root_.IsNilpotent (toEnd R L M x ∘ₗ toEnd R L M y) := by
   obtain ⟨k, hM⟩ := exists_lowerCentralSeries_eq_bot_of_isNilpotent R L M
   replace hM : lowerCentralSeries R L M (2 * k) = ⊥ := by
     rw [eq_bot_iff, ← hM]; exact antitone_lowerCentralSeries R L M (by omega)
   use k
   ext m
   rw [LinearMap.pow_apply, LinearMap.zero_apply, ← LieSubmodule.mem_bot (R := R) (L := L), ← hM]
-  exact iterate_toEndomorphism_mem_lowerCentralSeries₂ R L M x y m k
+  exact iterate_toEnd_mem_lowerCentralSeries₂ R L M x y m k
 
-@[simp] lemma maxGenEigenSpace_toEndomorphism_eq_top [IsNilpotent R L M] (x : L) :
-    ((toEndomorphism R L M x).maximalGeneralizedEigenspace 0) = ⊤ := by
+@[simp] lemma maxGenEigenSpace_toEnd_eq_top [IsNilpotent R L M] (x : L) :
+    ((toEnd R L M x).maximalGeneralizedEigenspace 0) = ⊤ := by
   ext m
   simp only [Module.End.mem_maximalGeneralizedEigenspace, zero_smul, sub_zero, Submodule.mem_top,
     iff_true]
-  obtain ⟨k, hk⟩ := exists_forall_pow_toEndomorphism_eq_zero R L M
+  obtain ⟨k, hk⟩ := exists_forall_pow_toEnd_eq_zero R L M
   exact ⟨k, by simp [hk x]⟩
 
 /-- If the quotient of a Lie module `M` by a Lie submodule on which the Lie algebra acts trivially
@@ -429,13 +429,13 @@ theorem nontrivial_max_triv_of_isNilpotent [Nontrivial M] [IsNilpotent R L M] :
 #align lie_module.nontrivial_max_triv_of_is_nilpotent LieModule.nontrivial_max_triv_of_isNilpotent
 
 @[simp]
-theorem coe_lcs_range_toEndomorphism_eq (k : ℕ) :
-    (lowerCentralSeries R (toEndomorphism R L M).range M k : Submodule R M) =
+theorem coe_lcs_range_toEnd_eq (k : ℕ) :
+    (lowerCentralSeries R (toEnd R L M).range M k : Submodule R M) =
       lowerCentralSeries R L M k := by
   induction' k with k ih
   · simp
   · simp only [lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span', ←
-      (lowerCentralSeries R (toEndomorphism R L M).range M k).mem_coeSubmodule, ih]
+      (lowerCentralSeries R (toEnd R L M).range M k).mem_coeSubmodule, ih]
     congr
     ext m
     constructor
@@ -443,16 +443,16 @@ theorem coe_lcs_range_toEndomorphism_eq (k : ℕ) :
       exact ⟨y, LieSubmodule.mem_top _, n, hn, rfl⟩
     · rintro ⟨x, -, n, hn, rfl⟩
       exact
-        ⟨⟨toEndomorphism R L M x, LieHom.mem_range_self _ x⟩, LieSubmodule.mem_top _, n, hn, rfl⟩
-#align lie_module.coe_lcs_range_to_endomorphism_eq LieModule.coe_lcs_range_toEndomorphism_eq
+        ⟨⟨toEnd R L M x, LieHom.mem_range_self _ x⟩, LieSubmodule.mem_top _, n, hn, rfl⟩
+#align lie_module.coe_lcs_range_to_endomorphism_eq LieModule.coe_lcs_range_toEnd_eq
 
 @[simp]
-theorem isNilpotent_range_toEndomorphism_iff :
-    IsNilpotent R (toEndomorphism R L M).range M ↔ IsNilpotent R L M := by
+theorem isNilpotent_range_toEnd_iff :
+    IsNilpotent R (toEnd R L M).range M ↔ IsNilpotent R L M := by
   constructor <;> rintro ⟨k, hk⟩ <;> use k <;>
       rw [← LieSubmodule.coe_toSubmodule_eq_iff] at hk ⊢ <;>
     simpa using hk
-#align lie_module.is_nilpotent_range_to_endomorphism_iff LieModule.isNilpotent_range_toEndomorphism_iff
+#align lie_module.is_nilpotent_range_to_endomorphism_iff LieModule.isNilpotent_range_toEnd_iff
 
 end LieModule
 
@@ -641,7 +641,7 @@ open LieAlgebra
 
 theorem LieAlgebra.nilpotent_ad_of_nilpotent_algebra [IsNilpotent R L] :
     ∃ k : ℕ, ∀ x : L, ad R L x ^ k = 0 :=
-  LieModule.exists_forall_pow_toEndomorphism_eq_zero R L L
+  LieModule.exists_forall_pow_toEnd_eq_zero R L L
 #align lie_algebra.nilpotent_ad_of_nilpotent_algebra LieAlgebra.nilpotent_ad_of_nilpotent_algebra
 
 -- TODO Generalise the below to Lie modules if / when we define morphisms, equivs of Lie modules
@@ -750,7 +750,7 @@ theorem LieHom.isNilpotent_range [IsNilpotent R L] (f : L →ₗ⁅R⁆ L') : Is
 #align lie_hom.is_nilpotent_range LieHom.isNilpotent_range
 
 /-- Note that this result is not quite a special case of
-`LieModule.isNilpotent_range_toEndomorphism_iff` which concerns nilpotency of the
+`LieModule.isNilpotent_range_toEnd_iff` which concerns nilpotency of the
 `(ad R L).range`-module `L`, whereas this result concerns nilpotency of the `(ad R L).range`-module
 `(ad R L).range`. -/
 @[simp]

--- a/Mathlib/Algebra/Lie/OfAssociative.lean
+++ b/Mathlib/Algebra/Lie/OfAssociative.lean
@@ -24,7 +24,7 @@ make such a definition in this file.
 
  * `LieAlgebra.ofAssociativeAlgebra`
  * `LieAlgebra.ofAssociativeAlgebraHom`
- * `LieModule.toEndomorphism`
+ * `LieModule.toEnd`
  * `LieAlgebra.ad`
  * `LinearEquiv.lieConj`
  * `AlgEquiv.toLieEquiv`
@@ -193,7 +193,7 @@ variable [LieRingModule L M] [LieModule R L M]
 
 See also `LieModule.toModuleHom`. -/
 @[simps]
-def LieModule.toEndomorphism : L →ₗ⁅R⁆ Module.End R M where
+def LieModule.toEnd : L →ₗ⁅R⁆ Module.End R M where
   toFun x :=
     { toFun := fun m => ⁅x, m⁆
       map_add' := lie_add x
@@ -201,11 +201,11 @@ def LieModule.toEndomorphism : L →ₗ⁅R⁆ Module.End R M where
   map_add' x y := by ext m; apply add_lie
   map_smul' t x := by ext m; apply smul_lie
   map_lie' {x y} := by ext m; apply lie_lie
-#align lie_module.to_endomorphism LieModule.toEndomorphism
+#align lie_module.to_endomorphism LieModule.toEnd
 
 /-- The adjoint action of a Lie algebra on itself. -/
 def LieAlgebra.ad : L →ₗ⁅R⁆ Module.End R L :=
-  LieModule.toEndomorphism R L L
+  LieModule.toEnd R L L
 #align lie_algebra.ad LieAlgebra.ad
 
 @[simp]
@@ -214,55 +214,55 @@ theorem LieAlgebra.ad_apply (x y : L) : LieAlgebra.ad R L x y = ⁅x, y⁆ :=
 #align lie_algebra.ad_apply LieAlgebra.ad_apply
 
 @[simp]
-theorem LieModule.toEndomorphism_module_end :
-    LieModule.toEndomorphism R (Module.End R M) M = LieHom.id := by ext g m; simp [lie_eq_smul]
-#align lie_module.to_endomorphism_module_End LieModule.toEndomorphism_module_end
+theorem LieModule.toEnd_module_end :
+    LieModule.toEnd R (Module.End R M) M = LieHom.id := by ext g m; simp [lie_eq_smul]
+#align lie_module.to_endomorphism_module_End LieModule.toEnd_module_end
 
-theorem LieSubalgebra.toEndomorphism_eq (K : LieSubalgebra R L) {x : K} :
-    LieModule.toEndomorphism R K M x = LieModule.toEndomorphism R L M x :=
+theorem LieSubalgebra.toEnd_eq (K : LieSubalgebra R L) {x : K} :
+    LieModule.toEnd R K M x = LieModule.toEnd R L M x :=
   rfl
-#align lie_subalgebra.to_endomorphism_eq LieSubalgebra.toEndomorphism_eq
+#align lie_subalgebra.to_endomorphism_eq LieSubalgebra.toEnd_eq
 
 @[simp]
-theorem LieSubalgebra.toEndomorphism_mk (K : LieSubalgebra R L) {x : L} (hx : x ∈ K) :
-    LieModule.toEndomorphism R K M ⟨x, hx⟩ = LieModule.toEndomorphism R L M x :=
+theorem LieSubalgebra.toEnd_mk (K : LieSubalgebra R L) {x : L} (hx : x ∈ K) :
+    LieModule.toEnd R K M ⟨x, hx⟩ = LieModule.toEnd R L M x :=
   rfl
-#align lie_subalgebra.to_endomorphism_mk LieSubalgebra.toEndomorphism_mk
+#align lie_subalgebra.to_endomorphism_mk LieSubalgebra.toEnd_mk
 
 section
 
 open BigOperators LieAlgebra LieModule
 
-lemma LieSubmodule.coe_toEndomorphism (N : LieSubmodule R L M) (x : L) (y : N) :
-    (toEndomorphism R L N x y : M) = toEndomorphism R L M x y := rfl
+lemma LieSubmodule.coe_toEnd (N : LieSubmodule R L M) (x : L) (y : N) :
+    (toEnd R L N x y : M) = toEnd R L M x y := rfl
 
-lemma LieSubmodule.coe_toEndomorphism_pow (N : LieSubmodule R L M) (x : L) (y : N) (n : ℕ) :
-    ((toEndomorphism R L N x ^ n) y : M) = (toEndomorphism R L M x ^ n) y := by
+lemma LieSubmodule.coe_toEnd_pow (N : LieSubmodule R L M) (x : L) (y : N) (n : ℕ) :
+    ((toEnd R L N x ^ n) y : M) = (toEnd R L M x ^ n) y := by
   induction n generalizing y with
   | zero => rfl
-  | succ n ih => simp only [pow_succ', LinearMap.mul_apply, ih, LieSubmodule.coe_toEndomorphism]
+  | succ n ih => simp only [pow_succ', LinearMap.mul_apply, ih, LieSubmodule.coe_toEnd]
 
 lemma LieSubalgebra.coe_ad (H : LieSubalgebra R L) (x y : H) :
     (ad R H x y : L) = ad R L x y := rfl
 
 lemma LieSubalgebra.coe_ad_pow (H : LieSubalgebra R L) (x y : H) (n : ℕ) :
     ((ad R H x ^ n) y : L) = (ad R L x ^ n) y :=
-  LieSubmodule.coe_toEndomorphism_pow R H L H.toLieSubmodule x y n
+  LieSubmodule.coe_toEnd_pow R H L H.toLieSubmodule x y n
 
 variable {L M}
 
-local notation "φ" => LieModule.toEndomorphism R L M
+local notation "φ" => LieModule.toEnd R L M
 
-lemma LieModule.toEndomorphism_lie (x y : L) (z : M) :
+lemma LieModule.toEnd_lie (x y : L) (z : M) :
     (φ x) ⁅y, z⁆ = ⁅ad R L x y, z⁆ + ⁅y, φ x z⁆ := by
   simp
 
 lemma LieAlgebra.ad_lie (x y z : L) :
     (ad R L x) ⁅y, z⁆ = ⁅ad R L x y, z⁆ + ⁅y, ad R L x z⁆ :=
-  toEndomorphism_lie _ x y z
+  toEnd_lie _ x y z
 
 open Finset in
-lemma LieModule.toEndomorphism_pow_lie (x y : L) (z : M) (n : ℕ) :
+lemma LieModule.toEnd_pow_lie (x y : L) (z : M) (n : ℕ) :
     ((φ x) ^ n) ⁅y, z⁆ =
       ∑ ij in antidiagonal n, n.choose ij.1 • ⁅((ad R L x) ^ ij.1) y, ((φ x) ^ ij.2) z⁆ := by
   induction n with
@@ -271,7 +271,7 @@ lemma LieModule.toEndomorphism_pow_lie (x y : L) (z : M) (n : ℕ) :
     rw [Finset.sum_antidiagonal_choose_succ_nsmul
       (fun i j ↦ ⁅((ad R L x) ^ i) y, ((φ x) ^ j) z⁆) n]
     simp only [pow_succ', LinearMap.mul_apply, ih, map_sum, map_nsmul,
-      toEndomorphism_lie, nsmul_add, sum_add_distrib]
+      toEnd_lie, nsmul_add, sum_add_distrib]
     rw [add_comm, add_left_cancel_iff, sum_congr rfl]
     rintro ⟨i, j⟩ hij
     rw [mem_antidiagonal] at hij
@@ -281,7 +281,7 @@ open Finset in
 lemma LieAlgebra.ad_pow_lie (x y z : L) (n : ℕ) :
     ((ad R L x) ^ n) ⁅y, z⁆ =
       ∑ ij in antidiagonal n, n.choose ij.1 • ⁅((ad R L x) ^ ij.1) y, ((ad R L x) ^ ij.2) z⁆ :=
-  toEndomorphism_pow_lie _ x y z n
+  toEnd_pow_lie _ x y z n
 
 end
 
@@ -292,15 +292,15 @@ namespace LieModule
 variable {M₂ : Type w₁} [AddCommGroup M₂] [Module R M₂] [LieRingModule L M₂] [LieModule R L M₂]
   (f : M →ₗ⁅R,L⁆ M₂) (k : ℕ) (x : L)
 
-lemma toEndomorphism_pow_comp_lieHom :
-    (toEndomorphism R L M₂ x ^ k) ∘ₗ f = f ∘ₗ toEndomorphism R L M x ^ k := by
+lemma toEnd_pow_comp_lieHom :
+    (toEnd R L M₂ x ^ k) ∘ₗ f = f ∘ₗ toEnd R L M x ^ k := by
   apply LinearMap.commute_pow_left_of_commute
   ext
   simp
 
-lemma toEndomorphism_pow_apply_map (m : M) :
-    (toEndomorphism R L M₂ x ^ k) (f m) = f ((toEndomorphism R L M x ^ k) m) :=
-  LinearMap.congr_fun (toEndomorphism_pow_comp_lieHom f k x) m
+lemma toEnd_pow_apply_map (m : M) :
+    (toEnd R L M₂ x ^ k) (f m) = f ((toEnd R L M x ^ k) m) :=
+  LinearMap.congr_fun (toEnd_pow_comp_lieHom f k x) m
 
 end LieModule
 
@@ -310,27 +310,27 @@ open LieModule Set
 
 variable {N : LieSubmodule R L M} {x : L}
 
-theorem coe_map_toEndomorphism_le :
-    (N : Submodule R M).map (LieModule.toEndomorphism R L M x) ≤ N := by
+theorem coe_map_toEnd_le :
+    (N : Submodule R M).map (LieModule.toEnd R L M x) ≤ N := by
   rintro n ⟨m, hm, rfl⟩
   exact N.lie_mem hm
-#align lie_submodule.coe_map_to_endomorphism_le LieSubmodule.coe_map_toEndomorphism_le
+#align lie_submodule.coe_map_to_endomorphism_le LieSubmodule.coe_map_toEnd_le
 
 variable (N x)
 
-theorem toEndomorphism_comp_subtype_mem (m : M) (hm : m ∈ (N : Submodule R M)) :
-    (toEndomorphism R L M x).comp (N : Submodule R M).subtype ⟨m, hm⟩ ∈ (N : Submodule R M) := by
+theorem toEnd_comp_subtype_mem (m : M) (hm : m ∈ (N : Submodule R M)) :
+    (toEnd R L M x).comp (N : Submodule R M).subtype ⟨m, hm⟩ ∈ (N : Submodule R M) := by
   simpa using N.lie_mem hm
-#align lie_submodule.to_endomorphism_comp_subtype_mem LieSubmodule.toEndomorphism_comp_subtype_mem
+#align lie_submodule.to_endomorphism_comp_subtype_mem LieSubmodule.toEnd_comp_subtype_mem
 
 @[simp]
-theorem toEndomorphism_restrict_eq_toEndomorphism (h := N.toEndomorphism_comp_subtype_mem x) :
-    (toEndomorphism R L M x).restrict h = toEndomorphism R L N x := by
+theorem toEnd_restrict_eq_toEnd (h := N.toEnd_comp_subtype_mem x) :
+    (toEnd R L M x).restrict h = toEnd R L N x := by
   ext; simp [LinearMap.restrict_apply]
-#align lie_submodule.to_endomorphism_restrict_eq_to_endomorphism LieSubmodule.toEndomorphism_restrict_eq_toEndomorphism
+#align lie_submodule.to_endomorphism_restrict_eq_to_endomorphism LieSubmodule.toEnd_restrict_eq_toEnd
 
-lemma mapsTo_pow_toEndomorphism_sub_algebraMap {φ : R} {k : ℕ} {x : L} :
-    MapsTo ((toEndomorphism R L M x - algebraMap R (Module.End R M) φ) ^ k) N N := by
+lemma mapsTo_pow_toEnd_sub_algebraMap {φ : R} {k : ℕ} {x : L} :
+    MapsTo ((toEnd R L M x - algebraMap R (Module.End R M) φ) ^ k) N N := by
   rw [LinearMap.coe_pow]
   exact MapsTo.iterate (fun m hm ↦ N.sub_mem (N.lie_mem hm) (N.smul_mem _ hm)) k
 

--- a/Mathlib/Algebra/Lie/Quotient.lean
+++ b/Mathlib/Algebra/Lie/Quotient.lean
@@ -83,7 +83,7 @@ theorem is_quotient_mk (m : M) : Quotient.mk'' m = (mk m : M ⧸ N) :=
 /-- Given a Lie module `M` over a Lie algebra `L`, together with a Lie submodule `N ⊆ M`, there
 is a natural linear map from `L` to the endomorphisms of `M` leaving `N` invariant. -/
 def lieSubmoduleInvariant : L →ₗ[R] Submodule.compatibleMaps N.toSubmodule N.toSubmodule :=
-  LinearMap.codRestrict _ (LieModule.toEndomorphism R L M) fun _ _ => N.lie_mem
+  LinearMap.codRestrict _ (LieModule.toEnd R L M) fun _ _ => N.lie_mem
 #align lie_submodule.quotient.lie_submodule_invariant LieSubmodule.Quotient.lieSubmoduleInvariant
 
 variable (N)
@@ -220,8 +220,8 @@ theorem lieModuleHom_ext ⦃f g : M ⧸ N →ₗ⁅R,L⁆ M⦄ (h : f.comp (mk' 
   LieModuleHom.ext fun x => Quotient.inductionOn' x <| LieModuleHom.congr_fun h
 #align lie_submodule.quotient.lie_module_hom_ext LieSubmodule.Quotient.lieModuleHom_ext
 
-lemma toEndomorphism_comp_mk' (x : L) :
-    LieModule.toEndomorphism R L (M ⧸ N) x ∘ₗ mk' N = mk' N ∘ₗ LieModule.toEndomorphism R L M x :=
+lemma toEnd_comp_mk' (x : L) :
+    LieModule.toEnd R L (M ⧸ N) x ∘ₗ mk' N = mk' N ∘ₗ LieModule.toEnd R L M x :=
   rfl
 
 end Quotient

--- a/Mathlib/Algebra/Lie/Rank.lean
+++ b/Mathlib/Algebra/Lie/Rank.lean
@@ -48,7 +48,7 @@ open LieAlgebra LinearMap Module.Free
 
 variable (R L M)
 
-local notation "φ" => LieHom.toLinearMap (LieModule.toEndomorphism R L M)
+local notation "φ" => LieHom.toLinearMap (LieModule.toEnd R L M)
 
 /--
 Let `M` be a representation of a Lie algebra `L` over a nontrivial commutative ring `R`,
@@ -78,7 +78,7 @@ lemma rank_le_finrank : rank R L M ≤ finrank R M :=
 variable {L}
 
 lemma rank_le_natTrailingDegree_charpoly_ad :
-    rank R L M ≤ (toEndomorphism R L M x).charpoly.natTrailingDegree :=
+    rank R L M ≤ (toEnd R L M x).charpoly.natTrailingDegree :=
   nilRank_le_natTrailingDegree_charpoly _ _
 
 /-- Let `x` be an element of a Lie algebra `L` over `R`, and write `n` for `rank R L`.
@@ -87,7 +87,7 @@ if the `n`-th coefficient of the characteristic polynomial of `ad R L x` is non-
 def IsRegular (x : L) : Prop := LinearMap.IsNilRegular φ x
 
 lemma isRegular_def :
-    IsRegular R M x ↔ (toEndomorphism R L M x).charpoly.coeff (rank R L M) ≠ 0 := Iff.rfl
+    IsRegular R M x ↔ (toEnd R L M x).charpoly.coeff (rank R L M) ≠ 0 := Iff.rfl
 
 lemma isRegular_iff_coeff_polyCharpoly_rank_ne_zero :
     IsRegular R M x ↔
@@ -96,7 +96,7 @@ lemma isRegular_iff_coeff_polyCharpoly_rank_ne_zero :
   LinearMap.isNilRegular_iff_coeff_polyCharpoly_nilRank_ne_zero _ _ _
 
 lemma isRegular_iff_natTrailingDegree_charpoly_eq_rank :
-    IsRegular R M x ↔ (toEndomorphism R L M x).charpoly.natTrailingDegree = rank R L M :=
+    IsRegular R M x ↔ (toEnd R L M x).charpoly.natTrailingDegree = rank R L M :=
   LinearMap.isNilRegular_iff_natTrailingDegree_charpoly_eq_nilRank _ _
 section IsDomain
 

--- a/Mathlib/Algebra/Lie/TensorProduct.lean
+++ b/Mathlib/Algebra/Lie/TensorProduct.lean
@@ -44,7 +44,7 @@ attribute [local ext] TensorProduct.ext
 expression of the fact that `L` acts by linear endomorphisms. It simplifies the proofs in
 `lieRingModule` below. -/
 def hasBracketAux (x : L) : Module.End R (M ⊗[R] N) :=
-  (toEndomorphism R L M x).rTensor N + (toEndomorphism R L N x).lTensor M
+  (toEnd R L M x).rTensor N + (toEnd R L N x).lTensor M
 #align tensor_product.lie_module.has_bracket_aux TensorProduct.LieModule.hasBracketAux
 
 /-- The tensor product of two Lie modules is a Lie ring module. -/
@@ -62,7 +62,7 @@ instance lieRingModule : LieRingModule L (M ⊗[R] N) where
     ext m n
     simp only [hasBracketAux, AlgebraTensorModule.curry_apply, curry_apply, sub_tmul, tmul_sub,
       LinearMap.coe_restrictScalars, Function.comp_apply, LinearMap.coe_comp,
-      LinearMap.rTensor_tmul, LieHom.map_lie, toEndomorphism_apply_apply, LinearMap.add_apply,
+      LinearMap.rTensor_tmul, LieHom.map_lie, toEnd_apply_apply, LinearMap.add_apply,
       LinearMap.map_add, LieHom.lie_apply, Module.End.lie_apply, LinearMap.lTensor_tmul]
     abel
 #align tensor_product.lie_module.lie_ring_module TensorProduct.LieModule.lieRingModule
@@ -79,7 +79,7 @@ instance lieModule : LieModule R L (M ⊗[R] N) where
 @[simp]
 theorem lie_tmul_right (x : L) (m : M) (n : N) : ⁅x, m ⊗ₜ[R] n⁆ = ⁅x, m⁆ ⊗ₜ n + m ⊗ₜ ⁅x, n⁆ :=
   show hasBracketAux x (m ⊗ₜ[R] n) = _ by
-    simp only [hasBracketAux, LinearMap.rTensor_tmul, toEndomorphism_apply_apply,
+    simp only [hasBracketAux, LinearMap.rTensor_tmul, toEnd_apply_apply,
       LinearMap.add_apply, LinearMap.lTensor_tmul]
 #align tensor_product.lie_module.lie_tmul_right TensorProduct.LieModule.lie_tmul_right
 
@@ -181,14 +181,14 @@ variable [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
 /-- The action of the Lie algebra on one of its modules, regarded as a morphism of Lie modules. -/
 def toModuleHom : L ⊗[R] M →ₗ⁅R,L⁆ M :=
   TensorProduct.LieModule.liftLie R L L M M
-    { (toEndomorphism R L M : L →ₗ[R] M →ₗ[R] M) with
+    { (toEnd R L M : L →ₗ[R] M →ₗ[R] M) with
       map_lie' := fun {x m} => by ext n; simp [LieRing.of_associative_ring_bracket] }
 #align lie_module.to_module_hom LieModule.toModuleHom
 
 @[simp]
 theorem toModuleHom_apply (x : L) (m : M) : toModuleHom R L M (x ⊗ₜ m) = ⁅x, m⁆ := by
   simp only [toModuleHom, TensorProduct.LieModule.liftLie_apply, LieModuleHom.coe_mk,
-    LinearMap.coe_mk, LinearMap.coe_toAddHom, LieHom.coe_toLinearMap, toEndomorphism_apply_apply]
+    LinearMap.coe_mk, LinearMap.coe_toAddHom, LieHom.coe_toLinearMap, toEnd_apply_apply]
 #align lie_module.to_module_hom_apply LieModule.toModuleHom_apply
 
 end LieModule

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -36,7 +36,7 @@ variable (R K L M : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]
   [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
   [Module.Free R M] [Module.Finite R M]
 
-local notation "φ" => LieModule.toEndomorphism R L M
+local notation "φ" => LieModule.toEnd R L M
 
 open LinearMap (trace)
 open Set BigOperators FiniteDimensional
@@ -96,7 +96,7 @@ lemma traceForm_apply_lie_apply' (x y z : L) :
   ext x y
   simp only [traceForm_apply_apply, LinearMap.zero_apply, ← isNilpotent_iff_eq_zero]
   apply LinearMap.isNilpotent_trace_of_isNilpotent
-  exact isNilpotent_toEndomorphism_of_isNilpotent₂ R L M x y
+  exact isNilpotent_toEnd_of_isNilpotent₂ R L M x y
 
 @[simp]
 lemma traceForm_weightSpace_eq [IsDomain R] [IsPrincipalIdealRing R]
@@ -109,11 +109,11 @@ lemma traceForm_weightSpace_eq [IsDomain R] [IsPrincipalIdealRing R]
   have := traceForm_eq_zero_of_isNilpotent R L (shiftedWeightSpace R L M χ)
   replace this := LinearMap.congr_fun (LinearMap.congr_fun this x) y
   rwa [LinearMap.zero_apply, LinearMap.zero_apply, traceForm_apply_apply,
-    shiftedWeightSpace.toEndomorphism_eq, shiftedWeightSpace.toEndomorphism_eq,
+    shiftedWeightSpace.toEnd_eq, shiftedWeightSpace.toEnd_eq,
     ← LinearEquiv.conj_comp, LinearMap.trace_conj', LinearMap.comp_sub, LinearMap.sub_comp,
     LinearMap.sub_comp, map_sub, map_sub, map_sub, LinearMap.comp_smul, LinearMap.smul_comp,
     LinearMap.comp_id, LinearMap.id_comp, LinearMap.map_smul, LinearMap.map_smul,
-    trace_toEndomorphism_weightSpace, trace_toEndomorphism_weightSpace,
+    trace_toEnd_weightSpace, trace_toEnd_weightSpace,
     LinearMap.comp_smul, LinearMap.smul_comp, LinearMap.id_comp, map_smul, map_smul,
     LinearMap.trace_id, ← traceForm_apply_apply, h₁, h₂, sub_zero, sub_eq_zero] at this
 
@@ -177,15 +177,15 @@ lemma eq_zero_of_mem_weightSpace_mem_posFitting [LieAlgebra.IsNilpotent R L]
   obtain ⟨m, rfl⟩ := (mem_posFittingCompOf R x m₁).mp hm₁ k
   simp [hB, hk]
 
-lemma trace_toEndomorphism_eq_zero_of_mem_lcs
+lemma trace_toEnd_eq_zero_of_mem_lcs
     {k : ℕ} {x : L} (hk : 1 ≤ k) (hx : x ∈ lowerCentralSeries R L L k) :
-    trace R _ (toEndomorphism R L M x) = 0 := by
+    trace R _ (toEnd R L M x) = 0 := by
   replace hx : x ∈ lowerCentralSeries R L L 1 := antitone_lowerCentralSeries _ _ _ hk hx
   replace hx : x ∈ Submodule.span R {m | ∃ u v : L, ⁅u, v⁆ = m} := by
     rw [lowerCentralSeries_succ, ← LieSubmodule.mem_coeSubmodule,
       LieSubmodule.lieIdeal_oper_eq_linear_span'] at hx
     simpa using hx
-  refine Submodule.span_induction (p := fun x ↦ trace R _ (toEndomorphism R L M x) = 0) hx
+  refine Submodule.span_induction (p := fun x ↦ trace R _ (toEnd R L M x) = 0) hx
     (fun y ⟨u, v, huv⟩ ↦ ?_) ?_ (fun u v hu hv ↦ ?_) (fun t u hu ↦ ?_)
   · simp [← huv]
   · simp
@@ -210,7 +210,7 @@ lemma traceForm_eq_sum_weightSpaceOf [IsTriangularizable R L M] (z : L) :
     traceForm R L M =
     ∑ χ in (finite_weightSpaceOf_ne_bot R L M z).toFinset, traceForm R L (weightSpaceOf M χ z) := by
   ext x y
-  have hxy : ∀ χ : R, MapsTo ((toEndomorphism R L M x).comp (toEndomorphism R L M y))
+  have hxy : ∀ χ : R, MapsTo ((toEnd R L M x).comp (toEnd R L M y))
       (weightSpaceOf M χ z) (weightSpaceOf M χ z) :=
     fun χ m hm ↦ LieSubmodule.lie_mem _ <| LieSubmodule.lie_mem _ hm
   have hfin : {χ : R | (weightSpaceOf M χ z : Submodule R M) ≠ ⊥}.Finite := by
@@ -236,7 +236,7 @@ lemma lowerCentralSeries_one_inf_center_le_ker_traceForm :
 
   Because `z` belongs to the indicated intersection, it has two key properties:
   (a) the trace of the action of `z` vanishes on any Lie module of `L`
-      (see `LieModule.trace_toEndomorphism_eq_zero_of_mem_lcs`),
+      (see `LieModule.trace_toEnd_eq_zero_of_mem_lcs`),
   (b) `z` commutes with all elements of `L`.
 
   If `φ x` were triangularizable, we could write `M` as a direct sum of generalized eigenspaces of
@@ -256,8 +256,8 @@ lemma lowerCentralSeries_one_inf_center_le_ker_traceForm :
     have _i : NoZeroSMulDivisors R A := NoZeroSMulDivisors.trans R (FractionRing R) A
     rw [← map_zero (algebraMap R A)] at this
     exact NoZeroSMulDivisors.algebraMap_injective R A this
-  rw [← LinearMap.trace_baseChange, LinearMap.baseChange_comp, ← toEndomorphism_baseChange,
-    ← toEndomorphism_baseChange]
+  rw [← LinearMap.trace_baseChange, LinearMap.baseChange_comp, ← toEnd_baseChange,
+    ← toEnd_baseChange]
   replace hz : 1 ⊗ₜ z ∈ lowerCentralSeries A (A ⊗[R] L) (A ⊗[R] L) 1 := by
     simp only [lowerCentralSeries_succ, lowerCentralSeries_zero] at hz ⊢
     rw [← LieSubmodule.baseChange_top, ← LieSubmodule.lie_baseChange]
@@ -268,9 +268,9 @@ lemma lowerCentralSeries_one_inf_center_le_ker_traceForm :
     exact y.induction_on rfl (fun a u ↦ by simp [hzc u]) (fun u v hu hv ↦ by simp [hu, hv])
   apply LinearMap.trace_comp_eq_zero_of_commute_of_trace_restrict_eq_zero
   · exact IsTriangularizable.iSup_eq_top (1 ⊗ₜ[R] x)
-  · exact fun μ ↦ trace_toEndomorphism_eq_zero_of_mem_lcs A (A ⊗[R] L)
+  · exact fun μ ↦ trace_toEnd_eq_zero_of_mem_lcs A (A ⊗[R] L)
       (weightSpaceOf (A ⊗[R] M) μ (1 ⊗ₜ x)) (le_refl 1) hz
-  · exact commute_toEndomorphism_of_mem_center_right (A ⊗[R] M) hzc (1 ⊗ₜ x)
+  · exact commute_toEnd_of_mem_center_right (A ⊗[R] M) hzc (1 ⊗ₜ x)
 
 /-- A nilpotent Lie algebra with a representation whose trace form is non-singular is Abelian. -/
 lemma isLieAbelian_of_ker_traceForm_eq_bot (h : LinearMap.ker (traceForm R L M) = ⊥) :
@@ -397,7 +397,7 @@ variable [LieAlgebra.IsNilpotent K L] [LinearWeights K L M] [IsTriangularizable 
 
 lemma traceForm_eq_sum_finrank_nsmul_mul (x y : L) :
     traceForm K L M x y = ∑ χ : Weight K L M, finrank K (weightSpace M χ) • (χ x * χ y) := by
-  have hxy : ∀ χ : Weight K L M, MapsTo (toEndomorphism K L M x ∘ₗ toEndomorphism K L M y)
+  have hxy : ∀ χ : Weight K L M, MapsTo (toEnd K L M x ∘ₗ toEnd K L M y)
       (weightSpace M χ) (weightSpace M χ) :=
     fun χ m hm ↦ LieSubmodule.lie_mem _ <| LieSubmodule.lie_mem _ hm
   classical

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -58,7 +58,7 @@ open scoped BigOperators TensorProduct
 section notation_weightSpaceOf
 
 /-- Until we define `LieModule.weightSpaceOf`, it is useful to have some notation as follows: -/
-local notation3 "𝕎("M", " χ", " x")" => (toEndomorphism R L M x).maximalGeneralizedEigenspace χ
+local notation3 "𝕎("M", " χ", " x")" => (toEnd R L M x).maximalGeneralizedEigenspace χ
 
 /-- See also `bourbaki1975b` Chapter VII §1.1, Proposition 2 (ii). -/
 protected theorem weight_vector_multiplication (M₁ M₂ M₃ : Type*)
@@ -74,7 +74,7 @@ protected theorem weight_vector_multiplication (M₁ M₂ M₃ : Type*)
     Module.End.mem_maximalGeneralizedEigenspace]
   rintro t rfl
   -- Set up some notation.
-  let F : Module.End R M₃ := toEndomorphism R L M₃ x - (χ₁ + χ₂) • ↑1
+  let F : Module.End R M₃ := toEnd R L M₃ x - (χ₁ + χ₂) • ↑1
   -- The goal is linear in `t` so use induction to reduce to the case that `t` is a pure tensor.
   refine t.induction_on ?_ ?_ ?_
   · use 0; simp only [LinearMap.map_zero, LieModuleHom.map_zero]
@@ -87,12 +87,12 @@ protected theorem weight_vector_multiplication (M₁ M₂ M₃ : Type*)
   rintro ⟨m₁, hm₁⟩ ⟨m₂, hm₂⟩
   change ∃ k, (F ^ k) ((g : M₁ ⊗[R] M₂ →ₗ[R] M₃) (m₁ ⊗ₜ m₂)) = (0 : M₃)
   -- Eliminate `g` from the picture.
-  let f₁ : Module.End R (M₁ ⊗[R] M₂) := (toEndomorphism R L M₁ x - χ₁ • ↑1).rTensor M₂
-  let f₂ : Module.End R (M₁ ⊗[R] M₂) := (toEndomorphism R L M₂ x - χ₂ • ↑1).lTensor M₁
+  let f₁ : Module.End R (M₁ ⊗[R] M₂) := (toEnd R L M₁ x - χ₁ • ↑1).rTensor M₂
+  let f₂ : Module.End R (M₁ ⊗[R] M₂) := (toEnd R L M₂ x - χ₂ • ↑1).lTensor M₁
   have h_comm_square : F ∘ₗ ↑g = (g : M₁ ⊗[R] M₂ →ₗ[R] M₃).comp (f₁ + f₂) := by
     ext m₁ m₂;
     simp only [f₁, f₂, F, ← g.map_lie x (m₁ ⊗ₜ m₂), add_smul, sub_tmul, tmul_sub, smul_tmul,
-      lie_tmul_right, tmul_smul, toEndomorphism_apply_apply, LieModuleHom.map_smul,
+      lie_tmul_right, tmul_smul, toEnd_apply_apply, LieModuleHom.map_smul,
       LinearMap.one_apply, LieModuleHom.coe_toLinearMap, LinearMap.smul_apply, Function.comp_apply,
       LinearMap.coe_comp, LinearMap.rTensor_tmul, LieModuleHom.map_add, LinearMap.add_apply,
       LieModuleHom.map_sub, LinearMap.sub_apply, LinearMap.lTensor_tmul,
@@ -133,7 +133,7 @@ protected theorem weight_vector_multiplication (M₁ M₂ M₃ : Type*)
       LinearMap.map_zero]
   · rw [LinearMap.mul_apply, LinearMap.pow_map_zero_of_le hj hf₂, LinearMap.map_zero]
 
-lemma lie_mem_maxGenEigenspace_toEndomorphism
+lemma lie_mem_maxGenEigenspace_toEnd
     {χ₁ χ₂ : R} {x y : L} {m : M} (hy : y ∈ 𝕎(L, χ₁, x)) (hm : m ∈ 𝕎(M, χ₂, x)) :
     ⁅y, m⁆ ∈ 𝕎(M, χ₁ + χ₂, x) := by
   apply LieModule.weight_vector_multiplication L M M (toModuleHom R L M) χ₁ χ₂
@@ -155,18 +155,18 @@ def weightSpaceOf (χ : R) (x : L) : LieSubmodule R L M :=
       simp only [AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup,
         Submodule.mem_toAddSubmonoid] at hm ⊢
       rw [← zero_add χ]
-      exact lie_mem_maxGenEigenspace_toEndomorphism (by simp) hm }
+      exact lie_mem_maxGenEigenspace_toEnd (by simp) hm }
 
 end notation_weightSpaceOf
 
 variable (M)
 
 theorem mem_weightSpaceOf (χ : R) (x : L) (m : M) :
-    m ∈ weightSpaceOf M χ x ↔ ∃ k : ℕ, ((toEndomorphism R L M x - χ • ↑1) ^ k) m = 0 := by
+    m ∈ weightSpaceOf M χ x ↔ ∃ k : ℕ, ((toEnd R L M x - χ • ↑1) ^ k) m = 0 := by
   simp [weightSpaceOf]
 
 theorem coe_weightSpaceOf_zero (x : L) :
-    ↑(weightSpaceOf M (0 : R) x) = ⨆ k, LinearMap.ker (toEndomorphism R L M x ^ k) := by
+    ↑(weightSpaceOf M (0 : R) x) = ⨆ k, LinearMap.ker (toEnd R L M x ^ k) := by
   simp [weightSpaceOf, Module.End.maximalGeneralizedEigenspace]
 
 /-- If `M` is a representation of a nilpotent Lie algebra `L` and `χ : L → R` is a family of
@@ -178,7 +178,7 @@ def weightSpace (χ : L → R) : LieSubmodule R L M :=
   ⨅ x, weightSpaceOf M (χ x) x
 
 theorem mem_weightSpace (χ : L → R) (m : M) :
-    m ∈ weightSpace M χ ↔ ∀ x, ∃ k : ℕ, ((toEndomorphism R L M x - χ x • ↑1) ^ k) m = 0 := by
+    m ∈ weightSpace M χ ↔ ∀ x, ∃ k : ℕ, ((toEnd R L M x - χ x • ↑1) ^ k) m = 0 := by
   simp [weightSpace, mem_weightSpaceOf]
 
 lemma weightSpace_le_weightSpaceOf (x : L) (χ : L → R) :
@@ -236,13 +236,13 @@ lemma weightSpaceOf_ne_bot (χ : Weight R L M) (x : L) :
   exact le_of_le_of_eq (iInf_le _ _) this
 
 lemma hasEigenvalueAt (χ : Weight R L M) (x : L) :
-    (toEndomorphism R L M x).HasEigenvalue (χ x) := by
-  obtain ⟨k : ℕ, hk : (toEndomorphism R L M x).generalizedEigenspace (χ x) k ≠ ⊥⟩ := by
+    (toEnd R L M x).HasEigenvalue (χ x) := by
+  obtain ⟨k : ℕ, hk : (toEnd R L M x).generalizedEigenspace (χ x) k ≠ ⊥⟩ := by
     simpa [Module.End.maximalGeneralizedEigenspace, weightSpaceOf] using χ.weightSpaceOf_ne_bot x
   exact Module.End.hasEigenvalue_of_hasGeneralizedEigenvalue hk
 
 lemma apply_eq_zero_of_isNilpotent [NoZeroSMulDivisors R M] [IsReduced R]
-    (x : L) (h : _root_.IsNilpotent (toEndomorphism R L M x)) (χ : Weight R L M) :
+    (x : L) (h : _root_.IsNilpotent (toEnd R L M x)) (χ : Weight R L M) :
     χ x = 0 :=
   ((χ.hasEigenvalueAt x).isNilpotent_of_isNilpotent h).eq_zero
 
@@ -269,31 +269,31 @@ theorem zero_weightSpace_eq_top_of_nilpotent [IsNilpotent R L M] :
     weightSpace M (0 : (⊤ : LieSubalgebra R L) → R) = ⊤ := by
   ext m
   simp only [mem_weightSpace, Pi.zero_apply, zero_smul, sub_zero, Subtype.forall, forall_true_left,
-    LieSubalgebra.toEndomorphism_mk, LieSubalgebra.mem_top, LieSubmodule.mem_top, iff_true]
+    LieSubalgebra.toEnd_mk, LieSubalgebra.mem_top, LieSubmodule.mem_top, iff_true]
   intro x
-  obtain ⟨k, hk⟩ := exists_forall_pow_toEndomorphism_eq_zero R L M
+  obtain ⟨k, hk⟩ := exists_forall_pow_toEnd_eq_zero R L M
   exact ⟨k, by simp [hk x]⟩
 #align lie_module.zero_weight_space_eq_top_of_nilpotent LieModule.zero_weightSpace_eq_top_of_nilpotent
 
 theorem exists_weightSpace_le_ker_of_isNoetherian [IsNoetherian R M] (χ : L → R) (x : L) :
     ∃ k : ℕ,
-      weightSpace M χ ≤ LinearMap.ker ((toEndomorphism R L M x - algebraMap R _ (χ x)) ^ k) := by
-  use (toEndomorphism R L M x).maximalGeneralizedEigenspaceIndex (χ x)
+      weightSpace M χ ≤ LinearMap.ker ((toEnd R L M x - algebraMap R _ (χ x)) ^ k) := by
+  use (toEnd R L M x).maximalGeneralizedEigenspaceIndex (χ x)
   intro m hm
-  replace hm : m ∈ (toEndomorphism R L M x).maximalGeneralizedEigenspace (χ x) :=
+  replace hm : m ∈ (toEnd R L M x).maximalGeneralizedEigenspace (χ x) :=
     weightSpace_le_weightSpaceOf M x χ hm
   rwa [Module.End.maximalGeneralizedEigenspace_eq] at hm
 
 variable (R) in
 theorem exists_weightSpace_zero_le_ker_of_isNoetherian
     [IsNoetherian R M] (x : L) :
-    ∃ k : ℕ, weightSpace M (0 : L → R) ≤ LinearMap.ker (toEndomorphism R L M x ^ k) := by
+    ∃ k : ℕ, weightSpace M (0 : L → R) ≤ LinearMap.ker (toEnd R L M x ^ k) := by
   simpa using exists_weightSpace_le_ker_of_isNoetherian M (0 : L → R) x
 
-lemma isNilpotent_toEndomorphism_sub_algebraMap [IsNoetherian R M] (χ : L → R) (x : L) :
-    _root_.IsNilpotent <| toEndomorphism R L (weightSpace M χ) x - algebraMap R _ (χ x) := by
-  have : toEndomorphism R L (weightSpace M χ) x - algebraMap R _ (χ x) =
-      (toEndomorphism R L M x - algebraMap R _ (χ x)).restrict
+lemma isNilpotent_toEnd_sub_algebraMap [IsNoetherian R M] (χ : L → R) (x : L) :
+    _root_.IsNilpotent <| toEnd R L (weightSpace M χ) x - algebraMap R _ (χ x) := by
+  have : toEnd R L (weightSpace M χ) x - algebraMap R _ (χ x) =
+      (toEnd R L M x - algebraMap R _ (χ x)).restrict
         (fun m hm ↦ sub_mem (LieSubmodule.lie_mem _ hm) (Submodule.smul_mem _ _ hm)) := by
     rfl
   obtain ⟨k, hk⟩ := exists_weightSpace_le_ker_of_isNoetherian M χ x
@@ -303,15 +303,15 @@ lemma isNilpotent_toEndomorphism_sub_algebraMap [IsNoetherian R M] (χ : L → R
 
 /-- A (nilpotent) Lie algebra acts nilpotently on the zero weight space of a Noetherian Lie
 module. -/
-theorem isNilpotent_toEndomorphism_weightSpace_zero [IsNoetherian R M] (x : L) :
-    _root_.IsNilpotent <| toEndomorphism R L (weightSpace M (0 : L → R)) x := by
-  simpa using isNilpotent_toEndomorphism_sub_algebraMap M (0 : L → R) x
-#align lie_module.is_nilpotent_to_endomorphism_weight_space_zero LieModule.isNilpotent_toEndomorphism_weightSpace_zero
+theorem isNilpotent_toEnd_weightSpace_zero [IsNoetherian R M] (x : L) :
+    _root_.IsNilpotent <| toEnd R L (weightSpace M (0 : L → R)) x := by
+  simpa using isNilpotent_toEnd_sub_algebraMap M (0 : L → R) x
+#align lie_module.is_nilpotent_to_endomorphism_weight_space_zero LieModule.isNilpotent_toEnd_weightSpace_zero
 
 /-- By Engel's theorem, the zero weight space of a Noetherian Lie module is nilpotent. -/
 instance [IsNoetherian R M] :
     IsNilpotent R L (weightSpace M (0 : L → R)) :=
-  isNilpotent_iff_forall'.mpr <| isNilpotent_toEndomorphism_weightSpace_zero M
+  isNilpotent_iff_forall'.mpr <| isNilpotent_toEnd_weightSpace_zero M
 
 variable (R L)
 
@@ -343,16 +343,16 @@ variable {L}
 
 /-- If `M` is a representation of a nilpotent Lie algebra `L`, and `x : L`, then
 `posFittingCompOf R M x` is the infimum of the decreasing system
-`range φₓ ⊇ range φₓ² ⊇ range φₓ³ ⊇ ⋯` where `φₓ : End R M := toEndomorphism R L M x`. We call this
+`range φₓ ⊇ range φₓ² ⊇ range φₓ³ ⊇ ⋯` where `φₓ : End R M := toEnd R L M x`. We call this
 the "positive Fitting component" because with appropriate assumptions (e.g., `R` is a field and
 `M` is finite-dimensional) `φₓ` induces the so-called Fitting decomposition: `M = M₀ ⊕ M₁` where
 `M₀ = weightSpaceOf M 0 x` and `M₁ = posFittingCompOf R M x`.
 
 It is a Lie submodule because `L` is nilpotent. -/
 def posFittingCompOf (x : L) : LieSubmodule R L M :=
-  { toSubmodule := ⨅ k, LinearMap.range (toEndomorphism R L M x ^ k)
+  { toSubmodule := ⨅ k, LinearMap.range (toEnd R L M x ^ k)
     lie_mem := by
-      set φ := toEndomorphism R L M x
+      set φ := toEnd R L M x
       intros y m hm
       simp only [AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup,
         Submodule.mem_toAddSubmonoid, Submodule.mem_iInf, LinearMap.mem_range] at hm ⊢
@@ -373,12 +373,12 @@ def posFittingCompOf (x : L) : LieSubmodule R L M :=
 
 variable {M} in
 lemma mem_posFittingCompOf (x : L) (m : M) :
-    m ∈ posFittingCompOf R M x ↔ ∀ (k : ℕ), ∃ n, (toEndomorphism R L M x ^ k) n = m := by
+    m ∈ posFittingCompOf R M x ↔ ∀ (k : ℕ), ∃ n, (toEnd R L M x ^ k) n = m := by
   simp [posFittingCompOf]
 
 @[simp] lemma posFittingCompOf_le_lowerCentralSeries (x : L) (k : ℕ) :
     posFittingCompOf R M x ≤ lowerCentralSeries R L M k := by
-  suffices ∀ m l, (toEndomorphism R L M x ^ l) m ∈ lowerCentralSeries R L M l by
+  suffices ∀ m l, (toEnd R L M x ^ l) m ∈ lowerCentralSeries R L M l by
     intro m hm
     obtain ⟨n, rfl⟩ := (mem_posFittingCompOf R x m).mp hm k
     exact this n k
@@ -424,18 +424,18 @@ lemma posFittingComp_le_iInf_lowerCentralSeries :
   apply iInf_lcs_le_of_isNilpotent_quot
   rw [LieModule.isNilpotent_iff_forall']
   intro x
-  obtain ⟨k, hk⟩ := Filter.eventually_atTop.mp (toEndomorphism R L M x).eventually_iInf_range_pow_eq
+  obtain ⟨k, hk⟩ := Filter.eventually_atTop.mp (toEnd R L M x).eventually_iInf_range_pow_eq
   use k
   ext ⟨m⟩
   set F := posFittingComp R L M
-  replace hk : (toEndomorphism R L M x ^ k) m ∈ F := by
+  replace hk : (toEnd R L M x ^ k) m ∈ F := by
     apply posFittingCompOf_le_posFittingComp R L M x
     simp_rw [← LieSubmodule.mem_coeSubmodule, posFittingCompOf, hk k (le_refl k)]
     apply LinearMap.mem_range_self
-  suffices (toEndomorphism R L (M ⧸ F) x ^ k) (LieSubmodule.Quotient.mk (N := F) m) =
-    LieSubmodule.Quotient.mk (N := F) ((toEndomorphism R L M x ^ k) m) by simpa [this]
+  suffices (toEnd R L (M ⧸ F) x ^ k) (LieSubmodule.Quotient.mk (N := F) m) =
+    LieSubmodule.Quotient.mk (N := F) ((toEnd R L M x ^ k) m) by simpa [this]
   have := LinearMap.congr_fun (LinearMap.commute_pow_left_of_commute
-    (LieSubmodule.Quotient.toEndomorphism_comp_mk' F x) k) m
+    (LieSubmodule.Quotient.toEnd_comp_mk' F x) k) m
   simpa using this
 
 @[simp] lemma posFittingComp_eq_bot_of_isNilpotent
@@ -459,7 +459,7 @@ lemma map_posFittingComp_le :
   intro k
   obtain ⟨n, hn⟩ := hm k
   use f n
-  rw [LieModule.toEndomorphism_pow_apply_map, hn]
+  rw [LieModule.toEnd_pow_apply_map, hn]
 
 lemma map_weightSpace_le :
     (weightSpace M χ).map f ≤ weightSpace M₂ χ := by
@@ -467,7 +467,7 @@ lemma map_weightSpace_le :
   intro m hm
   simp only [LieSubmodule.mem_comap, mem_weightSpace]
   intro x
-  have : (toEndomorphism R L M₂ x - χ x • ↑1) ∘ₗ f = f ∘ₗ (toEndomorphism R L M x - χ x • ↑1) := by
+  have : (toEnd R L M₂ x - χ x • ↑1) ∘ₗ f = f ∘ₗ (toEnd R L M x - χ x • ↑1) := by
     ext; simp
   obtain ⟨k, h⟩ := (mem_weightSpace _ _ _).mp hm x
   exact ⟨k, by simpa [h] using LinearMap.congr_fun (LinearMap.commute_pow_left_of_commute this k) m⟩
@@ -480,11 +480,11 @@ lemma comap_weightSpace_eq_of_injective (hf : Injective f) :
   · simp only [LieSubmodule.mem_comap, mem_weightSpace] at hm
     simp only [mem_weightSpace]
     intro x
-    have h : (toEndomorphism R L M₂ x - χ x • ↑1) ∘ₗ f =
-             f ∘ₗ (toEndomorphism R L M x - χ x • ↑1) := by ext; simp
+    have h : (toEnd R L M₂ x - χ x • ↑1) ∘ₗ f =
+             f ∘ₗ (toEnd R L M x - χ x • ↑1) := by ext; simp
     obtain ⟨k, hk⟩ := hm x
     use k
-    suffices f (((toEndomorphism R L M x - χ x • ↑1) ^ k) m) = 0 by
+    suffices f (((toEnd R L M x - χ x • ↑1) ^ k) m) = 0 by
       rw [← f.map_zero] at this; exact hf this
     simpa [hk] using (LinearMap.congr_fun (LinearMap.commute_pow_left_of_commute h k) m).symm
   · rw [← LieSubmodule.map_le_iff_le_comap]
@@ -542,7 +542,7 @@ lemma isCompl_weightSpaceOf_zero_posFittingCompOf (x : L) :
   simpa only [isCompl_iff, codisjoint_iff, disjoint_iff, ← LieSubmodule.coe_toSubmodule_eq_iff,
     LieSubmodule.sup_coe_toSubmodule, LieSubmodule.inf_coe_toSubmodule,
     LieSubmodule.top_coeSubmodule, LieSubmodule.bot_coeSubmodule, coe_weightSpaceOf_zero] using
-    (toEndomorphism R L M x).isCompl_iSup_ker_pow_iInf_range_pow
+    (toEnd R L M x).isCompl_iSup_ker_pow_iInf_range_pow
 
 /-- This lemma exists only to simplify the proof of
 `LieModule.isCompl_weightSpace_zero_posFittingComp`. -/
@@ -636,14 +636,14 @@ lemma independent_weightSpace [NoZeroSMulDivisors R M] :
     exact ⟨hx, this⟩
   obtain ⟨y, hy, z, hz, rfl⟩ := (LieSubmodule.mem_sup _ _ _).mp hx'; clear hx'
   suffices ∀ l, ∃ (k : ℕ),
-      ((toEndomorphism R L M l - algebraMap R (Module.End R M) (χ₂ l)) ^ k) (y + z) ∈
+      ((toEnd R L M l - algebraMap R (Module.End R M) (χ₂ l)) ^ k) (y + z) ∈
       weightSpace M χ₁ ⊓ Finset.sup s fun χ ↦ weightSpace M χ by
     simpa only [ih.eq_bot, LieSubmodule.mem_bot, mem_weightSpace] using this
   intro l
-  let g : Module.End R M := toEndomorphism R L M l - algebraMap R (Module.End R M) (χ₂ l)
+  let g : Module.End R M := toEnd R L M l - algebraMap R (Module.End R M) (χ₂ l)
   obtain ⟨k, hk : (g ^ k) y = 0⟩ := (mem_weightSpace _ _ _).mp hy l
   refine ⟨k, (LieSubmodule.mem_inf _ _ _).mp ⟨?_, ?_⟩⟩
-  · exact LieSubmodule.mapsTo_pow_toEndomorphism_sub_algebraMap _ hx
+  · exact LieSubmodule.mapsTo_pow_toEnd_sub_algebraMap _ hx
   · rw [map_add, hk, zero_add]
     suffices (s.sup fun χ ↦ weightSpace M χ : Submodule R M).map (g ^ k) ≤
         s.sup fun χ ↦ weightSpace M χ by
@@ -655,7 +655,7 @@ lemma independent_weightSpace [NoZeroSMulDivisors R M] :
       LieSubmodule.iSup_coe_toSubmodule]
     refine iSup₂_mono fun χ _ ↦ ?_
     rintro - ⟨u, hu, rfl⟩
-    exact LieSubmodule.mapsTo_pow_toEndomorphism_sub_algebraMap _ hu
+    exact LieSubmodule.mapsTo_pow_toEnd_sub_algebraMap _ hu
 
 lemma independent_weightSpace' [NoZeroSMulDivisors R M] :
     CompleteLattice.Independent fun χ : Weight R L M ↦ weightSpace M χ :=
@@ -665,7 +665,7 @@ lemma independent_weightSpace' [NoZeroSMulDivisors R M] :
 lemma independent_weightSpaceOf [NoZeroSMulDivisors R M] (x : L) :
     CompleteLattice.Independent fun (χ : R) ↦ weightSpaceOf M χ x := by
   rw [LieSubmodule.independent_iff_coe_toSubmodule]
-  exact (toEndomorphism R L M x).independent_generalizedEigenspace
+  exact (toEnd R L M x).independent_generalizedEigenspace
 
 lemma finite_weightSpaceOf_ne_bot [NoZeroSMulDivisors R M] [IsNoetherian R M] (x : L) :
     {χ : R | weightSpaceOf M χ x ≠ ⊥}.Finite :=
@@ -689,7 +689,7 @@ noncomputable instance Weight.instFintype [NoZeroSMulDivisors R M] [IsNoetherian
 /-- A Lie module `M` of a Lie algebra `L` is triangularizable if the endomorhpism of `M` defined by
 any `x : L` is triangularizable. -/
 class IsTriangularizable : Prop :=
-  iSup_eq_top : ∀ x, ⨆ φ, ⨆ k, (toEndomorphism R L M x).generalizedEigenspace φ k = ⊤
+  iSup_eq_top : ∀ x, ⨆ φ, ⨆ k, (toEnd R L M x).generalizedEigenspace φ k = ⊤
 
 @[simp]
 lemma iSup_weightSpaceOf_eq_top [IsTriangularizable R L M] (x : L) :
@@ -700,15 +700,15 @@ lemma iSup_weightSpaceOf_eq_top [IsTriangularizable R L M] (x : L) :
 
 open LinearMap FiniteDimensional in
 @[simp]
-lemma trace_toEndomorphism_weightSpace [IsDomain R] [IsPrincipalIdealRing R]
+lemma trace_toEnd_weightSpace [IsDomain R] [IsPrincipalIdealRing R]
     [Module.Free R M] [Module.Finite R M] (χ : L → R) (x : L) :
-    trace R _ (toEndomorphism R L (weightSpace M χ) x) = finrank R (weightSpace M χ) • χ x := by
-  suffices _root_.IsNilpotent ((toEndomorphism R L (weightSpace M χ) x) - χ x • LinearMap.id) by
+    trace R _ (toEnd R L (weightSpace M χ) x) = finrank R (weightSpace M χ) • χ x := by
+  suffices _root_.IsNilpotent ((toEnd R L (weightSpace M χ) x) - χ x • LinearMap.id) by
     replace this := (isNilpotent_trace_of_isNilpotent this).eq_zero
     rwa [map_sub, map_smul, trace_id, sub_eq_zero, smul_eq_mul, mul_comm,
       ← nsmul_eq_mul] at this
   rw [← Module.algebraMap_end_eq_smul_id]
-  exact isNilpotent_toEndomorphism_sub_algebraMap M χ x
+  exact isNilpotent_toEnd_sub_algebraMap M χ x
 
 section field
 
@@ -723,7 +723,7 @@ instance instIsTriangularizableOfIsAlgClosed [IsAlgClosed K] : IsTriangularizabl
 
 instance (N : LieSubmodule K L M) [IsTriangularizable K L M] : IsTriangularizable K L N := by
   refine ⟨fun y ↦ ?_⟩
-  rw [← N.toEndomorphism_restrict_eq_toEndomorphism y]
+  rw [← N.toEnd_restrict_eq_toEnd y]
   exact Module.End.iSup_generalizedEigenspace_restrict_eq_top _ (IsTriangularizable.iSup_eq_top y)
 
 /-- For a triangularizable Lie module in finite dimensions, the weight spaces span the entire space.

--- a/Mathlib/Algebra/Lie/Weights/Cartan.lean
+++ b/Mathlib/Algebra/Lie/Weights/Cartan.lean
@@ -66,7 +66,7 @@ theorem lie_mem_weightSpace_of_mem_weightSpace {χ₁ χ₂ : H → R} {x : L} {
     rw [rootSpace, weightSpace, LieSubmodule.mem_iInf] at hx; exact hx y
   replace hm : m ∈ weightSpaceOf M (χ₂ y) y := by
     rw [weightSpace, LieSubmodule.mem_iInf] at hm; exact hm y
-  exact lie_mem_maxGenEigenspace_toEndomorphism hx hm
+  exact lie_mem_maxGenEigenspace_toEnd hx hm
 #align lie_algebra.lie_mem_weight_space_of_mem_weight_space LieAlgebra.lie_mem_weightSpace_of_mem_weightSpace
 
 variable (R L H M)
@@ -121,9 +121,9 @@ theorem coe_rootSpaceWeightSpaceProduct_tmul (χ₁ χ₂ χ₃ : H → R) (hχ 
     Submodule.coe_mk]
 #align lie_algebra.coe_root_space_weight_space_product_tmul LieAlgebra.coe_rootSpaceWeightSpaceProduct_tmul
 
-theorem mapsTo_toEndomorphism_weightSpace_add_of_mem_rootSpace (α χ : H → R)
+theorem mapsTo_toEnd_weightSpace_add_of_mem_rootSpace (α χ : H → R)
     {x : L} (hx : x ∈ rootSpace H α) :
-    MapsTo (toEndomorphism R L M x) (weightSpace M χ) (weightSpace M (α + χ)) := by
+    MapsTo (toEnd R L M x) (weightSpace M χ) (weightSpace M (α + χ)) := by
   intro m hm
   let x' : rootSpace H α := ⟨x, hx⟩
   let m' : weightSpace M χ := ⟨m, hm⟩
@@ -161,7 +161,7 @@ theorem coe_zeroRootSubalgebra : (zeroRootSubalgebra R L H : Submodule R L) = ro
 #align lie_algebra.coe_zero_root_subalgebra LieAlgebra.coe_zeroRootSubalgebra
 
 theorem mem_zeroRootSubalgebra (x : L) :
-    x ∈ zeroRootSubalgebra R L H ↔ ∀ y : H, ∃ k : ℕ, (toEndomorphism R H L y ^ k) x = 0 := by
+    x ∈ zeroRootSubalgebra R L H ↔ ∀ y : H, ∃ k : ℕ, (toEnd R H L y ^ k) x = 0 := by
   change x ∈ rootSpace H 0 ↔ _
   simp only [mem_weightSpace, Pi.zero_apply, zero_smul, sub_zero]
 #align lie_algebra.mem_zero_root_subalgebra LieAlgebra.mem_zeroRootSubalgebra
@@ -173,17 +173,17 @@ theorem toLieSubmodule_le_rootSpace_zero : H.toLieSubmodule ≤ rootSpace H 0 :=
   intro y
   obtain ⟨k, hk⟩ := (inferInstance : IsNilpotent R H)
   use k
-  let f : Module.End R H := toEndomorphism R H H y
-  let g : Module.End R L := toEndomorphism R H L y
+  let f : Module.End R H := toEnd R H H y
+  let g : Module.End R L := toEnd R H L y
   have hfg : g.comp (H : Submodule R L).subtype = (H : Submodule R L).subtype.comp f := by
     ext z
-    simp only [toEndomorphism_apply_apply, Submodule.subtype_apply,
+    simp only [toEnd_apply_apply, Submodule.subtype_apply,
       LieSubalgebra.coe_bracket_of_module, LieSubalgebra.coe_bracket, Function.comp_apply,
       LinearMap.coe_comp]
     rfl
   change (g ^ k).comp (H : Submodule R L).subtype ⟨x, hx⟩ = 0
   rw [LinearMap.commute_pow_left_of_commute hfg k]
-  have h := iterate_toEndomorphism_mem_lowerCentralSeries R H H y ⟨x, hx⟩ k
+  have h := iterate_toEnd_mem_lowerCentralSeries R H H y ⟨x, hx⟩ k
   rw [hk, LieSubmodule.mem_bot] at h
   simp only [Submodule.subtype_apply, Function.comp_apply, LinearMap.pow_apply, LinearMap.coe_comp,
     Submodule.coe_eq_zero]
@@ -209,7 +209,7 @@ theorem zeroRootSubalgebra_normalizer_eq_self :
   obtain ⟨k, hk⟩ := hx ⟨y, hy⟩
   rw [← lie_skew, LinearMap.map_neg, neg_eq_zero] at hk
   use k + 1
-  rw [LinearMap.iterate_succ, LinearMap.coe_comp, Function.comp_apply, toEndomorphism_apply_apply,
+  rw [LinearMap.iterate_succ, LinearMap.coe_comp, Function.comp_apply, toEnd_apply_apply,
     LieSubalgebra.coe_bracket_of_module, Submodule.coe_mk, hk]
 #align lie_algebra.zero_root_subalgebra_normalizer_eq_self LieAlgebra.zeroRootSubalgebra_normalizer_eq_self
 

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -30,7 +30,7 @@ We provide basic definitions and results to support `α`-chain techniques in thi
    trivial.
  * `LieModule.weightSpaceChain`: given weights `χ₁`, `χ₂` together with integers `p` and `q`, this
    is the sum of the weight spaces `k • χ₁ + χ₂` for `p < k < q`.
- * `LieModule.trace_toEndomorphism_weightSpaceChain_eq_zero`: given a root `α` relative to a Cartan
+ * `LieModule.trace_toEnd_weightSpaceChain_eq_zero`: given a root `α` relative to a Cartan
    subalgebra `H`, there is a natural ideal `corootSpace α` in `H`. This lemma
    states that this ideal acts by trace-zero endomorphisms on the sum of root spaces of any
    `α`-chain, provided the weight spaces at the endpoints are both trivial.
@@ -153,11 +153,11 @@ section IsCartanSubalgebra
 
 variable [H.IsCartanSubalgebra] [IsNoetherian R L]
 
-lemma trace_toEndomorphism_weightSpaceChain_eq_zero
+lemma trace_toEnd_weightSpaceChain_eq_zero
     (hp : weightSpace M (p • α + χ) = ⊥)
     (hq : weightSpace M (q • α + χ) = ⊥)
     {x : H} (hx : x ∈ corootSpace α) :
-    LinearMap.trace R _ (toEndomorphism R H (weightSpaceChain M α χ p q) x) = 0 := by
+    LinearMap.trace R _ (toEnd R H (weightSpaceChain M α χ p q) x) = 0 := by
   rw [LieAlgebra.mem_corootSpace'] at hx
   induction hx using Submodule.span_induction'
   · next u hu =>
@@ -172,7 +172,7 @@ lemma trace_toEndomorphism_weightSpaceChain_eq_zero
           lie_mem_weightSpaceChain_of_weightSpace_eq_bot_left M α χ p q hp hz hm⟩
         map_add' := fun _ _ ↦ by simp
         map_smul' := fun t m ↦ by simp }
-    have hfg : toEndomorphism R H _ u = ⁅f, g⁆ := by ext; simp [f, g, ← hyz]
+    have hfg : toEnd R H _ u = ⁅f, g⁆ := by ext; simp [f, g, ← hyz]
     simp [hfg]
   · simp
   · simp_all
@@ -203,14 +203,14 @@ lemma exists_forall_mem_corootSpace_smul_add_eq_zero
     rw [← LieSubmodule.independent_iff_coe_toSubmodule]
     refine (independent_weightSpace R H M).comp fun i j hij ↦ ?_
     exact SetCoe.ext <| smul_left_injective ℤ hα <| by rwa [add_left_inj] at hij
-  have h₂ : ∀ i, MapsTo (toEndomorphism R H M x) ↑(N i) ↑(N i) := fun _ _ ↦ LieSubmodule.lie_mem _
+  have h₂ : ∀ i, MapsTo (toEnd R H M x) ↑(N i) ↑(N i) := fun _ _ ↦ LieSubmodule.lie_mem _
   have h₃ : weightSpaceChain M α χ p q = ⨆ i ∈ Finset.Ioo p q, N i := by
     simp_rw [weightSpaceChain_def', LieSubmodule.iSup_coe_toSubmodule]
-  rw [← trace_toEndomorphism_weightSpaceChain_eq_zero M α χ p q hp hq hx,
-    ← LieSubmodule.toEndomorphism_restrict_eq_toEndomorphism,
+  rw [← trace_toEnd_weightSpaceChain_eq_zero M α χ p q hp hq hx,
+    ← LieSubmodule.toEnd_restrict_eq_toEnd,
     LinearMap.trace_eq_sum_trace_restrict_of_eq_biSup _ h₁ h₂ (weightSpaceChain M α χ p q) h₃]
-  simp_rw [LieSubmodule.toEndomorphism_restrict_eq_toEndomorphism,
-    trace_toEndomorphism_weightSpace, Pi.add_apply, Pi.smul_apply, smul_add, ← smul_assoc,
+  simp_rw [LieSubmodule.toEnd_restrict_eq_toEnd,
+    trace_toEnd_weightSpace, Pi.add_apply, Pi.smul_apply, smul_add, ← smul_assoc,
     Finset.sum_add_distrib, ← Finset.sum_smul, natCast_zsmul]
 
 end IsCartanSubalgebra

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -103,8 +103,8 @@ lemma killingForm_apply_eq_zero_of_mem_rootSpace_of_add_ne_zero {α β : H → K
   have hσ : ∀ γ, σ γ ≠ γ := fun γ ↦ by simpa only [σ, ← add_assoc] using add_left_ne_self.mpr hαβ
   let f : Module.End K L := (ad K L x) ∘ₗ (ad K L y)
   have hf : ∀ γ, MapsTo f (rootSpace H γ) (rootSpace H (σ γ)) := fun γ ↦
-    (mapsTo_toEndomorphism_weightSpace_add_of_mem_rootSpace K L H L α (β + γ) hx).comp <|
-      mapsTo_toEndomorphism_weightSpace_add_of_mem_rootSpace K L H L β γ hy
+    (mapsTo_toEnd_weightSpace_add_of_mem_rootSpace K L H L α (β + γ) hx).comp <|
+      mapsTo_toEnd_weightSpace_add_of_mem_rootSpace K L H L β γ hy
   classical
   have hds := DirectSum.isInternal_submodule_of_independent_of_iSup_eq_top
     (LieSubmodule.independent_iff_coe_toSubmodule.mp <| independent_weightSpace K H L)
@@ -142,7 +142,7 @@ lemma eq_zero_of_isNilpotent_ad_of_mem_isCartanSubalgebra {x : L} (hx : x ∈ H)
   suffices ⟨x, hx⟩ ∈ LinearMap.ker (traceForm K H L) by simpa using this
   simp only [LinearMap.mem_ker]
   ext y
-  have comm : Commute (toEndomorphism K H L ⟨x, hx⟩) (toEndomorphism K H L y) := by
+  have comm : Commute (toEnd K H L ⟨x, hx⟩) (toEnd K H L y) := by
     rw [commute_iff_lie_eq, ← LieHom.map_lie, trivial_lie_zero, LieHom.map_zero]
   rw [traceForm_apply_apply, ← LinearMap.mul_eq_comp, LinearMap.zero_apply]
   exact (LinearMap.isNilpotent_trace_of_isNilpotent (comm.isNilpotent_mul_left hx')).eq_zero
@@ -166,7 +166,7 @@ lemma isSemisimple_ad_of_mem_isCartanSubalgebra [PerfectField K] {x : L} (hx : x
   have h_der (y z : L) (α β : H → K) (hy : y ∈ rootSpace H α) (hz : z ∈ rootSpace H β) :
       S ⁅y, z⁆ = ⁅S y, z⁆ + ⁅y, S z⁆ := by
     have hyz : ⁅y, z⁆ ∈ rootSpace H (α + β) :=
-      mapsTo_toEndomorphism_weightSpace_add_of_mem_rootSpace K L H L α β hy hz
+      mapsTo_toEnd_weightSpace_add_of_mem_rootSpace K L H L α β hy hz
     rw [aux hy, aux hz, aux hyz, smul_lie, lie_smul, ← add_smul, ← Pi.add_apply]
   /- Thus `S` is a derivation since root spaces span. -/
   replace h_der (y z : L) : S ⁅y, z⁆ = ⁅S y, z⁆ + ⁅y, S z⁆ := by
@@ -229,7 +229,7 @@ lemma cartanEquivDual_symm_apply_mem_corootSpace (α : Weight K H L) :
   apply mem_ker_killingForm_of_mem_rootSpace_of_forall_rootSpace_neg (α := (0 : H → K))
   · simp only [rootSpace_zero_eq, LieSubalgebra.mem_toLieSubmodule]
     refine sub_mem ?_ (H.smul_mem _ α'.property)
-    simpa using mapsTo_toEndomorphism_weightSpace_add_of_mem_rootSpace K L H L α (-α) heα hfα
+    simpa using mapsTo_toEnd_weightSpace_add_of_mem_rootSpace K L H L α (-α) heα hfα
   · intro z hz
     replace hz : z ∈ H := by simpa using hz
     replace he : ⁅z, e⁆ = α ⟨z, hz⟩ • e := by simpa using he ⟨z, hz⟩

--- a/Mathlib/Algebra/Lie/Weights/Linear.lean
+++ b/Mathlib/Algebra/Lie/Weights/Linear.lean
@@ -91,19 +91,19 @@ end Weight
 instance instLinearWeightsOfIsLieAbelian [IsLieAbelian L] [NoZeroSMulDivisors R M] :
     LinearWeights R L M :=
   have aux : ∀ (χ : L → R), weightSpace M χ ≠ ⊥ → ∀ (x y : L), χ (x + y) = χ x + χ y := by
-    have h : ∀ x y, Commute (toEndomorphism R L M x) (toEndomorphism R L M y) := fun x y ↦ by
+    have h : ∀ x y, Commute (toEnd R L M x) (toEnd R L M y) := fun x y ↦ by
       rw [commute_iff_lie_eq, ← LieHom.map_lie, trivial_lie_zero, LieHom.map_zero]
     intro χ hχ x y
     simp_rw [Ne, ← LieSubmodule.coe_toSubmodule_eq_iff, weightSpace, weightSpaceOf,
       LieSubmodule.iInf_coe_toSubmodule, LieSubmodule.bot_coeSubmodule] at hχ
     exact Module.End.map_add_of_iInf_generalizedEigenspace_ne_bot_of_commute
-      (toEndomorphism R L M).toLinearMap χ hχ h x y
+      (toEnd R L M).toLinearMap χ hχ h x y
   { map_add := aux
     map_smul := fun χ hχ t x ↦ by
       simp_rw [Ne, ← LieSubmodule.coe_toSubmodule_eq_iff, weightSpace, weightSpaceOf,
         LieSubmodule.iInf_coe_toSubmodule, LieSubmodule.bot_coeSubmodule] at hχ
       exact Module.End.map_smul_of_iInf_generalizedEigenspace_ne_bot
-        (toEndomorphism R L M).toLinearMap χ hχ t x
+        (toEnd R L M).toLinearMap χ hχ t x
     map_lie := fun χ hχ t x ↦ by
       rw [trivial_lie_zero, ← add_left_inj (χ 0), ← aux χ hχ, zero_add, zero_add] }
 
@@ -114,19 +114,19 @@ open FiniteDimensional
 variable [IsDomain R] [IsPrincipalIdealRing R] [Module.Free R M] [Module.Finite R M]
   [LieAlgebra.IsNilpotent R L]
 
-lemma trace_comp_toEndomorphism_weightSpace_eq (χ : L → R) :
-    LinearMap.trace R _ ∘ₗ (toEndomorphism R L (weightSpace M χ)).toLinearMap =
+lemma trace_comp_toEnd_weightSpace_eq (χ : L → R) :
+    LinearMap.trace R _ ∘ₗ (toEnd R L (weightSpace M χ)).toLinearMap =
     finrank R (weightSpace M χ) • χ := by
   ext x
-  let n := toEndomorphism R L (weightSpace M χ) x - χ x • LinearMap.id
-  have h₁ : toEndomorphism R L (weightSpace M χ) x = n + χ x • LinearMap.id := eq_add_of_sub_eq rfl
+  let n := toEnd R L (weightSpace M χ) x - χ x • LinearMap.id
+  have h₁ : toEnd R L (weightSpace M χ) x = n + χ x • LinearMap.id := eq_add_of_sub_eq rfl
   have h₂ : LinearMap.trace R _ n = 0 := IsReduced.eq_zero _ <|
-    LinearMap.isNilpotent_trace_of_isNilpotent <| isNilpotent_toEndomorphism_sub_algebraMap M χ x
+    LinearMap.isNilpotent_trace_of_isNilpotent <| isNilpotent_toEnd_sub_algebraMap M χ x
   rw [LinearMap.comp_apply, LieHom.coe_toLinearMap, h₁, map_add, h₂]
   simp [mul_comm (χ x)]
 
 @[deprecated] -- 2024-04-06
-alias trace_comp_toEndomorphism_weight_space_eq := trace_comp_toEndomorphism_weightSpace_eq
+alias trace_comp_toEnd_weight_space_eq := trace_comp_toEnd_weightSpace_eq
 
 variable {R L M} in
 lemma zero_lt_finrank_weightSpace {χ : L → R} (hχ : weightSpace M χ ≠ ⊥) :
@@ -140,13 +140,13 @@ instance instLinearWeightsOfCharZero [CharZero R] :
     LinearWeights R L M where
   map_add χ hχ x y := by
     rw [← smul_right_inj (zero_lt_finrank_weightSpace hχ).ne', smul_add, ← Pi.smul_apply,
-      ← Pi.smul_apply, ← Pi.smul_apply, ← trace_comp_toEndomorphism_weightSpace_eq, map_add]
+      ← Pi.smul_apply, ← Pi.smul_apply, ← trace_comp_toEnd_weightSpace_eq, map_add]
   map_smul χ hχ t x := by
     rw [← smul_right_inj (zero_lt_finrank_weightSpace hχ).ne', smul_comm, ← Pi.smul_apply,
-      ← Pi.smul_apply (finrank R _), ← trace_comp_toEndomorphism_weightSpace_eq, map_smul]
+      ← Pi.smul_apply (finrank R _), ← trace_comp_toEnd_weightSpace_eq, map_smul]
   map_lie χ hχ x y := by
     rw [← smul_right_inj (zero_lt_finrank_weightSpace hχ).ne', nsmul_zero, ← Pi.smul_apply,
-      ← trace_comp_toEndomorphism_weightSpace_eq, LinearMap.comp_apply, LieHom.coe_toLinearMap,
+      ← trace_comp_toEnd_weightSpace_eq, LinearMap.comp_apply, LieHom.coe_toLinearMap,
       LieHom.map_lie, Ring.lie_def, map_sub, LinearMap.trace_mul_comm, sub_self]
 
 end FiniteDimensional
@@ -198,15 +198,15 @@ instance : LieModule R L (shiftedWeightSpace R L M χ) where
 equivalent. -/
 @[simps!] def shift : weightSpace M χ ≃ₗ[R] shiftedWeightSpace R L M χ := LinearEquiv.refl R _
 
-lemma toEndomorphism_eq (x : L) :
-    toEndomorphism R L (shiftedWeightSpace R L M χ) x =
-    (shift R L M χ).conj (toEndomorphism R L (weightSpace M χ) x - χ x • LinearMap.id) := by
+lemma toEnd_eq (x : L) :
+    toEnd R L (shiftedWeightSpace R L M χ) x =
+    (shift R L M χ).conj (toEnd R L (weightSpace M χ) x - χ x • LinearMap.id) := by
   ext; simp [LinearEquiv.conj_apply]
 
 /-- By Engel's theorem, if `M` is Noetherian, the shifted action `⁅x, m⁆ - χ x • m` makes the
 `χ`-weight space into a nilpotent Lie module. -/
 instance [IsNoetherian R M] : IsNilpotent R L (shiftedWeightSpace R L M χ) :=
-  LieModule.isNilpotent_iff_forall'.mpr fun x ↦ isNilpotent_toEndomorphism_sub_algebraMap M χ x
+  LieModule.isNilpotent_iff_forall'.mpr fun x ↦ isNilpotent_toEnd_sub_algebraMap M χ x
 
 end shiftedWeightSpace
 


### PR DESCRIPTION
This commit was generated using

    rg -l toEndomorphism | xargs sed -i 's/toEndomorphism/toEnd/g'

The upshot is shorter names of the defn and of many lemmas.
It also matches the name `End` of the target of the map.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
