### PR TITLE
[Merged by Bors] - chore: shorten a proof in MeasureTheory.Function.AEEqOfIntegral

### DIFF
--- a/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
@@ -265,19 +265,7 @@ theorem ae_nonneg_of_forall_setIntegral_nonneg_of_stronglyMeasurable (hfm : Stro
   intro b hb_neg
   let s := {x | f x ≤ b}
   have hs : MeasurableSet s := hfm.measurableSet_le stronglyMeasurable_const
-  have mus : μ s < ∞ := by
-    let c : ℝ≥0 := ⟨|b|, abs_nonneg _⟩
-    have c_pos : (c : ℝ≥0∞) ≠ 0 := by simpa [c, ← NNReal.coe_eq_zero] using hb_neg.ne
-    calc
-      μ s ≤ μ {x | (c : ℝ≥0∞) ≤ ‖f x‖₊} := by
-        apply measure_mono
-        intro x hx
-        simp only [s, Set.mem_setOf_eq] at hx
-        simpa only [c, nnnorm, abs_of_neg hb_neg, abs_of_neg (hx.trans_lt hb_neg), Real.norm_eq_abs,
-          Subtype.mk_le_mk, neg_le_neg_iff, Set.mem_setOf_eq, ENNReal.coe_le_coe, NNReal] using hx
-      _ ≤ (∫⁻ x, ‖f x‖₊ ∂μ) / c :=
-        (meas_ge_le_lintegral_div hfm.aemeasurable.ennnorm c_pos ENNReal.coe_ne_top)
-      _ < ∞ := ENNReal.div_lt_top (ne_of_lt hf.2) c_pos
+  have mus : μ s < ∞ := Integrable.measure_le_lt_top hf hb_neg
   have h_int_gt : (∫ x in s, f x ∂μ) ≤ b * (μ s).toReal := by
     have h_const_le : (∫ x in s, f x ∂μ) ≤ ∫ _ in s, b ∂μ := by
       refine


### PR DESCRIPTION
Replaces 13 lines of proof with a single invocation of `Integrable.measure_le_lt_top`,
making the proof speed up from 0.23 seconds to 0.12 seconds.

Found by [tryAtEachStep](https://github.com/dwrensha/tryAtEachStep).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
