### PR TITLE
[Merged by Bors] - perf: reduce instance priority of IsDedekindDomain.toIsDomain

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Basic.lean
@@ -136,6 +136,8 @@ class IsDedekindDomain
   extends IsDomain A, IsDedekindRing A : Prop
 #align is_dedekind_domain IsDedekindDomain
 
+attribute [instance 90] IsDedekindDomain.toIsDomain
+
 /-- Make a Dedekind domain from a Dedekind ring given that it is a domain.
 
 `IsDedekindRing` and `IsDedekindDomain` form a cycle in the typeclass hierarchy:


### PR DESCRIPTION
We reduce the instance priority of `IsDedekindDomain.toIsDomain` to 90 (to move it behing `Field.isDomain`) and look at the performance impact.

There is a positive effect on some `NumberTheory`files and apparently no relevant slow-downs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
