### PR TITLE
[Merged by Bors] - feat(Order/Filter/Basic): eventually_iff_all_subsets and specializations

### DIFF
--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -1672,7 +1672,7 @@ theorem eventuallyEq_iff_sub [AddGroup β] {f g : α → β} {l : Filter α} :
 #align filter.eventually_eq_iff_sub Filter.eventuallyEq_iff_sub
 
 theorem eventuallyEq_iff_all_subsets {f g : α → β} {l : Filter α} :
-    f =ᶠ[l] g ↔ ∀ (s : Set α), ∀ᶠ x in l, x ∈ s → f x = g x :=
+    f =ᶠ[l] g ↔ ∀ s : Set α, ∀ᶠ x in l, x ∈ s → f x = g x :=
   eventually_iff_all_subsets
 
 section LE

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -1280,9 +1280,9 @@ theorem eventually_inf_principal {f : Filter α} {p : α → Prop} {s : Set α} 
 #align filter.eventually_inf_principal Filter.eventually_inf_principal
 
 theorem eventually_iff_all_subsets {f : Filter α} {p : α → Prop} :
-    (∀ᶠ x in f, p x) ↔ ∀ (s : Set α), ∀ᶠ x in f, x ∈ s → p x :=
-  ⟨(fun h _ ↦ by filter_upwards [h] with _ pa _ using pa),
-  (fun h ↦ by filter_upwards [h univ] with _ pa using (pa (by simp)))⟩
+    (∀ᶠ x in f, p x) ↔ ∀ (s : Set α), ∀ᶠ x in f, x ∈ s → p x where
+    mp h _ := by filter_upwards [h] with _ pa _ using pa
+    mpr h := by filter_upwards [h univ] with _ pa using pa (by simp)
 
 /-! ### Frequently -/
 

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -1698,7 +1698,7 @@ theorem eventuallyLE_congr {f f' g g' : α → β} (hf : f =ᶠ[l] f') (hg : g =
 #align filter.eventually_le_congr Filter.eventuallyLE_congr
 
 theorem eventuallyLE_iff_all_subsets {f g : α → β} {l : Filter α} :
-    f ≤ᶠ[l] g ↔ ∀ (s : Set α), ∀ᶠ x in l, x ∈ s → f x ≤ g x :=
+    f ≤ᶠ[l] g ↔ ∀ s : Set α, ∀ᶠ x in l, x ∈ s → f x ≤ g x :=
   eventually_iff_all_subsets
 
 end LE

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -1279,6 +1279,11 @@ theorem eventually_inf_principal {f : Filter α} {p : α → Prop} {s : Set α} 
   mem_inf_principal
 #align filter.eventually_inf_principal Filter.eventually_inf_principal
 
+theorem eventually_iff_all_subsets {f : Filter α} {p : α → Prop} :
+    (∀ᶠ x in f, p x) ↔ ∀ (s : Set α), ∀ᶠ x in f, x ∈ s → p x :=
+  ⟨(fun h _ ↦ by filter_upwards [h] with _ pa _ using pa),
+  (fun h ↦ by filter_upwards [h univ] with _ pa using (pa (by simp)))⟩
+
 /-! ### Frequently -/
 
 /-- `f.Frequently p` or `∃ᶠ x in f, p x` mean that `{x | ¬p x} ∉ f`. E.g., `∃ᶠ x in atTop, p x`
@@ -1666,6 +1671,10 @@ theorem eventuallyEq_iff_sub [AddGroup β] {f g : α → β} {l : Filter α} :
   ⟨fun h => h.sub_eq, fun h => by simpa using h.add (EventuallyEq.refl l g)⟩
 #align filter.eventually_eq_iff_sub Filter.eventuallyEq_iff_sub
 
+theorem eventuallyEq_iff_all_subsets {f g : α → β} {l : Filter α} :
+    f =ᶠ[l] g ↔ ∀ (s : Set α), ∀ᶠ x in l, x ∈ s → f x = g x :=
+  eventually_iff_all_subsets
+
 section LE
 
 variable [LE β] {l : Filter α}
@@ -1687,6 +1696,10 @@ theorem eventuallyLE_congr {f f' g g' : α → β} (hf : f =ᶠ[l] f') (hg : g =
     f ≤ᶠ[l] g ↔ f' ≤ᶠ[l] g' :=
   ⟨fun H => H.congr hf hg, fun H => H.congr hf.symm hg.symm⟩
 #align filter.eventually_le_congr Filter.eventuallyLE_congr
+
+theorem eventuallyLE_iff_all_subsets {f g : α → β} {l : Filter α} :
+    f ≤ᶠ[l] g ↔ ∀ (s : Set α), ∀ᶠ x in l, x ∈ s → f x ≤ g x :=
+  eventually_iff_all_subsets
 
 end LE
 

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -1281,8 +1281,8 @@ theorem eventually_inf_principal {f : Filter α} {p : α → Prop} {s : Set α} 
 
 theorem eventually_iff_all_subsets {f : Filter α} {p : α → Prop} :
     (∀ᶠ x in f, p x) ↔ ∀ (s : Set α), ∀ᶠ x in f, x ∈ s → p x where
-    mp h _ := by filter_upwards [h] with _ pa _ using pa
-    mpr h := by filter_upwards [h univ] with _ pa using pa (by simp)
+  mp h _ := by filter_upwards [h] with _ pa _ using pa
+  mpr h := by filter_upwards [h univ] with _ pa using pa (by simp)
 
 /-! ### Frequently -/
 


### PR DESCRIPTION
The set `{x | p x}` belongs to `f` iff `∀ s, {x | x ∈ s → p x} ∈ f`. Specialization for `EventuallyEq` and `Eventually.LE`.

Suggested by @urkud.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
