### PR TITLE
[Merged by Bors] - chore(Algebra/Lie): rename IsSemisimple to HasTrivialRadical

### DIFF
--- a/Mathlib/Algebra/Lie/Derivation/Killing.lean
+++ b/Mathlib/Algebra/Lie/Derivation/Killing.lean
@@ -75,7 +75,7 @@ variable [LieAlgebra.IsKilling R L]
 
 @[simp] lemma ad_apply_eq_zero_iff (x : L) : ad R L x = 0 ↔ x = 0 := by
   refine ⟨fun h ↦ ?_, fun h ↦ by simp [h]⟩
-  rwa [← LieHom.mem_ker, ad_ker_eq_center, LieAlgebra.center_eq_bot_of_semisimple,
+  rwa [← LieHom.mem_ker, ad_ker_eq_center, LieAlgebra.center_eq_bot_of_hasTrivialRadical,
     LieSubmodule.mem_bot] at h
 
 instance instIsKilling_range_ad : LieAlgebra.IsKilling R 𝕀 :=

--- a/Mathlib/Algebra/Lie/Killing.lean
+++ b/Mathlib/Algebra/Lie/Killing.lean
@@ -25,8 +25,8 @@ This file contains basic definitions and results for such Lie algebras.
 ## Main definitions
  * `LieAlgebra.IsKilling`: a typeclass encoding the fact that a Lie algebra has a non-singular
    Killing form.
- * `LieAlgebra.IsKilling.instIsSemisimple`: if a Lie algebra has non-singular Killing form then it
-   is semisimple.
+ * `LieAlgebra.IsKilling.instHasTrivialRadical`: if a Lie algebra has non-singular Killing form
+   then it has trivial radical.
 
 ## TODO
 
@@ -62,8 +62,8 @@ lemma killingForm_nondegenerate :
 
 /-- The converse of this is true over a field of characteristic zero. There are counterexamples
 over fields with positive characteristic. -/
-instance instIsSemisimple [IsDomain R] [IsPrincipalIdealRing R] : IsSemisimple R L := by
-  refine' (isSemisimple_iff_no_abelian_ideals R L).mpr fun I hI ↦ _
+instance instHasTrivialRadical [IsDomain R] [IsPrincipalIdealRing R] : HasTrivialRadical R L := by
+  refine' (hasTrivialRadical_iff_no_abelian_ideals R L).mpr fun I hI ↦ _
   rw [eq_bot_iff, ← killingCompl_top_eq_bot]
   exact I.le_killingCompl_top_of_isLieAbelian
 

--- a/Mathlib/Algebra/Lie/Semisimple.lean
+++ b/Mathlib/Algebra/Lie/Semisimple.lean
@@ -33,9 +33,10 @@ lie algebra, radical, simple, semisimple
 
 universe u v w w₁ w₂
 
-/-- A Lie module is *irreducible* if its only Lie submodules are `⊥` and `⊤` (which may coincide). -/
+/-- A Lie module is *irreducible* if its only Lie submodules are `⊥` and `⊤`
+(which may coincide). -/
 abbrev LieModule.IsIrreducible (R L M : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]
-  [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M] : Prop :=
+  [AddCommGroup M] [Module R M] [LieRingModule L M] : Prop :=
   IsSimpleOrder (LieSubmodule R L M)
 #align lie_module.is_irreducible LieModule.IsIrreducible
 
@@ -69,6 +70,9 @@ class HasTrivialRadical : Prop where
   radical_eq_bot : radical R L = ⊥
 #align lie_algebra.is_semisimple LieAlgebra.HasTrivialRadical
 
+export HasTrivialRadical (radical_eq_bot)
+attribute [simp] radical_eq_bot
+
 /--
 A *semisimple* Lie algebra is one that is a direct sum of simple Lie algebras.
 
@@ -87,10 +91,9 @@ class IsSemisimple : Prop where
 -- TODO: show that the atomic ideals of a semisimple Lie algebra are simple
 
 variable {R L} in
-@[simp]
-theorem HasTrivialRadical.eq_bot_of_isSolvable [h : HasTrivialRadical R L]
+theorem HasTrivialRadical.eq_bot_of_isSolvable [HasTrivialRadical R L]
     (I : LieIdeal R L) [hI : IsSolvable R I] : I = ⊥ :=
-  sSup_eq_bot.mp h.radical_eq_bot _ hI
+  sSup_eq_bot.mp radical_eq_bot _ hI
 
 variable {R L} in
 theorem hasTrivialRadical_of_no_solvable_ideals (h : ∀ I : LieIdeal R L, IsSolvable R I → I = ⊥) :

--- a/Mathlib/Algebra/Lie/Semisimple.lean
+++ b/Mathlib/Algebra/Lie/Semisimple.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
 import Mathlib.Algebra.Lie.Solvable
+import Mathlib.Order.Atoms
+import Mathlib.Order.Minimal
 
 #align_import algebra.lie.semisimple from "leanprover-community/mathlib"@"356447fe00e75e54777321045cdff7c9ea212e60"
 
@@ -49,55 +51,77 @@ class IsSimple extends LieModule.IsIrreducible R L L : Prop where
   non_abelian : ¬IsLieAbelian L
 #align lie_algebra.is_simple LieAlgebra.IsSimple
 
-/-- A semisimple Lie algebra is one with trivial radical.
+/--
+A Lie algebra *has trivial radical* if its radical is trivial.
+This is equivalent to having no non-trivial solvable ideals,
+and further equivalent to having no non-trivial abelian ideals.
+
+In characteristic zero, it is also equivalent to `LieAlgebra.IsSemisimple`.
 
 Note that the label 'semisimple' is apparently not universally agreed
 [upon](https://mathoverflow.net/questions/149391/on-radicals-of-a-lie-algebra#comment383669_149391)
-for general coefficients. We are following [Seligman, page 15](seligman1967) and using the label
-for the weakest of the various properties which are all equivalent over a field of characteristic
-zero. -/
+for general coefficients.
+
+For example [Seligman, page 15](seligman1967) uses the label for `LieAlgebra.HasTrivialRadical`,
+whereas we reserve it for Lie algebras that are a direct sum of simple Lie algebras.
+-/
+class HasTrivialRadical : Prop where
+  trivial_radical : radical R L = ⊥
+#align lie_algebra.is_semisimple LieAlgebra.HasTrivialRadical
+
+/--
+A *semisimple* Lie algebra is one that is a direct sum of simple Lie algebras.
+
+Note that the label 'semisimple' is apparently not universally agreed
+[upon](https://mathoverflow.net/questions/149391/on-radicals-of-a-lie-algebra#comment383669_149391)
+for general coefficients.
+
+For example [Seligman, page 15](seligman1967) uses the label for `LieAlgebra.HasTrivialRadical`,
+the weakest of the various properties which are all equivalent over a field of characteristic zero.
+-/
 class IsSemisimple : Prop where
-  semisimple : radical R L = ⊥
-#align lie_algebra.is_semisimple LieAlgebra.IsSemisimple
+  spanning : ⨆ (I : LieIdeal R L) (_hI : IsAtom I), I = ⊤
+  independent : CompleteLattice.SetIndependent {I : LieIdeal R L | IsAtom I}
+  isSimple_of_isAtom : ∀ I : LieIdeal R L, IsAtom I → IsSimple R I
 
-theorem isSemisimple_iff_no_solvable_ideals :
-    IsSemisimple R L ↔ ∀ I : LieIdeal R L, IsSolvable R I → I = ⊥ :=
-  ⟨fun h => sSup_eq_bot.mp h.semisimple, fun h => ⟨sSup_eq_bot.mpr h⟩⟩
-#align lie_algebra.is_semisimple_iff_no_solvable_ideals LieAlgebra.isSemisimple_iff_no_solvable_ideals
+theorem hasTrivialRadical_iff_no_solvable_ideals :
+    HasTrivialRadical R L ↔ ∀ I : LieIdeal R L, IsSolvable R I → I = ⊥ :=
+  ⟨fun h => sSup_eq_bot.mp h.trivial_radical, fun h => ⟨sSup_eq_bot.mpr h⟩⟩
+#align lie_algebra.is_semisimple_iff_no_solvable_ideals LieAlgebra.hasTrivialRadical_iff_no_solvable_ideals
 
-theorem isSemisimple_iff_no_abelian_ideals :
-    IsSemisimple R L ↔ ∀ I : LieIdeal R L, IsLieAbelian I → I = ⊥ := by
-  rw [isSemisimple_iff_no_solvable_ideals]
+theorem hasTrivialRadical_iff_no_abelian_ideals :
+    HasTrivialRadical R L ↔ ∀ I : LieIdeal R L, IsLieAbelian I → I = ⊥ := by
+  rw [hasTrivialRadical_iff_no_solvable_ideals]
   constructor <;> intro h₁ I h₂
   · haveI : IsLieAbelian I := h₂; apply h₁; exact LieAlgebra.ofAbelianIsSolvable R I
   · haveI : IsSolvable R I := h₂; rw [← abelian_of_solvable_ideal_eq_bot_iff]; apply h₁
     exact abelian_derivedAbelianOfIdeal I
-#align lie_algebra.is_semisimple_iff_no_abelian_ideals LieAlgebra.isSemisimple_iff_no_abelian_ideals
+#align lie_algebra.is_semisimple_iff_no_abelian_ideals LieAlgebra.hasTrivialRadical_iff_no_abelian_ideals
 
 @[simp]
-theorem center_eq_bot_of_semisimple [h : IsSemisimple R L] : center R L = ⊥ := by
-  rw [isSemisimple_iff_no_abelian_ideals] at h; apply h; infer_instance
+theorem center_eq_bot_of_semisimple [h : HasTrivialRadical R L] : center R L = ⊥ := by
+  rw [hasTrivialRadical_iff_no_abelian_ideals] at h; apply h; infer_instance
 #align lie_algebra.center_eq_bot_of_semisimple LieAlgebra.center_eq_bot_of_semisimple
 
-/-- A simple Lie algebra is semisimple. -/
-instance (priority := 100) isSemisimpleOfIsSimple [h : IsSimple R L] : IsSemisimple R L := by
-  rw [isSemisimple_iff_no_abelian_ideals]
+/-- A simple Lie algebra is has trivial radical. -/
+instance (priority := 100) hasTrivialRadicalOfIsSimple [h : IsSimple R L] : HasTrivialRadical R L := by
+  rw [hasTrivialRadical_iff_no_abelian_ideals]
   intro I hI
   obtain @⟨⟨h₁⟩, h₂⟩ := id h
   by_contra contra
   rw [h₁ I contra, lie_abelian_iff_equiv_lie_abelian LieIdeal.topEquiv] at hI
   exact h₂ hI
-#align lie_algebra.is_semisimple_of_is_simple LieAlgebra.isSemisimpleOfIsSimple
+#align lie_algebra.is_semisimple_of_is_simple LieAlgebra.hasTrivialRadicalOfIsSimple
 
-/-- A semisimple Abelian Lie algebra is trivial. -/
-theorem subsingleton_of_semisimple_lie_abelian [IsSemisimple R L] [h : IsLieAbelian L] :
+/-- An abelian Lie algebra with trivial radical is trivial. -/
+theorem subsingleton_of_hasTrivialRadical_lie_abelian [HasTrivialRadical R L] [h : IsLieAbelian L] :
     Subsingleton L := by
   rw [isLieAbelian_iff_center_eq_top R L, center_eq_bot_of_semisimple] at h
   exact (LieSubmodule.subsingleton_iff R L L).mp (subsingleton_of_bot_eq_top h)
-#align lie_algebra.subsingleton_of_semisimple_lie_abelian LieAlgebra.subsingleton_of_semisimple_lie_abelian
+#align lie_algebra.subsingleton_of_semisimple_lie_abelian LieAlgebra.subsingleton_of_hasTrivialRadical_lie_abelian
 
-theorem abelian_radical_of_semisimple [IsSemisimple R L] : IsLieAbelian (radical R L) := by
-  rw [IsSemisimple.semisimple]; infer_instance
+theorem abelian_radical_of_semisimple [HasTrivialRadical R L] : IsLieAbelian (radical R L) := by
+  rw [HasTrivialRadical.trivial_radical]; infer_instance
 #align lie_algebra.abelian_radical_of_semisimple LieAlgebra.abelian_radical_of_semisimple
 
 /-- The two properties shown to be equivalent here are possible definitions for a Lie algebra
@@ -114,7 +138,7 @@ theorem abelian_radical_iff_solvable_is_abelian [IsNoetherian R L] :
   · intro h; apply h; infer_instance
 #align lie_algebra.abelian_radical_iff_solvable_is_abelian LieAlgebra.abelian_radical_iff_solvable_is_abelian
 
-theorem ad_ker_eq_bot_of_semisimple [IsSemisimple R L] : (ad R L).ker = ⊥ := by simp
+theorem ad_ker_eq_bot_of_semisimple [HasTrivialRadical R L] : (ad R L).ker = ⊥ := by simp
 #align lie_algebra.ad_ker_eq_bot_of_semisimple LieAlgebra.ad_ker_eq_bot_of_semisimple
 
 end LieAlgebra

--- a/Mathlib/Algebra/Lie/Semisimple.lean
+++ b/Mathlib/Algebra/Lie/Semisimple.lean
@@ -35,8 +35,8 @@ universe u v w w₁ w₂
 
 /-- A Lie module is *irreducible* if its only Lie submodules are `⊥` and `⊤`
 (which may coincide). -/
-abbrev LieModule.IsIrreducible (R L M : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]
-  [AddCommGroup M] [Module R M] [LieRingModule L M] : Prop :=
+abbrev LieModule.IsIrreducible (R L M : Type*) [CommRing R] [LieRing L]
+    [AddCommGroup M] [Module R M] [LieRingModule L M] : Prop :=
   IsSimpleOrder (LieSubmodule R L M)
 #align lie_module.is_irreducible LieModule.IsIrreducible
 

--- a/Mathlib/Algebra/Lie/Semisimple.lean
+++ b/Mathlib/Algebra/Lie/Semisimple.lean
@@ -33,12 +33,23 @@ lie algebra, radical, simple, semisimple
 
 universe u v w w₁ w₂
 
-/-- A Lie module is *irreducible* if its only Lie submodules are `⊥` and `⊤`
-(which may coincide). -/
-abbrev LieModule.IsIrreducible (R L M : Type*) [CommRing R] [LieRing L]
-    [AddCommGroup M] [Module R M] [LieRingModule L M] : Prop :=
+section Irreducible
+
+variable (R L M : Type*) [CommRing R] [LieRing L] [AddCommGroup M] [Module R M] [LieRingModule L M]
+
+/-- A nontrivial Lie module is *irreducible* if its only Lie submodules are `⊥` and `⊤`. -/
+abbrev LieModule.IsIrreducible : Prop :=
   IsSimpleOrder (LieSubmodule R L M)
 #align lie_module.is_irreducible LieModule.IsIrreducible
+
+lemma LieModule.nontrivial_of_isIrreducible [LieModule.IsIrreducible R L M] : Nontrivial M where
+  exists_pair_ne := by
+    have aux : (⊥ : LieSubmodule R L M) ≠ ⊤ := bot_ne_top
+    contrapose! aux
+    ext m
+    simpa using aux m 0
+
+end Irreducible
 
 namespace LieAlgebra
 

--- a/Mathlib/Algebra/Lie/Semisimple.lean
+++ b/Mathlib/Algebra/Lie/Semisimple.lean
@@ -20,9 +20,10 @@ and prove some basic related results.
 
   * `LieModule.IsIrreducible`
   * `LieAlgebra.IsSimple`
+  * `LieAlgebra.HasTrivialRadical`
   * `LieAlgebra.IsSemisimple`
-  * `LieAlgebra.isSemisimple_iff_no_solvable_ideals`
-  * `LieAlgebra.isSemisimple_iff_no_abelian_ideals`
+  * `LieAlgebra.hasTrivialRadical_iff_no_solvable_ideals`
+  * `LieAlgebra.hasTrivialRadical_iff_no_abelian_ideals`
   * `LieAlgebra.abelian_radical_iff_solvable_is_abelian`
 
 ## Tags
@@ -37,7 +38,7 @@ universe u v w w₁ w₂
 class LieModule.IsIrreducible (R : Type u) (L : Type v) (M : Type w) [CommRing R] [LieRing L]
     [LieAlgebra R L] [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M] :
     Prop where
-  Irreducible : ∀ N : LieSubmodule R L M, N ≠ ⊥ → N = ⊤
+  irreducible : ∀ N : LieSubmodule R L M, N ≠ ⊥ → N = ⊤
 #align lie_module.is_irreducible LieModule.IsIrreducible
 
 namespace LieAlgebra
@@ -80,9 +81,11 @@ For example [Seligman, page 15](seligman1967) uses the label for `LieAlgebra.Has
 the weakest of the various properties which are all equivalent over a field of characteristic zero.
 -/
 class IsSemisimple : Prop where
-  spanning : ⨆ (I : LieIdeal R L) (_hI : IsAtom I), I = ⊤
+  spanning : sSup {I : LieIdeal R L | IsAtom I} = ⊤
   independent : CompleteLattice.SetIndependent {I : LieIdeal R L | IsAtom I}
-  isSimple_of_isAtom : ∀ I : LieIdeal R L, IsAtom I → IsSimple R I
+  non_abelian_of_isAtom : ∀ I : LieIdeal R L, IsAtom I → ¬ IsLieAbelian I
+
+-- TODO: show that the atomic ideals of a semisimple Lie algebra are simple
 
 theorem hasTrivialRadical_iff_no_solvable_ideals :
     HasTrivialRadical R L ↔ ∀ I : LieIdeal R L, IsSolvable R I → I = ⊥ :=
@@ -99,12 +102,13 @@ theorem hasTrivialRadical_iff_no_abelian_ideals :
 #align lie_algebra.is_semisimple_iff_no_abelian_ideals LieAlgebra.hasTrivialRadical_iff_no_abelian_ideals
 
 @[simp]
-theorem center_eq_bot_of_semisimple [h : HasTrivialRadical R L] : center R L = ⊥ := by
+theorem center_eq_bot_of_hasTrivialRadical [h : HasTrivialRadical R L] : center R L = ⊥ := by
   rw [hasTrivialRadical_iff_no_abelian_ideals] at h; apply h; infer_instance
-#align lie_algebra.center_eq_bot_of_semisimple LieAlgebra.center_eq_bot_of_semisimple
+#align lie_algebra.center_eq_bot_of_semisimple LieAlgebra.center_eq_bot_of_hasTrivialRadical
 
 /-- A simple Lie algebra is has trivial radical. -/
-instance (priority := 100) hasTrivialRadicalOfIsSimple [h : IsSimple R L] : HasTrivialRadical R L := by
+instance (priority := 100) hasTrivialRadicalOfIsSimple [h : IsSimple R L] :
+    HasTrivialRadical R L := by
   rw [hasTrivialRadical_iff_no_abelian_ideals]
   intro I hI
   obtain @⟨⟨h₁⟩, h₂⟩ := id h
@@ -116,13 +120,14 @@ instance (priority := 100) hasTrivialRadicalOfIsSimple [h : IsSimple R L] : HasT
 /-- An abelian Lie algebra with trivial radical is trivial. -/
 theorem subsingleton_of_hasTrivialRadical_lie_abelian [HasTrivialRadical R L] [h : IsLieAbelian L] :
     Subsingleton L := by
-  rw [isLieAbelian_iff_center_eq_top R L, center_eq_bot_of_semisimple] at h
+  rw [isLieAbelian_iff_center_eq_top R L, center_eq_bot_of_hasTrivialRadical] at h
   exact (LieSubmodule.subsingleton_iff R L L).mp (subsingleton_of_bot_eq_top h)
 #align lie_algebra.subsingleton_of_semisimple_lie_abelian LieAlgebra.subsingleton_of_hasTrivialRadical_lie_abelian
 
-theorem abelian_radical_of_semisimple [HasTrivialRadical R L] : IsLieAbelian (radical R L) := by
+theorem abelian_radical_of_hasTrivialRadical [HasTrivialRadical R L] :
+    IsLieAbelian (radical R L) := by
   rw [HasTrivialRadical.trivial_radical]; infer_instance
-#align lie_algebra.abelian_radical_of_semisimple LieAlgebra.abelian_radical_of_semisimple
+#align lie_algebra.abelian_radical_of_semisimple LieAlgebra.abelian_radical_of_hasTrivialRadical
 
 /-- The two properties shown to be equivalent here are possible definitions for a Lie algebra
 to be reductive.
@@ -138,7 +143,7 @@ theorem abelian_radical_iff_solvable_is_abelian [IsNoetherian R L] :
   · intro h; apply h; infer_instance
 #align lie_algebra.abelian_radical_iff_solvable_is_abelian LieAlgebra.abelian_radical_iff_solvable_is_abelian
 
-theorem ad_ker_eq_bot_of_semisimple [HasTrivialRadical R L] : (ad R L).ker = ⊥ := by simp
-#align lie_algebra.ad_ker_eq_bot_of_semisimple LieAlgebra.ad_ker_eq_bot_of_semisimple
+theorem ad_ker_eq_bot_of_hasTrivialRadical [HasTrivialRadical R L] : (ad R L).ker = ⊥ := by simp
+#align lie_algebra.ad_ker_eq_bot_of_semisimple LieAlgebra.ad_ker_eq_bot_of_hasTrivialRadical
 
 end LieAlgebra


### PR DESCRIPTION
This frees up the name `IsSemisimple` so that it can be used for the notion that matches the categorical concept.

In characteristic 0, this is equivalent to having a trivial radical.
In characteristic p > 0, there are counterexamples.

With this change, we depart from the terminology used by Seligman,
but we feel that the change is justified because we need a name for the categorical version of semisimplicity,
and the naming convention proposed in this PR is the "least surprising" one.

This PR also changes the definition of `LieModule.IsIrreducible` to exclude the trivial module.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
