### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Sites/LeftExact): weaken universe assumptions

### DIFF
--- a/Mathlib/CategoryTheory/Sites/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Sites/LeftExact.lean
@@ -21,12 +21,13 @@ open CategoryTheory Limits Opposite
 universe w' w v u
 
 variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
-variable {D : Type w} [Category.{max v u} D]
-variable [∀ (P : Cᵒᵖ ⥤ D) (X : C) (S : J.Cover X), HasMultiequalizer (S.index P)]
 
 noncomputable section
 
 namespace CategoryTheory.GrothendieckTopology
+
+variable {D : Type w} [Category.{max v u} D]
+variable [∀ (P : Cᵒᵖ ⥤ D) (X : C) (S : J.Cover X), HasMultiequalizer (S.index P)]
 
 /-- An auxiliary definition to be used in the proof of the fact that
 `J.diagramFunctor D X` preserves limits. -/
@@ -221,6 +222,10 @@ end CategoryTheory.GrothendieckTopology
 
 namespace CategoryTheory
 
+section
+
+variable {D : Type w} [Category.{max v u} D]
+variable [∀ (P : Cᵒᵖ ⥤ D) (X : C) (S : J.Cover X), HasMultiequalizer (S.index P)]
 variable [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]
 variable [ConcreteCategory.{max v u} D]
 variable [∀ X : C, PreservesColimitsOfShape (J.Cover X)ᵒᵖ (forget D)]
@@ -274,25 +279,28 @@ def plusPlusIsoSheafify (P : Cᵒᵖ ⥤ D) : J.sheafify P ≅ sheafify J P :=
 
 instance [HasFiniteLimits D] : HasSheafify J D := HasSheafify.mk' J D (plusPlusAdjunction J D)
 
-variable {J D}
+end
 
-instance [FinitaryExtensive D] [HasFiniteCoproducts D] [HasPullbacks D] :
+variable {D : Type w} [Category.{w'} D]
+
+instance [FinitaryExtensive D] [HasPullbacks D] [HasSheafify J D] :
     FinitaryExtensive (Sheaf J D) :=
-  finitaryExtensive_of_reflective (plusPlusAdjunction _ _)
+  finitaryExtensive_of_reflective (sheafificationAdjunction _ _)
 
-instance [Adhesive D] [HasPullbacks D] [HasPushouts D] : Adhesive (Sheaf J D) :=
-  adhesive_of_reflective (plusPlusAdjunction _ _)
+instance [Adhesive D] [HasPullbacks D] [HasPushouts D] [HasSheafify J D] :
+    Adhesive (Sheaf J D) :=
+  adhesive_of_reflective (sheafificationAdjunction _ _)
 
-instance SheafOfTypes.finitary_extensive {C : Type u} [SmallCategory C]
-    (J : GrothendieckTopology C) : FinitaryExtensive (Sheaf J (Type u)) :=
+instance SheafOfTypes.finitary_extensive [HasSheafify J (Type w)] :
+    FinitaryExtensive (Sheaf J (Type w)) :=
   inferInstance
 
-instance SheafOfTypes.adhesive {C : Type u} [SmallCategory C] (J : GrothendieckTopology C) :
-    Adhesive (Sheaf J (Type u)) :=
+instance SheafOfTypes.adhesive [HasSheafify J (Type w)] :
+    Adhesive (Sheaf J (Type w)) :=
   inferInstance
 
-instance SheafOfTypes.balanced {C : Type u} [SmallCategory C] (J : GrothendieckTopology C) :
-    Balanced (Sheaf J (Type u)) :=
+instance SheafOfTypes.balanced [HasSheafify J (Type w)] :
+    Balanced (Sheaf J (Type w)) :=
   inferInstance
 
 end CategoryTheory


### PR DESCRIPTION
In this PR, the assumptions are slightly weakened in order to show that categories of sheaves are balanced: we use the `HasSheafify` assumption when applicable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
