### PR TITLE
[Merged by Bors] - Feat(Algebra/Regular/SMul): Add some lemmas about `IsSMulRegular`

### DIFF
--- a/Mathlib/Algebra/Regular/SMul.lean
+++ b/Mathlib/Algebra/Regular/SMul.lean
@@ -125,8 +125,8 @@ theorem mul_and_mul_iff [Mul R] [IsScalarTower R R M] :
 lemma isSMulRegular_of_injective_of_isSMulRegular {N F} [SMul R N]
     [FunLike F M N] [MulActionHomClass F R M N] (f : F) {r : R}
     (h1 : Function.Injective f) (h2 : IsSMulRegular N r) : IsSMulRegular M r :=
-    fun x y h3 => h1 <| h2 <| Eq.trans (map_smulₛₗ f r x).symm <|
-      Eq.trans (congrArg f h3) (map_smulₛₗ f r y)
+    fun x y h3 => h1 <| h2 <| (map_smulₛₗ f r x).symm.trans <|
+      (congrArg f h3).trans <| map_smulₛₗ f r y
 
 end SMul
 
@@ -269,12 +269,12 @@ variable {M}
 protected
 lemma IsSMulRegular.eq_zero_of_smul_eq_zero [Zero M] [SMulZeroClass R M]
     {r : R} {x : M} (h1 : IsSMulRegular M r) (h2 : r • x = 0) : x = 0 :=
-  h1 <| Eq.trans h2 <| Eq.symm <| smul_zero r
+  h1 (h2.trans (smul_zero r).symm)
 
 end SMulZeroClass
 
 lemma Equiv.isSMulRegular_congr {R S M M'} [SMul R M] [SMul S M'] {e : M ≃ M'}
     {r : R} {s : S} (h : ∀ x, e (r • x) = s • e x) :
     IsSMulRegular M r ↔ IsSMulRegular M' s :=
-  Iff.trans (e.comp_injective _).symm <|
-    Iff.trans (iff_of_eq <| congrArg _ <| funext h) <| e.injective_comp _
+  (e.comp_injective _).symm.trans  <|
+    (iff_of_eq <| congrArg _ <| funext h).trans <| e.injective_comp _

--- a/Mathlib/Algebra/Regular/SMul.lean
+++ b/Mathlib/Algebra/Regular/SMul.lean
@@ -125,8 +125,8 @@ theorem mul_and_mul_iff [Mul R] [IsScalarTower R R M] :
 lemma isSMulRegular_of_injective_of_isSMulRegular {N F} [SMul R N]
     [FunLike F M N] [MulActionHomClass F R M N] (f : F) {r : R}
     (h1 : Function.Injective f) (h2 : IsSMulRegular N r) : IsSMulRegular M r :=
-    fun x y h' => h1 <| h2 <| Eq.trans (map_smulₛₗ f r x).symm <|
-      Eq.trans (congrArg f h') (map_smulₛₗ f r y)
+    fun x y h3 => h1 <| h2 <| Eq.trans (map_smulₛₗ f r x).symm <|
+      Eq.trans (congrArg f h3) (map_smulₛₗ f r y)
 
 end SMul
 

--- a/Mathlib/Algebra/Regular/SMul.lean
+++ b/Mathlib/Algebra/Regular/SMul.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
-import Mathlib.Algebra.SMulWithZero
 import Mathlib.Algebra.Regular.Basic
+import Mathlib.GroupTheory.GroupAction.Hom
 
 #align_import algebra.regular.smul from "leanprover-community/mathlib"@"550b58538991c8977703fdeb7c9d51a5aa27df11"
 
@@ -121,6 +121,12 @@ theorem mul_and_mul_iff [Mul R] [IsScalarTower R R M] :
   · rintro ⟨ha, hb⟩
     exact ⟨ha.mul hb, hb.mul ha⟩
 #align is_smul_regular.mul_and_mul_iff IsSMulRegular.mul_and_mul_iff
+
+lemma isSMulRegular_of_injective_of_isSMulRegular {N F} [SMul R N]
+    [FunLike F M N] [MulActionHomClass F R M N] (f : F) {r : R}
+    (h1 : Function.Injective f) (h2 : IsSMulRegular N r) : IsSMulRegular M r :=
+    fun x y h' => h1 <| h2 <| Eq.trans (map_smulₛₗ f r x).symm <|
+      Eq.trans (congrArg f h') (map_smulₛₗ f r y)
 
 end SMul
 
@@ -255,3 +261,20 @@ theorem IsUnit.isSMulRegular (ua : IsUnit a) : IsSMulRegular M a := by
 #align is_unit.is_smul_regular IsUnit.isSMulRegular
 
 end Units
+
+section SMulZeroClass
+
+variable {M}
+
+protected
+lemma IsSMulRegular.eq_zero_of_smul_eq_zero [Zero M] [SMulZeroClass R M]
+    {r : R} {x : M} (h1 : IsSMulRegular M r) (h2 : r • x = 0) : x = 0 :=
+  h1 <| Eq.trans h2 <| Eq.symm <| smul_zero r
+
+end SMulZeroClass
+
+lemma Equiv.isSMulRegular_congr {R S M M'} [SMul R M] [SMul S M'] {e : M ≃ M'}
+    {r : R} {s : S} (h : ∀ x, e (r • x) = s • e x) :
+    IsSMulRegular M r ↔ IsSMulRegular M' s :=
+  Iff.trans (e.comp_injective _).symm <|
+    Iff.trans (iff_of_eq <| congrArg _ <| funext h) <| e.injective_comp _


### PR DESCRIPTION
Add some lemmas about `IsSMulRegular`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I'm not sure if it's okay to add the `Mathlib.GroupTheory.GroupAction.Hom` import. My understanding is that this file is kept low in the hierarchy for some reason, but I'm not sure what that reason is or if this pushes it too far ahead. I added it for access to `MulActionHomClass` in `isSMulRegular_of_injective_of_isSMulRegular`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
