### PR TITLE
[Merged by Bors] - fix (RingTheory/HahnSeries/Multiplication) : rm defeq abuse in SMul instance

### DIFF
--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -123,13 +123,14 @@ variable {Γ R V : Type*} [OrderedCancelAddCommMonoid Γ] [AddCommMonoid V] [SMu
 instance instSMul [Zero R] : SMul (HahnSeries Γ R) (HahnModule Γ R V) where
   smul x y := {
     coeff := fun a =>
-      ∑ ij ∈ addAntidiagonal x.isPWO_support y.isPWO_support a,
+      ∑ ij ∈ addAntidiagonal x.isPWO_support ((of R).symm y).isPWO_support a,
         x.coeff ij.fst • ((of R).symm y).coeff ij.snd
     isPWO_support' :=
         haveI h :
-          {a : Γ | ∑ ij ∈ addAntidiagonal x.isPWO_support y.isPWO_support a,
-            x.coeff ij.fst • y.coeff ij.snd ≠ 0} ⊆
-            {a : Γ | (addAntidiagonal x.isPWO_support y.isPWO_support a).Nonempty} := by
+          {a : Γ | ∑ ij ∈ addAntidiagonal x.isPWO_support ((of R).symm y).isPWO_support a,
+            x.coeff ij.fst • ((of R).symm y).coeff ij.snd ≠ 0} ⊆
+            {a : Γ |
+              (addAntidiagonal x.isPWO_support ((of R).symm y).isPWO_support a).Nonempty} := by
           intro a ha
           contrapose! ha
           simp [not_nonempty_iff_eq_empty.1 ha]
@@ -137,7 +138,7 @@ instance instSMul [Zero R] : SMul (HahnSeries Γ R) (HahnModule Γ R V) where
 
 theorem smul_coeff [Zero R] (x : HahnSeries Γ R) (y : HahnModule Γ R V) (a : Γ) :
     ((of R).symm <| x • y).coeff a =
-      ∑ ij ∈ addAntidiagonal x.isPWO_support y.isPWO_support a,
+      ∑ ij ∈ addAntidiagonal x.isPWO_support ((of R).symm y).isPWO_support a,
         x.coeff ij.fst • ((of R).symm y).coeff ij.snd :=
   rfl
 
@@ -164,7 +165,7 @@ theorem smul_coeff_left [SMulWithZero R W] {x : HahnSeries Γ R}
     {y : HahnModule Γ R W} {a : Γ} {s : Set Γ}
     (hs : s.IsPWO) (hxs : x.support ⊆ s) :
     ((of R).symm <| x • y).coeff a =
-      ∑ ij ∈ addAntidiagonal hs y.isPWO_support a,
+      ∑ ij ∈ addAntidiagonal hs ((of R).symm y).isPWO_support a,
         x.coeff ij.fst • ((of R).symm y).coeff ij.snd := by
   rw [smul_coeff]
   apply sum_subset_zero_on_sdiff (addAntidiagonal_mono_left hxs) _ fun _ _ => rfl


### PR DESCRIPTION
This PR replaces `y` with `((of R).symm y)` in 6 places, so that functions that take Hahn series are given Hahn series instead of Hahn modules (which are defeq).

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
