### PR TITLE
CI test: nolint update workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,7 @@ jobs:
         with:
           linters: gcc
           run: |
-            bash -o pipefail -c "./scripts/update-style-exceptions.sh"
+            ./scripts/update-style-exceptions.sh
 
       - name: configure git setup
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,9 +201,10 @@ jobs:
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
       - name: lint mathlib and update style exceptions files
+        shell: bash
         run: |
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
-          bash -o pipefail -c "./scripts/update-style-exceptions.sh"
+          env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
+          ./scripts/update-style-exceptions.sh
 
       - name: configure git setup
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,7 @@ jobs:
         with:
           linters: gcc
           run: |
-            ./scripts/update-style-exceptions.sh
+            bash -o pipefail -c "./scripts/update-style-exceptions.sh"
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
 
       - name: configure git setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,10 @@ jobs:
         with:
           linters: gcc
           run: |
+            bash -o pipefail -c "./scripts/update-style-exceptions.sh"
+            bash -c "echo style-exceptions-complete"
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
+            bash -c "echo both-steps-complete"
 
       - name: configure git setup
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,7 @@ jobs:
         with:
           linters: gcc
           run: |
-            env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
             bash -o pipefail -c "./scripts/update-style-exceptions.sh"
 
       - name: configure git setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,7 @@ jobs:
         with:
           linters: gcc
           run: |
-            ./scripts/update-style-exceptions.sh
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
 
       - name: configure git setup
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,11 +201,9 @@ jobs:
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
       - name: lint mathlib and update style exceptions files
-        with:
-          linters: gcc
-          run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
-            bash -o pipefail -c "./scripts/update-style-exceptions.sh"
+        run: |
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
+          bash -o pipefail -c "./scripts/update-style-exceptions.sh"
 
       - name: configure git setup
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,7 @@ jobs:
           linters: gcc
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
-            bash -o pipefail -c "./scripts/update-style-exceptions.sh"
+            ./scripts/update-style-exceptions.sh
 
       - name: configure git setup
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,6 @@ jobs:
           linters: gcc
           run: |
             bash -o pipefail -c "./scripts/update-style-exceptions.sh"
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
 
       - name: configure git setup
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,17 +200,12 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
-      - name: lint mathlib
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
-        id: lint
-        uses: liskin/gh-problem-matcher-wrap@v3
+      - name: lint mathlib and update style exceptions files
         with:
           linters: gcc
           run: |
-            bash -o pipefail -c "./scripts/update-style-exceptions.sh"
-            bash -c "echo style-exceptions-complete"
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
-            bash -c "echo both-steps-complete"
+            bash -o pipefail -c "./scripts/update-style-exceptions.sh"
 
       - name: configure git setup
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,8 +207,8 @@ jobs:
         with:
           linters: gcc
           run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
             ./scripts/update-style-exceptions.sh
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
 
       - name: configure git setup
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,8 +234,7 @@ jobs:
         with:
           linters: gcc
           run: |
-            env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
-            ./scripts/update-style-exceptions.sh
+            bash -o pipefail -c "./scripts/update-style-exceptions.sh"
             git diff
 
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,6 +207,7 @@ jobs:
         with:
           linters: gcc
           run: |
+            env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
             bash -o pipefail -c "./scripts/update-style-exceptions.sh"
 
       - name: configure git setup
@@ -219,11 +220,6 @@ jobs:
           # github url so that it uses the github-actions[bot] user.  We want to access
           # github using a different username.
           git config --unset http.https://github.com/.extraheader
-
-      - name: file a PR to update nolints.json and style-exceptions.txt
-        run: ./scripts/update_nolints_CI.sh
-        env:
-          DEPLOY_GITHUB_TOKEN: ${{ secrets.UPDATE_NOLINTS_TOKEN }}
 
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.
       # Instead we run it in a cron job on master: see `lean4checker.yml`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,33 +200,6 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
-      - name: build archive
-        id: archive
-        run: |
-          # Note: we should not be including `Archive` and `Counterexamples` in the cache.
-          # We do this for now for the sake of not rebuilding them in every CI run
-          # even when they are not touched.
-          # Since `Archive` and `Counterexamples` files have very simple dependencies,
-          # it should be possible to determine whether they need to be built without actually
-          # storing and transferring oleans over the network.
-          # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
-          lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
-          lake exe cache put Archive.lean
-        env:
-          MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
-          MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
-
-      - name: build counterexamples
-        id: counterexamples
-        run: |
-          lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
-          lake exe cache put Counterexamples.lean
-        env:
-          MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
-          MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
-
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,47 +254,6 @@ jobs:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
-      - name: check for noisy stdout lines
-        id: noisy
-        run: |
-          buildMsgs="$(
-            ##  we exploit `lake`s replay feature: since the cache is present, running
-            ##  `lake build` will reproduce all the outputs without having to recompute
-            lake build Mathlib Archive Counterexamples |
-            ##  we filter out the output lines that begin with `✔ [xx/yy]`, where xx, yy
-            ##  are either numbers or ?, and the "Build completed successfully." message.
-            ##  We keep the rest, which are actual outputs of the files
-            awk '!($0 ~ "^\\s*✔ \\[[?0-9]*/[?0-9]*\\]" || $0 == "Build completed successfully."){ print $0 }')"
-          if [ -n "${buildMsgs}" ]
-          then
-            printf $'%s\n' "${buildMsgs}"
-            exit 1
-          fi
-
-      - name: check declarations in db files
-        run: |
-          python3 scripts/yaml_check.py docs/100.yaml docs/overview.yaml docs/undergrad.yaml
-          lake exe checkYaml
-
-      - name: verify `lake exe graph` works
-        run: |
-          lake exe graph
-          rm import_graph.dot
-
-      - name: test mathlib
-        id: test
-        uses: liskin/gh-problem-matcher-wrap@v3
-        with:
-          linters: gcc
-          run: lake test
-
-      - name: check for unused imports
-        id: shake
-        uses: liskin/gh-problem-matcher-wrap@v3
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
-
       - name: lint mathlib
         if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
         id: lint
