### PR TITLE
[Merged by Bors] - fix(Tactic/Elementwise): type inference in elementwise

### DIFF
--- a/Mathlib/Lean/Meta/Simp.lean
+++ b/Mathlib/Lean/Meta/Simp.lean
@@ -157,7 +157,11 @@ def simpOnlyNames (lemmas : List Name) (e : Expr) (config : Simp.Config := {}) :
 /--
 Given a simplifier `S : Expr → MetaM Simp.Result`,
 and an expression `e : Expr`, run `S` on the type of `e`, and then
-convert `e` into that simplified type, using a combination of type hints and `Eq.mp`.
+convert `e` into that simplified type,
+using a combination of type hints as well as casting if the proof is not definitional `Eq.mp`.
+
+The optional argument `type?`, if present, must be definitionally equal to the type of `e`.
+When it is specified we simplify this type rather than the inferred type of `e`.
 -/
 def simpType (S : Expr → MetaM Simp.Result) (e : Expr) (type? : Option Expr := none) :
     MetaM Expr := do

--- a/Mathlib/Lean/Meta/Simp.lean
+++ b/Mathlib/Lean/Meta/Simp.lean
@@ -159,7 +159,8 @@ Given a simplifier `S : Expr → MetaM Simp.Result`,
 and an expression `e : Expr`, run `S` on the type of `e`, and then
 convert `e` into that simplified type, using a combination of type hints and `Eq.mp`.
 -/
-def simpType (S : Expr → MetaM Simp.Result) (e : Expr) (typeHint : Option Expr := none) : MetaM Expr := do
+def simpType (S : Expr → MetaM Simp.Result) (e : Expr) (typeHint : Option Expr := none) : 
+    MetaM Expr := do
   let type ← typeHint.getDM  (inferType e)
   match ← S type with
   | ⟨ty', none, _⟩ => mkExpectedTypeHint e ty'

--- a/Mathlib/Lean/Meta/Simp.lean
+++ b/Mathlib/Lean/Meta/Simp.lean
@@ -159,9 +159,9 @@ Given a simplifier `S : Expr → MetaM Simp.Result`,
 and an expression `e : Expr`, run `S` on the type of `e`, and then
 convert `e` into that simplified type, using a combination of type hints and `Eq.mp`.
 -/
-def simpType (S : Expr → MetaM Simp.Result) (e : Expr) (typeHint : Option Expr := none) :
+def simpType (S : Expr → MetaM Simp.Result) (e : Expr) (type? : Option Expr := none) :
     MetaM Expr := do
-  let type ← typeHint.getDM  (inferType e)
+  let type ← type?.getDM (inferType e)
   match ← S type with
   | ⟨ty', none, _⟩ => mkExpectedTypeHint e ty'
   -- We use `mkExpectedTypeHint` in this branch as well, in order to preserve the binder types.

--- a/Mathlib/Lean/Meta/Simp.lean
+++ b/Mathlib/Lean/Meta/Simp.lean
@@ -159,7 +159,7 @@ Given a simplifier `S : Expr → MetaM Simp.Result`,
 and an expression `e : Expr`, run `S` on the type of `e`, and then
 convert `e` into that simplified type, using a combination of type hints and `Eq.mp`.
 -/
-def simpType (S : Expr → MetaM Simp.Result) (e : Expr) (typeHint : Option Expr := none) : 
+def simpType (S : Expr → MetaM Simp.Result) (e : Expr) (typeHint : Option Expr := none) :
     MetaM Expr := do
   let type ← typeHint.getDM  (inferType e)
   match ← S type with

--- a/Mathlib/Lean/Meta/Simp.lean
+++ b/Mathlib/Lean/Meta/Simp.lean
@@ -159,8 +159,9 @@ Given a simplifier `S : Expr → MetaM Simp.Result`,
 and an expression `e : Expr`, run `S` on the type of `e`, and then
 convert `e` into that simplified type, using a combination of type hints and `Eq.mp`.
 -/
-def simpType (S : Expr → MetaM Simp.Result) (e : Expr) : MetaM Expr := do
-  match ← S (← inferType e) with
+def simpType (S : Expr → MetaM Simp.Result) (e : Expr) (typeHint : Option Expr := none) : MetaM Expr := do
+  let type ← typeHint.getDM  (inferType e)
+  match ← S type with
   | ⟨ty', none, _⟩ => mkExpectedTypeHint e ty'
   -- We use `mkExpectedTypeHint` in this branch as well, in order to preserve the binder types.
   | ⟨ty', some prf, _⟩ => mkExpectedTypeHint (← mkEqMP prf e) ty'

--- a/Mathlib/Tactic/CategoryTheory/Elementwise.lean
+++ b/Mathlib/Tactic/CategoryTheory/Elementwise.lean
@@ -80,7 +80,7 @@ def elementwiseExpr (src : Name) (type pf : Expr) (simpSides := true) :
     MetaM (Expr × Option Level) := do
   let type := (← instantiateMVars type).cleanupAnnotations
   forallTelescope type fun fvars type' => do
-    mkHomElementwise type' (mkAppN pf fvars) fun eqPf instConcr? => do
+    mkHomElementwise type' (← mkExpectedTypeHint (mkAppN pf fvars) type') fun eqPf instConcr? => do
       -- First simplify using elementwise-specific lemmas
       let mut eqPf' ← simpType (simpOnlyNames elementwiseThms (config := { decide := false })) eqPf
       if (← inferType eqPf') == .const ``True [] then

--- a/test/CategoryTheory/Elementwise.lean
+++ b/test/CategoryTheory/Elementwise.lean
@@ -115,4 +115,23 @@ example {α β : Type} (f g : α ⟶ β) (w : f ≫ 𝟙 β = g) (a : α) : f a 
   guard_hyp w : ∀ (x : α), f x = g x
   rw [w]
 
+variable {C : Type*} [Category C]
+
+def f (X : C) : X ⟶ X := 𝟙 X
+def g (X : C) : X ⟶ X := 𝟙 X
+def h (X : C) : X ⟶ X := 𝟙 X
+
+lemma gh (X : C) : g X = h X := rfl
+
+@[elementwise]
+theorem fh (X : C) : f X = h X := gh X
+
+variable (X : C) [ConcreteCategory C] (x : X)
+
+-- Prior to https://github.com/leanprover-community/mathlib4/pull/13413 this would produce
+-- `fh_apply X x : (g X) x = (h X) x`.
+/-- info: fh_apply X x : (f X) x = (h X) x -/
+#guard_msgs in
+#check fh_apply X x
+
 end ElementwiseTest


### PR DESCRIPTION
added an optional type argument to SimpType; changed type inference in elementwise tactic

Co-authored-by: Kim Morrison <kim@tqft.net>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
