### PR TITLE
[Merged by Bors] - feat: corollary of Chinese Remainder Theorem

### DIFF
--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -245,14 +245,23 @@ noncomputable def quotientInfRingEquivPiQuotient [Finite ι] (f : ι → Ideal R
     quotientInfToPiQuotient f with }
 #align ideal.quotient_inf_ring_equiv_pi_quotient Ideal.quotientInfRingEquivPiQuotient
 
-/-- Corollary of Chinese Remainder Theorem: if `f i` are pairwise coprime ideals in a
-commutative ring then the canonical map `R → ∏ (R ⧸ f i)` is surjective. -/
-lemma pi_quotient_surjective {R : Type*} [CommRing R] {ι : Type*} [Finite ι] (f : ι → Ideal R)
-    (hf : Pairwise fun i j ↦ IsCoprime (f i) (f j)) (x : (i : ι) → R ⧸ f i) :
+/-- Corollary of Chinese Remainder Theorem: if `Iᵢ` are pairwise coprime ideals in a
+commutative ring then the canonical map `R → ∏ (R ⧸ Iᵢ)` is surjective. -/
+lemma pi_quotient_surjective {R : Type*} [CommRing R] {ι : Type*} [Finite ι] {I : ι → Ideal R}
+    (hf : Pairwise fun i j ↦ IsCoprime (I i) (I j)) (x : (i : ι) → R ⧸ I i) :
     ∃ r : R, ∀ i, r = x i := by
   obtain ⟨y, rfl⟩ := Ideal.quotientInfToPiQuotient_surj hf x
   obtain ⟨r, rfl⟩ := Ideal.Quotient.mk_surjective y
   exact ⟨r, fun i ↦ rfl⟩
