### PR TITLE
[Merged by Bors] - feat: generalize `one_div_mul_add_mul_one_div_eq_one_div_add_one_div`

### DIFF
--- a/Mathlib/Algebra/Field/Basic.lean
+++ b/Mathlib/Algebra/Field/Basic.lean
@@ -48,14 +48,14 @@ theorem div_add_one (h : b ≠ 0) : a / b + 1 = (a + b) / b :=
   (div_add_same h).symm
 #align div_add_one div_add_one
 
-theorem inv_mul_add_mul_inv_eq_inv_add_inv (ha : a ≠ 0) (hb : b ≠ 0) :
-    a⁻¹ * (a + b) * b⁻¹ = a⁻¹ + b⁻¹ :=
-  let _ := invertibleOfNonzero ha; let _ := invertibleOfNonzero hb;
-  invOf_mul_add_mul_invOf_eq_invOf_add_invOf a b
+/-- See `inv_add_inv` for the more convenient version when `K` is commutative. -/
+theorem inv_add_inv' (ha : a ≠ 0) (hb : b ≠ 0) :
+    a⁻¹ + b⁻¹ = a⁻¹ * (a + b) * b⁻¹ :=
+  let _ := invertibleOfNonzero ha; let _ := invertibleOfNonzero hb; invOf_add_invOf a b
 
 theorem one_div_mul_add_mul_one_div_eq_one_div_add_one_div (ha : a ≠ 0) (hb : b ≠ 0) :
     1 / a * (a + b) * (1 / b) = 1 / a + 1 / b := by
