### PR TITLE
[Merged by Bors] - Chore(LinearAlgebra/Basis/VectorSpace): Remove the single instance of `Module.Submodule` namespace in mathlib

### DIFF
--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -65,12 +65,10 @@ open Submodule
 open UniqueFactorizationMonoid
 
 theorem Submodule.isSemisimple_torsionBy_of_irreducible {a : R} (h : Irreducible a) :
-    IsSemisimpleModule R (torsionBy R M a) := by
-  rw [IsSemisimpleModule, ← (submodule_torsionBy_orderIso a).complementedLattice_iff]
-  set I : Ideal R := R ∙ a
-  have _i2 : I.IsMaximal := PrincipalIdealRing.isMaximal_of_irreducible h
-  let _i3 : Field (R ⧸ I) := Ideal.Quotient.field I
-  exact Module.Submodule.complementedLattice
+    IsSemisimpleModule R (torsionBy R M a) :=
+  haveI := PrincipalIdealRing.isMaximal_of_irreducible h
+  letI := Ideal.Quotient.field (R ∙ a)
+  (submodule_torsionBy_orderIso a).complementedLattice
 
 /-- A finitely generated torsion module over a PID is an internal direct sum of its
 `p i ^ e i`-torsion submodules for some primes `p i` and numbers `e i`. -/

--- a/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
@@ -233,9 +233,9 @@ theorem Submodule.exists_isCompl (p : Submodule K V) : ∃ q : Submodule K V, Is
   ⟨LinearMap.ker f, LinearMap.isCompl_of_proj <| LinearMap.ext_iff.1 hf⟩
 #align submodule.exists_is_compl Submodule.exists_isCompl
 
-instance Module.Submodule.complementedLattice : ComplementedLattice (Submodule K V) :=
+instance Submodule.complementedLattice : ComplementedLattice (Submodule K V) :=
   ⟨Submodule.exists_isCompl⟩
-#align module.submodule.complemented_lattice Module.Submodule.complementedLattice
+#align module.submodule.complemented_lattice Submodule.complementedLattice
 
 theorem LinearMap.exists_rightInverse_of_surjective (f : V →ₗ[K] V') (hf_surj : range f = ⊤) :
     ∃ g : V' →ₗ[K] V, f.comp g = LinearMap.id := by


### PR DESCRIPTION
Remove only usage of `Module.Submodule`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The existence of this namespace makes it awkward to do `open Submodule (...)` or `open Submodule renaming ...` while within the `Module` namespace, and since it's only used in one place I assume it's used in error here.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
