### PR TITLE
[Merged by Bors] - feat: Add `integrable_add_iff_of_nonneg`

### DIFF
--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -709,16 +709,9 @@ lemma integrable_add_iff_integrable_left {f g : α → β} (hf : Integrable f μ
 lemma integrable_left_of_integrable_add_of_nonneg {f g : α → ℝ}
     (h_meas : AEStronglyMeasurable f μ) (hf : 0 ≤ᵐ[μ] f) (hg : 0 ≤ᵐ[μ] g)
     (h_int : Integrable (f + g) μ) : Integrable f μ := by
-  simp_rw [Integrable, h_meas, true_and]
-  calc
-    (∫⁻ a, ‖f a‖₊ ∂μ) ≤ ∫⁻ a, ‖(f + g) a‖₊ ∂μ := by
-      apply lintegral_mono_ae
-      filter_upwards [hf, hg] with a haf hag
-      have hfg : 0 ≤ f a + g a := Left.add_nonneg haf hag
-      simp only [Pi.add_apply, ENNReal.coe_le_coe]
-      rw [← Real.toNNReal_eq_nnnorm_of_nonneg haf, ← Real.toNNReal_eq_nnnorm_of_nonneg hfg]
-      apply (Real.toNNReal_le_toNNReal_iff hfg).mpr ((le_add_iff_nonneg_right _).mpr hag)
-    _ < ⊤ := h_int.2
+  refine h_int.mono' h_meas ?_
+  filter_upwards [hf, hg] with a haf hag
+  exact (Real.norm_of_nonneg haf).symm ▸ (le_add_iff_nonneg_right _).mpr hag
 
 lemma integrable_right_of_integrable_add_of_nonneg {f g : α → ℝ}
     (h_meas : AEStronglyMeasurable f μ) (hf : 0 ≤ᵐ[μ] f) (hg : 0 ≤ᵐ[μ] g)

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -706,6 +706,40 @@ lemma integrable_add_iff_integrable_left {f g : α → β} (hf : Integrable f μ
     Integrable (g + f) μ ↔ Integrable g μ := by
   rw [add_comm, integrable_add_iff_integrable_right hf]
 
+lemma integrable_left_of_integrable_add_of_nonneg {f g : α → ℝ}
+    (h_meas : AEStronglyMeasurable f μ) (hf : 0 ≤ᵐ[μ] f) (hg : 0 ≤ᵐ[μ] g)
+    (h_int : Integrable (f + g) μ) : Integrable f μ := by
+  simp_rw [Integrable, h_meas, true_and]
+  calc
+    (∫⁻ a, ‖f a‖₊ ∂μ) ≤ ∫⁻ a, ‖(f + g) a‖₊ ∂μ := by
+      apply lintegral_mono_ae
+      filter_upwards [hf, hg] with a haf hag
+      have hfg : 0 ≤ f a + g a := Left.add_nonneg haf hag
+      simp only [Pi.add_apply, ENNReal.coe_le_coe]
+      rw [← Real.toNNReal_eq_nnnorm_of_nonneg haf, ← Real.toNNReal_eq_nnnorm_of_nonneg hfg]
+      apply (Real.toNNReal_le_toNNReal_iff hfg).mpr ((le_add_iff_nonneg_right _).mpr hag)
+    _ < ⊤ := h_int.2
+
+lemma integrable_right_of_integrable_add_of_nonneg {f g : α → ℝ}
+    (h_meas : AEStronglyMeasurable f μ) (hf : 0 ≤ᵐ[μ] f) (hg : 0 ≤ᵐ[μ] g)
+    (h_int : Integrable (f + g) μ) : Integrable g μ :=
+  integrable_left_of_integrable_add_of_nonneg
+    ((AEStronglyMeasurable.add_iff_right h_meas).mp h_int.aestronglyMeasurable)
+      hg hf (add_comm f g ▸ h_int)
+
+lemma integrable_add_iff_of_nonneg {f g : α → ℝ} (h_meas : AEStronglyMeasurable f μ)
+    (hf : 0 ≤ᵐ[μ] f) (hg : 0 ≤ᵐ[μ] g) :
+    Integrable (f + g) μ ↔ Integrable f μ ∧ Integrable g μ :=
+  ⟨fun h ↦ ⟨integrable_left_of_integrable_add_of_nonneg h_meas hf hg h,
+    integrable_right_of_integrable_add_of_nonneg h_meas hf hg h⟩, fun ⟨hf, hg⟩ ↦ hf.add hg⟩
+
+lemma integrable_add_iff_of_nonpos {f g : α → ℝ} (h_meas : AEStronglyMeasurable f μ)
+    (hf : f ≤ᵐ[μ] 0) (hg : g ≤ᵐ[μ] 0) :
+    Integrable (f + g) μ ↔ Integrable f μ ∧ Integrable g μ := by
+  rw [← integrable_neg_iff, ← integrable_neg_iff (f := f), ← integrable_neg_iff (f := g), neg_add]
+  exact integrable_add_iff_of_nonneg h_meas.neg (hf.mono (fun _ ↦ neg_nonneg_of_nonpos))
+    (hg.mono (fun _ ↦ neg_nonneg_of_nonpos))
+
 @[simp]
 lemma integrable_add_const_iff [IsFiniteMeasure μ] {f : α → β} {c : β} :
     Integrable (fun x ↦ f x + c) μ ↔ Integrable f μ :=


### PR DESCRIPTION
Add the lemma saying that if two functions are almost everywhere nonnegative then their sum is integrable iff they are both integrable. 

In particular, add the following lemmas:
1. `integrable_left_of_integrable_add_of_nonneg`
2. `integrable_right_of_integrable_add_of_nonneg`
3. `integrable_add_iff_of_nonneg`
4. `integrable_add_iff_of_nonpos`

1. and 2. are auxiliary for 3.; 4. is the same result for nonpositive functions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
