### PR TITLE
feat(RingTheory/Valuation/Basic): add API for ℤₘ₀

### DIFF
--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -894,8 +894,6 @@ section WithZero_Multiplicative_stuff
 
 open Multiplicative
 
-open scoped DiscreteValuation
-
 theorem WithZero.Multiplicative.eq_coe_of_pos {α : Type*} {x : WithZero (Multiplicative α)}
     (hx : x ≠ 0) : ∃ (n : α), x = ofAdd n :=
   Option.ne_none_iff_exists'.mp hx

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -907,7 +907,8 @@ theorem WithZero.Multiplicative.eq_zero_or_coe {α : Type*} (x : WithZero (Multi
 open WithZero.Multiplicative
 
 -- this makes `mul_lt_mul_left`, `mul_pos` etc work on `ℤₘ₀`
-instance : PosMulStrictMono ℤₘ₀ where
+instance {α : Type*} [Add α] [Preorder α] [CovariantClass α α (· + ·) (· < ·)]:
+    PosMulStrictMono (WithZero (Multiplicative α)) where
   elim := by
     intro ⟨x, hx⟩ a b (h : a < b)
     rcases eq_coe_of_pos hx.ne' with ⟨x, rfl⟩
@@ -916,23 +917,24 @@ instance : PosMulStrictMono ℤₘ₀ where
     · rw [mul_zero]
       rcases eq_coe_of_pos h.ne' with ⟨b, rfl⟩
       exact WithZero.zero_lt_coe _
-    · have hb : (0 : ℤₘ₀) < b := lt_trans (WithZero.zero_lt_coe (ofAdd a)) h
+    · have hb : 0 < b := lt_trans (WithZero.zero_lt_coe (ofAdd a)) h
       rcases eq_coe_of_pos hb.ne' with ⟨b, rfl⟩
       norm_cast at h ⊢
-      exact Int.add_lt_add_left h x
+      exact add_lt_add_left (α := α) h x
 
 -- This makes `lt_mul_of_le_of_one_lt'` work on `ℤₘ₀`
-instance : MulPosMono ℤₘ₀ where
+instance {α : Type*} [Add α] [Preorder α] [CovariantClass α α (swap (· + ·)) (· ≤ ·)]:
+    MulPosMono (WithZero (Multiplicative α)) where
   elim := by
     intro ⟨x, hx⟩ a b (h : a ≤ b)
     dsimp only
     rcases eq_zero_or_coe x with (rfl | ⟨x, rfl⟩)
     · simp only [mul_zero, le_refl]
     · rcases eq_zero_or_coe a with (rfl | ⟨a, rfl⟩)
-      · simp only [zero_mul, zero_le']
-      · have hb : (0 : ℤₘ₀) < b := lt_of_lt_of_le (WithZero.zero_lt_coe (ofAdd a)) h
+      · simp only [zero_mul, WithZero.zero_le]
+      · have hb : 0 < b := lt_of_lt_of_le (WithZero.zero_lt_coe (ofAdd a)) h
         rcases eq_coe_of_pos hb.ne' with ⟨b, rfl⟩
         norm_cast at h ⊢
-        exact (Int.add_le_add_iff_right x).mpr h
+        exact add_le_add_right (α := α) h x
 
 end WithZero_Multiplicative_stuff

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -894,35 +894,36 @@ section WithZero_Multiplicative_stuff
 
 open Multiplicative
 
-theorem WithZero.Multiplicative.eq_coe_of_pos {α : Type*} {x : WithZero (Multiplicative α)}
-    (hx : x ≠ 0) : ∃ (n : α), x = ofAdd n :=
+-- in the process of moving these
+theorem WithZero.eq_coe_of_ne_zero {α : Type*} {x : WithZero α}
+    (hx : x ≠ 0) : ∃ (n : α), x = n :=
   Option.ne_none_iff_exists'.mp hx
 
-theorem WithZero.Multiplicative.eq_zero_or_coe {α : Type*} (x : WithZero (Multiplicative α)) :
-    x = 0 ∨ ∃ (n : α), x = ofAdd n :=
-  or_iff_not_imp_left.mpr WithZero.Multiplicative.eq_coe_of_pos
+theorem WithZero.eq_zero_or_coe {α : Type*} (x : WithZero α) :
+    x = 0 ∨ ∃ (n : α), x = n :=
+  or_iff_not_imp_left.mpr Option.ne_none_iff_exists'.mp
 
-open WithZero.Multiplicative
+open WithZero
 
 -- this makes `mul_lt_mul_left`, `mul_pos` etc work on `ℤₘ₀`
-instance {α : Type*} [Add α] [Preorder α] [CovariantClass α α (· + ·) (· < ·)]:
-    PosMulStrictMono (WithZero (Multiplicative α)) where
+instance foo {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (· * ·) (· < ·)]:
+    PosMulStrictMono (WithZero α) where
   elim := by
     intro ⟨x, hx⟩ a b (h : a < b)
-    rcases eq_coe_of_pos hx.ne' with ⟨x, rfl⟩
+    rcases eq_coe_of_ne_zero hx.ne' with ⟨x, rfl⟩
     dsimp only
     rcases eq_zero_or_coe a with (rfl | ⟨a, rfl⟩)
     · rw [mul_zero]
-      rcases eq_coe_of_pos h.ne' with ⟨b, rfl⟩
+      rcases eq_coe_of_ne_zero h.ne' with ⟨b, rfl⟩
       exact WithZero.zero_lt_coe _
     · have hb : 0 < b := lt_trans (WithZero.zero_lt_coe (ofAdd a)) h
-      rcases eq_coe_of_pos hb.ne' with ⟨b, rfl⟩
+      rcases eq_coe_of_ne_zero hb.ne' with ⟨b, rfl⟩
       norm_cast at h ⊢
-      exact add_lt_add_left (α := α) h x
+      exact mul_lt_mul_left' (α := α) h x
 
 -- This makes `lt_mul_of_le_of_one_lt'` work on `ℤₘ₀`
-instance {α : Type*} [Add α] [Preorder α] [CovariantClass α α (swap (· + ·)) (· ≤ ·)]:
-    MulPosMono (WithZero (Multiplicative α)) where
+instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (swap (· * ·)) (· ≤ ·)]:
+    MulPosMono (WithZero α) where
   elim := by
     intro ⟨x, hx⟩ a b (h : a ≤ b)
     dsimp only
@@ -931,8 +932,8 @@ instance {α : Type*} [Add α] [Preorder α] [CovariantClass α α (swap (· + �
     · rcases eq_zero_or_coe a with (rfl | ⟨a, rfl⟩)
       · simp only [zero_mul, WithZero.zero_le]
       · have hb : 0 < b := lt_of_lt_of_le (WithZero.zero_lt_coe (ofAdd a)) h
-        rcases eq_coe_of_pos hb.ne' with ⟨b, rfl⟩
+        rcases eq_coe_of_ne_zero hb.ne' with ⟨b, rfl⟩
         norm_cast at h ⊢
-        exact add_le_add_right (α := α) h x
+        exact mul_le_mul_right' (α := α) h x
 
 end WithZero_Multiplicative_stuff

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -911,7 +911,7 @@ instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (· * ·) (·
     | ⟨(x : α), hx⟩, (a : α), (b : α), h => by
         dsimp only
         norm_cast at h ⊢
-        exact mul_lt_mul_left' (α := α) h x
+        exact mul_lt_mul_left' h x
 
 -- This makes `lt_mul_of_le_of_one_lt'` work on `ℤₘ₀`
 instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (swap (· * ·)) (· ≤ ·)]:
@@ -926,6 +926,6 @@ instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (swap (· * �
     | ⟨(x : α), hx⟩, (a : α), (b : α), h => by
         dsimp only
         norm_cast at h ⊢
-        exact mul_le_mul_right' (α := α) h x
+        exact mul_le_mul_right' h x
 
 end WithZero_Multiplicative_stuff


### PR DESCRIPTION
Add some basic instances which apply to `ℤₘ₀` to make it possible to do basic calculations in this monoid.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I am not sure about (a) which file this stuff should go in, and (b) the correct namespace to put it. But I seem to need stuff like `mul_pos` to work on `ℤₘ₀`  when manipulating valuations on Dedekind domains and their fields of fractions, so I seem to need these instances.

I am realising whilst working on this PR that actually I should be doing something more general, so this is WIP for now.
