### PR TITLE
[Merged by Bors] - Feat(RingTheory/Ideal/Operations): Misc lemmas about smul actions on submodules

### DIFF
--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -319,7 +319,7 @@ theorem map_smul'' (f : M →ₗ[R] M') : (I • N).map f = I • N.map f :=
 #align submodule.map_smul'' Submodule.map_smul''
 
 open Pointwise in
-theorem map_element_smul (r : R) (N : Submodule R M) (f : M →ₗ[R] M') :
+theorem map_pointwise_smul (r : R) (N : Submodule R M) (f : M →ₗ[R] M') :
     (r • N).map f = r • N.map f :=
   by simp_rw [← ideal_span_singleton_smul, map_smul'']
 

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -318,6 +318,11 @@ theorem map_smul'' (f : M →ₗ[R] M') : (I • N).map f = I • N.map f :=
       hfp ▸ f.map_smul r p ▸ mem_map_of_mem (smul_mem_smul hr hp)
 #align submodule.map_smul'' Submodule.map_smul''
 
+open Pointwise in
+theorem map_element_smul (r : R) (N : Submodule R M) (f : M →ₗ[R] M') :
+    (r • N).map f = r • N.map f :=
+  by simp_rw [← ideal_span_singleton_smul, map_smul'']
+
 variable {I}
 
 theorem mem_smul_span {s : Set M} {x : M} :
@@ -1401,5 +1406,10 @@ lemma span_smul_eq
     (s : Set R) (N : Submodule R M) :
     Ideal.span s • N = s • N := by
   rw [← coe_set_smul, coe_span_smul]
+
+theorem set_smul_top_eq_span (s : Set R) :
+    s • ⊤ = Ideal.span s :=
+  Eq.trans (span_smul_eq s ⊤).symm <|
+    Eq.trans (smul_eq_mul (Ideal R)) (Ideal.mul_top (.span s))
 
 end Submodule

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -307,6 +307,7 @@ theorem mem_of_span_eq_top_of_smul_pow_mem (M' : Submodule R M) (s : Set R) (hs 
 
 variable {M' : Type w} [AddCommMonoid M'] [Module R M']
 
+@[simp]
 theorem map_smul'' (f : M →ₗ[R] M') : (I • N).map f = I • N.map f :=
   le_antisymm
       (map_le_iff_le_comap.2 <|
@@ -319,6 +320,7 @@ theorem map_smul'' (f : M →ₗ[R] M') : (I • N).map f = I • N.map f :=
 #align submodule.map_smul'' Submodule.map_smul''
 
 open Pointwise in
+@[simp]
 theorem map_pointwise_smul (r : R) (N : Submodule R M) (f : M →ₗ[R] M') :
     (r • N).map f = r • N.map f :=
   by simp_rw [← ideal_span_singleton_smul, map_smul'']
@@ -1407,6 +1409,7 @@ lemma span_smul_eq
     Ideal.span s • N = s • N := by
   rw [← coe_set_smul, coe_span_smul]
 
+@[simp]
 theorem set_smul_top_eq_span (s : Set R) :
     s • ⊤ = Ideal.span s :=
   Eq.trans (span_smul_eq s ⊤).symm <|

--- a/Mathlib/RingTheory/Nakayama.lean
+++ b/Mathlib/RingTheory/Nakayama.lean
@@ -77,8 +77,7 @@ theorem sup_eq_sup_smul_of_le_smul_of_le_jacobson {I J : Ideal R} {N N' : Submod
     (sup_le_sup_left (Submodule.smul_le.2 fun _ _ _ => Submodule.smul_mem _ _) _)
   have h_comap := Submodule.comap_injective_of_surjective (LinearMap.range_eq_top.1 N.range_mkQ)
   have : (I • N').map N.mkQ = N'.map N.mkQ := by
-    rw [← h_comap.eq_iff]
-    simpa [comap_map_eq, sup_comm, eq_comm] using hNN'
+    simpa only [← h_comap.eq_iff, comap_map_mkQ, sup_comm, eq_comm] using hNN'
   have :=
     @Submodule.eq_smul_of_le_smul_of_le_jacobson _ _ _ _ _ I J (N'.map N.mkQ) (hN'.map _)
       (by rw [← map_smul'', this]) hIJ


### PR DESCRIPTION
Misc lemmas about smul actions on submodules.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The overall API of elements/sets/ideals acting on submodules kind of needs of an overhaul. There's a lot of stuff duplicated between these three actions, and it can be hard to find what you need because lemma names don't necessarily distinguish between the actions (eg `map_smul''` does not at all indicate it's about ideal-actions and not element-actions or set-actions). This is made worse by the fact that the actions of an ideal is defined in terms of map2, which only works over commutative rings.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
