### PR TITLE
[Merged by Bors] - Feat(RingTheory/Ideal/AssociatedPrime): Union of associated primes is the set of zero divisors

### DIFF
--- a/Mathlib/RingTheory/Ideal/AssociatedPrime.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime.lean
@@ -129,6 +129,18 @@ theorem associatedPrimes.nonempty [IsNoetherianRing R] [Nontrivial M] :
   exact ⟨P, hP⟩
 #align associated_primes.nonempty associatedPrimes.nonempty
 
+theorem biUnion_associatedPrimes_eq_zero_divisors [IsNoetherianRing R] :
+    ⋃ p ∈ associatedPrimes R M, p = { r : R | ∃ x : M, x ≠ 0 ∧ r • x = 0 } := by
+  simp_rw [← Submodule.mem_annihilator_span_singleton]
+  refine subset_antisymm (Set.iUnion₂_subset ?_) ?_
+  · rintro _ ⟨h, x, ⟨⟩⟩ r h'
+    refine ⟨x, ne_of_eq_of_ne (one_smul R x).symm ?_, h'⟩
+    refine mt (Submodule.mem_annihilator_span_singleton _ _).mpr ?_
+    exact (Ideal.ne_top_iff_one _).mp h.ne_top
+  · intro r ⟨x, h, h'⟩
+    obtain ⟨P, hP, hx⟩ := exists_le_isAssociatedPrime_of_isNoetherianRing R x h
+    exact Set.mem_biUnion hP (hx h')
+
 variable {R M}
 
 theorem IsAssociatedPrime.annihilator_le (h : IsAssociatedPrime I M) :


### PR DESCRIPTION
Add lemma that the union of associated primes is the set of zero divisors.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Note that we can't use sSup here because there's an implicit coercion of ideals to sets 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
