### PR TITLE
[Merged by Bors] - chore(Combinatorics/Additive/PluenneckeRuzsa): Use semantic lemma names

### DIFF
--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -19,10 +19,10 @@ inequality.
 
 ## Main declarations
 
-* `Finset.card_sub_mul_le_card_sub_mul_card_sub`: Ruzsa's triangle inequality, difference version.
-* `Finset.card_add_mul_le_card_add_mul_card_add`: Ruzsa's triangle inequality, sum version.
-* `Finset.pluennecke_petridis`: The Plünnecke-Petridis lemma.
-* `Finset.card_smul_div_smul_le`: The Plünnecke-Ruzsa inequality.
+* `Finset.ruzsa_triangle_inequality_sub_sub_sub`: The Ruzsa triangle inequality, difference version.
+* `Finset.ruzsa_triangle_inequality_add_add_add`: The Ruzsa triangle inequality, sum version.
+* `Finset.pluennecke_petridis_inequality_add`: The Plünnecke-Petridis inequality.
+* `Finset.pluennecke_ruzsa_inequality_nsmul_sub_nsmul_add`: The Plünnecke-Ruzsa inequality.
 
 ## References
 
@@ -30,19 +30,15 @@ inequality.
 * [Terrence Tao, Van Vu, *Additive Combinatorics][tao-vu]
 -/
 
-
 open Nat
-
-open NNRat Pointwise
-
+open scoped Pointwise
 namespace Finset
 
 variable {α : Type*} [CommGroup α] [DecidableEq α] {A B C : Finset α}
 
 /-- **Ruzsa's triangle inequality**. Division version. -/
-@[to_additive card_sub_mul_le_card_sub_mul_card_sub
-"**Ruzsa's triangle inequality**. Subtraction version."]
-theorem card_div_mul_le_card_div_mul_card_div (A B C : Finset α) :
+@[to_additive "**Ruzsa's triangle inequality**. Subtraction version."]
+theorem ruzsa_triangle_inequality_div_div_div (A B C : Finset α) :
     (A / C).card * B.card ≤ (A / B).card * (B / C).card := by
   rw [← card_product (A / B), ← mul_one ((A / B) ×ˢ (B / C)).card]
   refine card_mul_le_card_mul (fun b ac ↦ ac.1 * ac.2 = b) (fun x hx ↦ ?_)
@@ -54,42 +50,39 @@ theorem card_div_mul_le_card_div_mul_card_div (A B C : Finset α) :
     exact ⟨mk_mem_product (div_mem_div ha hb) (div_mem_div hb hc), div_mul_div_cancel' _ _ _⟩
   · exact div_right_injective (Prod.ext_iff.1 h).1
   · exact ((mem_bipartiteBelow _).1 hv).2
-#align finset.card_div_mul_le_card_div_mul_card_div Finset.card_div_mul_le_card_div_mul_card_div
-#align finset.card_sub_mul_le_card_sub_mul_card_sub Finset.card_sub_mul_le_card_sub_mul_card_sub
+#align finset.card_div_mul_le_card_div_mul_card_div Finset.ruzsa_triangle_inequality_div_div_div
+#align finset.card_sub_mul_le_card_sub_mul_card_sub Finset.ruzsa_triangle_inequality_sub_sub_sub
 
 /-- **Ruzsa's triangle inequality**. Div-mul-mul version. -/
-@[to_additive card_sub_mul_le_card_add_mul_card_add
-"**Ruzsa's triangle inequality**. Sub-add-add version."]
-theorem card_div_mul_le_card_mul_mul_card_mul (A B C : Finset α) :
+@[to_additive "**Ruzsa's triangle inequality**. Sub-add-add version."]
+theorem ruzsa_triangle_inequality_div_mul_mul (A B C : Finset α) :
     (A / C).card * B.card ≤ (A * B).card * (B * C).card := by
   rw [← div_inv_eq_mul, ← card_inv B, ← card_inv (B * C), mul_inv, ← div_eq_mul_inv]
-  exact card_div_mul_le_card_div_mul_card_div _ _ _
-#align finset.card_div_mul_le_card_mul_mul_card_mul Finset.card_div_mul_le_card_mul_mul_card_mul
-#align finset.card_sub_mul_le_card_add_mul_card_add Finset.card_sub_mul_le_card_add_mul_card_add
+  exact ruzsa_triangle_inequality_div_div_div _ _ _
+#align finset.card_div_mul_le_card_mul_mul_card_mul Finset.ruzsa_triangle_inequality_div_mul_mul
+#align finset.card_sub_mul_le_card_add_mul_card_add Finset.ruzsa_triangle_inequality_sub_add_add
 
