### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry/StructureSheaf): add two useful lemmas

### DIFF
--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -885,6 +885,10 @@ theorem isCompact_basicOpen (f : R) : IsCompact (basicOpen f : Set (PrimeSpectru
   exact isCompact_range (map_continuous _)
 #align prime_spectrum.is_compact_basic_open PrimeSpectrum.isCompact_basicOpen
 
+lemma comap_basicOpen {R S} [CommSemiring R] [CommSemiring S] (f : R →+* S) (x : R) :
+    TopologicalSpace.Opens.comap (comap f) (basicOpen x) = basicOpen (f x) :=
+  rfl
+
 end BasicOpen
 
 section Order

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -885,7 +885,7 @@ theorem isCompact_basicOpen (f : R) : IsCompact (basicOpen f : Set (PrimeSpectru
   exact isCompact_range (map_continuous _)
 #align prime_spectrum.is_compact_basic_open PrimeSpectrum.isCompact_basicOpen
 
-lemma comap_basicOpen {R S} [CommSemiring R] [CommSemiring S] (f : R →+* S) (x : R) :
+lemma comap_basicOpen (f : R →+* S) (x : R) :
     TopologicalSpace.Opens.comap (comap f) (basicOpen x) = basicOpen (f x) :=
   rfl
 

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -1220,6 +1220,13 @@ theorem toOpen_comp_comap (f : R →+* S) (U : Opens (PrimeSpectrum.Top R)) :
   RingHom.ext fun _ => Subtype.eq <| funext fun _ => Localization.localRingHom_to_map _ _ _ _ _
 #align algebraic_geometry.structure_sheaf.to_open_comp_comap AlgebraicGeometry.StructureSheaf.toOpen_comp_comap
 
+lemma comap_basicOpen (f : R →+* S) (x : R) :
+    comap f (PrimeSpectrum.basicOpen x) (PrimeSpectrum.basicOpen (f x))
+        (PrimeSpectrum.comap_basicOpen f x).le =
+      IsLocalization.map (M := .powers x) (T := .powers (f x)) _ f
+        (Submonoid.powers_le.mpr (Submonoid.mem_powers _)) :=
+  IsLocalization.ringHom_ext (.powers x) <| by simpa using toOpen_comp_comap f _
+
 end Comap
 
 end StructureSheaf


### PR DESCRIPTION
Let $f : R \to S$ be a ring map

1.  The preimage of some basic open set $D(x)$ under $\mathrm{Spec}f$ is $D(f(x))$ (proof is `rfl`)
2.  the ring map $\Gamma(\mathcal{O} _ {\mathrm{Spec}R}, D(x)) \to \Gamma(\mathcal{O}_{\mathrm{Spec} S}, D(f(x))$ is the map between localizations `R_x` and `S_{f(x)}.`

These are lemmas are found useful in #12371 by Andrew.

Co-authored-by: Andrew Yang <the.erd.one@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
