### PR TITLE
copy of chore: Rename more `coe_nat`/`coe_int` to `natCast`/`intCast`

### DIFF
--- a/Archive/Imo/Imo2008Q3.lean
+++ b/Archive/Imo/Imo2008Q3.lean
@@ -42,7 +42,7 @@ theorem p_lemma (p : ℕ) (hpp : Nat.Prime p) (hp_mod_4_eq_1 : p ≡ 1 [MOD 4]) 
   let n := Int.natAbs m
   have hnat₁ : p ∣ n ^ 2 + 1 := by
     refine Int.natCast_dvd_natCast.mp ?_
-    simp only [n, Int.natAbs_sq, Int.coe_nat_pow, Int.ofNat_succ, Int.natCast_dvd_natCast.mp]
+    simp only [n, Int.natAbs_sq, Int.natCast_pow, Int.ofNat_succ, Int.natCast_dvd_natCast.mp]
     refine (ZMod.intCast_zmod_eq_zero_iff_dvd (m ^ 2 + 1) p).mp ?_
     simp only [m, Int.cast_pow, Int.cast_add, Int.cast_one, ZMod.coe_valMinAbs]
     rw [pow_two, ← hy]; exact add_left_neg 1

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -276,14 +276,17 @@ theorem prod_one_sub_ordered [LinearOrder ι] (s : Finset ι) (f : ι → α) :
   simp
 #align finset.prod_one_sub_ordered Finset.prod_one_sub_ordered
 
-theorem prod_range_cast_nat_sub (n k : ℕ) :
+theorem prod_range_natCast_sub (n k : ℕ) :
     ∏ i ∈ range k, (n - i : α) = (∏ i ∈ range k, (n - i) : ℕ) := by
   rw [prod_natCast]
   rcases le_or_lt k n with hkn | hnk
   · exact prod_congr rfl fun i hi => (Nat.cast_sub <| (mem_range.1 hi).le.trans hkn).symm
   · rw [← mem_range] at hnk
     rw [prod_eq_zero hnk, prod_eq_zero hnk] <;> simp
-#align finset.prod_range_cast_nat_sub Finset.prod_range_cast_nat_sub
+#align finset.prod_range_cast_nat_sub Finset.prod_range_natCast_sub
+
+@[deprecated (since := "2024-05-27")] alias prod_range_cast_nat_sub := prod_range_natCast_sub
+
 
 end CommRing
 

--- a/Mathlib/Algebra/Order/Group/Int.lean
+++ b/Mathlib/Algebra/Order/Group/Int.lean
@@ -34,8 +34,10 @@ open Function Nat
 
 namespace Int
 
-theorem coe_nat_strictMono : StrictMono (· : ℕ → ℤ) := fun _ _ ↦ Int.ofNat_lt.2
-#align int.coe_nat_strict_mono Int.coe_nat_strictMono
+theorem natCast_strictMono : StrictMono (· : ℕ → ℤ) := fun _ _ ↦ Int.ofNat_lt.2
+#align int.coe_nat_strict_mono Int.natCast_strictMono
+
+@[deprecated (since := "2024-05-25")] alias coe_nat_strictMono := natCast_strictMono
 
 instance linearOrderedAddCommGroup : LinearOrderedAddCommGroup ℤ where
   __ := instLinearOrder

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -139,10 +139,13 @@ set_option linter.uppercaseLean3 false in
 
 -- these used to be about `algebraMap ℤ R`, but now the simp-normal form is `Int.castRingHom R`.
 @[simp]
-theorem ringHom_eval₂_cast_int_ringHom {R S : Type*} [Ring R] [Ring S] (p : ℤ[X]) (f : R →+* S)
+theorem ringHom_eval₂_intCastRingHom {R S : Type*} [Ring R] [Ring S] (p : ℤ[X]) (f : R →+* S)
     (r : R) : f (eval₂ (Int.castRingHom R) r p) = eval₂ (Int.castRingHom S) (f r) p :=
   algHom_eval₂_algebraMap p f.toIntAlgHom r
-#align polynomial.ring_hom_eval₂_cast_int_ring_hom Polynomial.ringHom_eval₂_cast_int_ringHom
+#align polynomial.ring_hom_eval₂_cast_int_ring_hom Polynomial.ringHom_eval₂_intCastRingHom
+
+@[deprecated (since := "2024-05-27")]
+alias ringHom_eval₂_cast_int_ringHom := ringHom_eval₂_intCastRingHom
 
 @[simp]
 theorem eval₂_intCastRingHom_X {R : Type*} [Ring R] (p : ℤ[X]) (f : ℤ[X] →+* R) :

--- a/Mathlib/Algebra/Polynomial/Eval.lean
+++ b/Mathlib/Algebra/Polynomial/Eval.lean
@@ -1332,8 +1332,10 @@ theorem sub_comp : (p - q).comp r = p.comp r - q.comp r :=
 #align polynomial.sub_comp Polynomial.sub_comp
 
 @[simp]
