### PR TITLE
[Merged by Bors] - chore: Do not import order theory in `Data.Int.Cast.Lemmas`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -540,6 +540,7 @@ import Mathlib.Algebra.Order.Positive.Ring
 import Mathlib.Algebra.Order.Rearrangement
 import Mathlib.Algebra.Order.Ring.Abs
 import Mathlib.Algebra.Order.Ring.Canonical
+import Mathlib.Algebra.Order.Ring.Cast
 import Mathlib.Algebra.Order.Ring.CharZero
 import Mathlib.Algebra.Order.Ring.Cone
 import Mathlib.Algebra.Order.Ring.Defs

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Module.Submodule.Ker
 import Mathlib.Algebra.Module.Submodule.RestrictScalars
 import Mathlib.Algebra.Module.ULift
 import Mathlib.Algebra.Ring.Subring.Basic
+import Mathlib.Data.Int.CharZero
 
 #align_import algebra.algebra.basic from "leanprover-community/mathlib"@"36b8aa61ea7c05727161f96a0532897bd72aedab"
 

--- a/Mathlib/Algebra/Category/GroupWithZeroCat.lean
+++ b/Mathlib/Algebra/Category/GroupWithZeroCat.lean
@@ -3,8 +3,9 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.CategoryTheory.Category.Bipointed
 import Mathlib.Algebra.Category.MonCat.Basic
+import Mathlib.Algebra.GroupWithZero.WithZero
+import Mathlib.CategoryTheory.Category.Bipointed
 
 #align_import algebra.category.GroupWithZero from "leanprover-community/mathlib"@"70fd9563a21e7b963887c9360bd29b2393e6225a"
 

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.CharZero.Lemmas
 import Mathlib.Algebra.Order.Interval.Set.Group
 import Mathlib.Algebra.Group.Int
 import Mathlib.Data.Int.Lemmas
-import Mathlib.Data.Int.CharZero
 import Mathlib.Data.Set.Subsingleton
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Order.GaloisConnection

--- a/Mathlib/Algebra/Order/Interval/Set/Group.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Group.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy Degenne
 -/
 import Mathlib.Algebra.GroupPower.Order
+import Mathlib.Algebra.Order.Group.Abs
+import Mathlib.Algebra.Order.Group.OrderIso
 import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.Order.Interval.Set.Basic
 import Mathlib.Logic.Pairwise

--- a/Mathlib/Algebra/Order/Ring/Cast.lean
+++ b/Mathlib/Algebra/Order/Ring/Cast.lean
@@ -15,7 +15,7 @@ import Mathlib.Data.Nat.Cast.Order
 This file proves additional properties about the *canonical* homomorphism from
 the integers into an additive group with a one (`Int.cast`),
 particularly results involving algebraic homomorphisms or the order structure on `ℤ`
-which were not available in the import dependencies of `Data.Int.Cast.Basic`.
+which were not available in the import dependencies of `Mathlib.Data.Int.Cast.Basic`.
 
 ## TODO
 

