### PR TITLE
[Merged by Bors] - chore: move LinearOrder Nat instance to Mathlib.Data.Nat.Defs

### DIFF
--- a/Archive/Arithcc.lean
+++ b/Archive/Arithcc.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Xi Wang
 -/
 import Mathlib.Init.Data.Nat.Lemmas
+import Mathlib.Data.Nat.Defs
 import Mathlib.Order.Basic
 import Mathlib.Tactic.Common
 

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad
 -/
-import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Init.Function
+import Mathlib.Init.Order.Defs
 
 #align_import data.bool.basic from "leanprover-community/mathlib"@"c4658a649d216f57e99621708b09dcb3dcccbd23"
 
@@ -276,7 +276,7 @@ theorem ofNat_le_ofNat {n m : Nat} (h : n ≤ m) : ofNat n ≤ ofNat m := by
   | isFalse hn =>
     cases Nat.decEq m 0 with
     | isFalse hm => rw [_root_.decide_eq_false hm]; exact Bool.le_true _
-    | isTrue hm => subst hm; have h := le_antisymm h (Nat.zero_le n); contradiction
+    | isTrue hm => subst hm; have h := Nat.le_antisymm h (Nat.zero_le n); contradiction
 #align bool.of_nat_le_of_nat Bool.ofNat_le_ofNat
 
 theorem toNat_le_toNat {b₀ b₁ : Bool} (h : b₀ ≤ b₁) : toNat b₀ ≤ toNat b₁ := by

--- a/Mathlib/Data/List/ReduceOption.lean
+++ b/Mathlib/Data/List/ReduceOption.lean
@@ -3,9 +3,10 @@ Copyright (c) 2020 Yakov Pechersky. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yakov Pechersky
 -/
-import Mathlib.Order.Basic
+import Batteries.Data.List.Lemmas
 import Mathlib.Init.Data.Bool.Lemmas
-import Mathlib.Init.Data.Nat.Lemmas
+import Mathlib.Tactic.Cases
+import Mathlib.Tactic.TypeStar
 
 /-!
 # Properties of `List.reduceOption`
@@ -67,7 +68,7 @@ theorem reduceOption_length_eq_iff {l : List (Option α)} :
       intro H
       have := reduceOption_length_le tl
       rw [H] at this
-      exact absurd (Nat.lt_succ_self _) (not_lt_of_le this)
+      exact absurd (Nat.lt_succ_self _) (Nat.not_lt_of_le this)
     · simp only [length, mem_cons, forall_eq_or_imp, Option.isSome_some, ← hl, reduceOption,
         true_and]
       omega
@@ -75,7 +76,8 @@ theorem reduceOption_length_eq_iff {l : List (Option α)} :
 
 theorem reduceOption_length_lt_iff {l : List (Option α)} :
     l.reduceOption.length < l.length ↔ none ∈ l := by
-  rw [(reduceOption_length_le l).lt_iff_ne, Ne, reduceOption_length_eq_iff]
+  rw [Nat.lt_iff_le_and_ne, and_iff_right (reduceOption_length_le l), Ne,
+    reduceOption_length_eq_iff]
   induction l <;> simp [*]
   rw [@eq_comm _ none, ← Option.not_isSome_iff_eq_none, Decidable.imp_iff_not_or]
 #align list.reduce_option_length_lt_iff List.reduceOption_length_lt_iff

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -64,6 +64,20 @@ open Function
 namespace Nat
 variable {a b c d m n k : ℕ} {p q : ℕ → Prop}
 
