### PR TITLE
[Merged by Bors] - feat: instances of the non-unital continuous functional calculus for C⋆-algebras

### DIFF
--- a/Mathlib/Algebra/Algebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Unitization.lean
@@ -6,7 +6,7 @@ Authors: Jireh Loreaux
 import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.Algebra.NonUnitalHom
 import Mathlib.Algebra.Star.Module
-import Mathlib.Algebra.Star.StarAlgHom
+import Mathlib.Algebra.Star.NonUnitalSubalgebra
 import Mathlib.LinearAlgebra.Prod
 
 #align_import algebra.algebra.unitization from "leanprover-community/mathlib"@"8f66240cab125b938b327d3850169d490cfbcdd8"
@@ -662,6 +662,14 @@ def inrNonUnitalStarAlgHom (R A : Type*) [CommSemiring R] [StarAddMonoid R]
     A →⋆ₙₐ[R] Unitization R A where
   toNonUnitalAlgHom := inrNonUnitalAlgHom R A
   map_star' := inr_star
+
+/-- The star algebra equivalence obtained by restricting `Unitization.inrNonUnitalStarAlgHom`
+to its range. -/
+@[simps!]
+def inrRangeEquiv (R A : Type*) [CommSemiring R] [StarAddMonoid R] [NonUnitalSemiring A]
+    [Star A] [Module R A] [IsScalarTower R A A] [SMulCommClass R A A] :
+    A ≃⋆ₐ[R] NonUnitalStarAlgHom.range (inrNonUnitalStarAlgHom R A) :=
+  StarAlgEquiv.ofLeftInverse' (snd_inr R)
 
 end coe
 

--- a/Mathlib/Algebra/Star/SelfAdjoint.lean
+++ b/Mathlib/Algebra/Star/SelfAdjoint.lean
@@ -174,6 +174,7 @@ theorem conjugate' {x : R} (hx : IsSelfAdjoint x) (z : R) : IsSelfAdjoint (star 
   simp only [isSelfAdjoint_iff, star_mul, star_star, mul_assoc, hx.star_eq]
 #align is_self_adjoint.conjugate' IsSelfAdjoint.conjugate'
 
+@[aesop 10% apply]
 theorem isStarNormal {x : R} (hx : IsSelfAdjoint x) : IsStarNormal x :=
   ⟨by simp only [Commute, SemiconjBy, hx.star_eq]⟩
 #align is_self_adjoint.is_star_normal IsSelfAdjoint.isStarNormal

