### PR TITLE
feat(NumberTheory/SmoothNumbers): multiplicativity (alternative proof)

### DIFF
--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -103,6 +103,18 @@ lemma mem_factoredNumbers' {s : Finset ℕ} {m : ℕ} :
     _ < 1 + s.sup id := lt_one_add _
     _ ≤ p := hp₁
 
+lemma primeFactors_subset_of_mem_factoredNumbers {s : Finset ℕ} {m : ℕ}
+    (hm : m ∈ factoredNumbers s) :
+    m.primeFactors ⊆ s := by
+  rw [mem_factoredNumbers] at hm
+  exact fun n hn ↦ hm.2 n (mem_primeFactors_iff_mem_factors.mp hn)
+
+lemma mem_factoredNumbers_of_primeFactors_subset {s : Finset ℕ} {m : ℕ} (hm : m ≠ 0)
+    (hp : m.primeFactors ⊆ s) :
+    m ∈ factoredNumbers s := by
+  rw [mem_factoredNumbers]
+  exact ⟨hm, fun p hp' ↦ hp <| mem_primeFactors_iff_mem_factors.mpr hp'⟩
+
 lemma ne_zero_of_mem_factoredNumbers {s : Finset ℕ} {m : ℕ} (h : m ∈ factoredNumbers s) : m ≠ 0 :=
   h.1
 

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -103,17 +103,18 @@ lemma mem_factoredNumbers' {s : Finset ℕ} {m : ℕ} :
     _ < 1 + s.sup id := lt_one_add _
     _ ≤ p := hp₁
 
+/--The prime factors of `m` are a subset of `s` if `m` is `s`-factored. -/
 lemma primeFactors_subset_of_mem_factoredNumbers {s : Finset ℕ} {m : ℕ}
     (hm : m ∈ factoredNumbers s) :
     m.primeFactors ⊆ s := by
   rw [mem_factoredNumbers] at hm
   exact fun n hn ↦ hm.2 n (mem_primeFactors_iff_mem_factors.mp hn)
 
+/-- `m` is `s`-factored if the prime factors of `m` are a subset of `s`. -/
 lemma mem_factoredNumbers_of_primeFactors_subset {s : Finset ℕ} {m : ℕ} (hm : m ≠ 0)
     (hp : m.primeFactors ⊆ s) :
-    m ∈ factoredNumbers s := by
-  rw [mem_factoredNumbers]
-  exact ⟨hm, fun p hp' ↦ hp <| mem_primeFactors_iff_mem_factors.mpr hp'⟩
+    m ∈ factoredNumbers s :=
+  mem_factoredNumbers.mp ⟨hm, fun _ hp' ↦ hp <| mem_primeFactors_iff_mem_factors.mpr hp'⟩
 
 lemma ne_zero_of_mem_factoredNumbers {s : Finset ℕ} {m : ℕ} (h : m ∈ factoredNumbers s) : m ≠ 0 :=
   h.1


### PR DESCRIPTION
Multiplicativity of smooth numbers via same of factored numbers. See #13115 for an alternative approach and for motivation of this PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
