### PR TITLE
[Merged by Bors] - chore: add `induction_eliminator` to `With{Top,Bot,Zero,One}`

### DIFF
--- a/Mathlib/Algebra/Group/WithOne/Basic.lean
+++ b/Mathlib/Algebra/Group/WithOne/Basic.lean
@@ -119,13 +119,13 @@ theorem map_coe (f : α →ₙ* β) (a : α) : map f (a : WithOne α) = f a :=
 @[to_additive (attr := simp)]
 theorem map_id : map (MulHom.id α) = MonoidHom.id (WithOne α) := by
   ext x
-  induction x using WithOne.cases_on <;> rfl
+  induction x <;> rfl
 #align with_one.map_id WithOne.map_id
 #align with_zero.map_id WithZero.map_id
 
 @[to_additive]
 theorem map_map (f : α →ₙ* β) (g : β →ₙ* γ) (x) : map g (map f x) = map (g.comp f) x := by
-  induction x using WithOne.cases_on <;> rfl
+  induction x <;> rfl
 #align with_one.map_map WithOne.map_map
 #align with_zero.map_map WithZero.map_map
 
@@ -142,8 +142,8 @@ theorem map_comp (f : α →ₙ* β) (g : β →ₙ* γ) : map (g.comp f) = (map
 def _root_.MulEquiv.withOneCongr (e : α ≃* β) : WithOne α ≃* WithOne β :=
   { map e.toMulHom with
     toFun := map e.toMulHom, invFun := map e.symm.toMulHom,
-    left_inv := (by induction · using WithOne.cases_on <;> simp)
-    right_inv := (by induction · using WithOne.cases_on <;> simp) }
+    left_inv := (by induction · <;> simp)
+    right_inv := (by induction · <;> simp) }
 #align mul_equiv.with_one_congr MulEquiv.withOneCongr
 #align add_equiv.with_zero_congr AddEquiv.withZeroCongr
 #align mul_equiv.with_one_congr_apply MulEquiv.withOneCongr_apply

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -115,7 +115,7 @@ instance coeTC : CoeTC α (WithOne α) :=
   ⟨coe⟩
 
 /-- Recursor for `WithOne` using the preferred forms `1` and `↑a`. -/
-@[to_additive (attr := elab_as_elim)
+@[to_additive (attr := elab_as_elim, induction_eliminator)
   "Recursor for `WithZero` using the preferred forms `0` and `↑a`."]
 def recOneCoe {C : WithOne α → Sort*} (h₁ : C 1) (h₂ : ∀ a : α, C a) : ∀ n : WithOne α, C n
   | Option.none => h₁
@@ -127,7 +127,7 @@ def recOneCoe {C : WithOne α → Sort*} (h₁ : C 1) (h₂ : ∀ a : α, C a) :
 -- would automatically get this; right now in Lean 4...I don't
 -- know if it does or not, and I don't know how to check, so
 -- I'll add it manually just to be sure.
-attribute [elab_as_elim] WithZero.recZeroCoe
+attribute [elab_as_elim, induction_eliminator] WithZero.recZeroCoe
 
 
 /-- Deconstruct an `x : WithOne α` to the underlying value in `α`, given a proof that `x ≠ 1`. -/

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -128,10 +128,10 @@ lemma map'_zero (f : α →* β) : map' f 0 = 0 := rfl
 
 @[simp]
 lemma map'_id : map' (MonoidHom.id β) = MonoidHom.id (WithZero β) := by
-  ext x; induction x using WithOne.cases_on <;> rfl
+  ext x; induction x <;> rfl
 
 lemma map'_map'  (f : α →* β) (g : β →* γ) (x) : map' g (map' f x) = map' (g.comp f) x := by
-  induction x using WithOne.cases_on <;> rfl
+  induction x <;> rfl
 
 @[simp]
 lemma map'_comp (f : α →* β) (g : β →* γ) : map' (g.comp f) = (map' g).comp (map' f) :=

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -343,8 +343,8 @@ theorem coe_le_iff {x : WithZero α} : (a : WithZero α) ≤ x ↔ ∃ b : α, x
 instance covariantClass_mul_le [Mul α] [CovariantClass α α (· * ·) (· ≤ ·)] :
     CovariantClass (WithZero α) (WithZero α) (· * ·) (· ≤ ·) := by
   refine ⟨fun a b c hbc => ?_⟩
