### PR TITLE
chore(PrimeCounting): change scope of the notation

### DIFF
--- a/Mathlib/NumberTheory/PrimeCounting.lean
+++ b/Mathlib/NumberTheory/PrimeCounting.lean
@@ -51,9 +51,9 @@ def primeCounting (n : ℕ) : ℕ :=
   primeCounting' (n + 1)
 #align nat.prime_counting Nat.primeCounting
 
-@[inherit_doc] scoped notation "π" => Nat.primeCounting
-
-@[inherit_doc] scoped notation "π'" => Nat.primeCounting'
+@[inherit_doc] scoped [PrimeCounting] notation "π" => Nat.primeCounting
+@[inherit_doc] scoped [PrimeCounting] notation "π'" => Nat.primeCounting'
+open scoped PrimeCounting
 
 theorem monotone_primeCounting' : Monotone primeCounting' :=
   count_monotone Prime


### PR DESCRIPTION
This way `open scoped Real Nat` doesn't lead to a conflict.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)