### PR TITLE
[Merged by Bors] - chore(Algebra–GroupTheory): remove `refine'`

### DIFF
--- a/Archive/Imo/Imo1960Q1.lean
+++ b/Archive/Imo/Imo1960Q1.lean
@@ -103,7 +103,7 @@ theorem right_direction {n : ℕ} : ProblemPredicate n → SolutionPredicate n :
 Now we just need to prove the equivalence, for the precise problem statement.
 -/
 theorem left_direction (n : ℕ) (spn : SolutionPredicate n) : ProblemPredicate n := by
-  rcases spn with (rfl | rfl) <;> refine' ⟨_, by decide, _⟩ <;> norm_num <;> rfl
+  rcases spn with (rfl | rfl) <;> refine ⟨?_, by decide, ?_⟩ <;> norm_num <;> rfl
 #align imo1960_q1.left_direction Imo1960Q1.left_direction
 
 end Imo1960Q1

--- a/Mathlib/Algebra/DirectLimit.lean
+++ b/Mathlib/Algebra/DirectLimit.lean
@@ -701,10 +701,10 @@ theorem of.zero_exact_aux [Nonempty ι] [IsDirected ι (· ≤ ·)] {x : FreeCom
   have := Classical.decEq
   refine span_induction (Ideal.Quotient.eq_zero_iff_mem.1 H) ?_ ?_ ?_ ?_
   · rintro x (⟨i, j, hij, x, rfl⟩ | ⟨i, rfl⟩ | ⟨i, x, y, rfl⟩ | ⟨i, x, y, rfl⟩)
-    · refine'
+    · refine
         ⟨j, {⟨i, x⟩, ⟨j, f' i j hij x⟩}, ?_,
-          isSupported_sub (isSupported_of.2 <| Or.inr rfl) (isSupported_of.2 <| Or.inl rfl),
-            fun [_] => _⟩
+          isSupported_sub (isSupported_of.2 <| Or.inr (by exact rfl))
+            (isSupported_of.2 <| Or.inl rfl), fun [_] => ?_⟩
       · rintro k (rfl | ⟨rfl | _⟩)
         · exact hij
         · rfl
@@ -716,19 +716,20 @@ theorem of.zero_exact_aux [Nonempty ι] [IsDirected ι (· ≤ ·)] {x : FreeCom
           rw [this]
           · exact sub_self _
         exacts [Or.inl rfl, Or.inr rfl]
-    · refine' ⟨i, {⟨i, 1⟩}, _, isSupported_sub (isSupported_of.2 rfl) isSupported_one, fun [_] => _⟩
+    · refine ⟨i, {⟨i, 1⟩}, ?_, isSupported_sub (isSupported_of.2 (by exact rfl))
+        isSupported_one, fun [_] => ?_⟩
       · rintro k (rfl | h)
         rfl
         -- Porting note: the Lean3 proof contained `rw [restriction_of]`, but this
         -- lemma does not seem to work here
       · rw [RingHom.map_sub, RingHom.map_sub]
         erw [lift_of, dif_pos rfl, RingHom.map_one, lift_of, RingHom.map_one, sub_self]
-    · refine'
+    · refine
         ⟨i, {⟨i, x + y⟩, ⟨i, x⟩, ⟨i, y⟩}, ?_,
           isSupported_sub (isSupported_of.2 <| Or.inl rfl)
             (isSupported_add (isSupported_of.2 <| Or.inr <| Or.inl rfl)
-              (isSupported_of.2 <| Or.inr <| Or.inr rfl)),
-          fun [_] => _⟩
+              (isSupported_of.2 <| Or.inr <| Or.inr (by exact rfl))),
+          fun [_] => ?_⟩
       · rintro k (rfl | ⟨rfl | ⟨rfl | hk⟩⟩) <;> rfl
       · rw [(restriction _).map_sub, (restriction _).map_add, restriction_of, restriction_of,
           restriction_of, dif_pos, dif_pos, dif_pos, RingHom.map_sub,
@@ -738,11 +739,11 @@ theorem of.zero_exact_aux [Nonempty ι] [IsDirected ι (· ≤ ·)] {x : FreeCom
           rw [(f' i i _).map_add]
           · exact sub_self _
         all_goals tauto
-    · refine'
-        ⟨i, {⟨i, x * y⟩, ⟨i, x⟩, ⟨i, y⟩}, _,
+    · refine
+        ⟨i, {⟨i, x * y⟩, ⟨i, x⟩, ⟨i, y⟩}, ?_,
           isSupported_sub (isSupported_of.2 <| Or.inl rfl)
             (isSupported_mul (isSupported_of.2 <| Or.inr <| Or.inl rfl)
-              (isSupported_of.2 <| Or.inr <| Or.inr rfl)), fun [_] => _⟩
+              (isSupported_of.2 <| Or.inr <| Or.inr (by exact rfl))), fun [_] => ?_⟩
       · rintro k (rfl | ⟨rfl | ⟨rfl | hk⟩⟩) <;> rfl
       · rw [(restriction _).map_sub, (restriction _).map_mul, restriction_of, restriction_of,
           restriction_of, dif_pos, dif_pos, dif_pos, RingHom.map_sub,

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -722,8 +722,8 @@ and an element of `M` is contained in the additive closure of `M`. -/
 theorem mul_right_mem_add_closure (ha : a ∈ AddSubmonoid.closure (S : Set R)) (hb : b ∈ S) :
     a * b ∈ AddSubmonoid.closure (S : Set R) := by
   revert b
-  refine' @AddSubmonoid.closure_induction _ _ _
-    (fun z => ∀ (b : R), b ∈ S → z * b ∈ AddSubmonoid.closure S) _ ha _ _ _ <;> clear ha a
+  apply @AddSubmonoid.closure_induction _ _ _
+    (fun z => ∀ (b : R), b ∈ S → z * b ∈ AddSubmonoid.closure S) _ ha <;> clear ha a
   · exact fun r hr b hb => AddSubmonoid.mem_closure.mpr fun y hy => hy (mul_mem hr hb)
   · exact fun b _ => by simp only [zero_mul, (AddSubmonoid.closure (S : Set R)).zero_mem]
   · simp_rw [add_mul]
@@ -735,9 +735,9 @@ additive closure of `M`. -/
 theorem mul_mem_add_closure (ha : a ∈ AddSubmonoid.closure (S : Set R))
     (hb : b ∈ AddSubmonoid.closure (S : Set R)) : a * b ∈ AddSubmonoid.closure (S : Set R) := by
   revert a
-  refine' @AddSubmonoid.closure_induction _ _ _
+  apply @AddSubmonoid.closure_induction _ _ _
     (fun z => ∀ {a : R}, a ∈ AddSubmonoid.closure ↑S → a * z ∈ AddSubmonoid.closure ↑S)
-      _ hb _ _ _ <;> clear hb b
+      _ hb <;> clear hb b
   · exact fun r hr b hb => MulMemClass.mul_right_mem_add_closure hb hr
   · exact fun _ => by simp only [mul_zero, (AddSubmonoid.closure (S : Set R)).zero_mem]
   · simp_rw [mul_add]

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -749,7 +749,8 @@ theorem coe_equivMapOfInjective_apply (f : M →* N) (hf : Function.Injective f)
 theorem closure_closure_coe_preimage {s : Set M} : closure (((↑) : closure s → M) ⁻¹' s) = ⊤ :=
   eq_top_iff.2 fun x =>
     Subtype.recOn x fun x hx _ => by
-      refine' closure_induction' _ (fun g hg => subset_closure hg) _ (fun g₁ g₂ hg₁ hg₂ => _) hx
+      refine closure_induction' (p := fun y hy ↦ ⟨y, hy⟩ ∈ closure (((↑) : closure s → M) ⁻¹' s))
+        (fun g hg => subset_closure hg) ?_ (fun g₁ g₂ hg₁ hg₂ => ?_) hx
       · exact Submonoid.one_mem _
       · exact Submonoid.mul_mem _
 #align submonoid.closure_closure_coe_preimage Submonoid.closure_closure_coe_preimage

--- a/Mathlib/Algebra/Group/Subsemigroup/Operations.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Operations.lean
@@ -624,9 +624,9 @@ theorem coe_equivMapOfInjective_apply (f : M →ₙ* N) (hf : Function.Injective
 theorem closure_closure_coe_preimage {s : Set M} :
     closure ((Subtype.val : closure s → M) ⁻¹' s) = ⊤ :=
   eq_top_iff.2 fun x =>
-    Subtype.recOn x fun x hx _ => by
-      refine' closure_induction' _ (fun g hg => subset_closure hg) (fun g₁ g₂ hg₁ hg₂ => _) hx
-      exact Subsemigroup.mul_mem _
+    Subtype.recOn x fun _ hx _ =>
+      closure_induction' (p := fun y hy ↦ ⟨y, hy⟩ ∈ closure (((↑) : closure s → M) ⁻¹' s))
+        (fun _ hg => subset_closure hg) (fun _ _ _ _ => Subsemigroup.mul_mem _) hx
 #align subsemigroup.closure_closure_coe_preimage Subsemigroup.closure_closure_coe_preimage
 #align add_subsemigroup.closure_closure_coe_preimage AddSubsemigroup.closure_closure_coe_preimage
 

--- a/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
@@ -358,7 +358,7 @@ noncomputable def Exact.leftHomologyDataOfIsLimitKernelFork
   wπ := comp_zero
   hπ := CokernelCofork.IsColimit.ofEpiOfIsZero _ (by
     have := hS.hasHomology
-    refine' ((MorphismProperty.RespectsIso.epimorphisms C).arrow_mk_iso_iff _).1
+    refine ((MorphismProperty.RespectsIso.epimorphisms C).arrow_mk_iso_iff ?_).1
       hS.epi_toCycles
     refine Arrow.isoMk (Iso.refl _)
       (IsLimit.conePointUniqueUpToIso S.cyclesIsKernel hkf) ?_
@@ -380,10 +380,10 @@ noncomputable def Exact.rightHomologyDataOfIsColimitCokernelCofork
   wι := zero_comp
   hι := KernelFork.IsLimit.ofMonoOfIsZero _ (by
     have := hS.hasHomology
-    refine' ((MorphismProperty.RespectsIso.monomorphisms C).arrow_mk_iso_iff _).2
+    refine ((MorphismProperty.RespectsIso.monomorphisms C).arrow_mk_iso_iff ?_).2
       hS.mono_fromOpcycles
-    refine' Arrow.isoMk (IsColimit.coconePointUniqueUpToIso hcc S.opcyclesIsCokernel)
-      (Iso.refl _) _
+    refine Arrow.isoMk (IsColimit.coconePointUniqueUpToIso hcc S.opcyclesIsCokernel)
+      (Iso.refl _) ?_
     apply Cofork.IsColimit.hom_ext hcc
     simp [IsColimit.coconePointUniqueUpToIso]) (isZero_zero C)
 

--- a/Mathlib/Algebra/MonoidAlgebra/Ideal.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Ideal.lean
@@ -39,7 +39,7 @@ theorem MonoidAlgebra.mem_ideal_span_of_image [Monoid G] [Semiring k] {s : Set G
         obtain rfl := hm
         -- Porting note: changed `Exists.imp` to `And.imp_right` due to change in `∃ x ∈ s`
         -- elaboration
-        refine' (hy _ hym).imp fun sm p => And.imp_right _ p
+        refine (hy _ hym).imp fun sm p => And.imp_right ?_ p
         rintro ⟨d, rfl⟩
         exact ⟨xm * d, (mul_assoc _ _ _).symm⟩ }
   change _ ↔ x ∈ RHS
@@ -48,7 +48,7 @@ theorem MonoidAlgebra.mem_ideal_span_of_image [Monoid G] [Semiring k] {s : Set G
     rw [← SetLike.le_def] -- Porting note: refine needs this even though it's defeq?
     refine Ideal.span_le.2 ?_
     rintro _ ⟨i, hi, rfl⟩ m hm
-    refine' ⟨_, hi, 1, _⟩
+    refine ⟨_, hi, 1, ?_⟩
     obtain rfl := Finset.mem_singleton.mp (Finsupp.support_single_subset hm)
     exact (one_mul _).symm
   · intro hx
@@ -57,7 +57,7 @@ theorem MonoidAlgebra.mem_ideal_span_of_image [Monoid G] [Semiring k] {s : Set G
     obtain ⟨d, hd, d2, rfl⟩ := hx _ hi
     convert Ideal.mul_mem_left _ (id <| Finsupp.single d2 <| x (d2 * d) : MonoidAlgebra k G) _
     pick_goal 3
-    · refine' Ideal.subset_span ⟨_, hd, rfl⟩
+    · exact Ideal.subset_span ⟨_, hd, rfl⟩
     rw [id, MonoidAlgebra.of_apply, MonoidAlgebra.single_mul_single, mul_one]
 #align monoid_algebra.mem_ideal_span_of_image MonoidAlgebra.mem_ideal_span_of_image
 

--- a/Mathlib/Algebra/Order/Group/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Abs.lean
@@ -474,7 +474,7 @@ theorem abs_sub_lt_of_nonneg_of_lt {a b n : α} (a_nonneg : 0 ≤ a) (a_lt_n : a
   exact ⟨lt_add_of_lt_of_nonneg a_lt_n b_nonneg, lt_add_of_lt_of_nonneg b_lt_n a_nonneg⟩
 
 theorem abs_eq (hb : 0 ≤ b) : |a| = b ↔ a = b ∨ a = -b := by
-  refine' ⟨eq_or_eq_neg_of_abs_eq, _⟩
+  refine ⟨eq_or_eq_neg_of_abs_eq, ?_⟩
   rintro (rfl | rfl) <;> simp only [abs_neg, abs_of_nonneg hb]
 #align abs_eq abs_eq
 

--- a/Mathlib/Algebra/Order/Group/MinMax.lean
+++ b/Mathlib/Algebra/Order/Group/MinMax.lean
@@ -94,7 +94,7 @@ theorem max_sub_max_le_max (a b c d : α) : max a b - max c d ≤ max (a - c) (b
 #align max_sub_max_le_max max_sub_max_le_max
 
 theorem abs_max_sub_max_le_max (a b c d : α) : |max a b - max c d| ≤ max |a - c| |b - d| := by
-  refine' abs_sub_le_iff.2 ⟨_, _⟩
+  refine abs_sub_le_iff.2 ⟨?_, ?_⟩
   · exact (max_sub_max_le_max _ _ _ _).trans (max_le_max (le_abs_self _) (le_abs_self _))
   · rw [abs_sub_comm a c, abs_sub_comm b d]
     exact (max_sub_max_le_max _ _ _ _).trans (max_le_max (le_abs_self _) (le_abs_self _))

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
@@ -590,7 +590,7 @@ theorem mul_eq_mul_iff_eq_and_eq_of_pos [PosMulStrictMono α] [MulPosStrictMono 
     a * c = b * d ↔ a = b ∧ c = d := by
   refine ⟨fun h ↦ ?_, by rintro ⟨rfl, rfl⟩; rfl⟩
   simp only [eq_iff_le_not_lt, hab, hcd, true_and]
-  refine' ⟨fun hab ↦ h.not_lt _, fun hcd ↦ h.not_lt _⟩
+  refine ⟨fun hab ↦ h.not_lt ?_, fun hcd ↦ h.not_lt ?_⟩
   · exact (mul_le_mul_of_nonneg_left hcd a0.le).trans_lt (mul_lt_mul_of_pos_right hab d0)
   · exact (mul_lt_mul_of_pos_left hcd a0).trans_le (mul_le_mul_of_nonneg_right hab d0.le)
 #align mul_eq_mul_iff_eq_and_eq_of_pos mul_eq_mul_iff_eq_and_eq_of_pos
@@ -600,7 +600,7 @@ theorem mul_eq_mul_iff_eq_and_eq_of_pos' [PosMulStrictMono α] [MulPosStrictMono
     a * c = b * d ↔ a = b ∧ c = d := by
   refine ⟨fun h ↦ ?_, by rintro ⟨rfl, rfl⟩; rfl⟩
   simp only [eq_iff_le_not_lt, hab, hcd, true_and]
-  refine' ⟨fun hab ↦ h.not_lt _, fun hcd ↦ h.not_lt _⟩
+  refine ⟨fun hab ↦ h.not_lt ?_, fun hcd ↦ h.not_lt ?_⟩
   · exact (mul_lt_mul_of_pos_right hab c0).trans_le (mul_le_mul_of_nonneg_left hcd b0.le)
   · exact (mul_le_mul_of_nonneg_right hab c0.le).trans_lt (mul_lt_mul_of_pos_left hcd b0)
 #align mul_eq_mul_iff_eq_and_eq_of_pos' mul_eq_mul_iff_eq_and_eq_of_pos'
@@ -614,11 +614,11 @@ variable [LinearOrder α]
 theorem pos_and_pos_or_neg_and_neg_of_mul_pos [PosMulMono α] [MulPosMono α] (hab : 0 < a * b) :
     0 < a ∧ 0 < b ∨ a < 0 ∧ b < 0 := by
   rcases lt_trichotomy a 0 with (ha | rfl | ha)
-  · refine' Or.inr ⟨ha, lt_imp_lt_of_le_imp_le (fun hb => _) hab⟩
+  · refine Or.inr ⟨ha, lt_imp_lt_of_le_imp_le (fun hb => ?_) hab⟩
     exact mul_nonpos_of_nonpos_of_nonneg ha.le hb
   · rw [zero_mul] at hab
     exact hab.false.elim
-  · refine' Or.inl ⟨ha, lt_imp_lt_of_le_imp_le (fun hb => _) hab⟩
+  · refine Or.inl ⟨ha, lt_imp_lt_of_le_imp_le (fun hb => ?_) hab⟩
     exact mul_nonpos_of_nonneg_of_nonpos ha.le hb
 #align pos_and_pos_or_neg_and_neg_of_mul_pos pos_and_pos_or_neg_and_neg_of_mul_pos
 

--- a/Mathlib/Algebra/Order/Interval/Set/Monoid.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Monoid.lean
@@ -25,17 +25,17 @@ namespace Set
 variable {M : Type*} [OrderedCancelAddCommMonoid M] [ExistsAddOfLE M] (a b c d : M)
 
 theorem Ici_add_bij : BijOn (· + d) (Ici a) (Ici (a + d)) := by
-  refine'
-    ⟨fun x h => add_le_add_right (mem_Ici.mp h) _, (add_left_injective d).injOn _, fun _ h => _⟩
+  refine
+    ⟨fun x h => add_le_add_right (mem_Ici.mp h) _, (add_left_injective d).injOn _, fun _ h => ?_⟩
   obtain ⟨c, rfl⟩ := exists_add_of_le (mem_Ici.mp h)
   rw [mem_Ici, add_right_comm, add_le_add_iff_right] at h
   exact ⟨a + c, h, by rw [add_right_comm]⟩
 #align set.Ici_add_bij Set.Ici_add_bij
 
 theorem Ioi_add_bij : BijOn (· + d) (Ioi a) (Ioi (a + d)) := by
-  refine'
+  refine
     ⟨fun x h => add_lt_add_right (mem_Ioi.mp h) _, fun _ _ _ _ h => add_right_cancel h, fun _ h =>
-      _⟩
+      ?_⟩
   obtain ⟨c, rfl⟩ := exists_add_of_le (mem_Ioi.mp h).le
   rw [mem_Ioi, add_right_comm, add_lt_add_iff_right] at h
   exact ⟨a + c, h, by rw [add_right_comm]⟩

--- a/Mathlib/Algebra/Order/Module/OrderedSMul.lean
+++ b/Mathlib/Algebra/Order/Module/OrderedSMul.lean
@@ -121,8 +121,7 @@ theorem OrderedSMul.mk' (h : ∀ ⦃a b : M⦄ ⦃c : 𝕜⦄, a < b → 0 < c �
     refine fun a b c hab hc => (h hab hc).lt_of_ne ?_
     rw [Ne, hc.ne'.isUnit.smul_left_cancel]
     exact hab.ne
-  refine' { smul_lt_smul_of_pos := fun {a b c} => hlt' a b c..}
-  intro a b c hab hc
+  refine ⟨fun {a b c} => hlt' a b c, fun {a b c hab hc} => ?_⟩
   obtain ⟨c, rfl⟩ := hc.ne'.isUnit
   rw [← inv_smul_smul c a, ← inv_smul_smul c b]
   refine hlt' _ _ _ hab (pos_of_mul_pos_right ?_ hc.le)

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -247,7 +247,7 @@ theorem one_lt_mul_iff : 1 < a * b ↔ 1 < a ∨ 1 < b := by
 @[to_additive]
 theorem exists_one_lt_mul_of_lt (h : a < b) : ∃ (c : _) (_ : 1 < c), a * c = b := by
   obtain ⟨c, hc⟩ := le_iff_exists_mul.1 h.le
-  refine' ⟨c, one_lt_iff_ne_one.2 _, hc.symm⟩
+  refine ⟨c, one_lt_iff_ne_one.2 ?_, hc.symm⟩
   rintro rfl
   simp [hc, lt_irrefl] at h
 #align exists_one_lt_mul_of_lt exists_one_lt_mul_of_lt

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -311,7 +311,7 @@ theorem mul_right_cancel'' [ContravariantClass α α (swap (· * ·)) (· ≤ ·
   haveI := covariantClass_le_of_lt α α (swap (· * ·))
   refine ⟨fun h ↦ ?_, by rintro ⟨rfl, rfl⟩; rfl⟩
   simp only [eq_iff_le_not_lt, ha, hb, true_and]
-  refine' ⟨fun ha ↦ h.not_lt _, fun hb ↦ h.not_lt _⟩
+  refine ⟨fun ha ↦ h.not_lt ?_, fun hb ↦ h.not_lt ?_⟩
   exacts [mul_lt_mul_of_lt_of_le ha hb, mul_lt_mul_of_le_of_lt ha hb]
 #align add_le_add_iff_of_ge add_le_add_iff_of_geₓ
 #align mul_le_mul_iff_of_ge mul_le_mul_iff_of_geₓ

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/MinMax.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/MinMax.lean
@@ -127,7 +127,7 @@ theorem mul_lt_mul_iff_of_le_of_le [CovariantClass α α (· * ·) (· ≤ ·)]
     [CovariantClass α α (Function.swap (· * ·)) (· ≤ ·)] [CovariantClass α α (· * ·) (· < ·)]
     [CovariantClass α α (Function.swap (· * ·)) (· < ·)] {a₁ a₂ b₁ b₂ : α} (ha : a₁ ≤ a₂)
     (hb : b₁ ≤ b₂) : a₁ * b₁ < a₂ * b₂ ↔ a₁ < a₂ ∨ b₁ < b₂ := by
-  refine' ⟨lt_or_lt_of_mul_lt_mul, fun h => _⟩
+  refine ⟨lt_or_lt_of_mul_lt_mul, fun h => ?_⟩
   cases' h with ha' hb'
   · exact mul_lt_mul_of_lt_of_le ha' hb
   · exact mul_lt_mul_of_le_of_lt ha hb'

--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -857,7 +857,7 @@ attribute [local instance] LinearOrderedSemiring.decidableLE LinearOrderedSemiri
 
 theorem nonneg_and_nonneg_or_nonpos_and_nonpos_of_mul_nonneg (hab : 0 ≤ a * b) :
     0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 := by
-  refine' Decidable.or_iff_not_and_not.2 _
+  refine Decidable.or_iff_not_and_not.2 ?_
   simp only [not_and, not_le]; intro ab nab; apply not_lt_of_le hab _
   rcases lt_trichotomy 0 a with (ha | rfl | ha)
   · exact mul_neg_of_pos_of_neg ha (ab ha.le)

--- a/Mathlib/Algebra/Order/Sub/Basic.lean
+++ b/Mathlib/Algebra/Order/Sub/Basic.lean
@@ -46,7 +46,7 @@ theorem OrderIso.map_tsub {M N : Type*} [Preorder M] [Add M] [Sub M] [OrderedSub
     [PartialOrder N] [Add N] [Sub N] [OrderedSub N] (e : M ≃o N)
     (h_add : ∀ a b, e (a + b) = e a + e b) (a b : M) : e (a - b) = e a - e b := by
   let e_add : M ≃+ N := { e with map_add' := h_add }
-  refine' le_antisymm _ (e_add.toAddHom.le_map_tsub e.monotone a b)
+  refine le_antisymm ?_ (e_add.toAddHom.le_map_tsub e.monotone a b)
   suffices e (e.symm (e a) - e.symm (e b)) ≤ e (e.symm (e a - e b)) by simpa
   exact e.monotone (e_add.symm.toAddHom.le_map_tsub e.symm.monotone _ _)
 #align order_iso.map_tsub OrderIso.map_tsub

--- a/Mathlib/Algebra/Order/Sub/Canonical.lean
+++ b/Mathlib/Algebra/Order/Sub/Canonical.lean
@@ -23,7 +23,7 @@ variable [AddCommSemigroup α] [PartialOrder α] [ExistsAddOfLE α]
 
 @[simp]
 theorem add_tsub_cancel_of_le (h : a ≤ b) : a + (b - a) = b := by
-  refine' le_antisymm _ le_add_tsub
+  refine le_antisymm ?_ le_add_tsub
   obtain ⟨c, rfl⟩ := exists_add_of_le h
   exact add_le_add_left add_tsub_le_left a
 #align add_tsub_cancel_of_le add_tsub_cancel_of_le
@@ -55,7 +55,7 @@ theorem tsub_inj_left (h₁ : a ≤ b) (h₂ : a ≤ c) : b - a = c - a → b = 
 
 /-- See `lt_of_tsub_lt_tsub_right` for a stronger statement in a linear order. -/
 theorem lt_of_tsub_lt_tsub_right_of_le (h : c ≤ b) (h2 : a - c < b - c) : a < b := by
-  refine' ((tsub_le_tsub_iff_right h).mp h2.le).lt_of_ne _
+  refine ((tsub_le_tsub_iff_right h).mp h2.le).lt_of_ne ?_
   rintro rfl
   exact h2.false
 #align lt_of_tsub_lt_tsub_right_of_le lt_of_tsub_lt_tsub_right_of_le
@@ -116,8 +116,8 @@ protected theorem le_tsub_iff_right (ha : AddLECancellable a) (h : a ≤ c) :
 
 protected theorem tsub_lt_iff_left (hb : AddLECancellable b) (hba : b ≤ a) :
     a - b < c ↔ a < b + c := by
-  refine' ⟨hb.lt_add_of_tsub_lt_left, _⟩
-  intro h; refine' (tsub_le_iff_left.mpr h.le).lt_of_ne _
+  refine ⟨hb.lt_add_of_tsub_lt_left, ?_⟩
+  intro h; refine (tsub_le_iff_left.mpr h.le).lt_of_ne ?_
   rintro rfl; exact h.ne' (add_tsub_cancel_of_le hba)
 #align add_le_cancellable.tsub_lt_iff_left AddLECancellable.tsub_lt_iff_left
 
@@ -139,7 +139,7 @@ protected theorem le_tsub_iff_le_tsub (ha : AddLECancellable a) (hc : AddLECance
 
 protected theorem lt_tsub_iff_right_of_le (hc : AddLECancellable c) (h : c ≤ b) :
     a < b - c ↔ a + c < b := by
-  refine' ⟨fun h' => (add_le_of_le_tsub_right_of_le h h'.le).lt_of_ne _, hc.lt_tsub_of_add_lt_right⟩
+  refine ⟨fun h' => (add_le_of_le_tsub_right_of_le h h'.le).lt_of_ne ?_, hc.lt_tsub_of_add_lt_right⟩
   rintro rfl
   exact h'.ne' hc.add_tsub_cancel_right
 #align add_le_cancellable.lt_tsub_iff_right_of_le AddLECancellable.lt_tsub_iff_right_of_le
@@ -371,7 +371,7 @@ namespace AddLECancellable
 
 protected theorem tsub_le_tsub_iff_left (ha : AddLECancellable a) (hc : AddLECancellable c)
     (h : c ≤ a) : a - b ≤ a - c ↔ c ≤ b := by
-  refine' ⟨_, fun h => tsub_le_tsub_left h a⟩
+  refine ⟨?_, fun h => tsub_le_tsub_left h a⟩
   rw [tsub_le_iff_left, ← hc.add_tsub_assoc_of_le h, hc.le_tsub_iff_right (h.trans le_add_self),
     add_comm b]
   apply ha
@@ -449,14 +449,14 @@ protected theorem tsub_lt_tsub_iff_right (hc : AddLECancellable c) (h : c ≤ a)
 #align add_le_cancellable.tsub_lt_tsub_iff_right AddLECancellable.tsub_lt_tsub_iff_right
 
 protected theorem tsub_lt_self (ha : AddLECancellable a) (h₁ : 0 < a) (h₂ : 0 < b) : a - b < a := by
-  refine' tsub_le_self.lt_of_ne fun h => _
+  refine tsub_le_self.lt_of_ne fun h => ?_
   rw [← h, tsub_pos_iff_lt] at h₁
   exact h₂.not_le (ha.add_le_iff_nonpos_left.1 <| add_le_of_le_tsub_left_of_le h₁.le h.ge)
 #align add_le_cancellable.tsub_lt_self AddLECancellable.tsub_lt_self
 
 protected theorem tsub_lt_self_iff (ha : AddLECancellable a) : a - b < a ↔ 0 < a ∧ 0 < b := by
-  refine'
-    ⟨fun h => ⟨(zero_le _).trans_lt h, (zero_le b).lt_of_ne _⟩, fun h => ha.tsub_lt_self h.1 h.2⟩
+  refine
+    ⟨fun h => ⟨(zero_le _).trans_lt h, (zero_le b).lt_of_ne ?_⟩, fun h => ha.tsub_lt_self h.1 h.2⟩
   rintro rfl
   rw [tsub_zero] at h
   exact h.false

--- a/Mathlib/Algebra/Order/Sub/Defs.lean
+++ b/Mathlib/Algebra/Order/Sub/Defs.lean
@@ -173,7 +173,7 @@ theorem tsub_tsub_le_tsub_add {a b c : α} : a - (b - c) ≤ a - b + c :=
 /-- See `tsub_add_tsub_comm` for the equality. -/
 theorem add_tsub_add_le_tsub_add_tsub : a + b - (c + d) ≤ a - c + (b - d) := by
   rw [add_comm c, tsub_le_iff_left, add_assoc, ← tsub_le_iff_left, ← tsub_le_iff_left]
-  refine' (tsub_le_tsub_right add_tsub_le_assoc c).trans _
+  refine (tsub_le_tsub_right add_tsub_le_assoc c).trans ?_
   rw [add_comm a, add_comm (a - c)]
   exact add_tsub_le_assoc
 #align add_tsub_add_le_tsub_add_tsub add_tsub_add_le_tsub_add_tsub
@@ -387,10 +387,10 @@ section Both
 variable [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)]
 
 theorem add_tsub_add_eq_tsub_right (a c b : α) : a + c - (b + c) = a - b := by
-  refine' add_tsub_add_le_tsub_right.antisymm (tsub_le_iff_right.2 <| le_of_add_le_add_right _)
-  · exact c
-  · rw [add_assoc]
-    exact le_tsub_add
+  refine add_tsub_add_le_tsub_right.antisymm (tsub_le_iff_right.2 <| ?_)
+  apply le_of_add_le_add_right
+  rw [add_assoc]
+  exact le_tsub_add
 #align add_tsub_add_eq_tsub_right add_tsub_add_eq_tsub_right
 
 theorem add_tsub_add_eq_tsub_left (a b c : α) : a + b - (a + c) = b - c := by

--- a/Mathlib/Algebra/Order/ToIntervalMod.lean
+++ b/Mathlib/Algebra/Order/ToIntervalMod.lean
@@ -634,7 +634,7 @@ theorem tfae_modEq :
   tfae_have 1 → 4
   · intro h
     rw [h, eq_comm, toIocMod_eq_iff, Set.right_mem_Ioc]
-    refine' ⟨lt_add_of_pos_right a hp, toIcoDiv hp a b - 1, _⟩
+    refine ⟨lt_add_of_pos_right a hp, toIcoDiv hp a b - 1, ?_⟩
     rw [sub_one_zsmul, add_add_add_comm, add_right_neg, add_zero]
     conv_lhs => rw [← toIcoMod_add_toIcoDiv_zsmul hp a b, h]
   tfae_have 2 → 1

--- a/Mathlib/Algebra/Polynomial/Degree/CardPowDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/CardPowDegree.lean
@@ -62,9 +62,9 @@ noncomputable def cardPowDegree : AbsoluteValue Fq[X] ℤ :=
       · simp only [hpq, hp, hq, eq_self_iff_true, if_true, if_false]
         exact add_nonneg (pow_pos _).le (pow_pos _).le
       simp only [hpq, hp, hq, if_false]
-      refine' le_trans (pow_le_pow_right (by omega) (Polynomial.natDegree_add_le _ _)) _
-      refine'
-        le_trans (le_max_iff.mpr _)
+      refine le_trans (pow_le_pow_right (by omega) (Polynomial.natDegree_add_le _ _)) ?_
+      refine
+        le_trans (le_max_iff.mpr ?_)
           (max_le_add_of_nonneg (pow_nonneg (by omega) _) (pow_nonneg (by omega) _))
       exact (max_choice p.natDegree q.natDegree).imp (fun h => by rw [h]) fun h => by rw [h]
     map_mul' := fun p q => by

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -373,7 +373,7 @@ theorem mem_lift_of_splits_of_roots_mem_range [Algebra R K] {f : K[X]}
     (hs : f.Splits (RingHom.id K)) (hm : f.Monic) (hr : ∀ a ∈ f.roots, a ∈ (algebraMap R K).range) :
     f ∈ Polynomial.lifts (algebraMap R K) := by
   rw [eq_prod_roots_of_monic_of_splits_id hm hs, lifts_iff_liftsRing]
-  refine' Subring.multiset_prod_mem _ _ fun P hP => _
+  refine Subring.multiset_prod_mem _ _ fun P hP => ?_
   obtain ⟨b, hb, rfl⟩ := Multiset.mem_map.1 hP
   exact Subring.sub_mem _ (X_mem_lifts _) (C'_mem_lifts (hr _ hb))
 #align polynomial.mem_lift_of_splits_of_roots_mem_range Polynomial.mem_lift_of_splits_of_roots_mem_range

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -170,7 +170,7 @@ are regular. -/
 `b + a` are add-regular."]
 theorem isRegular_mul_and_mul_iff :
     IsRegular (a * b) ∧ IsRegular (b * a) ↔ IsRegular a ∧ IsRegular b := by
-  refine' ⟨_, _⟩
+  refine ⟨?_, ?_⟩
   · rintro ⟨ab, ba⟩
     exact
       ⟨⟨IsLeftRegular.of_mul ba.left, IsRightRegular.of_mul ab.right⟩,
@@ -310,7 +310,7 @@ variable [CommSemigroup R] {a b : R}
 /-- A product is regular if and only if the factors are. -/
 @[to_additive "A sum is add-regular if and only if the summands are."]
 theorem isRegular_mul_iff : IsRegular (a * b) ↔ IsRegular a ∧ IsRegular b := by
-  refine' Iff.trans _ isRegular_mul_and_mul_iff
+  refine Iff.trans ?_ isRegular_mul_and_mul_iff
   exact ⟨fun ab => ⟨ab, by rwa [mul_comm]⟩, fun rab => rab.1⟩
 #align is_regular_mul_iff isRegular_mul_iff
 #align is_add_regular_add_iff isAddRegular_add_iff

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -681,7 +681,7 @@ abbrev commRing
   { CentroidHom.instRing with
     mul_comm := fun f g ↦ by
       ext
-      refine' sub_eq_zero.1 (or_self_iff.1 <| (h _ _) fun r ↦ _)
+      refine sub_eq_zero.1 (or_self_iff.1 <| (h _ _) fun r ↦ ?_)
       rw [mul_assoc, sub_mul, sub_eq_zero, ← map_mul_right, ← map_mul_right, coe_mul, coe_mul,
         comp_mul_comm] }
 #align centroid_hom.comm_ring CentroidHom.commRing

--- a/Mathlib/Algebra/Ring/Idempotents.lean
+++ b/Mathlib/Algebra/Ring/Idempotents.lean
@@ -91,8 +91,8 @@ theorem iff_eq_one {p : G} : IsIdempotentElem p ↔ p = 1 :=
 
 @[simp]
 theorem iff_eq_zero_or_one {p : G₀} : IsIdempotentElem p ↔ p = 0 ∨ p = 1 := by
-  refine'
-    Iff.intro (fun h => or_iff_not_imp_left.mpr fun hp => _) fun h =>
+  refine
+    Iff.intro (fun h => or_iff_not_imp_left.mpr fun hp => ?_) fun h =>
       h.elim (fun hp => hp.symm ▸ zero) fun hp => hp.symm ▸ one
   exact mul_left_cancel₀ hp (h.trans (mul_one p).symm)
 #align is_idempotent_elem.iff_eq_zero_or_one IsIdempotentElem.iff_eq_zero_or_one

--- a/Mathlib/Algebra/Ring/Regular.lean
+++ b/Mathlib/Algebra/Ring/Regular.lean
@@ -19,7 +19,7 @@ variable {α : Type*}
 The typeclass that restricts all terms of `α` to have this property is `NoZeroDivisors`. -/
 theorem isLeftRegular_of_non_zero_divisor [NonUnitalNonAssocRing α] (k : α)
     (h : ∀ x : α, k * x = 0 → x = 0) : IsLeftRegular k := by
-  refine' fun x y (h' : k * x = k * y) => sub_eq_zero.mp (h _ _)
+  refine fun x y (h' : k * x = k * y) => sub_eq_zero.mp (h _ ?_)
   rw [mul_sub, sub_eq_zero, h']
 #align is_left_regular_of_non_zero_divisor isLeftRegular_of_non_zero_divisor
 
@@ -27,7 +27,7 @@ theorem isLeftRegular_of_non_zero_divisor [NonUnitalNonAssocRing α] (k : α)
 The typeclass that restricts all terms of `α` to have this property is `NoZeroDivisors`. -/
 theorem isRightRegular_of_non_zero_divisor [NonUnitalNonAssocRing α] (k : α)
     (h : ∀ x : α, x * k = 0 → x = 0) : IsRightRegular k := by
-  refine' fun x y (h' : x * k = y * k) => sub_eq_zero.mp (h _ _)
+  refine fun x y (h' : x * k = y * k) => sub_eq_zero.mp (h _ ?_)
   rw [sub_mul, sub_eq_zero, h']
 #align is_right_regular_of_non_zero_divisor isRightRegular_of_non_zero_divisor
 

--- a/Mathlib/Algebra/Star/Free.lean
+++ b/Mathlib/Algebra/Star/Free.lean
@@ -51,11 +51,12 @@ instance : StarRing (FreeAlgebra R X) where
   star_involutive x := by
     unfold Star.star
     simp only [Function.comp_apply]
-    refine' FreeAlgebra.induction R X _ _ _ _ x
+    let y := lift R (X := X) (MulOpposite.op ∘ ι R)
+    apply induction (C := fun x ↦ (y (y x).unop).unop = x) _ _ _ _ x
     · intros
       simp only [AlgHom.commutes, MulOpposite.algebraMap_apply, MulOpposite.unop_op]
     · intros
-      simp only [lift_ι_apply, Function.comp_apply, MulOpposite.unop_op]
+      simp only [y, lift_ι_apply, Function.comp_apply, MulOpposite.unop_op]
     · intros
       simp only [*, map_mul, MulOpposite.unop_mul]
     · intros

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -229,7 +229,7 @@ theorem Scheme.map_PrimeSpectrum_basicOpen_of_affine
     rw [← ΓSpec.adjunction_unit_app_app_top X]
     rfl
   · dsimp
-    refine' (Scheme.preimage_basicOpen _ _).trans _
+    refine (Scheme.preimage_basicOpen _ _).trans ?_
     congr 1
     exact IsIso.inv_hom_id_apply _ _
 #align algebraic_geometry.Scheme.map_prime_spectrum_basic_open_of_affine AlgebraicGeometry.Scheme.map_PrimeSpectrum_basicOpen_of_affine
@@ -542,7 +542,7 @@ theorem isLocalization_stalk'
   rw [iff_iff_eq]
   congr 2
   rw [RingHom.algebraMap_toAlgebra]
-  refine' (PresheafedSpace.stalkMap_germ hU.fromSpec.1 _ ⟨_, hy⟩).trans _
+  refine (PresheafedSpace.stalkMap_germ hU.fromSpec.1 _ ⟨_, hy⟩).trans ?_
   rw [IsAffineOpen.fromSpec_app_self, Category.assoc, TopCat.Presheaf.germ_res]
   rfl
 

--- a/Mathlib/AlgebraicGeometry/Gluing.lean
+++ b/Mathlib/AlgebraicGeometry/Gluing.lean
@@ -133,7 +133,7 @@ def gluedScheme : Scheme := by
   · exact (D.U i).affineCover.map y
   constructor
   · erw [TopCat.coe_comp, Set.range_comp] -- now `erw` after #13170
-    refine' Set.mem_image_of_mem _ _
+    refine Set.mem_image_of_mem _ ?_
     exact (D.U i).affineCover.Covers y
   · infer_instance
 #align algebraic_geometry.Scheme.glue_data.glued_Scheme AlgebraicGeometry.Scheme.GlueData.gluedScheme
@@ -287,7 +287,7 @@ def gluedCoverT' (x y z : 𝒰.J) :
   refine (pullbackRightPullbackFstIso _ _ _).hom ≫ ?_
   refine ?_ ≫ (pullbackSymmetry _ _).hom
   refine ?_ ≫ (pullbackRightPullbackFstIso _ _ _).inv
-  refine' pullback.map _ _ _ _ (pullbackSymmetry _ _).hom (𝟙 _) (𝟙 _) _ _
+  refine pullback.map _ _ _ _ (pullbackSymmetry _ _).hom (𝟙 _) (𝟙 _) ?_ ?_
   · simp [pullback.condition]
   · simp
 #align algebraic_geometry.Scheme.open_cover.glued_cover_t' AlgebraicGeometry.Scheme.OpenCover.gluedCoverT'

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -555,7 +555,7 @@ theorem AffineTargetMorphismProperty.IsLocal.diagonal_affine_openCover_TFAE
   · exact fun H => ⟨Y.affineCover, inferInstance, H Y.affineCover⟩
   tfae_have 2 → 5
   · rintro ⟨𝒰, h𝒰, H⟩
-    refine' ⟨𝒰, inferInstance, fun _ => Scheme.affineCover _, inferInstance, _⟩
+    refine ⟨𝒰, inferInstance, fun _ => Scheme.affineCover _, inferInstance, ?_⟩
     intro i j k
     apply H
   tfae_have 5 → 1

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -393,15 +393,13 @@ theorem exists_eq_pow_mul_of_isCompact_of_isQuasiSeparated (X : Scheme.{u}) (U :
     replace hs : S ⊓ U.1 = iSup fun i : s => (i : Opens X.carrier) := by ext1; simpa using hs
     have hs₁ : ∀ i : s, i.1.1 ≤ S := by
       intro i; change (i : Opens X.carrier) ≤ S
-      refine' le_trans _ inf_le_left; swap
-      · exact U.1
+      refine le_trans ?_ (inf_le_left (b := U.1))
       erw [hs]
       -- Porting note: have to add argument explicitly
       exact @le_iSup (Opens X) s _ (fun (i : s) => (i : Opens X)) i
     have hs₂ : ∀ i : s, i.1.1 ≤ U.1 := by
       intro i; change (i : Opens X.carrier) ≤ U
-      refine' le_trans _ inf_le_right; swap
-      · exact S
+      refine le_trans ?_ (inf_le_right (a := S))
       erw [hs]
       -- Porting note: have to add argument explicitly
       exact @le_iSup (Opens X) s _ (fun (i : s) => (i : Opens X)) i

--- a/Mathlib/AlgebraicGeometry/Pullbacks.lean
+++ b/Mathlib/AlgebraicGeometry/Pullbacks.lean
@@ -101,7 +101,7 @@ def t' (i j k : 𝒰.J) :
   refine (pullbackRightPullbackFstIso ..).hom ≫ ?_
   refine ?_ ≫ (pullbackSymmetry _ _).hom
   refine ?_ ≫ (pullbackRightPullbackFstIso ..).inv
-  refine' pullback.map _ _ _ _ (t 𝒰 f g i j) (𝟙 _) (𝟙 _) _ _
+  refine pullback.map _ _ _ _ (t 𝒰 f g i j) (𝟙 _) (𝟙 _) ?_ ?_
   · simp_rw [Category.comp_id, t_fst_fst_assoc, ← pullback.condition]
   · rw [Category.comp_id, Category.id_comp]
 #align algebraic_geometry.Scheme.pullback.t' AlgebraicGeometry.Scheme.Pullback.t'
@@ -261,7 +261,7 @@ def gluedLiftPullbackMap (i j : 𝒰.J) :
     pullback ((𝒰.pullbackCover s.fst).map i) ((𝒰.pullbackCover s.fst).map j) ⟶
       (gluing 𝒰 f g).V ⟨i, j⟩ := by
   refine (pullbackRightPullbackFstIso _ _ _).hom ≫ ?_
-  refine' pullback.map _ _ _ _ _ (𝟙 _) (𝟙 _) _ _
+  refine pullback.map _ _ _ _ ?_ (𝟙 _) (𝟙 _) ?_ ?_
   · exact (pullbackSymmetry _ _).hom ≫
       pullback.map _ _ _ _ (𝟙 _) s.snd f (Category.id_comp _).symm s.condition
   · simpa using pullback.condition
@@ -565,10 +565,10 @@ def openCoverOfBase' (𝒰 : OpenCover Z) (f : X ⟶ Z) (g : Y ⟶ Z) : OpenCove
       (𝒰.map i) pullback.snd pullback.snd g pullback.condition.symm pullback.condition.symm
       (PullbackCone.isLimitOfFlip <| pullbackIsPullback _ _)
       (PullbackCone.isLimitOfFlip <| pullbackIsPullback _ _)
-  refine'
+  refine
     @openCoverOfIsIso
       (f := (pullbackSymmetry _ _).hom ≫ (limit.isoLimitCone ⟨_, this⟩).inv ≫
-        pullback.map _ _ _ _ (𝟙 _) (𝟙 _) (𝟙 _) _ _) ?_
+        pullback.map _ _ _ _ (𝟙 _) (𝟙 _) (𝟙 _) ?_ ?_) ?_
   · simp [← pullback.condition]
   · simp only [Category.comp_id, Category.id_comp]
   · infer_instance

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -226,7 +226,7 @@ noncomputable abbrev Scheme.restrictMapIso {X Y : Scheme.{u}} (f : X ⟶ Y) [IsI
     (Y.ofRestrict _) _
   dsimp [restrict]
   rw [Set.range_comp, Subtype.range_val, Subtype.range_coe]
-  refine' @Set.image_preimage_eq _ _ f.1.base U.1 _
+  refine @Set.image_preimage_eq _ _ f.1.base U.1 ?_
   rw [← TopCat.epi_iff_surjective]
   infer_instance
 #align algebraic_geometry.Scheme.restrict_map_iso AlgebraicGeometry.Scheme.restrictMapIso
@@ -419,7 +419,7 @@ def morphismRestrictRestrictBasicOpen {X Y : Scheme.{u}} (f : X ⟶ Y) (U : Open
         (f ∣_ U ∣_
           (Y ∣_ᵤ U).basicOpen (Y.presheaf.map (eqToHom U.openEmbedding_obj_top).op r)) ≅
       Arrow.mk (f ∣_ Y.basicOpen r) := by
-  refine' morphismRestrictRestrict _ _ _ ≪≫ morphismRestrictEq _ _
+  refine morphismRestrictRestrict _ _ _ ≪≫ morphismRestrictEq _ ?_
   have e := Scheme.preimage_basicOpen (Y.ofRestrict U.openEmbedding) r
   erw [Scheme.ofRestrict_val_c_app, Opens.adjunction_counit_app_self, eqToHom_op] at e
   rw [← (Y.restrict U.openEmbedding).basicOpen_res_eq _ (eqToHom U.inclusion_map_eq_top).op]

--- a/Mathlib/AlgebraicTopology/CechNerve.lean
+++ b/Mathlib/AlgebraicTopology/CechNerve.lean
@@ -166,7 +166,7 @@ def cechNerveEquiv (X : SimplicialObject.Augmented C) (F : Arrow C) :
   right_inv := by
     intro A
     ext x : 2
-    · refine' WidePullback.hom_ext _ _ _ (fun j => _) _
+    · refine WidePullback.hom_ext _ _ _ (fun j => ?_) ?_
       · dsimp
         simp
         rfl
@@ -203,8 +203,8 @@ variable [∀ n : ℕ, HasWidePushout f.left (fun _ : Fin (n + 1) => f.right) fu
 def cechConerve : CosimplicialObject C where
   obj n := widePushout f.left (fun _ : Fin (n.len + 1) => f.right) fun _ => f.hom
   map {x y} g := by
-    refine' WidePushout.desc (WidePushout.head _)
-      (fun i => (@WidePushout.ι _ _ _ _ _ (fun _ => f.hom) ?_ (g.toOrderHom i))) (fun j => _)
+    refine WidePushout.desc (WidePushout.head _)
+      (fun i => (@WidePushout.ι _ _ _ _ _ (fun _ => f.hom) (_) (g.toOrderHom i))) (fun j => ?_)
     erw [← WidePushout.arrow_ι]
 #align category_theory.arrow.cech_conerve CategoryTheory.Arrow.cechConerve
 
@@ -314,7 +314,7 @@ def cechConerveEquiv (F : Arrow C) (X : CosimplicialObject.Augmented C) :
     intro A
     ext x : 2
     · rfl
-    · refine' WidePushout.hom_ext _ _ _ (fun j => _) _
+    · refine WidePushout.hom_ext _ _ _ (fun j => ?_) ?_
       · dsimp
         simp only [Category.assoc, ← NatTrans.naturality A.right, Arrow.augmentedCechConerve_right,
           SimplexCategory.len_mk, Arrow.cechConerve_map, colimit.ι_desc,

--- a/Mathlib/AlgebraicTopology/DoldKan/HomotopyEquivalence.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/HomotopyEquivalence.lean
@@ -33,11 +33,11 @@ variable {C : Type*} [Category C] [Preadditive C] (X : SimplicialObject C)
 noncomputable def homotopyPToId : ∀ q : ℕ, Homotopy (P q : K[X] ⟶ _) (𝟙 _)
   | 0 => Homotopy.refl _
   | q + 1 => by
-    refine'
-      Homotopy.trans (Homotopy.ofEq _)
+    refine
+      Homotopy.trans (Homotopy.ofEq ?_)
         (Homotopy.trans
           (Homotopy.add (homotopyPToId q) (Homotopy.compLeft (homotopyHσToZero q) (P q)))
-          (Homotopy.ofEq _))
+          (Homotopy.ofEq ?_))
     · simp only [P_succ, comp_add, comp_id]
     · simp only [add_zero, comp_zero]
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/AlgebraicTopology/MooreComplex.lean
+++ b/Mathlib/AlgebraicTopology/MooreComplex.lean
@@ -132,7 +132,7 @@ def map (f : X ⟶ Y) : obj X ⟶ obj Y :=
     (fun n => factorThru _ (arrow _ ≫ f.app (op (SimplexCategory.mk n))) (by
       cases n <;> dsimp
       · apply top_factors
-      · refine' (finset_inf_factors _).mpr fun i _ => kernelSubobject_factors _ _ _
+      · refine (finset_inf_factors _).mpr fun i _ => kernelSubobject_factors _ _ ?_
         erw [Category.assoc, ← f.naturality,
           ← factorThru_arrow _ _ (finset_inf_arrow_factors Finset.univ _ i (by simp)),
           Category.assoc, kernelSubobject_arrow_comp_assoc, zero_comp, comp_zero]))

--- a/Mathlib/Analysis/Asymptotics/Asymptotics.lean
+++ b/Mathlib/Analysis/Asymptotics/Asymptotics.lean
@@ -1501,10 +1501,9 @@ theorem IsBigO.const_mul_left {f : α → R} (h : f =O[l] g) (c' : R) : (fun x =
 #align asymptotics.is_O.const_mul_left Asymptotics.IsBigO.const_mul_left
 
 theorem isBigOWith_self_const_mul' (u : Rˣ) (f : α → R) (l : Filter α) :
-    IsBigOWith ‖(↑u⁻¹ : R)‖ l f fun x => ↑u * f x := by
-  refine' (isBigOWith_const_mul_self ↑u⁻¹ _ l).congr_left _
-  exact fun x => u.inv_mul_cancel_left (f x)
-  -- Porting note: Lean just had trouble elaborating correctly, but this fixes it.
+    IsBigOWith ‖(↑u⁻¹ : R)‖ l f fun x => ↑u * f x :=
+  (isBigOWith_const_mul_self ↑u⁻¹ (fun x ↦ ↑u * f x) l).congr_left
+    fun x ↦ u.inv_mul_cancel_left (f x)
 #align asymptotics.is_O_with_self_const_mul' Asymptotics.isBigOWith_self_const_mul'
 
 theorem isBigOWith_self_const_mul (c : 𝕜) (hc : c ≠ 0) (f : α → 𝕜) (l : Filter α) :

--- a/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
@@ -205,7 +205,7 @@ def upperSubLower.{u} {G : Type u} [AddCommGroup G] (I₀ : Box (Fin (n + 1))) (
     (by
       intro J hJ j x
       rw [WithTop.coe_le_coe] at hJ
-      refine' i.succAboveCases (fun hx => _) (fun j hx => _) j
+      refine i.succAboveCases (fun hx => ?_) (fun j hx => ?_) j
       · simp only [Box.splitLower_def hx, Box.splitUpper_def hx, update_same, ← WithBot.some_eq_coe,
           Option.elim', Box.face, (· ∘ ·), update_noteq (Fin.succAbove_ne _ _)]
         abel

--- a/Mathlib/Analysis/Convex/Strict.lean
+++ b/Mathlib/Analysis/Convex/Strict.lean
@@ -346,8 +346,8 @@ theorem StrictConvex.add_smul_mem (hs : StrictConvex 𝕜 s) (hx : x ∈ s) (hxy
   have h : x + t • y = (1 - t) • x + t • (x + y) := by
     rw [smul_add, ← add_assoc, ← _root_.add_smul, sub_add_cancel, one_smul]
   rw [h]
-  refine' hs hx hxy (fun h => hy <| add_left_cancel _) (sub_pos_of_lt ht₁) ht₀ (sub_add_cancel _ _)
-  rw [← h, add_zero]
+  exact hs hx hxy (fun h => hy <| add_left_cancel (a := x) (by rw [← h, add_zero]))
+    (sub_pos_of_lt ht₁) ht₀ (sub_add_cancel 1 t)
 #align strict_convex.add_smul_mem StrictConvex.add_smul_mem
 
 theorem StrictConvex.smul_mem_of_zero_mem (hs : StrictConvex 𝕜 s) (zero_mem : (0 : E) ∈ s)

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -490,7 +490,7 @@ theorem hasDerivAt_fourier (n : ℤ) (x : ℝ) :
   simp_rw [fourier_coe_apply]
   refine (?_ : HasDerivAt (fun y => exp (2 * π * I * n * y / T)) _ _).comp_ofReal
   rw [(fun α β => by ring : ∀ α β : ℂ, α * exp β = exp β * α)]
-  refine' (hasDerivAt_exp _).comp ↑x _
+  refine (hasDerivAt_exp _).comp (x : ℂ) ?_
   convert hasDerivAt_mul_const (2 * ↑π * I * ↑n / T) using 1
   ext1 y; ring
 #align has_deriv_at_fourier hasDerivAt_fourier

--- a/Mathlib/Analysis/InnerProductSpace/Calculus.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Calculus.lean
@@ -378,7 +378,7 @@ variable {n : ℕ∞} {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ 
 theorem PartialHomeomorph.contDiff_univUnitBall : ContDiff ℝ n (univUnitBall : E → E) := by
   suffices ContDiff ℝ n fun x : E => (√(1 + ‖x‖ ^ 2 : ℝ))⁻¹ from this.smul contDiff_id
   have h : ∀ x : E, (0 : ℝ) < (1 : ℝ) + ‖x‖ ^ 2 := fun x => by positivity
-  refine' ContDiff.inv _ fun x => Real.sqrt_ne_zero'.mpr (h x)
+  refine ContDiff.inv ?_ fun x => Real.sqrt_ne_zero'.mpr (h x)
   exact (contDiff_const.add <| contDiff_norm_sq ℝ).sqrt fun x => (h x).ne'
 
 theorem PartialHomeomorph.contDiffOn_univUnitBall_symm :
@@ -387,8 +387,8 @@ theorem PartialHomeomorph.contDiffOn_univUnitBall_symm :
   suffices ContDiffAt ℝ n (fun y : E => (√(1 - ‖y‖ ^ 2 : ℝ))⁻¹) y from this.smul contDiffAt_id
   have h : (0 : ℝ) < (1 : ℝ) - ‖(y : E)‖ ^ 2 := by
     rwa [mem_ball_zero_iff, ← _root_.abs_one, ← abs_norm, ← sq_lt_sq, one_pow, ← sub_pos] at hy
-  refine' ContDiffAt.inv _ (Real.sqrt_ne_zero'.mpr h)
-  refine' (contDiffAt_sqrt h.ne').comp y _
+  refine ContDiffAt.inv ?_ (Real.sqrt_ne_zero'.mpr h)
+  refine (contDiffAt_sqrt h.ne').comp y ?_
   exact contDiffAt_const.sub (contDiff_norm_sq ℝ).contDiffAt
 
 theorem Homeomorph.contDiff_unitBall : ContDiff ℝ n fun x : E => (unitBall x : E) :=

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -873,7 +873,7 @@ instance (priority := 100) NormedDivisionRing.to_hasContinuousInv₀ : HasContin
       _ = ‖r - e‖ / ‖r‖ / ‖e‖ := by field_simp [mul_comm]
       _ ≤ ‖r - e‖ / ‖r‖ / ε := by gcongr
   refine squeeze_zero' (eventually_of_forall fun _ => norm_nonneg _) this ?_
-  refine' (((continuous_const.sub continuous_id).norm.div_const _).div_const _).tendsto' _ _ _
+  refine (((continuous_const.sub continuous_id).norm.div_const _).div_const _).tendsto' _ _ ?_
   simp
 #align normed_division_ring.to_has_continuous_inv₀ NormedDivisionRing.to_hasContinuousInv₀
 

--- a/Mathlib/Analysis/Normed/Group/Pointwise.lean
+++ b/Mathlib/Analysis/Normed/Group/Pointwise.lean
@@ -30,7 +30,7 @@ variable [SeminormedGroup E] {ε δ : ℝ} {s t : Set E} {x y : E}
 theorem Bornology.IsBounded.mul (hs : IsBounded s) (ht : IsBounded t) : IsBounded (s * t) := by
   obtain ⟨Rs, hRs⟩ : ∃ R, ∀ x ∈ s, ‖x‖ ≤ R := hs.exists_norm_le'
   obtain ⟨Rt, hRt⟩ : ∃ R, ∀ x ∈ t, ‖x‖ ≤ R := ht.exists_norm_le'
-  refine' isBounded_iff_forall_norm_le'.2 ⟨Rs + Rt, _⟩
+  refine isBounded_iff_forall_norm_le'.2 ⟨Rs + Rt, ?_⟩
   rintro z ⟨x, hx, y, hy, rfl⟩
   exact norm_mul_le_of_le (hRs x hx) (hRt y hy)
 #align metric.bounded.mul Bornology.IsBounded.mul

--- a/Mathlib/Analysis/NormedSpace/FiniteDimension.lean
+++ b/Mathlib/Analysis/NormedSpace/FiniteDimension.lean
@@ -585,7 +585,7 @@ def ContinuousLinearEquiv.piRing (ι : Type*) [Fintype ι] [DecidableEq ι] :
         LinearMap.coe_toContinuousLinearMap', LinearEquiv.piRing_symm_apply]
       apply le_trans (norm_sum_le _ _)
       rw [smul_mul_assoc]
-      refine' Finset.sum_le_card_nsmul _ _ _ fun i _ => _
+      refine Finset.sum_le_card_nsmul _ _ _ fun i _ => ?_
       rw [norm_smul, mul_comm]
       gcongr <;> apply norm_le_pi_norm }
 #align continuous_linear_equiv.pi_ring ContinuousLinearEquiv.piRing

--- a/Mathlib/Analysis/NormedSpace/PiLp.lean
+++ b/Mathlib/Analysis/NormedSpace/PiLp.lean
@@ -376,12 +376,12 @@ abbrev pseudoMetricAux : PseudoMetricSpace (PiLp p α) :=
     · rw [edist_eq_iSup, dist_eq_iSup]
       cases isEmpty_or_nonempty ι
       · simp only [Real.iSup_of_isEmpty, ciSup_of_empty, ENNReal.bot_eq_zero, ENNReal.zero_toReal]
-      · refine' le_antisymm (ciSup_le fun i => _) _
+      · refine le_antisymm (ciSup_le fun i => ?_) ?_
         · rw [← ENNReal.ofReal_le_iff_le_toReal (iSup_edist_ne_top_aux f g), ←
             PseudoMetricSpace.edist_dist]
           -- Porting note: `le_iSup` needed some help
           exact le_iSup (fun k => edist (f k) (g k)) i
-        · refine' ENNReal.toReal_le_of_le_ofReal (Real.sSup_nonneg _ _) (iSup_le fun i => _)
+        · refine ENNReal.toReal_le_of_le_ofReal (Real.sSup_nonneg _ ?_) (iSup_le fun i => ?_)
           · rintro - ⟨i, rfl⟩
             exact dist_nonneg
           · change PseudoMetricSpace.edist _ _ ≤ _

--- a/Mathlib/Analysis/NormedSpace/ProdLp.lean
+++ b/Mathlib/Analysis/NormedSpace/ProdLp.lean
@@ -368,7 +368,7 @@ abbrev prodPseudoMetricAux [PseudoMetricSpace α] [PseudoMetricSpace β] :
     fun f g => by
     rcases p.dichotomy with (rfl | h)
     · rw [prod_edist_eq_sup, prod_dist_eq_sup]
-      refine' le_antisymm (sup_le _ _) _
+      refine le_antisymm (sup_le ?_ ?_) ?_
       · rw [← ENNReal.ofReal_le_iff_le_toReal (prod_sup_edist_ne_top_aux f g),
           ← PseudoMetricSpace.edist_dist]
         exact le_sup_left

--- a/Mathlib/Analysis/NormedSpace/Star/ContinuousFunctionalCalculus/Restrict.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/ContinuousFunctionalCalculus/Restrict.lean
@@ -254,7 +254,7 @@ protected theorem cfc (f : C(S, R)) (halg : UniformEmbedding (algebraMap R S))
         exact ⟨_, this⟩
       · rintro ⟨y, rfl⟩
         rw [Set.mem_preimage]
-        refine' ⟨⟨algebraMap R S y, quasispectrum.algebraMap_mem S y.prop⟩, _⟩
+        refine ⟨⟨algebraMap R S y, quasispectrum.algebraMap_mem S y.prop⟩, ?_⟩
         simp only [nonUnitalStarAlgHom_postcomp_apply, NonUnitalStarAlgHom.coe_coe,
           Function.comp_apply, comp_apply, coe_mk, ContinuousMap.coe_mk, StarAlgHom.ofId_apply]
         congr

--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -400,7 +400,7 @@ variable {α : Type*} [LinearOrderedField α]
 set_option tactic.skipAssignedInstances false in
 theorem sum_Ioc_inv_sq_le_sub {k n : ℕ} (hk : k ≠ 0) (h : k ≤ n) :
     (∑ i ∈ Ioc k n, ((i : α) ^ 2)⁻¹) ≤ (k : α)⁻¹ - (n : α)⁻¹ := by
-  refine' Nat.le_induction _ _ n h
+  refine Nat.le_induction ?_ ?_ n h
   · simp only [Ioc_self, sum_empty, sub_self, le_refl]
   intro n hn IH
   rw [sum_Ioc_succ_top hn]

--- a/Mathlib/Analysis/Seminorm.lean
+++ b/Mathlib/Analysis/Seminorm.lean
@@ -482,7 +482,7 @@ noncomputable instance instInf : Inf (Seminorm 𝕜 E) where
         intro a x
         obtain rfl | ha := eq_or_ne a 0
         · rw [norm_zero, zero_mul, zero_smul]
-          refine'
+          refine
             ciInf_eq_of_forall_ge_of_forall_gt_exists_lt
               -- Porting note: the following was previously `fun i => by positivity`
               (fun i => add_nonneg (apply_nonneg _ _) (apply_nonneg _ _))

--- a/Mathlib/Analysis/SpecialFunctions/Complex/LogDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/LogDeriv.lean
@@ -36,7 +36,7 @@ noncomputable def expPartialHomeomorph : PartialHomeomorph ℂ ℂ :=
       target := slitPlane
       map_source' := by
         rintro ⟨x, y⟩ ⟨h₁ : -π < y, h₂ : y < π⟩
-        refine' (not_or_of_imp fun hz => _).symm
+        refine (not_or_of_imp fun hz => ?_).symm
         obtain rfl : y = 0 := by
           rw [exp_im] at hz
           simpa [(Real.exp_pos _).ne', Real.sin_eq_zero_iff_of_lt_of_lt h₁ h₂] using hz

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
@@ -290,22 +290,18 @@ theorem ge_logGammaSeq (hf_conv : ConvexOn ℝ (Ioi 0) f)
 theorem tendsto_logGammaSeq_of_le_one (hf_conv : ConvexOn ℝ (Ioi 0) f)
     (hf_feq : ∀ {y : ℝ}, 0 < y → f (y + 1) = f y + log y) (hx : 0 < x) (hx' : x ≤ 1) :
     Tendsto (logGammaSeq x) atTop (𝓝 <| f x - f 1) := by
-  refine' tendsto_of_tendsto_of_tendsto_of_le_of_le' _ tendsto_const_nhds _ _
-  -- Porting note: `show` no longer reorders goals
-  pick_goal 4
-  · show ∀ᶠ n : ℕ in atTop, logGammaSeq x n ≤ f x - f 1
-    filter_upwards [eventually_ne_atTop 0] with n hn using
-      le_sub_iff_add_le'.mpr (ge_logGammaSeq hf_conv hf_feq hx hn)
-  -- Porting note: `show` no longer reorders goals
-  pick_goal 3
-  · show ∀ᶠ n : ℕ in atTop, f x - f 1 - x * (log (n + 1) - log n) ≤ logGammaSeq x n
-    filter_upwards with n
-    rw [sub_le_iff_le_add', sub_le_iff_le_add']
-    convert le_logGammaSeq hf_conv (@hf_feq) hx hx' n using 1
-    ring
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le' (f := logGammaSeq x)
+    (g := fun n ↦ f x - f 1 - x * (log (n + 1) - log n)) ?_ tendsto_const_nhds ?_ ?_
   · have : f x - f 1 = f x - f 1 - x * 0 := by ring
     nth_rw 2 [this]
     exact Tendsto.sub tendsto_const_nhds (tendsto_log_nat_add_one_sub_log.const_mul _)
+  · filter_upwards with n
+    rw [sub_le_iff_le_add', sub_le_iff_le_add']
+    convert le_logGammaSeq hf_conv (@hf_feq) hx hx' n using 1
+    ring
+  · show ∀ᶠ n : ℕ in atTop, logGammaSeq x n ≤ f x - f 1
+    filter_upwards [eventually_ne_atTop 0] with n hn using
+      le_sub_iff_add_le'.mpr (ge_logGammaSeq hf_conv hf_feq hx hn)
 #align real.bohr_mollerup.tendsto_log_gamma_seq_of_le_one Real.BohrMollerup.tendsto_logGammaSeq_of_le_one
 
 theorem tendsto_logGammaSeq (hf_conv : ConvexOn ℝ (Ioi 0) f)

--- a/Mathlib/Analysis/SpecialFunctions/Gaussian/FourierTransform.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian/FourierTransform.lean
@@ -88,8 +88,8 @@ theorem verticalIntegral_norm_le (hb : 0 < b.re) (c : ℝ) {T : ℝ} (hT : 0 ≤
       gcongr
     · rwa [sq_le_sq]
   -- now main proof
-  refine' (intervalIntegral.norm_integral_le_of_norm_le_const _).trans _
-  pick_goal 3
+  apply (intervalIntegral.norm_integral_le_of_norm_le_const _).trans
+  pick_goal 1
   · rw [sub_zero]
     conv_lhs => simp only [mul_comm _ |c|]
     conv_rhs =>

--- a/Mathlib/Analysis/SpecialFunctions/Stirling.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Stirling.lean
@@ -134,7 +134,7 @@ theorem log_stirlingSeq_sub_log_stirlingSeq_succ (n : ℕ) :
     rw [← mul_lt_mul_right h₃]
     have H : 0 < (2 * ((n : ℝ) + 1) + 1) ^ 2 - 1 := by nlinarith [@cast_nonneg ℝ _ n]
     convert H using 1 <;> field_simp [h₃.ne']
-  refine' (log_stirlingSeq_diff_le_geo_sum n).trans _
+  refine (log_stirlingSeq_diff_le_geo_sum n).trans ?_
   push_cast
   rw [div_le_div_iff h₂ h₁]
   field_simp [h₃.ne']

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -97,7 +97,7 @@ statement simultaneously on `ℚ`, `ℝ` and `ℂ`. -/
 theorem tendsto_natCast_div_add_atTop {𝕜 : Type*} [DivisionRing 𝕜] [TopologicalSpace 𝕜]
     [CharZero 𝕜] [Algebra ℝ 𝕜] [ContinuousSMul ℝ 𝕜] [TopologicalDivisionRing 𝕜] (x : 𝕜) :
     Tendsto (fun n : ℕ ↦ (n : 𝕜) / (n + x)) atTop (𝓝 1) := by
-  refine' Tendsto.congr' ((eventually_ne_atTop 0).mp (eventually_of_forall fun n hn ↦ _)) _
+  convert Tendsto.congr' ((eventually_ne_atTop 0).mp (eventually_of_forall fun n hn ↦ _)) _
   · exact fun n : ℕ ↦ 1 / (1 + x / n)
   · field_simp [Nat.cast_ne_zero.mpr hn]
   · have : 𝓝 (1 : 𝕜) = 𝓝 (1 / (1 + x * (0 : 𝕜))) := by
@@ -364,8 +364,8 @@ theorem ENNReal.tsum_geometric (r : ℝ≥0∞) : ∑' n : ℕ, r ^ n = (1 - r)�
     convert ENNReal.tsum_coe_eq (NNReal.hasSum_geometric hr)
     rw [ENNReal.coe_inv <| ne_of_gt <| tsub_pos_iff_lt.2 hr, coe_sub, coe_one]
   · rw [tsub_eq_zero_iff_le.mpr hr, ENNReal.inv_zero, ENNReal.tsum_eq_iSup_nat, iSup_eq_top]
-    refine' fun a ha ↦
-      (ENNReal.exists_nat_gt (lt_top_iff_ne_top.1 ha)).imp fun n hn ↦ lt_of_lt_of_le hn _
+    refine fun a ha ↦
+      (ENNReal.exists_nat_gt (lt_top_iff_ne_top.1 ha)).imp fun n hn ↦ lt_of_lt_of_le hn ?_
     calc
       (n : ℝ≥0∞) = ∑ i ∈ range n, 1 := by rw [sum_const, nsmul_one, card_range]
       _ ≤ ∑ i ∈ range n, r ^ i := by gcongr; apply one_le_pow_of_one_le' hr

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -173,14 +173,14 @@ theorem TFAE_exists_lt_isLittleO_pow (f : ℕ → ℝ) (R : ℝ) :
   -- Add 7 and 8 using 2 → 8 → 7 → 3
   tfae_have 2 → 8
   · rintro ⟨a, ha, H⟩
-    refine' ⟨a, ha, (H.def zero_lt_one).mono fun n hn ↦ _⟩
+    refine ⟨a, ha, (H.def zero_lt_one).mono fun n hn ↦ ?_⟩
     rwa [Real.norm_eq_abs, Real.norm_eq_abs, one_mul, abs_pow, abs_of_pos ha.1] at hn
   tfae_have 8 → 7
   · exact fun ⟨a, ha, H⟩ ↦ ⟨a, ha.2, H⟩
   tfae_have 7 → 3
   · rintro ⟨a, ha, H⟩
     have : 0 ≤ a := nonneg_of_eventually_pow_nonneg (H.mono fun n ↦ (abs_nonneg _).trans)
-    refine' ⟨a, A ⟨this, ha⟩, IsBigO.of_bound 1 _⟩
+    refine ⟨a, A ⟨this, ha⟩, IsBigO.of_bound 1 ?_⟩
     simpa only [Real.norm_eq_abs, one_mul, abs_pow, abs_of_nonneg this]
   -- Porting note: used to work without explicitly having 6 → 7
   tfae_have 6 → 7
@@ -467,8 +467,8 @@ theorem NormedAddCommGroup.cauchy_series_of_le_geometric'' {C : ℝ} {u : ℕ �
   have : ∀ n ≥ N, u n = v n := by
     intro n hn
     simp [v, hn, if_neg (not_lt.mpr hn)]
-  refine'
-    cauchySeq_sum_of_eventually_eq this (NormedAddCommGroup.cauchy_series_of_le_geometric' hr₁ _)
+  apply cauchySeq_sum_of_eventually_eq this
+    (NormedAddCommGroup.cauchy_series_of_le_geometric' hr₁ _)
   · exact C
   intro n
   simp only [v]
@@ -510,9 +510,9 @@ theorem NormedRing.tsum_geometric_of_norm_lt_one (x : R) (h : ‖x‖ < 1) :
     ‖∑' n : ℕ, x ^ n‖ ≤ ‖(1 : R)‖ - 1 + (1 - ‖x‖)⁻¹ := by
   rw [tsum_eq_zero_add (summable_geometric_of_norm_lt_one x h)]
   simp only [_root_.pow_zero]
-  refine' le_trans (norm_add_le _ _) _
+  refine le_trans (norm_add_le _ _) ?_
   have : ‖∑' b : ℕ, (fun n ↦ x ^ (n + 1)) b‖ ≤ (1 - ‖x‖)⁻¹ - 1 := by
-    refine' tsum_of_norm_bounded _ fun b ↦ norm_pow_le' _ (Nat.succ_pos b)
+    refine tsum_of_norm_bounded ?_ fun b ↦ norm_pow_le' _ (Nat.succ_pos b)
     convert (hasSum_nat_add_iff' 1).mpr (hasSum_geometric_of_lt_one (norm_nonneg x) h)
     simp
   linarith

--- a/Mathlib/CategoryTheory/Abelian/EpiWithInjectiveKernel.lean
+++ b/Mathlib/CategoryTheory/Abelian/EpiWithInjectiveKernel.lean
@@ -62,7 +62,7 @@ instance : (epiWithInjectiveKernel : MorphismProperty C).IsMultiplicative where
     rw [epiWithInjectiveKernel_iff] at hg₁ hg₂ ⊢
     obtain ⟨I₁, _, f₁, w₁, ⟨σ₁⟩⟩ := hg₁
     obtain ⟨I₂, _, f₂, w₂, ⟨σ₂⟩⟩ := hg₂
-    refine' ⟨I₁ ⊞ I₂, inferInstance, biprod.fst ≫ f₁ + biprod.snd ≫ f₂ ≫ σ₁.s, _, ⟨_⟩⟩
+    refine ⟨I₁ ⊞ I₂, inferInstance, biprod.fst ≫ f₁ + biprod.snd ≫ f₂ ≫ σ₁.s, ?_, ⟨?_⟩⟩
     · ext
       · simp [reassoc_of% w₁]
       · simp [reassoc_of% σ₁.s_g, w₂]

--- a/Mathlib/CategoryTheory/Abelian/Subobject.lean
+++ b/Mathlib/CategoryTheory/Abelian/Subobject.lean
@@ -36,7 +36,8 @@ def subobjectIsoSubobjectOp [Abelian C] (X : C) : Subobject X ≃o (Subobject (o
     intro A f hf
     dsimp only [OrderHom.comp_coe, Function.comp_apply, kernelOrderHom_coe, Subobject.lift_mk,
       cokernelOrderHom_coe, OrderHom.id_coe, id]
-    refine' Subobject.mk_eq_mk_of_comm _ _ ⟨_, _, Quiver.Hom.unop_inj _, Quiver.Hom.unop_inj _⟩ _
+    refine Subobject.mk_eq_mk_of_comm _ _
+        ⟨?_, ?_, Quiver.Hom.unop_inj ?_, Quiver.Hom.unop_inj ?_⟩ ?_
     · exact (Abelian.epiDesc f.unop _ (cokernel.condition (kernel.ι f.unop))).op
     · exact (cokernel.desc _ _ (kernel.condition f.unop)).op
     · rw [← cancel_epi (cokernel.π (kernel.ι f.unop))]
@@ -50,7 +51,7 @@ def subobjectIsoSubobjectOp [Abelian C] (X : C) : Subobject X ≃o (Subobject (o
     intro A f hf
     dsimp only [OrderHom.comp_coe, Function.comp_apply, cokernelOrderHom_coe, Subobject.lift_mk,
       kernelOrderHom_coe, OrderHom.id_coe, id, unop_op, Quiver.Hom.unop_op]
-    refine' Subobject.mk_eq_mk_of_comm _ _ ⟨_, _, _, _⟩ _
+    refine Subobject.mk_eq_mk_of_comm _ _ ⟨?_, ?_, ?_, ?_⟩ ?_
     · exact Abelian.monoLift f _ (kernel.condition (cokernel.π f))
     · exact kernel.lift _ _ (cokernel.condition f)
     · simp only [← cancel_mono (kernel.ι (cokernel.π f)), Category.assoc, image.fac, monoLift_comp,

--- a/Mathlib/CategoryTheory/Adjunction/Lifting.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting.lean
@@ -153,7 +153,7 @@ noncomputable def constructLeftAdjointEquiv [∀ X : B, RegularEpi (adj₁.couni
 
 /-- Construct the left adjoint to `R`, with object map `constructLeftAdjointObj`. -/
 noncomputable def constructLeftAdjoint [∀ X : B, RegularEpi (adj₁.counit.app X)] : B ⥤ A := by
-  refine' Adjunction.leftAdjointOfEquiv (fun X Y => constructLeftAdjointEquiv R _ adj₁ adj₂ Y X) _
+  refine Adjunction.leftAdjointOfEquiv (fun X Y => constructLeftAdjointEquiv R _ adj₁ adj₂ Y X) ?_
   intro X Y Y' g h
   rw [constructLeftAdjointEquiv_apply, constructLeftAdjointEquiv_apply,
     Equiv.symm_apply_eq, Subtype.ext_iff]

--- a/Mathlib/CategoryTheory/Category/PartialFun.lean
+++ b/Mathlib/CategoryTheory/Category/PartialFun.lean
@@ -145,7 +145,7 @@ noncomputable def partialFunEquivPointed : PartialFun.{u} ≌ Pointed :=
           -- `Part.mem_bind_iff` means that `b ∈ Part.bind f g` is equivalent
           -- to `∃ (a : α), a ∈ f ∧ b ∈ g a`, while in mathlib3 it was equivalent
           -- to `∃ (a : α) (H : a ∈ f), b ∈ g a`
-          refine' (Part.mem_bind_iff.trans _).trans PFun.mem_toSubtype_iff.symm
+          refine (Part.mem_bind_iff.trans ?_).trans PFun.mem_toSubtype_iff.symm
           obtain ⟨b | b, hb⟩ := b
           · exact (hb rfl).elim
           · dsimp [Part.toOption]

--- a/Mathlib/CategoryTheory/DifferentialObject.lean
+++ b/Mathlib/CategoryTheory/DifferentialObject.lean
@@ -274,7 +274,7 @@ def shiftFunctor (n : S) : DifferentialObject S C ⥤ DifferentialObject S C whe
 @[simps!]
 nonrec def shiftFunctorAdd (m n : S) :
     shiftFunctor C (m + n) ≅ shiftFunctor C m ⋙ shiftFunctor C n := by
-  refine' NatIso.ofComponents (fun X => mkIso (shiftAdd X.obj _ _) _) (fun f => _)
+  refine NatIso.ofComponents (fun X => mkIso (shiftAdd X.obj _ _) ?_) (fun f => ?_)
   · dsimp
     rw [← cancel_epi ((shiftFunctorAdd C m n).inv.app X.obj)]
     simp only [Category.assoc, Iso.inv_hom_id_app_assoc]

--- a/Mathlib/CategoryTheory/GradedObject/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Trifunctor.lean
@@ -320,15 +320,15 @@ noncomputable def isColimitCofan₃MapBifunctor₁₂BifunctorMapObj (j : J) :
     fun ⟨⟨i₁₂, i₃⟩, hi⟩ => by
       refine (Cocones.precompose (Iso.hom ?_)).obj ((Cocones.whiskeringEquivalence
         (Discrete.equivalence (e i₁₂ i₃))).functor.obj (c₁₂' ⟨⟨i₁₂, i₃⟩, hi⟩))
-      refine' (Discrete.natIso (fun ⟨⟨i₁, i₂, i₃'⟩, hi⟩ =>
-        (G.obj ((F₁₂.obj (X₁ i₁)).obj (X₂ i₂))).mapIso (eqToIso _)))
+      refine (Discrete.natIso (fun ⟨⟨i₁, i₂, i₃'⟩, hi⟩ =>
+        (G.obj ((F₁₂.obj (X₁ i₁)).obj (X₂ i₂))).mapIso (eqToIso ?_)))
       obtain rfl : i₃' = i₃ := congr_arg _root_.Prod.snd hi
       rfl
   have h₁₂'' : ∀ i, IsColimit (c₁₂'' i) := fun _ =>
     (IsColimit.precomposeHomEquiv _ _).symm (IsColimit.whiskerEquivalenceEquiv _ (hc₁₂' _))
-  refine' IsColimit.ofIsoColimit (isColimitCofanMapObjComp Z p' ρ₁₂.q r ρ₁₂.hpq j
+  refine IsColimit.ofIsoColimit (isColimitCofanMapObjComp Z p' ρ₁₂.q r ρ₁₂.hpq j
     (fun ⟨i₁₂, i₃⟩ h => c₁₂'' ⟨⟨i₁₂, i₃⟩, h⟩) (fun ⟨i₁₂, i₃⟩ h => h₁₂'' ⟨⟨i₁₂, i₃⟩, h⟩) c hc)
-    (Cocones.ext (Iso.refl _) (fun ⟨⟨i₁, i₂, i₃⟩, h⟩ => _))
+    (Cocones.ext (Iso.refl _) (fun ⟨⟨i₁, i₂, i₃⟩, h⟩ => ?_))
   dsimp [Cofan.inj, c₁₂'', Z]
   rw [comp_id, Functor.map_id, id_comp]
   rfl
@@ -466,9 +466,9 @@ noncomputable def isColimitCofan₃MapBifunctorBifunctor₂₃MapObj (j : J) :
       rfl
   have h₂₃'' : ∀ i, IsColimit (c₂₃'' i) := fun _ =>
     (IsColimit.precomposeHomEquiv _ _).symm (IsColimit.whiskerEquivalenceEquiv _ (hc₂₃' _))
-  refine' IsColimit.ofIsoColimit (isColimitCofanMapObjComp Z p' ρ₂₃.q r ρ₂₃.hpq j
+  refine IsColimit.ofIsoColimit (isColimitCofanMapObjComp Z p' ρ₂₃.q r ρ₂₃.hpq j
     (fun ⟨i₁, i₂₃⟩ h => c₂₃'' ⟨⟨i₁, i₂₃⟩, h⟩) (fun ⟨i₁, i₂₃⟩ h => h₂₃'' ⟨⟨i₁, i₂₃⟩, h⟩) c hc)
-    (Cocones.ext (Iso.refl _) (fun ⟨⟨i₁, i₂, i₃⟩, h⟩ => _))
+    (Cocones.ext (Iso.refl _) (fun ⟨⟨i₁, i₂, i₃⟩, h⟩ => ?_))
   dsimp [Cofan.inj, c₂₃'']
   rw [comp_id, id_comp]
   rfl

--- a/Mathlib/CategoryTheory/Limits/Constructions/Equalizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Equalizers.lean
@@ -201,7 +201,7 @@ def preservesCoequalizersOfPreservesPushoutsAndBinaryCoproducts [HasBinaryCoprod
   ⟨fun {K} =>
     preservesColimitOfPreservesColimitCocone (coequalizerCoconeIsColimit K) <|
       { desc := fun c => by
-          refine' (PreservesPushout.iso _ _ _).inv ≫ pushout.desc _ _ _
+          refine (PreservesPushout.iso _ _ _).inv ≫ pushout.desc ?_ ?_ ?_
           · exact c.ι.app WalkingParallelPair.one
           · exact c.ι.app WalkingParallelPair.one
           apply (mapIsColimitOfPreservesOfIsColimit G _ _ (coprodIsCoprod _ _)).hom_ext

--- a/Mathlib/CategoryTheory/Limits/Constructions/FiniteProductsOfBinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/FiniteProductsOfBinaryProducts.lean
@@ -131,7 +131,7 @@ noncomputable def preservesFinOfPreservesBinaryAndTerminal :
   | n + 1 => by
     haveI := preservesFinOfPreservesBinaryAndTerminal n
     intro f
-    refine'
+    apply
       preservesLimitOfPreservesLimitCone
         (extendFanIsLimit f (limit.isLimit _) (limit.isLimit _)) _
     apply (isLimitMapConeFanMkEquiv _ _ _).symm _
@@ -270,7 +270,7 @@ noncomputable def preservesFinOfPreservesBinaryAndInitial :
   | n + 1 => by
     haveI := preservesFinOfPreservesBinaryAndInitial n
     intro f
-    refine'
+    apply
       preservesColimitOfPreservesColimitCocone
         (extendCofanIsColimit f (colimit.isColimit _) (colimit.isColimit _)) _
     apply (isColimitMapCoconeCofanMkEquiv _ _ _).symm _

--- a/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/LimitsOfProductsAndEqualizers.lean
@@ -177,7 +177,7 @@ noncomputable def preservesLimitOfPreservesEqualizersAndProduct : PreservesLimit
       preservesLimitOfPreservesLimitCone
         (buildIsLimit s t (by simp [s]) (by simp [t]) (limit.isLimit _) (limit.isLimit _)
           (limit.isLimit _))
-    refine' IsLimit.ofIsoLimit (buildIsLimit _ _ _ _ _ _ _) _
+    apply IsLimit.ofIsoLimit (buildIsLimit _ _ _ _ _ _ _) _
     · exact Fan.mk _ fun j => G.map (Pi.π _ j)
     · exact Fan.mk (G.obj Q) fun f => G.map (Pi.π _ f)
     · apply G.map s
@@ -403,7 +403,7 @@ noncomputable def preservesColimitOfPreservesCoequalizersAndCoproduct :
       preservesColimitOfPreservesColimitCocone
         (buildIsColimit s t (by simp [s]) (by simp [t]) (colimit.isColimit _) (colimit.isColimit _)
           (colimit.isColimit _))
-    refine' IsColimit.ofIsoColimit (buildIsColimit _ _ _ _ _ _ _) _
+    apply IsColimit.ofIsoColimit (buildIsColimit _ _ _ _ _ _ _) _
     · refine Cofan.mk (G.obj Q) fun j => G.map ?_
       apply Sigma.ι _ j
     -- fun j => G.map (Sigma.ι _ j)
@@ -426,7 +426,7 @@ noncomputable def preservesColimitOfPreservesCoequalizersAndCoproduct :
     · apply isColimitOfHasCoproductOfPreservesColimit
     · apply isColimitCoforkMapOfIsColimit
       apply coequalizerIsCoequalizer
-    refine' Cocones.ext (Iso.refl _) _
+    refine Cocones.ext (Iso.refl _) ?_
     intro j
     dsimp
     simp

--- a/Mathlib/CategoryTheory/Limits/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Limits/Presheaf.lean
@@ -377,9 +377,9 @@ noncomputable def natIsoOfNatIsoOnRepresentables (L₁ L₂ : (Cᵒᵖ ⥤ Type 
     [PreservesColimits L₁] [PreservesColimits L₂] (h : yoneda ⋙ L₁ ≅ yoneda ⋙ L₂) : L₁ ≅ L₂ := by
   apply NatIso.ofComponents _ _
   · intro P
-    refine'
+    refine
       (isColimitOfPreserves L₁ (colimitOfRepresentable P)).coconePointsIsoOfNatIso
-        (isColimitOfPreserves L₂ (colimitOfRepresentable P)) _
+        (isColimitOfPreserves L₂ (colimitOfRepresentable P)) ?_
     apply Functor.associator _ _ _ ≪≫ _
     exact isoWhiskerLeft (CategoryOfElements.π P).leftOp h
   · intro P₁ P₂ f

--- a/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
@@ -246,8 +246,8 @@ def binaryProductFunctor : Type u ⥤ Type u ⥤ Type u where
 explicit binary product functor given by the product type.
 -/
 noncomputable def binaryProductIsoProd : binaryProductFunctor ≅ (prod.functor : Type u ⥤ _) := by
-  refine' NatIso.ofComponents (fun X => _) (fun _ => _)
-  · refine' NatIso.ofComponents (fun Y => _) (fun _ => _)
+  refine NatIso.ofComponents (fun X => ?_) (fun _ => ?_)
+  · refine NatIso.ofComponents (fun Y => ?_) (fun _ => ?_)
     · exact ((limit.isLimit _).conePointUniqueUpToIso (binaryProductLimit X Y)).symm
     · apply Limits.prod.hom_ext <;> simp <;> rfl
   · ext : 2
@@ -361,7 +361,7 @@ noncomputable def isCoprodOfMono {X Y : Type u} (f : X ⟶ Y) [Mono f] :
     IsColimit (BinaryCofan.mk f (Subtype.val : ↑(Set.range f)ᶜ → Y)) := by
   apply Nonempty.some
   rw [binaryCofan_isColimit_iff]
-  refine' ⟨(mono_iff_injective f).mp inferInstance, Subtype.val_injective, _⟩
+  refine ⟨(mono_iff_injective f).mp inferInstance, Subtype.val_injective, ?_⟩
   symm
   rw [← eq_compl_iff_isCompl]
   exact Subtype.range_val
@@ -492,7 +492,7 @@ The converse of `unique_of_type_equalizer`.
 noncomputable def typeEqualizerOfUnique (t : ∀ y : Y, g y = h y → ∃! x : X, f x = y) :
     IsLimit (Fork.ofι _ w) :=
   Fork.IsLimit.mk' _ fun s => by
-    refine' ⟨fun i => _, _, _⟩
+    refine ⟨fun i => ?_, ?_, ?_⟩
     · apply Classical.choose (t (s.ι i) _)
       apply congr_fun s.condition i
     · funext i

--- a/Mathlib/CategoryTheory/Limits/SmallComplete.lean
+++ b/Mathlib/CategoryTheory/Limits/SmallComplete.lean
@@ -54,7 +54,7 @@ instance (priority := 100) : Quiver.IsThin C := fun X Y =>
       let α := #md
       apply not_le_of_lt (Cardinal.cantor α)
       let yp : C := ∏ᶜ fun _ : md => Y
-      refine' _root_.trans _ _
+      apply _root_.trans _ _
       · exact #(X ⟶ yp)
       · apply le_trans (Cardinal.power_le_power_right z)
         rw [Cardinal.power_def]

--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
@@ -337,7 +337,7 @@ namespace Localization
 /-- Composition of morphisms in the constructed localized category
 for a morphism property that has left calculus of fractions. -/
 noncomputable def Hom.comp {X Y Z : C} (z₁ : Hom W X Y) (z₂ : Hom W Y Z) : Hom W X Z := by
-  refine' Quot.lift₂ (fun a b => a.comp b) _ _ z₁ z₂
+  refine Quot.lift₂ (fun a b => a.comp b) ?_ ?_ z₁ z₂
   · rintro a b₁ b₂ ⟨U, t₁, t₂, hst, hft, ht⟩
     obtain ⟨z₁, fac₁⟩ := exists_leftFraction (RightFraction.mk a.s a.hs b₁.f)
     obtain ⟨z₂, fac₂⟩ := exists_leftFraction (RightFraction.mk a.s a.hs b₂.f)
@@ -352,7 +352,7 @@ noncomputable def Hom.comp {X Y Z : C} (z₁ : Hom W X Y) (z₂ : Hom W Y Z) : H
     simp only [assoc] at fac₄
     rw [comp_eq _ _ z₁ fac₁, comp_eq _ _ z₂ fac₂]
     apply Quot.sound
-    refine' ⟨Z, w₁.f ≫ u.f ≫ p, w₂.f ≫ u.s ≫ p, _, _, _⟩
+    refine ⟨Z, w₁.f ≫ u.f ≫ p, w₂.f ≫ u.s ≫ p, ?_, ?_, ?_⟩
     · dsimp
       simp only [assoc, ← reassoc_of% fac₁', ← reassoc_of% fac₂',
         reassoc_of% hst, reassoc_of% fac₃]
@@ -376,11 +376,11 @@ noncomputable def Hom.comp {X Y Z : C} (z₁ : Hom W X Y) (z₂ : Hom W Y Z) : H
     simp only [assoc] at fac₁' fac₂'
     rw [comp_eq _ _ z₁ fac₁, comp_eq _ _ z₂ fac₂]
     apply Quot.sound
-    refine' LeftFractionRel.trans _ ((_ : LeftFractionRel p₁ p₂).trans _)
+    refine LeftFractionRel.trans ?_ ((?_ : LeftFractionRel p₁ p₂).trans ?_)
     · have eq : a₁.s ≫ z₁.f ≫ w₁.s = a₁.s ≫ t₁ ≫ w₁.f := by rw [← fac₁', reassoc_of% fac₁]
       obtain ⟨Z, u, hu, fac₃⟩ := HasLeftCalculusOfFractions.ext _ _ _ a₁.hs eq
       simp only [assoc] at fac₃
-      refine' ⟨Z, w₁.s ≫ u, u, _, _, _⟩
+      refine ⟨Z, w₁.s ≫ u, u, ?_, ?_, ?_⟩
       · dsimp
         simp only [assoc]
       · dsimp
@@ -396,7 +396,7 @@ noncomputable def Hom.comp {X Y Z : C} (z₁ : Hom W X Y) (z₂ : Hom W Y Z) : H
         rw [← reassoc_of% fac₁', ← fac₃, reassoc_of% hst, reassoc_of% fac₂']
       obtain ⟨Z, u, hu, fac₄⟩ := HasLeftCalculusOfFractions.ext _ _ _ a₁.hs eq
       simp only [assoc] at fac₄
-      refine' ⟨Z, q.f ≫ u, q.s ≫ u, _, _, _⟩
+      refine ⟨Z, q.f ≫ u, q.s ≫ u, ?_, ?_, ?_⟩
       · simp only [assoc, reassoc_of% fac₃]
       · rw [assoc, assoc, assoc, assoc, fac₄, reassoc_of% hft]
       · simp only [assoc, ← reassoc_of% fac₃]
@@ -406,7 +406,7 @@ noncomputable def Hom.comp {X Y Z : C} (z₁ : Hom W X Y) (z₂ : Hom W Y Z) : H
         rw [← fac₂', reassoc_of% fac₂]
       obtain ⟨Z, u, hu, fac₄⟩ := HasLeftCalculusOfFractions.ext _ _ _ a₂.hs eq
       simp only [assoc] at fac₄
-      refine' ⟨Z, u, w₂.s ≫ u, _, _, _⟩
+      refine ⟨Z, u, w₂.s ≫ u, ?_, ?_, ?_⟩
       · dsimp
         simp only [assoc]
       · dsimp

--- a/Mathlib/CategoryTheory/MorphismProperty/Factorization.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Factorization.lean
@@ -72,7 +72,7 @@ def comp : MorphismProperty C := fun _ _ f => Nonempty (MapFactorizationData W�
 lemma comp_eq_top_iff : W₁.comp W₂ = ⊤ ↔ HasFactorization W₁ W₂ := by
   constructor
   · intro h
-    refine' ⟨fun f => _⟩
+    refine ⟨fun f => ?_⟩
     have : W₁.comp W₂ f := by simp only [h, top_apply]
     exact ⟨this.some⟩
   · intro

--- a/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
@@ -61,8 +61,8 @@ noncomputable def sheafificationWhiskerLeftIso (P : Cᵒᵖ ⥤ D)
         PreservesLimit (W.index P).multicospan F] :
     (whiskeringLeft _ _ E).obj (J.sheafify P) ≅
     (whiskeringLeft _ _ _).obj P ⋙ J.sheafification E := by
-  refine' J.plusFunctorWhiskerLeftIso _ ≪≫ _ ≪≫ Functor.associator _ _ _
-  refine' isoWhiskerRight _ _
+  refine J.plusFunctorWhiskerLeftIso _ ≪≫ ?_ ≪≫ Functor.associator _ _ _
+  refine isoWhiskerRight ?_ _
   exact J.plusFunctorWhiskerLeftIso _
 #align category_theory.grothendieck_topology.sheafification_whisker_left_iso CategoryTheory.GrothendieckTopology.sheafificationWhiskerLeftIso
 
@@ -91,10 +91,10 @@ the sheafification of `P ⋙ F`, functorially in `P`. -/
 noncomputable def sheafificationWhiskerRightIso :
     J.sheafification D ⋙ (whiskeringRight _ _ _).obj F ≅
       (whiskeringRight _ _ _).obj F ⋙ J.sheafification E := by
-  refine' Functor.associator _ _ _ ≪≫ _
-  refine' isoWhiskerLeft (J.plusFunctor D) (J.plusFunctorWhiskerRightIso _) ≪≫ _
-  refine' _ ≪≫ Functor.associator _ _ _
-  refine' (Functor.associator _ _ _).symm ≪≫ _
+  refine Functor.associator _ _ _ ≪≫ ?_
+  refine isoWhiskerLeft (J.plusFunctor D) (J.plusFunctorWhiskerRightIso _) ≪≫ ?_
+  refine ?_ ≪≫ Functor.associator _ _ _
+  refine (Functor.associator _ _ _).symm ≪≫ ?_
   exact isoWhiskerRight (J.plusFunctorWhiskerRightIso _) (J.plusFunctor E)
 #align category_theory.grothendieck_topology.sheafification_whisker_right_iso CategoryTheory.GrothendieckTopology.sheafificationWhiskerRightIso
 

--- a/Mathlib/CategoryTheory/Sites/DenseSubsite.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite.lean
@@ -335,26 +335,21 @@ noncomputable def sheafCoyonedaHom (α : G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) :
     conv_lhs => rw [← hf'.some.fac]
     simp only [← Category.assoc, op_comp, Functor.map_comp]
     congr 1
-    refine' (appHom_restrict (homOver α (unop X)) hf'.some.map.op x).trans _
-    simp
+    exact (appHom_restrict (homOver α (unop X)) hf'.some.map.op x).trans (by simp)
 #align category_theory.cover_dense.sheaf_coyoneda_hom CategoryTheory.Functor.IsCoverDense.sheafCoyonedaHom
 
 /--
 (Implementation). `sheafCoyonedaHom` but the order of the arguments of the functor are swapped.
 -/
 noncomputable def sheafYonedaHom (α : G.op ⋙ ℱ ⟶ G.op ⋙ ℱ'.val) :
-    ℱ ⋙ yoneda ⟶ ℱ'.val ⋙ yoneda := by
-  let α := sheafCoyonedaHom α
-  refine'
-    { app := _
-      naturality := _ }
-  · intro U
-    refine'
-      { app := fun X => (α.app X).app U
-        naturality := fun X Y f => by simpa using congr_app (α.naturality f) U }
-  · intro U V i
+    ℱ ⋙ yoneda ⟶ ℱ'.val ⋙ yoneda where
+  app U :=
+    let α := (sheafCoyonedaHom α)
+    { app := fun X => (α.app X).app U
+      naturality := fun X Y f => by simpa using congr_app (α.naturality f) U }
+  naturality U V i := by
     ext X x
-    exact congr_fun ((α.app X).naturality i) x
+    exact congr_fun (((sheafCoyonedaHom α).app X).naturality i) x
 #align category_theory.cover_dense.sheaf_yoneda_hom CategoryTheory.Functor.IsCoverDense.sheafYonedaHom
 
 /-- Given a natural transformation `G ⋙ ℱ ⟶ G ⋙ ℱ'` between presheaves of arbitrary category,

--- a/Mathlib/CategoryTheory/Sites/InducedTopology.lean
+++ b/Mathlib/CategoryTheory/Sites/InducedTopology.lean
@@ -112,7 +112,7 @@ variable (G K)
 theorem Functor.locallyCoverDense_of_isCoverDense [Full G] [G.IsCoverDense K] :
     LocallyCoverDense K G := by
   intro X T
-  refine' K.superset_covering _ (K.bind_covering T.property
+  refine K.superset_covering ?_ (K.bind_covering T.property
     fun Y f _ => G.is_cover_of_isCoverDense _ Y)
   rintro Y _ ⟨Z, _, f, hf, ⟨W, g, f', rfl : _ = _⟩, rfl⟩
   use W; use G.preimage (f' ≫ f); use g

--- a/Mathlib/CategoryTheory/Sites/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Sites/LeftExact.lean
@@ -64,7 +64,7 @@ abbrev liftToDiagramLimitObj {X : C} {K : Type max v u} [SmallCategory K] [HasLi
         (limit.lift F _).naturality, ← (limit.lift F _).naturality, ← Category.assoc, ←
         Category.assoc]
       congr 1
-      refine' limit.hom_ext (fun j => _)
+      refine limit.hom_ext (fun j => ?_)
       erw [Category.assoc, Category.assoc, limit.lift_π, limit.lift_π, limit.lift_π_assoc,
         limit.lift_π_assoc, Category.assoc, Category.assoc, Multiequalizer.condition]
       rfl)

--- a/Mathlib/CategoryTheory/Sites/LocallyInjective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallyInjective.lean
@@ -113,7 +113,7 @@ lemma isLocallyInjective_iff_equalizerSieve_mem_imp :
     · rintro Y f ⟨Z, a, g, hg, ha, rfl⟩
       simpa using ha
     · intro Y f hf
-      refine' J.superset_covering (Sieve.le_pullback_bind S.1 T _ hf)
+      refine J.superset_covering (Sieve.le_pullback_bind S.1 T _ hf)
         (equalizerSieve_mem J φ _ _ ?_)
       erw [NatTrans.naturality_apply, NatTrans.naturality_apply]
       exact hf

--- a/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
@@ -140,7 +140,7 @@ instance isLocallySurjective_comp {F₁ F₂ F₃ : Cᵒᵖ ⥤ A} (f₁ : F₁ 
     have : (Sieve.bind (imageSieve f₂ s) fun _ _ h => imageSieve f₁ h.choose) ≤
         imageSieve (f₁ ≫ f₂) s := by
       rintro V i ⟨W, i, j, H, ⟨t', ht'⟩, rfl⟩
-      refine' ⟨t', _⟩
+      refine ⟨t', ?_⟩
       rw [op_comp, F₃.map_comp, NatTrans.comp_app, comp_apply, comp_apply, ht',
         elementwise_of% f₂.naturality, H.choose_spec]
     apply J.superset_covering this
@@ -218,7 +218,7 @@ lemma isLocallySurjective_of_isLocallySurjective_of_isLocallyInjective
     let S := imageSieve (f₁ ≫ f₂) (f₂.app _ x)
     let T : ∀ ⦃Y : C⦄ (f : Y ⟶ X) (_ : S f), Sieve Y := fun Y f hf =>
       equalizerSieve (f₁.app _ (localPreimage (f₁ ≫ f₂) (f₂.app _ x) f hf)) (F₂.map f.op x)
-    refine' J.superset_covering ?_ (J.transitive (imageSieve_mem J (f₁ ≫ f₂) (f₂.app _ x))
+    refine J.superset_covering ?_ (J.transitive (imageSieve_mem J (f₁ ≫ f₂) (f₂.app _ x))
       (Sieve.bind S.1 T) ?_)
     · rintro Y _ ⟨Z, a, g, hg, ha, rfl⟩
       exact ⟨F₁.map a.op (localPreimage (f₁ ≫ f₂) _ _ hg), by simpa using ha⟩
@@ -276,7 +276,7 @@ noncomputable def sheafificationIsoImagePresheaf (F : Cᵒᵖ ⥤ Type max u v) 
     J.sheafify_hom_ext _ _ (J.sheafify_isSheaf _) (by simp [toImagePresheafSheafify])
   inv_hom_id := by
     rw [← cancel_mono (Subpresheaf.ι _), Category.id_comp, Category.assoc]
-    refine' Eq.trans _ (Category.comp_id _)
+    refine Eq.trans ?_ (Category.comp_id _)
     congr 1
     exact J.sheafify_hom_ext _ _ (J.sheafify_isSheaf _) (by simp [toImagePresheafSheafify])
 #align category_theory.sheafification_iso_image_presheaf CategoryTheory.Presheaf.sheafificationIsoImagePresheaf
@@ -289,10 +289,10 @@ instance isLocallySurjective_toPlus (P : Cᵒᵖ ⥤ Type max u v) :
     IsLocallySurjective J (J.toPlus P) where
   imageSieve_mem x := by
     obtain ⟨S, x, rfl⟩ := exists_rep x
-    refine' J.superset_covering (fun Y f hf => ⟨x.1 ⟨Y, f, hf⟩, _⟩) S.2
+    refine J.superset_covering (fun Y f hf => ⟨x.1 ⟨Y, f, hf⟩, ?_⟩) S.2
     dsimp
     rw [toPlus_eq_mk, res_mk_eq_mk_pullback, eq_mk_iff_exists]
-    refine' ⟨S.pullback f, homOfLE le_top, 𝟙 _, _⟩
+    refine ⟨S.pullback f, homOfLE le_top, 𝟙 _, ?_⟩
     ext ⟨Z, g, hg⟩
     simpa using x.2 (Cover.Relation.mk _ _ _ g (𝟙 Z) f (g ≫ f) hf
       (S.1.downward_closed hf g) (by simp))

--- a/Mathlib/CategoryTheory/Sites/Pretopology.lean
+++ b/Mathlib/CategoryTheory/Sites/Pretopology.lean
@@ -119,7 +119,7 @@ def toGrothendieck (K : Pretopology C) : GrothendieckTopology C where
   transitive' := by
     rintro X S ⟨R', hR', RS⟩ R t
     choose t₁ t₂ t₃ using t
-    refine' ⟨_, K.transitive _ _ hR' fun _ f hf => t₂ (RS _ hf), _⟩
+    refine ⟨_, K.transitive _ _ hR' fun _ f hf => t₂ (RS _ hf), ?_⟩
     rintro Y _ ⟨Z, g, f, hg, hf, rfl⟩
     apply t₃ (RS _ hg) _ hf
 #align category_theory.pretopology.to_grothendieck CategoryTheory.Pretopology.toGrothendieck

--- a/Mathlib/CategoryTheory/Sites/SheafHom.lean
+++ b/Mathlib/CategoryTheory/Sites/SheafHom.lean
@@ -164,7 +164,7 @@ lemma presheafHom_isSheafFor  :
     Presieve.IsSheafFor (presheafHom F G) S.arrows := by
   intro x hx
   apply exists_unique_of_exists_of_unique
-  · refine' ⟨
+  · refine ⟨
       { app := fun Y => app hG x hx Y.unop.hom
         naturality := by
           rintro ⟨Y₁ : Over X⟩ ⟨Y₂ : Over X⟩ ⟨φ : Y₂ ⟶ Y₁⟩
@@ -175,7 +175,7 @@ lemma presheafHom_isSheafFor  :
           erw [app_cond hG x hx Y₁.hom (Z.hom ≫ φ.left) (by simpa using hZ),
             ← F.map_comp_assoc, op_comp]
           congr 3
-          simp }, _⟩
+          simp }, ?_⟩
     rw [PresheafHom.isAmalgamation_iff _ _ hx]
     intro Y g hg
     dsimp

--- a/Mathlib/CategoryTheory/Sites/Spaces.lean
+++ b/Mathlib/CategoryTheory/Sites/Spaces.lean
@@ -62,7 +62,7 @@ def pretopology : Pretopology (Opens T) where
   has_isos X Y f i x hx := ⟨_, _, Presieve.singleton_self _, (inv f).le hx⟩
   pullbacks X Y f S hS x hx := by
     rcases hS _ (f.le hx) with ⟨U, g, hg, hU⟩
-    refine' ⟨_, _, Presieve.pullbackArrows.mk _ _ hg, _⟩
+    refine ⟨_, _, Presieve.pullbackArrows.mk _ _ hg, ?_⟩
     have : U ⊓ Y ≤ pullback g f :=
       leOfHom (pullback.lift (homOfLE inf_le_left) (homOfLE inf_le_right) rfl)
     apply this ⟨hU, hx⟩

--- a/Mathlib/CategoryTheory/Sites/Subsheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Subsheaf.lean
@@ -283,13 +283,13 @@ noncomputable def Subpresheaf.sheafifyLift (f : G.toPresheaf ⟶ F') (h : Presie
     ext s
     apply (h _ ((Subpresheaf.sheafify J G).toPresheaf.map i s).prop).isSeparatedFor.ext
     intro W j hj
-    refine' (Presieve.IsSheafFor.valid_glue (h _ ((G.sheafify J).toPresheaf.map i s).2)
-      ((G.family_of_elements_compatible _).compPresheafMap _) _ hj).trans _
+    refine (Presieve.IsSheafFor.valid_glue (h _ ((G.sheafify J).toPresheaf.map i s).2)
+      ((G.family_of_elements_compatible _).compPresheafMap _) _ hj).trans ?_
     dsimp
     conv_rhs => rw [← FunctorToTypes.map_comp_apply]
     change _ = F'.map (j ≫ i.unop).op _
-    refine' Eq.trans _ (Presieve.IsSheafFor.valid_glue (h _ s.2)
-      ((G.family_of_elements_compatible s.1).compPresheafMap f) (j ≫ i.unop) _).symm
+    refine Eq.trans ?_ (Presieve.IsSheafFor.valid_glue (h _ s.2)
+      ((G.family_of_elements_compatible s.1).compPresheafMap f) (j ≫ i.unop) ?_).symm
     swap -- Porting note: need to swap two goals otherwise the first goal needs to be proven
     -- inside the second goal any way
     · dsimp [Presieve.FamilyOfElements.compPresheafMap] at hj ⊢

--- a/Mathlib/CategoryTheory/Triangulated/Opposite.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite.lean
@@ -255,7 +255,7 @@ equivalence `triangleOpEquivalence C : (Triangle C)ᵒᵖ ≌ Triangle Cᵒᵖ` 
 @[simps!]
 noncomputable def counitIso : inverse C ⋙ functor C ≅ 𝟭 _ :=
   NatIso.ofComponents (fun T => by
-    refine' Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (Iso.refl _) _ _ _
+    refine Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (Iso.refl _) ?_ ?_ ?_
     · aesop_cat
     · aesop_cat
     · dsimp

--- a/Mathlib/CategoryTheory/Triangulated/Triangulated.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Triangulated.lean
@@ -136,8 +136,8 @@ def ofIso {X₁' X₂' X₃' Z₁₂' Z₂₃' Z₁₃' : C} (u₁₂' : X₁' �
   dsimp [iso₁₂, iso₂₃, iso₁₃] at eq₁₂ eq₁₂' eq₁₃ eq₁₃' eq₂₃ eq₂₃' rel₁₂ rel₁₃ rel₂₂ rel₂₃
   rw [Functor.map_id, comp_id] at rel₁₃
   rw [id_comp] at rel₂₂
-  refine' ⟨iso₁₂.hom.hom₃ ≫ H.m₁ ≫ iso₁₃.inv.hom₃,
-    iso₁₃.hom.hom₃ ≫ H.m₃ ≫ iso₂₃.inv.hom₃, _, _, _, _, _⟩
+  refine ⟨iso₁₂.hom.hom₃ ≫ H.m₁ ≫ iso₁₃.inv.hom₃,
+    iso₁₃.hom.hom₃ ≫ H.m₃ ≫ iso₂₃.inv.hom₃, ?_, ?_, ?_, ?_, ?_⟩
   · rw [reassoc_of% eq₁₂, ← cancel_mono iso₁₃.hom.hom₃, assoc, assoc, assoc, assoc,
       iso₁₃.inv_hom_id_triangle_hom₃, eq₁₃, reassoc_of% comm₂₃, ← rel₁₂]
     dsimp

--- a/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
@@ -197,7 +197,7 @@ nonrec theorem threeAPFree_sphere : ThreeAPFree (sphere n d k : Set (Fin n → �
       map_add' := fun _ _ => funext fun _ => cast_add _ _ }
   refine ThreeAPFree.of_image (AddMonoidHomClass.isAddFreimanHom f (Set.mapsTo_image _ _))
     (cast_injective.comp_left.injOn _) (Set.subset_univ _) ?_
-  refine' (threeAPFree_sphere 0 (√↑k)).mono (Set.image_subset_iff.2 fun x => _)
+  refine (threeAPFree_sphere 0 (√↑k)).mono (Set.image_subset_iff.2 fun x => ?_)
   rw [Set.mem_preimage, mem_sphere_zero_iff_norm]
   exact norm_of_mem_sphere
 #align behrend.add_salem_spencer_sphere Behrend.threeAPFree_sphere
@@ -205,15 +205,15 @@ nonrec theorem threeAPFree_sphere : ThreeAPFree (sphere n d k : Set (Fin n → �
 theorem threeAPFree_image_sphere :
     ThreeAPFree ((sphere n d k).image (map (2 * d - 1)) : Set ℕ) := by
   rw [coe_image]
-  refine' ThreeAPFree.image' (α := Fin n → ℕ) (β := ℕ) (s := sphere n d k) (map (2 * d - 1))
+  apply ThreeAPFree.image' (α := Fin n → ℕ) (β := ℕ) (s := sphere n d k) (map (2 * d - 1))
     (map_injOn.mono _) threeAPFree_sphere
+  · rw [Set.add_subset_iff]
+    rintro a ha b hb i
+    have hai := mem_box.1 (sphere_subset_box ha) i
+    have hbi := mem_box.1 (sphere_subset_box hb) i
+    rw [lt_tsub_iff_right, ← succ_le_iff, two_mul]
+    exact (add_add_add_comm _ _ 1 1).trans_le (_root_.add_le_add hai hbi)
   · exact x
-  rw [Set.add_subset_iff]
-  rintro a ha b hb i
-  have hai := mem_box.1 (sphere_subset_box ha) i
-  have hbi := mem_box.1 (sphere_subset_box hb) i
-  rw [lt_tsub_iff_right, ← succ_le_iff, two_mul]
-  exact (add_add_add_comm _ _ 1 1).trans_le (_root_.add_le_add hai hbi)
 #align behrend.add_salem_spencer_image_sphere Behrend.threeAPFree_image_sphere
 
 theorem sum_sq_le_of_mem_box (hx : x ∈ box n d) : ∑ i : Fin n, x i ^ 2 ≤ n * (d - 1) ^ 2 := by
@@ -239,13 +239,13 @@ theorem card_sphere_le_rothNumberNat (n d k : ℕ) :
   · dsimp; refine (card_le_univ _).trans_eq ?_; rfl
   cases d
   · simp
-  refine' threeAPFree_image_sphere.le_rothNumberNat _ _ (card_image_of_injOn _)
+  apply threeAPFree_image_sphere.le_rothNumberNat _ _ (card_image_of_injOn _)
   · intro; assumption
   · simp only [subset_iff, mem_image, and_imp, forall_exists_index, mem_range,
       forall_apply_eq_imp_iff₂, sphere, mem_filter]
     rintro _ x hx _ rfl
     exact (map_le_of_mem_box hx).trans_lt sum_lt
-  refine' map_injOn.mono fun x => _
+  apply map_injOn.mono fun x => ?_
   · intro; assumption
   simp only [mem_coe, sphere, mem_filter, mem_box, and_imp, two_mul]
   exact fun h _ i => (h i).trans_le le_self_add

--- a/Mathlib/Combinatorics/Additive/Dissociation.lean
+++ b/Mathlib/Combinatorics/Additive/Dissociation.lean
@@ -134,7 +134,7 @@ lemma exists_subset_mulSpan_card_le_of_forall_mulDissociated
     exists_maximal (s.powerset.filter fun s' : Finset α ↦ MulDissociated (s' : Set α))
       ⟨∅, mem_filter.2 ⟨empty_mem_powerset _, by simp⟩⟩
   simp only [mem_filter, mem_powerset, lt_eq_subset, and_imp] at hs' hs'max
-  refine' ⟨s', hs'.1, hs _ hs'.1 hs'.2, fun a ha ↦ _⟩
+  refine ⟨s', hs'.1, hs _ hs'.1 hs'.2, fun a ha ↦ ?_⟩
   by_cases ha' : a ∈ s'
   · exact subset_mulSpan ha'
   obtain ⟨t, u, ht, hu, htu⟩ := not_mulDissociated_iff_exists_disjoint.1 fun h ↦

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -44,14 +44,15 @@ variable {α : Type*} [CommGroup α] [DecidableEq α] {A B C : Finset α}
 theorem card_div_mul_le_card_div_mul_card_div (A B C : Finset α) :
     (A / C).card * B.card ≤ (A / B).card * (B / C).card := by
   rw [← card_product (A / B), ← mul_one ((A / B) ×ˢ (B / C)).card]
-  refine' card_mul_le_card_mul (fun b ac ↦ ac.1 * ac.2 = b) (fun x hx ↦ _)
+  refine card_mul_le_card_mul (fun b ac ↦ ac.1 * ac.2 = b) (fun x hx ↦ ?_)
     fun x _ ↦ card_le_one_iff.2 fun hu hv ↦
-      ((mem_bipartiteBelow _).1 hu).2.symm.trans ((mem_bipartiteBelow _).1 hv).2
+      ((mem_bipartiteBelow _).1 hu).2.symm.trans ?_
   obtain ⟨a, ha, c, hc, rfl⟩ := mem_div.1 hx
   refine card_le_card_of_inj_on (fun b ↦ (a / b, b / c)) (fun b hb ↦ ?_) fun b₁ _ b₂ _ h ↦ ?_
   · rw [mem_bipartiteAbove]
     exact ⟨mk_mem_product (div_mem_div ha hb) (div_mem_div hb hc), div_mul_div_cancel' _ _ _⟩
   · exact div_right_injective (Prod.ext_iff.1 h).1
+  · exact ((mem_bipartiteBelow _).1 hv).2
 #align finset.card_div_mul_le_card_div_mul_card_div Finset.card_div_mul_le_card_div_mul_card_div
 #align finset.card_sub_mul_le_card_sub_mul_card_sub Finset.card_sub_mul_le_card_sub_mul_card_sub
 
@@ -98,19 +99,19 @@ theorem mul_pluennecke_petridis (C : Finset α)
     rw [hA', inter_mul_singleton, (isUnit_singleton x).div_mul_cancel]
   have h₁ : A * B * C' = A * B * C ∪ (A * B * {x}) \ (A' * B * {x}) := by
     rw [hC', insert_eq, union_comm, mul_union]
-    refine' (sup_sdiff_eq_sup _).symm
+    refine (sup_sdiff_eq_sup ?_).symm
     rw [mul_right_comm, mul_right_comm A, h₀]
     exact mul_subset_mul_right (inter_subset_right _ _)
   have h₂ : A' * B * {x} ⊆ A * B * {x} :=
     mul_subset_mul_right (mul_subset_mul_right <| inter_subset_left _ _)
   have h₃ : (A * B * C').card ≤ (A * B * C).card + (A * B).card - (A' * B).card := by
     rw [h₁]
-    refine' (card_union_le _ _).trans_eq _
+    refine (card_union_le _ _).trans_eq ?_
     rw [card_sdiff h₂, ← add_tsub_assoc_of_le (card_le_card h₂), card_mul_singleton,
       card_mul_singleton]
-  refine' (mul_le_mul_right' h₃ _).trans _
+  refine (mul_le_mul_right' h₃ _).trans ?_
   rw [tsub_mul, add_mul]
-  refine' (tsub_le_tsub (add_le_add_right ih _) <| hA _ <| inter_subset_left _ _).trans_eq _
+  refine (tsub_le_tsub (add_le_add_right ih _) <| hA _ <| inter_subset_left _ _).trans_eq ?_
   rw [← mul_add, ← mul_tsub, ← hA', hC', insert_eq, mul_union, ← card_mul_singleton A x, ←
     card_mul_singleton A' x, add_comm (card _), h₀,
     eq_tsub_of_add_eq (card_union_add_card_inter _ _)]

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
@@ -493,7 +493,7 @@ theorem edgeDensity_chunk_not_uniform [Nonempty α] (hPα : P.parts.card * 16 ^ 
       · -- This seems faster than `exact div_nonneg (by positivity) (by positivity)` and *much*
         -- (tens of seconds) faster than `positivity` on its own.
         apply div_nonneg <;> positivity
-      refine' le_trans _ (mul_le_mul_of_nonneg_right UVl _)
+      refine le_trans ?_ (mul_le_mul_of_nonneg_right UVl ?_)
       · norm_num
         nlinarith
       · norm_num

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -222,7 +222,7 @@ theorem ppred : Partrec fun n => ppred n :=
     · exact
         eq_none_iff.2 fun a ⟨⟨m, h, _⟩, _⟩ => by
           simp [show 0 ≠ m.succ by intro h; injection h] at h
-    · refine' eq_some_iff.2 _
+    · refine eq_some_iff.2 ?_
       simp only [mem_rfind, not_true, IsEmpty.forall_iff, decide_True, mem_some_iff,
         false_eq_decide_iff, true_and]
       intro m h

--- a/Mathlib/Computability/RegularExpressions.lean
+++ b/Mathlib/Computability/RegularExpressions.lean
@@ -333,7 +333,7 @@ theorem star_rmatch_iff (P : RegularExpression α) :
           · simp only [forall_eq_or_imp, List.mem_cons] at helem
             simp only [eq_self_iff_true, not_true, Ne, false_and_iff] at helem
           simp only [List.join, List.cons_append, List.cons_eq_cons] at hsum
-          refine' ⟨t, U.join, hsum.2, _, _⟩
+          refine ⟨t, U.join, hsum.2, ?_, ?_⟩
           · specialize helem (b :: t) (by simp)
             rw [rmatch] at helem
             convert helem.2

--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -704,7 +704,8 @@ theorem code_is_ok (c) : Code.Ok c := by
     rw [reaches_eval]; swap
     · exact ReflTransGen.single rfl
     rw [stepRet, IHfs]; congr; funext v'
-    refine' Eq.trans _ (Eq.symm _) <;> try exact reaches_eval (ReflTransGen.single rfl)
+    refine Eq.trans (b := eval step (stepRet (Cont.cons₂ v k) v')) ?_ (Eq.symm ?_) <;>
+      exact reaches_eval (ReflTransGen.single rfl)
   | comp f g IHf IHg =>
     rw [Code.eval, IHg]
     simp only [bind_assoc, Cont.eval, pure_bind]; congr; funext v
@@ -1635,13 +1636,10 @@ theorem tr_ret_respects (k v s) : ∃ b₂,
     refine (move₂_ok (by decide) ?_ (splitAtPred_false _)).trans ?_; · rfl
     simp only [TM2.step, Option.mem_def, Option.elim, id_eq, elim_update_main, elim_main, elim_aux,
       List.append_nil, elim_update_aux]
-    refine' (move₂_ok (by decide) _ _).trans _
+    refine (move₂_ok (L₁ := ?_) (o := ?_) (L₂ := ?_) (by decide) rfl ?_).trans ?_
     pick_goal 4
-    · rfl
-    pick_goal 4
-    · exact
-        splitAtPred_eq _ _ _ (some Γ'.consₗ) _
-          (fun x h => Bool.decide_false (trList_ne_consₗ _ _ h)) ⟨rfl, rfl⟩
+    · exact splitAtPred_eq _ _ _ (some Γ'.consₗ) _
+        (fun x h => Bool.decide_false (trList_ne_consₗ _ _ h)) ⟨rfl, rfl⟩
     refine (move₂_ok (by decide) ?_ (splitAtPred_false _)).trans ?_; · rfl
     simp only [TM2.step, Option.mem_def, Option.elim, elim_update_stack, elim_main,
       List.append_nil, elim_update_main,  id_eq, elim_update_aux, ne_eq, Function.update_noteq,

--- a/Mathlib/Data/Finset/NoncommProd.lean
+++ b/Mathlib/Data/Finset/NoncommProd.lean
@@ -469,7 +469,7 @@ theorem noncommProd_mul_single [Fintype ι] [DecidableEq ι] (x : ∀ i, M i) :
   case a =>
     intro i _ j _ _
     exact Pi.mulSingle_apply_commute x i j
-  refine' (noncommProd_congr (insert_erase (mem_univ i)).symm _ _).trans _
+  convert (noncommProd_congr (insert_erase (mem_univ i)).symm _ _).trans _
   · intro j
     exact Pi.mulSingle j (x j) i
   · intro j _; dsimp

--- a/Mathlib/Data/Finset/Sym.lean
+++ b/Mathlib/Data/Finset/Sym.lean
@@ -287,7 +287,8 @@ def symInsertEquiv (h : a ∉ s) : (insert a s).sym n ≃ Σi : Fin (n + 1), s.s
   invFun m := ⟨m.2.1.fill a m.1, sym_fill_mem a m.2.2⟩
   left_inv m := Subtype.ext <| m.1.fill_filterNe a
   right_inv := fun ⟨i, m, hm⟩ ↦ by
-    refine' Function.Injective.sigma_map (Function.injective_id) (fun i ↦ _) _
+    refine Function.Injective.sigma_map (β₂ := ?_) (f₂ := ?_)
+        (Function.injective_id) (fun i ↦ ?_) ?_
     · exact fun i ↦ Sym α (n - i)
     swap
     · exact Subtype.coe_injective

--- a/Mathlib/Data/Fintype/Quotient.lean
+++ b/Mathlib/Data/Fintype/Quotient.lean
@@ -29,9 +29,8 @@ def Quotient.finChoiceAux {ι : Type*} [DecidableEq ι] {α : ι → Type*} [S :
     ∀ l : List ι, (∀ i ∈ l, Quotient (S i)) → @Quotient (∀ i ∈ l, α i) (by infer_instance)
   | [], _ => ⟦fun i h => nomatch List.not_mem_nil _ h⟧
   | i :: l, f => by
-    refine'
-      Quotient.liftOn₂ (f i (List.mem_cons_self _ _))
-        (Quotient.finChoiceAux l fun j h => f j (List.mem_cons_of_mem _ h)) _ _
+    refine Quotient.liftOn₂ (f i (List.mem_cons_self _ _))
+        (Quotient.finChoiceAux l fun j h => f j (List.mem_cons_of_mem _ h)) ?_ ?_
     · exact fun a l => ⟦fun j h =>
         if e : j = i then by rw [e]; exact a else l _ ((List.mem_cons.1 h).resolve_left e)⟧
     refine fun a₁ l₁ a₂ l₂ h₁ h₂ => Quotient.sound fun j h => ?_

--- a/Mathlib/Data/List/AList.lean
+++ b/Mathlib/Data/List/AList.lean
@@ -370,7 +370,7 @@ def insertRec {C : AList β → Sort*} (H0 : C ∅)
   | ⟨[], _⟩ => H0
   | ⟨c :: l, h⟩ => by
     rw [mk_cons_eq_insert]
-    refine' IH _ _ _ _ (insertRec H0 IH _)
+    refine IH _ _ _ ?_ (insertRec H0 IH _)
     exact not_mem_keys_of_nodupKeys_cons h
 #align alist.insert_rec AList.insertRec
 

--- a/Mathlib/Data/List/Cycle.lean
+++ b/Mathlib/Data/List/Cycle.lean
@@ -344,12 +344,12 @@ theorem prev_nthLe (l : List α) (h : Nodup l) (n : ℕ) (hn : n < l.length) :
       · intro H
         suffices n.succ.succ = 0 by simpa
         rw [nodup_iff_nthLe_inj] at h
-        refine' h _ _ hn Nat.succ_pos' _
+        refine h _ _ hn Nat.succ_pos' ?_
         simpa using H
       · intro H
         suffices n.succ.succ = 1 by simpa
         rw [nodup_iff_nthLe_inj] at h
-        refine' h _ _ hn (Nat.succ_lt_succ Nat.succ_pos') _
+        refine h _ _ hn (Nat.succ_lt_succ Nat.succ_pos') ?_
         simpa using H
 #align list.prev_nth_le List.prev_nthLe
 

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -836,7 +836,7 @@ theorem nodup_permutations'Aux_of_not_mem (s : List α) (x : α) (hx : x ∉ s) 
 
 set_option linter.deprecated false in
 theorem nodup_permutations'Aux_iff {s : List α} {x : α} : Nodup (permutations'Aux x s) ↔ x ∉ s := by
-  refine' ⟨fun h => _, nodup_permutations'Aux_of_not_mem _ _⟩
+  refine ⟨fun h => ?_, nodup_permutations'Aux_of_not_mem _ _⟩
   intro H
   obtain ⟨k, hk, hk'⟩ := nthLe_of_mem H
   rw [nodup_iff_nthLe_inj] at h
@@ -846,7 +846,7 @@ theorem nodup_permutations'Aux_iff {s : List α} {x : α} : Nodup (permutations'
   rw [nthLe_permutations'Aux, nthLe_permutations'Aux]
   have hl : length (insertNth k x s) = length (insertNth (k + 1) x s) := by
     rw [length_insertNth _ _ hk.le, length_insertNth _ _ (Nat.succ_le_of_lt hk)]
-  refine' ext_nthLe hl fun n hn hn' => _
+  refine ext_nthLe hl fun n hn hn' => ?_
   rcases lt_trichotomy n k with (H | rfl | H)
   · rw [nthLe_insertNth_of_lt _ _ _ _ H (H.trans hk),
       nthLe_insertNth_of_lt _ _ _ _ (H.trans (Nat.lt_succ_self _))]
@@ -877,7 +877,7 @@ theorem nodup_permutations (s : List α) (hs : Nodup s) : Nodup s.permutations :
       rw [mem_permutations'] at hy
       rw [nodup_permutations'Aux_iff, hy.mem_iff]
       exact fun H => h x H rfl
-    · refine' IH.pairwise_of_forall_ne fun as ha bs hb H => _
+    · refine IH.pairwise_of_forall_ne fun as ha bs hb H => ?_
       rw [disjoint_iff_ne]
       rintro a ha' b hb' rfl
       obtain ⟨⟨n, hn⟩, hn'⟩ := get_of_mem ha'

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -88,7 +88,7 @@ theorem rank_mul_le [StrongRankCondition R] (A : Matrix m n R) (B : Matrix n o R
 
 theorem rank_unit [StrongRankCondition R] [DecidableEq n] (A : (Matrix n n R)ˣ) :
     (A : Matrix n n R).rank = Fintype.card n := by
-  refine' le_antisymm (rank_le_card_width A) _
+  apply le_antisymm (rank_le_card_width (A : Matrix n n R)) _
   have := rank_mul_le_left (A : Matrix n n R) (↑A⁻¹ : Matrix n n R)
   rwa [← Units.val_mul, mul_inv_self, Units.val_one, rank_one] at this
 #align matrix.rank_unit Matrix.rank_unit

--- a/Mathlib/Data/Matroid/Dual.lean
+++ b/Mathlib/Data/Matroid/Dual.lean
@@ -70,8 +70,9 @@ section dual
     rintro X - I'⟨hI'E, B, hB, hI'B⟩ hI'X
     obtain ⟨I, hI⟩ := M.exists_basis (M.E \ X)
     obtain ⟨B', hB', hIB', hB'IB⟩ := hI.indep.exists_base_subset_union_base hB
-    refine' ⟨(X \ B') ∩ M.E,
-      ⟨_,subset_inter (subset_diff.mpr _) hI'E, (inter_subset_left _ _).trans (diff_subset _ _)⟩, _⟩
+    refine ⟨(X \ B') ∩ M.E,
+      ⟨?_, subset_inter (subset_diff.mpr ?_) hI'E, (inter_subset_left _ _).trans
+        (diff_subset _ _)⟩, ?_⟩
     · simp only [inter_subset_right, true_and]
       exact ⟨B', hB', disjoint_of_subset_left (inter_subset_left _ _) disjoint_sdiff_left⟩
     · rw [and_iff_right hI'X]

--- a/Mathlib/Data/Nat/Bits.lean
+++ b/Mathlib/Data/Nat/Bits.lean
@@ -122,7 +122,7 @@ lemma bodd_add_div2 : ∀ n, cond (bodd n) 1 0 + 2 * div2 n = n
   | 0 => rfl
   | succ n => by
     simp only [bodd_succ, Bool.cond_not, div2_succ, Nat.mul_comm]
-    refine' Eq.trans _ (congr_arg succ (bodd_add_div2 n))
+    refine Eq.trans ?_ (congr_arg succ (bodd_add_div2 n))
     cases bodd n
     · simp
     · simp; omega

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -1023,7 +1023,7 @@ Also works for functions to `Sort*`. Weakens the assumptions of `decreasing_indu
 def decreasingInduction' {P : ℕ → Sort*} (h : ∀ k < n, m ≤ k → P (k + 1) → P k)
     (mn : m ≤ n) (hP : P n) : P m := by
   revert h hP
-  refine' leRecOn' mn _ _
+  refine leRecOn' mn ?_ ?_
   · intro n mn ih h hP
     apply ih
     · exact fun k hk ↦ h k (Nat.lt.step hk)
@@ -1446,9 +1446,9 @@ lemma le_of_lt_add_of_dvd (h : a < b + n) : n ∣ a → n ∣ b → a ≤ b := b
 /-- `n` is not divisible by `a` iff it is between `a * k` and `a * (k + 1)` for some `k`. -/
 lemma not_dvd_iff_between_consec_multiples (n : ℕ) {a : ℕ} (ha : 0 < a) :
     (∃ k : ℕ, a * k < n ∧ n < a * (k + 1)) ↔ ¬a ∣ n := by
-  refine'
+  refine
     ⟨fun ⟨k, hk1, hk2⟩ => not_dvd_of_between_consec_multiples hk1 hk2, fun han =>
-      ⟨n / a, ⟨lt_of_le_of_ne (mul_div_le n a) _, lt_mul_div_succ _ ha⟩⟩⟩
+      ⟨n / a, ⟨lt_of_le_of_ne (mul_div_le n a) ?_, lt_mul_div_succ _ ha⟩⟩⟩
   exact mt (⟨n / a, Eq.symm ·⟩) han
 #align nat.not_dvd_iff_between_consec_multiples Nat.not_dvd_iff_between_consec_multiples
 
@@ -1664,7 +1664,7 @@ lemma sqrt_eq' (n : ℕ) : sqrt (n ^ 2) = n := sqrt_add_eq' n (zero_le _)
 lemma sqrt_succ_le_succ_sqrt (n : ℕ) : sqrt n.succ ≤ n.sqrt.succ :=
   le_of_lt_succ <| sqrt_lt.2 <| lt_succ_of_le <|
   succ_le_succ <| le_trans (sqrt_le_add n) <| Nat.add_le_add_right
-    (by refine' add_le_add (Nat.mul_le_mul_right _ _) _ <;> exact Nat.le_add_right _ 2) _
+    (by refine add_le_add (Nat.mul_le_mul_right _ ?_) ?_ <;> exact Nat.le_add_right _ 2) _
 #align nat.sqrt_succ_le_succ_sqrt Nat.sqrt_succ_le_succ_sqrt
 
 lemma exists_mul_self (x : ℕ) : (∃ n, n * n = x) ↔ sqrt x * sqrt x = x :=
@@ -1746,7 +1746,7 @@ lemma find_le {h : ∃ n, p n} (hn : p n) : Nat.find h ≤ n :=
 
 lemma find_comp_succ (h₁ : ∃ n, p n) (h₂ : ∃ n, p (n + 1)) (h0 : ¬ p 0) :
     Nat.find h₁ = Nat.find h₂ + 1 := by
-  refine' (find_eq_iff _).2 ⟨Nat.find_spec h₂, fun n hn ↦ _⟩
+  refine (find_eq_iff _).2 ⟨Nat.find_spec h₂, fun n hn ↦ ?_⟩
   cases n
   exacts [h0, @Nat.find_min (fun n ↦ p (n + 1)) _ h₂ _ (succ_lt_succ_iff.1 hn)]
 #align nat.find_comp_succ Nat.find_comp_succ

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -872,10 +872,10 @@ def recOnPosPrimePosCoprime {P : ℕ → Sort*} (hp : ∀ p n : ℕ, Prime p →
     by_cases ha1 : a = 1
     · rw [ha1, mul_one]
       exact hp p n hp' hn
-    refine' h (p ^ n) a (hp'.one_lt.trans_le (le_self_pow hn.ne' _)) _ _ (hp _ _ hp' hn) hPa
+    refine h (p ^ n) a (hp'.one_lt.trans_le (le_self_pow hn.ne' _)) ?_ ?_ (hp _ _ hp' hn) hPa
     · contrapose! hpa
       simp [lt_one_iff.1 (lt_of_le_of_ne hpa ha1)]
-    simpa [hn, Prime.coprime_iff_not_dvd hp']
+    · simpa [hn, Prime.coprime_iff_not_dvd hp']
 #align nat.rec_on_pos_prime_pos_coprime Nat.recOnPosPrimePosCoprime
 
 /-- Given `P 0`, `P (p ^ n)` for all prime powers, and a way to extend `P a` and `P b` to

--- a/Mathlib/Data/Nat/Factorization/PrimePow.lean
+++ b/Mathlib/Data/Nat/Factorization/PrimePow.lean
@@ -124,8 +124,8 @@ theorem Nat.Coprime.isPrimePow_dvd_mul {n a b : ℕ} (hab : Nat.Coprime a b) (hn
   rcases eq_or_ne b 0 with (rfl | hb)
   · simp only [Nat.coprime_zero_right] at hab
     simp [hab, Finset.filter_singleton, not_isPrimePow_one]
-  refine'
-    ⟨_, fun h =>
+  refine
+    ⟨?_, fun h =>
       Or.elim h (fun i => i.trans ((@dvd_mul_right a b a hab).mpr (dvd_refl a)))
           fun i => i.trans ((@dvd_mul_left a b b hab.symm).mpr (dvd_refl b))⟩
   obtain ⟨p, k, hp, _, rfl⟩ := (isPrimePow_nat_iff _).1 hn

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -105,7 +105,7 @@ theorem lt_pow_iff_log_lt {b : ℕ} (hb : 1 < b) {x y : ℕ} (hy : y ≠ 0) : y 
 #align nat.lt_pow_iff_log_lt Nat.lt_pow_iff_log_lt
 
 theorem pow_le_of_le_log {b x y : ℕ} (hy : y ≠ 0) (h : x ≤ log b y) : b ^ x ≤ y := by
-  refine' (le_or_lt b 1).elim (fun hb => _) fun hb => (pow_le_iff_le_log hb hy).2 h
+  refine (le_or_lt b 1).elim (fun hb => ?_) fun hb => (pow_le_iff_le_log hb hy).2 h
   rw [log_of_left_le_one hb, Nat.le_zero] at h
   rwa [h, Nat.pow_zero, one_le_iff_ne_zero]
 #align nat.pow_le_of_le_log Nat.pow_le_of_le_log
@@ -180,7 +180,7 @@ theorem pow_log_le_add_one (b : ℕ) : ∀ x, b ^ log b x ≤ x + 1
 #align nat.pow_log_le_add_one Nat.pow_log_le_add_one
 
 theorem log_monotone {b : ℕ} : Monotone (log b) := by
-  refine' monotone_nat_of_le_succ fun n => _
+  refine monotone_nat_of_le_succ fun n => ?_
   rcases le_or_lt b 1 with hb | hb
   · rw [log_of_left_le_one hb]
     exact zero_le _
@@ -288,7 +288,7 @@ theorem le_pow_iff_clog_le {b : ℕ} (hb : 1 < b) {x y : ℕ} : x ≤ b ^ y ↔ 
   induction' x using Nat.strong_induction_on with x ih generalizing y
   cases y
   · rw [Nat.pow_zero]
-    refine' ⟨fun h => (clog_of_right_le_one h b).le, _⟩
+    refine ⟨fun h => (clog_of_right_le_one h b).le, ?_⟩
     simp_rw [← not_lt]
     contrapose!
     exact clog_pos hb

--- a/Mathlib/Data/Nat/PSub.lean
+++ b/Mathlib/Data/Nat/PSub.lean
@@ -85,7 +85,7 @@ theorem psub_eq_some {m : ℕ} : ∀ {n k}, psub m n = some k ↔ k + n = m
 theorem psub_eq_none {m n : ℕ} : psub m n = none ↔ m < n := by
   cases s : psub m n <;> simp [eq_comm]
   · show m < n
-    refine' lt_of_not_ge fun h => _
+    refine lt_of_not_ge fun h => ?_
     cases' le.dest h with k e
     injection s.symm.trans (psub_eq_some.2 <| (add_comm _ _).trans e)
   · show n ≤ m

--- a/Mathlib/Data/Ordmap/Ordnode.lean
+++ b/Mathlib/Data/Ordmap/Ordnode.lean
@@ -212,7 +212,7 @@ def balanceL (l : Ordnode α) (x : α) (r : Ordnode α) : Ordnode α := by
                 (node (size lrr + 1) lrr x nil)
   · cases' id l with ls ll lx lr
     · exact node (rs + 1) nil x r
-    · refine' if ls > delta * rs then _ else node (ls + rs + 1) l x r
+    · refine if ls > delta * rs then ?_ else node (ls + rs + 1) l x r
       cases' id ll with lls
       · exact nil
       --should not happen
@@ -248,7 +248,7 @@ def balanceR (l : Ordnode α) (x : α) (r : Ordnode α) : Ordnode α := by
                 (node (size rlr + rrs + 1) rlr rx rr)
   · cases' id r with rs rl rx rr
     · exact node (ls + 1) l x nil
-    · refine' if rs > delta * ls then _ else node (ls + rs + 1) l x r
+    · refine if rs > delta * ls then ?_ else node (ls + rs + 1) l x r
       cases' id rr with rrs
       · exact nil
       --should not happen
@@ -294,8 +294,8 @@ def balance (l : Ordnode α) (x : α) (r : Ordnode α) : Ordnode α := by
             else
               node (ls + 1) (node (lls + size lrl + 1) ll lx lrl) lrx
                 (node (size lrr + 1) lrr x nil)
-    · refine'
-        if delta * ls < rs then _ else if delta * rs < ls then _ else node (ls + rs + 1) l x r
+    · refine
+        if delta * ls < rs then ?_ else if delta * rs < ls then ?_ else node (ls + rs + 1) l x r
       · cases' id rl with rls rll rlx rlr
         · exact nil
         --should not happen

--- a/Mathlib/Data/PSigma/Order.lean
+++ b/Mathlib/Data/PSigma/Order.lean
@@ -69,7 +69,7 @@ instance preorder [Preorder ι] [∀ i, Preorder (α i)] : Preorder (Σₗ' i, �
         apply le_trans
         repeat' assumption,
     lt_iff_le_not_le := by
-      refine' fun a b => ⟨fun hab => ⟨hab.mono_right fun i a b => le_of_lt, _⟩, _⟩
+      refine fun a b => ⟨fun hab => ⟨hab.mono_right fun i a b => le_of_lt, ?_⟩, ?_⟩
       · rintro (⟨i, a, hji⟩ | ⟨i, hba⟩) <;> obtain ⟨_, _, hij⟩ | ⟨_, hab⟩ := hab
         · exact hij.not_lt hji
         · exact lt_irrefl _ hji

--- a/Mathlib/Data/Part.lean
+++ b/Mathlib/Data/Part.lean
@@ -498,7 +498,7 @@ theorem mem_bind_iff {f : Part α} {g : α → Part β} {b} : b ∈ f.bind g ↔
 protected theorem Dom.bind {o : Part α} (h : o.Dom) (f : α → Part β) : o.bind f = f (o.get h) := by
   ext b
   simp only [Part.mem_bind_iff, exists_prop]
-  refine' ⟨_, fun hb => ⟨o.get h, Part.get_mem _, hb⟩⟩
+  refine ⟨?_, fun hb => ⟨o.get h, Part.get_mem _, hb⟩⟩
   rintro ⟨a, ha, hb⟩
   rwa [Part.get_eq_of_mem ha]
 #align part.dom.bind Part.Dom.bind

--- a/Mathlib/Data/QPF/Multivariate/Constructions/Cofix.lean
+++ b/Mathlib/Data/QPF/Multivariate/Constructions/Cofix.lean
@@ -431,17 +431,14 @@ variable {F: TypeVec (n + 1) → Type u} [MvFunctor F] [q : MvQPF F]
 
 theorem Cofix.abs_repr {α} (x : Cofix F α) : Quot.mk _ (Cofix.repr x) = x := by
   let R := fun x y : Cofix F α => abs (repr y) = x
-  refine' Cofix.bisim₂ R _ _ _ rfl
-  clear x;
-  rintro x y h;
+  refine Cofix.bisim₂ R ?_ _ _ rfl
+  clear x
+  rintro x y h
   subst h
   dsimp [Cofix.dest, Cofix.abs]
   induction y using Quot.ind
   simp only [Cofix.repr, M.dest_corec, abs_map, MvQPF.abs_repr, Function.comp]
-  conv =>
-    congr
-    rfl
-    rw [Cofix.dest]
+  conv => congr; rfl; rw [Cofix.dest]
   rw [MvFunctor.map_map, MvFunctor.map_map, ← appendFun_comp_id, ← appendFun_comp_id]
   apply liftR_map_last
   intros

--- a/Mathlib/Data/Seq/Seq.lean
+++ b/Mathlib/Data/Seq/Seq.lean
@@ -676,9 +676,9 @@ theorem append_assoc (s t u : Seq α) : append (append s t) u = append s (append
         · apply recOn t <;> simp
           · apply recOn u <;> simp
             · intro _ u
-              refine' ⟨nil, nil, u, _, _⟩ <;> simp
+              refine ⟨nil, nil, u, ?_, ?_⟩ <;> simp
           · intro _ t
-            refine' ⟨nil, t, u, _, _⟩ <;> simp
+            refine ⟨nil, t, u, ?_, ?_⟩ <;> simp
         · intro _ s
           exact ⟨s, t, u, rfl, rfl⟩
   · exact ⟨s, t, u, rfl, rfl⟩
@@ -725,7 +725,7 @@ theorem map_append (f : α → β) (s t) : map f (append s t) = append (map f s)
       apply recOn s <;> simp
       · apply recOn t <;> simp
         · intro _ t
-          refine' ⟨nil, t, _, _⟩ <;> simp
+          refine ⟨nil, t, ?_, ?_⟩ <;> simp
       · intro _ s
         exact ⟨s, t, rfl, rfl⟩
 #align stream.seq.map_append Stream'.Seq.map_append
@@ -794,13 +794,13 @@ theorem join_append (S T : Seq (Seq1 α)) : join (append S T) = append (join S) 
             · simp
             · intro s T
               cases' s with a s; simp only [join_cons, destruct_cons, true_and]
-              refine' ⟨s, nil, T, _, _⟩ <;> simp
+              refine ⟨s, nil, T, ?_, ?_⟩ <;> simp
           · intro s S
             cases' s with a s
             simpa using ⟨s, S, T, rfl, rfl⟩
         · intro _ s
           exact ⟨s, S, T, rfl, rfl⟩
-  · refine' ⟨nil, S, T, _, _⟩ <;> simp
+  · refine ⟨nil, S, T, ?_, ?_⟩ <;> simp
 #align stream.seq.join_append Stream'.Seq.join_append
 
 @[simp]
@@ -995,7 +995,7 @@ theorem map_join' (f : α → β) (S) : Seq.map f (Seq.join S) = Seq.join (Seq.m
             simpa [map] using ⟨_, _, rfl, rfl⟩
         · intro _ s
           exact ⟨s, S, rfl, rfl⟩
-  · refine' ⟨nil, S, _, _⟩ <;> simp
+  · refine ⟨nil, S, ?_, ?_⟩ <;> simp
 #align stream.seq1.map_join' Stream'.Seq1.map_join'
 
 @[simp]
@@ -1022,10 +1022,10 @@ theorem join_join (SS : Seq (Seq1 (Seq1 α))) :
             apply recOn s <;> simp
             · exact ⟨_, _, rfl, rfl⟩
             · intro x s
-              refine' ⟨Seq.cons x (append s (Seq.join S)), SS, _, _⟩ <;> simp
+              refine ⟨Seq.cons x (append s (Seq.join S)), SS, ?_, ?_⟩ <;> simp
         · intro _ s
           exact ⟨s, SS, rfl, rfl⟩
-  · refine' ⟨nil, SS, _, _⟩ <;> simp
+  · refine ⟨nil, SS, ?_, ?_⟩ <;> simp
 #align stream.seq1.join_join Stream'.Seq1.join_join
 
 @[simp]

--- a/Mathlib/Data/Seq/WSeq.lean
+++ b/Mathlib/Data/Seq/WSeq.lean
@@ -1760,10 +1760,10 @@ theorem map_join (f : α → β) (S) : map f (join S) = join (map (map f) S) := 
         induction' s using WSeq.recOn with a s s <;> simp
         · induction' S using WSeq.recOn with s S S <;> simp
           · exact ⟨map f s, S, rfl, rfl⟩
-          · refine' ⟨nil, S, _, _⟩ <;> simp
+          · refine ⟨nil, S, ?_, ?_⟩ <;> simp
         · exact ⟨_, _, rfl, rfl⟩
         · exact ⟨_, _, rfl, rfl⟩
-  · refine' ⟨nil, S, _, _⟩ <;> simp
+  · refine ⟨nil, S, ?_, ?_⟩ <;> simp
 #align stream.wseq.map_join Stream'.WSeq.map_join
 
 @[simp]

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1133,7 +1133,7 @@ theorem insert_subset_insert (h : s ⊆ t) : insert a s ⊆ insert a t := fun _ 
 #align set.insert_subset_insert Set.insert_subset_insert
 
 @[simp] theorem insert_subset_insert_iff (ha : a ∉ s) : insert a s ⊆ insert a t ↔ s ⊆ t := by
-  refine' ⟨fun h x hx => _, insert_subset_insert⟩
+  refine ⟨fun h x hx => ?_, insert_subset_insert⟩
   rcases h (subset_insert _ _ hx) with (rfl | hxt)
   exacts [(ha hx).elim, hxt]
 #align set.insert_subset_insert_iff Set.insert_subset_insert_iff
@@ -2310,7 +2310,7 @@ theorem ite_inter_of_inter_eq (t : Set α) {s₁ s₂ s : Set α} (h : s₁ ∩ 
 
 theorem subset_ite {t s s' u : Set α} : u ⊆ t.ite s s' ↔ u ∩ t ⊆ s ∧ u \ t ⊆ s' := by
   simp only [subset_def, ← forall_and]
-  refine' forall_congr' fun x => _
+  refine forall_congr' fun x => ?_
   by_cases hx : x ∈ t <;> simp [*, Set.ite]
 #align set.subset_ite Set.subset_ite
 

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -138,7 +138,7 @@ theorem range_extend_subset (f : α → β) (g : α → γ) (g' : β → γ) :
 
 theorem range_extend {f : α → β} (hf : Injective f) (g : α → γ) (g' : β → γ) :
     range (extend f g g') = range g ∪ g' '' (range f)ᶜ := by
-  refine' (range_extend_subset _ _ _).antisymm _
+  refine (range_extend_subset _ _ _).antisymm ?_
   rintro z (⟨x, rfl⟩ | ⟨y, hy, rfl⟩)
   exacts [⟨f x, hf.extend_apply _ _ _⟩, ⟨y, extend_apply' _ _ _ hy⟩]
 #align set.range_extend Set.range_extend
@@ -646,7 +646,7 @@ theorem InjOn.mono (h : s₁ ⊆ s₂) (ht : InjOn f s₂) : InjOn f s₁ := fun
 
 theorem injOn_union (h : Disjoint s₁ s₂) :
     InjOn f (s₁ ∪ s₂) ↔ InjOn f s₁ ∧ InjOn f s₂ ∧ ∀ x ∈ s₁, ∀ y ∈ s₂, f x ≠ f y := by
-  refine' ⟨fun H => ⟨H.mono <| subset_union_left _ _, H.mono <| subset_union_right _ _, _⟩, _⟩
+  refine ⟨fun H => ⟨H.mono <| subset_union_left _ _, H.mono <| subset_union_right _ _, ?_⟩, ?_⟩
   · intro x hx y hy hxy
     obtain rfl : x = y := H (Or.inl hx) (Or.inr hy) hxy
     exact h.le_bot ⟨hx, hy⟩
@@ -937,7 +937,7 @@ theorem SurjOn.image_eq_of_mapsTo (h₁ : SurjOn f s t) (h₂ : MapsTo f s t) : 
 #align set.surj_on.image_eq_of_maps_to Set.SurjOn.image_eq_of_mapsTo
 
 theorem image_eq_iff_surjOn_mapsTo : f '' s = t ↔ s.SurjOn f t ∧ s.MapsTo f t := by
-  refine' ⟨_, fun h => h.1.image_eq_of_mapsTo h.2⟩
+  refine ⟨?_, fun h => h.1.image_eq_of_mapsTo h.2⟩
   rintro rfl
   exact ⟨s.surjOn_image f, s.mapsTo_image f⟩
 #align set.image_eq_iff_surj_on_maps_to Set.image_eq_iff_surjOn_mapsTo
@@ -1164,7 +1164,7 @@ theorem image_inter' (hf : LeftInvOn f' f s) : f '' (s₁ ∩ s) = f' ⁻¹' s�
 theorem image_inter (hf : LeftInvOn f' f s) :
     f '' (s₁ ∩ s) = f' ⁻¹' (s₁ ∩ s) ∩ f '' s := by
   rw [hf.image_inter']
-  refine' Subset.antisymm _ (inter_subset_inter_left _ (preimage_mono <| inter_subset_left _ _))
+  refine Subset.antisymm ?_ (inter_subset_inter_left _ (preimage_mono <| inter_subset_left _ _))
   rintro _ ⟨h₁, x, hx, rfl⟩; exact ⟨⟨h₁, by rwa [hf hx]⟩, mem_image_of_mem _ hx⟩
 #align set.left_inv_on.image_inter Set.LeftInvOn.image_inter
 
@@ -1363,7 +1363,7 @@ theorem BijOn.invOn_invFunOn [Nonempty α] (h : BijOn f s t) : InvOn (invFunOn f
 
 theorem SurjOn.invOn_invFunOn [Nonempty α] (h : SurjOn f s t) :
     InvOn (invFunOn f s) f (invFunOn f s '' t) t := by
-  refine' ⟨_, h.rightInvOn_invFunOn⟩
+  refine ⟨?_, h.rightInvOn_invFunOn⟩
   rintro _ ⟨y, hy, rfl⟩
   rw [h.rightInvOn_invFunOn hy]
 #align set.surj_on.inv_on_inv_fun_on Set.SurjOn.invOn_invFunOn
@@ -1373,7 +1373,7 @@ theorem SurjOn.mapsTo_invFunOn [Nonempty α] (h : SurjOn f s t) : MapsTo (invFun
 #align set.surj_on.maps_to_inv_fun_on Set.SurjOn.mapsTo_invFunOn
 
 theorem SurjOn.bijOn_subset [Nonempty α] (h : SurjOn f s t) : BijOn f (invFunOn f s '' t) t := by
-  refine' h.invOn_invFunOn.bijOn _ (mapsTo_image _ _)
+  refine h.invOn_invFunOn.bijOn ?_ (mapsTo_image _ _)
   rintro _ ⟨y, hy, rfl⟩
   rwa [h.rightInvOn_invFunOn hy]
 #align set.surj_on.bij_on_subset Set.SurjOn.bijOn_subset
@@ -1558,7 +1558,7 @@ theorem MapsTo.piecewise_ite {s s₁ s₂ : Set α} {t t₁ t₂ : Set β} {f₁
     [∀ i, Decidable (i ∈ s)] (h₁ : MapsTo f₁ (s₁ ∩ s) (t₁ ∩ t))
     (h₂ : MapsTo f₂ (s₂ ∩ sᶜ) (t₂ ∩ tᶜ)) :
     MapsTo (s.piecewise f₁ f₂) (s.ite s₁ s₂) (t.ite t₁ t₂) := by
-  refine' (h₁.congr _).union_union (h₂.congr _)
+  refine (h₁.congr ?_).union_union (h₂.congr ?_)
   exacts [(piecewise_eqOn s f₁ f₂).symm.mono (inter_subset_right _ _),
     (piecewise_eqOn_compl s f₁ f₂).symm.mono (inter_subset_right _ _)]
 #align set.maps_to.piecewise_ite Set.MapsTo.piecewise_ite
@@ -1566,7 +1566,7 @@ theorem MapsTo.piecewise_ite {s s₁ s₂ : Set α} {t t₁ t₂ : Set β} {f₁
 theorem eqOn_piecewise {f f' g : α → β} {t} :
     EqOn (s.piecewise f f') g t ↔ EqOn f g (t ∩ s) ∧ EqOn f' g (t ∩ sᶜ) := by
   simp only [EqOn, ← forall_and]
-  refine' forall_congr' fun a => _; by_cases a ∈ s <;> simp [*]
+  refine forall_congr' fun a => ?_; by_cases a ∈ s <;> simp [*]
 #align set.eq_on_piecewise Set.eqOn_piecewise
 
 theorem EqOn.piecewise_ite' {f f' g : α → β} {t t'} (h : EqOn f g (t ∩ s))
@@ -1624,7 +1624,7 @@ theorem injective_piecewise_iff {f g : α → β} :
       InjOn f s ∧ InjOn g sᶜ ∧ ∀ x ∈ s, ∀ y ∉ s, f x ≠ g y := by
   rw [injective_iff_injOn_univ, ← union_compl_self s, injOn_union (@disjoint_compl_right _ _ s),
     (piecewise_eqOn s f g).injOn_iff, (piecewise_eqOn_compl s f g).injOn_iff]
-  refine' and_congr Iff.rfl (and_congr Iff.rfl <| forall₄_congr fun x hx y hy => _)
+  refine and_congr Iff.rfl (and_congr Iff.rfl <| forall₄_congr fun x hx y hy => ?_)
   rw [piecewise_eq_of_mem s f g hx, piecewise_eq_of_not_mem s f g hy]
 #align set.injective_piecewise_iff Set.injective_piecewise_iff
 

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -301,7 +301,9 @@ lemma monotone_image {f : α → β} : Monotone (image f) := fun _ _ => image_su
 theorem image_union (f : α → β) (s t : Set α) : f '' (s ∪ t) = f '' s ∪ f '' t :=
   ext fun x =>
     ⟨by rintro ⟨a, h | h, rfl⟩ <;> [left; right] <;> exact ⟨_, h, rfl⟩, by
-      rintro (⟨a, h, rfl⟩ | ⟨a, h, rfl⟩) <;> refine' ⟨_, _, rfl⟩ <;> [left; right] <;> exact h⟩
+      rintro (⟨a, h, rfl⟩ | ⟨a, h, rfl⟩) <;> refine ⟨_, ?_, rfl⟩
+      · exact mem_union_left t h
+      · exact mem_union_right s h⟩
 #align set.image_union Set.image_union
 
 @[simp]
@@ -576,7 +578,7 @@ theorem subset_image_iff {t : Set β} :
   rwa [image_preimage_inter, inter_eq_left]
 
 theorem image_subset_image_iff {f : α → β} (hf : Injective f) : f '' s ⊆ f '' t ↔ s ⊆ t := by
-  refine' Iff.symm <| (Iff.intro (image_subset f)) fun h => _
+  refine Iff.symm <| (Iff.intro (image_subset f)) fun h => ?_
   rw [← preimage_image_eq s hf, ← preimage_image_eq t hf]
   exact preimage_mono h
 #align set.image_subset_image_iff Set.image_subset_image_iff
@@ -613,10 +615,10 @@ theorem surjective_onto_image {f : α → β} {s : Set α} : Surjective (imageFa
 theorem image_perm {s : Set α} {σ : Equiv.Perm α} (hs : { a : α | σ a ≠ a } ⊆ s) : σ '' s = s := by
   ext i
   obtain hi | hi := eq_or_ne (σ i) i
-  · refine' ⟨_, fun h => ⟨i, h, hi⟩⟩
+  · refine ⟨?_, fun h => ⟨i, h, hi⟩⟩
     rintro ⟨j, hj, h⟩
     rwa [σ.injective (hi.trans h.symm)]
-  · refine' iff_of_true ⟨σ.symm i, hs fun h => hi _, σ.apply_symm_apply _⟩ (hs hi)
+  · refine iff_of_true ⟨σ.symm i, hs fun h => hi ?_, σ.apply_symm_apply _⟩ (hs hi)
     convert congr_arg σ h <;> exact (σ.apply_symm_apply _).symm
 #align set.image_perm Set.image_perm
 
@@ -632,7 +634,7 @@ theorem powerset_insert (s : Set α) (a : α) : 𝒫 insert a s = 𝒫 s ∪ ins
   · intro h
     by_cases hs : a ∈ t
     · right
-      refine' ⟨t \ {a}, _, _⟩
+      refine ⟨t \ {a}, ?_, ?_⟩
       · rw [diff_singleton_subset_iff]
         assumption
       · rw [insert_diff_singleton, insert_eq_of_mem hs]
@@ -1485,8 +1487,8 @@ namespace Option
 theorem injective_iff {α β} {f : Option α → β} :
     Injective f ↔ Injective (f ∘ some) ∧ f none ∉ range (f ∘ some) := by
   simp only [mem_range, not_exists, (· ∘ ·)]
-  refine'
-    ⟨fun hf => ⟨hf.comp (Option.some_injective _), fun x => hf.ne <| Option.some_ne_none _⟩, _⟩
+  refine
+    ⟨fun hf => ⟨hf.comp (Option.some_injective _), fun x => hf.ne <| Option.some_ne_none _⟩, ?_⟩
   rintro ⟨h_some, h_none⟩ (_ | a) (_ | b) hab
   exacts [rfl, (h_none _ hab.symm).elim, (h_none _ hab).elim, congr_arg some (h_some hab)]
 #align option.injective_iff Option.injective_iff
@@ -1520,7 +1522,7 @@ variable {α : Type u} {β : Type v} {f : α → β}
 
 @[simp]
 theorem preimage_injective : Injective (preimage f) ↔ Surjective f := by
-  refine' ⟨fun h y => _, Surjective.preimage_injective⟩
+  refine ⟨fun h y => ?_, Surjective.preimage_injective⟩
   obtain ⟨x, hx⟩ : (f ⁻¹' {y}).Nonempty := by
     rw [h.nonempty_apply_iff preimage_empty]
     apply singleton_nonempty
@@ -1529,14 +1531,14 @@ theorem preimage_injective : Injective (preimage f) ↔ Surjective f := by
 
 @[simp]
 theorem preimage_surjective : Surjective (preimage f) ↔ Injective f := by
-  refine' ⟨fun h x x' hx => _, Injective.preimage_surjective⟩
+  refine ⟨fun h x x' hx => ?_, Injective.preimage_surjective⟩
   cases' h {x} with s hs; have := mem_singleton x
   rwa [← hs, mem_preimage, hx, ← mem_preimage, hs, mem_singleton_iff, eq_comm] at this
 #align set.preimage_surjective Set.preimage_surjective
 
 @[simp]
 theorem image_surjective : Surjective (image f) ↔ Surjective f := by
-  refine' ⟨fun h y => _, Surjective.image_surjective⟩
+  refine ⟨fun h y => ?_, Surjective.image_surjective⟩
   cases' h {y} with s hs
   have := mem_singleton y; rw [← hs] at this; rcases this with ⟨x, _, hx⟩
   exact ⟨x, hx⟩
@@ -1544,7 +1546,7 @@ theorem image_surjective : Surjective (image f) ↔ Surjective f := by
 
 @[simp]
 theorem image_injective : Injective (image f) ↔ Injective f := by
-  refine' ⟨fun h x x' hx => _, Injective.image_injective⟩
+  refine ⟨fun h x x' hx => ?_, Injective.image_injective⟩
   rw [← singleton_eq_singleton_iff]; apply h
   rw [image_singleton, image_singleton, hx]
 #align set.image_injective Set.image_injective

--- a/Mathlib/Data/Set/List.lean
+++ b/Mathlib/Data/Set/List.lean
@@ -43,7 +43,7 @@ theorem range_list_get : range l.get = { x | x ∈ l } := by
 
 theorem range_list_get? : range l.get? = insert none (some '' { x | x ∈ l }) := by
   rw [← range_list_get, ← range_comp]
-  refine' (range_subset_iff.2 fun n => _).antisymm (insert_subset_iff.2 ⟨_, _⟩)
+  refine (range_subset_iff.2 fun n => ?_).antisymm (insert_subset_iff.2 ⟨?_, ?_⟩)
   exacts [(le_or_lt l.length n).imp get?_eq_none.2 (fun hlt => ⟨⟨_, hlt⟩, (get?_eq_get hlt).symm⟩),
     ⟨_, get?_eq_none.2 le_rfl⟩, range_subset_iff.2 fun k => ⟨_, get?_eq_get _⟩]
 #align set.range_list_nth Set.range_list_get?

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -386,7 +386,7 @@ theorem prod_subset_prod_iff : s ×ˢ t ⊆ s₁ ×ˢ t₁ ↔ s ⊆ s₁ ∧ t 
   rcases (s ×ˢ t).eq_empty_or_nonempty with h | h
   · simp [h, prod_eq_empty_iff.1 h]
   have st : s.Nonempty ∧ t.Nonempty := by rwa [prod_nonempty_iff] at h
-  refine' ⟨fun H => Or.inl ⟨_, _⟩, _⟩
+  refine ⟨fun H => Or.inl ⟨?_, ?_⟩, ?_⟩
   · have := image_subset (Prod.fst : α × β → α) H
     rwa [fst_image_prod _ st.2, fst_image_prod _ (h.mono H).snd] at this
   · have := image_subset (Prod.snd : α × β → β) H
@@ -759,7 +759,7 @@ theorem univ_pi_nonempty_iff : (pi univ t).Nonempty ↔ ∀ i, (t i).Nonempty :=
 theorem pi_eq_empty_iff : s.pi t = ∅ ↔ ∃ i, IsEmpty (α i) ∨ i ∈ s ∧ t i = ∅ := by
   rw [← not_nonempty_iff_eq_empty, pi_nonempty_iff]
   push_neg
-  refine' exists_congr fun i => _
+  refine exists_congr fun i => ?_
   cases isEmpty_or_nonempty (α i) <;> simp [*, forall_and, eq_empty_iff_forall_not_mem]
 #align set.pi_eq_empty_iff Set.pi_eq_empty_iff
 
@@ -839,7 +839,7 @@ theorem pi_if {p : ι → Prop} [h : DecidablePred p] (s : Set ι) (t₁ t₂ : 
     (pi s fun i => if p i then t₁ i else t₂ i) =
       pi ({ i ∈ s | p i }) t₁ ∩ pi ({ i ∈ s | ¬p i }) t₂ := by
   ext f
-  refine' ⟨fun h => _, _⟩
+  refine ⟨fun h => ?_, ?_⟩
   · constructor <;>
       · rintro i ⟨his, hpi⟩
         simpa [*] using h i
@@ -914,7 +914,7 @@ theorem eval_image_univ_pi_subset : eval i '' pi univ t ⊆ t i :=
 theorem subset_eval_image_pi (ht : (s.pi t).Nonempty) (i : ι) : t i ⊆ eval i '' s.pi t := by
   classical
   obtain ⟨f, hf⟩ := ht
-  refine' fun y hy => ⟨update f i y, fun j hj => _, update_same _ _ _⟩
+  refine fun y hy => ⟨update f i y, fun j hj => ?_, update_same _ _ _⟩
   obtain rfl | hji := eq_or_ne j i <;> simp [*, hf _ hj]
 #align set.subset_eval_image_pi Set.subset_eval_image_pi
 
@@ -929,8 +929,8 @@ theorem eval_image_univ_pi (ht : (pi univ t).Nonempty) :
 #align set.eval_image_univ_pi Set.eval_image_univ_pi
 
 theorem pi_subset_pi_iff : pi s t₁ ⊆ pi s t₂ ↔ (∀ i ∈ s, t₁ i ⊆ t₂ i) ∨ pi s t₁ = ∅ := by
-  refine'
-    ⟨fun h => or_iff_not_imp_right.2 _, fun h => h.elim pi_mono fun h' => h'.symm ▸ empty_subset _⟩
+  refine
+    ⟨fun h => or_iff_not_imp_right.2 ?_, fun h => h.elim pi_mono fun h' => h'.symm ▸ empty_subset _⟩
   rw [← Ne, ← nonempty_iff_ne_empty]
   intro hne i hi
   simpa only [eval_image_pi hi hne, eval_image_pi hi (hne.mono h)] using
@@ -956,7 +956,7 @@ theorem eval_preimage' [DecidableEq ι] {s : Set (α i)} :
 theorem update_preimage_pi [DecidableEq ι] {f : ∀ i, α i} (hi : i ∈ s)
     (hf : ∀ j ∈ s, j ≠ i → f j ∈ t j) : update f i ⁻¹' s.pi t = t i := by
   ext x
-  refine' ⟨fun h => _, fun hx j hj => _⟩
+  refine ⟨fun h => ?_, fun hx j hj => ?_⟩
   · convert h i hi
     simp
   · obtain rfl | h := eq_or_ne j i
@@ -978,7 +978,7 @@ theorem univ_pi_ite (s : Set ι) [DecidablePred (· ∈ s)] (t : ∀ i, Set (α 
     (pi univ fun i => if i ∈ s then t i else univ) = s.pi t := by
   ext
   simp_rw [mem_univ_pi]
-  refine' forall_congr' fun i => _
+  refine forall_congr' fun i => ?_
   split_ifs with h <;> simp [h]
 #align set.univ_pi_ite Set.univ_pi_ite
 

--- a/Mathlib/Data/Set/Subsingleton.lean
+++ b/Mathlib/Data/Set/Subsingleton.lean
@@ -98,7 +98,7 @@ theorem subsingleton_isBot (α : Type*) [PartialOrder α] : Set.Subsingleton { x
 
 theorem exists_eq_singleton_iff_nonempty_subsingleton :
     (∃ a : α, s = {a}) ↔ s.Nonempty ∧ s.Subsingleton := by
-  refine' ⟨_, fun h => _⟩
+  refine ⟨?_, fun h => ?_⟩
   · rintro ⟨a, rfl⟩
     exact ⟨singleton_nonempty a, subsingleton_singleton⟩
   · exact h.2.eq_empty_or_singleton.resolve_left h.1.ne_empty
@@ -108,7 +108,7 @@ theorem exists_eq_singleton_iff_nonempty_subsingleton :
 @[simp, norm_cast]
 theorem subsingleton_coe (s : Set α) : Subsingleton s ↔ s.Subsingleton := by
   constructor
-  · refine' fun h => fun a ha b hb => _
+  · refine fun h => fun a ha b hb => ?_
     exact SetCoe.ext_iff.2 (@Subsingleton.elim s h ⟨a, ha⟩ ⟨b, hb⟩)
   · exact fun h => Subsingleton.intro fun a b => SetCoe.ext (h a.property b.property)
 #align set.subsingleton_coe Set.subsingleton_coe

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -476,16 +476,16 @@ end Setoid
 theorem Quotient.subsingleton_iff {s : Setoid α} : Subsingleton (Quotient s) ↔ s = ⊤ := by
   simp only [_root_.subsingleton_iff, eq_top_iff, Setoid.le_def, Setoid.top_def, Pi.top_apply,
     forall_const]
-  refine' (surjective_quotient_mk' _).forall.trans (forall_congr' fun a => _)
-  refine' (surjective_quotient_mk' _).forall.trans (forall_congr' fun b => _)
+  refine (surjective_quotient_mk' _).forall.trans (forall_congr' fun a => ?_)
+  refine (surjective_quotient_mk' _).forall.trans (forall_congr' fun b => ?_)
   simp_rw [Prop.top_eq_true, true_implies, Quotient.eq']
   rfl
 #align quotient.subsingleton_iff Quotient.subsingleton_iff
 
 theorem Quot.subsingleton_iff (r : α → α → Prop) : Subsingleton (Quot r) ↔ EqvGen r = ⊤ := by
   simp only [_root_.subsingleton_iff, _root_.eq_top_iff, Pi.le_def, Pi.top_apply, forall_const]
-  refine' (surjective_quot_mk _).forall.trans (forall_congr' fun a => _)
-  refine' (surjective_quot_mk _).forall.trans (forall_congr' fun b => _)
+  refine (surjective_quot_mk _).forall.trans (forall_congr' fun a => ?_)
+  refine (surjective_quot_mk _).forall.trans (forall_congr' fun b => ?_)
   rw [Quot.eq]
   simp only [forall_const, le_Prop_eq, Pi.top_apply, Prop.top_eq_true, true_implies]
 #align quot.subsingleton_iff Quot.subsingleton_iff

--- a/Mathlib/Data/Sigma/Order.lean
+++ b/Mathlib/Data/Sigma/Order.lean
@@ -155,7 +155,7 @@ instance preorder [Preorder ι] [∀ i, Preorder (α i)] : Preorder (Σₗ i, α
     le_refl := fun ⟨i, a⟩ => Lex.right a a le_rfl,
     le_trans := fun _ _ _ => trans_of ((Lex (· < ·)) fun _ => (· ≤ ·)),
     lt_iff_le_not_le := by
-      refine' fun a b => ⟨fun hab => ⟨hab.mono_right fun i a b => le_of_lt, _⟩, _⟩
+      refine fun a b => ⟨fun hab => ⟨hab.mono_right fun i a b => le_of_lt, ?_⟩, ?_⟩
       · rintro (⟨b, a, hji⟩ | ⟨b, a, hba⟩) <;> obtain ⟨_, _, hij⟩ | ⟨_, _, hab⟩ := hab
         · exact hij.not_lt hji
         · exact lt_irrefl _ hji

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -174,7 +174,7 @@ instance instPreorderSum : Preorder (Sum α β) :=
     le_refl := fun x => LiftRel.refl _ _ _,
     le_trans := fun _ _ _ => LiftRel.trans _ _,
     lt_iff_le_not_le := fun a b => by
-      refine' ⟨fun hab => ⟨hab.mono (fun _ _ => le_of_lt) fun _ _ => le_of_lt, _⟩, _⟩
+      refine ⟨fun hab => ⟨hab.mono (fun _ _ => le_of_lt) fun _ _ => le_of_lt, ?_⟩, ?_⟩
       · rintro (⟨hba⟩ | ⟨hba⟩)
         · exact hba.not_lt (inl_lt_inl_iff.1 hab)
         · exact hba.not_lt (inr_lt_inr_iff.1 hab)
@@ -382,7 +382,7 @@ instance preorder : Preorder (α ⊕ₗ β) :=
     le_refl := refl_of (Lex (· ≤ ·) (· ≤ ·)),
     le_trans := fun _ _ _ => trans_of (Lex (· ≤ ·) (· ≤ ·)),
     lt_iff_le_not_le := fun a b => by
-      refine' ⟨fun hab => ⟨hab.mono (fun _ _ => le_of_lt) fun _ _ => le_of_lt, _⟩, _⟩
+      refine ⟨fun hab => ⟨hab.mono (fun _ _ => le_of_lt) fun _ _ => le_of_lt, ?_⟩, ?_⟩
       · rintro (⟨hba⟩ | ⟨hba⟩ | ⟨b, a⟩)
         · exact hba.not_lt (inl_lt_inl_iff.1 hab)
         · exact hba.not_lt (inr_lt_inr_iff.1 hab)

--- a/Mathlib/Data/ZMod/Quotient.lean
+++ b/Mathlib/Data/ZMod/Quotient.lean
@@ -98,7 +98,7 @@ noncomputable def zmultiplesQuotientStabilizerEquiv :
               exact isPeriodicPt_minimalPeriod (a +ᵥ ·) b))
           ⟨by
             rw [← ker_eq_bot_iff, eq_bot_iff]
-            refine' fun q => induction_on' q fun n hn => _
+            refine fun q => induction_on' q fun n hn => ?_
             rw [mem_bot, eq_zero_iff, Int.mem_zmultiples_iff, ←
               zsmul_vadd_eq_iff_minimalPeriod_dvd]
             exact (eq_zero_iff _).mp hn, fun q =>

--- a/Mathlib/Deprecated/Ring.lean
+++ b/Mathlib/Deprecated/Ring.lean
@@ -51,7 +51,7 @@ variable {β : Type v} [Semiring α] [Semiring β]
 variable {f : α → β} (hf : IsSemiringHom f) {x y : α}
 
 /-- The identity map is a semiring homomorphism. -/
-theorem id : IsSemiringHom (@id α) := by refine' { .. } <;> intros <;> rfl
+theorem id : IsSemiringHom (@id α) := by constructor <;> intros <;> rfl
 #align is_semiring_hom.id IsSemiringHom.id
 
 /-- The composition of two semiring homomorphisms is a semiring homomorphism. -/
@@ -116,7 +116,7 @@ theorem map_sub (hf : IsRingHom f) : f (x - y) = f x - f y := by
 #align is_ring_hom.map_sub IsRingHom.map_sub
 
 /-- The identity map is a ring homomorphism. -/
-theorem id : IsRingHom (@id α) := by refine' { .. } <;> intros <;> rfl
+theorem id : IsRingHom (@id α) := by constructor <;> intros <;> rfl
 #align is_ring_hom.id IsRingHom.id
 
 -- see Note [no instance on morphisms]

--- a/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
+++ b/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
@@ -691,7 +691,7 @@ theorem dist_map_zero_translationNumber_le : dist (f 0) (τ f) ≤ 1 :=
 theorem tendsto_translationNumber_of_dist_bounded_aux (x : ℕ → ℝ) (C : ℝ)
     (H : ∀ n : ℕ, dist ((f ^ n) 0) (x n) ≤ C) :
     Tendsto (fun n : ℕ => x (2 ^ n) / 2 ^ n) atTop (𝓝 <| τ f) := by
-  refine' f.tendsto_translationNumber_aux.congr_dist (squeeze_zero (fun _ => dist_nonneg) _ _)
+  apply f.tendsto_translationNumber_aux.congr_dist (squeeze_zero (fun _ => dist_nonneg) _ _)
   · exact fun n => C / 2 ^ n
   · intro n
     have : 0 < (2 ^ n : ℝ) := pow_pos zero_lt_two _

--- a/Mathlib/Dynamics/Ergodic/MeasurePreserving.lean
+++ b/Mathlib/Dynamics/Ergodic/MeasurePreserving.lean
@@ -154,7 +154,7 @@ lemma measure_symmDiff_preimage_iterate_le
     μ (s ∆ (f^[n] ⁻¹' s)) ≤ n • μ (s ∆ (f ⁻¹' s)) := by
   induction' n with n ih; · simp
   simp only [add_smul, one_smul, ← n.add_one]
-  refine' le_trans (measure_symmDiff_le s (f^[n] ⁻¹' s) (f^[n+1] ⁻¹' s)) (add_le_add ih _)
+  refine le_trans (measure_symmDiff_le s (f^[n] ⁻¹' s) (f^[n+1] ⁻¹' s)) (add_le_add ih ?_)
   replace hs : MeasurableSet (s ∆ (f ⁻¹' s)) := hs.symmDiff <| hf.measurable hs
   rw [iterate_succ', preimage_comp, ← preimage_symmDiff, (hf.iterate n).measure_preimage hs]
 

--- a/Mathlib/FieldTheory/Adjoin.lean
+++ b/Mathlib/FieldTheory/Adjoin.lean
@@ -1095,13 +1095,13 @@ noncomputable def adjoinRootEquivAdjoin (h : IsIntegral F α) :
           intro x
           obtain ⟨y, hy⟩ := this (Subtype.mem x)
           exact ⟨y, Subtype.ext hy⟩
-        refine' Subfield.closure_le.mpr (Set.union_subset (fun x hx => _) _)
+        refine Subfield.closure_le.mpr (Set.union_subset (fun x hx => ?_) ?_)
         · obtain ⟨y, hy⟩ := hx
           refine ⟨y, ?_⟩
           -- This used to be `rw`, but we need `erw` after leanprover/lean4#2644
           erw [RingHom.comp_apply, AdjoinRoot.lift_of (aeval_gen_minpoly F α)]
           exact hy
-        · refine' Set.singleton_subset_iff.mpr ⟨AdjoinRoot.root (minpoly F α), _⟩
+        · refine Set.singleton_subset_iff.mpr ⟨AdjoinRoot.root (minpoly F α), ?_⟩
           -- This used to be `rw`, but we need `erw` after leanprover/lean4#2644
           erw [RingHom.comp_apply, AdjoinRoot.lift_root (aeval_gen_minpoly F α)]
           rfl)

--- a/Mathlib/Geometry/Manifold/VectorBundle/FiberwiseLinear.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/FiberwiseLinear.lean
@@ -223,14 +223,6 @@ theorem SmoothFiberwiseLinear.locality_aux₂ (e : PartialHomeomorph (B × F) (B
 
 variable (F B IB)
 
--- Adaptation note: 2024-04-23
--- This `maxHeartbeats` was not previously required; increased from about 90k to about 320k.
--- The backwards compatibility flags do not help here:
--- set_option backward.isDefEq.lazyProjDelta false in
--- set_option backward.isDefEq.lazyWhnfCore false in
--- set_option backward.synthInstance.canonInstances false in
--- See https://leanprover.zulipchat.com/#narrow/stream/428973-nightly-testing/topic/Mathlib.20status.20updates/near/436257970
-set_option maxHeartbeats 400000 in
 /-- For `B` a manifold and `F` a normed space, the groupoid on `B × F` consisting of local
 homeomorphisms which are bi-smooth and fiberwise linear, and induce the identity on `B`.
 When a (topological) vector bundle is smooth, then the composition of charts associated
@@ -244,8 +236,8 @@ def smoothFiberwiseLinear : StructureGroupoid (B × F) where
   trans' := by
     simp only [mem_iUnion]
     rintro e e' ⟨φ, U, hU, hφ, h2φ, heφ⟩ ⟨φ', U', hU', hφ', h2φ', heφ'⟩
-    refine' ⟨fun b => (φ b).trans (φ' b), _, hU.inter hU', _, _,
-      Setoid.trans (PartialHomeomorph.EqOnSource.trans' heφ heφ') ⟨_, _⟩⟩
+    refine ⟨fun b => (φ b).trans (φ' b), _, hU.inter hU', ?_, ?_,
+      Setoid.trans (PartialHomeomorph.EqOnSource.trans' heφ heφ') ⟨?_, ?_⟩⟩
     · show
         SmoothOn IB 𝓘(𝕜, F →L[𝕜] F)
           (fun x : B => (φ' x).toContinuousLinearMap ∘L (φ x).toContinuousLinearMap) (U ∩ U')

--- a/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
+++ b/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
@@ -1006,12 +1006,12 @@ instance : LocallyRingedSpace.IsOpenImmersion (pullbackConeOfLeft f g).snd :=
 /-- The constructed `pullbackConeOfLeft` is indeed limiting. -/
 def pullbackConeOfLeftIsLimit : IsLimit (pullbackConeOfLeft f g) :=
   PullbackCone.isLimitAux' _ fun s => by
-    refine' ⟨LocallyRingedSpace.Hom.mk (PresheafedSpace.IsOpenImmersion.pullbackConeOfLeftLift
-        f.1 g.1 (PullbackCone.mk _ _ (congr_arg LocallyRingedSpace.Hom.val s.condition))) _,
-      LocallyRingedSpace.Hom.ext ?_ _
+    refine ⟨LocallyRingedSpace.Hom.mk (PresheafedSpace.IsOpenImmersion.pullbackConeOfLeftLift
+        f.1 g.1 (PullbackCone.mk _ _ (congr_arg LocallyRingedSpace.Hom.val s.condition))) ?_,
+      LocallyRingedSpace.Hom.ext _ _
         (PresheafedSpace.IsOpenImmersion.pullbackConeOfLeftLift_fst f.1 g.1 _),
-      LocallyRingedSpace.Hom.ext ?_ _
-          (PresheafedSpace.IsOpenImmersion.pullbackConeOfLeftLift_snd f.1 g.1 _), _⟩
+      LocallyRingedSpace.Hom.ext _ _
+          (PresheafedSpace.IsOpenImmersion.pullbackConeOfLeftLift_snd f.1 g.1 _), ?_⟩
     · intro x
       have :=
         PresheafedSpace.stalkMap.congr_hom _ _

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -111,7 +111,7 @@ theorem Subgroup.commProb_subgroup_le : commProb H ≤ commProb G * (H.index : �
       commuting pairs as `H`. -/
   rw [commProb_def, commProb_def, div_le_iff, mul_assoc, ← mul_pow, ← Nat.cast_mul,
     mul_comm H.index, H.card_mul_index, div_mul_cancel₀, Nat.cast_le]
-  · refine' Finite.card_le_of_injective (fun p ↦ ⟨⟨p.1.1, p.1.2⟩, Subtype.ext_iff.mp p.2⟩) _
+  · refine Finite.card_le_of_injective (fun p ↦ ⟨⟨p.1.1, p.1.2⟩, Subtype.ext_iff.mp p.2⟩) ?_
     exact fun p q h ↦ by simpa only [Subtype.ext_iff, Prod.ext_iff] using h
   · exact pow_ne_zero 2 (Nat.cast_ne_zero.mpr Finite.card_pos.ne')
   · exact pow_pos (Nat.cast_pos.mpr Finite.card_pos) 2

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -1180,7 +1180,7 @@ theorem reduce.not {p : Prop} :
       rcases L2 with (_ | ⟨a, L2⟩)
       · injections; subst_vars
         simp at h
-      · refine' @reduce.not _ L1 L2 L3 x' b' _
+      · refine @reduce.not _ L1 L2 L3 x' b' ?_
         injection H with _ H
         rw [r, H]; rfl
 #align free_group.reduce.not FreeGroup.reduce.not

--- a/Mathlib/GroupTheory/GroupAction/Blocks.lean
+++ b/Mathlib/GroupTheory/GroupAction/Blocks.lean
@@ -290,7 +290,7 @@ theorem IsBlock.iInter {ι : Type*} {B : ι → Set X} (hB : ∀ i : ι, IsBlock
   by_cases h : ∃ i : ι, Disjoint (g • B i) (B i)
   · right
     obtain ⟨j, hj⟩ := h
-    refine' Disjoint.mono _ _ hj <;> apply Set.iInter_subset
+    refine Disjoint.mono ?_ ?_ hj <;> apply Set.iInter_subset
   · left
     simp only [not_exists] at h
     have : ∀ i : ι, g • B i = B i := fun i => ((hB i).smul_eq_or_disjoint g).resolve_right (h i)

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
@@ -246,7 +246,9 @@ theorem val_smul (r : R) (x : p) : (↑(r • x) : M) = r • (x : M) :=
 variable (p)
 
 /-- Embedding of a submodule `p` to the ambient space `M`. -/
-protected def subtype : p →[R] M := by refine' { toFun := Subtype.val.. }; simp [val_smul]
+protected def subtype : p →[R] M where
+  toFun := Subtype.val
+  map_smul' := by simp [val_smul]
 #align sub_mul_action.subtype SubMulAction.subtype
 
 @[simp]

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction/Pointwise.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction/Pointwise.lean
@@ -88,7 +88,7 @@ instance mulOneClass : MulOneClass (SubMulAction R M) where
   one_mul a := by
     ext x
     simp only [mem_mul, mem_one, smul_mul_assoc, exists_exists_eq_and, one_mul]
-    refine' ⟨_, fun hx => ⟨1, x, hx, one_smul _ _⟩⟩
+    refine ⟨?_, fun hx => ⟨1, x, hx, one_smul _ _⟩⟩
     rintro ⟨r, y, hy, rfl⟩
     exact smul_mem _ _ hy
 

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -2094,7 +2094,7 @@ instance partialOrder : PartialOrder (Localization s) where
   le_trans a b c :=
     Localization.induction_on₃ a b c fun a b c hab hbc => by
       simp only [mk_le_mk] at hab hbc ⊢
-      refine' le_of_mul_le_mul_left' _
+      apply le_of_mul_le_mul_left' _
       · exact ↑b.2
       rw [mul_left_comm]
       refine (mul_le_mul_left' hab _).trans ?_

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -299,7 +299,7 @@ theorem nodup_toList (p : Perm α) (x : α) : Nodup (toList p x) := by
   have hm' : ¬orderOf (p.cycleOf x) ∣ m.succ := Nat.not_dvd_of_pos_of_lt m.zero_lt_succ hm
   rw [← hc.support_pow_eq_iff] at hn' hm'
   rw [← Nat.mod_eq_of_lt hn, ← Nat.mod_eq_of_lt hm, ← pow_inj_mod]
-  refine' support_congr _ _
+  refine support_congr ?_ ?_
   · rw [hm', hn']
   · rw [hm']
     intro y hy

--- a/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
@@ -396,10 +396,10 @@ theorem list_cycles_perm_list_cycles {α : Type*} [Finite α] {l₁ l₂ : List 
     (h₁l₂ : ∀ σ : Perm α, σ ∈ l₂ → σ.IsCycle) (h₂l₁ : l₁.Pairwise Disjoint)
     (h₂l₂ : l₂.Pairwise Disjoint) : l₁ ~ l₂ := by
   classical
-    refine'
+    refine
       (List.perm_ext_iff_of_nodup (nodup_of_pairwise_disjoint_cycles h₁l₁ h₂l₁)
             (nodup_of_pairwise_disjoint_cycles h₁l₂ h₂l₂)).mpr
-        fun σ => _
+        fun σ => ?_
     by_cases hσ : σ.IsCycle
     · obtain _ := not_forall.mp (mt ext hσ.ne_one)
       rw [mem_list_cycles_iff h₁l₁ h₂l₁, mem_list_cycles_iff h₁l₂ h₂l₂, h₀]
@@ -448,7 +448,7 @@ theorem cycleFactorsFinset_eq_list_toFinset {σ : Perm α} {l : List (Perm α)} 
   · intro h
     have hn' : l'.Nodup := nodup_of_pairwise_disjoint_cycles hc' hd'
     have hperm : l ~ l' := List.perm_of_nodup_nodup_toFinset_eq hn hn' h.symm
-    refine' ⟨_, _, _⟩
+    refine ⟨?_, ?_, ?_⟩
     · exact fun _ h => hc' _ (hperm.subset h)
     · have := List.Perm.pairwise_iff (@Disjoint.symmetric _) hperm
       rwa [this]
@@ -456,8 +456,8 @@ theorem cycleFactorsFinset_eq_list_toFinset {σ : Perm α} {l : List (Perm α)} 
       refine hd'.imp ?_
       exact Disjoint.commute
   · rintro ⟨hc, hd, hp⟩
-    refine' List.toFinset_eq_of_perm _ _ _
-    refine' list_cycles_perm_list_cycles _ hc' hc hd' hd
+    refine List.toFinset_eq_of_perm _ _ ?_
+    refine list_cycles_perm_list_cycles ?_ hc' hc hd' hd
     rw [hp, hp']
 #align equiv.perm.cycle_factors_finset_eq_list_to_finset Equiv.Perm.cycleFactorsFinset_eq_list_toFinset
 

--- a/Mathlib/GroupTheory/Perm/List.lean
+++ b/Mathlib/GroupTheory/Perm/List.lean
@@ -204,7 +204,7 @@ theorem formPerm_apply_nthLe (xs : List α) (h : Nodup xs) (n : ℕ) (hn : n < x
   cases' xs with x xs
   · simp at hn
   · have : n ≤ xs.length := by
-      refine' Nat.le_of_lt_succ _
+      refine Nat.le_of_lt_succ ?_
       simpa using hn
     rcases this.eq_or_lt with (rfl | hn')
     · simp; simp [nthLe]
@@ -234,7 +234,7 @@ theorem support_formPerm_of_nodup' (l : List α) (h : Nodup l) (h' : ∀ x : α,
     specialize h _ _ _ _ H
     rcases (Nat.succ_le_of_lt hn).eq_or_lt with hn' | hn'
     · simp only [← hn', Nat.mod_self] at h
-      refine' not_exists.mpr h' _
+      refine not_exists.mpr h' ?_
       rw [← length_eq_one]
       simpa [← h, eq_comm] using hn'
     · simp [Nat.mod_eq_of_lt hn'] at h
@@ -314,7 +314,7 @@ set_option linter.deprecated false in
 theorem formPerm_ext_iff {x y x' y' : α} {l l' : List α} (hd : Nodup (x :: y :: l))
     (hd' : Nodup (x' :: y' :: l')) :
     formPerm (x :: y :: l) = formPerm (x' :: y' :: l') ↔ (x :: y :: l) ~r (x' :: y' :: l') := by
-  refine' ⟨fun h => _, fun hr => formPerm_eq_of_isRotated hd hr⟩
+  refine ⟨fun h => ?_, fun hr => formPerm_eq_of_isRotated hd hr⟩
   rw [Equiv.Perm.ext_iff] at h
   have hx : x' ∈ x :: y :: l := by
     have : x' ∈ { z | formPerm (x :: y :: l) z ≠ z } := by
@@ -326,7 +326,7 @@ theorem formPerm_ext_iff {x y x' y' : α} {l l' : List α} (hd : Nodup (x :: y :
   obtain ⟨n, hn, hx'⟩ := nthLe_of_mem hx
   have hl : (x :: y :: l).length = (x' :: y' :: l').length := by
     rw [← dedup_eq_self.mpr hd, ← dedup_eq_self.mpr hd', ← card_toFinset, ← card_toFinset]
-    refine' congr_arg Finset.card _
+    refine congr_arg Finset.card ?_
     rw [← Finset.coe_inj, ← support_formPerm_of_nodup' _ hd (by simp), ←
       support_formPerm_of_nodup' _ hd' (by simp)]
     simp only [h]
@@ -336,7 +336,7 @@ theorem formPerm_ext_iff {x y x' y' : α} {l l' : List α} (hd : Nodup (x :: y :
   · intro k hk hk'
     rw [nthLe_rotate]
     induction' k with k IH
-    · refine' Eq.trans _ hx'
+    · refine Eq.trans ?_ hx'
       congr
       simpa using hn
     · conv => congr <;> · arg 2; rw [← Nat.mod_eq_of_lt hk']

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -466,11 +466,8 @@ theorem Sylow.normalizer_sup_eq_top {p : ℕ} [Fact p.Prime] {N : Subgroup G} [N
   apply mul_mem_sup (N.inv_mem n.2)
   rw [Sylow.smul_def, ← mul_smul, ← MulAut.conjNormal_val, ← MulAut.conjNormal.map_mul,
     Sylow.ext_iff, Sylow.pointwise_smul_def, Subgroup.pointwise_smul_def] at hn
-  refine' fun x =>
-    (mem_map_iff_mem
-            (show Function.Injective (MulAut.conj (↑n * g)).toMonoidHom from
-              (MulAut.conj (↑n * g)).injective)).symm.trans
-      _
+  have : Function.Injective (MulAut.conj (n * g)).toMonoidHom := (MulAut.conj (n * g)).injective
+  refine fun x ↦ (mem_map_iff_mem this).symm.trans ?_
   rw [map_map, ← congr_arg (map N.subtype) hn, map_map]
   rfl
 #align sylow.normalizer_sup_eq_top Sylow.normalizer_sup_eq_top
@@ -619,7 +616,7 @@ theorem exists_subgroup_card_pow_succ [Fintype G] {p : ℕ} {n : ℕ} [hp : Fact
       (preimageMkEquivSubgroupProdSet (H.subgroupOf H.normalizer) (zpowers x)), by
     intro y hy
     simp only [exists_prop, Subgroup.coeSubtype, mk'_apply, Subgroup.mem_map, Subgroup.mem_comap]
-    refine' ⟨⟨y, le_normalizer hy⟩, ⟨0, _⟩, rfl⟩
+    refine ⟨⟨y, le_normalizer hy⟩, ⟨0, ?_⟩, rfl⟩
     dsimp only
     rw [zpow_zero, eq_comm, QuotientGroup.eq_one_iff]
     simpa using hy⟩
@@ -820,7 +817,7 @@ noncomputable def directProductOfNormal [Fintype G]
     have hne' : p₁ ≠ p₂ := by simpa using hne
     apply Subgroup.commute_of_normal_of_disjoint _ _ (hn (P p₁)) (hn (P p₂))
     apply IsPGroup.disjoint_of_ne p₁ p₂ hne' _ _ (P p₁).isPGroup' (P p₂).isPGroup'
-  refine' MulEquiv.trans (N := ∀ p : ps, P p) _ _
+  refine MulEquiv.trans (N := ∀ p : ps, P p) ?_ ?_
   -- There is only one Sylow subgroup for each p, so the inner product is trivial
   · show (∀ p : ps, ∀ P : Sylow p G, P) ≃* ∀ p : ps, P p
     -- here we need to help the elaborator with an explicit instantiation


### PR DESCRIPTION
Split from #13385; this excludes usages where `refine'` was used to replace `refine_struct`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
