### PR TITLE
[Merged by Bors] - Feat(Algebra/Module/Submodule/Pointwise): Generalize `set_smul_eq_iSup` as in TODO

### DIFF
--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -393,6 +393,19 @@ lemma set_smul_le_of_le_le {s t : Set S} {p q : Submodule R M}
     (le_set : s ≤ t) (le_submodule : p ≤ q) : s • p ≤ t • q :=
   le_trans (set_smul_mono_left _ le_set) <| smul_mono_right _ le_submodule
 
+lemma set_smul_eq_iSup [SMulCommClass S R M] (s : Set S) (N : Submodule R M) :
+    s • N = ⨆ (a ∈ s), a • N := by
+  refine Eq.trans (congrArg sInf ?_) csInf_Ici
+  simp_rw [← Set.Ici_def, iSup_le_iff, @forall_comm M]
+  exact Set.ext fun _ => forall₂_congr (fun _ _ => Iff.symm map_le_iff_le_comap)
+
+theorem set_smul_span [SMulCommClass S R M] (s : Set S) (t : Set M) :
+    s • span R t = span R (s • t) := by
+  simp_rw [set_smul_eq_iSup, smul_span, iSup_span, Set.iUnion_smul_set]
+
+theorem span_set_smul [SMulCommClass S R M] (s : Set S) (t : Set M) :
+    span R (s • t) = s • span R t := (set_smul_span s t).symm
+
 variable {s N} in
 /--
 Induction principal for set acting on submodules. To prove `P` holds for all `s • N`, it is enough
@@ -525,17 +538,6 @@ protected def pointwiseSetMulAction [SMulCommClass R R M] :
         mem_set_smul_of_mem_mem (Set.mul_mem_mul hr (hc1 hr')) (c _).2)
 
 scoped[Pointwise] attribute [instance] Submodule.pointwiseSetMulAction
-
--- TODO: `r • N` should be generalized to allow `r` to be an element of `S`.
-lemma set_smul_eq_iSup [SMulCommClass R R M] :
-    sR • N = ⨆ (r ∈ sR), r • N :=
-  set_smul_eq_of_le _ _ _
-    (fun r m hr hm => (show r • N ≤ _ by
-      rw [iSup_subtype', ← sSup_range]
-      exact le_sSup ⟨⟨r, hr⟩, rfl⟩) ⟨_, hm, rfl⟩) <| by
-    rw [iSup_subtype', ← sSup_range, sSup_le_iff]
-    rintro _ ⟨⟨x, hx⟩, rfl⟩ _ ⟨y, hy, rfl⟩
-    exact mem_set_smul_of_mem_mem (mem1 := hx) (mem2 := hy)
 
 -- This cannot be generalized to `Set S` because `MulAction` can't be generalized already.
 /-- In a ring, sets acts on submodules. -/


### PR DESCRIPTION
Generalize `set_smul_eq_iSup` so it works with actions on `R`-submodules of bimodules.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
