### PR TITLE
[Merged by Bors] - fix(`gitpod.yml`): force elan to self-update in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,4 +6,6 @@ vscode:
     - leanprover.lean4
 
 tasks:
-  - init: lake exe cache get
+  - init: |
+      elan self update
+      lake exe cache get


### PR DESCRIPTION
Ensure that `elan` is up-to-date before trying to run `lake exe cache get` etc in gitpod containers.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Because this change is in `gitpod.yml` and not in the `Dockerfile`, this will be executed on startup of the container, and not cached. This means that we'll never be running an out-of-date `elan`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