--- a/Mathlib/Algebra/Order/Ring/Cast.lean
+++ b/Mathlib/Algebra/Order/Ring/Cast.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2017 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Mathlib.Algebra.Order.Ring.CharZero
+import Mathlib.Algebra.Order.Ring.Int
+import Mathlib.Data.Nat.Cast.Order
+
+#align_import data.int.cast.lemmas from "leanprover-community/mathlib"@"acebd8d49928f6ed8920e502a6c90674e75bd441"
+
+/-!
+# Order properties of cast of integers
+
+This file proves additional properties about the *canonical* homomorphism from
+the integers into an additive group with a one (`Int.cast`),
+particularly results involving algebraic homomorphisms or the order structure on `ℤ`
+which were not available in the import dependencies of `Data.Int.Cast.Basic`.
+
+## TODO
+
+Move order lemmas about `Nat.cast`, `Rat.cast`, `NNRat.cast` here.
+-/
+
+open Function Nat
+
+variable {R : Type*}
+
+namespace Int
+section OrderedRing
+variable [OrderedRing R]
+
+lemma cast_mono : Monotone (Int.cast : ℤ → R) := by
+  intro m n h
+  rw [← sub_nonneg] at h
+  lift n - m to ℕ using h with k hk
+  rw [← sub_nonneg, ← cast_sub, ← hk, cast_natCast]
+  exact k.cast_nonneg
+#align int.cast_mono Int.cast_mono
+
+variable [Nontrivial R] {m n : ℤ}
+
+@[simp] lemma cast_nonneg : ∀ {n : ℤ}, (0 : R) ≤ n ↔ 0 ≤ n
+  | (n : ℕ) => by simp
+  | -[n+1] => by
+    have : -(n : R) < 1 := lt_of_le_of_lt (by simp) zero_lt_one
+    simpa [(negSucc_lt_zero n).not_le, ← sub_eq_add_neg, le_neg] using this.not_le
+#align int.cast_nonneg Int.cast_nonneg
+
+@[simp, norm_cast] lemma cast_le : (m : R) ≤ n ↔ m ≤ n := by
+  rw [← sub_nonneg, ← cast_sub, cast_nonneg, sub_nonneg]
+#align int.cast_le Int.cast_le
+
+lemma cast_strictMono : StrictMono (fun x : ℤ => (x : R)) :=
+  strictMono_of_le_iff_le fun _ _ => cast_le.symm
+#align int.cast_strict_mono Int.cast_strictMono
+
+@[simp, norm_cast] lemma cast_lt : (m : R) < n ↔ m < n := cast_strictMono.lt_iff_lt
+#align int.cast_lt Int.cast_lt
+
+@[simp] lemma cast_nonpos : (n : R) ≤ 0 ↔ n ≤ 0 := by rw [← cast_zero, cast_le]
+#align int.cast_nonpos Int.cast_nonpos
+
+@[simp] lemma cast_pos : (0 : R) < n ↔ 0 < n := by rw [← cast_zero, cast_lt]
+#align int.cast_pos Int.cast_pos
+
+@[simp] lemma cast_lt_zero : (n : R) < 0 ↔ n < 0 := by rw [← cast_zero, cast_lt]
+#align int.cast_lt_zero Int.cast_lt_zero
+
+end OrderedRing
+
+section LinearOrderedRing
+variable [LinearOrderedRing R] {a b n : ℤ} {x : R}
+
+@[simp, norm_cast]
+lemma cast_min : ↑(min a b) = (min a b : R) := Monotone.map_min cast_mono
+#align int.cast_min Int.cast_min
+
+@[simp, norm_cast]
+lemma cast_max : (↑(max a b) : R) = max (a : R) (b : R) := Monotone.map_max cast_mono
+#align int.cast_max Int.cast_max
+
+@[simp, norm_cast]
+lemma cast_abs : (↑|a| : R) = |(a : R)| := by simp [abs_eq_max_neg]
+#align int.cast_abs Int.cast_abs
+
+lemma cast_one_le_of_pos (h : 0 < a) : (1 : R) ≤ a := mod_cast Int.add_one_le_of_lt h
+#align int.cast_one_le_of_pos Int.cast_one_le_of_pos
+
+lemma cast_le_neg_one_of_neg (h : a < 0) : (a : R) ≤ -1 := by
+  rw [← Int.cast_one, ← Int.cast_neg, cast_le]
+  exact Int.le_sub_one_of_lt h
+#align int.cast_le_neg_one_of_neg Int.cast_le_neg_one_of_neg
+
+variable (R) in
+lemma cast_le_neg_one_or_one_le_cast_of_ne_zero (hn : n ≠ 0) : (n : R) ≤ -1 ∨ 1 ≤ (n : R) :=
+  hn.lt_or_lt.imp cast_le_neg_one_of_neg cast_one_le_of_pos
+#align int.cast_le_neg_one_or_one_le_cast_of_ne_zero Int.cast_le_neg_one_or_one_le_cast_of_ne_zero
+
+lemma nneg_mul_add_sq_of_abs_le_one (n : ℤ) (hx : |x| ≤ 1) : (0 : R) ≤ n * x + n * n := by
+  have hnx : 0 < n → 0 ≤ x + n := fun hn => by
+    have := _root_.add_le_add (neg_le_of_abs_le hx) (cast_one_le_of_pos hn)
+    rwa [add_left_neg] at this
+  have hnx' : n < 0 → x + n ≤ 0 := fun hn => by
+    have := _root_.add_le_add (le_of_abs_le hx) (cast_le_neg_one_of_neg hn)
+    rwa [add_right_neg] at this
+  rw [← mul_add, mul_nonneg_iff]
+  rcases lt_trichotomy n 0 with (h | rfl | h)
+  · exact Or.inr ⟨mod_cast h.le, hnx' h⟩
+  · simp [le_total 0 x]
+  · exact Or.inl ⟨mod_cast h.le, hnx h⟩
+#align int.nneg_mul_add_sq_of_abs_le_one Int.nneg_mul_add_sq_of_abs_le_one
+
+lemma cast_natAbs : (n.natAbs : R) = |n| := by
+  cases n
+  · simp
+  · rw [abs_eq_natAbs, natAbs_negSucc, cast_succ, cast_natCast, cast_succ]
+#align int.cast_nat_abs Int.cast_natAbs
+
+end LinearOrderedRing
+end Int
+
+/-! ### Order dual -/
+
+open OrderDual
+
+namespace OrderDual
+
+instance instIntCast             [IntCast R]             : IntCast Rᵒᵈ             := ‹_›
+instance instAddGroupWithOne     [AddGroupWithOne R]     : AddGroupWithOne Rᵒᵈ     := ‹_›
+instance instAddCommGroupWithOne [AddCommGroupWithOne R] : AddCommGroupWithOne Rᵒᵈ := ‹_›
+
+end OrderDual
+
+@[simp] lemma toDual_intCast [IntCast R] (n : ℤ) : toDual (n : R) = n := rfl
+#align to_dual_int_cast toDual_intCast
+
+@[simp] lemma ofDual_intCast [IntCast R] (n : ℤ) : (ofDual n : R) = n := rfl
+#align of_dual_int_cast ofDual_intCast
+
+/-! ### Lexicographic order -/
+
+namespace Lex
+
+instance instIntCast             [IntCast R]             : IntCast (Lex R)             := ‹_›
+instance instAddGroupWithOne     [AddGroupWithOne R]     : AddGroupWithOne (Lex R)     := ‹_›
+instance instAddCommGroupWithOne [AddCommGroupWithOne R] : AddCommGroupWithOne (Lex R) := ‹_›
+
+end Lex
+
+@[simp] lemma toLex_intCast [IntCast R] (n : ℤ) : toLex (n : R) = n := rfl
+#align to_lex_int_cast toLex_intCast
+
+@[simp] lemma ofLex_intCast [IntCast R] (n : ℤ) : (ofLex n : R) = n := rfl
+#align of_lex_int_cast ofLex_intCast

