### PR TITLE
[Merged by Bors] - chore: shorten proof of Setoid.mkClasses.iseqv.trans

### DIFF
--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -52,12 +52,7 @@ def mkClasses (c : Set (Set α)) (H : ∀ a, ∃! b ∈ c, a ∈ b) : Setoid α 
   iseqv.symm := fun {x _y} h s hs hy => by
     obtain ⟨t, ⟨ht, hx⟩, _⟩ := H x
     rwa [eq_of_mem_eqv_class H hs hy ht (h t ht hx)]
-  iseqv.trans := fun {_x y z} h1 h2 s hs hx => by
-    obtain ⟨t, ⟨ht, hy⟩, _⟩ := H y
-    obtain ⟨t', ⟨ht', hy'⟩, _⟩ := H z
-    have hst : s = t := eq_of_mem_eqv_class H hs (h1 _ hs hx) ht hy
-    have htt' : t = t' := eq_of_mem_eqv_class H ht (h2 _ ht hy) ht' hy'
-    rwa [hst, htt']
+  iseqv.trans := fun {_x y z} h1 h2 s hs hx => h2 s hs (h1 s hs hx)
 #align setoid.mk_classes Setoid.mkClasses
 
 /-- Makes the equivalence classes of an equivalence relation. -/


### PR DESCRIPTION
Replaces 5 lines of tactic proof with a small direct term-mode proof.

Found by [tryAtEachStep](https://github.com/dwrensha/tryAtEachStep).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
