### PR TITLE
[Merged by Bors] - feat(CategoryTheory): aesop_cat uses sorry if there is a sorry in the goal

### DIFF
--- a/test/aesop_cat.lean
+++ b/test/aesop_cat.lean
@@ -1,0 +1,18 @@
+import Mathlib.CategoryTheory.Category.Basic
+
+structure Foo where
+  x : Nat
+  w : x = 37 := by aesop_cat
+
+/-- warning: declaration uses 'sorry' -/
+#guard_msgs in
+example : Foo where
+  x := sorry
+
+/--
+error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+⊢ 35 = 37
+-/
+#guard_msgs in
+example : Foo where
+  x := 35


### PR DESCRIPTION
This makes it slightly more ergonomic to construct structures. While you're still working on the data you don't get bothered about the proofs (which hopefully will be done by `aesop_cat` anyway).