### PR TITLE
[Merged by Bors] - feat: add more features to `ContinuousMapZero`

### DIFF
--- a/Mathlib/Topology/ContinuousFunction/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousFunction/ContinuousMapZero.lean
@@ -19,7 +19,12 @@ the purpose of this type.
 
 open Set Function
 
-/-- The type of continuous maps which map zero to zero. -/
+/-- The type of continuous maps which map zero to zero.
+
+Note that one should never use the structure projection `ContinuousMapZero.toContinuousMap` and
+instead favor the coercion `(↑) : C(X, R)₀ → C(X, R)` available from the instance of
+`ContinuousMapClass`. All the instances on `C(X, R)₀` from `C(X, R)` passes through this coercion,
+not the structure projection. Of course, the two are definitionally equal, but not reducibly so. -/
 structure ContinuousMapZero (X R : Type*) [Zero X] [Zero R] [TopologicalSpace X]
     [TopologicalSpace R] extends C(X, R) where
   map_zero' : toContinuousMap 0 = 0
@@ -50,16 +55,15 @@ lemma ext {f g : C(X, R)₀} (h : ∀ x, f x = g x) : f = g := DFunLike.ext f g 
 @[simp]
 lemma coe_mk {f : C(X, R)} {h0 : f 0 = 0} : ⇑(mk f h0) = f := rfl
 
-lemma toContinuousMap_injective [Zero R] : Injective (toContinuousMap (X := X) (R := R)) :=
+lemma toContinuousMap_injective [Zero R] : Injective ((↑) : C(X, R)₀ → C(X, R)) :=
   fun _ _ h ↦ congr(.mk $(h) _)
 
-lemma range_toContinuousMap : range (toContinuousMap (X := X) (R := R)) =
-    {f : C(X, R) | f 0 = 0} :=
+lemma range_toContinuousMap : range ((↑) : C(X, R)₀ → C(X, R)) = {f : C(X, R) | f 0 = 0} :=
   Set.ext fun f ↦ ⟨fun ⟨f', hf'⟩ ↦ hf' ▸ map_zero f', fun hf ↦ ⟨⟨f, hf⟩, rfl⟩⟩
 
 /-- Composition of continuous maps which map zero to zero. -/
 def comp (g : C(Y, R)₀) (f : C(X, Y)₀) : C(X, R)₀ where
-  toContinuousMap := g.toContinuousMap.comp f.toContinuousMap
+  toContinuousMap := (g : C(Y, R)).comp (f : C(X, Y))
   map_zero' := show g (f 0) = 0 from map_zero f ▸ map_zero g
 
 @[simp]
@@ -71,9 +75,9 @@ instance instPartialOrder [PartialOrder R] : PartialOrder C(X, R)₀ :=
 lemma le_def [PartialOrder R] (f g : C(X, R)₀) : f ≤ g ↔ ∀ x, f x ≤ g x := Iff.rfl
 
 protected instance instTopologicalSpace : TopologicalSpace C(X, R)₀ :=
-  TopologicalSpace.induced toContinuousMap inferInstance
+  TopologicalSpace.induced ((↑) : C(X, R)₀ → C(X, R)) inferInstance
 
-lemma embedding_toContinuousMap : Embedding (toContinuousMap (X := X) (R := R)) where
+lemma embedding_toContinuousMap : Embedding ((↑) : C(X, R)₀ → C(X, R)) where
   induced := rfl
   inj _ _ h := ext fun x ↦ congr($(h) x)
 
@@ -82,11 +86,20 @@ instance [T1Space R] : T1Space C(X, R)₀ := embedding_toContinuousMap.t1Space
 instance [T2Space R] : T2Space C(X, R)₀ := embedding_toContinuousMap.t2Space
 
 lemma closedEmbedding_toContinuousMap [T1Space R] :
-    ClosedEmbedding (toContinuousMap (X := X) (R := R)) where
+    ClosedEmbedding ((↑) : C(X, R)₀ → C(X, R)) where
   toEmbedding := embedding_toContinuousMap
   isClosed_range := by
     rw [range_toContinuousMap]
     exact isClosed_singleton.preimage <| ContinuousMap.continuous_eval_const 0