+-- TODO: Move the `LinearOrder ℕ` instance to `Order.Nat` (#13092).
+instance instLinearOrder : LinearOrder ℕ where
+  le := Nat.le
+  le_refl := @Nat.le_refl
+  le_trans := @Nat.le_trans
+  le_antisymm := @Nat.le_antisymm
+  le_total := @Nat.le_total
+  lt := Nat.lt
+  lt_iff_le_not_le := @Nat.lt_iff_le_not_le
+  decidableLT := inferInstance
+  decidableLE := inferInstance
+  decidableEq := inferInstance
+#align nat.linear_order Nat.instLinearOrder
+
 instance instNontrivial : Nontrivial ℕ := ⟨⟨0, 1, Nat.zero_ne_one⟩⟩
 
 @[simp] theorem default_eq_zero : default = 0 := rfl

--- a/Mathlib/Data/PNat/Defs.lean
+++ b/Mathlib/Data/PNat/Defs.lean
@@ -3,8 +3,8 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Neil Strickland
 -/
-import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Algebra.NeZero
+import Mathlib.Data.Nat.Defs
 import Mathlib.Order.Basic
 import Mathlib.Tactic.Coe
 import Mathlib.Tactic.Lift

--- a/Mathlib/Data/UnionFind.lean
+++ b/Mathlib/Data/UnionFind.lean
@@ -3,9 +3,9 @@ Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Init.Data.Nat.Lemmas
-import Mathlib.Init.Order.LinearOrder
 import Batteries.Data.Array.Lemmas
+import Mathlib.Init.Data.Nat.Notation
+import Mathlib.Init.Order.Defs
 
 set_option autoImplicit true
 
@@ -25,7 +25,7 @@ def push {n} (m : UFModel n) (k) (le : n ≤ k) : UFModel k where
   parent i :=
     if h : i < n then
       let ⟨a, h'⟩ := m.parent ⟨i, h⟩
-      ⟨a, lt_of_lt_of_le h' le⟩
+      ⟨a, Nat.lt_of_lt_of_le h' le⟩
     else i
   rank i := if i < n then m.rank i else 0
   rank_lt i := by
@@ -51,7 +51,7 @@ def setParentBump {n} (m : UFModel n) (x y : Fin n)
         (intro h; try simp [h] at h₂ <;> simp [h₁, h₂, h]))
     · simp [← h₁]; split <;> rename_i h₃
       · rw [h₃]; apply Nat.lt_succ_self
-      · exact lt_of_le_of_ne H h₃
+      · exact Nat.lt_of_le_of_ne H h₃
     · have := Fin.eq_of_val_eq h₂.1; subst this
       simp [hroot] at h
     · have := m.rank_lt i h
@@ -98,7 +98,7 @@ theorem push {arr : Array α} {n} {m : Fin n → β} (H : Agrees arr f m)
   refine mk' this fun i h₁ h₂ ↦ ?_
   simp [Array.get_push]; split <;> (rename_i h; simp at hm₁ ⊢)
   · rw [← hm₁ ⟨i, h₂⟩]; assumption
-  · cases show i = arr.size by apply le_antisymm <;> simp_all [Nat.lt_succ]
+  · cases show i = arr.size by apply Nat.le_antisymm <;> simp_all [Nat.lt_succ]
     rw [hm₂]
 
 theorem set {arr : Array α} {n} {m : Fin n → β} (H : Agrees arr f m)
@@ -181,9 +181,9 @@ def rankMaxAux (self : UnionFind α) : ∀ (i : Nat),
   | i+1 => by
     let ⟨k, H⟩ := rankMaxAux self i
     refine ⟨max k (if h : _ then (self.arr.get ⟨i, h⟩).rank else 0), fun j hj h ↦ ?_⟩
-    match j, lt_or_eq_of_le (Nat.le_of_lt_succ hj) with
-    | j, Or.inl hj => exact le_trans (H _ hj h) (le_max_left _ _)
-    | _, Or.inr rfl => simp [h, le_max_right]
+    match j, Nat.lt_or_eq_of_le (Nat.le_of_lt_succ hj) with
+    | j, Or.inl hj => exact Nat.le_trans (H _ hj h) (Nat.le_max_left _ _)
+    | _, Or.inr rfl => simp [h, Nat.le_max_right]
 
 def rankMax (self : UnionFind α) := (rankMaxAux self self.size).1 + 1
 