-  induction a using WithZero.recZeroCoe; · exact zero_le _
-  induction b using WithZero.recZeroCoe; · exact zero_le _
+  induction a; · exact zero_le _
+  induction b; · exact zero_le _
   rcases WithZero.coe_le_iff.1 hbc with ⟨c, rfl, hbc'⟩
   rw [← coe_mul _ c, ← coe_mul, coe_le_coe]
   exact mul_le_mul_left' hbc' _
@@ -354,11 +354,11 @@ instance covariantClass_mul_le [Mul α] [CovariantClass α α (· * ·) (· ≤ 
 protected lemma covariantClass_add_le [AddZeroClass α] [CovariantClass α α (· + ·) (· ≤ ·)]
     (h : ∀ a : α, 0 ≤ a) : CovariantClass (WithZero α) (WithZero α) (· + ·) (· ≤ ·) := by
   refine ⟨fun a b c hbc => ?_⟩
-  induction a using WithZero.recZeroCoe
+  induction a
   · rwa [zero_add, zero_add]
-  induction b using WithZero.recZeroCoe
+  induction b
   · rw [add_zero]
-    induction c using WithZero.recZeroCoe
+    induction c
     · rw [add_zero]
     · rw [← coe_add, coe_le_coe]
       exact le_add_of_nonneg_right (h _)
@@ -390,11 +390,11 @@ instance contravariantClass_mul_lt [Mul α] [ContravariantClass α α (· * ·) 
     ContravariantClass (WithZero α) (WithZero α) (· * ·) (· < ·) := by
   refine ⟨fun a b c h => ?_⟩
   have := ((zero_le _).trans_lt h).ne'
-  induction a using WithZero.recZeroCoe
+  induction a
   · simp at this
-  induction c using WithZero.recZeroCoe
+  induction c
   · simp at this
-  induction b using WithZero.recZeroCoe
+  induction b
   exacts [zero_lt_coe _, coe_lt_coe.mpr (lt_of_mul_lt_mul_left' <| coe_lt_coe.mp h)]
 #align with_zero.contravariant_class_mul_lt WithZero.contravariantClass_mul_lt
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -370,9 +370,9 @@ protected lemma covariantClass_add_le [AddZeroClass α] [CovariantClass α α (�
 
 instance existsAddOfLE [Add α] [ExistsAddOfLE α] : ExistsAddOfLE (WithZero α) :=
   ⟨fun {a b} => by
-    induction a using WithZero.cases_on
+    induction a
     · exact fun _ => ⟨b, (zero_add b).symm⟩
-    induction b using WithZero.cases_on
+    induction b
     · exact fun h => (WithBot.not_coe_le_bot _ h).elim
     intro h
     obtain ⟨c, rfl⟩ := exists_add_of_le (WithZero.coe_le_coe.1 h)
@@ -446,9 +446,9 @@ instance canonicallyOrderedAddCommMonoid [CanonicallyOrderedAddCommMonoid α] :
     WithZero.orderedAddCommMonoid _root_.zero_le,
     WithZero.existsAddOfLE with
     le_self_add := fun a b => by
-      induction a using WithZero.cases_on
+      induction a
       · exact bot_le
-      induction b using WithZero.cases_on
+      induction b
       · exact le_rfl
       · exact WithZero.coe_le_coe.2 le_self_add }
 #align with_zero.canonically_ordered_add_monoid WithZero.canonicallyOrderedAddCommMonoid

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -214,9 +214,9 @@ instance covariantClass_swap_add_le [LE α] [CovariantClass α α (swap (· + ·
 instance contravariantClass_add_lt [LT α] [ContravariantClass α α (· + ·) (· < ·)] :
     ContravariantClass (WithTop α) (WithTop α) (· + ·) (· < ·) :=
   ⟨fun a b c h => by
-    induction a using WithTop.recTopCoe; · exact (not_none_lt _ h).elim
-    induction b using WithTop.recTopCoe; · exact (not_none_lt _ h).elim
-    induction c using WithTop.recTopCoe
+    induction a; · exact (not_none_lt _ h).elim
+    induction b; · exact (not_none_lt _ h).elim
+    induction c
     · exact coe_lt_top _
     · exact coe_lt_coe.2 (lt_of_add_lt_add_left <| coe_lt_coe.1 h)⟩
 #align with_top.contravariant_class_add_lt WithTop.contravariantClass_add_lt
@@ -233,9 +233,9 @@ instance contravariantClass_swap_add_lt [LT α] [ContravariantClass α α (swap 
 protected theorem le_of_add_le_add_left [LE α] [ContravariantClass α α (· + ·) (· ≤ ·)] (ha : a ≠ ⊤)
     (h : a + b ≤ a + c) : b ≤ c := by
   lift a to α using ha
-  induction c using WithTop.recTopCoe
+  induction c
   · exact le_top
-  · induction b using WithTop.recTopCoe
+  · induction b
     · exact (not_top_le_coe _ h).elim
     · simp only [← coe_add, coe_le_coe] at h ⊢
       exact le_of_add_le_add_left h
@@ -306,9 +306,9 @@ protected theorem add_lt_add_of_lt_of_le [Preorder α] [CovariantClass α α (·
 protected theorem map_add {F} [Add β] [FunLike F α β] [AddHomClass F α β]
     (f : F) (a b : WithTop α) :
     (a + b).map f = a.map f + b.map f := by
-  induction a using WithTop.recTopCoe
+  induction a
   · exact (top_add _).symm
-  · induction b using WithTop.recTopCoe
+  · induction b
     · exact (add_top _).symm
     · rw [map_coe, map_coe, ← coe_add, ← coe_add, ← map_add]
       rfl

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -82,8 +82,8 @@ lemma coe_mul_eq_bind {a : α} (ha : a ≠ 0) : ∀ b, (a * b : WithTop α) = b.
 @[simp] lemma untop'_zero_mul (a b : WithTop α) : (a * b).untop' 0 = a.untop' 0 * b.untop' 0 := by
   by_cases ha : a = 0; · rw [ha, zero_mul, ← coe_zero, untop'_coe, zero_mul]
   by_cases hb : b = 0; · rw [hb, mul_zero, ← coe_zero, untop'_coe, mul_zero]
-  induction a using WithTop.recTopCoe; · rw [top_mul hb, untop'_top, zero_mul]
-  induction b using WithTop.recTopCoe; · rw [mul_top ha, untop'_top, mul_zero]
+  induction a; · rw [top_mul hb, untop'_top, zero_mul]
+  induction b; · rw [mul_top ha, untop'_top, mul_zero]
   rw [← coe_mul, untop'_coe, untop'_coe, untop'_coe]
 #align with_top.untop'_zero_mul WithTop.untop'_zero_mul
 
@@ -128,9 +128,9 @@ protected def _root_.MonoidWithZeroHom.withTopMap {R S : Type*} [MulZeroOneClass
       · simp
       rcases Decidable.eq_or_ne y 0 with (rfl | hy)
       · simp
-      induction' x using WithTop.recTopCoe with x
+      induction' x with x
       · simp [hy, this]
-      induction' y using WithTop.recTopCoe with y
+      induction' y with y
       · have : (f x : WithTop S) ≠ 0 := by simpa [hf.eq_iff' (map_zero f)] using hx
         simp [mul_top hx, mul_top this]
       · -- Porting note (#11215): TODO: `simp [← coe_mul]` times out
@@ -145,9 +145,9 @@ instance instSemigroupWithZero [SemigroupWithZero α] [NoZeroDivisors α] :
     rcases eq_or_ne b 0 with (rfl | hb); · simp only [zero_mul, mul_zero]
     rcases eq_or_ne c 0 with (rfl | hc); · simp only [mul_zero]
   -- Porting note: below needed to be rewritten due to changed `simp` behaviour for `coe`
-    induction' a using WithTop.recTopCoe with a; · simp [hb, hc]
-    induction' b using WithTop.recTopCoe with b; · simp [mul_top ha, top_mul hc]
-    induction' c using WithTop.recTopCoe with c
+    induction' a with a; · simp [hb, hc]
+    induction' b with b; · simp [mul_top ha, top_mul hc]
+    induction' c with c
     · rw [mul_top hb, mul_top ha]
       rw [← coe_zero, ne_eq, coe_eq_coe] at ha hb
       simp [ha, hb]
@@ -178,7 +178,7 @@ instance instCommMonoidWithZero [CommMonoidWithZero α] [NoZeroDivisors α] [Non
 variable [CanonicallyOrderedCommSemiring α]
 
 private theorem distrib' (a b c : WithTop α) : (a + b) * c = a * c + b * c := by
-  induction' c using WithTop.recTopCoe with c
+  induction' c with c
   · by_cases ha : a = 0 <;> simp [ha]
   · by_cases hc : c = 0
     · simp [hc]
@@ -262,8 +262,8 @@ lemma coe_mul_eq_bind {a : α} (ha : a ≠ 0) : ∀ b, (a * b : WithBot α) = b.
 lemma unbot'_zero_mul (a b : WithBot α) : (a * b).unbot' 0 = a.unbot' 0 * b.unbot' 0 := by
   by_cases ha : a = 0; · rw [ha, zero_mul, ← coe_zero, unbot'_coe, zero_mul]
   by_cases hb : b = 0; · rw [hb, mul_zero, ← coe_zero, unbot'_coe, mul_zero]
-  induction a using WithBot.recBotCoe; · rw [bot_mul hb, unbot'_bot, zero_mul]
-  induction b using WithBot.recBotCoe; · rw [mul_bot ha, unbot'_bot, mul_zero]
+  induction a; · rw [bot_mul hb, unbot'_bot, zero_mul]
+  induction b; · rw [mul_bot ha, unbot'_bot, mul_zero]
   rw [← coe_mul, unbot'_coe, unbot'_coe, unbot'_coe]
 #align with_bot.unbot'_zero_mul WithBot.unbot'_zero_mul
 
@@ -312,9 +312,9 @@ instance [MulZeroClass α] [Preorder α] [PosMulMono α] : PosMulMono (WithBot �
     lift x to α
     · rintro rfl
       exact (WithBot.bot_lt_coe (0 : α)).not_le x0
-    induction a using WithBot.recBotCoe
+    induction a
     · simp_rw [mul_bot x0', bot_le]
-    induction b using WithBot.recBotCoe
+    induction b
     · exact absurd h (bot_lt_coe _).not_le
     simp only [← coe_mul, coe_le_coe] at *
     norm_cast at x0
@@ -329,9 +329,9 @@ instance [MulZeroClass α] [Preorder α] [MulPosMono α] : MulPosMono (WithBot �
     lift x to α
     · rintro rfl
       exact (WithBot.bot_lt_coe (0 : α)).not_le x0
-    induction a using WithBot.recBotCoe
+    induction a
     · simp_rw [bot_mul x0', bot_le]
-    induction b using WithBot.recBotCoe
+    induction b
     · exact absurd h (bot_lt_coe _).not_le
     simp only [← coe_mul, coe_le_coe] at *
     norm_cast at x0
@@ -342,9 +342,9 @@ instance [MulZeroClass α] [Preorder α] [PosMulStrictMono α] : PosMulStrictMon
     intro ⟨x, x0⟩ a b h
     simp only [Subtype.coe_mk]
     lift x to α using x0.ne_bot
-    induction b using WithBot.recBotCoe
+    induction b
     · exact absurd h not_lt_bot
-    induction a using WithBot.recBotCoe
+    induction a
     · simp_rw [mul_bot x0.ne.symm, ← coe_mul, bot_lt_coe]
     simp only [← coe_mul, coe_lt_coe] at *
     norm_cast at x0
@@ -355,9 +355,9 @@ instance [MulZeroClass α] [Preorder α] [MulPosStrictMono α] : MulPosStrictMon
     intro ⟨x, x0⟩ a b h
     simp only [Subtype.coe_mk]
     lift x to α using x0.ne_bot
-    induction b using WithBot.recBotCoe
+    induction b
     · exact absurd h not_lt_bot
-    induction a using WithBot.recBotCoe
+    induction a
     · simp_rw [bot_mul x0.ne.symm, ← coe_mul, bot_lt_coe]
     simp only [← coe_mul, coe_lt_coe] at *
     norm_cast at x0
@@ -372,10 +372,10 @@ instance [MulZeroClass α] [Preorder α] [PosMulReflectLT α] : PosMulReflectLT 
     lift x to α
     · rintro rfl
       exact (WithBot.bot_lt_coe (0 : α)).not_le x0
-    induction b using WithBot.recBotCoe
+    induction b
     · rw [mul_bot x0'] at h
       exact absurd h bot_le.not_lt
-    induction a using WithBot.recBotCoe
+    induction a
     · exact WithBot.bot_lt_coe _
     simp only [← coe_mul, coe_lt_coe] at *
     norm_cast at x0
@@ -390,10 +390,10 @@ instance [MulZeroClass α] [Preorder α] [MulPosReflectLT α] : MulPosReflectLT 
     lift x to α
     · rintro rfl
       exact (WithBot.bot_lt_coe (0 : α)).not_le x0
-    induction b using WithBot.recBotCoe
+    induction b
     · rw [bot_mul x0'] at h
       exact absurd h bot_le.not_lt
-    induction a using WithBot.recBotCoe
+    induction a
     · exact WithBot.bot_lt_coe _
     simp only [← coe_mul, coe_lt_coe] at *
     norm_cast at x0
@@ -404,9 +404,9 @@ instance [MulZeroClass α] [Preorder α] [PosMulReflectLE α] : PosMulReflectLE 
     intro ⟨x, x0⟩ a b h
     simp only [Subtype.coe_mk] at h
     lift x to α using x0.ne_bot
-    induction a using WithBot.recBotCoe
+    induction a
     · exact bot_le
-    induction b using WithBot.recBotCoe
+    induction b
     · rw [mul_bot x0.ne.symm, ← coe_mul] at h
       exact absurd h (bot_lt_coe _).not_le
     simp only [← coe_mul, coe_le_coe] at *
@@ -418,9 +418,9 @@ instance [MulZeroClass α] [Preorder α] [MulPosReflectLE α] : MulPosReflectLE 
     intro ⟨x, x0⟩ a b h
     simp only [Subtype.coe_mk] at h
     lift x to α using x0.ne_bot
-    induction a using WithBot.recBotCoe
+    induction a
     · exact bot_le
-    induction b using WithBot.recBotCoe
+    induction b
     · rw [bot_mul x0.ne.symm, ← coe_mul] at h
       exact absurd h (bot_lt_coe _).not_le
     simp only [← coe_mul, coe_le_coe] at *

--- a/Mathlib/Algebra/Order/Sub/WithTop.lean
+++ b/Mathlib/Algebra/Order/Sub/WithTop.lean
@@ -46,7 +46,7 @@ theorem sub_top {a : WithTop α} : a - ⊤ = 0 := by cases a <;> rfl
 #align with_top.sub_top WithTop.sub_top
 
 @[simp] theorem sub_eq_top_iff {a b : WithTop α} : a - b = ⊤ ↔ a = ⊤ ∧ b ≠ ⊤ := by
-  induction a using recTopCoe <;> induction b using recTopCoe <;>
+  induction a <;> induction b <;>
     simp only [← coe_sub, coe_ne_top, sub_top, zero_ne_top, top_sub_coe, false_and, Ne,
       not_true_eq_false, not_false_eq_true, and_false, and_self]
 #align with_top.sub_eq_top_iff WithTop.sub_eq_top_iff

--- a/Mathlib/Algebra/Order/Sub/WithTop.lean
+++ b/Mathlib/Algebra/Order/Sub/WithTop.lean
@@ -65,9 +65,9 @@ variable [CanonicallyOrderedAddCommMonoid α] [Sub α] [OrderedSub α]
 instance : OrderedSub (WithTop α) := by
   constructor
   rintro x y z
-  induction y using WithTop.recTopCoe; · simp
-  induction x using WithTop.recTopCoe; · simp
-  induction z using WithTop.recTopCoe; · simp
+  induction y; · simp
+  induction x; · simp
+  induction z; · simp
   norm_cast; exact tsub_le_iff_right
 
 end WithTop

--- a/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
@@ -298,13 +298,13 @@ theorem isSome_iff : ∀ {I : WithBot (Box ι)}, I.isSome ↔ (I : Set (ι → �
 
 theorem biUnion_coe_eq_coe (I : WithBot (Box ι)) :
     ⋃ (J : Box ι) (_ : ↑J = I), (J : Set (ι → ℝ)) = I := by
-  induction I using WithBot.recBotCoe <;> simp [WithBot.coe_eq_coe]
+  induction I <;> simp [WithBot.coe_eq_coe]
 #align box_integral.box.bUnion_coe_eq_coe BoxIntegral.Box.biUnion_coe_eq_coe
 
 @[simp, norm_cast]
 theorem withBotCoe_subset_iff {I J : WithBot (Box ι)} : (I : Set (ι → ℝ)) ⊆ J ↔ I ≤ J := by
-  induction I using WithBot.recBotCoe; · simp
-  induction J using WithBot.recBotCoe; · simp [subset_empty_iff]
+  induction I; · simp
+  induction J; · simp [subset_empty_iff]
   simp [le_def]
 #align box_integral.box.with_bot_coe_subset_iff BoxIntegral.Box.withBotCoe_subset_iff
 
@@ -351,10 +351,10 @@ instance WithBot.inf : Inf (WithBot (Box ι)) :=
 
 @[simp]
 theorem coe_inf (I J : WithBot (Box ι)) : (↑(I ⊓ J) : Set (ι → ℝ)) = (I : Set _) ∩ J := by
-  induction I using WithBot.recBotCoe
+  induction I
   · change ∅ = _
     simp
-  induction J using WithBot.recBotCoe
+  induction J
   · change ∅ = _
     simp
   change ((mk' _ _ : WithBot (Box ι)) : Set (ι → ℝ)) = _

--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -1032,7 +1032,7 @@ theorem ContDiffWithinAt.fderivWithin'' {f : E → F → G} {g : E → F} {t : S
     refine hf'.congr_of_eventuallyEq_insert ?_
     filter_upwards [hv, ht]
     exact fun y hy h2y => (hvf' y hy).fderivWithin h2y
-  induction' m with m
+  induction' m using ENat.recTopCoe with m
   · obtain rfl := eq_top_iff.mpr hmn
     rw [contDiffWithinAt_top]
     exact fun m => this m le_top

--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -1032,7 +1032,7 @@ theorem ContDiffWithinAt.fderivWithin'' {f : E → F → G} {g : E → F} {t : S
     refine hf'.congr_of_eventuallyEq_insert ?_
     filter_upwards [hv, ht]
     exact fun y hy h2y => (hvf' y hy).fderivWithin h2y
-  induction' m using WithTop.recTopCoe with m
+  induction' m with m
   · obtain rfl := eq_top_iff.mpr hmn
     rw [contDiffWithinAt_top]
     exact fun m => this m le_top

--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -899,7 +899,7 @@ theorem sup'_induction {p : α → Prop} (hp : ∀ a₁, p a₁ → ∀ a₂, p 
   rintro (_ | a₁) h₁ a₂ h₂
   · rw [WithBot.none_eq_bot, bot_sup_eq]
     exact h₂
-  · cases a₂ using WithBot.recBotCoe with
+  · cases a₂ with
     | bot => exact h₁
     | coe a₂ => exact hp a₁ h₁ a₂ h₂
 #align finset.sup'_induction Finset.sup'_induction

--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -899,7 +899,7 @@ theorem sup'_induction {p : α → Prop} (hp : ∀ a₁, p a₁ → ∀ a₂, p 
   rintro (_ | a₁) h₁ a₂ h₂
   · rw [WithBot.none_eq_bot, bot_sup_eq]
     exact h₂
-  · cases a₂ with
+  · cases a₂ using WithBot.recBotCoe with
     | bot => exact h₁
     | coe a₂ => exact hp a₁ h₁ a₂ h₂
 #align finset.sup'_induction Finset.sup'_induction

--- a/Mathlib/Data/Nat/WithBot.lean
+++ b/Mathlib/Data/Nat/WithBot.lean
@@ -69,7 +69,7 @@ theorem lt_zero_iff {n : WithBot ℕ} : n < 0 ↔ n = ⊥ := WithBot.lt_coe_bot
 
 theorem one_le_iff_zero_lt {x : WithBot ℕ} : 1 ≤ x ↔ 0 < x := by
   refine' ⟨fun h => lt_of_lt_of_le (WithBot.coe_lt_coe.mpr zero_lt_one) h, fun h => _⟩
-  induction x using WithBot.recBotCoe
+  induction x
   · exact (not_lt_bot h).elim
   · exact WithBot.coe_le_coe.mpr (Nat.succ_le_iff.mpr (WithBot.coe_lt_coe.mp h))
 #align nat.with_bot.one_le_iff_zero_lt Nat.WithBot.one_le_iff_zero_lt

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -1144,7 +1144,7 @@ theorem pred_coe (a : α) : pred (↑a : WithTop α) = ↑(pred a) :=
 @[simp]
 theorem pred_untop :
     ∀ (a : WithTop α) (ha : a ≠ ⊤),
-      pred (a.untop ha) = (pred a).untop (by induction a using WithTop.recTopCoe <;> simp)
+      pred (a.untop ha) = (pred a).untop (by induction a <;> simp)
   | ⊤, ha => (ha rfl).elim
   | (a : α), _ => rfl
 #align with_top.pred_untop WithTop.pred_untop
@@ -1255,7 +1255,7 @@ theorem succ_coe (a : α) : succ (↑a : WithBot α) = ↑(succ a) :=
 @[simp]
 theorem succ_unbot :
     ∀ (a : WithBot α) (ha : a ≠ ⊥),
-      succ (a.unbot ha) = (succ a).unbot (by induction a using WithBot.recBotCoe <;> simp)
+      succ (a.unbot ha) = (succ a).unbot (by induction a <;> simp)
   | ⊥, ha => (ha rfl).elim
   | (a : α), _ => rfl
 #align with_bot.succ_unbot WithBot.succ_unbot

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -95,7 +95,7 @@ theorem coe_ne_bot : (a : WithBot α) ≠ ⊥ :=
 #align with_bot.coe_ne_bot WithBot.coe_ne_bot
 
 /-- Recursor for `WithBot` using the preferred forms `⊥` and `↑a`. -/
-@[elab_as_elim]
+@[elab_as_elim, induction_eliminator]
 def recBotCoe {C : WithBot α → Sort*} (bot : C ⊥) (coe : ∀ a : α, C a) : ∀ n : WithBot α, C n
   | ⊥ => bot
   | (a : α) => coe a
@@ -133,7 +133,7 @@ theorem coe_eq_coe : (a : WithBot α) = b ↔ a = b := coe_inj
 #align with_bot.coe_eq_coe WithBot.coe_eq_coe
 
 theorem unbot'_eq_iff {d y : α} {x : WithBot α} : unbot' d x = y ↔ x = y ∨ x = ⊥ ∧ y = d := by
-  induction x using recBotCoe <;> simp [@eq_comm _ d]
+  induction x <;> simp [@eq_comm _ d]
 #align with_bot.unbot'_eq_iff WithBot.unbot'_eq_iff
 
 @[simp] theorem unbot'_eq_self_iff {d : α} {x : WithBot α} : unbot' d x = d ↔ x = d ∨ x = ⊥ := by
@@ -142,7 +142,7 @@ theorem unbot'_eq_iff {d y : α} {x : WithBot α} : unbot' d x = y ↔ x = y ∨
 
 theorem unbot'_eq_unbot'_iff {d : α} {x y : WithBot α} :
     unbot' d x = unbot' d y ↔ x = y ∨ x = d ∧ y = ⊥ ∨ x = ⊥ ∧ y = d := by
- induction y using recBotCoe <;> simp [unbot'_eq_iff, or_comm]
+ induction y <;> simp [unbot'_eq_iff, or_comm]
 #align with_bot.unbot'_eq_unbot'_iff WithBot.unbot'_eq_unbot'_iff
 
 /-- Lift a map `f : α → β` to `WithBot α → WithBot β`. Implemented using `Option.map`. -/
@@ -276,7 +276,7 @@ theorem unbot_le_iff {a : WithBot α} (h : a ≠ ⊥) {b : α} :
 
 theorem unbot'_le_iff {a : WithBot α} {b c : α} (h : a = ⊥ → b ≤ c) :
     a.unbot' b ≤ c ↔ a ≤ c := by
-  induction a using recBotCoe
+  induction a
   · simpa using h rfl
   · simp
 #align with_bot.unbot'_bot_le_iff WithBot.unbot'_le_iff
@@ -334,7 +334,7 @@ protected theorem bot_lt_iff_ne_bot : ∀ {x : WithBot α}, ⊥ < x ↔ x ≠ �
 
 theorem unbot'_lt_iff {a : WithBot α} {b c : α} (h : a = ⊥ → b < c) :
     a.unbot' b < c ↔ a < c := by
-  induction a using recBotCoe
+  induction a
   · simpa [bot_lt_coe] using h rfl
   · simp
 
@@ -660,7 +660,7 @@ theorem coe_ne_top : (a : WithTop α) ≠ ⊤ :=
 #align with_top.coe_ne_top WithTop.coe_ne_top
 
 /-- Recursor for `WithTop` using the preferred forms `⊤` and `↑a`. -/
-@[elab_as_elim]
+@[elab_as_elim, induction_eliminator]
 def recTopCoe {C : WithTop α → Sort*} (top : C ⊤) (coe : ∀ a : α, C a) : ∀ n : WithTop α, C n
   | none => top
   | Option.some a => coe a

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -1287,7 +1287,7 @@ theorem prod_mono : ∀ {a b : FactorSet α}, a ≤ b → a.prod ≤ b.prod
 #align associates.prod_mono Associates.prod_mono
 
 theorem FactorSet.prod_eq_zero_iff [Nontrivial α] (p : FactorSet α) : p.prod = 0 ↔ p = ⊤ := by
-  induction p using WithTop.recTopCoe
+  induction p
   · simp only [iff_self_iff, eq_self_iff_true, Associates.prod_top]
   · rw [prod_coe, Multiset.prod_eq_zero_iff, Multiset.mem_map, eq_false WithTop.coe_ne_top,
       iff_false_iff, not_exists]
@@ -1391,7 +1391,7 @@ theorem unique' {p q : Multiset (Associates α)} :
 #align associates.unique' Associates.unique'
 
 theorem FactorSet.unique [Nontrivial α] {p q : FactorSet α} (h : p.prod = q.prod) : p = q := by
-  induction p using WithTop.recTopCoe <;> induction q using WithTop.recTopCoe
+  induction p <;> induction q
   · rfl
   · rw [eq_comm, ← FactorSet.prod_eq_zero_iff, ← h, Associates.prod_top]
   · rw [← FactorSet.prod_eq_zero_iff, h, Associates.prod_top]

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -1287,7 +1287,7 @@ theorem prod_mono : ∀ {a b : FactorSet α}, a ≤ b → a.prod ≤ b.prod
 #align associates.prod_mono Associates.prod_mono
 
 theorem FactorSet.prod_eq_zero_iff [Nontrivial α] (p : FactorSet α) : p.prod = 0 ↔ p = ⊤ := by
-  induction p
+  induction p using WithTop.recTopCoe -- TODO: `induction_eliminator` doesn't work with `abbrev`
   · simp only [iff_self_iff, eq_self_iff_true, Associates.prod_top]
   · rw [prod_coe, Multiset.prod_eq_zero_iff, Multiset.mem_map, eq_false WithTop.coe_ne_top,
       iff_false_iff, not_exists]
@@ -1391,7 +1391,8 @@ theorem unique' {p q : Multiset (Associates α)} :
 #align associates.unique' Associates.unique'
 
 theorem FactorSet.unique [Nontrivial α] {p q : FactorSet α} (h : p.prod = q.prod) : p = q := by
-  induction p <;> induction q
+  -- TODO: `induction_eliminator` doesn't work with `abbrev`
+  induction p using WithTop.recTopCoe <;> induction q using WithTop.recTopCoe
   · rfl
   · rw [eq_comm, ← FactorSet.prod_eq_zero_iff, ← h, Associates.prod_top]
   · rw [← FactorSet.prod_eq_zero_iff, h, Associates.prod_top]


### PR DESCRIPTION
This is a smaller version of #12605.

This allows `using` to be dropped from `induction`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