--- a/Mathlib/Algebra/Ring/Nat.lean
+++ b/Mathlib/Algebra/Ring/Nat.lean
@@ -3,6 +3,7 @@ Copyright (c) 2014 Floris van Doorn (c) 2016 Microsoft Corporation. All rights r
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
+import Mathlib.Algebra.CharZero.Defs
 import Mathlib.Algebra.Group.Nat
 import Mathlib.Algebra.Ring.Defs
 
@@ -42,6 +43,8 @@ instance instCancelCommMonoidWithZero : CancelCommMonoidWithZero ℕ where
 
 instance instMulDivCancelClass : MulDivCancelClass ℕ where
   mul_div_cancel _ _b hb := Nat.mul_div_cancel _ (Nat.pos_iff_ne_zero.2 hb)
+
+instance instCharZero : CharZero ℕ where cast_injective := Function.injective_id
 
 /-!
 ### Extra instances to short-circuit type class resolution

--- a/Mathlib/Data/Bool/Count.lean
+++ b/Mathlib/Data/Bool/Count.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Algebra.Order.Ring.CharZero
 import Mathlib.Algebra.Order.Ring.Nat
 import Mathlib.Data.List.Chain
 

--- a/Mathlib/Data/Int/CharZero.lean
+++ b/Mathlib/Data/Int/CharZero.lean
@@ -20,39 +20,6 @@ variable {α β : Type*}
 
 namespace Int
 
