### PR TITLE
feat(Algebra/Group/WithOne): add some API

### DIFF
--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -173,6 +173,14 @@ theorem ne_one_iff_exists {x : WithOne α} : x ≠ 1 ↔ ∃ a : α, ↑a = x :=
 #align with_zero.ne_zero_iff_exists WithZero.ne_zero_iff_exists
 
 @[to_additive]
+theorem eq_coe_of_ne_one {x : WithOne α} (hx : x ≠ 1) : ∃ a : α, ↑a = x :=
+  ne_one_iff_exists.mp hx
+
+@[to_additive]
+theorem eq_one_or_coe {x : WithOne α} : x = 1 ∨ ∃ a : α, ↑a = x :=
+  or_iff_not_imp_left.mpr eq_coe_of_ne_one
+
+@[to_additive]
 instance canLift : CanLift (WithOne α) α (↑) fun a => a ≠ 1 where
   prf _ := ne_one_iff_exists.1
 #align with_one.can_lift WithOne.canLift


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I am slightly worried by the fact that these don't exist already, so people might say "clearly we don't need them".

I think I need them for the following reason: I need to do some calculations in ℤₘ₀ := `WithZero (Multiplicative ℤ)`, and the way I'm doing them is "either it's 0 or it's coerced from `Multiplicative ℤ`; deal with each case separately" and the two lemmas here enable me to do all these case splits with `rcases` painlessly.

Example code (from a future PR proving an inequality with three variables x,a,b):
```
  ...
    rcases eq_coe_of_ne_zero hx.ne' with ⟨x, rfl⟩
    dsimp only
    rcases eq_zero_or_coe a with (rfl | ⟨a, rfl⟩)
    · rw [mul_zero]
      rcases eq_coe_of_ne_zero h.ne' with ⟨b, rfl⟩
      exact WithZero.zero_lt_coe _
  ...
```
