### PR TITLE
[Merged by Bors] - feat (RingTheory/Binomial) : Multichoose lemmata

### DIFF
--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -32,7 +32,7 @@ of cardinality `n`.
 
 ## TODO
 
-* Replace `Nat.multichoose` with `Ring.multichoose`.
+* Generalized versions of basic identities of Nat.choose.
 Further results in Elliot's paper:
 * A CommRing is binomial if and only if it admits a λ-ring structure with trivial Adams operations.
 * The free commutative binomial ring on a set `X` is the ring of integer-valued polynomials in the
@@ -78,6 +78,69 @@ theorem multichoose_eq_multichoose (r : R) (n : ℕ) :
 theorem factorial_nsmul_multichoose_eq_ascPochhammer (r : R) (n : ℕ) :
     n.factorial • multichoose r n = (ascPochhammer ℕ n).smeval r :=
   BinomialRing.factorial_nsmul_multichoose r n
+
+@[simp]
+theorem multichoose_zero_right' (r : R) : multichoose r 0 = r ^ 0 := by
+  refine nsmul_right_injective (Nat.factorial 0) (Nat.factorial_ne_zero 0) ?_
+  simp only
+  rw [factorial_nsmul_multichoose_eq_ascPochhammer, ascPochhammer_zero, smeval_one, Nat.factorial]
+
+theorem multichoose_zero_right [MulOneClass R] [NatPowAssoc R]
+    (r : R) : multichoose r 0 = 1 := by
+  rw [multichoose_zero_right', npow_zero]
+
+@[simp]
+theorem multichoose_one_right' (r : R) : multichoose r 1 = r ^ 1 := by
+  refine nsmul_right_injective (Nat.factorial 1) (Nat.factorial_ne_zero 1) ?_
+  simp only
+  rw [factorial_nsmul_multichoose_eq_ascPochhammer, ascPochhammer_one, smeval_X, Nat.factorial_one,
+    one_smul]
+
+theorem multichoose_one_right [MulOneClass R] [NatPowAssoc R] (r : R) : multichoose r 1 = r := by
+  rw [multichoose_one_right', npow_one]
+
+variable {R : Type*} [NonAssocSemiring R] [Pow R ℕ] [NatPowAssoc R] [BinomialRing R]
+
+@[simp]
+theorem multichoose_zero_succ (k : ℕ) : multichoose (0 : R) (k + 1) = 0 := by
+  refine nsmul_right_injective (Nat.factorial (k + 1)) (Nat.factorial_ne_zero (k + 1)) ?_
+  simp only
+  rw [factorial_nsmul_multichoose_eq_ascPochhammer, smul_zero, ascPochhammer_succ_left,
+    smeval_X_mul, zero_mul]
+
+theorem ascPochhammer_succ_succ (r : R) (k : ℕ) :
+    smeval (ascPochhammer ℕ (k + 1)) (r + 1) = Nat.factorial (k + 1) • multichoose (r + 1) k +
+    smeval (ascPochhammer ℕ (k + 1)) r := by
+  nth_rw 1 [ascPochhammer_succ_right, ascPochhammer_succ_left, mul_comm (ascPochhammer ℕ k)]
+  simp only [smeval_mul, smeval_comp ℕ _ _ r, smeval_add, smeval_X]
+  rw [Nat.factorial, mul_smul, factorial_nsmul_multichoose_eq_ascPochhammer]
+  simp only [smeval_one, npow_one, npow_zero, one_smul]
+  rw [← C_eq_natCast, smeval_C, npow_zero, add_assoc, add_mul, add_comm 1, @nsmul_one, add_mul]
+  rw [← @nsmul_eq_mul, @add_rotate', @succ_nsmul, add_assoc]
+  simp_all only [Nat.cast_id, nsmul_eq_mul, one_mul]
+
+theorem multichoose_succ_succ (r : R) (k : ℕ) :
+    multichoose (r + 1) (k + 1) = multichoose r (k + 1) + multichoose (r + 1) k := by
+  refine nsmul_right_injective (Nat.factorial (k + 1)) (Nat.factorial_ne_zero (k + 1)) ?_
+  simp only [factorial_nsmul_multichoose_eq_ascPochhammer, smul_add]
+  rw [add_comm (smeval (ascPochhammer ℕ (k+1)) r)]
+  exact ascPochhammer_succ_succ r k
+
+@[simp]
+theorem multichoose_one (k : ℕ) : multichoose (1 : R) k = 1 := by
+  induction k with
+  | zero => exact multichoose_zero_right 1
+  | succ n ih =>
+    rw [show (1 : R) = 0 + 1 by exact (@zero_add R _ 1).symm, multichoose_succ_succ,
+      multichoose_zero_succ, zero_add, zero_add, ih]
+
+theorem multichoose_two (k : ℕ) : multichoose (2 : R) k = k + 1 := by
+  induction k with
+  | zero =>
+    rw [multichoose_zero_right, Nat.cast_zero, zero_add]
+  | succ n ih =>
+    rw [one_add_one_eq_two.symm, multichoose_succ_succ, multichoose_one, one_add_one_eq_two, ih,
+      Nat.cast_succ, add_comm]
 
 end Ring
 

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -123,8 +123,7 @@ theorem multichoose_succ_succ (r : R) (k : ℕ) :
     multichoose (r + 1) (k + 1) = multichoose r (k + 1) + multichoose (r + 1) k := by
   refine nsmul_right_injective (Nat.factorial (k + 1)) (Nat.factorial_ne_zero (k + 1)) ?_
   simp only [factorial_nsmul_multichoose_eq_ascPochhammer, smul_add]
-  rw [add_comm (smeval (ascPochhammer ℕ (k+1)) r)]
-  exact ascPochhammer_succ_succ r k
+  rw [add_comm (smeval (ascPochhammer ℕ (k+1)) r), ascPochhammer_succ_succ r k]
 
 @[simp]
 theorem multichoose_one (k : ℕ) : multichoose (1 : R) k = 1 := by


### PR DESCRIPTION
This PR has some basic lemmas for the `Ring.multichoose` function.  They are generalizations of corresponding lemmas for `Nat.multichoose`.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
