### PR TITLE
[Merged by Bors] - chore(Algebra/Lie/Abelian): a nonabelian atomic Lie ideal is perfect

### DIFF
--- a/Mathlib/Algebra/Lie/Abelian.lean
+++ b/Mathlib/Algebra/Lie/Abelian.lean
@@ -96,6 +96,18 @@ theorem commutative_ring_iff_abelian_lie_ring {A : Type v} [Ring A] :
   simp only [h₁, h₂, LieRing.of_associative_ring_bracket, sub_eq_zero]
 #align commutative_ring_iff_abelian_lie_ring commutative_ring_iff_abelian_lie_ring
 
+-- TODO: introduce typeclass for perfect Lie algebras and use it here in the conclusion
+lemma lie_eq_self_of_isAtom_of_nonabelian {R L : Type*} [CommRing R] [LieRing L] [LieAlgebra R L]
+    (I : LieIdeal R L) (hI : IsAtom I) (h : ¬IsLieAbelian I) :
+    ⁅I, I⁆ = I := by
+  rw [← hI.le_iff_eq]
+  · exact LieSubmodule.lie_le_right I I
+  · contrapose! h
+    rw [LieSubmodule.lie_eq_bot_iff] at h
+    constructor
+    simpa only [LieIdeal.coe_bracket_of_module, Subtype.ext_iff, LieSubmodule.coe_bracket,
+      ZeroMemClass.coe_zero, Subtype.forall, LieSubmodule.mem_coeSubmodule] using h
+
 section Center
 
 variable (R : Type u) (L : Type v) (M : Type w) (N : Type w₁)


### PR DESCRIPTION
TODO: we do not have a predicate for perfect Lie algebras.
Once this is introduced it should be used in this lemma.

Prerequisite for #13265


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
