### PR TITLE
[Merged by Bors] - chore: adding missing copyright years

### DIFF
--- a/Mathlib/Algebra/Polynomial/PartialFractions.lean
+++ b/Mathlib/Algebra/Polynomial/PartialFractions.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) Sidharth Hariharan. All rights reserved.
+Copyright (c) 2023 Sidharth Hariharan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard, Sidharth Hariharan
 -/

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) Sébastien Gouëzel. All rights reserved.
+Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/

--- a/Mathlib/Analysis/Complex/OperatorNorm.lean
+++ b/Mathlib/Analysis/Complex/OperatorNorm.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) Sébastien Gouëzel. All rights reserved.
+Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/

--- a/Mathlib/Analysis/Complex/RealDeriv.lean
+++ b/Mathlib/Analysis/Complex/RealDeriv.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) Sébastien Gouëzel. All rights reserved.
+Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Yourong Zang
 -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Equivalence.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) Markus Himmel. All rights reserved.
+Copyright (c) 2022 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/


### PR DESCRIPTION
Five copyright headers were missing a year: add this - so the new style linter can enforce this rule.

---

Each file is in its own commit; the commit messages describes the key reasons why I chose that specific year.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
