### PR TITLE
[Merged by Bors] - style: change the notation for `CategoryTheory.Limits.piObj` from `∏ f` to `∏ᶜ f`

### DIFF
--- a/Mathlib/Algebra/Category/FGModuleCat/Limits.lean
+++ b/Mathlib/Algebra/Category/FGModuleCat/Limits.lean
@@ -40,7 +40,7 @@ variable {J : Type} [SmallCategory J] [FinCategory J]
 variable {k : Type v} [Field k]
 
 instance {J : Type} [Finite J] (Z : J → ModuleCat.{v} k) [∀ j, FiniteDimensional k (Z j)] :
-    FiniteDimensional k (∏ fun j => Z j : ModuleCat.{v} k) :=
+    FiniteDimensional k (∏ᶜ fun j => Z j : ModuleCat.{v} k) :=
   haveI : FiniteDimensional k (ModuleCat.of k (∀ j, Z j)) := by unfold ModuleCat.of; infer_instance
   FiniteDimensional.of_injective (ModuleCat.piIsoPi _).hom
     ((ModuleCat.mono_iff_injective _).1 (by infer_instance))

--- a/Mathlib/Algebra/Category/ModuleCat/Products.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Products.lean
@@ -51,7 +51,7 @@ variable [HasProduct Z]
 /-- The categorical product of a family of objects in `ModuleCat`
 agrees with the usual module-theoretical product.
 -/
-noncomputable def piIsoPi : ∏ Z ≅ ModuleCat.of R (∀ i, Z i) :=
+noncomputable def piIsoPi : ∏ᶜ Z ≅ ModuleCat.of R (∀ i, Z i) :=
   limit.isoLimitCone ⟨_, productConeIsLimit Z⟩
 #align Module.pi_iso_pi ModuleCat.piIsoPi
 

--- a/Mathlib/Algebra/Category/Ring/Constructions.lean
+++ b/Mathlib/Algebra/Category/Ring/Constructions.lean
@@ -237,14 +237,14 @@ def piFanIsLimit : IsLimit (piFan R) where
 /--
 The categorical product and the usual product agrees
 -/
-def piIsoPi : ∏ R ≅ CommRingCat.of ((i : ι) → R i) :=
+def piIsoPi : ∏ᶜ R ≅ CommRingCat.of ((i : ι) → R i) :=
   limit.isoLimitCone ⟨_, piFanIsLimit R⟩
 
 /--
 The categorical product and the usual product agrees
 -/
 def _root_.RingEquiv.piEquivPi (R : ι → Type u) [∀ i, CommRing (R i)] :
-    (∏ (fun i : ι ↦ CommRingCat.of (R i)) : CommRingCat.{u}) ≃+* ((i : ι) → R i) :=
+    (∏ᶜ (fun i : ι ↦ CommRingCat.of (R i)) : CommRingCat.{u}) ≃+* ((i : ι) → R i) :=
   (piIsoPi (CommRingCat.of <| R ·)).commRingCatIsoToRingEquiv
 
 end Pi

--- a/Mathlib/AlgebraicTopology/CechNerve.lean
+++ b/Mathlib/AlgebraicTopology/CechNerve.lean
@@ -348,7 +348,7 @@ end CosimplicialObject
 /-- Given an object `X : C`, the natural simplicial object sending `[n]` to `Xⁿ⁺¹`. -/
 def cechNerveTerminalFrom {C : Type u} [Category.{v} C] [HasFiniteProducts C] (X : C) :
     SimplicialObject C where
-  obj n := ∏ fun _ : Fin (n.unop.len + 1) => X
+  obj n := ∏ᶜ fun _ : Fin (n.unop.len + 1) => X
   map f := Limits.Pi.lift fun i => Limits.Pi.π _ (f.unop.toOrderHom i)
 #align category_theory.cech_nerve_terminal_from CategoryTheory.cechNerveTerminalFrom
 
@@ -371,7 +371,7 @@ variable [HasFiniteProducts C]
 /-- The product `Xᶥ` is the vertex of a limit cone on `wideCospan ι X`. -/
 def wideCospan.limitCone [Finite ι] (X : C) : LimitCone (wideCospan ι X) where
   cone :=
