### PR TITLE
[Merged by Bors] - fix: matrix simp-set error

### DIFF
--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -286,7 +286,7 @@ theorem vecMul_empty [Fintype n'] (v : n' → α) (B : Matrix n' (Fin 0) α) : v
 
 @[simp]
 theorem cons_vecMul (x : α) (v : Fin n → α) (B : Fin n.succ → o' → α) :
-    vecCons x v ᵥ* of B = x • vecHead B + v ᵥ* of vecTail B := by
+    vecCons x v ᵥ* of B = x • vecHead B + v ᵥ* of (vecTail B) := by
   ext i
   simp [vecMul]
 #align matrix.cons_vec_mul Matrix.cons_vecMul

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -158,4 +158,11 @@ example {α : Type _} [CommRing α] {a b c d e f g h i : α} :
       Finset.card_singleton, one_smul]
   ring
 
+example {R : Type*} [Semiring R] {a b c d : R} :
+    !![a, b] * (transpose !![c, d]) = !![a * c + b * d] := by
+  ext i j
+  fin_cases i
+  fin_cases j
+  simp [Matrix.vecHead, Matrix.vecTail]
+
 end Matrix


### PR DESCRIPTION
Correct an error in the statement of the lemma `Matrix.cons_vecMul` introduced in #10297 (as can be seen by checking the diff on that PR, cc @madvorak).

Add the example via which I caught this error, as a test case for the matrix simp-set.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