+
+-- variant of `IsDedekindDomain.exists_forall_sub_mem_ideal` which doesn't assume Dedekind domain!
+/-- Corollary of Chinese Remainder Theorem: if `Iᵢ` are pairwise coprime ideals in a
+commutative ring then given elements `xᵢ` you can find `r` with `r - xᵢ ∈ Iᵢ` for all `i`. -/
+lemma exists_forall_sub_mem_ideal {R : Type*} [CommRing R] {ι : Type*} [Finite ι]
+    {I : ι → Ideal R} (hI : Pairwise fun i j ↦ IsCoprime (I i) (I j)) (x : (i : ι) → R) :
+    ∃ r : R, ∀ i, r - x i ∈ I i := by
+  obtain ⟨y, hy⟩ := Ideal.pi_quotient_surjective hI (fun i ↦ x i)
+  exact ⟨y, fun i ↦ (Submodule.Quotient.eq (I i)).mp <| hy i⟩
 
 /-- **Chinese remainder theorem**, specialized to two ideals. -/
 noncomputable def quotientInfEquivQuotientProd (I J : Ideal R) (coprime : IsCoprime I J) :

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -258,7 +258,7 @@ lemma pi_quotient_surjective {R : Type*} [CommRing R] {ι : Type*} [Finite ι] {
 /-- Corollary of Chinese Remainder Theorem: if `Iᵢ` are pairwise coprime ideals in a
 commutative ring then given elements `xᵢ` you can find `r` with `r - xᵢ ∈ Iᵢ` for all `i`. -/
 lemma exists_forall_sub_mem_ideal {R : Type*} [CommRing R] {ι : Type*} [Finite ι]
-    {I : ι → Ideal R} (hI : Pairwise fun i j ↦ IsCoprime (I i) (I j)) (x : (i : ι) → R) :
+    {I : ι → Ideal R} (hI : Pairwise fun i j ↦ IsCoprime (I i) (I j)) (x : ι → R) :
     ∃ r : R, ∀ i, r - x i ∈ I i := by
   obtain ⟨y, hy⟩ := Ideal.pi_quotient_surjective hI (fun i ↦ x i)
   exact ⟨y, fun i ↦ (Submodule.Quotient.eq (I i)).mp <| hy i⟩

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -248,8 +248,8 @@ noncomputable def quotientInfRingEquivPiQuotient [Finite ι] (f : ι → Ideal R
 /-- Corollary of Chinese Remainder Theorem: if `f i` are pairwise coprime ideals in a
 commutative ring then the canonical map `R → ∏ (R ⧸ f i)` is surjective. -/
 lemma pi_quotient_surjective {R : Type*} [CommRing R] {ι : Type*} [Finite ι] (f : ι → Ideal R)
-    (hf : Pairwise fun i j ↦ IsCoprime (f i) (f j)) (x : (i : ι) → R ⧸ f i) : ∃ r : R,
-    ∀ i, r = x i := by
+    (hf : Pairwise fun i j ↦ IsCoprime (f i) (f j)) (x : (i : ι) → R ⧸ f i) :
+    ∃ r : R, ∀ i, r = x i := by
   obtain ⟨y, rfl⟩ := Ideal.quotientInfToPiQuotient_surj hf x
   obtain ⟨r, rfl⟩ := Ideal.Quotient.mk_surjective y
   exact ⟨r, fun i ↦ rfl⟩

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -237,12 +237,22 @@ lemma quotientInfToPiQuotient_surj [Finite ι] {I : ι → Ideal R}
   · intros j hj
     simp [(he j).2 i hj.symm]
 
-/-- Chinese Remainder Theorem. Eisenbud Ex.2.6. Similar to Atiyah-Macdonald 1.10 and Stacks 00DT -/
+/-- **Chinese Remainder Theorem**. Eisenbud Ex.2.6.
+Similar to Atiyah-Macdonald 1.10 and Stacks 00DT -/
 noncomputable def quotientInfRingEquivPiQuotient [Finite ι] (f : ι → Ideal R)
     (hf : Pairwise fun i j => IsCoprime (f i) (f j)) : (R ⧸ ⨅ i, f i) ≃+* ∀ i, R ⧸ f i :=
   { Equiv.ofBijective _ ⟨quotientInfToPiQuotient_inj f, quotientInfToPiQuotient_surj hf⟩,
     quotientInfToPiQuotient f with }
 #align ideal.quotient_inf_ring_equiv_pi_quotient Ideal.quotientInfRingEquivPiQuotient
+
+/-- Corollary of Chinese Remainder Theorem: if `f i` are pairwise coprime ideals in a
+commutative ring then the canonical map `R → ∏ (R ⧸ f i)` is surjective. -/
+lemma pi_quotient_surjective {R : Type*} [CommRing R] {ι : Type*} [Finite ι] (f : ι → Ideal R)
+    (hf : Pairwise fun i j ↦ IsCoprime (f i) (f j)) (x : (i : ι) → R ⧸ f i) : ∃ r : R,
+    ∀ i, r = x i := by
+  obtain ⟨y, rfl⟩ := Ideal.quotientInfToPiQuotient_surj hf x
+  obtain ⟨r, rfl⟩ := Ideal.Quotient.mk_surjective y
+  exact ⟨r, fun i ↦ rfl⟩
 
 /-- **Chinese remainder theorem**, specialized to two ideals. -/
 noncomputable def quotientInfEquivQuotientProd (I J : Ideal R) (coprime : IsCoprime I J) :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The nontrivial part of CRT (R / Inter J_i \iso prod R/J_i) is surjectivity. In `RingTheory/DedekindDomain/Ideal.lean` we have variants of CRT (valid when the J_i are `Prime` rather than maximal, although `Prime` implies maximal in a Dedekind domain...) but we also have various surjectivity statements as corollaries (e.g. `IsDedekindDomain.exists_representative_mod_finset`, `IsDedekindDomain.exists_forall_sub_mem_ideal`). I couldn't find these corollaries for a general commutative ring so I've added two (ironically in my application R is a Dedekind domain but I didn't want to assume it when unnecessary). 
