### PR TITLE
[Merged by Bors] - chore: fix comments about Pointwise files to point to renamed files

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -22,7 +22,7 @@ These actions are available in the `Pointwise` locale.
 
 ## Implementation notes
 
-The pointwise section of this file is almost identical to `GroupTheory/Submonoid/Pointwise.lean`.
+The pointwise section of this file is almost identical to `Algebra/Group/Submonoid/Pointwise.lean`.
 Where possible, try to keep them in sync.
 -/
 

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -22,7 +22,8 @@ These actions are available in the `Pointwise` locale.
 
 ## Implementation notes
 
-The pointwise section of this file is almost identical to `Algebra/Group/Submonoid/Pointwise.lean`.
+The pointwise section of this file is almost identical to
+the file `Mathlib.Algebra.Group.Submonoid.Pointwise`.
 Where possible, try to keep them in sync.
 -/
 

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -35,11 +35,11 @@ These actions are available in the `Pointwise` locale.
 ## Implementation notes
 
 For an `R`-module `M`, The action of a subset of `R` acting on a submodule of `M` introduced in
-section `set_acting_on_submodules` does not have a counterpart in
-`Mathlib/Algebra/Group/Submonoid/Pointwise.lean`.
+section `set_acting_on_submodules` does not have a counterpart in the file
+`Mathlib.Algebra.Group.Submonoid.Pointwise`.
 
 Other than section `set_acting_on_submodules`, most of the lemmas in this file are direct copies of
-lemmas from `Mathlib/Algebra/Group/Submonoid/Pointwise.lean`.
+lemmas from the file `Mathlib.Algebra.Group.Submonoid.Pointwise`.
 -/
 
 

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -36,10 +36,10 @@ These actions are available in the `Pointwise` locale.
 
 For an `R`-module `M`, The action of a subset of `R` acting on a submodule of `M` introduced in
 section `set_acting_on_submodules` does not have a counterpart in
-`Mathlib/GroupTheory/Submonoid/Pointwise.lean`.
+`Mathlib/Algebra/Group/Submonoid/Pointwise.lean`.
 
 Other than section `set_acting_on_submodules`, most of the lemmas in this file are direct copies of
-lemmas from `Mathlib/GroupTheory/Submonoid/Pointwise.lean`.
+lemmas from `Mathlib/Algebra/Group/Submonoid/Pointwise.lean`.
 -/
 
 

--- a/Mathlib/Algebra/Ring/Subring/Pointwise.lean
+++ b/Mathlib/Algebra/Ring/Subring/Pointwise.lean
@@ -19,8 +19,8 @@ This actions is available in the `Pointwise` locale.
 
 ## Implementation notes
 
-This file is almost identical to `Algebra/Ring/Subsemiring/Pointwise.lean`. Where possible, try to
-keep them in sync.
+This file is almost identical to the file `Mathlib.Algebra.Ring.Subsemiring.Pointwise`. Where
+possible, try to keep them in sync.
 
 -/
 

--- a/Mathlib/Algebra/Ring/Subring/Pointwise.lean
+++ b/Mathlib/Algebra/Ring/Subring/Pointwise.lean
@@ -19,7 +19,7 @@ This actions is available in the `Pointwise` locale.
 
 ## Implementation notes
 
-This file is almost identical to `RingTheory/Subsemiring/Pointwise.lean`. Where possible, try to
+This file is almost identical to `Algebra/Ring/Subsemiring/Pointwise.lean`. Where possible, try to
 keep them in sync.
 
 -/

--- a/Mathlib/Algebra/Ring/Subsemiring/Pointwise.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Pointwise.lean
@@ -19,7 +19,7 @@ This actions is available in the `Pointwise` locale.
 
 ## Implementation notes
 
-This file is almost identical to `GroupTheory/Submonoid/Pointwise.lean`. Where possible, try to
+This file is almost identical to `Algebra/Group/Submonoid/Pointwise.lean`. Where possible, try to
 keep them in sync.
 -/
 

--- a/Mathlib/Algebra/Ring/Subsemiring/Pointwise.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Pointwise.lean
@@ -19,8 +19,8 @@ This actions is available in the `Pointwise` locale.
 
 ## Implementation notes
 
-This file is almost identical to `Algebra/Group/Submonoid/Pointwise.lean`. Where possible, try to
-keep them in sync.
+This file is almost identical to the file `Mathlib.Algebra.Group.Submonoid.Pointwise`. Where
+possible, try to keep them in sync.
 -/
 
 

--- a/Mathlib/GroupTheory/Submonoid/Inverses.lean
+++ b/Mathlib/GroupTheory/Submonoid/Inverses.lean
@@ -17,7 +17,7 @@ since the inverses are unique. When `N ≤ IsUnit.Submonoid M`, this is precisel
 the pointwise inverse of `N`, and we may define `leftInvEquiv : S.leftInv ≃* S`.
 
 For the pointwise inverse of submonoids of groups, please refer to
-`Mathlib.GroupTheory.Submonoid.Pointwise`.
+`Mathlib.Algebra.Group.Submonoid.Pointwise`.
 
 `N.leftInv` is distinct from `N.units`, which is the subgroup of `Mˣ` containing all units that are
 in `N`. See the implementation notes of `Mathlib.GroupTheory.Submonoid.Units` for more details on

--- a/Mathlib/GroupTheory/Submonoid/Inverses.lean
+++ b/Mathlib/GroupTheory/Submonoid/Inverses.lean
@@ -16,7 +16,7 @@ left inverses of `N`. When `M` is commutative, we may define `fromCommLeftInv : 
 since the inverses are unique. When `N ≤ IsUnit.Submonoid M`, this is precisely
 the pointwise inverse of `N`, and we may define `leftInvEquiv : S.leftInv ≃* S`.
 
-For the pointwise inverse of submonoids of groups, please refer to
+For the pointwise inverse of submonoids of groups, please refer to the file
 `Mathlib.Algebra.Group.Submonoid.Pointwise`.
 
 `N.leftInv` is distinct from `N.units`, which is the subgroup of `Mˣ` containing all units that are

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -782,8 +782,8 @@ the action is by a group. Notably this provides an instances when `G` is `K ≃+
 
 These instances are in the `Pointwise` locale.
 
-The lemmas in this section are copied from `Algebra/Ring/Subring/Pointwise.lean`; try to keep these
-in sync.
+The lemmas in this section are copied from the file `Mathlib.Algebra.Ring.Subring.Pointwise`; try
+to keep these in sync.
 -/
 
 

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -782,7 +782,7 @@ the action is by a group. Notably this provides an instances when `G` is `K ≃+
 
 These instances are in the `Pointwise` locale.
 
-The lemmas in this section are copied from `RingTheory/Subring/Pointwise.lean`; try to keep these
+The lemmas in this section are copied from `Algebra/Ring/Subring/Pointwise.lean`; try to keep these
 in sync.
 -/
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

#11104 (amongst other things) renamed `GroupTheory/Submonoid/Pointwise.lean` to `Algebra/Group/Submonoid/Pointwise.lean`, `RingTheory/Subsemiring/Pointwise.lean` to `Algebra/Ring/Subsemiring/Pointwise.lean` and `RingTheory/Subring/Pointwise.lean` to `Algebra/Ring/Subring/Pointwise.lean`. It picked up all the pieces regarding getting mathlib compiling again, but these comments were still broken.