### PR TITLE
[Merged by Bors] - feat(CategoryTheory): surjective/injective factorizations in concrete categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1258,6 +1258,7 @@ import Mathlib.CategoryTheory.ConcreteCategory.Basic
 import Mathlib.CategoryTheory.ConcreteCategory.Bundled
 import Mathlib.CategoryTheory.ConcreteCategory.BundledHom
 import Mathlib.CategoryTheory.ConcreteCategory.Elementwise
+import Mathlib.CategoryTheory.ConcreteCategory.EpiMono
 import Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso
 import Mathlib.CategoryTheory.ConcreteCategory.UnbundledHom
 import Mathlib.CategoryTheory.Conj

--- a/Mathlib/CategoryTheory/ConcreteCategory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/EpiMono.lean
@@ -93,7 +93,7 @@ noncomputable def functorialSurjectiveInjectiveFactorizationData :
     (by rw [surjective_eq_epimorphisms])
     (by rw [injective_eq_monomorphisms])
 
-instance : HasFunctorialSurjectiveInjectiveFactorization C where
+instance (priority := 100) : HasFunctorialSurjectiveInjectiveFactorization C where
   nonempty_functorialFactorizationData :=
     ⟨functorialSurjectiveInjectiveFactorizationData C⟩
 

--- a/Mathlib/CategoryTheory/ConcreteCategory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/EpiMono.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Limits.Shapes.Images
+import Mathlib.CategoryTheory.MorphismProperty.Concrete
+import Mathlib.CategoryTheory.Types
+
+/-!
+# Epi and mono in concrete categories
+
+In this file, we relate epimorphisms and monomorphisms in a concrete category `C`
+to surjective and injective morphisms, and we show that if `C` has
+strong epi mono factorizations and is such that `forget C` preserves
+both epi and mono, then any morphism in `C` can be factored in a
+functorial manner as a composition of a surjective morphism followed
+an injective morphism.
+
+-/
+
+universe w v u
+
+namespace CategoryTheory
+
+variable (C : Type u) [Category.{v} C] [ConcreteCategory.{w} C]
+
+open Limits MorphismProperty
+
+namespace ConcreteCategory
+
+lemma surjective_le_epimorphisms :
+    MorphismProperty.surjective C ≤ epimorphisms C :=
+  fun _ _ _ hf => (forget C).epi_of_epi_map ((epi_iff_surjective _).2 hf)
+
+lemma injective_le_monomorphisms :
+    MorphismProperty.injective C ≤ monomorphisms C :=
+  fun _ _ _ hf => (forget C).mono_of_mono_map ((mono_iff_injective _).2 hf)
+
+lemma surjective_eq_epimorphisms_iff :
+    MorphismProperty.surjective C = epimorphisms C ↔ (forget C).PreservesEpimorphisms := by
+  constructor
+  · intro h
+    constructor
+    rintro _ _ f (hf : epimorphisms C f)
+    rw [epi_iff_surjective]
+    rw [← h] at hf
+    exact hf
+  · intro
+    apply le_antisymm (surjective_le_epimorphisms C)
+    intro _ _ f hf
+    have : Epi f := hf
+    change Function.Surjective ((forget C).map f)
+    rw [← epi_iff_surjective]
+    infer_instance
+
+lemma injective_eq_monomorphisms_iff :
+    MorphismProperty.injective C = monomorphisms C ↔ (forget C).PreservesMonomorphisms := by
+  constructor
+  · intro h
+    constructor
+    rintro _ _ f (hf : monomorphisms C f)
+    rw [mono_iff_injective]
+    rw [← h] at hf
+    exact hf
+  · intro
+    apply le_antisymm (injective_le_monomorphisms C)
+    intro _ _ f hf
+    have : Mono f := hf
+    change Function.Injective ((forget C).map f)
+    rw [← mono_iff_injective]
+    infer_instance
+
+lemma injective_eq_monomorphisms [(forget C).PreservesMonomorphisms] :
+    MorphismProperty.injective C = monomorphisms C := by
+  rw [injective_eq_monomorphisms_iff]
+  infer_instance
+
+lemma surjective_eq_epimorphisms [(forget C).PreservesEpimorphisms] :
+    MorphismProperty.surjective C = epimorphisms C := by
+  rw [surjective_eq_epimorphisms_iff]
+  infer_instance
+
+variable [HasStrongEpiMonoFactorisations C] [(forget C).PreservesMonomorphisms]
+  [(forget C).PreservesEpimorphisms]
+
+/-- A concrete category with strong epi mono factorizations and such that
+the forget functor preserves mono and epi admits functorial surjective/injective
+factorizations. -/
+noncomputable def functorialSurjectiveInjectiveFactorizationData :
+    FunctorialSurjectiveInjectiveFactorizationData C :=
+  (functorialEpiMonoFactorizationData C).ofLE
+    (by rw [surjective_eq_epimorphisms])
+    (by rw [injective_eq_monomorphisms])
+
+instance : HasFunctorialSurjectiveInjectiveFactorization C where
+  nonempty_functorialFactorizationData :=
+    ⟨functorialSurjectiveInjectiveFactorizationData C⟩
+
+end ConcreteCategory
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/ConcreteCategory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/EpiMono.lean
@@ -15,7 +15,7 @@ to surjective and injective morphisms, and we show that if `C` has
 strong epi mono factorizations and is such that `forget C` preserves
 both epi and mono, then any morphism in `C` can be factored in a
 functorial manner as a composition of a surjective morphism followed
