### PR TITLE
[Merged by Bors] - feat: add `Polynomial.coeff_list_sum_map`

### DIFF
--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -115,8 +115,7 @@ lemma coeff_list_sum (l : List R[X]) (n : ℕ) :
 
 lemma coeff_list_sum_map {ι : Type*} (l : List ι) (f : ι → R[X]) (n : ℕ) :
     (l.map f).sum.coeff n = (l.map (fun a => (f a).coeff n)).sum := by
-  rw [coeff_list_sum, List.map_map, Function.comp]
-  simp only [lcoeff_apply]
+  simp_rw [coeff_list_sum, List.map_map, Function.comp, lcoeff_apply]
 
 theorem coeff_sum [Semiring S] (n : ℕ) (f : ℕ → R → S[X]) :
     coeff (p.sum f) n = p.sum fun a b => coeff (f a b) n := by

--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -113,7 +113,6 @@ lemma coeff_list_sum (l : List R[X]) (n : ℕ) :
     l.sum.coeff n = (l.map (lcoeff R n)).sum :=
   map_list_sum (lcoeff R n) _
 
-@[simp]
 lemma coeff_list_sum_map {ι : Type*} (l : List ι) (f : ι → R[X]) (n : ℕ) :
     (l.map f).sum.coeff n = (l.map (fun a => (f a).coeff n)).sum := by
   rw [coeff_list_sum, List.map_map, Function.comp]

--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -109,21 +109,22 @@ theorem finset_sum_coeff {ι : Type*} (s : Finset ι) (f : ι → R[X]) (n : ℕ
   map_sum (lcoeff R n) _ _
 #align polynomial.finset_sum_coeff Polynomial.finset_sum_coeff
 
+lemma coeff_list_sum (l : List R[X]) (i : ℕ) :
+    l.sum.coeff i = (l.map (lcoeff R i)).sum := by
+  rw [← lcoeff_apply, map_list_sum]
+
+@[simp]
+lemma coeff_list_sum_map {ι : Type*} (l : List ι) (f : ι → R[X]) (i : ℕ) :
+    (l.map f).sum.coeff i = (l.map (fun a => (f a).coeff i)).sum := by
+  rw [coeff_list_sum, List.map_map, Function.comp]
+  simp only [lcoeff_apply]
+
 theorem coeff_sum [Semiring S] (n : ℕ) (f : ℕ → R → S[X]) :
     coeff (p.sum f) n = p.sum fun a b => coeff (f a b) n := by
   rcases p with ⟨⟩
   -- porting note (#10745): was `simp [Polynomial.sum, support, coeff]`.
   simp [Polynomial.sum, support_ofFinsupp, coeff_ofFinsupp]
 #align polynomial.coeff_sum Polynomial.coeff_sum
-
-lemma coeff_list_sum (l : List R[X]) (i : ℕ) :
-    l.sum.coeff i = (l.map (lcoeff R i)).sum := by
-  rw [← lcoeff_apply, map_list_sum]
-
-lemma coeff_list_sum_map {α : Type} (l : List α) (f : α → R[X]) (i : ℕ) :
-    (l.map f).sum.coeff i = (l.map (fun a => (f a).coeff i)).sum := by
-  rw [coeff_list_sum, List.map_map, Function.comp]
-  simp only [lcoeff_apply]
 
 /-- Decomposes the coefficient of the product `p * q` as a sum
 over `antidiagonal`. A version which sums over `range (n + 1)` can be obtained

--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -109,13 +109,13 @@ theorem finset_sum_coeff {ι : Type*} (s : Finset ι) (f : ι → R[X]) (n : ℕ
   map_sum (lcoeff R n) _ _
 #align polynomial.finset_sum_coeff Polynomial.finset_sum_coeff
 
-lemma coeff_list_sum (l : List R[X]) (i : ℕ) :
-    l.sum.coeff i = (l.map (lcoeff R i)).sum := by
+lemma coeff_list_sum (l : List R[X]) (n : ℕ) :
+    l.sum.coeff n = (l.map (lcoeff R n)).sum := by
   rw [← lcoeff_apply, map_list_sum]
 
 @[simp]
-lemma coeff_list_sum_map {ι : Type*} (l : List ι) (f : ι → R[X]) (i : ℕ) :
-    (l.map f).sum.coeff i = (l.map (fun a => (f a).coeff i)).sum := by
+lemma coeff_list_sum_map {ι : Type*} (l : List ι) (f : ι → R[X]) (n : ℕ) :
+    (l.map f).sum.coeff n = (l.map (fun a => (f a).coeff n)).sum := by
   rw [coeff_list_sum, List.map_map, Function.comp]
   simp only [lcoeff_apply]
 

--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -110,8 +110,8 @@ theorem finset_sum_coeff {ι : Type*} (s : Finset ι) (f : ι → R[X]) (n : ℕ
 #align polynomial.finset_sum_coeff Polynomial.finset_sum_coeff
 
 lemma coeff_list_sum (l : List R[X]) (n : ℕ) :
-    l.sum.coeff n = (l.map (lcoeff R n)).sum := by
-  rw [← lcoeff_apply, map_list_sum]
+    l.sum.coeff n = (l.map (lcoeff R n)).sum :=
+  map_list_sum (lcoeff R n) _
 
 @[simp]
 lemma coeff_list_sum_map {ι : Type*} (l : List ι) (f : ι → R[X]) (n : ℕ) :

--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.MonoidAlgebra.Support
 import Mathlib.Algebra.Polynomial.Basic
 import Mathlib.Algebra.Regular.Basic
 import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Tactic.RewriteSearch
 
 #align_import data.polynomial.coeff from "leanprover-community/mathlib"@"2651125b48fc5c170ab1111afd0817c903b1fc6c"
 
@@ -115,6 +116,15 @@ theorem coeff_sum [Semiring S] (n : ℕ) (f : ℕ → R → S[X]) :
   -- porting note (#10745): was `simp [Polynomial.sum, support, coeff]`.
   simp [Polynomial.sum, support_ofFinsupp, coeff_ofFinsupp]
 #align polynomial.coeff_sum Polynomial.coeff_sum
+
+lemma coeff_list_sum (l : List R[X]) (i : ℕ) :
+    l.sum.coeff i = (l.map (lcoeff R i)).sum := by
+  rw [← lcoeff_apply, map_list_sum]
+
+lemma coeff_list_sum_map {α : Type} (l : List α) (f : α → R[X]) (i : ℕ) :
+    (l.map f).sum.coeff i = (l.map (fun a => (f a).coeff i)).sum := by
+  rw [coeff_list_sum, List.map_map, Function.comp]
+  simp only [lcoeff_apply]
 
 /-- Decomposes the coefficient of the product `p * q` as a sum
 over `antidiagonal`. A version which sums over `range (n + 1)` can be obtained

--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.MonoidAlgebra.Support
 import Mathlib.Algebra.Polynomial.Basic
 import Mathlib.Algebra.Regular.Basic
 import Mathlib.Data.Nat.Choose.Sum
-import Mathlib.Tactic.RewriteSearch
 
 #align_import data.polynomial.coeff from "leanprover-community/mathlib"@"2651125b48fc5c170ab1111afd0817c903b1fc6c"
 


### PR DESCRIPTION
Adds lemmas about transposing a `coeff` with a sum of a list, analogous to `finset_sum_coeff` (although in this case I will not mark `simp` because the expression on the RHS is visually more complicated).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