-    { pt := ∏ fun _ : ι => X
+    { pt := ∏ᶜ fun _ : ι => X
       π :=
         { app := fun X => Option.casesOn X (terminal.from _) fun i => limit.π _ ⟨i⟩
           naturality := fun i j f => by
@@ -414,7 +414,7 @@ instance hasLimit_wideCospan [Finite ι] (X : C) : HasLimit (wideCospan ι X) :=
 -- Porting note: added to ease the definition of `iso`
 /-- the isomorphism to the product induced by the limit cone `wideCospan ι X` -/
 def wideCospan.limitIsoPi [Finite ι] (X : C) :
-    limit (wideCospan ι X) ≅ ∏ fun _ : ι => X :=
+    limit (wideCospan ι X) ≅ ∏ᶜ fun _ : ι => X :=
   (IsLimit.conePointUniqueUpToIso (limit.isLimit _)
     (wideCospan.limitCone ι X).2)
 

--- a/Mathlib/CategoryTheory/Adjunction/Evaluation.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Evaluation.lean
@@ -96,7 +96,7 @@ variable [∀ a b : C, HasProductsOfShape (a ⟶ b) D]
 @[simps]
 def evaluationRightAdjoint (c : C) : D ⥤ C ⥤ D where
   obj d :=
-    { obj := fun t => ∏ fun _ : t ⟶ c => d
+    { obj := fun t => ∏ᶜ fun _ : t ⟶ c => d
       map := fun f => Pi.lift fun g => Pi.π _ <| f ≫ g }
   map f :=
     { app := fun t => Pi.lift fun g => Pi.π _ g ≫ f

--- a/Mathlib/CategoryTheory/Category/Grpd.lean
+++ b/Mathlib/CategoryTheory/Category/Grpd.lean
@@ -142,7 +142,7 @@ set_option linter.uppercaseLean3 false in
 
 /-- The product of a family of groupoids is isomorphic
 to the product object in the category of Groupoids -/
-noncomputable def piIsoPi (J : Type u) (f : J → Grpd.{u, u}) : @of (∀ j, f j) _ ≅ ∏ f :=
+noncomputable def piIsoPi (J : Type u) (f : J → Grpd.{u, u}) : @of (∀ j, f j) _ ≅ ∏ᶜ f :=
   Limits.IsLimit.conePointUniqueUpToIso (piLimitFanIsLimit f)
     (Limits.limit.isLimit (Discrete.functor f))
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/CategoryTheory/Galois/Decomposition.lean
+++ b/Mathlib/CategoryTheory/Galois/Decomposition.lean
@@ -174,7 +174,7 @@ If `X` is any object, then its fiber is represented by some Galois object: There
 a Galois object `A` and an element `a` in the fiber of `A` such that the
 evaluation at `a` from `A ⟶ X` to `F.obj X` is bijective.
 
-To show this we consider the product `∏ (fun _ : F.obj X ↦ X)` and let `A`
+To show this we consider the product `∏ᶜ (fun _ : F.obj X ↦ X)` and let `A`
 be the connected component whose fiber contains the element `a` in the fiber of the self product
 that has at each index `x : F.obj X` the element `x`.
 
@@ -192,7 +192,7 @@ variable (X : C)
 
 /-- The self product of `X` indexed by its fiber. -/
 @[simp]
-private noncomputable def selfProd : C := ∏ (fun _ : F.obj X ↦ X)
+private noncomputable def selfProd : C := ∏ᶜ (fun _ : F.obj X ↦ X)
 
 /-- For `g : F.obj X → F.obj X`, this is the element in the fiber of the self product,
 which has at index `x : F.obj X` the element `g x`. -/

--- a/Mathlib/CategoryTheory/Generator.lean
+++ b/Mathlib/CategoryTheory/Generator.lean
@@ -608,7 +608,7 @@ theorem isCoseparator_prod_of_isCoseparator_right (G H : C) [HasBinaryProduct G 
 #align category_theory.is_coseparator_prod_of_is_coseparator_right CategoryTheory.isCoseparator_prod_of_isCoseparator_right
 
 theorem isCoseparator_pi {β : Type w} (f : β → C) [HasProduct f] :
-    IsCoseparator (∏ f) ↔ IsCoseparating (Set.range f) := by
+    IsCoseparator (∏ᶜ f) ↔ IsCoseparating (Set.range f) := by
   refine
     ⟨fun h X Y u v huv => ?_, fun h =>
       (isCoseparator_def _).2 fun X Y u v huv => h _ _ fun Z hZ g => ?_⟩
@@ -619,7 +619,7 @@ theorem isCoseparator_pi {β : Type w} (f : β → C) [HasProduct f] :
 #align category_theory.is_coseparator_pi CategoryTheory.isCoseparator_pi
 
 theorem isCoseparator_pi_of_isCoseparator {β : Type w} (f : β → C) [HasProduct f] (b : β)
-    (hb : IsCoseparator (f b)) : IsCoseparator (∏ f) :=
+    (hb : IsCoseparator (f b)) : IsCoseparator (∏ᶜ f) :=
   (isCoseparator_pi _).2 <| IsCoseparating.mono hb <| by simp
 #align category_theory.is_coseparator_pi_of_is_coseparator CategoryTheory.isCoseparator_pi_of_isCoseparator
 

--- a/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
@@ -120,7 +120,7 @@ theorem hasLimit_of_equalizer_and_product (F : J ⥤ C) [HasLimit (Discrete.func
 
 /-- A limit can be realised as a subobject of a product. -/
 noncomputable def limitSubobjectProduct [HasLimitsOfSize.{w, w} C] (F : J ⥤ C) :
-    limit F ⟶ ∏ fun j => F.obj j :=
+    limit F ⟶ ∏ᶜ fun j => F.obj j :=
   have := hasFiniteLimits_of_hasLimitsOfSize C
   (limit.isoLimitCone (limitConeOfEqualizerAndProduct F)).hom ≫ equalizer.ι _ _
 #align category_theory.limits.limit_subobject_product CategoryTheory.Limits.limitSubobjectProduct
@@ -167,8 +167,8 @@ variable (G : C ⥤ D) [PreservesLimitsOfShape WalkingParallelPair G]
 /-- If a functor preserves equalizers and the appropriate products, it preserves limits. -/
 noncomputable def preservesLimitOfPreservesEqualizersAndProduct : PreservesLimitsOfShape J G where
   preservesLimit {K} := by
-    let P := ∏ K.obj
-    let Q := ∏ fun f : Σp : J × J, p.fst ⟶ p.snd => K.obj f.1.2
+    let P := ∏ᶜ K.obj
+    let Q := ∏ᶜ fun f : Σp : J × J, p.fst ⟶ p.snd => K.obj f.1.2
     let s : P ⟶ Q := Pi.lift fun f => limit.π (Discrete.functor K.obj) ⟨_⟩ ≫ K.map f.2
     let t : P ⟶ Q := Pi.lift fun f => limit.π (Discrete.functor K.obj) ⟨f.1.2⟩
     let I := equalizer s t

--- a/Mathlib/CategoryTheory/Limits/Constructions/WeaklyInitial.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/WeaklyInitial.lean
@@ -35,7 +35,7 @@ object.
 -/
 theorem has_weakly_initial_of_weakly_initial_set_and_hasProducts [HasProducts.{v} C] {ι : Type v}
     {B : ι → C} (hB : ∀ A : C, ∃ i, Nonempty (B i ⟶ A)) : ∃ T : C, ∀ X, Nonempty (T ⟶ X) :=
-  ⟨∏ B, fun X => ⟨Pi.π _ _ ≫ (hB X).choose_spec.some⟩⟩
+  ⟨∏ᶜ B, fun X => ⟨Pi.π _ _ ≫ (hB X).choose_spec.some⟩⟩
 #align category_theory.has_weakly_initial_of_weakly_initial_set_and_has_products CategoryTheory.has_weakly_initial_of_weakly_initial_set_and_hasProducts
 
 /-- If `C` has (small) wide equalizers and a weakly initial object, then it has an initial object.

--- a/Mathlib/CategoryTheory/Limits/Lattice.lean
+++ b/Mathlib/CategoryTheory/Limits/Lattice.lean
@@ -83,7 +83,7 @@ theorem finite_colimit_eq_finset_univ_sup [SemilatticeSup α] [OrderBot α] (F :
 A finite product in the category of a `SemilatticeInf` with `OrderTop` is the same as the infimum.
 -/
 theorem finite_product_eq_finset_inf [SemilatticeInf α] [OrderTop α] {ι : Type u} [Fintype ι]
-    (f : ι → α) : ∏ f = Fintype.elems.inf f := by
+    (f : ι → α) : ∏ᶜ f = Fintype.elems.inf f := by
   trans
   · exact
       (IsLimit.conePointUniqueUpToIso (limit.isLimit _)

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -396,7 +396,7 @@ The canonical isomorphism from the opposite of the coproduct to the product in t
 category.
 -/
 def opCoproductIsoProduct :
-    op (∐ Z) ≅ ∏ (op <| Z ·) :=
+    op (∐ Z) ≅ ∏ᶜ (op <| Z ·) :=
   opCoproductIsoProduct' (coproductIsCoproduct Z) (productIsProduct (op <| Z ·))
 
 theorem opCoproductIsoProduct'_inv_comp_inj {c : Cofan Z} {f : Fan (op <| Z ·)}
@@ -487,7 +487,7 @@ The canonical isomorphism from the opposite of the product to the coproduct in t
 category.
 -/
 def opProductIsoCoproduct :
-    op (∏ Z) ≅ ∐ (op <| Z ·) :=
+    op (∏ᶜ Z) ≅ ∐ (op <| Z ·) :=
   opProductIsoCoproduct' (productIsProduct Z) (coproductIsCoproduct (op <| Z ·))
 
 theorem proj_comp_opProductIsoCoproduct'_hom {f : Fan Z} {c : Cofan (op <| Z ·)}

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Products.lean
@@ -90,7 +90,7 @@ variable [PreservesLimit (Discrete.functor f) G]
 If `G` preserves limits, we have an isomorphism from the image of a product to the product of the
 images.
 -/
-def PreservesProduct.iso : G.obj (∏ f) ≅ ∏ fun j => G.obj (f j) :=
+def PreservesProduct.iso : G.obj (∏ᶜ f) ≅ ∏ᶜ fun j => G.obj (f j) :=
   IsLimit.conePointUniqueUpToIso (isLimitOfHasProductOfPreservesLimit G f) (limit.isLimit _)
 #align category_theory.limits.preserves_product.iso CategoryTheory.Limits.PreservesProduct.iso
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -583,7 +583,7 @@ theorem biproduct.hom_ext' {f : J → C} [HasBiproduct f] {Z : C} (g h : ⨁ f �
 #align category_theory.limits.biproduct.hom_ext' CategoryTheory.Limits.biproduct.hom_ext'
 
 /-- The canonical isomorphism between the chosen biproduct and the chosen product. -/
-def biproduct.isoProduct (f : J → C) [HasBiproduct f] : ⨁ f ≅ ∏ f :=
+def biproduct.isoProduct (f : J → C) [HasBiproduct f] : ⨁ f ≅ ∏ᶜ f :=
   IsLimit.conePointUniqueUpToIso (biproduct.isLimit f) (limit.isLimit _)
 #align category_theory.limits.biproduct.iso_product CategoryTheory.Limits.biproduct.isoProduct
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -18,7 +18,7 @@ the preservation of products and pullbacks in order to describe these limits in 
 concrete category `C`.
 
 If `F : J → C` is a family of objects in `C`, we define a bijection
-`Limits.Concrete.productEquiv F : (forget C).obj (∏ F) ≃ ∀ j, F j`.
+`Limits.Concrete.productEquiv F : (forget C).obj (∏ᶜ F) ≃ ∀ j, F j`.
 
 Similarly, if `f₁ : X₁ ⟶ S` and `f₂ : X₂ ⟶ S` are two morphisms, the elements
 in `pullback f₁ f₂` are identified by `Limits.Concrete.pullbackEquiv`
@@ -44,13 +44,13 @@ section ProductEquiv
 variable [ConcreteCategory.{max w v} C] {J : Type w} (F : J → C)
   [HasProduct F] [PreservesLimit (Discrete.functor F) (forget C)]
 
-/-- The equivalence `(forget C).obj (∏ F) ≃ ∀ j, F j` if `F : J → C` is a family of objects
+/-- The equivalence `(forget C).obj (∏ᶜ F) ≃ ∀ j, F j` if `F : J → C` is a family of objects
 in a concrete category `C`. -/
-noncomputable def productEquiv : (forget C).obj (∏ F) ≃ ∀ j, F j :=
+noncomputable def productEquiv : (forget C).obj (∏ᶜ F) ≃ ∀ j, F j :=
   ((PreservesProduct.iso (forget C) F) ≪≫ (Types.productIso.{w, v} (fun j => F j))).toEquiv
 
 @[simp]
-lemma productEquiv_apply_apply (x : (forget C).obj (∏ F)) (j : J) :
+lemma productEquiv_apply_apply (x : (forget C).obj (∏ᶜ F)) (j : J) :
     productEquiv F x j = Pi.π F j x :=
   congr_fun (piComparison_comp_π (forget C) F j) x
 
@@ -70,7 +70,7 @@ variable {J : Type w} (f : J → C) [HasProduct f] {D : Type t} [Category.{r} D]
   [PreservesLimitsOfShape WalkingCospan (forget D)]
   [PreservesLimit (Discrete.functor fun b ↦ F.toPrefunctor.obj (f b)) (forget D)]
 
-lemma Pi.map_ext (x y : F.obj (∏ f : C))
+lemma Pi.map_ext (x y : F.obj (∏ᶜ f : C))
     (h : ∀ i, F.map (Pi.π f i) x = F.map (Pi.π f i) y) : x = y := by
   apply ConcreteCategory.injective_of_mono_of_preservesPullback (PreservesProduct.iso F f).hom
   apply @Concrete.limit_ext.{w, r, t} D

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteProducts.lean
@@ -51,7 +51,7 @@ instance hasLimitsOfShape_discrete [HasFiniteProducts C] (ι : Type w) [Finite �
 
 /-- We can now write this for powers. -/
 noncomputable example [HasFiniteProducts C] (X : C) : C :=
-  ∏ fun _ : Fin 5 => X
+  ∏ᶜ fun _ : Fin 5 => X
 
 /-- If a category has all products then in particular it has finite products.
 -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -213,13 +213,13 @@ theorem multicospan_map_snd (b) : I.multicospan.map (WalkingMulticospan.Hom.snd 
 
 variable [HasProduct I.left] [HasProduct I.right]
 
-/-- The induced map `∏ I.left ⟶ ∏ I.right` via `I.fst`. -/
-noncomputable def fstPiMap : ∏ I.left ⟶ ∏ I.right :=
+/-- The induced map `∏ᶜ I.left ⟶ ∏ᶜ I.right` via `I.fst`. -/
+noncomputable def fstPiMap : ∏ᶜ I.left ⟶ ∏ᶜ I.right :=
   Pi.lift fun b => Pi.π I.left (I.fstTo b) ≫ I.fst b
 #align category_theory.limits.multicospan_index.fst_pi_map CategoryTheory.Limits.MulticospanIndex.fstPiMap
 
-/-- The induced map `∏ I.left ⟶ ∏ I.right` via `I.snd`. -/
-noncomputable def sndPiMap : ∏ I.left ⟶ ∏ I.right :=
+/-- The induced map `∏ᶜ I.left ⟶ ∏ᶜ I.right` via `I.snd`. -/
+noncomputable def sndPiMap : ∏ᶜ I.left ⟶ ∏ᶜ I.right :=
   Pi.lift fun b => Pi.π I.left (I.sndTo b) ≫ I.snd b
 #align category_theory.limits.multicospan_index.snd_pi_map CategoryTheory.Limits.MulticospanIndex.sndPiMap
 
@@ -234,7 +234,7 @@ theorem sndPiMap_π (b) : I.sndPiMap ≫ Pi.π I.right b = Pi.π I.left _ ≫ I.
 #align category_theory.limits.multicospan_index.snd_pi_map_π CategoryTheory.Limits.MulticospanIndex.sndPiMap_π
 
 /-- Taking the multiequalizer over the multicospan index is equivalent to taking the equalizer over
-the two morphsims `∏ I.left ⇉ ∏ I.right`. This is the diagram of the latter.
+the two morphsims `∏ᶜ I.left ⇉ ∏ᶜ I.right`. This is the diagram of the latter.
 -/
 @[simps!]
 protected noncomputable def parallelPairDiagram :=
@@ -417,7 +417,7 @@ theorem pi_condition : Pi.lift K.ι ≫ I.fstPiMap = Pi.lift K.ι ≫ I.sndPiMap
   simp
 #align category_theory.limits.multifork.pi_condition CategoryTheory.Limits.Multifork.pi_condition
 
-/-- Given a multifork, we may obtain a fork over `∏ I.left ⇉ ∏ I.right`. -/
+/-- Given a multifork, we may obtain a fork over `∏ᶜ I.left ⇉ ∏ᶜ I.right`. -/
 @[simps pt]
 noncomputable def toPiFork (K : Multifork I) : Fork I.fstPiMap I.sndPiMap where
   pt := K.pt
@@ -445,7 +445,7 @@ theorem toPiFork_π_app_one : K.toPiFork.π.app WalkingParallelPair.one = Pi.lif
 
 variable (I)
 
-/-- Given a fork over `∏ I.left ⇉ ∏ I.right`, we may obtain a multifork. -/
+/-- Given a fork over `∏ᶜ I.left ⇉ ∏ᶜ I.right`, we may obtain a multifork. -/
 @[simps pt]
 noncomputable def ofPiFork (c : Fork I.fstPiMap I.sndPiMap) : Multifork I where
   pt := c.pt
@@ -508,7 +508,7 @@ noncomputable def ofPiForkFunctor : Fork I.fstPiMap I.sndPiMap ⥤ Multifork I w
       w := by rintro (_ | _) <;> simp }
 #align category_theory.limits.multicospan_index.of_pi_fork_functor CategoryTheory.Limits.MulticospanIndex.ofPiForkFunctor
 
-/-- The category of multiforks is equivalent to the category of forks over `∏ I.left ⇉ ∏ I.right`.
+/-- The category of multiforks is equivalent to the category of forks over `∏ᶜ I.left ⇉ ∏ᶜ I.right`.
 It then follows from `CategoryTheory.IsLimit.ofPreservesConeTerminal` (or `reflects`) that it
 preserves and reflects limit cones.
 -/
@@ -813,14 +813,14 @@ variable [HasProduct I.left] [HasProduct I.right]
 instance : HasEqualizer I.fstPiMap I.sndPiMap :=
   ⟨⟨⟨_, IsLimit.ofPreservesConeTerminal I.multiforkEquivPiFork.functor (limit.isLimit _)⟩⟩⟩
 
-/-- The multiequalizer is isomorphic to the equalizer of `∏ I.left ⇉ ∏ I.right`. -/
+/-- The multiequalizer is isomorphic to the equalizer of `∏ᶜ I.left ⇉ ∏ᶜ I.right`. -/
 def isoEqualizer : multiequalizer I ≅ equalizer I.fstPiMap I.sndPiMap :=
   limit.isoLimitCone
     ⟨_, IsLimit.ofPreservesConeTerminal I.multiforkEquivPiFork.inverse (limit.isLimit _)⟩
 #align category_theory.limits.multiequalizer.iso_equalizer CategoryTheory.Limits.Multiequalizer.isoEqualizer
 
-/-- The canonical injection `multiequalizer I ⟶ ∏ I.left`. -/
-def ιPi : multiequalizer I ⟶ ∏ I.left :=
+/-- The canonical injection `multiequalizer I ⟶ ∏ᶜ I.left`. -/
+def ιPi : multiequalizer I ⟶ ∏ᶜ I.left :=
   (isoEqualizer I).hom ≫ equalizer.ι I.fstPiMap I.sndPiMap
 #align category_theory.limits.multiequalizer.ι_pi CategoryTheory.Limits.Multiequalizer.ιPi
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -234,7 +234,7 @@ theorem sndPiMap_π (b) : I.sndPiMap ≫ Pi.π I.right b = Pi.π I.left _ ≫ I.
 #align category_theory.limits.multicospan_index.snd_pi_map_π CategoryTheory.Limits.MulticospanIndex.sndPiMap_π
 
 /-- Taking the multiequalizer over the multicospan index is equivalent to taking the equalizer over
-the two morphsims `∏ᶜ I.left ⇉ ∏ᶜ I.right`. This is the diagram of the latter.
+the two morphisms `∏ᶜ I.left ⇉ ∏ᶜ I.right`. This is the diagram of the latter.
 -/
 @[simps!]
 protected noncomputable def parallelPairDiagram :=

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -183,14 +183,14 @@ abbrev sigmaObj (f : β → C) [HasCoproduct f] :=
   colimit (Discrete.functor f)
 #align category_theory.limits.sigma_obj CategoryTheory.Limits.sigmaObj
 
-/-- notation for categorical products -/
-notation "∏ " f:60 => piObj f
+/-- notation for categorical products. We need `ᶜ` to avoid conflict between `Finset.prod`. -/
+notation "∏ᶜ " f:60 => piObj f
 
 /-- notation for categorical coproducts -/
 notation "∐ " f:60 => sigmaObj f
 
-/-- The `b`-th projection from the pi object over `f` has the form `∏ f ⟶ f b`. -/
-abbrev Pi.π (f : β → C) [HasProduct f] (b : β) : ∏ f ⟶ f b :=
+/-- The `b`-th projection from the pi object over `f` has the form `∏ᶜ f ⟶ f b`. -/
+abbrev Pi.π (f : β → C) [HasProduct f] (b : β) : ∏ᶜ f ⟶ f b :=
   limit.π (Discrete.functor f) (Discrete.mk b)
 #align category_theory.limits.pi.π CategoryTheory.Limits.Pi.π
 
@@ -203,7 +203,7 @@ abbrev Sigma.ι (f : β → C) [HasCoproduct f] (b : β) : f b ⟶ ∐ f :=
 -- `limit.hom_ext` would be applied, but the goal would involve terms
 -- in `Discrete β` rather than `β` itself
 @[ext 1050]
-lemma Pi.hom_ext {f : β → C} [HasProduct f] {X : C} (g₁ g₂ : X ⟶ ∏ f)
+lemma Pi.hom_ext {f : β → C} [HasProduct f] {X : C} (g₁ g₂ : X ⟶ ∏ᶜ f)
     (h : ∀ (b : β), g₁ ≫ Pi.π f b = g₂ ≫ Pi.π f b) : g₁ = g₂ :=
   limit.hom_ext (fun ⟨j⟩ => h j)
 
@@ -240,8 +240,8 @@ theorem Sigma.eqToHom_comp_ι {J : Type*} (f : J → C) [HasCoproduct f] {j j' :
   cases w
   simp
 
-/-- A collection of morphisms `P ⟶ f b` induces a morphism `P ⟶ ∏ f`. -/
-abbrev Pi.lift {f : β → C} [HasProduct f] {P : C} (p : ∀ b, P ⟶ f b) : P ⟶ ∏ f :=
+/-- A collection of morphisms `P ⟶ f b` induces a morphism `P ⟶ ∏ᶜ f`. -/
+abbrev Pi.lift {f : β → C} [HasProduct f] {P : C} (p : ∀ b, P ⟶ f b) : P ⟶ ∏ᶜ f :=
   limit.lift _ (Fan.mk P p)
 #align category_theory.limits.pi.lift CategoryTheory.Limits.Pi.lift
 
@@ -278,12 +278,12 @@ def Cofan.isColimitOfIsIsoSigmaDesc {f : β → C} [HasCoproduct f] (c : Cofan f
 /-- Construct a morphism between categorical products (indexed by the same type)
 from a family of morphisms between the factors.
 -/
-abbrev Pi.map {f g : β → C} [HasProduct f] [HasProduct g] (p : ∀ b, f b ⟶ g b) : ∏ f ⟶ ∏ g :=
+abbrev Pi.map {f g : β → C} [HasProduct f] [HasProduct g] (p : ∀ b, f b ⟶ g b) : ∏ᶜ f ⟶ ∏ᶜ g :=
   limMap (Discrete.natTrans fun X => p X.as)
 #align category_theory.limits.pi.map CategoryTheory.Limits.Pi.map
 
 @[simp]
-lemma Pi.map_id {f : α → C} [HasProduct f] : Pi.map (fun a => 𝟙 (f a)) = 𝟙 (∏ f) := by
+lemma Pi.map_id {f : α → C} [HasProduct f] : Pi.map (fun a => 𝟙 (f a)) = 𝟙 (∏ᶜ f) := by
   ext; simp
 
 lemma Pi.map_comp_map {f g h : α → C} [HasProduct f] [HasProduct g] [HasProduct h]
@@ -300,7 +300,7 @@ instance Pi.map_mono {f g : β → C} [HasProduct f] [HasProduct g] (p : ∀ b, 
 /-- Construct a morphism between categorical products from a family of morphisms between the
     factors. -/
 def Pi.map' {f : α → C} {g : β → C} [HasProduct f] [HasProduct g] (p : β → α)
-    (q : ∀ (b : β), f (p b) ⟶ g b) : ∏ f ⟶ ∏ g :=
+    (q : ∀ (b : β), f (p b) ⟶ g b) : ∏ᶜ f ⟶ ∏ᶜ g :=
   Pi.lift (fun a => Pi.π _ _ ≫ q a)
 
 @[reassoc (attr := simp)]
@@ -308,7 +308,7 @@ lemma Pi.map'_comp_π {f : α → C} {g : β → C} [HasProduct f] [HasProduct g
     (q : ∀ (b : β), f (p b) ⟶ g b) (b : β) : Pi.map' p q ≫ Pi.π g b = Pi.π f (p b) ≫ q b :=
   limit.lift_π _ _
 
-lemma Pi.map'_id_id {f : α → C} [HasProduct f] : Pi.map' id (fun a => 𝟙 (f a)) = 𝟙 (∏ f) := by
+lemma Pi.map'_id_id {f : α → C} [HasProduct f] : Pi.map' id (fun a => 𝟙 (f a)) = 𝟙 (∏ᶜ f) := by
   ext; simp
 
 @[simp]
@@ -340,7 +340,7 @@ lemma Pi.map'_eq {f : α → C} {g : β → C} [HasProduct f] [HasProduct g] {p 
 /-- Construct an isomorphism between categorical products (indexed by the same type)
 from a family of isomorphisms between the factors.
 -/
-abbrev Pi.mapIso {f g : β → C} [HasProductsOfShape β C] (p : ∀ b, f b ≅ g b) : ∏ f ≅ ∏ g :=
+abbrev Pi.mapIso {f g : β → C} [HasProductsOfShape β C] (p : ∀ b, f b ≅ g b) : ∏ᶜ f ≅ ∏ᶜ g :=
   lim.mapIso (Discrete.natIso fun X => p X.as)
 #align category_theory.limits.pi.map_iso CategoryTheory.Limits.Pi.mapIso
 
@@ -352,10 +352,10 @@ section
 variable (X : Discrete α ⥤ C) [HasProduct (fun j => X.obj (Discrete.mk j))]
 
 /-- A limit cone for `X : Discrete α ⥤ C` that is given
-by `∏ (fun j => X.obj (Discrete.mk j))`. -/
+by `∏ᶜ (fun j => X.obj (Discrete.mk j))`. -/
 @[simps]
 def Pi.cone : Cone X where
-  pt := ∏ (fun j => X.obj (Discrete.mk j))
+  pt := ∏ᶜ (fun j => X.obj (Discrete.mk j))
   π := Discrete.natTrans (fun _ => Pi.π _ _)
 
 /-- The cone `Pi.cone X` is a limit cone. -/
@@ -371,9 +371,9 @@ def productIsProduct' :
 
 variable [HasLimit X]
 
-/-- The isomorphism `∏ (fun j => X.obj (Discrete.mk j)) ≅ limit X`. -/
+/-- The isomorphism `∏ᶜ (fun j => X.obj (Discrete.mk j)) ≅ limit X`. -/
 def Pi.isoLimit :
-    ∏ (fun j => X.obj (Discrete.mk j)) ≅ limit X :=
+    ∏ᶜ (fun j => X.obj (Discrete.mk j)) ≅ limit X :=
   IsLimit.conePointUniqueUpToIso (productIsProduct' X) (limit.isLimit X)
 
 @[reassoc (attr := simp)]
@@ -391,7 +391,8 @@ end
 /-- Construct a morphism between categorical coproducts (indexed by the same type)
 from a family of morphisms between the factors.
 -/
-abbrev Sigma.map {f g : β → C} [HasCoproduct f] [HasCoproduct g] (p : ∀ b, f b ⟶ g b) : ∐ f ⟶ ∐ g :=
+abbrev Sigma.map {f g : β → C} [HasCoproduct f] [HasCoproduct g] (p : ∀ b, f b ⟶ g b) :
+    ∐ f ⟶ ∐ g :=
   colimMap (Discrete.natTrans fun X => p X.as)
 #align category_theory.limits.sigma.map CategoryTheory.Limits.Sigma.map
 
@@ -465,7 +466,7 @@ and up to isomorphism in the factors, are isomorphic.
 -/
 @[simps]
 def Pi.whiskerEquiv {J K : Type*} {f : J → C} {g : K → C} (e : J ≃ K) (w : ∀ j, g (e j) ≅ f j)
-    [HasProduct f] [HasProduct g] : ∏ f ≅ ∏ g where
+    [HasProduct f] [HasProduct g] : ∏ᶜ f ≅ ∏ᶜ g where
   hom := Pi.map' e.symm fun k => (w (e.symm k)).inv ≫ eqToHom (by simp)
   inv := Pi.map' e fun j => (w j).hom
 
@@ -479,10 +480,10 @@ def Sigma.whiskerEquiv {J K : Type*} {f : J → C} {g : K → C} (e : J ≃ K) (
   inv := Sigma.map' e.symm fun k => eqToHom (by simp) ≫ (w (e.symm k)).hom
 
 instance {ι : Type*} (f : ι → Type*) (g : (i : ι) → (f i) → C)
-    [∀ i, HasProduct (g i)] [HasProduct fun i => ∏ g i] :
+    [∀ i, HasProduct (g i)] [HasProduct fun i => ∏ᶜ g i] :
     HasProduct fun p : Σ i, f i => g p.1 p.2 where
   exists_limit := Nonempty.intro
-    { cone := Fan.mk (∏ fun i => ∏ g i) (fun X => Pi.π (fun i => ∏ g i) X.1 ≫ Pi.π (g X.1) X.2)
+    { cone := Fan.mk (∏ᶜ fun i => ∏ᶜ g i) (fun X => Pi.π (fun i => ∏ᶜ g i) X.1 ≫ Pi.π (g X.1) X.2)
       isLimit := mkFanLimit _ (fun s => Pi.lift fun b => Pi.lift fun c => s.proj ⟨b, c⟩)
         -- Adaptation note: nightly-2024-04-01
         -- Both of these proofs were previously by `aesop_cat`.
@@ -491,8 +492,8 @@ instance {ι : Type*} (f : ι → Type*) (g : (i : ι) → (f i) → C)
 /-- An iterated product is a product over a sigma type. -/
 @[simps]
 def piPiIso {ι : Type*} (f : ι → Type*) (g : (i : ι) → (f i) → C)
-    [∀ i, HasProduct (g i)] [HasProduct fun i => ∏ g i] :
-    (∏ fun i => ∏ g i) ≅ (∏ fun p : Σ i, f i => g p.1 p.2) where
+    [∀ i, HasProduct (g i)] [HasProduct fun i => ∏ᶜ g i] :
+    (∏ᶜ fun i => ∏ᶜ g i) ≅ (∏ᶜ fun p : Σ i, f i => g p.1 p.2) where
   hom := Pi.lift fun ⟨i, x⟩ => Pi.π _ i ≫ Pi.π _ x
   inv := Pi.lift fun i => Pi.lift fun x => Pi.π _ (⟨i, x⟩ : Σ i, f i)
 
@@ -524,7 +525,7 @@ variable (f : β → C)
 /-- The comparison morphism for the product of `f`. This is an iso iff `G` preserves the product
 of `f`, see `PreservesProduct.ofIsoComparison`. -/
 def piComparison [HasProduct f] [HasProduct fun b => G.obj (f b)] :
-    G.obj (∏ f) ⟶ ∏ fun b => G.obj (f b) :=
+    G.obj (∏ᶜ f) ⟶ ∏ᶜ fun b => G.obj (f b) :=
   Pi.lift fun b => G.map (Pi.π f b)
 #align category_theory.limits.pi_comparison CategoryTheory.Limits.piComparison
 
@@ -633,7 +634,7 @@ instance (priority := 100) hasProduct_unique : HasProduct f :=
 
 /-- A product over an index type with exactly one term is just the object over that term. -/
 @[simps!]
-def productUniqueIso : ∏ f ≅ f default :=
+def productUniqueIso : ∏ᶜ f ≅ f default :=
   IsLimit.conePointUniqueUpToIso (limit.isLimit _) (limitConeOfUnique f).isLimit
 #align category_theory.limits.product_unique_iso CategoryTheory.Limits.productUniqueIso
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -183,7 +183,7 @@ abbrev sigmaObj (f : β → C) [HasCoproduct f] :=
   colimit (Discrete.functor f)
 #align category_theory.limits.sigma_obj CategoryTheory.Limits.sigmaObj
 
-/-- notation for categorical products. We need `ᶜ` to avoid conflict between `Finset.prod`. -/
+/-- notation for categorical products. We need `ᶜ` to avoid conflict with `Finset.prod`. -/
 notation "∏ᶜ " f:60 => piObj f
 
 /-- notation for categorical coproducts -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
@@ -73,14 +73,14 @@ theorem pi_lift_π_apply' {β : Type v} (f : β → Type v) {P : Type v}
 @[simp 1001]
 theorem pi_map_π_apply {β : Type v} [Small.{u} β] {f g : β → Type u}
     (α : ∀ j, f j ⟶ g j) (b : β) (x) :
-    (Pi.π g b : ∏ g → g b) (Pi.map α x) = α b ((Pi.π f b : ∏ f → f b) x) :=
+    (Pi.π g b : ∏ᶜ g → g b) (Pi.map α x) = α b ((Pi.π f b : ∏ᶜ f → f b) x) :=
   Limit.map_π_apply.{v, u} _ _ _
 #align category_theory.limits.types.pi_map_π_apply CategoryTheory.Limits.Types.pi_map_π_apply
 
 /-- A restatement of `Types.Limit.map_π_apply` that uses `Pi.π` and `Pi.map`,
 with specialized universes. -/
 theorem pi_map_π_apply' {β : Type v} {f g : β → Type v} (α : ∀ j, f j ⟶ g j) (b : β) (x) :
-    (Pi.π g b : ∏ g → g b) (Pi.map α x) = α b ((Pi.π f b : ∏ f → f b) x) := by
+    (Pi.π g b : ∏ᶜ g → g b) (Pi.map α x) = α b ((Pi.π f b : ∏ᶜ f → f b) x) := by
   simp
 #align category_theory.limits.types.pi_map_π_apply' CategoryTheory.Limits.Types.pi_map_π_apply'
 
@@ -381,7 +381,7 @@ def productLimitCone {J : Type v} (F : J → TypeMax.{v, u}) :
 #align category_theory.limits.types.product_limit_cone CategoryTheory.Limits.Types.productLimitCone
 
 /-- The categorical product in `TypeMax.{v, u}` is the type theoretic product `Π j, F j`. -/
-noncomputable def productIso {J : Type v} (F : J → TypeMax.{v, u}) : ∏ F ≅ ∀ j, F j :=
+noncomputable def productIso {J : Type v} (F : J → TypeMax.{v, u}) : ∏ᶜ F ≅ ∀ j, F j :=
   limit.isoLimitCone (productLimitCone.{v, u} F)
 #align category_theory.limits.types.product_iso CategoryTheory.Limits.Types.productIso
 
@@ -426,7 +426,7 @@ noncomputable def productLimitCone :
 /-- The categorical product in `Type u` indexed in `Type v`
 is the type theoretic product `Π j, F j`, after shrinking back to `Type u`. -/
 noncomputable def productIso :
-    (∏ F : Type u) ≅ Shrink.{u} (∀ j, F j) :=
+    (∏ᶜ F : Type u) ≅ Shrink.{u} (∀ j, F j) :=
   limit.isoLimitCone (productLimitCone.{v, u} F)
 
 @[simp]

--- a/Mathlib/CategoryTheory/Limits/SmallComplete.lean
+++ b/Mathlib/CategoryTheory/Limits/SmallComplete.lean
@@ -53,7 +53,7 @@ instance (priority := 100) : Quiver.IsThin C := fun X Y =>
       let md := ΣZ W : C, Z ⟶ W
       let α := #md
       apply not_le_of_lt (Cardinal.cantor α)
-      let yp : C := ∏ fun _ : md => Y
+      let yp : C := ∏ᶜ fun _ : md => Y
       refine' _root_.trans _ _
       · exact #(X ⟶ yp)
       · apply le_trans (Cardinal.power_le_power_right z)

--- a/Mathlib/CategoryTheory/Preadditive/Injective.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Injective.lean
@@ -140,7 +140,7 @@ instance {P Q : C} [HasBinaryProduct P Q] [Injective P] [Injective Q] : Injectiv
     · simp only [prod.lift_fst]
     · simp only [prod.lift_snd]
 
-instance {β : Type v} (c : β → C) [HasProduct c] [∀ b, Injective (c b)] : Injective (∏ c) where
+instance {β : Type v} (c : β → C) [HasProduct c] [∀ b, Injective (c b)] : Injective (∏ᶜ c) where
   factors g f mono := by
     refine' ⟨Pi.lift fun b => factorThru (g ≫ Pi.π c _) f, _⟩
     ext b

--- a/Mathlib/CategoryTheory/Sites/EqualizerSheafCondition.lean
+++ b/Mathlib/CategoryTheory/Sites/EqualizerSheafCondition.lean
@@ -50,7 +50,7 @@ The middle object of the fork diagram given in Equation (3) of [MM92], as well a
 of <https://stacks.math.columbia.edu/tag/00VM>.
 -/
 def FirstObj : Type max v u :=
-  ∏ fun f : ΣY, { f : Y ⟶ X // R f } => P.obj (op f.1)
+  ∏ᶜ fun f : ΣY, { f : Y ⟶ X // R f } => P.obj (op f.1)
 #align category_theory.equalizer.first_obj CategoryTheory.Equalizer.FirstObj
 
 variable {P R}
@@ -100,7 +100,7 @@ namespace Sieve
 to check a family is compatible.
 -/
 def SecondObj : Type max v u :=
-  ∏ fun f : Σ(Y Z : _) (_ : Z ⟶ Y), { f' : Y ⟶ X // S f' } => P.obj (op f.2.1)
+  ∏ᶜ fun f : Σ(Y Z : _) (_ : Z ⟶ Y), { f' : Y ⟶ X // S f' } => P.obj (op f.2.1)
 #align category_theory.equalizer.sieve.second_obj CategoryTheory.Equalizer.Sieve.SecondObj
 
 variable {P S}
@@ -191,7 +191,7 @@ The rightmost object of the fork diagram of https://stacks.math.columbia.edu/tag
 contains the data used to check a family of elements for a presieve is compatible.
 -/
 @[simp] def SecondObj : Type max v u :=
-  ∏ fun fg : (ΣY, { f : Y ⟶ X // R f }) × ΣZ, { g : Z ⟶ X // R g } =>
+  ∏ᶜ fun fg : (ΣY, { f : Y ⟶ X // R f }) × ΣZ, { g : Z ⟶ X // R g } =>
     haveI := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
     P.obj (op (pullback fg.1.2.1 fg.2.2.1))
 #align category_theory.equalizer.presieve.second_obj CategoryTheory.Equalizer.Presieve.SecondObj
@@ -276,7 +276,7 @@ The middle object of the fork diagram of <https://stacks.math.columbia.edu/tag/0
 The difference between this and `Equalizer.FirstObj P (ofArrows X π)` arrises if the family of
 arrows `π` contains duplicates. The `Presieve.ofArrows` doesn't see those.
 -/
-def FirstObj : Type w := ∏ (fun i ↦ P.obj (op (X i)))
+def FirstObj : Type w := ∏ᶜ (fun i ↦ P.obj (op (X i)))
 
 @[ext]
 lemma FirstObj.ext (z₁ z₂ : FirstObj P X) (h : ∀ i, (Pi.π _ i : FirstObj P X ⟶ _) z₁ =
@@ -291,7 +291,7 @@ The difference between this and `Equalizer.Presieve.SecondObj P (ofArrows X π)`
 family of arrows `π` contains duplicates. The `Presieve.ofArrows` doesn't see those.
 -/
 def SecondObj : Type w  :=
-  ∏ (fun (ij : I × I) ↦ P.obj (op (pullback (π ij.1) (π ij.2))))
+  ∏ᶜ (fun (ij : I × I) ↦ P.obj (op (pullback (π ij.1) (π ij.2))))
 
 @[ext]
 lemma SecondObj.ext (z₁ z₂ : SecondObj P X π) (h : ∀ ij, (Pi.π _ ij : SecondObj P X π ⟶ _) z₁ =

--- a/Mathlib/CategoryTheory/Sites/Preserves.lean
+++ b/Mathlib/CategoryTheory/Sites/Preserves.lean
@@ -138,7 +138,7 @@ theorem isSheafFor_of_preservesProduct [PreservesLimit (Discrete.functor (fun x 
   apply_fun F.map ((opCoproductIsoProduct' hc (productIsProduct _)).hom) using injective_of_mono _
   simp only [← FunctorToTypes.map_comp_apply, Iso.op, Category.assoc]
   rw [ht₂ (F.map ((opCoproductIsoProduct' hc (productIsProduct _)).hom) y) (by simp [← hy])]
-  change (𝟙 (F.obj (∏ fun x ↦ op (X x)))) t = _
+  change (𝟙 (F.obj (∏ᶜ fun x ↦ op (X x)))) t = _
   rw [← Functor.map_id]
   refine congrFun ?_ t
   congr

--- a/Mathlib/CategoryTheory/Sites/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheaf.lean
@@ -599,7 +599,7 @@ The middle object of the fork diagram given in Equation (3) of [MM92], as well a
 of <https://stacks.math.columbia.edu/tag/00VM>.
 -/
 def firstObj : A :=
-  ∏ fun f : ΣV, { f : V ⟶ U // R f } => P.obj (op f.1)
+  ∏ᶜ fun f : ΣV, { f : V ⟶ U // R f } => P.obj (op f.1)
 #align category_theory.presheaf.first_obj CategoryTheory.Presheaf.firstObj
 
 /--
@@ -616,7 +616,7 @@ variable [HasPullbacks C]
 contains the data used to check a family of elements for a presieve is compatible.
 -/
 def secondObj : A :=
-  ∏ fun fg : (ΣV, { f : V ⟶ U // R f }) × ΣW, { g : W ⟶ U // R g } =>
+  ∏ᶜ fun fg : (ΣV, { f : V ⟶ U // R f }) × ΣW, { g : W ⟶ U // R g } =>
     P.obj (op (pullback fg.1.2.1 fg.2.2.1))
 #align category_theory.presheaf.second_obj CategoryTheory.Presheaf.secondObj
 

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -62,7 +62,7 @@ def piFanIsLimit {ι : Type v} (α : ι → TopCat.{max v u}) : IsLimit (piFan �
 /-- The product is homeomorphic to the product of the underlying spaces,
 equipped with the product topology.
 -/
-def piIsoPi {ι : Type v} (α : ι → TopCat.{max v u}) : ∏ α ≅ TopCat.of (∀ i, α i) :=
+def piIsoPi {ι : Type v} (α : ι → TopCat.{max v u}) : ∏ᶜ α ≅ TopCat.of (∀ i, α i) :=
   (limit.isLimit _).conePointUniqueUpToIso (piFanIsLimit.{v, u} α)
   -- Specifying the universes in `piFanIsLimit` wasn't necessary when we had `TopCatMax` 
 #align Top.pi_iso_pi TopCat.piIsoPi
@@ -78,10 +78,10 @@ theorem piIsoPi_inv_π_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : �
   ConcreteCategory.congr_hom (piIsoPi_inv_π α i) x
 #align Top.pi_iso_pi_inv_π_apply TopCat.piIsoPi_inv_π_apply
 
--- Porting note: needing the type ascription on `∏ α : TopCat.{max v u}` is unfortunate.
+-- Porting note: needing the type ascription on `∏ᶜ α : TopCat.{max v u}` is unfortunate.
 @[simp]
 theorem piIsoPi_hom_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι)
-    (x : (∏ α : TopCat.{max v u})) : (piIsoPi α).hom x i = (Pi.π α i : _) x := by
+    (x : (∏ᶜ α : TopCat.{max v u})) : (piIsoPi α).hom x i = (Pi.π α i : _) x := by
   have := piIsoPi_inv_π α i
   rw [Iso.inv_comp_eq] at this
   exact ConcreteCategory.congr_hom this x

--- a/Mathlib/Topology/Sheaves/Sheaf.lean
+++ b/Mathlib/Topology/Sheaves/Sheaf.lean
@@ -53,7 +53,7 @@ The equivalent formulations of the sheaf condition on `presheaf C X` are as foll
   `A : X`, there exists a unique gluing `A ⟶ F(U)` compatible with the restriction.
 
 2. `TopCat.Presheaf.IsSheafEqualizerProducts`: (requires `C` to have all products)
-  For each open cover `{ Uᵢ }` of `U`, `F(U) ⟶ ∏ F(Uᵢ)` is the equalizer of the two morphisms
+  For each open cover `{ Uᵢ }` of `U`, `F(U) ⟶ ∏ᶜ F(Uᵢ)` is the equalizer of the two morphisms
   `∏ F(Uᵢ) ⟶ ∏ F(Uᵢ ∩ Uⱼ)`.
   See `TopCat.Presheaf.isSheaf_iff_isSheafEqualizerProducts`.
 

--- a/Mathlib/Topology/Sheaves/Sheaf.lean
+++ b/Mathlib/Topology/Sheaves/Sheaf.lean
@@ -54,7 +54,7 @@ The equivalent formulations of the sheaf condition on `presheaf C X` are as foll
 
 2. `TopCat.Presheaf.IsSheafEqualizerProducts`: (requires `C` to have all products)
   For each open cover `{ Uᵢ }` of `U`, `F(U) ⟶ ∏ᶜ F(Uᵢ)` is the equalizer of the two morphisms
-  `∏ F(Uᵢ) ⟶ ∏ F(Uᵢ ∩ Uⱼ)`.
+  `∏ᶜ F(Uᵢ) ⟶ ∏ᶜ F(Uᵢ ∩ Uⱼ)`.
   See `TopCat.Presheaf.isSheaf_iff_isSheafEqualizerProducts`.
 
 3. `TopCat.Presheaf.IsSheafOpensLeCover`:

--- a/Mathlib/Topology/Sheaves/SheafCondition/EqualizerProducts.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/EqualizerProducts.lean
@@ -15,7 +15,7 @@ import Mathlib.Topology.Sheaves.SheafCondition.PairwiseIntersections
 Here we set up the machinery for the "usual" definition of the sheaf condition,
 e.g. as in https://stacks.math.columbia.edu/tag/0072
 in terms of an equalizer diagram where the two objects are
-`∏ F.obj (U i)` and `∏ F.obj (U i) ⊓ (U j)`.
+`∏ᶜ F.obj (U i)` and `∏ᶜ F.obj (U i) ⊓ (U j)`.
 
 We show that this sheaf condition is equivalent to the "pairwise intersections" sheaf condition when
 the presheaf is valued in a category with products, and thereby equivalent to the default sheaf
@@ -40,7 +40,7 @@ namespace SheafConditionEqualizerProducts
 
 /-- The product of the sections of a presheaf over a family of open sets. -/
 def piOpens : C :=
-  ∏ fun i : ι => F.obj (op (U i))
+  ∏ᶜ fun i : ι => F.obj (op (U i))
 set_option linter.uppercaseLean3 false in
 #align Top.presheaf.sheaf_condition_equalizer_products.pi_opens TopCat.Presheaf.SheafConditionEqualizerProducts.piOpens
 
@@ -48,7 +48,7 @@ set_option linter.uppercaseLean3 false in
 a family of open sets.
 -/
 def piInters : C :=
-  ∏ fun p : ι × ι => F.obj (op (U p.1 ⊓ U p.2))
+  ∏ᶜ fun p : ι × ι => F.obj (op (U p.1 ⊓ U p.2))
 set_option linter.uppercaseLean3 false in
 #align Top.presheaf.sheaf_condition_equalizer_products.pi_inters TopCat.Presheaf.SheafConditionEqualizerProducts.piInters
 
@@ -203,9 +203,9 @@ set_option linter.uppercaseLean3 false in
 end SheafConditionEqualizerProducts
 
 /-- The sheaf condition for a `F : presheaf C X` requires that the morphism
-`F.obj U ⟶ ∏ F.obj (U i)` (where `U` is some open set which is the union of the `U i`)
+`F.obj U ⟶ ∏ᶜ F.obj (U i)` (where `U` is some open set which is the union of the `U i`)
 is the equalizer of the two morphisms
-`∏ F.obj (U i) ⟶ ∏ F.obj (U i) ⊓ (U j)`.
+`∏ᶜ F.obj (U i) ⟶ ∏ᶜ F.obj (U i) ⊓ (U j)`.
 -/
 def IsSheafEqualizerProducts (F : Presheaf.{v', v, u} C X) : Prop :=
   ∀ ⦃ι : Type v'⦄ (U : ι → Opens X), Nonempty (IsLimit (SheafConditionEqualizerProducts.fork F U))


### PR DESCRIPTION
This notation is conflicting with `∏ x ∈ s, f x`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