+
+@[simps!]
+protected def id {s : Set R} [Zero s] (h0 : ((0 : s) : R) = 0) : C(s, R)₀ :=
+  ⟨.restrict s (.id R), h0⟩
+
+@[simp]
+lemma toContinuousMap_id {s : Set R} [Zero s] (h0 : ((0 : s) : R) = 0) :
+    (ContinuousMapZero.id h0 : C(s, R)) = .restrict s (.id R) :=
+  rfl
 
 end Basic
 
@@ -135,10 +148,18 @@ instance instSMulCommClass {M N : Type*} [SMulZeroClass M R] [ContinuousConstSMu
     SMulCommClass M N C(X, R)₀ where
   smul_comm _ _ _ := ext fun _ ↦ smul_comm ..
 
+instance instSMulCommClass' {M : Type*} [SMulZeroClass M R] [SMulCommClass M R R]
+    [ContinuousConstSMul M R] : SMulCommClass M C(X, R)₀ C(X, R)₀ where
+  smul_comm m f g := ext fun x ↦ smul_comm m (f x) (g x)
+
 instance instIsScalarTower {M N : Type*} [SMulZeroClass M R] [ContinuousConstSMul M R]
     [SMulZeroClass N R] [ContinuousConstSMul N R] [SMul M N] [IsScalarTower M N R] :
     IsScalarTower M N C(X, R)₀ where
   smul_assoc _ _ _ := ext fun _ ↦ smul_assoc ..
+
+instance instIsScalarTower' {M : Type*} [SMulZeroClass M R] [IsScalarTower M R R]
+    [ContinuousConstSMul M R] : IsScalarTower M C(X, R)₀ C(X, R)₀ where
+  smul_assoc m f g := ext fun x ↦ smul_assoc m (f x) (g x)
 
 instance instStarRing [StarRing R] [ContinuousStar R] : StarRing C(X, R)₀ where
   star f := ⟨star f, by simp⟩
@@ -146,10 +167,27 @@ instance instStarRing [StarRing R] [ContinuousStar R] : StarRing C(X, R)₀ wher
   star_mul _ _ := ext fun _ ↦ star_mul ..
   star_add _ _ := ext fun _ ↦ star_add ..
 
+instance instStarModule [StarRing R] {M : Type*} [SMulZeroClass M R] [ContinuousConstSMul M R]
+    [Star M] [StarModule M R] [ContinuousStar R] : StarModule M C(X, R)₀ where
+  star_smul r f := ext fun x ↦ star_smul r (f x)
+
 @[simp] lemma coe_star [StarRing R] [ContinuousStar R] (f : C(X, R)₀) : ⇑(star f) = star ⇑f := rfl
 
 instance instCanLift : CanLift C(X, R) C(X, R)₀ (↑) (fun f ↦ f 0 = 0) where
   prf f hf := ⟨⟨f, hf⟩, rfl⟩
+
+@[simps]
+def toContinuousMapHom [StarRing R] [ContinuousStar R] : C(X, R)₀ →⋆ₙₐ[R] C(X, R) where
+  toFun f := f
+  map_smul' _ _ := rfl
+  map_zero' := rfl
+  map_add' _ _ := rfl
+  map_mul' _ _ := rfl
+  map_star' _ := rfl
+
+lemma coe_toContinuousMapHom [StarRing R] [ContinuousStar R] :
+    ⇑(toContinuousMapHom (X := X) (R := R)) = (↑) :=
+  rfl
 
 end Semiring
 
@@ -168,6 +206,14 @@ instance instNonUnitalCommRing : NonUnitalCommRing C(X, R)₀ :=
   toContinuousMap_injective.nonUnitalCommRing _ rfl
   (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
+@[simp]
+lemma coe_neg (f : C(X, R)₀) : ⇑(-f) = -⇑f := rfl
+
+instance : ContinuousNeg C(X, R)₀ where
+  continuous_neg := by
+    rw [continuous_induced_rng]
+    exact continuous_neg.comp continuous_induced_dom
+
 end Ring
 
 end Algebra
@@ -180,7 +226,7 @@ variable [Zero R] [UniformSpace R]
 protected instance instUniformSpace : UniformSpace C(X, R)₀ := .comap toContinuousMap inferInstance
 
 lemma uniformEmbedding_toContinuousMap :
-    UniformEmbedding (toContinuousMap (X := X) (R := R)) where
+    UniformEmbedding ((↑) : C(X, R)₀ → C(X, R)) where
   comap_uniformity := rfl
   inj _ _ h := ext fun x ↦ congr($(h) x)
 
@@ -188,6 +234,56 @@ instance [T1Space R] [CompleteSpace C(X, R)] : CompleteSpace C(X, R)₀ :=
   completeSpace_iff_isComplete_range uniformEmbedding_toContinuousMap.toUniformInducing
     |>.mpr closedEmbedding_toContinuousMap.isClosed_range.isComplete
 
+lemma uniformEmbedding_comp {Y : Type*} [UniformSpace Y] [Zero Y] (g : C(Y, R)₀)
+    (hg : UniformEmbedding g) : UniformEmbedding (g.comp · : C(X, Y)₀ → C(X, R)₀) :=
+  uniformEmbedding_toContinuousMap.of_comp_iff.mp <|
+    ContinuousMap.uniformEmbedding_comp g.toContinuousMap hg |>.comp
+      uniformEmbedding_toContinuousMap
+
+def _root_.UniformEquiv.arrowCongrLeft₀ {Y : Type*} [TopologicalSpace Y] [Zero Y] (f : X ≃ₜ Y)
+    (hf : f 0 = 0) : C(X, R)₀ ≃ᵤ C(Y, R)₀ where
+  toFun g := g.comp ⟨f.symm.toContinuousMap, (f.toEquiv.apply_eq_iff_eq_symm_apply.eq ▸ hf).symm⟩
+  invFun g := g.comp ⟨f.toContinuousMap, hf⟩
+  left_inv g := ext fun _ ↦ congrArg g <| f.left_inv _
+  right_inv g := ext fun _ ↦ congrArg g <| f.right_inv _
+  uniformContinuous_toFun := uniformEmbedding_toContinuousMap.uniformContinuous_iff.mpr <|
+    ContinuousMap.uniformContinuous_comp_left f.symm.toContinuousMap |>.comp
+    uniformEmbedding_toContinuousMap.uniformContinuous
+  uniformContinuous_invFun := uniformEmbedding_toContinuousMap.uniformContinuous_iff.mpr <|
+    ContinuousMap.uniformContinuous_comp_left f.toContinuousMap |>.comp
+    uniformEmbedding_toContinuousMap.uniformContinuous
+
 end UniformSpace
+
+section CompHoms
+
+variable {X Y M R S : Type*} [Zero X] [Zero Y] [CommSemiring M]
+  [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace R] [TopologicalSpace S]
+  [CommSemiring R] [StarRing R] [TopologicalSemiring R] [ContinuousStar R]
+  [CommSemiring S] [StarRing S] [TopologicalSemiring S] [ContinuousStar S]
+  [Module M R] [Module M S] [ContinuousConstSMul M R] [ContinuousConstSMul M S]
+
+variable (R) in
+@[simps]
+def nonUnitalStarAlgHom_precomp (f : C(X, Y)₀) : C(Y, R)₀ →⋆ₙₐ[R] C(X, R)₀ where
+  toFun g := g.comp f
+  map_zero' := rfl
+  map_add' _ _ := rfl
+  map_mul' _ _ := rfl
+  map_star' _ := rfl
+  map_smul' _ _ := rfl
+
+variable (X) in
+@[simps apply]
+def nonUnitalStarAlgHom_postcomp (φ : R →⋆ₙₐ[M] S) (hφ : Continuous φ) :
+    C(X, R)₀ →⋆ₙₐ[M] C(X, S)₀ where
+  toFun := .comp ⟨⟨φ, hφ⟩, by simp⟩
+  map_zero' := ext <| by simp
+  map_add' _ _ := ext <| by simp
+  map_mul' _ _ := ext <| by simp
+  map_star' _ := ext <| by simp [map_star]
+  map_smul' r f := ext <| by simp
+
+end CompHoms
 
 end ContinuousMapZero

--- a/Mathlib/Topology/ContinuousFunction/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousFunction/ContinuousMapZero.lean
@@ -92,7 +92,7 @@ lemma closedEmbedding_toContinuousMap [T1Space R] :
     rw [range_toContinuousMap]
     exact isClosed_singleton.preimage <| ContinuousMap.continuous_eval_const 0
 
-/-- The identity function as an element of `C(s, R)` when `0 ∈ (s : Set R)`. -/
+/-- The identity function as an element of `C(s, R)₀` when `0 ∈ (s : Set R)`. -/
 @[simps!]
 protected def id {s : Set R} [Zero s] (h0 : ((0 : s) : R) = 0) : C(s, R)₀ :=
   ⟨.restrict s (.id R), h0⟩

--- a/Mathlib/Topology/ContinuousFunction/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousFunction/ContinuousMapZero.lean
@@ -92,6 +92,7 @@ lemma closedEmbedding_toContinuousMap [T1Space R] :
     rw [range_toContinuousMap]
     exact isClosed_singleton.preimage <| ContinuousMap.continuous_eval_const 0
 
+/-- The identity function as an element of `C(s, R)` when `0 ∈ (s : Set R)`. -/
 @[simps!]
 protected def id {s : Set R} [Zero s] (h0 : ((0 : s) : R) = 0) : C(s, R)₀ :=
   ⟨.restrict s (.id R), h0⟩
@@ -176,6 +177,7 @@ instance instStarModule [StarRing R] {M : Type*} [SMulZeroClass M R] [Continuous
 instance instCanLift : CanLift C(X, R) C(X, R)₀ (↑) (fun f ↦ f 0 = 0) where
   prf f hf := ⟨⟨f, hf⟩, rfl⟩
 
+/-- The coercion `C(X, R)₀ → C(X, R)` bundled as a non-unital star algebra homomorphism. -/
 @[simps]
 def toContinuousMapHom [StarRing R] [ContinuousStar R] : C(X, R)₀ →⋆ₙₐ[R] C(X, R) where
   toFun f := f
@@ -240,6 +242,8 @@ lemma uniformEmbedding_comp {Y : Type*} [UniformSpace Y] [Zero Y] (g : C(Y, R)�
     ContinuousMap.uniformEmbedding_comp g.toContinuousMap hg |>.comp
       uniformEmbedding_toContinuousMap
 
+/-- The uniform equivalence `C(X, R)₀ ≃ᵤ C(Y, R)₀` induced by a homeomorphism of the domains
+sending `0 : X` to `0 : Y`. -/
 def _root_.UniformEquiv.arrowCongrLeft₀ {Y : Type*} [TopologicalSpace Y] [Zero Y] (f : X ≃ₜ Y)
     (hf : f 0 = 0) : C(X, R)₀ ≃ᵤ C(Y, R)₀ where
   toFun g := g.comp ⟨f.symm.toContinuousMap, (f.toEquiv.apply_eq_iff_eq_symm_apply.eq ▸ hf).symm⟩
@@ -264,6 +268,8 @@ variable {X Y M R S : Type*} [Zero X] [Zero Y] [CommSemiring M]
   [Module M R] [Module M S] [ContinuousConstSMul M R] [ContinuousConstSMul M S]
 
 variable (R) in
+/-- The functor `C(·, R)₀` from topological spaces with zero (and `ContinuousMapZero` maps) to
+non-unital star algebras. -/
 @[simps]
 def nonUnitalStarAlgHom_precomp (f : C(X, Y)₀) : C(Y, R)₀ →⋆ₙₐ[R] C(X, R)₀ where
   toFun g := g.comp f
@@ -274,6 +280,8 @@ def nonUnitalStarAlgHom_precomp (f : C(X, Y)₀) : C(Y, R)₀ →⋆ₙₐ[R] C(
   map_smul' _ _ := rfl
 
 variable (X) in
+/-- The functor `C(X, ·)₀` from non-unital topological star algebras (with non-unital continuous
+star homomorphisms) to non-unital star algebras. -/
 @[simps apply]
 def nonUnitalStarAlgHom_postcomp (φ : R →⋆ₙₐ[M] S) (hφ : Continuous φ) :
     C(X, R)₀ →⋆ₙₐ[M] C(X, S)₀ where


### PR DESCRIPTION
This adds all the remaining material necessary for `ContinuousMapZero` to get the instances of the non-unital continuous functional calculus.

Co-authored-by: @adedecker

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