-/-- **Ruzsa's triangle inequality**. Mul-div-div version. -/
-@[to_additive card_add_mul_le_card_sub_mul_card_add
-"**Ruzsa's triangle inequality**. Add-sub-sub version."]
-theorem card_mul_mul_le_card_div_mul_card_mul (A B C : Finset α) :
+/-- **Ruzsa's triangle inequality**. Mul-div-mul version. -/
+@[to_additive "**Ruzsa's triangle inequality**. Add-sub-add version."]
+theorem ruzsa_triangle_inequality_mul_div_mul (A B C : Finset α) :
     (A * C).card * B.card ≤ (A / B).card * (B * C).card := by
   rw [← div_inv_eq_mul, ← div_inv_eq_mul B]
-  exact card_div_mul_le_card_div_mul_card_div _ _ _
-#align finset.card_mul_mul_le_card_div_mul_card_mul Finset.card_mul_mul_le_card_div_mul_card_mul
-#align finset.card_add_mul_le_card_sub_mul_card_add Finset.card_add_mul_le_card_sub_mul_card_add
+  exact ruzsa_triangle_inequality_div_div_div _ _ _
+#align finset.card_mul_mul_le_card_div_mul_card_mul Finset.ruzsa_triangle_inequality_mul_div_mul
+#align finset.card_add_mul_le_card_sub_mul_card_add Finset.ruzsa_triangle_inequality_add_sub_add
 
 /-- **Ruzsa's triangle inequality**. Mul-mul-div version. -/
-@[to_additive card_add_mul_le_card_add_mul_card_sub
-"**Ruzsa's triangle inequality**. Add-add-sub version."]
-theorem card_mul_mul_le_card_mul_mul_card_div (A B C : Finset α) :
+@[to_additive "**Ruzsa's triangle inequality**. Add-add-sub version."]
+theorem ruzsa_triangle_inequality_mul_mul_div (A B C : Finset α) :
     (A * C).card * B.card ≤ (A * B).card * (B / C).card := by
   rw [← div_inv_eq_mul, div_eq_mul_inv B]
-  exact card_div_mul_le_card_mul_mul_card_mul _ _ _
-#align finset.card_mul_mul_le_card_mul_mul_card_div Finset.card_mul_mul_le_card_mul_mul_card_div
-#align finset.card_add_mul_le_card_add_mul_card_sub Finset.card_add_mul_le_card_add_mul_card_sub
+  exact ruzsa_triangle_inequality_div_mul_mul _ _ _
+#align finset.card_mul_mul_le_card_mul_mul_card_div Finset.ruzsa_triangle_inequality_mul_mul_div
+#align finset.card_add_mul_le_card_add_mul_card_sub Finset.ruzsa_triangle_inequality_add_add_sub
 
 set_option backward.isDefEq.lazyWhnfCore false in -- See https://github.com/leanprover-community/mathlib4/issues/12534
 @[to_additive]