@@ -217,7 +217,7 @@ def findAux (self : UnionFind α) (x : Fin self.size) :
       m.Models self.arr ∧ m'.Models s ∧ m'.rank = m.rank ∧
       (∃ hr, (m'.parent ⟨root, hr⟩).1 = root) ∧
       m.rank x ≤ m.rank root := by
-  let y := self.arr[x].parent
+  let y := (self.arr[x]'(Fin.isLt x)).parent
   refine if h : y = x then ⟨self.arr, x, ?a'⟩ else
     have := Nat.sub_lt_sub_left (self.lt_rankMax x) (self.rank_lt _ h)
     let ⟨arr₁, root, H⟩ := self.findAux ⟨y, self.parent_lt _ x.2⟩
@@ -227,7 +227,7 @@ def findAux (self : UnionFind α) (x : Fin self.size) :
   -- start proof
   case a' => -- FIXME: hygiene bug causes `case a` to fail
     let ⟨m, hm⟩ := self.model'
-    exact ⟨_, m, m, hm, hm, rfl, ⟨x.2, by rwa [← hm.parent_eq]⟩, le_refl _⟩
+    exact ⟨_, m, m, hm, hm, rfl, ⟨x.2, by rwa [← hm.parent_eq]⟩, Nat.le_refl _⟩
   all_goals let ⟨n, m, m', hm, hm', e, ⟨_, hr⟩, le⟩ := H
   case hx => exact hm'.size_eq ▸ hm.size_eq.symm ▸ x.2
   case b' =>
@@ -235,11 +235,11 @@ def findAux (self : UnionFind α) (x : Fin self.size) :
     let root : Fin n := ⟨root, hm'.size_eq.symm ▸ root.2⟩
     have hy : (UFModel.parent m x').1 = y := by rw [← hm.parent_eq x x.2 x'.2]; rfl
     have := m.rank_lt x'; rw [hy] at this
-    have := lt_of_lt_of_le (this h) le
+    have := Nat.lt_of_lt_of_le (this h) le
     refine ⟨n, m, _, hm,
       hm'.setParent x' root (by rw [e]; exact this) hx _ rfl rfl, e,
-      ⟨root.2, ?_⟩, le_of_lt this⟩
-    have : x.1 ≠ root := mt (congrArg _) (ne_of_lt this); dsimp only at this
+      ⟨root.2, ?_⟩, Nat.le_of_lt this⟩
+    have : x.1 ≠ root := mt (congrArg _) (Nat.ne_of_lt this); dsimp only at this
     simp [UFModel.setParent, this, hr]
 termination_by self.rankMax - self.rank x
 
@@ -255,8 +255,8 @@ def find (self : UnionFind α) (x : Fin self.size) :
 def link (self : UnionFind α) (x y : Fin self.size)
     (yroot : (self.arr.get y).parent = y) : UnionFind α := by
   refine if ne : x.1 = y then self else
-    let nx := self.arr[x]
-    let ny := self.arr[y]
+    let nx := self.arr[x]'(Fin.isLt x)
+    let ny := self.arr[y]'(Fin.isLt y)
     if h : ny.rank < nx.rank then
       ⟨self.arr.set y {ny with parent := x}, ?a⟩
     else

--- a/Mathlib/Data/Vector/Defs.lean
+++ b/Mathlib/Data/Vector/Defs.lean
@@ -3,9 +3,7 @@ Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Init.Order.LinearOrder
 import Mathlib.Init.Data.List.Lemmas
-import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Tactic.Common
 
 #align_import data.vector from "leanprover-community/lean"@"855e5b74e3a52a40552e8f067169d747d48743fd"

--- a/Mathlib/Init/Data/Nat/Lemmas.lean
+++ b/Mathlib/Init/Data/Nat/Lemmas.lean
@@ -6,9 +6,11 @@ Authors: Leonardo de Moura, Jeremy Avigad
 import Batteries.Data.Nat.Lemmas
 import Batteries.WF
 import Mathlib.Init.Data.Nat.Basic
-import Mathlib.Init.Order.Defs
+import Mathlib.Util.AssertExists
 
 #align_import init.data.nat.lemmas from "leanprover-community/lean"@"38b59111b2b4e6c572582b27e8937e92fc70ac02"
+
+assert_not_exists Preorder
 
 universe u
 
@@ -106,19 +108,6 @@ theorem eq_zero_of_mul_eq_zero : ∀ {n m : ℕ}, n * m = 0 → n = 0 ∨ m = 0
 #align nat.lt_of_le_and_ne Nat.lt_of_le_of_ne
 
 #align nat.lt_iff_le_not_le Nat.lt_iff_le_not_le
-
-instance instLinearOrder : LinearOrder ℕ where
-  le := Nat.le
-  le_refl := @Nat.le_refl
-  le_trans := @Nat.le_trans
-  le_antisymm := @Nat.le_antisymm
-  le_total := @Nat.le_total
-  lt := Nat.lt
-  lt_iff_le_not_le := @Nat.lt_iff_le_not_le
-  decidableLT := inferInstance
-  decidableLE := inferInstance
-  decidableEq := inferInstance
-#align nat.linear_order Nat.instLinearOrder
 
 #align nat.eq_zero_of_le_zero Nat.eq_zero_of_le_zero
 
@@ -695,7 +684,7 @@ protected def findX : { n // p n ∧ ∀ m < n, ¬p m } :=
       if pm : p m then ⟨m, pm, al⟩
       else
         have : ∀ n ≤ m, ¬p n := fun n h =>
-          Or.elim (Decidable.lt_or_eq_of_le h) (al n) fun e => by rw [e]; exact pm
+          Or.elim (Nat.lt_or_eq_of_le h) (al n) fun e => by rw [e]; exact pm
         IH _ ⟨rfl, this⟩ fun n h => this n <| Nat.le_of_succ_le_succ h)
     0 fun n h => absurd h (Nat.not_lt_zero _)
 #align nat.find_x Nat.findX
@@ -724,7 +713,7 @@ protected theorem find_min : ∀ {m : ℕ}, m < Nat.find H → ¬p m :=
 #align nat.find_min Nat.find_min
 
 protected theorem find_min' {m : ℕ} (h : p m) : Nat.find H ≤ m :=
-  le_of_not_lt fun l => Nat.find_min H l h
+  Nat.le_of_not_lt fun l => Nat.find_min H l h
 #align nat.find_min' Nat.find_min'
 
 end Find

--- a/Mathlib/Order/Nat.lean
+++ b/Mathlib/Order/Nat.lean
@@ -14,7 +14,7 @@ See note [foundational algebra order theory].
 
 ## TODO
 
-Move the `LinearOrder ℕ` instance here (#13082).
+Move the `LinearOrder ℕ` instance here (#13092).
 -/
 
 namespace Nat

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro, Yury G. Kudryashov
 -/
-import Mathlib.Init.Data.Nat.Lemmas
+import Mathlib.Data.Nat.Defs
 import Mathlib.Logic.IsEmpty
 import Mathlib.Logic.Relation
 import Mathlib.Order.Basic

--- a/test/ExtractGoal.lean
+++ b/test/ExtractGoal.lean
@@ -1,6 +1,7 @@
 import Mathlib.Tactic.ExtractGoal
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Order.Basic
+import Mathlib.Data.Nat.Defs
 
 set_option pp.unicode.fun true
 set_option autoImplicit true

--- a/test/byContra.lean
+++ b/test/byContra.lean
@@ -4,6 +4,7 @@ import Mathlib.Tactic.Rename
 import Mathlib.Tactic.Set
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Order.Basic
+import Mathlib.Data.Nat.Defs
 
 set_option autoImplicit true
 example (a b : ℕ) (foo : False)  : a < b := by

--- a/test/notation3.lean
+++ b/test/notation3.lean
@@ -1,5 +1,6 @@
 import Mathlib.Mathport.Notation
 import Mathlib.Init.Data.Nat.Lemmas
+import Mathlib.Data.Nat.Defs
 
 set_option pp.unicode.fun true
 set_option autoImplicit true


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Preliminary to removing the order dependency from `Mathlib/Data/Nat/Defs.lean`, but that needs a little more work

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
