### PR TITLE
[Merged by Bors] - perf(VectorBundle/FiberwiseLinear): speed up

### DIFF
--- a/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
@@ -44,7 +44,7 @@ namespace ModelWithCorners
 /-! #### Model with corners -/
 
 protected theorem hasMFDerivAt {x} : HasMFDerivAt I 𝓘(𝕜, E) I x (ContinuousLinearMap.id _ _) :=
-  ⟨I.continuousAt, (hasFDerivWithinAt_id _ _).congr' I.rightInvOn (mem_range_self x)⟩
+  ⟨I.continuousAt, (hasFDerivWithinAt_id _ _).congr' I.rightInvOn (mem_range_self _)⟩
 #align model_with_corners.has_mfderiv_at ModelWithCorners.hasMFDerivAt
 
 protected theorem hasMFDerivWithinAt {s x} :
@@ -67,10 +67,10 @@ protected theorem mdifferentiableOn {s} : MDifferentiableOn I 𝓘(𝕜, E) I s 
 protected theorem mdifferentiable : MDifferentiable I 𝓘(𝕜, E) I := fun _ => I.mdifferentiableAt
 #align model_with_corners.mdifferentiable ModelWithCorners.mdifferentiable
 
-theorem hasMFDerivWithinAt_symm {x : E} (hx : x ∈ range I) :
+theorem hasMFDerivWithinAt_symm {x} (hx : x ∈ range I) :
     HasMFDerivWithinAt 𝓘(𝕜, E) I I.symm (range I) x (ContinuousLinearMap.id _ _) :=
   ⟨I.continuousWithinAt_symm,
-    (hasFDerivWithinAt_id _ _).congr' (fun _y hy ↦ I.rightInvOn hy.1) ⟨hx, mem_range_self x⟩⟩
+    (hasFDerivWithinAt_id _ _).congr' (fun _y hy => I.rightInvOn hy.1) ⟨hx, mem_range_self _⟩⟩
 #align model_with_corners.has_mfderiv_within_at_symm ModelWithCorners.hasMFDerivWithinAt_symm
 
 theorem mdifferentiableOn_symm : MDifferentiableOn 𝓘(𝕜, E) I I.symm (range I) := fun _x hx =>

--- a/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
@@ -44,7 +44,7 @@ namespace ModelWithCorners
 /-! #### Model with corners -/
 
 protected theorem hasMFDerivAt {x} : HasMFDerivAt I 𝓘(𝕜, E) I x (ContinuousLinearMap.id _ _) :=
-  ⟨I.continuousAt, (hasFDerivWithinAt_id _ _).congr' I.rightInvOn (mem_range_self _)⟩
+  ⟨I.continuousAt, (hasFDerivWithinAt_id _ _).congr' I.rightInvOn (mem_range_self x)⟩
 #align model_with_corners.has_mfderiv_at ModelWithCorners.hasMFDerivAt
 
 protected theorem hasMFDerivWithinAt {s x} :
@@ -67,10 +67,10 @@ protected theorem mdifferentiableOn {s} : MDifferentiableOn I 𝓘(𝕜, E) I s 
 protected theorem mdifferentiable : MDifferentiable I 𝓘(𝕜, E) I := fun _ => I.mdifferentiableAt
 #align model_with_corners.mdifferentiable ModelWithCorners.mdifferentiable
 
-theorem hasMFDerivWithinAt_symm {x} (hx : x ∈ range I) :
+theorem hasMFDerivWithinAt_symm {x : E} (hx : x ∈ range I) :
     HasMFDerivWithinAt 𝓘(𝕜, E) I I.symm (range I) x (ContinuousLinearMap.id _ _) :=
   ⟨I.continuousWithinAt_symm,
-    (hasFDerivWithinAt_id _ _).congr' (fun _y hy => I.rightInvOn hy.1) ⟨hx, mem_range_self _⟩⟩
+    (hasFDerivWithinAt_id _ _).congr' (fun _y hy ↦ I.rightInvOn hy.1) ⟨hx, mem_range_self x⟩⟩
 #align model_with_corners.has_mfderiv_within_at_symm ModelWithCorners.hasMFDerivWithinAt_symm
 
 theorem mdifferentiableOn_symm : MDifferentiableOn 𝓘(𝕜, E) I I.symm (range I) := fun _x hx =>

