### PR TITLE
[Merged by Bors] - feat: simp lemma replacing MulEquiv.toMonoidHom with coercion

### DIFF
--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -628,6 +628,10 @@ theorem coe_toMonoidHom (e : M ≃* N) : ⇑e.toMonoidHom = e := rfl
 #align mul_equiv.coe_to_monoid_hom MulEquiv.coe_toMonoidHom
 #align add_equiv.coe_to_add_monoid_hom AddEquiv.coe_toAddMonoidHom
 
+@[to_additive (attr := simp)]
+theorem toMonoidHom_eq_coe (f : M ≃* N) : f.toMonoidHom = (f : M →* N) :=
+  rfl
+
 set_option linter.deprecated false in
 @[to_additive]
 theorem toMonoidHom_injective : Injective (toMonoidHom : M ≃* N → M →* N) :=

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -724,7 +724,7 @@ def topEquiv : (⊤ : Submonoid M) ≃* M where
 #align submonoid.top_equiv_symm_apply_coe Submonoid.topEquiv_symm_apply_coe
 
 @[to_additive (attr := simp)]
-theorem topEquiv_toMonoidHom : (topEquiv : _ ≃* M).toMonoidHom = (⊤ : Submonoid M).subtype :=
+theorem topEquiv_toMonoidHom : ((topEquiv : _ ≃* M) : _ →* M) = (⊤ : Submonoid M).subtype :=
   rfl
 #align submonoid.top_equiv_to_monoid_hom Submonoid.topEquiv_toMonoidHom
 #align add_submonoid.top_equiv_to_add_monoid_hom AddSubmonoid.topEquiv_toAddMonoidHom
@@ -867,13 +867,13 @@ theorem map_equiv_eq_comap_symm (f : M ≃* N) (K : Submonoid M) :
 
 @[to_additive]
 theorem comap_equiv_eq_map_symm (f : N ≃* M) (K : Submonoid M) :
-    K.comap f.toMonoidHom = K.map f.symm.toMonoidHom :=
+    K.comap f = K.map f.symm :=
   (map_equiv_eq_comap_symm f.symm K).symm
 #align submonoid.comap_equiv_eq_map_symm Submonoid.comap_equiv_eq_map_symm
 #align add_submonoid.comap_equiv_eq_map_symm AddSubmonoid.comap_equiv_eq_map_symm
 
 @[to_additive (attr := simp)]
-theorem map_equiv_top (f : M ≃* N) : (⊤ : Submonoid M).map f.toMonoidHom = ⊤ :=
+theorem map_equiv_top (f : M ≃* N) : (⊤ : Submonoid M).map f = ⊤ :=
   SetLike.coe_injective <| Set.image_univ.trans f.surjective.range_eq
 #align submonoid.map_equiv_top Submonoid.map_equiv_top
 #align add_submonoid.map_equiv_top AddSubmonoid.map_equiv_top
@@ -1381,7 +1381,7 @@ See `MonoidHom.submonoidMap` for a variant for `MonoidHom`s. -/
       "An `AddEquiv` `φ` between two additive monoids `M` and `N` induces an `AddEquiv`
       between a submonoid `S ≤ M` and the submonoid `φ(S) ≤ N`. See
       `AddMonoidHom.addSubmonoidMap` for a variant for `AddMonoidHom`s."]
-def submonoidMap (e : M ≃* N) (S : Submonoid M) : S ≃* S.map e.toMonoidHom :=
+def submonoidMap (e : M ≃* N) (S : Submonoid M) : S ≃* S.map e :=
   { (e : M ≃ N).image S with map_mul' := fun _ _ => Subtype.ext (map_mul e _ _) }
 #align mul_equiv.submonoid_map MulEquiv.submonoidMap
 #align add_equiv.add_submonoid_map AddEquiv.addSubmonoidMap

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -274,7 +274,7 @@ theorem mapRange.addEquiv_symm (f : M ≃+ N) :
 
 @[simp]
 theorem mapRange.addEquiv_toAddMonoidHom (f : M ≃+ N) :
-    (mapRange.addEquiv f : (α →₀ _) ≃+ _).toAddMonoidHom =
+    ((mapRange.addEquiv f : (α →₀ _) ≃+ _) : _ →+ _) =
       (mapRange.addMonoidHom f.toAddMonoidHom : (α →₀ _) →+ _) :=
   AddMonoidHom.ext fun _ => rfl
 #align finsupp.map_range.add_equiv_to_add_monoid_hom Finsupp.mapRange.addEquiv_toAddMonoidHom


### PR DESCRIPTION
I was surprised to encounter post-simp goals that included both `x.toMonoidHom` and the coercion.

I think it would be good to follow up by avoiding `toMonoidHom` in favour of the coercion in the first place.