@@ -308,21 +267,6 @@ jobs:
       # Instead we run it in a cron job on master: see `lean4checker.yml`.
       # Output is posted to the zulip topic
       # https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers/topic/lean4checker
-
-      - name: Post comments for lean-pr-testing branch
-        if: always()
-        env:
-          TOKEN: ${{ secrets.LEAN_PR_TESTING }}
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
-          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
-          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
-          COUNTEREXAMPLE_OUTCOME: ${{ steps.counterexamples.outcome }}
-          LINT_OUTCOME: ${{ steps.lint.outcome }}
-          TEST_OUTCOME: ${{ steps.test.outcome }}
-        run: |
-          scripts/lean-pr-testing-comments.sh
 
   final:
     name: Post-CI job
@@ -340,23 +284,3 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Only return if PR is still open
           filterOutClosed: true
-
-      - id: remove_labels
-        name: Remove "awaiting-CI"
-        # we use curl rather than octokit/request-action so that the job won't fail
-        # (and send an annoying email) if the labels don't exist
-        run: |
-          curl --request DELETE \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.PR.outputs.number }}/labels/awaiting-CI \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
-
-      - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
-        name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
-        uses: GrantBirki/comment@v2.0.1
-        with:
-          token: ${{ secrets.AUTO_MERGE_TOKEN }}
-          issue-number: ${{ steps.PR.outputs.number }}
-          body: |
-            As this PR is labelled `auto-merge-after-CI`, we are now sending it to bors:
-
-            bors merge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,33 +200,6 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
-      - name: upload cache
-        # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
-        # but not if any earlier step failed or was cancelled.
-        # See discussion at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Some.20files.20not.20found.20in.20the.20cache/near/407183836
-        if: ${{ always() && steps.get.outcome == 'success' }}
-        run: |
-          # TODO: this is not doing anything currently, and needs to be integrated with put-unpacked
-          # lake exe cache commit || true
-          # run this in CI if it gets an incorrect lake hash for existing cache files somehow
-          # lake exe cache put!
-          # do not try to upload files just downloaded
-          lake exe cache put-unpacked
-        env:
-          MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
-          MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
-
-      - name: check the cache
-        run: |
-          # Because the `lean-pr-testing-NNNN` branches use toolchains that are "updated in place"
-          # the cache mechanism is unreliable, so we don't test it if we are on such a branch.
-          if [[ ! $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then
-            lake exe cache clean!
-            rm -rf .lake/build/lib/Mathlib
-            lake exe cache get || (sleep 1; lake exe cache get)
-            lake build --no-build
-          fi
-
       - name: build archive
         id: archive
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -302,11 +302,11 @@ jobs:
         with:
           linters: gcc
           run: |
-            echo "first step"
-            env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
-            echo "nolints updated"
+            printf "first step"
+            env LEAN_ABORT_ON_PANIC=1 "lake exe runLinter --update Mathlib"
+            printf "nolints updated"
             ./scripts/update-style-exceptions.sh
-            echo "style exceptions updated"
+            printf "style exceptions updated"
             git diff
 
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,7 +261,7 @@ jobs:
         with:
           linters: gcc
           run: |
-            env LEAN_ABORT_ON_PANIC=1 "lake exe runLinter --update Mathlib"
+            env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
 
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.
       # Instead we run it in a cron job on master: see `lean4checker.yml`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,13 @@ jobs:
         uses: liskin/gh-problem-matcher-wrap@v3
         with:
           linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 lake exe runLinter Mathlib
+          run: |
+            echo "first step"
+            env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
+            echo "nolints updated"
+            ./scripts/update-style-exceptions.sh
+            echo "style exceptions updated"
+            git diff
 
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.
       # Instead we run it in a cron job on master: see `lean4checker.yml`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,22 @@ jobs:
           linters: gcc
           run: |
             bash -o pipefail -c "./scripts/update-style-exceptions.sh"
-            git diff
+
+      - name: configure git setup
+        run: |
+          git remote add origin-bot "https://leanprover-community-bot:${{ secrets.UPDATE_NOLINTS_TOKEN }}@github.com/leanprover-community/mathlib.git"
+          git config user.email "leanprover.community@gmail.com"
+          git config user.name "leanprover-community-bot"
+
+          # By default, github actions overrides the credentials used to access any
+          # github url so that it uses the github-actions[bot] user.  We want to access
+          # github using a different username.
+          git config --unset http.https://github.com/.extraheader
+
+      - name: file a PR to update nolints.json and style-exceptions.txt
+        run: ./scripts/update_nolints_CI.sh
+        env:
+          DEPLOY_GITHUB_TOKEN: ${{ secrets.UPDATE_NOLINTS_TOKEN }}
 
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.
       # Instead we run it in a cron job on master: see `lean4checker.yml`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,6 +235,8 @@ jobs:
           linters: gcc
           run: |
             env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
+            ./scripts/update-style-exceptions.sh
+            git diff
 
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.
       # Instead we run it in a cron job on master: see `lean4checker.yml`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -302,12 +302,7 @@ jobs:
         with:
           linters: gcc
           run: |
-            printf "first step"
             env LEAN_ABORT_ON_PANIC=1 "lake exe runLinter --update Mathlib"
-            printf "nolints updated"
-            ./scripts/update-style-exceptions.sh
-            printf "style exceptions updated"
-            git diff
 
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.
       # Instead we run it in a cron job on master: see `lean4checker.yml`.

--- a/.github/workflows/nolints.yml
+++ b/.github/workflows/nolints.yml
@@ -55,12 +55,10 @@ jobs:
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
       - name: lint mathlib and update style exceptions files
-        id: lint
-        uses: liskin/gh-problem-matcher-wrap@v3
         with:
           linters: gcc
           run: |
-            env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib"
             bash -o pipefail -c "./scripts/update-style-exceptions.sh"
 
       - name: configure git setup

--- a/.github/workflows/nolints.yml
+++ b/.github/workflows/nolints.yml
@@ -59,8 +59,7 @@ jobs:
         with:
           linters: gcc
           run: |
-            env LEAN_ABORT_ON_PANIC=1 lake exe runLinter Mathlib
-            mv nolints.json scripts/nolints.json
+            env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
             ./scripts/update-style-exceptions.sh
             git diff
 

--- a/.github/workflows/nolints.yml
+++ b/.github/workflows/nolints.yml
@@ -53,7 +53,7 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
-      - name: lint mathlib
+      - name: lint mathlib and update style exceptions files
         id: lint
         uses: liskin/gh-problem-matcher-wrap@v3
         with:
@@ -75,7 +75,7 @@ jobs:
           # github using a different username.
           git config --unset http.https://github.com/.extraheader
 
-      - name: update nolints.json and style-exceptions.txt
+      - name: file a PR to update nolints.json and style-exceptions.txt
         run: ./scripts/update_nolints_CI.sh
         env:
           DEPLOY_GITHUB_TOKEN: ${{ secrets.UPDATE_NOLINTS_TOKEN }}

--- a/.github/workflows/nolints.yml
+++ b/.github/workflows/nolints.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           linters: gcc
           run: |
+            env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
       - name: lint mathlib and update style exceptions files

--- a/.github/workflows/nolints.yml
+++ b/.github/workflows/nolints.yml
@@ -59,12 +59,8 @@ jobs:
         with:
           linters: gcc
           run: |
-            echo "first step"
             env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
-            echo "nolints updated"
-            ./scripts/update-style-exceptions.sh
-            echo "style exceptions updated"
-            git diff
+            bash -o pipefail -c "./scripts/update-style-exceptions.sh"
 
       - name: configure git setup
         run: |

--- a/.github/workflows/nolints.yml
+++ b/.github/workflows/nolints.yml
@@ -22,9 +22,9 @@ jobs:
           set -o pipefail
           curl -sSfL https://github.com/leanprover/elan/releases/download/v3.0.0/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
           ./elan-init -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: print lean and lake versions
         run: |
@@ -47,15 +47,15 @@ jobs:
 
       - name: build mathlib
         id: build
-        uses: liskin/gh-problem-matcher-wrap@v2
+        uses: liskin/gh-problem-matcher-wrap@v3
         with:
           linters: gcc
           run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build -KCI | tee stdout.log"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
       - name: lint mathlib
         id: lint
-        uses: liskin/gh-problem-matcher-wrap@v2
+        uses: liskin/gh-problem-matcher-wrap@v3
         with:
           linters: gcc
           run: |

--- a/.github/workflows/nolints.yml
+++ b/.github/workflows/nolints.yml
@@ -59,8 +59,11 @@ jobs:
         with:
           linters: gcc
           run: |
+            echo "first step"
             env LEAN_ABORT_ON_PANIC=1 lake exe runLinter --update Mathlib
+            echo "nolints updated"
             ./scripts/update-style-exceptions.sh
+            echo "style exceptions updated"
             git diff
 
       - name: configure git setup


### PR DESCRIPTION
Test my theory about the nolint workflow failing: let's run my proposed fixed logic in the normal lint job and see how it fares.

This should be noisy, but hopefully the good kind of noise :-)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
