### PR TITLE
[Merged by Bors] - feat(NumberTheory/Zsqrtd/GaussianInt): Function.Injective GaussianInt.toComplex

### DIFF
--- a/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
@@ -142,6 +142,9 @@ theorem toComplex_inj {x y : ℤ[i]} : (x : ℂ) = y ↔ x = y := by
   cases x; cases y; simp [toComplex_def₂]
 #align gaussian_int.to_complex_inj GaussianInt.toComplex_inj
 
+lemma toComplex_injective : Function.Injective GaussianInt.toComplex :=
+  fun ⦃_ _⦄ ↦ toComplex_inj.mp
+
 @[simp]
 theorem toComplex_eq_zero {x : ℤ[i]} : (x : ℂ) = 0 ↔ x = 0 := by
   rw [← toComplex_zero, toComplex_inj]


### PR DESCRIPTION
This adds the `Function.Injective` version of the injectivity of the map from `ℤ[i]` to `ℂ`. (This is convenient for use with `apply_fun`, for example.)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
