### PR TITLE
[Merged by Bors] - chore(*): drop some uses of `some_eq_coe`, `none_eq_bot`

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -340,8 +340,7 @@ instance addMonoid : AddMonoid (WithTop α) where
     | ⊤, 0 => 0
     | ⊤, _n + 1 => ⊤
   nsmul_zero a := by cases a <;> simp [zero_nsmul]
-  nsmul_succ n a := by
-    cases a <;> cases n <;> simp [succ_nsmul, coe_add, some_eq_coe, none_eq_top]
+  nsmul_succ n a := by cases a <;> cases n <;> simp [succ_nsmul, coe_add]
 
 @[simp, norm_cast] lemma coe_nsmul (a : α) (n : ℕ) : ↑(n • a) = n • (a : WithTop α) := rfl
 

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -64,7 +64,7 @@ lemma top_mul' : ∀ (b : WithTop α), ⊤ * b = if b = 0 then 0 else ⊤
 
 lemma mul_def (a b : WithTop α) :
     a * b = if a = 0 ∨ b = 0 then 0 else WithTop.map₂ (· * ·) a b := by
-  cases a <;> cases b <;> aesop (add simp [none_eq_top, some_eq_coe])
+  cases a <;> cases b <;> aesop
 #align with_top.mul_def WithTop.mul_def
 
 lemma mul_eq_top_iff : a * b = ⊤ ↔ a ≠ 0 ∧ b = ⊤ ∨ a = ⊤ ∧ b ≠ 0 := by rw [mul_def]; aesop
@@ -164,7 +164,7 @@ instance instMonoidWithZero : MonoidWithZero (WithTop α) where
     | ⊤, 0 => 1
     | ⊤, _n + 1 => ⊤
   npow_zero a := by cases a <;> simp
-  npow_succ n a := by cases n <;> cases a <;> simp [none_eq_top, some_eq_coe, pow_succ]
+  npow_succ n a := by cases n <;> cases a <;> simp [pow_succ]
 
 @[simp, norm_cast] lemma coe_pow (a : α) (n : ℕ) : (↑(a ^ n) : WithTop α) = a ^ n := rfl
 
@@ -243,7 +243,7 @@ lemma bot_mul' : ∀ (b : WithBot α), ⊥ * b = if b = 0 then 0 else ⊥
 
 lemma mul_def (a b : WithBot α) :
     a * b = if a = 0 ∨ b = 0 then 0 else WithBot.map₂ (· * ·) a b := by
-  cases a <;> cases b <;> aesop (add simp [none_eq_bot, some_eq_coe])
+  cases a <;> cases b <;> aesop
 #align with_bot.mul_def WithBot.mul_def
 
 lemma mul_eq_bot_iff : a * b = ⊥ ↔ a ≠ 0 ∧ b = ⊥ ∨ a = ⊥ ∧ b ≠ 0 := by rw [mul_def]; aesop

