### PR TITLE
[Merged by Bors] - fix: align Set.empty_def with mathlib3

### DIFF
--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -524,7 +524,7 @@ theorem nonempty_of_nonempty_subtype [Nonempty (↥s)] : s.Nonempty :=
 /-! ### Lemmas about the empty set -/
 
 
-theorem empty_def : (↥(∅ : Set α)) = { _x : α | False } :=
+theorem empty_def : (∅ : Set α) = { _x : α | False } :=
   rfl
 #align set.empty_def Set.empty_def
 


### PR DESCRIPTION
During the port, a coercion to type slipped in where there was none in mathlib3.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

https://github.com/leanprover-community/mathlib4/commit/d6490afd1b91e4aa189bc329400727918476c5cb

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
