### PR TITLE
[Merged by Bors] - doc: removed old TODO note about implementing nlinarith

### DIFF
--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -85,9 +85,8 @@ which takes a list of comparisons and the largest variable
 index appearing in those comparisons, and returns a map from comparison indices to coefficients.
 An alternate oracle can be specified in the `LinarithConfig` object.
 
--- TODO Not implemented yet
 A variant, `nlinarith`, adds an extra preprocessing step to handle some basic nonlinear goals.
-There is a hook in the `linarith_config` configuration object to add custom preprocessing routines.
+There is a hook in the `LinarithConfig` configuration object to add custom preprocessing routines.
 
 The certificate checking step is *not* by reflection. `linarith` converts the certificate into a
 proof term of type `False`.


### PR DESCRIPTION
Remove a TODO note about implementing `nlinarith`, it has been done.
Update the name of a variable in the docstring to match its current (not the mathlib3) name.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