--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -897,13 +897,11 @@ theorem sup'_induction {p : α → Prop} (hp : ∀ a₁, p a₁ → ∀ a₂, p 
     (hs : ∀ b ∈ s, p (f b)) : p (s.sup' H f) := by
   show @WithBot.recBotCoe α (fun _ => Prop) True p ↑(s.sup' H f)
   rw [coe_sup']
-  refine sup_induction trivial ?_ hs
-  rintro (_ | a₁) h₁ a₂ h₂
-  · rw [WithBot.none_eq_bot, bot_sup_eq]
-    exact h₂
-  · cases a₂ using WithBot.recBotCoe with
-    | bot => exact h₁
-    | coe a₂ => exact hp a₁ h₁ a₂ h₂
+  refine sup_induction trivial (fun a₁ h₁ a₂ h₂ ↦ ?_) hs
+  match a₁, a₂ with
+  | ⊥, _ => rwa [bot_sup_eq]
+  | (a₁ : α), ⊥ => rwa [sup_bot_eq]
+  | (a₁ : α), (a₂ : α) => exact hp a₁ h₁ a₂ h₂
 #align finset.sup'_induction Finset.sup'_induction
 
 theorem sup'_mem (s : Set α) (w : ∀ᵉ (x ∈ s) (y ∈ s), x ⊔ y ∈ s) {ι : Type*}

--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -337,7 +337,7 @@ theorem minimum_not_lt_of_mem : a ∈ l → (minimum l : WithTop α) = m → ¬a
 theorem not_lt_maximum_of_mem' (ha : a ∈ l) : ¬maximum l < (a : WithBot α) := by
   cases h : l.maximum
   · simp_all
-  · simp [WithBot.some_eq_coe, WithBot.coe_lt_coe, not_lt_maximum_of_mem ha h, not_false_iff]
+  · simp [not_lt_maximum_of_mem ha h, not_false_iff]
 #align list.not_lt_maximum_of_mem' List.not_lt_maximum_of_mem'
 
 theorem not_lt_minimum_of_mem' (ha : a ∈ l) : ¬(a : WithTop α) < minimum l :=

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -740,12 +740,12 @@ def orderIsoPUnitSumLex : WithBot α ≃o PUnit ⊕ₗ α :=
   ⟨(Equiv.optionEquivSumPUnit α).trans <| (Equiv.sumComm _ _).trans toLex, @fun a b => by
     simp only [Equiv.optionEquivSumPUnit, Option.elim, Equiv.trans_apply, Equiv.coe_fn_mk,
       Equiv.sumComm_apply, swap, Lex.toLex_le_toLex, le_refl]
-    rcases a with (a | _) <;> rcases b with (b | _)
-    · simp only [elim_inr, lex_inl_inl, bot_le, none_eq_bot]
-    · simp only [elim_inr, elim_inl, Lex.sep, bot_le, none_eq_bot]
+    cases' a <;> cases' b
+    · simp only [elim_inr, lex_inl_inl, bot_le, le_rfl]
+    · simp only [elim_inr, elim_inl, Lex.sep, bot_le]
     · simp only [elim_inl, elim_inr, lex_inr_inl, false_iff]
       exact not_coe_le_bot _
-    · simp only [elim_inl, lex_inr_inr, coe_le_coe, WithBot.some_eq_coe]
+    · simp only [elim_inl, lex_inr_inr, coe_le_coe]
   ⟩
 #align with_bot.order_iso_punit_sum_lex WithBot.orderIsoPUnitSumLex
 
@@ -782,13 +782,12 @@ def orderIsoSumLexPUnit : WithTop α ≃o α ⊕ₗ PUnit :=
   ⟨(Equiv.optionEquivSumPUnit α).trans toLex, @fun a b => by
     simp only [Equiv.optionEquivSumPUnit, Option.elim, Equiv.trans_apply, Equiv.coe_fn_mk,
       ge_iff_le, Lex.toLex_le_toLex, le_refl, lex_inr_inr, le_top]
-    rcases a with (a | _) <;> rcases b with (b | _)
-    · simp only [lex_inr_inr, le_top, WithTop.none_eq_top]
+    cases' a <;> cases' b
+    · simp only [lex_inr_inr, le_top]
     · simp only [lex_inr_inl, false_iff]
       exact not_top_le_coe _
-    · simp only [Lex.sep, le_top, WithTop.none_eq_top]
-    · simp only [lex_inl_inl, coe_le_coe, WithTop.some_eq_coe]
-
+    · simp only [Lex.sep, le_top]
+    · simp only [lex_inl_inl, coe_le_coe]
   ⟩
 #align with_top.order_iso_sum_lex_punit WithTop.orderIsoSumLexPUnit
 

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -787,8 +787,7 @@ def orderIsoSumLexPUnit : WithTop α ≃o α ⊕ₗ PUnit :=
     · simp only [lex_inr_inl, false_iff]
       exact not_top_le_coe _
     · simp only [Lex.sep, le_top]
-    · simp only [lex_inl_inl, coe_le_coe]
-  ⟩
+    · simp only [lex_inl_inl, coe_le_coe]⟩
 #align with_top.order_iso_sum_lex_punit WithTop.orderIsoSumLexPUnit
 
 @[simp]

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -1866,7 +1866,7 @@ theorem is_pow_of_dvd_count [DecidableEq (Associates α)] {a : Associates α}
   obtain ⟨u, hu⟩ := Multiset.exists_smul_of_dvd_count _ hk'
   use FactorSet.prod (u : FactorSet α)
   apply eq_of_factors_eq_factors
-  rw [pow_factors, prod_factors, factors_mk a0 hz, ← WithTop.some_eq_coe, hu]
+  rw [pow_factors, prod_factors, factors_mk a0 hz, hu]
   exact WithBot.coe_nsmul u k
 #align associates.is_pow_of_dvd_count Associates.is_pow_of_dvd_count
 

--- a/Mathlib/Testing/SlimCheck/Functions.lean
+++ b/Mathlib/Testing/SlimCheck/Functions.lean
@@ -191,7 +191,7 @@ def applyFinsupp (tf : TotalFunction α β) : α →₀ β where
       have := List.mem_dlookup (List.nodupKeys_dedupKeys A) hval
       rw [(_ : List.dlookup a A = od)]
       · simpa using hod
-      · simpa [List.dlookup_dedupKeys, WithTop.some_eq_coe]
+      · simpa [List.dlookup_dedupKeys]
     · intro h
       use (A.dlookup a).getD (0 : β)
       rw [← List.dlookup_dedupKeys] at h ⊢


### PR DESCRIPTION
Partially migrate from `WithBot.some_eq_coe`, `WithTop.some_eq_coe`,
`WithBot.none_eq_bot`, and `WithTop.none_eq_top`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)