### PR TITLE
[Merged by Bors] - chore: Do not import `Module` in `SetTheory.Cardinal.Basic`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -382,6 +382,7 @@ import Mathlib.Algebra.Module.Algebra
 import Mathlib.Algebra.Module.Basic
 import Mathlib.Algebra.Module.BigOperators
 import Mathlib.Algebra.Module.Bimodule
+import Mathlib.Algebra.Module.Card
 import Mathlib.Algebra.Module.CharacterModule
 import Mathlib.Algebra.Module.DedekindDomain
 import Mathlib.Algebra.Module.Defs

--- a/Mathlib/Algebra/Module/Card.lean
+++ b/Mathlib/Algebra/Module/Card.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2023 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+-/
+import Mathlib.Algebra.Module.Defs
+import Mathlib.SetTheory.Cardinal.Basic
+
+/-!
+# Cardinality of a module
+
+This file proves that the cardinality of a module without zero divisors is at least the cardinality
+of its base ring.
+-/
+
+open Function
+
+universe u v
+
+namespace Cardinal
+
+/-- The cardinality of a nontrivial module over a ring is at least the cardinality of the ring if
+there are no zero divisors (for instance if the ring is a field) -/
+theorem mk_le_of_module (R : Type u) (E : Type v)
+    [AddCommGroup E] [Ring R] [Module R E] [Nontrivial E] [NoZeroSMulDivisors R E] :
+    Cardinal.lift.{v} (#R) ≤ Cardinal.lift.{u} (#E) := by
+  obtain ⟨x, hx⟩ : ∃ (x : E), x ≠ 0 := exists_ne 0
+  have : Injective (fun k ↦ k • x) := smul_left_injective R hx
+  exact lift_mk_le_lift_mk_of_injective this
+
+end Cardinal

--- a/Mathlib/Algebra/Ring/Rat.lean
+++ b/Mathlib/Algebra/Ring/Rat.lean
@@ -51,6 +51,7 @@ instance commGroupWithZero : CommGroupWithZero ℚ :=
     zero_mul := zero_mul }
 
 instance isDomain : IsDomain ℚ := NoZeroDivisors.to_isDomain _
+instance instCharZero : CharZero ℚ where cast_injective a b hab := by simpa using congr_arg num hab
 
 /-!
 ### Extra instances to short-circuit type class resolution

--- a/Mathlib/Data/Rat/Denumerable.lean
+++ b/Mathlib/Data/Rat/Denumerable.lean
@@ -3,8 +3,9 @@ Copyright (c) 2019 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import Mathlib.SetTheory.Cardinal.Basic
+import Mathlib.Algebra.Ring.Rat
 import Mathlib.Data.Rat.Order
+import Mathlib.SetTheory.Cardinal.Basic
 
 #align_import data.rat.denumerable from "leanprover-community/mathlib"@"dde670c9a3f503647fd5bfdf1037bad526d3397a"
 
@@ -14,6 +15,8 @@ import Mathlib.Data.Rat.Order
 This file proves that ℚ is infinite, denumerable, and deduces that it has cardinality `omega`.
 -/
 
+assert_not_exists Module
+assert_not_exists Field
 
 namespace Rat
 

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -80,8 +80,8 @@ cardinal number, cardinal arithmetic, cardinal exponentiation, aleph,
 Cantor's theorem, König's theorem, Konig's theorem
 -/
 
-assert_not_exists Module
 assert_not_exists Field
+assert_not_exists Module
 
 open scoped Classical
 open Function Set Order BigOperators

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -3,9 +3,9 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 -/
-import Mathlib.Algebra.Module.Defs
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Data.Finsupp.Defs
+import Mathlib.Data.Nat.Cast.Order
 import Mathlib.Data.Set.Countable
 import Mathlib.Logic.Small.Set
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
@@ -80,6 +80,8 @@ cardinal number, cardinal arithmetic, cardinal exponentiation, aleph,
 Cantor's theorem, König's theorem, Konig's theorem
 -/
 
+assert_not_exists Module
+assert_not_exists Field
 
 open scoped Classical
 open Function Set Order BigOperators
