### PR TITLE
Typo: Filter.ofCountableUnion

### DIFF
--- a/Mathlib/Order/Filter/CountableInter.lean
+++ b/Mathlib/Order/Filter/CountableInter.lean
@@ -154,7 +154,7 @@ theorem Filter.mem_ofCountableInter {l : Set (Set α)}
   Iff.rfl
 #align filter.mem_of_countable_Inter Filter.mem_ofCountableInter
 
-/-- Construct a filter with countable intersection property.
+/-- Construct a filter with countable union property.
 Similarly to `Filter.comk`, a set belongs to this filter if its complement satisfies the property.
 Similarly to `Filter.ofCountableInter`,
 this constructor deduces some properties from the countable intersection property


### PR DESCRIPTION
Changed "Construct a filter with countable intersection property" to "Construct a filter with countable union property"

I am not completely sure it is a typo. Maybe the "countable intersection property" refers to the fact that `Filter.ofCountableUnion l ⋯ ⋯ = Filter.ofCountableInter {s | sᶜ ∈ l} ⋯ ⋯`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
