### PR TITLE
[Merged by Bors] - chore: TODOs in `Data`

### DIFF
--- a/Mathlib/Data/Finmap.lean
+++ b/Mathlib/Data/Finmap.lean
@@ -398,7 +398,6 @@ def any (f : ∀ x, β x → Bool) (s : Finmap β) : Bool :=
     (fun _ _ _ _ => by simp_rw [Bool.or_assoc, Bool.or_comm, imp_true_iff]) false
 #align finmap.any Finmap.any
 
--- TODO: should this really return `false` if `s` is empty?
 /-- `all f s` returns `true` iff `f v = true` for all values `v` in `s`. -/
 def all (f : ∀ x, β x → Bool) (s : Finmap β) : Bool :=
   s.foldl (fun x y z => x && f y z)

--- a/Mathlib/Data/Rel.lean
+++ b/Mathlib/Data/Rel.lean
@@ -36,7 +36,7 @@ Relations are also known as set-valued functions, or partial multifunctions.
 
 The `Rel.comp` function uses the notation `r • s`, rather than the more common `r ∘ s` for things
 named `comp`. This is because the latter is already used for function composition, and causes a
-clash. A better notation should be found, perhaps a variant of `r ∘r s` or `r ; s`.
+clash. A better notation should be found, perhaps a variant of `r ∘r s` or `r; s`.
 
 -/
 

--- a/Mathlib/Data/Rel.lean
+++ b/Mathlib/Data/Rel.lean
@@ -36,7 +36,7 @@ Relations are also known as set-valued functions, or partial multifunctions.
 
 The `Rel.comp` function uses the notation `r • s`, rather than the more common `r ∘ s` for things
 named `comp`. This is because the latter is already used for function composition, and causes a
-clash.
+clash. A better notation should be found, perhaps a variant of `r ∘r s` or `r ; s`.
 
 -/
 

--- a/Mathlib/Data/Rel.lean
+++ b/Mathlib/Data/Rel.lean
@@ -36,8 +36,7 @@ Relations are also known as set-valued functions, or partial multifunctions.
 
 The `Rel.comp` function uses the notation `r • s`, rather than the more common `r ∘ s` for things
 named `comp`. This is because the latter is already used for function composition, and causes a
-clash. Perhaps a better name/notation for this operation would be `Rel.join` with ⋈ as the symbol,
-by analogy with the natural join in databases.
+clash.
 
 -/
 

--- a/Mathlib/Data/Rel.lean
+++ b/Mathlib/Data/Rel.lean
@@ -31,6 +31,14 @@ Relations are also known as set-valued functions, or partial multifunctions.
   related to `x` are in `s`.
 * `Rel.restrict_domain`: Domain-restriction of a relation to a subtype.
 * `Function.graph`: Graph of a function as a relation.
+
+## TODOs
+
+The `Rel.comp` function uses the notation `r • s`, rather than the more common `r ∘ s` for things
+named `comp`. This is because the latter is already used for function composition, and causes a
+clash. Perhaps a better name/notation for this operation would be `Rel.join` with ⋈ as the symbol,
+by analogy with the natural join in databases.
+
 -/
 
 variable {α β γ : Type*}
@@ -91,7 +99,6 @@ def comp (r : Rel α β) (s : Rel β γ) : Rel α γ := fun x z => ∃ y, r x y 
 #align rel.comp Rel.comp
 
 -- Porting note: the original `∘` syntax can't be overloaded here, lean considers it ambiguous.
--- TODO: Change this syntax to something nicer?
 /-- Local syntax for composition of relations. -/
 local infixr:90 " • " => Rel.comp
 
@@ -407,10 +414,8 @@ theorem Relation.is_graph_iff (r : Rel α β) : (∃! f, Function.graph f = r) �
 
 namespace Set
 
--- TODO: if image were defined with bounded quantification in corelib, the next two would
--- be definitional
 theorem image_eq (f : α → β) (s : Set α) : f '' s = (Function.graph f).image s := by
-  simp [Set.image, Rel.image]
+  rfl
 #align set.image_eq Set.image_eq
 
 theorem preimage_eq (f : α → β) (s : Set β) : f ⁻¹' s = (Function.graph f).preimage s := by

--- a/Mathlib/Data/Tree.lean
+++ b/Mathlib/Data/Tree.lean
@@ -22,6 +22,10 @@ We also specialize for `Tree Unit`, which is a binary tree without any
 additional data. We provide the notation `a △ b` for making a `Tree Unit` with children
 `a` and `b`.
 
+## TODO
+
+Implement a `Traversable` instance for `Tree`.
+
 ## References
 
 <https://leanprover-community.github.io/archive/stream/113488-general/topic/tactic.20question.html>
@@ -87,7 +91,7 @@ def getOrElse (n : PosNum) (t : Tree α) (v : α) : α :=
 #align tree.get_or_else Tree.getOrElse
 
 /-- Apply a function to each value in the tree.  This is the `map` function for the `Tree` functor.
-TODO: implement `Traversable Tree`. -/
+-/
 def map {β} (f : α → β) : Tree α → Tree β
   | nil => nil
   | node a l r => node (f a) (map f l) (map f r)


### PR DESCRIPTION
Handles TODOs in the TLD of `Mathlib/Data`. Some finished ones are removed, and some others are put at the top of the file, so that they can be better seen in potential future good-first-issue issues that reference these.

* Removes TODO about `FinMap.all` returning `false` for empty `FinMap`s, since it should and does return `true`.
* Moved comment about syntax of `Rel.comp` to module docstring.
* Removed TODO comment about `Rel.image` definition with bounded quantification in corelib, since it is now defined that way, and the commented lemma can indeed now be proven with `rfl`, (not so for `preimage`, but I believe the existing definition in terms of `image` has advantages)
* Moved TODO about `Traversible` for Trees to top of file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