-@[simp]
-theorem cast_eq_zero [AddGroupWithOne α] [CharZero α] {n : ℤ} : (n : α) = 0 ↔ n = 0 :=
-  ⟨fun h => by
-    cases n
-    · erw [Int.cast_natCast] at h
-      exact congr_arg _ (Nat.cast_eq_zero.1 h)
-    · rw [cast_negSucc, neg_eq_zero, Nat.cast_eq_zero] at h
-      contradiction,
-    fun h => by rw [h, cast_zero]⟩
-#align int.cast_eq_zero Int.cast_eq_zero
-
-@[simp, norm_cast]
-theorem cast_inj [AddGroupWithOne α] [CharZero α] {m n : ℤ} : (m : α) = n ↔ m = n := by
-  rw [← sub_eq_zero, ← cast_sub, cast_eq_zero, sub_eq_zero]
-#align int.cast_inj Int.cast_inj
-
-theorem cast_injective [AddGroupWithOne α] [CharZero α] : Function.Injective (Int.cast : ℤ → α)
-  | _, _ => cast_inj.1
-#align int.cast_injective Int.cast_injective
-
-theorem cast_ne_zero [AddGroupWithOne α] [CharZero α] {n : ℤ} : (n : α) ≠ 0 ↔ n ≠ 0 :=
-  not_congr cast_eq_zero
-#align int.cast_ne_zero Int.cast_ne_zero
-
-@[simp]
-theorem cast_eq_one [AddGroupWithOne α] [CharZero α] {n : ℤ} : (n : α) = 1 ↔ n = 1 := by
-  rw [← cast_one, cast_inj]
-#align int.cast_eq_one Int.cast_eq_one
-
-theorem cast_ne_one [AddGroupWithOne α] [CharZero α] {n : ℤ} : (n : α) ≠ 1 ↔ n ≠ 1 :=
-  cast_eq_one.not
-#align int.cast_ne_one Int.cast_ne_one
-
 @[simp, norm_cast]
 theorem cast_div_charZero {k : Type*} [DivisionRing k] [CharZero k] {m n : ℤ} (n_dvd : n ∣ m) :
     ((m / n : ℤ) : k) = m / n := by

--- a/Mathlib/Data/Nat/Cast/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Basic.lean
@@ -23,6 +23,13 @@ the natural numbers into an additive monoid with a one (`Nat.cast`).
 * `castRingHom`: `cast` bundled as a `RingHom`.
 -/
 
+assert_not_exists OrderedCommGroup
+assert_not_exists Commute.zero_right
+assert_not_exists Commute.add_right
+assert_not_exists abs_eq_max_neg
+assert_not_exists natCast_ne
+assert_not_exists MulOpposite.natCast
+
 -- Porting note: There are many occasions below where we need `simp [map_zero f]`
 -- where `simp [map_zero]` should suffice. (Similarly for `map_one`.)
 -- See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/simp.20regression.20with.20MonoidHomClass
@@ -335,12 +342,3 @@ theorem Sum.elim_natCast_natCast {α β γ : Type*} [NatCast γ] (n : ℕ) :
     Sum.elim (n : α → γ) (n : β → γ) = n :=
   Sum.elim_lam_const_lam_const (γ := γ) n
 #align sum.elim_nat_cast_nat_cast Sum.elim_natCast_natCast
-
--- Guard against import creep regression.
-assert_not_exists OrderedCommGroup
-assert_not_exists CharZero
-assert_not_exists Commute.zero_right
-assert_not_exists Commute.add_right
-assert_not_exists abs_eq_max_neg
-assert_not_exists natCast_ne
-assert_not_exists MulOpposite.natCast

--- a/Mathlib/Data/Nat/Prime.lean
+++ b/Mathlib/Data/Nat/Prime.lean
@@ -5,7 +5,6 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Algebra.Associated
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
-import Mathlib.Algebra.Order.Ring.CharZero
 import Mathlib.Algebra.Ring.Int
 import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.Data.Nat.GCD.Basic

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -3,11 +3,12 @@ Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.Num.Bitwise
-import Mathlib.Data.Int.CharZero
+import Mathlib.Algebra.Order.Ring.Cast
+import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.Data.Nat.Bitwise
 import Mathlib.Data.Nat.PSub
 import Mathlib.Data.Nat.Size
+import Mathlib.Data.Num.Bitwise
 
 #align_import data.num.lemmas from "leanprover-community/mathlib"@"2196ab363eb097c008d4497125e0dde23fb36db2"
 