--- a/Mathlib/Analysis/NormedSpace/Star/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/ContinuousFunctionalCalculus/Instances.lean
@@ -66,20 +66,20 @@ calc
   _             ≃⋆[𝕜] C(σ 𝕜 (↑a : A⁺¹), 𝕜) := Homeomorph.compStarAlgEquiv'
   _             →⋆ₐ[𝕜] A⁺¹ := cfcHom
 ```
-This range of this map is contained in the range of `(↑) : A → A⁺¹` (see `nucfcAux_mem_range_inr`),
+This range of this map is contained in the range of `(↑) : A → A⁺¹` (see `cfcₙAux_mem_range_inr`),
 and so we may restrict it to `A` to get the necessary homomorphism for the non-unital continuous
 functional calculus.
 -/
-noncomputable def nucfcAux : C(σₙ 𝕜 a, 𝕜)₀ →⋆ₙₐ[𝕜] A⁺¹ :=
+noncomputable def cfcₙAux : C(σₙ 𝕜 a, 𝕜)₀ →⋆ₙₐ[𝕜] A⁺¹ :=
   (cfcHom (R := 𝕜) (hp₁.mpr ha) : C(σ 𝕜 (a : A⁺¹), 𝕜) →⋆ₙₐ[𝕜] A⁺¹) |>.comp
     (Homeomorph.compStarAlgEquiv' 𝕜 𝕜 <| .setCongr <| (quasispectrum_eq_spectrum_inr' 𝕜 𝕜 a).symm)
     |>.comp ContinuousMapZero.toContinuousMapHom
 
-lemma nucfcAux_id : nucfcAux hp₁ a ha (ContinuousMapZero.id rfl) = a := cfcHom_id (hp₁.mpr ha)
+lemma cfcₙAux_id : cfcₙAux hp₁ a ha (ContinuousMapZero.id rfl) = a := cfcHom_id (hp₁.mpr ha)
 
 open Unitization in
-lemma closedEmbedding_nucfcAux : ClosedEmbedding (nucfcAux hp₁ a ha) := by
-  simp only [nucfcAux, NonUnitalStarAlgHom.coe_comp]
+lemma closedEmbedding_cfcₙAux : ClosedEmbedding (cfcₙAux hp₁ a ha) := by
+  simp only [cfcₙAux, NonUnitalStarAlgHom.coe_comp]
   refine ((cfcHom_closedEmbedding (hp₁.mpr ha)).comp ?_).comp
     ContinuousMapZero.closedEmbedding_toContinuousMap
   let e : C(σₙ 𝕜 a, 𝕜) ≃ₜ C(σ 𝕜 (a : A⁺¹), 𝕜) :=
@@ -89,8 +89,8 @@ lemma closedEmbedding_nucfcAux : ClosedEmbedding (nucfcAux hp₁ a ha) := by
       continuous_invFun := ContinuousMap.continuous_comp_left _ }
   exact e.closedEmbedding
 
-lemma spec_nucfcAux (f : C(σₙ 𝕜 a, 𝕜)₀) : σ 𝕜 (nucfcAux hp₁ a ha f) = Set.range f := by
-  rw [nucfcAux, NonUnitalStarAlgHom.comp_assoc, NonUnitalStarAlgHom.comp_apply]
+lemma spec_cfcₙAux (f : C(σₙ 𝕜 a, 𝕜)₀) : σ 𝕜 (cfcₙAux hp₁ a ha f) = Set.range f := by
+  rw [cfcₙAux, NonUnitalStarAlgHom.comp_assoc, NonUnitalStarAlgHom.comp_apply]
   simp only [NonUnitalStarAlgHom.comp_apply, NonUnitalStarAlgHom.coe_coe]
   rw [cfcHom_map_spectrum (hp₁.mpr ha) (R := 𝕜) _]
   ext x
@@ -99,16 +99,16 @@ lemma spec_nucfcAux (f : C(σₙ 𝕜 a, 𝕜)₀) : σ 𝕜 (nucfcAux hp₁ a h
   · exact ⟨⟨x, (Unitization.quasispectrum_eq_spectrum_inr' 𝕜 𝕜 a).symm ▸ x.property⟩, rfl⟩
   · exact ⟨⟨x, Unitization.quasispectrum_eq_spectrum_inr' 𝕜 𝕜 a ▸ x.property⟩, rfl⟩
 
-lemma nucfcAux_mem_range_inr (f : C(σₙ 𝕜 a, 𝕜)₀) :
-    nucfcAux hp₁ a ha f ∈ NonUnitalStarAlgHom.range (Unitization.inrNonUnitalStarAlgHom 𝕜 A) := by
-  have h₁ := (closedEmbedding_nucfcAux hp₁ a ha).continuous.range_subset_closure_image_dense
+lemma cfcₙAux_mem_range_inr (f : C(σₙ 𝕜 a, 𝕜)₀) :
+    cfcₙAux hp₁ a ha f ∈ NonUnitalStarAlgHom.range (Unitization.inrNonUnitalStarAlgHom 𝕜 A) := by
+  have h₁ := (closedEmbedding_cfcₙAux hp₁ a ha).continuous.range_subset_closure_image_dense
     (ContinuousMapZero.adjoin_id_dense (s := σₙ 𝕜 a) rfl) ⟨f, rfl⟩
   rw [← SetLike.mem_coe]
   refine closure_minimal ?_ ?_ h₁
   · rw [← NonUnitalStarSubalgebra.coe_map, SetLike.coe_subset_coe, NonUnitalStarSubalgebra.map_le]
     apply NonUnitalStarAlgebra.adjoin_le
     apply Set.singleton_subset_iff.mpr
-    rw [SetLike.mem_coe, NonUnitalStarSubalgebra.mem_comap, nucfcAux_id hp₁ a ha]
+    rw [SetLike.mem_coe, NonUnitalStarSubalgebra.mem_comap, cfcₙAux_id hp₁ a ha]
     exact ⟨a, rfl⟩
   · have : Continuous (Unitization.fst (R := 𝕜) (A := A)) :=
       Unitization.uniformEquivProd.continuous.fst
@@ -121,18 +121,18 @@ theorem RCLike.nonUnitalContinuousFunctionalCalculus :
     NonUnitalContinuousFunctionalCalculus 𝕜 (p : A → Prop) where
   exists_cfc_of_predicate a ha := by
     let ψ : C(σₙ 𝕜 a, 𝕜)₀ →⋆ₙₐ[𝕜] A := comp (inrRangeEquiv 𝕜 A).symm <|
-      codRestrict (nucfcAux hp₁ a ha) _ (nucfcAux_mem_range_inr hp₁ a ha)
-    have coe_ψ (f : C(σₙ 𝕜 a, 𝕜)₀) : ψ f = nucfcAux hp₁ a ha f :=
+      codRestrict (cfcₙAux hp₁ a ha) _ (cfcₙAux_mem_range_inr hp₁ a ha)
+    have coe_ψ (f : C(σₙ 𝕜 a, 𝕜)₀) : ψ f = cfcₙAux hp₁ a ha f :=
       congr_arg Subtype.val <| (inrRangeEquiv 𝕜 A).apply_symm_apply
-        ⟨nucfcAux hp₁ a ha f, nucfcAux_mem_range_inr hp₁ a ha f⟩
+        ⟨cfcₙAux hp₁ a ha f, cfcₙAux_mem_range_inr hp₁ a ha f⟩
     refine ⟨ψ, ?closedEmbedding, ?map_id, fun f ↦ ?map_spec, fun f ↦ ?isStarNormal⟩
     case closedEmbedding =>
       apply isometry_inr (𝕜 := 𝕜) (A := A) |>.closedEmbedding |>.of_comp_iff.mp
-      have : inr ∘ ψ = nucfcAux hp₁ a ha := by ext1; rw [Function.comp_apply, coe_ψ]
-      exact this ▸ closedEmbedding_nucfcAux hp₁ a ha
-    case map_id => exact inr_injective (R := 𝕜) <| coe_ψ _ ▸ nucfcAux_id hp₁ a ha
+      have : inr ∘ ψ = cfcₙAux hp₁ a ha := by ext1; rw [Function.comp_apply, coe_ψ]
+      exact this ▸ closedEmbedding_cfcₙAux hp₁ a ha
+    case map_id => exact inr_injective (R := 𝕜) <| coe_ψ _ ▸ cfcₙAux_id hp₁ a ha
     case map_spec =>
-      exact quasispectrum_eq_spectrum_inr' 𝕜 𝕜 (ψ f) ▸ coe_ψ _ ▸ spec_nucfcAux hp₁ a ha f
+      exact quasispectrum_eq_spectrum_inr' 𝕜 𝕜 (ψ f) ▸ coe_ψ _ ▸ spec_cfcₙAux hp₁ a ha f
     case isStarNormal => exact hp₁.mp <| coe_ψ _ ▸ cfcHom_predicate (R := 𝕜) (hp₁.mpr ha) _
 
 end RCLike
@@ -636,7 +636,7 @@ end NNRealEqReal
 section Unitary -- TODO: move to a new file
 
 /-!
-### conditions on unitary elements imposed by the continuous functional calculus
+### Conditions on unitary elements imposed by the continuous functional calculus
 -/
 
 variable {A : Type*} [TopologicalSpace A] [Ring A] [StarRing A] [Algebra ℂ A]

--- a/Mathlib/Analysis/NormedSpace/Star/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/ContinuousFunctionalCalculus/Instances.lean
@@ -6,6 +6,7 @@ Authors: Jireh Loreaux
 import Mathlib.Analysis.NormedSpace.Star.ContinuousFunctionalCalculus.Restrict
 import Mathlib.Analysis.NormedSpace.Star.ContinuousFunctionalCalculus
 import Mathlib.Analysis.NormedSpace.Star.Spectrum
+import Mathlib.Analysis.NormedSpace.Star.Unitization
 import Mathlib.Topology.ContinuousFunction.UniqueCFC
 
 /-! # Instances of the continuous functional calculus
@@ -32,19 +33,115 @@ continuous functional calculus, normal, selfadjoint
 
 noncomputable section
 
-section Normal
+local notation "σₙ" => quasispectrum
+local notation "σ" => spectrum
 
-instance IsStarNormal.cfc_map {R A : Type*} {p : A → Prop} [CommSemiring R] [StarRing R]
-    [MetricSpace R] [TopologicalSemiring R] [ContinuousStar R] [TopologicalSpace A] [Ring A]
-    [StarRing A] [Algebra R A] [ContinuousFunctionalCalculus R p] (a : A) (f : R → R) :
-    IsStarNormal (cfc f a) where
-  star_comm_self := by
-    rw [Commute, SemiconjBy]
-    by_cases h : ContinuousOn f (spectrum R a)
-    · rw [← cfc_star, ← cfc_mul .., ← cfc_mul ..]
-      congr! 2
-      exact mul_comm _ _
-    · simp [cfc_apply_of_not_continuousOn a h]
+/-!
+### Pull back a non-unital instance from a unital one on the unitization
+-/
+
+section RCLike
+
+variable {𝕜 A : Type*} [RCLike 𝕜] [NonUnitalNormedRing A] [StarRing A] [CstarRing A]
+variable [CompleteSpace A] [NormedSpace 𝕜 A] [IsScalarTower 𝕜 A A] [SMulCommClass 𝕜 A A]
+variable [StarModule 𝕜 A] {p : A → Prop} {p₁ : Unitization 𝕜 A → Prop}
+
+local postfix:max "⁺¹" => Unitization 𝕜
+
+variable (hp₁ : ∀ {x : A}, p₁ x ↔ p x) (a : A) (ha : p a)
+variable [ContinuousFunctionalCalculus 𝕜 p₁]
+
+open scoped ContinuousMapZero
+
+
+open Unitization in
+/--
+This is an auxiliary definition used for constructing an instance of the non-unital continuous
+functional calculus given a instance of the unital one on the unitization.
+
+This is the natural non-unital star homomorphism obtained from the chain
+```lean
+calc
+  C(σₙ 𝕜 a, 𝕜)₀ →⋆ₙₐ[𝕜] C(σₙ 𝕜 a, 𝕜) := ContinuousMapZero.toContinuousMapHom
+  _             ≃⋆[𝕜] C(σ 𝕜 (↑a : A⁺¹), 𝕜) := Homeomorph.compStarAlgEquiv'
+  _             →⋆ₐ[𝕜] A⁺¹ := cfcHom
+```
+This range of this map is contained in the range of `(↑) : A → A⁺¹` (see `nucfcAux_mem_range_inr`),
+and so we may restrict it to `A` to get the necessary homomorphism for the non-unital continuous
+functional calculus.
+-/
+noncomputable def nucfcAux : C(σₙ 𝕜 a, 𝕜)₀ →⋆ₙₐ[𝕜] A⁺¹ :=
+  (cfcHom (R := 𝕜) (hp₁.mpr ha) : C(σ 𝕜 (a : A⁺¹), 𝕜) →⋆ₙₐ[𝕜] A⁺¹) |>.comp
+    (Homeomorph.compStarAlgEquiv' 𝕜 𝕜 <| .setCongr <| (quasispectrum_eq_spectrum_inr' 𝕜 𝕜 a).symm)
+    |>.comp ContinuousMapZero.toContinuousMapHom
+
+lemma nucfcAux_id : nucfcAux hp₁ a ha (ContinuousMapZero.id rfl) = a := cfcHom_id (hp₁.mpr ha)
+
+open Unitization in
+lemma closedEmbedding_nucfcAux : ClosedEmbedding (nucfcAux hp₁ a ha) := by
+  simp only [nucfcAux, NonUnitalStarAlgHom.coe_comp]
+  refine ((cfcHom_closedEmbedding (hp₁.mpr ha)).comp ?_).comp
+    ContinuousMapZero.closedEmbedding_toContinuousMap
+  let e : C(σₙ 𝕜 a, 𝕜) ≃ₜ C(σ 𝕜 (a : A⁺¹), 𝕜) :=
+    { (Homeomorph.compStarAlgEquiv' 𝕜 𝕜 <| .setCongr <|
+        (quasispectrum_eq_spectrum_inr' 𝕜 𝕜 a).symm) with
+      continuous_toFun := ContinuousMap.continuous_comp_left _
+      continuous_invFun := ContinuousMap.continuous_comp_left _ }
+  exact e.closedEmbedding
+
+lemma spec_nucfcAux (f : C(σₙ 𝕜 a, 𝕜)₀) : σ 𝕜 (nucfcAux hp₁ a ha f) = Set.range f := by
+  rw [nucfcAux, NonUnitalStarAlgHom.comp_assoc, NonUnitalStarAlgHom.comp_apply]
+  simp only [NonUnitalStarAlgHom.comp_apply, NonUnitalStarAlgHom.coe_coe]
+  rw [cfcHom_map_spectrum (hp₁.mpr ha) (R := 𝕜) _]
+  ext x
+  constructor
+  all_goals rintro ⟨x, rfl⟩
+  · exact ⟨⟨x, (Unitization.quasispectrum_eq_spectrum_inr' 𝕜 𝕜 a).symm ▸ x.property⟩, rfl⟩
+  · exact ⟨⟨x, Unitization.quasispectrum_eq_spectrum_inr' 𝕜 𝕜 a ▸ x.property⟩, rfl⟩
+
+lemma nucfcAux_mem_range_inr (f : C(σₙ 𝕜 a, 𝕜)₀) :
+    nucfcAux hp₁ a ha f ∈ NonUnitalStarAlgHom.range (Unitization.inrNonUnitalStarAlgHom 𝕜 A) := by
+  have h₁ := (closedEmbedding_nucfcAux hp₁ a ha).continuous.range_subset_closure_image_dense
+    (ContinuousMapZero.adjoin_id_dense (s := σₙ 𝕜 a) rfl) ⟨f, rfl⟩
+  rw [← SetLike.mem_coe]
+  refine closure_minimal ?_ ?_ h₁
+  · rw [← NonUnitalStarSubalgebra.coe_map, SetLike.coe_subset_coe, NonUnitalStarSubalgebra.map_le]
+    apply NonUnitalStarAlgebra.adjoin_le
+    apply Set.singleton_subset_iff.mpr
+    rw [SetLike.mem_coe, NonUnitalStarSubalgebra.mem_comap, nucfcAux_id hp₁ a ha]
+    exact ⟨a, rfl⟩
+  · have : Continuous (Unitization.fst (R := 𝕜) (A := A)) :=
+      Unitization.uniformEquivProd.continuous.fst
+    simp only [NonUnitalStarAlgHom.coe_range]
+    convert IsClosed.preimage this (isClosed_singleton (x := 0))
+    aesop
+
+open Unitization NonUnitalStarAlgHom in
+theorem RCLike.nonUnitalContinuousFunctionalCalculus :
+    NonUnitalContinuousFunctionalCalculus 𝕜 (p : A → Prop) where
+  exists_cfc_of_predicate a ha := by
+    let ψ : C(σₙ 𝕜 a, 𝕜)₀ →⋆ₙₐ[𝕜] A := comp (inrRangeEquiv 𝕜 A).symm <|
+      codRestrict (nucfcAux hp₁ a ha) _ (nucfcAux_mem_range_inr hp₁ a ha)
+    have coe_ψ (f : C(σₙ 𝕜 a, 𝕜)₀) : ψ f = nucfcAux hp₁ a ha f :=
+      congr_arg Subtype.val <| (inrRangeEquiv 𝕜 A).apply_symm_apply
+        ⟨nucfcAux hp₁ a ha f, nucfcAux_mem_range_inr hp₁ a ha f⟩
+    refine ⟨ψ, ?closedEmbedding, ?map_id, fun f ↦ ?map_spec, fun f ↦ ?isStarNormal⟩
+    case closedEmbedding =>
+      apply isometry_inr (𝕜 := 𝕜) (A := A) |>.closedEmbedding |>.of_comp_iff.mp
+      have : inr ∘ ψ = nucfcAux hp₁ a ha := by ext1; rw [Function.comp_apply, coe_ψ]
+      exact this ▸ closedEmbedding_nucfcAux hp₁ a ha
+    case map_id => exact inr_injective (R := 𝕜) <| coe_ψ _ ▸ nucfcAux_id hp₁ a ha
+    case map_spec =>
+      exact quasispectrum_eq_spectrum_inr' 𝕜 𝕜 (ψ f) ▸ coe_ψ _ ▸ spec_nucfcAux hp₁ a ha f
+    case isStarNormal => exact hp₁.mp <| coe_ψ _ ▸ cfcHom_predicate (R := 𝕜) (hp₁.mpr ha) _
+
+end RCLike
+
+/-!
+### Continuous functional calculus for normal elements
+-/
+
+section Normal
 
 instance IsStarNormal.instContinuousFunctionalCalculus {A : Type*} [NormedRing A] [StarRing A]
     [CstarRing A] [CompleteSpace A] [NormedAlgebra ℂ A] [StarModule ℂ A] :
@@ -62,11 +159,93 @@ instance IsStarNormal.instContinuousFunctionalCalculus {A : Type*} [NormedRing A
         AlgEquiv.spectrum_eq (continuousFunctionalCalculus a), ContinuousMap.spectrum_eq_range]
     case predicate_hom => exact fun f ↦ ⟨by rw [← map_star]; exact Commute.all (star f) f |>.map _⟩
 
+instance IsStarNormal.instNonUnitalContinuousFunctionalCalculus {A : Type*} [NonUnitalNormedRing A]
+    [StarRing A] [CstarRing A] [CompleteSpace A] [NormedSpace ℂ A] [IsScalarTower ℂ A A]
+    [SMulCommClass ℂ A A] [StarModule ℂ A] :
+    NonUnitalContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop) :=
+  RCLike.nonUnitalContinuousFunctionalCalculus Unitization.isStarNormal_inr
+
+instance IsStarNormal.cfcₙ_map {R A : Type*} {p : A → Prop} [CommSemiring R] [StarRing R]
+    [MetricSpace R] [TopologicalSemiring R] [ContinuousStar R] [Nontrivial R] [TopologicalSpace A]
+    [NonUnitalRing A] [StarRing A] [Module R A] [IsScalarTower R A A] [SMulCommClass R A A]
+    [NonUnitalContinuousFunctionalCalculus R p] (a : A) (f : R → R) :
+    IsStarNormal (cfcₙ f a) where
+  star_comm_self := by
+    refine cfcₙ_cases (fun x ↦ Commute (star x) x) _ _ (Commute.zero_right _) fun _ _ _ ↦ ?_
+    simp only [Commute, SemiconjBy]
+    rw [← cfcₙ_apply f a, ← cfcₙ_star, ← cfcₙ_mul .., ← cfcₙ_mul ..]
+    congr! 2
+    exact mul_comm _ _
+
+instance IsStarNormal.cfc_map {R A : Type*} {p : A → Prop} [CommSemiring R] [StarRing R]
+    [MetricSpace R] [TopologicalSemiring R] [ContinuousStar R] [TopologicalSpace A] [Ring A]
+    [StarRing A] [Algebra R A] [ContinuousFunctionalCalculus R p] (a : A) (f : R → R) :
+    IsStarNormal (cfc f a) where
+  star_comm_self := by
+    rw [Commute, SemiconjBy]
+    by_cases h : ContinuousOn f (spectrum R a)
+    · rw [← cfc_star, ← cfc_mul .., ← cfc_mul ..]
+      congr! 2
+      exact mul_comm _ _
+    · simp [cfc_apply_of_not_continuousOn a h]
+end Normal
+
+/-!
+### Continuous functional calculus for selfadjoint elements
+-/
+
+section SelfAdjointNonUnital
+
+variable {A : Type*} [TopologicalSpace A] [NonUnitalRing A] [StarRing A] [Module ℂ A]
+  [IsScalarTower ℂ A A] [SMulCommClass ℂ A A] [StarModule ℂ A]
+  [NonUnitalContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop)]
+
+/-- An element in a non-unital C⋆-algebra is selfadjoint if and only if it is normal and its
+quasispectrum is contained in `ℝ`. -/
+lemma isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts {a : A} :
+    IsSelfAdjoint a ↔ IsStarNormal a ∧ QuasispectrumRestricts a Complex.reCLM := by
+  refine ⟨fun ha ↦ ⟨ha.isStarNormal, ⟨fun x hx ↦ ?_, Complex.ofReal_re⟩⟩, ?_⟩
+  · have := eqOn_of_cfcₙ_eq_cfcₙ <|
+      (cfcₙ_star (id : ℂ → ℂ) a).symm ▸ (cfcₙ_id ℂ a).symm ▸ ha.star_eq
+    exact Complex.conj_eq_iff_re.mp (by simpa using this hx)
+  · rintro ⟨ha₁, ha₂⟩
+    rw [isSelfAdjoint_iff]
+    nth_rw 2 [← cfcₙ_id ℂ a]
+    rw [← cfcₙ_star_id a (R := ℂ)]
+    refine cfcₙ_congr fun x hx ↦ ?_
+    obtain ⟨x, -, rfl⟩ := ha₂.algebraMap_image.symm ▸ hx
+    exact Complex.conj_ofReal _
+
+alias ⟨IsSelfAdjoint.quasispectrumRestricts, _⟩ :=
+  isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts
+
+/-- A normal element whose `ℂ`-quasispectrum is contained in `ℝ` is selfadjoint. -/
+lemma QuasispectrumRestricts.isSelfAdjoint (a : A) (ha : QuasispectrumRestricts a Complex.reCLM)
+    [IsStarNormal a] : IsSelfAdjoint a :=
+  isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts.mpr ⟨‹_›, ha⟩
+
+instance IsSelfAdjoint.instNonUnitalContinuousFunctionalCalculus
+    [∀ x : A, CompactSpace (σₙ ℂ x)] :
+    NonUnitalContinuousFunctionalCalculus ℝ (IsSelfAdjoint : A → Prop) :=
+  QuasispectrumRestricts.cfc (q := IsStarNormal) (p := IsSelfAdjoint) Complex.reCLM
+    Complex.isometry_ofReal.uniformEmbedding
+    (fun _ ↦ isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts)
+    (fun _ _ ↦ inferInstance)
+
+end SelfAdjointNonUnital
+
+section SelfAdjointUnital
+
+
 variable {A : Type*} [TopologicalSpace A] [Ring A] [StarRing A] [Algebra ℂ A]
   [StarModule ℂ A] [ContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop)]
 
-attribute [aesop safe apply] IsSelfAdjoint.isStarNormal
-
+/-
+TODO: REMOVE
+this is a duplicate of `isSelfAdjoint_iff_isStarNormal_and_quasispectrumRestricts`, because of
+`abbrev SpectrumRestricts := QuasispectrumRestricts` but we first need unital-to-non-unital
+instance)
+-/
 /-- An element in a C⋆-algebra is selfadjoint if and only if it is normal and its spectrum is
 contained in `ℝ`. -/
 lemma isSelfAdjoint_iff_isStarNormal_and_spectrumRestricts {a : A} :
@@ -82,10 +261,12 @@ lemma isSelfAdjoint_iff_isStarNormal_and_spectrumRestricts {a : A} :
     obtain ⟨x, -, rfl⟩ := ha₂.algebraMap_image.symm ▸ hx
     exact Complex.conj_ofReal _
 
+-- TODO: REMOVE (duplicate; see comment on `isSelfAdjoint_iff_isStarNormal_and_spectrumRestricts`)
 lemma IsSelfAdjoint.spectrumRestricts {a : A} (ha : IsSelfAdjoint a) :
     SpectrumRestricts a Complex.reCLM :=
   isSelfAdjoint_iff_isStarNormal_and_spectrumRestricts.mp ha |>.right
 
+-- TODO: REMOVE (duplicate; see comment on `isSelfAdjoint_iff_isStarNormal_and_spectrumRestricts`)
 /-- A normal element whose `ℂ`-spectrum is contained in `ℝ` is selfadjoint. -/
 lemma SpectrumRestricts.isSelfAdjoint (a : A) (ha : SpectrumRestricts a Complex.reCLM)
     [IsStarNormal a] : IsSelfAdjoint a :=
@@ -98,40 +279,56 @@ instance IsSelfAdjoint.instContinuousFunctionalCalculus [∀ x : A, CompactSpace
     (fun _ ↦ isSelfAdjoint_iff_isStarNormal_and_spectrumRestricts)
     (fun _ _ ↦ inferInstance)
 
-lemma unitary_iff_isStarNormal_and_spectrum_subset_circle {u : A} :
-    u ∈ unitary A ↔ IsStarNormal u ∧ spectrum ℂ u ⊆ circle := by
-  refine ⟨fun hu ↦ ?_, ?_⟩
-  · have h_normal := isStarNormal_of_mem_unitary hu
-    refine ⟨h_normal, ?_⟩
-    have h := unitary.star_mul_self_of_mem hu
-    rw [← cfc_id ℂ u, ← cfc_star id u, ← cfc_mul .., ← cfc_one ℂ u] at h
-    have := eqOn_of_cfc_eq_cfc h
-    peel this with x hx _
-    rw [SetLike.mem_coe, mem_circle_iff_normSq]
-    simpa using congr($(this).re)
-  · rintro ⟨_, hu⟩
-    rw [unitary.mem_iff, ← cfc_id ℂ u, ← cfc_star, ← cfc_mul .., ← cfc_mul .., ← cfc_one ℂ u]
-    simp only [id_eq]
-    constructor
-    all_goals
-      apply cfc_congr (fun x hx ↦ ?_)
-      simp only [RCLike.star_def, mul_comm x]
-      apply hu at hx
-      rwa [SetLike.mem_coe, mem_circle_iff_normSq, ← Complex.ofReal_injective.eq_iff,
-        Complex.normSq_eq_conj_mul_self] at hx
+end SelfAdjointUnital
 
-lemma mem_unitary_of_spectrum_subset_circle {u : A}
-    [IsStarNormal u] (hu : spectrum ℂ u ⊆ circle) : u ∈ unitary A :=
-  unitary_iff_isStarNormal_and_spectrum_subset_circle.mpr ⟨‹_›, hu⟩
-
-lemma spectrum_subset_circle_of_mem_unitary {u : A} (hu : u ∈ unitary A) :
-    spectrum ℂ u ⊆ circle :=
-  unitary_iff_isStarNormal_and_spectrum_subset_circle.mp hu |>.right
-
-end Normal
+/-!
+### Continuous functional calculus for nonnegative elements
+-/
 
 section Nonneg
 
+lemma CFC.exists_sqrt_of_isSelfAdjoint_of_quasispectrumRestricts {A : Type*} [NonUnitalRing A]
+    [StarRing A] [TopologicalSpace A] [Module ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A ]
+    [NonUnitalContinuousFunctionalCalculus ℝ (IsSelfAdjoint : A → Prop)]
+    {a : A} (ha₁ : IsSelfAdjoint a) (ha₂ : QuasispectrumRestricts a ContinuousMap.realToNNReal) :
+    ∃ x : A, IsSelfAdjoint x ∧ QuasispectrumRestricts x ContinuousMap.realToNNReal ∧ x * x = a := by
+  use cfcₙ Real.sqrt a, cfcₙ_predicate Real.sqrt a
+  constructor
+  · simpa only [QuasispectrumRestricts.nnreal_iff, cfcₙ_map_quasispectrum Real.sqrt a,
+      Set.mem_image, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+        using fun x _ ↦ Real.sqrt_nonneg x
+  · rw [← cfcₙ_mul ..]
+    nth_rw 2 [← cfcₙ_id ℝ a]
+    apply cfcₙ_congr fun x hx ↦ ?_
+    rw [QuasispectrumRestricts.nnreal_iff] at ha₂
+    apply ha₂ x at hx
+    simp [← sq, Real.sq_sqrt hx]
+
+variable {A : Type*} [NonUnitalRing A] [PartialOrder A] [StarRing A] [StarOrderedRing A]
+variable [TopologicalSpace A] [Module ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A]
+variable [NonUnitalContinuousFunctionalCalculus ℝ (IsSelfAdjoint : A → Prop)]
+variable [NonnegSpectrumClass ℝ A] [UniqueNonUnitalContinuousFunctionalCalculus ℝ A]
+
+lemma nonneg_iff_isSelfAdjoint_and_quasispectrumRestricts {a : A} :
+    0 ≤ a ↔ IsSelfAdjoint a ∧ QuasispectrumRestricts a ContinuousMap.realToNNReal := by
+  refine ⟨fun ha ↦ ⟨.of_nonneg ha, .nnreal_of_nonneg ha⟩, ?_⟩
+  rintro ⟨ha₁, ha₂⟩
+  obtain ⟨x, hx, -, rfl⟩ := CFC.exists_sqrt_of_isSelfAdjoint_of_quasispectrumRestricts ha₁ ha₂
+  simpa [sq, hx.star_eq] using star_mul_self_nonneg x
+
+open NNReal in
+instance Nonneg.instNonUnitalContinuousFunctionalCalculus [∀ a : A, CompactSpace (σₙ ℝ a)] :
+    NonUnitalContinuousFunctionalCalculus ℝ≥0 (fun x : A ↦ 0 ≤ x) :=
+  QuasispectrumRestricts.cfc (q := IsSelfAdjoint) ContinuousMap.realToNNReal
+    uniformEmbedding_subtype_val (fun _ ↦ nonneg_iff_isSelfAdjoint_and_quasispectrumRestricts)
+    (fun _ _ ↦ inferInstance)
+
+end Nonneg
+
+
+section Nonneg
+
+-- TODO: REMOVE (duplicate; see comment on `isSelfAdjoint_iff_isStarNormal_and_spectrumRestricts`)
 lemma CFC.exists_sqrt_of_isSelfAdjoint_of_spectrumRestricts {A : Type*} [Ring A] [StarRing A]
     [TopologicalSpace A] [Algebra ℝ A] [ContinuousFunctionalCalculus ℝ (IsSelfAdjoint : A → Prop)]
     {a : A} (ha₁ : IsSelfAdjoint a) (ha₂ : SpectrumRestricts a ContinuousMap.realToNNReal) :
@@ -151,6 +348,7 @@ variable {A : Type*} [Ring A] [PartialOrder A] [StarRing A] [StarOrderedRing A] 
 variable [Algebra ℝ A] [ContinuousFunctionalCalculus ℝ (IsSelfAdjoint : A → Prop)]
 variable [NonnegSpectrumClass ℝ A] [UniqueContinuousFunctionalCalculus ℝ A]
 
+-- TODO: REMOVE (duplicate; see comment on `isSelfAdjoint_iff_isStarNormal_and_spectrumRestricts`)
 lemma nonneg_iff_isSelfAdjoint_and_spectrumRestricts {a : A} :
     0 ≤ a ↔ IsSelfAdjoint a ∧ SpectrumRestricts a ContinuousMap.realToNNReal := by
   refine ⟨fun ha ↦ ⟨.of_nonneg ha, .nnreal_of_nonneg ha⟩, ?_⟩
@@ -166,6 +364,11 @@ instance Nonneg.instContinuousFunctionalCalculus [∀ a : A, CompactSpace (spect
     (fun _ _ ↦ inferInstance)
 
 end Nonneg
+
+/-!
+### The spectrum of a nonnegative element is nonnegative
+-/
+
 section SpectrumRestricts
 
 open NNReal ENNReal
@@ -192,7 +395,6 @@ lemma SpectrumRestricts.nnreal_add {a b : A} (ha₁ : IsSelfAdjoint a)
   refine nnnorm_add_le _ _ |>.trans ?_
   gcongr
   all_goals rw [← SpectrumRestricts.nnreal_iff_nnnorm] <;> first | rfl | assumption
-
 
 lemma IsSelfAdjoint.sq_spectrumRestricts {a : A} (ha : IsSelfAdjoint a) :
     SpectrumRestricts (a ^ 2) ContinuousMap.realToNNReal := by
@@ -228,7 +430,6 @@ lemma SpectrumRestricts.smul_of_nonneg {A : Type*} [Ring A] [Algebra ℝ A] {a :
     refine le_of_smul_le_smul_left ?_ (inv_pos.mpr <| lt_of_le_of_ne hr <| ne_comm.mpr hr')
     simpa [Units.smul_def] using ha _ hx
 
-set_option backward.isDefEq.lazyProjDelta false in -- See https://github.com/leanprover-community/mathlib4/issues/12535
 lemma spectrum_star_mul_self_nonneg {b : A} : ∀ x ∈ spectrum ℝ (star b * b), 0 ≤ x := by
   set a := star b * b
   have a_def : a = star b * b := rfl
@@ -279,7 +480,7 @@ lemma spectrum_star_mul_self_nonneg {b : A} : ∀ x ∈ spectrum ℝ (star b * b
   by_contra! hx'
   rw [← neg_pos] at hx'
   apply (pow_pos hx' 3).ne
-  have h_eqOn := eqOn_of_cfc_eq_cfc (a := star b * b) h_eq_a_neg
+  have h_eqOn := eqOn_of_cfc_eq_cfc (ha := IsSelfAdjoint.star_mul_self b) h_eq_a_neg
   simpa [sup_eq_left.mpr hx'.le] using h_eqOn hx
 
 end SpectrumRestricts
@@ -307,6 +508,83 @@ instance CstarRing.instNonnegSpectrumClass : NonnegSpectrumClass ℝ A :=
 
 end NonnegSpectrumClass
 
+section SpectralOrder
+
+variable (A : Type*) [NormedRing A] [CompleteSpace A] [StarRing A] [CstarRing A]
+variable [NormedAlgebra ℂ A] [StarModule ℂ A]
+
+/-- The partial order on a unital C⋆-algebra defined by `x ≤ y` if and only if `y - x` is
+selfadjoint and has nonnegative spectrum.
+
+This is not declared as an instance because one may already have a partial order with better
+definitional properties. However, it can be useful to invoke this as an instance in proofs. -/
+@[reducible]
+def CstarRing.spectralOrder : PartialOrder A where
+  le x y := IsSelfAdjoint (y - x) ∧ SpectrumRestricts (y - x) ContinuousMap.realToNNReal
+  le_refl := by
+    simp only [sub_self, isSelfAdjoint_zero, true_and, forall_const]
+    rw [SpectrumRestricts.nnreal_iff]
+    nontriviality A
+    simp
+  le_antisymm x y hxy hyx := by
+    rw [← sub_eq_zero]
+    exact hyx.2.eq_zero_of_neg hyx.1 (neg_sub x y ▸ hxy.2)
+  le_trans x y z hxy hyz :=
+    ⟨by simpa using hyz.1.add hxy.1, by simpa using hyz.2.nnreal_add hyz.1 hxy.1 hxy.2⟩
+
+/-- The `CstarRing.spectralOrder` on a unital C⋆-algebra is a `StarOrderedRing`. -/
+lemma CstarRing.spectralOrderedRing : @StarOrderedRing A _ (CstarRing.spectralOrder A) _ :=
+  let _ := CstarRing.spectralOrder A
+  { le_iff := by
+      intro x y
+      constructor
+      · intro h
+        obtain ⟨s, hs₁, _, hs₂⟩ := CFC.exists_sqrt_of_isSelfAdjoint_of_spectrumRestricts h.1 h.2
+        refine ⟨s ^ 2, ?_, by rwa [eq_sub_iff_add_eq', eq_comm] at hs₂⟩
+        exact AddSubmonoid.subset_closure ⟨s, by simp [hs₁.star_eq, sq]⟩
+      · rintro ⟨p, hp, rfl⟩
+        suffices IsSelfAdjoint p ∧ SpectrumRestricts p ContinuousMap.realToNNReal from
+          ⟨by simpa using this.1, by simpa using this.2⟩
+        induction hp using AddSubmonoid.closure_induction' with
+        | mem x hx =>
+          obtain ⟨s, rfl⟩ := hx
+          refine ⟨IsSelfAdjoint.star_mul_self s, ?_⟩
+          rw [SpectrumRestricts.nnreal_iff]
+          exact spectrum_star_mul_self_nonneg
+        | one =>
+          rw [SpectrumRestricts.nnreal_iff]
+          nontriviality A
+          simp
+        | mul x _ y _ hx hy =>
+          exact ⟨hx.1.add hy.1, hx.2.nnreal_add hx.1 hy.1 hy.2⟩ }
+
+end SpectralOrder
+
+section NonnegSpectrumClass
+
+variable {A : Type*} [NonUnitalNormedRing A] [CompleteSpace A]
+variable [PartialOrder A] [StarRing A] [StarOrderedRing A] [CstarRing A]
+variable [NormedSpace ℂ A] [IsScalarTower ℂ A A] [SMulCommClass ℂ A A] [StarModule ℂ A]
+
+instance CstarRing.instNonnegSpectrumClass' : NonnegSpectrumClass ℝ A where
+  quasispectrum_nonneg_of_nonneg a ha := by
+    rw [Unitization.quasispectrum_eq_spectrum_inr' _ ℂ]
+    -- should this actually be an instance on the `Unitization`? (probably scoped)
+    let _ := CstarRing.spectralOrder (Unitization ℂ A)
+    have := CstarRing.spectralOrderedRing (Unitization ℂ A)
+    apply spectrum_nonneg_of_nonneg
+    rw [StarOrderedRing.nonneg_iff] at ha ⊢
+    have := AddSubmonoid.mem_map_of_mem (Unitization.inrNonUnitalStarAlgHom ℂ A) ha
+    rw [AddMonoidHom.map_mclosure, ← Set.range_comp] at this
+    apply AddSubmonoid.closure_mono ?_ this
+    rintro _ ⟨s, rfl⟩
+    exact ⟨s, by simp⟩
+
+end NonnegSpectrumClass
+
+/-!
+### The restriction of a continuous functional calculus is equal to the original one
+-/
 section RealEqComplex
 
 variable {A : Type*} [TopologicalSpace A] [Ring A] [StarRing A] [Algebra ℂ A]
@@ -354,5 +632,46 @@ lemma cfc_nnreal_eq_real {a : A} (f : ℝ≥0 → ℝ≥0) (ha : 0 ≤ a := by c
     uniformEmbedding_subtype_val ha (.of_nonneg ha)
 
 end NNRealEqReal
+
+section Unitary -- TODO: move to a new file
+
+/-!
+### conditions on unitary elements imposed by the continuous functional calculus
+-/
+
+variable {A : Type*} [TopologicalSpace A] [Ring A] [StarRing A] [Algebra ℂ A]
+  [StarModule ℂ A] [ContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop)]
+
+lemma unitary_iff_isStarNormal_and_spectrum_subset_circle {u : A} :
+    u ∈ unitary A ↔ IsStarNormal u ∧ spectrum ℂ u ⊆ circle := by
+  refine ⟨fun hu ↦ ?_, ?_⟩
+  · have h_normal := isStarNormal_of_mem_unitary hu
+    refine ⟨h_normal, ?_⟩
+    have h := unitary.star_mul_self_of_mem hu
+    rw [← cfc_id ℂ u, ← cfc_star id u, ← cfc_mul .., ← cfc_one ℂ u] at h
+    have := eqOn_of_cfc_eq_cfc h
+    peel this with x hx _
+    rw [SetLike.mem_coe, mem_circle_iff_normSq]
+    simpa using congr($(this).re)
+  · rintro ⟨_, hu⟩
+    rw [unitary.mem_iff, ← cfc_id ℂ u, ← cfc_star, ← cfc_mul .., ← cfc_mul .., ← cfc_one ℂ u]
+    simp only [id_eq]
+    constructor
+    all_goals
+      apply cfc_congr (fun x hx ↦ ?_)
+      simp only [RCLike.star_def, mul_comm x]
+      apply hu at hx
+      rwa [SetLike.mem_coe, mem_circle_iff_normSq, ← Complex.ofReal_injective.eq_iff,
+        Complex.normSq_eq_conj_mul_self] at hx
+
+lemma mem_unitary_of_spectrum_subset_circle {u : A}
+    [IsStarNormal u] (hu : spectrum ℂ u ⊆ circle) : u ∈ unitary A :=
+  unitary_iff_isStarNormal_and_spectrum_subset_circle.mpr ⟨‹_›, hu⟩
+
+lemma spectrum_subset_circle_of_mem_unitary {u : A} (hu : u ∈ unitary A) :
+    spectrum ℂ u ⊆ circle :=
+  unitary_iff_isStarNormal_and_spectrum_subset_circle.mp hu |>.right
+
+end Unitary
 
 end

--- a/Mathlib/Analysis/NormedSpace/Unitization.lean
+++ b/Mathlib/Analysis/NormedSpace/Unitization.lean
@@ -200,6 +200,10 @@ end Aux
 instance instUniformSpace : UniformSpace (Unitization 𝕜 A) :=
   instUniformSpaceProd.comap (addEquiv 𝕜 A)
 
+/-- The natural equivalence between `Unitization 𝕜 A` and `𝕜 × A` as a uniform equivalence. -/
+def uniformEquivProd : (Unitization 𝕜 A) ≃ᵤ (𝕜 × A) :=
+  Equiv.toUniformEquivOfUniformInducing (addEquiv 𝕜 A) ⟨rfl⟩
+
 /-- The bornology on `Unitization 𝕜 A` is inherited from `𝕜 × A`. -/
 instance instBornology : Bornology (Unitization 𝕜 A) :=
   Bornology.induced <| addEquiv 𝕜 A


### PR DESCRIPTION
This adds instances of the non-unital continuous functional calculus (for normal, selfadjoint and nonnegative elements) for non-unital C⋆-algebras.

---

I'm sorry the diff on this is so bad. No existing results have been deleted (and one proof was only minimally modified), but this is I think the correct ordering of results in this file.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
