### PR TITLE
[Merged by Bors] - feat: trace of a permutation matrix

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2701,6 +2701,7 @@ import Mathlib.LinearAlgebra.Matrix.MvPolynomial
 import Mathlib.LinearAlgebra.Matrix.Nondegenerate
 import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 import Mathlib.LinearAlgebra.Matrix.Orthogonal
+import Mathlib.LinearAlgebra.Matrix.Permutation
 import Mathlib.LinearAlgebra.Matrix.Polynomial
 import Mathlib.LinearAlgebra.Matrix.PosDef
 import Mathlib.LinearAlgebra.Matrix.ProjectiveSpecialLinearGroup

--- a/Mathlib/LinearAlgebra/Matrix/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant.lean
@@ -3,17 +3,12 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Chris Hughes, Anne Baanen
 -/
-import Mathlib.Data.Matrix.PEquiv
 import Mathlib.Data.Matrix.Block
 import Mathlib.Data.Matrix.Notation
-import Mathlib.Data.Fintype.BigOperators
-import Mathlib.GroupTheory.Perm.Fin
-import Mathlib.GroupTheory.Perm.Sign
-import Mathlib.Algebra.Algebra.Defs
-import Mathlib.Tactic.Ring
-import Mathlib.LinearAlgebra.Alternating.Basic
-import Mathlib.LinearAlgebra.Pi
+import Mathlib.Data.Matrix.RowCol
 import Mathlib.GroupTheory.GroupAction.Ring
+import Mathlib.GroupTheory.Perm.Fin
+import Mathlib.LinearAlgebra.Alternating.Basic
 
 #align_import linear_algebra.matrix.determinant from "leanprover-community/mathlib"@"c3019c79074b0619edb4b27553a91b2e82242395"
 
@@ -268,14 +263,6 @@ For the `simp` version of this lemma, see `det_submatrix_equiv_self`; this one i
 theorem det_reindex_self (e : m ≃ n) (A : Matrix m m R) : det (reindex e e A) = det A :=
   det_submatrix_equiv_self e.symm A
 #align matrix.det_reindex_self Matrix.det_reindex_self
-
-/-- The determinant of a permutation matrix equals its sign. -/
-@[simp]
-theorem det_permutation (σ : Perm n) :
-    Matrix.det (σ.toPEquiv.toMatrix : Matrix n n R) = Perm.sign σ := by
-  rw [← Matrix.mul_one (σ.toPEquiv.toMatrix : Matrix n n R), PEquiv.toPEquiv_mul_matrix,
-    det_permute, det_one, mul_one]
-#align matrix.det_permutation Matrix.det_permutation
 
 theorem det_smul (A : Matrix n n R) (c : R) : det (c • A) = c ^ Fintype.card n * det A :=
   calc

--- a/Mathlib/LinearAlgebra/Matrix/Permutation.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Permutation.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2020 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+
+import Mathlib.Data.Matrix.PEquiv
+import Mathlib.Data.Set.Card
+import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Trace
+
+/-!
+# Permutation matrices
+
+This file defines the matrix associated with a permutation
+
+## Main definitions
+
+ - `Equiv.Perm.permMatrix`: the permutation matrix associated with an `Equiv.Perm`
+
+## Main results
+
+ - `Matrix.det_permutation`: the determinant is the sign of the permutation
+ - `Matrix.trace_permutation`: the trace is the number of fixed points of the permutation
+
+-/
+
+open BigOperators Matrix Equiv
+
+variable {n R : Type*} [DecidableEq n] [Fintype n] (σ : Perm n)
+
+abbrev Equiv.Perm.permMatrix [Zero R] [One R] : Matrix n n R :=
+  σ.toPEquiv.toMatrix
+
+namespace Matrix
+
+/-- The determinant of a permutation matrix equals its sign. -/
+@[simp]
+theorem det_permutation [CommRing R] : det (σ.permMatrix (R := R)) = Perm.sign σ := by
+  rw [← Matrix.mul_one σ.permMatrix, PEquiv.toPEquiv_mul_matrix,
+    det_permute, det_one, mul_one]
+#align matrix.det_permutation Matrix.det_permutation
+
+/-- The trace of a permutation matrix equals the number of fixed points. -/
+theorem trace_permutation [AddCommMonoid R] :
+    trace σ.permMatrix = (Function.fixedPoints σ).ncard := by
+  delta trace
+  simp [toPEquiv_apply, ← Set.ncard_coe_Finset, Function.fixedPoints, Function.IsFixedPt]
+
+end Matrix

