### PR TITLE
[Merged by Bors] - chore: add deprecation dates for `nat_cast` and `int_cast` lemmas

### DIFF
--- a/Mathlib/Algebra/CharP/ExpChar.lean
+++ b/Mathlib/Algebra/CharP/ExpChar.lean
@@ -401,6 +401,9 @@ theorem frobenius_natCast (n : ℕ) : frobenius R p n = n :=
   map_natCast (frobenius R p) n
 #align frobenius_nat_cast frobenius_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias frobenius_nat_cast := frobenius_natCast
+
 variable {R}
 
 theorem list_sum_pow_char (l : List R) : l.sum ^ p = (l.map (· ^ p : R → R)).sum :=

--- a/Mathlib/Algebra/CharZero/Lemmas.lean
+++ b/Mathlib/Algebra/CharZero/Lemmas.lean
@@ -67,9 +67,15 @@ lemma support_natCast (hn : n ≠ 0) : support (n : α → M) = univ :=
   support_const <| Nat.cast_ne_zero.2 hn
 #align function.support_nat_cast Function.support_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias support_nat_cast := support_natCast
+
 lemma mulSupport_natCast (hn : n ≠ 1) : mulSupport (n : α → M) = univ :=
   mulSupport_const <| Nat.cast_ne_one.2 hn
 #align function.mul_support_nat_cast Function.mulSupport_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias mulSupport_nat_cast := mulSupport_natCast
 
 end Function
 end AddMonoidWithOne

--- a/Mathlib/Algebra/DirectSum/Internal.lean
+++ b/Mathlib/Algebra/DirectSum/Internal.lean
@@ -68,6 +68,9 @@ theorem SetLike.natCast_mem_graded [Zero ι] [AddMonoidWithOne R] [SetLike σ R]
     exact add_mem n_ih (SetLike.one_mem_graded _)
 #align set_like.nat_cast_mem_graded SetLike.natCast_mem_graded
 
+@[deprecated (since := "2024-04-17")]
+alias SetLike.nat_cast_mem_graded := SetLike.natCast_mem_graded
+
 theorem SetLike.intCast_mem_graded [Zero ι] [AddGroupWithOne R] [SetLike σ R]
     [AddSubgroupClass σ R] (A : ι → σ) [SetLike.GradedOne A] (z : ℤ) : (z : R) ∈ A 0 := by
   induction z
@@ -76,6 +79,9 @@ theorem SetLike.intCast_mem_graded [Zero ι] [AddGroupWithOne R] [SetLike σ R]
   · rw [Int.cast_negSucc]
     exact neg_mem (SetLike.natCast_mem_graded _ _)
 #align set_like.int_cast_mem_graded SetLike.intCast_mem_graded
+
+@[deprecated (since := "2024-04-17")]
+alias SetLike.int_cast_mem_graded := SetLike.intCast_mem_graded
 
 section DirectSum
 

--- a/Mathlib/Algebra/Group/Hom/Instances.lean
+++ b/Mathlib/Algebra/Group/Hom/Instances.lean
@@ -103,6 +103,9 @@ theorem AddMonoid.End.intCast_apply [AddCommGroup M] (z : ℤ) (m : M) :
   rfl
 #align add_monoid.End.int_cast_apply AddMonoid.End.intCast_apply
 
+@[deprecated (since := "2024-04-17")]
+alias AddMonoid.End.int_cast_apply := AddMonoid.End.intCast_apply
+
 /-!
 ### Morphisms of morphisms
 

--- a/Mathlib/Algebra/Group/Subgroup/ZPowers.lean
+++ b/Mathlib/Algebra/Group/Subgroup/ZPowers.lean
@@ -149,10 +149,16 @@ theorem intCast_mul_mem_zmultiples : ↑(k : ℤ) * r ∈ zmultiples r := by
   simpa only [← zsmul_eq_mul] using zsmul_mem_zmultiples r k
 #align add_subgroup.int_cast_mul_mem_zmultiples AddSubgroup.intCast_mul_mem_zmultiples
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_mul_mem_zmultiples := intCast_mul_mem_zmultiples
+
 @[simp]
 theorem intCast_mem_zmultiples_one : ↑(k : ℤ) ∈ zmultiples (1 : R) :=
   mem_zmultiples_iff.mp ⟨k, by simp⟩
 #align add_subgroup.int_cast_mem_zmultiples_one AddSubgroup.intCast_mem_zmultiples_one
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_mem_zmultiples_one := intCast_mem_zmultiples_one
 
 end Ring
 

--- a/Mathlib/Algebra/Module/Basic.lean
+++ b/Mathlib/Algebra/Module/Basic.lean
@@ -22,6 +22,9 @@ universe u v
 
 variable {α R M M₂ : Type*}
 
+@[deprecated (since := "2024-04-17")]
+alias map_nat_cast_smul := map_natCast_smul
+
 theorem map_inv_natCast_smul [AddCommMonoid M] [AddCommMonoid M₂] {F : Type*} [FunLike F M M₂]
     [AddMonoidHomClass F M M₂] (f : F) (R S : Type*)
     [DivisionSemiring R] [DivisionSemiring S] [Module R M]
@@ -40,6 +43,9 @@ theorem map_inv_natCast_smul [AddCommMonoid M] [AddCommMonoid M₂] {F : Type*} 
   · rw [← inv_smul_smul₀ hS (f _), ← map_natCast_smul f R S, smul_inv_smul₀ hR]
 #align map_inv_nat_cast_smul map_inv_natCast_smul
 
+@[deprecated (since := "2024-04-17")]
+alias map_inv_nat_cast_smul := map_inv_natCast_smul
+
 theorem map_inv_intCast_smul [AddCommGroup M] [AddCommGroup M₂] {F : Type*} [FunLike F M M₂]
     [AddMonoidHomClass F M M₂] (f : F) (R S : Type*) [DivisionRing R] [DivisionRing S] [Module R M]
     [Module S M₂] (z : ℤ) (x : M) : f ((z⁻¹ : R) • x) = (z⁻¹ : S) • f x := by
@@ -49,6 +55,9 @@ theorem map_inv_intCast_smul [AddCommGroup M] [AddCommGroup M₂] {F : Type*} [F
       map_inv_natCast_smul _ R S]
 #align map_inv_int_cast_smul map_inv_intCast_smul
 
+@[deprecated (since := "2024-04-17")]
+alias map_inv_int_cast_smul := map_inv_intCast_smul
+
 theorem map_ratCast_smul [AddCommGroup M] [AddCommGroup M₂] {F : Type*} [FunLike F M M₂]
     [AddMonoidHomClass F M M₂] (f : F) (R S : Type*) [DivisionRing R] [DivisionRing S] [Module R M]
     [Module S M₂] (c : ℚ) (x : M) :
