### PR TITLE
[Merged by Bors] - chore: apply release-ci tag on lean-pr-testing failures

### DIFF
--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -58,14 +58,14 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
       -H "Authorization: Bearer $TOKEN" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       https://api.github.com/repos/leanprover/lean4/issues/$pr_number/labels/builds-mathlib
-    echo "Adding labels breaks-mathlib and full-ci"
+    echo "Adding labels breaks-mathlib and release-ci"
     curl -L -s \
       -X POST \
       -H "Accept: application/vnd.github+json" \
       -H "Authorization: Bearer $TOKEN" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       https://api.github.com/repos/leanprover/lean4/issues/$pr_number/labels \
-      -d '{"labels":["breaks-mathlib", "full-ci"]}'
+      -d '{"labels":["breaks-mathlib", "release-ci"]}'
   fi
 
   # Use GitHub API to check if a comment already exists


### PR DESCRIPTION
We've changed the CI setup at the lean4 repository. This ensures that a toolchain is built for all OSs if Mathlib testing fails, so that humans can then investigate what's happening on the lean-pr-testing-NNNN branch.