--- a/Mathlib/LinearAlgebra/Matrix/Permutation.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Permutation.lean
@@ -29,6 +29,8 @@ open BigOperators Matrix Equiv
 
 variable {n R : Type*} [DecidableEq n] [Fintype n] (σ : Perm n)
 
+variable (R) in
+/-- the permutation matrix associated with an `Equiv.Perm` -/
 abbrev Equiv.Perm.permMatrix [Zero R] [One R] : Matrix n n R :=
   σ.toPEquiv.toMatrix
 
@@ -36,14 +38,14 @@ namespace Matrix
 
 /-- The determinant of a permutation matrix equals its sign. -/
 @[simp]
-theorem det_permutation [CommRing R] : det (σ.permMatrix (R := R)) = Perm.sign σ := by
-  rw [← Matrix.mul_one σ.permMatrix, PEquiv.toPEquiv_mul_matrix,
+theorem det_permutation [CommRing R] : det (σ.permMatrix R) = Perm.sign σ := by
+  rw [← Matrix.mul_one (σ.permMatrix R), PEquiv.toPEquiv_mul_matrix,
     det_permute, det_one, mul_one]
 #align matrix.det_permutation Matrix.det_permutation
 
 /-- The trace of a permutation matrix equals the number of fixed points. -/
-theorem trace_permutation [AddCommMonoid R] :
-    trace σ.permMatrix = (Function.fixedPoints σ).ncard := by
+theorem trace_permutation [AddCommMonoidWithOne R] :
+    trace (σ.permMatrix R) = (Function.fixedPoints σ).ncard := by
   delta trace
   simp [toPEquiv_apply, ← Set.ncard_coe_Finset, Function.fixedPoints, Function.IsFixedPt]
 

--- a/Mathlib/LinearAlgebra/Matrix/Trace.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Trace.lean
@@ -3,12 +3,8 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 -/
-import Mathlib.Data.Matrix.Basic
 import Mathlib.Data.Matrix.Block
-import Mathlib.Data.Matrix.PEquiv
 import Mathlib.Data.Matrix.RowCol
-import Mathlib.Data.Set.Card
-import Mathlib.Dynamics.FixedPoints.Basic
 
 #align_import linear_algebra.matrix.trace from "leanprover-community/mathlib"@"32b08ef840dd25ca2e47e035c5da03ce16d2dc3c"
 
@@ -198,11 +194,6 @@ lemma trace_submatrix_succ {n : ℕ} [NonUnitalNonAssocSemiring R]
   delta trace
   rw [← (finSuccEquiv n).symm.sum_comp]
   simp
-
-theorem trace_permutation [DecidableEq n] [AddCommMonoidWithOne R] (σ : Equiv.Perm n) :
-    Matrix.trace (σ.toPEquiv.toMatrix : Matrix n n R) = (Function.fixedPoints σ).ncard := by
-  delta trace
-  simp [Equiv.toPEquiv_apply, ← Set.ncard_coe_Finset, Function.fixedPoints, Function.IsFixedPt]
 
 section Fin
 

--- a/Mathlib/LinearAlgebra/Matrix/Trace.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Trace.lean
@@ -5,7 +5,10 @@ Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 -/
 import Mathlib.Data.Matrix.Basic
 import Mathlib.Data.Matrix.Block
+import Mathlib.Data.Matrix.PEquiv
 import Mathlib.Data.Matrix.RowCol
+import Mathlib.Data.Set.Card
+import Mathlib.Dynamics.FixedPoints.Basic
 
 #align_import linear_algebra.matrix.trace from "leanprover-community/mathlib"@"32b08ef840dd25ca2e47e035c5da03ce16d2dc3c"
 
@@ -195,6 +198,11 @@ lemma trace_submatrix_succ {n : ℕ} [NonUnitalNonAssocSemiring R]
   delta trace
   rw [← (finSuccEquiv n).symm.sum_comp]
   simp
+
+theorem trace_permutation [DecidableEq n] [AddCommMonoidWithOne R] (σ : Equiv.Perm n) :
+    Matrix.trace (σ.toPEquiv.toMatrix : Matrix n n R) = (Function.fixedPoints σ).ncard := by
+  delta trace
+  simp [Equiv.toPEquiv_apply, ← Set.ncard_coe_Finset, Function.fixedPoints, Function.IsFixedPt]
 
 section Fin
 


### PR DESCRIPTION
To go with Matrix.det_permutation


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Question: this adds several imports to state the theorem. Should it be put elsewhere?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
