### PR TITLE
[Merged by Bors] - Refactor(Algebra/Group/Subgroup/Finite): Replace `Fintype.card` with `Nat.card`

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Finite.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Finite.lean
@@ -5,7 +5,7 @@ Authors: Kexing Ying
 -/
 import Mathlib.Algebra.Group.Subgroup.Basic
 import Mathlib.Algebra.Group.Submonoid.Membership
-import Mathlib.Data.Set.Finite
+import Mathlib.Data.Finite.Card
 
 #align_import group_theory.subgroup.finite from "leanprover-community/mathlib"@"f93c11933efbc3c2f0299e47b8ff83e9b539cbf6"
 
@@ -116,21 +116,28 @@ instance fintypeBot : Fintype (⊥ : Subgroup G) :=
 /- curly brackets `{}` are used here instead of instance brackets `[]` because
   the instance in a goal is often not the same as the one inferred by type class inference.  -/
 @[to_additive] -- Porting note: removed `simp` because `simpNF` says it can prove it.
-theorem card_bot {_ : Fintype (⊥ : Subgroup G)} : Fintype.card (⊥ : Subgroup G) = 1 :=
-  Fintype.card_eq_one_iff.2
-    ⟨⟨(1 : G), Set.mem_singleton 1⟩, fun ⟨_y, hy⟩ => Subtype.eq <| Subgroup.mem_bot.1 hy⟩
+theorem card_bot : Nat.card (⊥ : Subgroup G) = 1 :=
+  Nat.card_unique
 #align subgroup.card_bot Subgroup.card_bot
 #align add_subgroup.card_bot AddSubgroup.card_bot
 
 @[to_additive]
-theorem card_top [Fintype G] : Fintype.card (⊤ : Subgroup G) = Fintype.card G := by
-  rw [Fintype.card_eq]
-  exact Nonempty.intro Subgroup.topEquiv.toEquiv
+theorem card_top : Nat.card (⊤ : Subgroup G) = Nat.card G :=
+  Nat.card_congr Subgroup.topEquiv.toEquiv
 
 @[to_additive]
-theorem eq_top_of_card_eq [Fintype H] [Fintype G] (h : Fintype.card H = Fintype.card G) :
+theorem card_le_card_group [Finite G] : Nat.card H ≤ Nat.card G :=
+  Nat.card_le_card_of_injective _ Subtype.coe_injective
+
+@[to_additive]
+theorem eq_top_of_card_eq [Finite H] (h : Nat.card H = Nat.card G) :
     H = ⊤ := by
