### PR TITLE
Revert "chore: demote `charZero_of_expChar_one'` instance to a theorem"

### DIFF
--- a/Mathlib/Algebra/CharP/ExpChar.lean
+++ b/Mathlib/Algebra/CharP/ExpChar.lean
@@ -108,9 +108,9 @@ theorem char_zero_of_expChar_one (p : ℕ) [hp : CharP R p] [hq : ExpChar R 1] :
   · exact False.elim (CharP.char_ne_one R 1 rfl)
 #align char_zero_of_exp_char_one char_zero_of_expChar_one
 
--- This could be an instance, but there are no `ExpChar R 1` instances in mathlib.
+-- see Note [lower instance priority]
 /-- The characteristic is zero if the exponential characteristic is one. -/
-theorem charZero_of_expChar_one' [hq : ExpChar R 1] : CharZero R := by
+instance (priority := 100) charZero_of_expChar_one' [hq : ExpChar R 1] : CharZero R := by
   cases hq
   · assumption
   · exact False.elim (CharP.char_ne_one R 1 rfl)


### PR DESCRIPTION
Revert #7777, since the introduced workaround is no longer needed after https://github.com/leanprover/lean4/pull/4003.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
