### PR TITLE
[Merged by Bors] - fix: `move-decls` is aware of protected

### DIFF
--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -17,7 +17,7 @@ else
   git diff origin/master...HEAD
 fi |
   ## purge `@[...]`, to attempt to catch declaration names
-  sed 's=@\[[^]]*\] ==; s=noncomputable ==; s=nonrec ==' |
+  sed 's=@\[[^]]*\] ==; s=noncomputable ==; s=nonrec ==; s=protected ==' |
   ## extract lines that begin with '[+-]' followed by the input `theorem` or `lemma`
   ## in the `git diff`
   awk -v regex="^[+-]${begs}" 'BEGIN{ paired=0; added=0; removed=0 }


### PR DESCRIPTION
As reported on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60move-decls.60.20label/near/441435405).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