@@ -1798,12 +1800,12 @@ theorem aleph0_mul_nat {n : ℕ} (hn : n ≠ 0) : ℵ₀ * n = ℵ₀ := by rw [
 -- See note [no_index around OfNat.ofNat]
 @[simp]
 theorem ofNat_mul_aleph0 {n : ℕ} [Nat.AtLeastTwo n] : no_index (OfNat.ofNat n) * ℵ₀ = ℵ₀ :=
-  nat_mul_aleph0 (OfNat.ofNat_ne_zero n)
+  nat_mul_aleph0 (NeZero.ne n)
 
 -- See note [no_index around OfNat.ofNat]
 @[simp]
 theorem aleph0_mul_ofNat {n : ℕ} [Nat.AtLeastTwo n] : ℵ₀ * no_index (OfNat.ofNat n) = ℵ₀ :=
-  aleph0_mul_nat (OfNat.ofNat_ne_zero n)
+  aleph0_mul_nat (NeZero.ne n)
 
 @[simp]
 theorem add_le_aleph0 {c₁ c₂ : Cardinal} : c₁ + c₂ ≤ ℵ₀ ↔ c₁ ≤ ℵ₀ ∧ c₂ ≤ ℵ₀ :=
@@ -2333,16 +2335,6 @@ theorem powerlt_zero {a : Cardinal} : a ^< 0 = 0 := by
 #align cardinal.powerlt_zero Cardinal.powerlt_zero
 
 end powerlt
-
-/-- The cardinality of a nontrivial module over a ring is at least the cardinality of the ring if
-there are no zero divisors (for instance if the ring is a field) -/
-theorem mk_le_of_module (R : Type u) (E : Type v)
-    [AddCommGroup E] [Ring R] [Module R E] [Nontrivial E] [NoZeroSMulDivisors R E] :
-    Cardinal.lift.{v} (#R) ≤ Cardinal.lift.{u} (#E) := by
-  obtain ⟨x, hx⟩ : ∃ (x : E), x ≠ 0 := exists_ne 0
-  have : Injective (fun k ↦ k • x) := smul_left_injective R hx
-  exact lift_mk_le_lift_mk_of_injective this
-
 end Cardinal
 
 -- namespace Tactic

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -50,6 +50,8 @@ Some properties of the operations are also used to discuss general tools on ordi
 Various other basic arithmetic results are given in `Principal.lean` instead.
 -/
 
+assert_not_exists Field
+assert_not_exists Module
 
 noncomputable section
 
@@ -849,7 +851,7 @@ theorem mul_isLimit_left {a b : Ordinal} (l : IsLimit a) (b0 : 0 < b) : IsLimit 
 #align ordinal.mul_is_limit_left Ordinal.mul_isLimit_left
 
 theorem smul_eq_mul : ∀ (n : ℕ) (a : Ordinal), n • a = a * n
-  | 0, a => by rw [zero_smul, Nat.cast_zero, mul_zero]
+  | 0, a => by rw [zero_nsmul, Nat.cast_zero, mul_zero]
   | n + 1, a => by rw [succ_nsmul, Nat.cast_add, mul_add, Nat.cast_one, mul_one, smul_eq_mul n]
 #align ordinal.smul_eq_mul Ordinal.smul_eq_mul
 

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -55,6 +55,8 @@ for the empty set by convention.
 * `ω` is a notation for the first infinite ordinal in the locale `Ordinal`.
 -/
 
+assert_not_exists Module
+assert_not_exists Field
 
 noncomputable section
 

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Init.Data.Ordering.Lemmas
 import Mathlib.SetTheory.Ordinal.Principal
+import Mathlib.Tactic.NormNum
 
 #align_import set_theory.ordinal.notation from "leanprover-community/mathlib"@"b67044ba53af18680e1dd246861d9584e968495d"
 

--- a/Mathlib/Topology/Algebra/Module/Cardinality.lean
+++ b/Mathlib/Topology/Algebra/Module/Cardinality.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
+import Mathlib.Algebra.Module.Card
 import Mathlib.SetTheory.Cardinal.CountableCover
 import Mathlib.SetTheory.Cardinal.Continuum
 import Mathlib.Analysis.SpecificLimits.Normed


### PR DESCRIPTION
Move the one result that uses this wild dependency to a new file `Algebra.Module.Card`. Credit Sébastien for #6351.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
