### PR TITLE
[Merged by Bors] - chore(NumberTheory/LSeries): namespace Hurwitz zeta

### DIFF
--- a/Mathlib/NumberTheory/LSeries/HurwitzZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZeta.lean
@@ -37,6 +37,8 @@ This file gives the definition and properties of the following two functions:
 
 open Set Real Complex Filter Topology
 
+namespace HurwitzZeta
+
 /-!
 ## The Hurwitz zeta function
 -/
@@ -185,3 +187,5 @@ lemma expZeta_one_sub (a : UnitAddCircle) {s : ℂ} (hs : ∀ (n : ℕ), s ≠ 1
   ring_nf
   rw [I_sq]
   ring_nf
+
+namespace HurwitzZeta

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
@@ -48,6 +48,8 @@ noncomputable section
 
 open Complex Filter Topology Asymptotics Real Set Classical MeasureTheory
 
+namespace HurwitzZeta
+
 section kernel_defs
 /-!
 ## Definitions and elementary properties of kernels
@@ -801,3 +803,5 @@ lemma cosZeta_one_sub (a : UnitAddCircle) {s : ℂ} (hs : ∀ (n : ℕ), s ≠ 1
     hurwitzZetaEven_def_of_ne_or_ne (Or.inr (by simpa using hs 1))]
   generalize Gammaℂ s * cos (π * s / 2) = A -- speeds up ring_nf call
   ring_nf
+
+end HurwitzZeta

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -46,6 +46,8 @@ open Complex hiding abs_of_nonneg
 open Filter Topology Asymptotics Real Set MeasureTheory
 open scoped ComplexConjugate
 
+namespace HurwitzZeta
+
 section kernel_defs
 /-!
 ## Definitions and elementary properties of kernels
@@ -327,6 +329,8 @@ def hurwitzOddFEPair (a : UnitAddCircle) : StrongFEPair ℂ where
     oddKernel_functional_equation a, one_div x, one_div x⁻¹, inv_rpow (le_of_lt hx), one_div,
     inv_inv]
 
+end FEPair
+
 /-!
 ## Definition of the completed odd Hurwitz zeta function
 -/
@@ -574,3 +578,5 @@ lemma sinZeta_one_sub (a : UnitAddCircle) {s : ℂ} (hs : ∀ (n : ℕ), s ≠ -
   rw [← Gammaℂ, sinZeta, (by ring : 1 - s + 1 = 2 - s), div_eq_mul_inv, inv_Gammaℝ_two_sub hs,
     completedSinZeta_one_sub, hurwitzZetaOdd, ← div_eq_mul_inv, ← mul_div_assoc, ← mul_div_assoc,
     mul_comm]
+
+end HurwitzZeta

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
@@ -38,6 +38,8 @@ open Complex Real Set
 
 open scoped Nat
 
+namespace HurwitzZeta
+
 variable {k : ℕ} {x : ℝ}
 
 /-- Express the value of `cosZeta` at a positive even integer as a value
@@ -193,3 +195,5 @@ theorem hurwitzZeta_neg_nat (hk : k ≠ 0) (hx : x ∈ Icc (0 : ℝ) 1) :
   rcases Nat.even_or_odd' k with ⟨n, (rfl | rfl)⟩
   · exact_mod_cast hurwitzZeta_neg_two_mul_nat (by omega : n ≠ 0) hx
   · exact_mod_cast hurwitzZeta_one_sub_two_mul_nat (by omega : n + 1 ≠ 0) hx
+
+end HurwitzZeta


### PR DESCRIPTION
This wraps all the code added so far about Hurwitz zeta functions (& their cousins `expZeta`, `cosZeta`, etc) in a namespace `HurwitzZeta`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
