### PR TITLE
[Merged by Bors] - Feat(LinearAlgebra/Quotient): Alternate version of `ker_liftQ_eq_bot` in terms of equality

### DIFF
--- a/Mathlib/LinearAlgebra/Quotient.lean
+++ b/Mathlib/LinearAlgebra/Quotient.lean
@@ -488,7 +488,7 @@ theorem ker_liftQ_eq_bot (f : M →ₛₗ[τ₁₂] M₂) (h) (h' : ker f ≤ p)
 
 theorem ker_liftQ_eq_bot' (f : M →ₛₗ[τ₁₂] M₂) (h : p = ker f) :
     ker (p.liftQ f (le_of_eq h)) = ⊥ :=
-  ker_liftQ_eq_bot p f (le_of_eq h) (le_of_eq h.symm)
+  ker_liftQ_eq_bot p f h.le h.ge
 
 /-- The correspondence theorem for modules: there is an order isomorphism between submodules of the
 quotient of `M` by `p`, and submodules of `M` larger than `p`. -/

--- a/Mathlib/LinearAlgebra/Quotient.lean
+++ b/Mathlib/LinearAlgebra/Quotient.lean
@@ -486,6 +486,10 @@ theorem ker_liftQ_eq_bot (f : M →ₛₗ[τ₁₂] M₂) (h) (h' : ker f ≤ p)
   rw [ker_liftQ, le_antisymm h h', mkQ_map_self]
 #align submodule.ker_liftq_eq_bot Submodule.ker_liftQ_eq_bot
 
+theorem ker_liftQ_eq_bot' (f : M →ₛₗ[τ₁₂] M₂) (h : p = ker f) :
+    ker (p.liftQ f (le_of_eq h)) = ⊥ :=
+  ker_liftQ_eq_bot p f (le_of_eq h) (le_of_eq h.symm)
+
 /-- The correspondence theorem for modules: there is an order isomorphism between submodules of the
 quotient of `M` by `p`, and submodules of `M` larger than `p`. -/
 def comapMkQRelIso : Submodule R (M ⧸ p) ≃o { p' : Submodule R M // p ≤ p' } where


### PR DESCRIPTION
Add version of `ker_liftQ_eq_bot` with both-ways `≤` replaced by `=` in the hypotheses. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Because of proof irrelevance, the `le_of_eq h` in the goal doesn't really matter. It'll unify with any proof of `p ≤ ker f`. In some code I was writing I had a proof of `p = ker f` floating around (from an exact sequence), something in the goal that would reduce to an instance of `liftQ`, and it felt overly verbose to turn the proof of equality into a proof of `p ≤ ker f` and `ker f ≤ p`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
