### PR TITLE
[Merged by Bors] - fix(Mathlib/Tactic/CC/Addition): `cc` tactic throws error for literals

### DIFF
--- a/Mathlib/Tactic/CC/Addition.lean
+++ b/Mathlib/Tactic/CC/Addition.lean
@@ -1219,6 +1219,7 @@ partial def internalizeAppLit (e : Expr) : CCM Unit := do
   else
     mkEntry e false
     if (← get).values && isValue e then return -- we treat values as atomic symbols
+  unless e.isApp do return
   if let some (_, lhs, rhs) ← e.relSidesIfSymm? then
     internalizeCore lhs (some e)
     internalizeCore rhs (some e)

--- a/Mathlib/Tactic/CC/Addition.lean
+++ b/Mathlib/Tactic/CC/Addition.lean
@@ -1219,6 +1219,7 @@ partial def internalizeAppLit (e : Expr) : CCM Unit := do
   else
     mkEntry e false
     if (← get).values && isValue e then return -- we treat values as atomic symbols
+  -- At this point we should have handled a literal; otherwise we fail.
   unless e.isApp do return
   if let some (_, lhs, rhs) ← e.relSidesIfSymm? then
     internalizeCore lhs (some e)

--- a/test/cc.lean
+++ b/test/cc.lean
@@ -568,3 +568,10 @@ example {α : Type} {a b : α} (h : ¬ (a = b)) : ¬ (b = a) := by
   cc
 
 end Lean3Issue1608
+
+section rawNatLit
+
+example : nat_lit 0 = nat_lit 0 := by
+  cc
+
+end rawNatLit

--- a/test/cc.lean
+++ b/test/cc.lean
@@ -569,9 +569,12 @@ example {α : Type} {a b : α} (h : ¬ (a = b)) : ¬ (b = a) := by
 
 end Lean3Issue1608
 
-section rawNatLit
+section lit
 
 example : nat_lit 0 = nat_lit 0 := by
   cc
 
-end rawNatLit
+example : "Miyahara Kō" = "Miyahara Kō" := by
+  cc (config := { values := false })
+
+end lit


### PR DESCRIPTION
```lean
example : nat_lit 0 = nat_lit 0 := by
  cc
-- failed

example : "Miyahara Kō" = "Miyahara Kō" := by
  cc (config := { values := false })
-- failed
```
The cause of this error is that code on `Mathlib.Tactic.CC.CCM.internalizeAppLit` from L1222 onwards doesn't assume that the input is `Expr.lit`.
This error can be fixed simply by adding `unless e.isApp do return`.
Also, we add a test for this bug.

p.s. This is an new error in Lean 4 because Lean 3 has no `Expr.lit` so we doesn't have to fix code in Lean 3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
