### PR TITLE
[Merged by Bors] - Fix typos

### DIFF
--- a/Mathlib/Data/ZMod/Quotient.lean
+++ b/Mathlib/Data/ZMod/Quotient.lean
@@ -71,7 +71,7 @@ open BigOperators Ideal
 /-- The **Chinese remainder theorem**, elementary version for `ZMod`. See also
 `Mathlib.Data.ZMod.Basic` for versions involving only two numbers. -/
 def ZMod.prodEquivPi {ι : Type*} [Fintype ι] (a : ι → ℕ)
-    (coprime : Pairwise fun i j => Nat.Coprime (a i) (a j)) : ZMod (∏ i, a i) ≃+* ∀ i, ZMod (a i) :=
+    (coprime : Pairwise fun i j => Nat.Coprime (a i) (a j)) : ZMod (∏ i, a i) ≃+* Π i, ZMod (a i) :=
   have : Pairwise fun i j => IsCoprime (span {(a i : ℤ)}) (span {(a j : ℤ)}) :=
     fun _i _j h ↦ (isCoprime_span_singleton_iff _ _).mpr ((coprime h).cast (R := ℤ))
   Int.quotientSpanNatEquivZMod _ |>.symm.trans <|

--- a/Mathlib/Topology/MetricSpace/Sequences.lean
+++ b/Mathlib/Topology/MetricSpace/Sequences.lean
@@ -9,7 +9,7 @@ import Mathlib.Topology.MetricSpace.Bounded
 /-!
 # Sequencial compacts in metric spaces
 
-In this file we prove 2 versions of Bolzano-Weistrass theorem for proper metric spaces.
+In this file we prove 2 versions of Bolzano-Weierstrass theorem for proper metric spaces.
 -/
 
 open Filter Bornology Metric
@@ -26,7 +26,7 @@ nonrec theorem SeqCompact.lebesgue_number_lemma_of_metric {ι : Sort*} {c : ι �
 
 variable [ProperSpace X] {s : Set X}
 
-/-- A version of **Bolzano-Weistrass**: in a proper metric space (eg. $ℝ^n$),
+/-- A version of **Bolzano-Weierstrass**: in a proper metric space (eg. $ℝ^n$),
 every bounded sequence has a converging subsequence. This version assumes only
 that the sequence is frequently in some bounded set. -/
 theorem tendsto_subseq_of_frequently_bounded (hs : IsBounded s) {x : ℕ → X}
@@ -37,7 +37,7 @@ theorem tendsto_subseq_of_frequently_bounded (hs : IsBounded s) {x : ℕ → X}
   hcs.subseq_of_frequently_in hu'
 #align tendsto_subseq_of_frequently_bounded tendsto_subseq_of_frequently_bounded
 
-/-- A version of **Bolzano-Weistrass**: in a proper metric space (eg. $ℝ^n$),
+/-- A version of **Bolzano-Weierstrass**: in a proper metric space (eg. $ℝ^n$),
 every bounded sequence has a converging subsequence. -/
 theorem tendsto_subseq_of_bounded (hs : IsBounded s) {x : ℕ → X} (hx : ∀ n, x n ∈ s) :
     ∃ a ∈ closure s, ∃ φ : ℕ → ℕ, StrictMono φ ∧ Tendsto (x ∘ φ) atTop (𝓝 a) :=

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -335,7 +335,7 @@ protected theorem IsSeqCompact.isCompact (hs : IsSeqCompact s) : IsCompact s :=
   isCompact_iff_totallyBounded_isComplete.2 ⟨hs.totallyBounded, hs.isComplete⟩
 #align is_seq_compact.is_compact IsSeqCompact.isCompact
 
-/-- A version of Bolzano-Weistrass: in a uniform space with countably generated uniformity filter
+/-- A version of Bolzano-Weierstrass: in a uniform space with countably generated uniformity filter
 (e.g., in a metric space), a set is compact if and only if it is sequentially compact. -/
 protected theorem UniformSpace.isCompact_iff_isSeqCompact : IsCompact s ↔ IsSeqCompact s :=
   ⟨fun H => H.isSeqCompact, fun H => H.isCompact⟩


### PR DESCRIPTION
Fix typos:

* Use Π instead of ∀ for statement of Chinese Remainder Theorem
* Weistrass -> Weierstrass

---
Not sure if people would prefer this in two separate PRs.

For the first change, see: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Mathematics.20in.20Lean.2C.20CRT.20-.20Notation.20confusion

For the second, the German name is technically "Weierstraß", but "Weierstrass" is acceptable in English - and also it's consistent with the spelling elsewhere in the codebase.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
