### PR TITLE
[Merged by Bors] - chore: Make `Subgroup.coe_set_mk`/`Subsemigroup.coe_set_mk` a `norm_cast` lemma

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -406,7 +406,7 @@ theorem mem_mk {s : Set G} {x : G} (h_one) (h_mul) (h_inv) :
 #align subgroup.mem_mk Subgroup.mem_mk
 #align add_subgroup.mem_mk AddSubgroup.mem_mk
 
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp, norm_cast)]
 theorem coe_set_mk {s : Set G} (h_one) (h_mul) (h_inv) :
     (mk ⟨⟨s, h_one⟩, h_mul⟩ h_inv : Set G) = s :=
   rfl

--- a/Mathlib/Algebra/Group/Subsemigroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Basic.lean
@@ -120,7 +120,7 @@ theorem mem_mk {s : Set M} {x : M} (h_mul) : x ∈ mk s h_mul ↔ x ∈ s :=
 #align subsemigroup.mem_mk Subsemigroup.mem_mk
 #align add_subsemigroup.mem_mk AddSubsemigroup.mem_mk
 
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp, norm_cast)]
 theorem coe_set_mk {s : Set M} (h_mul) : (mk s h_mul : Set M) = s :=
   rfl
 #align subsemigroup.coe_set_mk Subsemigroup.coe_set_mk


### PR DESCRIPTION
Those are the only eligible lemmas of their series as all other `coe_set_mk` lemmas have a bundled set coercion on their RHS.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
