### PR TITLE
[Merged by Bors] - feat(NumberTheory/SmoothNumbers): multiplicativity

### DIFF
--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -275,7 +275,7 @@ lemma primeFactors_subset_of_mem_smoothNumbers {m n : ℕ} (hms : m ∈ n.smooth
     | ⟨_, h⟩  => h x (mem_primeFactors_iff_mem_factors.mp hpf)
   fun _ h => mem_primesBelow.mpr ⟨hxle h hms, prime_of_mem_primeFactors h⟩
 
-/-- `m > 1` is a `n`-smooth number if all of its prime factors are contained in the set of
+/-- `m` is an `n`-smooth number if all of its prime factors are contained in the set of
   primes below `n` -/
 lemma mem_smoothNumbers_of_primeFactors_subset {m n : ℕ} (hm : m ≠ 0)
     (hp : m.primeFactors ⊆ n.primesBelow) : m ∈ n.smoothNumbers :=

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -283,8 +283,8 @@ lemma mem_smoothNumbers_of_primeFactors_subset {m n : ℕ} (hm : m ≠ 0)
 
 /-- `m` is an `n`-smooth number iff all of its prime factors are contained in the set of
   primes below `n` -/
-lemma mem_smoothNumbers_iff_primeFactors_subset {m n : ℕ} (hm : m ≠ 0)
-    : m.primeFactors ⊆ n.primesBelow ↔ m ∈ n.smoothNumbers :=
+lemma mem_smoothNumbers_iff_primeFactors_subset {m n : ℕ} (hm : m ≠ 0) :
+    m.primeFactors ⊆ n.primesBelow ↔ m ∈ n.smoothNumbers :=
   Iff.intro (mem_smoothNumbers_of_primeFactors_subset hm) primeFactors_subset_of_mem_smoothNumbers
 
 /-- Zero is never a smooth number -/

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -265,7 +265,7 @@ lemma mem_smoothNumbers_iff_forall_le {n m : ℕ} :
 lemma mem_smoothNumbers' {n m : ℕ} : m ∈ smoothNumbers n ↔ ∀ p, p.Prime → p ∣ m → p < n := by
   simp only [smoothNumbers_eq_factoredNumbers, mem_factoredNumbers', Finset.mem_range]
 
-/-- The prime factors of `m > 1` are contained in the set of primes below `n`
+/-- The prime factors of an `n'-smooth number are contained in the set of primes below `n`
   if `m` is a `n`-smooth number -/
 lemma primeFactors_subset_of_mem_smoothNumbers {m n : ℕ} (hms : m ∈ n.smoothNumbers) :
     m.primeFactors ⊆ n.primesBelow :=

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -265,8 +265,7 @@ lemma mem_smoothNumbers_iff_forall_le {n m : ℕ} :
 lemma mem_smoothNumbers' {n m : ℕ} : m ∈ smoothNumbers n ↔ ∀ p, p.Prime → p ∣ m → p < n := by
   simp only [smoothNumbers_eq_factoredNumbers, mem_factoredNumbers', Finset.mem_range]
 
-/-- The prime factors of an `n`-smooth number are contained in the set of primes below `n`
-  if `m` is an `n`-smooth number -/
+/-- The prime factors of an `n`-smooth number are contained in the set of primes below `n`. -/
 lemma primeFactors_subset_of_mem_smoothNumbers {m n : ℕ} (hms : m ∈ n.smoothNumbers) :
     m.primeFactors ⊆ n.primesBelow :=
   have hxle {x : ℕ} (hpf : x ∈ m.primeFactors) (hms : m ∈ n.smoothNumbers) :

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -279,7 +279,7 @@ lemma primeFactors_subset_of_mem_smoothNumbers {m n : ℕ} (hms : m ∈ n.smooth
   primes below `n` -/
 lemma mem_smoothNumbers_of_primeFactors_subset (m n : ℕ) (hm : m ≠ 0)
     (hp : m.primeFactors ⊆ n.primesBelow) : m ∈ n.smoothNumbers :=
-  ⟨ hm, fun _ h' => lt_of_mem_primesBelow <| hp <| mem_primeFactors_iff_mem_factors.mpr h' ⟩
+  ⟨hm, fun _ h => lt_of_mem_primesBelow <| hp <| mem_primeFactors_iff_mem_factors.mpr h⟩
 
 /-- Zero is never a smooth number -/
 lemma ne_zero_of_mem_smoothNumbers {n m : ℕ} (h : m ∈ smoothNumbers n) : m ≠ 0 := h.1

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -281,6 +281,12 @@ lemma mem_smoothNumbers_of_primeFactors_subset {m n : ℕ} (hm : m ≠ 0)
     (hp : m.primeFactors ⊆ n.primesBelow) : m ∈ n.smoothNumbers :=
   ⟨hm, fun _ h => lt_of_mem_primesBelow <| hp <| mem_primeFactors_iff_mem_factors.mpr h⟩
 
+/-- `m` is an `n`-smooth number iff all of its prime factors are contained in the set of
+  primes below `n` -/
+lemma mem_smoothNumbers_iff_primeFactors_subset {m n : ℕ} (hm : m ≠ 0)
+    : m.primeFactors ⊆ n.primesBelow ↔ m ∈ n.smoothNumbers :=
+  Iff.intro (mem_smoothNumbers_of_primeFactors_subset hm) primeFactors_subset_of_mem_smoothNumbers
+
 /-- Zero is never a smooth number -/
 lemma ne_zero_of_mem_smoothNumbers {n m : ℕ} (h : m ∈ smoothNumbers n) : m ≠ 0 := h.1
 

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -269,8 +269,8 @@ lemma mem_smoothNumbers' {n m : ℕ} : m ∈ smoothNumbers n ↔ ∀ p, p.Prime 
   if `m` is a `n`-smooth number -/
 lemma primeFactors_subset_of_mem_smoothNumbers (m n : ℕ) (hms : m ∈ n.smoothNumbers) :
     m.primeFactors ⊆ n.primesBelow :=
-  have hxle (m n x : ℕ) (hpf : x ∈ m.primeFactors) (hms : m ∈ smoothNumbers n)
-      : x < n :=
+  have hxle (m n x : ℕ) (hpf : x ∈ m.primeFactors) (hms : m ∈ smoothNumbers n) :
+      x < n :=
     match mem_smoothNumbers.mp hms with
     | ⟨ _, h2 ⟩  => h2 x (mem_primeFactors_iff_mem_factors.mp hpf)
   fun w hh => mem_primesBelow.mpr ⟨hxle m n w hh hms, prime_of_mem_primeFactors hh⟩

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -267,8 +267,8 @@ lemma mem_smoothNumbers' {n m : ℕ} : m ∈ smoothNumbers n ↔ ∀ p, p.Prime 
 
 /-- The prime factors of `m > 1` are contained in the set of primes below `n`
   if `m` is a `n`-smooth number -/
-lemma primeFactors_subset_of_mem_smoothNumbers (m n : ℕ) (hms : m ∈ n.smoothNumbers)
-    : m.primeFactors ⊆ n.primesBelow :=
+lemma primeFactors_subset_of_mem_smoothNumbers (m n : ℕ) (hms : m ∈ n.smoothNumbers) :
+    m.primeFactors ⊆ n.primesBelow :=
   have hxle (m n x : ℕ) (hpf : x ∈ m.primeFactors) (hms : m ∈ smoothNumbers n)
       : x < n :=
     match mem_smoothNumbers.mp hms with
@@ -342,8 +342,8 @@ lemma map_prime_pow_mul {F : Type*} [CommSemiring F] {f : ℕ → F}
 
 /-- The product of two `n`-smooth numbers is a `n`-smooth number -/
 theorem mul_mem_smoothNumbers (m₁ m₂ n : ℕ)
-    (hm1 : m₁ ∈ n.smoothNumbers) (hm2 : m₂ ∈ n.smoothNumbers)
-      : (m₁ * m₂) ∈ n.smoothNumbers := by
+    (hm1 : m₁ ∈ n.smoothNumbers) (hm2 : m₂ ∈ n.smoothNumbers) :
+      (m₁ * m₂) ∈ n.smoothNumbers := by
   have hm1z : m₁ ≠ 0 := ne_zero_of_mem_smoothNumbers hm1
   have hm2z : m₂ ≠ 0 := ne_zero_of_mem_smoothNumbers hm2
   apply primeFactors_subset_of_mem_smoothNumbers at hm1

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -340,7 +340,7 @@ lemma map_prime_pow_mul {F : Type*} [CommSemiring F] {f : ℕ → F}
     f (p ^ e * m) = f (p ^ e) * f m :=
   hmul <| Coprime.pow_left _ <| hp.smoothNumbers_coprime <| Subtype.mem m
 
-/-- The product of two `n`-smooth numbers is a `n`-smooth number -/
+/-- The product of two `n`-smooth numbers is an `n`-smooth number -/
 theorem mul_mem_smoothNumbers {m₁ m₂ n : ℕ}
     (hm1 : m₁ ∈ n.smoothNumbers) (hm2 : m₂ ∈ n.smoothNumbers) :
       (m₁ * m₂) ∈ n.smoothNumbers :=

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -277,7 +277,7 @@ lemma primeFactors_subset_of_mem_smoothNumbers {m n : ℕ} (hms : m ∈ n.smooth
 
 /-- `m > 1` is a `n`-smooth number if all of its prime factors are contained in the set of
   primes below `n` -/
-lemma mem_smoothNumbers_of_primeFactors_subset (m n : ℕ) (hm : m ≠ 0)
+lemma mem_smoothNumbers_of_primeFactors_subset {m n : ℕ} (hm : m ≠ 0)
     (hp : m.primeFactors ⊆ n.primesBelow) : m ∈ n.smoothNumbers :=
   ⟨hm, fun _ h => lt_of_mem_primesBelow <| hp <| mem_primeFactors_iff_mem_factors.mpr h⟩
 

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -265,7 +265,7 @@ lemma mem_smoothNumbers_iff_forall_le {n m : ℕ} :
 lemma mem_smoothNumbers' {n m : ℕ} : m ∈ smoothNumbers n ↔ ∀ p, p.Prime → p ∣ m → p < n := by
   simp only [smoothNumbers_eq_factoredNumbers, mem_factoredNumbers', Finset.mem_range]
 
-/-- The prime factors of an `n'-smooth number are contained in the set of primes below `n`
+/-- The prime factors of an `n`-smooth number are contained in the set of primes below `n`
   if `m` is a `n`-smooth number -/
 lemma primeFactors_subset_of_mem_smoothNumbers {m n : ℕ} (hms : m ∈ n.smoothNumbers) :
     m.primeFactors ⊆ n.primesBelow :=

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -341,15 +341,13 @@ lemma map_prime_pow_mul {F : Type*} [CommSemiring F] {f : ℕ → F}
   hmul <| Coprime.pow_left _ <| hp.smoothNumbers_coprime <| Subtype.mem m
 
 /-- The product of two `n`-smooth numbers is a `n`-smooth number -/
-theorem mul_mem_smoothNumbers (m₁ m₂ n : ℕ)
+theorem mul_mem_smoothNumbers {m₁ m₂ n : ℕ}
     (hm1 : m₁ ∈ n.smoothNumbers) (hm2 : m₂ ∈ n.smoothNumbers) :
-      (m₁ * m₂) ∈ n.smoothNumbers := by
-  have hm1z : m₁ ≠ 0 := ne_zero_of_mem_smoothNumbers hm1
-  have hm2z : m₂ ≠ 0 := ne_zero_of_mem_smoothNumbers hm2
-  apply primeFactors_subset_of_mem_smoothNumbers at hm1
-  apply primeFactors_subset_of_mem_smoothNumbers at hm2
-  exact mem_smoothNumbers_of_primeFactors_subset (m₁ * m₂) n (mul_ne_zero hm1z hm2z)
-    <| (primeFactors_mul hm1z hm2z) ▸ Finset.union_subset hm1 hm2
+      (m₁ * m₂) ∈ n.smoothNumbers :=
+  have hm1' := primeFactors_subset_of_mem_smoothNumbers hm1
+  have hm2' := primeFactors_subset_of_mem_smoothNumbers hm2
+  mem_smoothNumbers_of_primeFactors_subset (mul_ne_zero hm1.1 hm2.1)
+    <| primeFactors_mul hm1.1 hm2.1 ▸ Finset.union_subset hm1' hm2'
 
 open List Perm Equiv in
 /-- We establish the bijection from `ℕ × smoothNumbers p` to `smoothNumbers (p+1)`

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -266,7 +266,7 @@ lemma mem_smoothNumbers' {n m : ℕ} : m ∈ smoothNumbers n ↔ ∀ p, p.Prime 
   simp only [smoothNumbers_eq_factoredNumbers, mem_factoredNumbers', Finset.mem_range]
 
 /-- The prime factors of an `n`-smooth number are contained in the set of primes below `n`
-  if `m` is a `n`-smooth number -/
+  if `m` is an `n`-smooth number -/
 lemma primeFactors_subset_of_mem_smoothNumbers {m n : ℕ} (hms : m ∈ n.smoothNumbers) :
     m.primeFactors ⊆ n.primesBelow :=
   have hxle {x : ℕ} (hpf : x ∈ m.primeFactors) (hms : m ∈ n.smoothNumbers) :

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Michael Stoll
+Authors: Michael Stoll, Ralf Stephan
 -/
 import Mathlib.Data.Nat.Factorization.Basic
 import Mathlib.Data.Nat.Squarefree
@@ -265,6 +265,23 @@ lemma mem_smoothNumbers_iff_forall_le {n m : ℕ} :
 lemma mem_smoothNumbers' {n m : ℕ} : m ∈ smoothNumbers n ↔ ∀ p, p.Prime → p ∣ m → p < n := by
   simp only [smoothNumbers_eq_factoredNumbers, mem_factoredNumbers', Finset.mem_range]
 
+/-- The prime factors of `m > 1` are contained in the set of primes below `n`
+  if `m` is a `n`-smooth number -/
+lemma primeFactors_subset_of_mem_smoothNumbers (m n : ℕ) (hms : m ∈ n.smoothNumbers)
+    : m.primeFactors ⊆ n.primesBelow :=
+  have hxle (m n x : ℕ) (hpf : x ∈ m.primeFactors) (hms : m ∈ smoothNumbers n)
+      : x < n :=
+    match mem_smoothNumbers.mp hms with
+    | ⟨ _, h2 ⟩  => h2 x (mem_primeFactors_iff_mem_factors.mp hpf)
+  fun w hh => mem_primesBelow.mpr ⟨hxle m n w hh hms, prime_of_mem_primeFactors hh⟩
+
+/-- `m > 1` is a `n`-smooth number if all of its prime factors are contained in the set of
+  primes below `n` -/
+lemma mem_smoothNumbers_of_primeFactors_subset (m n : ℕ) (hm : m ≠ 0)
+    (hp : m.primeFactors ⊆ n.primesBelow) : m ∈ n.smoothNumbers :=
+  ⟨ hm, fun _ h' => lt_of_mem_primesBelow <| hp <| mem_primeFactors_iff_mem_factors.mpr h' ⟩
+
+/-- Zero is never a smooth number -/
 lemma ne_zero_of_mem_smoothNumbers {n m : ℕ} (h : m ∈ smoothNumbers n) : m ≠ 0 := h.1
 
 @[simp]
@@ -322,6 +339,17 @@ lemma map_prime_pow_mul {F : Type*} [CommSemiring F] {f : ℕ → F}
     {m : p.smoothNumbers} :
     f (p ^ e * m) = f (p ^ e) * f m :=
   hmul <| Coprime.pow_left _ <| hp.smoothNumbers_coprime <| Subtype.mem m
+
+/-- The product of two `n`-smooth numbers is a `n`-smooth number -/
+theorem mul_mem_smoothNumbers (m₁ m₂ n : ℕ)
+    (hm1 : m₁ ∈ n.smoothNumbers) (hm2 : m₂ ∈ n.smoothNumbers)
+      : (m₁ * m₂) ∈ n.smoothNumbers := by
+  have hm1z : m₁ ≠ 0 := ne_zero_of_mem_smoothNumbers hm1
+  have hm2z : m₂ ≠ 0 := ne_zero_of_mem_smoothNumbers hm2
+  apply primeFactors_subset_of_mem_smoothNumbers at hm1
+  apply primeFactors_subset_of_mem_smoothNumbers at hm2
+  exact mem_smoothNumbers_of_primeFactors_subset (m₁ * m₂) n (mul_ne_zero hm1z hm2z)
+    <| (primeFactors_mul hm1z hm2z) ▸ Finset.union_subset hm1 hm2
 
 open List Perm Equiv in
 /-- We establish the bijection from `ℕ × smoothNumbers p` to `smoothNumbers (p+1)`

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -268,24 +268,23 @@ lemma mem_smoothNumbers' {n m : ℕ} : m ∈ smoothNumbers n ↔ ∀ p, p.Prime 
 /-- The prime factors of an `n`-smooth number are contained in the set of primes below `n`. -/
 lemma primeFactors_subset_of_mem_smoothNumbers {m n : ℕ} (hms : m ∈ n.smoothNumbers) :
     m.primeFactors ⊆ n.primesBelow :=
-  have hxle {x : ℕ} (hpf : x ∈ m.primeFactors) (hms : m ∈ n.smoothNumbers) :
-      x < n :=
-    match mem_smoothNumbers.mp hms with
-    | ⟨_, h⟩  => h x (mem_primeFactors_iff_mem_factors.mp hpf)
-  fun _ h => mem_primesBelow.mpr ⟨hxle h hms, prime_of_mem_primeFactors h⟩
+  have hxle {x : ℕ} (hpf : x ∈ m.primeFactors) : x < n := by
+    obtain ⟨_, h⟩ := mem_smoothNumbers.mp hms
+    exact h x (mem_primeFactors_iff_mem_factors.mp hpf)
+  fun _ h ↦ mem_primesBelow.mpr ⟨hxle h, prime_of_mem_primeFactors h⟩
 
 /-- `m` is an `n`-smooth number if all of its prime factors are contained in the set of
   primes below `n`. -/
 lemma mem_smoothNumbers_of_primeFactors_subset {m n : ℕ} (hm : m ≠ 0)
     (hp : m.primeFactors ⊆ n.primesBelow) : m ∈ n.smoothNumbers :=
-  ⟨hm, fun _ h => lt_of_mem_primesBelow <| hp <| mem_primeFactors_iff_mem_factors.mpr h⟩
+  ⟨hm, fun _ h ↦ lt_of_mem_primesBelow <| hp <| mem_primeFactors_iff_mem_factors.mpr h⟩
 
 /-- `m` is an `n`-smooth number iff all of its prime factors are contained in the set of
   primes below `n` -/
 lemma mem_smoothNumbers_iff_primeFactors_subset {m n : ℕ} :
     m ∈ n.smoothNumbers ↔ m ≠ 0 ∧ m.primeFactors ⊆ n.primesBelow :=
-  ⟨fun h => ⟨h.1, primeFactors_subset_of_mem_smoothNumbers h⟩,
-  fun h => mem_smoothNumbers_of_primeFactors_subset h.1 h.2⟩
+  ⟨fun h ↦ ⟨h.1, primeFactors_subset_of_mem_smoothNumbers h⟩,
+  fun h ↦ mem_smoothNumbers_of_primeFactors_subset h.1 h.2⟩
 
 /-- Zero is never a smooth number -/
 lemma ne_zero_of_mem_smoothNumbers {n m : ℕ} (h : m ∈ smoothNumbers n) : m ≠ 0 := h.1
@@ -348,8 +347,7 @@ lemma map_prime_pow_mul {F : Type*} [CommSemiring F] {f : ℕ → F}
 
 /-- The product of two `n`-smooth numbers is an `n`-smooth number -/
 theorem mul_mem_smoothNumbers {m₁ m₂ n : ℕ}
-    (hm1 : m₁ ∈ n.smoothNumbers) (hm2 : m₂ ∈ n.smoothNumbers) :
-      (m₁ * m₂) ∈ n.smoothNumbers :=
+    (hm1 : m₁ ∈ n.smoothNumbers) (hm2 : m₂ ∈ n.smoothNumbers) : m₁ * m₂ ∈ n.smoothNumbers :=
   have hm1' := primeFactors_subset_of_mem_smoothNumbers hm1
   have hm2' := primeFactors_subset_of_mem_smoothNumbers hm2
   mem_smoothNumbers_of_primeFactors_subset (mul_ne_zero hm1.1 hm2.1)

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -267,13 +267,13 @@ lemma mem_smoothNumbers' {n m : ℕ} : m ∈ smoothNumbers n ↔ ∀ p, p.Prime 
 
 /-- The prime factors of `m > 1` are contained in the set of primes below `n`
   if `m` is a `n`-smooth number -/
-lemma primeFactors_subset_of_mem_smoothNumbers (m n : ℕ) (hms : m ∈ n.smoothNumbers) :
+lemma primeFactors_subset_of_mem_smoothNumbers {m n : ℕ} (hms : m ∈ n.smoothNumbers) :
     m.primeFactors ⊆ n.primesBelow :=
-  have hxle (m n x : ℕ) (hpf : x ∈ m.primeFactors) (hms : m ∈ smoothNumbers n) :
+  have hxle {x : ℕ} (hpf : x ∈ m.primeFactors) (hms : m ∈ n.smoothNumbers) :
       x < n :=
     match mem_smoothNumbers.mp hms with
-    | ⟨ _, h2 ⟩  => h2 x (mem_primeFactors_iff_mem_factors.mp hpf)
-  fun w hh => mem_primesBelow.mpr ⟨hxle m n w hh hms, prime_of_mem_primeFactors hh⟩
+    | ⟨_, h⟩  => h x (mem_primeFactors_iff_mem_factors.mp hpf)
+  fun _ h => mem_primesBelow.mpr ⟨hxle h hms, prime_of_mem_primeFactors h⟩
 
 /-- `m > 1` is a `n`-smooth number if all of its prime factors are contained in the set of
   primes below `n` -/

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -275,7 +275,7 @@ lemma primeFactors_subset_of_mem_smoothNumbers {m n : ℕ} (hms : m ∈ n.smooth
   fun _ h => mem_primesBelow.mpr ⟨hxle h hms, prime_of_mem_primeFactors h⟩
 
 /-- `m` is an `n`-smooth number if all of its prime factors are contained in the set of
-  primes below `n` -/
+  primes below `n`. -/
 lemma mem_smoothNumbers_of_primeFactors_subset {m n : ℕ} (hm : m ≠ 0)
     (hp : m.primeFactors ⊆ n.primesBelow) : m ∈ n.smoothNumbers :=
   ⟨hm, fun _ h => lt_of_mem_primesBelow <| hp <| mem_primeFactors_iff_mem_factors.mpr h⟩

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -283,9 +283,10 @@ lemma mem_smoothNumbers_of_primeFactors_subset {m n : ℕ} (hm : m ≠ 0)
 
 /-- `m` is an `n`-smooth number iff all of its prime factors are contained in the set of
   primes below `n` -/
-lemma mem_smoothNumbers_iff_primeFactors_subset {m n : ℕ} (hm : m ≠ 0) :
-    m.primeFactors ⊆ n.primesBelow ↔ m ∈ n.smoothNumbers :=
-  Iff.intro (mem_smoothNumbers_of_primeFactors_subset hm) primeFactors_subset_of_mem_smoothNumbers
+lemma mem_smoothNumbers_iff_primeFactors_subset {m n : ℕ} :
+    m ∈ n.smoothNumbers ↔ m ≠ 0 ∧ m.primeFactors ⊆ n.primesBelow :=
+  ⟨fun h => ⟨h.1, primeFactors_subset_of_mem_smoothNumbers h⟩,
+  fun h => mem_smoothNumbers_of_primeFactors_subset h.1 h.2⟩
 
 /-- Zero is never a smooth number -/
 lemma ne_zero_of_mem_smoothNumbers {n m : ℕ} (h : m ∈ smoothNumbers n) : m ≠ 0 := h.1


### PR DESCRIPTION
Prove that the product of two `n`-smooth numbers is an `n`-smooth number. Uses two helper lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
