### PR TITLE
[Merged by Bors] - feat(Topology): fiberwise summation

### DIFF
--- a/Mathlib/Topology/Instances/ENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal.lean
@@ -1084,19 +1084,13 @@ theorem finset_card_const_le_le_of_tsum_le {ι : Type*} {a : ι → ℝ≥0∞} 
 #align ennreal.finset_card_const_le_le_of_tsum_le ENNReal.finset_card_const_le_le_of_tsum_le
 
 theorem HasSum_fiberwise {f : β → ENNReal} {a : ENNReal} (hf : HasSum f a) (g : β → γ) :
-    HasSum (fun (c : γ) ↦ ∑' (b : (g ⁻¹' {c})), f b) a := by
-  have B := @Equiv.hasSum_iff ENNReal β ((y : γ) × { x // g x = y }) _ _ f a (Equiv.sigmaFiberEquiv g)
-  replace B := B.2 hf
-  have C := @HasSum.sigma ENNReal γ _ _ _ _ (fun y : γ => { x // g x = y }) (f ∘ ⇑(Equiv.sigmaFiberEquiv g)) (fun c => ∑' (b : ↑(g ⁻¹' {c})), f ↑b) a B
-  apply C
-  intro b
-  have F := @Summable.hasSum_iff ENNReal _ _ _ (fun c => (f ∘ ⇑(Equiv.sigmaFiberEquiv g)) { fst := b, snd := c }) ((fun c => ∑' (b : ↑(g ⁻¹' {c})), f ↑b) b) _
-  apply (F _).2 rfl
-  apply ENNReal.summable
+    HasSum (fun (c : γ) ↦ ∑' (b : (g ⁻¹' {c})), f b) a :=
+  (((Equiv.sigmaFiberEquiv g).hasSum_iff).mpr hf).sigma <|
+    (fun _ ↦ ((ENNReal.summable).hasSum_iff).mpr rfl)
 
 theorem tsum_fiberwise (f : β → ENNReal) (g : β → γ) :
     ∑' (x : γ), ∑' (b : (g ⁻¹' {x})), f b = ∑' i : β, f i :=
-  HasSum.tsum_eq <| ENNReal.HasSum_fiberwise (Summable.hasSum ENNReal.summable) g
+  HasSum.tsum_eq <| HasSum_fiberwise (Summable.hasSum ENNReal.summable) g
 
 end tsum
 

--- a/Mathlib/Topology/Instances/ENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal.lean
@@ -1084,10 +1084,11 @@ theorem finset_card_const_le_le_of_tsum_le {ι : Type*} {a : ι → ℝ≥0∞} 
 #align ennreal.finset_card_const_le_le_of_tsum_le ENNReal.finset_card_const_le_le_of_tsum_le
 
 theorem tsum_fiberwise (f : β → ℝ≥0∞) (g : β → γ) :
-    ∑' (x : γ), ∑' (b : (g ⁻¹' {x})), f b = ∑' i : β, f i :=
-  HasSum.tsum_eq <|
-  (((Equiv.sigmaFiberEquiv g).hasSum_iff).mpr (Summable.hasSum ENNReal.summable)).sigma <|
-  (fun _ ↦ ((ENNReal.summable).hasSum_iff).mpr rfl)
+    ∑' (x : γ), ∑' (b : (g ⁻¹' {x})), f b = ∑' i : β, f i := by
+  apply HasSum.tsum_eq
+  let equiv := Equiv.sigmaFiberEquiv g
+  apply ((equiv.hasSum_iff).mpr (Summable.hasSum ENNReal.summable)).sigma
+  apply (fun _ ↦ ((ENNReal.summable).hasSum_iff).mpr rfl)
 
 end tsum
 

--- a/Mathlib/Topology/Instances/ENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal.lean
@@ -1083,6 +1083,21 @@ theorem finset_card_const_le_le_of_tsum_le {ι : Type*} {a : ι → ℝ≥0∞} 
     _ ≤ c := tsum_le_c
 #align ennreal.finset_card_const_le_le_of_tsum_le ENNReal.finset_card_const_le_le_of_tsum_le
 
+theorem HasSum_fiberwise {f : β → ENNReal} {a : ENNReal} (hf : HasSum f a) (g : β → γ) :
+    HasSum (fun (c : γ) ↦ ∑' (b : (g ⁻¹' {c})), f b) a := by
+  have B := @Equiv.hasSum_iff ENNReal β ((y : γ) × { x // g x = y }) _ _ f a (Equiv.sigmaFiberEquiv g)
+  replace B := B.2 hf
+  have C := @HasSum.sigma ENNReal γ _ _ _ _ (fun y : γ => { x // g x = y }) (f ∘ ⇑(Equiv.sigmaFiberEquiv g)) (fun c => ∑' (b : ↑(g ⁻¹' {c})), f ↑b) a B
+  apply C
+  intro b
+  have F := @Summable.hasSum_iff ENNReal _ _ _ (fun c => (f ∘ ⇑(Equiv.sigmaFiberEquiv g)) { fst := b, snd := c }) ((fun c => ∑' (b : ↑(g ⁻¹' {c})), f ↑b) b) _
+  apply (F _).2 rfl
+  apply ENNReal.summable
+
+theorem tsum_fiberwise (f : β → ENNReal) (g : β → γ) :
+  ∑' (x : γ), ∑' (b : (g ⁻¹' {x})), f b = ∑' i : β, f i :=
+  HasSum.tsum_eq <| ENNReal.HasSum_fiberwise (Summable.hasSum ENNReal.summable) g
+
 end tsum
 
 theorem tendsto_toReal_iff {ι} {fi : Filter ι} {f : ι → ℝ≥0∞} (hf : ∀ i, f i ≠ ∞) {x : ℝ≥0∞}

--- a/Mathlib/Topology/Instances/ENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal.lean
@@ -1084,11 +1084,11 @@ theorem finset_card_const_le_le_of_tsum_le {ι : Type*} {a : ι → ℝ≥0∞} 
 #align ennreal.finset_card_const_le_le_of_tsum_le ENNReal.finset_card_const_le_le_of_tsum_le
 
 theorem tsum_fiberwise (f : β → ℝ≥0∞) (g : β → γ) :
-    ∑' (x : γ), ∑' (b : (g ⁻¹' {x})), f b = ∑' i : β, f i := by
+    ∑' x, ∑' b : g ⁻¹' {x}, f b = ∑' i, f i := by
   apply HasSum.tsum_eq
   let equiv := Equiv.sigmaFiberEquiv g
-  apply ((equiv.hasSum_iff).mpr (Summable.hasSum ENNReal.summable)).sigma
-  apply (fun _ ↦ ((ENNReal.summable).hasSum_iff).mpr rfl)
+  apply (equiv.hasSum_iff.mpr ENNReal.summable.hasSum).sigma
+  exact fun _ ↦ ENNReal.summable.hasSum_iff.mpr rfl
 
 end tsum
 

--- a/Mathlib/Topology/Instances/ENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal.lean
@@ -1083,7 +1083,7 @@ theorem finset_card_const_le_le_of_tsum_le {ι : Type*} {a : ι → ℝ≥0∞} 
     _ ≤ c := tsum_le_c
 #align ennreal.finset_card_const_le_le_of_tsum_le ENNReal.finset_card_const_le_le_of_tsum_le
 
-theorem tsum_fiberwise (f : β → ENNReal) (g : β → γ) :
+theorem tsum_fiberwise (f : β → ℝ≥0∞) (g : β → γ) :
     ∑' (x : γ), ∑' (b : (g ⁻¹' {x})), f b = ∑' i : β, f i :=
   HasSum.tsum_eq <|
   (((Equiv.sigmaFiberEquiv g).hasSum_iff).mpr (Summable.hasSum ENNReal.summable)).sigma <|

--- a/Mathlib/Topology/Instances/ENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal.lean
@@ -1095,7 +1095,7 @@ theorem HasSum_fiberwise {f : β → ENNReal} {a : ENNReal} (hf : HasSum f a) (g
   apply ENNReal.summable
 
 theorem tsum_fiberwise (f : β → ENNReal) (g : β → γ) :
-  ∑' (x : γ), ∑' (b : (g ⁻¹' {x})), f b = ∑' i : β, f i :=
+    ∑' (x : γ), ∑' (b : (g ⁻¹' {x})), f b = ∑' i : β, f i :=
   HasSum.tsum_eq <| ENNReal.HasSum_fiberwise (Summable.hasSum ENNReal.summable) g
 
 end tsum

--- a/Mathlib/Topology/Instances/ENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal.lean
@@ -1083,14 +1083,11 @@ theorem finset_card_const_le_le_of_tsum_le {ι : Type*} {a : ι → ℝ≥0∞} 
     _ ≤ c := tsum_le_c
 #align ennreal.finset_card_const_le_le_of_tsum_le ENNReal.finset_card_const_le_le_of_tsum_le
 
-theorem HasSum_fiberwise {f : β → ENNReal} {a : ENNReal} (hf : HasSum f a) (g : β → γ) :
-    HasSum (fun (c : γ) ↦ ∑' (b : (g ⁻¹' {c})), f b) a :=
-  (((Equiv.sigmaFiberEquiv g).hasSum_iff).mpr hf).sigma <|
-    (fun _ ↦ ((ENNReal.summable).hasSum_iff).mpr rfl)
-
 theorem tsum_fiberwise (f : β → ENNReal) (g : β → γ) :
     ∑' (x : γ), ∑' (b : (g ⁻¹' {x})), f b = ∑' i : β, f i :=
-  HasSum.tsum_eq <| HasSum_fiberwise (Summable.hasSum ENNReal.summable) g
+  HasSum.tsum_eq <|
+  (((Equiv.sigmaFiberEquiv g).hasSum_iff).mpr (Summable.hasSum ENNReal.summable)).sigma <|
+  (fun _ ↦ ((ENNReal.summable).hasSum_iff).mpr rfl)
 
 end tsum
 


### PR DESCRIPTION
Fiberwise summation for extended non-negative reals.

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
