### PR TITLE
[Merged by Bors] - feat(Probability): add `indepFun_of_identDistrib_pair `

### DIFF
--- a/Mathlib/Probability/IdentDistrib.lean
+++ b/Mathlib/Probability/IdentDistrib.lean
@@ -373,22 +373,13 @@ lemma indepFun_of_identDistrib_pair
     {X : γ → α} {X' : δ → α} {Y : γ → β} {Y' : δ → β} (h_indep : IndepFun X Y μ)
     (h_ident : IdentDistrib (fun ω ↦ (X ω, Y ω)) (fun ω ↦ (X' ω, Y' ω)) μ μ') :
     IndepFun X' Y' μ' := by
-  have hX : AEMeasurable X μ := by
-    rw [(by ext; simp : X = Prod.fst ∘ (fun ω ↦ (X ω, Y ω)))]
-    exact measurable_fst.aemeasurable.comp_aemeasurable h_ident.aemeasurable_fst
-  have hY : AEMeasurable Y μ := by
-    rw [(by ext; simp : Y = Prod.snd ∘ (fun ω ↦ (X ω, Y ω)))]
-    exact measurable_snd.aemeasurable.comp_aemeasurable h_ident.aemeasurable_fst
-  have hX' : AEMeasurable X' μ' := by
-    rw [(by ext; simp : X' = Prod.fst ∘ (fun ω ↦ (X' ω, Y' ω)))]
-    exact measurable_fst.aemeasurable.comp_aemeasurable h_ident.aemeasurable_snd
-  have hY' : AEMeasurable Y' μ' := by
-    rw [(by ext; simp : Y' = Prod.snd ∘ (fun ω ↦ (X' ω, Y' ω)))]
-    exact measurable_snd.aemeasurable.comp_aemeasurable h_ident.aemeasurable_snd
-  apply (indepFun_iff_map_prod_eq_prod_map_map hX' hY').mpr
-  have iX : IdentDistrib X X' μ μ' := h_ident.comp measurable_fst
-  have iY : IdentDistrib Y Y' μ μ' := h_ident.comp measurable_snd
-  rw [← h_ident.map_eq, ← iX.map_eq, ← iY.map_eq]
-  exact indepFun_iff_map_prod_eq_prod_map_map hX hY |>.mp h_indep
+  rw [indepFun_iff_map_prod_eq_prod_map_map _ _, ← h_ident.map_eq,
+    (indepFun_iff_map_prod_eq_prod_map_map _ _).1 h_indep]
+  . exact congr (congrArg Measure.prod <| (h_ident.comp measurable_fst).map_eq)
+      (h_ident.comp measurable_snd).map_eq
+  . exact measurable_fst.aemeasurable.comp_aemeasurable h_ident.aemeasurable_fst
+  . exact measurable_snd.aemeasurable.comp_aemeasurable h_ident.aemeasurable_fst
+  . exact measurable_fst.aemeasurable.comp_aemeasurable h_ident.aemeasurable_snd
+  . exact measurable_snd.aemeasurable.comp_aemeasurable h_ident.aemeasurable_snd
 
 end ProbabilityTheory

--- a/Mathlib/Probability/IdentDistrib.lean
+++ b/Mathlib/Probability/IdentDistrib.lean
@@ -370,15 +370,27 @@ end UniformIntegrable
 then `X'` and `Y'` are independent. -/
 lemma indepFun_of_identDistrib_pair
     {μ : Measure γ} {μ' : Measure δ} [IsFiniteMeasure μ] [IsFiniteMeasure μ']
-    {X : γ → α} {X' : δ → α} {Y : γ → β} {Y' : δ → β} (hX : AEMeasurable X μ)
-    (hX' : AEMeasurable X' μ') (hY : AEMeasurable Y μ) (hY' : AEMeasurable Y' μ')
+    {X : γ → α} {X' : δ → α} {Y : γ → β} {Y' : δ → β} --(hX : AEMeasurable X μ)
+    --(hX' : AEMeasurable X' μ') (hY : AEMeasurable Y μ) (hY' : AEMeasurable Y' μ')
     (h_indep : IndepFun X Y μ)
     (h_ident : IdentDistrib (fun ω ↦ (X ω, Y ω)) (fun ω ↦ (X' ω, Y' ω)) μ μ') :
     IndepFun X' Y' μ' := by
-  apply (indepFun_iff_map_prod_eq_prod_map_map hX' hY').mpr
+  have hX : AEMeasurable X μ := by
+    rw [(by ext; simp : X = Prod.fst ∘ (fun ω ↦ (X ω, Y ω)))]
+    exact measurable_fst.aemeasurable.comp_aemeasurable h_ident.aemeasurable_fst
+  have hY : AEMeasurable Y μ := by
+    rw [(by ext; simp : Y = Prod.snd ∘ (fun ω ↦ (X ω, Y ω)))]
+    exact measurable_snd.aemeasurable.comp_aemeasurable h_ident.aemeasurable_fst
+  have hX' : AEMeasurable X' μ' := by
+    rw [(by ext; simp : X' = Prod.fst ∘ (fun ω ↦ (X' ω, Y' ω)))]
+    exact measurable_fst.aemeasurable.comp_aemeasurable h_ident.aemeasurable_snd
+  have hY' : AEMeasurable Y' μ' := by
+    rw [(by ext; simp : Y' = Prod.snd ∘ (fun ω ↦ (X' ω, Y' ω)))]
+    exact measurable_snd.aemeasurable.comp_aemeasurable h_ident.aemeasurable_snd
+  apply (indepFun_iff_map_prod_eq_prod_map_map (hX') (hY')).mpr
   have iX : IdentDistrib X X' μ μ' := h_ident.comp measurable_fst
   have iY : IdentDistrib Y Y' μ μ' := h_ident.comp measurable_snd
   rw [← h_ident.map_eq, ← iX.map_eq, ← iY.map_eq]
-  exact indepFun_iff_map_prod_eq_prod_map_map hX hY |>.mp h_indep
+  exact indepFun_iff_map_prod_eq_prod_map_map (hX) (hY) |>.mp h_indep
 
 end ProbabilityTheory

--- a/Mathlib/Probability/IdentDistrib.lean
+++ b/Mathlib/Probability/IdentDistrib.lean
@@ -385,10 +385,10 @@ lemma indepFun_of_identDistrib_pair
   have hY' : AEMeasurable Y' μ' := by
     rw [(by ext; simp : Y' = Prod.snd ∘ (fun ω ↦ (X' ω, Y' ω)))]
     exact measurable_snd.aemeasurable.comp_aemeasurable h_ident.aemeasurable_snd
-  apply (indepFun_iff_map_prod_eq_prod_map_map (hX') (hY')).mpr
+  apply (indepFun_iff_map_prod_eq_prod_map_map hX' hY').mpr
   have iX : IdentDistrib X X' μ μ' := h_ident.comp measurable_fst
   have iY : IdentDistrib Y Y' μ μ' := h_ident.comp measurable_snd
   rw [← h_ident.map_eq, ← iX.map_eq, ← iY.map_eq]
-  exact indepFun_iff_map_prod_eq_prod_map_map (hX) (hY) |>.mp h_indep
+  exact indepFun_iff_map_prod_eq_prod_map_map hX hY |>.mp h_indep
 
 end ProbabilityTheory

--- a/Mathlib/Probability/IdentDistrib.lean
+++ b/Mathlib/Probability/IdentDistrib.lean
@@ -377,9 +377,9 @@ lemma indepFun_of_identDistrib_pair
     (indepFun_iff_map_prod_eq_prod_map_map _ _).1 h_indep]
   · exact congr (congrArg Measure.prod <| (h_ident.comp measurable_fst).map_eq)
       (h_ident.comp measurable_snd).map_eq
-  . exact measurable_fst.aemeasurable.comp_aemeasurable h_ident.aemeasurable_fst
-  . exact measurable_snd.aemeasurable.comp_aemeasurable h_ident.aemeasurable_fst
-  . exact measurable_fst.aemeasurable.comp_aemeasurable h_ident.aemeasurable_snd
-  . exact measurable_snd.aemeasurable.comp_aemeasurable h_ident.aemeasurable_snd
+  · exact measurable_fst.aemeasurable.comp_aemeasurable h_ident.aemeasurable_fst
+  · exact measurable_snd.aemeasurable.comp_aemeasurable h_ident.aemeasurable_fst
+  · exact measurable_fst.aemeasurable.comp_aemeasurable h_ident.aemeasurable_snd
+  · exact measurable_snd.aemeasurable.comp_aemeasurable h_ident.aemeasurable_snd
 
 end ProbabilityTheory

--- a/Mathlib/Probability/IdentDistrib.lean
+++ b/Mathlib/Probability/IdentDistrib.lean
@@ -370,9 +370,7 @@ end UniformIntegrable
 then `X'` and `Y'` are independent. -/
 lemma indepFun_of_identDistrib_pair
     {μ : Measure γ} {μ' : Measure δ} [IsFiniteMeasure μ] [IsFiniteMeasure μ']
-    {X : γ → α} {X' : δ → α} {Y : γ → β} {Y' : δ → β} --(hX : AEMeasurable X μ)
-    --(hX' : AEMeasurable X' μ') (hY : AEMeasurable Y μ) (hY' : AEMeasurable Y' μ')
-    (h_indep : IndepFun X Y μ)
+    {X : γ → α} {X' : δ → α} {Y : γ → β} {Y' : δ → β} (h_indep : IndepFun X Y μ)
     (h_ident : IdentDistrib (fun ω ↦ (X ω, Y ω)) (fun ω ↦ (X' ω, Y' ω)) μ μ') :
     IndepFun X' Y' μ' := by
   have hX : AEMeasurable X μ := by

--- a/Mathlib/Probability/IdentDistrib.lean
+++ b/Mathlib/Probability/IdentDistrib.lean
@@ -375,7 +375,7 @@ lemma indepFun_of_identDistrib_pair
     IndepFun X' Y' μ' := by
   rw [indepFun_iff_map_prod_eq_prod_map_map _ _, ← h_ident.map_eq,
     (indepFun_iff_map_prod_eq_prod_map_map _ _).1 h_indep]
-  . exact congr (congrArg Measure.prod <| (h_ident.comp measurable_fst).map_eq)
+  · exact congr (congrArg Measure.prod <| (h_ident.comp measurable_fst).map_eq)
       (h_ident.comp measurable_snd).map_eq
   . exact measurable_fst.aemeasurable.comp_aemeasurable h_ident.aemeasurable_fst
   . exact measurable_snd.aemeasurable.comp_aemeasurable h_ident.aemeasurable_fst

--- a/Mathlib/Probability/IdentDistrib.lean
+++ b/Mathlib/Probability/IdentDistrib.lean
@@ -366,4 +366,19 @@ theorem Memℒp.uniformIntegrable_of_identDistrib {ι : Type*} {f : ι → α �
 
 end UniformIntegrable
 
+/-- If `X` and `Y` are independent and `(X, Y)` and `(X', Y')` are identically distributed,
+then `X'` and `Y'` are independent. -/
+lemma indepFun_of_identDistrib_pair
+    {μ : Measure γ} {μ' : Measure δ} [IsFiniteMeasure μ] [IsFiniteMeasure μ']
+    {X : γ → α} {X' : δ → α} {Y : γ → β} {Y' : δ → β} (hX : AEMeasurable X μ)
+    (hX' : AEMeasurable X' μ') (hY : AEMeasurable Y μ) (hY' : AEMeasurable Y' μ')
+    (h_indep : IndepFun X Y μ)
+    (h_ident : IdentDistrib (fun ω ↦ (X ω, Y ω)) (fun ω ↦ (X' ω, Y' ω)) μ μ') :
+    IndepFun X' Y' μ' := by
+  apply (indepFun_iff_map_prod_eq_prod_map_map hX' hY').mpr
+  have iX : IdentDistrib X X' μ μ' := h_ident.comp measurable_fst
+  have iY : IdentDistrib Y Y' μ μ' := h_ident.comp measurable_snd
+  rw [← h_ident.map_eq, ← iX.map_eq, ← iY.map_eq]
+  exact indepFun_iff_map_prod_eq_prod_map_map hX hY |>.mp h_indep
+
 end ProbabilityTheory


### PR DESCRIPTION
This PR adds the lemma claiming that if `X` and `Y` are independent and `(X, Y)` and `(X', Y')` are identically distributed, then `X'` and `Y'` are independent.

See the associated [Zulip topic](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/.60IndepFun.60.20of.20.60IdentDistrib.60.20pairs).