@@ -129,7 +130,7 @@ theorem mul_to_nat (m) : ∀ n, ((m * n : PosNum) : ℕ) = m * n
 #align pos_num.mul_to_nat PosNum.mul_to_nat
 
 theorem to_nat_pos : ∀ n : PosNum, 0 < (n : ℕ)
-  | 1 => zero_lt_one
+  | 1 => Nat.zero_lt_one
   | bit0 p =>
     let h := to_nat_pos p
     add_pos h h
@@ -138,7 +139,7 @@ theorem to_nat_pos : ∀ n : PosNum, 0 < (n : ℕ)
 
 theorem cmp_to_nat_lemma {m n : PosNum} : (m : ℕ) < n → (bit1 m : ℕ) < bit0 n :=
   show (m : ℕ) < n → (m + m + 1 + 1 : ℕ) ≤ n + n by
-    intro h; rw [Nat.add_right_comm m m 1, add_assoc]; exact add_le_add h h
+    intro h; rw [Nat.add_right_comm m m 1, add_assoc]; exact Nat.add_le_add h h
 #align pos_num.cmp_to_nat_lemma PosNum.cmp_to_nat_lemma
 
 theorem cmp_swap (m) : ∀ n, (cmp m n).swap = cmp n m := by
@@ -150,22 +151,22 @@ theorem cmp_to_nat : ∀ m n, (Ordering.casesOn (cmp m n) ((m : ℕ) < n) (m = n
   | 1, 1 => rfl
   | bit0 a, 1 =>
     let h : (1 : ℕ) ≤ a := to_nat_pos a
-    add_le_add h h
+    Nat.add_le_add h h
   | bit1 a, 1 => Nat.succ_lt_succ <| to_nat_pos <| bit0 a
   | 1, bit0 b =>
     let h : (1 : ℕ) ≤ b := to_nat_pos b
-    add_le_add h h
+    Nat.add_le_add h h
   | 1, bit1 b => Nat.succ_lt_succ <| to_nat_pos <| bit0 b
   | bit0 a, bit0 b => by
     dsimp [cmp]
     have := cmp_to_nat a b; revert this; cases cmp a b <;> dsimp <;> intro this
-    · exact add_lt_add this this
+    · exact Nat.add_lt_add this this
     · rw [this]
-    · exact add_lt_add this this
+    · exact Nat.add_lt_add this this
   | bit0 a, bit1 b => by
     dsimp [cmp]
     have := cmp_to_nat a b; revert this; cases cmp a b <;> dsimp <;> intro this
-    · exact Nat.le_succ_of_le (add_lt_add this this)
+    · exact Nat.le_succ_of_le (Nat.add_lt_add this this)
     · rw [this]
       apply Nat.lt_succ_self
     · exact cmp_to_nat_lemma this
@@ -175,13 +176,13 @@ theorem cmp_to_nat : ∀ m n, (Ordering.casesOn (cmp m n) ((m : ℕ) < n) (m = n
     · exact cmp_to_nat_lemma this
     · rw [this]
       apply Nat.lt_succ_self
-    · exact Nat.le_succ_of_le (add_lt_add this this)
+    · exact Nat.le_succ_of_le (Nat.add_lt_add this this)
   | bit1 a, bit1 b => by
     dsimp [cmp]
     have := cmp_to_nat a b; revert this; cases cmp a b <;> dsimp <;> intro this
-    · exact Nat.succ_lt_succ (add_lt_add this this)
+    · exact Nat.succ_lt_succ (Nat.add_lt_add this this)
     · rw [this]
-    · exact Nat.succ_lt_succ (add_lt_add this this)
+    · exact Nat.succ_lt_succ (Nat.add_lt_add this this)
 #align pos_num.cmp_to_nat PosNum.cmp_to_nat
 
 @[norm_cast]

--- a/Mathlib/Data/Rat/Cast/CharZero.lean
+++ b/Mathlib/Data/Rat/Cast/CharZero.lean
@@ -3,9 +3,8 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
-import Mathlib.Data.Rat.Cast.Defs
-import Mathlib.Data.Int.CharZero
 import Mathlib.Algebra.GroupWithZero.Units.Lemmas
+import Mathlib.Data.Rat.Cast.Defs
 
 #align_import data.rat.cast from "leanprover-community/mathlib"@"acebd8d49928f6ed8920e502a6c90674e75bd441"
 

--- a/Mathlib/Data/Set/Pointwise/Support.lean
+++ b/Mathlib/Data/Set/Pointwise/Support.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
+import Mathlib.Algebra.Group.Support
 import Mathlib.Data.Set.Pointwise.SMul
 
 #align_import data.set.pointwise.support from "leanprover-community/mathlib"@"f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c"

--- a/Mathlib/Tactic/NormNum/Ineq.lean
+++ b/Mathlib/Tactic/NormNum/Ineq.lean
@@ -5,8 +5,9 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Tactic.NormNum.Eq
 import Mathlib.Algebra.Order.Field.Defs
-import Mathlib.Algebra.Order.Monoid.WithTop
 import Mathlib.Algebra.Order.Invertible
+import Mathlib.Algebra.Order.Monoid.WithTop
+import Mathlib.Algebra.Order.Ring.Cast
 
 /-!
 # `norm_num` extensions for inequalities.
@@ -44,7 +45,7 @@ theorem isRat_le_true [LinearOrderedRing α] : {a b : α} → {na nb : ℤ} → 
     IsRat a na da → IsRat b nb db →
     decide (Int.mul na (.ofNat db) ≤ Int.mul nb (.ofNat da)) → a ≤ b
   | _, _, _, _, da, db, ⟨_, rfl⟩, ⟨_, rfl⟩, h => by
-    have h := Int.cast_mono (α := α) <| of_decide_eq_true h
+    have h := Int.cast_mono (R := α) <| of_decide_eq_true h
     have ha : 0 ≤ ⅟(da : α) := invOf_nonneg.mpr <| Nat.cast_nonneg da
     have hb : 0 ≤ ⅟(db : α) := invOf_nonneg.mpr <| Nat.cast_nonneg db
     have h := (mul_le_mul_of_nonneg_left · hb) <| mul_le_mul_of_nonneg_right h ha
@@ -54,7 +55,7 @@ theorem isRat_le_true [LinearOrderedRing α] : {a b : α} → {na nb : ℤ} → 
 theorem isRat_lt_true [LinearOrderedRing α] [Nontrivial α] : {a b : α} → {na nb : ℤ} → {da db : ℕ} →
     IsRat a na da → IsRat b nb db → decide (na * db < nb * da) → a < b
   | _, _, _, _, da, db, ⟨_, rfl⟩, ⟨_, rfl⟩, h => by
-    have h := Int.cast_strictMono (α := α) <| of_decide_eq_true h
+    have h := Int.cast_strictMono (R := α) <| of_decide_eq_true h
     have ha : 0 < ⅟(da : α) := pos_invOf_of_invertible_cast da
     have hb : 0 < ⅟(db : α) := pos_invOf_of_invertible_cast db
     have h := (mul_lt_mul_of_pos_left · hb) <| mul_lt_mul_of_pos_right h ha

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -6,8 +6,8 @@ Authors: Mario Carneiro, Heather Macbeth, Yaël Dillies
 import Mathlib.Tactic.NormNum.Core
 import Mathlib.Tactic.HaveI
 import Mathlib.Algebra.Order.Invertible
+import Mathlib.Algebra.Order.Ring.Cast
 import Mathlib.Data.Nat.Cast.Basic
-import Mathlib.Data.Int.Cast.Lemmas
 import Qq
 
 /-!

--- a/Mathlib/Tactic/Qify.lean
+++ b/Mathlib/Tactic/Qify.lean
@@ -5,7 +5,8 @@ Authors: Moritz Doll, Mario Carneiro, Robert Y. Lewis
 -/
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.Zify
-import Mathlib.Data.Int.CharZero
+import Mathlib.Algebra.Order.Ring.Cast
+import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.Data.Rat.Order
 
 /-!

--- a/test/Qify.lean
+++ b/test/Qify.lean
@@ -1,4 +1,5 @@
 import Mathlib.Algebra.Order.Field.Rat
+import Mathlib.Data.Int.CharZero
 import Mathlib.Tactic.Qify
 
 example (a b : ℕ) : (a : ℚ) ≤ b ↔ a ≤ b := by qify


### PR DESCRIPTION
Split off the lemmas about `OrderedRing` from `Data.Int.Cast.Lemmas` to a new file `Algebra.Order.Ring.Cast`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
