### PR TITLE
chore: Docstring style labels for `FinTM2` structure

### DIFF
--- a/Mathlib/Computability/TMComputable.lean
+++ b/Mathlib/Computability/TMComputable.lean
@@ -43,14 +43,22 @@ namespace Turing
 the namespace `Turing.TM2` in `TuringMachine.lean`), with an input and output stack,
  a main function, an initial state and some finiteness guarantees. -/
 structure FinTM2 where
-  {K : Type} [kDecidableEq : DecidableEq K] [kFin : Fintype K] -- index type of stacks
-  (k₀ k₁ : K) -- input and output stack
-  (Γ : K → Type) -- type of stack elements
+  /-- Index type of stacks -/
+  {K : Type} [kDecidableEq : DecidableEq K] [kFin : Fintype K]
+  /-- Input and output stack -/
+  (k₀ k₁ : K)
+  /-- Type of stack elements -/
+  (Γ : K → Type)
+  /-- Type of function labels -/
   (Λ : Type) (main : Λ) [ΛFin : Fintype Λ] -- type of function labels
-  (σ : Type) (initialState : σ) -- type of states of the machine
+  /-- Type of states of the machine -/
+  (σ : Type)
+  /-- Initial state of the machine -/
+  (initialState : σ)
   [σFin : Fintype σ]
   [Γk₀Fin : Fintype (Γ k₀)]
-  (m : Λ → Turing.TM2.Stmt Γ Λ σ) -- the program itself, i.e. one function for every function label
+  /-- The program itself, i.e. one function for every function label -/
+  (m : Λ → Turing.TM2.Stmt Γ Λ σ)
 #align turing.fin_tm2 Turing.FinTM2
 
 namespace FinTM2


### PR DESCRIPTION
Previously the comments describing the fields of this structure were inline comments. Changing these to docstring-style comments so that the docs will register them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
