### PR TITLE
[Merged by Bors] - feat(GroupTheory/OrderOfElement): equivalences preserve orders

### DIFF
--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1299,25 +1299,10 @@ end Prod
 
 section MulEquiv
 
-/-- An injective homomorphism of monoids preserves orders of elements. -/
-@[to_additive "An injective homomorphism of monoids preserves orders of elements."]
-lemma MulHom.orderOf_eq_of_injective {M M' : Type*} [Monoid M] [Monoid M'] (e : M →* M')
-    (he : Function.Injective e) (m : M) :
-    orderOf (e m) = orderOf m := by
-  rcases (orderOf m).eq_zero_or_pos with h | h
-  · rw [h]
-    rw [orderOf_eq_zero_iff'] at h ⊢
-    intro n h₀
-    have hn := h n h₀
-    contrapose! hn
-    rwa [← map_pow, map_eq_one_iff e he] at hn
-  · simp_rw [orderOf_eq_iff h, ← map_pow, ne_eq, map_eq_one_iff e he]
-    exact (orderOf_eq_iff h).mp rfl
-
 /-- A multiplicative equivalence preserves orders of elements. -/
 @[to_additive "An additive  equivalence preserves orders of elements."]
 lemma MulEquiv.orderOf_eq {M M' : Type*} [Monoid M] [Monoid M'] (e : M ≃* M') (m : M) :
     orderOf (e m) = orderOf m :=
-  MulHom.orderOf_eq_of_injective e e.injective m
+  orderOf_injective e e.injective m
 
 end MulEquiv

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -362,12 +362,19 @@ theorem orderOf_eq_orderOf_iff {H : Type*} [Monoid H] {y : H} :
 #align order_of_eq_order_of_iff orderOf_eq_orderOf_iff
 #align add_order_of_eq_add_order_of_iff addOrderOf_eq_addOrderOf_iff
 
-@[to_additive]
+/-- An injective homomorphism of monoids preserves orders of elements. -/
+@[to_additive "An injective homomorphism of additive monoids preserves orders of elements."]
 theorem orderOf_injective {H : Type*} [Monoid H] (f : G →* H) (hf : Function.Injective f) (x : G) :
     orderOf (f x) = orderOf x := by
   simp_rw [orderOf_eq_orderOf_iff, ← f.map_pow, ← f.map_one, hf.eq_iff, forall_const]
 #align order_of_injective orderOf_injective
 #align add_order_of_injective addOrderOf_injective
+
+/-- A multiplicative equivalence preserves orders of elements. -/
+@[to_additive (attr := simp) "An additive equivalence preserves orders of elements."]
+lemma MulEquiv.orderOf_eq {H : Type*} [Monoid H] (e : G ≃* H) (x : G) :
+    orderOf (e x) = orderOf x :=
+  orderOf_injective e e.injective x
 
 @[to_additive]
 theorem Function.Injective.isOfFinOrder_iff [Monoid H] {f : G →* H} (hf : Injective f) :
@@ -1296,13 +1303,3 @@ theorem IsOfFinOrder.prod_mk : IsOfFinOrder a → IsOfFinOrder b → IsOfFinOrde
 end Prod
 
 -- TODO: Corresponding `pi` lemmas. We cannot currently state them here because of import cycles
-
-section MulEquiv
-
-/-- A multiplicative equivalence preserves orders of elements. -/
-@[to_additive "An additive  equivalence preserves orders of elements."]
-lemma MulEquiv.orderOf_eq {M M' : Type*} [Monoid M] [Monoid M'] (e : M ≃* M') (m : M) :
-    orderOf (e m) = orderOf m :=
-  orderOf_injective e e.injective m
-
-end MulEquiv

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1300,9 +1300,9 @@ end Prod
 section MulEquiv
 
 /-- An injective homomorphism of monoids preserves orders of elements. -/
-@[to_additive "An injective homomorphism of additive monoids preserves orders of elements."]
+@[to_additive "An injective homomorphism of monoids preserves orders of elements."]
 lemma MulHom.orderOf_eq_of_injective {M M' : Type*} [Monoid M] [Monoid M'] (e : M →* M')
-      (he : Function.Injective e) (m : M) :
+    (he : Function.Injective e) (m : M) :
     orderOf (e m) = orderOf m := by
   rcases (orderOf m).eq_zero_or_pos with h | h
   · rw [h]

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1302,7 +1302,7 @@ section MulEquiv
 /-- An injective homomorphism of monoids preserves orders of elements. -/
 @[to_additive "An injective homomorphism of additive monoids preserves orders of elements."]
 lemma MulHom.orderOf_eq_of_injective {M M' : Type*} [Monoid M] [Monoid M'] (e : M →* M')
-      (he : Function.Injective e) (m : M) :
+    (he : Function.Injective e) (m : M) :
     orderOf (e m) = orderOf m := by
   rcases (orderOf m).eq_zero_or_pos with h | h
   · rw [h]

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1296,3 +1296,21 @@ theorem IsOfFinOrder.prod_mk : IsOfFinOrder a → IsOfFinOrder b → IsOfFinOrde
 end Prod
 
 -- TODO: Corresponding `pi` lemmas. We cannot currently state them here because of import cycles
+
+section MulEquiv
+
+/-- A multiplicative equivalence preserves orders of elements. -/
+@[to_additive "An additive  equivalence preserves orders of elements."]
+lemma MulEquiv.orderOf_eq {M M' : Type*} [Monoid M] [Monoid M'] (e : M ≃* M') (m : M) :
+    orderOf (e m) = orderOf m := by
+  rcases (orderOf m).eq_zero_or_pos with h | h
+  · rw [h]
+    rw [orderOf_eq_zero_iff'] at h ⊢
+    intro n h₀
+    have hn := h n h₀
+    contrapose! hn
+    rwa [← map_pow, e.map_eq_one_iff] at hn
+  · simp_rw [orderOf_eq_iff h, ← map_pow, ne_eq, e.map_eq_one_iff]
+    exact (orderOf_eq_iff h).mp rfl
+
+end MulEquiv

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1299,9 +1299,10 @@ end Prod
 
 section MulEquiv
 
-/-- A multiplicative equivalence preserves orders of elements. -/
-@[to_additive "An additive  equivalence preserves orders of elements."]
-lemma MulEquiv.orderOf_eq {M M' : Type*} [Monoid M] [Monoid M'] (e : M ≃* M') (m : M) :
+/-- An injective homomorphism of monoids preserves orders of elements. -/
+@[to_additive "An injective homomorphism of additive monoids preserves orders of elements."]
+lemma MulHom.orderOf_eq_of_injective {M M' : Type*} [Monoid M] [Monoid M'] (e : M →* M')
+      (he : Function.Injective e) (m : M) :
     orderOf (e m) = orderOf m := by
   rcases (orderOf m).eq_zero_or_pos with h | h
   · rw [h]
@@ -1309,8 +1310,14 @@ lemma MulEquiv.orderOf_eq {M M' : Type*} [Monoid M] [Monoid M'] (e : M ≃* M') 
     intro n h₀
     have hn := h n h₀
     contrapose! hn
-    rwa [← map_pow, e.map_eq_one_iff] at hn
-  · simp_rw [orderOf_eq_iff h, ← map_pow, ne_eq, e.map_eq_one_iff]
+    rwa [← map_pow, map_eq_one_iff e he] at hn
+  · simp_rw [orderOf_eq_iff h, ← map_pow, ne_eq, map_eq_one_iff e he]
     exact (orderOf_eq_iff h).mp rfl
+
+/-- A multiplicative equivalence preserves orders of elements. -/
+@[to_additive "An additive  equivalence preserves orders of elements."]
+lemma MulEquiv.orderOf_eq {M M' : Type*} [Monoid M] [Monoid M'] (e : M ≃* M') (m : M) :
+    orderOf (e m) = orderOf m :=
+  MulHom.orderOf_eq_of_injective e e.injective m
 
 end MulEquiv


### PR DESCRIPTION
We add the statement that (multiplicative and additive) equivalences preserve the order of an element.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