-theorem mul_pluennecke_petridis (C : Finset α)
+theorem pluennecke_petridis_inequality_mul (C : Finset α)
     (hA : ∀ A' ⊆ A, (A * B).card * A'.card ≤ (A' * B).card * A.card) :
     (A * B * C).card * A.card ≤ (A * B).card * (A * C).card := by
   induction' C using Finset.induction_on with x C _ ih
@@ -116,8 +109,8 @@ theorem mul_pluennecke_petridis (C : Finset α)
   rw [← mul_add, ← mul_tsub, ← hA', hC', insert_eq, mul_union, ← card_mul_singleton A x, ←
     card_mul_singleton A' x, add_comm (card _), h₀,
     eq_tsub_of_add_eq (card_union_add_card_inter _ _)]
-#align finset.mul_pluennecke_petridis Finset.mul_pluennecke_petridis
-#align finset.add_pluennecke_petridis Finset.add_pluennecke_petridis
+#align finset.mul_pluennecke_petridis Finset.pluennecke_petridis_inequality_mul
+#align finset.add_pluennecke_petridis Finset.pluennecke_petridis_inequality_add
 
 /-! ### Sum triangle inequality -/
 
@@ -137,9 +130,8 @@ private theorem mul_aux (hA : A.Nonempty) (hAB : A ⊆ B)
       (h _ <| mem_erase_of_ne_of_mem hA'.ne_empty <| mem_powerset.2 <| hAA'.trans hAB)
 
 /-- **Ruzsa's triangle inequality**. Multiplication version. -/
-@[to_additive card_add_mul_card_le_card_add_mul_card_add
-"**Ruzsa's triangle inequality**. Addition version."]
-theorem card_mul_mul_card_le_card_mul_mul_card_mul (A B C : Finset α) :
+@[to_additive "**Ruzsa's triangle inequality**. Addition version."]
+theorem ruzsa_triangle_inequality_mul_mul_mul (A B C : Finset α) :
     (A * C).card * B.card ≤ (A * B).card * (B * C).card := by
   obtain rfl | hB := B.eq_empty_or_nonempty
   · simp
@@ -157,55 +149,37 @@ theorem card_mul_mul_card_le_card_mul_mul_card_mul (A B C : Finset α) :
       (zero_le _) (zero_le _))
   rw [← mul_div_right_comm, ← mul_assoc]
   refine (le_div_iff <| cast_pos.2 hU.1.card_pos).2 ?_
-  exact mod_cast mul_pluennecke_petridis C (mul_aux hU.1 hU.2 hUA)
-#align finset.card_mul_mul_card_le_card_mul_mul_card_mul Finset.card_mul_mul_card_le_card_mul_mul_card_mul
-#align finset.card_add_mul_card_le_card_add_mul_card_add Finset.card_add_mul_card_le_card_add_mul_card_add
+  exact mod_cast pluennecke_petridis_inequality_mul C (mul_aux hU.1 hU.2 hUA)
+#align finset.card_mul_mul_card_le_card_mul_mul_card_mul Finset.ruzsa_triangle_inequality_mul_mul_mul
+#align finset.card_add_mul_card_le_card_add_mul_card_add Finset.ruzsa_triangle_inequality_add_add_add
 
 /-- **Ruzsa's triangle inequality**. Mul-div-div version. -/
-@[to_additive card_add_mul_le_card_sub_mul_card_sub
-"**Ruzsa's triangle inequality**. Add-sub-sub version."]
-theorem card_mul_mul_le_card_div_mul_card_div (A B C : Finset α) :
+@[to_additive "**Ruzsa's triangle inequality**. Add-sub-sub version."]
+theorem ruzsa_triangle_inequality_mul_div_div (A B C : Finset α) :
     (A * C).card * B.card ≤ (A / B).card * (B / C).card := by
   rw [div_eq_mul_inv, ← card_inv B, ← card_inv (B / C), inv_div', div_inv_eq_mul]
-  exact card_mul_mul_card_le_card_mul_mul_card_mul _ _ _
-#align finset.card_mul_mul_le_card_div_mul_card_div Finset.card_mul_mul_le_card_div_mul_card_div
+  exact ruzsa_triangle_inequality_mul_mul_mul _ _ _
+#align finset.card_mul_mul_le_card_div_mul_card_div Finset.ruzsa_triangle_inequality_mul_div_div
 
 /-- **Ruzsa's triangle inequality**. Div-mul-div version. -/
-@[to_additive card_sub_mul_le_card_add_mul_card_sub
-"**Ruzsa's triangle inequality**. Sub-add-sub version."]
-theorem card_div_mul_le_card_mul_mul_card_div (A B C : Finset α) :
+@[to_additive "**Ruzsa's triangle inequality**. Sub-add-sub version."]
+theorem ruzsa_triangle_inequality_div_mul_div (A B C : Finset α) :
     (A / C).card * B.card ≤ (A * B).card * (B / C).card := by
   rw [div_eq_mul_inv, div_eq_mul_inv]
-  exact card_mul_mul_card_le_card_mul_mul_card_mul _ _ _
-#align finset.card_div_mul_le_card_mul_mul_card_div Finset.card_div_mul_le_card_mul_mul_card_div
+  exact ruzsa_triangle_inequality_mul_mul_mul _ _ _
+#align finset.card_div_mul_le_card_mul_mul_card_div Finset.ruzsa_triangle_inequality_div_mul_div
 
 /-- **Ruzsa's triangle inequality**. Div-div-mul version. -/
-@[to_additive card_sub_mul_le_card_sub_mul_card_add
-"**Ruzsa's triangle inequality**. Sub-sub-add version."]
+@[to_additive "**Ruzsa's triangle inequality**. Sub-sub-add version."]
 theorem card_div_mul_le_card_div_mul_card_mul (A B C : Finset α) :
     (A / C).card * B.card ≤ (A / B).card * (B * C).card := by
   rw [← div_inv_eq_mul, div_eq_mul_inv]
-  exact card_mul_mul_le_card_div_mul_card_div _ _ _
+  exact ruzsa_triangle_inequality_mul_div_div _ _ _
 #align finset.card_div_mul_le_card_div_mul_card_mul Finset.card_div_mul_le_card_div_mul_card_mul
 
-theorem card_add_nsmul_le {α : Type*} [AddCommGroup α] [DecidableEq α] {A B : Finset α}
-    (hAB : ∀ A' ⊆ A, (A + B).card * A'.card ≤ (A' + B).card * A.card) (n : ℕ) :
-    (A + n • B).card ≤ ((A + B).card / A.card : ℚ≥0) ^ n * A.card := by
-  obtain rfl | hA := A.eq_empty_or_nonempty
-  · simp
-  induction' n with n ih
-  · simp
-  rw [succ_nsmul', ← add_assoc, _root_.pow_succ', mul_assoc, ← mul_div_right_comm, le_div_iff,
-    ← cast_mul]
-  swap
-  · exact cast_pos.2 hA.card_pos
-  refine (Nat.cast_le.2 <| add_pluennecke_petridis _ hAB).trans ?_
-  rw [cast_mul]
-  gcongr
-#align finset.card_add_nsmul_le Finset.card_add_nsmul_le
-
-@[to_additive existing]
-theorem card_mul_pow_le (hAB : ∀ A' ⊆ A, (A * B).card * A'.card ≤ (A' * B).card * A.card)
+-- Auxiliary lemma towards the Plünnecke-Ruzsa inequality
+@[to_additive]
+private lemma card_mul_pow_le (hAB : ∀ A' ⊆ A, (A * B).card * A'.card ≤ (A' * B).card * A.card)
     (n : ℕ) : (A * B ^ n).card ≤ ((A * B).card / A.card : ℚ≥0) ^ n * A.card := by
   obtain rfl | hA := A.eq_empty_or_nonempty
   · simp
@@ -215,16 +189,17 @@ theorem card_mul_pow_le (hAB : ∀ A' ⊆ A, (A * B).card * A'.card ≤ (A' * B)
     le_div_iff, ← cast_mul]
   swap
   · exact cast_pos.2 hA.card_pos
-  refine (Nat.cast_le.2 <| mul_pluennecke_petridis _ hAB).trans ?_
+  refine (Nat.cast_le.2 <| pluennecke_petridis_inequality_mul _ hAB).trans ?_
   rw [cast_mul]
   gcongr
-#align finset.card_mul_pow_le Finset.card_mul_pow_le
+#noalign finset.card_mul_pow_le
+#noalign finset.card_add_nsmul_le
 
 /-- The **Plünnecke-Ruzsa inequality**. Multiplication version. Note that this is genuinely harder
 than the division version because we cannot use a double counting argument. -/
 @[to_additive "The **Plünnecke-Ruzsa inequality**. Addition version. Note that this is genuinely
 harder than the subtraction version because we cannot use a double counting argument."]
-theorem card_pow_div_pow_le (hA : A.Nonempty) (B : Finset α) (m n : ℕ) :
+theorem pluennecke_ruzsa_inequality_pow_div_pow_mul (hA : A.Nonempty) (B : Finset α) (m n : ℕ) :
     ((B ^ m / B ^ n).card) ≤ ((A * B).card / A.card : ℚ≥0) ^ (m + n) * A.card := by
   have hA' : A ∈ A.powerset.erase ∅ := mem_erase_of_ne_of_mem hA.ne_empty (mem_powerset_self _)
   obtain ⟨C, hC, hCA⟩ :=
@@ -232,7 +207,7 @@ theorem card_pow_div_pow_le (hA : A.Nonempty) (B : Finset α) (m n : ℕ) :
   rw [mem_erase, mem_powerset, ← nonempty_iff_ne_empty] at hC
   refine (mul_le_mul_right <| cast_pos.2 hC.1.card_pos).1 ?_
   norm_cast
-  refine (Nat.cast_le.2 <| card_div_mul_le_card_mul_mul_card_mul _ _ _).trans ?_
+  refine (Nat.cast_le.2 <| ruzsa_triangle_inequality_div_mul_mul _ _ _).trans ?_
   push_cast
   rw [mul_comm _ C]
   refine (mul_le_mul (card_mul_pow_le (mul_aux hC.1 hC.2 hCA) _)
@@ -241,32 +216,32 @@ theorem card_pow_div_pow_le (hA : A.Nonempty) (B : Finset α) (m n : ℕ) :
   gcongr ((?_ ^ _) * Nat.cast ?_) * _
   · exact hCA _ hA'
   · exact card_le_card hC.2
-#align finset.card_pow_div_pow_le Finset.card_pow_div_pow_le
-#align finset.card_nsmul_sub_nsmul_le Finset.card_nsmul_sub_nsmul_le
+#align finset.card_pow_div_pow_le Finset.pluennecke_ruzsa_inequality_pow_div_pow_mul
+#align finset.card_nsmul_sub_nsmul_le Finset.pluennecke_ruzsa_inequality_nsmul_sub_nsmul_add
 
-/-- The **Plünnecke-Ruzsa inequality**. Subtraction version. -/
+/-- The **Plünnecke-Ruzsa inequality**. Division version. -/
 @[to_additive "The **Plünnecke-Ruzsa inequality**. Subtraction version."]
-theorem card_pow_div_pow_le' (hA : A.Nonempty) (B : Finset α) (m n : ℕ) :
+theorem pluennecke_ruzsa_inequality_pow_div_pow_div (hA : A.Nonempty) (B : Finset α) (m n : ℕ) :
     (B ^ m / B ^ n).card ≤ ((A / B).card / A.card : ℚ≥0) ^ (m + n) * A.card := by
   rw [← card_inv, inv_div', ← inv_pow, ← inv_pow, div_eq_mul_inv A]
-  exact card_pow_div_pow_le hA _ _ _
-#align finset.card_pow_div_pow_le' Finset.card_pow_div_pow_le'
-#align finset.card_nsmul_sub_nsmul_le' Finset.card_nsmul_sub_nsmul_le'
+  exact pluennecke_ruzsa_inequality_pow_div_pow_mul hA _ _ _
+#align finset.card_pow_div_pow_le' Finset.pluennecke_ruzsa_inequality_pow_div_pow_div
+#align finset.card_nsmul_sub_nsmul_le' Finset.pluennecke_ruzsa_inequality_nsmul_sub_nsmul_sub
 
 /-- Special case of the **Plünnecke-Ruzsa inequality**. Multiplication version. -/
 @[to_additive "Special case of the **Plünnecke-Ruzsa inequality**. Addition version."]
-theorem card_pow_le (hA : A.Nonempty) (B : Finset α) (n : ℕ) :
+theorem pluennecke_ruzsa_inequality_pow_mul (hA : A.Nonempty) (B : Finset α) (n : ℕ) :
     (B ^ n).card ≤ ((A * B).card / A.card : ℚ≥0) ^ n * A.card := by
-  simpa only [_root_.pow_zero, div_one] using card_pow_div_pow_le hA _ _ 0
-#align finset.card_pow_le Finset.card_pow_le
-#align finset.card_nsmul_le Finset.card_nsmul_le
+  simpa only [_root_.pow_zero, div_one] using pluennecke_ruzsa_inequality_pow_div_pow_mul hA _ _ 0
+#align finset.card_pow_le Finset.pluennecke_ruzsa_inequality_pow_mul
+#align finset.card_nsmul_le Finset.pluennecke_ruzsa_inequality_nsmul_add
 
 /-- Special case of the **Plünnecke-Ruzsa inequality**. Division version. -/
 @[to_additive "Special case of the **Plünnecke-Ruzsa inequality**. Subtraction version."]
-theorem card_pow_le' (hA : A.Nonempty) (B : Finset α) (n : ℕ) :
+theorem pluennecke_ruzsa_inequality_pow_div (hA : A.Nonempty) (B : Finset α) (n : ℕ) :
     (B ^ n).card ≤ ((A / B).card / A.card : ℚ≥0) ^ n * A.card := by
-  simpa only [_root_.pow_zero, div_one] using card_pow_div_pow_le' hA _ _ 0
-#align finset.card_pow_le' Finset.card_pow_le'
-#align finset.card_nsmul_le' Finset.card_nsmul_le'
+  simpa only [_root_.pow_zero, div_one] using pluennecke_ruzsa_inequality_pow_div_pow_div hA _ _ 0
+#align finset.card_pow_le' Finset.pluennecke_ruzsa_inequality_pow_div
+#align finset.card_nsmul_le' Finset.pluennecke_ruzsa_inequality_nsmul_sub
 
 end Finset


### PR DESCRIPTION
I, as the main author of those theorems, can never remember their names. Symbol-reading as a naming convention fails here because there are too many symbols to mention to
* distinguish the series of results from other results in Mathlib
* distinguish the different results within that series

Using semantic names solves both issues quite nicely.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
