### PR TITLE
[Merged by Bors] - chore: shorten proof of DecompositionMonoid.primal in GCDMonoid.Basic

### DIFF
--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -557,8 +557,7 @@ instance [h : Nonempty (GCDMonoid α)] : DecompositionMonoid α where
       simp
     · obtain ⟨a, ha⟩ := gcd_dvd_left k m
       refine ⟨gcd k m, a, gcd_dvd_right _ _, ?_, ha⟩
-      rw [← mul_dvd_mul_iff_left h0]
-      rw [← ha]
+      rw [← mul_dvd_mul_iff_left h0, ← ha]
       exact dvd_gcd_mul_of_dvd_mul H
 
 theorem gcd_mul_dvd_mul_gcd [GCDMonoid α] (k m n : α) : gcd k (m * n) ∣ gcd k m * gcd k n := by

--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -553,8 +553,7 @@ instance [h : Nonempty (GCDMonoid α)] : DecompositionMonoid α where
     by_cases h0 : gcd k m = 0
     · rw [gcd_eq_zero_iff] at h0
       rcases h0 with ⟨rfl, rfl⟩
-      refine ⟨0, n, dvd_refl 0, dvd_refl n, ?_⟩
-      simp
+      exact ⟨0, n, dvd_refl 0, dvd_refl n, by simp⟩
     · obtain ⟨a, ha⟩ := gcd_dvd_left k m
       refine ⟨gcd k m, a, gcd_dvd_right _ _, ?_, ha⟩
       rw [← mul_dvd_mul_iff_left h0, ← ha]

--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -553,15 +553,11 @@ instance [h : Nonempty (GCDMonoid α)] : DecompositionMonoid α where
     by_cases h0 : gcd k m = 0
     · rw [gcd_eq_zero_iff] at h0
       rcases h0 with ⟨rfl, rfl⟩
-      refine' ⟨0, n, dvd_refl 0, dvd_refl n, _⟩
+      refine ⟨0, n, dvd_refl 0, dvd_refl n, ?_⟩
       simp
     · obtain ⟨a, ha⟩ := gcd_dvd_left k m
-      refine' ⟨gcd k m, a, gcd_dvd_right _ _, _, ha⟩
-      suffices h : gcd k m * a ∣ gcd k m * n by
-        cases' h with b hb
-        use b
-        rw [mul_assoc] at hb
-        apply mul_left_cancel₀ h0 hb
+      refine ⟨gcd k m, a, gcd_dvd_right _ _, ?_, ha⟩
+      rw [← mul_dvd_mul_iff_left h0]
       rw [← ha]
       exact dvd_gcd_mul_of_dvd_mul H
 


### PR DESCRIPTION
* Replaces a 5-line `suffices` block with `rw [← mul_dvd_mul_iff_left h0]`. (Found by [tryAtEachStep](https://github.com/dwrensha/tryAtEachStep)).
* Updates two `refine'` usages to either `exact` or `refine`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
