### PR TITLE
[Merged by Bors] - feat: lint on isolated where and leading by

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -294,8 +294,8 @@ def Cofan.isColimitOfIsIsoSigmaDesc {f : β → C} [HasCoproduct f] (c : Cofan f
 lemma Cofan.isColimit_iff_isIso_sigmaDesc {f : β → C} [HasCoproduct f] (c : Cofan f) :
     IsIso (Sigma.desc c.inj) ↔ Nonempty (IsColimit c) := by
   refine ⟨fun h ↦ ⟨isColimitOfIsIsoSigmaDesc c⟩, fun ⟨hc⟩ ↦ ?_⟩
-  have : IsIso (((coproductIsCoproduct f).coconePointUniqueUpToIso hc).hom ≫ hc.desc c) :=
-    by simp; infer_instance
+  have : IsIso (((coproductIsCoproduct f).coconePointUniqueUpToIso hc).hom ≫ hc.desc c) := by
+    simp; infer_instance
   convert this
   ext
   simp only [colimit.ι_desc, mk_pt, mk_ι_app, IsColimit.coconePointUniqueUpToIso,

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -320,9 +320,11 @@ def isolated_by_dot_semicolon_check(lines, path):
             # We also error if the previous line ends on := and the current line starts with "by ".
             prev_line = newlines[-1][1].rstrip()
             if prev_line.endswith(":="):
-                errors += [(ERR_IBY, line_nr, path)]
                 # If the previous line is short enough, we can suggest an auto-fix.
+                # Future: error also if it is not: currently, mathlib contains about 30 such
+                # instances which are not obvious to fix.
                 if len(prev_line) <= 97:
+                    errors += [(ERR_IBY, line_nr, path)]
                     newlines[-1] = (line_nr - 1, prev_line + " by\n")
                     indent = " " * (len(line) - len(line.lstrip()))
                     line = f"{indent}{line.lstrip()[3:]}"

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -44,6 +44,7 @@ ERR_AUT = 7 # malformed authors list
 ERR_TAC = 9 # imported Mathlib.Tactic
 ERR_TAC2 = 10 # imported Lake in Mathlib
 ERR_IBY = 11 # isolated by
+ERR_IWH = 22 # isolated where
 ERR_DOT = 12 # isolated or low focusing dot
 ERR_SEM = 13 # the substring " ;"
 ERR_WIN = 14 # Windows line endings "\r\n"
@@ -315,6 +316,8 @@ def isolated_by_dot_semicolon_check(lines, path):
             prev_line = lines[line_nr - 2][1].rstrip()
             if not prev_line.endswith(",") and not re.search(", fun [^,]* (=>|↦)$", prev_line):
                 errors += [(ERR_IBY, line_nr, path)]
+        elif line.lstrip() == "where":
+            errors += [(ERR_IWH, line_nr, path)]
         if line.lstrip().startswith(". "):
             errors += [(ERR_DOT, line_nr, path)]
             line = line.replace(". ", "· ", 1)
@@ -385,6 +388,8 @@ def format_errors(errors):
             output_message(path, line_nr, "ERR_TAC2", "In the past, importing 'Lake' in mathlib has led to dramatic slow-downs of the linter (see e.g. mathlib4#13779). Please consider carefully if this import is useful and make sure to benchmark it. If this is fine, feel free to allow this linter.")
         if errno == ERR_IBY:
             output_message(path, line_nr, "ERR_IBY", "Line is an isolated 'by'")
+        if errno == ERR_IWH:
+            output_message(path, line_nr, "ERR_IWH", "Line is an isolated where")
         if errno == ERR_DOT:
             output_message(path, line_nr, "ERR_DOT", "Line is an isolated focusing dot or uses . instead of ·")
         if errno == ERR_SEM:

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -316,6 +316,16 @@ def isolated_by_dot_semicolon_check(lines, path):
             prev_line = lines[line_nr - 2][1].rstrip()
             if not prev_line.endswith(",") and not re.search(", fun [^,]* (=>|↦)$", prev_line):
                 errors += [(ERR_IBY, line_nr, path)]
+        elif line.lstrip().startswith("by "):
+            # We also error if the previous line ends on := and the current line starts with "by ".
+            prev_line = newlines[-1][1].rstrip()
+            if prev_line.endswith(":="):
+                errors += [(ERR_IBY, line_nr, path)]
+                # If the previous line is short enough, we can suggest an auto-fix.
+                if len(prev_line) <= 97:
+                    newlines[-1] = (line_nr - 1, prev_line + " by\n")
+                    indent = " " * (len(line) - len(line.lstrip()))
+                    line = f"{indent}{line.lstrip()[3:]}"
         elif line.lstrip() == "where":
             errors += [(ERR_IWH, line_nr, path)]
         if line.lstrip().startswith(". "):


### PR DESCRIPTION
Extend the style linter with two tiny features:
- lint on "isolated where": all occurrences were already fixed in #12991 and #13202.
- lint on "leading by": if one line starts with `by ` but the previous line ends with `:=`, according to the style guide the `by` should move to the previous line. For now, we only lint if the `by` fits on the previous line (fixed in #13618 and predecessors): there about other 28 cases in mathlib which don't have an obvious fix.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