-theorem cast_int_comp (i : ℤ) : comp (i : R[X]) p = i := by cases i <;> simp
-#align polynomial.cast_int_comp Polynomial.cast_int_comp
+theorem intCast_comp (i : ℤ) : comp (i : R[X]) p = i := by cases i <;> simp
+#align polynomial.cast_int_comp Polynomial.intCast_comp
+
+@[deprecated (since := "2024-05-27")] alias cast_int_comp := intCast_comp
 
 @[simp]
 theorem eval₂_at_intCast {S : Type*} [Ring S] (f : R →+* S) (n : ℤ) :

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Angle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Angle.lean
@@ -104,14 +104,17 @@ theorem coe_zsmul (z : ℤ) (x : ℝ) : ↑(z • x : ℝ) = z • (↑x : Angle
 #align real.angle.coe_zsmul Real.Angle.coe_zsmul
 
 @[simp, norm_cast]
-theorem coe_nat_mul_eq_nsmul (x : ℝ) (n : ℕ) : ↑((n : ℝ) * x) = n • (↑x : Angle) := by
+theorem natCast_mul_eq_nsmul (x : ℝ) (n : ℕ) : ↑((n : ℝ) * x) = n • (↑x : Angle) := by
   simpa only [nsmul_eq_mul] using coeHom.map_nsmul x n
-#align real.angle.coe_nat_mul_eq_nsmul Real.Angle.coe_nat_mul_eq_nsmul
+#align real.angle.coe_nat_mul_eq_nsmul Real.Angle.natCast_mul_eq_nsmul
 
 @[simp, norm_cast]
-theorem coe_int_mul_eq_zsmul (x : ℝ) (n : ℤ) : ↑((n : ℝ) * x : ℝ) = n • (↑x : Angle) := by
+theorem intCast_mul_eq_zsmul (x : ℝ) (n : ℤ) : ↑((n : ℝ) * x : ℝ) = n • (↑x : Angle) := by
   simpa only [zsmul_eq_mul] using coeHom.map_zsmul x n
-#align real.angle.coe_int_mul_eq_zsmul Real.Angle.coe_int_mul_eq_zsmul
+#align real.angle.coe_int_mul_eq_zsmul Real.Angle.intCast_mul_eq_zsmul
+
+@[deprecated (since := "2024-05-25")] alias coe_nat_mul_eq_nsmul := natCast_mul_eq_nsmul
+@[deprecated (since := "2024-05-25")] alias coe_int_mul_eq_zsmul := intCast_mul_eq_zsmul
 
 theorem angle_eq_iff_two_pi_dvd_sub {ψ θ : ℝ} : (θ : Angle) = ψ ↔ ∃ k : ℤ, θ - ψ = 2 * π * k := by
   simp only [QuotientAddGroup.eq, AddSubgroup.zmultiples_eq_closure,
@@ -159,11 +162,11 @@ theorem sub_coe_pi_eq_add_coe_pi (θ : Angle) : θ - π = θ + π := by
 #align real.angle.sub_coe_pi_eq_add_coe_pi Real.Angle.sub_coe_pi_eq_add_coe_pi
 
 @[simp]
-theorem two_nsmul_coe_pi : (2 : ℕ) • (π : Angle) = 0 := by simp [← coe_nat_mul_eq_nsmul]
+theorem two_nsmul_coe_pi : (2 : ℕ) • (π : Angle) = 0 := by simp [← natCast_mul_eq_nsmul]
 #align real.angle.two_nsmul_coe_pi Real.Angle.two_nsmul_coe_pi
 
 @[simp]
-theorem two_zsmul_coe_pi : (2 : ℤ) • (π : Angle) = 0 := by simp [← coe_int_mul_eq_zsmul]
+theorem two_zsmul_coe_pi : (2 : ℤ) • (π : Angle) = 0 := by simp [← intCast_mul_eq_zsmul]
 #align real.angle.two_zsmul_coe_pi Real.Angle.two_zsmul_coe_pi
 
 @[simp]
@@ -246,11 +249,11 @@ theorem cos_eq_iff_coe_eq_or_eq_neg {θ ψ : ℝ} :
     rcases Hcos with (⟨n, hn⟩ | ⟨n, hn⟩)
     · right
       rw [eq_div_iff_mul_eq (two_ne_zero' ℝ), ← sub_eq_iff_eq_add] at hn
-      rw [← hn, coe_sub, eq_neg_iff_add_eq_zero, sub_add_cancel, mul_assoc, coe_int_mul_eq_zsmul,
+      rw [← hn, coe_sub, eq_neg_iff_add_eq_zero, sub_add_cancel, mul_assoc, intCast_mul_eq_zsmul,
         mul_comm, coe_two_pi, zsmul_zero]
     · left
       rw [eq_div_iff_mul_eq (two_ne_zero' ℝ), eq_sub_iff_add_eq] at hn
-      rw [← hn, coe_add, mul_assoc, coe_int_mul_eq_zsmul, mul_comm, coe_two_pi, zsmul_zero,
+      rw [← hn, coe_add, mul_assoc, intCast_mul_eq_zsmul, mul_comm, coe_two_pi, zsmul_zero,
         zero_add]
   · rw [angle_eq_iff_two_pi_dvd_sub, ← coe_neg, angle_eq_iff_two_pi_dvd_sub]
     rintro (⟨k, H⟩ | ⟨k, H⟩)

--- a/Mathlib/Data/Finite/Card.lean
+++ b/Mathlib/Data/Finite/Card.lean
@@ -192,12 +192,15 @@ end Finite
 
 namespace PartENat
 
-theorem card_eq_coe_nat_card (α : Type*) [Finite α] : card α = Nat.card α := by
+theorem card_eq_coe_natCard (α : Type*) [Finite α] : card α = Nat.card α := by
   unfold PartENat.card
   apply symm
   rw [Cardinal.natCast_eq_toPartENat_iff]
   exact Finite.cast_card_eq_mk
-#align part_enat.card_of_finite PartENat.card_eq_coe_nat_card
+#align part_enat.card_of_finite PartENat.card_eq_coe_natCard
+
+
+@[deprecated (since := "2024-05-25")] alias card_eq_coe_nat_card := card_eq_coe_natCard
 
 end PartENat
 

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -205,9 +205,11 @@ theorem cast_natAbs : (n.natAbs : α) = |n| := by
 
 end LinearOrderedRing
 
-theorem coe_int_dvd [CommRing α] (m n : ℤ) (h : m ∣ n) : (m : α) ∣ (n : α) :=
+theorem cast_dvd_cast [CommRing α] (m n : ℤ) (h : m ∣ n) : (m : α) ∣ (n : α) :=
   RingHom.map_dvd (Int.castRingHom α) h
-#align int.coe_int_dvd Int.coe_int_dvd
+#align int.cast_dvd Int.cast_dvd_cast
+
+@[deprecated (since := "2024-05-25")] alias coe_int_dvd := cast_dvd_cast
 
 end cast
 
@@ -218,17 +220,21 @@ open Int
 namespace SemiconjBy
 variable [Ring α] {a x y : α}
 
-@[simp] lemma cast_int_mul_right (h : SemiconjBy a x y) (n : ℤ) : SemiconjBy a (n * x) (n * y) :=
+@[simp] lemma intCast_mul_right (h : SemiconjBy a x y) (n : ℤ) : SemiconjBy a (n * x) (n * y) :=
   SemiconjBy.mul_right (Int.commute_cast _ _) h
-#align semiconj_by.cast_int_mul_right SemiconjBy.cast_int_mul_right
+#align semiconj_by.cast_int_mul_right SemiconjBy.intCast_mul_right
 
-@[simp] lemma cast_int_mul_left (h : SemiconjBy a x y) (n : ℤ) : SemiconjBy (n * a) x y :=
+@[simp] lemma intCast_mul_left (h : SemiconjBy a x y) (n : ℤ) : SemiconjBy (n * a) x y :=
   SemiconjBy.mul_left (Int.cast_commute _ _) h
-#align semiconj_by.cast_int_mul_left SemiconjBy.cast_int_mul_left
+#align semiconj_by.cast_int_mul_left SemiconjBy.intCast_mul_left
 
-@[simp] lemma cast_int_mul_cast_int_mul (h : SemiconjBy a x y) (m n : ℤ) :
-    SemiconjBy (m * a) (n * x) (n * y) := (h.cast_int_mul_left m).cast_int_mul_right n
-#align semiconj_by.cast_int_mul_cast_int_mul SemiconjBy.cast_int_mul_cast_int_mul
+@[simp] lemma intCast_mul_intCast_mul (h : SemiconjBy a x y) (m n : ℤ) :
+    SemiconjBy (m * a) (n * x) (n * y) := (h.intCast_mul_left m).intCast_mul_right n
+#align semiconj_by.cast_int_mul_cast_int_mul SemiconjBy.intCast_mul_intCast_mul
+
+@[deprecated (since := "2024-05-27")] alias cast_int_mul_right := intCast_mul_right
+@[deprecated (since := "2024-05-27")] alias cast_int_mul_left := intCast_mul_left
+@[deprecated (since := "2024-05-27")] alias cast_int_mul_cast_int_mul := intCast_mul_intCast_mul
 
 end SemiconjBy
 
@@ -236,27 +242,31 @@ namespace Commute
 section NonAssocRing
 variable [NonAssocRing α] {a b : α} {n : ℤ}
 
-@[simp] lemma cast_int_left : Commute (n : α) a := Int.cast_commute _ _
-#align commute.cast_int_left Commute.cast_int_left
+@[simp] lemma intCast_left : Commute (n : α) a := Int.cast_commute _ _
+#align commute.cast_int_left Commute.intCast_left
 
-@[simp] lemma cast_int_right : Commute a n := Int.commute_cast _ _
-#align commute.cast_int_right Commute.cast_int_right
+@[simp] lemma intCast_right : Commute a n := Int.commute_cast _ _
+#align commute.cast_int_right Commute.intCast_right
+
+@[deprecated (since := "2024-05-27")] alias cast_int_right := intCast_right
+@[deprecated (since := "2024-05-27")] alias cast_int_left := intCast_left
+
 end NonAssocRing
 
 section Ring
 variable [Ring α] {a b : α} {n : ℤ}
 
-@[simp] lemma cast_int_mul_right (h : Commute a b) (m : ℤ) : Commute a (m * b) :=
-  SemiconjBy.cast_int_mul_right h m
-#align commute.cast_int_mul_right Commute.cast_int_mul_right
+@[simp] lemma intCast_mul_right (h : Commute a b) (m : ℤ) : Commute a (m * b) :=
+  SemiconjBy.intCast_mul_right h m
+#align commute.cast_int_mul_right Commute.intCast_mul_right
 
-@[simp] lemma cast_int_mul_left (h : Commute a b) (m : ℤ) : Commute (m  * a) b :=
-  SemiconjBy.cast_int_mul_left h m
-#align commute.cast_int_mul_left Commute.cast_int_mul_left
+@[simp] lemma intCast_mul_left (h : Commute a b) (m : ℤ) : Commute (m  * a) b :=
+  SemiconjBy.intCast_mul_left h m
+#align commute.cast_int_mul_left Commute.intCast_mul_left
 
-lemma cast_int_mul_cast_int_mul (h : Commute a b) (m n : ℤ) : Commute (m * a) (n * b) :=
-  SemiconjBy.cast_int_mul_cast_int_mul h m n
-#align commute.cast_int_mul_cast_int_mul Commute.cast_int_mul_cast_int_mul
+lemma intCast_mul_intCast_mul (h : Commute a b) (m n : ℤ) : Commute (m * a) (n * b) :=
+  SemiconjBy.intCast_mul_intCast_mul h m n
+#align commute.cast_int_mul_cast_int_mul Commute.intCast_mul_intCast_mul
 
 variable (a) (m n : ℤ)
 
@@ -265,20 +275,28 @@ simp can prove this:
   by simp only [Commute.cast_int_right, Commute.refl, Commute.mul_right]
 -/
 -- @[simp]
-lemma self_cast_int_mul : Commute a (n * a : α) := (Commute.refl a).cast_int_mul_right n
-#align commute.self_cast_int_mul Commute.self_cast_int_mul
+lemma self_intCast_mul : Commute a (n * a : α) := (Commute.refl a).intCast_mul_right n
+#align commute.self_cast_int_mul Commute.self_intCast_mul
 
 /- Porting note (#10618): `simp` attribute removed as linter reports:
 simp can prove this:
   by simp only [Commute.cast_int_left, Commute.refl, Commute.mul_left]
 -/
 -- @[simp]
-lemma cast_int_mul_self : Commute ((n : α) * a) a := (Commute.refl a).cast_int_mul_left n
-#align commute.cast_int_mul_self Commute.cast_int_mul_self
+lemma intCast_mul_self : Commute ((n : α) * a) a := (Commute.refl a).cast_int_mul_left n
+#align commute.cast_int_mul_self Commute.intCast_mul_self
 
-lemma self_cast_int_mul_cast_int_mul : Commute (m * a : α) (n * a : α) :=
+lemma self_intCast_mul_intCast_mul : Commute (m * a : α) (n * a : α) :=
   (Commute.refl a).cast_int_mul_cast_int_mul m n
-#align commute.self_cast_int_mul_cast_int_mul Commute.self_cast_int_mul_cast_int_mul
+#align commute.self_cast_int_mul_cast_int_mul Commute.self_intCast_mul_intCast_mul
+
+@[deprecated (since := "2024-05-27")] alias cast_int_mul_right := intCast_mul_right
+@[deprecated (since := "2024-05-27")] alias cast_int_mul_left := intCast_mul_left
+@[deprecated (since := "2024-05-27")] alias cast_int_mul_cast_int_mul := intCast_mul_intCast_mul
+@[deprecated (since := "2024-05-27")] alias self_cast_int_mul := self_intCast_mul
+@[deprecated (since := "2024-05-27")] alias cast_int_mul_self := intCast_mul_self
+@[deprecated (since := "2024-05-27")]
+alias self_cast_int_mul_cast_int_mul := self_intCast_mul_intCast_mul
 
 end Ring
 end Commute

--- a/Mathlib/Data/Int/Defs.lean
+++ b/Mathlib/Data/Int/Defs.lean
@@ -699,10 +699,10 @@ lemma natMod_lt {n : ℕ} (hn : n ≠ 0) : m.natMod n < n :=
   (toNat_lt' hn).2 <| emod_lt_of_pos _ <| by omega
 #align int.nat_mod_lt Int.natMod_lt
 
--- We want to use this lemma earlier than the lemmas simp can prove it with
-@[simp, nolint simpNF] lemma coe_nat_pow (m n : ℕ) : ↑(m ^ n : ℕ) = (m ^ n : ℤ) := by
-  induction n <;> simp [Int.pow_succ, Nat.pow_succ, Int.pow_zero, *]
-#align int.coe_nat_pow Int.coe_nat_pow
+attribute [simp] natCast_pow
+
+@[deprecated (since := "2024-05-25")] alias coe_nat_pow := natCast_pow
+#align int.coe_nat_pow Int.natCast_pow
 
 #align int.le_to_nat Int.self_le_toNat
 #align int.le_to_nat_iff Int.le_toNat

--- a/Mathlib/Data/Int/GCD.lean
+++ b/Mathlib/Data/Int/GCD.lean
@@ -169,9 +169,10 @@ namespace Int
 
 theorem gcd_def (i j : ℤ) : gcd i j = Nat.gcd i.natAbs j.natAbs := rfl
 
-protected theorem coe_nat_gcd (m n : ℕ) : Int.gcd ↑m ↑n = Nat.gcd m n :=
-  rfl
-#align int.coe_nat_gcd Int.coe_nat_gcd
+@[simp, norm_cast] protected lemma gcd_natCast_natCast (m n : ℕ) : gcd ↑m ↑n = m.gcd n := rfl
+#align int.coe_nat_gcd Int.gcd_natCast_natCast
+
+@[deprecated (since := "2024-05-25")] alias coe_nat_gcd := Int.gcd_natCast_natCast
 
 /-- The extended GCD `a` value in the equation `gcd x y = x * a + y * b`. -/
 def gcdA : ℤ → ℤ → ℤ

--- a/Mathlib/Data/Int/SuccPred.lean
+++ b/Mathlib/Data/Int/SuccPred.lean
@@ -84,13 +84,16 @@ theorem covBy_add_one (z : ℤ) : z ⋖ z + 1 :=
   Int.covBy_iff_succ_eq.mpr rfl
 #align int.covby_add_one Int.covBy_add_one
 
-end Int
-
 @[simp, norm_cast]
-theorem Nat.cast_int_covBy_iff {a b : ℕ} : (a : ℤ) ⋖ b ↔ a ⋖ b := by
+theorem natCast_covBy {a b : ℕ} : (a : ℤ) ⋖ b ↔ a ⋖ b := by
   rw [Nat.covBy_iff_succ_eq, Int.covBy_iff_succ_eq]
   exact Int.natCast_inj
-#align nat.cast_int_covby_iff Nat.cast_int_covBy_iff
+#align nat.cast_int_covby_iff Int.natCast_covBy
 
-alias ⟨_, CovBy.cast_int⟩ := Nat.cast_int_covBy_iff
-#align covby.cast_int CovBy.cast_int
+end Int
+
+alias ⟨_, CovBy.intCast⟩ := Int.natCast_covBy
+#align covby.cast_int CovBy.intCast
+
+@[deprecated (since := "2024-05-27")] alias Nat.cast_int_covBy_iff := Int.natCast_covBy
+@[deprecated (since := "2024-05-27")] alias CovBy.cast_int := CovBy.intCast

--- a/Mathlib/Data/Nat/Cast/Commute.lean
+++ b/Mathlib/Data/Nat/Cast/Commute.lean
@@ -48,55 +48,63 @@ namespace SemiconjBy
 variable [Semiring α] {a x y : α}
 
 @[simp]
-lemma cast_nat_mul_right (h : SemiconjBy a x y) (n : ℕ) : SemiconjBy a (n * x) (n * y) :=
+lemma natCast_mul_right (h : SemiconjBy a x y) (n : ℕ) : SemiconjBy a (n * x) (n * y) :=
   SemiconjBy.mul_right (Nat.commute_cast _ _) h
-#align semiconj_by.cast_nat_mul_right SemiconjBy.cast_nat_mul_right
+#align semiconj_by.cast_nat_mul_right SemiconjBy.natCast_mul_right
 
 @[simp]
-lemma cast_nat_mul_left (h : SemiconjBy a x y) (n : ℕ) : SemiconjBy (n * a) x y :=
+lemma natCast_mul_left (h : SemiconjBy a x y) (n : ℕ) : SemiconjBy (n * a) x y :=
   SemiconjBy.mul_left (Nat.cast_commute _ _) h
-#align semiconj_by.cast_nat_mul_left SemiconjBy.cast_nat_mul_left
+#align semiconj_by.cast_nat_mul_left SemiconjBy.natCast_mul_left
 
 @[simp]
-lemma cast_nat_mul_cast_nat_mul (h : SemiconjBy a x y) (m n : ℕ) :
+lemma natCast_mul_natCast_mul (h : SemiconjBy a x y) (m n : ℕ) :
     SemiconjBy (m * a) (n * x) (n * y) :=
-  (h.cast_nat_mul_left m).cast_nat_mul_right n
-#align semiconj_by.cast_nat_mul_cast_nat_mul SemiconjBy.cast_nat_mul_cast_nat_mul
+  (h.natCast_mul_left m).natCast_mul_right n
+#align semiconj_by.cast_nat_mul_cast_nat_mul SemiconjBy.natCast_mul_natCast_mul
 
 end SemiconjBy
 
 namespace Commute
 variable [Semiring α] {a b : α}
 
-@[simp] lemma cast_nat_mul_right (h : Commute a b) (n : ℕ) : Commute a (n * b) :=
-  SemiconjBy.cast_nat_mul_right h n
-#align commute.cast_nat_mul_right Commute.cast_nat_mul_right
+@[simp] lemma natCast_mul_right (h : Commute a b) (n : ℕ) : Commute a (n * b) :=
+  SemiconjBy.natCast_mul_right h n
+#align commute.cast_nat_mul_right Commute.natCast_mul_right
 
-@[simp] lemma cast_nat_mul_left (h : Commute a b) (n : ℕ) : Commute (n * a) b :=
-  SemiconjBy.cast_nat_mul_left h n
-#align commute.cast_nat_mul_left Commute.cast_nat_mul_left
+@[simp] lemma natCast_mul_left (h : Commute a b) (n : ℕ) : Commute (n * a) b :=
+  SemiconjBy.natCast_mul_left h n
+#align commute.cast_nat_mul_left Commute.natCast_mul_left
 
-@[simp] lemma cast_nat_mul_cast_nat_mul (h : Commute a b) (m n : ℕ) : Commute (m * a) (n * b) :=
-  SemiconjBy.cast_nat_mul_cast_nat_mul h m n
-#align commute.cast_nat_mul_cast_nat_mul Commute.cast_nat_mul_cast_nat_mul
+@[simp] lemma natCast_mul_natCast_mul (h : Commute a b) (m n : ℕ) : Commute (m * a) (n * b) :=
+  SemiconjBy.natCast_mul_natCast_mul h m n
+#align commute.cast_nat_mul_cast_nat_mul Commute.natCast_mul_natCast_mul
 
 variable (a) (m n : ℕ)
 
--- Porting note (#10618): `simp` can prove this using `Commute.refl`, `Commute.cast_nat_mul_right`
+-- Porting note (#10618): `simp` can prove this using `Commute.refl`, `Commute.natCast_mul_right`
 -- @[simp]
-lemma self_cast_nat_mul : Commute a (n * a) := (Commute.refl a).cast_nat_mul_right n
-#align commute.self_cast_nat_mul Commute.self_cast_nat_mul
+lemma self_natCast_mul : Commute a (n * a) := (Commute.refl a).natCast_mul_right n
+#align commute.self_cast_nat_mul Commute.self_natCast_mul
 
--- Porting note (#10618): `simp` can prove this using `Commute.refl`, `Commute.cast_nat_mul_left`
+-- Porting note (#10618): `simp` can prove this using `Commute.refl`, `Commute.natCast_mul_left`
 -- @[simp]
-lemma cast_nat_mul_self : Commute (n * a) a := (Commute.refl a).cast_nat_mul_left n
-#align commute.cast_nat_mul_self Commute.cast_nat_mul_self
+lemma natCast_mul_self : Commute (n * a) a := (Commute.refl a).natCast_mul_left n
+#align commute.cast_nat_mul_self Commute.natCast_mul_self
 
--- Porting note (#10618): `simp` can prove this using `Commute.refl`, `Commute.cast_nat_mul_left`,
--- `Commute.cast_nat_mul_right`
+-- Porting note (#10618): `simp` can prove this using `Commute.refl`, `Commute.natCast_mul_left`,
+-- `Commute.natCast_mul_right`
 -- @[simp]
-lemma self_cast_nat_mul_cast_nat_mul : Commute (m * a) (n * a) :=
-  (Commute.refl a).cast_nat_mul_cast_nat_mul m n
-#align commute.self_cast_nat_mul_cast_nat_mul Commute.self_cast_nat_mul_cast_nat_mul
+lemma self_natCast_mul_natCast_mul : Commute (m * a) (n * a) :=
+  (Commute.refl a).natCast_mul_natCast_mul m n
+#align commute.self_cast_nat_mul_cast_nat_mul Commute.self_natCast_mul_natCast_mul
+
+@[deprecated (since := "2024-05-27")] alias cast_nat_mul_right := natCast_mul_right
+@[deprecated (since := "2024-05-27")] alias cast_nat_mul_left := natCast_mul_left
+@[deprecated (since := "2024-05-27")] alias cast_nat_mul_cast_nat_mul := natCast_mul_natCast_mul
+@[deprecated (since := "2024-05-27")] alias self_cast_nat_mul := self_natCast_mul
+@[deprecated (since := "2024-05-27")] alias cast_nat_mul_self := natCast_mul_self
+@[deprecated (since := "2024-05-27")]
+alias self_cast_nat_mul_cast_nat_mul := self_natCast_mul_natCast_mul
 
 end Commute

--- a/Mathlib/Data/Nat/ModEq.lean
+++ b/Mathlib/Data/Nat/ModEq.lean
@@ -292,7 +292,7 @@ lemma cancel_left_div_gcd (hm : 0 < m) (h : c * a ≡ c * b [MOD m]) :  a ≡ b 
     rw [mul_sub]
     exact modEq_iff_dvd.mp h
   · show Int.gcd (m / d) (c / d) = 1
-    simp only [← Int.natCast_div, Int.coe_nat_gcd (m / d) (c / d), gcd_div hmd hcd,
+    simp only [← Int.natCast_div, Int.gcd_natCast_natCast (m / d) (c / d), gcd_div hmd hcd,
       Nat.div_self (gcd_pos_of_pos_left c hm)]
 #align nat.modeq.cancel_left_div_gcd Nat.ModEq.cancel_left_div_gcd
 

--- a/Mathlib/Data/Real/Irrational.lean
+++ b/Mathlib/Data/Real/Irrational.lean
@@ -58,7 +58,7 @@ theorem irrational_nrt_of_notint_nrt {x : ℝ} (n : ℕ) (m : ℤ) (hxr : x ^ n 
   rw [mk'_eq_divInt, cast_pow, cast_mk, div_pow, div_eq_iff_mul_eq c2, ← Int.cast_pow,
     ← Int.cast_pow, ← Int.cast_mul, Int.cast_inj] at hxr
   have hdivn : (D : ℤ) ^ n ∣ N ^ n := Dvd.intro_left m hxr
-  rw [← Int.dvd_natAbs, ← Int.coe_nat_pow, Int.natCast_dvd_natCast, Int.natAbs_pow,
+  rw [← Int.dvd_natAbs, ← Int.natCast_pow, Int.natCast_dvd_natCast, Int.natAbs_pow,
     Nat.pow_dvd_pow_iff hnpos.ne'] at hdivn
   obtain rfl : D = 1 := by rw [← Nat.gcd_eq_right hdivn, C.gcd_eq_one]
   refine hv ⟨N, ?_⟩

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -484,10 +484,12 @@ lemma ringEquivCongr_val {a b : ℕ} (h : a = b) (x : ZMod a) :
   subst h
   cases a <;> rfl
 
-lemma int_coe_ringEquivCongr {a b : ℕ} (h : a = b) (z : ℤ) :
+lemma ringEquivCongr_intCast {a b : ℕ} (h : a = b) (z : ℤ) :
     ZMod.ringEquivCongr h z = z := by
   subst h
   cases a <;> rfl
+
+@[deprecated (since := "2024-05-25")] alias int_coe_ringEquivCongr := ringEquivCongr_intCast
 
 end CharEq
 
@@ -564,7 +566,7 @@ theorem cast_sub_one {R : Type*} [Ring R] {n : ℕ} (k : ZMod n) :
       · exact hk
 #align zmod.cast_sub_one ZMod.cast_sub_one
 
-theorem nat_coe_zmod_eq_iff (p : ℕ) (n : ℕ) (z : ZMod p) [NeZero p] :
+theorem natCast_eq_iff (p : ℕ) (n : ℕ) (z : ZMod p) [NeZero p] :
     ↑n = z ↔ ∃ k, n = z.val + p * k := by
   constructor
   · rintro rfl
@@ -573,9 +575,9 @@ theorem nat_coe_zmod_eq_iff (p : ℕ) (n : ℕ) (z : ZMod p) [NeZero p] :
   · rintro ⟨k, rfl⟩
     rw [Nat.cast_add, natCast_zmod_val, Nat.cast_mul, natCast_self, zero_mul,
       add_zero]
-#align zmod.nat_coe_zmod_eq_iff ZMod.nat_coe_zmod_eq_iff
+#align zmod.nat_coe_zmod_eq_iff ZMod.natCast_eq_iff
 
-theorem int_coe_zmod_eq_iff (p : ℕ) (n : ℤ) (z : ZMod p) [NeZero p] :
+theorem intCast_eq_iff (p : ℕ) (n : ℤ) (z : ZMod p) [NeZero p] :
     ↑n = z ↔ ∃ k, n = z.val + p * k := by
   constructor
   · rintro rfl
@@ -584,7 +586,10 @@ theorem int_coe_zmod_eq_iff (p : ℕ) (n : ℤ) (z : ZMod p) [NeZero p] :
   · rintro ⟨k, rfl⟩
     rw [Int.cast_add, Int.cast_mul, Int.cast_natCast, Int.cast_natCast, natCast_val,
       ZMod.natCast_self, zero_mul, add_zero, cast_id]
-#align zmod.int_coe_zmod_eq_iff ZMod.int_coe_zmod_eq_iff
+#align zmod.int_coe_zmod_eq_iff ZMod.intCast_eq_iff
+
+@[deprecated (since := "2024-05-25")] alias nat_coe_zmod_eq_iff := natCast_eq_iff
+@[deprecated (since := "2024-05-25")] alias int_coe_zmod_eq_iff := intCast_eq_iff
 
 @[push_cast, simp]
 theorem intCast_mod (a : ℤ) (b : ℕ) : ((a % b : ℤ) : ZMod b) = (a : ZMod b) := by

--- a/Mathlib/Dynamics/Ergodic/AddCircle.lean
+++ b/Mathlib/Dynamics/Ergodic/AddCircle.lean
@@ -111,7 +111,7 @@ theorem ergodic_zsmul {n : ℤ} (hn : 1 < |n|) : Ergodic fun y : AddCircle T => 
           (pow_pos (pos_of_gt hn) j) (gcd_one_left _)
         norm_cast
       have hnu : ∀ j, n ^ j • u j = 0 := fun j => by
-        rw [← addOrderOf_dvd_iff_zsmul_eq_zero, hu₀, Int.coe_nat_pow, Int.natCast_natAbs, ← abs_pow,
+        rw [← addOrderOf_dvd_iff_zsmul_eq_zero, hu₀, Int.natCast_pow, Int.natCast_natAbs, ← abs_pow,
           abs_dvd]
       have hu₁ : ∀ j, (u j +ᵥ s : Set _) =ᵐ[volume] s := fun j => by
         rw [vadd_eq_self_of_preimage_zsmul_eq_self hs' (hnu j)]

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -377,7 +377,7 @@ theorem IsCyclic.unique_zpow_zmod (ha : ∀ x : α, x ∈ zpowers a) (x : α) :
   obtain ⟨n, rfl⟩ := ha x
   refine ⟨n, (?_ : a ^ n = _), fun y (hy : a ^ n = _) ↦ ?_⟩
   · rw [← zpow_natCast, zpow_eq_zpow_iff_modEq, orderOf_eq_card_of_forall_mem_zpowers ha,
-      Int.modEq_comm, Int.modEq_iff_add_fac, ← ZMod.int_coe_zmod_eq_iff]
+      Int.modEq_comm, Int.modEq_iff_add_fac, ← ZMod.intCast_eq_iff]
   · rw [← zpow_natCast, zpow_eq_zpow_iff_modEq, orderOf_eq_card_of_forall_mem_zpowers ha,
       ← ZMod.intCast_eq_intCast_iff] at hy
     simp [hy]

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
@@ -171,7 +171,7 @@ theorem evenOdd_induction (n : ZMod 2) {motive : ∀ x, x ∈ evenOdd Q n → Pr
     (x : CliffordAlgebra Q) (hx : x ∈ evenOdd Q n) : motive x hx := by
   apply Submodule.iSup_induction' (C := motive) _ (range_ι_pow 0 (Submodule.zero_mem _)) add
   refine Subtype.rec ?_
-  simp_rw [ZMod.nat_coe_zmod_eq_iff, add_comm n.val]
+  simp_rw [ZMod.natCast_eq_iff, add_comm n.val]
   rintro n' ⟨k, rfl⟩ xv
   simp_rw [pow_add, pow_mul]
   intro hxv

--- a/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
@@ -362,7 +362,8 @@ theorem div_four_left {a : ℤ} {b : ℕ} (ha4 : a % 4 = 0) (hb2 : b % 2 = 1) :
     J(a / 4 | b) = J(a | b) := by
   obtain ⟨a, rfl⟩ := Int.dvd_of_emod_eq_zero ha4
   have : Int.gcd (2 : ℕ) b = 1 := by
-    rw [Int.coe_nat_gcd, ← b.mod_add_div 2, hb2, Nat.gcd_add_mul_left_right, Nat.gcd_one_right]
+    rw [Int.gcd_natCast_natCast, ← b.mod_add_div 2, hb2, Nat.gcd_add_mul_left_right,
+      Nat.gcd_one_right]
   rw [Int.mul_ediv_cancel_left _ (by decide), jacobiSym.mul_left,
     (by decide : (4 : ℤ) = (2 : ℕ) ^ 2), jacobiSym.sq_one' this, one_mul]
 
@@ -584,7 +585,7 @@ private theorem fastJacobiSymAux.eq_jacobiSym {a b : ℕ} {flip : Bool} {ha0 : a
   split <;> rename_i hba
   · suffices J(a | b) = 0 by simp [this]
     refine eq_zero_iff.mpr ⟨fun h ↦ absurd (h ▸ hb1) (by decide), ?_⟩
-    rwa [Int.coe_nat_gcd, Nat.gcd_eq_left (Nat.dvd_of_mod_eq_zero hba)]
+    rwa [Int.gcd_natCast_natCast, Nat.gcd_eq_left (Nat.dvd_of_mod_eq_zero hba)]
   rw [IH (b % a) (b.mod_lt ha0) (Nat.mod_two_ne_zero.mp ha2) (lt_of_le_of_ne ha0 (Ne.symm ha1))]
   simp only [Int.natCast_mod, ← mod_left]
   rw [← quadratic_reciprocity_if (Nat.mod_two_ne_zero.mp ha2) hb2]

--- a/Mathlib/NumberTheory/Liouville/Basic.lean
+++ b/Mathlib/NumberTheory/Liouville/Basic.lean
@@ -63,12 +63,12 @@ protected theorem irrational {x : ℝ} (h : Liouville x) : Irrational x := by
   -- least one away from zero.  The gain here is what gets the proof going.
   have ap : 0 < |a * ↑q - ↑b * p| := abs_pos.mpr a0
   -- Actually, the absolute value of an integer is a natural number
+  -- FIXME: This `lift` call duplicates the hypotheses `a1` and `ap`
   lift |a * ↑q - ↑b * p| to ℕ using abs_nonneg (a * ↑q - ↑b * p) with e he
-  -- At a1, revert to natural numbers
-  rw [← Int.ofNat_mul, ← Int.coe_nat_pow, ← Int.ofNat_mul, Int.ofNat_lt] at a1
+  norm_cast at a1 ap q1
   -- Recall this is by contradiction: we obtained the inequality `b * q ≤ x * q ^ (b + 1)`, so
   -- we are done.
-  exact not_le.mpr a1 (Nat.mul_lt_mul_pow_succ (Int.natCast_pos.mp ap) (Int.ofNat_lt.mp q1)).le
+  exact not_le.mpr a1 (Nat.mul_lt_mul_pow_succ ap q1).le
 #align liouville.irrational Liouville.irrational
 
 open Polynomial Metric Set Real RingHom

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -157,13 +157,15 @@ theorem sZMod_eq_s (p' : ℕ) (i : ℕ) : sZMod (p' + 2) i = (s i : ZMod (2 ^ (p
 #align lucas_lehmer.s_zmod_eq_s LucasLehmer.sZMod_eq_s
 
 -- These next two don't make good `norm_cast` lemmas.
-theorem Int.coe_nat_pow_pred (b p : ℕ) (w : 0 < b) : ((b ^ p - 1 : ℕ) : ℤ) = (b : ℤ) ^ p - 1 := by
+theorem Int.natCast_pow_pred (b p : ℕ) (w : 0 < b) : ((b ^ p - 1 : ℕ) : ℤ) = (b : ℤ) ^ p - 1 := by
   have : 1 ≤ b ^ p := Nat.one_le_pow p b w
   norm_cast
-#align lucas_lehmer.int.coe_nat_pow_pred LucasLehmer.Int.coe_nat_pow_pred
+#align lucas_lehmer.int.coe_nat_pow_pred LucasLehmer.Int.natCast_pow_pred
+
+@[deprecated (since := "2024-05-25")] alias Int.coe_nat_pow_pred := Int.natCast_pow_pred
 
 theorem Int.coe_nat_two_pow_pred (p : ℕ) : ((2 ^ p - 1 : ℕ) : ℤ) = (2 ^ p - 1 : ℤ) :=
-  Int.coe_nat_pow_pred 2 p (by decide)
+  Int.natCast_pow_pred 2 p (by decide)
 #align lucas_lehmer.int.coe_nat_two_pow_pred LucasLehmer.Int.coe_nat_two_pow_pred
 
 theorem sZMod_eq_sMod (p : ℕ) (i : ℕ) : sZMod p i = (sMod p i : ZMod (2 ^ p - 1)) := by
@@ -308,13 +310,13 @@ instance : Monoid (X q) :=
 instance : NatCast (X q) where
     natCast := fun n => ⟨n, 0⟩
 
-@[simp] theorem nat_coe_fst (n : ℕ) : (n : X q).fst = (n : ZMod q) := rfl
+@[simp] theorem fst_natCast (n : ℕ) : (n : X q).fst = (n : ZMod q) := rfl
 set_option linter.uppercaseLean3 false in
-#align lucas_lehmer.X.nat_coe_fst LucasLehmer.X.nat_coe_fst
+#align lucas_lehmer.X.nat_coe_fst LucasLehmer.X.fst_natCast
 
-@[simp] theorem nat_coe_snd (n : ℕ) : (n : X q).snd = (0 : ZMod q) := rfl
+@[simp] theorem snd_natCast (n : ℕ) : (n : X q).snd = (0 : ZMod q) := rfl
 set_option linter.uppercaseLean3 false in
-#align lucas_lehmer.X.nat_coe_snd LucasLehmer.X.nat_coe_snd
+#align lucas_lehmer.X.nat_coe_snd LucasLehmer.X.snd_natCast
 
 -- See note [no_index around OfNat.ofNat]
 @[simp] theorem ofNat_fst (n : ℕ) [n.AtLeastTwo] :
@@ -361,16 +363,21 @@ instance [Fact (1 < (q : ℕ))] : Nontrivial (X q) :=
   ⟨⟨0, 1, ne_of_apply_ne Prod.fst zero_ne_one⟩⟩
 
 @[simp]
-theorem int_coe_fst (n : ℤ) : (n : X q).fst = (n : ZMod q) :=
+theorem fst_intCast (n : ℤ) : (n : X q).fst = (n : ZMod q) :=
   rfl
 set_option linter.uppercaseLean3 false in
-#align lucas_lehmer.X.int_coe_fst LucasLehmer.X.int_coe_fst
+#align lucas_lehmer.X.int_coe_fst LucasLehmer.X.fst_intCast
 
 @[simp]
-theorem int_coe_snd (n : ℤ) : (n : X q).snd = (0 : ZMod q) :=
+theorem snd_intCast (n : ℤ) : (n : X q).snd = (0 : ZMod q) :=
   rfl
 set_option linter.uppercaseLean3 false in
-#align lucas_lehmer.X.int_coe_snd LucasLehmer.X.int_coe_snd
+#align lucas_lehmer.X.int_coe_snd LucasLehmer.X.snd_intCast
+
+@[deprecated (since := "2024-05-25")] alias nat_coe_fst := fst_natCast
+@[deprecated (since := "2024-05-25")] alias nat_coe_snd := snd_natCast
+@[deprecated (since := "2024-05-25")] alias int_coe_fst := fst_intCast
+@[deprecated (since := "2024-05-25")] alias int_coe_snd := snd_intCast
 
 @[norm_cast]
 theorem coe_mul (n m : ℤ) : ((n * m : ℤ) : X q) = (n : X q) * (m : X q) := by ext <;> simp

--- a/Mathlib/NumberTheory/Multiplicity.lean
+++ b/Mathlib/NumberTheory/Multiplicity.lean
@@ -364,7 +364,7 @@ theorem Nat.two_pow_sub_pow {x y : ℕ} (hxy : 2 ∣ x - y) (hx : ¬2 ∣ x) {n 
   obtain hyx | hyx := le_total y x
   · iterate 3 rw [← multiplicity.Int.natCast_multiplicity]
     simp only [Int.ofNat_sub hyx, Int.ofNat_sub (pow_le_pow_left' hyx _), Int.ofNat_add,
-      Int.coe_nat_pow]
+      Int.natCast_pow]
     rw [← Int.natCast_dvd_natCast] at hx
     rw [← Int.natCast_dvd_natCast, Int.ofNat_sub hyx] at hxy
     convert Int.two_pow_sub_pow hxy hx hn using 2

--- a/Mathlib/NumberTheory/Padics/PadicVal.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal.lean
@@ -778,8 +778,7 @@ section padicValInt
 variable {p : ℕ} [hp : Fact p.Prime]
 
 theorem padicValInt_dvd_iff (n : ℕ) (a : ℤ) : (p : ℤ) ^ n ∣ a ↔ a = 0 ∨ n ≤ padicValInt p a := by
-  rw [padicValInt, ← Int.natAbs_eq_zero, ← padicValNat_dvd_iff, ← Int.natCast_dvd,
-    Int.coe_nat_pow]
+  rw [padicValInt, ← Int.natAbs_eq_zero, ← padicValNat_dvd_iff, ← Int.natCast_dvd, Int.natCast_pow]
 #align padic_val_int_dvd_iff padicValInt_dvd_iff
 
 theorem padicValInt_dvd (a : ℤ) : (p : ℤ) ^ padicValInt p a ∣ a := by

--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -143,7 +143,7 @@ theorem zmod_congr_of_sub_mem_span_aux (n : ℕ) (x : ℤ_[p]) (a b : ℤ)
     (ha : x - a ∈ (Ideal.span {(p : ℤ_[p]) ^ n}))
     (hb : x - b ∈ (Ideal.span {(p : ℤ_[p]) ^ n})) : (a : ZMod (p ^ n)) = b := by
   rw [Ideal.mem_span_singleton] at ha hb
-  rw [← sub_eq_zero, ← Int.cast_sub, ZMod.intCast_zmod_eq_zero_iff_dvd, Int.coe_nat_pow]
+  rw [← sub_eq_zero, ← Int.cast_sub, ZMod.intCast_zmod_eq_zero_iff_dvd, Int.natCast_pow]
   rw [← dvd_neg, neg_sub] at ha
   have := dvd_add ha hb
   rwa [sub_eq_add_neg, sub_eq_add_neg, add_assoc, neg_add_cancel_left, ← sub_eq_add_neg, ←
@@ -499,7 +499,7 @@ variable {f}
 theorem pow_dvd_nthHom_sub (r : R) (i j : ℕ) (h : i ≤ j) :
     (p : ℤ) ^ i ∣ nthHom f r j - nthHom f r i := by
   specialize f_compat i j h
-  rw [← Int.coe_nat_pow, ← ZMod.intCast_zmod_eq_zero_iff_dvd, Int.cast_sub]
+  rw [← Int.natCast_pow, ← ZMod.intCast_zmod_eq_zero_iff_dvd, Int.cast_sub]
   dsimp [nthHom]
   rw [← f_compat, RingHom.comp_apply]
   simp only [ZMod.cast_id, ZMod.castHom_apply, sub_self, ZMod.natCast_val, ZMod.intCast_cast]

--- a/Mathlib/NumberTheory/PythagoreanTriples.lean
+++ b/Mathlib/NumberTheory/PythagoreanTriples.lean
@@ -498,12 +498,8 @@ theorem isPrimitiveClassified_of_coprime_of_odd_of_pos (hc : Int.gcd x y = 1) (h
     norm_cast
     apply Rat.den_nz q
   have hq2 : q = n / m := (Rat.num_div_den q).symm
-  have hm2n2 : 0 < m ^ 2 + n ^ 2 := by
-    apply lt_add_of_pos_of_le _ (sq_nonneg n)
-    exact lt_of_le_of_ne (sq_nonneg m) (Ne.symm (pow_ne_zero 2 hm0))
-  have hm2n20 : (m : ℚ) ^ 2 + (n : ℚ) ^ 2 ≠ 0 := by
-    norm_cast
-    simpa only [Int.coe_nat_pow] using ne_of_gt hm2n2
+  have hm2n2 : 0 < m ^ 2 + n ^ 2 := by positivity
+  have hm2n20 : (m ^ 2 + n ^ 2 : ℚ) ≠ 0 := by positivity
   have hx1 {j k : ℚ} (h₁ : k ≠ 0) (h₂ : k ^ 2 + j ^ 2 ≠ 0) :
       (1 - (j / k) ^ 2) / (1 + (j / k) ^ 2) = (k ^ 2 - j ^ 2) / (k ^ 2 + j ^ 2) :=
     by field_simp

--- a/Mathlib/NumberTheory/Zsqrtd/Basic.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/Basic.lean
@@ -350,23 +350,12 @@ theorem mul_star {x y : ℤ} : (⟨x, y⟩ * star ⟨x, y⟩ : ℤ√d) = x * x 
   ext <;> simp [sub_eq_add_neg, mul_comm]
 #align zsqrtd.mul_star Zsqrtd.mul_star
 
-protected theorem coe_int_add (m n : ℤ) : (↑(m + n) : ℤ√d) = ↑m + ↑n :=
-  Int.cast_add m n
-#align zsqrtd.coe_int_add Zsqrtd.coe_int_add
+@[deprecated (since := "2024-05-25")] alias coe_int_add := Int.cast_add
+@[deprecated (since := "2024-05-25")] alias coe_int_sub := Int.cast_sub
+@[deprecated (since := "2024-05-25")] alias coe_int_mul := Int.cast_mul
+@[deprecated (since := "2024-05-25")] alias coe_int_inj := Int.cast_inj
 
-protected theorem coe_int_sub (m n : ℤ) : (↑(m - n) : ℤ√d) = ↑m - ↑n :=
-  Int.cast_sub m n
-#align zsqrtd.coe_int_sub Zsqrtd.coe_int_sub
-
-protected theorem coe_int_mul (m n : ℤ) : (↑(m * n) : ℤ√d) = ↑m * ↑n :=
-  Int.cast_mul m n
-#align zsqrtd.coe_int_mul Zsqrtd.coe_int_mul
-
-protected theorem coe_int_inj {m n : ℤ} (h : (↑m : ℤ√d) = ↑n) : m = n := by
-  simpa using congr_arg re h
-#align zsqrtd.coe_int_inj Zsqrtd.coe_int_inj
-
-theorem coe_int_dvd_iff (z : ℤ) (a : ℤ√d) : ↑z ∣ a ↔ z ∣ a.re ∧ z ∣ a.im := by
+theorem intCast_dvd (z : ℤ) (a : ℤ√d) : ↑z ∣ a ↔ z ∣ a.re ∧ z ∣ a.im := by
   constructor
   · rintro ⟨x, rfl⟩
     simp only [add_zero, intCast_re, zero_mul, mul_im, dvd_mul_right, and_self_iff,
@@ -375,17 +364,20 @@ theorem coe_int_dvd_iff (z : ℤ) (a : ℤ√d) : ↑z ∣ a ↔ z ∣ a.re ∧ 
     use ⟨r, i⟩
     rw [smul_val, Zsqrtd.ext_iff]
     exact ⟨hr, hi⟩
-#align zsqrtd.coe_int_dvd_iff Zsqrtd.coe_int_dvd_iff
+#align zsqrtd.coe_int_dvd_iff Zsqrtd.intCast_dvd
 
 @[simp, norm_cast]
-theorem coe_int_dvd_coe_int (a b : ℤ) : (a : ℤ√d) ∣ b ↔ a ∣ b := by
-  rw [coe_int_dvd_iff]
+theorem intCast_dvd_intCast (a b : ℤ) : (a : ℤ√d) ∣ b ↔ a ∣ b := by
+  rw [intCast_dvd]
   constructor
   · rintro ⟨hre, -⟩
     rwa [intCast_re] at hre
   · rw [intCast_re, intCast_im]
     exact fun hc => ⟨hc, dvd_zero a⟩
-#align zsqrtd.coe_int_dvd_coe_int Zsqrtd.coe_int_dvd_coe_int
+#align zsqrtd.coe_int_dvd_coe_int Zsqrtd.intCast_dvd_intCast
+
+@[deprecated (since := "2024-05-25")] alias coe_int_dvd_iff := intCast_dvd
+@[deprecated (since := "2024-05-25")] alias coe_int_dvd_coe_int := intCast_dvd_intCast
 
 protected theorem eq_of_smul_eq_smul_left {a : ℤ} {b c : ℤ√d} (ha : a ≠ 0) (h : ↑a * b = a * c) :
     b = c := by
@@ -413,9 +405,9 @@ theorem coprime_of_dvd_coprime {a b : ℤ√d} (hcoprime : IsCoprime a.re a.im) 
   · rintro z hz - hzdvdu hzdvdv
     apply hz
     obtain ⟨ha, hb⟩ : z ∣ a.re ∧ z ∣ a.im := by
-      rw [← coe_int_dvd_iff]
+      rw [← intCast_dvd]
       apply dvd_trans _ hdvd
-      rw [coe_int_dvd_iff]
+      rw [intCast_dvd]
       exact ⟨hzdvdu, hzdvdv⟩
     exact hcoprime.isUnit_of_dvd' ha hb
 #align zsqrtd.coprime_of_dvd_coprime Zsqrtd.coprime_of_dvd_coprime
@@ -571,14 +563,14 @@ theorem norm_eq_mul_conj (n : ℤ√d) : (norm n : ℤ√d) = n * star n := by
 theorem norm_neg (x : ℤ√d) : (-x).norm = x.norm :=
   -- Porting note: replaced `simp` with `rw`
   -- See https://github.com/leanprover-community/mathlib4/issues/5026
-  Zsqrtd.coe_int_inj <| by rw [norm_eq_mul_conj, star_neg, neg_mul_neg, norm_eq_mul_conj]
+  Int.cast_inj.1 <| by rw [norm_eq_mul_conj, star_neg, neg_mul_neg, norm_eq_mul_conj]
 #align zsqrtd.norm_neg Zsqrtd.norm_neg
 
 @[simp]
 theorem norm_conj (x : ℤ√d) : (star x).norm = x.norm :=
   -- Porting note: replaced `simp` with `rw`
   -- See https://github.com/leanprover-community/mathlib4/issues/5026
-  Zsqrtd.coe_int_inj <| by rw [norm_eq_mul_conj, star_star, mul_comm, norm_eq_mul_conj]
+  Int.cast_inj.1 <| by rw [norm_eq_mul_conj, star_star, mul_comm, norm_eq_mul_conj]
 #align zsqrtd.norm_conj Zsqrtd.norm_conj
 
 theorem norm_nonneg (hd : d ≤ 0) (n : ℤ√d) : 0 ≤ n.norm :=

--- a/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
@@ -296,7 +296,7 @@ theorem sq_add_sq_of_nat_prime_of_not_irreducible (p : ℕ) [hp : Fact p.Prime]
   let ⟨a, b, hpab, hau, hbu⟩ := hab
   have hnap : (norm a).natAbs = p :=
     ((hp.1.mul_eq_prime_sq_iff (mt norm_eq_one_iff.1 hau) (mt norm_eq_one_iff.1 hbu)).1 <| by
-        rw [← Int.natCast_inj, Int.coe_nat_pow, sq, ← @norm_natCast (-1), hpab]; simp).1
+        rw [← Int.natCast_inj, Int.natCast_pow, sq, ← @norm_natCast (-1), hpab]; simp).1
   ⟨a.re.natAbs, a.im.natAbs, by simpa [natAbs_norm_eq, sq] using hnap⟩
 #align gaussian_int.sq_add_sq_of_nat_prime_of_not_irreducible GaussianInt.sq_add_sq_of_nat_prime_of_not_irreducible
 

--- a/Mathlib/Order/Atoms/Finite.lean
+++ b/Mathlib/Order/Atoms/Finite.lean
@@ -74,7 +74,7 @@ open Finset
 -- see Note [lower instance priority]
 instance (priority := 100) Finite.to_isCoatomic [PartialOrder α] [OrderTop α] [Finite α] :
     IsCoatomic α := by
-  refine' IsCoatomic.mk fun b => or_iff_not_imp_left.2 fun ht => _
+  refine IsCoatomic.mk fun b => or_iff_not_imp_left.2 fun ht => ?_
   obtain ⟨c, hc, hmax⟩ :=
     Set.Finite.exists_maximal_wrt id { x : α | b ≤ x ∧ x ≠ ⊤ } (Set.toFinite _) ⟨b, le_rfl, ht⟩
   refine ⟨c, ⟨hc.2, fun y hcy => ?_⟩, hc.1⟩

--- a/Mathlib/Order/Atoms/Finite.lean
+++ b/Mathlib/Order/Atoms/Finite.lean
@@ -8,6 +8,7 @@ import Mathlib.Order.Atoms
 
 #align_import order.atoms.finite from "leanprover-community/mathlib"@"d6fad0e5bf2d6f48da9175d25c3dc5706b3834ce"
 
+
 /-!
 # Atoms, Coatoms, Simple Lattices, and Finiteness
 

--- a/Mathlib/Order/Atoms/Finite.lean
+++ b/Mathlib/Order/Atoms/Finite.lean
@@ -8,7 +8,6 @@ import Mathlib.Order.Atoms
 
 #align_import order.atoms.finite from "leanprover-community/mathlib"@"d6fad0e5bf2d6f48da9175d25c3dc5706b3834ce"
 
-
 /-!
 # Atoms, Coatoms, Simple Lattices, and Finiteness
 

--- a/Mathlib/Order/Grade.lean
+++ b/Mathlib/Order/Grade.lean
@@ -346,5 +346,5 @@ abbrev GradeMinOrder.finToNat (n : ℕ) [GradeMinOrder (Fin n) α] : GradeMinOrd
 #align grade_min_order.fin_to_nat GradeMinOrder.finToNat
 
 instance GradeOrder.natToInt [GradeOrder ℕ α] : GradeOrder ℤ α :=
-  (GradeOrder.liftLeft _ Int.coe_nat_strictMono) fun _ _ => CovBy.cast_int
+  (GradeOrder.liftLeft _ Int.natCast_strictMono) fun _ _ => CovBy.intCast
 #align grade_order.nat_to_int GradeOrder.natToInt

--- a/Mathlib/RingTheory/Coprime/Lemmas.lean
+++ b/Mathlib/RingTheory/Coprime/Lemmas.lean
@@ -42,7 +42,7 @@ theorem Int.isCoprime_iff_gcd_eq_one {m n : ℤ} : IsCoprime m n ↔ Int.gcd m n
     exact ⟨_, _, h⟩
 
 theorem Nat.isCoprime_iff_coprime {m n : ℕ} : IsCoprime (m : ℤ) n ↔ Nat.Coprime m n := by
-  rw [Int.isCoprime_iff_gcd_eq_one, Int.coe_nat_gcd]
+  rw [Int.isCoprime_iff_gcd_eq_one, Int.gcd_natCast_natCast]
 #align nat.is_coprime_iff_coprime Nat.isCoprime_iff_coprime
 
 alias ⟨IsCoprime.nat_coprime, Nat.Coprime.isCoprime⟩ := Nat.isCoprime_iff_coprime

--- a/Mathlib/Tactic/NormNum/GCD.lean
+++ b/Mathlib/Tactic/NormNum/GCD.lean
@@ -35,7 +35,7 @@ theorem nat_gcd_helper_dvd_right (x y : ℕ) (h : x % y = 0) : Nat.gcd x y = y :
 
 theorem nat_gcd_helper_2 (d x y a b : ℕ) (hu : x % d = 0) (hv : y % d = 0)
     (h : x * a = y * b + d) : Nat.gcd x y = d := by
-  rw [← Int.coe_nat_gcd]
+  rw [← Int.gcd_natCast_natCast]
   apply int_gcd_helper' a (-b)
     (Int.natCast_dvd_natCast.mpr (Nat.dvd_of_mod_eq_zero hu))
     (Int.natCast_dvd_natCast.mpr (Nat.dvd_of_mod_eq_zero hv))

--- a/Mathlib/Tactic/ReduceModChar.lean
+++ b/Mathlib/Tactic/ReduceModChar.lean
@@ -44,7 +44,7 @@ namespace ReduceModChar
 
 open Mathlib.Meta.NormNum
 
-lemma CharP.cast_int_eq_mod (R : Type _) [Ring R] (p : ℕ) [CharP R p] (k : ℤ) :
+lemma CharP.intCast_eq_mod (R : Type _) [Ring R] (p : ℕ) [CharP R p] (k : ℤ) :
     (k : R) = (k % p : ℤ) := by
   calc
     (k : R) = ↑(k % p + p * (k / p)) := by rw [Int.emod_add_ediv]
@@ -52,7 +52,7 @@ lemma CharP.cast_int_eq_mod (R : Type _) [Ring R] (p : ℕ) [CharP R p] (k : ℤ
 
 lemma CharP.isInt_of_mod {α : Type _} [Ring α] {n n' : ℕ} (inst : CharP α n) {e : α}
     (he : IsInt e e') (hn : IsNat n n') (h₂ : IsInt (e' % n') r) : IsInt e r :=
-  ⟨by rw [he.out, CharP.cast_int_eq_mod α n, show n = n' from hn.out, h₂.out, Int.cast_id]⟩
+  ⟨by rw [he.out, CharP.intCast_eq_mod α n, show n = n' from hn.out, h₂.out, Int.cast_id]⟩
 
 /-- Given an integral expression `e : t` such that `t` is a ring of characteristic `n`,
 reduce `e` modulo `n`. -/


### PR DESCRIPTION
A copy of #13205: the only difference is that I replaced a `refine'` by `refine` in `Mathlib.Order.Atoms.Finite`.  The reason is that the cache appears to be corrupted and forcing `lake` to rebuild `Mathlib.Order.Atoms.Finite` (or possibly a downstream file) makes the PR pass CI.

Authored-by: [YaelDillies](https://github.com/YaelDillies)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