-an injective morphism.
+by an injective morphism.
 
 -/
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
@@ -6,6 +6,7 @@ Authors: Scott Morrison, Markus Himmel
 import Mathlib.CategoryTheory.Limits.Shapes.Equalizers
 import Mathlib.CategoryTheory.Limits.Shapes.Pullbacks
 import Mathlib.CategoryTheory.Limits.Shapes.StrongEpi
+import Mathlib.CategoryTheory.MorphismProperty.Factorization
 
 #align_import category_theory.limits.shapes.images from "leanprover-community/mathlib"@"563aed347eb59dc4181cb732cda0d124d736eaa3"
 
@@ -1027,6 +1028,19 @@ theorem image.isoStrongEpiMono_inv_comp_mono {I' : C} (e : X ⟶ I') (m : I' ⟶
     [StrongEpi e] [Mono m] : (image.isoStrongEpiMono e m comm).inv ≫ m = image.ι f :=
   image.lift_fac _
 #align category_theory.limits.image.iso_strong_epi_mono_inv_comp_mono CategoryTheory.Limits.image.isoStrongEpiMono_inv_comp_mono
+
+open MorphismProperty
+
+variable (C)
+
+/-- A category with strong epi mono factorisations admits functorial epi/mono factorizations. -/
+noncomputable def functorialEpiMonoFactorizationData :
+    FunctorialFactorizationData (epimorphisms C) (monomorphisms C) where
+  Z := im
+  i := { app := fun f => factorThruImage f.hom }
+  p := { app := fun f => image.ι f.hom }
+  hi _ := epimorphisms.infer_property _
+  hp _ := monomorphisms.infer_property _
 
 end CategoryTheory.Limits
 

--- a/Mathlib/CategoryTheory/MorphismProperty/Factorization.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Factorization.lean
@@ -104,6 +104,16 @@ attribute [reassoc (attr := simp)] fac
 lemma fac_app {f : Arrow C} : data.i.app f ≫ data.p.app f = f.hom := by
   rw [← NatTrans.comp_app, fac,Arrow.leftToRight_app]
 
+/-- If `W₁ ≤ W₁'` and `W₂ ≤ W₂'`, then a functorial factorization for `W₁` and `W₂` induces
+a functorial factorization for `W₁'` and `W₂'`. -/
+def ofLE {W₁' W₂' : MorphismProperty C} (le₁ : W₁ ≤ W₁') (le₂ : W₂ ≤ W₂') :
+    FunctorialFactorizationData W₁' W₂' where
+  Z := data.Z
+  i := data.i
+  p := data.p
+  hi f := le₁ _ (data.hi f)
+  hp f := le₂ _ (data.hp f)
+
 /-- The term in `FactorizationData W₁ W₂` that is deduced from a functorial factorization. -/
 def factorizationData : FactorizationData W₁ W₂ := fun f =>
   { i := data.i.app (Arrow.mk f)


### PR DESCRIPTION
In this PR, we show that if `C` is a concrete category that has strong epi mono factorizations and is such that `forget C` preserves both epi and mono, then any morphism in `C` can be factored in a functorial manner as a composition of a surjective morphism followed an injective morphism.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