--- a/Mathlib/Geometry/Manifold/VectorBundle/FiberwiseLinear.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/FiberwiseLinear.lean
@@ -223,6 +223,22 @@ theorem SmoothFiberwiseLinear.locality_aux₂ (e : PartialHomeomorph (B × F) (B
 
 variable (F B IB)
 
+variable {F B IB} in
+-- This lemma is not necessary for the next declaration,
+-- but speeds up `simp` calls a lot.
+private theorem mem_aux {e : PartialHomeomorph (B × F) (B × F)} :
+    (e ∈ ⋃ (φ : B → F ≃L[𝕜] F) (U : Set B) (hU : IsOpen U)
+      (hφ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => φ x : B → F →L[𝕜] F) U)
+      (h2φ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (φ x).symm : B → F →L[𝕜] F) U),
+        {e | e.EqOnSource (FiberwiseLinear.partialHomeomorph φ hU hφ.continuousOn
+          h2φ.continuousOn)}) ↔
+      ∃ (φ : B → F ≃L[𝕜] F) (U : Set B) (hU : IsOpen U)
+        (hφ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => φ x : B → F →L[𝕜] F) U)
+        (h2φ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (φ x).symm : B → F →L[𝕜] F) U),
+          e.EqOnSource
+            (FiberwiseLinear.partialHomeomorph φ hU hφ.continuousOn h2φ.continuousOn) := by
+  simp only [mem_iUnion, mem_setOf_eq]
+
 -- Adaptation note: 2024-04-23
 -- This `maxHeartbeats` was not previously required; increased from about 90k to about 320k.
 -- The backwards compatibility flags do not help here:
@@ -242,7 +258,7 @@ def smoothFiberwiseLinear : StructureGroupoid (B × F) where
       (h2φ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (φ x).symm : B → F →L[𝕜] F) U),
         {e | e.EqOnSource (FiberwiseLinear.partialHomeomorph φ hU hφ.continuousOn h2φ.continuousOn)}
   trans' := by
-    simp only [mem_iUnion]
+    simp only [mem_aux]
     rintro e e' ⟨φ, U, hU, hφ, h2φ, heφ⟩ ⟨φ', U', hU', hφ', h2φ', heφ'⟩
     refine' ⟨fun b => (φ b).trans (φ' b), _, hU.inter hU', _, _,
       Setoid.trans (PartialHomeomorph.EqOnSource.trans' heφ heφ') ⟨_, _⟩⟩
@@ -259,43 +275,28 @@ def smoothFiberwiseLinear : StructureGroupoid (B × F) where
     · rintro ⟨b, v⟩ -; apply FiberwiseLinear.trans_partialHomeomorph_apply
   -- Porting note: without introducing `e` first, the first `simp only` fails
   symm' := fun e ↦ by
-    simp only [mem_iUnion]
+    simp only [mem_aux]
     rintro ⟨φ, U, hU, hφ, h2φ, heφ⟩
     refine ⟨fun b => (φ b).symm, U, hU, h2φ, ?_, PartialHomeomorph.EqOnSource.symm' heφ⟩
     simp_rw [ContinuousLinearEquiv.symm_symm]
     exact hφ
   id_mem' := by
-    simp_rw [mem_iUnion]
+    simp_rw [mem_aux]
     refine ⟨fun _ ↦ ContinuousLinearEquiv.refl 𝕜 F, univ, isOpen_univ, smoothOn_const,
       smoothOn_const, ⟨?_, fun b _hb ↦ rfl⟩⟩
     simp only [FiberwiseLinear.partialHomeomorph, PartialHomeomorph.refl_partialEquiv,
       PartialEquiv.refl_source, univ_prod_univ]
   locality' := by
     -- the hard work has been extracted to `locality_aux₁` and `locality_aux₂`
-    simp only [mem_iUnion]
+    simp only [mem_aux]
     intro e he
     obtain ⟨U, hU, h⟩ := SmoothFiberwiseLinear.locality_aux₁ e he
     exact SmoothFiberwiseLinear.locality_aux₂ e U hU h
   mem_of_eqOnSource' := by