-  letI : Fintype (H : Set G) := ‹Fintype H›
+  have : Nonempty H := ⟨1, one_mem H⟩
+  have h' : Nat.card H ≠ 0 := Nat.card_pos.ne'
+  have : Finite G := (Nat.finite_of_card_ne_zero (h ▸ h'))
+  have : Fintype G := Fintype.ofFinite G
+  have : Fintype H := Fintype.ofFinite H
+  rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card] at h
   rw [SetLike.ext'_iff, coe_top, ← Finset.coe_univ, ← (H : Set G).coe_toFinset, Finset.coe_inj, ←
     Finset.card_eq_iff_eq_univ, ← h, Set.toFinset_card]
   congr
@@ -138,50 +145,43 @@ theorem eq_top_of_card_eq [Fintype H] [Fintype G] (h : Fintype.card H = Fintype.
 #align add_subgroup.eq_top_of_card_eq AddSubgroup.eq_top_of_card_eq
 
 @[to_additive (attr := simp)]
-theorem card_eq_iff_eq_top [Fintype H] [Fintype G] : Fintype.card H = Fintype.card G ↔ H = ⊤ :=
+theorem card_eq_iff_eq_top [Finite H] : Nat.card H = Nat.card G ↔ H = ⊤ :=
   Iff.intro (eq_top_of_card_eq H) (fun h ↦ by simpa only [h] using card_top)
 
 @[to_additive]
-theorem eq_top_of_le_card [Fintype H] [Fintype G] (h : Fintype.card G ≤ Fintype.card H) : H = ⊤ :=
-  eq_top_of_card_eq H
-    (le_antisymm (Fintype.card_le_of_injective Subtype.val Subtype.coe_injective) h)
+theorem eq_top_of_le_card [Finite G] (h : Nat.card G ≤ Nat.card H) : H = ⊤ :=
+  eq_top_of_card_eq H (le_antisymm H.card_le_card_group h)
 #align subgroup.eq_top_of_le_card Subgroup.eq_top_of_le_card
 #align add_subgroup.eq_top_of_le_card AddSubgroup.eq_top_of_le_card
 
 @[to_additive]
-theorem eq_bot_of_card_le [Fintype H] (h : Fintype.card H ≤ 1) : H = ⊥ :=
-  let _ := Fintype.card_le_one_iff_subsingleton.mp h
+theorem eq_bot_of_card_le [Finite H] (h : Nat.card H ≤ 1) : H = ⊥ :=
+  let _ := Finite.card_le_one_iff_subsingleton.mp h
   eq_bot_of_subsingleton H
 #align subgroup.eq_bot_of_card_le Subgroup.eq_bot_of_card_le
 #align add_subgroup.eq_bot_of_card_le AddSubgroup.eq_bot_of_card_le
 
 @[to_additive]
-theorem eq_bot_of_card_eq [Fintype H] (h : Fintype.card H = 1) : H = ⊥ :=
-  H.eq_bot_of_card_le (le_of_eq h)
+theorem eq_bot_of_card_eq (h : Nat.card H = 1) : H = ⊥ :=
+  let _ := (Nat.card_eq_one_iff_unique.mp h).1
+  eq_bot_of_subsingleton H
 #align subgroup.eq_bot_of_card_eq Subgroup.eq_bot_of_card_eq
 #align add_subgroup.eq_bot_of_card_eq AddSubgroup.eq_bot_of_card_eq
 
 @[to_additive card_le_one_iff_eq_bot]
-theorem card_le_one_iff_eq_bot [Fintype H] : Fintype.card H ≤ 1 ↔ H = ⊥ :=
-  ⟨fun h =>
-    (eq_bot_iff_forall _).2 fun x hx => by
-      simpa [Subtype.ext_iff] using Fintype.card_le_one_iff.1 h ⟨x, hx⟩ 1,
-    fun h => by simp [h]⟩
+theorem card_le_one_iff_eq_bot [Finite H] : Nat.card H ≤ 1 ↔ H = ⊥ :=
+  ⟨H.eq_bot_of_card_le, fun h => by simp [h]⟩
 #align subgroup.card_le_one_iff_eq_bot Subgroup.card_le_one_iff_eq_bot
 #align add_subgroup.card_nonpos_iff_eq_bot AddSubgroup.card_le_one_iff_eq_bot
 
-@[to_additive] lemma eq_bot_iff_card [Fintype H] : H = ⊥ ↔ Fintype.card H = 1 :=
+@[to_additive] lemma eq_bot_iff_card : H = ⊥ ↔ Nat.card H = 1 :=
   ⟨by rintro rfl; exact card_bot, eq_bot_of_card_eq _⟩
 
 @[to_additive one_lt_card_iff_ne_bot]
-theorem one_lt_card_iff_ne_bot [Fintype H] : 1 < Fintype.card H ↔ H ≠ ⊥ :=
+theorem one_lt_card_iff_ne_bot [Finite H] : 1 < Nat.card H ↔ H ≠ ⊥ :=
   lt_iff_not_le.trans H.card_le_one_iff_eq_bot.not
 #align subgroup.one_lt_card_iff_ne_bot Subgroup.one_lt_card_iff_ne_bot
 #align add_subgroup.pos_card_iff_ne_bot AddSubgroup.one_lt_card_iff_ne_bot
-
-@[to_additive]
-theorem card_le_card_group [Fintype G] [Fintype H] : Fintype.card H ≤ Fintype.card G :=
-  Fintype.card_le_of_injective _ Subtype.coe_injective
 
 end Subgroup
 

--- a/Mathlib/Algebra/Group/Subgroup/Finite.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Finite.lean
@@ -113,8 +113,6 @@ instance fintypeBot : Fintype (⊥ : Subgroup G) :=
 #align subgroup.fintype_bot Subgroup.fintypeBot
 #align add_subgroup.fintype_bot AddSubgroup.fintypeBot
 
-/- curly brackets `{}` are used here instead of instance brackets `[]` because
-  the instance in a goal is often not the same as the one inferred by type class inference.  -/
 @[to_additive] -- Porting note: removed `simp` because `simpNF` says it can prove it.
 theorem card_bot : Nat.card (⊥ : Subgroup G) = 1 :=
   Nat.card_unique
@@ -124,10 +122,6 @@ theorem card_bot : Nat.card (⊥ : Subgroup G) = 1 :=
 @[to_additive]
 theorem card_top : Nat.card (⊤ : Subgroup G) = Nat.card G :=
   Nat.card_congr Subgroup.topEquiv.toEquiv
-
-@[to_additive]
-theorem card_le_card_group [Finite G] : Nat.card H ≤ Nat.card G :=
-  Nat.card_le_card_of_injective _ Subtype.coe_injective
 
 @[to_additive]
 theorem eq_top_of_card_eq [Finite H] (h : Nat.card H = Nat.card G) :
@@ -150,7 +144,7 @@ theorem card_eq_iff_eq_top [Finite H] : Nat.card H = Nat.card G ↔ H = ⊤ :=
 
 @[to_additive]
 theorem eq_top_of_le_card [Finite G] (h : Nat.card G ≤ Nat.card H) : H = ⊤ :=
-  eq_top_of_card_eq H (le_antisymm H.card_le_card_group h)
+  eq_top_of_card_eq H (le_antisymm (Nat.card_le_card_of_injective H.subtype H.subtype_injective) h)
 #align subgroup.eq_top_of_le_card Subgroup.eq_top_of_le_card
 #align add_subgroup.eq_top_of_le_card AddSubgroup.eq_top_of_le_card
 
@@ -182,6 +176,10 @@ theorem one_lt_card_iff_ne_bot [Finite H] : 1 < Nat.card H ↔ H ≠ ⊥ :=
   lt_iff_not_le.trans H.card_le_one_iff_eq_bot.not
 #align subgroup.one_lt_card_iff_ne_bot Subgroup.one_lt_card_iff_ne_bot
 #align add_subgroup.pos_card_iff_ne_bot AddSubgroup.one_lt_card_iff_ne_bot
+
+@[to_additive]
+theorem card_le_card_group [Finite G] : Nat.card H ≤ Nat.card G :=
+  Nat.card_le_card_of_injective _ Subtype.coe_injective
 
 end Subgroup
 

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -861,7 +861,8 @@ theorem IsPGroup.isNilpotent [Finite G] {p : ℕ} [hp : Fact (Nat.Prime p)] (h :
         rw [card_eq_card_quotient_mul_card_subgroup (center G)]
         apply lt_mul_of_one_lt_right
         · exact Fintype.card_pos_iff.mpr One.instNonempty
-        · exact (Subgroup.one_lt_card_iff_ne_bot _).mpr (ne_of_gt h.bot_lt_center)
+        · simp only [← Nat.card_eq_fintype_card]
+          exact (Subgroup.one_lt_card_iff_ne_bot _).mpr (ne_of_gt h.bot_lt_center)
       have hnq : IsNilpotent (G ⧸ center G) := ih _ hcq (h.to_quotient (center G))
       exact of_quotient_center_nilpotent hnq
 #align is_p_group.is_nilpotent IsPGroup.isNilpotent

--- a/Mathlib/GroupTheory/PGroup.lean
+++ b/Mathlib/GroupTheory/PGroup.lean
@@ -48,7 +48,7 @@ theorem of_card [Fintype G] {n : ℕ} (hG : card G = p ^ n) : IsPGroup p G := fu
 #align is_p_group.of_card IsPGroup.of_card
 
 theorem of_bot : IsPGroup p (⊥ : Subgroup G) :=
-  of_card (Subgroup.card_bot.trans (pow_zero p).symm)
+  of_card (by rw [← Nat.card_eq_fintype_card, Subgroup.card_bot, pow_zero])
 #align is_p_group.of_bot IsPGroup.of_bot
 
 theorem iff_card [Fact p.Prime] [Fintype G] : IsPGroup p G ↔ ∃ n : ℕ, card G = p ^ n := by
@@ -255,9 +255,8 @@ theorem center_nontrivial [Nontrivial G] [Finite G] : Nontrivial (Subgroup.cente
 
 theorem bot_lt_center [Nontrivial G] [Finite G] : ⊥ < Subgroup.center G := by
   haveI := center_nontrivial hG
-  cases nonempty_fintype G
   classical exact
-      bot_lt_iff_ne_bot.mpr ((Subgroup.center G).one_lt_card_iff_ne_bot.mp Fintype.one_lt_card)
+      bot_lt_iff_ne_bot.mpr ((Subgroup.center G).one_lt_card_iff_ne_bot.mp Finite.one_lt_card)
 #align is_p_group.bot_lt_center IsPGroup.bot_lt_center
 
 end GIsPGroup

--- a/Mathlib/GroupTheory/SchurZassenhaus.lean
+++ b/Mathlib/GroupTheory/SchurZassenhaus.lean
@@ -192,7 +192,7 @@ private theorem step2 (K : Subgroup G) [K.Normal] (hK : K ≤ N) : K = ⊥ ∨ K
   have h4 := step1 h1 h2 h3
   contrapose! h4
   have h5 : Fintype.card (G ⧸ K) < Fintype.card G := by
-    rw [← index_eq_card, ← K.index_mul_card]
+    rw [← index_eq_card, ← K.index_mul_card, ← Nat.card_eq_fintype_card]
     refine
       lt_mul_of_one_lt_right (Nat.pos_of_ne_zero index_ne_zero_of_finite)
         (K.one_lt_card_iff_ne_bot.mpr h4.1)
@@ -228,8 +228,9 @@ private theorem step3 (K : Subgroup N) [(K.map N.subtype).Normal] : K = ⊥ ∨ 
   rwa [inj.eq_iff, inj.eq_iff] at key
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
-private theorem step4 : (Fintype.card N).minFac.Prime :=
-  Nat.minFac_prime (N.one_lt_card_iff_ne_bot.mpr (step0 h1 h3)).ne'
+private theorem step4 : (Fintype.card N).minFac.Prime := by
+  rw [← Nat.card_eq_fintype_card]
+  exact Nat.minFac_prime (N.one_lt_card_iff_ne_bot.mpr (step0 h1 h3)).ne'
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
 private theorem step5 {P : Sylow (Fintype.card N).minFac N} : P.1 ≠ ⊥ :=

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -133,17 +133,18 @@ alias isAddCyclic_of_orderOf_eq_card := isAddCyclic_of_addOrderOf_eq_card
 
 @[to_additive]
 theorem Subgroup.eq_bot_or_eq_top_of_prime_card {G : Type*} [Group G] {_ : Fintype G}
-    (H : Subgroup G) {p : ℕ} [hp : Fact p.Prime] (h : Fintype.card G = p) : H = ⊥ ∨ H = ⊤ := by
+    (H : Subgroup G) [hp : Fact (Fintype.card G).Prime] : H = ⊥ ∨ H = ⊤ := by
   classical
   have := card_subgroup_dvd_card H
-  rwa [h, Nat.dvd_prime hp.1, ← h, ← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card,
+  rwa [Nat.dvd_prime hp.1, ← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card,
     ← eq_bot_iff_card, card_eq_iff_eq_top] at this
 
 /-- Any non-identity element of a finite group of prime order generates the group. -/
 @[to_additive "Any non-identity element of a finite group of prime order generates the group."]
 theorem zpowers_eq_top_of_prime_card {G : Type*} [Group G] {_ : Fintype G} {p : ℕ}
     [hp : Fact p.Prime] (h : Fintype.card G = p) {g : G} (hg : g ≠ 1) : zpowers g = ⊤ := by
-  have := (zpowers g).eq_bot_or_eq_top_of_prime_card h
+  subst h
+  have := (zpowers g).eq_bot_or_eq_top_of_prime_card
   rwa [zpowers_eq_bot, or_iff_right hg] at this
 
 @[to_additive]
@@ -517,12 +518,12 @@ alias IsAddCyclic.card_orderOf_eq_totient := IsAddCyclic.card_addOrderOf_eq_toti
 /-- A finite group of prime order is simple. -/
 @[to_additive "A finite group of prime order is simple."]
 theorem isSimpleGroup_of_prime_card {α : Type u} [Group α] [Fintype α] {p : ℕ} [hp : Fact p.Prime]
-    (h : Fintype.card α = p) : IsSimpleGroup α :=
+    (h : Fintype.card α = p) : IsSimpleGroup α := by
+  subst h
   have : Nontrivial α := by
-    have h' := Nat.Prime.one_lt (Fact.out (p := p.Prime))
-    rw [← h] at h'
+    have h' := Nat.Prime.one_lt hp.out
     exact Fintype.one_lt_card_iff_nontrivial.1 h'
-  ⟨fun H _ => H.eq_bot_or_eq_top_of_prime_card h⟩
+  exact ⟨fun H _ => H.eq_bot_or_eq_top_of_prime_card⟩
 #align is_simple_group_of_prime_card isSimpleGroup_of_prime_card
 #align is_simple_add_group_of_prime_card isSimpleAddGroup_of_prime_card
 

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -131,14 +131,20 @@ theorem isCyclic_of_orderOf_eq_card [Fintype α] (x : α) (hx : orderOf x = Fint
 @[deprecated] -- 2024-02-21
 alias isAddCyclic_of_orderOf_eq_card := isAddCyclic_of_addOrderOf_eq_card
 
+@[to_additive]
+theorem Subgroup.eq_bot_or_eq_top_of_prime_card {G : Type*} [Group G] {_ : Fintype G}
+    (H : Subgroup G) {p : ℕ} [hp : Fact p.Prime] (h : Fintype.card G = p) : H = ⊥ ∨ H = ⊤ := by
+  classical
+  have := card_subgroup_dvd_card H
+  rwa [h, Nat.dvd_prime hp.1, ← h, ← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card,
+    ← eq_bot_iff_card, card_eq_iff_eq_top] at this
+
 /-- Any non-identity element of a finite group of prime order generates the group. -/
 @[to_additive "Any non-identity element of a finite group of prime order generates the group."]
 theorem zpowers_eq_top_of_prime_card {G : Type*} [Group G] {_ : Fintype G} {p : ℕ}
     [hp : Fact p.Prime] (h : Fintype.card G = p) {g : G} (hg : g ≠ 1) : zpowers g = ⊤ := by
-  have := card_subgroup_dvd_card (zpowers g)
-  simp_rw [h, Nat.dvd_prime hp.1, ← eq_bot_iff_card, zpowers_eq_bot, hg, false_or, ← h,
-    card_eq_iff_eq_top] at this
-  exact this
+  have := (zpowers g).eq_bot_or_eq_top_of_prime_card h
+  rwa [zpowers_eq_bot, or_iff_right hg] at this
 
 @[to_additive]
 theorem mem_zpowers_of_prime_card {G : Type*} [Group G] {_ : Fintype G} {p : ℕ} [hp : Fact p.Prime]
@@ -193,7 +199,7 @@ theorem exists_pow_ne_one_of_isCyclic {G : Type*} [Group G] [Fintype G] [G_cycli
   use a
   contrapose! k_lt_card_G
   convert orderOf_le_of_pow_eq_one k_pos.bot_lt k_lt_card_G
-  rw [← Fintype.card_zpowers, eq_comm, Subgroup.card_eq_iff_eq_top, eq_top_iff]
+  rw [← Nat.card_eq_fintype_card, ← Nat.card_zpowers, eq_comm, card_eq_iff_eq_top, eq_top_iff]
   exact fun x _ ↦ ha x
 
 @[to_additive]
@@ -516,14 +522,7 @@ theorem isSimpleGroup_of_prime_card {α : Type u} [Group α] [Fintype α] {p : �
     have h' := Nat.Prime.one_lt (Fact.out (p := p.Prime))
     rw [← h] at h'
     exact Fintype.one_lt_card_iff_nontrivial.1 h'
-  ⟨fun H _ => by
-    classical
-      have hcard := card_subgroup_dvd_card H
-      rw [h, dvd_prime (Fact.out (p := p.Prime))] at hcard
-      refine hcard.imp (fun h1 => ?_) fun hp => ?_
-      · haveI := Fintype.card_le_one_iff_subsingleton.1 (le_of_eq h1)
-        apply eq_bot_of_subsingleton
-      · exact eq_top_of_card_eq _ (hp.trans h.symm)⟩
+  ⟨fun H _ => H.eq_bot_or_eq_top_of_prime_card h⟩
 #align is_simple_group_of_prime_card isSimpleGroup_of_prime_card
 #align is_simple_add_group_of_prime_card isSimpleAddGroup_of_prime_card
 

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -650,7 +650,9 @@ theorem exists_subgroup_card_pow_prime_le [Fintype G] (p : ℕ) :
   the cardinality of `G`, then there is a subgroup of cardinality `p ^ n` -/
 theorem exists_subgroup_card_pow_prime [Fintype G] (p : ℕ) {n : ℕ} [Fact p.Prime]
     (hdvd : p ^ n ∣ card G) : ∃ K : Subgroup G, Fintype.card K = p ^ n :=
-  let ⟨K, hK⟩ := exists_subgroup_card_pow_prime_le p hdvd ⊥ (card_bot.trans (by simp)) n.zero_le
+  let ⟨K, hK⟩ := exists_subgroup_card_pow_prime_le p hdvd ⊥
+    -- The @ is due to a Fintype ⊥ mismatch, but this will be fixed once we convert to Nat.card
+    (by rw [← @Nat.card_eq_fintype_card, card_bot, pow_zero]) n.zero_le
   ⟨K, hK.1⟩
 #align sylow.exists_subgroup_card_pow_prime Sylow.exists_subgroup_card_pow_prime
 
@@ -712,7 +714,8 @@ theorem ne_bot_of_dvd_card [Fintype G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow 
     (hdvd : p ∣ card G) : (P : Subgroup G) ≠ ⊥ := by
   refine fun h => hp.out.not_dvd_one ?_
   have key : p ∣ card (P : Subgroup G) := P.dvd_card_of_dvd_card hdvd
-  rwa [h, card_bot] at key
+  -- The @ is due to a Fintype ⊥ mismatch, but this will be fixed once we convert to Nat.card
+  rwa [h, ← @Nat.card_eq_fintype_card, card_bot] at key
 #align sylow.ne_bot_of_dvd_card Sylow.ne_bot_of_dvd_card
 
 /-- The cardinality of a Sylow subgroup is `p ^ n`


### PR DESCRIPTION
A lot of the group theory library still needs to be switched over from `Fintype.card` to `Nat.card`. This PR switches over `Algebra/Group/Subgroup/Finite.lean`. I had to add a little noise to a few other files, but these will get cleaned up once those files are switched over later.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