@@ -56,6 +65,9 @@ theorem map_ratCast_smul [AddCommGroup M] [AddCommGroup M₂] {F : Type*} [FunLi
   rw [Rat.cast_def, Rat.cast_def, div_eq_mul_inv, div_eq_mul_inv, mul_smul, mul_smul,
     map_intCast_smul f R S, map_inv_natCast_smul f R S]
 #align map_rat_cast_smul map_ratCast_smul
+
+@[deprecated (since := "2024-04-17")]
+alias map_rat_cast_smul := map_ratCast_smul
 
 theorem map_rat_smul [AddCommGroup M] [AddCommGroup M₂]
     [_instM : Module ℚ M] [_instM₂ : Module ℚ M₂]
@@ -78,12 +90,18 @@ theorem inv_natCast_smul_eq {E : Type*} (R S : Type*) [AddCommMonoid E] [Divisio
   map_inv_natCast_smul (AddMonoidHom.id E) R S n x
 #align inv_nat_cast_smul_eq inv_natCast_smul_eq
 
+@[deprecated (since := "2024-04-17")]
+alias inv_nat_cast_smul_eq := inv_natCast_smul_eq
+
 /-- If `E` is a vector space over two division rings `R` and `S`, then scalar multiplications
 agree on inverses of integer numbers in `R` and `S`. -/
 theorem inv_intCast_smul_eq {E : Type*} (R S : Type*) [AddCommGroup E] [DivisionRing R]
     [DivisionRing S] [Module R E] [Module S E] (n : ℤ) (x : E) : (n⁻¹ : R) • x = (n⁻¹ : S) • x :=
   map_inv_intCast_smul (AddMonoidHom.id E) R S n x
 #align inv_int_cast_smul_eq inv_intCast_smul_eq
+
+@[deprecated (since := "2024-04-17")]
+alias inv_int_cast_smul_eq := inv_intCast_smul_eq
 
 /-- If `E` is a vector space over a division semiring `R` and has a monoid action by `α`, then that
 action commutes by scalar multiplication of inverses of natural numbers in `R`. -/
@@ -93,6 +111,9 @@ theorem inv_natCast_smul_comm {α E : Type*} (R : Type*) [AddCommMonoid E] [Divi
   (map_inv_natCast_smul (DistribMulAction.toAddMonoidHom E s) R R n x).symm
 #align inv_nat_cast_smul_comm inv_natCast_smul_comm
 
+@[deprecated (since := "2024-04-17")]
+alias inv_nat_cast_smul_comm := inv_natCast_smul_comm
+
 /-- If `E` is a vector space over a division ring `R` and has a monoid action by `α`, then that
 action commutes by scalar multiplication of inverses of integers in `R` -/
 theorem inv_intCast_smul_comm {α E : Type*} (R : Type*) [AddCommGroup E] [DivisionRing R]
@@ -101,12 +122,18 @@ theorem inv_intCast_smul_comm {α E : Type*} (R : Type*) [AddCommGroup E] [Divis
   (map_inv_intCast_smul (DistribMulAction.toAddMonoidHom E s) R R n x).symm
 #align inv_int_cast_smul_comm inv_intCast_smul_comm
 
+@[deprecated (since := "2024-04-17")]
+alias inv_int_cast_smul_comm := inv_intCast_smul_comm
+
 /-- If `E` is a vector space over two division rings `R` and `S`, then scalar multiplications
 agree on rational numbers in `R` and `S`. -/
 theorem ratCast_smul_eq {E : Type*} (R S : Type*) [AddCommGroup E] [DivisionRing R]
     [DivisionRing S] [Module R E] [Module S E] (r : ℚ) (x : E) : (r : R) • x = (r : S) • x :=
   map_ratCast_smul (AddMonoidHom.id E) R S r x
 #align rat_cast_smul_eq ratCast_smul_eq
+
+@[deprecated (since := "2024-04-17")]
+alias rat_cast_smul_eq := ratCast_smul_eq
 
 instance IsScalarTower.rat {R : Type u} {M : Type v} [Ring R] [AddCommGroup M] [Module R M]
     [Module ℚ R] [Module ℚ M] : IsScalarTower ℚ R M where

--- a/Mathlib/Algebra/MonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Basic.lean
@@ -274,6 +274,9 @@ theorem natCast_def (n : ℕ) : (n : MonoidAlgebra k G) = single (1 : G) (n : k)
   rfl
 #align monoid_algebra.nat_cast_def MonoidAlgebra.natCast_def
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_def := natCast_def
+
 end MulOneClass
 
 /-! #### Semiring structure -/
@@ -351,6 +354,9 @@ theorem intCast_def [Ring k] [MulOneClass G] (z : ℤ) :
     (z : MonoidAlgebra k G) = single (1 : G) (z : k) :=
   rfl
 #align monoid_algebra.int_cast_def MonoidAlgebra.intCast_def
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_def := intCast_def
 
 instance ring [Ring k] [Monoid G] : Ring (MonoidAlgebra k G) :=
   { MonoidAlgebra.nonAssocRing, MonoidAlgebra.semiring with }
@@ -1425,6 +1431,9 @@ theorem natCast_def (n : ℕ) : (n : k[G]) = single (0 : G) (n : k) :=
   rfl
 #align add_monoid_algebra.nat_cast_def AddMonoidAlgebra.natCast_def
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_def := natCast_def
+
 end MulOneClass
 
 /-! #### Semiring structure -/
@@ -1503,6 +1512,9 @@ theorem intCast_def [Ring k] [AddZeroClass G] (z : ℤ) :
     (z : k[G]) = single (0 : G) (z : k) :=
   rfl
 #align add_monoid_algebra.int_cast_def AddMonoidAlgebra.intCast_def
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_def := intCast_def
 
 instance ring [Ring k] [AddMonoid G] : Ring k[G] :=
   { AddMonoidAlgebra.nonAssocRing, AddMonoidAlgebra.semiring with }

--- a/Mathlib/Algebra/Order/Interval/Set/Group.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Group.lean
@@ -240,11 +240,17 @@ theorem pairwise_disjoint_Ioc_add_intCast :
     pairwise_disjoint_Ioc_add_zsmul a (1 : α)
 #align set.pairwise_disjoint_Ioc_add_int_cast Set.pairwise_disjoint_Ioc_add_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias pairwise_disjoint_Ioc_add_int_cast := pairwise_disjoint_Ioc_add_intCast
+
 theorem pairwise_disjoint_Ico_add_intCast :
     Pairwise (Disjoint on fun n : ℤ => Ico (a + n) (a + n + 1)) := by
   simpa only [zsmul_one, Int.cast_add, Int.cast_one, ← add_assoc] using
     pairwise_disjoint_Ico_add_zsmul a (1 : α)
 #align set.pairwise_disjoint_Ico_add_int_cast Set.pairwise_disjoint_Ico_add_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias pairwise_disjoint_Ico_add_int_cast := pairwise_disjoint_Ico_add_intCast
 
 theorem pairwise_disjoint_Ioo_add_intCast :
     Pairwise (Disjoint on fun n : ℤ => Ioo (a + n) (a + n + 1)) := by
@@ -252,19 +258,31 @@ theorem pairwise_disjoint_Ioo_add_intCast :
     pairwise_disjoint_Ioo_add_zsmul a (1 : α)
 #align set.pairwise_disjoint_Ioo_add_int_cast Set.pairwise_disjoint_Ioo_add_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias pairwise_disjoint_Ioo_add_int_cast := pairwise_disjoint_Ioo_add_intCast
+
 variable (α)
 
 theorem pairwise_disjoint_Ico_intCast : Pairwise (Disjoint on fun n : ℤ => Ico (n : α) (n + 1)) :=
   by simpa only [zero_add] using pairwise_disjoint_Ico_add_intCast (0 : α)
 #align set.pairwise_disjoint_Ico_int_cast Set.pairwise_disjoint_Ico_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias pairwise_disjoint_Ico_int_cast := pairwise_disjoint_Ico_intCast
+
 theorem pairwise_disjoint_Ioo_intCast : Pairwise (Disjoint on fun n : ℤ => Ioo (n : α) (n + 1)) :=
   by simpa only [zero_add] using pairwise_disjoint_Ioo_add_intCast (0 : α)
 #align set.pairwise_disjoint_Ioo_int_cast Set.pairwise_disjoint_Ioo_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias pairwise_disjoint_Ioo_int_cast := pairwise_disjoint_Ioo_intCast
+
 theorem pairwise_disjoint_Ioc_intCast : Pairwise (Disjoint on fun n : ℤ => Ioc (n : α) (n + 1)) :=
   by simpa only [zero_add] using pairwise_disjoint_Ioc_add_intCast (0 : α)
 #align set.pairwise_disjoint_Ioc_int_cast Set.pairwise_disjoint_Ioc_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias pairwise_disjoint_Ioc_int_cast := pairwise_disjoint_Ioc_intCast
 
 end OrderedRing
 

--- a/Mathlib/Algebra/Order/Nonneg/Ring.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Ring.lean
@@ -228,7 +228,7 @@ protected theorem coe_natCast [OrderedSemiring α] (n : ℕ) : ((↑n : { x : α
 #align nonneg.coe_nat_cast Nonneg.coe_natCast
 
 @[deprecated (since := "2024-04-17")]
-alias coe_nat_cast := coe_natCast
+alias coe_nat_cast := Nonneg.coe_natCast
 
 @[simp]
 theorem mk_natCast [OrderedSemiring α] (n : ℕ) : (⟨n, n.cast_nonneg⟩ : { x : α // 0 ≤ x }) = n :=

--- a/Mathlib/Algebra/Order/Nonneg/Ring.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Ring.lean
@@ -227,10 +227,16 @@ protected theorem coe_natCast [OrderedSemiring α] (n : ℕ) : ((↑n : { x : α
   rfl
 #align nonneg.coe_nat_cast Nonneg.coe_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias coe_nat_cast := coe_natCast
+
 @[simp]
 theorem mk_natCast [OrderedSemiring α] (n : ℕ) : (⟨n, n.cast_nonneg⟩ : { x : α // 0 ≤ x }) = n :=
   rfl
 #align nonneg.mk_nat_cast Nonneg.mk_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias mk_nat_cast := mk_natCast
 
 instance pow [OrderedSemiring α] : Pow { x : α // 0 ≤ x } ℕ where
   pow x n := ⟨(x : α) ^ n, pow_nonneg x.2 n⟩

--- a/Mathlib/Algebra/Order/ToIntervalMod.lean
+++ b/Mathlib/Algebra/Order/ToIntervalMod.lean
@@ -1091,15 +1091,24 @@ theorem iUnion_Ioc_add_intCast : ⋃ n : ℤ, Ioc (a + n) (a + n + 1) = Set.univ
     iUnion_Ioc_add_zsmul zero_lt_one a
 #align Union_Ioc_add_int_cast iUnion_Ioc_add_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias iUnion_Ioc_add_int_cast := iUnion_Ioc_add_intCast
+
 theorem iUnion_Ico_add_intCast : ⋃ n : ℤ, Ico (a + n) (a + n + 1) = Set.univ := by
   simpa only [zsmul_one, Int.cast_add, Int.cast_one, ← add_assoc] using
     iUnion_Ico_add_zsmul zero_lt_one a
 #align Union_Ico_add_int_cast iUnion_Ico_add_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias iUnion_Ico_add_int_cast := iUnion_Ico_add_intCast
+
 theorem iUnion_Icc_add_intCast : ⋃ n : ℤ, Icc (a + n) (a + n + 1) = Set.univ := by
   simpa only [zsmul_one, Int.cast_add, Int.cast_one, ← add_assoc] using
     iUnion_Icc_add_zsmul zero_lt_one a
 #align Union_Icc_add_int_cast iUnion_Icc_add_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias iUnion_Icc_add_int_cast := iUnion_Icc_add_intCast
 
 variable (α)
 
@@ -1107,13 +1116,22 @@ theorem iUnion_Ioc_intCast : ⋃ n : ℤ, Ioc (n : α) (n + 1) = Set.univ := by
   simpa only [zero_add] using iUnion_Ioc_add_intCast (0 : α)
 #align Union_Ioc_int_cast iUnion_Ioc_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias iUnion_Ioc_int_cast := iUnion_Ioc_intCast
+
 theorem iUnion_Ico_intCast : ⋃ n : ℤ, Ico (n : α) (n + 1) = Set.univ := by
   simpa only [zero_add] using iUnion_Ico_add_intCast (0 : α)
 #align Union_Ico_int_cast iUnion_Ico_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias iUnion_Ico_int_cast := iUnion_Ico_intCast
+
 theorem iUnion_Icc_intCast : ⋃ n : ℤ, Icc (n : α) (n + 1) = Set.univ := by
   simpa only [zero_add] using iUnion_Icc_add_intCast (0 : α)
 #align Union_Icc_int_cast iUnion_Icc_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias iUnion_Icc_int_cast := iUnion_Icc_intCast
 
 end LinearOrderedRing
 

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -154,6 +154,9 @@ theorem eval₂_intCastRingHom_X {R : Type*} [Ring R] (p : ℤ[X]) (f : ℤ[X] �
 set_option linter.uppercaseLean3 false in
 #align polynomial.eval₂_int_cast_ring_hom_X Polynomial.eval₂_intCastRingHom_X
 
+@[deprecated (since := "2024-04-17")]
+alias eval₂_int_castRingHom_X := eval₂_intCastRingHom_X
+
 end CommSemiring
 
 section aeval
@@ -256,6 +259,9 @@ end deprecated
 theorem aeval_natCast (n : ℕ) : aeval x (n : R[X]) = n :=
   map_natCast _ _
 #align polynomial.aeval_nat_cast Polynomial.aeval_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias aeval_nat_cast := aeval_natCast
 
 theorem aeval_mul : aeval x (p * q) = aeval x p * aeval x q :=
   AlgHom.map_mul _ _ _

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -555,6 +555,9 @@ theorem C_eq_natCast (n : ℕ) : C (n : R) = (n : R[X]) :=
   map_natCast C n
 #align polynomial.C_eq_nat_cast Polynomial.C_eq_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias C_eq_nat_cast := C_eq_natCast
+
 @[simp]
 theorem C_mul_monomial : C a * monomial n b = monomial n (a * b) := by
   simp only [← monomial_zero_left, monomial_mul_monomial, zero_add]
@@ -756,6 +759,9 @@ lemma coeff_C_succ {r : R} {n : ℕ} : coeff (C r) (n + 1) = 0 := by simp [coeff
 @[simp]
 theorem coeff_natCast_ite : (Nat.cast m : R[X]).coeff n = ite (n = 0) m 0 := by
   simp only [← C_eq_natCast, coeff_C, Nat.cast_ite, Nat.cast_zero]
+
+@[deprecated (since := "2024-04-17")]
+alias coeff_nat_cast_ite := coeff_natCast_ite
 
 -- See note [no_index around OfNat.ofNat]
 @[simp]
@@ -966,6 +972,9 @@ theorem binomial_eq_binomial {k l m n : ℕ} {u v : R} (hu : u ≠ 0) (hv : v �
 theorem natCast_mul (n : ℕ) (p : R[X]) : (n : R[X]) * p = n • p :=
   (nsmul_eq_mul _ _).symm
 #align polynomial.nat_cast_mul Polynomial.natCast_mul
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_mul := natCast_mul
 
 /-- Summing the values of a function applied to the coefficients of a polynomial -/
 def sum {S : Type*} [AddCommMonoid S] (p : R[X]) (f : ℕ → R → S) : S :=
@@ -1223,6 +1232,9 @@ theorem support_neg {p : R[X]} : (-p).support = p.support := by
 
 theorem C_eq_intCast (n : ℤ) : C (n : R) = n := by simp
 #align polynomial.C_eq_int_cast Polynomial.C_eq_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias C_eq_int_cast := C_eq_intCast
 
 theorem C_neg : C (-a) = -C a :=
   RingHom.map_neg C a

--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -395,6 +395,9 @@ theorem natCast_coeff_zero {n : ℕ} {R : Type*} [Semiring R] : (n : R[X]).coeff
   simp only [coeff_natCast_ite, ite_true]
 #align polynomial.nat_cast_coeff_zero Polynomial.natCast_coeff_zero
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_coeff_zero := natCast_coeff_zero
+
 @[norm_cast] -- @[simp] -- Porting note (#10618): simp can prove this
 theorem natCast_inj {m n : ℕ} {R : Type*} [Semiring R] [CharZero R] :
     (↑m : R[X]) = ↑n ↔ m = n := by
@@ -406,10 +409,16 @@ theorem natCast_inj {m n : ℕ} {R : Type*} [Semiring R] [CharZero R] :
     rfl
 #align polynomial.nat_cast_inj Polynomial.natCast_inj
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_inj := natCast_inj
+
 @[simp]
 theorem intCast_coeff_zero {i : ℤ} {R : Type*} [Ring R] : (i : R[X]).coeff 0 = i := by
   cases i <;> simp
 #align polynomial.int_cast_coeff_zero Polynomial.intCast_coeff_zero
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_coeff_zero := intCast_coeff_zero
 
 @[norm_cast] -- @[simp] -- Porting note (#10618): simp can prove this
 theorem intCast_inj {m n : ℤ} {R : Type*} [Ring R] [CharZero R] : (↑m : R[X]) = ↑n ↔ m = n := by
@@ -420,6 +429,9 @@ theorem intCast_inj {m n : ℤ} {R : Type*} [Ring R] [CharZero R] : (↑m : R[X]
   · rintro rfl
     rfl
 #align polynomial.int_cast_inj Polynomial.intCast_inj
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_inj := intCast_inj
 
 end cast
 

--- a/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
@@ -280,7 +280,13 @@ theorem natDegree_natCast (n : ℕ) : natDegree (n : R[X]) = 0 := by
   simp only [← C_eq_natCast, natDegree_C]
 #align polynomial.nat_degree_nat_cast Polynomial.natDegree_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias natDegree_nat_cast := natDegree_natCast
+
 theorem degree_natCast_le (n : ℕ) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
+
+@[deprecated (since := "2024-04-17")]
+alias degree_nat_cast_le := degree_natCast_le
 
 @[simp]
 theorem degree_monomial (n : ℕ) (ha : a ≠ 0) : degree (monomial n a) = n := by
@@ -551,7 +557,13 @@ theorem natDegree_intCast (n : ℤ) : natDegree (n : R[X]) = 0 := by
   rw [← C_eq_intCast, natDegree_C]
 #align polynomial.nat_degree_intCast Polynomial.natDegree_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias natDegree_int_cast := natDegree_intCast
+
 theorem degree_intCast_le (n : ℤ) : degree (n : R[X]) ≤ 0 := degree_le_of_natDegree_le (by simp)
+
+@[deprecated (since := "2024-04-17")]
+alias degree_int_cast_le := degree_intCast_le
 
 @[simp]
 theorem leadingCoeff_neg (p : R[X]) : (-p).leadingCoeff = -p.leadingCoeff := by

--- a/Mathlib/Algebra/Polynomial/Degree/TrailingDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/TrailingDegree.lean
@@ -282,6 +282,9 @@ theorem natTrailingDegree_natCast (n : ℕ) : natTrailingDegree (n : R[X]) = 0 :
   simp only [← C_eq_natCast, natTrailingDegree_C]
 #align polynomial.nat_trailing_degree_nat_cast Polynomial.natTrailingDegree_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias natTrailingDegree_nat_cast := natTrailingDegree_natCast
+
 @[simp]
 theorem trailingDegree_C_mul_X_pow (n : ℕ) (ha : a ≠ 0) : trailingDegree (C a * X ^ n) = n := by
   rw [C_mul_X_pow_eq_monomial, trailingDegree_monomial ha]
@@ -515,6 +518,9 @@ theorem natTrailingDegree_neg (p : R[X]) : natTrailingDegree (-p) = natTrailingD
 theorem natTrailingDegree_intCast (n : ℤ) : natTrailingDegree (n : R[X]) = 0 := by
   simp only [← C_eq_intCast, natTrailingDegree_C]
 #align polynomial.nat_trailing_degree_int_cast Polynomial.natTrailingDegree_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias natTrailingDegree_int_cast := natTrailingDegree_intCast
 
 end Ring
 

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -231,6 +231,9 @@ theorem derivative_natCast {n : ℕ} : derivative (n : R[X]) = 0 := by
   exact derivative_C
 #align polynomial.derivative_nat_cast Polynomial.derivative_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias derivative_nat_cast := derivative_natCast
+
 -- Porting note (#10756): new theorem
 @[simp]
 theorem derivative_ofNat (n : ℕ) [n.AtLeastTwo] :
@@ -339,11 +342,17 @@ theorem derivative_natCast_mul {n : ℕ} {f : R[X]} :
   simp
 #align polynomial.derivative_nat_cast_mul Polynomial.derivative_natCast_mul
 
+@[deprecated (since := "2024-04-17")]
+alias derivative_nat_cast_mul := derivative_natCast_mul
+
 @[simp]
 theorem iterate_derivative_natCast_mul {n k : ℕ} {f : R[X]} :
     derivative^[k] ((n : R[X]) * f) = n * derivative^[k] f := by
   induction' k with k ih generalizing f <;> simp [*]
 #align polynomial.iterate_derivative_nat_cast_mul Polynomial.iterate_derivative_natCast_mul
+
+@[deprecated (since := "2024-04-17")]
+alias iterate_derivative_nat_cast_mul := iterate_derivative_natCast_mul
 
 theorem mem_support_derivative [NoZeroSMulDivisors ℕ R] (p : R[X]) (n : ℕ) :
     n ∈ (derivative p).support ↔ n + 1 ∈ p.support := by
@@ -491,6 +500,9 @@ theorem iterate_derivative_X_pow_eq_natCast_mul (n k : ℕ) :
 set_option linter.uppercaseLean3 false in
 #align polynomial.iterate_derivative_X_pow_eq_nat_cast_mul Polynomial.iterate_derivative_X_pow_eq_natCast_mul
 
+@[deprecated (since := "2024-04-17")]
+alias iterate_derivative_X_pow_eq_nat_cast_mul := iterate_derivative_X_pow_eq_natCast_mul
+
 theorem iterate_derivative_X_pow_eq_C_mul (n k : ℕ) :
     derivative^[k] (X ^ n : R[X]) = C (Nat.descFactorial n k : R) * X ^ (n - k) := by
   rw [iterate_derivative_X_pow_eq_natCast_mul n k, C_eq_natCast]
@@ -601,16 +613,25 @@ theorem derivative_intCast {n : ℤ} : derivative (n : R[X]) = 0 := by
   exact derivative_C
 #align polynomial.derivative_int_cast Polynomial.derivative_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias derivative_int_cast := derivative_intCast
+
 theorem derivative_intCast_mul {n : ℤ} {f : R[X]} : derivative ((n : R[X]) * f) =
     n * derivative f := by
   simp
 #align polynomial.derivative_int_cast_mul Polynomial.derivative_intCast_mul
+
+@[deprecated (since := "2024-04-17")]
+alias derivative_int_cast_mul := derivative_intCast_mul
 
 @[simp]
 theorem iterate_derivative_intCast_mul {n : ℤ} {k : ℕ} {f : R[X]} :
     derivative^[k] ((n : R[X]) * f) = n * derivative^[k] f := by
   induction' k with k ih generalizing f <;> simp [*]
 #align polynomial.iterate_derivative_int_cast_mul Polynomial.iterate_derivative_intCast_mul
+
+@[deprecated (since := "2024-04-17")]
+alias iterate_derivative_int_cast_mul := iterate_derivative_intCast_mul
 
 end Ring
 

--- a/Mathlib/Algebra/Polynomial/Eval.lean
+++ b/Mathlib/Algebra/Polynomial/Eval.lean
@@ -139,6 +139,9 @@ theorem eval₂_natCast (n : ℕ) : (n : R[X]).eval₂ f x = n := by
   · rw [n.cast_succ, eval₂_add, ih, eval₂_one, n.cast_succ]
 #align polynomial.eval₂_nat_cast Polynomial.eval₂_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias eval₂_nat_cast := eval₂_natCast
+
 -- See note [no_index around OfNat.ofNat]
 @[simp]
 lemma eval₂_ofNat {S : Type*} [Semiring S] (n : ℕ) [n.AtLeastTwo] (f : R →+* S) (a : S) :
@@ -351,6 +354,9 @@ theorem eval₂_at_natCast {S : Type*} [Semiring S] (f : R →+* S) (n : ℕ) :
   simp
 #align polynomial.eval₂_at_nat_cast Polynomial.eval₂_at_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias eval₂_at_nat_cast := eval₂_at_natCast
+
 -- See note [no_index around OfNat.ofNat]
 @[simp]
 theorem eval₂_at_ofNat {S : Type*} [Semiring S] (f : R →+* S) (n : ℕ) [n.AtLeastTwo] :
@@ -365,6 +371,9 @@ theorem eval_C : (C a).eval x = a :=
 @[simp]
 theorem eval_natCast {n : ℕ} : (n : R[X]).eval x = n := by simp only [← C_eq_natCast, eval_C]
 #align polynomial.eval_nat_cast Polynomial.eval_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias eval_nat_cast := eval_natCast
 
 -- See note [no_index around OfNat.ofNat]
 @[simp]
@@ -461,6 +470,9 @@ def leval {R : Type*} [Semiring R] (r : R) : R[X] →ₗ[R] R where
 theorem eval_natCast_mul {n : ℕ} : ((n : R[X]) * p).eval x = n * p.eval x := by
   rw [← C_eq_natCast, eval_C_mul]
 #align polynomial.eval_nat_cast_mul Polynomial.eval_natCast_mul
+
+@[deprecated (since := "2024-04-17")]
+alias eval_nat_cast_mul := eval_natCast_mul
 
 @[simp]
 theorem eval_mul_X : (p * X).eval x = p.eval x * x := by
@@ -567,6 +579,9 @@ theorem C_comp : (C a).comp p = C a :=
 theorem natCast_comp {n : ℕ} : (n : R[X]).comp p = n := by rw [← C_eq_natCast, C_comp]
 #align polynomial.nat_cast_comp Polynomial.natCast_comp
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_comp := natCast_comp
+
 -- Porting note (#10756): new theorem
 @[simp]
 theorem ofNat_comp (n : ℕ) [n.AtLeastTwo] : (no_index (OfNat.ofNat n) : R[X]).comp p = n :=
@@ -635,11 +650,17 @@ theorem natCast_mul_comp {n : ℕ} : ((n : R[X]) * p).comp r = n * p.comp r := b
   rw [← C_eq_natCast, C_mul_comp]
 #align polynomial.nat_cast_mul_comp Polynomial.natCast_mul_comp
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_mul_comp := natCast_mul_comp
+
 theorem mul_X_add_natCast_comp {n : ℕ} :
     (p * (X + (n : R[X]))).comp q = p.comp q * (q + n) := by
   rw [mul_add, add_comp, mul_X_comp, ← Nat.cast_comm, natCast_mul_comp, Nat.cast_comm, mul_add]
 set_option linter.uppercaseLean3 false in
 #align polynomial.mul_X_add_nat_cast_comp Polynomial.mul_X_add_natCast_comp
+
+@[deprecated (since := "2024-04-17")]
+alias mul_X_add_nat_cast_comp := mul_X_add_natCast_comp
 
 @[simp]
 theorem mul_comp {R : Type*} [CommSemiring R] (p q r : R[X]) :
@@ -778,6 +799,9 @@ theorem coe_mapRingHom (f : R →+* S) : ⇑(mapRingHom f) = map f :=
 protected theorem map_natCast (n : ℕ) : (n : R[X]).map f = n :=
   map_natCast (mapRingHom f) n
 #align polynomial.map_nat_cast Polynomial.map_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias map_nat_cast := map_natCast
 
 -- Porting note (#10756): new theorem
 -- See note [no_index around OfNat.ofNat]
@@ -1007,6 +1031,9 @@ theorem eval_natCast_map (f : R →+* S) (p : R[X]) (n : ℕ) :
     simp only [map_natCast f, eval_monomial, map_monomial, f.map_pow, f.map_mul]
 #align polynomial.eval_nat_cast_map Polynomial.eval_natCast_map
 
+@[deprecated (since := "2024-04-17")]
+alias eval_nat_cast_map := eval_natCast_map
+
 @[simp]
 theorem eval_intCast_map {R S : Type*} [Ring R] [Ring S] (f : R →+* S) (p : R[X]) (i : ℤ) :
     (p.map f).eval (i : S) = f (p.eval i) := by
@@ -1016,6 +1043,9 @@ theorem eval_intCast_map {R S : Type*} [Ring R] [Ring S] (f : R →+* S) (p : R[
   | h_monomial n r =>
     simp only [map_intCast, eval_monomial, map_monomial, map_pow, map_mul]
 #align polynomial.eval_int_cast_map Polynomial.eval_intCast_map
+
+@[deprecated (since := "2024-04-17")]
+alias eval_int_cast_map := eval_intCast_map
 
 end Map
 
@@ -1291,10 +1321,16 @@ protected theorem map_neg {S} [Ring S] (f : R →+* S) : (-p).map f = -p.map f :
   map_intCast (mapRingHom f) n
 #align polynomial.map_int_cast Polynomial.map_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias map_int_cast := map_intCast
+
 @[simp]
 theorem eval_intCast {n : ℤ} {x : R} : (n : R[X]).eval x = n := by
   simp only [← C_eq_intCast, eval_C]
 #align polynomial.eval_int_cast Polynomial.eval_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias eval_int_cast := eval_intCast
 
 @[simp]
 theorem eval₂_neg {S} [Ring S] (f : R →+* S) {x : S} : (-p).eval₂ f x = -p.eval₂ f x := by
@@ -1343,9 +1379,15 @@ theorem eval₂_at_intCast {S : Type*} [Ring S] (f : R →+* S) (n : ℤ) :
   convert eval₂_at_apply (p := p) f n
   simp
 
+@[deprecated (since := "2024-04-17")]
+alias eval₂_at_int_cast := eval₂_at_intCast
+
 theorem mul_X_sub_intCast_comp {n : ℕ} :
     (p * (X - (n : R[X]))).comp q = p.comp q * (q - n) := by
   rw [mul_sub, sub_comp, mul_X_comp, ← Nat.cast_comm, natCast_mul_comp, Nat.cast_comm, mul_sub]
+
+@[deprecated (since := "2024-04-17")]
+alias mul_X_sub_int_cast_comp := mul_X_sub_intCast_comp
 
 end Ring
 

--- a/Mathlib/Algebra/Polynomial/Smeval.lean
+++ b/Mathlib/Algebra/Polynomial/Smeval.lean
@@ -113,6 +113,9 @@ theorem smeval_natCast (n : ℕ) : (n : R[X]).smeval x = n • x ^ 0 := by
   · simp only [smeval_zero, Nat.cast_zero, Nat.zero_eq, zero_smul]
   · rw [n.cast_succ, smeval_add, ih, smeval_one, ← add_nsmul]
 
+@[deprecated (since := "2024-04-17")]
+alias smeval_nat_cast := smeval_natCast
+
 @[simp]
 theorem smeval_smul (r : R) : (r • p).smeval x = r • p.smeval x := by
   induction p using Polynomial.induction_on' with
@@ -184,6 +187,9 @@ theorem smeval_at_natCast (q : ℕ[X]): ∀(n : ℕ), q.smeval (n : S) = q.smeva
   | h_monomial n a =>
     intro n
     rw [smeval_monomial, smeval_monomial, nsmul_eq_mul, smul_eq_mul, Nat.cast_mul, Nat.cast_npow]
+
+@[deprecated (since := "2024-04-17")]
+alias smeval_at_nat_cast := smeval_at_natCast
 
 theorem smeval_at_zero : p.smeval (0 : S) = (p.coeff 0) • (1 : S)  := by
   induction p using Polynomial.induction_on' with

--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -410,60 +410,96 @@ theorem natCast_re (n : ℕ) : (n : ℍ[R,c₁,c₂]).re = n :=
   rfl
 #align quaternion_algebra.nat_cast_re QuaternionAlgebra.natCast_re
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_re := natCast_re
+
 @[simp, norm_cast]
 theorem natCast_imI (n : ℕ) : (n : ℍ[R,c₁,c₂]).imI = 0 :=
   rfl
 #align quaternion_algebra.nat_cast_im_i QuaternionAlgebra.natCast_imI
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_imI := natCast_imI
 
 @[simp, norm_cast]
 theorem natCast_imJ (n : ℕ) : (n : ℍ[R,c₁,c₂]).imJ = 0 :=
   rfl
 #align quaternion_algebra.nat_cast_im_j QuaternionAlgebra.natCast_imJ
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_imJ := natCast_imJ
+
 @[simp, norm_cast]
 theorem natCast_imK (n : ℕ) : (n : ℍ[R,c₁,c₂]).imK = 0 :=
   rfl
 #align quaternion_algebra.nat_cast_im_k QuaternionAlgebra.natCast_imK
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_imK := natCast_imK
 
 @[simp, norm_cast]
 theorem natCast_im (n : ℕ) : (n : ℍ[R,c₁,c₂]).im = 0 :=
   rfl
 #align quaternion_algebra.nat_cast_im QuaternionAlgebra.natCast_im
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_im := natCast_im
+
 @[norm_cast]
 theorem coe_natCast (n : ℕ) : ↑(n : R) = (n : ℍ[R,c₁,c₂]) :=
   rfl
 #align quaternion_algebra.coe_nat_cast QuaternionAlgebra.coe_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias coe_nat_cast := coe_natCast
 
 @[simp, norm_cast]
 theorem intCast_re (z : ℤ) : (z : ℍ[R,c₁,c₂]).re = z :=
   rfl
 #align quaternion_algebra.int_cast_re QuaternionAlgebra.intCast_re
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_re := intCast_re
+
 @[simp, norm_cast]
 theorem intCast_imI (z : ℤ) : (z : ℍ[R,c₁,c₂]).imI = 0 :=
   rfl
 #align quaternion_algebra.int_cast_im_i QuaternionAlgebra.intCast_imI
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_imI := intCast_imI
 
 @[simp, norm_cast]
 theorem intCast_imJ (z : ℤ) : (z : ℍ[R,c₁,c₂]).imJ = 0 :=
   rfl
 #align quaternion_algebra.int_cast_im_j QuaternionAlgebra.intCast_imJ
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_imJ := intCast_imJ
+
 @[simp, norm_cast]
 theorem intCast_imK (z : ℤ) : (z : ℍ[R,c₁,c₂]).imK = 0 :=
   rfl
 #align quaternion_algebra.int_cast_im_k QuaternionAlgebra.intCast_imK
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_imK := intCast_imK
 
 @[simp, norm_cast]
 theorem intCast_im (z : ℤ) : (z : ℍ[R,c₁,c₂]).im = 0 :=
   rfl
 #align quaternion_algebra.int_cast_im QuaternionAlgebra.intCast_im
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_im := intCast_im
+
 @[norm_cast]
 theorem coe_intCast (z : ℤ) : ↑(z : R) = (z : ℍ[R,c₁,c₂]) :=
   rfl
 #align quaternion_algebra.coe_int_cast QuaternionAlgebra.coe_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias coe_int_cast := coe_intCast
 
 instance instRing : Ring ℍ[R,c₁,c₂] where
   __ := inferInstanceAs (AddCommGroupWithOne ℍ[R,c₁,c₂])
@@ -1005,49 +1041,85 @@ theorem coe_pow (n : ℕ) : (↑(x ^ n) : ℍ[R]) = (x : ℍ[R]) ^ n :=
 theorem natCast_re (n : ℕ) : (n : ℍ[R]).re = n := rfl
 #align quaternion.nat_cast_re Quaternion.natCast_re
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_re := natCast_re
+
 @[simp, norm_cast]
 theorem natCast_imI (n : ℕ) : (n : ℍ[R]).imI = 0 := rfl
 #align quaternion.nat_cast_im_i Quaternion.natCast_imI
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_imI := natCast_imI
 
 @[simp, norm_cast]
 theorem natCast_imJ (n : ℕ) : (n : ℍ[R]).imJ = 0 := rfl
 #align quaternion.nat_cast_im_j Quaternion.natCast_imJ
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_imJ := natCast_imJ
+
 @[simp, norm_cast]
 theorem natCast_imK (n : ℕ) : (n : ℍ[R]).imK = 0 := rfl
 #align quaternion.nat_cast_im_k Quaternion.natCast_imK
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_imK := natCast_imK
 
 @[simp, norm_cast]
 theorem natCast_im (n : ℕ) : (n : ℍ[R]).im = 0 := rfl
 #align quaternion.nat_cast_im Quaternion.natCast_im
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_im := natCast_im
+
 @[norm_cast]
 theorem coe_natCast (n : ℕ) : ↑(n : R) = (n : ℍ[R]) := rfl
 #align quaternion.coe_nat_cast Quaternion.coe_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias coe_nat_cast := coe_natCast
 
 @[simp, norm_cast]
 theorem intCast_re (z : ℤ) : (z : ℍ[R]).re = z := rfl
 #align quaternion.int_cast_re Quaternion.intCast_re
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_re := intCast_re
+
 @[simp, norm_cast]
 theorem intCast_imI (z : ℤ) : (z : ℍ[R]).imI = 0 := rfl
 #align quaternion.int_cast_im_i Quaternion.intCast_imI
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_imI := intCast_imI
 
 @[simp, norm_cast]
 theorem intCast_imJ (z : ℤ) : (z : ℍ[R]).imJ = 0 := rfl
 #align quaternion.int_cast_im_j Quaternion.intCast_imJ
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_imJ := intCast_imJ
+
 @[simp, norm_cast]
 theorem intCast_imK (z : ℤ) : (z : ℍ[R]).imK = 0 := rfl
 #align quaternion.int_cast_im_k Quaternion.intCast_imK
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_imK := intCast_imK
 
 @[simp, norm_cast]
 theorem intCast_im (z : ℤ) : (z : ℍ[R]).im = 0 := rfl
 #align quaternion.int_cast_im Quaternion.intCast_im
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_im := intCast_im
+
 @[norm_cast]
 theorem coe_intCast (z : ℤ) : ↑(z : R) = (z : ℍ[R]) := rfl
 #align quaternion.coe_int_cast Quaternion.coe_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias coe_int_cast := coe_intCast
 
 theorem coe_injective : Function.Injective (coe : R → ℍ[R]) :=
   QuaternionAlgebra.coe_injective
@@ -1247,10 +1319,16 @@ theorem normSq_natCast (n : ℕ) : normSq (n : ℍ[R]) = (n : R) ^ 2 := by
   rw [← coe_natCast, normSq_coe]
 #align quaternion.norm_sq_nat_cast Quaternion.normSq_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias normSq_nat_cast := normSq_natCast
+
 @[norm_cast]
 theorem normSq_intCast (z : ℤ) : normSq (z : ℍ[R]) = (z : R) ^ 2 := by
   rw [← coe_intCast, normSq_coe]
 #align quaternion.norm_sq_int_cast Quaternion.normSq_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias normSq_int_cast := normSq_intCast
 
 @[simp]
 theorem normSq_neg : normSq (-a) = normSq a := by simp only [normSq_def, star_neg, neg_mul_neg]
@@ -1392,9 +1470,22 @@ instance instRatCast : RatCast ℍ[R] where ratCast q := (q : R)
 #align quaternion.rat_cast_im_j Quaternion.ratCast_imJ
 #align quaternion.rat_cast_im_k Quaternion.ratCast_imK
 
+@[deprecated (since := "2024-04-17")]
+alias rat_cast_imI := ratCast_imI
+
+@[deprecated (since := "2024-04-17")]
+alias rat_cast_imJ := ratCast_imJ
+
+@[deprecated (since := "2024-04-17")]
+alias rat_cast_imK := ratCast_imK
+
 @[norm_cast] lemma coe_nnratCast (q : ℚ≥0) : ↑(q : R) = (q : ℍ[R]) := rfl
+
 @[norm_cast] lemma coe_ratCast (q : ℚ) : ↑(q : R) = (q : ℍ[R]) := rfl
 #align quaternion.coe_rat_cast Quaternion.coe_ratCast
+
+@[deprecated (since := "2024-04-17")]
+alias coe_rat_cast := coe_ratCast
 
 instance instDivisionRing : DivisionRing ℍ[R] where
   __ := Quaternion.instGroupWithZero
@@ -1425,6 +1516,9 @@ theorem normSq_zpow (z : ℤ) : normSq (a ^ z) = normSq a ^ z :=
 theorem normSq_ratCast (q : ℚ) : normSq (q : ℍ[R]) = (q : ℍ[R]) ^ 2 := by
   rw [← coe_ratCast, normSq_coe, coe_pow]
 #align quaternion.norm_sq_rat_cast Quaternion.normSq_ratCast
+
+@[deprecated (since := "2024-04-17")]
+alias normSq_rat_cast := normSq_ratCast
 
 end Field
 

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -385,9 +385,15 @@ theorem coe_natCast (n : ℕ) : ⇑(n : CentroidHom α) = n • (CentroidHom.id 
   rfl
 #align centroid_hom.coe_nat_cast CentroidHom.coe_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias coe_nat_cast := coe_natCast
+
 theorem natCast_apply (n : ℕ) (m : α) : (n : CentroidHom α) m = n • m :=
   rfl
 #align centroid_hom.nat_cast_apply CentroidHom.natCast_apply
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_apply := natCast_apply
 
 @[simp]
 theorem toEnd_one : (1 : CentroidHom α).toEnd = 1 :=
@@ -408,6 +414,9 @@ theorem toEnd_pow (x : CentroidHom α) (n : ℕ) : (x ^ n).toEnd = x.toEnd ^ n :
 theorem toEnd_natCast (n : ℕ) : (n : CentroidHom α).toEnd = ↑n :=
   rfl
 #align centroid_hom.to_End_nat_cast CentroidHom.toEnd_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias toEnd_nat_cast := toEnd_natCast
 
 -- cf `add_monoid.End.semiring`
 instance : Semiring (CentroidHom α) :=
@@ -600,9 +609,15 @@ theorem coe_intCast (z : ℤ) : ⇑(z : CentroidHom α) = z • (CentroidHom.id 
   rfl
 #align centroid_hom.coe_int_cast CentroidHom.coe_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias coe_int_cast := coe_intCast
+
 theorem intCast_apply (z : ℤ) (m : α) : (z : CentroidHom α) m = z • m :=
   rfl
 #align centroid_hom.int_cast_apply CentroidHom.intCast_apply
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_apply := intCast_apply
 
 @[simp]
 theorem toEnd_neg (x : CentroidHom α) : (-x).toEnd = -x.toEnd :=
@@ -644,6 +659,9 @@ theorem sub_apply (f g : CentroidHom α) (a : α) : (f - g) a = f a - g a :=
 theorem toEnd_intCast (z : ℤ) : (z : CentroidHom α).toEnd = ↑z :=
   rfl
 #align centroid_hom.to_End_int_cast CentroidHom.toEnd_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias toEnd_int_cast := toEnd_intCast
 
 instance instRing : Ring (CentroidHom α) :=
   toEnd_injective.ring _ toEnd_zero toEnd_one toEnd_add toEnd_mul toEnd_neg toEnd_sub

--- a/Mathlib/Algebra/Star/Module.lean
+++ b/Mathlib/Algebra/Star/Module.lean
@@ -40,11 +40,17 @@ theorem star_natCast_smul [Semiring R] [AddCommMonoid M] [Module R M] [StarAddMo
   map_natCast_smul (starAddEquiv : M ≃+ M) R R n x
 #align star_nat_cast_smul star_natCast_smul
 
+@[deprecated (since := "2024-04-17")]
+alias star_nat_cast_smul := star_natCast_smul
+
 @[simp]
 theorem star_intCast_smul [Ring R] [AddCommGroup M] [Module R M] [StarAddMonoid M] (n : ℤ)
     (x : M) : star ((n : R) • x) = (n : R) • star x :=
   map_intCast_smul (starAddEquiv : M ≃+ M) R R n x
 #align star_int_cast_smul star_intCast_smul
+
+@[deprecated (since := "2024-04-17")]
+alias star_int_cast_smul := star_intCast_smul
 
 @[simp]
 theorem star_inv_natCast_smul [DivisionSemiring R] [AddCommMonoid M] [Module R M] [StarAddMonoid M]
@@ -52,17 +58,26 @@ theorem star_inv_natCast_smul [DivisionSemiring R] [AddCommMonoid M] [Module R M
   map_inv_natCast_smul (starAddEquiv : M ≃+ M) R R n x
 #align star_inv_nat_cast_smul star_inv_natCast_smul
 
+@[deprecated (since := "2024-04-17")]
+alias star_inv_nat_cast_smul := star_inv_natCast_smul
+
 @[simp]
 theorem star_inv_intCast_smul [DivisionRing R] [AddCommGroup M] [Module R M] [StarAddMonoid M]
     (n : ℤ) (x : M) : star ((n⁻¹ : R) • x) = (n⁻¹ : R) • star x :=
   map_inv_intCast_smul (starAddEquiv : M ≃+ M) R R n x
 #align star_inv_int_cast_smul star_inv_intCast_smul
 
+@[deprecated (since := "2024-04-17")]
+alias star_inv_int_cast_smul := star_inv_intCast_smul
+
 @[simp]
 theorem star_ratCast_smul [DivisionRing R] [AddCommGroup M] [Module R M] [StarAddMonoid M] (n : ℚ)
     (x : M) : star ((n : R) • x) = (n : R) • star x :=
   map_ratCast_smul (starAddEquiv : M ≃+ M) _ _ _ x
 #align star_rat_cast_smul star_ratCast_smul
+
+@[deprecated (since := "2024-04-17")]
+alias star_rat_cast_smul := star_ratCast_smul
 
 @[simp]
 theorem star_rat_smul {R : Type*} [AddCommGroup R] [StarAddMonoid R] [Module ℚ R] (x : R) (n : ℚ) :

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -535,15 +535,24 @@ theorem fst_natCast [AddMonoidWithOne R] [AddMonoid M] (n : ℕ) : (n : tsze R M
   rfl
 #align triv_sq_zero_ext.fst_nat_cast TrivSqZeroExt.fst_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias fst_nat_cast := fst_natCast
+
 @[simp]
 theorem snd_natCast [AddMonoidWithOne R] [AddMonoid M] (n : ℕ) : (n : tsze R M).snd = 0 :=
   rfl
 #align triv_sq_zero_ext.snd_nat_cast TrivSqZeroExt.snd_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias snd_nat_cast := snd_natCast
+
 @[simp]
 theorem inl_natCast [AddMonoidWithOne R] [AddMonoid M] (n : ℕ) : (inl n : tsze R M) = n :=
   rfl
 #align triv_sq_zero_ext.inl_nat_cast TrivSqZeroExt.inl_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias inl_nat_cast := inl_natCast
 
 instance addGroupWithOne [AddGroupWithOne R] [AddGroup M] : AddGroupWithOne (tsze R M) :=
   { TrivSqZeroExt.addGroup, TrivSqZeroExt.addMonoidWithOne with
@@ -556,15 +565,24 @@ theorem fst_intCast [AddGroupWithOne R] [AddGroup M] (z : ℤ) : (z : tsze R M).
   rfl
 #align triv_sq_zero_ext.fst_int_cast TrivSqZeroExt.fst_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias fst_int_cast := fst_intCast
+
 @[simp]
 theorem snd_intCast [AddGroupWithOne R] [AddGroup M] (z : ℤ) : (z : tsze R M).snd = 0 :=
   rfl
 #align triv_sq_zero_ext.snd_int_cast TrivSqZeroExt.snd_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias snd_int_cast := snd_intCast
+
 @[simp]
 theorem inl_intCast [AddGroupWithOne R] [AddGroup M] (z : ℤ) : (inl z : tsze R M) = z :=
   rfl
 #align triv_sq_zero_ext.inl_int_cast TrivSqZeroExt.inl_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias inl_int_cast := inl_intCast
 
 instance nonAssocSemiring [Semiring R] [AddCommMonoid M] [Module R M] [Module Rᵐᵒᵖ M] :
     NonAssocSemiring (tsze R M) :=

--- a/Mathlib/Analysis/Asymptotics/Asymptotics.lean
+++ b/Mathlib/Analysis/Asymptotics/Asymptotics.lean
@@ -2224,10 +2224,16 @@ theorem IsBigO.natCast_atTop {R : Type*} [StrictOrderedSemiring R] [Archimedean 
     (fun (n : ℕ) => f n) =O[atTop] (fun n => g n) :=
   IsBigO.comp_tendsto h tendsto_natCast_atTop_atTop
 
+@[deprecated (since := "2024-04-17")]
+alias IsBigO.nat_cast_atTop := IsBigO.natCast_atTop
+
 theorem IsLittleO.natCast_atTop {R : Type*} [StrictOrderedSemiring R] [Archimedean R]
     {f : R → E} {g : R → F} (h : f =o[atTop] g) :
     (fun (n : ℕ) => f n) =o[atTop] (fun n => g n) :=
   IsLittleO.comp_tendsto h tendsto_natCast_atTop_atTop
+
+@[deprecated (since := "2024-04-17")]
+alias IsLittleO.nat_cast_atTop := IsLittleO.natCast_atTop
 
 theorem isBigO_atTop_iff_eventually_exists {α : Type*} [SemilatticeSup α] [Nonempty α]
     {f : α → E} {g : α → F} : f =O[atTop] g ↔ ∀ᶠ n₀ in atTop, ∃ c, ∀ n ≥ n₀, ‖f n‖ ≤ c * ‖g n‖ := by

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -729,6 +729,9 @@ lemma zero_not_mem_slitPlane : 0 ∉ slitPlane := mt ofReal_mem_slitPlane.1 (lt_
 lemma natCast_mem_slitPlane {n : ℕ} : ↑n ∈ slitPlane ↔ n ≠ 0 := by
   simpa [pos_iff_ne_zero] using @ofReal_mem_slitPlane n
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_mem_slitPlane := natCast_mem_slitPlane
+
 @[simp]
 lemma ofNat_mem_slitPlane (n : ℕ) [n.AtLeastTwo] : no_index (OfNat.ofNat n) ∈ slitPlane :=
   natCast_mem_slitPlane.2 (NeZero.ne n)

--- a/Mathlib/Analysis/Normed/Group/AddCircle.lean
+++ b/Mathlib/Analysis/Normed/Group/AddCircle.lean
@@ -244,6 +244,9 @@ theorem norm_div_natCast {m n : ℕ} :
   rw [norm_eq' p hp.out, this, abs_sub_round_div_natCast_eq]
 #align add_circle.norm_div_nat_cast AddCircle.norm_div_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias norm_div_nat_cast := norm_div_natCast
+
 theorem exists_norm_eq_of_isOfFinAddOrder {u : AddCircle p} (hu : IsOfFinAddOrder u) :
     ∃ k : ℕ, ‖u‖ = p * (k / addOrderOf u) := by
   let n := addOrderOf u

--- a/Mathlib/Analysis/NormedSpace/Star/Multiplier.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Multiplier.lean
@@ -237,10 +237,16 @@ theorem natCast_toProd (n : ℕ) : (n : 𝓜(𝕜, A)).toProd = n :=
   rfl
 #align double_centralizer.nat_cast_to_prod DoubleCentralizer.natCast_toProd
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_toProd := natCast_toProd
+
 @[simp]
 theorem intCast_toProd (n : ℤ) : (n : 𝓜(𝕜, A)).toProd = n :=
   rfl
 #align double_centralizer.int_cast_to_prod DoubleCentralizer.intCast_toProd
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_toProd := intCast_toProd
 
 @[simp]
 theorem pow_toProd (n : ℕ) (a : 𝓜(𝕜, A)) : (a ^ n).toProd = a.toProd ^ n :=
@@ -301,17 +307,29 @@ theorem natCast_fst (n : ℕ) : (n : 𝓜(𝕜, A)).fst = n :=
   rfl
 #align double_centralizer.nat_cast_fst DoubleCentralizer.natCast_fst
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_fst := natCast_fst
+
 theorem natCast_snd (n : ℕ) : (n : 𝓜(𝕜, A)).snd = n :=
   rfl
 #align double_centralizer.nat_cast_snd DoubleCentralizer.natCast_snd
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_snd := natCast_snd
 
 theorem intCast_fst (n : ℤ) : (n : 𝓜(𝕜, A)).fst = n :=
   rfl
 #align double_centralizer.int_cast_fst DoubleCentralizer.intCast_fst
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_fst := intCast_fst
+
 theorem intCast_snd (n : ℤ) : (n : 𝓜(𝕜, A)).snd = n :=
   rfl
 #align double_centralizer.int_cast_snd DoubleCentralizer.intCast_snd
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_snd := intCast_snd
 
 theorem pow_fst (n : ℕ) (a : 𝓜(𝕜, A)) : (a ^ n).fst = a.fst ^ n :=
   rfl

--- a/Mathlib/Analysis/NormedSpace/lpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/lpSpace.lean
@@ -889,9 +889,15 @@ theorem _root_.natCast_memℓp_infty (n : ℕ) : Memℓp (n : ∀ i, B i) ∞ :=
   natCast_mem (lpInftySubring B) n
 #align nat_cast_mem_ℓp_infty natCast_memℓp_infty
 
+@[deprecated (since := "2024-04-17")]
+alias _root_.nat_cast_memℓp_infty := _root_.natCast_memℓp_infty
+
 theorem _root_.intCast_memℓp_infty (z : ℤ) : Memℓp (z : ∀ i, B i) ∞ :=
   intCast_mem (lpInftySubring B) z
 #align int_cast_mem_ℓp_infty intCast_memℓp_infty
+
+@[deprecated (since := "2024-04-17")]
+alias _root_.int_cast_memℓp_infty := _root_.intCast_memℓp_infty
 
 @[simp]
 theorem infty_coeFn_one : ⇑(1 : lp B ∞) = 1 :=
@@ -908,10 +914,16 @@ theorem infty_coeFn_natCast (n : ℕ) : ⇑(n : lp B ∞) = n :=
   rfl
 #align lp.infty_coe_fn_nat_cast lp.infty_coeFn_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias infty_coeFn_nat_cast := infty_coeFn_natCast
+
 @[simp]
 theorem infty_coeFn_intCast (z : ℤ) : ⇑(z : lp B ∞) = z :=
   rfl
 #align lp.infty_coe_fn_int_cast lp.infty_coeFn_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias infty_coeFn_int_cast := infty_coeFn_intCast
 
 instance [Nonempty I] : NormOneClass (lp B ∞) where
   norm_one := by simp_rw [lp.norm_eq_ciSup, infty_coeFn_one, Pi.one_apply, norm_one, ciSup_const]

--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -348,10 +348,16 @@ theorem not_summable_natCast_inv : ¬Summable (fun n => n⁻¹ : ℕ → ℝ) :=
   simpa
 #align real.not_summable_nat_cast_inv Real.not_summable_natCast_inv
 
+@[deprecated (since := "2024-04-17")]
+alias not_summable_nat_cast_inv := not_summable_natCast_inv
+
 /-- Harmonic series is not unconditionally summable. -/
 theorem not_summable_one_div_natCast : ¬Summable (fun n => 1 / n : ℕ → ℝ) := by
   simpa only [inv_eq_one_div] using not_summable_natCast_inv
 #align real.not_summable_one_div_nat_cast Real.not_summable_one_div_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias not_summable_one_div_nat_cast := not_summable_one_div_natCast
 
 /-- **Divergence of the Harmonic Series** -/
 theorem tendsto_sum_range_one_div_nat_succ_atTop :

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -75,6 +75,9 @@ theorem ofReal_log {x : ℝ} (hx : 0 ≤ x) : (x.log : ℂ) = log x :=
 @[simp, norm_cast]
 lemma natCast_log {n : ℕ} : Real.log n = log n := ofReal_natCast n ▸ ofReal_log n.cast_nonneg
 
+@[deprecated (since := "2024-04-17")]
+alias natCast_log := natCast_log
+
 @[simp]
 lemma ofNat_log {n : ℕ} [n.AtLeastTwo] :
     Real.log (no_index (OfNat.ofNat n)) = log (OfNat.ofNat n) :=

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -75,9 +75,6 @@ theorem ofReal_log {x : ℝ} (hx : 0 ≤ x) : (x.log : ℂ) = log x :=
 @[simp, norm_cast]
 lemma natCast_log {n : ℕ} : Real.log n = log n := ofReal_natCast n ▸ ofReal_log n.cast_nonneg
 
-@[deprecated (since := "2024-04-17")]
-alias natCast_log := natCast_log
-
 @[simp]
 lemma ofNat_log {n : ℕ} [n.AtLeastTwo] :
     Real.log (no_index (OfNat.ofNat n)) = log (OfNat.ofNat n) :=

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -418,6 +418,9 @@ theorem floor_logb_natCast {b : ℕ} {r : ℝ} (hb : 1 < b) (hr : 0 ≤ r) :
     exact Int.zpow_log_le_self hb hr
 #align real.floor_logb_nat_cast Real.floor_logb_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias floor_logb_nat_cast := floor_logb_natCast
+
 theorem ceil_logb_natCast {b : ℕ} {r : ℝ} (hb : 1 < b) (hr : 0 ≤ r) :
     ⌈logb b r⌉ = Int.clog b r := by
   obtain rfl | hr := hr.eq_or_lt
@@ -430,6 +433,9 @@ theorem ceil_logb_natCast {b : ℕ} {r : ℝ} (hb : 1 < b) (hr : 0 ≤ r) :
     refine (rpow_logb (zero_lt_one.trans hb1') hb1'.ne' hr).symm.trans_le ?_
     exact rpow_le_rpow_of_exponent_le hb1'.le (Int.le_ceil _)
 #align real.ceil_logb_nat_cast Real.ceil_logb_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias ceil_logb_nat_cast := ceil_logb_natCast
 
 @[simp]
 theorem logb_eq_zero : logb b x = 0 ↔ b = 0 ∨ b = 1 ∨ b = -1 ∨ x = 0 ∨ x = 1 ∨ x = -1 := by

--- a/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -224,9 +224,15 @@ theorem log_natCast_nonneg (n : ℕ) : 0 ≤ log n := by
     have : (1 : ℝ) ≤ n := mod_cast Nat.one_le_of_lt <| Nat.pos_of_ne_zero hn
     exact log_nonneg this
 
+@[deprecated (since := "2024-04-17")]
+alias log_nat_cast_nonneg := log_natCast_nonneg
+
 theorem log_neg_natCast_nonneg (n : ℕ) : 0 ≤ log (-n) := by
   rw [← log_neg_eq_log, neg_neg]
   exact log_natCast_nonneg _
+
+@[deprecated (since := "2024-04-17")]
+alias log_neg_nat_cast_nonneg := log_neg_natCast_nonneg
 
 theorem log_intCast_nonneg (n : ℤ) : 0 ≤ log n := by
   cases lt_trichotomy 0 n with
@@ -240,6 +246,9 @@ theorem log_intCast_nonneg (n : ℤ) : 0 ≤ log n := by
           have : (1 : ℝ) ≤ -n := by rw [← neg_zero, ← lt_neg] at hn; exact mod_cast hn
           rw [← log_neg_eq_log]
           exact log_nonneg this
+
+@[deprecated (since := "2024-04-17")]
+alias log_int_cast_nonneg := log_intCast_nonneg
 
 theorem strictMonoOn_log : StrictMonoOn log (Set.Ioi 0) := fun _ hx _ _ hxy => log_lt_log hx hxy
 #align real.strict_mono_on_log Real.strictMonoOn_log

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Complex.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Complex.lean
@@ -141,6 +141,9 @@ lemma cpow_mul_ofNat (x y : ℂ) (n : ℕ) [n.AtLeastTwo] :
 theorem cpow_natCast (x : ℂ) (n : ℕ) : x ^ (n : ℂ) = x ^ n := by simpa using cpow_nat_mul x n 1
 #align complex.cpow_nat_cast Complex.cpow_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias cpow_nat_cast := cpow_natCast
+
 /-- See Note [no_index around OfNat.ofNat] -/
 @[simp]
 lemma cpow_ofNat (x : ℂ) (n : ℕ) [n.AtLeastTwo] :
@@ -153,6 +156,9 @@ theorem cpow_two (x : ℂ) : x ^ (2 : ℂ) = x ^ (2 : ℕ) := cpow_ofNat x 2
 @[simp, norm_cast]
 theorem cpow_intCast (x : ℂ) (n : ℤ) : x ^ (n : ℂ) = x ^ n := by simpa using cpow_int_mul x n 1
 #align complex.cpow_int_cast Complex.cpow_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias cpow_int_cast := cpow_intCast
 
 @[simp]
 theorem cpow_nat_inv_pow (x : ℂ) {n : ℕ} (hn : n ≠ 0) : (x ^ (n⁻¹ : ℂ)) ^ n = x := by

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -132,6 +132,9 @@ theorem rpow_natCast (x : ℝ≥0) (n : ℕ) : x ^ (n : ℝ) = x ^ n :=
   NNReal.eq <| by simpa only [coe_rpow, coe_pow] using Real.rpow_natCast x n
 #align nnreal.rpow_nat_cast NNReal.rpow_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias rpow_nat_cast := rpow_natCast
+
 @[simp]
 lemma rpow_ofNat (x : ℝ≥0) (n : ℕ) [n.AtLeastTwo] :
     x ^ (no_index (OfNat.ofNat n) : ℝ) = x ^ (OfNat.ofNat n : ℕ) :=
@@ -570,6 +573,9 @@ theorem rpow_natCast (x : ℝ≥0∞) (n : ℕ) : x ^ (n : ℝ) = x ^ n := by
   · simp [coe_rpow_of_nonneg _ (Nat.cast_nonneg n)]
 #align ennreal.rpow_nat_cast ENNReal.rpow_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias rpow_nat_cast := rpow_natCast
+
 @[simp]
 lemma rpow_ofNat (x : ℝ≥0∞) (n : ℕ) [n.AtLeastTwo] :
     x ^ (no_index (OfNat.ofNat n) : ℝ) = x ^ (OfNat.ofNat n) :=
@@ -579,6 +585,9 @@ lemma rpow_ofNat (x : ℝ≥0∞) (n : ℕ) [n.AtLeastTwo] :
 lemma rpow_intCast (x : ℝ≥0∞) (n : ℤ) : x ^ (n : ℝ) = x ^ n := by
   cases n <;> simp only [Int.ofNat_eq_coe, Int.cast_natCast, rpow_natCast, zpow_natCast,
     Int.cast_negSucc, rpow_neg, zpow_negSucc]
+
+@[deprecated (since := "2024-04-17")]
+alias rpow_int_cast := rpow_intCast
 
 theorem rpow_two (x : ℝ≥0∞) : x ^ (2 : ℝ) = x ^ 2 := rpow_ofNat x 2
 #align ennreal.rpow_two ENNReal.rpow_two

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -82,9 +82,6 @@ theorem exp_one_rpow (x : ℝ) : exp 1 ^ x = exp x := by rw [← exp_mul, one_mu
 
 @[simp] lemma exp_one_pow (n : ℕ) : exp 1 ^ n = exp n := by rw [← rpow_natCast, exp_one_rpow]
 
-@[deprecated (since := "2024-04-17")]
-alias exp_one_pow := exp_one_pow
-
 theorem rpow_eq_zero_iff_of_nonneg (hx : 0 ≤ x) : x ^ y = 0 ↔ x = 0 ∧ y ≠ 0 := by
   simp only [rpow_def_of_nonneg hx]
   split_ifs <;> simp [*, exp_ne_zero]
@@ -1062,4 +1059,4 @@ end Mathlib.Meta.NormNum
 
 end Tactics
 
-@[deprecated] alias rpow_nonneg_of_nonneg := rpow_nonneg -- 2024-01-07
+@[deprecated (since := "2024-01-07")] alias rpow_nonneg_of_nonneg := rpow_nonneg

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -66,15 +66,24 @@ theorem rpow_intCast (x : ℝ) (n : ℤ) : x ^ (n : ℝ) = x ^ n := by
     Complex.ofReal_re]
 #align real.rpow_int_cast Real.rpow_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias rpow_int_cast := rpow_intCast
+
 @[simp, norm_cast]
 theorem rpow_natCast (x : ℝ) (n : ℕ) : x ^ (n : ℝ) = x ^ n := by simpa using rpow_intCast x n
 #align real.rpow_nat_cast Real.rpow_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias rpow_nat_cast := rpow_natCast
 
 @[simp]
 theorem exp_one_rpow (x : ℝ) : exp 1 ^ x = exp x := by rw [← exp_mul, one_mul]
 #align real.exp_one_rpow Real.exp_one_rpow
 
 @[simp] lemma exp_one_pow (n : ℕ) : exp 1 ^ n = exp n := by rw [← rpow_natCast, exp_one_rpow]
+
+@[deprecated (since := "2024-04-17")]
+alias exp_one_pow := exp_one_pow
 
 theorem rpow_eq_zero_iff_of_nonneg (hx : 0 ≤ x) : x ^ y = 0 ↔ x = 0 ∧ y ≠ 0 := by
   simp only [rpow_def_of_nonneg hx]

--- a/Mathlib/Data/Complex/Abs.lean
+++ b/Mathlib/Data/Complex/Abs.lean
@@ -243,7 +243,10 @@ theorem abs_im_div_abs_le_one (z : ℂ) : |z.im / Complex.abs z| ≤ 1 :=
 @[simp, norm_cast] lemma abs_intCast (n : ℤ) : abs n = |↑n| := by rw [← ofReal_intCast, abs_ofReal]
 #align complex.int_cast_abs Complex.abs_intCast
 
-@[deprecated] -- 2024-02-14
+@[deprecated (since := "2024-04-17")]
+alias abs_intCast := abs_intCast
+
+@[deprecated (since := "2024-02-14")]
 lemma int_cast_abs (n : ℤ) : |↑n| = Complex.abs n := (abs_intCast _).symm
 
 theorem normSq_eq_abs (x : ℂ) : normSq x = (Complex.abs x) ^ 2 := by

--- a/Mathlib/Data/Complex/Abs.lean
+++ b/Mathlib/Data/Complex/Abs.lean
@@ -243,9 +243,6 @@ theorem abs_im_div_abs_le_one (z : ℂ) : |z.im / Complex.abs z| ≤ 1 :=
 @[simp, norm_cast] lemma abs_intCast (n : ℤ) : abs n = |↑n| := by rw [← ofReal_intCast, abs_ofReal]
 #align complex.int_cast_abs Complex.abs_intCast
 
-@[deprecated (since := "2024-04-17")]
-alias abs_intCast := abs_intCast
-
 @[deprecated (since := "2024-02-14")]
 lemma int_cast_abs (n : ℤ) : |↑n| = Complex.abs n := (abs_intCast _).symm
 

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -508,6 +508,9 @@ noncomputable instance instRatCast : RatCast ℂ where ratCast q := ofReal' q
 #align complex.of_real_int_cast Complex.ofReal_intCast
 #align complex.of_real_rat_cast Complex.ofReal_ratCast
 
+@[deprecated (since := "2024-04-17")]
+alias ofReal_rat_cast := ofReal_ratCast
+
 -- See note [no_index around OfNat.ofNat]
 @[simp]
 lemma re_ofNat (n : ℕ) [n.AtLeastTwo] : (no_index (OfNat.ofNat n) : ℂ).re = OfNat.ofNat n := rfl
@@ -526,6 +529,9 @@ lemma re_ofNat (n : ℕ) [n.AtLeastTwo] : (no_index (OfNat.ofNat n) : ℂ).re = 
 #align complex.int_cast_im Complex.intCast_im
 #align complex.rat_cast_re Complex.ratCast_re
 #align complex.rat_cast_im Complex.ratCast_im
+
+@[deprecated (since := "2024-04-17")]
+alias rat_cast_im := ratCast_im
 
 @[norm_cast] lemma ofReal_nsmul (n : ℕ) (r : ℝ) : ↑(n • r) = n • (r : ℂ) := by simp
 @[norm_cast] lemma ofReal_zsmul (n : ℤ) (r : ℝ) : ↑(n • r) = n • (r : ℂ) := by simp
@@ -566,6 +572,9 @@ theorem conj_I : conj I = -I :=
 #noalign complex.conj_bit1
 
 theorem conj_natCast (n : ℕ) : conj (n : ℂ) = n := map_natCast _ _
+
+@[deprecated (since := "2024-04-17")]
+alias conj_nat_cast := conj_natCast
 
 -- See note [no_index around OfNat.ofNat]
 theorem conj_ofNat (n : ℕ) [n.AtLeastTwo] : conj (no_index (OfNat.ofNat n : ℂ)) = OfNat.ofNat n :=
@@ -629,11 +638,20 @@ theorem normSq_ofReal (r : ℝ) : normSq r = r * r := by
 @[simp]
 theorem normSq_natCast (n : ℕ) : normSq n = n * n := normSq_ofReal _
 
+@[deprecated (since := "2024-04-17")]
+alias normSq_nat_cast := normSq_natCast
+
 @[simp]
 theorem normSq_intCast (z : ℤ) : normSq z = z * z := normSq_ofReal _
 
+@[deprecated (since := "2024-04-17")]
+alias normSq_int_cast := normSq_intCast
+
 @[simp]
 theorem normSq_ratCast (q : ℚ) : normSq q = q * q := normSq_ofReal _
+
+@[deprecated (since := "2024-04-17")]
+alias normSq_rat_cast := normSq_ratCast
 
 -- See note [no_index around OfNat.ofNat]
 @[simp]
@@ -884,11 +902,20 @@ lemma div_ofReal (z : ℂ) (x : ℝ) : z / x = ⟨z.re / x, z.im / x⟩ := by
 lemma div_natCast (z : ℂ) (n : ℕ) : z / n = ⟨z.re / n, z.im / n⟩ :=
   mod_cast div_ofReal z n
 
+@[deprecated (since := "2024-04-17")]
+alias div_nat_cast := div_natCast
+
 lemma div_intCast (z : ℂ) (n : ℤ) : z / n = ⟨z.re / n, z.im / n⟩ :=
   mod_cast div_ofReal z n
 
+@[deprecated (since := "2024-04-17")]
+alias div_int_cast := div_intCast
+
 lemma div_ratCast (z : ℂ) (x : ℚ) : z / x = ⟨z.re / x, z.im / x⟩ :=
   mod_cast div_ofReal z x
+
+@[deprecated (since := "2024-04-17")]
+alias div_rat_cast := div_ratCast
 
 lemma div_ofNat (z : ℂ) (n : ℕ) [n.AtLeastTwo] :
     z / OfNat.ofNat n = ⟨z.re / OfNat.ofNat n, z.im / OfNat.ofNat n⟩ :=
@@ -902,6 +929,9 @@ lemma div_ofNat (z : ℂ) (n : ℕ) [n.AtLeastTwo] :
 @[simp] lemma div_intCast_im (z : ℂ) (n : ℤ) : (z / n).im = z.im / n := by rw [div_intCast]
 @[simp] lemma div_ratCast_re (z : ℂ) (x : ℚ) : (z / x).re = z.re / x := by rw [div_ratCast]
 @[simp] lemma div_ratCast_im (z : ℂ) (x : ℚ) : (z / x).im = z.im / x := by rw [div_ratCast]
+
+@[deprecated (since := "2024-04-17")]
+alias div_rat_cast_im := div_ratCast_im
 
 @[simp]
 lemma div_ofNat_re (z : ℂ) (n : ℕ) [n.AtLeastTwo] :

--- a/Mathlib/Data/ENNReal/Operations.lean
+++ b/Mathlib/Data/ENNReal/Operations.lean
@@ -383,6 +383,9 @@ theorem natCast_sub (m n : ℕ) : ↑(m - n) = (m - n : ℝ≥0∞) := by
   rw [← coe_natCast, Nat.cast_tsub, coe_sub, coe_natCast, coe_natCast]
 #align ennreal.nat_cast_sub ENNReal.natCast_sub
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_sub := natCast_sub
+
 protected theorem sub_eq_of_eq_add (hb : b ≠ ∞) : a = c + b → a - b = c :=
   (cancel_of_ne hb).tsub_eq_of_eq_add
 #align ennreal.sub_eq_of_eq_add ENNReal.sub_eq_of_eq_add

--- a/Mathlib/Data/ENNReal/Real.lean
+++ b/Mathlib/Data/ENNReal/Real.lean
@@ -232,6 +232,9 @@ alias ⟨_, ofReal_of_nonpos⟩ := ofReal_eq_zero
 lemma ofReal_lt_natCast {p : ℝ} {n : ℕ} (hn : n ≠ 0) : ENNReal.ofReal p < n ↔ p < n := by
   exact mod_cast ofReal_lt_ofReal_iff (Nat.cast_pos.2 hn.bot_lt)
 
+@[deprecated (since := "2024-04-17")]
+alias ofReal_lt_nat_cast := ofReal_lt_natCast
+
 @[simp]
 lemma ofReal_lt_one {p : ℝ} : ENNReal.ofReal p < 1 ↔ p < 1 := by
   exact mod_cast ofReal_lt_natCast one_ne_zero
@@ -244,6 +247,9 @@ lemma ofReal_lt_ofNat {p : ℝ} {n : ℕ} [n.AtLeastTwo] :
 @[simp]
 lemma natCast_le_ofReal {n : ℕ} {p : ℝ} (hn : n ≠ 0) : n ≤ ENNReal.ofReal p ↔ n ≤ p := by
   simp only [← not_lt, ofReal_lt_natCast hn]
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_le_ofReal := natCast_le_ofReal
 
 @[simp]
 lemma one_le_ofReal {p : ℝ} : 1 ≤ ENNReal.ofReal p ↔ 1 ≤ p := by
@@ -258,6 +264,9 @@ lemma ofNat_le_ofReal {n : ℕ} [n.AtLeastTwo] {p : ℝ} :
 lemma ofReal_le_natCast {r : ℝ} {n : ℕ} : ENNReal.ofReal r ≤ n ↔ r ≤ n :=
   coe_le_coe.trans Real.toNNReal_le_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias ofReal_le_nat_cast := ofReal_le_natCast
+
 @[simp]
 lemma ofReal_le_one {r : ℝ} : ENNReal.ofReal r ≤ 1 ↔ r ≤ 1 :=
   coe_le_coe.trans Real.toNNReal_le_one
@@ -271,6 +280,9 @@ lemma ofReal_le_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
 lemma natCast_lt_ofReal {n : ℕ} {r : ℝ} : n < ENNReal.ofReal r ↔ n < r :=
   coe_lt_coe.trans Real.natCast_lt_toNNReal
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_lt_ofReal := natCast_lt_ofReal
+
 @[simp]
 lemma one_lt_ofReal {r : ℝ} : 1 < ENNReal.ofReal r ↔ 1 < r := coe_lt_coe.trans Real.one_lt_toNNReal
 
@@ -282,6 +294,9 @@ lemma ofNat_lt_ofReal {n : ℕ} [n.AtLeastTwo] {r : ℝ} :
 @[simp]
 lemma ofReal_eq_natCast {r : ℝ} {n : ℕ} (h : n ≠ 0) : ENNReal.ofReal r = n ↔ r = n :=
   ENNReal.coe_inj.trans <| Real.toNNReal_eq_natCast h
+
+@[deprecated (since := "2024-04-17")]
+alias ofReal_eq_nat_cast := ofReal_eq_natCast
 
 @[simp]
 lemma ofReal_eq_one {r : ℝ} : ENNReal.ofReal r = 1 ↔ r = 1 :=

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -530,6 +530,9 @@ theorem ofNat''_eq_cast (n : ℕ) [NeZero n] (a : ℕ) : (Fin.ofNat'' a : Fin n)
 
 @[simp] lemma val_natCast (a n : ℕ) [NeZero n] : (a : Fin n).val = a % n := rfl
 
+@[deprecated (since := "2024-04-17")]
+alias val_nat_cast := val_natCast
+
 -- Porting note: is this the right name for things involving `Nat.cast`?
 /-- Converting an in-range number to `Fin (n + 1)` produces a result
 whose value is the original number.  -/
@@ -551,8 +554,14 @@ in the same value.  -/
 
 @[simp] lemma natCast_self (n : ℕ) [NeZero n] : (n : Fin n) = 0 := by ext; simp
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_self := natCast_self
+
 @[simp] lemma natCast_eq_zero {a n : ℕ} [NeZero n] : (a : Fin n) = 0 ↔ n ∣ a := by
   simp [ext_iff, Nat.dvd_iff_mod_eq_zero]
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_eq_zero := natCast_eq_zero
 
 @[simp]
 theorem natCast_eq_last (n) : (n : Fin (n + 1)) = Fin.last n := by ext; simp

--- a/Mathlib/Data/Int/AbsoluteValue.lean
+++ b/Mathlib/Data/Int/AbsoluteValue.lean
@@ -34,6 +34,9 @@ theorem AbsoluteValue.map_units_intCast [Nontrivial R] (abv : AbsoluteValue R S)
     abv ((x : ℤ) : R) = 1 := by rcases Int.units_eq_one_or x with (rfl | rfl) <;> simp
 #align absolute_value.map_units_int_cast AbsoluteValue.map_units_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias AbsoluteValue.map_units_int_cast := AbsoluteValue.map_units_intCast
+
 @[simp]
 theorem AbsoluteValue.map_units_int_smul (abv : AbsoluteValue R S) (x : ℤˣ) (y : R) :
     abv (x • y) = abv y := by rcases Int.units_eq_one_or x with (rfl | rfl) <;> simp

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -250,6 +250,9 @@ theorem eq_intCastAddHom (f : ℤ →+ A) (h1 : f 1 = 1) : f = Int.castAddHom A 
   ext_int <| by simp [h1]
 #align add_monoid_hom.eq_int_cast_hom AddMonoidHom.eq_intCastAddHom
 
+@[deprecated (since := "2024-04-17")]
+alias eq_int_castAddHom := eq_intCastAddHom
+
 end AddMonoidHom
 
 theorem eq_intCast' [AddGroupWithOne α] [FunLike F ℤ α] [AddMonoidHomClass F ℤ α]

--- a/Mathlib/Data/Int/CharZero.lean
+++ b/Mathlib/Data/Int/CharZero.lean
@@ -48,8 +48,14 @@ lemma support_intCast (hn : n ≠ 0) : support (n : α → β) = univ :=
   support_const <| Int.cast_ne_zero.2 hn
 #align function.support_int_cast Function.support_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias support_int_cast := support_intCast
+
 lemma mulSupport_intCast (hn : n ≠ 1) : mulSupport (n : α → β) = univ :=
   mulSupport_const <| Int.cast_ne_one.2 hn
 #align function.mul_support_int_cast Function.mulSupport_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias mulSupport_int_cast := mulSupport_intCast
 
 end Function

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -911,9 +911,7 @@ theorem castNum_eq_bitwise {f : Num → Num → Num} {g : Bool → Bool → Bool
 #align num.bitwise_to_nat Num.castNum_eq_bitwise
 
 @[simp, norm_cast]
-theorem castNum_or : ∀ m n : Num, ↑(m 
- n) = (↑m 
- ↑n : ℕ) := by
+theorem castNum_or : ∀ m n : Num, ↑(m ||| n) = (↑m ||| ↑n : ℕ) := by
   -- Porting note: A name of an implicit local hypothesis is not available so
   --               `cases_type*` is used.
   apply castNum_eq_bitwise fun x y => pos (PosNum.lor x y) <;>

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -481,6 +481,9 @@ theorem of_natCast {α} [AddMonoidWithOne α] (n : ℕ) : ((n : Num) : α) = n :
   rw [← cast_to_nat, to_of_nat]
 #align num.of_nat_cast Num.of_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias of_nat_cast := of_natCast
+
 @[norm_cast] -- @[simp] -- Porting note (#10618): simp can prove this
 theorem of_nat_inj {m n : ℕ} : (m : Num) = n ↔ m = n :=
   ⟨fun h => Function.LeftInverse.injective to_of_nat h, congr_arg _⟩
@@ -908,7 +911,9 @@ theorem castNum_eq_bitwise {f : Num → Num → Num} {g : Bool → Bool → Bool
 #align num.bitwise_to_nat Num.castNum_eq_bitwise
 
 @[simp, norm_cast]
-theorem castNum_or : ∀ m n : Num, ↑(m ||| n) = (↑m ||| ↑n : ℕ) := by
+theorem castNum_or : ∀ m n : Num, ↑(m 
+ n) = (↑m 
+ ↑n : ℕ) := by
   -- Porting note: A name of an implicit local hypothesis is not available so
   --               `cases_type*` is used.
   apply castNum_eq_bitwise fun x y => pos (PosNum.lor x y) <;>
@@ -1535,10 +1540,16 @@ theorem of_intCast [AddGroupWithOne α] (n : ℤ) : ((n : ZNum) : α) = n := by
   rw [← cast_to_int, to_of_int]
 #align znum.of_int_cast ZNum.of_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias of_int_cast := of_intCast
+
 @[simp, norm_cast]
 theorem of_natCast [AddGroupWithOne α] (n : ℕ) : ((n : ZNum) : α) = n := by
   rw [← Int.cast_natCast, of_intCast, Int.cast_natCast]
 #align znum.of_nat_cast ZNum.of_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias of_nat_cast := of_natCast
 
 @[simp, norm_cast]
 theorem dvd_to_int (m n : ZNum) : (m : ℤ) ∣ n ↔ m ∣ n :=

--- a/Mathlib/Data/Real/NNReal.lean
+++ b/Mathlib/Data/Real/NNReal.lean
@@ -358,6 +358,9 @@ protected theorem coe_natCast (n : ℕ) : (↑(↑n : ℝ≥0) : ℝ) = n :=
   map_natCast toRealHom n
 #align nnreal.coe_nat_cast NNReal.coe_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias coe_nat_cast := coe_natCast
+
 -- See note [no_index around OfNat.ofNat]
 @[simp, norm_cast]
 protected theorem coe_ofNat (n : ℕ) [n.AtLeastTwo] :
@@ -674,6 +677,9 @@ lemma toNNReal_eq_one {r : ℝ} : r.toNNReal = 1 ↔ r = 1 := toNNReal_eq_iff_eq
 lemma toNNReal_eq_natCast {r : ℝ} {n : ℕ} (hn : n ≠ 0) : r.toNNReal = n ↔ r = n :=
   mod_cast toNNReal_eq_iff_eq_coe <| Nat.cast_ne_zero.2 hn
 
+@[deprecated (since := "2024-04-17")]
+alias toNNReal_eq_nat_cast := toNNReal_eq_natCast
+
 @[simp]
 lemma toNNReal_eq_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
     r.toNNReal = no_index (OfNat.ofNat n) ↔ r = OfNat.ofNat n :=
@@ -696,9 +702,15 @@ lemma one_lt_toNNReal {r : ℝ} : 1 < r.toNNReal ↔ 1 < r := by
 lemma toNNReal_le_natCast {r : ℝ} {n : ℕ} : r.toNNReal ≤ n ↔ r ≤ n := by
   simpa using toNNReal_le_toNNReal_iff n.cast_nonneg
 
+@[deprecated (since := "2024-04-17")]
+alias toNNReal_le_nat_cast := toNNReal_le_natCast
+
 @[simp]
 lemma natCast_lt_toNNReal {r : ℝ} {n : ℕ} : n < r.toNNReal ↔ n < r := by
   simpa only [not_le] using toNNReal_le_natCast.not
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_lt_toNNReal := natCast_lt_toNNReal
 
 @[simp]
 lemma toNNReal_le_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :
@@ -750,13 +762,25 @@ lemma toNNReal_lt_one {r : ℝ} : r.toNNReal < 1 ↔ r < 1 := by simp only [← 
 lemma natCastle_toNNReal' {n : ℕ} {r : ℝ} : ↑n ≤ r.toNNReal ↔ n ≤ r ∨ n = 0 := by
   simpa [n.cast_nonneg.le_iff_eq] using toNNReal_le_toNNReal_iff' (r := n)
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_le_toNNReal' := natCastle_toNNReal'
+
 @[simp]
 lemma toNNReal_lt_natCast' {n : ℕ} {r : ℝ} : r.toNNReal < n ↔ r < n ∧ n ≠ 0 := by
   simpa [pos_iff_ne_zero] using toNNReal_lt_toNNReal_iff' (r := r) (p := n)
 
+@[deprecated (since := "2024-04-17")]
+alias toNNReal_lt_nat_cast' := toNNReal_lt_natCast'
+
 lemma natCast_le_toNNReal {n : ℕ} {r : ℝ} (hn : n ≠ 0) : ↑n ≤ r.toNNReal ↔ n ≤ r := by simp [hn]
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_le_toNNReal := natCast_le_toNNReal
+
 lemma toNNReal_lt_natCast {r : ℝ} {n : ℕ} (hn : n ≠ 0) : r.toNNReal < n ↔ r < n := by simp [hn]
+
+@[deprecated (since := "2024-04-17")]
+alias toNNReal_lt_nat_cast := toNNReal_lt_natCast
 
 @[simp]
 lemma toNNReal_lt_ofNat {r : ℝ} {n : ℕ} [n.AtLeastTwo] :

--- a/Mathlib/Data/Real/NNReal.lean
+++ b/Mathlib/Data/Real/NNReal.lean
@@ -359,7 +359,7 @@ protected theorem coe_natCast (n : ℕ) : (↑(↑n : ℝ≥0) : ℝ) = n :=
 #align nnreal.coe_nat_cast NNReal.coe_natCast
 
 @[deprecated (since := "2024-04-17")]
-alias coe_nat_cast := coe_natCast
+alias coe_nat_cast := NNReal.coe_natCast
 
 -- See note [no_index around OfNat.ofNat]
 @[simp, norm_cast]

--- a/Mathlib/Data/Real/Sign.lean
+++ b/Mathlib/Data/Real/Sign.lean
@@ -79,6 +79,9 @@ theorem sign_intCast (z : ℤ) : sign (z : ℝ) = ↑(Int.sign z) := by
   · rw [sign_of_pos (Int.cast_pos.mpr hp), Int.sign_eq_one_of_pos hp, Int.cast_one]
 #align real.sign_int_cast Real.sign_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias sign_int_cast := sign_intCast
+
 theorem sign_neg {r : ℝ} : sign (-r) = -sign r := by
   obtain hn | rfl | hp := lt_trichotomy r (0 : ℝ)
   · rw [sign_of_neg hn, sign_of_pos (neg_pos.mpr hn), neg_neg]

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -88,6 +88,9 @@ theorem val_natCast {n : ℕ} (a : ℕ) : (a : ZMod n).val = a % n := by
   · apply Fin.val_natCast
 #align zmod.val_nat_cast ZMod.val_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias val_nat_cast := val_natCast
+
 theorem val_unit' {n : ZMod 0} : IsUnit n ↔ n.val = 1 := by
   simp only [val]
   rw [Int.isUnit_iff, Int.natAbs_eq_iff, Nat.cast_one]
@@ -97,6 +100,9 @@ lemma eq_one_of_isUnit_natCast {n : ℕ} (h : IsUnit (n : ZMod 0)) : n = 1 := by
 
 theorem val_natCast_of_lt {n a : ℕ} (h : a < n) : (a : ZMod n).val = a := by
   rwa [val_natCast, Nat.mod_eq_of_lt]
+
+@[deprecated (since := "2024-04-17")]
+alias val_nat_cast_of_lt := val_natCast_of_lt
 
 instance charP (n : ℕ) : CharP (ZMod n) n where
   cast_eq_zero_iff' := by
@@ -138,10 +144,16 @@ theorem natCast_self (n : ℕ) : (n : ZMod n) = 0 :=
   CharP.cast_eq_zero (ZMod n) n
 #align zmod.nat_cast_self ZMod.natCast_self
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_self := natCast_self
+
 @[simp]
 theorem natCast_self' (n : ℕ) : (n + 1 : ZMod (n + 1)) = 0 := by
   rw [← Nat.cast_add_one, natCast_self (n + 1)]
 #align zmod.nat_cast_self' ZMod.natCast_self'
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_self' := natCast_self'
 
 section UniversalProperty
 
@@ -200,13 +212,22 @@ theorem natCast_zmod_val {n : ℕ} [NeZero n] (a : ZMod n) : (a.val : ZMod n) = 
   · apply Fin.cast_val_eq_self
 #align zmod.nat_cast_zmod_val ZMod.natCast_zmod_val
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_zmod_val := natCast_zmod_val
+
 theorem natCast_rightInverse [NeZero n] : Function.RightInverse val ((↑) : ℕ → ZMod n) :=
   natCast_zmod_val
 #align zmod.nat_cast_right_inverse ZMod.natCast_rightInverse
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_rightInverse := natCast_rightInverse
+
 theorem natCast_zmod_surjective [NeZero n] : Function.Surjective ((↑) : ℕ → ZMod n) :=
   natCast_rightInverse.surjective
 #align zmod.nat_cast_zmod_surjective ZMod.natCast_zmod_surjective
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_zmod_surjective := natCast_zmod_surjective
 
 /-- So-named because the outer coercion is `Int.cast` into `ZMod`. For `Int.cast` into an arbitrary
 ring, see `ZMod.intCast_cast`. -/
@@ -218,13 +239,22 @@ theorem intCast_zmod_cast (a : ZMod n) : ((cast a : ℤ) : ZMod n) = a := by
     erw [Int.cast_natCast, Fin.cast_val_eq_self]
 #align zmod.int_cast_zmod_cast ZMod.intCast_zmod_cast
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_zmod_cast := intCast_zmod_cast
+
 theorem intCast_rightInverse : Function.RightInverse (cast : ZMod n → ℤ) ((↑) : ℤ → ZMod n) :=
   intCast_zmod_cast
 #align zmod.int_cast_right_inverse ZMod.intCast_rightInverse
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_rightInverse := intCast_rightInverse
+
 theorem intCast_surjective : Function.Surjective ((↑) : ℤ → ZMod n) :=
   intCast_rightInverse.surjective
 #align zmod.int_cast_surjective ZMod.intCast_surjective
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_surjective := intCast_surjective
 
 theorem cast_id : ∀ (n) (i : ZMod n), (ZMod.cast i : ZMod n) = i
   | 0, _ => Int.cast_id
@@ -246,6 +276,9 @@ theorem natCast_comp_val [NeZero n] : ((↑) : ℕ → R) ∘ (val : ZMod n → 
   rfl
 #align zmod.nat_cast_comp_val ZMod.natCast_comp_val
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_comp_val := natCast_comp_val
+
 /-- The coercions are respectively `Int.cast`, `ZMod.cast`, and `ZMod.cast`. -/
 @[simp]
 theorem intCast_comp_cast : ((↑) : ℤ → R) ∘ (cast : ZMod n → ℤ) = cast := by
@@ -255,6 +288,9 @@ theorem intCast_comp_cast : ((↑) : ℤ → R) ∘ (cast : ZMod n → ℤ) = ca
     simp [ZMod, ZMod.cast]
 #align zmod.int_cast_comp_cast ZMod.intCast_comp_cast
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_comp_cast := intCast_comp_cast
+
 variable {R}
 
 @[simp]
@@ -262,10 +298,16 @@ theorem natCast_val [NeZero n] (i : ZMod n) : (i.val : R) = cast i :=
   congr_fun (natCast_comp_val R) i
 #align zmod.nat_cast_val ZMod.natCast_val
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_val := natCast_val
+
 @[simp]
 theorem intCast_cast (i : ZMod n) : ((cast i : ℤ) : R) = cast i :=
   congr_fun (intCast_comp_cast R) i
 #align zmod.int_cast_cast ZMod.intCast_cast
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_cast := intCast_cast
 
 theorem cast_add_eq_ite {n : ℕ} (a b : ZMod n) :
     (cast (a + b) : ℤ) =
@@ -361,10 +403,16 @@ theorem cast_natCast (h : m ∣ n) (k : ℕ) : (cast (k : ZMod n) : R) = k :=
   map_natCast (castHom h R) k
 #align zmod.cast_nat_cast ZMod.cast_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias cast_nat_cast := cast_natCast
+
 @[simp, norm_cast]
 theorem cast_intCast (h : m ∣ n) (k : ℤ) : (cast (k : ZMod n) : R) = k :=
   map_intCast (castHom h R) k
 #align zmod.cast_int_cast ZMod.cast_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias cast_int_cast := cast_intCast
 
 end CharDvd
 
@@ -405,10 +453,16 @@ theorem cast_natCast' (k : ℕ) : (cast (k : ZMod n) : R) = k :=
   cast_natCast dvd_rfl k
 #align zmod.cast_nat_cast' ZMod.cast_natCast'
 
+@[deprecated (since := "2024-04-17")]
+alias cast_nat_cast' := cast_natCast'
+
 @[simp, norm_cast]
 theorem cast_intCast' (k : ℤ) : (cast (k : ZMod n) : R) = k :=
   cast_intCast dvd_rfl k
 #align zmod.cast_int_cast' ZMod.cast_intCast'
+
+@[deprecated (since := "2024-04-17")]
+alias cast_int_cast' := cast_intCast'
 
 variable (R)
 
@@ -499,29 +553,50 @@ theorem intCast_eq_intCast_iff (a b : ℤ) (c : ℕ) : (a : ZMod c) = (b : ZMod 
   CharP.intCast_eq_intCast (ZMod c) c
 #align zmod.int_coe_eq_int_coe_iff ZMod.intCast_eq_intCast_iff
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_eq_int_cast_iff := intCast_eq_intCast_iff
+
 theorem intCast_eq_intCast_iff' (a b : ℤ) (c : ℕ) : (a : ZMod c) = (b : ZMod c) ↔ a % c = b % c :=
   ZMod.intCast_eq_intCast_iff a b c
 #align zmod.int_coe_eq_int_coe_iff' ZMod.intCast_eq_intCast_iff'
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_eq_int_cast_iff' := intCast_eq_intCast_iff'
 
 theorem natCast_eq_natCast_iff (a b c : ℕ) : (a : ZMod c) = (b : ZMod c) ↔ a ≡ b [MOD c] := by
   simpa [Int.natCast_modEq_iff] using ZMod.intCast_eq_intCast_iff a b c
 #align zmod.nat_coe_eq_nat_coe_iff ZMod.natCast_eq_natCast_iff
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_eq_nat_cast_iff := natCast_eq_natCast_iff
+
 theorem natCast_eq_natCast_iff' (a b c : ℕ) : (a : ZMod c) = (b : ZMod c) ↔ a % c = b % c :=
   ZMod.natCast_eq_natCast_iff a b c
 #align zmod.nat_coe_eq_nat_coe_iff' ZMod.natCast_eq_natCast_iff'
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_eq_nat_cast_iff' := natCast_eq_natCast_iff'
 
 theorem intCast_zmod_eq_zero_iff_dvd (a : ℤ) (b : ℕ) : (a : ZMod b) = 0 ↔ (b : ℤ) ∣ a := by
   rw [← Int.cast_zero, ZMod.intCast_eq_intCast_iff, Int.modEq_zero_iff_dvd]
 #align zmod.int_coe_zmod_eq_zero_iff_dvd ZMod.intCast_zmod_eq_zero_iff_dvd
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_zmod_eq_zero_iff_dvd := intCast_zmod_eq_zero_iff_dvd
+
 theorem intCast_eq_intCast_iff_dvd_sub (a b : ℤ) (c : ℕ) : (a : ZMod c) = ↑b ↔ ↑c ∣ b - a := by
   rw [ZMod.intCast_eq_intCast_iff, Int.modEq_iff_dvd]
 #align zmod.int_coe_eq_int_coe_iff_dvd_sub ZMod.intCast_eq_intCast_iff_dvd_sub
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_eq_int_cast_iff_dvd_sub := intCast_eq_intCast_iff_dvd_sub
+
 theorem natCast_zmod_eq_zero_iff_dvd (a b : ℕ) : (a : ZMod b) = 0 ↔ b ∣ a := by
   rw [← Nat.cast_zero, ZMod.natCast_eq_natCast_iff, Nat.modEq_zero_iff_dvd]
 #align zmod.nat_coe_zmod_eq_zero_iff_dvd ZMod.natCast_zmod_eq_zero_iff_dvd
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_zmod_eq_zero_iff_dvd := natCast_zmod_eq_zero_iff_dvd
 
 theorem val_intCast {n : ℕ} (a : ℤ) [NeZero n] : ↑(a : ZMod n).val = a % n := by
   have hle : (0 : ℤ) ≤ ↑(a : ZMod n).val := Int.natCast_nonneg _
@@ -530,11 +605,17 @@ theorem val_intCast {n : ℕ} (a : ℤ) [NeZero n] : ↑(a : ZMod n).val = a % n
   rw [← ZMod.intCast_eq_intCast_iff', Int.cast_natCast, ZMod.natCast_val, ZMod.cast_id]
 #align zmod.val_int_cast ZMod.val_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias val_int_cast := val_intCast
+
 theorem coe_intCast {n : ℕ} (a : ℤ) : cast (a : ZMod n) = a % n := by
   cases n
   · rw [Int.ofNat_zero, Int.emod_zero, Int.cast_id]; rfl
   · rw [← val_intCast, val]; rfl
 #align zmod.coe_int_cast ZMod.coe_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias coe_int_cast := coe_intCast
 
 @[simp]
 theorem val_neg_one (n : ℕ) : (-1 : ZMod n.succ).val = n := by
@@ -597,12 +678,18 @@ theorem intCast_mod (a : ℤ) (b : ℕ) : ((a % b : ℤ) : ZMod b) = (a : ZMod b
   apply Int.mod_modEq
 #align zmod.int_cast_mod ZMod.intCast_mod
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_mod := intCast_mod
+
 theorem ker_intCastAddHom (n : ℕ) :
     (Int.castAddHom (ZMod n)).ker = AddSubgroup.zmultiples (n : ℤ) := by
   ext
   rw [Int.mem_zmultiples_iff, AddMonoidHom.mem_ker, Int.coe_castAddHom,
     intCast_zmod_eq_zero_iff_dvd]
 #align zmod.ker_int_cast_add_hom ZMod.ker_intCastAddHom
+
+@[deprecated (since := "2024-04-17")]
+alias ker_int_castAddHom := ker_intCastAddHom
 
 theorem cast_injective_of_le {m n : ℕ} [nzm : NeZero m] (h : m ≤ n) :
     Function.Injective (@cast (ZMod n) _ m) := by
@@ -628,6 +715,9 @@ theorem natCast_toNat (p : ℕ) : ∀ {z : ℤ} (_h : 0 ≤ z), (z.toNat : ZMod 
   | (n : ℕ), _h => by simp only [Int.cast_natCast, Int.toNat_natCast]
   | Int.negSucc n, h => by simp at h
 #align zmod.nat_cast_to_nat ZMod.natCast_toNat
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_toNat := natCast_toNat
 
 theorem val_injective (n : ℕ) [NeZero n] : Function.Injective (val : ZMod n → ℕ) := by
   cases n
@@ -749,6 +839,9 @@ theorem natCast_mod (a : ℕ) (n : ℕ) : ((a % n : ℕ) : ZMod n) = a := by
       rw [← Nat.mod_add_div a n]
   simp
 #align zmod.nat_cast_mod ZMod.natCast_mod
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_mod := natCast_mod
 
 theorem eq_iff_modEq_nat (n : ℕ) {a b : ℕ} : (a : ZMod n) = b ↔ a ≡ b [MOD n] := by
   cases n
@@ -1135,6 +1228,9 @@ theorem natCast_natAbs_valMinAbs {n : ℕ} [NeZero n] (a : ZMod n) :
   · rw [← Int.cast_natCast, Int.ofNat_natAbs_of_nonpos this, Int.cast_neg, Int.cast_sub,
       Int.cast_natCast, Int.cast_natCast, natCast_self, sub_zero, natCast_zmod_val]
 #align zmod.nat_cast_nat_abs_val_min_abs ZMod.natCast_natAbs_valMinAbs
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_natAbs_valMinAbs := natCast_natAbs_valMinAbs
 
 theorem valMinAbs_neg_of_ne_half {n : ℕ} {a : ZMod n} (ha : 2 * a.val ≠ n) :
     (-a).valMinAbs = -a.valMinAbs := by

--- a/Mathlib/FieldTheory/PerfectClosure.lean
+++ b/Mathlib/FieldTheory/PerfectClosure.lean
@@ -374,10 +374,16 @@ theorem natCast (n x : ℕ) : (x : PerfectClosure K p) = mk K p (n, x) := by
   apply R.intro
 #align perfect_closure.nat_cast PerfectClosure.natCast
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast := natCast
+
 theorem intCast (x : ℤ) : (x : PerfectClosure K p) = mk K p (0, x) := by
   induction x <;> simp only [Int.ofNat_eq_coe, Int.cast_natCast, Int.cast_negSucc, natCast K p 0]
   rfl
 #align perfect_closure.int_cast PerfectClosure.intCast
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast := intCast
 
 theorem natCast_eq_iff (x y : ℕ) : (x : PerfectClosure K p) = y ↔ (x : K) = y := by
   constructor <;> intro H
@@ -386,6 +392,9 @@ theorem natCast_eq_iff (x y : ℕ) : (x : PerfectClosure K p) = y ↔ (x : K) = 
     simpa only [zero_add, iterate_fixed (frobenius_natCast K p _)] using H
   rw [natCast K p 0, natCast K p 0, H]
 #align perfect_closure.nat_cast_eq_iff PerfectClosure.natCast_eq_iff
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_eq_iff := natCast_eq_iff
 
 instance instCharP : CharP (PerfectClosure K p) p := by
   constructor; intro x; rw [← CharP.cast_eq_zero_iff K]

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -656,12 +656,18 @@ theorem natCast {f : ArithmeticFunction ℕ} [Semiring R] (h : f.IsMultiplicativ
   ⟨by simp [h], fun {m n} cop => by simp [h.2 cop]⟩
 #align nat.arithmetic_function.is_multiplicative.nat_cast ArithmeticFunction.IsMultiplicative.natCast
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast := natCast
+
 @[arith_mult]
 theorem intCast {f : ArithmeticFunction ℤ} [Ring R] (h : f.IsMultiplicative) :
     IsMultiplicative (f : ArithmeticFunction R) :=
                                  -- Porting note: was `by simp [cop, h]`
   ⟨by simp [h], fun {m n} cop => by simp [h.2 cop]⟩
 #align nat.arithmetic_function.is_multiplicative.int_cast ArithmeticFunction.IsMultiplicative.intCast
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast := intCast
 
 @[arith_mult]
 theorem mul [CommSemiring R] {f g : ArithmeticFunction R} (hf : f.IsMultiplicative)

--- a/Mathlib/NumberTheory/LegendreSymbol/ZModChar.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/ZModChar.lean
@@ -56,9 +56,6 @@ theorem isQuadratic_χ₄ : χ₄.IsQuadratic := by
 theorem χ₄_nat_mod_four (n : ℕ) : χ₄ n = χ₄ (n % 4 : ℕ) := by rw [← ZMod.natCast_mod n 4]
 #align zmod.χ₄_nat_mod_four ZMod.χ₄_nat_mod_four
 
-@[deprecated (since := "2024-04-17")]
-alias χ₄_nat_mod_four := χ₄_nat_mod_four
-
 /-- The value of `χ₄ n`, for `n : ℤ`, depends only on `n % 4`. -/
 theorem χ₄_int_mod_four (n : ℤ) : χ₄ n = χ₄ (n % 4 : ℤ) := by
   rw [← ZMod.intCast_mod n 4]
@@ -152,9 +149,6 @@ theorem isQuadratic_χ₈ : χ₈.IsQuadratic := by
 /-- The value of `χ₈ n`, for `n : ℕ`, depends only on `n % 8`. -/
 theorem χ₈_nat_mod_eight (n : ℕ) : χ₈ n = χ₈ (n % 8 : ℕ) := by rw [← ZMod.natCast_mod n 8]
 #align zmod.χ₈_nat_mod_eight ZMod.χ₈_nat_mod_eight
-
-@[deprecated (since := "2024-04-17")]
-alias χ₈_nat_mod_eight := χ₈_nat_mod_eight
 
 /-- The value of `χ₈ n`, for `n : ℤ`, depends only on `n % 8`. -/
 theorem χ₈_int_mod_eight (n : ℤ) : χ₈ n = χ₈ (n % 8 : ℤ) := by

--- a/Mathlib/NumberTheory/LegendreSymbol/ZModChar.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/ZModChar.lean
@@ -56,6 +56,9 @@ theorem isQuadratic_χ₄ : χ₄.IsQuadratic := by
 theorem χ₄_nat_mod_four (n : ℕ) : χ₄ n = χ₄ (n % 4 : ℕ) := by rw [← ZMod.natCast_mod n 4]
 #align zmod.χ₄_nat_mod_four ZMod.χ₄_nat_mod_four
 
+@[deprecated (since := "2024-04-17")]
+alias χ₄_nat_mod_four := χ₄_nat_mod_four
+
 /-- The value of `χ₄ n`, for `n : ℤ`, depends only on `n % 4`. -/
 theorem χ₄_int_mod_four (n : ℤ) : χ₄ n = χ₄ (n % 4 : ℤ) := by
   rw [← ZMod.intCast_mod n 4]
@@ -149,6 +152,9 @@ theorem isQuadratic_χ₈ : χ₈.IsQuadratic := by
 /-- The value of `χ₈ n`, for `n : ℕ`, depends only on `n % 8`. -/
 theorem χ₈_nat_mod_eight (n : ℕ) : χ₈ n = χ₈ (n % 8 : ℕ) := by rw [← ZMod.natCast_mod n 8]
 #align zmod.χ₈_nat_mod_eight ZMod.χ₈_nat_mod_eight
+
+@[deprecated (since := "2024-04-17")]
+alias χ₈_nat_mod_eight := χ₈_nat_mod_eight
 
 /-- The value of `χ₈ n`, for `n : ℤ`, depends only on `n % 8`. -/
 theorem χ₈_int_mod_eight (n : ℤ) : χ₈ n = χ₈ (n % 8 : ℤ) := by

--- a/Mathlib/NumberTheory/Padics/PadicIntegers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicIntegers.lean
@@ -156,9 +156,15 @@ instance instCommRing : CommRing ℤ_[p] := (by infer_instance : CommRing (subri
 theorem coe_natCast (n : ℕ) : ((n : ℤ_[p]) : ℚ_[p]) = n := rfl
 #align padic_int.coe_nat_cast PadicInt.coe_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias coe_nat_cast := coe_natCast
+
 @[simp, norm_cast]
 theorem coe_intCast (z : ℤ) : ((z : ℤ_[p]) : ℚ_[p]) = z := rfl
 #align padic_int.coe_int_cast PadicInt.coe_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias coe_int_cast := coe_intCast
 
 /-- The coercion from `ℤ_[p]` to `ℚ_[p]` as a ring homomorphism. -/
 def Coe.ringHom : ℤ_[p] →+* ℚ_[p] := (subring p).subtype
@@ -299,6 +305,9 @@ theorem padic_norm_e_of_padicInt (z : ℤ_[p]) : ‖(z : ℚ_[p])‖ = ‖z‖ :
 
 theorem norm_intCast_eq_padic_norm (z : ℤ) : ‖(z : ℤ_[p])‖ = ‖(z : ℚ_[p])‖ := by simp [norm_def]
 #align padic_int.norm_int_cast_eq_padic_norm PadicInt.norm_intCast_eq_padic_norm
+
+@[deprecated (since := "2024-04-17")]
+alias norm_int_cast_eq_padic_norm := norm_intCast_eq_padic_norm
 
 @[simp]
 theorem norm_eq_padic_norm {q : ℚ_[p]} (hq : ‖q‖ ≤ 1) : @norm ℤ_[p] _ ⟨q, hq⟩ = ‖q‖ := rfl

--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -459,6 +459,9 @@ theorem denseRange_natCast : DenseRange (Nat.cast : ℕ → ℤ_[p]) := by
   apply appr_spec
 #align padic_int.dense_range_nat_cast PadicInt.denseRange_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias denseRange_nat_cast := denseRange_natCast
+
 theorem denseRange_intCast : DenseRange (Int.cast : ℤ → ℤ_[p]) := by
   intro x
   refine DenseRange.induction_on denseRange_natCast x ?_ ?_
@@ -467,6 +470,9 @@ theorem denseRange_intCast : DenseRange (Int.cast : ℤ → ℤ_[p]) := by
     apply subset_closure
     exact Set.mem_range_self _
 #align padic_int.dense_range_int_cast PadicInt.denseRange_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias denseRange_int_cast := denseRange_intCast
 
 end RingHoms
 

--- a/Mathlib/NumberTheory/Zsqrtd/Basic.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/Basic.lean
@@ -537,10 +537,16 @@ theorem norm_one : norm (1 : ℤ√d) = 1 := by simp [norm]
 theorem norm_intCast (n : ℤ) : norm (n : ℤ√d) = n * n := by simp [norm]
 #align zsqrtd.norm_int_cast Zsqrtd.norm_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias norm_int_cast := norm_intCast
+
 @[simp]
 theorem norm_natCast (n : ℕ) : norm (n : ℤ√d) = n * n :=
   norm_intCast n
 #align zsqrtd.norm_nat_cast Zsqrtd.norm_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias norm_nat_cast := norm_natCast
 
 @[simp]
 theorem norm_mul (n m : ℤ√d) : norm (n * m) = norm n * norm m := by

--- a/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
@@ -152,10 +152,16 @@ theorem intCast_real_norm (x : ℤ[i]) : (x.norm : ℝ) = Complex.normSq (x : �
   rw [Zsqrtd.norm, normSq]; simp
 #align gaussian_int.nat_cast_real_norm GaussianInt.intCast_real_norm
 
+@[deprecated (since := "2024-04-17")]
+alias int_cast_real_norm := intCast_real_norm
+
 @[simp]
 theorem intCast_complex_norm (x : ℤ[i]) : (x.norm : ℂ) = Complex.normSq (x : ℂ) := by
   cases x; rw [Zsqrtd.norm, normSq]; simp
 #align gaussian_int.nat_cast_complex_norm GaussianInt.intCast_complex_norm
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_complex_norm := intCast_complex_norm
 
 theorem norm_nonneg (x : ℤ[i]) : 0 ≤ norm x :=
   Zsqrtd.norm_nonneg (by norm_num) _
@@ -180,6 +186,9 @@ theorem abs_natCast_norm (x : ℤ[i]) : (x.norm.natAbs : ℤ) = x.norm :=
 theorem natCast_natAbs_norm {α : Type*} [Ring α] (x : ℤ[i]) : (x.norm.natAbs : α) = x.norm := by
   rw [← Int.cast_natCast, abs_natCast_norm]
 #align gaussian_int.nat_cast_nat_abs_norm GaussianInt.natCast_natAbs_norm
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_natAbs_norm := natCast_natAbs_norm
 
 theorem natAbs_norm_eq (x : ℤ[i]) :
     x.norm.natAbs = x.re.natAbs * x.re.natAbs + x.im.natAbs * x.im.natAbs :=

--- a/Mathlib/Order/Filter/Archimedean.lean
+++ b/Mathlib/Order/Filter/Archimedean.lean
@@ -34,14 +34,23 @@ theorem tendsto_natCast_atTop_iff [StrictOrderedSemiring R] [Archimedean R] {f :
   tendsto_atTop_embedding (fun _ _ => Nat.cast_le) exists_nat_ge
 #align tendsto_coe_nat_at_top_iff tendsto_natCast_atTop_iff
 
+@[deprecated (since := "2024-04-17")]
+alias tendsto_nat_cast_atTop_iff := tendsto_natCast_atTop_iff
+
 theorem tendsto_natCast_atTop_atTop [OrderedSemiring R] [Archimedean R] :
     Tendsto ((↑) : ℕ → R) atTop atTop :=
   Nat.mono_cast.tendsto_atTop_atTop exists_nat_ge
 #align tendsto_coe_nat_at_top_at_top tendsto_natCast_atTop_atTop
 
+@[deprecated (since := "2024-04-17")]
+alias tendsto_nat_cast_atTop_atTop := tendsto_natCast_atTop_atTop
+
 theorem Filter.Eventually.natCast_atTop [OrderedSemiring R] [Archimedean R] {p : R → Prop}
     (h : ∀ᶠ (x:R) in atTop, p x) : ∀ᶠ (n:ℕ) in atTop, p n :=
   tendsto_natCast_atTop_atTop.eventually h
+
+@[deprecated (since := "2024-04-17")]
+alias Filter.Eventually.nat_cast_atTop := Filter.Eventually.natCast_atTop
 
 @[simp] theorem Int.comap_cast_atTop [StrictOrderedRing R] [Archimedean R] :
     comap ((↑) : ℤ → R) atTop = atTop :=
@@ -62,23 +71,38 @@ theorem tendsto_intCast_atTop_iff [StrictOrderedRing R] [Archimedean R] {f : α 
   rw [← @Int.comap_cast_atTop R, tendsto_comap_iff]; rfl
 #align tendsto_coe_int_at_top_iff tendsto_intCast_atTop_iff
 
+@[deprecated (since := "2024-04-17")]
+alias tendsto_int_cast_atTop_iff := tendsto_intCast_atTop_iff
+
 theorem tendsto_intCast_atBot_iff [StrictOrderedRing R] [Archimedean R] {f : α → ℤ}
     {l : Filter α} : Tendsto (fun n => (f n : R)) l atBot ↔ Tendsto f l atBot := by
   rw [← @Int.comap_cast_atBot R, tendsto_comap_iff]; rfl
 #align tendsto_coe_int_at_bot_iff tendsto_intCast_atBot_iff
+
+@[deprecated (since := "2024-04-17")]
+alias tendsto_int_cast_atBot_iff := tendsto_intCast_atBot_iff
 
 theorem tendsto_intCast_atTop_atTop [StrictOrderedRing R] [Archimedean R] :
     Tendsto ((↑) : ℤ → R) atTop atTop :=
   tendsto_intCast_atTop_iff.2 tendsto_id
 #align tendsto_coe_int_at_top_at_top tendsto_intCast_atTop_atTop
 
+@[deprecated (since := "2024-04-17")]
+alias tendsto_int_cast_atTop_atTop := tendsto_intCast_atTop_atTop
+
 theorem Filter.Eventually.intCast_atTop [StrictOrderedRing R] [Archimedean R] {p : R → Prop}
     (h : ∀ᶠ (x:R) in atTop, p x) : ∀ᶠ (n:ℤ) in atTop, p n := by
   rw [← Int.comap_cast_atTop (R := R)]; exact h.comap _
 
+@[deprecated (since := "2024-04-17")]
+alias Filter.Eventually.int_cast_atTop := Filter.Eventually.intCast_atTop
+
 theorem Filter.Eventually.intCast_atBot [StrictOrderedRing R] [Archimedean R] {p : R → Prop}
     (h : ∀ᶠ (x:R) in atBot, p x) : ∀ᶠ (n:ℤ) in atBot, p n := by
   rw [← Int.comap_cast_atBot (R := R)]; exact h.comap _
+
+@[deprecated (since := "2024-04-17")]
+alias Filter.Eventually.int_cast_atBot := Filter.Eventually.intCast_atBot
 
 @[simp]
 theorem Rat.comap_cast_atTop [LinearOrderedField R] [Archimedean R] :
@@ -99,18 +123,30 @@ theorem tendsto_ratCast_atTop_iff [LinearOrderedField R] [Archimedean R] {f : α
   rw [← @Rat.comap_cast_atTop R, tendsto_comap_iff]; rfl
 #align tendsto_coe_rat_at_top_iff tendsto_ratCast_atTop_iff
 
+@[deprecated (since := "2024-04-17")]
+alias tendsto_rat_cast_atTop_iff := tendsto_ratCast_atTop_iff
+
 theorem tendsto_ratCast_atBot_iff [LinearOrderedField R] [Archimedean R] {f : α → ℚ}
     {l : Filter α} : Tendsto (fun n => (f n : R)) l atBot ↔ Tendsto f l atBot := by
   rw [← @Rat.comap_cast_atBot R, tendsto_comap_iff]; rfl
 #align tendsto_coe_rat_at_bot_iff tendsto_ratCast_atBot_iff
 
+@[deprecated (since := "2024-04-17")]
+alias tendsto_rat_cast_atBot_iff := tendsto_ratCast_atBot_iff
+
 theorem Filter.Eventually.ratCast_atTop [LinearOrderedField R] [Archimedean R] {p : R → Prop}
     (h : ∀ᶠ (x:R) in atTop, p x) : ∀ᶠ (n:ℚ) in atTop, p n := by
   rw [← Rat.comap_cast_atTop (R := R)]; exact h.comap _
 
+@[deprecated (since := "2024-04-17")]
+alias Filter.Eventually.rat_cast_atTop := Filter.Eventually.ratCast_atTop
+
 theorem Filter.Eventually.ratCast_atBot [LinearOrderedField R] [Archimedean R] {p : R → Prop}
     (h : ∀ᶠ (x:R) in atBot, p x) : ∀ᶠ (n:ℚ) in atBot, p n := by
   rw [← Rat.comap_cast_atBot (R := R)]; exact h.comap _
+
+@[deprecated (since := "2024-04-17")]
+alias Filter.Eventually.rat_cast_atBot := Filter.Eventually.ratCast_atBot
 
 -- Porting note (#10756): new lemma
 theorem atTop_hasAntitoneBasis_of_archimedean [OrderedSemiring R] [Archimedean R] :

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -206,6 +206,9 @@ theorem choose_natCast [NatPowAssoc R] (n k : ℕ) : choose (n : R) k = Nat.choo
   rw [← descPochhammer_eq_factorial_smul_choose, nsmul_eq_mul, ← Nat.cast_mul,
   ← Nat.descFactorial_eq_factorial_mul_choose, ← descPochhammer_smeval_eq_descFactorial]
 
+@[deprecated (since := "2024-04-17")]
+alias choose_nat_cast := choose_natCast
+
 end Ring
 
 end Choose

--- a/Mathlib/RingTheory/Congruence.lean
+++ b/Mathlib/RingTheory/Congruence.lean
@@ -305,6 +305,9 @@ theorem coe_natCast (n : ℕ) : (↑(n : R) : c.Quotient) = n :=
   rfl
 #align ring_con.coe_nat_cast RingCon.coe_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias coe_nat_cast := coe_natCast
+
 end NatCast
 
 section IntCast
@@ -318,6 +321,9 @@ instance : IntCast c.Quotient :=
 theorem coe_intCast (n : ℕ) : (↑(n : R) : c.Quotient) = n :=
   rfl
 #align ring_con.coe_int_cast RingCon.coe_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias coe_int_cast := coe_intCast
 
 end IntCast
 

--- a/Mathlib/RingTheory/FractionalIdeal/Basic.lean
+++ b/Mathlib/RingTheory/FractionalIdeal/Basic.lean
@@ -637,6 +637,9 @@ theorem coe_natCast (n : ℕ) : ((n : FractionalIdeal S P) : Submodule R P) = n 
   by induction n <;> simp [*, Nat.unaryCast]
 #align fractional_ideal.coe_nat_cast FractionalIdeal.coe_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias coe_nat_cast := coe_natCast
+
 instance commSemiring : CommSemiring (FractionalIdeal S P) :=
   Function.Injective.commSemiring _ Subtype.coe_injective coe_zero coe_one coe_add coe_mul
     (fun _ _ => coe_nsmul _ _) coe_pow coe_natCast

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -1098,6 +1098,9 @@ theorem mk_natCast (m : ℕ) : (mk m 1 : Localization M) = m := by
   simpa using mk_algebraMap (R := R) (A := ℕ) _
 #align localization.mk_nat_cast Localization.mk_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias mk_nat_cast := mk_natCast
+
 variable [IsLocalization M S]
 
 section
@@ -1214,6 +1217,9 @@ theorem sub_mk (a c) (b d) : (mk a b : Localization M) - mk c d =
 theorem mk_intCast (m : ℤ) : (mk m 1 : Localization M) = m := by
   simpa using mk_algebraMap (R := R) (A := ℤ) _
 #align localization.mk_int_cast Localization.mk_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias mk_int_cast := mk_intCast
 
 end Localization
 

--- a/Mathlib/RingTheory/WittVector/Basic.lean
+++ b/Mathlib/RingTheory/WittVector/Basic.lean
@@ -131,10 +131,16 @@ theorem natCast (n : ℕ) : mapFun f (n : 𝕎 R) = n :=
     induction n <;> simp [*, Nat.unaryCast, add, one, zero] <;> rfl
 #align witt_vector.map_fun.nat_cast WittVector.mapFun.natCast
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast := natCast
+
 theorem intCast (n : ℤ) : mapFun f (n : 𝕎 R) = n :=
   show mapFun f n.castDef = (n : WittVector p S) by
     cases n <;> simp [*, Int.castDef, add, one, neg, zero, natCast] <;> rfl
 #align witt_vector.map_fun.int_cast WittVector.mapFun.intCast
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast := intCast
 
 end mapFun
 
@@ -193,6 +199,9 @@ private theorem ghostFun_natCast (i : ℕ) : ghostFun (i : 𝕎 R) = i :=
     induction i <;>
       simp [*, Nat.unaryCast, ghostFun_zero, ghostFun_one, ghostFun_add, -Pi.natCast_def]
 
+@[deprecated (since := "2024-04-17")]
+alias ghostFun_nat_cast := ghostFun_natCast
+
 private theorem ghostFun_sub : ghostFun (x - y) = ghostFun x - ghostFun y := by
   ghost_fun_tac X 0 - X 1, ![x.coeff, y.coeff]
 
@@ -205,6 +214,9 @@ private theorem ghostFun_intCast (i : ℤ) : ghostFun (i : 𝕎 R) = i :=
   show ghostFun i.castDef = _ by
     cases i <;> simp [*, Int.castDef, ghostFun_natCast, ghostFun_neg, -Pi.natCast_def,
       -Pi.intCast_def]
+
+@[deprecated (since := "2024-04-17")]
+alias ghostFun_int_cast := ghostFun_intCast
 
 private lemma ghostFun_nsmul (m : ℕ) (x : WittVector p R) : ghostFun (m • x) = m • ghostFun x := by
   -- porting note: I had to add the explicit type ascription.

--- a/Mathlib/RingTheory/WittVector/Truncated.lean
+++ b/Mathlib/RingTheory/WittVector/Truncated.lean
@@ -285,8 +285,14 @@ theorem truncateFun_pow (x : 𝕎 R) (m : ℕ) : truncateFun n (x ^ m) = truncat
 theorem truncateFun_natCast (m : ℕ) : truncateFun n (m : 𝕎 R) = m := rfl
 #align witt_vector.truncate_fun_nat_cast WittVector.truncateFun_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias truncateFun_nat_cast := truncateFun_natCast
+
 theorem truncateFun_intCast (m : ℤ) : truncateFun n (m : 𝕎 R) = m := rfl
 #align witt_vector.truncate_fun_int_cast WittVector.truncateFun_intCast
+
+@[deprecated (since := "2024-04-17")]
+alias truncateFun_int_cast := truncateFun_intCast
 
 end WittVector
 

--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -191,6 +191,9 @@ theorem birthday_natCast : ∀ n : ℕ, birthday n = n
   | n + 1 => by simp [birthday_natCast]
 #align pgame.birthday_nat_cast SetTheory.PGame.birthday_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias birthday_nat_cast := birthday_natCast
+
 theorem birthday_add_nat (n : ℕ) : (a + n).birthday = a.birthday + n := by simp
 #align pgame.birthday_add_nat SetTheory.PGame.birthday_add_nat
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -2305,6 +2305,9 @@ theorem one_add_natCast (m : ℕ) : 1 + (m : Ordinal) = succ m := by
   rfl
 #align ordinal.one_add_nat_cast Ordinal.one_add_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias one_add_nat_cast := one_add_natCast
+
 -- See note [no_index around OfNat.ofNat]
 @[simp]
 theorem one_add_ofNat (m : ℕ) [m.AtLeastTwo] :
@@ -2317,15 +2320,24 @@ theorem natCast_mul (m : ℕ) : ∀ n : ℕ, ((m * n : ℕ) : Ordinal) = m * n
   | n + 1 => by rw [Nat.mul_succ, Nat.cast_add, natCast_mul m n, Nat.cast_succ, mul_add_one]
 #align ordinal.nat_cast_mul Ordinal.natCast_mul
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_mul := natCast_mul
+
 /-- Alias of `Nat.cast_le`, specialized to `Ordinal` --/
 theorem natCast_le {m n : ℕ} : (m : Ordinal) ≤ n ↔ m ≤ n := by
   rw [← Cardinal.ord_nat, ← Cardinal.ord_nat, Cardinal.ord_le_ord, Cardinal.natCast_le]
 #align ordinal.nat_cast_le Ordinal.natCast_le
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_le := natCast_le
+
 /-- Alias of `Nat.cast_inj`, specialized to `Ordinal` --/
 theorem natCast_inj {m n : ℕ} : (m : Ordinal) = n ↔ m = n := by
   simp only [le_antisymm_iff, natCast_le]
 #align ordinal.nat_cast_inj Ordinal.natCast_inj
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_inj := natCast_inj
 
 instance charZero : CharZero Ordinal where
   cast_injective _ _ := natCast_inj.mp
@@ -2334,17 +2346,29 @@ instance charZero : CharZero Ordinal where
 theorem natCast_lt {m n : ℕ} : (m : Ordinal) < n ↔ m < n := Nat.cast_lt
 #align ordinal.nat_cast_lt Ordinal.natCast_lt
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_lt := natCast_lt
+
 /-- Alias of `Nat.cast_eq_zero`, specialized to `Ordinal` --/
 theorem natCast_eq_zero {n : ℕ} : (n : Ordinal) = 0 ↔ n = 0 := Nat.cast_eq_zero
 #align ordinal.nat_cast_eq_zero Ordinal.natCast_eq_zero
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_eq_zero := natCast_eq_zero
 
 /-- Alias of `Nat.cast_eq_zero`, specialized to `Ordinal` --/
 theorem natCast_ne_zero {n : ℕ} : (n : Ordinal) ≠ 0 ↔ n ≠ 0 := Nat.cast_ne_zero
 #align ordinal.nat_cast_ne_zero Ordinal.natCast_ne_zero
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_ne_zero := natCast_ne_zero
+
 /-- Alias of `Nat.cast_pos'`, specialized to `Ordinal` --/
 theorem natCast_pos {n : ℕ} : (0 : Ordinal) < n ↔ 0 < n := Nat.cast_pos'
 #align ordinal.nat_cast_pos Ordinal.natCast_pos
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_pos := natCast_pos
 
 @[simp, norm_cast]
 theorem natCast_sub (m n : ℕ) : ((m - n : ℕ) : Ordinal) = m - n := by
@@ -2354,6 +2378,9 @@ theorem natCast_sub (m n : ℕ) : ((m - n : ℕ) : Ordinal) = m - n := by
   · apply (add_left_cancel n).1
     rw [← Nat.cast_add, add_tsub_cancel_of_le h, Ordinal.add_sub_cancel_of_le (natCast_le.2 h)]
 #align ordinal.nat_cast_sub Ordinal.natCast_sub
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_sub := natCast_sub
 
 @[simp, norm_cast]
 theorem natCast_div (m n : ℕ) : ((m / n : ℕ) : Ordinal) = m / n := by
@@ -2368,17 +2395,26 @@ theorem natCast_div (m n : ℕ) : ((m / n : ℕ) : Ordinal) = m / n := by
       apply Nat.lt_succ_self
 #align ordinal.nat_cast_div Ordinal.natCast_div
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_div := natCast_div
+
 @[simp, norm_cast]
 theorem natCast_mod (m n : ℕ) : ((m % n : ℕ) : Ordinal) = m % n := by
   rw [← add_left_cancel, div_add_mod, ← natCast_div, ← natCast_mul, ← Nat.cast_add,
     Nat.div_add_mod]
 #align ordinal.nat_cast_mod Ordinal.natCast_mod
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_mod := natCast_mod
+
 @[simp]
 theorem lift_natCast : ∀ n : ℕ, lift.{u, v} n = n
   | 0 => by simp
   | n + 1 => by simp [lift_natCast n]
 #align ordinal.lift_nat_cast Ordinal.lift_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias lift_nat_cast := lift_natCast
 
 -- See note [no_index around OfNat.ofNat]
 @[simp]
@@ -2456,6 +2492,9 @@ theorem omega_le {o : Ordinal} : ω ≤ o ↔ ∀ n : ℕ, ↑n ≤ o :=
 theorem sup_natCast : sup Nat.cast = ω :=
   (sup_le fun n => (nat_lt_omega n).le).antisymm <| omega_le.2 <| le_sup _
 #align ordinal.sup_nat_cast Ordinal.sup_natCast
+
+@[deprecated (since := "2024-04-17")]
+alias sup_nat_cast := sup_natCast
 
 theorem nat_lt_limit {o} (h : IsLimit o) : ∀ n : ℕ, ↑n < o
   | 0 => lt_of_le_of_ne (Ordinal.zero_le o) h.1.symm

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -1095,6 +1095,9 @@ theorem natCast_succ (n : ℕ) : ↑n.succ = succ (n : Ordinal) :=
   rfl
 #align ordinal.nat_cast_succ Ordinal.natCast_succ
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_succ := natCast_succ
+
 instance uniqueIioOne : Unique (Iio (1 : Ordinal)) where
   default := ⟨0, by simp⟩
   uniq a := Subtype.ext <| lt_one_iff_zero.1 a.2

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -459,6 +459,9 @@ theorem natCast_opow (m : ℕ) : ∀ n : ℕ, ↑(m ^ n : ℕ) = (m : Ordinal) ^
     rw [pow_succ, natCast_mul, natCast_opow m n, Nat.cast_succ, add_one_eq_succ, opow_succ]
 #align ordinal.nat_cast_opow Ordinal.natCast_opow
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_opow := natCast_opow
+
 theorem sup_opow_nat {o : Ordinal} (ho : 0 < o) : (sup fun n : ℕ => o ^ (n : Ordinal)) = o ^ ω := by
   rcases lt_or_eq_of_le (one_le_iff_pos.2 ho) with (ho₁ | rfl)
   · exact (opow_isNormal ho₁).apply_omega

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -95,6 +95,9 @@ theorem natDegree_natCast_le (n : ℕ) : natDegree (n : R[X]) ≤ 0 := (natDegre
 theorem natDegree_zero_le : natDegree (0 : R[X]) ≤ 0 := natDegree_zero.le
 theorem natDegree_one_le : natDegree (1 : R[X]) ≤ 0 := natDegree_one.le
 
+@[deprecated (since := "2024-04-17")]
+alias natDegree_nat_cast_le := natDegree_natCast_le
+
 theorem coeff_add_of_eq {n : ℕ} {a b : R} {f g : R[X]}
     (h_add_left : f.coeff n = a) (h_add_right : g.coeff n = b) :
     (f + g).coeff n = a + b := by subst ‹_› ‹_›; apply coeff_add
@@ -175,11 +178,17 @@ variable [Ring R]
 
 theorem natDegree_intCast_le (n : ℤ) : natDegree (n : R[X]) ≤ 0 := (natDegree_intCast _).le
 
+@[deprecated (since := "2024-04-17")]
+alias natDegree_int_cast_le := natDegree_intCast_le
+
 theorem coeff_sub_of_eq {n : ℕ} {a b : R} {f g : R[X]} (hf : f.coeff n = a) (hg : g.coeff n = b) :
     (f - g).coeff n = a - b := by subst hf hg; apply coeff_sub
 
 theorem coeff_intCast_ite {n : ℕ} {a : ℤ} : (Int.cast a : R[X]).coeff n = ite (n = 0) a 0 := by
   simp only [← C_eq_intCast, coeff_C, Int.cast_ite, Int.cast_zero]
+
+@[deprecated (since := "2024-04-17")]
+alias coeff_int_cast_ite := coeff_intCast_ite
 
 end ring
 

--- a/Mathlib/Tactic/Linarith/Lemmas.lean
+++ b/Mathlib/Tactic/Linarith/Lemmas.lean
@@ -69,6 +69,9 @@ lemma zero_mul_eq {α} {R : α → α → Prop} [Semiring α] {a b : α} (h : a 
 
 lemma natCast_nonneg (α : Type u) [OrderedSemiring α] (n : ℕ) : (0 : α) ≤ n := Nat.cast_nonneg n
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_nonneg := natCast_nonneg
+
 end Linarith
 
 section

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -105,7 +105,7 @@ theorem isNat_natCast {R} [AddMonoidWithOne R] (n m : ℕ) :
     IsNat n m → IsNat (n : R) m := by rintro ⟨⟨⟩⟩; exact ⟨rfl⟩
 
 @[deprecated (since := "2024-04-17")]
-alias isNat_cast := isnatCast
+alias isNat_cast := isNat_natCast
 
 /-- The `norm_num` extension which identifies an expression `Nat.cast n`, returning `n`. -/
 @[norm_num Nat.cast _, NatCast.natCast _] def evalNatCast : NormNumExt where eval {u α} e := do

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -104,6 +104,9 @@ theorem isNat_natAbs_neg : {n : ℤ} → {a : ℕ} → IsInt n (.negOfNat a) →
 theorem isNat_natCast {R} [AddMonoidWithOne R] (n m : ℕ) :
     IsNat n m → IsNat (n : R) m := by rintro ⟨⟨⟩⟩; exact ⟨rfl⟩
 
+@[deprecated (since := "2024-04-17")]
+alias isNat_cast := isnatCast
+
 /-- The `norm_num` extension which identifies an expression `Nat.cast n`, returning `n`. -/
 @[norm_num Nat.cast _, NatCast.natCast _] def evalNatCast : NormNumExt where eval {u α} e := do
   let sα ← inferAddMonoidWithOne α
@@ -116,8 +119,14 @@ theorem isNat_natCast {R} [AddMonoidWithOne R] (n m : ℕ) :
 theorem isNat_intCast {R} [Ring R] (n : ℤ) (m : ℕ) :
     IsNat n m → IsNat (n : R) m := by rintro ⟨⟨⟩⟩; exact ⟨by simp⟩
 
+@[deprecated (since := "2024-04-17")]
+alias isNat_int_cast := isNat_intCast
+
 theorem isintCast {R} [Ring R] (n m : ℤ) :
     IsInt n m → IsInt (n : R) m := by rintro ⟨⟨⟩⟩; exact ⟨rfl⟩
+
+@[deprecated (since := "2024-04-17")]
+alias isInt_cast := isintCast
 
 /-- The `norm_num` extension which identifies an expression `Int.cast n`, returning `n`. -/
 @[norm_num Int.cast _, IntCast.intCast _] def evalIntCast : NormNumExt where eval {u α} e := do

--- a/Mathlib/Tactic/Qify.lean
+++ b/Mathlib/Tactic/Qify.lean
@@ -69,3 +69,6 @@ macro_rules
 @[qify_simps] lemma intCast_lt (a b : ℤ) : a < b ↔ (a : ℚ) < (b : ℚ) := Int.cast_lt.symm
 @[qify_simps] lemma intCast_ne (a b : ℤ) : a ≠ b ↔ (a : ℚ) ≠ (b : ℚ) := by
   simp only [ne_eq, Int.cast_inj]
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_ne := intCast_ne

--- a/Mathlib/Tactic/Rify.lean
+++ b/Mathlib/Tactic/Rify.lean
@@ -79,6 +79,9 @@ macro_rules
 @[rify_simps] lemma ratCast_lt (a b : ℚ) : a < b ↔ (a : ℝ) < (b : ℝ) := by simp
 @[rify_simps] lemma ratCast_ne (a b : ℚ) : a ≠ b ↔ (a : ℝ) ≠ (b : ℝ) := by simp
 
+@[deprecated (since := "2024-04-17")]
+alias rat_cast_ne := ratCast_ne
+
 -- See note [no_index around OfNat.ofNat]
 @[rify_simps] lemma ofNat_rat_real (a : ℕ) [a.AtLeastTwo] :
     ((no_index (OfNat.ofNat a : ℚ)) : ℝ) = (OfNat.ofNat a : ℝ) := rfl

--- a/Mathlib/Tactic/Zify.lean
+++ b/Mathlib/Tactic/Zify.lean
@@ -102,6 +102,9 @@ def zifyProof (simpArgs : Option (Syntax.TSepArray `Lean.Parser.Tactic.simpStar 
 -- TODO: is it worth adding lemmas for Prime and Coprime as well?
 -- Doing so in this file would require adding imports.
 
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_dvd := natCast_dvd
+
 
 -- `Nat.cast_sub` is already tagged as `norm_cast` but it does allow to use assumptions like
 -- `m < n` or more generally `m + k ≤ n`. We add two lemmas to increase the probability that

--- a/Mathlib/Topology/ContinuousFunction/Algebra.lean
+++ b/Mathlib/Topology/ContinuousFunction/Algebra.lean
@@ -114,10 +114,16 @@ theorem coe_natCast [NatCast β] (n : ℕ) : ((n : C(α, β)) : α → β) = n :
   rfl
 #align continuous_map.coe_nat_cast ContinuousMap.coe_natCast
 
+@[deprecated (since := "2024-04-17")]
+alias coe_nat_cast := coe_natCast
+
 @[simp]
 theorem natCast_apply [NatCast β] (n : ℕ) (x : α) : (n : C(α, β)) x = n :=
   rfl
 #align continuous_map.nat_cast_apply ContinuousMap.natCast_apply
+
+@[deprecated (since := "2024-04-17")]
+alias nat_cast_apply := natCast_apply
 
 /-! ### `Int.cast` -/
 
@@ -129,10 +135,16 @@ theorem coe_intCast [IntCast β] (n : ℤ) : ((n : C(α, β)) : α → β) = n :
   rfl
 #align continuous_map.coe_int_cast ContinuousMap.coe_intCast
 
+@[deprecated (since := "2024-04-17")]
+alias coe_int_cast := coe_intCast
+
 @[simp]
 theorem intCast_apply [IntCast β] (n : ℤ) (x : α) : (n : C(α, β)) x = n :=
   rfl
 #align continuous_map.int_cast_apply ContinuousMap.intCast_apply
+
+@[deprecated (since := "2024-04-17")]
+alias int_cast_apply := intCast_apply
 
 /-! ### `nsmul` and `pow` -/
 


### PR DESCRIPTION
Deprecations have been forgotten in #11486. We add them in this PR.

Methodology: start from the last commit of #11486, use the script by @adomani in https://github.com/leanprover-community/mathlib4/pull/10185#issuecomment-1925481325 to generate deprecation aliases (I am also adding an updated version of the script in a comment below) and commit. Then cherry pick this last commit on master and fix whatever has changed in between. This is not perfect as declarations which have been moved since #11486 won't get their deprecated alias, but this should be good enough.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
