### PR TITLE
[Merged by Bors] - chore: deprecate Nat.div_mod_eq_mod_mul_div and Nat.mul_div_mul_comm_of_dvd_dvd

### DIFF
--- a/Mathlib/Algebra/Ring/Parity.lean
+++ b/Mathlib/Algebra/Ring/Parity.lean
@@ -335,7 +335,7 @@ lemma Odd.of_mul_right (h : Odd (m * n)) : Odd n :=
 #align nat.odd.of_mul_right Nat.Odd.of_mul_right
 
 lemma even_div : Even (m / n) ↔ m % (2 * n) / n = 0 := by
-  rw [even_iff_two_dvd, dvd_iff_mod_eq_zero, ←Nat.mod_mul_right_div_self, mul_comm]
+  rw [even_iff_two_dvd, dvd_iff_mod_eq_zero, ← Nat.mod_mul_right_div_self, mul_comm]
 #align nat.even_div Nat.even_div
 
 @[parity_simps] lemma odd_add : Odd (m + n) ↔ (Odd m ↔ Even n) := by

--- a/Mathlib/Algebra/Ring/Parity.lean
+++ b/Mathlib/Algebra/Ring/Parity.lean
@@ -335,7 +335,7 @@ lemma Odd.of_mul_right (h : Odd (m * n)) : Odd n :=
 #align nat.odd.of_mul_right Nat.Odd.of_mul_right
 
 lemma even_div : Even (m / n) ↔ m % (2 * n) / n = 0 := by
-  rw [even_iff_two_dvd, dvd_iff_mod_eq_zero, Nat.div_mod_eq_mod_mul_div, mul_comm]
+  rw [even_iff_two_dvd, dvd_iff_mod_eq_zero, ←Nat.mod_mul_right_div_self, mul_comm]
 #align nat.even_div Nat.even_div
 
 @[parity_simps] lemma odd_add : Odd (m + n) ↔ (Odd m ↔ Even n) := by

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -1072,6 +1072,7 @@ attribute [simp] Nat.dvd_zero
   cases' mod_two_eq_zero_or_one n with h h <;> simp [h]
 #align nat.mod_two_ne_zero Nat.mod_two_ne_zero
 
+@[deprecated mod_mul_right_div_self (since := "2024-05-29")]
 lemma div_mod_eq_mod_mul_div (a b c : ℕ) : a / b % c = a % (b * c) / b :=
   (mod_mul_right_div_self a b c).symm
 #align nat.div_mod_eq_mod_mul_div Nat.div_mod_eq_mod_mul_div
@@ -1111,6 +1112,7 @@ protected lemma div_ne_zero_iff (hb : b ≠ 0) : a / b ≠ 0 ↔ b ≤ a := by
 protected lemma div_pos_iff (hb : b ≠ 0) : 0 < a / b ↔ b ≤ a := by
   rw [Nat.pos_iff_ne_zero, Nat.div_ne_zero_iff hb]
 
+@[deprecated div_mul_div_comm (since := "2024-05-29")]
 lemma mul_div_mul_comm_of_dvd_dvd (hba : b ∣ a) (hdc : d ∣ c) :
     a * c / (b * d) = a / b * (c / d) :=
   (div_mul_div_comm hba hdc).symm

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -1072,14 +1072,8 @@ attribute [simp] Nat.dvd_zero
   cases' mod_two_eq_zero_or_one n with h h <;> simp [h]
 #align nat.mod_two_ne_zero Nat.mod_two_ne_zero
 
-lemma div_mod_eq_mod_mul_div (a b c : ℕ) : a / b % c = a % (b * c) / b := by
-  obtain rfl | hb := eq_or_ne b 0
-  · simp
-  · rw [← @Nat.add_left_inj _ _ (c * (a / b / c)), mod_add_div, Nat.div_div_eq_div_mul, ←
-      Nat.mul_right_inj hb, ← @Nat.add_right_inj _ _ (a % b), mod_add_div, Nat.mul_add, ←
-      @Nat.add_right_inj _ _ (a % (b * c) % b), Nat.add_left_comm,
-      ← Nat.add_assoc (a % (b * c) % b), mod_add_div, ← Nat.mul_assoc, mod_add_div,
-      mod_mul_right_mod]
+lemma div_mod_eq_mod_mul_div (a b c : ℕ) : a / b % c = a % (b * c) / b :=
+  (mod_mul_right_div_self a b c).symm
 #align nat.div_mod_eq_mod_mul_div Nat.div_mod_eq_mod_mul_div
 
 protected lemma lt_div_iff_mul_lt (hdn : d ∣ n) (a : ℕ) : a < n / d ↔ d * a < n := by
@@ -1118,13 +1112,8 @@ protected lemma div_pos_iff (hb : b ≠ 0) : 0 < a / b ↔ b ≤ a := by
   rw [Nat.pos_iff_ne_zero, Nat.div_ne_zero_iff hb]
 
 lemma mul_div_mul_comm_of_dvd_dvd (hba : b ∣ a) (hdc : d ∣ c) :
-    a * c / (b * d) = a / b * (c / d) := by
-  obtain rfl | hb := b.eq_zero_or_pos; · simp
-  obtain rfl | hd := d.eq_zero_or_pos; · simp
-  obtain ⟨_, rfl⟩ := hba
-  obtain ⟨_, rfl⟩ := hdc
-  rw [Nat.mul_mul_mul_comm, Nat.mul_div_cancel_left _ hb, Nat.mul_div_cancel_left _ hd,
-    Nat.mul_div_cancel_left _ (Nat.mul_pos hb hd)]
+    a * c / (b * d) = a / b * (c / d) :=
+  (div_mul_div_comm hba hdc).symm
 #align nat.mul_div_mul_comm_of_dvd_dvd Nat.mul_div_mul_comm_of_dvd_dvd
 
 @[simp] lemma mul_mod_mod (a b c : ℕ) : (a * (b % c)) % c = a * b % c := by

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -382,7 +382,7 @@ theorem ord_compl_mul (a b p : ℕ) : ord_compl[p] (a * b) = ord_compl[p] a * or
   if ha : a = 0 then simp [ha] else
   if hb : b = 0 then simp [hb] else
   simp only [ord_proj_mul p ha hb]
-  rw [mul_div_mul_comm_of_dvd_dvd (ord_proj_dvd a p) (ord_proj_dvd b p)]
+  rw [div_mul_div_comm (ord_proj_dvd a p) (ord_proj_dvd b p)]
 #align nat.ord_compl_mul Nat.ord_compl_mul
 
 /-! ### Factorization and divisibility -/


### PR DESCRIPTION
* `div_mod_eq_mod_mul_div` is a flipped version of [`mod_mul_right_div_self`](https://github.com/leanprover/lean4/blob/91334702431b8a7bf07f3f9e5696603de7b11fb6/src/Init/Data/Nat/Mod.lean#L50).
* `mul_div_mul_comm_of_dvd_dvd` is a flipped version of [`div_mul_div_comm`](https://github.com/leanprover-community/mathlib4/blob/b6cb80af68d53667dbbe8267f20ca075d5ffa953/Mathlib/Data/Nat/Defs.lean#L583).

These were found by [tryAtEachStep](https://github.com/dwrensha/tryAtEachStep).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