-  simpa only [one_div] using inv_mul_add_mul_inv_eq_inv_add_inv ha hb
+  simpa only [one_div] using (inv_add_inv' ha hb).symm
 #align one_div_mul_add_mul_one_div_eq_one_div_add_one_div one_div_mul_add_mul_one_div_eq_one_div_add_one_div
 
 theorem add_div_eq_mul_add_div (a b : α) (hc : c ≠ 0) : a + b / c = (a * c + b) / c :=
@@ -176,14 +176,13 @@ theorem sub_div (a b c : K) : (a - b) / c = a / c - b / c :=
 #align sub_div sub_div
 
 /-- See `inv_sub_inv` for the more convenient version when `K` is commutative. -/
-theorem inv_sub_inv' {a b : K} (ha : a ≠ 0) (hb : b ≠ 0) : a⁻¹ - b⁻¹ = a⁻¹ * (b - a) * b⁻¹ := by
-  rw [mul_sub, sub_mul, mul_inv_cancel_right₀ hb, inv_mul_cancel ha, one_mul]
+theorem inv_sub_inv' {a b : K} (ha : a ≠ 0) (hb : b ≠ 0) : a⁻¹ - b⁻¹ = a⁻¹ * (b - a) * b⁻¹ :=
+  let _ := invertibleOfNonzero ha; let _ := invertibleOfNonzero hb; invOf_sub_invOf a b
 #align inv_sub_inv' inv_sub_inv'
 
 theorem one_div_mul_sub_mul_one_div_eq_one_div_add_one_div (ha : a ≠ 0) (hb : b ≠ 0) :
     1 / a * (b - a) * (1 / b) = 1 / a - 1 / b := by
-  rw [mul_sub_left_distrib (1 / a), one_div_mul_cancel ha, mul_sub_right_distrib, one_mul,
-    mul_assoc, mul_one_div_cancel hb, mul_one]
+  simpa only [one_div] using (inv_sub_inv' ha hb).symm
 #align one_div_mul_sub_mul_one_div_eq_one_div_add_one_div one_div_mul_sub_mul_one_div_eq_one_div_add_one_div
 
 -- see Note [lower instance priority]

--- a/Mathlib/Algebra/Field/Basic.lean
+++ b/Mathlib/Algebra/Field/Basic.lean
@@ -6,6 +6,7 @@ Authors: Robert Lewis, Leonardo de Moura, Johannes Hölzl, Mario Carneiro
 import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.GroupWithZero.Units.Lemmas
 import Mathlib.Algebra.Ring.Commute
+import Mathlib.Algebra.Ring.Invertible
 import Mathlib.Order.Synonym
 
 #align_import algebra.field.basic from "leanprover-community/mathlib"@"05101c3df9d9cfe9430edc205860c79b6d660102"
@@ -47,10 +48,14 @@ theorem div_add_one (h : b ≠ 0) : a / b + 1 = (a + b) / b :=
   (div_add_same h).symm
 #align div_add_one div_add_one
 
+theorem inv_mul_add_mul_inv_eq_inv_add_inv (ha : a ≠ 0) (hb : b ≠ 0) :
+    a⁻¹ * (a + b) * b⁻¹ = a⁻¹ + b⁻¹ :=
+  let _ := invertibleOfNonzero ha; let _ := invertibleOfNonzero hb;
+  invOf_mul_add_mul_invOf_eq_invOf_add_invOf a b
+
 theorem one_div_mul_add_mul_one_div_eq_one_div_add_one_div (ha : a ≠ 0) (hb : b ≠ 0) :
     1 / a * (a + b) * (1 / b) = 1 / a + 1 / b := by
-  rw [mul_add, one_div_mul_cancel ha, add_mul, one_mul, mul_assoc, mul_one_div_cancel hb, mul_one,
-    add_comm]
+  simpa only [one_div] using inv_mul_add_mul_inv_eq_inv_add_inv ha hb
 #align one_div_mul_add_mul_one_div_eq_one_div_add_one_div one_div_mul_add_mul_one_div_eq_one_div_add_one_div
 
 theorem add_div_eq_mul_add_div (a b : α) (hc : c ≠ 0) : a + b / c = (a * c + b) / c :=

--- a/Mathlib/Algebra/Ring/Invertible.lean
+++ b/Mathlib/Algebra/Ring/Invertible.lean
@@ -41,34 +41,33 @@ theorem invOf_two_add_invOf_two [NonAssocSemiring α] [Invertible (2 : α)] :
 theorem pos_of_invertible_cast [Semiring α] [Nontrivial α] (n : ℕ) [Invertible (n : α)] : 0 < n :=
   Nat.zero_lt_of_ne_zero fun h => nonzero_of_invertible (n : α) (h ▸ Nat.cast_zero)
 
-theorem invOf_mul_add_mul_invOf_eq_invOf_add_invOf
-    [Semiring α] (a b : α) [Invertible a] [Invertible b] :
-    ⅟a * (a + b) * ⅟b = ⅟a + ⅟b := by
+theorem invOf_add_invOf [Semiring α] (a b : α) [Invertible a] [Invertible b] :
+    ⅟a + ⅟b = ⅟a * (a + b) * ⅟b:= by
   rw [mul_add, invOf_mul_self, add_mul, one_mul, mul_assoc, mul_invOf_self, mul_one, add_comm]
 
-theorem invOf_mul_sub_mul_invOf_eq_invOf_sub_invOf
-    [Ring α] (a b : α) [Invertible a] [Invertible b] :
-    ⅟a * (a - b) * ⅟b = ⅟b - ⅟a := by
+/-- A version of `inv_sub_inv'` for `invOf`. -/
+theorem invOf_sub_invOf [Ring α] (a b : α) [Invertible a] [Invertible b] :
+    ⅟a - ⅟b = ⅟a * (b - a) * ⅟b := by
   rw [mul_sub, invOf_mul_self, sub_mul, one_mul, mul_assoc, mul_invOf_self, mul_one]
 
-theorem Ring.inverse_mul_add_mul_inverse_eq_inverse_add_inverse
-    [Semiring α] {a b : α} (h : IsUnit a ↔ IsUnit b) :
-    Ring.inverse a * (a + b) * Ring.inverse b = Ring.inverse a + Ring.inverse b := by
+/-- A version of `inv_add_inv'` for `Ring.inverse`. -/
+theorem Ring.inverse_add_inverse [Semiring α] {a b : α} (h : IsUnit a ↔ IsUnit b) :
+    Ring.inverse a + Ring.inverse b = Ring.inverse a * (a + b) * Ring.inverse b := by
   by_cases ha : IsUnit a
   · have hb := h.mp ha
     obtain ⟨ia⟩ := ha.nonempty_invertible
     obtain ⟨ib⟩ := hb.nonempty_invertible
-    simp_rw [inverse_invertible, invOf_mul_add_mul_invOf_eq_invOf_add_invOf]
+    simp_rw [inverse_invertible, invOf_add_invOf]
   · have hb := h.not.mp ha
     simp [inverse_non_unit, ha, hb]
 
-theorem Ring.inverse_mul_sub_mul_inverse_eq_inverse_sub_inverse
-    [Ring α] {a b : α} (h : IsUnit a ↔ IsUnit b) :
-    Ring.inverse a * (a - b) * Ring.inverse b = Ring.inverse b - Ring.inverse a := by
+/-- A version of `inv_sub_inv'` for `Ring.inverse`. -/
+theorem Ring.inverse_sub_inverse [Ring α] {a b : α} (h : IsUnit a ↔ IsUnit b) :
+    Ring.inverse a - Ring.inverse b = Ring.inverse a * (b - a) * Ring.inverse b := by
   by_cases ha : IsUnit a
   · have hb := h.mp ha
     obtain ⟨ia⟩ := ha.nonempty_invertible
     obtain ⟨ib⟩ := hb.nonempty_invertible
-    simp_rw [inverse_invertible, invOf_mul_sub_mul_invOf_eq_invOf_sub_invOf]
+    simp_rw [inverse_invertible, invOf_sub_invOf]
   · have hb := h.not.mp ha
     simp [inverse_non_unit, ha, hb]

--- a/Mathlib/Algebra/Ring/Invertible.lean
+++ b/Mathlib/Algebra/Ring/Invertible.lean
@@ -40,3 +40,19 @@ theorem invOf_two_add_invOf_two [NonAssocSemiring α] [Invertible (2 : α)] :
 
 theorem pos_of_invertible_cast [Semiring α] [Nontrivial α] (n : ℕ) [Invertible (n : α)] : 0 < n :=
   Nat.zero_lt_of_ne_zero fun h => nonzero_of_invertible (n : α) (h ▸ Nat.cast_zero)
+
+theorem invOf_mul_add_mul_invOf_eq_invOf_add_invOf
+    [Semiring α] (a b : α) [Invertible a] [Invertible b] :
+    ⅟a * (a + b) * ⅟b = ⅟a + ⅟b := by
+  rw [mul_add, invOf_mul_self, add_mul, one_mul, mul_assoc, mul_invOf_self, mul_one, add_comm]
+
+theorem Ring.inverse_mul_add_mul_inverse_eq_inverse_add_inverse
+    [Semiring α] {a b : α} (h : IsUnit a ↔ IsUnit b) :
+    Ring.inverse a * (a + b) * Ring.inverse b = Ring.inverse a + Ring.inverse b := by
+  by_cases ha : IsUnit a
+  · have hb := h.mp ha
+    obtain ⟨ia⟩ := ha.nonempty_invertible
+    obtain ⟨ib⟩ := hb.nonempty_invertible
+    simp_rw [inverse_invertible, invOf_mul_add_mul_invOf_eq_invOf_add_invOf]
+  · have hb := h.not.mp ha
+    simp [inverse_non_unit, ha, hb]

--- a/Mathlib/Algebra/Ring/Invertible.lean
+++ b/Mathlib/Algebra/Ring/Invertible.lean
@@ -46,6 +46,11 @@ theorem invOf_mul_add_mul_invOf_eq_invOf_add_invOf
     ⅟a * (a + b) * ⅟b = ⅟a + ⅟b := by
   rw [mul_add, invOf_mul_self, add_mul, one_mul, mul_assoc, mul_invOf_self, mul_one, add_comm]
 
+theorem invOf_mul_sub_mul_invOf_eq_invOf_sub_invOf
+    [Ring α] (a b : α) [Invertible a] [Invertible b] :
+    ⅟a * (a - b) * ⅟b = ⅟b - ⅟a := by
+  rw [mul_sub, invOf_mul_self, sub_mul, one_mul, mul_assoc, mul_invOf_self, mul_one]
+
 theorem Ring.inverse_mul_add_mul_inverse_eq_inverse_add_inverse
     [Semiring α] {a b : α} (h : IsUnit a ↔ IsUnit b) :
     Ring.inverse a * (a + b) * Ring.inverse b = Ring.inverse a + Ring.inverse b := by
@@ -54,5 +59,16 @@ theorem Ring.inverse_mul_add_mul_inverse_eq_inverse_add_inverse
     obtain ⟨ia⟩ := ha.nonempty_invertible
     obtain ⟨ib⟩ := hb.nonempty_invertible
     simp_rw [inverse_invertible, invOf_mul_add_mul_invOf_eq_invOf_add_invOf]
+  · have hb := h.not.mp ha
+    simp [inverse_non_unit, ha, hb]
+
+theorem Ring.inverse_mul_sub_mul_inverse_eq_inverse_sub_inverse
+    [Ring α] {a b : α} (h : IsUnit a ↔ IsUnit b) :
+    Ring.inverse a * (a - b) * Ring.inverse b = Ring.inverse b - Ring.inverse a := by
+  by_cases ha : IsUnit a
+  · have hb := h.mp ha
+    obtain ⟨ia⟩ := ha.nonempty_invertible
+    obtain ⟨ib⟩ := hb.nonempty_invertible
+    simp_rw [inverse_invertible, invOf_mul_sub_mul_invOf_eq_invOf_sub_invOf]
   · have hb := h.not.mp ha
     simp [inverse_non_unit, ha, hb]

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -669,6 +669,16 @@ theorem inv_inv_inv (A : Matrix n n α) : A⁻¹⁻¹⁻¹ = A⁻¹ := by
   · simp [nonsing_inv_apply_not_isUnit _ h]
 #align matrix.inv_inv_inv Matrix.inv_inv_inv
 
+theorem inv_mul_add_mul_inv_eq_inv_add_inv {A B : Matrix n n α} (h : IsUnit A ↔ IsUnit B) :
+    A⁻¹ * (A + B) * B⁻¹ = A⁻¹ + B⁻¹ := by
+  simpa only [nonsing_inv_eq_ring_inverse]
+    using Ring.inverse_mul_add_mul_inverse_eq_inverse_add_inverse h
+
+theorem inv_mul_sub_mul_inv_eq_inv_sub_inv {A B : Matrix n n α} (h : IsUnit A ↔ IsUnit B) :
+    A⁻¹ * (A - B) * B⁻¹ = B⁻¹ - A⁻¹ := by
+  simpa only [nonsing_inv_eq_ring_inverse]
+    using Ring.inverse_mul_sub_mul_inverse_eq_inverse_sub_inverse h
+
 theorem mul_inv_rev (A B : Matrix n n α) : (A * B)⁻¹ = B⁻¹ * A⁻¹ := by
   simp only [inv_def]
   rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul, det_mul, adjugate_mul_distrib,

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -672,12 +672,12 @@ theorem inv_inv_inv (A : Matrix n n α) : A⁻¹⁻¹⁻¹ = A⁻¹ := by
 /-- The `Matrix` version of `inv_add_inv'` -/
 theorem inv_add_inv {A B : Matrix n n α} (h : IsUnit A ↔ IsUnit B) :
     A⁻¹ + B⁻¹ = A⁻¹ * (A + B) * B⁻¹ := by
-  simpa only [nonsing_inv_eq_ring_inverse]
-    using Ring.inverse_mul_add_mul_inverse_eq_inverse_add_inverse h
+  simpa only [nonsing_inv_eq_ring_inverse] using Ring.inverse_add_inverse h
+
+/-- The `Matrix` version of `inv_sub_inv'` -/
 theorem inv_sub_inv {A B : Matrix n n α} (h : IsUnit A ↔ IsUnit B) :
     A⁻¹ - B⁻¹ = A⁻¹ * (B - A) * B⁻¹ := by
-  simpa only [nonsing_inv_eq_ring_inverse]
-    using Ring.inverse_mul_sub_mul_inverse_eq_inverse_sub_inverse h
+  simpa only [nonsing_inv_eq_ring_inverse] using Ring.inverse_sub_inverse h
 
 theorem mul_inv_rev (A B : Matrix n n α) : (A * B)⁻¹ = B⁻¹ * A⁻¹ := by
   simp only [inv_def]

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -669,13 +669,13 @@ theorem inv_inv_inv (A : Matrix n n α) : A⁻¹⁻¹⁻¹ = A⁻¹ := by
   · simp [nonsing_inv_apply_not_isUnit _ h]
 #align matrix.inv_inv_inv Matrix.inv_inv_inv
 
-theorem inv_mul_add_mul_inv_eq_inv_add_inv {A B : Matrix n n α} (h : IsUnit A ↔ IsUnit B) :
-    A⁻¹ * (A + B) * B⁻¹ = A⁻¹ + B⁻¹ := by
+/-- The `Matrix` version of `inv_add_inv'` -/
+theorem inv_add_inv {A B : Matrix n n α} (h : IsUnit A ↔ IsUnit B) :
+    A⁻¹ + B⁻¹ = A⁻¹ * (A + B) * B⁻¹ := by
   simpa only [nonsing_inv_eq_ring_inverse]
     using Ring.inverse_mul_add_mul_inverse_eq_inverse_add_inverse h
-
-theorem inv_mul_sub_mul_inv_eq_inv_sub_inv {A B : Matrix n n α} (h : IsUnit A ↔ IsUnit B) :
-    A⁻¹ * (A - B) * B⁻¹ = B⁻¹ - A⁻¹ := by
+theorem inv_sub_inv {A B : Matrix n n α} (h : IsUnit A ↔ IsUnit B) :
+    A⁻¹ - B⁻¹ = A⁻¹ * (B - A) * B⁻¹ := by
   simpa only [nonsing_inv_eq_ring_inverse]
     using Ring.inverse_mul_sub_mul_inverse_eq_inverse_sub_inverse h
 


### PR DESCRIPTION
This provides a variant that works on invertible elements of semirings, via `invOf` and `Ring.inverse`

This lets this be used on matrices.

The original lemma is from https://github.com/leanprover/lean3/commit/816c315b501481cea4edae1f9eecbd05c554fb61.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
