### PR TITLE
[Merged by Bors] - fix: `cc` tactic can't unify def-eq instances in `OfNat.ofNat`

### DIFF
--- a/Mathlib/Tactic/CC/Addition.lean
+++ b/Mathlib/Tactic/CC/Addition.lean
@@ -1449,7 +1449,25 @@ partial def propagateEqUp (e : Expr) : CCM Unit := do
   let rb ← getRoot b
   if ra != rb then
     let mut raNeRb : Option Expr := none
-    if ← isInterpretedValue ra <&&> isInterpretedValue rb then
+    /-
+    We disprove inequality for interpreted values here.
+    The possible types of interpreted values are in `{String, Char, Int, Nat}`.
+    1- `String`
+      `ra` & `rb` are string literals, so if `ra != rb`, `ra.int?.isNone` is `true` and we can
+      prove `$ra ≠ $rb`.
+    2- `Char`
+      `ra` & `rb` are the form of `Char.ofNat (nat_lit n)`, so if `ra != rb`, `ra.int?.isNone` is
+      `true` and we can prove `$ra ≠ $rb` (assuming that `n` is not pathological value, i.e.
+      `n.isValidChar`).
+    3- `Int`, `Nat`
+      `ra` & `rb` are the form of `@OfNat.ofNat ℤ (nat_lit n) i` or
+      `@Neg.neg ℤ i' (@OfNat.ofNat ℤ (nat_lit n) i)`, so even if `ra != rb`, `$ra ≠ $rb` can be
+      false when `i` or `i'` in `ra` & `rb` are not alpha-equivalent but def-eq.
+      If `ra.int? != rb.int?`, we can prove `$ra ≠ $rb` (assuming that `i` & `i'` are not
+      pathological instances).
+    -/
+    if ← isInterpretedValue ra <&&> isInterpretedValue rb <&&>
+        pure (ra.int?.isNone || ra.int? != rb.int?) then
       raNeRb := some
         (Expr.app (.proj ``Iff 0 (← mkAppM ``bne_iff_ne #[ra, rb])) (← mkEqRefl (.const ``true [])))
     else

--- a/Mathlib/Tactic/CC/Datatypes.lean
+++ b/Mathlib/Tactic/CC/Datatypes.lean
@@ -130,7 +130,7 @@ structure CCConfig where
   /-- If `true`, then use excluded middle -/
   em : Bool := true
   /-- If `true`, we treat values as atomic symbols -/
-  values : Bool := true
+  values : Bool := false
   deriving Inhabited
 #align cc_config Mathlib.Tactic.CC.CCConfig
 

--- a/test/cc.lean
+++ b/test/cc.lean
@@ -527,6 +527,13 @@ example (a b : String) : a = "hello" → b = "world" → a = b → False := by
 example (a b c : String) : a = c → a = "hello" → c = "world" → c = b → False := by
   cc
 
+local instance instOfNatNat' (n : ℕ) : OfNat ℕ n where
+  ofNat := n
+
+example : @OfNat.ofNat ℕ (nat_lit 0) (instOfNatNat _) =
+    @OfNat.ofNat ℕ (nat_lit 0) (instOfNatNat' _) := by
+  cc
+
 end CCValue
 
 section Config
@@ -575,6 +582,6 @@ example : nat_lit 0 = nat_lit 0 := by
   cc
 
 example : "Miyahara Kō" = "Miyahara Kō" := by
-  cc (config := { values := false })
+  cc
 
 end lit


### PR DESCRIPTION
This issue is consisted of one problem and one bug.

**Problem: `cc` treats an `OfNat.ofNat` term as an atomic value in the default config**
In the default `CCConfig`, the `values` field is set to `true` so `cc` treats an `OfNat.ofNat` term as an atomic and it doesn't unify `OfNat` instances.
This problem can be solved simply by setting `values := false` by default.

**Bug: `cc` tries to disprove `@OfNat α (nat_lit n) i₁ ≠ @OfNat α (nat_lit n) i₂` where `α` is `ℕ` or `ℤ` and `i₁` & `i₂` is not alpha-equivalent but def_eq**
`cc` tactic has a mechanism to disprove equality between two different values of `ℕ`, `ℤ`, `Char` & `String`, in the function `propagateEqUp`. This mechanism is trigered when the root representations of two values are not alpha-equivalent, so this example fails.
```lean
local instance instOfNatNat' (n : ℕ) : OfNat ℕ n where
  ofNat := n

example : @OfNat.ofNat ℕ (nat_lit 0) (instOfNatNat _) =
    @OfNat.ofNat ℕ (nat_lit 0) (instOfNatNat' _) := by
  cc
/-
application type mismatch
  (bne_iff_ne 0 0).1 (Eq.refl true)
argument has type
  true = true
but function has type
  (0 != 0) = true → 0 ≠ 0
-/
```
So we strengthen the condition in `propagateEqUp`. For the detail, refer to docs in this function.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Resolves #13362

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