-    simp only [mem_iUnion]
+    simp only [mem_aux]
     rintro e e' ⟨φ, U, hU, hφ, h2φ, heφ⟩ hee'
     exact ⟨φ, U, hU, hφ, h2φ, Setoid.trans hee' heφ⟩
 #align smooth_fiberwise_linear smoothFiberwiseLinear
-
-variable {F B IB} in
--- TODO: can this be inlined into the next lemma?
-private theorem mem_aux {e : PartialHomeomorph (B × F) (B × F)} :
-    (e ∈ ⋃ (φ : B → F ≃L[𝕜] F) (U : Set B) (hU : IsOpen U)
-      (hφ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => φ x : B → F →L[𝕜] F) U)
-      (h2φ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (φ x).symm : B → F →L[𝕜] F) U),
-        {e | e.EqOnSource (FiberwiseLinear.partialHomeomorph φ hU hφ.continuousOn
-          h2φ.continuousOn)}) ↔
-      ∃ (φ : B → F ≃L[𝕜] F) (U : Set B) (hU : IsOpen U)
-        (hφ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => φ x : B → F →L[𝕜] F) U)
-        (h2φ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => (φ x).symm : B → F →L[𝕜] F) U),
-          e.EqOnSource
-            (FiberwiseLinear.partialHomeomorph φ hU hφ.continuousOn h2φ.continuousOn) := by
-  simp only [mem_iUnion, mem_setOf_eq]
 
 @[simp]
 theorem mem_smoothFiberwiseLinear_iff (e : PartialHomeomorph (B × F) (B × F)) :

--- a/Mathlib/Geometry/Manifold/VectorBundle/FiberwiseLinear.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/FiberwiseLinear.lean
@@ -224,8 +224,7 @@ theorem SmoothFiberwiseLinear.locality_aux₂ (e : PartialHomeomorph (B × F) (B
 variable (F B IB)
 
 variable {F B IB} in
--- This lemma is not necessary for the next declaration,
--- but speeds up `simp` calls a lot.
+-- Having this private lemma speeds up `simp` calls a lot.
 private theorem mem_aux {e : PartialHomeomorph (B × F) (B × F)} :
     (e ∈ ⋃ (φ : B → F ≃L[𝕜] F) (U : Set B) (hU : IsOpen U)
       (hφ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => φ x : B → F →L[𝕜] F) U)

--- a/Mathlib/Geometry/Manifold/VectorBundle/FiberwiseLinear.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/FiberwiseLinear.lean
@@ -224,7 +224,9 @@ theorem SmoothFiberwiseLinear.locality_aux₂ (e : PartialHomeomorph (B × F) (B
 variable (F B IB)
 
 variable {F B IB} in
--- Having this private lemma speeds up `simp` calls a lot.
+-- Having this private lemma speeds up `simp` calls below a lot.
+-- TODO: understand why and fix the underlying issue (relatedly, the `simp` calls
+-- in `smoothFiberwiseLinear` are quite slow, even with this change)
 private theorem mem_aux {e : PartialHomeomorph (B × F) (B × F)} :
     (e ∈ ⋃ (φ : B → F ≃L[𝕜] F) (U : Set B) (hU : IsOpen U)
       (hφ : SmoothOn IB 𝓘(𝕜, F →L[𝕜] F) (fun x => φ x : B → F →L[𝕜] F) U)


### PR DESCRIPTION
#12061 regressed this file pretty badly; speed it up again by mostly reverting a change from that PR, and pushing it further: instead of applying `mem_iUnion` (which is slow), extract a more specialised statement `mem_aux` and use it.

Before these changes, the `profiler` output on `smoothFiberwiseLinear` was
```
simp took 2.01s
tactic execution of Lean.Parser.Tactic.rintro took 103ms
simp took 905ms
simp took 507ms
simp took 1.26s
simp took 1.14s
elaboration took 645ms
```
after these changes, it is
```
simp took 534ms
simp took 183ms
simp took 127ms
simp took 421ms
simp took 365ms
elaboration took 350ms
```
Still not great at all, but deeper fixes require more time and expertise than I currently have.

---

I cannot recover the link to the post-merge perf. run from speed.lean-lang.org; help with that welcome.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
